### PR TITLE
fix(runtime): Pin managed pto-isa to runtime revision

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,11 @@ jobs:
       - name: Guard against un-centralized toolchain literals
         run: |
           status=0
-          if grep -rnE 'pto-isa-commit=[0-9a-f]{7,}|git checkout [0-9a-f]{40}' .github/workflows/; then
+          if grep -rn -- 'pto-isa''-commit' python/ tests/ .github/workflows/; then
+            echo "::error::The PyPTO pto-isa commit override has been removed. Bump runtime/pto_isa.pin instead."
+            status=1
+          fi
+          if grep -rnE 'git checkout [0-9a-f]{40}' .github/workflows/; then
             echo "::error::Hardcoded pto-isa commit found in a workflow. Use \${{ needs.toolchain.outputs.pto_isa_commit }}; pto-isa is bumped via the runtime submodule (runtime/pto_isa.pin)."
             status=1
           fi
@@ -328,8 +332,7 @@ jobs:
             --ignore=tests/st/runtime/cross_core \
             --ignore=tests/st/runtime/framework_and_models/test_dump_tag.py \
             --precompile-workers=32 --execute-via-task-submit --execute-batch-size=64 \
-            --task-queue-timeout=1800 --task-max-time=600 --task-submit-device="$DEVICE_ID" \
-            --pto-isa-commit=${{ needs.toolchain.outputs.pto_isa_commit }}
+            --task-queue-timeout=1800 --task-max-time=600 --task-submit-device="$DEVICE_ID"
 
       - name: Kill orphaned task-submit tasks
         if: always()
@@ -421,8 +424,7 @@ jobs:
           python -m pytest tests/st/runtime/ops tests/st/runtime/cross_core \
             -v -m device_batch \
             --precompile-workers=32 --execute-via-task-submit --execute-batch-size=64 \
-            --task-queue-timeout=1800 --task-max-time=600 --task-submit-device="$DEVICE_ID" \
-            --pto-isa-commit=${{ needs.toolchain.outputs.pto_isa_commit }}
+            --task-queue-timeout=1800 --task-max-time=600 --task-submit-device="$DEVICE_ID"
 
       - name: Test direct-device (mechanism B — one card, in-process)
         timeout-minutes: 30
@@ -446,8 +448,7 @@ jobs:
               --ignore=tests/st/distributed \
               --ignore=tests/st/codegen \
               --ignore=tests/st/runtime/framework_and_models/test_perf_swimlane.py \
-              --device=\$TASK_DEVICE --platform=a2a3 \
-              --pto-isa-commit=${{ needs.toolchain.outputs.pto_isa_commit }}"
+              --device=\$TASK_DEVICE --platform=a2a3"
 
       - name: Test paged-attention codegen (numeric compare, in device env)
         # tests/st/codegen runs device-free in the CPU codegen-tests job, but this
@@ -459,8 +460,7 @@ jobs:
           task-submit --device "$DEVICE_ID" --timeout 3600 --max-time 600 \
             --run "cd $GITHUB_WORKSPACE/st-direct-checkout && source activate.sh && python -m pytest \
               tests/st/codegen/torch/test_torch_codegen_paged_attention.py \
-              -v --device=\$TASK_DEVICE --platform=a2a3 \
-              --pto-isa-commit=${{ needs.toolchain.outputs.pto_isa_commit }}"
+              -v --device=\$TASK_DEVICE --platform=a2a3"
 
       - name: Test multi-orch L2 (isolated pytest invocation)
         # Mechanism B: a single forked pytest wrapped whole in task-submit (no
@@ -471,19 +471,19 @@ jobs:
         run: |
           source activate.sh
           task-submit --device "$DEVICE_ID" --timeout 3600 --max-time 600 \
-            --run "cd $GITHUB_WORKSPACE/st-direct-checkout && source activate.sh && python -m pytest tests/st/distributed/test_l2_multi_orch.py -v --device=\$TASK_DEVICE --pto-isa-commit=${{ needs.toolchain.outputs.pto_isa_commit }}"
+            --run "cd $GITHUB_WORKSPACE/st-direct-checkout && source activate.sh && python -m pytest tests/st/distributed/test_l2_multi_orch.py -v --device=\$TASK_DEVICE"
 
       - name: Test swimlane output
         run: |
           source activate.sh
           task-submit --device "$DEVICE_ID" --timeout 3600 --max-time 600 \
-            --run "cd $GITHUB_WORKSPACE/st-direct-checkout && source activate.sh && python -m pytest tests/st/runtime/framework_and_models/test_perf_swimlane.py -v --device=\$TASK_DEVICE --platform=a2a3 --enable-l2-swimlane --forked --pto-isa-commit=${{ needs.toolchain.outputs.pto_isa_commit }}"
+            --run "cd $GITHUB_WORKSPACE/st-direct-checkout && source activate.sh && python -m pytest tests/st/runtime/framework_and_models/test_perf_swimlane.py -v --device=\$TASK_DEVICE --platform=a2a3 --enable-l2-swimlane --forked"
 
       - name: Test dump-args output
         run: |
           source activate.sh
           task-submit --device "$DEVICE_ID" --timeout 3600 --max-time 600 \
-            --run "cd $GITHUB_WORKSPACE/st-direct-checkout && source activate.sh && python -m pytest tests/st/runtime/framework_and_models/test_dump_tag.py -v --device=\$TASK_DEVICE --platform=a2a3 --dump-args --pto-isa-commit=${{ needs.toolchain.outputs.pto_isa_commit }} --forked"
+            --run "cd $GITHUB_WORKSPACE/st-direct-checkout && source activate.sh && python -m pytest tests/st/runtime/framework_and_models/test_dump_tag.py -v --device=\$TASK_DEVICE --platform=a2a3 --dump-args --forked"
 
       - name: Kill orphaned task-submit tasks
         if: always()
@@ -557,7 +557,7 @@ jobs:
         run: |
           source activate.sh
           task-submit --device "$DEVICE_ID" --device-num 2 --timeout 3600 --max-time 900 \
-            --run "cd $GITHUB_WORKSPACE/dist-checkout && source activate.sh && python -m pytest tests/st/distributed -v --device=\$TASK_DEVICE --pto-isa-commit=${{ needs.toolchain.outputs.pto_isa_commit }} --ignore=tests/st/distributed/test_l2_multi_orch.py"
+            --run "cd $GITHUB_WORKSPACE/dist-checkout && source activate.sh && python -m pytest tests/st/distributed -v --device=\$TASK_DEVICE --ignore=tests/st/distributed/test_l2_multi_orch.py"
 
       - name: Kill orphaned task-submit tasks
         if: always()
@@ -757,10 +757,10 @@ jobs:
         # against the runtime's bundled pto-isa, which still clones from the
         # stale PTO-ISA/pto-isa mirror (lacks pto::Coalesce) until the runtime
         # submodule is bumped past simpler #806. Re-enable once that lands.
-        run: pytest tests/st/runtime/ops/test_assemble.py tests/st/runtime/ops/test_mscatter.py tests/st/runtime/ops/test_random.py tests/st/runtime/framework_and_models/test_qwen3_decode_scope3_mixed.py tests/st/runtime/control_flow/test_dyn_orch_shape.py::TestDynOrchShapeOperations::test_dyn_orch_paged_attention -v --platform=a5sim --forked --pto-isa-commit=${{ needs.toolchain.outputs.pto_isa_commit }} -k "not TestMscatter"
+        run: pytest tests/st/runtime/ops/test_assemble.py tests/st/runtime/ops/test_mscatter.py tests/st/runtime/ops/test_random.py tests/st/runtime/framework_and_models/test_qwen3_decode_scope3_mixed.py tests/st/runtime/control_flow/test_dyn_orch_shape.py::TestDynOrchShapeOperations::test_dyn_orch_paged_attention -v --platform=a5sim --forked -k "not TestMscatter"
 
       - name: Test A5 cross-core system tests (simulator)
-        run: pytest tests/st/runtime/cross_core/test_cross_core.py -v --forked --platform=a5sim --pto-isa-commit=${{ needs.toolchain.outputs.pto_isa_commit }}
+        run: pytest tests/st/runtime/cross_core/test_cross_core.py -v --forked --platform=a5sim
 
       - name: Test A2A3 cross-core system tests (simulator)
-        run: pytest tests/st/runtime/cross_core/test_cross_core.py -v --forked --platform=a2a3sim --pto-isa-commit=${{ needs.toolchain.outputs.pto_isa_commit }}
+        run: pytest tests/st/runtime/cross_core/test_cross_core.py -v --forked --platform=a2a3sim

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Guard against un-centralized toolchain literals
         run: |
           status=0
-          if grep -rn -- 'pto-isa''-commit' python/ tests/ .github/workflows/; then
+          if grep -rn -- '--pto-isa''-commit' python/ tests/ .github/workflows/; then
             echo "::error::The PyPTO pto-isa commit override has been removed. Bump runtime/pto_isa.pin instead."
             status=1
           fi

--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -91,7 +91,7 @@ jobs:
         # can grep -F "$GITHUB_WORKSPACE" to find THIS job's task.
         run: |
           task-submit --timeout 3600 --max-time 1800 --device 6 \
-            --run "cd $GITHUB_WORKSPACE && pytest tests/st/runtime/ops/test_assemble.py tests/st/runtime/ops/test_mscatter.py tests/st/runtime/ops/test_random.py tests/st/runtime/framework_and_models/test_qwen3_decode_scope3_mixed.py tests/st/runtime/control_flow/test_dyn_orch_shape.py::TestDynOrchShapeOperations::test_dyn_orch_paged_attention -v --forked --platform=a5 --device=6 --pto-isa-commit=${{ needs.toolchain.outputs.pto_isa_commit }} \
+            --run "cd $GITHUB_WORKSPACE && pytest tests/st/runtime/ops/test_assemble.py tests/st/runtime/ops/test_mscatter.py tests/st/runtime/ops/test_random.py tests/st/runtime/framework_and_models/test_qwen3_decode_scope3_mixed.py tests/st/runtime/control_flow/test_dyn_orch_shape.py::TestDynOrchShapeOperations::test_dyn_orch_paged_attention -v --forked --platform=a5 --device=6 \
               -k 'not (test_tile_row_expand or test_fillpad_zero or test_fillpad_max or test_fillpad_min or TestMscatter)'"
 
       - name: Kill orphaned task-submit tasks

