### PR TITLE
feat(ir): add system.cacheinvalid cache-line invalidate op

### DIFF
--- a/docs/en/dev/ir/05-operators.md
+++ b/docs/en/dev/ir/05-operators.md
@@ -337,7 +337,7 @@ with ib.function("tile_computation") as f:
 | `system.bar_v` | Vector barrier | None |
 | `system.bar_m` | Matrix barrier | None |
 | `system.fence` | Memory barrier over global memory (lowers to `pto.fence.barrier_all #pto.fence_scope<gm>`) | None |
-| `system.cacheinvalid` | Invalidate a single cache line at `tensor` base + `offset` (lowers to `pto.addptr` + `pto.cmo.cacheinvalid %write_ptr single_cache_line`). Args: `tensor`, `offset` | None |
+| `system.cacheinvalid` | Invalidate the cache lines backing a tensor sub-region. Args: `tensor`, `offsets` (N-D), `shapes` (N-D). All-1 `shapes` (scalar write) lowers to `pto.addptr` + `pto.cmo.cacheinvalid %write_ptr single_cache_line`; a larger region (tile store) lowers to `pto.partition_view` + `pto.cmo.cacheinvalid %payload_view single_cache_line : !pto.partition_tensor_view<...>` | None |
 | `system.syncall` | Cross-core all-participant barrier (`pto::SYNCALL`). `mode="hard"` (FFTS, no operands) or `mode="soft"` (GM-polling, operands) | `core_type` (`"aiv_only"` \| `"aic_only"` \| `"mix"`), `mode` (`"hard"` \| `"soft"`) |
 | `system.sync_src` | Set sync flag | `set_pipe`, `wait_pipe`, `event_id` |
 | `system.sync_dst` | Wait sync flag | `set_pipe`, `wait_pipe`, `event_id` |

--- a/docs/en/dev/ir/05-operators.md
+++ b/docs/en/dev/ir/05-operators.md
@@ -337,6 +337,7 @@ with ib.function("tile_computation") as f:
 | `system.bar_v` | Vector barrier | None |
 | `system.bar_m` | Matrix barrier | None |
 | `system.fence` | Memory barrier over global memory (lowers to `pto.fence.barrier_all #pto.fence_scope<gm>`) | None |
+| `system.cacheinvalid` | Invalidate a single cache line at `tensor` base + `offset` (lowers to `pto.addptr` + `pto.cmo.cacheinvalid %write_ptr single_cache_line`). Args: `tensor`, `offset` | None |
 | `system.syncall` | Cross-core all-participant barrier (`pto::SYNCALL`). `mode="hard"` (FFTS, no operands) or `mode="soft"` (GM-polling, operands) | `core_type` (`"aiv_only"` \| `"aic_only"` \| `"mix"`), `mode` (`"hard"` \| `"soft"`) |
 | `system.sync_src` | Set sync flag | `set_pipe`, `wait_pipe`, `event_id` |
 | `system.sync_dst` | Wait sync flag | `set_pipe`, `wait_pipe`, `event_id` |

--- a/docs/en/dev/ir/05-operators.md
+++ b/docs/en/dev/ir/05-operators.md
@@ -337,7 +337,7 @@ with ib.function("tile_computation") as f:
 | `system.bar_v` | Vector barrier | None |
 | `system.bar_m` | Matrix barrier | None |
 | `system.fence` | Memory barrier over global memory (lowers to `pto.fence.barrier_all #pto.fence_scope<gm>`) | None |
-| `system.cacheinvalid` | Invalidate the cache lines backing a tensor sub-region. Args: `tensor`, `offsets` (N-D), `shapes` (N-D). All-1 `shapes` (scalar write) lowers to `pto.addptr` + `pto.cmo.cacheinvalid %write_ptr single_cache_line`; a larger region (tile store) lowers to `pto.partition_view` + `pto.cmo.cacheinvalid %payload_view single_cache_line : !pto.partition_tensor_view<...>` | None |
+| `system.cacheinvalid` | Invalidate the cache lines backing a tensor sub-region. Args: `tensor`, `shapes` (N-D), `offsets` (N-D). All-1 `shapes` (scalar write) lowers to `pto.addptr` + `pto.cmo.cacheinvalid %write_ptr single_cache_line`; a larger region (tile store) lowers to `pto.partition_view` + `pto.cmo.cacheinvalid %payload_view single_cache_line : !pto.partition_tensor_view<...>` | None |
 | `system.syncall` | Cross-core all-participant barrier (`pto::SYNCALL`). `mode="hard"` (FFTS, no operands) or `mode="soft"` (GM-polling, operands) | `core_type` (`"aiv_only"` \| `"aic_only"` \| `"mix"`), `mode` (`"hard"` \| `"soft"`) |
 | `system.sync_src` | Set sync flag | `set_pipe`, `wait_pipe`, `event_id` |
 | `system.sync_dst` | Wait sync flag | `set_pipe`, `wait_pipe`, `event_id` |

--- a/docs/zh-cn/dev/ir/05-operators.md
+++ b/docs/zh-cn/dev/ir/05-operators.md
@@ -331,6 +331,7 @@ with ib.function("tile_computation") as f:
 | `system.bar_v` | 向量屏障 | 无 |
 | `system.bar_m` | 矩阵屏障 | 无 |
 | `system.fence` | 全局内存屏障（下降为 `pto.fence.barrier_all #pto.fence_scope<gm>`） | 无 |
+| `system.cacheinvalid` | 使 `tensor` 基址 + `offset` 处的单个 cache line 失效（下降为 `pto.addptr` + `pto.cmo.cacheinvalid %write_ptr single_cache_line`）。参数：`tensor`、`offset` | 无 |
 | `system.syncall` | 跨核全员屏障（`pto::SYNCALL`）。`mode="hard"`（FFTS，无 operand）或 `mode="soft"`（GM 轮询，带 operand） | `core_type`（`"aiv_only"` \| `"aic_only"` \| `"mix"`）、`mode`（`"hard"` \| `"soft"`） |
 | `system.sync_src` | 设置同步标志 | `set_pipe`, `wait_pipe`, `event_id` |
 | `system.sync_dst` | 等待同步标志 | `set_pipe`, `wait_pipe`, `event_id` |

--- a/docs/zh-cn/dev/ir/05-operators.md
+++ b/docs/zh-cn/dev/ir/05-operators.md
@@ -331,7 +331,7 @@ with ib.function("tile_computation") as f:
 | `system.bar_v` | 向量屏障 | 无 |
 | `system.bar_m` | 矩阵屏障 | 无 |
 | `system.fence` | 全局内存屏障（下降为 `pto.fence.barrier_all #pto.fence_scope<gm>`） | 无 |
-| `system.cacheinvalid` | 使 `tensor` 基址 + `offset` 处的单个 cache line 失效（下降为 `pto.addptr` + `pto.cmo.cacheinvalid %write_ptr single_cache_line`）。参数：`tensor`、`offset` | 无 |
+| `system.cacheinvalid` | 使 tensor 某个子区域对应的 cache line 失效。参数：`tensor`、`offsets`（N 维）、`shapes`（N 维）。`shapes` 全为 1（标量写）时下降为 `pto.addptr` + `pto.cmo.cacheinvalid %write_ptr single_cache_line`；区域更大（TStore 写）时下降为 `pto.partition_view` + `pto.cmo.cacheinvalid %payload_view single_cache_line : !pto.partition_tensor_view<...>` | 无 |
 | `system.syncall` | 跨核全员屏障（`pto::SYNCALL`）。`mode="hard"`（FFTS，无 operand）或 `mode="soft"`（GM 轮询，带 operand） | `core_type`（`"aiv_only"` \| `"aic_only"` \| `"mix"`）、`mode`（`"hard"` \| `"soft"`） |
 | `system.sync_src` | 设置同步标志 | `set_pipe`, `wait_pipe`, `event_id` |
 | `system.sync_dst` | 等待同步标志 | `set_pipe`, `wait_pipe`, `event_id` |

