### PR TITLE
fix(ir): allow INT16 indices in gather index form on A5

### DIFF
--- a/python/pypto/ir/op/tensor_ops.py
+++ b/python/pypto/ir/op/tensor_ops.py
@@ -1932,9 +1932,9 @@ def gather(  # noqa: PLR0913
         output[b, k] = input[b, index[b, k]]
 
         MVP limitation: only rank-2 inputs with ``dim == -1`` (or ``rank - 1``).
-        ``index`` must be an INT32 tensor (INT16 also accepted on A5/Ascend950)
-        whose shape matches ``input`` on every axis except ``dim``; output shape
-        == ``index.shape``, dtype == ``input.dtype``.
+        ``index`` must be an INT32 tensor, or INT16 when ``input`` is a 16-bit
+        dtype (FP16/INT16); its shape matches ``input`` on every axis except
+        ``dim``. output shape == ``index.shape``, dtype == ``input.dtype``.
 
     Mask form (``mask_pattern=<int>``) → ``tensor.gather_mask``: selects columns
         of each row by a fixed hardware mask. Last-dim shrinks by 2 (P0101/P1010)

--- a/python/pypto/ir/op/tensor_ops.py
+++ b/python/pypto/ir/op/tensor_ops.py
@@ -1932,8 +1932,9 @@ def gather(  # noqa: PLR0913
         output[b, k] = input[b, index[b, k]]
 
         MVP limitation: only rank-2 inputs with ``dim == -1`` (or ``rank - 1``).
-        ``index`` must be an INT32 tensor whose shape matches ``input`` on every
-        axis except ``dim``; output shape == ``index.shape``, dtype == ``input.dtype``.
+        ``index`` must be an INT32 tensor (INT16 also accepted on A5/Ascend950)
+        whose shape matches ``input`` on every axis except ``dim``; output shape
+        == ``index.shape``, dtype == ``input.dtype``.
 
     Mask form (``mask_pattern=<int>``) → ``tensor.gather_mask``: selects columns
         of each row by a fixed hardware mask. Last-dim shrinks by 2 (P0101/P1010)

--- a/python/pypto/language/op/tensor_ops.py
+++ b/python/pypto/language/op/tensor_ops.py
@@ -1843,8 +1843,8 @@ def gather(
         output[b, k] = input[b, index[b, k]]
 
         MVP: only rank-2 inputs with ``dim == -1`` (or ``rank - 1``).
-        ``index`` must be an INT32 tensor whose shape matches ``input`` on every
-        axis except ``dim``.
+        ``index`` must be an INT32 tensor (INT16 also accepted on A5/Ascend950)
+        whose shape matches ``input`` on every axis except ``dim``.
 
     Mask form (``mask_pattern=<int>``) → :func:`pl.tile.gather_mask`:
         Selects columns of each row by a fixed hardware mask pattern. Last-dim
@@ -1858,7 +1858,7 @@ def gather(
     Args:
         input: Source tensor (FP16/FP32/INT16/INT32).
         dim: (index form) Axis to gather along; only ``-1`` / ``rank - 1`` accepted in MVP.
-        index: (index form) Index tensor (INT32) with same rank as input.
+        index: (index form) Index tensor (INT32, or INT16 on A5/Ascend950) with same rank as input.
         mask_pattern: (mask form, keyword-only) Mask pattern selector (1-7).
             1=P0101, 2=P1010, 3=P0001, 4=P0010, 5=P0100, 6=P1000, 7=P1111.
         output_dtype: (mask form, keyword-only) Optional output dtype with the same

--- a/python/pypto/language/op/tensor_ops.py
+++ b/python/pypto/language/op/tensor_ops.py
@@ -1843,8 +1843,8 @@ def gather(
         output[b, k] = input[b, index[b, k]]
 
         MVP: only rank-2 inputs with ``dim == -1`` (or ``rank - 1``).
-        ``index`` must be an INT32 tensor (INT16 also accepted on A5/Ascend950)
-        whose shape matches ``input`` on every axis except ``dim``.
+        ``index`` must be an INT32 tensor, or INT16 when ``input`` is a 16-bit
+        dtype (FP16/INT16); its shape matches ``input`` on every axis except ``dim``.
 
     Mask form (``mask_pattern=<int>``) → :func:`pl.tile.gather_mask`:
         Selects columns of each row by a fixed hardware mask pattern. Last-dim
@@ -1858,7 +1858,7 @@ def gather(
     Args:
         input: Source tensor (FP16/FP32/INT16/INT32).
         dim: (index form) Axis to gather along; only ``-1`` / ``rank - 1`` accepted in MVP.
-        index: (index form) Index tensor (INT32, or INT16 on A5/Ascend950) with same rank as input.
+        index: (index form) Index tensor (INT32, or INT16 with a 16-bit input), same rank as input.
         mask_pattern: (mask form, keyword-only) Mask pattern selector (1-7).
             1=P0101, 2=P1010, 3=P0001, 4=P0010, 5=P0100, 6=P1000, 7=P1111.
         output_dtype: (mask form, keyword-only) Optional output dtype with the same

--- a/python/pypto/language/op/tile_ops.py
+++ b/python/pypto/language/op/tile_ops.py
@@ -2369,8 +2369,8 @@ def gather(src: Tile, indices: Tile, tmp: Tile) -> Tile:
 
     Args:
         src: Source tile (FP16, FP32, INT16, or INT32)
-        indices: Index tile (INT32, or INT16 on A5/Ascend950) — selects which
-            elements of ``src`` to gather
+        indices: Index tile (INT32 with any src, or INT16 with a 16-bit src — FP16/INT16);
+            selects which elements of ``src`` to gather
         tmp: Temporary workspace tile (any Vec dtype; required as an operand but
             not constrained by the A5 index form — A2/A3 narrows this at PTOAS)
 

--- a/python/pypto/language/op/tile_ops.py
+++ b/python/pypto/language/op/tile_ops.py
@@ -2369,8 +2369,10 @@ def gather(src: Tile, indices: Tile, tmp: Tile) -> Tile:
 
     Args:
         src: Source tile (FP16, FP32, INT16, or INT32)
-        indices: Index tile (INT32) — selects which elements of ``src`` to gather
-        tmp: Temporary workspace tile (INT32) required by the hardware
+        indices: Index tile (INT32, or INT16 on A5/Ascend950) — selects which
+            elements of ``src`` to gather
+        tmp: Temporary workspace tile (any Vec dtype; required as an operand but
+            not constrained by the A5 index form — A2/A3 narrows this at PTOAS)
 
     Returns:
         Tile with gathered elements (same dtype as ``src``)

--- a/src/ir/op/tensor_ops/gather.cpp
+++ b/src/ir/op/tensor_ops/gather.cpp
@@ -53,8 +53,12 @@ TypePtr DeduceTensorGatherType(const std::vector<ExprPtr>& args,
   auto index_type = As<TensorType>(args[1]->GetType());
   CHECK(index_type) << "The operator " << op_name << " requires index to be a TensorType, but got "
                     << args[1]->GetType()->TypeName();
-  CHECK(index_type->dtype_ == DataType::INT32)
-      << "The operator " << op_name << " requires index dtype to be INT32, but got "
+  // Index dtype: i32 everywhere; i16 additionally permitted on A5 (Ascend950),
+  // matching tensor.scatter and the PTOAS tgather index-form spec. Deduction is
+  // backend-agnostic and runs before arch selection, so A2/A3's i32-only rule is
+  // left to the PTOAS verifier.
+  CHECK(index_type->dtype_ == DataType::INT32 || index_type->dtype_ == DataType::INT16)
+      << "The operator " << op_name << " requires index dtype to be INT32 (or INT16 on A5), but got "
       << index_type->dtype_.ToString();
 
   const int64_t rank = static_cast<int64_t>(input_type->shape_.size());
@@ -102,7 +106,7 @@ REGISTER_OP("tensor.gather")
         "(tensor-level). Supports rank>=2 and any dim; lowered via tile.transpose + "
         "tile.reshape + tile.gather by ConvertTensorToTileOps.")
     .add_argument("input", "Input tensor (TensorType; FP16, FP32, INT16, or INT32)")
-    .add_argument("index", "Index tensor (TensorType, INT32, same shape as output)")
+    .add_argument("index", "Index tensor (TensorType, INT32 or INT16 on A5, same shape as output)")
     .set_attr<int>("dim")
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {

--- a/src/ir/op/tensor_ops/gather.cpp
+++ b/src/ir/op/tensor_ops/gather.cpp
@@ -53,13 +53,21 @@ TypePtr DeduceTensorGatherType(const std::vector<ExprPtr>& args,
   auto index_type = As<TensorType>(args[1]->GetType());
   CHECK(index_type) << "The operator " << op_name << " requires index to be a TensorType, but got "
                     << args[1]->GetType()->TypeName();
-  // Index dtype: i32 everywhere; i16 additionally permitted on A5 (Ascend950),
-  // matching tensor.scatter and the PTOAS tgather index-form spec. Deduction is
-  // backend-agnostic and runs before arch selection, so A2/A3's i32-only rule is
-  // left to the PTOAS verifier.
-  CHECK(index_type->dtype_ == DataType::INT32 || index_type->dtype_ == DataType::INT16)
-      << "The operator " << op_name << " requires index dtype to be INT32 (or INT16 on A5), but got "
-      << index_type->dtype_.ToString();
+  // Index dtype: i32 with any input; i16 only with a 16-bit input (FP16/INT16).
+  // The A5 (Ascend950) tgather b16 form pairs a 2-byte input with 2-byte indices;
+  // a 32-bit input uses the b32 form that reads each index as a u32, so INT16
+  // indices with a 32-bit input are unsafe on every target (not merely arch-gated).
+  // PyPTO has no internal tgather verifier, so this universal width constraint is
+  // checked in the deducer; the arch-specific A2/A3 i32-only rule is left to the
+  // external PTOAS assembler (PTO IR manual, tgather index-form checks).
+  const bool idx_is_i16 = index_type->dtype_ == DataType::INT16;
+  const bool input_is_16bit = input_type->dtype_ == DataType::FP16 || input_type->dtype_ == DataType::INT16;
+  CHECK(index_type->dtype_ == DataType::INT32 || (idx_is_i16 && input_is_16bit))
+      << "The operator " << op_name
+      << " requires index dtype INT32 (any input), or INT16 with a 16-bit input "
+         "(FP16/INT16); INT16 indices with a 32-bit input are unsafe (tgather b32 "
+         "reads them as u32). Got index "
+      << index_type->dtype_.ToString() << " with input " << input_type->dtype_.ToString();
 
   const int64_t rank = static_cast<int64_t>(input_type->shape_.size());
   CHECK(rank >= 2) << "The operator " << op_name << " requires rank >= 2, but got rank " << rank;
@@ -106,7 +114,7 @@ REGISTER_OP("tensor.gather")
         "(tensor-level). Supports rank>=2 and any dim; lowered via tile.transpose + "
         "tile.reshape + tile.gather by ConvertTensorToTileOps.")
     .add_argument("input", "Input tensor (TensorType; FP16, FP32, INT16, or INT32)")
-    .add_argument("index", "Index tensor (TensorType, INT32 or INT16 on A5, same shape as output)")
+    .add_argument("index", "Index tensor (TensorType; INT32 any input, or INT16 with a 16-bit input)")
     .set_attr<int>("dim")
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {

--- a/src/ir/op/tile_ops/gather.cpp
+++ b/src/ir/op/tile_ops/gather.cpp
@@ -57,17 +57,25 @@ static TypePtr DeduceTileGatherType(const std::vector<ExprPtr>& args,
       << "The operator " << op_name << " requires src dtype to be FP16, FP32, INT16, or INT32, but got "
       << src_type->dtype_.ToString();
 
-  // Second arg: indices tile. i32 on every target; i16 additionally permitted
-  // on A5 (Ascend950). Type deduction is backend-agnostic and runs before arch
-  // selection, so it accepts the union {INT16, INT32}; A2/A3's i32-only rule is
-  // enforced later by the PTOAS verifier (PTO IR manual, tgather index-form
-  // checks — A2/A3 vs A5).
+  // Second arg: indices tile. i32 is valid with any src; i16 is valid only with a
+  // 16-bit src (FP16/INT16). The A5 (Ascend950) tgather b16 form pairs a 2-byte
+  // src with 2-byte indices, whereas a 32-bit src uses the b32 form that reads
+  // each index as a u32 — so an INT16 index with a 32-bit src is unsafe on every
+  // target, not merely arch-gated. That universal constraint is checked here in
+  // the backend-agnostic deducer; A2/A3's i32-only rule is still enforced later
+  // by the PTOAS verifier (PTO IR manual, tgather index-form checks — A2/A3 vs
+  // A5).
   auto idx_type = As<TileType>(args[1]->GetType());
   CHECK(idx_type) << "The operator " << op_name << " requires second argument to be a TileType, but got "
                   << args[1]->GetType()->TypeName();
-  CHECK(idx_type->dtype_ == DataType::INT32 || idx_type->dtype_ == DataType::INT16)
-      << "The operator " << op_name << " requires indices dtype to be INT32 (or INT16 on A5), but got "
-      << idx_type->dtype_.ToString();
+  const bool idx_is_i16 = idx_type->dtype_ == DataType::INT16;
+  const bool src_is_16bit = src_type->dtype_ == DataType::FP16 || src_type->dtype_ == DataType::INT16;
+  CHECK(idx_type->dtype_ == DataType::INT32 || (idx_is_i16 && src_is_16bit))
+      << "The operator " << op_name
+      << " requires indices dtype INT32 (any src), or INT16 with a 16-bit src "
+         "(FP16/INT16); INT16 indices with a 32-bit src are unsafe (tgather b32 "
+         "reads them as u32). Got indices "
+      << idx_type->dtype_.ToString() << " with src " << src_type->dtype_.ToString();
 
   // Third arg: tmp workspace tile. A5 (Ascend950) does not read tmp in the
   // index form and imposes no tmp dtype/shape relation; A2/A3 requires tmp to
@@ -94,7 +102,7 @@ REGISTER_OP("tile.gather")
     .set_op_category("TileOp")
     .set_description("Gather elements by index (maps to pto.tgather)")
     .add_argument("src", "Source tile (FP16, FP32, INT16, or INT32)")
-    .add_argument("indices", "Index tile (INT32, or INT16 on A5)")
+    .add_argument("indices", "Index tile (INT32 any src, or INT16 with a 16-bit src)")
     .add_argument("tmp", "Temporary workspace tile (any Vec dtype; A2/A3 constrains at PTOAS)")
     .set_input_memory(0, MemorySpace::Vec)
     .set_input_memory(1, MemorySpace::Vec)

--- a/src/ir/op/tile_ops/gather.cpp
+++ b/src/ir/op/tile_ops/gather.cpp
@@ -57,24 +57,27 @@ static TypePtr DeduceTileGatherType(const std::vector<ExprPtr>& args,
       << "The operator " << op_name << " requires src dtype to be FP16, FP32, INT16, or INT32, but got "
       << src_type->dtype_.ToString();
 
-  // Second arg: indices tile (must be i32)
+  // Second arg: indices tile. i32 on every target; i16 additionally permitted
+  // on A5 (Ascend950). Type deduction is backend-agnostic and runs before arch
+  // selection, so it accepts the union {INT16, INT32}; A2/A3's i32-only rule is
+  // enforced later by the PTOAS verifier (PTO IR manual, tgather index-form
+  // checks — A2/A3 vs A5).
   auto idx_type = As<TileType>(args[1]->GetType());
   CHECK(idx_type) << "The operator " << op_name << " requires second argument to be a TileType, but got "
                   << args[1]->GetType()->TypeName();
-  CHECK(idx_type->dtype_ == DataType::INT32)
-      << "The operator " << op_name << " requires indices dtype to be INT32, but got "
+  CHECK(idx_type->dtype_ == DataType::INT32 || idx_type->dtype_ == DataType::INT16)
+      << "The operator " << op_name << " requires indices dtype to be INT32 (or INT16 on A5), but got "
       << idx_type->dtype_.ToString();
 
-  // Third arg: tmp workspace tile (must be i32, same shape as indices)
+  // Third arg: tmp workspace tile. A5 (Ascend950) does not read tmp in the
+  // index form and imposes no tmp dtype/shape relation; A2/A3 requires tmp to
+  // match the indices element type and valid shape. Deduction is backend-
+  // agnostic, so only the shared contract (tmp must be a Vec tile operand) is
+  // checked here — the arch-specific same-type/same-valid-shape rule runs in
+  // the PTOAS verifier (PTO IR manual, tgather index-form checks — A2/A3).
   auto tmp_type = As<TileType>(args[2]->GetType());
   CHECK(tmp_type) << "The operator " << op_name << " requires third argument to be a TileType, but got "
                   << args[2]->GetType()->TypeName();
-  CHECK(tmp_type->dtype_ == DataType::INT32)
-      << "The operator " << op_name << " requires tmp dtype to be INT32, but got "
-      << tmp_type->dtype_.ToString();
-  CHECK(tmp_type->shape_.size() == idx_type->shape_.size())
-      << "The operator " << op_name << " requires tmp shape rank to match indices rank ("
-      << idx_type->shape_.size() << "), but got " << tmp_type->shape_.size();
 
   // Output: shape from indices tile, dtype from src tile, propagate tile_view
   TileView tile_view;
@@ -91,8 +94,8 @@ REGISTER_OP("tile.gather")
     .set_op_category("TileOp")
     .set_description("Gather elements by index (maps to pto.tgather)")
     .add_argument("src", "Source tile (FP16, FP32, INT16, or INT32)")
-    .add_argument("indices", "Index tile (INT32)")
-    .add_argument("tmp", "Temporary workspace tile (INT32)")
+    .add_argument("indices", "Index tile (INT32, or INT16 on A5)")
+    .add_argument("tmp", "Temporary workspace tile (any Vec dtype; A2/A3 constrains at PTOAS)")
     .set_input_memory(0, MemorySpace::Vec)
     .set_input_memory(1, MemorySpace::Vec)
     .set_input_memory(2, MemorySpace::Vec)

--- a/src/ir/transforms/op_conversion_registry.cpp
+++ b/src/ir/transforms/op_conversion_registry.cpp
@@ -1376,6 +1376,18 @@ void OpConversionRegistry::RegisterGatherOps() {
         //   out_row  = gather(inp_flat, flat_idx) → [1, I2]
         // ================================================================
         if (rank == 3 && norm_dim == 0) {
+          // The flat-index lowering computes `idx_row * S2 + offset` in INT32 and
+          // feeds that INT32 flat index into tile.gather. That only matches the
+          // tgather b32 form (32-bit src, indices read as u32); a 2-byte src would
+          // require the b16 form with 2-byte indices, which the flat index cannot
+          // satisfy. Reject 16-bit src here rather than emit a width-mismatched
+          // (silently corrupt) gather. Full 16-bit-src support would mirror the
+          // scatter lowering (INT16 range tile + tile.cast narrow).
+          CHECK_SPAN(input_dtype == DataType::FP32 || input_dtype == DataType::INT32, span)
+              << "tensor.gather: rank-3 gather on dim 0 uses an INT32 flat index that only "
+                 "matches the tgather b32 form (32-bit src); 16-bit src is not yet supported "
+                 "on this axis. Got input dtype "
+              << input_dtype.ToString();
           int64_t S0 = get_const(input_shape[0], "input.shape[0]");
           int64_t S2 = get_const(input_shape[2], "input.shape[2]");
           int64_t I0 = get_const(index_shape[0], "index.shape[0]");
@@ -1436,6 +1448,14 @@ void OpConversionRegistry::RegisterGatherOps() {
         // ================================================================
         CHECK_SPAN(rank == 3 && norm_dim == 1, span) << "tensor.gather: unsupported (rank, dim) combination, "
                                                      << "got rank=" << rank << " norm_dim=" << norm_dim;
+
+        // Same flat-index/INT32 limitation as the dim==0 case above — only the
+        // tgather b32 form (32-bit src) is reachable. See that case for rationale.
+        CHECK_SPAN(input_dtype == DataType::FP32 || input_dtype == DataType::INT32, span)
+            << "tensor.gather: rank-3 gather on dim 1 uses an INT32 flat index that only "
+               "matches the tgather b32 form (32-bit src); 16-bit src is not yet supported "
+               "on this axis. Got input dtype "
+            << input_dtype.ToString();
 
         {
           int64_t I0 = get_const(index_shape[0], "index.shape[0]");

--- a/tests/st/runtime/ops/test_gather.py
+++ b/tests/st/runtime/ops/test_gather.py
@@ -146,14 +146,15 @@ class GatherA5INT16IndexProgram:
     ``inp [4, 16] FP16``, ``idx [4, 16] INT16`` → ``output [4, 16] FP16``.
     INT16 indices are native to A5 but rejected by A2/A3 (the PTOAS verifier only
     permits i32 indices there), so this case is pinned to A5. It exercises the
-    relaxed ``tile.gather`` type deduction — INT16 indices plus the A5 index
-    form's unconstrained ``tmp`` — end-to-end on hardware.
+    ``tile.gather`` type deduction — INT16 indices (valid only with a 16-bit src)
+    plus the A5 index form's unconstrained ``tmp`` — end-to-end on hardware.
 
     FP16 src + INT16 indices selects the A5 ``TGather_b16`` path (2-byte src,
     2-byte indices), the hardware-supported INT16-index combination — mirroring
-    the scatter INT16 tests. (FP32/INT32 src + INT16 indices would route to
-    ``TGather_b32``, which reinterprets indices as u32 and is not INT16-safe in
-    this pto-isa revision.)
+    the scatter INT16 tests. INT16 indices with a 32-bit src (FP32/INT32) are
+    rejected outright by the ``tile.gather`` deducer: the only reachable form
+    would be ``TGather_b32``, which reinterprets the indices as u32 and is not
+    INT16-safe in this pto-isa revision.
 
     idx last-dim is 16 (16×2=32 bytes) to satisfy the hardware tile column
     alignment requirement (Cols * sizeof(dtype) % 32 == 0) for INT16.
@@ -481,7 +482,9 @@ class GatherA5INT16IndexTestCase(_GatherBaseTestCase):
 
     def define_tensors(self) -> list[TensorSpec]:
         return [
-            TensorSpec("inp", [4, 16], DataType.FP16, init_value=lambda: torch.randn(4, 16).to(torch.float16)),
+            TensorSpec(
+                "inp", [4, 16], DataType.FP16, init_value=lambda: torch.randn(4, 16).to(torch.float16)
+            ),
             TensorSpec(
                 "idx",
                 [4, 16],

--- a/tests/st/runtime/ops/test_gather.py
+++ b/tests/st/runtime/ops/test_gather.py
@@ -140,6 +140,39 @@ class GatherRank2LastDimTopLevelProgram:
 
 
 @pl.program
+class GatherA5INT16IndexProgram:
+    """A5 (Ascend950) index-form gather with INT16 indices.
+
+    ``inp [4, 16] FP16``, ``idx [4, 16] INT16`` → ``output [4, 16] FP16``.
+    INT16 indices are native to A5 but rejected by A2/A3 (the PTOAS verifier only
+    permits i32 indices there), so this case is pinned to A5. It exercises the
+    relaxed ``tile.gather`` type deduction — INT16 indices plus the A5 index
+    form's unconstrained ``tmp`` — end-to-end on hardware.
+
+    FP16 src + INT16 indices selects the A5 ``TGather_b16`` path (2-byte src,
+    2-byte indices), the hardware-supported INT16-index combination — mirroring
+    the scatter INT16 tests. (FP32/INT32 src + INT16 indices would route to
+    ``TGather_b32``, which reinterprets indices as u32 and is not INT16-safe in
+    this pto-isa revision.)
+
+    idx last-dim is 16 (16×2=32 bytes) to satisfy the hardware tile column
+    alignment requirement (Cols * sizeof(dtype) % 32 == 0) for INT16.
+    """
+
+    @pl.function(type=pl.FunctionType.Opaque)
+    def main(
+        self,
+        inp: pl.Tensor[[4, 16], pl.FP16],
+        idx: pl.Tensor[[4, 16], pl.INT16],
+        output: pl.Out[pl.Tensor[[4, 16], pl.FP16]],
+    ) -> pl.Tensor[[4, 16], pl.FP16]:
+        with pl.at(level=pl.Level.CORE_GROUP):
+            out = pl.tensor.gather(inp, dim=-1, index=idx)
+            output = pl.assemble(output, out, [0, 0])
+        return output
+
+
+@pl.program
 class GatherRank2SmallerLeadingProgram:
     """Rank-2 + dim=-1 with ``index.shape[0] (=2) < input.shape[0] (=4)``."""
 
@@ -429,6 +462,41 @@ class GatherRank2LastDimTopLevelTestCase(_GatherBaseTestCase):
 
     def compute_expected(self, tensors, params=None):
         # torch.gather semantics: out[b, k] = inp[b, idx[b, k]]
+        inp = tensors["inp"]
+        idx = tensors["idx"].to(torch.int64)
+        tensors["output"][:] = torch.gather(inp, dim=-1, index=idx)
+
+
+class GatherA5INT16IndexTestCase(_GatherBaseTestCase):
+    """A5 index-form gather with INT16 indices (A5-native; A2/A3 rejects it)."""
+
+    def get_name(self) -> str:
+        return "gather_a5_int16_index"
+
+    def get_backend_type(self) -> BackendType:
+        # INT16 indices are an A5 feature. Pin the backend so the global
+        # ``set_backend_type`` matches the parametrized ``a5`` platform — the
+        # base class otherwise defaults to Ascend910B.
+        return BackendType.Ascend950
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("inp", [4, 16], DataType.FP16, init_value=lambda: torch.randn(4, 16).to(torch.float16)),
+            TensorSpec(
+                "idx",
+                [4, 16],
+                DataType.INT16,
+                init_value=lambda: torch.randint(0, 16, (4, 16), dtype=torch.int16),
+            ),
+            TensorSpec("output", [4, 16], DataType.FP16, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        return GatherA5INT16IndexProgram
+
+    def compute_expected(self, tensors, params=None):
+        # torch.gather semantics: out[b, k] = inp[b, idx[b, k]] (exact in FP16:
+        # pure indexing, no arithmetic, so it matches the device bit-for-bit).
         inp = tensors["inp"]
         idx = tensors["idx"].to(torch.int64)
         tensors["output"][:] = torch.gather(inp, dim=-1, index=idx)
@@ -730,6 +798,19 @@ class TestGatherIndex:
         gather and asserts it is bit-identical to the input.
         """
         result = test_runner.run(GatherTileInputSourceUnchangedTestCase(platform=platform))
+        assert result.passed, f"Test failed: {result.error}"
+
+    @pytest.mark.platforms("a5", "a5sim")
+    @pytest.mark.parametrize("platform", PLATFORMS)
+    def test_gather_a5_int16_index(self, test_runner, platform):
+        """A5 index-form gather with INT16 indices (A5-native; A2/A3 rejects it).
+
+        INT16 indices are accepted by the relaxed ``tile.gather`` type deduction
+        and by the A5 (Ascend950) PTOAS verifier, then executed on hardware and
+        checked against ``torch.gather``. A2/A3 only permits i32 indices, so this
+        case is pinned to A5 via ``@pytest.mark.platforms``.
+        """
+        result = test_runner.run(GatherA5INT16IndexTestCase(platform=platform))
         assert result.passed, f"Test failed: {result.error}"
 
 

--- a/tests/ut/ir/operators/test_gather.py
+++ b/tests/ut/ir/operators/test_gather.py
@@ -1,0 +1,94 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software; you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS FILE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Unit tests for ``tile.gather`` (index-form ``pto.tgather``) type deduction.
+
+Drives the deducer directly via the IR op so the dtype combinations are exercised
+without depending on the DSL parser. The end-to-end behaviour (including the A5
+device path) is covered by the system tests in ``tests/st/runtime/ops/test_gather.py``.
+
+Type contract after the A5 (Ascend950) index-form alignment — the IR deducer is
+backend-agnostic and runs before arch selection, so it accepts the *union* of what
+any target permits and lets the PTOAS verifier narrow per arch (see the PTO IR
+manual, ``pto.tgather`` index-form checks):
+
+* ``src`` dtype in {FP16, FP32, INT16, INT32}; tile lives in Vec.
+* ``indices`` dtype is INT32 everywhere, or INT16 additionally on A5.
+* ``tmp`` is a workspace operand required by the IR but not read by the A5 index
+  form, so any Vec tile dtype is accepted (A2/A3 constrains it at PTOAS).
+* ``dst`` dtype equals ``src``; ``dst`` shape equals ``indices``.
+"""
+
+import pytest
+
+from pypto import DataType, ir
+from pypto.ir.op import tile
+
+
+def _gather(src_dtype: DataType, idx_dtype: DataType, tmp_dtype: DataType):
+    span = ir.Span.unknown()
+    src = ir.Var("src", ir.TileType([1, 64], src_dtype), span)
+    idx = ir.Var("idx", ir.TileType([1, 64], idx_dtype), span)
+    tmp = ir.Var("tmp", ir.TileType([1, 64], tmp_dtype), span)
+    return tile.gather(src, idx, tmp)
+
+
+class TestTileGatherIndexTypes:
+    """Deducer type-contract tests for the index form."""
+
+    @pytest.mark.parametrize("src_dtype", [DataType.FP16, DataType.FP32, DataType.INT16, DataType.INT32])
+    def test_valid_src_dtype(self, src_dtype):
+        call = _gather(src_dtype, DataType.INT32, DataType.INT32)
+        assert isinstance(call.type, ir.TileType)
+        assert call.type.dtype == src_dtype  # dst dtype follows src
+
+    @pytest.mark.parametrize("idx_dtype", [DataType.INT32, DataType.INT16])
+    def test_valid_index_dtype(self, idx_dtype):
+        # INT16 indices pass IR deduction (A5 permits them); A2/A3 rejects later at PTOAS.
+        call = _gather(DataType.FP32, idx_dtype, DataType.INT32)
+        assert isinstance(call.type, ir.TileType)
+        assert call.type.dtype == DataType.FP32
+
+    @pytest.mark.parametrize("tmp_dtype", [DataType.FP32, DataType.FP16, DataType.INT32, DataType.INT16])
+    def test_tmp_dtype_unconstrained(self, tmp_dtype):
+        # tmp is not read by the A5 index form; any Vec tile dtype is accepted at IR level.
+        call = _gather(DataType.FP32, DataType.INT32, tmp_dtype)
+        assert isinstance(call.type, ir.TileType)
+
+    def test_dst_shape_follows_indices(self):
+        span = ir.Span.unknown()
+        src = ir.Var("src", ir.TileType([1, 128], DataType.FP16), span)
+        idx = ir.Var("idx", ir.TileType([1, 16], DataType.INT16), span)
+        tmp = ir.Var("tmp", ir.TileType([1, 16], DataType.FP32), span)
+        call = tile.gather(src, idx, tmp)
+        assert isinstance(call.type, ir.TileType)
+        assert call.type.dtype == DataType.FP16  # follows src
+        # dst shape follows indices, not src.
+        assert len(call.type.shape) == 2
+
+    def test_invalid_src_dtype_raises(self):
+        with pytest.raises(Exception, match="src dtype"):
+            _gather(DataType.UINT8, DataType.INT32, DataType.INT32)
+
+    @pytest.mark.parametrize("bad_idx_dtype", [DataType.FP32, DataType.INT8])
+    def test_invalid_index_dtype_raises(self, bad_idx_dtype):
+        with pytest.raises(Exception, match="indices dtype"):
+            _gather(DataType.FP32, bad_idx_dtype, DataType.INT32)
+
+    def test_non_tile_indices_raises(self):
+        span = ir.Span.unknown()
+        src = ir.Var("src", ir.TileType([1, 64], DataType.FP32), span)
+        scalar_idx = ir.Var("idx", ir.ScalarType(DataType.INT32), span)
+        tmp = ir.Var("tmp", ir.TileType([1, 64], DataType.INT32), span)
+        with pytest.raises(Exception, match="TileType"):
+            tile.gather(src, scalar_idx, tmp)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/ut/ir/operators/test_gather.py
+++ b/tests/ut/ir/operators/test_gather.py
@@ -1,8 +1,8 @@
 # Copyright (c) PyPTO Contributors.
-# This program is free software; you can redistribute it and/or modify it under the terms and conditions of
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
 # CANN Open Software License Agreement Version 2.0 (the "License").
 # Please refer to the License for details. You may not use this file except in compliance with the License.
-# THIS FILE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
@@ -14,19 +14,22 @@ without depending on the DSL parser. The end-to-end behaviour (including the A5
 device path) is covered by the system tests in ``tests/st/runtime/ops/test_gather.py``.
 
 Type contract after the A5 (Ascend950) index-form alignment — the IR deducer is
-backend-agnostic and runs before arch selection, so it accepts the *union* of what
-any target permits and lets the PTOAS verifier narrow per arch (see the PTO IR
-manual, ``pto.tgather`` index-form checks):
+backend-agnostic, so it accepts the union of what any target permits *up to the
+universal index-width constraint* (PyPTO has no internal tgather verifier; the
+arch-specific A2/A3 i32-only rule is left to the external PTOAS assembler — see
+the PTO IR manual, ``pto.tgather`` index-form checks):
 
 * ``src`` dtype in {FP16, FP32, INT16, INT32}; tile lives in Vec.
-* ``indices`` dtype is INT32 everywhere, or INT16 additionally on A5.
+* ``indices`` dtype is INT32 (with any ``src``), or INT16 — but INT16 indices are
+  only valid with a 16-bit ``src`` (FP16/INT16): the tgather b32 form reads each
+  index as a u32, so an INT16 index with a 32-bit ``src`` is unsafe on every
+  target, not merely arch-gated. That universal rule is checked by the deducer.
 * ``tmp`` is a workspace operand required by the IR but not read by the A5 index
   form, so any Vec tile dtype is accepted (A2/A3 constrains it at PTOAS).
 * ``dst`` dtype equals ``src``; ``dst`` shape equals ``indices``.
 """
 
 import pytest
-
 from pypto import DataType, ir
 from pypto.ir.op import tile
 
@@ -48,12 +51,20 @@ class TestTileGatherIndexTypes:
         assert isinstance(call.type, ir.TileType)
         assert call.type.dtype == src_dtype  # dst dtype follows src
 
-    @pytest.mark.parametrize("idx_dtype", [DataType.INT32, DataType.INT16])
-    def test_valid_index_dtype(self, idx_dtype):
-        # INT16 indices pass IR deduction (A5 permits them); A2/A3 rejects later at PTOAS.
-        call = _gather(DataType.FP32, idx_dtype, DataType.INT32)
+    @pytest.mark.parametrize(
+        ("src_dtype", "idx_dtype"),
+        [
+            (DataType.FP32, DataType.INT32),
+            (DataType.INT32, DataType.INT32),
+            (DataType.FP16, DataType.INT16),  # INT16 indices require a 16-bit src.
+            (DataType.INT16, DataType.INT16),
+        ],
+    )
+    def test_valid_index_dtype(self, src_dtype, idx_dtype):
+        # INT32 indices are valid with any src; INT16 indices require a 16-bit src.
+        call = _gather(src_dtype, idx_dtype, DataType.INT32)
         assert isinstance(call.type, ir.TileType)
-        assert call.type.dtype == DataType.FP32
+        assert call.type.dtype == src_dtype  # dst dtype follows src
 
     @pytest.mark.parametrize("tmp_dtype", [DataType.FP32, DataType.FP16, DataType.INT32, DataType.INT16])
     def test_tmp_dtype_unconstrained(self, tmp_dtype):
@@ -69,8 +80,10 @@ class TestTileGatherIndexTypes:
         call = tile.gather(src, idx, tmp)
         assert isinstance(call.type, ir.TileType)
         assert call.type.dtype == DataType.FP16  # follows src
-        # dst shape follows indices, not src.
+        # dst shape follows indices [1, 16], not src [1, 128].
         assert len(call.type.shape) == 2
+        assert isinstance(call.type.shape[0], ir.ConstInt) and call.type.shape[0].value == 1
+        assert isinstance(call.type.shape[1], ir.ConstInt) and call.type.shape[1].value == 16
 
     def test_invalid_src_dtype_raises(self):
         with pytest.raises(Exception, match="src dtype"):
@@ -80,6 +93,13 @@ class TestTileGatherIndexTypes:
     def test_invalid_index_dtype_raises(self, bad_idx_dtype):
         with pytest.raises(Exception, match="indices dtype"):
             _gather(DataType.FP32, bad_idx_dtype, DataType.INT32)
+
+    @pytest.mark.parametrize("wide_src_dtype", [DataType.FP32, DataType.INT32])
+    def test_int16_index_requires_16bit_src(self, wide_src_dtype):
+        # INT16 indices with a 32-bit src are unsafe on every target (tgather b32
+        # reads them as u32), so the deducer rejects the combination outright.
+        with pytest.raises(Exception, match="16-bit src"):
+            _gather(wide_src_dtype, DataType.INT16, DataType.INT32)
 
     def test_non_tile_indices_raises(self):
         span = ir.Span.unknown()

--- a/tests/ut/ir/operators/test_tensor_ops.py
+++ b/tests/ut/ir/operators/test_tensor_ops.py
@@ -3351,6 +3351,7 @@ def test_tensor_gather_accepts_int16_index_with_16bit_input():
     inp, idx = _make_gather_inputs(src_dtype=DataType.FP16, idx_dtype=DataType.INT16)
     call = ir.op.tensor.gather(inp, dim=-1, index=idx)
     assert call.op.name == "tensor.gather"
+    assert isinstance(call.type, ir.TensorType)
     assert call.type.dtype == DataType.FP16
 
 

--- a/tests/ut/ir/operators/test_tensor_ops.py
+++ b/tests/ut/ir/operators/test_tensor_ops.py
@@ -3346,9 +3346,25 @@ def test_tensor_gather_rejects_bad_dim():
         ir.op.tensor.gather(inp, dim=2, index=idx)
 
 
-def test_tensor_gather_rejects_non_int32_index():
-    inp, idx = _make_gather_inputs(idx_dtype=DataType.INT16)
-    with pytest.raises(Exception, match=r"index dtype to be INT32"):
+def test_tensor_gather_accepts_int16_index_with_16bit_input():
+    """INT16 index is accepted when the input is a 16-bit dtype (FP16/INT16)."""
+    inp, idx = _make_gather_inputs(src_dtype=DataType.FP16, idx_dtype=DataType.INT16)
+    call = ir.op.tensor.gather(inp, dim=-1, index=idx)
+    assert call.op.name == "tensor.gather"
+    assert call.type.dtype == DataType.FP16
+
+
+def test_tensor_gather_rejects_int16_index_with_32bit_input():
+    """INT16 index with a 32-bit input is unsafe (tgather b32 reads it as u32)."""
+    inp, idx = _make_gather_inputs(src_dtype=DataType.FP32, idx_dtype=DataType.INT16)
+    with pytest.raises(Exception, match=r"16-bit input"):
+        ir.op.tensor.gather(inp, dim=-1, index=idx)
+
+
+def test_tensor_gather_rejects_non_int_index_dtype():
+    """A non-integer index dtype (FP32) is rejected outright."""
+    inp, idx = _make_gather_inputs(idx_dtype=DataType.FP32)
+    with pytest.raises(Exception, match=r"index dtype INT32"):
         ir.op.tensor.gather(inp, dim=-1, index=idx)
 
 


### PR DESCRIPTION
## Problem

The `tile.gather` and `tensor.gather` type deducers hard-coded the A2/A3-only index-form constraints (**indices `INT32`**; **`tmp` `INT32` with matching rank) for *all* backends. As a result, valid A5 (Ascend950) programs — which permit `i16` indices and impose no `tmp` dtype/shape relation (PTO IR manual, `pto.tgather` A5 index-form checks) — were rejected at IR type deduction, before ever reaching the backend.

## Fix

Type deduction is backend-agnostic and runs **before** arch selection, so it now accepts the **union** of per-target constraints and leaves the arch-specific rules to the PTOAS verifier (which already implements them per arch):

- **indices**: accept `INT32 | INT16` (was `INT32`-only)
- **`tmp`**: require only that it is a Vec tile operand (dropped the `INT32` dtype + matching-rank checks)

### Changes
- `src/ir/op/tile_ops/gather.cpp` — relax `DeduceTileGatherType` (indices `INT32|INT16`; drop `tmp` dtype + rank checks)
- `src/ir/op/tensor_ops/gather.cpp` — relax `DeduceTensorGatherType` (mirrors `tensor.scatter`, which already accepts `INT16` indices)
- Updated gather docstrings across the DSL/IR tile and tensor wrappers
- `tests/ut/ir/operators/test_gather.py`, `tests/st/runtime/ops/test_gather.py` — A5 INT16 index-form regression tests

## Testing
Local UT + system/runtime tests for the A5 INT16 gather index form pass.