### PR TITLE
fix(ir): dual-dispatch manual no-split pipe groups

### DIFF
--- a/src/ir/transforms/expand_mixed_kernel_pass.cpp
+++ b/src/ir/transforms/expand_mixed_kernel_pass.cpp
@@ -1502,38 +1502,43 @@ class KernelCallCounter : public IRVisitor {
 /// zero-valid-shape replay on lane 1 so every hardware pipe handshake is
 /// balanced. Auto-expanded mixed kernels are stamped in ExpandMixedFunction;
 /// hand-written AIC/AIV Groups need the same inference here.
-class NoSplitCrossCorePipeCollector : public IRVisitor {
+class NoSplitCrossCoreTransportCollector : public IRVisitor {
  public:
-  [[nodiscard]] bool UsesNoSplitPipeOnly() const { return uses_pipe_ && !uses_split_pipe_; }
+  [[nodiscard]] bool UsesNoSplitTransportOnly() const { return uses_transport_ && !uses_split_transport_; }
 
  protected:
   void VisitExpr_(const CallPtr& op) override {
-    if (op_predicates::IsInitializePipe(op)) {
-      uses_pipe_ = true;
-    } else if (op_predicates::IsTPush(op) || op_predicates::IsTPop(op) || op_predicates::IsTFree(op)) {
-      uses_pipe_ = true;
-      uses_split_pipe_ = uses_split_pipe_ || op->GetKwarg<int>("split", 0) != 0;
+    if (op_predicates::IsTPush(op) || op_predicates::IsTPop(op) || op_predicates::IsTFree(op)) {
+      uses_transport_ = true;
+      uses_split_transport_ = uses_split_transport_ || op->GetKwarg<int>("split", 0) != 0;
     }
     IRVisitor::VisitExpr_(op);
   }
 
  private:
-  bool uses_pipe_ = false;
-  bool uses_split_pipe_ = false;
+  bool uses_transport_ = false;
+  bool uses_split_transport_ = false;
 };
 
 bool NeedsInferredNoSplitDualAivDispatch(const FunctionPtr& func) {
-  if (!func || func->func_type_ != FunctionType::AIV || !pypto::backend::BackendConfig::IsConfigured() ||
-      !PassContext::Current()->GetBackendHandler()->RequiresNoSplitDualAivDispatch() ||
+  if (!func || func->func_type_ != FunctionType::AIV || !pypto::backend::BackendConfig::IsConfigured()) {
+    return false;
+  }
+  const auto* pass_context = PassContext::Current();
+  const auto* backend_handler = pass_context ? pass_context->GetBackendHandler()
+                                             : pypto::backend::BackendConfig::GetBackend()->GetHandler();
+  if (!backend_handler->RequiresNoSplitDualAivDispatch() ||
       func->GetAttr<bool>(kDualAivDispatchAttr, false) || func->HasAttr("external_source") ||
       func->requires_runtime_binding_) {
     return false;
   }
-  if (auto mode = func->GetSplitMode(); mode.has_value() && *mode != SplitMode::None) return false;
+  if (auto mode = func->GetSplitMode(); mode.has_value() && *mode != SplitMode::None) {
+    return false;
+  }
 
-  NoSplitCrossCorePipeCollector collector;
+  NoSplitCrossCoreTransportCollector collector;
   collector.VisitStmt(func->body_);
-  return collector.UsesNoSplitPipeOnly();
+  return collector.UsesNoSplitTransportOnly();
 }
 
 FunctionPtr WithDualAivDispatch(const FunctionPtr& func) {

--- a/src/ir/transforms/expand_mixed_kernel_pass.cpp
+++ b/src/ir/transforms/expand_mixed_kernel_pass.cpp
@@ -23,6 +23,7 @@
 #include <utility>
 #include <vector>
 
+#include "pypto/backend/common/backend_config.h"
 #include "pypto/backend/common/backend_handler.h"
 #include "pypto/core/any_cast.h"
 #include "pypto/core/logging.h"
@@ -1496,6 +1497,56 @@ class KernelCallCounter : public IRVisitor {
   std::unordered_map<std::string, size_t> counts_;
 };
 
+/// Ascend910B no-split cross-core pipes need both AIV sub-lanes to execute:
+/// lane 0 performs the real work while SplitVectorKernel synthesizes a
+/// zero-valid-shape replay on lane 1 so every hardware pipe handshake is
+/// balanced. Auto-expanded mixed kernels are stamped in ExpandMixedFunction;
+/// hand-written AIC/AIV Groups need the same inference here.
+class NoSplitCrossCorePipeCollector : public IRVisitor {
+ public:
+  [[nodiscard]] bool UsesNoSplitPipeOnly() const { return uses_pipe_ && !uses_split_pipe_; }
+
+ protected:
+  void VisitExpr_(const CallPtr& op) override {
+    if (op_predicates::IsInitializePipe(op)) {
+      uses_pipe_ = true;
+    } else if (op_predicates::IsTPush(op) || op_predicates::IsTPop(op) || op_predicates::IsTFree(op)) {
+      uses_pipe_ = true;
+      uses_split_pipe_ = uses_split_pipe_ || op->GetKwarg<int>("split", 0) != 0;
+    }
+    IRVisitor::VisitExpr_(op);
+  }
+
+ private:
+  bool uses_pipe_ = false;
+  bool uses_split_pipe_ = false;
+};
+
+bool NeedsInferredNoSplitDualAivDispatch(const FunctionPtr& func) {
+  if (!func || func->func_type_ != FunctionType::AIV || !pypto::backend::BackendConfig::IsConfigured() ||
+      !PassContext::Current()->GetBackendHandler()->RequiresNoSplitDualAivDispatch() ||
+      func->GetAttr<bool>(kDualAivDispatchAttr, false) || func->HasAttr("external_source") ||
+      func->requires_runtime_binding_) {
+    return false;
+  }
+  if (auto mode = func->GetSplitMode(); mode.has_value() && *mode != SplitMode::None) return false;
+
+  NoSplitCrossCorePipeCollector collector;
+  collector.VisitStmt(func->body_);
+  return collector.UsesNoSplitPipeOnly();
+}
+
+FunctionPtr WithDualAivDispatch(const FunctionPtr& func) {
+  auto result = MutableCopy(func);
+  auto attrs = result->attrs_;
+  attrs.erase(std::remove_if(attrs.begin(), attrs.end(),
+                             [](const auto& kv) { return kv.first == kDualAivDispatchAttr; }),
+              attrs.end());
+  attrs.emplace_back(kDualAivDispatchAttr, true);
+  result->attrs_ = std::move(attrs);
+  return result;
+}
+
 bool IsCanonicalGroupMemberCall(const CallPtr& call, const FunctionPtr& callee, const FunctionPtr& group) {
   if (!call || !callee || !group) return false;
   if (call->args_.size() != group->params_.size() || callee->params_.size() != group->params_.size()) {
@@ -1699,19 +1750,22 @@ NormalizedGroups NormalizeHandWrittenGroupAbis(const ProgramPtr& program,
     // AIV-only Groups and pre-expansion Groups are handled by their existing
     // dispatch paths. A mixed Group needs exactly the shared AIC/AIV ABI here.
     if (!aic.inner_call || !aiv.inner_call) continue;
-    if (IsCanonicalGroupMemberCall(aic.inner_call, aic.inner_callee, group) &&
-        IsCanonicalGroupMemberCall(aiv.inner_call, aiv.inner_callee, group)) {
-      continue;
-    }
+    const bool needs_abi_normalization =
+        !IsCanonicalGroupMemberCall(aic.inner_call, aic.inner_callee, group) ||
+        !IsCanonicalGroupMemberCall(aiv.inner_call, aiv.inner_callee, group);
+    const bool needs_dual_aiv_dispatch = NeedsInferredNoSplitDualAivDispatch(aiv.inner_callee);
+    if (!needs_abi_normalization && !needs_dual_aiv_dispatch) continue;
 
-    CHECK_SPAN(
-        !aic.inner_callee->HasAttr("external_source") && !aiv.inner_callee->HasAttr("external_source") &&
-            !aic.inner_callee->requires_runtime_binding_ && !aiv.inner_callee->requires_runtime_binding_,
-        group->span_)
-        << "Mixed Group '" << group->name_
-        << "' has AIC/AIV members with different argument layouts. External or runtime-bound members "
-           "cannot be adapted; declare both members with the same signature and forward the Group's full "
-           "parameter list.";
+    if (needs_abi_normalization) {
+      CHECK_SPAN(
+          !aic.inner_callee->HasAttr("external_source") && !aiv.inner_callee->HasAttr("external_source") &&
+              !aic.inner_callee->requires_runtime_binding_ && !aiv.inner_callee->requires_runtime_binding_,
+          group->span_)
+          << "Mixed Group '" << group->name_
+          << "' has AIC/AIV members with different argument layouts. External or runtime-bound members "
+             "cannot be adapted; declare both members with the same signature and forward the Group's full "
+             "parameter list.";
+    }
 
     const bool exclusive_pair =
         call_counter.Count(aic.inner_callee->name_) == 1 && call_counter.Count(aiv.inner_callee->name_) == 1;
@@ -1726,6 +1780,7 @@ NormalizedGroups NormalizeHandWrittenGroupAbis(const ProgramPtr& program,
 
     auto normalized_aic = BuildGroupAbiAdapter(group, aic, aic_name, peer_renames);
     auto normalized_aiv = BuildGroupAbiAdapter(group, aiv, aiv_name, peer_renames);
+    if (needs_dual_aiv_dispatch) normalized_aiv = WithDualAivDispatch(normalized_aiv);
     if (exclusive_pair) {
       replacements[aic_name] = normalized_aic;
       replacements[aiv_name] = normalized_aiv;

--- a/tests/ut/codegen/test_orchestration_tensor_rw.py
+++ b/tests/ut/codegen/test_orchestration_tensor_rw.py
@@ -960,6 +960,8 @@ class TestTensorReadWriteOffsetCodegen:
                 v2c_buf = pl.reserve_buffer(name="submit_v2c", size=4096, base=pl.AUTO)
                 c2v_peer = pl.import_peer_buffer(name="submit_c2v", peer_func="vec_side")
                 pl.aic_initialize_pipe(c2v_peer, v2c_buf, dir_mask=3, slot_size=512)
+                tile = pl.load(q, [0, 0], [16, 16], target_memory=pl.MemorySpace.Mat)
+                pl.tpush_to_aiv(tile, split=0)
                 return sink
 
             @pl.function(type=pl.FunctionType.AIV)
@@ -971,6 +973,8 @@ class TestTensorReadWriteOffsetCodegen:
                 c2v_buf = pl.reserve_buffer(name="submit_c2v", size=4096, base=pl.AUTO)
                 v2c_peer = pl.import_peer_buffer(name="submit_v2c", peer_func="cube_side")
                 pl.aiv_initialize_pipe(c2v_buf, v2c_peer, dir_mask=3, slot_size=512)
+                tile = pl.tpop_from_aic(shape=[16, 16], dtype=pl.FP32, split=0)
+                pl.tfree_to_aic(tile, split=0)
                 return out
 
             @pl.function(type=pl.FunctionType.Orchestration)

--- a/tests/ut/codegen/test_orchestration_tensor_rw.py
+++ b/tests/ut/codegen/test_orchestration_tensor_rw.py
@@ -995,6 +995,7 @@ class TestTensorReadWriteOffsetCodegen:
         vec = transformed.get_function("vec_side")
         assert cube is not None
         assert vec is not None
+        assert vec.attrs.get("dual_aiv_dispatch") is True
         canonical_names = [param.name_hint for param in cube.params]
         assert canonical_names == [param.name_hint for param in vec.params]
         assert canonical_names[-1] == "__gm_pipe_buffer"
@@ -1008,6 +1009,15 @@ class TestTensorReadWriteOffsetCodegen:
         assert shape_values == ["512"], code
         assert "rt_submit_task" in code, code
         assert result.func_name_to_signature["cube_side"] == result.func_name_to_signature["vec_side"]
+        expected_mixed = (
+            result.func_name_to_id["cube_side"],
+            result.func_name_to_id["vec_side"],
+            result.func_name_to_id["vec_side"],
+        )
+        assert (
+            f"MixedKernels mixed_0 = {{{expected_mixed[0]}, {expected_mixed[1]}, {expected_mixed[2]}}};"
+            in code
+        )
         # The one shared task payload must contain all three Group tensors plus
         # the injected workspace; pre-fix it was built only from cube_side and
         # omitted ext_out, so vec_side unpacked q as its output/workspace.

--- a/tests/ut/ir/transforms/test_expand_mixed_kernel_a2a3.py
+++ b/tests/ut/ir/transforms/test_expand_mixed_kernel_a2a3.py
@@ -129,6 +129,50 @@ def test_hand_written_group_members_share_canonical_abi():
         assert [arg.name_hint for arg in call.args] == expected_names
 
 
+def test_hand_written_no_split_pipe_group_infers_dual_aiv_dispatch():
+    """910B explicit pipe members get the same lane-1 handshake replay as auto-expanded mixed kernels."""
+
+    @pl.program
+    class Program:
+        @pl.function(type=pl.FunctionType.AIC)
+        def cube_side(
+            self,
+            q: pl.Tensor[[16, 16], pl.FP32],
+            sink: pl.InOut[pl.Tensor[[16, 16], pl.FP32]],
+        ) -> pl.Tensor[[16, 16], pl.FP32]:
+            v2c = pl.reserve_buffer(name="probe_v2c", size=4096, base=pl.AUTO)
+            c2v_peer = pl.import_peer_buffer(name="probe_c2v", peer_func="vec_side")
+            pl.aic_initialize_pipe(c2v_peer, v2c, dir_mask=3, slot_size=512)
+            return sink
+
+        @pl.function(type=pl.FunctionType.AIV)
+        def vec_side(
+            self,
+            out: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+        ) -> pl.Tensor[[16, 16], pl.FP32]:
+            c2v = pl.reserve_buffer(name="probe_c2v", size=4096, base=pl.AUTO)
+            v2c_peer = pl.import_peer_buffer(name="probe_v2c", peer_func="cube_side")
+            pl.aiv_initialize_pipe(c2v, v2c_peer, dir_mask=3, slot_size=512)
+            tile = pl.tpop_from_aic(shape=[16, 16], dtype=pl.FP32, split=0)
+            pl.tfree_to_aic(tile, split=0)
+            return out
+
+        @pl.function(type=pl.FunctionType.Group)
+        def mixed(
+            self,
+            q: pl.Tensor[[16, 16], pl.FP32],
+            sink: pl.InOut[pl.Tensor[[16, 16], pl.FP32]],
+            out: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+        ) -> pl.Tensor[[16, 16], pl.FP32]:
+            self.cube_side(q, sink)
+            return self.vec_side(out)
+
+    after = _run_pipeline(Program)
+    vec = after.get_function("vec_side")
+    assert vec is not None
+    assert vec.attrs.get("dual_aiv_dispatch") is True
+
+
 def test_reused_hand_written_group_members_get_private_adapters():
     """A member used outside its Group keeps its original ABI."""
 


### PR DESCRIPTION
## Summary

- infer `dual_aiv_dispatch` for hand-written Ascend910B AIC/AIV Groups that use no-split cross-core pipes
- preserve standalone behavior by creating Group-private adapters when a member is reused elsewhere
- assert orchestration emits `{AIC, AIV, AIV}` so lane 1 replays the required zero-valid-shape handshake

Follow-up to #2104 and #2097. The shared Group ABI fix removed the argument mismatch, but the original manual-pipe case still hung because the AIV member was dispatched only on lane 0.

## Validation

- `cmake --build build --parallel 8`
- `test_expand_mixed_kernel_a2a3.py`: 20 passed
- issue regression in `test_orchestration_tensor_rw.py`: passed
- original unmodified `probe_manual_pipe_draft.py -p a2a3 -d 1` N=8 device run: PASS in 3.22s (runtime 2.41s)