### PR TITLE
fix(codegen): Handle Submit nodes in cross-core pipes

### DIFF
--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -3787,6 +3787,50 @@ class ASTParser:
             hint=f"Use a standalone `with pl.spmd(..., {kwarg}):` (implicit cluster) to keep it.",
         )
 
+    def _reject_submit_dispatch_metadata_in_cluster(
+        self,
+        *,
+        user_dep_vars: list["ir.Var"],
+        core_num: "ir.Expr | None",
+        sync_start: bool,
+        allow_early_resolve: bool,
+        predicate: "ir.Expr | None",
+        span: "ir.Span",
+    ) -> None:
+        """Reject per-task metadata on a Submit nested inside ``pl.cluster()``.
+
+        A cluster body is outlined into one Group task. Calls or plain Submit
+        nodes inside that body identify the Group's AIC/AIV callees, but they
+        are not dispatched independently, so their task-level controls have no
+        runtime carrier and would otherwise be silently ignored.
+        """
+        if not self._is_inside_scope(ir.ScopeKind.Cluster):
+            return
+
+        metadata_fields: list[str] = []
+        if user_dep_vars:
+            metadata_fields.append("deps")
+        if core_num is not None:
+            metadata_fields.append("core_num")
+        if sync_start:
+            metadata_fields.append("sync_start")
+        if allow_early_resolve:
+            metadata_fields.append("allow_early_resolve")
+        if predicate is not None:
+            metadata_fields.append("predicate")
+        if not metadata_fields:
+            return
+
+        construct = "pl.spmd_submit" if core_num is not None else "pl.submit"
+        raise ParserSyntaxError(
+            f"`{construct}(...)` inside `pl.cluster()` cannot carry per-task dispatch metadata "
+            f"({', '.join(metadata_fields)}) — the cluster is dispatched as one Group task, so metadata on "
+            "an inner Submit would be ignored",
+            span=span,
+            hint="Move the dependency or launch control to the dispatch surrounding the cluster, "
+            "or omit it from the inner Submit.",
+        )
+
     @staticmethod
     def _spmd_body_reads_block_idx(body: "list[ast.stmt]") -> bool:
         """True if any statement in an inline SPMD body calls ``get_block_idx()``.
@@ -5887,6 +5931,14 @@ class ASTParser:
             predicate = self._parse_submit_predicate_kwarg(method_name, keywords)
             if predicate is not None:
                 self._validate_predicate_deps(method_name, predicate, user_dep_vars, span)
+            self._reject_submit_dispatch_metadata_in_cluster(
+                user_dep_vars=user_dep_vars,
+                core_num=core_num_expr,
+                sync_start=sync_start,
+                allow_early_resolve=allow_early_resolve,
+                predicate=predicate,
+                span=span,
+            )
         return_types = func_obj.return_types if func_obj else []
         # A callee that declares no ``-> `` annotation has empty ``return_types``
         # but may ``return <value>`` (e.g. an InCore kernel returning its

--- a/src/codegen/orchestration/orchestration_analysis.cpp
+++ b/src/codegen/orchestration/orchestration_analysis.cpp
@@ -104,7 +104,12 @@ int64_t ComputeGMPipeWorkspaceElements(const ProgramPtr& program, const Function
   std::function<void(const FunctionPtr&)> scan_func;
   scan_stmts = [&](const std::vector<StmtPtr>& stmts) {
     for (const auto& stmt : stmts) {
-      auto call = transform_utils::GetCallFromStmt(stmt);
+      CallPtr call;
+      if (auto assign = As<AssignStmt>(stmt)) {
+        call = transform_utils::AsCallOrSubmitView(assign->value_);
+      } else if (auto eval = As<EvalStmt>(stmt)) {
+        call = transform_utils::AsCallOrSubmitView(eval->expr_);
+      }
       if (op_predicates::IsInitializePipe(call)) {
         const int pipe_id = call->GetKwarg<int>("id", 0);
         const int dir_mask = call->GetKwarg<int>("dir_mask", 0);

--- a/src/ir/transforms/utils/wrapper_call_utils.cpp
+++ b/src/ir/transforms/utils/wrapper_call_utils.cpp
@@ -30,7 +30,7 @@ namespace ir {
 
 namespace {
 
-/// Shared scaffold: visit every Call in the body, resolve its op via
+/// Shared scaffold: visit every Call or Submit in the body, resolve its op via
 /// `GlobalVar` lookup, invoke @p on_match for each resolved (call, callee)
 /// pair. Returning `true` from @p on_match terminates the walk early.
 class CallVisitor : public IRVisitor {
@@ -53,6 +53,8 @@ class CallVisitor : public IRVisitor {
     }
     IRVisitor::VisitExpr_(call);
   }
+
+  void VisitExpr_(const SubmitPtr& submit) override { VisitExpr_(SubmitToCallView(submit)); }
 
  private:
   const ProgramPtr& program_;

--- a/src/ir/transforms/utils/wrapper_call_utils.cpp
+++ b/src/ir/transforms/utils/wrapper_call_utils.cpp
@@ -19,6 +19,7 @@
 #include <utility>
 #include <vector>
 
+#include "pypto/core/logging.h"
 #include "pypto/ir/expr.h"
 #include "pypto/ir/function.h"
 #include "pypto/ir/kind_traits.h"
@@ -37,8 +38,10 @@ class CallVisitor : public IRVisitor {
  public:
   using OnMatchFn = std::function<bool(const CallPtr&, const FunctionPtr&)>;
 
-  CallVisitor(const ProgramPtr& program, OnMatchFn on_match)
-      : program_(program), on_match_(std::move(on_match)) {}
+  CallVisitor(const ProgramPtr& program, OnMatchFn on_match, bool reject_submit_dispatch_metadata = false)
+      : program_(program),
+        on_match_(std::move(on_match)),
+        reject_submit_dispatch_metadata_(reject_submit_dispatch_metadata) {}
 
  protected:
   void VisitExpr_(const CallPtr& call) override {
@@ -54,11 +57,22 @@ class CallVisitor : public IRVisitor {
     IRVisitor::VisitExpr_(call);
   }
 
-  void VisitExpr_(const SubmitPtr& submit) override { VisitExpr_(SubmitToCallView(submit)); }
+  void VisitExpr_(const SubmitPtr& submit) override {
+    if (reject_submit_dispatch_metadata_) {
+      CHECK_SPAN(submit->deps_.empty() && !submit->core_num_.has_value() && !submit->sync_start_ &&
+                     !submit->allow_early_resolve_ && !submit->predicate_.has_value(),
+                 submit->span_)
+          << "A Submit nested inside a Group function cannot carry per-task dispatch metadata "
+             "(deps, core_num, sync_start, allow_early_resolve, or predicate). The Group is dispatched "
+             "as one task, so metadata on an inner Submit would be ignored.";
+    }
+    VisitExpr_(SubmitToCallView(submit));
+  }
 
  private:
   const ProgramPtr& program_;
   OnMatchFn on_match_;
+  bool reject_submit_dispatch_metadata_;
   bool stop_ = false;
 };
 
@@ -85,25 +99,28 @@ GroupCalleeInfo FindGroupCallees(const FunctionPtr& group_func, const ProgramPtr
   // and is what BuildWrapperReorderedParams expects (the call whose arg
   // order it reorders against). Group bodies emitted by ExpandMixedKernel
   // place AIC before AIV in source order, so the AIC call wins in practice.
-  CallVisitor visitor(program, [&](const CallPtr& call, const FunctionPtr& callee) {
-    if (callee->func_type_ == FunctionType::AIC && info.aic_name.empty()) {
-      info.aic_name = callee->name_;
-      if (!info.inner_call) {
-        info.inner_call = call;
-        info.inner_callee = callee;
-      }
-    } else if (callee->func_type_ == FunctionType::AIV && info.aiv_name.empty()) {
-      info.aiv_name = callee->name_;
-      if (!info.inner_call) {
-        info.inner_call = call;
-        info.inner_callee = callee;
-      }
-    } else if (callee->func_type_ == FunctionType::InCore && !info.inner_call) {
-      info.inner_call = call;
-      info.inner_callee = callee;
-    }
-    return false;  // collect all matches
-  });
+  CallVisitor visitor(
+      program,
+      [&](const CallPtr& call, const FunctionPtr& callee) {
+        if (callee->func_type_ == FunctionType::AIC && info.aic_name.empty()) {
+          info.aic_name = callee->name_;
+          if (!info.inner_call) {
+            info.inner_call = call;
+            info.inner_callee = callee;
+          }
+        } else if (callee->func_type_ == FunctionType::AIV && info.aiv_name.empty()) {
+          info.aiv_name = callee->name_;
+          if (!info.inner_call) {
+            info.inner_call = call;
+            info.inner_callee = callee;
+          }
+        } else if (callee->func_type_ == FunctionType::InCore && !info.inner_call) {
+          info.inner_call = call;
+          info.inner_callee = callee;
+        }
+        return false;  // collect all matches
+      },
+      /*reject_submit_dispatch_metadata=*/true);
   visitor.VisitStmt(group_func->body_);
   return info;
 }

--- a/tests/ut/codegen/test_orchestration_tensor_rw.py
+++ b/tests/ut/codegen/test_orchestration_tensor_rw.py
@@ -17,7 +17,7 @@ from _orchestration_codegen_common import (
     _generate_orch_code,
     _generate_orch_result,
 )
-from pypto import backend, passes
+from pypto import backend, codegen, passes
 from pypto.backend import BackendType
 from pypto.ir.pass_manager import OptimizationStrategy, PassManager
 from pypto.pypto_core import ir
@@ -942,6 +942,57 @@ class TestTensorReadWriteOffsetCodegen:
             "Expected per-callee GM workspace shapes (small=512*8*1 side / f32, "
             f"large=(1024*8+2048*8) / f32), got {shape_values}. Generated code:\n{code}"
         )
+
+    def test_submit_dispatched_pipe_group_sizes_workspace_and_resolves_callees(self):
+        """Submitted AIC/AIV pipe kernels remain visible to orchestration codegen."""
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        @pl.program
+        class SubmitPipeProgram:
+            @pl.function(type=pl.FunctionType.AIC)
+            def cube_side(
+                self,
+                out: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                v2c_buf = pl.reserve_buffer(name="submit_v2c", size=4096, base=pl.AUTO)
+                c2v_peer = pl.import_peer_buffer(name="submit_c2v", peer_func="vec_side")
+                pl.aic_initialize_pipe(c2v_peer, v2c_buf, dir_mask=3, slot_size=512)
+                return out
+
+            @pl.function(type=pl.FunctionType.AIV)
+            def vec_side(
+                self,
+                out: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                c2v_buf = pl.reserve_buffer(name="submit_c2v", size=4096, base=pl.AUTO)
+                v2c_peer = pl.import_peer_buffer(name="submit_v2c", peer_func="cube_side")
+                pl.aiv_initialize_pipe(c2v_buf, v2c_peer, dir_mask=3, slot_size=512)
+                return out
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                out: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                with pl.cluster():
+                    _cube_out, _cube_tid = pl.submit(self.cube_side, out)
+                    vec_out, _vec_tid = pl.submit(self.vec_side, out)
+                return vec_out
+
+        transformed = PassManager.get_strategy(OptimizationStrategy.Default).run_passes(SubmitPipeProgram)
+        transformed_text = transformed.as_python()
+        assert transformed_text.count("pl.submit(") == 2, transformed_text
+        assert "self.cube_side" in transformed_text, transformed_text
+        assert "self.vec_side" in transformed_text, transformed_text
+        orch_func = next(
+            func for func in transformed.functions.values() if func.func_type == ir.FunctionType.Orchestration
+        )
+        code = codegen.generate_orchestration(transformed, orch_func).code
+
+        shape_values = re.findall(r"gm_pipe_buffer_\d+_ci_shapes\[1\]\s*=\s*\{(\d+)\};", code)
+        assert shape_values == ["512"], code
+        assert "rt_submit_task" in code, code
 
 
 if __name__ == "__main__":

--- a/tests/ut/language/parser/test_manual_scope_parsing.py
+++ b/tests/ut/language/parser/test_manual_scope_parsing.py
@@ -127,15 +127,16 @@ class TestManualScopeParsing:
         assert k2_deps[0].type.dtype == pl.TASK_ID
 
     @pytest.mark.parametrize(
-        "submit_expr",
+        ("submit_expr", "metadata_field"),
         [
-            "pl.submit(self.k2, x, deps=[a_tid])",
-            "pl.submit(self.k2, x, allow_early_resolve=True)",
-            "pl.submit(self.k2, a, deps=[a_tid], predicate=(a[0] > 0))",
-            "pl.spmd_submit(self.k2, x, core_num=2)",
+            ("pl.submit(self.k2, x, deps=[a_tid])", "deps"),
+            ("pl.submit(self.k2, x, allow_early_resolve=True)", "allow_early_resolve"),
+            ("pl.submit(self.k2, a, deps=[a_tid], predicate=(a[0] > 0))", "predicate"),
+            ("pl.spmd_submit(self.k2, x, core_num=2)", "core_num"),
+            ("pl.spmd_submit(self.k2, x, core_num=2, sync_start=True)", "sync_start"),
         ],
     )
-    def test_cluster_nested_submit_rejects_per_task_dispatch_metadata(self, submit_expr):
+    def test_cluster_nested_submit_rejects_per_task_dispatch_metadata(self, submit_expr, metadata_field):
         """Inner Submit controls cannot be represented by the outlined Group dispatch."""
         source = f"""
 @pl.program
