### PR TITLE
feat(runtime): Allow inherited immutable host tensors

### DIFF
--- a/docs/en/user/00-getting_started.md
+++ b/docs/en/user/00-getting_started.md
@@ -446,13 +446,12 @@ dispatches the same program many times (e.g. a generate loop), call
 `compiled.prepare()` once to get a `DistributedWorker` handle that runs setup
 once and dispatches many times on the same worker.
 
-Per-call IO buffers (inputs **and** outputs) are **shared-memory host tensors
-allocated before `prepare()`** and reused in place — the forked chip worker
-reads/writes them through the inherited mapping, so you read the output straight
-back from the tensor. Large static weights are uploaded once to a worker-resident
-`DeviceTensor` via `rt.alloc_tensor` (its `init` source must also be a pre-`prepare`
-shared tensor) and mixed in. A non-shared host tensor (or one allocated after
-`prepare()`) is rejected — the chip worker would not see it.
+Mutable per-call IO buffers are **shared-memory host tensors allocated before `prepare()`** and reused
+in place, so child writes are visible to the parent. Immutable inputs may remain ordinary contiguous
+CPU tensors when the same objects are passed to `DistributedWorker(..., inherited_host_tensors=[...])`
+before fork; they are retained and read through inherited copy-on-write mappings. This exception is
+input-only: outputs, in-place tensors, and unregistered non-shared tensors are rejected. Large static
+weights may be uploaded once via `rt.alloc_tensor`; its `init` source must still be pre-`prepare()` shared.
 
 ```python
 compiled = ir.compile(MyDistributedProgram)

--- a/docs/en/user/00-getting_started.md
+++ b/docs/en/user/00-getting_started.md
@@ -448,8 +448,8 @@ once and dispatches many times on the same worker.
 
 Mutable per-call IO buffers are **shared-memory host tensors allocated before `prepare()`** and reused
 in place, so child writes are visible to the parent. Immutable inputs may remain ordinary contiguous
-CPU tensors when the same objects are passed to `compiled.prepare(inherited_host_tensors=[...])` before
-fork; they are retained and read through inherited copy-on-write mappings. This exception is
+CPU tensors when the same objects are passed to `DistributedWorker(..., inherited_host_tensors=[...])`
+before fork; they are retained and read through inherited copy-on-write mappings. This exception is
 input-only: outputs, in-place tensors, and unregistered non-shared tensors are rejected. Large static
 weights may be uploaded once via `rt.alloc_tensor`; its `init` source must still be pre-`prepare()` shared.
 

--- a/docs/en/user/00-getting_started.md
+++ b/docs/en/user/00-getting_started.md
@@ -448,8 +448,8 @@ once and dispatches many times on the same worker.
 
 Mutable per-call IO buffers are **shared-memory host tensors allocated before `prepare()`** and reused
 in place, so child writes are visible to the parent. Immutable inputs may remain ordinary contiguous
-CPU tensors when the same objects are passed to `DistributedWorker(..., inherited_host_tensors=[...])`
-before fork; they are retained and read through inherited copy-on-write mappings. This exception is
+CPU tensors when the same objects are passed to `compiled.prepare(inherited_host_tensors=[...])` before
+fork; they are retained and read through inherited copy-on-write mappings. This exception is
 input-only: outputs, in-place tensors, and unregistered non-shared tensors are rejected. Large static
 weights may be uploaded once via `rt.alloc_tensor`; its `init` source must still be pre-`prepare()` shared.
 

--- a/docs/zh-cn/user/00-getting_started.md
+++ b/docs/zh-cn/user/00-getting_started.md
@@ -419,11 +419,11 @@ compiled(x, weight, out)                       # weight：无 H2D/D2H 拷贝
 对反复 dispatch 同一程序的常驻服务（如 generate 循环），可调用一次 `compiled.prepare()` 得到
 一个 `DistributedWorker` 句柄：setup 只做一次，多次 dispatch 复用同一个 worker。
 
-per-call 的 IO buffer（输入**和**输出）是**在 `prepare()` 之前分配的共享内存 host 张量**，
-原地复用 —— fork 出的 chip worker 通过继承的映射读写它们，所以输出直接从该张量读回。大块静态
-权重则用 `rt.alloc_tensor` 一次性上传到 worker 常驻的 `DeviceTensor`（其 `init` 源同样必须是
-`prepare()` 之前共享的张量），混合传入。非共享的 host 张量（或 `prepare()` 之后才分配的）会被拒绝
-—— chip worker 看不到它。
+可变的 per-call IO buffer 是**在 `prepare()` 之前分配的共享内存 host 张量**并原地复用，这样子进程的写入
+对父进程可见。不可变输入也可以保留为普通的 CPU 连续张量：必须在 fork 前将同一个对象传给
+`DistributedWorker(..., inherited_host_tensors=[...])`，runtime 会保留其引用并通过继承的写时复制映射读取。
+该例外仅适用于输入；输出、原地修改张量以及未注册的非共享张量仍会被拒绝。大块静态权重也可以用
+`rt.alloc_tensor` 一次性上传，但其 `init` 源仍必须是 `prepare()` 之前分配的共享张量。
 
 ```python
 compiled = ir.compile(MyDistributedProgram)

