### PR TITLE
refactor(ir): move TileBufSignature out of codegen into ir

### DIFF
--- a/include/pypto/ir/transforms/utils/tile_buf_signature.h
+++ b/include/pypto/ir/transforms/utils/tile_buf_signature.h
@@ -9,8 +9,8 @@
  * -----------------------------------------------------------------------------------------------------------
  */
 
-#ifndef PYPTO_CODEGEN_PTO_TILE_BUF_SIGNATURE_H_
-#define PYPTO_CODEGEN_PTO_TILE_BUF_SIGNATURE_H_
+#ifndef PYPTO_IR_TRANSFORMS_UTILS_TILE_BUF_SIGNATURE_H_
+#define PYPTO_IR_TRANSFORMS_UTILS_TILE_BUF_SIGNATURE_H_
 
 #include <cstdint>
 
@@ -22,7 +22,7 @@
 #include "pypto/ir/type.h"
 
 namespace pypto {
-namespace codegen {
+namespace ir {
 
 /**
  * @brief PTO-visible typed buffer signature
@@ -177,7 +177,7 @@ struct TileBufSignature {
   }
 };
 
-}  // namespace codegen
+}  // namespace ir
 }  // namespace pypto
 
-#endif  // PYPTO_CODEGEN_PTO_TILE_BUF_SIGNATURE_H_
+#endif  // PYPTO_IR_TRANSFORMS_UTILS_TILE_BUF_SIGNATURE_H_

--- a/src/ir/transforms/fold_no_op_reshape_pass.cpp
+++ b/src/ir/transforms/fold_no_op_reshape_pass.cpp
@@ -12,7 +12,6 @@
 #include <memory>
 #include <string>
 
-#include "pypto/codegen/pto/tile_buf_signature.h"
 #include "pypto/ir/expr.h"
 #include "pypto/ir/function.h"
 #include "pypto/ir/kind_traits.h"
@@ -21,6 +20,7 @@
 #include "pypto/ir/transforms/base/mutator.h"
 #include "pypto/ir/transforms/pass_properties.h"
 #include "pypto/ir/transforms/passes.h"
+#include "pypto/ir/transforms/utils/tile_buf_signature.h"
 #include "pypto/ir/type.h"
 
 namespace pypto {
@@ -59,8 +59,8 @@ bool IsNoOpReshape(const AssignStmtPtr& assign) {
   if (!lhs_memref || !rhs_memref || !lhs_memref->base_ || !rhs_memref->base_) return false;
   if (lhs_memref->base_.get() != rhs_memref->base_.get()) return false;
 
-  auto lhs_sig = codegen::TileBufSignature::FromTileType(*lhs_tile);
-  auto rhs_sig = codegen::TileBufSignature::FromTileType(*rhs_tile);
+  auto lhs_sig = TileBufSignature::FromTileType(*lhs_tile);
+  auto rhs_sig = TileBufSignature::FromTileType(*rhs_tile);
   return lhs_sig == rhs_sig;
 }
 


### PR DESCRIPTION
## Summary

`TileBufSignature` (a normalized view of a tile's buffer layout: memory space, dtype, physical shape, layout, fractal, pad, valid-shape) is a **pure function of `ir::TileType`** — it has zero codegen dependencies — yet it lived in `namespace pypto::codegen` under `include/pypto/codegen/pto/tile_buf_signature.h`. Its **only** consumer is the IR pass `FoldNoOpReshape`, which therefore had to reverse-`#include` a codegen header from the IR layer: the same layering inversion (IR must not depend on codegen) as the recent `IsBuiltinOp` / wrapper-direction / return-to-param cleanups.

- Move the header to `include/pypto/ir/transforms/utils/tile_buf_signature.h` and change its namespace `pypto::codegen` → `pypto::ir` (include guard updated to match).
- Update `fold_no_op_reshape_pass.cpp`: fix the include path and drop the `codegen::` qualifier.
- No codegen `.cpp` referenced the type (it maintains parallel string-based logic in `PTOCodegen`), so codegen is unaffected.

Behavior-preserving: the header-only struct is moved verbatim (git detects a 97% rename).

## Relation to #2041

This is the second of two independent layering cleanups. Together they bring the IR layer's dependency on codegen to **zero**:

| PR | Reverse-dependency removed |
| --- | --- |
| #2041 | `orchestration_analysis.h` / `IsBuiltinOp` |
| this PR | `codegen/pto/tile_buf_signature.h` / `TileBufSignature` |

## Testing

- Build: full `cmake --build` green (linked `pypto_core`).
- IR transforms + codegen UTs: **2776 passed** (includes `test_fold_no_op_reshape.py`).