### PR TITLE
feat(ir): Require elementwise valid-region agreement

### DIFF
--- a/include/pypto/ir/type_inference.h
+++ b/include/pypto/ir/type_inference.h
@@ -372,6 +372,117 @@ std::vector<ExprPtr> InferWindowReadValidShape(const WindowReadValidShapeParams&
 const std::vector<ExprPtr>& GetEffectiveTensorValidShape(const TensorType& type);
 
 /**
+ * @brief How an elementwise family combines its operands' valid regions
+ */
+enum class ElementwiseValidCombine {
+  /// True elementwise. Every non-broadcast contributor to an output dimension
+  /// must have a provably equal valid extent, because the operation reads all of
+  /// them at each cell and writes one region.
+  kAgree,
+  /// Partial combine (``part_add`` / ``part_mul`` / ``part_max`` / ``part_min``).
+  /// Where only one source is valid the result copies that source, so the result
+  /// covers the *union* of the operand regions — admitted only when that union is
+  /// representable as an origin-anchored rectangle.
+  kUnion,
+};
+
+/**
+ * @brief One *value* operand's contribution to an elementwise result's valid region
+ *
+ * Scratch (``tmp``) and predicate (``mask``) operands are not value operands:
+ * their contract differs, so callers leave them out rather than passing them here.
+ */
+struct ElementwiseValidOperand {
+  std::vector<ExprPtr> physical;  ///< Operand physical shape
+  /// Operand effective valid shape, already resolved by ``GetValidShape`` — always
+  /// the same rank as ``physical`` (both are empty for a rank-0 operand).
+  std::vector<ExprPtr> valid;
+  std::string label;  ///< Operand name used in diagnostics ("lhs", "src0", ...)
+};
+
+/**
+ * @brief Inputs to the shared elementwise valid-region rule
+ */
+struct ElementwiseValidShapeParams {
+  std::vector<ElementwiseValidOperand> operands;  ///< Value operands, in signature order
+  std::vector<ExprPtr> result_shape;              ///< Broadcast result physical shape
+  ElementwiseValidCombine combine = ElementwiseValidCombine::kAgree;
+  std::string op_name;  ///< Operator name, used in diagnostics
+  Span span = Span::unknown();
+};
+
+/**
+ * @brief Derive the valid region of an elementwise result
+ *
+ * Operand shapes and valid shapes are right-aligned to the result rank, and each
+ * operand is classified per output dimension:
+ *
+ * ```text
+ * missing leading axis      -> implicit, fully valid singleton; exempt
+ * ConstInt 1 widening to >1 -> explicit physical singleton; exempt *only if* its
+ *                              sole cell is provably valid (valid == 1)
+ * otherwise                 -> non-broadcast contributor
+ * ```
+ *
+ * Singleton detection matches ``BroadcastShapes`` / ``IsBroadcastable`` (a constant
+ * one), so classification never disagrees with the broadcast that produced
+ * ``result_shape``.
+ *
+ * ``kAgree`` requires every non-broadcast contributor on a dimension to have a
+ * provably equal valid extent. Both a proven inequality and an *undecided*
+ * symbolic relation reject: no runtime guard is emitted, so an unproved relation
+ * would silently widen or narrow the result.
+ *
+ * ``kUnion`` first lifts each operand into output coordinates — a missing axis or
+ * an exempt singleton lifts to the full output extent, since broadcasting
+ * replicates that operand's valid cell across the axis — then admits the union
+ * only when one lifted rectangle provably contains all the others. That is
+ * exactly when the union is an origin-anchored rectangle; otherwise the
+ * componentwise maximum would claim cells valid in no operand at all.
+ *
+ * The result is independent of operand order: extents are chosen per dimension,
+ * preferring a constant representative, so a commutative operation yields
+ * structurally equal types either way round.
+ *
+ * @param params Elementwise description; see ElementwiseValidShapeParams
+ * @return The result valid shape, one extent per result dimension
+ * @throws pypto::ValueError on disagreement, an invalid broadcast singleton, or a
+ *         union that is not representable
+ */
+std::vector<ExprPtr> InferElementwiseValidShape(const ElementwiseValidShapeParams& params);
+
+/**
+ * @brief A tile operand paired with the name it is reported under
+ */
+struct ElementwiseTileOperand {
+  std::shared_ptr<const TileType> type;
+  std::string label;
+};
+
+/**
+ * @brief Build the ``TileView`` of a freshly computed elementwise tile result
+ *
+ * Combines the two halves of the rule: the valid region from
+ * ``InferElementwiseValidShape``, and the production layout from an operand whose
+ * physical shape equals the output shape — falling back to the layout implied by
+ * the output shape when no operand owns it, so a broadcast singleton can never
+ * dictate the result's layout.
+ *
+ * The result is fresh, not a view: no alias, stride, or start offset is carried
+ * over (and ``InheritTileViewLayout`` carries no padding either).
+ *
+ * @param operands Value operands, in signature order; scratch/mask excluded
+ * @param result_shape Broadcast result physical shape
+ * @param op_name Operator name, used in diagnostics
+ * @param span IR source location, reported on rejection
+ * @param combine Agreement (the default, for a true elementwise op) or representable union
+ */
+TileView MakeElementwiseTileView(const std::vector<ElementwiseTileOperand>& operands,
+                                 const std::vector<ExprPtr>& result_shape, const std::string& op_name,
+                                 const Span& span,
+                                 ElementwiseValidCombine combine = ElementwiseValidCombine::kAgree);
+
+/**
  * @brief Reject ``drop_dims`` axes that do not carry provably unit validity
  *
  * Rank reduction erases an axis, so the axis must have nothing left to say: its
@@ -584,13 +695,25 @@ bool IsBroadcastable(const ExprPtr& source_dim, const ExprPtr& target_dim);
 std::string FormatShape(const std::vector<ExprPtr>& shape);
 
 /**
- * @brief Propagate blayout and pad from a source TileType's tile_view into a new TileView
+ * @brief Propagate a source TileType's production layout into a fresh result's TileView
  *
- * Many tile ops preserve the layout properties of their primary input. This helper copies
- * blayout and pad when the source has a tile_view, avoiding repeated inline checks.
+ * Many tile ops produce a result laid out the same way as their primary input, so
+ * this copies ``blayout`` and ``slayout`` from the source's effective view.
+ *
+ * **Padding is deliberately not inherited.** A fresh result is a new allocation
+ * that the operation writes only across its valid region, so whatever the source
+ * promised about the cells *outside* that region does not survive: ``exp`` of a
+ * zero-padded tile is not zero-padded, it is padded with whatever the destination
+ * buffer already held. Claiming otherwise lets a consumer read padding as data.
+ * The result therefore carries ``PadValue::null`` — "nothing is promised out
+ * there" — and an operation that really does establish a pad (``tile.fillpad`` and
+ * the rest of that family) sets ``dst.pad`` itself after calling this.
+ *
+ * ``fractal`` is likewise not inherited: it stays at the ``TileView`` default,
+ * which matches the implicit layout of the Vec-space tiles these results live in.
  *
  * @param dst Destination TileView (valid_shape should already be set)
- * @param src Source TileType whose tile_view properties are inherited
+ * @param src Source TileType whose layout is inherited
  */
 inline void InheritTileViewLayout(TileView& dst, const std::shared_ptr<const TileType>& src) {
   // Use the effective view: under canonicalization an implicit view is stored
@@ -598,7 +721,6 @@ inline void InheritTileViewLayout(TileView& dst, const std::shared_ptr<const Til
   const TileView eff = tile_view_semantics::GetEffectiveTileView(*src);
   dst.blayout = eff.blayout;
   dst.slayout = eff.slayout;
-  dst.pad = eff.pad;
 }
 
 namespace detail {

--- a/src/ir/op/tensor_ops/elementwise.cpp
+++ b/src/ir/op/tensor_ops/elementwise.cpp
@@ -18,7 +18,6 @@
  */
 
 #include <any>
-#include <memory>
 #include <string>
 #include <utility>
 #include <vector>
@@ -43,9 +42,9 @@ static bool IsTSubsDataType(DataType dtype) {
          dtype == DataType::FP16 || dtype == DataType::FP32 || dtype == DataType::BF16;
 }
 
-TypePtr DeduceTensorOpElementwiseBinaryType(const std::vector<ExprPtr>& args,
-                                            const std::vector<std::pair<std::string, std::any>>& kwargs,
-                                            const std::string& op_name) {
+TypePtr DeduceTensorOpElementwiseBinaryType(
+    const std::vector<ExprPtr>& args, const std::vector<std::pair<std::string, std::any>>& kwargs,
+    const std::string& op_name, ElementwiseValidCombine combine = ElementwiseValidCombine::kAgree) {
   CHECK(args.size() == 2) << "The operator " << op_name << " requires exactly 2 arguments, but got "
                           << args.size();
 
@@ -72,7 +71,19 @@ TypePtr DeduceTensorOpElementwiseBinaryType(const std::vector<ExprPtr>& args,
                                   << FormatShape(tensor_type1->shape_) << " and "
                                   << FormatShape(tensor_type2->shape_);
 
-  return std::make_shared<TensorType>(broadcast_result.shape, *result_dtype);
+  // Same rule as the tile level: the operands must agree on the region they are
+  // combined over (or, for the partial-combine family, admit a representable
+  // union). The sum is new data, so the result is a fresh tensor.
+  std::vector<ExprPtr> valid_shape = InferElementwiseValidShape({
+      /*operands=*/
+      {{tensor_type1->shape_, GetValidShape(tensor_type1), "lhs"},
+       {tensor_type2->shape_, GetValidShape(tensor_type2), "rhs"}},
+      /*result_shape=*/broadcast_result.shape,
+      /*combine=*/combine,
+      /*op_name=*/op_name,
+      /*span=*/args[0]->span_,
+  });
+  return MakeFreshTensorType(broadcast_result.shape, *result_dtype, std::move(valid_shape));
 }
 
 TypePtr DeduceTensorOpElementwiseScalarType(const std::vector<ExprPtr>& args,
@@ -91,8 +102,9 @@ TypePtr DeduceTensorOpElementwiseScalarType(const std::vector<ExprPtr>& args,
                       << " requires second argument to be a ScalarType, but got "
                       << args[1]->GetType()->TypeName();
 
+  // Same fresh-result rule as the promoting path below; only the dtype differs.
   if (preserve_lhs_dtype) {
-    return std::make_shared<TensorType>(tensor_type1->shape_, tensor_type1->dtype_);
+    return MakeFreshTensorType(tensor_type1->shape_, tensor_type1->dtype_, GetValidShape(tensor_type1));
   }
 
   // TensorType + ScalarType - result is TensorType with same shape as first argument
@@ -100,7 +112,11 @@ TypePtr DeduceTensorOpElementwiseScalarType(const std::vector<ExprPtr>& args,
   CHECK(result_dtype) << "The operator " << op_name << " requires compatible data types, but got "
                       << args[0]->GetType()->TypeName() << " and " << args[1]->GetType()->TypeName();
 
-  return std::make_shared<TensorType>(tensor_type1->shape_, *result_dtype);
+  // The scalar has no region of its own, so the result keeps the tensor's: a
+  // partial input must not widen back to the full allocation, which would make
+  // padding indistinguishable from real data. Tile's equivalents (tile.adds and
+  // friends) already do this; this is the tensor-level dual.
+  return MakeFreshTensorType(tensor_type1->shape_, *result_dtype, GetValidShape(tensor_type1));
 }
 
 // ============================================================================
@@ -218,7 +234,8 @@ REGISTER_OP("tensor.part_add")
     .add_argument("src1", "Second source tensor (TensorType)")
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
-      return DeduceTensorOpElementwiseBinaryType(args, kwargs, "tensor.part_add");
+      return DeduceTensorOpElementwiseBinaryType(args, kwargs, "tensor.part_add",
+                                                 ElementwiseValidCombine::kUnion);
     });
 
 REGISTER_OP("tensor.part_mul")
@@ -228,7 +245,8 @@ REGISTER_OP("tensor.part_mul")
     .add_argument("src1", "Second source tensor (TensorType)")
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
-      return DeduceTensorOpElementwiseBinaryType(args, kwargs, "tensor.part_mul");
+      return DeduceTensorOpElementwiseBinaryType(args, kwargs, "tensor.part_mul",
+                                                 ElementwiseValidCombine::kUnion);
     });
 
 REGISTER_OP("tensor.part_max")
@@ -238,7 +256,8 @@ REGISTER_OP("tensor.part_max")
     .add_argument("src1", "Second source tensor (TensorType)")
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
-      return DeduceTensorOpElementwiseBinaryType(args, kwargs, "tensor.part_max");
+      return DeduceTensorOpElementwiseBinaryType(args, kwargs, "tensor.part_max",
+                                                 ElementwiseValidCombine::kUnion);
     });
 
 REGISTER_OP("tensor.part_min")
@@ -248,7 +267,8 @@ REGISTER_OP("tensor.part_min")
     .add_argument("src1", "Second source tensor (TensorType)")
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
-      return DeduceTensorOpElementwiseBinaryType(args, kwargs, "tensor.part_min");
+      return DeduceTensorOpElementwiseBinaryType(args, kwargs, "tensor.part_min",
+                                                 ElementwiseValidCombine::kUnion);
     });
 
 REGISTER_OP("tensor.fmod")

