### PR TITLE
fix(ci): Update pypto-lib model paths

### DIFF
--- a/.github/perf_baselines/qwen3_14b_decode.json
+++ b/.github/perf_baselines/qwen3_14b_decode.json
@@ -3,5 +3,5 @@
   "value": 1016.66,
   "threshold_pct": 15,
   "pypto_ref": "1eec39f1",
-  "notes": "makespan_us = the 'Total Test Time: <X> us' line from a --enable-l2-swimlane run. Captured from: python models/qwen3/14b/decode_layer.py -p a2a3 --enable-l2-swimlane --max-seq --seed 1234. value=median of 3 device runs (1098.12 / 1016.66 / 1011.98); observed run-to-run jitter ~8.5%, so threshold_pct=15 absorbs noise with margin. Refresh via PR when a perf change is intentional, and update pypto_ref to the capturing commit."
+  "notes": "makespan_us = the 'Total Test Time: <X> us' line from a --enable-l2-swimlane run. Captured from: python models/qwen3/14b/decode_fwd.py -p a2a3 --enable-l2-swimlane --max-seq --seed 1234. value=median of 3 device runs (1098.12 / 1016.66 / 1011.98); observed run-to-run jitter ~8.5%, so threshold_pct=15 absorbs noise with margin. Refresh via PR when a perf change is intentional, and update pypto_ref to the capturing commit."
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -667,7 +667,7 @@ jobs:
           pip-cache-name: pip-lib
           pto-isa-commit: ${{ needs.toolchain.outputs.pto_isa_commit }}
 
-      - name: Clone pypto-lib (Qwen3-14B + DeepSeek-V4 models)
+      - name: Clone pypto-lib (Qwen3-14B + DeepSeek-V4-Flash models)
         # $GITHUB_WORKSPACE/pypto-lib is a sibling of lib-checkout, so
         # actions/checkout won't clean it on a persistent self-hosted runner — a
         # leftover dir from a previous run makes `git clone` fail with
@@ -710,45 +710,45 @@ jobs:
       # CI only checks functional correctness; perf is noisy (~8.5% jitter) and
       # is sampled daily with multiple runs averaged to keep the signal stable.
 
-      - name: Run pypto-lib DeepSeek-V4 decode_attention_swa example
+      - name: Run pypto-lib DeepSeek-V4-Flash decode_attention_swa example
         env:
           PYTHONPATH: ${{ github.workspace }}/pypto-lib
         run: |
           source activate.sh
           task-submit --device "$DEVICE_ID" --timeout 3600 --max-time 1800 \
-            --run "source $GITHUB_WORKSPACE/lib-checkout/activate.sh && cd $GITHUB_WORKSPACE/pypto-lib && python models/deepseek/v4/decode_attention_swa.py -p a2a3 -d \$TASK_DEVICE"
+            --run "source $GITHUB_WORKSPACE/lib-checkout/activate.sh && cd $GITHUB_WORKSPACE/pypto-lib && python models/deepseek/v4-flash/decode_attention_swa.py -p a2a3 -d \$TASK_DEVICE"
 
-      - name: Run pypto-lib DeepSeek-V4 decode_attention_hca example
+      - name: Run pypto-lib DeepSeek-V4-Flash decode_attention_hca example
         env:
           PYTHONPATH: ${{ github.workspace }}/pypto-lib
         run: |
           source activate.sh
           task-submit --device "$DEVICE_ID" --timeout 3600 --max-time 1800 \
-            --run "source $GITHUB_WORKSPACE/lib-checkout/activate.sh && cd $GITHUB_WORKSPACE/pypto-lib && python models/deepseek/v4/decode_attention_hca.py -p a2a3 -d \$TASK_DEVICE"
+            --run "source $GITHUB_WORKSPACE/lib-checkout/activate.sh && cd $GITHUB_WORKSPACE/pypto-lib && python models/deepseek/v4-flash/decode_attention_hca.py -p a2a3 -d \$TASK_DEVICE"
 
-      - name: Run pypto-lib DeepSeek-V4 prefill_attention_csa example
+      - name: Run pypto-lib DeepSeek-V4-Flash prefill_attention_csa example
         env:
           PYTHONPATH: ${{ github.workspace }}/pypto-lib
         run: |
           source activate.sh
           task-submit --device "$DEVICE_ID" --timeout 3600 --max-time 1800 \
-            --run "source $GITHUB_WORKSPACE/lib-checkout/activate.sh && cd $GITHUB_WORKSPACE/pypto-lib && python models/deepseek/v4/prefill_attention_csa.py -p a2a3 -d \$TASK_DEVICE"
+            --run "source $GITHUB_WORKSPACE/lib-checkout/activate.sh && cd $GITHUB_WORKSPACE/pypto-lib && python models/deepseek/v4-flash/prefill_attention_csa.py -p a2a3 -d \$TASK_DEVICE"
 
