### PR TITLE
feat(runtime): Add offset device copy wrapper

### DIFF
--- a/python/pypto/runtime/distributed_runner.py
+++ b/python/pypto/runtime/distributed_runner.py
@@ -946,8 +946,8 @@ class DistributedWorker(Worker):
     construction + registration + ``init()`` (fork) — happens exactly once.
 
     Mirrors the L2 ``with ChipWorker(...)`` reuse block: it exposes device-memory
-    helpers (:meth:`malloc`, :meth:`copy_to`, :meth:`copy_from`, :meth:`free`,
-    :meth:`alloc_tensor`) so callers can build worker-resident
+    helpers (:meth:`malloc`, :meth:`copy_to`, :meth:`copy_to_offset`,
+    :meth:`copy_from`, :meth:`free`, :meth:`alloc_tensor`) so callers can build worker-resident
     :class:`~pypto.runtime.DeviceTensor` buffers that survive across dispatches,
     then call ``rt(*device_args)`` or ``rt.run(compiled, *device_args)``
     repeatedly.
@@ -1435,6 +1435,25 @@ class DistributedWorker(Worker):
         """H2D copy: ``nbytes`` from host *src_host_ptr* to device *dst_dev_ptr*."""
         self._require_open("copy_to")
         self._orch().copy_to(worker_id, dst_dev_ptr, src_host_ptr, nbytes)
+
+    def copy_to_offset(
+        self,
+        dst_base_ptr: int,
+        dst_offset: int,
+        src_host_ptr: int,
+        nbytes: int,
+        *,
+        worker_id: int = 0,
+    ) -> None:
+        """H2D copy to ``dst_base_ptr + dst_offset`` within a live device allocation."""
+        self._require_open("copy_to_offset")
+        self._orch().copy_to_offset(
+            worker_id,
+            dst_base_ptr,
+            dst_offset,
+            src_host_ptr,
+            nbytes,
+        )
 
     def copy_from(self, dst_host_ptr: int, src_dev_ptr: int, nbytes: int, *, worker_id: int = 0) -> None:
         """D2H copy: ``nbytes`` from device *src_dev_ptr* back to host *dst_host_ptr*."""

--- a/tests/ut/runtime/test_distributed_worker.py
+++ b/tests/ut/runtime/test_distributed_worker.py
@@ -316,6 +316,15 @@ class TestPerCallValidation:
 
 
 class TestDeviceMemoryApi:
+    def test_copy_to_offset_forwards_to_orchestrator(self, patched_setup):
+        compiled = _fake_compiled([_param("a", [16, 16])], [])
+        rt = DistributedWorker(compiled)
+
+        rt.copy_to_offset(0xA000, 256, 0xB000, 64, worker_id=1)
+
+        patched_setup["worker"]._orch.copy_to_offset.assert_called_once_with(1, 0xA000, 256, 0xB000, 64)
+        rt.close()
+
     def test_alloc_tensor_forwards_malloc_and_copy(self, patched_setup):
         compiled = _fake_compiled([_param("a", [16, 16])], [])
         rt = DistributedWorker(compiled)


### PR DESCRIPTION
## Summary

- Add `DistributedWorker.copy_to_offset` for H2D copies into an offset of a live device allocation.
- Forward the allocation base and byte offset separately to the simpler orchestrator.
- Document the helper on `DistributedWorker` and cover its argument forwarding with a unit test.

## Motivation

Simpler validates device-pointer provenance and rejects interior pointers passed through `copy_to`.
Callers updating a slice of a persistent allocation therefore need an explicit base-plus-offset API.
This wrapper exposes that API to PyPTO and unblocks offset cache-page updates in serving workloads.

## Dependency

- Depends on [hw-native-sys/simpler#1538](https://github.com/hw-native-sys/simpler/pull/1538).
- Merge the simpler PR before this wrapper PR.

## Validation

- `cmake --build build --parallel`
- `python -m pytest tests/ut/runtime/test_distributed_worker.py -n auto --maxprocesses 8 -q`: 104 passed
- PyPTO pre-commit checks on the changed files: passed, including Ruff and Pyright
- Full unit-suite attempt: 7772 passed, 2 skipped; 11 failures and 4 setup errors were caused by the locally installed `_task_interface` predating the simpler source-tree build stamp
