### PR TITLE
fix(ci): restore clang-tidy checks on main

### DIFF
--- a/src/ir/arith/canonical_simplify.cpp
+++ b/src/ir/arith/canonical_simplify.cpp
@@ -399,6 +399,8 @@ bool CanonicalSimplifier::Impl::TrySumFloorDiv(const SumExpr& sum, int64_t divis
   // Case 2: Single SplitExpr with base == 0.
   if (sum.args.size() == 1 && sum.base == 0) {
     const auto& split = sum.args[0];
+    INTERNAL_CHECK_SPAN(split.lower_factor > 0, split.index->span_)
+        << "Internal error: TrySumFloorDiv split lower factor must be positive, got " << split.lower_factor;
 
     // Sub-case 2a: scale is divisible by divisor.
     // e.g., (x * 4) // 2 = x * 2

--- a/src/ir/arith/canonical_simplify.cpp
+++ b/src/ir/arith/canonical_simplify.cpp
@@ -418,6 +418,8 @@ bool CanonicalSimplifier::Impl::TrySumFloorDiv(const SumExpr& sum, int64_t divis
       int64_t k = divisor / split.scale;
       if (MulWouldOverflow(split.lower_factor, k)) return false;
       int64_t new_lower = split.lower_factor * k;
+      INTERNAL_CHECK_SPAN(new_lower > 0, split.index->span_)
+          << "Internal error: TrySumFloorDiv computed non-positive lower factor " << new_lower;
       // Validity: new_lower must divide upper_factor (or upper == kPosInf)
       if (split.upper_factor != ConstIntBound::kPosInf && split.upper_factor % new_lower != 0) {
         return false;

--- a/tests/lint/clang_tidy.py
+++ b/tests/lint/clang_tidy.py
@@ -47,13 +47,12 @@ FULL_CHECK_PATHS = frozenset(
     {
         SELF_PATH,
         ".clang-tidy",
-        ".github/workflows/ci.yml",
         "3rdparty/libbacktrace",
         "3rdparty/msgpack-c",
         "runtime",
     }
 )
-FULL_CHECK_PREFIXES = ("cmake/",)
+FULL_CHECK_PREFIXES = (".github/workflows/", "cmake/")
 # Bound the *default* worker count: one clang-tidy process per core is wasteful on
 # a many-core dev box (each process holds a full TU in memory).  CI passes --jobs
 # explicitly and is not affected by this cap.

--- a/tests/lint/clang_tidy.py
+++ b/tests/lint/clang_tidy.py
@@ -43,6 +43,17 @@ SOURCE_EXTENSIONS = (".c", ".cc", ".cpp", ".cxx")
 HEADER_EXTENSIONS = (".h", ".hpp", ".hxx")
 DEFAULT_SOURCE_DIRS = ("src", "include")
 SELF_PATH = "tests/lint/clang_tidy.py"
+FULL_CHECK_PATHS = frozenset(
+    {
+        SELF_PATH,
+        ".clang-tidy",
+        ".github/workflows/ci.yml",
+        "3rdparty/libbacktrace",
+        "3rdparty/msgpack-c",
+        "runtime",
+    }
+)
+FULL_CHECK_PREFIXES = ("cmake/",)
 # Bound the *default* worker count: one clang-tidy process per core is wasteful on
 # a many-core dev box (each process holds a full TU in memory).  CI passes --jobs
 # explicitly and is not affected by this cap.
@@ -251,6 +262,17 @@ def _find_sources_including_headers(
     return dependent
 
 
+def _get_full_check_triggers(changed: set[str]) -> list[str]:
+    """Return changed lint/build infrastructure paths that require a full check."""
+    return sorted(
+        path
+        for path in changed
+        if path in FULL_CHECK_PATHS
+        or Path(path).name == "CMakeLists.txt"
+        or path.startswith(FULL_CHECK_PREFIXES)
+    )
+
+
 def _apply_diff_filter(
     files: list[str],
     headers: list[str],
@@ -265,9 +287,15 @@ def _apply_diff_filter(
         # git diff failed — lint everything
         return files, headers
 
-    # If this script itself changed, run a full check to validate the change.
-    if SELF_PATH in changed:
-        print("[clang-tidy] clang_tidy.py itself changed — running full check.")
+    # Diff filtering is safe only while the analysis configuration is unchanged.
+    # A runner/toolchain or CMake change can expose findings in any translation
+    # unit, so validate those changes with the same full-tree scan used on main.
+    full_check_triggers = _get_full_check_triggers(changed)
+    if full_check_triggers:
+        print(
+            "[clang-tidy] Lint/build infrastructure changed "
+            f"({', '.join(full_check_triggers)}) — running full check."
+        )
         return files, headers
 
     # Filter header files to only changed ones

--- a/tests/ut/ir/arith/test_canonical_simplify.py
+++ b/tests/ut/ir/arith/test_canonical_simplify.py
@@ -225,6 +225,17 @@ class TestFloorDiv:
         result = simplifier(ir.FloorDiv(inner, ci(3), INT, S))
         assert_same_expr(result, x)
 
+    def test_nested_div_with_scale_reassociation(self):
+        """((x // 2) * 3) // 6 => x // 4"""
+        inner = ir.FloorDiv(x, ci(2), INT, S)
+        scaled = ir.Mul(inner, ci(3), INT, S)
+        result = simplifier(ir.FloorDiv(scaled, ci(6), INT, S))
+
+        assert isinstance(result, ir.FloorDiv), f"Expected FloorDiv, got {type(result).__name__}"
+        assert result.left is x
+        assert isinstance(result.right, ir.ConstInt)
+        assert result.right.value == 4
+
     def test_const_fold_div(self):
         """12 // 4 => 3"""
         result = simplifier(ir.FloorDiv(ci(12), ci(4), INT, S))

--- a/tests/ut/tools/test_clang_tidy.py
+++ b/tests/ut/tools/test_clang_tidy.py
@@ -17,7 +17,7 @@ import pytest
 
 
 def _load_clang_tidy() -> ModuleType:
-    path = Path(__file__).parents[2] / "lint" / "clang_tidy.py"
+    path = Path(__file__).resolve().parents[2] / "lint" / "clang_tidy.py"
     spec = importlib.util.spec_from_file_location("pypto_clang_tidy", path)
     assert spec is not None
     assert spec.loader is not None
@@ -35,6 +35,7 @@ clang_tidy = _load_clang_tidy()
         "tests/lint/clang_tidy.py",
         ".clang-tidy",
         ".github/workflows/ci.yml",
+        ".github/workflows/daily_ci.yml",
         "CMakeLists.txt",
         "python/bindings/CMakeLists.txt",
         "cmake/libbacktrace.cmake",

--- a/tests/ut/tools/test_clang_tidy.py
+++ b/tests/ut/tools/test_clang_tidy.py
@@ -1,0 +1,55 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Tests for clang-tidy diff filtering."""
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+
+def _load_clang_tidy() -> ModuleType:
+    path = Path(__file__).parents[2] / "lint" / "clang_tidy.py"
+    spec = importlib.util.spec_from_file_location("pypto_clang_tidy", path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+clang_tidy = _load_clang_tidy()
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "tests/lint/clang_tidy.py",
+        ".clang-tidy",
+        ".github/workflows/ci.yml",
+        "CMakeLists.txt",
+        "python/bindings/CMakeLists.txt",
+        "cmake/libbacktrace.cmake",
+        "3rdparty/libbacktrace",
+        "3rdparty/msgpack-c",
+        "runtime",
+    ],
+)
+def test_lint_infrastructure_change_requires_full_check(path: str):
+    assert clang_tidy._get_full_check_triggers({path}) == [path]
+
+
+def test_source_change_does_not_require_full_check():
+    assert clang_tidy._get_full_check_triggers({"src/ir/arith/canonical_simplify.cpp"}) == []
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

- make the positive split-factor invariant explicit so clang-tidy can prove the modulo divisor is nonzero
- force a full clang-tidy scan when lint, workflow, CMake, runtime, or relevant third-party build inputs change
- add regression coverage for the arithmetic reassociation and full-scan trigger selection

## Root cause

The pull request that changed the self-hosted CI environment reported `[clang-tidy] No files to lint` because PR jobs filtered only directly changed source files. Main-branch pushes run a full scan, which then exposed a latent `clang-analyzer-core.DivideZero` finding in `TrySumFloorDiv`.

The local and remote clang-tidy binaries both report LLVM 21.1.0. Their surrounding environments differ, however, and the remote compiler/STL version is not logged.

## Validation

- `cmake --build build --parallel` — passed with no compiler warnings
- affected unit tests — 60 passed, including the new arithmetic and lint-tool regressions
- focused clang-tidy 21.1.0 check for `canonical_simplify.cpp` — passed
- pre-commit hooks for all changed files — passed
- full unit suite — 7,447 passed and 18 skipped; 20 runtime-only failures/errors remain because the local Simpler extension requires `GLIBCXX_3.4.30`, which the active conda `libstdc++.so.6` does not provide

## Remote CI

- clang-tidy full-tree scan — passed
- pre-commit, codegen, Linux/macOS unit tests, and all system-test variants — passed
- `pypto-lib-model` — fails because the external `pypto-lib` checkout does not contain `models/deepseek/v4/decode_attention_swa.py`; the same unrelated failure reproduced in two consecutive runs
