### PR TITLE
fix(ir): Admit per-lane ops in explicit split_aiv regions

### DIFF
--- a/docs/en/dev/passes/18-lower_auto_vector_split.md
+++ b/docs/en/dev/passes/18-lower_auto_vector_split.md
@@ -143,6 +143,36 @@ Three region body shapes are handled, selected by the region's `split_` mode:
   kernels) — so both lanes run the full body. Use this when the region's tiles
   cannot be halved (unit dims) or a reduction must stay full-width.
 
+### What may appear inside an explicit-boundary region
+
+Because that body is spliced through **unchanged**, every vector op in it must
+already be per-lane — an op left at full width would run identically on both AIV
+lanes. `ValidateMixedExplicitRegion` enforces this and rejects the region with an
+actionable error naming the offending ops. A tile-producing op is accepted when
+any of the following holds:
+
+| Accepted | Why |
+| -------- | --- |
+| Consumes a `tile.aiv_shard` result (transitively) | It is in the half-width dataflow by construction. |
+| A pure generator — `tile.full` / `tile.ci` / `tile.random` (and `tile.create`, which classifies `SHARED` and so was never reportable anyway) | Its result is a function of its attributes only: it reads no tile and no memory, so per-lane replication is correct at whatever extent the author wrote. |
+| An address-carrying op — `tile.load` / `tile.slice` / `tile.extract` — whose args reference the region's `aiv_id` | The author localized it explicitly, e.g. `data[base + aiv_id * HALF : ...]`. |
+
+Anything else that classifies `VECTOR` is reported. Two consequences worth
+knowing:
+
+- A generator is accepted for **itself only** — it does not join the half-width
+  dataflow. `z = pl.full([FULL, N]); y = pl.add(z, z)` still rejects on `y`,
+  because a full-width generator must not vouch for its consumers.
+- The lane reference is trusted **only** on an addressing op. On anything else a
+  lane-derived scalar is just an operand and proves nothing about width — so
+  `pl.set_validshape(full_width_tile, 1, aiv_id * HALF)` cannot launder a full
+  tile into the region.
+
+The guard proves *intent*, not *extent*: a load at a lane-strided offset but a
+full-width extent is accepted, and the two lanes then read overlapping windows.
+That is the same trust already extended to `tile.store`, whose lane-dependent
+offset the pass never checks.
+
 Because the region is built via the generic `BeginScope`/`EndScope` and is
 non-outlined, it can be **nested** inside a `pl.range` / `pl.pipeline` loop or an
 `if`; the region path recurses into compound statements to find and lower every

--- a/docs/en/dev/passes/18-lower_auto_vector_split.md
+++ b/docs/en/dev/passes/18-lower_auto_vector_split.md
@@ -155,7 +155,7 @@ any of the following holds:
 | -------- | --- |
 | Consumes a `tile.aiv_shard` result (transitively) | It is in the half-width dataflow by construction. |
 | A pure generator — `tile.full` / `tile.ci` / `tile.random` (and `tile.create`, which classifies `SHARED` and so was never reportable anyway) | Its result is a function of its attributes only: it reads no tile and no memory, so per-lane replication is correct at whatever extent the author wrote. |
-| An address-carrying op — `tile.load` / `tile.slice` / `tile.extract` — whose args reference the region's `aiv_id` | The author localized it explicitly, e.g. `data[base + aiv_id * HALF : ...]`. |
+| An address-carrying op — `tile.load` / `tile.slice` / `tile.extract` — whose **address** args reference the region's `aiv_id` | The author localized it explicitly, e.g. `data[base + aiv_id * HALF : ...]`. Only the offset args count (`tile.load` arg 1, `tile.slice` arg 2, `tile.extract` args 1–2) — a lane reference in a `shape` or `valid_shape` does not move the window, so it does not admit. |
 
 Anything else that classifies `VECTOR` is reported. Two consequences worth
 knowing:

--- a/docs/zh-cn/dev/passes/18-lower_auto_vector_split.md
+++ b/docs/zh-cn/dev/passes/18-lower_auto_vector_split.md
@@ -109,6 +109,31 @@ result = passes.lower_auto_vector_split()(program)
   lane-0-only 的非拆分 replay（后者只针对非 `split_aiv` 核）——故两个 lane 都运行完整函数体。
   当区域的 tile 无法折半（单位维）或归约必须保持全宽时使用本模式。
 
+### 显式边界区域内允许出现哪些算子
+
+由于该区域体是**原样**拼接的，其中每个 vector 算子都必须已经是 per-lane 的——保持全宽的
+算子会在两个 AIV lane 上运行出完全相同的结果。`ValidateMixedExplicitRegion` 负责校验这一
+点，并以可操作的错误信息列出违规算子。满足以下任一条件的 tile 生成算子会被接受：
+
+| 接受条件 | 原因 |
+| -------- | ---- |
+| （传递地）消费了 `tile.aiv_shard` 的结果 | 依构造即处于 half-width 数据流中。 |
+| 纯生成算子——`tile.full` / `tile.ci` / `tile.random`（以及 `tile.create`，它归类为 `SHARED`，本就不会被报告） | 其结果仅是自身属性的函数：不读取任何 tile、不读取内存，因此无论作者写的是什么 extent，per-lane 复制都是正确的。 |
+| 携带**地址**的算子——`tile.load` / `tile.slice` / `tile.extract`——且其参数引用了区域的 `aiv_id` | 作者已显式做了 per-lane 定位，例如 `data[base + aiv_id * HALF : ...]`。 |
+
+其余归类为 `VECTOR` 的算子都会被报告。有两点需要注意：
+
+- 生成算子**仅对其自身**被接受，它不会加入 half-width 数据流。
+  `z = pl.full([FULL, N]); y = pl.add(z, z)` 仍会在 `y` 处被拒绝——全宽生成算子不得为其
+  消费者背书。
+- lane 引用**仅**在携带地址的算子上被信任。在其他算子上，lane 派生的标量只是一个普通操作数，
+  并不能说明结果的宽度——因此 `pl.set_validshape(full_width_tile, 1, aiv_id * HALF)`
+  无法把一个全宽 tile 洗白进区域。
+
+该校验证明的是**意图**而非**范围**：偏移按 lane 跨步、但 extent 仍为全宽的 load 会被接受，
+此时两个 lane 会读到重叠的窗口。这与本 pass 从不检查 `tile.store` 的 lane 相关偏移是同一种
+信任。
+
 由于区域经由通用的 `BeginScope`/`EndScope` 构建且不被提取，它可**嵌套**在 `pl.range` /
 `pl.pipeline` 循环或 `if` 之内；区域路径会递归进入复合语句，找到并下降每个区域，同时保留
 外围控制流。

