### PR TITLE
test(printer): Accept valid quote styles for syncall

### DIFF
--- a/tests/ut/language/parser/test_system_ops.py
+++ b/tests/ut/language/parser/test_system_ops.py
@@ -9,6 +9,8 @@
 
 """Tests for system operation DSL parsing and round-trip."""
 
+import re
+
 import pypto.language as pl
 import pytest
 from pypto import ir
@@ -116,7 +118,7 @@ class TestSystemOpsParsing:
                 return x
 
         printed = Before.as_python()
-        assert 'pl.system.syncall(core_type="aiv_only")' in printed
+        assert re.search(r"""pl\.system\.syncall\(core_type=(["'])aiv_only\1\)""", printed)
 
         reparsed = pl.parse_program(printed)
         assert isinstance(reparsed, ir.Program)
@@ -133,7 +135,7 @@ class TestSystemOpsParsing:
                 return x
 
         printed = Before.as_python()
-        assert 'pl.system.syncall(core_type="mix")' in printed
+        assert re.search(r"""pl\.system\.syncall\(core_type=(["'])mix\1\)""", printed)
 
         reparsed = pl.parse_program(printed)
         assert isinstance(reparsed, ir.Program)


### PR DESCRIPTION
## Summary
- make hard `syncall` printer assertions accept either valid Python quote delimiter
- retain exact core type matching and structural round-trip verification

## Testing
- [x] `cmake --build build --parallel`
- [x] `python -m pytest tests/ut/ -n auto --maxprocesses 8 -v` (7,124 passed, 2 skipped)
- [x] pre-commit hooks, including Ruff and Pyright
- [x] independent code review