### PR TITLE
fix(ir): Canonicalize and serialize valid shapes

### DIFF
--- a/include/pypto/ir/tile_view_semantics.h
+++ b/include/pypto/ir/tile_view_semantics.h
@@ -160,14 +160,17 @@ inline std::vector<ExprPtr> GetPrintedValidShape(const std::optional<TileView>& 
   return shape;
 }
 
-/// Return the effective TileView for a TileType: the stored explicit view if
-/// present, else the implicit view for (shape, memory_space). Callers that
-/// need a concrete TileView for layout reasoning should use this — under the
-/// canonical encoding, an implicit view is stored as nullopt, so reading
-/// `tile_view_` directly would lose layout information for implicit-view tiles.
+/// Return the effective TileView for a TileType. Empty valid_shape is expanded
+/// to the physical shape, and an absent view receives the implicit layout for
+/// (shape, memory_space). Callers that need semantic view fields should use
+/// this rather than inspecting the canonical sparse storage directly.
 inline TileView GetEffectiveTileView(const TileType& tile_type) {
   if (tile_type.tile_view_.has_value()) {
-    return *tile_type.tile_view_;
+    TileView effective = *tile_type.tile_view_;
+    if (effective.valid_shape.empty()) {
+      effective.valid_shape = tile_type.shape_;
+    }
+    return effective;
   }
   return GetImplicitTileView(tile_type.shape_, tile_type.memory_space_);
 }

--- a/include/pypto/ir/type.h
+++ b/include/pypto/ir/type.h
@@ -458,8 +458,7 @@ class TensorType : public ShapedType {
    * @param tensor_view Tensor view information
    */
   TensorType(std::vector<ExprPtr> shape, DataType dtype, std::optional<MemRefPtr> memref,
-             std::optional<TensorView> tensor_view)
-      : ShapedType(dtype, std::move(shape), std::move(memref)), tensor_view_(std::move(tensor_view)) {}
+             std::optional<TensorView> tensor_view);
 
   /**
    * @brief Create a tensor type with constant shape and tensor view
@@ -470,8 +469,7 @@ class TensorType : public ShapedType {
    * @param tensor_view Optional tensor view information
    */
   TensorType(const std::vector<int64_t>& shape, DataType dtype, std::optional<MemRefPtr> memref,
-             std::optional<TensorView> tensor_view)
-      : ShapedType(dtype, shape, std::move(memref)), tensor_view_(std::move(tensor_view)) {}
+             std::optional<TensorView> tensor_view);
 
   [[nodiscard]] ObjectKind GetKind() const override { return ObjectKind::TensorType; }
   [[nodiscard]] std::string TypeName() const override { return "TensorType"; }

--- a/python/bindings/modules/ir.cpp
+++ b/python/bindings/modules/ir.cpp
@@ -497,9 +497,9 @@ void BindIR(nb::module_& m) {
   tile_type_class.def(
       "get_effective_tile_view",
       [](const TileType& self) { return tile_view_semantics::GetEffectiveTileView(self); },
-      "Return the effective TileView: the stored tile_view if present, else the implicit "
-      "view derived from (shape, memory_space). An implicit view is stored as None under "
-      "canonicalization, so callers that need to inspect layout fields should use this.");
+      "Return an effective TileView copy. A stored view keeps its metadata while an empty "
+      "valid_shape expands to shape; an absent view uses the implicit fields derived from "
+      "(shape, memory_space). Callers needing semantic fields should use this method.");
   BindFields<TileType>(tile_type_class);
 
   // ArrayType - on-core fixed-size 1-D homogeneous array (C-stack local)

--- a/python/pypto/language/parser/type_resolver.py
+++ b/python/pypto/language/parser/type_resolver.py
@@ -1289,7 +1289,10 @@ class TypeResolver:
             raise ParserTypeError(
                 f"Expected pl.TensorView(...) call, got: {ast.unparse(node)}",
                 span=self._get_span(node),
-                hint="Use pl.TensorView(valid_shape=[...], stride=[...], layout=pl.TensorLayout.NZ)",
+                hint=(
+                    "Use pl.TensorView(valid_shape=[...], stride=[...], "
+                    "layout=pl.TensorLayout.NZ, pad=pl.PadValue.zero)"
+                ),
             )
         if node.args:
             raise ParserTypeError(
@@ -1305,11 +1308,13 @@ class TypeResolver:
                 tv.stride = self._parse_tileview_expr_list(kw.value)
             elif kw.arg == "layout":
                 tv.layout = self.resolve_layout(kw.value)
+            elif kw.arg == "pad":
+                tv.pad = self._resolve_padvalue(kw.value)
             else:
                 raise ParserTypeError(
                     f"Unknown TensorView keyword argument: {kw.arg!r}",
                     span=self._get_span(kw),
-                    hint="Supported: valid_shape, stride, layout",
+                    hint="Supported: valid_shape, stride, layout, pad",
                 )
         return tv
 

--- a/python/pypto/pypto_core/ir.pyi
+++ b/python/pypto/pypto_core/ir.pyi
@@ -738,11 +738,11 @@ class TileType(ShapedType):
     def get_effective_tile_view(self) -> TileView:
         """Return the effective TileView for this tile.
 
-        If ``tile_view`` is set explicitly, returns that. Otherwise returns the
-        implicit view derived from ``(shape, memory_space)``. Under canonicalization
-        an implicit view is stored as ``None``, so callers that need to inspect
-        layout fields should use this method rather than reading ``tile_view``
-        directly.
+        Returns a copy of an explicit view with an empty ``valid_shape`` expanded
+        to ``shape`` while preserving all other metadata. If ``tile_view`` is
+        absent, returns the implicit view derived from ``(shape, memory_space)``.
+        Callers needing semantic fields should use this method rather than reading
+        the canonical sparse ``tile_view`` storage directly.
         """
 
 class ArrayType(ShapedType):

--- a/src/ir/serialization/deserializer.cpp
+++ b/src/ir/serialization/deserializer.cpp
@@ -213,7 +213,9 @@ class IRDeserializer::Impl : public detail::DeserializerContext {
           }
         }
       } else if (key == "start_offset") {
-        tile_view.start_offset = std::static_pointer_cast<const Expr>(DeserializeNode(p->val, zone));
+        if (!p->val.is_nil()) {
+          tile_view.start_offset = std::static_pointer_cast<const Expr>(DeserializeNode(p->val, zone));
+        }
       } else if (key == "blayout") {
         std::string blayout_str;
         p->val.convert(blayout_str);
@@ -281,6 +283,13 @@ class IRDeserializer::Impl : public detail::DeserializerContext {
                 std::static_pointer_cast<const Expr>(DeserializeNode(p->val.via.array.ptr[i], zone)));
           }
         }
