### PR TITLE
fix(ir): Gather the operand's split axis at the V->C boundary

### DIFF
--- a/docs/en/dev/passes/18-lower_auto_vector_split.md
+++ b/docs/en/dev/passes/18-lower_auto_vector_split.md
@@ -338,10 +338,42 @@ gathered tile keeps the FULL `[128, 128]` `Mat` shape — the cube side never
 sees a halved tile:
 
 ```python
-gathered_mat: pl.Tile[[..], pl.FP32, pl.Mem.Mat]  = pl.tile.aic_gather(vec, split=1)
+# `v` is the per-lane HALF the affinity gate produced, e.g. [64, 128].
+gathered_mat: pl.Tile[[128, 128], pl.FP32, pl.Mem.Mat] = pl.tile.aic_gather(v, split=1)
 gathered:     pl.Tile[[128, 128], pl.FP32, pl.Mem.Mat] = pl.tile.move(gathered_mat,
                                                                       target_memory=pl.Mem.Mat)
 ```
+
+**The operand must be a per-lane half.** `tile.aic_gather` is declared
+HALF → FULL, so the gather doubles `[64, 128] → [128, 128]`, which is exactly the
+FULL result type the cube placement move keeps. That agreement is a
+*precondition*, not a guarantee: a VECTOR value can reach the boundary un-halved
+— a `Vec` parameter used directly, or a tile whose split dim is a singleton the
+affinity gate deliberately preserves. Doubling such an operand would produce a
+`[256, 128]` gather feeding a move still typed `[128, 128]`, contradicting
+`tile.move`'s shape-preserving contract and yielding IR that does not survive
+print→parse. There is no correct gather for a value with no half, so the pass
+**rejects** it with an actionable `ValueError`:
+
+```text
+LowerAutoVectorSplit: the V->C boundary tile.move here carries a full-width
+vector operand 'vec'. tile.aic_gather reassembles the two AIV lanes' per-lane
+halves into the full tile the cube expects, so its operand must be a value the
+split halving produced (a tile.load / tile.slice / elementwise result inside the
+vector sub-region). An un-halved value has no half to gather — either derive the
+per-lane half first (load or slice the value inside the split function) and move
+that to the cube side, or, if the split axis is a singleton that cannot be
+halved, keep the value on the vector side.
+```
+
+**The gather follows the operand's split axis, not the function's.** A
+`tile.reshape` can migrate the split axis — the rms_norm `[N, 1] ↔ [1, N]` column
+reshape moves it from dim 0 to dim 1 — and `TileInfo::split_dim` tracks where it
+ended up. The gather is emitted with the `split` encoding of *that* dim
+(`dim 0 → 1`, `dim 1 → 2`), so a `[1, 8]` lane-local operand under an `UpDown`
+function gathers to `[1, 16]` via `split=2`, matching the move. Doubling the
+function axis instead would yield `[2, 8]`. A tracked split dim outside `{0, 1}`
+cannot be expressed as a `split` attr on a 2D gather and is rejected.
 
 The gather result is `Mat`, not `Vec`: the declared type of a boundary op names
 the **consuming** lane's space, and AIC pops a V→C transfer into L1. (`Vec` would

--- a/docs/zh-cn/dev/passes/18-lower_auto_vector_split.md
+++ b/docs/zh-cn/dev/passes/18-lower_auto_vector_split.md
@@ -280,10 +280,38 @@ V→C `tile.move` 变为 `tile.aic_gather`；对折叠后 tile 的 cube 放置 m
 `[128, 128]` `Mat`——cube 侧绝不会看到折半 tile：
 
 ```python
-gathered_mat: pl.Tile[[..], pl.FP32, pl.Mem.Mat]  = pl.tile.aic_gather(vec, split=1)
+# `v` 是 affinity gate 产出的每 lane 折半 tile，例如 [64, 128]。
+gathered_mat: pl.Tile[[128, 128], pl.FP32, pl.Mem.Mat] = pl.tile.aic_gather(v, split=1)
 gathered:     pl.Tile[[128, 128], pl.FP32, pl.Mem.Mat] = pl.tile.move(gathered_mat,
                                                                       target_memory=pl.Mem.Mat)
 ```
+
+**操作数必须是每 lane 的折半 tile。** `tile.aic_gather` 声明为 HALF → FULL，因此
+gather 把 `[64, 128]` 加倍为 `[128, 128]`，恰好等于 cube 放置 move 所保留的全尺寸
+结果类型。这种一致性是**前置条件**而非保证：向量值可能以未折半的形式到达边界——
+例如直接使用的 `Vec` 参数，或 split 维为 1 而被 affinity gate 特意保留的 tile。对
+这类操作数做加倍会得到 `[256, 128]` 的 gather，而其后的 move 仍是 `[128, 128]`，
+这与 `tile.move` 的保形契约矛盾，且产生的 IR 无法通过 print→parse 往返。既然没有
+折半就不存在正确的 gather，本 pass 会以可操作的 `ValueError` **拒绝**它：
+
+```text
+LowerAutoVectorSplit: the V->C boundary tile.move here carries a full-width
+vector operand 'vec'. tile.aic_gather reassembles the two AIV lanes' per-lane
+halves into the full tile the cube expects, so its operand must be a value the
+split halving produced (a tile.load / tile.slice / elementwise result inside the
+vector sub-region). An un-halved value has no half to gather — either derive the
+per-lane half first (load or slice the value inside the split function) and move
+that to the cube side, or, if the split axis is a singleton that cannot be
+halved, keep the value on the vector side.
+```
+
+**gather 沿操作数自身的 split 轴，而非函数的 split 轴。** `tile.reshape` 可能迁移
+split 轴——rms_norm 的 `[N, 1] ↔ [1, N]` 列 reshape 会把它从 dim 0 移到 dim 1——
+而 `TileInfo::split_dim` 记录了它最终所在的位置。gather 使用**该维度**对应的
+`split` 编码发射（`dim 0 → 1`，`dim 1 → 2`），因此在 `UpDown` 函数中，lane 本地
+的 `[1, 8]` 操作数经由 `split=2` gather 为 `[1, 16]`，与 move 一致；若改为对函数
+轴加倍则会得到 `[2, 8]`。若追踪到的 split 维不在 `{0, 1}` 内，则无法表示为 2D
+gather 的 `split` 属性，会被拒绝。
 
 gather 结果是 `Mat` 而非 `Vec`：边界算子声明的类型指的是**消费侧** lane 的空间，
 而 AIC 会把 V→C 传输 pop 进 L1。（`Vec` 指的是*生产侧* lane，与镜像算子

--- a/src/ir/transforms/lower_auto_vector_split_pass.cpp
+++ b/src/ir/transforms/lower_auto_vector_split_pass.cpp
@@ -66,6 +66,7 @@
 #include "pypto/ir/transforms/base/visitor.h"
 #include "pypto/ir/transforms/pass_properties.h"
 #include "pypto/ir/transforms/passes.h"
+#include "pypto/ir/transforms/structural_comparison.h"
 #include "pypto/ir/transforms/utils/core_affinity.h"
 #include "pypto/ir/transforms/utils/deep_clone_utils.h"
 #include "pypto/ir/transforms/utils/loop_state_repair.h"
