### PR TITLE
feat(passes): add HoistScopeLocalAllocs to mark manual-scope hoistable allocs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,6 +155,7 @@ set(PYPTO_SOURCES
     src/ir/transforms/stamp_tfree_split_pass.cpp
     src/ir/transforms/materialize_runtime_scopes_pass.cpp
     src/ir/transforms/classify_iter_arg_carry_pass.cpp
+    src/ir/transforms/hoist_scope_local_allocs_pass.cpp
     src/ir/transforms/fuse_create_assemble_to_slice_pass.cpp
     src/ir/transforms/memory_reuse_pass.cpp
     src/ir/transforms/normalize_return_order_pass.cpp
@@ -246,6 +247,7 @@ set(PYPTO_SOURCES
     src/ir/verifier/verify_pipeline_resolved.cpp
     src/ir/verifier/verify_unroll_resolved.cpp
     src/ir/verifier/verify_iter_arg_carry_classified.cpp
+    src/ir/verifier/verify_hoistable_allocs_marked.cpp
     src/ir/verifier/verify_call_directions.cpp
     src/ir/verifier/verify_tile_type_coherence.cpp
     src/ir/verifier/verify_assign_type_symmetry.cpp

--- a/docs/en/dev/passes/00-pass_manager.md
+++ b/docs/en/dev/passes/00-pass_manager.md
@@ -93,6 +93,7 @@ struct PassProperties {
 | Simplify | — | — | — |
 | MaterializeRuntimeScopes | SplitIncoreOrch, CallDirectionsResolved | RuntimeScopesMaterialized | — |
 | ClassifyIterArgCarry | CallDirectionsResolved, RuntimeScopesMaterialized | IterArgCarryClassified, RuntimeScopesMaterialized | — |
+| HoistScopeLocalAllocs | CallDirectionsResolved, RuntimeScopesMaterialized | HoistableAllocsMarked, RuntimeScopesMaterialized | — |
 
 > **Note**: VerifySSA and TypeCheck are **PropertyVerifiers** (verification rules), not Passes. They run via `VerificationInstrument` or the `run_verifier()` utility — see [Verifier](99-verifier.md).
 
@@ -411,6 +412,7 @@ The PTO-oriented tile stage shared by `Default` and `DebugTileOptimization` is:
 30. `Simplify`
 31. [`MaterializeRuntimeScopes`](41-materialize_runtime_scopes.md) (inserts AUTO RuntimeScopeStmt so orchestration codegen emits PTO2_SCOPE 1:1)
 32. [`ClassifyIterArgCarry`](42-classify_iter_arg_carry.md) (stamps each ForStmt iter_arg as trivial alias / rebind carry, and sizes manual-scope TaskId fence arrays)
+33. [`HoistScopeLocalAllocs`](43-hoist_scope_local_allocs.md) (stamps each enclosing-scope-valid `tensor.create` in a manual-scope body with `hoistable_alloc` so codegen hoists its declaration out of the block, #1697)
 
 `DebugTileOptimization` is a debug-only strategy for inspecting this tile stage
 without the tensor-only prefix passes. Use `Default` for normal compilation and

--- a/docs/en/dev/passes/43-hoist_scope_local_allocs.md
+++ b/docs/en/dev/passes/43-hoist_scope_local_allocs.md
@@ -1,0 +1,104 @@
+# HoistScopeLocalAllocs Pass
+
+Marks each `tensor.create` that sits directly in a `pl.manual_scope` body and is
+*enclosing-scope-valid* with the `hoistable_alloc` attribute, so the
+orchestration codegen hoists the buffer's declaration one C++ scope out instead
+of recovering the hoist set from emit-time indent arithmetic (issue #1697).
+
+## Overview
+
+A `pl.manual_scope` lowers to a `PTO2_SCOPE(PTO2ScopeMode::MANUAL) { ... }` C++
+block. A manual scope is a **scheduling** region, not a **storage** region: a
+buffer allocated inside it may be read by a task placed *after* the block. If the
+buffer's declaration stayed inside the block, the C++ local would die at the
+closing brace and the after-scope reader would fail to compile.
+
+`alloc_tensors(...)` carries no scheduling dependency, so emitting it one level
+out — ahead of the `PTO2_SCOPE(MANUAL) {` header — is semantically inert and
+keeps the buffer in scope both inside the block and at every after-scope reader.
+
+This pass makes "which creates get hoisted" an explicit IR fact. Previously the
+orchestration codegen recovered it at emit time from two signals: a
+`scope_hoist_sink_` pointer (are we buffering a manual scope?) and an indent
+comparison (`IsAtManualScopeBodyIndent()` — is this the scope's *direct* body?),
+plus an on-the-fly `ShapeDependsOnLocalVars` analysis. The indent heuristic and
+the shape analysis are exactly the analysis the ["strict 1-to-1
+codegen"](../codegen/01-orchestration_codegen.md) contract asks to move into a
+pass.
+
+**When to use**: after
+[`MaterializeRuntimeScopes`](41-materialize_runtime_scopes.md), so the
+manual-scope boundary is an explicit `RuntimeScopeStmt(manual=True)` edge rather
+than an indent level. Only `FunctionType::Orchestration` functions are touched.
+
+## What gets marked
+
+A `tensor.create` `Call` is stamped `hoistable_alloc = True` exactly when:
+
+1. Its `AssignStmt` is a **direct** child of a `RuntimeScopeStmt(manual=True)`
+   body (a create nested in a for/if *within* the scope is left in place — it
+   belongs to the loop/branch C++ scope, not the manual block).
+2. Its result shape references **no** `Var` defined inside that manual-scope body
+   — i.e. the buffer is *enclosing-scope-valid*. A shape dimension that depends
+   on a scope-local value could not be evaluated one level out, so such a create
+   stays put.
+
+Nested manual scopes are handled: each scope stamps only its own direct-body
+creates, computed against its own body-local def set, so a buffer hoisted out of
+an inner scope lands in the outer scope's body.
+
+The pass never rewrites structure — it only appends the attr to the create
+`Call`. The physical relocation (routing the `alloc_tensors` batch into the
+enclosing scope, and remapping aliasing kernel outputs) stays in codegen; this
+pass only supplies the decision.
+
+## Stamped attribute
+
+| Key | Type | Meaning |
+| --- | ---- | ------- |
+| `hoistable_alloc` | `bool` | `True` on a `tensor.create` `Call` = hoist this buffer's declaration out of its enclosing `pl.manual_scope`. Absent = leave in place. |
+
+The key round-trips through the printer/parser (see the `python_printer`
+op-attr allowlist and `ast_parser._parse_op_attrs`).
+
+## Example
+
+```python
+@pl.function(type=pl.FunctionType.Orchestration)
+def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+    with pl.manual_scope():
+        scratch = pl.create_tensor([64], dtype=pl.FP32)  # hoistable
+        a, a_tid = pl.submit(self.k, x, scratch)
+    b, _ = pl.submit(self.k, a, x)                        # reads `a` after the scope
+    return b
+```
+
+After the pass the `scratch` create carries `attrs={"hoistable_alloc": True}`.
+Codegen emits its `alloc_tensors` batch *before* the `PTO2_SCOPE(MANUAL) {`
+header, so the `const Tensor& scratch = ...;` declaration stays live for readers
+placed after the block.
+
+A create nested in a `for` within the scope, or one whose shape references a
+value computed inside the scope, is **not** marked and stays inside the block.
+
+## Pass properties
+
+| - | Properties |
+| - | ---------- |
+| Required | `CallDirectionsResolved`, `RuntimeScopesMaterialized` |
+| Produced | `HoistableAllocsMarked`, `RuntimeScopesMaterialized` |
+| Invalidated | — |
+
+`HoistableAllocsMarked` is a codegen precondition (see
+`VerifyOrchestrationCodegenPreconditions`) and has a registered property
+verifier: an enclosing-scope-valid `tensor.create` in a manual-scope body with no
+`hoistable_alloc` attr means the pass never ran, and codegen would leave the
+buffer declared inside the block — an after-scope reader would then reference an
+out-of-scope C++ local (#1697).
+
+## See also
+
+- [MaterializeRuntimeScopes](41-materialize_runtime_scopes.md) — materializes the `RuntimeScopeStmt(manual=True)` edge this pass keys on
+- [ClassifyIterArgCarry](42-classify_iter_arg_carry.md) — the sibling attr-stamping pass that runs just before
+- [Orchestration codegen](../codegen/01-orchestration_codegen.md) — the consumer of the stamped attr
+- [Pass manager](00-pass_manager.md)

--- a/docs/zh-cn/dev/passes/00-pass_manager.md
+++ b/docs/zh-cn/dev/passes/00-pass_manager.md
@@ -93,6 +93,7 @@ struct PassProperties {
 | Simplify | — | — | — |
 | MaterializeRuntimeScopes | SplitIncoreOrch, CallDirectionsResolved | RuntimeScopesMaterialized | — |
 | ClassifyIterArgCarry | CallDirectionsResolved, RuntimeScopesMaterialized | IterArgCarryClassified, RuntimeScopesMaterialized | — |
+| HoistScopeLocalAllocs | CallDirectionsResolved, RuntimeScopesMaterialized | HoistableAllocsMarked, RuntimeScopesMaterialized | — |
 
 > **注意**：VerifySSA 和 TypeCheck 是**属性验证器 (PropertyVerifier)**（验证规则），不是 Pass。它们通过 `VerificationInstrument` 或 `run_verifier()` 工具函数运行——参见[验证器](99-verifier.md)。
 
@@ -411,6 +412,7 @@ with passes.PassContext([passes.VerificationInstrument(passes.VerificationMode.A
 30. `Simplify`
 31. [`MaterializeRuntimeScopes`](41-materialize_runtime_scopes.md)（插入 AUTO RuntimeScopeStmt，使 orchestration codegen 1:1 emit PTO2_SCOPE）
 32. [`ClassifyIterArgCarry`](42-classify_iter_arg_carry.md)（把每个 ForStmt iter_arg 标注为平凡别名 / 重绑定 carry，并为 manual-scope TaskId fence 数组定尺）
+33. [`HoistScopeLocalAllocs`](43-hoist_scope_local_allocs.md)（给 manual-scope 体内每个 enclosing-scope-valid 的 `tensor.create` 打上 `hoistable_alloc`，使 codegen 把其声明外提出块，#1697）
 
 `DebugTileOptimization` 只是用于排查 PTO tile 阶段的调试策略，会跳过
 tensor-only 前缀 pass。正常编译和非 strategy 专项测试都应优先使用

--- a/docs/zh-cn/dev/passes/43-hoist_scope_local_allocs.md
+++ b/docs/zh-cn/dev/passes/43-hoist_scope_local_allocs.md
@@ -1,0 +1,95 @@
+# HoistScopeLocalAllocs Pass（分配外提）
+
+给每个**直接**位于 `pl.manual_scope` 体内、且 *enclosing-scope-valid*（外层作用域
+可见）的 `tensor.create` 打上 `hoistable_alloc` 属性，使 orchestration codegen 把
+该 buffer 的声明外提一层 C++ 作用域，而不再靠 emit 期缩进算术恢复外提集合
+（issue #1697）。
+
+## 概览
+
+`pl.manual_scope` 会降级为一个 `PTO2_SCOPE(PTO2ScopeMode::MANUAL) { ... }` C++ 块。
+manual scope 是**调度**（scheduling）区域，而非**存储**（storage）区域：块内分配的
+buffer 可能被排在块 *之后* 的 task 读取。若该 buffer 的声明留在块内，则这个 C++ 局部
+变量会在闭括号处出作用域，块后 reader 引用它就会编译失败。
+
+`alloc_tensors(...)` 没有任何调度依赖，所以把它外提一层（放到
+`PTO2_SCOPE(MANUAL) {` 头之前）在语义上是等价（inert）的，并且能让该 buffer 在块内
+与所有块后 reader 处都保持在作用域内。
+
+本 pass 把「哪些 create 会被外提」变成显式的 IR 事实。此前 orchestration codegen 在
+emit 期靠两个信号恢复它：`scope_hoist_sink_` 指针（当前是否正在缓冲一个 manual
+scope？）与缩进比较（`IsAtManualScopeBodyIndent()`——当前是否是该 scope 的*直接*体？），
+外加即时的 `ShapeDependsOnLocalVars` 分析。这套缩进启发式与 shape 分析，正是
+[「严格 1-to-1 codegen」](../codegen/01-orchestration_codegen.md) 契约要求搬进 pass 的内容。
+
+**使用时机**：在
+[`MaterializeRuntimeScopes`](41-materialize_runtime_scopes.md) 之后运行，使 manual-scope
+边界是一条显式的 `RuntimeScopeStmt(manual=True)` 边，而非某个缩进层级。仅处理
+`FunctionType::Orchestration` 函数。
+
+## 标记条件
+
+一个 `tensor.create` `Call` 会被打上 `hoistable_alloc = True`，当且仅当：
+
+1. 它的 `AssignStmt` 是某个 `RuntimeScopeStmt(manual=True)` 体的**直接**子语句
+   （嵌套在该 scope *内部* 某个 for/if 里的 create 保持原地——它属于 loop/branch 的
+   C++ 作用域，而不是 manual 块）。
+2. 它的结果 shape **不**引用该 manual-scope 体内定义的任何 `Var`——即该 buffer 是
+   *enclosing-scope-valid*（外层可见）。若某个 shape 维度依赖 scope-local 值，则外提
+   到外层后无法求值，因此这种 create 保持原地。
+
+支持嵌套 manual scope：每个 scope 只标记它自己的直接体 create，并按各自的体内定义
+集合计算，因此从内层 scope 外提的 buffer 会落在外层 scope 的体内。
+
+本 pass 从不改写结构——它只在 create `Call` 上追加属性。物理搬移（把
+`alloc_tensors` 批次路由到外层 scope，以及重映射别名到该 buffer 的 kernel 输出）仍留在
+codegen；本 pass 只提供决策。
+
+## 打上的属性
+
+| 键 | 类型 | 含义 |
+| -- | ---- | ---- |
+| `hoistable_alloc` | `bool` | `True` 打在 `tensor.create` `Call` 上 = 把该 buffer 的声明外提出其所在的 `pl.manual_scope`。缺省 = 保持原地。 |
+
+该键可经 printer/parser 往返（见 `python_printer` 的 op-attr 白名单与
+`ast_parser._parse_op_attrs`）。
+
+## 示例
+
+```python
+@pl.function(type=pl.FunctionType.Orchestration)
+def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+    with pl.manual_scope():
+        scratch = pl.create_tensor([64], dtype=pl.FP32)  # 可外提
+        a, a_tid = pl.submit(self.k, x, scratch)
+    b, _ = pl.submit(self.k, a, x)                        # 在 scope 之后读 `a`
+    return b
+```
+
+pass 运行后 `scratch` create 带上 `attrs={"hoistable_alloc": True}`。codegen 会把它的
+`alloc_tensors` 批次 emit 在 `PTO2_SCOPE(MANUAL) {` 头 *之前*，使
+`const Tensor& scratch = ...;` 声明对块后 reader 仍然存活。
+
+嵌套在 scope 内某个 `for` 里的 create、或 shape 引用了 scope 内计算值的 create，都**不会**
+被标记，保持在块内。
+
+## Pass 属性
+
+| - | 属性 |
+| - | ---- |
+| Required | `CallDirectionsResolved`、`RuntimeScopesMaterialized` |
+| Produced | `HoistableAllocsMarked`、`RuntimeScopesMaterialized` |
+| Invalidated | — |
+
+`HoistableAllocsMarked` 是 codegen 前置条件（见
+`VerifyOrchestrationCodegenPreconditions`），并注册了 property verifier：manual-scope 体内
+一个 enclosing-scope-valid 的 `tensor.create` 若没有 `hoistable_alloc` 属性，就意味着本
+pass 从未运行，codegen 会把该 buffer 留在块内声明——块后 reader 便会引用一个出作用域的
+C++ 局部变量（#1697）。
+
+## 参见
+
+- [MaterializeRuntimeScopes](41-materialize_runtime_scopes.md)——物化本 pass 所依赖的 `RuntimeScopeStmt(manual=True)` 边
+- [ClassifyIterArgCarry](42-classify_iter_arg_carry.md)——紧邻其前运行的同类属性标记 pass
+- [Orchestration codegen](../codegen/01-orchestration_codegen.md)——标记属性的消费者
+- [Pass manager](00-pass_manager.md)

--- a/include/pypto/ir/transforms/ir_property.h
+++ b/include/pypto/ir/transforms/ir_property.h
@@ -90,6 +90,10 @@ enum class IRProperty : uint64_t {
                                     ///< ``iter_arg_array_size_<i>`` for TaskId array carries), so
                                     ///< orchestration codegen reads the carry lowering instead of
                                     ///< re-deriving it
+  HoistableAllocsMarked,            ///< Every enclosing-scope-valid ``tensor.create`` sitting directly in a
+                                    ///< ``pl.manual_scope`` body carries the ``hoistable_alloc`` attr, so
+                                    ///< orchestration codegen reads the manual-scope allocation-hoist set
+                                    ///< instead of re-deriving it from emit-time indent arithmetic (#1697)
   kCount                            ///< Sentinel (must be last)
 };
 

--- a/include/pypto/ir/transforms/pass_properties.h
+++ b/include/pypto/ir/transforms/pass_properties.h
@@ -69,6 +69,16 @@ inline const PassProperties kClassifyIterArgCarryProperties{
     .required = {IRProperty::CallDirectionsResolved, IRProperty::RuntimeScopesMaterialized},
     .produced = {IRProperty::IterArgCarryClassified, IRProperty::RuntimeScopesMaterialized}};
 
+// -- HoistScopeLocalAllocs pass (runs after MaterializeRuntimeScopes) ---------
+//    Marks each enclosing-scope-valid ``tensor.create`` sitting directly in a
+//    ``pl.manual_scope`` body with the ``hoistable_alloc`` attr, so
+//    orchestration codegen reads the allocation-hoist set instead of re-deriving
+//    it from emit-time indent arithmetic (issue #1697). Requires the explicit
+//    RuntimeScopeStmt wrappers so the manual-scope boundary is a structural fact.
+inline const PassProperties kHoistScopeLocalAllocsProperties{
+    .required = {IRProperty::CallDirectionsResolved, IRProperty::RuntimeScopesMaterialized},
+    .produced = {IRProperty::HoistableAllocsMarked, IRProperty::RuntimeScopesMaterialized}};
+
 // -- Loop unrolling pass (runs before SSA) ------------------------------------
 
 inline const PassProperties kUnrollLoopsProperties{.produced = {IRProperty::UnrollResolved}};

--- a/include/pypto/ir/transforms/passes.h
+++ b/include/pypto/ir/transforms/passes.h
@@ -797,6 +797,30 @@ Pass MaterializeRuntimeScopes();
 Pass ClassifyIterArgCarry();
 
 /**
+ * @brief Mark manual-scope-local allocations that codegen must hoist (#1697)
+ *
+ * A ``pl.manual_scope`` (``RuntimeScopeStmt`` with ``manual_ == true``) is a
+ * scheduling region, not a storage scope: a buffer it allocates via
+ * ``tensor.create`` may be read by a task placed AFTER the block, so the
+ * generated C++ declaration must live one level out to stay in scope at the
+ * after-scope reader. Otherwise the local dies at the block's closing brace and
+ * the reference fails to compile (issue #1697).
+ *
+ * Orchestration codegen used to recover the alloc-hoist set from emit-time
+ * indent arithmetic plus an on-the-fly shape-locality analysis. This pass moves
+ * that decision into the IR: it stamps the ``hoistable_alloc`` attr on every
+ * ``tensor.create`` that sits directly in a manual-scope body (not nested in a
+ * for/if within it) and whose result shape references no Var defined inside that
+ * body — i.e. is enclosing-scope-valid. The batched-alloc hoist gate then reads
+ * the attr instead of the indent heuristic. Nested manual scopes are handled;
+ * only ``FunctionType::Orchestration`` functions are touched.
+ *
+ * Runs after ``MaterializeRuntimeScopes``, so the manual-scope boundary is an
+ * explicit structural fact rather than a codegen indent heuristic.
+ */
+Pass HoistScopeLocalAllocs();
+
+/**
  * @brief Copy each cross-core tpop's split/pipe-id onto its matching tfree op
  *
  * A `system.tfree_to_ai{c,v}` carries no split/id of its own — those live on the

--- a/include/pypto/ir/transforms/utils/attrs.h
+++ b/include/pypto/ir/transforms/utils/attrs.h
@@ -215,6 +215,20 @@ inline std::string IterArgArraySizeAttrKey(size_t idx) {
   return std::string(kIterArgArraySizeAttrPrefix) + std::to_string(idx);
 }
 
+/// ``bool`` attr on a ``tensor.create`` ``Call`` marking it as a scope-local
+/// allocation that codegen must hoist out of its enclosing ``pl.manual_scope``
+/// (``RuntimeScopeStmt`` with ``manual_ == true``) into the enclosing scope.
+///
+/// Stamped by ``HoistScopeLocalAllocs`` on exactly the creates that sit directly
+/// in a manual-scope body (not nested in a for/if within it) and whose result
+/// shape does not reference any Var defined inside that body — i.e. the buffer
+/// is enclosing-scope-valid. A manual_scope is a scheduling region, not a
+/// storage scope: a buffer it allocates may be read by a task placed AFTER the
+/// block, so its C++ declaration must live one level out to stay in scope at the
+/// after-scope reader (issue #1697). Orchestration codegen reads this attr
+/// instead of re-deriving the hoist set from emit-time indent arithmetic.
+inline constexpr const char* kAttrHoistableAlloc = "hoistable_alloc";
+
 }  // namespace ir
 }  // namespace pypto
 

--- a/include/pypto/ir/verifier/verifier.h
+++ b/include/pypto/ir/verifier/verifier.h
@@ -339,6 +339,18 @@ PropertyVerifierPtr CreateUnrollResolvedPropertyVerifier();
 PropertyVerifierPtr CreateIterArgCarryClassifiedPropertyVerifier();
 
 /**
+ * @brief Factory function for creating HoistableAllocsMarked property verifier
+ *
+ * Verifies that every enclosing-scope-valid ``tensor.create`` sitting directly
+ * in a ``pl.manual_scope`` body of a ``FunctionType::Orchestration`` function
+ * carries the ``hoistable_alloc`` attr stamped by ``HoistScopeLocalAllocs``
+ * (issue #1697).
+ *
+ * @return Shared pointer to HoistableAllocsMarked PropertyVerifier
+ */
+PropertyVerifierPtr CreateHoistableAllocsMarkedPropertyVerifier();
+
+/**
  * @brief Factory function for creating CallDirectionsResolved property verifier
  *
  * Verifies that every non-builtin ``Call`` in the program carries a fully

--- a/python/bindings/modules/passes.cpp
+++ b/python/bindings/modules/passes.cpp
@@ -115,7 +115,11 @@ void BindPass(nb::module_& m) {
       .value("IterArgCarryClassified", IRProperty::IterArgCarryClassified,
              "Every ForStmt with iter_args in an Orchestration function carries an "
              "attrs['iter_arg_rebind_<i>'] classification per slot (plus attrs['iter_arg_array_size_<i>'] "
-             "for TaskId array carries), so orchestration codegen reads the carry lowering");
+             "for TaskId array carries), so orchestration codegen reads the carry lowering")
+      .value("HoistableAllocsMarked", IRProperty::HoistableAllocsMarked,
+             "Every enclosing-scope-valid tensor.create sitting directly in a pl.manual_scope body "
+             "carries attrs['hoistable_alloc'], so orchestration codegen reads the allocation-hoist "
+             "set instead of re-deriving it from emit-time indent arithmetic (#1697)");
 
   // Bind IRPropertySet
   auto ir_property_set = nb::class_<IRPropertySet>(passes, "IRPropertySet", "A set of IR properties");
@@ -546,6 +550,13 @@ void BindPass(nb::module_& m) {
              "slot) and attrs['iter_arg_array_size_<i>'] (int, positive extents only) onto each\n"
              "ForStmt, so orchestration codegen reads the carry lowering instead of re-deriving\n"
              "it from an alias fixpoint. Runs last, after materialize_runtime_scopes.");
+  passes.def("hoist_scope_local_allocs", &pass::HoistScopeLocalAllocs,
+             "Mark manual-scope-local allocations that codegen must hoist (#1697).\n\n"
+             "For every Orchestration function, stamps attrs['hoistable_alloc']=True onto each\n"
+             "tensor.create that sits directly in a pl.manual_scope body and whose result shape\n"
+             "references no Var defined inside that body (enclosing-scope-valid). Orchestration\n"
+             "codegen reads this set instead of re-deriving it from emit-time indent arithmetic.\n"
+             "Runs after materialize_runtime_scopes.");
   passes.def("normalize_stmt_structure", &pass::NormalizeStmtStructure,
              "Create a pass that normalizes statement structure");
   passes.def("derive_call_directions", &pass::DeriveCallDirections,

--- a/python/pypto/ir/pass_manager.py
+++ b/python/pypto/ir/pass_manager.py
@@ -210,6 +210,13 @@ class PassManager:
             # MaterializeRuntimeScopes so the classified IR is exactly the IR
             # orchestration codegen lowers.
             passes.classify_iter_arg_carry,
+            # Mark manual-scope-local allocations that codegen must hoist out of
+            # their pl.manual_scope into the enclosing scope (#1697), stamping the
+            # ``hoistable_alloc`` attr onto each enclosing-scope-valid tensor.create
+            # sitting directly in a manual-scope body. Runs after
+            # MaterializeRuntimeScopes so the manual-scope boundary is an explicit
+            # RuntimeScopeStmt(manual=True) edge, not an emit-time indent heuristic.
+            passes.hoist_scope_local_allocs,
         )
         if strategy == OptimizationStrategy.Default:
             return tensor_prefix_passes + tensor_only_passes + tile_pto_passes

--- a/python/pypto/pypto_core/passes.pyi
+++ b/python/pypto/pypto_core/passes.pyi
@@ -55,6 +55,7 @@ class IRProperty(Enum):
     ReturnParamsExplicit = ...
     AivSplitValid = ...
     IterArgCarryClassified = ...
+    HoistableAllocsMarked = ...
 
 class IRPropertySet:
     """A set of IR properties backed by a bitset."""
@@ -677,6 +678,24 @@ def classify_iter_arg_carry() -> Pass:
 
     Runs last, after :func:`materialize_runtime_scopes`, so the classified IR is
     exactly the IR codegen lowers.
+    """
+
+def hoist_scope_local_allocs() -> Pass:
+    """Mark manual-scope-local allocations that codegen must hoist (#1697).
+
+    For every ``FunctionType.Orchestration`` function, stamps
+    ``attrs['hoistable_alloc'] = True`` onto each ``tensor.create`` that sits
+    directly in a ``pl.manual_scope`` body (``RuntimeScopeStmt`` with
+    ``manual_ == True``) and whose result shape references no ``Var`` defined
+    inside that body — i.e. the buffer is enclosing-scope-valid.
+
+    A ``pl.manual_scope`` is a scheduling region, not a storage scope: a buffer
+    it allocates may be read by a task placed after the block, so its C++
+    declaration must live one level out. Orchestration codegen reads this set
+    instead of re-deriving it from emit-time indent arithmetic.
+
+    Runs after :func:`materialize_runtime_scopes`, so the manual-scope boundary
+    is an explicit structural fact.
     """
 
 class NestedCallErrorType(Enum):

--- a/src/codegen/codegen_preconditions.cpp
+++ b/src/codegen/codegen_preconditions.cpp
@@ -66,10 +66,12 @@ void VerifyOrchestrationCodegenPreconditions(const ProgramPtr& program, const Fu
       << "Internal error: GenerateOrchestration preconditions — function must not be null";
 
   // Codegen assumes hierarchy references resolved, explicit RuntimeScopeStmt
-  // materialization, and a stamped iter_arg carry plan on every ForStmt.
+  // materialization, a stamped iter_arg carry plan on every ForStmt, and the
+  // manual-scope allocation-hoist set marked on every hoistable tensor.create.
   pass::VerifyProperties(
       IRPropertySet{IRProperty::SplitIncoreOrch, IRProperty::OrchestrationReferencesResolved,
-                    IRProperty::RuntimeScopesMaterialized, IRProperty::IterArgCarryClassified},
+                    IRProperty::RuntimeScopesMaterialized, IRProperty::IterArgCarryClassified,
+                    IRProperty::HoistableAllocsMarked},
       program, "GenerateOrchestration preconditions");
 }
 

--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -48,6 +48,7 @@
 #include "pypto/ir/scalar_expr.h"
 #include "pypto/ir/stmt.h"
 #include "pypto/ir/transforms/base/visitor.h"
+#include "pypto/ir/transforms/utils/attrs.h"
 #include "pypto/ir/transforms/utils/auto_name_utils.h"
 #include "pypto/ir/transforms/utils/transform_utils.h"
 #include "pypto/ir/transforms/utils/var_collectors.h"
@@ -2828,15 +2829,28 @@ class OrchestrationStmtCodegen : public CodegenBase {
     // deep block indent — so a buffer created inside the scope but read by a
     // task placed AFTER it stays in C++ scope. A manual_scope is a scheduling
     // region, not a storage scope: an ``alloc_tensors`` has no scheduling
-    // dependency, so emitting it one level out is semantically inert. The batch
-    // is enclosing-scope-valid by construction — ShapeDependsOnLocalVars already
-    // excluded any create whose shape references a scope-local value (those fall
-    // to the per-op path and stay put). The ``+ 4`` guard restricts this to the
-    // scope's own body, so a create nested in a for/if *within* the manual scope
-    // is left in place. Erasing the hoisted names from ``manual_local_names_``
-    // then lets a kernel output that aliases such a buffer remap to it
-    // (EmitTensorAlias / IsEnclosingScopeValid).
-    const bool hoist_batch = scope_hoist_sink_ != nullptr && IsAtManualScopeBodyIndent();
+    // dependency, so emitting it one level out is semantically inert.
+    //
+    // The alloc-hoist set is an explicit IR fact: HoistScopeLocalAllocs stamps
+    // ``hoistable_alloc`` on exactly the enclosing-scope-valid creates sitting
+    // directly in a manual-scope body (nested-in-for/if creates are not stamped).
+    // This gate reads that attr instead of recovering "direct manual-scope body"
+    // from ``IsAtManualScopeBodyIndent()`` (still used for the other hoist paths —
+    // mutable-carry decls, SSA-copy collapse). Every create that reaches
+    // ``creates`` inside a manual-scope body carries it (the pass's shape-locality
+    // gate and the collect-loop's ShapeDependsOnLocalVars gate agree), so the
+    // whole batch is hoisted iff its creates are stamped. Erasing the hoisted
+    // names from ``manual_local_names_`` then lets a kernel output that aliases
+    // such a buffer remap to it (EmitTensorAlias / IsEnclosingScopeValid).
+    const bool hoist_batch = scope_hoist_sink_ != nullptr && !creates.empty() &&
+                             creates.front().call->HasAttr(kAttrHoistableAlloc);
+    if (hoist_batch) {
+      for (const auto& c : creates) {
+        INTERNAL_CHECK_SPAN(c.call->HasAttr(kAttrHoistableAlloc), c.call->span_)
+            << "Internal error: manual-scope alloc batch mixes hoistable and non-hoistable creates; "
+               "HoistScopeLocalAllocs and EmitBatchedAllocTensors disagree on the hoist set";
+      }
+    }
     CodeEmitter batch_emitter;
     CodeEmitter* saved_active = active_emitter_;
     const int saved_indent_level = Active().GetIndentLevel();

--- a/src/ir/transforms/hoist_scope_local_allocs_pass.cpp
+++ b/src/ir/transforms/hoist_scope_local_allocs_pass.cpp
@@ -1,0 +1,205 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <any>
+#include <memory>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include "pypto/core/logging.h"
+#include "pypto/ir/expr.h"
+#include "pypto/ir/function.h"
+#include "pypto/ir/kind_traits.h"
+#include "pypto/ir/op_registry.h"
+#include "pypto/ir/program.h"
+#include "pypto/ir/scalar_expr.h"
+#include "pypto/ir/stmt.h"
+#include "pypto/ir/transforms/base/mutator.h"
+#include "pypto/ir/transforms/base/visitor.h"
+#include "pypto/ir/transforms/pass_properties.h"
+#include "pypto/ir/transforms/passes.h"
+#include "pypto/ir/transforms/utils/attrs.h"
+#include "pypto/ir/transforms/utils/mutable_copy.h"
+#include "pypto/ir/type.h"
+
+namespace pypto {
+namespace ir {
+namespace pass {
+
+namespace {
+
+/// True when @p stmt is ``X = tensor.create(...)``.
+CallPtr AsTensorCreateAssign(const StmtPtr& stmt) {
+  auto assign = As<AssignStmt>(stmt);
+  if (!assign) return nullptr;
+  auto call = As<Call>(assign->value_);
+  if (!call || !call->op_ || !IsOp(call, "tensor.create")) return nullptr;
+  return call;
+}
+
+/// Collects every Var *defined* anywhere within a statement subtree.
+///
+/// A ``tensor.create`` sitting directly in a manual-scope body can only be
+/// hoisted to the enclosing scope when its result shape is valid there — i.e.
+/// no dimension references a value produced inside the body. This visitor
+/// gathers that body-local def set. Collecting the whole subtree (rather than
+/// only the top-level predecessors the codegen tracked) is a safe superset:
+/// under SSA a top-level create's shape can only reference values that dominate
+/// it, so a def nested in a for/if — or one appearing later — never matches.
+class BodyDefCollector : public IRVisitor {
+ public:
+  std::unordered_set<const Var*> defs;
+
+ protected:
+  void VisitStmt_(const AssignStmtPtr& op) override {
+    if (op->var_) defs.insert(op->var_.get());
+    IRVisitor::VisitStmt_(op);
+  }
+
+  void VisitStmt_(const ForStmtPtr& op) override {
+    if (op->loop_var_) defs.insert(op->loop_var_.get());
+    for (const auto& ia : op->iter_args_) {
+      if (ia) defs.insert(ia.get());
+    }
+    for (const auto& rv : op->return_vars_) {
+      if (rv) defs.insert(rv.get());
+    }
+    IRVisitor::VisitStmt_(op);
+  }
+
+  void VisitStmt_(const IfStmtPtr& op) override {
+    for (const auto& rv : op->return_vars_) {
+      if (rv) defs.insert(rv.get());
+    }
+    IRVisitor::VisitStmt_(op);
+  }
+};
+
+/// True when @p expr references any Var in @p vars. Shape dimensions are simple
+/// integer expressions (Var / BinaryExpr / UnaryExpr / Cast), mirroring the
+/// former codegen ``ExprRefsAnyOf`` helper this pass replaces.
+bool ExprRefsAnyOf(const ExprPtr& expr, const std::unordered_set<const Var*>& vars) {
+  if (!expr) return false;
+  if (auto var = AsVarLike(expr)) return vars.count(var.get()) > 0;
+  if (auto bin = As<BinaryExpr>(expr)) {
+    return ExprRefsAnyOf(bin->left_, vars) || ExprRefsAnyOf(bin->right_, vars);
+  }
+  if (auto un = As<UnaryExpr>(expr)) return ExprRefsAnyOf(un->operand_, vars);
+  if (auto cast_expr = As<Cast>(expr)) return ExprRefsAnyOf(cast_expr->operand_, vars);
+  return false;
+}
+
+/// True when no dimension of the create's result shape references a body-local
+/// Var — i.e. the buffer is enclosing-scope-valid and may be hoisted.
+bool ShapeIsEnclosingScopeValid(const CallPtr& create, const std::unordered_set<const Var*>& body_defs) {
+  auto result_type = AsTensorTypeLike(create->GetType());
+  if (!result_type) return false;
+  for (const auto& dim : result_type->shape_) {
+    if (ExprRefsAnyOf(dim, body_defs)) return false;
+  }
+  return true;
+}
+
+/// Returns a copy of @p create carrying the ``hoistable_alloc`` attr. Idempotent
+/// on the attr key so a re-run does not accumulate duplicates.
+CallPtr WithHoistableAttr(const CallPtr& create) {
+  auto copy = MutableCopy(create);
+  for (auto& [k, v] : copy->attrs_) {
+    if (k == kAttrHoistableAlloc) {
+      v = std::any(true);
+      return copy;
+    }
+  }
+  copy->attrs_.emplace_back(kAttrHoistableAlloc, std::any(true));
+  return copy;
+}
+
+/// Given the body of a manual scope, stamp every direct top-level
+/// ``tensor.create`` whose shape is enclosing-scope-valid. Only the immediate
+/// children of the body are considered — a create nested in a for/if within the
+/// scope is not a direct-body statement and stays in place.
+StmtPtr StampDirectBodyCreates(const StmtPtr& body, const std::unordered_set<const Var*>& body_defs,
+                               bool* changed) {
+  auto stamp_one = [&](const StmtPtr& stmt) -> StmtPtr {
+    auto create = AsTensorCreateAssign(stmt);
+    if (!create || !ShapeIsEnclosingScopeValid(create, body_defs)) return stmt;
+    if (create->HasAttr(kAttrHoistableAlloc)) return stmt;  // already stamped
+    auto assign = As<AssignStmt>(stmt);
+    *changed = true;
+    return std::make_shared<const AssignStmt>(assign->var_, WithHoistableAttr(create), assign->span_,
+                                              assign->leading_comments_);
+  };
+
+  if (auto seq = As<SeqStmts>(body)) {
+    std::vector<StmtPtr> new_stmts;
+    new_stmts.reserve(seq->stmts_.size());
+    for (const auto& s : seq->stmts_) new_stmts.push_back(stamp_one(s));
+    return std::make_shared<const SeqStmts>(std::move(new_stmts), seq->span_, seq->leading_comments_);
+  }
+  return stamp_one(body);
+}
+
+/// Walks an Orchestration function body, stamping the hoistable-alloc set of
+/// every ``pl.manual_scope`` (``RuntimeScopeStmt`` with ``manual_ == true``).
+/// Nested manual scopes are handled by recursing first: each scope stamps only
+/// its own direct-body creates, computed against its own body-local def set.
+class HoistAllocStamper : public IRMutator {
+ protected:
+  StmtPtr VisitStmt_(const RuntimeScopeStmtPtr& op) override {
+    auto base = IRMutator::VisitStmt_(op);
+    if (!op->manual_) return base;
+
+    auto scope = As<RuntimeScopeStmt>(base);
+    INTERNAL_CHECK_SPAN(scope, op->span_)
+        << "Internal error: RuntimeScopeStmt mutation must yield a RuntimeScopeStmt";
+
+    BodyDefCollector collector;
+    collector.VisitStmt(scope->body_);
+
+    bool changed = false;
+    StmtPtr new_body = StampDirectBodyCreates(scope->body_, collector.defs, &changed);
+    if (!changed) return base;
+
+    auto copy = MutableCopy(scope);
+    copy->body_ = std::move(new_body);
+    return copy;
+  }
+};
+
+}  // namespace
+
+Pass HoistScopeLocalAllocs() {
+  auto pass_func = [](const ProgramPtr& program) -> ProgramPtr {
+    auto new_functions = program->functions_;
+    for (auto& [gvar, func] : new_functions) {
+      if (!func || !func->body_) continue;
+      // Only Orchestration functions carry ``pl.manual_scope`` regions whose
+      // allocations the orchestration codegen hoists (issue #1697).
+      if (func->func_type_ != FunctionType::Orchestration) continue;
+
+      HoistAllocStamper stamper;
+      auto new_body = stamper.VisitStmt(func->body_);
+      if (new_body.get() == func->body_.get()) continue;
+      func = std::make_shared<Function>(func->name_, func->params_, func->param_directions_,
+                                        func->return_types_, new_body, func->span_, func->func_type_,
+                                        func->level_, func->role_, func->attrs_);
+    }
+    if (new_functions == program->functions_) return program;
+    return std::make_shared<Program>(std::move(new_functions), program->name_, program->span_);
+  };
+
+  return CreateProgramPass(pass_func, "HoistScopeLocalAllocs", kHoistScopeLocalAllocsProperties);
+}
+
+}  // namespace pass
+}  // namespace ir
+}  // namespace pypto

--- a/src/ir/transforms/ir_property.cpp
+++ b/src/ir/transforms/ir_property.cpp
@@ -99,6 +99,8 @@ std::string IRPropertyToString(IRProperty prop) {
       return "HardSyncallOccupancyValid";
     case IRProperty::IterArgCarryClassified:
       return "IterArgCarryClassified";
+    case IRProperty::HoistableAllocsMarked:
+      return "HoistableAllocsMarked";
     default:
       return "Unknown";
   }

--- a/src/ir/transforms/python_printer.cpp
+++ b/src/ir/transforms/python_printer.cpp
@@ -1102,12 +1102,17 @@ void IRPythonPrinter::VisitExpr_(const CallPtr& op) {
   // either duplicate that surface or expose an internal marker the round-trip
   // tests don't expect. ``pipeline_membership`` (set by LowerPipelineLoops, read
   // by MemoryReuse) has no such surface and MUST round-trip, else the structural
-  // equality check after those passes fails. The matching reader is
-  // ``ast_parser`` (``_parse_op_attrs`` -> ``set_call_attrs``).
+  // equality check after those passes fails. ``hoistable_alloc`` (set by
+  // HoistScopeLocalAllocs on a manual-scope ``tensor.create``, read by
+  // orchestration codegen) is the same shape of internal marker and MUST
+  // round-trip too. The matching reader is ``ast_parser`` (``_parse_op_attrs``
+  // -> ``set_call_attrs``).
   {
     std::vector<const std::pair<std::string, std::any>*> serialized_attrs;
     for (const auto& kv : op->attrs_) {
-      if (kv.first == kPipelineMembershipAttr) serialized_attrs.push_back(&kv);
+      if (kv.first == kPipelineMembershipAttr || kv.first == kAttrHoistableAlloc) {
+        serialized_attrs.push_back(&kv);
+      }
     }
     if (!serialized_attrs.empty()) {
       stream_ << (need_comma ? ", " : "") << "attrs={";

--- a/src/ir/verifier/property_verifier_registry.cpp
+++ b/src/ir/verifier/property_verifier_registry.cpp
@@ -66,6 +66,7 @@ PropertyVerifierRegistry::PropertyVerifierRegistry() {
   Register(IRProperty::PipelineResolved, CreatePipelineResolvedPropertyVerifier);
   Register(IRProperty::UnrollResolved, CreateUnrollResolvedPropertyVerifier);
   Register(IRProperty::IterArgCarryClassified, CreateIterArgCarryClassifiedPropertyVerifier);
+  Register(IRProperty::HoistableAllocsMarked, CreateHoistableAllocsMarkedPropertyVerifier);
   Register(IRProperty::CallDirectionsResolved, CreateCallDirectionsResolvedPropertyVerifier);
   Register(IRProperty::TileTypeCoherence, CreateTileTypeCoherencePropertyVerifier);
   Register(IRProperty::InlineFunctionsEliminated, CreateInlineFunctionsEliminatedPropertyVerifier);

--- a/src/ir/verifier/verify_hoistable_allocs_marked.cpp
+++ b/src/ir/verifier/verify_hoistable_allocs_marked.cpp
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <memory>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+#include "pypto/core/error.h"
+#include "pypto/ir/expr.h"
+#include "pypto/ir/function.h"
+#include "pypto/ir/kind_traits.h"
+#include "pypto/ir/op_registry.h"
+#include "pypto/ir/program.h"
+#include "pypto/ir/scalar_expr.h"
+#include "pypto/ir/span.h"
+#include "pypto/ir/stmt.h"
+#include "pypto/ir/transforms/base/visitor.h"
+#include "pypto/ir/transforms/utils/attrs.h"
+#include "pypto/ir/type.h"
+#include "pypto/ir/verifier/verifier.h"
+
+namespace pypto {
+namespace ir {
+
+namespace {
+
+CallPtr AsTensorCreateAssign(const StmtPtr& stmt) {
+  auto assign = As<AssignStmt>(stmt);
+  if (!assign) return nullptr;
+  auto call = As<Call>(assign->value_);
+  if (!call || !call->op_ || !IsOp(call, "tensor.create")) return nullptr;
+  return call;
+}
+
+/// Collects every Var defined within a statement subtree — mirrors the
+/// enclosing-scope-validity gate ``HoistScopeLocalAllocs`` applies.
+class BodyDefCollector : public IRVisitor {
+ public:
+  std::unordered_set<const Var*> defs;
+
+ protected:
+  void VisitStmt_(const AssignStmtPtr& op) override {
+    if (op->var_) defs.insert(op->var_.get());
+    IRVisitor::VisitStmt_(op);
+  }
+  void VisitStmt_(const ForStmtPtr& op) override {
+    if (op->loop_var_) defs.insert(op->loop_var_.get());
+    for (const auto& ia : op->iter_args_) {
+      if (ia) defs.insert(ia.get());
+    }
+    for (const auto& rv : op->return_vars_) {
+      if (rv) defs.insert(rv.get());
+    }
+    IRVisitor::VisitStmt_(op);
+  }
+  void VisitStmt_(const IfStmtPtr& op) override {
+    for (const auto& rv : op->return_vars_) {
+      if (rv) defs.insert(rv.get());
+    }
+    IRVisitor::VisitStmt_(op);
+  }
+};
+
+bool ExprRefsAnyOf(const ExprPtr& expr, const std::unordered_set<const Var*>& vars) {
+  if (!expr) return false;
+  if (auto var = AsVarLike(expr)) return vars.count(var.get()) > 0;
+  if (auto bin = As<BinaryExpr>(expr)) {
+    return ExprRefsAnyOf(bin->left_, vars) || ExprRefsAnyOf(bin->right_, vars);
+  }
+  if (auto un = As<UnaryExpr>(expr)) return ExprRefsAnyOf(un->operand_, vars);
+  if (auto cast_expr = As<Cast>(expr)) return ExprRefsAnyOf(cast_expr->operand_, vars);
+  return false;
+}
+
+bool ShapeIsEnclosingScopeValid(const CallPtr& create, const std::unordered_set<const Var*>& body_defs) {
+  auto result_type = AsTensorTypeLike(create->GetType());
+  if (!result_type) return false;
+  for (const auto& dim : result_type->shape_) {
+    if (ExprRefsAnyOf(dim, body_defs)) return false;
+  }
+  return true;
+}
+
+/// Reports any enclosing-scope-valid ``tensor.create`` sitting directly in a
+/// ``pl.manual_scope`` body that is missing the ``hoistable_alloc`` attr. Such a
+/// create means ``HoistScopeLocalAllocs`` never ran — orchestration codegen
+/// would then leave the buffer declared inside the manual scope, and a task
+/// reading it after the block would reference an out-of-scope C++ local (#1697).
+class HoistMarkChecker : public IRVisitor {
+ public:
+  HoistMarkChecker(std::vector<Diagnostic>& diagnostics, const std::string& func_name)
+      : diagnostics_(diagnostics), func_name_(func_name) {}
+
+ protected:
+  void VisitStmt_(const RuntimeScopeStmtPtr& op) override {
+    if (op->manual_ && op->body_) {
+      BodyDefCollector collector;
+      collector.VisitStmt(op->body_);
+      CheckDirectBody(op->body_, collector.defs, op->span_);
+    }
+    IRVisitor::VisitStmt_(op);
+  }
+
+ private:
+  void CheckDirectBody(const StmtPtr& body, const std::unordered_set<const Var*>& body_defs,
+                       const Span& scope_span) {
+    auto check_one = [&](const StmtPtr& stmt) {
+      auto create = AsTensorCreateAssign(stmt);
+      if (!create || !ShapeIsEnclosingScopeValid(create, body_defs)) return;
+      if (create->HasAttr(kAttrHoistableAlloc)) return;
+      diagnostics_.emplace_back(
+          DiagnosticSeverity::Error, "HoistableAllocsMarked", 0,
+          "tensor.create in a pl.manual_scope body of function '" + func_name_ +
+              "' is enclosing-scope-valid but carries no attrs[\"" + std::string(kAttrHoistableAlloc) +
+              "\"]. HoistScopeLocalAllocs must run before orchestration codegen; without it the buffer "
+              "is declared inside the manual scope and an after-scope reader references an out-of-scope "
+              "C++ local (#1697).",
+          scope_span);
+    };
+    if (auto seq = As<SeqStmts>(body)) {
+      for (const auto& s : seq->stmts_) check_one(s);
+    } else {
+      check_one(body);
+    }
+  }
+
+  std::vector<Diagnostic>& diagnostics_;
+  const std::string& func_name_;
+};
+
+class HoistableAllocsMarkedPropertyVerifierImpl : public PropertyVerifier {
+ public:
+  [[nodiscard]] std::string GetName() const override { return "HoistableAllocsMarked"; }
+
+  void Verify(const ProgramPtr& program, std::vector<Diagnostic>& diagnostics) override {
+    if (!program) return;
+    for (const auto& [gv, func] : program->functions_) {
+      if (!func || !func->body_) continue;
+      if (func->func_type_ != FunctionType::Orchestration) continue;
+      HoistMarkChecker checker(diagnostics, func->name_);
+      checker.VisitStmt(func->body_);
+    }
+  }
+};
+
+}  // namespace
+
+PropertyVerifierPtr CreateHoistableAllocsMarkedPropertyVerifier() {
+  return std::make_shared<HoistableAllocsMarkedPropertyVerifierImpl>();
+}
+
+}  // namespace ir
+}  // namespace pypto

--- a/tests/ut/ir/transforms/test_hoist_scope_local_allocs.py
+++ b/tests/ut/ir/transforms/test_hoist_scope_local_allocs.py
@@ -1,0 +1,223 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Unit tests for the HoistScopeLocalAllocs pass.
+
+The pass stamps ``attrs['hoistable_alloc'] = True`` onto every ``tensor.create``
+that sits directly in a ``pl.manual_scope`` body (``RuntimeScopeStmt`` with
+``manual == True``) and whose result shape references no Var defined inside that
+body — the buffer is then enclosing-scope-valid and orchestration codegen hoists
+its declaration one level out (issue #1697). A create nested in a for/if within
+the scope, a shape-local create, or a create outside any manual scope is left
+unmarked.
+
+Tests assert on the stamped attr rather than a full Expected program: the pass
+rewrites nothing but the create Call's ``attrs``.
+"""
+
+import pypto.language as pl
+import pytest
+from pypto import backend, ir, passes
+from pypto.backend import BackendType
+from pypto.ir.pass_manager import OptimizationStrategy, PassManager
+from pypto.pypto_core import passes as _passes
+
+HOISTABLE_ATTR = "hoistable_alloc"
+FP32 = ir.DataType.FP32
+INDEX = ir.DataType.INDEX
+
+
+@pytest.fixture(autouse=True)
+def _setup_backend():
+    backend.reset_for_testing()
+    backend.set_backend_type(BackendType.Ascend910B)
+    yield
+    backend.reset_for_testing()
+
+
+def _create_call(shape):
+    return ir.Call(ir.Op("tensor.create"), [], ir.TensorType(shape, FP32), ir.Span.unknown())
+
+
+def _orch_program(body):
+    span = ir.Span.unknown()
+    func = ir.Function("orch", [], [], body, span, type=ir.FunctionType.Orchestration)
+    return ir.Program([func], "prog", span)
+
+
+def _run_pass(program):
+    """Run the pass on hand-built IR. Verification is disabled so the pass's
+    declared prerequisites (SSA / RuntimeScopesMaterialized / ...) need not be
+    materialised on the minimal fixtures — we exercise the stamping logic only."""
+    with passes.PassContext([], passes.VerificationLevel.NONE):
+        return passes.hoist_scope_local_allocs()(program)
+
+
+def _creates_in_program(program):
+    """Map ``var name_hint -> tensor.create Call`` for every create in the program."""
+    found = {}
+
+    def walk(node):
+        if node is None:
+            return
+        if isinstance(node, ir.RuntimeScopeStmt):
+            walk(node.body)
+        elif isinstance(node, ir.SeqStmts):
+            for c in node.stmts:
+                walk(c)
+        elif isinstance(node, ir.ForStmt):
+            walk(node.body)
+        elif isinstance(node, ir.IfStmt):
+            walk(node.then_body)
+            walk(node.else_body)
+        elif isinstance(node, ir.AssignStmt):
+            v = node.value
+            if isinstance(v, ir.Call) and v.op.name == ir.get_op("tensor.create").name:
+                found[node.var.name_hint] = v
+
+    for func in program.functions.values():
+        walk(func.body)
+    return found
+
+
+def _is_marked(call) -> bool:
+    return bool(dict(call.attrs).get(HOISTABLE_ATTR, False))
+
+
+def test_static_create_in_manual_scope_is_marked():
+    """A create with a constant shape directly in a manual-scope body is hoistable."""
+    span = ir.Span.unknown()
+    scratch = ir.Var("scratch", ir.TensorType([64], FP32), span)
+    manual_body = ir.SeqStmts([ir.AssignStmt(scratch, _create_call([64]), span)], span)
+    manual = ir.RuntimeScopeStmt(True, "m", body=manual_body, span=span)
+    body = ir.SeqStmts([manual, ir.ReturnStmt(span)], span)
+
+    out = _run_pass(_orch_program(body))
+    creates = _creates_in_program(out)
+    assert _is_marked(creates["scratch"]), "static manual-scope create must be marked hoistable"
+
+
+def test_create_outside_manual_scope_not_marked():
+    """A top-level create (no enclosing manual scope) is never marked."""
+    span = ir.Span.unknown()
+    t = ir.Var("t", ir.TensorType([64], FP32), span)
+    body = ir.SeqStmts([ir.AssignStmt(t, _create_call([64]), span), ir.ReturnStmt(span)], span)
+
+    out = _run_pass(_orch_program(body))
+    assert not _is_marked(_creates_in_program(out)["t"]), "create outside a manual scope must stay unmarked"
+
+
+def test_create_nested_in_for_within_manual_scope_not_marked():
+    """A create nested inside a for-loop within the manual scope is not a direct-body
+    statement, so it is not hoisted (it would fall out of the loop-body C++ scope)."""
+    span = ir.Span.unknown()
+    inner = ir.Var("inner", ir.TensorType([64], FP32), span)
+    loop_var = ir.Var("i", ir.ScalarType(INDEX), span)
+    for_body = ir.SeqStmts([ir.AssignStmt(inner, _create_call([64]), span)], span)
+    for_stmt = ir.ForStmt(
+        loop_var,
+        ir.ConstInt(0, INDEX, span),
+        ir.ConstInt(4, INDEX, span),
+        ir.ConstInt(1, INDEX, span),
+        [],
+        for_body,
+        [],
+        span,
+    )
+    manual = ir.RuntimeScopeStmt(True, "m", body=ir.SeqStmts([for_stmt], span), span=span)
+    body = ir.SeqStmts([manual, ir.ReturnStmt(span)], span)
+
+    out = _run_pass(_orch_program(body))
+    assert not _is_marked(_creates_in_program(out)["inner"]), "for-nested create must stay unmarked"
+
+
+def test_shape_local_create_not_marked():
+    """A create whose shape references a Var defined inside the manual-scope body is
+    not enclosing-scope-valid, so it is not hoisted."""
+    span = ir.Span.unknown()
+    dyn_n = ir.Var("n", ir.ScalarType(INDEX), span)
+    dim = ir.Mul(dyn_n, ir.ConstInt(16, INDEX, span), INDEX, span)
+
+    static_t = ir.Var("static_t", ir.TensorType([16, 8], FP32), span)
+    dyn_t = ir.Var("dyn_t", ir.TensorType([dim, ir.ConstInt(8, INDEX, span)], FP32), span)
+    manual_body = ir.SeqStmts(
+        [
+            ir.AssignStmt(static_t, _create_call([16, 8]), span),
+            ir.AssignStmt(dyn_n, ir.ConstInt(4, INDEX, span), span),  # body-local shape source
+            ir.AssignStmt(dyn_t, _create_call([dim, ir.ConstInt(8, INDEX, span)]), span),
+        ],
+        span,
+    )
+    manual = ir.RuntimeScopeStmt(True, "m", body=manual_body, span=span)
+    body = ir.SeqStmts([manual, ir.ReturnStmt(span)], span)
+
+    out = _run_pass(_orch_program(body))
+    creates = _creates_in_program(out)
+    assert _is_marked(creates["static_t"]), "constant-shape create must be marked"
+    assert not _is_marked(creates["dyn_t"]), "shape-local create must stay unmarked"
+
+
+def test_idempotent():
+    """Re-running the pass does not duplicate or flip the attr."""
+    span = ir.Span.unknown()
+    scratch = ir.Var("scratch", ir.TensorType([64], FP32), span)
+    manual = ir.RuntimeScopeStmt(
+        True, "m", body=ir.SeqStmts([ir.AssignStmt(scratch, _create_call([64]), span)], span), span=span
+    )
+    program = _orch_program(ir.SeqStmts([manual, ir.ReturnStmt(span)], span))
+
+    once = _run_pass(program)
+    twice = _run_pass(once)
+    call = _creates_in_program(twice)["scratch"]
+    keys = [k for k in dict(call.attrs) if k == HOISTABLE_ATTR]
+    assert keys == [HOISTABLE_ATTR], "attr must appear exactly once after a second run"
+    assert _is_marked(call)
+
+
+def test_pass_metadata():
+    """Required/produced properties."""
+    p = passes.hoist_scope_local_allocs()
+    required = p.get_required_properties()
+    produced = p.get_produced_properties()
+    assert required.contains(_passes.IRProperty.RuntimeScopesMaterialized)
+    assert required.contains(_passes.IRProperty.CallDirectionsResolved)
+    assert produced.contains(_passes.IRProperty.HoistableAllocsMarked)
+
+
+def test_full_pipeline_marks_manual_scope_create():
+    """End-to-end: a create inside a pl.manual_scope, consumed by a submit, is marked
+    by the default pipeline (which runs HoistScopeLocalAllocs after
+    MaterializeRuntimeScopes)."""
+
+    @pl.program
+    class Prog:
+        @pl.function(type=pl.FunctionType.InCore)
+        def k(
+            self, x: pl.Tensor[[64], pl.FP32], scratch: pl.Out[pl.Tensor[[64], pl.FP32]]
+        ) -> pl.Tensor[[64], pl.FP32]:
+            t = pl.load(x, [0], [64])
+            scratch = pl.store(t, [0], scratch)
+            return scratch
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            with pl.manual_scope():
+                scratch = pl.create_tensor([64], dtype=pl.FP32)
+                a, a_tid = pl.submit(self.k, x, scratch)
+            b, _ = pl.submit(self.k, a, x)
+            return b
+
+    transformed = PassManager.get_strategy(OptimizationStrategy.Default).run_passes(Prog)
+    creates = list(_creates_in_program(transformed).values())
+    assert creates, "expected a tensor.create in the compiled program"
+    assert all(_is_marked(c) for c in creates), "manual-scope create must be marked hoistable end-to-end"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/ut/ir/transforms/test_pass_manager.py
+++ b/tests/ut/ir/transforms/test_pass_manager.py
@@ -65,6 +65,7 @@ TENSOR_OPTIMIZATION_PASSES = [
     "Simplify",
     "MaterializeRuntimeScopes",
     "ClassifyIterArgCarry",
+    "HoistScopeLocalAllocs",
 ]
 
 DEBUG_TILE_OPTIMIZATION_PASSES = [
@@ -107,6 +108,7 @@ DEBUG_TILE_OPTIMIZATION_PASSES = [
     "Simplify",
     "MaterializeRuntimeScopes",
     "ClassifyIterArgCarry",
+    "HoistScopeLocalAllocs",
 ]
 
 


### PR DESCRIPTION
## Summary

Moves the manual-scope allocation-hoist decision (issue #1697) out of orchestration codegen's emit-time indent arithmetic and into an explicit IR fact, honoring the "strict 1-to-1 codegen" contract.

A `pl.manual_scope` is a **scheduling** region, not a **storage** region: a `tensor.create` inside it may be read by a task placed *after* the block, so its generated C++ declaration must be hoisted one scope out — otherwise the local dies at the closing brace and the after-scope reader fails to compile.

The new **`HoistScopeLocalAllocs`** pass stamps `hoistable_alloc` on every `tensor.create` that sits **directly** in a `RuntimeScopeStmt(manual=true)` body and whose result shape references no `Var` defined inside that body (i.e. is enclosing-scope-valid). Nested manual scopes are handled; only `Orchestration` functions are touched. Orchestration codegen's batched-alloc hoist gate now reads this attr instead of `IsAtManualScopeBodyIndent()` + an on-the-fly `ShapeDependsOnLocalVars` scan.

Threaded through every layer following the `ClassifyIterArgCarry` template:

- `IRProperty::HoistableAllocsMarked` + `PassProperties` + string mapping
- `PropertyVerifier` (`verify_hoistable_allocs_marked`) + registry entry
- `GenerateOrchestration` codegen precondition (guards against a skipped pass)
- `passes.h` factory, nanobind binding, `.pyi` stub, `pass_manager` insertion (after `MaterializeRuntimeScopes`)
- `python_printer` op-attr allowlist so the bool attr round-trips print → parse (binary `.pto` handles it generically by value type)
- docs `43-hoist_scope_local_allocs` (en + zh) + pass-manager overview

## Testing

- New pass unit tests (`test_hoist_scope_local_allocs.py`): static-marked, outside-scope-unmarked, for-nested-unmarked, shape-local-unmarked, idempotency, metadata, end-to-end pipeline
- Broad UT sweep green (transforms + codegen + printing + parser + serialization)
- End-to-end verified: `alloc_tensors(...)` is emitted before the `PTO2_SCOPE(MANUAL) {` header (the #1697 behavior), now driven by the IR attr

## Notes

- Orchestration-only in this PR. The distributed `_alloc_intermediates` (POSIX-shm pre-fork) hoisting is a distinct emission target and can adopt the same `hoistable_alloc` attr in a follow-up.

## Related Issues

Refs #1697