### PR TITLE
feat(ir): Verify valid shape bounds

### DIFF
--- a/include/pypto/ir/type_inference.h
+++ b/include/pypto/ir/type_inference.h
@@ -21,6 +21,7 @@
 #ifndef PYPTO_IR_TYPE_INFERENCE_H_
 #define PYPTO_IR_TYPE_INFERENCE_H_
 
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <optional>
@@ -158,6 +159,68 @@ std::optional<int64_t> GetConstantDimension(const ExprPtr& dim);
  * @return true if dimensions are equal
  */
 bool DimensionsEqual(const ExprPtr& dim1, const ExprPtr& dim2);
+
+/**
+ * @brief Tri-state result for symbolic valid-extent proof obligations
+ *
+ * A relation is true or false only when the arithmetic analyzer can prove that
+ * result. Symbolic relations that cannot be decided remain unknown.
+ */
+enum class ProofResult {
+  kTrue,
+  kFalse,
+  kUnknown,
+};
+
+/**
+ * @brief Prove whether two valid-extent expressions are equal
+ *
+ * Recognizes structural identity, equal constants, and relations established
+ * by the arithmetic analyzer.
+ */
+ProofResult ProveValidExtentEqual(const ExprPtr& lhs, const ExprPtr& rhs);
+
+/**
+ * @brief Prove whether one valid-extent expression is less than or equal to another
+ *
+ * @return kTrue when lhs <= rhs is proven, kFalse when lhs > rhs is proven,
+ *         and kUnknown otherwise
+ */
+ProofResult ProveValidExtentLessEqual(const ExprPtr& lhs, const ExprPtr& rhs);
+
+/**
+ * @brief Kinds of malformed explicit valid shapes
+ */
+enum class ValidShapeBoundsViolation {
+  kRankMismatch,
+  kNegativeExtent,
+  kExceedsPhysicalExtent,
+};
+
+/**
+ * @brief A structured valid-shape validation failure
+ */
+struct ValidShapeBoundsError {
+  ValidShapeBoundsViolation violation;
+  std::optional<size_t> dimension;
+  std::string message;
+};
+
+/**
+ * @brief Validate the standing bounds invariant for an explicit valid shape
+ *
+ * Checks rank(valid) == rank(physical) and every provable violation of
+ * 0 <= valid[i] <= physical[i]. Unknown symbolic relations are accepted.
+ * An empty valid shape represents the full physical shape and is valid.
+ *
+ * @param valid Explicit valid shape, or empty for implicit full validity
+ * @param physical Physical shape
+ * @param type_kind Shaped type name used in diagnostics
+ * @return All provable violations
+ */
+std::vector<ValidShapeBoundsError> ValidateValidShapeBounds(const std::vector<ExprPtr>& valid,
+                                                            const std::vector<ExprPtr>& physical,
+                                                            const std::string& type_kind);
 
 /**
  * @brief Check if a dimension is broadcastable to another

--- a/src/ir/op/type_inference.cpp
+++ b/src/ir/op/type_inference.cpp
@@ -236,15 +236,29 @@ bool DimensionsEqual(const ExprPtr& dim1, const ExprPtr& dim2) {
   return analyzer.CanProveEqual(dim1, dim2);
 }
 
-ProofResult ProveValidExtentEqual(const ExprPtr& lhs, const ExprPtr& rhs) {
+namespace {
+bool AreComparableIntegerScalarExprs(const ExprPtr& lhs, const ExprPtr& rhs) {
   if (!lhs || !rhs) {
+    return false;
+  }
+  auto lhs_type = As<ScalarType>(lhs->GetType());
+  auto rhs_type = As<ScalarType>(rhs->GetType());
+  if (!lhs_type || !rhs_type || !lhs_type->dtype_.IsInt() || !rhs_type->dtype_.IsInt()) {
+    return false;
+  }
+  return lhs_type->dtype_.IsSignedInt() == rhs_type->dtype_.IsSignedInt();
+}
+}  // namespace
+
+ProofResult ProveValidExtentEqual(const ExprPtr& lhs, const ExprPtr& rhs) {
+  if (!AreComparableIntegerScalarExprs(lhs, rhs)) {
     return ProofResult::kUnknown;
   }
   if (AreExprsEqual(lhs, rhs)) {
     return ProofResult::kTrue;
   }
 
-  arith::Analyzer analyzer;
+  thread_local arith::Analyzer analyzer;
   if (analyzer.CanProveEqual(lhs, rhs)) {
     return ProofResult::kTrue;
   }
@@ -255,14 +269,14 @@ ProofResult ProveValidExtentEqual(const ExprPtr& lhs, const ExprPtr& rhs) {
 }
 
 ProofResult ProveValidExtentLessEqual(const ExprPtr& lhs, const ExprPtr& rhs) {
-  if (!lhs || !rhs) {
+  if (!AreComparableIntegerScalarExprs(lhs, rhs)) {
     return ProofResult::kUnknown;
   }
   if (AreExprsEqual(lhs, rhs)) {
     return ProofResult::kTrue;
   }
 
-  arith::Analyzer analyzer;
+  thread_local arith::Analyzer analyzer;
   if (analyzer.CanProve(MakeLe(lhs, rhs))) {
     return ProofResult::kTrue;
   }
@@ -325,7 +339,7 @@ std::vector<ValidShapeBoundsError> ValidateValidShapeBounds(const std::vector<Ex
   }
 
   std::vector<ValidShapeBoundsError> errors;
-  const auto zero = std::make_shared<ConstInt>(0, DataType::INDEX, Span::unknown());
+  static const auto zero = std::make_shared<ConstInt>(0, DataType::INDEX, Span::unknown());
   for (size_t i = 0; i < valid.size(); ++i) {
     if (ProveValidExtentLessEqual(zero, valid[i]) == ProofResult::kFalse) {
       std::ostringstream msg;

--- a/src/ir/op/type_inference.cpp
+++ b/src/ir/op/type_inference.cpp
@@ -28,6 +28,7 @@
 #include "pypto/ir/expr.h"
 #include "pypto/ir/kind_traits.h"
 #include "pypto/ir/scalar_expr.h"
+#include "pypto/ir/span.h"
 #include "pypto/ir/transforms/printer.h"
 #include "pypto/ir/type.h"
 
@@ -235,6 +236,42 @@ bool DimensionsEqual(const ExprPtr& dim1, const ExprPtr& dim2) {
   return analyzer.CanProveEqual(dim1, dim2);
 }
 
+ProofResult ProveValidExtentEqual(const ExprPtr& lhs, const ExprPtr& rhs) {
+  if (!lhs || !rhs) {
+    return ProofResult::kUnknown;
+  }
+  if (AreExprsEqual(lhs, rhs)) {
+    return ProofResult::kTrue;
+  }
+
+  arith::Analyzer analyzer;
+  if (analyzer.CanProveEqual(lhs, rhs)) {
+    return ProofResult::kTrue;
+  }
+  if (analyzer.CanProve(MakeNe(lhs, rhs))) {
+    return ProofResult::kFalse;
+  }
+  return ProofResult::kUnknown;
+}
+
+ProofResult ProveValidExtentLessEqual(const ExprPtr& lhs, const ExprPtr& rhs) {
+  if (!lhs || !rhs) {
+    return ProofResult::kUnknown;
+  }
+  if (AreExprsEqual(lhs, rhs)) {
+    return ProofResult::kTrue;
+  }
+
+  arith::Analyzer analyzer;
+  if (analyzer.CanProve(MakeLe(lhs, rhs))) {
+    return ProofResult::kTrue;
+  }
+  if (analyzer.CanProve(MakeGt(lhs, rhs))) {
+    return ProofResult::kFalse;
+  }
+  return ProofResult::kUnknown;
+}
+
 bool IsBroadcastable(const ExprPtr& source_dim, const ExprPtr& target_dim) {
   // If dimensions are equal, they're broadcastable
   if (DimensionsEqual(source_dim, target_dim)) {
@@ -271,6 +308,40 @@ std::string FormatShape(const std::vector<ExprPtr>& shape) {
   }
   oss << "]";
   return oss.str();
+}
+
+std::vector<ValidShapeBoundsError> ValidateValidShapeBounds(const std::vector<ExprPtr>& valid,
+                                                            const std::vector<ExprPtr>& physical,
+                                                            const std::string& type_kind) {
+  if (valid.empty()) {
+    return {};
+  }
+
+  if (valid.size() != physical.size()) {
+    std::ostringstream msg;
+    msg << type_kind << " valid_shape rank mismatch: got rank " << valid.size() << " " << FormatShape(valid)
+        << ", but physical shape has rank " << physical.size() << " " << FormatShape(physical);
+    return {{ValidShapeBoundsViolation::kRankMismatch, std::nullopt, msg.str()}};
+  }
+
+  std::vector<ValidShapeBoundsError> errors;
+  const auto zero = std::make_shared<ConstInt>(0, DataType::INDEX, Span::unknown());
+  for (size_t i = 0; i < valid.size(); ++i) {
+    if (ProveValidExtentLessEqual(zero, valid[i]) == ProofResult::kFalse) {
+      std::ostringstream msg;
+      msg << type_kind << " valid_shape dimension " << i << " has provably negative extent "
+          << PythonPrint(valid[i]) << "; expected 0 <= valid_shape[" << i << "] <= shape[" << i << "] ("
+          << PythonPrint(physical[i]) << ")";
+      errors.push_back({ValidShapeBoundsViolation::kNegativeExtent, i, msg.str()});
+    }
+    if (ProveValidExtentLessEqual(valid[i], physical[i]) == ProofResult::kFalse) {
+      std::ostringstream msg;
+      msg << type_kind << " valid_shape dimension " << i << " extent " << PythonPrint(valid[i])
+          << " provably exceeds physical shape extent " << PythonPrint(physical[i]);
+      errors.push_back({ValidShapeBoundsViolation::kExceedsPhysicalExtent, i, msg.str()});
+    }
+  }
+  return errors;
 }
 
 // ============================================================================

--- a/src/ir/verifier/type_check_pass.cpp
+++ b/src/ir/verifier/type_check_pass.cpp
@@ -18,6 +18,7 @@
 #include "pypto/core/error.h"
 #include "pypto/ir/core.h"
 #include "pypto/ir/expr.h"
+#include "pypto/ir/function.h"
 #include "pypto/ir/kind_traits.h"
 #include "pypto/ir/program.h"
 #include "pypto/ir/scalar_expr.h"
@@ -25,6 +26,7 @@
 #include "pypto/ir/stmt.h"
 #include "pypto/ir/transforms/base/visitor.h"
 #include "pypto/ir/type.h"
+#include "pypto/ir/type_inference.h"
 #include "pypto/ir/verifier/verification_error.h"
 #include "pypto/ir/verifier/verifier.h"
 
@@ -67,6 +69,8 @@ class TypeChecker : public IRVisitor {
  public:
   explicit TypeChecker(std::vector<Diagnostic>& diagnostics) : diagnostics_(diagnostics) {}
 
+  void VisitFunction(const FunctionPtr& func) override;
+  void VisitExpr(const ExprPtr& expr) override;
   void VisitStmt_(const ForStmtPtr& op) override;
   void VisitStmt_(const WhileStmtPtr& op) override;
   void VisitStmt_(const IfStmtPtr& op) override;
@@ -106,12 +110,92 @@ class TypeChecker : public IRVisitor {
    * @brief Check if expression is a ScalarType with BOOL dtype (for if/while conditions)
    */
   void CheckIsBoolCondition(const ExprPtr& expr, const std::string& context, const Span& span);
