### PR TITLE
feat(ir): Infer representable valid-region unions for writes

### DIFF
--- a/include/pypto/ir/type_inference.h
+++ b/include/pypto/ir/type_inference.h
@@ -410,6 +410,103 @@ void CheckReductionInputNonEmpty(const std::vector<ExprPtr>& valid, const std::s
                                  const Span& span);
 
 /**
+ * @brief What a write is allowed to move, and therefore what has to fit in the target
+ *
+ * The dual of ``WindowReadKind``: a read asks which extent must lie inside the
+ * source, a write asks which extent must lie inside the target. As there, this is
+ * a property of the substrate beneath the operator, not of aliasing.
+ */
+enum class WriteBoundsKind {
+  /// The whole physical source is written, so all of it must fit.
+  ///
+  /// ``tile.assemble`` lowers to ``pto.tinsert``, which copies the source subview
+  /// wholesale; nothing consults a valid extent, so a source allocation that
+  /// overhangs the target corrupts memory past the target.
+  kExactSubview,
+  /// Only the source's effective valid region is transferred, so only that has to
+  /// fit and a larger physical source allocation is harmless.
+  ///
+  /// ``tensor.assemble`` and ``tile.store`` move data by DMA over the valid
+  /// extent, which is the standard idiom for a padded fixed-width staging buffer
+  /// holding a short tail.
+  kValidRegionTransfer,
+};
+
+/**
+ * @brief Inputs to the shared write valid-region union rule
+ *
+ * All shape-like vectors are in target coordinates and must share one rank.
+ */
+struct WriteValidShapeUnionParams {
+  std::vector<ExprPtr> target_physical;  ///< Physical shape of the target
+  /// Target valid shape, already resolved by ``GetValidShape`` /
+  /// ``GetEffectiveTensorValidShape`` — never empty.
+  std::vector<ExprPtr> target_valid;
+  std::vector<ExprPtr> source_physical;  ///< Physical shape of the source
+  /// Source valid shape, already resolved — never empty. This is the extent
+  /// actually written, and the rectangle whose union with the target is proven.
+  std::vector<ExprPtr> source_valid;
+  std::vector<ExprPtr> offsets;  ///< Write origin, in target coordinates
+  WriteBoundsKind kind = WriteBoundsKind::kExactSubview;
+  std::string op_name;  ///< Operator name, used in diagnostics
+  /// Way out, appended to a physical-bounds rejection. An overhang is most often
+  /// a coordinate-system mismatch rather than an arithmetic slip — a tile read
+  /// through a transposing view and written back to an untransposed destination
+  /// overflows on one axis while under-filling the other — so each write says how
+  /// its own substrate wants to be addressed instead of only reporting the sum.
+  std::string bounds_remedy;
+  Span span = Span::unknown();
+};
+
+/**
+ * @brief Derive the valid region left behind by a write, when it is representable
+ *
+ * A valid shape names one origin-anchored rectangle, so the region after a write
+ * is expressible only when the union of the target's rectangle and the written
+ * one is itself an origin-anchored rectangle. The bounding candidate is
+ *
+ * ```text
+ * out_valid[i] = min(shape[i], max(target_valid[i], offset[i] + source_valid[i]))
+ * ```
+ *
+ * and this returns it only where that union is *provably* exactly that rectangle.
+ *
+ * **Why the proof is needed.** Returning the target's full shape after a partial
+ * write lets a later store push padding out as real data; returning only the
+ * source discards real data the target already held. Both are silent. Writing
+ * `W = ∏[o[i], o[i]+s[i])` into `T = ∏[0, t[i])`, the candidate rectangle covers
+ * `T ∪ W` exactly in these cases, which are what this accepts:
+ *
+ * - the written region is empty — the write is a no-op and the target stands;
+ * - the target is empty — the result is the source, provided it sits at the origin;
+ * - the written region lies inside the target — the target stands (a fully valid
+ *   target is this case, so it stays fully valid);
+ * - the target lies inside an origin-anchored written region — the source stands;
+ * - the write grows exactly one dimension `d` and abuts what is already there
+ *   (`offset[d] <= target_valid[d]`, so no gap opens), while every other dimension
+ *   spans the target exactly (`offset[i] == 0` and `source_valid[i] == target_valid[i]`).
+ *   Anything less on a passenger dimension leaves the new slab narrower than the
+ *   region it extends — an L-shape, which no valid shape can name.
+ *
+ * Growth in two or more dimensions at once, a gap, a mismatched passenger
+ * dimension, and any of these relations left unproven all reject rather than
+ * widen. Extents are compared with the tri-state proof vocabulary, so symbolic
+ * appends stated by structural equality (`t = [k, 128]`, `s = [m, 128]` at
+ * `[k, 0]` yields `[k + m, 128]`) are accepted while unrelated symbols are not.
+ *
+ * Expressions are built through the same proof-first helpers the window-read rule
+ * uses, so constant arithmetic folds and no redundant ``min`` / ``max`` nesting
+ * reaches a type.
+ *
+ * @param params Write description; see WriteValidShapeUnionParams
+ * @return The target's valid shape after the write, one extent per dimension
+ * @throws pypto::ValueError on rank mismatch, a provably negative offset, a
+ *         provable physical-bounds violation, or a union that is not provably an
+ *         origin-anchored rectangle
+ */
+std::vector<ExprPtr> InferWriteValidShapeUnion(const WriteValidShapeUnionParams& params);
+
+/**
  * @brief Check if a dimension is broadcastable to another
  *
  * A dimension is broadcastable if:

--- a/src/ir/op/tensor_ops/memory.cpp
+++ b/src/ir/op/tensor_ops/memory.cpp
@@ -433,15 +433,50 @@ TypePtr DeduceTensorAssembleType(const std::vector<ExprPtr>& args,
         << dt.ToString();
   }
 
-  // Assemble returns a new tensor type with the same shape and dtype as target.
+  // The assembled result holds what the target already held plus what was just
+  // written. Only the source's valid region is transferred — a padded staging
+  // tensor whose physical allocation is larger than its real contents moves only
+  // the real part — so kValidRegionTransfer is the bound the write must respect.
+  // The rule needs the written region to be a rectangle in target coordinates,
+  // which holds whenever the source, the offsets, and the target share one rank.
+  // A rank-mismatched source is instead a reinterpreting write whose dimension
+  // correspondence OptimizeOrchTensors materializes as strides (e.g. a 2D source
+  // into a 3D parent), so it is not a rectangle on these axes and unioning it
+  // would target the wrong ones. Such a write keeps the result it had before this
+  // rule existed — the same exclusion lower-rank window reads carry.
+  std::vector<ExprPtr> offsets = ExtractTupleElements(args[2], offset_tuple_type->types_.size());
+  const size_t target_rank = target_type->shape_.size();
+  std::vector<ExprPtr> result_valid = target_type->shape_;
+  if (source_type->shape_.size() == target_rank && offsets.size() == target_rank) {
+    result_valid = InferWriteValidShapeUnion({
+        /*target_physical=*/target_type->shape_,
+        /*target_valid=*/GetValidShape(target_type),
+        /*source_physical=*/source_type->shape_,
+        /*source_valid=*/GetValidShape(source_type),
+        /*offsets=*/std::move(offsets),
+        /*kind=*/WriteBoundsKind::kValidRegionTransfer,
+        /*op_name=*/"tensor.assemble",
+        /*bounds_remedy=*/
+        "tensor.assemble transfers only the source's effective valid region, so it is that extent -- "
+        "not the whole source allocation -- that has to fit at this offset",
+        /*span=*/args[0]->span_,
+    });
+  }
+
+  // Assemble returns a new tensor type with the same shape and dtype as target,
+  // carrying that union. A result equal to the physical shape is canonicalized
+  // back to an absent view by the constructor, so a fully valid target still
+  // produces exactly the type it produced before this rule existed.
   // When the target is a DistributedTensorType, the result preserves that kind
   // along with its window_buffer_ — the assembled result is still a view into
   // the same comm-group allocation. A fresh shared_ptr avoids type aliasing.
+  TensorView result_view;
+  result_view.valid_shape = result_valid;
   if (auto dt = As<DistributedTensorType>(args[0]->GetType())) {
     return std::make_shared<DistributedTensorType>(target_type->shape_, target_type->dtype_, std::nullopt,
-                                                   std::nullopt, dt->window_buffer_);
+                                                   std::make_optional(result_view), dt->window_buffer_);
   }
