### PR TITLE
fix(language): Fold tensor.dim onto its dyn-dim symbol; add Qwen3 prefill CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -494,7 +494,7 @@ jobs:
           checkout-path: lib-checkout
           pto-isa-commit: ${{ needs.toolchain.outputs.pto_isa_commit }}
 
-      - name: Clone pypto-lib (Qwen3-14B decode)
+      - name: Clone pypto-lib (Qwen3-14B + DeepSeek-V4 models)
         # $GITHUB_WORKSPACE/pypto-lib is a sibling of lib-checkout, so
         # actions/checkout won't clean it on a persistent self-hosted runner — a
         # leftover dir from a previous run makes `git clone` fail with
@@ -518,6 +518,19 @@ jobs:
           source activate.sh
           task-submit --device "$DEVICE_ID" --timeout 3600 --max-time 1800 \
             --run "source $GITHUB_WORKSPACE/lib-checkout/activate.sh && cd $GITHUB_WORKSPACE/pypto-lib && python models/qwen3/14b/decode_fwd.py -p a2a3 -d \$TASK_DEVICE"
+
+      # Prefill exercises the dynamic-shape host path that decode does not: its
+      # token axis is a `pl.dynamic()` symbol, the per-layer temp is sized from
+      # `pl.tensor.dim(...)`, and the layer result is reassigned to the same
+      # loop-carried var. Regressions in cross-function dynamic-shape typing
+      # surface here (and only here) before they reach pypto-serving.
+      - name: Run pypto-lib Qwen3-14B prefill example
+        env:
+          PYTHONPATH: ${{ github.workspace }}/pypto-lib
+        run: |
+          source activate.sh
+          task-submit --device "$DEVICE_ID" --timeout 3600 --max-time 1800 \
+            --run "source $GITHUB_WORKSPACE/lib-checkout/activate.sh && cd $GITHUB_WORKSPACE/pypto-lib && python models/qwen3/14b/prefill_fwd.py -p a2a3 -d \$TASK_DEVICE"
 
       # NOTE: Qwen3-14B decode performance monitoring (L2-swimlane makespan +
       # perf_guard) lives in the daily_ci.yml `qwen3-perf` job, not here. Per-PR

--- a/docs/en/dev/codegen/01-orchestration_codegen.md
+++ b/docs/en/dev/codegen/01-orchestration_codegen.md
@@ -263,7 +263,7 @@ rt_submit_task(mixed_0, params_t0);
 | `tensor.slice` | `make_tensor_external(ptr + byte_offset, ...)` | Create view into existing tensor |
 | `tensor.transpose` | `Tensor xt = ext_x.transpose(axis1, axis2)` | Zero-copy metadata swap of two axes (lowers to runtime `Tensor::transpose`) |
 | `tensor.dim` (static) | `int64_t d0 = 16` | Constant dimension value |
-| `tensor.dim` (dynamic) | `int64_t d0 = (int64_t)orch_args.tensor(N).shapes[axis]` | Runtime dimension from ChipStorageTaskArgs. In an Orchestration body the parser folds it onto the declared extent instead — see below |
+| `tensor.dim` (dynamic) | `int64_t d0 = (int64_t)orch_args.tensor(N).ref().shapes[axis]` | Runtime dimension from ChipStorageTaskArgs. In an Orchestration body the parser folds it onto the declared extent instead — see below |
 
 ### Dynamic-dim symbols
 

--- a/docs/en/dev/codegen/01-orchestration_codegen.md
+++ b/docs/en/dev/codegen/01-orchestration_codegen.md
@@ -263,7 +263,31 @@ rt_submit_task(mixed_0, params_t0);
 | `tensor.slice` | `make_tensor_external(ptr + byte_offset, ...)` | Create view into existing tensor |
 | `tensor.transpose` | `Tensor xt = ext_x.transpose(axis1, axis2)` | Zero-copy metadata swap of two axes (lowers to runtime `Tensor::transpose`) |
 | `tensor.dim` (static) | `int64_t d0 = 16` | Constant dimension value |
-| `tensor.dim` (dynamic) | `int64_t d0 = (int64_t)orch_args.tensor(N).shapes[axis]` | Runtime dimension from ChipStorageTaskArgs |
+| `tensor.dim` (dynamic) | `int64_t d0 = (int64_t)orch_args.tensor(N).shapes[axis]` | Runtime dimension from ChipStorageTaskArgs. In an Orchestration body the parser folds it onto the declared extent instead — see below |
+
+### Dynamic-dim symbols
+
+A `pl.dynamic("M")` symbol names the runtime extent of whatever tensor argument
+declares it. In a kernel it is a type-level placeholder, but an Orchestration body
+may use it as a **value** — a loop bound, a `pl.create_tensor` extent, or a folded
+`pl.tensor.dim` — so each symbol the body references is defined once at entry, read
+from the descriptor of the first parameter declaring it:
+
+```cpp
+    // Dynamic-dim symbols (extent of the declaring argument)
+    int64_t M = (int64_t)orch_args.tensor(0).ref().shapes[0];
+```
+
+Only symbols the emitted body mentions get a definition; a symbol appearing solely
+in a parameter's type produces none (external tensor shapes are never printed).
+
+Because the symbol **is** the extent, the parser folds `pl.tensor.dim(x, i)` in an
+Orchestration body onto the extent `x`'s type already names — one runtime extent,
+one IR name. Reading it back would mint a second scalar that no analyzer can prove
+equal to the symbol, and every shape built from that copy would then disagree
+structurally with shapes built from the symbol. The fold is **Orchestration-only**:
+an Inline/InCore callee may be reached with a differently-shaped actual, so there
+`tensor.dim` stays a genuine runtime read.
 
 ## Complete Example
 

--- a/docs/zh-cn/dev/codegen/01-orchestration_codegen.md
+++ b/docs/zh-cn/dev/codegen/01-orchestration_codegen.md
@@ -256,7 +256,28 @@ rt_submit_task(mixed_0, params_t0);
 | `tensor.slice` | `make_tensor_external(ptr + byte_offset, ...)` | 创建现有张量的视图 |
 | `tensor.transpose` | `Tensor xt = ext_x.transpose(axis1, axis2)` | 零拷贝交换两个维度的元数据（lower 到运行时 `Tensor::transpose`） |
 | `tensor.dim`（静态） | `int64_t d0 = 16` | 编译时常量维度值 |
