### PR TITLE
fix(ir): Normalize mixed Group member ABI

### DIFF
--- a/docs/en/dev/passes/19-expand_mixed_kernel.md
+++ b/docs/en/dev/passes/19-expand_mixed_kernel.md
@@ -19,6 +19,33 @@ For **non-mixed InCore functions** (pure Cube or pure Vector), the pass converts
 
 After this pass, no `FunctionType::InCore` functions remain in the program.
 
+### Shared argument ABI for hand-written Groups
+
+One runtime `MixedKernels` submission creates a co-scheduled AIC/AIV task whose
+active lanes share one `L0TaskArgs` payload. Consequently, the two compiled
+kernel wrappers must unpack the same tensors-first argument layout. This is
+automatic for Groups created by the mixed-kernel splitter, because both member
+calls forward the complete Group signature.
+
+A hand-written `pl.cluster()` may instead submit members with different source
+signatures, for example `cube(q, k, v, sink, task)` and `vec(out, task)`. The
+outlined Group captures the union of those values. This pass normalizes both DSL
+members to that Group signature and rewrites both inner `Call` or `Submit` nodes
+to forward the complete list. Unused parameters remain valid wrapper arguments;
+each cloned body still references only the values from its original call.
+
+When both member kernels are exclusive to the Group, their names are preserved.
+If either kernel has another call site, the pass creates a Group-private adapter
+pair and rewrites `import_peer_buffer(peer_func=...)` to the adapter peer names,
+leaving the original ABI available to the other callers. External-source and
+runtime-bound members cannot be body-cloned; when their layouts differ, the pass
+rejects the Group and requires both declarations to use the same signature.
+
+This normalization happens before `InjectGMPipeBuffer`, so a backend-injected
+`__gm_pipe_buffer` parameter is appended to the already-identical member
+signatures. It does not require `sync_start`: AIC and AIV are subslots of one
+mixed task, while `sync_start` controls multi-block SPMD launch admission.
+
 ## Unsplittable transpose: reject with an actionable error
 
 A requested vector split is **rejected with a `ValueError`** when the kernel
@@ -253,6 +280,12 @@ Phase 2 — Expand each InCore function F:
 Phase 3 — Rewrite Group callers:
   For each Group function that calls a split InCore, replace the InCore call
   with an AIC call + AIV call sequence (EvalStmt for AIC, AssignStmt for AIV).
+
+Phase 4 — Normalize hand-written mixed Group ABIs:
+  For each Group whose AIC/AIV calls do not both forward the complete Group
+  signature, rebuild the DSL member bodies against one canonical parameter list
+  and rewrite both Call/Submit nodes to pass it. Preserve exclusive member names;
+  otherwise create Group-private adapters and retarget peer_func references.
 ```
 
 **Affinity classification**:

--- a/docs/zh-cn/dev/passes/19-expand_mixed_kernel.md
+++ b/docs/zh-cn/dev/passes/19-expand_mixed_kernel.md
@@ -19,6 +19,29 @@
 
 该 Pass 执行后，程序中不再存在 `FunctionType::InCore` 函数。
 
+### 手写 Group 的共享参数 ABI
+
+一次运行时 `MixedKernels` 提交会创建一个协同调度的 AIC/AIV task，其中所有
+active lane 共用同一份 `L0TaskArgs` payload。因此，两个已编译 kernel wrapper
+必须按完全相同的 tensors-first 参数布局解包。由 mixed-kernel 拆分器生成的 Group
+天然满足这一约束，因为两个成员调用都会转发完整的 Group 签名。
+
+手写 `pl.cluster()` 则可能提交源签名不同的成员，例如
+`cube(q, k, v, sink, task)` 与 `vec(out, task)`；outline 后的 Group 会捕获这些值的
+并集。本 Pass 会把两个 DSL 成员都归一化为该 Group 签名，并改写两个内层 `Call`
+或 `Submit`，使其转发完整参数列表。未使用的参数仍是合法的 wrapper 参数；克隆后的
+函数体依旧只引用原调用实际使用的值。
+
+当两个成员 kernel 都只属于该 Group 时，保留其原函数名。如果任一 kernel 还有其他
+调用点，Pass 会生成一对 Group 私有 adapter，并把
+`import_peer_buffer(peer_func=...)` 改写为 adapter 的 peer 名称，从而为其他调用者保留
+原 ABI。外部源码和 runtime-bound 成员无法安全克隆函数体；若它们的参数布局不同，
+Pass 会拒绝该 Group，并要求两个声明使用相同签名。
+
+归一化发生在 `InjectGMPipeBuffer` 之前，因此后端注入的 `__gm_pipe_buffer` 会追加到
+已经一致的两个成员签名末尾。该过程不需要 `sync_start`：AIC 与 AIV 是同一个 mixed
+task 的 subslot，而 `sync_start` 控制的是多 block SPMD 启动准入。
+
 ## 不可切分的转置：报错而非降级
 
 当内核含有一个**交换了切分轴**的 `tile.transpose` 时,**请求的向量切分会被以 `ValueError` 拒绝**。`tile.transpose` 交换两个轴,于是每个 lane 的切分数据迁移到了*另一个*维度,而 `SplitVectorKernel` 仍按*原*切分轴减半 —— 它无法正确定型这种转置,结果形状错误并会算错。这与切分模式(UP_DOWN dim 0 / LEFT_RIGHT dim 1)和 dtype 都无关。
@@ -220,6 +243,11 @@ program_expanded = expand_pass(program)
 阶段 3 — 改写 Group 调用者：
   对于每个调用了已拆分 InCore 的 Group 函数，将 InCore 调用替换为
   AIC 调用 + AIV 调用序列（AIC 用 EvalStmt，AIV 用 AssignStmt）。
+
+阶段 4 — 归一化手写 mixed Group 的 ABI：
+  对于 AIC/AIV 调用未同时转发完整 Group 签名的 Group，把两个 DSL 成员函数体
+  重建到同一份 canonical 参数列表上，并改写两个 Call/Submit 以传入完整列表。
+  独占成员保留原函数名；否则创建 Group 私有 adapter，并同步重定向 peer_func。
 ```
 
 **亲和性分类**：

