### PR TITLE
chore(runtime): bump runtime to a756969c

### DIFF
--- a/python/pypto/runtime/device_runner.py
+++ b/python/pypto/runtime/device_runner.py
@@ -699,6 +699,14 @@ def validate_golden(
 ) -> None:
     """Compare actual outputs against golden reference using ``torch.allclose``.
 
+    Positions where the golden holds ``NaN`` are treated as *don't-care* and are
+    excluded from the comparison. Tests use this to mark output regions that the
+    kernel leaves undefined by contract — e.g. the area outside a tile's
+    ``valid_shapes``, or an oversized scratch buffer's unused tail. (The runtime
+    no longer zero-fills pure-output buffers, so such regions hold pooled-allocator
+    garbage rather than 0.) A golden with no ``NaN`` compares every element, so this
+    is fully backward-compatible.
+
     Raises:
         AssertionError: If any output tensor does not match within tolerances.
     """
@@ -707,8 +715,11 @@ def validate_golden(
         expected = golden[name].cpu()
         logger.info(f"Comparing {name}: shape={actual.shape}, dtype={actual.dtype}")
 
-        if not torch.allclose(actual, expected, rtol=rtol, atol=atol):
-            close_mask = torch.isclose(actual, expected, rtol=rtol, atol=atol)
+        care_mask = ~torch.isnan(expected)
+        # An element passes if it is close OR the golden marked it don't-care (NaN).
+        close_mask = torch.isclose(actual, expected, rtol=rtol, atol=atol) | ~care_mask
+
+        if not bool(close_mask.all()):
             mismatch_indices = torch.where(~close_mask.flatten())[0]
             flat_actual = actual.flatten()
             flat_expected = expected.flatten()
@@ -718,15 +729,18 @@ def validate_golden(
                 f"    [{i.item()}] actual={flat_actual[i].item()}, expected={flat_expected[i].item()}"
                 for i in idx
             ]
+            n_dont_care = int((~care_mask).sum().item())
+            skipped = f" ({n_dont_care} don't-care skipped)" if n_dont_care else ""
             raise AssertionError(
                 f"Output '{name}' does not match golden.\n"
-                f"Mismatched elements: {mismatch_indices.numel()}/{actual.numel()}\n"
+                f"Mismatched elements: {mismatch_indices.numel()}/{actual.numel()}{skipped}\n"
                 f"rtol={rtol}, atol={atol}\n"
                 f"First {n_show} mismatches:\n" + "\n".join(lines)
             )
 
-        matched = torch.isclose(actual, expected, rtol=rtol, atol=atol).sum().item()
-        logger.info(f"  {name}: PASS ({matched}/{actual.numel()} elements matched)")
+        n_compared = int(care_mask.sum().item())
+        matched = int((close_mask & care_mask).sum().item())
+        logger.info(f"  {name}: PASS ({matched}/{n_compared} compared elements matched)")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/st/runtime/control_flow/test_ctrl_flow.py
+++ b/tests/st/runtime/control_flow/test_ctrl_flow.py
@@ -29,6 +29,7 @@ from typing import Any
 
 import pypto.language as pl
 import pytest
+import torch
 from harness.core.harness import PLATFORMS, DataType, PTOTestCase, TensorSpec
 
 
@@ -522,7 +523,7 @@ class TestForLoopContinue(PTOTestCase):
         return [
             TensorSpec("a", [256, 64], DataType.FP32, init_value=2.0),
             TensorSpec("b", [256, 64], DataType.FP32, init_value=3.0),
-            TensorSpec("c", [256, 64], DataType.FP32, is_output=True),
+            TensorSpec("c", [256, 64], DataType.FP32, init_value=torch.zeros, is_output=True),
         ]
 
     def get_program(self) -> Any:
@@ -533,7 +534,7 @@ class TestForLoopContinue(PTOTestCase):
                 self,
                 a: pl.Tensor[[256, 64], pl.FP32],
                 b: pl.Tensor[[256, 64], pl.FP32],
-                c: pl.Out[pl.Tensor[[256, 64], pl.FP32]],
+                c: pl.InOut[pl.Tensor[[256, 64], pl.FP32]],
             ) -> pl.Tensor[[256, 64], pl.FP32]:
                 for i in pl.range(4):
                     if i % 2 != 0:
@@ -550,7 +551,7 @@ class TestForLoopContinue(PTOTestCase):
                 self,
                 a: pl.Tensor[[256, 64], pl.FP32],
                 b: pl.Tensor[[256, 64], pl.FP32],
-                c: pl.Out[pl.Tensor[[256, 64], pl.FP32]],
+                c: pl.InOut[pl.Tensor[[256, 64], pl.FP32]],
             ) -> pl.Tensor[[256, 64], pl.FP32]:
                 c = self.kernel_continue(a, b, c)
                 return c

--- a/tests/st/runtime/control_flow/test_dyn_orch_shape.py
+++ b/tests/st/runtime/control_flow/test_dyn_orch_shape.py
@@ -371,6 +371,9 @@ class DynOrchValidShapeAddTestCase(PTOTestCase):
     def compute_expected(self, tensors, params=None):
         vr = int(tensors["vs"][0])
         vc = int(tensors["vs"][1])
+        # Only c[:vr, :vc] is written (valid_shapes-bounded store); outside that
+        # region is undefined-by-design -> mark NaN so validate_golden skips it.
+        tensors["c"][:] = float("nan")
         tensors["c"][:vr, :vc] = tensors["a"][:vr, :vc] + tensors["b"][:vr, :vc]
 
 

--- a/tests/st/runtime/control_flow/test_dynamic_shape.py
+++ b/tests/st/runtime/control_flow/test_dynamic_shape.py
@@ -183,6 +183,9 @@ class ValidShapeAddTestCase(PTOTestCase):
     def compute_expected(self, tensors, params=None):
         vr = tensors["valid_shape"][0]
         vc = tensors["valid_shape"][1]
+        # Only c[:vr, :vc] is written (valid_shapes-bounded store); outside that
+        # region is undefined-by-design -> mark NaN so validate_golden skips it.
+        tensors["c"][:] = float("nan")
         tensors["c"][:vr, :vc] = tensors["a"][:vr, :vc] + tensors["b"][:vr, :vc]
 
 

--- a/tests/st/runtime/cross_core/test_cross_core_dynamic_valid_shape.py
+++ b/tests/st/runtime/cross_core/test_cross_core_dynamic_valid_shape.py
@@ -151,6 +151,9 @@ class C2VDynamicTpopValidShapeTestCase(PTOTestCase):
         valid_rows = int(tensors["valid_shape"][0])
         valid_cols = int(tensors["valid_shape"][1])
         matmul = torch.matmul(tensors["a"].float(), tensors["b"].float())