--- a/docs/zh-cn/dev/passes/18-lower_auto_vector_split.md
+++ b/docs/zh-cn/dev/passes/18-lower_auto_vector_split.md
@@ -119,7 +119,7 @@ result = passes.lower_auto_vector_split()(program)
 | -------- | ---- |
 | （传递地）消费了 `tile.aiv_shard` 的结果 | 依构造即处于 half-width 数据流中。 |
 | 纯生成算子——`tile.full` / `tile.ci` / `tile.random`（以及 `tile.create`，它归类为 `SHARED`，本就不会被报告） | 其结果仅是自身属性的函数：不读取任何 tile、不读取内存，因此无论作者写的是什么 extent，per-lane 复制都是正确的。 |
-| 携带**地址**的算子——`tile.load` / `tile.slice` / `tile.extract`——且其参数引用了区域的 `aiv_id` | 作者已显式做了 per-lane 定位，例如 `data[base + aiv_id * HALF : ...]`。 |
+| 携带**地址**的算子——`tile.load` / `tile.slice` / `tile.extract`——且其**地址参数**引用了区域的 `aiv_id` | 作者已显式做了 per-lane 定位，例如 `data[base + aiv_id * HALF : ...]`。仅偏移参数计入（`tile.load` 第 1 个、`tile.slice` 第 2 个、`tile.extract` 第 1–2 个）——出现在 `shape` 或 `valid_shape` 中的 lane 引用并不会移动窗口，因此不予接受。 |
 
 其余归类为 `VECTOR` 的算子都会被报告。有两点需要注意：
 

--- a/src/ir/transforms/lower_auto_vector_split_pass.cpp
+++ b/src/ir/transforms/lower_auto_vector_split_pass.cpp
@@ -483,32 +483,114 @@ void ValidateTransposeSplitHazard(const std::vector<StmtPtr>& stmts, int split_d
   }
 }
 
+// Mutable state shared across the whole region walk, so propagation follows
+// program order. Bundled (rather than threaded as three out-params) to match
+// split_axis::SubblockInjectionResult, which this file already unpacks.
+struct HalfWidthScan {
+  std::unordered_set<const Var*> half_tiles;    // in the aiv_shard half-width dataflow
+  std::unordered_set<const Var*> lane_scalars;  // derived from the region's lane index
+  std::vector<std::string> full_width_vec_ops;  // offenders to report
+};
+
+// True iff any Var / IterArg referenced anywhere in ``exprs`` is lane-derived.
+// One collector over all of them: the walk covers each whole expression tree, so
+// a lane reference nested inside a MakeTuple offset list or an arithmetic
+// sub-expression is found. VarDefUseCollector overrides both the Var and the
+// IterArg handler (see var_collectors.h) — a loop-carried lane offset is a
+// reference too.
+bool ReferencesLaneIndex(const std::vector<ExprPtr>& exprs,
+                         const std::unordered_set<const Var*>& lane_scalars) {
+  if (lane_scalars.empty()) return false;
+  var_collectors::VarDefUseCollector collector;
+  for (const auto& e : exprs) {
+    if (e) collector.VisitExpr(e);
+  }
+  for (const auto* v : collector.var_uses) {
+    if (lane_scalars.count(v) != 0) return true;
+  }
+  return false;
+}
+
+// Ops that carry an ADDRESS (a base offset into GM or into a larger tile), so a
+// lane-derived scalar among their args genuinely selects this lane's window. For
+// every other op a lane-derived operand is just a value and says nothing about
+// the result's width — see the laundering note at the use site.
+bool IsAddressingOp(const CallPtr& call) {
+  return IsOp(call, "tile.load") || IsOp(call, "tile.slice") || IsOp(call, "tile.extract");
+}
+
 // Track tiles that are part of the half-width boundary dataflow: results of
 // tile.aiv_shard, plus results of VECTOR-affine ops that consume such a half
 // tile. Any VECTOR-affine op consuming NONE of them operates on full-width data
 // — exactly what the implicit affinity gate would have halved. Records the names
