### PR TITLE
perf(runtime): prewarm the prebuilt runtime arena at worker init

### DIFF
--- a/docs/en/dev/05-runtime-ring-sizing.md
+++ b/docs/en/dev/05-runtime-ring-sizing.md
@@ -84,9 +84,10 @@ ring sizes:
 ```python
 from pypto.runtime import RunConfig
 
-with compiled.prepare() as rt:           # setup once
-    prefill_cfg = RunConfig(platform="a2a3", ring_task_window=256)
-    decode_cfg = RunConfig(platform="a2a3", ring_task_window=64)
+prefill_cfg = RunConfig(platform="a2a3", ring_task_window=256)
+decode_cfg = RunConfig(platform="a2a3", ring_task_window=64)
+
+with compiled.prepare(prefill_cfg) as rt:              # setup once + prewarm
     rt(host_x, weight, host_out, config=prefill_cfg)   # large window for prefill
     rt(host_x, weight, host_out, config=decode_cfg)    # smaller window for decode
 
@@ -100,6 +101,45 @@ time, not per dispatch).
 
 Set only the fields you want to override; the rest stay unset and fall back per
 the precedence above.
+
+## Arena prewarm and the single-slot cache
+
+A ring sizing's runtime arena costs ~800 ms to build the first time it is used.
+Workers build it eagerly at `init` — `prepare(config)` / `ChipWorker` /
+`execute_on_device` — so the cold build lands in setup instead of inside the
+first (usually timed) dispatch.
+
+The arena cache is keyed on the **full per-ring sizing vector** (all four rings'
+`ring_task_window` / `ring_heap` / `ring_dep_pool`, hashed together). So a single
+dispatch that sizes rings differently — the list form, e.g.
+`ring_task_window=[256, 128, 64, 0]` — is one key and one arena: prewarm covers
+it completely, as long as `prepare(...)` gets that same `RunConfig`. The
+single-slot limit below is only about *different dispatches* using *different*
+sizing vectors, never about per-ring differences within one dispatch.
+
+The cache holds exactly **one** sizing vector per worker, and every arena build
+overwrites that slot. So:
+
+- Pass the dispatch `RunConfig` to `prepare(...)`. It is used for the prewarm
+  only — it is not stored, so every dispatch still needs its own `config=`
+  (as above: `prefill_cfg` goes to both).
+- The prewarm only removes the cold build from the **first** dispatch, and only
+  when that dispatch's sizing matches the prewarmed one — so prewarm the sizing
+  your *first* dispatch uses, not the most frequent one. Any first dispatch with
+  a different sizing misses, rebuilds, and overwrites the prewarmed slot, wasting
+  the prewarm.
+- Keep the ring sizing **constant across a worker's dispatches**. The single
+  slot is per worker and is overwritten on every switch, so alternating sizings
+  rebuild the arena on **each** switch regardless of prewarm (the `decode_cfg`
+  dispatch above pays a build, and the next `prefill_cfg` pays another). Splitting
+  the sizings across separate workers is usually not an option — the reason to
+  hold one worker (`prepare(..., extra_compiled=[...])`) is to share device-
+  resident state such as a KV cache, which separate workers cannot. So pick one
+  sizing that serves all of that worker's dispatch shapes rather than varying it
+  per dispatch.
+- L2 dispatch takes its ring sizing from the per-call `RunConfig`, so a
+  `ChipWorker` prewarms the runtime's default sizing; a per-call `RunConfig` that
+  sizes the rings differently rebuilds once.
 
 ## Related
 

--- a/docs/zh-cn/dev/05-runtime-ring-sizing.md
+++ b/docs/zh-cn/dev/05-runtime-ring-sizing.md
@@ -79,9 +79,10 @@ compiled = run(
 ```python
 from pypto.runtime import RunConfig
 