--- a/docs/zh-cn/user/00-getting_started.md
+++ b/docs/zh-cn/user/00-getting_started.md
@@ -421,7 +421,7 @@ compiled(x, weight, out)                       # weight：无 H2D/D2H 拷贝
 
 可变的 per-call IO buffer 是**在 `prepare()` 之前分配的共享内存 host 张量**并原地复用，这样子进程的写入
 对父进程可见。不可变输入也可以保留为普通的 CPU 连续张量：必须在 fork 前将同一个对象传给
-`DistributedWorker(..., inherited_host_tensors=[...])`，runtime 会保留其引用并通过继承的写时复制映射读取。
+`compiled.prepare(inherited_host_tensors=[...])`，runtime 会保留其引用并通过继承的写时复制映射读取。
 该例外仅适用于输入；输出、原地修改张量以及未注册的非共享张量仍会被拒绝。大块静态权重也可以用
 `rt.alloc_tensor` 一次性上传，但其 `init` 源仍必须是 `prepare()` 之前分配的共享张量。
 

--- a/docs/zh-cn/user/00-getting_started.md
+++ b/docs/zh-cn/user/00-getting_started.md
@@ -421,7 +421,7 @@ compiled(x, weight, out)                       # weight：无 H2D/D2H 拷贝
 
 可变的 per-call IO buffer 是**在 `prepare()` 之前分配的共享内存 host 张量**并原地复用，这样子进程的写入
 对父进程可见。不可变输入也可以保留为普通的 CPU 连续张量：必须在 fork 前将同一个对象传给
-`compiled.prepare(inherited_host_tensors=[...])`，runtime 会保留其引用并通过继承的写时复制映射读取。
+`DistributedWorker(..., inherited_host_tensors=[...])`，runtime 会保留其引用并通过继承的写时复制映射读取。
 该例外仅适用于输入；输出、原地修改张量以及未注册的非共享张量仍会被拒绝。大块静态权重也可以用
 `rt.alloc_tensor` 一次性上传，但其 `init` 源仍必须是 `prepare()` 之前分配的共享张量。
 

--- a/python/pypto/ir/distributed_compiled_program.py
+++ b/python/pypto/ir/distributed_compiled_program.py
@@ -419,7 +419,6 @@ class DistributedCompiledProgram:
         extra_compiled: Sequence["DistributedCompiledProgram"] = (),
         callbacks: dict[str, Callable[..., Any]] | None = None,
         sub_worker_overrides: dict[str, Callable[..., Any]] | None = None,
