### PR TITLE
fix(ci): orphaned-task cleanup via task-submit --find + raise --timeout to 3600s

### DIFF
--- a/.github/actions/kill-orphaned-tasks/action.yml
+++ b/.github/actions/kill-orphaned-tasks/action.yml
@@ -18,21 +18,46 @@ runs:
   steps:
     - name: Kill orphaned task-submit tasks
       shell: bash
+      # Pass checkout-path via env rather than inlining ${{ }} into the script:
+      # ${{ }} is textual substitution done before bash ever sees the script, so
+      # a path with spaces or shell metacharacters could break it or inject.
+      env:
+        CHECKOUT_PATH: ${{ inputs.checkout-path }}
       run: |
-        # Guard against an empty checkout-path: grep -F "$GITHUB_WORKSPACE/"
-        # would match every task on a shared workspace root and kill other jobs'
-        # tasks. checkout-path is a required input, but fail safe rather than
-        # sorry if a caller ever passes an empty string.
-        if [ -z "${{ inputs.checkout-path }}" ]; then
+        # Guard against an empty checkout-path: an empty pattern matches every
+        # task on a shared workspace root and would kill other jobs' tasks.
+        # checkout-path is a required input, but fail safe rather than sorry if
+        # a caller ever passes an empty string.
+        if [ -z "$CHECKOUT_PATH" ]; then
           echo "checkout-path is empty — skipping task-submit cleanup"
           exit 0
         fi
-        echo "cleaning up task-submit tasks for $GITHUB_WORKSPACE/${{ inputs.checkout-path }}"
-        task-submit --list 2>/dev/null \
-          | grep -F "$GITHUB_WORKSPACE/${{ inputs.checkout-path }}" \
-          | grep -oE 'task_[0-9_]+' \
-          | sort -u \
-          | while read -r tid; do
-              echo "  killing $tid"
-              task-submit --kill "$tid" || true
-            done || true
+
+        target="$GITHUB_WORKSPACE/$CHECKOUT_PATH"
+        echo "cleaning up task-submit tasks for $target"
+
+        # Match with `--find`, NOT `--list`: --list is a human-facing view that
+        # truncates the command column to 77 chars, so a grep for the full
+        # checkout path never matched and this cleanup silently did nothing for
+        # months. --find matches against the untruncated COMMAND and prints bare
+        # task-ids. It needs task-submit >= 2026-07-14 on the runner.
+        if ! ids=$(task-submit --find "$target"); then
+          echo "::error::task-submit --find failed — is task-submit up to date on this runner?"
+          exit 1
+        fi
+
+        if [ -z "$ids" ]; then
+          echo "  no orphaned tasks"
+          exit 0
+        fi
+
+        # Report what we killed. A cleanup step that prints nothing is
+        # indistinguishable from a cleanup step that is quietly broken.
+        n=0
+        while read -r tid; do
+          [ -n "$tid" ] || continue
+          echo "  killing $tid"
+          task-submit --kill "$tid" || echo "::warning::failed to kill $tid"
+          n=$((n + 1))
+        done <<< "$ids"
+        echo "killed $n orphaned task(s)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -314,7 +314,7 @@ jobs:
         # here collapses pytest's dir collection.)
         run: |
           source activate.sh
-          task-submit --device "$DEVICE_ID" --timeout 1800 --max-time 1800 \
+          task-submit --device "$DEVICE_ID" --timeout 3600 --max-time 1800 \
             --run "cd $GITHUB_WORKSPACE/st-checkout && source activate.sh && python -m pytest \
               tests/st -v -m 'not device_batch' \
               --ignore=tests/st/distributed \
@@ -330,7 +330,7 @@ jobs:
         # via task-submit) because it lives under the --ignore'd tests/st/codegen.
         run: |
           source activate.sh
-          task-submit --device "$DEVICE_ID" --timeout 1800 --max-time 600 \
+          task-submit --device "$DEVICE_ID" --timeout 3600 --max-time 600 \
             --run "cd $GITHUB_WORKSPACE/st-checkout && source activate.sh && python -m pytest \
               tests/st/codegen/torch/test_torch_codegen_paged_attention.py \
               -v --device=\$TASK_DEVICE --platform=a2a3 \
@@ -344,19 +344,19 @@ jobs:
         timeout-minutes: 5
         run: |
           source activate.sh
-          task-submit --device "$DEVICE_ID" --timeout 1800 --max-time 600 \
+          task-submit --device "$DEVICE_ID" --timeout 3600 --max-time 600 \
             --run "cd $GITHUB_WORKSPACE/st-checkout && source activate.sh && python -m pytest tests/st/distributed/test_l2_multi_orch.py -v --device=\$TASK_DEVICE --pto-isa-commit=${{ needs.toolchain.outputs.pto_isa_commit }}"
 
       - name: Test swimlane output
         run: |
           source activate.sh
