### PR TITLE
refactor(ir): dedup runtime facade, shared helpers, and dead code

### DIFF
--- a/python/pypto/ir/builder.py
+++ b/python/pypto/ir/builder.py
@@ -897,8 +897,46 @@ class FunctionBuilder:
         return self._result
 
 
-class ForLoopBuilder:
+class _ReturnVarsAccessor:
+    """Mixin: ``output()`` / ``outputs()`` over a completed statement's return vars.
+
+    Host builders (for / while / if) set the class attribute ``_result_kind``
+    (e.g. ``"for loop"``) and, once built, hold the statement in ``self._result``
+    with a ``return_vars`` sequence.
+    """
+
+    _result_kind: str
+    _result: "ir.ForStmt | ir.WhileStmt | ir.IfStmt | None"
+
+    def output(self, index: int = 0) -> ir.Var:
+        """Return a single return variable by index (default 0).
+
+        Raises:
+            AssertionError: If the statement is not yet complete.
+            IndexError: If ``index`` is out of range.
+        """
+        assert self._result is not None, f"{self._result_kind.capitalize()} not yet complete"
+        if index >= len(self._result.return_vars):
+            raise IndexError(
+                f"Return variable index {index} out of range "
+                f"({self._result_kind} has {len(self._result.return_vars)} return vars)"
+            )
+        return self._result.return_vars[index]
+
+    def outputs(self) -> list[ir.Var]:
+        """Return all return variables as a list.
+
+        Raises:
+            AssertionError: If the statement is not yet complete.
+        """
+        assert self._result is not None, f"{self._result_kind.capitalize()} not yet complete"
+        return list(self._result.return_vars)
+
+
+class ForLoopBuilder(_ReturnVarsAccessor):
     """Helper for building for loops within a loop context."""
+
+    _result_kind = "for loop"
 
     def __init__(self, builder: IRBuilder) -> None:
         """Initialize for loop builder.
@@ -1014,64 +1052,6 @@ class ForLoopBuilder:
         self._return_var_count += 1
         return var
 
-    def output(self, index: int = 0) -> ir.Var:
-        """Get a single output return variable from the for loop.
-
-        This is a convenience method to access the return variables after the for
-        loop is built. Use the index parameter to select which return variable.
-
-        Args:
-            index: Index of the return variable to get (default: 0)
-
-        Returns:
-            Var: The return variable at the specified index
-
-        Raises:
-            AssertionError: If called before for loop is complete
-            IndexError: If index is out of range
-
-        Example:
-            >>> with ib.for_loop(i, 0, 10, 1) as loop:
-            ...     sum_iter = loop.iter_arg("sum", 0)
-            ...     loop.return_var("sum_final")
-            ...     # ... loop body ...
-            >>> result = loop.output()  # Get the first return variable
-            >>> # Or for multiple return vars:
-            >>> result1 = loop.output(0)
-            >>> result2 = loop.output(1)
-        """
-        assert self._result is not None, "For loop not yet complete"
-        if index >= len(self._result.return_vars):
-            raise IndexError(
-                f"Return variable index {index} out of range "
-                f"(for loop has {len(self._result.return_vars)} return vars)"
-            )
-        return self._result.return_vars[index]
-
-    def outputs(self) -> list[ir.Var]:
-        """Get all output return variables from the for loop.
-
-        This is a convenience method to access all return variables at once after
-        the for loop is built.
-
-        Returns:
-            List of all return variables
-
-        Raises:
-            AssertionError: If called before for loop is complete
-
-        Example:
-            >>> with ib.for_loop(i, 0, 10, 1) as loop:
-            ...     sum_iter = loop.iter_arg("sum", 0)
-            ...     prod_iter = loop.iter_arg("prod", 1)
-            ...     loop.return_var("sum_final")
-            ...     loop.return_var("prod_final")
-            ...     # ... loop body ...
-            >>> sum_result, prod_result = loop.outputs()  # Get all return variables
-        """
-        assert self._result is not None, "For loop not yet complete"
-        return list(self._result.return_vars)
-
     def get_result(self) -> ir.ForStmt:
         """Get the built ForStmt.
 
@@ -1082,8 +1062,10 @@ class ForLoopBuilder:
         return self._result
 
 
-class WhileLoopBuilder:
+class WhileLoopBuilder(_ReturnVarsAccessor):
     """Helper for building while loops within a loop context."""
