### PR TITLE
feat(distributed): add multicore HOST AllReduce

### DIFF
--- a/docs/en/dev/distributed_ops.md
+++ b/docs/en/dev/distributed_ops.md
@@ -379,8 +379,8 @@ per-`MAX_RECV` variant mangling. Not supported inside a `for`/`while` loop in
 ### `pld.tensor.allreduce`
 
 ```text
-pld.tensor.allreduce(src, *, op: ReduceOp = ReduceOp.Sum, mode: str = "mesh") -> DistributedTensorType(src)
-pld.tensor.allreduce(src, signal, *, op: ReduceOp = ReduceOp.Sum, mode: str = "mesh") -> DistributedTensorType(src)
+pld.tensor.allreduce(src, *, op: ReduceOp = ReduceOp.Sum, mode: str = "mesh", core_num: int = 1) -> DistributedTensorType(src)
+pld.tensor.allreduce(src, signal, *, op: ReduceOp = ReduceOp.Sum, mode: str = "mesh", core_num: int = 1) -> DistributedTensorType(src)
 ```
 
 Reduces every participating rank's window-bound `src` slice in place and returns
@@ -436,7 +436,8 @@ dynamic physical target dimension is bound from that tensor parameter.
 
 Host-orchestrator user code may omit `signal` outside `for` and `while` loops;
 the [`SynthesizeAllReduceSignals`](passes/40-synthesize_allreduce_signals.md)
-pass inserts a private INT32 signal window with semantic shape `[world_size, 1]`
+pass inserts a private INT32 signal window with semantic shape
+`[world_size, core_num]`
 for that call (mesh mode only — `mode="ring"` requires an explicit signal). The
 pass binds `world_size = pld.world_size()` as a standalone statement and uses
 that variable in the synthesized buffer size and window shape. The
@@ -451,11 +452,59 @@ with `ReduceOp.Sum`, `Max`, `Min`, and `Prod` for arbitrary positive element
 counts. InCore lowering uses UB-bounded chunks; the host builtin uses
 256-element chunks. InCore mesh and ring round only the physical FP16 remote
 tail span to 32 bytes. The host builtin rounds ragged FP16 and FP32 load spans
-to 32 bytes. Both preserve the logical valid shape. The host builtin accepts either a
-rank-1 `[world_size]` signal or the synthesized rank-2 `[world_size, 1]`
-signal. Ring mode (`mode="ring"`) for the host orchestrator lowers to
-`builtin.tensor.allreduce_ring` and requires an explicit rank-2
-`[2 * (NR - 1) + 1, NR]` INT32 signal (one extra row for the return barrier).
+to 32 bytes. Both preserve the logical valid shape. The host builtin accepts
+either a rank-1 `[world_size]` signal or a rank-2
+`[world_size, signal_stride]` signal. Ring mode (`mode="ring"`) for the host
+orchestrator lowers to `builtin.tensor.allreduce_ring` and requires an explicit
+rank-2 `[2 * (NR - 1) + 1, NR]` INT32 signal (one extra row for the return
+barrier).
+
+#### Host multi-core AllReduce (`core_num`)
+
+`core_num` selects how many AIV blocks one HOST `pld.tensor.allreduce` dispatch
+uses **on each rank**. It does not change the task hierarchy: `device=r` still
+selects the card and the call still lowers to one builtin orchestration task per
+rank; that task now launches a synchronized SPMD grid of `core_num` blocks.
+
+```python
+data = pld.tensor.allreduce(data, signal, op=pld.ReduceOp.Sum, core_num=4)
+```
+
+| Constraint | Rule |
+| ---------- | ---- |
+| Range | Positive compile-time integer, default `1` (pre-existing behavior) |
+| Schedule | Mesh only — `mode="ring"` requires `core_num == 1` |
+| Capacity | At most the backend's AIV core count (submitted via `rt_submit_aiv_task`, so one block = one AIV core) |
+| InCore | Must stay `1`; use an enclosing `pl.spmd(...)` for multi-core work |
+
+**Signal layout.** The signal is a peer-major, lane-contiguous
+`[world_size, signal_stride]` matrix with `signal_stride >= core_num`. Block `b`
+waits on `signal_base + peer * signal_stride + b` and notifies peer `p` at
+`signal_base + my_rank * signal_stride + b`, so every `(peer, block)` pair owns
+an independent counter. A rank-1 `[world_size]` signal (stride 1) is valid only
+for `core_num == 1`. A synthesized signal is exactly `[world_size, core_num]`;
+an explicit signal may be wider.
+
+**Kernel partitioning.** Blocks own 256-element tiles block-cyclically — block
+`b` processes tiles `b, b + C, b + 2C, ...` for `C` launched blocks — so no two
+blocks touch the same chunk. Each block runs the ready barrier once, then a
+read-done barrier per chunk. That per-chunk barrier must stay **before** the
+store: without it a rank could overwrite its source chunk before the matching
+block on another rank has remote-loaded it. Blocks with no data still run the
+ready barrier, keeping ranks symmetric and letting `core_num` exceed the chunk
+count. Blocks at or beyond `signal_stride` have no lane to own, so they retire
+immediately without joining the barrier; `signal_stride` is equal on every rank,
+so all ranks retire the same blocks and the protocol stays symmetric.
+
+**Why one SPMD grid rather than `pl.parallel`.** `pl.parallel(N)` emits `N`
+independent tasks, each with its own TaskId and scheduling lifetime — unsafe for
+an in-place collective. Ranks may schedule chunk tasks in different orders, so a
+task waiting on another rank's matching chunk can deadlock, and conservative
+dependency tracking on the shared InOut window tends to serialize them anyway.
+One SPMD grid avoids both: `require_sync_start` admits all blocks together and
+`block_idx` gives deterministic, matching partitioning on every rank. That is a
+per-card admission guarantee, not a global simultaneous start across ranks — the
+ready barrier absorbs cross-rank launch skew.
 
 ### `pld.system.notify` (TNOTIFY)
 

--- a/docs/en/dev/passes/40-synthesize_allreduce_signals.md
+++ b/docs/en/dev/passes/40-synthesize_allreduce_signals.md
@@ -42,18 +42,18 @@ For every host-orchestration function:
 
 ```python
 __allreduce_signal_world_size_0 = pld.system.world_size()
-__allreduce_signal_buf_0: pl.Ptr = pld.tensor.alloc_window_buffer(__allreduce_signal_world_size_0 * pl.INT32.get_byte())
+__allreduce_signal_buf_0: pl.Ptr = pld.tensor.alloc_window_buffer(__allreduce_signal_world_size_0 * core_num * pl.INT32.get_byte())
 __allreduce_signal_0 = pld.tensor.window(
     __allreduce_signal_buf_0,
-    [__allreduce_signal_world_size_0, 1],
+    [__allreduce_signal_world_size_0, core_num],
     dtype=pl.INT32,
 )
 data = pld.tensor.allreduce(data, __allreduce_signal_0, op=pld.ReduceOp.Sum)
 ```
 
-The generated signal shape is rank-2 `[world_size, 1]`. This matches the InCore
-allreduce signal indexing model and gives host lowering a single canonical
-signal representation.
+The generated signal shape is rank-2 `[world_size, core_num]`, and its byte
+allocation uses the same lane count. The default `core_num=1` preserves the
+previous representation and behavior.
 
 ## Print / Parse Round Trip
 

--- a/docs/en/dev/passes/42-lower_host_tensor_collectives.md
+++ b/docs/en/dev/passes/42-lower_host_tensor_collectives.md
@@ -29,6 +29,7 @@ For a host-orchestrator call:
 
 ```python
 data = pld.tensor.allreduce(data, signal, op=pld.ReduceOp.Sum)
+data = pld.tensor.allreduce(data, signal, op=pld.ReduceOp.Sum, core_num=4)
 data = pld.tensor.allreduce(data, signal, op=pld.ReduceOp.Sum, mode="ring")
 signal = pld.tensor.barrier(signal)
 data = pld.tensor.broadcast(data, signal, root=0)
@@ -69,12 +70,12 @@ pld.system.world_size()` loop.
 
 Each generated builtin call carries the collective-specific args and kwarg
 attributes from the source `pld.tensor.*` call.  Window-bound INOUT tensors
-are threaded through as-is; scalar kwarg values (`op`, `root`, `dtype`) are
-forwarded to the builtin. `all_to_all_v`'s `MAX_RECV` is not a lowering-time
-attribute: the HOST kernel derives it at entry as `target.shape[0] / nranks`
-(the runtime comm-domain size), so no per-`MAX_RECV` codegen variant mangling
-is needed and the block layout stays consistent with the devices actually
-running.
+are threaded through as-is; scalar kwarg values (`op`, `root`, `dtype`, and
+mesh-AllReduce `core_num`) are forwarded to the builtin. `all_to_all_v`'s
+`MAX_RECV` is not a lowering-time attribute: the HOST kernel derives it at
+entry as `target.shape[0] / nranks` (the runtime comm-domain size), so no
+per-`MAX_RECV` codegen variant mangling is needed and the block layout stays
+consistent with the devices actually running.
 
 Assignments preserve the user-facing rebind idiom by appending
 `<result> = <original expr>` after the generated builtin calls.
@@ -87,8 +88,22 @@ the same `CommDomainScopeStmt`. The host allreduce builtin supports
 positive element counts. It processes 256-element chunks and rounds ragged FP16
 and FP32 load spans to 32 bytes without changing the logical tensor shape.
 Its INT32 signal tensor may be rank-1 `[world_size]` or rank-2