--- a/src/ir/op/tile_ops/broadcast.cpp
+++ b/src/ir/op/tile_ops/broadcast.cpp
@@ -94,11 +94,11 @@ TypePtr DeduceTileRowExpandType(const std::vector<ExprPtr>& args,
   CHECK(result_dtype) << "The operator " << op_name << " requires compatible data types, but got "
                       << tile_type->dtype_.ToString() << " and " << row_type->dtype_.ToString();
 
-  // Output has the same shape as the main tile, inheriting pad and blayout from src0.
-  // Broadcast ops preserve the main tile's valid_shape (issue #1450; same class as #1370 for unary ops).
-  TileView tile_view;
-  tile_view.valid_shape = GetValidShape(tile_type);
-  InheritTileViewLayout(tile_view, tile_type);
+  // Output has the same shape as the main tile. The row vector is a physical
+  // singleton on the column axis, so the shared elementwise rule exempts it there
+  // (given its one cell is valid) while still requiring the two to agree on rows.
+  TileView tile_view = MakeElementwiseTileView({{tile_type, "tile"}, {row_type, "row_vec"}}, tile_shape,
+                                               op_name, args[0]->span_);
   return std::make_shared<TileType>(tile_shape, *result_dtype, std::nullopt, tile_view);
 }
 
@@ -186,10 +186,11 @@ TypePtr DeduceTileColExpandType(const std::vector<ExprPtr>& args,
   auto result_dtype = PromoteDataTypes(target_type->dtype_, col_type->dtype_);
   CHECK(result_dtype) << "The operator " << op_name << " requires compatible data types";
 
-  // Broadcast ops preserve the target tile's valid_shape (issue #1450; same class as #1370 for unary ops).
-  TileView tile_view;
-  tile_view.valid_shape = GetValidShape(target_type);
-  InheritTileViewLayout(tile_view, target_type);
+  // The column tile is a physical singleton on the row axis, so the shared rule
+  // exempts it there (given its one cell is valid) while requiring the two to
+  // agree on columns.
+  TileView tile_view = MakeElementwiseTileView({{target_type, "target"}, {col_type, "col_tile"}},
+                                               target_type->shape_, op_name, args[0]->span_);
   return std::make_shared<TileType>(target_type->shape_, *result_dtype, std::nullopt, tile_view);
 }
 
@@ -214,10 +215,9 @@ TypePtr DeduceTileExpandScalarType(const std::vector<ExprPtr>& args,
   auto result_dtype = PromoteDataTypes(tile_type->dtype_, scalar_type->dtype_);
   CHECK(result_dtype) << "The operator " << op_name << " requires compatible data types";
 
-  // Broadcast ops preserve the target tile's valid_shape (issue #1450; same class as #1370 for unary ops).
-  TileView tile_view;
-  tile_view.valid_shape = GetValidShape(tile_type);
-  InheritTileViewLayout(tile_view, tile_type);
+  // The scalar has no region, so the target tile is the sole value operand.
+  TileView tile_view =
+      MakeElementwiseTileView({{tile_type, "target"}}, tile_type->shape_, op_name, args[0]->span_);
   return std::make_shared<TileType>(tile_type->shape_, *result_dtype, std::nullopt, tile_view);
 }
 

--- a/src/ir/op/tile_ops/elementwise.cpp
+++ b/src/ir/op/tile_ops/elementwise.cpp
@@ -73,9 +73,15 @@ static bool IsTSubsDataType(DataType dtype) {
          dtype == DataType::FP16 || dtype == DataType::FP32 || dtype == DataType::BF16;
 }
 
+// Build the packed predicate result of tile.cmp / tile.cmps.
+//
+// The mask's validity is the *value* validity of the comparison, bit-packed the
+// same way its shape is: the operands agree on a logical valid region through the
+// shared elementwise rule, then the column axis is packed 8 predicates to a byte.
 static std::shared_ptr<TileType> MakePackedPredicateTileType(
-    const std::vector<ExprPtr>& logical_shape, const std::shared_ptr<const TileType>& source_tile_type) {
-  INTERNAL_CHECK(!logical_shape.empty())
+    const std::vector<ExprPtr>& logical_shape, const std::vector<ElementwiseTileOperand>& operands,
+    const std::string& op_name, const Span& span) {
+  INTERNAL_CHECK_SPAN(!logical_shape.empty(), span)
       << "tile.cmp/tile.cmps require a non-empty tile shape for packed predicate mask inference";
 
   constexpr int64_t kA2A3PredicateBitsPerByte = 8;
@@ -86,12 +92,14 @@ static std::shared_ptr<TileType> MakePackedPredicateTileType(
   mask_shape[col_axis] = MakeRoundUpIndex(
       MakeCeilDivIndex(logical_shape[col_axis], kA2A3PredicateBitsPerByte), kA2A3PredicateColAlignment);
 
-  auto logical_valid_shape = GetValidShape(source_tile_type);
-  TileView tile_view;
-  tile_view.valid_shape = logical_valid_shape;
+  // The rule is asked about the *logical* comparison, not the packed mask: that is
+  // the shape the operands broadcast to and the region they must agree on. Layout
+  // therefore also comes from the logical shape — sound because packing only
+  // rescales the column axis, so a row_major/col_major choice made on
+  // `logical_shape` is the same one `mask_shape` would produce.
+  TileView tile_view = MakeElementwiseTileView(operands, logical_shape, op_name, span);
   tile_view.valid_shape[col_axis] =
-      MakeCeilDivIndex(logical_valid_shape[col_axis], kA2A3PredicateBitsPerByte);
-  InheritTileViewLayout(tile_view, source_tile_type);
+      MakeCeilDivIndex(tile_view.valid_shape[col_axis], kA2A3PredicateBitsPerByte);
   return std::make_shared<TileType>(mask_shape, DataType::UINT8, std::nullopt, tile_view);
 }
 
@@ -102,12 +110,13 @@ TypePtr DeduceTileOpTernaryType(const std::vector<ExprPtr>& args,
                                 const std::string& op_name, bool require_int);
 TypePtr DeduceTileOpTileScalarTileType(const std::vector<ExprPtr>& args,
                                        const std::vector<std::pair<std::string, std::any>>& kwargs,
-                                       const std::string& op_name);
+                                       const std::string& op_name, bool third_is_addend);
 
 TypePtr DeduceTileOpElementwiseBinaryType(const std::vector<ExprPtr>& args,
                                           const std::vector<std::pair<std::string, std::any>>& kwargs,
                                           const std::string& op_name, bool require_int = false,
-                                          bool require_tdiv_contract = false) {
+                                          bool require_tdiv_contract = false,
+                                          ElementwiseValidCombine combine = ElementwiseValidCombine::kAgree) {
   CHECK(args.size() == 2) << "The operator " << op_name << " requires exactly 2 arguments, but got "
                           << args.size();
 
@@ -179,11 +188,8 @@ TypePtr DeduceTileOpElementwiseBinaryType(const std::vector<ExprPtr>& args,
                                   << FormatShape(tile_type1->shape_) << " and "
                                   << FormatShape(tile_type2->shape_);
 
-  // TODO(YunjiQin): assumes both src tiles have the same valid_shape; may need refinement
-  // for cases where lhs and rhs have different valid_shapes (e.g. after broadcasting).
-  TileView tile_view;
-  tile_view.valid_shape = GetValidShape(tile_type1);
-  InheritTileViewLayout(tile_view, tile_type1);
+  TileView tile_view = MakeElementwiseTileView({{tile_type1, "lhs"}, {tile_type2, "rhs"}},
+                                               broadcast_result.shape, op_name, args[0]->span_, combine);
   return std::make_shared<TileType>(broadcast_result.shape, *result_dtype, std::nullopt, tile_view);
 }
 
@@ -210,11 +216,9 @@ TypePtr DeduceTileOpShiftBinaryType(const std::vector<ExprPtr>& args,
   auto broadcast_result = BroadcastShapes(tile_type1->shape_, tile_type2->shape_);
   CHECK(broadcast_result.success) << "The operator " << op_name << " requires compatible shapes";
 
-  // TODO(YunjiQin): assumes both src tiles have the same valid_shape; may need refinement
-  // for cases where lhs and rhs have different valid_shapes (e.g. after broadcasting).
-  TileView tile_view;
-  tile_view.valid_shape = GetValidShape(tile_type1);
-  InheritTileViewLayout(tile_view, tile_type1);
+  // The shift amount is read per element, so it is a value operand like any other.
+  TileView tile_view = MakeElementwiseTileView({{tile_type1, "lhs"}, {tile_type2, "rhs"}},
+                                               broadcast_result.shape, op_name, args[0]->span_);
   return std::make_shared<TileType>(broadcast_result.shape, tile_type1->dtype_, std::nullopt, tile_view);
 }
 
@@ -237,9 +241,9 @@ TypePtr DeduceTileOpScalarBinaryType(const std::vector<ExprPtr>& args,
   // Result preserves the tile's element type. The hardware scalar instructions
   // (e.g. pto.tmuls) require src and dst to share the same element type; the
   // scalar operand is implicitly narrowed to match the tile dtype at runtime.
-  TileView tile_view;
-  tile_view.valid_shape = GetValidShape(tile_type);
-  InheritTileViewLayout(tile_view, tile_type);
+  // The scalar has no region, so the tile is the sole value operand.
+  TileView tile_view =
+      MakeElementwiseTileView({{tile_type, "lhs"}}, tile_type->shape_, op_name, args[0]->span_);
   return std::make_shared<TileType>(tile_type->shape_, tile_type->dtype_, std::nullopt, tile_view);
 }
 
@@ -284,9 +288,8 @@ TypePtr DeduceTileOpIntScalarBinaryType(const std::vector<ExprPtr>& args,
                                      << scalar_type->dtype_.ToString();
 
   // Result has the same shape and dtype as the input tile; the shift amount does not change element type.
-  TileView tile_view;
-  tile_view.valid_shape = GetValidShape(tile_type);
-  InheritTileViewLayout(tile_view, tile_type);
+  TileView tile_view =
+      MakeElementwiseTileView({{tile_type, "lhs"}}, tile_type->shape_, op_name, args[0]->span_);
   return std::make_shared<TileType>(tile_type->shape_, tile_type->dtype_, std::nullopt, tile_view);
 }
 
@@ -407,7 +410,9 @@ REGISTER_OP("tile.part_add")
     .set_output_memory(MemorySpace::Vec)
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
-      return DeduceTileOpElementwiseBinaryType(args, kwargs, "tile.part_add");
+      return DeduceTileOpElementwiseBinaryType(args, kwargs, "tile.part_add", /*require_int=*/false,
+                                               /*require_tdiv_contract=*/false,
+                                               ElementwiseValidCombine::kUnion);
     });
 
 REGISTER_OP("tile.part_mul")
