### PR TITLE
feat(ir): dispatch-predicate scope form — Phase 3 (`with pl.spmd(predicate=...)`)

### DIFF
--- a/docs/en/dev/language/00-python_syntax.md
+++ b/docs/en/dev/language/00-python_syntax.md
@@ -373,7 +373,7 @@ shape (single kernel call, outlined `pl.at` region, or dependency-only fan-in).
 | `result, tid = pl.submit(kernel, *args, deps=[...], allow_early_resolve=False)` | single kernel call | The trailing `tid` is the producer `pl.Scalar[pl.TASK_ID]`. A parser construct (like `pl.range`), not a runtime function. `allow_early_resolve=True` opts this task in as a speculative early-dispatch producer (lets the scheduler pre-stage its consumers; lowers to `Arg::set_allow_early_resolve(true)`). Also accepts `predicate=(t[i] > 0)` — a dispatch predicate the scheduler evaluates at the dispatch point (see [Dispatch predicate](#dispatch-predicate-predicate)). |
 | `result, tid = pl.spmd_submit(kernel, *args, core_num=N, sync_start=False, deps=[...])` | single SPMD task launch | The SPMD sibling of `pl.submit`: dispatches the kernel across `N` blocks (one orchestration task → one `tid`). `core_num` is a required keyword (positive int expr); `sync_start=True` forces atomic launch of all blocks. Callee may be InCore / AIC / AIV / Group. Records the launch spec on `Submit.core_num` / `Submit.sync_start`. Also accepts `allow_early_resolve=True` (same early-dispatch opt-in as `pl.submit`) and `predicate=(t[i] > 0)` (see [Dispatch predicate](#dispatch-predicate-predicate)). |
 | `with pl.at(level=pl.Level.CORE_GROUP, deps=[...]) as tid:` | outlined `pl.at`-block | The whole block is outlined into an `InCore` kernel + `Submit`; `tid` captures the synthesized Submit's TaskId, usable as a dep for later `pl.submit` / `pl.at` sites. Without `as tid` the outliner synthesizes an unused TaskId Var — deps always travel on `Submit::deps_`. Also accepts `allow_early_resolve=True` (same early-dispatch opt-in as `pl.submit`); it forces the `Submit` shape even without `as tid` and lowers to `Arg::set_allow_early_resolve(true)`. |
-| `with pl.spmd(N, deps=[...]) as tid:` | outlined SPMD dispatch | The SPMD sibling of the `pl.at ... as tid` form. The inline body is auto-outlined into an `InCore` kernel and dispatched across `N` blocks; `tid` captures the grid-wide producer TaskId. `deps=` accepted only with `as tid`. `core_num` / `sync_start` ride on the outlined `Spmd` Function attrs (the lowered `Submit.core_num` is `None`); codegen reads them via the launch-function fallback. Also accepts `allow_early_resolve=True` (same early-dispatch opt-in as `pl.submit` / `pl.at`; valid on all three `pl.spmd` forms, forcing the `Submit` shape even without `as tid`). Cannot nest inside `pl.cluster()`. |
+| `with pl.spmd(N, deps=[...]) as tid:` | outlined SPMD dispatch | The SPMD sibling of the `pl.at ... as tid` form. The inline body is auto-outlined into an `InCore` kernel and dispatched across `N` blocks; `tid` captures the grid-wide producer TaskId. `deps=` accepted only with `as tid`. `core_num` / `sync_start` ride on the outlined `Spmd` Function attrs (the lowered `Submit.core_num` is `None`); codegen reads them via the launch-function fallback. Also accepts `allow_early_resolve=True` (same early-dispatch opt-in as `pl.submit` / `pl.at`; valid on all three `pl.spmd` forms, forcing the `Submit` shape even without `as tid`) and `predicate=(t[i] > 0)` (see [Dispatch predicate](#dispatch-predicate-predicate); also valid on all three forms and also forces the `Submit` shape). Cannot nest inside `pl.cluster()`. |
 | `barrier = pl.system.task_dummy(deps=[...])` | dependency-only barrier | Submits no kernel. The returned TaskId is a compact fan-in point for later `deps=[barrier]`. |
 | `None` (Python literal) | seed / dep entry | The "no producer yet" sentinel. `prev_tid = None` seeds a TaskId loop iter_arg; `None` in `deps=[None]` is dropped (contributes no edge). Lowers to `system.task_invalid` → `PTO2TaskId::invalid()`. |
 
@@ -532,10 +532,6 @@ comparisons (`0 < t[i] < 8`), arithmetic (`t[i] % 8 == 0`), boolean combination
 all rejected at parse time; reduce anything richer to a single gate value in a
 prior kernel and predicate on that.
 
-**Scope:** `predicate=` is on `pl.submit` / `pl.spmd_submit` only (the
-direct-`Submit` forms). The `with pl.spmd(predicate=...)` scope form is not yet
-supported.
-
 ```python
 with pl.manual_scope():
     rc, g_tid = pl.spmd_submit(self.gate, rc, core_num=1)       # producer of rc
@@ -545,6 +541,46 @@ with pl.manual_scope():
         predicate=(rc[0, 0] > 0),
     )
 ```
+
+**Scope:** `predicate=` is accepted on `pl.submit` / `pl.spmd_submit` (the
+direct-`Submit` forms) and on the `with pl.spmd(...)` scope form — all three
+spmd spellings (plain `with`, `with ... as tid`, and `for i in pl.spmd(...)`).
+It is not accepted on `pl.at(...)`.
+
+##### Scope form
+
+The scope form takes the same expression and the same validation; it differs
+only in how the predicate reaches the IR. It rides on `SpmdScopeStmt.attrs`
+until the scope is outlined, at which point it moves onto `Submit.predicate` —
+so the lowering, the codegen output, and the contract are identical.
+
+```python
+with pl.spmd(1) as g_tid:                                       # producer of rc
+    rc = self.gate(rc)
+
+with pl.spmd(4, deps=[g_tid], predicate=(rc[0, 0] > 0)) as tid:  # producer is a dep
+    out = self.expert(x, out)
+```
+
+Two things follow from that route:
+
+- **`deps=` needs the `as tid` form.** `deps=` is only accepted on
+  `with pl.spmd(...) as tid:`. A predicate over a tensor produced elsewhere in
+  the same function therefore needs that form — the plain `with` and `for`
+  forms can only carry a predicate over a tensor with no in-function producer
+  (typically a function parameter), which the contract check permits.
+- **No `as tid` is required otherwise.** Like `allow_early_resolve=True`, a
+  predicate forces the scope to lower to a `Submit`; when the scope has no
+  `as tid` the outliner synthesises an unused TaskId Var.
+
+A cluster-nested `pl.spmd` is unwrapped into the Group function and never
+produces a `Submit`, so `predicate=` (like `allow_early_resolve=`) is rejected
+there at parse time rather than silently dropped.
+
+The contract check covers scope producers too: a tensor assigned inside a
+`with pl.spmd(...) as tid:` body is recorded as produced by that scope, so
+omitting it from a later `deps=` is rejected. The same best-effort limits in the
+table above still apply (aliases, intervening calls, `Array[N, TASK_ID]` deps).
 
 #### `pl.parallel` under manual scope: array-carry fence
 

--- a/docs/zh-cn/dev/language/00-python_syntax.md
+++ b/docs/zh-cn/dev/language/00-python_syntax.md
@@ -368,7 +368,7 @@ DSL 暴露**两套正交的机制**，用户可任意组合：
 | `result, tid = pl.submit(kernel, *args, deps=[...], allow_early_resolve=False)` | 单个 kernel 调用 | 尾部 `tid` 是 producer `pl.Scalar[pl.TASK_ID]`。它是 parser construct（类似 `pl.range`），不是 runtime 函数。`allow_early_resolve=True` 将该 task 标记为推测式 early-dispatch producer（让调度器提前预置其 consumer；lower 为 `Arg::set_allow_early_resolve(true)`）。同样接受 `predicate=(t[i] > 0)` —— 调度器在 dispatch 点求值的调度谓词（参见[调度谓词](#调度谓词predicate)）。 |
 | `result, tid = pl.spmd_submit(kernel, *args, core_num=N, sync_start=False, deps=[...])` | 单个 SPMD task launch | `pl.submit` 的 SPMD 版本：将 kernel 在 `N` 个 block 上分发（一个 orchestration task → 一个 `tid`）。`core_num` 是必填关键字参数（正整数表达式）；`sync_start=True` 强制所有 block 原子启动。callee 可以是 InCore / AIC / AIV / Group。launch spec 记录在 `Submit.core_num` / `Submit.sync_start` 上。同样接受 `allow_early_resolve=True`（与 `pl.submit` 相同的 early-dispatch 选项）和 `predicate=(t[i] > 0)`（参见[调度谓词](#调度谓词predicate)）。 |
 | `with pl.at(level=pl.Level.CORE_GROUP, deps=[...]) as tid:` | outlined `pl.at`-块 | 整块被 outline 成 InCore kernel + `Submit`；`tid` 捕获被合成的 Submit 的 TaskId，可作为后续 `pl.submit` / `pl.at` 的 dep。不写 `as tid` 时 outliner 会合成一个未使用的 TaskId Var——deps 始终走 `Submit::deps_`。同样接受 `allow_early_resolve=True`（与 `pl.submit` 相同的 early-dispatch 选项）；即使不写 `as tid` 也会强制走 `Submit` 形态，并 lower 为 `Arg::set_allow_early_resolve(true)`。 |
-| `with pl.spmd(N, deps=[...]) as tid:` | outlined SPMD 分发 | `pl.at ... as tid` 形式的 SPMD 版本。内联 body 自动外包成 InCore kernel 并在 `N` 个 block 上分发；`tid` 捕获 grid 级 producer TaskId。`deps=` 仅在带 `as tid` 时可用。`core_num` / `sync_start` 记录在外包出的 `Spmd` Function attrs 上（lower 出的 `Submit.core_num` 为 `None`）；codegen 通过 launch-function 回退读取。同样接受 `allow_early_resolve=True`（与 `pl.submit` / `pl.at` 相同的 early-dispatch 选项；`pl.spmd` 三种形式均可用，即使不写 `as tid` 也会强制走 `Submit` 形态）。不能嵌套在 `pl.cluster()` 内。 |
+| `with pl.spmd(N, deps=[...]) as tid:` | outlined SPMD 分发 | `pl.at ... as tid` 形式的 SPMD 版本。内联 body 自动外包成 InCore kernel 并在 `N` 个 block 上分发；`tid` 捕获 grid 级 producer TaskId。`deps=` 仅在带 `as tid` 时可用。`core_num` / `sync_start` 记录在外包出的 `Spmd` Function attrs 上（lower 出的 `Submit.core_num` 为 `None`）；codegen 通过 launch-function 回退读取。同样接受 `allow_early_resolve=True`（与 `pl.submit` / `pl.at` 相同的 early-dispatch 选项；`pl.spmd` 三种形式均可用，即使不写 `as tid` 也会强制走 `Submit` 形态）和 `predicate=(t[i] > 0)`（参见[调度谓词](#调度谓词predicate)；同样三种形式均可用，同样强制走 `Submit` 形态）。不能嵌套在 `pl.cluster()` 内。 |
 | `barrier = pl.system.task_dummy(deps=[...])` | dependency-only barrier | 不提交 kernel。返回的 TaskId 是一个紧凑的 fan-in 点，可供后续 `deps=[barrier]` 使用。 |
 | `None`（Python 字面量） | 种子 / dep 条目 | "暂无 producer" 的哨兵。`prev_tid = None` 用作 TaskId 循环 iter_arg 的种子；`deps=[None]` 中的 `None` 被丢弃（不贡献任何边）。下沉为 `system.task_invalid` → `PTO2TaskId::invalid()`。 |
 
@@ -510,9 +510,6 @@ parser 只做**尽力而为的抽查**，不是保证:它记录 `pl.submit(...)`
 （`a[0] > 0 and b[0] > 0`）、以及非字面量的右侧（`t[i] > u[i]`）都会在解析期被拒绝；
 请在前序 kernel 里把它们归约成一个 gate 值，再对该值做谓词。
 
-**范围：** `predicate=` 仅在 `pl.submit` / `pl.spmd_submit`（直接产 `Submit` 的形式）上。
-`with pl.spmd(predicate=...)` 作用域形式尚未支持。
-
 ```python
 with pl.manual_scope():
     rc, g_tid = pl.spmd_submit(self.gate, rc, core_num=1)       # rc 的 producer
@@ -522,6 +519,40 @@ with pl.manual_scope():
         predicate=(rc[0, 0] > 0),
     )
 ```
+
+**范围：** `predicate=` 可用于 `pl.submit` / `pl.spmd_submit`（直接产 `Submit` 的形式），
+以及 `with pl.spmd(...)` 作用域形式的全部三种写法（普通 `with`、`with ... as tid`、
+`for i in pl.spmd(...)`）。`pl.at(...)` 不接受该参数。
+
+##### 作用域形式
+
+作用域形式使用相同的表达式与相同的校验，区别只在于谓词进入 IR 的路径：它先挂在
+`SpmdScopeStmt.attrs` 上，直到该作用域被 outline 时才移动到 `Submit.predicate`。
+因此 lowering、codegen 产物与契约都完全一致。
+
+```python
+with pl.spmd(1) as g_tid:                                        # rc 的 producer
+    rc = self.gate(rc)
+
+with pl.spmd(4, deps=[g_tid], predicate=(rc[0, 0] > 0)) as tid:  # producer 是依赖
+    out = self.expert(x, out)
+```
+
+由这条路径引出两点：
+
+- **`deps=` 需要 `as tid` 形式。** `deps=` 只在 `with pl.spmd(...) as tid:` 上被接受。
+  因此，若谓词读取的张量由同一函数内的其他任务产出，就必须用该形式；普通 `with` 与
+  `for` 形式只能对没有函数内 producer 的张量（通常是函数参数）加谓词——这种情况契约
+  检查会放行。
+- **其余情况不要求 `as tid`。** 与 `allow_early_resolve=True` 一样，谓词会强制该作用域
+  lower 为 `Submit`；当作用域没有 `as tid` 时，outliner 会合成一个未被使用的 TaskId Var。
+
+嵌套在 `pl.cluster()` 内的 `pl.spmd` 会被展开进 Group 函数、永远不会产生 `Submit`，
+因此 `predicate=`（与 `allow_early_resolve=` 一样）会在解析期被拒绝，而不是被静默丢弃。
+
+契约检查同样覆盖作用域 producer：在 `with pl.spmd(...) as tid:` 体内被赋值的张量会被记录
+为该作用域的产物，所以后续 `deps=` 漏写它会被拒绝。上表中列出的 best-effort 限制
+（别名、中间调用、`Array[N, TASK_ID]` 依赖）依然适用。
 
 #### Manual scope 下的 `pl.parallel`：array-carry fence
 

--- a/include/pypto/ir/expr.h
+++ b/include/pypto/ir/expr.h
@@ -844,6 +844,32 @@ inline std::vector<std::pair<std::string, std::any>> WithDumpVarsAttr(
 inline constexpr const char* kAttrDevice = "device";
 
 /**
+ * @brief Reserved attr key for a dispatch predicate — ``predicate=(t[i] > 0)``.
+ *
+ * Value type: ``ExprPtr`` — the comparison Expr as written (e.g.
+ * ``Gt(Cast(tensor.read(rc, [0, 0])), 0)``). Unlike ``kAttrTaskIdVar`` /
+ * ``kAttrDumpVars`` (``VarPtr`` shapes), this attr holds a whole expression
+ * tree, so every attr walker must recurse into it rather than remap a Var.
+ *
+ * Two carriers, one meaning:
+ *
+ * * On a ``SpmdScopeStmt`` — written by the parser for
+ *   ``with pl.spmd(..., predicate=(...)):``. The scope outlines into a
+ *   ``Submit`` only at ``OutlineSpmdScopes``, so the predicate rides here
+ *   across ``ConvertToSSA``; ``ScopeOutliner`` then moves it into
+ *   ``Submit::predicate_`` and the attr disappears.
+ * * On a ``Call`` — only ever the transient ``SubmitToCallView``
+ *   projection of ``Submit::predicate_``, so orchestration codegen can read
+ *   the predicate off the Call view. On a ``Submit`` the *field* is the single
+ *   source of truth; the view drops any stray attr of this key.
+ *
+ * SSA passes MUST substitute ``Var`` references inside this attr's value —
+ * the operand tensor and its index Vars are live SSA values. See
+ * ``kAttrDevice`` for the same requirement on the Call side.
+ */
+inline constexpr const char* kAttrPredicate = "predicate";
+
+/**
  * @brief Task-launch expression — ``pl.submit(self.kernel, args, deps=[...])``
  *
  * Produced by ``pl.submit(...)`` inside a ``pl.manual_scope`` body.
@@ -1114,7 +1140,7 @@ inline CallPtr SubmitToCallView(const SubmitPtr& submit) {
     // the same key so the field stays the single source of truth (Call::GetAttr
     // returns the first match, so a stale attr would otherwise shadow it).
     if (k != kAttrManualDepEdges && k != "core_num" && k != "sync_start" && k != "allow_early_resolve" &&
-        k != "predicate") {
+        k != kAttrPredicate) {
       attrs.emplace_back(k, v);
     }
   }
@@ -1172,7 +1198,7 @@ inline CallPtr SubmitToCallView(const SubmitPtr& submit) {
   // filters them explicitly; ``core_num`` / ``sync_start`` /
   // ``allow_early_resolve`` need the same care.
   if (submit->predicate_.has_value()) {
-    attrs.emplace_back("predicate", std::any(*submit->predicate_));
+    attrs.emplace_back(kAttrPredicate, std::any(*submit->predicate_));
   }
   return std::make_shared<Call>(submit->op_, submit->args_, submit->kwargs_, std::move(attrs),
                                 submit->GetType(), submit->span_);

--- a/include/pypto/ir/transforms/base/visitor.h
+++ b/include/pypto/ir/transforms/base/visitor.h
@@ -106,10 +106,25 @@ class IRVisitor : public IRFunctor<void> {
   void VisitStmt_(const HierarchyScopeStmtPtr& op) override;
 
   /// Visit Var-typed entries in a ScopeStmt's ``attrs_``
-  /// (``manual_dep_edges`` / ``task_id_var`` / ``arg_direction_overrides_vars``).
-  /// Called from the per-subclass visitors so analyses (unused-var detection,
-  /// SSA Var liveness) see Var refs stashed on the scope.
+  /// (``manual_dep_edges`` / ``task_id_var`` / ``arg_direction_overrides_vars``),
+  /// plus the Expr-valued ``predicate`` attr. Called from the per-subclass
+  /// visitors so analyses (unused-var detection, SSA Var liveness) see Var refs
+  /// stashed on the scope.
   void VisitScopeAttrs(const ScopeStmtPtr& op);
+
+  /// Per-attr opt-out consulted by ``VisitScopeAttrs``. Returning false skips
+  /// that key only; the rest of the walk is unchanged, so a subclass never
+  /// needs to restate the base's key handling (and cannot silently miss a key
+  /// added to it later).
+  ///
+  /// ``NoNestedCall`` returns false for ``kAttrPredicate``: that value is a
+  /// declarative comparison spec the scheduler evaluates at the dispatch
+  /// point, not an expression this program evaluates, so the three-address-code
+  /// invariant does not apply to it.
+  [[nodiscard]] virtual bool ShouldVisitScopeAttr(const std::string& key) const {
+    (void)key;
+    return true;
+  }
   void VisitStmt_(const SpmdScopeStmtPtr& op) override;
   void VisitStmt_(const SplitAivScopeStmtPtr& op) override;
   void VisitStmt_(const RuntimeScopeStmtPtr& op) override;

--- a/include/pypto/ir/transforms/base/visitor.h
+++ b/include/pypto/ir/transforms/base/visitor.h
@@ -12,6 +12,8 @@
 #ifndef PYPTO_IR_TRANSFORMS_BASE_VISITOR_H_
 #define PYPTO_IR_TRANSFORMS_BASE_VISITOR_H_
 
+#include <string>
+
 #include "pypto/ir/expr.h"
 #include "pypto/ir/function.h"
 #include "pypto/ir/memref.h"
@@ -121,10 +123,7 @@ class IRVisitor : public IRFunctor<void> {
   /// declarative comparison spec the scheduler evaluates at the dispatch
   /// point, not an expression this program evaluates, so the three-address-code
   /// invariant does not apply to it.
-  [[nodiscard]] virtual bool ShouldVisitScopeAttr(const std::string& key) const {
-    (void)key;
-    return true;
-  }
+  [[nodiscard]] virtual bool ShouldVisitScopeAttr(const std::string& /*key*/) const { return true; }
   void VisitStmt_(const SpmdScopeStmtPtr& op) override;
   void VisitStmt_(const SplitAivScopeStmtPtr& op) override;
   void VisitStmt_(const RuntimeScopeStmtPtr& op) override;

--- a/include/pypto/ir/transforms/utils/scope_outline_utils.h
+++ b/include/pypto/ir/transforms/utils/scope_outline_utils.h
@@ -1009,14 +1009,21 @@ class ScopeOutliner : public IRMutator {
     // Threaded onto the synthesised Submit below — same hint as
     // ``pl.submit(..., allow_early_resolve=True)``.
     bool scope_allow_early_resolve = op->GetAttr<bool>("allow_early_resolve", false);
+    // Dispatch predicate (``with pl.spmd(..., predicate=(t[i] > 0)):``). Rides
+    // on the scope from parse through SSA (which versions the Vars inside it);
+    // moved onto ``Submit::predicate_`` below, after which the attr is gone —
+    // the field is the single source of truth, so it is deliberately NOT copied
+    // into ``submit_attrs``.
+    ExprPtr scope_predicate = op->GetAttr<ExprPtr>(kAttrPredicate, nullptr);
 
-    // Dependency edges (or an early-resolve flag) force the Submit shape: deps
-    // live in the typed ``Submit::deps_`` field and the flag in
-    // ``Submit::allow_early_resolve_`` — neither has a plain-Call carrier. A
-    // scope written without ``as tid`` gets a synthetic (unused) TaskId Var; DCE
-    // keeps the Submit itself alive (task launches are effectful) and codegen
-    // skips the unconsumed trailing tuple element.
-    if ((!scope_dep_edges.empty() || scope_allow_early_resolve) && !scope_task_id_var) {
+    // Dependency edges (or an early-resolve flag, or a dispatch predicate)
+    // force the Submit shape: deps live in the typed ``Submit::deps_`` field,
+    // the flag in ``Submit::allow_early_resolve_`` and the predicate in
+    // ``Submit::predicate_`` — none has a plain-Call carrier. A scope written
+    // without ``as tid`` gets a synthetic (unused) TaskId Var; DCE keeps the
+    // Submit itself alive (task launches are effectful) and codegen skips the
+    // unconsumed trailing tuple element.
+    if ((!scope_dep_edges.empty() || scope_allow_early_resolve || scope_predicate) && !scope_task_id_var) {
       scope_task_id_var = std::make_shared<Var>(GenerateFreshSSAName("tid"),
                                                 std::make_shared<ScalarType>(DataType::TASK_ID), op->span_);
       var_types_[scope_task_id_var.get()] = scope_task_id_var->GetType();
@@ -1131,7 +1138,8 @@ class ScopeOutliner : public IRMutator {
           global_var, call_args, std::move(submit_deps), std::vector<std::pair<std::string, std::any>>{},
           std::move(submit_attrs), call_return_type ? call_return_type : std::make_shared<UnknownType>(),
           op->span_, /*core_num=*/std::nullopt, /*sync_start=*/false,
-          /*allow_early_resolve=*/scope_allow_early_resolve);
+          /*allow_early_resolve=*/scope_allow_early_resolve,
+          /*predicate=*/scope_predicate ? std::optional<ExprPtr>(scope_predicate) : std::nullopt);
     } else {
       std::vector<std::pair<std::string, std::any>> call_attrs;
       // ``dump_vars`` first — see the Submit branch above for the ordering

--- a/python/pypto/language/dsl_api.py
+++ b/python/pypto/language/dsl_api.py
@@ -659,6 +659,7 @@ class SpmdContext:
         optimizations: list[Optimization] | None = None,
         deps: list[Any] | None = None,
         allow_early_resolve: bool = False,
+        predicate: Any = None,
     ) -> None:
         self.core_num = core_num
         self.sync_start = sync_start
@@ -666,6 +667,7 @@ class SpmdContext:
         self.optimizations = optimizations
         self.deps = deps
         self.allow_early_resolve = allow_early_resolve
+        self.predicate = predicate
 
     def __enter__(self) -> Any:
         # The parser intercepts the ``with pl.spmd(...) [as tid]:`` pattern and
@@ -702,6 +704,7 @@ def spmd(
     optimizations: list[Optimization] | None = None,
     deps: list[Any] | None = None,
     allow_early_resolve: bool = False,
+    predicate: Any = None,
 ) -> SpmdContext:
     """Dispatch a kernel with SPMD (Single Program Multiple Data) multi-block execution.
 
@@ -760,6 +763,26 @@ def spmd(
             hint. Rejected on a ``pl.cluster()``-nested ``pl.spmd`` (such a scope
             is unwrapped into the Group function and never produces a Submit, so
             the hint would be lost).
+        predicate: Optional **dispatch predicate** — a single comparison of one
+            tensor element against an integer literal, e.g.
+            ``predicate=(row_count[e] > 0)``. Same surface, validation and
+            lowering as ``pl.spmd_submit(..., predicate=...)``: the scheduler
+            evaluates it at the dispatch point (after this scope's dependencies
+            are satisfied, so the value is current) and retires the task inline —
+            never dispatching it to a core — when it is false, while still
+            settling fanin/fanout so downstream consumers unlock. The comparison
+            is parsed but **never evaluated** in orchestration; reading it there
+            would stall on ``wait_for_tensor_ready``, exactly what the predicate
+            avoids. Like ``allow_early_resolve`` it forces the dispatch to lower
+            to an ``ir.Submit`` (even without ``as tid``) and is rejected on a
+            ``pl.cluster()``-nested ``pl.spmd``.
+
+            **Contract:** the operand tensor's producing task must be one of
+            ``deps=`` — otherwise the predicate may read a stale value. ``deps=``
+            is only available on the ``as tid`` form, so a predicate over a
+            tensor produced in the same function needs that form. The parser
+            makes a best-effort check (see ``pl.spmd_submit``); getting ``deps=``
+            right remains the author's responsibility.
 
     Returns:
         Context manager / loop iterator for the SPMD scope.
@@ -801,6 +824,12 @@ def spmd(
         >>> with pl.cluster():
         ...     with pl.spmd(4, sync_start=True):
         ...         out = self.kernel(a, b, out)
+        >>>
+        >>> # Dispatch predicate — skip the expert entirely when its row count is 0
+        >>> with pl.spmd(1) as gate_tid:
+        ...     row_count = self.gate(row_count)
+        >>> with pl.spmd(4, deps=[gate_tid], predicate=(row_count[0, 0] > 0)) as tid:
+        ...     out = self.expert(x, out)
     """
     if isinstance(core_num, bool) or not isinstance(core_num, (int, _ir.Expr)):
         raise ValueError(f"core_num must be a positive integer or ir.Expr, got {core_num!r}")
@@ -813,6 +842,7 @@ def spmd(
         optimizations=optimizations,
         deps=deps,
         allow_early_resolve=allow_early_resolve,
+        predicate=predicate,
     )
 
 

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -3594,15 +3594,18 @@ class ASTParser:
         *,
         usage_hint: str,
         allow_deps: bool = False,
-    ) -> tuple["ir.Expr", bool, str, "ir.SplitMode | None", "int | None", "list[ir.Var]", bool]:
+    ) -> tuple[
+        "ir.Expr", bool, str, "ir.SplitMode | None", "int | None", "list[ir.Var]", bool, "ir.Expr | None"
+    ]:
         """Parse the ``pl.spmd(core_num, *, sync_start=, name_hint=, optimizations=, deps=, ...)`` arguments.
 
         Also accepts ``allow_early_resolve=`` (the speculative early-dispatch
-        hint). The first positional argument is ``core_num`` (range-like). Returns
+        hint) and ``predicate=`` (the dispatch predicate). The first positional
+        argument is ``core_num`` (range-like). Returns
         ``(core_num, sync_start, name_hint, split_mode, split_slot_num, dep_vars,
-        allow_early_resolve)`` with ``sync_start`` / ``allow_early_resolve``
-        defaulting to ``False``, ``split_mode`` / ``split_slot_num`` to ``None``,
-        and ``dep_vars`` to ``[]``.
+        allow_early_resolve, predicate)`` with ``sync_start`` /
+        ``allow_early_resolve`` defaulting to ``False``, ``split_mode`` /
+        ``split_slot_num`` / ``predicate`` to ``None``, and ``dep_vars`` to ``[]``.
 
         ``optimizations=[...]`` accepts only ``pl.split(MODE)`` — see
         :meth:`_parse_spmd_optimizations_list`.
@@ -3617,6 +3620,15 @@ class ASTParser:
         (same as ``pl.submit`` / ``pl.at``); it is always accepted here (it needs
         no ``as tid``), and a cluster-nesting guard at the call site rejects it
         when the dispatch would be unwrapped into a Group function.
+
+        ``predicate=(t[i] > 0)`` is a dispatch predicate — the same surface and
+        the same validation as ``pl.spmd_submit(..., predicate=)``, shared via
+        :meth:`_parse_submit_predicate_kwarg`. It rides on the ``SpmdScopeStmt``
+        until ``OutlineSpmdScopes`` moves it onto the synthesised ``Submit``.
+        Like ``allow_early_resolve`` it needs no ``as tid`` (the outliner
+        synthesises a TaskId Var when the scope has none) and is rejected by the
+        same cluster-nesting guard. The producer-in-``deps=`` contract is checked
+        below, once ``dep_vars`` is resolved.
         """
         if len(call.args) > 1:
             raise ParserSyntaxError(
@@ -3633,6 +3645,7 @@ class ASTParser:
         split_slot_num: int | None = None
         deps_kw: ast.keyword | None = None
         allow_early_resolve: bool = False
+        predicate: ir.Expr | None = None
         for kw in call.keywords:
             if kw.arg is None:
                 # `pl.spmd(**cfg)` — ast.keyword.arg is None for **kwargs unpacking.
@@ -3668,13 +3681,17 @@ class ASTParser:
                 deps_kw = kw
             elif kw.arg == "allow_early_resolve":
                 allow_early_resolve = self._parse_spmd_bool_literal_kwarg(kw, usage_hint)
+            elif kw.arg == "predicate":
+                # Not a bool literal — parsed as an ordinary expression and
+                # shape-validated, exactly as on pl.spmd_submit.
+                predicate = self._parse_submit_predicate_kwarg("pl.spmd()", [kw])
             else:
                 supported = (
                     "Supported keywords: 'sync_start', 'name_hint', 'optimizations', 'deps', "
-                    "'allow_early_resolve'"
+                    "'allow_early_resolve', 'predicate'"
                     if allow_deps
                     else "Supported keywords: 'sync_start', 'name_hint', 'optimizations', "
-                    "'allow_early_resolve'"
+                    "'allow_early_resolve', 'predicate'"
                 )
                 raise ParserSyntaxError(
                     f"pl.spmd() got unexpected keyword argument '{kw.arg}'",
@@ -3691,26 +3708,57 @@ class ASTParser:
         if deps_kw is not None:
             anchor_span = self.span_tracker.get_span(anchor)
             dep_vars = self._parse_submit_deps_kwarg("pl.spmd()", [deps_kw], anchor_span)
-        return core_num, sync_start, name_hint, split_mode, split_slot_num, dep_vars, allow_early_resolve
-
-    def _reject_spmd_early_resolve_in_cluster(self, allow_early_resolve: bool, span: "ir.Span") -> None:
-        """Reject ``allow_early_resolve=True`` on a ``pl.cluster()``-nested ``pl.spmd``.
-
-        A cluster-nested Spmd scope is unwrapped into the Group function by
-        ``OutlineClusterScopes`` (``UnwrapNestedSpmd``) and never lowers to a
-        ``Submit``, so the early-dispatch hint would be silently dropped. Raise a
-        clear parse-time error instead, mirroring the ``as tid`` cluster rejection
-        in :meth:`_parse_spmd_scope_with_tid`.
-        """
-        if allow_early_resolve and self._is_inside_scope(ir.ScopeKind.Cluster):
-            raise ParserSyntaxError(
-                "`pl.spmd(..., allow_early_resolve=True)` cannot be nested inside `pl.cluster()` — "
-                "a cluster-nested pl.spmd is unwrapped into the Group function and never produces a "
-                "Submit, so the early-dispatch hint would be lost.",
-                span=span,
-                hint="Use a standalone `with pl.spmd(..., allow_early_resolve=True):` (implicit "
-                "cluster) to keep the hint.",
+        # Producer-in-deps contract, checked once dep_vars is known. Same
+        # best-effort spot check as pl.spmd_submit: the scheduler reads the
+        # operand at the dispatch point, so its producing task must be a
+        # dependency or the read may observe a stale value. On the plain /
+        # for-forms deps= is unavailable, so a tracked producer reports here and
+        # the error steers the author to the ``as tid`` form.
+        if predicate is not None:
+            self._validate_predicate_deps(
+                "pl.spmd()", predicate, dep_vars, self.span_tracker.get_span(anchor)
             )
+        return (
+            core_num,
+            sync_start,
+            name_hint,
+            split_mode,
+            split_slot_num,
+            dep_vars,
+            allow_early_resolve,
+            predicate,
+        )
+
+    def _reject_spmd_submit_only_kwargs_in_cluster(
+        self, allow_early_resolve: bool, predicate: "ir.Expr | None", span: "ir.Span"
+    ) -> None:
+        """Reject Submit-only ``pl.spmd()`` kwargs on a ``pl.cluster()``-nested scope.
+
+        Covers ``allow_early_resolve=True`` and ``predicate=(...)``: both are
+        carried by ``Submit`` fields with no plain-``Call`` equivalent. A
+        cluster-nested Spmd scope is unwrapped into the Group function by
+        ``OutlineClusterScopes`` (``UnwrapNestedSpmd``) and never lowers to a
+        ``Submit``, so either would be silently dropped. Raise a clear parse-time
+        error instead, mirroring the ``as tid`` cluster rejection in
+        :meth:`_parse_spmd_scope_with_tid`. ``UnwrapNestedSpmd`` re-asserts this
+        for hand-built / deserialized IR.
+        """
+        if not self._is_inside_scope(ir.ScopeKind.Cluster):
+            return
+        # Report the kwarg the user actually wrote, so the message names it.
+        if allow_early_resolve:
+            kwarg, lost = "allow_early_resolve=True", "the early-dispatch hint"
+        elif predicate is not None:
+            kwarg, lost = "predicate=(...)", "the dispatch predicate"
+        else:
+            return
+        raise ParserSyntaxError(
+            f"`pl.spmd(..., {kwarg})` cannot be nested inside `pl.cluster()` — "
+            "a cluster-nested pl.spmd is unwrapped into the Group function and never produces a "
+            f"Submit, so {lost} would be lost.",
+            span=span,
+            hint=f"Use a standalone `with pl.spmd(..., {kwarg}):` (implicit cluster) to keep it.",
+        )
 
     @staticmethod
     def _spmd_body_reads_block_idx(body: "list[ast.stmt]") -> bool:
@@ -3879,6 +3927,7 @@ class ASTParser:
             split_slot_num,
             dep_vars,
             allow_early_resolve,
+            predicate,
         ) = self._parse_spmd_kwargs(
             stmt, context_expr, usage_hint=with_hint, allow_deps=optional_vars is not None
         )
@@ -3897,18 +3946,25 @@ class ASTParser:
                 split_slot_num,
                 dep_vars,
                 allow_early_resolve,
+                predicate,
                 optional_vars,
             )
             return
 
         # ``allow_early_resolve`` opts the grid dispatch into speculative
-        # early-dispatch (mirrors pl.submit / pl.at). A cluster-nested pl.spmd is
+        # early-dispatch and ``predicate`` gates it at the dispatch point (both
+        # mirror pl.submit / pl.spmd_submit). A cluster-nested pl.spmd is
         # unwrapped into the Group function by OutlineClusterScopes and never
-        # lowers to a Submit, so the hint would be silently dropped — reject it
+        # lowers to a Submit, so either would be silently dropped — reject them
         # here (mirrors the ``as tid`` cluster rejection in
         # _parse_spmd_scope_with_tid).
-        self._reject_spmd_early_resolve_in_cluster(allow_early_resolve, span)
+        self._reject_spmd_submit_only_kwargs_in_cluster(allow_early_resolve, predicate, span)
         spmd_attrs: list[tuple[str, Any]] = [("allow_early_resolve", True)] if allow_early_resolve else []
+        # Canonical attr order: allow_early_resolve then predicate (matches the
+        # ``as tid`` form) so a print -> reparse compares equal under
+        # structural_equal's positional attr check.
+        if predicate is not None:
+            spmd_attrs.append(("predicate", predicate))
 
         # No ``as tid``: the plain with-form. ``deps=`` was already rejected above
         # (allow_deps=False), so dep_vars is empty here. The shared helper keeps the
@@ -3939,6 +3995,7 @@ class ASTParser:
         split_slot_num: "int | None",
         dep_vars: "list[ir.Var]",
         allow_early_resolve: bool,
+        predicate: "ir.Expr | None",
         optional_vars: "ast.expr",
     ) -> None:
         """Parse ``with pl.spmd(n, deps=[...]) as tid:`` capturing the dispatch TaskId.
@@ -3976,9 +4033,9 @@ class ASTParser:
                 hint="Use `with pl.spmd(...) as tid:` (single name; nested tuples are not allowed).",
             )
 
-        # Canonical attr order (deps, task_id_var, allow_early_resolve) mirrors
-        # _parse_at_meta so a print -> reparse cycle compares equal under
-        # structural_equal's positional attr check.
+        # Canonical attr order (deps, task_id_var, allow_early_resolve,
+        # predicate) mirrors _parse_at_meta so a print -> reparse cycle compares
+        # equal under structural_equal's positional attr check.
         scope_attrs: list[tuple[str, Any]] = []
         if dep_vars:
             scope_attrs.append(("manual_dep_edges", dep_vars))
@@ -3990,6 +4047,12 @@ class ASTParser:
         # _parse_at_meta does for pl.at scopes.
         if allow_early_resolve:
             scope_attrs.append(("allow_early_resolve", True))
+        # ``predicate`` after it — an Expr (not a flag), read off the scope by the
+        # Spmd outliner and moved onto ``Submit.predicate``. It carries live SSA
+        # Vars (the operand tensor and its indices), which ConvertToSSA versions
+        # via SubstScopeAttrs.
+        if predicate is not None:
+            scope_attrs.append(("predicate", predicate))
 
         # Emit the transient ``AssignStmt(tid, system.task_invalid())`` placeholder
         # one stmt BEFORE the scope so ConvertToSSA has a def for the tid Var; the
@@ -4018,6 +4081,48 @@ class ASTParser:
             split_slot_num,
             scope_attrs,
         )
+        self._record_scope_producer(stmt.body, tid_var)
+
+    def _record_scope_producer(self, body: "list[ast.stmt]", tid_var: "ir.Var") -> None:
+        """Record ``body``'s assigned Vars as produced by the scope's ``tid_var``.
+
+        The scope-form counterpart of the tracking ``_parse_submit_tuple_lhs``
+        does for ``out, tid = pl.submit(...)``. Without it a
+        ``with pl.spmd(...) as tid:`` that writes a tensor leaves no producer
+        record, so :meth:`_validate_predicate_deps` silently certifies a later
+        ``predicate=`` over that tensor even when the scope is absent from
+        ``deps=`` — the exact stale-read the contract exists to prevent, in the
+        form most natural to write.
+
+        Same best-effort scope as the call form: only names bound by a
+        top-level assignment in the scope body are tracked (aliases, writes
+        through ``pl.Out`` arguments, and rebinds via an intervening call are
+        not). The generation counter mirrors the submit path so a ``tid`` name
+        rebound by a later scope cannot match by Var identity alone.
+        """
+        names: list[str] = []
+
+        def collect(target: ast.expr) -> None:
+            if isinstance(target, ast.Name):
+                names.append(target.id)
+            elif isinstance(target, (ast.Tuple, ast.List)):
+                for elt in target.elts:
+                    collect(elt)
+
+        for node in body:
+            if isinstance(node, ast.Assign):
+                for target in node.targets:
+                    collect(target)
+            elif isinstance(node, ast.AnnAssign):
+                collect(node.target)
+        if not names:
+            return
+        gen = self._tid_binding_generation.get(tid_var.unique_id, 0) + 1
+        self._tid_binding_generation[tid_var.unique_id] = gen
+        for name in names:
+            produced = self.scope_manager.lookup_var(name)
+            if isinstance(produced, ir.Var):
+                self._submit_producer_tid[produced.unique_id] = (tid_var, gen)
 
     def _parse_spmd_for_loop(self, stmt: ast.For, iter_call: ast.Call) -> None:
         """Parse ``for i in pl.spmd(N, ...): body`` into
@@ -4061,16 +4166,20 @@ class ASTParser:
             split_slot_num,
             _,
             allow_early_resolve,
+            predicate,
         ) = self._parse_spmd_kwargs(stmt, iter_call, usage_hint=spmd_hint)
         spmd_name_hint, incore_name_hint = _split_spmd_for_loop_name_hints(name_hint)
 
         span = self.span_tracker.get_span(stmt)
-        # ``allow_early_resolve`` rides on the SpmdScopeStmt (read by the Spmd
-        # outliner onto the synthesised Submit). A cluster-nested pl.spmd is
-        # unwrapped into the Group and never produces a Submit, so reject the hint
-        # there (mirrors the with-form / as-tid guards).
-        self._reject_spmd_early_resolve_in_cluster(allow_early_resolve, span)
+        # ``allow_early_resolve`` / ``predicate`` ride on the SpmdScopeStmt (read
+        # by the Spmd outliner onto the synthesised Submit). A cluster-nested
+        # pl.spmd is unwrapped into the Group and never produces a Submit, so
+        # reject them there (mirrors the with-form / as-tid guards).
+        self._reject_spmd_submit_only_kwargs_in_cluster(allow_early_resolve, predicate, span)
         spmd_attrs: list[tuple[str, Any]] = [("allow_early_resolve", True)] if allow_early_resolve else []
+        # Canonical attr order — see the with-form.
+        if predicate is not None:
+            spmd_attrs.append(("predicate", predicate))
         # Merge forward-sticky pl.dump_tag tensors onto the auto-outlined InCore
         # scope — the kernel the loop body lowers to. The with-form (pl.at /
         # pl.spmd / pl.cluster) routes through _parse_scope_body for this; the
@@ -5748,7 +5857,7 @@ class ASTParser:
         predicate: ir.Expr | None = None
         if as_submit:
             allow_early_resolve = self._parse_submit_allow_early_resolve_kwarg(method_name, keywords)
-            predicate = self._parse_submit_predicate_kwarg(method_name, keywords, span)
+            predicate = self._parse_submit_predicate_kwarg(method_name, keywords)
             if predicate is not None:
                 self._validate_predicate_deps(method_name, predicate, user_dep_vars, span)
         return_types = func_obj.return_types if func_obj else []
@@ -6152,11 +6261,13 @@ class ASTParser:
         return kw.value.value
 
     def _parse_submit_predicate_kwarg(
-        self, method_name: str, keywords: list[ast.keyword], span: ir.Span
+        self, method_name: str, keywords: list[ast.keyword]
     ) -> ir.Expr | None:
         """Extract the optional ``predicate=(<tensor>[<indices>] <op> <int>)`` kwarg.
 
-        Accepted on ``pl.submit(...)`` and ``pl.spmd_submit(...)``. Encodes a
+        Accepted on ``pl.submit(...)``, ``pl.spmd_submit(...)`` and the
+        ``with pl.spmd(...)`` scope form (``method_name`` names the caller in
+        error messages). Encodes a
         dispatch predicate the scheduler evaluates at the dispatch point; a
         false result retires the task inline without dispatching to a core,
         while still settling fanin/fanout. Returns the comparison

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -3587,6 +3587,55 @@ class ASTParser:
             )
         return kw.value.value
 
+    # ``pl.spmd()`` keywords whose *value* the caller interprets. ``deps`` is
+    # conditionally legal (see _validate_spmd_kwarg_name).
+    _SPMD_KWARGS = frozenset(
+        {"core_num", "sync_start", "name_hint", "optimizations", "allow_early_resolve", "predicate"}
+    )
+
+    def _validate_spmd_kwarg_name(
+        self, kw: ast.keyword, anchor: ast.AST, *, usage_hint: str, allow_deps: bool
+    ) -> None:
+        """Reject a ``pl.spmd()`` keyword that is not legal in this context.
+
+        Split out of :meth:`_parse_spmd_kwargs` so that method handles only what
+        each keyword's *value* means, while "is this keyword name accepted here"
+        lives in one place. Covers three rejections:
+
+        * ``**kwargs`` unpacking (``kw.arg is None``) — the parser must see each
+          keyword literally.
+        * ``deps=`` outside the ``as tid`` capture form, where there is no TaskId
+          to hang the edges on.
+        * any unrecognised name, whose hint lists the keywords valid *here*.
+        """
+        if kw.arg is None:
+            # `pl.spmd(**cfg)` — ast.keyword.arg is None for **kwargs unpacking.
+            raise ParserSyntaxError(
+                "pl.spmd() does not accept **kwargs; pass core_num (positional) "
+                "and sync_start=/name_hint=/optimizations= explicitly",
+                span=self.span_tracker.get_span(kw.value),
+                hint=usage_hint,
+            )
+        if kw.arg == "deps" and not allow_deps:
+            raise ParserSyntaxError(
+                "pl.spmd() does not accept 'deps=' here",
+                span=self.span_tracker.get_span(kw.value),
+                hint="Use `with pl.spmd(n, deps=[...]) as tid:` (the with-form) to "
+                "declare explicit TaskId deps, or `out, tid = pl.spmd_submit(..., "
+                "deps=[...])` for the single-call form.",
+            )
+        if kw.arg == "deps" or kw.arg in self._SPMD_KWARGS:
+            return
+        supported = "'sync_start', 'name_hint', 'optimizations', "
+        if allow_deps:
+            supported += "'deps', "
+        supported += "'allow_early_resolve', 'predicate'"
+        raise ParserSyntaxError(
+            f"pl.spmd() got unexpected keyword argument '{kw.arg}'",
+            span=self.span_tracker.get_span(anchor),
+            hint=f"Supported keywords: {supported}",
+        )
+
     def _parse_spmd_kwargs(
         self,
         anchor: ast.AST,
@@ -3647,14 +3696,7 @@ class ASTParser:
         allow_early_resolve: bool = False
         predicate: ir.Expr | None = None
         for kw in call.keywords:
-            if kw.arg is None:
-                # `pl.spmd(**cfg)` — ast.keyword.arg is None for **kwargs unpacking.
-                raise ParserSyntaxError(
-                    "pl.spmd() does not accept **kwargs; pass core_num (positional) "
-                    "and sync_start=/name_hint=/optimizations= explicitly",
-                    span=self.span_tracker.get_span(kw.value),
-                    hint=usage_hint,
-                )
+            self._validate_spmd_kwarg_name(kw, anchor, usage_hint=usage_hint, allow_deps=allow_deps)
             if kw.arg == "name_hint":
                 name_hint = self._parse_scope_name_hint(kw.value, "pl.spmd()")
             elif kw.arg == "core_num":
@@ -3670,14 +3712,6 @@ class ASTParser:
             elif kw.arg == "optimizations":
                 split_mode, split_slot_num = self._parse_spmd_optimizations_list(kw.value)
             elif kw.arg == "deps":
-                if not allow_deps:
-                    raise ParserSyntaxError(
-                        "pl.spmd() does not accept 'deps=' here",
-                        span=self.span_tracker.get_span(kw.value),
-                        hint="Use `with pl.spmd(n, deps=[...]) as tid:` (the with-form) to "
-                        "declare explicit TaskId deps, or `out, tid = pl.spmd_submit(..., "
-                        "deps=[...])` for the single-call form.",
-                    )
                 deps_kw = kw
             elif kw.arg == "allow_early_resolve":
                 allow_early_resolve = self._parse_spmd_bool_literal_kwarg(kw, usage_hint)
@@ -3685,19 +3719,6 @@ class ASTParser:
                 # Not a bool literal — parsed as an ordinary expression and
                 # shape-validated, exactly as on pl.spmd_submit.
                 predicate = self._parse_submit_predicate_kwarg("pl.spmd()", [kw])
-            else:
-                supported = (
-                    "Supported keywords: 'sync_start', 'name_hint', 'optimizations', 'deps', "
-                    "'allow_early_resolve', 'predicate'"
-                    if allow_deps
-                    else "Supported keywords: 'sync_start', 'name_hint', 'optimizations', "
-                    "'allow_early_resolve', 'predicate'"
-                )
-                raise ParserSyntaxError(
-                    f"pl.spmd() got unexpected keyword argument '{kw.arg}'",
-                    span=self.span_tracker.get_span(anchor),
-                    hint=supported,
-                )
         if core_num is None:
             raise ParserSyntaxError(
                 "pl.spmd() requires core_num (first positional argument)",
@@ -6260,9 +6281,7 @@ class ASTParser:
             )
         return kw.value.value
 
-    def _parse_submit_predicate_kwarg(
-        self, method_name: str, keywords: list[ast.keyword]
-    ) -> ir.Expr | None:
+    def _parse_submit_predicate_kwarg(self, method_name: str, keywords: list[ast.keyword]) -> ir.Expr | None:
         """Extract the optional ``predicate=(<tensor>[<indices>] <op> <int>)`` kwarg.
 
         Accepted on ``pl.submit(...)``, ``pl.spmd_submit(...)`` and the

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -3737,7 +3737,13 @@ class ASTParser:
         # the error steers the author to the ``as tid`` form.
         if predicate is not None:
             self._validate_predicate_deps(
-                "pl.spmd()", predicate, dep_vars, self.span_tracker.get_span(anchor)
+                "pl.spmd()",
+                predicate,
+                dep_vars,
+                self.span_tracker.get_span(anchor),
+                # allow_deps is False on the plain / for-forms, where deps= is
+                # rejected outright — the hint must not tell the author to add one.
+                deps_accepted=allow_deps,
             )
         return (
             core_num,
@@ -6455,7 +6461,13 @@ class ASTParser:
             )
 
     def _validate_predicate_deps(
-        self, method_name: str, predicate: ir.Expr, dep_vars: list[ir.Var], span: ir.Span
+        self,
+        method_name: str,
+        predicate: ir.Expr,
+        dep_vars: list[ir.Var],
+        span: ir.Span,
+        *,
+        deps_accepted: bool = True,
     ) -> None:
         """Enforce that a ``predicate=`` operand's producer is one of ``deps=``.
 
@@ -6471,6 +6483,12 @@ class ASTParser:
         parameter, say) has no tracked producer, and an ``Array[N, TASK_ID]``
         dep entry does not name its producers individually — both are skipped
         rather than risk rejecting a correct program.
+
+        ``deps_accepted`` tailors the remediation hint. The plain
+        ``with pl.spmd(...):`` and ``for i in pl.spmd(...):`` forms do not take
+        ``deps=`` at all, so telling their author to add one would send them
+        into a second, different error; there the fix is to switch to the
+        ``as tid`` capture form.
         """
         if not isinstance(predicate, self._PREDICATE_CMP_TYPES):
             return
@@ -6491,14 +6509,23 @@ class ASTParser:
         if any(d is producer_tid for d in dep_vars) and current_gen == producer_gen:
             return
         tid_name = producer_tid.name_hint
+        why = (
+            "Without it the scheduler may evaluate the predicate before the producing task has "
+            "written the tensor."
+        )
+        hint = (
+            f"Add the producer to the dependency list: deps=[{tid_name}]. {why}"
+            if deps_accepted
+            else (
+                f"This form does not accept deps=. Capture the TaskId instead: "
+                f"`with pl.spmd(n, deps=[{tid_name}], predicate=...) as tid:`. {why}"
+            )
+        )
         raise ParserSyntaxError(
             f"'{method_name}' predicate reads '{operand.name_hint}', which is produced by the task "
             f"bound to '{tid_name}', but '{tid_name}' is not in deps=",
             span=span,
-            hint=(
-                f"Add the producer to the dependency list: deps=[{tid_name}]. Without it the scheduler "
-                "may evaluate the predicate before the producing task has written the tensor."
-            ),
+            hint=hint,
         )
 
     def _parse_dispatch_device_kwarg(

--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -2303,8 +2303,8 @@ class OrchestrationStmtCodegen : public CodegenBase {
   // here (the DSL parser rejects it earlier with a better message; this is the
   // backstop for IR built by other means).
   void EmitPredicateHint(const std::string& task_var, const CallPtr& call) {
-    if (!call->HasAttr("predicate")) return;
-    auto pred = call->GetAttr<ExprPtr>("predicate", nullptr);
+    if (!call->HasAttr(kAttrPredicate)) return;
+    auto pred = call->GetAttr<ExprPtr>(kAttrPredicate, nullptr);
     INTERNAL_CHECK_SPAN(pred, call->span_) << "Submit predicate attr is null";
     auto cmp = std::dynamic_pointer_cast<const BinaryExpr>(pred);
     CHECK_SPAN(cmp && RenderPredicateOp(pred->GetKind(), false) != nullptr, pred->span_)

--- a/src/ir/transforms/convert_to_ssa_pass.cpp
+++ b/src/ir/transforms/convert_to_ssa_pass.cpp
@@ -974,7 +974,10 @@ class SSAConverter {
 
   /// Substitute Var-typed entries in a ScopeStmt's ``attrs_``
   /// (``manual_dep_edges`` / ``task_id_var`` / ``arg_direction_overrides_vars`` /
-  /// ``dump_vars``). Returns the rebuilt attrs and a flag indicating whether any
+  /// ``dump_vars``), plus the Expr-valued ``predicate`` attr (the
+  /// ``with pl.spmd(..., predicate=(t[i] > 0)):`` dispatch predicate, whose
+  /// operand tensor and index Vars must be versioned like any other use).
+  /// Returns the rebuilt attrs and a flag indicating whether any
   /// entry was rewritten — mirrors the per-Call ``SubstCallAttrs`` so SSA
   /// renaming propagates into scope-level attrs the same way it does for Call
   /// attrs. ``dump_vars`` rides here as the carrier from ``pl.dump_tag`` /
@@ -1020,6 +1023,22 @@ class SSAConverter {
           if (it != cur_.end() && it->second.get() != var->get()) {
             changed = true;
             out.emplace_back(k, std::any(it->second));
+            continue;
+          }
+        }
+      } else if (k == kAttrPredicate) {
+        // ``with pl.spmd(..., predicate=(t[i] > 0)):`` — an ExprPtr, so
+        // substitute the whole subtree via SubstExpr rather than remapping a
+        // single Var (mirrors the kAttrDevice handling in SubstCallAttrs).
+        // Substituting here — before the body is converted, see ConvertScope —
+        // resolves the operand tensor to the SSA version visible at scope
+        // entry, which is the value the scheduler reads at the dispatch point.
+        const auto* pred = std::any_cast<ExprPtr>(&v);
+        if (pred && *pred) {
+          auto new_pred = SubstExpr(*pred);
+          if (new_pred.get() != pred->get()) {
+            changed = true;
+            out.emplace_back(k, std::any(std::move(new_pred)));
             continue;
           }
         }

--- a/src/ir/transforms/mutator.cpp
+++ b/src/ir/transforms/mutator.cpp
@@ -966,6 +966,19 @@ std::pair<std::vector<std::pair<std::string, std::any>>, bool> IRMutator::Mutate
           continue;
         }
       }
+    } else if (k == kAttrPredicate) {
+      // ``with pl.spmd(..., predicate=(t[i] > 0)):`` — an Expr tree, not a
+      // Var, so mutate the whole subtree (the operand tensor Var and its
+      // index Vars must follow any remapping the mutator is performing).
+      const auto* pred = std::any_cast<ExprPtr>(&v);
+      if (pred && *pred) {
+        auto remapped = ExprFunctor<ExprPtr>::VisitExpr(*pred);
+        if (remapped && remapped.get() != pred->get()) {
+          any_changed = true;
+          new_attrs.emplace_back(k, std::any(std::move(remapped)));
+          continue;
+        }
+      }
     }
     new_attrs.emplace_back(k, v);
   }

--- a/src/ir/transforms/mutator.cpp
+++ b/src/ir/transforms/mutator.cpp
@@ -970,6 +970,16 @@ std::pair<std::vector<std::pair<std::string, std::any>>, bool> IRMutator::Mutate
       // ``with pl.spmd(..., predicate=(t[i] > 0)):`` — an Expr tree, not a
       // Var, so mutate the whole subtree (the operand tensor Var and its
       // index Vars must follow any remapping the mutator is performing).
+      //
+      // No pipeline pass currently reaches this: the passes that run while the
+      // attr still exists (before OutlineSpmdScopes) either do not remap Vars
+      // inside it, or — like FlattenCallExpr — override the Spmd handler and
+      // copy attrs_ verbatim. ConvertToSSA has its own SubstScopeAttrs. This
+      // branch is therefore untested-by-construction, and kept for the same
+      // reason the sibling Var attrs above are handled here: any future
+      // IRMutator-based pass that renames Vars must not silently skip the
+      // predicate. Deleting it would make the predicate the one scope attr the
+      // generic mutator ignores.
       const auto* pred = std::any_cast<ExprPtr>(&v);
       if (pred && *pred) {
         auto remapped = ExprFunctor<ExprPtr>::VisitExpr(*pred);

--- a/src/ir/transforms/outline_cluster_scopes_pass.cpp
+++ b/src/ir/transforms/outline_cluster_scopes_pass.cpp
@@ -51,22 +51,25 @@ FunctionPtr UnwrapNestedSpmd(const FunctionPtr& group_func) {
           << "Only one pl.spmd() block is allowed per cluster scope";
       // A cluster-nested pl.spmd is unwrapped into the Group function and never
       // outlined to a Submit, so a captured producer TaskId (kAttrTaskIdVar), an
-      // explicit dependency fence (kAttrManualDepEdges), OR a speculative
-      // early-dispatch hint (allow_early_resolve) would be silently dropped. The
-      // parser rejects `with pl.spmd(...) as tid:` / `deps=` /
-      // `allow_early_resolve=True` inside pl.cluster() (see
+      // explicit dependency fence (kAttrManualDepEdges), a speculative
+      // early-dispatch hint (allow_early_resolve), OR a dispatch predicate
+      // (kAttrPredicate) would be silently dropped. The parser rejects
+      // `with pl.spmd(...) as tid:` / `deps=` / `allow_early_resolve=True` /
+      // `predicate=` inside pl.cluster() (see
       // ASTParser._parse_spmd_scope_with_tid and
-      // ASTParser._reject_spmd_early_resolve_in_cluster); guard here for
+      // ASTParser._reject_spmd_submit_only_kwargs_in_cluster); guard here for
       // hand-built / deserialized IR so the invalid case fails loudly instead of
       // miscompiling.
       INTERNAL_CHECK_SPAN(op->GetAttr<VarPtr>(kAttrTaskIdVar) == nullptr &&
                               !op->HasAttr(kAttrManualDepEdges) &&
-                              !op->GetAttr<bool>("allow_early_resolve", false),
+                              !op->GetAttr<bool>("allow_early_resolve", false) &&
+                              !op->HasAttr(kAttrPredicate),
                           op->span_)
           << "Internal error: a pl.spmd() nested inside pl.cluster() cannot carry a producer "
-             "TASK_ID (kAttrTaskIdVar), dependency edges (kAttrManualDepEdges), or an "
-             "allow_early_resolve hint; it is unwrapped into the Group function and never "
-             "outlined to a Submit. The parser must reject this at parse time.";
+             "TASK_ID (kAttrTaskIdVar), dependency edges (kAttrManualDepEdges), an "
+             "allow_early_resolve hint, or a dispatch predicate (kAttrPredicate); it is unwrapped "
+             "into the Group function and never outlined to a Submit. The parser must reject this "
+             "at parse time.";
       core_num = op->core_num_;
       sync_start = op->sync_start_;
       return VisitStmt(op->body_);

--- a/src/ir/transforms/outline_cluster_scopes_pass.cpp
+++ b/src/ir/transforms/outline_cluster_scopes_pass.cpp
@@ -60,11 +60,10 @@ FunctionPtr UnwrapNestedSpmd(const FunctionPtr& group_func) {
       // ASTParser._reject_spmd_submit_only_kwargs_in_cluster); guard here for
       // hand-built / deserialized IR so the invalid case fails loudly instead of
       // miscompiling.
-      INTERNAL_CHECK_SPAN(op->GetAttr<VarPtr>(kAttrTaskIdVar) == nullptr &&
-                              !op->HasAttr(kAttrManualDepEdges) &&
-                              !op->GetAttr<bool>("allow_early_resolve", false) &&
-                              !op->HasAttr(kAttrPredicate),
-                          op->span_)
+      INTERNAL_CHECK_SPAN(
+          op->GetAttr<VarPtr>(kAttrTaskIdVar) == nullptr && !op->HasAttr(kAttrManualDepEdges) &&
+              !op->GetAttr<bool>("allow_early_resolve", false) && !op->HasAttr(kAttrPredicate),
+          op->span_)
           << "Internal error: a pl.spmd() nested inside pl.cluster() cannot carry a producer "
              "TASK_ID (kAttrTaskIdVar), dependency edges (kAttrManualDepEdges), an "
              "allow_early_resolve hint, or a dispatch predicate (kAttrPredicate); it is unwrapped "

--- a/src/ir/transforms/python_printer.cpp
+++ b/src/ir/transforms/python_printer.cpp
@@ -373,6 +373,14 @@ class IRPythonPrinter : public IRVisitor {
   // it must survive a print/reparse roundtrip while the scope still exists.
   bool PrintScopeAllowEarlyResolveAttr(const ScopeStmtPtr& op);
 
+  // Emit ``predicate=(<expr>)`` if the scope carries ``kAttrPredicate``;
+  // returns true when printed. Same contract as
+  // PrintScopeAllowEarlyResolveAttr — the outliner reads the predicate off the
+  // scope and threads it onto the synthesised ``Submit``, so it must survive a
+  // print/reparse roundtrip while the scope still exists. The comparison Expr
+  // prints itself, so there is no bespoke syntax.
+  bool PrintScopePredicateAttr(const ScopeStmtPtr& op);
+
   // Emit ``windowize=True`` for an explicitly opted-in InCore scope.
   bool PrintScopeWindowizeAttr(const ScopeStmtPtr& op);
 
@@ -1727,6 +1735,15 @@ bool IRPythonPrinter::PrintScopeAllowEarlyResolveAttr(const ScopeStmtPtr& op) {
   return true;
 }
 
+bool IRPythonPrinter::PrintScopePredicateAttr(const ScopeStmtPtr& op) {
+  auto pred = op->GetAttr<ExprPtr>(kAttrPredicate, nullptr);
+  if (!pred) return false;
+  stream_ << ", predicate=(";
+  VisitExpr(pred);
+  stream_ << ")";
+  return true;
+}
+
 bool IRPythonPrinter::PrintScopeWindowizeAttr(const ScopeStmtPtr& op) {
   if (!op->GetAttr<bool>("windowize", false)) return false;
   stream_ << ", windowize=True";
@@ -1865,6 +1882,7 @@ void IRPythonPrinter::VisitStmt_(const SpmdScopeStmtPtr& op) {
     }
     PrintScopeDepsAttr(op);
     PrintScopeAllowEarlyResolveAttr(op);
+    PrintScopePredicateAttr(op);
     stream_ << ")";
     PrintScopeTaskIdVarSuffix(op);
     stream_ << ":\n";
@@ -1903,6 +1921,7 @@ void IRPythonPrinter::VisitStmt_(const SpmdScopeStmtPtr& op) {
       PrintSplitOptimizations(incore->split_.value_or(SplitMode::None), incore);
     }
     PrintScopeAllowEarlyResolveAttr(op);
+    PrintScopePredicateAttr(op);
     stream_ << "):\n";
     IncreaseIndent();
     // Emit the InCore body skipping the get_block_idx binding we just
@@ -1932,6 +1951,7 @@ void IRPythonPrinter::VisitStmt_(const SpmdScopeStmtPtr& op) {
     stream_ << ", name_hint=\"" << op->name_hint_ << "\"";
   }
   PrintScopeAllowEarlyResolveAttr(op);
+  PrintScopePredicateAttr(op);
   stream_ << "):\n";
   IncreaseIndent();
   PrintStmtBlock(op->body_);

--- a/src/ir/transforms/structural_hash.cpp
+++ b/src/ir/transforms/structural_hash.cpp
@@ -336,13 +336,21 @@ class StructuralHasher {
         // structural_equal compares it element-wise.
         const auto& idxs = AnyCast<std::vector<int32_t>>(value, "hashing kwarg: " + key);
         for (int32_t v : idxs) h = hash_combine(h, std::hash<int32_t>{}(v));
+      } else if (value.type() == typeid(VarPtr) || value.type() == typeid(std::vector<VarPtr>) ||
+                 value.type() == typeid(ExprPtr)) {
+        // Var-/Expr-valued attrs (task_id_var / manual_dep_edges / dump_vars /
+        // arg_direction_overrides_vars / device / predicate) are intentionally
+        // NOT hashed: hashing them via HashNode is auto-mapping-counter-order
+        // dependent, which would defeat the order-insensitivity this function
+        // guarantees. structural_equal still compares them, so skipping here
+        // only makes the hash coarser (a legal collision), never wrong.
+        //
+        // Skipped rather than thrown. The throw this replaced made
+        // structural_hash unusable on any scope carrying such an attr — every
+        // `with pl.spmd(...) as tid:` (task_id_var) and every
+        // `with pl.spmd(..., predicate=...)`, both perfectly valid IR.
+        continue;  // contributes nothing to `acc`
       } else {
-        // NOTE: Var-/Expr-valued attrs (dump_vars / manual_dep_edges /
-        // task_id_var / device) are intentionally not hashed here — hashing
-        // them via HashNode is auto-mapping-counter-order-dependent, which
-        // would defeat the order-insensitivity this function guarantees. They
-        // are compared by structural_equal but not currently part of the hash;
-        // this matches the pre-existing behaviour (a throw flags any attempt).
         throw TypeError("Unsupported kwarg type for key: " + key + ": " +
                         DemangleTypeName(value.type().name()));
       }

--- a/src/ir/transforms/utils/dead_code_elimination.cpp
+++ b/src/ir/transforms/utils/dead_code_elimination.cpp
@@ -183,6 +183,15 @@ void FindLiveRootsRecursiveImpl(const std::vector<StmtPtr>& stmts, const Removab
           }
         } else if (k == kAttrTaskIdVar) {
           if (const auto* var = std::any_cast<VarPtr>(&v)) add_var(*var);
+        } else if (k == kAttrPredicate) {
+          // ``with pl.spmd(..., predicate=(t[i] > 0)):`` — an Expr, so collect
+          // every Var it references (the operand tensor and its indices)
+          // rather than remapping a single Var. DCE runs at pass 5, well
+          // before OutlineSpmdScopes moves this onto Submit::predicate_, so
+          // the attr is live IR here: without this the operand's feeding
+          // assignment looks dead and its removal leaves a dangling reference
+          // — the same failure mode as issue #1456 above.
+          if (const auto* pred = std::any_cast<ExprPtr>(&v)) collect_expr_refs(*pred);
         }
       }
       if (auto spmd = std::dynamic_pointer_cast<const SpmdScopeStmt>(scope_stmt)) {

--- a/src/ir/transforms/utils/window_externalization.cpp
+++ b/src/ir/transforms/utils/window_externalization.cpp
@@ -1881,8 +1881,8 @@ class OutWindowExternalizer {
         // printer emits twice and that structural_hash cannot encode (its attr
         // codec has no ExprPtr branch). The fields themselves are threaded
         // explicitly through the constructor below.
-        static const std::array<const char*, 4> kViewSynthesizedKeys = {"predicate", "core_num", "sync_start",
-                                                                        "allow_early_resolve"};
+        static const std::array<const char*, 4> kViewSynthesizedKeys = {kAttrPredicate, "core_num",
+                                                                        "sync_start", "allow_early_resolve"};
         std::vector<std::pair<std::string, std::any>> submit_attrs;
         submit_attrs.reserve(new_attrs.size());
         for (const auto& attr : new_attrs) {

--- a/src/ir/transforms/utils/window_externalization.cpp
+++ b/src/ir/transforms/utils/window_externalization.cpp
@@ -1878,9 +1878,9 @@ class OutWindowExternalizer {
         // fields. RewriteCallAttrs copies every attr off the transient Call
         // view, so without this filter the rebuilt Submit would carry both the
         // real field and a stale attr copy of it — duplicated state that the
-        // printer emits twice and that structural_hash cannot encode (its attr
-        // codec has no ExprPtr branch). The fields themselves are threaded
-        // explicitly through the constructor below.
+        // printer emits twice and that structural_hash silently ignores (its
+        // attr codec skips Var-/Expr-valued entries). The fields themselves are
+        // threaded explicitly through the constructor below.
         static const std::array<const char*, 4> kViewSynthesizedKeys = {kAttrPredicate, "core_num",
                                                                         "sync_start", "allow_early_resolve"};
         std::vector<std::pair<std::string, std::any>> submit_attrs;

--- a/src/ir/transforms/visitor.cpp
+++ b/src/ir/transforms/visitor.cpp
@@ -276,6 +276,7 @@ void IRVisitor::VisitStmt_(const WhileStmtPtr& op) {
 // ``task_id_var`` / ``arg_direction_overrides_vars`` / ``dump_vars`` attrs.
 void IRVisitor::VisitScopeAttrs(const ScopeStmtPtr& op) {
   for (const auto& [k, v] : op->attrs_) {
+    if (!ShouldVisitScopeAttr(k)) continue;
     if (k == kAttrManualDepEdges || k == kAttrArgDirOverrideVars || k == kAttrDumpVars) {
       const auto* edges = std::any_cast<std::vector<VarPtr>>(&v);
       if (!edges) continue;
@@ -285,6 +286,13 @@ void IRVisitor::VisitScopeAttrs(const ScopeStmtPtr& op) {
     } else if (k == kAttrTaskIdVar) {
       const auto* var = std::any_cast<VarPtr>(&v);
       if (var && *var) VisitExpr(*var);
+    } else if (k == kAttrPredicate) {
+      // ``with pl.spmd(..., predicate=(t[i] > 0)):`` — unlike the keys above
+      // this is a whole Expr tree (a comparison over ``tensor.read``), so
+      // recurse into it: the operand tensor and its index Vars are live SSA
+      // values the outliner later moves onto ``Submit::predicate_``.
+      const auto* pred = std::any_cast<ExprPtr>(&v);
+      if (pred && *pred) VisitExpr(*pred);
     }
   }
 }

--- a/src/ir/transforms/visitor.cpp
+++ b/src/ir/transforms/visitor.cpp
@@ -273,7 +273,9 @@ void IRVisitor::VisitStmt_(const WhileStmtPtr& op) {
 // Visit Var-typed entries in a ScopeStmt's ``attrs_``. Mirrors the Call.attrs
 // handling in VisitExpr_(CallPtr) so analyses (unused-var detection, SSA Var
 // liveness, etc.) see Var refs stashed on a ScopeStmt's ``manual_dep_edges`` /
-// ``task_id_var`` / ``arg_direction_overrides_vars`` / ``dump_vars`` attrs.
+// ``task_id_var`` / ``arg_direction_overrides_vars`` / ``dump_vars`` attrs, plus
+// the Expr-valued ``predicate`` attr. Subclasses opt a key out via
+// ShouldVisitScopeAttr rather than by overriding this walk.
 void IRVisitor::VisitScopeAttrs(const ScopeStmtPtr& op) {
   for (const auto& [k, v] : op->attrs_) {
     if (!ShouldVisitScopeAttr(k)) continue;

--- a/src/ir/verifier/verify_no_nested_call_pass.cpp
+++ b/src/ir/verifier/verify_no_nested_call_pass.cpp
@@ -92,6 +92,7 @@ class NoNestedCallVerifier : public IRVisitor {
   void VisitExpr_(const BitNotPtr& op) override { VisitUnaryExpr(op); }
   void VisitExpr_(const CastPtr& op) override { VisitUnaryExpr(op); }
   void VisitExpr_(const SubmitPtr& op) override;
+  [[nodiscard]] bool ShouldVisitScopeAttr(const std::string& key) const override;
   void VisitStmt_(const IfStmtPtr& op) override;
   void VisitStmt_(const ForStmtPtr& op) override;
   void VisitStmt_(const WhileStmtPtr& op) override;
@@ -186,6 +187,20 @@ void NoNestedCallVerifier::VisitExpr_(const SubmitPtr& op) {
   if (op->core_num_.has_value() && *op->core_num_) {
     VisitExpr(*op->core_num_);
   }
+}
+
+// Same exemption, one stage earlier in the pipeline: a
+// ``with pl.spmd(..., predicate=(t[i] > 0)):`` scope carries the predicate on
+// ``ScopeStmt::attrs_`` until OutlineSpmdScopes moves it onto the synthesised
+// ``Submit::predicate_`` (exempted above). Between parse and that outline the
+// base ``VisitScopeAttrs`` walks the attr Expr — deliberately, so SSA and
+// use-def analyses see the operand Vars — which would otherwise report the
+// declarative ``Gt(Cast(tensor.read(..)), 0)`` as an illegal nested call.
+//
+// Opting out per key (rather than overriding the whole walk) keeps the base
+// the single source of truth: a scope attr added there stays covered here.
+bool NoNestedCallVerifier::ShouldVisitScopeAttr(const std::string& key) const {
+  return key != kAttrPredicate;
 }
 
 void NoNestedCallVerifier::VisitStmt_(const IfStmtPtr& op) {

--- a/tests/st/runtime/scheduling/test_predicated_dispatch.py
+++ b/tests/st/runtime/scheduling/test_predicated_dispatch.py
@@ -139,5 +139,86 @@ class TestPredicatedDispatch:
         assert result.passed, f"predicated dispatch (gate={gate_value}) failed: {result.error}"
 
 
+# ---------------------------------------------------------------------------
+# Scope form — ``with pl.spmd(..., predicate=...) as tid:``
+# ---------------------------------------------------------------------------
+#
+# Identical task chain and identical expected values as above; only the
+# authoring form differs. The scope form carries the predicate on the
+# SpmdScopeStmt until OutlineSpmdScopes moves it onto the Submit, so it
+# exercises a different frontend path (scope-attr walk + SSA substitution of
+# the operand Var) into the same runtime behaviour. Running both proves the two
+# spellings really are equivalent on hardware, not just in codegen text.
+
+
+def _build_scope_program():
+    R, C = _R, _C
+    SENTINEL, POISON = _SENTINEL, _POISON
+
+    @pl.program
+    class ScopePredicatedDispatchProgram:
+        @pl.function(type=pl.FunctionType.InCore)
+        def x_producer(self, x: pl.Out[pl.Tensor[[R, C], pl.FP32]]) -> pl.Tensor[[R, C], pl.FP32]:
+            t: pl.Tile[[R, C], pl.FP32] = pl.tile.full([R, C], dtype=pl.FP32, value=SENTINEL)
+            return pl.store(t, [0, 0], x)
+
+        @pl.function(type=pl.FunctionType.InCore)
+        def clobber(self, x: pl.Out[pl.Tensor[[R, C], pl.FP32]]) -> pl.Tensor[[R, C], pl.FP32]:
+            t: pl.Tile[[R, C], pl.FP32] = pl.tile.full([R, C], dtype=pl.FP32, value=POISON)
+            return pl.store(t, [0, 0], x)
+
+        @pl.function(type=pl.FunctionType.InCore)
+        def consumer(
+            self, x: pl.Tensor[[R, C], pl.FP32], out: pl.Out[pl.Tensor[[R, C], pl.FP32]]
+        ) -> pl.Tensor[[R, C], pl.FP32]:
+            t: pl.Tile[[R, C], pl.FP32] = pl.load(x, [0, 0], [R, C])
+            return pl.store(t, [0, 0], out)
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def main(
+            self,
+            x: pl.Out[pl.Tensor[[R, C], pl.FP32]],
+            gate: pl.Tensor[[R, C], pl.INT32],
+            out: pl.Out[pl.Tensor[[R, C], pl.FP32]],
+        ) -> pl.Tensor[[R, C], pl.FP32]:
+            with pl.spmd(1) as xp_tid:
+                x = self.x_producer(x)
+            # Predicated clobber authored as a scope: the predicate rides on the
+            # SpmdScopeStmt and is moved onto the Submit by the outliner.
+            # ``gate`` is a host-initialised input with no in-function producer,
+            # so ``deps=[xp_tid]`` covers the operand ordering requirement.
+            with pl.spmd(1, deps=[xp_tid], predicate=(gate[0, 0] > 0)) as clobber_tid:
+                x = self.clobber(x)
+            with pl.spmd(1, deps=[clobber_tid]) as _:
+                out = self.consumer(x, out)
+            return out
+
+    return ScopePredicatedDispatchProgram
+
+
+class _ScopePredicatedDispatchPTO(_PredicatedDispatchPTO):
+    """Same chain as _PredicatedDispatchPTO, authored with the pl.spmd scope form."""
+
+    __test__ = False
+
+    def get_name(self) -> str:
+        return f"scope_predicated_dispatch_gate{self._gate_value}_{_R}x{_C}"
+
+    def get_program(self) -> Any:
+        return _build_scope_program()
+
+
+class TestScopePredicatedDispatch:
+    """``with pl.spmd(..., predicate=...)`` must behave exactly like the submit form."""
+
+    @pytest.mark.parametrize("platform", PLATFORMS)
+    @pytest.mark.parametrize(
+        "gate_value", [0, 1], ids=["predicate_false_skips", "predicate_true_dispatches"]
+    )
+    def test_scope_predicated_dispatch(self, test_runner, platform, gate_value):
+        result = test_runner.run(_ScopePredicatedDispatchPTO(gate_value=gate_value, platform=platform))
+        assert result.passed, f"scope predicated dispatch (gate={gate_value}) failed: {result.error}"
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/st/runtime/scheduling/test_predicated_dispatch.py
+++ b/tests/st/runtime/scheduling/test_predicated_dispatch.py
@@ -212,9 +212,7 @@ class TestScopePredicatedDispatch:
     """``with pl.spmd(..., predicate=...)`` must behave exactly like the submit form."""
 
     @pytest.mark.parametrize("platform", PLATFORMS)
-    @pytest.mark.parametrize(
-        "gate_value", [0, 1], ids=["predicate_false_skips", "predicate_true_dispatches"]
-    )
+    @pytest.mark.parametrize("gate_value", [0, 1], ids=["predicate_false_skips", "predicate_true_dispatches"])
     def test_scope_predicated_dispatch(self, test_runner, platform, gate_value):
         result = test_runner.run(_ScopePredicatedDispatchPTO(gate_value=gate_value, platform=platform))
         assert result.passed, f"scope predicated dispatch (gate={gate_value}) failed: {result.error}"

--- a/tests/ut/codegen/test_predicate_codegen.py
+++ b/tests/ut/codegen/test_predicate_codegen.py
@@ -203,3 +203,106 @@ def test_set_predicate_precedes_task_submit():
     set_pred_at = code.index(".set_predicate(")
     submit_after = code.index("rt_submit_", set_pred_at)
     assert set_pred_at < submit_after, "set_predicate must be emitted before the task's rt_submit_*"
+
+
+# ---------------------------------------------------------------------------
+# Scope form — ``with pl.spmd(..., predicate=...)``
+# ---------------------------------------------------------------------------
+#
+# The scope form reaches ``Submit::predicate_`` by a different route than
+# ``pl.spmd_submit``: the predicate rides on ``SpmdScopeStmt::attrs_`` from
+# parse until ``OutlineSpmdScopes`` moves it onto the synthesised Submit. In
+# between it must survive ``ConvertToSSA``, which versions the operand tensor
+# Var *inside* the attr Expr. These tests drive the whole pipeline so a break
+# anywhere on that path (attr walk, SSA substitution, outliner threading)
+# surfaces as missing or wrong orchestration output.
+
+_SCOPE_PREDICATE_SRC = """
+import pypto.language as pl
+
+
+@pl.program
+class Prog:
+    @pl.function(type=pl.FunctionType.InCore)
+    def expert(
+        self, x: pl.Tensor[[512, 128], pl.FP32], out: pl.Out[pl.Tensor[[512, 128], pl.FP32]]
+    ) -> pl.Tensor[[512, 128], pl.FP32]:
+        t = pl.load(x, [0, 0], [128, 128])
+        out = pl.store(t, [0, 0], out)
+        return out
+
+    @pl.function(type=pl.FunctionType.InCore)
+    def gate(self, g: pl.Out[pl.Tensor[[512, 128], pl.INT32]]) -> pl.Tensor[[512, 128], pl.INT32]:
+        t = pl.load(g, [0, 0], [128, 128])
+        g = pl.store(t, [0, 0], g)
+        return g
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def main(
+        self,
+        x: pl.Tensor[[512, 128], pl.FP32],
+        out: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
+        rc: pl.Out[pl.Tensor[[512, 128], pl.INT32]],
+    ) -> pl.Tensor[[512, 128], pl.FP32]:
+        with pl.spmd(1) as g_tid:
+            rc = self.gate(rc)
+        with pl.spmd(1, deps=[g_tid], predicate=({PRED})) as t:
+            out = self.expert(x, out)
+        return out
+"""
+
+
+def _emit_scope_predicate(predicate_src: str) -> str:
+    """Compile a program whose ``with pl.spmd(...)`` scope carries ``predicate_src``."""
+    return _generate_orch_full_pipeline(
+        pl.parse_program(_SCOPE_PREDICATE_SRC.replace("{PRED}", predicate_src))
+    )
+
+
+def test_scope_form_emits_set_predicate_block():
+    """The scope form lowers to the same runtime sequence as pl.spmd_submit."""
+    code = _emit_scope_predicate("rc[0, 0] > 0")
+    assert "L0TaskPredicate" in code, code
+    # The operand survived SSA versioning inside the scope attr and resolved to
+    # the orchestration ext_ reference — the whole point of the attr walk.
+    assert ".operand.tensor = &ext_rc;" in code, code
+    assert ".operand.ndims = 2;" in code, code
+    assert ".op = PredicateOp::GT;" in code, code
+    assert ".target = 0;" in code, code
+    # Exactly one predicated task (the expert scope), not the gate scope.
+    assert code.count("set_predicate(") == 1, code
+
+
+def test_scope_form_set_predicate_precedes_task_submit():
+    code = _emit_scope_predicate("rc[1, 2] > 0")
+    set_pred_at = code.index(".set_predicate(")
+    submit_after = code.index("rt_submit_", set_pred_at)
+    assert set_pred_at < submit_after, "set_predicate must be emitted before the task's rt_submit_*"
+
+
+def test_scope_form_index_order_is_preserved():
+    code = _emit_scope_predicate("rc[1, 2] > 0")
+    assert ".operand.indices[0] = 1;" in code, code
+    assert ".operand.indices[1] = 2;" in code, code
+
+
+@pytest.mark.parametrize(
+    "written,expected_op",
+    [
+        ("rc[1, 2] >= 3", "GE"),
+        ("rc[1, 2] != 3", "NE"),
+        # Constant on the left — codegen flips so the tensor is the operand.
+        ("3 < rc[1, 2]", "GT"),
+        ("3 >= rc[1, 2]", "LE"),
+    ],
+)
+def test_scope_form_operator_mapping(written, expected_op):
+    """Spot-check the operator/operand-order table through the scope route.
+
+    The flip table itself is exhaustively covered by the pl.spmd_submit
+    parametrisation above; this only proves the scope form feeds it the same
+    unmodified comparison Expr.
+    """
+    code = _emit_scope_predicate(written)
+    assert f".op = PredicateOp::{expected_op};" in code, code
+    assert ".target = 3;" in code, code

--- a/tests/ut/ir/transforms/test_submit_passes.py
+++ b/tests/ut/ir/transforms/test_submit_passes.py
@@ -16,6 +16,7 @@ DCE / SSA and the printer's round-trip preserve the structural shape
 to Call.
 """
 
+import pypto.language as pl
 import pytest
 from pypto import DataType, ir, passes
 
@@ -209,6 +210,170 @@ def test_submit_single_lhs_form_round_trips():
     # the RoundtripInstrument on every pass. If the parser had still
     # required ``out, tid = ...`` unpacking, this call would raise.
     passes.convert_to_ssa()(program_before)
+
+
+
+# ---------------------------------------------------------------------------
+# Scope-form dispatch predicate — ``with pl.spmd(..., predicate=...)``
+# ---------------------------------------------------------------------------
+#
+# ``pl.spmd_submit(..., predicate=)`` builds a Submit at parse time, so the
+# predicate is covered by the Submit field walk above. The *scope* form is
+# outlined only later, so between parse and outline the predicate lives on
+# ``SpmdScopeStmt.attrs`` as an Expr carrying live SSA Vars (the operand tensor
+# and its indices).
+#
+# Three code paths must know about that attr — IRVisitor::VisitScopeAttrs,
+# IRMutator::MutateScopeAttrs, and ConvertToSSA::SubstScopeAttrs. Missing the
+# SSA one leaves the predicate pointing at the pre-SSA Var: the IR still
+# verifies and codegen still emits a predicate, but it reads a *dangling*
+# operand. These tests pin the observable consequence rather than the
+# mechanism.
+
+_SCOPE_PREDICATE_PROGRAM = """
+import pypto.language as pl
+
+
+@pl.program
+class Prog:
+    @pl.function(type=pl.FunctionType.InCore)
+    def expert(
+        self, x: pl.Tensor[[512, 128], pl.FP32], out: pl.Out[pl.Tensor[[512, 128], pl.FP32]]
+    ) -> pl.Tensor[[512, 128], pl.FP32]:
+        t = pl.load(x, [0, 0], [128, 128])
+        out = pl.store(t, [0, 0], out)
+        return out
+
+    @pl.function(type=pl.FunctionType.InCore)
+    def gate(
+        self, g: pl.Out[pl.Tensor[[512, 128], pl.INT32]]
+    ) -> pl.Tensor[[512, 128], pl.INT32]:
+        t = pl.load(g, [0, 0], [128, 128])
+        g = pl.store(t, [0, 0], g)
+        return g
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def main(
+        self,
+        x: pl.Tensor[[512, 128], pl.FP32],
+        out: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
+        rc: pl.Out[pl.Tensor[[512, 128], pl.INT32]],
+    ) -> pl.Tensor[[512, 128], pl.FP32]:
+        with pl.spmd(1) as g_tid:
+            rc = self.gate(rc)
+        with pl.spmd(1, deps=[g_tid], predicate=(rc[0, 0] > 0)) as t:
+            out = self.expert(x, out)
+        return out
+"""
+
+
+def _spmd_scopes(program: ir.Program) -> list:
+    """Every SpmdScopeStmt in ``main``, in source order."""
+    found: list = []
+
+    def walk(stmt) -> None:
+        if isinstance(stmt, ir.SpmdScopeStmt):
+            found.append(stmt)
+        for field in ("stmts", "body"):
+            value = getattr(stmt, field, None)
+            if isinstance(value, list):
+                for child in value:
+                    walk(child)
+            elif value is not None:
+                walk(value)
+
+    walk(program.get_function("main").body)
+    return found
+
+
+def _predicate_operand(scope) -> ir.Var:
+    """The tensor Var a scope's ``predicate`` attr reads."""
+    predicate = dict(scope.attrs.items())["predicate"]
+    operand = predicate.left
+    while isinstance(operand, ir.Cast):
+        operand = operand.operand
+    return operand.args[0]
+
+
+def test_ssa_renames_scope_predicate_operand():
+    """The operand Var inside the scope-attr Expr is versioned like any other use.
+
+    ``rc`` is rebound by the gate scope, so SSA must rewrite the predicate's
+    operand to the post-rebind version. Without the ConvertToSSA scope-attr
+    branch it would keep pointing at the original parameter Var.
+    """
+    program = pl.parse_program(_SCOPE_PREDICATE_PROGRAM)
+    before = _predicate_operand(_spmd_scopes(program)[1])
+    assert before.name_hint == "rc"
+
+    after_program = passes.convert_to_ssa()(program)
+    after = _predicate_operand(_spmd_scopes(after_program)[1])
+
+    assert after.unique_id != before.unique_id, "predicate operand was not SSA-versioned"
+    assert after.name_hint.startswith("rc"), after.name_hint
+
+
+def test_ssa_predicate_operand_matches_the_gate_scope_result():
+    """The versioned operand is the value the gate scope produced, not a fresh Var.
+
+    Renaming to *some* new Var would satisfy the test above; this pins that it
+    renames to the same SSA version the producing scope defines, which is what
+    makes the dispatch-point read observe the current value.
+    """
+    program = passes.convert_to_ssa()(pl.parse_program(_SCOPE_PREDICATE_PROGRAM))
+    gate_scope, expert_scope = _spmd_scopes(program)
+    operand = _predicate_operand(expert_scope)
+
+    produced = [
+        stmt.var.unique_id
+        for stmt in _flatten_stmts(gate_scope.body)
+        if isinstance(stmt, ir.AssignStmt) and isinstance(stmt.var, ir.Var)
+    ]
+    assert operand.unique_id in produced, (
+        "predicate operand should be the gate scope's SSA result, "
+        f"got {operand.name_hint} (#{operand.unique_id}), scope defines {produced}"
+    )
+
+
+def _flatten_stmts(stmt) -> list:
+    """All statements under ``stmt``, flattening SeqStmts and scope bodies."""
+    out: list = []
+
+    def walk(node) -> None:
+        out.append(node)
+        for field in ("stmts", "body"):
+            value = getattr(node, field, None)
+            if isinstance(value, list):
+                for child in value:
+                    walk(child)
+            elif value is not None:
+                walk(value)
+
+    walk(stmt)
+    return out
+
+def test_structural_hash_handles_var_and_expr_scope_attrs():
+    """Scopes carrying Var-/Expr-valued attrs must be hashable.
+
+    ``structural_hash``'s attr codec used to throw on any attr it could not
+    hash, which made every ``with pl.spmd(...) as tid:`` (``task_id_var``) and
+    every ``with pl.spmd(..., predicate=...)`` un-hashable — valid IR that a
+    caching or dedup path would crash on. Such attrs are now skipped (the hash
+    is coarser; ``structural_equal`` still distinguishes them).
+    """
+    program = pl.parse_program(_SCOPE_PREDICATE_PROGRAM)
+    assert isinstance(ir.structural_hash(program), int)
+
+    # Equal programs still hash equal.
+    again = pl.parse_program(_SCOPE_PREDICATE_PROGRAM)
+    assert ir.structural_hash(program) == ir.structural_hash(again)
+
+    # ...and structural_equal remains the authority on the predicate itself.
+    no_predicate = pl.parse_program(
+        _SCOPE_PREDICATE_PROGRAM.replace(", predicate=(rc[0, 0] > 0)", "")
+    )
+    assert isinstance(ir.structural_hash(no_predicate), int)
+    assert not ir.structural_equal(program, no_predicate)
 
 
 if __name__ == "__main__":

--- a/tests/ut/ir/transforms/test_submit_passes.py
+++ b/tests/ut/ir/transforms/test_submit_passes.py
@@ -212,7 +212,6 @@ def test_submit_single_lhs_form_round_trips():
     passes.convert_to_ssa()(program_before)
 
 
-
 # ---------------------------------------------------------------------------
 # Scope-form dispatch predicate — ``with pl.spmd(..., predicate=...)``
 # ---------------------------------------------------------------------------
@@ -282,7 +281,9 @@ def _spmd_scopes(program: ir.Program) -> list:
             elif value is not None:
                 walk(value)
 
-    walk(program.get_function("main").body)
+    main = program.get_function("main")
+    assert main is not None
+    walk(main.body)
     return found
 
 
@@ -292,7 +293,10 @@ def _predicate_operand(scope) -> ir.Var:
     operand = predicate.left
     while isinstance(operand, ir.Cast):
         operand = operand.operand
-    return operand.args[0]
+    assert isinstance(operand, ir.Call)  # tensor.read
+    tensor = operand.args[0]
+    assert isinstance(tensor, ir.Var)
+    return tensor
 
 
 def test_ssa_renames_scope_predicate_operand():
@@ -352,6 +356,7 @@ def _flatten_stmts(stmt) -> list:
     walk(stmt)
     return out
 
+
 def test_structural_hash_handles_var_and_expr_scope_attrs():
     """Scopes carrying Var-/Expr-valued attrs must be hashable.
 
@@ -369,11 +374,63 @@ def test_structural_hash_handles_var_and_expr_scope_attrs():
     assert ir.structural_hash(program) == ir.structural_hash(again)
 
     # ...and structural_equal remains the authority on the predicate itself.
-    no_predicate = pl.parse_program(
-        _SCOPE_PREDICATE_PROGRAM.replace(", predicate=(rc[0, 0] > 0)", "")
-    )
+    no_predicate = pl.parse_program(_SCOPE_PREDICATE_PROGRAM.replace(", predicate=(rc[0, 0] > 0)", ""))
     assert isinstance(ir.structural_hash(no_predicate), int)
     assert not ir.structural_equal(program, no_predicate)
+
+
+# A predicate whose index is a *computed* Var (``idx``), used nowhere else.
+# That makes the assignment feeding it dead unless DCE counts the predicate as a
+# use — see test_dce_keeps_the_predicate_operands_producer.
+_SCOPE_PREDICATE_LIVE_INDEX_PROGRAM = """
+import pypto.language as pl
+
+
+@pl.program
+class Prog:
+    @pl.function(type=pl.FunctionType.InCore)
+    def expert(
+        self, x: pl.Tensor[[512, 128], pl.FP32], out: pl.Out[pl.Tensor[[512, 128], pl.FP32]]
+    ) -> pl.Tensor[[512, 128], pl.FP32]:
+        t = pl.load(x, [0, 0], [128, 128])
+        out = pl.store(t, [0, 0], out)
+        return out
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def main(
+        self,
+        x: pl.Tensor[[512, 128], pl.FP32],
+        out: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
+        rc: pl.Tensor[[512, 128], pl.INT32],
+        i: pl.Scalar[pl.INT32],
+    ) -> pl.Tensor[[512, 128], pl.FP32]:
+        idx = i + 1
+        with pl.spmd(1, predicate=(rc[idx, 0] > 0)):
+            out = self.expert(x, out)
+        return out
+"""
+
+
+def test_dce_keeps_the_predicate_operands_producer():
+    """A Var used *only* inside the predicate is a live use, not dead code.
+
+    ``idx`` feeds nothing but the predicate's index. Without the predicate
+    branch in DCE's scope-attr live-root collection, its assignment is deleted
+    and the attr is left referencing a free variable — the IR still prints and
+    passes structural checks, so nothing else catches it. Regression for the
+    same failure class as issue #1456.
+    """
+    program = passes.simplify()(pl.parse_program(_SCOPE_PREDICATE_LIVE_INDEX_PROGRAM))
+    main = program.get_function("main")
+    assert main is not None
+    printed = ir.python_print(main)
+
+    assert "idx" in printed, printed
+    # The tell-tale of a dropped live root: the printer renders an undefined
+    # reference with a __FREE_VAR suffix.
+    assert "__FREE_VAR" not in printed, f"predicate references a dangling Var:\n{printed}"
+    # The assignment itself survived, not just the name inside the predicate.
+    assert "idx: pl.Scalar" in printed, printed
 
 
 if __name__ == "__main__":

--- a/tests/ut/language/parser/test_submit_predicate.py
+++ b/tests/ut/language/parser/test_submit_predicate.py
@@ -373,3 +373,232 @@ class Prog:
 """
     with pytest.raises(ParserSyntaxError, match="not in deps="):
         pl.parse_program(src)
+
+
+# ---------------------------------------------------------------------------
+# Scope form — ``with pl.spmd(..., predicate=...)``
+# ---------------------------------------------------------------------------
+#
+# The scope form shares every validation helper with pl.spmd_submit (the shape
+# checks above are not re-run per form), but reaches the IR by a different
+# route: the predicate rides on ``SpmdScopeStmt.attrs`` as an Expr until
+# OutlineSpmdScopes moves it onto ``Submit.predicate``. These tests cover the
+# attr landing, all three spmd spellings, the print round-trip, and the two
+# rejections specific to a scope (cluster nesting, producer-not-in-deps).
+
+_SCOPE_HEAD = f"""
+@pl.program
+class Prog:
+    @pl.function(type=pl.FunctionType.InCore)
+    def expert(self, x: {_FP32_T}, out: pl.Out[{_FP32_T}]) -> {_FP32_T}:
+        t = pl.load(x, [0, 0], [128, 128])
+        out = pl.store(t, [0, 0], out)
+        return out
+
+    @pl.function(type=pl.FunctionType.InCore)
+    def gate(self, g: pl.Out[{_INT32_T}]) -> {_INT32_T}:
+        t = pl.load(g, [0, 0], [128, 128])
+        g = pl.store(t, [0, 0], g)
+        return g
+"""
+
+
+def _scope_program(predicate_src: str = "rc[0, 0] > 0", deps_src: str = "deps=[g_tid], "):
+    """Two spmd scopes; the second carries ``predicate_src`` (as-tid form)."""
+    return pl.parse_program(
+        _SCOPE_HEAD
+        + f"""
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def main(
+        self, x: {_FP32_T}, out: pl.Out[{_FP32_T}], rc: pl.Out[{_INT32_T}]
+    ) -> {_FP32_T}:
+        with pl.spmd(1) as g_tid:
+            rc = self.gate(rc)
+        with pl.spmd(1, {deps_src}predicate=({predicate_src})) as t:
+            out = self.expert(x, out)
+        return out
+"""
+    )
+
+
+def _spmd_scopes(prog):
+    """All SpmdScopeStmts in ``main``, in source order."""
+    found = []
+
+    def walk(stmt):
+        if isinstance(stmt, ir.SpmdScopeStmt):
+            found.append(stmt)
+        for field in ("stmts", "body"):
+            value = getattr(stmt, field, None)
+            if isinstance(value, list):
+                for child in value:
+                    walk(child)
+            elif value is not None:
+                walk(value)
+
+    walk(prog.get_function("main").body)
+    return found
+
+
+def test_scope_predicate_lands_on_scope_attrs():
+    """The predicate is stored on the scope as the comparison Expr itself."""
+    prog = _scope_program("rc[0, 0] > 0")
+    gate_scope, expert_scope = _spmd_scopes(prog)
+    assert "predicate" not in dict(gate_scope.attrs.items())
+    predicate = dict(expert_scope.attrs.items())["predicate"]
+    assert isinstance(predicate, ir.Gt)
+    assert _pred_const(predicate).value == 0
+    # Reuses tensor.read rather than a bespoke encoding.
+    assert _pred_read(predicate).op.name == "tensor.read"
+    assert [c.value for c in _pred_indices(predicate)] == [0, 0]
+
+
+def test_scope_predicate_canonical_attr_order():
+    """deps -> task_id_var -> predicate; the print round-trip relies on it."""
+    prog = _scope_program()
+    _, expert_scope = _spmd_scopes(prog)
+    assert [k for k, _ in expert_scope.attrs.items()] == [
+        "manual_dep_edges",
+        "task_id_var",
+        "predicate",
+    ]
+
+
+def test_scope_predicate_print_parse_round_trip():
+    prog = _scope_program("rc[0, 0] >= 2")
+    printed = python_print(prog)
+    assert "predicate=(" in printed
+    reparsed = pl.parse_program(printed)
+    ir.assert_structural_equal(reparsed, prog)
+
+
+def test_scope_predicate_plain_with_form():
+    """No ``as tid``: the predicate still lands (the outliner synthesises a tid).
+
+    ``rc`` is a plain parameter here, so it has no tracked producer and the
+    deps contract check passes without a ``deps=`` (unavailable on this form).
+    """
+    prog = pl.parse_program(
+        _SCOPE_HEAD
+        + f"""
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def main(
+        self, x: {_FP32_T}, out: pl.Out[{_FP32_T}], rc: {_INT32_T}
+    ) -> {_FP32_T}:
+        with pl.spmd(1, predicate=(rc[0, 0] > 0)):
+            out = self.expert(x, out)
+        return out
+"""
+    )
+    (scope,) = _spmd_scopes(prog)
+    assert isinstance(dict(scope.attrs.items())["predicate"], ir.Gt)
+
+
+def test_scope_predicate_for_form():
+    """``for i in pl.spmd(n, predicate=...)`` records the predicate too."""
+    prog = pl.parse_program(
+        _SCOPE_HEAD
+        + f"""
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def main(
+        self, x: {_FP32_T}, out: pl.Out[{_FP32_T}], rc: {_INT32_T}
+    ) -> {_FP32_T}:
+        for i in pl.spmd(4, predicate=(rc[0, 0] > 0)):
+            t = pl.load(x, [i * 128, 0], [128, 128])
+            out = pl.store(t, [i * 128, 0], out)
+        return out
+"""
+    )
+    (scope,) = _spmd_scopes(prog)
+    assert isinstance(dict(scope.attrs.items())["predicate"], ir.Gt)
+
+
+def test_scope_predicate_operand_producer_must_be_in_deps():
+    """Same contract as the call form: omitting deps= is caught."""
+    with pytest.raises(ParserSyntaxError, match="produced by the task"):
+        _scope_program("rc[0, 0] > 0", deps_src="")
+
+
+def test_scope_predicate_rejected_inside_cluster():
+    """A cluster-nested pl.spmd never becomes a Submit, so the predicate is lost."""
+    with pytest.raises(ParserSyntaxError, match="cannot be nested inside `pl.cluster"):
+        pl.parse_program(
+            _SCOPE_HEAD
+            + f"""
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def main(
+        self, x: {_FP32_T}, out: pl.Out[{_FP32_T}], rc: {_INT32_T}
+    ) -> {_FP32_T}:
+        with pl.cluster():
+            with pl.spmd(1, predicate=(rc[0, 0] > 0)):
+                out = self.expert(x, out)
+        return out
+"""
+        )
+
+
+def test_scope_predicate_shape_validation_is_shared():
+    """The call form's shape rules apply verbatim — spot-check two."""
+    with pytest.raises(ParserSyntaxError, match="must compare one tensor element"):
+        _scope_program("rc[0, 0] % 8 == 0")
+    with pytest.raises(ParserSyntaxError, match="Only simple comparisons"):
+        _scope_program("0 < rc[0, 0] < 8")
+
+
+def test_scope_without_predicate_has_no_attr():
+    prog = pl.parse_program(
+        _SCOPE_HEAD
+        + f"""
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def main(self, x: {_FP32_T}, out: pl.Out[{_FP32_T}]) -> {_FP32_T}:
+        with pl.spmd(1):
+            out = self.expert(x, out)
+        return out
+"""
+    )
+    (scope,) = _spmd_scopes(prog)
+    assert "predicate" not in dict(scope.attrs.items())
+
+
+def test_scope_producer_is_tracked_for_the_deps_contract():
+    """A scope-produced operand IS tracked, so ``deps=`` is genuinely enforced.
+
+    The rejection test above only proves *something* raised; this pins the
+    mechanism: naming the producing scope in ``deps=`` accepts, and the same
+    program without it rejects. Before scope-producer tracking existed both
+    spellings parsed, silently certifying a stale-read predicate.
+    """
+    # Producer named in deps= -> accepted.
+    prog = _scope_program("rc[0, 0] > 0", deps_src="deps=[g_tid], ")
+    _, expert_scope = _spmd_scopes(prog)
+    assert isinstance(dict(expert_scope.attrs.items())["predicate"], ir.Gt)
+    # Same program, producer omitted -> rejected, naming the producing task.
+    with pytest.raises(ParserSyntaxError, match="produced by the task"):
+        _scope_program("rc[0, 0] > 0", deps_src="")
+
+
+def test_scope_producer_tracking_survives_tid_rebinding():
+    """A rebound ``tid`` name must not certify an unrelated scope.
+
+    Strict SSA reuses one ``ir.Var`` object across same-named rebindings, so
+    identity alone would match; the per-Var generation counter is what makes
+    this reject.
+    """
+    with pytest.raises(ParserSyntaxError, match="produced by the task"):
+        pl.parse_program(
+            _SCOPE_HEAD
+            + f"""
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def main(
+        self, x: {_FP32_T}, out: pl.Out[{_FP32_T}], rc: pl.Out[{_INT32_T}],
+        rc2: pl.Out[{_INT32_T}]
+    ) -> {_FP32_T}:
+        with pl.spmd(1) as tid:
+            rc = self.gate(rc)
+        with pl.spmd(1) as tid:
+            rc2 = self.gate(rc2)
+        with pl.spmd(1, deps=[tid], predicate=(rc[0, 0] > 0)) as t:
+            out = self.expert(x, out)
+        return out
+"""
+        )

--- a/tests/ut/language/parser/test_submit_predicate.py
+++ b/tests/ut/language/parser/test_submit_predicate.py
@@ -294,10 +294,6 @@ def test_print_parse_round_trip():
     ir.assert_structural_equal(reparsed, prog)
 
 
-if __name__ == "__main__":
-    pytest.main([__file__, "-v"])
-
-
 # ---------------------------------------------------------------------------
 # Runtime-ABI safety: operand dtype and index range
 # ---------------------------------------------------------------------------
@@ -521,7 +517,7 @@ def test_scope_predicate_operand_producer_must_be_in_deps():
 
 def test_scope_predicate_rejected_inside_cluster():
     """A cluster-nested pl.spmd never becomes a Submit, so the predicate is lost."""
-    with pytest.raises(ParserSyntaxError, match="cannot be nested inside `pl.cluster"):
+    with pytest.raises(ParserSyntaxError, match=r"cannot be nested inside `pl\.cluster"):
         pl.parse_program(
             _SCOPE_HEAD
             + f"""
@@ -602,3 +598,43 @@ def test_scope_producer_tracking_survives_tid_rebinding():
         return out
 """
         )
+
+
+def test_scope_predicate_deps_hint_matches_the_form():
+    """The remediation hint must be reachable from the form the author wrote.
+
+    Scope-producer tracking made this case reachable: on the plain / for-forms
+    ``deps=`` is rejected outright, so a hint saying "add deps=[tid]" would send
+    the author into a second, different error. Those forms are told to switch to
+    the ``as tid`` capture form instead.
+    """
+    # as-tid form: deps= is available, so "add it" is the right advice.
+    with pytest.raises(ParserSyntaxError) as as_tid:
+        _scope_program("rc[0, 0] > 0", deps_src="")
+    assert "deps=[g_tid]" in as_tid.value.hint, as_tid.value.hint
+
+    # plain with-form: deps= is not accepted; the hint must say so and point at
+    # the capture form rather than at a kwarg that would itself be rejected.
+    plain_src = (
+        _SCOPE_HEAD
+        + f"""
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def main(
+        self, x: {_FP32_T}, out: pl.Out[{_FP32_T}], rc: pl.Out[{_INT32_T}]
+    ) -> {_FP32_T}:
+        with pl.spmd(1) as g_tid:
+            rc = self.gate(rc)
+        with pl.spmd(1, predicate=(rc[0, 0] > 0)):
+            out = self.expert(x, out)
+        return out
+"""
+    )
+    with pytest.raises(ParserSyntaxError) as plain:
+        pl.parse_program(plain_src)
+    hint = plain.value.hint
+    assert "does not accept deps=" in hint, hint
+    assert "as tid" in hint, hint
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
> **Phase 3 of [hw-native-sys/pypto#2066](https://github.com/hw-native-sys/pypto/issues/2066)** — dispatch-predicate phased rollout. Phase 1 ([hw-native-sys/pypto#2067](https://github.com/hw-native-sys/pypto/pull/2067)) shipped the call form; this is the scope form. Pure frontend on the current runtime — no submodule bump.

## What this does

Extends `predicate=` from `pl.spmd_submit` to the `with pl.spmd(...)` scope form, accepted on all three spmd spellings (plain `with`, `with ... as tid`, `for i in pl.spmd(...)`):

```python
with pl.spmd(1) as g_tid:                                        # producer of rc
    rc = self.gate(rc)

with pl.spmd(4, deps=[g_tid], predicate=(rc[0, 0] > 0)) as tid:  # producer is a dep
    out = self.expert(x, out)
```

Same expression, same validation, same lowering, same runtime ABI as the call form. `pl.at(..., predicate=...)` is deliberately **not** included — the C++ side is shared, so a later cut is parser + `dsl_api` only.

## Why it is not just "another kwarg"

`pl.spmd_submit` builds a `Submit` at parse time, so `Submit::predicate_` is covered by the existing field walk with zero scope plumbing. A **scope** is outlined only at `OutlineSpmdScopes`, so between parse and outline the predicate rides on `SpmdScopeStmt::attrs_` as an Expr carrying **live SSA Vars** (the operand tensor and its indices).

That makes it the **first Expr-valued scope attr** — every scope-attr walker had a `VarPtr`-only allow-list:

| Walker | Why it must know |
| --- | --- |
| `IRVisitor::VisitScopeAttrs` | use-def / liveness analyses |
| `IRMutator::MutateScopeAttrs` | generic Expr remapping |
| `ConvertToSSA::SubstScopeAttrs` | versions the operand; mirrors the `kAttrDevice` `ExprPtr` handling on `Call`. Substituted **before** the body so the operand resolves to the value visible at scope entry — what the scheduler reads at the dispatch point |
| `DCE FindLiveRoots` | otherwise the operand's feeding assignment looks dead; removing it leaves a dangling attr ref (same failure mode as #1456) |

The tracking issue predicted the first three; **DCE was a fourth**, found in review.

`ScopeOutliner` then moves the attr onto `Submit::predicate_` and — like `allow_early_resolve` — forces the `Submit` shape, synthesising a TaskId Var when the scope has no `as tid`. Codegen is untouched.

## Also in this change

- **`kAttrPredicate`** replaces the raw `"predicate"` literals (`expr.h`, `orchestration_codegen`, `window_externalization`), per the `kAttrDevice` precedent.
- **`NoNestedCall` exemption**, as Phase 1 exempted the Submit field: the comparison is a declarative spec the scheduler evaluates at the dispatch point, so flattening it would hoist the read into a real orchestration load that stalls on `wait_for_tensor_ready` — the very stall the predicate exists to avoid. Implemented as a new `ShouldVisitScopeAttr(key)` hook rather than an override of the whole walk, so the base walker stays the single source of truth (an attr added there stays covered by the verifier).
- **Scope-producer tracking for the producer∈deps contract.** The tracking table was only written at `pl.submit`/`pl.spmd_submit` tuple unpacking, so a tensor produced by `with pl.spmd(...) as tid:` had **no recorded producer** and the check silently certified a stale read — in the spelling most natural to write. Same best-effort scope and generation counter as the submit path.
- **Cluster nesting rejects `predicate=`** at parse time, and `UnwrapNestedSpmd` asserts it for hand-built / deserialized IR: such a scope is unwrapped into the Group function and never produces a `Submit`, so the predicate would be silently dropped.

### Drive-by fix: `structural_hash` on scope attrs

`structural_hash`'s attr codec threw on anything it could not hash. That already made **every** `with pl.spmd(...) as tid:` un-hashable (`task_id_var`), and this PR would have extended it to any scope predicate. Var-/Expr-valued attrs are now **skipped** rather than thrown on — which is what the code's own comment always claimed ("compared by structural_equal but not currently part of the hash"). Skipping only makes the hash coarser (a legal collision); `structural_equal` still distinguishes them.

## Testing

- **Parser** — all three spmd forms, predicate lands on `SpmdScopeStmt.attrs`, canonical attr order, print → reparse round-trip, cluster rejection, producer∈deps rejection **and** acceptance, tid-rebinding generation check, shared shape validation.
- **Transforms** — SSA versions the operand *to the producing scope's result* (not merely to some new Var); `structural_hash` regression.
- **Codegen** — full `Default` pipeline → `L0TaskPredicate` + `set_predicate`, operator/operand-order mapping, `set_predicate` ordering vs `rt_submit_*`.
- **On-board ST** — `tests/st/runtime/scheduling/test_predicated_dispatch.py` gains a scope-form variant with the identical task chain and expected values, proving the two spellings agree on hardware rather than only in codegen text. **4/4 pass on a2a3** (gate=0 skips, gate=1 dispatches; the consumer unlocks in both cases, so inline-retire still settles fanout).
- **Regression** — full UT suite **7382 passed, 2 skipped**.

## Docs

`docs/en/dev/language/00-python_syntax.md` + `docs/zh-cn/...` — the stale "scope form is not yet supported" note is removed from both; new subsection covers the scope form, the `deps=`-needs-`as tid` consequence, cluster rejection, and scope-producer tracking.

Refs #2066