--- a/src/ir/transforms/expand_mixed_kernel_pass.cpp
+++ b/src/ir/transforms/expand_mixed_kernel_pass.cpp
@@ -28,6 +28,7 @@
 #include "pypto/ir/core_affinity_kind.h"
 #include "pypto/ir/expr.h"
 #include "pypto/ir/function.h"
+#include "pypto/ir/kind_traits.h"
 #include "pypto/ir/memory_space.h"
 #include "pypto/ir/op_registry.h"
 #include "pypto/ir/program.h"
@@ -52,6 +53,7 @@
 #include "pypto/ir/transforms/utils/tpop_tfree_finalizer.h"
 #include "pypto/ir/transforms/utils/transform_utils.h"
 #include "pypto/ir/transforms/utils/var_collectors.h"
+#include "pypto/ir/transforms/utils/wrapper_call_utils.h"
 #include "pypto/ir/type.h"
 
 namespace pypto {
@@ -1457,6 +1459,251 @@ bool FunctionCallsFunction(const FunctionPtr& func, const std::string& callee_na
   return false;
 }
 
+// ============================================================================
+// Hand-written Group ABI normalization
+// ============================================================================
+
+/// Runtime MixedKernels subslots share one L0TaskArgs payload. Auto-expanded
+/// Groups already satisfy that contract because both member calls forward the
+/// complete Group signature. A hand-written Group may call AIC/AIV functions
+/// with different subsets, however, so normalize both members to the Group ABI
+/// before orchestration codegen (#2097).
+
+class KernelCallCounter : public IRVisitor {
+ public:
+  [[nodiscard]] size_t Count(const std::string& name) const {
+    auto it = counts_.find(name);
+    return it == counts_.end() ? 0 : it->second;
+  }
+
+ protected:
+  void VisitExpr_(const CallPtr& op) override {
+    CountCallee(op->op_);
+    IRVisitor::VisitExpr_(op);
+  }
+
+  void VisitExpr_(const SubmitPtr& op) override {
+    CountCallee(op->op_);
+    IRVisitor::VisitExpr_(op);
+  }
+
+ private:
+  void CountCallee(const OpPtr& op) {
+    if (auto gv = std::dynamic_pointer_cast<const GlobalVar>(op)) ++counts_[gv->name_];
+  }
+
+  std::unordered_map<std::string, size_t> counts_;
+};
+
+bool IsCanonicalGroupMemberCall(const CallPtr& call, const FunctionPtr& callee, const FunctionPtr& group) {
+  if (!call || !callee || !group) return false;
+  if (call->args_.size() != group->params_.size() || callee->params_.size() != group->params_.size()) {
+    return false;
+  }
+  for (size_t i = 0; i < group->params_.size(); ++i) {
+    auto arg = AsVarLike(call->args_[i]);
+    if (!arg || arg.get() != group->params_[i].get()) return false;
+  }
+  return true;
+}
+
+/// Rewrite import_peer_buffer(peer_func=...) when a reused pair receives
+/// Group-private adapter names.
+class PeerFuncRewriter : public IRMutator {
+ public:
+  explicit PeerFuncRewriter(std::unordered_map<std::string, std::string> rename_map)
+      : rename_map_(std::move(rename_map)) {}
+
+ protected:
+  ExprPtr VisitExpr_(const CallPtr& op) override {
+    auto visited = As<Call>(IRMutator::VisitExpr_(op));
+    INTERNAL_CHECK_SPAN(visited != nullptr, op->span_) << "Call mutation produced a non-Call expression";
+
+    auto builtin = As<Op>(visited->op_);
+    if (!builtin || !IsOp(builtin, "system.import_peer_buffer")) return visited;
+
+    auto kwargs = visited->kwargs_;
+    bool changed = false;
+    for (auto& [key, value] : kwargs) {
+      if (key != "peer_func") continue;
+      auto peer = std::any_cast<std::string>(&value);
+      if (!peer) continue;
+      auto it = rename_map_.find(*peer);
+      if (it == rename_map_.end()) continue;
+      value = it->second;
+      changed = true;
+    }
+    if (!changed) return visited;
+    return std::make_shared<Call>(visited->op_, visited->args_, std::move(kwargs), visited->attrs_,
+                                  visited->GetType(), visited->span_);
+  }
+
+ private:
+  std::unordered_map<std::string, std::string> rename_map_;
+};
+
+FunctionPtr BuildGroupAbiAdapter(const FunctionPtr& group, const WrapperCallInfo& member,
+                                 const std::string& adapter_name,
+                                 const std::unordered_map<std::string, std::string>& peer_renames) {
+  const auto& callee = member.inner_callee;
+  const auto& call = member.inner_call;
+  INTERNAL_CHECK(group != nullptr && callee != nullptr && call != nullptr)
+      << "Internal error: incomplete Group member while normalizing its shared ABI";
+  CHECK_SPAN(call->args_.size() == callee->params_.size(), call->span_)
+      << "Group '" << group->name_ << "' calls member '" << callee->name_ << "' with " << call->args_.size()
+      << " arguments, but its signature has " << callee->params_.size();
+
+  std::vector<VarPtr> adapter_params;
+  adapter_params.reserve(group->params_.size());
+  std::unordered_map<const Var*, VarPtr> group_to_adapter;
+  for (const auto& param : group->params_) {
+    auto fresh = std::make_shared<Var>(param->name_hint_, param->GetType(), param->span_);
+    adapter_params.push_back(fresh);
+    group_to_adapter.emplace(param.get(), fresh);
+  }
+
+  // Bind every original member parameter to the corresponding Group call-site
+  // expression, rewritten onto the adapter's fresh canonical parameters.
+  std::unordered_map<const Var*, ExprPtr> member_to_adapter;
+  for (size_t i = 0; i < callee->params_.size(); ++i) {
+    member_to_adapter.emplace(callee->params_[i].get(),
+                              transform_utils::Substitute(call->args_[i], group_to_adapter));
+  }
+  auto cloned = DeepClone(callee->body_, member_to_adapter);
+  StmtPtr adapter_body = cloned.cloned_body;
+  if (!peer_renames.empty()) {
+    adapter_body = PeerFuncRewriter(peer_renames).VisitStmt(adapter_body);
+  }
+
+  return std::make_shared<Function>(adapter_name, std::move(adapter_params), group->param_directions_,
+                                    callee->return_types_, std::move(adapter_body), callee->span_,
+                                    callee->func_type_, callee->level_, callee->role_, callee->attrs_,
+                                    callee->requires_runtime_binding_);
+}
+
+class GroupMemberCallRewriter : public IRMutator {
+ public:
+  GroupMemberCallRewriter(std::unordered_map<std::string, std::string> callee_renames,
+                          std::vector<VarPtr> canonical_args)
+      : callee_renames_(std::move(callee_renames)), canonical_args_(std::move(canonical_args)) {}
+
+ protected:
+  ExprPtr VisitExpr_(const CallPtr& op) override {
+    auto gv = As<GlobalVar>(op->op_);
+    auto it = gv ? callee_renames_.find(gv->name_) : callee_renames_.end();
+    if (it == callee_renames_.end()) return IRMutator::VisitExpr_(op);
+    std::vector<ExprPtr> args(canonical_args_.begin(), canonical_args_.end());
+    return std::make_shared<Call>(std::make_shared<GlobalVar>(it->second), std::move(args), op->kwargs_,
+                                  op->attrs_, op->GetType(), op->span_);
+  }
+
+  ExprPtr VisitExpr_(const SubmitPtr& op) override {
+    auto gv = As<GlobalVar>(op->op_);
+    auto it = gv ? callee_renames_.find(gv->name_) : callee_renames_.end();
+    if (it == callee_renames_.end()) return IRMutator::VisitExpr_(op);
+    std::vector<ExprPtr> args(canonical_args_.begin(), canonical_args_.end());
+    return std::make_shared<Submit>(std::make_shared<GlobalVar>(it->second), std::move(args), op->deps_,
+                                    op->kwargs_, op->attrs_, op->GetType(), op->span_, op->core_num_,
+                                    op->sync_start_, op->allow_early_resolve_, op->predicate_);
+  }
+
+ private:
+  std::unordered_map<std::string, std::string> callee_renames_;
+  std::vector<VarPtr> canonical_args_;
+};
+
+std::string ReserveAdapterName(const std::string& base, std::unordered_set<std::string>& used_names) {
+  if (used_names.insert(base).second) return base;
+  for (size_t suffix = 1;; ++suffix) {
+    std::string candidate = base + "_" + std::to_string(suffix);
+    if (used_names.insert(candidate).second) return candidate;
+  }
+}
+
+struct NormalizedGroups {
+  std::vector<FunctionPtr> functions;
+};
+
+NormalizedGroups NormalizeHandWrittenGroupAbis(const ProgramPtr& program,
+                                               const std::vector<FunctionPtr>& functions) {
+  KernelCallCounter call_counter;
+  for (const auto& func : functions) {
+    if (func && func->body_) call_counter.VisitStmt(func->body_);
+  }
+
+  std::unordered_set<std::string> used_names;
+  std::unordered_map<std::string, FunctionPtr> replacements;
+  std::vector<FunctionPtr> adapters;
+  for (const auto& func : functions) used_names.insert(func->name_);
+
+  for (const auto& group : functions) {
+    if (!group || group->func_type_ != FunctionType::Group) continue;
+
+    WrapperCallInfo aic;
+    WrapperCallInfo aiv;
+    for (const auto& member : CollectInnerCalls(group, program)) {
+      if (member.inner_callee->func_type_ == FunctionType::AIC && !aic.inner_call) {
+        aic = member;
+      } else if (member.inner_callee->func_type_ == FunctionType::AIV && !aiv.inner_call) {
+        aiv = member;
+      }
+    }
+    // AIV-only Groups and pre-expansion Groups are handled by their existing
+    // dispatch paths. A mixed Group needs exactly the shared AIC/AIV ABI here.
+    if (!aic.inner_call || !aiv.inner_call) continue;
+    if (IsCanonicalGroupMemberCall(aic.inner_call, aic.inner_callee, group) &&
+        IsCanonicalGroupMemberCall(aiv.inner_call, aiv.inner_callee, group)) {
+      continue;
+    }
+
+    CHECK_SPAN(
+        !aic.inner_callee->HasAttr("external_source") && !aiv.inner_callee->HasAttr("external_source") &&
+            !aic.inner_callee->requires_runtime_binding_ && !aiv.inner_callee->requires_runtime_binding_,
+        group->span_)
+        << "Mixed Group '" << group->name_
+        << "' has AIC/AIV members with different argument layouts. External or runtime-bound members "
+           "cannot be adapted; declare both members with the same signature and forward the Group's full "
+           "parameter list.";
+
+    const bool exclusive_pair =
+        call_counter.Count(aic.inner_callee->name_) == 1 && call_counter.Count(aiv.inner_callee->name_) == 1;
+    const std::string aic_name = exclusive_pair
+                                     ? aic.inner_callee->name_
+                                     : ReserveAdapterName(group->name_ + "_aic_adapter", used_names);
+    const std::string aiv_name = exclusive_pair
+                                     ? aiv.inner_callee->name_
+                                     : ReserveAdapterName(group->name_ + "_aiv_adapter", used_names);
+    const std::unordered_map<std::string, std::string> peer_renames = {{aic.inner_callee->name_, aic_name},
+                                                                       {aiv.inner_callee->name_, aiv_name}};
+
+    auto normalized_aic = BuildGroupAbiAdapter(group, aic, aic_name, peer_renames);
+    auto normalized_aiv = BuildGroupAbiAdapter(group, aiv, aiv_name, peer_renames);
+    if (exclusive_pair) {
+      replacements[aic_name] = normalized_aic;
+      replacements[aiv_name] = normalized_aiv;
+    } else {
+      adapters.push_back(normalized_aic);
+      adapters.push_back(normalized_aiv);
+    }
+
+    std::unordered_map<std::string, std::string> callee_renames = {{aic.inner_callee->name_, aic_name},
+                                                                   {aiv.inner_callee->name_, aiv_name}};
+    auto mutable_group = MutableCopy(group);
+    mutable_group->body_ =
+        GroupMemberCallRewriter(std::move(callee_renames), group->params_).VisitStmt(group->body_);
+    replacements[group->name_] = mutable_group;
+  }
+
+  std::vector<FunctionPtr> result;
+  result.reserve(functions.size() + adapters.size());
+  result.insert(result.end(), adapters.begin(), adapters.end());
+  for (const auto& func : functions) {
+    auto it = replacements.find(func->name_);
+    result.push_back(it == replacements.end() ? func : it->second);
+  }
+  return {std::move(result)};
+}
+
 }  // namespace
 
 namespace pass {
@@ -1558,6 +1805,12 @@ Pass ExpandMixedKernel() {
         }
       }
     }
