### PR TITLE
feat(core): add FP8E8M0 dtype for MX block-scale exponents

### DIFF
--- a/docs/en/user/01-language_guide.md
+++ b/docs/en/user/01-language_guide.md
@@ -17,9 +17,10 @@ Complete reference for the `pypto.language` (`pl`) module.
 | `pl.FP16` | 16 | IEEE half-precision float |
 | `pl.BF16` | 16 | Brain float 16 |
 | `pl.FP32` | 32 | IEEE single-precision float |
-| `pl.FP4` | 4 | 4-bit float |
-| `pl.FP8E4M3FN` | 8 | 8-bit float (e4m3fn) |
-| `pl.FP8E5M2` | 8 | 8-bit float (e5m2) |
+| `pl.FP4` | 4 | 4-bit float (packed MXFP4 E2M1×2; PTOAS `!pto.f4E2M1x2`) |
+| `pl.FP8E4M3FN` | 8 | 8-bit float (e4m3fn); MXFP8 data |
+| `pl.FP8E5M2` | 8 | 8-bit float (e5m2); MXFP8 data |
+| `pl.FP8E8M0` | 8 | MX block-scale exponent (E8M0); PTOAS `!pto.f8E8M0` / pto-isa `float8_e8m0_t` |
 | `pl.HF4` / `pl.HF8` | 4/8 | Hisilicon float formats |
 | `pl.INDEX` | 64 | Index type for index computations — loop vars, dimensions |
 

--- a/docs/zh-cn/user/01-language_guide.md
+++ b/docs/zh-cn/user/01-language_guide.md
@@ -17,9 +17,10 @@
 | `pl.FP16` | 16 | IEEE 半精度浮点 |
 | `pl.BF16` | 16 | Brain Float 16 |
 | `pl.FP32` | 32 | IEEE 单精度浮点 |
-| `pl.FP4` | 4 | 4 位浮点 |
-| `pl.FP8E4M3FN` | 8 | 8 位浮点（e4m3fn） |
-| `pl.FP8E5M2` | 8 | 8 位浮点（e5m2） |
+| `pl.FP4` | 4 | 4 位浮点（打包 MXFP4 E2M1×2；PTOAS `!pto.f4E2M1x2`） |
+| `pl.FP8E4M3FN` | 8 | 8 位浮点（e4m3fn）；MXFP8 数据 |
+| `pl.FP8E5M2` | 8 | 8 位浮点（e5m2）；MXFP8 数据 |
+| `pl.FP8E8M0` | 8 | MX 块缩放指数（E8M0）；PTOAS `!pto.f8E8M0` / pto-isa `float8_e8m0_t` |
 | `pl.HF4` / `pl.HF8` | 4/8 | 昇腾浮点格式 |
 | `pl.INDEX` | 64 | 索引计算类型 —— 循环变量、维度 |
 