-| `tensor.dim`（动态） | `int64_t d0 = (int64_t)orch_args.tensor(N).shapes[axis]` | 从 ChipStorageTaskArgs 获取运行时维度 |
+| `tensor.dim`（动态） | `int64_t d0 = (int64_t)orch_args.tensor(N).shapes[axis]` | 从 ChipStorageTaskArgs 获取运行时维度。在编排（Orchestration）函数体内，解析器会将其折叠为已声明的 extent —— 见下文 |
+
+### 动态维度符号（Dynamic-dim symbols）
+
+`pl.dynamic("M")` 符号命名的是「声明它的那个张量实参」的运行时 extent。在 kernel 中它
+只是类型层面的占位符；但编排函数体可以把它当作**值**使用 —— 循环上界、`pl.create_tensor`
+的 extent，或折叠后的 `pl.tensor.dim`。因此函数体引用到的每个符号都会在入口处定义一次，
+从「首个声明该符号的参数」的描述符中读取：
+
+```cpp
+    // Dynamic-dim symbols (extent of the declaring argument)
+    int64_t M = (int64_t)orch_args.tensor(0).ref().shapes[0];
+```
+
+只有生成代码中真正出现的符号才会被定义；仅出现在参数类型中的符号不会产生定义
+（外部张量的 shape 从不会被打印）。
+
+由于符号**就是**该 extent，解析器会把编排函数体内的 `pl.tensor.dim(x, i)` 折叠为 `x`
+的类型已经命名的那个 extent —— 一个运行时 extent 只对应一个 IR 名字。若重新读取，会为
+同一个量再造出一个标量，而分析器无法证明它与该符号相等；由该副本构造出的所有 shape
+都会在结构上与由符号构造的 shape 不一致。该折叠**仅**适用于编排函数：Inline/InCore
+被调用方可能被传入形状不同的实参，因此在那里 `tensor.dim` 仍是真正的运行时读取。
 
 ## 完整示例
 

--- a/docs/zh-cn/dev/codegen/01-orchestration_codegen.md
+++ b/docs/zh-cn/dev/codegen/01-orchestration_codegen.md
@@ -256,7 +256,7 @@ rt_submit_task(mixed_0, params_t0);
 | `tensor.slice` | `make_tensor_external(ptr + byte_offset, ...)` | 创建现有张量的视图 |
 | `tensor.transpose` | `Tensor xt = ext_x.transpose(axis1, axis2)` | 零拷贝交换两个维度的元数据（lower 到运行时 `Tensor::transpose`） |
 | `tensor.dim`（静态） | `int64_t d0 = 16` | 编译时常量维度值 |
-| `tensor.dim`（动态） | `int64_t d0 = (int64_t)orch_args.tensor(N).shapes[axis]` | 从 ChipStorageTaskArgs 获取运行时维度。在编排（Orchestration）函数体内，解析器会将其折叠为已声明的 extent —— 见下文 |
+| `tensor.dim`（动态） | `int64_t d0 = (int64_t)orch_args.tensor(N).ref().shapes[axis]` | 从 ChipStorageTaskArgs 获取运行时维度。在编排（Orchestration）函数体内，解析器会将其折叠为已声明的 extent —— 见下文 |
 
 ### 动态维度符号（Dynamic-dim symbols）
 

--- a/python/pypto/debug/torch_codegen.py
+++ b/python/pypto/debug/torch_codegen.py
@@ -1241,6 +1241,35 @@ class TorchCodegen(_ir.IRVisitor):
         for _gv, func in program.functions.items():
             self.visit_function(func)
 
+    def _emit_dyn_dim_symbols(self, func: _ir.Function) -> None:
+        """Define the dyn-dim symbols this signature declares.
+
+        A ``pl.dynamic("M")`` symbol names the runtime extent of the argument
+        declaring it, and an Orchestration body may use it as a *value* — a folded
+        ``pl.tensor.dim``, a loop bound, a ``pl.create_tensor`` extent. Emitted as a
+        bare name it would simply be undefined at ``exec``, so read it from the
+        first parameter declaring it.
+
+        Orchestration only: a kernel is handed partial data for boundary tiles (see
+        the shape check above), so there a parameter's runtime shape is not the
+        extent its type declares.
+        """
+        if func.func_type != _ir.FunctionType.Orchestration:
+            return
+        defined: set[str] = set()
+        for param in func.params:
+            if not isinstance(param.type, _ir.TensorType):
+                continue
+            param_name = self._name_of(param)
+            for axis, extent in enumerate(param.type.shape):
+                if not isinstance(extent, _ir.Var):
+                    continue
+                name = self._name_of(extent)
+                if name == param_name or name in defined:
+                    continue
+                defined.add(name)
+                self._emit(f"{name} = {param_name}.shape[{axis}]")
+
     def visit_function(self, func: _ir.Function) -> None:
         # Keep names function-local. IR may reuse object ids across functions;
         # sharing maps at program scope can emit stale names.
@@ -1258,6 +1287,7 @@ class TorchCodegen(_ir.IRVisitor):
                 # InCore kernel params may receive partial data (boundary tiles),
                 # so only check dtype — not shape — for all function params.
                 self._emit_shape_dtype_check(self._name_of(p), p.type, shape=False)
+        self._emit_dyn_dim_symbols(func)
         n_before = len(self._lines)
         self.visit_stmt(func.body)
         if len(self._lines) == n_before:

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -591,6 +591,12 @@ class ASTParser:
         # ``pl.dump_tag`` only makes sense in Orchestration functions.
         self._func_type: ir.FunctionType = ir.FunctionType.Opaque
 