--- a/docs/zh-cn/dev/ir/05-operators.md
+++ b/docs/zh-cn/dev/ir/05-operators.md
@@ -331,7 +331,7 @@ with ib.function("tile_computation") as f:
 | `system.bar_v` | 向量屏障 | 无 |
 | `system.bar_m` | 矩阵屏障 | 无 |
 | `system.fence` | 全局内存屏障（下降为 `pto.fence.barrier_all #pto.fence_scope<gm>`） | 无 |
-| `system.cacheinvalid` | 使 tensor 某个子区域对应的 cache line 失效。参数：`tensor`、`offsets`（N 维）、`shapes`（N 维）。`shapes` 全为 1（标量写）时下降为 `pto.addptr` + `pto.cmo.cacheinvalid %write_ptr single_cache_line`；区域更大（TStore 写）时下降为 `pto.partition_view` + `pto.cmo.cacheinvalid %payload_view single_cache_line : !pto.partition_tensor_view<...>` | 无 |
+| `system.cacheinvalid` | 使 tensor 某个子区域对应的 cache line 失效。参数：`tensor`、`shapes`（N 维）、`offsets`（N 维）。`shapes` 全为 1（标量写）时下降为 `pto.addptr` + `pto.cmo.cacheinvalid %write_ptr single_cache_line`；区域更大（TStore 写）时下降为 `pto.partition_view` + `pto.cmo.cacheinvalid %payload_view single_cache_line : !pto.partition_tensor_view<...>` | 无 |
 | `system.syncall` | 跨核全员屏障（`pto::SYNCALL`）。`mode="hard"`（FFTS，无 operand）或 `mode="soft"`（GM 轮询，带 operand） | `core_type`（`"aiv_only"` \| `"aic_only"` \| `"mix"`）、`mode`（`"hard"` \| `"soft"`） |
 | `system.sync_src` | 设置同步标志 | `set_pipe`, `wait_pipe`, `event_id` |
 | `system.sync_dst` | 等待同步标志 | `set_pipe`, `wait_pipe`, `event_id` |

--- a/python/pypto/debug/torch_codegen.py
+++ b/python/pypto/debug/torch_codegen.py
@@ -1065,6 +1065,7 @@ def _register_ops() -> None:  # noqa: PLR0915
         "system.bar_m",
         "system.bar_all",
         "system.fence",
+        "system.cacheinvalid",
         "system.aic_initialize_pipe",
         "system.aiv_initialize_pipe",
         "system.reserve_buffer",

--- a/python/pypto/ir/op/system_ops.py
+++ b/python/pypto/ir/op/system_ops.py
@@ -145,14 +145,14 @@ def fence(*, span: Span | None = None) -> Call:
 
 def cacheinvalid(
     tensor: Expr,
+    shapes: Sequence[int | Expr],
     offsets: Sequence[int | Expr],
-    shapes: Sequence[int | Expr] | None = None,
     *,
     span: Span | None = None,
 ) -> Call:
     """Invalidate the cache lines backing a tensor sub-region.
 
-    The op carries an N-D ``offsets`` and ``shapes`` (both matching the tensor
+    The op carries an N-D ``shapes`` and ``offsets`` (both matching the tensor
     rank). Codegen picks the lowering by the region size:
 
     - ``shapes`` all 1 (scalar write): flatten ``offsets`` and lower to
@@ -162,9 +162,9 @@ def cacheinvalid(
 
     Args:
         tensor: Target tensor whose sub-region is invalidated
+        shapes: Per-dimension region sizes; length must equal the tensor rank
+            (all 1 selects the scalar-write / ptr form)
         offsets: Per-dimension start offsets; length must equal the tensor rank
-        shapes: Per-dimension region sizes; length must equal the tensor rank.
-            Defaults to all-1 (the scalar-write / ptr form)
         span: Optional source span for debugging (auto-captured if not provided)
 
     Returns:
@@ -177,22 +177,22 @@ def cacheinvalid(
         raise TypeError(f"system.cacheinvalid tensor must have TensorType, got {tensor_type}")
     rank = len(tensor_type.shape)
 
+    shapes = list(shapes)
+    if len(shapes) != rank:
+        raise ValueError(f"system.cacheinvalid shapes must match tensor rank {rank}, got {len(shapes)}")
     offsets = list(offsets)
     if len(offsets) != rank:
         raise ValueError(f"system.cacheinvalid offsets must match tensor rank {rank}, got {len(offsets)}")
-    shapes = [1] * rank if shapes is None else list(shapes)
-    if len(shapes) != rank:
-        raise ValueError(f"system.cacheinvalid shapes must match tensor rank {rank}, got {len(shapes)}")
 
-    offsets_tuple = _to_make_tuple(offsets, actual_span)
     shapes_tuple = _to_make_tuple(shapes, actual_span)
-    for name, elems in (("offsets", offsets_tuple.elements), ("shapes", shapes_tuple.elements)):
+    offsets_tuple = _to_make_tuple(offsets, actual_span)
+    for name, elems in (("shapes", shapes_tuple.elements), ("offsets", offsets_tuple.elements)):
         for elem in elems:
             elem_type = elem.type
             if isinstance(elem_type, ScalarType) and elem_type.dtype.is_float():
                 raise TypeError(f"system.cacheinvalid {name} must be integers, got dtype {elem_type.dtype}")
     return _ir_core.create_op_call(
-        "system.cacheinvalid", [tensor, offsets_tuple, shapes_tuple], {}, actual_span
+        "system.cacheinvalid", [tensor, shapes_tuple, offsets_tuple], {}, actual_span
     )
 
 

--- a/python/pypto/ir/op/system_ops.py
+++ b/python/pypto/ir/op/system_ops.py
@@ -22,7 +22,7 @@ from typing import Protocol, runtime_checkable
 
 from pypto.pypto_core import DataType
 from pypto.pypto_core import ir as _ir_core
-from pypto.pypto_core.ir import Call, ConstInt, Expr, PipeType, Span
+from pypto.pypto_core.ir import Call, ConstInt, Expr, PipeType, ScalarType, Span
 
 from ..utils import _get_span_or_capture, _normalize_expr
 from .tile_ops import (  # noqa: F401
@@ -158,6 +158,11 @@ def cacheinvalid(tensor: Expr, offset: int | Expr = 0, *, span: Span | None = No
     """
     actual_span = _get_span_or_capture(span)
     offset_expr = _normalize_expr(offset, actual_span)
+    offset_type = offset_expr.type
+    if isinstance(offset_type, ScalarType) and offset_type.dtype.is_float():
+        raise TypeError(
+            f"system.cacheinvalid offset must be an integer scalar, got dtype {offset_type.dtype}"
+        )
     return _ir_core.create_op_call("system.cacheinvalid", [tensor, offset_expr], {}, actual_span)
 
 