+        # Only output[:valid_rows, :valid_cols] is written; outside that region
+        # is undefined-by-design -> mark NaN so validate_golden skips it.
+        tensors["output"][:] = float("nan")
         tensors["output"][:valid_rows, :valid_cols] = matmul[:valid_rows, :valid_cols] + 1.0
 
 
@@ -285,6 +288,9 @@ class C2VDynamicTpushValidShapeTestCase(PTOTestCase):
         valid_rows = int(tensors["valid_shape"][0])
         valid_cols = int(tensors["valid_shape"][1])
         matmul = torch.matmul(tensors["a"].float(), tensors["b"].float())
+        # Only output[:valid_rows, :valid_cols] is written; outside that region
+        # is undefined-by-design -> mark NaN so validate_golden skips it.
+        tensors["output"][:] = float("nan")
         tensors["output"][:valid_rows, :valid_cols] = matmul[:valid_rows, :valid_cols] + 1.0
 
 

--- a/tests/st/runtime/cross_core/test_cross_core_split_parity.py
+++ b/tests/st/runtime/cross_core/test_cross_core_split_parity.py
@@ -297,6 +297,9 @@ class _C2VValidShapeParityCase(PTOTestCase):
         vr = int(tensors["valid_shape"][0])
         vc = int(tensors["valid_shape"][1])
         matmul = torch.matmul(tensors["a"].float(), tensors["b"].float())
+        # Only output[:vr, :vc] is written (localized per-subblock store); the
+        # rest is undefined-by-design -> mark NaN so validate_golden skips it.
+        tensors["output"][:] = float("nan")
         tensors["output"][:vr, :vc] = matmul[:vr, :vc] + 1.0
 
 

--- a/tests/st/runtime/cross_core/test_cross_core_tpush_valid_shape.py
+++ b/tests/st/runtime/cross_core/test_cross_core_tpush_valid_shape.py
@@ -149,6 +149,9 @@ class C2VTpushValidShapeTestCase(PTOTestCase):
         valid_rows = int(tensors["valid_shape"][0])
         valid_cols = int(tensors["valid_shape"][1])
         matmul = torch.matmul(tensors["a"].float(), tensors["b"].float())
+        # Only output[:valid_rows, :valid_cols] is written; rows >= valid_rows
+        # are never stored (localized store) -> mark NaN so validate_golden skips.
+        tensors["output"][:] = float("nan")
         tensors["output"][:valid_rows, :valid_cols] = matmul[:valid_rows, :valid_cols] + 1.0
 
 
@@ -264,7 +267,9 @@ class V2SetValidShapeOnVectorTestCase(PTOTestCase):
 
     def compute_expected(self, tensors: dict[str, torch.Tensor], params=None) -> None:
         matmul = torch.matmul(tensors["a"].float(), tensors["b"].float())
-        # Columns >= SV_VALID_COLS are invalid (not written) -> stay at init 0.
+        # Columns >= SV_VALID_COLS are invalid (not written) -> mark NaN so
+        # validate_golden skips them (runtime no longer zero-fills outputs).
+        tensors["output"][:] = float("nan")
         tensors["output"][:, :SV_VALID_COLS] = matmul[:, :SV_VALID_COLS] + 1.0
 
 

--- a/tests/st/runtime/framework_and_models/test_incore_array.py
+++ b/tests/st/runtime/framework_and_models/test_incore_array.py
@@ -41,7 +41,7 @@ class IncoreArrayRoundTripProgram:
         self,
         index_t: pl.Tensor[[1, 8], pl.INT32],
         src_t: pl.Tensor[[1, 32], pl.FP32],
-        dst_t: pl.Out[pl.Tensor[[32, 32], pl.FP32]],
+        dst_t: pl.InOut[pl.Tensor[[32, 32], pl.FP32]],
     ) -> pl.Tensor[[32, 32], pl.FP32]:
         index_tile: pl.Tile[[1, 8], pl.INT32] = pl.load(index_t, [0, 0], [1, 8])
         src_tile: pl.Tile[[1, 32], pl.FP32] = pl.load(src_t, [0, 0], [1, 32])
@@ -61,7 +61,7 @@ class IncoreArrayRoundTripProgram:
         self,
         index_t: pl.Tensor[[1, 8], pl.INT32],
         src_t: pl.Tensor[[1, 32], pl.FP32],
-        dst_t: pl.Out[pl.Tensor[[32, 32], pl.FP32]],
+        dst_t: pl.InOut[pl.Tensor[[32, 32], pl.FP32]],
     ) -> pl.Tensor[[32, 32], pl.FP32]:
         dst_t = self.kernel(index_t, src_t, dst_t)
         return dst_t
@@ -117,7 +117,7 @@ class IncoreArrayConditionalProgram:
         self,
         cond_t: pl.Tensor[[1, 8], pl.INT32],
         src_t: pl.Tensor[[1, 32], pl.FP32],
-        dst_t: pl.Out[pl.Tensor[[32, 32], pl.FP32]],
+        dst_t: pl.InOut[pl.Tensor[[32, 32], pl.FP32]],
     ) -> pl.Tensor[[32, 32], pl.FP32]:
         cond_tile: pl.Tile[[1, 8], pl.INT32] = pl.load(cond_t, [0, 0], [1, 8])
         src_tile: pl.Tile[[1, 32], pl.FP32] = pl.load(src_t, [0, 0], [1, 32])
@@ -138,7 +138,7 @@ class IncoreArrayConditionalProgram:
         self,
         cond_t: pl.Tensor[[1, 8], pl.INT32],
         src_t: pl.Tensor[[1, 32], pl.FP32],
-        dst_t: pl.Out[pl.Tensor[[32, 32], pl.FP32]],
+        dst_t: pl.InOut[pl.Tensor[[32, 32], pl.FP32]],
     ) -> pl.Tensor[[32, 32], pl.FP32]:
         dst_t = self.kernel(cond_t, src_t, dst_t)
         return dst_t

--- a/tests/st/runtime/framework_and_models/test_paged_attention_multi_config.py
+++ b/tests/st/runtime/framework_and_models/test_paged_attention_multi_config.py
@@ -135,7 +135,10 @@ class SoftmaxPrepareTestCase(PTOTestCase):
 
         # Pass 2: exp(scaled - global_max), cast to bf16, row_sum
         li_acc = None