-`[world_size, 1]`, with enough static capacity when the participating device
-count is statically known. Ring allreduce (`mode="ring"`) uses a rank-2 signal shaped
+`[world_size, signal_stride]`, with enough static capacity when the
+participating device count is statically known. Because the signal is produced
+by `pld.window`, it is packed by construction and the builtin indexes it as a
+flat row-major array.
+
+Mesh allreduce takes one signal lane per launched AIV block: a rank-1 signal is
+valid only when `core_num == 1`, and a rank-2 signal needs a constant
+`signal_stride >= core_num` (a wider stride is accepted, so an explicit signal
+may carry spare lanes). `core_num` must also fit the configured backend's AIV
+core count — the builtin is submitted as a standalone AIV kernel with
+`require_sync_start`, so an over-subscribed launch could never be admitted and
+would hang instead of failing. The bound is skipped when no backend is
+configured (pure-IR tests). Multicore is mesh-only: `mode="ring"` requires
+`core_num == 1`.
+
+Ring allreduce (`mode="ring"`) uses a rank-2 signal shaped
 `[2 * (NR - 1) + 1, NR]`, whose `shape[0]` must equal `2 * (NR - 1) + 1` when both
 signal dimensions are compile-time constants, and must be at least
 `2 * (NR - 1) + 1` when only `shape[0]` is statically known (no static check when

--- a/docs/en/user/distributed/01-collectives.md
+++ b/docs/en/user/distributed/01-collectives.md
@@ -23,12 +23,15 @@ data = pld.tensor.allreduce(data, op=pld.ReduceOp.Sum)  # mesh mode, in-place
 # InCore kernel — explicit signal.
 data = pld.tensor.allreduce(data, signal, op=pld.ReduceOp.Sum, mode="mesh")
 data = pld.tensor.allreduce(data, signal, op=pld.ReduceOp.Sum, mode="ring")
+
+# Host orchestrator — spread one call across 4 AIV cores per rank.
+data = pld.tensor.allreduce(data, op=pld.ReduceOp.Sum, core_num=4)
 ```
 
 ### Mesh Mode
 
 - O(N) remote traffic per step — every rank reads every peer
-- One global barrier per call (AtomicAdd/Ge on `[NR, 1]` signal)
+- One global barrier per call (AtomicAdd/Ge on `[NR, core_num]` signal)
 - Works with `pl.dynamic("NR")`
 - Best for small messages and low latency
 
@@ -51,14 +54,36 @@ data = pld.tensor.allreduce(data, signal, op=pld.ReduceOp.Sum, mode="ring")
 | ------ | ---- | ---- |
 | Remote traffic per step | O(N) — every rank reads every peer | O(N/P) — each rank reads one neighbour |
 | Barrier rounds | 1 (global AtomicAdd/Ge) | 2(P-1) — reduce-scatter + allgather phases |
-| Signal shape | `[NR, 1]` | `[2 × (NR − 1), NR]` |
+| Signal shape | `[NR, core_num]` | `[2 × (NR − 1), NR]` |
 | Best for | Small messages, low latency | Large messages, high bandwidth |
 
 **Rule of thumb:** Use the default `mode="mesh"`. Switch to `mode="ring"` when
 your payload exceeds ~16 KiB and you see mesh bandwidth plateau.
 
 The host orchestrator form (`signal` omitted) is syntactic sugar — the compiler
-synthesizes a signal of `[world_size(), 1]` (mesh only).
+synthesizes a signal of `[world_size(), core_num]` (mesh only).
+
+### Multi-core (`core_num`)
+
+On a host orchestrator, `core_num` spreads one AllReduce call across several
+AIV cores **on each rank**. It does not change the task hierarchy: `device=r`
+still selects the card; that rank's builtin task now launches a synchronized
+grid of `core_num` blocks that split the payload into 256-element tiles
+block-cyclically.
+
+```python
+data = pld.tensor.allreduce(data, op=pld.ReduceOp.Sum, core_num=4)
+```
+
+- Defaults to `1` (single block — the previous behaviour).
+- Mesh only: `mode="ring"` requires `core_num == 1`.
+- Must not exceed the target's AIV core count (48 on 910B, 36 on 950) — the
+  launch requires all blocks to be admitted at once, so an over-subscribed
+  request is rejected at compile time.
+- An explicit `signal` needs one lane per block: `[world_size(), stride]` with
+  `stride >= core_num`. A rank-1 `[world_size()]` signal only works for
+  `core_num=1`.
+- InCore kernels keep `core_num=1` and use an enclosing `pl.spmd(...)` instead.
 
 ### Mutation
 

--- a/docs/zh/dev/distributed_ops.md
+++ b/docs/zh/dev/distributed_ops.md
@@ -331,8 +331,8 @@ variant 混入。不支持在 `host_orch` 的 `for`/`while` 循环内调用（�
 ### `pld.tensor.allreduce`
 
 ```text
-pld.tensor.allreduce(src, *, op: ReduceOp = ReduceOp.Sum, mode: str = "mesh") -> DistributedTensorType(src)
-pld.tensor.allreduce(src, signal, *, op: ReduceOp = ReduceOp.Sum, mode: str = "mesh") -> DistributedTensorType(src)
+pld.tensor.allreduce(src, *, op: ReduceOp = ReduceOp.Sum, mode: str = "mesh", core_num: int = 1) -> DistributedTensorType(src)
+pld.tensor.allreduce(src, signal, *, op: ReduceOp = ReduceOp.Sum, mode: str = "mesh", core_num: int = 1) -> DistributedTensorType(src)
 ```
 
 完全有效的 packed mesh 目标会被视为一个逻辑 `[1, N]` 线性流，并按最大
@@ -377,7 +377,7 @@ chunk，Pass 会保留该元数据，并沿用单矩形路径只归约这个矩�
 host-orchestrator 用户代码可以省略 `signal`，包括在 `for` / `while`
 循环内；
 [`SynthesizeAllReduceSignals`](passes/40-synthesize_allreduce_signals.md) 阶段会为该 call 插入 private INT32 signal window，
-语义 shape 为 `[world_size, 1]`（仅 mesh 模式 — `mode="ring"` 必须显式传入
+语义 shape 为 `[world_size, core_num]`（仅 mesh 模式 — `mode="ring"` 必须显式传入
 signal）。该阶段会先插入 standalone `world_size = pld.world_size()` binding，
 再用该变量构造 buffer size 和 window shape。自清理协议（参见
 [屏障-信号协议](#屏障-信号协议)）使每次调用都是无状态循环，
@@ -390,9 +390,53 @@ host builtin 路径均支持 FP16、FP32，以及任意正元素数量下的
 分块，host builtin 使用 256 元素分块。InCore mesh 和 ring 只把 FP16 remote
 尾块的物理范围向上对齐到 32 字节；host builtin 会把 FP16 和 FP32 的 ragged load
 范围都对齐到 32 字节。两者都保留逻辑 valid shape。host builtin 接受 rank-1
-`[world_size]` 或合成的 rank-2 `[world_size, 1]` signal。Ring 模式
+`[world_size]` 或 rank-2 `[world_size, signal_stride]` signal。Ring 模式
 （`mode="ring"`）在 host orchestrator 中降级为 `builtin.tensor.allreduce_ring`，
 要求显式 rank-2 `[2 * (NR - 1) + 1, NR]` INT32 signal（额外增加一行用于返回屏障）。
+
+#### HOST 多核 AllReduce（`core_num`）
+
+`core_num` 表示**每个 rank** 上一次 HOST `pld.tensor.allreduce` 分发使用多少个
+AIV block。它不改变任务层级：`device=r` 仍然选择卡，调用仍然为每个 rank 降级为
+一个 builtin orchestration task，只是该 task 现在启动一个包含 `core_num` 个
+block 的同步 SPMD grid。
+
+```python
+data = pld.tensor.allreduce(data, signal, op=pld.ReduceOp.Sum, core_num=4)
+```
+
+| 约束 | 规则 |
+| ---- | ---- |
+| 取值 | 编译期正整数，默认 `1`（与既有行为一致） |
+| 调度 | 仅 mesh —— `mode="ring"` 要求 `core_num == 1` |
+| 容量 | 不超过 backend 的 AIV 核数（经 `rt_submit_aiv_task` 提交，一个 block 对应一个 AIV 核） |
+| InCore | 必须保持 `1`，多核应使用外层 `pl.spmd(...)` |
+
+**Signal 布局。** signal 是 peer-major、lane 连续的
+`[world_size, signal_stride]` 矩阵，且 `signal_stride >= core_num`。block `b` 在
+`signal_base + peer * signal_stride + b` 上等待，并在
+`signal_base + my_rank * signal_stride + b` 上通知 peer `p`，因此每个
+`(peer, block)` 组合拥有一个独立计数器。rank-1 `[world_size]` signal（stride 为
+1）仅在 `core_num == 1` 时有效。自动合成的 signal 恰好是
+`[world_size, core_num]`；显式 signal 可以更宽。
+
+**Kernel 切分。** block 以 block-cyclic 方式拥有 256 元素 tile：block `b` 处理
+tile `b, b + C, b + 2C, ...`（`C` 为启动的 block 数），因此任意两个 block 不会
+触碰同一个 chunk。每个 block 执行一次 ready barrier，然后每个 chunk 执行一次
+read-done barrier。该 per-chunk barrier 必须保持在 store **之前**：否则某个 rank
+可能在另一个 rank 上对应的 block 完成 remote load 之前就覆盖了自己的源 chunk。
+没有数据的 block 仍会执行 ready barrier，从而保持跨 rank 对称，也允许
+`core_num` 超过 chunk 数量。索引达到或超过 `signal_stride` 的 block 没有可用
+lane，会直接退出而不参与 barrier；由于各 rank 的 `signal_stride` 一致，所有 rank
+退出的是同一批 block，协议依然对称。
+
+**为什么用一个 SPMD grid 而不是 `pl.parallel`。** `pl.parallel(N)` 会产生 `N`
+个独立 task，每个都有自己的 TaskId 和调度生命周期，对这种原地集合通信并不安全：
+不同 rank 可能以不同顺序调度 chunk task，因此等待另一 rank 对应 chunk 的 task
+可能死锁；而且共享 InOut window 上保守的依赖分析往往会把它们串行化。单个 SPMD
+grid 避免了这两个问题 —— `require_sync_start` 让所有 block 一起准入，
+`block_idx` 在每个 rank 上给出确定且互相匹配的划分。它是单卡准入保证而非跨 rank
+的全局同时启动；跨 rank 的启动偏差由 ready barrier 吸收。
 
 ### `pld.system.notify`（TNOTIFY）
 

--- a/docs/zh/dev/passes/40-synthesize_allreduce_signals.md
+++ b/docs/zh/dev/passes/40-synthesize_allreduce_signals.md
@@ -38,17 +38,17 @@ allocation 处理，并放入 allreduce data buffer 所属的通信域。
 
 ```python
 __allreduce_signal_world_size_0 = pld.system.world_size()
-__allreduce_signal_buf_0: pl.Ptr = pld.tensor.alloc_window_buffer(__allreduce_signal_world_size_0 * pl.INT32.get_byte())
+__allreduce_signal_buf_0: pl.Ptr = pld.tensor.alloc_window_buffer(__allreduce_signal_world_size_0 * core_num * pl.INT32.get_byte())
 __allreduce_signal_0 = pld.tensor.window(
     __allreduce_signal_buf_0,
-    [__allreduce_signal_world_size_0, 1],
+    [__allreduce_signal_world_size_0, core_num],
     dtype=pl.INT32,
 )
 data = pld.tensor.allreduce(data, __allreduce_signal_0, op=pld.ReduceOp.Sum)
 ```
 
-合成 signal 使用 rank-2 `[world_size, 1]`。这个形态与 InCore allreduce 的
-signal 索引模型一致，也让 host lowering 面向同一种 canonical signal 表示。
+合成 signal 使用 rank-2 `[world_size, core_num]`，buffer 字节数也使用相同的
+lane 数。默认 `core_num=1`，因此保留原有表示和行为。
 
 ## Print / Parse Round Trip
 

--- a/docs/zh/dev/passes/42-lower_host_tensor_collectives.md
+++ b/docs/zh/dev/passes/42-lower_host_tensor_collectives.md
@@ -28,6 +28,7 @@ builtin chip dispatch。它在 [`MaterializeCommDomainScopes`](41-materialize_co
 
 ```python
 data = pld.tensor.allreduce(data, signal, op=pld.ReduceOp.Sum)
+data = pld.tensor.allreduce(data, signal, op=pld.ReduceOp.Sum, core_num=4)
 data = pld.tensor.allreduce(data, signal, op=pld.ReduceOp.Sum, mode="ring")
 signal = pld.tensor.barrier(signal)
 data = pld.tensor.broadcast(data, signal, root=0)
@@ -63,10 +64,10 @@ comm-domain scope 带有显式 device 列表，则生成 `SeqStmts`；否则生�
 
 每个生成的 builtin call 携带来源 `pld.tensor.*` 调用中 collective 特定的
 参数和 kwarg 属性。窗口绑定的 INOUT tensor 原样传递；标量 kwarg 值
-（`op`、`root`、`dtype`）转发给 builtin。`all_to_all_v` 的 `MAX_RECV` 不是
-lowering 时的属性：HOST 内核在入口把它推导为 `target.shape[0] / nranks`
-（运行时通信域大小），因此不再需要按 `MAX_RECV` 进行代码生成的 variant
-混入，块布局也始终与实际运行的设备数一致。
+（`op`、`root`、`dtype`，以及 mesh AllReduce 的 `core_num`）转发给 builtin。
+`all_to_all_v` 的 `MAX_RECV` 不是 lowering 时的属性：HOST 内核在入口把它推导为
+`target.shape[0] / nranks`（运行时通信域大小），因此不再需要按 `MAX_RECV`
+进行代码生成的 variant 混入，块布局也始终与实际运行的设备数一致。
 
 若用户代码使用赋值形式，pass 会在生成的 builtin 调用之后追加
 `<result> = <original expr>`，保留 public API 的 rebind 语义。
@@ -78,7 +79,19 @@ lowering 时的属性：HOST 内核在入口把它推导为 `target.shape[0] / n
 `ReduceOp.Sum`、`Max`、`Min` 和 `Prod`，并支持任意正元素数量。它按 256 个
 元素分块，并把 FP16 和 FP32 的 ragged load 范围都对齐到 32 字节，不改变逻辑 tensor shape。
 signal 必须是 INT32 tensor，形状可以是 rank-1 `[world_size]` 或 rank-2
-`[world_size, 1]`；当参与设备数静态可知时，signal 的静态容量必须足够。Ring allreduce（`mode="ring"`）
+`[world_size, signal_stride]`；当参与设备数静态可知时，signal 的静态容量必须足够。
+由于 signal 由 `pld.window` 产生，它天然是 packed 的，builtin 按扁平 row-major
+数组索引它。
+
+mesh allreduce 为每个启动的 AIV block 分配一条 signal lane：rank-1 signal 仅在
+`core_num == 1` 时有效；rank-2 signal 要求第二维是常量且
+`signal_stride >= core_num`（允许更宽的 stride，因此显式 signal 可以带有多余
+lane）。`core_num` 还必须不超过所配置 backend 的 AIV 核数——该 builtin 以
+standalone AIV kernel 提交并设置了 `require_sync_start`，超额的 launch 永远无法
+被准入，表现为挂死而非报错。未配置 backend 时（纯 IR 测试）跳过该检查。
+多核仅支持 mesh：`mode="ring"` 要求 `core_num == 1`。
+
+Ring allreduce（`mode="ring"`）
 的 signal 为 rank-2，形状为 `[2 * (NR - 1) + 1, NR]`，其
 `shape[0]` 在 signal 两个维度均为编译期常量时必须恰好等于 `2 * (NR - 1) + 1`；仅
 `shape[0]` 静态可知时则至少为 `2 * (NR - 1) + 1`（两个维度均为动态时无静态检查）。

--- a/docs/zh/user/distributed/01-collectives.md
+++ b/docs/zh/user/distributed/01-collectives.md
@@ -20,12 +20,15 @@ data = pld.tensor.allreduce(data, op=pld.ReduceOp.Sum)  # mesh 模式，就地
 # InCore kernel——显式 signal。
 data = pld.tensor.allreduce(data, signal, op=pld.ReduceOp.Sum, mode="mesh")
 data = pld.tensor.allreduce(data, signal, op=pld.ReduceOp.Sum, mode="ring")
+
+# Host 编排器——把一次调用分摊到每个 rank 的 4 个 AIV 核上。
+data = pld.tensor.allreduce(data, op=pld.ReduceOp.Sum, core_num=4)
 ```
 
 ### Mesh 模式
 
 - 每步 O(N) 远程流量——每个 rank 读取所有对端
-- 每次调用一个全局屏障（AtomicAdd/Ge 在 `[NR, 1]` signal 上）
+- 每次调用一个全局屏障（AtomicAdd/Ge 在 `[NR, core_num]` signal 上）
 - 支持 `pl.dynamic("NR")`
 - 最适合小消息和低延迟
 
@@ -46,14 +49,33 @@ data = pld.tensor.allreduce(data, signal, op=pld.ReduceOp.Sum, mode="ring")
 | ---- | ---- | ---- |
 | 每步远程流量 | O(N) | O(N/P) |
 | 屏障轮次 | 1 | 2(P-1) |
-| Signal 形状 | `[NR, 1]` | `[2 × (NR − 1), NR]` |
+| Signal 形状 | `[NR, core_num]` | `[2 × (NR − 1), NR]` |
 | 最适合 | 小消息，低延迟 | 大消息，高带宽 |
 
 **经验法则：** 默认使用 `mode="mesh"`。当负载超过约 16 KiB 且 mesh 带宽达到平台期时
 切换到 `mode="ring"`。
 
-Host 编排器形式（省略 `signal`）是语法糖——编译器合成 `[world_size(), 1]` 的
+Host 编排器形式（省略 `signal`）是语法糖——编译器合成 `[world_size(), core_num]` 的
 signal（仅限 mesh）。
+
+### 多核（`core_num`）
+
+在 host 编排器上，`core_num` 把一次 AllReduce 调用分摊到**每个 rank** 的多个
+AIV 核上。它不改变任务层级：`device=r` 仍然选择卡；该 rank 的 builtin task 现在
+启动一个包含 `core_num` 个 block 的同步 grid，以 block-cyclic 方式把负载切成
+256 元素的 tile。
+
+```python
+data = pld.tensor.allreduce(data, op=pld.ReduceOp.Sum, core_num=4)
+```
+
+- 默认为 `1`（单 block，即原有行为）。
+- 仅 mesh：`mode="ring"` 要求 `core_num == 1`。
+- 不得超过目标平台的 AIV 核数（910B 为 48，950 为 36）——该 launch 要求所有
+  block 同时准入，因此超额请求会在编译期被拒绝。
+- 显式 `signal` 需要每个 block 一条 lane：`[world_size(), stride]` 且
+  `stride >= core_num`。rank-1 的 `[world_size()]` signal 只适用于 `core_num=1`。
+- InCore kernel 保持 `core_num=1`，改用外层 `pl.spmd(...)`。
 
 ### 变更
 

--- a/python/pypto/ir/op/distributed/tensor_ops.py
+++ b/python/pypto/ir/op/distributed/tensor_ops.py
@@ -201,7 +201,14 @@ def get(
 
 
 @overload
-def allreduce(target: Expr, *, op: ReduceOp = ReduceOp.Sum, span: Span | None = None) -> Call: ...
+def allreduce(
+    target: Expr,
+    *,
+    op: ReduceOp = ReduceOp.Sum,
+    mode: str = "mesh",
+    core_num: int = 1,
+    span: Span | None = None,
+) -> Call: ...
 
 
 @overload
@@ -211,6 +218,7 @@ def allreduce(
     op: ReduceOp = ReduceOp.Sum,
     *,
     mode: str = "mesh",
+    core_num: int = 1,
     span: Span | None = None,
 ) -> Call: ...
 
@@ -221,6 +229,7 @@ def allreduce(
     op: ReduceOp = ReduceOp.Sum,
     *,
     mode: str = "mesh",
+    core_num: int = 1,
     span: Span | None = None,
 ) -> Call:
     """Build a ``pld.tensor.allreduce(target[, signal])`` Call.
@@ -249,6 +258,14 @@ def allreduce(
     type-metadata-only symbol is rejected during PTO codegen. A fully dynamic
     physical target dimension is bound from that tensor parameter.
     """
+    if not isinstance(core_num, int) or isinstance(core_num, bool):
+        raise TypeError(
+            "pld.tensor.allreduce core_num must be a positive compile-time int, "
+            f"got {type(core_num).__name__}"
+        )
+    if core_num <= 0:
+        raise ValueError(f"pld.tensor.allreduce core_num must be positive, got {core_num}")
+
     actual_span = _get_span_or_capture(span, frame_offset=1)
     if signal is _ALLREDUCE_SIGNAL_MISSING:
         args = [target]
@@ -260,7 +277,12 @@ def allreduce(
         args = [target, signal]
     else:
         raise TypeError(f"pld.tensor.allreduce signal must be an Expr, got {type(signal).__name__}")
-    return _ir_core.create_op_call("pld.tensor.allreduce", args, {"op": int(op), "mode": mode}, actual_span)
+    return _ir_core.create_op_call(
+        "pld.tensor.allreduce",
+        args,
+        {"op": int(op), "mode": mode, "core_num": core_num},
+        actual_span,
+    )
 
 
 def barrier(

--- a/python/pypto/language/distributed/op/tensor_ops.py
+++ b/python/pypto/language/distributed/op/tensor_ops.py
@@ -503,7 +503,11 @@ def get(
 
 @overload
 def allreduce(
-    target: DistributedTensor, *, op: ReduceOp = ReduceOp.Sum, mode: str = "mesh"
+    target: DistributedTensor,
+    *,
+    op: ReduceOp = ReduceOp.Sum,
+    mode: str = "mesh",
+    core_num: int = 1,
 ) -> DistributedTensor: ...
 
 
@@ -514,6 +518,7 @@ def allreduce(
     *,
     op: ReduceOp = ReduceOp.Sum,
     mode: str = "mesh",
+    core_num: int = 1,
 ) -> DistributedTensor: ...
 
 
@@ -523,6 +528,7 @@ def allreduce(
     *,
     op: ReduceOp = ReduceOp.Sum,
     mode: str = "mesh",
+    core_num: int = 1,
 ) -> DistributedTensor:
     """In-place cross-rank allreduce of a window-bound DistributedTensor.
 
@@ -630,7 +636,8 @@ def allreduce(
         signal: Optional window-bound INT32 :class:`pld.DistributedTensor`.
             In InCore code this remains required. In host-orchestrator code
             outside ``for`` / ``while`` loops, omitting it lets the compiler
-            synthesize a private signal of shape ``[pld.world_size(), 1]``.
+            synthesize a private signal of shape
+            ``[pld.world_size(), core_num]``.
         op: :class:`pld.ReduceOp` selecting element-wise ``Sum``, ``Max``,
             ``Min``, or ``Prod`` (keyword-only). Defaults to
             :attr:`pld.ReduceOp.Sum`.
@@ -640,13 +647,27 @@ def allreduce(
             requires an explicit ``signal`` — host signal synthesis is
             mesh-only, so omitting the signal with ``mode="ring"`` is
             rejected.
+        core_num: Number of AIV blocks used by a HOST AllReduce builtin
+            (keyword-only). Must be a positive compile-time Python integer and
+            may not exceed the configured backend's AIV core count. Defaults to
+            1. Multicore is ``mode="mesh"`` only — ``mode="ring"`` requires
+            ``core_num=1``. InCore calls must keep this value at 1 and use an
+            enclosing :func:`pl.spmd` for multi-core execution.
 
     Returns:
         The rebound :class:`pld.DistributedTensor` view of ``target`` —
         identical shape / dtype / window-buffer binding, post-reduce content.
     """
+    if not isinstance(core_num, int) or isinstance(core_num, bool):
+        raise TypeError(
+            "pld.tensor.allreduce core_num must be a positive compile-time int, "
+            f"got {type(core_num).__name__}"
+        )
+    if core_num <= 0:
+        raise ValueError(f"pld.tensor.allreduce core_num must be positive, got {core_num}")
+
     if signal is _ALLREDUCE_SIGNAL_MISSING:
-        # Host signal synthesis only produces a mesh-shaped [world_size, 1]
+        # Host signal synthesis produces a mesh-shaped [world_size, core_num]
         # signal. Ring mode needs a [2*(NR-1), NR] signal, so it must be
         # passed explicitly — reject the synthesized-signal path for it.
         if mode != "mesh":
@@ -656,7 +677,7 @@ def allreduce(
                 'signal, e.g. pld.tensor.allreduce(target, signal, mode="ring").'
             )
         (target_expr,) = _unwrap_distributed_tensors("pld.tensor.allreduce", target=target)
-        call = _ir_tensor.allreduce(target_expr, op=op)
+        call = _ir_tensor.allreduce(target_expr, op=op, core_num=core_num)
         return DistributedTensor(expr=call)
     if signal is None:
         raise TypeError(
@@ -666,7 +687,7 @@ def allreduce(
     target_expr, signal_expr = _unwrap_distributed_tensors(
         "pld.tensor.allreduce", target=target, signal=signal
     )
-    call = _ir_tensor.allreduce(target_expr, signal_expr, op, mode=mode)
+    call = _ir_tensor.allreduce(target_expr, signal_expr, op, mode=mode, core_num=core_num)
     return DistributedTensor(expr=call)
 
 

--- a/python/pypto/runtime/builtins/collectives/allreduce/templates/entry.cpp.in
+++ b/python/pypto/runtime/builtins/collectives/allreduce/templates/entry.cpp.in
@@ -34,6 +34,9 @@ void submit_allreduce_kernel(const L2TaskArgs &orch_args) {
   params.add_inout(signal);
   params.add_scalar(orch_args.scalar(0));  // nranks
   params.add_scalar(orch_args.scalar(1));  // CommContext device pointer
+  int32_t core_num = static_cast<int32_t>(orch_args.scalar(2));
+  params.launch_spec.{{launch_core_count_method}}(core_num);
+  params.launch_spec.set_require_sync_start(true);
   rt_submit_aiv_task(0, params);
 }
 
@@ -45,7 +48,7 @@ __attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestrati
     const L2TaskArgs &orch_args) {
   (void)orch_args;
   return PTO2OrchestrationConfig{
-      .expected_arg_count = 4,
+      .expected_arg_count = 5,
   };
 }
 

--- a/python/pypto/runtime/builtins/collectives/allreduce/templates/kernel.cpp.in
+++ b/python/pypto/runtime/builtins/collectives/allreduce/templates/kernel.cpp.in
@@ -27,6 +27,10 @@
 #define __aicore__ [aicore]
 #endif
 
+// Keep this after the qualifier fallbacks so hardware builds retain the
+// [aicore] entry annotation while using simpler's logical SPMD context.
+#include "intrinsic.h"
+
 namespace {
 
 static constexpr int64_t kTileCount = 256;
@@ -47,6 +51,8 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
   __gm__ Tensor *signal_tensor = reinterpret_cast<__gm__ Tensor *>(args[1]);
   int nranks = static_cast<int>(args[2]);
   __gm__ CommContext *comm_ctx = reinterpret_cast<__gm__ CommContext *>(args[3]);
+  int32_t block_idx = get_block_idx(args);
+  int32_t block_num = get_block_num(args);
 
   int64_t numel = 1;
   for (uint32_t dim = 0; dim < data_tensor->ndims; ++dim) {
@@ -58,22 +64,41 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
   __gm__ int32_t *signal_base =
       reinterpret_cast<__gm__ int32_t *>(signal_tensor->buffer.addr) + signal_tensor->start_offset;
 
-  if (nranks <= 0 || nranks > kMaxSupportedRanks || numel <= 0) {
+  if (nranks <= 0 || nranks > kMaxSupportedRanks || numel <= 0 || block_num <= 0 ||
+      block_idx < 0 || block_idx >= block_num) {
     pipe_barrier(PIPE_ALL);
     return;
   }
 
   int my_rank = static_cast<int>(comm_ctx->rankId);
+  int64_t signal_stride =
+      signal_tensor->ndims == 1 ? 1 : static_cast<int64_t>(signal_tensor->shapes[1]);
+
+  // Every signal lane is addressed as `peer * signal_stride + block_idx`, so a
+  // block index at or beyond `signal_stride` would run off the end of its own
+  // peer row and land in the next peer's counters. The communication window is
+  // legal writable memory, so that corruption is silent — it surfaces only as a
+  // premature release or a hang. Clamp the participating block count instead.
+  //
+  // `signal_stride` is identical on every rank, so taking the same minimum on
+  // each rank keeps the protocol symmetric and cannot introduce a deadlock.
+  int32_t active_blocks =
+      block_num < static_cast<int32_t>(signal_stride) ? block_num : static_cast<int32_t>(signal_stride);
+  if (block_idx >= active_blocks) {
+    pipe_barrier(PIPE_ALL);
+    return;
+  }
 
   for (int peer = 0; peer < nranks; ++peer) {
     if (peer == my_rank) continue;
-    __gm__ int32_t *remote_signal = CommRemotePtr(comm_ctx, signal_base + my_rank, peer);
+    __gm__ int32_t *remote_signal =
+        CommRemotePtr(comm_ctx, signal_base + my_rank * signal_stride + block_idx, peer);
     pto::comm::Signal sig(remote_signal);
     pto::comm::TNOTIFY(sig, static_cast<int32_t>(1), pto::comm::NotifyOp::AtomicAdd);
   }
   for (int peer = 0; peer < nranks; ++peer) {
     if (peer == my_rank) continue;
-    pto::comm::Signal sig(signal_base + peer);
+    pto::comm::Signal sig(signal_base + peer * signal_stride + block_idx);
     pto::comm::TWAIT(sig, static_cast<int32_t>(1), pto::comm::WaitCmp::GE);
   }
   pipe_barrier(PIPE_ALL);
@@ -89,7 +114,9 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
   TASSIGN(recv_tile, 0x10000);
 
   int32_t read_done_expected = 2;
-  for (int64_t base = 0; base < numel; base += kTileCount) {
+  for (int64_t base = static_cast<int64_t>(block_idx) * kTileCount;
+       base < numel;
+       base += static_cast<int64_t>(active_blocks) * kTileCount) {
     int64_t chunk64 = numel - base;
     if (chunk64 > kTileCount) chunk64 = kTileCount;
     int chunk = static_cast<int>(chunk64);
@@ -124,13 +151,14 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
 
     for (int peer = 0; peer < nranks; ++peer) {
       if (peer == my_rank) continue;
-      __gm__ int32_t *remote_signal = CommRemotePtr(comm_ctx, signal_base + my_rank, peer);
+      __gm__ int32_t *remote_signal =
+          CommRemotePtr(comm_ctx, signal_base + my_rank * signal_stride + block_idx, peer);
       pto::comm::Signal sig(remote_signal);
       pto::comm::TNOTIFY(sig, static_cast<int32_t>(1), pto::comm::NotifyOp::AtomicAdd);
     }
     for (int peer = 0; peer < nranks; ++peer) {
       if (peer == my_rank) continue;
-      pto::comm::Signal sig(signal_base + peer);
+      pto::comm::Signal sig(signal_base + peer * signal_stride + block_idx);
       pto::comm::TWAIT(sig, read_done_expected, pto::comm::WaitCmp::GE);
     }
     ++read_done_expected;

--- a/src/codegen/distributed/distributed_ops_codegen.cpp
+++ b/src/codegen/distributed/distributed_ops_codegen.cpp
@@ -16,8 +16,12 @@
 #include <set>
 #include <sstream>
 #include <string>
+#include <utility>
 #include <vector>
 
+#include "pypto/backend/common/backend.h"
+#include "pypto/backend/common/backend_config.h"
+#include "pypto/backend/common/backend_handler.h"
 #include "pypto/codegen/codegen_base.h"
 #include "pypto/codegen/distributed/distributed_codegen.h"
 #include "pypto/codegen/distributed/distributed_op_registry.h"
@@ -115,7 +119,8 @@ std::string ArgDirectionToTensorArgType(ir::ArgDirection dir) {
 }
 
 void EmitBuiltinWindowCollectiveDispatch(DistributedCodegen& codegen, const CallPtr& call,
-                                         const std::string& variant) {
+                                         const std::string& variant,
+                                         std::optional<int> core_num = std::nullopt) {
   INTERNAL_CHECK(call && call->op_)
       << "Internal error: builtin tensor collective dispatch needs a valid Call";
 
@@ -178,6 +183,9 @@ void EmitBuiltinWindowCollectiveDispatch(DistributedCodegen& codegen, const Call
 
   codegen.Emit(ta_var + ".add_scalar(" + *handle_var + "[" + rank_expr + "].domain_size)");
   codegen.Emit(ta_var + ".add_scalar(" + *handle_var + "[" + rank_expr + "].device_ctx)");
+  if (core_num.has_value()) {
+    codegen.Emit(ta_var + ".add_scalar(" + std::to_string(*core_num) + ")");
+  }
   codegen.Emit(cfg_var + " = CallConfig()");
   codegen.Emit(cfg_var + ".aicpu_thread_num = config.aicpu_thread_num");
   codegen.Emit("_keep.append(" + ta_var + ")");
@@ -223,33 +231,51 @@ REGISTER_DISTRIBUTED_OP(pld_tensor_window, "pld.tensor.window") {
 // builtin.tensor.allreduce: compiler-generated host collective chip dispatch.
 // ============================================================================
 
+/// Emit the chip dispatch shared by the mesh and ring host AllReduce builtins.
+///
+/// ``multicore`` is set only for the mesh builtin, which launches a synchronized
+/// SPMD AIV grid of ``core_num`` blocks. The ring builtin stays single-block, so
+/// it neither carries a ``core_num`` attr nor renders a launch-spec method.
+/// ``core_num`` itself is validated by ``LowerHostTensorCollectives`` — including
+/// the backend capacity bound — so codegen only forwards it.
 std::string EmitAllReduceLikeDispatch(DistributedCodegen& dist_codegen, const CallPtr& op,
-                                      bool include_reduce_inst) {
+                                      bool include_reduce_inst, bool multicore) {
   const int reduce_op = op->GetAttr<int>("op");
   const auto dtype = op->GetAttr<DataType>("dtype");
   const auto reduce_variant = GetAllReduceOpVariant(reduce_op);
   const auto dtype_variant = GetAllReduceDTypeVariant(dtype);
   const std::string variant = op->op_->name_ + "__" + reduce_variant.suffix + "__" + dtype_variant.suffix;
 
-  if (dist_codegen.MarkBuiltinEmitted(variant)) {
-    if (include_reduce_inst) {
-      dist_codegen.RecordBuiltinNextLevel(op, variant,
-                                          {{"op_cpp", reduce_variant.cpp},
-                                           {"reduce_inst", reduce_variant.instruction},
-                                           {"dtype_cpp", dtype_variant.cpp}});
-    } else {
-      dist_codegen.RecordBuiltinNextLevel(op, variant,
-                                          {{"op_cpp", reduce_variant.cpp}, {"dtype_cpp", dtype_variant.cpp}});
-    }
+  std::optional<int> core_num;
+  if (multicore) {
+    const int requested = op->GetAttr<int>("core_num");
+    INTERNAL_CHECK_SPAN(requested > 0, op->span_)
+        << "Internal error: builtin.tensor.allreduce core_num must be positive, got " << requested
+        << "; LowerHostTensorCollectives should have rejected it";
+    core_num = requested;
   }
-  EmitBuiltinWindowCollectiveDispatch(dist_codegen, op, variant);
+
+  if (dist_codegen.MarkBuiltinEmitted(variant)) {
+    std::map<std::string, std::string> template_vars{{"op_cpp", reduce_variant.cpp},
+                                                     {"dtype_cpp", dtype_variant.cpp}};
+    if (include_reduce_inst) {
+      template_vars["reduce_inst"] = reduce_variant.instruction;
+    }
+    if (multicore) {
+      template_vars["launch_core_count_method"] =
+          pypto::backend::GetBackend()->GetHandler()->GetLaunchSpecCoreCountMethod();
+    }
+    dist_codegen.RecordBuiltinNextLevel(op, variant, std::move(template_vars));
+  }
+  EmitBuiltinWindowCollectiveDispatch(dist_codegen, op, variant, core_num);
   return "";
 }
 
 REGISTER_DISTRIBUTED_OP(builtin_tensor_allreduce, "builtin.tensor.allreduce") {
   auto* dist_codegen = dynamic_cast<DistributedCodegen*>(&codegen);
   INTERNAL_CHECK(dist_codegen) << "builtin.tensor.allreduce codegen requires DistributedCodegen";
-  return EmitAllReduceLikeDispatch(*dist_codegen, op, /*include_reduce_inst=*/true);
+  return EmitAllReduceLikeDispatch(*dist_codegen, op, /*include_reduce_inst=*/true,
+                                   /*multicore=*/true);
 }
 
 // ============================================================================
@@ -258,7 +284,8 @@ REGISTER_DISTRIBUTED_OP(builtin_tensor_allreduce, "builtin.tensor.allreduce") {
 REGISTER_DISTRIBUTED_OP(builtin_tensor_allreduce_ring, "builtin.tensor.allreduce_ring") {
   auto* dist_codegen = dynamic_cast<DistributedCodegen*>(&codegen);
   INTERNAL_CHECK(dist_codegen) << "builtin.tensor.allreduce_ring codegen requires DistributedCodegen";
-  return EmitAllReduceLikeDispatch(*dist_codegen, op, /*include_reduce_inst=*/false);
+  return EmitAllReduceLikeDispatch(*dist_codegen, op, /*include_reduce_inst=*/false,
+                                   /*multicore=*/false);
 }
 
 // ============================================================================

--- a/src/ir/op/distributed/allreduce.cpp
+++ b/src/ir/op/distributed/allreduce.cpp
@@ -105,6 +105,9 @@ TypePtr DeduceTensorAllReduceType(const std::vector<ExprPtr>& args,
   CHECK(op_value >= static_cast<int>(ReduceOp::kSum) && op_value <= static_cast<int>(ReduceOp::kProd))
       << "pld.tensor.allreduce op must be ReduceOp.Sum, Max, Min, or Prod (got int " << op_value << ")";
 
+  auto core_num = GetRequiredKwarg<int>(kwargs, "core_num", "pld.tensor.allreduce");
+  CHECK(core_num > 0) << "pld.tensor.allreduce core_num must be positive, got " << core_num;
+
   // Result type: same DistributedTensorType as the input target (in-place
   // reduce — the same view holds the reduced value on every rank). Preserve
   // the window_buffer_ back-reference so downstream passes still see the
@@ -133,6 +136,7 @@ REGISTER_OP("pld.tensor.allreduce")
                   "Optional window-bound INT32 DistributedTensor used as cross-rank barrier (InOut)")
     .set_attr<int>("op")
     .set_attr<std::string>("mode")
+    .set_attr<int>("core_num")
     .no_memory_spec()
     .f_deduce_type(DeduceTensorAllReduceType);
 

--- a/src/ir/op/distributed/collective.cpp
+++ b/src/ir/op/distributed/collective.cpp
@@ -106,13 +106,18 @@ TypePtr DeduceBuiltinTensorAllReduceType(const std::vector<ExprPtr>& args,
   CHECK(signal_type->dtype_ == DataType::INT32)
       << kOpName << " signal dtype must be INT32, got " << signal_type->dtype_.ToString();
   CHECK(signal_type->shape_.size() == 1 || signal_type->shape_.size() == 2)
-      << kOpName << " signal must be rank-1 [world_size] or rank-2 [world_size, 1], got rank "
+      << kOpName << " signal must be rank-1 [world_size] or rank-2 [world_size, signal_stride], got rank "
       << signal_type->shape_.size();
+  auto core_num = GetRequiredKwarg<int>(kwargs, "core_num", kOpName);
+  CHECK(core_num > 0) << kOpName << " core_num must be positive, got " << core_num;
+  CHECK(signal_type->shape_.size() == 2 || core_num == 1)
+      << kOpName << " rank-1 signal is valid only when core_num=1, got core_num=" << core_num;
   if (signal_type->shape_.size() == 2) {
     auto second_extent = As<ConstInt>(signal_type->shape_[1]);
-    CHECK(second_extent) << kOpName << " rank-2 signal shape[1] must be the constant 1";
-    CHECK(second_extent->value_ == 1)
-        << kOpName << " rank-2 signal shape[1] must be 1, got " << second_extent->value_;
+    CHECK(second_extent) << kOpName << " rank-2 signal shape[1] must be a compile-time constant";
+    CHECK(second_extent->value_ >= core_num)
+        << kOpName << " rank-2 signal shape[1] (" << second_extent->value_ << ") must be at least core_num ("
+        << core_num << ")";
   }
 
   auto op_value = GetRequiredKwarg<int>(kwargs, "op", kOpName);
@@ -199,6 +204,7 @@ REGISTER_OP("builtin.tensor.allreduce")
     .add_argument("signal", "Window-bound INT32 DistributedTensor signal buffer")
     .set_attr<int>("op")
     .set_attr<DataType>("dtype")
+    .set_attr<int>("core_num")
     .no_memory_spec()
     .set_internal_only(true)
     .set_template_dir(":pypto.runtime.builtins.collectives.allreduce")

--- a/src/ir/transforms/lower_composite_ops_pass.cpp
+++ b/src/ir/transforms/lower_composite_ops_pass.cpp
@@ -882,6 +882,11 @@ ExprPtr LowerTensorAllReduceRule(const CallPtr& call, const std::vector<ExprPtr>
       << "pld.tensor.allreduce lowering received unknown ReduceOp " << op_value;
   const auto reduce_op = static_cast<ReduceOp>(op_value);
 
+  auto core_num = GetRequiredKwarg<int>(call->kwargs_, "core_num", "pld.tensor.allreduce");
+  CHECK_SPAN(core_num == 1, span)
+      << "pld.tensor.allreduce core_num > 1 is supported only in a HOST orchestrator; "
+         "use an enclosing pl.spmd(...) for multi-core InCore execution";
+
   // Mode dispatch: "ring" delegates to the chunked reduce-scatter + allgather
   // ring schedule; "mesh" (default) uses the direct-exchange lowering below.
   // `mode` is a public DSL kwarg, so an unknown value is a user error — reject

--- a/src/ir/transforms/lower_host_tensor_collectives_pass.cpp
+++ b/src/ir/transforms/lower_host_tensor_collectives_pass.cpp
@@ -22,12 +22,15 @@
 #include <utility>
 #include <vector>
 
+#include "pypto/backend/common/backend.h"
+#include "pypto/backend/common/backend_config.h"
 #include "pypto/core/dtype.h"
 #include "pypto/core/logging.h"
 #include "pypto/ir/expr.h"
 #include "pypto/ir/function.h"
 #include "pypto/ir/kind_traits.h"
 #include "pypto/ir/op_registry.h"
+#include "pypto/ir/pipe.h"
 #include "pypto/ir/program.h"
 #include "pypto/ir/scalar_expr.h"
 #include "pypto/ir/span.h"
@@ -116,21 +119,43 @@ static constexpr size_t kMaxSupportedRanks = 16;
   return nullptr;
 }
 
-void CheckStaticSignalCapacity(const CallPtr& call, const ExprPtr& signal_expr, size_t required_slots) {
+/// Validate a collective signal's shape against the participating device count.
+///
+/// ``required_lanes`` is the number of per-peer signal lanes the collective
+/// needs — one for every collective except the mesh AllReduce, which needs one
+/// lane per launched SPMD block. ``allow_wider_lanes`` lets an explicitly
+/// supplied signal carry spare lanes beyond the required count.
+///
+/// The builtins index the signal as a flat row-major array. That is always
+/// sound here because HOST collective signals originate from
+/// ``pld.tensor.window``, whose type deducer builds a plain
+/// ``DistributedTensorType(shape, dtype)`` with no ``tensor_view_`` — a
+/// window-bound signal is packed by construction, so there is no strided or
+/// partial-view case to reject.
+void CheckStaticSignalCapacity(const CallPtr& call, const ExprPtr& signal_expr, size_t required_slots,
+                               int64_t required_lanes = 1, bool allow_wider_lanes = false) {
   auto signal_type = As<DistributedTensorType>(signal_expr->GetType());
   INTERNAL_CHECK_SPAN(signal_type, call->span_)
       << "LowerHostTensorCollectives: collective signal must be DistributedTensorType";
   CHECK_SPAN(signal_type->shape_.size() == 1 || signal_type->shape_.size() == 2, call->span_)
       << "LowerHostTensorCollectives: collective signal must be rank-1 [world_size] "
-         "or rank-2 [world_size, 1]";
+         "or rank-2 [world_size, signal_stride]";
   if (signal_type->shape_.empty()) return;
+  CHECK_SPAN(signal_type->shape_.size() == 2 || required_lanes == 1, call->span_)
+      << "LowerHostTensorCollectives: rank-1 signal is valid only when one signal lane is required";
   if (signal_type->shape_.size() == 2) {
     auto second_extent = As<ConstInt>(signal_type->shape_[1]);
     CHECK_SPAN(second_extent, call->span_)
-        << "LowerHostTensorCollectives: collective rank-2 signal shape[1] must be the constant 1";
-    CHECK_SPAN(second_extent->value_ == 1, call->span_)
-        << "LowerHostTensorCollectives: collective rank-2 signal shape[1] must be 1, got "
-        << second_extent->value_;
+        << "LowerHostTensorCollectives: collective rank-2 signal shape[1] must be constant";
+    if (allow_wider_lanes) {
+      CHECK_SPAN(second_extent->value_ >= required_lanes, call->span_)
+          << "LowerHostTensorCollectives: collective rank-2 signal shape[1] (" << second_extent->value_
+          << ") must be at least the required lane count (" << required_lanes << ")";
+    } else {
+      CHECK_SPAN(second_extent->value_ == required_lanes, call->span_)
+          << "LowerHostTensorCollectives: collective rank-2 signal shape[1] (" << second_extent->value_
+          << ") must equal the required lane count (" << required_lanes << ")";
+    }
   }
   auto extent = As<ConstInt>(signal_type->shape_[0]);
   if (!extent) return;
@@ -206,8 +231,44 @@ void CheckRingSignalCapacity(const CallPtr& call, const ExprPtr& signal_expr, si
   }
 }
 
-void CheckAllReduceSignalCapacity(const CallPtr& call, const ExprPtr& signal_expr, size_t world_size) {
+/// Reject a `core_num` that the configured backend could never admit.
+///
+/// The mesh AllReduce builtin is submitted through `rt_submit_aiv_task`, so it
+/// is a standalone AIV kernel: one logical block maps to one AIV core, and the
+/// bound is the vector-core count rather than the cube-core count (the same
+/// mapping VerifyHardSyncAllOccupancy applies to standalone AIV kernels).
+///
+/// This bound is a correctness requirement, not an optimisation. The generated
+/// launch sets `require_sync_start`, which admits all blocks atomically, so a
+/// request above the physical core count can never be admitted — the device
+/// would hang rather than report an error. Reject it at compile time instead.
+///
+/// Pure-IR unit tests run without a configured backend; there is nothing to
+/// bound in that case.
+void CheckAllReduceCoreCapacity(const CallPtr& call, int64_t core_num) {
+  if (!backend::BackendConfig::IsConfigured()) return;
+  const auto* be = backend::GetBackend();
+  const auto max_blocks = static_cast<int64_t>(be->GetCoreCount(CoreType::VECTOR));
+  CHECK_SPAN(core_num <= max_blocks, call->span_)
+      << "pld.tensor.allreduce core_num (" << core_num << ") exceeds the backend AIV core count ("
+      << max_blocks << ")";
+}
+
+/// Validate a HOST AllReduce call.
+///
+/// ``world_size_known`` is false when the collective lowers to a loop over a
+/// dynamic ``pld.system.world_size``. The schedule/``core_num`` compatibility and
+/// signal-lane checks are world-size independent and always run; only the ring
+/// layout and rank-count checks are skipped when the device set is dynamic.
+void CheckAllReduceSignalCapacity(const CallPtr& call, const ExprPtr& signal_expr, size_t world_size,
+                                  bool world_size_known) {
+  const auto core_num = static_cast<int64_t>(call->GetKwarg<int>("core_num"));
   if (ShouldLowerAllReduceAsRing(call)) {
+    // The ring builtin runs a single block per rank; multicore is mesh-only.
+    CHECK_SPAN(core_num == 1, call->span_)
+        << R"(HOST pld.tensor.allreduce mode="ring" does not support core_num > 1, got core_num=)" << core_num
+        << R"(; use mode="mesh" for a multi-core AllReduce)";
+    if (!world_size_known) return;
     CheckRingSignalCapacity(call, signal_expr, world_size);
     CHECK_SPAN(world_size <= kMaxSupportedRanks, call->span_)
         << "LowerHostTensorCollectives: ring allreduce requires " << static_cast<int>(kMaxSupportedRanks)
@@ -217,7 +278,10 @@ void CheckAllReduceSignalCapacity(const CallPtr& call, const ExprPtr& signal_exp
     CheckRingChunkConstraints(call, call->args_[0], world_size);
     return;
   }
-  CheckStaticSignalCapacity(call, signal_expr, world_size);
+  CheckAllReduceCoreCapacity(call, core_num);
+  // A ``world_size`` of 0 makes the shape[0] bound vacuous, which is exactly the
+  // right behaviour when the participating device count is only known at runtime.
+  CheckStaticSignalCapacity(call, signal_expr, world_size, core_num, /*allow_wider_lanes=*/true);
 }
 
 [[nodiscard]] CallPtr MakeBuiltinCallWithAttrs(const std::string& builtin_name, const CallPtr& call,
@@ -238,6 +302,7 @@ void CheckAllReduceSignalCapacity(const CallPtr& call, const ExprPtr& signal_exp
   INTERNAL_CHECK_SPAN(src_type, call->span_)
       << "LowerHostTensorCollectives: pld.tensor.allreduce src must be DistributedTensorType";
   auto op_value = call->GetKwarg<int>("op");
+  const bool as_ring = ShouldLowerAllReduceAsRing(call);
   std::vector<std::pair<std::string, std::any>> kwargs = {
       {"op", op_value},
       {"dtype", src_type->dtype_},
@@ -246,11 +311,17 @@ void CheckAllReduceSignalCapacity(const CallPtr& call, const ExprPtr& signal_exp
       {"op", op_value},
       {"dtype", src_type->dtype_},
   };
+  // Only the mesh builtin launches an SPMD grid, so only it declares `core_num`.
+  // The ring builtin runs a single block per rank.
+  if (!as_ring) {
+    const auto core_num = call->GetKwarg<int>("core_num");
+    kwargs.emplace_back("core_num", core_num);
+    attrs.emplace_back("core_num", core_num);
+  }
   INTERNAL_CHECK_SPAN(call->args_.size() >= 2, call->span_)
       << "LowerHostTensorCollectives: expected pld.tensor.allreduce to have an explicit signal by the time "
          "this pass runs";
-  const char* builtin_name =
-      ShouldLowerAllReduceAsRing(call) ? "builtin.tensor.allreduce_ring" : "builtin.tensor.allreduce";
+  const char* builtin_name = as_ring ? "builtin.tensor.allreduce_ring" : "builtin.tensor.allreduce";
   return MakeBuiltinCallWithAttrs(builtin_name, call, call->args_, kwargs, device, std::move(attrs),
                                   {ArgDirection::InOut, ArgDirection::InOut});
 }
@@ -519,7 +590,8 @@ StmtPtr EmitPerDeviceBuiltinCalls(const CallPtr& call, const HostCollectiveRule&
                                   const std::vector<std::string>& leading_comments) {
   if (!scope->devices_.empty()) {
     if (IsOp(call, "pld.tensor.allreduce")) {
-      CheckAllReduceSignalCapacity(call, rule.signal_expr(call), scope->devices_.size());
+      CheckAllReduceSignalCapacity(call, rule.signal_expr(call), scope->devices_.size(),
+                                   /*world_size_known=*/true);
     } else {
       CheckStaticSignalCapacity(call, rule.signal_expr(call), scope->devices_.size());
     }
@@ -540,6 +612,13 @@ StmtPtr EmitPerDeviceBuiltinCalls(const CallPtr& call, const HostCollectiveRule&
   auto zero = std::make_shared<ConstInt>(0, DataType::INT64, call->span_);
   auto one = std::make_shared<ConstInt>(1, DataType::INT64, call->span_);
   auto stop = OpRegistry::GetInstance().Create("pld.system.world_size", {}, call->span_);
+  // The device set is dynamic here, so world-size-dependent capacity cannot be
+  // checked; pass 0 so only the world-size-independent constraints apply.
+  if (IsOp(call, "pld.tensor.allreduce")) {
+    CheckAllReduceSignalCapacity(call, rule.signal_expr(call), 0, /*world_size_known=*/false);
+  } else {
+    CheckStaticSignalCapacity(call, rule.signal_expr(call), 0);
+  }
   auto body = std::make_shared<EvalStmt>(rule.make_builtin(call, loop_var), call->span_);
   return std::make_shared<ForStmt>(loop_var, zero, stop, one, std::vector<IterArgPtr>{}, body,
                                    std::vector<VarPtr>{}, span, ForKind::Sequential,

--- a/src/ir/transforms/synthesize_allreduce_signals_pass.cpp
+++ b/src/ir/transforms/synthesize_allreduce_signals_pass.cpp
@@ -96,7 +96,7 @@ class AllReduceSignalSynthesizer : public IRMutator {
       return op;
     }
 
-    auto [prefix, signal] = MakeSignalBinding(call->span_);
+    auto [prefix, signal] = MakeSignalBinding(call->span_, call->GetKwarg<int>("core_num"));
     auto target = VisitExpr(call->args_[0]);
     auto rewritten_call = MakeAllReduceCall(call, target, signal);
     auto result = MutableCopy(op);
@@ -116,7 +116,7 @@ class AllReduceSignalSynthesizer : public IRMutator {
       return op;
     }
 
-    auto [prefix, signal] = MakeSignalBinding(call->span_);
+    auto [prefix, signal] = MakeSignalBinding(call->span_, call->GetKwarg<int>("core_num"));
     auto target = VisitExpr(call->args_[0]);
     auto rewritten_call = MakeAllReduceCall(call, target, signal);
     std::vector<StmtPtr> stmts = std::move(prefix);
@@ -145,7 +145,7 @@ class AllReduceSignalSynthesizer : public IRMutator {
       auto target = VisitExpr(call->args_[0]);
       ExprPtr signal;
       if (call->args_.size() == 1) {
-        auto [prefix, synthesized_signal] = MakeSignalBinding(call->span_);
+        auto [prefix, synthesized_signal] = MakeSignalBinding(call->span_, call->GetKwarg<int>("core_num"));
         for (auto& stmt : prefix) prelude.push_back(std::move(stmt));
         signal = synthesized_signal;
       } else {
@@ -224,15 +224,19 @@ class AllReduceSignalSynthesizer : public IRMutator {
     }
   }
 
-  [[nodiscard]] std::pair<std::vector<StmtPtr>, VarPtr> MakeSignalBinding(const Span& span) {
+  [[nodiscard]] std::pair<std::vector<StmtPtr>, VarPtr> MakeSignalBinding(const Span& span, int core_num) {
     auto names = FreshSignalNames();
+    INTERNAL_CHECK_SPAN(core_num > 0, span)
+        << "SynthesizeAllReduceSignals requires a positive allreduce core_num";
 
     auto world_size_call = OpRegistry::GetInstance().Create("pld.system.world_size", {}, span);
     auto world_size_var = std::make_shared<Var>(names.world_size_name, world_size_call->GetType(), span);
     auto world_size_assign = std::make_shared<AssignStmt>(world_size_var, world_size_call, span);
 
+    auto core_num_expr = std::make_shared<ConstInt>(core_num, DataType::INT64, span);
     auto four = std::make_shared<ConstInt>(4, DataType::INT64, span);
-    auto size_bytes = MakeMul(world_size_var, four, span);
+    auto signal_elements = MakeMul(world_size_var, core_num_expr, span);
+    auto size_bytes = MakeMul(signal_elements, four, span);
 
     std::vector<std::pair<std::string, std::any>> alloc_kwargs = {{"name", names.buf_name}};
     auto alloc_call =
@@ -240,8 +244,8 @@ class AllReduceSignalSynthesizer : public IRMutator {
     auto buf_var = std::make_shared<Var>(names.buf_name, alloc_call->GetType(), span);
     auto buf_assign = std::make_shared<AssignStmt>(buf_var, alloc_call, span);
 
-    auto one = std::make_shared<ConstInt>(1, DataType::INT64, span);
-    auto signal_shape = std::make_shared<MakeTuple>(std::vector<ExprPtr>{world_size_var, one}, span);
+    auto signal_shape =
+        std::make_shared<MakeTuple>(std::vector<ExprPtr>{world_size_var, core_num_expr}, span);
     std::vector<std::pair<std::string, std::any>> window_kwargs = {{"dtype", DataType::INT32}};
     auto window_call =
         OpRegistry::GetInstance().Create("pld.tensor.window", {buf_var, signal_shape}, window_kwargs, span);

--- a/tests/st/distributed/test_l3_host_tensor_allreduce_multicore.py
+++ b/tests/st/distributed/test_l3_host_tensor_allreduce_multicore.py
@@ -1,0 +1,224 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""L3 ST for HOST AllReduce with multiple synchronized AIV blocks.
+
+Each case checks the reduced FP32 output and, on device, waits for every
+requested signal lane.  The lane waits prove that every requested block
+started; output correctness additionally proves that active blocks processed
+their block-strided chunks.
+"""
+
+import sys
+
+import pypto.language as pl
+import pypto.language.distributed as pld
+import pytest
+import torch
+from pypto import ir
+from pypto.ir.distributed_compiled_program import DistributedConfig
+
+
+def _make_rank_inputs(n_ranks: int, size: int) -> torch.Tensor:
+    rows = [
+        torch.arange(r * 100.0, r * 100.0 + size, dtype=torch.float32).reshape(1, size)
+        for r in range(n_ranks)
+    ]
+    return torch.stack(rows)
+
+
+def _expected_allreduce(inputs: torch.Tensor) -> torch.Tensor:
+    reduced = inputs.sum(dim=0)
+    return torch.stack([reduced] * inputs.shape[0])
+
+
+def _build_multicore_allreduce_program(
+    n_ranks: int,
+    size: int,
+    core_num: int,
+    signal_stride: int,
+):
+    nr = n_ranks
+    sz = size
+    cores = core_num
+    stride = signal_stride
+    stage_rows = 8 if size == 1 else 1
+    stage_cols = 1 if size == 1 else ((size + 7) // 8) * 8
+    signal_stage_cols = ((signal_stride + 7) // 8) * 8
+
+    @pl.program
+    class HostTensorAllReduceMulticore:
+        @pl.function(type=pl.FunctionType.InCore)
+        def publish_step(
+            self,
+            inp: pl.Tensor[[1, sz], pl.FP32],
+            data: pl.InOut[pld.DistributedTensor[[1, sz], pl.FP32]],
+            signal: pl.InOut[pld.DistributedTensor[[nr, stride], pl.INT32]],
+        ) -> pld.DistributedTensor[[1, sz], pl.FP32]:
+            local = pl.load(
+                inp,
+                [0, 0],
+                [stage_rows, stage_cols],
+                valid_shape=[1, sz],
+            )
+            return pl.store(local, [0, 0], data)
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def publish_orch(
+            self,
+            inp: pl.Tensor[[1, sz], pl.FP32],
+            data: pl.InOut[pld.DistributedTensor[[1, sz], pl.FP32]],
+            signal: pl.InOut[pld.DistributedTensor[[nr, stride], pl.INT32]],
+        ) -> pld.DistributedTensor[[1, sz], pl.FP32]:
+            return self.publish_step(inp, data, signal)
+
+        @pl.function(type=pl.FunctionType.InCore)
+        def consume_step(
+            self,
+            data: pld.DistributedTensor[[1, sz], pl.FP32],
+            signal: pld.DistributedTensor[[nr, stride], pl.INT32],
+            out: pl.Out[pl.Tensor[[1, sz], pl.FP32]],
+            signal_out: pl.Out[pl.Tensor[[nr, stride], pl.INT32]],
+        ) -> pl.Tensor[[1, sz], pl.FP32]:
+            ctx = pld.get_comm_ctx(signal)
+            my_rank = pld.rank(ctx)
+            for peer in pl.range(nr):
+                if peer != my_rank:
+                    for lane in pl.range(cores):
+                        # The builtin's start barrier publishes one signal per
+                        # launched block, including blocks with no data chunk.
+                        # TWAIT performs the cache invalidation required for a
+                        # reliable device-side observation.
+                        pld.system.wait(
+                            signal=signal,
+                            offsets=[peer, lane],
+                            expected=1,
+                            cmp=pld.WaitCmp.Ge,
+                        )
+
+            reduced = pl.load(
+                data,
+                [0, 0],
+                [stage_rows, stage_cols],
+                valid_shape=[1, sz],
+            )
+            out = pl.store(reduced, [0, 0], out)
+
+            signal_values = pl.load(
+                signal,
+                [0, 0],
+                [nr, signal_stage_cols],
+                valid_shape=[nr, stride],
+            )
+            pl.store(signal_values, [0, 0], signal_out)
+            return out
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def consume_orch(
+            self,
+            data: pld.DistributedTensor[[1, sz], pl.FP32],
+            signal: pld.DistributedTensor[[nr, stride], pl.INT32],
+            out: pl.Out[pl.Tensor[[1, sz], pl.FP32]],
+            signal_out: pl.Out[pl.Tensor[[nr, stride], pl.INT32]],
+        ) -> pl.Tensor[[1, sz], pl.FP32]:
+            return self.consume_step(data, signal, out, signal_out)
+
+        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+        def host_orch(
+            self,
+            inputs: pl.Tensor[[nr, 1, sz], pl.FP32],
+            outputs: pl.Out[pl.Tensor[[nr, 1, sz], pl.FP32]],
+            signal_outputs: pl.Out[pl.Tensor[[nr, nr, stride], pl.INT32]],
+        ) -> pl.Tensor[[nr, 1, sz], pl.FP32]:
+            data_buf = pld.alloc_window_buffer(sz * pl.FP32.get_byte())
+            signal_buf = pld.alloc_window_buffer(pld.world_size() * stride * pl.INT32.get_byte())
+
+            for rank in pl.range(pld.world_size()):
+                data = pld.window(data_buf, [1, sz], dtype=pl.FP32)
+                signal = pld.window(signal_buf, [pld.world_size(), stride], dtype=pl.INT32)
+                self.publish_orch(inputs[rank], data, signal, device=rank)
+
+            data = pld.window(data_buf, [1, sz], dtype=pl.FP32)
+            signal = pld.window(signal_buf, [pld.world_size(), stride], dtype=pl.INT32)
+            data = pld.tensor.allreduce(
+                data,
+                signal,
+                op=pld.ReduceOp.Sum,
+                core_num=cores,
+            )
+
+            for rank in pl.range(pld.world_size()):
+                self.consume_orch(
+                    data,
+                    signal,
+                    outputs[rank],
+                    signal_outputs[rank],
+                    device=rank,
+                )
+            return outputs
+
+    return HostTensorAllReduceMulticore
+
+
+class TestL3HostTensorAllReduceMulticore:
+    @pytest.mark.parametrize(
+        ("n_ranks", "core_num", "size", "signal_stride"),
+        [
+            pytest.param(2, 2, 1, 2, id="p2-c2-idle-lane"),
+            pytest.param(2, 4, 4127, 6, id="p2-c4-wide-stride"),
+            pytest.param(4, 2, 1041, 2, id="p4-c2-multichunk"),
+        ],
+    )
+    def test_multicore_output_and_signal_lanes(
+        self,
+        test_config,
+        device_ids,
+        n_ranks,
+        core_num,
+        size,
+        signal_stride,
+    ):
+        if len(device_ids) < n_ranks:
+            pytest.skip(f"multicore host allreduce P={n_ranks} needs {n_ranks} devices, got {device_ids}")
+
+        program = _build_multicore_allreduce_program(n_ranks, size, core_num, signal_stride)
+        compiled = ir.compile(
+            program,
+            platform=test_config.platform,
+            distributed_config=DistributedConfig(
+                device_ids=device_ids[:n_ranks],
+                num_sub_workers=0,
+            ),
+        )
+
+        inputs = _make_rank_inputs(n_ranks, size)
+        outputs = torch.zeros((n_ranks, 1, size), dtype=torch.float32)
+        signal_outputs = torch.zeros((n_ranks, n_ranks, signal_stride), dtype=torch.int32)
+
+        compiled(inputs, outputs, signal_outputs)
+
+        expected_outputs = _expected_allreduce(inputs)
+        assert torch.allclose(outputs, expected_outputs, rtol=1e-4, atol=1e-5), (
+            f"multicore host allreduce P={n_ranks}, C={core_num}, size={size} mismatch: "
+            f"max diff = {(outputs - expected_outputs).abs().max().item()}"
+        )
+
+        for rank in range(n_ranks):
+            for peer in range(n_ranks):
+                if peer == rank:
+                    continue
+                assert torch.all(signal_outputs[rank, peer, :core_num] >= 1), (
+                    f"missing signal lane for P={n_ranks}, C={core_num}, size={size}, "
+                    f"stride={signal_stride}, receiver={rank}, sender={peer}: "
+                    f"got {signal_outputs[rank, peer].tolist()}"
+                )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", *sys.argv[1:]])

--- a/tests/ut/codegen/distributed/test_host_orch_distributed.py
+++ b/tests/ut/codegen/distributed/test_host_orch_distributed.py
@@ -39,7 +39,7 @@ import pypto.language as pl
 import pypto.language.distributed as pld
 import pytest
 from pypto import codegen
-from pypto.backend import pto_backend
+from pypto.backend import BackendType, pto_backend
 from pypto.pypto_core import passes  # match the import path used by ut/conftest.py
 
 SIZE = 64
@@ -52,7 +52,7 @@ NRANKS = 2
 
 
 @pytest.fixture(autouse=True)
-def pass_verification_context():
+def pass_verification_context(ascend_backend):
     """Override ``ut/conftest.py``'s autouse roundtrip-verification fixture.
 
     ``MaterializeCommDomainScopes`` materialises ``DistributedTensorType.window_buffer_``
@@ -623,6 +623,7 @@ def test_host_allreduce_builtin_codegen_uses_next_level_callable_key():
         "op_cpp": "ReduceOp::kSum",
         "reduce_inst": "TADD",
         "dtype_cpp": "float",
+        "launch_core_count_method": "set_block_num",
     }
 
 
@@ -674,7 +675,64 @@ def test_host_allreduce_builtin_supports_every_op(
         "op_cpp": op_cpp,
         "reduce_inst": reduce_inst,
         "dtype_cpp": "float",
+        "launch_core_count_method": "set_block_num",
     }
+
+
+def test_host_allreduce_multicore_codegen_propagates_launch_count():
+    @pl.program
+    class Prog:
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def chip_orch(self, data: pld.DistributedTensor[[SIZE], pl.FP32]):
+            return data
+
+        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+        def host_orch(self):
+            data_buf = pld.alloc_window_buffer(SIZE * pl.FP32.get_byte())
+            signal_buf = pld.alloc_window_buffer(pld.world_size() * 4 * pl.INT32.get_byte())
+            data = pld.window(data_buf, [SIZE], dtype=pl.FP32)
+            signal = pld.window(signal_buf, [pld.world_size(), 4], dtype=pl.INT32)
+            for r in pl.range(pld.world_size()):
+                self.chip_orch(data, device=r)
+            pld.tensor.allreduce(data, signal, op=pld.ReduceOp.Sum, core_num=4)
+            return 0
+
+    generated, cg = _lower_host_collectives(Prog)
+
+    assert ".add_scalar(4)" in generated, generated
+    assert ".block_dim" not in generated, generated
+    specs = cg.get_builtin_next_level_specs()
+    assert len(specs) == 1
+    assert specs[0].template_vars["launch_core_count_method"] == "set_block_num"
+
+
+def test_host_allreduce_reuses_variant_across_core_counts():
+    @pl.program
+    class Prog:
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def chip_orch(self, data: pld.DistributedTensor[[SIZE], pl.FP32]):
+            return data
+
+        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+        def host_orch(self):
+            data_buf = pld.alloc_window_buffer(SIZE * pl.FP32.get_byte())
+            signal_buf_2 = pld.alloc_window_buffer(pld.world_size() * 2 * pl.INT32.get_byte())
+            signal_buf_4 = pld.alloc_window_buffer(pld.world_size() * 4 * pl.INT32.get_byte())
+            data = pld.window(data_buf, [SIZE], dtype=pl.FP32)
+            signal_2 = pld.window(signal_buf_2, [pld.world_size(), 2], dtype=pl.INT32)
+            signal_4 = pld.window(signal_buf_4, [pld.world_size(), 4], dtype=pl.INT32)
+            for r in pl.range(pld.world_size()):
+                self.chip_orch(data, device=r)
+            pld.tensor.allreduce(data, signal_2, op=pld.ReduceOp.Sum, core_num=2)
+            pld.tensor.allreduce(data, signal_4, op=pld.ReduceOp.Sum, core_num=4)
+            return 0
+
+    generated, cg = _lower_host_collectives(Prog)
+
+    assert generated.count('callables["builtin.tensor.allreduce__sum__fp32"]') == 2, generated
+    assert ".add_scalar(2)" in generated, generated
+    assert ".add_scalar(4)" in generated, generated
+    assert len(cg.get_builtin_next_level_specs()) == 1
 
 
 def test_host_allreduce_builtin_codegen_supports_fp16_variant():
@@ -705,6 +763,7 @@ def test_host_allreduce_builtin_codegen_supports_fp16_variant():
         "op_cpp": "ReduceOp::kSum",
         "reduce_inst": "TADD",
         "dtype_cpp": "half",
+        "launch_core_count_method": "set_block_num",
     }
 
 
@@ -805,11 +864,16 @@ def test_backend_materializes_builtin_next_level_files(tmp_path):
     entry_cpp = files[f"{base}/orchestration/builtin_tensor_allreduce__sum__fp32.cpp"]
     assert "builtin_tensor_allreduce__sum__fp32" in entry_cpp
     assert "submit_allreduce_kernel<ReduceOp::kSum>" in entry_cpp
+    assert "orch_args.scalar(2)" in entry_cpp
+    assert "params.launch_spec.set_block_num(core_num)" in entry_cpp
+    assert "params.launch_spec.set_require_sync_start(true)" in entry_cpp
+    assert ".expected_arg_count = 5" in entry_cpp
 
     kernel_config = files[f"{base}/kernel_config.py"]
     assert '"aicpu_thread_num": 0' in kernel_config
     assert '"function_name": "aicpu_orchestration_entry"' in kernel_config
     assert '"signature": [_D.INOUT, _D.INOUT]' in kernel_config
+    assert '"block_dim"' not in kernel_config
 
     kernel_cpp = files[f"{base}/kernels/aiv/builtin_tensor_allreduce__sum__fp32_kernel.cpp"]
     assert "platform_comm/comm_context.h" in kernel_cpp
@@ -820,6 +884,40 @@ def test_backend_materializes_builtin_next_level_files(tmp_path):
     assert "acc_tile.SetValidShape(1, chunk)" in kernel_cpp
     assert "Global data_store_g" in kernel_cpp
     assert "TADD(acc_tile, acc_tile, recv_tile)" in kernel_cpp
+    assert "get_block_idx(args)" in kernel_cpp
+    assert "get_block_num(args)" in kernel_cpp
+    assert "signal_tensor->ndims == 1 ? 1" in kernel_cpp
+    assert "base += static_cast<int64_t>(active_blocks) * kTileCount" in kernel_cpp
+
+
+@pytest.mark.parametrize("ascend_backend", [BackendType.Ascend950], indirect=True)
+def test_backend_950_materializes_allreduce_with_core_num_launch(tmp_path, ascend_backend):
+    @pl.program
+    class Prog:
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def chip_orch(self, data: pld.DistributedTensor[[SIZE], pl.FP32]):
+            return data
+
+        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+        def host_orch(self):
+            data_buf = pld.alloc_window_buffer(SIZE * pl.FP32.get_byte())
+            signal_buf = pld.alloc_window_buffer(pld.world_size() * 4 * pl.INT32.get_byte())
+            data = pld.window(data_buf, [SIZE], dtype=pl.FP32)
+            signal = pld.window(signal_buf, [pld.world_size(), 4], dtype=pl.INT32)
+            for r in pl.range(pld.world_size()):
+                self.chip_orch(data, device=r)
+            pld.tensor.allreduce(data, signal, op=pld.ReduceOp.Sum, core_num=4)
+            return 0
+
+    program = passes.materialize_comm_domain_scopes()(Prog)
+    program = passes.lower_host_tensor_collectives()(program)
+    program = passes.materialize_dist_tensor_ctx()(program)
+    program = _finalize_chip_program_for_generate(program)
+    files = pto_backend.generate(program, str(tmp_path), skip_ptoas=True)
+
+    base = "next_levels/builtin.tensor.allreduce__sum__fp32"
+    entry_cpp = files[f"{base}/orchestration/builtin_tensor_allreduce__sum__fp32.cpp"]
+    assert "params.launch_spec.set_core_num(core_num)" in entry_cpp
 
 
 def test_host_allreduce_ring_builtin_codegen_uses_ring_next_level_callable_key():

--- a/tests/ut/ir/test_distributed_ops.py
+++ b/tests/ut/ir/test_distributed_ops.py
@@ -230,6 +230,7 @@ def test_tensor_allreduce_returns_src_type():
     call = dist_tensor_ops.allreduce(src, signal, op=ir.ReduceOp.Sum, span=span)
     assert call.type is src.type
     assert call.kwargs["op"] == int(ir.ReduceOp.Sum)
+    assert call.kwargs["core_num"] == 1
 
 
 @pytest.mark.parametrize(
@@ -274,6 +275,31 @@ def test_tensor_allreduce_accepts_missing_signal_for_later_host_synthesis():
     assert call.type is src.type
     assert len(call.args) == 1
     assert call.kwargs["op"] == int(ir.ReduceOp.Sum)
+
+
+def test_tensor_allreduce_accepts_static_core_num():
+    span = ir.Span.unknown()
+    src = _make_distributed_tensor_var("src", [16], DataType.FP32, span)
+    signal = _make_distributed_tensor_var("signal", [4, 8], DataType.INT32, span)
+    call = dist_tensor_ops.allreduce(src, signal, core_num=4, span=span)
+    assert call.kwargs["core_num"] == 4
+
+
+@pytest.mark.parametrize(
+    ("core_num", "error_type", "match"),
+    [
+        (True, TypeError, "compile-time int"),
+        (0, ValueError, "must be positive"),
+        (-1, ValueError, "must be positive"),
+        (1.5, TypeError, "compile-time int"),
+    ],
+)
+def test_tensor_allreduce_rejects_invalid_core_num(core_num, error_type, match):
+    span = ir.Span.unknown()
+    src = _make_distributed_tensor_var("src", [16], DataType.FP32, span)
+    signal = _make_distributed_tensor_var("signal", [4], DataType.INT32, span)
+    with pytest.raises(error_type, match=match):
+        dist_tensor_ops.allreduce(src, signal, core_num=core_num, span=span)
 
 
 def test_tensor_allreduce_rejects_explicit_none_signal():

--- a/tests/ut/ir/transforms/test_lower_composite_ops.py
+++ b/tests/ut/ir/transforms/test_lower_composite_ops.py
@@ -827,6 +827,25 @@ def test_allreduce_eval_stmt_with_signal_is_decomposed():
     assert not missing, f"lowered IR missing expected ops: {missing}"
 
 
+def test_incore_allreduce_rejects_local_multicore_request():
+    SIZE = _ALLREDUCE_SIZE
+    nr = _ALLREDUCE_NRANKS
+
+    @pl.program
+    class MultiCoreAllreduce:
+        @pl.function(type=pl.FunctionType.InCore)
+        def reduce_step(
+            self,
+            data: pl.InOut[pld.DistributedTensor[[1, SIZE], pl.FP32]],
+            signal: pl.InOut[pld.DistributedTensor[[nr, 4], pl.INT32]],
+        ) -> pld.DistributedTensor[[1, SIZE], pl.FP32]:
+            data = pld.tensor.allreduce(data, signal, core_num=4)
+            return data
+
+    with pytest.raises(ValueError, match="supported only in a HOST orchestrator"):
+        passes.lower_composite_ops()(MultiCoreAllreduce)
+
+
 def test_allreduce_in_for_loop_now_succeeds():
     """A dynamic trip count used to have no compile-time generation to wait for,
     so this was rejected. The self-clearing epilogue (each call restarts at

--- a/tests/ut/ir/transforms/test_lower_host_tensor_collectives.py
+++ b/tests/ut/ir/transforms/test_lower_host_tensor_collectives.py
@@ -26,6 +26,7 @@ import pypto.language as pl
 import pypto.language.distributed as pld
 import pytest
 from pypto.language.parser.diagnostics import InvalidOperationError
+from pypto.pypto_core import backend as _backend
 from pypto.pypto_core import ir, passes
 
 
@@ -235,8 +236,8 @@ def test_host_allreduce_lowers_to_builtin_world_size_loop():
         "builtin.tensor.allreduce",
         arg_names=["data", "signal"],
         arg_directions=[ir.ArgDirection.InOut, ir.ArgDirection.InOut],
-        kwargs={"op": int(pld.ReduceOp.Sum), "dtype": pl.FP32},
-        attrs={"op": int(pld.ReduceOp.Sum), "dtype": pl.FP32},
+        kwargs={"op": int(pld.ReduceOp.Sum), "dtype": pl.FP32, "core_num": 1},
+        attrs={"op": int(pld.ReduceOp.Sum), "dtype": pl.FP32, "core_num": 1},
     )
 
 
@@ -266,8 +267,8 @@ def test_implicit_host_allreduce_synthesizes_signal_then_lowers():
         "builtin.tensor.allreduce",
         arg_names=["data", "__allreduce_signal_0"],
         arg_directions=[ir.ArgDirection.InOut, ir.ArgDirection.InOut],
-        kwargs={"op": int(pld.ReduceOp.Sum), "dtype": pl.FP32},
-        attrs={"op": int(pld.ReduceOp.Sum), "dtype": pl.FP32},
+        kwargs={"op": int(pld.ReduceOp.Sum), "dtype": pl.FP32, "core_num": 1},
+        attrs={"op": int(pld.ReduceOp.Sum), "dtype": pl.FP32, "core_num": 1},
     )
 
 
@@ -303,8 +304,8 @@ def test_return_implicit_host_allreduce_synthesizes_signal_then_lowers():
         "builtin.tensor.allreduce",
         arg_names=["data", "__allreduce_signal_0"],
         arg_directions=[ir.ArgDirection.InOut, ir.ArgDirection.InOut],
-        kwargs={"op": int(pld.ReduceOp.Sum), "dtype": pl.FP32},
-        attrs={"op": int(pld.ReduceOp.Sum), "dtype": pl.FP32},
+        kwargs={"op": int(pld.ReduceOp.Sum), "dtype": pl.FP32, "core_num": 1},
+        attrs={"op": int(pld.ReduceOp.Sum), "dtype": pl.FP32, "core_num": 1},
     )
     assert len(returns) == 1
     _assert_alias_keeps_window_buffer(returns[0])
@@ -348,8 +349,8 @@ def test_return_explicit_host_allreduce_lowers_with_user_signal():
         "builtin.tensor.allreduce",
         arg_names=["data", "signal"],
         arg_directions=[ir.ArgDirection.InOut, ir.ArgDirection.InOut],
-        kwargs={"op": int(pld.ReduceOp.Sum), "dtype": pl.FP32},
-        attrs={"op": int(pld.ReduceOp.Sum), "dtype": pl.FP32},
+        kwargs={"op": int(pld.ReduceOp.Sum), "dtype": pl.FP32, "core_num": 1},
+        attrs={"op": int(pld.ReduceOp.Sum), "dtype": pl.FP32, "core_num": 1},
     )
     assert len(returns) == 1
     _assert_alias_keeps_window_buffer(returns[0])
@@ -518,7 +519,153 @@ def test_host_allreduce_rejects_rank2_signal_with_dynamic_second_extent():
             return 0
 
     program = passes.materialize_comm_domain_scopes()(P)
-    with pytest.raises(ValueError, match=r"rank-2 signal shape\[1\] must be the constant 1"):
+    with pytest.raises(ValueError, match=r"rank-2 signal shape\[1\] must be constant"):
+        passes.lower_host_tensor_collectives()(program)
+
+
+def test_host_allreduce_multicore_propagates_core_num_and_accepts_wider_signal():
+    @pl.program
+    class P:
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def chip_orch(self, data: pld.DistributedTensor[[256], pl.FP32]):
+            return data
+
+        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+        def host_orch(self):
+            data_buf = pld.alloc_window_buffer(256 * pl.FP32.get_byte())
+            signal_buf = pld.alloc_window_buffer(pld.world_size() * 8 * pl.INT32.get_byte())
+            data = pld.window(data_buf, [256], dtype=pl.FP32)
+            signal = pld.window(signal_buf, [pld.world_size(), 8], dtype=pl.INT32)
+            for r in pl.range(pld.world_size()):
+                self.chip_orch(data, device=r)
+            pld.tensor.allreduce(data, signal, op=pld.ReduceOp.Sum, core_num=4)
+            return 0
+
+    program = passes.materialize_comm_domain_scopes()(P)
+    result = passes.lower_host_tensor_collectives()(program)
+    host = _get_func(result, "host_orch")
+
+    # A stride of 8 is wider than the 4 requested lanes: the spare lanes are
+    # accepted and `core_num` reaches the builtin unchanged.
+    _assert_builtin_dispatch(
+        host.body,
+        "builtin.tensor.allreduce",
+        arg_names=["data", "signal"],
+        arg_directions=[ir.ArgDirection.InOut, ir.ArgDirection.InOut],
+        kwargs={"op": int(pld.ReduceOp.Sum), "dtype": pl.FP32, "core_num": 4},
+        attrs={"op": int(pld.ReduceOp.Sum), "dtype": pl.FP32, "core_num": 4},
+    )
+
+
+def test_host_allreduce_multicore_rejects_rank1_signal():
+    @pl.program
+    class P:
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def chip_orch(self, data: pld.DistributedTensor[[256], pl.FP32]):
+            return data
+
+        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+        def host_orch(self):
+            data_buf = pld.alloc_window_buffer(256 * pl.FP32.get_byte())
+            signal_buf = pld.alloc_window_buffer(pld.world_size() * pl.INT32.get_byte())
+            data = pld.window(data_buf, [256], dtype=pl.FP32)
+            signal = pld.window(signal_buf, [pld.world_size()], dtype=pl.INT32)
+            for r in pl.range(pld.world_size()):
+                self.chip_orch(data, device=r)
+            pld.tensor.allreduce(data, signal, op=pld.ReduceOp.Sum, core_num=4)
+            return 0
+
+    program = passes.materialize_comm_domain_scopes()(P)
+    with pytest.raises(ValueError, match=r"rank-1 signal is valid only when one signal lane is required"):
+        passes.lower_host_tensor_collectives()(program)
+
+
+def test_host_allreduce_multicore_rejects_narrow_rank2_signal():
+    @pl.program
+    class P:
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def chip_orch(self, data: pld.DistributedTensor[[256], pl.FP32]):
+            return data
+
+        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+        def host_orch(self):
+            data_buf = pld.alloc_window_buffer(256 * pl.FP32.get_byte())
+            signal_buf = pld.alloc_window_buffer(pld.world_size() * 2 * pl.INT32.get_byte())
+            data = pld.window(data_buf, [256], dtype=pl.FP32)
+            signal = pld.window(signal_buf, [pld.world_size(), 2], dtype=pl.INT32)
+            for r in pl.range(pld.world_size()):
+                self.chip_orch(data, device=r)
+            pld.tensor.allreduce(data, signal, op=pld.ReduceOp.Sum, core_num=4)
+            return 0
+
+    program = passes.materialize_comm_domain_scopes()(P)
+    with pytest.raises(ValueError, match=r"must be at least the required lane count"):
+        passes.lower_host_tensor_collectives()(program)
+
+
+def test_host_allreduce_rejects_core_num_above_backend_capacity(ascend_backend):
+    """The builtin is submitted with ``rt_submit_aiv_task``, so one block maps to
+    one AIV core and the bound is the vector-core count, not the cube-core count.
+
+    The launch also sets ``require_sync_start``, so an unsatisfiable request would
+    hang the device rather than fail — it has to be rejected at compile time.
+    """
+    backend = _backend.get_backend_instance(ascend_backend)
+    aiv_cores = backend.get_core_count(ir.CoreType.VECTOR)
+    aic_cores = backend.get_core_count(ir.CoreType.CUBE)
+    # Guards the regression this test exists for: a cube-derived bound would
+    # wrongly reject every core_num in (aic_cores, aiv_cores].
+    assert aiv_cores > aic_cores
+
+    def _build(core_num: int):
+        @pl.program
+        class P:
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def chip_orch(self, data: pld.DistributedTensor[[256], pl.FP32]):
+                return data
+
+            @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+            def host_orch(self):
+                data_buf = pld.alloc_window_buffer(256 * pl.FP32.get_byte())
+                signal_buf = pld.alloc_window_buffer(pld.world_size() * core_num * pl.INT32.get_byte())
+                data = pld.window(data_buf, [256], dtype=pl.FP32)
+                signal = pld.window(signal_buf, [pld.world_size(), core_num], dtype=pl.INT32)
+                for r in pl.range(pld.world_size()):
+                    self.chip_orch(data, device=r)
+                pld.tensor.allreduce(data, signal, op=pld.ReduceOp.Sum, core_num=core_num)
+                return 0
+
+        return passes.materialize_comm_domain_scopes()(P)
+
+    # Exactly at capacity is accepted.
+    passes.lower_host_tensor_collectives()(_build(aiv_cores))
+
+    with pytest.raises(ValueError, match="exceeds the backend AIV core count"):
+        passes.lower_host_tensor_collectives()(_build(aiv_cores + 1))
+
+
+def test_host_allreduce_ring_rejects_multicore():
+    """Multicore is a mesh-only capability: the ring builtin runs one block per rank."""
+
+    @pl.program
+    class P:
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def chip_orch(self, data: pld.DistributedTensor[[256], pl.FP32]):
+            return data
+
+        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+        def host_orch(self):
+            data_buf = pld.alloc_window_buffer(256 * pl.FP32.get_byte())
+            signal_buf = pld.alloc_window_buffer(pld.world_size() * 8 * pl.INT32.get_byte())
+            data = pld.window(data_buf, [256], dtype=pl.FP32)
+            signal = pld.window(signal_buf, [pld.world_size(), 8], dtype=pl.INT32)
+            for r in pl.range(pld.world_size()):
+                self.chip_orch(data, device=r)
+            pld.tensor.allreduce(data, signal, op=pld.ReduceOp.Sum, mode="ring", core_num=4)
+            return 0
+
+    program = passes.materialize_comm_domain_scopes()(P)
+    with pytest.raises(ValueError, match=r'mode="ring" does not support core_num > 1'):
         passes.lower_host_tensor_collectives()(program)
 
 

--- a/tests/ut/ir/transforms/test_materialize_comm_domain_scopes.py
+++ b/tests/ut/ir/transforms/test_materialize_comm_domain_scopes.py
@@ -460,6 +460,67 @@ def test_synthesize_allreduce_signals_normalizes_host_allreduce():
     assert _as_var(allreduces[0].args[1]).name_hint == signal_windows[0].var.name_hint
 
 
+def test_synthesize_multicore_allreduce_signal_uses_core_lanes_and_bytes():
+    @pl.program
+    class P:
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def chip_orch(self, data: pld.DistributedTensor[[256], pl.FP32]):
+            return data
+
+        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+        def host_orch(self):
+            data_buf = pld.alloc_window_buffer(256 * pl.FP32.get_byte())
+            data = pld.window(data_buf, [256], dtype=pl.FP32)
+            for r in pl.range(pld.world_size()):
+                self.chip_orch(data, device=r)
+            data = pld.tensor.allreduce(data, core_num=4)
+            return data
+
+    synthesized = _synthesize(P)
+    host = _get_func(synthesized, "host_orch")
+    stmts = _flatten_stmts(host.body)
+    window_stmt = next(
+        stmt
+        for stmt in stmts
+        if isinstance(stmt, ir.AssignStmt)
+        and isinstance(stmt.value, ir.Call)
+        and stmt.value.op.name == ir.get_op("pld.tensor.window").name
+        and stmt.var.name_hint.startswith("__allreduce_signal_")
+    )
+    alloc_stmt = next(
+        stmt
+        for stmt in stmts
+        if isinstance(stmt, ir.AssignStmt)
+        and isinstance(stmt.value, ir.Call)
+        and stmt.value.op.name == ir.get_op("pld.tensor.alloc_window_buffer").name
+        and stmt.var.name_hint.startswith("__allreduce_signal_buf_")
+    )
+    allreduce = next(
+        stmt.value
+        for stmt in stmts
+        if isinstance(stmt, ir.AssignStmt)
+        and isinstance(stmt.value, ir.Call)
+        and stmt.value.op.name == ir.get_op("pld.tensor.allreduce").name
+    )
+
+    signal_type = window_stmt.var.type
+    assert isinstance(signal_type, ir.DistributedTensorType)
+    assert isinstance(signal_type.shape[1], ir.ConstInt)
+    assert signal_type.shape[1].value == 4
+    assert allreduce.kwargs["core_num"] == 4
+
+    assert isinstance(alloc_stmt.value, ir.Call)
+    alloc_size = alloc_stmt.value.args[0]
+    assert isinstance(alloc_size, ir.Mul)
+    assert isinstance(alloc_size.right, ir.ConstInt)
+    assert alloc_size.right.value == pl.INT32.get_byte()
+    assert isinstance(alloc_size.left, ir.Mul)
+    assert isinstance(alloc_size.left.left, ir.Var)
+    assert alloc_size.left.left.name_hint.startswith("__allreduce_signal_world_size_")
+    assert isinstance(alloc_size.left.right, ir.ConstInt)
+    assert alloc_size.left.right.value == 4
+
+
 def test_synthesized_allreduce_signal_round_trips_after_materialization():
     @pl.program
     class P:


### PR DESCRIPTION
## Summary
- add a compile-time `core_num` option to HOST tensor AllReduce while preserving the single-core default
- synthesize and validate one signal lane per logical block, then launch a synchronized backend-specific AIV grid
- partition AllReduce chunks by block identity and document the API, lowering, launch, and signal contracts in English and Chinese
- add unit, codegen, and multi-device NPU coverage for idle lanes, wide signal strides, and multi-chunk execution

## Testing
- `ruff check .`
- `ruff format --check .`
- `pyright`
- targeted unit tests: `262 passed`
- full unit tests: `7801 passed, 2 skipped`
- NPU system tests: `3 passed` on A2/A3 (`2x2`, `2x4`, and `4x2` rank/core cases)