### PR TITLE
feat(distributed): Add pld.tensor.all_to_all_v (variable-size all-to-all)

### DIFF
--- a/docs/en/dev/distributed_ops.md
+++ b/docs/en/dev/distributed_ops.md
@@ -20,7 +20,7 @@ the `dst` side via `AsTensorTypeLike` — TGET only needs a writable local GM
 region to receive into, so kernels can TGET directly into host-backed output
 tensors; `src` still requires a window-bound `DistributedTensor`.
 
-There are **twelve ops** and **four ABI enums**:
+There are **thirteen ops** and **four ABI enums**:
 
 | Op | Direction | Result | Hardware |
 | -- | --------- | ------ | -------- |
@@ -34,6 +34,7 @@ There are **twelve ops** and **four ABI enums**:
 | `pld.tensor.reduce_scatter` | reduce and scatter chunks across ranks | `DistributedTensorType` (same as src) | builtin collective |
 | `pld.tensor.allgather` | gather data from all ranks via window | `DistributedTensorType` (same as src) | builtin collective |
 | `pld.tensor.all_to_all` | push-based symmetric personalized exchange — every rank pushes its per-destination chunks to every peer's window via `pld.tensor.put` (TPUT), returns window as result | `DistributedTensorType` (same as src) | composite / HOST builtin |
+| `pld.tensor.all_to_all_v` | variable-size all-to-all (MPI_Alltoallv) — pushes `min(send_counts[dest], MAX_RECV)` rows per destination into a flat 2D staging window, and publishes that clamped count into peer `recv_counts[my_rank, 0]` via `pld.system.notify` (Set) so the receiver can skip unwritten holes; returns window as result (same window-as-result pattern as symmetric `all_to_all`). Rows beyond a sender's count are not transferred, so those window rows keep their prior contents. InCore only — there is no HOST-orchestration lowering | `DistributedTensorType` (same as target) | composite InCore |
 | `pld.system.notify` | signal a peer's slot | `Unknown` (side effect) | TNOTIFY |
 | `pld.system.wait` | block on own slot | `Unknown` (side effect) | TWAIT |
 
@@ -273,6 +274,29 @@ region is in bounds (checked on static dims); any dynamic transfer dim requires
 a matching static chunk. Besides `chunk_rows` / `chunk_cols`, `get` accepts no
 keyword attributes.
 