+        # Dyn-dim symbols (``pl.dynamic()`` Vars) the current signature declares as
+        # a bare extent of a tensor param, by ``Var.unique_id``; and the Python
+        # names bound directly to one of them rather than to a Let of their own
+        # (see ``_fold_tensor_dim``). Both are per-function; reset in parse_function.
+        self._param_dim_symbols: set[int] = set()
+
         # Current function's auto_scope flag (set during parse_function). When
         # True (default) the compiler owns AUTO scope placement, so a hand-placed
         # AUTO `with pl.scope()` is rejected; set False to take control. MANUAL
@@ -717,6 +723,7 @@ class ASTParser:
         # auto_scope rides in func_attrs (key "auto_scope"); absent ⇒ default True.
         self._func_auto_scope = bool((func_attrs or {}).get("auto_scope", True))
         self._func_type = func_type
+        self._param_dim_symbols = set()
         func_span = self.span_tracker.get_span(func_def)
 
         # Enter function scope
@@ -765,6 +772,15 @@ class ASTParser:
 
                 # Add parameter to function with direction
                 param_var = f.param(param_name, param_type, param_span, direction=param_direction)
+
+                # A bare ``pl.dynamic()`` Var in a tensor param's shape names that
+                # argument's runtime extent. Orchestration codegen defines exactly
+                # these symbols from the task-arg descriptors, which is what makes
+                # them usable as values — and what ``_fold_tensor_dim`` folds onto.
+                if isinstance(param_type, ir.TensorType):
+                    for extent in param_type.shape:
+                        if isinstance(extent, ir.Var):
+                            self._param_dim_symbols.add(extent.unique_id)
 
                 # Register in scope
                 self.scope_manager.define_var(param_name, param_var, allow_redef=True)
@@ -1353,6 +1369,28 @@ class ASTParser:
     ) -> ir.Var:
         """Assign to existing Var if possible, otherwise create a new let binding."""
         existing_var = self.scope_manager.lookup_var(var_name)
+
+        # ``n = pl.tensor.dim(x, 0)`` folded to a dyn-dim symbol (see
+        # ``_fold_tensor_dim``): bind the Python name straight to the symbol. A Let
+        # would copy it, and every shape later built from ``n`` would then carry the
+        # copy rather than the symbol — the aliasing the fold exists to remove.
+        # Both guards test the Var the name is bound to, never a parallel set of
+        # names: scopes are a stack, so a name-keyed alias set desyncs the moment a
+        # non-leaking scope rebinds the name and exits.
+        if (
+            override_type is None
+            and self._func_type == ir.FunctionType.Orchestration
+            and self._is_param_dim_symbol(value_expr)
+            and (existing_var is None or self._is_param_dim_symbol(existing_var))
+        ):
+            return value_expr
+
+        # The name is bound to a symbol, which is immutable — it names an argument's
+        # extent. Rebind the name to a fresh let rather than assigning *through* the
+        # alias into the symbol itself.
+        if self._is_param_dim_symbol(existing_var):
+            return self.builder.let(var_name, value_expr, type=override_type, span=span)
+
         if existing_var is not None and type(existing_var) is ir.Var and not self.scope_manager.strict_ssa:
             # Reject reassignment with a different type (#642).  Same Python
             # variable maps to the same Var node, so the type must match.
@@ -7019,12 +7057,92 @@ class ASTParser:
         """Parse tensor operation."""
         if op_name == "alloc":
             return self._parse_printed_alloc_call(call)
+        if op_name == "dim":
+            folded = self._fold_tensor_dim(call)
+            if folded is not None:
+                return folded
         # Prefer the DSL wrapper (owns type-checking + dispatch); fall back to
         # the IR-builder layer for pass-internal ops like ``gather_mask``
         # that are emitted by the printer but have no DSL wrapper.
         if hasattr(_dsl_tensor, op_name):
             return self._dispatch_op(_dsl_tensor, "pl.tensor", op_name, call)
         return self._dispatch_ir_builder_op(ir_op.tensor, "pl.tensor", op_name, call)
+
+    @staticmethod
+    def _static_int(node: ast.expr) -> int | None:
+        """Return the value of an integer literal AST node (``0``, ``-1``), else None."""
+        if isinstance(node, ast.Constant):
+            value = node.value
+            return value if isinstance(value, int) and not isinstance(value, bool) else None
+        if isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.USub):
+            inner = ASTParser._static_int(node.operand)
+            return None if inner is None else -inner
+        return None
+
+    def _is_param_dim_symbol(self, expr: Any) -> TypeGuard[ir.Var]:
+        """Whether ``expr`` is a dyn-dim symbol this signature declares (see __init__).
+
+        Takes ``Any``: a scope lookup can yield ``None`` or a ``str`` placeholder
+        (loop yields), and both must simply answer "no".
+        """
+        return isinstance(expr, ir.Var) and expr.unique_id in self._param_dim_symbols
+
+    def _fold_tensor_dim(self, call: ast.Call) -> ir.Expr | None:
+        """Fold ``pl.tensor.dim(x, i)`` onto the extent ``x``'s type already names.
+
+        A tensor's declared extent *is* its runtime extent, so reading it back
+        mints a *second* scalar for the same quantity, which nothing downstream can
+        prove equal to the symbol the tensor types carry. Shapes built from the copy
+        then disagree structurally with shapes built from the symbol — breaking, for
+        one, calls into a callee that declares that same symbol. Fold instead: one
+        runtime extent, one IR name.
+
+        Orchestration bodies only. That is where the symbol is a value: codegen
+        defines it there from the declaring param's task-arg descriptor. An
+        Inline/InCore callee's placeholder is not the caller's (``InlineFunctions``
+        does not substitute callee symbols, and the callee may be reached with a
+        statically-shaped actual), so there ``tensor.dim`` stays a runtime read.
+
+        Returns the folded extent, or None to emit ``tensor.dim`` as usual.
+        """
+        if self._func_type != ir.FunctionType.Orchestration:
+            return None
+        # The *tensor* argument must be a bare name — the generic dispatch re-parses
+        # the AST, so parsing a non-trivial argument here would emit its statements
+        # twice. The axis carries no such restriction, and every spelling the DSL
+        # accepts must fold: the printer normalizes them all to ``dim(x, 0)``, so a
+        # spelling that did not fold would fold on reparse and break the round-trip.
+        if len(call.args) == 2 and not call.keywords:
+            tensor_arg, axis_arg = call.args
+        elif len(call.args) == 1 and len(call.keywords) == 1 and call.keywords[0].arg == "axis":
+            tensor_arg, axis_arg = call.args[0], call.keywords[0].value
+        else:
+            return None
+        if not isinstance(tensor_arg, ast.Name):
+            return None
+        axis = self._static_int(axis_arg)
+        if axis is None:
+            # A named constant (``pl.tensor.dim(x, ROWS)``) is still a static axis.
+            evaluated, value = self.expr_evaluator.try_eval_expr(axis_arg)
+            if not evaluated or not isinstance(value, int) or isinstance(value, bool):
+                return None
+            axis = value
+        tensor_var = self.scope_manager.lookup_var(tensor_arg.id)
+        tensor_type = getattr(tensor_var, "type", None)
+        if not isinstance(tensor_type, ir.TensorType):
+            return None
+        shape = tensor_type.shape
+        if axis < 0:
+            axis += len(shape)
+        # An out-of-range axis is the op's error to raise, not ours to fold.
+        if not 0 <= axis < len(shape):
+            return None
+        # Only a symbol this signature declares: those are the extents codegen
+        # materializes, so the folded value is sure to have a definition in the
+        # emitted host code. A local scalar in the shape may since have been
+        # reassigned, so it is left alone.
+        extent = shape[axis]
+        return extent if self._is_param_dim_symbol(extent) else None
 
     def _parse_tile_op(self, op_name: str, call: ast.Call) -> ir.Expr:
         """Parse tile operation."""

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -591,10 +591,9 @@ class ASTParser:
         # ``pl.dump_tag`` only makes sense in Orchestration functions.
         self._func_type: ir.FunctionType = ir.FunctionType.Opaque
 
