### PR TITLE
fix(language): preserve Call attrs when an annotation overrides the call type

### DIFF
--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -1319,8 +1319,17 @@ class ASTParser:
                 or not _types_match(value_expr.type, override_type)
             )
         ):
+            # Carry attrs through the rebuild: a forward-referenced callee has no
+            # known return type, so the annotation always overrides it and every
+            # call attr (arg_directions, arg_direction_overrides, dump_vars, ...)
+            # would otherwise be silently dropped.
             value_expr = ir.Call(
-                value_expr.op, value_expr.args, value_expr.kwargs, override_type, value_expr.span
+                value_expr.op,
+                value_expr.args,
+                value_expr.kwargs,
+                value_expr.attrs,
+                override_type,
+                value_expr.span,
             )
 
         # Reuse existing Var on reassignment (override_type is intentionally

--- a/tests/ut/language/parser/test_call_arg_directions_dsl.py
+++ b/tests/ut/language/parser/test_call_arg_directions_dsl.py
@@ -378,6 +378,94 @@ class Prog:
 
 
 # ---------------------------------------------------------------------------
+# Forward-referenced callees
+# ---------------------------------------------------------------------------
+
+
+class TestForwardReferencedCallee:
+    """``attrs={...}`` survives a call to a function declared later in the class.
+
+    Regression: an annotated assignment whose call has a *more precise* annotated
+    type than the inferred one rebuilds the ``ir.Call`` to carry the annotation.
+    That rebuild used the ``Call(op, args, kwargs, type, span)`` overload, which
+    has no ``attrs`` slot — so every attr was silently dropped.
+
+    A forward-referenced callee hits this every time: the parser fills
+    ``gvar_to_func`` incrementally in declaration order, so a callee declared
+    *later* is still unknown, the call's return type infers to ``UnknownType``,
+    the annotation always overrides it, and the rebuild fired. The result was a
+    call with ``arg_directions`` / ``arg_direction_overrides`` silently missing —
+    which also broke print -> reparse for any program whose call graph cannot be
+    emitted in dependency order (e.g. mutually recursive Group wrappers).
+    """
+
+    @staticmethod
+    def _program(callee_first: bool) -> str:
+        kernel = """    @pl.function(type=pl.FunctionType.InCore)
+    def kernel(
+        self,
+        x: pl.Tensor[[64], pl.FP32],
+        out: pl.Out[pl.Tensor[[64], pl.FP32]],
+    ) -> pl.Tensor[[64], pl.FP32]:
+        t: pl.Tile[[64], pl.FP32] = pl.load(x, [0], [64])
+        ret: pl.Tensor[[64], pl.FP32] = pl.store(t, [0], out)
+        return ret
+"""
+        main = """    @pl.function
+    def main(
+        self,
+        x: pl.Tensor[[64], pl.FP32],
+        dst: pl.Tensor[[64], pl.FP32],
+    ) -> pl.Tensor[[64], pl.FP32]:
+        r: pl.Tensor[[64], pl.FP32] = self.kernel(
+            x, dst, attrs={"arg_directions": [pl.adir.input, pl.adir.output_existing]}
+        )
+        return r
+"""
+        body = (kernel + "\n" + main) if callee_first else (main + "\n" + kernel)
+        return "import pypto.language as pl\n\n@pl.program\nclass Prog:\n" + body
+
+    @pytest.mark.parametrize("callee_first", [True, False], ids=["backward_ref", "forward_ref"])
+    def test_attrs_survive_regardless_of_declaration_order(self, callee_first: bool):
+        prog = pl.parse(self._program(callee_first))
+        call = _user_calls(prog, "kernel")[0]
+        assert list(call.arg_directions) == [
+            ir.ArgDirection.Input,
+            ir.ArgDirection.OutputExisting,
+        ]
+
+    def test_no_dep_override_attr_survives_forward_reference(self):
+        """The same rebuild must not drop the ``pl.no_dep`` marker attr either."""
+        code = """
+import pypto.language as pl
+
+@pl.program
+class Prog:
+    @pl.function
+    def main(
+        self,
+        x: pl.Tensor[[64], pl.FP32],
+        dst: pl.Tensor[[64], pl.FP32],
+    ) -> pl.Tensor[[64], pl.FP32]:
+        r: pl.Tensor[[64], pl.FP32] = self.kernel(x, pl.no_dep(dst))
+        return r
+
+    @pl.function(type=pl.FunctionType.InCore)
+    def kernel(
+        self,
+        x: pl.Tensor[[64], pl.FP32],
+        out: pl.Out[pl.Tensor[[64], pl.FP32]],
+    ) -> pl.Tensor[[64], pl.FP32]:
+        t: pl.Tile[[64], pl.FP32] = pl.load(x, [0], [64])
+        ret: pl.Tensor[[64], pl.FP32] = pl.store(t, [0], out)
+        return ret
+"""
+        prog = pl.parse(code)
+        call = _user_calls(prog, "kernel")[0]
+        assert call.attrs["arg_direction_overrides"] == [1]
+
+
+# ---------------------------------------------------------------------------
 # End-to-end round-trip
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

