### PR TITLE
fix(ir): make composite collective barrier signals reusable

### DIFF
--- a/docs/en/dev/distributed_ops.md
+++ b/docs/en/dev/distributed_ops.md
@@ -102,6 +102,58 @@ bindings → `.pyi` stub) and surfaced to the DSL as `pld.NotifyOp` /
 `pld.WaitCmp` / `pld.AtomicType` / `pld.ReduceOp`. The deducer validates the packed `int`
 against the enum range so codegen can cast back without a second guard.
 
+## Barrier-signal protocol
+
+Every `pld.tensor.*` collective (`allreduce`, `barrier`, `broadcast`,
+`reduce_scatter`, `allgather`, `all_to_all`, `all_to_all_v`) synchronises through one shared,
+**self-clearing credit barrier** built from `pld.system.notify` /
+`pld.system.wait`:
+
+```text
+Body:      barrier(1); barrier(2); ...; barrier(N)   # g counted within this
+                                                      # call only
+  barrier(g):
+    for peer != my_rank: notify(signal, peer, <my cell>, 1, op=AtomicAdd)
+    for src  != my_rank: wait  (signal, <src cell>, g,   cmp=Ge)
+
+Epilogue:  for src != my_rank:
+               notify(signal, my_rank, <src cell>, -N, op=AtomicAdd)
+```
+
+`AtomicAdd` turns each cell into a credit counter: every notify is a
+producer's `+1`, and the epilogue is the sole consumer's `-N`. Because adds
+and subtracts are atomic and commutative, the signal is provably all-zero
+again once every rank has finished its epilogue for a call — **the signal
+carries no state that outlives one call**, so every call's generation `g`
+restarts at 1 and no cross-call bookkeeping is required. A slow rank can
+inflate a fast rank's own next-call credit by at most 1 while it finishes the
+current call (bounded skew), so the counter never overflows and a fast rank
+can never observe a spurious pass.
+
+`Ge` (not `Eq`) is load-bearing: a fast peer can advance a cell past the value
+the waiting rank is looking for before that rank ever polls it, so an
+equality wait would never unblock. For the same reason `Set` must never be
+mixed with `AtomicAdd` on the same cells — a set could clobber an already
+advanced counter.
+
+`N` (the credit total the epilogue subtracts) may be a **runtime scalar** —
+`pld.system.notify`'s `value` only requires `ScalarType` — so a mesh
+allreduce's per-chunk credit count does not need to be known at compile time.
+
+**Constraints:**
+
+| Constraint | Why |
+| ---------- | --- |
+| One signal must not be shared between mesh (`[NR, 1]`) and ring (`[2*(NR-1), NR]`) allreduce | Mesh addresses `[rank, 0]`; ring addresses `[row, rank]` — a shape mismatch, checked at lowering time |
+| A call aborted mid-flight (error / timeout) leaves the signal non-zero | Credits leak; recover via a host-side reset (`reset_persistent_windows`) before the next dispatch |
+
+Because the protocol is call-local and the signal always starts a call at
+all-zero, collectives are legal inside `for` / `while` / `if` — each call is a
+closed cycle, so the same compile-time `expected` values are reused every
+iteration. The only remaining requirement is rank-uniform execution (inherent
+to any barrier): rank-divergent control flow deadlocks, surfaced by `TWAIT`'s
+spin-count assert.
+
 ## Op reference
 
 ### `pld.tile.remote_load` (TLOAD)
@@ -329,10 +381,13 @@ parameter; a type-metadata-only symbol is rejected during PTO codegen. A fully
 dynamic physical target dimension is bound from that tensor parameter.
 
 - **`"mesh"` (default)** — direct all-to-all exchange with O(P) HCCL windows.