+
+  /**
+   * @brief Recursively validate explicit valid shapes carried by a type
+   */
+  void ValidateTypeValidShape(const TypePtr& type, const std::string& context, const Span& span);
 };
 
 // TypeChecker implementation
 
 void TypeChecker::RecordError(typecheck::ErrorType type, const std::string& message, const Span& span) {
   diagnostics_.emplace_back(DiagnosticSeverity::Error, "TypeCheck", static_cast<int>(type), message, span);
+}
+
+void TypeChecker::VisitFunction(const FunctionPtr& func) {
+  if (!func) return;
+
+  for (size_t i = 0; i < func->params_.size(); ++i) {
+    const auto& param = func->params_[i];
+    if (!param) continue;
+    ValidateTypeValidShape(
+        param->GetType(),
+        "Function '" + func->name_ + "' parameter[" + std::to_string(i) + "] '" + param->name_hint_ + "'",
+        param->span_);
+  }
+  for (size_t i = 0; i < func->return_types_.size(); ++i) {
+    ValidateTypeValidShape(func->return_types_[i],
+                           "Function '" + func->name_ + "' return type[" + std::to_string(i) + "]",
+                           func->span_);
+  }
+  if (func->body_) {
+    VisitStmt(func->body_);
+  }
+}
+
+void TypeChecker::VisitExpr(const ExprPtr& expr) {
+  if (!expr) return;
+
+  std::string context = expr->TypeName() + " expression";
+  if (auto var = AsVarLike(expr)) {
+    context = var->TypeName() + " '" + var->name_hint_ + "'";
+  } else if (As<Call>(expr)) {
+    context = "Call result";
+  } else if (As<Submit>(expr)) {
+    context = "Submit result";
+  }
+  ValidateTypeValidShape(expr->GetType(), context, expr->span_);
+  IRVisitor::VisitExpr(expr);
+}
+
+void TypeChecker::ValidateTypeValidShape(const TypePtr& type, const std::string& context, const Span& span) {
+  if (!type) return;
+
+  if (auto tuple_type = As<TupleType>(type)) {
+    for (size_t i = 0; i < tuple_type->types_.size(); ++i) {
+      ValidateTypeValidShape(tuple_type->types_[i], context + " TupleType element[" + std::to_string(i) + "]",
+                             span);
+    }
+    return;
+  }
+
+  const std::vector<ExprPtr>* valid_shape = nullptr;
+  const std::vector<ExprPtr>* physical_shape = nullptr;
+  if (auto distributed_type = As<DistributedTensorType>(type)) {
+    if (distributed_type->tensor_view_) {
+      valid_shape = &distributed_type->tensor_view_->valid_shape;
+    }
+    physical_shape = &distributed_type->shape_;
+  } else if (auto tensor_type = As<TensorType>(type)) {
+    if (tensor_type->tensor_view_) {
+      valid_shape = &tensor_type->tensor_view_->valid_shape;
+    }
+    physical_shape = &tensor_type->shape_;
+  } else if (auto tile_type = As<TileType>(type)) {
+    if (tile_type->tile_view_) {
+      valid_shape = &tile_type->tile_view_->valid_shape;
+    }
+    physical_shape = &tile_type->shape_;
+  }
+
+  if (!valid_shape || !physical_shape || valid_shape->empty()) return;
+  for (const auto& error : ValidateValidShapeBounds(*valid_shape, *physical_shape, type->TypeName())) {
+    auto error_type = error.violation == ValidShapeBoundsViolation::kRankMismatch
+                          ? typecheck::ErrorType::SHAPE_DIMENSION_MISMATCH
+                          : typecheck::ErrorType::SHAPE_VALUE_MISMATCH;
+    RecordError(error_type, context + " has invalid " + error.message, span);
+  }
 }
 
 StmtPtr TypeChecker::GetLastStmt(const StmtPtr& stmt) {
@@ -586,11 +670,7 @@ class TypeCheckPropertyVerifierImpl : public PropertyVerifier {
 
       // Create type checker and run checking
       TypeChecker checker(diagnostics);
-
-      // Visit function body
-      if (func->body_) {
-        checker.VisitStmt(func->body_);
-      }
+      checker.VisitFunction(func);
     }
   }
 };

