### PR TITLE
fix(runtime): Scope the L3 swimlane name map to each dispatch's own L2 program

### DIFF
--- a/docs/en/dev/03-runtime-dfx.md
+++ b/docs/en/dev/03-runtime-dfx.md
@@ -43,6 +43,7 @@ namespaces the prefix per dispatch:
 ```text
 <work_dir>/dfx_outputs/
 ├── rank0/d0/          # rank 0, its 0th dispatch
+│   └── dispatch_program.json   # which next_levels/<program> ran here
 ├── rank0/d1/          # rank 0, its 1st dispatch
 └── rank1/d0/
 ```
@@ -54,6 +55,15 @@ under the chip it was placed on — those are handed out round-robin over
 the program's chips in submit order. Each leaf holds the flat artefacts
 from the table above, so the L2 contract applies unchanged within one
 dispatch directory.
+
+The path records *where* a dispatch ran, not *what* it ran, so
+`_submit_chip` also drops a `dispatch_program.json` naming the
+`next_levels/<program>` behind it. Kernel names must be resolved through
+it: `func_id` is a per-L2-program namespace — every program numbers its
+kernels from 0 — so a name map merged across programs relabels one
+program's tasks with another's names, silently and plausibly. A dispatch
+whose program cannot be resolved is converted with anonymous labels
+instead of guessed ones.
 
 ## L2 swimlane runs the kernel twice (onboard)
 
@@ -286,6 +296,8 @@ this hint at the end of every scope-stats-enabled run.
 | Pipeline bundle | [runner.py](../../../python/pypto/runtime/runner.py) | `_DfxOpts` dataclass + `_DfxOpts.from_run_config` |
 | Per-flag post-run dispatch | [runner.py](../../../python/pypto/runtime/runner.py) | `_collect_dfx_artifacts` |
 | Kernel-name map synthesis | [runner.py](../../../python/pypto/runtime/runner.py) | `_write_name_map` |
+| L3 per-dispatch program marker | [distributed_runner.py](../../../python/pypto/runtime/distributed_runner.py) | `_record_dispatch_program` / `_read_dispatch_program` |
+| L3 per-dispatch swimlane conversion | [distributed_runner.py](../../../python/pypto/runtime/distributed_runner.py) | `_collect_l3_swimlane` / `_write_dispatch_name_map` |
 | pytest entry | [tests/st/conftest.py](../../../tests/st/conftest.py) | `pytest_addoption` |
 | Harness pipeline ctx | [tests/st/harness/core/test_runner.py](../../../tests/st/harness/core/test_runner.py) | `start_pipeline(..., enable_*)` |
 

--- a/docs/zh-cn/dev/03-runtime-dfx.md
+++ b/docs/zh-cn/dev/03-runtime-dfx.md
@@ -39,6 +39,7 @@ dispatch——若共用同一 prefix，各次 dispatch 会互相覆盖同名产�
 ```text
 <work_dir>/dfx_outputs/
 ├── rank0/d0/          # rank 0 的第 0 次 dispatch
+│   └── dispatch_program.json   # 本次 dispatch 运行的 next_levels/<program>
 ├── rank0/d1/          # rank 0 的第 1 次 dispatch
 └── rank1/d0/
 ```
@@ -48,6 +49,14 @@ dispatch——若共用同一 prefix，各次 dispatch 会互相覆盖同名产�
 comm-less 的（没有 `device=`）则按被分配到的芯片——这类 dispatch 按提交
 顺序在程序的各芯片间轮询分配。每个叶子目录内是上表所述的扁平产物，
 因此在单个 dispatch 目录内 L2 契约完全适用。
+
+该路径只记录 dispatch 跑在**哪里**，不记录它跑的是**什么**，因此
+`_submit_chip` 还会写一份 `dispatch_program.json`，指明背后的
+`next_levels/<program>`。kernel 名称必须经由它解析：`func_id` 是
+**每个 L2 program 独立的命名空间**——每个 program 的 kernel 都从 0 开始
+编号，所以跨 program 合并的 name map 会把一个 program 的 task 标成另一个
+program 的名字，既静默又看似合理。若某次 dispatch 的 program 无法解析，
+转换时使用匿名标签，而不是猜一个名字。
 
 ## L2 泳道会把 kernel 跑两遍（onboard）
 
@@ -257,6 +266,8 @@ python runtime/tools/scope_stats_plot.py \
 | 流水线打包 | [runner.py](../../../python/pypto/runtime/runner.py) | `_DfxOpts` dataclass + `_DfxOpts.from_run_config` |
 | 按 flag 后处理分发 | [runner.py](../../../python/pypto/runtime/runner.py) | `_collect_dfx_artifacts` |
 | kernel 名称映射合成 | [runner.py](../../../python/pypto/runtime/runner.py) | `_write_name_map` |
+| L3 每次 dispatch 的 program 标记 | [distributed_runner.py](../../../python/pypto/runtime/distributed_runner.py) | `_record_dispatch_program` / `_read_dispatch_program` |
+| L3 每次 dispatch 的泳道转换 | [distributed_runner.py](../../../python/pypto/runtime/distributed_runner.py) | `_collect_l3_swimlane` / `_write_dispatch_name_map` |
 | pytest 入口 | [tests/st/conftest.py](../../../tests/st/conftest.py) | `pytest_addoption` |
 | Harness 流水线上下文 | [tests/st/harness/core/test_runner.py](../../../tests/st/harness/core/test_runner.py) | `start_pipeline(..., enable_*)` |
 

