### PR TITLE
fix(ir): Reject any pl.split(...) on a scope carrying pl.split_aiv regions

### DIFF
--- a/docs/en/dev/language/00-python_syntax.md
+++ b/docs/en/dev/language/00-python_syntax.md
@@ -318,6 +318,7 @@ for (x,) in pl.while_(init_values=(x_init,)):
 | `pl.cluster()` | `Cluster` | Co-scheduled AIC+AIV group |
 | `with pl.spmd(N)` / `for i in pl.spmd(N)` | `Spmd` (for-form wraps inner `InCore`) | SPMD multi-block dispatch — see [pl.spmd](#plspmd-multi-block-dispatch) |
 | `pl.spmd(N, optimizations=[pl.split(MODE)])` | `Spmd(InCore(split=MODE))` | Split hint applies to the inner InCore (both forms) |
+| `pl.spmd(N, optimizations=[pl.cross_core_slot(slot_num=N)])` | `Spmd(InCore(slot_num=N))` | Slot count applies to the inner InCore (both forms); combinable with `pl.split(MODE)` |
 | `pl.scope(mode=pl.ScopeMode.MANUAL)` / `pl.manual_scope()` | `Runtime(manual=true)` | Orchestrator MANUAL scope — user manages task ordering. Allowed in either `auto_scope` mode (it is a dependency-semantics choice). See [Manual dependency primitives](#manual-dependency-primitives) |
 | `pl.scope()` | `Runtime(manual=false)` | Orchestrator AUTO scope (`PTO2_SCOPE()`). Hand-placing one requires `@pl.function(auto_scope=False)` (in the default `auto_scope=True` the compiler owns AUTO placement). See [MaterializeRuntimeScopes](../passes/41-materialize_runtime_scopes.md) |
 

--- a/docs/en/dev/language/00-python_syntax.md
+++ b/docs/en/dev/language/00-python_syntax.md
@@ -313,6 +313,7 @@ for (x,) in pl.while_(init_values=(x_init,)):
 | ---- | ---------- | ----- |
 | `pl.at(level=pl.Level.CORE_GROUP)` | `InCore` | Fixed-boundary outline at CORE_GROUP |
 | `pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.split(MODE)])` | `InCore` | InCore + cross-core split hint |
+| `pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.cross_core_slot(slot_num=N)])` | `InCore` | InCore + cross-core pipe slot count |
 | `pl.at(level=pl.Level.HOST)` *(or any non-`CORE_GROUP` level)* | `Hierarchy` | Distributed hierarchy scope |
 | `pl.cluster()` | `Cluster` | Co-scheduled AIC+AIV group |
 | `with pl.spmd(N)` / `for i in pl.spmd(N)` | `Spmd` (for-form wraps inner `InCore`) | SPMD multi-block dispatch — see [pl.spmd](#plspmd-multi-block-dispatch) |
@@ -333,11 +334,16 @@ See [Language Guide](../../user/01-language_guide.md#incore-scopes) for examples
 
 All three `pl.spmd(...)` scope forms also accept `allow_early_resolve=True` (a boolean literal; same early-dispatch opt-in as `pl.submit` / `pl.at`). It forces the dispatch to lower to an `ir.Submit` even without `as tid` and lowers to `Arg::set_allow_early_resolve(true)`. Rejected on a `pl.cluster()`-nested `pl.spmd` (such a scope is unwrapped into the Group function and never produces a Submit, so the hint would be lost).
 
-Optional `optimizations=[pl.split(MODE)]`:
+Optional `optimizations=[...]`. The entries are orthogonal and may be combined
+in one list (e.g. `[pl.split(MODE), pl.cross_core_slot(slot_num=4)]`):
 
 | Entry | Form | Effect |
 | ----- | ---- | ------ |
 | `pl.split(MODE)` | both | Sets the inner InCore's `split_` field (cross-core transfer hint, consumed by `ExpandMixedKernel` / `MemoryReuse`). The with-form gains an inner `InCoreScopeStmt` wrapper around the call. |
+| `pl.cross_core_slot(slot_num=N)` | both | Sets the inner InCore's `slot_num` attr — the slot count (ring depth) of the automatic cross-core pipe, consumed by `ExpandMixedKernel`. Sizes a data channel only; it does **not** partition work, so it coexists with `pl.split_aiv` regions where `pl.split(...)` does not. Omit to keep the PTOAS default (8 one-directional, 4 per direction bidirectional). |
+
+> `pl.split(MODE, slot_num=N)` is a deprecated alias for the slot count and warns
+> — see [ExpandMixedKernel](../passes/19-expand_mixed_kernel.md#overriding-the-slot-count-slot_num).
 
 ### Manual dependency primitives
 

--- a/docs/en/dev/passes/08-outline_incore_scopes.md
+++ b/docs/en/dev/passes/08-outline_incore_scopes.md
@@ -205,3 +205,17 @@ a function-level representative `split`, which would silently collide with the
 user's `pl.split`). See
 [`LowerAutoVectorSplit`](18-lower_auto_vector_split.md) for how the surviving
 mechanism is lowered.
+
+**Any** `pl.split(...)` is rejected, `SplitMode.NONE` included (RFC #1820). NONE
+carries no split of its own, but writing it on a scope that also holds regions
+still reads as "auto and manual split mixed on one scope". The exemption that
+used to allow it existed only because the cross-core slot count had no carrier
+other than `pl.split(..., slot_num=N)`; it now has one —
+`optimizations=[pl.cross_core_slot(slot_num=N)]`, which is orthogonal to
+splitting and coexists with regions freely. The three states read distinctly:
+
+| Annotation | Meaning |
+| ---------- | ------- |
+| `optimizations=[pl.split(MODE)]` | AUTO split — the compiler partitions the vector work |
+| `for aiv_id in pl.split_aiv(2, mode=...)` | Manual split — the author partitions it per region |
+| `optimizations=[pl.cross_core_slot(slot_num=N)]` | Neither — just sizes the cross-core pipe |

--- a/docs/en/dev/passes/18-lower_auto_vector_split.md
+++ b/docs/en/dev/passes/18-lower_auto_vector_split.md
@@ -99,9 +99,11 @@ function is stamped `split_aiv` + `split_aiv_region_validated` (the latter signa
 transpose check — this pass validates each region's transpose hazard with the
 correct per-region split axis instead).
 
-A function-level AUTO split (`optimizations=[pl.split(mode)]`) and explicit
-`pl.split_aiv` regions are **mutually exclusive** — a scope carrying both is
-rejected. This is enforced earlier, at
+A function-level AUTO split (`optimizations=[pl.split(mode)]`, `SplitMode.NONE`
+included) and explicit `pl.split_aiv` regions are **mutually exclusive** — a
+scope carrying both is rejected. To pin a custom cross-core slot count on a
+region-carrying scope, use `optimizations=[pl.cross_core_slot(slot_num=N)]`,
+which sizes the pipe without annotating a split. This is enforced earlier, at
 [`OutlineIncoreScopes`](08-outline_incore_scopes.md), where the scope's own
 `split_` (the user's `pl.split`) and its regions are both still visible; the
 combination is rejected there because this region path would otherwise lower per

--- a/docs/en/dev/passes/19-expand_mixed_kernel.md
+++ b/docs/en/dev/passes/19-expand_mixed_kernel.md
@@ -147,20 +147,21 @@ Setup is derived from the split bodies:
 
 When cross-core directions use different tile sizes, the pass picks `max(all observed tile byte sizes)` as the common `slot_size` for `initialize_pipe`. Smaller tiles leave unused bytes in each slot but hardware correctness is preserved. Explicit user-authored programs can still create multiple independent pipes by supplying different `id` values to `initialize_pipe` and matching `tpush` / `tpop` / `tfree` ops.
 
-### Overriding the ring depth (`slot_num`)
+### Overriding the slot count (`slot_num`)
 
-The default ring depth (8 / 4) can be tuned per split scope with the optional
-`slot_num=` argument on `pl.split`:
+The default slot count (8 / 4) can be tuned per scope with the
+`pl.cross_core_slot(slot_num=N)` optimization entry:
 
 ```python
-# Shrink the auto-inserted cube->vector ring to free buffer space for a larger
-# vector tile (e.g. grow the vec tile past the default-8-slot ceiling).
-with pl.spmd(4, optimizations=[pl.split(pl.SplitMode.UP_DOWN, slot_num=4)]):
+# Shrink the auto-inserted ring to free buffer space for a larger vector tile
+# (e.g. grow the vec tile past the default-8-slot ceiling).
+with pl.spmd(4, optimizations=[pl.cross_core_slot(slot_num=4)]):
     ...
 
-# Or on the pl.at form:
+# Or on the pl.at form, alongside an independent split mode:
 with pl.at(level=pl.Level.CORE_GROUP,
-           optimizations=[pl.split(pl.SplitMode.UP_DOWN, slot_num=16)]):
+           optimizations=[pl.split(pl.SplitMode.UP_DOWN),
+                          pl.cross_core_slot(slot_num=16)]):
     ...
 ```
 
@@ -168,11 +169,20 @@ The value is carried as the `slot_num` scope attr, propagated by
 `OutlineIncoreScopes` to the outlined function's `slot_num` attr, and read here.
 When set it drives **both** the reserved buffer (`slot_size * slot_num`) and the
 emitted `initialize_pipe` `slot_num` attribute, so PTOAS and the auto-reserved
-buffer stay consistent. Omitting it keeps the PTOAS-derived default. `slot_num`
-must be positive and applies to any split scope, including `SplitMode.NONE`: a
-NONE mixed kernel still drives a cube->vector pipe (on a2a3 via dual-AIV
-dispatch — see below), so its ring is sized from `slot_num` too. It is ignored
-only when the outlined scope ends up with no cross-core ops.
+buffer stay consistent. Omitting the entry keeps the PTOAS-derived default.
+`slot_num` must be positive and is **orthogonal to splitting** — it sizes a data
+channel, it does not partition work. It applies in whichever directions the
+scope actually uses (cube->vector, vector->cube, or both), and to any scope that
+drives a pipe: a kernel with no split at all still drives one (on a2a3 via
+dual-AIV dispatch — see below). It is ignored only when the outlined scope ends
+up with no cross-core ops.
+
+**Deprecated:** `pl.split(MODE, slot_num=N)` still accepts the slot count and
+emits a `DeprecationWarning`. That spelling forced authors to name a split mode
+they did not want — the `pl.split(pl.SplitMode.NONE, slot_num=N)` idiom — which
+`OutlineIncoreScopes` now rejects on any scope carrying `pl.split_aiv` regions.
+Move the value to `pl.cross_core_slot(slot_num=N)`; the printer already
+normalises to that form.
 
 > Decoupling the logical ring depth from a smaller local resident window
 > (`local_slot_num < slot_num`, an a2/a3-only optimisation) is not yet exposed

--- a/docs/en/user/01-language_guide.md
+++ b/docs/en/user/01-language_guide.md
@@ -534,6 +534,21 @@ with pl.at(level=pl.Level.CORE_GROUP,
     y: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
 ```
 
+To pin the slot count (ring depth) of the automatic cross-core pipe, use
+`pl.cross_core_slot(...)`. It sizes a data channel rather than partitioning work,
+so it is independent of the split mode and the two combine freely:
+
+```python
+# Shrink the ring to 4 slots to free buffer space for a larger tile:
+with pl.at(level=pl.Level.CORE_GROUP,
+           optimizations=[pl.split(pl.SplitMode.UP_DOWN),
+                          pl.cross_core_slot(slot_num=4)]):
+    y: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
+```
+
+Omit the entry to keep the default (8 slots when one direction is live, 4 per
+direction when both are).
+
 ## Memory and Data Movement
 
 ### Memory Hierarchy

--- a/docs/zh-cn/dev/language/00-python_syntax.md
+++ b/docs/zh-cn/dev/language/00-python_syntax.md
@@ -316,6 +316,7 @@ for (x,) in pl.while_(init_values=(x_init,)):
 | `pl.cluster()` | `Cluster` | AIC+AIV 协同调度组 |
 | `with pl.spmd(N)` / `for i in pl.spmd(N)` | `Spmd`（for-form 内嵌 `InCore`） | SPMD 多 block 派发——见 [pl.spmd](#plspmd-多-block-派发) |
 | `pl.spmd(N, optimizations=[pl.split(MODE)])` | `Spmd(InCore(split=MODE))` | split 提示作用于内层 InCore（两种形式均适用） |
+| `pl.spmd(N, optimizations=[pl.cross_core_slot(slot_num=N)])` | `Spmd(InCore(slot_num=N))` | 槽位数作用于内层 InCore（两种形式均适用），可与 `pl.split(MODE)` 组合 |
 | `pl.scope(mode=pl.ScopeMode.MANUAL)` / `pl.manual_scope()` | `Runtime(manual=true)` | orchestrator 的 MANUAL scope——由用户管理任务排序。两种 `auto_scope` 模式下都可用（它是依赖语义选择）。见[手工依赖原语](#手工依赖原语) |
 | `pl.scope()` | `Runtime(manual=false)` | orchestrator 的 AUTO scope（`PTO2_SCOPE()`）。手写它需要 `@pl.function(auto_scope=False)`（默认 `auto_scope=True` 下由编译器决定 AUTO 放置）。见 [MaterializeRuntimeScopes](../passes/41-materialize_runtime_scopes.md) |
 

--- a/docs/zh-cn/dev/language/00-python_syntax.md
+++ b/docs/zh-cn/dev/language/00-python_syntax.md
@@ -311,6 +311,7 @@ for (x,) in pl.while_(init_values=(x_init,)):
 | ---- | ---------- | ---- |
 | `pl.at(level=pl.Level.CORE_GROUP)` | `InCore` | CORE_GROUP 级固定边界 outline |
 | `pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.split(MODE)])` | `InCore` | InCore + 跨核 split 提示 |
+| `pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.cross_core_slot(slot_num=N)])` | `InCore` | InCore + 跨核 pipe 槽位数 |
 | `pl.at(level=pl.Level.HOST)`（或任意非 `CORE_GROUP` 级别） | `Hierarchy` | 分布式层级作用域 |
 | `pl.cluster()` | `Cluster` | AIC+AIV 协同调度组 |
 | `with pl.spmd(N)` / `for i in pl.spmd(N)` | `Spmd`（for-form 内嵌 `InCore`） | SPMD 多 block 派发——见 [pl.spmd](#plspmd-多-block-派发) |
@@ -329,11 +330,16 @@ for (x,) in pl.while_(init_values=(x_init,)):
 
 以上三种形式也都接受 `allow_early_resolve=True`（布尔字面量；与 `pl.submit` / `pl.at` 相同的 early-dispatch 选项）。即使不写 `as tid` 也会强制走 `ir.Submit` 形态，并 lower 为 `Arg::set_allow_early_resolve(true)`。在嵌套于 `pl.cluster()` 内的 `pl.spmd` 上会被拒绝（此类 scope 会被 unwrap 进 Group 函数、永远不会产生 Submit，提示会丢失）。
 
-可选 `optimizations=[pl.split(MODE)]`：
+可选 `optimizations=[...]`。各条目彼此正交，可在同一列表中组合
+（例如 `[pl.split(MODE), pl.cross_core_slot(slot_num=4)]`）：
 
 | 条目 | 适用形式 | 作用 |
 | ---- | -------- | ---- |
 | `pl.split(MODE)` | 两种均适用 | 给内层 InCore 设置 `split_` 字段（跨核数据搬运提示，由 `ExpandMixedKernel` / `MemoryReuse` 消费）。with-form 会在原 call 外多包一层 `InCoreScopeStmt` 来承载该字段。 |
+| `pl.cross_core_slot(slot_num=N)` | 两种均适用 | 给内层 InCore 设置 `slot_num` 属性——自动跨核 pipe 的槽位数（环深），由 `ExpandMixedKernel` 消费。它只决定数据通道大小，**不**划分计算，因此可与 `pl.split_aiv` 区域共存（而 `pl.split(...)` 不能）。省略时沿用 PTOAS 默认值（单向 8，双向每方向 4）。 |
+
+> `pl.split(MODE, slot_num=N)` 是该槽位数的已废弃别名，会发出警告——参见
+> [ExpandMixedKernel](../passes/19-expand_mixed_kernel.md#覆盖槽位数slot_num)。
 
 示例参见 [语言指南](../../user/01-language_guide.md#incore-作用域)。
 

--- a/docs/zh-cn/dev/passes/08-outline_incore_scopes.md
+++ b/docs/zh-cn/dev/passes/08-outline_incore_scopes.md
@@ -197,3 +197,15 @@ passes.def("outline_incore_scopes", &pass::OutlineIncoreScopes, "Outline InCore 
 作用域共存。本 Pass 会拒绝该组合（它会把单个区域的模式桥接为函数级代表 `split`，从而与用户的
 `pl.split` 静默冲突）。幸存机制如何下降见
 [`LowerAutoVectorSplit`](18-lower_auto_vector_split.md)。
+
+**任何** `pl.split(...)` 都会被拒绝，包括 `SplitMode.NONE`（RFC #1820）。NONE 本身不
+携带拆分，但把它写在同时持有区域的作用域上，读起来仍像"在一个作用域里混用了自动与手动
+拆分"。此前之所以对它豁免，只是因为跨核槽位数除了 `pl.split(..., slot_num=N)` 之外没有
+别的承载方式；现在它有了自己的条目——`optimizations=[pl.cross_core_slot(slot_num=N)]`，
+与拆分正交，可自由地与区域共存。三种标注由此语义分明：
+
+| 标注 | 含义 |
+| ---- | ---- |
+| `optimizations=[pl.split(MODE)]` | AUTO 拆分——由编译器划分向量计算 |
+| `for aiv_id in pl.split_aiv(2, mode=...)` | 手动拆分——由作者按区域划分 |
+| `optimizations=[pl.cross_core_slot(slot_num=N)]` | 都不是——仅决定跨核 pipe 的大小 |

--- a/docs/zh-cn/dev/passes/18-lower_auto_vector_split.md
+++ b/docs/zh-cn/dev/passes/18-lower_auto_vector_split.md
@@ -80,8 +80,10 @@ result = passes.lower_auto_vector_split()(program)
 [`ExpandMixedKernel`](19-expand_mixed_kernel.md) 跳过其单一函数级模式的转置检查——
 改由本 pass 用每个区域正确的拆分轴校验各自的转置风险）。
 
-函数级 AUTO split（`optimizations=[pl.split(mode)]`）与显式 `pl.split_aiv` 区域是
-**互斥**的——同时携带二者的作用域会被拒绝。该检查在更早的
+函数级 AUTO split（`optimizations=[pl.split(mode)]`，包括 `SplitMode.NONE`）与显式
+`pl.split_aiv` 区域是**互斥**的——同时携带二者的作用域会被拒绝。若需在携带区域的作用域上
+指定自定义跨核槽位数，请使用 `optimizations=[pl.cross_core_slot(slot_num=N)]`：它只决定
+pipe 大小，不标注任何拆分。该检查在更早的
 [`OutlineIncoreScopes`](08-outline_incore_scopes.md) 中执行，那里作用域自身的 `split_`
 （用户的 `pl.split`）与其区域都仍可见；否则本区域路径会按区域下降并静默丢弃函数级 split。
 （提取后二者会无法区分地合并：**单个** `pl.split_aiv` 区域会合法地派生出一个函数级代表

--- a/docs/zh-cn/dev/passes/19-expand_mixed_kernel.md
+++ b/docs/zh-cn/dev/passes/19-expand_mixed_kernel.md
@@ -119,29 +119,37 @@ Ascend910B（a2a3）——跨核传输经过 GM → Mat，Mat 仅支持 NZ 布�
 
 当跨核方向使用了不同大小的 tile 时，Pass 会取所有观察到的 tile 字节大小的最大值作为 `initialize_pipe` 的公共 `slot_size`。较小 tile 写入时不会填满整个槽位，但不影响硬件正确性。用户手写程序仍然可以通过给 `initialize_pipe` 以及匹配的 `tpush` / `tpop` / `tfree` 传入不同 `id` 来创建多条独立 pipe。
 
-### 覆盖环形缓冲深度（`slot_num`）
+### 覆盖槽位数（`slot_num`）
 
-默认环深（8 / 4）可以通过 `pl.split` 上可选的 `slot_num=` 参数按拆分 scope 调整：
+默认槽位数（8 / 4）可以通过 `pl.cross_core_slot(slot_num=N)` 优化条目按 scope 调整：
 
 ```python
-# 收缩自动插入的 cube->vector 环以腾出 buffer 空间给更大的 vector tile
+# 收缩自动插入的环以腾出 buffer 空间给更大的 vector tile
 # （例如让 vec tile 突破默认 8 槽的上限）。
-with pl.spmd(4, optimizations=[pl.split(pl.SplitMode.UP_DOWN, slot_num=4)]):
+with pl.spmd(4, optimizations=[pl.cross_core_slot(slot_num=4)]):
     ...
 
-# 也支持 pl.at 形式：
+# 也支持 pl.at 形式，并可与彼此独立的 split 模式组合：
 with pl.at(level=pl.Level.CORE_GROUP,
-           optimizations=[pl.split(pl.SplitMode.UP_DOWN, slot_num=16)]):
+           optimizations=[pl.split(pl.SplitMode.UP_DOWN),
+                          pl.cross_core_slot(slot_num=16)]):
     ...
 ```
 
 该值作为 `slot_num` scope 属性记录，由 `OutlineIncoreScopes` 传播到被 outline
 函数的 `slot_num` 属性，并在此 Pass 读取。设置后它同时决定保留 buffer 的大小
 （`slot_size * slot_num`）与发射的 `initialize_pipe` 的 `slot_num` 属性，使 PTOAS
-与自动保留的 buffer 保持一致。省略时沿用 PTOAS 推导的默认值。`slot_num` 必须为
-正数，且适用于任意 split scope，包括 `SplitMode.NONE`：NONE mixed kernel 仍会驱动
-cube->vector pipe（a2a3 上通过双 AIV 派发——见下文），其环深同样由 `slot_num`
-决定。仅当被 outline 的 scope 最终没有跨核操作时才会被忽略。
+与自动保留的 buffer 保持一致。省略该条目时沿用 PTOAS 推导的默认值。`slot_num`
+必须为正数，且与拆分**正交**——它只决定数据通道的大小，不划分计算。它对 scope 实际
+使用的方向都生效（cube->vector、vector->cube 或双向），并适用于任何驱动 pipe 的
+scope：完全没有 split 的内核同样会驱动一条（a2a3 上通过双 AIV 派发——见下文）。
+仅当被 outline 的 scope 最终没有跨核操作时才会被忽略。
+
+**已废弃：** `pl.split(MODE, slot_num=N)` 仍接受该槽位数，但会发出
+`DeprecationWarning`。该写法迫使作者写出并不需要的 split 模式——即
+`pl.split(pl.SplitMode.NONE, slot_num=N)` 惯用法——而 `OutlineIncoreScopes`
+现在会在任何携带 `pl.split_aiv` 区域的 scope 上拒绝它。请把该值迁移到
+`pl.cross_core_slot(slot_num=N)`；打印器已统一输出为该形式。
 
 > 将逻辑环深与更小的本地驻留窗口解耦（`local_slot_num < slot_num`，仅 a2/a3 的
 > 优化）目前尚未在自动拆分路径暴露——如需该能力请使用手动的

--- a/docs/zh-cn/user/01-language_guide.md
+++ b/docs/zh-cn/user/01-language_guide.md
@@ -514,6 +514,19 @@ with pl.at(level=pl.Level.CORE_GROUP,
     y: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
 ```
 
+如需指定自动跨核 pipe 的槽位数（环深），使用 `pl.cross_core_slot(...)`。它只决定数据
+通道的大小，而不划分计算，因此与 split 模式相互独立，二者可自由组合：
+
+```python
+# 把环收缩到 4 槽，以腾出 buffer 空间给更大的 tile：
+with pl.at(level=pl.Level.CORE_GROUP,
+           optimizations=[pl.split(pl.SplitMode.UP_DOWN),
+                          pl.cross_core_slot(slot_num=4)]):
+    y: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
+```
+
+省略该条目时沿用默认值（单向生效时 8 槽，双向时每方向 4 槽）。
+
 ## 内存与数据搬运
 
 ### 内存层次结构

--- a/include/pypto/ir/transforms/utils/scope_outline_utils.h
+++ b/include/pypto/ir/transforms/utils/scope_outline_utils.h
@@ -915,19 +915,26 @@ class ScopeOutliner : public IRMutator {
       // are both visible only at outline time; post-outline they merge
       // indistinguishably into the function's split / split_aiv attrs (a single
       // pl.split_aiv region legitimately yields a derived function-level split).
-      CHECK_SPAN(!(incore_split.has_value() && incore_split.value() != SplitMode::None), op->span_)
+      //
+      // ANY pl.split(...) is rejected, SplitMode::None included (RFC #1820).
+      // NONE carries no split of its own, but writing it here still reads as
+      // "auto and manual split mixed on one scope". The cross-core slot count
+      // that used to force the NONE spelling now has its own orthogonal entry,
+      // pl.cross_core_slot(slot_num=N), so nothing needs the exemption.
+      CHECK_SPAN(!incore_split.has_value(), op->span_)
           << "scope combines a function-level pl.split(...) (optimizations=[pl.split(...)]) with "
              "pl.split_aiv region(s); these are mutually exclusive AIV-split mechanisms. Remove "
              "optimizations=[pl.split(...)] or the pl.split_aiv region(s) — the function-level "
-             "split would otherwise be silently dropped (the per-region split governs the lanes).";
+             "split would otherwise be silently dropped (the per-region split governs the lanes). "
+             "To pin a custom cross-core slot count, use "
+             "optimizations=[pl.cross_core_slot(slot_num=N)], which is orthogonal to splitting.";
       outlined_attrs.emplace_back("split_aiv", true);
       // Stamp a function-level representative ``split`` mode ONLY when all regions
-      // share one mode (``uniform_mode``) AND the scope carries no AUTO cross-core
-      // split (which has a separate meaning). Differing sibling modes have no
-      // single representative: leave the function-level mode unset — the
-      // authoritative per-region mode rides ``node->split_`` (consumed at pass 21).
-      if (finder.uniform_mode.has_value() &&
-          (!incore_split.has_value() || incore_split.value() == SplitMode::None)) {
+      // share one mode (``uniform_mode``). Differing sibling modes have no single
+      // representative: leave the function-level mode unset — the authoritative
+      // per-region mode rides ``node->split_`` (consumed at pass 21). No need to
+      // re-check incore_split here: the CHECK above guarantees it is unset.
+      if (finder.uniform_mode.has_value()) {
         outlined_attrs.emplace_back("split", static_cast<int>(finder.uniform_mode.value()));
       }
     };

--- a/python/pypto/language/__init__.py
+++ b/python/pypto/language/__init__.py
@@ -222,7 +222,7 @@ from .op.unified_ops import (
     transpose,
     write,
 )
-from .optimizations import split
+from .optimizations import cross_core_slot, split
 from .parser.decorator import InlineFunction, function, inline, program
 from .parser.text_parser import loads, loads_program, parse, parse_program
 from .scope import ScopeMode, manual_scope, scope, spmd_submit, submit
@@ -304,6 +304,7 @@ __all__ = [
     "split_aiv",
     "optimizations",
     "split",
+    "cross_core_slot",
     "adir",
     "array",
     "tile",

--- a/python/pypto/language/optimizations.py
+++ b/python/pypto/language/optimizations.py
@@ -20,13 +20,49 @@ Available entries:
           with pl.at(level=pl.Level.CORE_GROUP,
                      optimizations=[pl.split(pl.SplitMode.UP_DOWN)]):
               ...
+
+    - ``pl.cross_core_slot(slot_num=N)`` — Slot count (ring depth) for the
+      automatic cross-core pipe. Orthogonal to splitting; combine freely::
+
+          with pl.at(level=pl.Level.CORE_GROUP,
+                     optimizations=[pl.split(pl.SplitMode.UP_DOWN),
+                                    pl.cross_core_slot(slot_num=4)]):
+              ...
 """
 
 from __future__ import annotations
 
+import warnings
 from dataclasses import dataclass
 
 from pypto.pypto_core.ir import SplitMode
+
+# Shared by the ``pl.split()`` factory and the AST parser's ``pl.split(...)``
+# matcher so both deprecation paths say exactly the same thing.
+SPLIT_SLOT_NUM_DEPRECATION = (
+    "pl.split(slot_num=...) is deprecated: the cross-core slot count is orthogonal to the "
+    "split mode, and spelling it here forces a split mode you may not want (the "
+    "pl.split(pl.SplitMode.NONE, slot_num=N) idiom). Use "
+    "optimizations=[pl.cross_core_slot(slot_num=N)] instead, optionally alongside "
+    "pl.split(MODE)."
+)
+
+
+def _validate_slot_num(slot_num: int, api: str) -> None:
+    """Validate a cross-core slot count.
+
+    Args:
+        slot_num: Candidate slot count.
+        api: API name used in the error message (e.g. ``"pl.cross_core_slot"``).
+
+    Raises:
+        ValueError: If ``slot_num`` is not a positive integer.
+    """
+    # bool is a subclass of int — reject it so True/False can't pose as a count.
+    if not isinstance(slot_num, int) or isinstance(slot_num, bool):
+        raise ValueError(f"{api} slot_num must be a positive integer, got {slot_num!r}")
+    if slot_num <= 0:
+        raise ValueError(f"{api} slot_num must be a positive integer, got {slot_num}")
 
 
 class Optimization:
@@ -45,16 +81,9 @@ class Split(Optimization):
     Args:
         mode: Split mode (``SplitMode.NONE``, ``SplitMode.UP_DOWN``, or
             ``SplitMode.LEFT_RIGHT``).
-        slot_num: Optional cross-core ring-buffer depth for the automatic
-            cube→vector pipe inserted by ``ExpandMixedKernel``. ``None`` keeps
-            the PTOAS-derived default (8 unidirectional, 4 per direction
-            bidirectional). When set, both the reserved buffer
-            (``slot_size * slot_num``) and the emitted ``initialize_pipe``
-            ``slot_num`` attribute use this value. Valid with any ``mode``,
-            including ``SplitMode.NONE``: a NONE mixed kernel still drives a
-            cube→vector pipe (on Ascend910B via dual-AIV dispatch), so
-            ``slot_num`` sizes that ring regardless of split mode. It is ignored
-            only when the outlined scope ends up with no cross-core ops.
+        slot_num: **Deprecated** — use ``pl.cross_core_slot(slot_num=N)``, which
+            carries the same value without naming a split mode. Kept as an alias
+            so existing kernels keep working; see :class:`CrossCoreSlot`.
     """
 
     mode: SplitMode
@@ -67,9 +96,8 @@ def split(mode: SplitMode, *, slot_num: int | None = None) -> Split:
     Args:
         mode: Split mode. May be ``SplitMode.NONE``,
             ``SplitMode.UP_DOWN``, or ``SplitMode.LEFT_RIGHT``.
-        slot_num: Optional cross-core ring-buffer depth for the automatic
-            cube→vector pipe. Must be positive when set. Omit to keep the
-            PTOAS-derived default (8 unidirectional, 4 bidirectional).
+        slot_num: **Deprecated** — use ``pl.cross_core_slot(slot_num=N)``.
+            Must be positive when set. Emits a ``DeprecationWarning``.
 
     Returns:
         ``Split`` instance for use in ``pl.at(..., optimizations=[...])``.
@@ -78,16 +106,59 @@ def split(mode: SplitMode, *, slot_num: int | None = None) -> Split:
         ValueError: If ``slot_num`` is set but not positive.
     """
     if slot_num is not None:
-        # bool is a subclass of int — reject it so True/False can't pose as a depth.
-        if not isinstance(slot_num, int) or isinstance(slot_num, bool):
-            raise ValueError(f"pl.split slot_num must be a positive integer, got {slot_num!r}")
-        if slot_num <= 0:
-            raise ValueError(f"pl.split slot_num must be a positive integer, got {slot_num}")
+        _validate_slot_num(slot_num, "pl.split")
+        warnings.warn(SPLIT_SLOT_NUM_DEPRECATION, DeprecationWarning, stacklevel=2)
     return Split(mode=mode, slot_num=slot_num)
 
 
+@dataclass(frozen=True)
+class CrossCoreSlot(Optimization):
+    """Slot count (ring depth) for the automatic cross-core pipe.
+
+    Orthogonal to splitting — it sizes a data channel, it does not partition
+    work. Sets the ``slot_num`` scope attr, which ``OutlineIncoreScopes``
+    propagates to the outlined function and ``ExpandMixedKernel`` reads to size
+    **both** the reserved buffer (``slot_size * slot_num``) and the emitted
+    ``initialize_pipe`` ``slot_num`` attribute, in whichever directions the
+    scope actually uses (cube→vector, vector→cube, or both).
+
+    Omitting the entry keeps the PTOAS-derived default: 8 when one direction is
+    live, 4 per direction when both are. The value is ignored when the outlined
+    scope ends up with no cross-core ops.
+
+    Args:
+        slot_num: Ring depth. Must be a positive integer.
+    """
+
+    slot_num: int
+
+
+def cross_core_slot(*, slot_num: int) -> CrossCoreSlot:
+    """Create a ``CrossCoreSlot`` optimization entry.
+
+    Args:
+        slot_num: Cross-core pipe slot count (ring depth). Must be positive.
+
+    Returns:
+        ``CrossCoreSlot`` instance for use in ``pl.at(..., optimizations=[...])``.
+
+    Raises:
+        ValueError: If ``slot_num`` is not a positive integer.
+
+    Examples:
+        >>> # Shrink the auto-inserted ring to free buffer space for a larger tile
+        >>> with pl.at(level=pl.Level.CORE_GROUP,
+        ...            optimizations=[pl.cross_core_slot(slot_num=4)]):
+        ...     ...
+    """
+    _validate_slot_num(slot_num, "pl.cross_core_slot")
+    return CrossCoreSlot(slot_num=slot_num)
+
+
 __all__ = [
+    "CrossCoreSlot",
     "Optimization",
     "Split",
+    "cross_core_slot",
     "split",
 ]

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -3961,15 +3961,17 @@ class ASTParser:
         The two forms differ only in ``scope_attrs`` (the ``as tid`` form adds
         ``task_id_var`` / ``manual_dep_edges``); the body dispatch is identical:
 
-        * single call + no split → ``SpmdScopeStmt(body=Call)`` with no inner InCore
-          wrapper — the historical direct-dispatch shape (the callee is a pre-defined
-          kernel that reads the block index internally). This is also the shape
-          ``OutlineIncoreScopes`` leaves behind once an inline body is outlined, so
-          the IR round-trips identically across passes.
-        * inline multi-statement body, or single-call + split → wrap in
-          ``InCoreScopeStmt(split, <body>)`` for ``OutlineIncoreScopes`` to outline
-          into a synthetic per-block kernel, exactly like ``for i in pl.spmd(n):``.
-          Such an inline body must read the per-block index (see below).
+        * single call + no split and no slot count → ``SpmdScopeStmt(body=Call)``
+          with no inner InCore wrapper — the historical direct-dispatch shape (the
+          callee is a pre-defined kernel that reads the block index internally).
+          This is also the shape ``OutlineIncoreScopes`` leaves behind once an
+          inline body is outlined, so the IR round-trips identically across passes.
+        * inline multi-statement body, or single-call carrying any
+          ``optimizations=`` entry → wrap in ``InCoreScopeStmt(split, <body>)`` for
+          ``OutlineIncoreScopes`` to outline into a synthetic per-block kernel,
+          exactly like ``for i in pl.spmd(n):``. Both entries lower onto the InCore
+          scope (``split_`` and the ``slot_num`` attr), so either one forces the
+          wrapper. Such an inline body must read the per-block index (see below).
         """
         # A single body statement whose value is a Call — Assign/AnnAssign/Expr all
         # expose a `.value`, so one membership test covers the three call-carrying
@@ -3990,10 +3992,17 @@ class ASTParser:
                 hint="Add `i = pl.tile.get_block_idx()` inside the scope, or use "
                 "`for i in pl.spmd(n):` to bind the block index automatically.",
             )
-        if is_single_call and split_mode is None:
+        if is_single_call and split_mode is None and split_slot_num is None:
             # Historical no-InCore-wrapper shape. Any ``scope_attrs``
             # (allow_early_resolve, and for the ``as tid`` form task_id_var /
             # manual_dep_edges) ride on the SpmdScopeStmt.
+            #
+            # ``split_slot_num`` is checked alongside ``split_mode``: the slot
+            # count lands on the *InCore* scope (OutlineIncoreScopes reads
+            # ``slot_num`` off InCoreScopeStmt only), so taking this wrapper-less
+            # path with a slot count set would silently discard it. Before
+            # pl.cross_core_slot existed the two were coupled — slot_num could
+            # only arrive via pl.split(mode, slot_num=N), which always set a mode.
             self._parse_scope_body(
                 stmt,
                 scope_kind,

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -27,6 +27,7 @@ from pypto.language.op import array_ops as _dsl_array
 from pypto.language.op import system_ops as _dsl_system
 from pypto.language.op import tensor_ops as _dsl_tensor
 from pypto.language.op import tile_ops as _dsl_tile
+from pypto.language.optimizations import SPLIT_SLOT_NUM_DEPRECATION
 from pypto.pypto_core import DataType, ir
 from pypto.pypto_core import arith as _arith
 
@@ -422,8 +423,9 @@ class _AtKwargState:
     # ``Submit`` by the outliner (mirrors ``pl.submit(..., allow_early_resolve=)``).
     allow_early_resolve: bool = False
     split_mode: "ir.SplitMode | None" = None
-    # Optional cross-core ring-buffer depth from ``pl.split(mode, slot_num=N)``.
-    # Stored on the scope attrs and propagated to the outlined function attr.
+    # Optional cross-core pipe slot count from ``pl.cross_core_slot(slot_num=N)``
+    # (or the deprecated ``pl.split(mode, slot_num=N)`` spelling). Stored on the
+    # scope attrs and propagated to the outlined function attr.
     split_slot_num: "int | None" = None
     # Tracks the ``optimizations=`` kwarg AST so a duplicate ``optimizations=``
     # can be rejected in ``_handle_at_optimizations_kw``.
@@ -3217,9 +3219,11 @@ class ASTParser:
     ) -> tuple["ir.SplitMode | None", "int | None"]:
         """Parse ``optimizations=[...]`` for ``pl.at`` or ``pl.spmd``.
 
-        Each entry must be ``pl.split(MODE)`` — set the cross-core split mode.
-        The fully qualified form (``pl.optimizations.split(MODE)``) is also
-        accepted.
+        Two entries are recognised, freely combinable because they are
+        orthogonal — ``pl.split(MODE)`` sets the cross-core split mode, and
+        ``pl.cross_core_slot(slot_num=N)`` sets the cross-core pipe slot count.
+        The fully qualified forms (``pl.optimizations.split(MODE)`` etc.) are
+        also accepted.
 
         Args:
             owner: API name used in error messages (e.g. ``"pl.at"``, ``"pl.spmd"``).
@@ -3232,7 +3236,7 @@ class ASTParser:
         if list_hint is None:
             list_hint = "Use optimizations=[pl.split(pl.SplitMode.NONE)]."
         if entry_hint is None:
-            entry_hint = "Each entry must be pl.split(pl.SplitMode.X)."
+            entry_hint = "Each entry must be pl.split(pl.SplitMode.X) or pl.cross_core_slot(slot_num=N)."
         if not isinstance(value, ast.List):
             raise ParserSyntaxError(
                 f"{owner}(optimizations=...) must be a list literal",
@@ -3243,6 +3247,11 @@ class ASTParser:
         split_mode: ir.SplitMode | None = None
         split_slot_num: int | None = None
         seen_split = False
+        seen_cross_core_slot = False
+        # Tracks whether split_slot_num came from the deprecated
+        # ``pl.split(slot_num=)`` spelling, so a list carrying both sources for
+        # one value is rejected instead of letting entry order decide.
+        slot_num_from_split = False
 
         for entry in value.elts:
             if (parsed := self._try_parse_pl_split(entry)) is not None:
@@ -3253,10 +3262,30 @@ class ASTParser:
                     )
                 seen_split = True
                 split_mode, slot_num = parsed
-                # slot_num is valid with any split mode, including SplitMode.NONE:
-                # a NONE mixed kernel still drives a cube->vector cross-core pipe
-                # (on a2a3 via dual-AIV dispatch), and ExpandMixedKernel sizes
-                # that ring from slot_num regardless of split mode.
+                if slot_num is not None:
+                    if seen_cross_core_slot:
+                        raise ParserSyntaxError(
+                            "optimizations=[...] sets the cross-core slot count twice: via the "
+                            "deprecated pl.split(slot_num=...) and via pl.cross_core_slot(...)",
+                            span=self.span_tracker.get_span(entry),
+                            hint="Keep only pl.cross_core_slot(slot_num=N).",
+                        )
+                    split_slot_num = slot_num
+                    slot_num_from_split = True
+            elif (slot_num := self._try_parse_pl_cross_core_slot(entry)) is not None:
+                if seen_cross_core_slot:
+                    raise ParserSyntaxError(
+                        "Duplicate 'pl.cross_core_slot(...)' in optimizations=[...]",
+                        span=self.span_tracker.get_span(entry),
+                    )
+                if slot_num_from_split:
+                    raise ParserSyntaxError(
+                        "optimizations=[...] sets the cross-core slot count twice: via the "
+                        "deprecated pl.split(slot_num=...) and via pl.cross_core_slot(...)",
+                        span=self.span_tracker.get_span(entry),
+                        hint="Drop slot_num= from pl.split(...) and keep pl.cross_core_slot(slot_num=N).",
+                    )
+                seen_cross_core_slot = True
                 split_slot_num = slot_num
             else:
                 raise ParserSyntaxError(
@@ -3276,44 +3305,55 @@ class ASTParser:
             value,
             owner="pl.spmd",
             list_hint="Use optimizations=[pl.split(pl.SplitMode.NONE)].",
-            entry_hint="Each entry must be pl.split(pl.SplitMode.X).",
+            entry_hint="Each entry must be pl.split(pl.SplitMode.X) or pl.cross_core_slot(slot_num=N).",
+        )
+
+    def _is_pl_optimization_call(self, node: ast.expr, name: str) -> bool:
+        """True when ``node`` is ``pl.<name>(...)`` or ``pl.optimizations.<name>(...)``."""
+        if not isinstance(node, ast.Call):
+            return False
+        func = node.func
+        if not isinstance(func, ast.Attribute) or func.attr != name:
+            return False
+        # pl.<name>(...)
+        if isinstance(func.value, ast.Name) and func.value.id == "pl":
+            return True
+        # pl.optimizations.<name>(...)
+        return (
+            isinstance(func.value, ast.Attribute)
+            and func.value.attr == "optimizations"
+            and isinstance(func.value.value, ast.Name)
+            and func.value.value.id == "pl"
         )
 
     def _try_parse_pl_split(self, node: ast.expr) -> "tuple[ir.SplitMode, int | None] | None":
         """Return ``(SplitMode, slot_num)`` if the AST node is ``pl.split(MODE)``; else None.
 
-        ``slot_num`` is ``None`` unless the optional ``slot_num=N`` keyword is
+        ``slot_num`` is ``None`` unless the deprecated ``slot_num=N`` keyword is
         given. Also accepts the fully qualified form
         ``pl.optimizations.split(MODE)``.
         """
-        if not isinstance(node, ast.Call):
+        if not self._is_pl_optimization_call(node, "split"):
             return None
-        func = node.func
-        if not isinstance(func, ast.Attribute) or func.attr != "split":
-            return None
-        # pl.split(...)
-        if isinstance(func.value, ast.Name) and func.value.id == "pl":
-            pass
-        # pl.optimizations.split(...)
-        elif (
-            isinstance(func.value, ast.Attribute)
-            and func.value.attr == "optimizations"
-            and isinstance(func.value.value, ast.Name)
-            and func.value.value.id == "pl"
-        ):
-            pass
-        else:
-            return None
+        assert isinstance(node, ast.Call)  # narrowed by _is_pl_optimization_call
 
         slot_num: int | None = None
         for kw in node.keywords:
             if kw.arg == "slot_num":
-                slot_num = self._eval_pl_split_slot_num(kw.value)
+                slot_num = self._eval_slot_num_literal(
+                    kw.value,
+                    "pl.split(slot_num=...)",
+                    hint="Use e.g. pl.cross_core_slot(slot_num=16).",
+                )
+                # Deprecated spelling: the slot count is orthogonal to the split
+                # mode, so it has its own entry now. Warn rather than reject so
+                # existing kernels keep working.
+                warnings.warn(SPLIT_SLOT_NUM_DEPRECATION, DeprecationWarning, stacklevel=2)
             else:
                 raise ParserSyntaxError(
                     f"Unknown keyword argument '{kw.arg}' in pl.split()",
                     span=self.span_tracker.get_span(kw),
-                    hint="pl.split() accepts only the optional slot_num= keyword.",
+                    hint="pl.split() accepts only the deprecated slot_num= keyword.",
                 )
         if len(node.args) != 1:
             raise ParserSyntaxError(
@@ -3324,8 +3364,51 @@ class ASTParser:
         mode = extract_enum_value(node.args[0], SPLIT_MODE_MAP, "SplitMode", "pl.SplitMode")
         return mode, slot_num
 
-    def _eval_pl_split_slot_num(self, value: ast.expr) -> int:
-        """Evaluate ``slot_num=`` in ``pl.split(...)`` as a positive int literal."""
+    def _try_parse_pl_cross_core_slot(self, node: ast.expr) -> "int | None":
+        """Return the slot count if the node is ``pl.cross_core_slot(slot_num=N)``; else None.
+
+        Also accepts ``pl.optimizations.cross_core_slot(slot_num=N)``. The
+        ``slot_num=`` keyword is required and is the only accepted argument.
+        """
+        if not self._is_pl_optimization_call(node, "cross_core_slot"):
+            return None
+        assert isinstance(node, ast.Call)  # narrowed by _is_pl_optimization_call
+
+        usage_hint = "Use pl.cross_core_slot(slot_num=4)."
+        if node.args:
+            raise ParserSyntaxError(
+                f"pl.cross_core_slot() takes no positional arguments, got {len(node.args)}",
+                span=self.span_tracker.get_span(node),
+                hint=usage_hint,
+            )
+        slot_num: int | None = None
+        for kw in node.keywords:
+            if kw.arg == "slot_num":
+                slot_num = self._eval_slot_num_literal(
+                    kw.value, "pl.cross_core_slot(slot_num=...)", hint=usage_hint
+                )
+            else:
+                raise ParserSyntaxError(
+                    f"Unknown keyword argument '{kw.arg}' in pl.cross_core_slot()",
+                    span=self.span_tracker.get_span(kw),
+                    hint=usage_hint,
+                )
+        if slot_num is None:
+            raise ParserSyntaxError(
+                "pl.cross_core_slot() requires the slot_num= keyword argument",
+                span=self.span_tracker.get_span(node),
+                hint=usage_hint,
+            )
+        return slot_num
+
+    def _eval_slot_num_literal(self, value: ast.expr, api: str, *, hint: str) -> int:
+        """Evaluate a ``slot_num=`` argument as a positive int literal.
+
+        Args:
+            value: The keyword's value AST node.
+            api: API spelling used in error messages (e.g. ``"pl.cross_core_slot(slot_num=...)"``).
+            hint: Usage hint attached to the "not an integer literal" error.
+        """
         # bool is a subclass of int — reject it explicitly.
         if (
             not isinstance(value, ast.Constant)
@@ -3333,13 +3416,13 @@ class ASTParser:
             or not isinstance(value.value, int)
         ):
             raise ParserSyntaxError(
-                "pl.split(slot_num=...) must be an integer literal",
+                f"{api} must be an integer literal",
                 span=self.span_tracker.get_span(value),
-                hint="Use e.g. pl.split(pl.SplitMode.UP_DOWN, slot_num=16).",
+                hint=hint,
             )
         if value.value <= 0:
             raise ParserSyntaxError(
-                f"pl.split(slot_num=...) must be positive, got {value.value}",
+                f"{api} must be positive, got {value.value}",
                 span=self.span_tracker.get_span(value),
             )
         return value.value
@@ -4549,10 +4632,14 @@ class ASTParser:
 
         is_core_group = level == ir.Level.CORE_GROUP
 
-        if split_mode is not None and not is_core_group:
+        # Both optimizations= entries lower onto the InCore scope: pl.split(...)
+        # into split_, pl.cross_core_slot(...) into the slot_num attr. Neither
+        # has a meaning on a Hierarchy scope, so reject either at a non-CORE_GROUP
+        # level rather than silently attaching a dead attr.
+        if (split_mode is not None or state.split_slot_num is not None) and not is_core_group:
             raise ParserSyntaxError(
-                "split mode is only supported with level=pl.Level.CORE_GROUP "
-                "(via optimizations=[pl.split(...)])",
+                "optimizations=[pl.split(...)] / optimizations=[pl.cross_core_slot(...)] are only "
+                "supported with level=pl.Level.CORE_GROUP",
                 span=span,
                 hint="Use pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.split(pl.SplitMode.UP_DOWN)]).",
             )
@@ -4636,11 +4723,11 @@ class ASTParser:
     def _append_split_slot_num_attr(
         attrs: "list[tuple[str, Any]] | None", slot_num: "int | None"
     ) -> "list[tuple[str, Any]] | None":
-        """Append the ``slot_num`` scope attr (from ``pl.split(mode, slot_num=N)``).
+        """Append the ``slot_num`` scope attr (from ``pl.cross_core_slot(slot_num=N)``).
 
         Appended last so a print -> reparse cycle reproduces the same attr order
-        (``optimizations=[pl.split(...)]`` is printed alongside ``deps=`` /
-        ``dumps=``, and slot_num always lands at the tail here on both passes).
+        (``optimizations=[...]`` is printed alongside ``deps=`` / ``dumps=``, and
+        slot_num always lands at the tail here on both passes).
         Returns ``attrs`` unchanged when ``slot_num`` is ``None``.
         """
         if slot_num is None:

--- a/src/ir/transforms/python_printer.cpp
+++ b/src/ir/transforms/python_printer.cpp
@@ -74,15 +74,6 @@ std::string SplitModeToPythonString(SplitMode mode) {
   throw pypto::TypeError("Unknown SplitMode");
 }
 
-/// True when a scope must emit a ``pl.split(...)`` optimization entry: it carries
-/// a concrete split mode (UP_DOWN / LEFT_RIGHT) or a ``slot_num`` ring depth.
-/// ``slot_num`` is valid with ``SplitMode.None`` too (a NONE mixed kernel still
-/// drives a cube->vector pipe), so a bare ``slot_num`` forces the entry.
-bool ScopeHasSplitInfo(const std::optional<SplitMode>& split, const ScopeStmtPtr& slot_holder) {
-  const bool has_mode = split.has_value() && split.value() != SplitMode::None;
-  return has_mode || (slot_holder && slot_holder->HasAttr("slot_num"));
-}
-
 /// Convert cast round mode integer to its string name for printing.
 /// Inverse of the CAST_MODE_NAMES mapping in python/pypto/ir/utils.py.
 std::string CastModeToString(int mode) {
@@ -390,15 +381,16 @@ class IRPythonPrinter : public IRVisitor {
   // Emit ``windowize=True`` for an explicitly opted-in InCore scope.
   bool PrintScopeWindowizeAttr(const ScopeStmtPtr& op);
 
-  // Emit ``pl.split(pl.SplitMode.X[, slot_num=N])`` (a single optimizations list
-  // entry, no leading comma / wrapper), reading the optional ``slot_num`` ring
-  // depth from ``slot_num_holder``'s attrs (the scope carrying it).
-  void PrintSplitCall(SplitMode split, const ScopeStmtPtr& slot_num_holder);
-
-  // Emit ``, optimizations=[pl.split(pl.SplitMode.X[, slot_num=N])]`` for a
-  // split scope. Used by the flattened spmd with-tid / for-loop forms; the
-  // nested-scope forms round-trip slot_num via the InCoreScopeStmt printer.
-  void PrintSplitOptimizations(SplitMode split, const ScopeStmtPtr& slot_num_holder);
+  // Emit ``, optimizations=[...]`` for a scope carrying a concrete split mode
+  // (UP_DOWN / LEFT_RIGHT) and/or a ``slot_num`` cross-core slot count, read
+  // from ``slot_num_holder``'s attrs (the scope carrying it). The two are
+  // independent entries — ``pl.split(pl.SplitMode.X)`` and
+  // ``pl.cross_core_slot(slot_num=N)`` — so a bare slot count never fabricates
+  // a ``pl.SplitMode.NONE`` (which OutlineIncoreScopes rejects on a scope
+  // holding pl.split_aiv regions). Emits nothing when the scope carries
+  // neither. Used by the flattened spmd with-tid / for-loop forms; the
+  // nested-scope forms round-trip via the InCoreScopeStmt printer.
+  void PrintScopeOptimizations(const std::optional<SplitMode>& split, const ScopeStmtPtr& slot_num_holder);
 
   // Emit `` as <tid>`` if the scope carries ``kAttrTaskIdVar``. The caller is
   // responsible for placing the ``)`` before and the ``:\n`` after this call.
@@ -1772,17 +1764,20 @@ bool IRPythonPrinter::PrintScopeDepsAttr(const ScopeStmtPtr& op) {
   return PrintScopeVarListKwarg(op, kAttrManualDepEdges, "deps");
 }
 
-void IRPythonPrinter::PrintSplitCall(SplitMode split, const ScopeStmtPtr& slot_num_holder) {
-  stream_ << prefix_ << ".split(" << prefix_ << ".SplitMode." << SplitModeToPythonString(split);
-  if (slot_num_holder && slot_num_holder->HasAttr("slot_num")) {
-    stream_ << ", slot_num=" << slot_num_holder->GetAttr<int>("slot_num", 0);
-  }
-  stream_ << ")";
-}
-
-void IRPythonPrinter::PrintSplitOptimizations(SplitMode split, const ScopeStmtPtr& slot_num_holder) {
+void IRPythonPrinter::PrintScopeOptimizations(const std::optional<SplitMode>& split,
+                                              const ScopeStmtPtr& slot_num_holder) {
+  const bool has_mode = split.has_value() && split.value() != SplitMode::None;
+  const bool has_slot_num = slot_num_holder && slot_num_holder->HasAttr("slot_num");
+  if (!has_mode && !has_slot_num) return;
   stream_ << ", optimizations=[";
-  PrintSplitCall(split, slot_num_holder);
+  if (has_mode) {
+    stream_ << prefix_ << ".split(" << prefix_ << ".SplitMode." << SplitModeToPythonString(split.value())
+            << ")";
+  }
+  if (has_slot_num) {
+    if (has_mode) stream_ << ", ";
+    stream_ << prefix_ << ".cross_core_slot(slot_num=" << slot_num_holder->GetAttr<int>("slot_num", 0) << ")";
+  }
   stream_ << "]";
 }
 
@@ -1877,14 +1872,11 @@ void IRPythonPrinter::VisitStmt_(const HierarchyScopeStmtPtr& op) {
 
 void IRPythonPrinter::VisitStmt_(const InCoreScopeStmtPtr& op) {
   stream_ << "with " << prefix_ << ".at(level=" << prefix_ << ".Level.CORE_GROUP";
-  // Emit the surviving ``optimizations=[pl.split(mode[, slot_num=N])]`` form
-  // whenever there is a slot_num (a NONE mixed kernel still drives a
-  // cube->vector pipe and carries a ring depth) or a non-None split mode. A
-  // plain InCore with no split prints as ``pl.at(level=...)`` with no
+  // Emit ``optimizations=[...]`` for a non-None split mode and/or a slot_num
+  // (a NONE mixed kernel still drives a cross-core pipe and carries a slot
+  // count). A plain InCore with neither prints as ``pl.at(level=...)`` with no
   // optimizations list.
-  if (op->HasAttr("slot_num") || (op->split_.has_value() && op->split_.value() != SplitMode::None)) {
-    PrintSplitOptimizations(op->split_.value_or(SplitMode::None), op);
-  }
+  PrintScopeOptimizations(op->split_, op);
   if (!op->name_hint_.empty()) {
     stream_ << ", name_hint=\"" << op->name_hint_ << "\"";
   }
@@ -1938,8 +1930,8 @@ void IRPythonPrinter::VisitStmt_(const SpmdScopeStmtPtr& op) {
     if (!op->name_hint_.empty()) {
       stream_ << ", name_hint=\"" << op->name_hint_ << "\"";
     }
-    if (incore && ScopeHasSplitInfo(incore->split_, incore)) {
-      PrintSplitOptimizations(incore->split_.value_or(SplitMode::None), incore);
+    if (incore) {
+      PrintScopeOptimizations(incore->split_, incore);
     }
     PrintScopeDepsAttr(op);
     PrintScopeAllowEarlyResolveAttr(op);
@@ -1978,8 +1970,8 @@ void IRPythonPrinter::VisitStmt_(const SpmdScopeStmtPtr& op) {
     if (!op->name_hint_.empty()) {
       stream_ << ", name_hint=\"" << op->name_hint_ << "\"";
     }
-    if (incore && ScopeHasSplitInfo(incore->split_, incore)) {
-      PrintSplitOptimizations(incore->split_.value_or(SplitMode::None), incore);
+    if (incore) {
+      PrintScopeOptimizations(incore->split_, incore);
     }
     PrintScopeAllowEarlyResolveAttr(op);
     PrintScopePredicateAttr(op);

--- a/tests/ut/ir/parser/test_at_optimizations.py
+++ b/tests/ut/ir/parser/test_at_optimizations.py
@@ -199,5 +199,246 @@ def test_fully_qualified_split():
     assert cast(_HasSplit, scope).split == ir.SplitMode.UP_DOWN
 
 
+def test_fully_qualified_cross_core_slot():
+    """pl.optimizations.cross_core_slot(...) also works."""
+
+    @pl.function
+    def f(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+        with pl.at(
+            level=pl.Level.CORE_GROUP,
+            optimizations=[pl.optimizations.cross_core_slot(slot_num=4)],
+        ):
+            y = pl.add(x, x)
+        return y
+
+    scope = _find_scope_stmt(f.body)
+    assert scope is not None
+    assert scope.attrs.get("slot_num") == 4
+
+
+# ─── pl.cross_core_slot(slot_num=N): the orthogonal pipe-sizing entry ─────────
+
+
+def test_parse_optimizations_cross_core_slot_only():
+    """optimizations=[pl.cross_core_slot(...)] sets slot_num and leaves split unset.
+
+    This is the point of the entry: a scope can size the cross-core ring
+    without naming a SplitMode it does not want.
+    """
+
+    @pl.function
+    def f(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+        with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.cross_core_slot(slot_num=4)]):
+            y = pl.add(x, x)
+        return y
+
+    scope = _find_scope_stmt(f.body)
+    assert scope is not None
+    assert scope.scope_kind == ir.ScopeKind.InCore
+    assert scope.attrs.get("slot_num") == 4
+    assert cast(_HasSplit, scope).split is None
+
+
+def test_parse_optimizations_split_and_cross_core_slot():
+    """The two entries are orthogonal and combine in one list."""
+
+    @pl.function
+    def f(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+        with pl.at(
+            level=pl.Level.CORE_GROUP,
+            optimizations=[pl.split(pl.SplitMode.UP_DOWN), pl.cross_core_slot(slot_num=16)],
+        ):
+            y = pl.add(x, x)
+        return y
+
+    scope = _find_scope_stmt(f.body)
+    assert scope is not None
+    assert cast(_HasSplit, scope).split == ir.SplitMode.UP_DOWN
+    assert scope.attrs.get("slot_num") == 16
+
+
+def test_duplicate_cross_core_slot_errors():
+    """Two pl.cross_core_slot(...) entries in the same list is an error."""
+    with pytest.raises(ParserSyntaxError, match="Duplicate.*cross_core_slot"):
+
+        @pl.function
+        def f(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            with pl.at(
+                level=pl.Level.CORE_GROUP,
+                optimizations=[pl.cross_core_slot(slot_num=4), pl.cross_core_slot(slot_num=8)],
+            ):
+                y = pl.add(x, x)
+            return y
+
+
+def test_cross_core_slot_conflicts_with_deprecated_split_slot_num():
+    """Setting the slot count twice — via pl.split(slot_num=) and via the
+    dedicated entry — is rejected rather than resolved by list order."""
+    with pytest.raises(ParserSyntaxError, match="sets the cross-core slot count twice"):
+
+        @pl.function
+        def f(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            with pl.at(
+                level=pl.Level.CORE_GROUP,
+                optimizations=[
+                    pl.split(pl.SplitMode.UP_DOWN, slot_num=4),
+                    pl.cross_core_slot(slot_num=8),
+                ],
+            ):
+                y = pl.add(x, x)
+            return y
+
+
+def test_cross_core_slot_conflict_detected_in_either_order():
+    """Same conflict, entries swapped — the deprecated spelling appearing last."""
+    with pytest.raises(ParserSyntaxError, match="sets the cross-core slot count twice"):
+
+        @pl.function
+        def f(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            with pl.at(
+                level=pl.Level.CORE_GROUP,
+                optimizations=[
+                    pl.cross_core_slot(slot_num=8),
+                    pl.split(pl.SplitMode.UP_DOWN, slot_num=4),
+                ],
+            ):
+                y = pl.add(x, x)
+            return y
+
+
+def test_cross_core_slot_requires_slot_num_keyword():
+    """pl.cross_core_slot() without slot_num= is an error."""
+    with pytest.raises(ParserSyntaxError, match="requires the slot_num="):
+
+        @pl.function
+        def f(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.cross_core_slot()]):  # type: ignore[call-arg]
+                y = pl.add(x, x)
+            return y
+
+
+def test_cross_core_slot_rejects_positional_arg():
+    """The slot count must be passed by keyword."""
+    with pytest.raises(ParserSyntaxError, match="no positional arguments"):
+
+        @pl.function
+        def f(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.cross_core_slot(4)]):  # type: ignore[misc]
+                y = pl.add(x, x)
+            return y
+
+
+def test_cross_core_slot_rejects_unknown_keyword():
+    """Only slot_num= is accepted."""
+    with pytest.raises(ParserSyntaxError, match="Unknown keyword argument 'depth'"):
+
+        @pl.function
+        def f(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.cross_core_slot(depth=4)]):  # type: ignore[call-arg]
+                y = pl.add(x, x)
+            return y
+
+
+@pytest.mark.parametrize(
+    ("bad", "expected"),
+    [
+        ("0", "must be positive"),
+        # -1 is ast.UnaryOp(USub, Constant(1)), not an ast.Constant, so it is
+        # rejected one step earlier by the integer-literal check. Same shape as
+        # the pre-existing pl.split(slot_num=) behaviour.
+        ("-1", "must be an integer literal"),
+    ],
+)
+def test_cross_core_slot_rejects_non_positive(bad: str, expected: str):
+    """slot_num must be a positive integer literal."""
+    src = (
+        "import pypto.language as pl\n"
+        "@pl.function\n"
+        "def f(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:\n"
+        "    with pl.at(level=pl.Level.CORE_GROUP, "
+        f"optimizations=[pl.cross_core_slot(slot_num={bad})]):\n"
+        "        y = pl.add(x, x)\n"
+        "    return y\n"
+    )
+    with pytest.raises(ParserSyntaxError, match=expected):
+        pl.parse(src)
+
+
+def test_cross_core_slot_rejects_bool_literal():
+    """bool is a subclass of int — True must not pose as a slot count."""
+    with pytest.raises(ParserSyntaxError, match="must be an integer literal"):
+
+        @pl.function
+        def f(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            with pl.at(
+                level=pl.Level.CORE_GROUP,
+                optimizations=[pl.cross_core_slot(slot_num=True)],  # type: ignore[arg-type]
+            ):
+                y = pl.add(x, x)
+            return y
+
+
+def test_cross_core_slot_on_non_core_group_errors():
+    """pl.cross_core_slot(...) is only valid at CORE_GROUP — the slot_num attr
+    has no meaning on a Hierarchy scope, so it must not silently attach."""
+    with pytest.raises(ParserSyntaxError, match="CORE_GROUP"):
+
+        @pl.function
+        def f(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            with pl.at(level=pl.Level.HOST, optimizations=[pl.cross_core_slot(slot_num=4)]):
+                y = pl.add(x, x)
+            return y
+
+
+def test_cross_core_slot_factory_validates_at_runtime():
+    """The runtime factory rejects non-positive / non-int slot counts."""
+    assert pl.cross_core_slot(slot_num=4).slot_num == 4
+    with pytest.raises(ValueError, match="must be a positive integer"):
+        pl.cross_core_slot(slot_num=0)
+    with pytest.raises(ValueError, match="must be a positive integer"):
+        pl.cross_core_slot(slot_num=True)  # type: ignore[arg-type]
+
+
+# ─── Deprecated pl.split(slot_num=...) spelling ──────────────────────────────
+
+
+def test_split_slot_num_emits_deprecation_warning():
+    """The old carrier still parses, but warns and points at the new entry."""
+    with pytest.warns(DeprecationWarning, match="pl.cross_core_slot"):
+
+        @pl.function
+        def f(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            with pl.at(
+                level=pl.Level.CORE_GROUP,
+                optimizations=[pl.split(pl.SplitMode.UP_DOWN, slot_num=4)],
+            ):
+                y = pl.add(x, x)
+            return y
+
+    scope = _find_scope_stmt(f.body)
+    assert scope is not None
+    assert scope.attrs.get("slot_num") == 4
+    assert cast(_HasSplit, scope).split == ir.SplitMode.UP_DOWN
+
+
+def test_split_slot_num_factory_emits_deprecation_warning():
+    """The runtime factory warns on the same deprecated argument."""
+    with pytest.warns(DeprecationWarning, match="pl.cross_core_slot"):
+        entry = pl.split(pl.SplitMode.UP_DOWN, slot_num=4)
+    assert entry.slot_num == 4
+
+
+def test_split_without_slot_num_emits_no_warning():
+    """Only the slot_num= argument is deprecated, not pl.split itself."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+
+        @pl.function
+        def f(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.split(pl.SplitMode.UP_DOWN)]):
+                y = pl.add(x, x)
+            return y
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/ir/transforms/test_outline_incore_scopes.py
+++ b/tests/ut/ir/transforms/test_outline_incore_scopes.py
@@ -1506,6 +1506,83 @@ class TestOutlineNoDepArgs:
             with pytest.raises(ValueError, match="mutually exclusive"):
                 passes.outline_incore_scopes()(ssa)
 
+    def test_function_split_none_with_split_aiv_region_rejected(self):
+        """``optimizations=[pl.split(pl.SplitMode.NONE)]`` on a scope holding
+        pl.split_aiv region(s) is rejected too (RFC #1820).
+
+        NONE carries no split of its own, so this combination used to be
+        exempted — but writing it still reads as "auto and manual split mixed on
+        one scope". The exemption existed only because the cross-core slot count
+        had no carrier other than ``pl.split(..., slot_num=N)``; it now has one
+        (see test_cross_core_slot_with_split_aiv_region_accepted), so the
+        exemption is gone."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                a: pl.Tensor[[512, 128], pl.FP32],
+                out: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
+            ) -> pl.Tensor[[512, 128], pl.FP32]:
+                with pl.at(
+                    level=pl.Level.CORE_GROUP,
+                    name_hint="k",
+                    optimizations=[pl.split(pl.SplitMode.NONE)],
+                ):
+                    for aiv_id in pl.split_aiv(2, mode=pl.SplitMode.UP_DOWN):
+                        offset = aiv_id * 128
+                        t: pl.Tile[[128, 128], pl.FP32] = pl.load(a, [offset, 0], [128, 128])
+                        out = pl.store(t, [offset, 0], out)
+                return out
+
+        with passes.PassContext([]):
+            ssa = passes.convert_to_ssa()(Before)
+            with pytest.raises(ValueError, match="mutually exclusive"):
+                passes.outline_incore_scopes()(ssa)
+
+    def test_cross_core_slot_with_split_aiv_region_accepted(self):
+        """``optimizations=[pl.cross_core_slot(slot_num=N)]`` coexists with
+        pl.split_aiv region(s): sizing the cross-core ring is orthogonal to
+        partitioning work across the AIV lanes.
+
+        This is the migration path off the rejected
+        ``pl.split(pl.SplitMode.NONE, slot_num=N)`` idiom — the outlined function
+        carries both the slot count and the region-derived split_aiv marker."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                a: pl.Tensor[[512, 128], pl.FP32],
+                out: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
+            ) -> pl.Tensor[[512, 128], pl.FP32]:
+                with pl.at(
+                    level=pl.Level.CORE_GROUP,
+                    name_hint="k",
+                    optimizations=[pl.cross_core_slot(slot_num=4)],
+                ):
+                    for aiv_id in pl.split_aiv(2, mode=pl.SplitMode.UP_DOWN):
+                        offset = aiv_id * 128
+                        t: pl.Tile[[128, 128], pl.FP32] = pl.load(a, [offset, 0], [128, 128])
+                        out = pl.store(t, [offset, 0], out)
+                return out
+
+        # BEFORE_AND_AFTER rather than the default roundtrip level: the python
+        # printer does not emit the InCoreScopeStmt `split_aiv` marker, so a
+        # print->parse roundtrip of a split_aiv program spuriously fails — same
+        # caveat as test_outline_propagates_split_aiv_attr.
+        with passes.PassContext([passes.VerificationInstrument(passes.VerificationMode.BEFORE_AND_AFTER)]):
+            ssa = passes.convert_to_ssa()(Before)
+            After = passes.outline_incore_scopes()(ssa)
+
+        outlined = next(f for gv, f in After.functions.items() if f.func_type == ir.FunctionType.InCore)
+        assert outlined.attrs["slot_num"] == 4
+        assert outlined.attrs["split_aiv"] is True
+        # The region's mode is still bridged to a function-level representative.
+        assert outlined.attrs["split"] == pl.SplitMode.UP_DOWN.value
+
     def test_outline_multi_mode_regions_omits_func_split(self):
         """Two sibling pl.split_aiv regions with DIFFERING modes (UP_DOWN +
         LEFT_RIGHT) in one CORE_GROUP scope: the outlined function gets

--- a/tests/ut/language/parser/test_scope_parsing.py
+++ b/tests/ut/language/parser/test_scope_parsing.py
@@ -1006,6 +1006,85 @@ class TestSpmdOptimizations:
         incore = self._unique_descendant(spmd.body, ir.InCoreScopeStmt)
         assert incore.split == ir.SplitMode.UP_DOWN
 
+    def test_with_spmd_cross_core_slot_alone_wraps_call_in_incore(self):
+        """``with pl.spmd(N, optimizations=[pl.cross_core_slot(slot_num=N)]):``
+        wraps the single call in an ``InCoreScopeStmt`` carrying ``slot_num``.
+
+        Regression: the wrapper-less direct-dispatch fast path keys on "no split
+        mode". The slot count lands on the *InCore* scope (OutlineIncoreScopes
+        reads ``slot_num`` off ``InCoreScopeStmt`` only), so a slot-count-only
+        scope must still get the wrapper or the value is silently discarded and
+        the kernel falls back to the default ring depth.
+        """
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                a: pl.Tensor[[512, 128], pl.FP32],
+                out: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
+            ) -> pl.Tensor[[512, 128], pl.FP32]:
+                with pl.at(level=pl.Level.CORE_GROUP):
+                    out = pl.add(a, a)
+                return out
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                a: pl.Tensor[[512, 128], pl.FP32],
+                out: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
+            ) -> pl.Tensor[[512, 128], pl.FP32]:
+                with pl.spmd(4, optimizations=[pl.cross_core_slot(slot_num=4)]):
+                    out = self.kernel(a, out)
+                return out
+
+        main_func = list(Prog.functions.values())[-1]
+        spmd = self._unique_descendant(main_func.body, ir.SpmdScopeStmt)
+        incore = self._unique_descendant(spmd.body, ir.InCoreScopeStmt)
+        assert incore.split is None
+        assert incore.attrs.get("slot_num") == 4
+        # No round-trip assertion here: the plain with-form's printer emits the
+        # wrapper as a nested `with pl.at(...)`, which no longer reparses as a
+        # single call. That gap is pre-existing and identical for
+        # optimizations=[pl.split(MODE)] (see
+        # test_with_spmd_split_wraps_call_in_incore, which likewise asserts only
+        # the IR shape). The `as tid` form does round-trip — covered below.
+
+    def test_with_spmd_as_tid_cross_core_slot_alone_wraps_call_in_incore(self):
+        """Same regression on the ``as tid`` with-form, which shares
+        ``_emit_spmd_body``'s dispatch."""
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                a: pl.Tensor[[512, 128], pl.FP32],
+                out: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
+            ) -> pl.Tensor[[512, 128], pl.FP32]:
+                with pl.at(level=pl.Level.CORE_GROUP):
+                    out = pl.add(a, a)
+                return out
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                a: pl.Tensor[[512, 128], pl.FP32],
+                out: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
+            ) -> pl.Tensor[[512, 128], pl.FP32]:
+                with pl.spmd(4, optimizations=[pl.cross_core_slot(slot_num=8)]) as tid:
+                    out = self.kernel(a, out)
+                return out
+
+        main_func = list(Prog.functions.values())[-1]
+        spmd = self._unique_descendant(main_func.body, ir.SpmdScopeStmt)
+        incore = self._unique_descendant(spmd.body, ir.InCoreScopeStmt)
+        assert incore.attrs.get("slot_num") == 8
+        printed = Prog.as_python()
+        assert "optimizations=[pl.cross_core_slot(slot_num=8)]" in printed
+        assert Prog.as_python() == parse_program(printed).as_python()
+
     def test_with_spmd_split_splits_name_hint(self):
         """``with pl.spmd(..., name_hint=, optimizations=[pl.split]):`` routes hints like for-form."""
 

--- a/tests/ut/language/parser/test_scope_parsing.py
+++ b/tests/ut/language/parser/test_scope_parsing.py
@@ -745,9 +745,9 @@ class TestSpmdOptimizations:
         incore = self._unique_descendant(spmd.body, ir.InCoreScopeStmt)
         assert incore.split is None
 
-    def test_for_spmd_split_slot_num_sets_scope_attr(self):
-        """``pl.split(mode, slot_num=N)`` records ``slot_num`` on the inner
-        ``InCoreScopeStmt`` attrs alongside the split mode."""
+    def test_for_spmd_cross_core_slot_sets_scope_attr(self):
+        """``pl.cross_core_slot(slot_num=N)`` records ``slot_num`` on the inner
+        ``InCoreScopeStmt`` attrs alongside an independent split mode."""
 
         @pl.program
         class Prog:
@@ -757,7 +757,13 @@ class TestSpmdOptimizations:
                 a: pl.Tensor[[512, 128], pl.FP32],
                 out: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
             ) -> pl.Tensor[[512, 128], pl.FP32]:
-                for i in pl.spmd(4, optimizations=[pl.split(pl.SplitMode.UP_DOWN, slot_num=16)]):
+                for i in pl.spmd(
+                    4,
+                    optimizations=[
+                        pl.split(pl.SplitMode.UP_DOWN),
+                        pl.cross_core_slot(slot_num=16),
+                    ],
+                ):
                     offset = i * 128
                     t: pl.Tile[[128, 128], pl.FP32] = pl.load(a, [offset, 0], [128, 128])
                     out = pl.store(t, [offset, 0], out)
@@ -769,8 +775,12 @@ class TestSpmdOptimizations:
         assert incore.split == ir.SplitMode.UP_DOWN
         assert incore.attrs.get("slot_num") == 16
 
-    def test_for_spmd_split_slot_num_roundtrips(self):
-        """``slot_num`` survives a print -> reparse cycle on the for-spmd form."""
+    def test_for_spmd_cross_core_slot_roundtrips(self):
+        """``slot_num`` survives a print -> reparse cycle on the for-spmd form.
+
+        The two entries print as independent list elements, so the split mode
+        and the slot count each round-trip on their own.
+        """
 
         @pl.program
         class Prog:
@@ -780,20 +790,29 @@ class TestSpmdOptimizations:
                 a: pl.Tensor[[512, 128], pl.FP32],
                 out: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
             ) -> pl.Tensor[[512, 128], pl.FP32]:
-                for i in pl.spmd(4, optimizations=[pl.split(pl.SplitMode.LEFT_RIGHT, slot_num=12)]):
+                for i in pl.spmd(
+                    4,
+                    optimizations=[
+                        pl.split(pl.SplitMode.LEFT_RIGHT),
+                        pl.cross_core_slot(slot_num=12),
+                    ],
+                ):
                     offset = i * 128
                     t: pl.Tile[[128, 128], pl.FP32] = pl.load(a, [offset, 0], [128, 128])
                     out = pl.store(t, [offset, 0], out)
                 return out
 
         printed = Prog.as_python()
-        assert "slot_num=12" in printed
+        assert "optimizations=[pl.split(pl.SplitMode.LEFT_RIGHT), pl.cross_core_slot(slot_num=12)]" in printed
         assert Prog.as_python() == parse_program(printed).as_python()
 
-    def test_for_spmd_split_none_slot_num_roundtrips(self):
-        """``slot_num`` is valid with ``SplitMode.NONE`` on the for-spmd form and
-        survives a print -> reparse cycle (NONE mixed kernel still drives a
-        cube->vector pipe)."""
+    def test_for_spmd_cross_core_slot_alone_roundtrips(self):
+        """A bare slot count needs no split mode at all on the for-spmd form.
+
+        The printer emits only the ``pl.cross_core_slot`` entry — it must not
+        fabricate a ``pl.split(pl.SplitMode.NONE)``, which ``OutlineIncoreScopes``
+        rejects on a scope holding ``pl.split_aiv`` regions.
+        """
 
         @pl.program
         class Prog:
@@ -803,7 +822,7 @@ class TestSpmdOptimizations:
                 a: pl.Tensor[[512, 128], pl.FP32],
                 out: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
             ) -> pl.Tensor[[512, 128], pl.FP32]:
-                for i in pl.spmd(4, optimizations=[pl.split(pl.SplitMode.NONE, slot_num=8)]):
+                for i in pl.spmd(4, optimizations=[pl.cross_core_slot(slot_num=8)]):
                     offset = i * 128
                     t: pl.Tile[[128, 128], pl.FP32] = pl.load(a, [offset, 0], [128, 128])
                     out = pl.store(t, [offset, 0], out)
@@ -812,13 +831,48 @@ class TestSpmdOptimizations:
         main_func = list(Prog.functions.values())[0]
         spmd = self._unique_descendant(main_func.body, ir.SpmdScopeStmt)
         incore = self._unique_descendant(spmd.body, ir.InCoreScopeStmt)
+        assert incore.split is None
+        assert incore.attrs.get("slot_num") == 8
+        printed = Prog.as_python()
+        assert "optimizations=[pl.cross_core_slot(slot_num=8)]" in printed
+        assert "pl.split" not in printed
+        assert Prog.as_python() == parse_program(printed).as_python()
+
+    def test_deprecated_split_slot_num_prints_as_cross_core_slot(self):
+        """The deprecated ``pl.split(mode, slot_num=N)`` spelling still parses,
+        warns, and normalises to the dedicated entry when printed back.
+
+        With ``SplitMode.NONE`` the mode carries no information, so the printed
+        form drops it entirely and keeps only the slot count.
+        """
+        with pytest.warns(DeprecationWarning, match="pl.cross_core_slot"):
+
+            @pl.program
+            class Prog:
+                @pl.function(type=pl.FunctionType.Orchestration)
+                def main(
+                    self,
+                    a: pl.Tensor[[512, 128], pl.FP32],
+                    out: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
+                ) -> pl.Tensor[[512, 128], pl.FP32]:
+                    for i in pl.spmd(4, optimizations=[pl.split(pl.SplitMode.NONE, slot_num=8)]):
+                        offset = i * 128
+                        t: pl.Tile[[128, 128], pl.FP32] = pl.load(a, [offset, 0], [128, 128])
+                        out = pl.store(t, [offset, 0], out)
+                    return out
+
+        main_func = list(Prog.functions.values())[0]
+        spmd = self._unique_descendant(main_func.body, ir.SpmdScopeStmt)
+        incore = self._unique_descendant(spmd.body, ir.InCoreScopeStmt)
         assert incore.split == ir.SplitMode.NONE
         assert incore.attrs.get("slot_num") == 8
         printed = Prog.as_python()
-        assert "pl.split(pl.SplitMode.NONE, slot_num=8)" in printed
-        assert Prog.as_python() == parse_program(printed).as_python()
+        assert "optimizations=[pl.cross_core_slot(slot_num=8)]" in printed
+        assert "pl.split" not in printed
+        # Reparsing the normalised form is a fixpoint (split_ settles to None).
+        assert parse_program(printed).as_python() == printed
 
-    def test_at_incore_split_slot_num_roundtrips(self):
+    def test_at_incore_cross_core_slot_roundtrips(self):
         """``slot_num`` survives a print -> reparse cycle on the pl.at form."""
 
         @pl.program
@@ -827,23 +881,29 @@ class TestSpmdOptimizations:
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
                 with pl.at(
                     level=pl.Level.CORE_GROUP,
-                    optimizations=[pl.split(pl.SplitMode.UP_DOWN, slot_num=16)],
+                    optimizations=[
+                        pl.split(pl.SplitMode.UP_DOWN),
+                        pl.cross_core_slot(slot_num=16),
+                    ],
                 ):
                     y: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
                 return y
 
         main_func = list(Prog.functions.values())[0]
         incore = self._unique_descendant(main_func.body, ir.InCoreScopeStmt)
+        assert incore.split == ir.SplitMode.UP_DOWN
         assert incore.attrs.get("slot_num") == 16
         printed = Prog.as_python()
-        assert "slot_num=16" in printed
+        assert "optimizations=[pl.split(pl.SplitMode.UP_DOWN), pl.cross_core_slot(slot_num=16)]" in printed
         assert Prog.as_python() == parse_program(printed).as_python()
 
-    def test_split_slot_num_allowed_with_none_mode(self):
-        """``slot_num`` is valid with ``SplitMode.NONE``: a NONE mixed kernel
-        still drives a cube->vector pipe (a2a3 dual-AIV dispatch), so the
-        scope records ``slot_num`` alongside ``split=SplitMode.NONE`` and the
-        attr survives a print -> reparse cycle."""
+    def test_at_incore_cross_core_slot_alone_roundtrips(self):
+        """A bare slot count on the pl.at form needs no split mode.
+
+        This is the shape a manual ``pl.split_aiv`` kernel uses to pin a custom
+        ring depth without tripping the mutual-exclusion guard in
+        ``OutlineIncoreScopes``.
+        """
 
         @pl.program
         class Prog:
@@ -851,21 +911,40 @@ class TestSpmdOptimizations:
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
                 with pl.at(
                     level=pl.Level.CORE_GROUP,
-                    optimizations=[pl.split(pl.SplitMode.NONE, slot_num=8)],
+                    optimizations=[pl.cross_core_slot(slot_num=8)],
                 ):
                     y: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
                 return y
 
         main_func = list(Prog.functions.values())[0]
         incore = self._unique_descendant(main_func.body, ir.InCoreScopeStmt)
-        assert incore.split == ir.SplitMode.NONE
+        assert incore.split is None
         assert incore.attrs.get("slot_num") == 8
         printed = Prog.as_python()
-        assert "slot_num=8" in printed
+        assert "optimizations=[pl.cross_core_slot(slot_num=8)]" in printed
+        assert "pl.split" not in printed
         assert Prog.as_python() == parse_program(printed).as_python()
 
-    def test_split_slot_num_must_be_positive(self):
+    def test_cross_core_slot_must_be_positive(self):
         """A non-positive ``slot_num`` literal is rejected."""
+        src = (
+            "import pypto.language as pl\n\n"
+            "@pl.program\n"
+            "class P:\n"
+            "    @pl.function\n"
+            "    def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:\n"
+            "        with pl.at(level=pl.Level.CORE_GROUP, "
+            "optimizations=[pl.cross_core_slot(slot_num=0)]):\n"
+            "            y: pl.Tensor[[64], pl.FP32] = pl.add(x, x)\n"
+            "        return y\n"
+        )
+        with pytest.raises(ParserSyntaxError, match="must be positive"):
+            parse_program(src)
+
+    def test_split_slot_num_must_be_positive(self):
+        """A non-positive ``slot_num`` literal is rejected on the deprecated
+        ``pl.split(slot_num=)`` spelling too — validation runs before the
+        deprecation warning, so the error wins."""
         src = (
             "import pypto.language as pl\n\n"
             "@pl.program\n"


### PR DESCRIPTION
Fixes #2118

## Problem

A CORE_GROUP scope could carry **both** AIV-split annotations at once — a function-level `optimizations=[pl.split(...)]` *and* a `pl.split_aiv(...)` region — whenever the function-level mode was `SplitMode.NONE`. The guard in `OutlineIncoreScopes` already called the two "mutually exclusive AIV-split mechanisms", but its predicate exempted `None`, making it weaker than RFC #1820 (which specifies rejecting *any* co-occurring `pl.split(...)`).

The exemption existed because the cross-core slot count had **no carrier of its own**. `Split` was the only `Optimization` subclass, so pinning a non-default ring depth forced authors to name a split mode they did not want:

```python
optimizations=[pl.split(pl.SplitMode.NONE, slot_num=4)]   # NONE is vestigial
```

## Fix

Give the slot count its own orthogonal entry, then drop the exemption.

```python
# before — mode is vestigial, reads as auto+manual split mixed on one scope
optimizations=[pl.split(pl.SplitMode.NONE, slot_num=4)]

# after — unambiguously just pipe sizing
optimizations=[pl.cross_core_slot(slot_num=4)]
```

The three annotations now read distinctly:

| Annotation | Meaning |
| ---------- | ------- |
| `optimizations=[pl.split(MODE)]` | AUTO split — the compiler partitions the vector work |
| `for aiv_id in pl.split_aiv(2, mode=...)` | Manual split — the author partitions it per region |
| `optimizations=[pl.cross_core_slot(slot_num=N)]` | Neither — just sizes the cross-core pipe |

No IR change was needed: `slot_num` already rides as a scope attr on `InCoreScopeStmt` independently of `split_`; only the frontend forced it to be reached through a `SplitMode`.

## Naming

Named `cross_core_slot`, **not** the issue's proposed `c2v_ring`. One `slot_num` sizes the ring in whichever directions the kernel uses — `BuildDirMask` (`cross_core_pipe.cpp:119`) sets c2v and/or v2c from the ops actually present, and the same `buffer_size` feeds both reserves — so a c2v-specific name is wrong outright for a v2c-only kernel and half-right for a bidirectional one. "slot" is the established noun here (`slot_size` / `slot_num` / `local_slot_num`, `*_slot_buffer`).

The kwarg stays `slot_num=` to match `pl.aic_initialize_pipe(..., slot_num=16)`, the scope/function attrs, and the emitted PTO attr — one name across the whole chain.

## Backward compatibility

`pl.split(mode, slot_num=N)` keeps working as an alias and now emits a `DeprecationWarning` from both the runtime factory and the AST parser. A list that sets the slot count twice (deprecated spelling *and* the new entry) is rejected rather than resolved by entry order.

## Printer

The printer previously fabricated `pl.split(pl.SplitMode.NONE, slot_num=N)` whenever a scope carried a slot count but no real mode — exactly the combination the tightened guard rejects. It now emits the two as independent list entries, so a bare slot count round-trips without inventing a split mode:

```python
optimizations=[pl.split(pl.SplitMode.UP_DOWN), pl.cross_core_slot(slot_num=12)]
```

The CORE_GROUP-only check also grew to cover a slot count arriving without a split mode — newly reachable via the dedicated entry, and it would otherwise attach a dead attr to a Hierarchy scope.

## Tests

- `tests/ut/ir/parser/test_at_optimizations.py` — 14 new tests: the new entry alone and combined with `pl.split`, duplicate/conflict rejection, keyword and literal validation, CORE_GROUP guard, fully-qualified form, deprecation warnings from both the parser and the factory.
- `tests/ut/ir/transforms/test_outline_incore_scopes.py` — `pl.split(NONE)` + a region is now rejected; `pl.cross_core_slot(...)` + a region outlines cleanly carrying both `slot_num` and `split_aiv` (the issue's DeepSeek-V4 shape, and the migration path).
- `tests/ut/language/parser/test_scope_parsing.py` — existing `slot_num` tests migrated to the new entry, plus a test that the deprecated spelling normalises to it on print.

One test expectation changed deliberately: `test_for_spmd_split_none_slot_num_roundtrips` asserted the literal string `"pl.split(pl.SplitMode.NONE, slot_num=8)"` in the printed output — that exact form is what this change removes.

## Verification

- `tests/ut/`: **7723 passed, 2 skipped**
- All pre-commit hooks pass (clang-format, cpplint, markdownlint, ruff, pyright, EN/zh-CN doc parity)
- End-to-end: the issue's shape with `pl.cross_core_slot(slot_num=4)` + `pl.split_aiv(2, mode=UP_DOWN)` outlines with `slot_num=4` / `split_aiv=True`; the `pl.split(NONE, slot_num=4)` variant raises the mutual-exclusion error, which names `pl.cross_core_slot` as the migration path.

## Docs

Updated in EN and zh-CN: passes `08-outline_incore_scopes`, `18-lower_auto_vector_split`, `19-expand_mixed_kernel`, plus `00-python_syntax.md` and the user language guide.