+
+    _result_kind = "while loop"
 
     def __init__(self, builder: IRBuilder) -> None:
         """Initialize while loop builder.
@@ -1217,61 +1199,6 @@ class WhileLoopBuilder:
         self._return_var_count += 1
         return var
 
-    def output(self, index: int = 0) -> ir.Var:
-        """Get a single output return variable from the while loop.
-
-        This is a convenience method to access the return variables after the while
-        loop is built. Use the index parameter to select which return variable.
-
-        Args:
-            index: Index of the return variable to get (default: 0)
-
-        Returns:
-            Var: The return variable at the specified index
-
-        Raises:
-            AssertionError: If called before while loop is complete
-            IndexError: If index is out of range
-
-        Example:
-            >>> with ib.while_loop(condition) as loop:
-            ...     x_iter = loop.iter_arg("x_iter", 0)
-            ...     loop.return_var("x_final")
-            ...     # ... loop body ...
-            >>> result = loop.output()  # Get the first return variable
-        """
-        assert self._result is not None, "While loop not yet complete"
-        if index >= len(self._result.return_vars):
-            raise IndexError(
-                f"Return variable index {index} out of range "
-                f"(while loop has {len(self._result.return_vars)} return vars)"
-            )
-        return self._result.return_vars[index]
-
-    def outputs(self) -> list[ir.Var]:
-        """Get all output return variables from the while loop.
-
-        This is a convenience method to access all return variables at once after
-        the while loop is built.
-
-        Returns:
-            List of all return variables
-
-        Raises:
-            AssertionError: If called before while loop is complete
-
-        Example:
-            >>> with ib.while_loop(condition) as loop:
-            ...     x_iter = loop.iter_arg("x_iter", 0)
-            ...     y_iter = loop.iter_arg("y_iter", 1)
-            ...     loop.return_var("x_final")
-            ...     loop.return_var("y_final")
-            ...     # ... loop body ...
-            >>> x_result, y_result = loop.outputs()  # Get all return variables
-        """
-        assert self._result is not None, "While loop not yet complete"
-        return list(self._result.return_vars)
-
     def get_result(self) -> ir.WhileStmt:
         """Get the built WhileStmt.
 
@@ -1304,8 +1231,10 @@ class ScopeBuilder:
         return self._result
 
 
-class IfStmtBuilder:
+class IfStmtBuilder(_ReturnVarsAccessor):
     """Helper for building if statements within an if context."""
+
+    _result_kind = "if statement"
 
     def __init__(self, builder: IRBuilder) -> None:
         """Initialize if statement builder.
@@ -1344,61 +1273,6 @@ class IfStmtBuilder:
         actual_span = span if span is not None else self._builder._capture_call_span()
         var = ir.Var(name, type, actual_span)
         self._builder._builder.add_if_return_var(var)
-
-    def output(self, index: int = 0) -> ir.Var:
-        """Get a single output return variable from the if statement.
-
-        This is a convenience method to access the return variables after the if
-        statement is built. Use the index parameter to select which return variable.
-
-        Args:
-            index: Index of the return variable to get (default: 0)
-
-        Returns:
-            Var: The return variable at the specified index
-
-        Raises:
-            AssertionError: If called before if statement is complete
-            IndexError: If index is out of range
-
-        Example:
-            >>> with ib.if_stmt(condition) as if_builder:
-            ...     if_builder.return_var("result", ir.ScalarType(DataType.INT64))
-            ...     # ... if/else branches ...
-            >>> result = if_builder.output()  # Get the first return variable
-            >>> # Or for multiple return vars:
-            >>> result1 = if_builder.output(0)
-            >>> result2 = if_builder.output(1)
-        """
-        assert self._result is not None, "If statement not yet complete"
-        if index >= len(self._result.return_vars):
-            raise IndexError(
-                f"Return variable index {index} out of range "
-                f"(if statement has {len(self._result.return_vars)} return vars)"
-            )
-        return self._result.return_vars[index]
-
-    def outputs(self) -> list[ir.Var]:
-        """Get all output return variables from the if statement.
-
-        This is a convenience method to access all return variables at once after
-        the if statement is built.
-
-        Returns:
-            List of all return variables
-
-        Raises:
-            AssertionError: If called before if statement is complete
-
-        Example:
-            >>> with ib.if_stmt(condition) as if_builder:
-            ...     if_builder.return_var("x", ir.ScalarType(DataType.INT64))
-            ...     if_builder.return_var("y", ir.ScalarType(DataType.INT64))
-            ...     # ... if/else branches ...
-            >>> x, y = if_builder.outputs()  # Get all return variables
-        """
-        assert self._result is not None, "If statement not yet complete"
-        return list(self._result.return_vars)
 
     def get_result(self) -> ir.IfStmt:
         """Get the built IfStmt.