-        # Dyn-dim symbols (``pl.dynamic()`` Vars) the current signature declares as
-        # a bare extent of a tensor param, by ``Var.unique_id``; and the Python
-        # names bound directly to one of them rather than to a Let of their own
-        # (see ``_fold_tensor_dim``). Both are per-function; reset in parse_function.
+        # Dyn-dim symbols (``pl.dynamic()`` Vars) the current signature declares as a
+        # bare extent of a tensor param, keyed by ``Var.unique_id`` (see
+        # ``_fold_tensor_dim``). Per-function; reset in parse_function.
         self._param_dim_symbols: set[int] = set()
 
         # Current function's auto_scope flag (set during parse_function). When
@@ -1377,11 +1376,15 @@ class ASTParser:
         # Both guards test the Var the name is bound to, never a parallel set of
         # names: scopes are a stack, so a name-keyed alias set desyncs the moment a
         # non-leaking scope rebinds the name and exits.
+        # An LHS annotation that simply restates the symbol's own type (``n:
+        # pl.Scalar[pl.INDEX] = pl.tensor.dim(x, 0)`` — the form the printer emits)
+        # must not defeat the alias; only an annotation asking for a *different*
+        # type falls through to a Let of its own.
         if (
-            override_type is None
-            and self._func_type == ir.FunctionType.Orchestration
+            self._func_type == ir.FunctionType.Orchestration
             and self._is_param_dim_symbol(value_expr)
             and (existing_var is None or self._is_param_dim_symbol(existing_var))
+            and (override_type is None or _types_match(override_type, value_expr.type))
         ):
             return value_expr
 