@@ -155,8 +156,9 @@ class Prog:
             b, _ = {submit_expr}
         return b
 """
-        with pytest.raises(ParserSyntaxError, match="cannot carry per-task dispatch metadata"):
+        with pytest.raises(ParserSyntaxError, match="cannot carry per-task dispatch metadata") as exc_info:
             pl.parse_program(source)
+        assert metadata_field in str(exc_info.value)
 
     def test_submit_none_dep_entry_dropped(self):
         """A bare ``None`` entry in ``deps=`` contributes no edge."""

--- a/tests/ut/language/parser/test_manual_scope_parsing.py
+++ b/tests/ut/language/parser/test_manual_scope_parsing.py
@@ -12,7 +12,11 @@
 import pypto.language as pl
 import pytest
 from pypto import ir
-from pypto.language.parser.diagnostics.exceptions import ParserTypeError, UnsupportedFeatureError
+from pypto.language.parser.diagnostics.exceptions import (
+    ParserSyntaxError,
+    ParserTypeError,
+    UnsupportedFeatureError,
+)
 
 
 def _first_runtime_scope(stmt):
@@ -121,6 +125,38 @@ class TestManualScopeParsing:
         assert len(k2_deps) == 1
         assert isinstance(k2_deps[0].type, ir.ScalarType)
         assert k2_deps[0].type.dtype == pl.TASK_ID
+
+    @pytest.mark.parametrize(
+        "submit_expr",
+        [
+            "pl.submit(self.k2, x, deps=[a_tid])",
+            "pl.submit(self.k2, x, allow_early_resolve=True)",
+            "pl.submit(self.k2, a, deps=[a_tid], predicate=(a[0] > 0))",
+            "pl.spmd_submit(self.k2, x, core_num=2)",
+        ],
+    )
+    def test_cluster_nested_submit_rejects_per_task_dispatch_metadata(self, submit_expr):
+        """Inner Submit controls cannot be represented by the outlined Group dispatch."""
+        source = f"""
+@pl.program
+class Prog:
+    @pl.function(type=pl.FunctionType.AIC)
+    def k1(self, x: pl.Tensor[[64], pl.INT32]) -> pl.Tensor[[64], pl.INT32]:
+        return x
+
+    @pl.function(type=pl.FunctionType.AIV)
+    def k2(self, x: pl.Tensor[[64], pl.INT32]) -> pl.Tensor[[64], pl.INT32]:
+        return x
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def main(self, x: pl.Tensor[[64], pl.INT32]) -> pl.Tensor[[64], pl.INT32]:
+        with pl.cluster():
+            a, a_tid = pl.submit(self.k1, x)
+            b, _ = {submit_expr}
+        return b
+"""
+        with pytest.raises(ParserSyntaxError, match="cannot carry per-task dispatch metadata"):
+            pl.parse_program(source)
 
     def test_submit_none_dep_entry_dropped(self):
         """A bare ``None`` entry in ``deps=`` contributes no edge."""


### PR DESCRIPTION
## Summary
- make GM pipe workspace analysis treat Submit nodes as call-like expressions
- include submitted AIC/AIV functions when resolving wrapper group callees
- add a regression test for hand-written cross-core pipe dispatch through pl.submit

## Testing
- cmake --build build --parallel
- python -S -m pytest tests/ut/codegen/test_orchestration_tensor_rw.py::TestTensorReadWriteOffsetCodegen::test_submit_dispatched_pipe_group_sizes_workspace_and_resolves_callees -v
- related codegen suites: 76 passed
- ruff check and ruff format --check
- clang-tidy diff check
- full unit suite attempted: 7398 passed, 2 skipped; 11 failures and 9 setup errors are isolated to the locally installed _task_interface extension missing TENSOR_CHILD_MEMORY_OFFSET

## Related Issues
Fixes #2096

The device-side deadlock reported separately remains tracked by #2097.