@@ -311,11 +312,41 @@ std::vector<StmtPtr> LowerStmts(const std::vector<StmtPtr>& stmts, SplitMode mod
           // move). Resolve it to the halved var so aic_gather doubles HALF -> FULL;
           // using the original full-typed reference would over-double to 2x FULL.
           auto src = call->args_[0];
-          if (auto src_var = AsVarLike(src)) {
-            auto it = var_replacements.find(src_var.get());
-            if (it != var_replacements.end()) src = it->second;
+          auto src_var = AsVarLike(src);
+          auto tracked = src_var ? tile_vars.find(src_var.get()) : tile_vars.end();
+          // Precondition, not a guarantee: a Vec param moved straight to cube, or a
+          // singleton split dim the affinity gate preserves, reaches here un-halved.
+          // Reject rather than emit a doubled operand under a FULL-typed move.
+          CHECK_SPAN(tracked != tile_vars.end(), call->span_)
+              << "LowerAutoVectorSplit: the V->C boundary tile.move here carries a full-width "
+              << "vector operand" << (src_var ? " '" + src_var->name_hint_ + "'" : "")
+              << ". tile.aic_gather reassembles the two AIV lanes' per-lane halves into the full "
+              << "tile the cube expects, so its operand must be a value the split halving "
+              << "produced (a tile.load / tile.slice / elementwise result inside the vector "
+              << "sub-region). An un-halved value has no half to gather — either derive the "
+              << "per-lane half first (load or slice the value inside the split function) and "
+              << "move that to the cube side, or, if the split axis is a singleton that cannot "
+              << "be halved, keep the value on the vector side.";
+          if (auto it = var_replacements.find(src_var.get()); it != var_replacements.end()) {
+            src = it->second;
           }
-          auto gather = MakeReshapeOpCall("tile.aic_gather", src, split_int, call->span_);
+          // Gather along the OPERAND's own split axis, not the function/region mode:
+          // a tile.reshape can migrate the split axis (the rms_norm [N,1]<->[1,N]
+          // column reshape moves it from dim 0 to dim 1), and TileInfo::split_dim
+          // tracks where it actually ended up. Doubling the function axis instead
+          // would reassemble the wrong dimension — for a [1,8] operand under UP_DOWN
+          // it yields [2,8] where the cube-placement move expects [1,16].
+          const int tracked_split_dim = tracked->second.split_dim;
+          CHECK_SPAN(tracked_split_dim == 0 || tracked_split_dim == 1, call->span_)
+              << "LowerAutoVectorSplit: the V->C boundary operand"
+              << (src_var ? " '" + src_var->name_hint_ + "'" : "") << " carries its split on dim "
+              << tracked_split_dim
+              << ", but tile.aic_gather reassembles a 2D tile along dim 0 or dim 1 only. Cross to "
+              << "the cube side before the op that moved the split axis there.";
+          // SplitMode encoding: dim 0 -> UP_DOWN(1), dim 1 -> LEFT_RIGHT(2), matching
+          // DeduceSplitReshape's `axis = (split == 1) ? 0 : 1`.
+          const int gather_split = tracked_split_dim == 0 ? 1 : 2;
+          auto gather = MakeReshapeOpCall("tile.aic_gather", src, gather_split, call->span_);
           // Gather result: full shape, with the memory space OpRegistry::Create
           // fills in from tile.aic_gather's set_output_memory declaration — Mat, the
           // CONSUMING (cube) lane, which is the space ExpandMixedKernel pops the
@@ -331,7 +362,25 @@ std::vector<StmtPtr> LowerStmts(const std::vector<StmtPtr>& stmts, SplitMode mod
           auto full_mat_var =
               std::make_shared<Var>(assign->var_->name_hint_ + "_mat", gather_type, assign->span_);
           result.push_back(std::make_shared<AssignStmt>(full_mat_var, gather_typed, assign->span_));
-          // Original cube placement move, now on the FULL gathered tile.
+          // Original cube placement move, now on the FULL gathered tile. Keeping the
+          // move's original result type is only valid if the gather reassembled back
+          // to exactly that shape — now a genuine invariant, since the gather doubles
+          // the operand's own tracked split axis and both user-facing preconditions
+          // (operand halved; split dim gatherable) are enforced above. Compare shapes
+          // only: the gather type deliberately drops layout.
+          auto gathered_tile = As<TileType>(gather_type);
+          auto move_tile = As<TileType>(call->GetType());
+          INTERNAL_CHECK_SPAN(gathered_tile && move_tile, call->span_)
+              << "Internal error: a V->C boundary tile.move and its aic_gather must both be tiles";
+          INTERNAL_CHECK_SPAN(gathered_tile->shape_.size() == move_tile->shape_.size(), call->span_)
+              << "Internal error: aic_gather result rank " << gathered_tile->shape_.size()
+              << " does not match the cube-placement move's rank " << move_tile->shape_.size();
+          for (size_t i = 0; i < gathered_tile->shape_.size(); ++i) {
+            INTERNAL_CHECK_SPAN(structural_equal(gathered_tile->shape_[i], move_tile->shape_[i]), call->span_)
+                << "Internal error: aic_gather result dim " << i
+                << " does not match the cube-placement move's result type; the V->C boundary "
+                << "would emit a tile.move whose result shape contradicts its operand";
+          }
           std::vector<ExprPtr> move_args = call->args_;
           move_args[0] = full_mat_var;
           auto new_move = std::make_shared<Call>(call->op_, std::move(move_args), call->kwargs_,

--- a/src/ir/transforms/lower_auto_vector_split_pass.cpp
+++ b/src/ir/transforms/lower_auto_vector_split_pass.cpp
@@ -292,7 +292,10 @@ std::vector<StmtPtr> LowerStmts(const std::vector<StmtPtr>& stmts, SplitMode mod
               std::make_shared<Call>(shard->op_, shard->args_, shard->kwargs_, half_type, shard->span_);
           if (auto tt = std::dynamic_pointer_cast<const TileType>(call->GetType());
               tt && split_dim < static_cast<int>(tt->shape_.size())) {
-            TileInfo info{HalfDimExtent(tt->shape_[split_dim])};
+            // Record split_dim too: the V->C arm now gathers along the tracked
+            // dim, so a C->V shard result fed straight into a V->C boundary must
+            // carry the real dim (LEFT_RIGHT => 1), not the default 0.
+            TileInfo info{HalfDimExtent(tt->shape_[split_dim]), split_dim};
             tile_vars[assign->var_.get()] = info;
             tile_vars[new_var.get()] = info;
           }

--- a/tests/ut/ir/transforms/test_lower_auto_vector_split.py
+++ b/tests/ut/ir/transforms/test_lower_auto_vector_split.py
@@ -1135,6 +1135,49 @@ def test_vc_boundary_gathers_on_the_migrated_split_axis():
     ir.assert_structural_equal(_lower(Before), Expected)
 
 
+def test_vc_boundary_gathers_left_right_shard_fed_directly():
+    """LEFT_RIGHT: a C->V shard result fed straight into a V->C boundary gathers
+    on dim 1 (``split=2``), not dim 0.
+
+    The C->V arm seeds ``tile_vars`` with the shard's own ``split_dim``; if that
+    defaulted to 0, the gather would double rows (``[128, 64] -> [256, 64]``)
+    instead of columns and trip the shape invariant. ``popped`` is used directly
+    as the V->C operand (no intervening compute), so this exercises the shard
+    arm's seeding rather than the per-op halving path.
+    """
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore, attrs={"split": pl.SplitMode.LEFT_RIGHT})
+        def split_auto(
+            qk: pl.Tile[[128, 128], pl.FP32, pl.Mem.Mat],
+            out_0: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
+        ) -> pl.Tensor[[128, 128], pl.FP32]:
+            popped = pl.tile.move(qk, target_memory=pl.Mem.Vec)
+            back = pl.tile.move(popped, target_memory=pl.Mem.Mat)  # noqa: F841 - V->C boundary
+            out_store = pl.tile.store(popped, [0, 0], out_0)
+            return out_store
+
+    @pl.program
+    class Expected:
+        @pl.function(
+            type=pl.FunctionType.InCore,
+            attrs={"split": pl.SplitMode.LEFT_RIGHT, "split_aiv": True},
+        )
+        def split_auto(
+            qk: pl.Tile[[128, 128], pl.FP32, pl.Mem.Mat],
+            out_0: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
+        ) -> pl.Tensor[[128, 128], pl.FP32]:
+            subblock_idx = pl.tile.get_subblock_idx()
+            popped = pl.tile.aiv_shard(qk, split=2)
+            back_mat = pl.tile.aic_gather(popped, split=2)
+            back = pl.tile.move(back_mat, target_memory=pl.Mem.Mat)  # noqa: F841
+            out_store = pl.tile.store(popped, [0, 0 + subblock_idx * 64], out_0)
+            return out_store
+
+    ir.assert_structural_equal(_lower(Before), Expected)
+
+
 def test_pure_vector_split_is_left_untouched():
     """A PURE-vector ``pl.split`` function (no cube boundary) is NOT lowered.
 

--- a/tests/ut/ir/transforms/test_lower_auto_vector_split.py
+++ b/tests/ut/ir/transforms/test_lower_auto_vector_split.py
@@ -17,30 +17,37 @@ ExpandMixedKernel. It inserts ``tile.aiv_shard`` at C->V boundaries (and
 ``get_subblock_idx``, and stamps ``split`` + ``split_aiv``. CUBE-affine operands
 stay full (the affinity gate).
 
-These tests hand-build a minimal mixed InCore function at the
-post-InferTileMemorySpace level (memory spaces already assigned) and run the pass
-in isolation with verification disabled.
+Authoring style
+---------------
+The pass runs at the tile level (post-InferTileMemorySpace), but that does *not*
+put it out of reach of the ``@pl.program`` DSL: memory spaces are ordinary
+``pl.Mem.*`` annotations, and the lowered boundary ops have a dedicated outlined
+surface form (``pl.tile.aiv_shard(qk, split=1)``) that the printer emits for
+exactly this already-lowered shape. The AUTO-path tests below therefore use the
+project's mandated Before/Expected DSL style. Note that memrefs play no part
+here — ``init_mem_ref`` runs ten passes later, so no ``Before`` or ``Expected``
+in this file carries one.
 
-Why the transform-output tests hand-build IR instead of using the ``@pl.program``
-DSL (the project's default transform-test style): it is NOT that the DSL cannot
-express the shapes involved — it can author both this pass's tile-level input
-and, via the outlined boundary form (``pl.aiv_shard(qk, split=1)``), its lowered
-output. The reason is narrower: the pass runs at the tile level
-(post-InferTileMemorySpace), so writing an explicit ``Expected`` lowered program
-in the DSL means spelling out every assigned memory space and memref, which the
-hand-built helpers express directly. Each transform-output test therefore builds
-both the ``Before`` program and an explicit ``Expected`` lowered program with the
-same helpers and asserts ``ir.assert_structural_equal`` between the pass result
-and ``Expected``. Negative tests keep ``pytest.raises`` because a rejected
-transform produces no ``After`` IR. End-to-end DSL coverage of this authoring
-form lives in ``tests/st/codegen/torch/test_torch_codegen_cross_core.py``
+One group is deliberately NOT authored in the DSL: the explicit
+``SplitAivScopeStmt`` region tests, whose ``Before`` programs are hand-built so
+the region reaches the pass bare. That section's own comment explains why no DSL
+spelling can deliver one.
+
+The scope-nesting tests at the very bottom are DSL for the opposite reason: the
+DSL is what *produces* the shape under test (the parser's ``InCore`` scope
+wrapper), so hand-building would not exercise the guard at all.
+
+Negative tests keep ``pytest.raises``: a rejected transform produces no ``After``
+IR, so Before/Expected does not apply. Their ``Before`` programs are still DSL.
+
+``_lower`` keeps the print->parse roundtrip instrument ON (see its docstring for
+why property verification is not), so the pass's output is asserted round-trippable
+on every test but one — ``test_outlined_region_still_lowers_and_stamps``, which
+opts out for an upstream reason documented at that test.
+
+End-to-end DSL coverage of this authoring form lives in
+``tests/st/codegen/torch/test_torch_codegen_cross_core.py``
 (``SplitAivShardProgram``), where the numerics are checked against torch.
-
-The scope-nesting tests at the bottom of this file are the exception: they are
-authored in the DSL because the DSL is what produces the shape under test (the
-parser's ``InCore`` scope wrapper). A DSL-authored program *can* reach the
-region guards in general — declare the function ``@pl.function`` (Opaque) and
-prefix ``passes.outline_incore_scopes()`` so the wrapper is outlined first.
 
 The per-op vector halving tests (load / slice / reshape / store offset /
 singleton / loop tracking / reduce-on-split-axis throw) were migrated here from
@@ -49,16 +56,23 @@ facts are produced by the shared ``split_axis::ProcessStmts`` machinery, which
 SplitVectorKernel's deleted per-op halving driver and this pass both call. The new
 pass routes each VECTOR-affine leaf statement through that same machinery, so the
 halving is identical (Stage 1 proved byte-identity); only the entry point changed.
+
+A note on the ``cube_seed`` parameter that every AUTO-path ``Before`` carries:
+LowerAutoVectorSplit only lowers *mixed* cube<->vector functions, so each program
+opens with a ``pl.tile.move(cube_seed, target_memory=pl.Mem.Vec)`` C->V boundary
+to make the function genuinely mixed. Its result is unused; the op under test is
+the vector sub-region that gets halved. In the lowered ``Expected`` that boundary
+becomes ``pl.tile.aiv_shard(cube_seed, split=<mode>)``.
 """
 
 import pypto.language as pl
 import pytest
 from pypto import DataType, ir, passes
+from pypto.ir.instruments import make_roundtrip_instrument
 from pypto.ir.op import tile_ops as T
 
 MS = ir.MemorySpace
 FP32 = DataType.FP32
-INT16 = DataType.INT16
 _IN = ir.ParamDirection.In
 _OUT = ir.ParamDirection.Out
 
@@ -66,8 +80,8 @@ _OUT = ir.ParamDirection.Out
 _IDX = T.get_subblock_idx(span=ir.Span.unknown()).type
 
 
-def _tile(shape, view=None, mem=None):
-    return ir.TileType(shape, FP32, None, view, mem)
+def _tile(shape, mem=None):
+    return ir.TileType(shape, FP32, None, None, mem)
 
 
 def _tensor(shape):
@@ -75,54 +89,1089 @@ def _tensor(shape):
 
 
 def _lower(program):
-    with passes.PassContext([]):
+    """Run the pass with the print->parse roundtrip instrument kept ON.
+
+    The programs here are minimal and hand-shaped rather than pipeline-produced,
+    so BEFORE_AND_AFTER *property* verification (which the conftest also installs)
+    rejects them up front — the region ``Before`` bodies do not satisfy
+    ``IncoreTileOps``. That is why this file overrides the ambient context.
+
+    The roundtrip instrument is deliberately kept, though: it asserts the pass's
+    OUTPUT survives print->parse, which is cheap here and is exactly the check
+    that a fully suppressed ``PassContext([])`` was hiding — the V->C boundary
+    emitted a ``tile.move`` whose result shape contradicted its operand, and no
+    test noticed until the DSL conversion tripped over it.
+    """
+    with passes.PassContext([make_roundtrip_instrument()]):
         return passes.lower_auto_vector_split()(program)
 
 
-def _split_root_generator(op_name, shape, span):
-    if op_name == "tile.ci":
-        return T.ci(0, shape, dtype=DataType.INT32, span=span)
-    return T.random(1, 2, 3, 4, 5, 6, shape, span=span)
+# ---------------------------------------------------------------------------
+# AUTO whole-function ``pl.split`` path — Before / Expected in the DSL.
+# ---------------------------------------------------------------------------
 
 
-def _incore_program(params, stmts, return_types, *, mode=ir.SplitMode.UP_DOWN, name="split_auto"):
-    """Build a single-function mixed InCore Program carrying a function-level split mode.
+def test_c2v_boundary_becomes_aiv_shard_and_vector_region_is_halved():
+    """The C->V ``tile.move`` becomes ``tile.aiv_shard(split=1)`` and the vector
+    sub-region (add + store result) is halved to ``[64, 128]`` while the cube
+    operand ``qk`` stays full; ``subblock_idx`` is injected and ``split_aiv``
+    stamped.
 
-    ``params`` is a list of ``(Var, ParamDirection)`` pairs; ``stmts`` is the
-    flat body (including the terminating ``ReturnStmt``). The function is tagged
-    ``FunctionType.InCore`` with ``attrs={"split": mode}`` — exactly what reaches
-    LowerAutoVectorSplit in the real pipeline after InferTileMemorySpace.
-
-    A leading cube->vector boundary (``move(cube_seed Mat -> Vec)``) is injected so
-    the function is genuinely MIXED: LowerAutoVectorSplit only lowers mixed
-    cube<->vector functions — a pure-vector ``pl.split`` function has no boundary
-    to converge and is (correctly) left untouched. The boundary result is unused;
-    the op-under-test in ``stmts`` is the vector sub-region that gets halved.
+    The explicit ``TileView`` on ``y`` is the load-bearing part: the pass carries
+    the pre-split Vec col-major view through the halving, which is *not* what
+    ``tile.add`` would deduce from ``aiv_shard``'s view-less half result.
     """
-    span = ir.Span.unknown()
-    cube_seed = ir.Var("cube_seed", _tile([128, 128], mem=MS.Mat), span)
-    seed_move = T.move(cube_seed, MS.Vec, span=span)
-    assert isinstance(seed_move.type, ir.TileType)
-    seed_vec = ir.Var("seed_vec", _tile(seed_move.type.shape, seed_move.type.tile_view, MS.Vec), span)
-    func = ir.Function(
-        name,
-        [(cube_seed, _IN), *params],
-        return_types,
-        ir.SeqStmts([ir.AssignStmt(seed_vec, seed_move, span), *stmts], span),
-        span,
-        ir.FunctionType.InCore,
-        attrs={"split": mode},
-    )
-    return ir.Program([func], name, span)
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore, attrs={"split": pl.SplitMode.UP_DOWN})
+        def split_auto(
+            qk: pl.Tile[[128, 128], pl.FP32, pl.Mem.Mat],
+            out_0: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
+        ) -> pl.Tensor[[128, 128], pl.FP32]:
+            popped = pl.tile.move(qk, target_memory=pl.Mem.Vec)
+            y = pl.tile.add(popped, popped)
+            out_store = pl.tile.store(y, [0, 0], out_0)
+            return out_store
+
+    @pl.program
+    class Expected:
+        @pl.function(
+            type=pl.FunctionType.InCore,
+            attrs={"split": pl.SplitMode.UP_DOWN, "split_aiv": True},
+        )
+        def split_auto(
+            qk: pl.Tile[[128, 128], pl.FP32, pl.Mem.Mat],
+            out_0: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
+        ) -> pl.Tensor[[128, 128], pl.FP32]:
+            subblock_idx = pl.tile.get_subblock_idx()
+            popped = pl.tile.aiv_shard(qk, split=1)
+            y: pl.Tile[
+                [64, 128],
+                pl.FP32,
+                pl.Mem.Vec,
+                pl.TileView(blayout=pl.TileLayout.col_major, slayout=pl.TileLayout.row_major),
+            ] = pl.tile.add(popped, popped)
+            out_store = pl.tile.store(y, [0 + subblock_idx * 64, 0], out_0)
+            return out_store
+
+    ir.assert_structural_equal(_lower(Before), Expected)
+
+
+def test_store_offset_at_nonzero_base_localizes_additively():
+    """AdjustOffsets ADDS ``subblock_idx * half`` on the split axis rather than
+    overwriting the offset: a store at base row 16 becomes ``16 + subblock_idx * 64``.
+
+    The zero-base case is pinned by the C->V test above; this one is what
+    distinguishes "additive" from "replaced", so the base is deliberately non-zero
+    (and ``out_0`` is [256, 128] so the shifted store still fits).
+    """
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore, attrs={"split": pl.SplitMode.UP_DOWN})
+        def split_auto(
+            qk: pl.Tile[[128, 128], pl.FP32, pl.Mem.Mat],
+            out_0: pl.Out[pl.Tensor[[256, 128], pl.FP32]],
+        ) -> pl.Tensor[[256, 128], pl.FP32]:
+            popped = pl.tile.move(qk, target_memory=pl.Mem.Vec)
+            y = pl.tile.add(popped, popped)
+            out_store = pl.tile.store(y, [16, 0], out_0)
+            return out_store
+
+    @pl.program
+    class Expected:
+        @pl.function(
+            type=pl.FunctionType.InCore,
+            attrs={"split": pl.SplitMode.UP_DOWN, "split_aiv": True},
+        )
+        def split_auto(
+            qk: pl.Tile[[128, 128], pl.FP32, pl.Mem.Mat],
+            out_0: pl.Out[pl.Tensor[[256, 128], pl.FP32]],
+        ) -> pl.Tensor[[256, 128], pl.FP32]:
+            subblock_idx = pl.tile.get_subblock_idx()
+            popped = pl.tile.aiv_shard(qk, split=1)
+            y: pl.Tile[
+                [64, 128],
+                pl.FP32,
+                pl.Mem.Vec,
+                pl.TileView(blayout=pl.TileLayout.col_major, slayout=pl.TileLayout.row_major),
+            ] = pl.tile.add(popped, popped)
+            out_store = pl.tile.store(y, [16 + subblock_idx * 64, 0], out_0)
+            return out_store
+
+    ir.assert_structural_equal(_lower(Before), Expected)
 
 
 # ---------------------------------------------------------------------------
-# Expected-IR (lowered-form) construction helpers.
+# Vector sub-region per-op halving (migrated from test_split_vector_kernel.py).
 #
-# These build the *lowered* Expected the same way the Before is hand-built, so
-# each test asserts via ir.assert_structural_equal against an explicit Expected
-# program (not a python_print substring grep). See the module docstring for why
-# the DSL is not used to author either side.
+# Each builds a mixed InCore function whose vector sub-region contains the op
+# under test and asserts the new pass halves it via the shared split_axis
+# machinery — the same facts the deleted SplitVectorKernel halving driver
+# asserted, now exercised through LowerAutoVectorSplit.
+# ---------------------------------------------------------------------------
+
+
+def test_vector_load_halved_and_offset_localized():
+    """UP_DOWN: a VECTOR tile.load halves its result + shape/valid args (128 -> 64)
+    and localizes its split-dim offset per subblock."""
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore, attrs={"split": pl.SplitMode.UP_DOWN})
+        def split_auto(
+            cube_seed: pl.Tile[[128, 128], pl.FP32, pl.Mem.Mat],
+            data: pl.Tensor[[128, 128], pl.FP32],
+            out_0: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
+        ) -> pl.Tensor[[128, 128], pl.FP32]:
+            seed_vec = pl.tile.move(cube_seed, target_memory=pl.Mem.Vec)  # noqa: F841
+            prev = pl.tile.load(data, [0, 0], [128, 128], target_memory=pl.Mem.Vec)
+            out_store = pl.tile.store(prev, [0, 0], out_0)
+            return out_store
+
+    @pl.program
+    class Expected:
+        @pl.function(
+            type=pl.FunctionType.InCore,
+            attrs={"split": pl.SplitMode.UP_DOWN, "split_aiv": True},
+        )
+        def split_auto(
+            cube_seed: pl.Tile[[128, 128], pl.FP32, pl.Mem.Mat],
+            data: pl.Tensor[[128, 128], pl.FP32],
+            out_0: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
+        ) -> pl.Tensor[[128, 128], pl.FP32]:
+            subblock_idx = pl.tile.get_subblock_idx()
+            seed_vec = pl.tile.aiv_shard(cube_seed, split=1)  # noqa: F841
+            prev = pl.tile.load(data, [0 + subblock_idx * 64, 0], [64, 128], target_memory=pl.Mem.Vec)
+            out_store = pl.tile.store(prev, [0 + subblock_idx * 64, 0], out_0)
+            return out_store
+
+    ir.assert_structural_equal(_lower(Before), Expected)
+
+
+def test_vector_load_halved_left_right():
+    """LEFT_RIGHT: the load halves on dim1 (128 -> 64) and localizes the col offset."""
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore, attrs={"split": pl.SplitMode.LEFT_RIGHT})
+        def split_auto(
+            cube_seed: pl.Tile[[128, 128], pl.FP32, pl.Mem.Mat],
+            data: pl.Tensor[[128, 128], pl.FP32],
+            out_0: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
+        ) -> pl.Tensor[[128, 128], pl.FP32]:
+            seed_vec = pl.tile.move(cube_seed, target_memory=pl.Mem.Vec)  # noqa: F841
+            prev = pl.tile.load(data, [0, 0], [128, 128], target_memory=pl.Mem.Vec)
+            out_store = pl.tile.store(prev, [0, 0], out_0)
+            return out_store
+
+    @pl.program
+    class Expected:
+        @pl.function(
+            type=pl.FunctionType.InCore,
+            attrs={"split": pl.SplitMode.LEFT_RIGHT, "split_aiv": True},
+        )
+        def split_auto(
+            cube_seed: pl.Tile[[128, 128], pl.FP32, pl.Mem.Mat],
+            data: pl.Tensor[[128, 128], pl.FP32],
+            out_0: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
+        ) -> pl.Tensor[[128, 128], pl.FP32]:
+            subblock_idx = pl.tile.get_subblock_idx()
+            seed_vec = pl.tile.aiv_shard(cube_seed, split=2)  # noqa: F841
+            prev = pl.tile.load(data, [0, 0 + subblock_idx * 64], [128, 64], target_memory=pl.Mem.Vec)
+            out_store = pl.tile.store(prev, [0, 0 + subblock_idx * 64], out_0)
+            return out_store
+
+    ir.assert_structural_equal(_lower(Before), Expected)
+
+
+def test_vector_slice_halves_shape_and_localizes_offset():
+    """UP_DOWN: a tile.slice of a full (unsplit) Vec source halves its static shape
+    tuple in lockstep with the result (the qk_pv strided sub-slice fix) and
+    localizes its zero-base offset per subblock."""
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore, attrs={"split": pl.SplitMode.UP_DOWN})
+        def split_auto(
+            cube_seed: pl.Tile[[128, 128], pl.FP32, pl.Mem.Mat],
+            src: pl.Tile[[128, 128], pl.FP32, pl.Mem.Vec],
+            out_0: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
+        ) -> pl.Tensor[[128, 128], pl.FP32]:
+            seed_vec = pl.tile.move(cube_seed, target_memory=pl.Mem.Vec)  # noqa: F841
+            sub = pl.tile.slice(src, [128, 128], [0, 0])
+            out_store = pl.tile.store(sub, [0, 0], out_0)
+            return out_store
+
+    @pl.program
+    class Expected:
+        @pl.function(
+            type=pl.FunctionType.InCore,
+            attrs={"split": pl.SplitMode.UP_DOWN, "split_aiv": True},
+        )
+        def split_auto(
+            cube_seed: pl.Tile[[128, 128], pl.FP32, pl.Mem.Mat],
+            src: pl.Tile[[128, 128], pl.FP32, pl.Mem.Vec],
+            out_0: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
+        ) -> pl.Tensor[[128, 128], pl.FP32]:
+            subblock_idx = pl.tile.get_subblock_idx()
+            seed_vec = pl.tile.aiv_shard(cube_seed, split=1)  # noqa: F841
+            sub = pl.tile.slice(src, [64, 128], [0 + subblock_idx * 64, 0])
+            out_store = pl.tile.store(sub, [0 + subblock_idx * 64, 0], out_0)
+            return out_store
+
+    ir.assert_structural_equal(_lower(Before), Expected)
+
+
+def test_vector_slice_nonzero_base_offset_localizes_additively():
+    """UP_DOWN: a strided sub-slice at a non-zero base offset localizes additively —
+    the original offset is preserved and subblock_idx*half is added on the split
+    axis (the exact qk_pv ``oi[16:32]`` pattern)."""
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore, attrs={"split": pl.SplitMode.UP_DOWN})
+        def split_auto(
+            cube_seed: pl.Tile[[128, 128], pl.FP32, pl.Mem.Mat],
+            src: pl.Tile[[256, 128], pl.FP32, pl.Mem.Vec],
+            out_0: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
+        ) -> pl.Tensor[[128, 128], pl.FP32]:
+            seed_vec = pl.tile.move(cube_seed, target_memory=pl.Mem.Vec)  # noqa: F841
+            sub = pl.tile.slice(src, [128, 128], [16, 0])
+            out_store = pl.tile.store(sub, [0, 0], out_0)
+            return out_store
+
+    @pl.program
+    class Expected:
+        @pl.function(
+            type=pl.FunctionType.InCore,
+            attrs={"split": pl.SplitMode.UP_DOWN, "split_aiv": True},
+        )
+        def split_auto(
+            cube_seed: pl.Tile[[128, 128], pl.FP32, pl.Mem.Mat],
+            src: pl.Tile[[256, 128], pl.FP32, pl.Mem.Vec],
+            out_0: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
+        ) -> pl.Tensor[[128, 128], pl.FP32]:
+            subblock_idx = pl.tile.get_subblock_idx()
+            seed_vec = pl.tile.aiv_shard(cube_seed, split=1)  # noqa: F841
+            sub = pl.tile.slice(src, [64, 128], [16 + subblock_idx * 64, 0])
+            out_store = pl.tile.store(sub, [0 + subblock_idx * 64, 0], out_0)
+            return out_store
+
+    ir.assert_structural_equal(_lower(Before), Expected)
+
+
+def test_slice_of_split_tracked_source_halves_shape_keeps_offset():
+    """LEFT_RIGHT: a tile.slice whose source is already split-tracked (a halved
+    load) halves its static shape tuple but leaves its offset unchanged — the
+    source is already in lane-local coordinates."""
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore, attrs={"split": pl.SplitMode.LEFT_RIGHT})
+        def split_auto(
+            cube_seed: pl.Tile[[128, 128], pl.FP32, pl.Mem.Mat],
+            data: pl.Tensor[[16, 128], pl.FP32],
+            out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
+        ) -> pl.Tensor[[16, 128], pl.FP32]:
+            seed_vec = pl.tile.move(cube_seed, target_memory=pl.Mem.Vec)  # noqa: F841
+            prev = pl.tile.load(data, [0, 0], [16, 128], target_memory=pl.Mem.Vec)
+            sub = pl.tile.slice(prev, [16, 128], [0, 0])
+            out_store = pl.tile.store(sub, [0, 0], out_0)
+            return out_store
+
+    @pl.program
+    class Expected:
+        @pl.function(
+            type=pl.FunctionType.InCore,
+            attrs={"split": pl.SplitMode.LEFT_RIGHT, "split_aiv": True},
+        )
+        def split_auto(
+            cube_seed: pl.Tile[[128, 128], pl.FP32, pl.Mem.Mat],
+            data: pl.Tensor[[16, 128], pl.FP32],
+            out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
+        ) -> pl.Tensor[[16, 128], pl.FP32]:
+            subblock_idx = pl.tile.get_subblock_idx()
+            seed_vec = pl.tile.aiv_shard(cube_seed, split=2)  # noqa: F841
+            prev = pl.tile.load(data, [0, 0 + subblock_idx * 64], [16, 64], target_memory=pl.Mem.Vec)
+            sub = pl.tile.slice(prev, [16, 64], [0, 0])
+            out_store = pl.tile.store(sub, [0, 0 + subblock_idx * 64], out_0)
+            return out_store
+
+    ir.assert_structural_equal(_lower(Before), Expected)
+
+
+def test_reshape_of_rank1_load_is_sliced_per_subblock():
+    """UP_DOWN: a rank-1 load reshaped to [N, 1] is emitted at full width and
+    followed by a per-subblock column slice so each lane reads its own row-half
+    (the v2-minimal slice fix; rank-1 loads carry no 2D split axis)."""
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore, attrs={"split": pl.SplitMode.UP_DOWN})
+        def split_auto(
+            cube_seed: pl.Tile[[128, 128], pl.FP32, pl.Mem.Mat],
+            scale: pl.Tensor[[128], pl.FP32],
+            out_0: pl.Out[pl.Tensor[[128, 1], pl.FP32]],
+        ) -> pl.Tensor[[128, 1], pl.FP32]:
+            seed_vec = pl.tile.move(cube_seed, target_memory=pl.Mem.Vec)  # noqa: F841
+            scale_row = pl.tile.load(scale, [0], [128], target_memory=pl.Mem.Vec)
+            scale_2d = pl.tile.reshape(scale_row, [128, 1])
+            out_store = pl.tile.store(scale_2d, [0, 0], out_0)
+            return out_store
+
+    @pl.program
+    class Expected:
+        @pl.function(
+            type=pl.FunctionType.InCore,
+            attrs={"split": pl.SplitMode.UP_DOWN, "split_aiv": True},
+        )
+        def split_auto(
+            cube_seed: pl.Tile[[128, 128], pl.FP32, pl.Mem.Mat],
+            scale: pl.Tensor[[128], pl.FP32],
+            out_0: pl.Out[pl.Tensor[[128, 1], pl.FP32]],
+        ) -> pl.Tensor[[128, 1], pl.FP32]:
+            subblock_idx = pl.tile.get_subblock_idx()
+            seed_vec = pl.tile.aiv_shard(cube_seed, split=1)  # noqa: F841
+            scale_row = pl.tile.load(scale, [0], [128], target_memory=pl.Mem.Vec)
+            scale_2d = pl.tile.reshape(scale_row, [128, 1])
+            scale_2d_1 = pl.tile.slice(scale_2d, [64, 1], [subblock_idx * 64, 0])
+            out_store = pl.tile.store(scale_2d_1, [0 + subblock_idx * 64, 0], out_0)
+            return out_store
+
+    ir.assert_structural_equal(_lower(Before), Expected)
+
+
+def test_reshape_of_already_split_input_halves_shape_arg():
+    """UP_DOWN: a reshape whose input is already split halves its shape ARGUMENT
+    too ([256, 1] -> [128, 1]), not just the result type, so memory_reuse sizes
+    the output from the halved literal."""
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore, attrs={"split": pl.SplitMode.UP_DOWN})
+        def split_auto(
+            cube_seed: pl.Tile[[128, 128], pl.FP32, pl.Mem.Mat],
+            data: pl.Tensor[[16, 16], pl.FP32],
+            out_0: pl.Out[pl.Tensor[[256, 1], pl.FP32]],
+        ) -> pl.Tensor[[256, 1], pl.FP32]:
+            seed_vec = pl.tile.move(cube_seed, target_memory=pl.Mem.Vec)  # noqa: F841
+            prev = pl.tile.load(data, [0, 0], [16, 16], target_memory=pl.Mem.Vec)
+            flat = pl.tile.reshape(prev, [256, 1])
+            out_store = pl.tile.store(flat, [0, 0], out_0)
+            return out_store
+
+    @pl.program
+    class Expected:
+        @pl.function(
+            type=pl.FunctionType.InCore,
+            attrs={"split": pl.SplitMode.UP_DOWN, "split_aiv": True},
+        )
+        def split_auto(
+            cube_seed: pl.Tile[[128, 128], pl.FP32, pl.Mem.Mat],
+            data: pl.Tensor[[16, 16], pl.FP32],
+            out_0: pl.Out[pl.Tensor[[256, 1], pl.FP32]],
+        ) -> pl.Tensor[[256, 1], pl.FP32]:
+            subblock_idx = pl.tile.get_subblock_idx()
+            seed_vec = pl.tile.aiv_shard(cube_seed, split=1)  # noqa: F841
+            prev = pl.tile.load(data, [0 + subblock_idx * 8, 0], [8, 16], target_memory=pl.Mem.Vec)
+            flat = pl.tile.reshape(prev, [128, 1])
+            out_store = pl.tile.store(flat, [0 + subblock_idx * 128, 0], out_0)
+            return out_store
+
+    ir.assert_structural_equal(_lower(Before), Expected)
+
+
+def test_auto_reinterpret_view_of_split_input_scales_lane_local_shape():
+    """UP_DOWN: auto reinterpret keeps the tracked split axis and scales only the contiguous axis."""
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore, attrs={"split": pl.SplitMode.UP_DOWN})
+        def split_auto(
+            cube_seed: pl.Tile[[128, 128], pl.FP32, pl.Mem.Mat],
+            data: pl.Tensor[[16, 16], pl.FP32],
+            out_0: pl.Out[pl.Tensor[[16, 32], pl.INT16]],
+        ) -> pl.Tensor[[16, 32], pl.INT16]:
+            seed_vec = pl.tile.move(cube_seed, target_memory=pl.Mem.Vec)  # noqa: F841
+            prev = pl.tile.load(data, [0, 0], [16, 16], target_memory=pl.Mem.Vec)
+            bits = pl.tile.reinterpret_view(prev, dtype=pl.INT16)
+            out_store = pl.tile.store(bits, [0, 0], out_0)
+            return out_store
+
+    @pl.program
+    class Expected:
+        @pl.function(
+            type=pl.FunctionType.InCore,
+            attrs={"split": pl.SplitMode.UP_DOWN, "split_aiv": True},
+        )
+        def split_auto(
+            cube_seed: pl.Tile[[128, 128], pl.FP32, pl.Mem.Mat],
+            data: pl.Tensor[[16, 16], pl.FP32],
+            out_0: pl.Out[pl.Tensor[[16, 32], pl.INT16]],
+        ) -> pl.Tensor[[16, 32], pl.INT16]:
+            subblock_idx = pl.tile.get_subblock_idx()
+            seed_vec = pl.tile.aiv_shard(cube_seed, split=1)  # noqa: F841
+            prev = pl.tile.load(data, [0 + subblock_idx * 8, 0], [8, 16], target_memory=pl.Mem.Vec)
+            bits = pl.tile.reinterpret_view(prev, dtype=pl.INT16)
+            out_store = pl.tile.store(bits, [0 + subblock_idx * 8, 0], out_0)
+            return out_store
+
+    ir.assert_structural_equal(_lower(Before), Expected)
+
+
+def test_auto_equivalent_explicit_reinterpret_shape_is_halved_with_split_input():
+    """UP_DOWN: an explicit spelling of the auto shape is accepted and halved with the source."""
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore, attrs={"split": pl.SplitMode.UP_DOWN})
+        def split_auto(
+            cube_seed: pl.Tile[[128, 128], pl.FP32, pl.Mem.Mat],
+            data: pl.Tensor[[16, 16], pl.FP32],
+            out_0: pl.Out[pl.Tensor[[16, 32], pl.INT16]],
+        ) -> pl.Tensor[[16, 32], pl.INT16]:
+            seed_vec = pl.tile.move(cube_seed, target_memory=pl.Mem.Vec)  # noqa: F841
+            prev = pl.tile.load(data, [0, 0], [16, 16], target_memory=pl.Mem.Vec)
+            bits = pl.tile.reinterpret_view(prev, dtype=pl.INT16, shape=[16, 32])
+            out_store = pl.tile.store(bits, [0, 0], out_0)
+            return out_store
+
+    @pl.program
+    class Expected:
+        @pl.function(
+            type=pl.FunctionType.InCore,
+            attrs={"split": pl.SplitMode.UP_DOWN, "split_aiv": True},
+        )
+        def split_auto(
+            cube_seed: pl.Tile[[128, 128], pl.FP32, pl.Mem.Mat],
+            data: pl.Tensor[[16, 16], pl.FP32],
+            out_0: pl.Out[pl.Tensor[[16, 32], pl.INT16]],
+        ) -> pl.Tensor[[16, 32], pl.INT16]:
+            subblock_idx = pl.tile.get_subblock_idx()
+            seed_vec = pl.tile.aiv_shard(cube_seed, split=1)  # noqa: F841
+            prev = pl.tile.load(data, [0 + subblock_idx * 8, 0], [8, 16], target_memory=pl.Mem.Vec)
+            bits = pl.tile.reinterpret_view(prev, dtype=pl.INT16, shape=[8, 32])
+            out_store = pl.tile.store(bits, [0 + subblock_idx * 8, 0], out_0)
+            return out_store
+
+    ir.assert_structural_equal(_lower(Before), Expected)
+
+
+def test_arbitrary_explicit_reinterpret_shape_is_rejected_under_split():
+    """A byte-equivalent shape that redistributes dimensions has no safe physical split-axis mapping."""
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore, attrs={"split": pl.SplitMode.UP_DOWN})
+        def split_auto(
+            cube_seed: pl.Tile[[128, 128], pl.FP32, pl.Mem.Mat],
+            data: pl.Tensor[[16, 16], pl.FP32],
+            out_0: pl.Out[pl.Tensor[[8, 64], pl.INT16]],
+        ) -> pl.Tensor[[8, 64], pl.INT16]:
+            seed_vec = pl.tile.move(cube_seed, target_memory=pl.Mem.Vec)  # noqa: F841
+            prev = pl.tile.load(data, [0, 0], [16, 16], target_memory=pl.Mem.Vec)
+            bits = pl.tile.reinterpret_view(prev, dtype=pl.INT16, shape=[8, 64])
+            out_store = pl.tile.store(bits, [0, 0], out_0)
+            return out_store
+
+    with pytest.raises(ValueError, match="must match its auto-inferred shape"):
+        _lower(Before)
+
+
+def test_reinterpret_view_of_full_source_is_sliced_per_subblock():
+    """LEFT_RIGHT: an untracked full tile param is reinterpreted, then sliced per lane."""
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore, attrs={"split": pl.SplitMode.LEFT_RIGHT})
+        def split_auto(
+            cube_seed: pl.Tile[[128, 128], pl.FP32, pl.Mem.Mat],
+            data: pl.Tile[[16, 16], pl.FP32, pl.Mem.Vec],
+            out_0: pl.Out[pl.Tensor[[16, 32], pl.INT16]],
+        ) -> pl.Tensor[[16, 32], pl.INT16]:
+            seed_vec = pl.tile.move(cube_seed, target_memory=pl.Mem.Vec)  # noqa: F841
+            bits = pl.tile.reinterpret_view(data, dtype=pl.INT16)
+            out_store = pl.tile.store(bits, [0, 0], out_0)
+            return out_store
+
+    @pl.program
+    class Expected:
+        @pl.function(
+            type=pl.FunctionType.InCore,
+            attrs={"split": pl.SplitMode.LEFT_RIGHT, "split_aiv": True},
+        )
+        def split_auto(
+            cube_seed: pl.Tile[[128, 128], pl.FP32, pl.Mem.Mat],
+            data: pl.Tile[[16, 16], pl.FP32, pl.Mem.Vec],
+            out_0: pl.Out[pl.Tensor[[16, 32], pl.INT16]],
+        ) -> pl.Tensor[[16, 32], pl.INT16]:
+            subblock_idx = pl.tile.get_subblock_idx()
+            seed_vec = pl.tile.aiv_shard(cube_seed, split=2)  # noqa: F841
+            bits = pl.tile.reinterpret_view(data, dtype=pl.INT16)
+            bits_1 = pl.tile.slice(bits, [16, 16], [0, subblock_idx * 16])
+            out_store = pl.tile.store(bits_1, [0, 0 + subblock_idx * 16], out_0)
+            return out_store
+
+    ir.assert_structural_equal(_lower(Before), Expected)
+
+
+def test_reshape_migrates_split_axis_row_to_col_and_back():
+    """UP_DOWN: a [N,1]<->[1,N] reshape migrates the split axis, not corrupts it (gh#1864).
+
+    The rms_norm column reshape moves the split data (rows) into the column dim and
+    back. Each AIV lane keeps its own half, so the reshape targets must halve the
+    MIGRATED dim ([1,8], then [8,1]) -- not stay at the stale full width ([1,16])
+    which left lane 1 reading garbage and emitting inf. No per-subblock slice is
+    needed (the partition is lane-local through the migration)."""
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore, attrs={"split": pl.SplitMode.UP_DOWN})
+        def split_auto(
+            cube_seed: pl.Tile[[128, 128], pl.FP32, pl.Mem.Mat],
+            data: pl.Tensor[[16, 1], pl.FP32],
+            out_0: pl.Out[pl.Tensor[[16, 1], pl.FP32]],
+        ) -> pl.Tensor[[16, 1], pl.FP32]:
+            seed_vec = pl.tile.move(cube_seed, target_memory=pl.Mem.Vec)  # noqa: F841
+            col = pl.tile.load(data, [0, 0], [16, 1], target_memory=pl.Mem.Vec)
+            row = pl.tile.reshape(col, [1, 16])
+            inv_row = pl.tile.recip(row)
+            back = pl.tile.reshape(inv_row, [16, 1])
+            out_store = pl.tile.store(back, [0, 0], out_0)
+            return out_store
+
+    @pl.program
+    class Expected:
+        @pl.function(
+            type=pl.FunctionType.InCore,
+            attrs={"split": pl.SplitMode.UP_DOWN, "split_aiv": True},
+        )
+        def split_auto(
+            cube_seed: pl.Tile[[128, 128], pl.FP32, pl.Mem.Mat],
+            data: pl.Tensor[[16, 1], pl.FP32],
+            out_0: pl.Out[pl.Tensor[[16, 1], pl.FP32]],
+        ) -> pl.Tensor[[16, 1], pl.FP32]:
+            subblock_idx = pl.tile.get_subblock_idx()
+            seed_vec = pl.tile.aiv_shard(cube_seed, split=1)  # noqa: F841
+            col = pl.tile.load(data, [0 + subblock_idx * 8, 0], [8, 1], target_memory=pl.Mem.Vec)
+            row = pl.tile.reshape(col, [1, 8])
+            inv_row = pl.tile.recip(row)
+            back = pl.tile.reshape(inv_row, [8, 1])
+            out_store = pl.tile.store(back, [0 + subblock_idx * 8, 0], out_0)
+            return out_store
+
+    ir.assert_structural_equal(_lower(Before), Expected)
+
+
+def test_reshape_untrackable_split_axis_rejected():
+    """A reshape whose split partition can't map to a clean per-dim halving is rejected.
+
+    The dim-0 split of a [6, 4] tile partitions at flat offset 12 (rows 0-2 vs 3-5).
+    Reshaping to [3, 8] would place that boundary mid-row, so no result dim can
+    carry the halved split cleanly -- the pass rejects rather than miscompile."""
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore, attrs={"split": pl.SplitMode.UP_DOWN})
+        def split_auto(
+            cube_seed: pl.Tile[[128, 128], pl.FP32, pl.Mem.Mat],
+            data: pl.Tensor[[6, 4], pl.FP32],
+            out_0: pl.Out[pl.Tensor[[3, 8], pl.FP32]],
+        ) -> pl.Tensor[[3, 8], pl.FP32]:
+            seed_vec = pl.tile.move(cube_seed, target_memory=pl.Mem.Vec)  # noqa: F841
+            prev = pl.tile.load(data, [0, 0], [6, 4], target_memory=pl.Mem.Vec)
+            flat = pl.tile.reshape(prev, [3, 8])
+            out_store = pl.tile.store(flat, [0, 0], out_0)
+            return out_store
+
+    with pytest.raises(ValueError, match="moves the split axis"):
+        _lower(Before)
+
+
+def test_singleton_broadcast_tile_preserved():
+    """UP_DOWN: a [1, 128] broadcast tile is NOT halved on the singleton split dim."""
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore, attrs={"split": pl.SplitMode.UP_DOWN})
+        def split_auto(
+            cube_seed: pl.Tile[[128, 128], pl.FP32, pl.Mem.Mat],
+            src: pl.Tile[[1, 128], pl.FP32, pl.Mem.Vec],
+            out_0: pl.Out[pl.Tensor[[1, 128], pl.FP32]],
+        ) -> pl.Tensor[[1, 128], pl.FP32]:
+            seed_vec = pl.tile.move(cube_seed, target_memory=pl.Mem.Vec)  # noqa: F841
+            av = pl.tile.add(src, src)
+            out_store = pl.tile.store(av, [0, 0], out_0)
+            return out_store
+
+    @pl.program
+    class Expected:
+        @pl.function(
+            type=pl.FunctionType.InCore,
+            attrs={"split": pl.SplitMode.UP_DOWN, "split_aiv": True},
+        )
+        def split_auto(
+            cube_seed: pl.Tile[[128, 128], pl.FP32, pl.Mem.Mat],
+            src: pl.Tile[[1, 128], pl.FP32, pl.Mem.Vec],
+            out_0: pl.Out[pl.Tensor[[1, 128], pl.FP32]],
+        ) -> pl.Tensor[[1, 128], pl.FP32]:
+            subblock_idx = pl.tile.get_subblock_idx()  # noqa: F841
+            seed_vec = pl.tile.aiv_shard(cube_seed, split=1)  # noqa: F841
+            av = pl.tile.add(src, src)
+            out_store = pl.tile.store(av, [0, 0], out_0)
+            return out_store
+
+    ir.assert_structural_equal(_lower(Before), Expected)
+
+
+# ---------------------------------------------------------------------------
+# Position-dependent root generators (tile.ci / tile.random).
+#
+# These were a single ``@pytest.mark.parametrize`` over (op, mode, shape) when
+# the programs were hand-built. A DSL ``Before`` cannot be parametrized that way:
+# ``pl.Tile[...]`` annotations and op shape arguments are read from the AST, so
+# the shapes have to be literals. One test per case instead.
+# ---------------------------------------------------------------------------
+
+
+def test_ci_left_right_auto_halving_rejected():
+    """Root generators need lane-specific position state, not just a halved result type."""
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore, attrs={"split": pl.SplitMode.LEFT_RIGHT})
+        def split_auto(
+            cube_seed: pl.Tile[[128, 128], pl.FP32, pl.Mem.Mat],
+        ) -> pl.Tile[[1, 64], pl.INT32, pl.Mem.Vec]:
+            seed_vec = pl.tile.move(cube_seed, target_memory=pl.Mem.Vec)  # noqa: F841
+            value = pl.tile.ci(pl.const(0, pl.INT32), [1, 64], dtype=pl.INT32, descending=False)
+            return value
+
+    with pytest.raises(ValueError, match="automatic split-axis halving") as exc_info:
+        _lower(Before)
+    assert "tile.ci" in str(exc_info.value)
+
+
+def test_random_up_down_auto_halving_rejected():
+    """Root generators need lane-specific position state, not just a halved result type."""
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore, attrs={"split": pl.SplitMode.UP_DOWN})
+        def split_auto(
+            cube_seed: pl.Tile[[128, 128], pl.FP32, pl.Mem.Mat],
+        ) -> pl.Tile[[128, 64], pl.UINT32, pl.Mem.Vec]:
+            seed_vec = pl.tile.move(cube_seed, target_memory=pl.Mem.Vec)  # noqa: F841
+            value = pl.tile.random(
+                pl.const(1, pl.INT32),
+                pl.const(2, pl.INT32),
+                pl.const(3, pl.INT32),
+                pl.const(4, pl.INT32),
+                pl.const(5, pl.INT32),
+                pl.const(6, pl.INT32),
+                [128, 64],
+                dtype=pl.UINT32,
+                rounds=10,
+            )
+            return value
+
+    with pytest.raises(ValueError, match="automatic split-axis halving") as exc_info:
+        _lower(Before)
+    assert "tile.random" in str(exc_info.value)
+
+
+def test_random_left_right_auto_halving_rejected():
+    """Root generators need lane-specific position state, not just a halved result type."""
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore, attrs={"split": pl.SplitMode.LEFT_RIGHT})
+        def split_auto(
+            cube_seed: pl.Tile[[128, 128], pl.FP32, pl.Mem.Mat],
+        ) -> pl.Tile[[128, 64], pl.UINT32, pl.Mem.Vec]:
+            seed_vec = pl.tile.move(cube_seed, target_memory=pl.Mem.Vec)  # noqa: F841
+            value = pl.tile.random(
+                pl.const(1, pl.INT32),
+                pl.const(2, pl.INT32),
+                pl.const(3, pl.INT32),
+                pl.const(4, pl.INT32),
+                pl.const(5, pl.INT32),
+                pl.const(6, pl.INT32),
+                [128, 64],
+                dtype=pl.UINT32,
+                rounds=10,
+            )
+            return value
+
+    with pytest.raises(ValueError, match="automatic split-axis halving") as exc_info:
+        _lower(Before)
+    assert "tile.random" in str(exc_info.value)
+
+
+def test_ci_up_down_singleton_split_dim_preserved():
+    """A singleton split dimension requires no generator-state rewrite."""
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore, attrs={"split": pl.SplitMode.UP_DOWN})
+        def split_auto(
+            cube_seed: pl.Tile[[128, 128], pl.FP32, pl.Mem.Mat],
+        ) -> pl.Tile[[1, 64], pl.INT32, pl.Mem.Vec]:
+            seed_vec = pl.tile.move(cube_seed, target_memory=pl.Mem.Vec)  # noqa: F841
+            value = pl.tile.ci(pl.const(0, pl.INT32), [1, 64], dtype=pl.INT32, descending=False)
+            return value
+
+    @pl.program
+    class Expected:
+        @pl.function(
+            type=pl.FunctionType.InCore,
+            attrs={"split": pl.SplitMode.UP_DOWN, "split_aiv": True},
+        )
+        def split_auto(
+            cube_seed: pl.Tile[[128, 128], pl.FP32, pl.Mem.Mat],
+        ) -> pl.Tile[[1, 64], pl.INT32, pl.Mem.Vec]:
+            subblock_idx = pl.tile.get_subblock_idx()  # noqa: F841
+            seed_vec = pl.tile.aiv_shard(cube_seed, split=1)  # noqa: F841
+            value = pl.tile.ci(pl.const(0, pl.INT32), [1, 64], dtype=pl.INT32, descending=False)
+            return value
+
+    ir.assert_structural_equal(_lower(Before), Expected)
+
+
+def test_random_up_down_singleton_split_dim_preserved():
+    """A singleton split dimension requires no generator-state rewrite."""
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore, attrs={"split": pl.SplitMode.UP_DOWN})
+        def split_auto(
+            cube_seed: pl.Tile[[128, 128], pl.FP32, pl.Mem.Mat],
+        ) -> pl.Tile[[1, 64], pl.UINT32, pl.Mem.Vec]:
+            seed_vec = pl.tile.move(cube_seed, target_memory=pl.Mem.Vec)  # noqa: F841
+            value = pl.tile.random(
+                pl.const(1, pl.INT32),
+                pl.const(2, pl.INT32),
+                pl.const(3, pl.INT32),
+                pl.const(4, pl.INT32),
+                pl.const(5, pl.INT32),
+                pl.const(6, pl.INT32),
+                [1, 64],
+                dtype=pl.UINT32,
+                rounds=10,
+            )
+            return value
+
+    @pl.program
+    class Expected:
+        @pl.function(
+            type=pl.FunctionType.InCore,
+            attrs={"split": pl.SplitMode.UP_DOWN, "split_aiv": True},
+        )
+        def split_auto(
+            cube_seed: pl.Tile[[128, 128], pl.FP32, pl.Mem.Mat],
+        ) -> pl.Tile[[1, 64], pl.UINT32, pl.Mem.Vec]:
+            subblock_idx = pl.tile.get_subblock_idx()  # noqa: F841
+            seed_vec = pl.tile.aiv_shard(cube_seed, split=1)  # noqa: F841
+            value = pl.tile.random(
+                pl.const(1, pl.INT32),
+                pl.const(2, pl.INT32),
+                pl.const(3, pl.INT32),
+                pl.const(4, pl.INT32),
+                pl.const(5, pl.INT32),
+                pl.const(6, pl.INT32),
+                [1, 64],
+                dtype=pl.UINT32,
+                rounds=10,
+            )
+            return value
+
+    ir.assert_structural_equal(_lower(Before), Expected)
+
+
+def test_random_left_right_singleton_split_dim_preserved():
+    """A singleton split dimension requires no generator-state rewrite."""
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore, attrs={"split": pl.SplitMode.LEFT_RIGHT})
+        def split_auto(
+            cube_seed: pl.Tile[[128, 128], pl.FP32, pl.Mem.Mat],
+        ) -> pl.Tile[[128, 1], pl.UINT32, pl.Mem.Vec]:
+            seed_vec = pl.tile.move(cube_seed, target_memory=pl.Mem.Vec)  # noqa: F841
+            value = pl.tile.random(
+                pl.const(1, pl.INT32),
+                pl.const(2, pl.INT32),
+                pl.const(3, pl.INT32),
+                pl.const(4, pl.INT32),
+                pl.const(5, pl.INT32),
+                pl.const(6, pl.INT32),
+                [128, 1],
+                dtype=pl.UINT32,
+                rounds=10,
+            )
+            return value
+
+    @pl.program
+    class Expected:
+        @pl.function(
+            type=pl.FunctionType.InCore,
+            attrs={"split": pl.SplitMode.LEFT_RIGHT, "split_aiv": True},
+        )
+        def split_auto(
+            cube_seed: pl.Tile[[128, 128], pl.FP32, pl.Mem.Mat],
+        ) -> pl.Tile[[128, 1], pl.UINT32, pl.Mem.Vec]:
+            subblock_idx = pl.tile.get_subblock_idx()  # noqa: F841
+            seed_vec = pl.tile.aiv_shard(cube_seed, split=2)  # noqa: F841
+            value = pl.tile.random(
+                pl.const(1, pl.INT32),
+                pl.const(2, pl.INT32),
+                pl.const(3, pl.INT32),
+                pl.const(4, pl.INT32),
+                pl.const(5, pl.INT32),
+                pl.const(6, pl.INT32),
+                [128, 1],
+                dtype=pl.UINT32,
+                rounds=10,
+            )
+            return value
+
+    ir.assert_structural_equal(_lower(Before), Expected)
+
+
+def test_loop_iter_arg_keeps_split_tracking():
+    """UP_DOWN: a loop iter_arg seeded by a halved load keeps split-aware store
+    offsets inside the loop body (tile_vars tracking flows through iter_args)."""
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore, attrs={"split": pl.SplitMode.UP_DOWN})
+        def split_auto(
+            cube_seed: pl.Tile[[128, 128], pl.FP32, pl.Mem.Mat],
+            data: pl.Tensor[[128, 128], pl.FP32],
+            out_0: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
+        ) -> pl.Tensor[[128, 128], pl.FP32]:
+            seed_vec = pl.tile.move(cube_seed, target_memory=pl.Mem.Vec)  # noqa: F841
+            accum = pl.tile.load(data, [0, 0], [128, 128], target_memory=pl.Mem.Vec)
+            for i, (out_it,) in pl.range(2, init_values=(out_0,)):  # noqa: B007
+                out_it_next = pl.tile.store(accum, [0, 0], out_it)
+                out_loop = pl.yield_(out_it_next)
+            return out_loop
+
+    @pl.program
+    class Expected:
+        @pl.function(
+            type=pl.FunctionType.InCore,
+            attrs={"split": pl.SplitMode.UP_DOWN, "split_aiv": True},
+        )
+        def split_auto(
+            cube_seed: pl.Tile[[128, 128], pl.FP32, pl.Mem.Mat],
+            data: pl.Tensor[[128, 128], pl.FP32],
+            out_0: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
+        ) -> pl.Tensor[[128, 128], pl.FP32]:
+            subblock_idx = pl.tile.get_subblock_idx()
+            seed_vec = pl.tile.aiv_shard(cube_seed, split=1)  # noqa: F841
+            accum = pl.tile.load(data, [0 + subblock_idx * 64, 0], [64, 128], target_memory=pl.Mem.Vec)
+            for i, (out_it,) in pl.range(2, init_values=(out_0,)):  # noqa: B007
+                out_it_next = pl.tile.store(accum, [0 + subblock_idx * 64, 0], out_it)
+                out_loop = pl.yield_(out_it_next)
+            return out_loop
+
+    ir.assert_structural_equal(_lower(Before), Expected)
+
+
+def test_reduce_on_split_axis_rejected():
+    """A reduce that collapses the split axis (dim0 under UP_DOWN) raises ValueError —
+    a partial per-lane reduction is a miscompile.
+
+    ``col_sum`` is the axis-0 reduction (``pto.tcolsum``), so under UP_DOWN it
+    collapses exactly the split axis."""
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore, attrs={"split": pl.SplitMode.UP_DOWN})
+        def split_auto(
+            cube_seed: pl.Tile[[128, 128], pl.FP32, pl.Mem.Mat],
+            src: pl.Tile[[128, 128], pl.FP32, pl.Mem.Vec],
+            out_0: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
+        ) -> pl.Tensor[[128, 128], pl.FP32]:
+            seed_vec = pl.tile.move(cube_seed, target_memory=pl.Mem.Vec)  # noqa: F841
+            rv = pl.tile.col_sum(src)
+            out_store = pl.tile.store(rv, [0, 0], out_0)
+            return out_store
+
+    with pytest.raises(ValueError, match="reduces on the split axis"):
+        _lower(Before)
+
+
+# ---------------------------------------------------------------------------
+# V->C boundary.
+#
+# tile.aic_gather is declared HALF -> FULL, so its operand must be a per-lane
+# half the affinity gate produced. The pass enforces that precondition: an
+# un-halved vector operand is rejected rather than doubled (doubling would hand
+# the cube a 2x tile while the cube-placement move kept its original FULL result
+# type, contradicting tile.move's shape-preserving contract).
+# ---------------------------------------------------------------------------
+
+
+def test_vc_boundary_becomes_aic_gather_and_cube_placement_stays_full():
+    """UP_DOWN: a V->C tile.move boundary becomes tile.aic_gather, and the cube
+    placement move on the gathered tile stays FULL ([128, 128] Mat) — the cube
+    side never sees a halved tile.
+
+    The vector value crossing to the cube is a halved load, so the gather
+    reassembles [64, 128] -> [128, 128] and the move's kept [128, 128] agrees.
+    """
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore, attrs={"split": pl.SplitMode.UP_DOWN})
+        def split_auto(
+            cube_seed: pl.Tile[[128, 128], pl.FP32, pl.Mem.Mat],
+            data: pl.Tensor[[128, 128], pl.FP32],
+            out_0: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
+        ) -> pl.Tensor[[128, 128], pl.FP32]:
+            seed_vec = pl.tile.move(cube_seed, target_memory=pl.Mem.Vec)  # noqa: F841
+            v = pl.tile.load(data, [0, 0], [128, 128], target_memory=pl.Mem.Vec)
+            gathered = pl.tile.move(v, target_memory=pl.Mem.Mat)  # noqa: F841 - V->C boundary
+            out_store = pl.tile.store(v, [0, 0], out_0)
+            return out_store
+
+    @pl.program
+    class Expected:
+        @pl.function(
+            type=pl.FunctionType.InCore,
+            attrs={"split": pl.SplitMode.UP_DOWN, "split_aiv": True},
+        )
+        def split_auto(
+            cube_seed: pl.Tile[[128, 128], pl.FP32, pl.Mem.Mat],
+            data: pl.Tensor[[128, 128], pl.FP32],
+            out_0: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
+        ) -> pl.Tensor[[128, 128], pl.FP32]:
+            subblock_idx = pl.tile.get_subblock_idx()
+            seed_vec = pl.tile.aiv_shard(cube_seed, split=1)  # noqa: F841
+            v = pl.tile.load(data, [0 + subblock_idx * 64, 0], [64, 128], target_memory=pl.Mem.Vec)
+            gathered_mat = pl.tile.aic_gather(v, split=1)
+            gathered = pl.tile.move(gathered_mat, target_memory=pl.Mem.Mat)  # noqa: F841
+            out_store = pl.tile.store(v, [0 + subblock_idx * 64, 0], out_0)
+            return out_store
+
+    ir.assert_structural_equal(_lower(Before), Expected)
+
+
+def test_vc_boundary_rejects_unhalved_vector_operand():
+    """A full-width vector value at a V->C boundary has no half to gather.
+
+    ``vec`` is a Vec parameter used directly, so the affinity gate never halves
+    it. Doubling it via tile.aic_gather would produce a [256, 128] operand under
+    a cube-placement move still typed [128, 128] — shape-inconsistent IR that
+    does not survive print->parse. The pass reports the authoring error instead.
+    """
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore, attrs={"split": pl.SplitMode.UP_DOWN})
+        def split_auto(
+            cube_seed: pl.Tile[[128, 128], pl.FP32, pl.Mem.Mat],
+            vec: pl.Tile[[128, 128], pl.FP32, pl.Mem.Vec],
+            out_0: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
+        ) -> pl.Tensor[[128, 128], pl.FP32]:
+            seed_vec = pl.tile.move(cube_seed, target_memory=pl.Mem.Vec)  # noqa: F841
+            gathered = pl.tile.move(vec, target_memory=pl.Mem.Mat)  # noqa: F841 - V->C boundary
+            out_store = pl.tile.store(vec, [0, 0], out_0)
+            return out_store
+
+    with pytest.raises(ValueError, match="full-width vector operand"):
+        _lower(Before)
+
+
+def test_vc_boundary_gathers_on_the_migrated_split_axis():
+    """The gather reassembles the OPERAND's split axis, not the function's.
+
+    A ``[16, 1] -> [1, 16]`` reshape migrates the split axis from dim 0 to dim 1
+    (the rms_norm column-reshape shape). Gathering the *function* axis would
+    double dim 0, turning the lane-local ``[1, 8]`` into ``[2, 8]`` while the
+    cube-placement move still expects ``[1, 16]``. Gathering the tracked axis
+    yields ``[1, 16]`` — hence ``split=2`` here under an UP_DOWN function.
+    """
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore, attrs={"split": pl.SplitMode.UP_DOWN})
+        def split_auto(
+            cube_seed: pl.Tile[[128, 128], pl.FP32, pl.Mem.Mat],
+            data: pl.Tensor[[16, 1], pl.FP32],
+            out_0: pl.Out[pl.Tensor[[16, 1], pl.FP32]],
+        ) -> pl.Tensor[[16, 1], pl.FP32]:
+            seed_vec = pl.tile.move(cube_seed, target_memory=pl.Mem.Vec)  # noqa: F841
+            col = pl.tile.load(data, [0, 0], [16, 1], target_memory=pl.Mem.Vec)
+            row = pl.tile.reshape(col, [1, 16])
+            gathered = pl.tile.move(row, target_memory=pl.Mem.Mat)  # noqa: F841 - V->C boundary
+            out_store = pl.tile.store(col, [0, 0], out_0)
+            return out_store
+
+    @pl.program
+    class Expected:
+        @pl.function(
+            type=pl.FunctionType.InCore,
+            attrs={"split": pl.SplitMode.UP_DOWN, "split_aiv": True},
+        )
+        def split_auto(
+            cube_seed: pl.Tile[[128, 128], pl.FP32, pl.Mem.Mat],
+            data: pl.Tensor[[16, 1], pl.FP32],
+            out_0: pl.Out[pl.Tensor[[16, 1], pl.FP32]],
+        ) -> pl.Tensor[[16, 1], pl.FP32]:
+            subblock_idx = pl.tile.get_subblock_idx()
+            seed_vec = pl.tile.aiv_shard(cube_seed, split=1)  # noqa: F841
+            col = pl.tile.load(data, [0 + subblock_idx * 8, 0], [8, 1], target_memory=pl.Mem.Vec)
+            row = pl.tile.reshape(col, [1, 8])
+            gathered_mat = pl.tile.aic_gather(row, split=2)
+            gathered = pl.tile.move(gathered_mat, target_memory=pl.Mem.Mat)  # noqa: F841
+            out_store = pl.tile.store(col, [0 + subblock_idx * 8, 0], out_0)
+            return out_store
+
+    ir.assert_structural_equal(_lower(Before), Expected)
+
+
+def test_pure_vector_split_is_left_untouched():
+    """A PURE-vector ``pl.split`` function (no cube boundary) is NOT lowered.
+
+    Regression for the CI failure where LowerAutoVectorSplit stamped ``split_aiv``
+    on a pure-vector function (an elementwise op split across the AIV lanes);
+    ExpandMixedKernel then stripped the ``split`` attr in its non-mixed AIV-convert
+    path and the kernel lost its split entirely. There is no cube<->vector boundary
+    to converge here, so the pass must leave the function exactly as-is.
+    """
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore, attrs={"split": pl.SplitMode.UP_DOWN})
+        def pure_vec(
+            data: pl.Tensor[[128, 128], pl.FP32],
+            out_0: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
+        ) -> pl.Tensor[[128, 128], pl.FP32]:
+            t = pl.tile.load(data, [0, 0], [128, 128], target_memory=pl.Mem.Vec)
+            out_store = pl.tile.store(t, [0, 0], out_0)
+            return out_store
+
+    @pl.program
+    class Expected:
+        @pl.function(type=pl.FunctionType.InCore, attrs={"split": pl.SplitMode.UP_DOWN})
+        def pure_vec(
+            data: pl.Tensor[[128, 128], pl.FP32],
+            out_0: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
+        ) -> pl.Tensor[[128, 128], pl.FP32]:
+            t = pl.tile.load(data, [0, 0], [128, 128], target_memory=pl.Mem.Vec)
+            out_store = pl.tile.store(t, [0, 0], out_0)
+            return out_store
+
+    ir.assert_structural_equal(_lower(Before), Expected)
+
+
+# ---------------------------------------------------------------------------
+# Hand-built IR helpers for the explicit SplitAivScopeStmt region path below.
 # ---------------------------------------------------------------------------
 
 
@@ -144,1040 +1193,7 @@ def _shard_vec(tile, split, half_shape, span):
     type — so the pass itself attaches nothing. This helper still has to state Vec
     explicitly only because it builds the ``ir.Call`` directly, bypassing Create.
     """
-    return ir.Call(
-        ir.get_op("tile.aiv_shard"), [tile], {"split": split}, _tile(half_shape, None, MS.Vec), span
-    )
-
-
-def _gather_mat(tile, split, full_shape, span):
-    """A V->C boundary ``tile.aic_gather`` returning a doubled *Mat* tile.
-
-    The boundary op's declared memory is the CONSUMING lane's space: aic_gather
-    carries a vector-produced half to AIC, where ExpandMixedKernel pops it into
-    Mat. (The mirror op, aiv_shard, declares Vec for the same reason.)
-    """
-    return ir.Call(
-        ir.get_op("tile.aic_gather"), [tile], {"split": split}, _tile(full_shape, None, MS.Mat), span
-    )
-
-
-def _move_call(src, target_mem, result_type, span):
-    """``tile.move(src, target_memory=...)`` with an explicit result type.
-
-    The pass keeps the original cube-placement move's full ``[128, 128]`` Mat
-    result type while rebinding its input to the (doubled) gather result.
-    """
-    return ir.Call(ir.get_op("tile.move"), [src], {"target_memory": target_mem}, result_type, span)
-
-
-def _half_add_type(half_shape, span):
-    """The halved elementwise-add result type, carrying the Vec col-major
-    ``tile_view`` the pass preserves.
-
-    Derived by moving a half-shaped cube tile to Vec and adding — mirroring how
-    the original add result type was built, but at the halved extent so the
-    view's ``valid_shape`` halves in lockstep.
-    """
-    qkh = ir.Var("qkh", _tile(half_shape, mem=MS.Mat), span)
-    mvh = T.move(qkh, MS.Vec, span=span)
-    assert isinstance(mvh.type, ir.TileType)
-    pvh = ir.Var("pvh", _tile(mvh.type.shape, mvh.type.tile_view, MS.Vec), span)
-    return T.add(pvh, pvh, span).type
-
-
-def _expected_incore(params, lowered_stmts, return_types, *, mode, sub, name="split_auto"):
-    """Lowered counterpart of ``_incore_program``.
-
-    The injected cube-seed C->V boundary becomes
-    ``subblock_idx = tile.get_subblock_idx()`` + ``aiv_shard(cube_seed)``,
-    followed by the (already-halved) vector ``lowered_stmts`` the caller builds
-    using ``sub``. Stamps ``split`` + ``split_aiv``.
-    """
-    span = ir.Span.unknown()
-    cube_seed = ir.Var("cube_seed", _tile([128, 128], mem=MS.Mat), span)
-    half = [64, 128] if mode.value == 1 else [128, 64]
-    seed_shard = _shard_vec(cube_seed, mode.value, half, span)
-    assert isinstance(seed_shard.type, ir.Type)
-    seed_vec = ir.Var("seed_vec", seed_shard.type, span)
-    body = ir.SeqStmts(
-        [_get_subblock(sub, span), ir.AssignStmt(seed_vec, seed_shard, span), *lowered_stmts],
-        span,
-    )
-    func = ir.Function(
-        name,
-        [(cube_seed, _IN), *params],
-        return_types,
-        body,
-        span,
-        ir.FunctionType.InCore,
-        attrs={"split": mode, "split_aiv": True},
-    )
-    return ir.Program([func], name, span)
-
-
-def _build_c2v_mixed_program():
-    """Mixed InCore UP_DOWN: cube tile (Mat) --move(C->V)--> Vec, vector add, store.
-
-    The ``move(qk Mat -> Vec)`` is a CUBE_TO_VECTOR boundary; the vector add and
-    store form the vector sub-region that must be halved on dim0.
-    """
-    span = ir.Span.unknown()
-    qk = ir.Var("qk", _tile([128, 128], mem=MS.Mat), span)
-    out_0 = ir.Var("out_0", ir.TensorType([128, 128], FP32), span)
-
-    move = T.move(qk, MS.Vec, span=span)
-    assert isinstance(move.type, ir.TileType)
-    popped = ir.Var("popped", _tile(move.type.shape, move.type.tile_view, MS.Vec), span)
-    add = T.add(popped, popped, span)
-    assert isinstance(add.type, ir.TileType)
-    y = ir.Var("y", _tile(add.type.shape, add.type.tile_view, MS.Vec), span)
-    store = T.store(y, [0, 0], out_0, span=span)
-    out_store = ir.Var("out_store", store.type, span)
-
-    body = ir.SeqStmts(
-        [
-            ir.AssignStmt(popped, move, span),
-            ir.AssignStmt(y, add, span),
-            ir.AssignStmt(out_store, store, span),
-            ir.ReturnStmt([out_store], span),
-        ],
-        span,
-    )
-    func = ir.Function(
-        "split_auto",
-        [(qk, _IN), (out_0, _OUT)],
-        [out_0.type],
-        body,
-        span,
-        ir.FunctionType.InCore,
-        attrs={"split": ir.SplitMode.UP_DOWN},
-    )
-    return ir.Program([func], "test_c2v_mixed", span)
-
-
-def _expected_c2v_mixed_program():
-    """Lowered form of ``_build_c2v_mixed_program``: the C->V ``tile.move`` becomes
-    ``tile.aiv_shard(split=1)`` (HALF Vec), the vector add result halves to
-    ``[64, 128]`` (keeping its col-major view), the store offset is localized per
-    subblock, ``subblock_idx`` is injected, and ``split_aiv`` is stamped.
-    """
-    span = ir.Span.unknown()
-    qk = ir.Var("qk", _tile([128, 128], mem=MS.Mat), span)
-    out_0 = ir.Var("out_0", _tensor([128, 128]), span)
-    sub = _sub_var()
-    shard = _shard_vec(qk, 1, [64, 128], span)
-    popped = ir.Var("popped", shard.type, span)
-    y_type = _half_add_type([64, 128], span)
-    add = ir.Call(ir.get_op("tile.add"), [popped, popped], y_type, span)
-    y = ir.Var("y", y_type, span)
-    store = T.store(y, [0 + sub * 64, 0], out_0, span=span)
-    out_store = ir.Var("out_store", store.type, span)
-    body = ir.SeqStmts(
-        [
-            _get_subblock(sub, span),
-            ir.AssignStmt(popped, shard, span),
-            ir.AssignStmt(y, add, span),
-            ir.AssignStmt(out_store, store, span),
-            ir.ReturnStmt([out_store], span),
-        ],
-        span,
-    )
-    func = ir.Function(
-        "split_auto",
-        [(qk, _IN), (out_0, _OUT)],
-        [out_0.type],
-        body,
-        span,
-        ir.FunctionType.InCore,
-        attrs={"split": ir.SplitMode.UP_DOWN, "split_aiv": True},
-    )
-    return ir.Program([func], "test_c2v_mixed", span)
-
-
-def test_c2v_boundary_becomes_aiv_shard_and_vector_region_is_halved():
-    """The C->V ``tile.move`` becomes ``tile.aiv_shard(split=1)`` and the vector
-    sub-region (add + store result) is halved to ``[64, 128]`` while the cube
-    operand ``qk`` stays full; ``subblock_idx`` is injected and ``split_aiv``
-    stamped (the full lowered shape is pinned by ``Expected``)."""
-    ir.assert_structural_equal(_lower(_build_c2v_mixed_program()), _expected_c2v_mixed_program())
-
-
-def test_store_offset_is_localized_per_subblock():
-    """The vector store offset is localized: ``[0, 0] -> [0 + subblock_idx * 64, 0]``
-    (AdjustOffsets adds ``subblock_idx * half`` on the split axis, dim0)."""
-    ir.assert_structural_equal(_lower(_build_c2v_mixed_program()), _expected_c2v_mixed_program())
-
-
-# ---------------------------------------------------------------------------
-# Vector sub-region per-op halving (migrated from test_split_vector_kernel.py).
-#
-# Each builds a mixed InCore function whose vector sub-region contains the op
-# under test and asserts the new pass halves it via the shared split_axis
-# machinery — the same facts the deleted SplitVectorKernel halving driver
-# asserted, now exercised through LowerAutoVectorSplit.
-# ---------------------------------------------------------------------------
-
-
-def test_vector_load_halved_and_offset_localized():
-    """UP_DOWN: a VECTOR tile.load halves its result + shape/valid args (128 -> 64)
-    and localizes its split-dim offset per subblock."""
-    span = ir.Span.unknown()
-    data = ir.Var("data", _tensor([128, 128]), span)
-    out_0 = ir.Var("out_0", _tensor([128, 128]), span)
-    load = T.load(data, [0, 0], [128, 128], target_memory=MS.Vec, span=span)
-    prev = ir.Var("prev", load.type, span)
-    store = T.store(prev, [0, 0], out_0, span=span)
-    out_store = ir.Var("out_store", store.type, span)
-    program = _incore_program(
-        [(data, _IN), (out_0, _OUT)],
-        [
-            ir.AssignStmt(prev, load, span),
-            ir.AssignStmt(out_store, store, span),
-            ir.ReturnStmt([out_store], span),
-        ],
-        [out_0.type],
-    )
-
-    # Expected: load result + shape/valid args halve on dim0; offset localized.
-    sub = _sub_var()
-    e_data = ir.Var("data", _tensor([128, 128]), span)
-    e_out = ir.Var("out_0", _tensor([128, 128]), span)
-    e_load = T.load(e_data, [0 + sub * 64, 0], [64, 128], target_memory=MS.Vec, span=span)
-    e_prev = ir.Var("prev", e_load.type, span)
-    e_store = T.store(e_prev, [0 + sub * 64, 0], e_out, span=span)
-    e_out_store = ir.Var("out_store", e_store.type, span)
-    expected = _expected_incore(
-        [(e_data, _IN), (e_out, _OUT)],
-        [
-            ir.AssignStmt(e_prev, e_load, span),
-            ir.AssignStmt(e_out_store, e_store, span),
-            ir.ReturnStmt([e_out_store], span),
-        ],
-        [e_out.type],
-        mode=ir.SplitMode.UP_DOWN,
-        sub=sub,
-    )
-    ir.assert_structural_equal(_lower(program), expected)
-
-
-def test_vector_load_halved_left_right():
-    """LEFT_RIGHT: the load halves on dim1 (128 -> 64) and localizes the col offset."""
-    span = ir.Span.unknown()
-    data = ir.Var("data", _tensor([128, 128]), span)
-    out_0 = ir.Var("out_0", _tensor([128, 128]), span)
-    load = T.load(data, [0, 0], [128, 128], target_memory=MS.Vec, span=span)
-    prev = ir.Var("prev", load.type, span)
-    store = T.store(prev, [0, 0], out_0, span=span)
-    out_store = ir.Var("out_store", store.type, span)
-    program = _incore_program(
-        [(data, _IN), (out_0, _OUT)],
-        [
-            ir.AssignStmt(prev, load, span),
-            ir.AssignStmt(out_store, store, span),
-            ir.ReturnStmt([out_store], span),
-        ],
-        [out_0.type],
-        mode=ir.SplitMode.LEFT_RIGHT,
-    )
-
-    sub = _sub_var()
-    e_data = ir.Var("data", _tensor([128, 128]), span)
-    e_out = ir.Var("out_0", _tensor([128, 128]), span)
-    e_load = T.load(e_data, [0, 0 + sub * 64], [128, 64], target_memory=MS.Vec, span=span)
-    e_prev = ir.Var("prev", e_load.type, span)
-    e_store = T.store(e_prev, [0, 0 + sub * 64], e_out, span=span)
-    e_out_store = ir.Var("out_store", e_store.type, span)
-    expected = _expected_incore(
-        [(e_data, _IN), (e_out, _OUT)],
-        [
-            ir.AssignStmt(e_prev, e_load, span),
-            ir.AssignStmt(e_out_store, e_store, span),
-            ir.ReturnStmt([e_out_store], span),
-        ],
-        [e_out.type],
-        mode=ir.SplitMode.LEFT_RIGHT,
-        sub=sub,
-    )
-    ir.assert_structural_equal(_lower(program), expected)
-
-
-def test_vector_slice_halves_shape_and_localizes_offset():
-    """UP_DOWN: a tile.slice of a full (unsplit) Vec source halves its static shape
-    tuple in lockstep with the result (the qk_pv strided sub-slice fix) and
-    localizes its zero-base offset per subblock."""
-    span = ir.Span.unknown()
-    src = ir.Var("src", _tile([128, 128], mem=MS.Vec), span)
-    out_0 = ir.Var("out_0", _tensor([128, 128]), span)
-    sl = T.slice(src, [128, 128], [0, 0], span=span)
-    sub_t = ir.Var("sub", sl.type, span)
-    store = T.store(sub_t, [0, 0], out_0, span=span)
-    out_store = ir.Var("out_store", store.type, span)
-    program = _incore_program(
-        [(src, _IN), (out_0, _OUT)],
-        [
-            ir.AssignStmt(sub_t, sl, span),
-            ir.AssignStmt(out_store, store, span),
-            ir.ReturnStmt([out_store], span),
-        ],
-        [out_0.type],
-    )
-
-    # Result type AND the static shape tuple arg both halve to [64, 128].
-    sub = _sub_var()
-    e_src = ir.Var("src", _tile([128, 128], mem=MS.Vec), span)
-    e_out = ir.Var("out_0", _tensor([128, 128]), span)
-    e_sl = T.slice(e_src, [64, 128], [0 + sub * 64, 0], span=span)
-    e_sub_t = ir.Var("sub", e_sl.type, span)
-    e_store = T.store(e_sub_t, [0 + sub * 64, 0], e_out, span=span)
-    e_out_store = ir.Var("out_store", e_store.type, span)
-    expected = _expected_incore(
-        [(e_src, _IN), (e_out, _OUT)],
-        [
-            ir.AssignStmt(e_sub_t, e_sl, span),
-            ir.AssignStmt(e_out_store, e_store, span),
-            ir.ReturnStmt([e_out_store], span),
-        ],
-        [e_out.type],
-        mode=ir.SplitMode.UP_DOWN,
-        sub=sub,
-    )
-    ir.assert_structural_equal(_lower(program), expected)
-
-
-def test_vector_slice_nonzero_base_offset_localizes_additively():
-    """UP_DOWN: a strided sub-slice at a non-zero base offset localizes additively —
-    the original offset is preserved and subblock_idx*half is added on the split
-    axis (the exact qk_pv ``oi[16:32]`` pattern)."""
-    span = ir.Span.unknown()
-    src = ir.Var("src", _tile([256, 128], mem=MS.Vec), span)
-    out_0 = ir.Var("out_0", _tensor([128, 128]), span)
-    sl = T.slice(src, [128, 128], [16, 0], span=span)
-    sub_t = ir.Var("sub", sl.type, span)
-    store = T.store(sub_t, [0, 0], out_0, span=span)
-    out_store = ir.Var("out_store", store.type, span)
-    program = _incore_program(
-        [(src, _IN), (out_0, _OUT)],
-        [
-            ir.AssignStmt(sub_t, sl, span),
-            ir.AssignStmt(out_store, store, span),
-            ir.ReturnStmt([out_store], span),
-        ],
-        [out_0.type],
-    )
-
-    # Base offset 16 preserved, subblock_idx * 64 added on the split axis.
-    sub = _sub_var()
-    e_src = ir.Var("src", _tile([256, 128], mem=MS.Vec), span)
-    e_out = ir.Var("out_0", _tensor([128, 128]), span)
-    e_sl = T.slice(e_src, [64, 128], [16 + sub * 64, 0], span=span)
-    e_sub_t = ir.Var("sub", e_sl.type, span)
-    e_store = T.store(e_sub_t, [0 + sub * 64, 0], e_out, span=span)
-    e_out_store = ir.Var("out_store", e_store.type, span)
-    expected = _expected_incore(
-        [(e_src, _IN), (e_out, _OUT)],
-        [
-            ir.AssignStmt(e_sub_t, e_sl, span),
-            ir.AssignStmt(e_out_store, e_store, span),
-            ir.ReturnStmt([e_out_store], span),
-        ],
-        [e_out.type],
-        mode=ir.SplitMode.UP_DOWN,
-        sub=sub,
-    )
-    ir.assert_structural_equal(_lower(program), expected)
-
-
-def test_slice_of_split_tracked_source_halves_shape_keeps_offset():
-    """LEFT_RIGHT: a tile.slice whose source is already split-tracked (a halved
-    load) halves its static shape tuple but leaves its offset unchanged — the
-    source is already in lane-local coordinates."""
-    span = ir.Span.unknown()
-    data = ir.Var("data", _tensor([16, 128]), span)
-    out_0 = ir.Var("out_0", _tensor([16, 128]), span)
-    load = T.load(data, [0, 0], [16, 128], target_memory=MS.Vec, span=span)
-    prev = ir.Var("prev", load.type, span)
-    sl = T.slice(prev, [16, 128], [0, 0], span=span)
-    sub_t = ir.Var("sub", sl.type, span)
-    store = T.store(sub_t, [0, 0], out_0, span=span)
-    out_store = ir.Var("out_store", store.type, span)
-    program = _incore_program(
-        [(data, _IN), (out_0, _OUT)],
-        [
-            ir.AssignStmt(prev, load, span),
-            ir.AssignStmt(sub_t, sl, span),
-            ir.AssignStmt(out_store, store, span),
-            ir.ReturnStmt([out_store], span),
-        ],
-        [out_0.type],
-        mode=ir.SplitMode.LEFT_RIGHT,
-    )
-
-    # Source load halved [16,128] -> [16,64] (tracked); the slice halves its
-    # shape tuple in lockstep but keeps the [0, 0] lane-local offset.
-    sub = _sub_var()
-    e_data = ir.Var("data", _tensor([16, 128]), span)
-    e_out = ir.Var("out_0", _tensor([16, 128]), span)
-    e_load = T.load(e_data, [0, 0 + sub * 64], [16, 64], target_memory=MS.Vec, span=span)
-    e_prev = ir.Var("prev", e_load.type, span)
-    e_sl = T.slice(e_prev, [16, 64], [0, 0], span=span)
-    e_sub_t = ir.Var("sub", e_sl.type, span)
-    e_store = T.store(e_sub_t, [0, 0 + sub * 64], e_out, span=span)
-    e_out_store = ir.Var("out_store", e_store.type, span)
-    expected = _expected_incore(
-        [(e_data, _IN), (e_out, _OUT)],
-        [
-            ir.AssignStmt(e_prev, e_load, span),
-            ir.AssignStmt(e_sub_t, e_sl, span),
-            ir.AssignStmt(e_out_store, e_store, span),
-            ir.ReturnStmt([e_out_store], span),
-        ],
-        [e_out.type],
-        mode=ir.SplitMode.LEFT_RIGHT,
-        sub=sub,
-    )
-    ir.assert_structural_equal(_lower(program), expected)
-
-
-def test_reshape_of_rank1_load_is_sliced_per_subblock():
-    """UP_DOWN: a rank-1 load reshaped to [N, 1] is emitted at full width and
-    followed by a per-subblock column slice so each lane reads its own row-half
-    (the v2-minimal slice fix; rank-1 loads carry no 2D split axis)."""
-    span = ir.Span.unknown()
-    scale = ir.Var("scale", _tensor([128]), span)
-    out_0 = ir.Var("out_0", _tensor([128, 1]), span)
-    load = T.load(scale, [0], [128], target_memory=MS.Vec, span=span)
-    scale_row = ir.Var("scale_row", load.type, span)
-    reshape = T.reshape(scale_row, [128, 1], span=span)
-    scale_2d = ir.Var("scale_2d", reshape.type, span)
-    store = T.store(scale_2d, [0, 0], out_0, span=span)
-    out_store = ir.Var("out_store", store.type, span)
-    program = _incore_program(
-        [(scale, _IN), (out_0, _OUT)],
-        [
-            ir.AssignStmt(scale_row, load, span),
-            ir.AssignStmt(scale_2d, reshape, span),
-            ir.AssignStmt(out_store, store, span),
-            ir.ReturnStmt([out_store], span),
-        ],
-        [out_0.type],
-    )
-
-    # Rank-1 load bypassed (stays [128]); reshape stays full [128, 1]; a slice to
-    # [64, 1] at the per-subblock row offset is appended; store offset localized.
-    sub = _sub_var()
-    e_scale = ir.Var("scale", _tensor([128]), span)
-    e_out = ir.Var("out_0", _tensor([128, 1]), span)
-    e_load = T.load(e_scale, [0], [128], target_memory=MS.Vec, span=span)
-    e_scale_row = ir.Var("scale_row", e_load.type, span)
-    e_reshape = T.reshape(e_scale_row, [128, 1], span=span)
-    e_scale_2d = ir.Var("scale_2d", e_reshape.type, span)
-    e_sl = T.slice(e_scale_2d, [64, 1], [sub * 64, 0], span=span)
-    e_scale_2d_1 = ir.Var("scale_2d_1", e_sl.type, span)
-    e_store = T.store(e_scale_2d_1, [0 + sub * 64, 0], e_out, span=span)
-    e_out_store = ir.Var("out_store", e_store.type, span)
-    expected = _expected_incore(
-        [(e_scale, _IN), (e_out, _OUT)],
-        [
-            ir.AssignStmt(e_scale_row, e_load, span),
-            ir.AssignStmt(e_scale_2d, e_reshape, span),
-            ir.AssignStmt(e_scale_2d_1, e_sl, span),
-            ir.AssignStmt(e_out_store, e_store, span),
-            ir.ReturnStmt([e_out_store], span),
-        ],
-        [e_out.type],
-        mode=ir.SplitMode.UP_DOWN,
-        sub=sub,
-    )
-    ir.assert_structural_equal(_lower(program), expected)
-
-
-def test_reshape_of_already_split_input_halves_shape_arg():
-    """UP_DOWN: a reshape whose input is already split halves its shape ARGUMENT
-    too ([256, 1] -> [128, 1]), not just the result type, so memory_reuse sizes
-    the output from the halved literal."""
-    span = ir.Span.unknown()
-    data = ir.Var("data", _tensor([16, 16]), span)
-    out_0 = ir.Var("out_0", _tensor([256, 1]), span)
-    load = T.load(data, [0, 0], [16, 16], target_memory=MS.Vec, span=span)
-    prev = ir.Var("prev", load.type, span)
-    reshape = T.reshape(prev, [256, 1], span=span)
-    flat = ir.Var("flat", reshape.type, span)
-    store = T.store(flat, [0, 0], out_0, span=span)
-    out_store = ir.Var("out_store", store.type, span)
-    program = _incore_program(
-        [(data, _IN), (out_0, _OUT)],
-        [
-            ir.AssignStmt(prev, load, span),
-            ir.AssignStmt(flat, reshape, span),
-            ir.AssignStmt(out_store, store, span),
-            ir.ReturnStmt([out_store], span),
-        ],
-        [out_0.type],
-    )
-
-    # Input load halved [16,16] -> [8,16]; reshape result AND shape arg halve.
-    sub = _sub_var()
-    e_data = ir.Var("data", _tensor([16, 16]), span)
-    e_out = ir.Var("out_0", _tensor([256, 1]), span)
-    e_load = T.load(e_data, [0 + sub * 8, 0], [8, 16], target_memory=MS.Vec, span=span)
-    e_prev = ir.Var("prev", e_load.type, span)
-    e_reshape = T.reshape(e_prev, [128, 1], span=span)
-    e_flat = ir.Var("flat", e_reshape.type, span)
-    e_store = T.store(e_flat, [0 + sub * 128, 0], e_out, span=span)
-    e_out_store = ir.Var("out_store", e_store.type, span)
-    expected = _expected_incore(
-        [(e_data, _IN), (e_out, _OUT)],
-        [
-            ir.AssignStmt(e_prev, e_load, span),
-            ir.AssignStmt(e_flat, e_reshape, span),
-            ir.AssignStmt(e_out_store, e_store, span),
-            ir.ReturnStmt([e_out_store], span),
-        ],
-        [e_out.type],
-        mode=ir.SplitMode.UP_DOWN,
-        sub=sub,
-    )
-    ir.assert_structural_equal(_lower(program), expected)
-
-
-def test_auto_reinterpret_view_of_split_input_scales_lane_local_shape():
-    """UP_DOWN: auto reinterpret keeps the tracked split axis and scales only the contiguous axis."""
-    span = ir.Span.unknown()
-    data = ir.Var("data", _tensor([16, 16]), span)
-    out_0 = ir.Var("out_0", ir.TensorType([16, 32], INT16), span)
-    load = T.load(data, [0, 0], [16, 16], target_memory=MS.Vec, span=span)
-    prev = ir.Var("prev", load.type, span)
-    reinterpret = T.reinterpret_view(prev, INT16, span=span)
-    bits = ir.Var("bits", reinterpret.type, span)
-    store = T.store(bits, [0, 0], out_0, span=span)
-    out_store = ir.Var("out_store", store.type, span)
-    program = _incore_program(
-        [(data, _IN), (out_0, _OUT)],
-        [
-            ir.AssignStmt(prev, load, span),
-            ir.AssignStmt(bits, reinterpret, span),
-            ir.AssignStmt(out_store, store, span),
-            ir.ReturnStmt([out_store], span),
-        ],
-        [out_0.type],
-    )
-
-    sub = _sub_var()
-    e_data = ir.Var("data", _tensor([16, 16]), span)
-    e_out = ir.Var("out_0", ir.TensorType([16, 32], INT16), span)
-    e_load = T.load(e_data, [0 + sub * 8, 0], [8, 16], target_memory=MS.Vec, span=span)
-    e_prev = ir.Var("prev", e_load.type, span)
-    e_reinterpret = T.reinterpret_view(e_prev, INT16, span=span)
-    e_bits = ir.Var("bits", e_reinterpret.type, span)
-    e_store = T.store(e_bits, [0 + sub * 8, 0], e_out, span=span)
-    e_out_store = ir.Var("out_store", e_store.type, span)
-    expected = _expected_incore(
-        [(e_data, _IN), (e_out, _OUT)],
-        [
-            ir.AssignStmt(e_prev, e_load, span),
-            ir.AssignStmt(e_bits, e_reinterpret, span),
-            ir.AssignStmt(e_out_store, e_store, span),
-            ir.ReturnStmt([e_out_store], span),
-        ],
-        [e_out.type],
-        mode=ir.SplitMode.UP_DOWN,
-        sub=sub,
-    )
-    ir.assert_structural_equal(_lower(program), expected)
-
-
-def test_auto_equivalent_explicit_reinterpret_shape_is_halved_with_split_input():
-    """UP_DOWN: an explicit spelling of the auto shape is accepted and halved with the source."""
-    span = ir.Span.unknown()
-    data = ir.Var("data", _tensor([16, 16]), span)
-    out_0 = ir.Var("out_0", ir.TensorType([16, 32], INT16), span)
-    load = T.load(data, [0, 0], [16, 16], target_memory=MS.Vec, span=span)
-    prev = ir.Var("prev", load.type, span)
-    reinterpret = T.reinterpret_view(prev, INT16, shape=[16, 32], span=span)
-    bits = ir.Var("bits", reinterpret.type, span)
-    store = T.store(bits, [0, 0], out_0, span=span)
-    out_store = ir.Var("out_store", store.type, span)
-    program = _incore_program(
-        [(data, _IN), (out_0, _OUT)],
-        [
-            ir.AssignStmt(prev, load, span),
-            ir.AssignStmt(bits, reinterpret, span),
-            ir.AssignStmt(out_store, store, span),
-            ir.ReturnStmt([out_store], span),
-        ],
-        [out_0.type],
-    )
-
-    sub = _sub_var()
-    e_data = ir.Var("data", _tensor([16, 16]), span)
-    e_out = ir.Var("out_0", ir.TensorType([16, 32], INT16), span)
-    e_load = T.load(e_data, [0 + sub * 8, 0], [8, 16], target_memory=MS.Vec, span=span)
-    e_prev = ir.Var("prev", e_load.type, span)
-    e_reinterpret = T.reinterpret_view(e_prev, INT16, shape=[8, 32], span=span)
-    e_bits = ir.Var("bits", e_reinterpret.type, span)
-    e_store = T.store(e_bits, [0 + sub * 8, 0], e_out, span=span)
-    e_out_store = ir.Var("out_store", e_store.type, span)
-    expected = _expected_incore(
-        [(e_data, _IN), (e_out, _OUT)],
-        [
-            ir.AssignStmt(e_prev, e_load, span),
-            ir.AssignStmt(e_bits, e_reinterpret, span),
-            ir.AssignStmt(e_out_store, e_store, span),
-            ir.ReturnStmt([e_out_store], span),
-        ],
-        [e_out.type],
-        mode=ir.SplitMode.UP_DOWN,
-        sub=sub,
-    )
-    ir.assert_structural_equal(_lower(program), expected)
-
-
-def test_arbitrary_explicit_reinterpret_shape_is_rejected_under_split():
-    """A byte-equivalent shape that redistributes dimensions has no safe physical split-axis mapping."""
-    span = ir.Span.unknown()
-    data = ir.Var("data", _tensor([16, 16]), span)
-    out_0 = ir.Var("out_0", ir.TensorType([8, 64], INT16), span)
-    load = T.load(data, [0, 0], [16, 16], target_memory=MS.Vec, span=span)
-    prev = ir.Var("prev", load.type, span)
-    reinterpret = T.reinterpret_view(prev, INT16, shape=[8, 64], span=span)
-    bits = ir.Var("bits", reinterpret.type, span)
-    store = T.store(bits, [0, 0], out_0, span=span)
-    out_store = ir.Var("out_store", store.type, span)
-    program = _incore_program(
-        [(data, _IN), (out_0, _OUT)],
-        [
-            ir.AssignStmt(prev, load, span),
-            ir.AssignStmt(bits, reinterpret, span),
-            ir.AssignStmt(out_store, store, span),
-            ir.ReturnStmt([out_store], span),
-        ],
-        [out_0.type],
-    )
-
-    with pytest.raises(ValueError, match="must match its auto-inferred shape"):
-        _lower(program)
-
-
-def test_reinterpret_view_of_full_source_is_sliced_per_subblock():
-    """LEFT_RIGHT: an untracked full tile param is reinterpreted, then sliced per lane."""
-    span = ir.Span.unknown()
-    data = ir.Var("data", _tile([16, 16], mem=MS.Vec), span)
-    out_0 = ir.Var("out_0", ir.TensorType([16, 32], INT16), span)
-    reinterpret = T.reinterpret_view(data, INT16, span=span)
-    bits = ir.Var("bits", reinterpret.type, span)
-    store = T.store(bits, [0, 0], out_0, span=span)
-    out_store = ir.Var("out_store", store.type, span)
-    program = _incore_program(
-        [(data, _IN), (out_0, _OUT)],
-        [
-            ir.AssignStmt(bits, reinterpret, span),
-            ir.AssignStmt(out_store, store, span),
-            ir.ReturnStmt([out_store], span),
-        ],
-        [out_0.type],
-        mode=ir.SplitMode.LEFT_RIGHT,
-    )
-
-    sub = _sub_var()
-    e_data = ir.Var("data", _tile([16, 16], mem=MS.Vec), span)
-    e_out = ir.Var("out_0", ir.TensorType([16, 32], INT16), span)
-    e_reinterpret = T.reinterpret_view(e_data, INT16, span=span)
-    e_bits_full = ir.Var("bits", e_reinterpret.type, span)
-    e_slice = T.slice(e_bits_full, [16, 16], [0, sub * 16], span=span)
-    e_bits = ir.Var("bits_1", e_slice.type, span)
-    e_store = T.store(e_bits, [0, 0 + sub * 16], e_out, span=span)
-    e_out_store = ir.Var("out_store", e_store.type, span)
-    expected = _expected_incore(
-        [(e_data, _IN), (e_out, _OUT)],
-        [
-            ir.AssignStmt(e_bits_full, e_reinterpret, span),
-            ir.AssignStmt(e_bits, e_slice, span),
-            ir.AssignStmt(e_out_store, e_store, span),
-            ir.ReturnStmt([e_out_store], span),
-        ],
-        [e_out.type],
-        mode=ir.SplitMode.LEFT_RIGHT,
-        sub=sub,
-    )
-    ir.assert_structural_equal(_lower(program), expected)
-
-
-def test_reshape_migrates_split_axis_row_to_col_and_back():
-    """UP_DOWN: a [N,1]<->[1,N] reshape migrates the split axis, not corrupts it (gh#1864).
-
-    The rms_norm column reshape moves the split data (rows) into the column dim and
-    back. Each AIV lane keeps its own half, so the reshape targets must halve the
-    MIGRATED dim ([1,8], then [8,1]) -- not stay at the stale full width ([1,16])
-    which left lane 1 reading garbage and emitting inf. No per-subblock slice is
-    needed (the partition is lane-local through the migration)."""
-    span = ir.Span.unknown()
-    data = ir.Var("data", _tensor([16, 1]), span)
-    out_0 = ir.Var("out_0", _tensor([16, 1]), span)
-    load = T.load(data, [0, 0], [16, 1], target_memory=MS.Vec, span=span)
-    col = ir.Var("col", load.type, span)
-    to_row = T.reshape(col, [1, 16], span=span)
-    row = ir.Var("row", to_row.type, span)
-    inv = T.recip(row, span=span)
-    inv_row = ir.Var("inv_row", inv.type, span)
-    to_col = T.reshape(inv_row, [16, 1], span=span)
-    back = ir.Var("back", to_col.type, span)
-    store = T.store(back, [0, 0], out_0, span=span)
-    out_store = ir.Var("out_store", store.type, span)
-    program = _incore_program(
-        [(data, _IN), (out_0, _OUT)],
-        [
-            ir.AssignStmt(col, load, span),
-            ir.AssignStmt(row, to_row, span),
-            ir.AssignStmt(inv_row, inv, span),
-            ir.AssignStmt(back, to_col, span),
-            ir.AssignStmt(out_store, store, span),
-            ir.ReturnStmt([out_store], span),
-        ],
-        [out_0.type],
-    )
-    text = ir.python_print(_lower(program))
-    assert "col: pl.Tile[[8, 1]" in text  # load halved on the row split dim
-    assert "pl.tile.reshape(col, [1, 8])" in text  # row -> col migration (was [1, 16])
-    assert "pl.tile.reshape(inv_row, [8, 1])" in text  # col -> row migration back
-    assert "pl.tile.slice" not in text  # each lane self-contained; no slice needed
-    # Store offset localized on the row dim, one half per subblock.
-    assert "subblock_idx * 8" in text
-
-
-def test_reshape_untrackable_split_axis_rejected():
-    """A reshape whose split partition can't map to a clean per-dim halving is rejected.
-
-    The dim-0 split of a [6, 4] tile partitions at flat offset 12 (rows 0-2 vs 3-5).
-    Reshaping to [3, 8] would place that boundary mid-row, so no result dim can
-    carry the halved split cleanly -- the pass rejects rather than miscompile."""
-    span = ir.Span.unknown()
-    data = ir.Var("data", _tensor([6, 4]), span)
-    out_0 = ir.Var("out_0", _tensor([3, 8]), span)
-    load = T.load(data, [0, 0], [6, 4], target_memory=MS.Vec, span=span)
-    prev = ir.Var("prev", load.type, span)
-    reshape = T.reshape(prev, [3, 8], span=span)
-    flat = ir.Var("flat", reshape.type, span)
-    store = T.store(flat, [0, 0], out_0, span=span)
-    out_store = ir.Var("out_store", store.type, span)
-    program = _incore_program(
-        [(data, _IN), (out_0, _OUT)],
-        [
-            ir.AssignStmt(prev, load, span),
-            ir.AssignStmt(flat, reshape, span),
-            ir.AssignStmt(out_store, store, span),
-            ir.ReturnStmt([out_store], span),
-        ],
-        [out_0.type],
-    )
-    with pytest.raises(ValueError, match="moves the split axis"):
-        _lower(program)
-
-
-def test_singleton_broadcast_tile_preserved():
-    """UP_DOWN: a [1, 128] broadcast tile is NOT halved on the singleton split dim."""
-    span = ir.Span.unknown()
-    src = ir.Var("src", _tile([1, 128], mem=MS.Vec), span)
-    out_0 = ir.Var("out_0", _tensor([1, 128]), span)
-    add = T.add(src, src, span)
-    av = ir.Var("av", add.type, span)
-    store = T.store(av, [0, 0], out_0, span=span)
-    out_store = ir.Var("out_store", store.type, span)
-    program = _incore_program(
-        [(src, _IN), (out_0, _OUT)],
-        [
-            ir.AssignStmt(av, add, span),
-            ir.AssignStmt(out_store, store, span),
-            ir.ReturnStmt([out_store], span),
-        ],
-        [out_0.type],
-    )
-
-    # The singleton split dim is preserved: av stays [1, 128], store offset [0, 0].
-    sub = _sub_var()
-    e_src = ir.Var("src", _tile([1, 128], mem=MS.Vec), span)
-    e_out = ir.Var("out_0", _tensor([1, 128]), span)
-    e_add = T.add(e_src, e_src, span)
-    e_av = ir.Var("av", e_add.type, span)
-    e_store = T.store(e_av, [0, 0], e_out, span=span)
-    e_out_store = ir.Var("out_store", e_store.type, span)
-    expected = _expected_incore(
-        [(e_src, _IN), (e_out, _OUT)],
-        [
-            ir.AssignStmt(e_av, e_add, span),
-            ir.AssignStmt(e_out_store, e_store, span),
-            ir.ReturnStmt([e_out_store], span),
-        ],
-        [e_out.type],
-        mode=ir.SplitMode.UP_DOWN,
-        sub=sub,
-    )
-    ir.assert_structural_equal(_lower(program), expected)
-
-
-@pytest.mark.parametrize(
-    ("op_name", "mode", "shape"),
-    [
-        pytest.param("tile.ci", ir.SplitMode.LEFT_RIGHT, [1, 64], id="ci-left-right"),
-        pytest.param("tile.random", ir.SplitMode.UP_DOWN, [128, 64], id="random-up-down"),
-        pytest.param("tile.random", ir.SplitMode.LEFT_RIGHT, [128, 64], id="random-left-right"),
-    ],
-)
-def test_position_dependent_root_generator_auto_halving_rejected(op_name, mode, shape):
-    """Root generators need lane-specific position state, not just a halved result type.
-
-    NEGATIVE test: a rejected transform produces no ``After`` IR, so
-    Before-After-Expected does not apply.
-    """
-    span = ir.Span.unknown()
-    generator = _split_root_generator(op_name, shape, span)
-    value = ir.Var("value", generator.type, span)
-    program = _incore_program(
-        [],
-        [ir.AssignStmt(value, generator, span), ir.ReturnStmt([value], span)],
-        [generator.type],
-        mode=mode,
-    )
-
-    with pytest.raises(ValueError, match="automatic split-axis halving") as exc_info:
-        _lower(program)
-    assert op_name in str(exc_info.value)
-
-
-@pytest.mark.parametrize(
-    ("op_name", "mode", "shape"),
-    [
-        pytest.param("tile.ci", ir.SplitMode.UP_DOWN, [1, 64], id="ci-up-down"),
-        pytest.param("tile.random", ir.SplitMode.UP_DOWN, [1, 64], id="random-up-down"),
-        pytest.param("tile.random", ir.SplitMode.LEFT_RIGHT, [128, 1], id="random-left-right"),
-    ],
-)
-def test_position_dependent_root_generator_singleton_split_dim_preserved(op_name, mode, shape):
-    """A singleton split dimension requires no generator-state rewrite."""
-    span = ir.Span.unknown()
-    generator = _split_root_generator(op_name, shape, span)
-    value = ir.Var("value", generator.type, span)
-    program = _incore_program(
-        [],
-        [ir.AssignStmt(value, generator, span), ir.ReturnStmt([value], span)],
-        [generator.type],
-        mode=mode,
-    )
-
-    sub = _sub_var()
-    expected_generator = _split_root_generator(op_name, shape, span)
-    expected_value = ir.Var("value", expected_generator.type, span)
-    expected = _expected_incore(
-        [],
-        [
-            ir.AssignStmt(expected_value, expected_generator, span),
-            ir.ReturnStmt([expected_value], span),
-        ],
-        [expected_generator.type],
-        mode=mode,
-        sub=sub,
-    )
-    ir.assert_structural_equal(_lower(program), expected)
-
-
-def test_loop_iter_arg_keeps_split_tracking():
-    """UP_DOWN: a loop iter_arg seeded by a halved load keeps split-aware store
-    offsets inside the loop body (tile_vars tracking flows through iter_args)."""
-    span = ir.Span.unknown()
-    data = ir.Var("data", _tensor([128, 128]), span)
-    out_0 = ir.Var("out_0", _tensor([128, 128]), span)
-    load = T.load(data, [0, 0], [128, 128], target_memory=MS.Vec, span=span)
-    accum = ir.Var("accum", load.type, span)
-
-    # for i in range(2): out_0 = store(accum, [0,0], out_0)
-    i_var = ir.Var("i", ir.ScalarType(DataType.INDEX), span)
-    out_iter = ir.IterArg("out_it", out_0.type, out_0, span)
-    body_store = T.store(accum, [0, 0], out_iter, span=span)
-    body_store_var = ir.Var("out_it_next", body_store.type, span)
-    loop_ret = ir.Var("out_loop", out_0.type, span)
-    for_body = ir.SeqStmts(
-        [ir.AssignStmt(body_store_var, body_store, span), ir.YieldStmt([body_store_var], span)],
-        span,
-    )
-    for_stmt = ir.ForStmt(
-        i_var,
-        ir.ConstInt(0, DataType.INDEX, span),
-        ir.ConstInt(2, DataType.INDEX, span),
-        ir.ConstInt(1, DataType.INDEX, span),
-        [out_iter],
-        for_body,
-        [loop_ret],
-        span,
-    )
-    program = _incore_program(
-        [(data, _IN), (out_0, _OUT)],
-        [
-            ir.AssignStmt(accum, load, span),
-            for_stmt,
-            ir.ReturnStmt([loop_ret], span),
-        ],
-        [out_0.type],
-    )
-
-    # The loaded accumulator is halved; the in-loop store offset is localized
-    # using the same tracked half extent.
-    sub = _sub_var()
-    e_data = ir.Var("data", _tensor([128, 128]), span)
-    e_out = ir.Var("out_0", _tensor([128, 128]), span)
-    e_load = T.load(e_data, [0 + sub * 64, 0], [64, 128], target_memory=MS.Vec, span=span)
-    e_accum = ir.Var("accum", e_load.type, span)
-    e_i = ir.Var("i", ir.ScalarType(DataType.INDEX), span)
-    e_out_iter = ir.IterArg("out_it", e_out.type, e_out, span)
-    e_body_store = T.store(e_accum, [0 + sub * 64, 0], e_out_iter, span=span)
-    e_body_store_var = ir.Var("out_it_next", e_body_store.type, span)
-    e_loop_ret = ir.Var("out_loop", e_out.type, span)
-    e_for_body = ir.SeqStmts(
-        [ir.AssignStmt(e_body_store_var, e_body_store, span), ir.YieldStmt([e_body_store_var], span)],
-        span,
-    )
-    e_for_stmt = ir.ForStmt(
-        e_i,
-        ir.ConstInt(0, DataType.INDEX, span),
-        ir.ConstInt(2, DataType.INDEX, span),
-        ir.ConstInt(1, DataType.INDEX, span),
-        [e_out_iter],
-        e_for_body,
-        [e_loop_ret],
-        span,
-    )
-    expected = _expected_incore(
-        [(e_data, _IN), (e_out, _OUT)],
-        [
-            ir.AssignStmt(e_accum, e_load, span),
-            e_for_stmt,
-            ir.ReturnStmt([e_loop_ret], span),
-        ],
-        [e_out.type],
-        mode=ir.SplitMode.UP_DOWN,
-        sub=sub,
-    )
-    ir.assert_structural_equal(_lower(program), expected)
-
-
-def test_reduce_on_split_axis_rejected():
-    """A reduce that collapses the split axis (dim0 under UP_DOWN) raises ValueError —
-    a partial per-lane reduction is a miscompile. NEGATIVE test: a rejected
-    transform produces no ``After`` IR, so Before-After-Expected does not apply.
-
-    ``col_sum`` is the axis-0 reduction (``pto.tcolsum``), so under UP_DOWN it
-    collapses exactly the split axis."""
-    span = ir.Span.unknown()
-    src = ir.Var("src", _tile([128, 128], mem=MS.Vec), span)
-    out_0 = ir.Var("out_0", _tensor([128, 128]), span)
-    reduced = T.col_sum(src, span=span)
-    rv = ir.Var("rv", reduced.type, span)
-    store = T.store(rv, [0, 0], out_0, span=span)
-    out_store = ir.Var("out_store", store.type, span)
-    program = _incore_program(
-        [(src, _IN), (out_0, _OUT)],
-        [
-            ir.AssignStmt(rv, reduced, span),
-            ir.AssignStmt(out_store, store, span),
-            ir.ReturnStmt([out_store], span),
-        ],
-        [out_0.type],
-    )
-    with pytest.raises(ValueError, match="reduces on the split axis"):
-        _lower(program)
-
-
-def test_vc_boundary_becomes_aic_gather_and_cube_placement_stays_full():
-    """UP_DOWN: a V->C tile.move boundary becomes tile.aic_gather, and the cube
-    placement move on the gathered tile stays FULL ([128, 128] Mat) — the cube
-    side never sees a halved tile."""
-    span = ir.Span.unknown()
-    vec = ir.Var("vec", _tile([128, 128], mem=MS.Vec), span)
-    out_0 = ir.Var("out_0", _tensor([128, 128]), span)
-    move = T.move(vec, MS.Mat, span=span)  # V->C boundary
-    gathered = ir.Var("gathered", move.type, span)
-    store = T.store(vec, [0, 0], out_0, span=span)
-    out_store = ir.Var("out_store", store.type, span)
-    program = _incore_program(
-        [(vec, _IN), (out_0, _OUT)],
-        [
-            ir.AssignStmt(gathered, move, span),
-            ir.AssignStmt(out_store, store, span),
-            ir.ReturnStmt([out_store], span),
-        ],
-        [out_0.type],
-    )
-
-    # V->C move becomes aic_gather (HALF -> FULL, doubled to [256, 128] Mat —
-    # the consuming cube lane's space); the cube placement move keeps the FULL
-    # [128, 128] Mat tile.
-    sub = _sub_var()
-    e_vec = ir.Var("vec", _tile([128, 128], mem=MS.Vec), span)
-    e_out = ir.Var("out_0", _tensor([128, 128]), span)
-    e_gather = _gather_mat(e_vec, 1, [256, 128], span)
-    e_gathered_mat = ir.Var("gathered_mat", e_gather.type, span)
-    e_move = _move_call(e_gathered_mat, MS.Mat, _tile([128, 128], None, MS.Mat), span)
-    e_gathered = ir.Var("gathered", e_move.type, span)
-    e_store = T.store(e_vec, [0, 0], e_out, span=span)
-    e_out_store = ir.Var("out_store", e_store.type, span)
-    expected = _expected_incore(
-        [(e_vec, _IN), (e_out, _OUT)],
-        [
-            ir.AssignStmt(e_gathered_mat, e_gather, span),
-            ir.AssignStmt(e_gathered, e_move, span),
-            ir.AssignStmt(e_out_store, e_store, span),
-            ir.ReturnStmt([e_out_store], span),
-        ],
-        [e_out.type],
-        mode=ir.SplitMode.UP_DOWN,
-        sub=sub,
-    )
-    ir.assert_structural_equal(_lower(program), expected)
-
-
-def _pure_vector_program():
-    """A PURE-vector ``pl.split`` function (no cube boundary): load (Vec) -> store.
-
-    Built directly (NOT via ``_incore_program``, which injects a cube boundary) so
-    the function is genuinely pure-vector — there is no cube<->vector boundary to
-    converge, so the pass must leave it exactly as-is.
-    """
-    span = ir.Span.unknown()
-    data = ir.Var("data", _tensor([128, 128]), span)
-    out_0 = ir.Var("out_0", _tensor([128, 128]), span)
-    load = T.load(data, [0, 0], [128, 128], target_memory=MS.Vec, span=span)
-    t = ir.Var("t", load.type, span)
-    store = T.store(t, [0, 0], out_0, span=span)
-    out_store = ir.Var("out_store", store.type, span)
-    func = ir.Function(
-        "pure_vec",
-        [(data, _IN), (out_0, _OUT)],
-        [out_0.type],
-        ir.SeqStmts(
-            [
-                ir.AssignStmt(t, load, span),
-                ir.AssignStmt(out_store, store, span),
-                ir.ReturnStmt([out_store], span),
-            ],
-            span,
-        ),
-        span,
-        ir.FunctionType.InCore,
-        attrs={"split": ir.SplitMode.UP_DOWN},
-    )
-    return ir.Program([func], "pure_vec", span)
-
-
-def test_pure_vector_split_is_left_untouched():
-    """A PURE-vector ``pl.split`` function (no cube boundary) is NOT lowered.
-
-    Regression for the CI failure where LowerAutoVectorSplit stamped ``split_aiv``
-    on a pure-vector function (an elementwise op split across the AIV lanes);
-    ExpandMixedKernel then stripped the ``split`` attr in its non-mixed AIV-convert
-    branch, leaving ``split_aiv`` without a split mode and tripping
-    SplitVectorKernel. Such functions have no cube<->vector boundary to converge,
-    so the pass must leave them exactly as-is (split preserved, no split_aiv, body
-    un-halved) — the Expected is the input program, unchanged.
-    """
-    ir.assert_structural_equal(_lower(_pure_vector_program()), _pure_vector_program())
+    return ir.Call(ir.get_op("tile.aiv_shard"), [tile], {"split": split}, _tile(half_shape, MS.Vec), span)
 
 
 # ---------------------------------------------------------------------------
@@ -1188,6 +1204,20 @@ def test_pure_vector_split_is_left_untouched():
 # (region-local maps so no leak to sibling regions or out-of-region full-width
 # ops), validates a per-region transpose hazard, then DROPS the scope wrapper.
 # The AUTO whole-function path above is unchanged.
+#
+# These ``Before`` programs are hand-built rather than DSL-authored (the AUTO
+# section above is DSL). The reason is specific and verified: the parser wraps a
+# ``for aiv_id in pl.split_aiv(...)`` region in a scope whenever an InCore scope
+# is open — which it always is inside a function declared
+# ``pl.FunctionType.InCore`` — and OutlineIncoreScopes only outlines scopes out
+# of Opaque / Orchestration functions, so the wrapper survives to this pass,
+# which rejects a scope-nested region by design. That holds for a region at
+# function top level AND for one nested in a loop, so there is no DSL spelling
+# that delivers a *bare* region to this pass. Routing through a plain
+# ``@pl.function`` + ``outline_incore_scopes()`` does produce one, but renames
+# the function (``main`` -> ``main_incore_0``) and rewrites its parameter list,
+# so the pass would no longer be tested in isolation — that path is covered
+# once, deliberately, by test_outlined_region_still_lowers_and_stamps.
 # ---------------------------------------------------------------------------
 
 # Attrs the region path stamps on the function (no whole-function ``split`` mode —
@@ -1761,12 +1791,34 @@ def test_mixed_explicit_implicit_region_rejected():
 
 
 def test_auto_path_unchanged():
-    """The AUTO whole-function pl.split path is untouched: it still inserts
-    aiv_shard, halves the vector region, stamps split_aiv — and crucially does NOT
-    take the explicit-region branch (no split_aiv_region_validated marker). The
-    Expected carries ``{"split", "split_aiv"}`` only, so the absent region marker
-    is load-bearing in the structural comparison."""
-    ir.assert_structural_equal(_lower(_build_c2v_mixed_program()), _expected_c2v_mixed_program())
+    """An AUTO ``pl.split`` function must NOT take the explicit-region branch.
+
+    The full AUTO lowering is pinned by the Before/Expected tests at the top of
+    this file. What is asserted here is the one fact those do not isolate: the
+    region path's ``split_aiv_region_validated`` marker is absent, so a function
+    with no ``SplitAivScopeStmt`` provably went through the whole-function arm.
+    """
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore, attrs={"split": pl.SplitMode.UP_DOWN})
+        def split_auto(
+            qk: pl.Tile[[128, 128], pl.FP32, pl.Mem.Mat],
+            out_0: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
+        ) -> pl.Tensor[[128, 128], pl.FP32]:
+            popped = pl.tile.move(qk, target_memory=pl.Mem.Vec)
+            y = pl.tile.add(popped, popped)
+            out_store = pl.tile.store(y, [0, 0], out_0)
+            return out_store
+
+    (func,) = _lower(Before).functions.values()
+    attrs = func.attrs
+    # The mode survives as its SplitMode int encoding, not the enum object.
+    assert attrs.get("split") == ir.SplitMode.UP_DOWN.value
+    assert attrs.get("split_aiv") is True
+    assert "split_aiv_region_validated" not in attrs, (
+        "AUTO whole-function path must not stamp the region-path marker"
+    )
 
 
 def test_while_inside_region_halves_vector_op():
@@ -2229,9 +2281,16 @@ def test_outlined_region_still_lowers_and_stamps():
                 c = pl.store(pl.exp(pl.load(a, [base, 0], [64, 128])), [base, 0], c)
             return c
 
+    # This is the one test that cannot use ``_lower``: it must run with the
+    # roundtrip instrument OFF. OutlineIncoreScopes emits an InCore function that
+    # reads and writes ``c`` without declaring it a parameter
+    # (``def main_incore_0(a)`` with a free ``c``), so the outlined program does
+    # not survive print->parse ("Undefined variable 'c'") — verified BEFORE this
+    # pass runs. That is an OutlineIncoreScopes defect, not one of this pass; the
+    # region lowering below is what is under test here.
     with passes.PassContext([]):
         outlined = passes.outline_incore_scopes()(Canonical)
-        after = _lower(outlined)
+        after = passes.lower_auto_vector_split()(outlined)
 
     incore = [f for f in after.functions.values() if f.func_type == ir.FunctionType.InCore]
     assert len(incore) == 1, "OutlineIncoreScopes should have produced one InCore function"


### PR DESCRIPTION
## Summary

`LowerAutoVectorSplit` rewrites a vector→cube `tile.move` into `tile.aic_gather` plus the original cube-placement move, but kept that move's original result type without ever checking the gather actually reassembled back to it. Two ways that broke:

- **Un-halved operand.** A `Vec` parameter moved straight to cube (or a tile whose split dim is a singleton the affinity gate deliberately preserves) has no half to gather. Doubling it produced a `[256, 128]` operand under a move still typed `[128, 128]`. `tile.move` is shape-preserving, so the result was IR that contradicts its own op contract and does not survive print→parse. Now rejected with an actionable `ValueError`.
- **Migrated split axis.** The gather doubled the *function* split axis, but a `tile.reshape` can migrate it — the rms_norm `[N,1]↔[1,N]` column reshape — and `TileInfo::split_dim` tracks where it landed. A `[1, 8]` lane-local operand under `UP_DOWN` gathered to `[2, 8]` where the move expected `[1, 16]`. The gather now follows the operand's tracked split dim (`dim 0 → split=1`, `dim 1 → split=2`), so this case **lowers correctly** instead of emitting a contradiction.

An internal postcondition now asserts the gather result matches the kept move type, so any residual mismatch fails loudly instead of silently.

The parser was right to reject the old output; the pass was wrong. Per first-principles, the fix is in the pass.

## Test authoring

The pass's transform-output tests move to the mandated `@pl.program` Before/Expected style. The tile-level IR this pass consumes and produces *is* expressible in the DSL: memory spaces are ordinary `pl.Mem.*` annotations, the lowered boundary has a dedicated outlined form (`pl.tile.aiv_shard(x, split=N)`) the printer emits for exactly this shape, and no memref exists this early (`init_mem_ref` runs ten passes later).

The explicit `SplitAivScopeStmt` region tests stay hand-built, for a verified reason: the parser always wraps a `pl.split_aiv` region in a scope when the enclosing function is `pl.FunctionType.InCore`, and this pass rejects a scope-nested region by design — so no DSL spelling delivers a bare region. Verified for both top-level and loop-nested regions.

`_lower` now keeps the print→parse roundtrip instrument on. That check is what surfaced the defect, and the file previously suppressed it via a blanket `PassContext([])`. One test opts out, documented against its upstream cause (`OutlineIncoreScopes` emits an InCore function that reads/rebinds a captured `pl.Out` tensor without declaring it a parameter — pre-existing, filed separately).

Test count 52 → 54: the 6 parametrized generator cases map 1:1 to named tests (a DSL `Before` can't be parametrized over shape — annotations are read from the AST), `test_store_offset_*` was strengthened from a duplicate of the C→V program to a non-zero base that actually distinguishes additive from replaced offsets, plus two new regression tests for the fixes above.

## Testing

- `tests/ut` — 7595 passed, 2 skipped
- `tests/ut/ir/transforms` — 2391 passed (post-rebase)
- `tests/st/codegen/torch/test_torch_codegen_cross_core.py` — 27 passed (numeric golden vs torch, both V→C modes)
- clang-tidy, clang-format, cpplint, ruff, pyright, markdownlint — clean
- docs EN/ZH parity, English-only, headers — clean

## Documentation

`docs/en/dev/passes/18-lower_auto_vector_split.md` and the zh-CN mirror document the half-operand precondition, the tracked-split-axis rule, and quote the diagnostic verbatim.