### PR TITLE
fix(ir): Require the declared mode attr on every cast op

### DIFF
--- a/docs/en/dev/ir/05-operators.md
+++ b/docs/en/dev/ir/05-operators.md
@@ -171,19 +171,22 @@ TypePtr DeduceCastType(const std::vector<ExprPtr>& args,
                        const std::vector<std::pair<std::string, std::any>>& kwargs) {
   auto input = std::dynamic_pointer_cast<const TensorType>(args[0]->GetType());
 
-  // Required kwarg
+  // Required kwargs — `cast` declares both `target_type` and `mode`, and codegen
+  // reads `mode` unconditionally, so a missing one must fail here rather than
+  // silently default to round_mode NONE.
   auto it = kwargs.find("target_type");
   CHECK(it != kwargs.end()) << "tensor.cast requires 'target_type'";
   DataType target = static_cast<DataType>(std::any_cast<int>(it->second));
 
-  // Optional with default
-  int mode = 0;
-  auto mode_it = kwargs.find("mode");
-  if (mode_it != kwargs.end()) mode = std::any_cast<int>(mode_it->second);
+  CHECK(kwargs.find("mode") != kwargs.end()) << "tensor.cast requires 'mode'";
 
   return std::make_shared<TensorType>(input->shape_, target);
 }
 ```
+
+A genuinely optional kwarg (one codegen reads with a fallback, such as `tile.log`'s
+`high_precision`) is read via `Call::GetKwarg<T>(key, default_value)` instead of a
+`CHECK` — see `include/pypto/ir/expr.h`.
 
 ### Python - Using Kwargs
 

--- a/docs/en/dev/ir/05-operators.md
+++ b/docs/en/dev/ir/05-operators.md
@@ -171,14 +171,20 @@ TypePtr DeduceCastType(const std::vector<ExprPtr>& args,
                        const std::vector<std::pair<std::string, std::any>>& kwargs) {
   auto input = std::dynamic_pointer_cast<const TensorType>(args[0]->GetType());
 
+  // `kwargs` is a vector of pairs, not a map — scan it to look a key up.
+  auto find_kwarg = [&kwargs](const std::string& key) {
+    return std::find_if(kwargs.begin(), kwargs.end(),
+                        [&key](const auto& kv) { return kv.first == key; });
+  };
+
   // Required kwargs — `cast` declares both `target_type` and `mode`, and codegen
   // reads `mode` unconditionally, so a missing one must fail here rather than
   // silently default to round_mode NONE.
-  auto it = kwargs.find("target_type");
+  auto it = find_kwarg("target_type");
   CHECK(it != kwargs.end()) << "tensor.cast requires 'target_type'";
   DataType target = static_cast<DataType>(std::any_cast<int>(it->second));
 
-  CHECK(kwargs.find("mode") != kwargs.end()) << "tensor.cast requires 'mode'";
+  CHECK(find_kwarg("mode") != kwargs.end()) << "tensor.cast requires 'mode'";
 
   return std::make_shared<TensorType>(input->shape_, target);
 }

--- a/docs/zh-cn/dev/ir/05-operators.md
+++ b/docs/zh-cn/dev/ir/05-operators.md
@@ -165,19 +165,21 @@ TypePtr DeduceCastType(const std::vector<ExprPtr>& args,
                        const std::vector<std::pair<std::string, std::any>>& kwargs) {
   auto input = std::dynamic_pointer_cast<const TensorType>(args[0]->GetType());
 
-  // Required kwarg
+  // Required kwargs — `cast` declares both `target_type` and `mode`, and codegen
+  // reads `mode` unconditionally, so a missing one must fail here rather than
+  // silently default to round_mode NONE.
   auto it = kwargs.find("target_type");
   CHECK(it != kwargs.end()) << "tensor.cast requires 'target_type'";
   DataType target = static_cast<DataType>(std::any_cast<int>(it->second));
 
-  // Optional with default
-  int mode = 0;
-  auto mode_it = kwargs.find("mode");
-  if (mode_it != kwargs.end()) mode = std::any_cast<int>(mode_it->second);
+  CHECK(kwargs.find("mode") != kwargs.end()) << "tensor.cast requires 'mode'";
 
   return std::make_shared<TensorType>(input->shape_, target);
 }
 ```
