### PR TITLE
fix(ir): Normalize tile/tensor scalar operand dtype

### DIFF
--- a/docs/en/dev/ir/05-operators.md
+++ b/docs/en/dev/ir/05-operators.md
@@ -267,7 +267,7 @@ with ib.function("tensor_example") as f:
 | - | `tile.load` | TensorType → TileType (DDR to unified buffer) |
 | - | `tile.store` | TileType → TensorType (unified buffer to DDR) |
 | **Element-wise** | `tile.add/sub/mul/div` | Tile-Tile operations |
-| - | `tile.adds/subs/muls/divs` | Tile-Scalar operations. A constant scalar operand adopts the tile's element dtype (a bare int literal is otherwise parsed as `index`, which no `pto.t*s` op accepts); a non-constant `index` scalar (loop var, `pl.dim`) is rejected — convert it with `pl.cast`. Same rule for `tensor.*s`. |
+| - | `tile.adds/subs/muls/divs` | Tile-Scalar operations. A **constant** scalar operand adopts the tile's element dtype (a bare int literal is otherwise parsed as `index`, which no `pto.t*s` op accepts) — except a float literal on an integer tile, which keeps FP32 so promotion is preserved. An explicit `pl.const(v, dtype)` is a deliberate annotation and is left as-is, as is any non-constant expression; a non-constant `index` scalar (loop var, `pl.dim`) is rejected — convert it with `pl.cast`. Same rule for `tensor.*s`. |
 | **Unary** | `tile.sqrt` | Element-wise square root |
 | **Transform** | `tile.slice` | Extract a sub-tile with static shape, optional dynamic valid_shape, and optional `drop_dims` (numpy-style rank reduction over static unit axes; result clamped to a 2D minimum) |
 | - | `tile.extract` | Extract a sub-tile from `src` at `(index_row, index_col)` — ISA TEXTRACT Variant 1 (Mat→Left/Right, Acc→Mat) |

--- a/docs/en/dev/ir/05-operators.md
+++ b/docs/en/dev/ir/05-operators.md
@@ -267,7 +267,7 @@ with ib.function("tensor_example") as f:
 | - | `tile.load` | TensorType → TileType (DDR to unified buffer) |
 | - | `tile.store` | TileType → TensorType (unified buffer to DDR) |
 | **Element-wise** | `tile.add/sub/mul/div` | Tile-Tile operations |
-| - | `tile.adds/subs/muls/divs` | Tile-Scalar operations |
+| - | `tile.adds/subs/muls/divs` | Tile-Scalar operations. A constant scalar operand adopts the tile's element dtype (a bare int literal is otherwise parsed as `index`, which no `pto.t*s` op accepts); a non-constant `index` scalar (loop var, `pl.dim`) is rejected — convert it with `pl.cast`. Same rule for `tensor.*s`. |
 | **Unary** | `tile.sqrt` | Element-wise square root |
 | **Transform** | `tile.slice` | Extract a sub-tile with static shape, optional dynamic valid_shape, and optional `drop_dims` (numpy-style rank reduction over static unit axes; result clamped to a 2D minimum) |
 | - | `tile.extract` | Extract a sub-tile from `src` at `(index_row, index_col)` — ISA TEXTRACT Variant 1 (Mat→Left/Right, Acc→Mat) |

--- a/docs/zh-cn/dev/ir/05-operators.md
+++ b/docs/zh-cn/dev/ir/05-operators.md
@@ -261,7 +261,7 @@ with ib.function("tensor_example") as f:
 | - | `tile.load` | TensorType → TileType（DDR 到统一缓冲区） |
 | - | `tile.store` | TileType → TensorType（统一缓冲区到 DDR） |
 | **逐元素** | `tile.add/sub/mul/div` | Tile-Tile 操作 |
-| - | `tile.adds/subs/muls/divs` | Tile-Scalar 操作。常量标量操作数会采用 tile 的元素 dtype（裸整数字面量否则会被解析为 `index`，而任何 `pto.t*s` 算子都不接受它）；非常量的 `index` 标量（循环变量、`pl.dim`）会被拒绝——需用 `pl.cast` 转换。`tensor.*s` 同理。 |
+| - | `tile.adds/subs/muls/divs` | Tile-Scalar 操作。**常量**标量操作数会采用 tile 的元素 dtype（裸整数字面量否则会被解析为 `index`，而任何 `pto.t*s` 算子都不接受它）——但整数 tile 上的浮点字面量仍保持 FP32，以保留类型提升语义。显式的 `pl.const(v, dtype)` 属于用户的有意标注，与任何非常量表达式一样保持不变；非常量的 `index` 标量（循环变量、`pl.dim`）会被拒绝——需用 `pl.cast` 转换。`tensor.*s` 同理。 |
 | **一元** | `tile.sqrt` | 逐元素平方根 |
 | **变换** | `tile.slice` | 提取子 tile，静态 shape，可选动态 valid_shape |
 | - | `tile.extract` | 从 `src` 在 `(index_row, index_col)` 处提取子 tile —— ISA TEXTRACT Variant 1（Mat→Left/Right，Acc→Mat） |

--- a/docs/zh-cn/dev/ir/05-operators.md
+++ b/docs/zh-cn/dev/ir/05-operators.md
@@ -261,7 +261,7 @@ with ib.function("tensor_example") as f:
 | - | `tile.load` | TensorType → TileType（DDR 到统一缓冲区） |
 | - | `tile.store` | TileType → TensorType（统一缓冲区到 DDR） |
 | **逐元素** | `tile.add/sub/mul/div` | Tile-Tile 操作 |
-| - | `tile.adds/subs/muls/divs` | Tile-Scalar 操作 |
+| - | `tile.adds/subs/muls/divs` | Tile-Scalar 操作。常量标量操作数会采用 tile 的元素 dtype（裸整数字面量否则会被解析为 `index`，而任何 `pto.t*s` 算子都不接受它）；非常量的 `index` 标量（循环变量、`pl.dim`）会被拒绝——需用 `pl.cast` 转换。`tensor.*s` 同理。 |
 | **一元** | `tile.sqrt` | 逐元素平方根 |
 | **变换** | `tile.slice` | 提取子 tile，静态 shape，可选动态 valid_shape |
 | - | `tile.extract` | 从 `src` 在 `(index_row, index_col)` 处提取子 tile —— ISA TEXTRACT Variant 1（Mat→Left/Right，Acc→Mat） |

--- a/python/pypto/ir/op/tensor_ops.py
+++ b/python/pypto/ir/op/tensor_ops.py
@@ -27,7 +27,14 @@ from pypto.pypto_core.ir import (
     TensorLayout,
 )
 
-from ..utils import _get_span_or_capture, _normalize_expr, _to_int32_scalar, _to_make_tuple, resolve_cast_mode
+from ..utils import (
+    _get_span_or_capture,
+    _normalize_expr,
+    _normalize_scalar_operand,
+    _to_int32_scalar,
+    _to_make_tuple,
+    resolve_cast_mode,
+)
 from ._pad_value import normalize_pad_value
 from .tile_ops import resolve_gather_compare_cmp_mode
 
@@ -487,11 +494,7 @@ def mul(lhs: Expr, rhs: int | float | Expr, span: Span | None = None) -> Call:
         Call expression for element-wise multiplication
     """
     actual_span = _get_span_or_capture(span)
-    rhs_expr = (
-        _normalize_expr(rhs, actual_span, int_dtype=DataType.FP32, float_dtype=DataType.FP32)
-        if not isinstance(rhs, Expr)
-        else rhs
-    )
+    rhs_expr = _normalize_scalar_operand(lhs, rhs, actual_span, fallback_int_dtype=DataType.FP32)
 
     rhs_type = rhs_expr.type
     if isinstance(rhs_type, ScalarType):
@@ -512,11 +515,7 @@ def muls(lhs: Expr, rhs: int | float | Expr, span: Span | None = None) -> Call:
         Call expression for element-wise multiplication with scalar
     """
     actual_span = _get_span_or_capture(span)
-    rhs_expr = (
-        _normalize_expr(rhs, actual_span, int_dtype=DataType.FP32, float_dtype=DataType.FP32)
-        if not isinstance(rhs, Expr)
-        else rhs
-    )
+    rhs_expr = _normalize_scalar_operand(lhs, rhs, actual_span, fallback_int_dtype=DataType.FP32)
     return _ir_core.create_op_call("tensor.muls", [lhs, rhs_expr], {}, actual_span)
 
 
@@ -535,11 +534,7 @@ def add(lhs: Expr, rhs: int | float | Expr, span: Span | None = None) -> Call:
         Call expression for element-wise addition
     """
     actual_span = _get_span_or_capture(span)
-    rhs_expr = (
-        _normalize_expr(rhs, actual_span, int_dtype=DataType.FP32, float_dtype=DataType.FP32)
-        if not isinstance(rhs, Expr)
-        else rhs
-    )
+    rhs_expr = _normalize_scalar_operand(lhs, rhs, actual_span, fallback_int_dtype=DataType.FP32)
 
     rhs_type = rhs_expr.type
     if isinstance(rhs_type, ScalarType):
@@ -560,11 +555,7 @@ def adds(lhs: Expr, rhs: int | float | Expr, span: Span | None = None) -> Call:
         Call expression for element-wise addition with scalar
     """
     actual_span = _get_span_or_capture(span)
-    rhs_expr = (
-        _normalize_expr(rhs, actual_span, int_dtype=DataType.FP32, float_dtype=DataType.FP32)
-        if not isinstance(rhs, Expr)
-        else rhs
-    )
+    rhs_expr = _normalize_scalar_operand(lhs, rhs, actual_span, fallback_int_dtype=DataType.FP32)
     return _ir_core.create_op_call("tensor.adds", [lhs, rhs_expr], {}, actual_span)
 
 
@@ -583,11 +574,7 @@ def sub(lhs: Expr, rhs: int | float | Expr, span: Span | None = None) -> Call:
         Call expression for element-wise subtraction
     """
     actual_span = _get_span_or_capture(span)
-    rhs_expr = (
-        _normalize_expr(rhs, actual_span, int_dtype=DataType.FP32, float_dtype=DataType.FP32)
-        if not isinstance(rhs, Expr)
-        else rhs
-    )
+    rhs_expr = _normalize_scalar_operand(lhs, rhs, actual_span, fallback_int_dtype=DataType.FP32)
 
     rhs_type = rhs_expr.type
     if isinstance(rhs_type, ScalarType):
@@ -608,11 +595,7 @@ def subs(lhs: Expr, rhs: int | float | Expr, span: Span | None = None) -> Call:
         Call expression for element-wise subtraction with scalar
     """
     actual_span = _get_span_or_capture(span)