-        pij_out = torch.zeros(n_unroll_q, block_size, dtype=torch.bfloat16)
+        # pij_buf is oversized unroll scratch; only rows [0, n_blocks*q_tile) are
+        # written by the kernel. NaN-mark the unused tail rows as don't-care so
+        # validate_golden skips them (the runtime no longer zero-fills the buffer).
+        pij_out = torch.full((n_unroll_q, block_size), float("nan"), dtype=torch.bfloat16)
         for i in range(n_blocks):
             s_tile = sij_buf[i * q_tile : (i + 1) * q_tile, :]
             scaled = s_tile * scale
@@ -222,7 +225,10 @@ class QKMatmulTestCase(PTOTestCase):
         block_indices = tensors["block_indices"]
         n_blocks = int(tensors["n_blocks_cfg"][0].item())
 
-        sij_buf = torch.zeros(n_unroll_q, block_size, dtype=torch.float32)
+        # sij_buf is oversized unroll scratch; only rows [0, n_blocks*q_tile) are
+        # written by the kernel. NaN-mark the unused tail rows as don't-care so
+        # validate_golden skips them (the runtime no longer zero-fills the buffer).
+        sij_buf = torch.full((n_unroll_q, block_size), float("nan"), dtype=torch.float32)
         for i in range(n_blocks):
             bidx = int(block_indices[i].item())
             kj = key_cache[bidx]  # [block_size, head_dim]

--- a/tests/st/runtime/ops/test_activation_ops.py
+++ b/tests/st/runtime/ops/test_activation_ops.py
@@ -73,9 +73,16 @@ class _ActBase(PTOTestCase):
         return f"tile_{self.op_name}_{self._m}x{self._n}_{self._dtype.value}{v}{o}"
 
     def define_tensors(self) -> list[TensorSpec]:
+        # The output's unwritten region (valid_shapes tail or the complement of an
+        # offset store) is compared against golden zeros, so declare the output
+        # InOut with a zero init: the runtime stages defined zeros (pure outputs
+        # are no longer device-zeroed). The offset complement doubles as the
+        # spill-detection oracle for the bounded store.
         return [
             TensorSpec("a", [self._m, self._n], self._dtype, init_value=lambda: _signed(self._m, self._n)),
-            TensorSpec("out", [self._out_m, self._out_n], self._dtype, is_output=True),
+            TensorSpec(
+                "out", [self._out_m, self._out_n], self._dtype, is_output=True, init_value=torch.zeros
+            ),
         ]
 
     def _ref(self, a):
@@ -110,7 +117,7 @@ class TileReluTestCase(_ActBase):
         class ReluProgram:
             @pl.function(type=pl.FunctionType.InCore)
             def kernel(
-                self, a: pl.Tensor[[m, n], dt], out: pl.Out[pl.Tensor[[om, on], dt]]
+                self, a: pl.Tensor[[m, n], dt], out: pl.InOut[pl.Tensor[[om, on], dt]]
             ) -> pl.Tensor[[om, on], dt]:
                 a_tile = pl.load(a, [0, 0], [m, n], valid_shapes=vshape)
                 out = pl.store(pl.tile.relu(a_tile), off, out)
@@ -118,7 +125,7 @@ class TileReluTestCase(_ActBase):
 
             @pl.function(type=pl.FunctionType.Orchestration)
             def orchestrator(
-                self, a: pl.Tensor[[m, n], dt], out: pl.Out[pl.Tensor[[om, on], dt]]
+                self, a: pl.Tensor[[m, n], dt], out: pl.InOut[pl.Tensor[[om, on], dt]]
             ) -> pl.Tensor[[om, on], dt]:
                 out = self.kernel(a, out)
                 return out
@@ -151,7 +158,7 @@ class TileLreluTestCase(_ActBase):
         class LreluProgram:
             @pl.function(type=pl.FunctionType.InCore)
             def kernel(
-                self, a: pl.Tensor[[m, n], dt], out: pl.Out[pl.Tensor[[om, on], dt]]
+                self, a: pl.Tensor[[m, n], dt], out: pl.InOut[pl.Tensor[[om, on], dt]]
             ) -> pl.Tensor[[om, on], dt]:
                 a_tile = pl.load(a, [0, 0], [m, n], valid_shapes=vshape)
                 out = pl.store(pl.tile.lrelu(a_tile, slope), off, out)
@@ -159,7 +166,7 @@ class TileLreluTestCase(_ActBase):
 
             @pl.function(type=pl.FunctionType.Orchestration)
             def orchestrator(
-                self, a: pl.Tensor[[m, n], dt], out: pl.Out[pl.Tensor[[om, on], dt]]
+                self, a: pl.Tensor[[m, n], dt], out: pl.InOut[pl.Tensor[[om, on], dt]]
             ) -> pl.Tensor[[om, on], dt]:
                 out = self.kernel(a, out)
                 return out

--- a/tests/st/runtime/ops/test_argmax_reduction.py
+++ b/tests/st/runtime/ops/test_argmax_reduction.py
@@ -89,7 +89,7 @@ class _ArgBase(PTOTestCase):
     def define_tensors(self) -> list[TensorSpec]:
         return [
             TensorSpec("a", [self._m, self._n], self._dtype, init_value=_distinct(self._m, self._n)),
-            TensorSpec("out", self._out_shape(), DataType.INT32, is_output=True),
+            TensorSpec("out", self._out_shape(), DataType.INT32, is_output=True, init_value=torch.zeros),
         ]
 
     def compute_expected(self, tensors: dict[str, torch.Tensor], params=None) -> None:
@@ -125,7 +125,7 @@ class TileRowArgmax(_ArgBase):
         class RowArgmaxProgram:
             @pl.function(type=pl.FunctionType.InCore)
             def kernel(
-                self, a: pl.Tensor[[m, n], dt], out: pl.Out[pl.Tensor[[m, 1], pl.INT32]]
+                self, a: pl.Tensor[[m, n], dt], out: pl.InOut[pl.Tensor[[m, 1], pl.INT32]]
             ) -> pl.Tensor[[m, 1], pl.INT32]:
                 t: pl.Tile[[m, n], dt] = pl.load(a, [0, 0], [m, n], valid_shapes=vshape)
                 tmp: pl.Tile[[m, n], dt] = pl.tile.create([m, n], dtype=dt, target_memory=pl.MemorySpace.Vec)
