### PR TITLE
feat(distributed): add shape+dtype overload to alloc_window_buffer

### DIFF
--- a/python/pypto/language/distributed/op/tensor_ops.py
+++ b/python/pypto/language/distributed/op/tensor_ops.py
@@ -88,19 +88,129 @@ def _validate_pipeline(pipeline: bool, chunk_rows: int, chunk_cols: int, op_name
         )
 
 
-def alloc_window_buffer(size: IntLike, *, name: str = "") -> Ptr:
-    """Declare a per-rank HCCL window-buffer in a comm-domain scope slot of ``size`` bytes.
-
-    Mirrors ``tile.alloc(memory_space, size)``: pure allocation semantics, no
-    shape / dtype concept on the buffer itself. The result is the
-    allocation-identity token that ``pld.tensor.window`` consumes.
+def _validate_window_buffer_shape(shape: list[int | Expr]) -> None:
+    """Validate that a window-buffer shape is non-empty and static dims are positive.
 
     Args:
-        size: Per-rank allocation size in **bytes**. Accepts an ``int``
-            literal, a DSL ``Scalar``, or a raw :class:`ir.Expr`.
+        shape: Normalized shape — elements are ``int`` or :class:`ir.Expr`.
+
+    Raises:
+        ValueError: If ``shape`` is empty or any statically-known dimension
+            is non-positive.
+    """
+    if not shape:
+        raise ValueError("pld.tensor.alloc_window_buffer shape must be non-empty")
+    for i, d in enumerate(shape):
+        if isinstance(d, int):
+            if d <= 0:
+                raise ValueError(
+                    f"pld.tensor.alloc_window_buffer shape dimension[{i}] is {d}; "
+                    "all dimensions must be positive"
+                )
+        elif isinstance(d, _ir.ConstInt):
+            if d.value <= 0:
+                raise ValueError(
+                    f"pld.tensor.alloc_window_buffer shape dimension[{i}] is {d.value}; "
+                    "all dimensions must be positive"
+                )
+
+
+def _compute_window_buffer_bytes(shape: list[int | Expr], dtype: DataType) -> int | Expr:
+    """Compute byte size for a shape+dtype ``alloc_window_buffer`` call.
+
+    When all shape dimensions are statically known (Python ``int`` or
+    :class:`ir.ConstInt`) the product is computed eagerly as a Python
+    ``int`` (no IR nodes emitted).  Otherwise (any dimension is a dynamic
+    :class:`ir.Expr`) a chain of :class:`ir.Mul` nodes is emitted.
+
+    Args:
+        shape: Normalized shape — elements are ``int`` or :class:`ir.Expr`.
+        dtype: Element data type (byte size via ``dtype.get_byte()``).
+
+    Returns:
+        Byte size as ``int`` (static) or ``ir.Expr`` (dynamic).
+    """
+    _validate_window_buffer_shape(shape)
+
+    # Fold pure-static: Python ints AND ir.ConstInt — both are compile-time
+    # constants.  Per the parser, integer literals arrive as ConstInt(INDEX),
+    # not raw Python int, so we must check both.
+    static_total = 1
+    for d in shape:
+        if isinstance(d, int):
+            static_total *= d
+        elif isinstance(d, _ir.ConstInt):
+            static_total *= d.value
+        else:
+            break
+    else:
+        # All dims folded — return an eager Python int.
+        return static_total * dtype.get_byte()
+
+    # Dynamic path: at least one genuinely dynamic dim.
+    span = _ir.Span.unknown()
+    # Seed from the first dim instead of ConstInt(1) to avoid a redundant
+    # Mul(1, dim0) identity in the emitted IR.
+    first = shape[0]
+    if isinstance(first, int):
+        result: Expr = _ir.ConstInt(first, DataType.INT64, span)
+    elif isinstance(first, _ir.ConstInt):
+        result = _ir.ConstInt(first.value, DataType.INT64, span)
+    else:
+        result = first
+    for dim in shape[1:]:
+        if isinstance(dim, int):
+            dim_expr = _ir.ConstInt(dim, DataType.INT64, span)
+        elif isinstance(dim, _ir.ConstInt):
+            dim_expr = _ir.ConstInt(dim.value, DataType.INT64, span)
+        else:
+            dim_expr = dim
+        result = _ir.Mul(result, dim_expr, DataType.INT64, span)
+    byte_expr: Expr = _ir.ConstInt(dtype.get_byte(), DataType.INT64, span)
+    return _ir.Mul(result, byte_expr, DataType.INT64, span)
+
+
+@overload
+def alloc_window_buffer(size: IntLike, *, name: str = "") -> Ptr: ...
+
+
+@overload
+def alloc_window_buffer(shape: Sequence[IntLike], *, dtype: DataType, name: str = "") -> Ptr: ...
+
+
+def alloc_window_buffer(  # type: ignore[no-redef]
+    size: IntLike | Sequence[IntLike], *, dtype: DataType | None = None, name: str = ""
+) -> Ptr:
+    """Declare a per-rank HCCL window-buffer in a comm-domain scope slot.
+
+    Two forms:
+
+    * **Canonical byte form:**
+      ``alloc_window_buffer(size, *, name=...)`` — ``size`` is the per-rank
+      allocation size in **bytes**.  Accepts an ``int`` literal, a DSL
+      ``Scalar``, or a raw :class:`ir.Expr`.
+
+    * **Shape+dtype convenience overload:**
+      ``alloc_window_buffer(shape, *, dtype=..., name=...)`` — ``shape`` is a
+      list / tuple of per-rank dimensions.  The byte size is computed
+      automatically as ``product(shape) × dtype.get_byte()`` and the call
+      normalizes to the canonical byte form.  ``dtype`` is required when
+      ``shape`` is a sequence and rejected otherwise.
+
+    Both forms return the singleton :class:`ir.PtrType` allocation-identity
+    token that ``pld.tensor.window`` consumes.  The two-phase
+    ``alloc → window`` design is preserved — a single buffer can back multiple
+    ``window()`` views across loop iterations.
+
+    Args:
+        size: (Canonical form) Per-rank allocation size in **bytes**.
+        shape: (Convenience form) Per-rank shape as a sequence of per-dimension
+            sizes — ``int``, DSL ``Scalar``, or raw :class:`ir.Expr`.
+        dtype: (Convenience form, required) Element data type. Must be
+            ``None`` (default) in the canonical byte form.
         name: Unique buffer identifier. The parser injects this from the LHS
             of the surrounding assignment
