### PR TITLE
WIP: changes to run DeepSeek V4 on A5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -193,6 +193,7 @@ set(PYPTO_SOURCES
     src/ir/transforms/flatten_tile_nd_to_2d/rewrite_utils.cpp
     src/ir/transforms/flatten_tile_nd_to_2d/transpose.cpp
     src/ir/transforms/flatten_tile_nd_to_2d/verification.cpp
+    src/ir/transforms/legalize_tile_cast_pass.cpp
     src/ir/transforms/pass_context.cpp
     src/ir/transforms/passes.cpp
     src/ir/transforms/resolve_backend_op_layouts_pass.cpp

--- a/docs/en/dev/passes/14a-legalize_tile_cast.md
+++ b/docs/en/dev/passes/14a-legalize_tile_cast.md
@@ -1,0 +1,31 @@
+# LegalizeTileCast Pass
+
+Expands `tile.cast` `(src, dst)` pairs that the active `pto.tcvt` profile cannot emit as a single instruction into the shortest chain of native casts.
+
+## Overview
+
+For each `var = tile.cast(...)`:
+
+1. Look up the backend-specific adjacency table (from pto-isa `tcvt` Supported Conversions for A5 / A2A3).
+2. Already native: leave unchanged (including FIXPIPE-foldable `FP32→BF16/FP16` with `mode=rint`).
+3. Non-native: BFS for a shortest path; among equal-length paths prefer "same byte-width → float, then adjust width".
+
+Typical A5 results: `INT32→FP16` → `INT32→FP32→FP16`; `FP16→BF16` → `FP16→FP32→BF16`.
+
+Unreachable pairs hard-fail with src/dst/arch in the diagnostic.
+
+**Requires / Produces / Invalidates**: none (empty `PassProperties`).
+
+## When it runs
+
+Default pipeline:
+
+```text
+lower_composite_ops → flatten_tile_nd_to_2d → legalize_tile_cast → auto_tile_matmul_l0
+```
+
+## API
+
+| C++ | Python |
+| --- | ------ |
+| `pass::LegalizeTileCast()` | `passes.legalize_tile_cast()` |

--- a/docs/zh-cn/dev/passes/14a-legalize_tile_cast.md
+++ b/docs/zh-cn/dev/passes/14a-legalize_tile_cast.md
@@ -1,0 +1,38 @@
+# LegalizeTileCast Pass
+
+把目标 profile（A5 / A2A3）上 `pto.tcvt` **不支持** 的 `tile.cast` `(src, dst)` 对，展开为最短的原生 cast 链，避免静默发出非法 `tcvt`。
+
+## 概述
+
+`LegalizeTileCast` 是函数级 Pass。对每条 `var = tile.cast(...)`：
+
+1. 查当前 backend 的原生邻接表（来自 pto-isa `tcvt` Supported Conversions）。
+2. 已原生：原样保留（含可被 `AutoTileMatmulL0` FIXPIPE-fold 的 `FP32→BF16/FP16` + `rint`）。
+3. 非原生：在邻接图上 BFS 求最短路径；等长路径优先「同字节转浮点 → 再调宽度」。
+
+典型结果（A5）：
+
+| 用户 Cast | 分解 |
+|-----------|------|
+| INT32→FP16 | INT32→FP32 → FP32→FP16 |
+| FP16→BF16 | FP16→FP32 → FP32→BF16 |
+
+搜不到路径则硬失败（带 src/dst/arch）。
+
+**Requires / Produces / Invalidates**：无（空 `PassProperties`）。
+
+## 运行时机
+
+Default 流水线：
+
+```text
+lower_composite_ops → flatten_tile_nd_to_2d → legalize_tile_cast → auto_tile_matmul_l0
+```
+
+放在 Flatten 之后以覆盖其新插入的 cast；放在 MatmulL0 之前以免拆开本可 fold 的原生降精度 cast。
+
+## API
+
+| C++ | Python |
+| --- | ------ |
+| `pass::LegalizeTileCast()` | `passes.legalize_tile_cast()` |

--- a/include/pypto/ir/transforms/pass_properties.h
+++ b/include/pypto/ir/transforms/pass_properties.h
@@ -148,6 +148,15 @@ inline const PassProperties kFlattenTileNdTo2DProperties{
     .required = {IRProperty::SSAForm, IRProperty::IncoreTileOps, IRProperty::NormalizedStmtStructure},
     .produced = {IRProperty::SSAForm, IRProperty::TileOps2D, IRProperty::NormalizedStmtStructure}};
 
+// -- Legalize unsupported tile.cast pairs into native cast chains -------------
+//
+// Property-preserving: expands one tile.cast AssignStmt into a SeqStmts of
+// native tile.cast hops. Empty props (same rationale as LowerCompositeOps):
+// the rewrite stays inside the existing tile.cast vocabulary and does not
+// establish or destroy IRProperties. Pipeline position is FlattenTileNdTo2D
+// → LegalizeTileCast → AutoTileMatmulL0.
+inline const PassProperties kLegalizeTileCastProperties{};
+
 // -- Auto L0 matmul tiling pass -----------------------------------------------
 //
 // Property-preserving rewrite: replaces ``tile.matmul[_acc]`` over Mat-resident

--- a/include/pypto/ir/transforms/passes.h
+++ b/include/pypto/ir/transforms/passes.h
@@ -429,6 +429,26 @@ Pass OptimizeOrchTensors();
 Pass FlattenTileNdTo2D();
 
 /**
+ * @brief Expand hardware-unsupported ``tile.cast`` pairs into native cast chains.
+ *
+ * ``pto.tcvt`` only supports a profile-dependent subset of (src, dst) dtype
+ * pairs. This pass rewrites each non-native ``tile.cast`` into the shortest
+ * sequence of native casts (BFS over the ISA adjacency table for A5 / A2A3).
+ * Among equal-length paths it prefers "same byte-width → float, then adjust
+ * width" edges (e.g. A5 ``INT32→FP16`` becomes ``INT32→FP32→FP16``).
+ *
+ * Already-native casts (including FIXPIPE-foldable ``FP32→BF16/FP16`` with
+ * ``mode=rint``) are left untouched. Runs after ``FlattenTileNdTo2D`` (so
+ * newly inserted casts are also legalized) and before ``AutoTileMatmulL0``.
+ *
+ * Requirements:
+ * - Input IR must have 2D tile ops (run FlattenTileNdTo2D first)
+ * - A BackendHandler must be configured (PassContext) so the arch table
+ *   (``a5`` / ``a2a3``) can be selected via ``GetPtoTargetArch()``
+ */
+Pass LegalizeTileCast();
+
+/**
  * @brief Auto-tile Mat-resident matmul / matmul_acc into a C-stationary K-loop
  *
  * For each ``tile.matmul`` or ``tile.matmul_acc`` whose Mat operands have

--- a/python/bindings/modules/passes.cpp
+++ b/python/bindings/modules/passes.cpp
@@ -460,6 +460,12 @@ void BindPass(nb::module_& m) {
              "Create a pass that flattens ND tile ops to 2D in InCore functions\n\n"
              "Merges all dimensions except the last into a single dimension.\n"
              "E.g., tile [A, B, C] becomes [A*B, C]. Only converts 3D+ tiles.");
+  passes.def("legalize_tile_cast", &pass::LegalizeTileCast,
+             "Expand hardware-unsupported tile.cast pairs into native cast chains\n\n"
+             "Rewrites each non-native tile.cast into the shortest sequence of\n"
+             "pto.tcvt-supported casts for the active backend (A5 / A2A3).\n"
+             "Prefer same byte-width→float then adjust width (e.g. A5 INT32→FP16\n"
+             "becomes INT32→FP32→FP16). Already-native casts are left untouched.");
   passes.def("auto_tile_matmul_l0", &pass::AutoTileMatmulL0,
              "Create a pass that auto-tiles Mat-resident tile.matmul / tile.matmul_acc into a\n"
              "C-stationary K-loop\n\n"

--- a/python/pypto/ir/pass_manager.py
+++ b/python/pypto/ir/pass_manager.py
@@ -174,6 +174,10 @@ class PassManager:
         tile_pto_passes: tuple[PassFactory, ...] = (
             passes.lower_composite_ops,
             passes.flatten_tile_nd_to_2d,
+            # Expand non-native tile.cast (src,dst) pairs into shortest native
+            # cast chains (e.g. A5 INT32→FP16 → INT32→FP32→FP16) before
+            # AutoTileMatmulL0 may FIXPIPE-fold already-native f32→bf16/f16.
+            passes.legalize_tile_cast,
             passes.auto_tile_matmul_l0,
             passes.canonicalize_tile_slice,
             passes.infer_tile_memory_space,

--- a/src/ir/transforms/auto_tile_matmul_l0_pass.cpp
+++ b/src/ir/transforms/auto_tile_matmul_l0_pass.cpp
@@ -709,8 +709,28 @@ std::optional<MatmulTiling> AnalyzeMatmul(const AssignStmtPtr& assign, std::vect
     return std::nullopt;
   }
 
-  // Already L0-sized — nothing to do.
-  if (res.m == M && res.n == N && res.k == K) return std::nullopt;
+  // Already L0-sized.  Mat-fed matmuls need nothing.  A Vec-resident LHS still
+  // needs an explicit Vec→Mat ``tile.move`` so ExpandMixedKernel sees a
+  // ``CollectCVBoundaryMoves`` handshake (same as the K-tiled PV pattern).
+  // Without it InferTileMemorySpace inserts Vec→Left directly; on A5 the V→C
+  // ND→NZ adapt can then share the cast buffer and silently mis-transfer
+  // (prefill_indexer Hadamard / fused cast→matmul Left).
+  if (res.m == M && res.n == N && res.k == K) {
+    if (lhs_tile->GetMemorySpace() != MemorySpace::Vec) return std::nullopt;
+    MatmulTiling t;
+    t.assign = assign;
+    t.lhs = lhs;
+    t.rhs = rhs;
+    t.stage_lhs_to_mat = true;
+    t.acc_init = acc_var;
+    t.M = M;
+    t.N = N;
+    t.K = K;
+    t.m = M;
+    t.n = N;
+    t.k = K;
+    return t;
+  }
 
   if (!res.perf_hint.empty()) {
     hints.emplace_back(DiagnosticSeverity::PerfHint, kPassName, 0, "PH-AT-008",
@@ -747,6 +767,25 @@ std::optional<MatmulTiling> AnalyzeMatmul(const AssignStmtPtr& assign, std::vect
       << "); dbC=2 requires the full-K emitter";
   t.double_buffer_c = res.double_buffer_c;
   return t;
+}
+
+/// Stage-only rewrite for an already-L0-sized matmul whose LHS is Vec: insert
+/// ``tile.move``→Mat and rewrite the matmul to consume the Mat tile.  No K/M/N
+/// tiling — BuildKLoopRewrite requires ``k < K``.
+std::pair<std::vector<StmtPtr>, VarPtr> BuildStageOnlyVecLhs(const MatmulTiling& t) {
+  INTERNAL_CHECK_SPAN(t.stage_lhs_to_mat && t.m == t.M && t.n == t.N && t.k == t.K, t.assign->span_)
+      << "Internal error: BuildStageOnlyVecLhs expects full-size Vec→Mat staging";
+  const Span& sp = t.assign->span_;
+  const std::string& base = t.assign->var_->name_hint_;
+  std::vector<StmtPtr> out;
+  auto lhs_mat = BuildMoveToMat(t.lhs, base + "_l0_lmat", sp);
+  out.push_back(lhs_mat);
+  auto& reg = OpRegistry::GetInstance();
+  ExprPtr call = t.is_acc() ? reg.Create("tile.matmul_acc", {t.acc_init, lhs_mat->var_, t.rhs}, sp)
+                            : reg.Create("tile.matmul", {lhs_mat->var_, t.rhs}, sp);
+  auto cvar = std::make_shared<Var>(base, call->GetType(), sp);
+  out.push_back(std::make_shared<AssignStmt>(cvar, call, sp));
+  return {std::move(out), cvar};
 }
 
 /// Per-output-sub-tile origin offset ``base + delta``.  Folds the common
@@ -1487,9 +1526,18 @@ class AutoTileMutator : public IRMutator {
       if (auto assign = std::dynamic_pointer_cast<const AssignStmt>(current)) {
         if (auto tiling = AnalyzeMatmul(assign, hints)) {
           if (!tiling->needs_mn_tiling()) {
-            // Whole output fits L0c — tile K only.  k < K here (k == K with
-            // m == M, n == N would be already-L0-sized and skipped above); the
-            // chooser may return a non-divisor k that BuildKLoopRewrite peels.
+            // Whole output fits L0c.  k == K is the already-L0 Vec-LHS stage-only
+            // path (Mat LHS returns nullopt from AnalyzeMatmul); k < K tiles K
+            // (chooser may return a non-divisor k that BuildKLoopRewrite peels).
+            if (tiling->k == tiling->K) {
+              INTERNAL_CHECK_SPAN(tiling->stage_lhs_to_mat, tiling->assign->span_)
+                  << "Internal error: full-K L0-sized rewrite expects Vec→Mat staging";
+              auto [stmts, ret] = BuildStageOnlyVecLhs(*tiling);
+              remap[assign->var_.get()] = ret;
+              for (auto& s : stmts) out.push_back(std::move(s));
+              changed = true;
+              continue;
+            }
             INTERNAL_CHECK_SPAN(tiling->k < tiling->K, tiling->assign->span_)
                 << "Internal error: K-only tiling expects k < K (K=" << tiling->K << ", k=" << tiling->k
                 << ")";

--- a/src/ir/transforms/legalize_tile_cast_pass.cpp
+++ b/src/ir/transforms/legalize_tile_cast_pass.cpp
@@ -1,0 +1,362 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * @file legalize_tile_cast_pass.cpp
+ * @brief Expand hardware-unsupported tile.cast pairs into native cast chains.
+ *
+ * Converts (src, dst) pairs that the active pto.tcvt profile cannot emit as a
+ * single instruction into a shortest sequence of native casts. Path search is
+ * BFS over the ISA-supported adjacency table (A5 / A2A3). Typical outcome for
+ * A5 INT32→FP16 is INT32→FP32→FP16 — same byte-width to float, then resize —
+ * which does not introduce extra precision loss beyond the final narrow.
+ */
+
+#include <algorithm>
+#include <any>
+#include <array>
+#include <cstddef>
+#include <optional>
+#include <queue>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "pypto/backend/common/backend_handler.h"
+#include "pypto/core/dtype.h"
+#include "pypto/core/logging.h"
+#include "pypto/ir/expr.h"
+#include "pypto/ir/function.h"
+#include "pypto/ir/kind_traits.h"
+#include "pypto/ir/op_registry.h"
+#include "pypto/ir/span.h"
+#include "pypto/ir/stmt.h"
+#include "pypto/ir/transforms/base/mutator.h"
+#include "pypto/ir/transforms/pass_context.h"
+#include "pypto/ir/transforms/pass_properties.h"
+#include "pypto/ir/transforms/passes.h"
+#include "pypto/ir/transforms/utils/auto_name_utils.h"
+#include "pypto/ir/transforms/utils/mutable_copy.h"
+#include "pypto/ir/type.h"
+
+namespace pypto {
+namespace ir {
+namespace {
+
+// Round modes for tile.cast (None=0, RINT=1, ROUND=2, ...).
+constexpr int kCastModeRound = 2;
+
+enum class CastArch { A2A3, A5 };
+
+CastArch ResolveCastArch() {
+  const auto* ctx = PassContext::Current();
+  INTERNAL_CHECK(ctx) << "LegalizeTileCast requires an active PassContext";
+  const auto* handler = ctx->GetBackendHandler();
+  INTERNAL_CHECK(handler) << "LegalizeTileCast requires a configured BackendHandler";
+  const std::string arch = handler->GetPtoTargetArch();
+  if (arch == "a5") {
+    return CastArch::A5;
+  }
+  // Default "a2a3" (and any unknown arch treated as a2a3 until a new profile
+  // ships its own adjacency table).
+  return CastArch::A2A3;
+}
+
+using AdjList = std::unordered_map<uint8_t, std::vector<DataType>>;
+
+void AddEdge(AdjList& adj, DataType from, DataType to) {
+  if (from == to) return;
+  adj[from.Code()].push_back(to);
+}
+
+// ISA Supported Conversions from pto-isa tcvt docs (A2A3 / A5 columns).
+AdjList BuildAdj(CastArch arch) {
+  AdjList adj;
+
+  // FP32
+  AddEdge(adj, DataType::FP32, DataType::FP16);
+  AddEdge(adj, DataType::FP32, DataType::BF16);
+  AddEdge(adj, DataType::FP32, DataType::INT16);
+  AddEdge(adj, DataType::FP32, DataType::INT32);
+  AddEdge(adj, DataType::FP32, DataType::INT64);
+  if (arch == CastArch::A5) {
+    AddEdge(adj, DataType::FP32, DataType::FP8E4M3FN);
+    AddEdge(adj, DataType::FP32, DataType::FP8E5M2);
+    AddEdge(adj, DataType::FP32, DataType::HF8);
+  }
+
+  // FP16
+  AddEdge(adj, DataType::FP16, DataType::FP32);
+  AddEdge(adj, DataType::FP16, DataType::INT32);
+  AddEdge(adj, DataType::FP16, DataType::INT16);
+  AddEdge(adj, DataType::FP16, DataType::INT8);
+  AddEdge(adj, DataType::FP16, DataType::UINT8);
+  if (arch == CastArch::A2A3) {
+    AddEdge(adj, DataType::FP16, DataType::INT4);
+  } else {
+    AddEdge(adj, DataType::FP16, DataType::HF8);
+  }
+
+  // BF16
+  AddEdge(adj, DataType::BF16, DataType::FP32);
+  AddEdge(adj, DataType::BF16, DataType::INT32);
+  if (arch == CastArch::A5) {
+    AddEdge(adj, DataType::BF16, DataType::FP16);
+    AddEdge(adj, DataType::BF16, DataType::FP4);
+  }
+
+  // I16
+  AddEdge(adj, DataType::INT16, DataType::FP16);
+  AddEdge(adj, DataType::INT16, DataType::FP32);
+  if (arch == CastArch::A5) {
+    AddEdge(adj, DataType::INT16, DataType::UINT8);
+    AddEdge(adj, DataType::INT16, DataType::UINT32);
+    AddEdge(adj, DataType::INT16, DataType::INT32);
+  }
+
+  // I32
+  AddEdge(adj, DataType::INT32, DataType::FP32);
+  AddEdge(adj, DataType::INT32, DataType::INT16);
+  AddEdge(adj, DataType::INT32, DataType::INT64);
+  if (arch == CastArch::A2A3) {
+    AddEdge(adj, DataType::INT32, DataType::FP16);  // deq path
+  } else {
+    AddEdge(adj, DataType::INT32, DataType::UINT16);
+    AddEdge(adj, DataType::INT32, DataType::UINT8);
+  }
+
+  // I64
+  AddEdge(adj, DataType::INT64, DataType::FP32);
+  AddEdge(adj, DataType::INT64, DataType::INT32);
+
+  // U8
+  AddEdge(adj, DataType::UINT8, DataType::FP16);
+  if (arch == CastArch::A5) {
+    AddEdge(adj, DataType::UINT8, DataType::UINT16);
+  }
+
+  // I8
+  AddEdge(adj, DataType::INT8, DataType::FP16);
+  if (arch == CastArch::A5) {
+    AddEdge(adj, DataType::INT8, DataType::INT16);
+    AddEdge(adj, DataType::INT8, DataType::INT32);
+  }
+
+  // S4 (A2A3 only)
+  if (arch == CastArch::A2A3) {
+    AddEdge(adj, DataType::INT4, DataType::FP16);
+  }
+
+  // A5-only sources
+  if (arch == CastArch::A5) {
+    AddEdge(adj, DataType::UINT32, DataType::UINT8);
+    AddEdge(adj, DataType::UINT32, DataType::UINT16);
+    AddEdge(adj, DataType::UINT32, DataType::INT16);
+    AddEdge(adj, DataType::FP8E4M3FN, DataType::FP32);
+    AddEdge(adj, DataType::FP8E5M2, DataType::FP32);
+    AddEdge(adj, DataType::HF8, DataType::FP32);
+    AddEdge(adj, DataType::FP4, DataType::BF16);
+  }
+
+  return adj;
+}
+
+bool IsNativeCast(const AdjList& adj, DataType from, DataType to) {
+  if (from == to) return false;
+  auto it = adj.find(from.Code());
+  if (it == adj.end()) return false;
+  for (const DataType& d : it->second) {
+    if (d == to) return true;
+  }
+  return false;
+}
+
+// Preferred same-width float bridge used when preferring "convert kind without
+// changing width, then change width" paths among equal-length BFS results.
+std::optional<DataType> SameWidthFloat(DataType dt) {
+  if (dt.IsFloat()) return std::nullopt;
+  switch (dt.GetBit()) {
+    case 32:
+      return DataType::FP32;
+    case 16:
+      return DataType::FP16;
+    default:
+      return std::nullopt;
+  }
+}
+
+// Cost for ranking equal-length BFS paths: lower is better. Favours edges that
+// convert int→same-width float first, then float width changes.
+int EdgePreferenceCost(DataType from, DataType to) {
+  if (!from.IsFloat() && to.IsFloat() && from.GetBit() == to.GetBit()) {
+    return 0;  // same-byte → float
+  }
+  if (from.IsFloat() && to.IsFloat()) {
+    return 1;  // adjust byte width in float domain
+  }
+  return 2;
+}
+
+// BFS shortest path; returns the sequence of intermediate/final target types
+// (excluding `from`). Empty vector means already native? No — caller checks
+// native first. Empty here means unreachable.
+std::vector<DataType> FindCastChain(const AdjList& adj, DataType from, DataType to) {
+  if (from == to) return {};
+  if (IsNativeCast(adj, from, to)) {
+    return {to};
+  }
+
+  // State: dtype code → (parent code, edge-to dtype, path_len, path_pref_cost)
+  struct NodeInfo {
+    uint8_t parent = 0;
+    DataType via = DataType::BOOL;  // dtype of this node
+    int dist = -1;
+    int pref = 0;
+  };
+  std::array<NodeInfo, 256> info{};
+  std::queue<uint8_t> q;
+
+  info[from.Code()] = NodeInfo{from.Code(), from, 0, 0};
+  q.push(from.Code());
+
+  while (!q.empty()) {
+    uint8_t cur = q.front();
+    q.pop();
+    const NodeInfo& cur_info = info[cur];
+    auto it = adj.find(cur);
+    if (it == adj.end()) continue;
+
+    // Prefer same-width float neighbor first when expanding (stable among
+    // equal BFS depths via preference cost).
+    std::vector<DataType> neigh = it->second;
+    if (auto sw = SameWidthFloat(cur_info.via)) {
+      auto sw_it = std::find(neigh.begin(), neigh.end(), *sw);
+      if (sw_it != neigh.end()) {
+        std::iter_swap(neigh.begin(), sw_it);
+      }
+    }
+
+    for (const DataType& nxt : neigh) {
+      const int edge_cost = EdgePreferenceCost(cur_info.via, nxt);
+      const int new_dist = cur_info.dist + 1;
+      const int new_pref = cur_info.pref + edge_cost;
+      NodeInfo& nxt_info = info[nxt.Code()];
+      if (nxt_info.dist < 0) {
+        nxt_info = NodeInfo{cur, nxt, new_dist, new_pref};
+        q.push(nxt.Code());
+      } else if (nxt_info.dist == new_dist && new_pref < nxt_info.pref) {
+        nxt_info.parent = cur;
+        nxt_info.via = nxt;
+        nxt_info.pref = new_pref;
+      }
+    }
+  }
+
+  const NodeInfo& goal = info[to.Code()];
+  if (goal.dist < 0) {
+    return {};
+  }
+
+  std::vector<DataType> rev;
+  for (uint8_t c = to.Code(); c != from.Code(); c = info[c].parent) {
+    rev.push_back(info[c].via);
+  }
+  std::reverse(rev.begin(), rev.end());
+  return rev;
+}
+
+ExprPtr MakeCast(const ExprPtr& x, DataType to, int mode, const Span& span) {
+  std::vector<std::pair<std::string, std::any>> kw = {{"target_type", to}, {"mode", mode}};
+  return OpRegistry::GetInstance().Create("tile.cast", {x}, kw, span);
+}
+
+class LegalizeTileCastMutator : public IRMutator {
+ public:
+  explicit LegalizeTileCastMutator(CastArch arch) : arch_(arch), adj_(BuildAdj(arch)) {}
+
+  StmtPtr VisitStmt_(const AssignStmtPtr& op) override {
+    auto call = As<Call>(op->value_);
+    if (!call || !IsOp(call, "tile.cast")) {
+      return IRMutator::VisitStmt_(op);
+    }
+    if (call->args_.empty()) {
+      return IRMutator::VisitStmt_(op);
+    }
+
+    auto src_tile = As<TileType>(call->args_[0]->GetType());
+    INTERNAL_CHECK_SPAN(src_tile, op->span_) << "tile.cast input must be TileType";
+    DataType src = src_tile->dtype_;
+    DataType dst = call->GetKwarg<DataType>("target_type");
+    const int mode = call->GetKwarg<int>("mode", kCastModeRound);
+
+    if (IsNativeCast(adj_, src, dst)) {
+      return IRMutator::VisitStmt_(op);
+    }
+
+    std::vector<DataType> chain = FindCastChain(adj_, src, dst);
+    CHECK_SPAN(!chain.empty(), op->span_)
+        << "LegalizeTileCast: no native cast path from " << src.ToString() << " to " << dst.ToString()
+        << " for arch " << (arch_ == CastArch::A5 ? "a5" : "a2a3")
+        << "; pto.tcvt does not support this conversion";
+
+    // Intermediate hops use the original mode (matches model-side INT32→FP32→FP16
+    // chains where the narrow step carries mode="round"). Final hop also keeps it.
+    ExprPtr cur = VisitExpr(call->args_[0]);
+    std::vector<StmtPtr> stmts;
+    stmts.reserve(chain.size());
+
+    for (size_t i = 0; i + 1 < chain.size(); ++i) {
+      ExprPtr cast_expr = MakeCast(cur, chain[i], mode, op->span_);
+      const std::string name =
+          auto_name::BuildName(auto_name::GetBaseName(op->var_->name_hint_), "cast_" + chain[i].ToString(),
+                               "tmp", static_cast<int>(temp_counter_++));
+      auto mid_var = std::make_shared<Var>(name, cast_expr->GetType(), op->span_);
+      stmts.push_back(std::make_shared<AssignStmt>(mid_var, cast_expr, op->span_));
+      cur = mid_var;
+    }
+
+    auto final_assign = MutableCopy(op);
+    final_assign->value_ = MakeCast(cur, chain.back(), mode, op->span_);
+    stmts.push_back(std::move(final_assign));
+
+    if (stmts.size() == 1) return stmts.front();
+    return std::make_shared<SeqStmts>(std::move(stmts), op->span_);
+  }
+
+ private:
+  CastArch arch_;
+  AdjList adj_;
+  std::size_t temp_counter_ = 0;
+};
+
+FunctionPtr TransformLegalizeTileCast(const FunctionPtr& func) {
+  if (!func) return func;
+  // Tile casts only live in InCore (and AIC/AIV after expansion). Skip host orch.
+  if (func->level_.has_value() && *func->level_ == Level::HOST) {
+    return func;
+  }
+  LegalizeTileCastMutator mutator(ResolveCastArch());
+  return mutator.VisitFunction(func);
+}
+
+}  // namespace
+
+namespace pass {
+
+Pass LegalizeTileCast() {
+  return CreateFunctionPass(TransformLegalizeTileCast, "LegalizeTileCast", kLegalizeTileCastProperties);
+}
+
+}  // namespace pass
+
+}  // namespace ir
+}  // namespace pypto

--- a/src/ir/transforms/op_conversion_registry.cpp
+++ b/src/ir/transforms/op_conversion_registry.cpp
@@ -25,6 +25,7 @@
 
 #include "pypto/backend/common/backend.h"
 #include "pypto/backend/common/backend_config.h"
+#include "pypto/backend/common/backend_handler.h"
 #include "pypto/core/any_cast.h"
 #include "pypto/core/dtype.h"
 #include "pypto/core/logging.h"
@@ -49,6 +50,13 @@ using tile_conversion_utils::MakeZeroOffsets;
 namespace {
 
 bool IsConstOne(const ExprPtr& expr) { return IsConstValue(expr, 1); }
+
+// A5 index-form gather needs full-tile flat indices; A2A3 keeps the legacy
+// per-row path (see RegisterGatherOps Case 1/2).
+bool IsA5TargetArch() {
+  if (!backend::BackendConfig::IsConfigured()) return false;
+  return backend::BackendConfig::GetBackend()->GetHandler()->GetPtoTargetArch() == "a5";
+}
 
 // Detect row-broadcast pattern: [M, N] op [M, 1] or [M, 1] op [M, N]
 // Returns {wider_arg_idx, narrower_arg_idx} if broadcast detected, empty otherwise
@@ -1120,9 +1128,14 @@ void OpConversionRegistry::RegisterSortOps() {
 // ============================================================================
 // Generalized gather lowering.
 //
-// Hardware constraint: pto.tgather only works correctly when the source tile
-// has exactly 1 row (rows=1).  Therefore all lowering paths use ForStmt loops
-// to decompose the gather into single-row pto.tgather calls.
+// pto.tgather index form expects flat element offsets into src
+// (dst[i,j] = src_flat[indices[i,j]]). Torch-style last-dim gather exposes
+// column indices, so they must be expanded to flat offsets for multi-row src.
+//
+// A5 (GetPtoTargetArch()=="a5"): Case 1/2 emit one full-tile gather after
+//   flat_idx[i,j] = i * src_cols + index[i,j]  (mirrors tensor.scatter).
+// A2A3 / other: keep the legacy per-row (rows=1) loop where column indices
+//   equal flat indices within each 1-row src slice.
 //
 // FlattenTileNdTo2D constraint: tile.load, tile.store, tile.reshape may
 // produce/consume >2D tiles; all other tile ops must be 2D.
@@ -1141,14 +1154,12 @@ void OpConversionRegistry::RegisterSortOps() {
 // Four cases (by rank and norm_dim):
 //
 // Case 1  rank==2, dim==1 (last):
-//   Loop over I0 rows: load [1,S1] and [1,K], single-row gather.
-//   Accumulator [I0, K].  Phase 3 rewrites the loop to per-row tile.store.
+//   A5: load [I0,S1]/[I0,K], expand flat indices, one tile.gather → [I0,K].
+//   A2A3: loop over I0 rows: load [1,S1] and [1,K], single-row gather.
 //
 // Case 2  rank==3, dim==2 (last):
-//   Nested loop: outer I0 × inner I1.
-//   Load [1,1,S2]→reshape[1,S2]; Load [1,1,K]→reshape[1,K]; gather [1,K].
-//   Inner acc [I1,K]; reshape→[1,I1*K]; outer acc [I0,I1*K].
-//   Final reshape [I0,I1*K]→[I0*I1,K]; tile.store at [0,0,0].
+//   A5: reshape to [I0*I1,S2]/[I0*I1,K], then same flat full-tile gather.
+//   A2A3: nested loop: outer I0 × inner I1, single-row gathers + reshape.
 //
 // Case 3  rank==3, dim==0 (first):
 //   Flat-index gather: for each output row r = i0*I1+i1:
@@ -1299,13 +1310,96 @@ void OpConversionRegistry::RegisterGatherOps() {
           return c->value_;
         };
 
+        const DataType idx_dtype = index_info.second;
+
+        // A5 helper: flat_idx[i,j] = i * src_cols + index[i,j].
+        // Prefer a linear arange reshaped to [rows, idx_cols] so every allocated
+        // tile has a 32-byte-aligned row (avoids tile.ci([1, rows]) when rows is
+        // small). Falls back to row_expand_add for odd idx_cols (UT-only shapes).
+        auto emit_a5_flat_idx = [&](std::vector<StmtPtr>& stmts, const VarPtr& idx_2d, int64_t rows,
+                                    int64_t src_cols, int64_t idx_cols,
+                                    const std::string& prefix) -> ExprPtr {
+          const DataType compute_dtype(DataType::INT32);
+          auto make_cd = [&](int64_t v) -> ExprPtr {
+            return std::make_shared<ConstInt>(v, compute_dtype, span);
+          };
+          ExprPtr idx_i32 = idx_2d;
+          if (idx_dtype != compute_dtype) {
+            idx_i32 = emit_to(stmts, "tile.cast", {idx_2d}, {{"target_type", compute_dtype}},
+                              prefix + "_idx_i32");
+          }
+          if (rows == 1) {
+            return idx_dtype == compute_dtype
+                       ? idx_i32
+                       : emit_to(stmts, "tile.cast", {idx_i32}, {{"target_type", idx_dtype}},
+                                 prefix + "_flat_cast");
+          }
+
+          std::vector<std::pair<std::string, std::any>> ci_kw = {{"dtype", compute_dtype},
+                                                                  {"descending", false}};
+          ExprPtr flat;
+          // INT32 row is 32B-aligned when cols % 8 == 0 (K=8/32/64 on HW ST).
+          if ((idx_cols % 8) == 0) {
+            const int64_t nk = rows * idx_cols;
+            auto lin =
+                emit_to(stmts, "tile.ci", {make_cd(0), MakeShapeTuple({one, make_idx(nk)}, span)},
+                        ci_kw, prefix + "_lin");
+            auto lin_2d =
+                reshape_to(stmts, lin, {make_idx(rows), make_idx(idx_cols)}, prefix + "_lin2d");
+            auto row_ids =
+                emit_to(stmts, "tile.divs", {lin_2d, make_cd(idx_cols)}, {}, prefix + "_row_ids");
+            auto row_base =
+                emit_to(stmts, "tile.muls", {row_ids, make_cd(src_cols)}, {}, prefix + "_row_base");
+            flat = emit_to(stmts, "tile.add", {idx_i32, row_base}, {}, prefix + "_flat_idx");
+          } else {
+            auto row_flat =
+                emit_to(stmts, "tile.ci", {make_cd(0), MakeShapeTuple({one, make_idx(rows)}, span)},
+                        ci_kw, prefix + "_ci_rows");
+            auto row_ar =
+                reshape_to(stmts, row_flat, {make_idx(rows), one}, prefix + "_row_arange");
+            auto row_base =
+                emit_to(stmts, "tile.muls", {row_ar, make_cd(src_cols)}, {}, prefix + "_row_base");
+            flat = emit_to(stmts, "tile.row_expand_add", {idx_i32, row_base}, {}, prefix + "_flat_idx");
+          }
+          if (idx_dtype != compute_dtype) {
+            return emit_to(stmts, "tile.cast", {flat}, {{"target_type", idx_dtype}},
+                           prefix + "_flat_cast");
+          }
+          return flat;
+        };
+
         // ================================================================
         // Case 1  rank==2, dim==1 (last dim)
+        // A5: full-tile gather with flat indices (mirrors tensor.scatter).
+        // A2A3: legacy per-row loop (column index == flat within rows=1 src).
         // ================================================================
         if (rank == 2 && norm_dim == 1) {
           int64_t I0 = get_const(index_shape[0], "index.shape[0]");
           int64_t S1 = get_const(input_shape[1], "input.shape[1]");
           int64_t K = get_const(index_shape[1], "index.shape[1]");
+
+          if (IsA5TargetArch()) {
+            // INT16 flat-index range guard (same bound as tensor.scatter).
+            if (idx_dtype == DataType::INT16) {
+              const int64_t kMaxFlat = 32768;
+              const int64_t max_rows = S1 == 0 ? kMaxFlat : kMaxFlat / S1;
+              CHECK_SPAN(I0 <= max_rows, span)
+                  << "tensor.gather (A5) with INT16 indices: rows(" << I0 << ") * src_cols(" << S1
+                  << ") exceeds the INT16 index range (max flat index 32767, rows <= " << max_rows << ").";
+            }
+
+            auto zero_ofs = std::make_shared<MakeTuple>(std::vector<ExprPtr>{zero, zero}, span);
+            auto inp_sh = MakeShapeTuple({make_idx(I0), make_idx(S1)}, span);
+            auto inp_full = emit_load_or_slice(prologue, input, zero_ofs, inp_sh, "gather_inp");
+            auto idx_sh = MakeShapeTuple({make_idx(I0), make_idx(K)}, span);
+            auto idx_full = emit_load_or_slice(prologue, index, zero_ofs, idx_sh, "gather_idx");
+
+            auto flat_idx = emit_a5_flat_idx(prologue, idx_full, I0, S1, K, "gather");
+            auto tmp_sh = MakeShapeTuple({make_idx(I0), make_idx(K)}, span);
+            auto tmp = emit("tile.create", {tmp_sh}, tmp_create_kwargs, "gather_tmp");
+            auto result = emit("tile.gather", {inp_full, flat_idx, tmp}, {}, "gather");
+            return ConversionResult{std::move(prologue), result};
+          }
 
           auto result =
               make_loop(prologue, "gather", index_shape[0], I0, K, input_dtype,
@@ -1323,8 +1417,7 @@ void OpConversionRegistry::RegisterGatherOps() {
         // ================================================================
         // Case 2  rank==3, dim==2 (last dim)
         // Result tile: [I0*I1, K] where tile[i0*I1+i1, k] = output[i0, i1, k].
-        // Stored via tile.store at [0,0,0]; FlattenTileNdTo2D injects
-        // partition_shape [1, I0*I1, K] which covers all elements correctly.
+        // A5: reshape to 2D then full-tile flat gather. A2A3: nested row loops.
         // ================================================================
         if (rank == 3 && norm_dim == 2) {
           int64_t I0 = get_const(index_shape[0], "index.shape[0]");
@@ -1332,6 +1425,34 @@ void OpConversionRegistry::RegisterGatherOps() {
           int64_t S2 = get_const(input_shape[2], "input.shape[2]");
           int64_t K = get_const(index_shape[2], "index.shape[2]");
           int64_t I1K = I1 * K;
+          int64_t I0I1 = I0 * I1;
+
+          if (IsA5TargetArch()) {
+            if (idx_dtype == DataType::INT16) {
+              const int64_t kMaxFlat = 32768;
+              const int64_t max_rows = S2 == 0 ? kMaxFlat : kMaxFlat / S2;
+              CHECK_SPAN(I0I1 <= max_rows, span)
+                  << "tensor.gather (A5) with INT16 indices: rows(" << I0I1 << ") * src_cols(" << S2
+                  << ") exceeds the INT16 index range (max flat index 32767, rows <= " << max_rows << ").";
+            }
+
+            auto zero_ofs =
+                std::make_shared<MakeTuple>(std::vector<ExprPtr>{zero, zero, zero}, span);
+            auto inp_sh = MakeShapeTuple({make_idx(I0), make_idx(I1), make_idx(S2)}, span);
+            auto inp_raw = emit_load_or_slice(prologue, input, zero_ofs, inp_sh, "gather_inp_raw");
+            auto inp_2d = reshape_to(prologue, inp_raw, {make_idx(I0I1), make_idx(S2)}, "gather_inp");
+            auto idx_sh = MakeShapeTuple({make_idx(I0), make_idx(I1), make_idx(K)}, span);
+            auto idx_raw = emit_load_or_slice(prologue, index, zero_ofs, idx_sh, "gather_idx_raw");
+            auto idx_2d = reshape_to(prologue, idx_raw, {make_idx(I0I1), make_idx(K)}, "gather_idx");
+
+            auto flat_idx = emit_a5_flat_idx(prologue, idx_2d, I0I1, S2, K, "gather");
+            auto tmp_sh = MakeShapeTuple({make_idx(I0I1), make_idx(K)}, span);
+            auto tmp = emit("tile.create", {tmp_sh}, tmp_create_kwargs, "gather_tmp");
+            auto result = emit("tile.gather", {inp_2d, flat_idx, tmp}, {}, "gather");
+            // Trailing reshape keeps Phase 3 off (same as the legacy path).
+            auto out_2d = reshape_to(prologue, result, {make_idx(I0I1), make_idx(K)}, "gather_out");
+            return ConversionResult{std::move(prologue), out_2d};
+          }
 
           // Outer loop: i0=0..I0-1, accumulates [I0, I1*K].
           auto outer_result = make_loop(
@@ -1357,7 +1478,6 @@ void OpConversionRegistry::RegisterGatherOps() {
                 return reshape_to(ob, inner_result, {one, make_idx(I1K)}, "gather_inner_flat");
               });
           // Reshape [I0, I1*K] → [I0*I1, K].  Prevents Phase 3 and gives correct 2D layout.
-          int64_t I0I1 = I0 * I1;
           auto out_2d = reshape_to(prologue, outer_result, {make_idx(I0I1), make_idx(K)}, "gather_out");
           return ConversionResult{std::move(prologue), out_2d};
         }

--- a/src/ir/transforms/op_conversion_registry.cpp
+++ b/src/ir/transforms/op_conversion_registry.cpp
@@ -1368,6 +1368,25 @@ void OpConversionRegistry::RegisterGatherOps() {
           return flat;
         };
 
+        // A5 flat-index gather addresses the source as a flat 1D array
+        // (flat[i,j] = i * src_cols + index[i,j]), which assumes the source is
+        // stored row-major with stride == src_cols. A tile.slice *view* of a
+        // wider tile keeps the parent's stride (e.g. rope = full[:, nope:head]
+        // has stride HEAD_DIM, not ROPE_DIM), so the flat offset misaddresses
+        // every row past the first — only row 0 survives. tile.load already
+        // materializes TensorType sources to a fresh contiguous tile; only
+        // TileType sources — lowered to a view-only tile.slice by
+        // emit_load_or_slice — need this copy into a fresh contiguous tile.
+        auto materialize_src_contig = [&](const VarPtr& src, int64_t rows, int64_t cols,
+                                          DataType dtype, const std::string& name) -> VarPtr {
+          auto sh = MakeShapeTuple({make_idx(rows), make_idx(cols)}, span);
+          std::vector<std::pair<std::string, std::any>> alloc_kw = {
+              {"dtype", dtype}, {"target_memory", MemorySpace::Vec}};
+          auto contig = emit_to(prologue, "tile.create", {sh}, alloc_kw, name + "_alloc");
+          auto ofs = std::make_shared<MakeTuple>(std::vector<ExprPtr>{zero, zero}, span);
+          return emit_to(prologue, "tile.assemble", {contig, src, ofs}, {}, name + "_copy");
+        };
+
         // ================================================================
         // Case 1  rank==2, dim==1 (last dim)
         // A5: full-tile gather with flat indices (mirrors tensor.scatter).
@@ -1391,13 +1410,20 @@ void OpConversionRegistry::RegisterGatherOps() {
             auto zero_ofs = std::make_shared<MakeTuple>(std::vector<ExprPtr>{zero, zero}, span);
             auto inp_sh = MakeShapeTuple({make_idx(I0), make_idx(S1)}, span);
             auto inp_full = emit_load_or_slice(prologue, input, zero_ofs, inp_sh, "gather_inp");
+            // Materialize a possibly-strided TileType source (see comment on
+            // materialize_src_contig) so the flat-index gather addresses it
+            // correctly. TensorType sources are already contiguous (tile.load).
+            VarPtr gather_src = inp_full;
+            if (As<TileType>(input->GetType())) {
+              gather_src = materialize_src_contig(inp_full, I0, S1, input_dtype, "gather_src");
+            }
             auto idx_sh = MakeShapeTuple({make_idx(I0), make_idx(K)}, span);
             auto idx_full = emit_load_or_slice(prologue, index, zero_ofs, idx_sh, "gather_idx");
 
             auto flat_idx = emit_a5_flat_idx(prologue, idx_full, I0, S1, K, "gather");
             auto tmp_sh = MakeShapeTuple({make_idx(I0), make_idx(K)}, span);
             auto tmp = emit("tile.create", {tmp_sh}, tmp_create_kwargs, "gather_tmp");
-            auto result = emit("tile.gather", {inp_full, flat_idx, tmp}, {}, "gather");
+            auto result = emit("tile.gather", {gather_src, flat_idx, tmp}, {}, "gather");
             return ConversionResult{std::move(prologue), result};
           }
 
@@ -1441,6 +1467,13 @@ void OpConversionRegistry::RegisterGatherOps() {
             auto inp_sh = MakeShapeTuple({make_idx(I0), make_idx(I1), make_idx(S2)}, span);
             auto inp_raw = emit_load_or_slice(prologue, input, zero_ofs, inp_sh, "gather_inp_raw");
             auto inp_2d = reshape_to(prologue, inp_raw, {make_idx(I0I1), make_idx(S2)}, "gather_inp");
+            // Materialize a possibly-strided TileType source (see comment on
+            // materialize_src_contig); the reshape above preserves a strided
+            // 3D slice's wider stride, which would break the flat-index gather.
+            VarPtr gather_src = inp_2d;
+            if (As<TileType>(input->GetType())) {
+              gather_src = materialize_src_contig(inp_2d, I0I1, S2, input_dtype, "gather_src");
+            }
             auto idx_sh = MakeShapeTuple({make_idx(I0), make_idx(I1), make_idx(K)}, span);
             auto idx_raw = emit_load_or_slice(prologue, index, zero_ofs, idx_sh, "gather_idx_raw");
             auto idx_2d = reshape_to(prologue, idx_raw, {make_idx(I0I1), make_idx(K)}, "gather_idx");
@@ -1448,7 +1481,7 @@ void OpConversionRegistry::RegisterGatherOps() {
             auto flat_idx = emit_a5_flat_idx(prologue, idx_2d, I0I1, S2, K, "gather");
             auto tmp_sh = MakeShapeTuple({make_idx(I0I1), make_idx(K)}, span);
             auto tmp = emit("tile.create", {tmp_sh}, tmp_create_kwargs, "gather_tmp");
-            auto result = emit("tile.gather", {inp_2d, flat_idx, tmp}, {}, "gather");
+            auto result = emit("tile.gather", {gather_src, flat_idx, tmp}, {}, "gather");
             // Trailing reshape keeps Phase 3 off (same as the legacy path).
             auto out_2d = reshape_to(prologue, result, {make_idx(I0I1), make_idx(K)}, "gather_out");
             return ConversionResult{std::move(prologue), out_2d};

--- a/tests/st/runtime/ops/test_gather.py
+++ b/tests/st/runtime/ops/test_gather.py
@@ -43,6 +43,7 @@ import pypto.language as pl
 import pytest
 import torch
 from harness.core.harness import PLATFORMS, DataType, PTOTestCase, TensorSpec
+from pypto.backend import BackendType
 from pypto.ir.pass_manager import OptimizationStrategy
 
 # --- Shared init helpers ---
@@ -226,6 +227,55 @@ class GatherRank2SwapProgram:
     ) -> pl.Tensor[[4, 64], pl.FP32]:
         with pl.at(level=pl.Level.CORE_GROUP):
             out = pl.tensor.gather(inp, dim=-1, index=idx)
+            output = pl.assemble(output, out, [0, 0])
+        return output
+
+
+@pl.program
+class GatherRank2Swap16RowProgram:
+    """Rank-2 swap gather with 16 source rows (j^1 indices).
+
+    16 rows spans two A5 FP32 vector boxes, so this exercises the A5 full-tile
+    flat-index gather beyond the one-box (<=8-row) case that the 4-row variant
+    covers. Regression for the A5 ``pto.tgather`` >8-row index-tile corruption.
+    """
+
+    @pl.function(type=pl.FunctionType.Opaque)
+    def main(
+        self,
+        inp: pl.Tensor[[16, 64], pl.FP32],
+        idx: pl.Tensor[[16, 64], pl.INT32],
+        output: pl.Out[pl.Tensor[[16, 64], pl.FP32]],
+    ) -> pl.Tensor[[16, 64], pl.FP32]:
+        with pl.at(level=pl.Level.CORE_GROUP):
+            out = pl.tensor.gather(inp, dim=-1, index=idx)
+            output = pl.assemble(output, out, [0, 0])
+        return output
+
+
+@pl.program
+class GatherRank2Swap16RowStridedProgram:
+    """Rank-2 swap gather over a STRIDED column slice of a wider tile.
+
+    Mirrors DeepSeek sparse_attn inverse-RoPE exactly: the source is a [16, 128]
+    tile whose columns [64:128] (ROPE_DIM=64) are gathered, so the gather source
+    is a non-contiguous column slice with row stride 128, not 64. With a [16, 64]
+    swap index this is the shape that corrupted on A5. The contiguous [16, 64]
+    variant (GatherRank2Swap16RowProgram) does NOT reproduce it.
+    """
+
+    @pl.function(type=pl.FunctionType.Opaque)
+    def main(
+        self,
+        inp: pl.Tensor[[16, 128], pl.FP32],
+        idx: pl.Tensor[[16, 64], pl.INT32],
+        output: pl.Out[pl.Tensor[[16, 64], pl.FP32]],
+    ) -> pl.Tensor[[16, 64], pl.FP32]:
+        with pl.at(level=pl.Level.CORE_GROUP):
+            local = pl.create_tensor([16, 128], dtype=pl.FP32)
+            local = pl.assemble(local, inp, [0, 0])
+            rope = local[:, 64:128]
+            out = pl.tensor.gather(rope, dim=-1, index=idx)
             output = pl.assemble(output, out, [0, 0])
         return output
 
@@ -581,6 +631,12 @@ def _swap_indices_4x64() -> torch.Tensor:
     return (j ^ 1).unsqueeze(0).expand(4, -1).contiguous()
 
 
+def _swap_indices_16x64() -> torch.Tensor:
+    """Per-row adjacent swap over 16 rows: ``idx[r, j] = j ^ 1``."""
+    j = torch.arange(64, dtype=torch.int32)
+    return (j ^ 1).unsqueeze(0).expand(16, -1).contiguous()
+
+
 class GatherRank2ExpandTestCase(_GatherBaseTestCase):
     def get_name(self) -> str:
         return "gather_rank2_expand"
@@ -619,6 +675,46 @@ class GatherRank2SwapTestCase(_GatherBaseTestCase):
         inp = tensors["inp"]
         idx = tensors["idx"].to(torch.int64)
         tensors["output"][:] = torch.gather(inp, dim=-1, index=idx)
+
+
+class GatherRank2Swap16RowTestCase(_GatherBaseTestCase):
+    def get_name(self) -> str:
+        return "gather_rank2_swap_16row"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("inp", [16, 64], DataType.FP32, init_value=torch.randn),
+            TensorSpec("idx", [16, 64], DataType.INT32, init_value=_swap_indices_16x64),
+            TensorSpec("output", [16, 64], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        return GatherRank2Swap16RowProgram
+
+    def compute_expected(self, tensors, params=None):
+        inp = tensors["inp"]
+        idx = tensors["idx"].to(torch.int64)
+        tensors["output"][:] = torch.gather(inp, dim=-1, index=idx)
+
+
+class GatherRank2Swap16RowStridedTestCase(_GatherBaseTestCase):
+    def get_name(self) -> str:
+        return "gather_rank2_swap_16row_strided"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("inp", [16, 128], DataType.FP32, init_value=torch.randn),
+            TensorSpec("idx", [16, 64], DataType.INT32, init_value=_swap_indices_16x64),
+            TensorSpec("output", [16, 64], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        return GatherRank2Swap16RowStridedProgram
+
+    def compute_expected(self, tensors, params=None):
+        rope = tensors["inp"][:, 64:128]
+        idx = tensors["idx"].to(torch.int64)
+        tensors["output"][:] = torch.gather(rope, dim=-1, index=idx)
 
 
 class GatherRank3LastDimTestCase(_GatherBaseTestCase):
@@ -873,6 +969,20 @@ class TestGatherIndex:
     def test_gather_rank2_swap(self, test_runner, platform):
         """A5-focused swap gather (j^1) — rope-style adjacent swap."""
         result = test_runner.run(GatherRank2SwapTestCase(platform=platform))
+        assert result.passed, f"Test failed: {result.error}"
+
+    @pytest.mark.platforms("a5", "a5sim")
+    @pytest.mark.parametrize("platform", [pytest.param("a5sim", id="a5sim"), pytest.param("a5", id="a5")])
+    def test_gather_rank2_swap_16row(self, test_runner, platform):
+        """A5 swap gather over 16 rows (>8) — regression for tgather >8-row corruption."""
+        result = test_runner.run(GatherRank2Swap16RowTestCase(platform=platform))
+        assert result.passed, f"Test failed: {result.error}"
+
+    @pytest.mark.platforms("a5", "a5sim")
+    @pytest.mark.parametrize("platform", [pytest.param("a5sim", id="a5sim"), pytest.param("a5", id="a5")])
+    def test_gather_rank2_swap_16row_strided(self, test_runner, platform):
+        """A5 swap gather over a strided column slice — mirrors sparse_attn inverse-RoPE."""
+        result = test_runner.run(GatherRank2Swap16RowStridedTestCase(platform=platform))
         assert result.passed, f"Test failed: {result.error}"
 
     @pytest.mark.parametrize("platform", PLATFORMS)

--- a/tests/st/runtime/ops/test_gather.py
+++ b/tests/st/runtime/ops/test_gather.py
@@ -43,7 +43,6 @@ import pypto.language as pl
 import pytest
 import torch
 from harness.core.harness import PLATFORMS, DataType, PTOTestCase, TensorSpec
-from pypto.backend import BackendType
 from pypto.ir.pass_manager import OptimizationStrategy
 
 # --- Shared init helpers ---
@@ -184,6 +183,47 @@ class GatherRank2SmallerLeadingProgram:
         idx: pl.Tensor[[2, 8], pl.INT32],
         output: pl.Out[pl.Tensor[[2, 8], pl.FP32]],
     ) -> pl.Tensor[[2, 8], pl.FP32]:
+        with pl.at(level=pl.Level.CORE_GROUP):
+            out = pl.tensor.gather(inp, dim=-1, index=idx)
+            output = pl.assemble(output, out, [0, 0])
+        return output
+
+
+@pl.program
+class GatherRank2ExpandProgram:
+    """Rank-2 expand gather: ``index`` cols (64) > ``input`` cols (32).
+
+    Mirrors the DeepSeek rope cos/sin interleave pattern (column expand via
+    ``j >> 1`` indices). On A5 this exercises the full-tile flat-index path.
+    """
+
+    @pl.function(type=pl.FunctionType.Opaque)
+    def main(
+        self,
+        inp: pl.Tensor[[4, 32], pl.FP32],
+        idx: pl.Tensor[[4, 64], pl.INT32],
+        output: pl.Out[pl.Tensor[[4, 64], pl.FP32]],
+    ) -> pl.Tensor[[4, 64], pl.FP32]:
+        with pl.at(level=pl.Level.CORE_GROUP):
+            out = pl.tensor.gather(inp, dim=-1, index=idx)
+            output = pl.assemble(output, out, [0, 0])
+        return output
+
+
+@pl.program
+class GatherRank2SwapProgram:
+    """Rank-2 swap gather: adjacent-pair swap via ``j ^ 1`` indices.
+
+    Mirrors the DeepSeek rope swap pattern on the last dim.
+    """
+
+    @pl.function(type=pl.FunctionType.Opaque)
+    def main(
+        self,
+        inp: pl.Tensor[[4, 64], pl.FP32],
+        idx: pl.Tensor[[4, 64], pl.INT32],
+        output: pl.Out[pl.Tensor[[4, 64], pl.FP32]],
+    ) -> pl.Tensor[[4, 64], pl.FP32]:
         with pl.at(level=pl.Level.CORE_GROUP):
             out = pl.tensor.gather(inp, dim=-1, index=idx)
             output = pl.assemble(output, out, [0, 0])
@@ -412,9 +452,6 @@ class _GatherBaseTestCase(PTOTestCase):
     def get_strategy(self) -> OptimizationStrategy:
         return OptimizationStrategy.Default
 
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend910B
-
 
 class GatherRank2LastDimTestCase(_GatherBaseTestCase):
     def get_name(self) -> str:
@@ -528,6 +565,58 @@ class GatherRank2SmallerLeadingTestCase(_GatherBaseTestCase):
         # torch's index broadcast along the non-gather axis must match the
         # PyPTO contract: rows of the input beyond index.shape[0] are unused.
         inp = tensors["inp"][: tensors["idx"].shape[0]]
+        idx = tensors["idx"].to(torch.int64)
+        tensors["output"][:] = torch.gather(inp, dim=-1, index=idx)
+
+
+def _expand_indices_4x64() -> torch.Tensor:
+    """Per-row interleave indices: ``idx[r, j] = j >> 1`` (32 → 64 expand)."""
+    j = torch.arange(64, dtype=torch.int32)
+    return (j >> 1).unsqueeze(0).expand(4, -1).contiguous()
+
+
+def _swap_indices_4x64() -> torch.Tensor:
+    """Per-row adjacent swap: ``idx[r, j] = j ^ 1``."""
+    j = torch.arange(64, dtype=torch.int32)
+    return (j ^ 1).unsqueeze(0).expand(4, -1).contiguous()
+
+
+class GatherRank2ExpandTestCase(_GatherBaseTestCase):
+    def get_name(self) -> str:
+        return "gather_rank2_expand"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("inp", [4, 32], DataType.FP32, init_value=torch.randn),
+            TensorSpec("idx", [4, 64], DataType.INT32, init_value=_expand_indices_4x64),
+            TensorSpec("output", [4, 64], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        return GatherRank2ExpandProgram
+
+    def compute_expected(self, tensors, params=None):
+        inp = tensors["inp"]
+        idx = tensors["idx"].to(torch.int64)
+        tensors["output"][:] = torch.gather(inp, dim=-1, index=idx)
+
+
+class GatherRank2SwapTestCase(_GatherBaseTestCase):
+    def get_name(self) -> str:
+        return "gather_rank2_swap"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("inp", [4, 64], DataType.FP32, init_value=torch.randn),
+            TensorSpec("idx", [4, 64], DataType.INT32, init_value=_swap_indices_4x64),
+            TensorSpec("output", [4, 64], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        return GatherRank2SwapProgram
+
+    def compute_expected(self, tensors, params=None):
+        inp = tensors["inp"]
         idx = tensors["idx"].to(torch.int64)
         tensors["output"][:] = torch.gather(inp, dim=-1, index=idx)
 
@@ -770,6 +859,20 @@ class TestGatherIndex:
     @pytest.mark.parametrize("platform", PLATFORMS)
     def test_gather_rank2_smaller_leading(self, test_runner, platform):
         result = test_runner.run(GatherRank2SmallerLeadingTestCase(platform=platform))
+        assert result.passed, f"Test failed: {result.error}"
+
+    @pytest.mark.platforms("a5", "a5sim")
+    @pytest.mark.parametrize("platform", [pytest.param("a5sim", id="a5sim"), pytest.param("a5", id="a5")])
+    def test_gather_rank2_expand(self, test_runner, platform):
+        """A5-focused expand gather (K>S1) — rope-style interleave indices."""
+        result = test_runner.run(GatherRank2ExpandTestCase(platform=platform))
+        assert result.passed, f"Test failed: {result.error}"
+
+    @pytest.mark.platforms("a5", "a5sim")
+    @pytest.mark.parametrize("platform", [pytest.param("a5sim", id="a5sim"), pytest.param("a5", id="a5")])
+    def test_gather_rank2_swap(self, test_runner, platform):
+        """A5-focused swap gather (j^1) — rope-style adjacent swap."""
+        result = test_runner.run(GatherRank2SwapTestCase(platform=platform))
         assert result.passed, f"Test failed: {result.error}"
 
     @pytest.mark.parametrize("platform", PLATFORMS)

--- a/tests/ut/ir/transforms/test_auto_tile_matmul_l0.py
+++ b/tests/ut/ir/transforms/test_auto_tile_matmul_l0.py
@@ -477,6 +477,55 @@ class TestAutoTileMatmulL0KOnly:
         After = passes.auto_tile_matmul_l0()(Before)
         ir.assert_structural_equal(After, Before)
 
+    def test_already_l0_sized_vec_lhs_staged_to_mat(self):
+        """Already-L0-sized gemm with a Vec LHS still gets a Vec→Mat stage.
+
+        ChooseL0Tile returns (M, N, K) so there is no K/M/N tiling, but the
+        fused-attention / cast→matmul Left path still needs an explicit
+        ``tile.move`` so ExpandMixedKernel sees a CV boundary (same as the
+        K-tiled PV pattern).  Without it InferTileMemorySpace inserts
+        Vec→Left directly."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                lhs: pl.Tensor[[64, 64], pl.BF16],
+                rhs: pl.Tensor[[64, 64], pl.BF16],
+                out: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+            ) -> pl.Tensor[[64, 64], pl.FP32]:
+                lhs_vec: pl.Tile[[64, 64], pl.BF16, pl.Mem.Vec] = pl.tile.load(lhs, [0, 0], [64, 64])
+                rhs_mat: pl.Tile[[64, 64], pl.BF16, pl.Mem.Mat] = pl.tile.load(
+                    rhs, [0, 0], [64, 64], target_memory=pl.Mem.Mat
+                )
+                c: pl.Tile[[64, 64], pl.FP32, pl.Mem.Acc] = pl.tile.matmul(lhs_vec, rhs_mat)
+                out = pl.store(c, [0, 0], out)
+                return out
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                lhs: pl.Tensor[[64, 64], pl.BF16],
+                rhs: pl.Tensor[[64, 64], pl.BF16],
+                out: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+            ) -> pl.Tensor[[64, 64], pl.FP32]:
+                lhs_vec: pl.Tile[[64, 64], pl.BF16, pl.Mem.Vec] = pl.tile.load(lhs, [0, 0], [64, 64])
+                rhs_mat: pl.Tile[[64, 64], pl.BF16, pl.Mem.Mat] = pl.tile.load(
+                    rhs, [0, 0], [64, 64], target_memory=pl.Mem.Mat
+                )
+                lhs_mat: pl.Tile[[64, 64], pl.BF16, pl.Mem.Mat] = pl.tile.move(
+                    lhs_vec, target_memory=pl.Mem.Mat
+                )
+                c: pl.Tile[[64, 64], pl.FP32, pl.Mem.Acc] = pl.tile.matmul(lhs_mat, rhs_mat)
+                out = pl.store(c, [0, 0], out)
+                return out
+
+        After = passes.auto_tile_matmul_l0()(Before)
+        ir.assert_structural_equal(After, Expected)
+
     def test_pass_idempotent(self):
         """Running the pass twice produces the same result as running it once.
 

--- a/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
+++ b/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
@@ -3113,6 +3113,53 @@ class TestConvertGatherOp:
         assert "pl.tile.slice(" in after_src
         assert "pl.range(" not in after_src
 
+    def test_gather_conversion_strided_tile_source_materializes(self):
+        """A5 flat-index gather materializes a strided tile.slice source.
+
+        Regression for the strided-source corruption (DeepSeek sparse_attn
+        inverse-RoPE): flat[i,j] = i*src_cols + idx assumes the source is stored
+        row-major with stride == src_cols, but a tile.slice view of a wider tile
+        (rope = full[:, nope:head]) keeps the parent's wider stride, so every row
+        past the first is misaddressed. The converter now copies the TileType
+        source into a fresh contiguous tile (tile.create + tile.assemble) before
+        the flat-index tile.gather. The contiguous TensorType path
+        (test_gather_conversion) already materializes via tile.load and is not
+        copied.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                src: pl.Tensor[[4, 16], pl.FP32],
+                idx: pl.Tensor[[4, 8], pl.INT32],
+            ) -> pl.Tensor[[4, 8], pl.FP32]:
+                full: pl.Tensor[[4, 16], pl.FP32] = pl.create_tensor([4, 16], dtype=pl.FP32)
+                full_1: pl.Tensor[[4, 16], pl.FP32] = pl.assemble(full, src, [0, 0])
+                rope = full_1[:, 8:16]
+                out: pl.Tensor[[4, 8], pl.FP32] = pl.tensor.gather(rope, dim=-1, index=idx)
+                return out
+
+            @pl.function
+            def main(
+                self,
+                src: pl.Tensor[[4, 16], pl.FP32],
+                idx: pl.Tensor[[4, 8], pl.INT32],
+            ) -> pl.Tensor[[4, 8], pl.FP32]:
+                out: pl.Tensor[[4, 8], pl.FP32] = self.main_incore_0(src, idx)
+                return out
+
+        After = passes.convert_tensor_to_tile_ops()(Before)
+        after_src = After.as_python()
+
+        assert after_src.count("pl.tile.gather(") == 1
+        # The strided tile.slice source (rope = full[:, 8:16], row stride 16 not
+        # 8) is copied into a fresh contiguous tile that feeds the flat-index
+        # gather, instead of being gathered directly.
+        assert "pl.tile.assemble(gather_src_alloc, gather_inp" in after_src
+        assert "pl.tile.gather(gather_src_copy," in after_src
+
     def test_gather_mask_conversion(self):
         """tensor.gather(mask_pattern=...) -> tile.load + tile.gather_mask + tile.store."""
         before, expected = _make_pair(

--- a/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
+++ b/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
@@ -2962,10 +2962,15 @@ class TestConvertSortOps:
 
 
 class TestConvertGatherOp:
-    """Test conversion of tensor.gather (MVP: 2D + dim=-1)."""
+    """Test conversion of tensor.gather (MVP: 2D + dim=-1).
+
+    UT transforms conftest pins Ascend950 (A5), so the default path is the
+    full-tile flat-index lowering. A separate test switches to Ascend910B to
+    lock the legacy per-row loop.
+    """
 
     def test_gather_conversion(self):
-        """tensor.gather -> per-row loop of tile.load + tile.gather + tile.store."""
+        """A5: tensor.gather -> full-tile load + flat index + one tile.gather."""
 
         @pl.program
         class Before:
@@ -2987,43 +2992,86 @@ class TestConvertGatherOp:
                 out: pl.Tensor[[4, 3], pl.FP32] = self.main_incore_0(inp, idx)
                 return out
 
-        # tensor.gather is fully lowered into a per-row loop: each iteration loads a
-        # [1, 16] input row and a [1, 3] index row, runs the index-form tile.gather
-        # (which needs a [1, 3] INT32 scratch tile), and assembles the row into the
-        # accumulator. Phase 3 adds the Out tensor param for the result.
+        After = passes.convert_tensor_to_tile_ops()(Before)
+        after_src = After.as_python()
+
+        assert "tensor.gather" not in after_src
+        assert "pl.tile.gather(" in after_src
+        assert after_src.count("pl.tile.gather(") == 1
+        # Odd K (=3) uses row_expand_add fallback; still no per-row loop.
+        assert "tile.row_expand_add" in after_src or ("tile.divs" in after_src and "tile.add" in after_src)
+        assert "pl.range(" not in after_src
+        assert "pl.Out[pl.Tensor[[4, 3]" in after_src
+
+    def test_gather_conversion_expand(self):
+        """A5 expand gather (K > S1): flat uses src cols, not output cols."""
+
         @pl.program
-        class Expected:
+        class Before:
             @pl.function(type=pl.FunctionType.InCore)
             def main_incore_0(
                 self,
-                inp: pl.Tensor[[4, 16], pl.FP32],
-                idx: pl.Tensor[[4, 3], pl.INT32],
-                ret0__out: pl.Out[pl.Tensor[[4, 3], pl.FP32]],
-            ) -> pl.Tensor[[4, 3], pl.FP32]:
-                gather_acc_init = pl.tile.create([4, 3], dtype=pl.FP32, target_memory=pl.Mem.Vec)
-                for gather_lv, (gather_ia,) in pl.range(4, init_values=(gather_acc_init,)):
-                    gather_inp_row = pl.load(inp, [gather_lv, 0], [1, 16], [1, 16], target_memory=pl.Mem.Vec)
-                    gather_idx_row = pl.load(idx, [gather_lv, 0], [1, 3], [1, 3], target_memory=pl.Mem.Vec)
-                    gather_row_tmp = pl.tile.create([1, 3], dtype=pl.INT32, target_memory=pl.Mem.Vec)
-                    gather_row = pl.tile.gather(gather_inp_row, gather_idx_row, gather_row_tmp)
-                    gather_asmbl = pl.tile.assemble(gather_ia, gather_row, [gather_lv, 0])
-                    gather_rv = pl.yield_(gather_asmbl)
-                out__tile: pl.Tile[[4, 3], pl.FP32, pl.Mem.Vec] = gather_rv
-                ret0__store = pl.store(out__tile, [0, 0], ret0__out)
-                return ret0__store
+                inp: pl.Tensor[[4, 32], pl.FP32],
+                idx: pl.Tensor[[4, 64], pl.INT32],
+            ) -> pl.Tensor[[4, 64], pl.FP32]:
+                out: pl.Tensor[[4, 64], pl.FP32] = pl.tensor.gather(inp, dim=-1, index=idx)
+                return out
 
             @pl.function
             def main(
                 self,
-                inp: pl.Tensor[[4, 16], pl.FP32],
-                idx: pl.Tensor[[4, 3], pl.INT32],
-            ) -> pl.Tensor[[4, 3], pl.FP32]:
-                ret0__out = pl.create_tensor([4, 3], dtype=pl.FP32, layout=pl.TensorLayout.ND)
-                out = self.main_incore_0(inp, idx, ret0__out)
+                inp: pl.Tensor[[4, 32], pl.FP32],
+                idx: pl.Tensor[[4, 64], pl.INT32],
+            ) -> pl.Tensor[[4, 64], pl.FP32]:
+                out: pl.Tensor[[4, 64], pl.FP32] = self.main_incore_0(inp, idx)
                 return out
 
         After = passes.convert_tensor_to_tile_ops()(Before)
-        ir.assert_structural_equal(After, Expected)
+        after_src = After.as_python()
+
+        assert after_src.count("pl.tile.gather(") == 1
+        # Aligned K (=64): linear arange → divs → muls(src_cols=32) → add.
+        assert "tile.divs" in after_src
+        assert "tile.muls" in after_src
+        assert "pl.const(32," in after_src or "pl.const(32, " in after_src
+        assert "pl.range(" not in after_src
+    def test_gather_conversion_a2a3_per_row(self):
+        """Non-A5 keeps the legacy per-row single-row gather loop."""
+        from pypto import backend
+        from pypto.backend import BackendType
+
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+        try:
+
+            @pl.program
+            class Before:
+                @pl.function(type=pl.FunctionType.InCore)
+                def main_incore_0(
+                    self,
+                    inp: pl.Tensor[[4, 16], pl.FP32],
+                    idx: pl.Tensor[[4, 3], pl.INT32],
+                ) -> pl.Tensor[[4, 3], pl.FP32]:
+                    out: pl.Tensor[[4, 3], pl.FP32] = pl.tensor.gather(inp, dim=-1, index=idx)
+                    return out
+
+                @pl.function
+                def main(
+                    self,
+                    inp: pl.Tensor[[4, 16], pl.FP32],
+                    idx: pl.Tensor[[4, 3], pl.INT32],
+                ) -> pl.Tensor[[4, 3], pl.FP32]:
+                    out: pl.Tensor[[4, 3], pl.FP32] = self.main_incore_0(inp, idx)
+                    return out
+
+            After = passes.convert_tensor_to_tile_ops()(Before)
+            after_src = After.as_python()
+            assert "pl.range(" in after_src
+            assert "pl.tile.gather(" in after_src
+            assert "tile.row_expand_add" not in after_src
+        finally:
+            backend.reset_for_testing()
+            backend.set_backend_type(BackendType.Ascend950)
 
     def test_gather_conversion_with_tile_input(self):
         """tensor.gather whose input was already demoted to a tile by an upstream conversion.
@@ -3031,8 +3079,7 @@ class TestConvertGatherOp:
         Regression test for the case the converter previously crashed with
         CHECK(input_tensor_type): a local tensor.create + tensor.assemble feeds
         tensor.gather, so by the time gather is visited its `input` arg is a
-        TileType. The converter now emits tile.slice per row for the tile input
-        and keeps tile.load for the tensor index in the same call.
+        TileType. On A5 the converter emits a full-tile slice + flat gather.
         """
 
         @pl.program
@@ -3057,42 +3104,14 @@ class TestConvertGatherOp:
                 out: pl.Tensor[[4, 3], pl.FP32] = self.main_incore_0(src, idx)
                 return out
 
-        @pl.program
-        class Expected:
-            @pl.function(type=pl.FunctionType.InCore)
-            def main_incore_0(
-                self,
-                src: pl.Tensor[[4, 16], pl.FP32],
-                idx: pl.Tensor[[4, 3], pl.INT32],
-                ret0__out: pl.Out[pl.Tensor[[4, 3], pl.FP32]],
-            ) -> pl.Tensor[[4, 3], pl.FP32]:
-                tmp__tile = pl.tile.create([4, 16], dtype=pl.FP32, target_memory=pl.Mem.Vec)
-                assemble_src = pl.load(src, [0, 0], [4, 16], [4, 16], target_memory=pl.Mem.Vec)
-                tmp_1__tile = pl.tile.assemble(tmp__tile, assemble_src, [0, 0])
-                gather_acc_init = pl.tile.create([4, 3], dtype=pl.FP32, target_memory=pl.Mem.Vec)
-                for gather_lv, (gather_ia,) in pl.range(4, init_values=(gather_acc_init,)):
-                    gather_inp_row = pl.tile.slice(tmp_1__tile, [1, 16], [gather_lv, 0], [1, 16])
-                    gather_idx_row = pl.load(idx, [gather_lv, 0], [1, 3], [1, 3], target_memory=pl.Mem.Vec)
-                    gather_row_tmp = pl.tile.create([1, 3], dtype=pl.INT32, target_memory=pl.Mem.Vec)
-                    gather_row = pl.tile.gather(gather_inp_row, gather_idx_row, gather_row_tmp)
-                    gather_asmbl = pl.tile.assemble(gather_ia, gather_row, [gather_lv, 0])
-                    gather_rv = pl.yield_(gather_asmbl)
-                out__tile: pl.Tile[[4, 3], pl.FP32, pl.Mem.Vec] = gather_rv
-                ret0__store = pl.store(out__tile, [0, 0], ret0__out)
-                return ret0__store
-
-            @pl.function
-            def main(
-                self,
-                src: pl.Tensor[[4, 16], pl.FP32],
-                idx: pl.Tensor[[4, 3], pl.INT32],
-            ) -> pl.Tensor[[4, 3], pl.FP32]:
-                ret0__out = pl.create_tensor([4, 3], dtype=pl.FP32, layout=pl.TensorLayout.ND)
-                out = self.main_incore_0(src, idx, ret0__out)
-                return out
-
         After = passes.convert_tensor_to_tile_ops()(Before)
-        ir.assert_structural_equal(After, Expected)
+        after_src = After.as_python()
+
+        assert "pl.tile.gather(" in after_src
+        assert after_src.count("pl.tile.gather(") == 1
+        assert "tile.row_expand_add" in after_src or "tile.divs" in after_src
+        assert "pl.tile.slice(" in after_src
+        assert "pl.range(" not in after_src
 
     def test_gather_mask_conversion(self):
         """tensor.gather(mask_pattern=...) -> tile.load + tile.gather_mask + tile.store."""

--- a/tests/ut/ir/transforms/test_legalize_tile_cast.py
+++ b/tests/ut/ir/transforms/test_legalize_tile_cast.py
@@ -1,0 +1,185 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Tests for the LegalizeTileCast pass."""
+
+from __future__ import annotations
+
+import pypto.language as pl
+from pypto import backend, ir, passes
+from pypto.backend import BackendType
+
+
+class _CastTargetCollector(ir.IRVisitor):
+    """Record each tile.cast's (src_dtype, target_type) in visitation order."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.pairs: list[tuple[str, str]] = []
+
+    def visit_call(self, op: ir.Call) -> None:
+        if op.op.name == "tile.cast":
+            src_ty = op.args[0].type
+            src = str(src_ty.dtype)
+            dst = str(op.kwargs["target_type"])
+            self.pairs.append((src, dst))
+        super().visit_call(op)
+
+
+def _cast_pairs(prog) -> list[tuple[str, str]]:
+    c = _CastTargetCollector()
+    c.visit_program(prog)
+    return c.pairs
+
+
+def _run(program, backend_type: BackendType):
+    backend.reset_for_testing()
+    backend.set_backend_type(backend_type)
+    try:
+        return passes.legalize_tile_cast()(program)
+    finally:
+        backend.reset_for_testing()
+
+
+def test_legalize_tile_cast_pass_factory_exists():
+    p = passes.legalize_tile_cast()
+    assert p is not None
+    assert p.get_name() == "LegalizeTileCast"
+
+
+def test_a5_int32_to_fp16_becomes_fp32_bridge():
+    """A5 has no native I32→FP16; expand to I32→FP32→FP16."""
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore)
+        def kernel(
+            self,
+            x: pl.Tensor[[16, 16], pl.INT32],
+            out: pl.Out[pl.Tensor[[16, 16], pl.FP16]],
+        ) -> pl.Tensor[[16, 16], pl.FP16]:
+            t: pl.Tile[[16, 16], pl.INT32] = pl.load(x, [0, 0], [16, 16])
+            c: pl.Tile[[16, 16], pl.FP16] = pl.tile.cast(t, target_type=pl.FP16, mode="round")
+            out_t: pl.Tensor[[16, 16], pl.FP16] = pl.store(c, [0, 0], out)
+            return out_t
+
+        @pl.function
+        def main(self, x: pl.Tensor[[16, 16], pl.INT32]) -> pl.Tensor[[16, 16], pl.FP16]:
+            o: pl.Tensor[[16, 16], pl.FP16] = pl.create_tensor([16, 16], dtype=pl.FP16)
+            return self.kernel(x, o)
+
+    after = _run(Before, BackendType.Ascend950)
+    pairs = _cast_pairs(after)
+    assert pairs == [("int32", "fp32"), ("fp32", "fp16")], pairs
+
+
+def test_a2a3_int32_to_fp16_stays_native():
+    """A2A3 has a native I32→FP16 deq path — leave the single cast."""
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore)
+        def kernel(
+            self,
+            x: pl.Tensor[[16, 16], pl.INT32],
+            out: pl.Out[pl.Tensor[[16, 16], pl.FP16]],
+        ) -> pl.Tensor[[16, 16], pl.FP16]:
+            t: pl.Tile[[16, 16], pl.INT32] = pl.load(x, [0, 0], [16, 16])
+            c: pl.Tile[[16, 16], pl.FP16] = pl.tile.cast(t, target_type=pl.FP16, mode="round")
+            out_t: pl.Tensor[[16, 16], pl.FP16] = pl.store(c, [0, 0], out)
+            return out_t
+
+        @pl.function
+        def main(self, x: pl.Tensor[[16, 16], pl.INT32]) -> pl.Tensor[[16, 16], pl.FP16]:
+            o: pl.Tensor[[16, 16], pl.FP16] = pl.create_tensor([16, 16], dtype=pl.FP16)
+            return self.kernel(x, o)
+
+    after = _run(Before, BackendType.Ascend910B)
+    pairs = _cast_pairs(after)
+    assert pairs == [("int32", "fp16")], pairs
+
+
+def test_a5_fp16_to_bf16_via_fp32():
+    """A5 has no native FP16→BF16; expand via FP32."""
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore)
+        def kernel(
+            self,
+            x: pl.Tensor[[16, 16], pl.FP16],
+            out: pl.Out[pl.Tensor[[16, 16], pl.BF16]],
+        ) -> pl.Tensor[[16, 16], pl.BF16]:
+            t: pl.Tile[[16, 16], pl.FP16] = pl.load(x, [0, 0], [16, 16])
+            c: pl.Tile[[16, 16], pl.BF16] = pl.tile.cast(t, target_type=pl.BF16, mode="round")
+            out_t: pl.Tensor[[16, 16], pl.BF16] = pl.store(c, [0, 0], out)
+            return out_t
+
+        @pl.function
+        def main(self, x: pl.Tensor[[16, 16], pl.FP16]) -> pl.Tensor[[16, 16], pl.BF16]:
+            o: pl.Tensor[[16, 16], pl.BF16] = pl.create_tensor([16, 16], dtype=pl.BF16)
+            return self.kernel(x, o)
+
+    after = _run(Before, BackendType.Ascend950)
+    pairs = _cast_pairs(after)
+    assert pairs == [("fp16", "fp32"), ("fp32", "bfloat16")], pairs
+
+
+def test_native_fp32_to_fp16_unchanged_on_a5():
+    """Already-native casts (and FIXPIPE-foldable ones) must not be rewritten."""
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore)
+        def kernel(
+            self,
+            x: pl.Tensor[[16, 16], pl.FP32],
+            out: pl.Out[pl.Tensor[[16, 16], pl.FP16]],
+        ) -> pl.Tensor[[16, 16], pl.FP16]:
+            t: pl.Tile[[16, 16], pl.FP32] = pl.load(x, [0, 0], [16, 16])
+            c: pl.Tile[[16, 16], pl.FP16] = pl.tile.cast(t, target_type=pl.FP16, mode="rint")
+            out_t: pl.Tensor[[16, 16], pl.FP16] = pl.store(c, [0, 0], out)
+            return out_t
+
+        @pl.function
+        def main(self, x: pl.Tensor[[16, 16], pl.FP32]) -> pl.Tensor[[16, 16], pl.FP16]:
+            o: pl.Tensor[[16, 16], pl.FP16] = pl.create_tensor([16, 16], dtype=pl.FP16)
+            return self.kernel(x, o)
+
+    after = _run(Before, BackendType.Ascend950)
+    pairs = _cast_pairs(after)
+    assert pairs == [("fp32", "fp16")], pairs
+    ir.assert_structural_equal(after, Before)
+
+
+def test_idempotent_on_already_bridged_chain():
+    """Hand-written I32→FP32→FP16 stays unchanged (each hop already native)."""
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore)
+        def kernel(
+            self,
+            x: pl.Tensor[[16, 16], pl.INT32],
+            out: pl.Out[pl.Tensor[[16, 16], pl.FP16]],
+        ) -> pl.Tensor[[16, 16], pl.FP16]:
+            t: pl.Tile[[16, 16], pl.INT32] = pl.load(x, [0, 0], [16, 16])
+            m: pl.Tile[[16, 16], pl.FP32] = pl.tile.cast(t, target_type=pl.FP32, mode="round")
+            c: pl.Tile[[16, 16], pl.FP16] = pl.tile.cast(m, target_type=pl.FP16, mode="round")
+            out_t: pl.Tensor[[16, 16], pl.FP16] = pl.store(c, [0, 0], out)
+            return out_t
+
+        @pl.function
+        def main(self, x: pl.Tensor[[16, 16], pl.INT32]) -> pl.Tensor[[16, 16], pl.FP16]:
+            o: pl.Tensor[[16, 16], pl.FP16] = pl.create_tensor([16, 16], dtype=pl.FP16)
+            return self.kernel(x, o)
+
+    after = _run(Before, BackendType.Ascend950)
+    assert _cast_pairs(after) == [("int32", "fp32"), ("fp32", "fp16")]
+    ir.assert_structural_equal(after, Before)


### PR DESCRIPTION
## Summary

WIP stack for DeepSeek V4 (MXFP8/MXFP4) on Ascend950 (A5). Rebased onto current `main` (post-#2100).

### Included (unique to this PR)

1. **LegalizeTileCast** — expand unsupported `tile.cast` dtype pairs into native cast chains before AutoTileMatmulL0.
2. **A5 gather** — full-tile flat-index lowering for `tensor.gather`, plus materialize strided `tile.slice` sources before that path.
3. **AutoTile Vec→Mat staging** — when matmul is already L0-sized but LHS is still Vec-resident, insert `tile.move`→Mat (`BuildStageOnlyVecLhs`) so ExpandMixedKernel sees a proper V→C boundary (Hadamard / fused cast→matmul Left).

### Intentionally removed / not in this PR

- **#2100 already merged**: layout-aware same-addr `tile.move` elision + Vec-only ND↔NZ MemoryReuse gate. Do not re-land codegen elide or the wider `AreStorageLayoutsCompatible` gate (that caused Left overflow on `fits_l0c_split_k`).
- **VF-fusion / simpler fork pin**: outdated PR description; not part of the rebased commits (`runtime` follows main).

## Test plan

- [x] `pytest tests/ut/ir/transforms/test_legalize_tile_cast.py`
- [x] `pytest tests/ut/ir/transforms/test_auto_tile_matmul_l0.py`
- [x] `pytest tests/ut/ir/transforms/test_memory_reuse.py::TestStorageLayoutReuseGate` (still #2100 Vec-only)
- [x] gather-related UT filter (`-k gather ...`)
- [ ] CI full suite
- [ ] Optional board: `decode_sparse_attn.py` fused (no `--split-cast-matmul`) to confirm no #2100 regression
