### PR TITLE
fix(ir): forbid tile.move in-place reuse (root fix for #2100), revert #2100 workarounds

### DIFF
--- a/docs/en/dev/ir/05-operators.md
+++ b/docs/en/dev/ir/05-operators.md
@@ -457,6 +457,11 @@ destination's implicit view collapses to `nullopt` — the same per-space view
 [`InferTileMemorySpace`](../passes/17-infer_tile_memory_space.md) refreshes a
 retyped tile to.
 
+`tile.move` is not in-place safe: within one memory space, its source and result
+must resolve to distinct addresses. The PyPTO and DSA-RP planners enforce this
+constraint, and baked-address PTO codegen reports an error if an explicit
+MemRef binding or hand-built IR still presents a same-address move.
+
 ### Reshape and the valid region
 
 A reshape is a zero-copy view, so it cannot invent data: `tensor.reshape` and

--- a/docs/en/dev/passes/33-memory_reuse.md
+++ b/docs/en/dev/passes/33-memory_reuse.md
@@ -86,6 +86,7 @@ program_optimized = reuse_pass(program)
   | `tile.recip`, `tile.rsqrt` | `not_inplace_safe` | high-precision path reads the input **and** a tmp scratch while writing the output |
   | `tile.row_sum` / `row_max` / `row_min` | `not_inplace_safe` | `TROW*` reads the full input row + tmp scratch while writing the reduced `[M, 1]` output |
   | `tile.mrgsort_format1` | `not_inplace_safe` | merge-sort intrinsic requires `src != dst` |
+  | `tile.move` | `not_inplace_safe` | `TMOV` requires distinct source and destination addresses; baked-address PTO codegen rejects a remaining same-address move rather than silently treating it as a no-op |
   | `tile.fmod`, `tile.fmods` | `not_inplace_safe` | `TFMOD`/`TFMODS` compute `a - trunc(a/b)*b` by overwriting `dst = a/b` first, then re-reading the original `src0` (`a`) for the final subtraction; when `dst == src0` that subtraction sees the already-clobbered quotient and yields `0` for every element |
   | `tile.transpose` | `not_inplace_safe` | `pto.ttrans` is not in-place safe: the a2a3 unaligned scalar path writes `dst` directly from `src` (no tmp staging), so `dst == src` corrupts the data mid-write. The output always gets a fresh buffer (also enforced in InitMemRef, which never inherits the input's buffer for it). |
   | `tile.sel` | `forbid_output_alias(0)` (mask), `(3)` (tmp) | `TSEL` reads the predicate mask + tmp scratch while writing `dst` |

--- a/docs/en/dev/passes/34-allocate_memory_addr.md
+++ b/docs/en/dev/passes/34-allocate_memory_addr.md
@@ -82,8 +82,8 @@ post-alias allocation identity becomes one buffer with byte size, alignment,
 and a conservative half-open lifetime. The problem has:
 
 - **hard constraints** for lifetime interference, reserved ranges, semantic
-  no-alias rules, target hazards, incompatible Vec ND/NZ storage layouts, and
-  requested pipeline-stage separation. Author-declared `pl.MemRef` allocations
+  no-alias rules, target hazards, and requested pipeline-stage separation.
+  Author-declared `pl.MemRef` allocations
   are also hard-separated from every other allocation in their memory space.
   A multi-slot declaration is placed as one buffer covering its full declared
   extent, while each member retains its constant or runtime-selected slot offset;

--- a/docs/zh/dev/ir/05-operators.md
+++ b/docs/zh/dev/ir/05-operators.md
@@ -427,6 +427,10 @@ implicit view 一致时会折叠为 `nullopt` —— 这与
 [`InferTileMemorySpace`](../passes/17-infer_tile_memory_space.md) 为重新定型的 tile
 刷新的 per-space implicit view 是同一套。
 
+`tile.move` 不支持原地执行：在同一 memory space 内，源和结果必须解析到不同地址。
+PyPTO 与 DSA-RP 规划器会落实该约束；如果显式 MemRef 绑定或手工构造的 IR 仍留下
+同地址 move，baked-address PTO codegen 会直接报错。
+
 ### reshape 与有效区域（valid region）
 
 reshape 是零拷贝视图，无法凭空产生数据：`tensor.reshape` 与 `tile.reshape` 共用

--- a/docs/zh/dev/passes/33-memory_reuse.md
+++ b/docs/zh/dev/passes/33-memory_reuse.md
@@ -82,6 +82,7 @@ program_optimized = reuse_pass(program)
   | `tile.recip`、`tile.rsqrt` | `not_inplace_safe` | 高精度路径在写输出时读取输入**和** tmp scratch |
   | `tile.row_sum` / `row_max` / `row_min` | `not_inplace_safe` | `TROW*` 在写规约输出 `[M, 1]` 时读取整行输入 + tmp scratch |
   | `tile.mrgsort_format1` | `not_inplace_safe` | 归并排序 intrinsic 要求 `src != dst` |
+  | `tile.move` | `not_inplace_safe` | `TMOV` 要求源和目标地址不同；baked-address PTO codegen 会拒绝残留的同地址 move，而不是静默把它当成 no-op |
   | `tile.fmod`、`tile.fmods` | `not_inplace_safe` | `TFMOD`/`TFMODS` 按 `a - trunc(a/b)*b` 计算，先用 `dst = a/b` 覆盖输出，再重新读取原始 `src0`（`a`）做最后的减法；当 `dst == src0` 时该减法读到的是已被覆盖的商，导致每个元素都算成 `0` |
   | `tile.transpose` | `not_inplace_safe` | `pto.ttrans` 非 in-place 安全：a2a3 非对齐标量路径直接从 `src` 写 `dst`（不经 tmp 暂存），`dst == src` 会边写边读损坏数据。输出始终分配新 buffer（InitMemRef 也不会为其继承输入的 buffer）。 |
   | `tile.sel` | `forbid_output_alias(0)`（mask）、`(3)`（tmp） | `TSEL` 在写 `dst` 时读取 mask + tmp scratch |

--- a/docs/zh/dev/passes/34-allocate_memory_addr.md
+++ b/docs/zh/dev/passes/34-allocate_memory_addr.md
@@ -73,8 +73,8 @@ compile(program, memory_planner=passes.MemoryPlanner.DSA_RP)
 每个片上内存空间都是独立的固定容量 arena。强制别名物化后的每个分配身份成为一个
 buffer，带有字节大小、对齐和保守的半开生命周期。问题包含：
 
-- 生命周期干涉、预留范围、语义 no-alias、目标 hazard、不兼容的 Vec ND/NZ
-  存储布局和请求的流水线 stage 分离等**硬约束**；作者声明的 `pl.MemRef`
+- 生命周期干涉、预留范围、语义 no-alias、目标 hazard 和请求的流水线 stage
+  分离等**硬约束**；作者声明的 `pl.MemRef`
   分配还会与同一内存空间中的其他所有分配建立硬分离。多 slot 声明会作为覆盖完整
   声明范围的单个 buffer 放置，同时每个成员保留其常量或运行时选择的 slot 偏移；
 - 对生命周期兼容的物理复用，如果内置 recognizer 将其识别为跨 pipe WAR 或 WAW

--- a/include/pypto/ir/op_registry.h
+++ b/include/pypto/ir/op_registry.h
@@ -441,7 +441,8 @@ class OpRegistryEntry {
   }
 
   /// Mark this operation as NOT safe for in-place execution (src buffer == dst buffer).
-  /// MemoryReuse will skip producer-consumer reuse for such operations.
+  /// The shared allocation-constraint analysis prevents producer-consumer reuse
+  /// for such operations in both MemoryReuse and DSA-RP.
   inline OpRegistryEntry& not_inplace_safe() {
     is_inplace_safe_ = false;
     return *this;

--- a/include/pypto/ir/transforms/dsa/allocation_plan.h
+++ b/include/pypto/ir/transforms/dsa/allocation_plan.h
@@ -29,7 +29,6 @@ enum class AllocationSeparationReason : uint8_t {
   PipelineStage,
   TargetHazard,
   SemanticNoAlias,
-  StorageLayout,
   DeclaredAllocation,
 };
 

--- a/include/pypto/ir/transforms/utils/allocation_constraint_analysis.h
+++ b/include/pypto/ir/transforms/utils/allocation_constraint_analysis.h
@@ -38,7 +38,6 @@ using AllocationForbidAliasMap = std::map<const Var*, std::vector<VarPtr>>;
 struct AllocationConstraintAnalysis {
   std::map<const Var*, uint64_t> declared_allocation_sizes;
   std::set<const Var*> declared_allocation_bases;
-  std::map<const Var*, bool> vec_nz_layout_class;
   AllocationHazardInputs target_hazard_inputs;
   AllocationForbidAliasMap forbid_alias;
   bool needs_load_tpop_hazard_guard = false;

--- a/src/backend/common/pto_ops_elementwise.cpp
+++ b/src/backend/common/pto_ops_elementwise.cpp
@@ -33,9 +33,9 @@
 #include "pypto/core/logging.h"
 #include "pypto/ir/expr.h"
 #include "pypto/ir/kind_traits.h"
+#include "pypto/ir/memory_space.h"
 #include "pypto/ir/memref.h"
 #include "pypto/ir/scalar_expr.h"
-#include "pypto/ir/tile_view_semantics.h"
 #include "pypto/ir/type.h"
 #include "pypto/ir/type_inference.h"
 #include "src/backend/common/pto_ops_internal.h"
@@ -678,7 +678,7 @@ static const SimpleOpEntry kSimpleOps[] = {
     // tile.gemv_acc has custom codegen (in-place accumulation)
     // Data movement/layout operations
     {"tile.concat",          "pto.tconcat",          2},
-    // tile.move has custom codegen (no-op elision for same-space same-address moves)
+    // tile.move has custom codegen (PTOAS same-handle elision and baked-address validation)
     {"tile.move_fp",         "pto.tmov.fp",          2},
     // tile.transpose has custom codegen (MakeTileTransposeCodegenPTO): pto.ttrans needs
     // ins(%src, %tmp : tile_type, tile_type) where %tmp is a scratch workspace tile, NOT
@@ -769,26 +769,23 @@ void RegisterElementwiseOps(Backend& backend, const std::unordered_set<std::stri
     });
   }
 
-  // tile.move → pto.tmov with no-op elision.
-  // When MemoryReuse inserts a tile.move between two MemRefs that end up at the
-  // same physical address after AllocateMemoryAddr (e.g. acc→acc at the same Acc
-  // offset), the move is a no-op. Elide it to avoid emitting pto.tmov with
-  // unsupported same-space address pairs (fixes #1310).
+  // tile.move → pto.tmov.
   //
-  // Do NOT elide when TileView layouts, padding, or compact representations
-  // differ (e.g. A5 V→C ND→NZ adapt before tpush_to_aic). MemoryReuse may still
-  // co-locate the converted tile with its source at the same address; eliding
-  // then drops the real representation change and silently preserves the source
-  // format.
+  // tile.move is registered not_inplace_safe(), so the PyPTO and DSA-RP
+  // planners must assign distinct source and destination addresses. Validate
+  // that invariant here as well: explicit MemRef bindings and hand-built IR can
+  // bypass planner-created no-alias constraints, and TMOV does not support an
+  // in-place same-address instruction.
   reg("tile.move", [](const ir::CallPtr& op, codegen::CodegenBase& codegen_base) {
     auto& codegen = AsPto(codegen_base);
     CHECK(op->args_.size() == 1) << "tile.move requires 1 argument, got " << op->args_.size();
 
-    // Under memory_planner=PtoAS there is no baked address: AllocateMemoryAddr is
-    // skipped and every `byte_offset_` is still the -1 sentinel, so the offset
-    // comparison below would see `-1 == -1` and elide EVERY move — including the
-    // loop-carry write-back YieldFixupMutator inserts. There, two vars denote one
-    // buffer exactly when they collapsed onto the same tile_buf handle.
+    // Under memory_planner=PtoAS there is no baked address (AllocateMemoryAddr
+    // and the reuse-packer's not_inplace_safe gate are both skipped). A
+    // redundant loop-carry write-back that YieldFixupMutator inserts collapses
+    // onto a single tile_buf handle, and PTO codegen re-points the producer at
+    // the phi handle (#1956/#1985). Elide only that exact case — src and dst
+    // denote one handle — so we never emit an illegal same-handle pto.tmov.
     if (!codegen.EmitTileAddr()) {
       std::string src_ssa = codegen.GetExprAsCode(op->args_[0]);
       if (!src_ssa.empty() && src_ssa == codegen.GetCurrentResultTarget()) {
@@ -798,32 +795,25 @@ void RegisterElementwiseOps(Backend& backend, const std::unordered_set<std::stri
       return std::string("");
     }
 
-    auto src_var = AsVarLike(op->args_[0]);
-    auto dst_var = codegen.GetCurrentResultVar();
+    const auto src_var = AsVarLike(op->args_[0]);
+    const auto dst_var = codegen.GetCurrentResultVar();
     if (src_var && dst_var) {
-      auto src_tile = As<ir::TileType>(src_var->GetType());
-      auto dst_tile = As<ir::TileType>(dst_var->GetType());
+      const auto src_tile = As<ir::TileType>(src_var->GetType());
+      const auto dst_tile = As<ir::TileType>(dst_var->GetType());
       if (src_tile && dst_tile && src_tile->memref_.has_value() && dst_tile->memref_.has_value()) {
-        auto src_space = src_tile->GetMemorySpace();
-        auto dst_space = dst_tile->GetMemorySpace();
+        const auto src_space = src_tile->GetMemorySpace();
+        const auto dst_space = dst_tile->GetMemorySpace();
         if (src_space.has_value() && dst_space.has_value() && *src_space == *dst_space) {
-          auto src_offset = As<ir::ConstInt>((*src_tile->memref_)->byte_offset_);
-          auto dst_offset = As<ir::ConstInt>((*dst_tile->memref_)->byte_offset_);
-          if (src_offset && dst_offset && src_offset->value_ == dst_offset->value_) {
-            const auto src_view = ir::tile_view_semantics::GetEffectiveTileView(*src_tile);
-            const auto dst_view = ir::tile_view_semantics::GetEffectiveTileView(*dst_tile);
-            const bool same_representation =
-                src_view.blayout == dst_view.blayout && src_view.slayout == dst_view.slayout &&
-                src_view.fractal == dst_view.fractal && src_view.pad == dst_view.pad &&
-                src_view.compact == dst_view.compact;
-            if (same_representation) {
-              // Alias the destination to the source SSA value so downstream
-              // references use the source's defined buffer, not the destination's
-              // alloc_tile (which would be unwritten after eliding the tmov).
-              codegen.SetCurrentResultBuf(codegen.GetExprAsCode(op->args_[0]));
-              return std::string("");  // no-op: same space, same address, same layout
-            }
-            // Different layout at the same address: keep pto.tmov (ND↔NZ adapt).
+          const ir::MemRefPtr& src_memref = *src_tile->memref_;
+          const ir::MemRefPtr& dst_memref = *dst_tile->memref_;
+          if (src_memref && dst_memref && src_memref->byte_offset_ && dst_memref->byte_offset_ &&
+              ir::AreExprsEqual(src_memref->byte_offset_, dst_memref->byte_offset_)) {
+            const auto const_offset = As<ir::ConstInt>(src_memref->byte_offset_);
+            const std::string address = const_offset ? "byte offset " + std::to_string(const_offset->value_)
+                                                     : "the same symbolic byte offset";
+            CHECK_SPAN(false, op->span_)
+                << "tile.move requires distinct source and destination addresses in "
+                << ir::MemorySpaceToString(*src_space) << ", but both resolve to " << address;
           }
         }
       }

--- a/src/ir/op/tile_ops/memory.cpp
+++ b/src/ir/op/tile_ops/memory.cpp
@@ -1394,6 +1394,12 @@ REGISTER_OP("tile.move")
     .set_attr<MemorySpace>("target_memory")
     .set_attr<TileLayout>("blayout")
     .set_attr<TileLayout>("slayout")
+    // The TMOV intrinsic does not support src == dst (same-address move is not a
+    // legal instruction, only a no-op). Forbid MemoryReuse from landing the
+    // output on the input's buffer so a same-space layout-changing move (e.g.
+    // the A5 V->C ND->NZ fractal adapt) is never colocated with its source and
+    // then wrongly elided as a no-op.
+    .not_inplace_safe()
     .set_output_memory_from_kwarg("target_memory", MemorySpace::Vec)
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {

--- a/src/ir/op/tile_ops/memory.cpp
+++ b/src/ir/op/tile_ops/memory.cpp
@@ -1394,11 +1394,9 @@ REGISTER_OP("tile.move")
     .set_attr<MemorySpace>("target_memory")
     .set_attr<TileLayout>("blayout")
     .set_attr<TileLayout>("slayout")
-    // The TMOV intrinsic does not support src == dst (same-address move is not a
-    // legal instruction, only a no-op). Forbid MemoryReuse from landing the
-    // output on the input's buffer so a same-space layout-changing move (e.g.
-    // the A5 V->C ND->NZ fractal adapt) is never colocated with its source and
-    // then wrongly elided as a no-op.
+    // PTO TMOV requires distinct source and destination addresses. Keep memory
+    // planners from placing the result on any input buffer; baked-address PTO
+    // codegen also validates this invariant for explicit or hand-built aliases.
     .not_inplace_safe()
     .set_output_memory_from_kwarg("target_memory", MemorySpace::Vec)
     .f_deduce_type([](const std::vector<ExprPtr>& args,

--- a/src/ir/transforms/dsa/allocation_plan.cpp
+++ b/src/ir/transforms/dsa/allocation_plan.cpp
@@ -101,38 +101,6 @@ AllocationPlan BuildDsaAllocationPlan(const FunctionPtr& func) {
     }
   }
 
-  // Vec ND and NZ layouts cannot occupy the same bytes even when their
-  // ordinary lifetimes are disjoint. Enumerate only reusable cross-class pairs.
-  std::vector<size_t> vec_nd_intervals;
-  std::vector<size_t> vec_nz_intervals;
-  for (size_t index = 0; index < intervals.size(); ++index) {
-    const auto layout = constraints.vec_nz_layout_class.find(intervals[index].variable.get());
-    if (layout == constraints.vec_nz_layout_class.end()) continue;
-    (layout->second ? vec_nz_intervals : vec_nd_intervals).push_back(index);
-  }
-  auto add_disjoint_layout_pairs = [&intervals, &add_separation](std::vector<size_t> earlier,
-                                                                 std::vector<size_t> later) {
-    std::sort(earlier.begin(), earlier.end(), [&intervals](size_t lhs, size_t rhs) {
-      return std::pair{intervals[lhs].last_use_point, lhs} < std::pair{intervals[rhs].last_use_point, rhs};
-    });
-    std::sort(later.begin(), later.end(), [&intervals](size_t lhs, size_t rhs) {
-      return std::pair{intervals[lhs].def_point, lhs} < std::pair{intervals[rhs].def_point, rhs};
-    });
-
-    size_t eligible = 0;
-    for (size_t later_index : later) {
-      while (eligible < earlier.size() &&
-             intervals[earlier[eligible]].last_use_point <= intervals[later_index].def_point) {
-        ++eligible;
-      }
-      for (size_t prior = 0; prior < eligible; ++prior) {
-        add_separation(earlier[prior], later_index, AllocationSeparationReason::StorageLayout);
-      }
-    }
-  };
-  add_disjoint_layout_pairs(vec_nd_intervals, vec_nz_intervals);
-  add_disjoint_layout_pairs(vec_nz_intervals, vec_nd_intervals);
-
   // Preserve requested software-pipeline depth as hard separations first. The
   // DSA-RP driver alone may later relax this typed policy under capacity pressure.
   using GroupKey = std::pair<MemorySpace, int32_t>;

--- a/src/ir/transforms/dsa/reuse_penalty_recognizer.cpp
+++ b/src/ir/transforms/dsa/reuse_penalty_recognizer.cpp
@@ -33,7 +33,6 @@
 #include "pypto/ir/pipe.h"
 #include "pypto/ir/scalar_expr.h"
 #include "pypto/ir/stmt.h"
-#include "pypto/ir/tile_view_semantics.h"
 #include "pypto/ir/transforms/base/visitor.h"
 #include "pypto/ir/transforms/dsa/allocation_plan.h"
 #include "pypto/ir/transforms/utils/memref_utils.h"
@@ -130,26 +129,6 @@ bool SameAllocation(const VarPtr& first, const VarPtr& second) {
   const auto second_tile = second ? As<TileType>(second->GetType()) : nullptr;
   if (!first_tile || !second_tile || !first_tile->memref_ || !second_tile->memref_) return false;
   return GetDefinedMemRef(first_tile)->base_.get() == GetDefinedMemRef(second_tile)->base_.get();
-}
-
-bool SameAllocationOffset(const VarPtr& first, const VarPtr& second) {
-  const auto first_tile = first ? As<TileType>(first->GetType()) : nullptr;
-  const auto second_tile = second ? As<TileType>(second->GetType()) : nullptr;
-  if (!first_tile || !second_tile || !first_tile->memref_ || !second_tile->memref_) return false;
-  const MemRefPtr first_memref = GetDefinedMemRef(first_tile);
-  const MemRefPtr second_memref = GetDefinedMemRef(second_tile);
-  return first_memref->base_.get() == second_memref->base_.get() &&
-         AreExprsEqual(first_memref->byte_offset_, second_memref->byte_offset_);
-}
-
-bool HasSameEffectiveLayout(const VarPtr& first, const VarPtr& second) {
-  const auto first_tile = first ? As<TileType>(first->GetType()) : nullptr;
-  const auto second_tile = second ? As<TileType>(second->GetType()) : nullptr;
-  if (!first_tile || !second_tile) return false;
-  const TileView first_view = tile_view_semantics::GetEffectiveTileView(*first_tile);
-  const TileView second_view = tile_view_semantics::GetEffectiveTileView(*second_tile);
-  return first_view.blayout == second_view.blayout && first_view.slayout == second_view.slayout &&
-         first_view.fractal == second_view.fractal;
 }
 
 using TupleResultElements = std::unordered_map<const Var*, std::map<int, VarPtr>>;
@@ -303,21 +282,8 @@ class AccessCollector : public IRVisitor {
     return SameAllocation(target_var, result_var);
   }
 
-  static bool IsProvablyElidedTileMove(const CallPtr& call, const std::vector<VarPtr>& results) {
-    if (!IsOp(call, "tile.move") || call->args_.size() != 1 || results.size() != 1) return false;
-    const VarPtr source = AsVarLike(call->args_.front());
-    const VarPtr& destination = results.front();
-    return SameAllocationOffset(source, destination) && HasSameEffectiveLayout(source, destination);
-  }
-
   static ExecutionMemoryAccessEvidence ResolveAccessEvidence(const CallPtr& call,
                                                              const std::vector<VarPtr>& results) {
-    // Codegen aliases this result to its source and emits no pto.tmov. Treat
-    // only semantic same-allocation moves as no-access here: opportunistic
-    // address equality is a placement decision and cannot be assumed while
-    // recognizing candidate edges.
-    if (IsProvablyElidedTileMove(call, results)) return ExecutionMemoryAccessEvidence::NoAccess;
-
     const auto& registry = OpRegistry::GetInstance();
     if (!registry.IsRegistered(call->op_->name_)) return ExecutionMemoryAccessEvidence::Unknown;
 

--- a/src/ir/transforms/memory_reuse_pass.cpp
+++ b/src/ir/transforms/memory_reuse_pass.cpp
@@ -41,7 +41,6 @@
 #include "pypto/ir/op_registry.h"
 #include "pypto/ir/scalar_expr.h"
 #include "pypto/ir/stmt.h"
-#include "pypto/ir/tile_view_semantics.h"
 #include "pypto/ir/transforms/base/mutator.h"
 #include "pypto/ir/transforms/base/visitor.h"
 #include "pypto/ir/transforms/pass_context.h"
@@ -1428,36 +1427,12 @@ LifetimeAnalysisResult AnalyzeAllocationLifetimesImpl(const StmtPtr& func_body,
           std::move(pipeline_load_tiles)};
 }
 
-// NOTE: The former whole-tile reuse-compatibility gate (AreTileTypesCompatible:
-// shape + dtype + full TileView) was removed in #1788.  PTO codegen binds a
-// per-var alloc_tile, so tiles that share a MemRef may legally carry different
-// shapes/dtypes (each alloc_tile aliases the same base with its own static
-// signature).  In-place read/write hazards are handled by not_inplace_safe() and
-// forbid_output_alias() (see ForbidAliasCollector below).
-//
-// Vec ND↔NZ is still a hazard: A5 V→C inserts an ND→NZ ``tile.move`` (*_nz)
-// before tpush (NZ signal: effective blayout == col_major, matching
-// expand_mixed_kernel CreateMove).  If MemoryReuse colocates that NZ tile with
-// the ND cast result at one Vec address, even a kept ``pto.tmov`` is an
-// in-place layout adapt that silently mis-transfers (prefill_indexer Hadamard /
-// §3.0 family).  Gate *only* Vec ND↔NZ — allow Left/Right/Mat freely, and allow
-// same-family Vec layout quirks (e.g. fractal-only differences).  Keep
-// cross-shape / cross-dtype L0 reuse (#1595 / #1788).
-static bool IsNzLikeBlayout(TileLayout blayout) { return blayout == TileLayout::col_major; }
-
-static std::optional<bool> GetVecNzLayoutClass(const VarPtr& var) {
-  auto tile = As<TileType>(var->GetType());
-  if (!tile) return std::nullopt;
-  const auto space = tile->GetMemorySpace();
-  if (!space || *space != MemorySpace::Vec) return std::nullopt;
-  return IsNzLikeBlayout(tile_view_semantics::GetEffectiveTileView(*tile).blayout);
-}
-
-static bool AreVecNdNzCompatible(const VarPtr& var1, const VarPtr& var2) {
-  const auto class1 = GetVecNzLayoutClass(var1);
-  const auto class2 = GetVecNzLayoutClass(var2);
-  return !class1.has_value() || !class2.has_value() || class1 == class2;
-}
+// NOTE: The former tile-type reuse-compatibility gate (AreTileTypesCompatible)
+// has been removed. PTO codegen binds a per-var alloc_tile to each tile, so two
+// tiles that share a physical MemRef can legally carry different shapes, dtypes,
+// or TileView attributes. In-place read/write hazards are handled precisely by
+// not_inplace_safe() and per-operand forbid_output_alias() markers (see
+// ForbidAliasCollector below).
 
 /**
  * @brief Check if two lifetimes overlap.
@@ -2166,10 +2141,10 @@ std::map<VarPtr, VarPtr> IdentifyReuseOpportunities(
   // Can `cand` join a single physical buffer that already holds `member`?
   // Lifetimes must not overlap (touching is allowed: a buffer's reader is
   // consumed before the writer at the same statement produces its output), and
-  // neither directional gate may block.  Shape/dtype need not match: PTO binds a
-  // per-var alloc_tile so differing shapes/dtypes legally alias one base, and
-  // largest-first ordering guarantees the buffer is sized to its representative.
-  // On Vec only, ND and NZ must not share — see AreVecNdNzCompatible.
+  // neither directional gate may block. No tile-type / size check is needed:
+  // PTO binds a per-var alloc_tile so differing shapes/dtypes legally alias one
+  // base, and largest-first ordering guarantees the buffer is sized to its
+  // representative (no member is ever larger than the buffer it joins).
   auto can_share = [&](const LifetimeInterval& cand, const LifetimeInterval& member) {
     // Group-interval overlap is a fast reject; when it fires, fall back to the
     // precise per-var check so mutually-exclusive / same-value phi-family tiles
@@ -2179,7 +2154,6 @@ std::map<VarPtr, VarPtr> IdentifyReuseOpportunities(
     if (hazard_blocks(cand, member) || hazard_blocks(member, cand)) return false;
     if (forbid_blocks(cand, member) || forbid_blocks(member, cand)) return false;
     if (pipeline_blocks(cand, member)) return false;  // symmetric — one call suffices
-    if (!AreVecNdNzCompatible(cand.variable, member.variable)) return false;
     return true;
   };
 
@@ -3285,12 +3259,6 @@ AllocationConstraintAnalysis AnalyzeAllocationConstraints(const FunctionPtr& fun
     result.declared_allocation_bases.insert(base);
   }
   ValidateDeclaredAllocs(func->body_, result.declared_allocation_bases, lifetimes.var_liveness);
-
-  for (const LifetimeInterval& interval : lifetimes.lifetimes) {
-    if (const auto layout_class = GetVecNzLayoutClass(interval.variable)) {
-      result.vec_nz_layout_class.emplace(interval.variable.get(), *layout_class);
-    }
-  }
 
   result.needs_load_tpop_hazard_guard = NeedsLoadTpopHazardGuard(func);
   if (result.needs_load_tpop_hazard_guard) {

--- a/tests/ut/codegen/test_pto_codegen_ops.py
+++ b/tests/ut/codegen/test_pto_codegen_ops.py
@@ -22,7 +22,7 @@ import pypto
 import pypto.language as pl
 import pytest
 from _pto_loc_common import strip_loc
-from pypto import DataType, backend, codegen, ir
+from pypto import DataType, backend, codegen, ir, passes
 from pypto.backend import BackendType
 from pypto.ir.pass_manager import OptimizationStrategy, PassManager
 
@@ -2886,15 +2886,14 @@ class TestTileExtractCodegen:
         )
 
 
-class TestTileMoveAccNoopElision:
-    """Regression test for #1310: pto.tmov acc→acc must be elided.
+class TestTileMoveAccAddressInvariant:
+    """Regressions for #1310/#1352: lowering must not leave Acc→Acc moves.
 
     When AutoTileMatmulL0 rewrites matmul_acc into an inner K-loop, the fresh
     IterArg Vars carry different MemRef bases than the outer loop's accumulator.
-    MemoryReuse's YieldFixupMutator inserts tile.move(target_memory=Acc) for
-    these, but after AllocateMemoryAddr both sides share the same physical Acc
-    address. Codegen must elide the no-op pto.tmov to avoid the unsupported
-    acc→acc address-space pair on Ascend 910B.
+    The semantic-alias and MemoryReuse pipeline must keep the accumulator chain
+    on one buffer without leaving a redundant tile.move. Baked-address codegen
+    rejects any same-address move instead of masking an upstream mismatch.
     """
 
     def _generate_mlir(self, program_cls) -> str:
@@ -2941,9 +2940,8 @@ class TestTileMoveAccNoopElision:
 
         K=512 exceeds L0 capacity (256 for BF16), so AutoTileMatmulL0 rewrites
         each matmul into an inner K-loop with fresh IterArg Vars. MemoryReuse's
-        YieldFixupMutator may insert tile.move acc→acc when the inner loop's
-        yield MemRef has a different base_ pointer than the outer iter-arg init.
-        The codegen must elide this no-op move.
+        semantic-alias handling must align the inner yield with the outer
+        iter-arg so no redundant same-address tile.move reaches codegen.
         """
 
         @pl.program
@@ -3073,29 +3071,36 @@ class TestTileMoveAccNoopElision:
         )
 
 
-class TestTileMoveLayoutNoopElision:
-    """Same-addr tile.move must keep pto.tmov when layouts differ.
-
-    Complements #1310 (acc→acc same-layout elision): A5 V→C may co-locate an ND
-    cast result and an NZ ``*_nz`` adapt at one Vec address. Eliding that tmov
-    drops the fractal adapt and leaves TPUSH RowMajor vs AIC ColMajor.
-    Build IR with a shared MemRef so codegen sees same space+addr without relying
-    on MemoryReuse (which now gates layout coalescing).
-    """
+class TestTileMoveAddressValidation:
+    """Baked-address tile.move rejects in-place source/destination addresses."""
 
     @staticmethod
-    def _vec_tile_move_program(*, dst_view: ir.TileView | None, name: str) -> ir.Program:
+    def _vec_tile_move_program(
+        *,
+        dst_view: ir.TileView | None,
+        name: str,
+        dst_byte_offset: int = 0,
+        dst_space: ir.MemorySpace = ir.MemorySpace.Vec,
+        shared_base: bool = False,
+    ) -> ir.Program:
         span = ir.Span.unknown()
         size = 64
         nbytes = size * size * 2  # BF16
-        byte_offset_zero = ir.ConstInt(0, DataType.INT64, span)
-        shared = ir.MemRef(ir.MemorySpace.Vec, byte_offset_zero, nbytes, 0)
+        src_base = ir.Var(f"{name}_src_base", ir.PtrType(), span)
+        dst_base = src_base if shared_base else ir.Var(f"{name}_dst_base", ir.PtrType(), span)
+        src_memref = ir.MemRef(src_base, ir.ConstInt(0, DataType.INT64, span), nbytes, span)
+        dst_memref = ir.MemRef(
+            dst_base,
+            ir.ConstInt(dst_byte_offset, DataType.INT64, span),
+            nbytes,
+            span,
+        )
 
         inp = ir.Var("inp", ir.TensorType([size, size], DataType.BF16), span)
         out = ir.Var("out", ir.TensorType([size, size], DataType.BF16), span)
 
-        src_ty = ir.TileType([size, size], DataType.BF16, shared, None, ir.MemorySpace.Vec)
-        dst_ty = ir.TileType([size, size], DataType.BF16, shared, dst_view, ir.MemorySpace.Vec)
+        src_ty = ir.TileType([size, size], DataType.BF16, src_memref, None, ir.MemorySpace.Vec)
+        dst_ty = ir.TileType([size, size], DataType.BF16, dst_memref, dst_view, dst_space)
         src = ir.Var("src_nd", src_ty, span)
         dst = ir.Var("dst_layout", dst_ty, span)
         result = ir.Var("result", ir.TensorType([size, size], DataType.BF16), span)
@@ -3109,7 +3114,7 @@ class TestTileMoveLayoutNoopElision:
         move = ir.Call(
             ir.Op("tile.move"),
             [src],
-            {"target_memory": ir.MemorySpace.Vec},
+            {"target_memory": dst_space},
             dst_ty,
             span,
         )
@@ -3145,41 +3150,90 @@ class TestTileMoveLayoutNoopElision:
         backend.set_backend_type(BackendType.Ascend910B)
         return codegen.PTOCodegen().generate(program)
 
-    def test_same_addr_different_layout_emits_tmov(self):
-        """ND→NZ at one Vec address must still emit pto.tmov (not elide)."""
-        nz = ir.TileView(
-            blayout=ir.TileLayout.col_major,
-            slayout=ir.TileLayout.row_major,
-            fractal=1024,
-        )
-        mlir = self._generate_mlir(self._vec_tile_move_program(dst_view=nz, name="move_nd_to_nz_same_addr"))
-        tmovs = [ln for ln in mlir.splitlines() if "pto.tmov" in ln]
-        assert tmovs, f"same-addr ND→NZ tile.move must emit pto.tmov (layout adapt); got none in:\n{mlir}"
-        assert any("loc=vec" in ln for ln in tmovs), f"expected vec→vec tmov, got:\n{tmovs}"
+    @pytest.mark.parametrize(
+        ("dst_view", "name"),
+        [
+            pytest.param(None, "move_same_layout_same_addr", id="same-layout"),
+            pytest.param(
+                ir.TileView(
+                    blayout=ir.TileLayout.col_major,
+                    slayout=ir.TileLayout.row_major,
+                    fractal=1024,
+                ),
+                "move_nd_to_nz_same_addr",
+                id="different-layout",
+            ),
+            pytest.param(
+                ir.TileView(compact=ir.CompactMode.normal),
+                "move_noncompact_to_compact_same_addr",
+                id="different-compact",
+            ),
+            pytest.param(
+                ir.TileView(pad=ir.PadValue.max),
+                "move_unpadded_to_padded_same_addr",
+                id="different-pad",
+            ),
+        ],
+    )
+    def test_same_address_rejected(self, dst_view: ir.TileView | None, name: str):
+        """TMOV cannot use equal source and destination addresses."""
+        program = self._vec_tile_move_program(dst_view=dst_view, name=name)
+        with pytest.raises(ValueError, match="tile.move requires distinct source and destination addresses"):
+            self._generate_mlir(program)
 
-    def test_same_addr_same_layout_elides_tmov(self):
-        """Same space+addr+layout tile.move remains a no-op (elide pto.tmov)."""
-        mlir = self._generate_mlir(self._vec_tile_move_program(dst_view=None, name="move_nd_to_nd_same_addr"))
-        tmovs = [ln for ln in mlir.splitlines() if "pto.tmov" in ln]
-        assert not tmovs, f"same-addr same-layout tile.move must elide pto.tmov; got:\n{tmovs}\nfull:\n{mlir}"
-
-    def test_same_addr_different_compact_mode_emits_tmov(self):
-        """A compact representation change at one address is not a no-op."""
-        compact = ir.TileView(compact=ir.CompactMode.normal)
-        mlir = self._generate_mlir(
-            self._vec_tile_move_program(dst_view=compact, name="move_noncompact_to_compact_same_addr")
+    def test_same_base_distinct_addresses_emit_tmov(self):
+        """Different offsets in one allocation remain a functional move."""
+        program = self._vec_tile_move_program(
+            dst_view=None,
+            name="move_same_base_distinct_addresses",
+            dst_byte_offset=64 * 64 * 2,
+            shared_base=True,
         )
-        tmovs = [ln for ln in mlir.splitlines() if "pto.tmov" in ln]
-        assert tmovs, f"same-addr compact conversion must emit pto.tmov; got none in:\n{mlir}"
+        mlir = self._generate_mlir(program)
+        tmovs = [line for line in mlir.splitlines() if "pto.tmov" in line]
+        assert len(tmovs) == 1
+        assert "loc=vec" in tmovs[0]
 
-    def test_same_addr_different_pad_mode_emits_tmov(self):
-        """A pad-mode change at one address is not a no-op."""
-        padded = ir.TileView(pad=ir.PadValue.max)
-        mlir = self._generate_mlir(
-            self._vec_tile_move_program(dst_view=padded, name="move_unpadded_to_padded_same_addr")
+    def test_equal_numeric_addresses_in_different_spaces_emit_tmov(self):
+        """Equal offsets in independent memory spaces are not an in-place move."""
+        program = self._vec_tile_move_program(
+            dst_view=None,
+            name="move_vec_to_mat_at_zero",
+            dst_space=ir.MemorySpace.Mat,
         )
-        tmovs = [ln for ln in mlir.splitlines() if "pto.tmov" in ln]
-        assert tmovs, f"same-addr pad conversion must emit pto.tmov; got none in:\n{mlir}"
+        mlir = self._generate_mlir(program)
+        tmovs = [line for line in mlir.splitlines() if "pto.tmov" in line]
+        assert len(tmovs) == 1
+        assert "loc=vec" in tmovs[0]
+        assert "loc=mat" in tmovs[0]
+
+    @pytest.mark.parametrize("planner", [passes.MemoryPlanner.PYPTO, passes.MemoryPlanner.DSA_RP])
+    def test_declared_same_address_rejected_after_planning(self, planner, ascend_backend):
+        """A pinned allocation cannot bypass the baked-address invariant."""
+
+        @pl.program
+        class SameAddressMove:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                inp: pl.Tensor[[32, 128], pl.FP32],
+                out: pl.Out[pl.Tensor[[32, 128], pl.FP32]],
+            ) -> pl.Tensor[[32, 128], pl.FP32]:
+                src: pl.Tile[[32, 128], pl.FP32, pl.MemRef("shared"), pl.Mem.Vec] = pl.tile.load(
+                    inp, [0, 0], [32, 128]
+                )
+                dst: pl.Tile[[32, 128], pl.FP32, pl.MemRef("shared"), pl.Mem.Vec] = pl.tile.move(
+                    src, target_memory=pl.Mem.Vec
+                )
+                return pl.tile.store(dst, [0, 0], out)
+
+        with passes.PassContext([], memory_planner=planner):
+            optimized = PassManager.get_strategy(OptimizationStrategy.Default).run_passes(SameAddressMove)
+        function = next(func for func in optimized.functions.values() if ir.is_incore_type(func.func_type))
+        program = ir.Program([function], function.name, optimized.span)
+
+        with pytest.raises(ValueError, match="tile.move requires distinct source and destination addresses"):
+            self._generate_mlir(program)
 
 
 class TestTileStoreAtomicCodegen:

--- a/tests/ut/ir/transforms/test_dsa_reuse_penalty_recognizer.py
+++ b/tests/ut/ir/transforms/test_dsa_reuse_penalty_recognizer.py
@@ -168,6 +168,25 @@ def test_dsa_rp_preserves_not_inplace_safe_semantic_separation():
     assert not _overlap(ranges["source"], ranges["result"])
 
 
+def test_dsa_rp_preserves_tile_move_semantic_separation():
+    """tile.move source and destination remain physically disjoint."""
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.AIV)
+        def main(
+            self,
+            input_a: pl.Tensor[[32, 32], pl.FP32],
+            output: pl.Tensor[[32, 32], pl.FP32],
+        ) -> pl.Tensor[[32, 32], pl.FP32]:
+            source = pl.load(input_a, [0, 0], [32, 32])
+            moved = pl.tile.move(source, target_memory=pl.Mem.Vec)
+            return pl.store(moved, [0, 0], output)
+
+    ranges = _tile_ranges(_plan_with_dsa_rp(Before))
+    assert not _overlap(ranges["source"], ranges["moved"])
+
+
 def test_dsa_rp_preserves_tuple_result_not_inplace_safe_separation():
     """Every physical result of a tuple op inherits its semantic no-alias inputs."""
 
@@ -267,6 +286,76 @@ def test_dsa_rp_acc_to_acc_tile_move_uses_vector_resource(ascend_backend):
     assert frozenset(("_moved", "next_value")) in _recognized_pairs(Before)
     ranges = _tile_ranges(_plan_with_dsa_rp(Before))
     assert not _overlap(ranges["_moved"], ranges["next_value"])
+
+
+def test_dsa_rp_same_address_tile_move_remains_execution_access(ascend_backend):
+    """A same-address tile.move is functional, never NoAccess."""
+    span = ir.Span.unknown()
+    shared_base = ir.Var("shared", ir.PtrType(), span)
+    next_base = ir.Var("next", ir.PtrType(), span)
+    input_a_base = ir.Var("input_a_base", ir.PtrType(), span)
+    input_b_base = ir.Var("input_b_base", ir.PtrType(), span)
+
+    input_a = ir.Var(
+        "input_a",
+        ir.TensorType([32, 32], DataType.FP32, ir.MemRef(input_a_base, 0, 4096, span)),
+        span,
+    )
+    input_b = ir.Var(
+        "input_b",
+        ir.TensorType([32, 32], DataType.FP32, ir.MemRef(input_b_base, 0, 4096, span)),
+        span,
+    )
+    source_type = ir.TileType(
+        [32, 32],
+        DataType.FP32,
+        ir.MemRef(shared_base, 0, 4096, span),
+        None,
+        ir.MemorySpace.Vec,
+    )
+    moved_type = ir.TileType(
+        [32, 32],
+        DataType.FP32,
+        ir.MemRef(shared_base, 0, 4096, span),
+        None,
+        ir.MemorySpace.Vec,
+    )
+    next_type = ir.TileType(
+        [32, 32],
+        DataType.FP32,
+        ir.MemRef(next_base, 0, 4096, span),
+        None,
+        ir.MemorySpace.Vec,
+    )
+    source = ir.Var("source", source_type, span)
+    moved = ir.Var("moved", moved_type, span)
+    next_value = ir.Var("next_value", next_type, span)
+    body = ir.SeqStmts(
+        [
+            ir.AssignStmt(source, ir.Call(ir.Op("tile.load"), [input_a], source_type, span), span),
+            ir.AssignStmt(
+                moved,
+                ir.Call(
+                    ir.Op("tile.move"),
+                    [source],
+                    {"target_memory": ir.MemorySpace.Vec},
+                    moved_type,
+                    span,
+                ),
+                span,
+            ),
+            ir.AssignStmt(next_value, ir.Call(ir.Op("tile.load"), [input_b], next_type, span), span),
+            ir.ReturnStmt(span),
+        ],
+        span,
+    )
+    function = ir.Function("main", [input_a, input_b], [], body, span, type=ir.FunctionType.InCore)
+
+    edges = {
+        (edge["first_name"], edge["second_name"], edge["cost"])
+        for edge in testing.recognize_dsa_reuse_penalties(function)
+    }
+    assert edges == {("source", "next_value", 1)}
 
 
 def test_dsa_rp_same_base_different_offset_tile_move_is_not_elided():

--- a/tests/ut/ir/transforms/test_memory_reuse.py
+++ b/tests/ut/ir/transforms/test_memory_reuse.py
@@ -1361,12 +1361,10 @@ class TestInplaceOps:
     def test_move_output_must_not_alias_input(self):
         """tile.move's output must get a buffer distinct from its input.
 
-        The TMOV intrinsic cannot execute with src == dst (a same-address move
-        is not a legal instruction, only a no-op). If MemoryReuse colocated a
-        same-space layout-changing move (e.g. the A5 V->C ND->NZ fractal adapt)
-        with its source, codegen would see matching addresses and wrongly elide
-        the move as a no-op, dropping the layout adapt. tile.move is registered
-        ``.not_inplace_safe()`` to forbid that colocation.
+        The TMOV intrinsic cannot execute with src == dst. ``tile.move`` is
+        registered ``.not_inplace_safe()`` so MemoryReuse cannot colocate its
+        output with the input; baked-address codegen rejects any explicit alias
+        that bypasses memory planning.
         """
 
         @pl.program

--- a/tests/ut/ir/transforms/test_memory_reuse.py
+++ b/tests/ut/ir/transforms/test_memory_reuse.py
@@ -1358,6 +1358,39 @@ class TestInplaceOps:
         After = _run_pipeline(Before)
         ir.assert_structural_equal(After, Expected)
 
+    def test_move_output_must_not_alias_input(self):
+        """tile.move's output must get a buffer distinct from its input.
+
+        The TMOV intrinsic cannot execute with src == dst (a same-address move
+        is not a legal instruction, only a no-op). If MemoryReuse colocated a
+        same-space layout-changing move (e.g. the A5 V->C ND->NZ fractal adapt)
+        with its source, codegen would see matching addresses and wrongly elide
+        the move as a no-op, dropping the layout adapt. tile.move is registered
+        ``.not_inplace_safe()`` to forbid that colocation.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(
+                self,
+                input_a: pl.Tensor[[32, 32], pl.FP32],
+                output: pl.Out[pl.Tensor[[32, 32], pl.FP32]],
+            ) -> pl.Tensor[[32, 32], pl.FP32]:
+                tile_a: pl.Tile[[32, 32], pl.FP32, pl.MemorySpace.Vec] = pl.load(input_a, [0, 0], [32, 32])
+                tile_b: pl.Tile[[32, 32], pl.FP32, pl.MemorySpace.Vec] = pl.move(
+                    tile_a, target_memory=pl.MemorySpace.Vec
+                )
+                result: pl.Tensor[[32, 32], pl.FP32] = pl.store(tile_b, [0, 0], output)
+                return result
+
+        After = _run_pipeline(Before)
+        bases = _collect_tile_memref_bases(After)
+        assert bases["tile_b"] != bases["tile_a"], (
+            "move output must not reuse its input's buffer (tile.move is not in-place safe); "
+            f"both bound to {bases['tile_a']}"
+        )
+
     def test_inplace_unsafe_op_allows_non_producer_consumer_reuse(self):
         """tile.recip output must never share a buffer with its input.
 

--- a/tests/ut/ir/transforms/test_memory_reuse.py
+++ b/tests/ut/ir/transforms/test_memory_reuse.py
@@ -18,7 +18,7 @@ This aligns MemRef objects consistently: if two tiles share a MemRef in
 
 import pypto.language as pl
 import pytest
-from pypto import DataType, InternalError, backend, ir, passes
+from pypto import DataType, InternalError, backend, ir, passes, testing
 from pypto.backend import BackendType
 from pypto.ir.op import tile
 from pypto.ir.pass_manager import OptimizationStrategy, PassManager
@@ -3720,14 +3720,12 @@ class TestL0CrossShapeReuse:
         )
 
 
-class TestStorageLayoutReuseGate:
-    """Vec ND↔NZ tiles must not share a MemRef; other layout diffs may.
+class TestStorageLayoutReuse:
+    """Disjoint tiles may reuse storage across TileView representations.
 
-    A5 V→C inserts an ND→NZ ``*_nz`` adapt before tpush (NZ: col_major blayout).
-    Colocating that NZ tile with the ND source at one Vec address makes even a
-    kept ``pto.tmov`` an in-place layout rewrite that silently mis-transfers.
-    Gate only Vec ND↔NZ — same-family fractal quirks and non-Vec spaces stay
-    eligible for reuse (#1788).
+    The tile.move ``not_inplace_safe`` constraint precisely separates a move
+    from its source. Unrelated ND and NZ values therefore need no global layout
+    gate and remain eligible for ordinary lifetime-based reuse.
     """
 
     @staticmethod
@@ -3760,32 +3758,29 @@ class TestStorageLayoutReuseGate:
 
         return Before
 
-    def test_nd_and_nz_vec_tiles_do_not_reuse(self):
-        """Disjoint-lifetime ND and NZ Vec tiles of equal size keep separate buffers."""
+    def test_nd_and_nz_vec_tiles_can_reuse(self):
+        """Disjoint-lifetime ND and NZ Vec tiles of equal size share a buffer."""
 
         Before = self._build_nd_nz_program()
         After = _run_pipeline(Before)
         bases = _collect_tile_memref_bases(After)
         assert "tile_nd" in bases and "tile_nz" in bases, f"missing tiles in {bases}"
-        assert bases["tile_nd"] != bases["tile_nz"], (
-            f"ND and NZ Vec tiles must not share a MemRef; both bound to {bases['tile_nd']}"
+        assert bases["tile_nd"] == bases["tile_nz"], (
+            "unrelated ND and NZ Vec tiles should share a lifetime-compatible MemRef; "
+            f"got {bases['tile_nd']} vs {bases['tile_nz']}"
         )
 
-    def test_dsa_rp_nd_and_nz_vec_tiles_do_not_overlap(self):
-        """DSA-RP exports the ND/NZ restriction as an unrelaxable hard edge."""
+    def test_dsa_rp_nd_and_nz_vec_tiles_have_no_layout_separation(self, ascend_backend):
+        """DSA-RP does not add a hard edge solely for ND/NZ representations."""
 
         Before = self._build_nd_nz_program()
-        with passes.PassContext([], memory_planner=passes.MemoryPlanner.DSA_RP):
-            After = passes.allocate_memory_addr()(
-                passes.materialize_semantic_aliases()(passes.init_mem_ref()(Before))
-            )
-
-        ranges = _collect_allocated_tile_ranges(After)
-        nd_offset, nd_size = ranges["tile_nd"]
-        nz_offset, nz_size = ranges["tile_nz"]
-        assert nd_offset + nd_size <= nz_offset or nz_offset + nz_size <= nd_offset, (
-            f"DSA-RP must physically separate ND {ranges['tile_nd']} and NZ {ranges['tile_nz']} Vec tiles"
-        )
+        initialized = passes.init_mem_ref()(Before)
+        function = next(iter(initialized.functions.values()))
+        edges = {
+            (edge["first_name"], edge["second_name"], edge["cost"])
+            for edge in testing.recognize_dsa_reuse_penalties(function)
+        }
+        assert ("tile_nd", "tile_nz", 1) in edges
 
     def test_same_nz_family_different_fractal_vec_tiles_can_reuse(self):
         """Same NZ family (col_major) with fractal-only difference may coalesce."""


### PR DESCRIPTION
## Summary

Root-cause fix for the A5 V→C miscompile that #2100 worked around, plus removal of the now-redundant workarounds.

The `TMOV` intrinsic cannot execute with `src == dst` — a same-address move is not a legal instruction, only a no-op. `tile.move` was defaulting to in-place-safe, which let `MemoryReuse` colocate a same-space **layout-changing** move (the A5 V→C ND→NZ fractal adapt) with its source at one Vec address. Codegen then saw matching src/dst addresses and elided the `pto.tmov` as a no-op, silently dropping the layout adapt (RowMajor `TPUSH` vs ColMajor `TPOP`) → silent numerical FAIL.

Marking `tile.move` `.not_inplace_safe()` forbids that colocation at the op level, so `src` and `dst` always get distinct buffers. This removes the same-address precondition entirely, rather than tolerating it and special-casing the symptom downstream.

## Commits

1. **`revert(codegen/ir): drop #2100 layout-aware elide and Vec-only reuse gate`** — revert `a90f1584` (#2100): the codegen `same_layout` guard on `tile.move` elision and the `AreVecNdNzCompatible` Vec-only ND↔NZ reuse gate in `MemoryReuse`. Both are workarounds superseded by the root fix below.
2. **`fix(ir): forbid tile.move output from reusing its input buffer`** — mark `tile.move` `.not_inplace_safe()`; add a regression test asserting a same-space `tile.move` output gets a buffer distinct from its input.
3. **`refactor(codegen): drop same-address tmov elision for tile.move`** — with the move output never on its input buffer, the same-space same-address elision can never fire under baked addresses; remove that dead branch (and now-unused includes). `tile.move` always emits `pto.tmov` on the baked-address path.

## Why this supersedes #2100

- #2100 kept the illegal same-address colocation legal and (a) taught codegen to keep `pto.tmov` when `blayout`/`slayout`/`fractal` differ and (b) added a Vec-only ND↔NZ reuse gate. Both special-case the symptom.
- This PR eliminates the illegal colocation at its source, so neither special-case is needed — a same-address `tile.move` never reaches codegen.

## No collateral cost

Through the current Default pipeline, legitimate same-space same-layout no-op moves are not produced: loop-carry buffers are converged onto one base by `MaterializeSemanticAliases` / `AlignLoopCarriesToInit` via in-place retyping, not by inserting a move. Empirically, the same-address codegen elision is never hit by any `tests/ut/codegen` test even on `main` (0 hits across the suite). Cross-space moves (Mat→Left, etc.) live in different base-groups and are unaffected. The narrow `not_inplace_safe` flag does not touch the reuse packer's coalescing of unrelated lifetime-disjoint L0A tiles, so the split-K `Left` capacity path is unchanged.

**PtoAS path is preserved:** under `memory_planner=PtoAS` the reuse gate is skipped and a `YieldFixup` loop-carry write-back can still collapse onto one `tile_buf` handle, so the handle-based elision (`!EmitTileAddr()` branch) is intentionally kept to avoid emitting an illegal same-handle `pto.tmov`.

## Testing

- [x] `tests/ut/ir/transforms/test_memory_reuse.py` + `tests/ut/codegen/test_pto_codegen_ops.py` — 155 passed (incl. new test and the acc→acc regressions)
- [x] `tests/ut/ir/transforms/` + `tests/ut/codegen/` — 2850 passed (no reuse / L0 capacity regression)
- [x] clang-tidy clean; pre-commit (cpplint / clang-format / ruff / pyright) clean

## Related

Root-cause fix for the issue addressed by #2100; reverts #2100's workarounds.
