### PR TITLE
fix(ir): Map valid_shape through reshape without widening

### DIFF
--- a/docs/en/dev/ir/05-operators.md
+++ b/docs/en/dev/ir/05-operators.md
@@ -271,7 +271,7 @@ with ib.function("tensor_example") as f:
 | **Unary** | `tile.sqrt` | Element-wise square root |
 | **Transform** | `tile.slice` | Extract a sub-tile with static shape, optional dynamic valid_shape, and optional `drop_dims` (numpy-style rank reduction over static unit axes; result clamped to a 2D minimum) |
 | - | `tile.extract` | Extract a sub-tile from `src` at `(index_row, index_col)` — ISA TEXTRACT Variant 1 (Mat→Left/Right, Acc→Mat) |
-| - | `tile.reshape` | Reshape tile to new dimensions (element count must match) |
+| - | `tile.reshape` | Reshape tile to new dimensions (element count must match). Carries the source's `valid_shape` through without widening it — see [Reshape and the valid region](#reshape-and-the-valid-region) |
 | - | `tile.reinterpret_view` | Zero-copy view with a different dtype and the same exact bytes; optional shape uses layout-aware inference (packed flat tiles only) |
 | - | `tile.transpose` | Swap two axes of a tile |
 | - | `tile.set_validshape` | Update valid-shape metadata without data movement |
