### PR TITLE
fix(ir): Propagate matmul memory through tensor reshape

### DIFF
--- a/src/ir/op/tensor_ops/transform.cpp
+++ b/src/ir/op/tensor_ops/transform.cpp
@@ -576,6 +576,9 @@ TypePtr DeduceTensorViewType(const std::vector<ExprPtr>& args,
                                       std::make_optional(std::move(new_view)));
 }
 
+// Reshape is a zero-copy view.  Marking that relationship also lets
+// ConvertTensorToTileOps propagate a consumer's memory-space requirement back
+// through reshape to a load-like producer such as tensor.slice.
 REGISTER_OP("tensor.reshape")
     .set_op_category("TensorOp")
     .set_description("Reshape tensor to new shape")
@@ -584,6 +587,7 @@ REGISTER_OP("tensor.reshape")
     .add_argument("valid_shape",
                   "Optional logical valid shape (MakeTuple, same rank as `shape`) carried onto the "
                   "result TensorView; present only in the 3-arg form")
+    .set_output_memory_inherit_input()
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
       return DeduceTensorReshapeType(args, kwargs);

--- a/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
+++ b/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
@@ -230,6 +230,26 @@ def _find_first_call_to(func: ir.Function, op_name: str) -> ir.Call | None:
     return finder.found
 
 
+class _AllCallsFinder(ir.IRVisitor):
+    """Collect all ``Call`` nodes whose callee has the requested name."""
+
+    def __init__(self, op_name: str) -> None:
+        super().__init__()
+        self.op_name = op_name
+        self.found: list[ir.Call] = []
+
+    def visit_call(self, op: ir.Call) -> None:
+        if op.op.name == self.op_name:
+            self.found.append(op)
+        super().visit_call(op)
+
+
+def _find_calls_to(func: ir.Function, op_name: str) -> list[ir.Call]:
+    finder = _AllCallsFinder(op_name)
+    finder.visit_stmt(func.body)
+    return finder.found
+
+
 class _CallCounter(ir.IRVisitor):
     """Count Calls whose callee ``Op`` name appears in ``op_names``."""
 
@@ -2567,6 +2587,55 @@ class TestSliceMatmulConversion:
 
         After = passes.convert_tensor_to_tile_ops()(Before)
         ir.assert_structural_equal(After, Expected)
+
+    def test_slice_reshape_then_matmul_routes_load_to_mat(self):
+        """tensor.slice → tensor.reshape → tensor.matmul emits tile.load(Mat).
+
+        A singleton leading dimension is common when selecting one attention
+        work item from a stacked rank-3 tensor.  The reshape is a zero-copy view,
+        so the matmul's Mat demand must reach the rank-3 slice.  Otherwise the
+        slice lowers to Vec and the compiler inserts an unnecessary AIV→AIC
+        transfer for the entire operand.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                query: pl.Tensor[[128, 16, 128], pl.BF16],
+                key: pl.Tensor[[128, 512, 128], pl.BF16],
+                out: pl.Out[pl.Tensor[[16, 512], pl.FP32]],
+            ) -> pl.Tensor[[16, 512], pl.FP32]:
+                query_3d = pl.slice(query, [1, 16, 128], [0, 0, 0])
+                query_2d = pl.reshape(query_3d, [16, 128])
+                key_3d = pl.slice(key, [1, 512, 128], [0, 0, 0])
+                key_2d = pl.reshape(key_3d, [512, 128])
+                scores = pl.matmul(query_2d, key_2d, b_trans=True, out_dtype=pl.FP32)
+                out = pl.assemble(out, scores, [0, 0])
+                return out
+
+            @pl.function
+            def main(
+                self,
+                query: pl.Tensor[[128, 16, 128], pl.BF16],
+                key: pl.Tensor[[128, 512, 128], pl.BF16],
+                out: pl.Out[pl.Tensor[[16, 512], pl.FP32]],
+            ) -> pl.Tensor[[16, 512], pl.FP32]:
+                return self.main_incore_0(query, key, out)
+
+        after = passes.convert_tensor_to_tile_ops()(Before)
+        incore = after.get_function("main_incore_0")
+        assert incore is not None
+
+        loads = _find_calls_to(incore, "tile.load")
+        assert len(loads) == 2
+        for load in loads:
+            result_type = load.type
+            assert isinstance(result_type, ir.TileType)
+            assert result_type.memory_space == pl.Mem.Mat
+
+        assert _count_calls(incore, {"tile.move"})["tile.move"] == 0
 
     def test_slice_chain_of_aliases_then_matmul(self):
         """Demand propagates through a chain of SSA aliases, not just one hop.

--- a/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
+++ b/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
@@ -235,7 +235,7 @@ class _AllCallsFinder(ir.IRVisitor):
 
     def __init__(self, op_name: str) -> None:
         super().__init__()
-        self.op_name = op_name
+        self.op_name = ir.get_op(op_name).name
         self.found: list[ir.Call] = []
 
     def visit_call(self, op: ir.Call) -> None:
@@ -2635,7 +2635,14 @@ class TestSliceMatmulConversion:
             assert isinstance(result_type, ir.TileType)
             assert result_type.memory_space == pl.Mem.Mat
 
-        assert _count_calls(incore, {"tile.move"})["tile.move"] == 0
+        reshapes = _find_calls_to(incore, "tile.reshape")
+        assert len(reshapes) == 2
+        for reshape in reshapes:
+            result_type = reshape.type
+            assert isinstance(result_type, ir.TileType)
+            assert result_type.memory_space == pl.Mem.Mat
+
+        assert not _find_calls_to(incore, "tile.move")
 
     def test_slice_chain_of_aliases_then_matmul(self):
         """Demand propagates through a chain of SSA aliases, not just one hop.


### PR DESCRIPTION
## Summary

- Mark `tensor.reshape` as inheriting the input memory space, consistent with its zero-copy semantics.
- Preserve Mat memory demand through rank-3 slice → reshape → matmul lowering.
- Add regression coverage requiring direct Mat loads with no intervening `tile.move`.

## Motivation

While reconstructing the larger QK workload from #2079, rank-3 operands were sliced and reshaped to rank 2 before matmul. `tensor.reshape` did not propagate the consumer memory-space requirement to its input, so these operands could be lowered through Vec instead of loading directly into Mat. This produced unnecessary AIV→AIC transfers and incorrect device results in the reconstructed rank-3 workload.

This is an independent lowering bug discovered during the #2079 investigation; it does not change `ChooseL0Tile` and does not claim to resolve the performance report in #2079.

## Validation

- `cmake --build build --parallel 2`
- Focused unit tests: 475 passed
- Ruff, clang-format, header, and English-only checks passed
- A2/A3 device validation: all reconstructed rank-3 stack/page variants passed golden checks; reshaped operands loaded directly into Mat with no `tile.move`, `tpush`, or `tpop`

Related to #2079.