-        inherited_host_tensors: Sequence[torch.Tensor] | None = None,
     ) -> "DistributedWorker":
         """Prepare a reusable L3 execution handle (setup once, dispatch many).
 
@@ -434,11 +433,10 @@ class DistributedCompiledProgram:
         Per-call inputs and outputs are reused-in-place **shared-memory** host
         ``torch.Tensor`` buffers (allocated before ``prepare()``) and/or
         worker-resident ``DeviceTensor`` / simpler ``Tensor`` arguments.
-        Immutable, contiguous CPU inputs may instead be registered through
-        ``inherited_host_tensors`` before the fork. Other non-shared host
-        tensors are rejected. The convenience host-to-device upload of
-        arbitrary host ``torch.Tensor`` inputs is only available on the
-        one-shot ``compile(...)(*args)`` / ``execute_distributed`` path.
+        Non-shared host tensors are rejected (the forked chip worker cannot see
+        a buffer allocated after the fork). The convenience host-to-device
+        upload of arbitrary host ``torch.Tensor`` inputs is only available on
+        the one-shot ``compile(...)(*args)`` / ``execute_distributed`` path.
 
         Args:
             config: Optional run configuration (reserved; currently unused).
@@ -458,10 +456,6 @@ class DistributedCompiledProgram:
                 raises ``ValueError``. In multi-program mode the callbacks apply
                 to every prepared program.
             sub_worker_overrides: Deprecated alias for ``callbacks``.
-            inherited_host_tensors: Immutable contiguous CPU tensors to retain
-                before the worker fork. Registered tensors may be dispatched
-                only as input parameters; outputs and in-place tensors still
-                require shared memory.
 
         Returns:
             A :class:`DistributedWorker`; use it as a context manager or call
@@ -474,7 +468,6 @@ class DistributedCompiledProgram:
             config,
             callbacks=callbacks,
             sub_worker_overrides=sub_worker_overrides,
-            inherited_host_tensors=inherited_host_tensors,
         )
 
     @staticmethod

--- a/python/pypto/ir/distributed_compiled_program.py
+++ b/python/pypto/ir/distributed_compiled_program.py
@@ -419,6 +419,7 @@ class DistributedCompiledProgram:
         extra_compiled: Sequence["DistributedCompiledProgram"] = (),
         callbacks: dict[str, Callable[..., Any]] | None = None,
         sub_worker_overrides: dict[str, Callable[..., Any]] | None = None,
+        inherited_host_tensors: Sequence[torch.Tensor] | None = None,
     ) -> "DistributedWorker":
         """Prepare a reusable L3 execution handle (setup once, dispatch many).
 
@@ -433,10 +434,11 @@ class DistributedCompiledProgram:
         Per-call inputs and outputs are reused-in-place **shared-memory** host
         ``torch.Tensor`` buffers (allocated before ``prepare()``) and/or
         worker-resident ``DeviceTensor`` / simpler ``Tensor`` arguments.
-        Non-shared host tensors are rejected (the forked chip worker cannot see
-        a buffer allocated after the fork). The convenience host-to-device
-        upload of arbitrary host ``torch.Tensor`` inputs is only available on
-        the one-shot ``compile(...)(*args)`` / ``execute_distributed`` path.
+        Immutable, contiguous CPU inputs may instead be registered through
+        ``inherited_host_tensors`` before the fork. Other non-shared host
+        tensors are rejected. The convenience host-to-device upload of
+        arbitrary host ``torch.Tensor`` inputs is only available on the
+        one-shot ``compile(...)(*args)`` / ``execute_distributed`` path.
 
         Args:
             config: Optional run configuration (reserved; currently unused).
@@ -456,6 +458,10 @@ class DistributedCompiledProgram:
                 raises ``ValueError``. In multi-program mode the callbacks apply
                 to every prepared program.
             sub_worker_overrides: Deprecated alias for ``callbacks``.