--- a/docs/en/dev/00-ecosystem.md
+++ b/docs/en/dev/00-ecosystem.md
@@ -136,9 +136,10 @@ Defines the tile-level instruction set for the target hardware. Provides C++ hea
 **Interface:** C++ header library defining the instruction API. Downstream consumers `#include` pto-isa headers; the hardware vendor provides the target-specific implementations that back these headers.
 
 PyPTO's managed checkout under `build_output/_deps/pto-isa` uses the commit in
-`runtime/pto_isa.pin` by default, matching the runtime submodule's build. Pass
-`--pto-isa-commit` to override that revision for a test run. If the pin file is
-unavailable, PyPTO falls back to the pto-isa remote's default branch tip.
+`runtime/pto_isa.pin`, matching the runtime submodule's build. To change the
+revision, update the runtime-side pin. If the pin file is unavailable, PyPTO
+falls back to the pto-isa remote's default branch tip. A caller-provided
+`PTO_ISA_ROOT` is used as-is and remains under the caller's control.
 
 ### simpler — Task Runtime
 

--- a/docs/en/dev/00-ecosystem.md
+++ b/docs/en/dev/00-ecosystem.md
@@ -137,9 +137,11 @@ Defines the tile-level instruction set for the target hardware. Provides C++ hea
 
 PyPTO's managed checkout under `build_output/_deps/pto-isa` uses the commit in
 `runtime/pto_isa.pin`, matching the runtime submodule's build. To change the
-revision, update the runtime-side pin. If the pin file is unavailable, PyPTO
-falls back to the pto-isa remote's default branch tip. A caller-provided
-`PTO_ISA_ROOT` is used as-is and remains under the caller's control.
+revision, update the runtime-side pin. Source checkouts read the submodule pin;
+installed environments read the same pin packaged with `simpler_setup`. If the
+pin file is unavailable, PyPTO falls back to the pto-isa remote's default branch
+tip. A caller-provided `PTO_ISA_ROOT` is used as-is and remains under the
+caller's control.
 
 ### simpler — Task Runtime
 

--- a/docs/en/dev/00-ecosystem.md
+++ b/docs/en/dev/00-ecosystem.md
@@ -135,6 +135,11 @@ Defines the tile-level instruction set for the target hardware. Provides C++ hea
 
 **Interface:** C++ header library defining the instruction API. Downstream consumers `#include` pto-isa headers; the hardware vendor provides the target-specific implementations that back these headers.
 
+PyPTO's managed checkout under `build_output/_deps/pto-isa` uses the commit in
+`runtime/pto_isa.pin` by default, matching the runtime submodule's build. Pass
+`--pto-isa-commit` to override that revision for a test run. If the pin file is
+unavailable, PyPTO falls back to the pto-isa remote's default branch tip.
+
 ### simpler — Task Runtime
 
 Executes compiled programs on Ascend hardware. Manages the three-program execution model: Host, AICPU kernel, and AICore kernel.

--- a/docs/zh-cn/dev/00-ecosystem.md
+++ b/docs/zh-cn/dev/00-ecosystem.md
@@ -135,10 +135,11 @@ Python DSL → IR（不可变树）→ Pass Pipeline（20+ passes）→ CodeGen
 
 **接口：** 定义指令 API 的 C++ 头文件库。下游消费者 `#include` pto-isa 头文件；硬件厂商提供支撑这些头文件的目标特定实现。
 
-PyPTO 默认使用 `runtime/pto_isa.pin` 中的提交来管理
-`build_output/_deps/pto-isa` 下的检出，从而与 runtime 子模块的构建保持一致。可通过
-`--pto-isa-commit` 为单次测试覆盖该版本。如果 pin 文件不可用，PyPTO 会回退到
-pto-isa 远程仓库默认分支的最新提交。
+PyPTO 使用 `runtime/pto_isa.pin` 中的提交来管理
+`build_output/_deps/pto-isa` 下的检出，从而与 runtime 子模块的构建保持一致。如需
+更改版本，应更新 runtime 侧的 pin。如果 pin 文件不可用，PyPTO 会回退到 pto-isa
+远程仓库默认分支的最新提交。调用方提供的 `PTO_ISA_ROOT` 会直接使用，其版本由
+调用方自行管理。
 
 ### simpler — 任务运行时
 

--- a/docs/zh-cn/dev/00-ecosystem.md
+++ b/docs/zh-cn/dev/00-ecosystem.md
@@ -137,9 +137,10 @@ Python DSL → IR（不可变树）→ Pass Pipeline（20+ passes）→ CodeGen
 
 PyPTO 使用 `runtime/pto_isa.pin` 中的提交来管理
 `build_output/_deps/pto-isa` 下的检出，从而与 runtime 子模块的构建保持一致。如需
-更改版本，应更新 runtime 侧的 pin。如果 pin 文件不可用，PyPTO 会回退到 pto-isa
-远程仓库默认分支的最新提交。调用方提供的 `PTO_ISA_ROOT` 会直接使用，其版本由
-调用方自行管理。
+更改版本，应更新 runtime 侧的 pin。源码检出会读取子模块中的 pin，安装环境则读取
+随 `simpler_setup` 一同安装的相同 pin。如果 pin 文件不可用，PyPTO 会回退到
+pto-isa 远程仓库默认分支的最新提交。调用方提供的 `PTO_ISA_ROOT` 会直接使用，其
+版本由调用方自行管理。
 
 ### simpler — 任务运行时
 

--- a/docs/zh-cn/dev/00-ecosystem.md
+++ b/docs/zh-cn/dev/00-ecosystem.md
@@ -135,6 +135,11 @@ Python DSL → IR（不可变树）→ Pass Pipeline（20+ passes）→ CodeGen
 
 **接口：** 定义指令 API 的 C++ 头文件库。下游消费者 `#include` pto-isa 头文件；硬件厂商提供支撑这些头文件的目标特定实现。
 
+PyPTO 默认使用 `runtime/pto_isa.pin` 中的提交来管理
+`build_output/_deps/pto-isa` 下的检出，从而与 runtime 子模块的构建保持一致。可通过
+`--pto-isa-commit` 为单次测试覆盖该版本。如果 pin 文件不可用，PyPTO 会回退到
+pto-isa 远程仓库默认分支的最新提交。
+
 ### simpler — 任务运行时
 
 在 Ascend 硬件上执行编译后的程序。管理三程序执行模型：Host、AICPU kernel 和 AICore kernel。

--- a/python/pypto/ir/compiled_program.py
+++ b/python/pypto/ir/compiled_program.py
@@ -416,7 +416,6 @@ def _invoke_compiled(
         coerced,
         platform=platform,
         device_id=config.device_id,
-        pto_isa_commit=config.pto_isa_commit,
         dfx=_DfxOpts.from_run_config(config),
         block_dim=config.block_dim,
         aicpu_thread_num=config.aicpu_thread_num,
@@ -495,39 +494,26 @@ class _RuntimeFacade:
         :class:`CompiledProgram`) override this to redirect callers elsewhere.
         """
 
-    def _ensure_runtime_loaded(self, pto_isa_commit: str | None = None) -> None:
+    def _ensure_runtime_loaded(self) -> None:
         if self._chip_callable is not None:
             return
         self._check_runtime_access()
         from pypto.runtime.device_runner import compile_and_assemble  # noqa: PLC0415
 
-        cc, rn, rc = compile_and_assemble(self._output_dir, self._platform, pto_isa_commit)
+        cc, rn, rc = compile_and_assemble(self._output_dir, self._platform)
         # Publish the "loaded" sentinel (_chip_callable) last so a reader can
         # never observe it set while _runtime_name / _runtime_config are None.
         self._runtime_name = rn
         self._runtime_config = rc
         self._chip_callable = cc
 
-    def load(self, *, pto_isa_commit: str | None = None) -> None:
+    def load(self) -> None:
         """Eagerly compile-and-load the runtime artefacts.
 
         Optional — :attr:`chip_callable`, :attr:`runtime_name`, and
-        :attr:`runtime_config` all auto-load on first access. Use this only when
-        you need to pin a specific ``pto_isa_commit`` (which must happen before
-        any property access, since the result is cached).
-
-        Raises:
-            RuntimeError: When runtime artefacts are already loaded and a
-                non-None ``pto_isa_commit`` is supplied — the cached build
-                cannot be re-pinned.
+        :attr:`runtime_config` all auto-load on first access.
         """
-        if self._chip_callable is not None and pto_isa_commit is not None:
-            raise RuntimeError(
-                "Runtime artefacts already loaded; pto_isa_commit cannot change. "
-                "Call load(pto_isa_commit=...) before any chip_callable / "
-                "runtime_name / runtime_config access."
-            )
-        self._ensure_runtime_loaded(pto_isa_commit)
+        self._ensure_runtime_loaded()
 
     @property
     def chip_callable(self) -> Any:

--- a/python/pypto/runtime/_dep_gen_capture.py
+++ b/python/pypto/runtime/_dep_gen_capture.py
@@ -112,10 +112,9 @@ def main(argv: list[str]) -> int:
     platform = spec["platform"]
     device_id = int(spec["device_id"])
     dfx_dir = Path(spec["dfx_dir"])
-    pto_isa_commit = spec.get("pto_isa_commit")
     level = int(spec.get("level", 2))
 
-    chip_callable, runtime_name, runtime_config = compile_and_assemble(work_dir, platform, pto_isa_commit)
+    chip_callable, runtime_name, runtime_config = compile_and_assemble(work_dir, platform)
 
     if spec["mode"] == "golden":
         orch_args, _keepalive = _build_golden_orch_args(Path(spec["golden_path"]))

--- a/python/pypto/runtime/bench.py
+++ b/python/pypto/runtime/bench.py
@@ -894,7 +894,7 @@ def benchmark(
             Mutually exclusive with *config*. **L2 only** — not accepted for L3
             (device set comes from ``distributed_config.device_ids``).
         config: Optional :class:`~pypto.runtime.RunConfig`. L2: full control
-            (``block_dim`` / ``aicpu_thread_num`` / ``pto_isa_commit``); pass this
+            (``block_dim`` / ``aicpu_thread_num``); pass this
             *or* *platform*/*device_id*, not both. L3: forwarded per dispatch for
             ring-sizing overrides (``ring_task_window`` / ``ring_heap`` /
             ``ring_dep_pool``); ``None`` reuses the prepared baseline.

--- a/python/pypto/runtime/debug/replay.py
+++ b/python/pypto/runtime/debug/replay.py
@@ -227,7 +227,6 @@ def replay(
             list(tensors),
             platform=config.platform,
             device_id=config.device_id,
-            pto_isa_commit=config.pto_isa_commit,
             dfx=_DfxOpts.from_run_config(config),
         )
 

--- a/python/pypto/runtime/device_runner.py
+++ b/python/pypto/runtime/device_runner.py
@@ -144,7 +144,7 @@ def _get_pto_isa_clone_path() -> Path:
 def _read_runtime_pto_isa_pin() -> str | None:
     """Return the runtime's pinned PTO-ISA commit, or ``None`` when unavailable."""
     try:
-        commit = _PTO_ISA_PIN_PATH.read_text().strip()
+        commit = _PTO_ISA_PIN_PATH.read_text(encoding="utf-8").strip()
     except OSError as e:
         logger.warning(
             f"Failed to read runtime PTO-ISA pin at {_PTO_ISA_PIN_PATH}: {e}; "
@@ -205,24 +205,20 @@ def _clone_pto_isa(clone_path: Path, primary_url: str, fallback_url: str) -> boo
     return True
 
 
-def ensure_pto_isa_root(commit: str | None = None, clone_protocol: str = "https") -> str | None:
+def ensure_pto_isa_root(clone_protocol: str = "https") -> str | None:
     """Ensure ``PTO_ISA_ROOT`` is available, either from env or by cloning.
 
     Args:
-        commit: Commit to checkout. Defaults to the revision in
-            ``runtime/pto_isa.pin`` when that file is available.
         clone_protocol: ``"https"`` or ``"ssh"``.
 
     Returns:
         PTO-ISA root path if successful, ``None`` otherwise.
     """
-    resolved_commit = commit or _read_runtime_pto_isa_pin()
     existing_root = os.environ.get("PTO_ISA_ROOT")
     if existing_root:
-        if resolved_commit:
-            _checkout_pto_isa_commit(Path(existing_root), resolved_commit)
         return existing_root
 
+    resolved_commit = _read_runtime_pto_isa_pin()
     clone_path = _get_pto_isa_clone_path()
     include_dir = clone_path / "include"
 
@@ -233,10 +229,11 @@ def ensure_pto_isa_root(commit: str | None = None, clone_protocol: str = "https"
             primary_url, fallback_url = _PTO_ISA_SSH, _PTO_ISA_SSH_FALLBACK
         if not _clone_pto_isa(clone_path, primary_url, fallback_url):
             return None
-        if resolved_commit:
-            _checkout_pto_isa_commit(clone_path, resolved_commit)
+        if resolved_commit and not _checkout_pto_isa_commit(clone_path, resolved_commit):
+            return None
     elif resolved_commit:
-        _checkout_pto_isa_commit(clone_path, resolved_commit)
+        if not _checkout_pto_isa_commit(clone_path, resolved_commit):
+            return None
     else:
         _update_pto_isa_to_latest(clone_path)
 
@@ -248,19 +245,28 @@ def ensure_pto_isa_root(commit: str | None = None, clone_protocol: str = "https"
     return resolved
 
 
-def _checkout_pto_isa_commit(clone_path: Path, commit: str) -> None:
-    """Checkout the specified commit if the existing clone is at a different revision."""
+def _checkout_pto_isa_commit(clone_path: Path, commit: str) -> bool:
+    """Checkout *commit* and verify that the managed clone resolves to it."""
     try:
         result = subprocess.run(
-            ["git", "rev-parse", "--short", "HEAD"],
+            ["git", "rev-parse", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+            cwd=str(clone_path),
+            timeout=5,
+        )
+        current = result.stdout.strip()
+        target = subprocess.run(
+            ["git", "rev-parse", f"{commit}^{{commit}}"],
             check=False,
             capture_output=True,
             text=True,
             cwd=str(clone_path),
             timeout=5,
         )
-        current = result.stdout.strip() if result.returncode == 0 else ""
-        if current and not commit.startswith(current) and not current.startswith(commit):
+        target_revision = target.stdout.strip() if target.returncode == 0 else ""
+        if not target_revision or current != target_revision:
             subprocess.run(
                 ["git", "fetch", "origin"],
                 capture_output=True,
@@ -277,8 +283,29 @@ def _checkout_pto_isa_commit(clone_path: Path, commit: str) -> None:
                 timeout=30,
                 check=True,
             )
-    except Exception as e:
+            target_revision = subprocess.run(
+                ["git", "rev-parse", f"{commit}^{{commit}}"],
+                check=True,
+                capture_output=True,
+                text=True,
+                cwd=str(clone_path),
+                timeout=5,
+            ).stdout.strip()
+        checked_out = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+            cwd=str(clone_path),
+            timeout=5,
+        ).stdout.strip()
+        if checked_out != target_revision:
+            logger.warning(f"Failed to verify pto-isa commit {commit}: HEAD is {checked_out or 'unknown'}")
+            return False
+        return True
+    except (OSError, subprocess.SubprocessError) as e:
         logger.warning(f"Failed to checkout pto-isa commit {commit}: {e}")
+        return False
 
 
 def _update_pto_isa_to_latest(clone_path: Path) -> None:
@@ -442,7 +469,6 @@ def compile_single_orchestration(
 def compile_and_assemble(
     work_dir: Path,
     platform: str,
-    pto_isa_commit: str | None = None,
 ) -> tuple[ChipCallable, str, dict[str, Any]]:
     """Compile kernels + orchestration from *work_dir*, assemble ``ChipCallable``.
 
@@ -453,7 +479,6 @@ def compile_and_assemble(
         work_dir: Root output directory containing ``kernels/``, ``orchestration/``,
             and ``kernel_config.py`` (produced by :func:`compile_program`).
         platform: Target execution platform.
-        pto_isa_commit: If set, pin the pto-isa clone to this commit.
 
     Returns:
         ``(chip_callable, runtime_name, runtime_config)`` — the assembled
@@ -483,7 +508,7 @@ def compile_and_assemble(
     runtime_name = runtime_config.get("runtime", "tensormap_and_ringbuffer")
 
     # Ensure PTO-ISA root
-    pto_isa_root = ensure_pto_isa_root(commit=pto_isa_commit, clone_protocol="https")
+    pto_isa_root = ensure_pto_isa_root(clone_protocol="https")
     if pto_isa_root is None:
         raise OSError(
             "PTO_ISA_ROOT could not be resolved.\n"

--- a/python/pypto/runtime/device_runner.py
+++ b/python/pypto/runtime/device_runner.py
@@ -18,12 +18,13 @@ implementations of:
 - :func:`validate_golden`: Compare actual outputs against golden reference.
 - :func:`ensure_pto_isa_root`: Manage PTO-ISA repository (clone/checkout).
 
-These functions eliminate all Python-level imports from Simpler. The only
-Simpler dependency remaining is:
+These functions keep orchestration in PyPTO while relying on the installed
+runtime packages for two integration surfaces:
 
-- ``pip install simpler`` → provides the ``_task_interface`` nanobind C++ module.
-- The ``runtime/`` git submodule at the repository root provides C++ headers and
-  pre-built runtime binaries.
+- ``simpler`` provides the ``_task_interface`` nanobind C++ module.
+- ``simpler_setup`` provides the kernel compiler plus packaged runtime sources,
+  binaries, and ``pto_isa.pin`` for non-source installs. In a source checkout,
+  those assets come from the ``runtime/`` git submodule instead.
 """
 
 from __future__ import annotations
@@ -39,6 +40,7 @@ import tempfile
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
+from importlib import import_module
 from pathlib import Path
 from typing import Any
 
@@ -141,21 +143,31 @@ def _get_pto_isa_clone_path() -> Path:
     return _PROJECT_ROOT / "build_output" / "_deps" / "pto-isa"
 
 
+def _get_runtime_pto_isa_pin_path() -> Path:
+    """Locate the runtime pin in a source checkout or installed runtime package."""
+    if _PTO_ISA_PIN_PATH.parent.is_dir():
+        return _PTO_ISA_PIN_PATH
+
+    try:
+        runtime_root = getattr(import_module("simpler_setup.environment"), "PROJECT_ROOT")
+    except (ImportError, AttributeError):
+        return _PTO_ISA_PIN_PATH
+    return Path(runtime_root) / "pto_isa.pin"
+
+
 def _read_runtime_pto_isa_pin() -> str | None:
     """Return the runtime's pinned PTO-ISA commit, or ``None`` when unavailable."""
+    pin_path = _get_runtime_pto_isa_pin_path()
     try:
-        commit = _PTO_ISA_PIN_PATH.read_text(encoding="utf-8").strip()
+        commit = pin_path.read_text(encoding="utf-8").strip()
     except OSError as e:
         logger.warning(
-            f"Failed to read runtime PTO-ISA pin at {_PTO_ISA_PIN_PATH}: {e}; "
-            "falling back to the latest remote HEAD"
+            f"Failed to read runtime PTO-ISA pin at {pin_path}: {e}; falling back to the latest remote HEAD"
         )
         return None
 
     if not commit:
-        logger.warning(
-            f"Runtime PTO-ISA pin at {_PTO_ISA_PIN_PATH} is empty; falling back to the latest remote HEAD"
-        )
+        logger.warning(f"Runtime PTO-ISA pin at {pin_path} is empty; falling back to the latest remote HEAD")
         return None
     return commit
 

--- a/python/pypto/runtime/device_runner.py
+++ b/python/pypto/runtime/device_runner.py
@@ -132,11 +132,32 @@ _PTO_ISA_HTTPS_FALLBACK = "https://gitcode.com/luohuan40/pto-isa.git"
 _PTO_ISA_SSH_FALLBACK = "git@gitcode.com:luohuan40/pto-isa.git"
 _PTO_ISA_PRIMARY_CLONE_TIMEOUT = 60
 _PTO_ISA_FALLBACK_CLONE_TIMEOUT = 300
+_PROJECT_ROOT = Path(__file__).parents[3]
+_PTO_ISA_PIN_PATH = _PROJECT_ROOT / "runtime" / "pto_isa.pin"
 
 
 def _get_pto_isa_clone_path() -> Path:
     """Return the default path where PTO-ISA is cloned."""
-    return Path(__file__).parent.parent.parent.parent / "build_output" / "_deps" / "pto-isa"
+    return _PROJECT_ROOT / "build_output" / "_deps" / "pto-isa"
+
+
+def _read_runtime_pto_isa_pin() -> str | None:
+    """Return the runtime's pinned PTO-ISA commit, or ``None`` when unavailable."""
+    try:
+        commit = _PTO_ISA_PIN_PATH.read_text().strip()
+    except OSError as e:
+        logger.warning(
+            f"Failed to read runtime PTO-ISA pin at {_PTO_ISA_PIN_PATH}: {e}; "
+            "falling back to the latest remote HEAD"
+        )
+        return None
+
+    if not commit:
+        logger.warning(
+            f"Runtime PTO-ISA pin at {_PTO_ISA_PIN_PATH} is empty; falling back to the latest remote HEAD"
+        )
+        return None
+    return commit
 
 
 def _clone_pto_isa(clone_path: Path, primary_url: str, fallback_url: str) -> bool:
@@ -188,16 +209,18 @@ def ensure_pto_isa_root(commit: str | None = None, clone_protocol: str = "https"
     """Ensure ``PTO_ISA_ROOT`` is available, either from env or by cloning.
 
     Args:
-        commit: If provided, checkout this specific commit.
+        commit: Commit to checkout. Defaults to the revision in
+            ``runtime/pto_isa.pin`` when that file is available.
         clone_protocol: ``"https"`` or ``"ssh"``.
 
     Returns:
         PTO-ISA root path if successful, ``None`` otherwise.
     """
+    resolved_commit = commit or _read_runtime_pto_isa_pin()
     existing_root = os.environ.get("PTO_ISA_ROOT")
     if existing_root:
-        if commit:
-            _checkout_pto_isa_commit(Path(existing_root), commit)
+        if resolved_commit:
+            _checkout_pto_isa_commit(Path(existing_root), resolved_commit)
         return existing_root
 
     clone_path = _get_pto_isa_clone_path()
@@ -210,10 +233,10 @@ def ensure_pto_isa_root(commit: str | None = None, clone_protocol: str = "https"
             primary_url, fallback_url = _PTO_ISA_SSH, _PTO_ISA_SSH_FALLBACK
         if not _clone_pto_isa(clone_path, primary_url, fallback_url):
             return None
-        if commit:
-            _checkout_pto_isa_commit(clone_path, commit)
-    elif commit:
-        _checkout_pto_isa_commit(clone_path, commit)
+        if resolved_commit:
+            _checkout_pto_isa_commit(clone_path, resolved_commit)
+    elif resolved_commit:
+        _checkout_pto_isa_commit(clone_path, resolved_commit)
     else:
         _update_pto_isa_to_latest(clone_path)
 

--- a/python/pypto/runtime/execute_artifact.py
+++ b/python/pypto/runtime/execute_artifact.py
@@ -72,7 +72,6 @@ def execute_artifact_dir(
     platform: str,
     device_id: int,
     *,
-    pto_isa_commit: str | None = None,
     dfx: _DfxOpts = _DfxOpts(),
     validate: bool = True,
 ) -> None:
@@ -89,7 +88,6 @@ def execute_artifact_dir(
             ``kernels/``, ``orchestration/``, ``golden.py``, ``data/``).
         platform: Target execution platform (e.g. ``"a2a3"``).
         device_id: Hardware device index to run on.
-        pto_isa_commit: If set, pin the pto-isa clone to this commit.
         dfx: Runtime DFX toggles; artefacts land under ``work_dir/dfx_outputs``.
         validate: When ``True`` (manual repro default), compare outputs against
             the golden in-process using ``golden.py``'s tolerances. When
@@ -104,11 +102,11 @@ def execute_artifact_dir(
         Exception: Any device / validation error is propagated to the caller
             (``main`` turns it into ``PYPTO_EXEC_RESULT=FAIL`` + exit ``1``).
     """
-    chip_callable, runtime_name = _reconstruct_artifact(work_dir, platform, pto_isa_commit=pto_isa_commit)
+    chip_callable, runtime_name = _reconstruct_artifact(work_dir, platform)
     _run_on_device(work_dir, platform, device_id, chip_callable, runtime_name, dfx=dfx, validate=validate)
 
 
-def _reconstruct_artifact(work_dir: Path, platform: str, *, pto_isa_commit: str | None) -> tuple[Any, str]:
+def _reconstruct_artifact(work_dir: Path, platform: str) -> tuple[Any, str]:
     """Rebuild the cached artifact, reclassifying any failure as infra.
 
     ``compile_and_assemble`` reuses the cached ``.o``/``.so`` next to each kernel
@@ -119,9 +117,7 @@ def _reconstruct_artifact(work_dir: Path, platform: str, *, pto_isa_commit: str 
     from pypto.runtime.device_runner import compile_and_assemble  # noqa: PLC0415
 
     try:
-        chip_callable, runtime_name, _ = compile_and_assemble(
-            work_dir, platform, pto_isa_commit=pto_isa_commit
-        )
+        chip_callable, runtime_name, _ = compile_and_assemble(work_dir, platform)
     except Exception as exc:  # noqa: BLE001 — reclassified as infra, re-raised below
         raise ArtifactSetupError(f"artifact reconstruction failed for {work_dir}: {exc}") from exc
     return chip_callable, runtime_name
@@ -161,7 +157,6 @@ def execute_batch_manifest(
     manifest_path: Path,
     device_id: int,
     *,
-    pto_isa_commit: str | None = None,
     dfx: _DfxOpts = _DfxOpts(),
     validate: bool = False,
 ) -> bool:
@@ -204,7 +199,7 @@ def execute_batch_manifest(
 
     def _rebind(work_dir: Path, platform: str) -> tuple[Any, str]:
         # _reconstruct_artifact already wraps a compile failure as ArtifactSetupError.
-        chip_callable, runtime_name = _reconstruct_artifact(work_dir, platform, pto_isa_commit=pto_isa_commit)
+        chip_callable, runtime_name = _reconstruct_artifact(work_dir, platform)
         live_callables.append(chip_callable)
         return chip_callable, runtime_name
 
@@ -291,11 +286,6 @@ def _build_parser() -> argparse.ArgumentParser:
         "init for the whole batch). Mutually exclusive with --work-dir.",
     )
     parser.add_argument("--device-id", type=int, required=True, help="Hardware device index")
-    parser.add_argument(
-        "--pto-isa-commit",
-        default=None,
-        help="Override runtime/pto_isa.pin with this pto-isa commit",
-    )
     # DFX toggles — names mirror tests/st/conftest.py so the harness round-trip
     # (_dfx_to_cli) is symmetric.
     parser.add_argument("--enable-l2-swimlane", action="store_true", help="Capture L2 swimlane records")
@@ -345,7 +335,6 @@ def main(argv: list[str] | None = None) -> int:
             all_ok = execute_batch_manifest(
                 args.batch_manifest,
                 args.device_id,
-                pto_isa_commit=args.pto_isa_commit,
                 dfx=dfx,
                 validate=not args.no_validate,
             )
@@ -365,7 +354,6 @@ def main(argv: list[str] | None = None) -> int:
             args.work_dir,
             args.platform,
             args.device_id,
-            pto_isa_commit=args.pto_isa_commit,
             dfx=dfx,
             validate=not args.no_validate,
         )

--- a/python/pypto/runtime/execute_artifact.py
+++ b/python/pypto/runtime/execute_artifact.py
@@ -291,7 +291,11 @@ def _build_parser() -> argparse.ArgumentParser:
         "init for the whole batch). Mutually exclusive with --work-dir.",
     )
     parser.add_argument("--device-id", type=int, required=True, help="Hardware device index")
-    parser.add_argument("--pto-isa-commit", default=None, help="Pin pto-isa to this commit")
+    parser.add_argument(
+        "--pto-isa-commit",
+        default=None,
+        help="Override runtime/pto_isa.pin with this pto-isa commit",
+    )
     # DFX toggles — names mirror tests/st/conftest.py so the harness round-trip
     # (_dfx_to_cli) is symmetric.
     parser.add_argument("--enable-l2-swimlane", action="store_true", help="Capture L2 swimlane records")

--- a/python/pypto/runtime/runner.py
+++ b/python/pypto/runtime/runner.py
@@ -97,8 +97,6 @@ class RunConfig:
             ``build_output/<program_name>_<timestamp>``.
         codegen_only: If ``True``, stop after code generation without executing
             on device.  Useful for validating compilation output.
-        pto_isa_commit: If set, pin the pto-isa clone to this specific git
-            commit (hash or tag).  ``None`` means use the latest remote HEAD.
         enable_l2_swimlane: Capture per-task L2 perf records into
             ``<work_dir>/dfx_outputs/l2_swimlane_records.json``. On onboard
             platforms, ``swimlane_converter`` then produces
@@ -229,7 +227,6 @@ class RunConfig:
     save_kernels: bool = False
     save_kernels_dir: str | None = None
     codegen_only: bool = False
-    pto_isa_commit: str | None = None
     enable_l2_swimlane: bool = False
     enable_dump_args: int = 0  # 0=off, 1=partial (dump_tag-marked), 2=full
     enable_pmu: int = 0
@@ -924,7 +921,6 @@ def _execute_on_device(
                 "platform": platform,
                 "device_id": device_id,
                 "dfx_dir": str(dfx_dir),
-                "pto_isa_commit": None,
                 "level": 2,
             },
             dfx_dir,
@@ -1247,7 +1243,6 @@ def execute_compiled(  # noqa: PLR0913
     *,
     platform: str,
     device_id: int,
-    pto_isa_commit: str | None = None,
     dfx: _DfxOpts = _DfxOpts(),
     level: int = 2,
     block_dim: int | None = None,
@@ -1272,7 +1267,6 @@ def execute_compiled(  # noqa: PLR0913
             orchestration function's parameter order.
         platform: Target execution platform.
         device_id: Hardware device index.
-        pto_isa_commit: Optional git commit to pin pto-isa clone.
         dfx: Runtime DFX toggles. When any flag is enabled the artefacts
             land under ``<work_dir>/dfx_outputs/`` and the matching
             post-run converter is invoked.
@@ -1308,7 +1302,7 @@ def execute_compiled(  # noqa: PLR0913
         execute_on_device,
     )
 
-    chip_callable, runtime_name, runtime_config = compile_and_assemble(work_dir, platform, pto_isa_commit)
+    chip_callable, runtime_name, runtime_config = compile_and_assemble(work_dir, platform)
 
     # Caller-supplied values take precedence over the RUNTIME_CONFIG baked
     # into kernel_config.py. When neither is provided, the simpler runtime's
@@ -1358,7 +1352,6 @@ def execute_compiled(  # noqa: PLR0913
                 "platform": platform,
                 "device_id": device_id,
                 "dfx_dir": str(dfx_dir),
-                "pto_isa_commit": pto_isa_commit,
                 "level": level,
                 "block_dim": effective_block_dim,
                 "aicpu_thread_num": effective_aicpu_thread_num,

--- a/tests/st/conftest.py
+++ b/tests/st/conftest.py
@@ -202,7 +202,7 @@ def pytest_addoption(parser):
         "--pto-isa-commit",
         action="store",
         default=None,
-        help="Pin the pto-isa clone to a specific git commit (hash or tag). Default: use latest remote HEAD.",
+        help="Override runtime/pto_isa.pin with a specific pto-isa commit (hash or tag).",
     )
     parser.addoption(
         "--analyze-auto-scopes-for-deps",

--- a/tests/st/conftest.py
+++ b/tests/st/conftest.py
@@ -199,12 +199,6 @@ def pytest_addoption(parser):
         "Default: leave the runtime logger at its V5/INFO default.",
     )
     parser.addoption(
-        "--pto-isa-commit",
-        action="store",
-        default=None,
-        help="Override runtime/pto_isa.pin with a specific pto-isa commit (hash or tag).",
-    )
-    parser.addoption(
         "--analyze-auto-scopes-for-deps",
         action="store_true",
         default=False,
@@ -435,7 +429,6 @@ def test_config(request) -> RunConfig:
         save_kernels_dir=save_kernels_dir,
         dump_passes=request.config.getoption("--dump-passes"),
         codegen_only=request.config.getoption("--codegen-only"),
-        pto_isa_commit=request.config.getoption("--pto-isa-commit"),
         enable_l2_swimlane=request.config.getoption("--enable-l2-swimlane"),
         enable_dump_args=request.config.getoption("--dump-args"),
         enable_pmu=request.config.getoption("--enable-pmu"),
@@ -795,7 +788,6 @@ def pytest_collection_finish(session: pytest.Session) -> None:
 
     dump_passes: bool = session.config.getoption("--dump-passes")
     codegen_only: bool = session.config.getoption("--codegen-only")
-    pto_isa_commit: str | None = session.config.getoption("--pto-isa-commit")
     enable_l2_swimlane: bool = session.config.getoption("--enable-l2-swimlane")
     enable_dump_args: int = session.config.getoption("--dump-args")
     enable_pmu: int = session.config.getoption("--enable-pmu")
@@ -858,7 +850,6 @@ def pytest_collection_finish(session: pytest.Session) -> None:
         session_platform=session_platform,
         dump_passes=dump_passes,
         codegen_only=codegen_only,
-        pto_isa_commit=pto_isa_commit,
         compile_workers=max_workers,
         device_pool=device_pool,
         enable_l2_swimlane=enable_l2_swimlane,

--- a/tests/st/harness/core/test_runner.py
+++ b/tests/st/harness/core/test_runner.py
@@ -350,7 +350,6 @@ def _fused_compile_task(
     session_platform: str,
     dump_passes: bool,
     analyze_auto_scopes_for_deps: bool,
-    pto_isa_commit: str | None,
 ) -> CompileArtifact:
     """Compile IR → kernels/orch C++ → golden.py → .so for one test case.
 
@@ -376,9 +375,7 @@ def _fused_compile_task(
             )
         from pypto.runtime.device_runner import compile_and_assemble  # noqa: PLC0415
 
-        chip_callable, runtime_name, _ = compile_and_assemble(
-            work_dir, resolved, pto_isa_commit=pto_isa_commit
-        )
+        chip_callable, runtime_name, _ = compile_and_assemble(work_dir, resolved)
         return CompileArtifact(
             work_dir=work_dir,
             resolved_platform=resolved,
@@ -533,15 +530,13 @@ def _shell_quote_run(project_root: Path, inner: "list[str]") -> str:
     )
 
 
-def _build_execute_artifact_cmd(
-    mode_args: "list[str]", dfx: "_DfxOpts", pto_isa_commit: str | None
-) -> list[str]:
+def _build_execute_artifact_cmd(mode_args: "list[str]", dfx: "_DfxOpts") -> list[str]:
     """Assemble the ``python -m pypto.runtime.execute_artifact`` child argv.
 
     *mode_args* selects single (``--work-dir`` / ``--platform``) vs batch
     (``--batch-manifest``); everything else — the interpreter, ``--device-id
-    $TASK_DEVICE``, ``--no-validate``, the DFX flags and the optional pto-isa pin —
-    is shared by both task-submit paths.
+    $TASK_DEVICE``, ``--no-validate``, and the DFX flags — is shared by both
+    task-submit paths.
 
     Uses the exact interpreter running the harness (the per-job venv python), not
     bare ``"python"``: task-submit runs the child via ``runuser`` and bare
@@ -561,8 +556,6 @@ def _build_execute_artifact_cmd(
         "--no-validate",
         *_dfx_to_cli(dfx),
     ]
-    if pto_isa_commit:
-        inner += ["--pto-isa-commit", pto_isa_commit]
     return inner
 
 
@@ -615,7 +608,6 @@ def _run_artifact_via_task_submit(
     work_dir: Path,
     platform: str,
     dfx: "_DfxOpts",
-    pto_isa_commit: str | None,
     max_time: int,
     queue_timeout: int,
     device: str = "auto",
@@ -630,9 +622,7 @@ def _run_artifact_via_task_submit(
     card) or a specific id / range (pin to it — used to validate the flow before
     trusting auto-allocation).
     """
-    inner = _build_execute_artifact_cmd(
-        ["--work-dir", str(work_dir), "--platform", platform], dfx, pto_isa_commit
-    )
+    inner = _build_execute_artifact_cmd(["--work-dir", str(work_dir), "--platform", platform], dfx)
     proc, exec_err = _exec_task_submit(inner, device, max_time, queue_timeout, work_dir / "execute.log")
     if proc is None:
         return (False, exec_err, None)
@@ -646,7 +636,6 @@ def _run_batch_via_task_submit(
     manifest_path: Path,
     device: str,
     dfx: "_DfxOpts",
-    pto_isa_commit: str | None,
     max_time: int,
     queue_timeout: int,
 ) -> "dict[str, tuple[bool, str | None, int | None]]":
@@ -663,7 +652,7 @@ def _run_batch_via_task_submit(
         json.dumps([{"work_dir": str(wd), "platform": plat} for wd, plat in entries]),
         encoding="utf-8",
     )
-    inner = _build_execute_artifact_cmd(["--batch-manifest", str(manifest_path)], dfx, pto_isa_commit)
+    inner = _build_execute_artifact_cmd(["--batch-manifest", str(manifest_path)], dfx)
     proc, exec_err = _exec_task_submit(
         inner, device, max_time, queue_timeout, manifest_path.with_suffix(".log")
     )
@@ -879,7 +868,6 @@ def _batch_submitter(batch_size: int, cache_dir: Path) -> None:
         assert _execute_pool is not None, "execute pool not initialised"
         device = _pipeline_ctx.get("task_submit_device", "auto")
         dfx = _pipeline_ctx.get("dfx", _DfxOpts())
-        pto_isa_commit = _pipeline_ctx.get("pto_isa_commit")
         max_time = _pipeline_ctx.get("task_max_time", 600)
         queue_timeout = _pipeline_ctx.get("task_queue_timeout", 1800)
         # A 0 / negative batch size would never fill a batch (``len(pending) >= 0``
@@ -902,7 +890,6 @@ def _batch_submitter(batch_size: int, cache_dir: Path) -> None:
                 manifest_path,
                 device,
                 dfx,
-                pto_isa_commit,
                 batch_max_time,
                 queue_timeout,
             )
@@ -956,7 +943,6 @@ def start_pipeline(  # noqa: PLR0913
     session_platform: str,
     dump_passes: bool,
     codegen_only: bool,
-    pto_isa_commit: str | None,
     compile_workers: int,
     device_pool: "queue.Queue[int]",
     analyze_auto_scopes_for_deps: bool = False,
@@ -998,7 +984,7 @@ def start_pipeline(  # noqa: PLR0913
     if not codegen_only:
         from pypto.runtime.device_runner import ensure_pto_isa_root  # noqa: PLC0415
 
-        ensure_pto_isa_root(commit=pto_isa_commit, clone_protocol="https")
+        ensure_pto_isa_root(clone_protocol="https")
 
     _device_pool = device_pool
     _pipeline_ctx = {
@@ -1006,7 +992,6 @@ def start_pipeline(  # noqa: PLR0913
         "session_platform": session_platform,
         "dump_passes": dump_passes,
         "codegen_only": codegen_only,
-        "pto_isa_commit": pto_isa_commit,
         "analyze_auto_scopes_for_deps": analyze_auto_scopes_for_deps,
         "dfx": _DfxOpts(
             enable_l2_swimlane=enable_l2_swimlane,
@@ -1058,7 +1043,6 @@ def start_pipeline(  # noqa: PLR0913
                 session_platform,
                 dump_passes,
                 analyze_auto_scopes_for_deps,
-                pto_isa_commit,
             )
             _compile_futures[key] = cfut
             group_futs.append(cfut)
@@ -1097,9 +1081,9 @@ def configure_inline_task_submit(
 
     Used when ``--execute-via-task-submit`` is passed *without*
     ``--precompile-workers``: no compile pipeline runs, but ``_run_inline``
-    consults ``_pipeline_ctx`` to decide how to execute.  ``pto_isa_commit`` and
-    DFX still come from the test's ``RunConfig`` on that path, so only the
-    execute-mode toggle and task-submit knobs are stashed here.
+    consults ``_pipeline_ctx`` to decide how to execute. DFX still comes from
+    the test's ``RunConfig`` on that path, so only the execute-mode toggle and
+    task-submit knobs are stashed here.
     """
     _pipeline_ctx["execute_mode"] = "task-submit"
     _pipeline_ctx["task_max_time"] = task_max_time
@@ -1353,9 +1337,7 @@ class TestRunner:
 
             from pypto.runtime.device_runner import compile_and_assemble  # noqa: PLC0415
 
-            chip_callable, runtime_name, _ = compile_and_assemble(
-                work_dir, resolved_platform, pto_isa_commit=self.config.pto_isa_commit
-            )
+            chip_callable, runtime_name, _ = compile_and_assemble(work_dir, resolved_platform)
             # Undiscovered cases (the minority the collection scan can't see)
             # borrow a card via task-submit too, so EVERY device run goes through
             # task-submit's per-card lock. Running these in-process would bypass
@@ -1372,7 +1354,6 @@ class TestRunner:
                     work_dir,
                     resolved_platform,
                     _DfxOpts.from_run_config(self.config),
-                    self.config.pto_isa_commit,
                     _pipeline_ctx.get("task_max_time", 600),
                     _pipeline_ctx.get("task_queue_timeout", 1800),
                     _pipeline_ctx.get("task_submit_device", "auto"),

--- a/tests/st/runtime/cross_core/test_cross_core_grouped_tpop_tfree.py
+++ b/tests/st/runtime/cross_core/test_cross_core_grouped_tpop_tfree.py
@@ -223,9 +223,7 @@ class TestCrossCoreGroupedTpopTfree:
 
             kernel_config = _load_kernel_config(work_dir)
             runtime_cfg = getattr(kernel_config, "RUNTIME_CONFIG", {})
-            chip_callable, runtime_name, _ = compile_and_assemble(
-                work_dir, platform, pto_isa_commit=test_config.pto_isa_commit
-            )
+            chip_callable, runtime_name, _ = compile_and_assemble(work_dir, platform)
 
             for seed in (0, 1, 2):
                 torch.manual_seed(seed)

--- a/tests/st/runtime/test_explicit_dispatch_onboard.py
+++ b/tests/st/runtime/test_explicit_dispatch_onboard.py
@@ -120,7 +120,7 @@ def _pto_isa_root(test_config):
     """
     if str(test_config.platform).endswith("sim"):
         return
-    ensure_pto_isa_root(commit=test_config.pto_isa_commit, clone_protocol="https")
+    ensure_pto_isa_root(clone_protocol="https")
 
 
 @pytest.fixture

--- a/tests/ut/ir/test_compiled_program.py
+++ b/tests/ut/ir/test_compiled_program.py
@@ -574,7 +574,7 @@ class TestCompiledProgramExtraction:
         cc, _, patcher = self._patch_assemble()
         with patcher as mock:
             assert cp.chip_callable is cc
-            mock.assert_called_once_with(tmp_path.resolve(), cp.platform, None)
+            mock.assert_called_once_with(tmp_path.resolve(), cp.platform)
 
     def test_runtime_name_triggers_assemble(self, tmp_path):
         prog = _make_program_with_orchestration()
@@ -605,33 +605,23 @@ class TestCompiledProgramExtraction:
             _ = cp.chip_callable  # repeat
             assert mock.call_count == 1
 
-    def test_load_passes_pto_isa_commit(self, tmp_path):
+    def test_load_eagerly_assembles(self, tmp_path):
         prog = _make_program_with_orchestration()
         cp = CompiledProgram(prog, str(tmp_path))
 
         _, _, patcher = self._patch_assemble()
         with patcher as mock:
-            cp.load(pto_isa_commit="abc1234")
-            mock.assert_called_once_with(tmp_path.resolve(), cp.platform, "abc1234")
+            cp.load()
+            mock.assert_called_once_with(tmp_path.resolve(), cp.platform)
 
-    def test_load_after_first_access_with_commit_raises(self, tmp_path):
-        prog = _make_program_with_orchestration()
-        cp = CompiledProgram(prog, str(tmp_path))
-
-        _, _, patcher = self._patch_assemble()
-        with patcher:
-            _ = cp.chip_callable  # cache warmed
-            with pytest.raises(RuntimeError, match="already loaded"):
-                cp.load(pto_isa_commit="abc1234")
-
-    def test_load_after_first_access_without_commit_is_noop(self, tmp_path):
+    def test_load_after_first_access_is_noop(self, tmp_path):
         prog = _make_program_with_orchestration()
         cp = CompiledProgram(prog, str(tmp_path))
 
         _, _, patcher = self._patch_assemble()
         with patcher as mock:
             _ = cp.chip_callable
-            cp.load()  # no commit override → idempotent
+            cp.load()
             assert mock.call_count == 1
 
     def test_build_orch_args_inplace_returns_full_list(self, tmp_path):
@@ -844,7 +834,7 @@ class TestSubChipCallableExtraction:
         cc = MagicMock(name="sub_chip_callable")
         with _fake_compile_and_assemble((cc, "host_build_graph", {})) as mock:
             assert sub.chip_callable is cc
-            mock.assert_called_once_with(sub.output_dir, sub.platform, None)
+            mock.assert_called_once_with(sub.output_dir, sub.platform)
 
     def test_build_orch_args_routes_through_helper(self, tmp_path):
         sub = self._make_subchip(tmp_path)
@@ -859,14 +849,13 @@ class TestSubChipCallableExtraction:
         assert coerced == [a, b, c]
         assert return_style is False
 
-    def test_load_after_first_access_with_commit_raises(self, tmp_path):
-        """Same guard as on CompiledProgram: cannot re-pin once cached."""
+    def test_load_after_first_access_is_noop(self, tmp_path):
         sub = self._make_subchip(tmp_path)
         cc = MagicMock(name="sub_chip_callable")
-        with _fake_compile_and_assemble((cc, "host_build_graph", {})):
+        with _fake_compile_and_assemble((cc, "host_build_graph", {})) as mock:
             _ = sub.chip_callable  # cache warmed
-            with pytest.raises(RuntimeError, match="already loaded"):
-                sub.load(pto_isa_commit="abc1234")
+            sub.load()
+            assert mock.call_count == 1
 
 
 class TestValidateIr:

--- a/tests/ut/runtime/test_block_dim_plumbing.py
+++ b/tests/ut/runtime/test_block_dim_plumbing.py
@@ -141,7 +141,7 @@ def patched_execute_compiled(tmp_path):
 
     chip_args = MagicMock(name="ChipStorageTaskArgs_instance")
 
-    def _compile_and_assemble(_work_dir, _platform, _commit=None):
+    def _compile_and_assemble(_work_dir, _platform):
         # The third element is the freshly-loaded RUNTIME_CONFIG dict; tests
         # parametrize it via ``patched_execute_compiled_runtime_config``.
         return (

--- a/tests/ut/runtime/test_execute_artifact.py
+++ b/tests/ut/runtime/test_execute_artifact.py
@@ -106,13 +106,10 @@ def test_dfx_flags_parsed_into_dfx_opts(tmp_path):
                 "5",
                 "--enable-dep-gen",
                 "--enable-scope-stats",
-                "--pto-isa-commit",
-                "abc123",
             )
         )
     assert rc == 0
     _, kwargs = run.call_args
-    assert kwargs["pto_isa_commit"] == "abc123"
     assert kwargs["dfx"] == _DfxOpts(
         enable_l2_swimlane=True,
         enable_dump_args=2,
@@ -127,7 +124,6 @@ def test_plain_run_has_default_dfx(tmp_path):
         main(_argv(tmp_path))
     _, kwargs = run.call_args
     assert kwargs["dfx"] == _DfxOpts()
-    assert kwargs["pto_isa_commit"] is None
     # Default (manual repro): validate in-process.
     assert kwargs["validate"] is True
 
@@ -145,8 +141,8 @@ def test_execute_artifact_dir_wires_compile_then_execute(tmp_path, stub_compile_
     chip = object()
     stub_compile_and_assemble.return_value = (chip, "tensormap_and_ringbuffer", {})
     with patch.object(execute_artifact, "_execute_on_device") as exec_on_dev:
-        execute_artifact_dir(tmp_path, "a2a3", 1, pto_isa_commit="deadbeef")
-    stub_compile_and_assemble.assert_called_once_with(tmp_path, "a2a3", pto_isa_commit="deadbeef")
+        execute_artifact_dir(tmp_path, "a2a3", 1)
+    stub_compile_and_assemble.assert_called_once_with(tmp_path, "a2a3")
     args, _ = exec_on_dev.call_args
     # work_dir, golden_path, chip_callable, runtime_name, platform, device_id
     assert args[0] == tmp_path

--- a/tests/ut/runtime/test_pto_isa_resolution.py
+++ b/tests/ut/runtime/test_pto_isa_resolution.py
@@ -12,7 +12,7 @@
 import importlib
 import logging
 import sys
-from types import SimpleNamespace
+from types import ModuleType, SimpleNamespace
 from unittest.mock import Mock
 
 import pytest
@@ -60,6 +60,23 @@ def _configure_existing_clone(device_runner, monkeypatch, tmp_path):
     monkeypatch.delenv("PTO_ISA_ROOT", raising=False)
     monkeypatch.setattr(device_runner, "_get_pto_isa_clone_path", lambda: clone_path)
     return clone_path
+
+
+def test_installed_layout_reads_pin_from_runtime_package(device_runner, monkeypatch, tmp_path):
+    installed_pin = tmp_path / "simpler_setup" / "_assets" / "pto_isa.pin"
+    installed_pin.parent.mkdir(parents=True)
+    installed_pin.write_text(f"{_RUNTIME_PIN}\n", encoding="utf-8")
+    source_pin = tmp_path / "site-packages" / "runtime" / "pto_isa.pin"
+    monkeypatch.setattr(device_runner, "_PTO_ISA_PIN_PATH", source_pin)
+
+    runtime_package = ModuleType("simpler_setup")
+    setattr(runtime_package, "__path__", [])
+    runtime_environment = ModuleType("simpler_setup.environment")
+    setattr(runtime_environment, "PROJECT_ROOT", installed_pin.parent)
+    monkeypatch.setitem(sys.modules, "simpler_setup", runtime_package)
+    monkeypatch.setitem(sys.modules, "simpler_setup.environment", runtime_environment)
+
+    assert device_runner._read_runtime_pto_isa_pin() == _RUNTIME_PIN
 
 
 def test_default_revision_uses_runtime_pin(device_runner, monkeypatch, tmp_path):

--- a/tests/ut/runtime/test_pto_isa_resolution.py
+++ b/tests/ut/runtime/test_pto_isa_resolution.py
@@ -23,6 +23,8 @@ _RUNTIME_PIN = "83d01313d9bfc247c4b7c8bcf969d1019f0d106f"
 @pytest.fixture
 def device_runner(monkeypatch):
     """Import ``device_runner`` without requiring the optional simpler package."""
+    import pypto.runtime as runtime_package  # noqa: PLC0415
+
     fake_kernel_compiler = SimpleNamespace(KernelCompiler=object)
     fake_task_interface = SimpleNamespace(
         CallConfig=object,
@@ -38,6 +40,7 @@ def device_runner(monkeypatch):
 
     module_name = "pypto.runtime.device_runner"
     previous = sys.modules.pop(module_name, None)
+    previous_attribute = getattr(runtime_package, "device_runner", None)
     try:
         module = importlib.import_module(module_name)
         yield module
@@ -45,6 +48,10 @@ def device_runner(monkeypatch):
         sys.modules.pop(module_name, None)
         if previous is not None:
             sys.modules[module_name] = previous
+        if previous_attribute is not None:
+            setattr(runtime_package, "device_runner", previous_attribute)
+        elif hasattr(runtime_package, "device_runner"):
+            delattr(runtime_package, "device_runner")
 
 
 def _configure_existing_clone(device_runner, monkeypatch, tmp_path):
@@ -71,31 +78,18 @@ def test_default_revision_uses_runtime_pin(device_runner, monkeypatch, tmp_path)
     update_latest.assert_not_called()
 
 
-def test_explicit_revision_overrides_runtime_pin(device_runner, monkeypatch, tmp_path):
-    clone_path = _configure_existing_clone(device_runner, monkeypatch, tmp_path)
-    pin_path = tmp_path / "pto_isa.pin"
-    pin_path.write_text(f"{_RUNTIME_PIN}\n")
-    monkeypatch.setattr(device_runner, "_PTO_ISA_PIN_PATH", pin_path)
-    checkout = Mock()
-    monkeypatch.setattr(device_runner, "_checkout_pto_isa_commit", checkout)
-
-    device_runner.ensure_pto_isa_root(commit="explicit-revision")
-
-    checkout.assert_called_once_with(clone_path, "explicit-revision")
-
-
-def test_environment_root_is_checked_out_at_runtime_pin(device_runner, monkeypatch, tmp_path):
+def test_environment_root_is_used_without_checkout(device_runner, monkeypatch, tmp_path):
     pto_isa_root = tmp_path / "external-pto-isa"
-    pin_path = tmp_path / "pto_isa.pin"
-    pin_path.write_text(f"{_RUNTIME_PIN}\n")
     monkeypatch.setenv("PTO_ISA_ROOT", str(pto_isa_root))
-    monkeypatch.setattr(device_runner, "_PTO_ISA_PIN_PATH", pin_path)
     checkout = Mock()
+    read_pin = Mock()
     monkeypatch.setattr(device_runner, "_checkout_pto_isa_commit", checkout)
+    monkeypatch.setattr(device_runner, "_read_runtime_pto_isa_pin", read_pin)
 
     assert device_runner.ensure_pto_isa_root() == str(pto_isa_root)
 
-    checkout.assert_called_once_with(pto_isa_root, _RUNTIME_PIN)
+    checkout.assert_not_called()
+    read_pin.assert_not_called()
 
 
 def test_fresh_clone_checks_out_runtime_pin(device_runner, monkeypatch, tmp_path):
@@ -117,6 +111,17 @@ def test_fresh_clone_checks_out_runtime_pin(device_runner, monkeypatch, tmp_path
     assert device_runner.ensure_pto_isa_root() == str(clone_path.resolve())
 
     checkout.assert_called_once_with(clone_path, _RUNTIME_PIN)
+
+
+def test_checkout_failure_does_not_return_unpinned_managed_clone(device_runner, monkeypatch, tmp_path):
+    _configure_existing_clone(device_runner, monkeypatch, tmp_path)
+    pin_path = tmp_path / "pto_isa.pin"
+    pin_path.write_text(f"{_RUNTIME_PIN}\n", encoding="utf-8")
+    monkeypatch.setattr(device_runner, "_PTO_ISA_PIN_PATH", pin_path)
+    monkeypatch.setattr(device_runner, "_checkout_pto_isa_commit", Mock(return_value=False))
+
+    assert device_runner.ensure_pto_isa_root() is None
+    assert "PTO_ISA_ROOT" not in device_runner.os.environ
 
 
 @pytest.mark.parametrize("pin_contents", [None, ""])

--- a/tests/ut/runtime/test_pto_isa_resolution.py
+++ b/tests/ut/runtime/test_pto_isa_resolution.py
@@ -1,0 +1,145 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Regression tests for managed PTO-ISA revision resolution."""
+
+import importlib
+import logging
+import sys
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+_RUNTIME_PIN = "83d01313d9bfc247c4b7c8bcf969d1019f0d106f"
+
+
+@pytest.fixture
+def device_runner(monkeypatch):
+    """Import ``device_runner`` without requiring the optional simpler package."""
+    fake_kernel_compiler = SimpleNamespace(KernelCompiler=object)
+    fake_task_interface = SimpleNamespace(
+        CallConfig=object,
+        ChipCallable=object,
+        ChipStorageTaskArgs=object,
+        CoreCallable=object,
+        Worker=object,
+        make_tensor_arg=object,
+        scalar_to_uint64=object,
+    )
+    monkeypatch.setitem(sys.modules, "pypto.runtime.kernel_compiler", fake_kernel_compiler)
+    monkeypatch.setitem(sys.modules, "pypto.runtime.task_interface", fake_task_interface)
+
+    module_name = "pypto.runtime.device_runner"
+    previous = sys.modules.pop(module_name, None)
+    try:
+        module = importlib.import_module(module_name)
+        yield module
+    finally:
+        sys.modules.pop(module_name, None)
+        if previous is not None:
+            sys.modules[module_name] = previous
+
+
+def _configure_existing_clone(device_runner, monkeypatch, tmp_path):
+    clone_path = tmp_path / "pto-isa"
+    (clone_path / "include").mkdir(parents=True)
+    monkeypatch.delenv("PTO_ISA_ROOT", raising=False)
+    monkeypatch.setattr(device_runner, "_get_pto_isa_clone_path", lambda: clone_path)
+    return clone_path
+
+
+def test_default_revision_uses_runtime_pin(device_runner, monkeypatch, tmp_path):
+    clone_path = _configure_existing_clone(device_runner, monkeypatch, tmp_path)
+    pin_path = tmp_path / "pto_isa.pin"
+    pin_path.write_text(f"{_RUNTIME_PIN}\n")
+    monkeypatch.setattr(device_runner, "_PTO_ISA_PIN_PATH", pin_path)
+    checkout = Mock()
+    update_latest = Mock()
+    monkeypatch.setattr(device_runner, "_checkout_pto_isa_commit", checkout)
+    monkeypatch.setattr(device_runner, "_update_pto_isa_to_latest", update_latest)
+
+    assert device_runner.ensure_pto_isa_root() == str(clone_path.resolve())
+
+    checkout.assert_called_once_with(clone_path, _RUNTIME_PIN)
+    update_latest.assert_not_called()
+
+
+def test_explicit_revision_overrides_runtime_pin(device_runner, monkeypatch, tmp_path):
+    clone_path = _configure_existing_clone(device_runner, monkeypatch, tmp_path)
+    pin_path = tmp_path / "pto_isa.pin"
+    pin_path.write_text(f"{_RUNTIME_PIN}\n")
+    monkeypatch.setattr(device_runner, "_PTO_ISA_PIN_PATH", pin_path)
+    checkout = Mock()
+    monkeypatch.setattr(device_runner, "_checkout_pto_isa_commit", checkout)
+
+    device_runner.ensure_pto_isa_root(commit="explicit-revision")
+
+    checkout.assert_called_once_with(clone_path, "explicit-revision")
+
+
+def test_environment_root_is_checked_out_at_runtime_pin(device_runner, monkeypatch, tmp_path):
+    pto_isa_root = tmp_path / "external-pto-isa"
+    pin_path = tmp_path / "pto_isa.pin"
+    pin_path.write_text(f"{_RUNTIME_PIN}\n")
+    monkeypatch.setenv("PTO_ISA_ROOT", str(pto_isa_root))
+    monkeypatch.setattr(device_runner, "_PTO_ISA_PIN_PATH", pin_path)
+    checkout = Mock()
+    monkeypatch.setattr(device_runner, "_checkout_pto_isa_commit", checkout)
+
+    assert device_runner.ensure_pto_isa_root() == str(pto_isa_root)
+
+    checkout.assert_called_once_with(pto_isa_root, _RUNTIME_PIN)
+
+
+def test_fresh_clone_checks_out_runtime_pin(device_runner, monkeypatch, tmp_path):
+    clone_path = tmp_path / "pto-isa"
+    pin_path = tmp_path / "pto_isa.pin"
+    pin_path.write_text(f"{_RUNTIME_PIN}\n")
+    monkeypatch.delenv("PTO_ISA_ROOT", raising=False)
+    monkeypatch.setattr(device_runner, "_PTO_ISA_PIN_PATH", pin_path)
+    monkeypatch.setattr(device_runner, "_get_pto_isa_clone_path", lambda: clone_path)
+
+    def clone(*_args):
+        (clone_path / "include").mkdir(parents=True)
+        return True
+
+    monkeypatch.setattr(device_runner, "_clone_pto_isa", clone)
+    checkout = Mock()
+    monkeypatch.setattr(device_runner, "_checkout_pto_isa_commit", checkout)
+
+    assert device_runner.ensure_pto_isa_root() == str(clone_path.resolve())
+
+    checkout.assert_called_once_with(clone_path, _RUNTIME_PIN)
+
+
+@pytest.mark.parametrize("pin_contents", [None, ""])
+def test_unavailable_runtime_pin_falls_back_to_latest(
+    device_runner, monkeypatch, tmp_path, caplog, pin_contents
+):
+    clone_path = _configure_existing_clone(device_runner, monkeypatch, tmp_path)
+    pin_path = tmp_path / "pto_isa.pin"
+    if pin_contents is not None:
+        pin_path.write_text(pin_contents)
+    monkeypatch.setattr(device_runner, "_PTO_ISA_PIN_PATH", pin_path)
+    checkout = Mock()
+    update_latest = Mock()
+    monkeypatch.setattr(device_runner, "_checkout_pto_isa_commit", checkout)
+    monkeypatch.setattr(device_runner, "_update_pto_isa_to_latest", update_latest)
+
+    with caplog.at_level(logging.WARNING):
+        device_runner.ensure_pto_isa_root()
+
+    checkout.assert_not_called()
+    update_latest.assert_called_once_with(clone_path)
+    assert "falling back to the latest remote HEAD" in caplog.text
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/ut/runtime/test_run_config.py
+++ b/tests/ut/runtime/test_run_config.py
@@ -542,11 +542,8 @@ class TestRunConfigCompileForwarding:
     def test_execute_compiled_accepts_auto_scope_deps_switch(self, tmp_path, monkeypatch):
         captured: dict = {}
 
-        def fake_compile_and_assemble(_work_dir, platform, pto_isa_commit):
-            captured["compile"] = {
-                "platform": platform,
-                "pto_isa_commit": pto_isa_commit,
-            }
+        def fake_compile_and_assemble(_work_dir, platform):
+            captured["compile"] = {"platform": platform}
             return object(), "fake_runtime", {}
 
         def fake_execute_on_device(*args, **kwargs):

--- a/tests/ut/runtime/test_task_submit_dispatch.py
+++ b/tests/ut/runtime/test_task_submit_dispatch.py
@@ -100,7 +100,7 @@ def test_task_submit_argv_and_pass(tmp_path):
         return_value=_proc(0, "PYPTO_EXEC_RESULT=PASS device=4\n"),
     ) as run:
         passed, error, device = test_runner._run_artifact_via_task_submit(
-            tmp_path, "a2a3", dfx, "abc123", max_time=600, queue_timeout=1800
+            tmp_path, "a2a3", dfx, max_time=600, queue_timeout=1800
         )
     assert (passed, error, device) == (True, None, 4)
     argv = run.call_args.args[0]
@@ -116,7 +116,6 @@ def test_task_submit_argv_and_pass(tmp_path):
     assert "pypto.runtime.execute_artifact" in run_cmd
     assert "--device-id $TASK_DEVICE" in run_cmd
     assert "--enable-l2-swimlane" in run_cmd
-    assert "--pto-isa-commit abc123" in run_cmd
     # Device run only; the harness validates with the real tolerance afterwards.
     assert "--no-validate" in run_cmd
     # full child output persisted next to the artifact
@@ -129,7 +128,7 @@ def test_task_submit_pins_device_when_requested(tmp_path):
         test_runner.subprocess, "run", return_value=_proc(0, "PYPTO_EXEC_RESULT=PASS device=2\n")
     ) as run:
         passed, _, device = test_runner._run_artifact_via_task_submit(
-            tmp_path, "a2a3", _DfxOpts(), None, 600, 1800, device="2"
+            tmp_path, "a2a3", _DfxOpts(), 600, 1800, device="2"
         )
     assert passed is True
     assert device == 2
@@ -142,7 +141,7 @@ def test_task_submit_real_failure(tmp_path):
         test_runner.subprocess, "run", return_value=_proc(1, "PYPTO_EXEC_RESULT=FAIL\n", "Traceback: boom")
     ):
         passed, error, device = test_runner._run_artifact_via_task_submit(
-            tmp_path, "a2a3", _DfxOpts(), None, 600, 1800
+            tmp_path, "a2a3", _DfxOpts(), 600, 1800
         )
     assert passed is False
     assert device is None
@@ -152,18 +151,14 @@ def test_task_submit_real_failure(tmp_path):
 
 def test_task_submit_queue_timeout_is_distinguished(tmp_path):
     with patch.object(test_runner.subprocess, "run", return_value=_proc(1, "", "")):
-        passed, error, _ = test_runner._run_artifact_via_task_submit(
-            tmp_path, "a2a3", _DfxOpts(), None, 600, 1800
-        )
+        passed, error, _ = test_runner._run_artifact_via_task_submit(tmp_path, "a2a3", _DfxOpts(), 600, 1800)
     assert passed is False
     assert "queue wait timed out" in error
 
 
 def test_task_submit_watchdog_kill_is_distinguished(tmp_path):
     with patch.object(test_runner.subprocess, "run", return_value=_proc(137, "", "")):
-        passed, error, _ = test_runner._run_artifact_via_task_submit(
-            tmp_path, "a2a3", _DfxOpts(), None, 600, 1800
-        )
+        passed, error, _ = test_runner._run_artifact_via_task_submit(tmp_path, "a2a3", _DfxOpts(), 600, 1800)
     assert passed is False
     assert "--max-time" in error
 
@@ -174,9 +169,7 @@ def test_task_submit_exec_failure(tmp_path, exc):
     # not a device test failure — with the "do not pass --execute-via-task-submit"
     # hint so the operator knows to drop the flag on this host.
     with patch.object(test_runner.subprocess, "run", side_effect=exc):
-        passed, error, _ = test_runner._run_artifact_via_task_submit(
-            tmp_path, "a2a3", _DfxOpts(), None, 600, 1800
-        )
+        passed, error, _ = test_runner._run_artifact_via_task_submit(tmp_path, "a2a3", _DfxOpts(), 600, 1800)
     assert passed is False
     assert "do not pass --execute-via-task-submit" in error
 
@@ -229,9 +222,7 @@ def test_batch_argv_and_per_artifact_results(tmp_path):
     # wd2 fails, wd3 has no marker (process died before reaching it).
     stdout = f"PYPTO_EXEC_RESULT=PASS work_dir={wd1} device=2\nPYPTO_EXEC_RESULT=FAIL work_dir={wd2}\n"
     with patch.object(test_runner.subprocess, "run", return_value=_proc(1, stdout, "boom")) as run:
-        results = test_runner._run_batch_via_task_submit(
-            entries, manifest, "auto", _DfxOpts(), "abc123", 600, 1800
-        )
+        results = test_runner._run_batch_via_task_submit(entries, manifest, "auto", _DfxOpts(), 600, 1800)
     # manifest written + batch command shape
     assert json.loads(manifest.read_text()) == [
         {"work_dir": str(wd1), "platform": "a2a3"},
@@ -241,7 +232,6 @@ def test_batch_argv_and_per_artifact_results(tmp_path):
     run_cmd = run.call_args.args[0][-1]
     assert "--batch-manifest" in run_cmd
     assert "--no-validate" in run_cmd
-    assert "--pto-isa-commit abc123" in run_cmd
     # per-artifact verdicts
     assert results[str(wd1)] == (True, None, 2)
     assert results[str(wd2)][0] is False  # FAIL marker
@@ -253,7 +243,7 @@ def test_batch_missing_task_submit(tmp_path):
     entries = [(tmp_path / "a@a2a3", "a2a3")]
     with patch.object(test_runner.subprocess, "run", side_effect=FileNotFoundError):
         results = test_runner._run_batch_via_task_submit(
-            entries, tmp_path / "b.json", "auto", _DfxOpts(), None, 600, 1800
+            entries, tmp_path / "b.json", "auto", _DfxOpts(), 600, 1800
         )
     ok, error, _ = results[str(tmp_path / "a@a2a3")]
     assert ok is False


### PR DESCRIPTION
## Summary

- Use `runtime/pto_isa.pin` as the sole revision source for PyPTO-managed PTO-ISA checkouts; source trees read the submodule pin and installed environments read the copy packaged with `simpler_setup`.
- Remove the `--pto-isa-commit` option and all corresponding public API, artifact CLI, test harness, and CI forwarding paths.
- Leave caller-provided `PTO_ISA_ROOT` untouched, and fail managed resolution if the pinned checkout cannot be verified.
- Add regression coverage and synchronize the English and Chinese ecosystem documentation.

## Testing

- `cmake --build build --parallel`
- Focused runtime/API tests: 449 passed
- `python -m pytest tests/ut/ -n auto --maxprocesses 8 -q` (7310 passed, 2 skipped)
- `ruff check .`
- `ruff format --check .`
- `python tests/lint/check_english_only.py`
- `python tests/lint/check_headers.py`
- Targeted Pyright validation (0 errors)
- Full PR CI, including `system-tests-a5sim`

## Related Issues

Fixes #2086
