### PR TITLE
fix(runtime): Explain missing kernel config for compile-only artifacts

### DIFF
--- a/python/pypto/runtime/device_runner.py
+++ b/python/pypto/runtime/device_runner.py
@@ -478,6 +478,86 @@ def compile_single_orchestration(
 # ---------------------------------------------------------------------------
 
 
+def _missing_kernel_config_error(work_dir: Path) -> FileNotFoundError:
+    """Explain why a build output has no runtime manifest."""
+    config_path = work_dir / "kernel_config.py"
+    kernels_dir = work_dir / "kernels"
+    raw_pto_count = sum(1 for _ in kernels_dir.rglob("*.pto"))
+    if raw_pto_count == 0:
+        return FileNotFoundError(
+            f"Cannot execute PyPTO artifact '{work_dir}': required '{config_path}' is missing.\n"
+            f"No raw .pto kernel files were found under '{kernels_dir}' either. This directory "
+            "cannot be loaded as a single-chip PyPTO artifact; it may be incomplete or use a "
+            "different build layout.\n"
+            "Recompile the program and inspect any earlier codegen error."
+        )
+
+    ptoas_root = os.environ.get("PTOAS_ROOT")
+    configuration_step: str | None = None
+    if ptoas_root:
+        ptoas_path = Path(ptoas_root) / "ptoas"
+        if ptoas_path.is_file() and os.access(ptoas_path, os.X_OK):
+            environment_status = (
+                f"ptoas is now available at '{ptoas_path}', but this artifact was generated "
+                "without it and must be recompiled."
+            )
+        else:
+            environment_status = (
+                f"PTOAS_ROOT is set to '{ptoas_root}', but the expected executable "
+                f"'{ptoas_path}' does not exist or is not executable."
+            )
+            configuration_step = (
+                "Correct or remove the invalid PTOAS_ROOT setting:\n"
+                "       export PTOAS_ROOT=/path/to/ptoas-bin\n"
+                "     Or use a ptoas executable from PATH instead:\n"
+                "       unset PTOAS_ROOT\n"
+                "       export PATH=/path/to/ptoas-bin:$PATH\n"
+                "     On a managed PyPTO development machine, reset the invalid override first:\n"
+                "       unset PTOAS_ROOT\n"
+                '       eval "$(pypto-setup --export)"'
+            )
+    else:
+        ptoas_path = shutil.which("ptoas")
+        if ptoas_path:
+            environment_status = (
+                f"ptoas is now available on PATH at '{ptoas_path}', but this artifact was "
+                "generated without it and must be recompiled."
+            )
+        else:
+            environment_status = "PTOAS_ROOT is not set and 'ptoas' was not found on PATH."
+            configuration_step = (
+                "Configure ptoas with one of these options:\n"
+                "       export PTOAS_ROOT=/path/to/ptoas-bin\n"
+                "     Or:\n"
+                "       export PATH=/path/to/ptoas-bin:$PATH\n"
+                "     On a managed PyPTO development machine, run:\n"
+                '       eval "$(pypto-setup --export)"'
+            )
+
+    recovery_steps = []
+    if configuration_step is not None:
+        recovery_steps.append(configuration_step)
+    recovery_steps.extend(
+        [
+            "Restart the Python process and rerun the program so the artifact is recompiled.",
+            "If calling ir.compile() directly, use skip_ptoas=False.",
+        ]
+    )
+    recovery_text = "\n".join(f"  {index}. {step}" for index, step in enumerate(recovery_steps, start=1))
+
+    return FileNotFoundError(
+        f"Cannot execute PyPTO artifact '{work_dir}': required '{config_path}' was not generated.\n"
+        "Reason:\n"
+        f"  Found {raw_pto_count} raw .pto kernel file(s) under '{kernels_dir}'.\n"
+        "  This is a compile-only artifact produced with skip_ptoas=True. That mode intentionally "
+        "omits kernel_config.py and cannot be executed. @pl.jit selects it automatically when "
+        "ptoas is unavailable.\n"
+        "PTOAS check:\n"
+        f"  {environment_status}\n"
+        f"How to fix:\n{recovery_text}"
+    )
+
+
 def compile_and_assemble(
     work_dir: Path,
     platform: str,
@@ -499,11 +579,16 @@ def compile_and_assemble(
         ``kernel_config.py``. Callers can read defaults such as
         ``aicpu_thread_num`` from ``runtime_config`` — keys are only
         present when the producer of the artifact opted to bake them in.
+
+    Raises:
+        FileNotFoundError: If ``kernel_config.py`` is missing. Compile-only
+            artifacts include the detected ptoas configuration and recovery
+            steps in the error.
     """
     # Load kernel_config.py
     config_path = work_dir / "kernel_config.py"
     if not config_path.exists():
-        raise FileNotFoundError(f"kernel_config.py not found in {work_dir}")
+        raise _missing_kernel_config_error(work_dir)
 
     spec = importlib.util.spec_from_file_location("_kernel_config", str(config_path))
     if spec is None or spec.loader is None:

--- a/tests/ut/runtime/test_pto_isa_resolution.py
+++ b/tests/ut/runtime/test_pto_isa_resolution.py
@@ -7,7 +7,7 @@
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
 
-"""Regression tests for managed PTO-ISA revision resolution."""
+"""Regression tests for device-runner diagnostics and PTO-ISA resolution."""
 
 import importlib
 import logging
@@ -161,6 +161,84 @@ def test_unavailable_runtime_pin_falls_back_to_latest(
     checkout.assert_not_called()
     update_latest.assert_called_once_with(clone_path)
     assert "falling back to the latest remote HEAD" in caplog.text
+
+
+def _write_raw_pto(work_dir):
+    pto_path = work_dir / "kernels" / "aiv" / "tile_add.pto"
+    pto_path.parent.mkdir(parents=True)
+    pto_path.write_text("module {}", encoding="utf-8")
+
+
+def _missing_config_message(device_runner, work_dir):
+    with pytest.raises(FileNotFoundError) as exc_info:
+        device_runner.compile_and_assemble(work_dir, "a2a3")
+    return str(exc_info.value)
+
+
+def test_missing_kernel_config_explains_unavailable_ptoas(device_runner, monkeypatch, tmp_path):
+    _write_raw_pto(tmp_path)
+    monkeypatch.delenv("PTOAS_ROOT", raising=False)
+    monkeypatch.setattr(device_runner.shutil, "which", lambda _name: None)
+
+    message = _missing_config_message(device_runner, tmp_path)
+    assert str(tmp_path / "kernel_config.py") in message
+    assert "compile-only artifact produced with skip_ptoas=True" in message
+    assert "PTOAS_ROOT is not set" in message
+    assert "'ptoas' was not found on PATH" in message
+    assert "export PTOAS_ROOT=/path/to/ptoas-bin" in message
+    assert "Restart the Python process and rerun" in message
+
+
+def test_missing_kernel_config_reports_invalid_ptoas_root(device_runner, monkeypatch, tmp_path):
+    _write_raw_pto(tmp_path)
+    ptoas_root = tmp_path / "invalid-ptoas"
+    monkeypatch.setenv("PTOAS_ROOT", str(ptoas_root))
+
+    message = _missing_config_message(device_runner, tmp_path)
+    assert f"PTOAS_ROOT is set to '{ptoas_root}'" in message
+    assert str(ptoas_root / "ptoas") in message
+    assert "does not exist or is not executable" in message
+    assert "Correct or remove the invalid PTOAS_ROOT setting" in message
+    assert "unset PTOAS_ROOT" in message
+    assert 'unset PTOAS_ROOT\n       eval "$(pypto-setup --export)"' in message
+
+
+def test_missing_kernel_config_requires_recompile_when_ptoas_is_now_available(
+    device_runner, monkeypatch, tmp_path
+):
+    _write_raw_pto(tmp_path)
+    ptoas_root = tmp_path / "ptoas-bin"
+    ptoas_root.mkdir()
+    ptoas_path = ptoas_root / "ptoas"
+    ptoas_path.write_text("#!/bin/sh\n", encoding="utf-8")
+    ptoas_path.chmod(0o755)
+    monkeypatch.setenv("PTOAS_ROOT", str(ptoas_root))
+
+    message = _missing_config_message(device_runner, tmp_path)
+    assert f"ptoas is now available at '{ptoas_path}'" in message
+    assert "artifact was generated without it and must be recompiled" in message
+    assert "export PTOAS_ROOT" not in message
+
+
+def test_missing_kernel_config_requires_recompile_when_ptoas_is_now_on_path(
+    device_runner, monkeypatch, tmp_path
+):
+    _write_raw_pto(tmp_path)
+    monkeypatch.delenv("PTOAS_ROOT", raising=False)
+    ptoas_path = tmp_path / "bin" / "ptoas"
+    monkeypatch.setattr(device_runner.shutil, "which", lambda _name: str(ptoas_path))
+
+    message = _missing_config_message(device_runner, tmp_path)
+    assert f"ptoas is now available on PATH at '{ptoas_path}'" in message
+    assert "artifact was generated without it and must be recompiled" in message
+    assert "export PTOAS_ROOT" not in message
+
+
+def test_missing_kernel_config_reports_incomplete_artifact(device_runner, tmp_path):
+    message = _missing_config_message(device_runner, tmp_path)
+    assert str(tmp_path / "kernel_config.py") in message
+    assert "may be incomplete or use a different build layout" in message
+    assert "skip_ptoas=True" not in message
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Context
- Split the diagnostic-only change from #2119 into a standalone PR based directly on current `main`.

## Summary
- Explain that raw `.pto` files without `kernel_config.py` are compile-only artifacts produced with `skip_ptoas=True` when `ptoas` is unavailable.
- Report the exact `PTOAS_ROOT` / PATH state and provide environment-specific recovery commands.
- Distinguish stale compile-only artifacts from incomplete or different build layouts while preserving `FileNotFoundError` compatibility.
- Cover unavailable, invalid, restored, and incomplete artifact cases with regression tests.

## Testing
- [x] `cmake --build build --parallel`
- [x] `python -m pytest tests/ut/runtime/test_pto_isa_resolution.py -n auto --maxprocesses 8 -v` (12 passed)
- [x] `python -m pytest tests/ut/ -n auto --maxprocesses 8 -v` (7791 passed, 2 skipped)
- [x] `pre-commit run --all-files`
- [x] Independent code review and simplification review passed
- [x] Existing English and Chinese `skip_ptoas` documentation reviewed; no behavior or API documentation change required
- [x] GitHub CI (12/12 checks, including a2a3/a5 system tests)