-// of such full-width vector ops (a single ordered walk; ``half_tiles`` is shared
-// across recursion so the propagation follows program order).
-void ScanRegionHalfWidth(const std::vector<StmtPtr>& stmts, std::unordered_set<const Var*>& half_tiles,
-                         std::vector<std::string>& full_width_vec_ops) {
+// of such full-width vector ops in a single ordered walk.
+void ScanRegionHalfWidth(const std::vector<StmtPtr>& stmts, HalfWidthScan& scan) {
   for (const auto& stmt : stmts) {
     CallPtr leaf;
     VarPtr def_var;
-    if (auto assign = std::dynamic_pointer_cast<const AssignStmt>(stmt)) {
+    auto assign = std::dynamic_pointer_cast<const AssignStmt>(stmt);
+    if (assign) {
       leaf = AsCall(assign->value_);
       def_var = assign->var_;
     } else if (auto eval = std::dynamic_pointer_cast<const EvalStmt>(stmt)) {
       leaf = AsCall(eval->expr_);
     }
+
+    // --- Lane-index dataflow (SCALARS) --------------------------------------
+    // SEED: the region's own lane index, bound by ``aiv_id =
+    // tile.get_subblock_idx()`` (the parser emits it as the region body's first
+    // statement — ast_parser.py::_emit_split_aiv_region). Matched by OP, not by
+    // position, so a re-injected or reordered binding is still found. The parser
+    // emits it unconditionally, so the set is normally non-empty from statement
+    // one; it stays empty only if the binding is absent (e.g. DCE stripped an
+    // unused aiv_id, or hand-built IR omits it), in which case nothing is
+    // admitted below and the guard behaves exactly as before.
+    // PROPAGATE: any scalar bound from an expression referencing a lane-derived
+    // scalar (``kv_lane0 = kv0 + aiv_id * 64``). Program order + SSA put every
+    // def before its uses, so one forward pass reaches the fixpoint. A lane value
+    // carried through a loop iter_arg is NOT propagated (the walk does not visit
+    // loop phi defs) — conservative: it rejects rather than wrongly admits.
+    if (def_var && As<ScalarType>(def_var->GetType()) &&
+        (IsOp(leaf, "tile.get_subblock_idx") ||
+         // ``assign &&`` is defensive: def_var is currently only set in the
+         // AssignStmt arm above, so def_var non-null already implies it.
+         (assign && ReferencesLaneIndex({assign->value_}, scan.lane_scalars)))) {
+      scan.lane_scalars.insert(def_var.get());
+    }
+
     if (leaf && leaf->op_) {
       // aiv_shard produces a HALF tile (the C->V boundary); seed the dataflow.
       if (IsOp(leaf, "tile.aiv_shard")) {
-        if (def_var) half_tiles.insert(def_var.get());
+        if (def_var) scan.half_tiles.insert(def_var.get());
         continue;
       }
       // aic_gather doubles HALF -> FULL (the V->C boundary back to cube); its
       // result leaves the half-width dataflow, so it is not tracked.
       if (IsOp(leaf, "tile.aic_gather")) {
+        continue;
+      }
+      // Pure generators are lane-invariant ROOTS: the result is a function of the
+      // op's ATTRIBUTES ONLY -- they read no tile and no memory, so there is no
+      // "which half do I read?" question for them to get wrong, and replicating
+      // one on both lanes is correct by construction at whatever extent the
+      // author wrote.
+      //
+      // Deliberately NOT inserted into half_tiles: being lane-invariant makes a
+      // generator SAFE, it does not make it HALF-WIDTH. Admitting it would let a
+      // full-width generator vouch for its consumers and silently suppress a real
+      // rejection -- e.g. `z = tile.full([128,128]); y = tile.add(z, z);
+      // tile.store(y, [0,0], out, atomic)`, where both lanes would atomically add
+      // the same full tile (double-counted result). Leaving it NEUTRAL keeps each
+      // consumer judged on its own merits.
+      //
+      // (tile.create is listed for category completeness; it also classifies
+      // SHARED, so the VECTOR arm below would never report it anyway. For
+      // tile.random, replication means both lanes draw the SAME stream from the
+      // same key/counter -- identical to what the implicit path produces, since
+      // halving shrinks the shape, not the stream. Per-lane independence is the
+      // author's job: vary the counter with aiv_id.)
+      if (IsOp(leaf, "tile.full") || IsOp(leaf, "tile.create") || IsOp(leaf, "tile.ci") ||
+          IsOp(leaf, "tile.random")) {
         continue;
       }
       // Dataflow propagation over tile-producing ops. An op that consumes a half
@@ -524,33 +606,47 @@ void ScanRegionHalfWidth(const std::vector<StmtPtr>& stmts, std::unordered_set<c
         bool consumes_half = false;
         for (const auto& arg : leaf->args_) {
           if (auto v = AsVarLike(arg)) {
-            if (half_tiles.count(v.get()) != 0) {
+            if (scan.half_tiles.count(v.get()) != 0) {
               consumes_half = true;
               break;
             }
           }
         }
-        if (consumes_half) {
-          if (def_var) half_tiles.insert(def_var.get());  // stays in the half-width dataflow
+        // Stays in the half-width dataflow when it either consumes a half tile,
+        // or is AUTHOR-LOCALIZED: an ADDRESS-carrying op whose argument
+        // expressions reference the region's lane index, so the author explicitly
+        // wrote it per-lane — e.g. a GM load at ``[kv0 + aiv_id * 64, 0]``. That
+        // is the same trust the pass already extends to tile.store, whose
+        // lane-dependent offset it never checks (a store returns a TensorType, so
+        // it never reaches this branch).
+        //
+        // Localization is trusted only on addressing ops. A lane reference means
+        // "I picked my lane's WINDOW" only where the op takes an address; for a
+        // non-addressing op a lane-derived scalar is just some operand and proves
+        // nothing about width. Without the restriction,
+        // ``tile.set_validshape(full_width_tile, 1, valid_aiv)`` would launder a
+        // full-width tile into the half-width dataflow and silence every
+        // downstream check.
+        if (consumes_half || (!scan.lane_scalars.empty() && IsAddressingOp(leaf) &&
+                              ReferencesLaneIndex(leaf->args_, scan.lane_scalars))) {
+          if (def_var) scan.half_tiles.insert(def_var.get());
         } else if (ClassifyCallAffinity(leaf) == CoreAffinity::VECTOR) {
-          full_width_vec_ops.push_back(leaf->op_->name_);
+          scan.full_width_vec_ops.push_back(leaf->op_->name_);
         }
         continue;
       }
     }
     if (auto for_stmt = std::dynamic_pointer_cast<const ForStmt>(stmt)) {
-      ScanRegionHalfWidth(transform_utils::FlattenToStmts(for_stmt->body_), half_tiles, full_width_vec_ops);
+      ScanRegionHalfWidth(transform_utils::FlattenToStmts(for_stmt->body_), scan);
     } else if (auto if_stmt = std::dynamic_pointer_cast<const IfStmt>(stmt)) {
-      ScanRegionHalfWidth(transform_utils::FlattenToStmts(if_stmt->then_body_), half_tiles,
-                          full_width_vec_ops);
+      ScanRegionHalfWidth(transform_utils::FlattenToStmts(if_stmt->then_body_), scan);
       if (if_stmt->else_body_.has_value()) {
-        ScanRegionHalfWidth(transform_utils::FlattenToStmts(*if_stmt->else_body_), half_tiles,
-                            full_width_vec_ops);
+        ScanRegionHalfWidth(transform_utils::FlattenToStmts(*if_stmt->else_body_), scan);
       }
     } else if (auto while_stmt = std::dynamic_pointer_cast<const WhileStmt>(stmt)) {
-      ScanRegionHalfWidth(transform_utils::FlattenToStmts(while_stmt->body_), half_tiles, full_width_vec_ops);
+      ScanRegionHalfWidth(transform_utils::FlattenToStmts(while_stmt->body_), scan);
     } else if (auto seq = std::dynamic_pointer_cast<const SeqStmts>(stmt)) {
-      ScanRegionHalfWidth(seq->stmts_, half_tiles, full_width_vec_ops);
+      ScanRegionHalfWidth(seq->stmts_, scan);
     }
   }
 }
@@ -564,15 +660,14 @@ void ScanRegionHalfWidth(const std::vector<StmtPtr>& stmts, std::unordered_set<c
 // miscompile). A purely-explicit region — every vector op derived from the
 // aiv_shard result — passes through unchanged.
 void ValidateMixedExplicitRegion(const std::vector<StmtPtr>& stmts, const Span& region_span) {
-  std::unordered_set<const Var*> half_tiles;
-  std::vector<std::string> full_width_vec_ops;
-  ScanRegionHalfWidth(stmts, half_tiles, full_width_vec_ops);
-  if (full_width_vec_ops.empty()) return;
+  HalfWidthScan scan;
+  ScanRegionHalfWidth(stmts, scan);
+  if (scan.full_width_vec_ops.empty()) return;
 
   std::string ops;
-  for (size_t i = 0; i < full_width_vec_ops.size(); ++i) {
+  for (size_t i = 0; i < scan.full_width_vec_ops.size(); ++i) {
     if (i != 0) ops += ", ";
-    ops += full_width_vec_ops[i];
+    ops += scan.full_width_vec_ops[i];
   }
   CHECK_SPAN(false, region_span)
       << "LowerAutoVectorSplit: a pl.split_aiv region mixes explicit "
@@ -580,10 +675,11 @@ void ValidateMixedExplicitRegion(const std::vector<StmtPtr>& stmts, const Span& 
       << ops
       << "] that operate outside the per-lane half-width dataflow. The explicit boundary keeps the "
          "region in half-width form, so these full-width ops would be left un-localized and both AIV "
-         "lanes would compute the full tile. Fix it one of two ways: (1) author the whole region in "
-         "half-width form — derive every vector op from the tile.aiv_shard result; or (2) remove the "
-         "explicit tile.aiv_shard/tile.aic_gather and let the implicit affinity-gated path halve the "
-         "region.";
+         "lanes would compute the full tile. Fix it one of three ways: (1) derive the op from the "
+         "tile.aiv_shard result; (2) localize it yourself with the region's lane index, e.g. load at "
+         "'base + aiv_id * HALF' at the half extent — an op whose arguments reference aiv_id is "
+         "per-lane by construction and is accepted; or (3) remove the explicit "
+         "tile.aiv_shard/tile.aic_gather and let the implicit affinity-gated path halve the region.";
 }
 
 // Top-level walk for the explicit ``SplitAivScopeStmt`` path. Statements OUTSIDE

--- a/src/ir/transforms/lower_auto_vector_split_pass.cpp
+++ b/src/ir/transforms/lower_auto_vector_split_pass.cpp
@@ -511,12 +511,22 @@ bool ReferencesLaneIndex(const std::vector<ExprPtr>& exprs,
   return false;
 }
 
-// Ops that carry an ADDRESS (a base offset into GM or into a larger tile), so a
-// lane-derived scalar among their args genuinely selects this lane's window. For
-// every other op a lane-derived operand is just a value and says nothing about
-// the result's width — see the laundering note at the use site.
-bool IsAddressingOp(const CallPtr& call) {
-  return IsOp(call, "tile.load") || IsOp(call, "tile.slice") || IsOp(call, "tile.extract");
+// The positional args that carry an op's ADDRESS — the base offset selecting
+// which window of the source this call reads. Empty for anything that is not an
+// addressing op.
+//
+// Only these args are consulted for a lane reference. A lane-derived scalar
+// anywhere ELSE in an addressing op — a shape, a valid_shape — does not localize
+// the window: ``tile.load(data, [0, 0], [64, 128], valid_shapes=[aiv_id + 1,
+// 128])`` mentions aiv_id, yet both lanes still read the same base rows. Scanning
+// every arg would admit it and then trust its consumers as half-width.
+std::vector<ExprPtr> AddressArgs(const CallPtr& call) {
+  const auto& args = call->args_;
+  auto at = [&args](size_t i) -> ExprPtr { return i < args.size() ? args[i] : nullptr; };
+  if (IsOp(call, "tile.load")) return {at(1)};            // (tensor, offsets, shapes, valid_shapes)
+  if (IsOp(call, "tile.slice")) return {at(2)};           // (input, shape, offset, valid_shape, drop_dims)
+  if (IsOp(call, "tile.extract")) return {at(1), at(2)};  // (src, index_row, index_col, shape)
+  return {};
 }
 
 // Track tiles that are part of the half-width boundary dataflow: results of
@@ -613,22 +623,20 @@ void ScanRegionHalfWidth(const std::vector<StmtPtr>& stmts, HalfWidthScan& scan)
           }
         }
         // Stays in the half-width dataflow when it either consumes a half tile,
-        // or is AUTHOR-LOCALIZED: an ADDRESS-carrying op whose argument
-        // expressions reference the region's lane index, so the author explicitly
-        // wrote it per-lane — e.g. a GM load at ``[kv0 + aiv_id * 64, 0]``. That
-        // is the same trust the pass already extends to tile.store, whose
-        // lane-dependent offset it never checks (a store returns a TensorType, so
-        // it never reaches this branch).
+        // or is AUTHOR-LOCALIZED: an op whose ADDRESS args reference the region's
+        // lane index, so the author explicitly wrote it per-lane — e.g. a GM load
+        // at ``[kv0 + aiv_id * 64, 0]``. That is the same trust the pass already
+        // extends to tile.store, whose lane-dependent offset it never checks (a
+        // store returns a TensorType, so it never reaches this branch).
         //
-        // Localization is trusted only on addressing ops. A lane reference means
-        // "I picked my lane's WINDOW" only where the op takes an address; for a
-        // non-addressing op a lane-derived scalar is just some operand and proves
-        // nothing about width. Without the restriction,
+        // Localization is trusted only via AddressArgs, and so only on addressing
+        // ops. On any other op a lane-derived scalar is just an operand and proves
+        // nothing about width; without that restriction
         // ``tile.set_validshape(full_width_tile, 1, valid_aiv)`` would launder a
         // full-width tile into the half-width dataflow and silence every
         // downstream check.
-        if (consumes_half || (!scan.lane_scalars.empty() && IsAddressingOp(leaf) &&
-                              ReferencesLaneIndex(leaf->args_, scan.lane_scalars))) {
+        if (consumes_half ||
+            (!scan.lane_scalars.empty() && ReferencesLaneIndex(AddressArgs(leaf), scan.lane_scalars))) {
           if (def_var) scan.half_tiles.insert(def_var.get());
         } else if (ClassifyCallAffinity(leaf) == CoreAffinity::VECTOR) {
           scan.full_width_vec_ops.push_back(leaf->op_->name_);

--- a/tests/ut/ir/transforms/test_lower_auto_vector_split.py
+++ b/tests/ut/ir/transforms/test_lower_auto_vector_split.py
@@ -21,13 +21,25 @@ These tests hand-build a minimal mixed InCore function at the
 post-InferTileMemorySpace level (memory spaces already assigned) and run the pass
 in isolation with verification disabled.
 
-The pass runs at the tile level (post-InferTileMemorySpace), so the ``@pl.program``
-DSL cannot express its input *or* its lowered output. Each transform-output test
-therefore hand-builds both the ``Before`` program and an explicit ``Expected``
-lowered program with the same helpers and asserts ``ir.assert_structural_equal``
-between the pass result and ``Expected`` (the project's mandated transform-test
-style). The two negative tests (reduce-on-split-axis, transpose hazard) keep
-``pytest.raises`` because a rejected transform produces no ``After`` IR.
+Why these tests hand-build IR instead of using the ``@pl.program`` DSL (the
+project's default transform-test style): it is NOT that the DSL cannot express
+the shapes involved — it can author both this pass's tile-level input and, via
+the outlined boundary form (``pl.aiv_shard(qk, split=1)``), its lowered output.
+The blocker is that the DSL wraps a top-level ``for aiv_id in pl.split_aiv(...)``
+in an enclosing ``pl.at``/``ScopeStmt``, and this pass does not descend into a
+ScopeStmt — by the time it runs (pass 18) OutlineIncoreScopes has long since
+removed those. So on DSL-authored input the region is never visited: it survives
+unlowered and ``ValidateMixedExplicitRegion`` never runs, which would make every
+guard test here vacuous. Reproducing pass 18's real input from the DSL needs the
+whole upstream prefix, turning a unit test into an integration test.
+
+Each transform-output test therefore hand-builds both the ``Before`` program and
+an explicit ``Expected`` lowered program with the same helpers and asserts
+``ir.assert_structural_equal`` between the pass result and ``Expected``. Negative
+tests keep ``pytest.raises`` because a rejected transform produces no ``After``
+IR. End-to-end DSL coverage of this authoring form lives in
+``tests/st/codegen/torch/test_torch_codegen_cross_core.py`` (``SplitAivShardProgram``),
+where the numerics are checked against torch.
 
 The per-op vector halving tests (load / slice / reshape / store offset /
 singleton / loop tracking / reduce-on-split-axis throw) were migrated here from
@@ -99,10 +111,10 @@ def _incore_program(params, stmts, return_types, *, mode=ir.SplitMode.UP_DOWN, n
 # ---------------------------------------------------------------------------
 # Expected-IR (lowered-form) construction helpers.
 #
-# LowerAutoVectorSplit runs at the tile level, so the @pl.program DSL cannot
-# author its output. These helpers build the *lowered* Expected the same way the
-# Before is hand-built, so each test asserts via ir.assert_structural_equal
-# against an explicit Expected program (not a python_print substring grep).
+# These build the *lowered* Expected the same way the Before is hand-built, so
+# each test asserts via ir.assert_structural_equal against an explicit Expected
+# program (not a python_print substring grep). See the module docstring for why
+# the DSL is not used to author either side.
 # ---------------------------------------------------------------------------
 
 
@@ -1784,6 +1796,191 @@ def test_mixed_explicit_implicit_region_in_while_rejected():
     )
     with pytest.raises(ValueError, match="mixes explicit"):
         _lower(program)
+
+
+# ---------------------------------------------------------------------------
+# Explicit-region admissions: values that are NOT derived from tile.aiv_shard but
+# are still per-lane by construction. Two classes are admitted — pure generators
+# (tile.full/create/ci/random) and address-carrying ops (tile.load/slice/extract)
+# whose args reference the region's lane index. The rationale for each, and for
+# why a generator is NOT added to half_tiles, lives at ScanRegionHalfWidth in
+# src/ir/transforms/lower_auto_vector_split_pass.cpp — keep it in one place.
+#
+# The explicit path splices the region body through UNCHANGED, so a positive
+# test's Expected is literally its Before minus the scope wrapper. That identity
+# is the property under test, so one helper builds both.
+# ---------------------------------------------------------------------------
+
+
+def _admission_program(span, body_fn, *, wrap, nest_in_loop=False):
+    """matmul -> explicit region -> store, with ``body_fn`` supplying the middle.
+
+    ``wrap=True`` nests the region statements in a SplitAivScopeStmt (the Before).
+    ``wrap=False`` splices them flat and stamps the region attrs (the Expected) —
+    the explicit path drops only the wrapper.
+
+    ``body_fn(span, stmts, aiv_id, qk_h, data) -> VarPtr`` appends its statements
+    and returns the tile to store. ``nest_in_loop`` puts the body + store inside a
+    ForStmt so the lane-scalar dataflow must survive the walk's loop recursion.
+    """
+    a_left = ir.Var("a_left", _tile([128, 128], mem=MS.Left), span)
+    b_right = ir.Var("b_right", _tile([128, 128], mem=MS.Right), span)
+    data = ir.Var("data", _tensor([128, 128]), span)
+    out_0 = ir.Var("out_0", _tensor([128, 128]), span)
+
+    matmul = T.matmul(a_left, b_right, span=span)
+    qk = ir.Var("qk", matmul.type, span)
+    aiv_id = _sub_var("aiv_id")
+    shard = T.aiv_shard(qk, split=1, span=span)  # UP_DOWN => [64, 128] Vec
+    qk_h = ir.Var("qk_h", shard.type, span)
+
+    inner: list[ir.Stmt] = []
+    stored = body_fn(span, inner, aiv_id, qk_h, data)
+    store = T.store(stored, [0, 0], out_0, span=span)
+    out_store = ir.Var("out_store", store.type, span)
+    inner.append(ir.AssignStmt(out_store, store, span))
+
+    region_stmts: list[ir.Stmt] = [_get_subblock(aiv_id, span), ir.AssignStmt(qk_h, shard, span)]
+    if nest_in_loop:
+        region_stmts.append(
+            ir.ForStmt(
+                ir.Var("i", _IDX, span),
+                ir.ConstInt(0, DataType.INDEX, span),
+                ir.ConstInt(2, DataType.INDEX, span),
+                ir.ConstInt(1, DataType.INDEX, span),
+                [],
+                ir.SeqStmts(inner, span),
+                [],
+                span,
+            )
+        )
+    else:
+        region_stmts.extend(inner)
+
+    params = [(a_left, _IN), (b_right, _IN), (data, _IN), (out_0, _OUT)]
+    if wrap:
+        region = ir.SplitAivScopeStmt(
+            split=ir.SplitMode.UP_DOWN, body=ir.SeqStmts(region_stmts, span), span=span
+        )
+        return _explicit_region_program(
+            [ir.AssignStmt(qk, matmul, span), region, ir.ReturnStmt([out_store], span)],
+            params,
+            [out_0.type],
+        )
+    return _expected_region_program(
+        [ir.AssignStmt(qk, matmul, span), *region_stmts, ir.ReturnStmt([out_store], span)],
+        params,
+        [out_0.type],
+    )
+
+
+def _half_generator_body(span, stmts, aiv_id, qk_h, data):
+    """``zeros = tile.full([64, 128])`` at the per-lane half extent, combined with
+    the shard result."""
+    zeros = T.full([64, 128], FP32, 0.0, span=span)
+    z = ir.Var("zeros", zeros.type, span)
+    relu = T.maximum(qk_h, z, span=span)
+    r = ir.Var("relu", relu.type, span)
+    stmts += [ir.AssignStmt(z, zeros, span), ir.AssignStmt(r, relu, span)]
+    return r
+
+
+def _lane_localized_load_body(span, stmts, aiv_id, qk_h, data):
+    """A GM load the author localized with the region's own lane index:
+    ``tile.load(data, [aiv_id * 64, 0], [64, 128])``."""
+    off = aiv_id * 64
+    o = ir.Var("row0", off.type, span)
+    load = T.load(data, [o, 0], [64, 128], target_memory=MS.Vec, span=span)
+    t = ir.Var("t", load.type, span)
+    relu = T.maximum(qk_h, t, span=span)
+    r = ir.Var("relu", relu.type, span)
+    stmts += [ir.AssignStmt(o, off, span), ir.AssignStmt(t, load, span), ir.AssignStmt(r, relu, span)]
+    return r
+
+
+def _full_width_generator_body(span, stmts, aiv_id, qk_h, data):
+    """``z = tile.full([128, 128])`` at FULL width, consumed by an op that takes
+    nothing else — no shard lineage, no lane reference."""
+    zeros = T.full([128, 128], FP32, 0.0, span=span)
+    z = ir.Var("zeros", zeros.type, span)
+    add = T.add(z, z, span=span)
+    y = ir.Var("y", add.type, span)
+    stmts += [ir.AssignStmt(z, zeros, span), ir.AssignStmt(y, add, span)]
+    return y
+
+
+def _laundering_body(span, stmts, aiv_id, qk_h, data):
+    """``tile.set_validshape(full_width_tile, 1, aiv_id * 64)`` — a lane reference
+    on a NON-addressing op, which must not launder the full tile in."""
+    zeros = T.full([128, 128], FP32, 0.0, span=span)
+    z = ir.Var("zeros", zeros.type, span)
+    lane = aiv_id * 64
+    ln = ir.Var("lane", lane.type, span)
+    sv = T.set_validshape(z, 1, ln, span=span)
+    s = ir.Var("sv", sv.type, span)
+    add = T.add(s, s, span=span)
+    y = ir.Var("y", add.type, span)
+    stmts += [
+        ir.AssignStmt(z, zeros, span),
+        ir.AssignStmt(ln, lane, span),
+        ir.AssignStmt(s, sv, span),
+        ir.AssignStmt(y, add, span),
+    ]
+    return y
+
+
+def test_region_admits_half_width_generator():
+    """A pure generator authored at the per-lane half extent inside an explicit
+    region is admitted and spliced through UNCHANGED — the pass rewrites nothing
+    on the explicit path, so Expected is the Before minus the scope wrapper."""
+    span = ir.Span.unknown()
+    ir.assert_structural_equal(
+        _lower(_admission_program(span, _half_generator_body, wrap=True)),
+        _admission_program(span, _half_generator_body, wrap=False),
+    )
+
+
+def test_region_admits_lane_localized_load():
+    """An address-carrying op whose offset references the region's lane index is
+    per-lane by construction and is admitted, spliced through unchanged."""
+    span = ir.Span.unknown()
+    ir.assert_structural_equal(
+        _lower(_admission_program(span, _lane_localized_load_body, wrap=True)),
+        _admission_program(span, _lane_localized_load_body, wrap=False),
+    )
+
+
+def test_region_admits_lane_localized_load_nested_in_loop():
+    """The lane-scalar dataflow survives the walk's LOOP recursion: ``aiv_id`` is
+    bound at the region top level but the localized load sits inside a ForStmt, so
+    the scan must carry the lane set into the loop body to admit it. This is the
+    shape real kernels take (a per-lane load inside a cache-page loop)."""
+    span = ir.Span.unknown()
+    ir.assert_structural_equal(
+        _lower(_admission_program(span, _lane_localized_load_body, wrap=True, nest_in_loop=True)),
+        _admission_program(span, _lane_localized_load_body, wrap=False, nest_in_loop=True),
+    )
+
+
+def test_region_rejects_consumer_of_full_width_generator():
+    """A generator is admitted for ITSELF only — it does not join the half-width
+    dataflow. So a consumer reachable from a full-width generator and from no
+    shard is still reported. Without this, ``z = tile.full([128,128]);
+    y = tile.add(z, z)`` would be silently accepted and BOTH AIV lanes would
+    compute (and store) the full tile. NEGATIVE test: no ``After`` IR."""
+    with pytest.raises(ValueError, match=r"mixes explicit.*tile\.add"):
+        _lower(_admission_program(ir.Span.unknown(), _full_width_generator_body, wrap=True))
+
+
+def test_region_rejects_lane_reference_on_non_addressing_op():
+    """A lane reference is trusted only on an ADDRESS-carrying op. A lane-derived
+    scalar reaching a non-addressing op says nothing about the result's width, so
+    ``tile.set_validshape(full_width_tile, 1, aiv_id * 64)`` must not launder a
+    full-width tile into the half-width dataflow. NEGATIVE test: no ``After``
+    IR. (A full-width load with NO lane reference is covered by
+    test_mixed_explicit_implicit_region_rejected above.)"""
+    with pytest.raises(ValueError, match=r"mixes explicit.*tile\.set_validshape"):
+        _lower(_admission_program(ir.Span.unknown(), _laundering_body, wrap=True))
 
 
 if __name__ == "__main__":

--- a/tests/ut/ir/transforms/test_lower_auto_vector_split.py
+++ b/tests/ut/ir/transforms/test_lower_auto_vector_split.py
@@ -1898,6 +1898,60 @@ def _lane_localized_load_body(span, stmts, aiv_id, qk_h, data):
     return r
 
 
+def _lane_localized_slice_body(span, stmts, aiv_id, qk_h, data):
+    """A tile.slice localized via its OFFSET arg (index 2): the source is a
+    full-width Vec tile and each lane takes its own [64, 128] window."""
+    full = T.full([128, 128], FP32, 1.0, span=span)
+    f = ir.Var("full_t", full.type, span)
+    off = aiv_id * 64
+    o = ir.Var("row0", off.type, span)
+    sl = T.slice(f, [64, 128], [o, 0], span=span)
+    t = ir.Var("t", sl.type, span)
+    relu = T.maximum(qk_h, t, span=span)
+    r = ir.Var("relu", relu.type, span)
+    stmts += [
+        ir.AssignStmt(f, full, span),
+        ir.AssignStmt(o, off, span),
+        ir.AssignStmt(t, sl, span),
+        ir.AssignStmt(r, relu, span),
+    ]
+    return r
+
+
+def _lane_localized_extract_body(span, stmts, aiv_id, qk_h, data):
+    """A tile.extract localized via its index_row arg (index 1). The Mat source is
+    created in-region so it is a defined var (a free var could not be mapped by
+    structural comparison); tile.create is a generator, so it stays NEUTRAL and
+    the extract is admitted purely on its lane-referencing address arg."""
+    src_call = T.create([128, 128], FP32, MS.Mat, span=span)
+    src = ir.Var("src_mat", src_call.type, span)
+    row = aiv_id * 64
+    rv = ir.Var("row0", row.type, span)
+    ex = T.extract(src, rv, 0, [64, 128], target_memory=MS.Vec, span=span)
+    t = ir.Var("t", ex.type, span)
+    relu = T.maximum(qk_h, t, span=span)
+    r = ir.Var("relu", relu.type, span)
+    stmts += [
+        ir.AssignStmt(src, src_call, span),
+        ir.AssignStmt(rv, row, span),
+        ir.AssignStmt(t, ex, span),
+        ir.AssignStmt(r, relu, span),
+    ]
+    return r
+
+
+def _lane_ref_in_non_address_arg_body(span, stmts, aiv_id, qk_h, data):
+    """A tile.load whose OFFSET is [0, 0] — both lanes read the same base rows —
+    but which mentions aiv_id in its valid_shape. Scanning every arg instead of
+    just the address args would wrongly admit this."""
+    valid = aiv_id + 1
+    v = ir.Var("valid", valid.type, span)
+    load = T.load(data, [0, 0], [64, 128], valid_shapes=[v, 128], target_memory=MS.Vec, span=span)
+    t = ir.Var("t", load.type, span)
+    stmts += [ir.AssignStmt(v, valid, span), ir.AssignStmt(t, load, span)]
+    return t
+
+
 def _full_width_generator_body(span, stmts, aiv_id, qk_h, data):
     """``z = tile.full([128, 128])`` at FULL width, consumed by an op that takes
     nothing else — no shard lineage, no lane reference."""
@@ -1960,6 +2014,34 @@ def test_region_admits_lane_localized_load_nested_in_loop():
         _lower(_admission_program(span, _lane_localized_load_body, wrap=True, nest_in_loop=True)),
         _admission_program(span, _lane_localized_load_body, wrap=False, nest_in_loop=True),
     )
+
+
+def test_region_admits_lane_localized_slice():
+    """tile.slice localized through its OFFSET arg (index 2) is admitted — the
+    address-arg indices differ per op, so each addressing op needs its own case."""
+    span = ir.Span.unknown()
+    ir.assert_structural_equal(
+        _lower(_admission_program(span, _lane_localized_slice_body, wrap=True)),
+        _admission_program(span, _lane_localized_slice_body, wrap=False),
+    )
+
+
+def test_region_admits_lane_localized_extract():
+    """tile.extract localized through its index_row arg (index 1) is admitted."""
+    span = ir.Span.unknown()
+    ir.assert_structural_equal(
+        _lower(_admission_program(span, _lane_localized_extract_body, wrap=True)),
+        _admission_program(span, _lane_localized_extract_body, wrap=False),
+    )
+
+
+def test_region_rejects_lane_reference_outside_address_args():
+    """A lane reference only localizes when it lands in an op's ADDRESS args. A
+    tile.load at offset [0, 0] that mentions aiv_id only in its valid_shape has
+    BOTH lanes reading the same base rows, so it must still be reported —
+    otherwise its consumers would be trusted as half-width. NEGATIVE test."""
+    with pytest.raises(ValueError, match=r"mixes explicit.*tile\.load"):
+        _lower(_admission_program(ir.Span.unknown(), _lane_ref_in_non_address_arg_body, wrap=True))
 
 
 def test_region_rejects_consumer_of_full_width_generator():


### PR DESCRIPTION
## Summary

`ValidateMixedExplicitRegion` decided half-width membership purely by **dataflow lineage** from `tile.aiv_shard`, so it rejected two classes of op that are per-lane by construction but carry no shard lineage:

- **Pure generators** (`tile.full` / `tile.ci` / `tile.random`) — the result is a function of the op's attributes only: it reads no tile and no memory, so per-lane replication is correct at whatever extent the author wrote. A constant authored at *exactly* the per-lane half extent was still rejected, because the check never inspected shape.
- **Address-carrying ops** (`tile.load` / `tile.slice` / `tile.extract`) whose argument expressions reference the region's own `aiv_id` — the author localized them explicitly. That is the same trust the pass already extends to `tile.store`, whose lane-dependent offset it never checks.

Together these left **no legal placement** for a constant or a GM load in an explicit region: inside it was rejected here, and outside it could not be re-entered, because `tile.aiv_shard` requires an `Acc` (cube-produced) operand.

The guard **rewrites nothing** — the explicit path still splices the region body through unchanged. Only what is *accepted* changes.

## Two deliberate restrictions, each pinned by a negative test

- A generator is admitted for **itself only** and is **not** added to `half_tiles`. Lane-invariance makes it *safe*, not *half-width*. Admitting it would let a full-width generator vouch for its consumers: `z = tile.full([128,128]); y = tile.add(z, z); tile.store(y, [0,0], out, atomic)` would be silently accepted and both AIV lanes would atomically add the same full tile.
- The lane reference is trusted **only** on addressing ops. Elsewhere a lane-derived scalar is just an operand and proves nothing about width, so `tile.set_validshape(full_width_tile, 1, aiv_id * HALF)` cannot launder a full tile into the region.

Known limitation, documented: the check proves *intent*, not *extent*. A load at a lane-strided offset but full-width extent is accepted, and the lanes then read overlapping windows — the same trust already given to `tile.store`.

## Testing

- 5 new unit tests: two admissions, one covering the lane-scalar dataflow across **loop recursion** (the shape real kernels take), two negative guards.
- Each was verified load-bearing by re-introducing the corresponding bug and confirming the matching test — and only that test — fails.
- `tests/ut/ir/transforms/`: 2270 passed. clang-tidy clean. All pre-commit hooks pass.
- Validated end-to-end on **Ascend 910B** against a torch golden using the DeepSeek-V4 decode indexer, whose `score` scope motivated this: `score`, `topk_idxs`, `idx_kv_cache`, `idx_kv_scale` all pass, including a ragged `kv_seq_lens` fixture that exercises partial tail pages. Note that consumer lives in a separate repo, so **CI here does not cover it** — that validation is local only.

## Docs

Adds an acceptance-conditions section to `docs/en/dev/passes/18-lower_auto_vector_split.md` and its zh-cn mirror. The guard was previously undocumented.

## Follow-ups (not in this PR)

- The two op-name lists would be better as registry properties (`op_predicates.h` is the documented home). The same "which ops are per-lane / how do I halve them" knowledge is currently encoded in `lower_auto_vector_split_pass.cpp`, `split_axis_utils.cpp`, and `split_vector_kernel_pass.cpp` with lists that already disagree.
- `ReferencesLaneIndex` is a fifth private copy of "does this expression reference any Var in this set"; a shared `ExprUsesAnyVar` in `var_collectors.h` would dedupe all five.
- Related, not fixed here: #2118 (a scope may still carry both `optimizations=[pl.split(NONE, ...)]` and a `pl.split_aiv` region).