@@ -7107,17 +7110,21 @@ class ASTParser:
         """
         if self._func_type != ir.FunctionType.Orchestration:
             return None
-        # The *tensor* argument must be a bare name — the generic dispatch re-parses
-        # the AST, so parsing a non-trivial argument here would emit its statements
-        # twice. The axis carries no such restriction, and every spelling the DSL
-        # accepts must fold: the printer normalizes them all to ``dim(x, 0)``, so a
-        # spelling that did not fold would fold on reparse and break the round-trip.
-        if len(call.args) == 2 and not call.keywords:
-            tensor_arg, axis_arg = call.args
-        elif len(call.args) == 1 and len(call.keywords) == 1 and call.keywords[0].arg == "axis":
-            tensor_arg, axis_arg = call.args[0], call.keywords[0].value
-        else:
+        # Every spelling the DSL accepts must fold. The printer normalizes them all
+        # to ``dim(x, 0)``, so a spelling that did not fold here would fold on
+        # reparse — breaking the round-trip, and leaving the original source with
+        # the second-name-for-one-extent bug this fold exists to remove.
+        by_keyword = {kw.arg: kw.value for kw in call.keywords}
+        if set(by_keyword) - {"tensor", "axis"}:
             return None
+        positional = list(call.args)
+        tensor_arg = by_keyword.get("tensor") or (positional.pop(0) if positional else None)
+        axis_arg = by_keyword.get("axis") or (positional.pop(0) if positional else None)
+        if tensor_arg is None or axis_arg is None or positional:
+            return None
+        # The *tensor* argument must be a bare name: the generic dispatch re-parses
+        # the AST, so parsing a non-trivial argument here would emit its statements
+        # twice. The axis is under no such constraint — resolving it parses nothing.
         if not isinstance(tensor_arg, ast.Name):
             return None
         axis = self._static_int(axis_arg)

--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -13,6 +13,7 @@
 
 #include <algorithm>
 #include <any>
+#include <cctype>
 #include <cstddef>
 #include <cstdint>
 #include <functional>
@@ -195,6 +196,20 @@ class CodegenEffectiveUseCollector : public var_collectors::VarDefUseCollector {
  protected:
   void VisitStmt_(const ReturnStmtPtr&) override {}
 };
+
+/// Whether `code` mentions `name` as a whole C++ identifier rather than as a
+/// substring of a longer one (`M` must not match inside `M_DYN` or `ext_M`).
+bool ReferencesIdentifier(const std::string& code, const std::string& name) {
+  if (name.empty()) return false;
+  auto is_ident_char = [](char c) { return std::isalnum(static_cast<unsigned char>(c)) != 0 || c == '_'; };
+  for (size_t pos = code.find(name); pos != std::string::npos; pos = code.find(name, pos + 1)) {
+    const size_t end = pos + name.size();
+    const bool left_ok = pos == 0 || !is_ident_char(code[pos - 1]);
+    const bool right_ok = end >= code.size() || !is_ident_char(code[end]);
+    if (left_ok && right_ok) return true;
+  }
+  return false;
+}
 
 }  // namespace
 
@@ -3942,10 +3957,49 @@ OrchestrationResult GenerateOrchestration(const ir::ProgramPtr& program, const i
     }
   }
 
+  // A ``pl.dynamic("M")`` symbol names the runtime extent of whatever tensor
+  // argument declares it. In a kernel it stays a type-level placeholder, but an
+  // orchestration body may use it as a *value* — a loop bound, a
+  // ``pl.create_tensor`` extent, or a folded ``pl.tensor.dim`` — so the emitted
+  // C++ needs a definition for it: read it from the task-arg descriptor of the
+  // first parameter declaring it, the signature being what guarantees every
+  // argument carrying the symbol has that same extent.
+  //
+  // Gate on the generated text, not on an IR walk: a symbol also reaches the IR
+  // through value *types* whose shapes are never printed (an external tensor's
+  // extents), and defining those emits dead code.
+  const std::string body_code = stmt_codegen.GetGeneratedCode();
+  // Dedup by emitted *name*, not by Var: a symbol carries no emit-name mapping, so
+  // it prints as its name hint, and the body cannot distinguish two symbols that
+  // share one. Seeding with the scalar params keeps a caller that already passes an
+  // extent as a scalar of the same name — whose definition the body's reference
+  // resolves to today — from getting a second, conflicting definition here.
+  std::unordered_set<std::string> defined_names;
+  for (const auto& scalar : scalar_params) defined_names.insert(scalar.emit_name);
+  std::vector<std::string> dyn_dim_defs;
+  for (const auto& var : func->params_) {
+    auto tensor_type = AsTensorTypeLike(var->GetType());
+    if (!tensor_type) continue;
+    const std::string param_name = auto_name::GetCompatibleBaseName(var->name_hint_);
+    for (size_t axis = 0; axis < tensor_type->shape_.size(); ++axis) {
+      auto extent = As<Var>(tensor_type->shape_[axis]);
+      if (!extent) continue;
+      const std::string symbol_name = stmt_codegen.GetVarName(extent);
+      if (!defined_names.insert(symbol_name).second) continue;
+      if (!ReferencesIdentifier(body_code, symbol_name)) continue;
+      dyn_dim_defs.push_back("    int64_t " + symbol_name + " = " +
+                             stmt_codegen.GetTensorShapeDim(param_name, static_cast<int64_t>(axis)) + ";\n");
+    }
+  }
+  if (!dyn_dim_defs.empty()) {
+    oss << "\n    // Dynamic-dim symbols (extent of the declaring argument)\n";
+    for (const auto& def : dyn_dim_defs) oss << def;
+  }
+
   // The outermost PTO2_SCOPE() is now an explicit RuntimeScopeStmt emitted by
   // stmt_codegen (see MaterializeRuntimeScopes); just splice its output in.
   oss << "\n";
-  oss << stmt_codegen.GetGeneratedCode();
+  oss << body_code;
 
   oss << "}\n\n";
   oss << "}  // extern \"C\"\n";

--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -199,6 +199,9 @@ class CodegenEffectiveUseCollector : public var_collectors::VarDefUseCollector {
 
 /// Whether `code` mentions `name` as a whole C++ identifier rather than as a
 /// substring of a longer one (`M` must not match inside `M_DYN` or `ext_M`).
+///
+/// Occurrences inside a `//` comment do not count: they are not references, and
+/// defining a symbol for one would emit an unused variable (`-Wunused-variable`).
 bool ReferencesIdentifier(const std::string& code, const std::string& name) {
   if (name.empty()) return false;
   auto is_ident_char = [](char c) { return std::isalnum(static_cast<unsigned char>(c)) != 0 || c == '_'; };
@@ -206,7 +209,10 @@ bool ReferencesIdentifier(const std::string& code, const std::string& name) {
     const size_t end = pos + name.size();
     const bool left_ok = pos == 0 || !is_ident_char(code[pos - 1]);
     const bool right_ok = end >= code.size() || !is_ident_char(code[end]);
-    if (left_ok && right_ok) return true;
+    if (!left_ok || !right_ok) continue;
+    const size_t line_start = code.rfind('\n', pos) + 1;  // npos + 1 == 0 for the first line
+    const size_t comment = code.find("//", line_start);
+    if (comment == std::string::npos || comment > pos) return true;
   }
   return false;
 }
@@ -3970,12 +3976,16 @@ OrchestrationResult GenerateOrchestration(const ir::ProgramPtr& program, const i
   // extents), and defining those emits dead code.
   const std::string body_code = stmt_codegen.GetGeneratedCode();
   // Dedup by emitted *name*, not by Var: a symbol carries no emit-name mapping, so
-  // it prints as its name hint, and the body cannot distinguish two symbols that
-  // share one. Seeding with the scalar params keeps a caller that already passes an
-  // extent as a scalar of the same name — whose definition the body's reference
-  // resolves to today — from getting a second, conflicting definition here.
+  // it prints as its name hint, and neither the body nor this scan can distinguish
+  // two Vars that share one. Seed with every name already spoken for at entry — a
+  // scalar param, or a local the body defines — because a symbol sharing one of
+  // those names is not what the body's occurrences refer to, and defining it would
+  // shadow the real one inside the scope.
   std::unordered_set<std::string> defined_names;
   for (const auto& scalar : scalar_params) defined_names.insert(scalar.emit_name);
+  CodegenEffectiveUseCollector body_vars;
+  body_vars.VisitStmt(func->body_);
+  for (const auto* def : body_vars.var_defs) defined_names.insert(GetSSABaseName(def->name_hint_));
   std::vector<std::string> dyn_dim_defs;
   for (const auto& var : func->params_) {
     auto tensor_type = AsTensorTypeLike(var->GetType());

--- a/tests/ut/codegen/test_orchestration_codegen_more.py
+++ b/tests/ut/codegen/test_orchestration_codegen_more.py
@@ -1769,6 +1769,65 @@ class TestOrchestrationMore:
         assert l0_t0 < deps_t1, "L0TaskArgs must appear before set_dependencies"
         assert deps_t1 < submit_t1, "set_dependencies must appear before submit"
 
+    def test_dyn_dim_symbol_is_defined_from_the_declaring_argument(self):
+        """A ``pl.dynamic()`` symbol used as a value must be defined in the emitted C++.
+
+        The symbol names the runtime extent of whatever argument declares it, so an
+        orchestration body may use it as a value — a loop bound, a
+        ``pl.create_tensor`` extent, or a folded ``pl.tensor.dim``. Without a
+        definition read from the task-arg descriptor, the emitted host code
+        references a bare ``M`` that does not exist in that scope and fails to
+        compile.
+        """
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        m = pl.dynamic("M")
+        n = pl.dynamic("N")
+
+        @pl.program
+        class DynSymbolProgram:
+            @pl.function(type=pl.FunctionType.InCore)
+            def add_kernel(
+                self,
+                a: pl.Tensor[[m, n], pl.FP32],
+                b: pl.Tensor[[m, n], pl.FP32],
+                c: pl.Out[pl.Tensor[[m, n], pl.FP32]],
+            ) -> pl.Tensor[[m, n], pl.FP32]:
+                a_tile = pl.load(a, [0, 0], [16, 16], target_memory=pl.MemorySpace.Vec)
+                b_tile = pl.load(b, [0, 0], [16, 16])
+                return pl.store(pl.add(a_tile, b_tile), [0, 0], c)
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orchestrator(
+                self,
+                a: pl.Tensor[[m, n], pl.FP32],
+                b: pl.Tensor[[m, n], pl.FP32],
+                c: pl.Out[pl.Tensor[[m, n], pl.FP32]],
+            ) -> pl.Tensor[[m, n], pl.FP32]:
+                rows = pl.tensor.dim(a, 0)  # folds to M
+                tmp = pl.create_tensor([rows, n], dtype=pl.FP32)
+                staged = self.add_kernel(a, b, tmp)
+                return self.add_kernel(staged, b, c)
+
+        program = PassManager.get_strategy(OptimizationStrategy.Default).run_passes(DynSymbolProgram)
+        orch_func = next(
+            f for f in program.functions.values() if f.func_type == ir.FunctionType.Orchestration
+        )
+        code = codegen.generate_orchestration(program, orch_func).code
+
+        # Each symbol is read once, from the descriptor of the argument declaring it.
+        m_decl = re.search(r"int64_t M = \(int64_t\)orch_args\.tensor\(0\)\.ref\(\)\.shapes\[0\];", code)
+        n_decl = re.search(r"int64_t N = \(int64_t\)orch_args\.tensor\(0\)\.ref\(\)\.shapes\[1\];", code)
+        assert m_decl is not None, code
+        assert n_decl is not None, code
+
+        # The temp's extents are the symbols, and they are defined before that use.
+        tmp_shapes = re.search(r"uint32_t \w+_ci_shapes\[2\] = \{(.+?)\};", code)
+        assert tmp_shapes is not None, code
+        assert "M" in tmp_shapes.group(1) and "N" in tmp_shapes.group(1), tmp_shapes.group(1)
+        assert m_decl.start() < tmp_shapes.start(), code
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/ir/parser/test_cross_function_call_return_type.py
+++ b/tests/ut/ir/parser/test_cross_function_call_return_type.py
@@ -392,5 +392,151 @@ def test_distributed_return_kind_and_valid_shape_are_preserved():
     _assert_roundtrips(Prog)
 
 
+def test_tensor_dim_folds_onto_the_signature_dyn_symbol():
+    """``pl.tensor.dim(x, i)`` in an Orchestration body IS the extent x's type names.
+
+    Re-reading a declared extent at runtime would mint a second scalar for the
+    same quantity, and nothing downstream can prove the copy equal to the symbol
+    the tensor types carry. Fold instead: one runtime extent, one IR name.
+    """
+    tokens = pl.dynamic("TOKENS_DYN")
+
+    @pl.program
+    class Prog:
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def main(self, x: pl.Tensor[[tokens, 128], pl.FP32]):
+            n = pl.tensor.dim(x, 0)
+            return pl.create_tensor([n, 128], dtype=pl.FP32)
+
+    body = ir.python_print(Prog)
+    # The dim read folded away, and the temp is shaped by the symbol itself --
+    # not by a second scalar that happens to hold the same number.
+    assert "pl.tensor.dim(" not in body, body
+    assert "pl.tensor.create([TOKENS_DYN, 128]" in body, body
+    _assert_roundtrips(Prog)
+
+
+def test_dyn_symbol_survives_call_returning_into_a_loop_carried_var():
+    """The Qwen3-14B prefill shape: a shared dyn symbol + a `tensor.dim`-sized temp.
+
+    ``hidden_states`` is reassigned from a callee that declares the *same*
+    ``pl.dynamic`` symbol, while the callee's ``out`` argument is a temp the
+    caller sized from ``pl.tensor.dim(hidden_states, 0)``. Before the fold, that
+    temp carried a second name for the token extent, the call's deduced return
+    type came back in terms of that name, and reassigning ``hidden_states`` was
+    rejected as a type change (``was pl.Tensor[[TOKENS_DYN, ...]], got
+    pl.Tensor[[n, ...]]``).
+    """
+    tokens = pl.dynamic("TOKENS_DYN")
+
+    @pl.program
+    class Prog:
+        @pl.function(type=pl.FunctionType.Inline, auto_scope=False)
+        def layer(
+            self,
+            hidden_states: pl.Tensor[[tokens, 128], pl.BF16],
+            out: pl.Tensor[[tokens, 128], pl.BF16],
+        ) -> pl.Tensor[[tokens, 128], pl.BF16]:
+            return out
+
+        @pl.function(type=pl.FunctionType.Orchestration, auto_scope=False)
+        def main(self, hidden_states: pl.Tensor[[tokens, 128], pl.BF16]) -> pl.Tensor[[tokens, 128], pl.BF16]:
+            n = pl.tensor.dim(hidden_states, 0)
+            for _ in pl.range(2):
+                with pl.scope():
+                    nxt = pl.create_tensor([n, 128], dtype=pl.BF16)
+                    hidden_states = self.layer(hidden_states, nxt)
+            return hidden_states
+
+    # The call's return type keeps the caller's own symbol, so the reassignment
+    # of `hidden_states` type-checks against the parameter it was declared with.
+    (call_type,) = _user_call_types(Prog, "layer")
+    assert isinstance(call_type, ir.TensorType)
+    assert [str(dim) for dim in call_type.shape] == ["TOKENS_DYN", "128"]
+    _assert_roundtrips(Prog)
+
+
+def test_reassigning_a_folded_name_never_writes_into_the_symbol():
+    """Rebinding the folded name must not assign *through* it into the symbol.
+
+    The name is bound to the symbol, and the symbol names an argument's extent —
+    it is immutable. A non-leaking scope (an ``if`` with explicit yields) rebinds
+    ``n`` and then exits, restoring the outer ``n -> symbol`` binding, so the
+    guard has to test the Var the name is bound to rather than track names.
+    Writing to the symbol would corrupt the extent for every later use of it.
+    """
+    tokens = pl.dynamic("TOKENS_DYN")
+    cols = pl.dynamic("COLS_DYN")
+
+    @pl.program
+    class Prog:
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def main(self, x: pl.Tensor[[tokens, cols], pl.FP32], flag: pl.Scalar[pl.BOOL]):
+            n = pl.tensor.dim(x, 0)  # n -> TOKENS_DYN
+            if flag:
+                n = 3  # rebind inside a scope that does not leak its vars
+                k = pl.yield_(1)
+            else:
+                k = pl.yield_(2)
+            n = 5  # outer scope: n is bound to the symbol again
+            return pl.create_tensor([n, k], dtype=pl.FP32)
+
+    printed = ir.python_print(Prog)
+    # The symbol is never an assignment target -- it stays a pure extent name.
+    assert "TOKENS_DYN: pl.Scalar" not in printed, printed
+    assert "TOKENS_DYN = 5" not in printed, printed
+    _assert_roundtrips(Prog)
+
+
+def test_tensor_dim_folds_for_every_axis_spelling():
+    """``dim(x, axis=0)`` and a named-constant axis fold too.
+
+    The printer normalizes every spelling to ``pl.tensor.dim(x, 0)``, so a
+    spelling that did not fold would fold on reparse and break the round-trip --
+    and would quietly reintroduce the second-name-for-one-extent bug.
+    """
+    tokens = pl.dynamic("TOKENS_DYN")
+    row_axis = 0
+
+    @pl.program
+    class Prog:
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def keyword_axis(self, x: pl.Tensor[[tokens, 128], pl.FP32]):
+            n = pl.tensor.dim(x, axis=0)
+            return pl.create_tensor([n, 128], dtype=pl.FP32)
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def named_const_axis(self, x: pl.Tensor[[tokens, 128], pl.FP32]):
+            n = pl.tensor.dim(x, row_axis)
+            return pl.create_tensor([n, 128], dtype=pl.FP32)
+
+    printed = ir.python_print(Prog)
+    assert "pl.tensor.dim(" not in printed, printed
+    assert printed.count("pl.tensor.create([TOKENS_DYN, 128]") == 2, printed
+    _assert_roundtrips(Prog)
+
+
+def test_tensor_dim_is_not_folded_in_an_inline_callee():
+    """An Inline callee's ``tensor.dim`` must stay a runtime read.
+
+    Its placeholder is not the caller's: the same callee can be inlined into a
+    caller that passes a statically-shaped tensor, and ``InlineFunctions`` does
+    not rewrite the callee's dyn symbols. Only an Orchestration body -- where
+    codegen defines the symbol from the task-arg descriptor -- may fold.
+    """
+    tokens = pl.dynamic("TOKENS_DYN")
+
+    @pl.program
+    class Prog:
+        @pl.function(type=pl.FunctionType.Inline)
+        def layer(self, x: pl.Tensor[[tokens, 128], pl.FP32]):
+            n = pl.tensor.dim(x, 0)
+            return pl.create_tensor([n, 128], dtype=pl.FP32)
+
+    body = ir.python_print(Prog)
+    assert "pl.tensor.dim(x, 0)" in body
+    _assert_roundtrips(Prog)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/ir/parser/test_cross_function_call_return_type.py
+++ b/tests/ut/ir/parser/test_cross_function_call_return_type.py
@@ -488,12 +488,13 @@ def test_reassigning_a_folded_name_never_writes_into_the_symbol():
     _assert_roundtrips(Prog)
 
 
-def test_tensor_dim_folds_for_every_axis_spelling():
-    """``dim(x, axis=0)`` and a named-constant axis fold too.
+def test_tensor_dim_folds_for_every_call_spelling():
+    """Keyword args and an annotated LHS fold too.
 
-    The printer normalizes every spelling to ``pl.tensor.dim(x, 0)``, so a
-    spelling that did not fold would fold on reparse and break the round-trip --
-    and would quietly reintroduce the second-name-for-one-extent bug.
+    The printer normalizes every spelling to ``n: pl.Scalar[pl.INDEX] =
+    pl.tensor.dim(x, 0)``, so a spelling that did not fold would fold on reparse
+    and break the round-trip -- and would quietly reintroduce the
+    second-name-for-one-extent bug for the source that used it.
     """
     tokens = pl.dynamic("TOKENS_DYN")
     row_axis = 0