+            inherited_host_tensors: Immutable contiguous CPU tensors to retain
+                before the worker fork. Registered tensors may be dispatched
+                only as input parameters; outputs and in-place tensors still
+                require shared memory.
 
         Returns:
             A :class:`DistributedWorker`; use it as a context manager or call
@@ -468,6 +474,7 @@ class DistributedCompiledProgram:
             config,
             callbacks=callbacks,
             sub_worker_overrides=sub_worker_overrides,
+            inherited_host_tensors=inherited_host_tensors,
         )
 
     @staticmethod

--- a/python/pypto/runtime/distributed_runner.py
+++ b/python/pypto/runtime/distributed_runner.py
@@ -866,6 +866,12 @@ class DistributedWorker(Worker):
     (its ``init`` source must likewise be a pre-``prepare`` shared tensor) and
     mixed in. This mirrors the runtime's ``child_memory`` example.
 
+    Immutable input tensors may instead be supplied through
+    ``inherited_host_tensors``. They are retained before the chip workers fork
+    and subsequently read through their inherited copy-on-write mappings. This
+    path is input-only: outputs and in-place tensors still require shared memory
+    so child writes remain visible to the parent.
+
     ``callbacks`` binds a caller-supplied callable to a SubWorker by name — e.g.
     a real sampling closure. Abstract SubWorkers (declared with a ``...`` body)
     are runtime-bound callback points and MUST be supplied here; a missing
@@ -911,10 +917,25 @@ class DistributedWorker(Worker):
         *,
         callbacks: dict[str, Callable[..., Any]] | None = None,
         sub_worker_overrides: dict[str, Callable[..., Any]] | None = None,
+        inherited_host_tensors: Sequence[torch.Tensor] | None = None,
     ) -> None:
         super().__init__()  # initialize Worker ABC state (_owned_tensors)
         del config  # reserved for future per-runtime overrides
         callbacks = _coalesce_callbacks(callbacks, sub_worker_overrides)
+        inherited = tuple(inherited_host_tensors) if inherited_host_tensors is not None else ()
+        for tensor in inherited:
+            if not isinstance(tensor, torch.Tensor):
+                raise TypeError(
+                    "DistributedWorker inherited_host_tensors entries must be torch.Tensor objects, "
+                    f"got {type(tensor).__name__}."
+                )
+            if tensor.device.type != "cpu" or not tensor.is_contiguous():
+                raise ValueError(
+                    "DistributedWorker inherited_host_tensors must be contiguous CPU tensors; "
+                    f"got device={tensor.device} shape={tuple(tensor.shape)}."
+                )
+        self._inherited_host_tensors = inherited
+        self._inherited_host_tensor_ids = {id(tensor) for tensor in inherited}
 
         programs = list(compiled) if isinstance(compiled, Sequence) else [compiled]
         if not programs:
@@ -1358,12 +1379,16 @@ class DistributedWorker(Worker):
                 _validate_device_tensor(arg, info)
             elif isinstance(arg, torch.Tensor):
                 if not arg.is_shared():
