### PR TITLE
fix(codegen/ir): keep layout-aware tmov elide; Vec-only ND↔NZ reuse gate

### DIFF
--- a/src/backend/common/pto_ops_elementwise.cpp
+++ b/src/backend/common/pto_ops_elementwise.cpp
@@ -30,6 +30,7 @@
 #include "pypto/ir/expr.h"
 #include "pypto/ir/kind_traits.h"
 #include "pypto/ir/scalar_expr.h"
+#include "pypto/ir/tile_view_semantics.h"
 #include "pypto/ir/type.h"
 #include "src/backend/common/pto_ops_internal.h"
 
@@ -485,6 +486,11 @@ void RegisterElementwiseOps(Backend& backend, const std::unordered_set<std::stri
   // same physical address after AllocateMemoryAddr (e.g. acc→acc at the same Acc
   // offset), the move is a no-op. Elide it to avoid emitting pto.tmov with
   // unsupported same-space address pairs (fixes #1310).
+  //
+  // Do NOT elide when TileView layouts differ (e.g. A5 V→C ND→NZ adapt before
+  // tpush_to_aic). MemoryReuse may still co-locate the *_nz tile with the cast
+  // result at the same Vec addr; eliding then drops the real tmov and TPUSH keeps
+  // RowMajor while AIC TPOP expects Mat ColMajor — silent numerical FAIL.
   reg("tile.move", [](const ir::CallPtr& op, codegen::CodegenBase& codegen_base) {
     auto& codegen = AsPto(codegen_base);
     CHECK(op->args_.size() == 1) << "tile.move requires 1 argument, got " << op->args_.size();
@@ -515,11 +521,19 @@ void RegisterElementwiseOps(Backend& backend, const std::unordered_set<std::stri
           auto src_offset = As<ir::ConstInt>((*src_tile->memref_)->byte_offset_);
           auto dst_offset = As<ir::ConstInt>((*dst_tile->memref_)->byte_offset_);
           if (src_offset && dst_offset && src_offset->value_ == dst_offset->value_) {
-            // Alias the destination to the source SSA value so downstream
-            // references use the source's defined buffer, not the destination's
-            // alloc_tile (which would be unwritten after eliding the tmov).
-            codegen.SetCurrentResultBuf(codegen.GetExprAsCode(op->args_[0]));
-            return std::string("");  // no-op: same space, same address
+            const auto src_view = ir::tile_view_semantics::GetEffectiveTileView(*src_tile);
+            const auto dst_view = ir::tile_view_semantics::GetEffectiveTileView(*dst_tile);
+            const bool same_layout = src_view.blayout == dst_view.blayout &&
+                                     src_view.slayout == dst_view.slayout &&
+                                     src_view.fractal == dst_view.fractal;
+            if (same_layout) {
+              // Alias the destination to the source SSA value so downstream
+              // references use the source's defined buffer, not the destination's
+              // alloc_tile (which would be unwritten after eliding the tmov).
+              codegen.SetCurrentResultBuf(codegen.GetExprAsCode(op->args_[0]));
+              return std::string("");  // no-op: same space, same address, same layout
+            }
+            // Different layout at the same address: keep pto.tmov (ND↔NZ adapt).
           }
         }
       }

--- a/src/ir/transforms/memory_reuse_pass.cpp
+++ b/src/ir/transforms/memory_reuse_pass.cpp
@@ -39,6 +39,7 @@
 #include "pypto/ir/op_registry.h"
 #include "pypto/ir/scalar_expr.h"
 #include "pypto/ir/stmt.h"
+#include "pypto/ir/tile_view_semantics.h"
 #include "pypto/ir/transforms/base/mutator.h"
 #include "pypto/ir/transforms/base/visitor.h"
 #include "pypto/ir/transforms/pass_context.h"
@@ -1390,15 +1391,34 @@ LifetimeAnalysisResult ComputeLifetimes(const StmtPtr& func_body) {
           std::move(pipeline_load_tiles)};
 }
 
-// NOTE: The former tile-type reuse-compatibility gate (AreTileTypesCompatible)
-// has been removed.  PTO codegen binds a per-var alloc_tile to each tile, so two
-// tiles that share a physical MemRef can legally carry different shapes, dtypes,
-// or TileView attributes (each alloc_tile aliases the same base with its own
-// static signature).  The only genuine hazard was an op that reads an operand
-// while writing its output in place onto that operand's buffer; that is now
-// handled precisely by not_inplace_safe() and the per-operand
-// forbid_output_alias() markers (see ForbidAliasCollector below), rather than by
-// a coarse whole-tile shape/dtype match.
+// NOTE: The former whole-tile reuse-compatibility gate (AreTileTypesCompatible:
+// shape + dtype + full TileView) was removed in #1788.  PTO codegen binds a
+// per-var alloc_tile, so tiles that share a MemRef may legally carry different
+// shapes/dtypes (each alloc_tile aliases the same base with its own static
+// signature).  In-place read/write hazards are handled by not_inplace_safe() and
+// forbid_output_alias() (see ForbidAliasCollector below).
+//
+// Vec ND↔NZ is still a hazard: A5 V→C inserts an ND→NZ ``tile.move`` (*_nz)
+// before tpush (NZ signal: effective blayout == col_major, matching
+// expand_mixed_kernel CreateMove).  If MemoryReuse colocates that NZ tile with
+// the ND cast result at one Vec address, even a kept ``pto.tmov`` is an
+// in-place layout adapt that silently mis-transfers (prefill_indexer Hadamard /
+// §3.0 family).  Gate *only* Vec ND↔NZ — allow Left/Right/Mat freely, and allow
+// same-family Vec layout quirks (e.g. fractal-only differences).  Keep
+// cross-shape / cross-dtype L0 reuse (#1595 / #1788).
+static bool IsNzLikeBlayout(TileLayout blayout) { return blayout == TileLayout::col_major; }
+
+static bool AreVecNdNzCompatible(const VarPtr& var1, const VarPtr& var2) {
+  auto t1 = As<TileType>(var1->GetType());
+  auto t2 = As<TileType>(var2->GetType());
+  if (!t1 || !t2) return true;
+  const auto s1 = t1->GetMemorySpace();
+  const auto s2 = t2->GetMemorySpace();
+  if (!s1 || !s2 || *s1 != MemorySpace::Vec || *s2 != MemorySpace::Vec) return true;
+  const TileView v1 = tile_view_semantics::GetEffectiveTileView(*t1);
+  const TileView v2 = tile_view_semantics::GetEffectiveTileView(*t2);
+  return IsNzLikeBlayout(v1.blayout) == IsNzLikeBlayout(v2.blayout);
+}
 
 /**
  * @brief Check if two lifetimes overlap.
@@ -1918,10 +1938,10 @@ std::map<VarPtr, VarPtr> IdentifyReuseOpportunities(
   // Can `cand` join a single physical buffer that already holds `member`?
   // Lifetimes must not overlap (touching is allowed: a buffer's reader is
   // consumed before the writer at the same statement produces its output), and
-  // neither directional gate may block.  No tile-type / size check is needed:
-  // PTO binds a per-var alloc_tile so differing shapes/dtypes legally alias one
-  // base, and largest-first ordering guarantees the buffer is sized to its
-  // representative (no member is ever larger than the buffer it joins).
+  // neither directional gate may block.  Shape/dtype need not match: PTO binds a
+  // per-var alloc_tile so differing shapes/dtypes legally alias one base, and
+  // largest-first ordering guarantees the buffer is sized to its representative.
+  // On Vec only, ND and NZ must not share — see AreVecNdNzCompatible.
   auto can_share = [&](const LifetimeInterval& cand, const LifetimeInterval& member) {
     // Group-interval overlap is a fast reject; when it fires, fall back to the
     // precise per-var check so mutually-exclusive / same-value phi-family tiles
@@ -1931,6 +1951,7 @@ std::map<VarPtr, VarPtr> IdentifyReuseOpportunities(
     if (hazard_blocks(cand, member) || hazard_blocks(member, cand)) return false;
     if (forbid_blocks(cand, member) || forbid_blocks(member, cand)) return false;
     if (pipeline_blocks(cand, member)) return false;  // symmetric — one call suffices
+    if (!AreVecNdNzCompatible(cand.variable, member.variable)) return false;
     return true;
   };
 

--- a/tests/ut/codegen/test_pto_codegen_ops.py
+++ b/tests/ut/codegen/test_pto_codegen_ops.py
@@ -2403,6 +2403,97 @@ class TestTileMoveAccNoopElision:
         )
 
 
+class TestTileMoveLayoutNoopElision:
+    """Same-addr tile.move must keep pto.tmov when layouts differ.
+
+    Complements #1310 (acc→acc same-layout elision): A5 V→C may co-locate an ND
+    cast result and an NZ ``*_nz`` adapt at one Vec address. Eliding that tmov
+    drops the fractal adapt and leaves TPUSH RowMajor vs AIC ColMajor.
+    Build IR with a shared MemRef so codegen sees same space+addr without relying
+    on MemoryReuse (which now gates layout coalescing).
+    """
+
+    @staticmethod
+    def _vec_tile_move_program(*, dst_view: ir.TileView | None, name: str) -> ir.Program:
+        span = ir.Span.unknown()
+        size = 64
+        nbytes = size * size * 2  # BF16
+        byte_offset_zero = ir.ConstInt(0, DataType.INT64, span)
+        shared = ir.MemRef(ir.MemorySpace.Vec, byte_offset_zero, nbytes, 0)
+
+        inp = ir.Var("inp", ir.TensorType([size, size], DataType.BF16), span)
+        out = ir.Var("out", ir.TensorType([size, size], DataType.BF16), span)
+
+        src_ty = ir.TileType([size, size], DataType.BF16, shared, None, ir.MemorySpace.Vec)
+        dst_ty = ir.TileType([size, size], DataType.BF16, shared, dst_view, ir.MemorySpace.Vec)
+        src = ir.Var("src_nd", src_ty, span)
+        dst = ir.Var("dst_layout", dst_ty, span)
+        result = ir.Var("result", ir.TensorType([size, size], DataType.BF16), span)
+
+        zero = ir.ConstInt(0, DataType.INDEX, span)
+        dim = ir.ConstInt(size, DataType.INDEX, span)
+        offsets = ir.MakeTuple([zero, zero], span)
+        shapes = ir.MakeTuple([dim, dim], span)
+
+        load = ir.Call(ir.Op("tile.load"), [inp, offsets, shapes], {}, src_ty, span)
+        move = ir.Call(
+            ir.Op("tile.move"),
+            [src],
+            {"target_memory": ir.MemorySpace.Vec},
+            dst_ty,
+            span,
+        )
+        store = ir.Call(ir.Op("tile.store"), [dst, offsets, out], result.type, span)
+
+        body = ir.SeqStmts(
+            [
+                ir.SeqStmts(
+                    [
+                        ir.AssignStmt(src, load, span),
+                        ir.AssignStmt(dst, move, span),
+                        ir.AssignStmt(result, store, span),
+                    ],
+                    span,
+                ),
+                ir.ReturnStmt([result], span),
+            ],
+            span,
+        )
+        func = ir.Function(
+            name,
+            [(inp, ir.ParamDirection.In), (out, ir.ParamDirection.Out)],
+            [ir.TensorType([size, size], DataType.BF16)],
+            body,
+            span,
+            ir.FunctionType.InCore,
+        )
+        return ir.Program([func], f"{name}_program", span)
+
+    @staticmethod
+    def _generate_mlir(program: ir.Program) -> str:
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+        return codegen.PTOCodegen().generate(program)
+
+    def test_same_addr_different_layout_emits_tmov(self):
+        """ND→NZ at one Vec address must still emit pto.tmov (not elide)."""
+        nz = ir.TileView(
+            blayout=ir.TileLayout.col_major,
+            slayout=ir.TileLayout.row_major,
+            fractal=1024,
+        )
+        mlir = self._generate_mlir(self._vec_tile_move_program(dst_view=nz, name="move_nd_to_nz_same_addr"))
+        tmovs = [ln for ln in mlir.splitlines() if "pto.tmov" in ln]
+        assert tmovs, f"same-addr ND→NZ tile.move must emit pto.tmov (layout adapt); got none in:\n{mlir}"
+        assert any("loc=vec" in ln for ln in tmovs), f"expected vec→vec tmov, got:\n{tmovs}"
+
+    def test_same_addr_same_layout_elides_tmov(self):
+        """Same space+addr+layout tile.move remains a no-op (elide pto.tmov)."""
+        mlir = self._generate_mlir(self._vec_tile_move_program(dst_view=None, name="move_nd_to_nd_same_addr"))
+        tmovs = [ln for ln in mlir.splitlines() if "pto.tmov" in ln]
+        assert not tmovs, f"same-addr same-layout tile.move must elide pto.tmov; got:\n{tmovs}\nfull:\n{mlir}"
+
+
 class TestTileStoreAtomicCodegen:
     """Tests for tile.store atomic-add codegen (pto.tstore atomicType attr)."""
 

--- a/tests/ut/ir/transforms/test_memory_reuse.py
+++ b/tests/ut/ir/transforms/test_memory_reuse.py
@@ -3525,6 +3525,127 @@ class TestL0CrossShapeReuse:
         )
 
 
+class TestStorageLayoutReuseGate:
+    """Vec ND↔NZ tiles must not share a MemRef; other layout diffs may.
+
+    A5 V→C inserts an ND→NZ ``*_nz`` adapt before tpush (NZ: col_major blayout).
+    Colocating that NZ tile with the ND source at one Vec address makes even a
+    kept ``pto.tmov`` an in-place layout rewrite that silently mis-transfers.
+    Gate only Vec ND↔NZ — same-family fractal quirks and non-Vec spaces stay
+    eligible for reuse (#1788).
+    """
+
+    def test_nd_and_nz_vec_tiles_do_not_reuse(self):
+        """Disjoint-lifetime ND and NZ Vec tiles of equal size keep separate buffers."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                inp: pl.Tensor[[64, 64], pl.BF16],
+                out_nd: pl.Out[pl.Tensor[[64, 64], pl.BF16]],
+                out_nz: pl.Out[pl.Tensor[[64, 64], pl.BF16]],
+            ) -> pl.Tensor[[64, 64], pl.BF16]:
+                tile_nd: pl.Tile[[64, 64], pl.BF16, pl.Mem.Vec] = pl.tile.load(
+                    inp, [0, 0], [64, 64], target_memory=pl.Mem.Vec
+                )
+                _a: pl.Tensor[[64, 64], pl.BF16] = pl.tile.store(tile_nd, [0, 0], out_nd)
+                tile_nz: pl.Tile[
+                    [64, 64],
+                    pl.BF16,
+                    pl.Mem.Vec,
+                    pl.TileView(
+                        blayout=pl.TileLayout.col_major,
+                        slayout=pl.TileLayout.row_major,
+                        fractal=1024,
+                    ),
+                ] = pl.tile.load(inp, [0, 0], [64, 64], target_memory=pl.Mem.Vec)
+                result: pl.Tensor[[64, 64], pl.BF16] = pl.tile.store(tile_nz, [0, 0], out_nz)
+                return result
+
+        After = _run_pipeline(Before)
+        bases = _collect_tile_memref_bases(After)
+        assert "tile_nd" in bases and "tile_nz" in bases, f"missing tiles in {bases}"
+        assert bases["tile_nd"] != bases["tile_nz"], (
+            f"ND and NZ Vec tiles must not share a MemRef; both bound to {bases['tile_nd']}"
+        )
+
+    def test_same_nz_family_different_fractal_vec_tiles_can_reuse(self):
+        """Same NZ family (col_major) with fractal-only difference may coalesce."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                inp: pl.Tensor[[64, 64], pl.BF16],
+                out_a: pl.Out[pl.Tensor[[64, 64], pl.BF16]],
+                out_b: pl.Out[pl.Tensor[[64, 64], pl.BF16]],
+            ) -> pl.Tensor[[64, 64], pl.BF16]:
+                tile_a: pl.Tile[
+                    [64, 64],
+                    pl.BF16,
+                    pl.Mem.Vec,
+                    pl.TileView(
+                        blayout=pl.TileLayout.col_major,
+                        slayout=pl.TileLayout.row_major,
+                        fractal=512,
+                    ),
+                ] = pl.tile.load(inp, [0, 0], [64, 64], target_memory=pl.Mem.Vec)
+                _a: pl.Tensor[[64, 64], pl.BF16] = pl.tile.store(tile_a, [0, 0], out_a)
+                tile_b: pl.Tile[
+                    [64, 64],
+                    pl.BF16,
+                    pl.Mem.Vec,
+                    pl.TileView(
+                        blayout=pl.TileLayout.col_major,
+                        slayout=pl.TileLayout.row_major,
+                        fractal=1024,
+                    ),
+                ] = pl.tile.load(inp, [0, 0], [64, 64], target_memory=pl.Mem.Vec)
+                result: pl.Tensor[[64, 64], pl.BF16] = pl.tile.store(tile_b, [0, 0], out_b)
+                return result
+
+        After = _run_pipeline(Before)
+        bases = _collect_tile_memref_bases(After)
+        assert "tile_a" in bases and "tile_b" in bases, f"missing tiles in {bases}"
+        assert bases["tile_a"] == bases["tile_b"], (
+            "same NZ-family Vec tiles should still share a MemRef; "
+            f"got {bases['tile_a']} vs {bases['tile_b']}"
+        )
+
+    def test_same_layout_nd_vec_tiles_can_reuse(self):
+        """Equal-size ND Vec tiles with matching layout still coalesce (#1788)."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                inp: pl.Tensor[[64, 64], pl.BF16],
+                out_a: pl.Out[pl.Tensor[[64, 64], pl.BF16]],
+                out_b: pl.Out[pl.Tensor[[64, 64], pl.BF16]],
+            ) -> pl.Tensor[[64, 64], pl.BF16]:
+                tile_a: pl.Tile[[64, 64], pl.BF16, pl.Mem.Vec] = pl.tile.load(
+                    inp, [0, 0], [64, 64], target_memory=pl.Mem.Vec
+                )
+                _a: pl.Tensor[[64, 64], pl.BF16] = pl.tile.store(tile_a, [0, 0], out_a)
+                tile_b: pl.Tile[[64, 64], pl.BF16, pl.Mem.Vec] = pl.tile.load(
+                    inp, [0, 0], [64, 64], target_memory=pl.Mem.Vec
+                )
+                result: pl.Tensor[[64, 64], pl.BF16] = pl.tile.store(tile_b, [0, 0], out_b)
+                return result
+
+        After = _run_pipeline(Before)
+        bases = _collect_tile_memref_bases(After)
+        assert "tile_a" in bases and "tile_b" in bases, f"missing tiles in {bases}"
+        assert bases["tile_a"] == bases["tile_b"], (
+            "matching-layout ND Vec tiles should still share a MemRef; "
+            f"got {bases['tile_a']} vs {bases['tile_b']}"
+        )
+
+
 class TestAscend910BLoadTpopHazard:
     """MemoryReuse must not coalesce a writer that consumes a tile.load result
     and a tile.tpop_from_aic value into the load's buffer on Ascend910B split-AIV


### PR DESCRIPTION
## Summary

On A5, the ND→NZ `tile.move` already inserted before V→C TPUSH was dropped under same-addr elision/colocation; this PR keeps that layout adapt.

### Background

- On Ascend950, `RequiresVtoCFractalAdapt()` already causes ExpandMixedKernel to insert an ND→NZ `tile.move` (`*_nz`) before AIV V→C `tpush`. **This PR does not add that conversion** — it only stops it from being discarded.
- A2/A3 (`910B`) skip the insert path (`RequiresVtoCFractalAdapt() == false`; #942 / ub→gm→mat stays ND). The fix is still platform-wide correct for true layout-changing same-addr moves; same-layout no-op elision is unchanged.

### Symptoms

Silent numerical FAIL on A5 fused V→C paths (fused PV / sparse attention family and related), while still compiling and running. Historical workarounds (AIC GM TLOAD overlay after TPOP, `--split-cast-matmul`) masked the same root cause.

### Root cause

1. ExpandMixedKernel inserts ND→NZ before A5 V→C TPUSH.
2. **MemoryReuse** colocates the `*_nz` tile with the preceding ND cast at the **same Vec address** (post-#1788: shape/dtype may alias one MemRef).
3. **Codegen** treated same-space + same-addr `tile.move` as a no-op and **elided `pto.tmov`** (#1310-style elision). The fractal layout adapt was dropped → AIV `TPUSH` remained **RowMajor** while AIC `TPOP` expected **Mat ColMajor** → silent numerical FAIL.

### Fix

1. **Codegen** (`pto_ops_elementwise.cpp`): same-addr `tile.move` elision also requires matching `blayout` / `slayout` / `fractal`; layout mismatch keeps `pto.tmov`.
2. **MemoryReuse** (`memory_reuse_pass.cpp`): `AreVecNdNzCompatible` — **Vec-only** ND↔NZ forbid colocation (NZ signal: effective `blayout == col_major`). Narrowed after a broader layout gate caused **Left overflow** on `fits_l0c_split_k` ST; Left/Right/Mat and same-family fractal quirks may still pack so L0 Left stays within capacity. Cross-shape / cross-dtype L0 reuse (#1595 / #1788) is preserved.

### Out of scope

- Vec→Mat staging
- Acc C2V `srcStride` (pto-isa)
- VF fusion defaults
- Intentionally **not** extending the PTOAS `!EmitTileAddr` guard, or folding stride/pad into the codegen `same_layout` check

## Test plan

### Unit tests (tip)

**Codegen** — `TestTileMoveLayoutNoopElision` in `tests/ut/codegen/test_pto_codegen_ops.py`:

- `test_same_addr_different_layout_emits_tmov` — ND→NZ at one Vec addr still emits `pto.tmov`
- `test_same_addr_same_layout_elides_tmov` — same space+addr+layout still elides (keeps #1310)

**MemoryReuse** — `TestStorageLayoutReuseGate` in `tests/ut/ir/transforms/test_memory_reuse.py`:

- `test_nd_and_nz_vec_tiles_do_not_reuse` — Vec ND↔NZ must not share a MemRef
- `test_same_nz_family_different_fractal_vec_tiles_can_reuse` — same NZ family (col_major) with fractal-only diff may still coalesce (Vec-only gate)
- `test_same_layout_nd_vec_tiles_can_reuse` — matching ND still coalesces (#1788)

Regression note: the earlier broad layout gate (forbid all layout-mismatched reuse) overflowed **Left** on `fits_l0c_split_k` ST; the tip’s **Vec-only** `AreVecNdNzCompatible` gate fixes that while still blocking the ND↔NZ hazard.

### Board verification (§3.0; still accurate)

Without `--split-cast-matmul` / GM overlay / with `gm_scratch=False`, after this fix:

- **PASS**: `decode_sparse_attn` / `_hca` / `_swa`, `prefill_sparse_attn`, Desktop `test_qk_pv_pv_segment` fused, `decode_attention_hca` / `_swa`, `hc_head` e2e `y`
- Still **FAIL** (not claimed fixed here): `decode_attention_csa` (`x_out`), `prefill_attention_{csa,hca,swa}`, `decode_indexer`, `prefill_indexer` without §5.1/§5.2