@@ -506,13 +507,23 @@ def test_tensor_dim_folds_for_every_axis_spelling():
             return pl.create_tensor([n, 128], dtype=pl.FP32)
 
         @pl.function(type=pl.FunctionType.Orchestration)
+        def keyword_tensor(self, x: pl.Tensor[[tokens, 128], pl.FP32]):
+            n = pl.tensor.dim(tensor=x, axis=0)
+            return pl.create_tensor([n, 128], dtype=pl.FP32)
+
+        @pl.function(type=pl.FunctionType.Orchestration)
         def named_const_axis(self, x: pl.Tensor[[tokens, 128], pl.FP32]):
             n = pl.tensor.dim(x, row_axis)
             return pl.create_tensor([n, 128], dtype=pl.FP32)
 
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def annotated_target(self, x: pl.Tensor[[tokens, 128], pl.FP32]):
+            n: pl.Scalar[pl.INDEX] = pl.tensor.dim(x, 0)
+            return pl.create_tensor([n, 128], dtype=pl.FP32)
+
     printed = ir.python_print(Prog)
     assert "pl.tensor.dim(" not in printed, printed
-    assert printed.count("pl.tensor.create([TOKENS_DYN, 128]") == 2, printed
+    assert printed.count("pl.tensor.create([TOKENS_DYN, 128]") == 4, printed
     _assert_roundtrips(Prog)
 
 