+
+真正可选的 kwarg（codegen 读取时带回退值，例如 `tile.log` 的 `high_precision`）应使用
+`Call::GetKwarg<T>(key, default_value)` 读取，而不是 `CHECK`——参见 `include/pypto/ir/expr.h`。
 
 ### Python - 使用 Kwargs
 

--- a/docs/zh-cn/dev/ir/05-operators.md
+++ b/docs/zh-cn/dev/ir/05-operators.md
@@ -165,14 +165,20 @@ TypePtr DeduceCastType(const std::vector<ExprPtr>& args,
                        const std::vector<std::pair<std::string, std::any>>& kwargs) {
   auto input = std::dynamic_pointer_cast<const TensorType>(args[0]->GetType());
 
+  // `kwargs` is a vector of pairs, not a map — scan it to look a key up.
+  auto find_kwarg = [&kwargs](const std::string& key) {
+    return std::find_if(kwargs.begin(), kwargs.end(),
+                        [&key](const auto& kv) { return kv.first == key; });
+  };
+
   // Required kwargs — `cast` declares both `target_type` and `mode`, and codegen
   // reads `mode` unconditionally, so a missing one must fail here rather than
   // silently default to round_mode NONE.
-  auto it = kwargs.find("target_type");
+  auto it = find_kwarg("target_type");
   CHECK(it != kwargs.end()) << "tensor.cast requires 'target_type'";
   DataType target = static_cast<DataType>(std::any_cast<int>(it->second));
 
-  CHECK(kwargs.find("mode") != kwargs.end()) << "tensor.cast requires 'mode'";
+  CHECK(find_kwarg("mode") != kwargs.end()) << "tensor.cast requires 'mode'";
 
   return std::make_shared<TensorType>(input->shape_, target);
 }

--- a/src/ir/op/tensor_ops/unary.cpp
+++ b/src/ir/op/tensor_ops/unary.cpp
@@ -16,6 +16,7 @@
  * This file implements unary operations for tensors that operate element-wise.
  */
 
+#include <algorithm>
 #include <any>
 #include <memory>
 #include <string>
@@ -223,7 +224,15 @@ TypePtr DeduceTensorCastType(const std::vector<ExprPtr>& args,
       << " equals input dtype; same-dtype cast is not a valid operation. "
       << "Remove the cast or use a different target_type.";
 
-  // mode kwarg is optional, not used in type deduction
+  // `mode` does not affect type deduction, but ConvertTensorToTileOps forwards this
+  // op's kwargs verbatim to tile.cast, whose codegen reads `mode` unconditionally.
+  // Require it here so a missing kwarg is reported against the op the caller wrote
+  // rather than surfacing later as a tile.cast failure inside the conversion pass.
+  const bool found_mode =
+      std::any_of(kwargs.begin(), kwargs.end(), [](const auto& kv) { return kv.first == "mode"; });
+  CHECK(found_mode) << "tensor.cast requires a 'mode' kwarg (round mode: none(0), rint(1), "
+                       "round(2), floor(3), ceil(4), trunc(5), odd(6)). Pass mode=\"round\" (2) "
+                       "to match the pl.cast / tensor_ops.cast default.";
 
   // Cast preserves shape and the input's valid region; only dtype changes.
   return DeduceTensorUnaryResultType(tensor_type, target_dtype);

--- a/src/ir/op/tile_ops/unary.cpp
+++ b/src/ir/op/tile_ops/unary.cpp
@@ -17,6 +17,7 @@
  * Unary operations take a TileType and return a TileType with the same shape.
  */
 
+#include <algorithm>
 #include <any>
 #include <cstddef>
 #include <memory>
@@ -138,6 +139,18 @@ TypePtr DeduceTileCastType(const std::vector<ExprPtr>& args,
     }
   }
   CHECK(found_target_type) << "tile.cast requires 'target_type' kwarg";