-    rhs_expr = (
-        _normalize_expr(rhs, actual_span, int_dtype=DataType.FP32, float_dtype=DataType.FP32)
-        if not isinstance(rhs, Expr)
-        else rhs
-    )
+    rhs_expr = _normalize_scalar_operand(lhs, rhs, actual_span, fallback_int_dtype=DataType.FP32)
     return _ir_core.create_op_call("tensor.subs", [lhs, rhs_expr], {}, actual_span)
 
 
@@ -631,11 +614,7 @@ def div(lhs: Expr, rhs: int | float | Expr, span: Span | None = None) -> Call:
         Call expression for element-wise division
     """
     actual_span = _get_span_or_capture(span)
-    rhs_expr = (
-        _normalize_expr(rhs, actual_span, int_dtype=DataType.FP32, float_dtype=DataType.FP32)
-        if not isinstance(rhs, Expr)
-        else rhs
-    )
+    rhs_expr = _normalize_scalar_operand(lhs, rhs, actual_span, fallback_int_dtype=DataType.FP32)
 
     rhs_type = rhs_expr.type
     if isinstance(rhs_type, ScalarType):
@@ -656,11 +635,7 @@ def divs(lhs: Expr, rhs: int | float | Expr, span: Span | None = None) -> Call:
         Call expression for element-wise division with scalar
     """
     actual_span = _get_span_or_capture(span)
-    rhs_expr = (
-        _normalize_expr(rhs, actual_span, int_dtype=DataType.FP32, float_dtype=DataType.FP32)
-        if not isinstance(rhs, Expr)
-        else rhs
-    )
+    rhs_expr = _normalize_scalar_operand(lhs, rhs, actual_span, fallback_int_dtype=DataType.FP32)
     return _ir_core.create_op_call("tensor.divs", [lhs, rhs_expr], {}, actual_span)
 
 
@@ -740,11 +715,7 @@ def fmod(lhs: Expr, rhs: int | float | Expr, span: Span | None = None) -> Call:
         Call expression for element-wise floating-point remainder
     """
     actual_span = _get_span_or_capture(span)
-    rhs_expr = (
-        _normalize_expr(rhs, actual_span, int_dtype=DataType.FP32, float_dtype=DataType.FP32)
-        if not isinstance(rhs, Expr)
-        else rhs
-    )
+    rhs_expr = _normalize_scalar_operand(lhs, rhs, actual_span, fallback_int_dtype=DataType.FP32)
 
     rhs_type = rhs_expr.type
     if isinstance(rhs_type, ScalarType):
@@ -765,11 +736,7 @@ def fmods(lhs: Expr, rhs: int | float | Expr, span: Span | None = None) -> Call:
         Call expression for element-wise floating-point remainder with scalar
     """
     actual_span = _get_span_or_capture(span)
-    rhs_expr = (
-        _normalize_expr(rhs, actual_span, int_dtype=DataType.FP32, float_dtype=DataType.FP32)
-        if not isinstance(rhs, Expr)
-        else rhs
-    )
+    rhs_expr = _normalize_scalar_operand(lhs, rhs, actual_span, fallback_int_dtype=DataType.FP32)
     return _ir_core.create_op_call("tensor.fmods", [lhs, rhs_expr], {}, actual_span)
 
 
@@ -789,11 +756,7 @@ def maximum(lhs: Expr, rhs: int | float | Expr, span: Span | None = None) -> Cal
         Call expression for element-wise maximum
     """
     actual_span = _get_span_or_capture(span)
-    rhs_expr = (
-        _normalize_expr(rhs, actual_span, int_dtype=DataType.FP32, float_dtype=DataType.FP32)
-        if not isinstance(rhs, Expr)
-        else rhs
-    )
+    rhs_expr = _normalize_scalar_operand(lhs, rhs, actual_span, fallback_int_dtype=DataType.FP32)
     return _ir_core.create_op_call("tensor.maximum", [lhs, rhs_expr], {}, actual_span)
 
 
@@ -813,11 +776,7 @@ def minimum(lhs: Expr, rhs: int | float | Expr, span: Span | None = None) -> Cal
         Call expression for element-wise minimum
     """
     actual_span = _get_span_or_capture(span)
-    rhs_expr = (
-        _normalize_expr(rhs, actual_span, int_dtype=DataType.FP32, float_dtype=DataType.FP32)
-        if not isinstance(rhs, Expr)
-        else rhs
-    )
+    rhs_expr = _normalize_scalar_operand(lhs, rhs, actual_span, fallback_int_dtype=DataType.FP32)
     return _ir_core.create_op_call("tensor.minimum", [lhs, rhs_expr], {}, actual_span)
 
 