+
+    // Phase 4: normalize hand-written mixed Groups to the runtime's one-shared-
+    // payload ABI. Rebuild a lookup program after the Phase 3 rewrites so the
+    // callee scan sees the final AIC/AIV functions.
+    auto rewritten_program = std::make_shared<Program>(new_functions, program->name_, program->span_);
+    new_functions = NormalizeHandWrittenGroupAbis(rewritten_program, new_functions).functions;
 
     return std::make_shared<Program>(new_functions, program->name_, program->span_);
   };

--- a/src/ir/transforms/expand_mixed_kernel_pass.cpp
+++ b/src/ir/transforms/expand_mixed_kernel_pass.cpp
@@ -12,6 +12,7 @@
 #include <algorithm>
 #include <any>
 #include <cstddef>
+#include <cstdint>
 #include <functional>
 #include <map>
 #include <memory>
@@ -1585,7 +1586,11 @@ class GroupMemberCallRewriter : public IRMutator {
  public:
   GroupMemberCallRewriter(std::unordered_map<std::string, std::string> callee_renames,
                           std::vector<VarPtr> canonical_args)
-      : callee_renames_(std::move(callee_renames)), canonical_args_(std::move(canonical_args)) {}
+      : callee_renames_(std::move(callee_renames)), canonical_args_(std::move(canonical_args)) {
+    for (size_t i = 0; i < canonical_args_.size(); ++i) {
+      canonical_arg_indices_.emplace(canonical_args_[i].get(), static_cast<int32_t>(i));
+    }
+  }
 
  protected:
   ExprPtr VisitExpr_(const CallPtr& op) override {
@@ -1594,7 +1599,8 @@ class GroupMemberCallRewriter : public IRMutator {
     if (it == callee_renames_.end()) return IRMutator::VisitExpr_(op);
     std::vector<ExprPtr> args(canonical_args_.begin(), canonical_args_.end());
     return std::make_shared<Call>(std::make_shared<GlobalVar>(it->second), std::move(args), op->kwargs_,
-                                  op->attrs_, op->GetType(), op->span_);
+                                  RemapPositionalAttrs(op->attrs_, op->args_, op->op_, op->span_),
+                                  op->GetType(), op->span_);
   }
 
   ExprPtr VisitExpr_(const SubmitPtr& op) override {
@@ -1602,14 +1608,56 @@ class GroupMemberCallRewriter : public IRMutator {
     auto it = gv ? callee_renames_.find(gv->name_) : callee_renames_.end();
     if (it == callee_renames_.end()) return IRMutator::VisitExpr_(op);
     std::vector<ExprPtr> args(canonical_args_.begin(), canonical_args_.end());
-    return std::make_shared<Submit>(std::make_shared<GlobalVar>(it->second), std::move(args), op->deps_,
-                                    op->kwargs_, op->attrs_, op->GetType(), op->span_, op->core_num_,
-                                    op->sync_start_, op->allow_early_resolve_, op->predicate_);
+    return std::make_shared<Submit>(
+        std::make_shared<GlobalVar>(it->second), std::move(args), op->deps_, op->kwargs_,
+        RemapPositionalAttrs(op->attrs_, op->args_, op->op_, op->span_), op->GetType(), op->span_,
+        op->core_num_, op->sync_start_, op->allow_early_resolve_, op->predicate_);
   }
 
  private:
+  std::vector<std::pair<std::string, std::any>> RemapPositionalAttrs(
+      const std::vector<std::pair<std::string, std::any>>& source_attrs,
+      const std::vector<ExprPtr>& source_args, const OpPtr& source_op, const Span& source_span) const {
+    std::vector<std::pair<std::string, std::any>> attrs;
+    attrs.reserve(source_attrs.size());
+    for (const auto& [key, value] : source_attrs) {
+      // These directions describe the old member argument list. The standard
+      // pipeline derives them again after ExpandMixedKernel, so retaining the
+      // vector would make the widened Call/Submit fail constructor validation.
+      if (key == kAttrArgDirections) continue;
+      if (key != kAttrArgDirectionOverrides) {
+        attrs.emplace_back(key, value);
+        continue;
+      }
+
+      const auto* old_indices = std::any_cast<std::vector<int32_t>>(&value);
+      INTERNAL_CHECK_SPAN(old_indices != nullptr, source_span)
+          << "Internal error: " << kAttrArgDirectionOverrides << " attr must hold std::vector<int32_t>";
+      std::vector<int32_t> remapped_indices;
+      remapped_indices.reserve(old_indices->size());
+      for (int32_t old_index : *old_indices) {
+        INTERNAL_CHECK_SPAN(old_index >= 0 && static_cast<size_t>(old_index) < source_args.size(),
+                            source_span)
+            << "Internal error: " << kAttrArgDirectionOverrides << " index " << old_index
+            << " is out of range for Group member call to '" << source_op->name_ << "'";
+        auto old_arg = AsVarLike(source_args[static_cast<size_t>(old_index)]);
+        CHECK_SPAN(old_arg != nullptr, source_span)
+            << "Cannot preserve pl.no_dep on non-variable argument " << old_index << " of Group member '"
+            << source_op->name_ << "' while normalizing its shared ABI";
+        auto canonical_it = canonical_arg_indices_.find(old_arg.get());
+        CHECK_SPAN(canonical_it != canonical_arg_indices_.end(), source_span)
+            << "Cannot map pl.no_dep argument " << old_index << " of Group member '" << source_op->name_
+            << "' to a canonical Group parameter";
+        remapped_indices.push_back(canonical_it->second);
+      }
+      attrs.emplace_back(key, std::move(remapped_indices));
+    }
+    return attrs;
+  }
+
   std::unordered_map<std::string, std::string> callee_renames_;
   std::vector<VarPtr> canonical_args_;
+  std::unordered_map<const Var*, int32_t> canonical_arg_indices_;
 };
 
 std::string ReserveAdapterName(const std::string& base, std::unordered_set<std::string>& used_names) {

--- a/tests/ut/codegen/test_orchestration_tensor_rw.py
+++ b/tests/ut/codegen/test_orchestration_tensor_rw.py
@@ -944,7 +944,7 @@ class TestTensorReadWriteOffsetCodegen:
         )
 
     def test_submit_dispatched_pipe_group_sizes_workspace_and_resolves_callees(self):
-        """Submitted AIC/AIV pipe kernels remain visible to orchestration codegen."""
+        """Submitted pipe kernels with different signatures share one Group ABI (#2097)."""
         backend.reset_for_testing()
         backend.set_backend_type(BackendType.Ascend910B)
 
@@ -953,17 +953,20 @@ class TestTensorReadWriteOffsetCodegen:
             @pl.function(type=pl.FunctionType.AIC)
             def cube_side(
                 self,
-                out: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+                q: pl.Tensor[[16, 16], pl.FP32],
+                sink: pl.InOut[pl.Tensor[[16, 16], pl.FP32]],
+                task: pl.Scalar[pl.INDEX],
             ) -> pl.Tensor[[16, 16], pl.FP32]:
                 v2c_buf = pl.reserve_buffer(name="submit_v2c", size=4096, base=pl.AUTO)
                 c2v_peer = pl.import_peer_buffer(name="submit_c2v", peer_func="vec_side")
                 pl.aic_initialize_pipe(c2v_peer, v2c_buf, dir_mask=3, slot_size=512)
-                return out
+                return sink
 
             @pl.function(type=pl.FunctionType.AIV)
             def vec_side(
                 self,
                 out: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+                task: pl.Scalar[pl.INDEX],
             ) -> pl.Tensor[[16, 16], pl.FP32]:
                 c2v_buf = pl.reserve_buffer(name="submit_c2v", size=4096, base=pl.AUTO)
                 v2c_peer = pl.import_peer_buffer(name="submit_v2c", peer_func="cube_side")
@@ -973,11 +976,14 @@ class TestTensorReadWriteOffsetCodegen:
             @pl.function(type=pl.FunctionType.Orchestration)
             def main(
                 self,
+                q: pl.Tensor[[16, 16], pl.FP32],
+                sink: pl.InOut[pl.Tensor[[16, 16], pl.FP32]],
                 out: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+                task: pl.Scalar[pl.INDEX],
             ) -> pl.Tensor[[16, 16], pl.FP32]:
                 with pl.cluster():
-                    _cube_out, _cube_tid = pl.submit(self.cube_side, out)
-                    vec_out, _vec_tid = pl.submit(self.vec_side, out)
+                    _cube_out, _cube_tid = pl.submit(self.cube_side, q, sink, task)
+                    vec_out, _vec_tid = pl.submit(self.vec_side, out, task)
                 return vec_out
 
         transformed = PassManager.get_strategy(OptimizationStrategy.Default).run_passes(SubmitPipeProgram)
@@ -985,14 +991,28 @@ class TestTensorReadWriteOffsetCodegen:
         assert transformed_text.count("pl.submit(") == 2, transformed_text
         assert "self.cube_side" in transformed_text, transformed_text
         assert "self.vec_side" in transformed_text, transformed_text
+        cube = transformed.get_function("cube_side")
+        vec = transformed.get_function("vec_side")
+        canonical_names = [param.name_hint for param in cube.params]
+        assert canonical_names == [param.name_hint for param in vec.params]
+        assert canonical_names[-1] == "__gm_pipe_buffer"
         orch_func = next(
             func for func in transformed.functions.values() if func.func_type == ir.FunctionType.Orchestration
         )
-        code = codegen.generate_orchestration(transformed, orch_func).code
+        result = codegen.generate_orchestration(transformed, orch_func)
+        code = result.code
 
         shape_values = re.findall(r"gm_pipe_buffer_\d+_ci_shapes\[1\]\s*=\s*\{(\d+)\};", code)
         assert shape_values == ["512"], code
         assert "rt_submit_task" in code, code
+        assert result.func_name_to_signature["cube_side"] == result.func_name_to_signature["vec_side"]
+        # The one shared task payload must contain all three Group tensors plus
+        # the injected workspace; pre-fix it was built only from cube_side and
+        # omitted ext_out, so vec_side unpacked q as its output/workspace.
+        task_add_lines = [line for line in code.splitlines() if "params_t0.add_" in line]
+        task_add_text = "\n".join(task_add_lines)
+        for expected in ("ext_q", "ext_sink", "ext_out", "gm_pipe_buffer_0", "task"):
+            assert expected in task_add_text, code
 
 
 if __name__ == "__main__":

--- a/tests/ut/codegen/test_orchestration_tensor_rw.py
+++ b/tests/ut/codegen/test_orchestration_tensor_rw.py
@@ -993,6 +993,8 @@ class TestTensorReadWriteOffsetCodegen:
         assert "self.vec_side" in transformed_text, transformed_text
         cube = transformed.get_function("cube_side")
         vec = transformed.get_function("vec_side")
+        assert cube is not None
+        assert vec is not None
         canonical_names = [param.name_hint for param in cube.params]
         assert canonical_names == [param.name_hint for param in vec.params]
         assert canonical_names[-1] == "__gm_pipe_buffer"

--- a/tests/ut/ir/transforms/test_expand_mixed_kernel_a2a3.py
+++ b/tests/ut/ir/transforms/test_expand_mixed_kernel_a2a3.py
@@ -63,6 +63,129 @@ def _op_name(stmt: ir.Stmt) -> str:
     return ""
 
 
+def test_hand_written_group_members_share_canonical_abi():
+    """Different AIC/AIV signatures are normalized to the Group ABI (#2097).
+
+    ``MixedKernels`` gives every active lane the same runtime argument array.
+    A hand-written Group is allowed to capture the union of its member inputs,
+    so ExpandMixedKernel must make both member wrappers consume that union in
+    the same order instead of letting orchestration codegen use the first call's
+    shorter signature for both lanes.
+    """
+
+    @pl.program
+    class Program:
+        @pl.function(type=pl.FunctionType.AIC)
+        def cube_side(
+            self,
+            q: pl.Tensor[[16, 16], pl.FP32],
+            sink: pl.InOut[pl.Tensor[[16, 16], pl.FP32]],
+            task: pl.Scalar[pl.INDEX],
+        ) -> pl.Tensor[[16, 16], pl.FP32]:
+            return sink
+
+        @pl.function(type=pl.FunctionType.AIV)
+        def vec_side(
+            self,
+            out: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+            task: pl.Scalar[pl.INDEX],
+        ) -> pl.Tensor[[16, 16], pl.FP32]:
+            return out
+
+        @pl.function(type=pl.FunctionType.Group)
+        def mixed(
+            self,
+            q: pl.Tensor[[16, 16], pl.FP32],
+            sink: pl.InOut[pl.Tensor[[16, 16], pl.FP32]],
+            out: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+            task: pl.Scalar[pl.INDEX],
+        ) -> pl.Tensor[[16, 16], pl.FP32]:
+            self.cube_side(q, sink, task)
+            result = self.vec_side(out, task)
+            return result
+
+    after = _run_pipeline(Program)
+    cube = after.get_function("cube_side")
+    vec = after.get_function("vec_side")
+    group = after.get_function("mixed")
+    expected_names = [param.name_hint for param in group.params]
+
+    assert [param.name_hint for param in cube.params] == expected_names
+    assert [param.name_hint for param in vec.params] == expected_names
+    assert cube.param_directions == group.param_directions
+    assert vec.param_directions == group.param_directions
+
+    member_calls = []
+    for stmt in ir.flatten_to_stmts(group.body):
+        if isinstance(stmt, ir.AssignStmt) and isinstance(stmt.value, ir.Call):
+            member_calls.append(stmt.value)
+        elif isinstance(stmt, ir.EvalStmt) and isinstance(stmt.expr, ir.Call):
+            member_calls.append(stmt.expr)
+    assert len(member_calls) == 2
+    for call in member_calls:
+        assert [arg.name_hint for arg in call.args] == expected_names
+
+
+def test_reused_hand_written_group_members_get_private_adapters():
+    """A member used outside its Group keeps its original ABI."""
+
+    @pl.program
+    class Program:
+        @pl.function(type=pl.FunctionType.AIC)
+        def cube_side(
+            self,
+            q: pl.Tensor[[16, 16], pl.FP32],
+            sink: pl.InOut[pl.Tensor[[16, 16], pl.FP32]],
+            task: pl.Scalar[pl.INDEX],
+        ) -> pl.Tensor[[16, 16], pl.FP32]:
+            return sink
+
+        @pl.function(type=pl.FunctionType.AIV)
+        def vec_side(
+            self,
+            out: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+            task: pl.Scalar[pl.INDEX],
+        ) -> pl.Tensor[[16, 16], pl.FP32]:
+            return out
+
+        @pl.function(type=pl.FunctionType.Group)
+        def mixed(
+            self,
+            q: pl.Tensor[[16, 16], pl.FP32],
+            sink: pl.InOut[pl.Tensor[[16, 16], pl.FP32]],
+            out: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+            task: pl.Scalar[pl.INDEX],
+        ) -> pl.Tensor[[16, 16], pl.FP32]:
+            self.cube_side(q, sink, task)
+            result = self.vec_side(out, task)
+            return result
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def main(
+            self,
+            q: pl.Tensor[[16, 16], pl.FP32],
+            sink: pl.InOut[pl.Tensor[[16, 16], pl.FP32]],
+            out: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+            task: pl.Scalar[pl.INDEX],
+        ) -> pl.Tensor[[16, 16], pl.FP32]:
+            sink = self.cube_side(q, sink, task)
+            return self.mixed(q, sink, out, task)
+
+    after = _run_pipeline(Program)
+    group = after.get_function("mixed")
+    aic_adapter = after.get_function("mixed_aic_adapter")
+    aiv_adapter = after.get_function("mixed_aiv_adapter")
+    canonical_names = [param.name_hint for param in group.params]
+
+    assert len(after.get_function("cube_side").params) == 3
+    assert len(after.get_function("vec_side").params) == 2
+    assert [param.name_hint for param in aic_adapter.params] == canonical_names
+    assert [param.name_hint for param in aiv_adapter.params] == canonical_names
+    group_text = group.as_python()
+    assert "mixed_aic_adapter(" in group_text
+    assert "mixed_aiv_adapter(" in group_text
+
+
 def test_explicit_sync_core_type_routes_each_event_to_one_lane():
     """Mixed JIT kernels must not duplicate set/wait onto both core types."""
 

--- a/tests/ut/ir/transforms/test_expand_mixed_kernel_a2a3.py
+++ b/tests/ut/ir/transforms/test_expand_mixed_kernel_a2a3.py
@@ -108,6 +108,9 @@ def test_hand_written_group_members_share_canonical_abi():
     cube = after.get_function("cube_side")
     vec = after.get_function("vec_side")
     group = after.get_function("mixed")
+    assert cube is not None
+    assert vec is not None
+    assert group is not None
     expected_names = [param.name_hint for param in group.params]
 
     assert [param.name_hint for param in cube.params] == expected_names
@@ -175,15 +178,74 @@ def test_reused_hand_written_group_members_get_private_adapters():
     group = after.get_function("mixed")
     aic_adapter = after.get_function("mixed_aic_adapter")
     aiv_adapter = after.get_function("mixed_aiv_adapter")
+    cube = after.get_function("cube_side")
+    vec = after.get_function("vec_side")
+    assert group is not None
+    assert aic_adapter is not None
+    assert aiv_adapter is not None
+    assert cube is not None
+    assert vec is not None
     canonical_names = [param.name_hint for param in group.params]
 
-    assert len(after.get_function("cube_side").params) == 3
-    assert len(after.get_function("vec_side").params) == 2
+    assert len(cube.params) == 3
+    assert len(vec.params) == 2
     assert [param.name_hint for param in aic_adapter.params] == canonical_names
     assert [param.name_hint for param in aiv_adapter.params] == canonical_names
     group_text = group.as_python()
     assert "mixed_aic_adapter(" in group_text
     assert "mixed_aiv_adapter(" in group_text
+
+
+def test_hand_written_group_submit_remaps_no_dep_override():
+    """A widened Submit keeps no_dep attached to the original member argument."""
+
+    @pl.program
+    class Program:
+        @pl.function(type=pl.FunctionType.AIC)
+        def cube_side(
+            self,
+            q: pl.Tensor[[16, 16], pl.FP32],
+            task: pl.Scalar[pl.INDEX],
+        ) -> pl.Tensor[[16, 16], pl.FP32]:
+            return q
+
+        @pl.function(type=pl.FunctionType.AIV)
+        def vec_side(
+            self,
+            out: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+            task: pl.Scalar[pl.INDEX],
+        ) -> pl.Tensor[[16, 16], pl.FP32]:
+            return out
+
+        @pl.function(type=pl.FunctionType.Group)
+        def mixed(
+            self,
+            q: pl.Tensor[[16, 16], pl.FP32],
+            out: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+            task: pl.Scalar[pl.INDEX],
+        ) -> pl.Tensor[[16, 16], pl.FP32]:
+            _cube_out, _cube_tid = pl.submit(self.cube_side, q, task)
+            vec_out, _vec_tid = pl.submit(
+                self.vec_side,
+                pl.no_dep(out),
+                task,
+                attrs={"arg_directions": [pl.adir.output_existing, pl.adir.scalar]},
+            )
+            return vec_out
+
+    after = _run_pipeline(Program)
+    group = after.get_function("mixed")
+    assert group is not None
+    submits = [
+        stmt.value
+        for stmt in ir.flatten_to_stmts(group.body)
+        if isinstance(stmt, ir.AssignStmt) and isinstance(stmt.value, ir.Submit)
+    ]
+    vec_submit = next(submit for submit in submits if submit.op.name == "vec_side")
+
+    assert list(vec_submit.args) == list(group.params)
+    assert vec_submit.attrs["arg_direction_overrides"] == [1]
+    assert list(vec_submit.arg_directions) == []
 
 
 def test_explicit_sync_core_type_routes_each_event_to_one_lane():


### PR DESCRIPTION
## Summary
- Normalize hand-written mixed Group AIC/AIV members to the shared runtime task-argument ABI.
- Preserve reused kernels through Group-private adapters and retarget peer-buffer references.
- Add pass and orchestration regressions and synchronize English/Chinese pass documentation.

## Testing
- CMake build
- 109 relevant unit and orchestration codegen tests
- clang-tidy, clang-format, Ruff, and git diff --check

Hardware system tests were not run in this environment.

Fixes #2097