### PR TITLE
docs(codegen): Clarify compiler-derived task dep edge scope

### DIFF
--- a/docs/en/dev/codegen/01-orchestration_codegen.md
+++ b/docs/en/dev/codegen/01-orchestration_codegen.md
@@ -483,11 +483,18 @@ it writes the user's `pl.submit(..., deps=[tid1, tid2])` kwarg into the typed
 variables). Plain `Call` carriers of `manual_dep_edges` no longer exist — the
 ManualDepsOnSubmitOnly structural property verifies that no cross-function
 `Call` carries it; only the `system.task_dummy` barrier op keeps the attr as
-its fanin contract. Compiler-derived manual-scope edges come from
+its fanin contract. Compiler-derived edges come from
 [`AutoDeriveTaskDependencies`](../passes/36-auto_derive_task_dependencies.md)
 in `Call.attrs["compiler_manual_dep_edges"]` (a separate key, allowed on plain
-calls). Codegen merges the two lists in that order and deduplicates by Var
-identity before emitting the stack array.
+calls). That pass never analyzes a user-written MANUAL scope — inside
+`pl.manual_scope()` the explicit `deps=[...]` list stays the only source of
+dependency edges. It analyzes AUTO regions only, and only under the compile-time
+`analyze_auto_scopes_for_deps` switch: a fully covered region is then
+materialized as a *compiler-owned* MANUAL scope, a partially covered
+default-mode region stays AUTO with its representable edges emitted on top of
+runtime auto-tracking, and a hand-placed `pl.scope()` that falls back has its
+partial edges stripped. Codegen merges the two lists in that order and
+deduplicates by Var identity before emitting the stack array.
 
 ### TaskId sourcing
 

--- a/docs/en/dev/codegen/01-orchestration_codegen.md
+++ b/docs/en/dev/codegen/01-orchestration_codegen.md
@@ -464,23 +464,19 @@ if (carry.is_valid()) params_t1_deps[params_t1_deps_count++] = carry;  // loop c
 params_t1.set_dependencies(params_t1_deps, params_t1_deps_count);
 ```
 
-A dep slot is wrapped in `if (task_id.is_valid())` only when the TaskId may
-legitimately hold the `PTO2TaskId::invalid()` sentinel — a `None` loop-carry
-seed, an early loop iteration's iter_arg carry, or an unwritten array slot —
-because an invalid id must never reach `set_dependencies`. A **fresh
-direct-producer** TaskId (the output of a `pl.submit(...)` earlier in the same
-straight-line scope) is statically always-valid, so its insert is emitted
-unguarded (issue #1966), dropping the redundant always-true branch from the
-orchestration hot path.
+A dep slot is guarded with `if (task_id.is_valid())` only when the TaskId may
+legitimately hold the `PTO2TaskId::invalid()` sentinel, because an invalid id
+must never reach `set_dependencies`; a **fresh direct-producer** TaskId is
+statically always-valid and is emitted unguarded (issue #1966). See
+[TaskId sourcing](#taskid-sourcing) for the full case list.
 
-There is no `params.add_dep(...)` call any more, and there is no 16-dep cap
-— the runtime `Arg::set_dependencies` primitive has no upper bound, and the
-stack array is sized to the exact count. User edges come from the parser:
-it writes the user's `pl.submit(..., deps=[tid1, tid2])` kwarg into the typed
-`Submit::deps_` field; codegen reads them through the transient
-`SubmitToCallView`, which surfaces `deps_` as a synthesised
-`attrs["manual_dep_edges"]` entry (a `vector<VarPtr>` of `Scalar[TASK_ID]`
-variables). Plain `Call` carriers of `manual_dep_edges` no longer exist — the
+There is no `params.add_dep(...)` call and no 16-dep cap — the runtime
+`Arg::set_dependencies` primitive has no upper bound, and the stack array is
+sized to the exact count. User edges come from the parser: it writes the user's
+`pl.submit(..., deps=[tid1, tid2])` kwarg into the typed `Submit::deps_` field;
+codegen reads them through the transient `SubmitToCallView`, which surfaces
+`deps_` as a synthesised `attrs["manual_dep_edges"]` entry. Plain `Call`
+carriers of `manual_dep_edges` no longer exist — the
 ManualDepsOnSubmitOnly structural property verifies that no cross-function
 `Call` carries it; only the `system.task_dummy` barrier op keeps the attr as
 its fanin contract. Compiler-derived edges come from
@@ -489,20 +485,19 @@ in `Call.attrs["compiler_manual_dep_edges"]` (a separate key, allowed on plain
 calls). That pass never analyzes a user-written MANUAL scope — inside
 `pl.manual_scope()` the explicit `deps=[...]` list stays the only source of
 dependency edges. It analyzes AUTO regions only, and only under the compile-time
-`analyze_auto_scopes_for_deps` switch: a fully covered region is then
-materialized as a *compiler-owned* MANUAL scope, a partially covered
-default-mode region stays AUTO with its representable edges emitted on top of
-runtime auto-tracking, and a hand-placed `pl.scope()` that falls back has its
-partial edges stripped. Codegen merges the two lists in that order and
+`analyze_auto_scopes_for_deps` switch. A default-mode (`auto_scope=True`) region
+becomes a *compiler-owned* MANUAL scope when fully covered, and otherwise stays
+AUTO with its representable edges emitted on top of runtime auto-tracking. A
+hand-placed `pl.scope()` always keeps `manual=false`, and has its partial edges
+stripped if analysis falls back. Codegen merges the two lists in that order and
 deduplicates by Var identity before emitting the stack array.
 
 ### TaskId sourcing
 
-Every kernel task launch inside a manual scope is a `Submit`; the
-`SubmitToCallView` adapter presents its `deps_` to codegen as
-`manual_dep_edges` — a `vector<VarPtr>` of `Scalar[TASK_ID]` variables.
-Compiler-derived edges arrive as `attrs["compiler_manual_dep_edges"]` on
-plain calls. Each entry resolves at codegen time through
+Every kernel task launch inside a manual scope is a `Submit`. Each dep entry —
+`manual_dep_edges` synthesised from `deps_` by `SubmitToCallView`, or
+`compiler_manual_dep_edges` on a plain call — is a TaskId `VarPtr`
+(`Scalar[TASK_ID]` or `Array[N, TASK_ID]`) and resolves at codegen time through
 `manual_task_id_map_` to one of the following forms:
 
 | Producer kind | C++ source emitted by codegen |

--- a/docs/zh-cn/dev/codegen/01-orchestration_codegen.md
+++ b/docs/zh-cn/dev/codegen/01-orchestration_codegen.md
@@ -467,11 +467,15 @@ kwarg 写入类型化的 `Submit::deps_` 字段；codegen 通过临时的 `Submi
 `vector<VarPtr>`，每项为 `Scalar[TASK_ID]` 类型的 Var）。普通 `Call` 携带
 `manual_dep_edges` 的形态已不存在——ManualDepsOnSubmitOnly 结构性属性会校验
 任何跨函数 `Call` 都不携带它；只有 `system.task_dummy` barrier op 作为 fanin