-            (``buf = pld.tensor.alloc_window_buffer(N)``); users **must not**
+            (``buf = pld.tensor.alloc_window_buffer(...)``); users **must not**
             pass it explicitly.
 
     Returns:
@@ -112,16 +222,32 @@ def alloc_window_buffer(size: IntLike, *, name: str = "") -> Ptr:
 
     Raises:
         ValueError: If ``name`` is empty (the parser must have injected it).
+        ValueError: If ``shape`` is a sequence but ``dtype`` is not provided.
+        ValueError: If ``size`` is scalar but ``dtype`` is provided.
     """
     if not name:
         raise ValueError(
             "pld.tensor.alloc_window_buffer must appear as the RHS of a simple assignment "
             "(its result must be bound to a named variable)"
         )
+
     if isinstance(size, (list, tuple)):
+        if dtype is None:
+            raise ValueError(
+                "pld.tensor.alloc_window_buffer requires dtype= when the first argument is a shape "
+                "(list / tuple of per-rank dimensions)"
+            )
+        shape_normalized: list[int | Expr] = _normalize_intlike(size)
+        byte_size: int | Expr = _compute_window_buffer_bytes(shape_normalized, dtype)
+        call = _ir_tensor.alloc_window_buffer(_unwrap(byte_size), name=name)
+        return Ptr(expr=call)
+
+    if dtype is not None:
         raise ValueError(
-            "pld.tensor.alloc_window_buffer size must be a scalar (int / Expr in bytes), not a list/tuple"
+            "pld.tensor.alloc_window_buffer dtype= is only valid when the first argument is a shape "
+            "(list / tuple), not a scalar byte size"
         )
+
     call = _ir_tensor.alloc_window_buffer(_unwrap(size), name=name)
     return Ptr(expr=call)
 

--- a/tests/ut/ir/parser/test_alloc_window_buffer.py
+++ b/tests/ut/ir/parser/test_alloc_window_buffer.py
@@ -11,21 +11,27 @@
 """Parser tests for ``pld.tensor.alloc_window_buffer`` (and its
 ``pld.alloc_window_buffer`` short form).
 
-After the MemRef-mirror redesign, the alloc op is a pure-allocation primitive
-(parallel to ``tile.alloc(memspace, size)``):
+The alloc op supports two forms:
 
