### PR TITLE
feat(distributed): host-orchestrated ring allreduce with builtin.tensor.allreduce_ring

### DIFF
--- a/docs/en/dev/distributed_ops.md
+++ b/docs/en/dev/distributed_ops.md
@@ -368,7 +368,9 @@ counts. InCore lowering uses UB-bounded chunks; the host builtin uses
 tail span to 32 bytes. The host builtin rounds ragged FP16 and FP32 load spans
 to 32 bytes. Both preserve the logical valid shape. The host builtin accepts either a
 rank-1 `[world_size]` signal or the synthesized rank-2 `[world_size, 1]`
-signal.
+signal. Ring mode (`mode="ring"`) for the host orchestrator lowers to
+`builtin.tensor.allreduce_ring` and requires an explicit rank-2
+`[2 * (NR - 1) + 1, NR]` INT32 signal (one extra row for the return barrier).
 
 ### `pld.system.notify` (TNOTIFY)
 
@@ -440,6 +442,7 @@ dispatches before the final `Simplify`.
   (each likewise dynamic-NR, P=2/P=4),
   `test_l3_tensor_allreduce_intrinsic.py`, `test_l3_tensor_allreduce_ring_intrinsic.py`,
   `test_l3_allreduce_ring.py` (hand-rolled ring RS+AG), `test_l3_host_tensor_allreduce.py`,
+  `test_l3_host_tensor_allreduce_ring.py`,
   `test_l3_ep_dispatch_combine.py`, `test_l3_notify_wait.py`,
   `test_l3_tensor_all_to_all_v_intrinsic.py`, and related L3 STs
   under `tests/st/distributed/`. **Put/get canonical e2e contracts** are now

--- a/docs/en/dev/passes/40-lower_host_tensor_collectives.md
+++ b/docs/en/dev/passes/40-lower_host_tensor_collectives.md
@@ -29,6 +29,7 @@ For a host-orchestrator call:
 
 ```python
 data = pld.tensor.allreduce(data, signal, op=pld.ReduceOp.Sum)
+data = pld.tensor.allreduce(data, signal, op=pld.ReduceOp.Sum, mode="ring")
 signal = pld.tensor.barrier(signal)
 data = pld.tensor.broadcast(data, signal, root=0)
 data = pld.tensor.reduce_scatter(data, signal, op=pld.ReduceOp.Sum)
@@ -36,14 +37,24 @@ data = pld.tensor.allgather(stage, data, signal)
 data = pld.tensor.all_to_all(stage, data, signal)
 ```
 
+`pld.tensor.allreduce` dispatches on its `mode` kwarg: the default
+`mode="mesh"` lowers to `builtin.tensor.allreduce`, while `mode="ring"` lowers
+to `builtin.tensor.allreduce_ring`. Any other value is rejected as a user
+error.
+
 For `allgather` / `all_to_all`, `stage` (TPUT source) and `data` (result)
 must be two distinct windows. For `allgather` the `stage` window holds only
 this rank's single chunk and is `[1, SIZE]`; for `all_to_all` it carries one
 per-destination chunk per row and is `[NR, SIZE]`. In both cases `data` is the
 `[NR, SIZE]` result window peers push into.
-the pass emits the corresponding `builtin.tensor.*` dispatch per participating
-device.  When the surrounding comm-domain scope has an explicit device list,
-the pass emits a `SeqStmts`; otherwise it emits a sequential `for r in
+
+The pass emits the corresponding `builtin.tensor.*` dispatch per participating
+device (including `builtin.tensor.allreduce` /
+`builtin.tensor.allreduce_ring`, `builtin.tensor.barrier`,
+`builtin.tensor.broadcast`, `builtin.tensor.reduce_scatter`,
+`builtin.tensor.allgather`, and `builtin.tensor.all_to_all`). When the
+surrounding comm-domain scope has an explicit device list, the pass emits a
+`SeqStmts`; otherwise it emits a sequential `for r in
 pld.system.world_size()` loop.
 
 Each generated builtin call carries the collective-specific args and kwarg
@@ -63,7 +74,21 @@ positive element counts. It processes 256-element chunks and rounds ragged FP16
 and FP32 load spans to 32 bytes without changing the logical tensor shape.
 Its INT32 signal tensor may be rank-1 `[world_size]` or rank-2
 `[world_size, 1]`, with enough static capacity when the participating device
-count is statically known.
+count is statically known. Ring allreduce (`mode="ring"`) uses a rank-2 signal shaped
+`[2 * (NR - 1) + 1, NR]`, whose `shape[0]` must equal `2 * (NR - 1) + 1` when both
+signal dimensions are compile-time constants, and must be at least
+`2 * (NR - 1) + 1` when only `shape[0]` is statically known (no static check when
+both dims are dynamic). When the participating device count is statically known, the signal
+must have enough static capacity. Ring allreduce additionally requires `numel(src) % NR == 0`
+(the ring schedule partitions src into NR contiguous chunks; a non-zero remainder would leave a
+trailing partial chunk the kernel cannot handle). The host-ring `src` shape must be
+statically known — dynamic extents are rejected, since the kernel would otherwise silently
+return unreduced data when the runtime `numel` is not divisible by `NR`.
+
+Ring allreduce currently supports only `ReduceOp.Sum` with `dtype=FP32`.
+`ReduceOp.Max`, `ReduceOp.Min`, `ReduceOp.Prod`, and `FP16` are not yet available
+with `mode="ring"`. Ring allreduce also supports at most 16 participating
+devices (`world_size <= 16`).
 
 ## Pass properties
 

--- a/docs/zh/dev/distributed_ops.md
+++ b/docs/zh/dev/distributed_ops.md
@@ -318,7 +318,9 @@ host builtin 路径均支持 FP16、FP32，以及任意正元素数量下的
 分块，host builtin 使用 256 元素分块。InCore mesh 和 ring 只把 FP16 remote
 尾块的物理范围向上对齐到 32 字节；host builtin 会把 FP16 和 FP32 的 ragged load
 范围都对齐到 32 字节。两者都保留逻辑 valid shape。host builtin 接受 rank-1
-`[world_size]` 或合成的 rank-2 `[world_size, 1]` signal。
+`[world_size]` 或合成的 rank-2 `[world_size, 1]` signal。Ring 模式
+（`mode="ring"`）在 host orchestrator 中降级为 `builtin.tensor.allreduce_ring`，
+要求显式 rank-2 `[2 * (NR - 1) + 1, NR]` INT32 signal（额外增加一行用于返回屏障）。
 
 ### `pld.system.notify`（TNOTIFY）
 
@@ -386,6 +388,7 @@ host_orch 函数体包裹进嵌套的 `CommDomainScopeStmt` 节点（按推断�
   P=2/P=4）、`test_l3_tensor_allreduce_intrinsic.py`、
   `test_l3_tensor_allreduce_ring_intrinsic.py`、
   `test_l3_allreduce_ring.py`（手写 ring RS+AG）、
+  `test_l3_host_tensor_allreduce.py`、`test_l3_host_tensor_allreduce_ring.py`、
   `test_l3_ep_dispatch_combine.py`、`test_l3_notify_wait.py`、
   `test_l3_tensor_all_to_all_v_intrinsic.py`，以及
   `tests/st/distributed/` 下其他 L3 ST。**Put/Get 端到端权威契约** 已启用：

--- a/docs/zh/dev/passes/40-lower_host_tensor_collectives.md
+++ b/docs/zh/dev/passes/40-lower_host_tensor_collectives.md
@@ -28,6 +28,7 @@ builtin chip dispatch。它在 [`MaterializeCommDomainScopes`](39-materialize_co
 
 ```python
 data = pld.tensor.allreduce(data, signal, op=pld.ReduceOp.Sum)
+data = pld.tensor.allreduce(data, signal, op=pld.ReduceOp.Sum, mode="ring")
 signal = pld.tensor.barrier(signal)
 data = pld.tensor.broadcast(data, signal, root=0)
 data = pld.tensor.reduce_scatter(data, signal, op=pld.ReduceOp.Sum)
