### PR TITLE
ci: run only a smoke subset of unit tests on macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,24 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
         python-version: ["3.10"]
+        # Linux runs the full unit-test suite; macOS runs only a small
+        # foundational smoke subset. The C++ extension's macOS compilation is
+        # already validated by the `pip install -v .[dev]` build step below, so
+        # macOS only needs to confirm the built module imports and executes —
+        # duplicating all ~6.7k cases on both OSes is wasted CI time. The `include`
+        # entries add a per-OS `ut_paths` without creating extra jobs, so the
+        # required-check names `unit-tests (<os>, 3.10)` are preserved.
+        include:
+          - os: ubuntu-latest
+            ut_paths: tests/ut
+            ut_label: full suite
+          - os: macos-latest
+            # Smoke: core object system (dtype/error/logging) + basic IR node
+            # construction — the layers where a macOS-specific binding or
+            # compile/execute break would surface. Widen this list if a macOS-only
+            # regression slips through.
+            ut_paths: tests/ut/core tests/ut/ir/core
+            ut_label: smoke subset (compile + execute check)
 
     steps:
     - name: Checkout
@@ -140,8 +158,8 @@ jobs:
         pip install torch --index-url https://download.pytorch.org/whl/cpu
         pip install -v .[dev]
 
-    - name: Test unit tests
-      run: pytest tests/ut -n auto --maxprocesses 8 -v
+    - name: Test unit tests (${{ matrix.ut_label }})
+      run: pytest ${{ matrix.ut_paths }} -n auto --maxprocesses 8 -v
 
   codegen-tests:
     # Codegen-only: verifies IR → kernel/orch C++ generation without going


### PR DESCRIPTION
## Problem

The `unit-tests` matrix ran the full `tests/ut` suite (~6.7k cases) on **both** `ubuntu-latest` and `macos-latest`. The second OS re-validates the same pure-Python / IR logic, roughly doubling unit-test CI cost for little added signal (macOS unit-tests ≈ 8.5 min).

## Change

Keep the full suite on Linux; run a small foundational **smoke subset** on macOS:

| OS | pytest target | cases |
| --- | --- | --- |
| ubuntu-latest | `tests/ut` (full) | ~6700 |
| macos-latest | `tests/ut/core` + `tests/ut/ir/core` | 243 |

The C++ extension's macOS compilation is already validated by the `pip install -v .[dev]` build step, so macOS only needs to confirm the built module **imports and executes**. The chosen dirs cover the core object system (dtype / error / logging) and basic IR node construction — the layers where a macOS-specific binding or compile/execute break would surface.

## Implementation

Uses matrix `include` entries that attach a per-OS `ut_paths` to the existing `os × python-version` matrix. This adds **no new jobs**, so the required-check names `unit-tests (ubuntu-latest, 3.10)` and `unit-tests (macos-latest, 3.10)` are unchanged.

```yaml
matrix:
  os: [ubuntu-latest, macos-latest]
  python-version: ["3.10"]
  include:
    - os: ubuntu-latest
      ut_paths: tests/ut
    - os: macos-latest
      ut_paths: tests/ut/core tests/ut/ir/core
```

## Verification

- `pytest tests/ut/core tests/ut/ir/core` locally on macOS: **242 passed, 1 skipped in 3.4s**.
- Matrix expansion checked: still exactly 2 jobs with the original names; Linux → full, macOS → smoke.

## Note

macOS no longer catches macOS-only failures outside the smoke dirs (e.g. codegen / language layers). Linux still runs everything; widen `ut_paths` for macOS if a macOS-specific regression slips through.