-* ``size`` is a scalar **byte** count; no shape, no dtype on the alloc.
-* The op returns the singleton :class:`PtrType`; the parser binds the LHS as
-  a plain :class:`ir.Var` of type :class:`ir.PtrType`. The
-  comm-collection pass later wraps the Ptr in an :class:`ir.WindowBuffer` Var
-  subclass and registers it on ``CommDomainScopeStmt wrappers in each host_orch body``.
-* The LHS variable name flows through ``Var.name_hint`` (and is also injected
-  as the op's ``name`` kwarg so the comm-collection pass can find it).
+* **Canonical byte form:** ``alloc_window_buffer(size)`` — ``size`` is a scalar
+  **byte** count; no shape, no dtype on the alloc.
+* **Shape+dtype convenience overload:** ``alloc_window_buffer(shape, *, dtype=...)``
+  — ``shape`` is a list / tuple of per-rank dimensions. The byte size is computed
+  automatically as ``product(shape) × dtype.get_byte()`` and the call normalizes
+  to the canonical byte form in IR.
+
+The op returns the singleton :class:`PtrType`; the parser binds the LHS as
+a plain :class:`ir.Var` of type :class:`ir.PtrType`. The
+comm-collection pass later wraps the Ptr in an :class:`ir.WindowBuffer` Var
+subclass and registers it on ``CommDomainScopeStmt wrappers in each host_orch body``.
+The LHS variable name flows through ``Var.name_hint`` (and is also injected
+as the op's ``name`` kwarg so the comm-collection pass can find it).
 """
 
 import pypto.language as pl
 import pypto.language.distributed as pld
 import pytest
+from pypto import DataType
 from pypto.pypto_core import ir
 
 
@@ -172,15 +178,14 @@ def test_alloc_window_buffer_rejects_duplicate_names():
 
 
 def test_alloc_window_buffer_rejects_user_kwargs():
-    """The user-facing alloc takes only a positional size — no kwargs are allowed.
-    Unknown kwargs surface from the DSL wrapper's Python signature."""
-    with pytest.raises(Exception, match="unexpected keyword argument"):
+    """``dtype=`` is rejected on the scalar byte form — it is only valid with the shape form."""
+    with pytest.raises(Exception, match="dtype= is only valid when the first argument is a shape"):
 
         @pl.program
         class P:  # noqa: F841
             @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
             def host_orch(self):
-                buf = pld.alloc_window_buffer(8, dtype=pl.FP32)  # noqa: F841
+                buf = pld.alloc_window_buffer(8, dtype=pl.FP32)  # pyright: ignore[reportArgumentType] # noqa: F841
                 return buf
 
 
@@ -208,9 +213,9 @@ def test_alloc_window_buffer_rejects_bare_call_outside_assignment():
                 return 0
 
 
-def test_alloc_window_buffer_rejects_list_for_size():
-    """The redesigned signature takes a scalar byte size, not a shape list."""
-    with pytest.raises(Exception, match="size must be a scalar"):
+def test_alloc_window_buffer_rejects_list_without_dtype():
+    """A list/tuple without ``dtype=`` is rejected — the shape form requires dtype."""
+    with pytest.raises(Exception, match="requires dtype="):
 
         @pl.program
         class P:  # noqa: F841
@@ -218,6 +223,114 @@ def test_alloc_window_buffer_rejects_list_for_size():
             def host_orch(self):
                 buf = pld.alloc_window_buffer([256])  # pyright: ignore[reportArgumentType] # noqa: F841
                 return buf
+
+
+def test_alloc_window_buffer_shaped_static():
+    """Shape+dtype form with static int-literal dimensions folds to a single ``ConstInt``
+    carrying the total byte size (not a Mul chain)."""
+
+    @pl.program
+    class P:
+        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+        def host_orch(self):
+            buf = pld.alloc_window_buffer([64, 128], dtype=pl.FP32)
+            return buf
+
+    func = _get_host_orch(P)
+    stmt = _find_alloc_assignment(func)
+    assert isinstance(stmt.value, ir.Call)
+    call = stmt.value
+    assert call.op.name == "pld.tensor.alloc_window_buffer"
+    assert call.kwargs["name"] == "buf"
+    assert "dtype" not in call.kwargs
+    assert len(call.args) == 1
+    # Static shape must fold to a single ConstInt byte-size arg.
+    assert isinstance(call.args[0], ir.ConstInt)
+    assert call.args[0].value == 64 * 128 * 4  # FP32 = 4 bytes
+    assert call.args[0].dtype == DataType.INT64
+
+
+def test_alloc_window_buffer_shaped_long_form():
+    """Shape+dtype form works with the 3-segment ``pld.tensor.alloc_window_buffer`` form
+    and folds static dims to a ConstInt byte-size arg."""
+
+    @pl.program
+    class P:
+        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+        def host_orch(self):
+            buf = pld.tensor.alloc_window_buffer([32, 16], dtype=pl.INT32)
+            return buf
+
+    func = _get_host_orch(P)
+    stmt = _find_alloc_assignment(func)
+    assert isinstance(stmt.value, ir.Call)
+    call = stmt.value
+    assert call.op.name == "pld.tensor.alloc_window_buffer"
+    assert call.kwargs["name"] == "buf"
+    assert len(call.args) == 1
+    # Static shape must fold to a single ConstInt byte-size arg.
+    assert isinstance(call.args[0], ir.ConstInt)
+    assert call.args[0].value == 32 * 16 * 4  # INT32 = 4 bytes
+    assert call.args[0].dtype == DataType.INT64
+
+
+def test_alloc_window_buffer_rejects_empty_shape():
+    """An empty shape list is rejected with a clear error."""
+    with pytest.raises(Exception, match="shape must be non-empty"):
+
+        @pl.program
+        class P:  # noqa: F841
+            @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+            def host_orch(self):
+                buf = pld.alloc_window_buffer([], dtype=pl.FP32)  # noqa: F841
+                return buf
+
+
+def test_alloc_window_buffer_rejects_non_positive_static_dim():
+    """Zero and negative static dimensions are rejected with a clear error."""
+    with pytest.raises(Exception, match="all dimensions must be positive"):
+
+        @pl.program
+        class P:  # noqa: F841
+            @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+            def host_orch(self):
+                buf = pld.alloc_window_buffer([0, 128], dtype=pl.FP32)  # noqa: F841
+                return buf
+
+    with pytest.raises(Exception, match="all dimensions must be positive"):
+
+        @pl.program
+        class P:  # noqa: F841
+            @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+            def host_orch(self):
+                buf = pld.alloc_window_buffer([64, -1], dtype=pl.FP32)  # noqa: F841
+                return buf
+
+
+def test_alloc_window_buffer_shaped_dynamic():
+    """Shape+dtype form with a dynamic dim (``pld.world_size()``) produces a Mul chain
+    (not a single ConstInt) and parses successfully."""
+
+    @pl.program
+    class P:
+        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+        def host_orch(self):
+            buf = pld.alloc_window_buffer([64, pld.world_size()], dtype=pl.FP32)
+            return buf
+
+    func = _get_host_orch(P)
+    stmt = _find_alloc_assignment(func)
+    assert isinstance(stmt.value, ir.Call)
+    call = stmt.value
+    assert call.op.name == "pld.tensor.alloc_window_buffer"
+    assert call.kwargs["name"] == "buf"
+    assert "dtype" not in call.kwargs
+    assert len(call.args) == 1
+    # Dynamic shape — the byte size is a Mul chain, not a ConstInt.
+    byte_size = call.args[0]
+    assert isinstance(byte_size, ir.Mul)
+    assert isinstance(byte_size.type, ir.ScalarType)
+    assert byte_size.type.dtype == DataType.INT64
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Adds `pld.alloc_window_buffer(shape, *, dtype=...)` — a convenience overload
that computes the per-rank byte size from the shape and dtype, eliminating
manual `product(shape) * dtype.get_byte()` arithmetic. Normalizes to the
existing IR op — no C++ changes, no new IR surface.

Implements option 5 of RFC #1968.

## Before / After

```
# Canonical byte form (preserved)
data_buf   = pld.alloc_window_buffer(nr * SIZE * pl.FP32.get_byte())
signal_buf = pld.alloc_window_buffer(nr * pl.INT32.get_byte())

# Shape+dtype overload (new)
data_buf   = pld.alloc_window_buffer([nr, SIZE], dtype=pl.FP32)
signal_buf = pld.alloc_window_buffer([nr], dtype=pl.INT32)
```

The canonical form is unchanged. The two-phase `alloc -> window` design
remains first-class — a single buffer can still back multiple `window()`
views across loop iterations.

## Changes (2 files, DSL-only)

| File | Change |
|------|--------|
| `tensor_ops.py` | `_compute_window_buffer_bytes` helper, two `@overload` signatures, dispatch on first-arg type |
| `test_alloc_window_buffer.py` | 2 new tests, 2 error-match strings updated |

## Verification

- [x] `pytest tests/ut/ir/parser/test_alloc_window_buffer.py` — 12/12 pass (sim Docker)
- [ ] Distributed ST regression
