### PR TITLE
chore(runtime): update Simpler to 3165cc89

### DIFF
--- a/docs/en/dev/03-logging.md
+++ b/docs/en/dev/03-logging.md
@@ -25,7 +25,8 @@ each level.
 
 ### Levels
 
-`LogLevel` is a coarse enum exposed in [python/pypto/pypto_core/logging.pyi:18](../../../python/pypto/pypto_core/logging.pyi#L18):
+`LogLevel` is a coarse enum exposed in
+[python/pypto/pypto_core/logging.pyi](../../../python/pypto/pypto_core/logging.pyi):
 
 | Value | Name | Use |
 | ----- | ---- | --- |
@@ -67,7 +68,7 @@ launching kernels, waiting on tasks, or tearing down the worker flows
 through here.
 
 The user-facing entry point lives in
-[python/pypto/runtime/log_config.py:38](../../../python/pypto/runtime/log_config.py#L38):
+[python/pypto/runtime/log_config.py](../../../python/pypto/runtime/log_config.py):
 
 ```python
 from pypto.runtime import configure_log, log_level
@@ -103,7 +104,7 @@ visible while ordinary INFO and DEBUG traffic stays silent.
 | `sync_pypto` | `bool` (default `False`) | When `True`, also push the closest `LogLevel` band onto PyPTO's C++ logger — useful when you want a single knob to cover both subsystems. |
 
 The band mapping used by `sync_pypto=True`
-([log_config.py:63-81](../../../python/pypto/runtime/log_config.py#L63-L81)):
+([log_config.py](../../../python/pypto/runtime/log_config.py)):
 
 | runtime threshold | PyPTO `LogLevel` |
 | ----------------- | ---------------- |
@@ -144,7 +145,7 @@ env bootstrap chose.
 ## 3. pytest options (`tests/st/`)
 
 The integration-test harness exposes both subsystems as CLI options
-([tests/st/conftest.py:157-170](../../../tests/st/conftest.py#L157-L170)).
+([tests/st/conftest.py](../../../tests/st/conftest.py)).
 They are applied in `pytest_configure` so collection-time logs already
 respect them.
 

--- a/docs/en/dev/03-logging.md
+++ b/docs/en/dev/03-logging.md
@@ -72,29 +72,28 @@ The user-facing entry point lives in
 ```python
 from pypto.runtime import configure_log, log_level
 
-configure_log("v7")                # finer than INFO, coarser than DEBUG
-print(log_level())                 # → 22  (Python logging int)
+configure_log("timing")            # stable performance markers, but no INFO chatter
+print(log_level())                 # → 25  (Python logging int)
 ```
 
 ### Levels
 
-The runtime logger uses a finer band than PyPTO's C++ enum. The canonical
-table lives in
+The runtime logger has a dedicated timing tier that PyPTO's C++ enum does not.
+The canonical table lives in
 [runtime/simpler_setup/log_config.py](../../../runtime/simpler_setup/log_config.py)
 and `pypto.runtime.configure_log()` delegates parsing there:
 
 | Name(s) | Python `logging` int | Notes |
 | ------- | -------------------- | ----- |
 | `debug` | 10 | full verbosity |
-| `v0` .. `v9` | 15..24 | INFO sub-tiers; `v5` == `info` (20) |
-| `info` | 20 | runtime default |
+| `info` | 20 | lifecycle and summary messages |
+| `timing` | 25 | runtime default; stable performance markers such as `[STRACE]` |
 | `warn` / `warning` | 30 | |
 | `error` | 40 | |
 | `null` | 60 | silence everything |
 
-`v0..v9` is what makes the runtime logger different from the PyPTO C++
-one: you get ten gradations inside INFO so noisy subsystems can be
-turned up without dropping back to full `debug`.
+At the default `timing` threshold, timing markers, warnings, and errors are
+visible while ordinary INFO and DEBUG traffic stays silent.
 
 ### `configure_log(level, *, sync_pypto=False)`
 
@@ -108,11 +107,14 @@ The band mapping used by `sync_pypto=True`
 
 | runtime threshold | PyPTO `LogLevel` |
 | ----------------- | ---------------- |
-| ≤14 | `DEBUG` |
-| 15..24 (`v0..v9`) | `INFO` |
-| 25..39 (`warn`) | `WARN` |
-| 40..59 (`error`) | `ERROR` |
-| ≥60 (`null`) | `NONE` |
+| ≤10 (`debug`) | `DEBUG` |
+| 11..20 (`info`) | `INFO` |
+| 21..30 (`timing` / `warn`) | `WARN` |
+| 31..40 (`error`) | `ERROR` |
+| ≥41 (`null`) | `NONE` |
+
+`timing` maps to `WARN` because PyPTO has no timing-only level; mapping it to
+`INFO` would also enable ordinary compiler information messages.
 
 Read back the effective threshold with
 `pypto.runtime.log_level()` (re-exported from `current_level()`).
@@ -125,12 +127,12 @@ Python:
 
 | Env var | Effect |
 | ------- | ------ |
-| `PYPTO_RUNTIME_LOG` | Same string accepted by `configure_log(level=...)`. Unset = keep the runtime logger at its V5 default. |
+| `PYPTO_RUNTIME_LOG` | Same string accepted by `configure_log(level=...)`. Unset = keep the runtime logger at its `timing` default. |
 | `PYPTO_RUNTIME_LOG_SYNC` | When `=1`, flips the default of `sync_pypto` to `True` for the env-var bootstrap. Ignored when `PYPTO_RUNTIME_LOG` is unset. |
 
 ```bash
-# Verbose runtime logs, leave PyPTO C++ untouched
-PYPTO_RUNTIME_LOG=v7 python -m my_test
+# Runtime lifecycle logs, leave PyPTO C++ untouched
+PYPTO_RUNTIME_LOG=info python -m my_test
 
 # One knob for both subsystems
 PYPTO_RUNTIME_LOG=debug PYPTO_RUNTIME_LOG_SYNC=1 python -m my_test
@@ -149,11 +151,11 @@ respect them.
 | Option | Default | Drives |
 | ------ | ------- | ------ |
 | `--pypto-log-level` | `ERROR` | PyPTO C++ logger via `set_log_level(LogLevel[name])` |
-| `--runtime-log-level` | unset (keeps `v5`) | PyPTO runtime logger via `configure_log(level)` — note this **does not** pass `sync_pypto=True` |
+| `--runtime-log-level` | unset (keeps `timing`) | PyPTO runtime logger via `configure_log(level)` — note this **does not** pass `sync_pypto=True` |
 
 ```bash
 # Quiet PyPTO compile chatter, verbose runtime logs
-pytest tests/st/ --pypto-log-level=ERROR --runtime-log-level=v8
+pytest tests/st/ --pypto-log-level=ERROR --runtime-log-level=info
 
 # Debug both
 pytest tests/st/ --pypto-log-level=DEBUG --runtime-log-level=debug
@@ -167,7 +169,7 @@ pytest tests/st/ --pypto-log-level=DEBUG --runtime-log-level=debug
 | See pass-by-pass tracing | `set_log_level(LogLevel.DEBUG)` |
 | Read perf hints on stderr | leave PyPTO at default `INFO` (or `PYPTO_LOG_LEVEL=info`) — see [passes/92-diagnostics.md](passes/92-diagnostics.md) |
 | Trace a hang at execute time | `configure_log("debug")` or `PYPTO_RUNTIME_LOG=debug` |
-| Bump only one noisy runtime subsystem | `configure_log("v7")` (V0..V9 is finer than `info`/`debug`) |
+| Show runtime lifecycle messages without DEBUG traffic | `configure_log("info")` or `PYPTO_RUNTIME_LOG=info` |
 | One env var to silence everything | `PYPTO_RUNTIME_LOG=null PYPTO_RUNTIME_LOG_SYNC=1 PYPTO_LOG_LEVEL=none` |
 
 ## 5. Common pitfalls

--- a/docs/en/dev/03-runtime-dfx.md
+++ b/docs/en/dev/03-runtime-dfx.md
@@ -354,7 +354,7 @@ python -m pypto.runtime.debug.replay build_output/_jit_xxx/ \
 hand-edited cpps are picked up. Pass `recompile=False` (or
 `--no-recompile`) when no cpp changed and you want to skip the rebuild.
 `--log-level` accepts the same values as `PYPTO_RUNTIME_LOG`
-(`debug`, `v0..v9`, `info`, `warn`, `error`, `null`); add
+(`debug`, `info`, `timing`, `warn`, `error`, `null`); add
 `--log-sync-pypto` to also push the band to PyPTO's C++ logger.
 
 Pass `validate=True` (or `--validate`) to compare each output tensor

--- a/docs/en/dev/03-runtime-dfx.md
+++ b/docs/en/dev/03-runtime-dfx.md
@@ -350,9 +350,15 @@ python -m pypto.runtime.debug.replay build_output/_jit_xxx/ \
     --pmu 2 --swimlane --log-level debug
 ```
 
-`recompile=True` (default) deletes cached `.so`/`.bin` artefacts so
+`recompile=True` (default) force-invalidates cached `.so`/`.bin` artefacts so
 hand-edited cpps are picked up. Pass `recompile=False` (or
-`--no-recompile`) when no cpp changed and you want to skip the rebuild.
+`--no-recompile`) to disable only that forced invalidation. Runtime / PTO-ISA
+compatibility checks still run and may invalidate and rebuild cached artefacts.
+Reuse also requires resolvable runtime and PTO-ISA identities. Runtime source
+checkouts must be clean; an installed runtime may instead use its embedded
+build commit. PTO-ISA currently must be a clean Git checkout. If either
+identity cannot be established, PyPTO fails closed and rebuilds instead of
+trusting the existing binaries.
 `--log-level` accepts the same values as `PYPTO_RUNTIME_LOG`
 (`debug`, `info`, `timing`, `warn`, `error`, `null`); add
 `--log-sync-pypto` to also push the band to PyPTO's C++ logger.

--- a/docs/en/dev/06-persistent-l3.md
+++ b/docs/en/dev/06-persistent-l3.md
@@ -85,7 +85,7 @@ worker execute multiple L3 DAGs concurrently.
 This implementation does not modify Simpler. Each queued request uses the
 public `Worker.run()` completion boundary. PyPTO detaches retained CommDomains
 from Simpler's per-run release set and releases them when the prepared worker
-closes. That retention currently depends on Simpler's private global
+closes. That retention currently depends on Simpler's private Worker-level
 live-domain registry and active run-resource journal (`_live_domains` and
 `_building_run_resources.live_domains`); a future public retention API should
 encapsulate this lifecycle.

--- a/docs/en/dev/06-persistent-l3.md
+++ b/docs/en/dev/06-persistent-l3.md
@@ -85,6 +85,7 @@ worker execute multiple L3 DAGs concurrently.
 This implementation does not modify Simpler. Each queued request uses the
 public `Worker.run()` completion boundary. PyPTO detaches retained CommDomains
 from Simpler's per-run release set and releases them when the prepared worker
-closes. That retention currently depends on Simpler's private live-domain and
-deferred-release hooks; a future public retention API should encapsulate this
-lifecycle.
+closes. That retention currently depends on Simpler's private global
+live-domain registry and active run-resource journal (`_live_domains` and
+`_building_run_resources.live_domains`); a future public retention API should
+encapsulate this lifecycle.

--- a/docs/en/dev/codegen/00-pto_codegen.md
+++ b/docs/en/dev/codegen/00-pto_codegen.md
@@ -596,8 +596,8 @@ The orchestration codegen generates identical orchestration C++ code using the P
 
 | Key | When emitted | Notes |
 | --- | ------------ | ----- |
-| `runtime` | Always | Currently `"tensormap_and_ringbuffer"` — the runtime requires 4 AICPU threads (3 schedulers + 1 orchestrator on thread 3). |
-| `aicpu_thread_num` | Always (`4`) | Dictated by the chosen runtime. |
+| `runtime` | Always | Currently `"tensormap_and_ringbuffer"`. |
+| `aicpu_thread_num` | Always (`0`) | `0` selects the runtime's architecture default (a2a3: 4; a5: 5); callers may explicitly override it. |
 
 ### Argument Unpacking
 

--- a/docs/en/user/00-getting_started.md
+++ b/docs/en/user/00-getting_started.md
@@ -164,7 +164,7 @@ exposed under both `device_wall_us_*` and shorter `device_us_*` names, with
 `samples` aliasing the raw `device_wall_us` list.
 
 `benchmark` reads timing from the `[STRACE]` markers (simpler PR #1177): it
-raises the runtime log level to `v9` for the worker's lifetime and captures
+sets the runtime log level to `timing` for the worker's lifetime and captures
 `stderr` at the fd level around the measured loop, so stderr emitted during the
 loop is diverted into a temp file rather than shown live. `device_wall_us` is a
 real on-NPU wall for L2 single-chip runs (see the L3 note below for distributed

--- a/docs/zh/dev/03-logging.md
+++ b/docs/zh/dev/03-logging.md
@@ -68,27 +68,27 @@ worker 阶段的所有日志都经此输出。
 ```python
 from pypto.runtime import configure_log, log_level
 
-configure_log("v7")                # 比 INFO 细，比 DEBUG 粗
-print(log_level())                 # → 22  (Python logging 整数)
+configure_log("timing")            # 保留稳定性能标记，不打开普通 INFO 日志
+print(log_level())                 # → 25  (Python logging 整数)
 ```
 
 ### 级别
 
-runtime 日志使用比 PyPTO C++ 更细的级别表，定义在
+runtime 日志提供了 PyPTO C++ 枚举中没有的独立 timing 档位，定义在
 [runtime/simpler_setup/log_config.py](../../../runtime/simpler_setup/log_config.py)，
 `pypto.runtime.configure_log()` 直接复用其 `parse_level`：
 
 | 名称 | Python `logging` 整数 | 说明 |
 | ---- | --------------------- | ---- |
 | `debug` | 10 | 全量详细 |
-| `v0` .. `v9` | 15..24 | INFO 子档；`v5` == `info` (20) |
-| `info` | 20 | runtime 默认 |
+| `info` | 20 | 生命周期与汇总信息 |
+| `timing` | 25 | runtime 默认；`[STRACE]` 等稳定性能标记 |
 | `warn` / `warning` | 30 | |
 | `error` | 40 | |
 | `null` | 60 | 全部静音 |
 
-`v0..v9` 是与 PyPTO C++ 日志的最大差异：在 INFO 内部细分 10 档，可在
-不切到 `debug` 的前提下单独放大某些噪声较多的子系统。
+默认 `timing` 阈值会显示 timing 标记、warning 和 error，同时屏蔽普通
+INFO 与 DEBUG 日志。
 
 ### `configure_log(level, *, sync_pypto=False)`
 
@@ -102,11 +102,14 @@ runtime 日志使用比 PyPTO C++ 更细的级别表，定义在
 
 | runtime 阈值 | PyPTO `LogLevel` |
 | ------------ | ---------------- |
-| ≤14 | `DEBUG` |
-| 15..24 (`v0..v9`) | `INFO` |
-| 25..39 (`warn`) | `WARN` |
-| 40..59 (`error`) | `ERROR` |
-| ≥60 (`null`) | `NONE` |
+| ≤10 (`debug`) | `DEBUG` |
+| 11..20 (`info`) | `INFO` |
+| 21..30 (`timing` / `warn`) | `WARN` |
+| 31..40 (`error`) | `ERROR` |
+| ≥41 (`null`) | `NONE` |
+
+`timing` 映射为 `WARN`，因为 PyPTO 没有只显示 timing 的档位；如果映射为
+`INFO`，普通编译器信息也会被一并打开。
 
 可用 `pypto.runtime.log_level()`（即 `current_level()` 的别名）回读
 当前生效阈值。
@@ -118,12 +121,12 @@ bootstrap，因此可以不写 Python，仅靠 shell 环境变量驱动：
 
 | 环境变量 | 作用 |
 | -------- | ---- |
-| `PYPTO_RUNTIME_LOG` | 接受与 `configure_log(level=...)` 相同的字符串；未设置则保持 runtime 日志的 `v5` 默认 |
+| `PYPTO_RUNTIME_LOG` | 接受与 `configure_log(level=...)` 相同的字符串；未设置则保持 runtime 日志的 `timing` 默认 |
 | `PYPTO_RUNTIME_LOG_SYNC` | 设为 `=1` 时把 bootstrap 阶段 `sync_pypto` 的默认值翻成 `True`；当 `PYPTO_RUNTIME_LOG` 未设置时被忽略 |
 
 ```bash
-# runtime 详细日志，不影响 PyPTO C++ 日志
-PYPTO_RUNTIME_LOG=v7 python -m my_test
+# runtime 生命周期日志，不影响 PyPTO C++ 日志
+PYPTO_RUNTIME_LOG=info python -m my_test
 
 # 一个开关同时管两套
 PYPTO_RUNTIME_LOG=debug PYPTO_RUNTIME_LOG_SYNC=1 python -m my_test
@@ -141,11 +144,11 @@ PYPTO_RUNTIME_LOG=debug PYPTO_RUNTIME_LOG_SYNC=1 python -m my_test
 | 选项 | 默认值 | 作用 |
 | ---- | ------ | ---- |
 | `--pypto-log-level` | `ERROR` | 通过 `set_log_level(LogLevel[name])` 控制 PyPTO C++ 日志 |
-| `--runtime-log-level` | 未设置（保留 `v5`） | 通过 `configure_log(level)` 控制 PyPTO runtime 日志；**不会** 同时传 `sync_pypto=True` |
+| `--runtime-log-level` | 未设置（保留 `timing`） | 通过 `configure_log(level)` 控制 PyPTO runtime 日志；**不会** 同时传 `sync_pypto=True` |
 
 ```bash
 # 抑制编译噪声，放大 runtime 日志
-pytest tests/st/ --pypto-log-level=ERROR --runtime-log-level=v8
+pytest tests/st/ --pypto-log-level=ERROR --runtime-log-level=info
 
 # 两侧都开 debug
 pytest tests/st/ --pypto-log-level=DEBUG --runtime-log-level=debug
@@ -159,7 +162,7 @@ pytest tests/st/ --pypto-log-level=DEBUG --runtime-log-level=debug
 | 查看 Pass 级跟踪 | `set_log_level(LogLevel.DEBUG)` |
 | 在 stderr 看到性能提示 | 保持 PyPTO 默认 `INFO`（或 `PYPTO_LOG_LEVEL=info`），详见 [passes/92-diagnostics.md](passes/92-diagnostics.md) |
 | 排查执行期 hang | `configure_log("debug")` 或 `PYPTO_RUNTIME_LOG=debug` |
-| 仅放大 runtime 的某个噪声子系统 | `configure_log("v7")`（V0..V9 比 `info`/`debug` 粒度更细） |
+| 不打开 DEBUG、只显示 runtime 生命周期信息 | `configure_log("info")` 或 `PYPTO_RUNTIME_LOG=info` |
 | 一条环境变量全部静音 | `PYPTO_RUNTIME_LOG=null PYPTO_RUNTIME_LOG_SYNC=1 PYPTO_LOG_LEVEL=none` |
 
 ## 5. 常见坑

--- a/docs/zh/dev/03-logging.md
+++ b/docs/zh/dev/03-logging.md
@@ -23,7 +23,7 @@ Diagnostics（`Warning`、`PerfHint`）；各级别在何处触发请参考
 ### 级别
 
 `LogLevel` 是一组较粗的枚举，定义见
-[python/pypto/pypto_core/logging.pyi:18](../../../python/pypto/pypto_core/logging.pyi#L18)：
+[python/pypto/pypto_core/logging.pyi](../../../python/pypto/pypto_core/logging.pyi)：
 
 | 值 | 名称 | 用途 |
 | -- | ---- | ---- |
@@ -63,7 +63,7 @@ python my_program.py
 worker 阶段的所有日志都经此输出。
 
 用户入口位于
-[python/pypto/runtime/log_config.py:38](../../../python/pypto/runtime/log_config.py#L38)：
+[python/pypto/runtime/log_config.py](../../../python/pypto/runtime/log_config.py)：
 
 ```python
 from pypto.runtime import configure_log, log_level
@@ -98,7 +98,7 @@ INFO 与 DEBUG 日志。
 | `sync_pypto` | `bool`，默认 `False` | 为 `True` 时同步把对应 band 的 `LogLevel` 推送给 PyPTO C++ 日志器，便于一个开关同时控制两套子系统 |
 
 `sync_pypto=True` 使用的 band 映射见
-[log_config.py:63-81](../../../python/pypto/runtime/log_config.py#L63-L81)：
+[log_config.py](../../../python/pypto/runtime/log_config.py)：
 
 | runtime 阈值 | PyPTO `LogLevel` |
 | ------------ | ---------------- |
@@ -137,7 +137,7 @@ PYPTO_RUNTIME_LOG=debug PYPTO_RUNTIME_LOG_SYNC=1 python -m my_test
 ## 3. pytest 选项（`tests/st/`）
 
 集成测试 harness 把两套子系统都暴露成命令行参数，定义见
-[tests/st/conftest.py:157-170](../../../tests/st/conftest.py#L157-L170)，
+[tests/st/conftest.py](../../../tests/st/conftest.py)，
 并在 `pytest_configure` 中提前应用，因此 collection 阶段的日志也会
 受影响。
 

--- a/docs/zh/dev/03-runtime-dfx.md
+++ b/docs/zh/dev/03-runtime-dfx.md
@@ -319,7 +319,7 @@ python -m pypto.runtime.debug.replay build_output/_jit_xxx/ \
 默认 `recompile=True` 会清掉缓存的 `.so` / `.bin`,确保手改的 cpp
 能被重新编译。如果没改 cpp、想跳过重编译,传 `recompile=False`
 （或 CLI 的 `--no-recompile`）即可。`--log-level` 接受和
-`PYPTO_RUNTIME_LOG` 相同的值（`debug`、`v0..v9`、`info`、`warn`、
+`PYPTO_RUNTIME_LOG` 相同的值（`debug`、`info`、`timing`、`warn`、
 `error`、`null`）;加上 `--log-sync-pypto` 可以把同一档位推到
 PyPTO 的 C++ logger。
 

--- a/docs/zh/dev/03-runtime-dfx.md
+++ b/docs/zh/dev/03-runtime-dfx.md
@@ -316,9 +316,14 @@ python -m pypto.runtime.debug.replay build_output/_jit_xxx/ \
     --pmu 2 --swimlane --log-level debug
 ```
 
-默认 `recompile=True` 会清掉缓存的 `.so` / `.bin`,确保手改的 cpp
-能被重新编译。如果没改 cpp、想跳过重编译,传 `recompile=False`
-（或 CLI 的 `--no-recompile`）即可。`--log-level` 接受和
+默认 `recompile=True` 会强制清掉缓存的 `.so` / `.bin`,确保手改的 cpp
+能被重新编译。`recompile=False`（或 CLI 的 `--no-recompile`）只关闭该
+强制失效；runtime / PTO-ISA 兼容性检查仍会运行，并可能清理和重建缓存产物。
+复用还要求 runtime 与 PTO-ISA 的身份都能确定。runtime 源码 checkout 必须
+保持干净；安装版 runtime 也可以使用内嵌的 build commit。PTO-ISA 目前必须是
+干净的 Git checkout。若任一身份无法确定，PyPTO 会按安全失败策略重新构建，
+而不会信任已有二进制。
+`--log-level` 接受和
 `PYPTO_RUNTIME_LOG` 相同的值（`debug`、`info`、`timing`、`warn`、
 `error`、`null`）;加上 `--log-sync-pypto` 可以把同一档位推到
 PyPTO 的 C++ logger。

--- a/docs/zh/dev/06-persistent-l3.md
+++ b/docs/zh/dev/06-persistent-l3.md
@@ -74,7 +74,7 @@ program 仍须满足原有的 platform、runtime 和 device ID 兼容性检查�
 
 该实现不修改 Simpler。每个 Queue 请求都使用公开的 `Worker.run()` completion
 boundary。PyPTO 会让 retained CommDomain 脱离 Simpler 的 per-run release set，
-并在 prepared worker 关闭时统一释放。目前该保留机制仍依赖 Simpler 私有的全局
-live-domain registry 和当前 run-resource journal（`_live_domains` 和
+并在 prepared worker 关闭时统一释放。目前该保留机制仍依赖 Simpler 私有的
+Worker 级 live-domain registry 和当前 run-resource journal（`_live_domains` 和
 `_building_run_resources.live_domains`）；后续应由公开的 retention API 封装该
 lifecycle。

--- a/docs/zh/dev/06-persistent-l3.md
+++ b/docs/zh/dev/06-persistent-l3.md
@@ -74,6 +74,7 @@ program 仍须满足原有的 platform、runtime 和 device ID 兼容性检查�
 
 该实现不修改 Simpler。每个 Queue 请求都使用公开的 `Worker.run()` completion
 boundary。PyPTO 会让 retained CommDomain 脱离 Simpler 的 per-run release set，
-并在 prepared worker 关闭时统一释放。目前该保留机制仍依赖 Simpler 私有的
-live-domain 和 deferred-release hook；后续应由公开的 retention API 封装该
+并在 prepared worker 关闭时统一释放。目前该保留机制仍依赖 Simpler 私有的全局
+live-domain registry 和当前 run-resource journal（`_live_domains` 和
+`_building_run_resources.live_domains`）；后续应由公开的 retention API 封装该
 lifecycle。

--- a/docs/zh/dev/codegen/00-pto_codegen.md
+++ b/docs/zh/dev/codegen/00-pto_codegen.md
@@ -584,8 +584,8 @@ output_dir/
 
 | 键 | 何时写入 | 备注 |
 | -- | -------- | ---- |
-| `runtime` | 总是 | 目前为 `"tensormap_and_ringbuffer"`——该运行时要求 4 个 AICPU 线程 (3 个调度器 + 1 个编排器位于 thread 3)。 |
-| `aicpu_thread_num` | 总是 (`4`) | 由所选运行时决定。 |
+| `runtime` | 总是 | 目前为 `"tensormap_and_ringbuffer"`。 |
+| `aicpu_thread_num` | 总是 (`0`) | `0` 选择 runtime 的架构默认值（a2a3：4；a5：5），调用方也可显式覆盖。 |
 
 ### 参数解包
 

--- a/docs/zh/user/00-getting_started.md
+++ b/docs/zh/user/00-getting_started.md
@@ -148,7 +148,7 @@ print(stats.device_wall_us_median, stats.device_wall_us_min, len(stats.samples))
 `device_wall_us` 列表的别名。
 
 `benchmark` 从 `[STRACE]` 标记读取计时（simpler PR #1177）：它在 worker 生命周期内
-将 runtime 日志级别提升到 `v9`，并在测量循环期间以 fd 级别捕获 `stderr`，因此循环
+将 runtime 日志级别设为 `timing`，并在测量循环期间以 fd 级别捕获 `stderr`，因此循环
 期间产生的 stderr 会被转存到临时文件，而非实时打印。`device_wall_us` 在 L2 单芯片
 运行时是真实的 NPU 墙钟（分布式见下方 L3 说明）；在未开启 `SIMPLER_HOST_STRACE` 的
 runtime 上或 `*sim` 平台上为 `0`（用 `stats.all_zero_device` 判断）。

--- a/examples/runtime/distributed_callback.py
+++ b/examples/runtime/distributed_callback.py
@@ -103,7 +103,7 @@ def run_with_callback() -> None:
     compiled = ir.compile(
         InspectProgram,
         platform=PLATFORM,
-        distributed_config=DistributedConfig(device_ids=[0], num_sub_workers=1, aicpu_thread_num=4),
+        distributed_config=DistributedConfig(device_ids=[0], num_sub_workers=1),
     )
 
     # Shared-memory IO, allocated BEFORE prepare() so the forked workers inherit
@@ -132,7 +132,7 @@ def show_missing_binding_error() -> None:
     compiled = ir.compile(
         InspectProgram,
         platform=PLATFORM,
-        distributed_config=DistributedConfig(device_ids=[0], num_sub_workers=1, aicpu_thread_num=4),
+        distributed_config=DistributedConfig(device_ids=[0], num_sub_workers=1),
     )
     try:
         compiled.prepare()  # no callbacks → inspect_result is unbound

--- a/python/pypto/backend/pto_backend.py
+++ b/python/pypto/backend/pto_backend.py
@@ -832,7 +832,7 @@ def _generate_config_file(
     runtime_lines = [
         "RUNTIME_CONFIG = {",
         '\t"runtime": "tensormap_and_ringbuffer",',
-        '\t"aicpu_thread_num": 4,',
+        '\t"aicpu_thread_num": 0,',
     ]
     if enable_sdma:
         runtime_lines.append('\t"enable_sdma": True,')
@@ -851,7 +851,7 @@ def _generate_config_file(
     lines = [
         *header,
         "# Runtime configuration for tensormap_and_ringbuffer.",
-        "# This runtime requires 4 AICPU threads (3 schedulers + 1 orchestrator on thread 3).",
+        "# AICPU thread count 0 selects the runtime's architecture default (a2a3: 4; a5: 5).",
         *runtime_lines,
         "ORCHESTRATION = {",
         f'\t"source": str(_ROOT_DIR / "orchestration" / "{orch_func_name}.cpp"),',

--- a/python/pypto/ir/distributed_compiled_program.py
+++ b/python/pypto/ir/distributed_compiled_program.py
@@ -71,14 +71,16 @@ class DistributedConfig:
             pipelining scenarios.
         runtime: Simpler runtime flavour. ``"tensormap_and_ringbuffer"`` (default)
             enables the tensor-map helpers and the ring-buffer DMA driver.
-        aicpu_thread_num: Number of aiCPU threads allocated to the simpler
-            runtime (3 schedulers + 1 dispatcher = 4 by default). Must be ≥ 1.
+        aicpu_thread_num: Number of AICPU threads allocated to the simpler
+            runtime. ``0`` (default) selects the architecture default (a2a3: 4;
+            a5: 5). Explicit normal-run values must be at least 2 and are
+            validated against the selected platform's limit by the runtime.
     """
 
     device_ids: list[int] = field(default_factory=lambda: [0])
     num_sub_workers: int = 0
     runtime: str = "tensormap_and_ringbuffer"
-    aicpu_thread_num: int = 4
+    aicpu_thread_num: int = 0
 
 
 class DistributedCompiledProgram:

--- a/python/pypto/runtime/_binary_cache.py
+++ b/python/pypto/runtime/_binary_cache.py
@@ -9,8 +9,6 @@
 
 """Compatibility stamps for generated kernel and orchestration binaries."""
 
-from __future__ import annotations
-
 import contextlib
 import fcntl
 import json
@@ -27,7 +25,7 @@ _BINARY_CONTEXT_FILENAME = "binary_context.json"
 
 @dataclass(frozen=True)
 class BinaryCacheContext:
-    """Inputs whose ABI/content determine whether generated binaries are reusable."""
+    """Runtime and PTO-ISA inputs checked before reusing generated binaries."""
 
     platform: str
     runtime_name: str
@@ -62,7 +60,7 @@ def binary_context_lock(work_dir: Path | str) -> Iterator[None]:
             fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
 
 
-def invalidate_binary_artifacts(work_dir: Path | str) -> int:
+def _invalidate_binary_artifacts(work_dir: Path | str) -> int:
     """Delete reusable binaries for one chip sub-build, preserving all sources."""
     work_dir = Path(work_dir)
     candidates: list[Path] = []
@@ -93,10 +91,9 @@ def invalidate_binary_context(work_dir: Path | str) -> int:
     deliberately not included in that count because it is metadata, not a
     generated binary.
     """
-    removed = invalidate_binary_artifacts(work_dir)
     with contextlib.suppress(FileNotFoundError):
         binary_context_path(work_dir).unlink()
-    return removed
+    return _invalidate_binary_artifacts(work_dir)
 
 
 def _read_binary_context(path: Path) -> dict[str, Any] | None:
@@ -108,17 +105,21 @@ def _read_binary_context(path: Path) -> dict[str, Any] | None:
 
 
 def prepare_binary_context(work_dir: Path | str, context: BinaryCacheContext | None) -> int:
-    """Invalidate binaries unless their recorded context exactly matches *context*.
+    """Begin a cache transaction, invalidating binaries with a mismatched context.
 
     ``None`` means that the current runtime identity cannot be established. In
-    that case cached binaries are never trusted and no compatibility stamp is
-    retained for a later call to mistake as reusable.
+    that case cached binaries are never trusted.  A matching stamp preserves
+    the binaries for this transaction, but the stamp itself is always discarded
+    before compilation starts.  A caller must write a fresh stamp only after all
+    binaries assemble successfully so an interrupted transaction fails closed.
 
     Returns the number of binary files removed.
     """
     stamp_path = binary_context_path(work_dir)
     cached = _read_binary_context(stamp_path)
     if context is not None and cached == context.to_dict():
+        with contextlib.suppress(FileNotFoundError):
+            stamp_path.unlink()
         return 0
 
     return invalidate_binary_context(work_dir)
@@ -151,7 +152,6 @@ __all__ = [
     "BinaryCacheContext",
     "binary_context_lock",
     "binary_context_path",
-    "invalidate_binary_artifacts",
     "invalidate_binary_context",
     "prepare_binary_context",
     "record_binary_context",

--- a/python/pypto/runtime/_binary_cache.py
+++ b/python/pypto/runtime/_binary_cache.py
@@ -1,0 +1,158 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Compatibility stamps for generated kernel and orchestration binaries."""
+
+from __future__ import annotations
+
+import contextlib
+import fcntl
+import json
+import os
+import tempfile
+from collections.abc import Iterator
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+_BINARY_CONTEXT_SCHEMA = 1
+_BINARY_CONTEXT_FILENAME = "binary_context.json"
+
+
+@dataclass(frozen=True)
+class BinaryCacheContext:
+    """Inputs whose ABI/content determine whether generated binaries are reusable."""
+
+    platform: str
+    runtime_name: str
+    runtime_revision: str
+    pto_isa_revision: str
+    schema: int = _BINARY_CONTEXT_SCHEMA
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def binary_context_path(work_dir: Path | str) -> Path:
+    """Return the compatibility-stamp path for one complete chip sub-build."""
+    return Path(work_dir) / "cache" / _BINARY_CONTEXT_FILENAME
+
+
+@contextlib.contextmanager
+def binary_context_lock(work_dir: Path | str) -> Iterator[None]:
+    """Serialize cache validation, compilation, and stamping for *work_dir*.
+
+    The lock file is intentionally persistent: removing it while another
+    process is waiting would let callers lock different inodes and enter the
+    same cache transaction concurrently.
+    """
+    lock_path = Path(work_dir) / "cache" / ".binary_context.lock"
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with lock_path.open("a+b") as lock_file:
+        fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+
+
+def invalidate_binary_artifacts(work_dir: Path | str) -> int:
+    """Delete reusable binaries for one chip sub-build, preserving all sources."""
+    work_dir = Path(work_dir)
+    candidates: list[Path] = []
+    cache_dir = work_dir / "cache"
+    if cache_dir.is_dir():
+        candidates.extend(cache_dir.glob("*.bin"))
+    for subdir in ("kernels", "orchestration"):
+        root = work_dir / subdir
+        if not root.is_dir():
+            continue
+        for extension in ("*.so", "*.o"):
+            candidates.extend(root.rglob(extension))
+
+    removed = 0
+    for path in candidates:
+        try:
+            path.unlink()
+        except FileNotFoundError:
+            continue
+        removed += 1
+    return removed
+
+
+def invalidate_binary_context(work_dir: Path | str) -> int:
+    """Delete reusable binaries and discard the context that authorized them.
+
+    Returns the number of binary files removed.  The compatibility stamp is
+    deliberately not included in that count because it is metadata, not a
+    generated binary.
+    """
+    removed = invalidate_binary_artifacts(work_dir)
+    with contextlib.suppress(FileNotFoundError):
+        binary_context_path(work_dir).unlink()
+    return removed
+
+
+def _read_binary_context(path: Path) -> dict[str, Any] | None:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def prepare_binary_context(work_dir: Path | str, context: BinaryCacheContext | None) -> int:
+    """Invalidate binaries unless their recorded context exactly matches *context*.
+
+    ``None`` means that the current runtime identity cannot be established. In
+    that case cached binaries are never trusted and no compatibility stamp is
+    retained for a later call to mistake as reusable.
+
+    Returns the number of binary files removed.
+    """
+    stamp_path = binary_context_path(work_dir)
+    cached = _read_binary_context(stamp_path)
+    if context is not None and cached == context.to_dict():
+        return 0
+
+    return invalidate_binary_context(work_dir)
+
+
+def record_binary_context(work_dir: Path | str, context: BinaryCacheContext | None) -> None:
+    """Atomically record *context* after all binaries assemble successfully."""
+    if context is None:
+        return
+
+    path = binary_context_path(work_dir)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(dir=path.parent, prefix=path.name + ".", suffix=".tmp")
+    try:
+        file = os.fdopen(fd, "w", encoding="utf-8")
+        fd = -1
+        with file:
+            json.dump(context.to_dict(), file, indent=2, sort_keys=True)
+            file.write("\n")
+        os.replace(tmp_name, path)
+    except BaseException:
+        if fd >= 0:
+            os.close(fd)
+        with contextlib.suppress(OSError):
+            os.unlink(tmp_name)
+        raise
+
+
+__all__ = [
+    "BinaryCacheContext",
+    "binary_context_lock",
+    "binary_context_path",
+    "invalidate_binary_artifacts",
+    "invalidate_binary_context",
+    "prepare_binary_context",
+    "record_binary_context",
+]

--- a/python/pypto/runtime/bench.py
+++ b/python/pypto/runtime/bench.py
@@ -22,10 +22,10 @@ Timing source (simpler PR #1177)
 ``Worker.run`` no longer returns a ``RunTiming``. The host runtime instead
 emits one ``[STRACE]`` marker line per stage to **stderr** on every launch
 (``fprintf(stderr, ...)`` from the C++ host logger, gated by the compile-time
-``SIMPLER_HOST_STRACE`` macro and emitted at the ``LOG_INFO_V9`` tier). This
+``SIMPLER_HOST_STRACE`` macro and emitted at the ``LOG_TIMING`` tier). This
 module therefore:
 
-1. raises the simpler runtime log level to ``v9`` so the markers print (the
+1. sets the simpler runtime log level to ``timing`` so the markers print (the
    C++ host logger is seeded from the Python logger snapshot at
    ``ChipWorker.init``), then restores the prior level afterward;
 2. redirects ``stderr`` at the file-descriptor level (``os.dup2`` — Python's
@@ -315,8 +315,8 @@ def _span_names() -> dict[str, str]:
         return dict(_LEGACY_SPAN_NAMES)
 
 
-# Runtime log level that makes the ``LOG_INFO_V9`` ``[STRACE]`` markers visible.
-_STRACE_LOG_LEVEL = "v9"
+# Runtime log level that makes the ``LOG_TIMING`` ``[STRACE]`` markers visible.
+_STRACE_LOG_LEVEL = "timing"
 
 # Metric name → the per-dispatch :class:`TraceInvocation` attribute it reads
 # (used by ``BenchmarkStats.per_dispatch`` / ``per_rank`` / ``per_round``).
@@ -1243,7 +1243,7 @@ def benchmark(
     arg building.
 
     Timing is read from the runtime's ``[STRACE]`` stderr markers (simpler PR
-    #1177): this raises the runtime log level to ``v9`` for the worker's
+    #1177): this sets the runtime log level to ``timing`` for the worker's
     lifetime (restored afterward) and captures ``stderr`` at the file-descriptor
     level, so the emitted stderr is diverted into a temp file rather than shown
     live. For L2 the capture wraps only the measured loop; for L3 it must wrap
@@ -1423,7 +1423,7 @@ def benchmark(
         raise RuntimeError(
             f"benchmark(): no [STRACE] markers captured across {warmup + rounds} launches. "
             "The runtime emits per-launch timing markers only when built with the "
-            "SIMPLER_HOST_STRACE macro (LOG_INFO_V9 tier); this runtime emitted none. "
+            "SIMPLER_HOST_STRACE macro (LOG_TIMING tier); this runtime emitted none. "
             "Rebuild the runtime with SIMPLER_HOST_STRACE enabled to read benchmark timing."
         )
     return stats

--- a/python/pypto/runtime/bench.py
+++ b/python/pypto/runtime/bench.py
@@ -1363,7 +1363,7 @@ def benchmark(
 
     # The C++ host logger that prints the ``[STRACE]`` markers is seeded from the
     # simpler Python logger snapshot at worker ``init`` (and inherited by the L3
-    # fork), so raise the level before constructing the worker. Restore afterward.
+    # fork), so set the level to ``timing`` before constructing the worker. Restore afterward.
     prior_level = current_level()
     configure_log(_STRACE_LOG_LEVEL)
     try:

--- a/python/pypto/runtime/builtins/collectives/all_to_all/templates/kernel_config.py.in
+++ b/python/pypto/runtime/builtins/collectives/all_to_all/templates/kernel_config.py.in
@@ -7,7 +7,7 @@ _ROOT_DIR = Path(__file__).parent
 
 RUNTIME_CONFIG = {
     "runtime": "tensormap_and_ringbuffer",
-    "aicpu_thread_num": 4,
+    "aicpu_thread_num": 0,
 }
 
 ORCHESTRATION = {

--- a/python/pypto/runtime/builtins/collectives/allgather/templates/kernel_config.py.in
+++ b/python/pypto/runtime/builtins/collectives/allgather/templates/kernel_config.py.in
@@ -7,7 +7,7 @@ _ROOT_DIR = Path(__file__).parent
 
 RUNTIME_CONFIG = {
     "runtime": "tensormap_and_ringbuffer",
-    "aicpu_thread_num": 4,
+    "aicpu_thread_num": 0,
 }
 
 ORCHESTRATION = {

--- a/python/pypto/runtime/builtins/collectives/allreduce/templates/kernel_config.py.in
+++ b/python/pypto/runtime/builtins/collectives/allreduce/templates/kernel_config.py.in
@@ -7,7 +7,7 @@ _ROOT_DIR = Path(__file__).parent
 
 RUNTIME_CONFIG = {
     "runtime": "tensormap_and_ringbuffer",
-    "aicpu_thread_num": 4,
+    "aicpu_thread_num": 0,
 }
 
 ORCHESTRATION = {

--- a/python/pypto/runtime/builtins/collectives/allreduce_ring/templates/kernel_config.py.in
+++ b/python/pypto/runtime/builtins/collectives/allreduce_ring/templates/kernel_config.py.in
@@ -7,7 +7,7 @@ _ROOT_DIR = Path(__file__).parent
 
 RUNTIME_CONFIG = {
     "runtime": "tensormap_and_ringbuffer",
-    "aicpu_thread_num": 4,
+    "aicpu_thread_num": 0,
     "block_dim": 1,
 }
 

--- a/python/pypto/runtime/builtins/collectives/barrier/templates/kernel_config.py.in
+++ b/python/pypto/runtime/builtins/collectives/barrier/templates/kernel_config.py.in
@@ -7,7 +7,7 @@ _ROOT_DIR = Path(__file__).parent
 
 RUNTIME_CONFIG = {
     "runtime": "tensormap_and_ringbuffer",
-    "aicpu_thread_num": 4,
+    "aicpu_thread_num": 0,
 }
 
 ORCHESTRATION = {

--- a/python/pypto/runtime/builtins/collectives/broadcast/templates/kernel_config.py.in
+++ b/python/pypto/runtime/builtins/collectives/broadcast/templates/kernel_config.py.in
@@ -7,7 +7,7 @@ _ROOT_DIR = Path(__file__).parent
 
 RUNTIME_CONFIG = {
     "runtime": "tensormap_and_ringbuffer",
-    "aicpu_thread_num": 4,
+    "aicpu_thread_num": 0,
 }
 
 ORCHESTRATION = {

--- a/python/pypto/runtime/builtins/collectives/reduce_scatter/templates/kernel_config.py.in
+++ b/python/pypto/runtime/builtins/collectives/reduce_scatter/templates/kernel_config.py.in
@@ -7,7 +7,7 @@ _ROOT_DIR = Path(__file__).parent
 
 RUNTIME_CONFIG = {
     "runtime": "tensormap_and_ringbuffer",
-    "aicpu_thread_num": 4,
+    "aicpu_thread_num": 0,
 }
 
 ORCHESTRATION = {

--- a/python/pypto/runtime/debug/replay.py
+++ b/python/pypto/runtime/debug/replay.py
@@ -116,10 +116,11 @@ def replay(
             corresponding host tensors.
         config: Run configuration (platform, device_id, DFX flags, ...).
             Defaults to ``RunConfig()``.
-        recompile: When ``True`` (default), invalidate cached kernel /
+        recompile: When ``True`` (default), force-invalidate cached kernel /
             orchestration binaries via :func:`invalidate_binary_cache` so
-            hand-edited cpps are picked up. Set to ``False`` to reuse
-            cached binaries (faster re-runs when no cpp has been modified).
+            hand-edited cpps are picked up. Set to ``False`` to skip only
+            this forced invalidation. Runtime / PTO-ISA compatibility checks
+            still invalidate and rebuild incompatible cached binaries.
         rebuild_from_pto: When ``True`` (default), before cache
             invalidation, scan ``ptoas/*.pto`` and rerun ``ptoas`` for any
             file newer than its sibling ``ptoas/<unit>.cpp``; the new body
@@ -188,7 +189,7 @@ def replay(
     if recompile:
         invalidate_binary_cache(work_dir)
     else:
-        print("[cpp->.so] reusing cached binaries (recompile=False)")
+        print("[cpp->.so] skipped forced invalidation; compatibility checks still apply (recompile=False)")
 
     print("[execute] running on device...")
     if is_l3:
@@ -328,7 +329,10 @@ def _main(
     parser.add_argument(
         "--no-recompile",
         action="store_true",
-        help="Reuse cached binaries (faster, but ignores cpp edits)",
+        help=(
+            "Skip forced invalidation for cpp edits; runtime/PTO-ISA compatibility "
+            "checks may still rebuild cached binaries"
+        ),
     )
     parser.add_argument(
         "--no-rebuild-from-pto",

--- a/python/pypto/runtime/debug/replay.py
+++ b/python/pypto/runtime/debug/replay.py
@@ -51,35 +51,12 @@ from types import ModuleType
 
 import torch
 
+from pypto.runtime._binary_cache import binary_context_lock, invalidate_binary_context
 from pypto.runtime.debug.pto_rebuild import rebuild_kernel_cpp_from_pto
 from pypto.runtime.device_tensor import DeviceTensor
 from pypto.runtime.runner import RunConfig, _DfxOpts, execute_compiled
 
 __all__ = ["replay", "invalidate_binary_cache"]
-
-
-def _invalidate_one_dir(base: Path) -> int:
-    """Remove cached binaries directly under *base*; return the count removed.
-
-    Deletes ``<base>/cache/*.bin`` (the pre-build cache written by
-    ``prebuild_binaries``) and the sibling ``.so`` / ``.o`` files under
-    ``<base>/kernels`` and ``<base>/orchestration``. CPP sources are untouched.
-    """
-    removed = 0
-    cache_dir = base / "cache"
-    if cache_dir.is_dir():
-        for f in cache_dir.glob("*.bin"):
-            f.unlink()
-            removed += 1
-    for sub in ("kernels", "orchestration"):
-        root = base / sub
-        if not root.is_dir():
-            continue
-        for ext in ("*.so", "*.o"):
-            for f in root.rglob(ext):
-                f.unlink()
-                removed += 1
-    return removed
 
 
 def invalidate_binary_cache(work_dir: Path | str) -> None:
@@ -102,12 +79,14 @@ def invalidate_binary_cache(work_dir: Path | str) -> None:
     can see the ``cpp -> .o`` rebuild path was taken.
     """
     work_dir = Path(work_dir)
-    removed = _invalidate_one_dir(work_dir)
+    with binary_context_lock(work_dir):
+        removed = invalidate_binary_context(work_dir)
     next_levels = work_dir / "next_levels"
     if next_levels.is_dir():
         for rank_dir in sorted(next_levels.iterdir()):
             if rank_dir.is_dir():
-                removed += _invalidate_one_dir(rank_dir)
+                with binary_context_lock(rank_dir):
+                    removed += invalidate_binary_context(rank_dir)
     if removed:
         print(f"[cpp->.so] invalidated {removed} cached binary file(s); cpp will rebuild")
     else:
@@ -361,7 +340,7 @@ def _main(
         default=None,
         metavar="LEVEL",
         help=(
-            "PyPTO runtime log level (debug, v0..v9, info, warn, error, null). "
+            "PyPTO runtime log level (debug, info, timing, warn, error, null). "
             "Equivalent to setting PYPTO_RUNTIME_LOG=<level> in the environment. "
             "Pass --log-sync-pypto to also push the band to PyPTO's C++ logger."
         ),

--- a/python/pypto/runtime/debug/run_script_writer.py
+++ b/python/pypto/runtime/debug/run_script_writer.py
@@ -105,7 +105,7 @@ CLI flags (forwarded to ``pypto.runtime.debug.replay._main``)
   --dep-gen                enable dep_gen profiling
   --no-recompile           reuse cached .so/.bin (ignores cpp edits)
   --no-rebuild-from-pto    skip ptoas/*.pto -> kernels/*.cpp rebuild
-  --log-level LEVEL        runtime log level: debug/v0..v9/info/warn/error/null
+  --log-level LEVEL        runtime log level: debug/info/timing/warn/error/null
   --log-sync-pypto         also push --log-level to PyPTO's C++ logger
   --validate               compare outputs vs. golden.py (auto-on if golden.py exists)
   --no-validate            skip golden validation; runs ``_user_compare`` instead

--- a/python/pypto/runtime/debug/run_script_writer.py
+++ b/python/pypto/runtime/debug/run_script_writer.py
@@ -103,7 +103,7 @@ CLI flags (forwarded to ``pypto.runtime.debug.replay._main``)
   --swimlane               enable L2 swimlane capture
   --dump-args [LEVEL]      dump per-task arguments to disk (bare=1 partial, 2 full)
   --dep-gen                enable dep_gen profiling
-  --no-recompile           reuse cached .so/.bin (ignores cpp edits)
+  --no-recompile           skip forced cpp-edit invalidation; compatibility checks may rebuild
   --no-rebuild-from-pto    skip ptoas/*.pto -> kernels/*.cpp rebuild
   --log-level LEVEL        runtime log level: debug/info/timing/warn/error/null
   --log-sync-pypto         also push --log-level to PyPTO's C++ logger
@@ -114,7 +114,8 @@ Examples:
   python {{this_file}} --pmu 2 --swimlane              # DFX-on run
   python {{this_file}} --log-level debug               # verbose runtime trace
   python {{this_file}} --no-validate                   # skip golden, run _user_compare
-  python {{this_file}} --no-recompile --no-rebuild-from-pto   # fast re-run, no rebuild
+  # Skip forced invalidation; compatibility checks still apply.
+  python {{this_file}} --no-recompile --no-rebuild-from-pto
 
 Run ``python {{this_file}} --help`` for the authoritative list — flags are
 defined in :func:`pypto.runtime.debug.replay._main`, not here, so the

--- a/python/pypto/runtime/device_runner.py
+++ b/python/pypto/runtime/device_runner.py
@@ -48,6 +48,12 @@ import torch
 
 from pypto._external_source import kernel_binary_cache_path
 
+from ._binary_cache import (
+    BinaryCacheContext,
+    binary_context_lock,
+    prepare_binary_context,
+    record_binary_context,
+)
 from .elf_parser import elf_build_id_64, extract_text_section
 from .kernel_compiler import KernelCompiler
 from .task_interface import (
@@ -170,6 +176,85 @@ def _read_runtime_pto_isa_pin() -> str | None:
         logger.warning(f"Runtime PTO-ISA pin at {pin_path} is empty; falling back to the latest remote HEAD")
         return None
     return commit
+
+
+def _clean_git_revision(repo_root: Path) -> tuple[bool, str | None]:
+    """Return ``(is_checkout, HEAD)`` when *repo_root* is a clean checkout.
+
+    ``is_checkout`` remains true for a dirty or unreadable checkout. Callers use
+    that distinction to avoid falling back to packaged revision metadata that
+    does not describe the source files which will actually be compiled.
+    """
+    if not (repo_root / ".git").exists():
+        return False, None
+    try:
+        revision_result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=str(repo_root),
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+        status_result = subprocess.run(
+            ["git", "status", "--porcelain=v1", "--untracked-files=normal"],
+            cwd=str(repo_root),
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return True, None
+
+    revision = revision_result.stdout.strip()
+    if (
+        revision_result.returncode != 0
+        or status_result.returncode != 0
+        or not revision
+        or status_result.stdout.strip()
+    ):
+        return True, None
+    return True, revision
+
+
+def _runtime_revision(compiler: KernelCompiler) -> str | None:
+    """Return the runtime source/build revision used by *compiler*."""
+    project_root = getattr(compiler, "project_root", None)
+    if project_root is not None:
+        is_checkout, revision = _clean_git_revision(Path(project_root))
+        if is_checkout:
+            return revision
+
+    # Wheels carry the runtime sources under simpler_setup/_assets without a
+    # .git directory. The runtime binding embeds the source commit at build time
+    # so the wheel still has a stable compatibility identity.
+    try:
+        task_interface = import_module("_task_interface")
+    except ImportError:
+        return None
+    revision = getattr(task_interface, "__build_commit__", "")
+    return revision.strip() if isinstance(revision, str) and revision.strip() else None
+
+
+def _current_binary_context(
+    compiler: KernelCompiler,
+    *,
+    platform: str,
+    runtime_name: str,
+    pto_isa_root: str,
+) -> BinaryCacheContext | None:
+    """Build the compatibility identity for generated binary reuse."""
+    runtime_revision = _runtime_revision(compiler)
+    _, pto_isa_revision = _clean_git_revision(Path(pto_isa_root))
+    if runtime_revision is None or pto_isa_revision is None:
+        return None
+    return BinaryCacheContext(
+        platform=platform,
+        runtime_name=runtime_name,
+        runtime_revision=runtime_revision,
+        pto_isa_revision=pto_isa_revision,
+    )
 
 
 def _clone_pto_isa(clone_path: Path, primary_url: str, fallback_url: str) -> bool:
@@ -616,6 +701,22 @@ def compile_and_assemble(
     work_dir: Path,
     platform: str,
 ) -> tuple[ChipCallable, str, dict[str, Any]]:
+    """Compile and assemble one chip artifact under a work-directory lock.
+
+    Serializing the complete cache transaction prevents concurrent callers
+    from pairing a context stamp with binaries produced for another runtime or
+    platform.
+    """
+    if not (work_dir / "kernel_config.py").exists():
+        raise _missing_kernel_config_error(work_dir)
+    with binary_context_lock(work_dir):
+        return _compile_and_assemble_locked(work_dir, platform)
+
+
+def _compile_and_assemble_locked(
+    work_dir: Path,
+    platform: str,
+) -> tuple[ChipCallable, str, dict[str, Any]]:
     """Compile kernels + orchestration from *work_dir*, assemble ``ChipCallable``.
 
     Reads ``kernel_config.py`` from *work_dir* to discover kernel sources,
@@ -638,6 +739,9 @@ def compile_and_assemble(
         FileNotFoundError: If ``kernel_config.py`` is missing. Compile-only
             artifacts include the detected ptoas configuration and recovery
             steps in the error.
+
+    Notes:
+        The caller must hold :func:`binary_context_lock` for *work_dir*.
     """
     # Load kernel_config.py
     config_path = work_dir / "kernel_config.py"
@@ -668,6 +772,39 @@ def compile_and_assemble(
 
     # Create compiler
     compiler = KernelCompiler(platform=platform)
+
+    # Generated binaries include runtime and PTO-ISA headers. A runtime bump can
+    # therefore make both cache/*.bin and source-adjacent .so/.o files ABI
+    # incompatible even though their paths did not change. Validate the whole
+    # sub-build before the first cache lookup; legacy artifacts have no stamp and
+    # are rebuilt once.
+    binary_context = _current_binary_context(
+        compiler,
+        platform=platform,
+        runtime_name=runtime_name,
+        pto_isa_root=pto_isa_root,
+    )
+    invalidated = prepare_binary_context(work_dir, binary_context)
+    if invalidated:
+        if binary_context is None:
+            logger.warning(
+                "Could not determine the current Simpler/PTO-ISA revision; invalidated %d cached "
+                "PyPTO binary file(s) under %s and will rebuild from generated C++",
+                invalidated,
+                work_dir,
+            )
+        else:
+            logger.info(
+                "Cached PyPTO binaries under %s have no matching build context for "
+                "runtime %s@%s, platform %s, PTO-ISA %s; invalidated %d file(s) and "
+                "will rebuild from generated C++",
+                work_dir,
+                runtime_name,
+                binary_context.runtime_revision[:12],
+                platform,
+                binary_context.pto_isa_revision[:12],
+                invalidated,
+            )
 
     # --- Parallel compilation ---
 
@@ -737,6 +874,11 @@ def compile_and_assemble(
     # ``func_name``, the shared AICPU entry symbol) so benchmark timing can be
     # attributed to a readable orchestration rather than an opaque hash.
     register_callable_identity(orch_so_binary, callable_display_name(orchestration))
+
+    # A stamp denotes a complete, successfully assembled binary set. Do not
+    # write it earlier: a failed kernel/orchestration compile must leave the
+    # partial cache untrusted on the next attempt.
+    record_binary_context(work_dir, binary_context)
 
     return chip_callable, runtime_name, runtime_config
 

--- a/python/pypto/runtime/distributed_runner.py
+++ b/python/pypto/runtime/distributed_runner.py
@@ -15,6 +15,7 @@ import ctypes
 import importlib.util
 import inspect
 import json
+import logging
 import queue
 import sys
 import threading
@@ -31,6 +32,8 @@ import torch
 
 from .device_tensor import DeviceTensor, StackedDeviceTensor
 from .runtime_base import Worker
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from pypto.ir.distributed_compiled_program import DistributedCompiledProgram, DistributedConfig
@@ -330,6 +333,37 @@ def _construct_worker(
         runtime=runtime_name,
         enable_sdma=enable_sdma,
     )
+
+
+def _close_local_worker(w: Any) -> None:
+    """Close a locally owned Worker, retrying incomplete Simpler cleanup once.
+
+    Simpler keeps failed cleanup-journal entries for the next ``close()`` call.
+    Local workers are not returned to the user, so give transient cleanup one
+    bounded retry here while still surfacing a persistent failure.
+    """
+    try:
+        w.close()
+    except BaseException as first_error:  # noqa: BLE001 - cleanup can preserve control-flow failures
+        try:
+            w.close()
+        except BaseException:  # noqa: BLE001 - surface the retry outcome
+            raise
+        if not isinstance(first_error, Exception):
+            # Cleanup completed, but KeyboardInterrupt/SystemExit must remain
+            # visible when there is no earlier operation failure to preserve.
+            raise
+
+
+def _close_local_worker_after_error(w: Any, operation: str) -> None:
+    """Best-effort cleanup without replacing an active operation failure."""
+    try:
+        _close_local_worker(w)
+    except BaseException:  # noqa: BLE001 - preserve the primary failure below
+        logger.exception(
+            "%s failed; Worker cleanup was interrupted or still failed after one retry",
+            operation,
+        )
 
 
 def _register_callables(
@@ -1073,9 +1107,13 @@ def execute_distributed(
             # build inside the timed dispatch. No-op without a prebuilt arena.
             w.init(prewarm_config=call_config)
             _dispatch(w, entry_fn, tensors, chip_cids, sub_ids, call_config, len(dc.device_ids))
-        finally:
+        except BaseException:  # noqa: BLE001 - cleanup must also run for interruption
             if w is not None:
-                w.close()
+                _close_local_worker_after_error(w, "one-shot distributed execution")
+            raise
+        else:
+            if w is not None:
+                _close_local_worker(w)
 
     dfx_base = output_dir / "dfx_outputs"
     swimlane = config is not None and config.enable_l2_swimlane
@@ -1376,15 +1414,13 @@ class DistributedWorker(Worker):
             # separate call into Simpler's private startup implementation.
             if self._persistent:
                 self._start_persistent_dispatcher()
-        except Exception:
+        except BaseException:  # noqa: BLE001 - partially built Workers still require cleanup
             if self._w is not None:
-                try:
-                    self._w.close()
-                except Exception:
-                    pass
+                _close_local_worker_after_error(self._w, "DistributedWorker construction")
             raise
 
         self._closed = False
+        self._close_complete = False
         # Live RegistrationHandles so close() can mark them closed. WeakSet
         # so handles that drop out of scope first don't pin DistributedWorker.
         self._handles: weakref.WeakSet[Any] = weakref.WeakSet()
@@ -2036,25 +2072,32 @@ class DistributedWorker(Worker):
             raise RuntimeError(f"DistributedWorker.{op}() called after close()")
 
     def close(self) -> None:
-        """Release the Worker and comm rootinfo file. Idempotent."""
-        if self._closed:
+        """Release runtime resources, retrying incomplete Worker cleanup."""
+        if self._close_complete:
             return
-        # Auto-free any DeviceTensors the caller forgot. Run BEFORE we set
-        # ``_closed`` so the per-op ``_require_open`` guard inside ``free``
-        # still admits these calls, and BEFORE we tear down the underlying
-        # worker so the free path is still live.
-        self._close_owned_tensors()
-        self._closed = True
-        # Mark every still-alive RegistrationHandle as closed so subsequent
-        # handle(...) calls raise instead of dispatching to a torn-down runtime.
-        for handle in list(self._handles):
-            handle._mark_closed()
-        self._handles.clear()
+        first_attempt = not self._closed
+        if first_attempt:
+            # Auto-free any DeviceTensors the caller forgot. Run BEFORE we set
+            # ``_closed`` so the per-op ``_require_open`` guard inside ``free``
+            # still admits these calls, and BEFORE we tear down the underlying
+            # worker so the free path is still live.
+            self._close_owned_tensors()
+            self._closed = True
+            # Mark every still-alive RegistrationHandle as closed so subsequent
+            # handle(...) calls raise instead of dispatching to a torn-down runtime.
+            for handle in list(self._handles):
+                handle._mark_closed()
+            self._handles.clear()
         try:
-            self._stop_persistent_dispatcher()
+            if first_attempt:
+                self._stop_persistent_dispatcher()
         finally:
             try:
                 self._w.close()
+                # Recent Simpler versions keep a cleanup journal when close()
+                # fails. Only mark cleanup complete after that journal drains,
+                # so a later close() can retry the underlying Worker.
+                self._close_complete = True
             finally:
                 self._inherited_host_tensors = ()
                 self._inherited_host_storage_ptrs.clear()

--- a/python/pypto/runtime/distributed_runner.py
+++ b/python/pypto/runtime/distributed_runner.py
@@ -1434,12 +1434,11 @@ class DistributedWorker(Worker):
         if not self._persistent:
             return
         live_domains = getattr(self._w, "_live_domains", None)
-        execute_pending = getattr(self._w, "_execute_pending_domain_releases", None)
         missing = []
         if not isinstance(live_domains, dict):
             missing.append("_live_domains")
-        if not callable(execute_pending):
-            missing.append("_execute_pending_domain_releases")
+        if not hasattr(self._w, "_building_run_resources"):
+            missing.append("_building_run_resources")
         if missing:
             raise RuntimeError(
                 "persistent distributed execution requires Simpler's private retention hooks: "
@@ -1465,24 +1464,40 @@ class DistributedWorker(Worker):
                     )
 
     def _detach_persistent_domain(self, handle: Any) -> None:
-        """Exclude a retained CommDomain from simpler's per-run release sweep."""
+        """Transfer one CommDomain from the current run to Worker ownership.
+
+        Simpler records a newly allocated domain in both the current
+        ``_RunResources.live_domains`` journal and ``Worker._live_domains``.
+        Remove only the run-local claim: the global entry must remain reachable
+        so ``Worker.close()`` can reclaim it if request finalization is
+        interrupted before the run is retired.
+        """
         live_domains = getattr(self._w, "_live_domains", None)
-        if not isinstance(live_domains, dict) or live_domains.get(handle.name) is not handle:
+        resources = getattr(self._w, "_building_run_resources", None)
+        run_live_domains = getattr(resources, "live_domains", None)
+        domain_lock = getattr(resources, "domain_lock", None)
+        if (
+            not isinstance(live_domains, dict)
+            or not isinstance(run_live_domains, dict)
+            or domain_lock is None
+        ):
             raise RuntimeError(
-                "persistent distributed execution requires Simpler's live-domain retention hook"
+                "persistent distributed execution requires Simpler's active per-run CommDomain journal"
             )
-        del live_domains[handle.name]
+        with domain_lock:
+            if bool(getattr(resources, "retired", False)):
+                raise RuntimeError("persistent CommDomain cannot be retained from an already-retired run")
+            if live_domains.get(handle.name) is not handle or run_live_domains.get(handle.name) is not handle:
+                raise RuntimeError(
+                    "persistent distributed execution could not transfer the CommDomain's run-local ownership"
+                )
+            del run_live_domains[handle.name]
 
     def _release_persistent_domains(
         self,
         domains_by_program: dict[str, dict[str, tuple[tuple[Any, ...], Any]]],
     ) -> None:
         """Release retained domains after the last request run-fence."""
-        execute_pending = getattr(self._w, "_execute_pending_domain_releases", None)
-        if not callable(execute_pending):
-            raise RuntimeError(
-                "persistent distributed execution requires Simpler's deferred domain-release hook"
-            )
         handles = [
             handle
             for program_domains in reversed(tuple(domains_by_program.values()))
@@ -1490,7 +1505,6 @@ class DistributedWorker(Worker):
         ]
         for handle in handles:
             handle.release()
-        execute_pending()
         not_freed = [handle for handle in handles if not bool(getattr(handle, "freed", False))]
         if not_freed:
             names = ", ".join(repr(handle.name) for handle in not_freed)
@@ -1567,19 +1581,17 @@ class DistributedWorker(Worker):
             if terminal is not None and terminal.error is None:
                 terminal.error = exc
         finally:
-            try:
-                self._release_persistent_domains(domains_by_program)
-            except BaseException as exc:  # noqa: BLE001 - surfaced by run/close
-                if self._persistent_error is None:
+            # A normally returned Worker.run() has completed every cleanup
+            # cursor step, including ``retire_domains``. Only then is the
+            # handle's captured owner guaranteed to free synchronously. On any
+            # request/finalization error, keep the global live-domain claim
+            # untouched and let Worker.close() perform its whole-tree sweep.
+            if self._persistent_error is None:
+                try:
+                    self._release_persistent_domains(domains_by_program)
+                except BaseException as exc:  # noqa: BLE001 - surfaced by close
                     self._persistent_error = exc
                     self._persistent_error_reported = False
-                elif self._persistent_error.__context__ is None:
-                    self._persistent_error.__context__ = exc
-                else:
-                    print(
-                        f"persistent CommDomain teardown also failed: {type(exc).__name__}: {exc}",
-                        file=sys.stderr,
-                    )
             terminal = self._persistent_terminal_request
             if terminal is not None:
                 terminal.keepalive.clear()
@@ -1657,42 +1669,31 @@ class DistributedWorker(Worker):
     # ------------------------------------------------------------------
     # Device memory primitives
     #
-    # Routed through the simpler Orchestrator facade (``Worker._orch``) rather
-    # than ``Worker.malloc`` etc.: the level>=3 branch of those wrappers calls
-    # ``self._orch._impl.<op>(...)``, but the orchestrator's C++ handle lives on
-    # ``_o`` (no ``_impl``), so ``Worker.malloc`` raises ``AttributeError``. The
-    # facade methods (``malloc(worker_id, size)`` etc.) are the working path the
-    # generated host_orch and runtime examples use. ``_orch`` exists because
-    # __init__ starts the hierarchy eagerly.
+    # Simpler's public Worker methods own lifecycle admission and serialize
+    # device control against close() and in-flight hierarchical runs. Keep all
+    # memory traffic on that public surface instead of bypassing its lease via
+    # the private Orchestrator facade.
     # ------------------------------------------------------------------
-
-    def _orch(self) -> Any:
-        orch = getattr(self._w, "_orch", None)
-        if orch is None:
-            raise RuntimeError(
-                "DistributedWorker worker has no active orchestrator; the chip hierarchy was not started."
-            )
-        return orch
 
     def malloc(self, nbytes: int, *, worker_id: int = 0) -> int:
         """Allocate ``nbytes`` on chip *worker_id*; returns a device pointer."""
         self._require_open("malloc")
-        return int(self._orch().malloc(worker_id, nbytes))
+        return int(self._w.malloc(nbytes, worker_id))
 
     def free(self, ptr: int, *, worker_id: int = 0) -> None:
         """Release a pointer previously returned by :meth:`malloc`."""
         self._require_open("free")
-        self._orch().free(worker_id, ptr)
+        self._w.free(ptr, worker_id)
 
     def copy_to(self, dst_dev_ptr: int, src_host_ptr: int, nbytes: int, *, worker_id: int = 0) -> None:
         """H2D copy: ``nbytes`` from host *src_host_ptr* to device *dst_dev_ptr*."""
         self._require_open("copy_to")
-        self._orch().copy_to(worker_id, dst_dev_ptr, src_host_ptr, nbytes)
+        self._w.copy_to(dst_dev_ptr, src_host_ptr, nbytes, worker_id)
 
     def copy_from(self, dst_host_ptr: int, src_dev_ptr: int, nbytes: int, *, worker_id: int = 0) -> None:
         """D2H copy: ``nbytes`` from device *src_dev_ptr* back to host *dst_host_ptr*."""
         self._require_open("copy_from")
-        self._orch().copy_from(worker_id, dst_host_ptr, src_dev_ptr, nbytes)
+        self._w.copy_from(dst_host_ptr, src_dev_ptr, nbytes, worker_id)
 
     # ``alloc_tensor`` / ``free_tensor`` are inherited from Worker ABC.
     # Only the two behaviours that genuinely differ from L2 are overridden below:

--- a/python/pypto/runtime/log_config.py
+++ b/python/pypto/runtime/log_config.py
@@ -70,7 +70,7 @@ def configure_log(level: int | str, *, sync_pypto: bool = False) -> None:
 
     Args:
         level: Python ``logging`` int (e.g. ``20``) or string (``"debug"``,
-            ``"v0".."v9"``, ``"info"``, ``"warn"``, ``"error"``, ``"null"``).
+            ``"info"``, ``"timing"``, ``"warn"``, ``"error"``, ``"null"``).
             Case-insensitive. See :data:`simpler_setup.log_config.LOG_LEVEL_CHOICES`.
         sync_pypto: When ``True``, also push the closest PyPTO ``LogLevel`` to
             the C++ side so both subsystems display the same band. Defaults to
@@ -89,19 +89,20 @@ def configure_log(level: int | str, *, sync_pypto: bool = False) -> None:
 def _sync_to_pypto(threshold: int) -> None:
     """Map the unified threshold onto PyPTO's coarser LogLevel enum.
 
-    Bands mirror :func:`simpler._log._split_threshold`:
-    ``<=14`` DEBUG, ``15..24`` (V0..V9) INFO, ``25..39`` WARN,
-    ``40..59`` ERROR, ``>=60`` NUL/NONE.
+    Bands follow the severity thresholds parsed by
+    :func:`simpler_setup.log_config.parse_level`. Simpler's TIMING tier maps
+    to PyPTO WARN because PyPTO has no timing-only level; mapping it to INFO
+    would also enable ordinary compiler information messages.
     """
     from pypto.pypto_core import LogLevel, set_log_level  # noqa: PLC0415
 
-    if threshold <= 14:
+    if threshold <= 10:
         set_log_level(LogLevel.DEBUG)
-    elif threshold <= 24:
+    elif threshold <= 20:
         set_log_level(LogLevel.INFO)
-    elif threshold <= 39:
+    elif threshold <= 30:
         set_log_level(LogLevel.WARN)
-    elif threshold <= 59:
+    elif threshold <= 40:
         set_log_level(LogLevel.ERROR)
     else:
         set_log_level(LogLevel.NONE)

--- a/src/backend/common/pto_ops_datamove.cpp
+++ b/src/backend/common/pto_ops_datamove.cpp
@@ -462,7 +462,7 @@ static std::string MakeGatherRowCodegenPTO(const CallPtr& op, codegen::CodegenBa
     // DN view: shape [C, R], strides [1, C] -> DN[i, j] aliases src[j, i].
     mv << dn_view << " = pto.make_tensor_view " << src_ptr << ", shape = [" << cols_code << ", " << rows_code
        << "], strides = [" << one_code << ", " << cols_code
-       << "] {layout = #pto.layout<dn>}: " << src_view_type;
+       << "] {layout = #pto.layout<dn>} : " << src_view_type;
     codegen.Emit(mv.str());
     // Read src[phys, col_off : col_off + c] presented as the DN column [c, 1]:
     // offsets [col_off, phys] (swapped). xfer_elems/xfer_codes are already in

--- a/src/backend/common/pto_ops_memory.cpp
+++ b/src/backend/common/pto_ops_memory.cpp
@@ -783,8 +783,8 @@ void RegisterMemoryOps(Backend& backend, const std::unordered_set<std::string>& 
       if (j > 0) oss << ", ";
       oss << stride_names[j];
     }
-    oss << "] {layout = #pto.layout<" << layout_str << ">}";
-    oss << ": !pto.tensor_view<";
+    oss << "] {layout = #pto.layout<" << layout_str << ">} : ";
+    oss << "!pto.tensor_view<";
     for (size_t j = 0; j < rank; ++j) {
       if (j > 0) oss << "x";
       oss << "?";

--- a/src/codegen/pto/pto_codegen.cpp
+++ b/src/codegen/pto/pto_codegen.cpp
@@ -1099,9 +1099,9 @@ void PTOCodegen::EmitMakeTensorViews(const FunctionPtr& func) {
       case ir::TensorLayout::ND:
         break;
     }
-    stream_ << " {layout = #pto.layout<" << layout_str << ">}";
+    stream_ << " {layout = #pto.layout<" << layout_str << ">} : ";
 
-    stream_ << ": !pto.tensor_view<";
+    stream_ << "!pto.tensor_view<";
     for (size_t j = 0; j < rank; ++j) {
       if (j > 0) stream_ << "x";
       stream_ << "?";

--- a/src/codegen/tensor_op_codegen.cpp
+++ b/src/codegen/tensor_op_codegen.cpp
@@ -160,10 +160,10 @@ REGISTER_ORCHESTRATION_OP(tensor_read, ("tensor.read")) {
   // tensor.read(tensor, indices_tuple) -> scalar value
   //
   // Emit a call to the runtime's get_tensor_data<T>(tensor, ndims, indices).
-  // The runtime spin-waits on the producer task in TensorMap (for
-  // internally-allocated tensors) before reading, and reads immediately for
-  // external tensors with no producer entry. Using the API uniformly avoids
-  // both the missing producer-sync bug and the type-unsafe raw deref via
+  // The runtime owns the access policy: host-build-graph reads the registered
+  // host staging view of an external tensor and rejects task-produced tensors,
+  // while other runtimes may synchronize with a producer. Using the API
+  // uniformly preserves that policy and avoids the type-unsafe raw deref via
   // buffer.addr that a direct static_cast<T*>(ptr)[idx] would imply.
   CHECK(op->args_.size() == 2) << "tensor.read requires 2 arguments";
 
@@ -210,11 +210,10 @@ REGISTER_ORCHESTRATION_OP(tensor_write, ("tensor.write")) {
   // tensor.write(tensor, indices_tuple, value) -> write scalar value to tensor at indices
   //
   // Emit a call to the runtime's set_tensor_data<T>(tensor, ndims, indices, value).
-  // The runtime spin-waits on the producer task in TensorMap (and any
-  // tracked INOUT consumers) before writing, so cross-thread WAW/WAR
-  // hazards stay contained — same rationale as tensor.read using
-  // get_tensor_data<T>(). For external tensors with no TensorMap entry
-  // the write happens immediately (matches the previous raw store).
+  // The runtime owns the access policy: host-build-graph updates the registered
+  // host staging view of an external tensor and rejects task-produced tensors,
+  // while other runtimes may synchronize with producers and consumers. This is
+  // the same reason tensor.read uses get_tensor_data<T>() instead of a raw store.
   CHECK(op->args_.size() == 3) << "tensor.write requires 3 arguments";
 
   std::string input_name = codegen.TryGetVarName(op->args_[0]);

--- a/src/codegen/tensor_op_codegen.cpp
+++ b/src/codegen/tensor_op_codegen.cpp
@@ -161,7 +161,7 @@ REGISTER_ORCHESTRATION_OP(tensor_read, ("tensor.read")) {
   //
   // Emit a call to the runtime's get_tensor_data<T>(tensor, ndims, indices).
   // The runtime owns the access policy: host-build-graph reads the registered
-  // host staging view of an external tensor and rejects task-produced tensors,
+  // host view of an external tensor and does not support task-produced tensors,
   // while other runtimes may synchronize with a producer. Using the API
   // uniformly preserves that policy and avoids the type-unsafe raw deref via
   // buffer.addr that a direct static_cast<T*>(ptr)[idx] would imply.
@@ -211,7 +211,7 @@ REGISTER_ORCHESTRATION_OP(tensor_write, ("tensor.write")) {
   //
   // Emit a call to the runtime's set_tensor_data<T>(tensor, ndims, indices, value).
   // The runtime owns the access policy: host-build-graph updates the registered
-  // host staging view of an external tensor and rejects task-produced tensors,
+  // host view of an external tensor and does not support task-produced tensors,
   // while other runtimes may synchronize with producers and consumers. This is
   // the same reason tensor.read uses get_tensor_data<T>() instead of a raw store.
   CHECK(op->args_.size() == 3) << "tensor.write requires 3 arguments";

--- a/tests/st/conftest.py
+++ b/tests/st/conftest.py
@@ -195,8 +195,8 @@ def pytest_addoption(parser):
         "--runtime-log-level",
         action="store",
         default=None,
-        help="PyPTO runtime log level (debug, v0..v9, info, warn, error, null). "
-        "Default: leave the runtime logger at its V5/INFO default.",
+        help="PyPTO runtime log level (debug, info, timing, warn, error, null). "
+        "Default: leave the runtime logger at its TIMING default.",
     )
     parser.addoption(
         "--analyze-auto-scopes-for-deps",

--- a/tests/st/runtime/cross_core/test_cross_core_grouped_tpop_tfree.py
+++ b/tests/st/runtime/cross_core/test_cross_core_grouped_tpop_tfree.py
@@ -247,7 +247,7 @@ class TestCrossCoreGroupedTpopTfree:
                     platform,
                     runtime_name,
                     device_id,
-                    aicpu_thread_num=runtime_cfg.get("aicpu_thread_num", 4),
+                    aicpu_thread_num=runtime_cfg.get("aicpu_thread_num", 0),
                     output_prefix=output_prefix,
                     enable_l2_swimlane=test_config.enable_l2_swimlane,
                     enable_dump_args=test_config.enable_dump_args,

--- a/tests/st/runtime/framework_and_models/test_benchmark_st.py
+++ b/tests/st/runtime/framework_and_models/test_benchmark_st.py
@@ -13,7 +13,7 @@ The unit test (``tests/ut/runtime/test_benchmark.py``) mocks the worker and the
 stderr capture, so it only proves the parse / warmup-discard / aggregation
 logic. This system test runs a real kernel on device and exercises the full
 on-device path that the UT cannot: ``benchmark`` raising the runtime log level
-to ``v9``, fd-level capturing the host runtime's ``[STRACE]`` stderr markers
+to ``timing``, fd-level capturing the host runtime's ``[STRACE]`` stderr markers
 (simpler PR #1177), and parsing the *measured* per-launch ``device_wall_us``
 out of them.
 

--- a/tests/st/runtime/framework_and_models/test_benchmark_st.py
+++ b/tests/st/runtime/framework_and_models/test_benchmark_st.py
@@ -12,7 +12,7 @@
 The unit test (``tests/ut/runtime/test_benchmark.py``) mocks the worker and the
 stderr capture, so it only proves the parse / warmup-discard / aggregation
 logic. This system test runs a real kernel on device and exercises the full
-on-device path that the UT cannot: ``benchmark`` raising the runtime log level
+on-device path that the UT cannot: ``benchmark`` setting the runtime log level
 to ``timing``, fd-level capturing the host runtime's ``[STRACE]`` stderr markers
 (simpler PR #1177), and parsing the *measured* per-launch ``device_wall_us``
 out of them.

--- a/tests/st/runtime/framework_and_models/test_compiled_program.py
+++ b/tests/st/runtime/framework_and_models/test_compiled_program.py
@@ -222,8 +222,8 @@ class TestManualWorkerExtraction:
         b = torch.full((128, 128), 3.0, dtype=torch.float32)
         tile_add_128(a, b, torch.zeros_like(a), config=test_config)
         compiled = _get_cached_compiled(tile_add_128)
-        # 3, not the 4 baked into RUNTIME_CONFIG — otherwise the assert cannot
-        # tell an applied override from the default.
+        # 3, not the auto value baked into RUNTIME_CONFIG — otherwise the
+        # assertion cannot tell an applied override from the default.
         cfg = compiled.build_call_config(test_config, aicpu_thread_num=3)
         assert cfg.aicpu_thread_num == 3
         coerced, _ = _manual_dispatch(compiled, a, b, device_id=test_config.device_id, call_config=cfg)

--- a/tests/ut/backend/test_kernel_config_signature.py
+++ b/tests/ut/backend/test_kernel_config_signature.py
@@ -48,6 +48,7 @@ class TestKernelConfigSignature:
         )
         # ArgDirection import is present and the kernel carries the signature.
         assert "from simpler.task_interface import ArgDirection as _D" in text
+        assert '"aicpu_thread_num": 0' in text
         assert '"signature": [_D.IN, _D.IN, _D.INOUT]' in text
         # 3 non-SCALAR entries == payload tensor_count for the matmul (a, b, c).
         assert text.count("_D.") == 3

--- a/tests/ut/codegen/distributed/test_host_orch_distributed.py
+++ b/tests/ut/codegen/distributed/test_host_orch_distributed.py
@@ -807,6 +807,7 @@ def test_backend_materializes_builtin_next_level_files(tmp_path):
     assert "submit_allreduce_kernel<ReduceOp::kSum>" in entry_cpp
 
     kernel_config = files[f"{base}/kernel_config.py"]
+    assert '"aicpu_thread_num": 0' in kernel_config
     assert '"function_name": "aicpu_orchestration_entry"' in kernel_config
     assert '"signature": [_D.INOUT, _D.INOUT]' in kernel_config
 
@@ -1164,6 +1165,7 @@ def test_host_collective_builtin_template_package_exists(package_name, variant):
     assert templates.is_dir(), f"missing templates/ for {package_name}"
     for name in ("entry.cpp.in", "kernel.cpp.in", "kernel_config.py.in"):
         assert (templates / name).is_file(), f"missing {name} in {package_name}"
+    assert '"aicpu_thread_num": 0' in (templates / "kernel_config.py.in").read_text()
     assert (root / "__init__.py").is_file(), f"missing __init__.py in {package_name}"
     assert variant.startswith("builtin.tensor."), variant
 

--- a/tests/ut/codegen/test_orchestration_codegen.py
+++ b/tests/ut/codegen/test_orchestration_codegen.py
@@ -216,8 +216,8 @@ class TestOrchestration:
         assert "c_ci.set_initial_value(0);" in code
 
     def test_tensor_read(self):
-        """Test tensor.read emits get_tensor_data<T>() so the runtime spin-waits
-        on the producer task before reading (no raw host buffer deref)."""
+        """tensor.read delegates access policy to get_tensor_data<T>() instead
+        of dereferencing a host buffer directly."""
         backend.reset_for_testing()
         backend.set_backend_type(BackendType.Ascend910B)
 
@@ -250,9 +250,9 @@ class TestOrchestration:
 
         code = _generate_orch_code(TensorReadProgram)
 
-        # tensor.read emits a typed get_tensor_data<T>() call (the runtime
-        # spin-waits on TensorMap producers before reading), and packs the
+        # tensor.read emits a typed get_tensor_data<T>() call and packs the
         # multi-dim indices into a uint32_t indices_<var>[N] = {...} array.
+        # The selected runtime then applies its own access policy.
         # ConstInt indices are emitted bare via EmitAsUint32 (no redundant cast).
         assert "uint32_t indices_val[2] = {1, 3};" in code
         assert "float val = get_tensor_data<float>(ext_t, 2, indices_val);" in code
@@ -261,12 +261,13 @@ class TestOrchestration:
         assert "host_t" not in code
         assert "buffer.addr" not in code
 
-    def test_orch_internal_tensor_read_uses_get_tensor_data(self):
+    def test_orch_internal_tensor_read_uses_runtime_api(self):
         """Regression for #1487: an orch-level read of an internally-allocated
-        tensor (produced by a device-scope task) must go through
-        ``get_tensor_data<T>()`` so the runtime spin-waits on the producer's
-        TensorMap entry. A raw ``buffer.addr`` deref returns stale/zero data
-        before the producer has finished writing.
+        tensor must go through ``get_tensor_data<T>()``. The selected runtime
+        owns the contract: one runtime may synchronize with the producer, while
+        host-build-graph rejects this access because device scheduling starts
+        only after graph construction. A raw ``buffer.addr`` deref bypasses
+        both policies and can return stale or invalid data.
         """
         backend.reset_for_testing()
         backend.set_backend_type(BackendType.Ascend910B)
@@ -295,7 +296,8 @@ class TestOrchestration:
 
         code = _generate_orch_code(InternalReadProgram)
 
-        # The runtime API call is what gives us producer-sync; it must be present.
+        # The runtime API call preserves runtime-specific validation or
+        # synchronization; codegen must not bypass it with a raw dereference.
         assert "get_tensor_data<int32_t>(cnt" in code
         # The pre-fix raw-deref shapes must not return — including the
         # buffer.addr / reinterpret_cast path from the dead #1479 attempt.

--- a/tests/ut/codegen/test_orchestration_codegen.py
+++ b/tests/ut/codegen/test_orchestration_codegen.py
@@ -261,11 +261,11 @@ class TestOrchestration:
         assert "host_t" not in code
         assert "buffer.addr" not in code
 
-    def test_orch_internal_tensor_read_uses_runtime_api(self):
+    def test_orch_internal_tensor_read_uses_get_tensor_data(self):
         """Regression for #1487: an orch-level read of an internally-allocated
         tensor must go through ``get_tensor_data<T>()``. The selected runtime
         owns the contract: one runtime may synchronize with the producer, while
-        host-build-graph rejects this access because device scheduling starts
+        host-build-graph does not support it because device scheduling starts
         only after graph construction. A raw ``buffer.addr`` deref bypasses
         both policies and can return stale or invalid data.
         """

--- a/tests/ut/codegen/test_orchestration_codegen_more.py
+++ b/tests/ut/codegen/test_orchestration_codegen_more.py
@@ -155,9 +155,9 @@ class TestOrchestrationMore:
         assert "uint32_t chunk_offsets[2] = {static_cast<uint32_t>((i * 16)), 0};" in code
         assert "Tensor chunk = ext_data.view(chunk_shapes, chunk_offsets);" in code
 
-        # tensor.read now goes through get_tensor_data<T>() (producer-sync
-        # via TensorMap) instead of a raw orch_args.tensor().data_as<void>()
-        # deref. See #1487.
+        # tensor.read now goes through get_tensor_data<T>() so the runtime owns
+        # access validation/synchronization, instead of bypassing it with a raw
+        # orch_args.tensor().data_as<void>() dereference. See #1487.
         assert "uint32_t indices_n_blocks[1] = {0};" in code
         assert "int64_t n_blocks = get_tensor_data<int64_t>(ext_config, 1, indices_n_blocks);" in code
 

--- a/tests/ut/codegen/test_orchestration_tensor_rw.py
+++ b/tests/ut/codegen/test_orchestration_tensor_rw.py
@@ -122,8 +122,8 @@ class TestTensorReadWriteOffsetCodegen:
 
         code = _generate_orch_code(Prog)
         # Read uses get_tensor_data<T>; write goes through the symmetric
-        # set_tensor_data<T> API so the runtime can spin-wait on producers /
-        # tracked INOUT consumers before writing.
+        # set_tensor_data<T> API so the runtime owns access validation and any
+        # producer/consumer synchronization.
         assert "float val = get_tensor_data<float>(ext_t, 2, indices_val);" in code
         assert "uint32_t indices_t[2] = {1, 3};" in code
         assert "set_tensor_data<float>(ext_t, 2, indices_t, val);" in code

--- a/tests/ut/codegen/test_pto_codegen.py
+++ b/tests/ut/codegen/test_pto_codegen.py
@@ -254,6 +254,7 @@ def test_pto_codegen_tensor_parameters():
     assert "pto.make_tensor_view" in mlir_code
     assert "shape = [%c64_index, %c64_index]" in mlir_code or "shape = [%c32_index, %c32_index]" in mlir_code
     assert "strides = " in mlir_code
+    assert "} : !pto.tensor_view" in mlir_code
     assert "!pto.tensor_view<?x?xf32>" in mlir_code
 
 
@@ -2774,6 +2775,7 @@ def test_pto_codegen_tensor_view_aliases_input_base_ptr():
     view_line = _single_line(lines, "pto.make_tensor_view %arg0, shape = [%c16_index, %c8_index]")
     assert "strides = [%c1_index, %c16_index]" in view_line
     assert "{layout = #pto.layout<dn>}" in view_line
+    assert "} : !pto.tensor_view" in view_line
 
     view_ssa = view_line.split(" = ", 1)[0].strip()
     assert any(f"pto.partition_view {view_ssa}" in line for line in lines), (

--- a/tests/ut/codegen/test_pto_codegen_gather_row.py
+++ b/tests/ut/codegen/test_pto_codegen_gather_row.py
@@ -90,8 +90,13 @@ def test_gather_row_transpose_emits_dn_source_view():
     mlir = _codegen_incore(_build_program(transpose=True))
     assert "pto.gather_row" not in mlir  # lowered to subview + tload, not a single op
     # The transposing source view: a DN make_tensor_view of the GM source.
-    assert "make_tensor_view" in mlir
-    assert "layout = #pto.layout<dn>" in mlir
+    dn_view_lines = [
+        line
+        for line in mlir.splitlines()
+        if "pto.make_tensor_view" in line and "layout = #pto.layout<dn>" in line
+    ]
+    assert len(dn_view_lines) == 1, f"expected exactly one DN source view, got: {dn_view_lines}"
+    assert "} : !pto.tensor_view" in dn_view_lines[0]
     # The row is read as a [c, 1] DN column partition (1x... source partition).
     assert "pto.tload" in mlir
     assert "pto.subview" in mlir

--- a/tests/ut/conftest.py
+++ b/tests/ut/conftest.py
@@ -9,13 +9,50 @@
 
 """Shared fixtures for unit tests."""
 
+import importlib
 import os
+import sys
+from types import SimpleNamespace
 
 import pytest
 from pypto import backend as _backend
 from pypto.backend import BackendType
 from pypto.ir.pass_manager import OptimizationStrategy, PassManager
 from pypto.pypto_core import passes
+
+
+@pytest.fixture
+def device_runner(monkeypatch):
+    """Import ``device_runner`` without requiring the optional Simpler package."""
+    import pypto.runtime as runtime_package  # noqa: PLC0415
+
+    fake_kernel_compiler = SimpleNamespace(KernelCompiler=object)
+    fake_task_interface = SimpleNamespace(
+        CallConfig=object,
+        ChipCallable=object,
+        ChipStorageTaskArgs=object,
+        CoreCallable=object,
+        Worker=object,
+        make_tensor_arg=object,
+        scalar_to_uint64=object,
+    )
+    monkeypatch.setitem(sys.modules, "pypto.runtime.kernel_compiler", fake_kernel_compiler)
+    monkeypatch.setitem(sys.modules, "pypto.runtime.task_interface", fake_task_interface)
+
+    module_name = "pypto.runtime.device_runner"
+    previous = sys.modules.pop(module_name, None)
+    previous_attribute = getattr(runtime_package, "device_runner", None)
+    try:
+        module = importlib.import_module(module_name)
+        yield module
+    finally:
+        sys.modules.pop(module_name, None)
+        if previous is not None:
+            sys.modules[module_name] = previous
+        if previous_attribute is not None:
+            setattr(runtime_package, "device_runner", previous_attribute)
+        elif hasattr(runtime_package, "device_runner"):
+            delattr(runtime_package, "device_runner")
 
 
 @pytest.fixture

--- a/tests/ut/ir/test_distributed_compiled_program.py
+++ b/tests/ut/ir/test_distributed_compiled_program.py
@@ -171,6 +171,7 @@ def test_compile_persists_distributed_meta(compiled, tmp_path):
     assert meta["platform"] == "a2a3sim"
     assert meta["backend_type"] == "Ascend910B"
     assert meta["distributed_config"]["runtime"] == "tensormap_and_ringbuffer"
+    assert meta["distributed_config"]["aicpu_thread_num"] == 0
 
 
 def test_from_dir_round_trips_param_metadata(compiled, tmp_path):

--- a/tests/ut/runtime/test_benchmark.py
+++ b/tests/ut/runtime/test_benchmark.py
@@ -82,7 +82,7 @@ def _strace_line(
     attrs = " clk=dev" if dev else ""
     ts_ns = ts if ts is not None else inv * 1000
     return (
-        f"[2026-01-01][T0x1][INFO_V9] {name}: [STRACE] v=1 pid={pid} tid=1 "
+        f"[2026-01-01][T0x1][TIMING] {name}: [STRACE] v=1 pid={pid} tid=1 "
         f"inv={inv} hid={hid} depth={depth} name={name} ts={ts_ns} dur={dur_ns}{attrs}"
     )
 
@@ -928,10 +928,10 @@ def test_benchmark_registers_once_and_loops_warmup_plus_rounds():
     assert stats.rounds == 3
 
 
-def test_benchmark_raises_log_level_to_v9_and_restores():
+def test_benchmark_sets_log_level_to_timing_and_restores():
     _stats, _worker, _ctor, cfg, _parse = _run_benchmark(rounds=1, warmup=0)
-    # First call raises to v9; the final call restores the saved level (20).
-    assert cfg.call_args_list[0].args == ("v9",)
+    # First call enables TIMING markers; the final call restores the saved level (20).
+    assert cfg.call_args_list[0].args == ("timing",)
     assert cfg.call_args_list[-1].args == (20,)
 
 

--- a/tests/ut/runtime/test_binary_cache_context.py
+++ b/tests/ut/runtime/test_binary_cache_context.py
@@ -9,10 +9,7 @@
 
 """Regression tests for generated-binary runtime compatibility stamps."""
 
-from __future__ import annotations
-
 import fcntl
-import importlib
 import json
 import multiprocessing
 import subprocess
@@ -22,6 +19,7 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import Mock
 
+import pypto.runtime._binary_cache as binary_cache
 import pytest
 from pypto.runtime._binary_cache import (
     BinaryCacheContext,
@@ -106,7 +104,7 @@ def test_runtime_revision_change_invalidates_both_orchestration_caches(tmp_path:
     assert not binary_context_path(tmp_path).exists()
 
 
-def test_matching_context_preserves_orchestration_caches(tmp_path: Path) -> None:
+def test_matching_context_preserves_binaries_but_discards_stamp(tmp_path: Path) -> None:
     context = _context()
     record_binary_context(tmp_path, context)
     orch_prebuild = _touch(tmp_path / "cache" / "orch_main.bin")
@@ -115,7 +113,7 @@ def test_matching_context_preserves_orchestration_caches(tmp_path: Path) -> None
     assert prepare_binary_context(tmp_path, context) == 0
     assert orch_prebuild.exists()
     assert orch_sidecar.exists()
-    assert binary_context_path(tmp_path).exists()
+    assert not binary_context_path(tmp_path).exists()
 
 
 def test_legacy_unstamped_cache_is_invalidated_once(tmp_path: Path) -> None:
@@ -168,7 +166,27 @@ def test_unknown_current_identity_never_authorizes_binary_reuse(tmp_path: Path) 
     assert not binary_context_path(tmp_path).exists()
 
 
-def test_record_binary_context_writes_schema_atomically(tmp_path: Path) -> None:
+def test_invalidation_discards_stamp_before_removing_artifacts(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    context = _context()
+    stamp = binary_context_path(tmp_path)
+    record_binary_context(tmp_path, context)
+
+    def fail_artifact_removal(_work_dir: Path | str) -> int:
+        assert not stamp.exists()
+        raise RuntimeError("artifact removal failed")
+
+    monkeypatch.setattr(binary_cache, "_invalidate_binary_artifacts", fail_artifact_removal)
+
+    with pytest.raises(RuntimeError, match="artifact removal failed"):
+        binary_cache.invalidate_binary_context(tmp_path)
+
+    assert not stamp.exists()
+
+
+def test_record_binary_context_writes_schema_and_cleans_temp_file(tmp_path: Path) -> None:
     context = _context()
 
     record_binary_context(tmp_path, context)
@@ -176,40 +194,6 @@ def test_record_binary_context_writes_schema_atomically(tmp_path: Path) -> None:
     stamp = binary_context_path(tmp_path)
     assert json.loads(stamp.read_text(encoding="utf-8")) == context.to_dict()
     assert not list(stamp.parent.glob(f"{stamp.name}.*.tmp"))
-
-
-@pytest.fixture
-def device_runner(monkeypatch):
-    """Import device_runner with optional Simpler/compiler surfaces stubbed."""
-    import pypto.runtime as runtime_package  # noqa: PLC0415
-
-    fake_kernel_compiler = SimpleNamespace(KernelCompiler=object)
-    fake_task_interface = SimpleNamespace(
-        CallConfig=object,
-        ChipCallable=object,
-        ChipStorageTaskArgs=object,
-        CoreCallable=object,
-        Worker=object,
-        make_tensor_arg=object,
-        scalar_to_uint64=object,
-    )
-    monkeypatch.setitem(sys.modules, "pypto.runtime.kernel_compiler", fake_kernel_compiler)
-    monkeypatch.setitem(sys.modules, "pypto.runtime.task_interface", fake_task_interface)
-
-    module_name = "pypto.runtime.device_runner"
-    previous = sys.modules.pop(module_name, None)
-    previous_attribute = getattr(runtime_package, "device_runner", None)
-    try:
-        module = importlib.import_module(module_name)
-        yield module
-    finally:
-        sys.modules.pop(module_name, None)
-        if previous is not None:
-            sys.modules[module_name] = previous
-        if previous_attribute is not None:
-            setattr(runtime_package, "device_runner", previous_attribute)
-        elif hasattr(runtime_package, "device_runner"):
-            delattr(runtime_package, "device_runner")
 
 
 def test_dirty_runtime_checkout_disables_binary_reuse(device_runner, monkeypatch, tmp_path: Path) -> None:
@@ -356,6 +340,34 @@ def test_compile_and_assemble_does_not_stamp_failed_assembly(
     record.assert_not_called()
 
 
+def test_failed_matching_cache_is_invalidated_before_retry(
+    device_runner,
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    context = _context()
+    record_binary_context(tmp_path, context)
+    cached_binary = _touch(tmp_path / "cache" / "orch_main.bin", b"cached orchestration")
+    chip = object()
+    build = Mock(side_effect=[RuntimeError("assemble failed"), chip])
+    _stub_assembly(device_runner, monkeypatch, tmp_path, build)
+    compile_orchestration = device_runner.compile_single_orchestration
+
+    with pytest.raises(RuntimeError, match="assemble failed"):
+        device_runner.compile_and_assemble(tmp_path, "a2a3sim")
+
+    assert cached_binary.exists()
+    assert not binary_context_path(tmp_path).exists()
+    compile_orchestration.assert_not_called()
+
+    assembled, _, _ = device_runner.compile_and_assemble(tmp_path, "a2a3sim")
+
+    assert assembled is chip
+    assert not cached_binary.exists()
+    compile_orchestration.assert_called_once()
+    assert json.loads(binary_context_path(tmp_path).read_text(encoding="utf-8")) == context.to_dict()
+
+
 def test_compile_and_assemble_serializes_same_work_dir(
     device_runner,
     monkeypatch,
@@ -397,3 +409,7 @@ def test_compile_and_assemble_serializes_same_work_dir(
         if process.is_alive():
             process.terminate()
         process.join(timeout=5)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/ut/runtime/test_binary_cache_context.py
+++ b/tests/ut/runtime/test_binary_cache_context.py
@@ -1,0 +1,399 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Regression tests for generated-binary runtime compatibility stamps."""
+
+from __future__ import annotations
+
+import fcntl
+import importlib
+import json
+import multiprocessing
+import subprocess
+import sys
+from dataclasses import replace
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+from pypto.runtime._binary_cache import (
+    BinaryCacheContext,
+    binary_context_path,
+    prepare_binary_context,
+    record_binary_context,
+)
+
+_RUNTIME_OLD = "a" * 40
+_RUNTIME_NEW = "b" * 40
+_PTO_ISA = "c" * 40
+
+
+def _context(**changes) -> BinaryCacheContext:
+    context = BinaryCacheContext(
+        platform="a2a3sim",
+        runtime_name="tensormap_and_ringbuffer",
+        runtime_revision=_RUNTIME_OLD,
+        pto_isa_revision=_PTO_ISA,
+    )
+    return replace(context, **changes)
+
+
+def _touch(path: Path, content: bytes = b"binary") -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(content)
+    return path
+
+
+def _init_git_repo(path: Path) -> str:
+    path.mkdir(parents=True)
+    subprocess.run(["git", "init", "--quiet"], cwd=path, check=True)
+    (path / "tracked.hpp").write_text("// committed\n", encoding="utf-8")
+    subprocess.run(["git", "add", "tracked.hpp"], cwd=path, check=True)
+    subprocess.run(
+        [
+            "git",
+            "-c",
+            "user.name=PyPTO Tests",
+            "-c",
+            "user.email=pypto-tests@example.invalid",
+            "commit",
+            "--quiet",
+            "-m",
+            "initial",
+        ],
+        cwd=path,
+        check=True,
+    )
+    return subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=path,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def test_runtime_revision_change_invalidates_both_orchestration_caches(tmp_path: Path) -> None:
+    """A runtime-header revision change invalidates prebuild and sibling binaries."""
+    old_context = _context()
+    record_binary_context(tmp_path, old_context)
+    orch_prebuild = _touch(tmp_path / "cache" / "orch_main.bin")
+    orch_sidecar = _touch(tmp_path / "orchestration" / "main.so")
+    kernel_sidecar = _touch(tmp_path / "kernels" / "aiv" / "kernel.so")
+    kernel_object = _touch(tmp_path / "kernels" / "aic" / "kernel.o")
+    orch_source = _touch(tmp_path / "orchestration" / "main.cpp", b"// source\n")
+    kernel_source = _touch(tmp_path / "kernels" / "aiv" / "kernel.cpp", b"// source\n")
+
+    removed = prepare_binary_context(
+        tmp_path,
+        replace(old_context, runtime_revision=_RUNTIME_NEW),
+    )
+
+    assert removed == 4
+    assert not orch_prebuild.exists()
+    assert not orch_sidecar.exists()
+    assert not kernel_sidecar.exists()
+    assert not kernel_object.exists()
+    assert orch_source.exists()
+    assert kernel_source.exists()
+    assert not binary_context_path(tmp_path).exists()
+
+
+def test_matching_context_preserves_orchestration_caches(tmp_path: Path) -> None:
+    context = _context()
+    record_binary_context(tmp_path, context)
+    orch_prebuild = _touch(tmp_path / "cache" / "orch_main.bin")
+    orch_sidecar = _touch(tmp_path / "orchestration" / "main.so")
+
+    assert prepare_binary_context(tmp_path, context) == 0
+    assert orch_prebuild.exists()
+    assert orch_sidecar.exists()
+    assert binary_context_path(tmp_path).exists()
+
+
+def test_legacy_unstamped_cache_is_invalidated_once(tmp_path: Path) -> None:
+    orch_prebuild = _touch(tmp_path / "cache" / "orch_main.bin")
+    orch_sidecar = _touch(tmp_path / "orchestration" / "main.so")
+
+    assert prepare_binary_context(tmp_path, _context()) == 2
+    assert not orch_prebuild.exists()
+    assert not orch_sidecar.exists()
+
+
+@pytest.mark.parametrize(
+    "changed_context",
+    [
+        _context(platform="a2a3"),
+        _context(runtime_name="host_build_graph"),
+        _context(pto_isa_revision="d" * 40),
+    ],
+)
+def test_any_abi_context_change_invalidates_cache(
+    tmp_path: Path,
+    changed_context: BinaryCacheContext,
+) -> None:
+    record_binary_context(tmp_path, _context())
+    binary = _touch(tmp_path / "cache" / "orch_main.bin")
+
+    assert prepare_binary_context(tmp_path, changed_context) == 1
+    assert not binary.exists()
+
+
+def test_malformed_stamp_never_authorizes_binary_reuse(tmp_path: Path) -> None:
+    stamp = binary_context_path(tmp_path)
+    stamp.parent.mkdir(parents=True)
+    stamp.write_text("{not json", encoding="utf-8")
+    binary = _touch(tmp_path / "cache" / "orch_main.bin")
+
+    assert prepare_binary_context(tmp_path, _context()) == 1
+    assert not binary.exists()
+    assert not stamp.exists()
+
+
+def test_unknown_current_identity_never_authorizes_binary_reuse(tmp_path: Path) -> None:
+    record_binary_context(tmp_path, _context())
+    binary = _touch(tmp_path / "cache" / "orch_main.bin")
+
+    assert prepare_binary_context(tmp_path, None) == 1
+    assert not binary.exists()
+    assert not binary_context_path(tmp_path).exists()
+    record_binary_context(tmp_path, None)
+    assert not binary_context_path(tmp_path).exists()
+
+
+def test_record_binary_context_writes_schema_atomically(tmp_path: Path) -> None:
+    context = _context()
+
+    record_binary_context(tmp_path, context)
+
+    stamp = binary_context_path(tmp_path)
+    assert json.loads(stamp.read_text(encoding="utf-8")) == context.to_dict()
+    assert not list(stamp.parent.glob(f"{stamp.name}.*.tmp"))
+
+
+@pytest.fixture
+def device_runner(monkeypatch):
+    """Import device_runner with optional Simpler/compiler surfaces stubbed."""
+    import pypto.runtime as runtime_package  # noqa: PLC0415
+
+    fake_kernel_compiler = SimpleNamespace(KernelCompiler=object)
+    fake_task_interface = SimpleNamespace(
+        CallConfig=object,
+        ChipCallable=object,
+        ChipStorageTaskArgs=object,
+        CoreCallable=object,
+        Worker=object,
+        make_tensor_arg=object,
+        scalar_to_uint64=object,
+    )
+    monkeypatch.setitem(sys.modules, "pypto.runtime.kernel_compiler", fake_kernel_compiler)
+    monkeypatch.setitem(sys.modules, "pypto.runtime.task_interface", fake_task_interface)
+
+    module_name = "pypto.runtime.device_runner"
+    previous = sys.modules.pop(module_name, None)
+    previous_attribute = getattr(runtime_package, "device_runner", None)
+    try:
+        module = importlib.import_module(module_name)
+        yield module
+    finally:
+        sys.modules.pop(module_name, None)
+        if previous is not None:
+            sys.modules[module_name] = previous
+        if previous_attribute is not None:
+            setattr(runtime_package, "device_runner", previous_attribute)
+        elif hasattr(runtime_package, "device_runner"):
+            delattr(runtime_package, "device_runner")
+
+
+def test_dirty_runtime_checkout_disables_binary_reuse(device_runner, monkeypatch, tmp_path: Path) -> None:
+    runtime_root = tmp_path / "runtime"
+    pto_isa_root = tmp_path / "pto-isa"
+    _init_git_repo(runtime_root)
+    _init_git_repo(pto_isa_root)
+    (runtime_root / "tracked.hpp").write_text("// locally modified\n", encoding="utf-8")
+    monkeypatch.setitem(
+        sys.modules,
+        "_task_interface",
+        SimpleNamespace(__build_commit__=_RUNTIME_OLD),
+    )
+
+    context = device_runner._current_binary_context(
+        SimpleNamespace(project_root=runtime_root),
+        platform="a2a3sim",
+        runtime_name="tensormap_and_ringbuffer",
+        pto_isa_root=str(pto_isa_root),
+    )
+
+    assert context is None
+
+
+def test_dirty_pto_isa_checkout_disables_binary_reuse(device_runner, monkeypatch, tmp_path: Path) -> None:
+    pto_isa_root = tmp_path / "pto-isa"
+    _init_git_repo(pto_isa_root)
+    (pto_isa_root / "tracked.hpp").write_text("// locally modified\n", encoding="utf-8")
+    monkeypatch.setattr(device_runner, "_runtime_revision", Mock(return_value=_RUNTIME_OLD))
+
+    context = device_runner._current_binary_context(
+        object(),
+        platform="a2a3sim",
+        runtime_name="tensormap_and_ringbuffer",
+        pto_isa_root=str(pto_isa_root),
+    )
+
+    assert context is None
+
+
+def test_non_git_pto_isa_root_does_not_use_pin_as_actual_identity(
+    device_runner,
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    pto_isa_root = tmp_path / "pto-isa"
+    pto_isa_root.mkdir()
+    monkeypatch.setattr(device_runner, "_runtime_revision", Mock(return_value=_RUNTIME_OLD))
+    read_pin = Mock(return_value=_PTO_ISA)
+    monkeypatch.setattr(device_runner, "_read_runtime_pto_isa_pin", read_pin)
+
+    context = device_runner._current_binary_context(
+        object(),
+        platform="a2a3sim",
+        runtime_name="tensormap_and_ringbuffer",
+        pto_isa_root=str(pto_isa_root),
+    )
+
+    assert context is None
+    read_pin.assert_not_called()
+
+
+def test_installed_runtime_uses_embedded_revision_with_clean_pto_isa(
+    device_runner,
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    runtime_assets = tmp_path / "wheel-assets"
+    runtime_assets.mkdir()
+    pto_isa_root = tmp_path / "pto-isa"
+    pto_isa_revision = _init_git_repo(pto_isa_root)
+    monkeypatch.setitem(
+        sys.modules,
+        "_task_interface",
+        SimpleNamespace(__build_commit__=_RUNTIME_OLD),
+    )
+
+    context = device_runner._current_binary_context(
+        SimpleNamespace(project_root=runtime_assets),
+        platform="a2a3sim",
+        runtime_name="tensormap_and_ringbuffer",
+        pto_isa_root=str(pto_isa_root),
+    )
+
+    assert context == _context(pto_isa_revision=pto_isa_revision)
+
+
+def _write_minimal_artifact(work_dir: Path) -> None:
+    source = work_dir / "orchestration" / "main.cpp"
+    source.parent.mkdir(parents=True)
+    source.write_text("// orchestration\n", encoding="utf-8")
+    (work_dir / "kernel_config.py").write_text(
+        "KERNELS = []\n"
+        f"ORCHESTRATION = {{'source': {str(source)!r}, 'function_name': 'entry'}}\n"
+        "RUNTIME_CONFIG = {'runtime': 'tensormap_and_ringbuffer'}\n",
+        encoding="utf-8",
+    )
+
+
+def _stub_assembly(device_runner, monkeypatch, tmp_path: Path, chip_build: Mock) -> BinaryCacheContext:
+    _write_minimal_artifact(tmp_path)
+    context = _context()
+    monkeypatch.setattr(device_runner, "ensure_pto_isa_root", Mock(return_value="/pto-isa"))
+    monkeypatch.setattr(device_runner, "KernelCompiler", Mock(return_value=object()))
+    monkeypatch.setattr(device_runner, "_current_binary_context", Mock(return_value=context))
+    monkeypatch.setattr(
+        device_runner,
+        "compile_single_orchestration",
+        Mock(return_value=b"orchestration binary"),
+    )
+    monkeypatch.setattr(device_runner, "ChipCallable", SimpleNamespace(build=chip_build))
+    monkeypatch.setattr(device_runner, "register_callable_identity", Mock())
+    return context
+
+
+def test_compile_and_assemble_records_context_after_success(
+    device_runner,
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    chip = object()
+    context = _stub_assembly(device_runner, monkeypatch, tmp_path, Mock(return_value=chip))
+    record = Mock()
+    monkeypatch.setattr(device_runner, "record_binary_context", record)
+
+    assembled, _, _ = device_runner.compile_and_assemble(tmp_path, "a2a3sim")
+
+    assert assembled is chip
+    record.assert_called_once_with(tmp_path, context)
+
+
+def test_compile_and_assemble_does_not_stamp_failed_assembly(
+    device_runner,
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    _stub_assembly(device_runner, monkeypatch, tmp_path, Mock(side_effect=RuntimeError("assemble failed")))
+    record = Mock()
+    monkeypatch.setattr(device_runner, "record_binary_context", record)
+
+    with pytest.raises(RuntimeError, match="assemble failed"):
+        device_runner.compile_and_assemble(tmp_path, "a2a3sim")
+
+    record.assert_not_called()
+
+
+def test_compile_and_assemble_serializes_same_work_dir(
+    device_runner,
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    _write_minimal_artifact(tmp_path)
+    process_context = multiprocessing.get_context("fork")
+    entered = process_context.Event()
+    release = process_context.Event()
+
+    def assemble_locked(_work_dir, _platform):
+        entered.set()
+        if not release.wait(timeout=5):
+            raise TimeoutError("assembly was not released")
+        return object(), "runtime", {}
+
+    monkeypatch.setattr(device_runner, "_compile_and_assemble_locked", assemble_locked)
+    process = process_context.Process(
+        target=device_runner.compile_and_assemble,
+        args=(tmp_path, "a2a3sim"),
+    )
+    process.start()
+    try:
+        assert entered.wait(timeout=5)
+        lock_path = tmp_path / "cache" / ".binary_context.lock"
+        with lock_path.open("a+b") as lock_file:
+            with pytest.raises(BlockingIOError):
+                fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+
+        release.set()
+        process.join(timeout=5)
+        assert process.exitcode == 0
+
+        with lock_path.open("a+b") as lock_file:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+    finally:
+        release.set()
+        if process.is_alive():
+            process.terminate()
+        process.join(timeout=5)

--- a/tests/ut/runtime/test_distributed_worker.py
+++ b/tests/ut/runtime/test_distributed_worker.py
@@ -752,17 +752,27 @@ class TestLifecycle:
         rt.close()  # second close is a no-op
         assert patched_setup["worker"].close.call_count == 1
 
-    def test_close_releases_inherited_refs_when_worker_close_raises(self, patched_setup):
+    def test_close_retries_worker_cleanup_after_failure(self, patched_setup):
         compiled = _fake_compiled([_param("weight", [16, 16])], [])
         weight = torch.zeros(16, 16, dtype=torch.float32)
         rt = DistributedWorker(compiled, inherited_host_tensors=[weight])
-        patched_setup["worker"].close.side_effect = RuntimeError("worker close failed")
+        worker = patched_setup["worker"]
+        worker.close.side_effect = [RuntimeError("worker close failed"), None]
 
         with pytest.raises(RuntimeError, match="worker close failed"):
             rt.close()
 
+        assert rt._closed is True
+        assert rt._close_complete is False
         assert rt._inherited_host_tensors == ()
         assert not rt._inherited_host_storage_ptrs
+        with pytest.raises(RuntimeError, match="after close"):
+            rt(DeviceTensor(0x1000, (16, 16), torch.float32))
+
+        rt.close()
+        assert rt._close_complete is True
+        rt.close()  # cleanup completed, so further calls are no-ops
+        assert worker.close.call_count == 2
 
     def test_context_manager_closes(self, patched_setup):
         compiled = _fake_compiled([_param("a", [16, 16])], [])
@@ -907,6 +917,17 @@ class TestOneShotRegression:
 
         assert patched_setup["construct"].call_args.kwargs["enable_sdma"] is True
 
+    def test_one_shot_retries_incomplete_worker_cleanup(self, patched_setup):
+        from pypto.runtime.distributed_runner import execute_distributed  # noqa: PLC0415
+
+        worker = patched_setup["worker"]
+        worker.close.side_effect = [RuntimeError("cleanup pending"), None]
+        compiled = _fake_compiled([_param("a", [8, 8])], [])
+
+        execute_distributed(compiled, [torch.zeros(8, 8, dtype=torch.float32)])
+
+        assert worker.close.call_count == 2
+
 
 class TestWorkerConstruction:
     def test_forwards_enable_sdma_to_simpler_worker(self, monkeypatch):
@@ -924,6 +945,33 @@ class TestWorkerConstruction:
             runtime="tensormap_and_ringbuffer",
             enable_sdma=True,
         )
+
+    def test_failure_preserves_primary_error_when_cleanup_retry_fails(self, patched_setup, caplog):
+        worker = patched_setup["worker"]
+        worker.init.side_effect = RuntimeError("init failed")
+        worker.close.side_effect = [
+            RuntimeError("cleanup pending"),
+            RuntimeError("cleanup still pending"),
+        ]
+        compiled = _fake_compiled([_param("a", [8, 8])], [])
+
+        with pytest.raises(RuntimeError, match="init failed"):
+            DistributedWorker(compiled)
+
+        assert worker.close.call_count == 2
+        assert "Worker cleanup was interrupted or still failed after one retry" in caplog.text
+
+    def test_interrupted_failure_still_retries_cleanup_and_preserves_primary(self, patched_setup, caplog):
+        worker = patched_setup["worker"]
+        worker.init.side_effect = KeyboardInterrupt("init interrupted")
+        worker.close.side_effect = [KeyboardInterrupt("cleanup interrupted"), None]
+        compiled = _fake_compiled([_param("a", [8, 8])], [])
+
+        with pytest.raises(KeyboardInterrupt, match="init interrupted"):
+            DistributedWorker(compiled)
+
+        assert worker.close.call_count == 2
+        assert "Worker cleanup was interrupted or still failed after one retry" in caplog.text
 
 
 class TestExplicitDispatchAPI:

--- a/tests/ut/runtime/test_distributed_worker.py
+++ b/tests/ut/runtime/test_distributed_worker.py
@@ -76,8 +76,8 @@ def patched_setup():
     worker = MagicMock(name="Worker(level=3)")
     worker.chip_contexts = []
     worker._live_domains = {}
-    # Device-memory ops route through the Orchestrator facade (worker._orch).
-    worker._orch.malloc.return_value = 0xDEAD0000
+    worker._building_run_resources = None
+    worker.malloc.return_value = 0xDEAD0000
 
     mod = "pypto.runtime.distributed_runner"
     chip_callables = ({"chip_orch": object()}, "rt_name", False)
@@ -492,12 +492,10 @@ class TestDeviceMemoryApi:
         assert isinstance(dev, DeviceTensor)
         assert dev.data_ptr == 0xDEAD0000
         assert dev.shape == (16, 16)
-        # worker_id first for the Orchestrator facade; nbytes = 16*16*4.
-        patched_setup["worker"]._orch.malloc.assert_called_once_with(0, 16 * 16 * 4)
-        # copy_to(worker_id, dst=ptr, src=host.data_ptr(), nbytes) — no defensive copy.
-        patched_setup["worker"]._orch.copy_to.assert_called_once_with(
-            0, 0xDEAD0000, host.data_ptr(), 16 * 16 * 4
-        )
+        # Simpler's public Worker takes payload arguments first and worker_id last.
+        patched_setup["worker"].malloc.assert_called_once_with(16 * 16 * 4, 0)
+        # No defensive host copy is made before the public Worker call.
+        patched_setup["worker"].copy_to.assert_called_once_with(0xDEAD0000, host.data_ptr(), 16 * 16 * 4, 0)
         rt.close()
 
     def test_alloc_tensor_rejects_non_shared_init(self, patched_setup):
@@ -506,33 +504,33 @@ class TestDeviceMemoryApi:
         with pytest.raises(ValueError, match="shared-memory"):
             rt.alloc_tensor((16, 16), torch.float32, init=torch.zeros(16, 16, dtype=torch.float32))
         # rolled back the malloc'd pointer.
-        patched_setup["worker"]._orch.free.assert_called_once_with(0, 0xDEAD0000)
+        patched_setup["worker"].free.assert_called_once_with(0xDEAD0000, 0)
         rt.close()
 
     def test_alloc_tensor_rolls_back_on_copy_failure(self, patched_setup):
         compiled = _fake_compiled([_param("a", [16, 16])], [])
         rt = DistributedWorker(compiled)
-        patched_setup["worker"]._orch.copy_to.side_effect = RuntimeError("boom")
+        patched_setup["worker"].copy_to.side_effect = RuntimeError("boom")
         host = torch.zeros(16, 16, dtype=torch.float32).share_memory_()
 
         with pytest.raises(RuntimeError, match="boom"):
             rt.alloc_tensor((16, 16), torch.float32, init=host)
 
         # malloc'd pointer is freed on the failure path.
-        patched_setup["worker"]._orch.free.assert_called_once_with(0, 0xDEAD0000)
+        patched_setup["worker"].free.assert_called_once_with(0xDEAD0000, 0)
         rt.close()
 
     def test_alloc_tensor_forwards_nonzero_worker_id(self, patched_setup):
         # A non-default worker_id is supported: malloc is forwarded to that
-        # worker (facade order is ``malloc(worker_id, nbytes)``) and the buffer
+        # worker (public order is ``malloc(nbytes, worker_id)``) and the buffer
         # is tracked under (worker_id, ptr) for per-worker auto-free.
         compiled = _fake_compiled([_param("a", [16, 16])], [])
         rt = DistributedWorker(compiled)
         dev = rt.alloc_tensor((16, 16), torch.float32, worker_id=1)
-        patched_setup["worker"]._orch.malloc.assert_called_once_with(1, 16 * 16 * 4)
+        patched_setup["worker"].malloc.assert_called_once_with(16 * 16 * 4, 1)
         assert (1, dev.data_ptr) in rt._owned_tensors
         rt.free_tensor(dev, worker_id=1)
-        patched_setup["worker"]._orch.free.assert_called_once_with(1, 0xDEAD0000)
+        patched_setup["worker"].free.assert_called_once_with(0xDEAD0000, 1)
         rt.close()
 
 
@@ -546,7 +544,7 @@ class TestAllocStackedTensor:
     """``alloc_stacked_tensor`` uploads each leading-dim shard to its worker once."""
 
     def test_identity_uploads_shard_per_worker(self, patched_setup):
-        patched_setup["worker"]._orch.malloc.side_effect = [0xA000, 0xB000]
+        patched_setup["worker"].malloc.side_effect = [0xA000, 0xB000]
         rt = DistributedWorker(_compiled_2cards())
         host = torch.arange(2 * 4 * 4, dtype=torch.float32).view(2, 4, 4).share_memory_()
 
@@ -555,76 +553,76 @@ class TestAllocStackedTensor:
         assert stacked.full_shape == (2, 4, 4)
         assert stacked.worker_ids == (0, 1)
         assert tuple(s.shape for s in stacked.shards) == ((4, 4), (4, 4))
-        orch = patched_setup["worker"]._orch
-        # shard 0 -> worker 0, shard 1 -> worker 1 (facade arg order worker_id first).
+        worker = patched_setup["worker"]
+        # shard 0 -> worker 0, shard 1 -> worker 1.
         nbytes = 4 * 4 * 4
-        orch.malloc.assert_any_call(0, nbytes)
-        orch.malloc.assert_any_call(1, nbytes)
-        orch.copy_to.assert_any_call(0, 0xA000, host[0].contiguous().data_ptr(), nbytes)
-        orch.copy_to.assert_any_call(1, 0xB000, host[1].contiguous().data_ptr(), nbytes)
+        worker.malloc.assert_any_call(nbytes, 0)
+        worker.malloc.assert_any_call(nbytes, 1)
+        worker.copy_to.assert_any_call(0xA000, host[0].contiguous().data_ptr(), nbytes, 0)
+        worker.copy_to.assert_any_call(0xB000, host[1].contiguous().data_ptr(), nbytes, 1)
         # Tracked per (worker_id, ptr) for auto-free.
         assert (0, 0xA000) in rt._owned_tensors
         assert (1, 0xB000) in rt._owned_tensors
         rt.close()
 
     def test_registered_inherited_storage_uploads_without_shared_memory(self, patched_setup):
-        patched_setup["worker"]._orch.malloc.side_effect = [0xA000, 0xB000]
+        patched_setup["worker"].malloc.side_effect = [0xA000, 0xB000]
         host = torch.arange(2 * 4 * 4, dtype=torch.float32).view(2, 4, 4)
         rt = DistributedWorker(_compiled_2cards(), inherited_host_tensors=[host])
 
         stacked = rt.alloc_stacked_tensor(host)
 
         assert stacked.worker_ids == (0, 1)
-        orch = patched_setup["worker"]._orch
+        worker = patched_setup["worker"]
         nbytes = 4 * 4 * 4
-        orch.copy_to.assert_any_call(0, 0xA000, host[0].data_ptr(), nbytes)
-        orch.copy_to.assert_any_call(1, 0xB000, host[1].data_ptr(), nbytes)
+        worker.copy_to.assert_any_call(0xA000, host[0].data_ptr(), nbytes, 0)
+        worker.copy_to.assert_any_call(0xB000, host[1].data_ptr(), nbytes, 1)
         rt.close()
 
     def test_permuted_worker_ids_place_shards(self, patched_setup):
-        patched_setup["worker"]._orch.malloc.side_effect = [0xA000, 0xB000]
+        patched_setup["worker"].malloc.side_effect = [0xA000, 0xB000]
         rt = DistributedWorker(_compiled_2cards())
         host = torch.zeros(2, 4, 4, dtype=torch.float32).share_memory_()
 
         stacked = rt.alloc_stacked_tensor(host, worker_ids=[1, 0])
 
         assert stacked.worker_ids == (1, 0)
-        orch = patched_setup["worker"]._orch
+        worker = patched_setup["worker"]
         nbytes = 4 * 4 * 4
         # shard 0 -> worker 1, shard 1 -> worker 0.
-        orch.malloc.assert_any_call(1, nbytes)
-        orch.malloc.assert_any_call(0, nbytes)
+        worker.malloc.assert_any_call(nbytes, 1)
+        worker.malloc.assert_any_call(nbytes, 0)
         assert (1, 0xA000) in rt._owned_tensors
         assert (0, 0xB000) in rt._owned_tensors
         rt.close()
 
     def test_free_stacked_tensor_releases_each_shard(self, patched_setup):
-        patched_setup["worker"]._orch.malloc.side_effect = [0xA000, 0xB000]
+        patched_setup["worker"].malloc.side_effect = [0xA000, 0xB000]
         rt = DistributedWorker(_compiled_2cards())
         host = torch.zeros(2, 4, 4, dtype=torch.float32).share_memory_()
         stacked = rt.alloc_stacked_tensor(host, worker_ids=[1, 0])
 
-        patched_setup["worker"]._orch.free.reset_mock()
+        patched_setup["worker"].free.reset_mock()
         rt.free_stacked_tensor(stacked)
 
-        orch = patched_setup["worker"]._orch
-        orch.free.assert_any_call(1, 0xA000)
-        orch.free.assert_any_call(0, 0xB000)
+        worker = patched_setup["worker"]
+        worker.free.assert_any_call(0xA000, 1)
+        worker.free.assert_any_call(0xB000, 0)
         assert (1, 0xA000) not in rt._owned_tensors
         assert (0, 0xB000) not in rt._owned_tensors
         rt.close()
 
     def test_close_auto_frees_stacked_shards(self, patched_setup):
-        patched_setup["worker"]._orch.malloc.side_effect = [0xA000, 0xB000]
+        patched_setup["worker"].malloc.side_effect = [0xA000, 0xB000]
         rt = DistributedWorker(_compiled_2cards())
         host = torch.zeros(2, 4, 4, dtype=torch.float32).share_memory_()
         rt.alloc_stacked_tensor(host)  # leak — close() must release both shards
 
-        patched_setup["worker"]._orch.free.reset_mock()
+        patched_setup["worker"].free.reset_mock()
         rt.close()
-        orch = patched_setup["worker"]._orch
-        orch.free.assert_any_call(0, 0xA000)
-        orch.free.assert_any_call(1, 0xB000)
+        worker = patched_setup["worker"]
+        worker.free.assert_any_call(0xA000, 0)
+        worker.free.assert_any_call(0xB000, 1)
 
     def test_worker_ids_out_of_range_rejected(self, patched_setup):
         rt = DistributedWorker(_compiled_2cards())
@@ -640,7 +638,7 @@ class TestAllocStackedTensor:
         host = torch.zeros(0, 4, 4, dtype=torch.float32).share_memory_()
         with pytest.raises(ValueError, match="at least one shard"):
             rt.alloc_stacked_tensor(host)
-        patched_setup["worker"]._orch.malloc.assert_not_called()
+        patched_setup["worker"].malloc.assert_not_called()
         rt.close()
 
     def test_worker_ids_length_mismatch_rejected(self, patched_setup):
@@ -651,7 +649,7 @@ class TestAllocStackedTensor:
         rt.close()
 
     def test_non_shared_host_rejected_and_rolled_back(self, patched_setup):
-        patched_setup["worker"]._orch.malloc.side_effect = [0xA000, 0xB000]
+        patched_setup["worker"].malloc.side_effect = [0xA000, 0xB000]
         rt = DistributedWorker(_compiled_2cards())
         host = torch.zeros(2, 4, 4, dtype=torch.float32)  # NOT shared
 
@@ -666,11 +664,11 @@ class TestCopyStackedFrom:
     """``copy_stacked_from`` reads each resident shard back into host[i] (D2H)."""
 
     def _make_stacked(self, patched_setup, worker_ids=None):
-        patched_setup["worker"]._orch.malloc.side_effect = [0xA000, 0xB000]
+        patched_setup["worker"].malloc.side_effect = [0xA000, 0xB000]
         rt = DistributedWorker(_compiled_2cards())
         host = torch.zeros(2, 4, 4, dtype=torch.float32).share_memory_()
         stacked = rt.alloc_stacked_tensor(host, worker_ids=worker_ids)
-        patched_setup["worker"]._orch.copy_from.reset_mock()
+        patched_setup["worker"].copy_from.reset_mock()
         return rt, stacked
 
     def test_reads_each_shard_back(self, patched_setup):
@@ -679,12 +677,11 @@ class TestCopyStackedFrom:
 
         rt.copy_stacked_from(stacked, out)
 
-        orch = patched_setup["worker"]._orch
+        worker = patched_setup["worker"]
         nbytes = 4 * 4 * 4
-        # Facade arg order: copy_from(worker_id, dst_host_ptr, src_dev_ptr, nbytes).
-        orch.copy_from.assert_any_call(0, out[0].data_ptr(), 0xA000, nbytes)
-        orch.copy_from.assert_any_call(1, out[1].data_ptr(), 0xB000, nbytes)
-        assert orch.copy_from.call_count == 2
+        worker.copy_from.assert_any_call(out[0].data_ptr(), 0xA000, nbytes, 0)
+        worker.copy_from.assert_any_call(out[1].data_ptr(), 0xB000, nbytes, 1)
+        assert worker.copy_from.call_count == 2
         rt.close()
 
     def test_permuted_worker_ids(self, patched_setup):
@@ -693,11 +690,11 @@ class TestCopyStackedFrom:
 
         rt.copy_stacked_from(stacked, out)
 
-        orch = patched_setup["worker"]._orch
+        worker = patched_setup["worker"]
         nbytes = 4 * 4 * 4
         # shard 0 resides on worker 1, shard 1 on worker 0.
-        orch.copy_from.assert_any_call(1, out[0].data_ptr(), 0xA000, nbytes)
-        orch.copy_from.assert_any_call(0, out[1].data_ptr(), 0xB000, nbytes)
+        worker.copy_from.assert_any_call(out[0].data_ptr(), 0xA000, nbytes, 1)
+        worker.copy_from.assert_any_call(out[1].data_ptr(), 0xB000, nbytes, 0)
         rt.close()
 
     def test_shape_mismatch_rejected(self, patched_setup):
@@ -1011,12 +1008,11 @@ class TestExplicitDispatchAPI:
         t = rt.alloc_tensor((4,), torch.float32, init=host)
         assert (0, t.data_ptr) in rt._owned_tensors
 
-        # Spy on the orchestrator's free so we can assert close drove the
-        # auto-free path (L3 routes free through the orchestrator facade).
-        orch = patched_setup["worker"]._orch
-        orch.free.reset_mock()
+        # Spy on Simpler's public free so we can assert close drove auto-free.
+        worker = patched_setup["worker"]
+        worker.free.reset_mock()
         rt.close()
-        assert orch.free.called
+        assert worker.free.called
 
 
 class TestLoadOrchEntry:
@@ -1922,25 +1918,81 @@ class TestMakeCallConfigDepGenType:
         assert cfg.enable_dep_gen is True
 
 
+class _PersistentRunResources:
+    """Small model of Simpler's per-run domain journal."""
+
+    def __init__(self) -> None:
+        self.live_domains: dict[str, Any] = {}
+        self.pending_release_domains: list[Any] = []
+        self.retired = False
+        self.domain_lock = threading.Lock()
+        self.requires_ordered_cleanup = False
+
+
 class _PersistentDomainHandle:
-    def __init__(self, name: str, workers: list[int], window_size: int, allocation_index: int) -> None:
+    def __init__(
+        self,
+        name: str,
+        workers: list[int],
+        window_size: int,
+        allocation_index: int,
+        worker: Any,
+        owner: _PersistentRunResources,
+    ) -> None:
         self.name = name
         self.workers = tuple(workers)
         self.contexts = {
-            worker: SimpleNamespace(
-                local_window_base=0x10000000 + allocation_index * 0x100000 + worker * 0x10000,
+            worker_id: SimpleNamespace(
+                local_window_base=0x10000000 + allocation_index * 0x100000 + worker_id * 0x10000,
                 actual_window_size=window_size,
             )
-            for worker in workers
+            for worker_id in workers
         }
+        self.worker = worker
+        self.owner = owner
         self.release_count = 0
+        self.close_sweep_count = 0
+        self.backend_release_count = 0
+        self.released = False
         self.freed = False
+        self.release_error: BaseException | None = None
+        self.free_on_release = True
 
     def __getitem__(self, worker_id: int):
         return self.contexts[worker_id]
 
     def release(self) -> None:
+        if self.released:
+            return
+        self.released = True
         self.release_count += 1
+        with self.owner.domain_lock:
+            if not self.owner.retired:
+                self.owner.pending_release_domains.append(self)
+                self.owner.live_domains.pop(self.name, None)
+                if self.worker._live_domains.get(self.name) is self:
+                    self.worker._live_domains.pop(self.name)
+                return
+        self._free_from_global_registry(from_close=False)
+
+    def close_sweep(self) -> None:
+        """Model Worker.close()'s direct global live-domain sweep."""
+        self.close_sweep_count += 1
+        self.released = True
+        self._free_from_global_registry(from_close=True)
+
+    def _free_from_global_registry(self, *, from_close: bool) -> None:
+        if self.freed:
+            return
+        if not from_close and not self.free_on_release:
+            return
+        if self.backend_release_count == 0:
+            self.backend_release_count = 1
+        if self.release_error is not None:
+            raise self.release_error
+        self.freed = True
+        if self.worker._live_domains.get(self.name) is self:
+            self.worker._live_domains.pop(self.name)
 
 
 class _PersistentOrch:
@@ -1949,27 +2001,77 @@ class _PersistentOrch:
         self.allocate_calls: list[dict[str, Any]] = []
         self.copy_calls: list[tuple[int, int, int, int]] = []
         self.handles: list[_PersistentDomainHandle] = []
-        self.worker._execute_pending_domain_releases.side_effect = self._mark_released_domains_freed
+        self.resources: list[_PersistentRunResources] = []
+        self.worker.close.side_effect = self._close_live_domains
+
+    def _begin_run(self) -> _PersistentRunResources:
+        resources = _PersistentRunResources()
+        self.resources.append(resources)
+        self.worker._building_run_resources = resources
+        return resources
+
+    def _retire_run(self, resources: _PersistentRunResources) -> None:
+        assert self.worker._building_run_resources is resources
+        self.worker._building_run_resources = None
+        with resources.domain_lock:
+            resources.retired = True
+
+    def run(self, fn, *, before_retire=None, on_error=None):
+        resources = self._begin_run()
+        try:
+            result = fn(self, None, None)
+        except BaseException:
+            if on_error is not None:
+                on_error()
+            raise
+        else:
+            if before_retire is not None:
+                before_retire()
+            return result
+        finally:
+            self._retire_run(resources)
+
+    def run_with_abandoned_finalization(self, fn):
+        """Leave the owner unretired, as an ambiguous finalizer boundary does."""
+        resources = self._begin_run()
+        try:
+            fn(self, None, None)
+        finally:
+            assert self.worker._building_run_resources is resources
+            self.worker._building_run_resources = None
+        raise RuntimeError("run finalization abandoned")
 
     def allocate_domain(self, **kwargs):
         self.allocate_calls.append(kwargs)
+        resources = self.worker._building_run_resources
+        assert isinstance(resources, _PersistentRunResources)
         handle = _PersistentDomainHandle(
             kwargs["name"],
             list(kwargs["workers"]),
             int(kwargs["window_size"]),
             len(self.handles),
+            self.worker,
+            resources,
         )
         self.handles.append(handle)
         self.worker._live_domains[handle.name] = handle
+        resources.live_domains[handle.name] = handle
+        resources.requires_ordered_cleanup = True
         return handle
 
     def copy_to(self, worker_id: int, dst: int, src: int, size: int) -> None:
         self.copy_calls.append((worker_id, dst, src, size))
 
-    def _mark_released_domains_freed(self) -> None:
-        for handle in self.handles:
-            if handle.release_count:
-                handle.freed = True
+    def _close_live_domains(self) -> None:
+        first_error: BaseException | None = None
+        for handle in list(self.worker._live_domains.values())[::-1]:
+            try:
+                handle.close_sweep()
+            except BaseException as exc:  # noqa: BLE001 - model best-effort close
+                if first_error is None:
+                    first_error = exc
+        if first_error is not None:
+            raise first_error
 
 
 def _persistent_entry(window_size: int, seen_handles: list[Any]):
@@ -2009,16 +2111,13 @@ class TestPersistentDistributedWorker:
         with pytest.raises(ValueError, match="requires regenerated host orchestration"):
             DistributedWorker(compiled, persistent=True)
 
-    @pytest.mark.parametrize(
-        ("attribute", "value"),
-        [
-            ("_live_domains", None),
-            ("_execute_pending_domain_releases", None),
-        ],
-    )
-    def test_rejects_missing_persistent_runtime_hooks_before_init(self, patched_setup, attribute, value):
+    @pytest.mark.parametrize("attribute", ["_live_domains", "_building_run_resources"])
+    def test_rejects_missing_persistent_runtime_hooks_before_init(self, patched_setup, attribute):
         m = patched_setup
-        setattr(m["worker"], attribute, value)
+        if attribute == "_live_domains":
+            m["worker"]._live_domains = None
+        else:
+            del m["worker"]._building_run_resources
         m["load_entry"].return_value = (_persistent_entry(64, []), None)
         compiled = _fake_compiled([_param("a", [16, 16])], [])
 
@@ -2032,7 +2131,7 @@ class TestPersistentDistributedWorker:
         m = patched_setup
         m["worker"]._live_domains = {}
         orch = _PersistentOrch(m["worker"])
-        m["worker"].run.side_effect = lambda fn: fn(orch, None, None)
+        m["worker"].run.side_effect = orch.run
         seen_handles: list[Any] = []
         window_size = (1 << 20) + 17
         m["load_entry"].return_value = (_persistent_entry(window_size, seen_handles), None)
@@ -2042,6 +2141,14 @@ class TestPersistentDistributedWorker:
         rt = DistributedWorker(compiled, persistent=True)
         arg = DeviceTensor(0x1000, (16, 16), torch.float32)
         rt(arg)
+        handle = orch.handles[0]
+        owner = orch.resources[0]
+        assert owner.live_domains == {}
+        assert owner.retired
+        assert owner.requires_ordered_cleanup
+        assert m["worker"]._live_domains == {"p0:comm_d0": handle}
+        assert not handle.released
+        assert not handle.freed
         rt(arg)
         rt.close()
 
@@ -2059,15 +2166,17 @@ class TestPersistentDistributedWorker:
         ]
         # A retained domain survives both request run-fences and is released
         # once when the persistent dispatcher closes.
-        assert orch.handles[0].release_count == 1
+        assert handle.release_count == 1
+        assert handle.close_sweep_count == 0
+        assert handle.backend_release_count == 1
+        assert handle.freed
         assert m["worker"]._live_domains == {}
-        m["worker"]._execute_pending_domain_releases.assert_called_once_with()
 
     def test_reused_domain_skips_window_reset_when_disabled(self, patched_setup):
         m = patched_setup
         m["worker"]._live_domains = {}
         orch = _PersistentOrch(m["worker"])
-        m["worker"].run.side_effect = lambda fn: fn(orch, None, None)
+        m["worker"].run.side_effect = orch.run
         seen_handles: list[Any] = []
         m["load_entry"].return_value = (_persistent_entry(64, seen_handles), None)
         compiled = _fake_compiled([_param("a", [16, 16])], [])
@@ -2115,13 +2224,9 @@ class TestPersistentDistributedWorker:
             assert task_args_ref is not None
             assert task_args_ref() is not None
 
-        def worker_run(fn):
-            fn(orch, None, None)
-            # The request-owned keepalive stays populated until Worker.run's
-            # completion fence and cleanup return.
-            assert_task_args_alive()
-
-        m["worker"].run.side_effect = worker_run
+        # The request-owned keepalive stays populated until Worker.run's
+        # completion fence and cleanup return.
+        m["worker"].run.side_effect = lambda fn: orch.run(fn, before_retire=assert_task_args_alive)
         m["load_entry"].return_value = (entry, None)
         compiled = _fake_compiled([_param("a", [16, 16])], [])
 
@@ -2138,7 +2243,7 @@ class TestPersistentDistributedWorker:
         m = patched_setup
         m["worker"]._live_domains = {}
         orch = _PersistentOrch(m["worker"])
-        m["worker"].run.side_effect = lambda fn: fn(orch, None, None)
+        m["worker"].run.side_effect = orch.run
         seen_a: list[Any] = []
         seen_b: list[Any] = []
         m["load_entry"].side_effect = [
@@ -2173,47 +2278,59 @@ class TestPersistentDistributedWorker:
         # Isolation does not change final ownership: each retained domain is
         # released exactly once when the shared persistent worker closes.
         assert [handle.release_count for handle in orch.handles] == [1, 1]
+        assert [handle.close_sweep_count for handle in orch.handles] == [0, 0]
+        assert [handle.backend_release_count for handle in orch.handles] == [1, 1]
 
     def test_domain_release_error_reaches_close(self, patched_setup):
         m = patched_setup
         m["worker"]._live_domains = {}
         orch = _PersistentOrch(m["worker"])
-        m["worker"].run.side_effect = lambda fn: fn(orch, None, None)
+        m["worker"].run.side_effect = orch.run
         m["load_entry"].return_value = (_persistent_entry(64, []), None)
         compiled = _fake_compiled([_param("a", [16, 16])], [])
         rt = DistributedWorker(compiled, persistent=True)
         rt(DeviceTensor(0x1000, (16, 16), torch.float32))
-        m["worker"]._execute_pending_domain_releases.side_effect = RuntimeError(
-            "persistent domain release failed"
-        )
+        handle = orch.handles[0]
+        handle.release_error = RuntimeError("persistent domain release failed")
 
         with pytest.raises(RuntimeError, match="persistent domain release failed"):
             rt.close()
 
-        assert orch.handles[0].release_count == 1
+        assert handle.release_count == 1
+        assert handle.close_sweep_count == 1
+        # Worker.close() observes the cached backend failure instead of
+        # issuing the collective release a second time.
+        assert handle.backend_release_count == 1
+        assert not handle.freed
+        assert m["worker"]._live_domains == {"p0:comm_d0": handle}
         m["worker"].close.assert_called_once_with()
 
     def test_unfreed_domain_release_reaches_close(self, patched_setup):
         m = patched_setup
         orch = _PersistentOrch(m["worker"])
-        m["worker"].run.side_effect = lambda fn: fn(orch, None, None)
+        m["worker"].run.side_effect = orch.run
         m["load_entry"].return_value = (_persistent_entry(64, []), None)
         compiled = _fake_compiled([_param("a", [16, 16])], [])
         rt = DistributedWorker(compiled, persistent=True)
         rt(DeviceTensor(0x1000, (16, 16), torch.float32))
-        m["worker"]._execute_pending_domain_releases.side_effect = None
+        handle = orch.handles[0]
+        handle.free_on_release = False
 
         with pytest.raises(RuntimeError, match="did not free.*p0:comm_d0"):
             rt.close()
 
-        assert not orch.handles[0].freed
+        assert handle.release_count == 1
+        assert handle.close_sweep_count == 1
+        assert handle.backend_release_count == 1
+        assert handle.freed
+        assert m["worker"]._live_domains == {}
         m["worker"].close.assert_called_once_with()
 
-    def test_dispatch_error_reaches_caller_and_releases_domain(self, patched_setup):
+    def test_dispatch_error_defers_domain_to_worker_close(self, patched_setup):
         m = patched_setup
         m["worker"]._live_domains = {}
         orch = _PersistentOrch(m["worker"])
-        m["worker"].run.side_effect = lambda fn: fn(orch, None, None)
+        m["worker"].run.side_effect = orch.run
 
         def failing_entry(
             orch,
@@ -2244,44 +2361,51 @@ class TestPersistentDistributedWorker:
 
         with pytest.raises(RuntimeError, match="persistent dispatch failed"):
             rt(arg)
+        handle = orch.handles[0]
+        owner = orch.resources[0]
+        assert owner.retired
+        assert owner.live_domains == {}
+        assert handle.release_count == 0
+        assert handle.close_sweep_count == 0
+        assert m["worker"]._live_domains == {"p0:comm_d0": handle}
+
         rt.close()
 
-        # The failing request's Worker.run completes before the error reaches
-        # the caller, then dispatcher teardown releases the retained domain.
-        assert orch.handles[0].release_count == 1
+        # A failed request never calls handle.release(): even a conservatively
+        # unretired owner must stay globally reachable for whole-tree teardown.
+        assert handle.release_count == 0
+        assert handle.close_sweep_count == 1
+        assert handle.backend_release_count == 1
+        assert handle.freed
+        assert m["worker"]._live_domains == {}
         assert m["worker"].run.call_count == 1
 
-    def test_dispatch_error_keeps_teardown_error_as_context(self, patched_setup):
+    def test_abandoned_run_keeps_domain_reachable_for_worker_close(self, patched_setup):
         m = patched_setup
         orch = _PersistentOrch(m["worker"])
-        m["worker"].run.side_effect = lambda fn: fn(orch, None, None)
-
-        def failing_entry(
-            orch,
-            _args,
-            config,
-            *,
-            tensors,
-            callables,
-            sub_ids,
-            _keep,
-            world_size,
-            _domain_provider=None,
-        ):
-            del orch, _args, config, tensors, callables, sub_ids, _keep, world_size, _domain_provider
-            raise RuntimeError("persistent dispatch failed")
-
-        m["load_entry"].return_value = (failing_entry, None)
-        m["worker"]._execute_pending_domain_releases.side_effect = RuntimeError("persistent teardown failed")
+        m["worker"].run.side_effect = orch.run_with_abandoned_finalization
+        m["load_entry"].return_value = (_persistent_entry(64, []), None)
         compiled = _fake_compiled([_param("a", [16, 16])], [])
         rt = DistributedWorker(compiled, persistent=True)
 
-        with pytest.raises(RuntimeError, match="persistent dispatch failed") as exc_info:
+        with pytest.raises(RuntimeError, match="run finalization abandoned"):
             rt(DeviceTensor(0x1000, (16, 16), torch.float32))
 
-        assert isinstance(exc_info.value.__context__, RuntimeError)
-        assert str(exc_info.value.__context__) == "persistent teardown failed"
+        handle = orch.handles[0]
+        owner = orch.resources[0]
+        assert not owner.retired
+        assert owner.live_domains == {}
+        assert owner.pending_release_domains == []
+        assert handle.release_count == 0
+        assert m["worker"]._live_domains == {"p0:comm_d0": handle}
+
         rt.close()
+
+        assert handle.release_count == 0
+        assert handle.close_sweep_count == 1
+        assert handle.backend_release_count == 1
+        assert handle.freed
+        assert m["worker"]._live_domains == {}
 
     def test_dispatch_error_waits_for_request_worker_cleanup(self, patched_setup):
         m = patched_setup
@@ -2290,17 +2414,13 @@ class TestPersistentDistributedWorker:
         request_finalizer_started = threading.Event()
         allow_request_finalizer_to_finish = threading.Event()
 
-        def worker_run(fn):
-            try:
-                fn(orch, None, None)
-            except BaseException:
-                # Model the interval between orchestration failing and this
-                # request's Worker.run fence/cleanup finally completing.
-                request_finalizer_started.set()
-                assert allow_request_finalizer_to_finish.wait(timeout=2)
-                raise
+        def wait_for_request_finalizer() -> None:
+            # Model the interval between orchestration failing and this
+            # request's Worker.run fence/cleanup finally completing.
+            request_finalizer_started.set()
+            assert allow_request_finalizer_to_finish.wait(timeout=2)
 
-        m["worker"].run.side_effect = worker_run
+        m["worker"].run.side_effect = lambda fn: orch.run(fn, on_error=wait_for_request_finalizer)
 
         def failing_entry(
             orch,

--- a/tests/ut/runtime/test_log_config.py
+++ b/tests/ut/runtime/test_log_config.py
@@ -1,0 +1,42 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Tests for PyPTO runtime log-level synchronization."""
+
+from unittest.mock import patch
+
+import pytest
+from pypto import LogLevel
+from pypto.runtime.log_config import _sync_to_pypto
+
+
+@pytest.mark.parametrize(
+    ("threshold", "expected"),
+    [
+        (10, LogLevel.DEBUG),
+        (11, LogLevel.INFO),
+        (20, LogLevel.INFO),
+        (21, LogLevel.WARN),
+        (25, LogLevel.WARN),
+        (30, LogLevel.WARN),
+        (31, LogLevel.ERROR),
+        (40, LogLevel.ERROR),
+        (41, LogLevel.NONE),
+        (60, LogLevel.NONE),
+    ],
+)
+def test_sync_to_pypto_matches_simpler_severity_thresholds(threshold, expected):
+    with patch("pypto.pypto_core.set_log_level") as set_log_level:
+        _sync_to_pypto(threshold)
+
+    set_log_level.assert_called_once_with(expected)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/ut/runtime/test_pto_isa_resolution.py
+++ b/tests/ut/runtime/test_pto_isa_resolution.py
@@ -9,49 +9,14 @@
 
 """Regression tests for device-runner diagnostics and PTO-ISA resolution."""
 
-import importlib
 import logging
 import sys
-from types import ModuleType, SimpleNamespace
+from types import ModuleType
 from unittest.mock import Mock
 
 import pytest
 
 _RUNTIME_PIN = "83d01313d9bfc247c4b7c8bcf969d1019f0d106f"
-
-
-@pytest.fixture
-def device_runner(monkeypatch):
-    """Import ``device_runner`` without requiring the optional simpler package."""
-    import pypto.runtime as runtime_package  # noqa: PLC0415
-
-    fake_kernel_compiler = SimpleNamespace(KernelCompiler=object)
-    fake_task_interface = SimpleNamespace(
-        CallConfig=object,
-        ChipCallable=object,
-        ChipStorageTaskArgs=object,
-        CoreCallable=object,
-        Worker=object,
-        make_tensor_arg=object,
-        scalar_to_uint64=object,
-    )
-    monkeypatch.setitem(sys.modules, "pypto.runtime.kernel_compiler", fake_kernel_compiler)
-    monkeypatch.setitem(sys.modules, "pypto.runtime.task_interface", fake_task_interface)
-
-    module_name = "pypto.runtime.device_runner"
-    previous = sys.modules.pop(module_name, None)
-    previous_attribute = getattr(runtime_package, "device_runner", None)
-    try:
-        module = importlib.import_module(module_name)
-        yield module
-    finally:
-        sys.modules.pop(module_name, None)
-        if previous is not None:
-            sys.modules[module_name] = previous
-        if previous_attribute is not None:
-            setattr(runtime_package, "device_runner", previous_attribute)
-        elif hasattr(runtime_package, "device_runner"):
-            delattr(runtime_package, "device_runner")
 
 
 def _configure_existing_clone(device_runner, monkeypatch, tmp_path):

--- a/tests/ut/runtime/test_replay.py
+++ b/tests/ut/runtime/test_replay.py
@@ -88,6 +88,17 @@ def test_invalidate_binary_cache_walks_next_levels(tmp_path: Path) -> None:
     assert cpp_r0.exists(), "cpp source must not be deleted"
 
 
+def test_invalidate_binary_cache_discards_context_stamps(tmp_path: Path) -> None:
+    """Manual replay invalidation cannot leave partial rebuilds authorized."""
+    root_stamp = _touch(tmp_path / "cache" / "binary_context.json")
+    rank_stamp = _touch(tmp_path / "next_levels" / "rank0" / "cache" / "binary_context.json")
+
+    invalidate_binary_cache(tmp_path)
+
+    assert not root_stamp.exists()
+    assert not rank_stamp.exists()
+
+
 def test_invalidate_binary_cache_noop_on_empty_dir(tmp_path: Path) -> None:
     invalidate_binary_cache(tmp_path)  # must not raise
 

--- a/tests/ut/runtime/test_run_config.py
+++ b/tests/ut/runtime/test_run_config.py
@@ -398,6 +398,7 @@ class TestMakeCallConfigRing:
         from pypto.ir.distributed_compiled_program import DistributedConfig  # noqa: PLC0415
 
         cfg = _make_dist_call_config_with_fake(DistributedConfig(), None, monkeypatch)
+        assert cfg.aicpu_thread_num == 0
         assert cfg.runtime_env.ring_task_window == 0
         assert cfg.runtime_env.ring_heap == 0
         assert cfg.runtime_env.ring_dep_pool == 0


### PR DESCRIPTION
## TL;DR

- **Runtime pin:** advance Simpler from `dccb8379` to `3165cc89` (**119 upstream commits**).
- **Runtime integration:** adapt PyPTO to the new logging, AICPU, Worker memory, CommDomain, cleanup, and host-build-graph contracts.
- **Binary safety:** prevent stale or partially rebuilt `.bin` / `.so` / `.o` files from being reused after a runtime or PTO-ISA change.
- **Codegen correctness:** fix all three `pto.make_tensor_view` emitters to generate PTOAS-compatible syntax.
- **Coverage:** update the affected code, templates, examples, EN/ZH docs, and regression tests.
- **Current status:** all CI jobs that ran at `9f9d5047` are green; the PR only awaits required review.

## What changed, and why

### 1. Update the Simpler runtime pin

```text
dccb8379080b43173744b9981de2542b3d025e19
  -> 3165cc89b6ea6b58a0bc01cbec2d5f72f2029c35
```

**Why:** PyPTO needs the latest runtime lifecycle, scheduling, A5, validation, and documentation fixes.

**What changed:** the `runtime` submodule now points to `3165cc89`. The 119 upstream commits include:

- progressable Worker lifecycle, callable-admission fencing, cooperative initialization cancellation, and retryable cleanup;
- public Worker memory APIs and stricter memory-range checks;
- architecture-aware AICPU defaults (`a2a3: 4`, `a5: 5`);
- named logging levels and runtime build-revision stamping;
- A5 host-build-graph, SDMA workspace, TMR scheduling, swimlane, and DFX updates;
- generation-safe scheduling, pipeline, endpoint, and launch-acceptance fixes;
- larger chip-level argument sets and updated task-interface data types;
- host-build-graph validation for invalid block/subtask totals and forged producer IDs;
- deterministic 128-bit MIX placement and teardown with a single cleanup owner;
- Simpler documentation landing pages and strict dead-link checking.

### 2. Migrate runtime logging levels

**Why:** Simpler replaced `v0..v9` with named levels, so the old values are no longer valid runtime options.

**What changed:**

- use `debug`, `info`, `timing`, `warn`, `error`, and `null` throughout runtime-facing configuration;
- use `timing` for benchmark `[STRACE]` output;
- map Simpler levels to PyPTO levels as follows:
  - `debug -> DEBUG`
  - `info -> INFO`
  - `timing/warn -> WARN`
  - `error -> ERROR`
  - `null -> NONE`
- update pytest options, replay help, generated debug runners, examples, tests, and EN/ZH logging docs.

`timing` maps to `WARN` because PyPTO has no timing-only tier; mapping it to `INFO` would also enable unrelated compiler messages.

### 3. Make AICPU thread defaults architecture-aware

**Why:** the previous hard-coded default of four threads is correct for A2/A3 but not A5.

**What changed:**

- change `DistributedConfig.aicpu_thread_num` from `4` to `0`;
- define `0` as “let the runtime select the platform default”;
- the runtime selects `4` for A2/A3 and `5` for A5;
- preserve explicit user overrides and runtime-side limit validation;
- synchronize generated `RUNTIME_CONFIG`, all seven independent collective templates, examples, fallbacks, metadata tests, and docs.

### 4. Use public Worker memory APIs

**Why:** direct calls through the private Orchestrator facade bypass the Worker lifecycle admission and synchronization added by the new runtime.

**What changed:**

- route `malloc`, `free`, `copy_to`, and `copy_from` through public Simpler `Worker` methods;
- adapt payload and `worker_id` argument ordering;
- cover default and non-zero workers, stacked tensors, rollback, copy, and auto-free paths.

### 5. Preserve persistent CommDomain ownership correctly

**Why:** the new runtime tracks domains in both Worker-level ownership and the active run-resource journal. Removing the wrong claim can release a persistent domain too early or lose ownership after a failed dispatch.

**What changed:**

- recognize Worker `_live_domains` and active-run `_building_run_resources.live_domains`;
- under `domain_lock`, remove only the run-local claim and retain the Worker-level claim;
- reject missing hooks, mismatched handles, and retired run journals explicitly;
- release retained domains only after the final run fence succeeds;
- on dispatch/finalization failure, leave reclamation to `Worker.close()` to avoid leaks, premature release, and double release.

### 6. Make Worker cleanup retryable without repeating teardown

**Why:** cleanup may be interrupted or fail partway through. A Worker must remain closed to new work while allowing its incomplete runtime cleanup journal to make progress later.

**What changed:**

- track logical closure separately from cleanup completion;
- allow later `close()` calls to retry only unfinished cleanup;
- avoid repeating one-time tensor, handle, persistent-dispatcher, and inherited-reference teardown;
- give locally owned one-shot and partially constructed Workers one bounded cleanup retry because they are never returned to users;
- preserve the primary execution/construction exception when cleanup also fails;
- preserve `KeyboardInterrupt` / `SystemExit` when no earlier operation error exists.

### 7. Add a fail-closed generated-binary compatibility transaction

**Why:** generated paths and source text may stay unchanged while runtime or PTO-ISA ABI changes. Reusing an old binary can therefore fail much later with an opaque runtime error.

**What changed:** every work directory now records a compatibility context containing:

- schema version;
- platform;
- runtime name;
- exact runtime source/build revision;
- exact PTO-ISA revision.

The transaction then:

1. resolves a clean runtime checkout revision, or installed `_task_interface.__build_commit__`;
2. fails closed for dirty/unreadable runtime sources or an unverifiable PTO-ISA checkout;
3. invalidates mismatched, malformed, legacy, or unknown contexts;
4. removes `cache/*.bin` and generated `.so` / `.o` files while preserving generated source;
5. holds one `fcntl.flock` across validation, compilation, assembly, and stamping;
6. removes the old stamp before building;
7. atomically writes a new stamp only after every binary succeeds.

This prevents an interrupted build from authorizing partial artifacts. L3 rank sub-builds use the same transaction independently. Replay now shares this implementation, and `--no-recompile` no longer bypasses runtime/PTO-ISA compatibility checks.

No new schema field is required for the final HBG update: the exact `runtime_revision=3165cc89...` already invalidates artifacts built with any earlier runtime revision.

### 8. Align host-build-graph behavior and documentation

**Why:** older comments described producer/consumer spin-waiting as a universal guarantee, but the current HBG runtime has a narrower contract.

**What changed:**

- keep generated code using `get_tensor_data<T>()` / `set_tensor_data<T>()`;
- document that HBG graph construction uses registered host views of external tensors;
- document that task-produced/runtime-created tensors are unsupported in this path;
- clarify that forged or unbound producer IDs return `INVALID_ARGS`;
- update production comments and regression descriptions without changing the public API or adding a redundant PyPTO verifier.

The pinned runtime itself also validates invalid launch widths, preserves the full 128-bit MIX placement mask, and publishes cleanup only after final runtime destruction.

### 9. Fix `pto.make_tensor_view` syntax in all emitters

**Why:** three emitters generated a missing-space form that PTOAS reports as `expected ':'` during distributed codegen.

```text
# Before
{layout = ...}: !pto.tensor_view

# After
{layout = ...} : !pto.tensor_view
```

**What changed:** fix and test the tensor-parameter, tensor-view alias, and gather-row DN-view generation paths.

### 10. Synchronize docs, templates, examples, and tests

The final diff contains **52 paths (`+1407/-406`)**:

- 10 documentation files;
- 17 Python, example, and template files;
- 4 C++ codegen files;
- 20 test files;
- 1 runtime submodule pointer.

The redundancy review found no removable functional changes:

- the seven collective templates are separate packaged inputs and must remain synchronized;
- EN/ZH documentation changes are repository pairs;
- Worker/cache tests cover different lifecycle, failure, concurrency, and compatibility branches;
- the duplicate `device_runner` fixture was consolidated into `tests/ut/conftest.py`;
- replay's duplicate cache invalidator was removed in favor of the shared implementation;
- HBG behavior remains covered by Simpler's paired A2/A3 and A5 simulator tests instead of a duplicate PyPTO verifier.

The final `ci: retry codegen tests` commit is intentionally empty. It only retriggered CI after the previous self-hosted runner lost communication; the rerun passed.

## User-visible behavior

| Before | After |
| --- | --- |
| Runtime log options used `v0..v9` | Runtime log options use named severity levels |
| AICPU default was always `4` | `0` selects `4` on A2/A3 and `5` on A5 |
| Memory operations bypassed Worker admission | Memory operations use public Worker APIs |
| Persistent domains could be retired at the wrong ownership layer | Run-local and Worker ownership are handled separately |
| Cleanup was treated as a single terminal action | Incomplete cleanup can be retried safely |
| Cached binaries had no runtime/PTO-ISA identity | Incompatible or unverifiable artifacts are invalidated before use |
| HBG comments implied universal producer waiting | Docs state the actual registered-external-tensor contract |
| Three tensor-view emitters produced PTOAS-invalid text | All emitters produce canonical `} : !pto.tensor_view` syntax |

## Validation

At head `9f9d5047`, all executed GitHub CI and Docs checks are green, including Linux/macOS unit tests, codegen tests, system/direct/distributed tests, A5 simulation, pypto-lib model tests, pre-commit, clang-tidy, Docs, and CodeRabbit.

<details>
<summary>Full local validation</summary>

- [x] Runtime source and `_task_interface.__build_commit__` both resolve to `3165cc89b6ea`
- [x] Native Simpler editable rebuild
- [x] PyPTO unit tests — **8,752 passed, 2 skipped**
- [x] Simpler non-hardware Python tests — **1,072 passed, 13 skipped, 14 deselected**
- [x] Simpler non-hardware C++ tests — **79/79 passed**
- [x] Distributed Worker tests — **132 passed**
- [x] Focused PyPTO runtime/cache compatibility tests — **407 passed**
- [x] Final binary-cache/Worker rerun — **63 passed**
- [x] Focused Simpler Worker lifecycle tests — **99 passed**
- [x] HBG validation/wide-dispatch/prepared-callable simulation — **11 passed on A2/A3 simulator and 11 passed on A5 simulator**
- [x] Tensor read/write orchestration codegen — **92 passed**
- [x] Exact whitespace regressions — **3 passed**
- [x] A2/A3 hello-world simulation
- [x] A5 hello-world simulation twice, including cache reuse
- [x] Persistent two-rank CommDomain simulation
- [x] `pre-commit run --all-files`
- [x] Full clang-tidy gate
- [x] PyPTO and Simpler `mkdocs build --strict`
- [x] `git diff --check origin/main`

</details>

<details>
<summary>Hardware validation note</summary>

Local hardware execution was unavailable because DCMI initialization failed with `npu-smi` error `-8005`. In an earlier PR run, shared devices 8–11 failed during AICPU bootstrap with `ACL_ERROR_RT_AICPU_EXCEPTION (507018)`; contemporaneous `main` and unrelated PR runs showed the same infrastructure failure, while both Qwen3 jobs from this branch passed on device 15.

</details>

## Scope boundaries

- Persistent CommDomain retention currently relies on Simpler's pinned private `_live_domains` and `_building_run_resources` hooks. A future public retention API should encapsulate this integration.
- The binary-context stamp covers runtime/PTO-ISA compatibility; it is not a universal fingerprint of every PyPTO, CANN, compiler, or flag input.
- The improved missing-`kernel_config.py` diagnostic is not part of this diff; it was split out and has already merged in PR #2155.
