### PR TITLE
refactor(ir): Make pass pipeline the single source of truth

### DIFF
--- a/docs/en/dev/passes/00-pass_manager.md
+++ b/docs/en/dev/passes/00-pass_manager.md
@@ -297,10 +297,11 @@ class PassPipeline {
   void AddPass(Pass pass);
   ProgramPtr Run(const ProgramPtr& program) const;  // executes passes in order
   std::vector<std::string> GetPassNames() const;
+  std::vector<Pass> GetPasses() const;
 };
 ```
 
-`PassPipeline` is a simple ordered list of passes. Each pass's `operator()` checks the active `PassContext` for instruments.
+`PassPipeline` is the single source of truth for ordered pass objects and their names. `GetPasses()` returns lightweight copies of the pass handles for inspection or composing another pipeline. Each pass's `operator()` checks the active `PassContext` for instruments.
 
 ### Automatic Verification
 
@@ -357,6 +358,7 @@ ir.compile(program, verification_level=ir.VerificationLevel.NONE)
 | `get_strategy(strategy)` | Get PassManager configured for strategy |
 | `run_passes(program, dump_ir, output_dir, prefix)` | Execute passes via PassPipeline |
 | `get_pass_names()` | Get names of all passes |
+| `passes` / `pass_names` | Read-only snapshots derived from the underlying PassPipeline |
 
 ### Usage
 

--- a/docs/zh-cn/dev/passes/00-pass_manager.md
+++ b/docs/zh-cn/dev/passes/00-pass_manager.md
@@ -297,10 +297,11 @@ class PassPipeline {
   void AddPass(Pass pass);
   ProgramPtr Run(const ProgramPtr& program) const;  // executes passes in order
   std::vector<std::string> GetPassNames() const;
+  std::vector<Pass> GetPasses() const;
 };
 ```
 
-`PassPipeline` 是简单的有序 Pass 列表。每个 Pass 的 `operator()` 检查活跃的 `PassContext` 以获取插桩。
+`PassPipeline` 是有序 Pass 对象及其名称的单一事实来源。`GetPasses()` 返回轻量的 Pass 句柄副本，用于检查或组合新的 pipeline。每个 Pass 的 `operator()` 检查活跃的 `PassContext` 以获取插桩。
 
 ### 自动验证
 
@@ -357,6 +358,7 @@ ir.compile(program, verification_level=ir.VerificationLevel.NONE)
 | `get_strategy(strategy)` | 获取按策略配置的 PassManager |
 | `run_passes(program, dump_ir, output_dir, prefix)` | 通过 PassPipeline 执行 Pass |
 | `get_pass_names()` | 获取所有 Pass 的名称 |
+| `passes` / `pass_names` | 从底层 PassPipeline 派生的只读快照 |
 
 ### 用法
 

--- a/include/pypto/ir/transforms/passes.h
+++ b/include/pypto/ir/transforms/passes.h
@@ -860,6 +860,15 @@ class PassPipeline {
    */
   [[nodiscard]] std::vector<std::string> GetPassNames() const;
 
+  /**
+   * @brief Get copies of the passes in execution order
+   *
+   * Pass is a lightweight shared handle, so returning a vector by value keeps
+   * the pipeline's ordered storage private while allowing callers to inspect or
+   * compose a new pipeline without maintaining a second pass list.
+   */
+  [[nodiscard]] std::vector<Pass> GetPasses() const;
+
  private:
   std::vector<Pass> passes_;
 };

