### PR TITLE
feat(ir): Add valid_shape operand to gather_row for dynamic row counts

### DIFF
--- a/docs/en/dev/passes/10-convert_tensor_to_tile_ops.md
+++ b/docs/en/dev/passes/10-convert_tensor_to_tile_ops.md
@@ -166,9 +166,23 @@ Only the small index / page-table metadata is scalar-read from GM; the bulk KV d
 | Op | Lowers to | Role |
 | -- | --------- | ---- |
 | `tensor.create_l1(shape, dtype, transpose=...)` | `tile.create(target_memory=Mat, transpose=...)` | seed the loop-carried L1 accumulator |
-| `tensor.gather_row(acc, src, dst_off, src_off, shapes, transpose=...)` | `tile.gather_row` (DPS) | DMA one **caller-addressed** GM row into `acc` |
+| `tensor.gather_row(acc, src, dst_off, src_off, shapes, valid_shape=..., transpose=...)` | `tile.gather_row` (DPS) | DMA one **caller-addressed** GM row into `acc` |
 
 Both deduce a `TensorType`, so the gathered result composes with tensor-level `tensor.matmul` / softmax; both are registered self-loading (`src` stays GM). The caller computes `src_off` and the `dst_off` slot, then fills the accumulator row by row in its own loop.
+
+**Dynamic transfer length (`valid_shape`).** `shapes` must stay compile-time constant: it becomes `pto.subview`'s `sizes`, which the PTO dialect types as a static `I64ArrayAttr` (`SubViewOp` in `PTOOps.td`). The optional `valid_shape` carries the *runtime* extent instead — it feeds the subview's `valid_row` / `valid_col`, declared `Optional<Index>` SSA operands, and the GM `pto.partition_view` sizes, which accept a dynamic `?` dim. So a dynamic row count changes neither the allocation nor the box alignment below: the sub-region stays statically `shapes`-sized and only the copy length varies. Omitting `valid_shape` transfers the whole window, which is the pre-existing behaviour.
+
+This turns a run of consecutive rows whose length is only known at runtime into one call instead of a guarded per-row loop:
+
+```python
+kv = pl.create_l1([128, HEAD_DIM], pl.BF16)
+# r1 is a runtime Scalar[INDEX] — e.g. a page-boundary split point
+kv = pl.gather_row(kv, pool, [0, 0],  [b0, 0], [128, HEAD_DIM], valid_shape=[r1, HEAD_DIM])
+kv = pl.gather_row(kv, pool, [r1, 0], [b1, 0], [128, HEAD_DIM], valid_shape=[128 - r1, HEAD_DIM])
+oi = pl.matmul(q, kv, b_trans=True)
+```
+
+`valid_shape` is a positional operand rather than an attr precisely because it may be a runtime value: it has to stay in the use-def chain so SSA/liveness keep the scalar alive. It is rejected together with `transpose=True` (see below) — that path would need a runtime *column* extent on a boxed NZ tile, which is unverified on device. The deducer rejects any *provable* violation of `0 <= valid_shape[i] <= shapes[i]`; a symbolic extent it cannot decide is accepted, which is the case the operand exists for.
 
 **Transpose (ZN) for a `b_trans` matmul operand.** `transpose=True` makes the gathered tile a transposed matmul B-operand without a GM round-trip:
 