-                    raise TypeError(
-                        f"Parameter {info.name!r}: a host torch.Tensor passed to a DistributedWorker "
-                        f"must be shared memory allocated BEFORE prepare() (call .share_memory_() and "
-                        f"reuse the same buffer across dispatches), so the forked chip worker can see "
-                        f"it. Got a non-shared tensor."
-                    )
+                    if id(arg) not in self._inherited_host_tensor_ids:
+                        raise TypeError(
+                            f"Parameter {info.name!r}: a non-shared host tensor must be registered "
+                            "through inherited_host_tensors before the chip workers fork."
+                        )
+                    if info.direction.name != "In":
+                        raise TypeError(
+                            f"Parameter {info.name!r}: inherited host tensors are input-only; "
+                            f"direction {info.direction.name} requires shared memory."
+                        )
             elif not _is_simpler_tensor(arg):
                 raise TypeError(
                     f"DistributedWorker parameter {info.name!r} got {type(arg).__name__}; expected a "
@@ -1417,6 +1442,8 @@ class DistributedWorker(Worker):
             handle._mark_closed()
         self._handles.clear()
         self._w.close()
+        self._inherited_host_tensors = ()
+        self._inherited_host_tensor_ids.clear()
 
     def __enter__(self) -> DistributedWorker:
         return self

--- a/python/pypto/runtime/distributed_runner.py
+++ b/python/pypto/runtime/distributed_runner.py
@@ -26,6 +26,8 @@ from typing import TYPE_CHECKING, Any
 import numpy as np  # pyright: ignore[reportMissingImports]
 import torch
 
+from pypto.pypto_core.ir import ParamDirection
+
 from .device_tensor import DeviceTensor, StackedDeviceTensor
 from .runtime_base import Worker
 
@@ -1384,10 +1386,10 @@ class DistributedWorker(Worker):
                             f"Parameter {info.name!r}: a non-shared host tensor must be registered "
                             "through inherited_host_tensors before the chip workers fork."
                         )