-  return std::make_shared<TensorType>(target_type->shape_, target_type->dtype_);
+  return MakeFreshTensorType(target_type->shape_, target_type->dtype_, std::move(result_valid));
 }
 
 TypePtr DeduceTensorFullType(const std::vector<ExprPtr>& args,

--- a/src/ir/op/tile_ops/memory.cpp
+++ b/src/ir/op/tile_ops/memory.cpp
@@ -246,8 +246,9 @@ TypePtr DeduceTileStoreType(const std::vector<ExprPtr>& args,
       << args[2]->GetType()->TypeName();
 
   // Optional fourth argument (when 4 args total) must be a shapes tuple
+  MakeTuplePtr shapes_tuple;
   if (args.size() == 4) {
-    auto shapes_tuple = As<MakeTuple>(args[3]);
+    shapes_tuple = As<MakeTuple>(args[3]);
     CHECK(shapes_tuple) << "The operator " << op_name
                         << " requires optional 4th argument to be a shapes tuple (MakeTuple)";
     CHECK(!shapes_tuple->elements_.empty())
@@ -279,8 +280,81 @@ TypePtr DeduceTileStoreType(const std::vector<ExprPtr>& args,
         << dt.ToString();
   }
 
-  // store returns the output tensor (same type)
-  return output_tensor_type;
+  // ---- Valid-region union -------------------------------------------------
+  // A store writes into the destination tensor, so the tensor it returns holds
+  // what that tensor already held plus the region just written.
+  const std::vector<ExprPtr>& dest_shape = output_tensor_type->shape_;
+  const size_t dest_rank = dest_shape.size();
+
+  // The rectangle written, in destination coordinates. The optional ``shapes``
+  // operand is the authoritative original-rank partition — FlattenTileNdTo2D
+  // records it precisely because the flattened 2D tile no longer carries the ND
+  // extent — so it wins whenever it is present.
+  std::vector<ExprPtr> transfer_physical;
+  std::vector<ExprPtr> transfer_valid;
+  if (shapes_tuple) {
+    // ``shapes`` is authoritative for the partition's *physical* extent, but the
+    // region actually written is the flattened tile's valid one, and recovering
+    // that on ND axes is the ND-to-2D mapping problem rather than this rule's.
+    // So a partially valid tile leaves the destination type alone: claiming the
+    // whole partition was written would promote the tile's padding to real data,
+    // which is exactly what this rule exists to prevent.
+    if (!AreExprVectorsEqual(GetValidShape(tile_type), tile_type->shape_)) {
+      return output_tensor_type;
+    }
+    transfer_physical = shapes_tuple->elements_;
+    transfer_valid = transfer_physical;
+  } else {
+    transfer_physical = tile_type->shape_;
+    transfer_valid = GetValidShape(tile_type);
+  }
+
+  // As for assemble, the union is derivable only when the transfer, the offsets,
+  // and the destination share one rank. A store whose tile addresses the
+  // destination through a reinterpreting view — a lower-rank window, or a DN
+  // layout that permutes the axes — is not a rectangle on these axes, so it keeps
+  // the destination type it returned before this rule existed.
+  if (transfer_physical.size() != dest_rank || offsets_tuple->elements_.size() != dest_rank) {
+    return output_tensor_type;
+  }
+
+  // Only the tile's valid extent is moved by the DMA, so a tile whose physical
+  // allocation is larger than its real contents is bounded by what it actually
+  // transfers rather than by its allocation.
+  std::vector<ExprPtr> dest_valid = GetValidShape(output_tensor_type);
+  std::vector<ExprPtr> result_valid = InferWriteValidShapeUnion({
+      /*target_physical=*/dest_shape,
+      /*target_valid=*/dest_valid,
+      /*source_physical=*/std::move(transfer_physical),
+      /*source_valid=*/std::move(transfer_valid),
+      /*offsets=*/offsets_tuple->elements_,
+      /*kind=*/WriteBoundsKind::kValidRegionTransfer,
+      /*op_name=*/op_name,
+      /*bounds_remedy=*/
+      "A store performs no layout conversion (RFC #1300 P7): the offsets and the tile extent must "
+      "already be in the destination's coordinate system. If the tile was read through a view whose "
+      "layout differs from the destination's -- a DN view transposes it -- take the matching view of "
+      "the destination, pl.view(out, layout=...), and store into that",
+      /*span=*/args[2]->span_,
+  });
+
+  // A store that leaves the destination's valid region exactly as it found it —
+  // which every store into a fully valid destination does — returns the
+  // destination type itself, so the common case keeps the very type, and the
+  // memref and comm-group binding on it, that it carried before this rule existed.
+  if (AreExprVectorsEqual(result_valid, dest_valid)) {
+    return output_tensor_type;
+  }
+
+  TensorView result_view = output_tensor_type->tensor_view_.value_or(TensorView{});
+  result_view.valid_shape = std::move(result_valid);
+  if (auto dt = As<DistributedTensorType>(args[2]->GetType())) {
+    return std::make_shared<DistributedTensorType>(dest_shape, output_tensor_type->dtype_,
+                                                   output_tensor_type->memref_,
+                                                   std::make_optional(result_view), dt->window_buffer_);
+  }
+  return std::make_shared<TensorType>(dest_shape, output_tensor_type->dtype_, output_tensor_type->memref_,
+                                      std::make_optional(result_view));
 }
 
 TypePtr DeduceTileMoveType(const std::vector<ExprPtr>& args,

--- a/src/ir/op/tile_ops/memory.cpp
+++ b/src/ir/op/tile_ops/memory.cpp
@@ -286,28 +286,22 @@ TypePtr DeduceTileStoreType(const std::vector<ExprPtr>& args,
   const std::vector<ExprPtr>& dest_shape = output_tensor_type->shape_;
   const size_t dest_rank = dest_shape.size();
 
-  // The rectangle written, in destination coordinates. The optional ``shapes``
-  // operand is the authoritative original-rank partition — FlattenTileNdTo2D
-  // records it precisely because the flattened 2D tile no longer carries the ND
-  // extent — so it wins whenever it is present.
-  std::vector<ExprPtr> transfer_physical;
-  std::vector<ExprPtr> transfer_valid;
+  // The optional ``shapes`` operand carries FlattenTileNdTo2D's ND partition,
+  // which is a *collapsed-dims* descriptor rather than a rectangle in
+  // destination coordinates: it is built as leading 1s followed by the
+  // pre-flatten tile shape, whose leading extent may be the product of several
+  // destination axes. A [2, 3, 8] gather, for one, stores its collapsed [6, 8]
+  // tile as partition [1, 6, 8], where 6 spans two axes of a destination whose
+  // own axis 1 is only 3. Codegen consumes that through pto.partition_view,
+  // which understands the collapse; reading it as an origin-anchored rectangle
+  // here would both mis-bound the write and place the union on the wrong axes.
+  // So the ND form keeps the destination type it had — recovering the written
+  // region on ND axes is the ND-to-2D mapping problem, not this rule's.
   if (shapes_tuple) {
-    // ``shapes`` is authoritative for the partition's *physical* extent, but the
-    // region actually written is the flattened tile's valid one, and recovering
-    // that on ND axes is the ND-to-2D mapping problem rather than this rule's.
-    // So a partially valid tile leaves the destination type alone: claiming the
-    // whole partition was written would promote the tile's padding to real data,
-    // which is exactly what this rule exists to prevent.
-    if (!AreExprVectorsEqual(GetValidShape(tile_type), tile_type->shape_)) {
-      return output_tensor_type;
-    }
-    transfer_physical = shapes_tuple->elements_;
-    transfer_valid = transfer_physical;
-  } else {
-    transfer_physical = tile_type->shape_;
-    transfer_valid = GetValidShape(tile_type);
+    return output_tensor_type;
   }
+  std::vector<ExprPtr> transfer_physical = tile_type->shape_;
+  std::vector<ExprPtr> transfer_valid = GetValidShape(tile_type);
 
   // As for assemble, the union is derivable only when the transfer, the offsets,
   // and the destination share one rank. A store whose tile addresses the

--- a/src/ir/op/tile_ops/transform.cpp
+++ b/src/ir/op/tile_ops/transform.cpp
@@ -614,17 +614,44 @@ TypePtr DeduceTileAssembleType(const std::vector<ExprPtr>& args,
          "Acc->Mat FIXPIPE downcast to bf16/f16), but got "
       << target_type->dtype_.ToString() << " and " << source_type->dtype_.ToString();
 
-  // Inherit the target's TileView *and its optionality*.  When the target carries
-  // an implicit view (``tile_view_ == nullopt`` — e.g. a tile.create'd Mat scratch,
-  // whose effective layout is the Mat NZ implicit col_major/row_major), the result
-  // must stay implicit too, so its effective layout matches the target's rather than
-  // collapsing to the raw struct default (row_major/none_box — the VEC layout, not a
-  // Mat operand's).  An in-place Acc->Mat assemble chain then shares one consistent
-  // layout (see GetEffectiveTileView, which only honors an *explicit* view).
-  std::optional<TileView> tile_view = target_type->tile_view_;
-  if (tile_view.has_value()) {
-    tile_view->valid_shape = target_type->shape_;
+  // The result holds what the target already held plus what was just written.
+  // ``pto.tinsert`` copies the whole source subview rather than consulting its
+  // valid extent, so the *physical* source is what has to fit inside the target.
+  // As for tensor.assemble, the union is derivable only when the source, the
+  // offsets, and the target share one rank; a rank-mismatched write is a
+  // reinterpreting one whose axes do not correspond, and keeps its previous result.
+  std::vector<ExprPtr> offsets = ExtractTupleElements(args[2], offset_tuple_type->types_.size());
+  const size_t target_rank = target_type->shape_.size();
+  std::vector<ExprPtr> result_valid = target_type->shape_;
+  if (source_type->shape_.size() == target_rank && offsets.size() == target_rank) {
+    result_valid = InferWriteValidShapeUnion({
+        /*target_physical=*/target_type->shape_,
+        /*target_valid=*/GetValidShape(target_type),
+        /*source_physical=*/source_type->shape_,
+        /*source_valid=*/GetValidShape(source_type),
+        /*offsets=*/std::move(offsets),
+        /*kind=*/WriteBoundsKind::kExactSubview,
+        /*op_name=*/"tile.assemble",
+        /*bounds_remedy=*/
+        "tile.assemble lowers to pto.tinsert, which copies the whole source subview rather than only "
+        "its valid region, so the source allocation itself has to fit -- unlike tensor.assemble, "
+        "which transfers only the valid extent",
+        /*span=*/args[0]->span_,
+    });
   }
+
+  // Seed from the target's EFFECTIVE view so the result keeps the layout the
+  // target's shape and memory space imply.  When the target carries an implicit
+  // view (``tile_view_ == nullopt`` — e.g. a tile.create'd Mat scratch, whose
+  // effective layout is the Mat NZ implicit col_major/row_major), that layout must
+  // survive rather than collapsing to the raw struct default (row_major/none_box —
+  // the VEC layout, not a Mat operand's).  An in-place Acc->Mat assemble chain then
+  // shares one consistent layout (see GetEffectiveTileView, which only honors an
+  // *explicit* view).  A fully valid union canonicalizes straight back to an
+  // implicit view in the TileType constructor, so a target that was implicit before
+  // stays implicit unless the write genuinely leaves the result partially valid.
+  TileView tile_view = tile_view_semantics::GetEffectiveTileView(*target_type);
+  tile_view.valid_shape = std::move(result_valid);
   return std::make_shared<TileType>(target_type->shape_, target_type->dtype_, std::nullopt, tile_view,
                                     target_type->memory_space_);
 }

--- a/src/ir/op/type_inference.cpp
+++ b/src/ir/op/type_inference.cpp
@@ -712,6 +712,234 @@ void ValidateDropDimsValidExtents(const std::vector<int64_t>& drop_dims,
 }
 
 // ============================================================================
+// Write valid-region unions (assemble / store)
+// ============================================================================
+
+namespace {
+
+/// Dual of `MinExtent`: the provably larger operand when the ordering is settled,
+/// and a folded `max` only when it is not.
+ExprPtr MaxExtent(const ExprPtr& lhs, const ExprPtr& rhs, const Span& span) {
+  if (ProveValidExtentLessEqual(lhs, rhs) == ProofResult::kTrue) {
+    return rhs;
+  }
+  if (ProveValidExtentLessEqual(rhs, lhs) == ProofResult::kTrue) {
+    return lhs;
+  }
+  return FoldExtent(MakeMax(lhs, rhs, span));
+}
+
+/// Whether `valid` names the whole of `physical`, dimension by dimension.
+///
+/// Canonicalization stores redundant full validity as an absent view, so this is
+/// usually the identity `GetValidShape` returned; an explicit spelling that the
+/// analyzer can still settle is accepted too.
+bool IsFullyValid(const std::vector<ExprPtr>& valid, const std::vector<ExprPtr>& physical) {
+  for (size_t i = 0; i < valid.size(); ++i) {
+    if (!AreExprsEqual(valid[i], physical[i]) &&
+        ProveValidExtentEqual(valid[i], physical[i]) != ProofResult::kTrue) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/// Whether every offset is provably zero, i.e. the written region is itself
+/// origin-anchored and can stand alone as a valid shape.
+bool IsOriginAnchored(const std::vector<ExprPtr>& offsets) {
+  for (const auto& offset : offsets) {
+    if (!IsProvablyEmptyExtent(offset)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+std::string FormatDimensionList(const std::vector<size_t>& dims) {
+  std::string out;
+  for (size_t i = 0; i < dims.size(); ++i) {
+    if (i != 0) {
+      out += i + 1 == dims.size() ? " and " : ", ";
+    }
+    out += std::to_string(dims[i]);
+  }
+  return out;
+}
+
+void CheckWriteUnionRanks(const WriteValidShapeUnionParams& p) {
+  const size_t rank = p.target_physical.size();
+  CHECK_SPAN(p.source_physical.size() == rank, p.span)
+      << p.op_name << " requires the source and the target to have the same rank, but got source rank "
+      << p.source_physical.size() << " " << FormatShape(p.source_physical) << " and target rank " << rank
+      << " " << FormatShape(p.target_physical);
+  CHECK_SPAN(p.offsets.size() == rank, p.span)
+      << p.op_name << " requires one offset per target dimension, but got " << p.offsets.size()
+      << " offsets for target rank " << rank;
+  CHECK_SPAN(p.target_valid.size() == rank, p.span)
+      << p.op_name << " target valid_shape rank " << p.target_valid.size()
+      << " does not match its shape rank " << rank;
+  CHECK_SPAN(p.source_valid.size() == rank, p.span)
+      << p.op_name << " source valid_shape rank " << p.source_valid.size()
+      << " does not match its shape rank " << rank;
+}
+
+/// The extent of dimension `i` the write must keep inside the target.
+///
+/// Under `kExactSubview` the whole physical source lands, so all of it has to fit,
+/// however small its valid region. Under `kValidRegionTransfer` only the valid
+/// region moves, so a larger physical source allocation is free.
+const ExprPtr& WriteReach(const WriteValidShapeUnionParams& p, size_t i) {
+  return p.kind == WriteBoundsKind::kExactSubview ? p.source_physical[i] : p.source_valid[i];
+}
+
+/// Enforce what a write promises about dimension `i` before its union is derived:
+/// it starts inside the target, and the extent it touches also ends inside it.
+///
+/// Provable violations reject; relations that stay symbolic are taken on trust,
+/// exactly as for a non-clamping window read, because that inequality is the
+/// operator's precondition rather than a guess.
+void CheckWriteDimBounds(const WriteValidShapeUnionParams& p, size_t i) {
+  const ExprPtr& offset = p.offsets[i];
+  const ExprPtr& target = p.target_physical[i];
+
+  CHECK_SPAN(ProveValidExtentLessEqual(IndexZero(), offset) != ProofResult::kFalse, p.span)
+      << p.op_name << " offset " << i << " is provably negative (" << PythonPrint(offset)
+      << "); a write must start inside its target";
+
+  const ExprPtr& reach = WriteReach(p, i);
+  if (IsIntegerScalarExpr(offset) && IsIntegerScalarExpr(reach) && IsIntegerScalarExpr(target)) {
+    const ExprPtr end = FoldExtent(MakeAdd(offset, reach, p.span));
+    CHECK_SPAN(ProveValidExtentLessEqual(end, target) != ProofResult::kFalse, p.span)
+        << p.op_name << " writes past the end of dimension " << i << ": offset " << PythonPrint(offset)
+        << " + extent " << PythonPrint(reach) << " exceeds the target extent " << PythonPrint(target)
+        << (p.bounds_remedy.empty() ? "" : ". ") << p.bounds_remedy;
+  }
+}
+
+/// The far edge `offset[i] + source_valid[i]` of the written region.
+ExprPtr WriteFarEdge(const WriteValidShapeUnionParams& p, size_t i) {
+  const ExprPtr& offset = p.offsets[i];
+  const ExprPtr& extent = p.source_valid[i];
+  if (IsProvablyEmptyExtent(offset)) {
+    return extent;
+  }
+  CHECK_SPAN(IsIntegerScalarExpr(offset) && IsIntegerScalarExpr(extent), p.span)
+      << p.op_name << " needs an integer scalar offset and valid extent to place dimension " << i
+      << " against a partially valid target, but got offset " << offset->GetType()->TypeName()
+      << " and extent " << extent->GetType()->TypeName();
+  return FoldExtent(MakeAdd(offset, extent, p.span));
+}
+
+}  // namespace
+
+std::vector<ExprPtr> InferWriteValidShapeUnion(const WriteValidShapeUnionParams& params) {
+  CheckWriteUnionRanks(params);
+  const size_t rank = params.target_physical.size();
+  for (size_t i = 0; i < rank; ++i) {
+    CheckWriteDimBounds(params, i);
+  }
+
+  const std::vector<ExprPtr>& target_valid = params.target_valid;
+  const std::vector<ExprPtr>& source_valid = params.source_valid;
+
+  // An empty written region leaves the target exactly as it was.
+  for (size_t i = 0; i < rank; ++i) {
+    if (IsProvablyEmptyExtent(source_valid[i])) {
+      return target_valid;
+    }
+  }
+
+  // An empty target holds nothing to union with, so the result is the written
+  // region alone — which is a valid shape only if it starts at the origin.
+  for (size_t i = 0; i < rank; ++i) {
+    if (IsProvablyEmptyExtent(target_valid[i])) {
+      CHECK_SPAN(IsOriginAnchored(params.offsets), params.span)
+          << params.op_name << " writes at offset " << FormatShape(params.offsets)
+          << " into a target whose valid region is empty (dimension " << i
+          << " has extent 0), which would leave a region that does not start at the origin. A valid "
+             "shape names one origin-anchored rectangle, so initialize an empty target at offset 0";
+      return source_valid;
+    }
+  }
+
+  // A fully valid target stays fully valid: the physical bounds asserted above
+  // are exactly the containment proof, including for the symbolic offsets that
+  // dominate real code, so this must not be re-derived from the weaker
+  // per-dimension proofs below.
+  if (IsFullyValid(target_valid, params.target_physical)) {
+    return target_valid;
+  }
+
+  // Dimensions the write may push past the target's valid region. Everything it
+  // cannot reach is already covered, so an empty set means the write lands inside.
+  std::vector<ExprPtr> far_edge;
+  std::vector<size_t> growing;
+  far_edge.reserve(rank);
+  for (size_t i = 0; i < rank; ++i) {
+    far_edge.push_back(WriteFarEdge(params, i));
+    if (ProveValidExtentLessEqual(far_edge[i], target_valid[i]) != ProofResult::kTrue) {
+      growing.push_back(i);
+    }
+  }
+  if (growing.empty()) {
+    return target_valid;
+  }
+
+  // The written region swallows the target whole, and starts at the origin, so it
+  // stands alone. This is the multi-dimensional overwrite the single-axis rule
+  // below cannot express.
+  if (IsOriginAnchored(params.offsets)) {
+    bool covers_target = true;
+    for (size_t i = 0; i < rank && covers_target; ++i) {
+      covers_target = ProveValidExtentLessEqual(target_valid[i], source_valid[i]) == ProofResult::kTrue;
+    }
+    if (covers_target) {
+      return source_valid;
+    }
+  }
+
+  // Otherwise the only representable growth is along a single axis: the new slab
+  // must abut what is already there, and must span every other axis exactly, or
+  // the union is an L-shape that no valid shape can name.
+  CHECK_SPAN(growing.size() == 1, params.span)
+      << params.op_name << " grows the valid region along dimensions " << FormatDimensionList(growing)
+      << " at once, whose union with the target is an L-shape rather than one origin-anchored "
+         "rectangle. Target valid "
+      << FormatShape(target_valid) << ", writing " << FormatShape(source_valid) << " at offset "
+      << FormatShape(params.offsets);
+
+  const size_t axis = growing.front();
+  CHECK_SPAN(ProveValidExtentLessEqual(params.offsets[axis], target_valid[axis]) == ProofResult::kTrue,
+             params.span)
+      << params.op_name << " leaves a gap in dimension " << axis << ": the write starts at "
+      << PythonPrint(params.offsets[axis]) << ", which is not provably at or before the target valid extent "
+      << PythonPrint(target_valid[axis])
+      << ". A valid shape names one contiguous origin-anchored rectangle, so a write that grows it must "
+         "abut the region already there";
+
+  for (size_t i = 0; i < rank; ++i) {
+    if (i == axis) {
+      continue;
+    }
+    CHECK_SPAN(IsProvablyEmptyExtent(params.offsets[i]), params.span)
+        << params.op_name << " grows dimension " << axis << ", so it must span dimension " << i
+        << " from the origin, but it starts at " << PythonPrint(params.offsets[i])
+        << ". The added region would be narrower than the region it extends, making the union an L-shape";
+    CHECK_SPAN(ProveValidExtentEqual(source_valid[i], target_valid[i]) == ProofResult::kTrue, params.span)
+        << params.op_name << " grows dimension " << axis << ", so its extent in dimension " << i << " ("
+        << PythonPrint(source_valid[i]) << ") must provably equal the target valid extent ("
+        << PythonPrint(target_valid[i])
+        << "). The added region would otherwise not line up with the region it extends, making the union "
+           "an L-shape";
+  }
+
+  std::vector<ExprPtr> result = target_valid;
+  result[axis] = MinExtent(MaxExtent(target_valid[axis], far_edge[axis], params.span),
+                           params.target_physical[axis], params.span);
+  return result;
+}
+
+// ============================================================================
 // Slice rank-reduction (drop_dims) helpers
 // ============================================================================
 

--- a/tests/ut/codegen/test_pto_codegen.py
+++ b/tests/ut/codegen/test_pto_codegen.py
@@ -2665,13 +2665,19 @@ def test_pto_codegen_tensor_view_aliases_input_base_ptr():
     view_var = ir.Var("src_dn", view_call.type, span)
     tile_call = ir.op.tile.load(view_var, [0, 0], [16, 8])
     tile_var = ir.Var("tile", tile_call.type, span)
-    store_call = ir.op.tile.store(tile_var, [0, 0], out)
+    # The DN view transposes [8, 16] to [16, 8], so the tile is in DN coordinates.
+    # tile.store does no layout conversion (RFC #1300 P7), so the destination is
+    # addressed through the matching view rather than in its untransposed shape.
+    out_view_call = ir.op.tensor.view(out, layout=ir.TensorLayout.DN)
+    out_view_var = ir.Var("out_dn", out_view_call.type, span)
+    store_call = ir.op.tile.store(tile_var, [0, 0], out_view_var)
     result_var = ir.Var("result", store_call.type, span)
 
     body = ir.SeqStmts(
         [
             ir.AssignStmt(view_var, view_call, span),
             ir.AssignStmt(tile_var, tile_call, span),
+            ir.AssignStmt(out_view_var, out_view_call, span),
             ir.AssignStmt(result_var, store_call, span),
             ir.ReturnStmt([result_var], span),
         ],

--- a/tests/ut/ir/operators/test_tensor_ops.py
+++ b/tests/ut/ir/operators/test_tensor_ops.py
@@ -4176,5 +4176,217 @@ class TestTensorRandomOp:
         assert pl.random is pl.tensor.random
 
 
+class TestTensorAssembleValidRegionUnion:
+    """The valid region left behind by ``tensor.assemble``.
+
+    A valid shape names one origin-anchored rectangle, so the union of what the
+    target already held with what was just written is representable only in the
+    cases proven below; everything else rejects rather than widening padding into
+    real data or narrowing real data away.
+    """
+
+    @staticmethod
+    def _symbol(name):
+        return ir.Var(name, ir.ScalarType(DataType.INDEX), ir.Span.unknown())
+
+    def test_fully_valid_target_stays_fully_valid(self):
+        """A write inside a fully valid target leaves nothing to narrow."""
+        span = ir.Span.unknown()
+        target = ir.Var("dst", ir.TensorType([64, 128], DataType.FP32), span)
+        source = _partial_tensor_var([16, 128], [12, 128], name="src")
+
+        result_type = ir.op.tensor.assemble(target, source, [8, 0]).type
+
+        # Full validity is the redundant encoding, so the view collapses away.
+        assert isinstance(result_type, ir.TensorType)
+        assert result_type.tensor_view is None
+
+    def test_empty_source_is_a_no_op(self):
+        """Writing an empty region leaves the target exactly as it was."""
+        target = _partial_tensor_var([64, 128], [20, 128], name="dst")
+        source = _partial_tensor_var([16, 128], [0, 128], name="src")
+
+        result_type = ir.op.tensor.assemble(target, source, [20, 0]).type
+
+        assert _valid_of(result_type) == [20, 128]
+
+    def test_empty_target_is_initialized_by_an_origin_anchored_source(self):
+        """An empty accumulator takes the written region as its whole valid region."""
+        target = _partial_tensor_var([64, 128], [0, 128], name="dst")
+        source = _partial_tensor_var([16, 128], [12, 128], name="src")
+
+        result_type = ir.op.tensor.assemble(target, source, [0, 0]).type
+
+        assert _valid_of(result_type) == [12, 128]
+
+    def test_empty_target_written_off_origin_rejects(self):
+        """A region that does not start at the origin is not a valid shape."""
+        target = _partial_tensor_var([64, 128], [0, 128], name="dst")
+        source = _partial_tensor_var([16, 128], [12, 128], name="src")
+
+        with pytest.raises(ValueError, match="does not start at the origin"):
+            ir.op.tensor.assemble(target, source, [8, 0])
+
+    def test_source_contained_in_target_preserves_target_validity(self):
+        """Overwriting real data that is already there adds nothing."""
+        target = _partial_tensor_var([64, 128], [40, 128], name="dst")
+        source = _partial_tensor_var([16, 128], [8, 128], name="src")
+
+        result_type = ir.op.tensor.assemble(target, source, [0, 0]).type
+
+        assert _valid_of(result_type) == [40, 128]
+
+    def test_contiguous_growth_extends_one_dimension(self):
+        """An append that abuts the target grows exactly that axis."""
+        target = _partial_tensor_var([64, 128], [20, 128], name="dst")
+        source = _partial_tensor_var([16, 128], [12, 128], name="src")
+
+        result_type = ir.op.tensor.assemble(target, source, [20, 0]).type
+
+        assert _valid_of(result_type) == [32, 128]
+
+    def test_overlapping_growth_is_still_contiguous(self):
+        """A write that starts inside the target and runs past it leaves no gap."""
+        target = _partial_tensor_var([64, 128], [20, 128], name="dst")
+        source = _partial_tensor_var([16, 128], [16, 128], name="src")
+
+        result_type = ir.op.tensor.assemble(target, source, [12, 0]).type
+
+        assert _valid_of(result_type) == [28, 128]
+
+    def test_gap_between_target_and_write_rejects(self):
+        """A write starting past the target's edge leaves an unrepresentable hole."""
+        target = _partial_tensor_var([64, 128], [20, 128], name="dst")
+        source = _partial_tensor_var([16, 128], [12, 128], name="src")
+
+        with pytest.raises(ValueError, match="leaves a gap in dimension 0"):
+            ir.op.tensor.assemble(target, source, [24, 0])
+
+    def test_growth_in_two_dimensions_rejects(self):
+        """Growing two axes at once makes the union an L-shape."""
+        target = _partial_tensor_var([64, 256], [20, 64], name="dst")
+        source = _partial_tensor_var([32, 128], [12, 80], name="src")
+
+        with pytest.raises(ValueError, match="dimensions 0 and 1 at once"):
+            ir.op.tensor.assemble(target, source, [20, 0])
+
+    def test_passenger_dimension_must_match_the_target_exactly(self):
+        """A narrower slab than the region it extends is an L-shape."""
+        target = _partial_tensor_var([64, 256], [20, 128], name="dst")
+        source = _partial_tensor_var([32, 128], [12, 64], name="src")
+
+        with pytest.raises(ValueError, match="must provably equal the target valid extent"):
+            ir.op.tensor.assemble(target, source, [20, 0])
+
+    def test_passenger_dimension_must_start_at_the_origin(self):
+        """An offset slab does not line up with the region it extends.
+
+        Dimension 1 stays inside the target (8 + 64 <= 128), so this reaches the
+        passenger rule rather than the two-dimensional growth rule above.
+        """
+        target = _partial_tensor_var([64, 256], [20, 128], name="dst")
+        source = _partial_tensor_var([32, 128], [12, 64], name="src")
+
+        with pytest.raises(ValueError, match="must span dimension 1 from the origin"):
+            ir.op.tensor.assemble(target, source, [20, 8])
+
+    def test_target_swallowed_by_an_origin_anchored_write(self):
+        """A write covering the target on every axis stands alone."""
+        target = _partial_tensor_var([64, 128], [4, 8], name="dst")
+        source = _partial_tensor_var([32, 128], [32, 128], name="src")
+
+        result_type = ir.op.tensor.assemble(target, source, [0, 0]).type
+
+        assert _valid_of(result_type) == [32, 128]
+
+    def test_negative_offset_rejects(self):
+        """A write must start inside its target."""
+        span = ir.Span.unknown()
+        target = _partial_tensor_var([64, 128], [20, 128], name="dst")
+        source = _partial_tensor_var([16, 128], [12, 128], name="src")
+        neg = ir.ConstInt(-4, DataType.INDEX, span)
+
+        with pytest.raises(ValueError, match="provably negative"):
+            ir.op.tensor.assemble(target, source, [neg, 0])
+
+    def test_write_past_the_target_end_rejects(self):
+        """The written region must fit inside the target allocation."""
+        span = ir.Span.unknown()
+        target = ir.Var("dst", ir.TensorType([64, 128], DataType.FP32), span)
+        source = _partial_tensor_var([32, 128], [32, 128], name="src")
+
+        with pytest.raises(ValueError, match="writes past the end of dimension 0"):
+            ir.op.tensor.assemble(target, source, [56, 0])
+
+    def test_only_the_source_valid_region_has_to_fit(self):
+        """A padded source transfers its real extent, not its whole allocation.
+
+        The counterpart tile.assemble rejects this same write, because
+        ``pto.tinsert`` copies the physical subview rather than the valid one.
+        """
+        span = ir.Span.unknown()
+        target = ir.Var("dst", ir.TensorType([64, 128], DataType.FP32), span)
+        # 48 rows allocated, only 8 of them real, landing on the last 8 target rows.
+        source = _partial_tensor_var([48, 128], [8, 128], name="src")
+
+        result_type = ir.op.tensor.assemble(target, source, [56, 0]).type
+
+        assert isinstance(result_type, ir.TensorType)
+        assert result_type.tensor_view is None
+
+    def test_symbolic_contiguous_append_is_proven_by_structural_equality(self):
+        """``t = [k, 128]`` appended at ``[k, 0]`` grows to ``k + m``."""
+        k = self._symbol("k")
+        m = self._symbol("m")
+        target = _partial_tensor_var([64, 128], [k, 128], name="dst")
+        source = _partial_tensor_var([32, 128], [m, 128], name="src")
+
+        result_type = ir.op.tensor.assemble(target, source, [k, 0]).type
+
+        # Capped at the physical extent, which no proof settles for symbolic k + m.
+        assert isinstance(result_type, ir.TensorType)
+        view = result_type.tensor_view
+        assert view is not None
+        assert ir.python_print(view.valid_shape[0]) == "pl.min(k + m, 64)"
+        assert _valid_of(result_type)[1] == 128
+
+    def test_unprovable_symbolic_offset_rejects(self):
+        """An offset unrelated to the target's extent cannot be shown to abut it."""
+        k = self._symbol("k")
+        m = self._symbol("m")
+        j = self._symbol("j")
+        target = _partial_tensor_var([64, 128], [k, 128], name="dst")
+        source = _partial_tensor_var([32, 128], [m, 128], name="src")
+
+        with pytest.raises(ValueError, match="leaves a gap in dimension 0"):
+            ir.op.tensor.assemble(target, source, [j, 0])
+
+    def test_monotonic_multi_step_accumulation(self):
+        """Repeated appends stay one rectangle and never narrow."""
+        span = ir.Span.unknown()
+        target = _partial_tensor_var([64, 128], [0, 128], name="acc")
+        source = _partial_tensor_var([8, 128], [8, 128], name="src")
+
+        for step, expected in enumerate([8, 16, 24]):
+            result_type = ir.op.tensor.assemble(target, source, [step * 8, 0]).type
+            assert _valid_of(result_type) == [expected, 128]
+            target = ir.Var(f"acc{step}", result_type, span)
+
+    def test_rank_mismatched_write_keeps_its_previous_result(self):
+        """A reinterpreting write is not a rectangle on these axes, so it is left alone.
+
+        ``OptimizeOrchTensors`` materializes the dimension correspondence of a
+        lower-rank source as strides, exactly as for a lower-rank window read.
+        """
+        span = ir.Span.unknown()
+        target = ir.Var("dst", ir.TensorType([2, 4, 8], DataType.FP32), span)
+        source = _partial_tensor_var([2, 4], [1, 4], name="src")
+
+        result_type = ir.op.tensor.assemble(target, source, [0, 0, 0]).type
+
+        assert isinstance(result_type, ir.TensorType)
+        assert result_type.tensor_view is None
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/ir/operators/test_tile_ops.py
+++ b/tests/ut/ir/operators/test_tile_ops.py
@@ -5068,34 +5068,37 @@ class TestWriteValidRegionUnion:
         with pytest.raises(ValueError, match="leaves a gap in dimension 0"):
             tile.store(src, [24, 0], out)
 
-    def test_store_uses_the_authoritative_original_rank_partition(self):
-        """The ND ``shapes`` operand names the written region, not the 2D tile.
+    def test_store_leaves_the_nd_partition_form_alone(self):
+        """The ND ``shapes`` operand is a collapsed-dims descriptor, not a rectangle.
 
-        FlattenTileNdTo2D records it precisely because a flattened tile no longer
-        carries the ND extent.
+        FlattenTileNdTo2D builds it as leading 1s followed by the pre-flatten tile
+        shape, so its leading extent can be a product of several destination axes
+        and need not fit the matching one. Reading it as an origin-anchored
+        rectangle would mis-bound the write and place the union on the wrong axes,
+        so the destination type is passed through untouched.
         """
         out = self._partial_tensor([2, 3, 16, 64], [1, 3, 16, 64])
         src = self._partial_tile([16, 64], [16, 64], name="src")
 
         result_type = tile.store(src, [1, 0, 0, 0], out, [1, 3, 16, 64]).type
 
-        assert self._tensor_valid_of(result_type) == [2, 3, 16, 64]
-
-    def test_store_partial_tile_does_not_claim_the_whole_nd_partition(self):
-        """A partially valid tile must not promote its padding to real data.
-
-        ``shapes`` is authoritative for the partition's physical extent, but the
-        region actually written is the flattened tile's valid one. Recovering that
-        on ND axes is the ND-to-2D mapping problem, so the destination is left
-        alone rather than reported as fully written.
-        """
-        out = self._partial_tensor([2, 3, 16, 64], [1, 3, 16, 64])
-        # Only 8 of the tile's 16 rows are real.
-        src = self._partial_tile([16, 64], [8, 64], name="src")
-
-        result_type = tile.store(src, [1, 0, 0, 0], out, [1, 3, 16, 64]).type
-
         assert self._tensor_valid_of(result_type) == [1, 3, 16, 64]
+
+    def test_store_accepts_a_collapsed_nd_partition(self):
+        """A partition extent may exceed the destination axis it nominally sits on.
+
+        This is the shape ``tests/st/runtime/ops/test_gather.py`` produces: a
+        ``[2, 3, 8]`` gather whose lowering collapses the leading dims to a
+        ``[6, 8]`` tile, stored as partition ``[1, 6, 8]`` where 6 > 3.
+        """
+        span = ir.Span.unknown()
+        out = ir.Var("out", ir.TensorType([2, 3, 8], DataType.FP32), span)
+        src = self._partial_tile([6, 8], [6, 8], name="src")
+
+        result_type = tile.store(src, [0, 0, 0], out, [1, 6, 8]).type
+
+        assert isinstance(result_type, ir.TensorType)
+        assert result_type.tensor_view is None
 
     def test_store_rank_mismatch_keeps_its_previous_result(self):
         """A reinterpreting store is not a rectangle on the destination axes."""

--- a/tests/ut/ir/operators/test_tile_ops.py
+++ b/tests/ut/ir/operators/test_tile_ops.py
@@ -4884,6 +4884,35 @@ class TestWriteValidRegionUnion:
         assert isinstance(result_type, ir.TileType)
         assert result_type.tile_view is None
 
+    def test_assemble_padded_source_does_not_disturb_the_target_beyond_it(self):
+        """An ISA-padded source moves its valid region, not its allocation.
+
+        Codegen emits ``pto.subview %dst[...] sizes [R, C] valid [Vr, Vc]`` and
+        moves into that view, so the band between the source's valid extent and
+        its allocation is addressed but not transferred. The target keeps what it
+        had there, which is why a fully valid target stays fully valid and the
+        ISA-padding idiom of PR #1528 is accepted.
+        """
+        span = ir.Span.unknown()
+        target = ir.Var("dst", ir.TileType([64, 128], DataType.FP32), span)
+        # 8 of 16 rows real -- the classic fixed-width staging tile.
+        source = self._partial_tile([16, 128], [8, 128], name="src")
+
+        result_type = tile.assemble(target, source, [0, 0]).type
+
+        assert isinstance(result_type, ir.TileType)
+        assert result_type.tile_view is None
+
+    def test_assemble_padded_source_appends_only_its_valid_region(self):
+        """The append grows by the source's real extent, not its allocation."""
+        target = self._partial_tile([64, 128], [20, 128], name="dst")
+        source = self._partial_tile([16, 128], [8, 128], name="src")
+
+        result_type = tile.assemble(target, source, [20, 0]).type
+
+        # 8 real rows land at 20-27; the allocation's remaining 8 rows move nothing.
+        assert self._tile_valid_of(result_type) == [28, 128]
+
     def test_assemble_contiguous_growth_extends_one_dimension(self):
         """An append that abuts the target grows exactly that axis."""
         target = self._partial_tile([64, 128], [20, 128], name="dst")

--- a/tests/ut/ir/operators/test_tile_ops.py
+++ b/tests/ut/ir/operators/test_tile_ops.py
@@ -4970,6 +4970,15 @@ class TestWriteValidRegionUnion:
         with pytest.raises(ValueError, match="writes past the end of dimension 0"):
             tile.assemble(target, source, [56, 0])
 
+    def test_assemble_bounds_rejection_names_the_subview_rule(self):
+        """tile.assemble's overhang error explains why the allocation must fit."""
+        span = ir.Span.unknown()
+        target = ir.Var("dst", ir.TileType([64, 128], DataType.FP32), span)
+        source = self._partial_tile([48, 128], [8, 128], name="src")
+
+        with pytest.raises(ValueError, match="copies the whole source subview"):
+            tile.assemble(target, source, [56, 0])
+
     def test_assemble_keeps_the_target_layout_while_narrowing(self):
         """A partial union must not cost the target its layout metadata."""
         target = self._partial_tile([64, 128], [20, 128], name="dst", blayout=ir.TileLayout.col_major)
@@ -5050,15 +5059,6 @@ class TestWriteValidRegionUnion:
 
         with pytest.raises(ValueError, match="performs no layout conversion"):
             tile.store(src, [0, 0], out)
-
-    def test_assemble_bounds_rejection_names_the_subview_rule(self):
-        """tile.assemble's overhang error explains why the allocation must fit."""
-        span = ir.Span.unknown()
-        target = ir.Var("dst", ir.TileType([64, 128], DataType.FP32), span)
-        source = self._partial_tile([48, 128], [8, 128], name="src")
-
-        with pytest.raises(ValueError, match="copies the whole source subview"):
-            tile.assemble(target, source, [56, 0])
 
     def test_store_gap_rejects(self):
         """A store that does not abut the destination's valid region rejects."""

--- a/tests/ut/ir/operators/test_tile_ops.py
+++ b/tests/ut/ir/operators/test_tile_ops.py
@@ -4836,5 +4836,249 @@ class TestWindowReadValidRegion:
         assert self._valid_of(call.type) == [24, 32]
 
 
+class TestWriteValidRegionUnion:
+    """The valid-region union rule shared by tile.assemble and tile.store.
+
+    out_valid[i] = min(shape[i], max(target_valid[i], offset[i] + source_valid[i]))
+
+    accepted only where that candidate provably *is* the union of the target
+    rectangle and the written one.
+    """
+
+    @staticmethod
+    def _partial_tile(shape, valid_shape, name="t", **view_kwargs):
+        span = ir.Span.unknown()
+        view = ir.TileView(valid_shape=valid_shape, stride=[], start_offset=None, **view_kwargs)
+        return ir.Var(name, ir.TileType(shape, DataType.FP32, tile_view=view), span)
+
+    @staticmethod
+    def _partial_tensor(shape, valid_shape, name="out"):
+        span = ir.Span.unknown()
+        view = ir.TensorView(stride=[], layout=ir.TensorLayout.ND, valid_shape=valid_shape)
+        return ir.Var(name, ir.TensorType(shape, DataType.FP32, tensor_view=view), span)
+
+    @staticmethod
+    def _tile_valid_of(result_type):
+        view = result_type.tile_view
+        if view is None or not view.valid_shape:
+            return [d.value for d in result_type.shape if isinstance(d, ir.ConstInt)]
+        return [d.value if isinstance(d, ir.ConstInt) else d for d in view.valid_shape]
+
+    @staticmethod
+    def _tensor_valid_of(result_type):
+        view = result_type.tensor_view
+        if view is None or not view.valid_shape:
+            return [d.value for d in result_type.shape if isinstance(d, ir.ConstInt)]
+        return [d.value if isinstance(d, ir.ConstInt) else d for d in view.valid_shape]
+
+    # --- tile.assemble ------------------------------------------------------
+
+    def test_assemble_fully_valid_target_stays_implicit(self):
+        """A full target keeps the implicit view its layout depends on."""
+        span = ir.Span.unknown()
+        target = ir.Var("dst", ir.TileType([64, 128], DataType.FP32), span)
+        source = self._partial_tile([16, 128], [12, 128], name="src")
+
+        result_type = tile.assemble(target, source, [8, 0]).type
+
+        assert isinstance(result_type, ir.TileType)
+        assert result_type.tile_view is None
+
+    def test_assemble_contiguous_growth_extends_one_dimension(self):
+        """An append that abuts the target grows exactly that axis."""
+        target = self._partial_tile([64, 128], [20, 128], name="dst")
+        source = self._partial_tile([12, 128], [12, 128], name="src")
+
+        result_type = tile.assemble(target, source, [20, 0]).type
+
+        assert self._tile_valid_of(result_type) == [32, 128]
+
+    def test_assemble_empty_source_is_a_no_op(self):
+        """Writing an empty region leaves the target exactly as it was."""
+        target = self._partial_tile([64, 128], [20, 128], name="dst")
+        source = self._partial_tile([16, 128], [0, 128], name="src")
+
+        result_type = tile.assemble(target, source, [20, 0]).type
+
+        assert self._tile_valid_of(result_type) == [20, 128]
+
+    def test_assemble_empty_target_is_initialized_from_the_origin(self):
+        """An empty accumulator takes the written region as its valid region."""
+        target = self._partial_tile([64, 128], [0, 128], name="dst")
+        source = self._partial_tile([16, 128], [12, 128], name="src")
+
+        result_type = tile.assemble(target, source, [0, 0]).type
+
+        assert self._tile_valid_of(result_type) == [12, 128]
+
+    def test_assemble_gap_rejects(self):
+        """A write starting past the target's edge leaves an unrepresentable hole."""
+        target = self._partial_tile([64, 128], [20, 128], name="dst")
+        source = self._partial_tile([12, 128], [12, 128], name="src")
+
+        with pytest.raises(ValueError, match="leaves a gap in dimension 0"):
+            tile.assemble(target, source, [24, 0])
+
+    def test_assemble_l_shape_rejects(self):
+        """Growing two axes at once is not one origin-anchored rectangle."""
+        target = self._partial_tile([64, 256], [20, 64], name="dst")
+        source = self._partial_tile([32, 128], [12, 80], name="src")
+
+        with pytest.raises(ValueError, match="dimensions 0 and 1 at once"):
+            tile.assemble(target, source, [20, 0])
+
+    def test_assemble_validates_the_physical_source_subview(self):
+        """``pto.tinsert`` copies the whole subview, so all of it must fit.
+
+        The tensor.assemble counterpart accepts this same write, because a tensor
+        transfer moves only the source's valid region.
+        """
+        span = ir.Span.unknown()
+        target = ir.Var("dst", ir.TileType([64, 128], DataType.FP32), span)
+        # 48 rows allocated, only 8 real; the allocation overhangs the target.
+        source = self._partial_tile([48, 128], [8, 128], name="src")
+
+        with pytest.raises(ValueError, match="writes past the end of dimension 0"):
+            tile.assemble(target, source, [56, 0])
+
+    def test_assemble_keeps_the_target_layout_while_narrowing(self):
+        """A partial union must not cost the target its layout metadata."""
+        target = self._partial_tile([64, 128], [20, 128], name="dst", blayout=ir.TileLayout.col_major)
+        source = self._partial_tile([12, 128], [12, 128], name="src")
+
+        result_type = tile.assemble(target, source, [20, 0]).type
+
+        assert isinstance(result_type, ir.TileType)
+        view = result_type.tile_view
+        assert view is not None
+        assert view.blayout == ir.TileLayout.col_major
+        assert self._tile_valid_of(result_type) == [32, 128]
+
+    def test_assemble_negative_offset_rejects(self):
+        """A write must start inside its target."""
+        span = ir.Span.unknown()
+        target = self._partial_tile([64, 128], [20, 128], name="dst")
+        source = self._partial_tile([12, 128], [12, 128], name="src")
+        neg = ir.ConstInt(-4, DataType.INDEX, span)
+
+        with pytest.raises(ValueError, match="provably negative"):
+            tile.assemble(target, source, [neg, 0])
+
+    # --- tile.store ---------------------------------------------------------
+
+    def test_store_into_fully_valid_destination_is_unchanged(self):
+        """The overwhelmingly common store keeps the destination type it had."""
+        span = ir.Span.unknown()
+        out = ir.Var("out", ir.TensorType([64, 128], DataType.FP32), span)
+        src = self._partial_tile([16, 128], [12, 128], name="src")
+
+        result_type = tile.store(src, [8, 0], out).type
+
+        assert isinstance(result_type, ir.TensorType)
+        assert result_type.tensor_view is None
+
+    def test_store_unions_into_a_partially_valid_destination(self):
+        """A store appends to the destination's valid region."""
+        out = self._partial_tensor([64, 128], [20, 128])
+        src = self._partial_tile([16, 128], [12, 128], name="src")
+
+        result_type = tile.store(src, [20, 0], out).type
+
+        assert self._tensor_valid_of(result_type) == [32, 128]
+
+    def test_store_transfers_only_the_tile_valid_region(self):
+        """The DMA moves the real extent, so a padded tile is bounded by it."""
+        span = ir.Span.unknown()
+        out = ir.Var("out", ir.TensorType([64, 128], DataType.FP32), span)
+        # 64 rows allocated, 8 real, landing on the destination's last 8 rows.
+        src = self._partial_tile([64, 128], [8, 128], name="src")
+
+        result_type = tile.store(src, [56, 0], out).type
+
+        assert isinstance(result_type, ir.TensorType)
+        assert result_type.tensor_view is None
+
+    def test_store_validates_destination_bounds(self):
+        """A transfer that runs off the destination rejects."""
+        span = ir.Span.unknown()
+        out = ir.Var("out", ir.TensorType([64, 128], DataType.FP32), span)
+        src = self._partial_tile([32, 128], [32, 128], name="src")
+
+        with pytest.raises(ValueError, match="writes past the end of dimension 0"):
+            tile.store(src, [56, 0], out)
+
+    def test_store_bounds_rejection_names_the_layout_remedy(self):
+        """An overhang is usually a coordinate mismatch, so the error says so.
+
+        A tile read through a DN view is transposed; storing it into the
+        destination's untransposed shape overflows one axis while under-filling
+        the other. ``tile.store`` converts no layouts (RFC #1300 P7), so the
+        diagnostic points at taking the matching view of the destination.
+        """
+        span = ir.Span.unknown()
+        out = ir.Var("out", ir.TensorType([8, 16], DataType.FP32), span)
+        src = self._partial_tile([16, 8], [16, 8], name="src")
+
+        with pytest.raises(ValueError, match="performs no layout conversion"):
+            tile.store(src, [0, 0], out)
+
+    def test_assemble_bounds_rejection_names_the_subview_rule(self):
+        """tile.assemble's overhang error explains why the allocation must fit."""
+        span = ir.Span.unknown()
+        target = ir.Var("dst", ir.TileType([64, 128], DataType.FP32), span)
+        source = self._partial_tile([48, 128], [8, 128], name="src")
+
+        with pytest.raises(ValueError, match="copies the whole source subview"):
+            tile.assemble(target, source, [56, 0])
+
+    def test_store_gap_rejects(self):
+        """A store that does not abut the destination's valid region rejects."""
+        out = self._partial_tensor([64, 128], [20, 128])
+        src = self._partial_tile([16, 128], [12, 128], name="src")
+
+        with pytest.raises(ValueError, match="leaves a gap in dimension 0"):
+            tile.store(src, [24, 0], out)
+
+    def test_store_uses_the_authoritative_original_rank_partition(self):
+        """The ND ``shapes`` operand names the written region, not the 2D tile.
+
+        FlattenTileNdTo2D records it precisely because a flattened tile no longer
+        carries the ND extent.
+        """
+        out = self._partial_tensor([2, 3, 16, 64], [1, 3, 16, 64])
+        src = self._partial_tile([16, 64], [16, 64], name="src")
+
+        result_type = tile.store(src, [1, 0, 0, 0], out, [1, 3, 16, 64]).type
+
+        assert self._tensor_valid_of(result_type) == [2, 3, 16, 64]
+
+    def test_store_partial_tile_does_not_claim_the_whole_nd_partition(self):
+        """A partially valid tile must not promote its padding to real data.
+
+        ``shapes`` is authoritative for the partition's physical extent, but the
+        region actually written is the flattened tile's valid one. Recovering that
+        on ND axes is the ND-to-2D mapping problem, so the destination is left
+        alone rather than reported as fully written.
+        """
+        out = self._partial_tensor([2, 3, 16, 64], [1, 3, 16, 64])
+        # Only 8 of the tile's 16 rows are real.
+        src = self._partial_tile([16, 64], [8, 64], name="src")
+
+        result_type = tile.store(src, [1, 0, 0, 0], out, [1, 3, 16, 64]).type
+
+        assert self._tensor_valid_of(result_type) == [1, 3, 16, 64]
+
+    def test_store_rank_mismatch_keeps_its_previous_result(self):
+        """A reinterpreting store is not a rectangle on the destination axes."""
+        span = ir.Span.unknown()
+        out = ir.Var("out", ir.TensorType([1, 16, 64], DataType.FP32), span)
+        src = self._partial_tile([16, 64], [8, 64], name="src")
+
+        result_type = tile.store(src, [0, 0], out).type
+
+        assert isinstance(result_type, ir.TensorType)
+        assert result_type.tensor_view is None
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## What changed

`tensor.assemble`, `tile.assemble`, and `tile.store` now derive the valid region a
write leaves behind, instead of claiming the target's full shape. The candidate is

```text
out_valid[i] = min(shape[i], max(target_valid[i], offset[i] + source_valid[i]))
```

returned only where that provably *is* the union of the target rectangle and the
written one. It is implemented once as `InferWriteValidShapeUnion` in
`type_inference.h/cpp`, alongside brief 08's `InferWindowReadValidShape`, and reuses
the existing proof vocabulary (`ProveValidExtentEqual`, `ProveValidExtentLessEqual`,
`GetValidShape`, `GetEffectiveTensorValidShape`, `MakeFreshTensorType`).

### Why a proof is needed

Returning the target's full shape after a partial write lets a later store push
padding out as real data; returning only the source discards real data the target
already held. Both are silent. A valid shape names one origin-anchored rectangle, so
writing `W = ∏[o[i], o[i]+s[i])` into `T = ∏[0, t[i])` is representable only when
`T ∪ W` is itself origin-anchored. Accepted cases:

| Case | Result |
| ---- | ------ |
| Written region empty | target unchanged |
| Target empty, write at the origin | the written region |
| Write contained in target (a fully valid target is this case) | target unchanged |
| Target contained in an origin-anchored write | the written region |
| Growth along exactly one axis `d` | `t` with `t[d]` extended |

Single-axis growth additionally requires the write to abut what is there
(`offset[d] <= target_valid[d]`, so no gap opens) and to span every other axis
exactly (`offset[i] == 0` and `source_valid[i] == target_valid[i]`). Anything less
on a passenger axis leaves the new slab narrower than the region it extends — an
L-shape, which no valid shape can name.

Growth in two or more axes at once, a gap, a mismatched passenger axis, a provably
negative offset, and any of these relations left unproven all reject rather than
widen. Symbolic appends stated by structural equality are accepted: a target valid
`[k, 128]` written at `[k, 0]` from `[m, 128]` yields `[min(k + m, 64), 128]`.

### Tensor / tile asymmetry

The same split brief 08 drew between clamped and exact window reads, on the write
side — the substrate genuinely differs:

- **`tile.assemble` (`kExactSubview`)** — codegen emits
  `pto.subview %dst[...] sizes [R, C] valid [Vr, Vc]` where `sizes` is the source's
  *physical* shape, and `pto.subview` is a pure view with hard bounds, so the source
  *allocation* must fit inside the target.
- **`tensor.assemble` / `tile.store` (`kValidRegionTransfer`)** — the transfer is
  bounded by the valid extent, so a padded staging buffer holding a short tail is fine.

The kind governs *bounds only*. On the assemble path what actually moves is still the
valid region — the subview's explicit `valid [Vr, Vc]` operands, which PTOAS checks
against the result tile_buf's `v_row`/`v_col` — so the band between a source's valid
extent and its allocation is addressed but never transferred, and the target keeps
what it had there. That is what makes the ISA-padding idiom of #1528 sound, and it is
now pinned down by `test_assemble_padded_source_does_not_disturb_the_target_beyond_it`
and `test_assemble_padded_source_appends_only_its_valid_region`.

Expressions are built proof-first through the same helpers, so constant arithmetic
folds and no redundant `min`/`max` nesting reaches a type.

## Deviations from the brief

1. **Rank-mismatched writes are excluded, not unioned** — the write-side twin of
   brief 08's deviation 3. `tensor.assemble` legitimately takes a 2D source into a 3D
   target, and `tile.store` takes lower-rank windows; `OptimizeOrchTensors`
   materializes that dimension correspondence as strides, so the write is not a
   rectangle on the target's axes and unioning it would target the wrong ones. These
   keep the result they had before. Six in-tree tests proved the case is load-bearing.
2. **A fully valid target is a first-class early accept**, ahead of the
   per-dimension proofs. Deriving it from the containment proof instead would reject
   the ordinary dynamic-loop idiom (fully valid target, symbolic offset), where
   `offset + extent <= shape` is trusted rather than proven — the same trust brief 08
   established for non-clamping reads. This is what the brief's "fully valid target
   remains full, **after physical bounds checks**" requires.
3. **`tile.store` unions, but `FlattenTileNdTo2D` discards it for ND stores** — that
   pass rebuilds the `Call` with `out_type = args[2]`'s type, bypassing the deducer.
   ND valid-region remapping belongs to brief 18.
4. **The 4-arg ND partition form of `tile.store` is exempt entirely** — no union, no
   bounds check, destination type passed through. That operand is not a rectangle in
   destination coordinates: `FlattenTileNdTo2D` builds it as leading 1s followed by
   the *pre-flatten* tile shape, so its leading extent can be the product of several
   destination axes. A `[2, 3, 8]` gather collapses to a `[6, 8]` tile and stores it
   as partition `[1, 6, 8]`, where 6 spans two axes of a destination whose own axis 1
   is 3. Codegen consumes that through `pto.partition_view`, which understands the
   collapse; bounding it per-axis against the destination does not. Recovering the
   written region on ND axes is the ND-to-2D mapping problem (brief 18). The 3-arg
   form, where the tile really does describe a destination rectangle, keeps the full
   union and its bounds validation.
5. **`tensor.assemble` still returns a fresh result type** (`MakeFreshTensorType`:
   default layout, empty stride, no memref), where `tile.store` now preserves the
   destination's view and memref and `tile.assemble` seeds from the target's effective
   tile view. This matches `tensor.assemble`'s pre-change behavior exactly — it
   returned `TensorType(shape, dtype)` — so preserving stride/memref here would be a
   behavior change outside this brief with real blast radius in `InitMemRef` and
   `MemoryReuse`. Flagged as a follow-up rather than folded in.
6. **Docs deferred** to brief 04, per the series rules.

## Behavior change

`tile.store` previously had no rank, offset, or destination-bounds validation at all.
It does now, and one in-tree call site was genuinely out of bounds.

`test_pto_codegen_tensor_view_aliases_input_base_ptr` loaded a `[16, 8]` tile through
a DN view of an `[8, 16]` tensor, then stored it into that tensor's *untransposed*
`[8, 16]` shape. Per RFC #1300 P7 (`src/backend/common/pto_ops_memory.cpp:176`),
`tile.store` performs no implicit `dn_swap` — matching coordinate systems is the IR's
responsibility — so this emitted a `[16, 8]` `partition_view` over an `[8, 16]` view.
The test now takes the matching DN view of the destination before storing; every
existing assertion is unchanged.

Because an overhang is usually a coordinate-system mismatch rather than an arithmetic
slip, physical-bounds rejections carry a per-operator `bounds_remedy` (brief 08's
pattern) naming how that substrate wants to be addressed:

```text
tile.store writes past the end of dimension 0: offset 0 + extent 16 exceeds the
target extent 8. A store performs no layout conversion (RFC #1300 P7): the offsets
and the tile extent must already be in the destination's coordinate system. If the
tile was read through a view whose layout differs from the destination's -- a DN
view transposes it -- take the matching view of the destination,
pl.view(out, layout=...), and store into that
```

Stores into a fully valid destination — the overwhelmingly common case — return the
destination type itself, preserving its memref and comm-group binding. A fully valid
assemble result canonicalizes back to an absent view, so unpadded code is unchanged.

## New diagnostics

All `CHECK_SPAN`, on user-authored writes:

- writes past the end of dimension *i* (with the per-operator remedy above)
- offset *i* is provably negative
- leaves a gap in dimension *i*
- grows the valid region along dimensions *i* and *j* at once (L-shape)
- must span dimension *i* from the origin
- extent in dimension *i* must provably equal the target valid extent
- writes into a target whose valid region is empty at a non-origin offset

## Tests

40 focused tests in `tests/ut/ir/operators/test_tensor_ops.py` and `test_tile_ops.py`
covering every required case with static and symbolic extents on both tensor and
tile, plus monotonic multi-step accumulation, the authoritative original-rank ND
store partition, the tensor/tile bounds asymmetry, layout preservation through a
partial tile union, the partial-tile ND carve-out, and the rank-mismatch exclusion.

## Validation

| Check | Result |
| ----- | ------ |
| `cmake --build build --parallel` | clean |
| `pytest -k 'assemble or store'` | 5 pre-existing + 40 new pass |
| `tests/st/runtime/ops/test_gather.py` rank-3 compiles | pass on Ascend910B and Ascend950 |
| Full unit suite | 7825 passed, 2 skipped, 0 failed |
| `pre-commit` (8 changed files) | all hooks pass |
| `clang_tidy.py --diff-base --strict-version` | clean |

Baseline before this change was 7785 passed, 2 skipped, 0 failed on the same base;
the 2 skips are pre-existing.

Part of the unified `valid_shape` series (brief 09). Depends on the merged briefs 05
(#2031), 06 (#2037), 07 (#2043), 08 (#2048), and 11 (#2051).