@@ -420,7 +425,9 @@ REGISTER_OP("tile.part_mul")
     .set_output_memory(MemorySpace::Vec)
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
-      return DeduceTileOpElementwiseBinaryType(args, kwargs, "tile.part_mul");
+      return DeduceTileOpElementwiseBinaryType(args, kwargs, "tile.part_mul", /*require_int=*/false,
+                                               /*require_tdiv_contract=*/false,
+                                               ElementwiseValidCombine::kUnion);
     });
 
 REGISTER_OP("tile.part_max")
@@ -433,7 +440,9 @@ REGISTER_OP("tile.part_max")
     .set_output_memory(MemorySpace::Vec)
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
-      return DeduceTileOpElementwiseBinaryType(args, kwargs, "tile.part_max");
+      return DeduceTileOpElementwiseBinaryType(args, kwargs, "tile.part_max", /*require_int=*/false,
+                                               /*require_tdiv_contract=*/false,
+                                               ElementwiseValidCombine::kUnion);
     });
 
 REGISTER_OP("tile.part_min")
@@ -446,7 +455,9 @@ REGISTER_OP("tile.part_min")
     .set_output_memory(MemorySpace::Vec)
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
-      return DeduceTileOpElementwiseBinaryType(args, kwargs, "tile.part_min");
+      return DeduceTileOpElementwiseBinaryType(args, kwargs, "tile.part_min", /*require_int=*/false,
+                                               /*require_tdiv_contract=*/false,
+                                               ElementwiseValidCombine::kUnion);
     });
 
 REGISTER_OP("tile.fmod")
@@ -525,7 +536,7 @@ REGISTER_OP("tile.rems")
     .set_output_memory(MemorySpace::Vec)
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
-      return DeduceTileOpTileScalarTileType(args, kwargs, "tile.rems");
+      return DeduceTileOpTileScalarTileType(args, kwargs, "tile.rems", /*third_is_addend=*/false);
     });
 
 REGISTER_OP("tile.fmods")
@@ -701,11 +712,10 @@ TypePtr DeduceTileOpTernaryType(const std::vector<ExprPtr>& args,
   auto broadcast_result = BroadcastShapes(tile_type1->shape_, tile_type2->shape_);
   CHECK(broadcast_result.success) << "The operator " << op_name << " requires compatible shapes";
 
-  // TODO(YunjiQin): assumes both src tiles have the same valid_shape; may need refinement
-  // for cases where lhs and rhs have different valid_shapes (e.g. after broadcasting).
-  TileView tile_view;
-  tile_view.valid_shape = GetValidShape(tile_type1);
-  InheritTileViewLayout(tile_view, tile_type1);
+  // args[2] is a hardware scratch buffer, not a value operand: it is written
+  // before it is read, so it carries no region the result has to agree with.
+  TileView tile_view = MakeElementwiseTileView({{tile_type1, "lhs"}, {tile_type2, "rhs"}},
+                                               broadcast_result.shape, op_name, args[0]->span_);
   return std::make_shared<TileType>(broadcast_result.shape, *result_dtype, std::nullopt, tile_view);
 }
 
@@ -736,18 +746,22 @@ TypePtr DeduceTileOpTriTileType(const std::vector<ExprPtr>& args,
   auto broadcast_result = BroadcastShapes(broadcast12.shape, tile_type3->shape_);
   CHECK(broadcast_result.success) << "The operator " << op_name << " requires compatible shapes";
 
-  // TODO(YunjiQin): assumes all src tiles have the same valid_shape; may need refinement
-  // for cases where tiles have different valid_shapes (e.g. after broadcasting).
-  TileView tile_view;
-  tile_view.valid_shape = GetValidShape(tile_type1);
-  InheritTileViewLayout(tile_view, tile_type1);
+  TileView tile_view =
+      MakeElementwiseTileView({{tile_type1, "lhs"}, {tile_type2, "rhs"}, {tile_type3, "rhs2"}},
+                              broadcast_result.shape, op_name, args[0]->span_);
   return std::make_shared<TileType>(broadcast_result.shape, *result_dtype, std::nullopt, tile_view);
 }
 
-// (Tile, Scalar, Tile) pattern (addsc, subsc): any scalar type, promote output from all three inputs.
+// (Tile, Scalar, Tile) pattern: any scalar type, promote output from all three inputs.
+//
+// The third tile means two different things across this deducer's users, and only
+// the caller knows which: for tile.addsc / tile.subsc it is a real addend (rhs2),
+// but for tile.rems it is the hardware scratch buffer. Clear @p third_is_addend for
+// the latter — a scratch buffer is written before it is read, so demanding that it
+// agree on a valid region would reject perfectly good code.
 TypePtr DeduceTileOpTileScalarTileType(const std::vector<ExprPtr>& args,
                                        const std::vector<std::pair<std::string, std::any>>& kwargs,
-                                       const std::string& op_name) {
+                                       const std::string& op_name, bool third_is_addend) {
   CHECK(args.size() == 3) << "The operator " << op_name << " requires exactly 3 arguments, but got "
                           << args.size();
 
@@ -771,11 +785,12 @@ TypePtr DeduceTileOpTileScalarTileType(const std::vector<ExprPtr>& args,
   auto broadcast_result = BroadcastShapes(tile_type1->shape_, tile_type2->shape_);
   CHECK(broadcast_result.success) << "The operator " << op_name << " requires compatible shapes";
 
-  // TODO(YunjiQin): assumes both src tiles have the same valid_shape; may need refinement
-  // for cases where lhs and rhs tiles have different valid_shapes (e.g. after broadcasting).
-  TileView tile_view;
-  tile_view.valid_shape = GetValidShape(tile_type1);
-  InheritTileViewLayout(tile_view, tile_type1);
+  std::vector<ElementwiseTileOperand> value_operands = {{tile_type1, "lhs"}};
+  if (third_is_addend) {
+    value_operands.push_back({tile_type2, "rhs2"});
+  }
+  TileView tile_view =
+      MakeElementwiseTileView(value_operands, broadcast_result.shape, op_name, args[0]->span_);
   return std::make_shared<TileType>(broadcast_result.shape, *result_dtype, std::nullopt, tile_view);
 }
 
@@ -806,9 +821,9 @@ TypePtr DeduceTileOpXorScalarType(const std::vector<ExprPtr>& args,
       << args[2]->GetType()->TypeName();
 
   // Result has the same shape and dtype as the input tile; bitwise ops do not change element type.
-  TileView tile_view;
-  tile_view.valid_shape = GetValidShape(tile_type);
-  InheritTileViewLayout(tile_view, tile_type);
+  // args[2] is scratch, so the input tile is the sole value operand.
+  TileView tile_view =
+      MakeElementwiseTileView({{tile_type, "lhs"}}, tile_type->shape_, op_name, args[0]->span_);
   return std::make_shared<TileType>(tile_type->shape_, tile_type->dtype_, std::nullopt, tile_view);
 }
 
@@ -898,7 +913,7 @@ REGISTER_OP("tile.addsc")
     .set_output_memory(MemorySpace::Vec)
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
-      return DeduceTileOpTileScalarTileType(args, kwargs, "tile.addsc");
+      return DeduceTileOpTileScalarTileType(args, kwargs, "tile.addsc", /*third_is_addend=*/true);
     });
 
 REGISTER_OP("tile.subsc")
@@ -912,7 +927,7 @@ REGISTER_OP("tile.subsc")
     .set_output_memory(MemorySpace::Vec)
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
-      return DeduceTileOpTileScalarTileType(args, kwargs, "tile.subsc");
+      return DeduceTileOpTileScalarTileType(args, kwargs, "tile.subsc", /*third_is_addend=*/true);
     });
 
 REGISTER_OP("tile.lrelu")
@@ -961,11 +976,11 @@ TypePtr DeduceTileSelType(const std::vector<ExprPtr>& args,
                                   << FormatShape(tile_type1->shape_) << " and "
                                   << FormatShape(tile_type2->shape_);
 
-  // TODO(YunjiQin): assumes both src tiles have the same valid_shape; may need refinement
-  // for cases where lhs and rhs have different valid_shapes (e.g. after broadcasting).
-  TileView tile_view;
-  tile_view.valid_shape = GetValidShape(tile_type1);
-  InheritTileViewLayout(tile_view, tile_type1);
+  // Only the two selected-from tiles carry values: args[0] is a packed predicate
+  // mask in a target-defined encoding and args[3] is TSEL scratch, so neither
+  // participates in value-validity agreement.
+  TileView tile_view = MakeElementwiseTileView({{tile_type1, "lhs"}, {tile_type2, "rhs"}},
+                                               broadcast_result.shape, op_name, args[1]->span_);
   return std::make_shared<TileType>(broadcast_result.shape, *result_dtype, std::nullopt, tile_view);
 }
 
@@ -1024,11 +1039,9 @@ TypePtr DeduceTileSelScalarType(const std::vector<ExprPtr>& args,
                                   << FormatShape(tile_type1->shape_) << " and "
                                   << FormatShape(tile_type2->shape_);
 
-  // TODO(YunjiQin): assumes both src tiles have the same valid_shape; may need refinement
-  // for cases where lhs and rhs have different valid_shapes (e.g. after broadcasting).
-  TileView tile_view;
-  tile_view.valid_shape = GetValidShape(tile_type1);
-  InheritTileViewLayout(tile_view, tile_type1);
+  // args[2] is the scalar select mode, so the two source tiles are the value operands.
+  TileView tile_view = MakeElementwiseTileView({{tile_type1, "lhs"}, {tile_type2, "rhs"}},
+                                               broadcast_result.shape, op_name, args[0]->span_);
   return std::make_shared<TileType>(broadcast_result.shape, *result_dtype, std::nullopt, tile_view);
 }
 
@@ -1075,7 +1088,7 @@ TypePtr DeduceTileCmpType(const std::vector<ExprPtr>& args,
                        << " requires second argument to be a ScalarType, but got "
                        << args[1]->GetType()->TypeName();
 
-    return MakePackedPredicateTileType(tile_type1->shape_, tile_type1);
+    return MakePackedPredicateTileType(tile_type1->shape_, {{tile_type1, "lhs"}}, op_name, args[0]->span_);
   } else {
     // Second argument must be TileType
     auto tile_type2 = As<TileType>(args[1]->GetType());
@@ -1087,7 +1100,8 @@ TypePtr DeduceTileCmpType(const std::vector<ExprPtr>& args,
                                     << FormatShape(tile_type1->shape_) << " and "
                                     << FormatShape(tile_type2->shape_);
 
-    return MakePackedPredicateTileType(broadcast_result.shape, tile_type1);
+    return MakePackedPredicateTileType(broadcast_result.shape, {{tile_type1, "lhs"}, {tile_type2, "rhs"}},
+                                       op_name, args[0]->span_);
   }
 }
 

--- a/src/ir/op/type_inference.cpp
+++ b/src/ir/op/type_inference.cpp
@@ -729,9 +729,17 @@ AxisView ClassifyAxis(const ElementwiseValidOperand& operand, size_t dim, size_t
     return {AxisRole::kAbsent, nullptr};
   }
   const size_t axis = dim - lead;
+  // A literal one is what `IsBroadcastable` widens, so that is what can widen here.
   const auto physical = GetConstantDimension(operand.physical[axis]);
-  const auto result = GetConstantDimension(result_extent);
-  const bool widens = physical && *physical == 1 && !(result && *result == 1);
+  const bool physical_is_one = physical && *physical == 1;
+  // ... but only if the result is actually wider. `BroadcastShapes` keeps the *first*
+  // operand's expression for equal dimensions, so a unit result axis can arrive here
+  // in symbolic form (`n - n + 1` against a literal 1) — prove it rather than
+  // pattern-matching a literal, or the same commutative operation would classify its
+  // operands differently depending on which one came first.
+  const bool result_is_one =
+      physical_is_one && ProveValidExtentEqual(result_extent, OneExtent()) == ProofResult::kTrue;
+  const bool widens = physical_is_one && !result_is_one;
   return {widens ? AxisRole::kBroadcast : AxisRole::kContributor, operand.valid[axis]};
 }
 
