### PR TITLE
chore(3rdparty): Track upstream libbacktrace instead of fork

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,6 @@
 [submodule "3rdparty/libbacktrace"]
 	path = 3rdparty/libbacktrace
-	url = https://github.com/Hzfengsy/libbacktrace.git
-	branch = macho-bundle-support
+	url = https://github.com/ianlancetaylor/libbacktrace.git
 [submodule "3rdparty/msgpack-c"]
 	path = 3rdparty/msgpack-c
 	url = https://github.com/msgpack/msgpack-c.git

--- a/cmake/libbacktrace.cmake
+++ b/cmake/libbacktrace.cmake
@@ -57,7 +57,11 @@ set_target_properties(libbacktrace PROPERTIES
 )
 add_dependencies(libbacktrace project_libbacktrace)
 
-# Function to run dsymutil on macOS for libbacktrace debug symbols
+# Function to run dsymutil on macOS to emit a .dSYM bundle.
+#
+# Note: libbacktrace no longer consults this. Upstream's Mach-O reader rejects the MH_BUNDLE
+# filetype of a CPython extension module before it ever looks for a companion .dSYM, so macOS
+# gets no C++ stack traces regardless. Kept because the .dSYM is still what lldb reads.
 function(pypto_add_apple_dsymutil target_name)
     if(APPLE)
         find_program(DSYMUTIL dsymutil)

--- a/docs/en/dev/02-error-handling.md
+++ b/docs/en/dev/02-error-handling.md
@@ -36,9 +36,11 @@ std::runtime_error
 Upstream's Mach-O reader accepts only `MH_EXECUTE`, `MH_DYLIB` and `MH_DSYM`, but a CPython
 extension module is an `MH_BUNDLE` — so on **macOS** symbolization fails and `GetFullMessage()`
 falls back to `No stack trace available`. No build mode changes this; it is a filetype gate, not
-missing debug info. Linux (ELF) is unaffected and produces full traces.
+missing debug info. Linux (ELF) is unaffected, but still needs debug info: `Debug` or
+`RelWithDebInfo` (the default) pass `-g` and produce full traces, while a plain `Release` build is
+`-O2 -DNDEBUG` with no `-g`, so frames carry no source location and the same fallback appears.
 
-`Backtrace::ErrorCallback` reports each distinct libbacktrace *message* only once. Without that,
+`Backtrace::ErrorCallback` reports each distinct `(message, errno)` pair only once. Without that,
 macOS would emit one `no debug info in Mach-O executable` line per stack frame of every captured
 trace, since the dyld init path succeeds overall and installs `macho_nodebug` as the fileline
 handler.

--- a/docs/en/dev/02-error-handling.md
+++ b/docs/en/dev/02-error-handling.md
@@ -30,6 +30,19 @@ std::runtime_error
 
 `Error::GetFullMessage()` returns the error message plus a formatted C++ stack trace.
 