-                    if info.direction.name != "In":
+                    if info.direction != ParamDirection.In:
                         raise TypeError(
                             f"Parameter {info.name!r}: inherited host tensors are input-only; "
-                            f"direction {info.direction.name} requires shared memory."
+                            f"direction {info.direction} requires shared memory."
                         )
             elif not _is_simpler_tensor(arg):
                 raise TypeError(

--- a/tests/ut/runtime/test_distributed_worker.py
+++ b/tests/ut/runtime/test_distributed_worker.py
@@ -986,16 +986,10 @@ class TestMultiProgram:
 
         primary = _fake_compiled([_param("a", [4])], [])
         extra = _fake_compiled([_param("b", [8])], [])
-        inherited = [torch.zeros(4)]
         with patch("pypto.runtime.distributed_runner.DistributedWorker") as fake_worker:
-            DistributedCompiledProgram.prepare(
-                primary,
-                extra_compiled=[extra],
-                inherited_host_tensors=inherited,
-            )
+            DistributedCompiledProgram.prepare(primary, extra_compiled=[extra])
         # prepare() delegates to DistributedWorker([primary, *extra_compiled], ...).
         assert fake_worker.call_args.args[0] == [primary, extra]
-        assert fake_worker.call_args.kwargs["inherited_host_tensors"] is inherited
 
     def test_empty_sequence_raises(self, patched_setup):
         with pytest.raises(ValueError, match="at least one compiled program"):

--- a/tests/ut/runtime/test_distributed_worker.py
+++ b/tests/ut/runtime/test_distributed_worker.py
@@ -202,9 +202,45 @@ class TestPerCallValidation:
     def test_rejects_non_shared_host_torch_tensor(self, patched_setup):
         compiled = _fake_compiled([_param("a", [128, 128]), _param("b", [128, 128])], [])
         rt = DistributedWorker(compiled)
-        with pytest.raises(TypeError, match="shared memory"):
+        with pytest.raises(TypeError, match="inherited_host_tensors"):
             rt(torch.zeros(128, 128), DeviceTensor(0x2000, (128, 128), torch.float32))
         rt.close()
+
+    def test_accepts_registered_prefork_input_tensor(self, patched_setup):
+        compiled = _fake_compiled([_param("weight", [128, 128])], [])
+        weight = torch.zeros(128, 128, dtype=torch.float32)
+
+        rt = DistributedWorker(compiled, inherited_host_tensors=[weight])
+        rt(weight)
+
+        tensors = patched_setup["dispatch"].call_args.args[2]
+        assert tensors["weight"] is weight
+        rt.close()
+
+    @pytest.mark.parametrize("direction", [ParamDirection.Out, ParamDirection.InOut])
+    def test_rejects_registered_prefork_mutable_tensor(self, patched_setup, direction):
+        compiled = _fake_compiled([_param("buffer", [128, 128], direction)], [])
+        buffer = torch.zeros(128, 128, dtype=torch.float32)
+        rt = DistributedWorker(compiled, inherited_host_tensors=[buffer])
+
+        with pytest.raises(TypeError, match="input-only"):
+            rt(buffer)
+
+        rt.close()
+
+    @pytest.mark.parametrize(
+        ("weight", "expected_exception"),
+        [
+            (object(), TypeError),
+            (torch.zeros(128, 128, dtype=torch.float32).t(), ValueError),
+            (torch.empty(1, device="meta"), ValueError),
+        ],
+    )
+    def test_rejects_invalid_prefork_tensor_registration(self, patched_setup, weight, expected_exception):
+        compiled = _fake_compiled([_param("weight", [128, 128])], [])
+
+        with pytest.raises(expected_exception, match="torch.Tensor|contiguous CPU"):
+            DistributedWorker(compiled, inherited_host_tensors=[weight])
 
     def test_scalar_param_forwarded_as_is(self, patched_setup):
         # Scalar params (shape=None, e.g. seq_len) bypass tensor validation and

--- a/tests/ut/runtime/test_distributed_worker.py
+++ b/tests/ut/runtime/test_distributed_worker.py
@@ -239,7 +239,7 @@ class TestPerCallValidation:
     def test_rejects_invalid_prefork_tensor_registration(self, patched_setup, weight, expected_exception):
         compiled = _fake_compiled([_param("weight", [128, 128])], [])
 
-        with pytest.raises(expected_exception, match="torch.Tensor|contiguous CPU"):
+        with pytest.raises(expected_exception, match=r"torch\.Tensor|contiguous CPU"):
             DistributedWorker(compiled, inherited_host_tensors=[weight])
 
     def test_scalar_param_forwarded_as_is(self, patched_setup):
@@ -986,10 +986,16 @@ class TestMultiProgram:
 
         primary = _fake_compiled([_param("a", [4])], [])
         extra = _fake_compiled([_param("b", [8])], [])
+        inherited = [torch.zeros(4)]
         with patch("pypto.runtime.distributed_runner.DistributedWorker") as fake_worker:
-            DistributedCompiledProgram.prepare(primary, extra_compiled=[extra])
+            DistributedCompiledProgram.prepare(
+                primary,
+                extra_compiled=[extra],
+                inherited_host_tensors=inherited,
+            )
         # prepare() delegates to DistributedWorker([primary, *extra_compiled], ...).
         assert fake_worker.call_args.args[0] == [primary, extra]
+        assert fake_worker.call_args.kwargs["inherited_host_tensors"] is inherited
 
     def test_empty_sequence_raises(self, patched_setup):
         with pytest.raises(ValueError, match="at least one compiled program"):


### PR DESCRIPTION
## Summary

This PR adds support for passing immutable host tensors to `DistributedWorker` through inherited process memory.

It is the PyPTO runtime companion for [pypto-serving#70](https://github.com/hw-native-sys/pypto-serving/pull/70).

## Changes

- Add the `inherited_host_tensors` argument to `DistributedWorker`.
- Retain registered CPU tensors before worker processes are forked.
- Allow registered tensors to be used as read-only `In` arguments without shared-memory staging.
- Continue requiring shared memory for `Out` and `InOut` arguments.
- Validate that registered objects are contiguous CPU tensors.
- Add unit tests for supported and rejected cases.
- Document the behavior in both English and Chinese.

## Motivation

Large immutable serving weights can be inherited by forked worker processes through copy-on-write mappings. This avoids copying those tensors into shared memory before worker creation.

## Testing

- Focused runtime unit tests: 88 passed
- Full unit test suite: 7166 passed, 33 skipped
- `ruff check` passed
- `ruff format --check` passed
- `cmake --build build --parallel` passed