@@ -748,12 +756,25 @@ std::string FormatOperandRegions(const ElementwiseValidShapeParams& params) {
 }
 
 /// Whether @p candidate should replace @p current as a dimension's representative
-/// extent. Both are already known to denote the same extent; preferring a constant
-/// makes the choice independent of operand order, so a commutative operation yields
-/// structurally equal types whichever way round its operands are given. Used by both
-/// combine modes so the guarantee cannot drift between them.
+/// extent. Both are already known to denote the same extent, so this only has to be
+/// *deterministic*: a commutative operation must yield structurally equal types
+/// whichever way round its operands are given. Used by both combine modes so the
+/// guarantee cannot drift between them.
 bool PrefersAsRepresentative(const ExprPtr& current, const ExprPtr& candidate) {
-  return !As<ConstInt>(current) && As<ConstInt>(candidate) != nullptr;
+  const bool current_is_const = As<ConstInt>(current) != nullptr;
+  const bool candidate_is_const = As<ConstInt>(candidate) != nullptr;
+  if (current_is_const != candidate_is_const) {
+    return candidate_is_const;  // a literal is the clearest representative
+  }
+  if (current_is_const || AreExprsEqual(current, candidate)) {
+    return false;  // already the same expression, literal or not
+  }
+  // Two symbolic extents the analyzer proved equal but that are *not* structurally
+  // equal (`n` against `n + 0`). Type equality and hashing compare structurally, so
+  // keeping whichever was seen first would still let operand order change the result
+  // type. Break the tie on a stable printed key. Reached only when a dimension has
+  // two differing symbolic contributors, so the formatting cost is rare.
+  return PythonPrint(candidate) < PythonPrint(current);
 }
 
 /// Whether @p shape is the result shape, dimension for dimension.

--- a/src/ir/op/type_inference.cpp
+++ b/src/ir/op/type_inference.cpp
@@ -31,6 +31,7 @@
 #include "pypto/ir/kind_traits.h"
 #include "pypto/ir/scalar_expr.h"
 #include "pypto/ir/span.h"
+#include "pypto/ir/tile_view_semantics.h"
 #include "pypto/ir/transforms/printer.h"
 #include "pypto/ir/transforms/structural_comparison.h"
 #include "pypto/ir/transforms/utils/memref_utils.h"
@@ -694,17 +695,268 @@ std::vector<ExprPtr> InferWindowReadValidShape(const WindowReadValidShapeParams&
   return result;
 }
 