-          task-submit --device "$DEVICE_ID" --timeout 1800 --max-time 600 \
+          task-submit --device "$DEVICE_ID" --timeout 3600 --max-time 600 \
             --run "cd $GITHUB_WORKSPACE/st-checkout && source activate.sh && python -m pytest tests/st/runtime/framework_and_models/test_perf_swimlane.py -v --device=\$TASK_DEVICE --platform=a2a3 --enable-l2-swimlane --forked --pto-isa-commit=${{ needs.toolchain.outputs.pto_isa_commit }}"
 
       - name: Test dump-args output
         run: |
           source activate.sh
-          task-submit --device "$DEVICE_ID" --timeout 1800 --max-time 600 \
+          task-submit --device "$DEVICE_ID" --timeout 3600 --max-time 600 \
             --run "cd $GITHUB_WORKSPACE/st-checkout && source activate.sh && python -m pytest tests/st/runtime/framework_and_models/test_dump_tag.py -v --device=\$TASK_DEVICE --platform=a2a3 --dump-args --pto-isa-commit=${{ needs.toolchain.outputs.pto_isa_commit }} --forked"
 
       - name: Kill orphaned task-submit tasks
@@ -430,7 +430,7 @@ jobs:
         # HCCL); task-submit preserves that env into the child.
         run: |
           source activate.sh
-          task-submit --device "$DEVICE_ID" --device-num 2 --timeout 1800 --max-time 900 \
+          task-submit --device "$DEVICE_ID" --device-num 2 --timeout 3600 --max-time 900 \
             --run "cd $GITHUB_WORKSPACE/dist-checkout && source activate.sh && python -m pytest tests/st/distributed -v --device=\$TASK_DEVICE --pto-isa-commit=${{ needs.toolchain.outputs.pto_isa_commit }} --ignore=tests/st/distributed/test_l2_multi_orch.py"
 
       - name: Kill orphaned task-submit tasks
@@ -516,7 +516,7 @@ jobs:
           PYTHONPATH: ${{ github.workspace }}/pypto-lib
         run: |
           source activate.sh
-          task-submit --device "$DEVICE_ID" --timeout 1800 --max-time 1800 \
+          task-submit --device "$DEVICE_ID" --timeout 3600 --max-time 1800 \
             --run "source $GITHUB_WORKSPACE/lib-checkout/activate.sh && cd $GITHUB_WORKSPACE/pypto-lib && python models/qwen3/14b/decode_fwd.py -p a2a3 -d \$TASK_DEVICE"
 
       # NOTE: Qwen3-14B decode performance monitoring (L2-swimlane makespan +
@@ -529,7 +529,7 @@ jobs:
           PYTHONPATH: ${{ github.workspace }}/pypto-lib
         run: |
           source activate.sh
-          task-submit --device "$DEVICE_ID" --timeout 1800 --max-time 1800 \
+          task-submit --device "$DEVICE_ID" --timeout 3600 --max-time 1800 \
             --run "source $GITHUB_WORKSPACE/lib-checkout/activate.sh && cd $GITHUB_WORKSPACE/pypto-lib && python models/deepseek/v4/decode_attention_swa.py -p a2a3 -d \$TASK_DEVICE"
 
       - name: Run pypto-lib DeepSeek-V4 decode_attention_hca example
@@ -537,7 +537,7 @@ jobs:
           PYTHONPATH: ${{ github.workspace }}/pypto-lib
         run: |
           source activate.sh
-          task-submit --device "$DEVICE_ID" --timeout 1800 --max-time 1800 \
+          task-submit --device "$DEVICE_ID" --timeout 3600 --max-time 1800 \
             --run "source $GITHUB_WORKSPACE/lib-checkout/activate.sh && cd $GITHUB_WORKSPACE/pypto-lib && python models/deepseek/v4/decode_attention_hca.py -p a2a3 -d \$TASK_DEVICE"
 
       - name: Run pypto-lib DeepSeek-V4 prefill_attention_csa example
@@ -545,7 +545,7 @@ jobs:
           PYTHONPATH: ${{ github.workspace }}/pypto-lib
         run: |
           source activate.sh
-          task-submit --device "$DEVICE_ID" --timeout 1800 --max-time 1800 \
+          task-submit --device "$DEVICE_ID" --timeout 3600 --max-time 1800 \
             --run "source $GITHUB_WORKSPACE/lib-checkout/activate.sh && cd $GITHUB_WORKSPACE/pypto-lib && python models/deepseek/v4/prefill_attention_csa.py -p a2a3 -d \$TASK_DEVICE"
 
       - name: Run pypto-lib DeepSeek-V4 prefill_attention_hca example
@@ -553,7 +553,7 @@ jobs:
           PYTHONPATH: ${{ github.workspace }}/pypto-lib
         run: |
           source activate.sh