+### `pld.tensor.all_to_all_v`
+
+```text
+pld.tensor.all_to_all_v(
+    input, target, signal, send_counts, recv_counts
+) -> DistributedTensorType(target)
+```
+
+InCore-only variable-size all-to-all (MPI_Alltoallv). Flat 2D layouts:
+
+- `input` — Tensor or DistributedTensor `[NR*MAX_RECV, SIZE]`
+- `target` — DistributedTensor `[NR*MAX_RECV, SIZE]` (window-as-result)
+- `signal` — DistributedTensor INT32 `[NR, 1]` (single-use Set(1)/wait≥1 barrier)
+- `send_counts` — Tensor-like INT32 `[NR]` or `[NR, 1]` (runtime rows per dest)
+- `recv_counts` — DistributedTensor INT32 `[NR, 1]` (InOut recvcounts)
+
+`MAX_RECV = target.shape[0] // NR`. Lowering reads `send_counts[dest]` at
+runtime, clamps to `MAX_RECV`, TPUTs that many rows into the peer window, and
+publishes the **clamped** count into peer `recv_counts[my_rank, 0]` via
+`pld.system.notify` (Set). After the barrier the receiver uses
+`recv_counts[src, 0]` to skip unwritten holes. Rows beyond the count are not
+transferred (window tails keep prior contents).
+
 ### `pld.tensor.allreduce`
 
 ```text
@@ -416,7 +440,8 @@ dispatches before the final `Simplify`.
   (each likewise dynamic-NR, P=2/P=4),
   `test_l3_tensor_allreduce_intrinsic.py`, `test_l3_tensor_allreduce_ring_intrinsic.py`,
   `test_l3_allreduce_ring.py` (hand-rolled ring RS+AG), `test_l3_host_tensor_allreduce.py`,
-  `test_l3_ep_dispatch_combine.py`, `test_l3_notify_wait.py`, and related L3 STs
+  `test_l3_ep_dispatch_combine.py`, `test_l3_notify_wait.py`,
+  `test_l3_tensor_all_to_all_v_intrinsic.py`, and related L3 STs
   under `tests/st/distributed/`. **Put/get canonical e2e contracts** are now
   enabled: `test_l3_put.py` (ring overwrite, row-offset put, atomic-add put, and
   chunked/pipelined transfers ✅), `test_l3_get.py` (ring read, row-offset get ✅),

--- a/docs/zh/dev/distributed_ops.md
+++ b/docs/zh/dev/distributed_ops.md
@@ -16,7 +16,7 @@ N6 分布式算子族为 Python DSL 提供了对硬件跨 rank（cross-rank）�
 区域来接收数据,因此 kernel 可以将 TGET 结果直接写入 host 输出 tensor；
 `src` 仍然必须是窗口绑定的 `DistributedTensor`。
 
-共有**十二个算子**和**四个 ABI 枚举**：
+共有**十三个算子**和**四个 ABI 枚举**：
 
 | 算子 | 方向 | 结果 | 硬件 |
 | ---- | ---- | ---- | ---- |
@@ -30,6 +30,7 @@ N6 分布式算子族为 Python DSL 提供了对硬件跨 rank（cross-rank）�
 | `pld.tensor.reduce_scatter` | 跨 rank 规约并分散 | `DistributedTensorType`（同 src） | builtin collective |
 | `pld.tensor.allgather` | 从所有 rank 收集数据到窗口 | `DistributedTensorType`（同 src） | builtin collective |
 | `pld.tensor.all_to_all` | 基于推送的对称个性化交换——每个 rank 通过 `pld.tensor.put`（TPUT）将自己的各目标 block 推送到每个对等方的窗口中，返回窗口作为结果 | `DistributedTensorType`（同 src） | composite / HOST builtin |
+| `pld.tensor.all_to_all_v` | 变长 all-to-all（MPI_Alltoallv）——按 `min(send_counts[dest], MAX_RECV)` 向每个目标推送对应行数，写入平面 2D 暂存窗口，同时通过 `pld.system.notify`（Set）把该钳制后的计数发布到对端 `recv_counts[my_rank, 0]`，使接收方能跳过未写入的空洞；返回窗口作为结果（与对称 `all_to_all` 相同的窗口即结果模式）。超出发送方计数的行不会传输，因此窗口中这些行保留原有内容。仅支持 InCore——没有 HOST 编排层的下降实现 | `DistributedTensorType`（与 target 相同） | composite InCore |
 | `pld.system.notify` | 给 peer 的槽位发信号 | `Unknown`（副作用） | TNOTIFY |
 | `pld.system.wait` | 在自身槽位上阻塞 | `Unknown`（副作用） | TWAIT |
 
@@ -238,6 +239,27 @@ full-slice `get` 要求 `dst` / `src` 形状一致；subregion `get` 允许完�
 不同,只要显式传输区域不越界（仅校验静态维）；任何动态传输维都需配套静态 chunk。
 除 `chunk_rows` / `chunk_cols` 外,`get` 不接受 keyword attributes。
 
+### `pld.tensor.all_to_all_v`
+
+```text
+pld.tensor.all_to_all_v(
+    input, target, signal, send_counts, recv_counts
+) -> DistributedTensorType(target)
+```
+
+仅 InCore 的变长 all-to-all（MPI_Alltoallv）。平面 2D 布局：
+
+- `input` — Tensor 或 DistributedTensor `[NR*MAX_RECV, SIZE]`
+- `target` — DistributedTensor `[NR*MAX_RECV, SIZE]`（窗口即结果）
+- `signal` — DistributedTensor INT32 `[NR, 1]`（单次使用的 Set(1)/wait≥1 屏障）
+- `send_counts` — Tensor-like INT32 `[NR]` 或 `[NR, 1]`（运行时每目标行数）
+- `recv_counts` — DistributedTensor INT32 `[NR, 1]`（InOut recvcounts）
+
+`MAX_RECV = target.shape[0] // NR`。降级在运行时读取 `send_counts[dest]`、钳制到
+`MAX_RECV`、按该行数 TPUT 到对端窗口，并把**钳制后**的计数通过
+`pld.system.notify`（Set）写入对端 `recv_counts[my_rank, 0]`。屏障之后接收方用
+`recv_counts[src, 0]` 跳过未写入的空洞。计数之外的行不传输（窗口尾部保留原有内容）。
+
 ### `pld.tensor.allreduce`
 
 ```text
@@ -364,7 +386,8 @@ host_orch 函数体包裹进嵌套的 `CommDomainScopeStmt` 节点（按推断�
   P=2/P=4）、`test_l3_tensor_allreduce_intrinsic.py`、
   `test_l3_tensor_allreduce_ring_intrinsic.py`、
   `test_l3_allreduce_ring.py`（手写 ring RS+AG）、
-  `test_l3_ep_dispatch_combine.py`、`test_l3_notify_wait.py`，以及
+  `test_l3_ep_dispatch_combine.py`、`test_l3_notify_wait.py`、
+  `test_l3_tensor_all_to_all_v_intrinsic.py`，以及
   `tests/st/distributed/` 下其他 L3 ST。**Put/Get 端到端权威契约** 已启用：
   `test_l3_put.py`（环形覆写、行偏移 put、原子加 put、分块/流水 transfer ✅）、
   `test_l3_get.py`（环形读、行偏移 get ✅）、以及 `test_l3_remote_store.py`

--- a/python/pypto/backend/pto_backend.py
+++ b/python/pypto/backend/pto_backend.py
@@ -235,6 +235,48 @@ _KERNEL_HEADER = """\
 #include "tensor.h"
 {spmd_override}
 
+#if defined(__CPU_SIM)
+// PTOAS v0.50+ emits cache_line_t::ENTIRE_DATA_CACHE / SINGLE_CACHE_LINE as
+// scoped identifiers, but the pto-isa cpu_stub.hpp defines them as bare macros
+// (#define ENTIRE_DATA_CACHE 0) — which breaks cache_line_t::ENTIRE_DATA_CACHE
+// into cache_line_t::0. Undefine the macros and provide proper namespace-scoped
+// constexpr constants. The same headers also #define dcci/dsb as macros that
+// would expand our own inlines, so undefine + redefine all of them here.
+#include <atomic>
+
+// Forward-declare the overloads so the undefs below don't break chained includes.
+namespace pypto_sim_detail {{
+    template <typename... Args>
+    static inline void sim_dcci(Args...);  // defined after the undefs
+    static inline void sim_dsb(int kind);  // ditto
+}}
+
+// Undefine conflicting macros from pto-isa cpu_stub.hpp / inner_kernel.h
+// so our namespace-scoped constants and inline functions are used instead.
+#undef ENTIRE_DATA_CACHE
+#undef SINGLE_CACHE_LINE
+#undef DSB_DDR
+#undef dcci
+#undef dsb
+#undef CACHELINE_OUT
+
+namespace cache_line_t {{
+    constexpr int ENTIRE_DATA_CACHE = 0;
+    constexpr int SINGLE_CACHE_LINE = 0;
+    constexpr int CACHELINE_OUT     = 0;
+}}
+typedef int mem_dsb_t;
+#define DSB_DDR 0
+
+static inline void dcci(...) {{
+    std::atomic_thread_fence(std::memory_order_seq_cst);
+}}
+static inline void dsb(mem_dsb_t) {{
+    std::atomic_thread_fence(std::memory_order_seq_cst);
+}}
+#endif  // __CPU_SIM
+
+
 using namespace pto;
 
 """

--- a/python/pypto/ir/op/distributed/tensor_ops.py
+++ b/python/pypto/ir/op/distributed/tensor_ops.py
@@ -379,8 +379,41 @@ def all_to_all(
     return _ir_core.create_op_call("pld.tensor.all_to_all", _args, {}, actual_span)
 
 
+def all_to_all_v(
+    input: Expr,
+    target: Expr,
+    signal: Expr,
+    send_counts: Expr,
+    recv_counts: Expr,
+    *,
+    span: Span | None = None,
+) -> Call:
+    """Build a ``pld.tensor.all_to_all_v(...)`` Call.
+
+    5-arg window-as-result intrinsic: 2D Tensor or DistributedTensor
+    [NR*MAX_RECV, SIZE] input, DistributedTensor [NR*MAX_RECV, SIZE] target
+    (staging window / result), INT32 barrier signal [NR, 1], INT32
+    ``send_counts`` [NR] / [NR, 1] holding the number of rows to send to each
+    destination, and window-bound INT32 ``recv_counts`` [NR, 1] that receives
+    per-source valid-row counts after the barrier (published via
+    ``pld.system.notify`` as ``min(send_counts[dest], MAX_RECV)``). Powered by
+    LowerCompositeOps into a 2-phase push-based decomposition (push → barrier),
+    returning the target window. The caller reads back from the window with
+    ``pl.load``, using ``recv_counts[src, 0]`` to skip unwritten holes.
+
+    ``send_counts`` is read at runtime, so the counts may be data-dependent;
+    each count is clamped to the per-peer capacity ``MAX_RECV =
+    target.shape[0] // NR``. The barrier signal is single-use and must not be
+    reused inside a ``for``/``while`` loop.
+    """
+    actual_span = _get_span_or_capture(span, frame_offset=1)
+    _args: list[Expr] = [input, target, signal, send_counts, recv_counts]
+    return _ir_core.create_op_call("pld.tensor.all_to_all_v", _args, {}, actual_span)
+
+
 __all__ = [
     "all_to_all",
+    "all_to_all_v",
     "alloc_window_buffer",
     "allgather",
     "allreduce",

--- a/python/pypto/language/distributed/op/tensor_ops.py
+++ b/python/pypto/language/distributed/op/tensor_ops.py
@@ -810,8 +810,84 @@ def all_to_all(
     return DistributedTensor(expr=call)
 
 
+def all_to_all_v(
+    input: Tensor | DistributedTensor,
+    target: DistributedTensor,
+    signal: DistributedTensor,
+    send_counts: Tensor | DistributedTensor,
+    recv_counts: DistributedTensor,
+) -> DistributedTensor:
+    """All-to-all: variable-size personalized exchange (push-based, window-as-result).
+
+    5-arg form: ``pld.tensor.all_to_all_v(input, target, signal, send_counts,
+    recv_counts)``.
+
+    Each rank sends ``send_counts[dest]`` rows to peer ``dest`` — the counts are
+    read at runtime, so they may be data-dependent (e.g. MoE tokens per expert),
+    and only those rows cross the interconnect.  Mirrors the symmetric
+    ``pld.tensor.all_to_all`` otherwise: rows are pushed into a flat 2D staging
+    window via ``pld.tile.put``, and the window is returned so the caller can
+    read back via ``pl.load``.  There is no built-in read-back phase — the user
+    writes the read-back loop in the InCore function.
+
+    ``input`` is a flat 2D [NR*MAX_RECV, SIZE] Tensor or DistributedTensor whose
+    rows ``dest*MAX_RECV .. dest*MAX_RECV + send_counts[dest] - 1`` hold the
+    chunk for peer ``dest``.  ``target`` is a flat 2D DistributedTensor
+    [NR*MAX_RECV, SIZE] — the staging window that doubles as the result;
+    rank ``src``'s rows land at ``src*MAX_RECV ...``.
+
+    ``MAX_RECV = target.shape[0] // NR`` is the compile-time per-peer
+    *capacity*, not the transfer size: it fixes the row-index arithmetic so a
+    receiver can locate each sender's block without knowing that sender's
+    count.  Counts are clamped to ``MAX_RECV``.  Rows beyond a sender's count
+    are never written, so those window rows keep their prior contents — as with
+    ``MPI_Alltoallv``, the untouched tail of the receive buffer is not zeroed.
+    Zero it yourself if the read-back path relies on it.
+
+    During the same push, each rank also publishes
+    ``min(send_counts[dest], MAX_RECV)`` into peer ``dest``'s
+    ``recv_counts[my_rank, 0]`` via ``pld.system.notify`` (Set). After the
+    barrier, ``recv_counts[src, 0]`` tells this rank how many valid rows ``src``
+    wrote — use that count to skip the unwritten holes. This is the
+    MPI_Alltoallv recvcounts side (published value equals rows actually
+    transferred).
+
+    The barrier ``signal`` is single-use (same Set(1)/wait≥1 protocol as
+    allreduce) and must not be reused inside a ``for``/``while`` loop.
+
+    Args:
+        input: Flat 2D Tensor or DistributedTensor [NR*MAX_RECV, SIZE] with
+            per-destination chunks (e.g. a window published by a preceding
+            exchange).
+        target: :class:`pld.DistributedTensor` [NR*MAX_RECV, SIZE] —
+            flat 2D staging window (InOut); returned as the result.
+        signal: :class:`pld.DistributedTensor` [NR, 1] INT32 barrier (InOut).
+        send_counts: INT32 [NR] or [NR, 1] rows-per-destination counts (Input).
+            A plain :class:`pl.Tensor` or a window-bound
+            :class:`pld.DistributedTensor` (e.g. counts published by a
+            preceding exchange).
+        recv_counts: :class:`pld.DistributedTensor` INT32 [NR, 1] — after the
+            call, ``recv_counts[src, 0]`` holds how many rows ``src`` actually
+            sent here (clamped to ``MAX_RECV``) (InOut).
+
+    Returns:
+        The ``target`` :class:`pld.DistributedTensor` with received chunks.
+    """
+    target_expr, signal_expr, recv_expr = _unwrap_distributed_tensors(
+        "pld.tensor.all_to_all_v",
+        target=target,
+        signal=signal,
+        recv_counts=recv_counts,
+    )
+    input_expr = _unwrap(input)
+    counts_expr = _unwrap(send_counts)
+    call = _ir_tensor.all_to_all_v(input_expr, target_expr, signal_expr, counts_expr, recv_expr)
+    return DistributedTensor(expr=call)
+
+
 __all__ = [
     "all_to_all",
+    "all_to_all_v",
     "alloc_window_buffer",
     "allgather",
     "allreduce",

--- a/src/ir/op/distributed/collective.cpp
+++ b/src/ir/op/distributed/collective.cpp
@@ -25,6 +25,7 @@
  *   - pld.tensor.allgather(local_data, target, signal) (unified 3-arg)  -> DistributedTensorType
  *   - pld.tensor.reduce_scatter(target, signal, op)                -> DistributedTensorType
  *   - pld.tensor.all_to_all(input, target, signal)                 -> DistributedTensorType
+ *   - pld.tensor.all_to_all_v(input, target, signal, send_counts, recv_counts)  -> DistributedTensorType
  *
  * The six builtin.tensor.* ops are internal chip-dispatch targets emitted by the
  * host-orchestrator lowering pass (LowerHostTensorCollectives):
@@ -439,6 +440,171 @@ REGISTER_OP("pld.tensor.all_to_all")
     .add_argument("signal", "Window-bound INT32 DistributedTensor used as cross-rank barrier (InOut)")
     .no_memory_spec()
     .f_deduce_type(DeduceTensorAllToAllType);
+
+// ============================================================================
+// pld.tensor.all_to_all_v — variable-size all-to-all (5-arg InCore composite)
+// ============================================================================
+
+namespace {
+
+TypePtr DeduceTensorAllToAllVType(const std::vector<ExprPtr>& args,
+                                  const std::vector<std::pair<std::string, std::any>>& kwargs) {
+  (void)kwargs;
+  CHECK(args.size() == 5) << "pld.tensor.all_to_all_v requires 5 args "
+                             "(input, target, signal, send_counts, recv_counts), but got "
+                          << args.size();
+  for (size_t i = 0; i < args.size(); ++i) {
+    CHECK(args[i]) << "pld.tensor.all_to_all_v positional argument #" << i << " must not be null";
+  }
+
+  // input: flattened send buffer [NR*MAX_RECV, SIZE] — Tensor or DistributedTensor
+  // (same Tensor-like contract as symmetric all_to_all / send_counts).
+  auto input_type = AsTensorTypeLike(args[0]->GetType());
+  CHECK(input_type) << "pld.tensor.all_to_all_v input must be a Tensor or DistributedTensor, got "
+                    << args[0]->GetType()->TypeName();
+  CHECK(input_type->shape_.size() == 2)
+      << "pld.tensor.all_to_all_v input must be 2D [NR*MAX_RECV, SIZE], got " << input_type->shape_.size()
+      << " dims";
+
+  // target: DistributedTensor [NR*MAX_RECV, SIZE] — flat 2D for pld.tile.put compatibility
+  auto target_type = As<DistributedTensorType>(args[1]->GetType());
+  CHECK(target_type) << "pld.tensor.all_to_all_v target must be a DistributedTensor (window-bound), got "
+                     << args[1]->GetType()->TypeName();
+  CHECK(target_type->shape_.size() == 2)
+      << "pld.tensor.all_to_all_v target must be 2D [NR*MAX_RECV, SIZE], got " << target_type->shape_.size()
+      << " dims";
+  // Dim 0 (NR*MAX_RECV): must agree when both are static; dim 1 (SIZE) is a
+  // literal, so use a strict structural check (same pattern as symmetric all_to_all).
+  CheckDimAgreesIfStatic(target_type->shape_[0], input_type->shape_[0], "pld.tensor.all_to_all_v", "target",
+                         "input");
+  CHECK(AreExprsEqual(target_type->shape_[1], input_type->shape_[1]))
+      << "pld.tensor.all_to_all_v target SIZE must equal input SIZE";
+  CHECK(target_type->dtype_ == input_type->dtype_)
+      << "pld.tensor.all_to_all_v target dtype " << target_type->dtype_.ToString()
+      << " must match input dtype " << input_type->dtype_.ToString();
+
+  // signal: DistributedTensor INT32 [NR, 1].  Restricted to the 2-D form because
+  // the composite lowering always emits MakeSignalOffsets(rank) → [rank, 0];
+  // pld.system.notify/wait reject a rank mismatch against a 1-D signal.
+  auto signal_type = As<DistributedTensorType>(args[2]->GetType());
+  CHECK(signal_type) << "pld.tensor.all_to_all_v signal must be a DistributedTensor (window-bound), got "
+                     << args[2]->GetType()->TypeName();
+  CHECK(signal_type->dtype_ == DataType::INT32)
+      << "pld.tensor.all_to_all_v signal must have INT32 element type, got dtype "
+      << signal_type->dtype_.ToString();
+  CHECK(signal_type->shape_.size() == 2)
+      << "pld.tensor.all_to_all_v signal must be 2D [NR, 1], got " << signal_type->shape_.size() << " dims";
+  {
+    auto signal_dim1 = As<ConstInt>(signal_type->shape_[1]);
+    CHECK(signal_dim1 && signal_dim1->value_ == 1)
+        << "pld.tensor.all_to_all_v signal second dimension must be 1, got "
+        << (signal_dim1 ? std::to_string(signal_dim1->value_) : "<dynamic>");
+  }
+
+  // MAX_RECV = target[0] / signal[0] (deducer-enforced compile-time
+  // constants; both dims must be static).
+  auto target_dim0 = As<ConstInt>(target_type->shape_[0]);
+  CHECK(target_dim0) << "pld.tensor.all_to_all_v target dim 0 (NR*MAX_RECV) must be a compile-time constant";
+  auto signal_dim0 = As<ConstInt>(signal_type->shape_[0]);
+  CHECK(signal_dim0) << "pld.tensor.all_to_all_v signal dim 0 (NR) must be a compile-time constant";
+  CHECK(signal_dim0->value_ > 0) << "pld.tensor.all_to_all_v signal dim 0 (NR) must be positive, got "
+                                 << signal_dim0->value_;
+  CHECK(target_dim0->value_ % signal_dim0->value_ == 0)
+      << "pld.tensor.all_to_all_v signal dim 0 (" << signal_dim0->value_ << ") must divide target dim 0 ("
+      << target_dim0->value_ << ")";
+
+  // send_counts: per-destination row counts, read at runtime by the lowering
+  // (``tensor.read``) to bound each destination's push loop — this is what
+  // makes the exchange genuinely variable-size rather than a padded transfer
+  // of the full MAX_RECV capacity.  Tensor-like so counts that live in a
+  // window (e.g. published by a preceding exchange) are accepted too.
+  auto counts_type = AsTensorTypeLike(args[3]->GetType());
+  CHECK(counts_type) << "pld.tensor.all_to_all_v send_counts must be a Tensor or DistributedTensor, got "
+                     << args[3]->GetType()->TypeName();
+  CHECK(counts_type->dtype_ == DataType::INT32)
+      << "pld.tensor.all_to_all_v send_counts must have INT32 element type, got dtype "
+      << counts_type->dtype_.ToString();
+  CHECK(counts_type->shape_.size() == 1 || counts_type->shape_.size() == 2)
+      << "pld.tensor.all_to_all_v send_counts must be 1D [NR] or 2D [NR, 1], got "
+      << counts_type->shape_.size() << " dims";
+  if (counts_type->shape_.size() == 2) {
+    auto counts_dim1 = As<ConstInt>(counts_type->shape_[1]);
+    CHECK(counts_dim1 && counts_dim1->value_ == 1)
+        << "pld.tensor.all_to_all_v send_counts second dimension must be 1, got "
+        << (counts_dim1 ? std::to_string(counts_dim1->value_) : "<dynamic>");
+  }
+  auto counts_dim0 = As<ConstInt>(counts_type->shape_[0]);
+  CHECK(counts_dim0) << "pld.tensor.all_to_all_v send_counts dim 0 (NR) must be a compile-time constant";
+  CHECK(counts_dim0->value_ == signal_dim0->value_)
+      << "pld.tensor.all_to_all_v send_counts dim 0 (" << counts_dim0->value_
+      << ") must equal signal dim 0 (NR = " << signal_dim0->value_ << ")";
+
+  // recv_counts: window where each peer publishes how many rows it sent to me
+  // (MPI_Alltoallv recvcounts).  Same 2D [NR, 1] INT32 layout as ``signal`` —
+  // published via ``pld.system.notify`` (Set) as ``min(send_counts[dest],
+  // MAX_RECV)`` into ``recv_counts[my_rank, 0]``.  After the barrier the
+  // receiver reads ``recv_counts[src, 0]`` to skip the unwritten holes at the
+  // tail of each source's MAX_RECV slot.
+  auto recv_type = As<DistributedTensorType>(args[4]->GetType());
+  CHECK(recv_type) << "pld.tensor.all_to_all_v recv_counts must be a DistributedTensor (window-bound), got "
+                   << args[4]->GetType()->TypeName();
+  CHECK(recv_type->dtype_ == DataType::INT32)
+      << "pld.tensor.all_to_all_v recv_counts must have INT32 element type, got dtype "
+      << recv_type->dtype_.ToString();
+  CHECK(recv_type->shape_.size() == 2) << "pld.tensor.all_to_all_v recv_counts must be 2D [NR, 1], got "
+                                       << recv_type->shape_.size() << " dims";
+  {
+    auto recv_dim1 = As<ConstInt>(recv_type->shape_[1]);
+    CHECK(recv_dim1 && recv_dim1->value_ == 1)
+        << "pld.tensor.all_to_all_v recv_counts second dimension must be 1, got "
+        << (recv_dim1 ? std::to_string(recv_dim1->value_) : "<dynamic>");
+  }
+  auto recv_dim0 = As<ConstInt>(recv_type->shape_[0]);
+  CHECK(recv_dim0) << "pld.tensor.all_to_all_v recv_counts dim 0 (NR) must be a compile-time constant";
+  CHECK(recv_dim0->value_ == signal_dim0->value_)
+      << "pld.tensor.all_to_all_v recv_counts dim 0 (" << recv_dim0->value_
+      << ") must equal signal dim 0 (NR = " << signal_dim0->value_ << ")";
+
+  // Window-as-result: return target
+  return target_type;
+}
+
+}  // namespace
+
+REGISTER_OP("pld.tensor.all_to_all_v")
+    .set_description(
+        "All-to-all: variable-size personalized exchange (push-based, "
+        "window-as-result).  Each rank pushes ``send_counts[dest]`` rows — a "
+        "runtime, data-dependent count — to each peer via ``pld.tile.put``, "
+        "into a 2D staging window [NR*MAX_RECV, SIZE] addressed with flat "
+        "row-index arithmetic ``dest*MAX_RECV+r``.  MAX_RECV is the "
+        "compile-time per-peer capacity; counts above it are clamped.  Rows "
+        "beyond a sender's count are not transferred, so the corresponding "
+        "receive-window rows keep their prior contents (MPI_Alltoallv "
+        "semantics).  During the same push phase each rank also publishes "
+        "``min(send_counts[dest], MAX_RECV)`` into peer ``dest``'s "
+        "``recv_counts[my_rank, 0]`` via ``pld.system.notify`` (Set) — the "
+        "receive-side count vector (MPI_Alltoallv recvcounts; equal to rows "
+        "actually written) so the receiver can skip unwritten holes. "
+        "Returns the target window so the caller can read back via "
+        "``tile.load`` — same pattern as the symmetric "
+        "``pld.tensor.all_to_all`` intrinsic.")
+    .set_op_category("DistributedOp")
+    .add_argument("input",
+                  "Tensor or DistributedTensor [NR*MAX_RECV, SIZE] with per-destination chunks (Input)")
+    .add_argument("target",
+                  "Window-bound DistributedTensor [NR*MAX_RECV, SIZE] — staging area for exchange (InOut)")
+    .add_argument("signal",
+                  "Window-bound INT32 DistributedTensor [NR, 1] used as a single-use cross-rank "
+                  "barrier (InOut); not reusable inside for/while loops")
+    .add_argument("send_counts",
+                  "INT32 Tensor [NR] or [NR, 1] — rows to send to each destination, read at "
+                  "runtime and clamped to MAX_RECV (Input)")
+    .add_argument("recv_counts",
+                  "Window-bound INT32 DistributedTensor [NR, 1] — after the barrier, "
+                  "recv_counts[src, 0] holds how many rows src sent to this rank (InOut)")
+    .no_memory_spec()
+    .f_deduce_type(DeduceTensorAllToAllVType);
 
 // ============================================================================
 // pld.tensor.reduce_scatter — reduce + scatter chunks across ranks

--- a/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
+++ b/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
@@ -913,6 +913,18 @@ ExprPtr GetWriteTargetExpr(const CallPtr& call) {
   if (IsOp(call, "pld.tensor.broadcast") && !call->args_.empty()) {
     return call->args_[0];
   }
+  // pld.tensor.all_to_all(input, target, signal): 3-arg push-based
+  // window-as-result.  target (args_[1]) receives peers' writes via TPUT.
+  if (IsOp(call, "pld.tensor.all_to_all") && call->args_.size() >= 2) {
+    return call->args_[1];
+  }
+  // pld.tensor.all_to_all_v(input, target, signal, send_counts, recv_counts):
+  // 5-arg variable-size push-based window-as-result.  target (args_[1]) receives
+  // peers' writes; recv_counts (args_[4]) receives per-source valid-row counts;
+  // send_counts is read-only.
+  if (IsOp(call, "pld.tensor.all_to_all_v") && call->args_.size() >= 2) {
+    return call->args_[1];
+  }
   return nullptr;
 }
 
@@ -1112,6 +1124,24 @@ void AnalyzeCallAccess(const CallPtr& call, const AliasOriginMap& origin_map, st
       auto origins = CollectReferencedOrigins(call->args_[i], origin_map);
       MarkAccess(origins, has_read);
       MarkAccess(origins, has_write);
+    }
+    return;
+  }
+
+  if (IsOp(call, "pld.tensor.all_to_all") || IsOp(call, "pld.tensor.all_to_all_v")) {
+    // Push-based window-as-result: input (arg[0]) is read-only (Tensor or
+    // DistributedTensor); target (arg[1]) receives peer writes via TPUT and
+    // is returned in-place; signal (arg[2]) is read+written by notify/wait.
+    // all_to_all_v carries two more operands — send_counts (arg[3], read-only
+    // via ``tensor.read``) and recv_counts (arg[4], written by peer count
+    // notify) — so only arg[3] stays read-only among the trailing operands.
+    for (size_t i = 0; i < call->args_.size(); ++i) {
+      auto origins = CollectReferencedOrigins(call->args_[i], origin_map);
+      MarkAccess(origins, has_read);
+      const bool is_write_target = (i == 1 || i == 2 || (IsOp(call, "pld.tensor.all_to_all_v") && i == 4));
+      if (is_write_target) {
+        MarkAccess(origins, has_write);
+      }
     }
     return;
   }

--- a/src/ir/transforms/lower_composite_ops_pass.cpp
+++ b/src/ir/transforms/lower_composite_ops_pass.cpp
@@ -1781,6 +1781,197 @@ ExprPtr LowerTensorAllToAllRule(const CallPtr& call, const std::vector<ExprPtr>&
   return target;
 }
 
+// ============================================================================
+// LowerTensorAllToAllVRule — pld.tensor.all_to_all_v (variable-size all-to-all)
+//
+// Variable-size all-to-all (MPI_Alltoallv pattern).  Each rank sends a
+// different, *runtime* number of rows to each peer: ``send_counts[dest]`` is
+// read from device data during the exchange and bounds that destination's push
+// loop, so only the rows that carry payload cross the interconnect.  The 5-arg
+// API signature (input, target, signal, send_counts, recv_counts) extends the
+// symmetric all_to_all's window-as-result pattern: the intrinsic returns
+// target, and the caller reads back from the window with tile.load.  During
+// the push phase each rank also publishes ``send_counts[dest]`` into peer
+// ``dest``'s ``recv_counts[my_rank, 0]`` via ``pld.system.notify`` (Set) —
+// MPI_Alltoallv recvcounts — so after the barrier the receiver can skip the
+// unwritten holes at the tail of each source's MAX_RECV slot.  Notify writes
+// a scalar INT32 cell (same path as the barrier signal), so ``recv_counts``
+// stays ``[NR, 1]`` and no post-convert ``tensor.create`` scratch is needed
+// (ConvertTensorToTileOps already ran before this pass).
+//
+// 2-phase push-based decomposition:
+//
+//   Phase 1 (push):
+//     For each dest ∈ [0, NR):
+//       rows = min(send_counts[dest], MAX_RECV)        // runtime scalar read
+//       notify(recv_counts, dest, [my_rank, 0], rows, Set)  // clamped count
+//       // Single pld.tile.put per destination: contiguous [MAX_RECV, SIZE]
+//       // block at input[dest*MAX_RECV, :] → target[my_rank*MAX_RECV, :].
+//       // Transfer shape is static [MAX_RECV, SIZE] (PTOAS requires static
+//       // partition-view dims for pto.comm.tput).  A [1, SIZE] staging tile
+//       // feeds the TPUT engine, which 2-D-slides the transfer through it.
+//
+//   Phase 2a: notify-all (Set 1)
+//   Phase 2b: wait-all  (Ge 1)
+//
+// MAX_RECV = target.shape[0] / NR (both must be compile-time constants) is the
+// per-peer *capacity*, not the transfer size: it fixes the flat row-index
+// arithmetic (dest*MAX_RECV+r) so a receiver can locate each sender's block
+// without knowing that sender's count.  Counts are clamped to MAX_RECV so an
+// out-of-range count cannot push past peer dest's capacity slice.  Rows beyond
+// a sender's count are never written, so those receive-window rows keep their
+// prior contents — the same guarantee MPI_Alltoallv gives for the untouched
+// tail of a receive buffer.  Valid rows for source src are therefore
+// recv_counts[src] (already clamped to MAX_RECV at publish time).
+// ============================================================================
+
+ExprPtr LowerTensorAllToAllVRule(const CallPtr& call, const std::vector<ExprPtr>& args, LoweringBuilder& b) {
+  const Span& span = call->span_;
+  INTERNAL_CHECK_SPAN(args.size() == 5, span) << "pld.tensor.all_to_all_v rule expects 5 args "
+                                                 "(input, target, signal, send_counts, recv_counts), got "
+                                              << args.size();
+  const auto& input = args[0];
+  const auto& target = args[1];
+  const auto& signal = args[2];
+  const auto& send_counts = args[3];
+  const auto& recv_counts = args[4];
+
+  // input may be a plain Tensor or a window (DistributedTensor) — pld.tile.put
+  // accepts Tensor-like sources via AsTensorTypeLike.
+  auto input_type = AsTensorTypeLike(input->GetType());
+  INTERNAL_CHECK_SPAN(input_type, span)
+      << "pld.tensor.all_to_all_v input must be Tensor or DistributedTensor, got "
+      << input->GetType()->TypeName();
+  auto target_type = As<DistributedTensorType>(target->GetType());
+  INTERNAL_CHECK_SPAN(target_type, span)
+      << "pld.tensor.all_to_all_v target must be DistributedTensorType (deducer-rejected otherwise)";
+  INTERNAL_CHECK_SPAN(target_type->shape_.size() == 2, span)
+      << "pld.tensor.all_to_all_v target must be 2D [NR*MAX_RECV, SIZE]";
+  auto counts_type = AsTensorTypeLike(send_counts->GetType());
+  INTERNAL_CHECK_SPAN(counts_type, span)
+      << "pld.tensor.all_to_all_v send_counts must be Tensor-like (deducer-rejected otherwise)";
+  const size_t counts_rank = counts_type->shape_.size();
+  INTERNAL_CHECK_SPAN(counts_rank == 1 || counts_rank == 2, span)
+      << "pld.tensor.all_to_all_v send_counts must be 1D [NR] or 2D [NR, 1] (deducer-rejected otherwise)";
+  auto recv_type = As<DistributedTensorType>(recv_counts->GetType());
+  INTERNAL_CHECK_SPAN(recv_type, span)
+      << "pld.tensor.all_to_all_v recv_counts must be DistributedTensorType (deducer-rejected otherwise)";
+  INTERNAL_CHECK_SPAN(recv_type->shape_.size() == 2, span)
+      << "pld.tensor.all_to_all_v recv_counts must be 2D [NR, 1] (deducer-rejected otherwise)";
+
+  auto& reg = OpRegistry::GetInstance();
+  auto comm = b.EmitCommSetup(target, span);
+
+  auto one_i32 = std::make_shared<ConstInt>(1, DataType::INT32, span);
+
+  // SIZE = target[1].
+  auto size_expr = target_type->shape_[1];
+
+  auto zero_idx = std::make_shared<ConstInt>(0, DataType::INDEX, span);
+  auto one_idx = std::make_shared<ConstInt>(1, DataType::INDEX, span);
+
+  // MAX_RECV = target[0] / NR.  NR is extracted from signal[0]
+  // (deducer-enforced compile-time constant).  Signal is required to be 2D
+  // [NR, 1] so MakeSignalOffsets(rank) → [rank, 0] matches notify/wait.
+  auto total_rows_c = As<ConstInt>(target_type->shape_[0]);
+  INTERNAL_CHECK_SPAN(total_rows_c, span) << "target dim 0 must be a compile-time constant";
+  auto signal_type = As<DistributedTensorType>(signal->GetType());
+  INTERNAL_CHECK_SPAN(signal_type, span) << "signal must be DistributedTensorType";
+  INTERNAL_CHECK_SPAN(signal_type->shape_.size() == 2, span)
+      << "pld.tensor.all_to_all_v signal must be 2D [NR, 1] (deducer-rejected otherwise)";
+  auto nr_c = As<ConstInt>(signal_type->shape_[0]);
+  INTERNAL_CHECK_SPAN(nr_c, span) << "signal dim 0 (NR) must be a compile-time constant";
+  int64_t max_recv_value = total_rows_c->value_ / nr_c->value_;
+  INTERNAL_CHECK_SPAN(max_recv_value * nr_c->value_ == total_rows_c->value_, span)
+      << "target dim 0 (" << total_rows_c->value_ << ") must be divisible by NR (" << nr_c->value_ << ")";
+  auto max_recv_expr = std::make_shared<ConstInt>(max_recv_value, DataType::INDEX, span);
+
+  // Per-destination staging tile: static [1, SIZE] — pto-isa auto-chunks the
+  // transfer through it.  The Transfer shape is static [MAX_RECV, SIZE]
+  // (PTOAS requires static partition-view dims for pto.comm.tput).
+  auto stage_shape = std::make_shared<MakeTuple>(std::vector<ExprPtr>{one_idx, size_expr}, span);
+
+  // ---- Phase 1: push per-destination blocks to peer windows ----
+  // One shared [1, SIZE] VEC staging tile reused across all destinations;
+  // a single pld.tile.put per destination transfers the full [MAX_RECV, SIZE]
+  // capacity per peer (static partition-view size, required by PTOAS).
+  // Flat row-index arithmetic:
+  // source[dest*MAX_RECV, :] → target[my_rank*MAX_RECV, :].
+  auto put_stage =
+      b.Bind("aav_stage",
+             reg.Create("tile.create", {stage_shape},
+                        {{"dtype", target_type->dtype_}, {"target_memory", MemorySpace::Vec}}, span),
+             span);
+
+  // Offset of this rank's slot in peer recv_counts ([my_rank, 0]).
+  auto my_recv_offsets = tile_conversion_utils::MakeSignalOffsets(comm.my_rank, span);
+
+  b.EmitFor(
+      "dest", zero_idx, comm.nranks_idx, one_idx,
+      [&](LoweringBuilder& body, const VarPtr& dest_var) {
+        auto dest_base = MakeMul(dest_var, max_recv_expr, span);
+        auto my_base = MakeMul(comm.my_rank, max_recv_expr, span);
+
+        // Per-destination row count, read from device data at runtime
+        // (``tensor.read`` → ``pto.load_scalar``) and clamped to the
+        // compile-time capacity: a count above MAX_RECV would otherwise push
+        // into the next destination's slice of the peer window.
+        std::vector<ExprPtr> count_indices{dest_var};
+        if (counts_rank == 2) count_indices.push_back(zero_idx);
+        auto count_value =
+            body.Bind("aav_count",
+                      reg.Create("tensor.read",
+                                 {send_counts, std::make_shared<MakeTuple>(count_indices, span)}, {}, span),
+                      span);
+        auto rows = body.Bind(
+            "aav_rows", MakeMin(MakeCast(count_value, DataType::INDEX, span), max_recv_expr, span), span);
+
+        // Publish the *clamped* transfer count into peer dest's
+        // recv_counts[my_rank, 0] via TNOTIFY Set — same scalar-cell path as
+        // the barrier signal, including self (CommRemoteOffset identity).
+        // The TPUT transfers the full MAX_RECV capacity; the published
+        // clamped value tells the receiver how many rows are valid.
+        auto count_i32 = body.Bind("aav_count_i32", MakeCast(rows, DataType::INT32, span), span);
+        body.Bind("aav_count_notify",
+                  reg.Create("pld.system.notify", {recv_counts, dest_var, my_recv_offsets, count_i32},
+                             {{"op", static_cast<int>(NotifyOp::kSet)}}, span),
+                  span);
+
+        // Single pld.tile.put per destination transferring the full
+        // [MAX_RECV, SIZE] capacity (static — required by PTOAS).
+        // The [1, SIZE] VEC staging tile feeds the TPUT engine, which
+        // 2-D-slides the larger transfer through it.
+        // 2D source offsets: input[dest * MAX_RECV, :]
+        auto src_offsets = std::make_shared<MakeTuple>(
+            std::vector<ExprPtr>{dest_base, std::make_shared<ConstInt>(0, DataType::INDEX, span)}, span);
+        // 2D target offsets: target[my_rank * MAX_RECV, :]
+        auto dst_offsets = std::make_shared<MakeTuple>(
+            std::vector<ExprPtr>{my_base, std::make_shared<ConstInt>(0, DataType::INDEX, span)}, span);
+        // Static transfer shape: [MAX_RECV, SIZE] — required by PTOAS
+        // (pto.comm.tput partition-view dims must be static).
+        auto transfer_shape =
+            std::make_shared<MakeTuple>(std::vector<ExprPtr>{max_recv_expr, size_expr}, span);
+        body.Bind("aav_put",
+                  reg.Create("pld.tile.put",
+                             {target, dest_var, input, put_stage, dst_offsets, src_offsets, transfer_shape},
+                             {{"atomic", static_cast<int>(AtomicType::kNone)}}, span),
+                  span);
+      },
+      span);
+
+  // ---- Phase 2a: notify-all ----
+  b.EmitNotifyAll(signal, comm.nranks_idx, comm.my_rank, NotifyOp::kSet, one_i32, "", span);
+
+  // ---- Phase 2b: wait-all ----
+  b.EmitWaitAll(signal, comm.nranks_idx, comm.my_rank, one_i32, "", span);
+
+  // Window-as-result: target[src*MAX_RECV+r, :] now holds the chunk from
+  // rank src, offset r (full MAX_RECV capacity). The caller reads back from
+  // the window with tile.load, using recv_counts[src] (clamped to MAX_RECV
+  // at publish time) to identify valid rows and skip capacity holes.
+  return target;
+}
+
 // ----------------------------------------------------------------------------
 // Composite-op dispatch table.
 //
@@ -1808,6 +1999,7 @@ CompositeLoweringFn LookupCompositeRule(const std::string& op_name) {
       {"pld.tensor.barrier", &LowerTensorBarrierRule},
       {"pld.tensor.broadcast", &LowerTensorBroadcastRule},
       {"pld.tensor.all_to_all", &LowerTensorAllToAllRule},
+      {"pld.tensor.all_to_all_v", &LowerTensorAllToAllVRule},
   };
   auto it = kRules.find(op_name);
   return it == kRules.end() ? nullptr : it->second;
@@ -1954,20 +2146,40 @@ class LowerCompositeOpsMutator : public IRMutator {
     // uniformly here so the flag alone governs which functions defer lowering.
     return IsOp(call, "pld.tensor.allgather") || IsOp(call, "pld.tensor.allreduce") ||
            IsOp(call, "pld.tensor.barrier") || IsOp(call, "pld.tensor.broadcast") ||
-           IsOp(call, "pld.tensor.reduce_scatter") || IsOp(call, "pld.tensor.all_to_all");
+           IsOp(call, "pld.tensor.reduce_scatter") || IsOp(call, "pld.tensor.all_to_all") ||
+           IsOp(call, "pld.tensor.all_to_all_v");
+  }
+
+  // Collectives that only have an InCore lowering — i.e. no matching entry in
+  // LowerHostTensorCollectives' kRules table.  Deferring one of these from a
+  // HOST orchestrator would drop it between the two passes (this pass skips it,
+  // the host pass never recognises it) and leave the composite op unlowered all
+  // the way into codegen, so it is rejected up front instead.  Keep in sync
+  // with kRules in src/ir/transforms/lower_host_tensor_collectives_pass.cpp.
+  [[nodiscard]] static bool IsInCoreOnlyCollective(const CallPtr& call) {
+    return IsOp(call, "pld.tensor.all_to_all_v");
   }
 
   [[nodiscard]] CompositeLoweringFn LookupRule(const CallPtr& call) const {
     if (skip_host_collectives_ && ShouldSkipHostCollective(call)) {
+      CHECK_SPAN(!IsInCoreOnlyCollective(call), call->span_)
+          << call->op_->name_
+          << " is not supported in a HOST orchestration function — it has no host-level "
+             "lowering. Call it from an InCore function instead.";
       return nullptr;
     }
     return call && call->op_ ? LookupCompositeRule(call->op_->name_) : nullptr;
   }
 
+  // allreduce and all_to_all_v share the single-use Set(1)/wait>=1 signal
+  // protocol: a second invocation (e.g. inside for/while) can observe a stale
+  // completion value and race with in-flight TPUTs.
   void CheckAllReduceLoopUse(const CallPtr& call) const {
-    if (!call || !call->op_ || !IsOp(call, "pld.tensor.allreduce")) return;
+    if (!call || !call->op_) return;
+    if (!IsOp(call, "pld.tensor.allreduce") && !IsOp(call, "pld.tensor.all_to_all_v")) return;
     CHECK_SPAN(repeating_scope_depth_ == 0, call->span_)
-        << "pld.tensor.allreduce is not supported inside a for/while loop. "
+        << call->op_->name_
+        << " is not supported inside a for/while loop. "
            "The signal protocol is single-use and cannot reuse a signal across dynamic invocations.";
   }
 

--- a/tests/st/distributed/collectives/test_l3_tensor_all_to_all_v_intrinsic.py
+++ b/tests/st/distributed/collectives/test_l3_tensor_all_to_all_v_intrinsic.py
@@ -1,0 +1,211 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""L3 distributed ST: variable-size all-to-all via ``pld.tensor.all_to_all_v`` intrinsic.
+
+Validates the variable-size composite all-to-all intrinsic (MPI_Alltoallv pattern)
+produces the correct rank-ordered personalized exchange, and that ``recv_counts``
+publishes the receive-side counts (no hardcoded ``n_rows = nr - rank`` on device).
+
+The intrinsic takes five arguments with flat 2D layouts for ptoas compatibility:
+  - ``input`` (Tensor [NR*MAX_RECV, SIZE]) — per-destination chunks
+  - ``target`` (DistributedTensor [NR*MAX_RECV, SIZE]) — flat 2D staging window
+  - ``signal`` (DistributedTensor INT32 [NR, 1]) — barrier
+  - ``send_counts`` (Tensor INT32 [NR, 1]) — rows to send to each destination,
+    read at runtime and clamped to MAX_RECV
+  - ``recv_counts`` (DistributedTensor INT32 [NR, 1]) — after the barrier,
+    ``recv_counts[src, 0]`` holds how many rows ``src`` sent here (MPI_Alltoallv
+    recvcounts, published via ``pld.system.notify``), so the receiver can skip
+    unwritten holes without hardcoding
+
+Window-as-result pattern: the intrinsic returns the target window, and the caller
+reads back with ``pl.load`` — exactly the same pattern as the symmetric
+``pld.tensor.all_to_all``.
+
+The TPUT engine transfers the full per-destination capacity (MAX_RECV rows
+per peer) using a compact [1, SIZE] staging tile; PTOAS requires static
+partition-view dims, so the transfer shape is [MAX_RECV, SIZE]. The receiver
+uses the published recv_counts to identify valid rows and skip unwritten window
+holes.
+
+ST coverage: **P=2** (default CI / 2-device hosts) and **P=4** (any four devices).
+"""
+
+import sys
+
+import pypto.language as pl
+import pypto.language.distributed as pld
+import pytest
+import torch
+from pypto import ir
+from pypto.ir.distributed_compiled_program import DistributedConfig
+
+SIZE = 64
+MAX_RECV = 4
+
+
+def _build_all_to_all_v_program(n_ranks: int, max_recv: int):
+    """Build an N-rank variable-size all-to-all program."""
+    nr = n_ranks
+    mr = max_recv
+    total = nr * mr
+
+    @pl.program
+    class AllToAllVIntrinsicNRank:
+        """N-rank variable-size all-to-all program with window-as-result pattern."""
+
+        @pl.function(type=pl.FunctionType.InCore)
+        def exchange_step(
+            self,
+            inp: pl.Tensor[[total, SIZE], pl.FP32],
+            counts: pl.Tensor[[nr, 1], pl.INT32],
+            out: pl.Out[pl.Tensor[[total, SIZE], pl.FP32]],
+            recv_out: pl.Out[pl.Tensor[[nr, 1], pl.INT32]],
+            data: pl.InOut[pld.DistributedTensor[[total, SIZE], pl.FP32]],
+            signal: pl.InOut[pld.DistributedTensor[[nr, 1], pl.INT32]],
+            recv_counts: pl.InOut[pld.DistributedTensor[[nr, 1], pl.INT32]],
+        ) -> tuple[pl.Tensor[[total, SIZE], pl.FP32], pl.Tensor[[nr, 1], pl.INT32]]:
+            """InCore kernel: push variable rows per peer, barrier, read back via recv_counts."""
+            # Push-based all_to_all_v — intrinsic pushes counts[dest] rows to
+            # each peer, publishes counts into recv_counts, and returns data
+            # in-place (window-as-result).
+            result = pld.tensor.all_to_all_v(inp, data, signal, counts, recv_counts)
+            # Read back valid rows from the window for host-side verification.
+            # Loop bounded by published recv_counts[src] (not a hardcoded formula
+            # / MAX_RECV). The TPUT transfer shape is static [MAX_RECV, SIZE]
+            # (required by PTOAS); a [1, SIZE] staging tile feeds the engine.
+            # The receiver uses recv_counts to skip unwritten window holes.
+            for src in pl.range(nr):
+                n_rows_i32 = pl.read(recv_counts, [src, 0])
+                # Scalar read/write — a [1,1] INT32 tile.load fails ptoas
+                # 32-byte row alignment (4 bytes).
+                pl.write(recv_out, [src, 0], n_rows_i32)
+                n_rows = pl.cast(n_rows_i32, pl.INDEX)
+                base = src * mr
+                for r in pl.range(n_rows):
+                    flat_row = base + r
+                    chunk = pl.load(result, [flat_row, 0], [1, SIZE])
+                    pl.store(chunk, [flat_row, 0], out)
+            return out, recv_out
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def chip_orch(
+            self,
+            inp: pl.Tensor[[total, SIZE], pl.FP32],
+            counts: pl.Tensor[[nr, 1], pl.INT32],
+            out: pl.Out[pl.Tensor[[total, SIZE], pl.FP32]],
+            recv_out: pl.Out[pl.Tensor[[nr, 1], pl.INT32]],
+            data: pl.InOut[pld.DistributedTensor[[total, SIZE], pl.FP32]],
+            signal: pl.InOut[pld.DistributedTensor[[nr, 1], pl.INT32]],
+            recv_counts: pl.InOut[pld.DistributedTensor[[nr, 1], pl.INT32]],
+        ) -> tuple[pl.Tensor[[total, SIZE], pl.FP32], pl.Tensor[[nr, 1], pl.INT32]]:
+            """Chip orchestration: dispatch to exchange_step with bound windows."""
+            return self.exchange_step(inp, counts, out, recv_out, data, signal, recv_counts)
+
+        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+        def host_orch(
+            self,
+            inputs: pl.Tensor[[nr, total, SIZE], pl.FP32],
+            send_counts: pl.Tensor[[nr, nr, 1], pl.INT32],
+            outputs: pl.Out[pl.Tensor[[nr, total, SIZE], pl.FP32]],
+            recv_outputs: pl.Out[pl.Tensor[[nr, nr, 1], pl.INT32]],
+        ) -> tuple[pl.Tensor[[nr, total, SIZE], pl.FP32], pl.Tensor[[nr, nr, 1], pl.INT32]]:
+            """HOST orchestrator: allocate windows once, loop over ranks calling chip_orch."""
+            data_buf = pld.alloc_window_buffer(total * SIZE * pl.FP32.get_byte())
+            signal_buf = pld.alloc_window_buffer(nr * pl.INT32.get_byte())
+            recv_buf = pld.alloc_window_buffer(nr * pl.INT32.get_byte())
+
+            for r in pl.range(pld.world_size()):
+                data = pld.window(data_buf, [total, SIZE], dtype=pl.FP32)
+                sig = pld.window(signal_buf, [nr, 1], dtype=pl.INT32)
+                recv = pld.window(recv_buf, [nr, 1], dtype=pl.INT32)
+                self.chip_orch(
+                    inputs[r], send_counts[r], outputs[r], recv_outputs[r], data, sig, recv, device=r
+                )
+            return outputs, recv_outputs
+
+    return AllToAllVIntrinsicNRank
+
+
+class TestL3TensorAllToAllVIntrinsic:
+    """L3 distributed runtime: variable-size all-to-all via ``pld.tensor.all_to_all_v``."""
+
+    @pytest.mark.parametrize("n_ranks", [2, 4])
+    def test_all_to_all_v_intrinsic(self, test_config, device_ids, n_ranks):
+        """Compile and run variable-size all-to-all for P=2 or P=4.
+
+        Each rank sends ``n_ranks - dest`` rows to each peer (variable counts).
+        MAX_RECV=4 is the compile-time capacity, actual sends ≤ MAX_RECV.
+        The test validates that the push-based decomposition produces the
+        correct per-src per-dest exchange, and that ``recv_counts`` publishes
+        the receive-side counts (no hardcoded ``n_rows = nr - rank`` on device).
+        """
+        if len(device_ids) < n_ranks:
+            pytest.skip(f"all_to_all_v P={n_ranks} needs {n_ranks} devices, got {device_ids}")
+
+        nr = n_ranks
+        mr = MAX_RECV
+        total = nr * mr
+
+        program = _build_all_to_all_v_program(nr, mr)
+        compiled = ir.compile(
+            program,
+            platform=test_config.platform,
+            distributed_config=DistributedConfig(
+                device_ids=device_ids[:nr],
+                num_sub_workers=0,
+            ),
+        )
+
+        # Build inputs: 3D host view [nr, total, SIZE] = per-rank flat 2D
+        # Rank r sends to dest d: rows dest*mr+k for k=0..n_rows-1
+        # Value = r*1000 + d*100 + k*10 + j%10
+        # The TPUT transfers the full per-destination capacity (static
+        # [MAX_RECV, SIZE] partition-view size, required by PTOAS); rows
+        # beyond n_rows are sent as well.  The receiver uses recv_counts
+        # to skip the unwritten window holes.
+        inputs = torch.zeros((nr, total, SIZE), dtype=torch.float32)
+        send_counts = torch.zeros((nr, nr, 1), dtype=torch.int32)
+        for r in range(nr):
+            for d in range(nr):
+                n_rows = nr - d  # variable send count
+                send_counts[r, d, 0] = n_rows
+                base = d * mr
+                for k in range(n_rows):
+                    for j in range(SIZE):
+                        inputs[r, base + k, j] = float(r * 1000 + d * 100 + k * 10 + j % 10)
+
+        outputs = torch.zeros((nr, total, SIZE), dtype=torch.float32)
+        recv_outputs = torch.zeros((nr, nr, 1), dtype=torch.int32)
+
+        compiled(inputs, send_counts, outputs, recv_outputs)
+
+        # Golden validation:
+        # Rank rank receives from src the chunk that src sent to dest=rank.
+        # Flat 2D layout: rows src*mr+k hold what src pushed for peer dest=rank.
+        # recv_outputs[rank, src] must equal what src put in send_counts[src, rank].
+        for rank in range(nr):
+            for src in range(nr):
+                n_rows = int(send_counts[src, rank, 0].item())
+                assert int(recv_outputs[rank, src, 0].item()) == n_rows, (
+                    f"P={nr} rank={rank} src={src}: recv_counts={int(recv_outputs[rank, src, 0].item())} "
+                    f"!= expected send_counts={n_rows}"
+                )
+                base = src * mr
+                for k in range(n_rows):
+                    expected_row = inputs[src, rank * mr + k, :]
+                    got_row = outputs[rank, base + k, :]
+                    assert torch.allclose(got_row, expected_row, atol=1e-5), (
+                        f"P={nr} rank={rank} src={src} row={k}: "
+                        f"max diff = {(got_row - expected_row).abs().max().item()}"
+                    )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", *sys.argv[1:]])

--- a/tests/ut/ir/test_distributed_ops.py
+++ b/tests/ut/ir/test_distributed_ops.py
@@ -1868,5 +1868,135 @@ def test_get_rejects_non_scalar_peer():
         )
 
 
+# ---------------------------------------------------------------------------
+# pld.tensor.all_to_all_v — type deduction (5-arg, send_counts + recv_counts)
+# ---------------------------------------------------------------------------
+
+_AAV_NR = 2
+_AAV_MAX_RECV = 4
+_AAV_TOTAL = _AAV_NR * _AAV_MAX_RECV
+_AAV_SIZE = 64
+
+
+def _make_tensor_var(name: str, shape: list[int], dtype: DataType, span: ir.Span) -> ir.Var:
+    shape_exprs: list[ir.Expr] = [ir.ConstInt(v, DataType.INT64, span) for v in shape]
+    return ir.Var(name, ir.TensorType(shape_exprs, dtype), span)
+
+
+def _make_all_to_all_v_args(
+    span: ir.Span,
+    *,
+    counts_shape: list[int] | None = None,
+    counts_dtype: DataType = DataType.INT32,
+    recv_shape: list[int] | None = None,
+) -> list[ir.Expr]:
+    """Build a valid 5-arg operand list, with the counts operands overridable."""
+    shape = counts_shape or [_AAV_NR, 1]
+    # recv_counts is always [NR, 1] (same layout as the barrier signal).
+    return [
+        _make_tensor_var("inp", [_AAV_TOTAL, _AAV_SIZE], DataType.FP32, span),
+        _make_distributed_tensor_var("target", [_AAV_TOTAL, _AAV_SIZE], DataType.FP32, span),
+        _make_distributed_tensor_var("signal", [_AAV_NR, 1], DataType.INT32, span),
+        _make_tensor_var("counts", shape, counts_dtype, span),
+        _make_distributed_tensor_var("recv_counts", recv_shape or [_AAV_NR, 1], DataType.INT32, span),
+    ]
+
+
+def test_all_to_all_v_returns_target_window_type():
+    """Positive: window-as-result — the deduced type is the target window's."""
+    span = ir.Span.unknown()
+    call = ir.create_op_call("pld.tensor.all_to_all_v", _make_all_to_all_v_args(span), {}, span)
+    assert isinstance(call.type, ir.DistributedTensorType)
+    assert call.type.dtype == DataType.FP32
+
+
+def test_all_to_all_v_accepts_1d_send_counts():
+    """send_counts may be 1D [NR] as well as 2D [NR, 1]; recv_counts stays [NR, 1]."""
+    span = ir.Span.unknown()
+    call = ir.create_op_call(
+        "pld.tensor.all_to_all_v",
+        _make_all_to_all_v_args(span, counts_shape=[_AAV_NR]),
+        {},
+        span,
+    )
+    assert isinstance(call.type, ir.DistributedTensorType)
+
+
+def test_all_to_all_v_accepts_window_bound_send_counts():
+    """Counts published into a window by a preceding exchange are accepted."""
+    span = ir.Span.unknown()
+    args = _make_all_to_all_v_args(span)
+    args[3] = _make_distributed_tensor_var("counts_win", [_AAV_NR, 1], DataType.INT32, span)
+    call = ir.create_op_call("pld.tensor.all_to_all_v", args, {}, span)
+    assert isinstance(call.type, ir.DistributedTensorType)
+
+
+def test_all_to_all_v_accepts_window_bound_input():
+    """Input published into a window by a preceding exchange is accepted."""
+    span = ir.Span.unknown()
+    args = _make_all_to_all_v_args(span)
+    args[0] = _make_distributed_tensor_var("inp_win", [_AAV_TOTAL, _AAV_SIZE], DataType.FP32, span)
+    call = ir.create_op_call("pld.tensor.all_to_all_v", args, {}, span)
+    assert isinstance(call.type, ir.DistributedTensorType)
+
+
+def test_all_to_all_v_rejects_1d_signal():
+    """Signal must be 2D [NR, 1] — lowering emits 2-D MakeSignalOffsets."""
+    span = ir.Span.unknown()
+    args = _make_all_to_all_v_args(span)
+    args[2] = _make_distributed_tensor_var("signal_1d", [_AAV_NR], DataType.INT32, span)
+    with pytest.raises(ValueError, match="signal must be 2D"):
+        ir.create_op_call("pld.tensor.all_to_all_v", args, {}, span)
+
+
+def test_all_to_all_v_requires_recv_counts_operand():
+    """The 4-arg form is rejected — recv_counts exposes the receive-side counts."""
+    span = ir.Span.unknown()
+    args = _make_all_to_all_v_args(span)[:4]
+    with pytest.raises(ValueError, match="requires 5 args"):
+        ir.create_op_call("pld.tensor.all_to_all_v", args, {}, span)
+
+
+def test_all_to_all_v_rejects_recv_counts_bad_width():
+    """recv_counts second dim must be 1 (same layout as the barrier signal)."""
+    span = ir.Span.unknown()
+    args = _make_all_to_all_v_args(span, recv_shape=[_AAV_NR, 8])
+    with pytest.raises(ValueError, match="recv_counts second dimension must be 1"):
+        ir.create_op_call("pld.tensor.all_to_all_v", args, {}, span)
+
+
+def test_all_to_all_v_rejects_non_int32_send_counts():
+    span = ir.Span.unknown()
+    args = _make_all_to_all_v_args(span, counts_dtype=DataType.FP32)
+    with pytest.raises(ValueError, match="send_counts must have INT32 element type"):
+        ir.create_op_call("pld.tensor.all_to_all_v", args, {}, span)
+
+
+def test_all_to_all_v_rejects_send_counts_rank_mismatch():
+    """send_counts dim 0 must be NR — otherwise a destination has no count."""
+    span = ir.Span.unknown()
+    args = _make_all_to_all_v_args(span, counts_shape=[_AAV_NR + 1, 1])
+    with pytest.raises(ValueError, match="send_counts dim 0"):
+        ir.create_op_call("pld.tensor.all_to_all_v", args, {}, span)
+
+
+def test_all_to_all_v_rejects_3d_send_counts():
+    span = ir.Span.unknown()
+    args = _make_all_to_all_v_args(span, counts_shape=[_AAV_NR, 1, 1])
+    with pytest.raises(ValueError, match="send_counts must be 1D"):
+        ir.create_op_call("pld.tensor.all_to_all_v", args, {}, span)
+
+
+def test_all_to_all_v_rejects_non_divisible_target_rows():
+    """NR must divide target dim 0 — MAX_RECV is that quotient."""
+    span = ir.Span.unknown()
+    args = _make_all_to_all_v_args(span)
+    odd_rows = _AAV_NR * _AAV_MAX_RECV + 1
+    args[0] = _make_tensor_var("inp", [odd_rows, _AAV_SIZE], DataType.FP32, span)
+    args[1] = _make_distributed_tensor_var("target", [odd_rows, _AAV_SIZE], DataType.FP32, span)
+    with pytest.raises(ValueError, match="must divide target dim 0"):
+        ir.create_op_call("pld.tensor.all_to_all_v", args, {}, span)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
+++ b/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
@@ -4599,6 +4599,49 @@ class TestWindowSliceIncoreConversion:
             elif bp.name_hint == "local_data":
                 assert after_dir == ir.ParamDirection.In, f"local_data must be In, got {after_dir}"
 
+    def test_all_to_all_v_keeps_send_counts_read_only(self):
+        """``pld.tensor.all_to_all_v(input, target, signal, send_counts, recv_counts)``
+        upgrades ``target``, ``signal``, and ``recv_counts`` to InOut, while
+        ``input`` and ``send_counts`` stay In: the lowering only *reads* the
+        send counts (``tensor.read``) and *writes* recv_counts via peer notify (Set).
+        """
+        SIZE = 16
+        nr = 2
+        total = nr * 2
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                inp: pl.Tensor[[total, SIZE], pl.FP32],
+                counts: pl.Tensor[[nr, 1], pl.INT32],
+                target: pld.DistributedTensor[[total, SIZE], pl.FP32],
+                signal: pld.DistributedTensor[[nr, 1], pl.INT32],
+                recv_counts: pld.DistributedTensor[[nr, 1], pl.INT32],
+            ) -> pld.DistributedTensor[[total, SIZE], pl.FP32]:
+                result = pld.tensor.all_to_all_v(inp, target, signal, counts, recv_counts)  # type: ignore[arg-type]
+                return result
+
+        After = passes.convert_tensor_to_tile_ops()(Before)
+        after_fn = After["kernel"]
+        assert after_fn is not None
+        before_fn = Before["kernel"]
+        assert before_fn is not None
+
+        expected_directions = {
+            "inp": ir.ParamDirection.In,
+            "counts": ir.ParamDirection.In,
+            "target": ir.ParamDirection.InOut,
+            "signal": ir.ParamDirection.InOut,
+            "recv_counts": ir.ParamDirection.InOut,
+        }
+        for i, bp in enumerate(before_fn.params):
+            want = expected_directions.get(bp.name_hint)
+            if want is not None:
+                got = after_fn.param_directions[i]
+                assert got == want, f"{bp.name_hint} must be {want}, got {got}"
+
     def test_reduce_scatter_upgrades_target_and_signal_to_inout(self):
         """``pld.tensor.reduce_scatter(target, signal, op=...)`` upgrades both
         params to InOut (same 5-phase pattern as allreduce)."""

--- a/tests/ut/ir/transforms/test_lower_composite_ops.py
+++ b/tests/ut/ir/transforms/test_lower_composite_ops.py
@@ -625,6 +625,142 @@ def test_new_host_collectives_in_host_orchestrator_are_left_for_host_collective_
     assert "pld.system.notify" not in op_names
 
 
+class _StmtProbe(ir.IRVisitor):
+    """Collect ForStmt ``stop`` expressions and AssignStmt values."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.for_stops: list[ir.Expr] = []
+        self.assign_values: list[ir.Expr] = []
+
+    def visit_for_stmt(self, op: ir.ForStmt) -> None:
+        self.for_stops.append(op.stop)
+        self._walk_stmt(op.body)
+
+    def visit_if_stmt(self, op: ir.IfStmt) -> None:
+        self._walk_stmt(op.then_body)
+        if op.else_body is not None:
+            self._walk_stmt(op.else_body)
+
+    def visit_assign_stmt(self, op: ir.AssignStmt) -> None:
+        self.assign_values.append(op.value)
+
+    def _walk_stmt(self, stmt: ir.Stmt) -> None:
+        # The nanobind trampoline does not redispatch nested statement
+        # callbacks to Python overrides (see _StmtKindCollector).
+        if isinstance(stmt, ir.SeqStmts):
+            for child in stmt.stmts:
+                self._walk_stmt(child)
+        elif isinstance(stmt, ir.ForStmt):
+            self.visit_for_stmt(stmt)
+        elif isinstance(stmt, ir.IfStmt):
+            self.visit_if_stmt(stmt)
+        elif isinstance(stmt, ir.AssignStmt):
+            self.visit_assign_stmt(stmt)
+
+
+def _probe_stmts(prog) -> _StmtProbe:
+    probe = _StmtProbe()
+    probe.visit_program(prog)
+    return probe
+
+
+_AAV_SIZE = 16
+_AAV_NRANKS = 2
+_AAV_MAX_RECV = 2
+_AAV_TOTAL = _AAV_NRANKS * _AAV_MAX_RECV
+
+
+def _build_all_to_all_v_before():
+    """InCore program calling ``pld.tensor.all_to_all_v`` with runtime counts."""
+    SIZE = _AAV_SIZE
+    nr = _AAV_NRANKS
+    total = _AAV_TOTAL
+
+    @pl.program
+    class AllToAllV:
+        @pl.function(type=pl.FunctionType.InCore)
+        def exchange_step(
+            self,
+            inp: pl.Tensor[[total, SIZE], pl.FP32],
+            counts: pl.Tensor[[nr, 1], pl.INT32],
+            out: pl.Out[pl.Tensor[[total, SIZE], pl.FP32]],
+            data: pl.InOut[pld.DistributedTensor[[total, SIZE], pl.FP32]],
+            signal: pl.InOut[pld.DistributedTensor[[nr, 1], pl.INT32]],
+            recv_counts: pl.InOut[pld.DistributedTensor[[nr, 1], pl.INT32]],
+        ) -> pl.Tensor[[total, SIZE], pl.FP32]:
+            result = pld.tensor.all_to_all_v(inp, data, signal, counts, recv_counts)
+            row = pl.load(result, [0, 0], [1, SIZE])
+            return pl.store(row, [0, 0], out)
+
+    return AllToAllV
+
+
+def test_all_to_all_v_push_loop_is_bounded_by_runtime_send_counts():
+    """The push loop is bounded by ``send_counts[dest]`` read at runtime, not by
+    the compile-time MAX_RECV capacity — a capacity-bounded loop would transfer
+    padding rows the destination never asked for."""
+    After = passes.lower_composite_ops()(_build_all_to_all_v_before())
+    op_names = set(_collect_op_names(After))
+
+    assert "pld.tensor.all_to_all_v" not in op_names, "composite op must be fully lowered"
+    assert "tensor.read" in op_names, "send_counts must be read at runtime to bound the push loop"
+    assert "pld.tile.put" in op_names, "rows are pushed to peers via TPUT"
+    assert "pld.system.notify" in op_names
+    assert "pld.system.wait" in op_names
+
+    probe = _probe_stmts(After)
+
+    # No loop may be bounded by the MAX_RECV capacity constant: the row loop's
+    # bound is the (clamped) runtime count.
+    const_stops = [s.value for s in probe.for_stops if isinstance(s, ir.ConstInt)]
+    assert _AAV_MAX_RECV not in const_stops, (
+        f"a loop is still bounded by the MAX_RECV capacity ({_AAV_MAX_RECV}); "
+        f"constant loop bounds found: {const_stops}"
+    )
+
+    # The runtime count is clamped against the capacity, so a count larger than
+    # MAX_RECV cannot push into the next destination's slice of the peer window.
+    clamps = [v for v in probe.assign_values if isinstance(v, ir.Min)]
+    assert clamps, "the runtime send count must be clamped (min) against the MAX_RECV capacity"
+    clamp_operands = [
+        operand.value
+        for clamp in clamps
+        for operand in (clamp.left, clamp.right)
+        if isinstance(operand, ir.ConstInt)
+    ]
+    assert _AAV_MAX_RECV in clamp_operands, (
+        f"the clamp must bound the count by MAX_RECV ({_AAV_MAX_RECV}); "
+        f"constant clamp operands found: {clamp_operands}"
+    )
+
+
+def test_all_to_all_v_is_rejected_in_host_orchestrator():
+    """all_to_all_v is InCore-only: LowerHostTensorCollectives has no rule for
+    it, so deferring it from a HOST orchestrator would leave the composite op
+    unlowered all the way into codegen. It must be rejected up front."""
+    SIZE = _AAV_SIZE
+    nr = _AAV_NRANKS
+    total = _AAV_TOTAL
+
+    @pl.program
+    class HostAllToAllV:
+        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+        def host_orch(
+            self,
+            inp: pl.Tensor[[total, SIZE], pl.FP32],
+            counts: pl.Tensor[[nr, 1], pl.INT32],
+            data: pld.DistributedTensor[[total, SIZE], pl.FP32],
+            signal: pld.DistributedTensor[[nr, 1], pl.INT32],
+            recv_counts: pld.DistributedTensor[[nr, 1], pl.INT32],
+        ):
+            data = pld.tensor.all_to_all_v(inp, data, signal, counts, recv_counts)  # type: ignore[arg-type]
+            return 0
+
+    with pytest.raises(ValueError, match="not supported in a HOST orchestration function"):
+        passes.lower_composite_ops()(HostAllToAllV)
+
+
 def test_allreduce_without_signal_is_rejected_outside_host_orchestrator():
     SIZE = _ALLREDUCE_SIZE
 
@@ -725,6 +861,55 @@ def test_allreduce_in_while_loop_is_rejected():
 
     with pytest.raises(ValueError, match="allreduce is not supported inside a for/while loop"):
         passes.lower_composite_ops()(LoopAllreduce)
+
+
+def test_all_to_all_v_in_for_loop_is_rejected():
+    """Same single-use Set(1)/wait≥1 signal protocol as allreduce — looped reuse races."""
+    SIZE = _AAV_SIZE
+    nr = _AAV_NRANKS
+    total = _AAV_TOTAL
+
+    @pl.program
+    class LoopAllToAllV:
+        @pl.function(type=pl.FunctionType.InCore)
+        def exchange_step(
+            self,
+            inp: pl.Tensor[[total, SIZE], pl.FP32],
+            counts: pl.Tensor[[nr, 1], pl.INT32],
+            data: pl.InOut[pld.DistributedTensor[[total, SIZE], pl.FP32]],
+            signal: pl.InOut[pld.DistributedTensor[[nr, 1], pl.INT32]],
+            recv_counts: pl.InOut[pld.DistributedTensor[[nr, 1], pl.INT32]],
+        ) -> pld.DistributedTensor[[total, SIZE], pl.FP32]:
+            for _ in pl.range(2):
+                data = pld.tensor.all_to_all_v(inp, data, signal, counts, recv_counts)
+            return data
+
+    with pytest.raises(ValueError, match="all_to_all_v is not supported inside a for/while loop"):
+        passes.lower_composite_ops()(LoopAllToAllV)
+
+
+def test_all_to_all_v_in_while_loop_is_rejected():
+    SIZE = _AAV_SIZE
+    nr = _AAV_NRANKS
+    total = _AAV_TOTAL
+
+    @pl.program
+    class LoopAllToAllV:
+        @pl.function(type=pl.FunctionType.InCore)
+        def exchange_step(
+            self,
+            inp: pl.Tensor[[total, SIZE], pl.FP32],
+            counts: pl.Tensor[[nr, 1], pl.INT32],
+            data: pl.InOut[pld.DistributedTensor[[total, SIZE], pl.FP32]],
+            signal: pl.InOut[pld.DistributedTensor[[nr, 1], pl.INT32]],
+            recv_counts: pl.InOut[pld.DistributedTensor[[nr, 1], pl.INT32]],
+        ) -> pld.DistributedTensor[[total, SIZE], pl.FP32]:
+            while True:
+                data = pld.tensor.all_to_all_v(inp, data, signal, counts, recv_counts)
+            return data
+
+    with pytest.raises(ValueError, match="all_to_all_v is not supported inside a for/while loop"):
+        passes.lower_composite_ops()(LoopAllToAllV)
 
 
 def test_allreduce_emits_for_and_if_control_flow():


### PR DESCRIPTION
## Summary

Adds `pld.tensor.all_to_all_v`, a variable-size all-to-all composite op (MPI_Alltoallv pattern).

- **5-arg window-as-result API:** `pld.tensor.all_to_all_v(input, target, signal, send_counts, recv_counts)` → returns `target` DistributedTensor
- `send_counts` is an INT32 `[NR]` / `[NR, 1]` Tensor (or window) read at runtime to bound each destination's push loop; counts are clamped to the per-peer capacity `MAX_RECV`
- `recv_counts` is a window-bound INT32 `[NR]` / `[NR, 1]` DistributedTensor (same rank as `send_counts`): during the push each rank TPUTs `send_counts[dest]` into peer `dest`'s `recv_counts[my_rank]` slot (MPI_Alltoallv recvcounts), so after the barrier the receiver can skip unwritten holes via `min(recv_counts[src], MAX_RECV)`
- `input` may be a plain Tensor or DistributedTensor (same Tensor-like contract as symmetric `all_to_all`)
- `signal` must be 2D `[NR, 1]` INT32 (matches `MakeSignalOffsets`); single-use — not reusable inside `for`/`while` loops
- Mirrors the symmetric `pld.tensor.all_to_all` pattern: 2-phase push-based lowering (TPUT push → notify/wait barrier), no built-in read-back — caller reads back with `pl.load`
- Flat 2D `[NR*MAX_RECV, SIZE]` layout avoids ptoas 3D tile alignment issues
- InCore-only — HOST orchestration calls are rejected
- Also adds `all_to_all` and `all_to_all_v` to `GetWriteTargetExpr` / `AnalyzeCallAccess` in `convert_tensor_to_tile_ops_pass.cpp`

## Test plan

- [ ] UT: `test_distributed_ops.py` — deducer accept/reject (window input, 2D signal, send/recv counts)
- [ ] UT: `test_lower_composite_ops.py` — runtime-bounded push, HOST reject, loop reject
- [ ] UT: `test_convert_tensor_to_tile_ops.py` — send_counts stays In; target/signal/recv_counts InOut
- [ ] ST: `test_l3_tensor_all_to_all_v_intrinsic.py` (P=2 / P=4) — validates data + published `recv_counts`