+// ============================================================================
+// Elementwise valid-region agreement
+// ============================================================================
+
+namespace {
+
+/// One, in the dtype the analyzer compares extents in.
+const ExprPtr& OneExtent() {
+  static const ExprPtr one = std::make_shared<ConstInt>(1, DataType::INDEX, Span::unknown());
+  return one;
+}
+
+/// How a single operand meets a single output dimension.
+enum class AxisRole {
+  kAbsent,       ///< Missing leading axis: an implicit, fully valid singleton
+  kBroadcast,    ///< Explicit constant-1 physical extent widening to a larger output dim
+  kContributor,  ///< Carries the output extent, so its valid extent participates
+};
+
+struct AxisView {
+  AxisRole role;
+  ExprPtr valid;  ///< The operand's valid extent on this axis; null when kAbsent
+};
+
+/// Right-align @p operand to the result rank and classify how it meets dimension
+/// @p dim. Singleton detection is a *constant* one, matching `IsBroadcastable`, so
+/// this never disagrees with the broadcast that produced the result shape.
+AxisView ClassifyAxis(const ElementwiseValidOperand& operand, size_t dim, size_t result_rank,
+                      const ExprPtr& result_extent) {
+  const size_t lead = result_rank - operand.physical.size();
+  if (dim < lead) {
+    return {AxisRole::kAbsent, nullptr};
+  }
+  const size_t axis = dim - lead;
+  const auto physical = GetConstantDimension(operand.physical[axis]);
+  const auto result = GetConstantDimension(result_extent);
+  const bool widens = physical && *physical == 1 && !(result && *result == 1);
+  return {widens ? AxisRole::kBroadcast : AxisRole::kContributor, operand.valid[axis]};
+}
+
+/// "lhs [4, 8], rhs [4, 6]" — every operand's region, for a diagnostic.
+std::string FormatOperandRegions(const ElementwiseValidShapeParams& params) {
+  std::ostringstream oss;
+  for (size_t k = 0; k < params.operands.size(); ++k) {
+    if (k > 0) {
+      oss << ", ";
+    }
+    oss << params.operands[k].label << " " << FormatShape(params.operands[k].valid);
+  }
+  return oss.str();
+}
+
+/// Whether @p candidate should replace @p current as a dimension's representative
+/// extent. Both are already known to denote the same extent; preferring a constant
+/// makes the choice independent of operand order, so a commutative operation yields
+/// structurally equal types whichever way round its operands are given. Used by both
+/// combine modes so the guarantee cannot drift between them.
+bool PrefersAsRepresentative(const ExprPtr& current, const ExprPtr& candidate) {
+  return !As<ConstInt>(current) && As<ConstInt>(candidate) != nullptr;
+}
+
+/// Whether @p shape is the result shape, dimension for dimension.
+bool OwnsResultShape(const std::vector<ExprPtr>& shape, const std::vector<ExprPtr>& result_shape) {
+  return shape.size() == result_shape.size() &&
+         std::equal(shape.begin(), shape.end(), result_shape.begin(), DimensionsEqual);
+}
+
+/// Each operand's contribution to each output dimension: its valid extent where it
+/// is a non-broadcast contributor, and null where it is exempt (a missing leading
+/// axis or a physical singleton widening to the dimension).
+using ContributionGrid = std::vector<std::vector<ExprPtr>>;
+
+/// Classify every operand against every output dimension, rejecting a broadcast
+/// singleton whose sole cell is not provably valid.
+ContributionGrid ClassifyContributions(const ElementwiseValidShapeParams& params) {
+  const size_t rank = params.result_shape.size();
+  ContributionGrid grid(params.operands.size(), std::vector<ExprPtr>(rank));
+
+  for (size_t k = 0; k < params.operands.size(); ++k) {
+    const ElementwiseValidOperand& operand = params.operands[k];
+    for (size_t dim = 0; dim < rank; ++dim) {
+      const AxisView axis = ClassifyAxis(operand, dim, rank, params.result_shape[dim]);
+      if (axis.role == AxisRole::kBroadcast) {
+        CHECK_SPAN(ProveValidExtentEqual(axis.valid, OneExtent()) == ProofResult::kTrue, params.span)
+            << params.op_name << ": operand " << operand.label << " broadcasts dimension " << dim
+            << " from a physical extent of 1, but its valid extent there is " << PythonPrint(axis.valid)
+            << ", which is not provably 1. A broadcast singleton replicates its one cell across "
+               "the whole output dimension, so that cell must be valid";
+      }
+      if (axis.role == AxisRole::kContributor) {
+        grid[k][dim] = axis.valid;
+      }
+    }
+  }
+  return grid;
+}
+
+/// Require every non-broadcast contributor to a dimension to hold the same valid
+/// extent, and answer with that extent.
+std::vector<ExprPtr> ResolveAgreement(const ContributionGrid& grid,
+                                      const ElementwiseValidShapeParams& params) {
+  const size_t rank = params.result_shape.size();
+  std::vector<ExprPtr> agreed_shape;
+  agreed_shape.reserve(rank);
+
+  for (size_t dim = 0; dim < rank; ++dim) {
+    ExprPtr agreed;
+    const ElementwiseValidOperand* agreed_by = nullptr;
+    for (size_t k = 0; k < grid.size(); ++k) {
+      const ExprPtr& extent = grid[k][dim];
+      if (!extent) {
+        continue;  // exempt on this axis
+      }
+      const ElementwiseValidOperand& operand = params.operands[k];
+      if (!agreed) {
+        agreed = extent;
+        agreed_by = &operand;
+        continue;
+      }
+      // Both a proven inequality and an undecided symbolic relation reject: no
+      // runtime guard is emitted, so an unproved relation would silently widen
+      // or narrow the result region.
+      CHECK_SPAN(ProveValidExtentEqual(agreed, extent) == ProofResult::kTrue, params.span)
+          << params.op_name << ": operands " << agreed_by->label << " and " << operand.label
+          << " do not provably agree on the valid extent of dimension " << dim << " (" << agreed_by->label
+          << ": " << PythonPrint(agreed) << ", " << operand.label << ": " << PythonPrint(extent)
+          << "). An elementwise operation reads every operand at each cell and writes one region, "
+             "so every non-broadcast operand must have a provably equal valid extent. Narrow the "
+             "wider operand, or fill its padding with a fillpad before combining";
+      if (PrefersAsRepresentative(agreed, extent)) {
+        agreed = extent;
+        agreed_by = &operand;
+      }
+    }
+    // Every operand can be exempt here — a lower-rank sole value operand leaves the
+    // leading axes of a result broadcast against an excluded scratch operand with no
+    // contributor at all. Nothing constrains the dimension, so it is fully valid.
+    agreed_shape.push_back(agreed ? agreed : params.result_shape[dim]);
+  }
+  return agreed_shape;
+}
+
+/// The union of origin-anchored rectangles is itself an origin-anchored rectangle
+/// exactly when one of them contains all the others. Otherwise the componentwise
+/// maximum covers cells that lie in no operand at all, which is the silent
+/// widening this rule exists to prevent.
+std::vector<ExprPtr> ResolveRepresentableUnion(const ContributionGrid& grid,
+                                               const ElementwiseValidShapeParams& params) {
+  const size_t rank = params.result_shape.size();
+  std::vector<ExprPtr> widest;
+  widest.reserve(rank);
+  // Whether each operand's region still matches the widest extent on every
+  // dimension so far. Accumulated alongside the scan, so the "is the union some
+  // single operand's rectangle" test costs no second pass over the grid.
+  std::vector<bool> spans_every_dim(grid.size(), true);
+
+  for (size_t dim = 0; dim < rank; ++dim) {
+    // An exempt operand is fully valid on this axis: broadcasting replicates its
+    // one (valid) cell across the whole dimension.
+    auto extent_of = [&](size_t k) -> const ExprPtr& {
+      return grid[k][dim] ? grid[k][dim] : params.result_shape[dim];
+    };
+
+    // The extent that provably covers every other on this dimension. Picked per
+    // dimension, preferring a constant, so operand order cannot change the type.
+    const ExprPtr* best = nullptr;
+    for (size_t k = 0; k < grid.size(); ++k) {
+      const ExprPtr& candidate = extent_of(k);
+      bool covers = true;
+      for (size_t other = 0; other < grid.size() && covers; ++other) {
+        covers = ProveValidExtentLessEqual(extent_of(other), candidate) == ProofResult::kTrue;
+      }
+      if (covers && (best == nullptr || PrefersAsRepresentative(*best, candidate))) {
+        best = &candidate;
+      }
+    }
+    CHECK_SPAN(best != nullptr, params.span)
+        << params.op_name << ": the operand valid regions (" << FormatOperandRegions(params)
+        << ") have no provably widest extent on dimension " << dim
+        << ", so their union cannot be expressed as a valid_shape. A partial combine copies "
+           "whichever source is valid at a cell, so one operand's region must provably contain "
+           "the others";
+    widest.push_back(*best);
+
+    for (size_t k = 0; k < grid.size(); ++k) {
+      spans_every_dim[k] =
+          spans_every_dim[k] && ProveValidExtentEqual(extent_of(k), *best) == ProofResult::kTrue;
+    }
+  }
+
+  CHECK_SPAN(std::find(spans_every_dim.begin(), spans_every_dim.end(), true) != spans_every_dim.end(),
+             params.span)
+      << params.op_name << ": the operand valid regions (" << FormatOperandRegions(params)
+      << ") are not ordered by containment, so their union " << FormatShape(widest)
+      << " is not an origin-anchored rectangle and would claim cells that are valid in no "
+         "operand. Narrow one operand so that one region contains the other";
+  return widest;
+}
+
+}  // namespace
+
+std::vector<ExprPtr> InferElementwiseValidShape(const ElementwiseValidShapeParams& params) {
+  const size_t rank = params.result_shape.size();
+  for (const auto& operand : params.operands) {
+    INTERNAL_CHECK_SPAN(operand.physical.size() <= rank, params.span)
+        << "Internal error: " << params.op_name << " operand " << operand.label << " has rank "
+        << operand.physical.size() << ", which exceeds the broadcast result rank " << rank;
+    INTERNAL_CHECK_SPAN(operand.valid.size() == operand.physical.size(), params.span)
+        << "Internal error: " << params.op_name << " operand " << operand.label << " valid_shape rank ("
+        << operand.valid.size() << ") must match its physical rank (" << operand.physical.size() << ")";
+  }
+
+  const ContributionGrid grid = ClassifyContributions(params);
+  return params.combine == ElementwiseValidCombine::kAgree ? ResolveAgreement(grid, params)
+                                                           : ResolveRepresentableUnion(grid, params);
+}
+
+TileView MakeElementwiseTileView(const std::vector<ElementwiseTileOperand>& operands,
+                                 const std::vector<ExprPtr>& result_shape, const std::string& op_name,
+                                 const Span& span, ElementwiseValidCombine combine) {
+  std::vector<ElementwiseValidOperand> value_operands;
+  value_operands.reserve(operands.size());
+  for (const auto& operand : operands) {
+    INTERNAL_CHECK_SPAN(operand.type, span) << "Internal error: " << op_name << " operand " << operand.label
+                                            << " must be a TileType to derive an elementwise valid region";
+    value_operands.push_back({operand.type->shape_, GetValidShape(operand.type), operand.label});
+  }
+
+  TileView view;
+  view.valid_shape = InferElementwiseValidShape({
+      /*operands=*/std::move(value_operands),
+      /*result_shape=*/result_shape,
+      /*combine=*/combine,
+      /*op_name=*/op_name,
+      /*span=*/span,
+  });
+
+  // Production layout comes from an operand that owns the whole output shape. A
+  // broadcast singleton describes a differently shaped physical object, so letting
+  // it decide the layout is what made commutative operations order-dependent.
+  for (const auto& operand : operands) {
+    if (OwnsResultShape(operand.type->shape_, result_shape)) {
+      InheritTileViewLayout(view, operand.type);
+      return view;
+    }
+  }
+  const TileView implicit = tile_view_semantics::GetImplicitTileView(result_shape);
+  view.blayout = implicit.blayout;
+  view.slayout = implicit.slayout;
+  return view;
+}
+
 void ValidateDropDimsValidExtents(const std::vector<int64_t>& drop_dims,
                                   const std::vector<ExprPtr>& valid_shape, const std::string& op_name,
                                   const Span& span) {
-  static const auto one = std::make_shared<ConstInt>(1, DataType::INDEX, Span::unknown());
   for (int64_t axis : drop_dims) {
     const auto index = static_cast<size_t>(axis);
     INTERNAL_CHECK_SPAN(index < valid_shape.size(), span)
         << "Internal error: " << op_name << " drop_dims axis " << axis
         << " is out of range for valid_shape rank " << valid_shape.size();
     const ExprPtr& extent = valid_shape[index];
-    CHECK_SPAN(ProveValidExtentEqual(extent, one) == ProofResult::kTrue, span)
+    CHECK_SPAN(ProveValidExtentEqual(extent, OneExtent()) == ProofResult::kTrue, span)
         << op_name << " cannot drop dimension " << axis << ": its valid extent is " << PythonPrint(extent)
         << ", which is not provably 1. Rank reduction erases an axis, so the axis must be fully valid; "
            "keep the dimension instead of dropping it";

--- a/tests/ut/ir/operators/test_tensor_ops.py
+++ b/tests/ut/ir/operators/test_tensor_ops.py
@@ -4669,6 +4669,98 @@ class TestTensorAssembleValidRegionUnion:
         assert isinstance(result_type, ir.TensorType)
         assert result_type.tensor_view is None
 
+class TestTensorElementwiseValidRegion:
+    """Tensor elementwise ops follow the same valid-region rule as tile ops.
+
+    A tensor elementwise op lowers 1:1 to its tile counterpart, so the region
+    contract has to match: non-broadcast operands must provably agree, and only
+    the ``part_*`` family unites regions.
+    """
+
+    @staticmethod
+    def _tensor(shape, valid_shape=None, dtype=DataType.FP32, name="a"):
+        span = ir.Span.unknown()
+        view = (
+            None
+            if valid_shape is None
+            else ir.TensorView(stride=[], layout=ir.TensorLayout.ND, valid_shape=valid_shape)
+        )
+        return ir.Var(name, ir.TensorType(shape, dtype, tensor_view=view), span)
+
+    @staticmethod
+    def _valid_of(result_type):
+        view = result_type.tensor_view
+        shape = result_type.shape if view is None or not view.valid_shape else view.valid_shape
+        return [d.value if isinstance(d, ir.ConstInt) else d for d in shape]
+
+    def test_matching_partial_operands_propagate(self):
+        call = tensor.add(self._tensor([8, 16], [8, 4]), self._tensor([8, 16], [8, 4]))
+        assert self._valid_of(call.type) == [8, 4]
+
+    def test_fully_valid_operands_canonicalize_to_no_valid_shape(self):
+        result_type = tensor.add(self._tensor([8, 16]), self._tensor([8, 16])).type
+        assert isinstance(result_type, ir.TensorType)
+        view = result_type.tensor_view
+        assert view is None or not view.valid_shape
+
+    def test_static_disagreement_rejects(self):
+        with pytest.raises(ValueError, match=r"do not provably agree on the valid extent"):
+            tensor.add(self._tensor([8, 16], [8, 4]), self._tensor([8, 16], [8, 16]))
+
+    def test_lower_rank_operand_right_aligns(self):
+        call = tensor.add(self._tensor([4, 8], [4, 6]), self._tensor([8], [6]))
+        assert self._valid_of(call.type) == [4, 6]
+
+    def test_broadcast_singleton_is_exempt(self):
+        call = tensor.add(self._tensor([4, 8], [4, 6]), self._tensor([4, 1], [4, 1]))
+        assert self._valid_of(call.type) == [4, 6]
+
+    def test_empty_broadcast_singleton_rejects(self):
+        with pytest.raises(ValueError, match=r"broadcasts dimension .* not provably 1"):
+            tensor.add(self._tensor([4, 8], [4, 6]), self._tensor([4, 1], [4, 0]))
+
+    def test_operand_order_is_irrelevant(self):
+        lhs = self._tensor([8, 16], [8, 4], name="a")
+        rhs = self._tensor([8, 16], [8, 4], name="b")
+        assert self._valid_of(tensor.add(lhs, rhs).type) == self._valid_of(tensor.add(rhs, lhs).type)
+
+    def test_part_takes_the_containing_region(self):
+        call = tensor.part_add(self._tensor([8, 16], [8, 4]), self._tensor([8, 16], [8, 10]))
+        assert self._valid_of(call.type) == [8, 10]
+
+    def test_part_rejects_a_non_rectangular_union(self):
+        with pytest.raises(ValueError, match=r"not ordered by containment"):
+            tensor.part_add(self._tensor([8, 16], [4, 10]), self._tensor([8, 16], [8, 4]))
+
+    @pytest.mark.parametrize(
+        "scalar_op",
+        [tensor.adds, tensor.subs, tensor.muls, tensor.divs, tensor.fmods],
+        ids=["adds", "subs", "muls", "divs", "fmods"],
+    )
+    def test_scalar_binary_preserves_validity(self, scalar_op):
+        """A scalar has no region, so the tensor's must survive (it used to be dropped)."""
+        call = scalar_op(self._tensor([8, 16], [8, 4]), 2.0)
+        assert self._valid_of(call.type) == [8, 4]
+
+    def test_result_carries_no_source_alias_metadata(self):
+        """A computed tensor is a new allocation, not a view of either operand."""
+        span = ir.Span.unknown()
+        strided = ir.TensorView(
+            stride=[ir.ConstInt(32, DataType.INDEX, span), ir.ConstInt(1, DataType.INDEX, span)],
+            layout=ir.TensorLayout.ND,
+            valid_shape=[8, 4],
+            pad=ir.PadValue.zero,
+        )
+        src = ir.Var("src", ir.TensorType([8, 16], DataType.FP32, tensor_view=strided), span)
+
+        for call in (tensor.add(src, src), tensor.adds(src, 1.0)):
+            result_type = call.type
+            assert isinstance(result_type, ir.TensorType)
+            view = result_type.tensor_view
+            assert view is not None and not view.stride
+            assert view.pad == ir.PadValue.null
+            assert view.layout == ir.TensorLayout.ND
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/ir/operators/test_tile_ops.py
+++ b/tests/ut/ir/operators/test_tile_ops.py
@@ -5625,5 +5625,281 @@ class TestWriteValidRegionUnion:
         assert result_type.tensor_view is None
 
 
+class TestTileElementwiseValidRegion:
+    """The valid-region rule shared by every elementwise / broadcast tile family.
+
+    Every non-broadcast operand must provably agree on each dimension's valid
+    extent -- that is the hardware contract (``TADD_IMPL`` asserts
+    ``src.GetValidRow() == dst.GetValidRow()`` for both sources), and no choice of
+    result region can satisfy it when the operands disagree. The partial-combine
+    family (``part_*``) instead takes the union, which ``TPartInstr`` realises by
+    testing each source's extent per cell -- admitted only when that union is an
+    origin-anchored rectangle.
+    """
+
+    @staticmethod
+    def _tile(shape, valid_shape=None, dtype=DataType.FP32, name="t"):
+        """A tile Var, optionally narrowed to ``valid_shape``."""
+        span = ir.Span.unknown()
+        view = None if valid_shape is None else ir.TileView(valid_shape=valid_shape)
+        return ir.Var(name, ir.TileType(shape, dtype, tile_view=view), span)
+
+    @staticmethod
+    def _valid_of(result_type):
+        """Effective valid extents, with ConstInt unwrapped to int."""
+        view = result_type.tile_view
+        shape = result_type.shape if view is None or not view.valid_shape else view.valid_shape
+        return [d.value if isinstance(d, ir.ConstInt) else d for d in shape]
+
+    # --- agreement ----------------------------------------------------------
+
+    def test_matching_partial_operands_propagate(self):
+        """Operands that agree hand their common region to the result."""
+        call = tile.add(self._tile([8, 16], [8, 4]), self._tile([8, 16], [8, 4]))
+        assert self._valid_of(call.type) == [8, 4]
+
+    def test_fully_valid_operands_canonicalize_to_no_valid_shape(self):
+        """A fully valid result carries no explicit valid_shape at all."""
+        result_type = tile.add(self._tile([8, 16]), self._tile([8, 16])).type
+        assert isinstance(result_type, ir.TileType)
+        assert result_type.tile_view is None or not result_type.tile_view.valid_shape
+
+    def test_static_disagreement_rejects(self):
+        """4 != 10 is provable, so the operands cannot be combined."""
+        with pytest.raises(ValueError, match=r"do not provably agree on the valid extent"):
+            tile.add(self._tile([8, 16], [8, 4]), self._tile([8, 16], [8, 10]))
+
+    def test_symbolic_agreement_accepted(self):
+        """The same symbol on both sides is provably equal, and survives onto the result."""
+        span = ir.Span.unknown()
+        n = ir.Var("n", ir.ScalarType(DataType.INDEX), span)
+        rows = ir.ConstInt(8, DataType.INDEX, span)
+        call = tile.add(self._tile([8, 16], [rows, n]), self._tile([8, 16], [rows, n]))
+        valid = self._valid_of(call.type)
+        assert valid[0] == 8
+        assert isinstance(valid[1], ir.Var) and valid[1].name_hint == "n"
+
+    def test_symbolic_disagreement_rejects_as_unknown(self):
+        """An undecidable relation rejects: no runtime guard is emitted."""
+        span = ir.Span.unknown()
+        n = ir.Var("n", ir.ScalarType(DataType.INDEX), span)
+        m = ir.Var("m", ir.ScalarType(DataType.INDEX), span)
+        rows = ir.ConstInt(8, DataType.INDEX, span)
+        with pytest.raises(ValueError, match=r"do not provably agree on the valid extent"):
+            tile.add(self._tile([8, 16], [rows, n]), self._tile([8, 16], [rows, m]))
+
+    def test_constant_representative_makes_order_irrelevant(self):
+        """A constant extent is preferred, so either operand order prints the same."""
+        span = ir.Span.unknown()
+        four = ir.ConstInt(4, DataType.INDEX, span)
+        eight = ir.ConstInt(8, DataType.INDEX, span)
+        lhs = self._tile([8, 16], [eight, four], name="a")
+        rhs = self._tile([8, 16], [eight, four], name="b")
+        assert self._valid_of(tile.add(lhs, rhs).type) == self._valid_of(tile.add(rhs, lhs).type)
+
+    # --- broadcasting -------------------------------------------------------
+
+    def test_broadcast_singleton_is_exempt_from_agreement(self):
+        """A [8, 1] row vector widens to [8, 16] and does not have to match cols."""
+        call = tile.row_expand_sub(self._tile([8, 16], [8, 4]), self._tile([8, 1], [8, 1]))
+        assert self._valid_of(call.type) == [8, 4]
+
+    def test_empty_broadcast_singleton_rejects(self):
+        """A singleton replicates its one cell, so that cell must be valid."""
+        with pytest.raises(ValueError, match=r"broadcasts dimension .* not provably 1"):
+            tile.row_expand_sub(self._tile([8, 16], [8, 4]), self._tile([8, 1], [8, 0]))
+
+    def test_unknown_broadcast_singleton_rejects(self):
+        """An unproved singleton extent rejects for the same reason."""
+        span = ir.Span.unknown()
+        n = ir.Var("n", ir.ScalarType(DataType.INDEX), span)
+        rows = ir.ConstInt(8, DataType.INDEX, span)
+        with pytest.raises(ValueError, match=r"broadcasts dimension .* not provably 1"):
+            tile.row_expand_sub(self._tile([8, 16], [8, 4]), self._tile([8, 1], [rows, n]))
+
+    def test_broadcast_operand_still_agrees_on_its_non_broadcast_axis(self):
+        """A [1, 16] column tile broadcasts rows, but its 16 columns still must agree."""
+        with pytest.raises(ValueError, match=r"do not provably agree on the valid extent"):
+            tile.col_expand_mul(self._tile([8, 16], [4, 16]), self._tile([1, 16], [1, 8]))
+
+    def test_lower_rank_operand_right_aligns(self):
+        """A rank-1 operand's missing leading axis is an implicit valid singleton."""
+        call = tile.add(self._tile([4, 8], [4, 6]), self._tile([8], [6]))
+        assert self._valid_of(call.type) == [4, 6]
+
+    def test_mutually_broadcasting_shapes(self):
+        """[4, 1] x [1, 8]: each operand is a singleton on the other's axis."""
+        call = tile.add(self._tile([4, 1], [4, 1]), self._tile([1, 8], [1, 8]))
+        assert self._valid_of(call.type) == [4, 8]
+
+    def test_layout_derives_from_the_output_when_no_operand_owns_it(self):
+        """[4, 1] x [1, 8] -> [4, 8]: neither operand owns the result shape.
+
+        A bare [4, 1] tile is implicitly col_major. Taking layout from operand 0 --
+        what the deducers used to do unconditionally -- would stamp col_major onto a
+        [4, 8] result, and make a commutative op's layout depend on operand order.
+        Deriving from the output shape gives row_major, which for a fully valid
+        result is the implicit layout, so the view canonicalizes away entirely.
+        """
+        col_vec = self._tile([4, 1], name="col")
+        row_vec = self._tile([1, 8], name="row")
+        for lhs, rhs in ((col_vec, row_vec), (row_vec, col_vec)):
+            result_type = tile.add(lhs, rhs).type
+            assert isinstance(result_type, ir.TileType)
+            assert self._valid_of(result_type) == [4, 8]
+            # A retained view here would mean a non-default (inherited) blayout.
+            assert result_type.tile_view is None
+
+    # --- every multi-operand family -----------------------------------------
+
+    @pytest.mark.parametrize(
+        "make",
+        [
+            pytest.param(lambda a, b: tile.add(a, b), id="binary"),
+            pytest.param(lambda a, b: tile.maximum(a, b), id="maximum"),
+            pytest.param(lambda a, b: tile.sels(a, b, 1), id="sels"),
+        ],
+    )
+    def test_family_rejects_disagreement(self, make):
+        with pytest.raises(ValueError, match=r"do not provably agree on the valid extent"):
+            make(self._tile([8, 16], [8, 4]), self._tile([8, 16], [8, 10]))
+
+    def test_shift_amount_is_a_value_operand(self):
+        """tile.shl reads the shift tile per element, so it must agree."""
+
+        def int_tile(valid):
+            return self._tile([8, 16], valid, dtype=DataType.INT32)
+
+        assert self._valid_of(tile.shl(int_tile([8, 4]), int_tile([8, 4])).type) == [8, 4]
+        with pytest.raises(ValueError, match=r"do not provably agree on the valid extent"):
+            tile.shl(int_tile([8, 4]), int_tile([8, 10]))
+
+    def test_ternary_tmp_is_excluded(self):
+        """tile.rem's tmp is scratch: it is written before it is read."""
+        call = tile.rem(
+            self._tile([8, 16], [8, 4]), self._tile([8, 16], [8, 4]), self._tile([8, 16], [8, 16])
+        )
+        assert self._valid_of(call.type) == [8, 4]
+
+    def test_tri_tile_all_three_agree(self):
+        """tile.addc reads all three operands, so all three must agree."""
+        assert self._valid_of(
+            tile.addc(
+                self._tile([8, 16], [8, 4]), self._tile([8, 16], [8, 4]), self._tile([8, 16], [8, 4])
+            ).type
+        ) == [8, 4]
+        with pytest.raises(ValueError, match=r"do not provably agree on the valid extent"):
+            tile.addc(self._tile([8, 16], [8, 4]), self._tile([8, 16], [8, 4]), self._tile([8, 16], [8, 10]))
+
+    def test_tile_scalar_tile_distinguishes_addend_from_scratch(self):
+        """tile.addsc's third tile is a real addend; tile.rems' is scratch."""
+        with pytest.raises(ValueError, match=r"do not provably agree on the valid extent"):
+            tile.addsc(self._tile([8, 16], [8, 4]), 1.0, self._tile([8, 16], [8, 10]))
+        # Same shapes through tile.rems: the tmp is excluded, so this is fine.
+        call = tile.rems(self._tile([8, 16], [8, 4]), 1.0, self._tile([8, 16], [8, 10]))
+        assert self._valid_of(call.type) == [8, 4]
+
+    def test_sel_excludes_mask_and_tmp(self):
+        """tile.sel's mask is a packed predicate and its tmp is scratch."""
+        call = tile.sel(
+            self._tile([8, 4], [8, 4], dtype=DataType.UINT8),
+            self._tile([8, 16], [8, 4]),
+            self._tile([8, 16], [8, 4]),
+            self._tile([1, 32], None, dtype=DataType.UINT8),
+        )
+        assert self._valid_of(call.type) == [8, 4]
+
+    def test_cmp_packs_the_agreed_region(self):
+        """The mask's valid columns are the agreed columns, 8 predicates per byte."""
+        call = tile.cmp(self._tile([8, 64], [8, 40]), self._tile([8, 64], [8, 40]), cmp_type=0)
+        assert self._valid_of(call.type) == [8, 5]  # ceil(40 / 8)
+        with pytest.raises(ValueError, match=r"do not provably agree on the valid extent"):
+            tile.cmp(self._tile([8, 64], [8, 40]), self._tile([8, 64], [8, 48]), cmp_type=0)
+
+    # --- part_* union -------------------------------------------------------
+
+    @pytest.mark.parametrize(
+        "part_op",
+        [tile.part_add, tile.part_mul, tile.part_max, tile.part_min],
+        ids=["add", "mul", "max", "min"],
+    )
+    def test_part_takes_the_containing_region(self, part_op):
+        """Where only one source is valid the result copies it, so regions unite."""
+        narrow = self._tile([8, 16], [8, 4])
+        wide = self._tile([8, 16], [8, 10])
+        assert self._valid_of(part_op(narrow, wide).type) == [8, 10]
+
+    def test_part_union_is_operand_order_independent(self):
+        narrow = self._tile([8, 16], [8, 4])
+        wide = self._tile([8, 16], [8, 10])
+        assert (
+            self._valid_of(tile.part_add(narrow, wide).type)
+            == self._valid_of(tile.part_add(wide, narrow).type)
+            == [8, 10]
+        )
+
+    def test_part_rejects_a_non_rectangular_union(self):
+        """[4, 10] u [8, 4] is an L-shape; [8, 10] would claim cells valid in neither."""
+        with pytest.raises(ValueError, match=r"not ordered by containment"):
+            tile.part_add(self._tile([8, 16], [4, 10]), self._tile([8, 16], [8, 4]))
+
+    def test_part_union_of_symbolically_equal_regions(self):
+        """Two regions carrying the same symbol are provably ordered, so the union is that symbol."""
+        span = ir.Span.unknown()
+        n = ir.Var("n", ir.ScalarType(DataType.INDEX), span)
+        rows = ir.ConstInt(8, DataType.INDEX, span)
+        call = tile.part_add(self._tile([8, 16], [rows, n]), self._tile([8, 16], [rows, n]))
+        valid = self._valid_of(call.type)
+        assert valid[0] == 8
+        assert isinstance(valid[1], ir.Var) and valid[1].name_hint == "n"
+
+    def test_part_rejects_an_unorderable_symbolic_union(self):
+        span = ir.Span.unknown()
+        n = ir.Var("n", ir.ScalarType(DataType.INDEX), span)
+        m = ir.Var("m", ir.ScalarType(DataType.INDEX), span)
+        rows = ir.ConstInt(8, DataType.INDEX, span)
+        with pytest.raises(ValueError, match=r"no provably widest extent"):
+            tile.part_add(self._tile([8, 16], [rows, n]), self._tile([8, 16], [rows, m]))
+
+    # --- fresh result metadata ----------------------------------------------
+
+    def test_result_carries_no_source_alias_metadata(self):
+        """A computed tile is a new allocation, not a view of either operand."""
+        span = ir.Span.unknown()
+        aliased = ir.TileView(
+            valid_shape=[8, 4], stride=[32, 1], start_offset=ir.ConstInt(64, DataType.INDEX, span)
+        )
+        src = ir.Var("src", ir.TileType([8, 16], DataType.FP32, tile_view=aliased), span)
+
+        result_type = tile.add(src, src).type
+        assert isinstance(result_type, ir.TileType)
+        view = result_type.tile_view
+        assert view is not None and not view.stride
+        assert view.start_offset is None
+
+    def test_fresh_result_does_not_inherit_pad(self):
+        """exp() of a zero-padded tile is not zero-padded: only the valid region is written."""
+        padded = tile.fillpad(self._tile([8, 16], [8, 4]), pad_value=ir.PadValue.zero)
+        padded_type = padded.type
+        assert isinstance(padded_type, ir.TileType)
+        assert padded_type.tile_view is not None
+        assert padded_type.tile_view.pad == ir.PadValue.zero
+
+        for call in (tile.exp(padded), tile.add(padded, padded), tile.muls(padded, 2.0)):
+            result_type = call.type
+            assert isinstance(result_type, ir.TileType)
+            view = result_type.tile_view
+            assert view is None or view.pad == ir.PadValue.null
+
+    def test_fillpad_family_still_establishes_its_pad(self):
+        """The ops that really do write the padding still say so."""
+        expanded_type = tile.fillpad_expand(
+            self._tile([8, 16], [8, 4]), [8, 32], pad_value=ir.PadValue.max
+        ).type
+        assert isinstance(expanded_type, ir.TileType)
+        assert expanded_type.tile_view is not None
+        assert expanded_type.tile_view.pad == ir.PadValue.max
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/ir/operators/test_tile_ops.py
+++ b/tests/ut/ir/operators/test_tile_ops.py
@@ -5688,6 +5688,26 @@ class TestTileElementwiseValidRegion:
         with pytest.raises(ValueError, match=r"do not provably agree on the valid extent"):
             tile.add(self._tile([8, 16], [rows, n]), self._tile([8, 16], [rows, m]))
 
+    def test_provably_equal_symbolic_extents_pick_one_representative(self):
+        """`n` and `n + 0` are proven equal but differ structurally.
+
+        Type equality and hashing compare expressions structurally, so keeping
+        whichever operand came first would let a commutative operation produce
+        unequal types and trip a reassignment/join type check downstream.
+        """
+        span = ir.Span.unknown()
+        n = ir.Var("n", ir.ScalarType(DataType.INDEX), span)
+        n_plus_zero = ir.Add(n, ir.ConstInt(0, DataType.INDEX, span), DataType.INDEX, span)
+        rows = ir.ConstInt(8, DataType.INDEX, span)
+
+        plain = self._tile([8, 16], [rows, n], name="a")
+        padded = self._tile([8, 16], [rows, n_plus_zero], name="b")
+
+        forward = tile.add(plain, padded).type
+        reverse = tile.add(padded, plain).type
+        assert isinstance(forward, ir.TileType) and isinstance(reverse, ir.TileType)
+        assert ir.structural_equal(forward, reverse)
+
     def test_constant_representative_makes_order_irrelevant(self):
         """A constant extent is preferred, so either operand order prints the same."""
         span = ir.Span.unknown()
@@ -5716,6 +5736,31 @@ class TestTileElementwiseValidRegion:
         rows = ir.ConstInt(8, DataType.INDEX, span)
         with pytest.raises(ValueError, match=r"broadcasts dimension .* not provably 1"):
             tile.row_expand_sub(self._tile([8, 16], [8, 4]), self._tile([8, 1], [rows, n]))
+
+    def test_symbolically_unit_result_axis_is_not_widening(self):
+        """A unit axis that reaches the rule in symbolic form must not read as broadcasting.
+
+        BroadcastShapes keeps the *first* operand's expression for provably equal
+        dims, so pairing a symbolic-but-unit extent with a literal 1 yields a result
+        axis that is one without being a ConstInt. Classifying the literal operand as
+        a broadcast singleton there would demand its valid extent be 1 -- rejecting an
+        empty axis that widens nothing, and only in one operand order.
+        """
+        span = ir.Span.unknown()
+        n = ir.Var("n", ir.ScalarType(DataType.INDEX), span)
+        # n - n + 1: provably 1, but not a ConstInt.
+        symbolic_one = ir.Add(
+            ir.Sub(n, n, DataType.INDEX, span), ir.ConstInt(1, DataType.INDEX, span), DataType.INDEX, span
+        )
+        rows = ir.ConstInt(8, DataType.INDEX, span)
+        zero = ir.ConstInt(0, DataType.INDEX, span)
+
+        symbolic = self._tile([rows, symbolic_one], [rows, zero], name="sym")
+        literal = self._tile([8, 1], [8, 0], name="lit")
+
+        # Neither axis widens, so an empty unit axis is legal in either order.
+        assert self._valid_of(tile.add(symbolic, literal).type)[1] == 0
+        assert self._valid_of(tile.add(literal, symbolic).type)[1] == 0
 
     def test_broadcast_operand_still_agrees_on_its_non_broadcast_axis(self):
         """A [1, 16] column tile broadcasts rows, but its 16 columns still must agree."""

--- a/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
+++ b/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
@@ -2436,17 +2436,28 @@ class TestGmLocalTensorConversion:
             # confuses pyright's overload matching of ``slice``'s ``span`` param).
             return [8, extras[0]] if with_valid_shape else None
 
+        # The gm input is narrowed to the same region as the local slice: an
+        # elementwise add requires its operands to agree on a valid region (TADD
+        # asserts src.valid == dst.valid), so adding a full-valid tile to a
+        # narrowed one is not a legal program. The pass folds that slice of a gm
+        # param into the pre-load, hence the load_* overrides below; the subject
+        # of this test is still the *local* slice becoming a tile.slice.
         def before_body(ib, ins, extras=()):
             t = ib.let("t", tensor_ops.create([16, 64], DataType.FP32))
             s = ib.let("s", tensor_ops.slice(t, [8, 32], [0, 0], valid_shape=_valid_shape(extras)))
-            return ib.let("y", tensor_ops.add(s, ins[0]))
+            xs = ib.let("xs", tensor_ops.slice(ins[0], [8, 32], [0, 0], valid_shape=_valid_shape(extras)))
+            return ib.let("y", tensor_ops.add(s, xs))
 
-        def expected_body(ib, tiles, extras=()):
+        # ``preload=False`` because the pass folds the gm slice into its load, and
+        # the load carries the (possibly symbolic) valid_shape, which is only in
+        # scope here — so the expected body issues the load itself.
+        def expected_body(ib, tensors, extras=()):
             t_tile = ib.let("t_tile", tile_ops.create([16, 64], DataType.FP32))
             s_tile = ib.let(
                 "s_tile", tile_ops.slice(t_tile, [8, 32], [0, 0], valid_shape=_valid_shape(extras))
             )
-            return ib.let("y_tile", tile_ops.add(s_tile, tiles[0]))
+            xs_tile = ib.let("xs_tile", tile_ops.load(tensors[0], [0, 0], [8, 32], _valid_shape(extras)))
+            return ib.let("y_tile", tile_ops.add(s_tile, xs_tile))
 
         before = _make_before(
             in_specs=in_specs,
@@ -2460,6 +2471,7 @@ class TestGmLocalTensorConversion:
             out_shape=[8, 32],
             out_dtype=DataType.FP32,
             body=expected_body,
+            preload=False,
             extra_specs=extra_specs,
         )
         _assert_convert_equal(before, expected)
@@ -2468,25 +2480,33 @@ class TestGmLocalTensorConversion:
         """tensor.slice(..., pad_value=X) on a local tensor lowers to tile.slice(..., pad_value=X)."""
         in_specs: list[InSpec] = [("x", [8, 32], DataType.FP32)]
 
+        # As above: the addends must agree on a valid region, so the gm input is
+        # narrowed to the slice's region and its load carries that valid_shape.
         def before_body(ib, ins):
             t = ib.let("t", tensor_ops.create([16, 64], DataType.FP32))
             s = ib.let(
                 "s",
                 tensor_ops.slice(t, [8, 32], [0, 0], valid_shape=[8, 8], pad_value=PadValue.min),
             )
-            return ib.let("y", tensor_ops.add(s, ins[0]))
+            xs = ib.let("xs", tensor_ops.slice(ins[0], [8, 32], [0, 0], valid_shape=[8, 8]))
+            return ib.let("y", tensor_ops.add(s, xs))
 
-        def expected_body(ib, tiles):
+        def expected_body(ib, tensors):
             t_tile = ib.let("t_tile", tile_ops.create([16, 64], DataType.FP32))
             s_tile = ib.let(
                 "s_tile",
                 tile_ops.slice(t_tile, [8, 32], [0, 0], valid_shape=[8, 8], pad_value=PadValue.min),
             )
-            return ib.let("y_tile", tile_ops.add(s_tile, tiles[0]))
+            xs_tile = ib.let("xs_tile", tile_ops.load(tensors[0], [0, 0], [8, 32], [8, 8]))
+            return ib.let("y_tile", tile_ops.add(s_tile, xs_tile))
 
         before = _make_before(in_specs=in_specs, out_shape=[8, 32], out_dtype=DataType.FP32, body=before_body)
         expected = _make_expected(
-            in_specs=in_specs, out_shape=[8, 32], out_dtype=DataType.FP32, body=expected_body
+            in_specs=in_specs,
+            out_shape=[8, 32],
+            out_dtype=DataType.FP32,
+            body=expected_body,
+            preload=False,
         )
         _assert_convert_equal(before, expected)
 

--- a/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
+++ b/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
@@ -995,7 +995,6 @@ class TestConvertTensorToTileOps:
 
     def test_div_row_broadcast_requires_divisor_valid_rows_to_cover_dividend(self):
         """The row-expand template reads one divisor scalar for every valid output row."""
-        span = ir.Span.unknown()
         lhs_type = ir.TensorType(
             [8, 16],
             DataType.FP32,
@@ -1008,17 +1007,15 @@ class TestConvertTensorToTileOps:
             None,
             ir.TensorView(layout=ir.TensorLayout.ND, valid_shape=[6, 1]),
         )
+        # The elementwise valid-region rule rejects this at type deduction, before
+        # the conversion pass gets a chance to apply its own divisor-cover check:
+        # 7 and 6 are both non-broadcast row extents and are provably unequal.
         ib = IRBuilder()
         with ib.function("kernel", type=ir.FunctionType.InCore) as f:
             lhs = f.param("lhs", lhs_type)
             rhs = f.param("rhs", rhs_type)
-            result = ib.let("result", tensor_ops.div(lhs, rhs))
-            f.return_type(result.type)
-            ib.return_stmt(result)
-        before = ir.Program([f.get_result()], "ShortDivisorValidRows", span)
-
-        with pytest.raises(ValueError, match=r"divisor valid rows to cover the dividend"):
-            passes.convert_tensor_to_tile_ops()(before)
+            with pytest.raises(ValueError, match=r"do not provably agree on the valid extent"):
+                ib.let("result", tensor_ops.div(lhs, rhs))
 
     def test_div_row_broadcast_dynamic_valid_rows_must_be_provably_covered(self):
         """A shared runtime extent is safe, while unrelated extents need a runtime guard."""
@@ -1052,8 +1049,11 @@ class TestConvertTensorToTileOps:
         kernel = _require_function(converted, "kernel")
         assert _find_first_call_to(kernel, "tile.row_expand_div") is not None
 
-        with pytest.raises(ValueError, match=r"divisor valid rows to cover the dividend"):
-            passes.convert_tensor_to_tile_ops()(make_program(unrelated_rows, "UnknownDivValidRows"))
+        # Unrelated symbols cannot be proven equal, so the elementwise valid-region
+        # rule rejects the program while it is still being built — earlier than the
+        # conversion pass's own divisor-cover check.
+        with pytest.raises(ValueError, match=r"do not provably agree on the valid extent"):
+            make_program(unrelated_rows, "UnknownDivValidRows")
 
     def test_div_mixed_float_row_broadcast_inserts_explicit_cast(self):
         """Row-expand division receives one exact floating dtype after tensor promotion."""
@@ -1122,7 +1122,6 @@ class TestConvertTensorToTileOps:
 
     def test_div_rejects_mismatched_valid_shapes_conversion(self):
         """Equal physical shapes with different source valid regions cannot lower to tdiv."""
-        span = ir.Span.unknown()
         lhs_type = ir.TensorType(
             [8, 16],
             DataType.FP32,
@@ -1135,17 +1134,14 @@ class TestConvertTensorToTileOps:
             None,
             ir.TensorView(layout=ir.TensorLayout.ND, valid_shape=[8, 16]),
         )
+        # Rejected at type deduction now: 7 and 8 are provably unequal non-broadcast
+        # row extents, so the program cannot be built for the pass to inspect.
         ib = IRBuilder()
         with ib.function("kernel", type=ir.FunctionType.InCore) as f:
             lhs = f.param("lhs", lhs_type)
             rhs = f.param("rhs", rhs_type)
-            result = ib.let("result", tensor_ops.div(lhs, rhs))
-            f.return_type(result.type)
-            ib.return_stmt(result)
-        before = ir.Program([f.get_result()], "MismatchedDivValidShapes", span)
-
-        with pytest.raises(ValueError, match=r"requires src0, src1, and dst to have the same valid_shape"):
-            passes.convert_tensor_to_tile_ops()(before)
+            with pytest.raises(ValueError, match=r"do not provably agree on the valid extent"):
+                ib.let("result", tensor_ops.div(lhs, rhs))
 
     def test_subs_mixed_dtype_conversion_preserves_lhs_dtype(self):
         """An explicit FP32 scalar stays FP32 while the i16 tsubs result stays i16."""


### PR DESCRIPTION
Implements brief 12 of the unified `valid_shape` series (*Require elementwise
valid-region agreement*). Follows #2031 (canonicalization), #2037 (proof/bounds),
#2043 (type boundaries), #2048 (window reads) and #2051 (unary/reduction).

## Summary

One shared rule now decides the valid region of every elementwise result, for
tensor and tile alike. Previously each deducer copied `GetValidShape(arg0)` onto
the result under a standing `TODO(YunjiQin): assumes both src tiles have the same
valid_shape`, which silently widened or narrowed the result whenever the operands
disagreed, and made commutative operations operand-order-dependent.

- **`InferElementwiseValidShape`** right-aligns the operands to the result rank
  and classifies each per output dimension — missing leading axis, physical
  singleton broadcasting up, or non-broadcast contributor — then requires every
  non-broadcast contributor to hold a **provably equal** valid extent.
- **`MakeElementwiseTileView`** pairs that with layout taken from an operand
  whose physical shape equals the output shape, falling back to the layout
  implied by the output shape. A broadcast singleton can no longer dictate the
  result's layout.
- **`part_add` / `part_mul` / `part_max` / `part_min`** instead take the *union*,
  admitted only when it is representable as an origin-anchored rectangle.
- **Fresh results no longer inherit `pad`**, and **tensor scalar-binary ops now
  preserve validity** — the two items #2051 deferred to this brief.

A fully valid input still yields a fully valid, view-less result, so no existing
program changes shape.

## What the ISA says

Both the CPU model and the a2a3 NPU path assert the sources against the
destination (`cpu/TAdd.hpp:70-74`, `npu/a2a3/TAdd.hpp:65-70`):

```cpp
unsigned validRows = dst.GetValidRow();
unsigned validCols = dst.GetValidCol();
PTO_ASSERT(src0.GetValidRow() == validRows && src0.GetValidCol() == validCols, ...);
PTO_ASSERT(src1.GetValidRow() == validRows && src1.GetValidCol() == validCols, ...);
```

That assert is what this PR's equality rule encodes. **But see the open question
at the bottom** — `PTO_ASSERT` is `_DEBUG`-only, and the release kernel enforces
the weaker `dst.valid <= every src.valid`, which changes what the right rule is.

`TPartOp.hpp` conversely tests each source per cell and **zeroes** cells in
neither:

```cpp
bool InSrc0 = i < Src0ValidRow && j < Src0ValidCol;
bool InSrc1 = i < Src1ValidRow && j < Src1ValidCol;
...
} else { dst[DstOffset] = 0; }
```

That is exactly why the union must be a representable rectangle: claiming
`[6, 8]` for `[4, 8] ∪ [6, 6]` would type silently-zeroed cells as valid data.

## Observable behavior

```text
add(valid [8,4], valid [8,4])          -> [8,4]        (was [8,4])
add(valid [8,4], valid [8,10])         -> rejected     (was [8,4] — silently narrowed)
add(full,        full)                 -> no valid_shape (canonicalized, unchanged)
add(t[4,8] v[4,6], t[8] v[6])          -> [4,6]        (rank-1 right-aligned)
add(t[4,1] v[4,1], t[1,8] v[1,8])      -> [4,8]        (mutually broadcasting)
row_expand_sub(v [8,4], row [8,1] v [8,1]) -> [8,4]    (singleton exempt on cols)
row_expand_sub(v [8,4], row [8,1] v [8,0]) -> rejected (its one cell is not valid)
part_add(valid [8,4], valid [8,10])    -> [8,10]       (union; order-independent)
part_add(valid [4,10], valid [8,4])    -> rejected     (L-shape, not a rectangle)
cmp(v [8,40], v [8,40])                -> mask valid [8,5]  (ceil(40/8), agreed region)
exp(fillpad(t, zero))                  -> pad = null   (was pad = zero)
tensor.adds(v [8,4], 2.0)              -> [8,4]        (was: validity dropped)
```

Commutative operations now produce structurally equal result types in either
order: extents are chosen per dimension, preferring a constant representative.

## New diagnostics

| Condition | Error |
| --------- | ----- |
| Non-broadcast operands disagree (proven unequal **or** undecided) | `<op>: operands <a> and <b> do not provably agree on the valid extent of dimension <n> (<a>: X, <b>: Y). An elementwise operation reads every operand at each cell and writes one region, so every non-broadcast operand must have a provably equal valid extent. Narrow the wider operand, or fill its padding with a fillpad before combining` |
| Broadcast singleton whose sole cell is not provably valid | `<op>: operand <label> broadcasts dimension <n> from a physical extent of 1, but its valid extent there is X, which is not provably 1. A broadcast singleton replicates its one cell across the whole output dimension, so that cell must be valid` |
| `part_*` operands with no provable ordering on some dimension | `<op>: the operand valid regions (...) have no provably widest extent on dimension <n>, so their union cannot be expressed as a valid_shape...` |
| `part_*` operands not ordered by containment | `<op>: the operand valid regions (...) are not ordered by containment, so their union [...] is not an origin-anchored rectangle and would claim cells that are valid in no operand. Narrow one operand so that one region contains the other` |

Undecided symbolic equality rejects deliberately: no runtime guard is emitted, so
taking an unproved relation on trust would silently widen or narrow the region.

## Operand audit

Scratch and predicate operands are excluded from value-validity agreement:

| Deducer | Value operands | Excluded |
| ------- | -------------- | -------- |
| binary (add/sub/mul/div/max/min/fmod/and/or, **part_\***) | 0, 1 | — |
| shift (shl/shr) | 0, 1 — the shift tile is read per element | — |
| ternary (rem/xor/prelu) | 0, 1 | 2 = tmp scratch |
| tri-tile (addc/subc) | 0, 1, 2 | — |
| tile-scalar-tile | **rems**: 0 · **addsc/subsc**: 0, 2 | rems arg 2 = tmp |
| sel | 1, 2 | 0 = packed mask, 3 = TSEL scratch |
| sels | 0, 1 | 2 = scalar mode |
| cmp / cmps | 0, 1 / 0 | result is a packed mask |
| row_expand\* / col_expand\* | 0, 1 | — |
| tensor binary + **part_\*** | 0, 1 | — |
| tensor scalar-binary | 0 | scalar |

Two consequences worth calling out:

- `DeduceTileOpTileScalarTileType` served both `tile.rems` (arg 2 = **scratch**)
  and `tile.addsc`/`subsc` (arg 2 = **real addend**). It gained a
  `third_is_addend` flag; without it a scratch buffer would be held to agreement.
- `MakePackedPredicateTileType` now bit-packs the *agreed* logical region rather
  than reading lhs directly, so mask validity follows the same rule as value
  validity.

## Deviations from the brief

- **`fractal` is derived, not inherited.** The brief says "inherit production
  layout/fractal". `InheritTileViewLayout` has never copied `fractal`, and adding
  it would change unary/gather/sort too — outside this brief's inherited scope.
  The derive-from-output-shape branch yields the `TileView` default (512), which
  is correct for these Vec-space ops.
- **Tensor scalar-binary validity is in this PR rather than split out.** It is a
  validity-semantics change and is what makes the brief's acceptance criterion
  "tensor and tile operations follow the same validity rule" hold.

## A pre-existing bug this surfaces

A partially-valid `[M, 1]` column-broadcast add now **fails to compile**.
Measured on both sides of the change:

```python
at = pl.load(a, [0, 0], [128, 128], valid_shapes=[40, 64])
bt = pl.load(b, [0, 0], [128, 1],   valid_shapes=[40, 1])
r  = pl.add(bt, at)
```

| | result |
| - | ------ |
| before | compiles; `tile.add` result carries `pl.TileView(valid_shape=[1, 128])` — 1 row x 128 cols, when the real data is 40 x 64. The store writes the wrong region. |
| after | rejected: `tile.add: operands lhs and rhs do not provably agree on the valid extent of dimension 1 (lhs: 128, rhs: 64)` |

The old output was **silently wrong**, so the loud failure is strictly better.
Root cause is `ResolveBackendOpLayouts`' column-vector repair
(`src/ir/transforms/resolve_backend_op_layouts_pass.cpp:188-204`), which reshapes
`[M,1] -> [1,M]` and naively transposes `valid_shape` instead of mapping it onto
the broadcast axis it actually occupies. That is layout-repair territory, not
elementwise deduction — the deducers only ever see the already-reshaped operand.
The row-broadcast `[1,N]` form and all fully-valid broadcasts are unaffected.

## Test-scaffolding change

Two cases in `test_convert_tensor_to_tile_ops.py` added a narrowed slice to a
**fully-valid** gm input — programs that would trip `PTO_ASSERT` on device. The
`add` there is scaffolding; the subject is `tensor.slice -> tile.slice` preserving
`valid_shape` / `pad_value`. The gm operand is now narrowed to match, and its load
carries that valid shape. No assertion was weakened.

## Testing

- 46 new tests across `tests/ut/ir/operators/{test_tile_ops,test_tensor_ops}.py`:
  matching partials, static and symbolic disagreement, symbolic agreement,
  singleton full/empty/unknown validity, lower-rank and mutually broadcasting
  shapes, operand order, every tile multi-operand family (binary, shift, ternary,
  tri-tile, tile-scalar-tile, sel, sels, cmp), mask validity, `part_*` union and
  its rejections, and fresh-result metadata (no alias, stride, offset or pad).
- Full unit suite: **7814 passed, 2 skipped**.
- `tests/st/codegen` + `tests/st/examples`: no new failures against the
  pre-change baseline.
- `pre-commit` and the diff-based `clang-tidy` gate are clean.

User-facing English and Chinese documentation is deferred to the series'
documentation PR, per the series rules.

---

## ⚠️ Open question: two device jobs fail, one root cause

`dist-system-tests` and `pypto-lib-model` both fail, and both reduce to the same
pattern — **a statically-full operand combined with a symbolically-narrowed one**:

```text
tests/st/distributed/collectives/test_l3_reduce_scatter.py:116
  acc  = pl.load(scratch, [0, my_rank*SIZE], [1, SIZE])   # valid [1, 64]
  recv = pld.tile.remote_load(...)                        # valid [1, min(max(STAGED - rank*64, 0), 64)]
  pl.add(acc, recv)   -> rejected: 64 vs the clamp is not provable

pypto-lib models/qwen3/14b/prefill_fwd.py:1085
  out_proj_chunk = pl.slice(out_proj_tile, ...)                       # valid [64, ...]
  resid_chunk    = pl.slice(hidden_states, ..., valid_shape=[valid_tok, ...])
  pl.add(out_proj_chunk, resid_chunk)  -> rejected: 64 vs valid_tok is not provable
```

Both are real, currently-passing programs (Qwen3-14B **decode** still passes on
device with this branch; only prefill trips).

**What the hardware actually does.** `PTO_ASSERT` is compiled out unless `_DEBUG`
(`pto/common/debug.h:33-36`), and the release kernel bounds its loops by **`dst`**'s
extents while reading the sources by row-stride offset
(`npu/a2a3/TAdd.hpp:37-51`, `TADD_IMPL` passing `dst.GetValidRow()/GetValidCol()`).
So the enforced release contract is not equality but

```text
dst.valid <= every src.valid          (else the op reads that source's padding)
```

with the `_DEBUG` equality assert acting as a stricter "you should have narrowed
already" check.

That makes all three candidate rules comparable:

| rule | Qwen prefill | sound on release path? |
| ---- | ------------ | ---------------------- |
| old (`dst = lhs.valid`) | compiles | **no** — reads the residual's padding rows for rows >= `valid_tok` |
| this PR (provable equality, unknown rejects) | **rejected** | yes |
| intersection (`dst = min(...)`) | compiles | yes — `min(64, valid_tok) <= both` |

Intersection accepts both programs *and* is sound, which suggests the brief's
"provably equal / unknown rejects" wording may be the wrong rule. Changing it is a
core-semantics decision beyond what this PR should take unilaterally, so I have
left the brief's rule implemented as specified and am flagging it for a call.