@@ -134,7 +134,7 @@ class TileRowArgmax(_ArgBase):
 
             @pl.function(type=pl.FunctionType.Orchestration)
             def orchestrator(
-                self, a: pl.Tensor[[m, n], dt], out: pl.Out[pl.Tensor[[m, 1], pl.INT32]]
+                self, a: pl.Tensor[[m, n], dt], out: pl.InOut[pl.Tensor[[m, 1], pl.INT32]]
             ) -> pl.Tensor[[m, 1], pl.INT32]:
                 return self.kernel(a, out)
 
@@ -155,7 +155,7 @@ class TileRowArgmin(_ArgBase):
         class RowArgminProgram:
             @pl.function(type=pl.FunctionType.InCore)
             def kernel(
-                self, a: pl.Tensor[[m, n], dt], out: pl.Out[pl.Tensor[[m, 1], pl.INT32]]
+                self, a: pl.Tensor[[m, n], dt], out: pl.InOut[pl.Tensor[[m, 1], pl.INT32]]
             ) -> pl.Tensor[[m, 1], pl.INT32]:
                 t: pl.Tile[[m, n], dt] = pl.load(a, [0, 0], [m, n], valid_shapes=vshape)
                 tmp: pl.Tile[[m, n], dt] = pl.tile.create([m, n], dtype=dt, target_memory=pl.MemorySpace.Vec)
@@ -164,7 +164,7 @@ class TileRowArgmin(_ArgBase):
 
             @pl.function(type=pl.FunctionType.Orchestration)
             def orchestrator(
-                self, a: pl.Tensor[[m, n], dt], out: pl.Out[pl.Tensor[[m, 1], pl.INT32]]
+                self, a: pl.Tensor[[m, n], dt], out: pl.InOut[pl.Tensor[[m, 1], pl.INT32]]
             ) -> pl.Tensor[[m, 1], pl.INT32]:
                 return self.kernel(a, out)
 
@@ -185,7 +185,7 @@ class TileColArgmax(_ArgBase):
         class ColArgmaxProgram:
             @pl.function(type=pl.FunctionType.InCore)
             def kernel(
-                self, a: pl.Tensor[[m, n], dt], out: pl.Out[pl.Tensor[[1, n], pl.INT32]]
+                self, a: pl.Tensor[[m, n], dt], out: pl.InOut[pl.Tensor[[1, n], pl.INT32]]
             ) -> pl.Tensor[[1, n], pl.INT32]:
                 t: pl.Tile[[m, n], dt] = pl.load(a, [0, 0], [m, n], valid_shapes=vshape)
                 tmp: pl.Tile[[m, n], dt] = pl.tile.create([m, n], dtype=dt, target_memory=pl.MemorySpace.Vec)
@@ -194,7 +194,7 @@ class TileColArgmax(_ArgBase):
 
             @pl.function(type=pl.FunctionType.Orchestration)
             def orchestrator(
-                self, a: pl.Tensor[[m, n], dt], out: pl.Out[pl.Tensor[[1, n], pl.INT32]]
+                self, a: pl.Tensor[[m, n], dt], out: pl.InOut[pl.Tensor[[1, n], pl.INT32]]
             ) -> pl.Tensor[[1, n], pl.INT32]:
                 return self.kernel(a, out)
 
@@ -215,7 +215,7 @@ class TileColArgmin(_ArgBase):
         class ColArgminProgram:
             @pl.function(type=pl.FunctionType.InCore)
             def kernel(
-                self, a: pl.Tensor[[m, n], dt], out: pl.Out[pl.Tensor[[1, n], pl.INT32]]
+                self, a: pl.Tensor[[m, n], dt], out: pl.InOut[pl.Tensor[[1, n], pl.INT32]]
             ) -> pl.Tensor[[1, n], pl.INT32]:
                 t: pl.Tile[[m, n], dt] = pl.load(a, [0, 0], [m, n], valid_shapes=vshape)
                 tmp: pl.Tile[[m, n], dt] = pl.tile.create([m, n], dtype=dt, target_memory=pl.MemorySpace.Vec)
@@ -224,7 +224,7 @@ class TileColArgmin(_ArgBase):
 
             @pl.function(type=pl.FunctionType.Orchestration)
             def orchestrator(
-                self, a: pl.Tensor[[m, n], dt], out: pl.Out[pl.Tensor[[1, n], pl.INT32]]
+                self, a: pl.Tensor[[m, n], dt], out: pl.InOut[pl.Tensor[[1, n], pl.INT32]]
             ) -> pl.Tensor[[1, n], pl.INT32]:
                 return self.kernel(a, out)
 
@@ -250,14 +250,14 @@ class TensorRowArgmax(_ArgBase):
         class TensorRowArgmaxProgram:
             @pl.function(type=pl.FunctionType.InCore)
             def kernel(
-                self, a: pl.Tensor[[32, 64], pl.FP32], out: pl.Out[pl.Tensor[[32, 1], pl.INT32]]
+                self, a: pl.Tensor[[32, 64], pl.FP32], out: pl.InOut[pl.Tensor[[32, 1], pl.INT32]]
             ) -> pl.Tensor[[32, 1], pl.INT32]:
                 r: pl.Tensor[[32, 1], pl.INT32] = pl.row_argmax(a)
                 return pl.assemble(out, r, [0, 0])
 
             @pl.function(type=pl.FunctionType.Orchestration)
             def orchestrator(
-                self, a: pl.Tensor[[32, 64], pl.FP32], out: pl.Out[pl.Tensor[[32, 1], pl.INT32]]
+                self, a: pl.Tensor[[32, 64], pl.FP32], out: pl.InOut[pl.Tensor[[32, 1], pl.INT32]]
             ) -> pl.Tensor[[32, 1], pl.INT32]:
                 return self.kernel(a, out)
 
@@ -277,14 +277,14 @@ class TensorColArgmax(_ArgBase):
         class TensorColArgmaxProgram:
             @pl.function(type=pl.FunctionType.InCore)
             def kernel(
-                self, a: pl.Tensor[[32, 64], pl.FP32], out: pl.Out[pl.Tensor[[1, 64], pl.INT32]]
+                self, a: pl.Tensor[[32, 64], pl.FP32], out: pl.InOut[pl.Tensor[[1, 64], pl.INT32]]
             ) -> pl.Tensor[[1, 64], pl.INT32]:
                 r: pl.Tensor[[1, 64], pl.INT32] = pl.col_argmax(a)
                 return pl.assemble(out, r, [0, 0])
 
             @pl.function(type=pl.FunctionType.Orchestration)
             def orchestrator(
-                self, a: pl.Tensor[[32, 64], pl.FP32], out: pl.Out[pl.Tensor[[1, 64], pl.INT32]]
+                self, a: pl.Tensor[[32, 64], pl.FP32], out: pl.InOut[pl.Tensor[[1, 64], pl.INT32]]
             ) -> pl.Tensor[[1, 64], pl.INT32]:
                 return self.kernel(a, out)
 