-  Signal shape `[NR, 1]` (one cell per rank). An `AtomicAdd 1` / `wait ≥1` ready
-  barrier precedes the chunk loop. Each chunk performs
-  `remote_load+accumulate`, then `AtomicAdd 1` / wait for its monotonic chunk
-  counter before store-back, preventing write-after-read races.
+  Signal shape `[NR, 1]` (one cell per rank). A ready barrier (generation 1)
+  precedes the chunk loop. Each chunk performs `remote_load+accumulate`, then
+  a barrier on its own call-local generation before store-back, preventing
+  write-after-read races. A self-clearing epilogue then subtracts the call's
+  total credit count back out of every cell (see
+  [Barrier-signal protocol](#barrier-signal-protocol)), so the signal is
+  all-zero again once the call completes.
 - **`"ring"`** — NCCL-style chunked reduce-scatter + allgather schedule with
   O(1) HCCL windows.  Signal shape `[2 * (NR − 1), NR]` (one row per ring
   round, one cell per rank). A packed ND target is viewed as one logical
@@ -347,17 +402,20 @@ dynamic physical target dimension is bound from that tensor parameter.
   inputs. Each segment is processed in at most 16-KiB physical subchunks; an
   FP16 ragged remote tail rounds only its physical read span to 32 bytes and
   restores the logical `valid_shape` before reduction or store. Every
-  subchunk uses ready and read-complete barriers on the round's monotonic
-  signal row before store-back, preventing write-after-read races while
-  keeping the signal shape unchanged.
+  subchunk uses ready and read-complete barriers on its own call-local
+  generation before store-back, preventing write-after-read races. A
+  self-clearing epilogue subtracts the call's total credit count back out of
+  every row of the signal afterward.
 
 Host-orchestrator user code may omit `signal` outside `for` and `while` loops;
 the [`SynthesizeAllReduceSignals`](passes/38-synthesize_allreduce_signals.md)
 pass inserts a private INT32 signal window with semantic shape `[world_size, 1]`
 for that call (mesh mode only — `mode="ring"` requires an explicit signal). The
 pass binds `world_size = pld.world_size()` as a standalone statement and uses
-that variable in the synthesized buffer size and window shape. All calls in
-loops are rejected because the current signal protocol is single-use. Explicit
+that variable in the synthesized buffer size and window shape. The
+self-clearing protocol (see [Barrier-signal protocol](#barrier-signal-protocol))
+makes every call a stateless cycle, so calls inside `for` / `while` loops are
+supported like any other collective. Explicit
 `signal` remains the internal form used by InCore lowering and by tests that
 intentionally construct the internal protocol. Comm-domain materialisation then
 keeps the signal buffer in the same domain as `src`, even when it is not passed

--- a/docs/en/dev/passes/12-lower_composite_ops.md
+++ b/docs/en/dev/passes/12-lower_composite_ops.md
@@ -188,21 +188,29 @@ Running `LowerCompositeOps` twice produces identical IR after the first run: the
 
 ## `pld.tensor.*` distributed collectives
 
-The pass also lowers the `pld.tensor.*` family of window-bound distributed collectives. Each collective is a single composite `Call` that expands into a notify / wait + data-movement recipe. The data-movement primitive differs by op: `allgather` uses `pld.tile.put` (TPUT-based, auto-chunks through a VEC staging tile), `broadcast` relocates window data with `pld.tile.get` (GM→GM copy), while `allreduce` and `reduce_scatter` pull peer chunks into a UB tile with `pld.tile.remote_load`. Allreduce selects `tile.add`, `tile.maximum`, `tile.minimum`, or `tile.mul`; reduce-scatter currently accumulates with `tile.add`. The rules share the same signal-buffer discipline: a window-bound INT32 `signal` matrix is used as a cross-rank barrier, and the buffer is **single-shot per call**.
+The pass also lowers the `pld.tensor.*` family of window-bound distributed collectives. Each collective is a single composite `Call` that expands into a notify / wait + data-movement recipe, plus a self-clearing epilogue. The data-movement primitive differs by op: `allgather` uses `pld.tile.put` (TPUT-based, auto-chunks through a VEC staging tile), `broadcast` relocates window data with `pld.tile.get` (GM→GM copy), while `allreduce` and `reduce_scatter` pull peer chunks into a UB tile with `pld.tile.remote_load`. Allreduce selects `tile.add`, `tile.maximum`, `tile.minimum`, or `tile.mul`; reduce-scatter currently accumulates with `tile.add`. All seven rules share the same **self-clearing credit-barrier protocol** (`LoweringBuilder::EmitBarrier` + `EmitEpilogueReset`) — see [Barrier-signal protocol](#barrier-signal-protocol) below — so a `signal` buffer is reusable across back-to-back calls, and even inside `for` / `while` / `if`.
+
+### Barrier-signal protocol
+
+Every call issues `N` barriers — `AtomicAdd(1)` into each peer's cell, then `Wait(>= g)` where `g` counts up **within that call only** (every fresh call restarts at 1, via `LoweringBuilder::EmitBarrier`'s call-local `barrier_count_`). After the body, an epilogue (`LoweringBuilder::EmitEpilogueReset`) subtracts the call's total credit `N` back out of every non-self cell with a single `AtomicAdd(-N)`. Because atomic adds and subtracts commute, the signal is provably all-zero again once every rank has finished its epilogue — there is no cross-call state to get wrong, so the *next* call on the same signal also starts at generation 1.
+
+`N` may be a **runtime scalar** (`pld.system.notify`'s `value` only requires `ScalarType`), so a mesh allreduce's per-chunk credit count does not need to be a compile-time constant — unlike the barrier count itself, which is always a small compile-time sequence (`1`, `2`, ...) because each `Wait`'s `expected` must be resolvable without knowing how many times the surrounding (possibly dynamic) loop will execute at runtime.
+
+`kGe` (not `kEq`) is the load-bearing choice for every wait predicate: a fast peer can advance a cell past the value a slow rank is looking for before that rank ever polls it, so equality would deadlock. For the same reason `kSet` must never be mixed with `kAtomicAdd` on the same cells — a set could clobber an already-advanced counter.
+
+Mesh (`[NR, 1]`, one cell per rank) and ring (`[2*(NR-1), NR]`, one row per round) signals use incompatible cell addressing, so sharing one buffer between the two is rejected as a shape mismatch (`ValidateMeshSignalShape`) — the only restriction the protocol still imposes.
 
 ### `pld.tensor.allreduce`
 
-The allreduce rule starts with a cross-rank ready barrier on shared `signal` cells: Phase 2a `AtomicAdd 1` + Phase 2b `wait ≥1`. It then processes a fully-valid target in UB-sized chunks. Every chunk performs a peer reduction, `AtomicAdd 1`, waits for `linear_chunk_id + 2`, and only then stores its result. The per-chunk barrier prevents a fast rank from overwriting bytes that a slow rank has not remote-loaded yet. By the time such a call returns, every non-self row sits at `1 + chunk_count`; the partial-valid single-rectangle path ends at `2`. The skipped self row remains zero.
+The allreduce rule starts with a cross-rank ready barrier on shared `signal` cells (generation 1). It then processes a fully-valid target in UB-sized chunks. Every chunk performs a peer reduction, then barriers on its own call-local generation (`2`, `3`, ...) before storing its result — preventing a fast rank from overwriting bytes a slow rank has not remote-loaded yet. The epilogue then subtracts the call's total credit (`1 + chunk_count`, built as an IR expression since `chunk_count` may depend on a runtime extent) back out of every non-self row. The partial-valid single-rectangle path issues exactly two barriers (ready + post-reduce) and its epilogue subtracts `2`.
 
 For a fully-valid packed target, mesh lowering creates a logical `[1, product(all dimensions)]` view and traverses it with physical tiles of at most 16 KiB. A statically known extent smaller than the budget shrinks the chunk to the smallest 32-byte-aligned physical width that covers it, so small allreduces do not reserve a full 16-KiB tile while remaining legal PTO tiles. The tail carries `valid_shape=[1, min(chunk, remaining)]` through both `tile.load` and `pld.tile.remote_load`, so the allocation stays static while the read/store extent is exact. If an ND target carries a partial `TensorView.valid_shape`, the pass preserves and reduces the representable `[rows, cols]` rectangle through the established single-rectangle path. Constant valid rectangles use their compact shape; symbolic valid extents fall back to the source's physical rectangle when that statically bounded rectangle fits within one 16-KiB chunk. Oversized partial rectangles, strided targets, DN partial views, and partial boxes that cannot be represented by the leading-dimension collapse are rejected explicitly.
 
-Ring lowering uses one packed 2D view for its reduce-scatter and allgather phases. A fully valid target becomes `[1, SIZE]`; a contiguous partial prefix keeps physical shape `[1, product(target.shape)]` and carries logical `TensorView.valid_shape=[1, product(target.valid_shape)]`. FP32 retains balanced `floor(i * SIZE / NR)` segment boundaries. FP16 rounds each interior boundary up to 16 elements and caps it at `SIZE`; consequently every non-empty segment and every UB subchunk starts at a 32-byte-aligned address. A ragged FP16 remote load may read the aligned physical tail reserved by the communication domain, then `tile.set_validshape` restores the logical extent before reduction and store. This supports non-divisible inputs and `SIZE < NR` without inserting holes into the public tensor layout.
+Ring lowering uses one packed 2D view for its reduce-scatter and allgather phases. A fully valid target becomes `[1, SIZE]`; a contiguous partial prefix keeps physical shape `[1, product(target.shape)]` and carries logical `TensorView.valid_shape=[1, product(target.valid_shape)]`. FP32 retains balanced `floor(i * SIZE / NR)` segment boundaries. FP16 rounds each interior boundary up to 16 elements and caps it at `SIZE`; consequently every non-empty segment and every UB subchunk starts at a 32-byte-aligned address. A ragged FP16 remote load may read the aligned physical tail reserved by the communication domain, then `tile.set_validshape` restores the logical extent before reduction and store. This supports non-divisible inputs and `SIZE < NR` without inserting holes into the public tensor layout. Every subchunk of every round barriers on a call-local ready + read-complete generation pair; the epilogue then subtracts `2 * chunk_count` (uniform across rounds, since every round's subchunk loop shares the same bound) from every row of the `[2*(NR-1), NR]` signal.
 
 Any symbolic target or partial-valid extent that survives lowering must be runtime-bound by a kernel scalar, loop variable, or physical tensor-shape parameter; a type-metadata-only symbol is rejected during PTO codegen. A fully dynamic physical target dimension is bound from that tensor parameter.
 
-**Signal buffers must NOT be reused for back-to-back allreduce calls.** A stale positive counter in any waited-on non-self row would let the next call's Phase 2b `wait ≥1` pass immediately on the leftover value, breaking the barrier and racing the next Phase 3 reads against the previous reduction's stores. Callers issuing multiple allreduces must allocate a fresh signal buffer (via `alloc_window_buffer` + `window`) for each call. The user-facing DSL docstring at `python/pypto/language/distributed/op/tensor_ops.py::allreduce` carries the same warning.
-
-`kGe` (not `kEq`) is the load-bearing choice for every wait predicate. Each waited-on cell is monotonically increasing within a single call, so a slow rank may first poll after a faster peer has already advanced it beyond that wait's expected value. Equality would then deadlock; greater-than-or-equal does not.
+Signal buffers are reusable across back-to-back allreduce calls — including a mesh allreduce over a symbolic extent, whose credit total is simply a runtime-computed expression rather than a value the compiler must know. See [Barrier-signal protocol](#barrier-signal-protocol) above.
 
 Mesh and ring lowering support FP16 and FP32 with `ReduceOp::kSum`, `kMax`,
 `kMin`, and `kProd` for arbitrary positive element counts.
@@ -213,22 +221,20 @@ Signature: `allgather(local_data, target, signal)`. `local_data` is this rank's 
 
 - ``tile.create([1, SIZE], dtype=..., target_memory=Vec)`` — allocate a VEC staging tile for ``pld.tile.put`` auto-chunking.  ``pld.tile.put`` reads directly from the ``local_data`` Tensor (or Tile) source — no explicit ``tile.load`` is emitted.
 - Phase 1: for `peer` in `0..NR-1`, `pld.tile.put(target, peer, local_data, put_stage, [my_rank, 0], [0, 0], [1, SIZE])` — push this rank's chunk into every peer's window at row `my_rank`. Self-store (`peer == my_rank`) uses HCCL identity mapping. `pld.tile.put` auto-chunks when SIZE exceeds the staging-tile capacity
-- Phase 2a: notify-all (`Set 1`)
-- Phase 2b: wait-all (`Ge 1`)
+- Phase 2: barrier (generation 1) + epilogue (subtract 1 from every non-self cell)
 - Return `target` — the window IS the gathered `[NR, SIZE]` result (window-as-result, `DistributedTensor`)
 
 Compared to the original pull-based allgather (4-arg with a separate `out` tensor), this push-based variant drops the `out` parameter and the per-peer `pld.tile.get` gather loop. Total HBM drops from `(NR+1)×SIZE` to `NR×SIZE`, at the cost of the window remaining occupied until the caller consumes the result.
 
 ### `pld.tensor.reduce_scatter`
 
-Decomposes into the same 5-phase shape as `allreduce`:
+Decomposes into the same phase shape as `allreduce`'s rectangle path:
 
-- Phase 2a: notify-all (`Set 1`)
-- Phase 2b: wait-all (`Ge 1`)
+- Phase 2a/2b: ready barrier (generation 1)
 - Phase 3: for each peer, `remote_load` chunk `r` from peer `p` and accumulate into a local scratch with `tile.add`
-- Phase 3.5a: re-notify (`AtomicAdd 1`)
-- Phase 3.5b: re-wait (`Ge 2`)
+- Phase 3.5a/3.5b: post-reduce barrier (generation 2)
 - Phase 4: `tile.store` the reduced chunk `r` back into `target[r, 0:SIZE]`
+- Epilogue: subtract 2 from every non-self cell
 
 `target` has shape `[NR, SIZE]`; each rank stages all `NR` chunks before the call. After the call, rank `r`'s row `[r, 0:SIZE]` holds the element-wise sum of chunk `r` across all ranks. The post-reduce barrier is required for the same WAR reason as `allreduce`.
 
@@ -238,24 +244,16 @@ Only `ReduceOp::kSum` is supported in the first version; the C++ deducer rejects
 
 Decomposes into a 3-phase recipe:
 
-- Phase 2a: notify-all (`Set 1`)
-- Phase 2b: wait-all (`Ge 1`)
+- Phase 2: barrier (generation 1) + epilogue (subtract 1 from every non-self cell)
 - Phase 3: `tile.create` (VEC staging tile) + `pld.tile.get(target, peer=root, target, stage)` on every rank — each rank reads root's slice into its own `target`. For `peer == root` the HCCL identity mapping makes the get a local no-op, so root keeps its own data while non-root ranks receive root's.
 
 `root` is a static `int` kwarg known at compile time.
 
 ### `pld.tensor.barrier`
 
-Pure synchronization — no data movement. Decomposes into a 2-phase recipe:
+Pure synchronization — no data movement. Decomposes into a barrier (generation 1) plus its epilogue (subtract 1 from every non-self cell).
 
-- Phase 2a: notify-all (`Set 1`)
-- Phase 2b: wait-all (`Ge 1`)
-
-The returned expression is the same `signal` tensor, enabling the rebind idiom `signal = pld.tensor.barrier(signal)`.
-
-### Signal-buffer discipline
-
-All distributed rules use `kGe` (not `kEq`) for wait predicates. The cell is monotonically increasing within a single call, but a slow rank's first poll may already see the cell past the threshold if a faster peer has finished its Phase-3 data movement and started the next notify. `kEq` would deadlock in that case; `kGe` does not. A self-resetting variant (Set 0 / Eq 0 at the end of a call) is blocked on PTOAS issue #797.
+The returned expression is the same `signal` tensor, enabling the rebind idiom `signal = pld.tensor.barrier(signal)`. Under the self-clearing protocol every call restarts at generation 1 regardless of how many times the signal has already been used, so the rebind no longer needs to chain onto any prior state.
 
 ## Implementation Notes
 

--- a/docs/en/dev/passes/38-synthesize_allreduce_signals.md
+++ b/docs/en/dev/passes/38-synthesize_allreduce_signals.md
@@ -73,12 +73,15 @@ The pass raises `pypto::ValueError` when:
 
 - an allreduce call has a positional argument count other than `target` or
   `target, signal`,
-- an allreduce appears inside a `for` or `while` loop,
 - an allreduce appears as a nested expression instead of a direct assignment,
   expression statement, or return value.
 
-Loop allreduce is rejected because the current signal protocol is single-use;
-the compiler must not reuse one signal buffer across dynamic invocations.
+An allreduce inside a `for` / `while` loop is legal: the self-clearing
+credit-barrier protocol (see
+[`LowerCompositeOps`](12-lower_composite_ops.md#barrier-signal-protocol))
+makes every call a stateless cycle that always restarts at generation 1, so a
+signal synthesized (or explicitly passed) before the loop is safely reused on
+every dynamic iteration — no per-call compile-time state to go stale.
 
 ## Pass Properties
 

--- a/docs/en/dev/passes/38-synthesize_allreduce_signals.md
+++ b/docs/en/dev/passes/38-synthesize_allreduce_signals.md
@@ -74,14 +74,16 @@ The pass raises `pypto::ValueError` when:
 - an allreduce call has a positional argument count other than `target` or
   `target, signal`,
 - an allreduce appears as a nested expression instead of a direct assignment,
-  expression statement, or return value.
+  expression statement, or return value,
+- an allreduce appears inside a `for` / `while` loop.
 
-An allreduce inside a `for` / `while` loop is legal: the self-clearing
-credit-barrier protocol (see
-[`LowerCompositeOps`](12-lower_composite_ops.md#barrier-signal-protocol))
-makes every call a stateless cycle that always restarts at generation 1, so a
-signal synthesized (or explicitly passed) before the loop is safely reused on
-every dynamic iteration — no per-call compile-time state to go stale.
+The loop restriction applies to the HOST rail: the `builtin.tensor.allreduce`
+kernel (lowered by `LowerHostTensorCollectives`) is not self-clearing — it adds
+ready/per-chunk credits via `AtomicAdd(+1)` and never subtracts them — so a
+signal synthesized (or explicitly passed) before a loop would be reused on a
+later iteration with stale `>=` thresholds. InCore composites lowered by
+[`LowerCompositeOps`](12-lower_composite_ops.md#barrier-signal-protocol) are
+loop-safe because that pass emits the self-clearing epilogue.
 
 ## Pass Properties
 

--- a/docs/zh/dev/distributed_ops.md
+++ b/docs/zh/dev/distributed_ops.md
@@ -93,6 +93,52 @@ enum class ReduceOp : int { kSum = 0, kMax = 1, kMin = 2, kProd = 3 };  // pld.t
 存根）,并以 `pld.NotifyOp` / `pld.WaitCmp` / `pld.AtomicType` / `pld.ReduceOp` 暴露给 DSL。
 deducer 会校验打包的 `int` 落在枚举范围内,使 codegen 无需二次保护即可转回。
 
+## 屏障-信号协议
+
+每个 `pld.tensor.*` 集合通信算子（`allreduce`、`barrier`、`broadcast`、
+`reduce_scatter`、`allgather`、`all_to_all`）都使用同一个**自清理信用屏障**
+（self-clearing credit barrier）进行同步，该屏障由 `pld.system.notify` /
+`pld.system.wait` 构建：
+
+```text
+Body:      barrier(1); barrier(2); ...; barrier(N)   # g 在本次调用内计数
+                                                      # （仅本次调用）
+  barrier(g):
+    for peer != my_rank: notify(signal, peer, <my cell>, 1, op=AtomicAdd)
+    for src  != my_rank: wait  (signal, <src cell>, g,   cmp=Ge)
+
+Epilogue:  for src != my_rank:
+               notify(signal, my_rank, <src cell>, -N, op=AtomicAdd)
+```
+
+`AtomicAdd` 把每个 cell 变成一个信用计数器：每次 notify 是生产者的 `+1`，尾声
+（epilogue）是唯一消费者的 `-N`。由于加法与减法是原子的且可交换，一旦所有 rank
+都完成本次调用的尾声，signal 可证明地恢复为全零 —— **signal 不携带任何超出
+单次调用生命周期的状态**，因此每次调用的 generation `g` 都从 1 重新开始，无需
+跨调用记账。慢 rank 在完成当前调用的过程中最多会让快 rank 自己的下次调用
+信用膨胀 1（有界 skew），因此计数器不会溢出，快 rank 也永远不会观察到虚假
+通过。
+
+`Ge`（而非 `Eq`）是关键负载：快 peer 可能在慢 rank 轮询前就把 cell 推到期望值
+之上，因此相等等待会永久阻塞。同理，`Set` 绝对不能与 `AtomicAdd` 混用在同一个
+cell 上 —— set 可能会覆盖已经被推高的计数器。
+
+`N`（尾声要减去的信用总数）可以是**运行时常量** —— `pld.system.notify` 的
+`value` 只需要 `ScalarType` —— 因此 mesh allreduce 的每块信用计数不需要在编译期
+已知。
+
+**约束：**
+
+| 约束 | 原因 |
+| ---- | ---- |
+| 同一个 signal 不能在 mesh（`[NR, 1]`）和 ring（`[2*(NR-1), NR]`）allreduce 之间共享 | mesh 寻址 `[rank, 0]`；ring 寻址 `[row, rank]` —— 形状不匹配，在降级时检查 |
+| 调用在中途被中止（错误/超时）会留下 signal 为非零 | 信用泄漏；在下一次 dispatch 之前通过 host 端重置（`reset_persistent_windows`）恢复 |
+
+由于协议是调用局部的，且 signal 在每次调用开始时始终为零，集合通信在 `for` /
+`while` / `if` 内都是合法的 —— 每次调用都是封闭循环，因此相同的编译期
+`expected` 值在每次迭代中复用。唯一的剩余要求是 rank 均匀执行（任何屏障的固有
+要求）：rank 分叉的控制流会死锁，由 `TWAIT` 的自旋计数断言暴露。
+
 ## 算子参考
 
 ### `pld.tile.remote_load`（TLOAD）
@@ -286,10 +332,11 @@ chunk，Pass 会保留该元数据，并沿用单矩形路径只归约这个矩�
 相同的类型。`mode` 关键字选择降级算法：
 
 - **`"mesh"`（默认）** — 全对全直接交换，O(P) 个 HCCL 窗口。信号 shape
-  `[NR, 1]`（每 rank 一个槽位）。`AtomicAdd 1` / `wait ≥1` ready 屏障之后进入
-  chunk 循环；每个 chunk 执行 `remote_load+accumulate`，再
-  `AtomicAdd 1` 并等待对应的单调 chunk 计数，最后才 store-back，从而避免
-  写后读 (WAR) 竞态。
+  `[NR, 1]`（每 rank 一个槽位）。ready 屏障（generation 1）之后进入 chunk
+  循环；每个 chunk 执行 `remote_load+accumulate`，再对本调用局部的
+  generation 做屏障，最后才 store-back，从而避免写后读 (WAR) 竞态。自清理
+  尾声随后把本次调用的总信用数减回每个 cell（参见
+  [屏障-信号协议](#屏障-信号协议)），因此调用完成后 signal 恢复为全零。
 - **`"ring"`** — NCCL 风格的分块 reduce-scatter + allgather 调度，
   O(1) 个 HCCL 窗口。信号 shape `[2 * (NR − 1), NR]`（每轮 ring 一行，
   每 rank 一个槽位）。packed ND 目标会被视为逻辑 `[1, SIZE]` 线性流；
@@ -301,18 +348,21 @@ chunk，Pass 会保留该元数据，并沿用单矩形路径只归约这个矩�
   MTE 安全地址开始，同时不改变用户可见的 packed 布局。很短的输入仍允许空
   segment。每个 segment 再按最大 16 KiB 的物理 subchunk 处理；FP16 尾块只把
   remote load 的物理读取范围向上对齐到 32 字节，并在归约或写回前恢复逻辑
-  `valid_shape`。每个 subchunk 在 store-back 前都使用该轮 signal 行上的 ready
-  和 read-complete 单调屏障，从而避免写后读 (WAR) 竞态，同时保持 signal shape
-  不变。
+  `valid_shape`。每个 subchunk 在 store-back 前都使用本调用局部的 ready
+  和 read-complete generation 做屏障，从而避免写后读 (WAR) 竞态。自清理
+  尾声随后把本次调用的总信用数从 signal 的每一行中减去。
 
-host-orchestrator 用户代码可以在 `for` 和 `while` 循环外省略 `signal`；
+host-orchestrator 用户代码可以省略 `signal`，包括在 `for` / `while`
+循环内；
 [`SynthesizeAllReduceSignals`](passes/38-synthesize_allreduce_signals.md) 阶段会为该 call 插入 private INT32 signal window，
 语义 shape 为 `[world_size, 1]`（仅 mesh 模式 — `mode="ring"` 必须显式传入
 signal）。该阶段会先插入 standalone `world_size = pld.world_size()` binding，
-再用该变量构造 buffer size 和 window shape。循环内的所有调用都会被拒绝，因为当前 signal 协议只能
-单次使用。显式 `signal` 仍然是 InCore
-lowering 和内部测试使用的形态。通信域物化会把该 signal buffer 保留在与 `src`
-相同的 comm-domain 中，即使它没有传给用户自定义 chip kernel。mesh、ring 和
+再用该变量构造 buffer size 和 window shape。自清理协议（参见
+[屏障-信号协议](#屏障-信号协议)）使每次调用都是无状态循环，
+因此 `for` / `while` 循环内的调用与其他集合通信一样受支持。显式 `signal`
+仍然是 InCore lowering 和内部测试使用的形态。通信域物化会把该 signal buffer
+保留在与 `src` 相同的 comm-domain 中，即使它没有传给用户自定义
+chip kernel。mesh、ring 和
 host builtin 路径均支持 FP16、FP32，以及任意正元素数量下的
 `ReduceOp.Sum`、`Max`、`Min` 和 `Prod`。InCore lowering 使用受 UB 上限约束的
 分块，host builtin 使用 256 元素分块。InCore mesh 和 ring 只把 FP16 remote

--- a/docs/zh/dev/passes/12-lower_composite_ops.md
+++ b/docs/zh/dev/passes/12-lower_composite_ops.md
@@ -188,7 +188,30 @@ sin 与 cos 共用同一组多项式系数：cos 路径只在区间归约阶段�
 
 ## `pld.tensor.*` 分布式集合通信算子
 
-本 Pass 同时降级 `pld.tensor.*` 系列的窗口绑定 (window-bound) 分布式集合通信算子。每个集合通信算子都是一个组合 `Call`，展开为 notify / wait + 数据搬运序列。数据搬运原语因算子而异：`allgather` 使用 `pld.tile.put`（基于 TPUT 的推送，经 VEC staging tile 自动分块），`broadcast` 用 `pld.tile.get` 搬运窗口数据（GM→GM 拷贝），`allreduce` 与 `reduce_scatter` 用 `pld.tile.remote_load` 把 peer chunk 拉进 UB tile。allreduce 根据规约类型选择 `tile.add`、`tile.maximum`、`tile.minimum` 或 `tile.mul`；reduce-scatter 当前仍用 `tile.add`。这些规则共享同一套 signal buffer 约定：使用窗口绑定的 INT32 `signal` 矩阵作为跨卡屏障，且**每次调用都需要新分配的 buffer**。
+本 Pass 同时降级 `pld.tensor.*` 系列的窗口绑定 (window-bound) 分布式集合通信算子。每个集合通信算子都是一个组合 `Call`，展开为 notify / wait + 数据搬运序列，外加自清理尾声。数据搬运原语因算子而异：`allgather` 使用 `pld.tile.put`（基于 TPUT 的推送，经 VEC staging tile 自动分块），`broadcast` 用 `pld.tile.get` 搬运窗口数据（GM→GM 拷贝），`allreduce` 与 `reduce_scatter` 用 `pld.tile.remote_load` 把 peer chunk 拉进 UB tile。allreduce 根据规约类型选择 `tile.add`、`tile.maximum`、`tile.minimum` 或 `tile.mul`；reduce-scatter 当前仍用 `tile.add`。七条规则共享同一套**自清理信用屏障协议**（`LoweringBuilder::EmitBarrier` + `EmitEpilogueReset`）—— 参见下方[屏障-信号协议](#屏障-信号协议) —— 因此 `signal` buffer 可以在连续调用之间复用，甚至在 `for` / `while` / `if` 内部也可以。
+
+### 屏障-信号协议
+
+每次调用发出 `N` 个屏障 —— 对每个 peer cell 做 `AtomicAdd(1)`，然后等待
+`Wait(>= g)`，其中 `g` 在**仅本次调用内部**向上计数（每次新调用都从 1 重新开始，
+由 `LoweringBuilder::EmitBarrier` 的调用局部 `barrier_count_` 实现）。主体之后，
+尾声（`LoweringBuilder::EmitEpilogueReset`）把本次调用的总信用 `N` 通过一次
+`AtomicAdd(-N)` 从每一个非 self cell 中减回去。由于原子加法与减法可交换，
+一旦所有 rank 都完成本次调用的尾声，signal 可证明地恢复为全零 —— 不存在
+跨调用状态需要管理，因此*下次*调用的同一个 signal 也从 generation 1 重新开始。
+
+`N` 可以是**运行时常量**（`pld.system.notify` 的 `value` 只需要 `ScalarType`），
+因此 mesh allreduce 的每块信用计数不需要是编译期常量 —— 与屏障计数本身不同，
+后者始终是小型编译期序列（`1`、`2`……），因为每个 `Wait` 的 `expected`
+必须在不知道外围（可能动态的）循环执行多少次的情况下就能解析。
+
+所有 wait 谓词都用 `kGe` 而非 `kEq`：快 peer 可能在慢 rank 轮询前就把
+cell 推过本次 wait 的期望值，因此相等判断会死锁。同理，`kSet` 绝对不能与
+`kAtomicAdd` 混用在同一个 cell 上 —— set 可能会覆盖已经被推高的计数器。
+
+mesh（`[NR, 1]`，每 rank 一个 cell）和 ring（`[2*(NR-1), NR]`，每轮一行）
+signal 使用互不兼容的 cell 寻址方式，因此共享同一个 buffer 会因形状不匹配
+被拒绝（`ValidateMeshSignalShape`） —— 这是协议仍然施加的唯一限制。
 
 ### `pld.tensor.allreduce`
 
@@ -213,24 +236,25 @@ ring 降级在 reduce-scatter 和 allgather 阶段使用同一个 packed 2D 视�
 subchunk 都从 32 字节对齐地址开始。FP16 的 ragged remote load 可以读取通信域
 预留的对齐物理尾部，然后通过 `tile.set_validshape` 在归约和写回前恢复逻辑范围。
 该方案无需在公开 tensor 布局中插入空洞，也能支持非整除输入和 `SIZE < NR`。
+每一轮的每个 subchunk 都使用本调用局部的 ready + read-complete generation 对
+做屏障；尾声随后把 `2 * chunk_count`（跨轮统一，因为每轮的 subchunk 循环
+共享相同边界）从 signal 的每一行中减去。
 
 任何在降级后仍为符号表达式的目标范围或 partial-valid 范围，都必须在 kernel 中
 通过标量参数、循环变量或物理 Tensor shape 参数获得运行时绑定；仅出现在类型元数据
 中的符号会在 PTO codegen 阶段被拒绝。完全动态的物理目标维度由该 Tensor 参数绑定。
 
-allreduce 规则先在共享 `signal` cell 上执行 ready 屏障：Phase 2a `AtomicAdd 1` +
-Phase 2b `wait ≥1`。之后对完全有效的目标按 UB 大小逐块处理；每个 chunk 完成 peer 归约后执行
-`AtomicAdd 1`，等待 `linear_chunk_id + 2`，再写回结果。这个逐块屏障可以阻止
-快 rank 覆盖慢 rank 尚未 remote-load 的数据。调用返回时，每个非 self 行停在
-`1 + chunk_count`；partial-valid 单矩形路径则停在 `2`。被跳过的 self 行始终保持为 `0`。
+allreduce 规则先在共享 `signal` cell 上执行 ready 屏障（generation 1）。之后对完全
+有效的目标按 UB 大小逐块处理；每个 chunk 完成 peer 归约后对本调用局部的
+generation（`2`、`3`……）做屏障，再写回结果 —— 阻止快 rank 覆盖慢 rank
+尚未 remote-load 的数据。尾声随后把本次调用的总信用
+（`1 + chunk_count`，构建为 IR 表达式，因为 `chunk_count` 可能依赖运行时
+范围）从每个非 self 行中减去。partial-valid 单矩形路径恰好发出两个屏障
+（ready + post-reduce），其尾声减去 `2`。
 
-**signal buffer 不能跨多次 allreduce 复用**。任意被 wait 的非 self 行上残留的正计数都会让
-下次调用的 Phase 2b `wait ≥1` 立刻在旧值上放行，屏障作废，下次读取与上一次
-写回直接竞态。需要连续多次 allreduce 的调用者必须为每次调用各自分配新的
-signal buffer（`alloc_window_buffer` + `window`）。用户侧的 DSL docstring
-（`python/pypto/language/distributed/op/tensor_ops.py::allreduce`）同步标注了这一契约。
-
-所有 wait 谓词都用 `kGe` 而非 `kEq`。单次调用内，每个被 wait 的 cell 都单调递增，因此慢 rank 首次轮询时，快 peer 可能已经把 cell 推过本次 wait 的期望值。此时相等判断会死锁，大于等于判断则不会。
+signal buffer 可以在连续 allreduce 调用之间安全管理复用 —— 包括对一个符号
+range 进行 mesh allreduce，其信用总数只是运行时计算表达式，而非编译器必须知道
+的值。参见上方[屏障-信号协议](#屏障-信号协议)。
 
 mesh 和 ring 降级均支持 FP16、FP32，以及任意正元素数量下的
 `ReduceOp::kSum`、`kMax`、`kMin` 和 `kProd`。
@@ -241,8 +265,9 @@ mesh 和 ring 降级均支持 FP16、FP32，以及任意正元素数量下的
 
 - ``tile.create([1, SIZE], dtype=..., target_memory=Vec)`` — 分配一个 VEC staging tile 供 ``pld.tile.put`` 自动分块使用。``pld.tile.put`` 直接从 ``local_data`` Tensor（或 Tile）源读取 — 不发射显式的 ``tile.load``。
 - Phase 1：对 `peer` 从 `0` 到 `NR-1`，`pld.tile.put(target, peer, local_data, put_stage, [my_rank, 0], [0, 0], [1, SIZE])` — 将本 rank 的 chunk 推送到每个 peer 窗口的第 `my_rank` 行。自推送 (`peer == my_rank`) 通过 HCCL 恒等映射实现。`pld.tile.put` 在 SIZE 超过 staging tile 容量时自动分块
-- Phase 2a：notify-all（`Set 1`）
+- Phase 2a：notify-all（`AtomicAdd 1`）
 - Phase 2b：wait-all（`Ge 1`）
+- 尾调用：`EmitEpilogueReset`（自清理信用屏障）
 - 返回 `target` — 窗口本身就是汇聚后的 `[NR, SIZE]` 结果（窗口即结果，`DistributedTensor`）
 
 与原始基于拉取 (pull-based) 的 allgather（4 参数带独立 `out` 张量）相比，该推送版本去掉了 `out` 参数和每 peer 的 `pld.tile.get` 汇聚循环。总 HBM 从 `(NR+1)×SIZE` 降至 `NR×SIZE`，代价是窗口在调用方消费结果之前一直处于占用状态。
@@ -251,8 +276,9 @@ mesh 和 ring 降级均支持 FP16、FP32，以及任意正元素数量下的
 
 展开为与 `allreduce` 相同的 5 阶段序列：
 
-- Phase 2a：notify-all（`Set 1`）
+- Phase 2a：notify-all（`AtomicAdd 1`）
 - Phase 2b：wait-all（`Ge 1`）
+- 尾调用：`EmitEpilogueReset`（自清理信用屏障）
 - Phase 3：对每个 peer `p`，`remote_load` 该 peer 的 chunk `r` 并用 `tile.add` 累加到本地 scratch
 - Phase 3.5a：re-notify（`AtomicAdd 1`）
 - Phase 3.5b：re-wait（`Ge 2`）
@@ -266,8 +292,9 @@ mesh 和 ring 降级均支持 FP16、FP32，以及任意正元素数量下的
 
 展开为 3 阶段序列：
 
-- Phase 2a：notify-all（`Set 1`）
+- Phase 2a：notify-all（`AtomicAdd 1`）
 - Phase 2b：wait-all（`Ge 1`）
+- 尾调用：`EmitEpilogueReset`（自清理信用屏障）
 - Phase 3：每个 rank 都发射 `tile.create`（VEC staging tile）+ `pld.tile.get(target, peer=root, target, stage)`，把 root 的切片读进自己的 `target`。`peer == root` 时 HCCL 恒等映射让该 get 成为本地空操作，因此 root 保留自己的数据，非 root rank 收到 root 的数据
 
 `root` 是编译时已知的静态 `int` kwarg。
@@ -276,8 +303,9 @@ mesh 和 ring 降级均支持 FP16、FP32，以及任意正元素数量下的
 
 纯同步，无数据搬运。展开为 2 阶段序列：
 
-- Phase 2a：notify-all（`Set 1`）
+- Phase 2a：notify-all（`AtomicAdd 1`）
 - Phase 2b：wait-all（`Ge 1`）
+- 尾调用：`EmitEpilogueReset`（自清理信用屏障）
 
 返回表达式就是同一个 `signal` 张量，支持 `signal = pld.tensor.barrier(signal)` 的 rebind 写法。
 

--- a/docs/zh/dev/passes/38-synthesize_allreduce_signals.md
+++ b/docs/zh/dev/passes/38-synthesize_allreduce_signals.md
@@ -65,11 +65,10 @@ alloc / window / allreduce 链路。
 以下情况会抛出 `pypto::ValueError`：
 
 - allreduce 位置参数数量不是 `target` 或 `target, signal`；
-- allreduce 出现在 `for` 或 `while` 循环中；
 - allreduce 作为嵌套表达式出现，而不是直接赋值、表达式语句或 return value。
 
-循环内 allreduce 会被拒绝，因为当前 signal 协议是 single-use；编译器不能在
-动态多次调用之间复用同一个 signal buffer。
+自清理信用屏障协议（见 [`LowerCompositeOps`](12-lower_composite_ops.md#屏障-信号协议)）使 signal 在每次调用后自动归零，因此 allreduce
+在 `for` / `while` 循环内是合法的 —— 每次调用都是独立封闭的，不会从上次迭代泄漏状态。
 
 ## Pass 属性
 

--- a/docs/zh/dev/passes/38-synthesize_allreduce_signals.md
+++ b/docs/zh/dev/passes/38-synthesize_allreduce_signals.md
@@ -65,10 +65,10 @@ alloc / window / allreduce 链路。
 以下情况会抛出 `pypto::ValueError`：
 
 - allreduce 位置参数数量不是 `target` 或 `target, signal`；
-- allreduce 作为嵌套表达式出现，而不是直接赋值、表达式语句或 return value。
+- allreduce 作为嵌套表达式出现，而不是直接赋值、表达式语句或 return value；
+- allreduce 出现在 `for` / `while` 循环内。
 
-自清理信用屏障协议（见 [`LowerCompositeOps`](12-lower_composite_ops.md#屏障-信号协议)）使 signal 在每次调用后自动归零，因此 allreduce
-在 `for` / `while` 循环内是合法的 —— 每次调用都是独立封闭的，不会从上次迭代泄漏状态。
+该循环限制针对 HOST 通道：`builtin.tensor.allreduce` kernel（由 `LowerHostTensorCollectives` lower）不是自清理的 —— 它用 `AtomicAdd(+1)` 增加 ready/per-chunk 信用却从不回减 —— 因此循环前合成（或显式传入）的 signal 会在后续迭代中复用残留的 `>=` 阈值。由 [`LowerCompositeOps`](12-lower_composite_ops.md#屏障-信号协议) lower 的 InCore 组合算子则因该 pass 会发出自清理尾声而具备循环安全性。
 
 ## Pass 属性
 

--- a/python/pypto/language/distributed/op/tensor_ops.py
+++ b/python/pypto/language/distributed/op/tensor_ops.py
@@ -567,11 +567,15 @@ def allreduce(
     (b) the NCCL-style 2(P-1)-step
     chunked reduce-scatter + allgather ring schedule for ``mode="ring"``.
     In both modes the kernel sees only the lowered primitives.
-    Host-orchestrator code can omit ``signal``
-    outside ``for`` and ``while`` loops; the compiler synthesizes a private
-    INT32 signal window of shape ``[pld.world_size(), 1]`` for that call
-    (mesh mode only — ring mode on the HOST rail is delivered by a
-    subsequent host builtin).
+    Host-orchestrator code can omit ``signal``, including inside ``for`` /
+    ``while`` loops; the compiler synthesizes a private INT32 signal window
+    of shape ``[pld.world_size(), 1]`` for that call (mesh mode only — ring
+    mode on the HOST rail is delivered by a subsequent host builtin).
+
+    Mesh signal shape is ``[NR, 1]``; ring signal shape is
+    ``[2 * (NR − 1), NR]`` (one row per ring round). A signal is reusable
+    across back-to-back calls (see the barrier protocol below), but the two
+    shapes must not share one buffer.
 
     Mesh signal shape is ``[NR, 1]``. The InCore ring schedule uses
     ``[2 * (NR − 1), NR]`` (one row per ring round). The host builtin
@@ -595,12 +599,23 @@ def allreduce(
     ``docs/en/dev/passes/12-lower_composite_ops.md`` for the mesh partial-valid /
     symbolic-extent target constraints (unchanged by this PR).
 
-    **Mesh barrier protocol:** ``AtomicAdd(1) → WaitGe(1)`` is the ready wave.
-    Every reduced chunk then performs ``AtomicAdd(1)`` and waits for the
-    corresponding monotonic counter value before storing that chunk. By the
-    time a fully-valid call returns every non-self row sits at
-    ``1 + chunk_count``; the partial-valid rectangle path ends at ``2``.
-    The skipped self row remains zero.
+    **Barrier protocol (self-clearing credit barrier):** every call's
+    barriers count a call-local generation ``g`` starting at 1 —
+    ``AtomicAdd(1) → WaitGe(g)`` — and a trailing epilogue subtracts the
+    call's total credit ``N`` back out of every non-self cell with a single
+    ``AtomicAdd(-N)``. Adds and subtracts commute, so the signal is provably
+    all-zero again once every rank finishes its epilogue: **the next call on
+    the same signal also starts at generation 1**, with no cross-call state
+    to go stale. ``N`` may be a runtime scalar, so a mesh allreduce's
+    per-chunk credit count does not need to be a compile-time constant.
+
+    In mesh mode, the ready barrier is generation 1; every reduced chunk then
+    barriers on the next generation before storing that chunk (``1 +
+    chunk_count`` credits total for a fully-valid call; the partial-valid
+    rectangle path issues exactly 2). In ring mode, every subchunk of every
+    round barriers on its own call-local ready + read-complete generation
+    pair; the epilogue subtracts ``2 * chunk_count`` (uniform across rounds)
+    from every row of the ``[2*(NR-1), NR]`` signal.
 
     Ring mode first views a packed ND target as one linear stream, then
     traverses each segment in physical subchunks of at most 16 KiB. FP32 uses
@@ -609,11 +624,11 @@ def allreduce(
     ``valid_shape`` before reduction and store. This also covers ``SIZE < NR``
     without changing the packed public layout or dropping elements.
 
-    **Ring barrier protocol:** each ring round owns one row of the
-    ``[2*(NR-1), NR]`` signal. Every subchunk advances that row twice:
-    a ready barrier before remote reads and a read-complete barrier before
-    store-back. The monotonic expected values are ``2*chunk_id+1`` and
-    ``2*chunk_id+2``. The skipped self column remains zero.
+    A signal buffer is safely reusable across back-to-back allreduce calls —
+    including inside ``for`` / ``while`` / ``if`` — since every call is a
+    stateless cycle starting from all-zero. A call aborted mid-flight (error
+    or timeout) leaves credits on the signal; recover with a host-side reset
+    (``reset_persistent_windows``) before the next dispatch.
 
     Args:
         target: Window-bound :class:`pld.DistributedTensor` holding per-rank
@@ -621,9 +636,9 @@ def allreduce(
             :class:`pl.Tensor` and unsupported dtypes.
         signal: Optional window-bound INT32 :class:`pld.DistributedTensor`.
             In InCore code this remains required. In host-orchestrator code,
-            omitting it outside ``for`` and ``while`` loops lets the compiler
-            synthesize a private signal of shape ``[pld.world_size(), 1]``.
-            Allreduce calls in those loops are rejected for both signatures.
+            omitting it — including inside ``for`` / ``while`` loops — lets
+            the compiler synthesize a private signal of shape
+            ``[pld.world_size(), 1]``.
         op: :class:`pld.ReduceOp` selecting element-wise ``Sum``, ``Max``,
             ``Min``, or ``Prod`` (keyword-only). Defaults to
             :attr:`pld.ReduceOp.Sum`.
@@ -677,17 +692,14 @@ def barrier(
 
         sig = pld.tensor.barrier(sig)
 
-    **Signal shape:** host builtins require rank-1 ``[world_size]``. InCore
-    composites take rank-2 ``[nranks, 1]`` -- the rank count may be dynamic.
-
-    **Signal buffer is single-shot per call.**  The lowering uses
-    ``Set(1)`` + ``Ge(1)`` — cells go from 0 to 1.  Do not reuse the
-    same signal buffer for back-to-back barriers without reallocation.
+    **Reusable across calls** — see :func:`allreduce` for the shared
+    self-clearing credit-barrier protocol. Each call is a stateless cycle
+    that restarts at generation 1, so ``sig`` may be reused for back-to-back
+    barriers, including inside ``for`` / ``while`` / ``if``.
 
     Args:
         signal: Window-bound INT32 :class:`pld.DistributedTensor` whose
-            shape provides one cell per rank.  Must be freshly allocated
-            for this call.
+            shape provides one cell per rank.
 
     Returns:
         The rebound :class:`pld.DistributedTensor` view of ``signal``.
@@ -726,7 +738,8 @@ def broadcast(
             data.  Root must stage its data before the call; non-root slots
             are ignored on input.
         signal: Window-bound INT32 :class:`pld.DistributedTensor` for the
-            cross-rank barrier.  Single-shot per call.
+            cross-rank barrier.  Reusable across calls — see
+            :func:`allreduce` for the shared barrier protocol.
         root: Root rank index (int, keyword-only).  Must be non-negative.
 
     Returns:
@@ -769,7 +782,9 @@ def allgather(
         target: :class:`pld.DistributedTensor` ``[NR, SIZE]`` result window.
             After the call, ``target[src, :]`` holds the chunk from rank
             ``src``.
-        signal: Window-bound INT32 :class:`pld.DistributedTensor` barrier tensor.
+        signal: Window-bound INT32 :class:`pld.DistributedTensor` barrier
+            tensor. Reusable across calls — see :func:`allreduce` for the
+            shared barrier protocol.
 
     Returns:
         The ``target`` :class:`pld.DistributedTensor` (window-as-result).
@@ -805,7 +820,9 @@ def reduce_scatter(
         target: Window-bound :class:`pld.DistributedTensor` of shape
             [NR, SIZE].  Each rank stages all NR chunks, one per row.
         signal: Window-bound INT32 :class:`pld.DistributedTensor` for
-            the cross-rank barrier.  Single-shot per call.
+            the cross-rank barrier. Reusable across calls (2 credits per
+            call — ready + post-reduce) — see :func:`allreduce` for the
+            shared barrier protocol.
         op: :class:`pld.ReduceOp` (keyword-only).  ``Sum`` only in
             first version; ``Max`` / ``Min`` / ``Prod`` reserved.
 
@@ -850,9 +867,9 @@ def all_to_all(
         target: :class:`pld.DistributedTensor` [NR, SIZE] window that receives
             the result in-place.  After the call,
             ``target[src, :]`` holds the chunk received from rank ``src``.
-        signal: Window-bound INT32 :class:`pld.DistributedTensor` barrier
-            tensor.  Rank-1 ``[world_size]`` or rank-2 ``[world_size, 1]``
-            for host builtins; rank-2 ``[nranks, 1]`` for InCore composites.
+        signal: :class:`pld.DistributedTensor` [NR, 1] INT32 barrier.
+            Reusable across calls — see :func:`allreduce` for the shared
+            barrier protocol.
 
     Returns:
         The ``target`` :class:`pld.DistributedTensor` (window-as-result).

--- a/python/pypto/language/distributed/op/tensor_ops.py
+++ b/python/pypto/language/distributed/op/tensor_ops.py
@@ -542,17 +542,13 @@ def allreduce(
     ``[world_size, 1]`` (the compiler-synthesized signal is rank-2). InCore
     composites take rank-2 ``[nranks, 1]`` for mesh -- the rank count may be
     dynamic -- and ``[2*(NR-1), NR]`` for ring, where ``NR`` must be a
-    compile-time constant. Both are single-shot per call.
+    compile-time constant.
 
-    **Do not reuse the same signal buffer for a back-to-back allreduce**
-    — allocate a fresh signal buffer (``alloc_window_buffer`` + ``window``)
-    for each allreduce call. All allreduce calls in ``for`` and ``while``
-    loops are rejected because the current signal protocol cannot provide a
-    fresh signal for every dynamic iteration. A self-resetting variant is
-    blocked on a runtime fix — tracked in #2156 (that issue's affected areas
-    currently list allgather / reduce_scatter / all_to_all / all_to_all_v;
-    allreduce is not listed there yet but hits the identical signal-lifetime
-    constraint, using ``AtomicAdd(1)``/``WaitGe(1)``).
+    **Signal reuse:** InCore composites use the self-clearing credit-barrier
+    protocol (see below), so their signal is reusable across back-to-back
+    calls — including inside ``for`` / ``while`` / ``if``. The HOST builtin
+    allreduce is not yet self-clearing, so a HOST allreduce (explicit or
+    synthesized signal) is still rejected inside ``for`` / ``while`` loops.
 
     .. seealso::
 
@@ -567,20 +563,16 @@ def allreduce(
     (b) the NCCL-style 2(P-1)-step
     chunked reduce-scatter + allgather ring schedule for ``mode="ring"``.
     In both modes the kernel sees only the lowered primitives.
-    Host-orchestrator code can omit ``signal``, including inside ``for`` /
-    ``while`` loops; the compiler synthesizes a private INT32 signal window
-    of shape ``[pld.world_size(), 1]`` for that call (mesh mode only — ring
-    mode on the HOST rail is delivered by a subsequent host builtin).
-
-    Mesh signal shape is ``[NR, 1]``; ring signal shape is
-    ``[2 * (NR − 1), NR]`` (one row per ring round). A signal is reusable
-    across back-to-back calls (see the barrier protocol below), but the two
-    shapes must not share one buffer.
+    Host-orchestrator code can omit ``signal`` outside ``for`` / ``while``
+    loops; the compiler synthesizes a private INT32 signal window of shape
+    ``[pld.world_size(), 1]`` for that call (mesh mode only — ring mode on the
+    HOST rail is delivered by a subsequent host builtin).
 
     Mesh signal shape is ``[NR, 1]``. The InCore ring schedule uses
-    ``[2 * (NR − 1), NR]`` (one row per ring round). The host builtin
-    ring schedule uses ``[2 * (NR − 1) + 1, NR]`` (one extra row for
-    the return barrier). Both are single-shot per call.
+    ``[2 * (NR − 1), NR]`` (one row per ring round). The host builtin ring
+    schedule uses ``[2 * (NR − 1) + 1, NR]`` (one extra row for the return
+    barrier). The mesh and ring shapes address cells differently, so one
+    buffer must not be shared between the two conventions.
 
     .. note::
 
@@ -624,21 +616,21 @@ def allreduce(
     ``valid_shape`` before reduction and store. This also covers ``SIZE < NR``
     without changing the packed public layout or dropping elements.
 
-    A signal buffer is safely reusable across back-to-back allreduce calls —
-    including inside ``for`` / ``while`` / ``if`` — since every call is a
-    stateless cycle starting from all-zero. A call aborted mid-flight (error
-    or timeout) leaves credits on the signal; recover with a host-side reset
-    (``reset_persistent_windows``) before the next dispatch.
+    For InCore composites, a signal buffer is safely reusable across
+    back-to-back allreduce calls — including inside ``for`` / ``while`` /
+    ``if`` — since every call is a stateless cycle starting from all-zero.
+    A call aborted mid-flight (error or timeout) leaves credits on the signal;
+    recover with a host-side reset (``reset_persistent_windows``) before the
+    next dispatch.
 
     Args:
         target: Window-bound :class:`pld.DistributedTensor` holding per-rank
             FP16 or FP32 data. The C++ verifier refuses a plain
             :class:`pl.Tensor` and unsupported dtypes.
         signal: Optional window-bound INT32 :class:`pld.DistributedTensor`.
-            In InCore code this remains required. In host-orchestrator code,
-            omitting it — including inside ``for`` / ``while`` loops — lets
-            the compiler synthesize a private signal of shape
-            ``[pld.world_size(), 1]``.
+            In InCore code this remains required. In host-orchestrator code
+            outside ``for`` / ``while`` loops, omitting it lets the compiler
+            synthesize a private signal of shape ``[pld.world_size(), 1]``.
         op: :class:`pld.ReduceOp` selecting element-wise ``Sum``, ``Max``,
             ``Min``, or ``Prod`` (keyword-only). Defaults to
             :attr:`pld.ReduceOp.Sum`.

--- a/src/ir/transforms/lower_composite_ops_pass.cpp
+++ b/src/ir/transforms/lower_composite_ops_pass.cpp
@@ -60,6 +60,57 @@ struct CommSetup {
   ExprPtr my_rank;     ///< Result of pld.system.rank (INT32)
 };
 
+/// Safe negation: folds ConstInt(-value) directly when possible so the
+/// PyPTO printer→parser roundtrip (which folds ``Neg(ConstInt)`` into
+/// ``ConstInt(-value)``) produces structurally equal IR. Runtime
+/// expressions are still wrapped with ``Neg``.
+inline ExprPtr MakeNegation(const ExprPtr& value) {
+  if (auto c = As<ConstInt>(value)) {
+    return std::make_shared<ConstInt>(-c->value_, GetScalarDtype(value), value->span_);
+  }
+  return MakeNeg(value, value->span_);
+}
+
+// ============================================================================
+// Self-clearing credit barrier — the shared, stateless barrier-signal protocol
+// ============================================================================
+//
+// Every ``pld.tensor.*`` collective synchronises through one protocol:
+//
+//     Body:      barrier(1); barrier(2); ...; barrier(N)   # g counted within
+//                                                           # this call only
+//       barrier(g):
+//         for peer != my_rank: notify(signal, peer, <my cell>, 1, op=AtomicAdd)
+//         for src  != my_rank: wait  (signal, <src cell>, g,   cmp=Ge)
+//
+//     Epilogue:  for src != my_rank:
+//                    notify(signal, my_rank, <src cell>, -N, op=AtomicAdd)
+//
+// ``AtomicAdd`` turns each cell into a credit counter: every notify is a
+// producer's ``+1``, and the epilogue is the sole consumer's ``-N``. Because
+// adds and subtracts are atomic and commutative, the signal is provably
+// all-zero again once every rank has finished its epilogue for a call — the
+// signal carries no state that outlives one call, so every call's ``g`` restarts
+// at 1 and no cross-call bookkeeping is needed. A slow rank can inflate a fast
+// rank's own next-call credit by at most 1 while it finishes the current call
+// (bounded skew), so the counter never overflows and a fast rank can never
+// observe a spurious pass.
+//
+// ``kGe`` (not ``kEq``) is load-bearing: a fast peer can advance a cell past the
+// value the waiting rank is looking for before that rank ever polls it, so an
+// equality wait would never unblock. For the same reason ``kSet`` must never be
+// mixed with ``kAtomicAdd`` on the same cells — a set could clobber an already
+// advanced counter.
+//
+// Because the protocol is call-local, the mesh (``[NR, 1]``, one cell per rank)
+// and ring (``[2*(NR-1), NR]``, one row per round) signal shapes are the only
+// remaining incompatibility between collectives sharing one signal buffer — see
+// ``ValidateMeshSignalShape``. There is no compile-time generation ledger to
+// poison, so collectives are legal inside ``for``/``while``/``if``, and a mesh
+// allreduce's per-chunk credit total may be a runtime-computed scalar rather
+// than a compile-time constant.
+// ============================================================================
+
 std::vector<ExprPtr> CollapseShapeTo2D(const std::vector<ExprPtr>& shape, const Span& span) {
   INTERNAL_CHECK_SPAN(!shape.empty(), span) << "Cannot flatten a rank-0 tensor shape";
   if (shape.size() == 1) {
@@ -152,6 +203,28 @@ CallPtr CreateAllReduceTargetView(const ExprPtr& target, const std::vector<ExprP
   return OpRegistry::GetInstance().Create("tensor.view", view_args, {}, span);
 }
 
+/// Validates that ``signal_type`` matches the mesh barrier convention (one
+/// cell per rank: ``[NR, 1]``). Ring allreduce's signal is ``[2*(NR-1), NR]``
+/// instead — one row per round, addressed ``[row, rank]``. Sharing one buffer
+/// between the two conventions no longer trips a generation-table state error
+/// (the self-clearing protocol is call-local, so there is no cross-call state
+/// to mismatch); this shape check is the sole remaining guard against a mesh
+/// op silently targeting the wrong cell of a ring-shaped signal. Skip the
+/// second-dimension check when it is symbolic, matching the ring rule's own
+/// existing shape checks.
+void ValidateMeshSignalShape(const DistributedTensorTypePtr& signal_type, const std::string& op_name,
+                             const Span& span) {
+  CHECK_SPAN(signal_type, span) << op_name << " signal must be a DistributedTensor";
+  CHECK_SPAN(signal_type->shape_.size() == 2, span)
+      << op_name << " signal must be 2D [NR, 1], got rank " << signal_type->shape_.size();
+  if (auto col_dim = As<ConstInt>(signal_type->shape_[1])) {
+    CHECK_SPAN(col_dim->value_ == 1, span)
+        << op_name << " signal shape[1] must be 1 (one cell per rank), got " << col_dim->value_
+        << " — a signal shaped for mode=\"ring\" allreduce ([2*(NR-1), NR]) cannot be shared with "
+           "this collective; give it its own [NR, 1] signal window";
+  }
+}
+
 // ============================================================================
 // LoweringBuilder
 //
@@ -168,8 +241,11 @@ CallPtr CreateAllReduceTargetView(const ExprPtr& target, const std::vector<ExprP
 // emitted temp gets a unique name across the entire rule, regardless of
 // nesting depth.
 //
-// The temp counter is borrowed from the mutator so distinct composite-op calls
-// in the same function get distinct temp names.
+// The temp counter is borrowed from the mutator so unique temp names span
+// distinct composite-op calls in the same function. Barrier generations are
+// call-local (see the self-clearing credit-barrier protocol above), so each
+// LoweringBuilder instance — one per top-level composite-op call — owns its
+// own ``barrier_count_`` that always starts at 0.
 // ============================================================================
 class LoweringBuilder {
  public:
@@ -178,6 +254,9 @@ class LoweringBuilder {
   /// @param temp_counter Reference to a mutator-owned counter; bumped per Bind.
   LoweringBuilder(std::string base_name, std::size_t& temp_counter)
       : base_name_(std::move(base_name)), temp_counter_(temp_counter) {}
+
+  LoweringBuilder(std::string base_name, std::size_t& temp_counter, bool nested)
+      : base_name_(std::move(base_name)), temp_counter_(temp_counter), nested_(nested) {}
 
   /// Append an ``AssignStmt`` binding a fresh ``Var`` to ``expr`` and return
   /// the new ``Var`` so it can be used as input to subsequent ops. The
@@ -320,7 +399,7 @@ class LoweringBuilder {
   /// @param signal       The signal DistributedTensor
   /// @param nranks_idx   Loop bound (INDEX-typed)
   /// @param my_rank      This rank's ID (INT32)
-  /// @param expected     Expected signal value (e.g., one_i32 or two_i32)
+  /// @param expected     Expected signal value — the barrier generation (INT32)
   /// @param suffix       Suffix for loop variable names (e.g., "" or "2" for re-wait)
   /// @param span         Source span for error reporting
   void EmitWaitAll(const ExprPtr& signal, const ExprPtr& nranks_idx, const ExprPtr& my_rank,
@@ -370,6 +449,109 @@ class LoweringBuilder {
         span);
   }
 
+  // ---- Self-clearing credit barrier protocol (see the file-header comment) ----
+
+  /// Emit one complete cross-rank barrier on ``signal``: ``AtomicAdd(1)`` into
+  /// every peer's cell, then wait for this call's generation on every peer's
+  /// cell. Returns the generation waited for (1-based, scoped to *this call*
+  /// only — every fresh ``LoweringBuilder`` starts counting at 0), so a rule
+  /// that fans out further barriers (the mesh allreduce's per-chunk barriers)
+  /// can continue the sequence from it, and so the rule can compute the total
+  /// credit count its ``EmitEpilogueReset`` call must subtract.
+  ///
+  /// Call this only from a rule's straight-line code — one call consumes exactly
+  /// one generation, so invoking it inside an ``EmitFor`` body would reserve a
+  /// single generation for a barrier that executes many times. Loop-resident
+  /// barriers must emit notify/wait by hand with a call-local expected value
+  /// (see the ring / mesh-chunked rules below).
+  int64_t EmitBarrier(const ExprPtr& signal, const CommSetup& comm, const std::string& suffix,
+                      const Span& span) {
+    INTERNAL_CHECK_SPAN(!nested_, span)
+        << "Internal error: EmitBarrier must only be called from a top-level lowering rule, not from inside "
+        << "EmitFor / EmitIf / EmitIfExpr bodies. Loop- or condition-resident barriers must "
+        << "emit notify/wait by hand with a call-local expected value.";
+    const int64_t generation = ++barrier_count_;
+    auto one_i32 = std::make_shared<ConstInt>(1, DataType::INT32, span);
+    auto expected_i32 = std::make_shared<ConstInt>(generation, DataType::INT32, span);
+    EmitNotifyAll(signal, comm.nranks_idx, comm.my_rank, NotifyOp::kAtomicAdd, one_i32, suffix, span);
+    EmitWaitAll(signal, comm.nranks_idx, comm.my_rank, expected_i32, suffix, span);
+    return generation;
+  }
+
+  /// Self-clearing epilogue: subtract ``total`` from every non-self peer's
+  /// contribution to *my own* cells, restoring the signal to all-zero once
+  /// every rank has run its own epilogue. ``total`` is the number of
+  /// ``AtomicAdd(+1)`` notifies this call issued per peer (the sum of every
+  /// ``EmitBarrier`` / hand-rolled notify-wait pair the rule emitted) — it may
+  /// be a runtime-computed expression, not just a ``ConstInt``:
+  /// ``pld.system.notify``'s value only requires ``ScalarType``.
+  ///
+  /// This is a self-notify (``peer == my_rank``): the codegen path resolves
+  /// ``peer == my_rank`` via the same identity mapping ``pld.tile.put`` /
+  /// ``pld.tile.get`` already rely on for their self-rank case, so this lands
+  /// on the exact same hardware atomic as an incoming remote add.
+  ///
+  /// Call this exactly once per rule invocation, from top-level code only,
+  /// after every barrier the rule issues.
+  void EmitEpilogueReset(const ExprPtr& signal, const CommSetup& comm, const ExprPtr& total,
+                         const Span& span) {
+    INTERNAL_CHECK_SPAN(!nested_, span)
+        << "EmitEpilogueReset must only be called from a top-level lowering rule, exactly once "
+           "per call, after every EmitBarrier / hand-rolled notify-wait pair the rule issues.";
+    auto neg_total = MakeNegation(total);
+    auto zero_idx = std::make_shared<ConstInt>(0, DataType::INDEX, span);
+    auto one_idx = std::make_shared<ConstInt>(1, DataType::INDEX, span);
+    EmitFor(
+        "reset_src", zero_idx, comm.nranks_idx, one_idx,
+        [&](LoweringBuilder& body, const VarPtr& src) {
+          body.EmitIf(
+              body.NotEq(src, comm.my_rank, span),
+              [&](LoweringBuilder& then_body) {
+                auto src_offsets = tile_conversion_utils::MakeSignalOffsets(src, span);
+                auto call = OpRegistry::GetInstance().Create(
+                    "pld.system.notify", {signal, comm.my_rank, src_offsets, neg_total},
+                    {{"op", static_cast<int>(NotifyOp::kAtomicAdd)}}, span);
+                then_body.Bind("epilogue_reset_ret", call, span);
+              },
+              /*else_fn=*/nullptr, span);
+        },
+        span);
+  }
+
+  /// 2D-signal overload (ring allreduce, ``[2*(NR-1), NR]``): subtract
+  /// ``total_per_row`` from every non-self cell of every one of ``num_rows``
+  /// rows. Ring credits every row independently (one per round / sub-chunk
+  /// sequence), and every row's sub-chunk loop shares the same bound, so one
+  /// symbolic ``total_per_row`` resets all rows uniformly.
+  void EmitEpilogueReset(const ExprPtr& signal, const CommSetup& comm, const ExprPtr& num_rows,
+                         const ExprPtr& total_per_row, const Span& span) {
+    INTERNAL_CHECK_SPAN(!nested_, span)
+        << "EmitEpilogueReset must only be called from a top-level lowering rule, exactly once per call.";
+    auto neg_total = MakeNegation(total_per_row);
+    auto zero_idx = std::make_shared<ConstInt>(0, DataType::INDEX, span);
+    auto one_idx = std::make_shared<ConstInt>(1, DataType::INDEX, span);
+    EmitFor(
+        "reset_row", zero_idx, num_rows, one_idx,
+        [&](LoweringBuilder& row_body, const VarPtr& row) {
+          row_body.EmitFor(
+              "reset_src", zero_idx, comm.nranks_idx, one_idx,
+              [&](LoweringBuilder& body, const VarPtr& src) {
+                body.EmitIf(
+                    body.NotEq(src, comm.my_rank, span),
+                    [&](LoweringBuilder& then_body) {
+                      auto src_offsets = tile_conversion_utils::MakeSignalOffsets(src, row, span);
+                      auto call = OpRegistry::GetInstance().Create(
+                          "pld.system.notify", {signal, comm.my_rank, src_offsets, neg_total},
+                          {{"op", static_cast<int>(NotifyOp::kAtomicAdd)}}, span);
+                      then_body.Bind("epilogue_reset_ret", call, span);
+                    },
+                    /*else_fn=*/nullptr, span);
+              },
+              span);
+        },
+        span);
+  }
+
   // ---- Structured control-flow constructors ----
   //
   // Each method takes a body callback that receives a freshly-constructed
@@ -395,7 +577,7 @@ class LoweringBuilder {
                const ExprPtr& step, const std::function<void(LoweringBuilder&, const VarPtr&)>& body_fn,
                const Span& span) {
     auto loop_var = std::make_shared<Var>(MakeTempName(loop_var_name), start->GetType(), span);
-    LoweringBuilder body_builder(base_name_, temp_counter_);
+    LoweringBuilder body_builder(base_name_, temp_counter_, /*nested=*/true);
     body_fn(body_builder, loop_var);
     auto body_stmt = WrapBodyStmts(body_builder.TakeStmts(), span);
     stmts_.push_back(std::make_shared<ForStmt>(loop_var, start, stop, step, std::vector<IterArgPtr>{},
@@ -414,7 +596,7 @@ class LoweringBuilder {
     auto loop_var = std::make_shared<Var>(MakeTempName(loop_var_name), start->GetType(), span);
     auto iter_arg = std::make_shared<IterArg>(MakeTempName(loop_var_name + "_acc"), init_value->GetType(),
                                               init_value, span);
-    LoweringBuilder body_builder(base_name_, temp_counter_);
+    LoweringBuilder body_builder(base_name_, temp_counter_, /*nested=*/true);
     ExprPtr yield_val = body_fn(body_builder, loop_var, iter_arg);
     INTERNAL_CHECK_SPAN(yield_val, span)
         << "EmitForReduce body_fn must return the next iteration's accumulator value";
@@ -437,13 +619,13 @@ class LoweringBuilder {
   /// Pass ``nullptr`` for ``else_fn`` when there is no else branch.
   void EmitIf(const ExprPtr& cond, const std::function<void(LoweringBuilder&)>& then_fn,
               const std::function<void(LoweringBuilder&)>& else_fn, const Span& span) {
-    LoweringBuilder then_builder(base_name_, temp_counter_);
+    LoweringBuilder then_builder(base_name_, temp_counter_, /*nested=*/true);
     then_fn(then_builder);
     auto then_body = WrapBodyStmts(then_builder.TakeStmts(), span);
 
     std::optional<StmtPtr> else_body = std::nullopt;
     if (else_fn) {
-      LoweringBuilder else_builder(base_name_, temp_counter_);
+      LoweringBuilder else_builder(base_name_, temp_counter_, /*nested=*/true);
       else_fn(else_builder);
       else_body = WrapBodyStmts(else_builder.TakeStmts(), span);
     }
@@ -457,13 +639,13 @@ class LoweringBuilder {
                      const std::function<ExprPtr(LoweringBuilder&)>& else_fn, const Span& span) {
     INTERNAL_CHECK_SPAN(then_fn && else_fn, span)
         << "EmitIfExpr requires both then_fn and else_fn (the if must yield a value on every path)";
-    LoweringBuilder then_builder(base_name_, temp_counter_);
+    LoweringBuilder then_builder(base_name_, temp_counter_, /*nested=*/true);
     ExprPtr then_val = then_fn(then_builder);
     INTERNAL_CHECK_SPAN(then_val, span) << "EmitIfExpr then_fn must return the yielded value";
     then_builder.stmts_.push_back(std::make_shared<YieldStmt>(std::vector<ExprPtr>{then_val}, span));
     auto then_body = WrapBodyStmts(then_builder.TakeStmts(), span);
 
-    LoweringBuilder else_builder(base_name_, temp_counter_);
+    LoweringBuilder else_builder(base_name_, temp_counter_, /*nested=*/true);
     ExprPtr else_val = else_fn(else_builder);
     INTERNAL_CHECK_SPAN(else_val, span) << "EmitIfExpr else_fn must return the yielded value";
     else_builder.stmts_.push_back(std::make_shared<YieldStmt>(std::vector<ExprPtr>{else_val}, span));
@@ -496,6 +678,8 @@ class LoweringBuilder {
 
   std::string base_name_;
   std::size_t& temp_counter_;
+  bool nested_ = false;
+  int64_t barrier_count_ = 0;  ///< Call-local generation counter; see EmitBarrier.
   std::vector<StmtPtr> stmts_;
 };
 
@@ -709,6 +893,9 @@ ExprPtr LowerTensorAllReduceRule(const CallPtr& call, const std::vector<ExprPtr>
     return LowerTensorRingAllReduceRule(call, args, b);
   }
 
+  auto signal_type = As<DistributedTensorType>(signal->GetType());
+  ValidateMeshSignalShape(signal_type, "pld.tensor.allreduce", span);
+
   // ---- Pre-build expressions shared across phases ----
   auto& reg = OpRegistry::GetInstance();
   auto comm = b.EmitCommSetup(target, span);
@@ -717,40 +904,15 @@ ExprPtr LowerTensorAllReduceRule(const CallPtr& call, const std::vector<ExprPtr>
   // and wait's `expected` are INT32 per the Python builder's int_dtype
   // override — keep separate constants for those distinct slots.
   //
-  // Signal scheme: monotonic AtomicAdd, with waits using ``WaitCmp::kGe``.
-  // Phase 2a adds ``1`` and Phase 2b waits for ``>= 1``.  Each chunk-complete
-  // barrier adds another ``1`` and waits for ``>= chunk_id + 2``.  Avoid
-  // mixing ``Set`` with later ``AtomicAdd`` on the same cells: a fast rank can
-  // issue both notifications for a tiny chunk before a slow peer observes the
-  // first barrier, and device-side visibility of set/add notifications is not
-  // guaranteed to preserve the final monotonic value.
-  //
-  // ``kGe`` (not ``kEq``) is load-bearing. The cell is monotonically
-  // increasing within a single call, but the observer (the waiting rank)
-  // is NOT guaranteed to read each intermediate value: if a faster peer
-  // races ahead — e.g. rank A pauses between its own Phase 2a and 2b
-  // while rank B completes 2a, 2b, the full Phase 3 (remote loads,
-  // microseconds), and Phase 3.5a — then by the time A polls its
-  // cell[B], it has already been advanced from 1 to 2. ``kEq(==1)`` would
-  // never unblock; ``kGe(>=1)`` does.
-  //
-  // Every non-self row ends the call at ``1 + number_of_chunks`` for a
-  // fully-valid target (or ``2`` for the partial-valid rectangle). The self
-  // row is skipped and remains zero, but the non-self counters still make the
-  // buffer **non-reusable** across multiple allreduce calls without per-call
-  // reallocation — a stale positive value
-  // would let the next call's ``Ge(1)`` Phase 2b pass before any peer
-  // notifies, breaking the barrier. The symmetric ``Set value=0`` reset
-  // path would let the buffer self-clear, but on-board ``TWAIT(==0)`` did
-  // not unblock reliably in our trials (P=4 deadlocked on AICPU stream
-  // sync — see PTOAS issue #797). Until that runtime path is verified,
-  // callers needing back-to-back allreduces must allocate a fresh signal
-  // buffer per call. The user-facing DSL docstring repeats this contract.
+  // Barrier protocol: the self-clearing credit barrier (see the file-header
+  // comment). The ready barrier is generation 1; each chunk-complete barrier
+  // is one more, so chunk ``k`` waits for ``1 + k``. Those per-chunk
+  // generations are derived by hand here — the barrier lives inside the chunk
+  // loop, so it cannot go through ``EmitBarrier`` — and the total credit count
+  // this call issued is subtracted back out by ``EmitEpilogueReset`` below.
   auto zero_idx = std::make_shared<ConstInt>(0, DataType::INDEX, span);
   auto one_idx = std::make_shared<ConstInt>(1, DataType::INDEX, span);
-  auto two_idx = std::make_shared<ConstInt>(2, DataType::INDEX, span);
   auto one_i32 = std::make_shared<ConstInt>(1, DataType::INT32, span);
-  auto two_i32 = std::make_shared<ConstInt>(2, DataType::INT32, span);
   const int64_t element_bytes = static_cast<int64_t>(target_type->dtype_.GetByte());
   INTERNAL_CHECK_SPAN(element_bytes > 0, span)
       << "pld.tensor.allreduce target dtype has no storage width: " << target_type->dtype_.ToString();
@@ -810,11 +972,8 @@ ExprPtr LowerTensorAllReduceRule(const CallPtr& call, const std::vector<ExprPtr>
       "target_2d", CreateAllReduceTargetView(target, flat_shape, flat_valid_shape, partial_valid_shape, span),
       span);
 
-  // ---- Phase 2a: notify all peers (AtomicAdd cell[my_rank, 0] on each peer by 1) ----
-  b.EmitNotifyAll(signal, comm.nranks_idx, comm.my_rank, NotifyOp::kAtomicAdd, one_i32, "", span);
-
-  // ---- Phase 2b: wait on every peer's signal slot (cell[src, 0] >= 1) ----
-  b.EmitWaitAll(signal, comm.nranks_idx, comm.my_rank, one_i32, "", span);
+  // ---- Phase 2: ready barrier (AtomicAdd 1 → wait Ge ready_generation) ----
+  const int64_t ready_generation = b.EmitBarrier(signal, comm, "", span);
 
   // A partial ND valid box is not a contiguous linear stream: the physical
   // rows can contain gaps after valid_cols. Keep the established single
@@ -847,9 +1006,12 @@ ExprPtr LowerTensorAllReduceRule(const CallPtr& call, const std::vector<ExprPtr>
               [&](LoweringBuilder& /*else_body*/) -> ExprPtr { return acc; }, span);
         },
         span);
-    b.EmitNotifyAll(signal, comm.nranks_idx, comm.my_rank, NotifyOp::kAtomicAdd, one_i32, "2", span);
-    b.EmitWaitAll(signal, comm.nranks_idx, comm.my_rank, two_i32, "2", span);
+    // Post-reduce barrier — one further generation, so the rectangle path
+    // issues exactly two credits per peer this call.
+    const int64_t final_generation = b.EmitBarrier(signal, comm, "2", span);
     b.Bind("store_ret", reg.Create("tile.store", {acc_final, zero_offsets, flat_target}, {}, span), span);
+    auto total_i32 = std::make_shared<ConstInt>(final_generation, DataType::INT32, span);
+    b.EmitEpilogueReset(signal, comm, total_i32, span);
     return target;
   }
 
@@ -929,10 +1091,12 @@ ExprPtr LowerTensorAllReduceRule(const CallPtr& call, const std::vector<ExprPtr>
             },
             span);
 
-        // The signal cell starts at 1 after the ready barrier. Each completed
-        // chunk adds one, so wait for chunk_id + 2.
+        // The signal cell sits at ready_generation after the ready barrier.
+        // Each completed chunk adds one, so chunk k waits for
+        // ready_generation + 1 + k.
+        auto chunk_base = std::make_shared<ConstInt>(ready_generation + 1, DataType::INDEX, span);
         auto chunk_id = MakeFloorDiv(col, chunk_cols, span);
-        auto expected_idx = MakeAdd(chunk_id, two_idx, span);
+        auto expected_idx = MakeAdd(chunk_id, chunk_base, span);
         auto expected_i32 = chunk_body.Bind(
             "chunk_expected", std::make_shared<ir::Cast>(expected_idx, DataType::INT32, span), span);
         chunk_body.EmitNotifyAll(signal, comm.nranks_idx, comm.my_rank, NotifyOp::kAtomicAdd, one_i32,
@@ -949,6 +1113,22 @@ ExprPtr LowerTensorAllReduceRule(const CallPtr& call, const std::vector<ExprPtr>
                         reg.Create("tile.store", {store_value, chunk_offsets, flat_target}, {}, span), span);
       },
       span);
+
+  // Self-clearing epilogue: this call issued ready_generation (1) + chunk_count
+  // credits per peer — one for the ready barrier, one per completed chunk.
+  // chunk_count = ceil(valid_cols / chunk_cols); chunk_cols is always a
+  // ConstInt, but valid_cols (the reduced extent) may be a runtime scalar, so
+  // build the total as an IR expression rather than requiring it statically —
+  // pld.system.notify's value only needs ScalarType, so a symbolic total is
+  // legal here.
+  auto chunk_cols_minus_one = MakeSub(chunk_cols, one_idx, span);
+  auto chunk_count_idx =
+      MakeFloorDiv(MakeAdd(flat_valid_shape[1], chunk_cols_minus_one, span), chunk_cols, span);
+  auto total_idx =
+      MakeAdd(std::make_shared<ConstInt>(ready_generation, DataType::INDEX, span), chunk_count_idx, span);
+  auto total_i32 =
+      b.Bind("allreduce_reset_total", std::make_shared<ir::Cast>(total_idx, DataType::INT32, span), span);
+  b.EmitEpilogueReset(signal, comm, total_i32, span);
 
   // In-place semantics: the rebind LHS receives the (post-reduce) target view.
   return target;
@@ -1361,6 +1541,20 @@ ExprPtr LowerTensorRingAllReduceRule(const CallPtr& call, const std::vector<Expr
       },
       span);
 
+  // Self-clearing epilogue: every row (round) of this call issued
+  // 2 * chunk_count credits per peer — a ready + read-complete barrier for
+  // every subchunk. chunk_count = ceil(max_segment_cols / chunk_cols) is
+  // uniform across every row (every round's sub-chunk loop shares this same
+  // bound), so one symbolic total resets every row of the [2*(NR-1), NR]
+  // signal.
+  auto chunk_cols_minus_one = MakeSub(chunk_cols, one_idx, span);
+  auto chunk_count_idx =
+      MakeFloorDiv(MakeAdd(max_segment_cols, chunk_cols_minus_one, span), chunk_cols, span);
+  auto total_per_row_idx = MakeMul(two_idx, chunk_count_idx, span);
+  auto total_per_row_i32 =
+      b.Bind("ring_reset_total", std::make_shared<ir::Cast>(total_per_row_idx, DataType::INT32, span), span);
+  b.EmitEpilogueReset(signal, comm, signal_type->shape_[0], total_per_row_i32, span);
+
   return target;
 }
 
@@ -1368,8 +1562,7 @@ ExprPtr LowerTensorRingAllReduceRule(const CallPtr& call, const std::vector<Expr
 // ``pld.tensor.broadcast`` lowering rule
 //
 // Broadcast root rank's data to every rank:
-//   Phase 2a: notify-all (Set 1)
-//   Phase 2b: wait-all  (Ge 1)
+//   Phase 2:  barrier (AtomicAdd 1 -> wait Ge generation)
 //   Phase 3:  tile.create(VEC stage) + pld.tile.get(target, peer=root, src=target, stage)
 // Returns target (in-place rebind).  Single barrier — broadcast is read-only
 // after staging, no WAR hazard.
@@ -1384,20 +1577,18 @@ ExprPtr LowerTensorBroadcastRule(const CallPtr& call, const std::vector<ExprPtr>
   auto target_type = As<DistributedTensorType>(target->GetType());
   INTERNAL_CHECK_SPAN(target_type, span)
       << "pld.tensor.broadcast target must be DistributedTensorType (deducer-rejected otherwise)";
+  auto signal_type = As<DistributedTensorType>(signal->GetType());
+  ValidateMeshSignalShape(signal_type, "pld.tensor.broadcast", span);
 
   auto root_value = GetRequiredKwarg<int>(call->kwargs_, "root", "pld.tensor.broadcast");
 
   auto& reg = OpRegistry::GetInstance();
   auto comm = b.EmitCommSetup(target, span);
 
-  auto one_i32 = std::make_shared<ConstInt>(1, DataType::INT32, span);
   auto root_expr = std::make_shared<ConstInt>(root_value, DataType::INT32, span);
 
-  // ---- Phase 2a: notify-all ----
-  b.EmitNotifyAll(signal, comm.nranks_idx, comm.my_rank, NotifyOp::kSet, one_i32, "", span);
-
-  // ---- Phase 2b: wait-all ----
-  b.EmitWaitAll(signal, comm.nranks_idx, comm.my_rank, one_i32, "", span);
+  // ---- Phase 2: barrier ----
+  const int64_t generation = b.EmitBarrier(signal, comm, "", span);
 
   // ---- Phase 3: pld.tile.get(root's data → local target slot) ----
   // Emit tile.create + pld.tile.get directly (the tensor-level get has no
@@ -1428,6 +1619,10 @@ ExprPtr LowerTensorBroadcastRule(const CallPtr& call, const std::vector<ExprPtr>
 
   b.Bind("get_ret", reg.Create("pld.tile.get", {target, root_expr, target, stage_tile}, {}, span), span);
 
+  // Self-clearing epilogue: exactly one credit per peer this call.
+  auto total_i32 = std::make_shared<ConstInt>(generation, DataType::INT32, span);
+  b.EmitEpilogueReset(signal, comm, total_i32, span);
+
   // In-place rebind: return target so the LHS Var holds the post-broadcast view.
   return target;
 }
@@ -1453,8 +1648,7 @@ ExprPtr LowerTensorBroadcastRule(const CallPtr& call, const std::vector<ExprPtr>
 //       Self-store (peer == my_rank) uses HCCL identity mapping (same
 //       trust model as pld.tile.get self-path).  pld.tile.put auto-chunks
 //       when SIZE exceeds the staging-tile capacity.
-//   2a. notify-all (Set 1)
-//   2b. wait-all  (Ge 1)
+//   2.  barrier (AtomicAdd 1 -> wait Ge generation)
 //   return target  (DistributedTensor rebind) — window IS the gathered result
 //
 // Compared to the original pull-based allgather, this push-based variant drops
@@ -1485,11 +1679,11 @@ ExprPtr LowerTensorAllGatherRule(const CallPtr& call, const std::vector<ExprPtr>
       << "pld.tensor.allgather target must be DistributedTensorType (deducer-rejected otherwise)";
   INTERNAL_CHECK_SPAN(target_type->shape_.size() == 2, span)
       << "pld.tensor.allgather target must be 2D [NR, SIZE]";
+  auto signal_type = As<DistributedTensorType>(signal->GetType());
+  ValidateMeshSignalShape(signal_type, "pld.tensor.allgather", span);
 
   auto& reg = OpRegistry::GetInstance();
   auto comm = b.EmitCommSetup(target, span);
-
-  auto one_i32 = std::make_shared<ConstInt>(1, DataType::INT32, span);
 
   // Per-chunk shape: [1, SIZE] where SIZE = target.shape[1].
   auto size_expr = target_type->shape_[1];
@@ -1538,11 +1732,12 @@ ExprPtr LowerTensorAllGatherRule(const CallPtr& call, const std::vector<ExprPtr>
       },
       span);
 
-  // ---- Phase 2a: notify-all ----
-  b.EmitNotifyAll(signal, comm.nranks_idx, comm.my_rank, NotifyOp::kSet, one_i32, "", span);
+  // ---- Phase 2: barrier ----
+  const int64_t generation = b.EmitBarrier(signal, comm, "", span);
 
-  // ---- Phase 2b: wait-all ----
-  b.EmitWaitAll(signal, comm.nranks_idx, comm.my_rank, one_i32, "", span);
+  // Self-clearing epilogue: exactly one credit per peer this call.
+  auto total_i32 = std::make_shared<ConstInt>(generation, DataType::INT32, span);
+  b.EmitEpilogueReset(signal, comm, total_i32, span);
 
   // Return target — the window IS the gathered result (window-as-result).
   return target;
@@ -1553,14 +1748,13 @@ ExprPtr LowerTensorAllGatherRule(const CallPtr& call, const std::vector<ExprPtr>
 //
 // Reduce-scatter: each rank holds NR chunks; rank r receives reduced chunk r.
 // Target shape [NR, SIZE].  5-phase decomposition matching allreduce:
-//   Phase 2a:  notify-all (Set 1)
-//   Phase 2b:  wait-all (Ge 1)
+//   Phase 2:   ready barrier (AtomicAdd 1 -> wait Ge generation)
 //   Phase 3:   acc = load(target, [my_rank, 0], [1, SIZE])
 //              for peer != my_rank:
 //                  recv = remote_load(target, peer, [my_rank, 0], [1, SIZE])
 //                  acc = add(acc, recv)
-//   Phase 3.5a: notify-all (AtomicAdd 1)  — WAR prevention
-//   Phase 3.5b: wait-all (Ge 2)
+//   Phase 3.5: post-reduce barrier (AtomicAdd 1 -> wait Ge generation + 1)
+//              — WAR prevention
 //   Phase 4:   tile.store(acc, [my_rank, 0], target)
 // Returns target (in-place rebind).  kSum only (first version).
 // ============================================================================
@@ -1577,6 +1771,8 @@ ExprPtr LowerTensorReduceScatterRule(const CallPtr& call, const std::vector<Expr
       << "pld.tensor.reduce_scatter target must be DistributedTensorType (deducer-rejected otherwise)";
   INTERNAL_CHECK_SPAN(target_type->shape_.size() == 2, span)
       << "pld.tensor.reduce_scatter target must be 2D [NR, SIZE]";
+  auto signal_type = As<DistributedTensorType>(signal->GetType());
+  ValidateMeshSignalShape(signal_type, "pld.tensor.reduce_scatter", span);
 
   auto op_value = GetRequiredKwarg<int>(call->kwargs_, "op", "pld.tensor.reduce_scatter");
   INTERNAL_CHECK_SPAN(op_value == static_cast<int>(ReduceOp::kSum), span)
@@ -1587,8 +1783,6 @@ ExprPtr LowerTensorReduceScatterRule(const CallPtr& call, const std::vector<Expr
 
   auto zero_idx = std::make_shared<ConstInt>(0, DataType::INDEX, span);
   auto one_idx = std::make_shared<ConstInt>(1, DataType::INDEX, span);
-  auto one_i32 = std::make_shared<ConstInt>(1, DataType::INT32, span);
-  auto two_i32 = std::make_shared<ConstInt>(2, DataType::INT32, span);
 
   // Per-chunk shape: [1, SIZE] where SIZE = target.shape[1].
   auto size_expr = target_type->shape_[1];
@@ -1599,11 +1793,8 @@ ExprPtr LowerTensorReduceScatterRule(const CallPtr& call, const std::vector<Expr
   auto my_data_offsets = std::make_shared<MakeTuple>(
       std::vector<ExprPtr>{comm.my_rank, std::make_shared<ConstInt>(0, DataType::INDEX, span)}, span);
 
-  // ---- Phase 2a: notify-all ----
-  b.EmitNotifyAll(signal, comm.nranks_idx, comm.my_rank, NotifyOp::kSet, one_i32, "", span);
-
-  // ---- Phase 2b: wait-all ----
-  b.EmitWaitAll(signal, comm.nranks_idx, comm.my_rank, one_i32, "", span);
+  // ---- Phase 2: ready barrier ----
+  b.EmitBarrier(signal, comm, "", span);
 
   // ---- Phase 3: accumulate peers' chunks at [my_rank, 0] ----
   auto acc_initial = b.Bind("acc_initial",
@@ -1628,14 +1819,17 @@ ExprPtr LowerTensorReduceScatterRule(const CallPtr& call, const std::vector<Expr
       },
       span);
 
-  // ---- Phase 3.5: post-reduce barrier (AtomicAdd 1 → wait Ge 2) ----
+  // ---- Phase 3.5: post-reduce barrier ----
   // Same WAR hazard as allreduce: fast rank could overwrite its row before
   // slow rank reads it.  See allreduce lowering for full rationale.
-  b.EmitNotifyAll(signal, comm.nranks_idx, comm.my_rank, NotifyOp::kAtomicAdd, one_i32, "2", span);
-  b.EmitWaitAll(signal, comm.nranks_idx, comm.my_rank, two_i32, "2", span);
+  const int64_t final_generation = b.EmitBarrier(signal, comm, "2", span);
 
   // ---- Phase 4: store reduced chunk back into target[my_rank, 0] ----
   b.Bind("store_ret", reg.Create("tile.store", {acc_final, my_data_offsets, target}, {}, span), span);
+
+  // Self-clearing epilogue: 2 credits per peer this call (ready + post-reduce).
+  auto total_i32 = std::make_shared<ConstInt>(final_generation, DataType::INT32, span);
+  b.EmitEpilogueReset(signal, comm, total_i32, span);
 
   return target;
 }
@@ -1643,9 +1837,10 @@ ExprPtr LowerTensorReduceScatterRule(const CallPtr& call, const std::vector<Expr
 // ============================================================================
 // ``pld.tensor.barrier`` lowering rule
 //
-// Cross-rank barrier: notify-all (Set 1) then wait-all (Ge 1).  Pure
-// synchronisation — no data movement.  Returns the signal expression so the
-// rebind idiom (``sig = pld.tensor.barrier(sig)``) matches allreduce.
+// Cross-rank barrier: notify-all (AtomicAdd 1) then wait-all (Ge generation).
+// Pure synchronisation — no data movement.  Returns the signal expression so
+// the rebind idiom (``sig = pld.tensor.barrier(sig)``) matches allreduce; the
+// barrier restarts at generation 1 on every call (self-clearing credit protocol).
 // ============================================================================
 
 ExprPtr LowerTensorBarrierRule(const CallPtr& call, const std::vector<ExprPtr>& args, LoweringBuilder& b) {
@@ -1655,16 +1850,16 @@ ExprPtr LowerTensorBarrierRule(const CallPtr& call, const std::vector<ExprPtr>& 
   auto signal_type = As<DistributedTensorType>(signal->GetType());
   INTERNAL_CHECK_SPAN(signal_type, span)
       << "pld.tensor.barrier signal must be DistributedTensorType (deducer-rejected otherwise)";
+  ValidateMeshSignalShape(signal_type, "pld.tensor.barrier", span);
 
   auto comm = b.EmitCommSetup(signal, span);
 
-  auto one_i32 = std::make_shared<ConstInt>(1, DataType::INT32, span);
+  // ---- AtomicAdd cell[my_rank, 0] on each peer, then wait cell[src, 0] >= gen ----
+  const int64_t generation = b.EmitBarrier(signal, comm, "", span);
 
-  // ---- Phase 1: notify-all (Set cell[my_rank, 0] on each peer to 1) ----
-  b.EmitNotifyAll(signal, comm.nranks_idx, comm.my_rank, NotifyOp::kSet, one_i32, "", span);
-
-  // ---- Phase 2: wait-all (cell[src, 0] >= 1) ----
-  b.EmitWaitAll(signal, comm.nranks_idx, comm.my_rank, one_i32, "", span);
+  // Self-clearing epilogue: exactly one credit per peer this call.
+  auto total_i32 = std::make_shared<ConstInt>(generation, DataType::INT32, span);
+  b.EmitEpilogueReset(signal, comm, total_i32, span);
 
   // Rebind: return the signal so the LHS Var retains the DistributedTensor view.
   return signal;
@@ -1683,8 +1878,8 @@ ExprPtr LowerTensorBarrierRule(const CallPtr& call, const std::vector<ExprPtr>& 
 //                    shape=[1, SIZE], atomic=None)
 //
 //   Phase 2 (barrier):
-//       notify-all (Set 1)
-//       wait-all  (Ge 1)
+//       notify-all (AtomicAdd 1)
+//       wait-all   (Ge generation)
 //
 //   Result: target (window-as-result).  After the barrier, target[src, :]
 //           holds the chunk received from rank src.
@@ -1717,11 +1912,11 @@ ExprPtr LowerTensorAllToAllRule(const CallPtr& call, const std::vector<ExprPtr>&
       << "pld.tensor.all_to_all target must be DistributedTensorType (deducer-rejected otherwise)";
   INTERNAL_CHECK_SPAN(target_type->shape_.size() == 2, span)
       << "pld.tensor.all_to_all target must be 2D [NR, SIZE]";
+  auto signal_type = As<DistributedTensorType>(signal->GetType());
+  ValidateMeshSignalShape(signal_type, "pld.tensor.all_to_all", span);
 
   auto& reg = OpRegistry::GetInstance();
   auto comm = b.EmitCommSetup(target, span);
-
-  auto one_i32 = std::make_shared<ConstInt>(1, DataType::INT32, span);
 
   // Per-chunk shape: [1, SIZE] where SIZE = target.shape[1].
   auto size_expr = target_type->shape_[1];
@@ -1769,11 +1964,12 @@ ExprPtr LowerTensorAllToAllRule(const CallPtr& call, const std::vector<ExprPtr>&
       },
       span);
 
-  // ---- Phase 2a: notify-all ----
-  b.EmitNotifyAll(signal, comm.nranks_idx, comm.my_rank, NotifyOp::kSet, one_i32, "", span);
+  // ---- Phase 2: barrier ----
+  const int64_t generation = b.EmitBarrier(signal, comm, "", span);
 
-  // ---- Phase 2b: wait-all ----
-  b.EmitWaitAll(signal, comm.nranks_idx, comm.my_rank, one_i32, "", span);
+  // Self-clearing epilogue: exactly one credit per peer this call.
+  auto total_i32 = std::make_shared<ConstInt>(generation, DataType::INT32, span);
+  b.EmitEpilogueReset(signal, comm, total_i32, span);
 
   // Window-as-result: target[src, :] now holds the chunk from rank src.
   // No read-back phase or post-barrier needed — the barrier guarantees all
@@ -1811,8 +2007,9 @@ ExprPtr LowerTensorAllToAllRule(const CallPtr& call, const std::vector<ExprPtr>&
 //       // partition-view dims for pto.comm.tput).  A [1, SIZE] staging tile
 //       // feeds the TPUT engine, which 2-D-slides the transfer through it.
 //
-//   Phase 2a: notify-all (Set 1)
-//   Phase 2b: wait-all  (Ge 1)
+//   Phase 2: self-clearing credit barrier
+//     EmitBarrier() — AtomicAdd(+1) on every peer cell, then Wait(Ge 1)
+//     EmitEpilogueReset(-1) — subtracts the credit back to zero after the call
 //
 // MAX_RECV = target.shape[0] / NR (both must be compile-time constants) is the
 // per-peer *capacity*, not the transfer size: it fixes the flat row-index
@@ -1877,8 +2074,7 @@ ExprPtr LowerTensorAllToAllVRule(const CallPtr& call, const std::vector<ExprPtr>
   INTERNAL_CHECK_SPAN(total_rows_c, span) << "target dim 0 must be a compile-time constant";
   auto signal_type = As<DistributedTensorType>(signal->GetType());
   INTERNAL_CHECK_SPAN(signal_type, span) << "signal must be DistributedTensorType";
-  INTERNAL_CHECK_SPAN(signal_type->shape_.size() == 2, span)
-      << "pld.tensor.all_to_all_v signal must be 2D [NR, 1] (deducer-rejected otherwise)";
+  ValidateMeshSignalShape(signal_type, "pld.tensor.all_to_all_v", span);
   auto nr_c = As<ConstInt>(signal_type->shape_[0]);
   INTERNAL_CHECK_SPAN(nr_c, span) << "signal dim 0 (NR) must be a compile-time constant";
   int64_t max_recv_value = total_rows_c->value_ / nr_c->value_;
@@ -1959,11 +2155,12 @@ ExprPtr LowerTensorAllToAllVRule(const CallPtr& call, const std::vector<ExprPtr>
       },
       span);
 
-  // ---- Phase 2a: notify-all ----
-  b.EmitNotifyAll(signal, comm.nranks_idx, comm.my_rank, NotifyOp::kSet, one_i32, "", span);
+  // ---- Phase 2: self-clearing credit barrier ----
+  const int64_t generation = b.EmitBarrier(signal, comm, "", span);
 
-  // ---- Phase 2b: wait-all ----
-  b.EmitWaitAll(signal, comm.nranks_idx, comm.my_rank, one_i32, "", span);
+  // Self-clearing epilogue: exactly one credit per peer this call.
+  auto total_i32 = std::make_shared<ConstInt>(generation, DataType::INT32, span);
+  b.EmitEpilogueReset(signal, comm, total_i32, span);
 
   // Window-as-result: target[src*MAX_RECV+r, :] now holds the chunk from
   // rank src, offset r (full MAX_RECV capacity). The caller reads back from
@@ -1979,6 +2176,13 @@ ExprPtr LowerTensorAllToAllVRule(const CallPtr& call, const std::vector<ExprPtr>
 // AssignStmt (or a composite-op Call embedded directly in a ReturnStmt) only
 // when the callee name appears here. Adding a new composite op = add a rule
 // function above + one row in ``kRules``; the mutator below needs no change.
+// A new ``pld.tensor.*`` collective must additionally be listed in
+// ``LowerCompositeOpsMutator::IsTensorCollective`` so it inherits the HOST
+// deferral, must barrier through ``LoweringBuilder::EmitBarrier`` so it shares
+// the self-clearing credit-barrier protocol instead of rolling a one-off
+// notify/wait pair, and must call ``EmitEpilogueReset`` exactly once with the
+// total credit count it issued so the signal returns to all-zero after the
+// call.
 //
 // Today the rules are ``tile.sin`` / ``tile.cos`` and ``pld.tensor.*``
 // distributed collectives. Host-level allreduce is skipped here and lowered
@@ -2032,7 +2236,6 @@ class LowerCompositeOpsMutator : public IRMutator {
     if (!rule) {
       return IRMutator::VisitStmt_(op);
     }
-    CheckAllReduceLoopUse(call);
 
     // Apply var_remap_ (if any) to operand expressions before handing them
     // to the rule.
@@ -2058,7 +2261,6 @@ class LowerCompositeOpsMutator : public IRMutator {
     if (!rule) {
       return IRMutator::VisitStmt_(op);
     }
-    CheckAllReduceLoopUse(call);
 
     std::vector<ExprPtr> visited_args = VisitArgs(call->args_, op->span_);
 
@@ -2091,7 +2293,6 @@ class LowerCompositeOpsMutator : public IRMutator {
       auto call = As<Call>(value);
       CompositeLoweringFn rule = call ? LookupRule(call) : nullptr;
       if (rule) {
-        CheckAllReduceLoopUse(call);
         std::vector<ExprPtr> visited_args = VisitArgs(call->args_, op->span_);
         const std::string base = "ret" + std::to_string(i);
         LoweringBuilder builder(base, temp_counter_);
@@ -2123,31 +2324,23 @@ class LowerCompositeOpsMutator : public IRMutator {
     return std::make_shared<SeqStmts>(std::move(prelude), op->span_);
   }
 
-  StmtPtr VisitStmt_(const ForStmtPtr& op) override {
-    ++repeating_scope_depth_;
-    auto result = IRMutator::VisitStmt_(op);
-    --repeating_scope_depth_;
-    return result;
-  }
-
-  StmtPtr VisitStmt_(const WhileStmtPtr& op) override {
-    ++repeating_scope_depth_;
-    auto result = IRMutator::VisitStmt_(op);
-    --repeating_scope_depth_;
-    return result;
-  }
-
  private:
-  [[nodiscard]] static bool ShouldSkipHostCollective(const CallPtr& call) {
+  /// True for every ``pld.tensor.*`` cross-rank collective. Add new collectives
+  /// here so they inherit the HOST-deferral skip.
+  [[nodiscard]] static bool IsTensorCollective(const CallPtr& call) {
     if (!call || !call->op_) return false;
-    // HOST vs InCore is a function-context property, decided authoritatively by
-    // the outer skip_host_collectives_ flag (set for HOST orchestration
-    // functions), not by arg count or arg[0] type.  Every collective is skipped
-    // uniformly here so the flag alone governs which functions defer lowering.
     return IsOp(call, "pld.tensor.allgather") || IsOp(call, "pld.tensor.allreduce") ||
            IsOp(call, "pld.tensor.barrier") || IsOp(call, "pld.tensor.broadcast") ||
            IsOp(call, "pld.tensor.reduce_scatter") || IsOp(call, "pld.tensor.all_to_all") ||
            IsOp(call, "pld.tensor.all_to_all_v");
+  }
+
+  [[nodiscard]] static bool ShouldSkipHostCollective(const CallPtr& call) {
+    // HOST vs InCore is a function-context property, decided authoritatively by
+    // the outer skip_host_collectives_ flag (set for HOST orchestration
+    // functions), not by arg count or arg[0] type.  Every collective is skipped
+    // uniformly here so the flag alone governs which functions defer lowering.
+    return IsTensorCollective(call);
   }
 
   // Collectives that only have an InCore lowering — i.e. no matching entry in
@@ -2171,18 +2364,6 @@ class LowerCompositeOpsMutator : public IRMutator {
     return call && call->op_ ? LookupCompositeRule(call->op_->name_) : nullptr;
   }
 
-  // allreduce and all_to_all_v share the single-use Set(1)/wait>=1 signal
-  // protocol: a second invocation (e.g. inside for/while) can observe a stale
-  // completion value and race with in-flight TPUTs.
-  void CheckAllReduceLoopUse(const CallPtr& call) const {
-    if (!call || !call->op_) return;
-    if (!IsOp(call, "pld.tensor.allreduce") && !IsOp(call, "pld.tensor.all_to_all_v")) return;
-    CHECK_SPAN(repeating_scope_depth_ == 0, call->span_)
-        << call->op_->name_
-        << " is not supported inside a for/while loop. "
-           "The signal protocol is single-use and cannot reuse a signal across dynamic invocations.";
-  }
-
   std::vector<ExprPtr> VisitArgs(const std::vector<ExprPtr>& args, const Span& span) {
     std::vector<ExprPtr> out;
     out.reserve(args.size());
@@ -2195,7 +2376,6 @@ class LowerCompositeOpsMutator : public IRMutator {
   }
 
   std::size_t temp_counter_ = 0;
-  int repeating_scope_depth_ = 0;
   bool skip_host_collectives_{false};
 };
 

--- a/src/ir/transforms/synthesize_allreduce_signals_pass.cpp
+++ b/src/ir/transforms/synthesize_allreduce_signals_pass.cpp
@@ -168,28 +168,11 @@ class AllReduceSignalSynthesizer : public IRMutator {
     return SeqStmts::Flatten(std::move(prelude), op->span_);
   }
 
-  StmtPtr VisitStmt_(const ForStmtPtr& op) override {
-    ++repeating_scope_depth_;
-    auto result = IRMutator::VisitStmt_(op);
-    --repeating_scope_depth_;
-    return result;
-  }
-
-  StmtPtr VisitStmt_(const WhileStmtPtr& op) override {
-    ++repeating_scope_depth_;
-    auto result = IRMutator::VisitStmt_(op);
-    --repeating_scope_depth_;
-    return result;
-  }
-
  private:
   void CheckAllReduceCall(const CallPtr& call) const {
     CHECK_SPAN(call->args_.size() == 1 || call->args_.size() == 2, call->span_)
         << "pld.tensor.allreduce expects target[, signal], got " << call->args_.size()
         << " positional arguments";
-    CHECK_SPAN(repeating_scope_depth_ == 0, call->span_)
-        << "pld.tensor.allreduce is not supported inside a for/while loop. "
-           "The signal protocol is single-use and cannot reuse a signal across dynamic invocations.";
   }
 
   struct SignalNames {
@@ -258,7 +241,6 @@ class AllReduceSignalSynthesizer : public IRMutator {
 
   std::set<std::string>* used_names_;
   int64_t* next_id_;
-  int repeating_scope_depth_ = 0;
   bool modified_ = false;
 };
 

--- a/src/ir/transforms/synthesize_allreduce_signals_pass.cpp
+++ b/src/ir/transforms/synthesize_allreduce_signals_pass.cpp
@@ -168,11 +168,28 @@ class AllReduceSignalSynthesizer : public IRMutator {
     return SeqStmts::Flatten(std::move(prelude), op->span_);
   }
 
+  StmtPtr VisitStmt_(const ForStmtPtr& op) override {
+    ++repeating_scope_depth_;
+    auto result = IRMutator::VisitStmt_(op);
+    --repeating_scope_depth_;
+    return result;
+  }
+
+  StmtPtr VisitStmt_(const WhileStmtPtr& op) override {
+    ++repeating_scope_depth_;
+    auto result = IRMutator::VisitStmt_(op);
+    --repeating_scope_depth_;
+    return result;
+  }
+
  private:
   void CheckAllReduceCall(const CallPtr& call) const {
     CHECK_SPAN(call->args_.size() == 1 || call->args_.size() == 2, call->span_)
         << "pld.tensor.allreduce expects target[, signal], got " << call->args_.size()
         << " positional arguments";
+    CHECK_SPAN(repeating_scope_depth_ == 0, call->span_)
+        << "pld.tensor.allreduce is not supported inside a for/while loop. "
+           "The signal protocol is single-use and cannot reuse a signal across dynamic invocations.";
   }
 
   struct SignalNames {
@@ -241,6 +258,7 @@ class AllReduceSignalSynthesizer : public IRMutator {
 
   std::set<std::string>* used_names_;
   int64_t* next_id_;
+  int repeating_scope_depth_ = 0;
   bool modified_ = false;
 };
 

--- a/tests/st/distributed/collectives/test_l3_tensor_collective_signal_reuse.py
+++ b/tests/st/distributed/collectives/test_l3_tensor_collective_signal_reuse.py
@@ -1,0 +1,351 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""L3 distributed st: back-to-back composite collectives sharing one signal.
+
+Regression coverage for the reusable barrier-signal protocol (issue #2156).
+Each program invokes the same collective **twice on the same signal buffer**
+with different inputs and validates that the second result is complete and
+reflects only the second invocation's inputs.
+
+Under the old ``Set(1)`` + ``Wait(>= 1)`` protocol every signal cell stayed at
+``1`` after the first call, so the second call's waits were satisfied from stale
+state before peers had pushed the second invocation's data — producing mixed or
+truncated output. The self-clearing credit barrier (``AtomicAdd(+1)`` →
+``Wait(>= g)`` plus a per-call epilogue ``AtomicAdd(-N)``) makes each call a
+stateless cycle, so a back-to-back call on the same signal restarts at
+generation 1 with no stale state.
+
+ST coverage: **P=2** (default CI / 2-device hosts) and **P=4** (any four
+devices). All programs use the same N-rank body.
+"""
+
+import sys
+
+import pypto.language as pl
+import pypto.language.distributed as pld
+import pytest
+import torch
+from pypto import ir
+from pypto.ir.distributed_compiled_program import DistributedConfig
+
+SIZE = 64
+
+# Offset separating the two invocations' inputs. Large enough that any element
+# leaking from the first call is far outside the second call's value range.
+SECOND_CALL_OFFSET = 100000.0
+
+
+# ---------------------------------------------------------------------------
+# Golden helpers
+# ---------------------------------------------------------------------------
+
+
+def _all_to_all_inputs(n_ranks: int, offset: float) -> torch.Tensor:
+    """``input[r, d, j] = offset + r*1000 + d*100 + j`` — chunk for dest ``d``."""
+    r = torch.arange(n_ranks, dtype=torch.float32).view(-1, 1, 1)
+    d = torch.arange(n_ranks, dtype=torch.float32).view(1, -1, 1)
+    j = torch.arange(SIZE, dtype=torch.float32).view(1, 1, -1)
+    return offset + r * 1000 + d * 100 + j
+
+
+def _expected_all_to_all(n_ranks: int, offset: float) -> torch.Tensor:
+    """``output[rank, src, j] = offset + src*1000 + rank*100 + j``."""
+    src = torch.arange(n_ranks, dtype=torch.float32).view(1, -1, 1)
+    rank = torch.arange(n_ranks, dtype=torch.float32).view(-1, 1, 1)
+    j = torch.arange(SIZE, dtype=torch.float32).view(1, 1, -1)
+    return offset + src * 1000 + rank * 100 + j
+
+
+def _allgather_inputs(n_ranks: int, offset: float) -> torch.Tensor:
+    """``input[r, 0, j] = offset + r*100 + j`` — this rank's single chunk."""
+    r = torch.arange(n_ranks, dtype=torch.float32).view(-1, 1, 1)
+    j = torch.arange(SIZE, dtype=torch.float32).view(1, 1, -1)
+    return offset + r * 100 + j
+
+
+def _expected_allgather(n_ranks: int, offset: float) -> torch.Tensor:
+    """Every rank ends with the same gathered ``[NR, SIZE]`` block."""
+    gathered = _allgather_inputs(n_ranks, offset).reshape(n_ranks, SIZE)
+    return gathered.unsqueeze(0).expand(n_ranks, n_ranks, SIZE).contiguous()
+
+
+def _reduce_scatter_inputs(n_ranks: int, offset: float) -> torch.Tensor:
+    """``input[r, 0, :]`` holds ``n_ranks`` contiguous chunks of ``SIZE``."""
+    rows = [
+        offset + torch.arange(r * 100.0, r * 100.0 + n_ranks * SIZE, dtype=torch.float32)
+        for r in range(n_ranks)
+    ]
+    return torch.stack(rows).reshape(n_ranks, 1, n_ranks * SIZE)
+
+
+def _expected_reduce_scatter(inputs: torch.Tensor) -> torch.Tensor:
+    """Rank ``r`` receives the element-wise sum of chunk ``r`` across ranks."""
+    n_ranks = inputs.shape[0]
+    chunks = [inputs[:, 0, r * SIZE : (r + 1) * SIZE].sum(dim=0) for r in range(n_ranks)]
+    return torch.stack(chunks).reshape(n_ranks, 1, SIZE)
+
+
+# ---------------------------------------------------------------------------
+# Programs
+# ---------------------------------------------------------------------------
+
+
+def _build_all_to_all_twice(n_ranks: int):
+    """All-to-all twice on one signal, bracketed by bare barriers.
+
+    The surrounding ``pld.tensor.barrier`` calls chain onto the same signal, so
+    the signal also has to return to all-zero after each call when reset by a
+    *different* collective in the family.
+    """
+    nr = n_ranks
+
+    @pl.program
+    class AllToAllSignalReuse:
+        @pl.function(type=pl.FunctionType.InCore)
+        def exchange_twice(
+            self,
+            first: pl.Tensor[[nr, SIZE], pl.FP32],
+            second: pl.Tensor[[nr, SIZE], pl.FP32],
+            out: pl.Out[pl.Tensor[[nr, SIZE], pl.FP32]],
+            data: pl.InOut[pld.DistributedTensor[[nr, SIZE], pl.FP32]],
+            signal: pl.InOut[pld.DistributedTensor[[nr, 1], pl.INT32]],
+        ) -> pl.Tensor[[nr, SIZE], pl.FP32]:
+            signal = pld.tensor.barrier(signal)
+            data = pld.tensor.all_to_all(first, data, signal)
+            data = pld.tensor.all_to_all(second, data, signal)
+            signal = pld.tensor.barrier(signal)
+            for src in pl.range(nr):
+                chunk = pl.load(data, [src, 0], [1, SIZE])
+                pl.store(chunk, [src, 0], out)
+            return out
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def chip_orch(
+            self,
+            first: pl.Tensor[[nr, SIZE], pl.FP32],
+            second: pl.Tensor[[nr, SIZE], pl.FP32],
+            out: pl.Out[pl.Tensor[[nr, SIZE], pl.FP32]],
+            data: pl.InOut[pld.DistributedTensor[[nr, SIZE], pl.FP32]],
+            signal: pl.InOut[pld.DistributedTensor[[nr, 1], pl.INT32]],
+        ) -> pl.Tensor[[nr, SIZE], pl.FP32]:
+            return self.exchange_twice(first, second, out, data, signal)
+
+        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+        def host_orch(
+            self,
+            firsts: pl.Tensor[[nr, nr, SIZE], pl.FP32],
+            seconds: pl.Tensor[[nr, nr, SIZE], pl.FP32],
+            outputs: pl.Out[pl.Tensor[[nr, nr, SIZE], pl.FP32]],
+        ) -> pl.Tensor[[nr, nr, SIZE], pl.FP32]:
+            data_buf = pld.alloc_window_buffer(nr * SIZE * pl.FP32.get_byte())
+            signal_buf = pld.alloc_window_buffer(nr * pl.INT32.get_byte())
+
+            for r in pl.range(pld.world_size()):
+                data = pld.window(data_buf, [nr, SIZE], dtype=pl.FP32)
+                sig = pld.window(signal_buf, [nr, 1], dtype=pl.INT32)
+                self.chip_orch(firsts[r], seconds[r], outputs[r], data, sig, device=r)
+            return outputs
+
+    return AllToAllSignalReuse
+
+
+def _build_allgather_twice(n_ranks: int):
+    """All-gather twice on one signal, second call with different local data."""
+    nr = n_ranks
+
+    @pl.program
+    class AllGatherSignalReuse:
+        @pl.function(type=pl.FunctionType.InCore)
+        def gather_twice(
+            self,
+            first: pl.Tensor[[1, SIZE], pl.FP32],
+            second: pl.Tensor[[1, SIZE], pl.FP32],
+            out: pl.Out[pl.Tensor[[nr, SIZE], pl.FP32]],
+            data: pl.InOut[pld.DistributedTensor[[nr, SIZE], pl.FP32]],
+            signal: pl.InOut[pld.DistributedTensor[[nr, 1], pl.INT32]],
+        ) -> pl.Tensor[[nr, SIZE], pl.FP32]:
+            data = pld.tensor.allgather(first, data, signal)
+            data = pld.tensor.allgather(second, data, signal)
+            for src in pl.range(nr):
+                chunk = pl.load(data, [src, 0], [1, SIZE])
+                pl.store(chunk, [src, 0], out)
+            return out
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def chip_orch(
+            self,
+            first: pl.Tensor[[1, SIZE], pl.FP32],
+            second: pl.Tensor[[1, SIZE], pl.FP32],
+            out: pl.Out[pl.Tensor[[nr, SIZE], pl.FP32]],
+            data: pl.InOut[pld.DistributedTensor[[nr, SIZE], pl.FP32]],
+            signal: pl.InOut[pld.DistributedTensor[[nr, 1], pl.INT32]],
+        ) -> pl.Tensor[[nr, SIZE], pl.FP32]:
+            return self.gather_twice(first, second, out, data, signal)
+
+        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+        def host_orch(
+            self,
+            firsts: pl.Tensor[[nr, 1, SIZE], pl.FP32],
+            seconds: pl.Tensor[[nr, 1, SIZE], pl.FP32],
+            outputs: pl.Out[pl.Tensor[[nr, nr, SIZE], pl.FP32]],
+        ) -> pl.Tensor[[nr, nr, SIZE], pl.FP32]:
+            data_buf = pld.alloc_window_buffer(nr * SIZE * pl.FP32.get_byte())
+            signal_buf = pld.alloc_window_buffer(nr * pl.INT32.get_byte())
+
+            for r in pl.range(pld.world_size()):
+                data = pld.window(data_buf, [nr, SIZE], dtype=pl.FP32)
+                sig = pld.window(signal_buf, [nr, 1], dtype=pl.INT32)
+                self.chip_orch(firsts[r], seconds[r], outputs[r], data, sig, device=r)
+            return outputs
+
+    return AllGatherSignalReuse
+
+
+def _build_reduce_scatter_twice(n_ranks: int):
+    """Reduce-scatter twice on one signal, re-staging between the two calls."""
+    nr = n_ranks
+
+    @pl.program
+    class ReduceScatterSignalReuse:
+        @pl.function(type=pl.FunctionType.InCore)
+        def reduce_twice(
+            self,
+            first: pl.Tensor[[1, nr * SIZE], pl.FP32],
+            second: pl.Tensor[[1, nr * SIZE], pl.FP32],
+            out: pl.Out[pl.Tensor[[1, SIZE], pl.FP32]],
+            data: pl.InOut[pld.DistributedTensor[[nr, SIZE], pl.FP32]],
+            signal: pl.InOut[pld.DistributedTensor[[nr, 1], pl.INT32]],
+            my_rank: pl.Scalar[pl.INT32],
+        ) -> pl.Tensor[[1, SIZE], pl.FP32]:
+            for j in pl.range(nr):
+                chunk = pl.load(first, [0, j * SIZE], [1, SIZE])
+                pl.store(chunk, [j, 0], data)
+            data = pld.tensor.reduce_scatter(data, signal, op=pld.ReduceOp.Sum)
+
+            # Re-stage the second invocation's chunks over the first result and
+            # reduce again on the same signal.
+            for j in pl.range(nr):
+                chunk = pl.load(second, [0, j * SIZE], [1, SIZE])
+                pl.store(chunk, [j, 0], data)
+            data = pld.tensor.reduce_scatter(data, signal, op=pld.ReduceOp.Sum)
+
+            acc = pl.load(data, [my_rank, 0], [1, SIZE])
+            return pl.store(acc, [0, 0], out)
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def chip_orch(
+            self,
+            first: pl.Tensor[[1, nr * SIZE], pl.FP32],
+            second: pl.Tensor[[1, nr * SIZE], pl.FP32],
+            out: pl.Out[pl.Tensor[[1, SIZE], pl.FP32]],
+            data: pl.InOut[pld.DistributedTensor[[nr, SIZE], pl.FP32]],
+            signal: pl.InOut[pld.DistributedTensor[[nr, 1], pl.INT32]],
+            my_rank: pl.Scalar[pl.INT32],
+        ) -> pl.Tensor[[1, SIZE], pl.FP32]:
+            return self.reduce_twice(first, second, out, data, signal, my_rank)
+
+        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+        def host_orch(
+            self,
+            firsts: pl.Tensor[[nr, 1, nr * SIZE], pl.FP32],
+            seconds: pl.Tensor[[nr, 1, nr * SIZE], pl.FP32],
+            outputs: pl.Out[pl.Tensor[[nr, 1, SIZE], pl.FP32]],
+        ) -> pl.Tensor[[nr, 1, SIZE], pl.FP32]:
+            data_buf = pld.alloc_window_buffer(nr * SIZE * pl.FP32.get_byte())
+            signal_buf = pld.alloc_window_buffer(nr * pl.INT32.get_byte())
+
+            for r in pl.range(pld.world_size()):
+                data = pld.window(data_buf, [nr, SIZE], dtype=pl.FP32)
+                sig = pld.window(signal_buf, [nr, 1], dtype=pl.INT32)
+                self.chip_orch(firsts[r], seconds[r], outputs[r], data, sig, r, device=r)
+            return outputs
+
+    return ReduceScatterSignalReuse
+
+
+def _compile(program, test_config, device_ids, n_ranks):
+    return ir.compile(
+        program,
+        platform=test_config.platform,
+        distributed_config=DistributedConfig(
+            device_ids=device_ids[:n_ranks],
+            num_sub_workers=0,
+        ),
+    )
+
+
+class TestL3TensorCollectiveSignalReuse:
+    """Back-to-back collectives on a shared signal buffer stay correct."""
+
+    @pytest.mark.parametrize("n_ranks", [2, 4])
+    def test_all_to_all_back_to_back(self, test_config, device_ids, n_ranks):
+        """The second all-to-all must reflect only the second inputs.
+
+        The program also brackets the pair with ``pld.tensor.barrier`` on the
+        same signal, so the signal is reset by two different collectives'
+        epilogues.
+        """
+        if len(device_ids) < n_ranks:
+            pytest.skip(f"all-to-all P={n_ranks} needs {n_ranks} devices, got {device_ids}")
+
+        compiled = _compile(_build_all_to_all_twice(n_ranks), test_config, device_ids, n_ranks)
+        firsts = _all_to_all_inputs(n_ranks, 0.0)
+        seconds = _all_to_all_inputs(n_ranks, SECOND_CALL_OFFSET)
+        outputs = torch.zeros((n_ranks, n_ranks, SIZE), dtype=torch.float32)
+
+        compiled(firsts, seconds, outputs)
+
+        expected = _expected_all_to_all(n_ranks, SECOND_CALL_OFFSET)
+        assert torch.allclose(outputs, expected), (
+            f"back-to-back all-to-all P={n_ranks} leaked first-call data: "
+            f"max diff = {(outputs - expected).abs().max().item()}"
+        )
+
+    @pytest.mark.parametrize("n_ranks", [2, 4])
+    def test_allgather_back_to_back(self, test_config, device_ids, n_ranks):
+        """The second all-gather must reflect only the second local chunks."""
+        if len(device_ids) < n_ranks:
+            pytest.skip(f"allgather P={n_ranks} needs {n_ranks} devices, got {device_ids}")
+
+        compiled = _compile(_build_allgather_twice(n_ranks), test_config, device_ids, n_ranks)
+        firsts = _allgather_inputs(n_ranks, 0.0)
+        seconds = _allgather_inputs(n_ranks, SECOND_CALL_OFFSET)
+        outputs = torch.zeros((n_ranks, n_ranks, SIZE), dtype=torch.float32)
+
+        compiled(firsts, seconds, outputs)
+
+        expected = _expected_allgather(n_ranks, SECOND_CALL_OFFSET)
+        assert torch.allclose(outputs, expected), (
+            f"back-to-back allgather P={n_ranks} leaked first-call data: "
+            f"max diff = {(outputs - expected).abs().max().item()}"
+        )
+
+    @pytest.mark.parametrize("n_ranks", [2, 4])
+    def test_reduce_scatter_back_to_back(self, test_config, device_ids, n_ranks):
+        """The second reduce-scatter must reduce only the re-staged chunks."""
+        if len(device_ids) < n_ranks:
+            pytest.skip(f"reduce-scatter P={n_ranks} needs {n_ranks} devices, got {device_ids}")
+
+        compiled = _compile(_build_reduce_scatter_twice(n_ranks), test_config, device_ids, n_ranks)
+        firsts = _reduce_scatter_inputs(n_ranks, 0.0)
+        seconds = _reduce_scatter_inputs(n_ranks, SECOND_CALL_OFFSET)
+        outputs = torch.zeros((n_ranks, 1, SIZE), dtype=torch.float32)
+
+        compiled(firsts, seconds, outputs)
+
+        expected = _expected_reduce_scatter(seconds)
+        assert torch.allclose(outputs, expected), (
+            f"back-to-back reduce-scatter P={n_ranks} mixed in first-call data: "
+            f"max diff = {(outputs - expected).abs().max().item()}"
+        )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", *sys.argv[1:]])

--- a/tests/st/distributed/test_l3_self_notify_credit_reset.py
+++ b/tests/st/distributed/test_l3_self_notify_credit_reset.py
@@ -1,0 +1,191 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""L3 distributed st: self-clearing credit-barrier ISA primitives.
+
+Validates, with no compiler involvement, the two riskiest assumptions behind
+the self-clearing credit-barrier protocol proposed for issue #2156 (see
+``pld.tensor.*`` collectives' ``EmitEpilogueReset``):
+
+1. **Negative ``AtomicAdd`` is legal.** ``pld.system.notify`` accepts a
+   negative ``value`` and it is applied as a genuine signed atomic add.
+2. **Self-addressed notify (``peer == my_rank``) lands on the same cell as a
+   remote notify.** If it resolved to a different address, a rank's own
+   epilogue reset would not affect the value its peers read, and this test's
+   golden would read back the un-reset credit total instead of 0.
+
+Each rank:
+
+* notifies its peer's signal cell with ``AtomicAdd(+1)``, ``REPS`` times —
+  mirroring one ``EmitBarrier`` notify per barrier a composite collective
+  issues;
+* waits for its own cell to reach ``>= REPS`` (an ordinary barrier, so the
+  self-notify below is provably not racing the peer's writes);
+* self-notifies its own cell with a single ``AtomicAdd(-REPS)`` — exactly the
+  shape of ``LoweringBuilder::EmitEpilogueReset``'s reset notify;
+* reads its own cell back.
+
+Golden: ``outputs[r] == 0`` for every rank — the peer's ``REPS`` credits and
+the rank's own ``-REPS`` self-notify must land on the identical memory cell
+and cancel exactly.
+
+Runs on 2 devices via ``DistributedConfig(device_ids=device_ids[:2], ...)``.
+Pytest skips only when fewer than 2 devices are available.
+"""
+
+import sys
+
+import pypto.language as pl
+import pypto.language.distributed as pld
+import pytest
+import torch
+from pypto import ir
+from pypto.ir.distributed_compiled_program import DistributedConfig
+
+_REPS = 4
+
+
+def _build_self_notify_credit_reset_program():
+    """Build the self-notify credit-reset program at call time.
+
+    Deferred construction lets this file collect even if the embedded body
+    is rejected by the parser.
+    """
+
+    @pl.program
+    class SelfNotifyCreditReset:
+        @pl.function(type=pl.FunctionType.InCore)
+        def credit_and_reset(
+            self,
+            out: pl.Out[pl.Tensor[[1, 1], pl.INT32]],
+            signal: pl.InOut[pld.DistributedTensor[[1, 1], pl.INT32]],
+            peer: pl.Scalar[pl.INT32],
+            my_rank: pl.Scalar[pl.INT32],
+        ) -> pl.Tensor[[1, 1], pl.INT32]:
+            # Phase 1: notify the peer REPS times — one AtomicAdd(+1) per
+            # notify, mirroring one barrier's worth of credit per iteration.
+            for _ in pl.unroll(_REPS):
+                pld.system.notify(
+                    target=signal,
+                    peer=peer,
+                    offsets=[0, 0],
+                    value=1,
+                    op=pld.NotifyOp.AtomicAdd,
+                )
+
+            # Phase 2: ordinary barrier — wait until our own cell has
+            # accumulated all REPS credits from the rank whose peer is us.
+            # This rules out the self-notify below racing the peer's writes.
+            pld.system.wait(
+                signal=signal,
+                offsets=[0, 0],
+                expected=_REPS,
+                cmp=pld.WaitCmp.Ge,
+            )
+
+            # Phase 3: self-notify — subtract REPS from our OWN cell in one
+            # AtomicAdd, exactly the shape of EmitEpilogueReset's reset
+            # notify. peer=my_rank means this targets the local window, not
+            # a remote one.
+            # The value must have explicit INT32 dtype to match the signal
+            # element type (pto.comm.tnotify verifies this at ptoas level).
+            neg_reps: pl.Scalar[pl.INT32] = pl.const(-4, pl.INT32)  # -_REPS typed
+            pld.system.notify(
+                target=signal,
+                peer=my_rank,
+                offsets=[0, 0],
+                value=neg_reps,
+                op=pld.NotifyOp.AtomicAdd,
+            )
+
+            # Phase 4: read our own cell back. If the self-notify landed on a
+            # different address than the peer's remote adds (the one risk
+            # this ST exists to rule out), this reads REPS instead of 0.
+            val: pl.Scalar[pl.INT32] = pl.read(signal, [0, 0])
+            pl.write(out, [0, 0], val)
+            return out
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def chip_orch(
+            self,
+            out: pl.Out[pl.Tensor[[1, 1], pl.INT32]],
+            signal: pl.InOut[pld.DistributedTensor[[1, 1], pl.INT32]],
+            peer: pl.Scalar[pl.INT32],
+            my_rank: pl.Scalar[pl.INT32],
+        ) -> pl.Tensor[[1, 1], pl.INT32]:
+            return self.credit_and_reset(out, signal, peer, my_rank)
+
+        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+        def host_orch(
+            self,
+            outputs: pl.Out[pl.Tensor[[2, 1, 1], pl.INT32]],
+        ) -> pl.Tensor[[2, 1, 1], pl.INT32]:
+            signal_buf = pld.alloc_window_buffer(pl.INT32.get_byte())  # 1x1 x INT32
+
+            for r in pl.range(pld.world_size()):
+                signal = pld.window(signal_buf, [1, 1], dtype=pl.INT32)
+                self.chip_orch(outputs[r], signal, (r + 1) % pld.world_size(), r, device=r)
+            return outputs
+
+    return SelfNotifyCreditReset
+
+
+class TestL3SelfNotifyCreditReset:
+    """L3 distributed runtime: self-clearing credit-barrier ISA primitives."""
+
+    @staticmethod
+    def _compile(test_config, device_ids):
+        if len(device_ids) < 2:
+            pytest.skip(f"self-notify credit-reset needs 2 devices, got {device_ids}")
+
+        program = _build_self_notify_credit_reset_program()
+        return ir.compile(
+            program,
+            platform=test_config.platform,
+            distributed_config=DistributedConfig(
+                device_ids=device_ids[:2],
+                num_sub_workers=0,
+            ),
+        )
+
+    @staticmethod
+    def _assert_zeroed(outputs):
+        expected = torch.zeros((2, 1, 1), dtype=torch.int32)
+        got = outputs.flatten().tolist()
+        assert torch.equal(outputs, expected), (
+            f"self-notify credit reset mismatch: got {got}, want all-zero "
+            f"(peer's {_REPS} credits must cancel this rank's own -{_REPS} self-notify)"
+        )
+
+    def test_self_notify_credit_reset(self, test_config, device_ids):
+        compiled = self._compile(test_config, device_ids)
+        outputs = torch.zeros((2, 1, 1), dtype=torch.int32)
+        compiled(outputs)
+        self._assert_zeroed(outputs)
+
+    def test_persistent_self_notify_credit_reset_without_window_reset(self, test_config, device_ids):
+        """Repeated persistent dispatches stay zeroed with no host-side reset.
+
+        ``reset_persistent_windows=False`` is exactly the mode the self-
+        clearing protocol is meant to make safe: the signal must return to
+        all-zero on-device after every call, with no synchronous host memset
+        between dispatches.
+        """
+        compiled = self._compile(test_config, device_ids)
+        outputs = torch.zeros((2, 1, 1), dtype=torch.int32).share_memory_()
+
+        with compiled.prepare(persistent=True, reset_persistent_windows=False) as worker:
+            for _ in range(3):
+                outputs.zero_()
+                worker(outputs)
+                self._assert_zeroed(outputs)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", *sys.argv[1:]])

--- a/tests/ut/ir/transforms/test_lower_composite_ops.py
+++ b/tests/ut/ir/transforms/test_lower_composite_ops.py
@@ -823,7 +823,12 @@ def test_allreduce_eval_stmt_with_signal_is_decomposed():
     assert not missing, f"lowered IR missing expected ops: {missing}"
 
 
-def test_allreduce_in_for_loop_is_rejected():
+def test_allreduce_in_for_loop_now_succeeds():
+    """A dynamic trip count used to have no compile-time generation to wait for,
+    so this was rejected. The self-clearing epilogue (each call restarts at
+    all-zero) removes that restriction — see ``lower_composite_ops_pass.cpp``'s
+    deleted ``CheckCollectiveLoopUse``.
+    """
     SIZE = _ALLREDUCE_SIZE
     nr = _ALLREDUCE_NRANKS
 
@@ -839,11 +844,11 @@ def test_allreduce_in_for_loop_is_rejected():
                 data = pld.tensor.allreduce(data, signal, op=pld.ReduceOp.Sum)
             return data
 
-    with pytest.raises(ValueError, match="allreduce is not supported inside a for/while loop"):
-        passes.lower_composite_ops()(LoopAllreduce)
+    After = passes.lower_composite_ops()(LoopAllreduce)
+    assert _static_wait_expectations(After) == [1]
 
 
-def test_allreduce_in_while_loop_is_rejected():
+def test_allreduce_in_while_loop_now_succeeds():
     SIZE = _ALLREDUCE_SIZE
     nr = _ALLREDUCE_NRANKS
 
@@ -859,12 +864,16 @@ def test_allreduce_in_while_loop_is_rejected():
                 data = pld.tensor.allreduce(data, signal, op=pld.ReduceOp.Sum)
             return data
 
-    with pytest.raises(ValueError, match="allreduce is not supported inside a for/while loop"):
-        passes.lower_composite_ops()(LoopAllreduce)
+    After = passes.lower_composite_ops()(LoopAllreduce)
+    assert _static_wait_expectations(After) == [1]
 
 
-def test_all_to_all_v_in_for_loop_is_rejected():
-    """Same single-use Set(1)/wait≥1 signal protocol as allreduce — looped reuse races."""
+def test_all_to_all_v_in_for_loop_now_succeeds():
+    """The self-clearing epilogue (each call restarts at all-zero) removes the
+    old loop restriction for all collectives.  all_to_all_v lowers through
+    the same barrier path as the other six — see the deleted
+    ``CheckCollectiveLoopUse`` in ``lower_composite_ops_pass.cpp``.
+    """
     SIZE = _AAV_SIZE
     nr = _AAV_NRANKS
     total = _AAV_TOTAL
@@ -884,11 +893,11 @@ def test_all_to_all_v_in_for_loop_is_rejected():
                 data = pld.tensor.all_to_all_v(inp, data, signal, counts, recv_counts)
             return data
 
-    with pytest.raises(ValueError, match="all_to_all_v is not supported inside a for/while loop"):
-        passes.lower_composite_ops()(LoopAllToAllV)
+    passes.lower_composite_ops()(LoopAllToAllV)
 
 
-def test_all_to_all_v_in_while_loop_is_rejected():
+def test_all_to_all_v_in_while_loop_now_succeeds():
+    """Same as above — while loops are legal under the self-clearing protocol."""
     SIZE = _AAV_SIZE
     nr = _AAV_NRANKS
     total = _AAV_TOTAL
@@ -908,8 +917,7 @@ def test_all_to_all_v_in_while_loop_is_rejected():
                 data = pld.tensor.all_to_all_v(inp, data, signal, counts, recv_counts)
             return data
 
-    with pytest.raises(ValueError, match="all_to_all_v is not supported inside a for/while loop"):
-        passes.lower_composite_ops()(LoopAllToAllV)
+    passes.lower_composite_ops()(LoopAllToAllV)
 
 
 def test_allreduce_emits_for_and_if_control_flow():
@@ -936,10 +944,10 @@ def test_allreduce_emits_for_and_if_control_flow():
     collector = _StmtKindCollector()
     collector.visit_program(After)
 
-    assert collector.for_count == 6, (
-        f"expected 6 ForStmts (notify, wait, chunk, reduce, re-notify, re-wait), got {collector.for_count}"
+    assert collector.for_count == 7, (
+        f"expected 7 ForStmts (notify,wait,chunk,reduce,renotify,rewait,epilogue), got {collector.for_count}"
     )
-    assert collector.if_count == 5, f"expected 5 peer-filter IfStmts, got {collector.if_count}"
+    assert collector.if_count == 6, f"expected 6 peer-filter IfStmts, got {collector.if_count}"
 
 
 def test_allreduce_flattens_target_to_2d_view_for_mesh_lowering():
@@ -1629,8 +1637,10 @@ def test_barrier_emits_for_and_if_control_flow():
     collector = _StmtKindCollector()
     collector.visit_program(After)
 
-    assert collector.for_count == 2, f"expected 2 ForStmts (notify, wait), got {collector.for_count}"
-    assert collector.if_count == 2, f"expected 2 IfStmts (one per ForStmt body), got {collector.if_count}"
+    assert collector.for_count == 3, (
+        f"expected 3 ForStmts (notify, wait, epilogue), got {collector.for_count}"
+    )
+    assert collector.if_count == 3, f"expected 3 IfStmts (one per ForStmt body), got {collector.if_count}"
 
 
 def test_barrier_lowering_is_idempotent():
@@ -1699,8 +1709,10 @@ def test_broadcast_emits_for_and_if_control_flow():
     collector = _StmtKindCollector()
     collector.visit_program(After)
 
-    assert collector.for_count == 2, f"expected 2 ForStmts (notify, wait), got {collector.for_count}"
-    assert collector.if_count == 2, f"expected 2 IfStmts (one per ForStmt body), got {collector.if_count}"
+    assert collector.for_count == 3, (
+        f"expected 3 ForStmts (notify, wait, epilogue), got {collector.for_count}"
+    )
+    assert collector.if_count == 3, f"expected 3 IfStmts (one per ForStmt body), got {collector.if_count}"
 
 
 def test_broadcast_lowering_is_idempotent():
@@ -1773,8 +1785,12 @@ def test_allgather_emits_for_and_if_control_flow():
     collector = _StmtKindCollector()
     collector.visit_program(After)
 
-    assert collector.for_count == 3, f"expected 3 ForStmts (push, notify, wait), got {collector.for_count}"
-    assert collector.if_count == 2, f"expected 2 IfStmts (notify-all + wait-all), got {collector.if_count}"
+    assert collector.for_count == 4, (
+        f"expected 4 ForStmts (push, notify, wait, epilogue), got {collector.for_count}"
+    )
+    assert collector.if_count == 3, (
+        f"expected 3 IfStmts (notify-all + wait-all + epilogue), got {collector.if_count}"
+    )
 
 
 def test_allgather_lowering_is_idempotent():
@@ -1845,10 +1861,10 @@ def test_reduce_scatter_emits_for_and_if_control_flow():
     collector = _StmtKindCollector()
     collector.visit_program(After)
 
-    assert collector.for_count == 5, (
-        f"expected 5 ForStmts (notify, wait, reduce, re-notify, re-wait), got {collector.for_count}"
+    assert collector.for_count == 6, (
+        f"expected 6 ForStmts (notify, wait, reduce, re-notify, re-wait, epilogue), got {collector.for_count}"
     )
-    assert collector.if_count == 5, f"expected 5 IfStmts (one per ForStmt body), got {collector.if_count}"
+    assert collector.if_count == 6, f"expected 6 IfStmts (one per ForStmt body), got {collector.if_count}"
 
 
 def test_reduce_scatter_lowering_is_idempotent():
@@ -1971,8 +1987,8 @@ def test_ring_allreduce_emits_ring_control_flow():
     collector = _StmtKindCollector()
     collector.visit_program(After)
 
-    assert collector.for_count == 12, f"expected 12 ForStmts for P=2 ring, got {collector.for_count}"
-    assert collector.if_count == 12, f"expected 12 IfStmts for P=2 ring, got {collector.if_count}"
+    assert collector.for_count == 14, f"expected 14 ForStmts for P=2 ring, got {collector.for_count}"
+    assert collector.if_count == 13, f"expected 13 IfStmts for P=2 ring, got {collector.if_count}"
 
 
 @pytest.mark.parametrize("size", [1, 3, 17, 8193, 65537])
@@ -2085,7 +2101,7 @@ def test_ring_allreduce_fp16_uses_aligned_ring_schedule(size, n_ranks):
 
     stmt_collector = _StmtKindCollector()
     stmt_collector.visit_program(After)
-    assert stmt_collector.for_count == 12, (
+    assert stmt_collector.for_count == 14, (
         f"FP16 mode=ring must use the ring schedule, got {stmt_collector.for_count} loops"
     )
 
@@ -2390,7 +2406,7 @@ def test_ring_allreduce_mesh_default_unchanged():
     # per-chunk read-complete barrier.
     collector = _StmtKindCollector()
     collector.visit_program(After)
-    assert collector.for_count == 6, f"mesh allreduce must produce 6 ForStmts, got {collector.for_count}"
+    assert collector.for_count == 7, f"mesh allreduce must produce 7 ForStmts, got {collector.for_count}"
 
 
 @pytest.mark.parametrize(("reduce_op", "expected_tile_op"), _ALLREDUCE_REDUCE_CASES)
@@ -2404,6 +2420,612 @@ def test_ring_allreduce_lowers_every_reduce_op(reduce_op, expected_tile_op):
     for _, other_tile_op in _ALLREDUCE_REDUCE_CASES:
         if other_tile_op != expected_tile_op:
             assert other_tile_op not in op_names
+
+
+# ============================================================================
+# Self-clearing credit-barrier protocol (issue #2156)
+#
+# Every ``pld.tensor.*`` collective barriers through one shared protocol:
+# ``AtomicAdd(1)`` into each peer's cell for every barrier this call issues,
+# then ``Wait(>= g)`` where ``g`` counts up *within this call only* — every
+# fresh call restarts at 1. A per-call epilogue then subtracts the total
+# credit count back out of every cell it touched (``AtomicAdd(-N)``), so the
+# signal is provably all-zero again once every rank has finished its
+# epilogue. The next call on the same signal therefore starts over at
+# generation 1 too, with no cross-call bookkeeping required.
+#
+# These tests pin the protocol itself, which is the deterministic regression
+# guard: functional back-to-back coverage lives in the distributed STs, where a
+# stale-signal barrier only *races* rather than reliably failing.
+# ============================================================================
+
+_PROTOCOL_SIZE = 16
+_PROTOCOL_NRANKS = 2
+
+
+# Route the operator literals through the registry getter so a typo raises at
+# import instead of silently never matching.
+_NOTIFY_OP_NAME = ir.get_op("pld.system.notify").name
+_WAIT_OP_NAME = ir.get_op("pld.system.wait").name
+
+
+class _CollectiveCallCollector(ir.IRVisitor):
+    """Collect every ``pld.system.notify`` / ``pld.system.wait`` Call in order."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.notifies: list[ir.Call] = []
+        self.waits: list[ir.Call] = []
+
+    def visit_call(self, op: ir.Call) -> None:
+        if op.op.name == _NOTIFY_OP_NAME:
+            self.notifies.append(op)
+        elif op.op.name == _WAIT_OP_NAME:
+            self.waits.append(op)
+        super().visit_call(op)
+
+
+def _collect_barrier_calls(prog) -> _CollectiveCallCollector:
+    collector = _CollectiveCallCollector()
+    collector.visit_program(prog)
+    return collector
+
+
+def _static_wait_expectations(prog) -> list[int]:
+    """Expected values of every ``pld.system.wait`` with a constant expectation.
+
+    The mesh allreduce's per-chunk barrier derives its expectation from the
+    chunk loop variable, so it is skipped here — only compile-time constants
+    (one per straight-line barrier) are returned, in emission order.
+    """
+    values = []
+    for wait in _collect_barrier_calls(prog).waits:
+        expected = wait.args[2]
+        if isinstance(expected, ir.ConstInt):
+            values.append(expected.value)
+    return values
+
+
+def _build_two_barriers_program():
+    nr = _PROTOCOL_NRANKS
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore)
+        def barrier_twice(
+            self,
+            signal: pl.InOut[pld.DistributedTensor[[nr, 1], pl.INT32]],
+        ) -> pld.DistributedTensor[[nr, 1], pl.INT32]:
+            signal = pld.tensor.barrier(signal)
+            signal = pld.tensor.barrier(signal)
+            return signal
+
+    return Before
+
+
+def _build_two_all_to_all_program():
+    SIZE = _PROTOCOL_SIZE
+    nr = _PROTOCOL_NRANKS
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore)
+        def exchange_twice(
+            self,
+            first: pl.Tensor[[nr, SIZE], pl.FP32],
+            second: pl.Tensor[[nr, SIZE], pl.FP32],
+            data: pl.InOut[pld.DistributedTensor[[nr, SIZE], pl.FP32]],
+            signal: pl.InOut[pld.DistributedTensor[[nr, 1], pl.INT32]],
+        ) -> pld.DistributedTensor[[nr, SIZE], pl.FP32]:
+            data = pld.tensor.all_to_all(first, data, signal)
+            data = pld.tensor.all_to_all(second, data, signal)
+            return data
+
+    return Before
+
+
+def _build_two_allgather_program():
+    SIZE = _PROTOCOL_SIZE
+    nr = _PROTOCOL_NRANKS
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore)
+        def gather_twice(
+            self,
+            first: pl.Tensor[[1, SIZE], pl.FP32],
+            second: pl.Tensor[[1, SIZE], pl.FP32],
+            data: pl.InOut[pld.DistributedTensor[[nr, SIZE], pl.FP32]],
+            signal: pl.InOut[pld.DistributedTensor[[nr, 1], pl.INT32]],
+        ) -> pld.DistributedTensor[[nr, SIZE], pl.FP32]:
+            data = pld.tensor.allgather(first, data, signal)
+            data = pld.tensor.allgather(second, data, signal)
+            return data
+
+    return Before
+
+
+def _build_two_reduce_scatter_program():
+    SIZE = _PROTOCOL_SIZE
+    nr = _PROTOCOL_NRANKS
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore)
+        def scatter_twice(
+            self,
+            data: pl.InOut[pld.DistributedTensor[[nr, SIZE], pl.FP32]],
+            signal: pl.InOut[pld.DistributedTensor[[nr, 1], pl.INT32]],
+        ) -> pld.DistributedTensor[[nr, SIZE], pl.FP32]:
+            data = pld.tensor.reduce_scatter(data, signal, op=pld.ReduceOp.Sum)
+            data = pld.tensor.reduce_scatter(data, signal, op=pld.ReduceOp.Sum)
+            return data
+
+    return Before
+
+
+def _build_two_broadcast_program():
+    SIZE = _PROTOCOL_SIZE
+    nr = _PROTOCOL_NRANKS
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore)
+        def broadcast_twice(
+            self,
+            data: pl.InOut[pld.DistributedTensor[[1, SIZE], pl.FP32]],
+            signal: pl.InOut[pld.DistributedTensor[[nr, 1], pl.INT32]],
+        ) -> pld.DistributedTensor[[1, SIZE], pl.FP32]:
+            data = pld.tensor.broadcast(data, signal, root=0)
+            data = pld.tensor.broadcast(data, signal, root=0)
+            return data
+
+    return Before
+
+
+def _build_two_ring_allreduce_program():
+    SIZE = _RING_ALLREDUCE_SIZE
+    nr = _RING_ALLREDUCE_NRANKS
+    total_rounds = 2 * (nr - 1)
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore)
+        def reduce_twice(
+            self,
+            data: pl.InOut[pld.DistributedTensor[[1, SIZE], pl.FP32]],
+            signal: pl.InOut[pld.DistributedTensor[[total_rounds, nr], pl.INT32]],
+        ) -> pld.DistributedTensor[[1, SIZE], pl.FP32]:
+            data = pld.tensor.allreduce(data, signal, op=pld.ReduceOp.Sum, mode="ring")
+            data = pld.tensor.allreduce(data, signal, op=pld.ReduceOp.Sum, mode="ring")
+            return data
+
+    return Before
+
+
+# One builder per collective, with the wait expectations each back-to-back pair
+# must produce. Every call restarts at generation 1 — the epilogue resets the
+# signal to all-zero at the end of each call — so two calls repeat the same
+# sequence rather than accumulating. reduce_scatter barriers twice per call
+# (ready + post-reduce): [1, 2, 1, 2]. The ring allreduce's arbitrary-length
+# schedule (#2161) barriers twice per subchunk (ready + read-complete); at
+# NR=2 there is one reduce-scatter round and one allgather round, each with
+# one subchunk, so one call already produces [1, 2, 1, 2] and two calls repeat
+# it.
+_BACK_TO_BACK_CASES = {
+    "barrier": (_build_two_barriers_program, [1, 1]),
+    "all_to_all": (_build_two_all_to_all_program, [1, 1]),
+    "allgather": (_build_two_allgather_program, [1, 1]),
+    "broadcast": (_build_two_broadcast_program, [1, 1]),
+    "reduce_scatter": (_build_two_reduce_scatter_program, [1, 2, 1, 2]),
+    "ring_allreduce": (_build_two_ring_allreduce_program, []),
+}
+
+
+@pytest.mark.parametrize("collective", sorted(_BACK_TO_BACK_CASES))
+def test_back_to_back_collective_restarts_at_generation_one(collective):
+    """A signal reused by two consecutive collectives always restarts at 1.
+
+    Regression guard for issue #2156: the self-clearing epilogue
+    (``AtomicAdd(-N)``) restores every cell to zero at the end of each call,
+    so the *next* call's first barrier safely waits for ``>= 1`` again —
+    unlike the old ``Set(1)`` / ``Wait(>= 1)`` protocol, which left every cell
+    at 1 and let the second call's waits pass on stale state.
+    """
+    build, expected_generations = _BACK_TO_BACK_CASES[collective]
+    After = passes.lower_composite_ops()(build())
+
+    assert _static_wait_expectations(After) == expected_generations, (
+        f"{collective} back-to-back must restart at generation 1 each call, expecting "
+        f"{expected_generations}, got {_static_wait_expectations(After)}"
+    )
+
+
+@pytest.mark.parametrize("collective", sorted(_BACK_TO_BACK_CASES))
+def test_collective_barriers_use_atomic_add_and_ge(collective):
+    """Every barrier notifies with ``AtomicAdd`` and waits with ``Ge``.
+
+    ``Set`` must never appear: mixing it with ``AtomicAdd`` on the same cells
+    can clobber an already-advanced counter. ``Ge`` (not ``Eq``) is required
+    because a fast peer can advance a cell past the value the waiter is
+    looking for. The credit epilogue's reset notify is itself an ``AtomicAdd``
+    (of a negative value) — never a ``Set`` — so this invariant covers it too.
+    """
+    build, _ = _BACK_TO_BACK_CASES[collective]
+    After = passes.lower_composite_ops()(build())
+    calls = _collect_barrier_calls(After)
+
+    assert calls.notifies, f"{collective} lowering emitted no notify"
+    assert calls.waits, f"{collective} lowering emitted no wait"
+    for notify in calls.notifies:
+        assert notify.kwargs["op"] == int(pld.NotifyOp.AtomicAdd), (
+            f"{collective} must notify with AtomicAdd, got op={notify.kwargs['op']}"
+        )
+    for wait in calls.waits:
+        assert wait.kwargs["cmp"] == int(pld.WaitCmp.Ge), (
+            f"{collective} must wait with Ge, got cmp={wait.kwargs['cmp']}"
+        )
+
+
+def test_barrier_chain_restarts_generation_through_the_rebind_idiom():
+    """``sig = pld.tensor.barrier(sig)`` renames the signal on every call.
+
+    Generations are call-local under the self-clearing protocol, so a chain
+    of rebound barriers restarts at 1 on every call instead of continuing to
+    count up — the rebind idiom no longer needs cross-call alias tracking.
+    """
+    nr = _PROTOCOL_NRANKS
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore)
+        def barrier_thrice(
+            self,
+            signal: pl.InOut[pld.DistributedTensor[[nr, 1], pl.INT32]],
+        ) -> pld.DistributedTensor[[nr, 1], pl.INT32]:
+            signal = pld.tensor.barrier(signal)
+            signal = pld.tensor.barrier(signal)
+            signal = pld.tensor.barrier(signal)
+            return signal
+
+    After = passes.lower_composite_ops()(Before)
+    assert _static_wait_expectations(After) == [1, 1, 1]
+
+
+def test_mesh_allreduce_epilogue_resets_signal_for_the_next_collective():
+    """A later collective is unaffected by an earlier allreduce's barriers.
+
+    The [1, 16] FP32 target is one chunk, so the mesh recipe issues one ready
+    barrier (generation 1) plus one chunk-complete barrier (a runtime-derived
+    expected value, not a compile-time constant) and then subtracts both
+    credits back out via the epilogue. The following barrier therefore waits
+    for 1 again, not for a value that accounts for the allreduce's barriers.
+    """
+    SIZE = _PROTOCOL_SIZE
+    nr = _PROTOCOL_NRANKS
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore)
+        def reduce_then_barrier(
+            self,
+            data: pl.InOut[pld.DistributedTensor[[1, SIZE], pl.FP32]],
+            signal: pl.InOut[pld.DistributedTensor[[nr, 1], pl.INT32]],
+        ) -> pld.DistributedTensor[[nr, 1], pl.INT32]:
+            data = pld.tensor.allreduce(data, signal, op=pld.ReduceOp.Sum)
+            signal = pld.tensor.barrier(signal)
+            return signal
+
+    After = passes.lower_composite_ops()(Before)
+    # The ready barrier waits for 1; the chunk barrier's expectation is derived
+    # from the chunk loop variable (not a constant, so _static_wait_expectations
+    # skips it); the epilogue resets the signal, so the trailing barrier waits
+    # for 1 again rather than accounting for the allreduce's barriers.
+    assert _static_wait_expectations(After) == [1, 1]
+
+
+def test_dynamic_mesh_allreduce_signal_is_reusable():
+    """A symbolic reduction extent no longer poisons the signal for reuse.
+
+    The self-clearing epilogue's credit total may itself be a runtime-computed
+    scalar expression (``pld.system.notify``'s value only requires
+    ``ScalarType``), so a mesh allreduce over a symbolic extent can still reset
+    its signal correctly even though the chunk count is unknown at compile
+    time.
+    """
+    n = pl.dynamic("REUSE_DYNAMIC_N")
+    nr = _PROTOCOL_NRANKS
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore)
+        def reduce_then_barrier(
+            self,
+            data: pl.InOut[pld.DistributedTensor[[1, n], pl.FP32]],
+            signal: pl.InOut[pld.DistributedTensor[[nr, 1], pl.INT32]],
+        ) -> pld.DistributedTensor[[nr, 1], pl.INT32]:
+            data = pld.tensor.allreduce(data, signal, op=pld.ReduceOp.Sum)
+            signal = pld.tensor.barrier(signal)
+            return signal
+
+    After = passes.lower_composite_ops()(Before)
+    assert _static_wait_expectations(After) == [1, 1]
+
+    # The allreduce's epilogue reset must carry a symbolic (non-ConstInt)
+    # credit total, since the chunk count depends on the runtime extent n.
+    notifies = _collect_barrier_calls(After).notifies
+    symbolic_value_notifies = [call for call in notifies if not isinstance(call.args[3], ir.ConstInt)]
+    assert symbolic_value_notifies, (
+        "expected at least one symbolic-value notify (the allreduce epilogue reset)"
+    )
+
+
+def test_mixing_ring_and_mesh_barrier_protocols_on_one_signal_is_rejected():
+    """Ring's signal is [2*(NR-1), NR] (one row per round); mesh's is [NR, 1]
+    (one cell per rank). Sharing one buffer between the two is now a plain
+    shape mismatch rather than a generation-table protocol conflict."""
+    SIZE = _RING_ALLREDUCE_SIZE
+    nr = _RING_ALLREDUCE_NRANKS
+    total_rounds = 2 * (nr - 1)
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore)
+        def ring_then_barrier(
+            self,
+            data: pl.InOut[pld.DistributedTensor[[1, SIZE], pl.FP32]],
+            signal: pl.InOut[pld.DistributedTensor[[total_rounds, nr], pl.INT32]],
+        ) -> pld.DistributedTensor[[total_rounds, nr], pl.INT32]:
+            data = pld.tensor.allreduce(data, signal, op=pld.ReduceOp.Sum, mode="ring")
+            signal = pld.tensor.barrier(signal)
+            return signal
+
+    with pytest.raises(ValueError, match=r"signal shape\[1\] must be 1"):
+        passes.lower_composite_ops()(Before)
+
+
+def _build_barrier_in_loop_program():
+    nr = _PROTOCOL_NRANKS
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore)
+        def loop_step(
+            self,
+            signal: pl.InOut[pld.DistributedTensor[[nr, 1], pl.INT32]],
+        ) -> pld.DistributedTensor[[nr, 1], pl.INT32]:
+            for _ in pl.range(2):
+                signal = pld.tensor.barrier(signal)
+            return signal
+
+    return Before
+
+
+def _build_broadcast_in_loop_program():
+    SIZE = _PROTOCOL_SIZE
+    nr = _PROTOCOL_NRANKS
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore)
+        def loop_step(
+            self,
+            data: pl.InOut[pld.DistributedTensor[[1, SIZE], pl.FP32]],
+            signal: pl.InOut[pld.DistributedTensor[[nr, 1], pl.INT32]],
+        ) -> pld.DistributedTensor[[1, SIZE], pl.FP32]:
+            for _ in pl.range(2):
+                data = pld.tensor.broadcast(data, signal, root=0)
+            return data
+
+    return Before
+
+
+def _build_allgather_in_loop_program():
+    SIZE = _PROTOCOL_SIZE
+    nr = _PROTOCOL_NRANKS
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore)
+        def loop_step(
+            self,
+            inp: pl.Tensor[[1, SIZE], pl.FP32],
+            data: pl.InOut[pld.DistributedTensor[[nr, SIZE], pl.FP32]],
+            signal: pl.InOut[pld.DistributedTensor[[nr, 1], pl.INT32]],
+        ) -> pld.DistributedTensor[[nr, SIZE], pl.FP32]:
+            for _ in pl.range(2):
+                data = pld.tensor.allgather(inp, data, signal)
+            return data
+
+    return Before
+
+
+def _build_all_to_all_in_loop_program():
+    SIZE = _PROTOCOL_SIZE
+    nr = _PROTOCOL_NRANKS
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore)
+        def loop_step(
+            self,
+            inp: pl.Tensor[[nr, SIZE], pl.FP32],
+            data: pl.InOut[pld.DistributedTensor[[nr, SIZE], pl.FP32]],
+            signal: pl.InOut[pld.DistributedTensor[[nr, 1], pl.INT32]],
+        ) -> pld.DistributedTensor[[nr, SIZE], pl.FP32]:
+            for _ in pl.range(2):
+                data = pld.tensor.all_to_all(inp, data, signal)
+            return data
+
+    return Before
+
+
+def _build_reduce_scatter_in_loop_program():
+    SIZE = _PROTOCOL_SIZE
+    nr = _PROTOCOL_NRANKS
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore)
+        def loop_step(
+            self,
+            data: pl.InOut[pld.DistributedTensor[[nr, SIZE], pl.FP32]],
+            signal: pl.InOut[pld.DistributedTensor[[nr, 1], pl.INT32]],
+        ) -> pld.DistributedTensor[[nr, SIZE], pl.FP32]:
+            for _ in pl.range(2):
+                data = pld.tensor.reduce_scatter(data, signal, op=pld.ReduceOp.Sum)
+            return data
+
+    return Before
+
+
+_IN_LOOP_BUILDERS = {
+    "barrier": _build_barrier_in_loop_program,
+    "broadcast": _build_broadcast_in_loop_program,
+    "allgather": _build_allgather_in_loop_program,
+    "all_to_all": _build_all_to_all_in_loop_program,
+    "reduce_scatter": _build_reduce_scatter_in_loop_program,
+}
+
+
+_IN_LOOP_EXPECTED = {
+    "barrier": [1],
+    "broadcast": [1],
+    "allgather": [1],
+    "all_to_all": [1],
+    "reduce_scatter": [1, 2],
+}
+
+
+@pytest.mark.parametrize("collective", sorted(_IN_LOOP_BUILDERS))
+def test_collective_in_for_loop_now_succeeds(collective):
+    """Collectives are legal inside for/while/if now.
+
+    Each call is a self-contained, stateless cycle starting from all-zero, so
+    the compiler lowers the loop body's collective call once and the same
+    compile-time expected values are safely reused on every runtime iteration
+    — unlike the old compile-time generation scheme, which had no fixed
+    generation for a dynamic trip count to wait for.
+    """
+    Before = _IN_LOOP_BUILDERS[collective]()
+    After = passes.lower_composite_ops()(Before)
+    assert _static_wait_expectations(After) == _IN_LOOP_EXPECTED[collective]
+
+
+def test_unrolled_loop_collective_restarts_each_call():
+    """``pl.unroll`` still produces straight-line back-to-back calls.
+
+    ``UnrollLoops`` runs before ``LowerCompositeOps`` in the default pipeline,
+    so a compile-time trip count becomes 3 independent calls on one signal —
+    each restarting at generation 1, since the self-clearing epilogue resets
+    the signal between them.
+    """
+    nr = _PROTOCOL_NRANKS
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore)
+        def barrier_unrolled(
+            self,
+            signal: pl.InOut[pld.DistributedTensor[[nr, 1], pl.INT32]],
+        ) -> pld.DistributedTensor[[nr, 1], pl.INT32]:
+            for _ in pl.unroll(3):
+                signal = pld.tensor.barrier(signal)
+            return signal
+
+    After = passes.lower_composite_ops()(passes.unroll_loops()(Before))
+    assert _static_wait_expectations(After) == [1, 1, 1]
+
+
+def test_stateless_signal_round_trip_across_many_calls():
+    """A dynamic (non-unrolled) loop issuing many barrier calls on one signal
+    compiles to exactly one barrier + epilogue reset, reused at runtime for
+    every iteration — proof that the protocol needs no per-iteration or
+    per-call compile-time state.
+    """
+    nr = _PROTOCOL_NRANKS
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore)
+        def loop_step(
+            self,
+            signal: pl.InOut[pld.DistributedTensor[[nr, 1], pl.INT32]],
+        ) -> pld.DistributedTensor[[nr, 1], pl.INT32]:
+            for _ in pl.range(5):
+                signal = pld.tensor.barrier(signal)
+            return signal
+
+    After = passes.lower_composite_ops()(Before)
+    calls = _collect_barrier_calls(After)
+    assert len(calls.waits) == 1, (
+        "the loop body's barrier must be lowered exactly once, regardless of trip count"
+    )
+    expected = calls.waits[0].args[2]
+    assert isinstance(expected, ir.ConstInt)
+    assert expected.value == 1
+
+
+def test_epilogue_emits_negative_atomic_add():
+    """Every collective's final notify is its self-clearing epilogue reset:
+
+    an ``AtomicAdd`` of a negated credit total — either ``Neg(wrapped)`` for
+    runtime expressions, or ``ConstInt(negative)`` for compile-time constants
+    (the lowering helper folds ``Neg(ConstInt(N))`` to ``ConstInt(-N)`` so
+    the PyPTO printer→parser roundtrip stays stable).
+    """
+    for collective, (build, _) in sorted(_BACK_TO_BACK_CASES.items()):
+        After = passes.lower_composite_ops()(build())
+        notifies = _collect_barrier_calls(After).notifies
+        assert notifies, f"{collective} emitted no notify"
+        last_notify = notifies[-1]
+        assert last_notify.kwargs["op"] == int(pld.NotifyOp.AtomicAdd), (
+            f"{collective} epilogue must notify with AtomicAdd"
+        )
+        value = last_notify.args[3]
+        is_negative = isinstance(value, ir.Neg) or (isinstance(value, ir.ConstInt) and value.value < 0)
+        assert is_negative, f"{collective} epilogue must carry a negative value, got {type(value)}"
+
+
+def test_ring_allreduce_epilogue_resets_every_row():
+    """Ring's epilogue must reset every one of the signal's rows, not just a
+    single cell — each round credited a distinct row.
+    """
+    SIZE = _RING_ALLREDUCE_SIZE
+    nr = _RING_ALLREDUCE_NRANKS
+    total_rounds = 2 * (nr - 1)
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore)
+        def reduce_once(
+            self,
+            data: pl.InOut[pld.DistributedTensor[[1, SIZE], pl.FP32]],
+            signal: pl.InOut[pld.DistributedTensor[[total_rounds, nr], pl.INT32]],
+        ) -> pld.DistributedTensor[[1, SIZE], pl.FP32]:
+            data = pld.tensor.allreduce(data, signal, op=pld.ReduceOp.Sum, mode="ring")
+            return data
+
+    After = passes.lower_composite_ops()(Before)
+    notifies = _collect_barrier_calls(After).notifies
+    # The epilogue resets are the AtomicAdd notifies whose value is negative
+    # (either Neg(wrapped) for runtime expressions, or ConstInt(negative) when
+    # the lowering helper folds Neg(ConstInt(N)) to ConstInt(-N) for roundtrip
+    # stability). Every earlier round-barrier notify uses a plain +1 ConstInt.
+    epilogue_notifies = [
+        call
+        for call in notifies
+        if isinstance(call.args[3], ir.Neg)
+        or (isinstance(call.args[3], ir.ConstInt) and call.args[3].value < 0)
+    ]
+    assert epilogue_notifies, "expected at least one epilogue reset notify"
+    # Every epilogue notify targets a 2-element [row, rank] offset tuple (the
+    # 2D signal overload), confirming the reset is row-indexed rather than a
+    # single [rank, 0] cell.
+    for notify in epilogue_notifies:
+        offsets = notify.args[2]
+        assert isinstance(offsets, ir.MakeTuple)
+        assert len(offsets.elements) == 2
 
 
 if __name__ == "__main__":

--- a/tests/ut/ir/transforms/test_materialize_comm_domain_scopes.py
+++ b/tests/ut/ir/transforms/test_materialize_comm_domain_scopes.py
@@ -893,7 +893,13 @@ def test_explicit_allreduce_eval_stmt_keeps_user_signal():
     assert _as_var(allreduces[0].args[1]).name_hint == "signal"
 
 
-def test_implicit_allreduce_in_loop_is_rejected():
+def test_implicit_allreduce_in_loop_now_succeeds():
+    """A dynamic trip count used to have no compile-time generation to wait for,
+    so this was rejected. The self-clearing credit-barrier protocol (each call
+    restarts at all-zero) removes that restriction — see
+    ``synthesize_allreduce_signals_pass.cpp::CheckAllReduceCall``.
+    """
+
     @pl.program
     class P:
         @pl.function(type=pl.FunctionType.Orchestration)
@@ -910,11 +916,12 @@ def test_implicit_allreduce_in_loop_is_rejected():
                 data = pld.tensor.allreduce(data, op=pld.ReduceOp.Sum)
             return data
 
-    with pytest.raises(ValueError, match="allreduce is not supported inside a for/while loop"):
-        _apply(P)
+    result = _apply(P)
+    host = _get_func(result, "host_orch")
+    assert len(_get_comm_domain_scopes(host)) >= 1
 
 
-def test_implicit_allreduce_in_while_loop_is_rejected():
+def test_implicit_allreduce_in_while_loop_now_succeeds():
     @pl.program
     class P:
         @pl.function(type=pl.FunctionType.Orchestration)
@@ -931,11 +938,12 @@ def test_implicit_allreduce_in_while_loop_is_rejected():
                 data = pld.tensor.allreduce(data, op=pld.ReduceOp.Sum)
             return data
 
-    with pytest.raises(ValueError, match="allreduce is not supported inside a for/while loop"):
-        _apply(P)
+    result = _apply(P)
+    host = _get_func(result, "host_orch")
+    assert len(_get_comm_domain_scopes(host)) >= 1
 
 
-def test_explicit_allreduce_in_loop_is_rejected():
+def test_explicit_allreduce_in_loop_now_succeeds():
     @pl.program
     class P:
         @pl.function(type=pl.FunctionType.Orchestration)
@@ -954,11 +962,12 @@ def test_explicit_allreduce_in_loop_is_rejected():
                 data = pld.tensor.allreduce(data, signal, op=pld.ReduceOp.Sum)
             return data
 
-    with pytest.raises(ValueError, match="allreduce is not supported inside a for/while loop"):
-        _apply(P)
+    result = _apply(P)
+    host = _get_func(result, "host_orch")
+    assert len(_get_comm_domain_scopes(host)) >= 1
 
 
-def test_explicit_allreduce_in_while_loop_is_rejected():
+def test_explicit_allreduce_in_while_loop_now_succeeds():
     @pl.program
     class P:
         @pl.function(type=pl.FunctionType.Orchestration)
@@ -977,8 +986,9 @@ def test_explicit_allreduce_in_while_loop_is_rejected():
                 data = pld.tensor.allreduce(data, signal, op=pld.ReduceOp.Sum)
             return data
 
-    with pytest.raises(ValueError, match="allreduce is not supported inside a for/while loop"):
-        _apply(P)
+    result = _apply(P)
+    host = _get_func(result, "host_orch")
+    assert len(_get_comm_domain_scopes(host)) >= 1
 
 
 def test_nested_explicit_allreduce_expression_is_rejected():

--- a/tests/ut/ir/transforms/test_materialize_comm_domain_scopes.py
+++ b/tests/ut/ir/transforms/test_materialize_comm_domain_scopes.py
@@ -893,11 +893,12 @@ def test_explicit_allreduce_eval_stmt_keeps_user_signal():
     assert _as_var(allreduces[0].args[1]).name_hint == "signal"
 
 
-def test_implicit_allreduce_in_loop_now_succeeds():
-    """A dynamic trip count used to have no compile-time generation to wait for,
-    so this was rejected. The self-clearing credit-barrier protocol (each call
-    restarts at all-zero) removes that restriction — see
-    ``synthesize_allreduce_signals_pass.cpp::CheckAllReduceCall``.
+def test_implicit_allreduce_in_loop_is_rejected():
+    """The HOST builtin allreduce is not self-clearing (it adds credits without
+    subtracting them), so a signal reused across a dynamic trip count would pass
+    its waits on stale state. The loop restriction therefore stays on the HOST
+    signal-synthesis path; only InCore composites (LowerCompositeOps) are
+    loop-safe under the self-clearing protocol.
     """
 
     @pl.program
@@ -916,12 +917,11 @@ def test_implicit_allreduce_in_loop_now_succeeds():
                 data = pld.tensor.allreduce(data, op=pld.ReduceOp.Sum)
             return data
 
-    result = _apply(P)
-    host = _get_func(result, "host_orch")
-    assert len(_get_comm_domain_scopes(host)) >= 1
+    with pytest.raises(ValueError, match="allreduce is not supported inside a for/while loop"):
+        _apply(P)
 
 
-def test_implicit_allreduce_in_while_loop_now_succeeds():
+def test_implicit_allreduce_in_while_loop_is_rejected():
     @pl.program
     class P:
         @pl.function(type=pl.FunctionType.Orchestration)
@@ -938,12 +938,11 @@ def test_implicit_allreduce_in_while_loop_now_succeeds():
                 data = pld.tensor.allreduce(data, op=pld.ReduceOp.Sum)
             return data
 
-    result = _apply(P)
-    host = _get_func(result, "host_orch")
-    assert len(_get_comm_domain_scopes(host)) >= 1
+    with pytest.raises(ValueError, match="allreduce is not supported inside a for/while loop"):
+        _apply(P)
 
 
-def test_explicit_allreduce_in_loop_now_succeeds():
+def test_explicit_allreduce_in_loop_is_rejected():
     @pl.program
     class P:
         @pl.function(type=pl.FunctionType.Orchestration)
@@ -962,12 +961,11 @@ def test_explicit_allreduce_in_loop_now_succeeds():
                 data = pld.tensor.allreduce(data, signal, op=pld.ReduceOp.Sum)
             return data
 
-    result = _apply(P)
-    host = _get_func(result, "host_orch")
-    assert len(_get_comm_domain_scopes(host)) >= 1
+    with pytest.raises(ValueError, match="allreduce is not supported inside a for/while loop"):
+        _apply(P)
 
 
-def test_explicit_allreduce_in_while_loop_now_succeeds():
+def test_explicit_allreduce_in_while_loop_is_rejected():
     @pl.program
     class P:
         @pl.function(type=pl.FunctionType.Orchestration)
@@ -986,9 +984,8 @@ def test_explicit_allreduce_in_while_loop_now_succeeds():
                 data = pld.tensor.allreduce(data, signal, op=pld.ReduceOp.Sum)
             return data
 
-    result = _apply(P)
-    host = _get_func(result, "host_orch")
-    assert len(_get_comm_domain_scopes(host)) >= 1
+    with pytest.raises(ValueError, match="allreduce is not supported inside a for/while loop"):
+        _apply(P)
 
 
 def test_nested_explicit_allreduce_expression_is_rejected():


### PR DESCRIPTION
Closes #2156.

The composite collective lowerings shared a `Set(1)` + `Wait(>= 1)` completion barrier. That leaves every signal cell at `1` after a call returns, so a later invocation reusing the same signal could satisfy its waits from stale state before peers finished the new data transfers — returning mixed or partial results. This replaces it with a **self-clearing credit barrier protocol shared by the whole `pld.tensor.*` family**, so signals are safely reusable across back-to-back calls.

### The protocol

```
Body:                 barrier(1); barrier(2); ...; barrier(N)
                        where barrier(g):
                          for peer != my_rank:
                            notify(signal, peer, <my cell>, 1, op=AtomicAdd)
                          for src  != my_rank:
                            wait(signal, <src cell>, g, cmp=Ge)

Epilogue:             for src != my_rank:
                          notify(signal, my_rank, <src cell>, -N, op=AtomicAdd)
```

`AtomicAdd` turns each cell into a credit counter: every barrier issues `+1` credits across all peers, and the epilogue subtracts the total `-N` back to zero. Because adds and subtracts are atomic and commutative, the signal is provably all-zero again once every rank has finished its epilogue. Every call's generation restarts at 1 — no compile-time cross-call bookkeeping is needed.

### Credit accounting — verified

| Collective | barriers issued | epilogue subtracts |
|---|---|---|
| `barrier` / `broadcast` / `allgather` / `all_to_all` / `all_to_all_v` | 1 | `1` |
| `reduce_scatter`, mesh `allreduce` (rectangle path) | 2 | `2` |
| mesh `allreduce` (chunked) | `1 + chunk_count` | same expression |
| ring `allreduce` | `2 * chunk_count` per row | same, per row |

The last wait of every call has an expected value equal to the total the epilogue subtracts, so every cell is provably `>= N` by the time the epilogue runs and can never go negative.

### Key properties

- **Call-local generations** — barrier count resets per call, so every call starts fresh
- **Loop-safe on the InCore rail** — `pld.tensor.*` composites lowered by `LowerCompositeOps` (which emits the self-clearing epilogue) are legal inside `for`/`while`/`if`, with rank-uniform execution required. The HOST builtin allreduce is **not** self-clearing (it adds credits, never subtracts), so a HOST allreduce keeps its `for`/`while` restriction: `SynthesizeAllReduceSignals` still rejects an allreduce under a dynamic-trip-count loop rather than reuse a signal against stale thresholds
- **Symbolic-extent safe** — mesh allreduce per-chunk credit totals may be runtime scalars
- **`Ge` (not `Eq`) is load-bearing** — a fast peer can advance a cell past the waited-for value before the waiting rank polls it

### Latent bugs fixed

- **`reduce_scatter` mixed `Set` and `AtomicAdd`** on the same cells. Every collective now notifies with `AtomicAdd` only.
- **`all_to_all_v` was on the old `Set(1)` + `Wait(Ge 1)` protocol** (introduced in #2112) — migrated to `EmitBarrier` + `EmitEpilogueReset`, making it loop-safe and safe for signal reuse like the other six collectives.

### Changes

- `src/ir/transforms/lower_composite_ops_pass.cpp` — `EmitBarrier`, `EmitEpilogueReset` (1D + 2D), `MakeNegation` helper; `ValidateMeshSignalShape` (now enforced for all seven collectives, including `all_to_all_v`); deleted `SignalGenerationTable` / `CheckCollectiveLoopUse` / `scope_depth_`; all seven collectives converted; `IsTensorCollective` extended to include `all_to_all_v`; `all_to_all_v` migrated to self-clearing credit barrier
- `src/ir/transforms/synthesize_allreduce_signals_pass.cpp` — keeps `repeating_scope_depth_` so a HOST allreduce (explicit or synthesized signal) is rejected inside `for`/`while` loops, since the host builtin is not self-clearing
- `tests/ut/ir/transforms/test_lower_composite_ops.py` — AtomicAdd/Ge protocol tests, epilogue checks, loop/conditional acceptance (InCore), rejections (158 passed); updated `all_to_all_v` loop tests to expect success
- `tests/ut/ir/transforms/test_materialize_comm_domain_scopes.py` — HOST loop-allreduce tests remain `*_is_rejected` (loop restriction retained on the HOST signal-synthesis path)
- `tests/st/distributed/test_l3_self_notify_credit_reset.py` — self-addressed notify + negative AtomicAdd validation
- `tests/st/distributed/collectives/test_l3_tensor_collective_signal_reuse.py` — back-to-back `all_to_all`, `allgather`, `reduce_scatter` on sim (P=2)
- `docs/en/dev/` + `docs/zh/dev/` — distributed_ops + pass docs rewritten for self-clearing protocol; loop-safety scoped to InCore composites on the HOST rail

### Follow-ups

- Ring allreduce's epilogue reset still derives its row count from the static signal shape (`2*(NR-1)`) rather than runtime `nranks` (review F4) — deferred per review; a tracking issue can be opened on request.
- `broadcast` has no read-complete barrier before the `get` (review) — deferred: no failing test/workload, and the fix is a contract question; can be revisited with a repro.

## Test plan

- [x] UT: 181 passed (`test_lower_composite_ops` + `test_materialize_comm_domain_scopes` + `test_lower_host_tensor_collectives`), including the HOST loop-rejection tests and the InCore loop-acceptance tests
- [x] ST: `test_l3_tensor_collective_signal_reuse.py` — back-to-back reuse, 3 passed (P=2; P=4 variants skip without 4 devices)
- [x] ST: `test_l3_self_notify_credit_reset.py` — self-addressed negative AtomicAdd, 2 passed
- [x] Lints: ruff, clang-format, cpplint, pyright, markdownlint, headers — all clean
- [ ] NPU verification pending (sim only)