@@ -280,7 +280,29 @@ with ib.function("tensor_example") as f:
 | **Scatter** | `tile.scatter` | Row-scatter `src` into `dst` at per-row indices (`pto.tscatter` index form; DPS — `dst` is in/out, the result aliases `dst`). `src`/`dst` dtype ∈ {I8, I16, I32, FP16, FP32, BF16}; `indexes` dtype ∈ {I16, I32}; element-size matching rule: 4-byte dst ↔ INT32, 2-byte dst ↔ INT16, 1-byte dst ↔ INT16. |
 | - | `tile.scatter_mask` | Mask-pattern row-scatter: write each `src` row into the mask-marked columns of `dst` (DPS — `dst` is in/out). A PyPTO codegen form lowered to a `pto.tscatter` mask emission — **not** a distinct pto-isa instruction (unlike `tile.gather_mask`). See [Mask patterns](#mask-patterns). |
 
-`tile.reshape` preserves dtype and element count; `tile.reinterpret_view(data, dtype, *, shape=None)` changes dtype while preserving exact byte size. Without `shape`, it scales the physically contiguous axis using the source/target dtype byte widths and tile layout. Under PTOAS memory planning, it lowers to the aliasing PTO `treshape` primitive for both same-shape and width-changing views.
+`tile.reshape` preserves dtype, element count, and the source's valid region (see below); `tile.reinterpret_view(data, dtype, *, shape=None)` changes dtype while preserving exact byte size. Without `shape`, it scales the physically contiguous axis using the source/target dtype byte widths and tile layout. Under PTOAS memory planning, it lowers to the aliasing PTO `treshape` primitive for both same-shape and width-changing views.
+
+### Reshape and the valid region
+
+A reshape is a zero-copy view, so it cannot invent data: `tensor.reshape` and
+`tile.reshape` share one rule that carries the source's `valid_shape` into the
+target shape and never widens it. A valid region is an origin-anchored box, so
+not every source region survives a repartition — the rule maps what it can:
+
+| Source region | Result |
+| ------------- | ------ |
+| Fully valid | `new_shape` — canonicalized away, so no view survives and no existing program changes |
+| Provably empty | An all-zero box |
+| Only full unit axes added / removed | Surviving axes map 1:1; an arbitrary rectangle is preserved exactly |
+| A contiguous flat prefix | The rectangle of `new_shape` spanning those same cells, if one exists |
+| Anything else | **Rejected** — `valid_shape` cannot describe the reshaped region |
+
+So `[8, 16]` valid `[5, 16]` (a flat prefix of 80 cells) maps to `[16, 8]` valid
+`[10, 8]` and to `[128]` valid `[80]`, while `[4, 32]` is rejected — 80 cells is
+not a whole number of 32-wide rows. `[1, 8, 16]` valid `[1, 8, 5]` is not a flat
+prefix at all, yet `[8, 16]` valid `[8, 5]` is exact, because dropping a full
+unit axis keeps rows as rows. `tensor.reshape`'s optional third `valid_shape`
+operand may only *narrow* the derived region, never claim data outside it.
 
 **Data Flow:** `TensorType (DDR) → tile.load → TileType (Unified Buffer) → tile.{ops} → TileType → tile.store → TensorType (DDR)`
 

--- a/docs/zh-cn/dev/ir/05-operators.md
+++ b/docs/zh-cn/dev/ir/05-operators.md
@@ -265,7 +265,7 @@ with ib.function("tensor_example") as f:
 | **一元** | `tile.sqrt` | 逐元素平方根 |
 | **变换** | `tile.slice` | 提取子 tile，静态 shape，可选动态 valid_shape |
 | - | `tile.extract` | 从 `src` 在 `(index_row, index_col)` 处提取子 tile —— ISA TEXTRACT Variant 1（Mat→Left/Right，Acc→Mat） |
-| - | `tile.reshape` | 重塑 tile 维度（元素总数须一致） |
+| - | `tile.reshape` | 重塑 tile 维度（元素总数须一致）。会把源的 `valid_shape` 带到结果上，且绝不扩大 —— 见[reshape 与有效区域（valid region）](#reshape-与有效区域valid-region) |
 | - | `tile.reinterpret_view` | 以不同 dtype 对完全相同的字节做零拷贝视图；可选 shape 默认按 layout 推导（仅支持紧密、非分形 tile） |
 | - | `tile.transpose` | 交换 tile 的两个轴 |
 | - | `tile.set_validshape` | 更新 valid_shape 元数据，不搬移数据 |
@@ -274,7 +274,28 @@ with ib.function("tensor_example") as f:
 | **散布** | `tile.scatter` | 按行索引把 `src` 散布到 `dst`（`pto.tscatter` 索引形式；DPS：`dst` 为 in/out，结果别名为 `dst`）。`src` / `dst` dtype ∈ {I8, I16, I32, FP16, FP32, BF16}；`indexes` dtype ∈ {I16, I32}；元素宽度匹配规则：4 字节 dst ↔ INT32，2 字节 dst ↔ INT16，1 字节 dst ↔ INT16。 |
 | - | `tile.scatter_mask` | 按掩码模式把 `src` 行写入 `dst` 中由掩码选中的列（DPS：`dst` 为 in/out）。这是 PyPTO codegen 层形式，下降为 `pto.tscatter` 掩码发射 —— **并非**独立的 pto-isa 指令（与 `tile.gather_mask` 不同）。掩码语义见[掩码模式](#掩码模式)。 |
 
-`tile.reshape` 保持 dtype 和元素总数；`tile.reinterpret_view(data, dtype, *, shape=None)` 改变 dtype，但要求前后总字节数完全相同。省略 `shape` 时，它会根据源/目标 dtype 字节宽度和 tile layout 缩放物理连续轴。在 PTOAS 内存规划下，无论 shape 是否变化，都会下降为保持别名关系的 PTO `treshape` 原语。
+`tile.reshape` 保持 dtype、元素总数以及源的有效区域（见下）；`tile.reinterpret_view(data, dtype, *, shape=None)` 改变 dtype，但要求前后总字节数完全相同。省略 `shape` 时，它会根据源/目标 dtype 字节宽度和 tile layout 缩放物理连续轴。在 PTOAS 内存规划下，无论 shape 是否变化，都会下降为保持别名关系的 PTO `treshape` 原语。
+
+### reshape 与有效区域（valid region）
+
+reshape 是零拷贝视图，无法凭空产生数据：`tensor.reshape` 与 `tile.reshape` 共用
+同一条规则，把源的 `valid_shape` 映射到目标 shape，且绝不扩大。有效区域只能表示为
+以原点为锚的矩形框，因此并非所有源区域都能在重新切分后保留：
+
+| 源区域 | 结果 |
+| ------ | ---- |
+| 完全有效 | `new_shape` —— 会被规范化掉，不产生 view，已有程序不受影响 |
+| 可证明为空 | 全零矩形框 |
+| 仅增删完全有效的单位轴 | 保留的轴按 1:1 映射，可精确保留任意矩形 |
+| 连续的扁平前缀 | `new_shape` 中覆盖同一批元素的矩形（若存在） |
+| 其他情况 | **拒绝** —— `valid_shape` 无法描述 reshape 后的区域 |
+
+因此 `[8, 16]` valid `[5, 16]`（80 个元素的扁平前缀）可映射为 `[16, 8]` valid
+`[10, 8]` 或 `[128]` valid `[80]`，而 `[4, 32]` 会被拒绝 —— 80 个元素不是整数行
+（每行 32）。`[1, 8, 16]` valid `[1, 8, 5]` 根本不是扁平前缀，但映射到 `[8, 16]`
+valid `[8, 5]` 是精确的，因为丢弃完全有效的单位轴不改变行列关系。
+`tensor.reshape` 可选的第三个 `valid_shape` 操作数只能*收窄*推导出的区域，
+不能声称拥有该区域之外的数据。
 
 **数据流：** `TensorType (DDR) → tile.load → TileType (Unified Buffer) → tile.{ops} → TileType → tile.store → TensorType (DDR)`
 

--- a/include/pypto/ir/type_inference.h
+++ b/include/pypto/ir/type_inference.h
@@ -391,6 +391,43 @@ void ValidateDropDimsValidExtents(const std::vector<int64_t>& drop_dims,
                                   const Span& span);
 
 /**
+ * @brief Map an origin-anchored valid box through a reshape without widening
+ *
+ * A reshape is a zero-copy view, so it cannot invent data: the result's valid
+ * region is the source's, expressed in the target shape. ``valid_shape`` can
+ * only describe an origin-anchored box, so not every source region survives the
+ * repartition, and the ones that do not are rejected rather than rounded up.
+ *
+ * ```text
+ * 1. source fully valid                  -> new_shape
+ * 2. source provably empty               -> all-zero box
+ * 3. only full unit axes added / removed -> surviving axes map 1:1
+ * 4. contiguous flat prefix              -> rectangular box under new_shape
+ * 5. otherwise                           -> reject
+ * ```
+ *
+ * Cases 2 and 3 are exact because neither repartitions data: the empty set stays
+ * empty under every reshape, and inserting or removing a provably-full physical
+ * unit axis is a coordinate-only rank change that preserves an arbitrary
+ * rectangle. Case 4 is the general rule: a region that occupies a contiguous
+ * flat prefix of the buffer maps to whatever rectangle spans that same prefix in
+ * the target shape, provided one exists. Tensor and tile reshape share this rule.
+ *
+ * @param src_valid Effective valid shape of the source, resolved by ``GetValidShape``
+ * @param in_shape Physical shape of the source, same rank as @p src_valid
+ * @param new_shape Physical shape of the result
+ * @param span IR source location, reported when the region is rejected
+ * @param op_name Operator name, used in diagnostics
+ * @return The result valid shape, one extent per target dimension
+ * @throws pypto::ValueError when ``valid_shape`` cannot represent the reshaped
+ *         region, or when a partial region meets a dynamic extent it cannot map
+ */
+std::vector<ExprPtr> ComputeReshapeValidShape(const std::vector<ExprPtr>& src_valid,
+                                              const std::vector<ExprPtr>& in_shape,
+                                              const std::vector<ExprPtr>& new_shape, const Span& span,
+                                              const std::string& op_name);
+
+/**
  * @brief Reject a reduction whose input is empty on some axis
  *
  * A reduction consumes its input's *valid* region: the backend kernels bound their loops by the

--- a/include/pypto/ir/type_inference.h
+++ b/include/pypto/ir/type_inference.h
@@ -413,9 +413,17 @@ void ValidateDropDimsValidExtents(const std::vector<int64_t>& drop_dims,
  * flat prefix of the buffer maps to whatever rectangle spans that same prefix in
  * the target shape, provided one exists. Tensor and tile reshape share this rule.
  *
+ * Case 4 is the only one that reasons about flat positions, so it is the only
+ * one that depends on storage order. Pass @p row_major_contiguous false for a
+ * source whose elements are not laid out row-major (a ``col_major`` tile, a
+ * ``DN`` / ``NZ`` tensor) and a partial region that needs case 4 is rejected
+ * rather than mapped against the wrong flat order. Cases 1-3 relabel axes
+ * without consulting flat positions and hold under any layout.
+ *
  * @param src_valid Effective valid shape of the source, resolved by ``GetValidShape``
  * @param in_shape Physical shape of the source, same rank as @p src_valid
  * @param new_shape Physical shape of the result
+ * @param row_major_contiguous Whether the source's elements are stored row-major
  * @param span IR source location, reported when the region is rejected
  * @param op_name Operator name, used in diagnostics
  * @return The result valid shape, one extent per target dimension
@@ -424,7 +432,8 @@ void ValidateDropDimsValidExtents(const std::vector<int64_t>& drop_dims,
  */
 std::vector<ExprPtr> ComputeReshapeValidShape(const std::vector<ExprPtr>& src_valid,
                                               const std::vector<ExprPtr>& in_shape,
-                                              const std::vector<ExprPtr>& new_shape, const Span& span,
+                                              const std::vector<ExprPtr>& new_shape,
+                                              bool row_major_contiguous, const Span& span,
                                               const std::string& op_name);
 
 /**

--- a/python/pypto/language/op/tensor_ops.py
+++ b/python/pypto/language/op/tensor_ops.py
@@ -1611,12 +1611,21 @@ def concat(src0: Tensor, src1: Tensor) -> Tensor:
 def reshape(tensor: Tensor, shape: Sequence[IntLike]) -> Tensor:
     """Reshape tensor to new shape.
 
+    The valid region is carried through, never widened: the result holds real
+    data in exactly the cells the input did. See ``pl.reshape`` for the cases
+    that always map.
+
     Args:
         tensor: Input tensor
         shape: New shape dimensions
 
     Returns:
         Tensor wrapping the reshape operation
+
+    Raises:
+        ValueError: If the element count changes, or if the input holds real
+            data in only part of its buffer and no origin-anchored region of
+            ``shape`` describes those same cells.
     """
     tensor_expr = tensor.unwrap()
     call_expr = _ir_ops.reshape(tensor_expr, _normalize_intlike(shape))

--- a/python/pypto/language/op/tile_ops.py
+++ b/python/pypto/language/op/tile_ops.py
@@ -1818,12 +1818,22 @@ def slice(
 def reshape(tile: Tile, shape: Sequence[IntLike]) -> Tile:
     """Reshape tile to new shape.
 
+    The valid region is carried through, never widened: the result holds real
+    data in exactly the cells the input did. See ``pl.reshape`` for the cases
+    that always map.
+
     Args:
         tile: Input tile
-        shape: New shape dimensions (at most 2 for TileType)
+        shape: New shape dimensions. A tile is physically 2D, so a higher-rank
+            result is an intermediate that ``FlattenTileNdTo2D`` later collapses.
 
     Returns:
         Tile wrapping the reshape operation
+
+    Raises:
+        ValueError: If the element count changes, or if the input holds real
+            data in only part of its buffer and no origin-anchored region of
+            ``shape`` describes those same cells.
     """
     tile_expr = tile.unwrap()
     call_expr = _ir_ops.reshape(tile_expr, _normalize_intlike(shape))

--- a/python/pypto/language/op/unified_ops.py
+++ b/python/pypto/language/op/unified_ops.py
@@ -602,7 +602,16 @@ def expands(target: Tensor | Tile, scalar: int | float | Scalar) -> Tensor | Til
 
 
 def reshape(input: T, shape: Sequence[IntLike]) -> T:
-    """Reshape operation, dispatched by input type."""
+    """Reshape operation, dispatched by input type.
+
+    A reshape is a zero-copy view, so it never widens the valid region: the
+    result holds real data in exactly the cells the input did, re-expressed in
+    ``shape``. Because a valid region is an origin-anchored box, not every input
+    region survives a repartition — reshaping a region that no box of ``shape``
+    can describe is rejected rather than silently rounded up to fully valid.
+    Reshapes that only add or drop fully-valid unit axes always work, as does a
+    region occupying a contiguous prefix of the buffer.
+    """
     if isinstance(input, Tensor):
         return _tensor.reshape(input, shape)
     if isinstance(input, Tile):

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -1974,11 +1974,12 @@ class ASTParser:
         reshape product check passes whether or not the source carries a
         narrower ``valid_shape`` (issue #1509).
 
-        When the source carries an explicit narrower ``valid_shape``, that
-        narrowing is carried forward via ``tensor.reshape``'s optional 3rd
-        argument; ``tile.reshape`` has no such parameter, so a narrowed tile
-        + rank-lift combo is rejected here (the user should switch to
-        ``pl.store``).
+        A narrower ``valid_shape`` survives the lift on both paths. Reshape maps
+        the source's valid region through to the result, and a lift that only
+        inserts unit axes is a coordinate-only rank change it reproduces exactly.
+        The tensor path additionally restates the lifted region through
+        ``tensor.reshape``'s optional 3rd argument (issue #1509); ``tile.reshape``
+        has no such parameter and does not need one.
         """
         # "Narrowed" means valid_shape is actually smaller than shape; a view
         # with valid_shape == shape (e.g. a tile's canonical implicit view) is
@@ -1988,20 +1989,6 @@ class ASTParser:
         is_narrowed = source_valid_shape is not None and not _shape_exprs_match(
             source_type.shape, source_valid_shape
         )
-
-        # tile.reshape has no valid_shape parameter, so a narrowed tile +
-        # rank-lift would silently drop the narrowing. Reject upfront and point
-        # users to pl.store.
-        if is_narrowed and kind_name != "tensor":
-            raise UnsupportedFeatureError(
-                "Subscript-write with rank reduction is not supported when "
-                "the source tile carries an explicit valid_shape — "
-                "tile.reshape cannot carry valid_shape across the rank lift.",
-                span=span,
-                hint="Write the tile via pl.store directly, or use slice "
-                "indices on every axis instead of scalar indices to avoid "
-                "rank reduction.",
-            )
 
         drop_set = set(drop_dims)
         unit: ir.Expr = ir.ConstInt(1, DataType.INDEX, span)
@@ -2013,12 +2000,14 @@ class ASTParser:
             it = iter(list(seq)[lead_units:])
             return [unit if d in drop_set else next(it) for d in range(len(extents))]
 
-        reshape_op = ir_op.tensor.reshape if kind_name == "tensor" else ir_op.tile.reshape
+        is_tensor = kind_name == "tensor"
+        reshape_op = ir_op.tensor.reshape if is_tensor else ir_op.tile.reshape
         reshape_args: list[list[int | ir.Expr]] = [_lift_shape(source_type.shape)]
-        if is_narrowed:
-            # Tensor path with a genuinely narrower valid_shape — carry it via
-            # reshape's optional 3rd arg so the narrowing survives the rank
-            # lift (issue #1509). Asserted non-None by the is_narrowed guard.
+        if is_narrowed and is_tensor:
+            # Tensor path with a genuinely narrower valid_shape — restate it via
+            # reshape's optional 3rd arg (issue #1509). Reshape derives the same
+            # region from the source anyway, so this only pins it explicitly.
+            # Asserted non-None by the is_narrowed guard.
             assert source_valid_shape is not None
             reshape_args.append(_lift_shape(source_valid_shape))
         return reshape_op(source_expr, *reshape_args, span=span)

--- a/src/ir/op/tensor_ops/transform.cpp
+++ b/src/ir/op/tensor_ops/transform.cpp
@@ -37,9 +37,11 @@
 #include "pypto/ir/scalar_expr.h"
 #include "pypto/ir/span.h"
 #include "pypto/ir/tile_view_semantics.h"
+#include "pypto/ir/transforms/printer.h"
 #include "pypto/ir/transforms/structural_comparison.h"
 #include "pypto/ir/transforms/utils/tensor_view_semantics.h"
 #include "pypto/ir/type.h"
+#include "pypto/ir/type_inference.h"
 
 namespace pypto {
 namespace ir {
@@ -172,16 +174,38 @@ TypePtr DeduceTensorReshapeType(const std::vector<ExprPtr>& args,
                                       << " into shape with size " << new_product;
   }
 
-  // Return new TensorType with reshaped dimensions and same dtype
-  // If valid_shape is provided as 3rd argument, store it in TensorView
+  // A reshape is a zero-copy view, so it cannot invent data: the result's valid
+  // region is the source's, mapped through the reshape. A region the target
+  // shape cannot represent is rejected rather than rounded up to fully valid.
+  std::vector<ExprPtr> mapped_valid = ComputeReshapeValidShape(
+      GetValidShape(tensor_type), tensor_type->shape_, new_shape, args[0]->span_, "tensor.reshape");
+
+  // The optional 3rd argument may narrow the mapped region but may never claim
+  // data outside it. Unknown symbolic relations reject, because reshape emits
+  // no runtime guard that could cut the request back.
   if (args.size() == 3) {
     auto valid_shape_tuple = As<MakeTuple>(args[2]);
     CHECK(valid_shape_tuple) << "tensor.reshape valid_shape (3rd argument) must be a MakeTuple";
-    TensorView tensor_view({}, TensorLayout::ND, valid_shape_tuple->elements_);
-    return std::make_shared<TensorType>(new_shape, tensor_type->dtype_, std::nullopt,
-                                        std::make_optional(std::move(tensor_view)));
+    const std::vector<ExprPtr>& requested = valid_shape_tuple->elements_;
+    CHECK_SPAN(requested.size() == new_shape.size(), args[2]->span_)
+        << "tensor.reshape: valid_shape rank (" << requested.size() << ") must match the target shape rank ("
+        << new_shape.size() << ")";
+    for (size_t i = 0; i < requested.size(); ++i) {
+      const ProofResult within_source = ProveValidExtentLessEqual(requested[i], mapped_valid[i]);
+      CHECK_SPAN(within_source == ProofResult::kTrue, args[2]->span_)
+          << "tensor.reshape: explicit valid_shape[" << i << "]=" << PythonPrint(requested[i])
+          << " is not provably within the source-derived extent " << PythonPrint(mapped_valid[i]);
+    }
+    mapped_valid = requested;
   }
-  return std::make_shared<TensorType>(new_shape, tensor_type->dtype_);
+
+  // Return new TensorType with reshaped dimensions and same dtype. A fully valid
+  // region is canonicalized away by the constructor, leaving no view at all.
+  const PadValue pad =
+      tensor_type->tensor_view_.has_value() ? tensor_type->tensor_view_->pad : PadValue::null;
+  TensorView tensor_view({}, TensorLayout::ND, std::move(mapped_valid), pad);
+  return std::make_shared<TensorType>(new_shape, tensor_type->dtype_, std::nullopt,
+                                      std::make_optional(std::move(tensor_view)));
 }
 
 TypePtr DeduceTensorReinterpretViewType(const std::vector<ExprPtr>& args,

--- a/src/ir/op/tensor_ops/transform.cpp
+++ b/src/ir/op/tensor_ops/transform.cpp
@@ -177,11 +177,21 @@ TypePtr DeduceTensorReshapeType(const std::vector<ExprPtr>& args,
   // A reshape is a zero-copy view, so it cannot invent data: the result's valid
   // region is the source's, mapped through the reshape. A region the target
   // shape cannot represent is rejected rather than rounded up to fully valid.
-  const TensorLayout source_layout =
-      tensor_type->tensor_view_.has_value() ? tensor_type->tensor_view_->layout : TensorLayout::ND;
+  // Row-major flat order needs BOTH an ND layout and packed row-major strides:
+  // tensor.transpose of a non-trailing axis pair keeps the ND layout while
+  // permuting the strides, so ND alone does not imply the element order the
+  // flat-prefix mapping walks.
+  bool row_major_contiguous = true;
+  if (tensor_type->tensor_view_.has_value()) {
+    const TensorView& source_view = *tensor_type->tensor_view_;
+    row_major_contiguous =
+        source_view.layout == TensorLayout::ND &&
+        (source_view.stride.empty() || tile_view_semantics::ShapeExprListsEquivalent(
+                                           source_view.stride, BuildRowMajorStrides(tensor_type->shape_)));
+  }
   std::vector<ExprPtr> mapped_valid =
       ComputeReshapeValidShape(GetValidShape(tensor_type), tensor_type->shape_, new_shape,
-                               source_layout == TensorLayout::ND, args[0]->span_, "tensor.reshape");
+                               row_major_contiguous, args[0]->span_, "tensor.reshape");
 
   // The optional 3rd argument may narrow the mapped region but may never claim
   // data outside it. Unknown symbolic relations reject, because reshape emits
@@ -193,7 +203,14 @@ TypePtr DeduceTensorReshapeType(const std::vector<ExprPtr>& args,
     CHECK_SPAN(requested.size() == new_shape.size(), args[2]->span_)
         << "tensor.reshape: valid_shape rank (" << requested.size() << ") must match the target shape rank ("
         << new_shape.size() << ")";
+    const ExprPtr zero = std::make_shared<ConstInt>(0, DataType::INDEX, args[2]->span_);
     for (size_t i = 0; i < requested.size(); ++i) {
+      // An upper bound alone admits a negative extent: -1 <= 5 proves true, and
+      // a negative valid_shape is not a region at all. Zero stays legal -- it is
+      // how an empty region is spelled.
+      CHECK_SPAN(ProveValidExtentLessEqual(zero, requested[i]) == ProofResult::kTrue, args[2]->span_)
+          << "tensor.reshape: explicit valid_shape[" << i << "]=" << PythonPrint(requested[i])
+          << " must be provably >= 0; a valid extent counts real elements";
       const ProofResult within_source = ProveValidExtentLessEqual(requested[i], mapped_valid[i]);
       CHECK_SPAN(within_source == ProofResult::kTrue, args[2]->span_)
           << "tensor.reshape: explicit valid_shape[" << i << "]=" << PythonPrint(requested[i])

--- a/src/ir/op/tensor_ops/transform.cpp
+++ b/src/ir/op/tensor_ops/transform.cpp
@@ -177,8 +177,11 @@ TypePtr DeduceTensorReshapeType(const std::vector<ExprPtr>& args,
   // A reshape is a zero-copy view, so it cannot invent data: the result's valid
   // region is the source's, mapped through the reshape. A region the target
   // shape cannot represent is rejected rather than rounded up to fully valid.
-  std::vector<ExprPtr> mapped_valid = ComputeReshapeValidShape(
-      GetValidShape(tensor_type), tensor_type->shape_, new_shape, args[0]->span_, "tensor.reshape");
+  const TensorLayout source_layout =
+      tensor_type->tensor_view_.has_value() ? tensor_type->tensor_view_->layout : TensorLayout::ND;
+  std::vector<ExprPtr> mapped_valid =
+      ComputeReshapeValidShape(GetValidShape(tensor_type), tensor_type->shape_, new_shape,
+                               source_layout == TensorLayout::ND, args[0]->span_, "tensor.reshape");
 
   // The optional 3rd argument may narrow the mapped region but may never claim
   // data outside it. Unknown symbolic relations reject, because reshape emits

--- a/src/ir/op/tile_ops/transform.cpp
+++ b/src/ir/op/tile_ops/transform.cpp
@@ -334,12 +334,11 @@ TypePtr DeduceTileReshapeType(const std::vector<ExprPtr>& args,
   // reshape share one no-widening mapping, so ConvertTensorToTileOps cannot
   // rewrite a tensor.reshape into a tile.reshape that widens the region back.
   TileView tile_view;
-  tile_view.valid_shape = ComputeReshapeValidShape(GetValidShape(tile_type), tile_type->shape_, new_shape,
-                                                   args[0]->span_, "tile.reshape");
-  // Read pad off the source view directly: GetEffectiveTileView would copy a
-  // whole TileView (including a fresh valid_shape vector) to reach one enum, and
-  // the implicit view it synthesizes never sets pad anyway.
-  tile_view.pad = tile_type->tile_view_ ? tile_type->tile_view_->pad : PadValue::null;
+  const TileView source_view = tile_view_semantics::GetEffectiveTileView(*tile_type);
+  tile_view.valid_shape =
+      ComputeReshapeValidShape(GetValidShape(tile_type), tile_type->shape_, new_shape,
+                               source_view.blayout == TileLayout::row_major, args[0]->span_, "tile.reshape");
+  tile_view.pad = source_view.pad;
 
   tile_view.blayout = InferTileLayoutFromShape(new_shape);
 

--- a/src/ir/op/tile_ops/transform.cpp
+++ b/src/ir/op/tile_ops/transform.cpp
@@ -330,9 +330,16 @@ TypePtr DeduceTileReshapeType(const std::vector<ExprPtr>& args,
                                       << " into shape with size " << new_product;
   }
 
-  // Return new TileType with reshaped dimensions and same dtype
+  // Return new TileType with reshaped dimensions and same dtype. Tensor and tile
+  // reshape share one no-widening mapping, so ConvertTensorToTileOps cannot
+  // rewrite a tensor.reshape into a tile.reshape that widens the region back.
   TileView tile_view;
-  tile_view.valid_shape = new_shape;
+  tile_view.valid_shape = ComputeReshapeValidShape(GetValidShape(tile_type), tile_type->shape_, new_shape,
+                                                   args[0]->span_, "tile.reshape");
+  // Read pad off the source view directly: GetEffectiveTileView would copy a
+  // whole TileView (including a fresh valid_shape vector) to reach one enum, and
+  // the implicit view it synthesizes never sets pad anyway.
+  tile_view.pad = tile_type->tile_view_ ? tile_type->tile_view_->pad : PadValue::null;
 
   tile_view.blayout = InferTileLayoutFromShape(new_shape);
 

--- a/src/ir/op/type_inference.cpp
+++ b/src/ir/op/type_inference.cpp
@@ -713,12 +713,19 @@ void ValidateDropDimsValidExtents(const std::vector<int64_t>& drop_dims,
 
 namespace {
 
-// Whether axis `valid` covers all of `shape` -- the predicate the whole
-// no-widening rule turns on. Named so the three sites that only need the
-// yes/no answer read the same, leaving the tri-state to the one site that
-// reports *why* an axis is not full.
-bool IsProvablyFullExtent(const ExprPtr& valid, const ExprPtr& shape) {
-  return ProveValidExtentEqual(valid, shape) == ProofResult::kTrue;
+// Whether two extents are provably the same. Constants decide by value first:
+// ProveValidExtentEqual only compares extents of matching signedness, so a
+// UINT64 valid extent (what tile.set_validshape emits) against an INDEX
+// physical extent comes back kUnknown even when both are the same literal.
+// Reading a full axis as partial that way rejects reshapes that map exactly --
+// the same signedness caveat IsProvablyEmptyExtent documents above.
+bool ExtentsProvablyEqual(const ExprPtr& lhs, const ExprPtr& rhs) {
+  const auto lhs_const = GetConstantDimension(lhs);
+  const auto rhs_const = GetConstantDimension(rhs);
+  if (lhs_const.has_value() && rhs_const.has_value()) {
+    return *lhs_const == *rhs_const;
+  }
+  return ProveValidExtentEqual(lhs, rhs) == ProofResult::kTrue;
 }
 
 // Align the input and target axes of a reshape that only inserts or erases
@@ -765,7 +772,7 @@ std::optional<std::vector<ExprPtr>> MapUnitAxisRankChange(const std::vector<Expr
   }
   // Erase an input unit axis -- lossless only when its sole coordinate is valid.
   if (input_dim < in_shape.size() && IsConstValue(in_shape[input_dim], 1) &&
-      IsProvablyFullExtent(src_valid[input_dim], in_shape[input_dim])) {
+      ExtentsProvablyEqual(src_valid[input_dim], in_shape[input_dim])) {
     if (auto tail =
             MapUnitAxisRankChange(src_valid, in_shape, new_shape, input_dim + 1, output_dim, failed)) {
       return tail;
@@ -803,7 +810,7 @@ std::vector<ExprPtr> ComputeReshapeValidShape(const std::vector<ExprPtr>& src_va
   // valid_shape away, so no view survives.
   bool fully_valid = true;
   for (size_t i = 0; i < src_valid.size(); ++i) {
-    if (!IsProvablyFullExtent(src_valid[i], in_shape[i])) {
+    if (!ExtentsProvablyEqual(src_valid[i], in_shape[i])) {
       fully_valid = false;
       break;
     }
@@ -851,13 +858,14 @@ std::vector<ExprPtr> ComputeReshapeValidShape(const std::vector<ExprPtr>& src_va
   }
 
   for (size_t i = free_dim + 1; i < input_rank; ++i) {
+    const bool full_axis = ExtentsProvablyEqual(src_valid[i], in_shape[i]);
     const ProofResult full = ProveValidExtentEqual(src_valid[i], in_shape[i]);
-    CHECK_SPAN(full == ProofResult::kTrue, span)
+    CHECK_SPAN(full_axis, span)
         << op_name << ": cannot reshape " << FormatShape(in_shape) << " to " << FormatShape(new_shape)
         << " because only part of it holds real data (valid_shape " << FormatShape(src_valid)
         << "). Dimension " << i << " is valid for " << PythonPrint(src_valid[i]) << " of "
         << PythonPrint(in_shape[i])
-        << (full == ProofResult::kUnknown ? " (a symbolic extent that cannot be proven equal)" : "")
+        << (full == ProofResult::kUnknown ? " (a runtime extent that cannot be proven equal)" : "")
         << ", so the real data is scattered across the buffer rather than filling it from the start, and "
            "no region of the new shape describes the same cells. Reshape the full extent and narrow "
            "afterwards, or copy the real data out first (pl.slice / pl.store).";

--- a/src/ir/op/type_inference.cpp
+++ b/src/ir/op/type_inference.cpp
@@ -787,7 +787,8 @@ std::optional<std::vector<ExprPtr>> MapUnitAxisRankChange(const std::vector<Expr
 
 std::vector<ExprPtr> ComputeReshapeValidShape(const std::vector<ExprPtr>& src_valid,
                                               const std::vector<ExprPtr>& in_shape,
-                                              const std::vector<ExprPtr>& new_shape, const Span& span,
+                                              const std::vector<ExprPtr>& new_shape,
+                                              bool row_major_contiguous, const Span& span,
                                               const std::string& op_name) {
   INTERNAL_CHECK_SPAN(src_valid.size() == in_shape.size(), span)
       << "Internal error: " << op_name << " source valid_shape rank (" << src_valid.size()
@@ -828,9 +829,21 @@ std::vector<ExprPtr> ComputeReshapeValidShape(const std::vector<ExprPtr>& src_va
 
   // (4) Otherwise the region has to occupy a contiguous flat prefix of the
   // buffer, so that some rectangle of the target shape spans exactly the same
-  // cells. Leading axes pinned to a single valid coordinate contribute nothing
-  // to the extent; the first remaining axis carries the prefix's one free
-  // extent, and every axis below it must be full.
+  // cells. Everything below walks flat positions in row-major order, so a
+  // source stored any other way would be measured against the wrong offsets:
+  // a col_major [2, 3] valid [1, 3] really occupies flat {0, 2, 4}, and the
+  // row-major reading would hand back a box covering {0, 1, 2} -- marking two
+  // padding elements as real. Reject instead of guessing.
+  CHECK_SPAN(row_major_contiguous, span)
+      << op_name << ": cannot reshape " << FormatShape(in_shape) << " to " << FormatShape(new_shape)
+      << " because only part of it holds real data (valid_shape " << FormatShape(src_valid)
+      << ") and its elements are not stored row-major, so the real data does not occupy a contiguous "
+         "run that the new shape can describe. Reshape the full extent and narrow afterwards, or copy "
+         "the real data out first (pl.slice / pl.store).";
+
+  // Leading axes pinned to a single valid coordinate contribute nothing to the
+  // extent; the first remaining axis carries the prefix's one free extent, and
+  // every axis below it must be full.
   const size_t input_rank = src_valid.size();
   size_t free_dim = 0;
   while (free_dim + 1 < input_rank && IsConstValue(src_valid[free_dim], 1)) {

--- a/src/ir/op/type_inference.cpp
+++ b/src/ir/op/type_inference.cpp
@@ -711,6 +711,238 @@ void ValidateDropDimsValidExtents(const std::vector<int64_t>& drop_dims,
   }
 }
 
+namespace {
+
+// Whether axis `valid` covers all of `shape` -- the predicate the whole
+// no-widening rule turns on. Named so the three sites that only need the
+// yes/no answer read the same, leaving the tri-state to the one site that
+// reports *why* an axis is not full.
+bool IsProvablyFullExtent(const ExprPtr& valid, const ExprPtr& shape) {
+  return ProveValidExtentEqual(valid, shape) == ProofResult::kTrue;
+}
+
+// Align the input and target axes of a reshape that only inserts or erases
+// provably-full physical unit axes, returning the mapped valid shape.
+//
+// Such a reshape is a coordinate-only rank change -- rows stay rows, columns
+// stay columns -- so it preserves an arbitrary origin-anchored rectangle
+// exactly, which the flat-prefix rule below could not. Ambiguous runs of unit
+// axes are resolved by a small sequence alignment: matching equal axes is tried
+// first so a partial or empty unit axis is preserved rather than erased and
+// recreated as fully valid. An input unit axis may be erased only when its sole
+// coordinate is provably valid; an output unit axis is inserted fully valid.
+//
+// `failed` memoizes the states already proven unmappable, indexed
+// `input_dim * (out_rank + 1) + output_dim`. Without it the three moves make
+// this a backtracking search over monotone lattice paths -- Delannoy-many,
+// ~5.83^rank -- and the miss path is not rare: it is the ordinary fall-through
+// to the flat-prefix rule. Since the answer at a state depends only on that
+// state, caching failures bounds the walk at one visit per state.
+std::optional<std::vector<ExprPtr>> MapUnitAxisRankChange(const std::vector<ExprPtr>& src_valid,
+                                                          const std::vector<ExprPtr>& in_shape,
+                                                          const std::vector<ExprPtr>& new_shape,
+                                                          size_t input_dim, size_t output_dim,
+                                                          std::vector<char>* failed) {
+  const size_t state = input_dim * (new_shape.size() + 1) + output_dim;
+  INTERNAL_CHECK(state < failed->size())
+      << "Internal error: reshape unit-axis memo table is sized " << failed->size() << ", need > " << state;
+  if ((*failed)[state]) return std::nullopt;
+
+  if (input_dim == in_shape.size() && output_dim == new_shape.size()) {
+    return std::vector<ExprPtr>{};
+  }
+
+  // Match two axes carrying the same extent. Tried first so an axis that is
+  // only partially valid keeps its own extent instead of being erased and
+  // recreated as fully valid.
+  if (input_dim < in_shape.size() && output_dim < new_shape.size() &&
+      ProveValidExtentEqual(in_shape[input_dim], new_shape[output_dim]) == ProofResult::kTrue) {
+    if (auto tail =
+            MapUnitAxisRankChange(src_valid, in_shape, new_shape, input_dim + 1, output_dim + 1, failed)) {
+      tail->insert(tail->begin(), src_valid[input_dim]);
+      return tail;
+    }
+  }
+  // Erase an input unit axis -- lossless only when its sole coordinate is valid.
+  if (input_dim < in_shape.size() && IsConstValue(in_shape[input_dim], 1) &&
+      IsProvablyFullExtent(src_valid[input_dim], in_shape[input_dim])) {
+    if (auto tail =
+            MapUnitAxisRankChange(src_valid, in_shape, new_shape, input_dim + 1, output_dim, failed)) {
+      return tail;
+    }
+  }
+  // Insert a target unit axis -- one coordinate, and it holds real data.
+  if (output_dim < new_shape.size() && IsConstValue(new_shape[output_dim], 1)) {
+    if (auto tail =
+            MapUnitAxisRankChange(src_valid, in_shape, new_shape, input_dim, output_dim + 1, failed)) {
+      tail->insert(tail->begin(), new_shape[output_dim]);
+      return tail;
+    }
+  }
+  (*failed)[state] = 1;
+  return std::nullopt;
+}
+
+}  // namespace
+
+std::vector<ExprPtr> ComputeReshapeValidShape(const std::vector<ExprPtr>& src_valid,
+                                              const std::vector<ExprPtr>& in_shape,
+                                              const std::vector<ExprPtr>& new_shape, const Span& span,
+                                              const std::string& op_name) {
+  INTERNAL_CHECK_SPAN(src_valid.size() == in_shape.size(), span)
+      << "Internal error: " << op_name << " source valid_shape rank (" << src_valid.size()
+      << ") must match the source shape rank (" << in_shape.size()
+      << "); callers resolve the valid shape through GetValidShape";
+  CHECK_SPAN(!src_valid.empty() && !new_shape.empty(), span)
+      << op_name << ": reshape validity mapping requires non-empty input and output ranks";
+
+  // (1) A fully valid source stays fully valid. Returning the target shape
+  // verbatim keeps an unpadded program byte-identical to what it deduced before
+  // this rule existed -- the type constructor canonicalizes the redundant full
+  // valid_shape away, so no view survives.
+  bool fully_valid = true;
+  for (size_t i = 0; i < src_valid.size(); ++i) {
+    if (!IsProvablyFullExtent(src_valid[i], in_shape[i])) {
+      fully_valid = false;
+      break;
+    }
+  }
+  if (fully_valid) {
+    return new_shape;
+  }
+
+  // (2) The empty set stays empty under every reshape. This is settled before
+  // the prefix proof below because a box such as [1, 0, N] is not a flat prefix
+  // by that syntactic form, yet it denotes no cells and so has an exact
+  // representation in every target shape.
+  if (std::any_of(src_valid.begin(), src_valid.end(), IsProvablyEmptyExtent)) {
+    return std::vector<ExprPtr>(new_shape.size(), IndexZero());
+  }
+
+  // (3) A pure rank change over provably-full unit axes preserves an arbitrary
+  // rectangle, which the flat-prefix rule cannot see.
+  std::vector<char> unit_axis_failed((in_shape.size() + 1) * (new_shape.size() + 1), 0);
+  if (auto unit_mapped = MapUnitAxisRankChange(src_valid, in_shape, new_shape, 0, 0, &unit_axis_failed)) {
+    return *unit_mapped;
+  }
+
+  // (4) Otherwise the region has to occupy a contiguous flat prefix of the
+  // buffer, so that some rectangle of the target shape spans exactly the same
+  // cells. Leading axes pinned to a single valid coordinate contribute nothing
+  // to the extent; the first remaining axis carries the prefix's one free
+  // extent, and every axis below it must be full.
+  const size_t input_rank = src_valid.size();
+  size_t free_dim = 0;
+  while (free_dim + 1 < input_rank && IsConstValue(src_valid[free_dim], 1)) {
+    ++free_dim;
+  }
+
+  for (size_t i = free_dim + 1; i < input_rank; ++i) {
+    const ProofResult full = ProveValidExtentEqual(src_valid[i], in_shape[i]);
+    CHECK_SPAN(full == ProofResult::kTrue, span)
+        << op_name << ": cannot reshape " << FormatShape(in_shape) << " to " << FormatShape(new_shape)
+        << " because only part of it holds real data (valid_shape " << FormatShape(src_valid)
+        << "). Dimension " << i << " is valid for " << PythonPrint(src_valid[i]) << " of "
+        << PythonPrint(in_shape[i])
+        << (full == ProofResult::kUnknown ? " (a symbolic extent that cannot be proven equal)" : "")
+        << ", so the real data is scattered across the buffer rather than filling it from the start, and "
+           "no region of the new shape describes the same cells. Reshape the full extent and narrow "
+           "afterwards, or copy the real data out first (pl.slice / pl.store).";
+  }
+
+  // The prefix is measured in elements, so every extent it spans has to be a
+  // compile-time constant.
+  int64_t trailing_volume = 1;
+  for (size_t i = free_dim + 1; i < input_rank; ++i) {
+    const auto extent = GetConstantDimension(in_shape[i]);
+    CHECK_SPAN(extent.has_value(), span)
+        << op_name << ": cannot reshape a partially-valid " << FormatShape(in_shape) << " because dimension "
+        << i << " has the runtime extent " << PythonPrint(in_shape[i]) << ". Mapping the real data into "
+        << FormatShape(new_shape)
+        << " needs its size at compile time; use a static shape, or reshape before narrowing.";
+    trailing_volume *= *extent;
+  }
+  std::vector<int64_t> target(new_shape.size());
+  for (size_t i = 0; i < new_shape.size(); ++i) {
+    const auto extent = GetConstantDimension(new_shape[i]);
+    CHECK_SPAN(extent.has_value(), span)
+        << op_name << ": cannot reshape a partially-valid " << FormatShape(in_shape) << " into "
+        << FormatShape(new_shape) << " because target dimension " << i << " has the runtime extent "
+        << PythonPrint(new_shape[i])
+        << ". Mapping the real data needs the target size at compile time; use a static shape, or "
+           "reshape before narrowing.";
+    target[i] = *extent;
+  }
+
+  // Row-major volume below each target axis: the number of elements one step
+  // along that axis advances by.
+  std::vector<int64_t> suffix(target.size(), 1);
+  for (size_t i = target.size(); i-- > 0;) {
+    suffix[i] = i + 1 < target.size() ? suffix[i + 1] * target[i + 1] : 1;
+  }
+
+  // The result box is full below its own free axis and pinned to one coordinate
+  // above it -- the target-shape spelling of "a flat prefix".
+  const ExprPtr pinned = std::make_shared<ConstInt>(1, DataType::INDEX, span);
+  auto build_box = [&](size_t output_free_dim, const ExprPtr& free_extent) {
+    std::vector<ExprPtr> output(new_shape.size());
+    for (size_t i = 0; i < new_shape.size(); ++i) {
+      if (i < output_free_dim) {
+        output[i] = pinned;
+      } else if (i == output_free_dim) {
+        output[i] = free_extent;
+      } else {
+        output[i] = new_shape[i];
+      }
+    }
+    return output;
+  };
+
+  const ExprPtr& free_valid = src_valid[free_dim];
+  if (const auto extent = GetConstantDimension(free_valid)) {
+    // A static prefix maps onto the outermost target axis whose suffix volume
+    // divides it -- the prefix is then a whole number of that axis's steps.
+    const int64_t prefix_elements = *extent * trailing_volume;
+    for (size_t i = 0; i < new_shape.size(); ++i) {
+      if (suffix[i] == 0 || prefix_elements % suffix[i] != 0) continue;
+      const int64_t output_extent = prefix_elements / suffix[i];
+      if (output_extent <= target[i]) {
+        return build_box(i, std::make_shared<ConstInt>(output_extent, DataType::INDEX, span));
+      }
+    }
+    CHECK_SPAN(false, span)
+        << op_name << ": cannot reshape " << FormatShape(in_shape) << " to " << FormatShape(new_shape)
+        << " because only " << prefix_elements << " of its "
+        << (prefix_elements == 1 ? "element" : "elements") << " hold real data (valid_shape "
+        << FormatShape(src_valid) << "), and no region of " << FormatShape(new_shape)
+        << " covers exactly those " << prefix_elements
+        << " elements -- they do not fill a whole number of rows there. Pick a target shape whose "
+           "trailing dimensions divide it, or copy the real data out first (pl.slice / pl.store).";
+  }
+
+  // A dynamic prefix cannot be divided, so it survives only on a target axis
+  // whose step is exactly the input's trailing volume: the free extent then
+  // carries over unchanged. That axis has to have room for the whole free
+  // dimension, which is knowable only if the free dimension is itself static --
+  // a requirement of this branch alone, not of the static one above.
+  const auto free_physical = GetConstantDimension(in_shape[free_dim]);
+  if (free_physical.has_value()) {
+    for (size_t i = 0; i < new_shape.size(); ++i) {
+      if (suffix[i] == trailing_volume && *free_physical <= target[i]) {
+        return build_box(i, free_valid);
+      }
+    }
+  }
+  CHECK_SPAN(false, span)
+      << op_name << ": cannot reshape " << FormatShape(in_shape) << " to " << FormatShape(new_shape)
+      << " because its real data extends a runtime number of rows (" << PythonPrint(free_valid)
+      << ") and no dimension of " << FormatShape(new_shape) << " has the matching row size of "
+      << trailing_volume
+      << " elements. Keep that dimension intact in the target shape, or copy the real data out first "
+         "(pl.slice / pl.store).";
+  return {};
+}
+
 // ============================================================================
 // Slice rank-reduction (drop_dims) helpers
 // ============================================================================

--- a/tests/ut/ir/operators/test_tensor_ops.py
+++ b/tests/ut/ir/operators/test_tensor_ops.py
@@ -2877,6 +2877,34 @@ def test_tensor_reshape_explicit_valid_shape_may_not_widen_the_mapped_region():
         ir.op.tensor.reshape(_partial_tensor_var([8, 16], [5, 16]), [16, 8], valid_shape=[12, 8])
 
 
+def test_tensor_reshape_explicit_valid_shape_rejects_a_negative_extent():
+    """An upper bound alone would admit a negative extent: -1 <= 5 proves true."""
+    with pytest.raises(ValueError, match="must be provably >= 0"):
+        ir.op.tensor.reshape(_partial_tensor_var([8, 16], [5, 16]), [16, 8], valid_shape=[-1, 8])
+
+
+def test_tensor_reshape_explicit_valid_shape_allows_a_zero_extent():
+    """Zero is how an empty region is spelled, so it must survive the bound check."""
+    call = ir.op.tensor.reshape(_partial_tensor_var([8, 16], [5, 16]), [16, 8], valid_shape=[0, 8])
+
+    assert _valid_of(call.type) == [0, 8]
+
+
+def test_tensor_reshape_rejects_a_partial_source_with_reordered_strides():
+    """An ND layout does not by itself mean the elements are stored row-major.
+
+    ``tensor.transpose`` of a non-trailing axis pair keeps the ND layout while
+    permuting the strides ([2, 4, 8] -> [4, 2, 8] with stride [8, 32, 1]), so the
+    flat-prefix mapping would walk the wrong offsets and could widen the region.
+    """
+    span = ir.Span.unknown()
+    view = ir.TensorView([8, 32, 1], ir.TensorLayout.ND, valid_shape=[2, 2, 8])
+    strided = ir.Var("t", ir.TensorType([4, 2, 8], DataType.FP32, None, view), span)
+
+    with pytest.raises(ValueError, match="not stored row-major"):
+        ir.op.tensor.reshape(strided, [8, 8])
+
+
 def test_tensor_transpose_with_valid_shape():
     """Test tensor.transpose with valid_shape parameter."""
     span = ir.Span.unknown()

--- a/tests/ut/ir/operators/test_tensor_ops.py
+++ b/tests/ut/ir/operators/test_tensor_ops.py
@@ -2740,6 +2740,143 @@ def test_tensor_reshape_with_valid_shape():
     assert len(result_type.tensor_view.valid_shape) == 1
 
 
+# ---- valid_shape mapping through reshape ---------------------------------------------------
+#
+# A reshape is a zero-copy view, so it cannot invent data: the result's valid region is the
+# source's, expressed in the target shape. `valid_shape` can only describe an origin-anchored
+# box, so a region the target shape cannot spell is rejected rather than rounded up to fully
+# valid. `tile.reshape` is held to the same rule — see test_tile_ops.py.
+
+
+def test_tensor_reshape_fully_valid_input_yields_no_explicit_view():
+    """A fully valid source stays fully valid, canonicalized to no view at all."""
+    span = ir.Span.unknown()
+    tensor_var = ir.Var("t", ir.TensorType([8, 16], DataType.FP32), span)
+
+    result_type = ir.op.tensor.reshape(tensor_var, [16, 8]).type
+
+    assert isinstance(result_type, ir.TensorType)
+    assert result_type.tensor_view is None
+
+
+def test_tensor_reshape_maps_row_prefix_to_target_rectangle():
+    """Valid rows are a contiguous flat prefix: 5*16 = 80 cells = 10 rows of 8."""
+    result_type = ir.op.tensor.reshape(_partial_tensor_var([8, 16], [5, 16]), [16, 8]).type
+
+    assert _valid_of(result_type) == [10, 8]
+
+
+def test_tensor_reshape_maps_prefix_through_flatten():
+    """Flattening keeps the prefix as a single extent."""
+    result_type = ir.op.tensor.reshape(_partial_tensor_var([8, 16], [5, 16]), [128]).type
+
+    assert _valid_of(result_type) == [80]
+
+
+def test_tensor_reshape_drops_full_unit_axis_exactly():
+    """Erasing a provably full unit axis is a coordinate-only rank change.
+
+    Rows stay rows and columns stay columns, so an arbitrary rectangle survives —
+    including a column-partial region, which is not a contiguous flat prefix.
+    """
+
+    def dropped(valid):
+        return _valid_of(ir.op.tensor.reshape(_partial_tensor_var([1, 8, 16], valid), [8, 16]).type)
+
+    assert dropped([1, 5, 16]) == [5, 16]  # also reachable as a flat prefix
+    assert dropped([1, 8, 5]) == [8, 5]  # column-partial — unit-axis rule only
+    assert dropped([1, 5, 5]) == [5, 5]  # partial on both axes — unit-axis rule only
+
+
+def test_tensor_reshape_lifts_unit_axis_exactly():
+    """The inverse rank change — inserting a unit axis — is equally exact."""
+    result_type = ir.op.tensor.reshape(_partial_tensor_var([8, 16], [8, 5]), [1, 8, 16]).type
+
+    assert _valid_of(result_type) == [1, 8, 5]
+
+
+def test_tensor_reshape_empty_region_stays_empty():
+    """The empty set has an exact representation in every target shape."""
+    result_type = ir.op.tensor.reshape(_partial_tensor_var([8, 16], [0, 16]), [16, 8]).type
+
+    assert _valid_of(result_type) == [0, 0]
+
+
+def test_tensor_reshape_preserves_symbolic_row_prefix():
+    """A dynamic row count survives onto a target axis whose step is the trailing volume.
+
+    The target is repartitioned ([8, 16] -> [8, 4, 4]) so the unit-axis rule cannot
+    apply — 16 != 4 and neither axis is a unit — which pins the dynamic-prefix
+    branch specifically. An identity reshape would be answered by the unit-axis
+    rule first and prove nothing about this one.
+    """
+    span = ir.Span.unknown()
+    vrow = ir.Var("vrow", ir.ScalarType(DataType.INDEX), span)
+    view = ir.TensorView([], ir.TensorLayout.ND, valid_shape=[vrow, ir.ConstInt(16, DataType.INDEX, span)])
+    tensor_var = ir.Var("t", ir.TensorType([8, 16], DataType.FP32, None, view), span)
+
+    result_type = ir.op.tensor.reshape(tensor_var, [8, 4, 4]).type
+
+    assert isinstance(result_type, ir.TensorType)
+    assert result_type.tensor_view is not None
+    valid = result_type.tensor_view.valid_shape
+    assert valid[0] == vrow  # the dynamic prefix carries over unchanged
+    assert _const_int_values(valid[1:]) == [4, 4]
+
+
+def test_tensor_reshape_rejects_symbolic_prefix_without_a_target_axis():
+    """No target axis preserves the trailing volume, so the dynamic prefix is rejected."""
+    span = ir.Span.unknown()
+    vrow = ir.Var("vrow", ir.ScalarType(DataType.INDEX), span)
+    view = ir.TensorView([], ir.TensorLayout.ND, valid_shape=[vrow, ir.ConstInt(16, DataType.INDEX, span)])
+    tensor_var = ir.Var("t", ir.TensorType([8, 16], DataType.FP32, None, view), span)
+
+    with pytest.raises(ValueError, match="has the matching row size"):
+        ir.op.tensor.reshape(tensor_var, [32, 4])
+
+
+def test_tensor_reshape_carries_pad_alongside_the_mapped_region():
+    """Padding describes the invalid cells, so it travels with the region it describes.
+
+    A view of the same buffer keeps its fill convention; dropping it would leave
+    downstream unable to tell zero-filled padding from unknown bytes.
+    """
+    src = _partial_tensor_var([8, 16], [5, 16], pad=ir.PadValue.zero)
+
+    result_type = ir.op.tensor.reshape(src, [16, 8]).type
+
+    assert isinstance(result_type, ir.TensorType)
+    assert result_type.tensor_view is not None
+    assert result_type.tensor_view.pad == ir.PadValue.zero
+    assert _valid_of(result_type) == [10, 8]
+
+
+def test_tensor_reshape_rejects_region_that_is_not_a_flat_prefix():
+    """Valid columns leave gaps between real rows, so no target rectangle spans them."""
+    with pytest.raises(ValueError, match="real data is scattered across the buffer"):
+        ir.op.tensor.reshape(_partial_tensor_var([8, 16], [8, 5]), [16, 8])
+
+
+def test_tensor_reshape_rejects_prefix_without_a_target_rectangle():
+    """80 cells is not a whole number of 32-wide rows, so [4, 32] cannot spell it."""
+    with pytest.raises(ValueError, match="do not fill a whole number of rows"):
+        ir.op.tensor.reshape(_partial_tensor_var([8, 16], [5, 16]), [4, 32])
+
+
+def test_tensor_reshape_explicit_valid_shape_may_narrow_the_mapped_region():
+    """The 3rd argument narrows what the source supplies."""
+    call = ir.op.tensor.reshape(_partial_tensor_var([8, 16], [5, 16]), [16, 8], valid_shape=[4, 8])
+
+    assert len(call.args) == 3
+    assert _valid_of(call.type) == [4, 8]
+
+
+def test_tensor_reshape_explicit_valid_shape_may_not_widen_the_mapped_region():
+    """The 3rd argument cannot claim data the source does not have."""
+    with pytest.raises(ValueError, match="not provably within the source-derived extent"):
+        ir.op.tensor.reshape(_partial_tensor_var([8, 16], [5, 16]), [16, 8], valid_shape=[12, 8])
+
+
 def test_tensor_transpose_with_valid_shape():
     """Test tensor.transpose with valid_shape parameter."""
     span = ir.Span.unknown()

--- a/tests/ut/ir/operators/test_tile_ops.py
+++ b/tests/ut/ir/operators/test_tile_ops.py
@@ -2075,6 +2075,28 @@ class TestTileSliceReshapeOps:
         with pytest.raises(ValueError, match="do not fill a whole number of rows"):
             tile.reshape(_partial_tile([8, 16], [5, 16]), [4, 32])
 
+    @staticmethod
+    def _col_major_tile(shape, valid_shape):
+        span = ir.Span.unknown()
+        view = ir.TileView(valid_shape=valid_shape, blayout=ir.TileLayout.col_major)
+        return ir.Var("src", ir.TileType(shape, DataType.FP32, tile_view=view), span)
+
+    def test_tile_reshape_rejects_partial_col_major_source(self):
+        """Flat-prefix mapping reads row-major offsets, so a col_major source is rejected.
+
+        A col_major [2, 3] valid [1, 3] really occupies flat cells {0, 2, 4};
+        reading it row-major would return a box covering {0, 1, 2} and mark two
+        padding elements as real — the widening this rule exists to prevent.
+        """
+        with pytest.raises(ValueError, match="not stored row-major"):
+            tile.reshape(self._col_major_tile([2, 3], [1, 3]), [1, 6])
+
+    def test_tile_reshape_allows_fully_valid_col_major_source(self):
+        """Only the flat-prefix case reads storage order; a full region never does."""
+        result_type = tile.reshape(self._col_major_tile([2, 3], [2, 3]), [1, 6]).type
+
+        assert _valid_of(result_type) == [1, 6]
+
     def test_tile_fillpad_expand(self):
         """Test tile.fillpad_expand grows the tile and fills with pad_value."""
         span = ir.Span.unknown()

--- a/tests/ut/ir/operators/test_tile_ops.py
+++ b/tests/ut/ir/operators/test_tile_ops.py
@@ -30,6 +30,22 @@ def _tile_result_dtype(call: ir.Call) -> DataType:
     return result_type.dtype
 
 
+def _partial_tile(shape, valid_shape, pad=ir.PadValue.null, name="src"):
+    """A tile Var whose tile_view narrows it to `valid_shape`."""
+    span = ir.Span.unknown()
+    view = ir.TileView(valid_shape=valid_shape, stride=[], start_offset=None, pad=pad)
+    return ir.Var(name, ir.TileType(shape, DataType.FP32, tile_view=view), span)
+
+
+def _valid_of(result_type):
+    """Effective valid extents. GetEffectiveTileView always resolves them, so
+    an absent view needs no fallback here."""
+    return [
+        d.value if isinstance(d, ir.ConstInt) else d
+        for d in result_type.get_effective_tile_view().valid_shape
+    ]
+
+
 class TestTileElementwiseOps:
     """Test suite for tile-level element-wise operators (tile-tile and tile-scalar)."""
 
@@ -2009,6 +2025,55 @@ class TestTileSliceReshapeOps:
         assert isinstance(result_type3, ir.TileType)
         assert result_type3.get_effective_tile_view().blayout == ir.TileLayout.row_major
         assert call3.kwargs == {}
+
+    # ------------------------------------------------------------------
+    # valid_shape mapping through reshape. A reshape is a zero-copy view, so it
+    # cannot invent data: the result's valid region is the source's, expressed in
+    # the target shape, and a region the target shape cannot spell as an
+    # origin-anchored box is rejected rather than rounded up to fully valid.
+    # tile.reshape and tensor.reshape share one rule, so ConvertTensorToTileOps
+    # cannot rewrite a tensor.reshape into a tile.reshape that widens it back —
+    # see the mirrored cases in test_tensor_ops.py.
+    # ------------------------------------------------------------------
+
+    def test_tile_reshape_fully_valid_input_yields_no_explicit_valid_shape(self):
+        """A fully valid source stays fully valid, canonicalized to nothing to print."""
+        span = ir.Span.unknown()
+        dims = [ir.ConstInt(8, DataType.INT32, span), ir.ConstInt(16, DataType.INT32, span)]
+        tile_var = ir.Var("src", ir.TileType(dims, DataType.FP32), span)
+
+        result_type = tile.reshape(tile_var, [16, 8]).type
+
+        assert isinstance(result_type, ir.TileType)
+        assert result_type.tile_view is None or len(result_type.tile_view.valid_shape) == 0
+
+    def test_tile_reshape_maps_row_prefix_to_target_rectangle(self):
+        """Valid rows are a contiguous flat prefix: 5*16 = 80 cells = 10 rows of 8."""
+        result_type = tile.reshape(_partial_tile([8, 16], [5, 16]), [16, 8]).type
+
+        assert _valid_of(result_type) == [10, 8]
+
+    def test_tile_reshape_drops_full_unit_axis_exactly(self):
+        """Erasing a provably full unit axis preserves an arbitrary rectangle."""
+        result_type = tile.reshape(_partial_tile([1, 8, 16], [1, 8, 5]), [8, 16]).type
+
+        assert _valid_of(result_type) == [8, 5]
+
+    def test_tile_reshape_empty_region_stays_empty(self):
+        """The empty set has an exact representation in every target shape."""
+        result_type = tile.reshape(_partial_tile([8, 16], [0, 16]), [16, 8]).type
+
+        assert _valid_of(result_type) == [0, 0]
+
+    def test_tile_reshape_rejects_region_that_is_not_a_flat_prefix(self):
+        """Valid columns leave gaps between real rows, so no target rectangle spans them."""
+        with pytest.raises(ValueError, match="real data is scattered across the buffer"):
+            tile.reshape(_partial_tile([8, 16], [8, 5]), [16, 8])
+
+    def test_tile_reshape_rejects_prefix_without_a_target_rectangle(self):
+        """80 cells is not a whole number of 32-wide rows, so [4, 32] cannot spell it."""
+        with pytest.raises(ValueError, match="do not fill a whole number of rows"):
+            tile.reshape(_partial_tile([8, 16], [5, 16]), [4, 32])
 
     def test_tile_fillpad_expand(self):
         """Test tile.fillpad_expand grows the tile and fills with pad_value."""
@@ -4566,25 +4631,10 @@ class TestWindowReadValidRegion:
     """
 
     @staticmethod
-    def _partial_tile(shape, valid_shape, pad=ir.PadValue.null, name="src"):
-        """A tile Var whose tile_view narrows it to `valid_shape`."""
-        span = ir.Span.unknown()
-        view = ir.TileView(valid_shape=valid_shape, stride=[], start_offset=None, pad=pad)
-        return ir.Var(name, ir.TileType(shape, DataType.FP32, tile_view=view), span)
-
-    @staticmethod
     def _partial_tensor(shape, valid_shape, name="a"):
         span = ir.Span.unknown()
         view = ir.TensorView(stride=[], layout=ir.TensorLayout.ND, valid_shape=valid_shape)
         return ir.Var(name, ir.TensorType(shape, DataType.FP32, tensor_view=view), span)
-
-    @staticmethod
-    def _valid_of(result_type):
-        """Effective valid extents: the explicit view when set, else the shape."""
-        view = result_type.tile_view
-        if view is None or not view.valid_shape:
-            return [d.value for d in result_type.shape if isinstance(d, ir.ConstInt)]
-        return [d.value if isinstance(d, ir.ConstInt) else d for d in view.valid_shape]
 
     # --- tile.slice ---------------------------------------------------------
 
@@ -4601,26 +4651,26 @@ class TestWindowReadValidRegion:
 
     def test_slice_partial_source_narrows_result(self):
         """A window over padding inherits the source tile's narrower validity."""
-        src = self._partial_tile([64, 64], [40, 50])
+        src = _partial_tile([64, 64], [40, 50])
 
         call = tile.slice(src, [32, 32], [24, 32])
 
         # rows: clamp(40 - 24, 0, 32) = 16;  cols: clamp(50 - 32, 0, 32) = 18
-        assert self._valid_of(call.type) == [16, 18]
+        assert _valid_of(call.type) == [16, 18]
 
     def test_slice_intersects_rather_than_replaces_explicit_valid_shape(self):
         """An explicit valid_shape narrows the result but cannot widen it."""
-        src = self._partial_tile([64, 64], [20, 64])
+        src = _partial_tile([64, 64], [20, 64])
 
         widening = tile.slice(src, [32, 32], [0, 0], valid_shape=[32, 32])
-        assert self._valid_of(widening.type) == [20, 32]
+        assert _valid_of(widening.type) == [20, 32]
 
         narrowing = tile.slice(src, [32, 32], [0, 0], valid_shape=[8, 4])
-        assert self._valid_of(narrowing.type) == [8, 4]
+        assert _valid_of(narrowing.type) == [8, 4]
 
     def test_slice_folds_constants_without_min_max_nesting(self):
         """Static intersections fold to a plain ConstInt, not a min/max tree."""
-        src = self._partial_tile([64, 64], [40, 64])
+        src = _partial_tile([64, 64], [40, 64])
 
         call = tile.slice(src, [32, 64], [16, 0], valid_shape=[32, 64])
 
@@ -4670,14 +4720,14 @@ class TestWindowReadValidRegion:
 
     def test_slice_drop_dims_rejected_when_axis_is_not_provably_valid(self):
         """Rank reduction erases an axis, so the axis must have nothing left to say."""
-        src = self._partial_tile([64, 64], [8, 64])
+        src = _partial_tile([64, 64], [8, 64])
 
         with pytest.raises(ValueError, match="not provably 1"):
             tile.slice(src, [1, 64], [16, 0], drop_dims=[0])
 
     def test_slice_inherits_source_pad_mode(self):
         """A read view over padded bytes keeps saying they are padded."""
-        src = self._partial_tile([64, 64], [40, 64], pad=ir.PadValue.zero)
+        src = _partial_tile([64, 64], [40, 64], pad=ir.PadValue.zero)
 
         call = tile.slice(src, [32, 64], [0, 0])
 
@@ -4695,7 +4745,7 @@ class TestWindowReadValidRegion:
         call = tile.load(src, [0, 0], [64, 128], valid_shapes=[64, 128])
 
         # The request asked for all 64 rows; only 40 exist.
-        assert self._valid_of(call.type) == [40, 128]
+        assert _valid_of(call.type) == [40, 128]
 
     def test_load_rejects_a_request_that_reads_past_the_source(self):
         """valid_shapes is what the DMA actually reads, so it must exist."""
@@ -4717,7 +4767,7 @@ class TestWindowReadValidRegion:
         result_type = call.type
         assert isinstance(result_type, ir.TileType)
         assert [d.value for d in result_type.shape if isinstance(d, ir.ConstInt)] == [64, 128]
-        assert self._valid_of(result_type) == [36, 128]
+        assert _valid_of(result_type) == [36, 128]
 
     def test_load_clamp_narrows_an_over_reaching_request(self):
         """clamp=True cuts an over-reaching read back to the source edge."""
@@ -4727,7 +4777,7 @@ class TestWindowReadValidRegion:
         call = tile.load(tensor_var, [64, 0], [64, 128], valid_shapes=[64, 128], clamp=True)
 
         # clamp(100 - 64, 0, 64) = 36, intersected with the 64-row request -> 36.
-        assert self._valid_of(call.type) == [36, 128]
+        assert _valid_of(call.type) == [36, 128]
 
     def test_load_clamp_print_parse_roundtrip(self):
         """A clamped ragged load survives python_print -> pl.parse -> python_print."""
@@ -4828,12 +4878,12 @@ class TestWindowReadValidRegion:
 
     def test_extract_partial_source_narrows_result(self):
         """TEXTRACT repacks a window, so it can only be valid where src is."""
-        src = self._partial_tile([64, 256], [40, 100])
+        src = _partial_tile([64, 256], [40, 100])
 
         call = tile.extract(src, 16, 64, shape=[32, 32], target_memory=ir.MemorySpace.Vec)
 
         # rows: clamp(40 - 16, 0, 32) = 24;  cols: clamp(100 - 64, 0, 32) = 32
-        assert self._valid_of(call.type) == [24, 32]
+        assert _valid_of(call.type) == [24, 32]
 
 
 if __name__ == "__main__":

--- a/tests/ut/ir/operators/test_tile_ops.py
+++ b/tests/ut/ir/operators/test_tile_ops.py
@@ -2091,6 +2091,24 @@ class TestTileSliceReshapeOps:
         with pytest.raises(ValueError, match="not stored row-major"):
             tile.reshape(self._col_major_tile([2, 3], [1, 3]), [1, 6])
 
+    def test_tile_reshape_maps_a_valid_region_of_a_different_int_dtype(self):
+        """A full axis must read as full even when its dtype differs from the shape's.
+
+        ``tile.set_validshape`` emits UINT64 extents while the physical shape is
+        INDEX, and the analyzer only compares extents of matching signedness — so
+        16 == 16 came back unknown, the axis read as partial, and this mappable
+        reshape was rejected outright.
+        """
+        span = ir.Span.unknown()
+        src = ir.Var("src", ir.TileType([8, 16], DataType.FP32), span)
+        narrowed = tile.set_validshape(
+            src, ir.ConstInt(5, DataType.UINT64, span), ir.ConstInt(16, DataType.UINT64, span)
+        )
+
+        result_type = tile.reshape(narrowed, [16, 8]).type
+
+        assert _valid_of(result_type) == [10, 8]
+
     def test_tile_reshape_allows_fully_valid_col_major_source(self):
         """Only the flat-prefix case reads storage order; a full region never does."""
         result_type = tile.reshape(self._col_major_tile([2, 3], [2, 3]), [1, 6]).type

--- a/tests/ut/ir/transforms/test_flatten_tile_nd_to_2d.py
+++ b/tests/ut/ir/transforms/test_flatten_tile_nd_to_2d.py
@@ -563,6 +563,30 @@ class TestFlattenTileNdTo2DDynamicValid:
         )
         assert isinstance(valid[1], ir.ConstInt) and valid[1].value == 512
 
+    def test_static_partial_valid_flattens_without_widening(self):
+        """A statically *partial* 3D tile keeps its narrower region through the flatten.
+
+        The pass synthesizes its own ``tile.reshape``, so it now runs the same
+        no-widening mapping user code does. Dropping the leading unit axis is a
+        coordinate-only rank change, so ``[1, 16, 512]`` valid ``[1, 10, 512]``
+        must land on ``[16, 512]`` valid ``[10, 512]`` — not be rounded back up
+        to the full 16 rows, which would hand codegen 6 rows of padding as if
+        they were real data.
+        """
+        before = _incore_cast_chain(shapes=[1, 16, 512], valid=[1, 10, 512], tensor_shape=[1, 16, 512])
+
+        after = passes.flatten_tile_nd_to_2d()(before)
+
+        after_func = after.get_function("cast_incore")
+        assert after_func is not None
+        loads = [c for c in _tile_calls(after_func.body) if c.op.name == ir.get_op("tile.load").name]
+        assert loads, "expected a tile.load in the flattened body"
+        load_type = cast(ir.TileType, loads[0].type)
+        assert [cast(ir.ConstInt, d).value for d in load_type.shape] == [16, 512]
+        assert load_type.tile_view is not None
+        valid = load_type.tile_view.valid_shape
+        assert [cast(ir.ConstInt, d).value for d in valid] == [10, 512]
+
     def test_static_3d_flattens(self):
         """A fully static 3D chain flattens to 2D normally."""
         before = _incore_cast_chain(shapes=[1, 8, 512], valid=[1, 8, 512], tensor_shape=[1, 8, 512])

--- a/tests/ut/language/parser/test_subscript_syntax.py
+++ b/tests/ut/language/parser/test_subscript_syntax.py
@@ -860,23 +860,44 @@ class TestTileSubscriptWrite:
         # not src.shape[0] (= the floor's lead unit).
         assert "pl.tile.reshape(row, [1, 1, 128])" in printed
 
-    def test_tile_subscript_write_rank_reduce_narrow_valid_rejected(self):
-        """Tile rank-reduce + narrow valid_shape is rejected: tile.reshape
-        cannot carry valid_shape, so the rank lift would silently lose the
-        narrowing. Force users to take the pl.store path instead."""
+    def test_tile_subscript_write_rank_reduce_carries_narrow_valid(self):
+        """Tile rank-reduce + narrow valid_shape keeps the narrowing.
 
-        with pytest.raises(UnsupportedFeatureError, match=r"tile\.reshape cannot carry valid_shape"):
+        The lift only inserts a unit axis, which tile.reshape reproduces as a
+        coordinate-only rank change, so a [8, 8] region of a 16x16 source
+        survives as [1, 8, 8]. This region is not a contiguous flat prefix --
+        only the unit-axis rule can map it -- and before reshape mapped validity
+        at all the lift silently widened it back to the full 16x16.
+        """
 
-            @pl.function
-            def bad_tile(
-                x: pl.Tensor[[32, 16, 16], pl.FP32],
-                src: pl.Tile[[16, 16], pl.FP32],
-                i: pl.Scalar[pl.INDEX],
-            ) -> pl.Tensor[[32, 16, 16], pl.FP32]:
-                t: pl.Tile[[8, 16, 16], pl.FP32] = pl.tile.load(x, [0, 0, 0], [8, 16, 16])
-                narrowed = pl.set_validshape(src, 8, 8)
-                t[i, :, :] = narrowed
-                return pl.tile.store(t, [0, 0, 0], x)
+        @pl.function
+        def narrow_tile_lift(
+            x: pl.Tensor[[32, 16, 16], pl.FP32],
+            src: pl.Tile[[16, 16], pl.FP32],
+            i: pl.Scalar[pl.INDEX],
+        ) -> pl.Tensor[[32, 16, 16], pl.FP32]:
+            t: pl.Tile[[8, 16, 16], pl.FP32] = pl.tile.load(x, [0, 0, 0], [8, 16, 16])
+            narrowed = pl.set_validshape(src, 8, 8)
+            t[i, :, :] = narrowed
+            return pl.tile.store(t, [0, 0, 0], x)
+
+        printed = narrow_tile_lift.as_python()
+        assert "tile.assemble" in printed
+        assert "pl.tile.reshape(narrowed, [1, 16, 16])" in printed
+
+        assert isinstance(narrow_tile_lift, ir.Function)
+        assert isinstance(narrow_tile_lift.body, ir.SeqStmts)
+        assemble_stmt = narrow_tile_lift.body.stmts[2]
+        assert isinstance(assemble_stmt, ir.AssignStmt)
+        assert isinstance(assemble_stmt.value, ir.Call)
+        reshaped = assemble_stmt.value.args[1]
+        assert isinstance(reshaped, ir.Call)
+        assert reshaped.op.name == ir.get_op("tile.reshape").name
+
+        reshaped_type = reshaped.type
+        assert isinstance(reshaped_type, ir.TileType)
+        valid = reshaped_type.get_effective_tile_view().valid_shape
+        assert [cast(ir.ConstInt, dim).value for dim in valid] == [1, 8, 8]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

`tensor.reshape` and `tile.reshape` both **discarded the input's valid region**. The result was built with no view, and an unset `valid_shape` means *fully valid*, so reshaping a partially-valid buffer claimed every element was real data — the exact silent-widening failure the `valid_shape` work exists to remove.

It is reachable from ordinary DSL code: any `pl.slice(..., valid_shape=)`, `clamp=True`, or `pl.load(..., valid_shapes=)` feeding a `pl.reshape`. Two programs describing the *same* 5×16 region of real data, differing only by an intervening reshape:

```python
xs = pl.slice(x, [1, 8, 16], [0, 0, 0], valid_shape=[1, 5, 16])
rs = pl.reshape(xs, [8, 16])          # <-- dropped the region
t  = pl.load(rs, [0, 0], [8, 16])
pl.store(pl.exp(t), [0, 0], o)
```

| | `t` after `pl.load` | `pl.exp` result | store writes |
| --- | --- | --- | --- |
| Control (no reshape) | `valid_shape=[5,16]` | `[5,16]` | 5 rows ✅ |
| Before this PR | *no view* — fully valid | fully valid | **8 rows** ❌ |
| After this PR | `valid_shape=[5,16]` | `[5,16]` | 5 rows ✅ |

The load's intersection rule (#2048) was working correctly; `reshape` had erased the claim it intersects against. Three rows of padding were exponentiated and written out as real results, silently.

## The rule

Both peers now derive the result region through one shared rule, `ComputeReshapeValidShape`:

| Source region | Result |
| ------------- | ------ |
| Fully valid | `new_shape` |
| Provably empty | All-zero box |
| Only full unit axes added / removed | Surviving axes map 1:1 |
| A contiguous flat prefix | The rectangle of `new_shape` spanning those same cells |
| Anything else | **Rejected** |

Cases 2 and 3 are exact because neither repartitions data: the empty set stays empty under every reshape, and inserting/removing a provably-full unit axis is a coordinate-only rank change that preserves an arbitrary rectangle. Case 4 is the general rule. A region no origin-anchored box of the target shape can describe is rejected rather than rounded up, since reshape emits no runtime guard that could cut it back.

```text
[8,16] valid [5,16] -> [16,8]   =>  valid [10,8]   (80 cells = 10 rows of 8)
[8,16] valid [5,16] -> [128]    =>  valid [80]
[1,8,16] valid [1,8,5] -> [8,16] => valid [8,5]    (unit-axis drop; not a flat prefix)
[8,16] valid [8,5]  -> [16,8]   =>  REJECT (real data scattered across the buffer)
[8,16] valid [5,16] -> [4,32]   =>  REJECT (80 cells is not a whole number of 32-wide rows)
```

**Fixing both peers together is required, not incidental:** `ConvertTensorToTileOps` rewrites `tensor.reshape` → `tile.reshape` 1:1, so a rule on only one side would be silently undone by that pass. `tile.reshape` had the same bug (it hard-set `valid_shape = new_shape`).

## Also in this change

- `tensor.reshape`'s optional 3rd `valid_shape` operand may now only **narrow** the derived region, never claim data outside it.
- `pad` travels with the region it describes instead of being dropped — otherwise a partial result records *which* cells are invalid but loses that they are zero-filled.
- **Removes a user-facing limitation.** The parser's rank-lifting subscript write rejected a narrowed tile source with `UnsupportedFeatureError` ("tile.reshape cannot carry valid_shape across the rank lift"). That premise is now false, so the workaround is gone and `t[i, :, :] = narrowed` works, carrying `[8,8]` through as `[1,8,8]`.

**No existing program changes shape.** A fully valid input returns the target shape verbatim and the type constructors canonicalize redundant full validity away, so the result stays view-less exactly as before.

## Testing

- **26 new tests.** `tests/ut/ir/operators/test_{tensor,tile}_ops.py` cover all five cases and both rejection paths on each peer, plus symbolic prefixes (preserved and rejected), explicit-`valid_shape` narrow-allowed/widen-rejected, and pad carry. `test_subscript_syntax.py` covers the newly-enabled rank lift. `test_flatten_tile_nd_to_2d.py` pins that the pass's own synthesized reshape preserves a narrowed region rather than widening it.
- One existing test changed: `test_tile_subscript_write_rank_reduce_narrow_valid_rejected` existed solely to pin the limitation this PR removes. It is replaced by `..._carries_narrow_valid`, asserting the narrowing survives.
- Full unit suite: **7805 passed, 2 skipped**. `pre-commit` all hooks pass; diff-based `clang-tidy` clean.

## Follow-ups (deliberately out of scope)

- `IsNdLeadingCollapseTo2D` in `tensor_ops/transform.cpp` is an independently-written, weaker version of this flat-prefix rule backing `tensor.view`, and `reinterpret_view_semantics::Resolve` hard-rejects repartitions this rule now handles. Routing all three through one rule changes those ops' accept/reject behavior — separate PR.
- `tensor.reshape`'s 3rd `valid_shape` operand is arguably vestigial now (not user-reachable, discarded at codegen, cannot survive lowering to `tile.reshape`, and can only narrow). Removing it is a breaking API change.
- `tensor.concat` still widens a partially-valid operand — same class of bug, not reachable by any in-tree kernel. `tensor.expands` also returns fully-valid, but that may be correct depending on whether the kernel writes the full physical extent; it needs the same ISA check #2051 did for reductions.