--- a/docs/en/dev/passes/10-convert_tensor_to_tile_ops.md
+++ b/docs/en/dev/passes/10-convert_tensor_to_tile_ops.md
@@ -182,7 +182,9 @@ kv = pl.gather_row(kv, pool, [r1, 0], [b1, 0], [128, HEAD_DIM], valid_shape=[128
 oi = pl.matmul(q, kv, b_trans=True)
 ```
 
-`valid_shape` is a positional operand rather than an attr precisely because it may be a runtime value: it has to stay in the use-def chain so SSA/liveness keep the scalar alive. It is rejected together with `transpose=True` (see below) — that path would need a runtime *column* extent on a boxed NZ tile, which is unverified on device. The deducer rejects any *provable* violation of `0 <= valid_shape[i] <= shapes[i]`; a symbolic extent it cannot decide is accepted, which is the case the operand exists for.
+**Bounds are on the written region, not the window.** `shapes` sizes the static `pto.subview`, so with a runtime `dst_offset` the declared window may reach past the destination — in the example above run 2 declares rows `[r1, r1 + 128)` on a 128-row tile. That is sound only because the transfer is bounded by `valid_shape`, not by `shapes`: the rows actually written are `[r1, r1 + (128 - r1))`, which stay inside. The caller's obligation is therefore `dst_offset + valid_shape <= dst.shape` per dimension; `dst_offset + shapes` need not fit. The two-run form above is covered on device by `test_gather_row_two_run_split`.
+
+`valid_shape` is keyword-only in the DSL — `transpose` already owned the sixth positional slot, and taking it would silently reinterpret an existing `gather_row(..., shapes, True)` call. At the IR level it is a positional operand rather than an attr precisely because it may be a runtime value: it has to stay in the use-def chain so SSA/liveness keep the scalar alive. It is rejected together with `transpose=True` (see below) — that path would need a runtime *column* extent on a boxed NZ tile, which is unverified on device. The deducer rejects any *provable* violation of `0 <= valid_shape[i] <= shapes[i]`; a symbolic extent it cannot decide is accepted, which is the case the operand exists for.
 
 **Transpose (ZN) for a `b_trans` matmul operand.** `transpose=True` makes the gathered tile a transposed matmul B-operand without a GM round-trip:
 

--- a/docs/zh-cn/dev/passes/10-convert_tensor_to_tile_ops.md
+++ b/docs/zh-cn/dev/passes/10-convert_tensor_to_tile_ops.md
@@ -173,7 +173,9 @@ kv = pl.gather_row(kv, pool, [r1, 0], [b1, 0], [128, HEAD_DIM], valid_shape=[128
 oi = pl.matmul(q, kv, b_trans=True)
 ```
 
-`valid_shape` 之所以是位置操作数而非 attr，正是因为它可能是运行期值：它必须留在 use-def 链上，SSA / 活跃性分析才会保住这个标量。它与 `transpose=True` 互斥（见下文）——那条路径需要在 boxed NZ tile 上给出运行期*列*范围，尚未在设备上验证。类型推导会拒绝任何*可证明*违反 `0 <= valid_shape[i] <= shapes[i]` 的情形；无法判定的符号范围则予以接受，而这正是该操作数存在的意义。
+**边界约束的是被写区域，而非窗口。** `shapes` 决定静态 `pto.subview` 的尺寸，因此当 `dst_offset` 为运行期值时，声明出的窗口可能越过目标末尾——上例中 run 2 在 128 行的 tile 上声明了 `[r1, r1 + 128)`。这之所以成立，是因为传输长度由 `valid_shape` 而非 `shapes` 界定：实际写入的行是 `[r1, r1 + (128 - r1))`，仍在范围内。因此调用方的义务是逐维满足 `dst_offset + valid_shape <= dst.shape`，而 `dst_offset + shapes` 无需成立。上述两段式写法已由 `test_gather_row_two_run_split` 在设备上覆盖。
+
+`valid_shape` 在 DSL 中是仅关键字参数——第 6 个位置参数早已属于 `transpose`，占用它会静默改变既有 `gather_row(..., shapes, True)` 调用的含义。在 IR 层它是位置操作数而非 attr，正是因为它可能是运行期值：它必须留在 use-def 链上，SSA / 活跃性分析才会保住这个标量。它与 `transpose=True` 互斥（见下文）——那条路径需要在 boxed NZ tile 上给出运行期*列*范围，尚未在设备上验证。类型推导会拒绝任何*可证明*违反 `0 <= valid_shape[i] <= shapes[i]` 的情形；无法判定的符号范围则予以接受，而这正是该操作数存在的意义。
 
 **转置（ZN）以构造 `b_trans` matmul 操作数。** `transpose=True` 让聚合后的 tile 直接成为转置的 matmul B 操作数，无需 GM 往返：
 

--- a/docs/zh-cn/dev/passes/10-convert_tensor_to_tile_ops.md
+++ b/docs/zh-cn/dev/passes/10-convert_tensor_to_tile_ops.md
@@ -157,9 +157,23 @@ for i in [0, rows):                                    # ForStmt，iter_arg = ac
 | 算子 | 下降到 | 作用 |
 | ---- | ------ | ---- |
 | `tensor.create_l1(shape, dtype, transpose=...)` | `tile.create(target_memory=Mat, transpose=...)` | 初始化循环携带的 L1 累加器 |
-| `tensor.gather_row(acc, src, dst_off, src_off, shapes, transpose=...)` | `tile.gather_row`（DPS） | 把一条**调用方寻址**的 GM 行 DMA 进 `acc` |
+| `tensor.gather_row(acc, src, dst_off, src_off, shapes, valid_shape=..., transpose=...)` | `tile.gather_row`（DPS） | 把一条**调用方寻址**的 GM 行 DMA 进 `acc` |
 
 两者都推导出 `TensorType`，因此聚合结果可与张量级 `tensor.matmul` / softmax 组合；两者都注册为 self-loading（`src` 保持为 GM）。调用方自行计算 `src_off` 与 `dst_off` 槽位，在自己的循环里逐行填充累加器。
+
+**动态传输长度（`valid_shape`）。** `shapes` 必须是编译期常量：它会成为 `pto.subview` 的 `sizes`，而 PTO 方言把该字段定义为静态的 `I64ArrayAttr`（`PTOOps.td` 中的 `SubViewOp`）。可选的 `valid_shape` 承载*运行期*范围——它填入 subview 的 `valid_row` / `valid_col`（声明为 `Optional<Index>` SSA 操作数），以及 GM 侧 `pto.partition_view` 的 sizes（接受动态 `?` 维）。因此动态行数既不改变内存分配，也不影响下文的 box 对齐：子区域仍然按 `shapes` 静态定尺寸，只有拷贝长度可变。省略 `valid_shape` 即传输整个窗口，与既有行为一致。
+
+这样一来，长度只有运行期才知道的连续行区间只需一次调用，而不必写成带条件的逐行循环：
+
+```python
+kv = pl.create_l1([128, HEAD_DIM], pl.BF16)
+# r1 是运行期 Scalar[INDEX]——例如页边界的切分点
+kv = pl.gather_row(kv, pool, [0, 0],  [b0, 0], [128, HEAD_DIM], valid_shape=[r1, HEAD_DIM])
+kv = pl.gather_row(kv, pool, [r1, 0], [b1, 0], [128, HEAD_DIM], valid_shape=[128 - r1, HEAD_DIM])
+oi = pl.matmul(q, kv, b_trans=True)
+```
+
+`valid_shape` 之所以是位置操作数而非 attr，正是因为它可能是运行期值：它必须留在 use-def 链上，SSA / 活跃性分析才会保住这个标量。它与 `transpose=True` 互斥（见下文）——那条路径需要在 boxed NZ tile 上给出运行期*列*范围，尚未在设备上验证。类型推导会拒绝任何*可证明*违反 `0 <= valid_shape[i] <= shapes[i]` 的情形；无法判定的符号范围则予以接受，而这正是该操作数存在的意义。
 
 **转置（ZN）以构造 `b_trans` matmul 操作数。** `transpose=True` 让聚合后的 tile 直接成为转置的 matmul B 操作数，无需 GM 往返：
 

--- a/include/pypto/ir/type_inference.h
+++ b/include/pypto/ir/type_inference.h
@@ -21,6 +21,7 @@
 #ifndef PYPTO_IR_TYPE_INFERENCE_H_
 #define PYPTO_IR_TYPE_INFERENCE_H_
 
+#include <any>
 #include <cstddef>
 #include <cstdint>
 #include <memory>
@@ -223,6 +224,37 @@ struct ValidShapeBoundsError {
 std::vector<ValidShapeBoundsError> ValidateValidShapeBounds(const std::vector<ExprPtr>& valid,
                                                             const std::vector<ExprPtr>& physical,
                                                             const std::string& type_kind);
+
+/**
+ * @brief Validate the operand contract of ``tile.gather_row`` / ``tensor.gather_row``
+ *
+ * Shared by the two deducers (tile and tensor level) so the contract is stated
+ * once and the user hits it at trace time rather than in a pass or the backend.
+ * Enforces, for ``args = (dst, src, dst_offset, src_offset, shapes[, valid_shape])``:
+ *
+ * - every ``shapes`` element is a ``ConstInt`` — it sizes ``pto.subview``, whose
+ *   ``sizes`` ptoas types as a static ``I64ArrayAttr``, so a dynamic window is
+ *   not expressible at all;
+ * - ``valid_shape``, when present, matches ``shapes`` in rank and violates
+ *   ``0 <= valid_shape[i] <= shapes[i]`` in no *provable* way — a symbolic extent
+ *   that cannot be decided is accepted, since that dynamic case is the whole
+ *   point of the operand;
+ * - ``valid_shape`` is fully static when ``transpose=True``, because that path
+ *   lowers through a DN2NZ ``pto.tload`` that would need a runtime column extent
+ *   on a boxed NZ tile.
+ *
+ * Note the bounds check cannot be left to ``TypeChecker``'s
+ * ``ValidateValidShapeBounds`` sweep: gather_row's ``valid_shape`` narrows only
+ * the transfer and never reaches the result ``TileType``/``TensorType``, so the
+ * verifier has nothing to inspect.
+ *
+ * @param args Operand list, 5 or 6 entries
+ * @param kwargs Operator kwargs, read for ``transpose``
+ * @param op_name Operator name used in diagnostics
+ */
+void CheckGatherRowOperands(const std::vector<ExprPtr>& args,
+                            const std::vector<std::pair<std::string, std::any>>& kwargs,
+                            const std::string& op_name);
 
 /**
  * @brief Read the elements of a tuple-typed operand

--- a/python/pypto/ir/op/tensor_ops.py
+++ b/python/pypto/ir/op/tensor_ops.py
@@ -2188,6 +2188,7 @@ def gather_row(  # noqa: PLR0913
     dst_offset: Sequence[int | Expr] | _ir_core.MakeTuple,
     src_offset: Sequence[int | Expr] | _ir_core.MakeTuple,
     shapes: Sequence[int | Expr] | _ir_core.MakeTuple,
+    valid_shape: Sequence[int | Expr] | _ir_core.MakeTuple | None = None,
     transpose: bool = False,
     span: Span | None = None,
 ) -> Call:
@@ -2205,7 +2206,10 @@ def gather_row(  # noqa: PLR0913
         src: Source tensor in GM.
         dst_offset: ``[row, col]`` offset within ``acc``, or a MakeTuple.
         src_offset: ``[row, col]`` offset within the GM ``src``, or a MakeTuple.
-        shapes: GM row window shape ``[r, c]`` (typically ``[1, size]``), or a MakeTuple.
+        shapes: GM row window shape ``[r, c]``, or a MakeTuple. Must be
+            compile-time constant.
+        valid_shape: Runtime transfer extent within ``shapes``, or a MakeTuple.
+            May hold runtime ``Scalar[INDEX]`` values. Defaults to ``shapes``.
         transpose: Place the GM row ``[r, c]`` as an L1 column ``[c, r]`` (for a
             matmul B-operand the consumer reads with ``b_trans``).
         span: Optional source span (auto-captured if not provided).
@@ -2217,9 +2221,10 @@ def gather_row(  # noqa: PLR0913
     dst_off = _to_make_tuple(dst_offset, actual_span)
     src_off = _to_make_tuple(src_offset, actual_span)
     shapes_tuple = _to_make_tuple(shapes, actual_span)
-    return _ir_core.create_op_call(
-        "tensor.gather_row", [acc, src, dst_off, src_off, shapes_tuple], {"transpose": transpose}, actual_span
-    )
+    args: list[Any] = [acc, src, dst_off, src_off, shapes_tuple]
+    if valid_shape is not None:
+        args.append(_to_make_tuple(valid_shape, actual_span))
+    return _ir_core.create_op_call("tensor.gather_row", args, {"transpose": transpose}, actual_span)
 
 
 # ============================================================================

--- a/python/pypto/ir/op/tensor_ops.py
+++ b/python/pypto/ir/op/tensor_ops.py
@@ -2188,9 +2188,10 @@ def gather_row(  # noqa: PLR0913
     dst_offset: Sequence[int | Expr] | _ir_core.MakeTuple,
     src_offset: Sequence[int | Expr] | _ir_core.MakeTuple,
     shapes: Sequence[int | Expr] | _ir_core.MakeTuple,
-    valid_shape: Sequence[int | Expr] | _ir_core.MakeTuple | None = None,
     transpose: bool = False,
     span: Span | None = None,
+    *,
+    valid_shape: Sequence[int | Expr] | _ir_core.MakeTuple | None = None,
 ) -> Call:
     """Gather one GM row into a sub-region of an on-chip accumulator (tensor-level, DPS).
 

--- a/python/pypto/ir/op/tile_ops.py
+++ b/python/pypto/ir/op/tile_ops.py
@@ -291,12 +291,13 @@ def assemble(
     return _ir_core.create_op_call("tile.assemble", [target, source, offset_tuple], {}, actual_span)
 
 
-def gather_row(
+def gather_row(  # noqa: PLR0913
     dst: Expr,
     src: Expr,
     dst_offset: Sequence[int | Expr] | _ir_core.MakeTuple,
     src_offset: Sequence[int | Expr] | _ir_core.MakeTuple,
     shapes: Sequence[int | Expr] | _ir_core.MakeTuple,
+    valid_shape: Sequence[int | Expr] | _ir_core.MakeTuple | None = None,
     transpose: bool = False,
     span: Span | None = None,
 ) -> Call:
@@ -312,7 +313,10 @@ def gather_row(
         src: Source tensor in GM (TensorType).
         dst_offset: ``[row, col]`` offset within ``dst``, or a MakeTuple.
         src_offset: ``[row, col]`` offset within the GM ``src``, or a MakeTuple.
-        shapes: GM row window shape ``[r, c]``, or a MakeTuple.
+        shapes: GM row window shape ``[r, c]``, or a MakeTuple. Must be
+            compile-time constant.
+        valid_shape: Runtime transfer extent within ``shapes``, or a MakeTuple.
+            May hold runtime ``Scalar[INDEX]`` values. Defaults to ``shapes``.
         transpose: Place the GM row ``[r, c]`` as an L1 column ``[c, r]``.
         span: Optional source span for debugging (auto-captured if not provided).
 
@@ -323,9 +327,10 @@ def gather_row(
     dst_off = _to_make_tuple(dst_offset, actual_span)
     src_off = _to_make_tuple(src_offset, actual_span)
     shapes_tuple = _to_make_tuple(shapes, actual_span)
-    return _ir_core.create_op_call(
-        "tile.gather_row", [dst, src, dst_off, src_off, shapes_tuple], {"transpose": transpose}, actual_span
-    )
+    args: list[Any] = [dst, src, dst_off, src_off, shapes_tuple]
+    if valid_shape is not None:
+        args.append(_to_make_tuple(valid_shape, actual_span))
+    return _ir_core.create_op_call("tile.gather_row", args, {"transpose": transpose}, actual_span)
 
 
 def scatter_update(

--- a/python/pypto/ir/op/tile_ops.py
+++ b/python/pypto/ir/op/tile_ops.py
@@ -297,9 +297,10 @@ def gather_row(  # noqa: PLR0913
     dst_offset: Sequence[int | Expr] | _ir_core.MakeTuple,
     src_offset: Sequence[int | Expr] | _ir_core.MakeTuple,
     shapes: Sequence[int | Expr] | _ir_core.MakeTuple,
-    valid_shape: Sequence[int | Expr] | _ir_core.MakeTuple | None = None,
     transpose: bool = False,
     span: Span | None = None,
+    *,
+    valid_shape: Sequence[int | Expr] | _ir_core.MakeTuple | None = None,
 ) -> Call:
     """Load one GM row directly into a sub-region of an on-chip (Mat/Vec) tile.
 

--- a/python/pypto/language/op/tensor_ops.py
+++ b/python/pypto/language/op/tensor_ops.py
@@ -2039,12 +2039,13 @@ def create_l1(shape: Sequence[IntLike], dtype: DataType, transpose: bool = False
     return Tensor(expr=call_expr)
 
 
-def gather_row(
+def gather_row(  # noqa: PLR0913
     acc: Tensor,
     src: Tensor,
     dst_offset: Sequence[IntLike],
     src_offset: Sequence[IntLike],
     shapes: Sequence[IntLike],
+    valid_shape: Sequence[IntLike] | None = None,
     transpose: bool = False,
 ) -> Tensor:
     """Gather one GM row into a sub-region of an on-chip accumulator (DPS).
@@ -2062,11 +2063,17 @@ def gather_row(
         dst_offset: ``[row, col]`` slot within ``acc`` to write.
         src_offset: ``[row, col]`` physical offset within the GM ``src``.
         shapes: GM row window ``[r, c]`` (typically ``[1, size]``).
+            Must be compile-time constant.
+        valid_shape: How much of that window to actually transfer, defaulting to
+            all of it. May hold runtime ``Scalar`` values, so a dynamic row count
+            leaves the accumulator's allocation and layout untouched. Not
+            supported together with ``transpose=True``.
         transpose: Place the GM row ``[r, c]`` as an L1 column ``[c, r]`` — use
             for a matmul B-operand whose consumer would otherwise need ``b_trans``.
 
     Returns:
         Tensor aliasing ``acc`` (written in place).
+
     """
     call_expr = _ir_ops.gather_row(
         acc.unwrap(),
@@ -2074,6 +2081,7 @@ def gather_row(
         _normalize_intlike(dst_offset),
         _normalize_intlike(src_offset),
         _normalize_intlike(shapes),
+        _normalize_intlike(valid_shape) if valid_shape is not None else None,
         transpose,
     )
     return Tensor(expr=call_expr)

--- a/python/pypto/language/op/tensor_ops.py
+++ b/python/pypto/language/op/tensor_ops.py
@@ -2045,8 +2045,9 @@ def gather_row(  # noqa: PLR0913
     dst_offset: Sequence[IntLike],
     src_offset: Sequence[IntLike],
     shapes: Sequence[IntLike],
-    valid_shape: Sequence[IntLike] | None = None,
     transpose: bool = False,
+    *,
+    valid_shape: Sequence[IntLike] | None = None,
 ) -> Tensor:
     """Gather one GM row into a sub-region of an on-chip accumulator (DPS).
 
@@ -2081,8 +2082,8 @@ def gather_row(  # noqa: PLR0913
         _normalize_intlike(dst_offset),
         _normalize_intlike(src_offset),
         _normalize_intlike(shapes),
-        _normalize_intlike(valid_shape) if valid_shape is not None else None,
         transpose,
+        valid_shape=_normalize_intlike(valid_shape) if valid_shape is not None else None,
     )
     return Tensor(expr=call_expr)
 

--- a/python/pypto/language/op/tile_ops.py
+++ b/python/pypto/language/op/tile_ops.py
@@ -466,12 +466,13 @@ def assemble(target: Tile, source: Tile, offset: Sequence[IntLike]) -> Tile:
     return Tile(expr=call_expr)
 
 
-def gather_row(
+def gather_row(  # noqa: PLR0913
     dst: Tile,
     src: Tensor,
     dst_offset: Sequence[IntLike],
     src_offset: Sequence[IntLike],
     shapes: Sequence[IntLike],
+    valid_shape: Sequence[IntLike] | None = None,
     transpose: bool = False,
 ) -> Tile:
     """Load one GM row directly into a sub-region of an on-chip tile (DPS).
@@ -491,6 +492,11 @@ def gather_row(
         dst_offset: ``[row, col]`` slot within ``dst`` to write.
         src_offset: ``[row, col]`` physical offset within the GM ``src``.
         shapes: GM row window shape ``[r, c]`` (typically ``[1, size]``).
+            Must be compile-time constant.
+        valid_shape: How much of that window to actually transfer, defaulting to
+            all of it. May hold runtime ``Scalar`` values, so a dynamic row count
+            leaves the tile's allocation and layout untouched. Not supported
+            together with ``transpose=True``.
         transpose: Place the GM row ``[r, c]`` as an on-chip column ``[c, r]`` —
             fills a matmul ``b_trans`` B-operand without a GM round-trip
             (Mat/L1 only).
@@ -504,6 +510,7 @@ def gather_row(
         _normalize_intlike(dst_offset),
         _normalize_intlike(src_offset),
         _normalize_intlike(shapes),
+        _normalize_intlike(valid_shape) if valid_shape is not None else None,
         transpose,
     )
     return Tile(expr=call_expr)

--- a/python/pypto/language/op/tile_ops.py
+++ b/python/pypto/language/op/tile_ops.py
@@ -472,8 +472,9 @@ def gather_row(  # noqa: PLR0913
     dst_offset: Sequence[IntLike],
     src_offset: Sequence[IntLike],
     shapes: Sequence[IntLike],
-    valid_shape: Sequence[IntLike] | None = None,
     transpose: bool = False,
+    *,
+    valid_shape: Sequence[IntLike] | None = None,
 ) -> Tile:
     """Load one GM row directly into a sub-region of an on-chip tile (DPS).
 
@@ -510,8 +511,8 @@ def gather_row(  # noqa: PLR0913
         _normalize_intlike(dst_offset),
         _normalize_intlike(src_offset),
         _normalize_intlike(shapes),
-        _normalize_intlike(valid_shape) if valid_shape is not None else None,
         transpose,
+        valid_shape=_normalize_intlike(valid_shape) if valid_shape is not None else None,
     )
     return Tile(expr=call_expr)
 

--- a/src/backend/common/pto_ops_datamove.cpp
+++ b/src/backend/common/pto_ops_datamove.cpp
@@ -290,19 +290,27 @@ static std::string MakeTileAssembleCodegenPTO(const CallPtr& op, codegen::Codege
 
 // tile.gather_row: load one GM row directly into a sub-region of the destination
 // (Mat/Vec) accumulator. Lowering (no pto.tmov):
-//   1. %dst_view = pto.subview %dst[row, col] sizes [R, C] valid [R, C] : ... -> ...
-//   2. %src_pview = pto.partition_view %src_view, offsets = [...], sizes = [r, c] : ... -> ...
+//   1. %dst_view = pto.subview %dst[row, col] sizes [R, C] valid [vr, vc] : ... -> ...
+//   2. %src_pview = pto.partition_view %src_view, offsets = [...], sizes = [vr, vc] : ... -> ...
 //   3. pto.tload ins(%src_pview) outs(%dst_view)
 // Filling an L1 (Mat) tile is only valid via GM->Mat tload (MAT->MAT tmov is
 // unsupported on a2a3), so the row is written straight into the accumulator
 // sub-region. DPS: %dst is the in-place result target. ``transpose`` swaps the
 // destination subview dims (GM row [r, c] -> L1 column [c, r]) for the matmul
 // B-operand layout.
+//
+// The optional 6th operand ``valid_shape`` carries the *runtime* transfer extent
+// [vr, vc]; without it the transfer covers the whole [R, C] window and the emitted
+// text is byte-identical to the pre-valid_shape lowering. The split matters
+// because ptoas types pto.subview's `sizes` as a static I64ArrayAttr while
+// `valid_row`/`valid_col` are Optional<Index> SSA operands (PTOOps.td SubViewOp) —
+// so only the valid side, and the GM partition_view sizes, can be dynamic.
 static std::string MakeGatherRowCodegenPTO(const CallPtr& op, codegen::CodegenBase& codegen_base) {
   auto& codegen = AsPto(codegen_base);
-  CHECK(op->args_.size() == 5) << "tile.gather_row requires 5 arguments "
-                                  "(dst, src, dst_offset, src_offset, shapes), got "
-                               << op->args_.size();
+  CHECK(op->args_.size() == 5 || op->args_.size() == 6)
+      << "tile.gather_row requires 5-6 arguments "
+         "(dst, src, dst_offset, src_offset, shapes[, valid_shape]), got "
+      << op->args_.size();
 
   auto dst_tile_type = ir::As<ir::TileType>(op->args_[0]->GetType());
   INTERNAL_CHECK_SPAN(dst_tile_type, op->span_) << "tile.gather_row dst must be a TileType";
@@ -321,18 +329,41 @@ static std::string MakeGatherRowCodegenPTO(const CallPtr& op, codegen::CodegenBa
       op->span_)
       << "tile.gather_row offsets and shapes must have at least 2 elements";
 
+  // Optional valid_shape: the runtime transfer extent inside the static window.
+  // Absent => the whole window, which reproduces the original 5-arg lowering.
+  auto valid = shapes;
+  if (op->args_.size() == 6) {
+    valid = ir::As<ir::MakeTuple>(op->args_[5]);
+    INTERNAL_CHECK_SPAN(valid && valid->elements_.size() >= 2, op->span_)
+        << "tile.gather_row valid_shape must be a literal tuple with at least 2 elements";
+  }
+
   bool transpose = false;
   for (const auto& [k, v] : op->kwargs_) {
     if (k == "transpose") transpose = AnyCast<bool>(v, "transpose");
   }
 
+  // Constant `shapes`, and static valid under transpose, are op preconditions the
+  // deducer already rejected with a user-facing message (DeduceTileGatherRowType).
+  // Reaching codegen without them means a pass built the call, i.e. a compiler bug.
   auto r_const = ir::As<ir::ConstInt>(shapes->elements_[0]);
   auto c_const = ir::As<ir::ConstInt>(shapes->elements_[1]);
   INTERNAL_CHECK_SPAN(r_const && c_const, op->span_)
-      << "tile.gather_row shapes must be compile-time constants for pto.subview sizes";
+      << "Internal error: tile.gather_row shapes must be compile-time constants for pto.subview sizes";
   // Destination subview shape: transpose maps a GM row [r, c] to an L1 column [c, r].
   const int64_t sv_rows = transpose ? c_const->value_ : r_const->value_;
   const int64_t sv_cols = transpose ? r_const->value_ : c_const->value_;
+
+  // Transfer extent in *GM partition* order. transpose presents the GM row [r, c]
+  // as a DN column, so the source order is swapped there — and that swap makes
+  // the first two entries the destination subview's [valid_row, valid_col] in
+  // both cases (same rule as sv_rows/sv_cols above).
+  const std::vector<ExprPtr> xfer_elems =
+      transpose ? std::vector<ExprPtr>{valid->elements_[1], valid->elements_[0]} : valid->elements_;
+  auto vr_const = ir::As<ir::ConstInt>(xfer_elems[0]);
+  auto vc_const = ir::As<ir::ConstInt>(xfer_elems[1]);
+  INTERNAL_CHECK_SPAN(!transpose || (vr_const && vc_const), op->span_)
+      << "Internal error: tile.gather_row transpose=True requires a static valid_shape";
 
   std::string dst = codegen.GetCurrentResultTarget();
   std::string dst_type = codegen.GetCurrentResultTileBufTypeString();
@@ -349,9 +380,11 @@ static std::string MakeGatherRowCodegenPTO(const CallPtr& op, codegen::CodegenBa
   // be a whole number of boxes per dim (ptoas: "boxed layout subview sizes must
   // be multiples of inner shape"). A per-row gather writes a single row, so we
   // carve a box-aligned physical sub-region (size = phys_rows x phys_cols) but
-  // mark only the real extent valid (valid = sv_rows x sv_cols); the tload then
-  // fills just that row. ND tiles (Vec, slayout=none_box) have no inner box and
-  // use the exact per-row size.
+  // mark only the real extent valid; the tload then fills just that row. ND tiles
+  // (Vec, slayout=none_box) have no inner box and use the exact per-row size.
+  // Alignment is computed from the *static* window (sv_rows/sv_cols), never from
+  // valid_shape, so a dynamic transfer extent leaves the physical carve-out — and
+  // hence this box-multiple invariant — untouched.
   const bool boxed = view_info.slayout != ir::TileLayout::none_box;
   auto round_up = [](int64_t n, int64_t mult) { return ((n + mult - 1) / mult) * mult; };
   // NZ fractal granularity: M0 = 16 rows; the C0 lane count along columns is
@@ -367,35 +400,54 @@ static std::string MakeGatherRowCodegenPTO(const CallPtr& op, codegen::CodegenBa
 
   view_info.rows = phys_rows;
   view_info.cols = phys_cols;
-  view_info.v_row = sv_rows;
-  view_info.v_row_dynamic = false;
-  view_info.v_col = sv_cols;
-  view_info.v_col_dynamic = false;
+  // Per-dim static/dynamic, deliberately NOT promoted together — see the same
+  // handling in tile.slice below for why PTOAS requires this.
+  view_info.v_row_dynamic = vr_const == nullptr;
+  view_info.v_col_dynamic = vc_const == nullptr;
+  if (vr_const) view_info.v_row = vr_const->value_;
+  if (vc_const) view_info.v_col = vc_const->value_;
   std::string view_type = codegen::FormatTileBufTypeString(
       codegen::MemorySpaceToMLIR(dst_space), view_info.dtype_str, view_info.rows, view_info.cols,
       view_info.blayout, view_info.slayout, view_info.fractal, view_info.pad, view_info.v_row,
       view_info.v_col, view_info.v_row_dynamic, view_info.v_col_dynamic);
 
-  std::string valid_rows = codegen.GetOrEmitConstant(sv_rows, DataType::INDEX);
-  std::string valid_cols = codegen.GetOrEmitConstant(sv_cols, DataType::INDEX);
+  // Coerce the extent to `index` once, then feed both consumers from it:
+  // pto.subview's valid_row/valid_col are Optional<Index> and partition_view sizes
+  // are index-typed, and EmitCastToIndex is not memoized — computing these twice
+  // would emit a second, identical arith.index_cast into the kernel body for a
+  // runtime extent.
+  const std::vector<std::string> xfer_codes = GetSizeCodes(xfer_elems, codegen);
   std::string dst_view = codegen.NewNamedTemp("gather_row_view");
   std::ostringstream sv;
   sv << dst_view << " = pto.subview " << dst << "[" << row_off << ", " << col_off << "] sizes [" << phys_rows
-     << ", " << phys_cols << "] valid [" << valid_rows << ", " << valid_cols << "]";
+     << ", " << phys_cols << "] valid [" << xfer_codes[0] << ", " << xfer_codes[1] << "]";
   if (!dst_type.empty() && !view_type.empty()) {
     sv << " : " << dst_type << " -> " << view_type;
   }
   codegen.Emit(sv.str());
   if (!view_type.empty()) codegen.RegisterTileBufType(dst_view, view_type);
 
-  // GM source window [r, c] -> partition_view, then tload into the subview.
+  // GM source window -> partition_view, then tload into the subview. The
+  // partition carries the *transfer extent*, not the static window — same as
+  // tile.load, which likewise builds its partition type and sizes from
+  // valid_shapes. GetDimStrings renders a non-ConstInt extent as `?`, which
+  // TLoadOp::verify accepts on the src partition shape.
+  //
+  // Narrowing the partition is LOAD-BEARING, not tidiness: on a2a3 the GM->L1
+  // fractal path `TLoadGm2L1Nd2nz` takes `validRow`/`validCol` and never reads
+  // them, deriving the DMA extent solely from the GlobalTensor shape — and unlike
+  // its non-fractal `TLoadGm2L1Nd2nd` sibling it has no PTO_ASSERT cross-checking
+  // the two. Setting only the subview's `valid [...]` would move the whole window
+  // with no error anywhere. (a5 mirrors this: its tilelang tload template reads
+  // `dst.valid_shape` instead.) Feeding both is what makes a dynamic extent
+  // correct on either arch; tests/st/runtime/ops/test_gather_row_dynamic_valid_shape.py
+  // is the on-device sentinel guarding it.
   std::string dtype_str = codegen.GetTypeString(src_tensor_type->dtype_);
   std::string src_view_type = codegen.GetTensorViewTypeString(src_tensor_type.get());
-  const auto& shape_elems = shapes->elements_;
+  std::string partition_type = MakePartitionTensorViewType(GetDimStrings(xfer_elems), dtype_str);
   const auto& soff_elems = src_off->elements_;
 
   std::string src_pview;
-  std::string partition_type;
   if (transpose) {
     // Transposing per-row gather: the GM row [r=1, c] must land as the L1 column
     // [c, 1]. pto.tload itself does NOT transpose, so we feed it a DN-strided
@@ -419,19 +471,15 @@ static std::string MakeGatherRowCodegenPTO(const CallPtr& op, codegen::CodegenBa
        << "] {layout = #pto.layout<dn>}: " << src_view_type;
     codegen.Emit(mv.str());
     // Read src[phys, col_off : col_off + c] presented as the DN column [c, 1]:
-    // offsets [col_off, phys] (swapped), sizes [c, r] (swapped).
+    // offsets [col_off, phys] (swapped). xfer_elems/xfer_codes are already in
+    // this swapped source order.
     std::vector<ExprPtr> tr_off = {soff_elems[1], soff_elems[0]};
-    std::vector<ExprPtr> tr_shape = {shape_elems[1], shape_elems[0]};
-    partition_type = MakePartitionTensorViewType(GetDimStrings(tr_shape), dtype_str);
-    src_pview =
-        EmitPartitionViewPTO(src->name_hint_, dn_view, src_view_type, partition_type,
-                             GetIndexOffsetCodes(tr_off, codegen), GetSizeCodes(tr_shape, codegen), codegen);
+    src_pview = EmitPartitionViewPTO(src->name_hint_, dn_view, src_view_type, partition_type,
+                                     GetIndexOffsetCodes(tr_off, codegen), xfer_codes, codegen);
   } else {
     std::string src_view = codegen.GetOrCreateTensorView(src);
-    partition_type = MakePartitionTensorViewType(GetDimStrings(shape_elems), dtype_str);
     src_pview = EmitPartitionViewPTO(src->name_hint_, src_view, src_view_type, partition_type,
-                                     GetIndexOffsetCodes(soff_elems, codegen),
-                                     GetSizeCodes(shape_elems, codegen), codegen);
+                                     GetIndexOffsetCodes(soff_elems, codegen), xfer_codes, codegen);
   }
 
   std::ostringstream tload_line;

--- a/src/ir/op/tensor_ops/paged_gather.cpp
+++ b/src/ir/op/tensor_ops/paged_gather.cpp
@@ -42,6 +42,7 @@
 #include "pypto/ir/scalar_expr.h"
 #include "pypto/ir/span.h"
 #include "pypto/ir/type.h"
+#include "pypto/ir/type_inference.h"
 
 namespace pypto {
 namespace ir {
@@ -231,11 +232,12 @@ TypePtr DeduceTensorCreateL1Type(const std::vector<ExprPtr>& args,
 }
 
 TypePtr DeduceTensorGatherRowType(const std::vector<ExprPtr>& args,
-                                  const std::vector<std::pair<std::string, std::any>>& /*kwargs*/,
+                                  const std::vector<std::pair<std::string, std::any>>& kwargs,
                                   const std::string& op_name) {
-  CHECK(args.size() == 5) << "The operator " << op_name
-                          << " requires 5 arguments (acc, src, dst_offset, src_offset, shapes), but got "
-                          << args.size();
+  CHECK(args.size() == 5 || args.size() == 6)
+      << "The operator " << op_name
+      << " requires 5-6 arguments (acc, src, dst_offset, src_offset, shapes[, valid_shape]), but got "
+      << args.size();
   auto acc_type = As<TensorType>(args[0]->GetType());
   CHECK(acc_type) << "The operator " << op_name
                   << " requires acc to be a TensorType (from tensor.create_l1), but got "
@@ -246,7 +248,12 @@ TypePtr DeduceTensorGatherRowType(const std::vector<ExprPtr>& args,
   CHECK(acc_type->dtype_ == src_type->dtype_)
       << "The operator " << op_name << " requires acc and src to share dtype, but got "
       << acc_type->dtype_.ToString() << " and " << src_type->dtype_.ToString();
-  // DPS: result is the accumulator, written in place.
+
+  CheckGatherRowOperands(args, kwargs, op_name);
+
+  // DPS: result is the accumulator, written in place. The optional valid_shape
+  // narrows only this transfer, so it must NOT propagate into the result type —
+  // the accumulator keeps the full extent it was allocated with.
   return args[0]->GetType();
 }
 
@@ -275,6 +282,9 @@ REGISTER_OP("tensor.gather_row")
     .add_argument("dst_offset", "[row, col] offset within acc (TupleType of ScalarType)")
     .add_argument("src_offset", "[row, col] offset within the GM src (TupleType of ScalarType)")
     .add_argument("shapes", "GM row window shape [r, c] (TupleType of ScalarType)")
+    .add_argument("valid_shape",
+                  "Optional runtime transfer extent [r, c] within shapes (TupleType of ScalarType). "
+                  "May be a runtime Scalar[INDEX]; defaults to shapes.")
     .set_attr<bool>("transpose")
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {

--- a/src/ir/op/tile_ops/paged_gather.cpp
+++ b/src/ir/op/tile_ops/paged_gather.cpp
@@ -24,6 +24,14 @@
  * Destination-Preserve-Source (DPS): the op writes into its first argument in
  * place (``set_output_reuses_input(0)``), so a loop-carried accumulator is
  * updated row by row without copying the whole tile.
+ *
+ * ``shapes`` vs the optional ``valid_shape``: ptoas types ``pto.subview``'s
+ * ``sizes`` as a static ``I64ArrayAttr``, so the window shape can never be
+ * dynamic. ``valid_shape`` carries the *runtime* transfer extent instead — it
+ * feeds the subview's ``Optional<Index> valid_row/valid_col`` operands and the
+ * GM ``pto.partition_view`` sizes, both of which accept dynamic SSA values. A
+ * dynamic row count therefore costs nothing in allocation or box alignment: the
+ * tile stays statically ``shapes``-sized and only the copy length varies.
  */
 
 #include <any>
@@ -32,19 +40,22 @@
 #include <vector>
 
 #include "pypto/core/logging.h"
+#include "pypto/ir/expr.h"
 #include "pypto/ir/kind_traits.h"
 #include "pypto/ir/op_registry.h"
 #include "pypto/ir/type.h"
+#include "pypto/ir/type_inference.h"
 
 namespace pypto {
 namespace ir {
 
 static TypePtr DeduceTileGatherRowType(const std::vector<ExprPtr>& args,
-                                       const std::vector<std::pair<std::string, std::any>>& /*kwargs*/,
+                                       const std::vector<std::pair<std::string, std::any>>& kwargs,
                                        const std::string& op_name) {
-  CHECK(args.size() == 5) << "The operator " << op_name
-                          << " requires 5 arguments (dst, src, dst_offset, src_offset, shapes), but got "
-                          << args.size();
+  CHECK(args.size() == 5 || args.size() == 6)
+      << "The operator " << op_name
+      << " requires 5-6 arguments (dst, src, dst_offset, src_offset, shapes[, valid_shape]), but got "
+      << args.size();
 
   auto dst_type = As<TileType>(args[0]->GetType());
   CHECK(dst_type) << "The operator " << op_name << " requires dst to be a TileType, but got "
@@ -57,7 +68,12 @@ static TypePtr DeduceTileGatherRowType(const std::vector<ExprPtr>& args,
       << "The operator " << op_name << " requires dst and src to share dtype, but got "
       << dst_type->dtype_.ToString() << " and " << src_type->dtype_.ToString();
 
-  // DPS: the result is the destination accumulator, written in place.
+  CheckGatherRowOperands(args, kwargs, op_name);
+
+  // DPS: the result is the destination accumulator, written in place. The
+  // optional valid_shape narrows only *this* transfer — the accumulator keeps
+  // its full extent (its other rows hold previously gathered data), so it must
+  // NOT propagate into the result type.
   return dst_type;
 }
 
@@ -72,6 +88,9 @@ REGISTER_OP("tile.gather_row")
     .add_argument("dst_offset", "Destination [row, col] offset (TupleType of ScalarType)")
     .add_argument("src_offset", "Source [row, col] offset within the GM tensor (TupleType of ScalarType)")
     .add_argument("shapes", "GM row window shape [r, c] (TupleType of ScalarType)")
+    .add_argument("valid_shape",
+                  "Optional runtime transfer extent [r, c] within shapes (TupleType of ScalarType). "
+                  "May be a runtime Scalar[INDEX]; defaults to shapes.")
     .set_attr<bool>("transpose")
     .set_output_reuses_input(0)
     .f_deduce_type([](const std::vector<ExprPtr>& args,

--- a/src/ir/op/type_inference.cpp
+++ b/src/ir/op/type_inference.cpp
@@ -418,6 +418,16 @@ void CheckGatherRowOperands(const std::vector<ExprPtr>& args,
   CHECK(valid->elements_.size() == shapes->elements_.size())
       << "The operator " << op_name << " requires valid_shape to have the same rank as shapes ("
       << shapes->elements_.size() << "), but got rank " << valid->elements_.size();
+  // The bounds proofs below return "unknown" for a non-integer scalar rather than
+  // rejecting it, so a literal like [1.5, 128] would otherwise reach lowering as a
+  // fractional transfer extent.
+  for (size_t i = 0; i < valid->elements_.size(); ++i) {
+    auto dtype = ExtractDataType(valid->elements_[i]->GetType());
+    CHECK(dtype.has_value() && !dtype->IsFloat())
+        << "The operator " << op_name << " requires valid_shape[" << i
+        << "] to be an integer extent, but got "
+        << (dtype.has_value() ? dtype->ToString() : valid->elements_[i]->GetType()->TypeName());
+  }
 
   bool transpose = false;
   for (const auto& [k, v] : kwargs) {

--- a/src/ir/op/type_inference.cpp
+++ b/src/ir/op/type_inference.cpp
@@ -411,6 +411,13 @@ void CheckGatherRowOperands(const std::vector<ExprPtr>& args,
   auto valid = As<MakeTuple>(args[5]);
   CHECK(valid) << "The operator " << op_name << " requires valid_shape to be a literal tuple, but got "
                << args[5]->TypeName();
+  // Rank must be checked here, not left to ValidateValidShapeBounds: that helper
+  // reads an *empty* valid shape as "implicitly fully valid" and accepts it, which
+  // is right for a type's valid_shape but wrong for an explicit operand — an empty
+  // one would sail past deduction and trip an INTERNAL_CHECK in the backend.
+  CHECK(valid->elements_.size() == shapes->elements_.size())
+      << "The operator " << op_name << " requires valid_shape to have the same rank as shapes ("
+      << shapes->elements_.size() << "), but got rank " << valid->elements_.size();
 
   bool transpose = false;
   for (const auto& [k, v] : kwargs) {

--- a/src/ir/op/type_inference.cpp
+++ b/src/ir/op/type_inference.cpp
@@ -12,6 +12,7 @@
 #include "pypto/ir/type_inference.h"
 
 #include <algorithm>
+#include <any>
 #include <cstddef>
 #include <memory>
 #include <optional>
@@ -21,7 +22,9 @@
 #include <utility>
 #include <vector>
 
+#include "pypto/core/any_cast.h"
 #include "pypto/core/dtype.h"
+#include "pypto/core/error.h"
 #include "pypto/core/logging.h"
 #include "pypto/ir/arith/analyzer.h"
 #include "pypto/ir/expr.h"
@@ -387,6 +390,53 @@ std::vector<ValidShapeBoundsError> ValidateValidShapeBounds(const std::vector<Ex
     }
   }
   return errors;
+}
+
+void CheckGatherRowOperands(const std::vector<ExprPtr>& args,
+                            const std::vector<std::pair<std::string, std::any>>& kwargs,
+                            const std::string& op_name) {
+  auto shapes = As<MakeTuple>(args[4]);
+  CHECK(shapes) << "The operator " << op_name << " requires shapes to be a literal tuple, but got "
+                << args[4]->TypeName();
+  for (size_t i = 0; i < shapes->elements_.size(); ++i) {
+    CHECK(As<ConstInt>(shapes->elements_[i]))
+        << "The operator " << op_name << " requires shapes[" << i
+        << "] to be a compile-time constant (it sizes pto.subview, whose sizes is a static attribute), "
+           "but got a runtime value. Pass a dynamic row count through valid_shape instead — it keeps "
+           "the window (and so the tile allocation and box alignment) static while varying only the "
+           "transfer length.";
+  }
+  if (args.size() < 6) return;
+
+  auto valid = As<MakeTuple>(args[5]);
+  CHECK(valid) << "The operator " << op_name << " requires valid_shape to be a literal tuple, but got "
+               << args[5]->TypeName();
+
+  bool transpose = false;
+  for (const auto& [k, v] : kwargs) {
+    if (k == "transpose") transpose = AnyCast<bool>(v, "transpose");
+  }
+  if (transpose) {
+    for (const auto& elem : valid->elements_) {
+      CHECK(As<ConstInt>(elem))
+          << "The operator " << op_name
+          << " does not support a dynamic valid_shape together with transpose=True (the DN2NZ per-row "
+             "path would need a runtime column extent on a boxed NZ tile). Use a static valid_shape "
+             "with transpose=True, or gather without transpose and read the operand with "
+             "matmul(b_trans=True).";
+    }
+  }
+
+  // Report every violation at once rather than only the first — the messages
+  // already carry the op name and dimension index.
+  const auto errors = ValidateValidShapeBounds(valid->elements_, shapes->elements_, op_name);
+  if (errors.empty()) return;
+  std::ostringstream msg;
+  for (size_t i = 0; i < errors.size(); ++i) {
+    if (i > 0) msg << "; ";
+    msg << errors[i].message;
+  }
+  throw ValueError(msg.str());
 }
 
 void CheckReductionInputNonEmpty(const std::vector<ExprPtr>& valid, const std::string& op_name,

--- a/src/ir/transforms/op_conversion_registry.cpp
+++ b/src/ir/transforms/op_conversion_registry.cpp
@@ -1885,9 +1885,9 @@ void OpConversionRegistry::RegisterPagedGatherOps() {
       "tensor.gather_row",
       [](const std::vector<ExprPtr>& args, const std::vector<std::pair<std::string, std::any>>& kwargs,
          const Span& span) -> ConversionResult {
-        INTERNAL_CHECK_SPAN(args.size() == 5, span)
-            << "tensor.gather_row conversion expects 5 args (acc, src, dst_offset, src_offset, shapes), "
-               "but got "
+        INTERNAL_CHECK_SPAN(args.size() == 5 || args.size() == 6, span)
+            << "tensor.gather_row conversion expects 5-6 args (acc, src, dst_offset, src_offset, "
+               "shapes[, valid_shape]), but got "
             << args.size();
         auto& op_reg = OpRegistry::GetInstance();
         bool transpose = false;
@@ -1895,8 +1895,9 @@ void OpConversionRegistry::RegisterPagedGatherOps() {
           if (k == "transpose") transpose = AnyCast<bool>(v, "transpose");
         }
         std::vector<std::pair<std::string, std::any>> gr_kwargs = {{"transpose", transpose}};
-        auto gr_call =
-            op_reg.Create("tile.gather_row", {args[0], args[1], args[2], args[3], args[4]}, gr_kwargs, span);
+        // tile.gather_row shares the 5-or-6 arg signature, so the optional
+        // valid_shape (args[5]) forwards verbatim.
+        auto gr_call = op_reg.Create("tile.gather_row", args, gr_kwargs, span);
         return ConversionResult{gr_call};
       });
 }

--- a/src/ir/transforms/python_printer.cpp
+++ b/src/ir/transforms/python_printer.cpp
@@ -1060,8 +1060,16 @@ void IRPythonPrinter::VisitExpr_(const CallPtr& op) {
     return;
   }
 
+  // gather_row's optional 6th operand is keyword-only in the DSL: `transpose`
+  // already owned the 6th positional slot before valid_shape existed, and taking
+  // it would silently reinterpret an existing `gather_row(..., shapes, True)` as
+  // a shape. Print it as a kwarg so the round-trip matches the Python signature.
+  const bool gather_row_kw_valid =
+      (IsOp(op, "tile.gather_row") || IsOp(op, "tensor.gather_row")) && op->args_.size() == 6;
+
   // Print positional arguments
   for (size_t i = 0; i < op->args_.size(); ++i) {
+    if (gather_row_kw_valid && i == 5) continue;
     if (i > 0) stream_ << ", ";
 
     // Special handling for tile.alloc/tensor.alloc first argument (memory_space)
@@ -1080,6 +1088,11 @@ void IRPythonPrinter::VisitExpr_(const CallPtr& op) {
 
   // Print kwargs as keyword arguments
   bool need_comma = !op->args_.empty();
+  if (gather_row_kw_valid) {
+    stream_ << ", valid_shape=";
+    VisitExpr(op->args_[5]);
+    need_comma = true;
+  }
   if (IsOp(op, "system.task_dummy")) {
     const std::vector<VarPtr>* deps_to_print = nullptr;
     for (const auto& [k, v] : op->attrs_) {

--- a/tests/st/runtime/ops/test_gather_row_dynamic_valid_shape.py
+++ b/tests/st/runtime/ops/test_gather_row_dynamic_valid_shape.py
@@ -149,6 +149,60 @@ class GatherRowDynamicValidShapeTestCase(PTOTestCase):
         tensors["output"][:] = _gather_row_dynamic_golden(tensors["src"], self._valid_rows).to(torch.float32)
 
 
+@pl.program
+class GatherRowTwoRunProgram:
+    """Two contiguous runs into one accumulator, split at a runtime row ``r1``.
+
+    The motivating shape: a page-aligned KV window that straddles a block boundary
+    is 1-2 contiguous runs whose split point is only known at runtime. Run 2 writes
+    at the runtime offset ``r1``, so its static ``shapes`` window spans rows
+    ``[r1, r1 + ROWS)`` — past the end of the tile. Only ``ROWS - r1`` rows are
+    actually transferred, so the *write* stays in bounds, but whether the declared
+    window is tolerated is a device question, which is what this exercises.
+    """
+
+    @pl.function(type=pl.FunctionType.Opaque)
+    def main(
+        self,
+        src: pl.Tensor[[POOL_ROWS, HEAD_DIM], pl.FP16],
+        n: pl.Tensor[[1], pl.INT32],
+        eye: pl.Tensor[[ROWS, ROWS], pl.FP16],
+        output: pl.Out[pl.Tensor[[ROWS, HEAD_DIM], pl.FP32]],
+    ) -> pl.Tensor[[ROWS, HEAD_DIM], pl.FP32]:
+        with pl.at(level=pl.Level.CORE_GROUP):
+            r1 = pl.cast(pl.read(n, [0]), pl.INDEX)
+            kv = pl.create_l1([ROWS, HEAD_DIM], pl.FP16)
+            # Run 1: pool rows [0, r1) -> slots [0, r1).
+            kv = pl.gather_row(kv, src, [0, 0], [0, 0], [ROWS, HEAD_DIM], valid_shape=[r1, HEAD_DIM])
+            # Run 2: pool rows [SENT_BASE, SENT_BASE + ROWS - r1) -> slots [r1, ROWS).
+            kv = pl.gather_row(
+                kv, src, [r1, 0], [SENT_BASE, 0], [ROWS, HEAD_DIM], valid_shape=[ROWS - r1, HEAD_DIM]
+            )
+            result = pl.matmul(eye, kv, out_dtype=pl.FP32)
+            output = pl.assemble(output, result, [0, 0])
+        return output
+
+
+class GatherRowTwoRunTestCase(GatherRowDynamicValidShapeTestCase):
+    """Two-run split at a runtime boundary."""
+
+    __test__ = False
+
+    def get_name(self) -> str:
+        return f"gather_row_two_run_r{self._valid_rows}"
+
+    def get_program(self) -> Any:
+        return GatherRowTwoRunProgram
+
+    def compute_expected(self, tensors, params=None):
+        r = self._valid_rows
+        src = tensors["src"]
+        out = torch.empty(ROWS, HEAD_DIM, dtype=torch.float16)
+        out[:r, :] = src[:r, :HEAD_DIM]
+        out[r:, :] = src[SENT_BASE : SENT_BASE + (ROWS - r), :HEAD_DIM]
+        tensors["output"][:] = out.to(torch.float32)
+
+
 class TestGatherRowDynamicValidShape:
     """A runtime valid_shape limits a GM -> L1 gather on real hardware."""
 
@@ -156,6 +210,13 @@ class TestGatherRowDynamicValidShape:
     @pytest.mark.parametrize("platform", PLATFORMS)
     def test_gather_row_dynamic_valid_shape(self, test_runner, platform, valid_rows):
         result = test_runner.run(GatherRowDynamicValidShapeTestCase(valid_rows, platform=platform))
+        assert result.passed, f"Test failed: {result.error}"
+
+    @pytest.mark.parametrize("valid_rows", [1, 63, 127])
+    @pytest.mark.parametrize("platform", PLATFORMS)
+    def test_gather_row_two_run_split(self, test_runner, platform, valid_rows):
+        """Two runs split at a runtime row — the page-boundary shape this exists for."""
+        result = test_runner.run(GatherRowTwoRunTestCase(valid_rows, platform=platform))
         assert result.passed, f"Test failed: {result.error}"
 
 

--- a/tests/st/runtime/ops/test_gather_row_dynamic_valid_shape.py
+++ b/tests/st/runtime/ops/test_gather_row_dynamic_valid_shape.py
@@ -1,0 +1,163 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""On-device sentinel test for ``pl.gather_row(..., valid_shape=[<runtime>, ...])``.
+
+``shapes`` sizes the ``pto.subview`` carved out of the L1 accumulator and must be
+compile-time constant (ptoas types ``sizes`` as a static ``I64ArrayAttr``). The
+optional ``valid_shape`` carries the *runtime* transfer extent instead, feeding
+the subview's ``valid_row``/``valid_col`` operands and the GM
+``pto.partition_view`` sizes. These tests prove on real hardware that a runtime
+row count genuinely limits how many rows move.
+
+**Why a sentinel, and why it is discriminating.** A partial gather is only
+observable if the untouched part of the destination holds something recognisable,
+so each case fills the accumulator twice:
+
+1. A **full-window** gather (plain 5-arg form) from pool rows ``[SENT_BASE, SENT_BASE+ROWS)``
+   paints all ``ROWS`` slots with sentinel values.
+2. A **dynamic** gather from pool rows ``[0, r)`` with ``valid_shape=[r, HEAD_DIM]``
+   overwrites only the first ``r`` slots.
+
+Because ``src[p, :] == p`` (row-id encoding, FP16-exact for ``p <= 255``), the
+expected result is ``out[i, :] == i`` for ``i < r`` and ``out[i, :] == SENT_BASE + i``
+for ``i >= r``. If the runtime extent were ignored and the full window moved,
+every row would read ``i`` and the tail assertion fails immediately — which is
+exactly the silent-wrong-data failure this guards against. The two source regions
+are disjoint and their values differ by ``SENT_BASE`` in every element, so an
+off-by-one or a partially-applied extent is caught too.
+
+The gathered tile carries the matmul-operand NZ (boxed) layout and so cannot be
+pushed straight to GM; as in ``test_paged_gather.py`` it is read back via
+``eye @ gathered``, which reproduces the gathered rows exactly.
+
+The row count arrives as a **GM scalar read** rather than a kernel parameter, so
+it cannot be constant-folded into the static ``shapes`` — the value is genuinely
+unknown at compile time.
+"""
+
+from typing import Any
+
+import pypto.language as pl
+import pytest
+import torch
+from harness.core.harness import PLATFORMS, DataType, PTOTestCase, TensorSpec
+from pypto.backend import BackendType
+from pypto.ir.pass_manager import OptimizationStrategy
+
+HEAD_DIM = 128
+ROWS = 128  # L1 accumulator rows == the static gather window
+SENT_BASE = 128  # sentinel source rows: [128, 256)
+POOL_ROWS = SENT_BASE + ROWS  # 256 — max row id 255 stays FP16-exact
+
+# Runtime extents under test. r >= 1 is required by the device library:
+# TLoadGm2L1Nd2nz asserts `gShape3 > 0`, and gShape3 is the transfer row count.
+# r == ROWS is the control case (dynamic operand that happens to equal the window).
+VALID_ROWS = [1, 63, 127, ROWS]
+
+
+def _make_src() -> torch.Tensor:
+    """src[p, c] = p — row-id encoding, so a gathered slot reveals its source row."""
+    rows = torch.arange(POOL_ROWS, dtype=torch.float32).reshape(POOL_ROWS, 1)
+    return rows.expand(POOL_ROWS, HEAD_DIM).to(torch.float16).contiguous()
+
+
+def _gather_row_dynamic_golden(src: torch.Tensor, r: int) -> torch.Tensor:
+    """Sentinel fill of the whole window, then the first r rows overwritten."""
+    out = src[SENT_BASE : SENT_BASE + ROWS, :HEAD_DIM].clone()
+    out[:r, :] = src[:r, :HEAD_DIM]
+    return out
+
+
+@pl.program
+class GatherRowDynamicValidShapeProgram:
+    """Sentinel-fill an L1 accumulator, then overwrite a runtime number of rows.
+
+    ``n`` is read from GM so the extent is opaque to the compiler. The first
+    ``pl.gather_row`` omits ``valid_shape`` (the pre-existing 5-arg form) and
+    paints the sentinel; the second passes the runtime ``rows`` and must touch
+    only that many slots.
+    """
+
+    @pl.function(type=pl.FunctionType.Opaque)
+    def main(
+        self,
+        src: pl.Tensor[[POOL_ROWS, HEAD_DIM], pl.FP16],
+        n: pl.Tensor[[1], pl.INT32],
+        eye: pl.Tensor[[ROWS, ROWS], pl.FP16],
+        output: pl.Out[pl.Tensor[[ROWS, HEAD_DIM], pl.FP32]],
+    ) -> pl.Tensor[[ROWS, HEAD_DIM], pl.FP32]:
+        with pl.at(level=pl.Level.CORE_GROUP):
+            rows = pl.cast(pl.read(n, [0]), pl.INDEX)
+            kv = pl.create_l1([ROWS, HEAD_DIM], pl.FP16)
+            # Sentinel: every slot gets pool row SENT_BASE + i.
+            kv = pl.gather_row(kv, src, [0, 0], [SENT_BASE, 0], [ROWS, HEAD_DIM])
+            # Dynamic: only the first `rows` slots get pool row i.
+            kv = pl.gather_row(kv, src, [0, 0], [0, 0], [ROWS, HEAD_DIM], valid_shape=[rows, HEAD_DIM])
+            result = pl.matmul(eye, kv, out_dtype=pl.FP32)
+            output = pl.assemble(output, result, [0, 0])
+        return output
+
+
+class GatherRowDynamicValidShapeTestCase(PTOTestCase):
+    """One case per runtime extent in VALID_ROWS."""
+
+    __test__ = False
+
+    def __init__(self, valid_rows: int, *, platform: str | None = None):
+        super().__init__(None, platform=platform)
+        self._valid_rows = valid_rows
+
+    def get_name(self) -> str:
+        return f"gather_row_dynamic_valid_shape_r{self._valid_rows}"
+
+    def get_strategy(self) -> OptimizationStrategy:
+        return OptimizationStrategy.Default
+
+    def get_backend_type(self) -> BackendType:
+        return BackendType.Ascend910B
+
+    def get_program(self) -> Any:
+        return GatherRowDynamicValidShapeProgram
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("src", [POOL_ROWS, HEAD_DIM], DataType.FP16, init_value=_make_src),
+            TensorSpec(
+                "n",
+                [1],
+                DataType.INT32,
+                init_value=torch.tensor([self._valid_rows], dtype=torch.int32),
+            ),
+            TensorSpec(
+                "eye",
+                [ROWS, ROWS],
+                DataType.FP16,
+                init_value=lambda: torch.eye(ROWS, dtype=torch.float16),
+            ),
+            TensorSpec("output", [ROWS, HEAD_DIM], DataType.FP32, is_output=True),
+        ]
+
+    def compute_expected(self, tensors, params=None):
+        # eye @ gathered == gathered, so the golden is the accumulator contents.
+        tensors["output"][:] = _gather_row_dynamic_golden(tensors["src"], self._valid_rows).to(torch.float32)
+
+
+class TestGatherRowDynamicValidShape:
+    """A runtime valid_shape limits a GM -> L1 gather on real hardware."""
+
+    @pytest.mark.parametrize("valid_rows", VALID_ROWS)
+    @pytest.mark.parametrize("platform", PLATFORMS)
+    def test_gather_row_dynamic_valid_shape(self, test_runner, platform, valid_rows):
+        result = test_runner.run(GatherRowDynamicValidShapeTestCase(valid_rows, platform=platform))
+        assert result.passed, f"Test failed: {result.error}"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/ut/codegen/test_pto_codegen_gather_row.py
+++ b/tests/ut/codegen/test_pto_codegen_gather_row.py
@@ -106,5 +106,125 @@ def test_gather_row_no_transpose_keeps_nd_source_view():
     assert "layout = #pto.layout<dn>" not in mlir
 
 
+STATIC_ROWS = ROWS // 2
+
+
+def _build_dynamic_valid_program():
+    """Gather the whole ROWS-row window in one call, transferring only ``n`` rows.
+
+    ``shapes`` stays the static [ROWS, HEAD_DIM] window (it sizes pto.subview);
+    only the transfer length varies, and here it is read from a GM scalar at
+    runtime — the case the operand exists for.
+    """
+
+    @pl.program
+    class Program:
+        @pl.function(type=pl.FunctionType.InCore)
+        def kernel(
+            self,
+            src: pl.Tensor[[NSRC, HEAD_DIM], pl.BF16],
+            a: pl.Tensor[[MM, ROWS], pl.BF16],
+            n: pl.Tensor[[1], pl.INT32],
+        ) -> pl.Tensor[[MM, HEAD_DIM], pl.FP32]:
+            rows = pl.cast(pl.read(n, [0]), pl.INDEX)
+            kv = pl.create_l1([ROWS, HEAD_DIM], pl.BF16)
+            kv = pl.gather_row(kv, src, [0, 0], [0, 0], [ROWS, HEAD_DIM], valid_shape=[rows, HEAD_DIM])
+            return pl.matmul(a, kv, out_dtype=pl.FP32)
+
+        @pl.function
+        def main(
+            self,
+            src: pl.Tensor[[NSRC, HEAD_DIM], pl.BF16],
+            a: pl.Tensor[[MM, ROWS], pl.BF16],
+            n: pl.Tensor[[1], pl.INT32],
+        ) -> pl.Tensor[[MM, HEAD_DIM], pl.FP32]:
+            r = self.kernel(src, a, n)
+            return r
+
+    return Program
+
+
+def _build_static_valid_program():
+    """Same kernel shape, but with a compile-time constant transfer extent.
+
+    A separate builder rather than a flag on the dynamic one because the two
+    kernels differ in signature — the dynamic case needs the ``n`` scalar operand
+    to read the extent from, and threading an unused one through here would
+    obscure that this path has no runtime input at all.
+    """
+
+    @pl.program
+    class Program:
+        @pl.function(type=pl.FunctionType.InCore)
+        def kernel(
+            self,
+            src: pl.Tensor[[NSRC, HEAD_DIM], pl.BF16],
+            a: pl.Tensor[[MM, ROWS], pl.BF16],
+        ) -> pl.Tensor[[MM, HEAD_DIM], pl.FP32]:
+            kv = pl.create_l1([ROWS, HEAD_DIM], pl.BF16)
+            kv = pl.gather_row(kv, src, [0, 0], [0, 0], [ROWS, HEAD_DIM], valid_shape=[STATIC_ROWS, HEAD_DIM])
+            return pl.matmul(a, kv, out_dtype=pl.FP32)
+
+        @pl.function
+        def main(
+            self,
+            src: pl.Tensor[[NSRC, HEAD_DIM], pl.BF16],
+            a: pl.Tensor[[MM, ROWS], pl.BF16],
+        ) -> pl.Tensor[[MM, HEAD_DIM], pl.FP32]:
+            r = self.kernel(src, a)
+            return r
+
+    return Program
+
+
+def _subview_result_type(mlir: str) -> str:
+    """The gather_row subview's *result* tile_buf type (the text after ``->``).
+
+    Asserting on the whole module would be meaningless for v_row/v_col: a plain
+    (non-subview) tile type always renders as ``v_row=?, v_col=?`` regardless of
+    its IR valid_shape, so the parent operand type on the very same line reads
+    ``?`` in both the static and dynamic cases.
+    """
+    lines = [ln for ln in mlir.splitlines() if "gather_row_view = pto.subview" in ln]
+    assert len(lines) == 1, f"expected exactly one gather_row subview, got {len(lines)}"
+    return lines[0].split("->", 1)[1].strip()
+
+
+def test_gather_row_dynamic_valid_shape_emits_dynamic_subview_and_partition():
+    """A runtime row count narrows the transfer without making the window dynamic.
+
+    ptoas types pto.subview's `sizes` as a static I64ArrayAttr but `valid_row` /
+    `valid_col` as Optional<Index> SSA operands, so the dynamic extent must land
+    on the valid side and on the GM partition, while `sizes` keeps the static
+    window (and with it the tile allocation and NZ box alignment).
+    """
+    mlir = _codegen_incore(_build_dynamic_valid_program())
+    subview = [ln for ln in mlir.splitlines() if "gather_row_view = pto.subview" in ln][0]
+    # Static window survives in `sizes`; the L1 tile allocation is unaffected.
+    assert f"sizes [{ROWS}, {HEAD_DIM}]" in subview
+    # The row extent is an SSA operand, not a folded constant.
+    assert f"valid [%2, %c{HEAD_DIM}_index]" in subview
+    # Per-dim result valid: dynamic row, static col. SubViewOp::verify's
+    # expectedValidDim marks only the non-constant operand kDynamic and rejects a
+    # result type that disagrees per dim, so these must NOT both be `?`.
+    result_type = _subview_result_type(mlir)
+    assert f"v_row=?, v_col={HEAD_DIM}" in result_type
+    # GM side carries the same dynamic extent.
+    assert f"!pto.partition_tensor_view<?x{HEAD_DIM}xbf16>" in mlir
+    assert "pto.tload" in mlir
+
+
+def test_gather_row_static_valid_shape_stays_static():
+    """A constant valid_shape keeps both the subview result type and the partition static."""
+    mlir = _codegen_incore(_build_static_valid_program())
+    subview = [ln for ln in mlir.splitlines() if "gather_row_view = pto.subview" in ln][0]
+    assert f"sizes [{ROWS}, {HEAD_DIM}]" in subview
+    assert f"valid [%c{STATIC_ROWS}_index, %c{HEAD_DIM}_index]" in subview
+    result_type = _subview_result_type(mlir)
+    assert f"v_row={STATIC_ROWS}, v_col={HEAD_DIM}" in result_type
+    assert "v_row=?" not in result_type
+    assert f"!pto.partition_tensor_view<{STATIC_ROWS}x{HEAD_DIM}xbf16>" in mlir
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/ir/transforms/test_gather_row.py
+++ b/tests/ut/ir/transforms/test_gather_row.py
@@ -190,6 +190,135 @@ def test_gather_row_rejects_dtype_mismatch():
                 return kv
 
 
+def test_gather_row_forwards_valid_shape_to_tile_op():
+    """The optional valid_shape rides through ConvertTensorToTileOps verbatim.
+
+    ``shapes`` sizes the pto.subview (a static attribute in the PTO dialect), so a
+    dynamic transfer length has to travel as a separate operand. Here both are
+    static, which makes the forwarded 6th operand assertable in printed IR.
+    """
+
+    @pl.program
+    class Program:
+        @pl.function(type=pl.FunctionType.InCore)
+        def kernel(self, src: pl.Tensor[[256, 128], pl.BF16]) -> pl.Tensor[[16, 128], pl.BF16]:
+            kv0 = pl.create_l1([16, 128], pl.BF16)
+            # Window is 4 rows; only 3 of them are actually transferred.
+            kv1 = pl.gather_row(kv0, src, [0, 0], [0, 0], [4, 128], valid_shape=[3, 128])
+            return kv1
+
+        @pl.function
+        def main(self, src: pl.Tensor[[256, 128], pl.BF16]) -> pl.Tensor[[16, 128], pl.BF16]:
+            r = self.kernel(src)
+            return r
+
+    text = _print_after_convert(Program)
+    assert "pl.tile.gather_row(" in text
+    assert "[0, 0], [0, 0], [4, 128], [3, 128], transpose=False)" in text
+
+
+def test_gather_row_valid_shape_roundtrips():
+    """A dynamic valid_shape survives print -> parse.
+
+    The runtime extent is a genuine SSA operand (not an attr) precisely so it can
+    be a runtime value; this pins that the printer emits it positionally and the
+    parser threads it back to the same IR.
+    """
+
+    @pl.program
+    class Program:
+        @pl.function(type=pl.FunctionType.InCore)
+        def kernel(
+            self, src: pl.Tensor[[256, 128], pl.BF16], n: pl.Tensor[[1], pl.INT32]
+        ) -> pl.Tile[[16, 128], pl.BF16, pl.Mem.Mat]:
+            rows = pl.cast(pl.read(n, [0]), pl.INDEX)
+            kv0 = pl.tile.create([16, 128], dtype=pl.BF16, target_memory=pl.Mem.Mat)
+            kv1 = pl.tile.gather_row(kv0, src, [0, 0], [0, 0], [16, 128], valid_shape=[rows, 128])
+            return kv1
+
+        @pl.function
+        def main(
+            self, src: pl.Tensor[[256, 128], pl.BF16], n: pl.Tensor[[1], pl.INT32]
+        ) -> pl.Tile[[16, 128], pl.BF16, pl.Mem.Mat]:
+            return self.kernel(src, n)
+
+    text = ir.python_print(Program, format=False)
+    assert "pl.tile.gather_row(" in text
+    reparsed = pl.parse(text)
+    ir.assert_structural_equal(Program, reparsed)
+
+
+def test_gather_row_rejects_valid_shape_exceeding_shapes():
+    """A provable valid_shape > shapes is rejected at type deduction."""
+    with pytest.raises(Exception, match="provably exceeds physical shape extent"):
+
+        @pl.program
+        class Program:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main(self, src: pl.Tensor[[256, 128], pl.BF16]) -> pl.Tensor[[16, 128], pl.BF16]:
+                kv = pl.create_l1([16, 128], pl.BF16)
+                kv = pl.gather_row(kv, src, [0, 0], [0, 0], [4, 128], valid_shape=[5, 128])
+                return kv
+
+
+def test_gather_row_rejects_valid_shape_rank_mismatch():
+    """valid_shape must have the same rank as shapes."""
+    with pytest.raises(Exception, match="valid_shape rank mismatch"):
+
+        @pl.program
+        class Program:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main(self, src: pl.Tensor[[256, 128], pl.BF16]) -> pl.Tensor[[16, 128], pl.BF16]:
+                kv = pl.create_l1([16, 128], pl.BF16)
+                kv = pl.gather_row(kv, src, [0, 0], [0, 0], [4, 128], valid_shape=[4])
+                return kv
+
+
+def test_gather_row_rejects_dynamic_shapes_at_trace_time():
+    """A runtime `shapes` fails where the user wrote it, and names valid_shape as the fix.
+
+    `shapes` sizes the pto.subview, whose `sizes` the PTO dialect types as a static
+    attribute, so a dynamic window is unrepresentable. Catching it in the deducer
+    (rather than in the backend) is what makes the error land on the pl.gather_row
+    line.
+    """
+    with pytest.raises(Exception, match="Pass a dynamic row count through valid_shape instead"):
+
+        @pl.program
+        class Program:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main(
+                self, src: pl.Tensor[[256, 128], pl.BF16], n: pl.Tensor[[1], pl.INT32]
+            ) -> pl.Tensor[[16, 128], pl.BF16]:
+                rows = pl.cast(pl.read(n, [0]), pl.INDEX)
+                kv = pl.create_l1([16, 128], pl.BF16)
+                kv = pl.gather_row(kv, src, [0, 0], [0, 0], [rows, 128])
+                return kv
+
+
+def test_gather_row_rejects_dynamic_valid_shape_with_transpose():
+    """Dynamic valid_shape + transpose=True is refused, at trace time.
+
+    The transposing gather lowers through a DN2NZ tload, which would need a runtime
+    *column* extent on a boxed NZ tile — unverified on device, so it is rejected
+    rather than silently emitted.
+    """
+    with pytest.raises(Exception, match="does not support a dynamic valid_shape together with transpose"):
+
+        @pl.program
+        class Program:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main(
+                self, src: pl.Tensor[[256, 128], pl.BF16], n: pl.Tensor[[1], pl.INT32]
+            ) -> pl.Tensor[[128, 16], pl.BF16]:
+                rows = pl.cast(pl.read(n, [0]), pl.INDEX)
+                kv = pl.create_l1([128, 16], pl.BF16, transpose=True)
+                kv = pl.gather_row(
+                    kv, src, [0, 0], [0, 0], [16, 128], valid_shape=[rows, 128], transpose=True
+                )
+                return kv
+
+
 def test_create_l1_rejects_non_positive_shape():
     """create_l1 shape dims must be positive compile-time ConstInt."""
     with pytest.raises(Exception, match="positive compile-time ConstInt"):

--- a/tests/ut/ir/transforms/test_gather_row.py
+++ b/tests/ut/ir/transforms/test_gather_row.py
@@ -23,11 +23,17 @@ transposed Mat (ZN) fractal and gather_row places each GM row [r, c] as an L1
 column [c, r].
 """
 
+import inspect
+
 import pypto.language as pl
 import pytest
 from pypto import ir, passes
 from pypto.backend import BackendType, is_backend_configured, set_backend_type
+from pypto.ir.op import tensor_ops as _ir_tensor_ops
+from pypto.ir.op import tile_ops as _ir_tile_ops
 from pypto.ir.pass_manager import OptimizationStrategy, PassManager
+from pypto.language.op import tensor_ops as _dsl_tensor_ops
+from pypto.language.op import tile_ops as _dsl_tile_ops
 
 
 def _build_program(
@@ -214,7 +220,10 @@ def test_gather_row_forwards_valid_shape_to_tile_op():
 
     text = _print_after_convert(Program)
     assert "pl.tile.gather_row(" in text
-    assert "[0, 0], [0, 0], [4, 128], [3, 128], transpose=False)" in text
+    # valid_shape prints as a kwarg: `transpose` owns the 6th positional slot in
+    # the DSL, so the operand cannot be emitted positionally without changing what
+    # an existing `gather_row(..., shapes, True)` call means.
+    assert "[0, 0], [0, 0], [4, 128], valid_shape=[3, 128], transpose=False)" in text
 
 
 def test_gather_row_valid_shape_roundtrips():
@@ -261,17 +270,47 @@ def test_gather_row_rejects_valid_shape_exceeding_shapes():
                 return kv
 
 
-def test_gather_row_rejects_valid_shape_rank_mismatch():
-    """valid_shape must have the same rank as shapes."""
-    with pytest.raises(Exception, match="valid_shape rank mismatch"):
+@pytest.mark.parametrize("valid_shape", [[4], []])
+def test_gather_row_rejects_valid_shape_rank_mismatch(valid_shape):
+    """valid_shape must match the rank of shapes.
+
+    The empty case matters on its own: ValidateValidShapeBounds reads an empty
+    valid shape as "implicitly fully valid" and accepts it, which is right for a
+    type but wrong for an explicit operand — without the rank check it would reach
+    the backend and trip an INTERNAL_CHECK instead of telling the user.
+    """
+    with pytest.raises(Exception, match="valid_shape to have the same rank as shapes"):
 
         @pl.program
         class Program:
             @pl.function(type=pl.FunctionType.InCore)
             def main(self, src: pl.Tensor[[256, 128], pl.BF16]) -> pl.Tensor[[16, 128], pl.BF16]:
                 kv = pl.create_l1([16, 128], pl.BF16)
-                kv = pl.gather_row(kv, src, [0, 0], [0, 0], [4, 128], valid_shape=[4])
+                kv = pl.gather_row(kv, src, [0, 0], [0, 0], [4, 128], valid_shape=valid_shape)
                 return kv
+
+
+def test_gather_row_valid_shape_is_keyword_only():
+    """Adding valid_shape must not re-bind an existing positional `transpose`.
+
+    `gather_row(..., shapes, True)` was a valid call before valid_shape existed.
+    Had valid_shape taken the 6th slot, that call would silently pass `True` as a
+    shape and fail with an opaque "'Scalar' object is not iterable", so it is
+    keyword-only in all four wrappers. Asserted on the signatures because that is
+    the contract an external caller binds against.
+    """
+    wrappers = [
+        (_dsl_tensor_ops.gather_row, "pl.gather_row"),
+        (_dsl_tile_ops.gather_row, "pl.tile.gather_row"),
+        (_ir_tensor_ops.gather_row, "ir.op.tensor_ops.gather_row"),
+        (_ir_tile_ops.gather_row, "ir.op.tile_ops.gather_row"),
+    ]
+    for fn, name in wrappers:
+        params = list(inspect.signature(fn).parameters.values())
+        positional = [p.name for p in params if p.kind is p.POSITIONAL_OR_KEYWORD]
+        keyword_only = [p.name for p in params if p.kind is p.KEYWORD_ONLY]
+        assert positional[5] == "transpose", f"{name}: 6th positional is {positional[5]!r}, not 'transpose'"
+        assert "valid_shape" in keyword_only, f"{name}: valid_shape must be keyword-only"
 
 
 def test_gather_row_rejects_dynamic_shapes_at_trace_time():

--- a/tests/ut/ir/transforms/test_gather_row.py
+++ b/tests/ut/ir/transforms/test_gather_row.py
@@ -313,6 +313,25 @@ def test_gather_row_valid_shape_is_keyword_only():
         assert "valid_shape" in keyword_only, f"{name}: valid_shape must be keyword-only"
 
 
+def test_gather_row_rejects_non_integer_valid_shape():
+    """A fractional extent is rejected rather than reaching lowering.
+
+    The bounds proofs answer "unknown" for a non-integer scalar instead of
+    rejecting it, so without an explicit dtype check `valid_shape=[1.5, 128]`
+    would pass deduction.
+    """
+    with pytest.raises(Exception, match="valid_shape\\[0\\] to be an integer extent"):
+
+        @pl.program
+        class Program:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main(self, src: pl.Tensor[[256, 128], pl.BF16]) -> pl.Tensor[[16, 128], pl.BF16]:
+                kv = pl.create_l1([16, 128], pl.BF16)
+                # Deliberately ill-typed: this asserts the *runtime* rejection.
+                kv = pl.gather_row(kv, src, [0, 0], [0, 0], [4, 128], valid_shape=[1.5, 128])  # type: ignore[list-item]
+                return kv
+
+
 def test_gather_row_rejects_dynamic_shapes_at_trace_time():
     """A runtime `shapes` fails where the user wrote it, and names valid_shape as the fix.
 


### PR DESCRIPTION
## Problem

`tile.gather_row` is the only GM→L1 path — it performs the ND→ZN layout conversion a matmul B-operand needs — but it could not express a **runtime row count**. `shapes` must stay compile-time constant because ptoas types `pto.subview`'s `sizes` as a static `I64ArrayAttr` (`SubViewOp` in `PTOOps.td`), so a dynamic window is not expressible at all.

This came up rewriting a DeepSeek-V4-Flash HCA decode attention to assemble its sparse-K operand on-chip: the window is 128 consecutive positions over a page-aligned paged KV cache, i.e. 1–2 contiguous runs whose split point is a runtime value. The workaround was a binary decomposition into ≤8 guarded constant-length calls plus ~30 lines of arithmetic.

## Change

Add an optional trailing `valid_shape` operand carrying the runtime transfer extent. It feeds the subview's `valid_row`/`valid_col` (`Optional<Index>` SSA operands) and the GM `partition_view` sizes — both of which accept dynamic values — so the tile stays statically `shapes`-sized and only the copy length varies. Allocation and NZ box alignment are untouched.

```python
kv = pl.create_l1([128, HEAD_DIM], pl.BF16)
kv = pl.gather_row(kv, pool, [0, 0],  [b0, 0], [128, HEAD_DIM], valid_shape=[r1, HEAD_DIM])
kv = pl.gather_row(kv, pool, [r1, 0], [b1, 0], [128, HEAD_DIM], valid_shape=[128 - r1, HEAD_DIM])
oi = pl.matmul(q, kv, b_trans=True)
```

Omitting `valid_shape` reproduces the previous lowering byte for byte; all existing 5-arg callers are unaffected.

## Why the GM partition must be narrowed too

This is the subtle part, and it is load-bearing rather than tidiness. On a2a3 the fractal path `TLoadGm2L1Nd2nz` (`pto-isa .../memory/tload_common.hpp`) takes `validRow`/`validCol` as parameters and **never reads them**, deriving the DMA extent solely from the GlobalTensor shape (`nValue = gShape3`). Unlike its non-fractal `TLoadGm2L1Nd2nd` sibling it has **no `PTO_ASSERT`** cross-checking the two. So setting only the subview's `valid [...]` would move the whole static window with no error at any level.

a5 is the mirror image — its tilelang tload template drives the extent from `dst.valid_shape`. Feeding both is what makes a dynamic extent correct on either arch. This is documented at the line that would break, with a pointer to the guarding test.

## Design notes

- **Positional operand, not an attr** — a runtime extent must stay in the use-def chain so SSA/liveness keep the scalar alive.
- **Does not propagate into the DPS result type** — unlike `tile.load`, the accumulator keeps the full extent it was allocated with, because its other rows hold previously gathered data.
- **Preconditions live in the deducer**, so they fail at the `pl.gather_row(...)` line rather than in the backend: constant `shapes` (message names `valid_shape` as the fix), rank + provable bounds against `shapes`, and static `valid_shape` under `transpose=True` (that path lowers through a DN2NZ tload that would need a runtime *column* extent on a boxed NZ tile — unverified on device, so refused rather than silently emitted).

## Testing

**On-device (910B):** `tests/st/runtime/ops/test_gather_row_dynamic_valid_shape.py` sentinel-fills the accumulator with one full-window gather, overwrites a runtime number of rows with a second, and checks the untouched tail keeps its sentinel — at r = 1, 63, 127, 128. Since the two source regions are disjoint row-id-encoded ranges, a transfer that ignored the extent fails immediately. I ran a negative control (golden = "extent ignored") and confirmed it mismatches, so the test demonstrably has teeth.

**Emitted form** verified through the real ptoas 0.48 (`rc=0`), per-dim static/dynamic as `SubViewOp::verify` requires:

```mlir
%gather_row_view = pto.subview %0[...] sizes [128, 128] valid [%2, %c128_index]
    : !pto.tile_buf<loc=mat, ..., v_row=?, v_col=?, ...> -> !pto.tile_buf<loc=mat, ..., v_row=?, v_col=128, ...>
%src_pview = pto.partition_view %src_view, ..., sizes = [%2, %c128_index]
    : !pto.tensor_view<?x?xbf16> -> !pto.partition_tensor_view<?x128xbf16>
```

**Unit tests:** 7710 passed / 2 skipped. New coverage for forwarding through `ConvertTensorToTileOps`, dynamic round-trip, the three trace-time rejections, and codegen assertions for the dynamic/static paths.

**Lint:** ruff, clang-format, clang-tidy, and all pre-commit hooks clean.

Docs updated in `docs/en/` and `docs/zh-cn/` `10-convert_tensor_to_tile_ops.md`.