### PR TITLE
fix(ir): Reject a split_aiv region that survives LowerAutoVectorSplit

### DIFF
--- a/docs/en/dev/passes/18-lower_auto_vector_split.md
+++ b/docs/en/dev/passes/18-lower_auto_vector_split.md
@@ -96,7 +96,7 @@ an out-of-region full-width op. Statements **outside** any region are emitted
 full-width. After all regions are lowered, the scope wrappers are dropped and the
 function is stamped `split_aiv` + `split_aiv_region_validated` (the latter signals
 [`ExpandMixedKernel`](19-expand_mixed_kernel.md) to skip its single-func-mode
-transpose check — pass 21 validates each region's transpose hazard with the
+transpose check — this pass validates each region's transpose hazard with the
 correct per-region split axis instead).
 
 A function-level AUTO split (`optimizations=[pl.split(mode)]`) and explicit
@@ -177,6 +177,44 @@ Because the region is built via the generic `BeginScope`/`EndScope` and is
 non-outlined, it can be **nested** inside a `pl.range` / `pl.pipeline` loop or an
 `if`; the region path recurses into compound statements to find and lower every
 region while preserving the surrounding control flow.
+
+### Regions must be scope-free
+
+Region lowering recurses into `ForStmt` / `WhileStmt` / `IfStmt` / `SeqStmts` but
+deliberately **not** into a `ScopeStmt`: a scope carries outlining and
+name-visibility semantics that region-local halving must not reach through. Every
+region must therefore already be scope-free when this pass runs — normally
+guaranteed by [`OutlineIncoreScopes`](08-outline_incore_scopes.md) (pass 8), which
+lifts the enclosing `InCore` scope into its own function.
+
+That guarantee has a hole, so the pass enforces it rather than assuming it. Pass 7
+only outlines scopes out of `Opaque` / `Orchestration` functions, while the parser
+wraps a top-level `for aiv_id in pl.split_aiv(...)` in an `InCore` scope
+regardless of the enclosing function's type. Declaring the function
+`pl.FunctionType.InCore` directly therefore delivers a scope-wrapped region here:
+
+```python
+@pl.function(type=pl.FunctionType.InCore)   # pass 8 skips this function
+def f(self, a: pl.Tensor[[128, 128], pl.FP32],
+      c: pl.Out[pl.Tensor[[128, 128], pl.FP32]]) -> pl.Tensor[[128, 128], pl.FP32]:
+    for aiv_id in pl.split_aiv(2, mode=pl.SplitMode.NONE):   # wrapped in an InCore scope
+        base = aiv_id * 64
+        c = pl.store(pl.exp(pl.load(a, [base, 0], [64, 128])), [base, 0], c)
+    return c
+```
+
+After lowering, `LowerExplicitRegionFunction` re-scans the body and rejects any
+surviving region with a `ValueError` pointing at the `pl.split_aiv` line. Use
+plain `@pl.function` / `@pl.jit` (Opaque) so pass 8 outlines the scope, or move
+the region out of the enclosing scope.
+
+The guard is also what makes the `split_aiv_region_validated` stamp trustworthy:
+the attrs are written only once every region has actually been consumed, so
+[`ExpandMixedKernel`](19-expand_mixed_kernel.md) skipping its own func-mode check
+on the strength of that stamp is always backed by a real per-region validation.
+Without it a scope-nested region passed through unlowered *and* un-validated
+while still being stamped "region validated", and the failure surfaced much later
+as an internal assertion in PTO codegen (`SplitAivScopeStmt reached PTO codegen`).
 
 ## Split-axis dispatch
 

--- a/docs/zh-cn/dev/passes/18-lower_auto_vector_split.md
+++ b/docs/zh-cn/dev/passes/18-lower_auto_vector_split.md
@@ -78,7 +78,7 @@ result = passes.lower_auto_vector_split()(program)
 到同级区域或区域外的全宽算子。任何区域**之外**的语句以全宽发出。所有区域下降后，作用域
 包装被丢弃，函数被打上 `split_aiv` + `split_aiv_region_validated`（后者通知
 [`ExpandMixedKernel`](19-expand_mixed_kernel.md) 跳过其单一函数级模式的转置检查——