--- a/tests/ut/ir/verifier/test_valid_shape_bounds.py
+++ b/tests/ut/ir/verifier/test_valid_shape_bounds.py
@@ -114,6 +114,13 @@ def test_allows_genuinely_unknown_symbolic_bounds():
     assert _verify(_program(params=[ir.Var("x", symbolic_type, _SPAN)])) == []
 
 
+def test_allows_unsupported_extent_type_as_unknown():
+    float_extent = ir.ConstFloat(1.0, DataType.FP32, _SPAN)
+    unsupported_type = _tensor_type([_const(16)], [float_extent])
+
+    assert _verify(_program(params=[ir.Var("x", unsupported_type, _SPAN)])) == []
+
+
 def test_analyzer_proves_composite_extent_in_bounds():
     n = _sym("n")
     valid = _sub(_add(n, _const(64)), n)
@@ -176,23 +183,24 @@ def test_checks_local_variable_type():
 
 def test_checks_iter_arg_type():
     invalid_type = _tensor_type([_const(16)], [_const(17)])
-    initial = ir.Var("initial", ir.ScalarType(DataType.INT64), _SPAN)
+    scalar_type = ir.ScalarType(DataType.INT64)
+    initial = ir.Var("initial", scalar_type, _SPAN)
     carry = ir.IterArg("carry", invalid_type, initial, _SPAN)
