### PR TITLE
fix(runtime): Expose stacked tensor shape

### DIFF
--- a/python/pypto/runtime/device_tensor.py
+++ b/python/pypto/runtime/device_tensor.py
@@ -104,6 +104,8 @@ class StackedDeviceTensor:
         shards: One :class:`DeviceTensor` per leading-dim index; ``shards[i]`` is
             resident on worker ``worker_ids[i]`` with shape ``full_shape[1:]``.
         full_shape: The logical stacked shape ``(B, *tail)``.
+        shape: Alias for ``full_shape``, matching the :class:`DeviceTensor`
+            interface.
         worker_ids: ``worker_ids[i]`` is the worker holding ``shards[i]``.
     """
 
@@ -158,6 +160,11 @@ class StackedDeviceTensor:
     def dtype(self) -> torch.dtype:
         """Element ``torch.dtype`` shared by all shards."""
         return self.shards[0].dtype
+
+    @property
+    def shape(self) -> tuple[int, ...]:
+        """Logical stacked shape, matching the ``DeviceTensor`` interface."""
+        return self.full_shape
 
     def __getitem__(self, idx: int | slice | tuple) -> DeviceTensor:
         """Return shard ``i`` for a leading-index ``i`` or ``(i, <full slices>)``.

--- a/tests/ut/runtime/test_device_tensor.py
+++ b/tests/ut/runtime/test_device_tensor.py
@@ -113,6 +113,7 @@ class TestStackedDeviceTensorConstruction:
         s = StackedDeviceTensor(sh, (3, 4, 5), (0, 1, 2))
         assert s.shards == tuple(sh)
         assert s.full_shape == (3, 4, 5)
+        assert s.shape == (3, 4, 5)
         assert s.worker_ids == (0, 1, 2)
         assert s.dtype is torch.float32
 


### PR DESCRIPTION
## Summary

- expose `StackedDeviceTensor.shape` as an alias for `full_shape`
- keep the stacked handle compatible with the `DeviceTensor` metadata interface
- document the alias in the class docstring and add regression coverage

## Why

Callers that handle `DeviceTensor` and `StackedDeviceTensor` uniformly expect both objects to expose logical shape metadata through `.shape`. `StackedDeviceTensor` previously stored the same information only as `.full_shape`, forcing special-case handling.

## Impact

Existing `full_shape` behavior is unchanged. Runtime callers can now read `stacked.shape` and receive the logical `(B, *tail)` shape.

## Testing

- fresh CMake build (`RelWithDebInfo`)
- focused runtime and operator-registry tests: `47 passed`
- full unit suite: `7576 passed, 2 skipped`
- applicable pre-commit hooks: headers, English-only, docs parity, Ruff check/format, and Pyright

No standalone developer documentation change is needed because this is a small runtime metadata accessor; the public class docstring now documents the new attribute.