### PR DESCRIPTION
## Problem

A tensor's declared extent **is** its runtime extent, so reading it back with `pl.tensor.dim` minted a *second* scalar naming the same quantity. Nothing downstream can prove that copy equal to the `pl.dynamic()` symbol the tensor types carry, so every shape built from the copy disagreed structurally with the shapes built from the symbol.

That is what broke Qwen3-14B prefill in pypto-serving after #2043 (which turned on the cross-function return-type substitution that had, until then, been a silent no-op — `As<ShapedType>` never matched a `TensorType`, so `DeduceCallReturnType` returned the callee's declared types verbatim):

```python
PREFILL_TOKENS_DYN = pl.dynamic("PREFILL_TOKENS_DYN")

def prefill_fwd(hidden_states: pl.Tensor[[PREFILL_TOKENS_DYN, HIDDEN], pl.BF16], ...):
    prefill_tokens = pl.tensor.dim(hidden_states, 0)          # a SECOND name for the same extent
    for layer_idx in pl.range(num_layers_actual):
        with pl.scope():
            layer_next_hidden = pl.create_tensor([prefill_tokens, HIDDEN], dtype=pl.BF16)
            hidden_states = prefill_layer(hidden_states, ..., layer_next_hidden, layer_idx)
```

The callee declares the *same* symbol, so `DeduceCallReturnType` bound `PREFILL_TOKENS_DYN -> prefill_tokens` from the `out` argument and returned `pl.Tensor[[prefill_tokens, 5120]]`, while `hidden_states` is declared `pl.Tensor[[PREFILL_TOKENS_DYN, 5120]]`:

