### PR TITLE
fix(runtime): exclude prewarm traces from L3 benchmark rounds

### DIFF
--- a/python/pypto/runtime/bench.py
+++ b/python/pypto/runtime/bench.py
@@ -678,6 +678,11 @@ def _inv_span_us(inv: Any, name: str) -> float:
     return span.dur / 1000.0 if span is not None else 0.0
 
 
+def _is_dispatch_invocation(inv: Any, host_name: str) -> bool:
+    """Whether *inv* contains the canonical dispatch host span at depth 0."""
+    return any(span.depth == 0 and span.name == host_name for span in inv.spans)
+
+
 def _parse_l3_stats(invocations: Any, stats: BenchmarkStats, *, rounds: int, warmup: int) -> BenchmarkStats:
     """Aggregate L3 (distributed) ``[STRACE]`` markers into per-round stats.
 
@@ -703,25 +708,22 @@ def _parse_l3_stats(invocations: Any, stats: BenchmarkStats, *, rounds: int, war
     dispatch shape where per-round alignment cannot be trusted.
     """
     launches = warmup + rounds
-    by_pid: dict[int, list[Any]] = defaultdict(list)
-    for inv in invocations:
-        by_pid[inv.pid].append(inv)
-    for invs in by_pid.values():
-        invs.sort(key=lambda i: i.inv)
 
-    # Keep only actual dispatch invocation groups. The capture must begin before
-    # ``prepare()`` so forked chip workers inherit its fd, but prepare-time setup
-    # can emit unrelated groups such as ``simpler_prewarm.build``. Those groups
-    # lack the canonical run root and would add one invocation per rank, making a
-    # deterministic ``warmup + rounds`` stream look non-divisible. Do not filter
-    # on ``device_wall`` per invocation: retaining a real run with a missing
-    # device marker preserves its round alignment and exposes a zero metric.
+    # The capture must begin before ``prepare()`` so forked chip workers inherit
+    # its fd, but prepare-time setup can emit unrelated invocation groups such as
+    # ``simpler_prewarm.build``. Only a depth-0 canonical run root identifies an
+    # actual dispatch. Do not filter on ``device_wall`` per invocation: retaining
+    # a real run with a missing device marker preserves its round alignment and
+    # exposes a zero metric.
     names = _span_names()
     host_name = names["host"]
     device_name = names["device"]
-    by_pid = {
-        pid: [inv for inv in invs if inv.by_name().get(host_name) is not None] for pid, invs in by_pid.items()
-    }
+    by_pid: dict[int, list[Any]] = defaultdict(list)
+    for inv in invocations:
+        if _is_dispatch_invocation(inv, host_name):
+            by_pid[inv.pid].append(inv)
+    for invs in by_pid.values():
+        invs.sort(key=lambda i: i.inv)
 
     # A real chip-child rank emits at least one ``device_wall`` span; the L3
     # host-orch parent process emits its own run root without any chip