--- a/tests/st/runtime/ops/test_bitwise.py
+++ b/tests/st/runtime/ops/test_bitwise.py
@@ -78,7 +78,9 @@ class BitwiseNotTestCase(PTOTestCase):
     def define_tensors(self) -> list[TensorSpec]:
         return [
             TensorSpec("a", [self._m, self._n], self._dtype, init_value=lambda: _a_input(self._m, self._n)),
-            TensorSpec("out", [self._out_m, self._out_n], self._dtype, is_output=True),
+            TensorSpec(
+                "out", [self._out_m, self._out_n], self._dtype, is_output=True, init_value=torch.zeros
+            ),
         ]
 
     def get_program(self) -> Any:
@@ -90,7 +92,7 @@ class BitwiseNotTestCase(PTOTestCase):
         class BitwiseNotProgram:
             @pl.function(type=pl.FunctionType.InCore)
             def kernel(
-                self, a: pl.Tensor[[m, n], dt], out: pl.Out[pl.Tensor[[om, on], dt]]
+                self, a: pl.Tensor[[m, n], dt], out: pl.InOut[pl.Tensor[[om, on], dt]]
             ) -> pl.Tensor[[om, on], dt]:
                 a_tile = pl.load(a, [0, 0], [m, n], valid_shapes=vshape)
                 out = pl.store(pl.tile.not_(a_tile), off, out)
@@ -98,7 +100,7 @@ class BitwiseNotTestCase(PTOTestCase):
 
             @pl.function(type=pl.FunctionType.Orchestration)
             def orchestrator(
-                self, a: pl.Tensor[[m, n], dt], out: pl.Out[pl.Tensor[[om, on], dt]]
+                self, a: pl.Tensor[[m, n], dt], out: pl.InOut[pl.Tensor[[om, on], dt]]
             ) -> pl.Tensor[[om, on], dt]:
                 out = self.kernel(a, out)
                 return out

--- a/tests/st/runtime/ops/test_col_expand_arith.py
+++ b/tests/st/runtime/ops/test_col_expand_arith.py
@@ -87,9 +87,10 @@ class _TileColExpandBase(PTOTestCase):
 
     def compute_expected(self, tensors: dict[str, torch.Tensor], params=None) -> None:
         a, v = tensors["a"], tensors["v"]
-        res = torch.zeros_like(a)
         if self._valid:
             vm, vn = self._valid
+            # Region outside valid_shapes is undefined by contract — mark NaN so validate_golden skips it.
+            res = torch.full_like(a, float("nan"))
             res[:vm, :vn] = self._ref(a[:vm, :vn], v[:, :vn])
         else:
             res = self._ref(a, v)

--- a/tests/st/runtime/ops/test_elementwise_nd.py
+++ b/tests/st/runtime/ops/test_elementwise_nd.py
@@ -38,7 +38,7 @@ class Tile4DMulPartialProgram:
     def kernel(
         self,
         a: pl.Tensor[[4, 3, 8, 64], pl.FP32],
-        out: pl.Out[pl.Tensor[[4, 3, 8, 64], pl.FP32]],
+        out: pl.InOut[pl.Tensor[[4, 3, 8, 64], pl.FP32]],
     ) -> pl.Tensor[[4, 3, 8, 64], pl.FP32]:
         a_tile = pl.load(a, [0, 0, 0, 0], [2, 3, 8, 64])
         c_tile = pl.tile.mul(a_tile, a_tile)
@@ -49,7 +49,7 @@ class Tile4DMulPartialProgram:
     def orchestrator(
         self,
         a: pl.Tensor[[4, 3, 8, 64], pl.FP32],
-        out: pl.Out[pl.Tensor[[4, 3, 8, 64], pl.FP32]],
+        out: pl.InOut[pl.Tensor[[4, 3, 8, 64], pl.FP32]],
     ) -> pl.Tensor[[4, 3, 8, 64], pl.FP32]:
         out = self.kernel(a, out)
         return out
@@ -73,7 +73,7 @@ class Tile4DQuadrantProgram:
     def kernel(
         self,
         a: pl.Tensor[[2, 2, 8, 16], pl.FP32],
-        out: pl.Out[pl.Tensor[[2, 2, 8, 16], pl.FP32]],
+        out: pl.InOut[pl.Tensor[[2, 2, 8, 16], pl.FP32]],
     ) -> pl.Tensor[[2, 2, 8, 16], pl.FP32]:
         tile = pl.load(a, [0, 1, 0, 0], [1, 1, 8, 16])
         result_tile = pl.tile.mul(tile, tile)
@@ -84,7 +84,7 @@ class Tile4DQuadrantProgram:
     def orchestrator(
         self,
         a: pl.Tensor[[2, 2, 8, 16], pl.FP32],
-        out: pl.Out[pl.Tensor[[2, 2, 8, 16], pl.FP32]],
+        out: pl.InOut[pl.Tensor[[2, 2, 8, 16], pl.FP32]],
     ) -> pl.Tensor[[2, 2, 8, 16], pl.FP32]:
         out = self.kernel(a, out)
         return out
@@ -109,7 +109,7 @@ class Tile4DTopToBottomProgram:
         self,
         a: pl.Tensor[[2, 2, 8, 16], pl.FP32],
         b: pl.Tensor[[2, 2, 8, 16], pl.FP32],
-        out: pl.Out[pl.Tensor[[2, 2, 8, 16], pl.FP32]],
+        out: pl.InOut[pl.Tensor[[2, 2, 8, 16], pl.FP32]],
     ) -> pl.Tensor[[2, 2, 8, 16], pl.FP32]:
         a_tile = pl.load(a, [0, 0, 0, 0], [1, 2, 8, 16])
         b_tile = pl.load(b, [0, 0, 0, 0], [1, 2, 8, 16])
@@ -122,7 +122,7 @@ class Tile4DTopToBottomProgram:
         self,
         a: pl.Tensor[[2, 2, 8, 16], pl.FP32],
         b: pl.Tensor[[2, 2, 8, 16], pl.FP32],
-        out: pl.Out[pl.Tensor[[2, 2, 8, 16], pl.FP32]],
+        out: pl.InOut[pl.Tensor[[2, 2, 8, 16], pl.FP32]],
     ) -> pl.Tensor[[2, 2, 8, 16], pl.FP32]:
         out = self.kernel(a, b, out)
         return out