+
+  // `mode` is a declared attr that codegen reads unconditionally
+  // (MakeModalCodegenPTO -> pto.tcvt {rmode = ...}). A missing kwarg silently
+  // reads back as 0 == round_mode NONE instead of the DSL default ROUND, so
+  // require it here rather than let a mode-less cast reach the backend.
+  const bool found_mode =
+      std::any_of(kwargs.begin(), kwargs.end(), [](const auto& kv) { return kv.first == "mode"; });
+  CHECK(found_mode) << op_name
+                    << " requires a 'mode' kwarg (round mode: none(0), rint(1), round(2), "
+                       "floor(3), ceil(4), trunc(5), odd(6)). Pass mode=\"round\" (2) to match "
+                       "the pl.cast / tile_ops.cast default, or mode=\"none\" (0) when the "
+                       "conversion cannot round (e.g. int -> int).";
 
   // Reject same-dtype cast: the hardware pto.tcvt instruction is for
   // cross-dtype conversion, and a same-dtype invocation can corrupt values

--- a/src/ir/transforms/op_conversion_registry.cpp
+++ b/src/ir/transforms/op_conversion_registry.cpp
@@ -49,6 +49,15 @@ using tile_conversion_utils::MakeZeroOffsets;
 
 namespace {
 
+// tile.cast round mode: None(0), RINT(1), ROUND(2), FLOOR(3), CEIL(4), TRUNC(5), ODD(6).
+// `mode` is a declared attr that codegen reads unconditionally when emitting
+// `pto.tcvt {rmode = ...}`, so every tile.cast built here must supply one.
+// Follows the LowerCompositeOps convention: ROUND only where a conversion actually
+// rounds (float -> int), NONE where it cannot — all the index casts below are
+// int -> int, where the rounding mode is a no-op.
+constexpr int kCastModeNone = 0;
+constexpr int kCastModeRound = 2;
+
 bool IsConstOne(const ExprPtr& expr) { return IsConstValue(expr, 1); }
 
 // A5 index-form gather needs full-tile flat indices; A2A3 keeps the legacy
@@ -248,7 +257,7 @@ void OpConversionRegistry::RegisterElementwiseBinaryOps() {
           if (arg_types[i]->dtype_ == *promoted_dtype) continue;
           std::vector<std::pair<std::string, std::any>> cast_kwargs = {
               {"target_type", *promoted_dtype},
-              {"mode", 2},  // round
+              {"mode", kCastModeRound},
           };
           auto cast_call = op_reg.Create("tile.cast", {converted_args[i]}, cast_kwargs, span);
           const std::string name = i == 0 ? "div_lhs_cast" : "div_rhs_cast";
@@ -563,7 +572,8 @@ void OpConversionRegistry::RegisterMemoryOps() {
     // row_base[k] = index.flat[k] * d, broadcast across cols; flat_idx = index.flat[k]*d + c.
     ExprPtr idx_src = args[1];
     if (idx_tile->dtype_ != compute_dtype) {
-      idx_src = emit("tile.cast", {idx_src}, {{"target_type", compute_dtype}}, "su_idx_i32");
+      idx_src = emit("tile.cast", {idx_src}, {{"target_type", compute_dtype}, {"mode", kCastModeNone}},
+                     "su_idx_i32");
     }
     auto idx_flat =
         emit("tile.reshape", {idx_src, MakeShapeTuple({make_idx(n), one}, span)}, {}, "su_idx_flat");
@@ -571,7 +581,8 @@ void OpConversionRegistry::RegisterMemoryOps() {
     auto flat_idx = emit("tile.row_expand_add", {col_nd, row_base}, {}, "su_flat_idx");
     // Narrow the finished row-major [n, d] flat indices to the tscatter-required width.
     if (idx_dtype != compute_dtype) {
-      flat_idx = emit("tile.cast", {flat_idx}, {{"target_type", idx_dtype}}, "su_flat_idx_cast");
+      flat_idx = emit("tile.cast", {flat_idx}, {{"target_type", idx_dtype}, {"mode", kCastModeNone}},
+                      "su_flat_idx_cast");
     }
 
     const int dt_bytes = static_cast<int>(dt.GetBit()) / 8;
@@ -1400,13 +1411,13 @@ void OpConversionRegistry::RegisterGatherOps() {
           };
           ExprPtr idx_i32 = idx_2d;
           if (idx_dtype != compute_dtype) {
-            idx_i32 =
-                emit_to(stmts, "tile.cast", {idx_2d}, {{"target_type", compute_dtype}}, prefix + "_idx_i32");
+            idx_i32 = emit_to(stmts, "tile.cast", {idx_2d},
+                              {{"target_type", compute_dtype}, {"mode", kCastModeNone}}, prefix + "_idx_i32");
           }
           if (rows == 1) {
-            return idx_dtype == compute_dtype ? idx_i32
-                                              : emit_to(stmts, "tile.cast", {idx_i32},
-                                                        {{"target_type", idx_dtype}}, prefix + "_flat_cast");
+            if (idx_dtype == compute_dtype) return idx_i32;
+            return emit_to(stmts, "tile.cast", {idx_i32},
+                           {{"target_type", idx_dtype}, {"mode", kCastModeNone}}, prefix + "_flat_cast");
           }
 
           std::vector<std::pair<std::string, std::any>> ci_kw = {{"dtype", compute_dtype},
@@ -1432,7 +1443,8 @@ void OpConversionRegistry::RegisterGatherOps() {
             flat = emit_to(stmts, "tile.row_expand_add", {idx_i32, row_base}, {}, prefix + "_flat_idx");
           }
           if (idx_dtype != compute_dtype) {
-            return emit_to(stmts, "tile.cast", {flat}, {{"target_type", idx_dtype}}, prefix + "_flat_cast");
+            return emit_to(stmts, "tile.cast", {flat}, {{"target_type", idx_dtype}, {"mode", kCastModeNone}},
+                           prefix + "_flat_cast");
           }
           return flat;
         };

--- a/tests/ut/ir/operators/test_op_registry.py
+++ b/tests/ut/ir/operators/test_op_registry.py
@@ -400,8 +400,9 @@ def test_cast_with_datatype_kwarg():
     type_fp16 = ir.TensorType([dim8], DataType.FP16)
     var_a = ir.Var("a", type_fp16, span)
 
-    # Cast from FP16 to FP32
-    kwargs = {"target_type": DataType.FP32}
+    # Cast from FP16 to FP32. `mode` is a declared attr codegen reads unconditionally,
+    # so tensor.cast requires it alongside target_type (2 == round, the DSL default).
+    kwargs = {"target_type": DataType.FP32, "mode": 2}
     call = ir.create_op_call("tensor.cast", [var_a], kwargs, span)
 
     # Check result type

--- a/tests/ut/ir/operators/test_tile_ops.py
+++ b/tests/ut/ir/operators/test_tile_ops.py
@@ -635,6 +635,28 @@ class TestTileUnaryOps:
         with pytest.raises(ValueError, match="same-dtype cast is not a valid operation"):
             tile.cast(src_var, DataType.FP32)
 
+    def test_tile_cast_requires_mode_kwarg(self):
+        """tile.cast must reject a missing `mode` kwarg at construction time.
+
+        `mode` is a declared attr that codegen reads unconditionally when emitting
+        `pto.tcvt {rmode = ...}`. A missing kwarg reads back as 0 (round_mode NONE)
+        instead of the DSL default ROUND, so DeduceTileCastType rejects it rather
+        than letting a mode-less cast reach the backend.
+        """
+        span = ir.Span.unknown()
+        src_type = ir.TileType(
+            [ir.ConstInt(8, DataType.INT32, span), ir.ConstInt(16, DataType.INT32, span)],
+            DataType.INT32,
+        )
+        src_var = ir.Var("src", src_type, span)
+
+        with pytest.raises(ValueError, match="requires a 'mode' kwarg"):
+            ir.create_op_call("tile.cast", [src_var], {"target_type": DataType.INT16}, span)
+
+        # The canonical DSL constructor injects mode="round" — it must still work.
+        call = tile.cast(src_var, DataType.INT16)
+        assert dict(call.kwargs)["mode"] == 2
+
     def test_tile_rsqrt_preserves_input_valid_shape(self):
         """tile.rsqrt must propagate the source TileView's valid_shape (issue #1370)."""
         sliced = self._make_sliced_tile_with_valid_shape()

--- a/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
+++ b/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
@@ -3045,11 +3045,7 @@ class TestScatterUpdateConversion:
                 result: pl.Tensor[[16, 64], pl.FP16] = self.main_incore_0(index, src)
                 return result
 
-        # NOTE: bypass tracks a known pass bug — ConvertTensorToTileOps scatter_update
-        # emits tile.cast without the declared `mode` attr (op_conversion_registry.cpp),
-        # which fails the print->parse roundtrip. Remove NONE once the pass is fixed.
-        with passes.PassContext([], passes.VerificationLevel.NONE):
-            After = passes.convert_tensor_to_tile_ops()(Before)
+        After = passes.convert_tensor_to_tile_ops()(Before)
         text = ir.python_print(After)
         # Assert exact op presence: scatter_update must lower to the index-form tile.scatter,
         # never the mask-form tile.scatter_mask (substring "tile.scatter" would match both).
@@ -3057,6 +3053,12 @@ class TestScatterUpdateConversion:
         assert "pl.tile.scatter_mask(" not in text
         assert text.count("pl.tile.scatter(") >= 1
         assert "scatter_update" not in text
+        # The flat-index narrowing cast must carry the declared `mode` attr: codegen reads
+        # it unconditionally when emitting `pto.tcvt {rmode = ...}`. This i32 -> i16 index
+        # cast cannot round, so it must be `none`(0), not `round`(2).
+        casts = _find_calls_to(_require_function(After, "main_incore_0"), "tile.cast")
+        assert len(casts) == 1, f"expected one flat-index cast, got {len(casts)}"
+        assert dict(casts[0].kwargs)["mode"] == 0
 
     def test_scatter_update_fp16_rejects_oversized_flat_index(self):
         """2-byte dst with m*d > 32767 overflows the i16 flat index — must raise, not miscompile."""
@@ -3467,6 +3469,41 @@ class TestConvertGatherOp:
 
         After = passes.convert_tensor_to_tile_ops()(Before)
         ir.assert_structural_equal(After, Expected)
+
+    def test_gather_int16_index_casts_carry_mode(self):
+        """A5 INT16-index gather: both flat-index tile.casts carry the `mode` attr.
+
+        An INT16 index (legal with a 16-bit input) is widened to INT32 for the flat-index
+        arithmetic and narrowed back afterwards. Codegen reads `mode` unconditionally when
+        emitting `pto.tcvt {rmode = ...}`; both casts are int -> int and cannot round, so
+        each must carry `none`(0).
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                inp: pl.Tensor[[4, 16], pl.FP16],
+                idx: pl.Tensor[[4, 8], pl.INT16],
+            ) -> pl.Tensor[[4, 8], pl.FP16]:
+                out: pl.Tensor[[4, 8], pl.FP16] = pl.tensor.gather(inp, dim=-1, index=idx)
+                return out
+
+            @pl.function
+            def main(
+                self,
+                inp: pl.Tensor[[4, 16], pl.FP16],
+                idx: pl.Tensor[[4, 8], pl.INT16],
+            ) -> pl.Tensor[[4, 8], pl.FP16]:
+                out: pl.Tensor[[4, 8], pl.FP16] = self.main_incore_0(inp, idx)
+                return out
+
+        After = passes.convert_tensor_to_tile_ops()(Before)
+        casts = _find_calls_to(_require_function(After, "main_incore_0"), "tile.cast")
+        assert len(casts) == 2, f"expected widen + narrow casts, got {len(casts)}"
+        for cast in casts:
+            assert dict(cast.kwargs)["mode"] == 0
 
     def test_gather_conversion_expand(self):
         """A5 expand gather (K > S1): flat uses src cols, not output cols."""


### PR DESCRIPTION
## Summary

`ConvertTensorToTileOps` emitted five `tile.cast` calls carrying only `target_type` and no `mode`, even though `tile.cast` declares both attrs — two in the `scatter_update` flat-index lowering, three in the `tensor.gather` A5 flat-index helper.

Two consequences:

1. **The print→parse roundtrip failed.** The printer emits only the kwargs present, and a reparse re-injects the DSL default, so `assert_structural_equal` reported `Kwargs size mismatch (1 != 2)`. A `VerificationLevel.NONE` bypass in the `scatter_update` test existed solely to mask this.
2. **The emitted round mode was decided by a default, not by the pass.** Codegen reads `mode` unconditionally via `GetKwarg<int>` (`expr.h`), which returns `0` when the kwarg is absent, and `round_modes[0] == "NONE"` (`pto_ops_shared.cpp`).

## What the fix does

All five sites cast between INT32 and INT16 **index** tiles, where rounding cannot occur, so they now pass `mode=none(0)` explicitly. This follows the `LowerCompositeOps` convention — `round` only where a conversion actually rounds (float→int), `none` where it cannot — and leaves the generated `.pto` **byte-identical**. The `tensor.div` promotion cast keeps `round(2)`.

So this is IR hygiene, not a codegen change. Verified by compiling the FP16 `scatter_update` kernel before and after: both emit `pto.tcvt ... {rmode = #pto<round_mode NONE>}`.

To stop the omission recurring, `DeduceTileCastType` and `DeduceTensorCastType` now `CHECK` that `mode` is present, symmetric with the existing `target_type` check. `tensor.cast` is included because `ConvertTensorToTileOps` forwards its kwargs verbatim to `tile.cast` — without it, a missing kwarg would surface as a `tile.cast` failure inside the pass rather than against the op the caller wrote.

Audited every construction path: all other C++ emitters (`legalize_tile_cast_pass`, `lower_composite_ops_pass`, `flatten_tile_nd_to_2d/batch_matmul`) already pass `mode`; both Python wrappers default `mode="round"`; the `.pto` deserializer never re-runs `f_deduce_type`. One test built a `tensor.cast` without `mode` and was updated.

## Testing

- Full unit suite: **8016 passed, 2 skipped**.
- `scatter_update` test drops the `VerificationLevel.NONE` bypass and now asserts the emitted `mode` value.
- New coverage for the previously untested gather path (A5 + INT16 index) and for the construction-time guard.
- `clang-tidy` clean; all pre-commit hooks pass.

## Note for reviewers

`tests/ut/runtime/test_benchmark.py::test_benchmark_l3_ignores_prepare_setup_groups` fails on current `main`, independent of this PR: `478ddad5`'s test stub `_CompiledEmittingPrewarmAtPrepare.prepare()` does not accept the `persistent=` kwarg that `340d6c56` added to `prepare()` — two PRs that were green independently collided on merge.

It does not show up in CI because the module `pytest.importorskip`s `simpler_setup`, which is absent on the unit-test runner, so the whole file skips there. It reproduces in any local environment with the simpler runtime installed. Untouched here.