--- a/python/pypto/runtime/bench.py
+++ b/python/pypto/runtime/bench.py
@@ -709,16 +709,29 @@ def _parse_l3_stats(invocations: Any, stats: BenchmarkStats, *, rounds: int, war
     for invs in by_pid.values():
         invs.sort(key=lambda i: i.inv)
 
-    # Keep only chip-child ranks. A real rank emits a ``device_wall`` span; the
-    # L3 host-orch parent process emits its own ``run_prepared`` root without any
-    # chip ``device_wall``, so its pid must not be grouped as a rank — otherwise
-    # it adds a fake zero-device rank that corrupts ``per_rank`` / rank counts and
+    # Keep only actual dispatch invocation groups. The capture must begin before
+    # ``prepare()`` so forked chip workers inherit its fd, but prepare-time setup
+    # can emit unrelated groups such as ``simpler_prewarm.build``. Those groups
+    # lack the canonical run root and would add one invocation per rank, making a
+    # deterministic ``warmup + rounds`` stream look non-divisible. Do not filter
+    # on ``device_wall`` per invocation: retaining a real run with a missing
+    # device marker preserves its round alignment and exposes a zero metric.
+    names = _span_names()
+    host_name = names["host"]
+    device_name = names["device"]
+    by_pid = {
+        pid: [inv for inv in invs if inv.by_name().get(host_name) is not None] for pid, invs in by_pid.items()
+    }
+
+    # A real chip-child rank emits at least one ``device_wall`` span; the L3
+    # host-orch parent process emits its own run root without any chip
+    # ``device_wall``, so its pid must not be grouped as a rank — otherwise it
+    # adds a fake zero-device rank that corrupts ``per_rank`` / rank counts and
     # pollutes the ``host_wall`` / ``union`` windows with the parent orch span.
-    device_name = _span_names()["device"]
     by_pid = {
         pid: invs
         for pid, invs in by_pid.items()
-        if any(inv.by_name().get(device_name) is not None for inv in invs)
+        if invs and any(inv.by_name().get(device_name) is not None for inv in invs)
     }
     if not by_pid:
         return stats

--- a/tests/ut/runtime/test_benchmark.py
+++ b/tests/ut/runtime/test_benchmark.py
@@ -296,6 +296,20 @@ def test_parse_l3_ignores_prepare_time_prewarm_groups(span_root):
     assert {root.name for root in roots if root is not None} == {span_root}
 
 
+def test_parse_l3_keeps_dispatch_missing_one_device_marker(span_root):
+    """A real dispatch with no device span remains aligned and reports zero."""
+    lines = [_strace_line(0, span_root, 100_000, depth=0, pid=100)]
+    lines += _launch_lines(1, span_root, host_us=300, device_us=30, pid=100)
+    lines += _launch_lines(0, span_root, host_us=200, device_us=20, pid=101)
+    lines += _launch_lines(1, span_root, host_us=50, device_us=5, pid=101)
+
+    stats = _parse_stats_from_strace("\n".join(lines), rounds=2, warmup=0, distributed=True)
+
+    assert stats.fallback_flattened is False
+    assert stats.per_rank("device") == {100: [0.0, 30.0], 101: [20.0, 5.0]}
+    assert len(stats.rounds_dispatches[0][100]) == 1
+
+
 def test_parse_l3_recovers_interleaved_records_on_one_line(span_root):
     """Two ``[STRACE]`` records mashed onto one physical line are both recovered.
 

--- a/tests/ut/runtime/test_benchmark.py
+++ b/tests/ut/runtime/test_benchmark.py
@@ -274,6 +274,28 @@ def test_parse_l3_two_ranks_per_round_max(span_root):
     assert stats.host_wall_us == [200.0, 300.0]
 
 
+def test_parse_l3_ignores_prepare_time_prewarm_groups(span_root):
+    """Setup-only prewarm groups do not break per-rank round segmentation."""
+    lines: list[str] = []
+    for pid, measured_us in ((100, [10.0, 30.0]), (101, [20.0, 5.0])):
+        # ``prepare()`` runs before benchmark dispatches while stderr is already
+        # captured. Simpler's arena prewarm emits this non-dispatch STRACE group
+        # with no canonical run root or device-wall span.
+        lines.append(_strace_line(0, "simpler_prewarm.build", 800_000, pid=pid, hid="0"))
+        lines += _launch_lines(1, span_root, host_us=99, device_us=99, pid=pid)  # warmup
+        lines += _launch_lines(2, span_root, host_us=100, device_us=measured_us[0], pid=pid)
+        lines += _launch_lines(3, span_root, host_us=300, device_us=measured_us[1], pid=pid)
+
+    stats = _parse_stats_from_strace("\n".join(lines), rounds=2, warmup=1, distributed=True)
+
+    assert stats.fallback_flattened is False
+    assert stats.per_rank("device") == {100: [10.0, 30.0], 101: [20.0, 5.0]}
+    assert len(stats.invocations) == 4
+    roots = [inv.root() for inv in stats.invocations]
+    assert all(root is not None for root in roots)
+    assert {root.name for root in roots if root is not None} == {span_root}
+
+
 def test_parse_l3_recovers_interleaved_records_on_one_line(span_root):
     """Two ``[STRACE]`` records mashed onto one physical line are both recovered.
 
@@ -641,6 +663,41 @@ def test_benchmark_l3_capture_wraps_prepare(span_root):
     # Prepare-time markers were captured and aggregated (per-round max across ranks).
     assert stats.device_wall_us == [20.0]
     assert set(stats.per_rank("device")) == {100, 101}
+
+
+def test_benchmark_l3_ignores_prepare_setup_groups(span_root):
+    """Setup-only groups captured around ``prepare()`` are not dispatches."""
+
+    class _CompiledEmittingPrewarmAtPrepare(_FakeDistributedCompiled):
+        def prepare(self, config: Any = None) -> _FakeDistributedWorker:
+            for pid in (100, 101):
+                line = _strace_line(0, "simpler_prewarm.build", 800_000, pid=pid, hid="0")
+                os.write(2, (line + "\n").encode())
+            return self._rt
+
+    rt = _FakeDistributedWorker()
+
+    def emit_dispatch(*_args: Any, **_kwargs: Any) -> None:
+        for pid, dev_us in ((100, 10.0), (101, 20.0)):
+            for line in _launch_lines(1, span_root, host_us=5.0, device_us=dev_us, pid=pid):
+                os.write(2, (line + "\n").encode())
+
+    rt.handle.side_effect = emit_dispatch
+    with (
+        patch.object(dcp_mod, "DistributedCompiledProgram", _FakeDistributedCompiled),
+        patch("pypto.runtime.bench.configure_log"),
+        patch("pypto.runtime.bench.current_level", return_value=20),
+    ):
+        stats = benchmark(
+            _CompiledEmittingPrewarmAtPrepare(rt),
+            [MagicMock(name="arg")],
+            rounds=1,
+            warmup=0,
+        )
+
+    assert stats.device_wall_us == [20.0]
+    assert set(stats.per_rank("device")) == {100, 101}
+    assert all(len(dispatches) == 1 for dispatches in stats.rounds_dispatches[0].values())
 
 
 def test_benchmark_raises_when_no_markers_captured():


### PR DESCRIPTION
## Summary

- exclude prepare-time trace groups without the canonical dispatch root before L3 rank/round segmentation
- preserve real dispatch groups even when an individual device marker is missing
- add parser and fd-capture regressions for simpler_prewarm.build
- keep the existing cross-rank BenchmarkStats aggregation semantics unchanged

## Why

The L3 benchmark captures stderr around prepare() so forked chip workers inherit the capture fd. Simpler prewarming also emits one setup-only trace group per rank. Counting those groups as dispatches makes warmup + rounds non-divisible, triggers fallback_flattened, and loses rank/round alignment.

## Testing

- all pre-commit hooks passed, including Ruff and Pyright
- tests/ut/runtime/test_benchmark.py: 30 passed
- pypto-lib DeepSeek MoE on devices 4,6: 100/100 valid aligned rounds