### PR TITLE
refactor(ir): dedup IsBuiltinOp into ir::op_predicates

### DIFF
--- a/include/pypto/codegen/orchestration/orchestration_analysis.h
+++ b/include/pypto/codegen/orchestration/orchestration_analysis.h
@@ -25,6 +25,7 @@
 #include "pypto/ir/scalar_expr.h"
 #include "pypto/ir/stmt.h"
 #include "pypto/ir/transforms/base/visitor.h"
+#include "pypto/ir/transforms/utils/op_predicates.h"
 #include "pypto/ir/transforms/utils/transform_utils.h"
 #include "pypto/ir/type.h"
 
@@ -36,7 +37,12 @@ namespace codegen {
 // ---------------------------------------------------------------------------
 
 std::string GetSSABaseName(const std::string& name);
-bool IsBuiltinOp(const std::string& op_name);
+
+/// Thin forward to ``ir::op_predicates::IsBuiltinOp`` so codegen call sites read
+/// unqualified. The canonical builtin-op classifier lives in the IR layer;
+/// codegen must not own a second copy.
+inline bool IsBuiltinOp(const std::string& op_name) { return ir::op_predicates::IsBuiltinOp(op_name); }
+
 bool IsTensorOp(const std::string& op_name);
 
 /// True for ops starting with ``array.`` (create / get_element / update_element).

--- a/include/pypto/ir/transforms/utils/op_predicates.h
+++ b/include/pypto/ir/transforms/utils/op_predicates.h
@@ -46,6 +46,18 @@ bool IsInitializePipe(const CallPtr& call);
 /// propagation and the tpop lifetime / tfree finalizer.
 bool IsBufferAliasingViewOp(const std::string& op_name);
 
+/// True for builtin ops whose name is namespaced `tile.` / `tensor.` /
+/// `system.` / `array.`. Builtin ops are never user Functions, so they carry
+/// no callee body and no Out/InOut params to trace.
+///
+/// This is a deliberate string-prefix *family* check, not a registry lookup:
+/// it must classify op names that may not be registered (e.g. during `.pto`
+/// deserialization or partway through a lowering pass). It matches an entire
+/// namespace, not a single operator, so `IsOp` / `GetOp` do not apply here
+/// (see `operator-identity-checks.md`). It is the single canonical home for a
+/// predicate that was previously copy-pasted across the IR and codegen layers.
+bool IsBuiltinOp(const std::string& op_name);
+
 }  // namespace op_predicates
 }  // namespace ir
 }  // namespace pypto

--- a/src/codegen/orchestration/orchestration_analysis.cpp
+++ b/src/codegen/orchestration/orchestration_analysis.cpp
@@ -50,10 +50,8 @@ using namespace pypto::ir;  // NOLINT(build/namespaces)
 
 std::string GetSSABaseName(const std::string& name) { return auto_name::GetCompatibleBaseName(name); }
 
-bool IsBuiltinOp(const std::string& op_name) {
-  return op_name.find("tile.") == 0 || op_name.find("tensor.") == 0 || op_name.find("system.") == 0 ||
-         op_name.find("array.") == 0;
-}
+// IsBuiltinOp now lives in ir::op_predicates and is thin-forwarded from the
+// header; codegen call sites still read unqualified via that forward.
 
 bool IsTensorOp(const std::string& op_name) { return op_name.find("tensor.") == 0; }
 

--- a/src/ir/transforms/auto_derive_task_dependencies_pass.cpp
+++ b/src/ir/transforms/auto_derive_task_dependencies_pass.cpp
@@ -26,7 +26,6 @@
 #include <utility>
 #include <vector>
 
-#include "pypto/codegen/orchestration/orchestration_analysis.h"
 #include "pypto/core/logging.h"
 #include "pypto/ir/expr.h"
 #include "pypto/ir/function.h"
@@ -42,6 +41,7 @@
 #include "pypto/ir/transforms/pass_properties.h"
 #include "pypto/ir/transforms/passes.h"
 #include "pypto/ir/transforms/utils/attrs.h"
+#include "pypto/ir/transforms/utils/op_predicates.h"
 #include "pypto/ir/transforms/utils/tensor_view_semantics.h"
 #include "pypto/ir/type.h"
 