-改由 pass 21 用每个区域正确的拆分轴校验各自的转置风险）。
+改由本 pass 用每个区域正确的拆分轴校验各自的转置风险）。
 
 函数级 AUTO split（`optimizations=[pl.split(mode)]`）与显式 `pl.split_aiv` 区域是
 **互斥**的——同时携带二者的作用域会被拒绝。该检查在更早的
@@ -137,6 +137,39 @@ result = passes.lower_auto_vector_split()(program)
 由于区域经由通用的 `BeginScope`/`EndScope` 构建且不被提取，它可**嵌套**在 `pl.range` /
 `pl.pipeline` 循环或 `if` 之内；区域路径会递归进入复合语句，找到并下降每个区域，同时保留
 外围控制流。
+
+### 区域必须不被 scope 包裹
+
+区域下降会递归进入 `ForStmt` / `WhileStmt` / `IfStmt` / `SeqStmts`，但**刻意不**进入
+`ScopeStmt`：scope 携带提取（outlining）与名字可见性语义，区域局部的折半不应跨越它。因此本
+pass 运行时每个区域都必须已不被 scope 包裹——通常由
+[`OutlineIncoreScopes`](08-outline_incore_scopes.md)（pass 8）保证，它会把外围的 `InCore`
+scope 提取为独立函数。
+
+该保证存在一个缺口，故本 pass 选择强制校验而非假定成立。pass 8 只对 `Opaque` /
+`Orchestration` 函数提取 scope，而解析器无论外围函数类型如何，都会把顶层的
+`for aiv_id in pl.split_aiv(...)` 包进一个 `InCore` scope。因此直接把函数声明为
+`pl.FunctionType.InCore` 时，到达此处的区域仍被 scope 包裹：
+
+```python
+@pl.function(type=pl.FunctionType.InCore)   # pass 8 会跳过该函数
+def f(self, a: pl.Tensor[[128, 128], pl.FP32],
+      c: pl.Out[pl.Tensor[[128, 128], pl.FP32]]) -> pl.Tensor[[128, 128], pl.FP32]:
+    for aiv_id in pl.split_aiv(2, mode=pl.SplitMode.NONE):   # 被包进 InCore scope
+        base = aiv_id * 64
+        c = pl.store(pl.exp(pl.load(a, [base, 0], [64, 128])), [base, 0], c)
+    return c
+```
+
+下降完成后，`LowerExplicitRegionFunction` 会重新扫描函数体，对任何存活下来的区域抛出
+`ValueError`，并把源位置指向 `pl.split_aiv` 那一行。修复方式：改用普通的 `@pl.function` /
+`@pl.jit`（Opaque）让 pass 8 提取该 scope，或把区域移出外围 scope。
+
+该守卫也正是 `split_aiv_region_validated` 标记可信的依据：只有当每个区域都确实被消费后才写入
+attrs，因此 [`ExpandMixedKernel`](19-expand_mixed_kernel.md) 凭该标记跳过自身的 func-mode
+检查时，背后总有一次真实的逐区域校验。若无此守卫，被 scope 包裹的区域会既未下降、又未校验，
+却仍被标记为“已完成区域校验”，问题要到很晚才以 PTO codegen 的内部断言
+（`SplitAivScopeStmt reached PTO codegen`）暴露。
 
 ## 拆分轴分派
 

--- a/src/ir/transforms/lower_auto_vector_split_pass.cpp
+++ b/src/ir/transforms/lower_auto_vector_split_pass.cpp
@@ -93,7 +93,7 @@ using split_axis::TileInfo;
 
 constexpr const char* kDualAivDispatchAttr = "dual_aiv_dispatch";
 constexpr const char* kSplitAivAttr = "split_aiv";
-// Stamped by the explicit-region path so ExpandMixedKernel (pass 21) skips its
+// Stamped by the explicit-region path so ExpandMixedKernel (pass 19) skips its
 // single-func-mode transpose-hazard check (validated per-region here instead).
 constexpr const char* kSplitAivRegionValidatedAttr = "split_aiv_region_validated";
 
@@ -754,27 +754,41 @@ std::vector<StmtPtr> LowerExplicitRegions(const std::vector<StmtPtr>& stmts,
   return result;
 }
 