-      - name: Run pypto-lib DeepSeek-V4 prefill_attention_hca example
+      - name: Run pypto-lib DeepSeek-V4-Flash prefill_attention_hca example
         env:
           PYTHONPATH: ${{ github.workspace }}/pypto-lib
         run: |
           source activate.sh
           task-submit --device "$DEVICE_ID" --timeout 3600 --max-time 1800 \
-            --run "source $GITHUB_WORKSPACE/lib-checkout/activate.sh && cd $GITHUB_WORKSPACE/pypto-lib && python models/deepseek/v4/prefill_attention_hca.py -p a2a3 -d \$TASK_DEVICE"
+            --run "source $GITHUB_WORKSPACE/lib-checkout/activate.sh && cd $GITHUB_WORKSPACE/pypto-lib && python models/deepseek/v4-flash/prefill_attention_hca.py -p a2a3 -d \$TASK_DEVICE"
 
-      - name: Run pypto-lib DeepSeek-V4 prefill_attention_swa example
+      - name: Run pypto-lib DeepSeek-V4-Flash prefill_attention_swa example
         env:
           PYTHONPATH: ${{ github.workspace }}/pypto-lib
         run: |
           source activate.sh
           task-submit --device "$DEVICE_ID" --timeout 3600 --max-time 1800 \
-            --run "source $GITHUB_WORKSPACE/lib-checkout/activate.sh && cd $GITHUB_WORKSPACE/pypto-lib && python models/deepseek/v4/prefill_attention_swa.py -p a2a3 -d \$TASK_DEVICE"
+            --run "source $GITHUB_WORKSPACE/lib-checkout/activate.sh && cd $GITHUB_WORKSPACE/pypto-lib && python models/deepseek/v4-flash/prefill_attention_swa.py -p a2a3 -d \$TASK_DEVICE"
 
       - name: Kill orphaned task-submit tasks
         if: always()

--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -167,7 +167,7 @@ jobs:
           pip-cache-name: pip-perf
           pto-isa-commit: ${{ needs.toolchain.outputs.pto_isa_commit }}
 
-      - name: Clone pypto-lib (Qwen3-14B decode)
+      - name: Clone pypto-lib (Qwen3-14B decode forward)
         # $GITHUB_WORKSPACE/pypto-lib is a sibling of the perf-checkout checkout
         # path, so actions/checkout won't clean it on a persistent self-hosted
         # runner — a leftover dir from a previous run makes `git clone` fail with
@@ -197,7 +197,7 @@ jobs:
           for i in $(seq 1 5); do
             echo "=== qwen3 decode perf sample $i/5 ==="
             task-submit --device "$DEVICE_ID" --timeout 3600 --max-time 1800 \
-              --run "source $GITHUB_WORKSPACE/perf-checkout/activate.sh && cd $GITHUB_WORKSPACE/pypto-lib && python models/qwen3/14b/decode_layer.py -p a2a3 -d \$TASK_DEVICE --enable-l2-swimlane --max-seq --seed 1234" \
+              --run "source $GITHUB_WORKSPACE/perf-checkout/activate.sh && cd $GITHUB_WORKSPACE/pypto-lib && python models/qwen3/14b/decode_fwd.py -p a2a3 -d \$TASK_DEVICE --enable-l2-swimlane --max-seq --seed 1234" \
               2>&1 | tee -a "$GITHUB_WORKSPACE/qwen3_perf.log" \
               || echo "WARN: perf sample $i exited non-zero"
           done
@@ -210,7 +210,7 @@ jobs:
           python .github/scripts/perf_guard.py
           --log "$GITHUB_WORKSPACE/qwen3_perf.log"
           --baseline .github/perf_baselines/qwen3_14b_decode.json
-          --name "qwen3-14b decode_layer"
+          --name "qwen3-14b decode_fwd"
           --metric makespan_us
 
       - name: Kill orphaned task-submit tasks


### PR DESCRIPTION
## Summary
- update DeepSeek V4 model CI commands to use the new `models/deepseek/v4-flash/` directory
- update the Qwen3 daily performance command from `decode_layer.py` to `decode_fwd.py`
- keep the Qwen3 performance baseline metadata aligned with the executable command

## Testing
- parsed `.github/workflows/ci.yml` and `.github/workflows/daily_ci.yml` with PyYAML
- parsed `.github/perf_baselines/qwen3_14b_decode.json`
- verified every referenced pypto-lib model target exists at pypto-lib `main` (`72ee6a1`)
- `git diff --check`

Hardware model jobs were not run locally; this change only updates CI paths after upstream file moves.