### PR TITLE
chore(ci): raise task-submit --timeout to 3600s

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -314,7 +314,7 @@ jobs:
         # here collapses pytest's dir collection.)
         run: |
           source activate.sh
-          task-submit --device "$DEVICE_ID" --timeout 1800 --max-time 1800 \
+          task-submit --device "$DEVICE_ID" --timeout 3600 --max-time 1800 \
             --run "cd $GITHUB_WORKSPACE/st-checkout && source activate.sh && python -m pytest \
               tests/st -v -m 'not device_batch' \
               --ignore=tests/st/distributed \
@@ -330,7 +330,7 @@ jobs:
         # via task-submit) because it lives under the --ignore'd tests/st/codegen.
         run: |
           source activate.sh
-          task-submit --device "$DEVICE_ID" --timeout 1800 --max-time 600 \
+          task-submit --device "$DEVICE_ID" --timeout 3600 --max-time 600 \
             --run "cd $GITHUB_WORKSPACE/st-checkout && source activate.sh && python -m pytest \
               tests/st/codegen/torch/test_torch_codegen_paged_attention.py \
               -v --device=\$TASK_DEVICE --platform=a2a3 \
@@ -344,19 +344,19 @@ jobs:
         timeout-minutes: 5
         run: |
           source activate.sh
-          task-submit --device "$DEVICE_ID" --timeout 1800 --max-time 600 \
+          task-submit --device "$DEVICE_ID" --timeout 3600 --max-time 600 \
             --run "cd $GITHUB_WORKSPACE/st-checkout && source activate.sh && python -m pytest tests/st/distributed/test_l2_multi_orch.py -v --device=\$TASK_DEVICE --pto-isa-commit=${{ needs.toolchain.outputs.pto_isa_commit }}"
 
       - name: Test swimlane output
         run: |
           source activate.sh
-          task-submit --device "$DEVICE_ID" --timeout 1800 --max-time 600 \
+          task-submit --device "$DEVICE_ID" --timeout 3600 --max-time 600 \
             --run "cd $GITHUB_WORKSPACE/st-checkout && source activate.sh && python -m pytest tests/st/runtime/framework_and_models/test_perf_swimlane.py -v --device=\$TASK_DEVICE --platform=a2a3 --enable-l2-swimlane --forked --pto-isa-commit=${{ needs.toolchain.outputs.pto_isa_commit }}"
 
       - name: Test dump-args output
         run: |
           source activate.sh
-          task-submit --device "$DEVICE_ID" --timeout 1800 --max-time 600 \
+          task-submit --device "$DEVICE_ID" --timeout 3600 --max-time 600 \
             --run "cd $GITHUB_WORKSPACE/st-checkout && source activate.sh && python -m pytest tests/st/runtime/framework_and_models/test_dump_tag.py -v --device=\$TASK_DEVICE --platform=a2a3 --dump-args --pto-isa-commit=${{ needs.toolchain.outputs.pto_isa_commit }} --forked"
 
       - name: Kill orphaned task-submit tasks
@@ -430,7 +430,7 @@ jobs:
         # HCCL); task-submit preserves that env into the child.
         run: |
           source activate.sh
-          task-submit --device "$DEVICE_ID" --device-num 2 --timeout 1800 --max-time 900 \
+          task-submit --device "$DEVICE_ID" --device-num 2 --timeout 3600 --max-time 900 \
             --run "cd $GITHUB_WORKSPACE/dist-checkout && source activate.sh && python -m pytest tests/st/distributed -v --device=\$TASK_DEVICE --pto-isa-commit=${{ needs.toolchain.outputs.pto_isa_commit }} --ignore=tests/st/distributed/test_l2_multi_orch.py"
 
       - name: Kill orphaned task-submit tasks
@@ -516,7 +516,7 @@ jobs:
           PYTHONPATH: ${{ github.workspace }}/pypto-lib
         run: |
           source activate.sh
-          task-submit --device "$DEVICE_ID" --timeout 1800 --max-time 1800 \
+          task-submit --device "$DEVICE_ID" --timeout 3600 --max-time 1800 \
             --run "source $GITHUB_WORKSPACE/lib-checkout/activate.sh && cd $GITHUB_WORKSPACE/pypto-lib && python models/qwen3/14b/decode_fwd.py -p a2a3 -d \$TASK_DEVICE"
 
       # NOTE: Qwen3-14B decode performance monitoring (L2-swimlane makespan +
@@ -529,7 +529,7 @@ jobs:
           PYTHONPATH: ${{ github.workspace }}/pypto-lib
         run: |
           source activate.sh
-          task-submit --device "$DEVICE_ID" --timeout 1800 --max-time 1800 \
+          task-submit --device "$DEVICE_ID" --timeout 3600 --max-time 1800 \
             --run "source $GITHUB_WORKSPACE/lib-checkout/activate.sh && cd $GITHUB_WORKSPACE/pypto-lib && python models/deepseek/v4/decode_attention_swa.py -p a2a3 -d \$TASK_DEVICE"
 
       - name: Run pypto-lib DeepSeek-V4 decode_attention_hca example
@@ -537,7 +537,7 @@ jobs:
           PYTHONPATH: ${{ github.workspace }}/pypto-lib
         run: |
           source activate.sh