--- a/python/bindings/modules/passes.cpp
+++ b/python/bindings/modules/passes.cpp
@@ -311,7 +311,8 @@ void BindPass(nb::module_& m) {
       .def(nb::init<>(), "Create an empty pipeline")
       .def("add_pass", &PassPipeline::AddPass, nb::arg("pass_obj"), "Add a pass to the pipeline")
       .def("run", &PassPipeline::Run, nb::arg("program"), "Execute all passes in sequence")
-      .def("get_pass_names", &PassPipeline::GetPassNames, "Get names of all passes");
+      .def("get_pass_names", &PassPipeline::GetPassNames, "Get names of all passes")
+      .def("get_passes", &PassPipeline::GetPasses, "Get copies of all passes in execution order");
 
   // Factory functions with snake_case names
   passes.def("init_mem_ref", &pass::InitMemRef,

--- a/python/pypto/ir/pass_manager.py
+++ b/python/pypto/ir/pass_manager.py
@@ -82,7 +82,7 @@ def _format_warnings(
     return "\n".join(out) + "\n" if out else ""
 
 
-PassSpec = tuple[str, Callable[[], passes.Pass]]
+PassFactory = Callable[[], passes.Pass]
 
 
 class OptimizationStrategy(Enum):
@@ -110,79 +110,80 @@ class PassManager:
             result = pm.run_passes(program)
     """
 
-    # Static storage: strategy -> List of (pass_name, pass_factory) tuples
-    _strategy_passes: dict[OptimizationStrategy, list[PassSpec]] = {}
-
-    @classmethod
-    def _register_passes(cls):
-        """Register all strategy Pass configurations."""
-        tensor_prefix_passes: list[PassSpec] = [
+    @staticmethod
+    def _get_pass_factories(
+        strategy: OptimizationStrategy,
+        *,
+        analyze_auto_scopes_for_deps: bool,
+    ) -> tuple[PassFactory, ...]:
+        """Build the immutable pass-factory recipe for an optimization strategy."""
+        tensor_prefix_passes: tuple[PassFactory, ...] = (
             # Eliminate FunctionType.Inline functions by splicing their bodies at
             # every call site. Runs FIRST so no downstream pass observes Inline
             # functions or Calls to them.
-            ("InlineFunctions", lambda: passes.inline_functions()),
-            ("UnrollLoops", lambda: passes.unroll_loops()),
-            ("CtrlFlowTransform", lambda: passes.ctrl_flow_transform()),
-            ("ConvertToSSA", lambda: passes.convert_to_ssa()),
+            passes.inline_functions,
+            passes.unroll_loops,
+            passes.ctrl_flow_transform,
+            passes.convert_to_ssa,
             # Propagate scalar constants (e.g. `CHUNK_K: Scalar[INDEX] = 512`)
             # into downstream expression and type-annotation uses before tile
             # lowering inspects them. Runs post-SSA to exploit single-definition.
-            ("Simplify", lambda: passes.simplify()),
-            ("NormalizeStmtStructure", lambda: passes.normalize_stmt_structure()),
-            ("FlattenCallExpr", lambda: passes.flatten_call_expr()),
-        ]
-        tensor_only_passes: list[PassSpec] = [
-            ("OutlineHierarchyScopes", lambda: passes.outline_hierarchy_scopes()),
-            ("OutlineIncoreScopes", lambda: passes.outline_incore_scopes()),
-            ("OutlineClusterScopes", lambda: passes.outline_cluster_scopes()),
-            ("ConvertTensorToTileOps", lambda: passes.convert_tensor_to_tile_ops()),
-            ("OptimizeOrchTensors", lambda: passes.optimize_orch_tensors()),
-        ]
-        tile_pto_passes: list[PassSpec] = [
-            ("LowerCompositeOps", lambda: passes.lower_composite_ops()),
-            ("FlattenTileNdTo2D", lambda: passes.flatten_tile_nd_to_2d()),
-            ("AutoTileMatmulL0", lambda: passes.auto_tile_matmul_l0()),
-            ("CanonicalizeTileSlice", lambda: passes.canonicalize_tile_slice()),
-            ("InferTileMemorySpace", lambda: passes.infer_tile_memory_space()),
-            ("ResolveBackendOpLayouts", lambda: passes.resolve_backend_op_layouts()),
+            passes.simplify,
+            passes.normalize_stmt_structure,
+            passes.flatten_call_expr,
+        )
+        tensor_only_passes: tuple[PassFactory, ...] = (
+            passes.outline_hierarchy_scopes,
+            passes.outline_incore_scopes,
+            passes.outline_cluster_scopes,
+            passes.convert_tensor_to_tile_ops,
+            passes.optimize_orch_tensors,
+        )
+        tile_pto_passes: tuple[PassFactory, ...] = (
+            passes.lower_composite_ops,
+            passes.flatten_tile_nd_to_2d,
+            passes.auto_tile_matmul_l0,
+            passes.canonicalize_tile_slice,
+            passes.infer_tile_memory_space,
+            passes.resolve_backend_op_layouts,
             # RFC #1300: convert AUTO pl.split mixed InCore functions into the explicit
             # split_aiv form (aiv_shard/aic_gather + halved vector sub-region) so
             # ExpandMixedKernel folds them into split-stamped tpush/tpop uniformly. This
             # is the live auto-split lowering path; after it runs every split function
             # reaches SplitVectorKernel already split_aiv-marked, so SplitVectorKernel
             # only stamps attrs. Runs immediately before ExpandMixedKernel.
-            ("LowerAutoVectorSplit", lambda: passes.lower_auto_vector_split()),
-            ("ExpandMixedKernel", lambda: passes.expand_mixed_kernel()),
-            ("InjectGMPipeBuffer", lambda: passes.inject_gm_pipe_buffer()),
-            ("SplitVectorKernel", lambda: passes.split_vector_kernel()),
+            passes.lower_auto_vector_split,
+            passes.expand_mixed_kernel,
+            passes.inject_gm_pipe_buffer,
+            passes.split_vector_kernel,
             # Copy each cross-core tpop's split/pipe-id onto its matching tfree op so
             # codegen reads them from the op (no codegen-side tpop lookup table). Runs
             # right after SplitVectorKernel finalizes split on tpops and before
             # SkewCrossCorePipeline clones tpop/tfree pairs (so clones carry split).
-            ("StampTfreeSplit", lambda: passes.stamp_tfree_split()),
-            ("NormalizeReturnOrder", lambda: passes.normalize_return_order()),
-            ("SkewCrossCorePipeline", lambda: passes.skew_cross_core_pipeline()),
-            ("LowerPipelineLoops", lambda: passes.lower_pipeline_loops()),
-            ("CanonicalizeIOOrder", lambda: passes.canonicalize_io_order()),
+            passes.stamp_tfree_split,
+            passes.normalize_return_order,
+            passes.skew_cross_core_pipeline,
+            passes.lower_pipeline_loops,
+            passes.canonicalize_io_order,
             # MaterializeTensorStrides fills empty stride slots on every
             # TensorView with packed canonical strides (RFC #1300 §2.4).
-            ("MaterializeTensorStrides", lambda: passes.materialize_tensor_strides()),
-            ("InitMemRef", lambda: passes.init_mem_ref()),
+            passes.materialize_tensor_strides,
+            passes.init_mem_ref,
             # MaterializeSemanticAliases forces loop-carried / in-place buffers to
             # share one MemRef (semantics-required aliasing). It always runs; only
             # the opportunistic lifetime coalescing (MemoryReuse) is skippable when
             # ptoas owns reuse (memory_planner=PTOAS).
-            ("MaterializeSemanticAliases", lambda: passes.materialize_semantic_aliases()),
+            passes.materialize_semantic_aliases,
             # MemoryReuse coalesces independent tile buffers by lifetime; on
             # Ascend910B split-AIV it also avoids the load + tpop_from_aic in-place
             # hazard so a separate legalisation pass is no longer needed.
-            ("MemoryReuse", lambda: passes.memory_reuse()),
-            ("AllocateMemoryAddr", lambda: passes.allocate_memory_addr()),
-            ("FoldNoOpReshape", lambda: passes.fold_no_op_reshape()),
-            ("FuseCreateAssembleToSlice", lambda: passes.fuse_create_assemble_to_slice()),
-            ("DeriveCallDirections", lambda: passes.derive_call_directions()),
-            ("AutoDeriveTaskDependencies", lambda: passes.auto_derive_task_dependencies()),
-            ("ExpandManualPhaseFence", lambda: passes.expand_manual_phase_fence()),
+            passes.memory_reuse,
+            passes.allocate_memory_addr,
+            passes.fold_no_op_reshape,
+            passes.fuse_create_assemble_to_slice,
+            passes.derive_call_directions,
+            lambda: passes.auto_derive_task_dependencies(analyze_auto_scopes=analyze_auto_scopes_for_deps),
+            passes.expand_manual_phase_fence,
             # First normalize host allreduce calls that omit signal into the
             # explicit internal allreduce(data, signal, op=...) form. Then
             # trace pld.tensor.alloc_window_buffer -> pld.tensor.window ->
@@ -193,27 +194,28 @@ class PassManager:
             # LowerHostTensorCollectives, because host_orch is never
             # tile-lowered and the alloc/window/dispatch/allreduce chain is
             # still discoverable.
-            ("SynthesizeAllReduceSignals", lambda: passes.synthesize_allreduce_signals()),
-            ("MaterializeCommDomainScopes", lambda: passes.materialize_comm_domain_scopes()),
-            ("LowerHostTensorCollectives", lambda: passes.lower_host_tensor_collectives()),
-            ("MaterializeDistTensorCtx", lambda: passes.materialize_dist_tensor_ctx()),
-            ("Simplify", lambda: passes.simplify()),
+            passes.synthesize_allreduce_signals,
+            passes.materialize_comm_domain_scopes,
+            passes.lower_host_tensor_collectives,
+            passes.materialize_dist_tensor_ctx,
+            passes.simplify,
             # Insert explicit AUTO RuntimeScopeStmt nodes (function body + for/if
             # bodies) into Orchestration functions so codegen emits PTO2_SCOPE
             # 1:1 from the IR. Runs dead last, after the final Simplify, so no
             # other transform has to reason about the inserted scope wrappers.
-            ("MaterializeRuntimeScopes", lambda: passes.materialize_runtime_scopes()),
+            passes.materialize_runtime_scopes,
             # Classify each Orchestration ForStmt iter_arg as a trivial alias or a
             # materialised rebind carry (and size manual-scope TaskId array
             # carries), stamping the plan onto ForStmt.attrs. Runs after
             # MaterializeRuntimeScopes so the classified IR is exactly the IR
             # orchestration codegen lowers.
-            ("ClassifyIterArgCarry", lambda: passes.classify_iter_arg_carry()),
-        ]
-        cls._strategy_passes = {
-            OptimizationStrategy.Default: tensor_prefix_passes + tensor_only_passes + tile_pto_passes,
-            OptimizationStrategy.DebugTileOptimization: tensor_prefix_passes + tile_pto_passes,
-        }
+            passes.classify_iter_arg_carry,
+        )
+        if strategy == OptimizationStrategy.Default:
+            return tensor_prefix_passes + tensor_only_passes + tile_pto_passes
+        if strategy == OptimizationStrategy.DebugTileOptimization:
+            return tensor_prefix_passes + tile_pto_passes
+        raise ValueError(f"Unsupported optimization strategy: {strategy!r}")
 
     @classmethod
     def get_strategy(
@@ -236,8 +238,6 @@ class PassManager:
         Returns:
             A PassManager instance configured with the appropriate passes
         """
-        if not cls._strategy_passes:
-            cls._register_passes()
         return cls(
             strategy,
             analyze_auto_scopes_for_deps=analyze_auto_scopes_for_deps,
@@ -258,8 +258,6 @@ class PassManager:
         """
         self.strategy = strategy
         self.analyze_auto_scopes_for_deps = analyze_auto_scopes_for_deps
-        self.passes: list[passes.Pass] = []
-        self.pass_names: list[str] = []
 
         # When the active PassContext selects ptoas as the memory planner, skip
         # the opportunistic lifetime reuse (MemoryReuse) and address assignment
@@ -282,22 +280,29 @@ class PassManager:
         skip_mem_planning = self._construction_planner == passes.MemoryPlanner.PTOAS
         _mem_planning_passes = ("MemoryReuse", "AllocateMemoryAddr")
 
-        # Build pass list
-        for pass_name, pass_factory in self._strategy_passes[strategy]:
-            if skip_mem_planning and pass_name in _mem_planning_passes:
-                continue
-            if pass_name == "AutoDeriveTaskDependencies":
-                self.passes.append(
-                    passes.auto_derive_task_dependencies(analyze_auto_scopes=analyze_auto_scopes_for_deps)
-                )
-            else:
-                self.passes.append(pass_factory())
-            self.pass_names.append(pass_name)
-
-        # Build C++ PassPipeline
+        # The C++ pipeline is the single source of truth for both pass objects
+        # and names. Strategy recipes contain factories only; names always come
+        # from the constructed Pass instances.
         self._pipeline = passes.PassPipeline()
-        for p in self.passes:
-            self._pipeline.add_pass(p)
+        pass_factories = self._get_pass_factories(
+            strategy,
+            analyze_auto_scopes_for_deps=analyze_auto_scopes_for_deps,
+        )
+        for pass_factory in pass_factories:
+            pass_obj = pass_factory()
+            if skip_mem_planning and pass_obj.get_name() in _mem_planning_passes:
+                continue
+            self._pipeline.add_pass(pass_obj)
+
+    @property
+    def passes(self) -> tuple[passes.Pass, ...]:
+        """Get the pipeline's passes in execution order as an immutable snapshot."""
+        return tuple(self._pipeline.get_passes())
+
+    @property
+    def pass_names(self) -> list[str]:
+        """Get pass names derived from the pipeline's actual Pass instances."""
+        return self._pipeline.get_pass_names()
 
     def _check_planner_consistency(self) -> None:
         """Fail loud if the run-time memory planner differs from the construction-time one.
@@ -370,8 +375,9 @@ class PassManager:
                 f.write("\n")
 
         # Use instrument for IR dumping -- verification handled by C++ pipeline.
-        # We index self.pass_names (Python-side names from _register_passes) rather than
-        # _pass_obj.get_name() because registered names may differ from C++ names.
+        # Snapshot the pipeline-derived names for stable callback indexing during
+        # this run. Pass names have no independent Python-side storage.
+        pass_names = self.pass_names
         pass_index = 0
 
         # Resolve diagnostic checks once for post-pass dump.
@@ -391,12 +397,12 @@ class PassManager:
         def before_pass_profiling(_pass_obj: passes.Pass, _program: core_ir.Program) -> None:
             nonlocal stage_open
             if prof is not None:
-                prof._begin_stage(self.pass_names[pass_index])
+                prof._begin_stage(pass_names[pass_index])
                 stage_open = True
 
         def after_pass(_pass_obj: passes.Pass, program: core_ir.Program) -> None:
             nonlocal pass_index, stage_open
-            pass_name = self.pass_names[pass_index]
+            pass_name = pass_names[pass_index]
             stem = f"{pass_index + 1:02d}_after_{pass_name}"
 
             # Dump IR
@@ -465,12 +471,13 @@ class PassManager:
 
     def _run_with_profiling(self, input_ir: core_ir.Program, prof: CompileProfiler) -> core_ir.Program:
         """Run the pipeline with per-pass timing recorded into *prof*."""
+        pass_names = self.pass_names
         pass_index = 0
         stage_open = False
 
         def before_pass(_pass_obj: passes.Pass, _program: core_ir.Program) -> None:
             nonlocal pass_index, stage_open
-            prof._begin_stage(self.pass_names[pass_index])
+            prof._begin_stage(pass_names[pass_index])
             stage_open = True
 
         def after_pass(_pass_obj: passes.Pass, _program: core_ir.Program) -> None:
@@ -507,10 +514,6 @@ class PassManager:
         """Get the names of all passes in this manager.
 
         Returns:
-            List of pass names assigned during registration
+            Pass names derived from the underlying pipeline
         """
-        return self.pass_names
-
-
-# Initialize the pass registry when the module is loaded
-PassManager._register_passes()
+        return self._pipeline.get_pass_names()

--- a/python/pypto/pypto_core/passes.pyi
+++ b/python/pypto/pypto_core/passes.pyi
@@ -323,6 +323,9 @@ class PassPipeline:
     def get_pass_names(self) -> list[str]:
         """Get names of all passes."""
 
+    def get_passes(self) -> list[Pass]:
+        """Get copies of all passes in execution order."""
+
 # Factory functions
 
 def init_mem_ref() -> Pass:

--- a/src/ir/transforms/passes.cpp
+++ b/src/ir/transforms/passes.cpp
@@ -302,5 +302,7 @@ std::vector<std::string> PassPipeline::GetPassNames() const {
   return names;
 }
 
+std::vector<Pass> PassPipeline::GetPasses() const { return passes_; }
+
 }  // namespace ir
 }  // namespace pypto

--- a/tests/ut/ir/transforms/test_memory_reuse.py
+++ b/tests/ut/ir/transforms/test_memory_reuse.py
@@ -4502,7 +4502,6 @@ class TestCapacityGatedReuse:
             for p in pm.passes[: idx + 1]:
                 pipe.add_pass(p)
             pm._pipeline = pipe
-            pm.pass_names = pm.pass_names[: idx + 1]
             return pm
 
         # Real LowerPipelineLoops tags reach MemoryReuse's input (they are stripped in

--- a/tests/ut/ir/transforms/test_pass_manager.py
+++ b/tests/ut/ir/transforms/test_pass_manager.py
@@ -184,6 +184,27 @@ class TestPassManagerBasics:
 
         assert captured == [False, True]
 
+    def test_pipeline_is_single_source_of_passes_and_names(self):
+        """PassManager views follow the C++ pipeline and cannot drift independently."""
+        pm = ir.PassManager.get_strategy(ir.OptimizationStrategy.Default)
+        original_names = pm.pass_names
+
+        names_snapshot = pm.pass_names
+        names_snapshot.pop()
+        assert pm.pass_names == original_names
+
+        shortened_pipeline = passes.PassPipeline()
+        for pass_obj in pm.passes[:2]:
+            shortened_pipeline.add_pass(pass_obj)
+        pm._pipeline = shortened_pipeline
+
+        assert pm.pass_names == original_names[:2]
+        assert [pass_obj.get_name() for pass_obj in pm.passes] == original_names[:2]
+        with pytest.raises(AttributeError):
+            setattr(pm, "pass_names", original_names)
+        with pytest.raises(AttributeError):
+            setattr(pm, "passes", ())
+
 
 class TestPassManagerExecution:
     """Test PassManager execution functionality."""

--- a/tests/ut/ir/transforms/test_pass_pipeline.py
+++ b/tests/ut/ir/transforms/test_pass_pipeline.py
@@ -41,6 +41,10 @@ class TestPassPipeline:
         pipeline.add_pass(passes.convert_to_ssa())
         pipeline.add_pass(passes.flatten_call_expr())
         assert pipeline.get_pass_names() == ["ConvertToSSA", "FlattenCallExpr"]
+        assert [pass_obj.get_name() for pass_obj in pipeline.get_passes()] == [
+            "ConvertToSSA",
+            "FlattenCallExpr",
+        ]
 
     def test_run_empty_pipeline(self):
         """Test running an empty pipeline returns the same program."""


### PR DESCRIPTION
## Summary

- make `PassPipeline` the single source of truth for ordered passes and pass names
- derive `PassManager` compatibility views from the underlying pipeline and remove duplicated mutable strategy/name state
- expose `get_passes` across C++, nanobind, and type stubs, with synchronized tests and documentation

## Testing

- `cmake --build build --parallel`
- affected unit test suite: 212 passed
- final PassManager and PassPipeline regression suite: 58 passed
- `ruff check .`
- `ruff format --check .`
- `pyright python/pypto/ir/pass_manager.py`
- `git diff --check`

## Notes

- Diff clang-tidy was attempted, but this environment provides clang-tidy 18.1.8 instead of the required 21.1.0, and the temporary lint build could not provide `backtrace.h`; therefore it did not produce a reliable source-level result.