```
ParserTypeError: Cannot reassign 'hidden_states' with a different type:
  was pl.Tensor[[PREFILL_TOKENS_DYN, 5120], pl.BF16],
  got pl.Tensor[[prefill_tokens, 5120], pl.BF16]
```

Both types denote the same extent. The compiler simply cannot say so — see RFC #2047 for the general gap.

## Fix

**Parser** — in an Orchestration body, `pl.tensor.dim(x, i)` folds to the extent `x`'s type already names, and the Python name binds *straight to that symbol* instead of copying it into a `Let`. The direct binding is the point: a copy would be what lands in every shape built from the name, recreating the alias immediately. One runtime extent, one IR name.

**Codegen** — orchestration entry now defines each symbol the emitted body references, once, from the task-arg descriptor of the first parameter declaring it:

```cpp
    // Dynamic-dim symbols (extent of the declaring argument)
    int64_t PREFILL_TOKENS_DYN = (int64_t)orch_args.tensor(0).ref().shapes[0];
```

This also fixes a **pre-existing** bug: `pl.create_tensor([M, N])` emitted `{static_cast<uint32_t>(M), ...}` with `M` undefined — host C++ that does not compile. Any model sizing a temp with a dyn symbol was silently broken.

The fold is **Orchestration-only**, which is exactly where the symbol is a value. An Inline/InCore callee's placeholder is not the caller's — `InlineFunctions` does not substitute callee symbols, and the callee may be reached with a statically-shaped actual — so there `tensor.dim` stays a genuine runtime read (pinned by a test).

## CI

Adds a Qwen3-14B **prefill** step to the `pypto-lib-model` job, mirroring the existing decode step. Prefill exercises the dynamic-shape host path decode does not (a `pl.dynamic` token axis, a temp sized from `pl.tensor.dim`, and a layer result reassigned into a loop-carried var), which is why this regression reached pypto-serving unseen.

## Tests

`tests/ut/ir/parser/test_cross_function_call_return_type.py` (5 new):
- the fold itself, and the Qwen3 loop-carried-reassignment regression;
- reassigning a folded name must never write **through** the alias into the symbol (the symbol names an argument's extent — it is immutable). Scopes are a stack, so the guard tests the Var the name is bound to rather than tracking names;
- every axis spelling folds (`dim(x, axis=0)`, a named constant) — the printer normalizes them all to `dim(x, 0)`, so a spelling that did not fold would fold on reparse and break the round-trip;
- an Inline callee keeps `tensor.dim` as a runtime read.

`tests/ut/codegen/test_orchestration_codegen_more.py` (1 new): each symbol is read once from the declaring argument's descriptor, and is defined before the use that needs it.

Full `tests/ut/`: **7240 passed, 2 skipped**. ruff / clang-format / clang-tidy / pyright clean.

## Notes

- Codegen gates on the *generated body text*, not an IR walk: a symbol also reaches the IR through value types whose shapes are never printed (external tensor extents), and defining those emitted dead code — caught by `test_dynamic_gm_pipe_buffer_alloc_follows_its_size_local`.
- Symbol definitions dedup by emitted *name* and are seeded with the scalar-param names, so a caller that already passes an extent as a scalar of the same name does not get a second, conflicting definition.
- Not verified locally: the new NPU CI step itself (needs a device) and the pypto-serving run.