-          task-submit --device "$DEVICE_ID" --timeout 1800 --max-time 1800 \
+          task-submit --device "$DEVICE_ID" --timeout 3600 --max-time 1800 \
             --run "source $GITHUB_WORKSPACE/lib-checkout/activate.sh && cd $GITHUB_WORKSPACE/pypto-lib && python models/deepseek/v4/decode_attention_hca.py -p a2a3 -d \$TASK_DEVICE"
 
       - name: Run pypto-lib DeepSeek-V4 prefill_attention_csa example
@@ -545,7 +545,7 @@ jobs:
           PYTHONPATH: ${{ github.workspace }}/pypto-lib
         run: |
           source activate.sh
-          task-submit --device "$DEVICE_ID" --timeout 1800 --max-time 1800 \
+          task-submit --device "$DEVICE_ID" --timeout 3600 --max-time 1800 \
             --run "source $GITHUB_WORKSPACE/lib-checkout/activate.sh && cd $GITHUB_WORKSPACE/pypto-lib && python models/deepseek/v4/prefill_attention_csa.py -p a2a3 -d \$TASK_DEVICE"
 
       - name: Run pypto-lib DeepSeek-V4 prefill_attention_hca example
@@ -553,7 +553,7 @@ jobs:
           PYTHONPATH: ${{ github.workspace }}/pypto-lib
         run: |
           source activate.sh
-          task-submit --device "$DEVICE_ID" --timeout 1800 --max-time 1800 \
+          task-submit --device "$DEVICE_ID" --timeout 3600 --max-time 1800 \
             --run "source $GITHUB_WORKSPACE/lib-checkout/activate.sh && cd $GITHUB_WORKSPACE/pypto-lib && python models/deepseek/v4/prefill_attention_hca.py -p a2a3 -d \$TASK_DEVICE"
 
       - name: Run pypto-lib DeepSeek-V4 prefill_attention_swa example
@@ -561,7 +561,7 @@ jobs:
           PYTHONPATH: ${{ github.workspace }}/pypto-lib
         run: |
           source activate.sh
-          task-submit --device "$DEVICE_ID" --timeout 1800 --max-time 1800 \
+          task-submit --device "$DEVICE_ID" --timeout 3600 --max-time 1800 \
             --run "source $GITHUB_WORKSPACE/lib-checkout/activate.sh && cd $GITHUB_WORKSPACE/pypto-lib && python models/deepseek/v4/prefill_attention_swa.py -p a2a3 -d \$TASK_DEVICE"
 
       - name: Kill orphaned task-submit tasks

--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -90,7 +90,7 @@ jobs:
         # puts the workspace path into the task command so the cleanup step below
         # can grep -F "$GITHUB_WORKSPACE" to find THIS job's task.
         run: |
-          task-submit --timeout 1800 --max-time 1800 --device 6 \
+          task-submit --timeout 3600 --max-time 1800 --device 6 \
             --run "cd $GITHUB_WORKSPACE && pytest tests/st/runtime/ops/test_assemble.py tests/st/runtime/ops/test_mscatter.py tests/st/runtime/ops/test_random.py tests/st/runtime/framework_and_models/test_qwen3_decode_scope3_mixed.py tests/st/runtime/control_flow/test_dyn_orch_shape.py::TestDynOrchShapeOperations::test_dyn_orch_paged_attention -v --forked --platform=a5 --device=6 --pto-isa-commit=${{ needs.toolchain.outputs.pto_isa_commit }} \
               -k 'not (test_tile_row_expand or test_fillpad_zero or test_fillpad_max or test_fillpad_min or TestMscatter)'"
 
@@ -196,7 +196,7 @@ jobs:
           : > "$GITHUB_WORKSPACE/qwen3_perf.log"   # truncate any stale log
           for i in $(seq 1 5); do
             echo "=== qwen3 decode perf sample $i/5 ==="
-            task-submit --device "$DEVICE_ID" --timeout 1800 --max-time 1800 \
+            task-submit --device "$DEVICE_ID" --timeout 3600 --max-time 1800 \
               --run "source $GITHUB_WORKSPACE/perf-checkout/activate.sh && cd $GITHUB_WORKSPACE/pypto-lib && python models/qwen3/14b/decode_layer.py -p a2a3 -d \$TASK_DEVICE --enable-l2-swimlane --max-seq --seed 1234" \
               2>&1 | tee -a "$GITHUB_WORKSPACE/qwen3_perf.log" \
               || echo "WARN: perf sample $i exited non-zero"


### PR DESCRIPTION
## Summary
- Bump every `task-submit --timeout` from `1800s` to `3600s` across `.github/workflows/ci.yml` (12 invocations) and `.github/workflows/daily_ci.yml` (2 invocations).
- `--timeout` governs the device-acquisition **queue wait** — raising it gives device jobs more tolerance for runner contention before task-submit gives up waiting for a card.
- `--max-time` (the run wall-clock cap: 1800 / 900 / 600) is deliberately **left unchanged**, so this only grants more queue-wait headroom, not longer executions.

## Testing
- [ ] CI config change — validated by the CI runs on this PR.

## Notes
- The `--timeout 60` in the kill-orphaned-tasks path and `--task-queue-timeout=1800` in the batched system-tests step are different flags and are intentionally untouched.