--- a/include/pypto/core/dtype.h
+++ b/include/pypto/core/dtype.h
@@ -75,9 +75,10 @@ class DataType {
   static constexpr uint8_t kFp8e5m2Code = 0x32;
   static constexpr uint8_t kFp16Code = 0x33;
   static constexpr uint8_t kFp32Code = 0x34;
-  static constexpr uint8_t kFp64Code = 0x35;  // Reserved for future FP64 support
+  static constexpr uint8_t kFp64Code = 0x35;     // Reserved for future FP64 support
+  static constexpr uint8_t kFp8e8m0Code = 0x36;  // MX block-scale exponent (E8M0)
   static constexpr uint8_t kIeeeFloatRangeEnd = 0x3F;
-  // 0x36-0x3F reserved for future IEEE float types
+  // 0x37-0x3F reserved for future IEEE float types
 
   // Brain/Hisilicon float types: 0x40-0x4F (16 slots reserved)
   static constexpr uint8_t kBrainFloatRangeStart = 0x40;
@@ -110,6 +111,7 @@ class DataType {
   static const DataType FP4;        // 4-bit floating point
   static const DataType FP8E4M3FN;  // 8-bit floating point (IEEE 754 e4m3fn format)
   static const DataType FP8E5M2;    // 8-bit floating point (IEEE 754 e5m2 format)
+  static const DataType FP8E8M0;    // 8-bit floating point (E8M0 MX block-scale exponent)
   static const DataType FP16;       // 16-bit floating point (IEEE 754 half precision)
   static const DataType FP32;       // 32-bit floating point (IEEE 754 single precision)
   static const DataType BF16;       // 16-bit brain floating point
@@ -160,6 +162,7 @@ class DataType {
       case kHf8Code:
       case kFp8e4m3fnCode:
       case kFp8e5m2Code:
+      case kFp8e8m0Code:
       case kUInt8Code:
       case kInt8Code:
         return 8;
@@ -227,6 +230,8 @@ class DataType {
         return "fp8e4m3fn";
       case kFp8e5m2Code:
         return "fp8e5m2";
+      case kFp8e8m0Code:
+        return "fp8e8m0";
       case kFp16Code:
         return "fp16";
       case kFp32Code:
@@ -284,6 +289,15 @@ class DataType {
         return "double";
       case kBf16Code:
         return "bfloat16_t";
+      case kFp8e4m3fnCode:
+        return "float8_e4m3_t";
+      case kFp8e5m2Code:
+        return "float8_e5m2_t";
+      case kFp8e8m0Code:
+        // Align with PTOAS EmitC for !pto.f8E8M0 → float8_e8m0_t.
+        return "float8_e8m0_t";
+      case kFp4Code:
+        return "float4_e2m1x2_t";
       default:
         return "unknown";
     }
@@ -376,6 +390,7 @@ inline constexpr DataType DataType::UINT64 = DataType(kUInt64Code);
 inline constexpr DataType DataType::FP4 = DataType(kFp4Code);
 inline constexpr DataType DataType::FP8E4M3FN = DataType(kFp8e4m3fnCode);
 inline constexpr DataType DataType::FP8E5M2 = DataType(kFp8e5m2Code);
+inline constexpr DataType DataType::FP8E8M0 = DataType(kFp8e8m0Code);
 inline constexpr DataType DataType::FP16 = DataType(kFp16Code);
 inline constexpr DataType DataType::FP32 = DataType(kFp32Code);
 inline constexpr DataType DataType::BF16 = DataType(kBf16Code);
@@ -415,6 +430,7 @@ inline std::string DataTypeToString(const DataType& dtype) {
   if (dtype == DataType::FP4) return "FP4";
   if (dtype == DataType::FP8E4M3FN) return "FP8E4M3FN";
   if (dtype == DataType::FP8E5M2) return "FP8E5M2";
+  if (dtype == DataType::FP8E8M0) return "FP8E8M0";
   if (dtype == DataType::FP16) return "FP16";
   if (dtype == DataType::FP32) return "FP32";
   if (dtype == DataType::BF16) return "BF16";

--- a/python/bindings/modules/core.cpp
+++ b/python/bindings/modules/core.cpp
@@ -40,6 +40,7 @@ void BindCore(nb::module_& m) {
       .def_ro_static("FP4", &DataType::FP4, "4-bit floating point")
       .def_ro_static("FP8E4M3FN", &DataType::FP8E4M3FN, "8-bit floating point (E4M3FN format)")
       .def_ro_static("FP8E5M2", &DataType::FP8E5M2, "8-bit floating point (E5M2 format)")
+      .def_ro_static("FP8E8M0", &DataType::FP8E8M0, "8-bit floating point (E8M0 MX block-scale exponent)")
       .def_ro_static("FP16", &DataType::FP16, "16-bit floating point (IEEE 754 half precision)")
       .def_ro_static("FP32", &DataType::FP32, "32-bit floating point (IEEE 754 single precision)")
       .def_ro_static("BF16", &DataType::BF16, "16-bit brain floating point")

--- a/python/pypto/__init__.py
+++ b/python/pypto/__init__.py
@@ -51,6 +51,7 @@ DT_UINT64: DataType = cast(DataType, DataType.UINT64)
 DT_FP4: DataType = cast(DataType, DataType.FP4)
 DT_FP8E4M3FN: DataType = cast(DataType, DataType.FP8E4M3FN)
 DT_FP8E5M2: DataType = cast(DataType, DataType.FP8E5M2)
+DT_FP8E8M0: DataType = cast(DataType, DataType.FP8E8M0)
 DT_FP16: DataType = cast(DataType, DataType.FP16)
 DT_FP32: DataType = cast(DataType, DataType.FP32)
 DT_BF16: DataType = cast(DataType, DataType.BF16)
@@ -97,6 +98,7 @@ __all__ = [
     "DT_FP4",
     "DT_FP8E4M3FN",
     "DT_FP8E5M2",
+    "DT_FP8E8M0",
     "DT_FP16",
     "DT_FP32",
     "DT_BF16",

--- a/python/pypto/ir/__init__.py
+++ b/python/pypto/ir/__init__.py
@@ -72,6 +72,7 @@ from .type import (  # also shadows C++ TensorView/TileView with Python subclass
 FP4 = DataType.FP4
 FP8E4M3FN = DataType.FP8E4M3FN
 FP8E5M2 = DataType.FP8E5M2
+FP8E8M0 = DataType.FP8E8M0  # MX block-scale exponent
 FP16 = DataType.FP16
 FP32 = DataType.FP32
 BF16 = DataType.BF16

--- a/python/pypto/ir/__init__.pyi
+++ b/python/pypto/ir/__init__.pyi
@@ -52,6 +52,7 @@ scalar_dir: ArgDirection
 FP4: DataType
 FP8E4M3FN: DataType
 FP8E5M2: DataType
+FP8E8M0: DataType
 FP16: DataType
 FP32: DataType
 BF16: DataType

--- a/python/pypto/ir/compiled_program.py
+++ b/python/pypto/ir/compiled_program.py
@@ -71,6 +71,19 @@ for _name in ("uint16", "uint32", "uint64"):
     if _torch_dtype is not None:
         _DATATYPE_TO_TORCH[_name] = _torch_dtype
 del _name, _torch_dtype
+# Float8 / MX scale dtypes (PyTorch 2.1+ / 2.3+ / 2.7+); map IR string → torch.dtype.
+# Packed MXFP4 (fp4 ↔ float4_e2m1fn_x2) must be here so return-style execution
+# can allocate FP4 outputs after JIT specialization accepts the torch dtype.
+for _ir_name, _torch_name in (
+    ("fp8e4m3fn", "float8_e4m3fn"),
+    ("fp8e5m2", "float8_e5m2"),
+    ("fp8e8m0", "float8_e8m0fnu"),
+    ("fp4", "float4_e2m1fn_x2"),
+):
+    _torch_dtype = getattr(torch, _torch_name, None)
+    if _torch_dtype is not None:
+        _DATATYPE_TO_TORCH[_ir_name] = _torch_dtype
+del _ir_name, _torch_name, _torch_dtype
 
 # IR DataType -> ctypes scalar constructor mapping.
 # Used to wrap Python int/float/bool values into the correct ctypes scalar
@@ -117,7 +130,7 @@ class _ParamInfo:
 _STR_TO_DATATYPE: dict[str, DataType] = {}
 for _dt_name in (
     "BOOL", "INT4", "INT8", "INT16", "INT32", "INT64", "UINT4", "UINT8", "UINT16",
-    "UINT32", "UINT64", "FP4", "FP8E4M3FN", "FP8E5M2", "FP16", "FP32", "BF16",
+    "UINT32", "UINT64", "FP4", "FP8E4M3FN", "FP8E5M2", "FP8E8M0", "FP16", "FP32", "BF16",
     "HF4", "HF8", "INDEX", "TASK_ID",
 ):  # fmt: skip
     _dt = getattr(DataType, _dt_name, None)

--- a/python/pypto/jit/decorator.py
+++ b/python/pypto/jit/decorator.py
@@ -143,6 +143,18 @@ def _get_torch() -> Any:
                     torch.bool: DataType.BOOL,
                 }
             )
+            # Optional low-precision MX dtypes (PyTorch 2.1+/2.3+/2.7+); required
+            # for MX DSL ST. float4_e2m1fn_x2 is the packed MXFP4 weight dtype.
+            for _torch_name, _pto_dt in (
+                ("float8_e4m3fn", DataType.FP8E4M3FN),
+                ("float8_e5m2", DataType.FP8E5M2),
+                ("float8_e8m0fnu", DataType.FP8E8M0),
+                ("float4_e2m1fn_x2", DataType.FP4),
+            ):
+                _td = getattr(torch, _torch_name, None)
+                if _td is not None:
+                    _TORCH_DTYPE_MAP[_td] = _pto_dt
+
         except ImportError:
             _TORCH_CACHE.append(None)
     return _TORCH_CACHE[0]
@@ -153,7 +165,8 @@ def _torch_dtype_to_pypto(torch_dtype: Any) -> DataType:
     if torch_dtype not in _TORCH_DTYPE_MAP:
         raise TypeError(
             f"Unsupported torch dtype {torch_dtype}. "
-            "Supported: float16, float32, bfloat16, int8/16/32/64, uint8, bool."
+            "Supported: float16, float32, bfloat16, int8/16/32/64, uint8, bool, "
+            "float8_e4m3fn/e5m2/e8m0fnu, float4_e2m1fn_x2 (where torch supports them)."
         )
     return _TORCH_DTYPE_MAP[torch_dtype]
 

--- a/python/pypto/jit/specializer.py
+++ b/python/pypto/jit/specializer.py
@@ -201,6 +201,7 @@ _DTYPE_TO_PL: dict[DataType, str] = {
     DataType.FP4: "pl.FP4",
     DataType.FP8E4M3FN: "pl.FP8E4M3FN",
     DataType.FP8E5M2: "pl.FP8E5M2",
+    DataType.FP8E8M0: "pl.FP8E8M0",
     DataType.FP16: "pl.FP16",
     DataType.FP32: "pl.FP32",
     DataType.BF16: "pl.BF16",

--- a/python/pypto/language/__init__.py
+++ b/python/pypto/language/__init__.py
@@ -243,6 +243,7 @@ NZ = TensorLayout.NZ
 FP4 = DataType.FP4
 FP8E4M3FN = DataType.FP8E4M3FN
 FP8E5M2 = DataType.FP8E5M2
+FP8E8M0 = DataType.FP8E8M0
 FP16 = DataType.FP16
 FP32 = DataType.FP32
 BF16 = DataType.BF16
@@ -476,6 +477,7 @@ __all__ = [
     "FP4",
     "FP8E4M3FN",
     "FP8E5M2",
+    "FP8E8M0",
     "FP16",
     "FP32",
     "BF16",

--- a/python/pypto/language/parser/type_resolver.py
+++ b/python/pypto/language/parser/type_resolver.py
@@ -134,6 +134,7 @@ class TypeResolver:
         "FP4": DataType.FP4,
         "FP8E4M3FN": DataType.FP8E4M3FN,
         "FP8E5M2": DataType.FP8E5M2,
+        "FP8E8M0": DataType.FP8E8M0,
         "FP16": DataType.FP16,
         "FP32": DataType.FP32,
         "BF16": DataType.BF16,

--- a/python/pypto/pypto_core/__init__.pyi
+++ b/python/pypto/pypto_core/__init__.pyi
@@ -47,6 +47,7 @@ class DataType:
     FP4: DataType  # 4-bit floating point
     FP8E4M3FN: DataType  # 8-bit floating point (IEEE 754 e4m3fn format)
     FP8E5M2: DataType  # 8-bit floating point (IEEE 754 e5m2 format)
+    FP8E8M0: DataType  # 8-bit floating point (E8M0 MX block-scale exponent)
     FP16: DataType  # 16-bit floating point (IEEE 754 half precision)
     FP32: DataType  # 32-bit floating point (IEEE 754 single precision)
     BF16: DataType  # 16-bit brain floating point

--- a/src/codegen/codegen_base.cpp
+++ b/src/codegen/codegen_base.cpp
@@ -126,6 +126,9 @@ std::string CodegenBase::GetRuntimeDataTypeString(const DataType& dtype) const {
   if (dtype == DataType::UINT16) return "DataType::UINT16";
   if (dtype == DataType::UINT32) return "DataType::UINT32";
   if (dtype == DataType::BF16) return "DataType::BFLOAT16";
+  if (dtype == DataType::FP8E4M3FN) return "DataType::FP8E4M3FN";
+  if (dtype == DataType::FP8E5M2) return "DataType::FP8E5M2";
+  if (dtype == DataType::FP8E8M0) return "DataType::FP8E8M0";
   // INDEX is a semantic type in the IR; the runtime represents it as INT64
   if (dtype == DataType::INDEX) return "DataType::INT64";
   if (dtype == DataType::INT64) return "DataType::INT64";

--- a/src/codegen/pto/pto_type_utils.cpp
+++ b/src/codegen/pto/pto_type_utils.cpp
@@ -36,6 +36,22 @@ std::string DataTypeToMLIR(DataType dtype) {
     return "f16";
   } else if (dtype == DataType::BF16) {
     return "bf16";
+  } else if (dtype == DataType::FP8E4M3FN) {
+    // PTOAS v0.48 tile_buf dtype spelling (lowercase f8e4m3 does not parse).
+    return "f8E4M3FN";
+  } else if (dtype == DataType::FP8E5M2) {
+    return "f8E5M2";
+  } else if (dtype == DataType::FP8E8M0) {
+    // Bare `f8E8M0` does not parse; PTOAS v0.48+ requires the dialect type.
+    // EmitC maps loc=scaling + !pto.f8E8M0 → TileType::ScaleLeft/ScaleRight
+    // (ui8 would wrongly become Fixpipe TileType::Scaling).
+    return "!pto.f8E8M0";
+  } else if (dtype == DataType::FP4) {
+    // MXFP4 E2M1 packed form used by pto-isa / PTOAS for MX matmul. Bare
+    // `f4E2M1x2` does not parse in PTOAS (the bare-keyword parser lacks it);
+    // the dialect type `!pto.f4E2M1x2` (TableGen mnemonic) is accepted in all
+    // emit contexts (ptr<>, tile_buf dtype=, tensor_view element).
+    return "!pto.f4E2M1x2";
   } else if (dtype == DataType::INT32) {
     return "i32";
   } else if (dtype == DataType::UINT32) {

--- a/tests/ut/core/test_dtype.py
+++ b/tests/ut/core/test_dtype.py
@@ -17,6 +17,7 @@ from pypto import (
     DT_FP4,
     DT_FP8E4M3FN,
     DT_FP8E5M2,
+    DT_FP8E8M0,
     DT_FP16,
     DT_FP32,
     DT_HF4,
@@ -52,6 +53,7 @@ class TestDataTypeEnum:
         # Floating point
         assert hasattr(DataType, "FP8E4M3FN")
         assert hasattr(DataType, "FP8E5M2")
+        assert hasattr(DataType, "FP8E8M0")
         assert hasattr(DataType, "FP16")
         assert hasattr(DataType, "FP32")
         assert hasattr(DataType, "BF16")
@@ -89,6 +91,7 @@ class TestDataTypeEnum:
             DataType.FP4,
             DataType.FP8E4M3FN,
             DataType.FP8E5M2,
+            DataType.FP8E8M0,
             DataType.FP16,
             DataType.FP32,
             DataType.BF16,
@@ -123,6 +126,7 @@ class TestDataTypeEnum:
         assert DT_FP4 == DataType.FP4
         assert DT_FP8E4M3FN == DataType.FP8E4M3FN
         assert DT_FP8E5M2 == DataType.FP8E5M2
+        assert DT_FP8E8M0 == DataType.FP8E8M0
         assert DT_FP16 == DataType.FP16
         assert DT_FP32 == DataType.FP32
         assert DT_BF16 == DataType.BF16
@@ -146,6 +150,7 @@ class TestDataTypeEnum:
         assert hasattr(pypto, "DT_FP4")
         assert hasattr(pypto, "DT_FP8E4M3FN")
         assert hasattr(pypto, "DT_FP8E5M2")
+        assert hasattr(pypto, "DT_FP8E8M0")
         assert hasattr(pypto, "DT_FP16")
         assert hasattr(pypto, "DT_FP32")
         assert hasattr(pypto, "DT_BF16")
@@ -176,6 +181,7 @@ class TestDataTypeBit:
         assert pypto.DT_UINT8.get_bit() == 8
         assert pypto.DT_FP8E4M3FN.get_bit() == 8
         assert pypto.DT_FP8E5M2.get_bit() == 8
+        assert pypto.DT_FP8E8M0.get_bit() == 8
         assert pypto.DT_HF8.get_bit() == 8
 
     def test_16bit_types(self):
@@ -221,6 +227,7 @@ class TestDataTypeString:
         assert pypto.DT_FP4.to_string() == "fp4"
         assert pypto.DT_FP8E4M3FN.to_string() == "fp8e4m3fn"
         assert pypto.DT_FP8E5M2.to_string() == "fp8e5m2"
+        assert pypto.DT_FP8E8M0.to_string() == "fp8e8m0"
         assert pypto.DT_FP16.to_string() == "fp16"
         assert pypto.DT_FP32.to_string() == "fp32"
         assert pypto.DT_BF16.to_string() == "bfloat16"
@@ -244,6 +251,7 @@ class TestDataTypePredicates:
         assert pypto.DT_FP4.is_float() is True
         assert pypto.DT_FP8E4M3FN.is_float() is True
         assert pypto.DT_FP8E5M2.is_float() is True
+        assert pypto.DT_FP8E8M0.is_float() is True
         assert pypto.DT_FP16.is_float() is True
         assert pypto.DT_FP32.is_float() is True
         assert pypto.DT_BF16.is_float() is True
@@ -302,6 +310,7 @@ class TestDataTypePredicates:
         assert pypto.DT_FP4.is_int() is False
         assert pypto.DT_FP8E4M3FN.is_int() is False
         assert pypto.DT_FP8E5M2.is_int() is False
+        assert pypto.DT_FP8E8M0.is_int() is False
         assert pypto.DT_FP16.is_int() is False
         assert pypto.DT_FP32.is_int() is False
         assert pypto.DT_BF16.is_int() is False
@@ -320,6 +329,7 @@ class TestDataTypePredicates:
             DT_FP4,
             DT_FP8E4M3FN,
             DT_FP8E5M2,
+            DT_FP8E8M0,
             DT_FP16,
             DT_FP32,
             DT_BF16,


### PR DESCRIPTION
## Summary

Introduce `DataType::FP8E8M0` (1-byte E8M0 MX scale exponent) through the dtype system, EmitC/MLIR spellings (`float8_e8m0_t` / `!pto.f8E8M0`), and Python bindings/stubs/DSL resolver/JIT torch maps. Also fills previously missing EmitC/MLIR mappings for FP8E4M3FN, FP8E5M2, and packed FP4. No new memory spaces or ops.

## pto-isa / PTOAS interface alignment

This PR only adds the **dtype / type-string** surface that later MX PRs wire into ops. Mapping:

### pto-isa (A5 MX)

| C++ type | Role |
| -------- | ---- |
| `float8_e8m0_t` | MX block-scale shared exponent (E8=8, M=0, bias=127); `include/pto/cpu/MXTypes.hpp`; A5 `TypeGet` → `vector_f8e8m0` |
| `float8_e4m3_t` / `float8_e5m2_t` | MXFP8 data element types |
| `float4_e2m1x2_t` | Packed MXFP4 E2M1×2 |
| `TileType::ScaleLeft` / `ScaleRight` | L0A / L0B MX scale buffers (`include/pto/common/type.hpp`); scale tiles use `float8_e8m0_t` (e.g. `TLoad` with `MX_A_ZZ` / `MX_B_NN`) |

### PTOAS (v0.48+ dialect + EmitC)

| MLIR / loc | EmitC / ISA |
| ---------- | ----------- |
| `!pto.f8E8M0` | `float8_e8m0_t` |
| `f8E4M3FN` | `float8_e4m3_t` |
| `f8E5M2` | `float8_e5m2_t` |
| `!pto.f4E2M1x2` | `float4_e2m1x2_t` |
| `loc=scaling` + `!pto.f8E8M0` | `TileType::ScaleLeft` / `ScaleRight` (**not** Fixpipe `TileType::Scaling`; bare `ui8`+`scaling` maps wrongly) |

Bare keywords `f8E8M0` / `f4E2M1x2` do not parse in PTOAS — dialect types are required.

### PyPTO

| `DataType` | MLIR | pto-isa C++ | torch (optional) |
| ---------- | ---- | ----------- | ---------------- |
| `FP8E8M0` | `!pto.f8E8M0` | `float8_e8m0_t` | `float8_e8m0fnu` |
| `FP8E4M3FN` | `f8E4M3FN` | `float8_e4m3_t` | `float8_e4m3fn` |
| `FP8E5M2` | `f8E5M2` | `float8_e5m2_t` | `float8_e5m2` |
| `FP4` | `!pto.f4E2M1x2` | `float4_e2m1x2_t` | `float4_e2m1fn_x2` |

## Test plan

- [x] `pytest tests/ut/core/test_dtype.py -q`
- [ ] Language guide dtype tables list `pl.FP8E8M0` (en + zh)
- [ ] `_DATATYPE_TO_TORCH` includes `fp4` → `float4_e2m1fn_x2` when torch exposes it