### PR TITLE
chore(codex): Link shared skills for discovery

### DIFF
--- a/.agents/skills
+++ b/.agents/skills
@@ -1,0 +1,1 @@
+../.claude/skills


### PR DESCRIPTION
## Summary
- expose the existing repository skills through Codex native `.agents/skills` discovery
- keep `.claude/skills` as the single source of truth via a relative symlink

## Testing
- focused pre-commit code review passed
- verified Git records `.agents/skills` as symlink mode `120000`
- verified all 13 `SKILL.md` files resolve through the link
- runtime tests skipped because this is a repository configuration-only change