-契约保留该 attr。编译器推导的 manual-scope 依赖来自
+契约保留该 attr。编译器推导的依赖边来自
 [`AutoDeriveTaskDependencies`](../passes/36-auto_derive_task_dependencies.md)，
 保存在 `Call.attrs["compiler_manual_dep_edges"]`（独立的 key，允许出现在普通
-call 上）。Codegen 会按这个顺序合并两组列表，并按 Var identity 去重后再发出
-栈数组。
+call 上）。该 pass 从不分析用户写的 MANUAL scope——在 `pl.manual_scope()` 内，
+显式的 `deps=[...]` 仍是唯一的依赖边来源。它只分析 AUTO 区域，且仅当编译期开关
+`analyze_auto_scopes_for_deps` 打开时才生效：被完整覆盖的区域随后会被物化为
+*编译器自有*的 MANUAL scope；部分覆盖的默认模式区域保持 AUTO，其可表示的边叠加
+在 runtime 自动追踪之上发出；手工放置的 `pl.scope()` 一旦回退，则会剥离其部分
+推导边。Codegen 会按这个顺序合并两组列表，并按 Var identity 去重后再发出栈数组。
 
 ### TaskId 的来源
 

--- a/docs/zh-cn/dev/codegen/01-orchestration_codegen.md
+++ b/docs/zh-cn/dev/codegen/01-orchestration_codegen.md
@@ -453,18 +453,15 @@ params_t1.set_dependencies(params_t1_deps, params_t1_deps_count);
 ```
 
 只有当 TaskId 可能合法地持有 `PTO2TaskId::invalid()` 哨兵时，dep 槽位才被
-`if (task_id.is_valid())` 包裹——`None` 循环 carry 种子、循环首次迭代的
-iter_arg carry，或未写入的数组槽——因为 invalid id 绝不能进入
-`set_dependencies`。而**新鲜的直接生产者** TaskId（同一直线作用域中更早的
-`pl.submit(...)` 的输出）静态上恒为有效，因此其插入不加守卫（issue #1966），
-从编排热路径上消除了这个恒真分支。
+`if (task_id.is_valid())` 包裹，因为 invalid id 绝不能进入
+`set_dependencies`；而**新鲜的直接生产者** TaskId 静态上恒为有效，因此其插入
+不加守卫（issue #1966）。完整的分类见 [TaskId 的来源](#taskid-的来源)。
 
 不再有 `params.add_dep(...)` 调用，也没有 16 条依赖上限——runtime 的
-`Arg::set_dependencies` 原语没有上限，栈数组按精确数量定长。dep 边
-用户依赖来自 parser：parser 把用户的 `pl.submit(..., deps=[tid1, tid2])`
-kwarg 写入类型化的 `Submit::deps_` 字段；codegen 通过临时的 `SubmitToCallView`
-读取它们——该 view 把 `deps_` 合成为 `attrs["manual_dep_edges"]`（一个
-`vector<VarPtr>`，每项为 `Scalar[TASK_ID]` 类型的 Var）。普通 `Call` 携带
+`Arg::set_dependencies` 原语没有上限，栈数组按精确数量定长。用户依赖来自
+parser：parser 把用户的 `pl.submit(..., deps=[tid1, tid2])` kwarg 写入类型化的
+`Submit::deps_` 字段；codegen 通过临时的 `SubmitToCallView` 读取它们——该 view
+把 `deps_` 合成为 `attrs["manual_dep_edges"]`。普通 `Call` 携带
 `manual_dep_edges` 的形态已不存在——ManualDepsOnSubmitOnly 结构性属性会校验
 任何跨函数 `Call` 都不携带它；只有 `system.task_dummy` barrier op 作为 fanin
 契约保留该 attr。编译器推导的依赖边来自
@@ -472,10 +469,11 @@ kwarg 写入类型化的 `Submit::deps_` 字段；codegen 通过临时的 `Submi
 保存在 `Call.attrs["compiler_manual_dep_edges"]`（独立的 key，允许出现在普通
 call 上）。该 pass 从不分析用户写的 MANUAL scope——在 `pl.manual_scope()` 内，
 显式的 `deps=[...]` 仍是唯一的依赖边来源。它只分析 AUTO 区域，且仅当编译期开关