+    result = ir.Var("result", scalar_type, _SPAN)
     loop = ir.ForStmt(
         ir.Var("i", ir.ScalarType(DataType.INDEX), _SPAN),
         _const(0),
         _const(1),
         _const(1),
         [carry],
-        ir.YieldStmt([], _SPAN),
-        [],
+        ir.YieldStmt([initial], _SPAN),
+        [result],
         _SPAN,
     )
     diagnostics = _verify(_program(statements=[loop]))
 
-    valid_shape_diagnostics = [d for d in diagnostics if "valid_shape" in d.message]
-    assert len(valid_shape_diagnostics) == 1
-    assert "IterArg 'carry' has invalid TensorType" in valid_shape_diagnostics[0].message
+    assert len(diagnostics) == 1
+    assert "IterArg 'carry' has invalid TensorType" in diagnostics[0].message
 
 
 def test_checks_call_result_type():

--- a/tests/ut/ir/verifier/test_valid_shape_bounds.py
+++ b/tests/ut/ir/verifier/test_valid_shape_bounds.py
@@ -1,0 +1,208 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Tests for valid-shape rank and bounds verification."""
+
+import pytest
+from pypto import DataType, ir, passes
+
+_SPAN = ir.Span.unknown()
+
+
+def _const(value: int) -> ir.ConstInt:
+    return ir.ConstInt(value, DataType.INDEX, _SPAN)
+
+
+def _sym(name: str) -> ir.Var:
+    return ir.Var(name, ir.ScalarType(DataType.INDEX), _SPAN)
+
+
+def _add(lhs: ir.Expr, rhs: ir.Expr) -> ir.Add:
+    return ir.Add(lhs, rhs, DataType.INDEX, _SPAN)
+
+
+def _sub(lhs: ir.Expr, rhs: ir.Expr) -> ir.Sub:
+    return ir.Sub(lhs, rhs, DataType.INDEX, _SPAN)
+
+
+def _tensor_type(shape: list[ir.Expr], valid_shape: list[ir.Expr] | None = None) -> ir.TensorType:
+    view = None if valid_shape is None else ir.TensorView(layout=ir.TensorLayout.ND, valid_shape=valid_shape)
+    return ir.TensorType(shape, DataType.FP32, None, view)
+
+
+def _tile_type(shape: list[ir.Expr], valid_shape: list[ir.Expr] | None = None) -> ir.TileType:
+    view = None if valid_shape is None else ir.TileView(valid_shape=valid_shape)
+    return ir.TileType(shape, DataType.FP32, None, view)
+
+
+def _program(
+    *,
+    params: list[ir.Var] | None = None,
+    return_types: list[ir.Type] | None = None,
+    statements: list[ir.Stmt] | None = None,
+) -> ir.Program:
+    body = ir.SeqStmts([*(statements or []), ir.ReturnStmt([], _SPAN)], _SPAN)
+    function = ir.Function("main", params or [], return_types or [], body, _SPAN)
+    return ir.Program([function], "test", _SPAN)
+
+
+def _verify(program: ir.Program) -> list[passes.Diagnostic]:
+    properties = passes.IRPropertySet()
+    properties.insert(passes.IRProperty.TypeChecked)
+    return passes.PropertyVerifierRegistry.verify(properties, program)
+
+
+def test_rejects_negative_tensor_valid_extent():
+    invalid_type = _tensor_type([_const(16)], [_const(-1)])
+    diagnostics = _verify(_program(params=[ir.Var("x", invalid_type, _SPAN)]))
+
+    assert len(diagnostics) == 1
+    assert diagnostics[0].error_code == 104
+    assert "TensorType valid_shape dimension 0" in diagnostics[0].message
+    assert "negative extent -1" in diagnostics[0].message
+
+
+def test_rejects_tile_valid_extent_larger_than_shape():
+    invalid_type = _tile_type([_const(8), _const(16)], [_const(8), _const(17)])
+    diagnostics = _verify(_program(return_types=[invalid_type]))
+
+    assert len(diagnostics) == 1
+    assert diagnostics[0].error_code == 104
+    assert "Function 'main' return type[0]" in diagnostics[0].message
+    assert "TileType valid_shape dimension 1 extent 17" in diagnostics[0].message
+    assert "physical shape extent 16" in diagnostics[0].message
+
+
+def test_rejects_valid_shape_rank_mismatch():
+    invalid_type = _tensor_type([_const(8), _const(16)], [_const(8)])
+    diagnostics = _verify(_program(params=[ir.Var("x", invalid_type, _SPAN)]))
+
+    assert len(diagnostics) == 1
+    assert diagnostics[0].error_code == 103
+    assert "TensorType valid_shape rank mismatch" in diagnostics[0].message
+    assert "got rank 1" in diagnostics[0].message
+    assert "physical shape has rank 2" in diagnostics[0].message
+
+
+def test_unset_and_explicit_full_valid_shapes_pass():
+    unset_tensor = _tensor_type([_const(8), _const(16)])
+    full_tensor = _tensor_type([_const(8), _const(16)], [_const(8), _const(16)])
+    unset_tile = _tile_type([_const(8), _const(16)])
+    full_tile = _tile_type([_const(8), _const(16)], [_const(8), _const(16)])
+
+    assert full_tensor.tensor_view is None
+    assert full_tile.tile_view is None
+    params = [
+        ir.Var("unset_tensor", unset_tensor, _SPAN),
+        ir.Var("full_tensor", full_tensor, _SPAN),
+        ir.Var("unset_tile", unset_tile, _SPAN),
+        ir.Var("full_tile", full_tile, _SPAN),
+    ]
+    assert _verify(_program(params=params)) == []
+
+
+def test_allows_genuinely_unknown_symbolic_bounds():
+    valid_rows = _sym("valid_rows")
+    symbolic_type = _tensor_type([_const(16)], [valid_rows])
+
+    assert _verify(_program(params=[ir.Var("x", symbolic_type, _SPAN)])) == []
+
+
+def test_analyzer_proves_composite_extent_in_bounds():
+    n = _sym("n")
+    valid = _sub(_add(n, _const(64)), n)
+    symbolic_type = _tensor_type([_const(64)], [valid])
+
+    assert _verify(_program(params=[ir.Var("x", symbolic_type, _SPAN)])) == []
+
+
+def test_analyzer_rejects_composite_extent_larger_than_shape():
+    n = _sym("n")
+    valid = _sub(_add(n, _const(65)), n)
+    invalid_type = _tensor_type([_const(64)], [valid])
+    diagnostics = _verify(_program(params=[ir.Var("x", invalid_type, _SPAN)]))
+
+    assert len(diagnostics) == 1
+    assert "TensorType valid_shape dimension 0" in diagnostics[0].message
+    assert "65" in diagnostics[0].message
+    assert "physical shape extent 64" in diagnostics[0].message
+
+
+def test_analyzer_rejects_composite_negative_extent():
+    n = _sym("n")
+    valid = _sub(_sub(n, n), _const(1))
+    invalid_type = _tensor_type([_const(64)], [valid])
+    diagnostics = _verify(_program(params=[ir.Var("x", invalid_type, _SPAN)]))
+
+    assert len(diagnostics) == 1
+    assert "provably negative extent" in diagnostics[0].message
+    assert "n" in diagnostics[0].message
+
+
+def test_recurses_into_tuple_function_return_type():
+    invalid_tensor = _tensor_type([_const(8)], [_const(9)])
+    tuple_type = ir.TupleType([ir.ScalarType(DataType.INT64), invalid_tensor])
+    diagnostics = _verify(_program(return_types=[tuple_type]))
+
+    assert len(diagnostics) == 1
+    assert "return type[0] TupleType element[1]" in diagnostics[0].message
+    assert "TensorType valid_shape dimension 0" in diagnostics[0].message
+
+
+def test_checks_distributed_tensor_valid_shape():
+    view = ir.TensorView(layout=ir.TensorLayout.ND, valid_shape=[_const(4), _const(17)])
+    invalid_type = ir.DistributedTensorType([_const(4), _const(16)], DataType.FP32, None, view)
+    diagnostics = _verify(_program(params=[ir.Var("remote", invalid_type, _SPAN)]))
+
+    assert len(diagnostics) == 1
+    assert "DistributedTensorType valid_shape dimension 1" in diagnostics[0].message
+
+
+def test_checks_local_variable_type():
+    invalid_type = _tile_type([_const(16)], [_const(17)])
+    local = ir.Var("local", invalid_type, _SPAN)
+    assign = ir.AssignStmt(local, ir.ConstInt(0, DataType.INT64, _SPAN), _SPAN)
+    diagnostics = _verify(_program(statements=[assign]))
+
+    assert len(diagnostics) == 1
+    assert "Var 'local' has invalid TileType valid_shape dimension 0" in diagnostics[0].message
+
+
+def test_checks_iter_arg_type():
+    invalid_type = _tensor_type([_const(16)], [_const(17)])
+    initial = ir.Var("initial", ir.ScalarType(DataType.INT64), _SPAN)
+    carry = ir.IterArg("carry", invalid_type, initial, _SPAN)
+    loop = ir.ForStmt(
+        ir.Var("i", ir.ScalarType(DataType.INDEX), _SPAN),
+        _const(0),
+        _const(1),
+        _const(1),
+        [carry],
+        ir.YieldStmt([], _SPAN),
+        [],
+        _SPAN,
+    )
+    diagnostics = _verify(_program(statements=[loop]))
+
+    valid_shape_diagnostics = [d for d in diagnostics if "valid_shape" in d.message]
+    assert len(valid_shape_diagnostics) == 1
+    assert "IterArg 'carry' has invalid TensorType" in valid_shape_diagnostics[0].message
+
+
+def test_checks_call_result_type():
+    invalid_type = _tensor_type([_const(16)], [_const(17)])
+    call = ir.Call(ir.Op("test.call"), [], invalid_type, _SPAN)
+    diagnostics = _verify(_program(statements=[ir.EvalStmt(call, _SPAN)]))
+
+    assert len(diagnostics) == 1
+    assert "Call result has invalid TensorType valid_shape dimension 0" in diagnostics[0].message
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

- add tri-state proof utilities for symbolic valid-extent equality and ordering
- validate explicit valid-shape rank and provable `0 <= valid[i] <= shape[i]` bounds
- recursively enforce the invariant for tensor, tile, distributed, tuple, signature, local, loop-carried, and call-result types
- add focused verifier coverage for constant, symbolic, composite, and canonical full-shape cases

## Why

A shaped value can represent padded storage where only part of the physical shape is valid. Without a standing verifier invariant, malformed metadata such as a `[64, 68]` valid shape on `[64, 64]` storage can survive until a later compiler pass and fail far from its source. This change reports provable violations at the normal type-verification boundary while preserving genuinely unknown symbolic bounds.

## Impact

There is no new user-facing API. Compiler passes that create or propagate valid-shape metadata now receive early diagnostics for definite rank and bounds errors, providing the safety foundation for later valid-shape propagation work.

## Validation

- `cmake --build build --parallel`
- `python -m pytest tests/ut/ir/transforms/test_type_check_pass.py tests/ut/ir/test_tensor_view_semantics.py tests/ut/ir/verifier/test_valid_shape_bounds.py -n auto --maxprocesses 8 -q` (67 passed)
- `pre-commit run --files include/pypto/ir/type_inference.h src/ir/op/type_inference.cpp src/ir/verifier/type_check_pass.cpp tests/ut/ir/verifier/test_valid_shape_bounds.py`
- `python tests/lint/clang_tidy.py --diff-base HEAD`
