### PR TITLE
feat(dsl): expose tile.gather_row as a first-class DSL interface

### DIFF
--- a/python/pypto/language/op/tile_ops.py
+++ b/python/pypto/language/op/tile_ops.py
@@ -29,6 +29,7 @@ __all__ = [
     "load",
     "store",
     "assemble",
+    "gather_row",
     "extract",
     "scatter_update",
     "concat",
@@ -461,6 +462,49 @@ def assemble(target: Tile, source: Tile, offset: Sequence[IntLike]) -> Tile:
         Tile wrapping the assemble operation
     """
     call_expr = _ir_ops.assemble(target.unwrap(), source.unwrap(), _normalize_intlike(offset))
+    return Tile(expr=call_expr)
+
+
+def gather_row(
+    dst: Tile,
+    src: Tensor,
+    dst_offset: Sequence[IntLike],
+    src_offset: Sequence[IntLike],
+    shapes: Sequence[IntLike],
+    transpose: bool = False,
+) -> Tile:
+    """Load one GM row directly into a sub-region of an on-chip tile (DPS).
+
+    Per-row primitive of the paged-gather lowering: DMAs one GM row window
+    straight into ``dst`` at ``dst_offset`` (``pto.subview`` of ``dst`` +
+    ``pto.tload``, ``GM -> on-chip``, no ``pto.tmov``). The caller computes the
+    physical ``src_offset`` (block-table lookup + bias) and the ``dst_offset``
+    slot itself, so arbitrary gather logic stays in the kernel. Writes ``dst``
+    in place, so a loop-carried accumulator is filled row by row and feeds
+    ``pl.matmul`` directly — the tile-level counterpart of
+    :func:`pypto.language.op.tensor_ops.gather_row`.
+
+    Args:
+        dst: Destination on-chip accumulator tile (Mat/L1 or Vec/UB).
+        src: Source pool in GM (a ``Tensor``).
+        dst_offset: ``[row, col]`` slot within ``dst`` to write.
+        src_offset: ``[row, col]`` physical offset within the GM ``src``.
+        shapes: GM row window shape ``[r, c]`` (typically ``[1, size]``).
+        transpose: Place the GM row ``[r, c]`` as an on-chip column ``[c, r]`` —
+            fills a matmul ``b_trans`` B-operand without a GM round-trip
+            (Mat/L1 only).
+
+    Returns:
+        Tile aliasing ``dst`` (written in place).
+    """
+    call_expr = _ir_ops.gather_row(
+        dst.unwrap(),
+        src.unwrap(),
+        _normalize_intlike(dst_offset),
+        _normalize_intlike(src_offset),
+        _normalize_intlike(shapes),
+        transpose,
+    )
     return Tile(expr=call_expr)
 
 

--- a/tests/ut/ir/transforms/test_gather_row.py
+++ b/tests/ut/ir/transforms/test_gather_row.py
@@ -148,6 +148,35 @@ def test_gather_row_transpose_writes_column():
     assert "[0, 1], [1, 0], [1, 128], transpose=True)" in text
 
 
+def test_tile_gather_row_dsl_interface_roundtrips():
+    """The exposed ``pl.tile.gather_row`` DSL wrapper round-trips through the parser.
+
+    A hand-authored tile-level kernel writes GM rows straight into a Mat tile via
+    ``pl.tile.gather_row`` (no tensor-level ``create_l1`` / lowering involved).
+    Printing and re-parsing must reproduce the same IR, which exercises the
+    language wrapper dispatch path (``_dsl_tile.gather_row``) rather than the raw
+    IR-builder fallback the printer previously round-tripped through.
+    """
+
+    @pl.program
+    class Program:
+        @pl.function(type=pl.FunctionType.InCore)
+        def kernel(self, src: pl.Tensor[[256, 128], pl.BF16]) -> pl.Tile[[16, 128], pl.BF16, pl.Mem.Mat]:
+            kv0 = pl.tile.create([16, 128], dtype=pl.BF16, target_memory=pl.Mem.Mat)
+            kv1 = pl.tile.gather_row(kv0, src, [0, 0], [0, 0], [1, 128])
+            kv2 = pl.tile.gather_row(kv1, src, [1, 0], [1, 0], [1, 128], transpose=False)
+            return kv2
+
+        @pl.function
+        def main(self, src: pl.Tensor[[256, 128], pl.BF16]) -> pl.Tile[[16, 128], pl.BF16, pl.Mem.Mat]:
+            return self.kernel(src)
+
+    text = ir.python_print(Program, format=False)
+    assert "pl.tile.gather_row(" in text
+    reparsed = pl.parse(text)
+    ir.assert_structural_equal(Program, reparsed)
+
+
 def test_gather_row_rejects_dtype_mismatch():
     """acc and src must share dtype (matmul operand integrity)."""
     with pytest.raises(Exception, match="share dtype"):


### PR DESCRIPTION
## Summary

`tile.gather_row` was previously reachable only through the parser's IR-builder fallback (`_dispatch_ir_builder_op`): the C++ printer emits `pl.tile.gather_row(...)`, but the language layer had no matching wrapper, so the op carried no type-checked signature, docstring, or IDE surface and was handled like a pass-internal lowering op.

This PR promotes it to a first-class DSL interface:

- Add a `gather_row` wrapper to `pypto.language.op.tile_ops` (mirroring `load` / `store` / `assemble`), exposing `pl.tile.gather_row(dst, src, dst_offset, src_offset, shapes, transpose=...)` with `Tile` / `Tensor` typing and a docstring.
- The parser now dispatches `pl.tile.gather_row` through the DSL-wrapper path (`_dsl_tile.gather_row`) instead of the raw IR-builder fallback. Printed IR round-trips identically (structurally equal).

No IR / op-registry or C++ changes — the `tile.gather_row` op itself is unchanged.

## Testing

- Added a round-trip regression test (`test_tile_gather_row_dsl_interface_roundtrips`) exercising a hand-authored tile-level kernel that calls `pl.tile.gather_row` directly.
- `tests/ut/ir/transforms/test_gather_row.py` — 10 passed.
- `test_paged_gather.py`, `test_pto_codegen_gather_row.py`, `test_convert_tensor_to_tile_ops.py` — all green (feature is orthogonal to these paths).