@@ -50,7 +50,7 @@ namespace ir {
 
 namespace {
 
-using ::pypto::codegen::IsBuiltinOp;
+using ::pypto::ir::op_predicates::IsBuiltinOp;
 
 enum class AccessKind { Read, Write, ReadWrite };
 

--- a/src/ir/transforms/derive_call_directions_pass.cpp
+++ b/src/ir/transforms/derive_call_directions_pass.cpp
@@ -21,7 +21,6 @@
 #include <utility>
 #include <vector>
 
-#include "pypto/codegen/orchestration/orchestration_analysis.h"
 #include "pypto/core/logging.h"
 #include "pypto/ir/expr.h"
 #include "pypto/ir/function.h"
@@ -33,6 +32,7 @@
 #include "pypto/ir/transforms/passes.h"
 #include "pypto/ir/transforms/utils/buffer_root_collector.h"
 #include "pypto/ir/transforms/utils/mutable_copy.h"
+#include "pypto/ir/transforms/utils/op_predicates.h"
 #include "pypto/ir/transforms/utils/wrapper_call_utils.h"
 #include "pypto/ir/type.h"
 
@@ -41,9 +41,9 @@ namespace ir {
 
 namespace {
 
-using ::pypto::codegen::IsBuiltinOp;
 using ::pypto::ir::buffer_root::AmbiguousRootPolicy;
 using ::pypto::ir::buffer_root::BufferRootCollector;
+using ::pypto::ir::op_predicates::IsBuiltinOp;
 
 /// Decide whether an argument expression refers to a tensor (not a scalar/index).
 bool IsTensorTypedArg(const ExprPtr& arg) {

--- a/src/ir/transforms/materialize_runtime_scopes_pass.cpp
+++ b/src/ir/transforms/materialize_runtime_scopes_pass.cpp
@@ -16,7 +16,6 @@
 #include <utility>
 #include <vector>
 
-#include "pypto/codegen/orchestration/orchestration_analysis.h"
 #include "pypto/ir/expr.h"
 #include "pypto/ir/function.h"
 #include "pypto/ir/kind_traits.h"
@@ -27,6 +26,7 @@
 #include "pypto/ir/transforms/passes.h"
 #include "pypto/ir/transforms/utils/attrs.h"
 #include "pypto/ir/transforms/utils/mutable_copy.h"
+#include "pypto/ir/transforms/utils/op_predicates.h"
 
 namespace pypto {
 namespace ir {
@@ -34,7 +34,7 @@ namespace pass {
 
 namespace {
 
-using ::pypto::codegen::IsBuiltinOp;
+using ::pypto::ir::op_predicates::IsBuiltinOp;
 
 constexpr const char* kAttrCompilerAutoManualLayerCandidate = "__compiler_auto_manual_layer_candidate";
 

--- a/src/ir/transforms/utils/buffer_root_collector.cpp
+++ b/src/ir/transforms/utils/buffer_root_collector.cpp
@@ -23,6 +23,7 @@
 #include "pypto/ir/program.h"
 #include "pypto/ir/stmt.h"
 #include "pypto/ir/transforms/base/visitor.h"
+#include "pypto/ir/transforms/utils/op_predicates.h"
 #include "pypto/ir/transforms/utils/transform_utils.h"
 #include "pypto/ir/type.h"
 
@@ -31,14 +32,7 @@ namespace ir {
 namespace buffer_root {
 namespace {
 
-// Builtin ops (tile.* / tensor.* / system.* / array.*) are never user
-// functions, so they carry no callee Out/InOut params to trace. Mirrors the
-// canonical IsBuiltinOp predicate; kept file-local to avoid a cross-layer
-// dependency from this IR util onto the codegen module.
-bool IsBuiltinOpName(const std::string& op_name) {
-  return op_name.find("tile.") == 0 || op_name.find("tensor.") == 0 || op_name.find("system.") == 0 ||
-         op_name.find("array.") == 0;
-}
+using op_predicates::IsBuiltinOp;
 
 }  // namespace
 
@@ -97,7 +91,7 @@ void BufferRootCollector::VisitStmt_(const AssignStmtPtr& assign) {
           buffer_roots[assign->var_.get()] = target_root;
         }
       }
-    } else if (!IsBuiltinOpName(op_name)) {
+    } else if (!IsBuiltinOp(op_name)) {
       auto out_roots = CollectCallOutputRoots(call);
       if (As<TupleType>(call->GetType())) {
         std::vector<const Var*> roots;

--- a/src/ir/transforms/utils/op_predicates.cpp
+++ b/src/ir/transforms/utils/op_predicates.cpp
@@ -54,6 +54,11 @@ bool IsBufferAliasingViewOp(const std::string& op_name) {
   return entry.OutputMemoryInheritsInput() && entry.IsInplaceSafe();
 }
 
+bool IsBuiltinOp(const std::string& op_name) {
+  return op_name.rfind("tile.", 0) == 0 || op_name.rfind("tensor.", 0) == 0 ||
+         op_name.rfind("system.", 0) == 0 || op_name.rfind("array.", 0) == 0;
+}
+
 }  // namespace op_predicates
 }  // namespace ir
 }  // namespace pypto

--- a/src/ir/transforms/utils/return_lineage_utils.cpp
+++ b/src/ir/transforms/utils/return_lineage_utils.cpp
@@ -28,6 +28,7 @@
 #include "pypto/ir/program.h"
 #include "pypto/ir/stmt.h"
 #include "pypto/ir/transforms/base/visitor.h"
+#include "pypto/ir/transforms/utils/op_predicates.h"
 #include "pypto/ir/transforms/utils/wrapper_call_utils.h"
 #include "pypto/ir/type.h"
 
@@ -37,10 +38,7 @@ namespace return_lineage {
 
 namespace {
 
-bool IsBuiltinOp(const std::string& op_name) {
-  return op_name.find("tile.") == 0 || op_name.find("tensor.") == 0 || op_name.find("system.") == 0 ||
-         op_name.find("array.") == 0;
-}
+using op_predicates::IsBuiltinOp;
 
 CallPtr AsCallOrSubmitView(const ExprPtr& expr) {
   if (auto call = As<Call>(expr)) return call;

--- a/src/ir/transforms/utils/window_externalization.cpp
+++ b/src/ir/transforms/utils/window_externalization.cpp
@@ -27,7 +27,6 @@
 #include <utility>
 #include <vector>
 
-#include "pypto/codegen/orchestration/orchestration_analysis.h"
 #include "pypto/core/dtype.h"
 #include "pypto/core/logging.h"
 #include "pypto/ir/arith/analyzer.h"
@@ -44,6 +43,7 @@
 #include "pypto/ir/transforms/structural_comparison.h"
 #include "pypto/ir/transforms/utils/deep_clone_utils.h"
 #include "pypto/ir/transforms/utils/mutable_copy.h"
+#include "pypto/ir/transforms/utils/op_predicates.h"
 #include "pypto/ir/transforms/utils/tensor_view_semantics.h"
 #include "pypto/ir/transforms/utils/transform_utils.h"
 #include "pypto/ir/transforms/utils/var_collectors.h"
@@ -2264,7 +2264,7 @@ class OutWindowExternalizer {
             if (source_root) rewriter_->RecordSiblingCarrierAliasRoot(source_root.get(), parent_root);
           }
 
-          if (!call || pypto::codegen::IsBuiltinOp(call->op_->name_)) {
+          if (!call || op_predicates::IsBuiltinOp(call->op_->name_)) {
             IRVisitor::VisitStmt_(op);
             return;
           }
@@ -4138,7 +4138,7 @@ class OutWindowExternalizer {
   AnalysisMap Analyze(const ProgramPtr& program) {
     AnalysisMap analyses;
     for (const auto& [gvar, func] : program->functions_) {
-      if (!func || pypto::codegen::IsBuiltinOp(func->name_) || !IsInCoreType(func->func_type_)) {
+      if (!func || op_predicates::IsBuiltinOp(func->name_) || !IsInCoreType(func->func_type_)) {
         continue;
       }
 

--- a/src/ir/transforms/utils/window_externalization.cpp
+++ b/src/ir/transforms/utils/window_externalization.cpp
@@ -2264,7 +2264,7 @@ class OutWindowExternalizer {
             if (source_root) rewriter_->RecordSiblingCarrierAliasRoot(source_root.get(), parent_root);
           }
 
-          if (!call || op_predicates::IsBuiltinOp(call->op_->name_)) {
+          if (!call || !call->op_ || op_predicates::IsBuiltinOp(call->op_->name_)) {
             IRVisitor::VisitStmt_(op);
             return;
           }

--- a/src/ir/verifier/verify_call_directions.cpp
+++ b/src/ir/verifier/verify_call_directions.cpp
@@ -16,13 +16,13 @@
 #include <utility>
 #include <vector>
 
-#include "pypto/codegen/orchestration/orchestration_analysis.h"
 #include "pypto/core/error.h"
 #include "pypto/ir/expr.h"
 #include "pypto/ir/function.h"
 #include "pypto/ir/kind_traits.h"
 #include "pypto/ir/program.h"
 #include "pypto/ir/transforms/base/visitor.h"
+#include "pypto/ir/transforms/utils/op_predicates.h"
 #include "pypto/ir/transforms/utils/wrapper_call_utils.h"
 #include "pypto/ir/type.h"
 #include "pypto/ir/verifier/verifier.h"
@@ -31,7 +31,7 @@ namespace pypto {
 namespace ir {
 namespace {
 
-using ::pypto::codegen::IsBuiltinOp;
+using ::pypto::ir::op_predicates::IsBuiltinOp;
 
 bool IsTensorTypedArg(const ExprPtr& arg) {
   TypePtr ty = arg ? arg->GetType() : TypePtr{};

--- a/src/ir/verifier/verify_orchestration_references.cpp
+++ b/src/ir/verifier/verify_orchestration_references.cpp
@@ -20,20 +20,14 @@
 #include "pypto/ir/function.h"
 #include "pypto/ir/program.h"
 #include "pypto/ir/transforms/base/visitor.h"
+#include "pypto/ir/transforms/utils/op_predicates.h"
 #include "pypto/ir/verifier/verifier.h"
 
 namespace pypto {
 namespace ir {
 namespace {
 
-/// Local copy of the builtin-op classifier. Verifiers live in the IR layer
-/// and must not depend on `pypto::codegen::IsBuiltinOp`. The classification
-/// is intentionally a string-prefix check; if a third reader appears,
-/// promote it to a shared IR utility.
-bool IsBuiltinOpName(const std::string& name) {
-  return name.rfind("tile.", 0) == 0 || name.rfind("tensor.", 0) == 0 || name.rfind("system.", 0) == 0 ||
-         name.rfind("array.", 0) == 0;
-}
+using op_predicates::IsBuiltinOp;
 
 class OrchestrationCallTargetChecker : public IRVisitor {
  public:
@@ -45,7 +39,7 @@ class OrchestrationCallTargetChecker : public IRVisitor {
   void VisitExpr_(const CallPtr& call) override {
     IRVisitor::VisitExpr_(call);
     if (!call || !call->op_) return;
-    if (IsBuiltinOpName(call->op_->name_)) return;
+    if (IsBuiltinOp(call->op_->name_)) return;
     if (program_ && program_->GetFunction(call->op_->name_)) return;
 
     std::ostringstream oss;


### PR DESCRIPTION
## Summary

The IR layer duplicated the builtin-op classifier and reverse-`#include`d a codegen header — a layering violation, since codegen depends on IR, never the reverse. This PR removes both.

- **Dedup `IsBuiltinOp`.** The `tile.`/`tensor.`/`system.`/`array.` namespace-family predicate had four copy-pasted implementations: the canonical one in codegen `orchestration_analysis.cpp`, plus file-local copies in `return_lineage_utils.cpp`, `verify_orchestration_references.cpp`, and `buffer_root_collector.cpp` (the latter two even carried a "if a third reader appears, promote to a shared util" comment — the third reader already existed). Promoted to a single canonical home in `ir::op_predicates`, next to the other string-based op predicates. codegen keeps its unqualified call sites via a thin inline forward.
- **Remove the reverse dependency.** With the predicate in the IR layer, five IR passes/verifiers (`derive_call_directions`, `auto_derive_task_dependencies`, `materialize_runtime_scopes`, `window_externalization`, `verify_call_directions`) no longer `#include "pypto/codegen/orchestration/orchestration_analysis.h"`. IR→codegen includes are now zero.

This is the follow-up that #1994 explicitly deferred — after moving the wrapper-direction and return-to-param analyses out of codegen, its notes read: *"derive_call_directions_pass.cpp still imports the codegen layer for BufferRootCollector / IsBuiltinOp ... closing it properly is its own change."* This PR is that change (rebased on top of #1994).

Behavior-preserving: `name.find(x) == 0` and `name.rfind(x, 0) == 0` are equivalent prefix checks.

## Testing

- Build: full `cmake --build` green (188/188 targets, `pypto_core` relinked).
- IR transforms + verifier + codegen UTs: **2811 passed** (rebased on #1994, includes its new tests).
- Code review: pass. clang-tidy: no new findings attributable to this diff.