--- a/python/pypto/runtime/distributed_runner.py
+++ b/python/pypto/runtime/distributed_runner.py
@@ -507,6 +507,13 @@ def _make_call_config(
 _RANK_DIR_GLOB = "rank*"
 _DISPATCH_DIR_GLOB = "d[0-9]*"
 
+# Written by ``_submit_chip`` into each dispatch dir and read back by
+# ``_collect_l3_swimlane``. ``rank{w}/d{k}`` records *where* a dispatch ran but not
+# *what* it ran, and a kernel's ``func_id`` only means something within one
+# ``next_levels/<program>`` — so naming a dispatch's tasks needs this marker
+# (issue #2169).
+_DISPATCH_PROGRAM_FILE = "dispatch_program.json"
+
 
 def _dfx_rank_label(worker: int) -> str:
     """Directory name namespacing one card's DFX artifacts.
@@ -544,6 +551,53 @@ def _resolve_chip_worker(orch: Any, worker: int | None) -> int:
     return seq % chip_count
 
 
+def _reset_dfx_dispatch_state(orch: Any, chip_cids: dict[str, Any]) -> None:
+    """Reset the per-run dispatch state :func:`_submit_chip` reads off ``orch``.
+
+    ``_dfx_dispatch_idx`` numbers each card's dispatches ``d0, d1, ...`` fresh per
+    run, so the swimlane two-pass files one dispatch under one directory.
+
+    ``_dfx_chip_names`` reverses the registered ``callables`` mapping so
+    ``_submit_chip`` can name the L2 program behind an otherwise opaque
+    ``CallableHandle``. Keyed by ``id()``: the handle is not required to be
+    hashable, and ``chip_cids`` holds every one alive for the whole run, so the
+    ids are stable and unique.
+    """
+    orch._dfx_dispatch_idx = {}
+    orch._dfx_chip_names = {id(cid): name for name, cid in chip_cids.items()}
+
+
+def _record_dispatch_program(orch: Any, callable_id: Any, disp_dir: Path) -> None:
+    """Record which L2 program a dispatch runs, for the swimlane post-pass.
+
+    A kernel's ``func_id`` is a per-L2-program namespace — every
+    ``next_levels/<program>/kernel_config.py`` numbers its kernels from 0 — so
+    labelling a dispatch's records requires knowing the program that produced
+    them. This wrapper is the only place that sees both the dispatch directory
+    and the callable being dispatched, so it stamps the pairing on disk
+    (:data:`_DISPATCH_PROGRAM_FILE`) for :func:`_collect_l3_swimlane` to read
+    back. Going through the filesystem keeps the two halves independent of where
+    the runtime places the L3 orchestrator, and the marker is rewritten
+    identically by both swimlane passes.
+
+    Best-effort: a marker that cannot be written costs kernel labels, never the
+    run. Silent when the caller bypassed :func:`_reset_dfx_dispatch_state` and
+    left no name table on ``orch``.
+    """
+    name = getattr(orch, "_dfx_chip_names", {}).get(id(callable_id))
+    if name is None:
+        return
+    try:
+        disp_dir.mkdir(parents=True, exist_ok=True)
+        (disp_dir / _DISPATCH_PROGRAM_FILE).write_text(json.dumps({"program": name}), encoding="utf-8")
+    except OSError as e:
+        print(
+            f"Could not record the dispatch program for {disp_dir} ({type(e).__name__}: {e}); "
+            "its swimlane falls back to anonymous task labels unless the build has a single "
+            "L2 program"
+        )
+
+
 def _submit_chip(orch: Any, callable_id: Any, task_args: Any, config: Any, worker: int | None) -> Any:
     """``orch.submit_next_level`` with per-dispatch DFX ``output_prefix`` isolation.
 
@@ -561,8 +615,11 @@ def _submit_chip(orch: Any, callable_id: Any, task_args: Any, config: Any, worke
     so it never races the already-queued task.
 
     ``k`` comes from a per-card counter on ``orch`` reset at the top of every
-    run (see ``_dispatch.orch_fn``), so the numbering is deterministic and
-    matches across the swimlane two-pass.
+    run (see :func:`_reset_dfx_dispatch_state`), so the numbering is
+    deterministic and matches across the swimlane two-pass. The dispatched
+    program is stamped into the same directory by
+    :func:`_record_dispatch_program`, so the offline post-pass can label the
+    records with the right program's kernel names.
 
     Every dispatch is namespaced ``rank{worker}/d{k}`` by the chip it runs on.
     When DFX is off (``output_prefix`` unset) the call is forwarded unchanged.
@@ -585,6 +642,7 @@ def _submit_chip(orch: Any, callable_id: Any, task_args: Any, config: Any, worke
     k = idx_map.get(rank_label, 0)
     idx_map[rank_label] = k + 1
     config.output_prefix = f"{base}/{rank_label}/d{k}"
+    _record_dispatch_program(orch, callable_id, Path(config.output_prefix))
     try:
         return orch.submit_next_level(callable_id, task_args, config, worker=worker)
     finally:
@@ -615,6 +673,65 @@ def _clear_dfx_dispatch_dirs(dfx_base: Path) -> None:
                 shutil.rmtree(disp_dir, ignore_errors=True)
 
 
+def _read_dispatch_program(disp_dir: Path) -> str | None:
+    """Name of the L2 program that ran this dispatch, or ``None`` if unrecorded.
+
+    Reads back the marker :func:`_record_dispatch_program` wrote. A missing or
+    malformed marker is not an error — it only means the labels for this dispatch
+    cannot be resolved (see :func:`_collect_l3_swimlane`).
+    """
+    marker = disp_dir / _DISPATCH_PROGRAM_FILE
+    if not marker.exists():
+        return None
+    try:
+        program = json.loads(marker.read_text(encoding="utf-8"))["program"]
+    except (OSError, ValueError, KeyError, TypeError):
+        return None
+    return str(program)
+
+
+def _write_dispatch_name_map(disp_dir: Path, chip_dir: Path, cache: dict[str, dict[str, str]]) -> Path | None:
+    """Write *disp_dir*'s ``name_map.json`` from *chip_dir*'s ``kernel_config.py``.
+
+    The map is the one the L2 path synthesises (:func:`~pypto.runtime.runner._write_name_map`),
+    scoped to a single program: ``func_id`` numbering restarts per
+    ``next_levels/<program>``, so merging several programs' tables would silently
+    relabel one program's tasks with another's names (issue #2169).
+
+    *cache* memoises the per-program table across the dispatches that share a
+    program, so each ``kernel_config.py`` is exec'd once per run.
+
+    Returns the written path, or ``None`` when no table could be resolved (the
+    converter then falls back to anonymous ``task(rXtY)`` labels).
+    """
+    program = chip_dir.name
+    if program not in cache:
+        kc = chip_dir / "kernel_config.py"
+        table: dict[str, str] = {}
+        if kc.exists():
+            try:
+                from simpler_setup.tools.swimlane_converter import (  # noqa: PLC0415  # pyright: ignore[reportMissingImports]
+                    load_kernel_config,
+                )
+
+                table = load_kernel_config(str(kc))
+            except Exception as e:  # noqa: BLE001 - best-effort label resolution, never fatal
+                print(
+                    f"Skipping L3 swimlane name_map for {program} ({type(e).__name__}: {e}); "
+                    "its labels fall back to defaults"
+                )
+        cache[program] = table
+    table = cache[program]
+    if not table:
+        return None
+    name_map_path = disp_dir / "name_map.json"
+    name_map_path.write_text(
+        json.dumps({"level": 2, "orchestrator_name": None, "callable_id_to_name": table}, indent=2),
+        encoding="utf-8",
+    )
+    return name_map_path
+
+
 def _collect_l3_swimlane(output_dir: Path, platform: str) -> None:
     """Convert each dispatch's swimlane records into a ``merged_swimlane_*.json``.
 
@@ -624,12 +741,18 @@ def _collect_l3_swimlane(output_dir: Path, platform: str) -> None:
     swimlane). Globbing ``rank*`` — rather than iterating a rank count — picks up
     whichever cards actually ran, so a comm-less / single-card L3 program (which never
     creates ``rank{0..n}``) still has its records converted. This best-effort
-    post-pass runs the offline ``swimlane_converter`` once per dispatch dir,
-    resolving kernel names from a merged map of every chip callable's
-    ``kernel_config.py`` (``next_levels/*/``). Each dispatch's records are
-    single-chip, so the L2 converter applies unchanged — and a card that ran
-    several (possibly different) programs keeps one swimlane per dispatch instead
-    of overwriting down to the last.
+    post-pass runs the offline ``swimlane_converter`` once per dispatch dir. Each
+    dispatch's records are single-chip, so the L2 converter applies unchanged —
+    and a card that ran several (possibly different) programs keeps one swimlane
+    per dispatch instead of overwriting down to the last.
+
+    Kernel names are resolved **per dispatch**, from the ``kernel_config.py`` of
+    the ``next_levels/<program>`` that :func:`_record_dispatch_program` stamped on
+    that dispatch. ``func_id`` numbering restarts in every program, so a table
+    merged across programs would relabel one program's tasks with another's names
+    — silently and plausibly (issue #2169). A dispatch whose program cannot be
+    resolved is therefore converted with anonymous labels rather than guessed
+    ones, and says so.
 
     Onboard-only: the simulator emits records but not the task metadata the
     converter joins against, so conversion is skipped there (mirrors the L2
@@ -647,19 +770,18 @@ def _collect_l3_swimlane(output_dir: Path, platform: str) -> None:
 
     # ``glob("*/")`` directory filtering is only reliable on 3.11+; filter
     # explicitly so this works on the 3.10 baseline too.
-    chip_dirs = sorted(d for d in (output_dir / "next_levels").glob("*") if d.is_dir())
-    merged: dict = {}
-    try:
-        from simpler_setup.tools.swimlane_converter import (  # noqa: PLC0415  # pyright: ignore[reportMissingImports]
-            load_kernel_config,
-        )
-
-        for chip_dir in chip_dirs:
-            kc = chip_dir / "kernel_config.py"
-            if kc.exists():
-                merged.update(load_kernel_config(str(kc)))
-    except Exception as e:  # noqa: BLE001 - best-effort label resolution, never fatal
-        print(f"Skipping L3 swimlane name_map ({type(e).__name__}: {e}); labels fall back to defaults")
+    # A ``next_levels/<name>/`` is an L2 program exactly when it carries a
+    # ``kernel_config.py`` — the same test ``_assemble_chip_callables`` applies,
+    # so both halves count the same programs and a stray subdir cannot make the
+    # single-program fallback below look ambiguous.
+    chip_dirs = {
+        d.name: d
+        for d in sorted((output_dir / "next_levels").glob("*"))
+        if d.is_dir() and (d / "kernel_config.py").exists()
+    }
+    # program name -> its ``func_id`` table; filled on first use by
+    # ``_write_dispatch_name_map`` so each config is loaded once per run.
+    name_map_cache: dict[str, dict[str, str]] = {}
 
     dfx_base = output_dir / "dfx_outputs"
     # See the docstring for why we glob rather than iterate a rank count.
@@ -678,19 +800,36 @@ def _collect_l3_swimlane(output_dir: Path, platform: str) -> None:
             # dispatch must not turn a successful run into a post-processing
             # crash. The raw records remain on disk for manual conversion.
             try:
-                name_map_path: Path | None = None
-                if merged:
-                    name_map_path = disp_dir / "name_map.json"
-                    name_map_path.write_text(
-                        json.dumps(
-                            {"level": 2, "orchestrator_name": None, "callable_id_to_name": merged},
-                            indent=2,
-                        ),
-                        encoding="utf-8",
+                program = _read_dispatch_program(disp_dir)
+                if program is None and len(chip_dirs) == 1:
+                    # One L2 program in the build: no ambiguity to resolve, so an
+                    # unmarked dispatch (e.g. artifacts from an older run) can
+                    # still be named correctly.
+                    program = next(iter(chip_dirs))
+                if program is None or program not in chip_dirs:
+                    print(
+                        f"No L2 program recorded for {rank_dir.name}/{disp_dir.name}; converting with "
+                        "anonymous task labels. For real kernel names, re-run: python -m "
+                        "simpler_setup.tools.swimlane_converter "
+                        f"{records} -k {output_dir / 'next_levels'}/<program>/kernel_config.py"
                     )
-                # ``work_dir`` only feeds the converter's ``-k`` fallback; the
-                # merged ``name_map`` passed as ``func_names`` takes precedence.
-                work_dir = chip_dirs[0] if chip_dirs else output_dir
+                    # No ``kernel_config.py`` here, so ``_generate_swimlane``
+                    # omits ``-k`` rather than pointing the converter at another
+                    # program's table.
+                    work_dir: Path = output_dir
+                    name_map_path: Path | None = None
+                    # With neither option the converter auto-discovers a sibling
+                    # ``name_map*.json``, so a map left by an earlier run would
+                    # quietly resurrect the mislabelling. Drop it: anonymous
+                    # labels are the point of this branch.
+                    for stale in disp_dir.glob("name_map*.json"):
+                        stale.unlink(missing_ok=True)
+                else:
+                    # ``work_dir`` feeds the converter's ``-k`` fallback and the
+                    # ``name_map`` passed as ``func_names`` takes precedence —
+                    # both must name the program that ran this dispatch.
+                    work_dir = chip_dirs[program]
+                    name_map_path = _write_dispatch_name_map(disp_dir, work_dir, name_map_cache)
                 _generate_swimlane(work_dir, disp_dir, records, func_names=name_map_path)
             except Exception as e:  # noqa: BLE001 - best-effort post-pass, never fatal
                 print(
@@ -740,8 +879,10 @@ def _dispatch(
         # ``_submit_chip`` numbers a card's dispatches ``d0, d1, ...`` fresh each
         # pass. Two-pass swimlane reissues the same dispatch order, so pass 1
         # (deps.json) and pass 2 (records) land the same dispatch in the same
-        # ``rank{w}/d{k}`` dir — letting the converter join them.
-        orch._dfx_dispatch_idx = {}
+        # ``rank{w}/d{k}`` dir — letting the converter join them. The same call
+        # publishes the callable -> L2 program names ``_submit_chip`` stamps into
+        # each dispatch dir.
+        _reset_dfx_dispatch_state(orch, chip_cids)
         # Comm-less dispatches carry no rank, so ``_resolve_chip_worker`` hands
         # them out round-robin over the program's chips; both the count and the
         # sequence live on ``orch`` so the wrapper stays a pure function of the
@@ -1331,7 +1472,7 @@ class DistributedWorker(Worker):
                     program_domains = domains_by_program.get(program_id)
                     if program_domains and self._reset_persistent_windows:
                         self._reset_persistent_domains(orch, program_domains)
-                    orch._dfx_dispatch_idx = {}
+                    _reset_dfx_dispatch_state(orch, request.state["chip_cids"])
                     request.state["entry_fn"](
                         orch,
                         None,

--- a/python/pypto/runtime/distributed_runner.py
+++ b/python/pypto/runtime/distributed_runner.py
@@ -800,6 +800,15 @@ def _collect_l3_swimlane(output_dir: Path, platform: str) -> None:
             # dispatch must not turn a successful run into a post-processing
             # crash. The raw records remain on disk for manual conversion.
             try:
+                # A dispatch must be rendered from a map this run wrote, so drop
+                # any left by an earlier one before deciding what to write. When
+                # no map is passed, the converter falls back to a sibling
+                # ``name_map*.json``, and a stale one quietly resurrects the
+                # mislabelling below. Doing it here — rather than per branch —
+                # makes that hold whatever the converter's own precedence
+                # between ``--func-names``, ``-k`` and the sibling turns out to be.
+                for stale in disp_dir.glob("name_map*.json"):
+                    stale.unlink(missing_ok=True)
                 program = _read_dispatch_program(disp_dir)
                 if program is None and len(chip_dirs) == 1:
                     # One L2 program in the build: no ambiguity to resolve, so an
@@ -818,12 +827,6 @@ def _collect_l3_swimlane(output_dir: Path, platform: str) -> None:
                     # program's table.
                     work_dir: Path = output_dir
                     name_map_path: Path | None = None
-                    # With neither option the converter auto-discovers a sibling
-                    # ``name_map*.json``, so a map left by an earlier run would
-                    # quietly resurrect the mislabelling. Drop it: anonymous
-                    # labels are the point of this branch.
-                    for stale in disp_dir.glob("name_map*.json"):
-                        stale.unlink(missing_ok=True)
                 else:
                     # ``work_dir`` feeds the converter's ``-k`` fallback and the
                     # ``name_map`` passed as ``func_names`` takes precedence —

--- a/python/pypto/runtime/runner.py
+++ b/python/pypto/runtime/runner.py
@@ -1120,7 +1120,9 @@ def _generate_swimlane(
     Output is written to *swimlane_dir* alongside the input ``l2_swimlane_records_*.json``.
 
     Args:
-        work_dir: Directory containing ``kernel_config.py``.
+        work_dir: Directory containing ``kernel_config.py``. Passed to the
+            converter as ``-k`` when the file exists, and omitted when it does
+            not (the converter rejects a missing path).
         swimlane_dir: Directory where swimlane JSON files are written.
         perf_file: Path to the ``l2_swimlane_records_*.json`` file produced by
             CodeRunner and already moved into *swimlane_dir*.  When ``None``,
@@ -1153,9 +1155,13 @@ def _generate_swimlane(
         str(perf_file),
         "-o",
         str(output_path),
-        "-k",
-        str(kernel_config_path),
     ]
+    # The converter *errors out* on a ``-k`` path that does not exist, so only
+    # pass it when there is a config to read: a caller with no single owning
+    # program (see ``_collect_l3_swimlane``) still gets a swimlane, just with
+    # anonymous task labels.
+    if kernel_config_path.exists():
+        cmd += ["-k", str(kernel_config_path)]
     # ``--func-names`` (the synthesised name_map) takes precedence over ``-k``
     # for label resolution; ``-k`` stays as the fallback when no map was written.
     if func_names is not None:

--- a/tests/ut/runtime/test_distributed_worker.py
+++ b/tests/ut/runtime/test_distributed_worker.py
@@ -17,6 +17,8 @@ domains, and a complete synchronous cleanup boundary for every caller-visible
 request.
 """
 
+import importlib.util
+import json
 import sys
 import threading
 import weakref
@@ -38,6 +40,7 @@ from pypto.runtime.distributed_runner import (
     _clear_dfx_dispatch_dirs,
     _collect_l3_swimlane,
     _make_call_config,
+    _reset_dfx_dispatch_state,
     _submit_chip,
 )
 from pypto.runtime.runner import RunConfig
@@ -1288,6 +1291,39 @@ class TestSubmitChip:
         _submit_chip(orch, "chip", "ta", cfg, 1)
         assert [c[1] for c in orch.calls] == [1, 0, 1]
 
+    def test_records_each_dispatchs_l2_program(self, tmp_path):
+        # Issue #2169: ``rank{w}/d{k}`` says where a dispatch ran, not what it
+        # ran, and ``func_id`` only means something within one L2 program. The
+        # marker written here is what lets the offline post-pass label a
+        # dispatch's records with its own program's kernel names.
+        chip_cids = {"lm_head": object(), "mtp_decode_layer": object()}
+        orch = _RecordingOrch()
+        _reset_dfx_dispatch_state(orch, chip_cids)
+        cfg = _SpyDfxConfig(output_prefix=str(tmp_path))
+
+        # One card, two different programs -> d0 and d1 name their own program.
+        _submit_chip(orch, chip_cids["mtp_decode_layer"], "ta", cfg, 0)
+        _submit_chip(orch, chip_cids["lm_head"], "ta", cfg, 0)
+
+        assert json.loads((tmp_path / "rank0" / "d0" / "dispatch_program.json").read_text()) == {
+            "program": "mtp_decode_layer"
+        }
+        assert json.loads((tmp_path / "rank0" / "d1" / "dispatch_program.json").read_text()) == {
+            "program": "lm_head"
+        }
+
+    def test_no_marker_when_chip_names_unstamped(self, tmp_path):
+        # A caller that bypassed ``_reset_dfx_dispatch_state`` leaves no name
+        # table on ``orch``; the dispatch must still go through (the marker is a
+        # diagnostic, never a precondition).
+        orch = _RecordingOrch()
+        cfg = _SpyDfxConfig(output_prefix=str(tmp_path))
+
+        _submit_chip(orch, "chip_a", "ta", cfg, 0)
+
+        assert orch.calls == [("chip_a", 0, f"{tmp_path}/rank0/d0")]
+        assert not (tmp_path / "rank0" / "d0" / "dispatch_program.json").exists()
+
 
 def _write_dfx_dispatch_dirs(dfx: Path, *rels: str) -> None:
     """Lay down ``<dfx>/<rel>/l2_swimlane_records.json`` for each dispatch dir.
@@ -1298,6 +1334,54 @@ def _write_dfx_dispatch_dirs(dfx: Path, *rels: str) -> None:
     for rel in rels:
         (dfx / rel).mkdir(parents=True)
         (dfx / rel / "l2_swimlane_records.json").write_text("{}", encoding="utf-8")
+
+
+def _write_chip_program(output_dir: Path, program: str, *kernel_names: str) -> None:
+    """Lay down ``next_levels/<program>/kernel_config.py`` naming *kernel_names*.
+
+    Every L2 program numbers its kernels from ``func_id`` 0 — that shared
+    numbering is exactly what makes a name map merged across programs wrong
+    (issue #2169), so each program written here starts at 0 on purpose.
+    """
+    chip_dir = output_dir / "next_levels" / program
+    chip_dir.mkdir(parents=True)
+    kernels = [{"func_id": i, "name": name} for i, name in enumerate(kernel_names)]
+    (chip_dir / "kernel_config.py").write_text(f"KERNELS = {kernels!r}\n", encoding="utf-8")
+
+
+def _mark_dispatch_program(disp_dir: Path, program: str) -> None:
+    """Stamp the marker ``_submit_chip`` writes for a dispatch of *program*."""
+    (disp_dir / "dispatch_program.json").write_text(json.dumps({"program": program}), encoding="utf-8")
+
+
+@pytest.fixture
+def fake_swimlane_converter(monkeypatch):
+    """Register a fake ``simpler_setup.tools.swimlane_converter``.
+
+    The real module ships with the optional ``simpler`` runtime package, which is
+    not installed in CI. The fake reproduces the one function pypto calls,
+    ``load_kernel_config``, with the real contract: import the ``kernel_config.py``
+    and return its ``func_id`` (as ``str``) -> ``name`` mapping. Tests therefore
+    still exercise the genuine on-disk layout.
+    """
+    pkg = ModuleType("simpler_setup")
+    tools = ModuleType("simpler_setup.tools")
+    mod = ModuleType("simpler_setup.tools.swimlane_converter")
+
+    def load_kernel_config(config_path: str) -> dict[str, str]:
+        spec = importlib.util.spec_from_file_location("kernel_config", config_path)
+        assert spec is not None and spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return {str(k["func_id"]): k["name"] for k in module.KERNELS}
+
+    mod.load_kernel_config = load_kernel_config  # pyright: ignore[reportAttributeAccessIssue]
+    tools.swimlane_converter = mod  # pyright: ignore[reportAttributeAccessIssue]
+    pkg.tools = tools  # pyright: ignore[reportAttributeAccessIssue]
+    monkeypatch.setitem(sys.modules, "simpler_setup", pkg)
+    monkeypatch.setitem(sys.modules, "simpler_setup.tools", tools)
+    monkeypatch.setitem(sys.modules, "simpler_setup.tools.swimlane_converter", mod)
+    return mod
 
 
 class TestClearDfxDispatchDirs:
@@ -1330,14 +1414,16 @@ class TestCollectL3Swimlane:
     """``_collect_l3_swimlane`` converts every ``rank*/d{k}`` dispatch's records."""
 
     @staticmethod
-    def _spy_generate_swimlane(monkeypatch) -> list[Path]:
-        """Record which dispatch dirs the converter was invoked on."""
+    def _spy_generate_swimlane(monkeypatch) -> list[SimpleNamespace]:
+        """Record each converter invocation (dispatch dir, ``-k`` dir, name map)."""
         import pypto.runtime.runner as _runner  # noqa: PLC0415
 
-        seen: list[Path] = []
+        seen: list[SimpleNamespace] = []
 
-        def _fake(work_dir, out_dir, records, func_names=None):  # noqa: ANN001, ARG001
-            seen.append(out_dir)
+        def _fake(work_dir, out_dir, records, func_names=None):  # noqa: ANN001
+            seen.append(
+                SimpleNamespace(work_dir=work_dir, out_dir=out_dir, records=records, func_names=func_names)
+            )
 
         monkeypatch.setattr(_runner, "_generate_swimlane", _fake)
         return seen
@@ -1358,7 +1444,7 @@ class TestCollectL3Swimlane:
 
         _collect_l3_swimlane(tmp_path, "a2a3")
 
-        assert sorted(str(p.relative_to(dfx)) for p in seen) == [
+        assert sorted(str(s.out_dir.relative_to(dfx)) for s in seen) == [
             "rank0/d0",
             "rank0/d1",
             "rank1/d0",
@@ -1381,6 +1467,112 @@ class TestCollectL3Swimlane:
         _collect_l3_swimlane(tmp_path, "a2a3")
 
         assert seen == []
+
+    def test_name_map_is_scoped_to_each_dispatchs_own_program(
+        self, tmp_path, monkeypatch, fake_swimlane_converter
+    ):
+        # Regression for issue #2169. Two L2 programs both number their kernels
+        # from func_id 0, so a name map merged across them relabels one
+        # program's tasks with the other's names — silently and plausibly
+        # (``lm_head_dispatch_wait``, a cross-card spin-wait, printed as
+        # ``mtp_projection_norm``). Each dispatch must get its own program's map.
+        seen = self._spy_generate_swimlane(monkeypatch)
+        _write_chip_program(tmp_path, "lm_head", "lm_head_dispatch_push", "lm_head_dispatch_wait")
+        _write_chip_program(tmp_path, "mtp_decode_layer", "mtp_projection_rms", "mtp_projection_norm")
+        dfx = tmp_path / "dfx_outputs"
+        _write_dfx_dispatch_dirs(dfx, "rank0/d0", "rank0/d1")
+        _mark_dispatch_program(dfx / "rank0" / "d0", "mtp_decode_layer")
+        _mark_dispatch_program(dfx / "rank0" / "d1", "lm_head")
+
+        _collect_l3_swimlane(tmp_path, "a2a3")
+
+        by_dir = {s.out_dir.name: s for s in seen}
+        assert set(by_dir) == {"d0", "d1"}
+        # Each dispatch's name map holds its own program's kernels...
+        for disp, program, names in (
+            ("d0", "mtp_decode_layer", ["mtp_projection_rms", "mtp_projection_norm"]),
+            ("d1", "lm_head", ["lm_head_dispatch_push", "lm_head_dispatch_wait"]),
+        ):
+            name_map = json.loads((dfx / "rank0" / disp / "name_map.json").read_text())
+            assert name_map["callable_id_to_name"] == {"0": names[0], "1": names[1]}
+            assert by_dir[disp].func_names == dfx / "rank0" / disp / "name_map.json"
+            # ...and the converter's ``-k`` fallback names the same program, so
+            # the two label sources can never disagree.
+            assert by_dir[disp].work_dir == tmp_path / "next_levels" / program
+
+    def test_sole_program_names_an_unmarked_dispatch(self, tmp_path, monkeypatch, fake_swimlane_converter):
+        # Only one L2 program in the build: there is no namespace to confuse, so
+        # a dispatch without a marker (e.g. artifacts from an older run) is still
+        # labelled rather than degraded to anonymous tasks.
+        seen = self._spy_generate_swimlane(monkeypatch)
+        _write_chip_program(tmp_path, "only_chip", "rms", "matmul")
+        dfx = tmp_path / "dfx_outputs"
+        _write_dfx_dispatch_dirs(dfx, "rank0/d0")
+
+        _collect_l3_swimlane(tmp_path, "a2a3")
+
+        name_map = json.loads((dfx / "rank0" / "d0" / "name_map.json").read_text())
+        assert name_map["callable_id_to_name"] == {"0": "rms", "1": "matmul"}
+        assert seen[0].work_dir == tmp_path / "next_levels" / "only_chip"
+
+    def test_unresolvable_dispatch_converts_without_names(
+        self, tmp_path, monkeypatch, fake_swimlane_converter, capsys
+    ):
+        # Several programs and no marker: the program is genuinely unknown. The
+        # records still convert, but with anonymous labels — a wrong name is
+        # worse than no name, since it reads as a real measurement.
+        seen = self._spy_generate_swimlane(monkeypatch)
+        _write_chip_program(tmp_path, "lm_head", "lm_head_dispatch_push")
+        _write_chip_program(tmp_path, "mtp_decode_layer", "mtp_projection_rms")
+        dfx = tmp_path / "dfx_outputs"
+        _write_dfx_dispatch_dirs(dfx, "rank0/d0")
+
+        _collect_l3_swimlane(tmp_path, "a2a3")
+
+        assert len(seen) == 1
+        assert seen[0].func_names is None
+        assert not (dfx / "rank0" / "d0" / "name_map.json").exists()
+        # ``work_dir`` holds no kernel_config.py, so no other program's table is
+        # handed to the converter's ``-k`` fallback either.
+        assert not (seen[0].work_dir / "kernel_config.py").exists()
+        assert "No L2 program recorded for rank0/d0" in capsys.readouterr().out
+
+    def test_unresolvable_dispatch_drops_a_stale_name_map(
+        self, tmp_path, monkeypatch, fake_swimlane_converter
+    ):
+        # With neither ``--func-names`` nor ``-k``, the converter auto-discovers
+        # a sibling ``name_map*.json`` — so a map left by an earlier run would
+        # quietly resurrect the mislabelling this fix removes.
+        self._spy_generate_swimlane(monkeypatch)
+        _write_chip_program(tmp_path, "lm_head", "lm_head_dispatch_push")
+        _write_chip_program(tmp_path, "mtp_decode_layer", "mtp_projection_rms")
+        dfx = tmp_path / "dfx_outputs"
+        _write_dfx_dispatch_dirs(dfx, "rank0/d0")
+        stale = dfx / "rank0" / "d0" / "name_map.json"
+        stale.write_text('{"callable_id_to_name": {"0": "mtp_projection_rms"}}', encoding="utf-8")
+
+        _collect_l3_swimlane(tmp_path, "a2a3")
+
+        assert not stale.exists()
+
+    def test_stray_subdir_does_not_hide_the_sole_program(
+        self, tmp_path, monkeypatch, fake_swimlane_converter
+    ):
+        # ``next_levels/`` may hold a subdir that is not an L2 program (no
+        # kernel_config.py). Counting it would make the build look multi-program
+        # and needlessly drop the unmarked dispatch to anonymous labels.
+        seen = self._spy_generate_swimlane(monkeypatch)
+        _write_chip_program(tmp_path, "only_chip", "rms")
+        (tmp_path / "next_levels" / "scratch").mkdir()
+        dfx = tmp_path / "dfx_outputs"
+        _write_dfx_dispatch_dirs(dfx, "rank0/d0")
+
+        _collect_l3_swimlane(tmp_path, "a2a3")
+
+        assert seen[0].work_dir == tmp_path / "next_levels" / "only_chip"
+        assert json.loads((dfx / "rank0" / "d0" / "name_map.json").read_text())["callable_id_to_name"] == {
+            "0": "rms"
+        }
 
 
 class _BoolStrictCallConfig:

--- a/tests/ut/runtime/test_distributed_worker.py
+++ b/tests/ut/runtime/test_distributed_worker.py
@@ -1540,14 +1540,32 @@ class TestCollectL3Swimlane:
     def test_unresolvable_dispatch_drops_a_stale_name_map(
         self, tmp_path, monkeypatch, fake_swimlane_converter
     ):
-        # With neither ``--func-names`` nor ``-k``, the converter auto-discovers
-        # a sibling ``name_map*.json`` — so a map left by an earlier run would
-        # quietly resurrect the mislabelling this fix removes.
+        # With no map passed, the converter auto-discovers a sibling
+        # ``name_map*.json`` — so a map left by an earlier run would quietly
+        # resurrect the mislabelling this fix removes.
         self._spy_generate_swimlane(monkeypatch)
         _write_chip_program(tmp_path, "lm_head", "lm_head_dispatch_push")
         _write_chip_program(tmp_path, "mtp_decode_layer", "mtp_projection_rms")
         dfx = tmp_path / "dfx_outputs"
         _write_dfx_dispatch_dirs(dfx, "rank0/d0")
+        stale = dfx / "rank0" / "d0" / "name_map.json"
+        stale.write_text('{"callable_id_to_name": {"0": "mtp_projection_rms"}}', encoding="utf-8")
+
+        _collect_l3_swimlane(tmp_path, "a2a3")
+
+        assert not stale.exists()
+
+    def test_resolved_program_without_a_table_drops_a_stale_name_map(
+        self, tmp_path, monkeypatch, fake_swimlane_converter
+    ):
+        # The program resolves, but its ``kernel_config.py`` names no kernels, so
+        # no map is written for this run. A previous run's map must not survive to
+        # be picked up in its place — this dispatch renders anonymously.
+        self._spy_generate_swimlane(monkeypatch)
+        _write_chip_program(tmp_path, "lm_head")  # KERNELS = []
+        dfx = tmp_path / "dfx_outputs"
+        _write_dfx_dispatch_dirs(dfx, "rank0/d0")
+        _mark_dispatch_program(dfx / "rank0" / "d0", "lm_head")
         stale = dfx / "rank0" / "d0" / "name_map.json"
         stale.write_text('{"callable_id_to_name": {"0": "mtp_projection_rms"}}', encoding="utf-8")
 

--- a/tests/ut/runtime/test_swimlane_two_pass.py
+++ b/tests/ut/runtime/test_swimlane_two_pass.py
@@ -18,11 +18,13 @@ host-register mappings between DFX runs. These tests drive
 """
 
 import ctypes
+from pathlib import Path
 
+import pypto.runtime.runner as _runner
 import pytest
 import torch
 from pypto.runtime.device_tensor import DeviceTensor
-from pypto.runtime.runner import _build_args_spec, _DfxOpts, _execute_dfx_passes
+from pypto.runtime.runner import _build_args_spec, _DfxOpts, _execute_dfx_passes, _generate_swimlane
 
 
 def _drive(dfx: _DfxOpts, platform: str) -> tuple[list[_DfxOpts], int]:
@@ -130,6 +132,44 @@ def test_build_args_spec_scalar(tmp_path):
 def test_build_args_spec_rejects_unknown_type(tmp_path):
     with pytest.raises(TypeError):
         _build_args_spec(["not an arg"], tmp_path)  # type: ignore[list-item]  # pyright: ignore[reportArgumentType]
+
+
+def _converter_argv(monkeypatch, work_dir: Path, swimlane_dir: Path) -> list[str]:
+    """Run ``_generate_swimlane`` with the converter stubbed; return its argv."""
+    monkeypatch.setattr(_runner.importlib.util, "find_spec", lambda name: object())
+    argv: list[list[str]] = []
+    monkeypatch.setattr(_runner.subprocess, "run", lambda cmd, check: argv.append(cmd))
+    records = swimlane_dir / "l2_swimlane_records.json"
+    records.write_text("{}", encoding="utf-8")
+    _generate_swimlane(work_dir, swimlane_dir, records)
+    assert len(argv) == 1
+    return argv[0]
+
+
+def test_generate_swimlane_passes_kernel_config_when_present(tmp_path, monkeypatch):
+    # The usual case: ``work_dir`` owns the kernels being converted, so its
+    # config is the converter's ``-k`` label fallback.
+    work_dir = tmp_path / "work"
+    work_dir.mkdir()
+    (work_dir / "kernel_config.py").write_text("KERNELS = []\n", encoding="utf-8")
+
+    cmd = _converter_argv(monkeypatch, work_dir, tmp_path)
+
+    assert "-k" in cmd
+    assert str(work_dir / "kernel_config.py") in cmd
+
+
+def test_generate_swimlane_omits_missing_kernel_config(tmp_path, monkeypatch):
+    # No config to point at — e.g. an L3 dispatch whose owning program could not
+    # be resolved. The converter *errors out* on a ``-k`` path that does not
+    # exist, so passing it would lose the swimlane entirely instead of just its
+    # kernel names.
+    work_dir = tmp_path / "work"
+    work_dir.mkdir()
+
+    cmd = _converter_argv(monkeypatch, work_dir, tmp_path)
+
+    assert "-k" not in cmd
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

`_collect_l3_swimlane` merged every `next_levels/*/kernel_config.py` into one flat `func_id -> name` table and wrote it into **every** `rank*/d{k}` dispatch dir. `func_id` is a per-L2-program namespace — each program numbers its kernels from 0 — so the alphabetically-later program won ids `0..N` and every other dispatch was rendered with its names. The converter's `-k` fallback had the same flaw (`work_dir` was always `chip_dirs[0]`).

On a two-program L3 kernel this printed `lm_head_dispatch_wait` (a cross-card spin-wait) as `mtp_projection_norm` — a 24 ms barrier reading as a 24 ms RMS-norm kernel, in the console table and in the Perfetto trace alike. Silent, and actively misleading for performance work.

Nothing on disk recorded which program produced which dispatch. `_submit_chip` is the only place that sees both the dispatch directory and the callable being dispatched, so it now stamps a `dispatch_program.json` marker there; the offline post-pass reads it back and resolves names from that program's `kernel_config.py` alone, keeping `--func-names` and the `-k` fallback in agreement. The marker goes through the filesystem so the two halves stay independent of where the runtime places the L3 orchestrator, and both swimlane passes rewrite it identically.

- A dispatch whose program cannot be resolved (multi-program build, no marker) is converted with **anonymous** labels instead of guessed ones — a plausible wrong name reads as a real measurement. That path also drops a stale sibling `name_map.json` the converter would otherwise auto-discover.
- `_generate_swimlane` omits `-k` when the config is absent rather than handing the converter a path it rejects (it errors out on a missing `-k`, losing the swimlane entirely).
- Consolidates the two duplicated `orch._dfx_dispatch_idx = {}` reset sites into `_reset_dfx_dispatch_state`, which publishes the callable -> program names alongside the per-card dispatch counter.

## Testing

- [x] All tests pass — `tests/ut` 7981 passed / 2 skipped; `tests/ut/runtime` + `tests/lint` green after rebase; pre-commit (ruff, pyright, markdownlint, en-zh parity) clean
- [x] Code review completed
- [x] Documentation updated — `docs/{en,zh-cn}/dev/03-runtime-dfx.md`: the marker in the L3 dispatch-dir layout, why names must be resolved per dispatch, and the new implementation-map rows

New coverage in `tests/ut/runtime/test_distributed_worker.py` and `test_swimlane_two_pass.py`:

- the regression itself — two programs both numbering `func_id` from 0, asserting each dispatch's `name_map.json` and `-k` dir name its own program (today the two maps are byte-identical)
- the single-program fallback for an unmarked dispatch, and that a non-program subdir under `next_levels/` does not hide it
- the unresolvable case: no name map, no foreign `-k`, stale map dropped
- `_generate_swimlane` passing / omitting `-k` by config presence

Both key cases were verified to be genuine discriminators: they fail against `main` and pass with the fix. The `simpler_setup` converter is mocked in tests (optional runtime dep), not vendored.

## Related Issues

Fixes #2169