-with compiled.prepare() as rt:           # 仅一次性 setup
-    prefill_cfg = RunConfig(platform="a2a3", ring_task_window=256)
-    decode_cfg = RunConfig(platform="a2a3", ring_task_window=64)
+prefill_cfg = RunConfig(platform="a2a3", ring_task_window=256)
+decode_cfg = RunConfig(platform="a2a3", ring_task_window=64)
+
+with compiled.prepare(prefill_cfg) as rt:              # 一次性 setup + 预热
     rt(host_x, weight, host_out, config=prefill_cfg)   # prefill 用较大的 window
     rt(host_x, weight, host_out, config=decode_cfg)    # decode 用较小的 window
 
@@ -93,6 +94,34 @@ compiled(a, b, c, config=RunConfig(platform="a2a3", ring_heap=8 * 1024 * 1024))
 忽略（它们在编译 / prepare 时设置，而非按派发设置）。
 
 只设置你想覆盖的字段即可；其余字段保持未设置，并按上述优先级回退。
+
+## Arena 预热与单槽缓存
+
+某个 ring 尺寸对应的运行时 arena，首次使用时需要约 800ms 构建。worker 现在会在
+`init` 时主动构建它 —— `prepare(config)` / `ChipWorker` / `execute_on_device` ——
+使这次冷构建落在 setup 阶段，而不是落在第一次（通常被计时的）派发里。
+
+arena 缓存以**完整的 per-ring 尺寸向量**为 key（4 个 ring 的 `ring_task_window` /
+`ring_heap` / `ring_dep_pool` 一起 hash）。所以"一次派发内各 ring 尺寸不同"——即
+list 形式，如 `ring_task_window=[256, 128, 64, 0]`——是**一个** key、**一块** arena：
+只要 `prepare(...)` 传的是同一个 `RunConfig`，预热就完整覆盖它。下面的单槽限制**只**针对
+*不同派发之间*使用*不同*尺寸向量，与"一次派发内各 ring 不同"无关。
+
+缓存**每个 worker 只保留一个**尺寸向量，且每次构建 arena 都会**覆盖**那个槽，因此：
+
+- 把派发用的 `RunConfig` 传给 `prepare(...)`。它**只**用于预热、不会被保存，所以每次
+  派发仍需各自传 `config=`（如上例，`prefill_cfg` 两处都要传）。
+- 预热只能省掉**首个**派发的冷构建，且仅当首个派发的尺寸与预热尺寸一致时才生效——所以
+  请预热你**首个**派发使用的尺寸，而非最频繁的那个。任何首个派发用了别的尺寸都会 miss、
+  重建、覆盖掉预热槽，预热白费。
+- **同一个 worker 的多次派发之间尽量保持 ring 尺寸不变**。单槽是每个 worker 各一个、每次切换
+  都被覆盖，所以交替尺寸时**每次**切换都会重建 arena（与预热无关；上例 `decode_cfg` 那次付
+  一次构建，紧接着的 `prefill_cfg` 又付一次）。把不同尺寸拆到不同 worker 通常行不通——之所以
+  要常驻一个 worker（`prepare(..., extra_compiled=[...])`），正是为了共享 KV cache 这类
+  设备驻留状态，而分开的 worker 无法共享。所以应挑一个能服务该 worker 所有派发形状的尺寸，而
+  不是逐次派发改尺寸。
+- L2 派发的 ring 尺寸来自每次调用的 `RunConfig`，因此 `ChipWorker` 预热的是运行时的默认
+  尺寸；若某次调用的 `RunConfig` 指定了不同的 ring 尺寸，则会重建一次。
 
 ## 相关文档
 