-`analyze_auto_scopes_for_deps` 打开时才生效：被完整覆盖的区域随后会被物化为
-*编译器自有*的 MANUAL scope；部分覆盖的默认模式区域保持 AUTO，其可表示的边叠加
-在 runtime 自动追踪之上发出；手工放置的 `pl.scope()` 一旦回退，则会剥离其部分
-推导边。Codegen 会按这个顺序合并两组列表，并按 Var identity 去重后再发出栈数组。
+`analyze_auto_scopes_for_deps` 打开时才生效。默认模式（`auto_scope=True`）区域
+在被完整覆盖时会成为*编译器自有*的 MANUAL scope，否则保持 AUTO，其可表示的边
+叠加在 runtime 自动追踪之上发出；手工放置的 `pl.scope()` 始终保持
+`manual=false`，一旦分析回退则会剥离其部分推导边。Codegen 会按这个顺序合并两组
+列表，并按 Var identity 去重后再发出栈数组。
 
 ### TaskId 的来源
 

--- a/docs/zh-cn/dev/passes/36-auto_derive_task_dependencies.md
+++ b/docs/zh-cn/dev/passes/36-auto_derive_task_dependencies.md
@@ -137,4 +137,4 @@ deps，并保持 AUTO tracking。已实现的 fallback 触发条件包括：
 - Lowering: [Orchestration Code Generation][orchestration-lowering]
 
 [pass-source]: ../../../../src/ir/transforms/auto_derive_task_dependencies_pass.cpp
-[orchestration-lowering]: ../codegen/01-orchestration_codegen.md#manual-scope-and-taskid-lowering
+[orchestration-lowering]: ../codegen/01-orchestration_codegen.md#manual-scope-与-taskid-降级