+      } else if (key == "valid_shape") {
+        if (p->val.type == msgpack::type::ARRAY) {
+          for (uint32_t i = 0; i < p->val.via.array.size; ++i) {
+            tensor_view.valid_shape.push_back(
+                std::static_pointer_cast<const Expr>(DeserializeNode(p->val.via.array.ptr[i], zone)));
+          }
+        }
       } else if (key == "layout") {
         std::string layout_str;
         p->val.convert(layout_str);
@@ -308,7 +317,8 @@ class IRDeserializer::Impl : public detail::DeserializerContext {
           CHECK(false) << "Unknown PadValue: " << pad_str;
         }
       }
-      // Older serialized IR may omit "pad"; default stays PadValue::null.
+      // Older serialized IR may omit "valid_shape" or "pad"; defaults stay
+      // fully valid and PadValue::null, respectively.
     }
 
     return tensor_view;

--- a/src/ir/serialization/serializer.cpp
+++ b/src/ir/serialization/serializer.cpp
@@ -289,8 +289,9 @@ class IRSerializer::Impl {
     }
     tv_map["stride"] = msgpack::object(stride_vec, zone);
 
-    // Serialize start_offset
-    tv_map["start_offset"] = SerializeNode(tile_view->start_offset, zone);
+    // Serialize a missing start_offset as MessagePack nil.
+    tv_map["start_offset"] =
+        tile_view->start_offset ? SerializeNode(tile_view->start_offset, zone) : msgpack::object();
 
     // Serialize blayout
     std::string blayout_str;
@@ -362,6 +363,13 @@ class IRSerializer::Impl {
 
     // Serialize layout enum
     tv_map["layout"] = msgpack::object(TensorLayoutToString(tensor_view->layout), zone);
+
+    // Serialize valid_shape
+    std::vector<msgpack::object> valid_shape_vec;
+    for (const auto& dim : tensor_view->valid_shape) {
+      valid_shape_vec.push_back(SerializeNode(dim, zone));
+    }
+    tv_map["valid_shape"] = msgpack::object(valid_shape_vec, zone);
 
     // Serialize pad enum (same string encoding as TileView::pad)
     std::string pad_str;

--- a/src/ir/transforms/materialize_tensor_strides_pass.cpp
+++ b/src/ir/transforms/materialize_tensor_strides_pass.cpp
@@ -82,7 +82,7 @@ TypePtr MaterializeType(const TypePtr& type) {
     }
     auto materialized_stride =
         tensor_view_semantics::BuildLogicalStridesFromLayout(tensor_type->shape_, view.layout);
-    TensorView new_view(std::move(materialized_stride), view.layout, view.valid_shape);
+    TensorView new_view(std::move(materialized_stride), view.layout, view.valid_shape, view.pad);
     return std::make_shared<TensorType>(tensor_type->shape_, tensor_type->dtype_, tensor_type->memref_,
                                         std::make_optional(std::move(new_view)));
   }