--- a/python/pypto/ir/distributed_compiled_program.py
+++ b/python/pypto/ir/distributed_compiled_program.py
@@ -368,7 +368,7 @@ class DistributedCompiledProgram:
 
     def prepare(
         self,
-        config: Any = None,
+        config: "RunConfig | None" = None,
         *,
         extra_compiled: Sequence["DistributedCompiledProgram"] = (),
         callbacks: dict[str, Callable[..., Any]] | None = None,
@@ -393,7 +393,13 @@ class DistributedCompiledProgram:
         the one-shot ``compile(...)(*args)`` / ``execute_distributed`` path.
 
         Args:
-            config: Optional run configuration (reserved; currently unused).
+            config: Optional :class:`~pypto.runtime.RunConfig` used **only** to
+                prewarm the runtime-arena cache with its ring sizing, so the first
+                dispatch skips the ~800ms cold build. It is not stored: every
+                dispatch still takes its own ``config=``, so pass the same
+                ``RunConfig`` to both. ``None`` prewarms the program's baseline
+                sizing (env / compile-time fallback). The cache is single-slot, so
+                dispatches that alternate ring sizings rebuild on each switch.
             extra_compiled: Additional compatible programs to prepare on the
                 same L3 worker (multi-program serving — e.g. ``prefill`` prepares
                 the worker and passes ``[decode]`` here so both share the worker

--- a/python/pypto/runtime/bench.py
+++ b/python/pypto/runtime/bench.py
@@ -982,7 +982,9 @@ def benchmark(
                 # stderr too; on failure it is echoed back so diagnostics survive.
                 try:
                     with _capture_fd_stderr(log_path):
-                        with compiled.prepare() as rt:
+                        # Pass the dispatch config so prepare() prewarms the ring
+                        # sizing the loop below actually dispatches with.
+                        with compiled.prepare(config) as rt:
                             handle = rt.register(compiled)  # register once (cid=0)
                             _dispatch_loop(handle, args, rounds=rounds, warmup=warmup, dispatch_config=config)
                 except Exception:

--- a/python/pypto/runtime/device_runner.py
+++ b/python/pypto/runtime/device_runner.py
@@ -675,7 +675,10 @@ def execute_on_device(  # noqa: PLR0913
             active._run_chip(chip_callable, orch_args, cfg)
             return
         worker = Worker(level=level, device_id=device_id, platform=platform, runtime=runtime_name)
-        worker.init()
+        # Prewarm with this dispatch's own config so the single run below hits the
+        # prebuilt runtime-arena cache instead of paying the ~800ms cold build
+        # inside the timed dispatch. No-op without a prebuilt arena.
+        worker.init(prewarm_config=cfg)
         try:
             # Simpler's L2 ABI now dispatches by callable id (see runtime PR #710);
             # register the callable, run it, then close — close() runs finalize()

--- a/python/pypto/runtime/distributed_runner.py
+++ b/python/pypto/runtime/distributed_runner.py
@@ -740,7 +740,10 @@ def execute_distributed(
         try:
             w = _construct_worker(dc, compiled.platform, runtime_name, num_sub)
             sub_ids, chip_cids = _register_callables(w, sub_worker_fns, chip_callables)
-            w.init()
+            # Prewarm with this dispatch's own config so the single run below hits
+            # the prebuilt runtime-arena cache instead of paying the ~800ms cold
+            # build inside the timed dispatch. No-op without a prebuilt arena.
+            w.init(prewarm_config=call_config)
             _dispatch(w, entry_fn, tensors, chip_cids, sub_ids, call_config, len(dc.device_ids))
         finally:
             if w is not None:
@@ -915,14 +918,13 @@ class DistributedWorker(Worker):
     def __init__(
         self,
         compiled: DistributedCompiledProgram | Sequence[DistributedCompiledProgram],
-        config: Any = None,
+        config: RunConfig | None = None,
         *,
         callbacks: dict[str, Callable[..., Any]] | None = None,
         sub_worker_overrides: dict[str, Callable[..., Any]] | None = None,
         inherited_host_tensors: Sequence[torch.Tensor] | None = None,
     ) -> None:
         super().__init__()  # initialize Worker ABC state (_owned_tensors)
-        del config  # reserved for future per-runtime overrides
         callbacks = _coalesce_callbacks(callbacks, sub_worker_overrides)
         inherited = tuple(inherited_host_tensors) if inherited_host_tensors is not None else ()
         for tensor in inherited:
@@ -1017,7 +1019,17 @@ class DistributedWorker(Worker):
                 self._states[prog]["sub_ids"] = sub_ids
                 self._states[prog]["chip_cids"] = chip_cids
 
-            self._w.init()
+            # Prewarm the prebuilt runtime-arena cache so the first run() hits it
+            # instead of paying the ~800ms cold build. The cache is single-slot per
+            # worker: exactly one ring sizing is prewarmed — ``config``'s when given
+            # (built exactly as ``run()`` builds it, so the sizing keys match), else
+            # the primary program's baseline. No-op without a prebuilt arena.
+            prewarm_cc = self._states[primary]["call_config"]
+            if config is not None:
+                prewarm_cc = _make_call_config(
+                    primary._distributed_config, config, dfx_base=primary.output_dir / "dfx_outputs"
+                )
+            self._w.init(prewarm_config=prewarm_cc)
 
             # Fork the chip/sub workers now (rather than lazily on the first
             # ``run()``) so the device-memory API — ``malloc`` / ``copy_to`` /

--- a/python/pypto/runtime/worker.py
+++ b/python/pypto/runtime/worker.py
@@ -57,6 +57,7 @@ if TYPE_CHECKING:
 # would make ``simpler`` a hard import-time dependency of ``pypto.runtime`` and
 # break unit-test environments that do not install simpler.
 _SimplerWorker: type | None = None
+_SimplerCallConfig: type | None = None
 
 
 def _get_simpler_worker_cls() -> type:
@@ -69,6 +70,18 @@ def _get_simpler_worker_cls() -> type:
         _SimplerWorker = _W
     assert _SimplerWorker is not None
     return _SimplerWorker
+
+
+def _get_simpler_call_config_cls() -> type:
+    global _SimplerCallConfig  # noqa: PLW0603 - module-level cache that tests patch directly
+    if _SimplerCallConfig is None:
+        from .task_interface import (  # noqa: PLC0415
+            CallConfig as _CC,  # pyright: ignore[reportAttributeAccessIssue]
+        )
+
+        _SimplerCallConfig = _CC
+    assert _SimplerCallConfig is not None
+    return _SimplerCallConfig
 
 
 # Stack of active ChipWorkers (most-recent last). ContextVar gives correct
@@ -175,7 +188,16 @@ class ChipWorker(Worker):
         """Initialize device state. Idempotent — a second call is a no-op."""
         if self._initialized:
             return
-        self._impl.init()
+        # Prewarm the prebuilt runtime-arena cache so the first run() hits it
+        # instead of paying the ~800ms cold build inside a (usually timed)
+        # dispatch. Only ring sizing keys the cache, and dispatch takes its ring
+        # sizing from the *per-call* RunConfig (``_dispatch``) — never from this
+        # worker's ``_config`` — so a bare CallConfig is what an unsized dispatch
+        # resolves to (runtime_env 0 -> PTO2_RING_* / compile-time fallback).
+        # Transcribing ``_config``'s rings here would instead build an arena no
+        # dispatch asks for. A per-call RunConfig that sizes the rings differently
+        # rebuilds once, as before. No-op without a prebuilt arena.
+        self._impl.init(prewarm_config=_get_simpler_call_config_cls()())
         self._initialized = True
 
     def close(self) -> None:

--- a/tests/st/distributed/test_l3_ring_sizing_prewarm.py
+++ b/tests/st/distributed/test_l3_ring_sizing_prewarm.py
@@ -1,0 +1,129 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""End-to-end L3 arena prewarm via ``DistributedCompiledProgram.prepare(config=...)``.
+
+Exercises the runtime-arena prewarm path: ``prepare(rc)`` eagerly builds the
+prebuilt runtime arena for ``rc``'s ring sizing at worker ``init``, and each
+dispatch passes the **same** ``rc`` so its sizing key matches the prewarmed
+arena (first dispatch hits the cache instead of paying the cold build). Keeping
+the sizing constant across the worker's dispatches is the single-slot-cache
+guidance from ``docs/en/dev/05-runtime-ring-sizing.md``.
+
+This is a **functional** check — it asserts the prewarm-then-dispatch path with
+an explicit, non-default ring sizing produces correct results
+(``f = a + b``). It does not assert timing (the ~800ms cold-build saving is not
+observable without flakiness). On the host simulator the prewarm is a no-op
+(no prebuilt arena); the dispatch path still runs and is validated there.
+"""
+
+import sys
+
+import pypto.language as pl
+import pytest
+import torch
+from pypto import ir
+from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.runtime import RunConfig
+
+
+@pl.program
+class L3AddProgram:
+    """L3: HOST orch → CHIP worker (``f = a + b``)."""
+
+    @pl.function(type=pl.FunctionType.InCore)
+    def tile_add(
+        self,
+        a: pl.Tensor[[128, 128], pl.FP32],
+        b: pl.Tensor[[128, 128], pl.FP32],
+        f: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
+    ) -> pl.Tensor[[128, 128], pl.FP32]:
+        tile_a = pl.load(a, [0, 0], [128, 128])
+        tile_b = pl.load(b, [0, 0], [128, 128])
+        tile_f = pl.add(tile_a, tile_b)
+        return pl.store(tile_f, [0, 0], f)
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def chip_orch(
+        self,
+        a: pl.Tensor[[128, 128], pl.FP32],
+        b: pl.Tensor[[128, 128], pl.FP32],
+        f: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
+    ) -> pl.Tensor[[128, 128], pl.FP32]:
+        out_f = self.tile_add(a, b, f)
+        return out_f
+
+    @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+    def host_orch(
+        self,
+        a: pl.Tensor[[128, 128], pl.FP32],
+        b: pl.Tensor[[128, 128], pl.FP32],
+        f: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
+    ) -> pl.Tensor[[128, 128], pl.FP32]:
+        out_f: pl.Tensor[[128, 128], pl.FP32] = self.chip_orch(a, b, f)
+        return out_f
+
+
+class TestL3RingSizingPrewarm:
+    """prepare(config=ring-sized) prewarms; dispatches reuse that sizing."""
+
+    def test_prewarmed_sizing_matches_dispatch(self, test_config, device_ids):
+        """``f = a + b`` over two dispatches under an explicit, prewarmed ring sizing.
+
+        Verifies that:
+        1. ``prepare(rc)`` accepts a ring-sized ``RunConfig`` and prewarms it at
+           ``init`` (the prebuilt-arena build lands in setup, onboard).
+        2. Dispatching with the **same** ``rc`` — the sizing the arena was
+           prewarmed for — computes correctly across repeated reuse of the
+           handle (first dispatch hits the prewarmed arena onboard).
+        """
+        if not device_ids:
+            pytest.skip("L3 ring-sizing prewarm test needs at least one device")
+
+        compiled = ir.compile(
+            L3AddProgram,
+            platform=test_config.platform,
+            distributed_config=DistributedConfig(
+                device_ids=device_ids[:1],
+                num_sub_workers=0,
+                block_dim=3,
+                aicpu_thread_num=4,
+            ),
+        )
+
+        # A non-default, valid ring sizing (power-of-2 window/heap; dep_pool in
+        # range). The same rc is passed to prepare() (prewarm) and to every
+        # dispatch, so the prewarmed arena's sizing key matches the run's.
+        rc = RunConfig(
+            platform=test_config.platform,
+            ring_task_window=64,
+            ring_heap=8 * 1024 * 1024,
+            ring_dep_pool=256,
+        )
+
+        # Shared-memory host buffers MUST be allocated before prepare() so the
+        # forked chip worker inherits their mappings; per-call IO is reused in
+        # place across dispatches.
+        host_a = torch.zeros((128, 128), dtype=torch.float32).share_memory_()
+        host_b = torch.zeros((128, 128), dtype=torch.float32).share_memory_()
+        host_out = torch.zeros((128, 128), dtype=torch.float32).share_memory_()
+
+        with compiled.prepare(rc) as rt:
+            for a_val, b_val in ((2.0, 3.0), (7.0, 4.0)):
+                host_a.fill_(a_val)
+                host_b.fill_(b_val)
+                host_out.zero_()
+                rt(host_a, host_b, host_out, config=rc)
+
+                expected = torch.full((128, 128), a_val + b_val, dtype=torch.float32)
+                torch.testing.assert_close(host_out, expected, rtol=1e-5, atol=1e-5)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", *sys.argv[1:]])

--- a/tests/ut/runtime/test_benchmark.py
+++ b/tests/ut/runtime/test_benchmark.py
@@ -563,8 +563,10 @@ class _FakeDistributedCompiled:
     def __init__(self, rt: _FakeDistributedWorker) -> None:
         self._rt = rt
         self.platform = "a2a3sim"
+        self.prepare_config: Any = "unset"
 
-    def prepare(self) -> _FakeDistributedWorker:
+    def prepare(self, config: Any = None) -> _FakeDistributedWorker:
+        self.prepare_config = config
         return self._rt
 
 
@@ -585,6 +587,9 @@ def test_benchmark_l3_dispatches_via_distributed_worker():
     assert rt.register_calls == 1  # registered exactly once
     assert rt.handle.call_count == 3  # warmup + rounds launches
     assert chip_ctor.call_count == 0  # L3 must NOT touch ChipWorker
+    # prepare() gets the dispatch config, so it prewarms the runtime arena with
+    # the ring sizing the loop dispatches with (here: None -> baseline sizing).
+    assert compiled.prepare_config is None
     # The parser is told this is a distributed run.
     assert parse.call_args.kwargs == {"rounds": 2, "warmup": 1, "distributed": True}
     assert stats.rounds == 2
@@ -616,7 +621,7 @@ def test_benchmark_l3_capture_wraps_prepare(span_root):
     """
 
     class _CompiledEmittingAtPrepare(_FakeDistributedCompiled):
-        def prepare(self) -> _FakeDistributedWorker:
+        def prepare(self, config: Any = None) -> _FakeDistributedWorker:
             # Two ranks each emit one dispatch's markers at fork/prepare time,
             # before the measured loop runs.
             for pid, dev_us in ((100, 10.0), (101, 20.0)):

--- a/tests/ut/runtime/test_chip_worker_explicit_dispatch.py
+++ b/tests/ut/runtime/test_chip_worker_explicit_dispatch.py
@@ -25,7 +25,11 @@ from pypto.runtime import ChipWorker, RegistrationHandle, RunConfig
 @pytest.fixture
 def fake_simpler_worker():
     """Patch ``simpler.worker.Worker`` so ChipWorker construction does no I/O."""
-    with patch("pypto.runtime.worker._SimplerWorker") as cls:
+    with (
+        patch("pypto.runtime.worker._SimplerWorker") as cls,
+        # init() builds a prewarm CallConfig; patch the cache so no simpler import happens.
+        patch("pypto.runtime.worker._SimplerCallConfig", MagicMock()),
+    ):
         instance = MagicMock()
         instance.register.side_effect = lambda cc: 100 + id(cc) % 100  # deterministic cid
         instance.aicpu_dlopen_count = 0

--- a/tests/ut/runtime/test_distributed_worker.py
+++ b/tests/ut/runtime/test_distributed_worker.py
@@ -180,6 +180,43 @@ class TestPerTaskRingSizing:
         rt.close()
 
 
+class TestArenaPrewarm:
+    """``init`` prewarms the prebuilt runtime-arena cache with the ring sizing the
+    first dispatch will use, so the ~800ms cold build lands at prepare() time
+    rather than inside the first (usually timed) dispatch.
+    """
+
+    def test_prewarms_with_prepared_baseline_when_no_config(self, patched_setup):
+        m = patched_setup
+        compiled = _fake_compiled([_param("a", [16, 16])], [])
+        rt = DistributedWorker(compiled)
+
+        # No worker RunConfig → the program's baseline CallConfig (the same one
+        # config-less dispatches reuse) is what init prewarms with; no rebuild.
+        assert m["make_call_config"].call_count == 1
+        assert m["worker"].init.call_args.kwargs["prewarm_config"] is m["make_call_config"].return_value
+        rt.close()
+
+    def test_prewarms_with_worker_config_ring_sizing(self, patched_setup):
+        from pypto.runtime import RunConfig  # noqa: PLC0415
+
+        m = patched_setup
+        compiled = _fake_compiled([_param("a", [16, 16])], [])
+        rc = RunConfig(platform="a2a3sim", ring_heap=4 * 1024 * 1024)
+
+        rt = DistributedWorker(compiled, rc)
+
+        # A worker RunConfig builds a second CallConfig from (program
+        # DistributedConfig, rc) — the same construction a dispatch with rc uses,
+        # so the prewarmed arena's sizing key matches that dispatch's.
+        assert m["make_call_config"].call_count == 2
+        prewarm_build = m["make_call_config"].call_args
+        assert prewarm_build.args[0] is compiled._distributed_config
+        assert prewarm_build.args[1] is rc
+        assert m["worker"].init.call_args.kwargs["prewarm_config"] is m["make_call_config"].return_value
+        rt.close()
+
+
 class TestPerCallValidation:
     def test_accepts_device_tensor(self, patched_setup):
         compiled = _fake_compiled([_param("a", [128, 128]), _param("b", [128, 128])], [])

--- a/tests/ut/runtime/test_worker_memory.py
+++ b/tests/ut/runtime/test_worker_memory.py
@@ -24,7 +24,11 @@ from pypto.runtime import ChipWorker, DeviceTensor, RunConfig
 @pytest.fixture
 def fake_simpler_worker():
     """Patch ``simpler.worker.Worker`` so ChipWorker construction does not touch a device."""
-    with patch("pypto.runtime.worker._SimplerWorker") as cls:
+    with (
+        patch("pypto.runtime.worker._SimplerWorker") as cls,
+        # init() builds a prewarm CallConfig; patch the cache so no simpler import happens.
+        patch("pypto.runtime.worker._SimplerCallConfig", MagicMock()),
+    ):
         instance = MagicMock()
         cls.return_value = instance
         yield instance

--- a/tests/ut/runtime/test_worker_owned_tensors.py
+++ b/tests/ut/runtime/test_worker_owned_tensors.py
@@ -25,7 +25,11 @@ from pypto.runtime import ChipWorker, RunConfig
 @pytest.fixture
 def fake_simpler_worker():
     """Patch ``simpler.worker.Worker`` so ChipWorker construction does no I/O."""
-    with patch("pypto.runtime.worker._SimplerWorker") as cls:
+    with (
+        patch("pypto.runtime.worker._SimplerWorker") as cls,
+        # init() builds a prewarm CallConfig; patch the cache so no simpler import happens.
+        patch("pypto.runtime.worker._SimplerCallConfig", MagicMock()),
+    ):
         instance = MagicMock()
         # Deterministic malloc: incrementing pointer.
         ptr_state = {"next": 0x1000}

--- a/tests/ut/runtime/test_worker_reuse.py
+++ b/tests/ut/runtime/test_worker_reuse.py
@@ -28,7 +28,11 @@ from pypto.runtime import ChipWorker, RunConfig
 @pytest.fixture
 def fake_simpler_worker():
     """Patch ``simpler.worker.Worker`` so ChipWorker construction does not touch a device."""
-    with patch("pypto.runtime.worker._SimplerWorker") as cls:
+    with (
+        patch("pypto.runtime.worker._SimplerWorker") as cls,
+        # init() builds a prewarm CallConfig; patch the cache so no simpler import happens.
+        patch("pypto.runtime.worker._SimplerCallConfig", MagicMock()),
+    ):
         instance = MagicMock()
         cls.return_value = instance
         yield instance
@@ -49,6 +53,14 @@ class TestLifecycleIdempotency:
     def test_auto_init_on_construction(self, fake_simpler_worker):
         ChipWorker(config=RunConfig(platform="a2a3sim"))
         fake_simpler_worker.init.assert_called_once()
+
+    def test_init_prewarms_arena_cache(self, fake_simpler_worker):
+        ChipWorker(config=RunConfig(platform="a2a3sim"))
+        # init() builds the prebuilt runtime-arena so the first dispatch doesn't
+        # pay the ~800ms cold build. Sizing is the runtime's own default (a bare
+        # CallConfig): dispatch takes ring sizing from the per-call RunConfig, so
+        # prewarming this worker's config would build an arena nobody asks for.
+        assert fake_simpler_worker.init.call_args.kwargs["prewarm_config"] is not None
 
     def test_init_idempotent(self, fake_simpler_worker):
         w = ChipWorker(config=RunConfig(platform="a2a3sim"))  # first init


### PR DESCRIPTION
## Summary

The first dispatch with a given ring sizing pays a **~800 ms cold build** of the prebuilt runtime arena. That cost previously landed inside the first (usually timed) dispatch, inflating benchmarks and first-token latency. Workers now build it eagerly at `init`, so the cold build lands in setup instead.

- **L3**: `DistributedWorker.__init__` and `execute_distributed`'s one-shot path. `DistributedWorker`'s `config` (previously `del`'d as reserved) is now the `RunConfig` whose ring sizing is prewarmed; its `CallConfig` is built through `_make_call_config` — the same construction `run()` uses — so the prewarmed arena's sizing key matches the dispatch's.
- **L2**: `ChipWorker.init` and `execute_on_device`'s one-shot path. L2 dispatch takes ring sizing from the per-call `RunConfig`, never from the worker's own `config`, so `ChipWorker` prewarms a bare `CallConfig` (the runtime's default sizing) — transcribing its config's rings would build an arena no dispatch asks for.
- `benchmark()` now forwards its dispatch config to `prepare()`, which otherwise prewarmed the baseline sizing that the first dispatch immediately discarded.

The arena cache is keyed on the full per-ring sizing vector and is **single-slot per worker**, so dispatches that alternate ring sizings rebuild on each switch. Guidance (keep the sizing constant across a worker's dispatches; per-ring differences within one dispatch are fully covered) is documented in `docs/en/dev/05-runtime-ring-sizing.md` and its zh-cn mirror.

**Dependency:** requires the simpler runtime's `Worker.init(prewarm_config=...)` parameter, landed via the runtime bump to `a756969c` (upstream/main `chore(runtime): bump runtime to a756969c (#2061)`).

## Testing

- [x] Runtime unit tests pass (`tests/ut/runtime/`), including new mock-based prewarm assertions: `test_distributed_worker.py::TestArenaPrewarm` (baseline + ring-sized `config` branches) and `test_worker_reuse.py::test_init_prewarms_arena_cache`; `test_benchmark.py` asserts `benchmark()` forwards its config to `prepare()`.
- [x] Code review completed; `ruff` + `pyright` + `markdownlint` clean.
- [x] Documentation updated (en + zh-cn `05-runtime-ring-sizing.md`).
- [ ] New end-to-end ST `tests/st/distributed/test_l3_ring_sizing_prewarm.py` (functional `f = a + b` under an explicit prewarmed ring sizing) — needs an onboard run; not verified locally due to a pre-existing pto-isa/build_output mismatch that breaks all L3 sim STs in the dev env.