--- a/include/pypto/ir/transforms/pass_properties.h
+++ b/include/pypto/ir/transforms/pass_properties.h
@@ -356,8 +356,9 @@ inline const PassProperties kExpandManualPhaseFenceProperties{
 // MANUAL scopes are never analyzed: their explicit ``deps=[...]`` edges remain
 // the only task dependencies. AUTO-scope analysis is controlled by the pass
 // option and remains off by default at high-level pipeline entry points. The
-// pass preserves CallDirectionsResolved because it does not rewrite call args
-// or direction attrs.
+// pass preserves CallDirectionsResolved because it does not rewrite call args:
+// in an analyzed AUTO region it only refines already-resolved directions
+// (``Input -> NoDep``, ``InOut -> OutputExisting``), leaving every arg resolved.
 inline const PassProperties kAutoDeriveTaskDependenciesProperties{
     .required = {IRProperty::SplitIncoreOrch, IRProperty::CallDirectionsResolved},
     .produced = {IRProperty::CallDirectionsResolved}};

--- a/include/pypto/ir/transforms/pass_properties.h
+++ b/include/pypto/ir/transforms/pass_properties.h
@@ -352,11 +352,12 @@ inline const PassProperties kExpandManualPhaseFenceProperties{
 // -- Automatic runtime-scope task dependency pass -----------------------------
 //
 // Reads ``Call.attrs_["arg_directions"]`` and writes
-// ``Call.attrs_["compiler_manual_dep_edges"]`` for runtime scopes. MANUAL
-// scopes are analyzed in the default pipeline. AUTO-scope analysis is
-// controlled by the pass option and remains off by default at high-level
-// pipeline entry points. The pass preserves CallDirectionsResolved because it
-// does not rewrite call args or direction attrs.
+// ``Call.attrs_["compiler_manual_dep_edges"]`` for runtime scopes. User-written
+// MANUAL scopes are never analyzed: their explicit ``deps=[...]`` edges remain
+// the only task dependencies. AUTO-scope analysis is controlled by the pass
+// option and remains off by default at high-level pipeline entry points. The
+// pass preserves CallDirectionsResolved because it does not rewrite call args
+// or direction attrs.
 inline const PassProperties kAutoDeriveTaskDependenciesProperties{
     .required = {IRProperty::SplitIncoreOrch, IRProperty::CallDirectionsResolved},
     .produced = {IRProperty::CallDirectionsResolved}};


### PR DESCRIPTION
## Summary

`AutoDeriveTaskDependencies` never analyzes a user-written MANUAL scope — `auto_derive_task_dependencies_pass.cpp:1394` returns the scope unchanged when `op->manual_` is set. Inside `pl.manual_scope()`, the explicit `deps=[...]` list is the only source of task dependency edges.

The orchestration codegen doc contradicted this by calling `compiler_manual_dep_edges` **"compiler-derived manual-scope edges"**, which implies the compiler infers dependencies there. That wording could lead users to omit required `deps=[...]` edges in a MANUAL scope.

Changes:

- **`docs/{en,zh-cn}/dev/codegen/01-orchestration_codegen.md`** — drop "manual-scope" from the phrase and state where derived edges actually come from: AUTO regions only, gated on the compile-time `analyze_auto_scopes_for_deps` switch. Spells out all three outcomes:
  - fully covered → materialized as a *compiler-owned* MANUAL scope
  - partially covered default-mode → stays AUTO, representable edges emitted on top of runtime auto-tracking
  - hand-placed `pl.scope()` that falls back → partial edges stripped (`StripCompilerDeps`, `:1451`)
- **`include/pypto/ir/transforms/pass_properties.h`** — correct the `kAutoDeriveTaskDependenciesProperties` comment, which claimed "MANUAL scopes are analyzed in the default pipeline". This is false per the code and contradicted both the new doc text and `passes.h:733`. Comment-only change.
- **`docs/zh-cn/dev/passes/36-auto_derive_task_dependencies.md`** — fix a broken cross-reference anchor that pointed at the English heading slug instead of the translated one.

## Testing

- [x] `tests/lint/check_docs_en_zh_parity.py` — 80 paired paths OK
- [x] `tests/lint/check_english_only.py` — 1080 passed, 0 failed
- [x] Pre-commit hooks: markdownlint-cli2, cpplint, clang-format, check-headers all pass
- [x] Claims verified against `auto_derive_task_dependencies_pass.cpp`, `materialize_runtime_scopes_pass.cpp`, `orchestration_codegen.cpp`, and `tests/ut/codegen/test_orchestration_task_deps.py`
- No build/test run locally: the only non-doc change is a C++ comment, which cannot affect behavior.

## Note

`docs/en/dev/codegen/01-orchestration_codegen.md` is now 704 lines (was 697), just over the 700-line split threshold in `.claude/rules/documentation-length.md`. The file was already at the limit before this change; splitting the ~250-line `## Manual Scope and TaskId Lowering` section is a reasonable follow-up but is out of scope here.