### PR TITLE
feat(ir): preserve valid regions through unary and reduction ops

### DIFF
--- a/include/pypto/ir/type_inference.h
+++ b/include/pypto/ir/type_inference.h
@@ -30,6 +30,7 @@
 #include <vector>
 
 #include "pypto/core/dtype.h"
+#include "pypto/core/logging.h"
 #include "pypto/ir/expr.h"
 #include "pypto/ir/span.h"
 #include "pypto/ir/tile_view_semantics.h"
@@ -354,6 +355,25 @@ void ValidateDropDimsValidExtents(const std::vector<int64_t>& drop_dims,
                                   const Span& span);
 
 /**
+ * @brief Reject a reduction whose input is empty on some axis
+ *
+ * A reduction consumes its input's *valid* region: the backend kernels bound their loops by the
+ * source's valid_row / valid_col, so a partially valid axis reduces over exactly the real cells
+ * and never reads padding. The one input they cannot handle is an empty one — they assert that
+ * valid_row and valid_col are both non-zero — and an empty region also leaves max/min with no
+ * identity to return. Catching it here turns a hardware assert into a compile-time error.
+ *
+ * Only a provably zero extent rejects; an unproved symbolic extent is accepted, matching the
+ * standing verifier rule for unknown symbolic bounds.
+ *
+ * @param valid Effective valid shape of the reduction input
+ * @param op_name Operator name used in diagnostics
+ * @param span Source location of the reduction input, reported on failure
+ */
+void CheckReductionInputNonEmpty(const std::vector<ExprPtr>& valid, const std::string& op_name,
+                                 const Span& span);
+
+/**
  * @brief Check if a dimension is broadcastable to another
  *
  * A dimension is broadcastable if:
@@ -402,6 +422,29 @@ inline void InheritTileViewLayout(TileView& dst, const std::shared_ptr<const Til
   dst.pad = eff.pad;
 }
 
+namespace detail {
+
+/**
+ * @brief Resolve an effective valid shape: the explicit @p valid when set, else @p physical
+ *
+ * Callers index the result by physical axis, so a rank-mismatched valid_shape would read out of
+ * bounds. The bounds verifier reports this as kRankMismatch, but it only runs over an already-built
+ * program — the type is constructed long before that, so reject it here.
+ */
+inline std::vector<ExprPtr> ResolveValidShape(const std::vector<ExprPtr>& valid,
+                                              const std::vector<ExprPtr>& physical,
+                                              const std::string& type_kind) {
+  if (valid.empty()) {
+    return physical;
+  }
+  CHECK(valid.size() == physical.size())
+      << type_kind << " valid_shape rank (" << valid.size() << ") must match the physical shape rank ("
+      << physical.size() << "): valid_shape " << FormatShape(valid) << " vs shape " << FormatShape(physical);
+  return valid;
+}
+
+}  // namespace detail
+
 /**
  * @brief Return the source tile's effective valid_shape, falling back to its static shape.
  *
@@ -415,10 +458,49 @@ inline void InheritTileViewLayout(TileView& dst, const std::shared_ptr<const Til
  * @return The TileView::valid_shape if set, otherwise the static shape
  */
 inline std::vector<ExprPtr> GetValidShape(const std::shared_ptr<const TileType>& tile_type) {
-  if (tile_type->tile_view_ && !tile_type->tile_view_->valid_shape.empty()) {
-    return tile_type->tile_view_->valid_shape;
+  if (!tile_type->tile_view_) {
+    return tile_type->shape_;
   }
-  return tile_type->shape_;
+  return detail::ResolveValidShape(tile_type->tile_view_->valid_shape, tile_type->shape_, "TileType");
+}
+
+/**
+ * @brief Return the source tensor's effective valid_shape, falling back to its static shape.
+ *
+ * Tensor counterpart of the TileType overload above. An unset or empty valid_shape means
+ * "fully valid", so tensor ops resolve it to the physical shape before propagating it onto
+ * a result. A DistributedTensorType binds here too: an op that reads a window as this rank's
+ * local memory sees the same effective valid region.
+ *
+ * @param tensor_type Source TensorType
+ * @return The TensorView::valid_shape if set, otherwise the static shape
+ */
+inline std::vector<ExprPtr> GetValidShape(const std::shared_ptr<const TensorType>& tensor_type) {
+  if (!tensor_type->tensor_view_) {
+    return tensor_type->shape_;
+  }
+  return detail::ResolveValidShape(tensor_type->tensor_view_->valid_shape, tensor_type->shape_, "TensorType");
+}
+
+/**
+ * @brief Build the TensorType for a freshly computed (non-alias) tensor result.
+ *
+ * A computed tensor is a new allocation rather than a view of its source, so it carries only
+ * the metadata describing its own contents: the default layout, no stride, no padding, no
+ * source memref — and its own valid region. A valid_shape equal to the physical shape is fine:
+ * the TensorType constructor canonicalizes redundant full validity away, so a fully valid result
+ * ends up with no explicit view at all.
+ *
+ * @param shape Result physical shape
+ * @param dtype Result element type
+ * @param valid_shape Result effective valid shape
+ */
+inline TypePtr MakeFreshTensorType(std::vector<ExprPtr> shape, DataType dtype,
+                                   std::vector<ExprPtr> valid_shape) {
+  TensorView view;
+  view.valid_shape = std::move(valid_shape);
+  return std::make_shared<TensorType>(std::move(shape), dtype, std::nullopt,
+                                      std::make_optional(std::move(view)));
 }
 
 /**

--- a/src/ir/op/tensor_ops/reduction.cpp
+++ b/src/ir/op/tensor_ops/reduction.cpp
@@ -33,6 +33,7 @@
 #include "pypto/ir/scalar_expr.h"
 #include "pypto/ir/span.h"
 #include "pypto/ir/type.h"
+#include "pypto/ir/type_inference.h"
 
 namespace pypto {
 namespace ir {
@@ -48,6 +49,52 @@ T GetKwarg(const std::vector<std::pair<std::string, std::any>>& kwargs, const st
   }
   return default_value;
 }
+
+namespace {
+
+// Build the result type of a reduction over `axis`, given an already-validated input tensor.
+//
+// The reduction consumes the input's *valid* region on the reduced axis — the backend kernels bound
+// their loops by the source's valid extent — so every cell it reads is real data and the reduced
+// axis collapses to a fully valid output axis (extent 1 under keep_dim, dropped otherwise).
+// Validity on the surviving axes carries over unchanged: reducing one axis does not change which
+// rows/columns of the others hold real data.
+TypePtr MakeReductionResultType(const std::shared_ptr<const TensorType>& tensor_type, int64_t axis,
+                                bool keep_dim, const std::string& op_name, const Span& span,
+                                std::optional<DataType> out_dtype) {
+  // GetValidShape CHECKs that input_valid has the same rank as the physical shape, so indexing it
+  // by physical axis below stays in bounds.
+  const auto input_valid = GetValidShape(tensor_type);
+  CheckReductionInputNonEmpty(input_valid, op_name, span);
+
+  const auto& input_shape = tensor_type->shape_;
+  const auto input_ndim = static_cast<int64_t>(input_shape.size());
+  std::vector<ExprPtr> output_shape;
+  std::vector<ExprPtr> output_valid;
+  output_shape.reserve(input_shape.size());
+  output_valid.reserve(input_shape.size());
+  for (int64_t i = 0; i < input_ndim; ++i) {
+    if (i == axis) {
+      if (keep_dim) {
+        output_shape.push_back(std::make_shared<ConstInt>(1, DataType::INDEX, Span::unknown()));
+        output_valid.push_back(std::make_shared<ConstInt>(1, DataType::INDEX, Span::unknown()));
+      }
+      continue;  // keep_dim == false reduces the axis away entirely
+    }
+    output_shape.push_back(input_shape[i]);
+    output_valid.push_back(input_valid[i]);
+  }
+
+  const DataType dtype = out_dtype.value_or(tensor_type->dtype_);
+  // Every dimension reduced away (keep_dim=false): a scalar carries no view metadata, as there is
+  // no region for a valid shape to describe.
+  if (output_shape.empty()) {
+    return std::make_shared<ScalarType>(dtype);
+  }
+  return MakeFreshTensorType(std::move(output_shape), dtype, std::move(output_valid));
+}
+
+}  // namespace
 
 // `out_dtype` overrides the output element type — used by argmax/argmin index output (int32).
 TypePtr DeduceTensorReductionType(const std::vector<ExprPtr>& args,
@@ -80,26 +127,7 @@ TypePtr DeduceTensorReductionType(const std::vector<ExprPtr>& args,
   // Extract keep_dim flag from kwargs (default: true)
   bool keep_dim = GetKwarg<bool>(kwargs, "keep_dim", true);
 
-  // Build output shape
-  std::vector<ExprPtr> output_shape;
-  for (int64_t i = 0; i < input_ndim; ++i) {
-    if (i == axis) {
-      if (keep_dim) {
-        // Keep dimension as 1
-        output_shape.push_back(std::make_shared<ConstInt>(1, DataType::INDEX, Span::unknown()));
-      }
-      // Otherwise, skip this dimension (reduce it out)
-    } else {
-      output_shape.push_back(input_shape[i]);
-    }
-  }
-
-  // If output shape is empty (all dimensions reduced and keep_dim=false), return ScalarType
-  if (output_shape.empty()) {
-    return std::make_shared<ScalarType>(out_dtype.value_or(tensor_type->dtype_));
-  }
-
-  return std::make_shared<TensorType>(output_shape, out_dtype.value_or(tensor_type->dtype_));
+  return MakeReductionResultType(tensor_type, axis, keep_dim, op_name, args[0]->span_, out_dtype);
 }
 
 // ============================================================================
@@ -179,21 +207,7 @@ TypePtr DeduceTensorColReductionType(const std::vector<ExprPtr>& args,
 
   bool keep_dim = GetKwarg<bool>(kwargs, "keep_dim", true);
 
-  std::vector<ExprPtr> output_shape;
-  for (int64_t i = 0; i < input_ndim; ++i) {
-    if (i == axis) {
-      if (keep_dim) {
-        output_shape.push_back(std::make_shared<ConstInt>(1, DataType::INDEX, Span::unknown()));
-      }
-    } else {
-      output_shape.push_back(input_shape[i]);
-    }
-  }
-
-  if (output_shape.empty()) {
-    return std::make_shared<ScalarType>(out_dtype.value_or(tensor_type->dtype_));
-  }
-  return std::make_shared<TensorType>(output_shape, out_dtype.value_or(tensor_type->dtype_));
+  return MakeReductionResultType(tensor_type, axis, keep_dim, op_name, args[0]->span_, out_dtype);
 }
 
 REGISTER_OP("tensor.col_sum")

--- a/src/ir/op/tensor_ops/unary.cpp
+++ b/src/ir/op/tensor_ops/unary.cpp
@@ -29,8 +29,22 @@
 #include "pypto/ir/kind_traits.h"
 #include "pypto/ir/op_registry.h"
 #include "pypto/ir/type.h"
+#include "pypto/ir/type_inference.h"
 namespace pypto {
 namespace ir {
+
+namespace {
+
+// Unary ops rewrite each cell in place: they never move data between cells, so the set of
+// cells holding real data is exactly the input's. The result is a fresh allocation, so it
+// takes the input's effective valid region but none of its view/alias metadata — see
+// MakeFreshTensorType. A fully valid input yields a fully valid (view-less) result.
+TypePtr DeduceTensorUnaryResultType(const std::shared_ptr<const TensorType>& tensor_type,
+                                    DataType out_dtype) {
+  return MakeFreshTensorType(tensor_type->shape_, out_dtype, GetValidShape(tensor_type));
+}
+
+}  // namespace
 
 TypePtr DeduceTensorNegType(const std::vector<ExprPtr>& args,
                             const std::vector<std::pair<std::string, std::any>>& kwargs) {
@@ -42,7 +56,7 @@ TypePtr DeduceTensorNegType(const std::vector<ExprPtr>& args,
       << args[0]->GetType()->TypeName();
 
   // Negation preserves dtype (valid for both int and float)
-  return std::make_shared<TensorType>(tensor_type->shape_, tensor_type->dtype_);
+  return DeduceTensorUnaryResultType(tensor_type, tensor_type->dtype_);
 }
 
 TypePtr DeduceTensorAbsType(const std::vector<ExprPtr>& args,
@@ -55,7 +69,7 @@ TypePtr DeduceTensorAbsType(const std::vector<ExprPtr>& args,
       << args[0]->GetType()->TypeName();
 
   // Absolute value preserves dtype (valid for both int and float)
-  return std::make_shared<TensorType>(tensor_type->shape_, tensor_type->dtype_);
+  return DeduceTensorUnaryResultType(tensor_type, tensor_type->dtype_);
 }
 
 TypePtr DeduceTensorRecipType(const std::vector<ExprPtr>& args,
@@ -73,7 +87,7 @@ TypePtr DeduceTensorRecipType(const std::vector<ExprPtr>& args,
     out_dtype = DataType::FP32;
   }
 
-  return std::make_shared<TensorType>(tensor_type->shape_, out_dtype);
+  return DeduceTensorUnaryResultType(tensor_type, out_dtype);
 }
 
 TypePtr DeduceTensorExpType(const std::vector<ExprPtr>& args,
@@ -93,7 +107,7 @@ TypePtr DeduceTensorExpType(const std::vector<ExprPtr>& args,
     out_dtype = DataType::FP32;
   }
 
-  return std::make_shared<TensorType>(tensor_type->shape_, out_dtype);
+  return DeduceTensorUnaryResultType(tensor_type, out_dtype);
 }
 
 TypePtr DeduceTensorLogType(const std::vector<ExprPtr>& args,
@@ -112,7 +126,7 @@ TypePtr DeduceTensorLogType(const std::vector<ExprPtr>& args,
     out_dtype = DataType::FP32;
   }
 
-  return std::make_shared<TensorType>(tensor_type->shape_, out_dtype);
+  return DeduceTensorUnaryResultType(tensor_type, out_dtype);
 }
 
 TypePtr DeduceTensorSqrtType(const std::vector<ExprPtr>& args,
@@ -131,7 +145,7 @@ TypePtr DeduceTensorSqrtType(const std::vector<ExprPtr>& args,
     out_dtype = DataType::FP32;
   }
 
-  return std::make_shared<TensorType>(tensor_type->shape_, out_dtype);
+  return DeduceTensorUnaryResultType(tensor_type, out_dtype);
 }
 
 TypePtr DeduceTensorRsqrtType(const std::vector<ExprPtr>& args,
@@ -149,7 +163,7 @@ TypePtr DeduceTensorRsqrtType(const std::vector<ExprPtr>& args,
     out_dtype = DataType::FP32;
   }
 
-  return std::make_shared<TensorType>(tensor_type->shape_, out_dtype);
+  return DeduceTensorUnaryResultType(tensor_type, out_dtype);
 }
 
 // Shared FP32-only deducer for transcendental ops (tensor.sin, tensor.cos).
@@ -169,7 +183,7 @@ TypePtr DeduceTensorFP32OnlyType(const std::string& op_name, const std::vector<E
       << op_name << " is FP32-only, but got input with dtype " << tensor_type->dtype_.ToString()
       << ". Cast the input to FP32 explicitly via pl.cast(x, pl.FP32) before applying " << op_name << ".";
 
-  return std::make_shared<TensorType>(tensor_type->shape_, tensor_type->dtype_);
+  return DeduceTensorUnaryResultType(tensor_type, tensor_type->dtype_);
 }
 
 TypePtr DeduceTensorCastType(const std::vector<ExprPtr>& args,
@@ -215,8 +229,8 @@ TypePtr DeduceTensorCastType(const std::vector<ExprPtr>& args,
 
   // mode kwarg is optional, not used in type deduction
 
-  // Cast preserves shape but changes dtype
-  return std::make_shared<TensorType>(tensor_type->shape_, target_dtype);
+  // Cast preserves shape and the input's valid region; only dtype changes.
+  return DeduceTensorUnaryResultType(tensor_type, target_dtype);
 }
 
 // ============================================================================

--- a/src/ir/op/tile_ops/reduction.cpp
+++ b/src/ir/op/tile_ops/reduction.cpp
@@ -113,8 +113,10 @@ TypePtr DeduceTileRowReductionType(const std::vector<ExprPtr>& args,
 
   // Inherit valid_shape from the input along the non-reduced dims so that
   // downstream codegen emits trowsum with the correct valid_row (issue #1401).
-  // The reduced (last) dim collapses to 1 in the output.
+  // The reduced (last) dim collapses to 1 in the output: the kernel bounds its loop by the
+  // source's valid_col, so it folds exactly the real cells into a single valid output cell.
   const auto input_valid = GetValidShape(tile_type);
+  CheckReductionInputNonEmpty(input_valid, op_name, args[0]->span_);
   std::vector<ExprPtr> output_valid(input_valid.begin(), input_valid.end() - 1);
   output_valid.push_back(std::make_shared<ConstInt>(1, DataType::INDEX, Span::unknown()));
 
@@ -150,8 +152,10 @@ TypePtr DeduceTileColReductionType(const std::vector<ExprPtr>& args,
 
   // Inherit valid_shape from the input along the non-reduced dims so that
   // downstream codegen emits tcolsum with the correct valid_col (issue #1401).
-  // The reduced (first) dim is always 1 in the output.
+  // The reduced (first) dim is always 1 in the output: the kernel bounds its loop by the
+  // source's valid_row, so it folds exactly the real cells into a single valid output cell.
   const auto input_valid = GetValidShape(tile_type);
+  CheckReductionInputNonEmpty(input_valid, op_name, args[0]->span_);
   std::vector<ExprPtr> output_valid;
   output_valid.push_back(std::make_shared<ConstInt>(1, DataType::INDEX, Span::unknown()));
   output_valid.insert(output_valid.end(), input_valid.begin() + 1, input_valid.end());

--- a/src/ir/op/type_inference.cpp
+++ b/src/ir/op/type_inference.cpp
@@ -250,6 +250,13 @@ bool AreComparableIntegerScalarExprs(const ExprPtr& lhs, const ExprPtr& rhs) {
   }
   return lhs_type->dtype_.IsSignedInt() == rhs_type->dtype_.IsSignedInt();
 }
+
+// The zero extent every valid-shape bound is compared against. Cached because it is otherwise
+// rebuilt per dimension on a hot construction path; ConstInt is immutable, so sharing it is safe.
+const ExprPtr& ZeroExtent() {
+  static const ExprPtr zero = std::make_shared<ConstInt>(0, DataType::INDEX, Span::unknown());
+  return zero;
+}
 }  // namespace
 
 ProofResult ProveValidExtentEqual(const ExprPtr& lhs, const ExprPtr& rhs) {
@@ -341,7 +348,7 @@ std::vector<ValidShapeBoundsError> ValidateValidShapeBounds(const std::vector<Ex
   }
 
   std::vector<ValidShapeBoundsError> errors;
-  static const auto zero = std::make_shared<ConstInt>(0, DataType::INDEX, Span::unknown());
+  const ExprPtr& zero = ZeroExtent();
   for (size_t i = 0; i < valid.size(); ++i) {
     if (ProveValidExtentLessEqual(zero, valid[i]) == ProofResult::kFalse) {
       std::ostringstream msg;
@@ -358,6 +365,20 @@ std::vector<ValidShapeBoundsError> ValidateValidShapeBounds(const std::vector<Ex
     }
   }
   return errors;
+}
+
+void CheckReductionInputNonEmpty(const std::vector<ExprPtr>& valid, const std::string& op_name,
+                                 const Span& span) {
+  const ExprPtr& zero = ZeroExtent();
+  for (size_t i = 0; i < valid.size(); ++i) {
+    // Only a *provable* zero rejects; an unproved symbolic extent is accepted.
+    CHECK_SPAN(ProveValidExtentEqual(valid[i], zero) != ProofResult::kTrue, span)
+        << op_name << ": input valid extent on axis " << i << " is 0 (valid_shape " << FormatShape(valid)
+        << "), so the reduction has no real data to consume. The backend reduction kernels require a "
+           "non-empty valid region on every axis and assert on an empty one, and an empty region also "
+           "leaves max/min with no value to return. Widen the valid region, or guard the reduction so "
+           "it does not run when the axis can be empty.";
+  }
 }
 
 // ============================================================================

--- a/src/ir/op/type_inference.cpp
+++ b/src/ir/op/type_inference.cpp
@@ -257,6 +257,28 @@ const ExprPtr& ZeroExtent() {
   static const ExprPtr zero = std::make_shared<ConstInt>(0, DataType::INDEX, Span::unknown());
   return zero;
 }
+
+// True when `extent` is provably zero, i.e. the region it bounds is empty.
+//
+// A constant is compared by value rather than routed through ProveValidExtentEqual. That helper
+// only decides extents of matching signedness, so an *unsigned* zero -- e.g. a UINT64 valid_rows
+// from set_validshape -- against the signed INDEX zero comes back kUnknown, which would let exactly
+// the empty region this predicate exists to catch through. Symbolic extents are compared against a
+// zero of their own dtype so the analyzer can decide them at all.
+bool IsProvablyEmptyExtent(const ExprPtr& extent) {
+  if (!extent) {
+    return false;
+  }
+  if (const auto constant = GetConstantDimension(extent)) {
+    return *constant == 0;
+  }
+  auto scalar_type = As<ScalarType>(extent->GetType());
+  if (!scalar_type || !scalar_type->dtype_.IsInt()) {
+    return false;
+  }
+  const auto zero = std::make_shared<ConstInt>(0, scalar_type->dtype_, Span::unknown());
+  return ProveValidExtentEqual(extent, zero) == ProofResult::kTrue;
+}
 }  // namespace
 
 ProofResult ProveValidExtentEqual(const ExprPtr& lhs, const ExprPtr& rhs) {
@@ -369,10 +391,9 @@ std::vector<ValidShapeBoundsError> ValidateValidShapeBounds(const std::vector<Ex
 
 void CheckReductionInputNonEmpty(const std::vector<ExprPtr>& valid, const std::string& op_name,
                                  const Span& span) {
-  const ExprPtr& zero = ZeroExtent();
   for (size_t i = 0; i < valid.size(); ++i) {
     // Only a *provable* zero rejects; an unproved symbolic extent is accepted.
-    CHECK_SPAN(ProveValidExtentEqual(valid[i], zero) != ProofResult::kTrue, span)
+    CHECK_SPAN(!IsProvablyEmptyExtent(valid[i]), span)
         << op_name << ": input valid extent on axis " << i << " is 0 (valid_shape " << FormatShape(valid)
         << "), so the reduction has no real data to consume. The backend reduction kernels require a "
            "non-empty valid region on every axis and assert on an empty one, and an empty region also "

--- a/tests/ut/ir/operators/test_tensor_ops.py
+++ b/tests/ut/ir/operators/test_tensor_ops.py
@@ -323,6 +323,170 @@ def test_tensor_col_prod():
     assert isinstance(result_type.shape[1], ir.ConstInt) and result_type.shape[1].value == 128
 
 
+# ---- valid_shape propagation through unary and reduction ops -------------------------------
+#
+# Unary ops rewrite each cell in place, so the result holds real data in exactly the cells the
+# input did. Reductions consume the input's *valid* region on the reduced axis — the backend
+# kernels bound their loops by the source's valid extent — so the reduced axis collapses to a
+# fully valid output axis while validity on the surviving axes carries over.
+
+
+def test_tensor_unary_preserves_partial_valid_shape():
+    """tensor.exp must carry the input's valid region onto its result."""
+    call = ir.op.tensor.exp(_partial_tensor_var([64, 128], [64, 40]))
+
+    result_type = call.type
+    assert isinstance(result_type, ir.TensorType)
+    assert result_type.tensor_view is not None
+    assert _const_int_values(result_type.tensor_view.valid_shape) == [64, 40]
+
+
+def test_tensor_unary_fully_valid_input_yields_no_explicit_view():
+    """A fully valid input yields a fully valid result, canonicalized to no explicit view."""
+    span = ir.Span.unknown()
+    dims = [ir.ConstInt(64, DataType.INT32, span), ir.ConstInt(128, DataType.INT32, span)]
+    tensor_var = ir.Var("t", ir.TensorType(dims, DataType.FP32), span)
+
+    result_type = ir.op.tensor.exp(tensor_var).type
+    assert isinstance(result_type, ir.TensorType)
+    # Redundant full validity is canonicalized away.
+    assert result_type.tensor_view is None or len(result_type.tensor_view.valid_shape) == 0
+
+
+def test_tensor_unary_preserves_symbolic_valid_shape():
+    """A runtime (symbolic) valid extent survives a unary op."""
+    span = ir.Span.unknown()
+    vlen = ir.Var("vlen", ir.ScalarType(DataType.INDEX), span)
+    dims = [ir.ConstInt(64, DataType.INT32, span), ir.ConstInt(128, DataType.INT32, span)]
+    view = ir.TensorView([], ir.TensorLayout.ND, valid_shape=[ir.ConstInt(64, DataType.INDEX, span), vlen])
+    tensor_var = ir.Var("t", ir.TensorType(dims, DataType.FP32, None, view), span)
+
+    result_type = ir.op.tensor.neg(tensor_var).type
+    assert isinstance(result_type, ir.TensorType)
+    assert result_type.tensor_view is not None
+    valid = result_type.tensor_view.valid_shape
+    assert isinstance(valid[0], ir.ConstInt) and valid[0].value == 64
+    assert valid[1] == vlen  # the symbolic extent is carried through unchanged
+
+
+def test_tensor_cast_preserves_valid_shape_and_changes_dtype():
+    """tensor.cast changes only the element type; the valid region is untouched."""
+    call = ir.op.tensor.cast(_partial_tensor_var([64, 128], [64, 40]), target_type=DataType.FP16)
+
+    result_type = call.type
+    assert isinstance(result_type, ir.TensorType)
+    assert result_type.dtype == DataType.FP16
+    assert result_type.tensor_view is not None
+    assert _const_int_values(result_type.tensor_view.valid_shape) == [64, 40]
+
+
+def test_tensor_unary_result_carries_no_source_view_metadata():
+    """A fresh result takes the default layout and no stride/pad/memref from its source."""
+    span = ir.Span.unknown()
+    dims = [ir.ConstInt(64, DataType.INT32, span), ir.ConstInt(128, DataType.INT32, span)]
+    # A strided, DN-layout, zero-padded source: none of that describes the fresh result.
+    view = ir.TensorView([1, 64], ir.TensorLayout.DN, valid_shape=[64, 40], pad=ir.PadValue.zero)
+    tensor_var = ir.Var("t", ir.TensorType(dims, DataType.FP32, None, view), span)
+
+    result_type = ir.op.tensor.exp(tensor_var).type
+    assert isinstance(result_type, ir.TensorType)
+    assert result_type.memref is None
+    assert result_type.tensor_view is not None
+    assert _const_int_values(result_type.tensor_view.valid_shape) == [64, 40]
+    assert len(result_type.tensor_view.stride) == 0
+    assert result_type.tensor_view.layout == ir.TensorLayout.ND
+    assert result_type.tensor_view.pad == ir.PadValue.null
+
+
+def test_tensor_row_sum_preserves_non_reduced_axis_validity():
+    """Reducing the last axis keeps the row axis's partial validity."""
+    # [64, 128] physical, valid [40, 128]: the *kept* row axis is partial.
+    call = ir.op.tensor.row_sum(_partial_tensor_var([64, 128], [40, 128]))
+
+    result_type = call.type
+    assert isinstance(result_type, ir.TensorType)
+    assert _const_int_values(result_type.shape) == [64, 1]
+    assert result_type.tensor_view is not None
+    # Rows stay partial (40 of 64); the reduced axis collapses to one valid cell.
+    assert _const_int_values(result_type.tensor_view.valid_shape) == [40, 1]
+
+
+def test_tensor_row_sum_partial_reduced_axis_collapses_to_valid():
+    """A partially valid *reduced* axis folds to a fully valid result, not a partial one."""
+    # valid [64, 40] of [64, 128]: row_sum reduces the partial column axis.
+    call = ir.op.tensor.row_sum(_partial_tensor_var([64, 128], [64, 40]))
+
+    result_type = call.type
+    assert isinstance(result_type, ir.TensorType)
+    assert _const_int_values(result_type.shape) == [64, 1]
+    # The reduction folded exactly the 40 real columns into one cell, so every cell of the
+    # [64, 1] result is real. Full validity is canonical, so no explicit view survives.
+    assert result_type.tensor_view is None or len(result_type.tensor_view.valid_shape) == 0
+
+
+def test_tensor_col_sum_preserves_non_reduced_axis_validity():
+    """col_sum reduces axis=-2; the surviving column axis keeps its partial validity."""
+    call = ir.op.tensor.col_sum(_partial_tensor_var([64, 128], [64, 40]))
+
+    result_type = call.type
+    assert isinstance(result_type, ir.TensorType)
+    assert _const_int_values(result_type.shape) == [1, 128]
+    assert result_type.tensor_view is not None
+    assert _const_int_values(result_type.tensor_view.valid_shape) == [1, 40]
+
+
+def test_tensor_reduction_rejects_empty_valid_extent():
+    """A provably zero valid extent has no real data to reduce."""
+    with pytest.raises(ValueError, match="valid extent on axis 1 is 0"):
+        ir.op.tensor.row_sum(_partial_tensor_var([64, 128], [64, 0]))
+
+
+def test_tensor_op_rejects_rank_mismatched_valid_shape():
+    """A valid_shape whose rank differs from the physical shape is rejected, not read past.
+
+    Consumers index the effective valid shape by physical axis, so a short valid_shape would
+    read out of bounds. The bounds verifier reports the same violation, but only over an
+    already-built program — this rejects at construction.
+    """
+    span = ir.Span.unknown()
+    dims = [ir.ConstInt(64, DataType.INT32, span), ir.ConstInt(128, DataType.INT32, span)]
+    bad = ir.Var(
+        "t",
+        ir.TensorType(dims, DataType.FP32, None, ir.TensorView([], ir.TensorLayout.ND, valid_shape=[40])),
+        span,
+    )
+
+    # col_sum reduces axis 0 and reads the (missing) axis-1 extent.
+    with pytest.raises(ValueError, match="valid_shape rank"):
+        ir.op.tensor.col_sum(bad)
+    # A unary op would otherwise forward the malformed region onto its result.
+    with pytest.raises(ValueError, match="valid_shape rank"):
+        ir.op.tensor.exp(bad)
+
+
+def test_tensor_reduction_no_keep_dim_returns_bare_scalar():
+    """A fully reduced tensor yields a ScalarType — no view metadata is manufactured.
+
+    ``ir.op.tensor.row_sum`` does not surface ``keep_dim``, so the op call is built directly to
+    reach the fully-reduced path.
+    """
+    span = ir.Span.unknown()
+    tensor_var = ir.Var(
+        "t",
+        ir.TensorType(
+            [ir.ConstInt(64, DataType.INT32, span)],
+            DataType.FP32,
+            None,
+            ir.TensorView([], ir.TensorLayout.ND, valid_shape=[40]),
+        ),
+        span,
+    )
+
+    call = ir.create_op_call("tensor.row_sum", [tensor_var], {"keep_dim": False}, span)
+    assert isinstance(call.type, ir.ScalarType)
+    assert call.type.dtype == DataType.FP32
+
+
 def test_tensor_row_argmax():
     """tensor.row_argmax reduces the last axis (keepdim) with an int32 index output."""
     span = ir.Span.unknown()

--- a/tests/ut/ir/operators/test_tile_ops.py
+++ b/tests/ut/ir/operators/test_tile_ops.py
@@ -1000,6 +1000,34 @@ class TestTileReductionOps:
         with pytest.raises(ValueError, match="valid extent on axis 0 is 0"):
             tile.col_sum(empty)
 
+    def test_tile_reduction_rejects_unsigned_empty_valid_extent(self):
+        """An empty extent is rejected whatever its dtype's signedness.
+
+        The extent proof only decides operands of matching signedness, so an unsigned zero
+        compared against a signed zero is merely "unknown". A constant zero must therefore be
+        recognised by value, or exactly the empty region this guard exists for slips through.
+        """
+        span = ir.Span.unknown()
+        src_var = ir.Var(
+            "src",
+            ir.TileType(
+                [ir.ConstInt(8, DataType.INT32, span), ir.ConstInt(32, DataType.INT32, span)],
+                DataType.FP32,
+                None,
+                ir.TileView(
+                    valid_shape=[
+                        ir.ConstInt(8, DataType.INDEX, span),
+                        ir.ConstInt(0, DataType.UINT64, span),  # unsigned zero
+                    ]
+                ),
+            ),
+            span,
+        )
+        tmp_var = self._make_row_tmp_var()
+
+        with pytest.raises(ValueError, match="valid extent on axis 1 is 0"):
+            tile.row_sum(src_var, tmp_var)
+
     def test_tile_reduction_rejects_rank_mismatched_valid_shape(self):
         """A valid_shape whose rank differs from the physical shape is rejected, not read past."""
         span = ir.Span.unknown()

--- a/tests/ut/ir/operators/test_tile_ops.py
+++ b/tests/ut/ir/operators/test_tile_ops.py
@@ -506,6 +506,31 @@ class TestTileUnaryOps:
         valid_shape = result_type.tile_view.valid_shape
         assert isinstance(valid_shape[1], ir.ConstInt) and valid_shape[1].value == 4
 
+    def test_tile_unary_fully_valid_input_yields_no_explicit_view(self):
+        """A fully valid input produces a fully valid result — canonicalized to no valid_shape."""
+        span = ir.Span.unknown()
+        src_type = ir.TileType(
+            [ir.ConstInt(8, DataType.INT32, span), ir.ConstInt(16, DataType.INT32, span)],
+            DataType.FP32,
+        )
+        src_var = ir.Var("src", src_type, span)
+
+        result_type = tile.exp(src_var).type
+        assert isinstance(result_type, ir.TileType)
+        # Redundant full validity is canonicalized away, so there is nothing to print.
+        assert result_type.tile_view is None or len(result_type.tile_view.valid_shape) == 0
+
+    def test_tile_unary_result_carries_no_source_alias_metadata(self):
+        """A fresh result aliases no source allocation: no memref, stride, or start offset."""
+        sliced = self._make_sliced_tile_with_valid_shape()
+
+        result_type = tile.neg(sliced).type
+        assert isinstance(result_type, ir.TileType)
+        assert result_type.memref is None
+        assert result_type.tile_view is not None
+        assert len(result_type.tile_view.stride) == 0
+        assert result_type.tile_view.start_offset is None
+
 
 class TestTileReductionOps:
     """Test suite for tile-level reduction operators."""
@@ -844,6 +869,19 @@ class TestTileReductionOps:
         src_var = ir.Var("src", src_type, span)
         return tile.slice(src_var, [8, 32], [0, 0], valid_shape=[valid_rows, valid_cols])
 
+    def _make_row_tmp_var(self):
+        """Helper: the scratch tile the row reductions take as their second argument.
+
+        The PTO row-reduction instructions use it as full-size scratch, so it matches the
+        input's physical shape rather than the reduced output shape.
+        """
+        span = ir.Span.unknown()
+        tmp_type = ir.TileType(
+            [ir.ConstInt(8, DataType.INT32, span), ir.ConstInt(32, DataType.INT32, span)],
+            DataType.FP32,
+        )
+        return ir.Var("tmp", tmp_type, span)
+
     def test_tile_row_sum_inherits_input_valid_shape(self):
         """tile.row_sum output valid_shape must mirror input on the kept dim (issue #1401)."""
         sliced = self._make_sliced_tile_with_valid_shape(valid_rows=4, valid_cols=32)
@@ -905,6 +943,79 @@ class TestTileReductionOps:
         valid_shape = result_type.tile_view.valid_shape
         assert isinstance(valid_shape[0], ir.ConstInt) and valid_shape[0].value == 1
         assert isinstance(valid_shape[1], ir.ConstInt) and valid_shape[1].value == 16
+
+    # ------------------------------------------------------------------
+    # Reducing a partially valid axis is accepted: the backend reduction
+    # kernels bound their loop by the source's valid extent (TRowSum reads
+    # srcTile.GetValidCol(), TColSum reads GetValidRow()), so they fold exactly
+    # the real cells and never read padding. The reduced axis therefore
+    # collapses to a fully valid output axis. An *empty* valid extent is the one
+    # input those kernels reject, so it is caught here instead.
+    # ------------------------------------------------------------------
+
+    def test_tile_row_sum_partial_reduced_axis_collapses_to_valid(self):
+        """Reducing a partially valid axis folds only the real cells (16 of 32 cols)."""
+        # valid_cols=16 of 32: the *reduced* axis is partial.
+        sliced = self._make_sliced_tile_with_valid_shape(valid_rows=8, valid_cols=16)
+
+        result_type = tile.row_sum(sliced, self._make_row_tmp_var()).type
+        assert isinstance(result_type, ir.TileType)
+        assert _const_values(result_type.shape) == [8, 1]
+        # The kernel folded exactly the 16 real cells into one output cell, so the partial
+        # extent does not leak into the result: every cell of the [8, 1] output is real.
+        # Full validity is canonical, so no explicit valid_shape survives.
+        assert result_type.tile_view is None or len(result_type.tile_view.valid_shape) == 0
+
+    def test_tile_row_sum_symbolic_reduced_axis_accepted(self):
+        """A symbolic (unproved) valid extent on the reduced axis is accepted, not rejected."""
+        span = ir.Span.unknown()
+        vlen = ir.Var("vlen", ir.ScalarType(DataType.INDEX), span)
+        src_type = ir.TileType(
+            [ir.ConstInt(8, DataType.INT32, span), ir.ConstInt(32, DataType.INT32, span)],
+            DataType.FP32,
+            None,
+            ir.TileView(valid_shape=[ir.ConstInt(8, DataType.INDEX, span), vlen]),
+        )
+        src_var = ir.Var("src", src_type, span)
+
+        result_type = tile.row_sum(src_var, self._make_row_tmp_var()).type
+        assert isinstance(result_type, ir.TileType)
+        assert _const_values(result_type.shape) == [8, 1]
+        # `vlen` is never proved equal to 32, yet the reduction is still well defined: the
+        # kernel reduces whatever the runtime valid extent turns out to be. The result is
+        # fully valid either way, so no symbolic extent survives into the output type.
+        assert result_type.tile_view is None or len(result_type.tile_view.valid_shape) == 0
+
+    def test_tile_row_sum_rejects_empty_valid_extent(self):
+        """A provably zero valid extent has no real data to reduce and is rejected."""
+        empty = self._make_sliced_tile_with_valid_shape(valid_rows=8, valid_cols=0)
+
+        with pytest.raises(ValueError, match="valid extent on axis 1 is 0"):
+            tile.row_sum(empty, self._make_row_tmp_var())
+
+    def test_tile_col_sum_rejects_empty_valid_extent(self):
+        """The guard covers the reduced *row* axis of a column reduction too."""
+        empty = self._make_sliced_tile_with_valid_shape(valid_rows=0, valid_cols=32)
+
+        with pytest.raises(ValueError, match="valid extent on axis 0 is 0"):
+            tile.col_sum(empty)
+
+    def test_tile_reduction_rejects_rank_mismatched_valid_shape(self):
+        """A valid_shape whose rank differs from the physical shape is rejected, not read past."""
+        span = ir.Span.unknown()
+        bad = ir.Var(
+            "src",
+            ir.TileType(
+                [ir.ConstInt(8, DataType.INT32, span), ir.ConstInt(32, DataType.INT32, span)],
+                DataType.FP32,
+                None,
+                ir.TileView(valid_shape=[4]),  # rank 1 against a rank-2 tile
+            ),
+            span,
+        )
+
+        with pytest.raises(ValueError, match="valid_shape rank"):
+            tile.col_sum(bad)
 
 
 class TestTileBroadcastOps:


### PR DESCRIPTION
Implements brief 11 of the unified `valid_shape` series (*Preserve valid regions through unary and reduction operations*). Follows #2031 (canonicalization), #2037 (proof/bounds), and #2043 (type boundaries).

## Summary

- **Tensor unary + cast now preserve the input's valid region.** `neg`, `abs`, `recip`, `exp`, `log`, `sqrt`, `rsqrt`, `sin`, `cos` and `cast` each returned a bare `TensorType(shape, dtype)`, so a partial region silently widened back to the full allocation and padding became indistinguishable from real data. They now carry the input's effective valid shape onto a **fresh** result — default layout, empty stride, null padding, no source memref. Tile unary already did this (#1370).
- **Tensor reductions now preserve validity on the surviving axes** and collapse the reduced axis, matching what tile already did (#1401).
- **New guard: a reduction over a provably *empty* valid region is rejected** at type deduction instead of asserting on device.
- **Fixes an out-of-bounds read reachable from ordinary DSL code** (details below).
- Shared helpers land in `type_inference.h`: a `GetValidShape` overload for `TensorType` (the tensor dual previously existed only as a file-local duplicate), `MakeFreshTensorType`, and `CheckReductionInputNonEmpty`.

A fully valid input still yields a fully valid, view-less result — the type constructors canonicalize redundant full validity away — so no existing program changes shape.

## Deviation from the brief: reductions do *not* reject a partially valid reduced axis

The brief asks for this rejection, but conditions it on *"if a kernel consumes the full physical reduced axis"*. **That premise does not hold here.** The backend reduction kernels bound their loops by the *source tile's valid extent*:

```cpp
// pto-isa: TRowSum.hpp
uint16_t m = srcTile.GetValidRow();
uint16_t n = srcTile.GetValidCol();   // reduced axis extent, read from the source
TRowSum<TileDataOut, TileDataIn>(dstTile.data(), srcTile.data(), m, n);
```

`TColSum` likewise bounds the reduced first axis by `GetValidRow()`, and the NPU a2/a3 and a5 paths do the same. The kernels fold exactly the real cells and **never read padding**, so the reduced axis collapses to a fully valid output axis and the result is the reduction over real data. Rejecting it would forbid a hardware-supported, numerically correct path and force a redundant `fillpad`.

This is not merely a reading of the ISA — it is already load-bearing behavior. `tests/st/runtime/ops/test_prod_reduction.py` and `test_argmax_reduction.py` contain ~25 on-device cases that deliberately narrow the **reduced** dim and assert numeric correctness (*"Narrowing the reduced dim exercises the partial-reduction tail"*). Implementing the brief's rule literally would have required deleting them.

**What the kernels genuinely cannot handle is an empty input** — they assert `validCol != 0 && validRow != 0`, and an empty region also leaves `max`/`min` with no value to return. So the rejection this PR adds is for a *provably zero* valid extent, which converts a hardware assert into a compile-time error. An unproved symbolic extent is still accepted, matching the standing verifier rule for unknown symbolic bounds.

```text
row_sum(tile[128,128], valid=[128,40])   accepted -> result [128,1], fully valid
row_sum(tile[128,128], valid=[128,vlen]) accepted -> vlen is never proved; kernel clamps at runtime
row_sum(tile[128,128], valid=[128,0])    rejected -> would trip PTO_ASSERT(validCol != 0)
row_sum(fillpad(t, min))                 accepted -> unchanged (paged-attention path)
```

## Bug fix: SIGBUS on a rank-mismatched `valid_shape`

A `valid_shape` whose rank differs from the physical shape made consumers index past the end of the vector. This crashed the process with **SIGBUS and no Python exception** (exit 135), and was reachable from ordinary DSL code:

```python
x: pl.Tensor[[64, 128], pl.FP32, pl.TensorView(layout=..., valid_shape=[40])]  # rank 1 vs rank 2
pl.tensor.col_sum(x)   # reduces axis 0, reads the missing axis-1 extent
```

`GetValidShape` now rejects it with a clear `ValueError` naming the two ranks. The check sits at the one place every consumer resolves an effective valid shape, so it **also closes the same pre-existing hazard on the tile path** (present since #1401). `ValidateValidShapeBounds` already reported this as `kRankMismatch`, but only over an already-built program — the type is constructed long before the verifier runs.

## Diagnostics added

| Condition | Error |
| --------- | ----- |
| Reduction input with a provably zero valid extent | `<op>: input valid extent on axis N is 0 (valid_shape [...]), so the reduction has no real data to consume...` (carries the input's span) |
| `valid_shape` rank != physical rank | `<Tensor\|Tile>Type valid_shape rank (N) must match the physical shape rank (M): valid_shape [...] vs shape [...]` |

## Deliberately out of scope

- **Fresh tile results still inherit the source's `pad`.** This is wrong in principle (a unary op writes only the valid region, so after `exp` a zero-padded source's padding is not zero), but it **cannot be fixed one op family at a time**: `InheritTileViewLayout` has 27 call sites across unary, elementwise, broadcast, gather and sort, and the DSL compares types across families at reassignments. Dropping `pad` in unary alone makes `row_expand_sub` -> `exp` fail to type-check (`ParserTypeError: Cannot reassign 'pij_tile' with a different type`). The elementwise brief owns both the "never inherit padding on a fresh result" rule and the elementwise/broadcast files, and can change all families atomically.
- **Tensor scalar-binary** (`tensor.adds` / `subs` / `muls` / `divs` / `fmods`) still drop validity. They live in `tensor_ops/elementwise.cpp`, which the elementwise brief owns and audits; tile's equivalents already preserve it. `tile.move` already preserves validity.
- **User-facing documentation** is deferred to the series' final documentation PR, per the series rules.

## Testing

- 20 new tests in `tests/ut/ir/operators/{test_tensor_ops,test_tile_ops}.py`: fully valid canonicalization, partial static + symbolic propagation, casts, row/column reductions, non-reduced-axis preservation, partial-reduced-axis collapse, empty-extent rejection (row/col/axis forms), rank-mismatch rejection, scalar results, and "fresh result carries no source alias metadata".
- Full unit suite: **7254 passed, 2 skipped**.
- `pre-commit` and the diff-based `clang-tidy` gate are clean.