-          task-submit --device "$DEVICE_ID" --timeout 1800 --max-time 1800 \
+          task-submit --device "$DEVICE_ID" --timeout 3600 --max-time 1800 \
             --run "source $GITHUB_WORKSPACE/lib-checkout/activate.sh && cd $GITHUB_WORKSPACE/pypto-lib && python models/deepseek/v4/prefill_attention_hca.py -p a2a3 -d \$TASK_DEVICE"
 
       - name: Run pypto-lib DeepSeek-V4 prefill_attention_swa example
@@ -561,7 +561,7 @@ jobs:
           PYTHONPATH: ${{ github.workspace }}/pypto-lib
         run: |
           source activate.sh
-          task-submit --device "$DEVICE_ID" --timeout 1800 --max-time 1800 \
+          task-submit --device "$DEVICE_ID" --timeout 3600 --max-time 1800 \
             --run "source $GITHUB_WORKSPACE/lib-checkout/activate.sh && cd $GITHUB_WORKSPACE/pypto-lib && python models/deepseek/v4/prefill_attention_swa.py -p a2a3 -d \$TASK_DEVICE"
 
       - name: Kill orphaned task-submit tasks

--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -90,7 +90,7 @@ jobs:
         # puts the workspace path into the task command so the cleanup step below
         # can grep -F "$GITHUB_WORKSPACE" to find THIS job's task.
         run: |
-          task-submit --timeout 1800 --max-time 1800 --device 6 \
+          task-submit --timeout 3600 --max-time 1800 --device 6 \
             --run "cd $GITHUB_WORKSPACE && pytest tests/st/runtime/ops/test_assemble.py tests/st/runtime/ops/test_mscatter.py tests/st/runtime/ops/test_random.py tests/st/runtime/framework_and_models/test_qwen3_decode_scope3_mixed.py tests/st/runtime/control_flow/test_dyn_orch_shape.py::TestDynOrchShapeOperations::test_dyn_orch_paged_attention -v --forked --platform=a5 --device=6 --pto-isa-commit=${{ needs.toolchain.outputs.pto_isa_commit }} \
               -k 'not (test_tile_row_expand or test_fillpad_zero or test_fillpad_max or test_fillpad_min or TestMscatter)'"
 
@@ -196,7 +196,7 @@ jobs:
           : > "$GITHUB_WORKSPACE/qwen3_perf.log"   # truncate any stale log
           for i in $(seq 1 5); do
             echo "=== qwen3 decode perf sample $i/5 ==="
-            task-submit --device "$DEVICE_ID" --timeout 1800 --max-time 1800 \
+            task-submit --device "$DEVICE_ID" --timeout 3600 --max-time 1800 \
               --run "source $GITHUB_WORKSPACE/perf-checkout/activate.sh && cd $GITHUB_WORKSPACE/pypto-lib && python models/qwen3/14b/decode_layer.py -p a2a3 -d \$TASK_DEVICE --enable-l2-swimlane --max-seq --seed 1234" \
               2>&1 | tee -a "$GITHUB_WORKSPACE/qwen3_perf.log" \
               || echo "WARN: perf sample $i exited non-zero"


### PR DESCRIPTION
## Summary

This PR bundles two related CI reliability changes to the device-job workflows.

### 1. Fix orphaned-task cleanup (`.github/actions/kill-orphaned-tasks`)
- The cleanup action matched task-submit output with `task-submit --list`, whose human-facing view truncates the command column to 77 chars. The full `$GITHUB_WORKSPACE/$CHECKOUT_PATH` grep never matched, so the cleanup was silently a no-op. Switch to `task-submit --find "$target"`, which matches against the untruncated COMMAND and prints bare task-ids.
- Pass `checkout-path` via an `env:` var (`CHECKOUT_PATH`) instead of inlining `${{ inputs.checkout-path }}` into the `run:` script, so a path with spaces or shell metacharacters cannot break the command or inject into it (`${{ }}` is textual pre-substitution before bash sees the script).
- Add observability: report the killed count, and surface `--find`/`--kill` failures with `::error::`/`::warning::` instead of failing silently.

### 2. Raise `task-submit --timeout` to 3600s (`ci.yml`, `daily_ci.yml`)
- Bump every `task-submit --timeout` from `1800s` to `3600s` (12 invocations in `ci.yml`, 2 in `daily_ci.yml`).
- `--timeout` governs the device-acquisition **queue wait** — raising it gives device jobs more tolerance for runner contention before task-submit gives up waiting for a card.
- `--max-time` (the run wall-clock cap: 1800 / 900 / 600) is deliberately **left unchanged**, so this only grants more queue-wait headroom, not longer executions. The `--timeout 60` in the kill-orphaned-tasks path and `--task-queue-timeout=1800` in the batched system-tests step are different flags and are intentionally untouched.

## Testing
- [ ] CI config change — validated by the CI runs on this PR.

## Notes
- `--find` requires `task-submit >= 2026-07-14` on the runner. The cleanup step now `exit 1`s if `--find` is unavailable ("fail safe rather than sorry"), so the runner-side tool update should land in lockstep with this merge.