@@ -142,7 +142,7 @@ class Tile2DStoreTo3DProgram:
         self,
         a: pl.Tensor[[4, 16], pl.FP32],
         b: pl.Tensor[[4, 16], pl.FP32],
-        out: pl.Out[pl.Tensor[[2, 4, 16], pl.FP32]],
+        out: pl.InOut[pl.Tensor[[2, 4, 16], pl.FP32]],
     ) -> pl.Tensor[[2, 4, 16], pl.FP32]:
         a_tile = pl.load(a, [0, 0], [1, 16])
         b_tile = pl.load(b, [0, 0], [1, 16])
@@ -155,7 +155,7 @@ class Tile2DStoreTo3DProgram:
         self,
         a: pl.Tensor[[4, 16], pl.FP32],
         b: pl.Tensor[[4, 16], pl.FP32],
-        out: pl.Out[pl.Tensor[[2, 4, 16], pl.FP32]],
+        out: pl.InOut[pl.Tensor[[2, 4, 16], pl.FP32]],
     ) -> pl.Tensor[[2, 4, 16], pl.FP32]:
         out = self.kernel(a, b, out)
         return out
@@ -211,7 +211,7 @@ class Tile4DMulPartialTestCase(PTOTestCase):
     def define_tensors(self) -> list[TensorSpec]:
         return [
             TensorSpec("a", [4, 3, 8, 64], DataType.FP32, init_value=torch.randn),
-            TensorSpec("out", [4, 3, 8, 64], DataType.FP32, is_output=True),
+            TensorSpec("out", [4, 3, 8, 64], DataType.FP32, init_value=torch.zeros, is_output=True),
         ]
 
     def get_program(self) -> Any:
@@ -236,7 +236,7 @@ class Tile4DTopToBottomTestCase(PTOTestCase):
         return [
             TensorSpec("a", [2, 2, 8, 16], DataType.FP32, init_value=torch.randn),
             TensorSpec("b", [2, 2, 8, 16], DataType.FP32, init_value=torch.randn),
-            TensorSpec("out", [2, 2, 8, 16], DataType.FP32, is_output=True),
+            TensorSpec("out", [2, 2, 8, 16], DataType.FP32, init_value=torch.zeros, is_output=True),
         ]
 
     def get_program(self) -> Any:
@@ -260,7 +260,7 @@ class Tile4DQuadrantTestCase(PTOTestCase):
     def define_tensors(self) -> list[TensorSpec]:
         return [
             TensorSpec("a", [2, 2, 8, 16], DataType.FP32, init_value=torch.randn),
-            TensorSpec("out", [2, 2, 8, 16], DataType.FP32, is_output=True),
+            TensorSpec("out", [2, 2, 8, 16], DataType.FP32, init_value=torch.zeros, is_output=True),
         ]
 
     def get_program(self) -> Any:
@@ -291,7 +291,7 @@ class Tile2DStoreTo3DTestCase(PTOTestCase):
         return [
             TensorSpec("a", [4, 16], DataType.FP32, init_value=torch.randn),
             TensorSpec("b", [4, 16], DataType.FP32, init_value=torch.randn),
-            TensorSpec("out", [2, 4, 16], DataType.FP32, is_output=True),
+            TensorSpec("out", [2, 4, 16], DataType.FP32, init_value=torch.zeros, is_output=True),
         ]
 
     def get_program(self) -> Any:

--- a/tests/st/runtime/ops/test_scatter_update.py
+++ b/tests/st/runtime/ops/test_scatter_update.py
@@ -170,7 +170,7 @@ class IndexCastFromTileReadProgram:
         self,
         index_t: pl.Tensor[[1, 8], pl.INT32],
         src_t: pl.Tensor[[1, 32], pl.FP32],
-        dst_t: pl.Out[pl.Tensor[[32, 32], pl.FP32]],
+        dst_t: pl.InOut[pl.Tensor[[32, 32], pl.FP32]],
     ) -> pl.Tensor[[32, 32], pl.FP32]:
         index_tile: pl.Tile[[1, 8], pl.INT32] = pl.load(index_t, [0, 0], [1, 8])
         src_tile: pl.Tile[[1, 32], pl.FP32] = pl.load(src_t, [0, 0], [1, 32])
@@ -184,7 +184,7 @@ class IndexCastFromTileReadProgram:
         self,
         index_t: pl.Tensor[[1, 8], pl.INT32],
         src_t: pl.Tensor[[1, 32], pl.FP32],
-        dst_t: pl.Out[pl.Tensor[[32, 32], pl.FP32]],
+        dst_t: pl.InOut[pl.Tensor[[32, 32], pl.FP32]],
     ) -> pl.Tensor[[32, 32], pl.FP32]:
         dst_t = self.kernel(index_t, src_t, dst_t)
         return dst_t

--- a/tests/st/runtime/ops/test_unary_math.py
+++ b/tests/st/runtime/ops/test_unary_math.py
@@ -118,7 +118,9 @@ class _UnaryMathBase(PTOTestCase):
             TensorSpec(
                 "a", [self._m, self._n], self._dtype, init_value=lambda: self._input_fn(self._m, self._n)
             ),
-            TensorSpec("out", [self._out_m, self._out_n], self._dtype, is_output=True),
+            TensorSpec(
+                "out", [self._out_m, self._out_n], self._dtype, is_output=True, init_value=torch.zeros
+            ),
         ]
 
     def _ref(self, a: torch.Tensor) -> torch.Tensor:
@@ -130,6 +132,7 @@ class _UnaryMathBase(PTOTestCase):
         r, c = self._off
         if self._valid:
             vm, vn = self._valid
+            # Region outside valid_shapes stays zero — matches the InOut zero-init staged to device.
             res = torch.zeros_like(a)
             res[:vm, :vn] = self._ref(a[:vm, :vn])
         else:
@@ -153,7 +156,7 @@ class TileSinTestCase(_UnaryMathBase):
         class SinProgram:
             @pl.function(type=pl.FunctionType.InCore)
             def kernel(
-                self, a: pl.Tensor[[m, n], dt], out: pl.Out[pl.Tensor[[om, on], dt]]
+                self, a: pl.Tensor[[m, n], dt], out: pl.InOut[pl.Tensor[[om, on], dt]]
             ) -> pl.Tensor[[om, on], dt]:
                 a_tile = pl.load(a, [0, 0], [m, n], valid_shapes=vshape)
                 out = pl.store(pl.tile.sin(a_tile), off, out)
