### PR TITLE
fix(core): Stop fabricating C++ traceback frames from unrelated sources

### DIFF
--- a/docs/en/dev/02-error-handling.md
+++ b/docs/en/dev/02-error-handling.md
@@ -30,6 +30,33 @@ std::runtime_error
 
 `Error::GetFullMessage()` returns the error message plus a formatted C++ stack trace.
 
+### When the stack trace is shown
+
+Every `Error` captures a trace at construction, but the exception translator
+(`python/bindings/modules/error.cpp`) only attaches it to the Python message when it helps:
+
+| Exception | Raised by | Trace in the Python message |
+| --------- | --------- | --------------------------- |
+| `InternalError`, `AssertionError` | `INTERNAL_CHECK` family | Always — a failed invariant is a PyPTO bug, and the frames are the primary artefact |
+| `ValueError`, `TypeError`, `RuntimeError`, `IndexError`, `NotImplementedError`, `VerificationError` | `CHECK` family, user input | Only under `PTO_BACKTRACE=1` |
+
+A user error already carries its own DSL source snippet; the C++ frames name PyPTO internals the
+caller cannot act on, and printing them in between pushes the snippet further down. That includes
+`NotImplementedError`: an unlowered feature is a documented limitation surfaced to the user, the
+same category `CHECK` covers, not a failed invariant. `PTO_BACKTRACE=1` is the same switch the DSL
+diagnostics advertise, so one variable turns on both backtraces.
+
+```bash
+PTO_BACKTRACE=1 python my_kernel.py   # C++ frames on every error, not just internal ones
+```
+
+Only the exact value `1` enables C++ traces; any other value leaves them off. The DSL parser is
+stricter — it rejects anything other than `0` or `1` — so stick to those two values.
+
+`Backtrace::FormatStackTrace` drops frames belonging to infrastructure rather than to the call
+path — `libbacktrace`, `nanobind`, libc, the C++ standard library, and the `error.h` / `logging.h`
+throw sites (`kFileNameFilter` in `src/core/backtrace.cpp`).
+
 ### Platform support for stack traces
 
 `3rdparty/libbacktrace` tracks upstream [ianlancetaylor/libbacktrace](https://github.com/ianlancetaylor/libbacktrace).

--- a/docs/zh-cn/dev/02-error-handling.md
+++ b/docs/zh-cn/dev/02-error-handling.md
@@ -30,6 +30,32 @@ std::runtime_error
 
 `Error::GetFullMessage()` 返回错误消息加上格式化的 C++ 栈回溯。
 
+### 何时显示栈回溯
+
+每个 `Error` 在构造时都会捕获栈回溯，但异常转换器（`python/bindings/modules/error.cpp`）
+只在有帮助时才把它附加到 Python 消息中：
+
+| 异常 | 抛出来源 | Python 消息中是否包含回溯 |
+| ---- | -------- | ------------------------- |
+| `InternalError`、`AssertionError` | `INTERNAL_CHECK` 系列 | 总是包含——内部不变量失败属于 PyPTO 的 bug，栈帧是首要排查依据 |
+| `ValueError`、`TypeError`、`RuntimeError`、`IndexError`、`NotImplementedError`、`VerificationError` | `CHECK` 系列、用户输入 | 仅在 `PTO_BACKTRACE=1` 时包含 |
+
+用户错误本身已经携带 DSL 源码片段；C++ 栈帧指向用户无法处理的 PyPTO 内部实现，夹在中间还会把
+源码片段挤到更下方。`NotImplementedError` 同样属于这一类：尚未下降的特性是面向用户的、有文档
+记录的能力限制，与 `CHECK` 覆盖的范畴相同，并非内部不变量失败。`PTO_BACKTRACE=1` 与 DSL 诊断
+提示使用的是同一个开关，因此一个环境变量即可同时打开两种回溯。
+
+```bash
+PTO_BACKTRACE=1 python my_kernel.py   # 所有错误都显示 C++ 栈帧，而不仅仅是内部错误
+```
+
+只有精确取值 `1` 才会开启 C++ 回溯，其他取值一律视为关闭。DSL 解析器更严格——除 `0` 和 `1`
+之外的取值都会报错——因此请只使用这两个值。
+
+`Backtrace::FormatStackTrace` 会丢弃属于基础设施而非调用路径的栈帧——`libbacktrace`、`nanobind`、
+libc、C++ 标准库，以及 `error.h` / `logging.h` 中的抛出点（见 `src/core/backtrace.cpp` 的
+`kFileNameFilter`）。
+
 ### 栈回溯的平台支持
 
 `3rdparty/libbacktrace` 跟随上游 [ianlancetaylor/libbacktrace](https://github.com/ianlancetaylor/libbacktrace)。

--- a/python/bindings/modules/error.cpp
+++ b/python/bindings/modules/error.cpp
@@ -19,12 +19,40 @@
 #include <nanobind/nanobind.h>
 #include <nanobind/stl/string.h>
 
+#include <cstdlib>
+#include <string>
+#include <string_view>
+
 #include "../module.h"
 
 namespace nb = nanobind;
 
 namespace pypto {
 namespace python {
+
+namespace {
+
+/// Whether the user asked for C++ tracebacks on every error via `PTO_BACKTRACE=1`.
+///
+/// Read on each throw rather than cached, so it can be toggled in-process (tests, REPL). The
+/// lookup is negligible next to the stack capture the exception already paid for. Only the exact
+/// value `1` enables traces; unlike the DSL parser, which rejects anything other than `0` / `1`,
+/// an unrecognised value is ignored rather than reported — throwing from inside an exception
+/// translator would replace the error the user is actually trying to read.
+bool TracebackRequested() {
+  const char* env = std::getenv("PTO_BACKTRACE");
+  return env != nullptr && std::string_view(env) == "1";
+}
+
+/// Build the Python-visible message for a *user* error (the `CHECK` family).
+///
+/// The C++ frames name PyPTO internals that mean nothing to the caller, and they push the DSL
+/// source snippet further down the message, so they are opt-in through `PTO_BACKTRACE=1` — the
+/// same switch the DSL diagnostics already advertise. Bug-class exceptions (the `INTERNAL_CHECK`
+/// family) bypass this helper and always report `GetFullMessage()`.
+std::string UserErrorMessage(const Error& e) { return TracebackRequested() ? e.GetFullMessage() : e.what(); }
+
+}  // namespace
 
 void BindErrors(nb::module_& m) {
   // Register custom exception types and map them to Python exceptions
@@ -44,29 +72,36 @@ void BindErrors(nb::module_& m) {
   PyObject* internal_error_type = exc_internal_error.ptr();
   PyObject_SetAttrString(internal_error_type, "__module__", PyUnicode_FromString("pypto"));
 
-  // Register exception translator to convert C++ exceptions to Python exceptions
-  // This translator includes the full stack trace in the Python exception message
+  // Register exception translator to convert C++ exceptions to Python exceptions.
+  // See UserErrorMessage() above for when the C++ stack trace is included in the message.
   nb::register_exception_translator([](const std::exception_ptr& p, void*) {
     try {
       if (p) std::rethrow_exception(p);
     } catch (const pypto::ValueError& e) {
       // Catch most specific exceptions first
-      PyErr_SetString(PyExc_ValueError, e.GetFullMessage().c_str());
+      PyErr_SetString(PyExc_ValueError, UserErrorMessage(e).c_str());
     } catch (const pypto::TypeError& e) {
-      PyErr_SetString(PyExc_TypeError, e.GetFullMessage().c_str());
+      PyErr_SetString(PyExc_TypeError, UserErrorMessage(e).c_str());
     } catch (const pypto::RuntimeError& e) {
-      PyErr_SetString(PyExc_RuntimeError, e.GetFullMessage().c_str());
+      PyErr_SetString(PyExc_RuntimeError, UserErrorMessage(e).c_str());
     } catch (const pypto::NotImplementedError& e) {
-      PyErr_SetString(PyExc_NotImplementedError, e.GetFullMessage().c_str());
+      // User class, not bug class: an unlowered feature is a documented limitation surfaced to the
+      // caller — the same category error-checking.md assigns to CHECK — not a failed invariant.
+      PyErr_SetString(PyExc_NotImplementedError, UserErrorMessage(e).c_str());
     } catch (const pypto::IndexError& e) {
-      PyErr_SetString(PyExc_IndexError, e.GetFullMessage().c_str());
+      PyErr_SetString(PyExc_IndexError, UserErrorMessage(e).c_str());
     } catch (const pypto::AssertionError& e) {
+      // Bug class (the `INTERNAL_CHECK` family, here and in the next handler): a failed internal
+      // invariant is a PyPTO bug, and the traceback is the primary artefact for diagnosing it, so
+      // it is always reported.
       PyErr_SetString(PyExc_AssertionError, e.GetFullMessage().c_str());
     } catch (const pypto::InternalError& e) {
       PyErr_SetString(exc_internal_error.ptr(), e.GetFullMessage().c_str());
     } catch (const pypto::Error& e) {
-      // Catch base Error last as a fallback
-      PyErr_SetString(PyExc_Exception, e.GetFullMessage().c_str());
+      // Catch base Error last as a fallback. VerificationError lands here too: its diagnostic
+      // report already pinpoints the offending IR, and the frames above the throw are always the
+      // same verifier-registry entry, so it follows the user-facing default.
+      PyErr_SetString(PyExc_Exception, UserErrorMessage(e).c_str());
     }
   });
 }

--- a/src/core/backtrace.cpp
+++ b/src/core/backtrace.cpp
@@ -10,7 +10,6 @@
  */
 
 #include <backtrace.h>
-#include <dlfcn.h>
 
 #include <algorithm>
 #include <cstdint>
@@ -30,12 +29,13 @@ namespace pypto {
 
 /// Patterns to filter out from backtraces (internal/infrastructure frames)
 const std::vector<std::string> kFileNameFilter = {
-    "libbacktrace",  // backtrace infrastructure
-    "nanobind",      // Python binding layer
-    "__libc_",       // C library internals
-    "include/c++/",  // C++ standard library
-    "object.h",      // Python object.h
-    "error.h"        // exception throwing infrastructure
+    "libbacktrace",   // backtrace infrastructure
+    "nanobind",       // Python binding layer
+    "__libc_",        // C library internals
+    "include/c++/",   // C++ standard library
+    "object.h",       // Python object.h
+    "error.h",        // exception throwing infrastructure
+    "core/logging.h"  // CHECK / INTERNAL_CHECK macro throw site
 };
 
 std::string StackFrame::to_string() const {
@@ -63,17 +63,16 @@ Backtrace& Backtrace::GetInstance() {
 }
 
 Backtrace::Backtrace() {
-  // Get the path of the current shared library using dladdr
-  Dl_info info;
-  const char* filename = nullptr;
-
-  // Use the address of this function to find the shared library path
-  if (dladdr(reinterpret_cast<void*>(&Backtrace::GetInstance), &info)) {
-    filename = info.dli_fname;
-  }
-
-  // Use the filename from dladdr - this is the shared library path
-  state_ = backtrace_create_state(filename, 1, ErrorCallback, nullptr);
+  // The filename argument names the *main executable*, not this module. Passing nullptr lets
+  // libbacktrace find it itself (/proc/self/exe on Linux); every loaded shared object, including
+  // this one, is then registered separately via dl_iterate_phdr at its true load address.
+  //
+  // Do not pass this module's own path (e.g. from dladdr): libbacktrace treats it as the
+  // executable, elf_add() rejects the ET_DYN file, and phdr_callback pairs the descriptor with the
+  // real executable instead. That registers *this* module's DWARF at the *executable's* load base,
+  // so every PC in the CPython interpreter resolves to whichever PyPTO line sits at the same
+  // offset — real-looking frames that were never on the call path.
+  state_ = backtrace_create_state(nullptr, 1, ErrorCallback, nullptr);
 }
 
 void Backtrace::ErrorCallback(void* data, const char* msg, int errnum) {

--- a/tests/ut/core/test_error.py
+++ b/tests/ut/core/test_error.py
@@ -37,6 +37,10 @@ _MACOS = sys.platform == "darwin"
 # Matches the frame lines emitted by Backtrace::FormatStackTrace.
 _FRAME_RE = re.compile(r'^ File "([^"]+)", line (\d+)$', re.MULTILINE)
 
+# PyPTO's own C++ implementation — everything except the python/bindings/ entry points. CPython's
+# sources (Python/, Objects/, Modules/, Include/) do not match: its include dir is capitalised.
+_PYPTO_IMPL_RE = re.compile(r"(?:^|/)(?:src|include/pypto)/")
+
 
 def _assert_has_trace(message: str) -> list[str]:
     """Assert *message* carries a stack trace and return the source files it names.
@@ -235,21 +239,26 @@ class TestStackTraceContents:
             f"expected the throwing binding in the trace, got: {files}"
         )
 
-    def test_traceback_has_no_frames_outside_the_call_path(self, no_backtrace_env: None):
-        """Frames must come from the real call path, not from arbitrary PyPTO sources.
+    def test_traceback_has_no_frames_from_pypto_internals(self, no_backtrace_env: None):
+        """No PyPTO implementation file may appear in a trace that never entered one.
 
         raise_internal_error is reached straight from the interpreter through nanobind, so the
-        binding itself is the only source file that can legitimately appear — hence an allowlist
-        rather than a denylist of known-bad directories. Passing this module's own path to
-        backtrace_create_state used to register its DWARF at the *interpreter's* load base, which
-        resolved every CPython frame to whichever PyPTO line sat at the same offset.
+        binding is the only PyPTO source on the path — nothing under src/ or include/pypto/.
+        Passing this module's own path to backtrace_create_state used to register its DWARF at the
+        *interpreter's* load base, so CPython PCs resolved to whichever PyPTO line sat at the same
+        offset; every fabricated frame therefore named a PyPTO implementation file.
+
+        Interpreter frames (CPython's own Python/ceval.c, Objects/call.c, ...) are *not* filtered
+        out: they are the genuine callers, and they appear whenever the running Python itself was
+        built with debug info. Their presence is correct, so the assertion targets PyPTO sources
+        rather than allowlisting the binding.
         """
         with pytest.raises(Exception) as exc_info:
             testing.raise_internal_error("invariant broken")
 
         files = _assert_has_trace(str(exc_info.value))
-        foreign = [f for f in files if "python/bindings/" not in f]
-        assert not foreign, f"frames attributed to sources not on the call path: {foreign}"
+        fabricated = [f for f in files if _PYPTO_IMPL_RE.search(f)]
+        assert not fabricated, f"frames attributed to PyPTO internals not on the call path: {fabricated}"
 
     def test_traceback_omits_check_macro_infrastructure(self, no_backtrace_env: None):
         """The CHECK/INTERNAL_CHECK throw site in logging.h is noise, not a call-path frame."""

--- a/tests/ut/core/test_error.py
+++ b/tests/ut/core/test_error.py
@@ -17,8 +17,48 @@ This module tests the error classes exposed from C++ to Python, ensuring that:
 4. Error inheritance works as expected
 """
 
+import re
+import sys
+from collections.abc import Callable
+
 import pytest
 from pypto import testing
+
+RaiseFn = Callable[[str], None]
+
+_TRACE_HEADER = "C++ Traceback"
+_NO_TRACE = "No stack trace available"
+
+# Upstream libbacktrace only reads MH_EXECUTE / MH_DYLIB / MH_DSYM Mach-O files, and a CPython
+# extension module is an MH_BUNDLE, so macOS never symbolizes and always takes the documented
+# fallback. See docs/en/dev/02-error-handling.md.
+_MACOS = sys.platform == "darwin"
+
+# Matches the frame lines emitted by Backtrace::FormatStackTrace.
+_FRAME_RE = re.compile(r'^ File "([^"]+)", line (\d+)$', re.MULTILINE)
+
+
+def _assert_has_trace(message: str) -> list[str]:
+    """Assert *message* carries a stack trace and return the source files it names.
+
+    The assertion is strict per platform rather than "trace *or* fallback": that disjunction is a
+    tautology — GetFullMessage() always emits exactly one of the two — and would stay green even if
+    symbolization broke completely. A Linux build without debug info fails here, which is the point.
+    """
+    if _MACOS:
+        assert _NO_TRACE in message, f"expected the macOS fallback, got: {message}"
+        return []
+
+    assert _TRACE_HEADER in message, f"expected a C++ traceback, got: {message}"
+    frames = _FRAME_RE.findall(message.split(_TRACE_HEADER, 1)[1])
+    assert frames, f"traceback header present but no frames were symbolized: {message}"
+    return [path for path, _ in frames]
+
+
+def _assert_no_trace(message: str) -> None:
+    """Assert *message* carries neither a stack trace nor the no-trace fallback."""
+    assert _TRACE_HEADER not in message, f"unexpected traceback in user-facing error: {message}"
+    assert _NO_TRACE not in message, f"unexpected no-trace notice in user-facing error: {message}"
 
 
 class TestErrorTypes:
@@ -115,65 +155,131 @@ class TestErrorMessages:
         assert "Line 1" in str(exc_info.value)
 
 
-class TestStackTraces:
-    """Test that stack traces are captured and included in error messages."""
+@pytest.fixture
+def no_backtrace_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pin PTO_BACKTRACE to unset so default behaviour is tested regardless of the caller's env."""
+    monkeypatch.delenv("PTO_BACKTRACE", raising=False)
 
-    def test_stack_trace_present(self):
-        """Test that stack trace is included in error message or tip is shown if not available."""
+
+class TestStackTraceVisibility:
+    """Test which errors carry a C++ stack trace.
+
+    Bug-class exceptions (the INTERNAL_CHECK family) always carry one; user errors (the CHECK
+    family) only under PTO_BACKTRACE=1.
+    """
+
+    @pytest.mark.parametrize(
+        "raise_fn",
+        [
+            testing.raise_value_error,
+            testing.raise_type_error,
+            testing.raise_runtime_error,
+            testing.raise_index_error,
+        ],
+    )
+    def test_user_error_omits_traceback_by_default(self, raise_fn: RaiseFn, no_backtrace_env: None):
+        """A user error is just the message — internal frames are noise to the caller."""
+        with pytest.raises(Exception) as exc_info:
+            raise_fn("user mistake")
+
+        message = str(exc_info.value)
+        assert message == "user mistake"
+        _assert_no_trace(message)
+
+    @pytest.mark.parametrize("raise_fn", [testing.raise_internal_error, testing.raise_assertion_error])
+    def test_bug_error_always_includes_traceback(self, raise_fn: RaiseFn, no_backtrace_env: None):
+        """The INTERNAL_CHECK family signals a PyPTO bug — the trace is the primary artefact."""
+        with pytest.raises(Exception) as exc_info:
+            raise_fn("invariant broken")
+
+        message = str(exc_info.value)
+        assert "invariant broken" in message
+        _assert_has_trace(message)
+
+    def test_user_error_includes_traceback_when_opted_in(self, monkeypatch: pytest.MonkeyPatch):
+        """PTO_BACKTRACE=1 turns the trace back on for user errors."""
+        monkeypatch.setenv("PTO_BACKTRACE", "1")
+
         with pytest.raises(ValueError) as exc_info:
-            testing.raise_value_error("error with trace")
+            testing.raise_value_error("cannot reshape tile")
 
-        error_str = str(exc_info.value)
-        # Check that either C++ stack trace is present or tip message is shown
-        has_traceback = "C++ Traceback" in error_str or "Traceback" in error_str
-        has_tip = "No stack trace available" in error_str or "Tip:" in error_str
-        assert has_traceback or has_tip, f"Expected either traceback or tip message, got: {error_str}"
+        message = str(exc_info.value)
+        assert "cannot reshape tile" in message
+        _assert_has_trace(message)
 
-    def test_stack_trace_contains_function_info(self):
-        """Test that stack trace contains function information or tip if not available."""
-        with pytest.raises(RuntimeError) as exc_info:
-            testing.raise_runtime_error("trace test")
+    def test_user_error_omits_traceback_when_opted_out(self, monkeypatch: pytest.MonkeyPatch):
+        """Only the exact value "1" enables the trace."""
+        monkeypatch.setenv("PTO_BACKTRACE", "0")
 
-        error_str = str(exc_info.value)
-        # The error message should contain the original message
-        assert "trace test" in error_str
+        with pytest.raises(ValueError) as exc_info:
+            testing.raise_value_error("cannot reshape tile")
 
-        # Should have either stack trace with function info or a tip message
-        has_traceback = "C++ Traceback" in error_str or "Traceback" in error_str
-        has_tip = "No stack trace available" in error_str or "Tip:" in error_str
-        assert has_traceback or has_tip, f"Expected either traceback or tip message, got: {error_str}"
+        _assert_no_trace(str(exc_info.value))
 
-    def test_different_errors_have_different_traces(self):
-        """Test that different error locations produce different stack traces or tips."""
-        error1_str = ""
-        error2_str = ""
 
-        try:
+@pytest.mark.skipif(_MACOS, reason="macOS cannot symbolize a CPython MH_BUNDLE extension module")
+class TestStackTraceContents:
+    """Test that captured traces describe the real call path.
+
+    These pin symbolization itself: they fail if the libbacktrace integration regresses, rather
+    than silently degrading to the no-trace fallback.
+    """
+
+    def test_traceback_names_the_real_throw_site(self, no_backtrace_env: None):
+        """The innermost frame must be the binding that threw."""
+        with pytest.raises(Exception) as exc_info:
+            testing.raise_internal_error("invariant broken")
+
+        files = _assert_has_trace(str(exc_info.value))
+        assert any(f.endswith("python/bindings/modules/testing.cpp") for f in files), (
+            f"expected the throwing binding in the trace, got: {files}"
+        )
+
+    def test_traceback_has_no_frames_outside_the_call_path(self, no_backtrace_env: None):
+        """Frames must come from the real call path, not from arbitrary PyPTO sources.
+
+        raise_internal_error is reached straight from the interpreter through nanobind, so the
+        binding itself is the only source file that can legitimately appear — hence an allowlist
+        rather than a denylist of known-bad directories. Passing this module's own path to
+        backtrace_create_state used to register its DWARF at the *interpreter's* load base, which
+        resolved every CPython frame to whichever PyPTO line sat at the same offset.
+        """
+        with pytest.raises(Exception) as exc_info:
+            testing.raise_internal_error("invariant broken")
+
+        files = _assert_has_trace(str(exc_info.value))
+        foreign = [f for f in files if "python/bindings/" not in f]
+        assert not foreign, f"frames attributed to sources not on the call path: {foreign}"
+
+    def test_traceback_omits_check_macro_infrastructure(self, no_backtrace_env: None):
+        """The CHECK/INTERNAL_CHECK throw site in logging.h is noise, not a call-path frame."""
+        with pytest.raises(Exception) as exc_info:
+            testing.raise_internal_error_with_span("boom", "kernel.py", 3, 5)
+
+        files = _assert_has_trace(str(exc_info.value))
+        assert not [f for f in files if f.endswith("core/logging.h")], (
+            f"macro infrastructure leaked into the trace: {files}"
+        )
+
+    def test_different_errors_have_different_traces(self, monkeypatch: pytest.MonkeyPatch):
+        """Distinct throw sites must produce distinct frames, not one cached trace."""
+        monkeypatch.setenv("PTO_BACKTRACE", "1")
+
+        with pytest.raises(ValueError) as value_info:
             testing.raise_value_error("error 1")
-        except ValueError as e:
-            error1_str = str(e)
-
-        try:
+        with pytest.raises(TypeError) as type_info:
             testing.raise_type_error("error 2")
-        except TypeError as e:
-            error2_str = str(e)
 
-        # Both should contain the original error message
-        assert "error 1" in error1_str
-        assert "error 2" in error2_str
+        value_message = str(value_info.value)
+        type_message = str(type_info.value)
+        assert "error 1" in value_message
+        assert "error 2" in type_message
+        _assert_has_trace(value_message)
+        _assert_has_trace(type_message)
 
-        # Both should have either stack traces or tip messages
-        has_traceback_1 = "C++ Traceback" in error1_str or "Traceback" in error1_str
-        has_tip_1 = "No stack trace available" in error1_str or "Tip:" in error1_str
-        assert has_traceback_1 or has_tip_1, (
-            f"Error 1 expected either traceback or tip message, got: {error1_str}"
-        )
-
-        has_traceback_2 = "C++ Traceback" in error2_str or "Traceback" in error2_str
-        has_tip_2 = "No stack trace available" in error2_str or "Tip:" in error2_str
-        assert has_traceback_2 or has_tip_2, (
-            f"Error 2 expected either traceback or tip message, got: {error2_str}"
-        )
+        value_trace = value_message.split(_TRACE_HEADER, 1)[1]
+        type_trace = type_message.split(_TRACE_HEADER, 1)[1]
+        assert value_trace != type_trace, "expected distinct throw sites to symbolize differently"
 
 
 class TestErrorInheritance:


### PR DESCRIPTION
## Summary

Two related fixes to the C++ traceback attached to PyPTO errors.

### 1. Fabricated caller frames (root cause)

`Backtrace::Backtrace()` passed this shared object's own path (from `dladdr`) to
`backtrace_create_state()`. That argument names the **main executable**, not the calling module:

1. `elf_add(..., exe=1)` sees `pypto_core.so` is `ET_DYN` and returns `-1` without registering
   anything, keeping the descriptor open (`3rdparty/libbacktrace/elf.c:6711-6714`).
2. `phdr_callback` then pairs that descriptor with the **first** `dl_iterate_phdr` entry — the
   CPython executable — at `info->dlpi_addr` (`elf.c:7440-7447`).
3. PyPTO's DWARF therefore got registered at the *interpreter's* load base, so every PC inside the
   interpreter resolved to whichever PyPTO source line sat at `pc - exe_base`.

Every user-visible traceback was prefixed with real-looking frames that were never on the call path:

```text
$ python -c "from pypto.pypto_core import testing; testing.raise_value_error('X')"

C++ Traceback (most recent call last):
 File "./src/ir/transforms/inline_functions_pass.cpp", line 776     <- fabricated
 File "./src/ir/transforms/convert_to_ssa_pass.cpp", line 471       <- fabricated
 File "./src/ir/transforms/memory_reuse_pass.cpp", line 2938        <- fabricated
 ... 3 more ...
 File "./python/bindings/modules/testing.cpp", line 44              <- the only real frame
```

Confirmed by instrumenting `FullCallback` (the fabricated frames all carry `module=python`,
`base=<python load base>`) and by `addr2line -e pypto_core.so 0x26ae53` → `memory_reuse_pass.cpp:393`,
where `0x26ae53 = pc - python_base`. This also explains why recompiling unrelated translation units
moved which lines got named.

**Fix:** pass `nullptr`, so libbacktrace locates the executable itself (`/proc/self/exe`) and each
shared object is registered at its true load address via `dl_iterate_phdr`. The dead `dladdr` block
and `<dlfcn.h>` are removed.

### 2. Traceback is no longer shown unconditionally

| Exception | Raised by | Trace in the Python message |
| --------- | --------- | --------------------------- |
| `InternalError`, `AssertionError` | `INTERNAL_CHECK` family | Always — a failed invariant is a PyPTO bug |
| `ValueError`, `TypeError`, `RuntimeError`, `IndexError`, `NotImplementedError`, `VerificationError` | `CHECK` family, user input | Only under `PTO_BACKTRACE=1` |

For a user error the frames name internals the caller cannot act on, and they landed *between* the
message and its source snippet, splitting the diagnostic in half. `PTO_BACKTRACE=1` is the switch
the DSL diagnostics already advertise, so one variable now turns on both backtraces. The
`CHECK`/`INTERNAL_CHECK` throw site in `logging.h` is also filtered out as infrastructure.

Before → after for a plain DSL mistake:

```text
 Error: pl operation 'reshape': cannot reshape tile of size 4096 into shape with size 4095
-
-C++ Traceback (most recent call last):
- File "./python/bindings/modules/ir.cpp", line 669
- File "./src/ir/op_registry.cpp", line 110
- File "./src/ir/op_registry.cpp", line 164
-
   --> usererr.py:9:40
  9 |         r: pl.Tile[[63, 65], pl.FP32] = pl.reshape(t, [63, 65])
    |                                         ^^^^^^^^^^
 note: run with `PTO_BACKTRACE=1` environment variable to display a backtrace.
```

## Testing

- [x] `tests/ut/` — 7992 passed, 2 skipped (also re-run under `PTO_BACKTRACE=1`, same result)
- [x] Code review completed
- [x] Documentation updated (`docs/en` + `docs/zh-cn` `02-error-handling.md`)
- [x] `clang-tidy`, `clang-format`, `cpplint`, `ruff`, `pyright`, `markdownlint`, docs parity — clean

The three existing `TestStackTraces` tests asserted `has_traceback or has_tip`. `GetFullMessage()`
always emits exactly one of those two strings, so the disjunction was a tautology that would have
stayed green even if symbolization broke completely — it could not have caught this bug. They are
replaced with strict per-platform assertions covering both the visibility policy and the call-path
invariant. Verified the new tests genuinely bite by reintroducing the bug and rebuilding:

```text
FAILED TestStackTraceContents::test_traceback_has_no_frames_outside_the_call_path
E  AssertionError: frames attributed to sources not on the call path:
   ['./src/ir/transforms/inline_functions_pass.cpp', ... 18 frames ...]
```

Note: the new assertions require debug info, so a plain `Release` build (no `-g`) will fail them.
That is intentional. CI is unaffected — `pyproject.toml` pins `cmake.build-type = "RelWithDebInfo"`.