+### Platform support for stack traces
+
+`3rdparty/libbacktrace` tracks upstream [ianlancetaylor/libbacktrace](https://github.com/ianlancetaylor/libbacktrace).
+Upstream's Mach-O reader accepts only `MH_EXECUTE`, `MH_DYLIB` and `MH_DSYM`, but a CPython
+extension module is an `MH_BUNDLE` — so on **macOS** symbolization fails and `GetFullMessage()`
+falls back to `No stack trace available`. No build mode changes this; it is a filetype gate, not
+missing debug info. Linux (ELF) is unaffected and produces full traces.
+
+`Backtrace::ErrorCallback` reports each distinct libbacktrace *message* only once. Without that,
+macOS would emit one `no debug info in Mach-O executable` line per stack frame of every captured
+trace, since the dyld init path succeeds overall and installs `macho_nodebug` as the fileline
+handler.
+
 ## Assertion Macros
 
 ### User-facing checks — `CHECK` / `CHECK_SPAN`

--- a/docs/zh-cn/dev/02-error-handling.md
+++ b/docs/zh-cn/dev/02-error-handling.md
@@ -36,9 +36,11 @@ std::runtime_error
 上游的 Mach-O 读取器只接受 `MH_EXECUTE`、`MH_DYLIB` 和 `MH_DSYM`，而 CPython 扩展模块是
 `MH_BUNDLE`——因此在 **macOS** 上符号化会失败，`GetFullMessage()` 退化为
 `No stack trace available`。任何构建模式都无法改变这一点：这是文件类型（filetype）的限制，
-而非缺少调试信息。Linux（ELF）不受影响，可生成完整回溯。
+而非缺少调试信息。Linux（ELF）不受影响，但仍然需要调试信息：`Debug` 和 `RelWithDebInfo`
+（默认值）会传入 `-g`，可生成完整回溯；而纯 `Release` 构建为 `-O2 -DNDEBUG`、不含 `-g`，
+栈帧因此没有源码位置，同样会退化为上述提示。
 
-`Backtrace::ErrorCallback` 对每条不同的 libbacktrace *消息*只上报一次。否则在 macOS 上，每次
+`Backtrace::ErrorCallback` 对每个不同的 `(消息, errno)` 组合只上报一次。否则在 macOS 上，每次
 捕获回溯都会为**每个栈帧**打印一行 `no debug info in Mach-O executable`——因为 dyld 初始化
 路径整体上是成功的，并会把 `macho_nodebug` 装为 fileline 处理函数。
 

--- a/docs/zh-cn/dev/02-error-handling.md
+++ b/docs/zh-cn/dev/02-error-handling.md
@@ -30,6 +30,18 @@ std::runtime_error
 
 `Error::GetFullMessage()` 返回错误消息加上格式化的 C++ 栈回溯。
 
+### 栈回溯的平台支持
+
+`3rdparty/libbacktrace` 跟随上游 [ianlancetaylor/libbacktrace](https://github.com/ianlancetaylor/libbacktrace)。
+上游的 Mach-O 读取器只接受 `MH_EXECUTE`、`MH_DYLIB` 和 `MH_DSYM`，而 CPython 扩展模块是
+`MH_BUNDLE`——因此在 **macOS** 上符号化会失败，`GetFullMessage()` 退化为
+`No stack trace available`。任何构建模式都无法改变这一点：这是文件类型（filetype）的限制，
+而非缺少调试信息。Linux（ELF）不受影响，可生成完整回溯。
+
+`Backtrace::ErrorCallback` 对每条不同的 libbacktrace *消息*只上报一次。否则在 macOS 上，每次
+捕获回溯都会为**每个栈帧**打印一行 `no debug info in Mach-O executable`——因为 dyld 初始化
+路径整体上是成功的，并会把 `macho_nodebug` 装为 fileline 处理函数。
+
 ## 断言宏
 
 ### 面向用户的检查 — `CHECK` / `CHECK_SPAN`

--- a/include/pypto/core/error.h
+++ b/include/pypto/core/error.h
@@ -129,6 +129,11 @@ class Backtrace {
 
   /**
    * @brief Error callback for libbacktrace
+   *
+   * Writes the failure to stderr, but only the first time a given (msg, errnum) pair is seen.
+   * A platform that cannot symbolize at all reports the same failure on every captured trace,
+   * which would otherwise emit the same lines on every exception PyPTO throws.
+   *
    * @param data User data pointer
    * @param msg Error message from libbacktrace
    * @param errnum Error number

--- a/src/core/backtrace.cpp
+++ b/src/core/backtrace.cpp
@@ -17,8 +17,11 @@
 #include <cstdio>
 #include <fstream>
 #include <ios>
+#include <mutex>
+#include <set>
 #include <sstream>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "pypto/core/error.h"
@@ -74,10 +77,27 @@ Backtrace::Backtrace() {
 }
 
 void Backtrace::ErrorCallback(void* data, const char* msg, int errnum) {
-  // Always report libbacktrace errors to stderr so failures in backtrace generation are not silent
-  if (msg) {
-    fprintf(stderr, "libbacktrace error: %s (errno: %d)\n", msg, errnum);
+  // Report libbacktrace errors to stderr so failures in backtrace generation are not silent, but
+  // report each distinct message only once. When a platform cannot supply symbol information at
+  // all, the same failure repeats without bound. macOS is the case in practice: upstream
+  // libbacktrace accepts only MH_EXECUTE / MH_DYLIB / MH_DSYM Mach-O files, and a CPython
+  // extension module is an MH_BUNDLE. Its dyld initialization path still succeeds overall, so it
+  // installs macho_nodebug as the fileline handler — and that fires once per *frame* of every
+  // captured trace, on top of one rejection message per loaded bundle.
+  if (msg == nullptr) {
+    return;
   }
+
+  // The state is created with threaded=1, so the dedupe set needs its own lock. Holding it across
+  // the write also keeps concurrent reports from interleaving.
+  static std::mutex reported_mutex;
+  static std::set<std::pair<std::string, int>> reported;
+  std::scoped_lock lock(reported_mutex);
+  if (!reported.emplace(msg, errnum).second) {
+    return;
+  }
+
+  fprintf(stderr, "libbacktrace error: %s (errno: %d)\n", msg, errnum);
 }
 
 /// Clean up file paths from debug info that may contain temp build directory prefixes.

--- a/src/core/error.cpp
+++ b/src/core/error.cpp
@@ -32,7 +32,8 @@ std::string Error::GetFullMessage() const {
     // Upstream libbacktrace accepts only MH_EXECUTE / MH_DYLIB / MH_DSYM Mach-O files, and a
     // CPython extension module is an MH_BUNDLE — so no build mode enables traces on macOS.
     oss << "\n\nNo stack trace available. \n"
-           "(C++ stack traces are not supported on macOS; build on Linux to get them.)";
+           "(C++ stack traces are not supported on macOS; use a Linux Debug or RelWithDebInfo "
+           "build to get them.)";
 #else
     oss << "\n\nNo stack trace available. \n"
            "(Tip: Build with CMake in Debug or RelWithDebInfo mode to enable stack trace support.)";

--- a/src/core/error.cpp
+++ b/src/core/error.cpp
@@ -28,8 +28,15 @@ std::string Error::GetFullMessage() const {
     oss << "\n\nC++ Traceback (most recent call last):\n";
     oss << stack_trace;
   } else {
+#ifdef __APPLE__
+    // Upstream libbacktrace accepts only MH_EXECUTE / MH_DYLIB / MH_DSYM Mach-O files, and a
+    // CPython extension module is an MH_BUNDLE — so no build mode enables traces on macOS.
+    oss << "\n\nNo stack trace available. \n"
+           "(C++ stack traces are not supported on macOS; build on Linux to get them.)";
+#else
     oss << "\n\nNo stack trace available. \n"
            "(Tip: Build with CMake in Debug or RelWithDebInfo mode to enable stack trace support.)";
+#endif
   }
 
   return oss.str();


### PR DESCRIPTION
## Summary

`3rdparty/libbacktrace` pointed at a personal fork (`Hzfengsy/libbacktrace` @ `macho-bundle-support`) whose only delta from upstream was a two-line macOS patch adding `MH_BUNDLE` to the Mach-O filetypes `macho.c` accepts. This drops the fork and tracks [`ianlancetaylor/libbacktrace`](https://github.com/ianlancetaylor/libbacktrace) directly, advancing the pin from `c1e0f40` to `6f8310e` — nine commits newer than the fork's base.

- `.gitmodules`: URL → upstream, `branch = macho-bundle-support` dropped (the pin is by commit)
- `3rdparty/libbacktrace`: `c1e0f40` → `6f8310e` (upstream master, 2026-07-06)

No call-site change is needed. Upstream's July 2026 `backtrace.h` rework renames `threaded` → `flags` and adds a `MOREDATA` bit, but keeps it bit-compatible: `backtrace_create_state(filename, 1, ...)` still selects THREADED, and `backtrace_full_callback` is unchanged.

## Trade-off: macOS loses C++ stack traces

A CPython extension module is a Mach-O `MH_BUNDLE`, which upstream rejects, so `GetFullMessage()` falls back to `No stack trace available` on macOS. Linux (ELF) is unaffected. macOS is a smoke-test-only target in CI (`tests/ut/core` + `tests/ut/ir/core`); the real targets are Linux arm64 CPU/NPU. This removes a fork-maintenance burden in exchange.

Two consequences are handled here rather than left to bite:

1. **stderr spam.** macOS's dyld init path (`macho.c:1241`) skips each rejected bundle and still returns success, so libbacktrace installs `macho_nodebug` as the fileline handler — and `unwind` calls that **once per frame** of every captured trace. `Backtrace::ErrorCallback` now reports each distinct `(msg, errnum)` pair once.
2. **Misleading tip.** `"Build with CMake in Debug or RelWithDebInfo mode to enable stack trace support"` is false on macOS now — it is a filetype gate, not missing debug info. Made platform-conditional in `src/core/error.cpp`.

Also documented that `pypto_add_apple_dsymutil` no longer feeds libbacktrace (the `.dSYM` is never consulted, since the filetype gate rejects the bundle first). Kept because `lldb` still reads it.

## Testing

- [x] Full unit suite green: **7702 passed, 2 skipped** (both pre-existing and unrelated)
- [x] Full `clang-tidy` clean
- [x] Docs parity / english-only / header lint pass; all pre-commit hooks pass
- [x] **Linux symbolization verified unchanged** — emitted tracebacks built against `c1e0f40` (fork) and `6f8310e` (upstream) are byte-identical
- [x] Docs updated in both `docs/en` and `docs/zh-cn`

The macOS path could not be executed on the Linux dev box: there `backtrace_initialize` succeeds via `dl_iterate_phdr` regardless of the filename argument, which is precisely why Linux never hits this. The macOS behavior above is established by reading `macho.c` / `fileline.c` / `backtrace.c`, not from a run.

## Known gap

The dedupe has no unit test. `ErrorCallback` is a private static with no binding, and its trigger is unreachable on Linux, so covering it would mean widening the public API purely for a test. Flagged deliberately rather than silently skipped.