--- a/python/pypto/ir/builder.py
+++ b/python/pypto/ir/builder.py
@@ -912,10 +912,11 @@ class _ReturnVarsAccessor:
         """Return a single return variable by index (default 0).
 
         Raises:
-            AssertionError: If the statement is not yet complete.
+            RuntimeError: If the statement is not yet complete.
             IndexError: If ``index`` is out of range.
         """
-        assert self._result is not None, f"{self._result_kind.capitalize()} not yet complete"
+        if self._result is None:
+            raise RuntimeError(f"{self._result_kind.capitalize()} not yet complete")
         if index >= len(self._result.return_vars):
             raise IndexError(
                 f"Return variable index {index} out of range "
@@ -927,9 +928,10 @@ class _ReturnVarsAccessor:
         """Return all return variables as a list.
 
         Raises:
-            AssertionError: If the statement is not yet complete.
+            RuntimeError: If the statement is not yet complete.
         """
-        assert self._result is not None, f"{self._result_kind.capitalize()} not yet complete"
+        if self._result is None:
+            raise RuntimeError(f"{self._result_kind.capitalize()} not yet complete")
         return list(self._result.return_vars)
 
 

--- a/python/pypto/ir/compiled_program.py
+++ b/python/pypto/ir/compiled_program.py
@@ -20,6 +20,7 @@ torch tensors::
 
 import ctypes
 import os
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -438,7 +439,114 @@ def _default_platform(backend_type: BackendType) -> str:
     return _backend_core.get_backend_instance(backend_type).get_handler().get_default_sim_platform()
 
 
-class CompiledProgram:
+def _write_debug_runner(
+    output_dir: Path,
+    platform: str,
+    get_metadata: Callable[[], tuple[list[_ParamInfo], list[int], list[Any]]],
+) -> None:
+    """Write ``<output_dir>/debug/run.py`` so the kernel can be replayed via
+    ``python .../debug/run.py``.
+
+    Best-effort: programs that lack a clean orchestration entry (unusual shapes,
+    edge-case codegen) cannot have their param signature extracted, so the file
+    is skipped — the replay CLI is still usable directly against the output dir.
+
+    Shared by :class:`CompiledProgram` and
+    :class:`~pypto.ir.distributed_compiled_program.DistributedCompiledProgram`;
+    ``get_metadata`` is the caller's ``_get_metadata`` bound method.
+
+    Disable globally by setting ``PYPTO_EMIT_DEBUG_RUNNER=0`` (also accepts
+    ``false`` / ``no``).
+    """
+    if os.environ.get("PYPTO_EMIT_DEBUG_RUNNER", "").strip().lower() in ("0", "false", "no"):
+        return
+
+    from pypto.runtime.debug.run_script_writer import write_run_script  # noqa: PLC0415
+
+    try:
+        param_infos, _, _ = get_metadata()
+    except (ValueError, TypeError):
+        return
+    write_run_script(output_dir, param_infos, platform=platform)
+
+
+class _RuntimeFacade:
+    """Lazy compile-and-load of runtime artefacts.
+
+    Shared by :class:`CompiledProgram` and :class:`_SubChipCallable`. The host
+    class must define the backing fields ``_output_dir`` (Path), ``_platform``
+    (str), and the lazily-populated ``_chip_callable`` / ``_runtime_name`` /
+    ``_runtime_config`` (initialised to ``None``). A host may override
+    :meth:`_check_runtime_access` to forbid direct loading.
+    """
+
+    _output_dir: Path
+    _platform: str
+    _chip_callable: Any
+    _runtime_name: str | None
+    _runtime_config: dict[str, Any] | None
+
+    def _check_runtime_access(self) -> None:
+        """Hook run before the first compile-and-load. Default: allow.
+
+        Hosts that have no single canonical runtime (e.g. a multi-orch
+        :class:`CompiledProgram`) override this to redirect callers elsewhere.
+        """
+
+    def _ensure_runtime_loaded(self, pto_isa_commit: str | None = None) -> None:
+        if self._chip_callable is not None:
+            return
+        self._check_runtime_access()
+        from pypto.runtime.device_runner import compile_and_assemble  # noqa: PLC0415
+
+        cc, rn, rc = compile_and_assemble(self._output_dir, self._platform, pto_isa_commit)
+        self._chip_callable = cc
+        self._runtime_name = rn
+        self._runtime_config = rc
+
+    def load(self, *, pto_isa_commit: str | None = None) -> None:
+        """Eagerly compile-and-load the runtime artefacts.
+
+        Optional — :attr:`chip_callable`, :attr:`runtime_name`, and
+        :attr:`runtime_config` all auto-load on first access. Use this only when
+        you need to pin a specific ``pto_isa_commit`` (which must happen before
+        any property access, since the result is cached).
+
+        Raises:
+            RuntimeError: When runtime artefacts are already loaded and a
+                non-None ``pto_isa_commit`` is supplied — the cached build
+                cannot be re-pinned.
+        """
+        if self._chip_callable is not None and pto_isa_commit is not None:
+            raise RuntimeError(
+                "Runtime artefacts already loaded; pto_isa_commit cannot change. "
+                "Call load(pto_isa_commit=...) before any chip_callable / "
+                "runtime_name / runtime_config access."
+            )
+        self._ensure_runtime_loaded(pto_isa_commit)
+
+    @property
+    def chip_callable(self) -> Any:
+        """Simpler ``ChipCallable`` — hand to ``simpler.worker.Worker.register``."""
+        self._ensure_runtime_loaded()
+        return self._chip_callable
+
+    @property
+    def runtime_name(self) -> str:
+        """Runtime ABI name baked into ``kernel_config.py`` (e.g. ``"tensormap_and_ringbuffer"``)."""
+        self._ensure_runtime_loaded()
+        assert self._runtime_name is not None
+        return self._runtime_name
+
+    @property
+    def runtime_config(self) -> dict[str, Any]:
+        """``RUNTIME_CONFIG`` dict from ``kernel_config.py`` (e.g. ``block_dim``, ``aicpu_thread_num``)."""
+        self._ensure_runtime_loaded()
+        assert self._runtime_config is not None
+        return self._runtime_config
+
+
+class CompiledProgram(_RuntimeFacade):
     """A compiled PyPTO program that can be called with torch tensors.
 
     Returned by :func:`ir.compile`.  ``CompiledProgram`` is a **compiled
@@ -519,30 +627,7 @@ class CompiledProgram:
         # point; multi-orch programs have one sub-build (and one debug script)
         # per orch, emitted by each sub-build's own pipeline.
         if not self._sub_chip_dirs:
-            self._emit_debug_runner()
-
-    def _emit_debug_runner(self) -> None:
-        """Write ``<output_dir>/debug/run.py`` so the kernel can be replayed via
-        ``python .../debug/run.py``.
-
-        Best-effort: programs that lack a clean orchestration entry (unusual
-        shapes, edge-case codegen) cannot have their param signature extracted
-        here. In that case the file is skipped — the replay CLI is still usable
-        directly against the output directory.
-
-        Disable globally by setting ``PYPTO_EMIT_DEBUG_RUNNER=0`` (also accepts
-        ``false`` / ``no``).
-        """
-        if os.environ.get("PYPTO_EMIT_DEBUG_RUNNER", "").strip().lower() in ("0", "false", "no"):
-            return
-
-        from pypto.runtime.debug.run_script_writer import write_run_script  # noqa: PLC0415
-
-        try:
-            param_infos, _, _ = self._get_metadata()
-        except (ValueError, TypeError):
-            return
-        write_run_script(self._output_dir, param_infos, platform=self._platform)
+            _write_debug_runner(self._output_dir, self._platform, self._get_metadata)
 
     # --- Properties -----------------------------------------------------------
 
@@ -615,73 +700,20 @@ class CompiledProgram:
             )
         validate_pass_ir_codegen_results(str(passes_dump), tensors, expected, rtol=rtol, atol=atol)
 
-    # --- Runtime artefacts (lazy) --------------------------------------------
+    # --- Runtime artefacts (lazy) — see _RuntimeFacade -----------------------
     #
-    # These three properties expose the simpler-side products of
-    # ``compile_and_assemble`` so callers that want to drive execution
-    # themselves (e.g. with a hand-constructed ``simpler.worker.Worker``)
-    # can pull them out of the CompiledProgram. First access triggers
-    # the assemble step; the result is cached for the lifetime of the
-    # CompiledProgram. For programs that need ``pto_isa_commit`` pinned,
-    # call :meth:`load` explicitly before accessing the properties.
+    # load() / chip_callable / runtime_name / runtime_config live on the shared
+    # _RuntimeFacade base. A single-orch program loads on first access; a
+    # multi-orch program has no single canonical runtime, so the override below
+    # steers callers to the per-orch sub-callable instead.
 
-    def _ensure_runtime_loaded(self, pto_isa_commit: str | None = None) -> None:
-        if self._chip_callable is not None:
-            return
+    def _check_runtime_access(self) -> None:
         if self._sub_chip_dirs:
             raise TypeError(
                 f"Multi-orch program has {len(self._sub_chip_dirs)} orchestrations "
                 f"{sorted(self._sub_chip_dirs)}; access runtime artefacts via "
                 f"compiled[<name>] instead."
             )
-        from pypto.runtime.device_runner import compile_and_assemble  # noqa: PLC0415
-
-        cc, rn, rc = compile_and_assemble(self._output_dir, self._platform, pto_isa_commit)
-        self._chip_callable = cc
-        self._runtime_name = rn
-        self._runtime_config = rc
-
-    def load(self, *, pto_isa_commit: str | None = None) -> None:
-        """Eagerly compile-and-load the runtime artefacts.
-
-        Optional — :attr:`chip_callable`, :attr:`runtime_name`, and
-        :attr:`runtime_config` all auto-load on first access. Use this
-        only when you need to pin a specific ``pto_isa_commit`` (which
-        must happen before any property access, since the result is
-        cached).
-
-        Raises:
-            RuntimeError: When runtime artefacts are already loaded and
-                a non-None ``pto_isa_commit`` is supplied — the cached
-                build cannot be re-pinned.
-        """
-        if self._chip_callable is not None and pto_isa_commit is not None:
-            raise RuntimeError(
-                "Runtime artefacts already loaded; pto_isa_commit cannot change. "
-                "Call load(pto_isa_commit=...) before any chip_callable / "
-                "runtime_name / runtime_config access."
-            )
-        self._ensure_runtime_loaded(pto_isa_commit)
-
-    @property
-    def chip_callable(self) -> Any:
-        """Simpler ``ChipCallable`` — hand to ``simpler.worker.Worker.register``."""
-        self._ensure_runtime_loaded()
-        return self._chip_callable
-
-    @property
-    def runtime_name(self) -> str:
-        """Runtime ABI name baked into ``kernel_config.py`` (e.g. ``"tensormap_and_ringbuffer"``)."""
-        self._ensure_runtime_loaded()
-        assert self._runtime_name is not None
-        return self._runtime_name
-
-    @property
-    def runtime_config(self) -> dict[str, Any]:
-        """``RUNTIME_CONFIG`` dict from ``kernel_config.py`` (e.g. ``block_dim``, ``aicpu_thread_num``)."""
-        self._ensure_runtime_loaded()
-        assert self._runtime_config is not None
-        return self._runtime_config
 
     # --- Argument builders (for users driving a simpler.Worker directly) -----
 
@@ -890,7 +922,7 @@ class CompiledProgram:
         )
 
 
-class _SubChipCallable:
+class _SubChipCallable(_RuntimeFacade):
     """One L2 orchestration of a multi-orch :class:`CompiledProgram`.
 
     Returned by ``compiled[name]`` / ``compiled.<name>``. Self-contained:
@@ -930,47 +962,6 @@ class _SubChipCallable:
     @property
     def output_indices(self) -> list[int]:
         return list(self._output_indices)
-
-    # --- Runtime artefacts (lazy) — mirror CompiledProgram --------------------
-
-    def _ensure_runtime_loaded(self, pto_isa_commit: str | None = None) -> None:
-        if self._chip_callable is not None:
-            return
-        from pypto.runtime.device_runner import compile_and_assemble  # noqa: PLC0415
-
-        cc, rn, rc = compile_and_assemble(self._output_dir, self._platform, pto_isa_commit)
-        self._chip_callable = cc
-        self._runtime_name = rn
-        self._runtime_config = rc
-
-    def load(self, *, pto_isa_commit: str | None = None) -> None:
-        """Eagerly compile-and-load the runtime artefacts. Mirrors
-        :meth:`CompiledProgram.load`; see that method for full semantics.
-        """
-        if self._chip_callable is not None and pto_isa_commit is not None:
-            raise RuntimeError(
-                "Runtime artefacts already loaded; pto_isa_commit cannot change. "
-                "Call load(pto_isa_commit=...) before any chip_callable / "
-                "runtime_name / runtime_config access."
-            )
-        self._ensure_runtime_loaded(pto_isa_commit)
-
-    @property
-    def chip_callable(self) -> Any:
-        self._ensure_runtime_loaded()
-        return self._chip_callable
-
-    @property
-    def runtime_name(self) -> str:
-        self._ensure_runtime_loaded()
-        assert self._runtime_name is not None
-        return self._runtime_name
-
-    @property
-    def runtime_config(self) -> dict[str, Any]:
-        self._ensure_runtime_loaded()
-        assert self._runtime_config is not None
-        return self._runtime_config
 
     def build_orch_args(
         self,

--- a/python/pypto/ir/compiled_program.py
+++ b/python/pypto/ir/compiled_program.py
@@ -463,11 +463,13 @@ def _write_debug_runner(
 
     from pypto.runtime.debug.run_script_writer import write_run_script  # noqa: PLC0415
 
+    # Best-effort: neither metadata extraction nor writing the replay script may
+    # crash the compile/execute pipeline, so any failure just skips the file.
     try:
         param_infos, _, _ = get_metadata()
-    except (ValueError, TypeError):
+        write_run_script(output_dir, param_infos, platform=platform)
+    except Exception:  # noqa: BLE001
         return
-    write_run_script(output_dir, param_infos, platform=platform)
 
 
 class _RuntimeFacade:
@@ -500,9 +502,11 @@ class _RuntimeFacade:
         from pypto.runtime.device_runner import compile_and_assemble  # noqa: PLC0415
 
         cc, rn, rc = compile_and_assemble(self._output_dir, self._platform, pto_isa_commit)
-        self._chip_callable = cc
+        # Publish the "loaded" sentinel (_chip_callable) last so a reader can
+        # never observe it set while _runtime_name / _runtime_config are None.
         self._runtime_name = rn
         self._runtime_config = rc
+        self._chip_callable = cc
 
     def load(self, *, pto_isa_commit: str | None = None) -> None:
         """Eagerly compile-and-load the runtime artefacts.

--- a/python/pypto/ir/distributed_compiled_program.py
+++ b/python/pypto/ir/distributed_compiled_program.py
@@ -32,6 +32,7 @@ from pypto.runtime.device_tensor import DeviceTensor, StackedDeviceTensor
 from .compiled_program import (
     CallArg,
     _default_platform,
+    _extract_func_param_infos,
     _extract_param_infos,
     _param_info_from_dict,
     _param_info_to_dict,
@@ -39,6 +40,7 @@ from .compiled_program import (
     _to_torch_dtype,
     _validate_device_tensor,
     _validate_stacked_tensor,
+    _write_debug_runner,
 )
 
 # Filename of the small JSON sidecar persisted alongside the build artifacts so
@@ -50,34 +52,6 @@ _META_SCHEMA = 1
 if TYPE_CHECKING:
     from pypto.runtime.distributed_runner import DistributedWorker
     from pypto.runtime.runner import RunConfig
-
-
-def _extract_param_infos_from_func(func):
-    """Extract parameter metadata from a specific function."""
-    from pypto.pypto_core.ir import ConstInt, ParamDirection, ScalarType, ShapedType  # noqa: PLC0415
-
-    param_infos = []
-    output_indices = []
-
-    for i, (param, direction) in enumerate(zip(func.params, func.param_directions, strict=True)):
-        param_type = param.type
-        shape = None
-
-        if isinstance(param_type, ShapedType):
-            dtype = param_type.dtype
-            shape = [dim.value if isinstance(dim, ConstInt) else -1 for dim in param_type.shape]
-        elif isinstance(param_type, ScalarType):
-            dtype = param_type.dtype
-        else:
-            raise TypeError(
-                f"Unsupported parameter type for {param.name_hint!r}: {type(param_type).__name__}"
-            )
-
-        param_infos.append(_ParamInfo(name=param.name_hint, direction=direction, shape=shape, dtype=dtype))
-        if direction == ParamDirection.Out:
-            output_indices.append(i)
-
-    return param_infos, output_indices, list(func.return_types)
 
 
 @dataclass
@@ -151,27 +125,7 @@ class DistributedCompiledProgram:
         # already-present metadata file.
         if program is not None:
             self._persist_metadata()
-            self._emit_debug_runner()
-
-    def _emit_debug_runner(self) -> None:
-        """Write ``<output_dir>/debug/run.py`` for replaying this program.
-
-        Best-effort: distributed programs without a clean orchestration entry
-        will skip emission (the replay CLI is still usable directly).
-
-        Disable globally by setting ``PYPTO_EMIT_DEBUG_RUNNER=0`` (also accepts
-        ``false`` / ``no``).
-        """
-        if os.environ.get("PYPTO_EMIT_DEBUG_RUNNER", "").strip().lower() in ("0", "false", "no"):
-            return
-
-        from pypto.runtime.debug.run_script_writer import write_run_script  # noqa: PLC0415
-
-        try:
-            param_infos, _, _ = self._get_metadata()
-        except (ValueError, TypeError):
-            return
-        write_run_script(self._output_dir, param_infos, platform=self._platform)
+            _write_debug_runner(self._output_dir, self._platform, self._get_metadata)
 
     def _persist_metadata(self) -> None:
         """Write ``<output_dir>/distributed_meta.json`` for :meth:`from_dir`.
@@ -185,7 +139,7 @@ class DistributedCompiledProgram:
         layout and needs no persistence.
 
         Best-effort: a program without a resolvable orchestrator signature
-        skips emission (mirrors :meth:`_emit_debug_runner`); :meth:`from_dir`
+        skips emission (mirrors :func:`_write_debug_runner`); :meth:`from_dir`
         then reports the missing file with a recompile hint.
         """
         try:
@@ -327,7 +281,7 @@ class DistributedCompiledProgram:
                     break
 
             if host_orch is not None:
-                self._param_infos, self._output_indices, self._return_types = _extract_param_infos_from_func(
+                self._param_infos, self._output_indices, self._return_types = _extract_func_param_infos(
                     host_orch
                 )
             else:

--- a/python/pypto/ir/op/tensor_ops.py
+++ b/python/pypto/ir/op/tensor_ops.py
@@ -27,7 +27,7 @@ from pypto.pypto_core.ir import (
     TensorLayout,
 )
 
-from ..utils import _get_span_or_capture, _normalize_expr, _to_make_tuple, resolve_cast_mode
+from ..utils import _get_span_or_capture, _normalize_expr, _to_int32_scalar, _to_make_tuple, resolve_cast_mode
 from ._pad_value import normalize_pad_value
 from .tile_ops import resolve_gather_compare_cmp_mode
 
@@ -172,15 +172,6 @@ def ci(
 
 
 arange = ci
-
-
-def _to_int32_scalar(value: int | Expr, span: Span) -> Expr:
-    """Normalize a seed value to an INT32 scalar expression."""
-    if isinstance(value, Expr):
-        if isinstance(value, ConstInt) and value.dtype != DataType.INT32:
-            return ConstInt(value.value, DataType.INT32, span)
-        return value
-    return ConstInt(value, DataType.INT32, span)
 
 
 def random(

--- a/python/pypto/ir/op/tile_ops.py
+++ b/python/pypto/ir/op/tile_ops.py
@@ -31,7 +31,7 @@ from pypto.pypto_core.ir import (
     TileLayout,
 )
 
-from ..utils import _get_span_or_capture, _normalize_expr, _to_make_tuple, resolve_cast_mode
+from ..utils import _get_span_or_capture, _normalize_expr, _to_int32_scalar, _to_make_tuple, resolve_cast_mode
 from ._pad_value import normalize_pad_value
 
 
@@ -608,15 +608,6 @@ def ci(
 
 
 arange = ci
-
-
-def _to_int32_scalar(value: int | Expr, span: Span) -> Expr:
-    """Normalize a seed value to an INT32 scalar expression."""
-    if isinstance(value, Expr):
-        if isinstance(value, ConstInt) and value.dtype != DataType.INT32:
-            return ConstInt(value.value, DataType.INT32, span)
-        return value
-    return ConstInt(value, DataType.INT32, span)
 
 
 def random(  # noqa: PLR0913

--- a/python/pypto/ir/utils.py
+++ b/python/pypto/ir/utils.py
@@ -202,11 +202,25 @@ def has_partial_valid_region(expr: _ir.Expr) -> bool:
     return view is not None and bool(view.valid_shape)
 
 
+def _to_int32_scalar(value: int | _ir.Expr, span: _ir.Span) -> _ir.Expr:
+    """Normalize a seed value to an INT32 scalar expression.
+
+    Shared by the counter-based ``random`` ops (tensor and tile), which coerce
+    every key/counter word to an INT32 scalar before building the call.
+    """
+    if isinstance(value, _ir.Expr):
+        if isinstance(value, _ir.ConstInt) and value.dtype != DataType.INT32:
+            return _ir.ConstInt(value.value, DataType.INT32, span)
+        return value
+    return _ir.ConstInt(value, DataType.INT32, span)
+
+
 __all__ = [
     "CAST_MODE_NAMES",
     "_get_span_or_capture",
     "_normalize_expr",
     "_normalize_shape",
+    "_to_int32_scalar",
     "_to_make_tuple",
     "has_partial_valid_region",
     "resolve_cast_mode",

--- a/python/pypto/jit/specializer.py
+++ b/python/pypto/jit/specializer.py
@@ -399,20 +399,6 @@ def _collect_annotation_dynamic_dims_cached(
     return dims, bindings, literals
 
 
-def _collect_dep_names(func_def: ast.FunctionDef, jit_func_names: set[str]) -> list[str]:
-    """Return names of @pl.jit.incore functions called in this function body."""
-    deps: list[str] = []
-    seen: set[str] = set()
-    for node in ast.walk(func_def):
-        if not isinstance(node, ast.Call):
-            continue
-        func = node.func
-        if isinstance(func, ast.Name) and func.id in jit_func_names and func.id not in seen:
-            deps.append(func.id)
-            seen.add(func.id)
-    return deps
-
-
 # ---------------------------------------------------------------------------
 # Build annotated type string for a parameter
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Removes duplication across the IR Python layer, in three independent groups (combines what were PRs #2054 and #2055).

### 1. Compiled-program runtime facade
`CompiledProgram`, `_SubChipCallable`, and `DistributedCompiledProgram` each re-maintained the same runtime facade.
- **Unify param-metadata extraction.** `distributed_compiled_program._extract_param_infos_from_func` was a verbatim copy of `compiled_program._extract_func_param_infos` that had drifted to a bare/untyped signature and a shorter error message. Deleted it; the distributed path reuses `_extract_func_param_infos`. Only observable change: the distributed `TypeError` gains the richer `". Expected ShapedType or ScalarType."` wording.
- **Share the debug-runner emitter.** The byte-identical `_emit_debug_runner` bodies become one module-level `_write_debug_runner(output_dir, platform, get_metadata)`.
- **Light runtime-facade mixin.** `load` / `chip_callable` / `runtime_name` / `runtime_config` / `_ensure_runtime_loaded`, duplicated between `CompiledProgram` and `_SubChipCallable`, move into a `_RuntimeFacade` mixin. `CompiledProgram`'s multi-orch guard is preserved via an overridable `_check_runtime_access()` hook. `DistributedCompiledProgram` has no such facade and is untouched — no `__call__` / execution semantics are merged.

### 2. Small shared helpers
- **`_to_int32_scalar`** (RNG seed normalizer) was copy-pasted byte-for-byte in `op/tensor_ops.py` and `op/tile_ops.py`; moved to the shared `ir/utils.py`.
- **Builder `output()` / `outputs()`** — identical across `ForLoopBuilder` / `WhileLoopBuilder` / `IfStmtBuilder` (differing only in the "for loop" / "while loop" / "if statement" message label) — extracted into a `_ReturnVarsAccessor` mixin; each builder sets `_result_kind`.

### 3. Dead code
- `jit/specializer._collect_dep_names` had no callers anywhere — deleted.

### Review feedback addressed
- Builder `output()`/`outputs()` raise `RuntimeError` (not `assert`, which `-O` strips).
- `_write_debug_runner` wraps the script write in its best-effort try/except so a debug-file I/O error never crashes compilation.
- `_RuntimeFacade._ensure_runtime_loaded` publishes the `_chip_callable` sentinel last, after `_runtime_name` / `_runtime_config`.

## Not in scope
- Two items from the original review were already resolved by #2035 (ST fuzz framework removal): `_analyze_input_usage` and the Torch golden op-conversion duplication.
- `DistributedCompiledProgram`'s static `_build_full_args` near-duplicates the module-level one but intentionally omits an in-place-style hint in its `ValueError`; merging it would change a user-facing message, so it is left as a follow-up.

## Testing
- `ruff check` + `ruff format --check` + `pyright` (pre-commit): clean.
- `tests/ut/ir/` + `tests/ut/jit/`: 4935 passed, 1 skipped (rebuilt `pypto_core`).
- `test_compiled_program.py`, `test_distributed_compiled_program.py`, `test_run_script_writer.py`, `test_builder.py`: 149 passed.
- (3 unrelated `test_run_config.py` dfx tests fail locally on a stale `simpler` package — `ImportError: Tensor from simpler.task_interface` — an environment issue independent of this change.)