The DSL parser silently dropped **every attr** on a call to a function declared *later* in the same `@pl.program` class.

An annotated assignment whose call type is less precise than the annotation rebuilds the `Call` to carry the annotated type (`ast_parser.py`, `visit_AnnAssign`). That rebuild used the `Call(op, args, kwargs, type, span)` overload — which has no `attrs` slot — so the attrs were simply not carried over.

A forward-referenced callee hits this on *every* call: `gvar_to_func` is filled incrementally in declaration order, so a callee declared below the caller is still unknown → the call's return type infers to `UnknownType` → the annotation always overrides it → the rebuild fires.

Two programs differing only in the order of the two `def`s therefore parsed differently:

```python
r: pl.Tensor[[64], pl.FP32] = self.kernel(
    x, dst, attrs={"arg_directions": [pl.adir.input, pl.adir.output_existing]}
)
```

| declaration order | parsed result |
| ----------------- | ------------- |
| `kernel` above `main` (backward ref) | `attrs=['arg_directions']`, `dirs=[Input, OutputExisting]` |
| `kernel` below `main` (forward ref) | `attrs=[]`, `dirs=[]` — silently empty |

### Impact

Everything carried in `Call.attrs` was affected on a forward-referenced call, not just `arg_directions`:

- `arg_direction_overrides` — a user's `pl.no_dep(arg)` was silently ignored, so `DeriveCallDirections` had nothing to override and the slot took the very dependency the user opted out of.
- `dump_vars` — a requested `pl.dump_tag` / `dumps=` silently did not dump.
- `device` — the per-dispatch device subset was lost.

It also broke `print -> reparse` for any program whose call graph cannot be emitted callee-first — e.g. mutually recursive Group wrappers, where whichever wrapper is printed first loses its call attrs on reparse.

## Fix

Carry `attrs` through the rebuild by using the attrs-taking overload, matching what the sibling rebuild on the tile-subscript path already does:

```python
 value_expr = ir.Call(
-    value_expr.op, value_expr.args, value_expr.kwargs, override_type, value_expr.span
+    value_expr.op,
+    value_expr.args,
+    value_expr.kwargs,
+    value_expr.attrs,   # <- was dropped
+    override_type,
+    value_expr.span,
 )
```

`Submit` is unaffected: it derives from `Expr`, not `Call`, so `isinstance(expr, ir.Call)` never matches a `Submit` and this path cannot lower one (pass-submit-awareness rule 3).

## Testing

New `TestForwardReferencedCallee` in `tests/ut/language/parser/test_call_arg_directions_dsl.py`:

- `test_attrs_survive_regardless_of_declaration_order` — parametrized `backward_ref` / `forward_ref` over the *same* program, so the test pins the asymmetry itself.
- `test_no_dep_override_attr_survives_forward_reference` — the `pl.no_dep` marker attr survives too.

Both were confirmed to **fail without the fix** (`forward_ref` fails, `backward_ref` passes) and pass with it.

- [x] Full unit suite green: 7198 passed, 2 skipped
- [x] `ruff check` / `ruff format` / pyright / header + english-only lints clean