### PR TITLE
fix(codegen): Preserve distributed alias communication context

### DIFF
--- a/src/codegen/pto/pto_codegen.cpp
+++ b/src/codegen/pto/pto_codegen.cpp
@@ -1521,7 +1521,13 @@ void PTOCodegen::VisitStmt_(const AssignStmtPtr& op) {
         BindTensorView(op->var_, view);
         BindVarToMlir(op->var_, view);  // view name == SSA name, as in ForStmt
         RegisterBasePtr(op->var_, GetTensorBasePtr(rhs_var));
-        RegisterCommCtxFor(op->var_, GetCommCtxSSAFor(rhs_var.get()));
+        const std::string comm_ctx = GetCommCtxSSAFor(rhs_var.get());
+        if (As<ir::DistributedTensorType>(op->var_->GetType())) {
+          INTERNAL_CHECK_SPAN(!comm_ctx.empty(), op->span_)
+              << "Internal error: DistributedTensor alias '" << op->var_->name_hint_ << "' from source '"
+              << rhs_var->name_hint_ << "' has no CommContext binding";
+        }
+        RegisterCommCtxFor(op->var_, comm_ctx);
         return;
       }
     } else if (!emit_tile_addr_ && As<TileType>(op->var_->GetType())) {

--- a/src/codegen/pto/pto_control_flow_codegen.cpp
+++ b/src/codegen/pto/pto_control_flow_codegen.cpp
@@ -99,7 +99,13 @@ void PTOCodegen::VisitStmt_(const YieldStmtPtr& op) {
           // GetTensorBasePtr would fall back to the view SSA). Both branches
           // yield the same backing, so the recorded base ptr is consistent.
           fs_.view_ssa_to_base_ptr[view] = GetTensorBasePtr(tensor_var);
-          if (std::string comm_ctx = GetCommCtxSSAFor(tensor_var.get()); !comm_ctx.empty()) {
+          std::string comm_ctx = GetCommCtxSSAFor(tensor_var.get());
+          if (As<ir::DistributedTensorType>(expr->GetType())) {
+            INTERNAL_CHECK_SPAN(!comm_ctx.empty(), op->span_)
+                << "Internal error: yielded DistributedTensor '" << tensor_var->name_hint_
+                << "' has no CommContext binding";
+          }
+          if (!comm_ctx.empty()) {
             fs_.view_ssa_to_comm_ctx[view] = std::move(comm_ctx);
           }
           yielded_values.push_back(view);
@@ -172,27 +178,33 @@ bool IsDefinedInBranch(const ir::Var* var, const StmtPtr& body) {
     return true;
   }
   if (auto seq = As<ir::SeqStmts>(body)) {
-    for (const auto& s : seq->stmts_)
+    for (const auto& s : seq->stmts_) {
       if (IsDefinedInBranch(var, s)) return true;
+    }
     return false;
   }
   if (auto for_stmt = As<ir::ForStmt>(body)) {
-    for (const auto& ia : for_stmt->iter_args_)
+    for (const auto& ia : for_stmt->iter_args_) {
       if (ia.get() == var) return true;
-    for (const auto& rv : for_stmt->return_vars_)
+    }
+    for (const auto& rv : for_stmt->return_vars_) {
       if (rv.get() == var) return true;
+    }
     return IsDefinedInBranch(var, for_stmt->body_);
   }
   if (auto while_stmt = As<ir::WhileStmt>(body)) {
-    for (const auto& ia : while_stmt->iter_args_)
+    for (const auto& ia : while_stmt->iter_args_) {
       if (ia.get() == var) return true;
-    for (const auto& rv : while_stmt->return_vars_)
+    }
+    for (const auto& rv : while_stmt->return_vars_) {
       if (rv.get() == var) return true;
+    }
     return IsDefinedInBranch(var, while_stmt->body_);
   }
   if (auto if_stmt = As<ir::IfStmt>(body)) {
-    for (const auto& rv : if_stmt->return_vars_)
+    for (const auto& rv : if_stmt->return_vars_) {
       if (rv.get() == var) return true;
+    }
     if (IsDefinedInBranch(var, if_stmt->then_body_)) return true;
     return if_stmt->else_body_.has_value() && IsDefinedInBranch(var, *if_stmt->else_body_);
   }
@@ -307,6 +319,7 @@ void PTOCodegen::VisitStmt_(const IfStmtPtr& op) {
     // yield the same SSA because every array.update_element / pl.assemble
     // aliases the one backing array / tensor.
     std::vector<std::string> inplace_return_ssa(op->return_vars_.size());
+    std::vector<std::string> inplace_return_comm_ctx(op->return_vars_.size());
 
     auto emit_branch = [&](const StmtPtr& body, const char* branch_name) {
       // Fix #1956: under memory_planner=PTOAS, MemoryReuse (which would alias the
@@ -346,6 +359,30 @@ void PTOCodegen::VisitStmt_(const IfStmtPtr& op) {
           scalar_yields.push_back(branch_yields[i]);
         } else if (As<ir::ArrayType>(op->return_vars_[i]->GetType()) ||
                    ir::AsTensorTypeLike(op->return_vars_[i]->GetType())) {
+          if (As<ir::DistributedTensorType>(op->return_vars_[i]->GetType())) {
+            auto comm_ctx_it = fs_.view_ssa_to_comm_ctx.find(branch_yields[i]);
+            INTERNAL_CHECK_SPAN(comm_ctx_it != fs_.view_ssa_to_comm_ctx.end(), op->span_)
+                << "Internal error: IfStmt " << branch_name << "-branch DistributedTensor return_var '"
+                << op->return_vars_[i]->name_hint_ << "' yielded SSA '" << branch_yields[i]
+                << "' without a CommContext binding";
+            if (inplace_return_comm_ctx[i].empty()) {
+              inplace_return_comm_ctx[i] = comm_ctx_it->second;
+            } else {
+              // This tensor result stays outside scf.if and aliases one backing
+              // SSA. Choosing either branch's context here could pair the other
+              // branch's data pointer with the wrong remote-window table.
+              // Supporting that selection requires merging the base pointer and
+              // CommContext together, then rebuilding the static tensor view;
+              // tracked by GitHub issue #2027.
+              INTERNAL_CHECK_SPAN(inplace_return_comm_ctx[i] == comm_ctx_it->second, op->span_)
+                  << "Internal error: IfStmt DistributedTensor return_var '"
+                  << op->return_vars_[i]->name_hint_
+                  << "' yields different CommContext SSAs across branches: " << inplace_return_comm_ctx[i]
+                  << " vs " << comm_ctx_it->second
+                  << "; dynamic DistributedTensor selection must merge its base pointer and CommContext "
+                     "together (not yet supported; see GitHub issue #2027)";
+            }
+          }
           // In-place backing SSA (array or tensor); bound to the return var
           // after the branches. Both branches must agree on the same storage SSA
           // (every array.update_element / pl.assemble aliases the one backing
@@ -427,6 +464,7 @@ void PTOCodegen::VisitStmt_(const IfStmtPtr& op) {
       const auto& return_var = op->return_vars_[i];
       const bool is_array = As<ir::ArrayType>(return_var->GetType()) != nullptr;
       const bool is_tensor = ir::AsTensorTypeLike(return_var->GetType()) != nullptr;
+      const bool is_distributed = As<ir::DistributedTensorType>(return_var->GetType()) != nullptr;
       if (!is_array && !is_tensor) continue;
       INTERNAL_CHECK_SPAN(!inplace_return_ssa[i].empty(), op->span_)
           << "Internal error: in-place IfStmt return_var '" << return_var->name_hint_
@@ -440,9 +478,11 @@ void PTOCodegen::VisitStmt_(const IfStmtPtr& op) {
         if (base_it != fs_.view_ssa_to_base_ptr.end()) {
           RegisterBasePtr(return_var, base_it->second);
         }
-        auto comm_ctx_it = fs_.view_ssa_to_comm_ctx.find(inplace_return_ssa[i]);
-        if (comm_ctx_it != fs_.view_ssa_to_comm_ctx.end()) {
-          RegisterCommCtxFor(return_var, comm_ctx_it->second);
+        if (is_distributed) {
+          INTERNAL_CHECK_SPAN(!inplace_return_comm_ctx[i].empty(), op->span_)
+              << "Internal error: IfStmt DistributedTensor return_var '" << return_var->name_hint_
+              << "' has no merged CommContext binding";
+          RegisterCommCtxFor(return_var, inplace_return_comm_ctx[i]);
         }
       }
     }
@@ -530,6 +570,11 @@ void PTOCodegen::VisitStmt_(const ForStmtPtr& op) {
       RegisterBasePtr(iter_arg, base_ptr);
       RegisterBasePtr(return_var, base_ptr);
       const auto comm_ctx = GetCommCtxSSAFor(init_var.get());
+      if (As<ir::DistributedTensorType>(iter_arg->GetType())) {
+        INTERNAL_CHECK_SPAN(!comm_ctx.empty(), op->span_)
+            << "Internal error: ForStmt DistributedTensor iter_arg '" << iter_arg->name_hint_
+            << "' initialization '" << init_var->name_hint_ << "' has no CommContext binding";
+      }
       RegisterCommCtxFor(iter_arg, comm_ctx);
       RegisterCommCtxFor(return_var, comm_ctx);
     } else if (auto tile_type = ir::GetTileTypeWithMemRef(iter_arg->GetType())) {
@@ -675,6 +720,11 @@ void PTOCodegen::VisitStmt_(const WhileStmtPtr& op) {
       RegisterBasePtr(iter_arg, base_ptr);
       RegisterBasePtr(return_var, base_ptr);
       const auto comm_ctx = GetCommCtxSSAFor(init_var.get());
+      if (As<ir::DistributedTensorType>(iter_arg->GetType())) {
+        INTERNAL_CHECK_SPAN(!comm_ctx.empty(), op->span_)
+            << "Internal error: WhileStmt DistributedTensor iter_arg '" << iter_arg->name_hint_
+            << "' initialization '" << init_var->name_hint_ << "' has no CommContext binding";
+      }
       RegisterCommCtxFor(iter_arg, comm_ctx);
       RegisterCommCtxFor(return_var, comm_ctx);
     } else if (auto tile_type = ir::GetTileTypeWithMemRef(iter_arg->GetType())) {

--- a/tests/ut/codegen/distributed/test_distributed_pto_codegen.py
+++ b/tests/ut/codegen/distributed/test_distributed_pto_codegen.py
@@ -43,8 +43,10 @@ import re
 import pypto.language as pl
 import pypto.language.distributed as pld
 import pytest
-from pypto import backend, codegen, ir
+from pypto import DataType, InternalError, backend, codegen, ir
 from pypto.backend import BackendType
+from pypto.ir.builder import IRBuilder
+from pypto.ir.op.distributed import system_ops as dist_system
 from pypto.ir.pass_manager import OptimizationStrategy, PassManager
 
 
@@ -415,6 +417,24 @@ def test_get_comm_ctx_emits_no_mlir_aliases_ctx_arg():
     assert "!pto.ptr<i64>" in header, header
 
 
+def test_plain_distributed_alias_preserves_comm_ctx():
+    """A direct AssignStmt alias keeps the source view, base pointer, and ctx."""
+    ty = ir.DistributedTensorType([16, 16], DataType.INT32)
+
+    ib = IRBuilder()
+    with ib.function("alias_wait", type=ir.FunctionType.InCore) as f:
+        data = f.param("data", ty)
+        f.param("data_ctx", ir.CommCtxType.get())
+        alias = ib.let("alias", data)
+        ib.eval_stmt(dist_system.wait(alias, [0, 0], 1, ir.WaitCmp.Eq))
+        ib.return_stmt()
+
+    program = ir.Program([f.get_result()], "alias_wait", ir.Span.unknown())
+    mlir = codegen.PTOCodegen().generate(program)
+    body = mlir.split("func.func @alias_wait", 1)[1]
+    assert "pto.comm.twait" in body, body
+
+
 def test_tensor_view_preserves_loop_carried_distributed_metadata():
     """Post-loop views keep the distributed tensor's base pointer and ctx."""
 
@@ -475,6 +495,30 @@ def test_tensor_view_preserves_if_merged_distributed_metadata():
     assert "scf.if" in body, body
     assert body.count("pto.make_tensor_view %arg0") >= 2, body
     assert "pto.comm.twait" in body, body
+
+
+def test_if_merged_distributed_metadata_rejects_conflicting_contexts():
+    """An in-place if cannot select data and context from different allocations."""
+
+    @pl.program
+    class P:
+        @pl.function(type=pl.FunctionType.InCore)
+        def kernel(
+            self,
+            lhs: pld.DistributedTensor[[16, 16], pl.INT32],
+            rhs: pld.DistributedTensor[[16, 16], pl.INT32],
+            cond: pl.Scalar[pl.BOOL],
+        ):
+            result = lhs
+            if cond:
+                result = rhs
+            pld.system.wait(result, offsets=[0, 0], expected=1, cmp=pld.WaitCmp.Eq)
+
+    with pytest.raises(
+        InternalError,
+        match="dynamic DistributedTensor selection must merge its base pointer and CommContext together",
+    ):
+        _generate_mlir(P)
 
 
 def test_rank_emits_pto_load_scalar_at_slot_2_plus_trunci():


### PR DESCRIPTION
## Summary

- Preserve each `DistributedTensor` communication-context binding through direct aliases, `if` merges that retain one allocation, and `for` / `while` carriers.
- Fail early with construct-specific internal diagnostics when distributed tensor metadata loses its `CommContext`.
- Reject `if` branches that merge different context SSAs, because choosing either static context can pair the other branch data pointer with the wrong remote-window table.
- Add regression coverage for direct alias propagation and conflicting-context rejection.
- Apply the configured brace style to existing single-line loops in the touched control-flow file so diff-scoped clang-tidy passes.

## Why

PTO codegen represents a distributed tensor with three coordinated pieces of state: its tensor view, backing base pointer, and a side-table mapping to the runtime `CommContext` pointer. Alias and structured-control-flow lowering already propagated the view and base pointer, but context propagation was optional on several paths. Losing that binding makes later remote or synchronization operations unable to resolve the correct communication domain.

A dynamic merge of tensors from different allocations cannot safely retain one branch context. Supporting that case requires selecting the base pointer and context together, then rebuilding the static tensor view. That larger design is tracked separately in #2027; this PR keeps the conservative rejection.

## User impact

Aliases and same-allocation control-flow carriers now remain valid inputs to distributed PTO operations. Invalid or unsupported metadata flows fail at the point where context is lost or conflicts, instead of silently selecting an incorrect communication window or failing later with a less actionable error.

## Testing

- `cmake --build build --parallel`
- `cmake --build build-pypto --parallel` using the existing Python 3.12 test environment
- `python -m pytest tests/ut/codegen/distributed/test_distributed_pto_codegen.py -n auto --maxprocesses 8 -q` — 28 passed
- `pre-commit run --files src/codegen/pto/pto_codegen.cpp src/codegen/pto/pto_control_flow_codegen.cpp tests/ut/codegen/distributed/test_distributed_pto_codegen.py`
- `python tests/lint/clang_tidy.py --diff-base HEAD`
- Full unit suite — 7,134 passed, 2 skipped, 1 unrelated environment failure in `test_no_dfx_without_output_prefix_is_ok`: the installed `_task_interface.CallConfig` lacks `enable_dump_args`

## Related issues

- #2027 tracks dynamic paired base-pointer / `CommContext` selection across control flow.
- #1533 and #1956 describe the static-view and PTOAS constraints behind the current conservative lowering.