@@ -838,11 +797,7 @@ def cmp(lhs: Expr, rhs: int | float | Expr, cmp_type: int = 0, span: Span | None
         Call expression for element-wise comparison (0/1 tensor)
     """
     actual_span = _get_span_or_capture(span)
-    rhs_expr = (
-        _normalize_expr(rhs, actual_span, int_dtype=DataType.FP32, float_dtype=DataType.FP32)
-        if not isinstance(rhs, Expr)
-        else rhs
-    )
+    rhs_expr = _normalize_scalar_operand(lhs, rhs, actual_span, fallback_int_dtype=DataType.FP32)
     return _ir_core.create_op_call("tensor.cmp", [lhs, rhs_expr], {"cmp_type": cmp_type}, actual_span)
 
 
@@ -1320,11 +1275,7 @@ def expands(target: Expr, scalar: int | float | Expr, span: Span | None = None) 
         Call expression for scalar expansion
     """
     actual_span = _get_span_or_capture(span)
-    scalar_expr = (
-        _normalize_expr(scalar, actual_span, int_dtype=DataType.FP32, float_dtype=DataType.FP32)
-        if not isinstance(scalar, Expr)
-        else scalar
-    )
+    scalar_expr = _normalize_scalar_operand(target, scalar, actual_span, fallback_int_dtype=DataType.FP32)
     return _ir_core.create_op_call("tensor.expands", [target, scalar_expr], {}, actual_span)
 
 

--- a/python/pypto/ir/op/tile_ops.py
+++ b/python/pypto/ir/op/tile_ops.py
@@ -979,7 +979,9 @@ def shls(lhs: Expr, rhs: int | Expr, span: Span | None = None) -> Call:
 
     Args:
         lhs: Tile (TileType)
-        rhs: Scalar shift amount (int/Expr with INT32 ScalarType); must be >= 0
+        rhs: Scalar shift amount; must be >= 0. A constant literal is re-stamped
+            to the lhs element dtype (the IR permits any integer width -- codegen
+            casts the shift count to i32); a typed Expr is used as-is
         span: Optional source span for debugging (auto-captured if not provided)
 
     Returns:
@@ -1018,7 +1020,9 @@ def shrs(lhs: Expr, rhs: int | Expr, span: Span | None = None) -> Call:
 
     Args:
         lhs: Tile (TileType)
-        rhs: Scalar shift amount (int/Expr with INT32 ScalarType); must be >= 0
+        rhs: Scalar shift amount; must be >= 0. A constant literal is re-stamped
+            to the lhs element dtype (the IR permits any integer width -- codegen
+            casts the shift count to i32); a typed Expr is used as-is
         span: Optional source span for debugging (auto-captured if not provided)
 
     Returns:

--- a/python/pypto/ir/op/tile_ops.py
+++ b/python/pypto/ir/op/tile_ops.py
@@ -31,7 +31,15 @@ from pypto.pypto_core.ir import (
     TileLayout,
 )
 
-from ..utils import _get_span_or_capture, _normalize_expr, _to_int32_scalar, _to_make_tuple, resolve_cast_mode
+from ..utils import (
+    _get_span_or_capture,
+    _normalize_const_to_dtype,
+    _normalize_expr,
+    _normalize_scalar_operand,
+    _to_int32_scalar,
+    _to_make_tuple,
+    resolve_cast_mode,
+)
 from ._pad_value import normalize_pad_value
 
 
@@ -54,15 +62,6 @@ def _validate_offsets_shapes(offsets_tuple: _ir_core.MakeTuple, shapes_tuple: _i
         raise ValueError("offsets and shapes must have at least one dimension")
 
 
-def _normalize_tile_binary_rhs(rhs: int | float | Expr, span: Span) -> Expr:
-    """Normalize a tile binary-op rhs into an IR expression."""
-    return (
-        _normalize_expr(rhs, span, int_dtype=DataType.INT32, float_dtype=DataType.FP32)
-        if not isinstance(rhs, Expr)
-        else rhs
-    )
-
-
 def _create_tile_binary_call(
     tile_op_name: str,
     scalar_op_name: str,
@@ -71,7 +70,7 @@ def _create_tile_binary_call(
     span: Span,
 ) -> Call:
     """Create a tile binary call with scalar auto-dispatch."""
-    rhs_expr = _normalize_tile_binary_rhs(rhs, span)
+    rhs_expr = _normalize_scalar_operand(lhs, rhs, span)
     if isinstance(rhs_expr.type, ScalarType):
         return _ir_core.create_op_call(scalar_op_name, [lhs, rhs_expr], {}, span)
     return _ir_core.create_op_call(tile_op_name, [lhs, rhs_expr], {}, span)
@@ -839,11 +838,7 @@ def rems(lhs: Expr, rhs: int | float | Expr, tmp: Expr, span: Span | None = None
         Call expression for element-wise remainder with scalar
     """
     actual_span = _get_span_or_capture(span)
-    rhs_expr = (
-        _normalize_expr(rhs, actual_span, int_dtype=DataType.INT32, float_dtype=DataType.FP32)
-        if not isinstance(rhs, Expr)
-        else rhs
-    )
+    rhs_expr = _normalize_scalar_operand(lhs, rhs, actual_span)
     return _ir_core.create_op_call("tile.rems", [lhs, rhs_expr, tmp], {}, actual_span)
 
 
@@ -952,11 +947,7 @@ def fmods(lhs: Expr, rhs: int | float | Expr, span: Span | None = None) -> Call:
         Call expression for element-wise floating-point remainder with scalar
     """
     actual_span = _get_span_or_capture(span)
-    rhs_expr = (
-        _normalize_expr(rhs, actual_span, int_dtype=DataType.INT32, float_dtype=DataType.FP32)
-        if not isinstance(rhs, Expr)
-        else rhs
-    )
+    rhs_expr = _normalize_scalar_operand(lhs, rhs, actual_span)
     return _ir_core.create_op_call("tile.fmods", [lhs, rhs_expr], {}, actual_span)
 
 
@@ -995,9 +986,7 @@ def shls(lhs: Expr, rhs: int | Expr, span: Span | None = None) -> Call:
         Call expression for element-wise bitwise left shift with scalar
     """
     actual_span = _get_span_or_capture(span)
-    rhs_expr = (
-        _normalize_expr(rhs, actual_span, int_dtype=DataType.INT32) if not isinstance(rhs, Expr) else rhs
-    )
+    rhs_expr = _normalize_scalar_operand(lhs, rhs, actual_span)
     return _ir_core.create_op_call("tile.shls", [lhs, rhs_expr], {}, actual_span)
 
 
@@ -1036,9 +1025,7 @@ def shrs(lhs: Expr, rhs: int | Expr, span: Span | None = None) -> Call:
         Call expression for element-wise bitwise right shift with scalar
     """
     actual_span = _get_span_or_capture(span)
-    rhs_expr = (
-        _normalize_expr(rhs, actual_span, int_dtype=DataType.INT32) if not isinstance(rhs, Expr) else rhs
-    )
+    rhs_expr = _normalize_scalar_operand(lhs, rhs, actual_span)
     return _ir_core.create_op_call("tile.shrs", [lhs, rhs_expr], {}, actual_span)
 
 
@@ -1073,9 +1060,7 @@ def ands(lhs: Expr, rhs: int | Expr, span: Span | None = None) -> Call:
         Call expression for element-wise bitwise AND with scalar
     """
     actual_span = _get_span_or_capture(span)
-    rhs_expr = (
-        _normalize_expr(rhs, actual_span, int_dtype=DataType.INT32) if not isinstance(rhs, Expr) else rhs
-    )
+    rhs_expr = _normalize_scalar_operand(lhs, rhs, actual_span)
     return _ir_core.create_op_call("tile.ands", [lhs, rhs_expr], {}, actual_span)
 
 
@@ -1110,9 +1095,7 @@ def ors(lhs: Expr, rhs: int | Expr, span: Span | None = None) -> Call:
         Call expression for element-wise bitwise OR with scalar
     """
     actual_span = _get_span_or_capture(span)
-    rhs_expr = (
-        _normalize_expr(rhs, actual_span, int_dtype=DataType.INT32) if not isinstance(rhs, Expr) else rhs
-    )
+    rhs_expr = _normalize_scalar_operand(lhs, rhs, actual_span)
     return _ir_core.create_op_call("tile.ors", [lhs, rhs_expr], {}, actual_span)
 
 
@@ -1149,9 +1132,7 @@ def xors(lhs: Expr, rhs: int | Expr, tmp: Expr, span: Span | None = None) -> Cal
         Call expression for element-wise bitwise XOR with scalar
     """
     actual_span = _get_span_or_capture(span)
-    rhs_expr = (
-        _normalize_expr(rhs, actual_span, int_dtype=DataType.INT32) if not isinstance(rhs, Expr) else rhs
-    )
+    rhs_expr = _normalize_scalar_operand(lhs, rhs, actual_span)
     return _ir_core.create_op_call("tile.xors", [lhs, rhs_expr, tmp], {}, actual_span)
 
 
@@ -1224,11 +1205,7 @@ def addsc(lhs: Expr, rhs: int | float | Expr, rhs2: Expr, span: Span | None = No
         Call expression for element-wise tile-scalar-tile addition
     """
     actual_span = _get_span_or_capture(span)
-    rhs_expr = (
-        _normalize_expr(rhs, actual_span, int_dtype=DataType.INT32, float_dtype=DataType.FP32)
-        if not isinstance(rhs, Expr)
-        else rhs
-    )
+    rhs_expr = _normalize_scalar_operand(lhs, rhs, actual_span)
     return _ir_core.create_op_call("tile.addsc", [lhs, rhs_expr, rhs2], {}, actual_span)
 
 
@@ -1247,11 +1224,7 @@ def subsc(lhs: Expr, rhs: int | float | Expr, rhs2: Expr, span: Span | None = No
         Call expression for element-wise tile-scalar-tile subtraction
     """
     actual_span = _get_span_or_capture(span)
-    rhs_expr = (
-        _normalize_expr(rhs, actual_span, int_dtype=DataType.INT32, float_dtype=DataType.FP32)
-        if not isinstance(rhs, Expr)
-        else rhs
-    )
+    rhs_expr = _normalize_scalar_operand(lhs, rhs, actual_span)
     return _ir_core.create_op_call("tile.subsc", [lhs, rhs_expr, rhs2], {}, actual_span)
 
 
@@ -1269,11 +1242,8 @@ def lrelu(tile: Expr, slope: int | float | Expr, span: Span | None = None) -> Ca
         Call expression for element-wise leaky ReLU
     """
     actual_span = _get_span_or_capture(span)
-    slope_expr = (
-        _normalize_expr(slope, actual_span, int_dtype=DataType.FP32, float_dtype=DataType.FP32)
-        if not isinstance(slope, Expr)
-        else slope
-    )
+    # The slope is a float coefficient fixed by the op, not a tile element value.
+    slope_expr = _normalize_const_to_dtype(slope, DataType.FP32, actual_span)
     return _ir_core.create_op_call("tile.lrelu", [tile, slope_expr], {}, actual_span)
 
 
@@ -1313,11 +1283,8 @@ def sels(lhs: Expr, rhs: Expr, select_mode: int | float | Expr, span: Span | Non
         Call expression for tile select
     """
     actual_span = _get_span_or_capture(span)
-    select_mode_expr = (
-        _normalize_expr(select_mode, actual_span, int_dtype=DataType.INT32, float_dtype=DataType.FP32)
-        if not isinstance(select_mode, Expr)
-        else select_mode
-    )
+    # select_mode is a mode flag interpreted by codegen, not a tile element value.
+    select_mode_expr = _normalize_const_to_dtype(select_mode, DataType.INT32, actual_span)
     return _ir_core.create_op_call("tile.sels", [lhs, rhs, select_mode_expr], {}, actual_span)
 
 
@@ -1333,11 +1300,7 @@ def muls(lhs: Expr, rhs: int | float | Expr, span: Span | None = None) -> Call:
         Call expression for element-wise multiplication with scalar
     """
     actual_span = _get_span_or_capture(span)
-    rhs_expr = (
-        _normalize_expr(rhs, actual_span, int_dtype=DataType.INT32, float_dtype=DataType.FP32)
-        if not isinstance(rhs, Expr)
-        else rhs
-    )
+    rhs_expr = _normalize_scalar_operand(lhs, rhs, actual_span)
     return _ir_core.create_op_call("tile.muls", [lhs, rhs_expr], {}, actual_span)
 
 
@@ -1353,11 +1316,7 @@ def adds(lhs: Expr, rhs: int | float | Expr, span: Span | None = None) -> Call:
         Call expression for element-wise addition with scalar
     """
     actual_span = _get_span_or_capture(span)
-    rhs_expr = (
-        _normalize_expr(rhs, actual_span, int_dtype=DataType.INT32, float_dtype=DataType.FP32)
-        if not isinstance(rhs, Expr)
-        else rhs
-    )
+    rhs_expr = _normalize_scalar_operand(lhs, rhs, actual_span)
     return _ir_core.create_op_call("tile.adds", [lhs, rhs_expr], {}, actual_span)
 
 
@@ -1373,11 +1332,7 @@ def divs(lhs: Expr, rhs: int | float | Expr, span: Span | None = None) -> Call:
         Call expression for element-wise division with scalar
     """
     actual_span = _get_span_or_capture(span)
-    rhs_expr = (
-        _normalize_expr(rhs, actual_span, int_dtype=DataType.INT32, float_dtype=DataType.FP32)
-        if not isinstance(rhs, Expr)
-        else rhs
-    )
+    rhs_expr = _normalize_scalar_operand(lhs, rhs, actual_span)
     return _ir_core.create_op_call("tile.divs", [lhs, rhs_expr], {}, actual_span)
 
 
@@ -1393,11 +1348,7 @@ def subs(lhs: Expr, rhs: int | float | Expr, span: Span | None = None) -> Call:
         Call expression for element-wise subtraction with scalar
     """
     actual_span = _get_span_or_capture(span)
-    rhs_expr = (
-        _normalize_expr(rhs, actual_span, int_dtype=DataType.INT32, float_dtype=DataType.FP32)
-        if not isinstance(rhs, Expr)
-        else rhs
-    )
+    rhs_expr = _normalize_scalar_operand(lhs, rhs, actual_span)
     return _ir_core.create_op_call("tile.subs", [lhs, rhs_expr], {}, actual_span)
 
 
@@ -1443,11 +1394,7 @@ def cmps(
         Use tile.sel with an explicit tmp tile to materialize values.
     """
     actual_span = _get_span_or_capture(span)
-    rhs_expr = (
-        _normalize_expr(rhs, actual_span, int_dtype=DataType.INT32, float_dtype=DataType.FP32)
-        if not isinstance(rhs, Expr)
-        else rhs
-    )
+    rhs_expr = _normalize_scalar_operand(lhs, rhs, actual_span)
     kwargs: dict[str, Any] = {"cmp_type": cmp_type}
     return _ir_core.create_op_call("tile.cmps", [lhs, rhs_expr], kwargs, actual_span)
 
@@ -2098,11 +2045,7 @@ def expands(target: Expr, scalar: int | float | Expr, span: Span | None = None) 
         Call expression for scalar expansion
     """
     actual_span = _get_span_or_capture(span)
-    scalar_expr = (
-        _normalize_expr(scalar, actual_span, int_dtype=DataType.FP32, float_dtype=DataType.FP32)
-        if not isinstance(scalar, Expr)
-        else scalar
-    )
+    scalar_expr = _normalize_scalar_operand(target, scalar, actual_span, fallback_int_dtype=DataType.FP32)
     return _ir_core.create_op_call("tile.expands", [target, scalar_expr], {}, actual_span)
 
 
@@ -2154,11 +2097,7 @@ def maximums(lhs: Expr, rhs: int | float | Expr, span: Span | None = None) -> Ca
         Call expression for element-wise maximum with scalar
     """
     actual_span = _get_span_or_capture(span)
-    rhs_expr = (
-        _normalize_expr(rhs, actual_span, int_dtype=DataType.INT32, float_dtype=DataType.FP32)
-        if not isinstance(rhs, Expr)
-        else rhs
-    )
+    rhs_expr = _normalize_scalar_operand(lhs, rhs, actual_span)
     return _ir_core.create_op_call("tile.maximums", [lhs, rhs_expr], {}, actual_span)
 
 
@@ -2176,11 +2115,7 @@ def minimums(lhs: Expr, rhs: int | float | Expr, span: Span | None = None) -> Ca
         Call expression for element-wise minimum with scalar
     """
     actual_span = _get_span_or_capture(span)
-    rhs_expr = (
-        _normalize_expr(rhs, actual_span, int_dtype=DataType.INT32, float_dtype=DataType.FP32)
-        if not isinstance(rhs, Expr)
-        else rhs
-    )
+    rhs_expr = _normalize_scalar_operand(lhs, rhs, actual_span)
     return _ir_core.create_op_call("tile.minimums", [lhs, rhs_expr], {}, actual_span)
 
 

--- a/python/pypto/ir/utils.py
+++ b/python/pypto/ir/utils.py
@@ -215,10 +215,166 @@ def _to_int32_scalar(value: int | _ir.Expr, span: _ir.Span) -> _ir.Expr:
     return _ir.ConstInt(value, DataType.INT32, span)
 
 
+def _elem_dtype(operand: _ir.Expr) -> DataType | None:
+    """Element dtype of a tile/tensor operand, or None if not statically known."""
+    operand_type = operand.type
+    if isinstance(operand_type, (_ir.TileType, _ir.TensorType, _ir.DistributedTensorType)):
+        return operand_type.dtype
+    return None
+
+
+def _check_not_index_scalar(scalar: _ir.Expr, target: DataType | None) -> None:
+    """Reject a non-constant ``index`` scalar operand with an actionable hint.
+
+    ``index`` is never a legal operand type for a ``pto.t*s`` instruction. A
+    *constant* carrying it is merely the parser's placeholder and is re-typed
+    silently, but a *value* -- a loop variable, ``pl.dim(...)``, an offset -- needs
+    a real conversion whose target only the user can choose.
+
+    Raises:
+        ValueError: If ``scalar`` is an ``index``-typed scalar expression.
+    """
+    scalar_type = scalar.type
+    if not isinstance(scalar_type, _ir.ScalarType) or scalar_type.dtype != DataType.INDEX:
+        return
+
+    # Codegen lowers index<->int via arith.index_cast but rejects index<->float
+    # outright (pto_scalar_expr_codegen.cpp), so a float operand needs two steps.
+    if target is not None and target.is_float():
+        hint = f"pl.cast(pl.cast(<value>, pl.INT32), pl.{str(target).upper()})"
+        why = "; `index` cannot convert to a float dtype in one step"
+    else:
+        name = str(target).upper() if target is not None else "INT32"
+        hint = f"pl.cast(<value>, pl.{name})"
+        why = ""
+    raise ValueError(
+        f"Scalar operand has dtype `index`, which tile/tensor scalar instructions do "
+        f"not accept. Convert it explicitly: {hint}{why}."
+    )
+
+
+def _const_at_dtype(value: int | float, dtype: DataType, span: _ir.Span) -> _ir.Expr:
+    """Build a scalar constant carrying exactly ``dtype``.
+
+    The node kind follows ``dtype``, not the Python type of ``value``: codegen
+    dispatches on ConstInt vs ConstFloat, so an int paired with a float dtype
+    must become a ConstFloat or MLIR receives ``arith.constant 5 : f32``.
+    """
+    if dtype.is_float():
+        return _ir.ConstFloat(float(value), dtype, span)
+    return _ir.ConstInt(int(value), dtype, span)
+
+
+def _placeholder_value(scalar: int | float | _ir.Expr, hint_dtype: DataType | None) -> int | float | None:
+    """Numeric value of a re-typable scalar placeholder, or ``None`` to pass through.
+
+    A scalar is a re-typable placeholder when it is a raw Python literal or the
+    parser's ``ConstInt(v, INDEX)`` -- these carry no deliberate dtype, so a caller
+    may stamp one on. Any other expression already declares its dtype and is
+    signalled with ``None`` so the caller keeps it unchanged; the sole exception is
+    a non-constant ``index`` value, rejected here via ``_check_not_index_scalar``
+    (``hint_dtype`` shapes the ``pl.cast`` hint).
+
+    Returns:
+        The literal/placeholder value to re-stamp, or ``None`` for an already-typed
+        expression that must be left as-is.
+    """
+    if not isinstance(scalar, _ir.Expr):
+        return scalar  # raw Python literal
+    if isinstance(scalar, _ir.ConstInt) and scalar.dtype == DataType.INDEX:
+        return scalar.value  # parser's INDEX placeholder
+    _check_not_index_scalar(scalar, hint_dtype)
+    return None  # already-typed expr -- leave untouched
+
+
+def _normalize_scalar_operand(
+    operand: _ir.Expr,
+    scalar: int | float | _ir.Expr,
+    span: _ir.Span,
+    *,
+    fallback_int_dtype: DataType = DataType.INT32,
+    fallback_float_dtype: DataType = DataType.FP32,
+) -> _ir.Expr:
+    """Normalize an untyped scalar constant to the paired tile/tensor element dtype.
+
+    The DSL parser turns every bare int literal into ``ConstInt(v, INDEX)``
+    (``ast_parser.parse_constant``). ``index`` is not a legal operand type for any
+    ``pto.t*s`` instruction, and at the tensor level it also propagates through
+    ``PromoteDataTypes`` into the *result* tensor dtype. ``INDEX`` is therefore
+    treated as "dtype not yet decided" and re-stamped to the ``operand`` element
+    dtype, alongside raw Python literals which carry no dtype at all.
+
+    Any constant that already carries a real dtype is left untouched -- an explicit
+    ``pl.const(42, pl.INT32)`` is a deliberate user annotation, not a placeholder.
+    A float literal paired with an integer operand keeps ``fallback_float_dtype``
+    so existing promotion semantics (``int32_tensor * 2.5 -> fp32``) are preserved.
+
+    Args:
+        operand: The tile/tensor the scalar is paired with.
+        scalar: Python int/float, or an existing IR expression.
+        span: Span for any constant created here.
+        fallback_int_dtype: Int dtype used when ``operand`` is not statically typed.
+        fallback_float_dtype: Float dtype used when ``operand`` is not statically typed.
+
+    Returns:
+        An expression whose dtype matches the operand element dtype where the rule
+        above applies; otherwise ``scalar`` unchanged.
+
+    Raises:
+        ValueError: If ``scalar`` is a non-constant ``index`` value (see
+            ``_check_not_index_scalar``) -- convert it with ``pl.cast``.
+    """
+    target = _elem_dtype(operand)
+    value = _placeholder_value(scalar, target)
+    if value is None:
+        assert isinstance(scalar, _ir.Expr)  # _placeholder_value returns None only for exprs
+        return scalar  # already-typed expr, kept as-is
+
+    # Unknown operand type, or a float constant on an integer operand: fall back
+    # to the literal-kind default so promotion behaviour is unchanged.
+    if target is None or (isinstance(value, float) and target.is_int()):
+        target = fallback_float_dtype if isinstance(value, float) else fallback_int_dtype
+
+    if target.is_float() or target.is_int():
+        return _const_at_dtype(value, target, span)
+
+    # Neither int nor float (e.g. BOOL): keep prior behaviour.
+    return _normalize_expr(scalar, span, int_dtype=fallback_int_dtype, float_dtype=fallback_float_dtype)
+
+
+def _normalize_const_to_dtype(
+    scalar: int | float | _ir.Expr,
+    dtype: DataType,
+    span: _ir.Span,
+    *,
+    float_dtype: DataType = DataType.FP32,
+) -> _ir.Expr:
+    """Re-stamp an untyped scalar constant whose dtype is fixed by the operator.
+
+    For operands that do *not* follow a tile/tensor element dtype -- a mode flag
+    or float coefficient. Shares the placeholder rule via ``_placeholder_value``
+    (only the parser's ``INDEX`` constants and raw Python literals are re-typed),
+    and a float literal paired with an integer ``dtype`` keeps ``float_dtype``.
+
+    Raises:
+        ValueError: If ``scalar`` is a non-constant ``index`` value (see
+            ``_check_not_index_scalar``) -- convert it with ``pl.cast``.
+    """
+    value = _placeholder_value(scalar, dtype)
+    if value is None:
+        assert isinstance(scalar, _ir.Expr)  # _placeholder_value returns None only for exprs
+        return scalar  # already-typed expr, kept as-is
+
+    target = float_dtype if (isinstance(value, float) and dtype.is_int()) else dtype
+    return _const_at_dtype(value, target, span)
+
+
 __all__ = [
     "CAST_MODE_NAMES",
     "_get_span_or_capture",
+    "_normalize_const_to_dtype",
     "_normalize_expr",
+    "_normalize_scalar_operand",
     "_normalize_shape",
     "_to_int32_scalar",
     "_to_make_tuple",

--- a/python/pypto/ir/utils.py
+++ b/python/pypto/ir/utils.py
@@ -238,18 +238,16 @@ def _check_not_index_scalar(scalar: _ir.Expr, target: DataType | None) -> None:
     if not isinstance(scalar_type, _ir.ScalarType) or scalar_type.dtype != DataType.INDEX:
         return
 
-    # Codegen lowers index<->int via arith.index_cast but rejects index<->float
-    # outright (pto_scalar_expr_codegen.cpp), so a float operand needs two steps.
-    if target is not None and target.is_float():
-        hint = f"pl.cast(pl.cast(<value>, pl.INT32), pl.{str(target).upper()})"
-        why = "; `index` cannot convert to a float dtype in one step"
+    # Codegen lowers index->int via arith.index_cast but rejects index<->float
+    # outright (pto_scalar_expr_codegen.cpp), so a float operand routes via INT32 --
+    # an integer scalar against a float tile is accepted by the hardware ops.
+    if target is not None and target.is_int():
+        hint = f"pl.cast(<value>, pl.{str(target).upper()})"
     else:
-        name = str(target).upper() if target is not None else "INT32"
-        hint = f"pl.cast(<value>, pl.{name})"
-        why = ""
+        hint = "pl.cast(<value>, pl.INT32)"
     raise ValueError(
         f"Scalar operand has dtype `index`, which tile/tensor scalar instructions do "
-        f"not accept. Convert it explicitly: {hint}{why}."
+        f"not accept. Convert it explicitly, e.g. {hint}."
     )
 
 

--- a/tests/ut/codegen/test_pto_codegen.py
+++ b/tests/ut/codegen/test_pto_codegen.py
@@ -790,6 +790,48 @@ def test_pto_codegen_tile_adds():
     assert ": f32" in mlir_code
 
 
+def test_pto_codegen_tile_int_literal_scalar_is_not_index():
+    """A bare int literal on an INT32 tile must emit an i32 operand, never index.
+
+    Regression: the DSL parses ``5`` to ``ConstInt(5, INDEX)``; ``index`` is not
+    a legal ``pto.t*s`` operand type. IR-construction unit tests stop before
+    codegen, so this checks the emitted operand type at the codegen boundary.
+    """
+
+    @pl.program
+    class IntAddsProgram:
+        @pl.function(type=pl.FunctionType.InCore)
+        def adds_test(self, a: pl.Tensor[[32, 32], pl.INT32], b: pl.Tensor[[32, 32], pl.INT32]):
+            tile_a = pl.load(a, offsets=[0, 0], shapes=[32, 32])
+            tile_b = pl.add(tile_a, 5)
+            pl.store(tile_b, offsets=[0, 0], output_tensor=b)
+
+    lines = _get_mlir_lines(_generate_default_mlir(IntAddsProgram))
+    tadds = _single_line(lines, "pto.tadds")
+    assert "index" not in tadds, f"scalar operand is still index: {tadds}"
+    assert ", i32)" in tadds, f"scalar operand is not i32: {tadds}"
+
+
+def test_pto_codegen_tensor_int_literal_scalar_is_not_index():
+    """A tensor-level int literal must lower to an i32-operand tadds, never index.
+
+    The tensor path is stricter: an index scalar promotes the *result* tensor to
+    index. This guards the lowered ``tile.adds`` after ConvertTensorToTileOps.
+    """
+
+    @pl.program
+    class TensorIntAddsProgram:
+        @pl.function(type=pl.FunctionType.InCore)
+        def adds_test(self, a: pl.Tensor[[32, 32], pl.INT32]) -> pl.Tensor[[32, 32], pl.INT32]:
+            return pl.tensor.adds(a, 5)
+
+    lines = _get_mlir_lines(_generate_default_mlir(TensorIntAddsProgram))
+    tadds = _find_lines(lines, "pto.tadds")
+    assert tadds, "no pto.tadds emitted"
+    assert all("index" not in ln for ln in tadds), f"a scalar operand is still index: {tadds}"
+    assert any(", i32)" in ln for ln in tadds), f"no i32 scalar operand: {tadds}"
+
+
 def test_pto_codegen_constants():
     """Test that constants are generated correctly."""
 

--- a/tests/ut/ir/operators/test_tensor_ops.py
+++ b/tests/ut/ir/operators/test_tensor_ops.py
@@ -3489,6 +3489,131 @@ def test_tensor_scatter_update_invalid_dim():
         ir.op.tensor.scatter_update(input_var, 0, index_var, src_var)
 
 
+def _operand_dtype(expr: ir.Expr) -> DataType:
+    """Return a constant operand's dtype, narrowing ``Expr`` for the type checker."""
+    assert isinstance(expr, (ir.ConstInt, ir.ConstFloat)), f"expected a constant, got {type(expr).__name__}"
+    return expr.dtype
+
+
+def _tensor_result_dtype(call: ir.Call) -> DataType:
+    """Return a tensor call's result element dtype, narrowing ``Type``."""
+    result_type = call.type
+    assert isinstance(result_type, ir.TensorType)
+    return result_type.dtype
+
+
+class TestTensorScalarOperandDtype:
+    """A constant scalar operand of a tensor x scalar op adopts the tensor dtype.
+
+    The tensor path is stricter than the tile path: ``DeduceTensorOpElementwiseScalarType``
+    runs the scalar dtype through ``PromoteDataTypes``, so an ``index`` placeholder
+    does not just break codegen -- it silently retypes the *result* tensor. The
+    wrappers must re-stamp the placeholder to the tensor element dtype, reject
+    non-constant ``index`` values, and preserve genuine promotion (int tensor +
+    float literal -> float result).
+    """
+
+    _TENSOR_SCALAR_WRAPPERS = [
+        ("add", tensor.add),
+        ("sub", tensor.sub),
+        ("mul", tensor.mul),
+        ("div", tensor.div),
+        ("adds", tensor.adds),
+        ("subs", tensor.subs),
+        ("muls", tensor.muls),
+        ("divs", tensor.divs),
+        ("maximum", tensor.maximum),
+        ("minimum", tensor.minimum),
+        ("cmp", tensor.cmp),
+    ]
+
+    @staticmethod
+    def _tensor(dtype=DataType.INT32, shape=(64, 64)):
+        return ir.Var("x", ir.TensorType(list(shape), dtype), ir.Span.unknown())
+
+    def test_dsl_int_literal_adopts_tensor_dtype(self):
+        """`pl.add(x, 5)` yields a scalar operand at the tensor dtype, not index."""
+        for dtype in (DataType.INT32, DataType.INT16, DataType.FP16, DataType.FP32):
+            call = tensor.add(self._tensor(dtype), 5)
+            assert _operand_dtype(call.args[1]) == dtype
+
+    def test_result_tensor_dtype_preserved(self):
+        """The tensor-specific severity: an int literal must not retype the result.
+
+        Before the fix, `tensor.adds(x_i32, 5)` had an index scalar that promoted
+        the whole result tensor to `index`.
+        """
+        for dtype in (DataType.INT32, DataType.INT16, DataType.FP16):
+            call = tensor.adds(self._tensor(dtype), 5)
+            assert _tensor_result_dtype(call) == dtype
+
+    def test_no_index_survives_any_tensor_scalar_op(self):
+        """No wrapper leaves an index-typed constant operand."""
+        for name, fn in self._TENSOR_SCALAR_WRAPPERS:
+            call = fn(self._tensor(DataType.INT32), 5)
+            assert _operand_dtype(call.args[1]) != DataType.INDEX, f"{name} left an index operand"
+
+    def test_int_literal_on_float_tensor_is_const_float(self):
+        """An int literal on a float tensor becomes a ConstFloat at the tensor dtype."""
+        for dtype in (DataType.FP16, DataType.FP32):
+            call = tensor.adds(self._tensor(dtype), 5)
+            rhs = call.args[1]
+            assert isinstance(rhs, ir.ConstFloat)
+            assert rhs.dtype == dtype
+
+    def test_float_literal_on_int_tensor_still_promotes(self):
+        """A float literal keeps FP32 and promotion still lifts the result to float."""
+        call = tensor.muls(self._tensor(DataType.INT32), 2.5)
+        rhs = call.args[1]
+        assert isinstance(rhs, ir.ConstFloat)
+        assert rhs.dtype == DataType.FP32
+        assert _tensor_result_dtype(call) == DataType.FP32
+
+    def test_ir_level_restamps_index_const(self):
+        """A hand-built ConstInt(INDEX) operand (parser output) is re-stamped."""
+        span = ir.Span.unknown()
+        call = tensor.adds(self._tensor(DataType.INT16), ir.ConstInt(5, DataType.INDEX, span))
+        assert _operand_dtype(call.args[1]) == DataType.INT16
+        assert _tensor_result_dtype(call) == DataType.INT16
+
+    def test_explicitly_typed_const_is_not_restamped(self):
+        """An explicit pl.const(v, dtype) is a user annotation, left untouched."""
+        span = ir.Span.unknown()
+        typed = ir.ConstInt(5, DataType.INT32, span)
+        call = tensor.adds(self._tensor(DataType.INT16), typed)
+        assert _operand_dtype(call.args[1]) == DataType.INT32
+
+    def test_typed_scalar_param_passes_through(self):
+        """A typed pl.Scalar operand is not re-stamped."""
+        span = ir.Span.unknown()
+        k = ir.Var("k", ir.ScalarType(DataType.INT32), span)
+        call = tensor.adds(self._tensor(DataType.INT16), k)
+        assert call.args[1] is k
+
+    def test_tensor_rhs_untouched(self):
+        """A tensor rhs dispatches to the tensor-tensor op, operand unchanged."""
+        span = ir.Span.unknown()
+        lhs = ir.Var("a", ir.TensorType([64, 64], DataType.INT32), span)
+        rhs = ir.Var("b", ir.TensorType([64, 64], DataType.INT32), span)
+        call = tensor.add(lhs, rhs)
+        assert call.op.name == ir.get_op("tensor.add").name
+        assert call.args[1] is rhs
+
+    def test_expands_adopts_target_dtype(self):
+        """tensor.expands re-stamps its scalar to the target tensor dtype (not FP32)."""
+        call = tensor.expands(self._tensor(DataType.INT32), 5)
+        assert _operand_dtype(call.args[1]) == DataType.INT32
+
+    def test_index_scalar_value_is_rejected(self):
+        """A non-constant index scalar operand is rejected, pointing at pl.cast."""
+        span = ir.Span.unknown()
+        idx = ir.Var("i", ir.ScalarType(DataType.INDEX), span)
+        with pytest.raises((ValueError, TypeError), match="index"):
+            tensor.adds(self._tensor(DataType.INT32), idx)
+        with pytest.raises((ValueError, TypeError), match="pl.cast"):
+            tensor.adds(self._tensor(DataType.INT32), idx)
+
+
 class TestTensorFormatShapeError:
     """Regression tests for issue #824: FormatShape prints readable shapes, not pointer addresses."""
 

--- a/tests/ut/ir/operators/test_tile_ops.py
+++ b/tests/ut/ir/operators/test_tile_ops.py
@@ -3365,6 +3365,18 @@ class TestTileScalarOperandDtype:
             call = fn(self._int_tile(DataType.INT16), 255)
             assert _operand_dtype(call.args[1]) == DataType.INT16
 
+    def test_narrow_shift_literal_adopts_tile_dtype(self):
+        """Shift counts follow the tile dtype, including narrow int tiles.
+
+        `DeduceTileOpIntScalarBinaryType` permits any integer width for the
+        shift operand ("codegen casts to i32"), and an i8/i16 shift count is
+        accepted end-to-end by ptoas, so narrowing here is safe.
+        """
+        for dtype in (DataType.INT8, DataType.INT16):
+            for fn in (tile.shls, tile.shrs):
+                call = fn(self._int_tile(dtype), 3)
+                assert _operand_dtype(call.args[1]) == dtype, f"{fn.__name__} on {dtype}"
+
     def test_ir_level_restamps_index_const(self):
         """A hand-built ConstInt(INDEX) operand (parser output) is re-stamped."""
         span = ir.Span.unknown()

--- a/tests/ut/ir/operators/test_tile_ops.py
+++ b/tests/ut/ir/operators/test_tile_ops.py
@@ -17,6 +17,19 @@ from pypto import DataType, ir
 from pypto.ir.op import tile
 
 
+def _operand_dtype(expr: ir.Expr) -> DataType:
+    """Return a constant operand's dtype, narrowing ``Expr`` for the type checker."""
+    assert isinstance(expr, (ir.ConstInt, ir.ConstFloat)), f"expected a constant, got {type(expr).__name__}"
+    return expr.dtype
+
+
+def _tile_result_dtype(call: ir.Call) -> DataType:
+    """Return a tile call's result element dtype, narrowing ``Type``."""
+    result_type = call.type
+    assert isinstance(result_type, ir.TileType)
+    return result_type.dtype
+
+
 class TestTileElementwiseOps:
     """Test suite for tile-level element-wise operators (tile-tile and tile-scalar)."""
 
@@ -3264,6 +3277,155 @@ class TestTileBitwiseArithmeticOps:
 
         ir_str = str(Program)
         assert "tile.sel" in ir_str
+
+
+class TestTileScalarOperandDtype:
+    """A constant scalar operand of a tile x scalar op adopts the tile dtype.
+
+    Regression: a DSL bare int literal is parsed to ``ConstInt(v, INDEX)``, and
+    ``index`` is not a legal operand type for any ``pto.t*s`` instruction. The
+    tile scalar wrappers must re-stamp such placeholders to the tile element
+    dtype (``_normalize_scalar_operand``), reject non-constant ``index`` values,
+    and leave already-typed / non-constant operands untouched.
+    """
+
+    # Every tile x scalar wrapper that normalizes a constant operand. Each entry
+    # builds a 2-arg call ``fn(tile, 5)`` (extra positional args are appended).
+    _INT_TILE_WRAPPERS = [
+        ("adds", tile.adds, ()),
+        ("subs", tile.subs, ()),
+        ("muls", tile.muls, ()),
+        ("divs", tile.divs, ()),
+        ("maximums", tile.maximums, ()),
+        ("minimums", tile.minimums, ()),
+        ("cmps", tile.cmps, ()),
+        ("ands", tile.ands, ()),
+        ("ors", tile.ors, ()),
+        ("shls", tile.shls, ()),
+        ("shrs", tile.shrs, ()),
+    ]
+
+    @staticmethod
+    def _int_tile(dtype=DataType.INT32, shape=(32, 32)):
+        return ir.Var("t", ir.TileType(list(shape), dtype), ir.Span.unknown())
+
+    def test_dsl_int_literal_adopts_tile_dtype(self):
+        """`pl.add(tile_i32, 5)` yields an INT32 scalar operand, not index."""
+        for dtype in (DataType.INT32, DataType.INT16, DataType.INT8):
+            for fn in (tile.add, tile.sub, tile.mul):
+                call = fn(self._int_tile(dtype), 5)
+                rhs = call.args[1]
+                assert isinstance(rhs, ir.ConstInt)
+                assert rhs.dtype == dtype, f"{fn.__name__} on {dtype}: {rhs.dtype}"
+
+    def test_no_index_survives_any_tile_scalar_op(self):
+        """The direct regression: no wrapper leaves an index-typed constant."""
+        for name, fn, extra in self._INT_TILE_WRAPPERS:
+            call = fn(self._int_tile(DataType.INT32), 5, *extra)
+            dtype = _operand_dtype(call.args[1])
+            assert dtype != DataType.INDEX, f"{name} left an index operand"
+            assert dtype == DataType.INT32, f"{name}: {dtype}"
+
+    def test_int_literal_on_float_tile_becomes_const_float(self):
+        """An int literal on a float tile becomes a ConstFloat at the tile dtype.
+
+        Codegen dispatches on the node kind, so an int operand on a float tile
+        must be a ConstFloat or MLIR receives ``arith.constant 5 : f32``.
+        """
+        for dtype in (DataType.FP16, DataType.FP32, DataType.BF16):
+            call = tile.adds(ir.Var("t", ir.TileType([32, 32], dtype), ir.Span.unknown()), 5)
+            rhs = call.args[1]
+            assert isinstance(rhs, ir.ConstFloat)
+            assert rhs.dtype == dtype
+
+    def test_float_literal_on_int_tile_keeps_fp32(self):
+        """A float literal on an int tile keeps FP32 (promotion is preserved)."""
+        call = tile.adds(self._int_tile(DataType.INT32), 2.5)
+        rhs = call.args[1]
+        assert isinstance(rhs, ir.ConstFloat)
+        assert rhs.dtype == DataType.FP32
+        # The tile op still deduces its result at the tile dtype.
+        assert _tile_result_dtype(call) == DataType.INT32
+
+    def test_float_literal_on_float_tile_adopts_tile_dtype(self):
+        """A float literal on a low-precision float tile adopts the tile dtype.
+
+        `tile.adds(fp16_tile, 2.5)` -> ConstFloat(fp16) (previously fp32); the
+        scalar follows the tile element dtype rather than defaulting to FP32.
+        """
+        for dtype in (DataType.FP16, DataType.BF16):
+            call = tile.adds(ir.Var("t", ir.TileType([32, 32], dtype), ir.Span.unknown()), 2.5)
+            rhs = call.args[1]
+            assert isinstance(rhs, ir.ConstFloat)
+            assert rhs.dtype == dtype
+
+    def test_bitwise_literal_adopts_tile_dtype(self):
+        """Bitwise scalar ops re-stamp the literal to the tile dtype."""
+        for fn in (tile.ands, tile.ors):
+            call = fn(self._int_tile(DataType.INT16), 255)
+            assert _operand_dtype(call.args[1]) == DataType.INT16
+
+    def test_ir_level_restamps_index_const(self):
+        """A hand-built ConstInt(INDEX) operand (parser output) is re-stamped."""
+        span = ir.Span.unknown()
+        call = tile.adds(self._int_tile(DataType.INT16), ir.ConstInt(5, DataType.INDEX, span))
+        assert _operand_dtype(call.args[1]) == DataType.INT16
+
+    def test_explicitly_typed_const_is_not_restamped(self):
+        """An explicit pl.const(v, dtype) is a user annotation, left untouched."""
+        span = ir.Span.unknown()
+        typed = ir.ConstInt(5, DataType.INT32, span)
+        call = tile.adds(ir.Var("t", ir.TileType([32, 32], DataType.INT16), span), typed)
+        # INT32 constant preserved even though the tile is INT16.
+        assert _operand_dtype(call.args[1]) == DataType.INT32
+
+    def test_index_scalar_value_is_rejected(self):
+        """A non-constant index scalar (loop var, dim) is rejected with a hint."""
+        span = ir.Span.unknown()
+        idx = ir.Var("i", ir.ScalarType(DataType.INDEX), span)
+        with pytest.raises((ValueError, TypeError), match="index"):
+            tile.adds(self._int_tile(DataType.INT32), idx)
+
+    def test_index_scalar_reject_hint_names_cast(self):
+        """The rejection points the user at pl.cast."""
+        span = ir.Span.unknown()
+        idx = ir.Var("i", ir.ScalarType(DataType.INDEX), span)
+        with pytest.raises((ValueError, TypeError), match="pl.cast"):
+            tile.adds(self._int_tile(DataType.INT32), idx)
+
+    def test_typed_scalar_param_passes_through(self):
+        """A typed pl.Scalar operand is not re-stamped."""
+        span = ir.Span.unknown()
+        k = ir.Var("k", ir.ScalarType(DataType.INT32), span)
+        call = tile.adds(ir.Var("t", ir.TileType([32, 32], DataType.INT16), span), k)
+        assert call.args[1] is k
+
+    def test_tile_rhs_untouched(self):
+        """A tile rhs dispatches to the tile-tile op, operand unchanged."""
+        span = ir.Span.unknown()
+        lhs = ir.Var("a", ir.TileType([32, 32], DataType.INT32), span)
+        rhs = ir.Var("b", ir.TileType([32, 32], DataType.INT32), span)
+        call = tile.add(lhs, rhs)
+        assert call.op.name == ir.get_op("tile.add").name
+        assert call.args[1] is rhs
+
+    def test_expands_literal_adopts_target_dtype(self):
+        """tile.expands re-stamps its scalar to the target tile dtype (not FP32)."""
+        call = tile.expands(self._int_tile(DataType.INT32), 5)
+        assert _operand_dtype(call.args[1]) == DataType.INT32
+
+    def test_lrelu_slope_stays_fp32(self):
+        """tile.lrelu keeps its slope at FP32 and never leaves it index."""
+        call = tile.lrelu(ir.Var("t", ir.TileType([32, 32], DataType.FP32), ir.Span.unknown()), 1)
+        assert _operand_dtype(call.args[1]) == DataType.FP32
+
+    def test_sels_mode_stays_int32(self):
+        """tile.sels keeps its select-mode flag at INT32 and never index."""
+        span = ir.Span.unknown()
+        lhs = ir.Var("a", ir.TileType([32, 32], DataType.FP32), span)
+        rhs = ir.Var("b", ir.TileType([32, 32], DataType.FP32), span)
+        call = tile.sels(lhs, rhs, 1)
+        assert _operand_dtype(call.args[2]) == DataType.INT32
 
 
 class TestTileLoadOp:

--- a/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
+++ b/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
@@ -3836,7 +3836,8 @@ class TestSpmdBlockIdentityConversion:
             @pl.function(type=pl.FunctionType.InCore)
             def main_incore_0(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
                 idx: pl.Scalar[pl.INDEX] = pl.tensor.get_block_idx()
-                y: pl.Tensor[[64], pl.FP32] = pl.add(x, idx)
+                # ``idx`` is INDEX; cast before use as a tensor scalar operand.
+                y: pl.Tensor[[64], pl.FP32] = pl.add(x, pl.cast(idx, pl.INT32))
                 return y
 
             @pl.function
@@ -3854,7 +3855,7 @@ class TestSpmdBlockIdentityConversion:
             ) -> pl.Tensor[[64], pl.FP32]:
                 x__tile = pl.load(x, [0], [64], [64], target_memory=pl.Mem.Vec)
                 idx = pl.tile.get_block_idx()
-                y__tile = pl.tile.adds(x__tile, idx)
+                y__tile = pl.tile.adds(x__tile, pl.cast(idx, pl.INT32))
                 ret0__store = pl.store(y__tile, [0], ret0__out)
                 return ret0__store
 
@@ -3873,7 +3874,8 @@ class TestSpmdBlockIdentityConversion:
             @pl.function(type=pl.FunctionType.InCore)
             def main_incore_0(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
                 idx: pl.Scalar[pl.INDEX] = pl.tensor.get_subblock_idx()
-                y: pl.Tensor[[64], pl.FP32] = pl.add(x, idx)
+                # ``idx`` is INDEX; cast before use as a tensor scalar operand.
+                y: pl.Tensor[[64], pl.FP32] = pl.add(x, pl.cast(idx, pl.INT32))
                 return y
 
             @pl.function
@@ -3891,7 +3893,7 @@ class TestSpmdBlockIdentityConversion:
             ) -> pl.Tensor[[64], pl.FP32]:
                 x__tile = pl.load(x, [0], [64], [64], target_memory=pl.Mem.Vec)
                 idx = pl.tile.get_subblock_idx()
-                y__tile = pl.tile.adds(x__tile, idx)
+                y__tile = pl.tile.adds(x__tile, pl.cast(idx, pl.INT32))
                 ret0__store = pl.store(y__tile, [0], ret0__out)
                 return ret0__store
 
@@ -3910,7 +3912,8 @@ class TestSpmdBlockIdentityConversion:
             @pl.function(type=pl.FunctionType.InCore)
             def main_incore_0(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
                 n: pl.Scalar[pl.INDEX] = pl.tensor.get_block_num()
-                y: pl.Tensor[[64], pl.FP32] = pl.add(x, n)
+                # ``n`` is INDEX; cast before use as a tensor scalar operand.
+                y: pl.Tensor[[64], pl.FP32] = pl.add(x, pl.cast(n, pl.INT32))
                 return y
 
             @pl.function
@@ -3928,7 +3931,7 @@ class TestSpmdBlockIdentityConversion:
             ) -> pl.Tensor[[64], pl.FP32]:
                 x__tile = pl.load(x, [0], [64], [64], target_memory=pl.Mem.Vec)
                 n = pl.tile.get_block_num()
-                y__tile = pl.tile.adds(x__tile, n)
+                y__tile = pl.tile.adds(x__tile, pl.cast(n, pl.INT32))
                 ret0__store = pl.store(y__tile, [0], ret0__out)
                 return ret0__store
 
@@ -3952,7 +3955,8 @@ class TestSpmdBlockIdentityConversion:
                 i: pl.Scalar[pl.INDEX] = pl.get_block_idx()
                 s: pl.Scalar[pl.INDEX] = pl.get_subblock_idx()
                 n: pl.Scalar[pl.INDEX] = pl.get_block_num()
-                y: pl.Tensor[[64], pl.FP32] = pl.add(x, i + s + n)
+                # ``i + s + n`` is an INDEX scalar; cast before use as an operand.
+                y: pl.Tensor[[64], pl.FP32] = pl.add(x, pl.cast(i + s + n, pl.INT32))
                 return y
 
             @pl.function
@@ -3972,7 +3976,7 @@ class TestSpmdBlockIdentityConversion:
                 i = pl.tile.get_block_idx()
                 s = pl.tile.get_subblock_idx()
                 n = pl.tile.get_block_num()
-                y__tile = pl.tile.adds(x__tile, i + s + n)
+                y__tile = pl.tile.adds(x__tile, pl.cast(i + s + n, pl.INT32))
                 ret0__store = pl.store(y__tile, [0], ret0__out)
                 return ret0__store
 

--- a/tests/ut/ir/transforms/test_convert_to_ssa_pass.py
+++ b/tests/ut/ir/transforms/test_convert_to_ssa_pass.py
@@ -1690,7 +1690,9 @@ class TestEscapingVariables:
                 acc: pl.Tensor[[64], pl.FP32] = x
                 for i in pl.range(4):
                     k0 = i * 8
-                    chunk: pl.Tensor[[64], pl.FP32] = pl.add(x, k0)
+                    # ``k0`` is an INDEX scalar; cast it before use as a tensor
+                    # scalar operand (index is not a legal t*s operand type).
+                    chunk: pl.Tensor[[64], pl.FP32] = pl.add(x, pl.cast(k0, pl.INT32))
                     acc = pl.add(acc, chunk)
                 result: pl.Tensor[[64], pl.FP32] = pl.mul(acc, 2.0)
                 return result
@@ -1704,7 +1706,7 @@ class TestEscapingVariables:
                 acc_0 = x_0
                 for i_0, (acc_iter_1,) in pl.range(0, 4, 1, init_values=(acc_0,)):
                     k0_0 = i_0 * 8
-                    chunk_0 = pl.add(x_0, k0_0)
+                    chunk_0 = pl.add(x_0, pl.cast(k0_0, pl.INT32))
                     acc_2 = pl.add(acc_iter_1, chunk_0)
                     acc_1 = pl.yield_(acc_2)
                 result_0 = pl.mul(acc_1, 2.0)

--- a/tests/ut/ir/transforms/test_unroll_loops_pass.py
+++ b/tests/ut/ir/transforms/test_unroll_loops_pass.py
@@ -82,16 +82,18 @@ class TestBasicUnroll:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
                 for i in pl.unroll(3):
-                    x = pl.add(x, i)
+                    # ``i`` is an INDEX loop var; a tile/tensor scalar operand may
+                    # not carry ``index``, so cast it (see _normalize_scalar_operand).
+                    x = pl.add(x, pl.cast(i, pl.INT32))
                 return x
 
         @pl.program
         class Expected:
             @pl.function(strict_ssa=True)
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                x_0: pl.Tensor[[64], pl.FP32] = pl.add(x, 0)
-                x_1: pl.Tensor[[64], pl.FP32] = pl.add(x_0, 1)
-                x_2: pl.Tensor[[64], pl.FP32] = pl.add(x_1, 2)
+                x_0: pl.Tensor[[64], pl.FP32] = pl.add(x, pl.cast(pl.const(0, pl.INDEX), pl.INT32))
+                x_1: pl.Tensor[[64], pl.FP32] = pl.add(x_0, pl.cast(pl.const(1, pl.INDEX), pl.INT32))
+                x_2: pl.Tensor[[64], pl.FP32] = pl.add(x_1, pl.cast(pl.const(2, pl.INDEX), pl.INT32))
                 return x_2
 
         After = _unroll_and_ssa(Before)
@@ -134,16 +136,17 @@ class TestBasicUnroll:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
                 for i in pl.unroll(6, 0, -2):
-                    x = pl.add(x, i)
+                    # ``i`` is an INDEX loop var; cast before use as a scalar operand.
+                    x = pl.add(x, pl.cast(i, pl.INT32))
                 return x
 
         @pl.program
         class Expected:
             @pl.function(strict_ssa=True)
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                x_0: pl.Tensor[[64], pl.FP32] = pl.add(x, 6)
-                x_1: pl.Tensor[[64], pl.FP32] = pl.add(x_0, 4)
-                x_2: pl.Tensor[[64], pl.FP32] = pl.add(x_1, 2)
+                x_0: pl.Tensor[[64], pl.FP32] = pl.add(x, pl.cast(pl.const(6, pl.INDEX), pl.INT32))
+                x_1: pl.Tensor[[64], pl.FP32] = pl.add(x_0, pl.cast(pl.const(4, pl.INDEX), pl.INT32))
+                x_2: pl.Tensor[[64], pl.FP32] = pl.add(x_1, pl.cast(pl.const(2, pl.INDEX), pl.INT32))
                 return x_2
 
         After = _unroll_and_ssa(Before)

--- a/tests/ut/language/parser/test_closure_var_resolution.py
+++ b/tests/ut/language/parser/test_closure_var_resolution.py
@@ -105,7 +105,8 @@ class TestClosureVarAsPositionalArg:
 
         @pl.function
         def func(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-            result: pl.Tensor[[64], pl.FP32] = pl.mul(x, M)  # type: ignore[arg-type]
+            # ``M`` is a DynVar (INDEX); cast before use as a tensor scalar operand.
+            result: pl.Tensor[[64], pl.FP32] = pl.mul(x, pl.cast(M, pl.INT32))  # type: ignore[arg-type]
             return result
 
         assert isinstance(func, ir.Function)

--- a/tests/ut/language/parser/test_constant_folding.py
+++ b/tests/ut/language/parser/test_constant_folding.py
@@ -55,7 +55,7 @@ class TestBinopConstantFolding:
         ROPE_DIM = 8
 
         @pl.function
-        def func(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+        def func(x: pl.Tensor[[64], pl.INT32]) -> pl.Tensor[[64], pl.INT32]:
             result = pl.mul(x, ROPE_DIM // 2)
             return result
 
@@ -74,7 +74,7 @@ class TestBinopConstantFolding:
         B = 20
 
         @pl.function
-        def func(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+        def func(x: pl.Tensor[[64], pl.INT32]) -> pl.Tensor[[64], pl.INT32]:
             result = pl.mul(x, A + B)
             return result
 
@@ -93,7 +93,7 @@ class TestBinopConstantFolding:
         FACTOR = 2
 
         @pl.function
-        def func(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+        def func(x: pl.Tensor[[64], pl.INT32]) -> pl.Tensor[[64], pl.INT32]:
             result = pl.mul(x, BASE * FACTOR)
             return result
 
@@ -110,7 +110,7 @@ class TestBinopConstantFolding:
         M = 5
 
         @pl.function
-        def func(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+        def func(x: pl.Tensor[[64], pl.INT32]) -> pl.Tensor[[64], pl.INT32]:
             result = pl.mul(x, N % M)
             return result
 
@@ -128,7 +128,7 @@ class TestBinopConstantFolding:
         C = 4
 
         @pl.function
-        def func(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+        def func(x: pl.Tensor[[64], pl.INT32]) -> pl.Tensor[[64], pl.INT32]:
             result = pl.mul(x, (A + B) // C)
             return result
 
@@ -167,7 +167,7 @@ class TestUnaryopConstantFolding:
         VAL = 42
 
         @pl.function
-        def func(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+        def func(x: pl.Tensor[[64], pl.INT32]) -> pl.Tensor[[64], pl.INT32]:
             result = pl.mul(x, -VAL)
             return result
 
@@ -194,10 +194,10 @@ class TestMixedExpressionFallback:
         @pl.function
         def func(
             x: pl.Tensor[[64], pl.FP32],
-            cfg: pl.Tensor[[1], pl.INDEX],
+            cfg: pl.Tensor[[1], pl.INT32],
         ) -> pl.Tensor[[64], pl.FP32]:
-            idx: pl.Scalar[pl.INDEX] = pl.tensor.read(cfg, [0])
-            shifted: pl.Scalar[pl.INDEX] = idx + OFFSET
+            idx: pl.Scalar[pl.INT32] = pl.tensor.read(cfg, [0])
+            shifted: pl.Scalar[pl.INT32] = idx + OFFSET
             result = pl.mul(x, shifted)
             return result
 
@@ -301,7 +301,9 @@ class TestScopeShadowingSafety:
             cfg: pl.Tensor[[1], pl.INDEX],
         ) -> pl.Tensor[[64], pl.FP32]:
             N: pl.Scalar[pl.INDEX] = pl.tensor.read(cfg, [0])
-            result = pl.mul(x, N // 2)
+            # ``N // 2`` is an INDEX scalar; a tensor scalar operand may not carry
+            # `index`, so cast it explicitly (folding behaviour is unaffected).
+            result = pl.mul(x, pl.cast(N // 2, pl.INT32))
             return result
 
         assert isinstance(func, ir.Function)
@@ -310,8 +312,11 @@ class TestScopeShadowingSafety:
         mul_calls = _collect_call_args(func, "tensor.muls")
         assert len(mul_calls) == 1
         scalar_arg = mul_calls[0][1]
+        # Look through the explicit cast to the folded-or-not expression.
+        assert isinstance(scalar_arg, ir.Cast)
+        inner = scalar_arg.operand
         # Must NOT be ConstInt(4) — N is a DSL runtime variable
-        assert not isinstance(scalar_arg, ir.ConstInt) or scalar_arg.value != 4, (
+        assert not isinstance(inner, ir.ConstInt) or inner.value != 4, (
             "Folding incorrectly used closure value for DSL-scoped variable N"
         )
 
@@ -325,16 +330,20 @@ class TestScopeShadowingSafety:
             cfg: pl.Tensor[[1], pl.INDEX],
         ) -> pl.Tensor[[64], pl.FP32]:
             idx: pl.Scalar[pl.INDEX] = pl.tensor.read(cfg, [0])
-            result = pl.mul(x, idx + M)
+            # ``idx + M`` is an INDEX scalar; a tensor scalar operand may not carry
+            # `index`, so cast it explicitly (folding behaviour is unaffected).
+            result = pl.mul(x, pl.cast(idx + M, pl.INT32))
             return result
 
         assert isinstance(func, ir.Function)
         mul_calls = _collect_call_args(func, "tensor.muls")
         assert len(mul_calls) == 1
         scalar_arg = mul_calls[0][1]
-        # idx + M must remain an Add node, not a folded constant
-        assert isinstance(scalar_arg, ir.Add), (
-            f"Expected ir.Add for mixed DSL+closure expression, got {type(scalar_arg).__name__}"
+        # Look through the explicit cast: idx + M must remain an Add node,
+        # not a folded constant.
+        assert isinstance(scalar_arg, ir.Cast)
+        assert isinstance(scalar_arg.operand, ir.Add), (
+            f"Expected ir.Add for mixed DSL+closure expression, got {type(scalar_arg.operand).__name__}"
         )
 
 

--- a/tests/ut/language/parser/test_control_flow.py
+++ b/tests/ut/language/parser/test_control_flow.py
@@ -26,7 +26,8 @@ class TestForLoops:
             init: pl.Tensor[[1], pl.INT32] = pl.create_tensor([1], dtype=pl.INT32)
 
             for i, (sum_val,) in pl.range(10, init_values=(init,)):
-                new_sum: pl.Tensor[[1], pl.INT32] = pl.add(sum_val, i)
+                # ``i`` is an INDEX loop var; cast before use as a scalar operand.
+                new_sum: pl.Tensor[[1], pl.INT32] = pl.add(sum_val, pl.cast(i, pl.INT32))
                 result = pl.yield_(new_sum)
 
             return result
@@ -43,7 +44,7 @@ class TestForLoops:
             init2: pl.Tensor[[1], pl.INT32] = pl.create_tensor([1], dtype=pl.INT32)
 
             for i, (val1, val2) in pl.range(5, init_values=(init1, init2)):
-                new1: pl.Tensor[[1], pl.INT32] = pl.add(val1, i)
+                new1: pl.Tensor[[1], pl.INT32] = pl.add(val1, pl.cast(i, pl.INT32))
                 new2: pl.Tensor[[1], pl.INT32] = pl.mul(val2, 2)
                 out1, out2 = pl.yield_(new1, new2)
 
@@ -59,7 +60,7 @@ class TestForLoops:
             init: pl.Tensor[[1], pl.INT32] = pl.create_tensor([1], dtype=pl.INT32)
 
             for i, (acc,) in pl.range(0, 10, 2, init_values=(init,)):
-                new_acc: pl.Tensor[[1], pl.INT32] = pl.add(acc, i)
+                new_acc: pl.Tensor[[1], pl.INT32] = pl.add(acc, pl.cast(i, pl.INT32))
                 result = pl.yield_(new_acc)
 
             return result
@@ -250,7 +251,7 @@ class TestParallelForLoops:
             init: pl.Tensor[[1], pl.INT32] = pl.create_tensor([1], dtype=pl.INT32)
 
             for i, (sum_val,) in pl.parallel(10, init_values=(init,)):
-                new_sum: pl.Tensor[[1], pl.INT32] = pl.add(sum_val, i)
+                new_sum: pl.Tensor[[1], pl.INT32] = pl.add(sum_val, pl.cast(i, pl.INT32))
                 result = pl.yield_(new_sum)
 
             return result
@@ -279,7 +280,7 @@ class TestParallelForLoops:
             init: pl.Tensor[[1], pl.INT32] = pl.create_tensor([1], dtype=pl.INT32)
 
             for i, (acc,) in pl.parallel(0, 10, 2, init_values=(init,)):
-                new_acc: pl.Tensor[[1], pl.INT32] = pl.add(acc, i)
+                new_acc: pl.Tensor[[1], pl.INT32] = pl.add(acc, pl.cast(i, pl.INT32))
                 result = pl.yield_(new_acc)
 
             return result


### PR DESCRIPTION
## Summary

A bare int literal in the DSL is parsed to `ConstInt(v, INDEX)`, but `index` is not a legal operand type for any `pto.t*s` instruction — so **every tile/tensor × integer-literal op failed ptoas parse/verify**:

```python
pl.add(tile_i32, 5)     # -> pto.tadds ins(..., %c5_index : ..., index)
                        # error: 'pto.tadds' op operand #1 must be numeric (integer/float), but got 'index'
pl.ands(tile_i32, 255)  # error: custom op 'pto.tands' invalid kind of type specified
```

The tile wrappers already tried to fix this via `_normalize_expr(..., int_dtype=INT32)`, but that call was a no-op: `_normalize_expr` returns early when the value is already an `Expr`, which it always is coming from the parser.

On the **tensor** path it was worse — the `index` scalar propagated through `PromoteDataTypes` and silently retyped the *result* tensor to `index`, so `pl.add(x_i32, 5)` produced an `index` tensor that then failed to rebind to its `Out` param.

Float literals were unaffected (`5.0` → `ConstFloat(FP32)`), which is why this stayed hidden.

## Approach

All tile/tensor scalar wrappers now route through one shared normalizer in `python/pypto/ir/utils.py` (18 tile wrappers, 14 tensor wrappers):

- A **constant** scalar operand adopts the operand's element dtype. The node kind follows the target dtype (`ConstInt` vs `ConstFloat`) because codegen dispatches on it — an int literal on a float tile must become a `ConstFloat`, or MLIR receives `arith.constant 5 : f32`.
- A **float literal on an integer operand keeps FP32**, preserving existing promotion semantics (`int32_tensor * 2.5 -> fp32`).
- An explicit **`pl.const(v, dtype)` is left untouched** — it is a deliberate user annotation, not a placeholder. Same for typed `pl.Scalar` params and any non-constant expression.
- A **non-constant `index` value** (loop var, `pl.dim`, block idx) is **rejected** with an actionable `pl.cast` hint instead of silently miscompiling.

| expression | before | after |
| --- | --- | --- |
| `pl.add(tile_i32, 5)` | `index` → ptoas reject | `i32` ✅ |
| `pl.tensor.adds(x_i32, 5)` | result retyped to `index` | result `int32` ✅ |
| `pl.add(tile_i32, 2.5)` | `f32` | `f32` (unchanged) |
| `pl.const(42, pl.INT32)` on i16 tile | `i32` | `i32` (unchanged) |
| `pl.add(acc, i)` (`i` = loop var) | silent bad IR | `ValueError` + `pl.cast` hint |

### Behaviour changes worth noting

- `tensor.adds(x_i32, 5)` now yields an **int32** result instead of `fp32`.
- An int literal on a float tile becomes a **matching-dtype `ConstFloat`** (e.g. `fp16`) instead of `fp32`.
- Passing a raw `index` value to a scalar operand now **raises**. Tests that did this were producing uncompilable IR and now cast explicitly.

## Testing

- New `TestTileScalarOperandDtype` (15) and `TestTensorScalarOperandDtype` (11) unit tests.
- Two **codegen-boundary** tests in `test_pto_codegen.py` asserting the emitted `pto.tadds` operand is `i32`, never `index` — every IR-construction test stops before codegen, which is exactly why this class of bug shipped.
- Updated tests that fed a raw `index` value to a scalar operand (unroll / SSA / tensor→tile lowering / parser control-flow, folding, closure) to cast it explicitly.
- Full unit suite on the rebased tree: **7750 passed, 2 skipped, 0 failed**.
- `ruff`, `ruff format`, `pyright`, and all pre-commit hooks clean.
- Docs updated in both `docs/en` and `docs/zh-cn`.