--- a/python/pypto/ir/op/system_ops.py
+++ b/python/pypto/ir/op/system_ops.py
@@ -18,13 +18,14 @@ System operations handle hardware synchronization and cross-core communication:
 - reserve_buffer / import_peer_buffer: Cross-core buffer management (i32 SSA results)
 """
 
+from collections.abc import Sequence
 from typing import Protocol, runtime_checkable
 
 from pypto.pypto_core import DataType
 from pypto.pypto_core import ir as _ir_core
-from pypto.pypto_core.ir import Call, ConstInt, Expr, PipeType, ScalarType, Span
+from pypto.pypto_core.ir import Call, ConstInt, Expr, PipeType, ScalarType, Span, TensorType
 
-from ..utils import _get_span_or_capture, _normalize_expr
+from ..utils import _get_span_or_capture, _to_make_tuple
 from .tile_ops import (  # noqa: F401
     tpop_from_aic,
     tpop_from_aiv,
@@ -142,28 +143,57 @@ def fence(*, span: Span | None = None) -> Call:
     return _create_barrier_op("system.fence", span=span)
 
 
-def cacheinvalid(tensor: Expr, offset: int | Expr = 0, *, span: Span | None = None) -> Call:
-    """Invalidate a single cache line at ``tensor`` base pointer + ``offset``.
+def cacheinvalid(
+    tensor: Expr,
+    offsets: Sequence[int | Expr],
+    shapes: Sequence[int | Expr] | None = None,
+    *,
+    span: Span | None = None,
+) -> Call:
+    """Invalidate the cache lines backing a tensor sub-region.
 
-    Lowers to ``pto.addptr`` (base + offset) followed by
-    ``pto.cmo.cacheinvalid %write_ptr single_cache_line``.
+    The op carries an N-D ``offsets`` and ``shapes`` (both matching the tensor
+    rank). Codegen picks the lowering by the region size:
+
+    - ``shapes`` all 1 (scalar write): flatten ``offsets`` and lower to
+      ``pto.addptr`` + ``pto.cmo.cacheinvalid %write_ptr single_cache_line``.
+    - otherwise (tile store): lower to ``pto.partition_view`` +
+      ``pto.cmo.cacheinvalid %payload_view single_cache_line : !pto.partition_tensor_view<...>``.
 
     Args:
-        tensor: Target tensor whose write pointer is invalidated
-        offset: Element offset added to the base pointer (int or integer Expr)
+        tensor: Target tensor whose sub-region is invalidated
+        offsets: Per-dimension start offsets; length must equal the tensor rank
+        shapes: Per-dimension region sizes; length must equal the tensor rank.
+            Defaults to all-1 (the scalar-write / ptr form)
         span: Optional source span for debugging (auto-captured if not provided)
 
     Returns:
         Call expression for system.cacheinvalid
     """
     actual_span = _get_span_or_capture(span)
-    offset_expr = _normalize_expr(offset, actual_span)
-    offset_type = offset_expr.type
-    if isinstance(offset_type, ScalarType) and offset_type.dtype.is_float():
-        raise TypeError(
-            f"system.cacheinvalid offset must be an integer scalar, got dtype {offset_type.dtype}"
-        )
-    return _ir_core.create_op_call("system.cacheinvalid", [tensor, offset_expr], {}, actual_span)
+
+    tensor_type = tensor.type
+    if not isinstance(tensor_type, TensorType):
+        raise TypeError(f"system.cacheinvalid tensor must have TensorType, got {tensor_type}")
+    rank = len(tensor_type.shape)
+
+    offsets = list(offsets)
+    if len(offsets) != rank:
+        raise ValueError(f"system.cacheinvalid offsets must match tensor rank {rank}, got {len(offsets)}")
+    shapes = [1] * rank if shapes is None else list(shapes)
+    if len(shapes) != rank:
+        raise ValueError(f"system.cacheinvalid shapes must match tensor rank {rank}, got {len(shapes)}")
+
+    offsets_tuple = _to_make_tuple(offsets, actual_span)
+    shapes_tuple = _to_make_tuple(shapes, actual_span)
+    for name, elems in (("offsets", offsets_tuple.elements), ("shapes", shapes_tuple.elements)):
+        for elem in elems:
+            elem_type = elem.type
+            if isinstance(elem_type, ScalarType) and elem_type.dtype.is_float():
+                raise TypeError(f"system.cacheinvalid {name} must be integers, got dtype {elem_type.dtype}")
+    return _ir_core.create_op_call(
+        "system.cacheinvalid", [tensor, offsets_tuple, shapes_tuple], {}, actual_span
+    )
 
 
 _SYNCALL_CORE_TYPES = ("aiv_only", "aic_only", "mix")

--- a/python/pypto/ir/op/system_ops.py
+++ b/python/pypto/ir/op/system_ops.py
@@ -24,7 +24,7 @@ from pypto.pypto_core import DataType
 from pypto.pypto_core import ir as _ir_core
 from pypto.pypto_core.ir import Call, ConstInt, Expr, PipeType, Span
 