--- a/src/ir/transforms/python_printer.cpp
+++ b/src/ir/transforms/python_printer.cpp
@@ -2729,7 +2729,8 @@ std::string IRPythonPrinter::PrintTileView(const TileView& tile_view, const std:
   TileView implicit_view = tile_view_semantics::GetImplicitTileView(tile_shape, memory_space);
 
   // valid_shape — omit if it matches the parent tile's shape
-  bool valid_shape_matches = tile_view_semantics::ShapeExprListsEquivalent(tile_view.valid_shape, tile_shape);
+  bool valid_shape_matches = tile_view.valid_shape.empty() ||
+                             tile_view_semantics::ShapeExprListsEquivalent(tile_view.valid_shape, tile_shape);
   if (!valid_shape_matches) {
     maybe_comma();
     oss << "valid_shape=[";

--- a/src/ir/type.cpp
+++ b/src/ir/type.cpp
@@ -50,13 +50,33 @@ std::optional<MemorySpace> ValidateTileMemorySpaceConsistency(const std::optiona
   return memory_space;
 }
 
-// Canonical encoding: an explicit TileView matching the implicit semantics for
-// (shape, memory_space) collapses to nullopt. One in-memory form per semantic
-// state — required for lossless print/parse round-trip.
+void ClearRedundantFullValidShape(std::vector<ExprPtr>& valid_shape, const std::vector<ExprPtr>& shape) {
+  if (!valid_shape.empty() && AreExprVectorsEqual(valid_shape, shape)) {
+    valid_shape.clear();
+  }
+}
+
+void CanonicalizeTensorViewInPlace(std::optional<TensorView>& tensor_view,
+                                   const std::vector<ExprPtr>& shape) {
+  if (!tensor_view.has_value()) {
+    return;
+  }
+
+  ClearRedundantFullValidShape(tensor_view->valid_shape, shape);
+  if (tensor_view->stride.empty() && tensor_view->layout == TensorLayout::ND &&
+      tensor_view->valid_shape.empty() && tensor_view->pad == PadValue::null) {
+    tensor_view.reset();
+  }
+}
+
 void CanonicalizeTileViewInPlace(std::optional<TileView>& tile_view, const std::vector<ExprPtr>& shape,
                                  const std::optional<MemorySpace>& memory_space) {
-  if (tile_view.has_value() &&
-      tile_view_semantics::IsImplicitPrintedTileView(*tile_view, shape, memory_space)) {
+  if (!tile_view.has_value()) {
+    return;
+  }
+
+  ClearRedundantFullValidShape(tile_view->valid_shape, shape);
+  if (tile_view_semantics::IsImplicitPrintedTileView(*tile_view, shape, memory_space)) {
     tile_view.reset();
   }
 }
@@ -203,6 +223,18 @@ ShapedType::ShapedType(DataType dtype, std::vector<ExprPtr> shape, MemRefPtr mem
 
 ShapedType::ShapedType(DataType dtype, std::vector<ExprPtr> shape, std::optional<MemRefPtr> memref)
     : dtype_(dtype), shape_(std::move(shape)), memref_(std::move(memref)) {}
+
+TensorType::TensorType(std::vector<ExprPtr> shape, DataType dtype, std::optional<MemRefPtr> memref,
+                       std::optional<TensorView> tensor_view)
+    : ShapedType(dtype, std::move(shape), std::move(memref)), tensor_view_(std::move(tensor_view)) {
+  CanonicalizeTensorViewInPlace(tensor_view_, shape_);
+}
+
+TensorType::TensorType(const std::vector<int64_t>& shape, DataType dtype, std::optional<MemRefPtr> memref,
+                       std::optional<TensorView> tensor_view)
+    : ShapedType(dtype, shape, std::move(memref)), tensor_view_(std::move(tensor_view)) {
+  CanonicalizeTensorViewInPlace(tensor_view_, shape_);
+}
 
 TileType::TileType(const std::vector<int64_t>& shape, DataType dtype, std::optional<MemRefPtr> memref,
                    std::optional<TileView> tile_view, std::optional<MemorySpace> memory_space)

--- a/tests/ut/ir/memory/test_memref.py
+++ b/tests/ut/ir/memory/test_memref.py
@@ -399,7 +399,8 @@ class TestTileTypeWithMemRef:
         tile_type = ir.TileType(shape, DataType.FP16, memref, tile_view, ir.MemorySpace.Vec)
         assert tile_type.memref is not None
         assert tile_type.tile_view is not None
-        assert len(tile_type.tile_view.valid_shape) == 2
+        assert len(tile_type.tile_view.valid_shape) == 0
+        assert len(tile_type.get_effective_tile_view().valid_shape) == 2
 
     def test_tile_type_1d_with_memref(self):
         """Test 1D TileType with MemRef."""
@@ -548,7 +549,8 @@ class TestMemRefSerialization:
         assert isinstance(restored.type, ir.TileType)
         assert restored.type.memref is not None
         assert restored.type.tile_view is not None
-        assert len(restored.type.tile_view.valid_shape) == 2
+        assert len(restored.type.tile_view.valid_shape) == 0
+        assert len(restored.type.get_effective_tile_view().valid_shape) == 2
 
     def test_serialize_tensor_with_tensorview(self):
         """Test serializing TensorType with TensorView."""

--- a/tests/ut/ir/operators/test_tensor_ops.py
+++ b/tests/ut/ir/operators/test_tensor_ops.py
@@ -1667,7 +1667,7 @@ def test_tensor_transpose_explicit_valid_shape_not_swapped():
     rt = call.type
     assert isinstance(rt, ir.TensorType)
     assert rt.tensor_view is not None
-    assert _const_int_values(rt.tensor_view.valid_shape) == [16, 8]
+    assert list(rt.tensor_view.valid_shape) == []
     # Layout is still toggled to DN (trailing-two-dim transpose), and the
     # explicit-strides path also records swapped row-major strides.
     assert rt.tensor_view.layout == ir.TensorLayout.DN
@@ -1933,11 +1933,7 @@ def test_tensor_fillpad_clears_valid_shape():
     result_type = call.type
     assert isinstance(result_type, ir.TensorType)
     assert result_type.dtype == DataType.FP32
-    assert result_type.tensor_view is not None
-    assert result_type.tensor_view.layout == ir.TensorLayout.ND
-    assert len(result_type.tensor_view.valid_shape) == 2
-    assert result_type.tensor_view.valid_shape[0] == dim8
-    assert result_type.tensor_view.valid_shape[1] == dim16
+    assert result_type.tensor_view is None
 
 
 def test_tensor_fillpad_expand():
@@ -1968,9 +1964,7 @@ def test_tensor_fillpad_expand():
     assert cols.value == 128
     assert result_type.tensor_view is not None
     assert result_type.tensor_view.pad == ir.PadValue.zero
-    vrows = result_type.tensor_view.valid_shape[0]
-    assert isinstance(vrows, ir.ConstInt)
-    assert vrows.value == 64
+    assert list(result_type.tensor_view.valid_shape) == []
 
 
 def test_tensor_fillpad_expand_shrink_raises():
@@ -2135,7 +2129,7 @@ def test_tensor_transpose_with_valid_shape():
     assert result_type.dtype == DataType.FP32
     assert len(call.args) == 4
     assert result_type.tensor_view is not None
-    assert len(result_type.tensor_view.valid_shape) == 2
+    assert len(result_type.tensor_view.valid_shape) == 0
 
 
 class TestTensorScalarMemoryOps:

--- a/tests/ut/ir/test_tensor_view_semantics.py
+++ b/tests/ut/ir/test_tensor_view_semantics.py
@@ -16,8 +16,12 @@ to Python via ``ir.tensor_view_semantics``. They define the canonical
 materialization pass).
 """
 
+import ast
+
 import pytest
 from pypto import DataType, ir
+from pypto.language.parser.expr_evaluator import ExprEvaluator
+from pypto.language.parser.type_resolver import TypeResolver
 
 tvs = ir.tensor_view_semantics
 
@@ -46,6 +50,16 @@ def _const_value(expr):
 
 def _values_of(exprs):
     return [_const_value(e) for e in exprs]
+
+
+def _assert_type_print_round_trip(original):
+    printed = ir.python_print_type(original)
+    node = ast.parse(printed, mode="eval").body
+    restored = TypeResolver(expr_evaluator=ExprEvaluator(closure_vars={})).resolve_type(node)
+    assert isinstance(restored, ir.Type)
+    original_var = ir.Var("value", original, _span())
+    restored_var = ir.Var("value", restored, _span())
+    ir.assert_structural_equal(original_var, restored_var, enable_auto_mapping=True)
 
 
 # ============================================================================
@@ -263,6 +277,145 @@ def test_canonicalize_view_dn_2d():
     view = tvs.canonicalize_view(_shape(4, 8), ir.TensorLayout.DN)
     assert view.layout == ir.TensorLayout.DN
     assert _values_of(view.stride) == [1, 4]
+
+
+# ============================================================================
+# TensorType and TileType valid_shape canonicalization
+# ============================================================================
+
+
+def test_tensor_type_without_view_stays_without_view():
+    tensor_type = ir.TensorType([8, 16], DataType.FP32)
+    assert tensor_type.tensor_view is None
+
+
+def test_tensor_type_explicit_full_default_view_collapses():
+    view = ir.TensorView(layout=ir.TensorLayout.ND, valid_shape=[8, 16])
+    tensor_type = ir.TensorType([8, 16], DataType.FP32, tensor_view=view)
+    assert tensor_type.tensor_view is None
+
+
+def test_tensor_type_full_valid_shape_preserves_other_view_metadata():
+    view = ir.TensorView(
+        stride=[1, 8],
+        layout=ir.TensorLayout.DN,
+        valid_shape=[8, 16],
+        pad=ir.PadValue.max,
+    )
+    tensor_type = ir.TensorType([8, 16], DataType.FP32, tensor_view=view)
+
+    assert tensor_type.tensor_view is not None
+    assert list(tensor_type.tensor_view.valid_shape) == []
+    assert _values_of(tensor_type.tensor_view.stride) == [1, 8]
+    assert tensor_type.tensor_view.layout == ir.TensorLayout.DN
+    assert tensor_type.tensor_view.pad == ir.PadValue.max
+
+
+def test_tensor_type_partial_and_symbolic_valid_shapes_stay_explicit():
+    partial_type = ir.TensorType(
+        [8, 16],
+        DataType.FP32,
+        tensor_view=ir.TensorView(layout=ir.TensorLayout.ND, valid_shape=[4, 16]),
+    )
+    assert partial_type.tensor_view is not None
+    assert _values_of(partial_type.tensor_view.valid_shape) == [4, 16]
+
+    valid_rows = _sym("valid_rows")
+    symbolic_type = ir.TensorType(
+        [8, 16],
+        DataType.FP32,
+        tensor_view=ir.TensorView(layout=ir.TensorLayout.ND, valid_shape=[valid_rows, 16]),
+    )
+    assert symbolic_type.tensor_view is not None
+    assert symbolic_type.tensor_view.valid_shape[0] is valid_rows
+
+
+def test_tensor_type_symbolic_full_valid_shape_collapses():
+    rows = _sym("rows")
+    tensor_type = ir.TensorType(
+        [rows, _const(16)],
+        DataType.FP32,
+        tensor_view=ir.TensorView(
+            layout=ir.TensorLayout.ND,
+            valid_shape=[rows, _const(16)],
+        ),
+    )
+    assert tensor_type.tensor_view is None
+
+
+def test_tile_type_without_view_stays_without_view():
+    tile_type = ir.TileType([8, 16], DataType.FP32)
+    assert tile_type.tile_view is None
+
+
+def test_tile_type_explicit_full_default_view_collapses():
+    view = ir.TileView(valid_shape=[8, 16])
+    tile_type = ir.TileType([8, 16], DataType.FP32, tile_view=view)
+    assert tile_type.tile_view is None
+
+
+def test_tile_type_symbolic_full_valid_shape_collapses():
+    rows = _sym("rows")
+    tile_type = ir.TileType(
+        [rows, _const(16)],
+        DataType.FP32,
+        tile_view=ir.TileView(valid_shape=[rows, _const(16)]),
+    )
+    assert tile_type.tile_view is None
+
+
+def test_tile_type_full_valid_shape_preserves_other_view_metadata():
+    start_offset = _const(3)
+    view = ir.TileView(
+        valid_shape=[8, 16],
+        stride=[32, 2],
+        start_offset=start_offset,
+        blayout=ir.TileLayout.col_major,
+        slayout=ir.TileLayout.row_major,
+        fractal=1024,
+        pad=ir.PadValue.min,
+    )
+    tile_type = ir.TileType([8, 16], DataType.FP32, tile_view=view)
+
+    assert tile_type.tile_view is not None
+    assert list(tile_type.tile_view.valid_shape) == []
+    assert _values_of(tile_type.tile_view.stride) == [32, 2]
+    assert tile_type.tile_view.start_offset is start_offset
+    assert tile_type.tile_view.blayout == ir.TileLayout.col_major
+    assert tile_type.tile_view.slayout == ir.TileLayout.row_major
+    assert tile_type.tile_view.fractal == 1024
+    assert tile_type.tile_view.pad == ir.PadValue.min
+
+
+def test_tile_type_partial_and_symbolic_valid_shapes_stay_explicit():
+    partial_type = ir.TileType([8, 16], DataType.FP32, tile_view=ir.TileView(valid_shape=[4, 16]))
+    assert partial_type.tile_view is not None
+    assert _values_of(partial_type.tile_view.valid_shape) == [4, 16]
+
+    valid_rows = _sym("valid_rows")
+    symbolic_type = ir.TileType([8, 16], DataType.FP32, tile_view=ir.TileView(valid_shape=[valid_rows, 16]))
+    assert symbolic_type.tile_view is not None
+    assert symbolic_type.tile_view.valid_shape[0] is valid_rows
+
+
+def test_canonical_view_types_survive_print_parse_round_trip():
+    tensor_type = ir.TensorType(
+        [8, 16],
+        DataType.FP32,
+        tensor_view=ir.TensorView(
+            stride=[1, 8],
+            layout=ir.TensorLayout.DN,
+            valid_shape=[8, 16],
+        ),
+    )
+    tile_type = ir.TileType(
+        [8, 16],
+        DataType.FP32,
+        tile_view=ir.TileView(valid_shape=[4, 16]),
+    )
+
+    _assert_type_print_round_trip(tensor_type)
+    _assert_type_print_round_trip(tile_type)
 
 
 # ============================================================================

--- a/tests/ut/ir/transforms/test_materialize_tensor_strides_pass.py
+++ b/tests/ut/ir/transforms/test_materialize_tensor_strides_pass.py
@@ -133,6 +133,38 @@ def test_empty_dn_stride_filled_3d():
     assert _verify_strict(After) == []
 
 
+def test_empty_stride_materialization_preserves_pad():
+    @pl.program
+    class Before:
+        @pl.function
+        def f(
+            self,
+            x: pl.Tensor[
+                [8, 16],
+                pl.FP32,
+                pl.TensorView(stride=[], layout=pl.TensorLayout.ND, pad=pl.PadValue.zero),
+            ],
+        ):
+            pl.const(0, pl.INT64)
+
+    @pl.program
+    class Expected:
+        @pl.function
+        def f(
+            self,
+            x: pl.Tensor[
+                [8, 16],
+                pl.FP32,
+                pl.TensorView(stride=[16, 1], layout=pl.TensorLayout.ND, pad=pl.PadValue.zero),
+            ],
+        ):
+            pl.const(0, pl.INT64)
+
+    After = _materialize(Before)
+    ir.assert_structural_equal(After, Expected)
+    assert _verify_strict(After) == []
+
+
 def test_empty_default_nd_view_canonicalizes_absent():
     # Empty ND is the default TensorView and canonicalizes to no explicit view.
     @pl.program

--- a/tests/ut/ir/transforms/test_materialize_tensor_strides_pass.py
+++ b/tests/ut/ir/transforms/test_materialize_tensor_strides_pass.py
@@ -133,8 +133,8 @@ def test_empty_dn_stride_filled_3d():
     assert _verify_strict(After) == []
 
 
-def test_empty_nd_stride_filled():
-    # An ND view with empty stride is also materialized to row-major packed.
+def test_empty_default_nd_view_canonicalizes_absent():
+    # Empty ND is the default TensorView and canonicalizes to no explicit view.
     @pl.program
     class Before:
         @pl.function
@@ -149,11 +149,12 @@ def test_empty_nd_stride_filled():
         @pl.function
         def f(
             self,
-            x: pl.Tensor[[8, 16], pl.FP32, pl.TensorView(stride=[16, 1], layout=pl.TensorLayout.ND)],
+            x: pl.Tensor[[8, 16], pl.FP32],
         ):
             pl.const(0, pl.INT64)
 
     After = _materialize(Before)
+    assert After is Before
     ir.assert_structural_equal(After, Expected)
 
 

--- a/tests/ut/ir/transforms/test_python_printer.py
+++ b/tests/ut/ir/transforms/test_python_printer.py
@@ -324,12 +324,13 @@ class TestTileViewTensorViewPrinting:
         printed = "import pypto.language as pl\nresult = " + ir.python_print_type(tile_type)
         compile(printed, "<string>", "exec")  # must not raise SyntaxError
 
-    def test_tensorview_always_emitted_when_present(self):
+    def test_default_tensorview_canonicalizes_to_absent(self):
         tensor_view = ir.TensorView()  # all-default fields
         tensor_type = ir.TensorType([64], DataType.FP32, tensor_view=tensor_view)
 
         printed = ir.python_print_type(tensor_type)
-        assert "pl.TensorView()" in printed  # all-default fields must still be emitted
+        assert tensor_type.tensor_view is None
+        assert "pl.TensorView()" not in printed
 
     def test_tileview_tensorview_parseable_by_type_resolver(self):
         span = ir.Span.unknown()

--- a/tests/ut/ir/transforms/test_serialization.py
+++ b/tests/ut/ir/transforms/test_serialization.py
@@ -18,6 +18,28 @@ import pytest
 from pypto import DataType, ir
 
 
+def _drop_fixmap_entries(payload: bytes, map_field: str, entries: list[bytes]) -> bytes:
+    """Remove fixed-size entries to model payloads written by older serializers."""
+    data = bytearray(payload)
+    map_header_offset = data.index(map_field.encode()) + len(map_field)
+    map_header = data[map_header_offset]
+    assert 0x80 <= map_header <= 0x8F
+
+    for entry in entries:
+        entry_offset = data.index(entry, map_header_offset + 1)
+        del data[entry_offset : entry_offset + len(entry)]
+
+    data[map_header_offset] = map_header - len(entries)
+    return bytes(data)
+
+
+def _round_trip_type(type_: ir.Type) -> ir.Type:
+    var = ir.Var("value", type_, ir.Span.unknown())
+    restored = cast(ir.Var, ir.deserialize(ir.serialize(var)))
+    ir.assert_structural_equal(var, restored, enable_auto_mapping=True)
+    return restored.type
+
+
 class TestBasicSerialization:
     """Tests for basic serialization of simple IR nodes."""
 
@@ -1021,6 +1043,146 @@ class TestTypeSerialization:
         assert restored_tensor_type.tensor_view.pad == ir.PadValue.zero
 
         ir.assert_structural_equal(var, restored_var, enable_auto_mapping=True)
+
+    def test_tensortype_without_view_survives_round_trip(self):
+        restored = _round_trip_type(ir.TensorType([16, 32], DataType.FP32))
+
+        assert isinstance(restored, ir.TensorType)
+        assert restored.tensor_view is None
+
+    def test_tensortype_explicit_full_view_round_trip_is_canonical(self):
+        tensor_type = ir.TensorType(
+            [16, 32],
+            DataType.FP32,
+            tensor_view=ir.TensorView(layout=ir.TensorLayout.ND, valid_shape=[16, 32]),
+        )
+        assert tensor_type.tensor_view is None
+
+        restored = _round_trip_type(tensor_type)
+        assert isinstance(restored, ir.TensorType)
+        assert restored.tensor_view is None
+
+    def test_tensortype_full_valid_shape_preserves_strided_padded_view(self):
+        tensor_type = ir.TensorType(
+            [16, 32],
+            DataType.FP32,
+            tensor_view=ir.TensorView(
+                stride=[64, 1],
+                layout=ir.TensorLayout.ND,
+                valid_shape=[16, 32],
+                pad=ir.PadValue.zero,
+            ),
+        )
+        assert tensor_type.tensor_view is not None
+        assert list(tensor_type.tensor_view.valid_shape) == []
+
+        restored = _round_trip_type(tensor_type)
+        assert isinstance(restored, ir.TensorType)
+        assert restored.tensor_view is not None
+        assert list(restored.tensor_view.valid_shape) == []
+        assert [cast(ir.ConstInt, dim).value for dim in restored.tensor_view.stride] == [64, 1]
+        assert restored.tensor_view.pad == ir.PadValue.zero
+
+    def test_tensortype_partial_symbolic_valid_shape_survives_round_trip(self):
+        span = ir.Span.unknown()
+        valid_rows = ir.Var("valid_rows", ir.ScalarType(DataType.INDEX), span)
+        tensor_type = ir.TensorType(
+            [16, 32],
+            DataType.FP32,
+            tensor_view=ir.TensorView(
+                layout=ir.TensorLayout.ND,
+                valid_shape=[valid_rows, 32],
+            ),
+        )
+
+        restored = _round_trip_type(tensor_type)
+        assert isinstance(restored, ir.TensorType)
+        assert restored.tensor_view is not None
+        assert isinstance(restored.tensor_view.valid_shape[0], ir.Var)
+        assert restored.tensor_view.valid_shape[0].name_hint == "valid_rows"
+
+    def test_tensortype_legacy_view_without_valid_shape_or_pad_deserializes(self):
+        tensor_type = ir.TensorType(
+            [16, 32],
+            DataType.FP32,
+            tensor_view=ir.TensorView(stride=[32, 1], layout=ir.TensorLayout.ND),
+        )
+        var = ir.Var("value", tensor_type, ir.Span.unknown())
+        payload = ir.serialize(var)
+        legacy_payload = _drop_fixmap_entries(
+            payload,
+            "tensor_view",
+            [b"\xabvalid_shape\x90", b"\xa3pad\xa4null"],
+        )
+
+        restored = cast(ir.Var, ir.deserialize(legacy_payload)).type
+        assert isinstance(restored, ir.TensorType)
+        assert restored.tensor_view is not None
+        assert list(restored.tensor_view.valid_shape) == []
+        assert restored.tensor_view.pad == ir.PadValue.null
+        assert [cast(ir.ConstInt, dim).value for dim in restored.tensor_view.stride] == [32, 1]
+
+    def test_tiletype_explicit_full_view_round_trip_is_canonical(self):
+        tile_type = ir.TileType(
+            [16, 32],
+            DataType.FP32,
+            tile_view=ir.TileView(valid_shape=[16, 32]),
+        )
+        assert tile_type.tile_view is None
+
+        restored = _round_trip_type(tile_type)
+        assert isinstance(restored, ir.TileType)
+        assert restored.tile_view is None
+
+    def test_tiletype_without_view_survives_round_trip(self):
+        restored = _round_trip_type(ir.TileType([16, 32], DataType.FP32))
+
+        assert isinstance(restored, ir.TileType)
+        assert restored.tile_view is None
+
+    def test_tiletype_full_valid_shape_preserves_view_metadata(self):
+        tile_type = ir.TileType(
+            [16, 32],
+            DataType.FP32,
+            tile_view=ir.TileView(
+                valid_shape=[16, 32],
+                stride=[64, 2],
+                start_offset=3,
+                blayout=ir.TileLayout.col_major,
+                slayout=ir.TileLayout.row_major,
+                fractal=1024,
+                pad=ir.PadValue.max,
+            ),
+        )
+        assert tile_type.tile_view is not None
+        assert list(tile_type.tile_view.valid_shape) == []
+
+        restored = _round_trip_type(tile_type)
+        assert isinstance(restored, ir.TileType)
+        assert restored.tile_view is not None
+        assert list(restored.tile_view.valid_shape) == []
+        assert [cast(ir.ConstInt, dim).value for dim in restored.tile_view.stride] == [64, 2]
+        assert cast(ir.ConstInt, restored.tile_view.start_offset).value == 3
+        assert restored.tile_view.blayout == ir.TileLayout.col_major
+        assert restored.tile_view.slayout == ir.TileLayout.row_major
+        assert restored.tile_view.fractal == 1024
+        assert restored.tile_view.pad == ir.PadValue.max
+
+    def test_tiletype_partial_symbolic_valid_shape_with_null_offset_round_trip(self):
+        span = ir.Span.unknown()
+        valid_rows = ir.Var("valid_rows", ir.ScalarType(DataType.INDEX), span)
+        tile_type = ir.TileType(
+            [16, 32],
+            DataType.FP32,
+            tile_view=ir.TileView(valid_shape=[valid_rows, 32], start_offset=None),
+        )
+
+        restored = _round_trip_type(tile_type)
+        assert isinstance(restored, ir.TileType)
+        assert restored.tile_view is not None
+        assert restored.tile_view.start_offset is None
+        assert isinstance(restored.tile_view.valid_shape[0], ir.Var)
+        assert restored.tile_view.valid_shape[0].name_hint == "valid_rows"
 
     def test_tiletype_with_memref_and_memory_space(self):
         """TileType with both memref and memory_space preserves both."""

--- a/tests/ut/ir/transforms/test_serialization.py
+++ b/tests/ut/ir/transforms/test_serialization.py
@@ -1054,7 +1054,7 @@ class TestTypeSerialization:
         tensor_type = ir.TensorType(
             [16, 32],
             DataType.FP32,
-            tensor_view=ir.TensorView(layout=ir.TensorLayout.ND, valid_shape=[16, 32]),
+            tensor_view=ir.TensorView(stride=[], layout=ir.TensorLayout.ND, valid_shape=[16, 32]),
         )
         assert tensor_type.tensor_view is None
 
@@ -1090,6 +1090,7 @@ class TestTypeSerialization:
             [16, 32],
             DataType.FP32,
             tensor_view=ir.TensorView(
+                stride=[],
                 layout=ir.TensorLayout.ND,
                 valid_shape=[valid_rows, 32],
             ),

--- a/tests/ut/language/parser/test_type_resolver.py
+++ b/tests/ut/language/parser/test_type_resolver.py
@@ -1394,7 +1394,7 @@ class TestLayoutResolution:
         ],
     )
     def test_resolve_tensor_with_layout(self, layout_str, expected_layout):
-        """Tensor with various layouts creates TensorType with TensorView.
+        """Tensor layout syntax preserves non-default layouts and canonicalizes ND.
 
         ``pl.DN`` is covered separately by ``test_resolve_tensor_with_dn_layout_warns``
         — it emits a ``DeprecationWarning`` (RFC #1300 supplementary 1) so we
@@ -1407,8 +1407,11 @@ class TestLayoutResolution:
         assert isinstance(result, ir.TensorType)
         assert len(result.shape) == 2
         assert result.dtype == DataType.FP16
-        assert result.tensor_view is not None
-        assert result.tensor_view.layout == expected_layout
+        if expected_layout == ir.TensorLayout.ND:
+            assert result.tensor_view is None
+        else:
+            assert result.tensor_view is not None
+            assert result.tensor_view.layout == expected_layout
 
     def test_resolve_tensor_with_dn_layout_warns(self):
         """``pl.Tensor[..., pl.DN]`` shorthand is deprecated (RFC #1300 supp. 1).
@@ -1609,8 +1612,11 @@ class TestLayoutIntegration:
 
         param_type = func.params[0].type
         assert isinstance(param_type, ir.TensorType)
-        assert param_type.tensor_view is not None
-        assert param_type.tensor_view.layout == expected
+        if expected == ir.TensorLayout.ND:
+            assert param_type.tensor_view is None
+        else:
+            assert param_type.tensor_view is not None
+            assert param_type.tensor_view.layout == expected
 
     def test_function_with_dn_layout_warns(self):
         """@pl.function with ``pl.DN`` shorthand emits ``DeprecationWarning``.
@@ -1722,16 +1728,13 @@ class TestTensorViewResolution:
     """Tests for TensorView resolution in Tensor type annotations."""
 
     def test_resolve_tensor_with_empty_tensorview(self):
-        """Tensor with TensorView() (all defaults) creates TensorType with empty tensor_view."""
+        """TensorView() canonicalizes to the implicit fully valid tensor view."""
         resolver = _make_resolver()
         node = ast.parse("pl.Tensor[[64, 128], pl.FP32, pl.TensorView()]", mode="eval").body
         result = resolver.resolve_type(node)
 
         assert isinstance(result, ir.TensorType)
-        assert result.tensor_view is not None
-        assert len(result.tensor_view.stride) == 0
-        assert len(result.tensor_view.valid_shape) == 0
-        assert result.tensor_view.layout == ir.TensorLayout.ND
+        assert result.tensor_view is None
 
     def test_resolve_tensor_with_tensorview_valid_shape(self):
         """TensorView with valid_shape creates correct tensor_view."""
@@ -1850,6 +1853,45 @@ class TestTensorViewResolution:
         assert isinstance(tv.valid_shape[1], ir.ConstInt)
         assert tv.valid_shape[1].value == 32
 
+    @pytest.mark.parametrize(
+        ("pad", "printed_name"),
+        [
+            (ir.PadValue.zero, "zero"),
+            (ir.PadValue.max, "max"),
+            (ir.PadValue.min, "min"),
+        ],
+    )
+    def test_tensorview_padding_printer_roundtrip(self, pad, printed_name):
+        """Non-default TensorView padding survives Python print and parse."""
+        span = ir.Span.unknown()
+        original = ir.TensorType(
+            [8, 64],
+            DataType.FP32,
+            tensor_view=ir.TensorView(
+                stride=[
+                    ir.ConstInt(64, DataType.INDEX, span),
+                    ir.ConstInt(1, DataType.INDEX, span),
+                ],
+                layout=ir.TensorLayout.ND,
+                pad=pad,
+            ),
+        )
+
+        printed = ir.python_print_type(original)
+        assert f"pad=pl.PadValue.{printed_name}" in printed
+
+        node = ast.parse(printed, mode="eval").body
+        reparsed = _make_resolver().resolve_type(node)
+
+        assert isinstance(reparsed, ir.TensorType)
+        assert reparsed.tensor_view is not None
+        assert reparsed.tensor_view.pad == pad
+        ir.assert_structural_equal(
+            ir.Var("value", original, span),
+            ir.Var("value", reparsed, span),
+            enable_auto_mapping=True,
+        )
+
     def test_tensorview_with_memref_four_args(self):
         """Tensor with TensorView and MemRef as 4-arg form."""
         resolver = _make_resolver()
@@ -1861,8 +1903,7 @@ class TestTensorViewResolution:
         result = resolver.resolve_type(node)
 
         assert isinstance(result, ir.TensorType)
-        assert result.tensor_view is not None
-        assert result.tensor_view.layout == ir.TensorLayout.ND
+        assert result.tensor_view is None
         assert result.memref is not None
 
 


### PR DESCRIPTION
## Summary
- canonicalize redundant full tensor and tile valid shapes while preserving meaningful metadata
- serialize tensor valid-shape expressions and nullable tile offsets with legacy payload compatibility
- make Python print/parse round-trips preserve TensorView padding and canonical effective TileView semantics
- add regression coverage for TensorView zero, max, and min padding modes

## Testing
- cmake --build build --parallel
- python -m pytest tests/ut/ -n auto --maxprocesses 8 -q (7165 passed, 2 skipped)
- pre-commit run on all changed files (all hooks passed)
- changed-line clang-tidy audit (no diagnostics on the canonicalization changes; repository-wide dependent-file diagnostics remain pre-existing)