### PR TITLE
fix(runtime): Recover interleaved [STRACE] records in L3 bench parse

### DIFF
--- a/python/pypto/runtime/bench.py
+++ b/python/pypto/runtime/bench.py
@@ -793,7 +793,17 @@ def _parse_stats_from_strace(
 
     names = _span_names()
     stats = BenchmarkStats(rounds=rounds, warmup=warmup)
-    invocations = group_invocations(parse_spans(log_text.splitlines()))
+    # L3 forks one chip worker per rank, all sharing the capture fd; their
+    # concurrent writes can interleave two complete ``[STRACE]`` records onto one
+    # physical line. simpler's ``parse_spans`` reads at most one record per line
+    # (``search`` + greedy ``attrs=.*``), silently dropping the 2nd — which loses
+    # that dispatch's orch/sched spans and makes the (round, rank) read as 0.
+    # Each record's payload is intact on the wire; only the line boundary was lost,
+    # so re-split on the ``[STRACE]`` marker to give every record its own line
+    # before handing the (unmodified) simpler parser the text. Prefix text left on a
+    # line with no marker simply fails the regex and is skipped, as before.
+    lines = log_text.replace("[STRACE]", "\n[STRACE]").splitlines()
+    invocations = group_invocations(parse_spans(lines))
     if not invocations:
         return stats
 

--- a/tests/ut/runtime/test_benchmark.py
+++ b/tests/ut/runtime/test_benchmark.py
@@ -274,6 +274,30 @@ def test_parse_l3_two_ranks_per_round_max(span_root):
     assert stats.host_wall_us == [200.0, 300.0]
 
 
+def test_parse_l3_recovers_interleaved_records_on_one_line(span_root):
+    """Two ``[STRACE]`` records mashed onto one physical line are both recovered.
+
+    L3 forks one chip worker per rank sharing the capture fd; concurrent writes
+    can interleave two complete records onto a single physical line. The parser
+    must re-split on the ``[STRACE]`` marker and recover both — dropping the
+    second record would zero that (round, rank).
+    """
+    lines = _launch_lines(0, span_root, host_us=100, device_us=10, pid=100)
+    lines += _launch_lines(1, span_root, host_us=300, device_us=30, pid=100)
+    # Simulate the wire collision: inv0's device-wall record and inv1's host
+    # record land on the same physical line (no newline between them). Every
+    # other record keeps its own line.
+    mashed = "\n".join([lines[0], f"{lines[1]} {lines[2]}", lines[3]])
+
+    stats = _parse_stats_from_strace(mashed, rounds=2, warmup=0, distributed=True)
+
+    # Both invocations survive. Without the re-split, the second record on the
+    # mashed line is dropped, so inv1's host span reads 0 for round1.
+    assert stats.fallback_flattened is False
+    assert stats.per_rank("device") == {100: [10.0, 30.0]}
+    assert stats.per_rank("host") == {100: [100.0, 300.0]}
+
+
 def test_parse_l3_multi_dispatch_sums_within_round(span_root):
     """A rank dispatched multiple times per round (heterogeneous hids) sums within the round."""
     lines: list[str] = []


### PR DESCRIPTION
## Summary
- L3 benchmark parsing (`distributed=True`) forks one chip worker per rank, all sharing the capture fd. Their concurrent writes can interleave two complete `[STRACE]` records onto a single physical line.
- simpler's `parse_spans` reads at most one record per line (`search` + greedy `attrs=.*`), so it silently drops the second record — losing that dispatch's orch/sched spans and making the affected `(round, rank)` read as **0**.
- Fix: in `_parse_stats_from_strace`, re-split the captured log on the `[STRACE]` marker (`log_text.replace("[STRACE]", "\n[STRACE]")`) so every record gets its own line before handing the text to the **unmodified** simpler parser. Each record's payload is intact on the wire — only the line boundary was lost. A prefix left on a marker-less line simply fails the regex and is skipped, as before.

## Testing
- [x] Added L3 regression test `test_parse_l3_recovers_interleaved_records_on_one_line` mashing two records onto one physical line; asserts both invocations survive. Verified it **fails without the fix** (round1 host reads `0.0`) and passes with it.
- [x] `tests/ut/runtime/test_benchmark.py` — 28 passed.
- [x] Full `tests/ut/` suite run; no new regressions from this change.