-from ..utils import _get_span_or_capture
+from ..utils import _get_span_or_capture, _normalize_expr
 from .tile_ops import (  # noqa: F401
     tpop_from_aic,
     tpop_from_aiv,
@@ -140,6 +140,25 @@ def fence(*, span: Span | None = None) -> Call:
     Lowers to ``pto.fence.barrier_all #pto.fence_scope<gm>``.
     """
     return _create_barrier_op("system.fence", span=span)
+
+
+def cacheinvalid(tensor: Expr, offset: int | Expr = 0, *, span: Span | None = None) -> Call:
+    """Invalidate a single cache line at ``tensor`` base pointer + ``offset``.
+
+    Lowers to ``pto.addptr`` (base + offset) followed by
+    ``pto.cmo.cacheinvalid %write_ptr single_cache_line``.
+
+    Args:
+        tensor: Target tensor whose write pointer is invalidated
+        offset: Element offset added to the base pointer (int or integer Expr)
+        span: Optional source span for debugging (auto-captured if not provided)
+
+    Returns:
+        Call expression for system.cacheinvalid
+    """
+    actual_span = _get_span_or_capture(span)
+    offset_expr = _normalize_expr(offset, actual_span)
+    return _ir_core.create_op_call("system.cacheinvalid", [tensor, offset_expr], {}, actual_span)
 
 
 _SYNCALL_CORE_TYPES = ("aiv_only", "aic_only", "mix")

--- a/python/pypto/language/op/system_ops.py
+++ b/python/pypto/language/op/system_ops.py
@@ -172,19 +172,32 @@ def syncall(
     return _ir_ops.syncall_soft(core_type, args, span=actual_span)
 
 
-def cacheinvalid(tensor: Tensor, offset: int | Scalar = 0, *, span: Span | None = None) -> Call:
-    """Invalidate a single cache line at the tensor's write pointer + offset.
+def cacheinvalid(
+    tensor: Tensor,
+    offsets: Sequence[int | Scalar],
+    shapes: Sequence[int | Scalar] | None = None,
+    *,
+    span: Span | None = None,
+) -> Call:
+    """Invalidate the cache lines backing a tensor sub-region.
 
-    Lowers to ``pto.addptr`` (base + offset) followed by
-    ``pto.cmo.cacheinvalid %write_ptr single_cache_line``.
+    Codegen picks the lowering by the region size:
+
+    - ``shapes`` all 1 (scalar write): ``pto.addptr`` +
+      ``pto.cmo.cacheinvalid %write_ptr single_cache_line``.
+    - otherwise (tile store): ``pto.partition_view`` +
+      ``pto.cmo.cacheinvalid %payload_view single_cache_line : !pto.partition_tensor_view<...>``.
 
     Args:
-        tensor: Target tensor whose write pointer is invalidated.
-        offset: Element offset added to the base pointer (compile-time int or Scalar).
+        tensor: Target tensor whose sub-region is invalidated.
+        offsets: Per-dimension start offsets; length must equal the tensor rank.
+        shapes: Per-dimension region sizes; length must equal the tensor rank.
+            Defaults to all-1 (the scalar-write / ptr form).
         span: Optional source span for debugging (auto-captured if not provided).
     """
-    off = offset.unwrap() if isinstance(offset, Scalar) else offset
-    return _ir_ops.cacheinvalid(tensor.unwrap(), off, span=span)
+    off = [o.unwrap() if isinstance(o, Scalar) else o for o in offsets]
+    shp = None if shapes is None else [s.unwrap() if isinstance(s, Scalar) else s for s in shapes]
+    return _ir_ops.cacheinvalid(tensor.unwrap(), off, shp, span=span)
 
 
 def tpush_to_aiv(tile: Tile, *, split: int, id: int | None = None, span: Span | None = None) -> Call:

--- a/python/pypto/language/op/system_ops.py
+++ b/python/pypto/language/op/system_ops.py
@@ -45,6 +45,7 @@ __all__ = [
     "bar_m",
     "bar_all",
     "fence",
+    "cacheinvalid",
     "syncall",
     "tpush_to_aiv",
     "tpush_to_aic",
@@ -169,6 +170,21 @@ def syncall(
         scratch_l1 = _l1_scratch(scratch_l1)
         args = [gm_workspace.unwrap(), scratch.unwrap(), scratch_l1.unwrap(), used_const]
     return _ir_ops.syncall_soft(core_type, args, span=actual_span)
+
+
+def cacheinvalid(tensor: Tensor, offset: int | Scalar = 0, *, span: Span | None = None) -> Call:
+    """Invalidate a single cache line at the tensor's write pointer + offset.
+
+    Lowers to ``pto.addptr`` (base + offset) followed by
+    ``pto.cmo.cacheinvalid %write_ptr single_cache_line``.
+
+    Args:
+        tensor: Target tensor whose write pointer is invalidated.
+        offset: Element offset added to the base pointer (compile-time int or Scalar).
+        span: Optional source span for debugging (auto-captured if not provided).
+    """
+    off = offset.unwrap() if isinstance(offset, Scalar) else offset
+    return _ir_ops.cacheinvalid(tensor.unwrap(), off, span=span)
 
 
 def tpush_to_aiv(tile: Tile, *, split: int, id: int | None = None, span: Span | None = None) -> Call:

--- a/python/pypto/language/op/system_ops.py
+++ b/python/pypto/language/op/system_ops.py
@@ -174,8 +174,8 @@ def syncall(
 
 def cacheinvalid(
     tensor: Tensor,
+    shapes: Sequence[int | Scalar],
     offsets: Sequence[int | Scalar],
-    shapes: Sequence[int | Scalar] | None = None,
     *,
     span: Span | None = None,
 ) -> Call:
@@ -190,14 +190,14 @@ def cacheinvalid(
 
     Args:
         tensor: Target tensor whose sub-region is invalidated.
+        shapes: Per-dimension region sizes; length must equal the tensor rank
+            (all 1 selects the scalar-write / ptr form).
         offsets: Per-dimension start offsets; length must equal the tensor rank.
-        shapes: Per-dimension region sizes; length must equal the tensor rank.
-            Defaults to all-1 (the scalar-write / ptr form).
         span: Optional source span for debugging (auto-captured if not provided).
     """
+    shp = [s.unwrap() if isinstance(s, Scalar) else s for s in shapes]
     off = [o.unwrap() if isinstance(o, Scalar) else o for o in offsets]
-    shp = None if shapes is None else [s.unwrap() if isinstance(s, Scalar) else s for s in shapes]
-    return _ir_ops.cacheinvalid(tensor.unwrap(), off, shp, span=span)
+    return _ir_ops.cacheinvalid(tensor.unwrap(), shp, off, span=span)
 
 
 def tpush_to_aiv(tile: Tile, *, split: int, id: int | None = None, span: Span | None = None) -> Call:

--- a/src/backend/common/pto_ops_memory.cpp
+++ b/src/backend/common/pto_ops_memory.cpp
@@ -815,6 +815,21 @@ void RegisterMemoryOps(Backend& backend, const std::unordered_set<std::string>& 
     codegen.Emit("pto.fence.barrier_all #pto.fence_scope<gm>");
     return std::string("");
   });
+
+  reg("system.cacheinvalid", [](const ir::CallPtr& op, codegen::CodegenBase& codegen_base) {
+    auto& codegen = AsPto(codegen_base);
+    INTERNAL_CHECK_SPAN(op->args_.size() == 2, op->span_)
+        << "system.cacheinvalid takes 2 arguments (tensor, offset), got " << op->args_.size();
+    auto tensor_type = AsTensorTypeLike(op->args_[0]->GetType());
+    INTERNAL_CHECK_SPAN(tensor_type, op->span_) << "system.cacheinvalid first argument must be a tensor";
+    const std::string base_ptr = codegen.GetTensorBasePtr(AsVarLike(op->args_[0]));
+    const std::string ptr_type = "!pto.ptr<" + codegen.GetTypeString(tensor_type->dtype_) + ">";
+    const std::string off = codegen.EmitCastToIndex(op->args_[1], codegen.GetExprAsCode(op->args_[1]));
+    const std::string write_ptr = codegen.NewTemp();
+    codegen.Emit(write_ptr + " = pto.addptr " + base_ptr + ", " + off + " : " + ptr_type + " -> " + ptr_type);
+    codegen.Emit("pto.cmo.cacheinvalid " + write_ptr + " single_cache_line");
+    return std::string("");
+  });
 }
 }  // namespace backend
 }  // namespace pypto

--- a/src/backend/common/pto_ops_memory.cpp
+++ b/src/backend/common/pto_ops_memory.cpp
@@ -818,19 +818,52 @@ void RegisterMemoryOps(Backend& backend, const std::unordered_set<std::string>& 
 
   reg("system.cacheinvalid", [](const ir::CallPtr& op, codegen::CodegenBase& codegen_base) {
     auto& codegen = AsPto(codegen_base);
-    INTERNAL_CHECK_SPAN(op->args_.size() == 2, op->span_)
-        << "system.cacheinvalid takes 2 arguments (tensor, offset), got " << op->args_.size();
-    auto tensor_type = AsTensorTypeLike(op->args_[0]->GetType());
-    INTERNAL_CHECK_SPAN(tensor_type, op->span_) << "system.cacheinvalid first argument must be a tensor";
+    INTERNAL_CHECK_SPAN(op->args_.size() == 3, op->span_)
+        << "system.cacheinvalid takes 3 arguments (tensor, offsets, shapes), got " << op->args_.size();
     const auto tensor_var = AsVarLike(op->args_[0]);
     INTERNAL_CHECK_SPAN(tensor_var, op->span_)
         << "system.cacheinvalid first argument must be a tensor variable";
-    const std::string base_ptr = codegen.GetTensorBasePtr(tensor_var);
-    const std::string ptr_type = "!pto.ptr<" + codegen.GetTypeString(tensor_type->dtype_) + ">";
-    const std::string off = codegen.EmitCastToIndex(op->args_[1], codegen.GetExprAsCode(op->args_[1]));
-    const std::string write_ptr = codegen.NewTemp();
-    codegen.Emit(write_ptr + " = pto.addptr " + base_ptr + ", " + off + " : " + ptr_type + " -> " + ptr_type);
-    codegen.Emit("pto.cmo.cacheinvalid " + write_ptr + " single_cache_line");
+    auto tensor_type = AsTensorTypeLike(tensor_var->GetType());
+    INTERNAL_CHECK_SPAN(tensor_type, op->span_) << "system.cacheinvalid first argument must be a tensor";
+    auto offsets_tuple = As<ir::MakeTuple>(op->args_[1]);
+    INTERNAL_CHECK_SPAN(offsets_tuple, op->span_) << "system.cacheinvalid offsets must be a tuple";
+    auto shapes_tuple = As<ir::MakeTuple>(op->args_[2]);
+    INTERNAL_CHECK_SPAN(shapes_tuple, op->span_) << "system.cacheinvalid shapes must be a tuple";
+
+    const std::string dtype_str = codegen.GetTypeString(tensor_type->dtype_);
+
+    // A region of all-ones sizes is a single element (scalar write): flatten the
+    // N-D offsets into a linear element offset and invalidate through a raw ptr.
+    // Any larger dimension (or a dynamic size) is a tile store: address the region
+    // through a partition_tensor_view, matching tile.store's outs() operand.
+    bool is_scalar_write = true;
+    for (const auto& size : shapes_tuple->elements_) {
+      auto size_const = As<ir::ConstInt>(size);
+      if (!size_const || size_const->value_ != 1) {
+        is_scalar_write = false;
+        break;
+      }
+    }
+
+    if (is_scalar_write) {
+      const std::string base_ptr = codegen.GetTensorBasePtr(tensor_var);
+      const std::string ptr_type = "!pto.ptr<" + dtype_str + ">";
+      const std::string off = GetFlatOffsetSSA(offsets_tuple, tensor_type->shape_, codegen);
+      const std::string write_ptr = codegen.NewTemp();
+      codegen.Emit(write_ptr + " = pto.addptr " + base_ptr + ", " + off + " : " + ptr_type + " -> " +
+                   ptr_type);
+      codegen.Emit("pto.cmo.cacheinvalid " + write_ptr + " single_cache_line");
+    } else {
+      const std::string tensor_view = codegen.GetOrCreateTensorView(tensor_var);
+      const std::string tensor_view_type = codegen.GetTensorViewTypeString(tensor_type.get());
+      const std::string partition_type =
+          MakePartitionTensorViewType(GetDimStrings(shapes_tuple->elements_), dtype_str);
+      const std::string payload_view =
+          EmitPartitionViewPTO(tensor_var->name_hint_, tensor_view, tensor_view_type, partition_type,
+                               GetIndexOffsetCodes(offsets_tuple->elements_, codegen),
+                               GetSizeCodes(shapes_tuple->elements_, codegen), codegen);
+      codegen.Emit("pto.cmo.cacheinvalid " + payload_view + " single_cache_line : " + partition_type);
+    }
     return std::string("");
   });
 }

--- a/src/backend/common/pto_ops_memory.cpp
+++ b/src/backend/common/pto_ops_memory.cpp
@@ -822,7 +822,10 @@ void RegisterMemoryOps(Backend& backend, const std::unordered_set<std::string>& 
         << "system.cacheinvalid takes 2 arguments (tensor, offset), got " << op->args_.size();
     auto tensor_type = AsTensorTypeLike(op->args_[0]->GetType());
     INTERNAL_CHECK_SPAN(tensor_type, op->span_) << "system.cacheinvalid first argument must be a tensor";
-    const std::string base_ptr = codegen.GetTensorBasePtr(AsVarLike(op->args_[0]));
+    const auto tensor_var = AsVarLike(op->args_[0]);
+    INTERNAL_CHECK_SPAN(tensor_var, op->span_)
+        << "system.cacheinvalid first argument must be a tensor variable";
+    const std::string base_ptr = codegen.GetTensorBasePtr(tensor_var);
     const std::string ptr_type = "!pto.ptr<" + codegen.GetTypeString(tensor_type->dtype_) + ">";
     const std::string off = codegen.EmitCastToIndex(op->args_[1], codegen.GetExprAsCode(op->args_[1]));
     const std::string write_ptr = codegen.NewTemp();

--- a/src/backend/common/pto_ops_memory.cpp
+++ b/src/backend/common/pto_ops_memory.cpp
@@ -825,10 +825,10 @@ void RegisterMemoryOps(Backend& backend, const std::unordered_set<std::string>& 
         << "system.cacheinvalid first argument must be a tensor variable";
     auto tensor_type = AsTensorTypeLike(tensor_var->GetType());
     INTERNAL_CHECK_SPAN(tensor_type, op->span_) << "system.cacheinvalid first argument must be a tensor";
-    auto offsets_tuple = As<ir::MakeTuple>(op->args_[1]);
-    INTERNAL_CHECK_SPAN(offsets_tuple, op->span_) << "system.cacheinvalid offsets must be a tuple";
-    auto shapes_tuple = As<ir::MakeTuple>(op->args_[2]);
+    auto shapes_tuple = As<ir::MakeTuple>(op->args_[1]);
     INTERNAL_CHECK_SPAN(shapes_tuple, op->span_) << "system.cacheinvalid shapes must be a tuple";
+    auto offsets_tuple = As<ir::MakeTuple>(op->args_[2]);
+    INTERNAL_CHECK_SPAN(offsets_tuple, op->span_) << "system.cacheinvalid offsets must be a tuple";
 
     const std::string dtype_str = codegen.GetTypeString(tensor_type->dtype_);
 

--- a/src/ir/op/sync_ops/sync.cpp
+++ b/src/ir/op/sync_ops/sync.cpp
@@ -89,6 +89,15 @@ REGISTER_OP("system.fence")
     .no_argument()
     .f_deduce_type(DeduceUnknownType);
 
+// Register system.cacheinvalid (Cache Maintenance Operation)
+// Args: tensor (write pointer base), offset (element offset added to the base)
+REGISTER_OP("system.cacheinvalid")
+    .set_description("Invalidate a single cache line at (tensor base + offset)")
+    .set_op_category("SyncOp")
+    .add_argument("tensor", "Target tensor whose write pointer is invalidated")
+    .add_argument("offset", "Element offset added to the base pointer (integer scalar)")
+    .f_deduce_type(DeduceUnknownType);
+
 // Register system.syncall (Cross-core all-participant barrier). Models
 // pto::SYNCALL with two modes selected by the `mode` attribute:
 //   - "hard" (default): FFTS barrier, no operands. Codegen emits

--- a/src/ir/op/sync_ops/sync.cpp
+++ b/src/ir/op/sync_ops/sync.cpp
@@ -90,12 +90,17 @@ REGISTER_OP("system.fence")
     .f_deduce_type(DeduceUnknownType);
 
 // Register system.cacheinvalid (Cache Maintenance Operation)
-// Args: tensor (write pointer base), offset (element offset added to the base)
+// Args: tensor, offsets (N-D start, matches tensor rank), shapes (N-D region size).
+// Codegen dispatches on shapes: all-1 -> scalar-write ptr form (pto.addptr);
+// otherwise -> tile-store partition-view form (pto.partition_view).
 REGISTER_OP("system.cacheinvalid")
-    .set_description("Invalidate a single cache line at (tensor base + offset)")
+    .set_description(
+        "Invalidate cache lines for a tensor sub-region (ptr form when the region is a single "
+        "element, partition-view form otherwise)")
     .set_op_category("SyncOp")
-    .add_argument("tensor", "Target tensor whose write pointer is invalidated")
-    .add_argument("offset", "Element offset added to the base pointer (integer scalar)")
+    .add_argument("tensor", "Target tensor whose sub-region is invalidated")
+    .add_argument("offsets", "Per-dimension start offsets (N-D tuple matching tensor rank)")
+    .add_argument("shapes", "Per-dimension region sizes (N-D tuple; all 1 selects the scalar/ptr form)")
     .f_deduce_type(DeduceUnknownType);
 
 // Register system.syncall (Cross-core all-participant barrier). Models

--- a/src/ir/op/sync_ops/sync.cpp
+++ b/src/ir/op/sync_ops/sync.cpp
@@ -90,7 +90,7 @@ REGISTER_OP("system.fence")
     .f_deduce_type(DeduceUnknownType);
 
 // Register system.cacheinvalid (Cache Maintenance Operation)
-// Args: tensor, offsets (N-D start, matches tensor rank), shapes (N-D region size).
+// Args: tensor, shapes (N-D region size), offsets (N-D start); both match tensor rank.
 // Codegen dispatches on shapes: all-1 -> scalar-write ptr form (pto.addptr);
 // otherwise -> tile-store partition-view form (pto.partition_view).
 REGISTER_OP("system.cacheinvalid")
@@ -99,8 +99,8 @@ REGISTER_OP("system.cacheinvalid")
         "element, partition-view form otherwise)")
     .set_op_category("SyncOp")
     .add_argument("tensor", "Target tensor whose sub-region is invalidated")
-    .add_argument("offsets", "Per-dimension start offsets (N-D tuple matching tensor rank)")
     .add_argument("shapes", "Per-dimension region sizes (N-D tuple; all 1 selects the scalar/ptr form)")
+    .add_argument("offsets", "Per-dimension start offsets (N-D tuple matching tensor rank)")
     .f_deduce_type(DeduceUnknownType);
 
 // Register system.syncall (Cross-core all-participant barrier). Models

--- a/tests/ut/codegen/test_pto_codegen_ops.py
+++ b/tests/ut/codegen/test_pto_codegen_ops.py
@@ -2811,8 +2811,17 @@ class TestFenceCodegen:
         )
 
 
+def _cmo_cacheinvalid_line(mlir: str) -> str:
+    """Return the single `pto.cmo.cacheinvalid` line (the whole module contains a
+    partition_tensor_view from the surrounding tile.store, so cmo-form assertions
+    must inspect this line, not the module)."""
+    lines = [line.strip() for line in mlir.splitlines() if "pto.cmo.cacheinvalid" in line]
+    assert len(lines) == 1, f"expected exactly one pto.cmo.cacheinvalid line, got {lines}"
+    return lines[0]
+
+
 class TestCacheInvalidCodegen:
-    """Tests that pl.system.cacheinvalid lowers to pto.addptr + pto.cmo.cacheinvalid."""
+    """Tests that pl.system.cacheinvalid lowers to a ptr or partition-view cmo."""
 
     def _generate_mlir(self, program_cls) -> str:
         backend.reset_for_testing()
@@ -2826,8 +2835,8 @@ class TestCacheInvalidCodegen:
         single = ir.Program([funcs[0]], funcs[0].name, optimized.span)
         return codegen_instance.generate(single)
 
-    def test_cacheinvalid_emits_cmo(self):
-        """pl.system.cacheinvalid(out, off) emits pto.addptr + pto.cmo.cacheinvalid."""
+    def test_cacheinvalid_scalar_write_emits_ptr(self):
+        """All-ones shapes (scalar write) lower to pto.addptr + a ptr-form cmo."""
 
         @pl.program
         class Prog:
@@ -2839,16 +2848,41 @@ class TestCacheInvalidCodegen:
             ) -> pl.Tensor[[16, 16], pl.FP32]:
                 tile: pl.Tile[[16, 16], pl.FP32] = pl.load(x, [0, 0], [16, 16])
                 updated: pl.Tensor[[16, 16], pl.FP32] = pl.store(tile, [0, 0], out)
-                pl.system.cacheinvalid(updated, 8)
+                pl.system.cacheinvalid(updated, [0, 8], [1, 1])
                 return updated
 
         mlir = self._generate_mlir(Prog)
         assert "pto.addptr" in mlir, f"pto.addptr not found in MLIR:\n{mlir}"
-        assert "pto.cmo.cacheinvalid" in mlir, f"pto.cmo.cacheinvalid not found in MLIR:\n{mlir}"
-        assert "single_cache_line" in mlir, f"single_cache_line not found in MLIR:\n{mlir}"
+        cmo_line = _cmo_cacheinvalid_line(mlir)
+        # The ptr form emits a bare pointer operand, no partition_tensor_view annotation.
+        assert "single_cache_line" in cmo_line
+        assert "partition_tensor_view" not in cmo_line, f"unexpected partition view in ptr form: {cmo_line}"
+
+    def test_cacheinvalid_region_emits_partition_view(self):
+        """A multi-element region (tile store) lowers to a partition_tensor_view cmo."""
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel_cacheinvalid_region(
+                self,
+                x: pl.Tensor[[16, 16], pl.FP32],
+                out: pl.Tensor[[16, 16], pl.FP32],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                tile: pl.Tile[[16, 16], pl.FP32] = pl.load(x, [0, 0], [16, 16])
+                updated: pl.Tensor[[16, 16], pl.FP32] = pl.store(tile, [0, 0], out)
+                pl.system.cacheinvalid(updated, [0, 0], [16, 16])
+                return updated
+
+        mlir = self._generate_mlir(Prog)
+        assert "pto.partition_view" in mlir, f"pto.partition_view not found in MLIR:\n{mlir}"
+        cmo_line = _cmo_cacheinvalid_line(mlir)
+        # The region form addresses a partition_tensor_view, not a raw pointer.
+        assert "single_cache_line" in cmo_line
+        assert "partition_tensor_view" in cmo_line, f"partition view not in cmo line: {cmo_line}"
 
     def test_cacheinvalid_dynamic_offset(self):
-        """A runtime offset expression (loop-var arithmetic) is fed to pto.addptr."""
+        """A runtime offset expression (loop-var arithmetic) reaches the flattened ptr offset."""
 
         @pl.program
         class Prog:
@@ -2861,14 +2895,12 @@ class TestCacheInvalidCodegen:
                 tile: pl.Tile[[16, 16], pl.FP32] = pl.load(x, [0, 0], [16, 16])
                 updated: pl.Tensor[[16, 16], pl.FP32] = pl.store(tile, [0, 0], out)
                 for i in pl.range(4):
-                    # offset is computed at runtime from the loop index
-                    pl.system.cacheinvalid(updated, i * 16)
+                    # offset row is computed at runtime from the loop index
+                    pl.system.cacheinvalid(updated, [i, 0], [1, 1])
                 return updated
 
         mlir = self._generate_mlir(Prog)
-        # The offset arithmetic (i * 16) is materialized as its own SSA value...
-        assert "arith.muli" in mlir, f"offset arithmetic not found in MLIR:\n{mlir}"
-        # ...and that dynamic SSA is the addptr offset, not a compile-time constant.
+        # The dynamic row index feeds the flattened offset, then pto.addptr.
         assert "pto.addptr" in mlir, f"pto.addptr not found in MLIR:\n{mlir}"
         assert "pto.cmo.cacheinvalid" in mlir, f"pto.cmo.cacheinvalid not found in MLIR:\n{mlir}"
         assert "single_cache_line" in mlir, f"single_cache_line not found in MLIR:\n{mlir}"

--- a/tests/ut/codegen/test_pto_codegen_ops.py
+++ b/tests/ut/codegen/test_pto_codegen_ops.py
@@ -2811,5 +2811,68 @@ class TestFenceCodegen:
         )
 
 
+class TestCacheInvalidCodegen:
+    """Tests that pl.system.cacheinvalid lowers to pto.addptr + pto.cmo.cacheinvalid."""
+
+    def _generate_mlir(self, program_cls) -> str:
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        pm = PassManager.get_strategy(OptimizationStrategy.Default)
+        optimized = pm.run_passes(program_cls)
+        codegen_instance = codegen.PTOCodegen()
+        funcs = list(optimized.functions.values())
+        assert funcs, "Program has no functions"
+        single = ir.Program([funcs[0]], funcs[0].name, optimized.span)
+        return codegen_instance.generate(single)
+
+    def test_cacheinvalid_emits_cmo(self):
+        """pl.system.cacheinvalid(out, off) emits pto.addptr + pto.cmo.cacheinvalid."""
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel_cacheinvalid(
+                self,
+                x: pl.Tensor[[16, 16], pl.FP32],
+                out: pl.Tensor[[16, 16], pl.FP32],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                tile: pl.Tile[[16, 16], pl.FP32] = pl.load(x, [0, 0], [16, 16])
+                updated: pl.Tensor[[16, 16], pl.FP32] = pl.store(tile, [0, 0], out)
+                pl.system.cacheinvalid(updated, 8)
+                return updated
+
+        mlir = self._generate_mlir(Prog)
+        assert "pto.addptr" in mlir, f"pto.addptr not found in MLIR:\n{mlir}"
+        assert "pto.cmo.cacheinvalid" in mlir, f"pto.cmo.cacheinvalid not found in MLIR:\n{mlir}"
+        assert "single_cache_line" in mlir, f"single_cache_line not found in MLIR:\n{mlir}"
+
+    def test_cacheinvalid_dynamic_offset(self):
+        """A runtime offset expression (loop-var arithmetic) is fed to pto.addptr."""
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel_cacheinvalid_dyn(
+                self,
+                x: pl.Tensor[[16, 16], pl.FP32],
+                out: pl.Tensor[[16, 16], pl.FP32],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                tile: pl.Tile[[16, 16], pl.FP32] = pl.load(x, [0, 0], [16, 16])
+                updated: pl.Tensor[[16, 16], pl.FP32] = pl.store(tile, [0, 0], out)
+                for i in pl.range(4):
+                    # offset is computed at runtime from the loop index
+                    pl.system.cacheinvalid(updated, i * 16)
+                return updated
+
+        mlir = self._generate_mlir(Prog)
+        # The offset arithmetic (i * 16) is materialized as its own SSA value...
+        assert "arith.muli" in mlir, f"offset arithmetic not found in MLIR:\n{mlir}"
+        # ...and that dynamic SSA is the addptr offset, not a compile-time constant.
+        assert "pto.addptr" in mlir, f"pto.addptr not found in MLIR:\n{mlir}"
+        assert "pto.cmo.cacheinvalid" in mlir, f"pto.cmo.cacheinvalid not found in MLIR:\n{mlir}"
+        assert "single_cache_line" in mlir, f"single_cache_line not found in MLIR:\n{mlir}"
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/codegen/test_pto_codegen_ops.py
+++ b/tests/ut/codegen/test_pto_codegen_ops.py
@@ -2848,7 +2848,7 @@ class TestCacheInvalidCodegen:
             ) -> pl.Tensor[[16, 16], pl.FP32]:
                 tile: pl.Tile[[16, 16], pl.FP32] = pl.load(x, [0, 0], [16, 16])
                 updated: pl.Tensor[[16, 16], pl.FP32] = pl.store(tile, [0, 0], out)
-                pl.system.cacheinvalid(updated, [0, 8], [1, 1])
+                pl.system.cacheinvalid(updated, [1, 1], [0, 8])
                 return updated
 
         mlir = self._generate_mlir(Prog)
@@ -2871,7 +2871,7 @@ class TestCacheInvalidCodegen:
             ) -> pl.Tensor[[16, 16], pl.FP32]:
                 tile: pl.Tile[[16, 16], pl.FP32] = pl.load(x, [0, 0], [16, 16])
                 updated: pl.Tensor[[16, 16], pl.FP32] = pl.store(tile, [0, 0], out)
-                pl.system.cacheinvalid(updated, [0, 0], [16, 16])
+                pl.system.cacheinvalid(updated, [16, 16], [0, 0])
                 return updated
 
         mlir = self._generate_mlir(Prog)
@@ -2896,7 +2896,7 @@ class TestCacheInvalidCodegen:
                 updated: pl.Tensor[[16, 16], pl.FP32] = pl.store(tile, [0, 0], out)
                 for i in pl.range(4):
                     # offset row is computed at runtime from the loop index
-                    pl.system.cacheinvalid(updated, [i, 0], [1, 1])
+                    pl.system.cacheinvalid(updated, [1, 1], [i, 0])
                 return updated
 
         mlir = self._generate_mlir(Prog)

--- a/tests/ut/language/parser/test_system_ops.py
+++ b/tests/ut/language/parser/test_system_ops.py
@@ -126,18 +126,35 @@ class TestSystemOpsParsing:
         assert isinstance(reparsed, ir.Program)
         ir.assert_structural_equal(Before, reparsed)
 
-    def test_cacheinvalid_round_trip(self):
-        """Test round-trip for pl.system.cacheinvalid."""
+    def test_cacheinvalid_round_trip_scalar(self):
+        """Round-trip for the scalar-write (all-ones shapes) form."""
 
         @pl.program
         class Before:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                pl.system.cacheinvalid(x, 4)
+                pl.system.cacheinvalid(x, [4], [1])
                 return x
 
         printed = Before.as_python()
-        assert "pl.system.cacheinvalid(x, 4)" in printed
+        assert "pl.system.cacheinvalid(x, [4], [1])" in printed
+
+        reparsed = pl.parse_program(printed)
+        assert isinstance(reparsed, ir.Program)
+        ir.assert_structural_equal(Before, reparsed)
+
+    def test_cacheinvalid_round_trip_region(self):
+        """Round-trip for the partition-view (region) form."""
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(self, x: pl.Tensor[[16, 16], pl.FP32]) -> pl.Tensor[[16, 16], pl.FP32]:
+                pl.system.cacheinvalid(x, [0, 0], [16, 16])
+                return x
+
+        printed = Before.as_python()
+        assert "pl.system.cacheinvalid(x, [0, 0], [16, 16])" in printed
 
         reparsed = pl.parse_program(printed)
         assert isinstance(reparsed, ir.Program)
@@ -148,8 +165,16 @@ class TestSystemOpsParsing:
         span = ir.Span.unknown()
         dim = ir.ConstInt(64, DataType.INT32, span)
         tensor = ir.Var("x", ir.TensorType([dim], DataType.FP32), span)
-        with pytest.raises(TypeError, match="offset must be an integer"):
-            system_ops.cacheinvalid(tensor, 3.5)  # type: ignore[arg-type]  # intentionally wrong type
+        with pytest.raises(TypeError, match="offsets must be integers"):
+            system_ops.cacheinvalid(tensor, [3.5], [1])  # type: ignore[list-item]  # intentionally wrong type
+
+    def test_cacheinvalid_rejects_rank_mismatch(self):
+        """offsets/shapes length must match the tensor rank."""
+        span = ir.Span.unknown()
+        dim = ir.ConstInt(16, DataType.INT32, span)
+        tensor = ir.Var("x", ir.TensorType([dim, dim], DataType.FP32), span)
+        with pytest.raises(ValueError, match="offsets must match tensor rank 2"):
+            system_ops.cacheinvalid(tensor, [0], [1, 1])
 
     def test_syncall_round_trip(self):
         """Test round-trip for pl.system.syncall with an explicit core_type."""

--- a/tests/ut/language/parser/test_system_ops.py
+++ b/tests/ut/language/parser/test_system_ops.py
@@ -133,11 +133,11 @@ class TestSystemOpsParsing:
         class Before:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                pl.system.cacheinvalid(x, [4], [1])
+                pl.system.cacheinvalid(x, [1], [4])
                 return x
 
         printed = Before.as_python()
-        assert "pl.system.cacheinvalid(x, [4], [1])" in printed
+        assert "pl.system.cacheinvalid(x, [1], [4])" in printed
 
         reparsed = pl.parse_program(printed)
         assert isinstance(reparsed, ir.Program)
@@ -150,11 +150,11 @@ class TestSystemOpsParsing:
         class Before:
             @pl.function
             def main(self, x: pl.Tensor[[16, 16], pl.FP32]) -> pl.Tensor[[16, 16], pl.FP32]:
-                pl.system.cacheinvalid(x, [0, 0], [16, 16])
+                pl.system.cacheinvalid(x, [16, 16], [0, 0])
                 return x
 
         printed = Before.as_python()
-        assert "pl.system.cacheinvalid(x, [0, 0], [16, 16])" in printed
+        assert "pl.system.cacheinvalid(x, [16, 16], [0, 0])" in printed
 
         reparsed = pl.parse_program(printed)
         assert isinstance(reparsed, ir.Program)
@@ -166,7 +166,7 @@ class TestSystemOpsParsing:
         dim = ir.ConstInt(64, DataType.INT32, span)
         tensor = ir.Var("x", ir.TensorType([dim], DataType.FP32), span)
         with pytest.raises(TypeError, match="offsets must be integers"):
-            system_ops.cacheinvalid(tensor, [3.5], [1])  # type: ignore[list-item]  # intentionally wrong type
+            system_ops.cacheinvalid(tensor, [1], [3.5])  # type: ignore[list-item]  # intentionally wrong type
 
     def test_cacheinvalid_rejects_rank_mismatch(self):
         """offsets/shapes length must match the tensor rank."""
@@ -174,7 +174,7 @@ class TestSystemOpsParsing:
         dim = ir.ConstInt(16, DataType.INT32, span)
         tensor = ir.Var("x", ir.TensorType([dim, dim], DataType.FP32), span)
         with pytest.raises(ValueError, match="offsets must match tensor rank 2"):
-            system_ops.cacheinvalid(tensor, [0], [1, 1])
+            system_ops.cacheinvalid(tensor, [1, 1], [0])
 
     def test_syncall_round_trip(self):
         """Test round-trip for pl.system.syncall with an explicit core_type."""

--- a/tests/ut/language/parser/test_system_ops.py
+++ b/tests/ut/language/parser/test_system_ops.py
@@ -124,6 +124,23 @@ class TestSystemOpsParsing:
         assert isinstance(reparsed, ir.Program)
         ir.assert_structural_equal(Before, reparsed)
 
+    def test_cacheinvalid_round_trip(self):
+        """Test round-trip for pl.system.cacheinvalid."""
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                pl.system.cacheinvalid(x, 4)
+                return x
+
+        printed = Before.as_python()
+        assert "pl.system.cacheinvalid(x, 4)" in printed
+
+        reparsed = pl.parse_program(printed)
+        assert isinstance(reparsed, ir.Program)
+        ir.assert_structural_equal(Before, reparsed)
+
     def test_syncall_round_trip(self):
         """Test round-trip for pl.system.syncall with an explicit core_type."""
 

--- a/tests/ut/language/parser/test_system_ops.py
+++ b/tests/ut/language/parser/test_system_ops.py
@@ -14,6 +14,8 @@ import re
 import pypto.language as pl
 import pytest
 from pypto import ir
+from pypto.ir.op import system_ops
+from pypto.pypto_core import DataType
 
 
 class TestSystemOpsParsing:
@@ -140,6 +142,14 @@ class TestSystemOpsParsing:
         reparsed = pl.parse_program(printed)
         assert isinstance(reparsed, ir.Program)
         ir.assert_structural_equal(Before, reparsed)
+
+    def test_cacheinvalid_rejects_float_offset(self):
+        """A non-integer offset is rejected at the IR wrapper, not deep in codegen."""
+        span = ir.Span.unknown()
+        dim = ir.ConstInt(64, DataType.INT32, span)
+        tensor = ir.Var("x", ir.TensorType([dim], DataType.FP32), span)
+        with pytest.raises(TypeError, match="offset must be an integer"):
+            system_ops.cacheinvalid(tensor, 3.5)  # type: ignore[arg-type]  # intentionally wrong type
 
     def test_syncall_round_trip(self):
         """Test round-trip for pl.system.syncall with an explicit core_type."""


### PR DESCRIPTION
## Summary

Adds a `system.cacheinvalid` SyncOp that invalidates the cache lines backing a tensor sub-region. The op carries a uniform N-D `(shapes, offsets)` region (both matching the tensor rank), and codegen picks one of two lowerings by the region size — covering both a scalar write and a tile store.

- **IR registration** (`src/ir/op/sync_ops/sync.cpp`): `SyncOp` category, args `tensor`, `shapes`, `offsets`, `DeduceUnknownType`.
- **Python IR wrapper** (`python/pypto/ir/op/system_ops.py`): builds the `shapes`/`offsets` tuples; validates that both match the tensor rank and carry integer coordinates.
- **DSL** (`python/pypto/language/op/system_ops.py`): unwraps the `Tensor`/`Scalar` args; exported in `__all__`.
- **Codegen** (`src/backend/common/pto_ops_memory.cpp`): two-form dispatch (see below), reusing the existing `GetFlatOffsetSSA` and partition-view helpers (`EmitPartitionViewPTO` / `MakePartitionTensorViewType`).
- **Torch reference** (`python/pypto/debug/torch_codegen.py`): registered as a no-op alongside `system.fence`.
- **Docs**: EN + ZH operator tables.

## Two codegen forms

Dispatch is on `shapes`: an all-1 region is a single element (scalar write) and lowers through a raw pointer; any larger (or dynamic) dimension is a tile store and lowers through a `partition_tensor_view`, matching `tile.store`'s `outs()` operand.

**Scalar write — `shapes` all 1** (`pl.system.cacheinvalid(t, [1, 1], [0, 8])`):

```mlir
%0 = pto.addptr %arg1, %c8_index : !pto.ptr<f32> -> !pto.ptr<f32>
pto.cmo.cacheinvalid %0 single_cache_line
```

The N-D `offsets` are flattened over the tensor shape (supports a dynamic offset, e.g. a loop variable).

**Tile store — larger region** (`pl.system.cacheinvalid(t, [128], [0])`):

```mlir
%payload_view = pto.partition_view %t_view, offsets = [%c0_index], sizes = [%c128_index] : !pto.tensor_view<?xf32> -> !pto.partition_tensor_view<128xf32>
pto.cmo.cacheinvalid %payload_view single_cache_line : !pto.partition_tensor_view<128xf32>
```

## API

```python
pl.system.cacheinvalid(tensor, shapes, offsets)   # shapes first, then offsets; both N-D, matching tensor rank
```

## Testing

- [x] Parser round-trip for both the scalar (all-1 shapes) and region forms
- [x] Codegen: scalar write emits the ptr-form `pto.cmo.cacheinvalid` (no partition-view annotation)
- [x] Codegen: region emits `pto.partition_view` + a `!pto.partition_tensor_view<...>` cmo
- [x] Codegen: dynamic (loop-variable) offset reaches the flattened ptr offset
- [x] IR wrapper rejects rank mismatch (`ValueError`) and non-integer coordinates (`TypeError`)
- [x] Full unit suite passes (no regressions)
- [x] Code review, clang-tidy, pre-commit hooks clean
