### PR TITLE
fix(codegen): Preserve distributed alias communication context

### DIFF
--- a/include/pypto/codegen/pto/pto_codegen.h
+++ b/include/pypto/codegen/pto/pto_codegen.h
@@ -765,8 +765,6 @@ class PTOCodegen : public CodegenBase {
     std::map<const ir::Var*, std::string> tensor_to_base_ptr;  ///< tensor var → base ptr SSA
     std::map<std::string, std::string>
         view_ssa_to_base_ptr;  ///< tensor_view SSA → base ptr SSA (for rebinding IfStmt phi return_vars)
-    std::map<std::string, std::string>
-        view_ssa_to_comm_ctx;  ///< tensor_view SSA → CommContext SSA (for distributed IfStmt phi return_vars)
     std::map<const ir::Var*, std::string> memref_to_mlir;    ///< keyed by base_ Ptr
     std::map<const ir::Var*, const ir::Var*> var_to_memref;  ///< maps tile var → base_ Ptr
     std::map<const ir::Var*, std::shared_ptr<const ir::TileType>>
@@ -853,7 +851,6 @@ class PTOCodegen : public CodegenBase {
       tensor_to_view.clear();
       tensor_to_base_ptr.clear();
       view_ssa_to_base_ptr.clear();
-      view_ssa_to_comm_ctx.clear();
       memref_to_mlir.clear();
       var_to_memref.clear();
       memref_to_tile_type.clear();

--- a/src/codegen/pto/pto_codegen.cpp
+++ b/src/codegen/pto/pto_codegen.cpp
@@ -1539,7 +1539,13 @@ void PTOCodegen::VisitStmt_(const AssignStmtPtr& op) {
         BindTensorView(op->var_, view);
         BindVarToMlir(op->var_, view);  // view name == SSA name, as in ForStmt
         RegisterBasePtr(op->var_, GetTensorBasePtr(rhs_var));
-        RegisterCommCtxFor(op->var_, GetCommCtxSSAFor(rhs_var.get()));
+        const std::string comm_ctx = GetCommCtxSSAFor(rhs_var.get());
+        if (As<ir::DistributedTensorType>(op->var_->GetType())) {
+          INTERNAL_CHECK_SPAN(!comm_ctx.empty(), op->span_)
+              << "Internal error: DistributedTensor alias '" << op->var_->name_hint_ << "' from source '"
+              << rhs_var->name_hint_ << "' has no CommContext binding";
+        }
+        RegisterCommCtxFor(op->var_, comm_ctx);
         return;
       }
     } else if (!emit_tile_addr_ && As<TileType>(op->var_->GetType())) {

--- a/src/codegen/pto/pto_control_flow_codegen.cpp
+++ b/src/codegen/pto/pto_control_flow_codegen.cpp
@@ -99,14 +99,10 @@ void PTOCodegen::VisitStmt_(const YieldStmtPtr& op) {
           // GetTensorBasePtr would fall back to the view SSA). Both branches
           // yield the same backing, so the recorded base ptr is consistent.
           fs_.view_ssa_to_base_ptr[view] = GetTensorBasePtr(tensor_var);
-          std::string comm_ctx = GetCommCtxSSAFor(tensor_var.get());
           if (As<ir::DistributedTensorType>(expr->GetType())) {
-            INTERNAL_CHECK_SPAN(!comm_ctx.empty(), op->span_)
+            INTERNAL_CHECK_SPAN(!GetCommCtxSSAFor(tensor_var.get()).empty(), op->span_)
                 << "Internal error: yielded DistributedTensor '" << tensor_var->name_hint_
                 << "' has no CommContext binding";
-          }
-          if (!comm_ctx.empty()) {
-            fs_.view_ssa_to_comm_ctx[view] = std::move(comm_ctx);
           }
           yielded_values.push_back(view);
           continue;
@@ -322,6 +318,7 @@ void PTOCodegen::VisitStmt_(const IfStmtPtr& op) {
     std::vector<std::string> inplace_return_comm_ctx(op->return_vars_.size());
 
     auto emit_branch = [&](const StmtPtr& body, const char* branch_name) {
+      const YieldStmtPtr yield = FindBranchYield(body);
       // Fix #1956: under memory_planner=PTOAS, MemoryReuse (which would alias the
       // branch yields onto the phi return_var's canonical MemRef via
       // YieldFixupMutator) is skipped. Without it, each branch's tile producer
@@ -330,19 +327,17 @@ void PTOCodegen::VisitStmt_(const IfStmtPtr& op) {
       // return_var's (head-declared) handle so this branch's producer writes it.
       // Under PYPTO (emit_tile_addr_) the IR-level aliasing already holds, so
       // leave the bindings untouched.
-      if (!emit_tile_addr_) {
-        if (auto yield = FindBranchYield(body)) {
-          for (size_t i = 0; i < op->return_vars_.size(); ++i) {
-            if (i >= yield->value_.size()) continue;
-            if (!As<TileType>(op->return_vars_[i]->GetType())) continue;
-            auto src = ir::AsVarLike(yield->value_[i]);
-            if (!src) continue;
-            // Only re-point a branch-local producer; an outer var yielded through
-            // the branch is read elsewhere and must keep its own handle.
-            if (!IsDefinedInBranch(src.get(), body)) continue;
-            auto phi_it = fs_.var_to_mlir.find(GetVarKey(op->return_vars_[i]));
-            if (phi_it != fs_.var_to_mlir.end()) BindVarToMlir(src, phi_it->second);
-          }
+      if (!emit_tile_addr_ && yield) {
+        for (size_t i = 0; i < op->return_vars_.size(); ++i) {
+          if (i >= yield->value_.size()) continue;
+          if (!As<TileType>(op->return_vars_[i]->GetType())) continue;
+          auto src = ir::AsVarLike(yield->value_[i]);
+          if (!src) continue;
+          // Only re-point a branch-local producer; an outer var yielded through
+          // the branch is read elsewhere and must keep its own handle.
+          if (!IsDefinedInBranch(src.get(), body)) continue;
+          auto phi_it = fs_.var_to_mlir.find(GetVarKey(op->return_vars_[i]));
+          if (phi_it != fs_.var_to_mlir.end()) BindVarToMlir(src, phi_it->second);
         }
       }
       fs_.yield_buffer.clear();
@@ -360,13 +355,19 @@ void PTOCodegen::VisitStmt_(const IfStmtPtr& op) {
         } else if (As<ir::ArrayType>(op->return_vars_[i]->GetType()) ||
                    ir::AsTensorTypeLike(op->return_vars_[i]->GetType())) {
           if (As<ir::DistributedTensorType>(op->return_vars_[i]->GetType())) {
-            auto comm_ctx_it = fs_.view_ssa_to_comm_ctx.find(branch_yields[i]);
-            INTERNAL_CHECK_SPAN(comm_ctx_it != fs_.view_ssa_to_comm_ctx.end(), op->span_)
+            // Resolve the context from the yielded Var, as For/While do for their
+            // init values. A yield whose tensor has no registered tensor_view falls
+            // back to the plain expr lowering above, so keying off the yielded SSA
+            // would miss it.
+            std::string comm_ctx;
+            if (yield && i < yield->value_.size()) {
+              if (auto src = ir::AsVarLike(yield->value_[i])) comm_ctx = GetCommCtxSSAFor(src.get());
+            }
+            INTERNAL_CHECK_SPAN(!comm_ctx.empty(), op->span_)
                 << "Internal error: IfStmt " << branch_name << "-branch DistributedTensor return_var '"
-                << op->return_vars_[i]->name_hint_ << "' yielded SSA '" << branch_yields[i]
-                << "' without a CommContext binding";
+                << op->return_vars_[i]->name_hint_ << "' has no CommContext binding";
             if (inplace_return_comm_ctx[i].empty()) {
-              inplace_return_comm_ctx[i] = comm_ctx_it->second;
+              inplace_return_comm_ctx[i] = std::move(comm_ctx);
             } else {
               // This tensor result stays outside scf.if and aliases one backing
               // SSA. Choosing either branch's context here could pair the other
@@ -374,13 +375,12 @@ void PTOCodegen::VisitStmt_(const IfStmtPtr& op) {
               // Supporting that selection requires merging the base pointer and
               // CommContext together, then rebuilding the static tensor view;
               // tracked by GitHub issue #2027.
-              INTERNAL_CHECK_SPAN(inplace_return_comm_ctx[i] == comm_ctx_it->second, op->span_)
-                  << "Internal error: IfStmt DistributedTensor return_var '"
+              CHECK_SPAN(inplace_return_comm_ctx[i] == comm_ctx, op->span_)
+                  << "Assigning a different DistributedTensor in each branch of an `if` is not supported: '"
                   << op->return_vars_[i]->name_hint_
-                  << "' yields different CommContext SSAs across branches: " << inplace_return_comm_ctx[i]
-                  << " vs " << comm_ctx_it->second
-                  << "; dynamic DistributedTensor selection must merge its base pointer and CommContext "
-                     "together (not yet supported; see GitHub issue #2027)";
+                  << "' would take its data pointer from one allocation and its communication context from "
+                     "another. Assign a single DistributedTensor before the `if`, and branch on the data "
+                     "read from it instead (see GitHub issue #2027).";
             }
           }
           // In-place backing SSA (array or tensor); bound to the return var

--- a/src/codegen/pto/pto_control_flow_codegen.cpp
+++ b/src/codegen/pto/pto_control_flow_codegen.cpp
@@ -99,7 +99,13 @@ void PTOCodegen::VisitStmt_(const YieldStmtPtr& op) {
           // GetTensorBasePtr would fall back to the view SSA). Both branches
           // yield the same backing, so the recorded base ptr is consistent.
           fs_.view_ssa_to_base_ptr[view] = GetTensorBasePtr(tensor_var);
-          if (std::string comm_ctx = GetCommCtxSSAFor(tensor_var.get()); !comm_ctx.empty()) {
+          std::string comm_ctx = GetCommCtxSSAFor(tensor_var.get());
+          if (As<ir::DistributedTensorType>(expr->GetType())) {
+            INTERNAL_CHECK_SPAN(!comm_ctx.empty(), op->span_)
+                << "Internal error: yielded DistributedTensor '" << tensor_var->name_hint_
+                << "' has no CommContext binding";
+          }
+          if (!comm_ctx.empty()) {
             fs_.view_ssa_to_comm_ctx[view] = std::move(comm_ctx);
           }
           yielded_values.push_back(view);
@@ -313,6 +319,7 @@ void PTOCodegen::VisitStmt_(const IfStmtPtr& op) {
     // yield the same SSA because every array.update_element / pl.assemble
     // aliases the one backing array / tensor.
     std::vector<std::string> inplace_return_ssa(op->return_vars_.size());
+    std::vector<std::string> inplace_return_comm_ctx(op->return_vars_.size());
 
     auto emit_branch = [&](const StmtPtr& body, const char* branch_name) {
       // Fix #1956: under memory_planner=PTOAS, MemoryReuse (which would alias the
@@ -352,6 +359,30 @@ void PTOCodegen::VisitStmt_(const IfStmtPtr& op) {
           scalar_yields.push_back(branch_yields[i]);
         } else if (As<ir::ArrayType>(op->return_vars_[i]->GetType()) ||
                    ir::AsTensorTypeLike(op->return_vars_[i]->GetType())) {
+          if (As<ir::DistributedTensorType>(op->return_vars_[i]->GetType())) {
+            auto comm_ctx_it = fs_.view_ssa_to_comm_ctx.find(branch_yields[i]);
+            INTERNAL_CHECK_SPAN(comm_ctx_it != fs_.view_ssa_to_comm_ctx.end(), op->span_)
+                << "Internal error: IfStmt " << branch_name << "-branch DistributedTensor return_var '"
+                << op->return_vars_[i]->name_hint_ << "' yielded SSA '" << branch_yields[i]
+                << "' without a CommContext binding";
+            if (inplace_return_comm_ctx[i].empty()) {
+              inplace_return_comm_ctx[i] = comm_ctx_it->second;
+            } else {
+              // This tensor result stays outside scf.if and aliases one backing
+              // SSA. Choosing either branch's context here could pair the other
+              // branch's data pointer with the wrong remote-window table.
+              // Supporting that selection requires merging the base pointer and
+              // CommContext together, then rebuilding the static tensor view;
+              // tracked by GitHub issue #2027.
+              INTERNAL_CHECK_SPAN(inplace_return_comm_ctx[i] == comm_ctx_it->second, op->span_)
+                  << "Internal error: IfStmt DistributedTensor return_var '"
+                  << op->return_vars_[i]->name_hint_
+                  << "' yields different CommContext SSAs across branches: " << inplace_return_comm_ctx[i]
+                  << " vs " << comm_ctx_it->second
+                  << "; dynamic DistributedTensor selection must merge its base pointer and CommContext "
+                     "together (not yet supported; see GitHub issue #2027)";
+            }
+          }
           // In-place backing SSA (array or tensor); bound to the return var
           // after the branches. Both branches must agree on the same storage SSA
           // (every array.update_element / pl.assemble aliases the one backing
@@ -433,6 +464,7 @@ void PTOCodegen::VisitStmt_(const IfStmtPtr& op) {
       const auto& return_var = op->return_vars_[i];
       const bool is_array = As<ir::ArrayType>(return_var->GetType()) != nullptr;
       const bool is_tensor = ir::AsTensorTypeLike(return_var->GetType()) != nullptr;
+      const bool is_distributed = As<ir::DistributedTensorType>(return_var->GetType()) != nullptr;
       if (!is_array && !is_tensor) continue;
       INTERNAL_CHECK_SPAN(!inplace_return_ssa[i].empty(), op->span_)
           << "Internal error: in-place IfStmt return_var '" << return_var->name_hint_
@@ -446,9 +478,11 @@ void PTOCodegen::VisitStmt_(const IfStmtPtr& op) {
         if (base_it != fs_.view_ssa_to_base_ptr.end()) {
           RegisterBasePtr(return_var, base_it->second);
         }
-        auto comm_ctx_it = fs_.view_ssa_to_comm_ctx.find(inplace_return_ssa[i]);
-        if (comm_ctx_it != fs_.view_ssa_to_comm_ctx.end()) {
-          RegisterCommCtxFor(return_var, comm_ctx_it->second);
+        if (is_distributed) {
+          INTERNAL_CHECK_SPAN(!inplace_return_comm_ctx[i].empty(), op->span_)
+              << "Internal error: IfStmt DistributedTensor return_var '" << return_var->name_hint_
+              << "' has no merged CommContext binding";
+          RegisterCommCtxFor(return_var, inplace_return_comm_ctx[i]);
         }
       }
     }
@@ -536,6 +570,11 @@ void PTOCodegen::VisitStmt_(const ForStmtPtr& op) {
       RegisterBasePtr(iter_arg, base_ptr);
       RegisterBasePtr(return_var, base_ptr);
       const auto comm_ctx = GetCommCtxSSAFor(init_var.get());
+      if (As<ir::DistributedTensorType>(iter_arg->GetType())) {
+        INTERNAL_CHECK_SPAN(!comm_ctx.empty(), op->span_)
+            << "Internal error: ForStmt DistributedTensor iter_arg '" << iter_arg->name_hint_
+            << "' initialization '" << init_var->name_hint_ << "' has no CommContext binding";
+      }
       RegisterCommCtxFor(iter_arg, comm_ctx);
       RegisterCommCtxFor(return_var, comm_ctx);
     } else if (auto tile_type = ir::GetTileTypeWithMemRef(iter_arg->GetType())) {
@@ -681,6 +720,11 @@ void PTOCodegen::VisitStmt_(const WhileStmtPtr& op) {
       RegisterBasePtr(iter_arg, base_ptr);
       RegisterBasePtr(return_var, base_ptr);
       const auto comm_ctx = GetCommCtxSSAFor(init_var.get());
+      if (As<ir::DistributedTensorType>(iter_arg->GetType())) {
+        INTERNAL_CHECK_SPAN(!comm_ctx.empty(), op->span_)
+            << "Internal error: WhileStmt DistributedTensor iter_arg '" << iter_arg->name_hint_
+            << "' initialization '" << init_var->name_hint_ << "' has no CommContext binding";
+      }
       RegisterCommCtxFor(iter_arg, comm_ctx);
       RegisterCommCtxFor(return_var, comm_ctx);
     } else if (auto tile_type = ir::GetTileTypeWithMemRef(iter_arg->GetType())) {

--- a/tests/ut/codegen/distributed/test_distributed_pto_codegen.py
+++ b/tests/ut/codegen/distributed/test_distributed_pto_codegen.py
@@ -43,8 +43,10 @@ import re
 import pypto.language as pl
 import pypto.language.distributed as pld
 import pytest
-from pypto import backend, codegen, ir
+from pypto import DataType, InternalError, backend, codegen, ir
 from pypto.backend import BackendType
+from pypto.ir.builder import IRBuilder
+from pypto.ir.op.distributed import system_ops as dist_system
 from pypto.ir.pass_manager import OptimizationStrategy, PassManager
 
 
@@ -449,6 +451,24 @@ def test_get_comm_ctx_emits_no_mlir_aliases_ctx_arg():
     assert "!pto.ptr<i64>" in header, header
 
 
+def test_plain_distributed_alias_preserves_comm_ctx():
+    """A direct AssignStmt alias keeps the source view, base pointer, and ctx."""
+    ty = ir.DistributedTensorType([16, 16], DataType.INT32)
+
+    ib = IRBuilder()
+    with ib.function("alias_wait", type=ir.FunctionType.InCore) as f:
+        data = f.param("data", ty)
+        f.param("data_ctx", ir.CommCtxType.get())
+        alias = ib.let("alias", data)
+        ib.eval_stmt(dist_system.wait(alias, [0, 0], 1, ir.WaitCmp.Eq))
+        ib.return_stmt()
+
+    program = ir.Program([f.get_result()], "alias_wait", ir.Span.unknown())
+    mlir = codegen.PTOCodegen().generate(program)
+    body = mlir.split("func.func @alias_wait", 1)[1]
+    assert "pto.comm.twait" in body, body
+
+
 def test_tensor_view_preserves_loop_carried_distributed_metadata():
     """Post-loop views keep the distributed tensor's base pointer and ctx."""
 
@@ -509,6 +529,30 @@ def test_tensor_view_preserves_if_merged_distributed_metadata():
     assert "scf.if" in body, body
     assert body.count("pto.make_tensor_view %arg0") >= 2, body
     assert "pto.comm.twait" in body, body
+
+
+def test_if_merged_distributed_metadata_rejects_conflicting_contexts():
+    """An in-place if cannot select data and context from different allocations."""
+
+    @pl.program
+    class P:
+        @pl.function(type=pl.FunctionType.InCore)
+        def kernel(
+            self,
+            lhs: pld.DistributedTensor[[16, 16], pl.INT32],
+            rhs: pld.DistributedTensor[[16, 16], pl.INT32],
+            cond: pl.Scalar[pl.BOOL],
+        ):
+            result = lhs
+            if cond:
+                result = rhs
+            pld.system.wait(result, offsets=[0, 0], expected=1, cmp=pld.WaitCmp.Eq)
+
+    with pytest.raises(
+        InternalError,
+        match="dynamic DistributedTensor selection must merge its base pointer and CommContext together",
+    ):
+        _generate_mlir(P)
 
 
 def test_rank_emits_pto_load_scalar_at_slot_2_plus_trunci():

--- a/tests/ut/codegen/distributed/test_distributed_pto_codegen.py
+++ b/tests/ut/codegen/distributed/test_distributed_pto_codegen.py
@@ -43,7 +43,7 @@ import re
 import pypto.language as pl
 import pypto.language.distributed as pld
 import pytest
-from pypto import DataType, InternalError, backend, codegen, ir
+from pypto import DataType, backend, codegen, ir
 from pypto.backend import BackendType
 from pypto.ir.builder import IRBuilder
 from pypto.ir.op.distributed import system_ops as dist_system
@@ -549,8 +549,8 @@ def test_if_merged_distributed_metadata_rejects_conflicting_contexts():
             pld.system.wait(result, offsets=[0, 0], expected=1, cmp=pld.WaitCmp.Eq)
 
     with pytest.raises(
-        InternalError,
-        match="dynamic DistributedTensor selection must merge its base pointer and CommContext together",
+        ValueError,
+        match="Assigning a different DistributedTensor in each branch of an `if` is not supported",
     ):
         _generate_mlir(P)
 


### PR DESCRIPTION
## Summary

PTO codegen describes a `DistributedTensor` with three coordinated pieces of state: its tensor view, its backing base pointer, and a side-table mapping to the runtime `CommContext` pointer. Alias and structured-control-flow lowering already propagated the view and the base pointer, but `CommContext` propagation was **optional** on several paths — a missing binding was silently tolerated. A later `remote_load` / `remote_store` / `put` / `notify` / `wait` could then lose its communication domain, or pair a data pointer with the wrong remote-window table.

This makes the binding a verified invariant instead:

- Direct `AssignStmt` aliases inherit the source tensor view, base pointer, and `CommContext`.
- `YieldStmt`, `IfStmt`, `ForStmt`, and `WhileStmt` carriers retain the initialization context when they keep the same allocation.
- A `DistributedTensor` alias or yield that loses its context now fails **at the point where the metadata is lost**, with a construct-specific internal diagnostic, rather than surfacing later as a less actionable error.
- An `IfStmt` whose branches yield different context SSAs is rejected. The tensor result stays outside `scf.if` and aliases one backing SSA, so selecting either branch's context could pair the other branch's data pointer with the wrong remote-window table.

The DSL and public API are unchanged.

## Why the conflicting-`if` case is rejected rather than merged

Supporting a dynamic cross-allocation merge requires selecting the base pointer and the `CommContext` **together** and then rebuilding the static tensor view — a larger control-flow design under the PTOAS static-view constraints. That is tracked separately in #2027; this PR keeps the conservative rejection with an explanatory diagnostic.

## Testing

- `cmake --build build --parallel`
- `python -m pytest tests/ut/codegen/ -q` — 571 passed (including all 28 distributed PTO codegen tests)
- Full unit suite — 7,169 passed, 2 skipped. The single failure, `tests/ut/runtime/test_run_config.py::TestExecuteOnDeviceDfxValidation::test_no_dfx_without_output_prefix_is_ok`, reproduces identically on a clean `main` with these changes stashed: the installed `_task_interface.CallConfig` lacks `enable_dump_args`. It is a pre-existing environment issue, not a regression.
- `pre-commit run --files src/codegen/pto/pto_codegen.cpp src/codegen/pto/pto_control_flow_codegen.cpp tests/ut/codegen/distributed/test_distributed_pto_codegen.py`
- `python tests/lint/clang_tidy.py --diff-base HEAD --strict-version` (pinned clang-tidy 21.1.0) — clean

## Regression coverage

New: direct-alias `CommContext` propagation, and conflicting-context `IfStmt` rejection. Consistent `if` / `for` / `while` carriers were already covered by the existing `test_tensor_view_preserves_*_distributed_metadata` tests.

## Notes

This re-lands the closed prototype #2028. Its brace-style cleanup in `IsDefinedInBranch` is no longer part of the diff — that formatting landed on `main` independently via #2030, so only the functional changes remain here.

## Related issues

Fixes #2029

- #2027 tracks dynamic paired base-pointer / `CommContext` selection across control flow.
- #1533 and #1956 describe the static-view and PTOAS constraints behind the current conservative lowering.