-// Detect any live ``SplitAivScopeStmt`` in a body (O(N) single walk).
-class HasSplitAivScopeFinder : public IRVisitor {
+// Find the first live ``SplitAivScopeStmt`` in a body (O(N) single walk), so a
+// caller can point a diagnostic at the author's ``for aiv_id in
+// pl.split_aiv(...)`` line via the returned node's span. Unlike the hand-rolled
+// walks above this is an IRVisitor, so it descends into ScopeStmt bodies too —
+// that asymmetry is exactly what the post-lowering guard below exists to catch.
+class SplitAivScopeFinder : public IRVisitor {
  public:
-  bool found_ = false;
+  SplitAivScopeStmtPtr found_;
 
  protected:
-  void VisitStmt_(const SplitAivScopeStmtPtr& op) override { found_ = true; }
+  void VisitStmt_(const SplitAivScopeStmtPtr& op) override {
+    if (!found_) found_ = op;
+  }
 };
 
-bool BodyContainsSplitAivScope(const StmtPtr& body) {
-  if (!body) return false;
-  HasSplitAivScopeFinder finder;
+SplitAivScopeStmtPtr FindFirstSplitAivScope(const StmtPtr& body) {
+  if (!body) return nullptr;
+  SplitAivScopeFinder finder;
   finder.VisitStmt(body);
   return finder.found_;
 }
+
+bool BodyContainsSplitAivScope(const StmtPtr& body) { return FindFirstSplitAivScope(body) != nullptr; }
 
 // Lower an InCore function that carries explicit ``SplitAivScopeStmt`` regions:
 // halve only the vector compute inside each region (region-local), leave
 // out-of-region compute full-width, drop each scope wrapper, and stamp
 // ``split_aiv`` (idempotent — already bridged at OutlineIncoreScopes) plus
-// ``split_aiv_region_validated`` (signals pass 21 to skip its func-mode check).
+// ``split_aiv_region_validated`` (signals ExpandMixedKernel (pass 19) to skip its func-mode check).
+//
+// Region lowering deliberately does NOT cross a ``ScopeStmt``: a scope carries
+// outlining and name-visibility semantics that region-local halving must not
+// reach through. So every region must already be scope-free by the time this
+// runs, and the guard below enforces that instead of letting an unreachable one
+// ride through — unlowered and un-validated, yet stamped "region validated".
 FunctionPtr LowerExplicitRegionFunction(const FunctionPtr& func) {
   auto stmts = transform_utils::FlattenToStmts(func->body_);
   // Seed the reservation set with every name visible in the function body (params
@@ -785,9 +799,35 @@ FunctionPtr LowerExplicitRegionFunction(const FunctionPtr& func) {
   auto new_stmts = LowerExplicitRegions(stmts, used_names);
   StmtPtr new_body =
       (new_stmts.size() == 1) ? new_stmts[0] : std::make_shared<SeqStmts>(new_stmts, func->span_);
+
+  // Every region must have been consumed. A surviving one means it sat behind a
+  // scope the lowering walk does not enter — reachable today because the parser
+  // wraps a top-level ``pl.split_aiv`` in an InCore ScopeStmt while
+  // OutlineIncoreScopes only outlines scopes out of Opaque / Orchestration
+  // functions, so the wrapper reaches this pass intact inside a function the
+  // author declared ``pl.FunctionType.InCore``. Reject it here, pointing at the
+  // region; passing it through would skip every region guard and then fail far
+  // downstream as an internal assertion in PTO codegen.
+  //
+  // Span safety: the check fails exactly when ``survivor`` is non-null, so the
+  // dereference in the span argument is only evaluated when it is valid.
+  auto survivor = FindFirstSplitAivScope(new_body);
+  CHECK_SPAN(!survivor, survivor->span_)
+      << "LowerAutoVectorSplit: this pl.split_aiv region is nested inside a scope and cannot be "
+         "lowered — region lowering does not cross a scope boundary. The scope may be one you "
+         "wrote ('with pl.at(...)') or the InCore scope the parser adds around a top-level "
+         "pl.split_aiv. OutlineIncoreScopes only outlines scopes out of Opaque / Orchestration "
+         "functions, so a scope inside a function declared pl.FunctionType.InCore reaches this "
+         "pass intact. Fix it one of two ways: (1) declare the enclosing function with plain "
+         "@pl.function / @pl.jit so the scope is outlined before this pass runs; or (2) move the "
+         "pl.split_aiv region out of the enclosing scope.";
+
   auto [cloned_body, clone_map_unused] = DeepClone(new_body);
   (void)clone_map_unused;
 
+  // Earned only now: the guard above proves every region was actually lowered,
+  // so ``split_aiv_region_validated`` is a true claim and pass 19
+  // (SplitVectorKernel) may skip its own single-func-mode check on its strength.
   auto attrs = func->attrs_;
   attrs.erase(std::remove_if(attrs.begin(), attrs.end(),
                              [](const auto& kv) {

--- a/tests/ut/ir/transforms/test_lower_auto_vector_split.py
+++ b/tests/ut/ir/transforms/test_lower_auto_vector_split.py
@@ -21,25 +21,26 @@ These tests hand-build a minimal mixed InCore function at the
 post-InferTileMemorySpace level (memory spaces already assigned) and run the pass
 in isolation with verification disabled.
 
-Why these tests hand-build IR instead of using the ``@pl.program`` DSL (the
-project's default transform-test style): it is NOT that the DSL cannot express
-the shapes involved — it can author both this pass's tile-level input and, via
-the outlined boundary form (``pl.aiv_shard(qk, split=1)``), its lowered output.
-The blocker is that the DSL wraps a top-level ``for aiv_id in pl.split_aiv(...)``
-in an enclosing ``pl.at``/``ScopeStmt``, and this pass does not descend into a
-ScopeStmt — by the time it runs (pass 18) OutlineIncoreScopes has long since
-removed those. So on DSL-authored input the region is never visited: it survives
-unlowered and ``ValidateMixedExplicitRegion`` never runs, which would make every
-guard test here vacuous. Reproducing pass 18's real input from the DSL needs the
-whole upstream prefix, turning a unit test into an integration test.
+Why the transform-output tests hand-build IR instead of using the ``@pl.program``
+DSL (the project's default transform-test style): it is NOT that the DSL cannot
+express the shapes involved — it can author both this pass's tile-level input
+and, via the outlined boundary form (``pl.aiv_shard(qk, split=1)``), its lowered
+output. The reason is narrower: the pass runs at the tile level
+(post-InferTileMemorySpace), so writing an explicit ``Expected`` lowered program
+in the DSL means spelling out every assigned memory space and memref, which the
+hand-built helpers express directly. Each transform-output test therefore builds
+both the ``Before`` program and an explicit ``Expected`` lowered program with the
+same helpers and asserts ``ir.assert_structural_equal`` between the pass result
+and ``Expected``. Negative tests keep ``pytest.raises`` because a rejected
+transform produces no ``After`` IR. End-to-end DSL coverage of this authoring
+form lives in ``tests/st/codegen/torch/test_torch_codegen_cross_core.py``
+(``SplitAivShardProgram``), where the numerics are checked against torch.
 
-Each transform-output test therefore hand-builds both the ``Before`` program and
-an explicit ``Expected`` lowered program with the same helpers and asserts
-``ir.assert_structural_equal`` between the pass result and ``Expected``. Negative
-tests keep ``pytest.raises`` because a rejected transform produces no ``After``
-IR. End-to-end DSL coverage of this authoring form lives in
-``tests/st/codegen/torch/test_torch_codegen_cross_core.py`` (``SplitAivShardProgram``),
-where the numerics are checked against torch.
+The scope-nesting tests at the bottom of this file are the exception: they are
+authored in the DSL because the DSL is what produces the shape under test (the
+parser's ``InCore`` scope wrapper). A DSL-authored program *can* reach the
+region guards in general — declare the function ``@pl.function`` (Opaque) and
+prefix ``passes.outline_incore_scopes()`` so the wrapper is outlined first.
 
 The per-op vector halving tests (load / slice / reshape / store offset /
 singleton / loop tracking / reduce-on-split-axis throw) were migrated here from
@@ -50,6 +51,7 @@ leaf statement through that same machinery, so the halving is identical (Stage 1
 proved byte-identity); only the entry point changed.
 """
 
+import pypto.language as pl
 import pytest
 from pypto import DataType, ir, passes
 from pypto.ir.op import tile_ops as T
@@ -2063,6 +2065,108 @@ def test_region_rejects_lane_reference_on_non_addressing_op():
     test_mixed_explicit_implicit_region_rejected above.)"""
     with pytest.raises(ValueError, match=r"mixes explicit.*tile\.set_validshape"):
         _lower(_admission_program(ir.Span.unknown(), _laundering_body, wrap=True))
+
+
+# ---------------------------------------------------------------------------
+# Scope-nested regions are rejected, not silently passed through.
+#
+# Region lowering walks for / while / if / seq but deliberately NOT ScopeStmt: a
+# scope carries outlining and name-visibility semantics that region-local
+# halving must not reach through. A region behind a scope therefore cannot be
+# lowered, and the pass must say so instead of stamping
+# ``split_aiv_region_validated`` on a function whose region guards never ran.
+#
+# These are the only tests here authored in the ``@pl.program`` DSL, because the
+# DSL is what produces the shape: the parser wraps a top-level
+# ``for aiv_id in pl.split_aiv(...)`` in an InCore ScopeStmt, and
+# OutlineIncoreScopes only outlines scopes out of Opaque / Orchestration
+# functions — so the wrapper survives into a function declared
+# ``pl.FunctionType.InCore``.
+# ---------------------------------------------------------------------------
+
+_SCOPE_NESTED_MSG = "nested inside a scope"
+
+
+def test_scope_nested_region_rejected():
+    """A region behind a ScopeStmt is rejected with an actionable diagnostic."""
+
+    @pl.program
+    class Nested:
+        @pl.function(type=pl.FunctionType.InCore)
+        def f(
+            self,
+            a: pl.Tensor[[128, 128], pl.FP32],
+            c: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
+        ) -> pl.Tensor[[128, 128], pl.FP32]:
+            # The parser wraps this top-level region in an InCore ScopeStmt.
+            for aiv_id in pl.split_aiv(2, mode=pl.SplitMode.NONE):
+                base = aiv_id * 64
+                c = pl.store(pl.exp(pl.load(a, [base, 0], [64, 128])), [base, 0], c)
+            return c
+
+    with pytest.raises(ValueError, match=_SCOPE_NESTED_MSG):
+        _lower(Nested)
+
+
+def test_scope_nested_region_guards_not_bypassed():
+    """The guard fires even for a body that would trip a per-region check.
+
+    Before the guard, this body's ``ValidateMixedExplicitRegion`` violation (a
+    full-width ``tile.load`` alongside an explicit ``tile.aiv_shard``) went
+    completely unchecked because the region was never visited.
+    """
+
+    @pl.program
+    class NestedMixed:
+        @pl.function(type=pl.FunctionType.InCore)
+        def f(
+            self,
+            a_left: pl.Tile[[128, 128], pl.FP32, pl.MemorySpace.Left],
+            b_right: pl.Tile[[128, 128], pl.FP32, pl.MemorySpace.Right],
+            data: pl.Tensor[[128, 128], pl.FP32],
+            out_0: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
+        ) -> pl.Tensor[[128, 128], pl.FP32]:
+            qk = pl.matmul(a_left, b_right)
+            for aiv_id in pl.split_aiv(2, mode=pl.SplitMode.UP_DOWN):  # noqa: B007
+                qk_h = pl.aiv_shard(qk)  # noqa: F841 - explicit boundary
+                t = pl.load(data, [0, 0], [128, 128], target_memory=pl.MemorySpace.Vec)  # full width
+                out_0 = pl.tile.store(t, [0, 0], out_0)
+            return out_0
+
+    with pytest.raises(ValueError, match=_SCOPE_NESTED_MSG):
+        _lower(NestedMixed)
+
+
+def test_outlined_region_still_lowers_and_stamps():
+    """The canonical Opaque form is unaffected: pass 7 outlines, pass 18 lowers.
+
+    Guards the boundary of the rejection above — the scope must be gone by the
+    time this pass runs, and when it is, the region lowers and the function is
+    stamped as before.
+    """
+
+    @pl.program
+    class Canonical:
+        @pl.function
+        def main(
+            self,
+            a: pl.Tensor[[128, 128], pl.FP32],
+            c: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
+        ) -> pl.Tensor[[128, 128], pl.FP32]:
+            for aiv_id in pl.split_aiv(2, mode=pl.SplitMode.NONE):
+                base = aiv_id * 64
+                c = pl.store(pl.exp(pl.load(a, [base, 0], [64, 128])), [base, 0], c)
+            return c
+
+    with passes.PassContext([]):
+        outlined = passes.outline_incore_scopes()(Canonical)
+        after = _lower(outlined)
+
+    incore = [f for f in after.functions.values() if f.func_type == ir.FunctionType.InCore]
+    assert len(incore) == 1, "OutlineIncoreScopes should have produced one InCore function"
+    assert "pl.split_aiv" not in ir.python_print(after), "region must be erased"
+    for key, value in _REGION_ATTRS.items():
+        assert incore[0].attrs.get(key) == value, f"expected {key}={value}"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

`LowerExplicitRegions` walks `ForStmt` / `WhileStmt` / `IfStmt` / `SeqStmts` but deliberately **not** `ScopeStmt` — a scope carries outlining and name-visibility semantics that region-local halving must not reach through. The *detector* (`BodyContainsSplitAivScope`) is an `IRVisitor` and **does** descend into scopes, so the two disagreed:

- a region behind a `ScopeStmt` entered the explicit-region path,
- was passed through **unlowered**,
- and was still stamped `split_aiv` + `split_aiv_region_validated` — an affirmative claim that `ValidateMixedExplicitRegion` / `ValidateTransposeSplitHazard` had run when they had not.

The whole `Default` pipeline then completed and the failure surfaced only as an internal assertion in PTO codegen (`SplitAivScopeStmt reached PTO codegen`, `pto_codegen.cpp:1429`).

**This is reachable from the DSL.** The parser wraps a top-level `pl.split_aiv` in an `InCore` scope based on an open-*scope* test rather than a function-*type* test (`ast_parser.py:4404`), while `OutlineIncoreScopes` only outlines scopes out of `Opaque` / `Orchestration` functions (`outline_incore_scopes_pass.cpp:77`). So the wrapper survives inside a function the author declared `pl.FunctionType.InCore`. The canonical `@pl.function` / `@pl.jit` (Opaque) form is unaffected, which is why no in-tree test hit this.

## Changes

- `LowerExplicitRegionFunction` re-scans the lowered body and rejects any surviving region with a `CHECK_SPAN` pointing at the `pl.split_aiv` line, listing the two concrete fixes.
- The `split_aiv` / `split_aiv_region_validated` attrs are stamped **only after** that guard passes, so the region-validated stamp is always backed by a real per-region validation.
- `HasSplitAivScopeFinder` → `SplitAivScopeFinder` returning the node (matching the existing `FindFirstReturn` / `FindFirstInnerCall` convention) so the diagnostic can carry the region's span.
- Corrects stale pass numbers in the touched comments/docs: `OutlineIncoreScopes` is pass 8, the `split_aiv_region_validated` consumer is `ExpandMixedKernel` (pass 19), and the per-region transpose hazard is validated by this pass rather than pass 21.

### Before → after

| | before | after |
| --- | --- | --- |
| Scope-nested region | pipeline completes, region live, attrs falsely stamped | `ValueError` at pass 18 pointing at the `pl.split_aiv` line |
| Failure surface | `InternalError` in PTO codegen | actionable user diagnostic with two named fixes |
| Canonical Opaque / `@pl.jit` form | lowers | unchanged — lowers |

Deliberately **not** fixed here: recursing into `ScopeStmt`. Lowering a region across a scope boundary has semantics we do not want to guess at — failing loudly is the correct behaviour, and the underlying parser/pass-8 interaction is the real fix.

## Testing

- [x] 3 new tests in `tests/ut/ir/transforms/test_lower_auto_vector_split.py` (38 in file): the two rejection cases, plus a boundary test that the outlined form still lowers **and** stamps, so the rejection cannot silently become over-broad.
- [x] Full `tests/ut/` — 7572 passed, 2 skipped.
- [x] clang-format, clang-tidy, cpplint, ruff, pyright, markdownlint, docs en↔zh parity, english-only — all clean.
- [x] Documentation updated (en + zh-cn): new "Regions must be scope-free" section.

These are the first DSL-authored tests in that file, because the DSL is what produces the shape under test.