@@ -35,15 +36,20 @@ data = pld.tensor.allgather(stage, data, signal)
 data = pld.tensor.all_to_all(stage, data, signal)
 ```
 
+`pld.tensor.allreduce` 根据 `mode` kwarg 进行分发：默认 `mode="mesh"` 会 lower 到
+`builtin.tensor.allreduce`，而 `mode="ring"` 会 lower 到
+`builtin.tensor.allreduce_ring`。其他取值将作为用户错误被拒绝。
+
 对于 `allgather` / `all_to_all`，`stage`（TPUT 源）与 `data`（结果）
 必须是两个不同的 window。`allgather` 的 `stage` 只保存本 rank 的单个分片，
 形状为 `[1, SIZE]`；`all_to_all` 的 `stage` 每行携带一个按目的地划分的分片，
 形状为 `[NR, SIZE]`。两种情况下 `data` 都是 peer 推入的 `[NR, SIZE]` 结果窗口。
 
 本 pass 会为每个参与设备生成对应的 `builtin.tensor.*` 调用（如
-`builtin.tensor.allreduce`、`builtin.tensor.barrier`、
-`builtin.tensor.broadcast`、`builtin.tensor.reduce_scatter`、
-`builtin.tensor.allgather`、`builtin.tensor.all_to_all`）。若外层
+`builtin.tensor.allreduce`、`builtin.tensor.allreduce_ring`、
+`builtin.tensor.barrier`、`builtin.tensor.broadcast`、
+`builtin.tensor.reduce_scatter`、`builtin.tensor.allgather`、
+`builtin.tensor.all_to_all`）。若外层
 comm-domain scope 带有显式 device 列表，则生成 `SeqStmts`；否则生成顺序
 `for r in pld.system.world_size()` 循环。
 
@@ -61,7 +67,16 @@ comm-domain scope 带有显式 device 列表，则生成 `SeqStmts`；否则生�
 `ReduceOp.Sum`、`Max`、`Min` 和 `Prod`，并支持任意正元素数量。它按 256 个
 元素分块，并把 FP16 和 FP32 的 ragged load 范围都对齐到 32 字节，不改变逻辑 tensor shape。
 signal 必须是 INT32 tensor，形状可以是 rank-1 `[world_size]` 或 rank-2
-`[world_size, 1]`；当参与设备数静态可知时，signal 的静态容量必须足够。
+`[world_size, 1]`；当参与设备数静态可知时，signal 的静态容量必须足够。Ring allreduce（`mode="ring"`）
+的 signal 为 rank-2，形状为 `[2 * (NR - 1) + 1, NR]`，其
+`shape[0]` 在 signal 两个维度均为编译期常量时必须恰好等于 `2 * (NR - 1) + 1`；仅
+`shape[0]` 静态可知时则至少为 `2 * (NR - 1) + 1`（两个维度均为动态时无静态检查）。
+当参与设备数静态可知时，signal 的静态容量必须足够。ring allreduce 还要求 `numel(src) % NR == 0`（ring schedule 将 src 划分为 NR 个连续 chunk；余数非零会留下内核无法处理的尾部部分 chunk）。host-ring 的 `src` 形状必须静态已知——动态 extent 会被拒绝，否则运行时 `numel` 不被 `NR` 整除时内核会静默返回未归约的数据。
+
+Ring allreduce 目前仅支持 `ReduceOp.Sum` 和 `dtype=FP32`。
+`ReduceOp.Max`、`ReduceOp.Min`、`ReduceOp.Prod` 以及 `FP16` 在
+`mode="ring"` 下尚未支持。Ring allreduce 最多支持 16 个参与设备
+（`world_size <= 16`）。
 
 ## Pass 属性
 

--- a/python/pypto/language/distributed/op/_utils.py
+++ b/python/pypto/language/distributed/op/_utils.py
@@ -10,7 +10,7 @@
 """Shared helpers for ``pld.*`` DSL wrappers."""
 
 from collections.abc import Sequence
-from typing import Any
+from typing import Any, overload
 
 from pypto.language.typing import IntLike, Scalar
 from pypto.pypto_core import ir as _ir
@@ -32,6 +32,24 @@ def _unwrap(value: Any) -> Any:
 def _normalize_intlike(seq: Sequence[IntLike]) -> list[int | Expr]:
     """Unwrap Scalar elements to Expr so the sequence matches C++ binding types."""
     return [elem.unwrap() if isinstance(elem, Scalar) else elem for elem in seq]
+
+
+@overload
+def _unwrap_distributed_tensors(op_name: str, *, target: Any) -> tuple[Expr]: ...
+
+
+@overload
+def _unwrap_distributed_tensors(op_name: str, *, signal: Any) -> tuple[Expr]: ...
+
+
+@overload
+def _unwrap_distributed_tensors(op_name: str, *, target: Any, signal: Any) -> tuple[Expr, Expr]: ...
+
+
+@overload
+def _unwrap_distributed_tensors(
+    op_name: str, *, target: Any, signal: Any, recv_counts: Any
+) -> tuple[Expr, Expr, Expr]: ...
 
 
 def _unwrap_distributed_tensors(op_name: str, **named: Any) -> tuple[Expr, ...]:

--- a/python/pypto/language/distributed/op/tensor_ops.py
+++ b/python/pypto/language/distributed/op/tensor_ops.py
@@ -573,6 +573,18 @@ def allreduce(
     (mesh mode only — ring mode on the HOST rail is delivered by a
     subsequent host builtin).
 
+    Mesh signal shape is ``[NR, 1]``. The InCore ring schedule uses
+    ``[2 * (NR − 1), NR]`` (one row per ring round). The host builtin
+    ring schedule uses ``[2 * (NR − 1) + 1, NR]`` (one extra row for
+    the return barrier). Both are single-shot per call.
+
+    .. note::
+
+        The host-builtin ring schedule currently supports only
+        ``ReduceOp.Sum`` with ``dtype=FP32``.  ``ReduceOp.Max``,
+        ``ReduceOp.Min``, ``ReduceOp.Prod``, and ``FP16`` are not yet
+        available with ``mode="ring"``.
+
     Fully-valid packed mesh targets are viewed as one logical 1D stream and
     processed in chunks of at most 16 KiB. For statically known smaller targets,
     the physical chunk width shrinks to the smallest 32-byte-aligned width that
@@ -602,16 +614,6 @@ def allreduce(
     a ready barrier before remote reads and a read-complete barrier before
     store-back. The monotonic expected values are ``2*chunk_id+1`` and
     ``2*chunk_id+2``. The skipped self column remains zero.
-
-    **Do not reuse the same signal buffer for a back-to-back allreduce**
-    — allocate a fresh signal buffer (``alloc_window_buffer`` + ``window``)
-    for each allreduce call. All allreduce calls in ``for`` and ``while``
-    loops are rejected because the current signal protocol cannot provide a
-    fresh signal for every dynamic iteration. A self-resetting variant is
-    blocked on a runtime fix — tracked in #2156 (that issue's affected areas
-    currently list allgather / reduce_scatter / all_to_all / all_to_all_v;
-    allreduce is not listed there yet but hits the identical signal-lifetime
-    constraint, using ``AtomicAdd(1)``/``WaitGe(1)``).
 
     Args:
         target: Window-bound :class:`pld.DistributedTensor` holding per-rank

--- a/python/pypto/runtime/builtins/collectives/allreduce_ring/__init__.py
+++ b/python/pypto/runtime/builtins/collectives/allreduce_ring/__init__.py
@@ -1,0 +1,9 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Ring allreduce builtin source templates (host orchestrator chip dispatch)."""

--- a/python/pypto/runtime/builtins/collectives/allreduce_ring/templates/entry.cpp.in
+++ b/python/pypto/runtime/builtins/collectives/allreduce_ring/templates/entry.cpp.in
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+// Generated from {{template_package}}.
+
+#include <cstdint>
+
+#include "pto_orchestration_api.h"
+
+namespace {
+
+enum class ReduceOp : int32_t {
+  kSum = 0,
+};
+
+template <ReduceOp Op, typename DType>
+void submit_allreduce_ring_kernel(const L2TaskArgs &orch_args) {
+  const Tensor &data = orch_args.tensor(0).ref();
+  const Tensor &signal = orch_args.tensor(1).ref();
+
+  L0TaskArgs params;
+  params.add_inout(data);
+  params.add_inout(signal);
+  params.add_scalar(orch_args.scalar(0));  // nranks
+  params.add_scalar(orch_args.scalar(1));  // CommContext device pointer
+  rt_submit_aiv_task(0, params);
+}
+
+}  // namespace
+
+extern "C" {
+
+__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(
+    const L2TaskArgs &orch_args) {
+  (void)orch_args;
+  return PTO2OrchestrationConfig{
+      .expected_arg_count = 4,
+  };
+}
+
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const L2TaskArgs &orch_args) {
+  submit_allreduce_ring_kernel<{{op_cpp}}, {{dtype_cpp}}>(orch_args);
+}
+
+// The sanitized builtin symbol is kept as an alias-like wrapper for easier
+// debugging of materialized sources; kernel_config.py still uses the standard
+// aicpu_orchestration_entry symbol expected by compile_and_assemble.
+__attribute__((visibility("default"))) void {{entry}}(const L2TaskArgs &orch_args) {
+  aicpu_orchestration_entry(orch_args);
+}
+
+}  // extern "C"

--- a/python/pypto/runtime/builtins/collectives/allreduce_ring/templates/kernel.cpp.in
+++ b/python/pypto/runtime/builtins/collectives/allreduce_ring/templates/kernel.cpp.in
@@ -1,0 +1,272 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+// Generated from {{template_package}}.
+//
+// Host builtin ring allreduce — in-place chunked reduce-scatter + allgather.
+//
+// ABI (matches mesh host builtins):
+//   tensor(0) = data   window-bound FP32 buffer (InOut)
+//   tensor(1) = signal window-bound INT32 matrix [2*(NR-1) + 1, NR] (InOut)
+//   scalar(0) = nranks
+//   scalar(1) = CommContext device pointer
+//
+// Each rank's data buffer holds SIZE elements (product of tensor shapes). The
+// ring partitions data into NR contiguous chunks of chunk_elems = SIZE // NR
+// and performs RS+AG in-place on those chunk slots. The signal holds one row
+// per ring round (2*(NR-1) rounds) plus a final row for the return barrier.
+
+#include <cstdint>
+#include <pto/pto-inst.hpp>
+
+#include "platform_comm/comm_context.h"
+#include "pto/comm/comm_types.hpp"
+#include "pto/comm/pto_comm_inst.hpp"
+#include "tensor.h"
+
+#ifndef __gm__
+#define __gm__
+#endif
+
+#ifndef __aicore__
+#define __aicore__ [aicore]
+#endif
+
+namespace {
+
+static constexpr int kMaxSupportedRanks = 16;
+static constexpr int64_t kTileCount = 256;
+
+template <typename T>
+AICORE inline __gm__ T *CommRemotePtr(__gm__ CommContext *ctx, __gm__ T *local_ptr, int pe) {
+  uint64_t local_base = ctx->windowsIn[ctx->rankId];
+  uint64_t offset = reinterpret_cast<uint64_t>(local_ptr) - local_base;
+  return reinterpret_cast<__gm__ T *>(ctx->windowsIn[pe] + offset);
+}
+
+// Per-round barrier row: AtomicAdd(0→1) / WaitGe(1), single-shot per row.
+//
+// RoundBarrier follows the simpler repo's ring collective pattern
+// (tests/st/worker/collectives/allreduce/kernels/aiv/allreduce_ibing_kernel.cpp):
+// TNOTIFY / TWAIT + pipe_barrier(PIPE_ALL) without dcci / dsb in the barrier
+// itself.  The step body flushes locally-written chunks to DDR with
+// dcci(…, CACHELINE_OUT) before pipe_barrier(PIPE_ALL), so TSTORE results are
+// globally visible when TNOTIFY fires.  TWAIT ensures the peer has also
+// reached the barrier and drained its own MTE pipes.  The trailing
+// pipe_barrier(PIPE_ALL) then drains any in-flight TNOTIFY / TWAIT traffic
+// before the next TLOAD reads the peer's buffer.
+//
+// Future optimisation: once the kernel moves to a TPUT push model, the
+// barrier can be relaxed to O(1) per invocation (NeighborBarrier:
+// left/right only).  TPUT's write pipeline handles the DDR ordering.
+AICORE inline void RoundBarrier(__gm__ CommContext *ctx, __gm__ int32_t *signal_row, int my_rank,
+                                int nranks) {
+  for (int peer = 0; peer < nranks; ++peer) {
+    if (peer == my_rank) {
+      continue;
+    }
+    __gm__ int32_t *remote_signal = CommRemotePtr(ctx, signal_row + my_rank, peer);
+    pto::comm::Signal sig(remote_signal);
+    pto::comm::TNOTIFY(sig, static_cast<int32_t>(1), pto::comm::NotifyOp::AtomicAdd);
+  }
+  for (int peer = 0; peer < nranks; ++peer) {
+    if (peer == my_rank) {
+      continue;
+    }
+    pto::comm::Signal sig(signal_row + peer);
+    pto::comm::TWAIT(sig, static_cast<int32_t>(1), pto::comm::WaitCmp::GE);
+  }
+  pipe_barrier(PIPE_ALL);
+}
+
+}  // namespace
+
+extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ int64_t *args) {
+  __gm__ Tensor *data_tensor = reinterpret_cast<__gm__ Tensor *>(args[0]);
+  __gm__ Tensor *signal_tensor = reinterpret_cast<__gm__ Tensor *>(args[1]);
+  int nranks = static_cast<int>(args[2]);
+  __gm__ CommContext *comm_ctx = reinterpret_cast<__gm__ CommContext *>(args[3]);
+
+  int64_t numel = 1;
+  for (uint32_t dim = 0; dim < data_tensor->ndims; ++dim) {
+    numel *= static_cast<int64_t>(data_tensor->shapes[dim]);
+  }
+
+  __gm__ {{dtype_cpp}} *data =
+      reinterpret_cast<__gm__ {{dtype_cpp}} *>(data_tensor->buffer.addr) + data_tensor->start_offset;
+  __gm__ int32_t *signal_base =
+      reinterpret_cast<__gm__ int32_t *>(signal_tensor->buffer.addr) + signal_tensor->start_offset;
+
+  int signal_rows = 1;
+  int signal_cols = nranks;
+  if (signal_tensor->ndims >= 2) {
+    signal_rows = static_cast<int>(signal_tensor->shapes[0]);
+    signal_cols = static_cast<int>(signal_tensor->shapes[1]);
+  } else if (signal_tensor->ndims == 1) {
+    signal_cols = static_cast<int>(signal_tensor->shapes[0]);
+  }
+
+  // Soft guards: on any unsupported shape the kernel drains its pipes and
+  // returns without touching data. The host lowering pass and the builtin
+  // type deducer validate divisibility at compile time, so a well-formed
+  // program never hits these early returns; they exist only to keep the
+  // device kernel memory-safe if invoked directly.
+  if (nranks <= 1 || nranks > kMaxSupportedRanks || numel <= 0 || (numel % nranks) != 0) {
+    pipe_barrier(PIPE_ALL);
+    return;
+  }
+
+  const int64_t chunk_elems = numel / nranks;
+
+  const int expected_rounds = 2 * (nranks - 1) + 1;
+  if (signal_rows < expected_rounds || signal_cols < nranks) {
+    pipe_barrier(PIPE_ALL);
+    return;
+  }
+
+  int my_rank = static_cast<int>(comm_ctx->rankId);
+  __gm__ {{dtype_cpp}} *chunks = data;
+
+  using ShapeDyn = pto::Shape<pto::DYNAMIC, pto::DYNAMIC, pto::DYNAMIC, pto::DYNAMIC, pto::DYNAMIC>;
+  using StrideDyn = pto::Stride<pto::DYNAMIC, pto::DYNAMIC, pto::DYNAMIC, pto::DYNAMIC, pto::DYNAMIC>;
+  using Global = pto::GlobalTensor<{{dtype_cpp}}, ShapeDyn, StrideDyn, pto::Layout::ND>;
+  using TileData = pto::Tile<pto::TileType::Vec, {{dtype_cpp}}, 1, kTileCount, pto::BLayout::RowMajor, -1,
+                             -1>;
+
+  TileData chunk_tile(1, kTileCount);
+  TileData recv_tile(1, kTileCount);
+  static_assert(sizeof({{dtype_cpp}}) == 4,
+                "builtin.tensor.allreduce_ring currently only supports 4-byte element types");
+  constexpr int kRecvTileInitFill = 0x10000;  // bind-time placeholder; overwritten by TLOAD
+  TASSIGN(chunk_tile, 0x0);
+  TASSIGN(recv_tile, kRecvTileInitFill);
+
+  const int tile_cols = static_cast<int>(chunk_elems < kTileCount ? chunk_elems : kTileCount);
+
+  int round = 0;
+
+  // Phase 1: reduce-scatter — (NR-1) ring steps.
+  for (int step = 1; step < nranks; ++step) {
+    const int recv_add_idx = (my_rank - step - 1 + nranks) % nranks;
+
+    RoundBarrier(comm_ctx, signal_base + round * signal_cols, my_rank, nranks);
+    ++round;
+
+    const int left = (my_rank - 1 + nranks) % nranks;
+
+    const int left_send_idx = (left - step + nranks) % nranks;
+
+    for (int64_t tile_off = 0; tile_off < chunk_elems; tile_off += tile_cols) {
+      int64_t remain64 = chunk_elems - tile_off;
+      int tile_elems = static_cast<int>(remain64 < tile_cols ? remain64 : tile_cols);
+
+      chunk_tile.SetValidShape(1, tile_elems);
+      recv_tile.SetValidShape(1, tile_elems);
+
+      ShapeDyn tile_shape(1, 1, 1, 1, tile_elems);
+      StrideDyn tile_stride(tile_elems, tile_elems, tile_elems, tile_elems, 1);
+
+      {
+        __gm__ {{dtype_cpp}} *remote_chunk =
+            CommRemotePtr(comm_ctx, chunks + static_cast<size_t>(left_send_idx * chunk_elems + tile_off), left);
+        Global remote_g(remote_chunk, tile_shape, tile_stride);
+        TLOAD(recv_tile, remote_g);
+        set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+        wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+      }
+
+      Global acc_g(chunks + static_cast<size_t>(recv_add_idx * chunk_elems + tile_off), tile_shape, tile_stride);
+      TLOAD(chunk_tile, acc_g);
+      set_flag(PIPE_MTE2, PIPE_V, EVENT_ID1);
+      wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID1);
+      TADD(chunk_tile, chunk_tile, recv_tile);
+      set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+      wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+      TSTORE(acc_g, chunk_tile);
+      set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
+      wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
+    }
+    // Flush written chunk to DDR so peers' AG TLOAD sees fresh data.
+    //
+    // The 16-element stride only covers the whole chunk when chunk_elems is a
+    // multiple of 16 (64 B-aligned chunk base); numel % NR == 0 does not
+    // guarantee that, so an unaligned chunk's trailing cache line is not
+    // flushed here (and in the AG-phase flush below).  Unaligned-chunk flush
+    // and the 32 B transfer alignment are shared mesh/ring work handled
+    // separately.
+    {
+      constexpr int kCacheLineFloats = 16;  // 64 B cache line / 4 B per float
+      for (int64_t off = 0; off < chunk_elems; off += kCacheLineFloats) {
+        dcci(chunks + static_cast<size_t>(recv_add_idx * chunk_elems + off),
+             SINGLE_CACHE_LINE, CACHELINE_OUT);
+      }
+    }
+    pipe_barrier(PIPE_ALL);
+  }
+
+  // Phase 2: allgather — (NR-1) ring steps.
+  for (int step = 1; step < nranks; ++step) {
+    const int recv_idx = (my_rank - step + nranks) % nranks;
+
+    RoundBarrier(comm_ctx, signal_base + round * signal_cols, my_rank, nranks);
+    ++round;
+
+    const int left = (my_rank - 1 + nranks) % nranks;
+
+    const int left_send_idx = (left - step + 1 + nranks) % nranks;
+
+    for (int64_t tile_off = 0; tile_off < chunk_elems; tile_off += tile_cols) {
+      int64_t remain64 = chunk_elems - tile_off;
+      int tile_elems = static_cast<int>(remain64 < tile_cols ? remain64 : tile_cols);
+
+      recv_tile.SetValidShape(1, tile_elems);
+
+      ShapeDyn tile_shape(1, 1, 1, 1, tile_elems);
+      StrideDyn tile_stride(tile_elems, tile_elems, tile_elems, tile_elems, 1);
+
+      {
+        __gm__ {{dtype_cpp}} *remote_chunk =
+            CommRemotePtr(comm_ctx, chunks + static_cast<size_t>(left_send_idx * chunk_elems + tile_off), left);
+        Global remote_g(remote_chunk, tile_shape, tile_stride);
+        TLOAD(recv_tile, remote_g);
+        set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+        wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+      }
+
+      Global dst_g(chunks + static_cast<size_t>(recv_idx * chunk_elems + tile_off), tile_shape, tile_stride);
+      set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+      wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+      TSTORE(dst_g, recv_tile);
+      set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
+      wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
+    }
+    // Flush received chunk to DDR so peers' next-round AG TLOAD sees fresh data.
+    {
+      constexpr int kCacheLineFloats = 16;  // 64 B cache line / 4 B per float
+      for (int64_t off = 0; off < chunk_elems; off += kCacheLineFloats) {
+        dcci(chunks + static_cast<size_t>(recv_idx * chunk_elems + off),
+             SINGLE_CACHE_LINE, CACHELINE_OUT);
+      }
+    }
+    pipe_barrier(PIPE_ALL);
+  }
+
+  // Final cross-rank barrier: guarantee every rank has finished reading from
+  // all its peers' buffers before any rank returns to the host.  Each round's
+  // RoundBarrier at the top of the step protects the current step's data
+  // motion, but there is nothing that coordinates the last allgather step's
+  // reads.  Without this barrier a fast rank could return, have its buffer
+  // reused by the next host statement, and corrupt the slow right-hand peer's
+  // final TLOAD.
+  RoundBarrier(comm_ctx, signal_base + round * signal_cols, my_rank, nranks);
+
+  pipe_barrier(PIPE_ALL);
+}

--- a/python/pypto/runtime/builtins/collectives/allreduce_ring/templates/kernel_config.py.in
+++ b/python/pypto/runtime/builtins/collectives/allreduce_ring/templates/kernel_config.py.in
@@ -1,0 +1,28 @@
+# Kernel and Orchestration Configuration
+from pathlib import Path
+
+from simpler.task_interface import ArgDirection as _D
+
+_ROOT_DIR = Path(__file__).parent
+
+RUNTIME_CONFIG = {
+    "runtime": "tensormap_and_ringbuffer",
+    "aicpu_thread_num": 4,
+    "block_dim": 1,
+}
+
+ORCHESTRATION = {
+    "source": str(_ROOT_DIR / "orchestration" / "{{entry}}.cpp"),
+    "function_name": "aicpu_orchestration_entry",
+    "signature": [_D.INOUT, _D.INOUT],
+}
+
+KERNELS = [
+    {
+        "func_id": 0,
+        "name": "{{kernel_name}}",
+        "source": str(_ROOT_DIR / "kernels" / "aiv" / "{{kernel_name}}.cpp"),
+        "core_type": "aiv",
+        "signature": [_D.INOUT, _D.INOUT],
+    },
+]

--- a/python/pypto/runtime/distributed_runner.py
+++ b/python/pypto/runtime/distributed_runner.py
@@ -471,7 +471,7 @@ def _make_call_config(
         ValueError: a DFX flag is enabled but *dfx_base* is ``None``.
     """
     from simpler.task_interface import (  # noqa: PLC0415  # pyright: ignore[reportMissingImports]
-        CallConfig,
+        CallConfig,  # pyright: ignore[reportAttributeAccessIssue]
     )
 
     call_config = CallConfig()

--- a/python/pypto/runtime/task_interface.py
+++ b/python/pypto/runtime/task_interface.py
@@ -15,16 +15,16 @@ torch-aware helpers (make_tensor_arg, scalar_to_uint64) come from the
 """
 
 from simpler.task_interface import (  # pyright: ignore[reportMissingImports]
-    CallConfig,
-    ChipCallable,
-    ChipStorageTaskArgs,
-    CoreCallable,
-    DataType,
-    Tensor,
-    scalar_to_uint64,
+    CallConfig,  # pyright: ignore[reportAttributeAccessIssue]
+    ChipCallable,  # pyright: ignore[reportAttributeAccessIssue]
+    ChipStorageTaskArgs,  # pyright: ignore[reportAttributeAccessIssue]
+    CoreCallable,  # pyright: ignore[reportAttributeAccessIssue]
+    DataType,  # pyright: ignore[reportAttributeAccessIssue]
+    Tensor,  # pyright: ignore[reportAttributeAccessIssue]
+    scalar_to_uint64,  # pyright: ignore[reportAttributeAccessIssue]
 )
-from simpler.worker import Worker  # pyright: ignore[reportMissingImports]
-from simpler_setup.torch_interop import (  # pyright: ignore[reportMissingImports]
+from simpler.worker import Worker  # pyright: ignore[reportMissingImports, reportAttributeAccessIssue]
+from simpler_setup.torch_interop import (  # pyright: ignore[reportMissingImports, reportAttributeAccessIssue]
     make_tensor_arg,
     torch_dtype_to_datatype,
 )

--- a/src/codegen/distributed/distributed_ops_codegen.cpp
+++ b/src/codegen/distributed/distributed_ops_codegen.cpp
@@ -222,23 +222,43 @@ REGISTER_DISTRIBUTED_OP(pld_tensor_window, "pld.tensor.window") {
 // ============================================================================
 // builtin.tensor.allreduce: compiler-generated host collective chip dispatch.
 // ============================================================================
-REGISTER_DISTRIBUTED_OP(builtin_tensor_allreduce, "builtin.tensor.allreduce") {
-  auto* dist_codegen = dynamic_cast<DistributedCodegen*>(&codegen);
-  INTERNAL_CHECK(dist_codegen) << "builtin.tensor.allreduce codegen requires DistributedCodegen";
+
+std::string EmitAllReduceLikeDispatch(DistributedCodegen& dist_codegen, const CallPtr& op,
+                                      bool include_reduce_inst) {
   const int reduce_op = op->GetAttr<int>("op");
   const auto dtype = op->GetAttr<DataType>("dtype");
   const auto reduce_variant = GetAllReduceOpVariant(reduce_op);
   const auto dtype_variant = GetAllReduceDTypeVariant(dtype);
   const std::string variant = op->op_->name_ + "__" + reduce_variant.suffix + "__" + dtype_variant.suffix;
 
-  if (dist_codegen->MarkBuiltinEmitted(variant)) {
-    dist_codegen->RecordBuiltinNextLevel(op, variant,
-                                         {{"op_cpp", reduce_variant.cpp},
-                                          {"reduce_inst", reduce_variant.instruction},
-                                          {"dtype_cpp", dtype_variant.cpp}});
+  if (dist_codegen.MarkBuiltinEmitted(variant)) {
+    if (include_reduce_inst) {
+      dist_codegen.RecordBuiltinNextLevel(op, variant,
+                                          {{"op_cpp", reduce_variant.cpp},
+                                           {"reduce_inst", reduce_variant.instruction},
+                                           {"dtype_cpp", dtype_variant.cpp}});
+    } else {
+      dist_codegen.RecordBuiltinNextLevel(op, variant,
+                                          {{"op_cpp", reduce_variant.cpp}, {"dtype_cpp", dtype_variant.cpp}});
+    }
   }
-  EmitBuiltinWindowCollectiveDispatch(*dist_codegen, op, variant);
+  EmitBuiltinWindowCollectiveDispatch(dist_codegen, op, variant);
   return "";
+}
+
+REGISTER_DISTRIBUTED_OP(builtin_tensor_allreduce, "builtin.tensor.allreduce") {
+  auto* dist_codegen = dynamic_cast<DistributedCodegen*>(&codegen);
+  INTERNAL_CHECK(dist_codegen) << "builtin.tensor.allreduce codegen requires DistributedCodegen";
+  return EmitAllReduceLikeDispatch(*dist_codegen, op, /*include_reduce_inst=*/true);
+}
+
+// ============================================================================
+// builtin.tensor.allreduce_ring: host ring allreduce chip dispatch.
+// ============================================================================
+REGISTER_DISTRIBUTED_OP(builtin_tensor_allreduce_ring, "builtin.tensor.allreduce_ring") {
+  auto* dist_codegen = dynamic_cast<DistributedCodegen*>(&codegen);
+  INTERNAL_CHECK(dist_codegen) << "builtin.tensor.allreduce_ring codegen requires DistributedCodegen";
+  return EmitAllReduceLikeDispatch(*dist_codegen, op, /*include_reduce_inst=*/false);
 }
 
 // ============================================================================

--- a/src/ir/op/distributed/collective.cpp
+++ b/src/ir/op/distributed/collective.cpp
@@ -27,13 +27,14 @@
  *   - pld.tensor.all_to_all(input, target, signal)                 -> DistributedTensorType
  *   - pld.tensor.all_to_all_v(input, target, signal, send_counts, recv_counts)  -> DistributedTensorType
  *
- * The six builtin.tensor.* ops are internal chip-dispatch targets emitted by the
+ * The seven builtin.tensor.* ops are internal chip-dispatch targets emitted by the
  * host-orchestrator lowering pass (LowerHostTensorCollectives):
- * builtin.tensor.{allreduce,barrier,broadcast,reduce_scatter,allgather}.
+ * builtin.tensor.{allreduce,allreduce_ring,barrier,broadcast,reduce_scatter,allgather,all_to_all}.
  */
 
 #include <any>
 #include <cstddef>
+#include <cstdint>
 #include <string>
 #include <utility>
 #include <vector>
@@ -121,6 +122,73 @@ TypePtr DeduceBuiltinTensorAllReduceType(const std::vector<ExprPtr>& args,
   return args[0]->GetType();
 }
 
+// The ring kernel services at most 16 ranks (same limit as
+// lower_host_tensor_collectives_pass.cpp's kMaxSupportedRanks).  Enforcing it
+// here also covers loop-based host collectives, which have no static device
+// list and therefore skip the pass-level check.
+static constexpr int64_t kMaxSupportedRingRanks = 16;
+
+TypePtr DeduceBuiltinTensorAllReduceRingType(const std::vector<ExprPtr>& args,
+                                             const std::vector<std::pair<std::string, std::any>>& kwargs) {
+  constexpr const char* kOpName = "builtin.tensor.allreduce_ring";
+  CHECK(args.size() == 2) << kOpName << " requires exactly 2 positional arguments (src, signal), but got "
+                          << args.size();
+  for (size_t i = 0; i < args.size(); ++i) {
+    CHECK(args[i]) << kOpName << " positional argument #" << i << " must not be null";
+  }
+
+  auto src_type = As<DistributedTensorType>(args[0]->GetType());
+  CHECK(src_type) << kOpName << " src must be a DistributedTensor, got " << args[0]->GetType()->TypeName();
+  auto signal_type = As<DistributedTensorType>(args[1]->GetType());
+  CHECK(signal_type) << kOpName << " signal must be a DistributedTensor, got "
+                     << args[1]->GetType()->TypeName();
+  CHECK(signal_type->dtype_ == DataType::INT32)
+      << kOpName << " signal dtype must be INT32, got " << signal_type->dtype_.ToString();
+  CHECK(signal_type->shape_.size() == 2)
+      << kOpName << " signal must be rank-2 [2*(NR-1) + 1, NR], got rank " << signal_type->shape_.size();
+
+  auto sig_shape0_const = As<ConstInt>(signal_type->shape_[0]);
+  auto sig_shape1_const = As<ConstInt>(signal_type->shape_[1]);
+  if (sig_shape1_const && sig_shape1_const->value_ > 0) {
+    CHECK(sig_shape1_const->value_ <= kMaxSupportedRingRanks)
+        << kOpName << " requires " << kMaxSupportedRingRanks
+        << " or fewer ranks (signal shape[1] = " << sig_shape1_const->value_ << ")";
+  }
+  if (sig_shape0_const && sig_shape1_const && sig_shape1_const->value_ > 0) {
+    CHECK(sig_shape0_const->value_ == 2 * (sig_shape1_const->value_ - 1) + 1)
+        << kOpName << " signal shape[0] (" << sig_shape0_const->value_
+        << ") must equal 2*(NR-1) + 1 = " << 2 * (sig_shape1_const->value_ - 1) + 1
+        << " for NR = " << sig_shape1_const->value_;
+  }
+
+  // Compile-time validation: the host builtin ring kernel partitions src into
+  // NR contiguous compile-time chunks, so the src shape must be statically
+  // known — a dynamic extent could reach the kernel with a runtime numel that
+  // is not divisible by NR and silently return unreduced data.  A non-divisible
+  // numel would produce a trailing partial chunk the schedule cannot handle.
+  if (sig_shape1_const && sig_shape1_const->value_ > 0) {
+    int64_t src_numel = 1;
+    for (const auto& dim : src_type->shape_) {
+      auto extent = As<ConstInt>(dim);
+      CHECK(extent) << kOpName
+                    << " requires a statically-known src shape (dynamic host-ring extents are not "
+                       "supported; the ring schedule partitions src into NR compile-time chunks)";
+      src_numel *= extent->value_;
+    }
+    const int64_t nr = sig_shape1_const->value_;
+    CHECK(src_numel % nr == 0) << kOpName << " requires the src data size (product of shape = " << src_numel
+                               << ") to be an exact multiple of the rank count (" << nr
+                               << "); got a remainder of " << (src_numel % nr);
+  }
+
+  auto op_value = GetRequiredKwarg<int>(kwargs, "op", kOpName);
+  auto dtype = GetRequiredKwarg<DataType>(kwargs, "dtype", kOpName);
+  CHECK(dtype == src_type->dtype_) << kOpName << " dtype kwarg (" << dtype.ToString()
+                                   << ") must match src dtype (" << src_type->dtype_.ToString() << ")";
+  CheckSupportedSumFp32BuiltinVariant(op_value, dtype, kOpName);
+  return args[0]->GetType();
+}
+
 }  // namespace
 
 REGISTER_OP("builtin.tensor.allreduce")
@@ -134,6 +202,18 @@ REGISTER_OP("builtin.tensor.allreduce")
     .set_internal_only(true)
     .set_template_dir(":pypto.runtime.builtins.collectives.allreduce")
     .f_deduce_type(DeduceBuiltinTensorAllReduceType);
+
+REGISTER_OP("builtin.tensor.allreduce_ring")
+    .set_op_category("DistributedOp")
+    .set_description("Internal chip-dispatch builtin for pld.tensor.allreduce(mode=\"ring\").")
+    .add_argument("src", "Window-bound DistributedTensor to reduce in place")
+    .add_argument("signal", "Window-bound INT32 ring signal matrix [2*(NR-1) + 1, NR]")
+    .set_attr<int>("op")
+    .set_attr<DataType>("dtype")
+    .no_memory_spec()
+    .set_internal_only(true)
+    .set_template_dir(":pypto.runtime.builtins.collectives.allreduce_ring")
+    .f_deduce_type(DeduceBuiltinTensorAllReduceRingType);
 
 // ============================================================================
 // pld.tensor.barrier — cross-rank barrier (notify-all + wait-all)

--- a/src/ir/transforms/lower_host_tensor_collectives_pass.cpp
+++ b/src/ir/transforms/lower_host_tensor_collectives_pass.cpp
@@ -42,6 +42,27 @@ namespace ir {
 
 namespace {
 
+static constexpr size_t kMaxSupportedRanks = 16;
+
+[[nodiscard]] std::string GetAllReduceMode(const CallPtr& call) {
+  if (call->HasKwarg("mode")) {
+    return call->GetKwarg<std::string>("mode");
+  }
+  if (call->HasAttr("mode")) {
+    return call->GetAttr<std::string>("mode");
+  }
+  return "mesh";
+}
+
+[[nodiscard]] bool ShouldLowerAllReduceAsRing(const CallPtr& call) {
+  // An absent mode kwarg means the default mesh schedule. Never infer the
+  // schedule from the signal shape.
+  const std::string mode = GetAllReduceMode(call);
+  CHECK_SPAN(mode == "ring" || mode == "mesh", call->span_)
+      << R"(pld.tensor.allreduce mode must be "ring" or "mesh", got ")" << mode << "\"";
+  return mode == "ring";
+}
+
 [[nodiscard]] bool IsHostOrch(const FunctionPtr& func) {
   if (!func || !func->level_.has_value() || *func->level_ != Level::HOST) return false;
   return func->func_type_ == FunctionType::Orchestration ||
@@ -117,6 +138,87 @@ void CheckStaticSignalCapacity(const CallPtr& call, const ExprPtr& signal_expr, 
       << ") must be at least the participating device count (" << required_slots << ")";
 }
 
+void CheckRingChunkConstraints(const CallPtr& call, const ExprPtr& src_expr, size_t world_size) {
+  auto src_type = As<DistributedTensorType>(src_expr->GetType());
+  INTERNAL_CHECK_SPAN(src_type, call->span_)
+      << "LowerHostTensorCollectives: ring allreduce src must be DistributedTensorType";
+  if (src_type->shape_.empty()) return;
+
+  // The ring kernel partitions src into NR contiguous compile-time chunks
+  // (chunk_elems = numel / NR), so the host-ring path requires a
+  // statically-known src shape.  A dynamic extent would let a runtime numel
+  // that is not divisible by NR reach the kernel, which silently returns
+  // unreduced data instead of failing — reject dynamic host-ring extents here.
+  int64_t src_numel = 1;
+  for (const auto& dim : src_type->shape_) {
+    auto extent = As<ConstInt>(dim);
+    CHECK_SPAN(extent, call->span_)
+        << "LowerHostTensorCollectives: ring allreduce requires a statically-known "
+           "src shape (dynamic host-ring extents are not supported; the ring "
+           "schedule partitions src into NR compile-time chunks)";
+    src_numel *= extent->value_;
+  }
+
+  int64_t nr = static_cast<int64_t>(world_size);
+
+  // Divisibility: the host builtin ring schedule partitions data into NR
+  // contiguous chunks of chunk_elems = numel // NR.  A non-divisible numel
+  // would produce a trailing partial chunk that the kernel cannot handle.
+  CHECK_SPAN(src_numel % nr == 0, call->span_)
+      << "LowerHostTensorCollectives: ring allreduce requires the per-rank data size (product of src shape = "
+      << src_numel << ") to be an exact multiple of the rank count (" << nr << "); got a remainder of "
+      << (src_numel % nr);
+}
+
+void CheckRingSignalCapacity(const CallPtr& call, const ExprPtr& signal_expr, size_t world_size) {
+  auto signal_type = As<DistributedTensorType>(signal_expr->GetType());
+  INTERNAL_CHECK_SPAN(signal_type, call->span_)
+      << "LowerHostTensorCollectives: ring allreduce signal must be DistributedTensorType";
+  CHECK_SPAN(signal_type->dtype_ == DataType::INT32, call->span_)
+      << "LowerHostTensorCollectives: ring allreduce signal dtype must be INT32, got "
+      << signal_type->dtype_.ToString();
+  CHECK_SPAN(signal_type->shape_.size() == 2, call->span_)
+      << "LowerHostTensorCollectives: ring allreduce signal must be rank-2 [2*(NR-1) + 1, NR], got rank "
+      << signal_type->shape_.size();
+
+  const auto required_rounds = static_cast<int64_t>(2 * (world_size - 1) + 1);
+  auto sig_rounds = As<ConstInt>(signal_type->shape_[0]);
+  if (sig_rounds) {
+    CHECK_SPAN(sig_rounds->value_ >= required_rounds, call->span_)
+        << "LowerHostTensorCollectives: ring allreduce signal shape[0] (" << sig_rounds->value_
+        << ") must be at least 2*(NR-1) + 1 = " << required_rounds << " for NR = " << world_size;
+  }
+  auto sig_nr = As<ConstInt>(signal_type->shape_[1]);
+  if (sig_nr) {
+    CHECK_SPAN(sig_nr->value_ == static_cast<int64_t>(world_size), call->span_)
+        << "LowerHostTensorCollectives: ring allreduce signal shape[1] (" << sig_nr->value_
+        << ") must equal the participating device count (" << world_size << ")";
+  }
+  if (sig_rounds && sig_nr && sig_nr->value_ > 0) {
+    // Exact match mirrors builtin.tensor.allreduce_ring's type deducer so an
+    // internally-inconsistent signal is rejected here with a clear message
+    // instead of failing later at builtin construction.
+    const auto expected_rounds = 2 * (sig_nr->value_ - 1) + 1;
+    CHECK_SPAN(sig_rounds->value_ == expected_rounds, call->span_)
+        << "LowerHostTensorCollectives: ring allreduce signal shape[0] (" << sig_rounds->value_
+        << ") must equal 2*(NR-1) + 1 = " << expected_rounds << " for NR = " << sig_nr->value_;
+  }
+}
+
+void CheckAllReduceSignalCapacity(const CallPtr& call, const ExprPtr& signal_expr, size_t world_size) {
+  if (ShouldLowerAllReduceAsRing(call)) {
+    CheckRingSignalCapacity(call, signal_expr, world_size);
+    CHECK_SPAN(world_size <= kMaxSupportedRanks, call->span_)
+        << "LowerHostTensorCollectives: ring allreduce requires " << static_cast<int>(kMaxSupportedRanks)
+        << " or fewer participating devices, got " << world_size;
+    INTERNAL_CHECK_SPAN(call->args_.size() >= 1, call->span_)
+        << "LowerHostTensorCollectives: ring allreduce requires a src arg";
+    CheckRingChunkConstraints(call, call->args_[0], world_size);
+    return;
+  }
+  CheckStaticSignalCapacity(call, signal_expr, world_size);
+}
+
 [[nodiscard]] CallPtr MakeBuiltinCallWithAttrs(const std::string& builtin_name, const CallPtr& call,
                                                const std::vector<ExprPtr>& args,
                                                const std::vector<std::pair<std::string, std::any>>& kwargs,
@@ -143,8 +245,13 @@ void CheckStaticSignalCapacity(const CallPtr& call, const ExprPtr& signal_expr, 
       {"op", op_value},
       {"dtype", src_type->dtype_},
   };
-  return MakeBuiltinCallWithAttrs("builtin.tensor.allreduce", call, call->args_, kwargs, device,
-                                  std::move(attrs), {ArgDirection::InOut, ArgDirection::InOut});
+  INTERNAL_CHECK_SPAN(call->args_.size() >= 2, call->span_)
+      << "LowerHostTensorCollectives: expected pld.tensor.allreduce to have an explicit signal by the time "
+         "this pass runs";
+  const char* builtin_name =
+      ShouldLowerAllReduceAsRing(call) ? "builtin.tensor.allreduce_ring" : "builtin.tensor.allreduce";
+  return MakeBuiltinCallWithAttrs(builtin_name, call, call->args_, kwargs, device, std::move(attrs),
+                                  {ArgDirection::InOut, ArgDirection::InOut});
 }
 
 [[nodiscard]] CallPtr MakeBuiltinBarrier(const CallPtr& call, const ExprPtr& device) {
@@ -321,7 +428,11 @@ StmtPtr EmitPerDeviceBuiltinCalls(const CallPtr& call, const HostCollectiveRule&
                                   const CommDomainScopeStmtPtr& scope, const Span& span,
                                   const std::vector<std::string>& leading_comments) {
   if (!scope->devices_.empty()) {
-    CheckStaticSignalCapacity(call, rule.signal_expr(call), scope->devices_.size());
+    if (IsOp(call, "pld.tensor.allreduce")) {
+      CheckAllReduceSignalCapacity(call, rule.signal_expr(call), scope->devices_.size());
+    } else {
+      CheckStaticSignalCapacity(call, rule.signal_expr(call), scope->devices_.size());
+    }
     std::vector<StmtPtr> stmts;
     stmts.reserve(scope->devices_.size());
     for (auto device : scope->devices_) {

--- a/tests/st/distributed/test_l3_host_tensor_allreduce_ring.py
+++ b/tests/st/distributed/test_l3_host_tensor_allreduce_ring.py
@@ -1,0 +1,133 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""L3 distributed ST: host-orchestrator ``pld.tensor.allreduce(mode="ring")`` builtin dispatch."""
+
+import sys
+
+import pypto.language as pl
+import pypto.language.distributed as pld
+import pytest
+import torch
+from pypto import ir
+from pypto.ir.distributed_compiled_program import DistributedConfig
+
+SIZE = 256
+
+
+def _expected_allreduce(inputs: torch.Tensor) -> torch.Tensor:
+    reduced = inputs.sum(dim=0)
+    return torch.stack([reduced] * inputs.shape[0])
+
+
+def _make_rank_inputs(n_ranks: int) -> torch.Tensor:
+    rows = [
+        torch.arange(r * 100.0, r * 100.0 + SIZE, dtype=torch.float32).reshape(1, SIZE)
+        for r in range(n_ranks)
+    ]
+    return torch.stack(rows)
+
+
+def _build_host_ring_allreduce_program(n_ranks: int):
+    total_rounds = 2 * (n_ranks - 1) + 1
+
+    @pl.program
+    class HostTensorAllReduceRing:
+        @pl.function(type=pl.FunctionType.InCore)
+        def publish_step(
+            self,
+            inp: pl.Tensor[[1, SIZE], pl.FP32],
+            data: pl.InOut[pld.DistributedTensor[[1, SIZE], pl.FP32]],
+        ) -> pld.DistributedTensor[[1, SIZE], pl.FP32]:
+            local = pl.load(inp, [0, 0], [1, SIZE])
+            return pl.store(local, [0, 0], data)
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def publish_orch(
+            self,
+            inp: pl.Tensor[[1, SIZE], pl.FP32],
+            data: pl.InOut[pld.DistributedTensor[[1, SIZE], pl.FP32]],
+        ) -> pld.DistributedTensor[[1, SIZE], pl.FP32]:
+            return self.publish_step(inp, data)
+
+        @pl.function(type=pl.FunctionType.InCore)
+        def consume_step(
+            self,
+            data: pld.DistributedTensor[[1, SIZE], pl.FP32],
+            out: pl.Out[pl.Tensor[[1, SIZE], pl.FP32]],
+        ) -> pl.Tensor[[1, SIZE], pl.FP32]:
+            reduced = pl.load(data, [0, 0], [1, SIZE])
+            return pl.store(reduced, [0, 0], out)
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def consume_orch(
+            self,
+            data: pld.DistributedTensor[[1, SIZE], pl.FP32],
+            out: pl.Out[pl.Tensor[[1, SIZE], pl.FP32]],
+        ) -> pl.Tensor[[1, SIZE], pl.FP32]:
+            return self.consume_step(data, out)
+
+        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+        def host_orch(
+            self,
+            inputs: pl.Tensor[[n_ranks, 1, SIZE], pl.FP32],
+            outputs: pl.Out[pl.Tensor[[n_ranks, 1, SIZE], pl.FP32]],
+        ) -> pl.Tensor[[n_ranks, 1, SIZE], pl.FP32]:
+            data_buf = pld.alloc_window_buffer(SIZE * pl.FP32.get_byte())
+            signal_buf = pld.alloc_window_buffer(total_rounds * n_ranks * pl.INT32.get_byte())
+
+            for r in pl.range(pld.world_size()):
+                data = pld.window(data_buf, [1, SIZE], dtype=pl.FP32)
+                self.publish_orch(inputs[r], data, device=r)
+
+            data = pld.window(data_buf, [1, SIZE], dtype=pl.FP32)
+            signal = pld.window(signal_buf, [total_rounds, n_ranks], dtype=pl.INT32)
+            data = pld.tensor.allreduce(data, signal, op=pld.ReduceOp.Sum, mode="ring")
+
+            for r in pl.range(pld.world_size()):
+                self.consume_orch(data, outputs[r], device=r)
+
+            return outputs
+
+    return HostTensorAllReduceRing
+
+
+class TestL3HostTensorAllReduceRing:
+    @pytest.mark.parametrize("n_ranks", [2, 4])
+    def test_host_tensor_allreduce_ring(self, test_config, device_ids, n_ranks):
+        if len(device_ids) < n_ranks:
+            pytest.skip(f"host ring allreduce P={n_ranks} needs {n_ranks} devices, got {device_ids}")
+
+        program = _build_host_ring_allreduce_program(n_ranks)
+        compiled = ir.compile(
+            program,
+            platform=test_config.platform,
+            distributed_config=DistributedConfig(
+                device_ids=device_ids[:n_ranks],
+                num_sub_workers=0,
+            ),
+        )
+
+        variant_dir = compiled.output_dir / "next_levels" / "builtin.tensor.allreduce_ring__sum__fp32"
+        assert variant_dir.is_dir()
+        assert (variant_dir / "kernel_config.py").is_file()
+
+        inputs = _make_rank_inputs(n_ranks)
+        outputs = torch.zeros((n_ranks, 1, SIZE), dtype=torch.float32)
+
+        compiled(inputs, outputs)
+
+        expected = _expected_allreduce(inputs)
+        assert torch.allclose(outputs, expected), (
+            f"host ring allreduce P={n_ranks} mismatch: max diff = {(outputs - expected).abs().max().item()}"
+        )
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v", *sys.argv[1:]]))

--- a/tests/ut/codegen/distributed/test_host_orch_distributed.py
+++ b/tests/ut/codegen/distributed/test_host_orch_distributed.py
@@ -821,6 +821,78 @@ def test_backend_materializes_builtin_next_level_files(tmp_path):
     assert "TADD(acc_tile, acc_tile, recv_tile)" in kernel_cpp
 
 
+def test_host_allreduce_ring_builtin_codegen_uses_ring_next_level_callable_key():
+    @pl.program
+    class Prog:
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def chip_orch(self, data: pld.DistributedTensor[[SIZE], pl.FP32]):
+            return data
+
+        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+        def host_orch(self):
+            data_buf = pld.alloc_window_buffer(SIZE * pl.FP32.get_byte())
+            signal_buf = pld.alloc_window_buffer(7 * 4 * pl.INT32.get_byte())
+            data = pld.window(data_buf, [SIZE], dtype=pl.FP32)
+            signal = pld.window(signal_buf, [7, 4], dtype=pl.INT32)
+            for r in pl.range(pld.world_size()):
+                self.chip_orch(data, device=r)
+            data = pld.tensor.allreduce(data, signal, op=pld.ReduceOp.Sum, mode="ring")
+            self.chip_orch(data, device=0)
+            return 0
+
+    generated, cg = _lower_host_collectives(Prog)
+
+    assert 'callables["builtin.tensor.allreduce_ring__sum__fp32"]' in generated, generated
+    assert "orch.submit_next_level" in generated, generated
+    assert "distributed_collectives" not in generated, generated
+
+    specs = cg.get_builtin_next_level_specs()
+    assert len(specs) == 1
+    spec = specs[0]
+    assert spec.op_name == "builtin.tensor.allreduce_ring"
+    assert spec.variant == "builtin.tensor.allreduce_ring__sum__fp32"
+    assert spec.entry_symbol == "builtin_tensor_allreduce_ring__sum__fp32"
+    assert spec.template_dir == ":pypto.runtime.builtins.collectives.allreduce_ring"
+    assert spec.template_vars == {"op_cpp": "ReduceOp::kSum", "dtype_cpp": "float"}
+
+
+def test_backend_materializes_ring_allreduce_builtin_next_level_files(tmp_path):
+    @pl.program
+    class Prog:
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def chip_orch(self, data: pld.DistributedTensor[[SIZE], pl.FP32]):
+            return data
+
+        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+        def host_orch(self):
+            data_buf = pld.alloc_window_buffer(SIZE * pl.FP32.get_byte())
+            signal_buf = pld.alloc_window_buffer(7 * 4 * pl.INT32.get_byte())
+            data = pld.window(data_buf, [SIZE], dtype=pl.FP32)
+            signal = pld.window(signal_buf, [7, 4], dtype=pl.INT32)
+            for r in pl.range(pld.world_size()):
+                self.chip_orch(data, device=r)
+            pld.tensor.allreduce(data, signal, op=pld.ReduceOp.Sum, mode="ring")
+            return 0
+
+    program = passes.materialize_comm_domain_scopes()(Prog)
+    program = passes.lower_host_tensor_collectives()(program)
+    program = passes.materialize_dist_tensor_ctx()(program)
+    program = _finalize_chip_program_for_generate(program)
+    files = pto_backend.generate(program, str(tmp_path), skip_ptoas=True)
+
+    base = "next_levels/builtin.tensor.allreduce_ring__sum__fp32"
+    assert f"{base}/kernel_config.py" in files
+    assert f"{base}/orchestration/builtin_tensor_allreduce_ring__sum__fp32.cpp" in files
+    assert f"{base}/kernels/aiv/builtin_tensor_allreduce_ring__sum__fp32_kernel.cpp" in files
+
+    entry_cpp = files[f"{base}/orchestration/builtin_tensor_allreduce_ring__sum__fp32.cpp"]
+    assert "submit_allreduce_ring_kernel<ReduceOp::kSum, float>" in entry_cpp
+
+    kernel_cpp = files[f"{base}/kernels/aiv/builtin_tensor_allreduce_ring__sum__fp32_kernel.cpp"]
+    assert "RoundBarrier" in kernel_cpp
+    assert "signal_rows" in kernel_cpp
+
+
 # ---------------------------------------------------------------------------
 # Dynamic-dim recovery preamble (issue #1873). A HOST orchestrator that slices a
 # per-rank sub-tensor whose bound uses a ``pl.dynamic()`` dim must bind that dim
@@ -1076,6 +1148,8 @@ def _assert_host_collective_next_level_files(program_cls, tmp_path, variant, sig
 @pytest.mark.parametrize(
     ("package_name", "variant"),
     [
+        ("allreduce", "builtin.tensor.allreduce__sum__fp32"),
+        ("allreduce_ring", "builtin.tensor.allreduce_ring__sum__fp32"),
         ("barrier", "builtin.tensor.barrier__fp32"),
         ("broadcast", "builtin.tensor.broadcast__root0__fp32"),
         ("reduce_scatter", "builtin.tensor.reduce_scatter__sum__fp32"),

--- a/tests/ut/ir/transforms/test_lower_host_tensor_collectives.py
+++ b/tests/ut/ir/transforms/test_lower_host_tensor_collectives.py
@@ -745,6 +745,7 @@ def test_host_all_to_all_lowers_to_namesake_builtin():
     program = passes.materialize_comm_domain_scopes()(P)
     result = passes.lower_host_tensor_collectives()(program)
     host = _get_func(result, "host_orch")
+
     loops = _collect_for_stmts(host.body)
     builtin_loops = [
         loop
@@ -801,6 +802,166 @@ def test_lowered_collective_is_printable_with_dtype_attr():
     assert "builtin.tensor.allreduce" in printed, printed
     # The DataType attr renders in the ``pl.<DTYPE>`` DSL form, not dropped.
     assert '"dtype": pl.FP32' in printed, printed
+
+
+def test_host_allreduce_ring_lowers_to_ring_builtin():
+    @pl.program
+    class P:
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def chip_orch(self, data: pld.DistributedTensor[[256], pl.FP32]):
+            return data
+
+        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+        def host_orch(self):
+            data_buf = pld.alloc_window_buffer(256 * pl.FP32.get_byte())
+            signal_buf = pld.alloc_window_buffer(7 * 4 * pl.INT32.get_byte())
+            data = pld.window(data_buf, [256], dtype=pl.FP32)
+            signal = pld.window(signal_buf, [7, 4], dtype=pl.INT32)
+            for r in pl.range(pld.world_size()):
+                self.chip_orch(data, device=r)
+            pld.tensor.allreduce(data, signal, op=pld.ReduceOp.Sum, mode="ring")
+            return 0
+
+    program = cast(ir.Program, passes.materialize_comm_domain_scopes()(P))
+    result = cast(ir.Program, passes.lower_host_tensor_collectives()(program))
+    host = _get_func(result, "host_orch")
+
+    loops = _collect_for_stmts(host.body)
+    builtin_loops = [
+        loop
+        for loop in loops
+        if isinstance(loop.body, ir.EvalStmt)
+        and isinstance(loop.body.expr, ir.Call)
+        and loop.body.expr.op.name == ir.get_op("builtin.tensor.allreduce_ring").name
+    ]
+    assert len(builtin_loops) == 1
+
+    call = _eval_call(builtin_loops[0].body)
+    assert call.kwargs["op"] == int(pld.ReduceOp.Sum)
+    assert call.kwargs["dtype"] == pl.FP32
+    assert list(call.arg_directions) == [ir.ArgDirection.InOut, ir.ArgDirection.InOut]
+
+
+def test_host_allreduce_rejects_unknown_mode():
+    @pl.program
+    class P:
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def chip_orch(self, data: pld.DistributedTensor[[256], pl.FP32]):
+            return data
+
+        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+        def host_orch(self):
+            data_buf = pld.alloc_window_buffer(256 * pl.FP32.get_byte())
+            signal_buf = pld.alloc_window_buffer(4 * pl.INT32.get_byte())
+            data = pld.window(data_buf, [256], dtype=pl.FP32)
+            signal = pld.window(signal_buf, [4], dtype=pl.INT32)
+            self.chip_orch(data, device=0)
+            self.chip_orch(data, device=1)
+            self.chip_orch(data, device=2)
+            self.chip_orch(data, device=3)
+            pld.tensor.allreduce(data, signal, op=pld.ReduceOp.Sum, mode="star")
+            return 0
+
+    program = passes.materialize_comm_domain_scopes()(P)
+    with pytest.raises(ValueError, match=r'mode must be "ring" or "mesh"'):
+        passes.lower_host_tensor_collectives()(program)
+
+
+def test_host_allreduce_ring_rejects_mismatched_signal_shape():
+    """Ring signal [5, 4] fails: shape[0]=5 != 2*(4-1)+1 = 7 at P=4."""
+
+    @pl.program
+    class P:
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def chip_orch(self, data: pld.DistributedTensor[[256], pl.FP32]):
+            return data
+
+        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+        def host_orch(self):
+            data_buf = pld.alloc_window_buffer(256 * pl.FP32.get_byte())
+            signal_buf = pld.alloc_window_buffer(5 * 4 * pl.INT32.get_byte())
+            data = pld.window(data_buf, [256], dtype=pl.FP32)
+            signal = pld.window(signal_buf, [5, 4], dtype=pl.INT32)
+            self.chip_orch(data, device=0)
+            self.chip_orch(data, device=1)
+            self.chip_orch(data, device=2)
+            self.chip_orch(data, device=3)
+            pld.tensor.allreduce(data, signal, op=pld.ReduceOp.Sum, mode="ring")
+            return 0
+
+    program = passes.materialize_comm_domain_scopes()(P)
+    with pytest.raises(ValueError, match=r"must be at least 2\*\(NR-1\)"):
+        passes.lower_host_tensor_collectives()(program)
+
+
+def test_host_allreduce_ring_rejects_nondivisible_numel():
+    """Ring allreduce rejects numel that is not an exact multiple of NR at P=4."""
+    SIZE = 27  # 27 % 4 != 0
+
+    @pl.program
+    class P:
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def chip_orch(self, data: pld.DistributedTensor[[SIZE], pl.FP32]):
+            return data
+
+        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+        def host_orch(self):
+            data_buf = pld.alloc_window_buffer(SIZE * pl.FP32.get_byte())
+            signal_buf = pld.alloc_window_buffer(7 * 4 * pl.INT32.get_byte())
+            data = pld.window(data_buf, [SIZE], dtype=pl.FP32)
+            signal = pld.window(signal_buf, [7, 4], dtype=pl.INT32)
+            self.chip_orch(data, device=0)
+            self.chip_orch(data, device=1)
+            self.chip_orch(data, device=2)
+            self.chip_orch(data, device=3)
+            pld.tensor.allreduce(data, signal, op=pld.ReduceOp.Sum, mode="ring")
+            return 0
+
+    program = passes.materialize_comm_domain_scopes()(P)
+    with pytest.raises(ValueError, match=r"exact multiple of the rank count"):
+        passes.lower_host_tensor_collectives()(program)
+
+
+def test_host_allreduce_ring_rejects_too_many_ranks():
+    """Ring allreduce rejects more than 16 participating devices (P=17)."""
+    SIZE = 64
+    ROUNDS = 2 * (17 - 1) + 1  # 33 signal rows
+
+    @pl.program
+    class P:
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def chip_orch(self, data: pld.DistributedTensor[[SIZE], pl.FP32]):
+            return data
+
+        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+        def host_orch(self):
+            data_buf = pld.alloc_window_buffer(SIZE * pl.FP32.get_byte())
+            signal_buf = pld.alloc_window_buffer(ROUNDS * 17 * pl.INT32.get_byte())
+            data = pld.window(data_buf, [SIZE], dtype=pl.FP32)
+            signal = pld.window(signal_buf, [ROUNDS, 17], dtype=pl.INT32)
+            self.chip_orch(data, device=0)
+            self.chip_orch(data, device=1)
+            self.chip_orch(data, device=2)
+            self.chip_orch(data, device=3)
+            self.chip_orch(data, device=4)
+            self.chip_orch(data, device=5)
+            self.chip_orch(data, device=6)
+            self.chip_orch(data, device=7)
+            self.chip_orch(data, device=8)
+            self.chip_orch(data, device=9)
+            self.chip_orch(data, device=10)
+            self.chip_orch(data, device=11)
+            self.chip_orch(data, device=12)
+            self.chip_orch(data, device=13)
+            self.chip_orch(data, device=14)
+            self.chip_orch(data, device=15)
+            self.chip_orch(data, device=16)
+            pld.tensor.allreduce(data, signal, op=pld.ReduceOp.Sum, mode="ring")
+            return 0
+
+    program = passes.materialize_comm_domain_scopes()(P)
+    with pytest.raises(ValueError, match=r"16 or fewer"):
+        passes.lower_host_tensor_collectives()(program)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Adds `builtin.tensor.allreduce_ring` — a host-orchestrated ring allreduce builtin following the same rail as the existing mesh allreduce (`builtin.tensor.allreduce`).
- Wires `mode="ring"` dispatch in `LowerHostTensorCollectives` so that `pld.tensor.allreduce(data, signal, op=ReduceOp.Sum, mode="ring")` in `host_orch` lowers to the ring builtin.
- Ring schedule: 2(NR-1) rounds — chunked reduce-scatter (NR-1 steps) followed by allgather (NR-1 steps).
- Signal shape: `[2*(NR-1) + 1, NR]` — one row per ring round plus one extra row for the return barrier; one cell per rank, zero-initialised by `alloc_window_buffer`. Per-round `AtomicAdd(0->1)` / `WaitGe(1)` single-shot.
- Compile-time validation: `numel % NR == 0` (divisibility), `world_size <= 16`, signal `shape[1] == NR` exact match (via `CHECK_SPAN`), and when both signal dimensions are compile-time constants, `shape[0] == 2*(NR-1) + 1` exact match; `shape[0] >= 2*(NR-1) + 1` guard otherwise.
- Tiled kernel (256-element vector tiles) handles arbitrary chunk sizes with no hard cap.
- `RoundBarrier` (O(P) per invocation, O(P²) total across the 2(NR-1) ring rounds) with notify-all/wait-all pattern. A `dcci(..., CACHELINE_OUT)` flush followed by `pipe_barrier(PIPE_ALL)` follows each phase's TSTORE loop (after `RoundBarrier` returns) for correct NPU memory ordering with the pull model (TLOAD/TSTORE). A final `RoundBarrier` on the extra signal row guarantees all ranks have finished reading from each other's buffers before any rank returns to the host.

## Algorithm parity with InCore ring allreduce

The host builtin ring kernel deliberately uses the same algorithm as the existing InCore composite ring intrinsic (`pld.tensor.allreduce(mode="ring")`, merged in #1942, tested in `test_l3_tensor_allreduce_ring_intrinsic.py`):

- Same 2(NR-1)-round reduce-scatter + allgather schedule
- Same per-round barrier pattern (`RoundBarrier` with `AtomicAdd(0->1)` / `WaitGe(1)`, single-shot per row)
- Signal shape `[2*(NR-1) + 1, NR]` (one extra row vs the InCore intrinsic, for the return barrier)
- Same publish pattern after each phase's TSTORE loop — `dcci(..., CACHELINE_OUT)` flush + `pipe_barrier(PIPE_ALL)`. The flush ensures TSTORE data is committed to DDR before the next `RoundBarrier` TNOTIFY fires, preventing the downstream rank's TLOAD from reading stale data.

A `NeighborBarrier` (O(1) neighbour-only sync) is planned for a future PR and will require switching to a TPUT push model. The in-code future-work comment at the top of the `RoundBarrier` in `kernel.cpp.in` explains this path.

## Changes

| Layer | Files | What |
|-------|-------|------|
| C++ IR op | `src/ir/op/distributed/collective.cpp` | Register `builtin.tensor.allreduce_ring`, type deducer, `INT32` signal dtype validation, `numel % NR == 0` divisibility check, exact signal shape check when both dims are const |
| C++ pass | `src/ir/transforms/lower_host_tensor_collectives_pass.cpp` | `mode="ring"` dispatch, signal shape validation (`shape[0] >= 2*(NR-1) + 1`, exact when both dims const; `shape[1] == NR`), `IsOp` dispatch, `numel % NR == 0` compile-time guard, `world_size <= 16` compile-time guard |
| C++ codegen | `src/codegen/distributed/distributed_ops_codegen.cpp` | Wire `builtin.tensor.allreduce_ring` in `next_levels/` magic setup |
| Kernel template | `python/pypto/runtime/builtins/collectives/allreduce_ring/` | Ring RS+AG kernel with tiling, `RoundBarrier` per round + final return barrier, `dcci(CACHELINE_OUT)` flush after each phase loop, per-round signal rows, `int64_t` chunk-offset arithmetic |
| Python bindings | auto-generated via existing codegen dispatch | — |
| DSL wrappers | `python/pypto/language/distributed/op/tensor_ops.py` | `allreduce` docstrings for the ring signal shape and the Sum/FP32 limitation |
| Docs (EN + ZH) | `docs/en/dev/passes/40-lower_host_tensor_collectives.md`, `docs/zh/dev/passes/40-lower_host_tensor_collectives.md`, `docs/en/dev/distributed_ops.md`, `docs/zh/dev/distributed_ops.md` | Ring builtin lowering, signal shape contract (`[2*(NR-1) + 1, NR]`), chunking, `world_size <= 16` cap |
| UT: lowering | `tests/ut/ir/transforms/test_lower_host_tensor_collectives.py` | Ring lowering + signal shape mismatch rejection |
| UT: codegen | `tests/ut/codegen/distributed/test_host_orch_distributed.py` | Template package exists + `RoundBarrier` emitted |
| ST: E2E | `tests/st/distributed/test_l3_host_tensor_allreduce_ring.py` | P=2/P=4 host ring allreduce runtime test |

## Housekeeping (bundled in this PR)

- Type-checker cleanup in `python/pypto/language/distributed/op/_utils.py`: `@overload` arity stubs for `_unwrap_distributed_tensors` (resolves the unbalanced-tuple-unpacking diagnostics). The public `input` keyword of `all_to_all` / `all_to_all_v` is kept unchanged.
- Review cleanups: restore the `pytest.main` block in the ring lowering UT, document the `world_size <= 16` ring cap in en/zh pass doc 40, correct the `numel(src) % NR == 0` divisibility wording, reject dynamic host-ring `src` extents (with UT), add the >16-rank rejection UT, and note the unaligned-chunk flush limitation in the ring kernel template.

## Test plan

- [x] UT: `test_lower_host_tensor_collectives.py` ring tests — sim Docker
- [x] UT: `test_host_orch_distributed.py` ring template + materialisation — sim Docker
- [x] ST: `test_l3_host_tensor_allreduce_ring.py` P=2/4 — sim Docker
- [x] ST: same, P=2 (NPU verify)
- [x] ST: same, P=4 (NPU verify)