@@ -161,7 +164,7 @@ class TileSinTestCase(_UnaryMathBase):
 
             @pl.function(type=pl.FunctionType.Orchestration)
             def orchestrator(
-                self, a: pl.Tensor[[m, n], dt], out: pl.Out[pl.Tensor[[om, on], dt]]
+                self, a: pl.Tensor[[m, n], dt], out: pl.InOut[pl.Tensor[[om, on], dt]]
             ) -> pl.Tensor[[om, on], dt]:
                 out = self.kernel(a, out)
                 return out
@@ -184,7 +187,7 @@ class TileCosTestCase(_UnaryMathBase):
         class CosProgram:
             @pl.function(type=pl.FunctionType.InCore)
             def kernel(
-                self, a: pl.Tensor[[m, n], dt], out: pl.Out[pl.Tensor[[om, on], dt]]
+                self, a: pl.Tensor[[m, n], dt], out: pl.InOut[pl.Tensor[[om, on], dt]]
             ) -> pl.Tensor[[om, on], dt]:
                 a_tile = pl.load(a, [0, 0], [m, n], valid_shapes=vshape)
                 out = pl.store(pl.tile.cos(a_tile), off, out)
@@ -192,7 +195,7 @@ class TileCosTestCase(_UnaryMathBase):
 
             @pl.function(type=pl.FunctionType.Orchestration)
             def orchestrator(
-                self, a: pl.Tensor[[m, n], dt], out: pl.Out[pl.Tensor[[om, on], dt]]
+                self, a: pl.Tensor[[m, n], dt], out: pl.InOut[pl.Tensor[[om, on], dt]]
             ) -> pl.Tensor[[om, on], dt]:
                 out = self.kernel(a, out)
                 return out
@@ -215,7 +218,7 @@ class TileSqrtTestCase(_UnaryMathBase):
         class SqrtProgram:
             @pl.function(type=pl.FunctionType.InCore)
             def kernel(
-                self, a: pl.Tensor[[m, n], dt], out: pl.Out[pl.Tensor[[om, on], dt]]
+                self, a: pl.Tensor[[m, n], dt], out: pl.InOut[pl.Tensor[[om, on], dt]]
             ) -> pl.Tensor[[om, on], dt]:
                 a_tile = pl.load(a, [0, 0], [m, n], valid_shapes=vshape)
                 out = pl.store(pl.tile.sqrt(a_tile), off, out)
@@ -223,7 +226,7 @@ class TileSqrtTestCase(_UnaryMathBase):
 
             @pl.function(type=pl.FunctionType.Orchestration)
             def orchestrator(
-                self, a: pl.Tensor[[m, n], dt], out: pl.Out[pl.Tensor[[om, on], dt]]
+                self, a: pl.Tensor[[m, n], dt], out: pl.InOut[pl.Tensor[[om, on], dt]]
             ) -> pl.Tensor[[om, on], dt]:
                 out = self.kernel(a, out)
                 return out

--- a/tests/st/runtime/ops/test_vector_misc.py
+++ b/tests/st/runtime/ops/test_vector_misc.py
@@ -77,7 +77,9 @@ class _ScalarOpBase(PTOTestCase):
     def define_tensors(self) -> list[TensorSpec]:
         return [
             TensorSpec("a", [self._m, self._n], self._dtype, init_value=lambda: _randn(self._m, self._n)),
-            TensorSpec("out", [self._out_m, self._out_n], self._dtype, is_output=True),
+            TensorSpec(
+                "out", [self._out_m, self._out_n], self._dtype, is_output=True, init_value=torch.zeros
+            ),
         ]
 
     def _ref(self, a):
@@ -89,6 +91,7 @@ class _ScalarOpBase(PTOTestCase):
         r, c = self._off
         if self._valid:
             vm, vn = self._valid
+            # Region outside valid_shapes stays zero — matches the InOut zero-init staged to device.
             res = torch.zeros_like(a)
             res[:vm, :vn] = self._ref(a[:vm, :vn])
         else:
@@ -112,7 +115,7 @@ class TileMulsTestCase(_ScalarOpBase):
         class MulsProgram:
             @pl.function(type=pl.FunctionType.InCore)
             def kernel(
-                self, a: pl.Tensor[[m, n], dt], out: pl.Out[pl.Tensor[[om, on], dt]]
+                self, a: pl.Tensor[[m, n], dt], out: pl.InOut[pl.Tensor[[om, on], dt]]
             ) -> pl.Tensor[[om, on], dt]:
                 a_tile = pl.load(a, [0, 0], [m, n], valid_shapes=vshape)
                 out = pl.store(pl.tile.muls(a_tile, rhs), off, out)
@@ -120,7 +123,7 @@ class TileMulsTestCase(_ScalarOpBase):
 
             @pl.function(type=pl.FunctionType.Orchestration)
             def orchestrator(
-                self, a: pl.Tensor[[m, n], dt], out: pl.Out[pl.Tensor[[om, on], dt]]
+                self, a: pl.Tensor[[m, n], dt], out: pl.InOut[pl.Tensor[[om, on], dt]]
             ) -> pl.Tensor[[om, on], dt]:
                 out = self.kernel(a, out)
                 return out
@@ -143,7 +146,7 @@ class TileDivsTestCase(_ScalarOpBase):
         class DivsProgram:
             @pl.function(type=pl.FunctionType.InCore)
             def kernel(
-                self, a: pl.Tensor[[m, n], dt], out: pl.Out[pl.Tensor[[om, on], dt]]
+                self, a: pl.Tensor[[m, n], dt], out: pl.InOut[pl.Tensor[[om, on], dt]]
             ) -> pl.Tensor[[om, on], dt]:
                 a_tile = pl.load(a, [0, 0], [m, n], valid_shapes=vshape)
                 out = pl.store(pl.tile.divs(a_tile, rhs), off, out)
@@ -151,7 +154,7 @@ class TileDivsTestCase(_ScalarOpBase):
 
             @pl.function(type=pl.FunctionType.Orchestration)
             def orchestrator(
-                self, a: pl.Tensor[[m, n], dt], out: pl.Out[pl.Tensor[[om, on], dt]]
+                self, a: pl.Tensor[[m, n], dt], out: pl.InOut[pl.Tensor[[om, on], dt]]
             ) -> pl.Tensor[[om, on], dt]:
                 out = self.kernel(a, out)
                 return out
@@ -189,7 +192,9 @@ class ColExpandAddTestCase(PTOTestCase):
         return [
             TensorSpec("a", [self._m, self._n], self._dtype, init_value=lambda: _randn(self._m, self._n)),
             TensorSpec("col_vec", [1, self._n], self._dtype, init_value=lambda: _randn(1, self._n)),
-            TensorSpec("out", [self._out_m, self._out_n], self._dtype, is_output=True),
+            TensorSpec(
+                "out", [self._out_m, self._out_n], self._dtype, is_output=True, init_value=torch.zeros
+            ),
         ]
 
     def get_program(self) -> Any:
@@ -205,7 +210,7 @@ class ColExpandAddTestCase(PTOTestCase):
                 self,
                 a: pl.Tensor[[m, n], dt],
                 col_vec: pl.Tensor[[1, n], dt],
-                out: pl.Out[pl.Tensor[[om, on], dt]],
+                out: pl.InOut[pl.Tensor[[om, on], dt]],
             ) -> pl.Tensor[[om, on], dt]:
                 a_tile = pl.load(a, [0, 0], [m, n], valid_shapes=vshape)
                 col_tile = pl.load(col_vec, [0, 0], [1, n], valid_shapes=col_vshape)
@@ -217,7 +222,7 @@ class ColExpandAddTestCase(PTOTestCase):
                 self,
                 a: pl.Tensor[[m, n], dt],
                 col_vec: pl.Tensor[[1, n], dt],
-                out: pl.Out[pl.Tensor[[om, on], dt]],
+                out: pl.InOut[pl.Tensor[[om, on], dt]],
             ) -> pl.Tensor[[om, on], dt]:
                 out = self.kernel(a, col_vec, out)
                 return out
@@ -230,6 +235,7 @@ class ColExpandAddTestCase(PTOTestCase):
         r, c = self._off
         if self._valid:
             vm, vn = self._valid
+            # Region outside valid_shapes stays zero — matches the InOut zero-init staged to device.
             res = torch.zeros_like(a)
             res[:vm, :vn] = a[:vm, :vn] + col[:, :vn]
         else:

--- a/tests/st/runtime/test_fused_matmul_scatter.py
+++ b/tests/st/runtime/test_fused_matmul_scatter.py
@@ -74,7 +74,7 @@ class FusedMatmulScatterProgram:
         self,
         x: pl.Tensor[[B, H], pl.BF16],
         w: pl.Tensor[[H, H], pl.BF16],
-        cache: pl.Out[pl.Tensor[[B * CACHE, H], pl.BF16]],
+        cache: pl.InOut[pl.Tensor[[B * CACHE, H], pl.BF16]],
     ) -> pl.Tensor[[B * CACHE, H], pl.BF16]:
         kv_final = pl.create_tensor([B, H], dtype=pl.FP32)
         with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.split(pl.SplitMode.LEFT_RIGHT)]):
@@ -104,7 +104,7 @@ class FusedMatmulScatterNoSplitProgram:
         self,
         x: pl.Tensor[[B, H], pl.BF16],
         w: pl.Tensor[[H, H], pl.BF16],
-        cache: pl.Out[pl.Tensor[[B * CACHE, H], pl.BF16]],
+        cache: pl.InOut[pl.Tensor[[B * CACHE, H], pl.BF16]],
     ) -> pl.Tensor[[B * CACHE, H], pl.BF16]:
         kv_final = pl.create_tensor([B, H], dtype=pl.FP32)
         with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.split(pl.SplitMode.NONE)]):
@@ -127,7 +127,7 @@ class ScatterOnlyProgram:
     def fused(
         self,
         kv_final: pl.Tensor[[B, H], pl.FP32],
-        cache: pl.Out[pl.Tensor[[B * CACHE, H], pl.BF16]],
+        cache: pl.InOut[pl.Tensor[[B * CACHE, H], pl.BF16]],
     ) -> pl.Tensor[[B * CACHE, H], pl.BF16]:
         with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.split(pl.SplitMode.NONE)]):
             for b in pl.range(B):  # per-row scatter to distinct cache rows
@@ -153,7 +153,7 @@ class FusedMatmulScatterTestCase(PTOTestCase):
         return [
             TensorSpec("x", [B, H], DataType.BF16, init_value=_make_x),
             TensorSpec("w", [H, H], DataType.BF16, init_value=lambda: torch.ones(H, H, dtype=torch.bfloat16)),
-            TensorSpec("cache", [B * CACHE, H], DataType.BF16, is_output=True),
+            TensorSpec("cache", [B * CACHE, H], DataType.BF16, init_value=torch.zeros, is_output=True),
         ]
 
     def get_program(self) -> Any:
@@ -195,7 +195,7 @@ class ScatterOnlyTestCase(PTOTestCase):
     def define_tensors(self) -> list[TensorSpec]:
         return [
             TensorSpec("kv_final", [B, H], DataType.FP32, init_value=_make_kv_final),
-            TensorSpec("cache", [B * CACHE, H], DataType.BF16, is_output=True),
+            TensorSpec("cache", [B * CACHE, H], DataType.BF16, init_value=torch.zeros, is_output=True),
         ]
 
     def get_program(self) -> Any:


### PR DESCRIPTION
## Summary

Advance the `runtime` submodule 18 commits: `438d5cb1` → `a756969c`.

Notable changes in range:
- **feat(runtime/pto2)**: predicated dispatch — the scheduler evaluates a per-task predicate at the dispatch point (#1314)
- **perf**: skip device staging for pure-output tensors (#1365)
- **feat**: eager prebuilt runtime-arena prewarm at worker init (#1322)
- **update(distributed)**: `all_to_all` converted to push-based lowering (#1267)
- **dfx**: L2-swimlane critical-path analysis + profiling collector sharding/rebalance

## Interface compatibility

No pypto adaptation is required:
- Codegen emits only stable runtime APIs (`rt_submit_*_task` / `TaskOutputTensors` / `get_ref` / `alloc_tensors` / `add_output`), none of which changed.
- The `pto_types.h` / `pto_submit_types.h` predicate additions (`DispatchPredicate`, `L0TaskPredicate`, `Arg::predicate_`, `PTO2_SUBTASK_FLAG_HAS_PREDICATE`) are purely additive.
- `simpler_init` / `ChipWorker::init` gained an optional `prewarm_config` parameter — defaulted on the C++ side and absorbed by the runtime's own Python wrapper (pypto calls `.init()` with no positional args).
- `call_config.h` is unchanged; all DFX/feature flags pypto sets remain valid.
- pypto's C++ never includes runtime headers (codegen emits C++ as text), so the internal profiling-header refactor in this range has no effect on the pypto build.

## Testing
- [ ] Build the worktree and run an on-device kernel to exercise the prewarm `init` path