### PR TITLE
fix(codegen): Reject unsatisfiable user task dependency edges

### DIFF
--- a/docs/en/dev/codegen/01-orchestration_codegen.md
+++ b/docs/en/dev/codegen/01-orchestration_codegen.md
@@ -490,7 +490,11 @@ becomes a *compiler-owned* MANUAL scope when fully covered, and otherwise stays
 AUTO with its representable edges emitted on top of runtime auto-tracking. A
 hand-placed `pl.scope()` always keeps `manual=false`, and has its partial edges
 stripped if analysis falls back. Codegen merges the two lists in that order and
-deduplicates by Var identity before emitting the stack array.
+deduplicates by Var identity before emitting the stack array, tagging each entry
+with its provenance (`DepEdge::user_written`).
+
+The provenance decides what happens when an edge fails to resolve to a live
+TaskId binding — see [Unresolvable dep edges](#unresolvable-dep-edges).
 
 ### TaskId sourcing
 
@@ -524,6 +528,36 @@ and `array_carry_vars_` on entry and restores them on exit, so a binding
 produced inside a scope does not leak to an enclosing scope where its identifier
 would be out of C++ scope. Loop / branch carries are declared *before* their
 body's `PTO2_SCOPE`, so they correctly survive the block.
+
+### Unresolvable dep edges
+
+A consequence of that lifetime rule: a dep edge naming a TaskId produced in a
+scope that has **already closed** cannot resolve — the binding was restored away
+on scope exit. Codegen's response depends on the edge's provenance:
+
+| Edge provenance | Behavior when unresolvable |
+| --------------- | -------------------------- |
+| Compiler-derived (`compiler_manual_dep_edges`) | Silently skipped. These are a best-effort hazard patch; `PrepareCrossScopeTaskIdHoists` already LCA-hoists the ones it can, and dropping the rest is safe because the pass only ever *adds* ordering |
+| User-written (`deps=[...]`) | **Hard error** — `CHECK_SPAN` raises a `pypto::ValueError` naming the TaskId and the DSL source line |
+
+Provenance is the attr key, with one exception: the `system.task_dummy`
+phase-fence barrier synthesised by
+[`ExpandManualPhaseFence`](../passes/37-expand_manual_phase_fence.md) carries its
+fanin under `manual_dep_edges` too, so a carrier marked `attrs["dummy_task"]` is
+classified compiler-authored and keeps the tolerant skip.
+
+Dropping a user edge would leave the consumer unordered against its producer and
+surface at runtime as a silent stale read, so codegen refuses to emit rather than
+emit wrong code. `ResolveDepEdgeBinding` is the single resolve-and-validate site
+both `CountManualDeps` (array sizing) and `EmitManualDeps` (array fill) route
+through, so the two can never disagree on which edges survive.
+
+The scope that closed need not be user-written. `MaterializeRuntimeScopes` wraps
+every `ForStmt` body and every `IfStmt` branch body in its own AUTO scope, so
+this fires on ordinary orchestration code with no `pl.scope()` / `pl.manual_scope()`
+in sight — e.g. a TaskId captured inside a `pl.range` body and depended on after
+the loop. The fix is to keep the consumer in the producer's scope, or hoist the
+producer outward.
 
 One exception applies to the `array_carry_vars_` restore on a `MANUAL` scope: an
 array carry registered *inside* the scope whose backing array was declared in

--- a/docs/en/dev/codegen/01-orchestration_codegen.md
+++ b/docs/en/dev/codegen/01-orchestration_codegen.md
@@ -540,11 +540,13 @@ on scope exit. Codegen's response depends on the edge's provenance:
 | Compiler-derived (`compiler_manual_dep_edges`) | Silently skipped. These are a best-effort hazard patch; `PrepareCrossScopeTaskIdHoists` already LCA-hoists the ones it can, and dropping the rest is safe because the pass only ever *adds* ordering |
 | User-written (`deps=[...]`) | **Hard error** — `CHECK_SPAN` raises a `pypto::ValueError` naming the TaskId and the DSL source line |
 
-Provenance is the attr key, with one exception: the `system.task_dummy`
-phase-fence barrier synthesised by
-[`ExpandManualPhaseFence`](../passes/37-expand_manual_phase_fence.md) carries its
-fanin under `manual_dep_edges` too, so a carrier marked `attrs["dummy_task"]` is
-classified compiler-authored and keeps the tolerant skip.
+Provenance is the attr key. Note that `attrs["dummy_task"]` is *not* an
+authorship marker: the parser stamps it on a user-written
+`pl.system.task_dummy(deps=[...])` exactly as
+[`ExpandManualPhaseFence`](../passes/37-expand_manual_phase_fence.md) does on the
+barriers it synthesises, so every `manual_dep_edges` carrier is enforced. The
+synthesised barrier only ever names a TaskId live in the manual scope it
+rewrites, so its fanin always resolves.
 
 Dropping a user edge would leave the consumer unordered against its producer and
 surface at runtime as a silent stale read, so codegen refuses to emit rather than

--- a/docs/zh-cn/dev/codegen/01-orchestration_codegen.md
+++ b/docs/zh-cn/dev/codegen/01-orchestration_codegen.md
@@ -519,10 +519,11 @@ MANUAL）在进入时快照 `manual_task_id_map_` 与 `array_carry_vars_`、退�
 | 编译器推导（`compiler_manual_dep_edges`） | 静默跳过。这类边是尽力而为的 hazard 补丁；`PrepareCrossScopeTaskIdHoists` 已对能处理的部分做了 LCA 提升，丢弃其余是安全的，因为该 pass 只会*增加*定序 |
 | 用户书写（`deps=[...]`） | **硬报错**——`CHECK_SPAN` 抛出 `pypto::ValueError`，并指出该 TaskId 与对应的 DSL 源码行 |
 
-来源由 attr key 判定，但有一个例外：
-[`ExpandManualPhaseFence`](../passes/37-expand_manual_phase_fence.md) 合成的
-`system.task_dummy` phase-fence barrier 同样把 fanin 放在 `manual_dep_edges` 下，
-因此带有 `attrs["dummy_task"]` 标记的载体被归类为编译器生成，保留静默跳过的行为。
+来源由 attr key 判定。注意 `attrs["dummy_task"]` **不是**作者身份标记：parser 会把
+它打在用户书写的 `pl.system.task_dummy(deps=[...])` 上，与
+[`ExpandManualPhaseFence`](../passes/37-expand_manual_phase_fence.md) 给自己合成的
+barrier 打的完全相同，因此所有 `manual_dep_edges` 载体一律强制校验。合成的 barrier
+只会引用其所改写的 manual scope 内仍然活跃的 TaskId，故其 fanin 必然可解析。
 
 丢弃用户边会让消费者与其生产者之间失去定序，在运行时表现为静默的陈旧数据读取，
 因此 codegen 宁可拒绝生成，也不生成错误的代码。`ResolveDepEdgeBinding` 是唯一的

--- a/docs/zh-cn/dev/codegen/01-orchestration_codegen.md
+++ b/docs/zh-cn/dev/codegen/01-orchestration_codegen.md
@@ -473,7 +473,11 @@ call 上）。该 pass 从不分析用户写的 MANUAL scope——在 `pl.manual
 在被完整覆盖时会成为*编译器自有*的 MANUAL scope，否则保持 AUTO，其可表示的边
 叠加在 runtime 自动追踪之上发出；手工放置的 `pl.scope()` 始终保持
 `manual=false`，一旦分析回退则会剥离其部分推导边。Codegen 会按这个顺序合并两组
-列表，并按 Var identity 去重后再发出栈数组。
+列表，并按 Var identity 去重后再发出栈数组，同时为每个条目标注其来源
+（`DepEdge::user_written`）。
+
+当某条依赖边无法解析到活跃的 TaskId 绑定时，处理方式取决于该来源——参见
+[无法解析的依赖边](#无法解析的依赖边)。
 
 ### TaskId 的来源
 
@@ -503,6 +507,33 @@ call 上）。该 pass 从不分析用户写的 MANUAL scope——在 `pl.manual
 MANUAL）在进入时快照 `manual_task_id_map_` 与 `array_carry_vars_`、退出时恢复，
 因此在某作用域内产生的绑定不会泄漏到外层作用域（否则其标识符会超出 C++ 作用域）。
 循环 / 分支的 carry 在其 body 的 `PTO2_SCOPE` *之前*声明，因此能正确地在块结束后存活。
+
+### 无法解析的依赖边
+
+上述生命周期规则带来一个结果：若某条依赖边引用的 TaskId 产生于一个**已经关闭**的
+作用域，则它无法解析——该绑定在作用域退出时已被恢复掉。Codegen 的处理方式取决于
+这条边的来源：
+
+| 边的来源 | 无法解析时的行为 |
+| -------- | ---------------- |
+| 编译器推导（`compiler_manual_dep_edges`） | 静默跳过。这类边是尽力而为的 hazard 补丁；`PrepareCrossScopeTaskIdHoists` 已对能处理的部分做了 LCA 提升，丢弃其余是安全的，因为该 pass 只会*增加*定序 |
+| 用户书写（`deps=[...]`） | **硬报错**——`CHECK_SPAN` 抛出 `pypto::ValueError`，并指出该 TaskId 与对应的 DSL 源码行 |
+
+来源由 attr key 判定，但有一个例外：
+[`ExpandManualPhaseFence`](../passes/37-expand_manual_phase_fence.md) 合成的
+`system.task_dummy` phase-fence barrier 同样把 fanin 放在 `manual_dep_edges` 下，
+因此带有 `attrs["dummy_task"]` 标记的载体被归类为编译器生成，保留静默跳过的行为。
+
+丢弃用户边会让消费者与其生产者之间失去定序，在运行时表现为静默的陈旧数据读取，
+因此 codegen 宁可拒绝生成，也不生成错误的代码。`ResolveDepEdgeBinding` 是唯一的
+解析并校验入口，`CountManualDeps`（数组定长）与 `EmitManualDeps`（数组填充）都经由
+它，因此两者对"哪些边存活"的判断绝不会不一致。
+
+被关闭的作用域不一定由用户书写。`MaterializeRuntimeScopes` 会把每个 `ForStmt`
+body 和每个 `IfStmt` 分支 body 各自包进一个 AUTO 作用域，因此在完全没有出现
+`pl.scope()` / `pl.manual_scope()` 的普通编排代码中也会触发——例如在 `pl.range`
+body 内捕获 TaskId、却在循环之后依赖它。修复方式是把消费者放到生产者所在的
+作用域内，或把生产者外提。
 
 对 `MANUAL` 作用域的 `array_carry_vars_` 恢复有一个例外：在该作用域 *内部* 注册、
 但其底层数组声明于 *外层* 作用域的 array carry 必须在恢复后存活。这就是将

--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -2473,14 +2473,18 @@ class OrchestrationStmtCodegen : public CodegenBase {
         return;
       }
     };
-    // ``manual_dep_edges`` is the user's ``deps=[...]`` on every carrier except
-    // one: ``ExpandManualPhaseFence`` synthesises a ``system.task_dummy``
-    // barrier under the same key (its fanin contract). That barrier is
-    // compiler-authored, so its edges must keep the tolerant skip — raising a
-    // "you wrote deps=[...]" error for it would name a Var the user never
-    // spelled.
-    const bool is_synthesised_barrier = call->GetAttr<bool>(kAttrDummyTask, false);
-    append_edges(kAttrManualDepEdges, /*user_written=*/!is_synthesised_barrier);
+    // Every ``manual_dep_edges`` carrier is treated as user-authored. The two
+    // shapes that reach here are a ``pl.submit(..., deps=[...])`` (via
+    // ``SubmitToCallView``) and a ``system.task_dummy`` barrier — and the
+    // barrier is NOT reliably compiler-authored: the parser stamps the same
+    // ``dummy_task`` attr on a user-written ``pl.system.task_dummy(deps=[...])``,
+    // whose edges must be enforced like any other user edge.
+    //
+    // ``ExpandManualPhaseFence`` also synthesises barriers under this key, but
+    // it only ever names a TaskId live in the same manual scope it rewrites, so
+    // those always resolve. Were one not to, raising is still the right answer —
+    // a dropped fanin there is a genuinely lost ordering edge.
+    append_edges(kAttrManualDepEdges, /*user_written=*/true);
     append_edges(kAttrCompilerManualDepEdges, /*user_written=*/false);
     return merged;
   }

--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -225,6 +225,17 @@ class OrchestrationStmtCodegen : public CodegenBase {
  public:
   using ManualTaskIdBinding = std::variant<int, std::string, std::vector<std::string>>;
 
+  /// One task dependency edge plus its provenance. ``user_written`` marks an
+  /// edge the user spelled as ``deps=[...]`` (``kAttrManualDepEdges``, or the
+  /// typed ``Submit::deps_`` projected through ``SubmitToCallView``) as opposed
+  /// to a compiler-derived hazard patch (``kAttrCompilerManualDepEdges``).
+  /// Only the former is an error when it fails to resolve — see
+  /// ``ResolveDepEdgeBinding``.
+  struct DepEdge {
+    VarPtr var;
+    bool user_written;
+  };
+
   explicit OrchestrationStmtCodegen(const ProgramPtr& prog, std::map<std::string, int>* func_ids,
                                     std::map<std::string, CoreType>* core_types,
                                     std::map<std::string, std::vector<std::string>>* func_signatures,
@@ -2446,10 +2457,10 @@ class OrchestrationStmtCodegen : public CodegenBase {
   /// runtime adds these on top of any auto-tracked deps in auto scope (final
   /// fanin = auto ∪ explicit), so this count fires whenever the parser
   /// attached ``deps=[...]`` to the Call.
-  std::vector<VarPtr> GetDependencyEdges(const CallPtr& call) const {
-    std::vector<VarPtr> merged;
+  std::vector<DepEdge> GetDependencyEdges(const CallPtr& call) const {
+    std::vector<DepEdge> merged;
     std::unordered_set<uint64_t> seen;
-    auto append_edges = [&](const char* key) {
+    auto append_edges = [&](const char* key, bool user_written) {
       for (const auto& [k, v] : call->attrs_) {
         if (k != key) continue;
         const auto* edges = std::any_cast<std::vector<VarPtr>>(&v);
@@ -2457,14 +2468,67 @@ class OrchestrationStmtCodegen : public CodegenBase {
         for (const auto& edge : *edges) {
           if (!edge) continue;
           if (!seen.insert(edge->UniqueId()).second) continue;
-          merged.push_back(edge);
+          merged.push_back(DepEdge{edge, user_written});
         }
         return;
       }
     };
-    append_edges(kAttrManualDepEdges);
-    append_edges(kAttrCompilerManualDepEdges);
+    // ``manual_dep_edges`` is the user's ``deps=[...]`` on every carrier except
+    // one: ``ExpandManualPhaseFence`` synthesises a ``system.task_dummy``
+    // barrier under the same key (its fanin contract). That barrier is
+    // compiler-authored, so its edges must keep the tolerant skip — raising a
+    // "you wrote deps=[...]" error for it would name a Var the user never
+    // spelled.
+    const bool is_synthesised_barrier = call->GetAttr<bool>(kAttrDummyTask, false);
+    append_edges(kAttrManualDepEdges, /*user_written=*/!is_synthesised_barrier);
+    append_edges(kAttrCompilerManualDepEdges, /*user_written=*/false);
     return merged;
+  }
+
+  /// Resolve ``edge`` to the live ``PTO2TaskId`` binding of its producer, or
+  /// ``nullptr`` when no binding is visible here — the producer sits in a
+  /// scope that has already closed, so its C++ local is gone and the edge is
+  /// dropped from the emitted ``set_dependencies`` call.
+  ///
+  /// Dropping is benign for a *compiler-derived* edge: it is a best-effort
+  /// hazard patch and may legitimately name a TaskId produced inside a closed
+  /// scope. For a *user-written* ``deps=[...]`` edge it is not — the consumer
+  /// would be left unordered against its producer, which surfaces at runtime
+  /// as a silent stale read — so fail loudly instead of emitting wrong code.
+  ///
+  /// ``CountManualDeps`` and ``EmitManualDeps`` both resolve through here, so
+  /// the dep-array sizing and the dep-array fill never disagree on which edges
+  /// survive.
+  const ManualTaskIdBinding* ResolveDepEdgeBinding(const DepEdge& edge, const CallPtr& call) const {
+    if (!edge.var) return nullptr;
+    const auto* binding = ResolveManualTaskIdBinding(edge.var.get());
+    if (binding == nullptr) {
+      if (edge.user_written) {
+        // ``GetSSABaseName`` can itself strip to "" (see the loop-var note
+        // below), so fall back on the stripped result, not the raw hint.
+        std::string name = GetSSABaseName(edge.var->name_hint_);
+        if (name.empty()) name = "<anonymous>";
+        CHECK_SPAN(false, call->span_)
+            << "Task dependency deps=[" << name << "] cannot be honored: its TaskId is produced inside a "
+            << "scope that has already closed at this point, so the ordering edge would be lost and the "
+            << "consumer could read stale data. Note that pl.range / pl.parallel loop bodies and if/else "
+            << "branches each open their own scope, so this fires even with no pl.scope() in the source. "
+            << "Either consume the TaskId inside the scope that produces it (for example, keep producer "
+            << "and consumer in one pl.manual_scope()), or hoist the producer out of the inner scope. For "
+            << "a TaskId produced in a loop body, consume it in that same body or accumulate the ids into "
+            << "an Array[N, TASK_ID] and depend on that after the loop.";
+      }
+      return nullptr;
+    }
+    // Invariant: a dep edge never resolves directly to a kernel-Call LHS
+    // (int-variant entry). The parser enforces that ``deps=[...]`` only
+    // accepts ``Scalar[TASK_ID]`` Vars, so an edge always resolves to a TaskId
+    // binding (string variant) or a TaskId iter_arg array (vector variant).
+    INTERNAL_CHECK_SPAN(std::get_if<int>(binding) == nullptr, call->span_)
+        << "Internal error: manual_dep_edge var '" << edge.var->name_hint_
+        << "' resolves to a kernel-Call LHS (int variant). Expected "
+        << "a Scalar[TASK_ID] Var (string variant).";
+    return binding;
   }
 
   void CollectCompilerDepTaskIds(const ProgramPtr& program) {
@@ -2546,18 +2610,12 @@ class OrchestrationStmtCodegen : public CodegenBase {
     return vars;
   }
 
-  size_t CountManualDeps(const std::vector<VarPtr>& edges, const CallPtr& call) const {
+  size_t CountManualDeps(const std::vector<DepEdge>& edges, const CallPtr& call) const {
     size_t total = 0;
     std::unordered_set<std::string> seen_names;
     for (const auto& edge : edges) {
-      if (!edge) continue;
-      const auto* binding = ResolveManualTaskIdBinding(edge.get());
+      const auto* binding = ResolveDepEdgeBinding(edge, call);
       if (!binding) continue;
-      if (std::get_if<int>(binding)) {
-        INTERNAL_CHECK_SPAN(false, call->span_) << "Internal error: manual_dep_edge var '" << edge->name_hint_
-                                                << "' resolves to a kernel-Call LHS (int variant). Expected "
-                                                << "a Scalar[TASK_ID] Var (string variant).";
-      }
       if (auto* names = std::get_if<std::vector<std::string>>(binding)) {
         for (const auto& name : *names) {
           if (seen_names.insert(name).second) {
@@ -2747,25 +2805,15 @@ class OrchestrationStmtCodegen : public CodegenBase {
       EmitDepArrayInsert(name, deps_arr, deps_cnt);
     };
     for (const auto& edge : edges) {
-      if (!edge) continue;
-      const auto* binding = ResolveManualTaskIdBinding(edge.get());
+      const auto* binding = ResolveDepEdgeBinding(edge, call);
       if (!binding) {
-        // Compiler-derived edges may reference TaskIds produced inside a
-        // closed ``pl.scope()`` that is no longer visible at this point in
-        // the manual scope.  ``CountManualDeps`` already skips these, so
-        // emit must be consistent: silently drop the out-of-scope edge.
+        // A compiler-derived edge may name a TaskId produced inside a closed
+        // ``pl.scope()`` that is no longer visible here. ``CountManualDeps``
+        // already skips it when sizing the array, so emit must be consistent
+        // and silently drop it too. (A *user* edge in this state threw above.)
         continue;
       }
-      if (std::get_if<int>(binding)) {
-        // Invariant: a ``manual_dep_edges`` entry should never resolve
-        // directly to a kernel-Call LHS (int-variant entry). The parser
-        // enforces that ``deps=[...]`` only accepts ``Scalar[TASK_ID]``
-        // Vars, so dep edges should always resolve to a TaskId binding
-        // (string variant) or a TaskId iter_arg array (vector variant).
-        INTERNAL_CHECK_SPAN(false, call->span_) << "Internal error: manual_dep_edge var '" << edge->name_hint_
-                                                << "' resolves to a kernel-Call LHS (int variant). Expected "
-                                                << "a Scalar[TASK_ID] Var (string variant).";
-      } else if (auto* names = std::get_if<std::vector<std::string>>(binding)) {
+      if (auto* names = std::get_if<std::vector<std::string>>(binding)) {
         // Array-carry iter_arg: include every valid slot.
         for (const auto& name : *names) {
           emit_one_dep(name);

--- a/tests/ut/codegen/test_orchestration_task_deps.py
+++ b/tests/ut/codegen/test_orchestration_task_deps.py
@@ -23,6 +23,23 @@ from pypto.backend import BackendType
 from pypto.ir.pass_manager import OptimizationStrategy, PassManager
 
 
+def _assert_dep_edge_rejected(program, edge_name: str) -> str:
+    """Assert the full pipeline rejects ``program`` over its ``edge_name`` dep edge.
+
+    A user-written ``deps=[...]`` edge whose TaskId is no longer bound — its
+    producer sits in a scope that has since closed — must raise a
+    ``pypto::ValueError`` naming that TaskId. Returns the diagnostic so callers
+    can assert on its remaining details.
+    """
+    with pytest.raises(ValueError) as excinfo:
+        _generate_orch_full_pipeline(program, allow_relaxed_verification=True)
+
+    msg = str(excinfo.value)
+    assert edge_name in msg, msg
+    assert "cannot be honored" in msg, msg
+    return msg
+
+
 def test_array_slot_task_id_usable_as_submit_dep():
     """Regression for issue #1577.
 
@@ -118,15 +135,20 @@ def test_direct_producer_dep_skips_is_valid_guard():
     assert re.search(r"\.set_dependencies\(", code), code
 
 
-def test_task_id_binding_does_not_leak_past_pl_scope():
-    """Regression for the issue #1577 lifetime hazard.
+def test_user_dep_edge_across_closed_scope_is_rejected():
+    """A user ``deps=[tid]`` naming a TaskId from a closed scope is an error.
 
-    A producer TaskId declared inside a nested AUTO ``pl.scope()`` names a
-    ``PTO2TaskId`` C++ local that dies at the block's closing brace. Codegen must
-    not reference it after the block — before the fix it emitted a
-    ``set_dependencies`` fill from the out-of-scope local (uncompilable C++).
-    The TaskId binding is now scoped to the ``PTO2_SCOPE`` it is produced in, so
-    its identifier appears exactly once (its declaration) in the generated code.
+    Regression for the issue #1577 lifetime hazard *and* for the silent-drop
+    that replaced it. A producer TaskId declared inside a nested AUTO
+    ``pl.scope()`` names a ``PTO2TaskId`` C++ local that dies at the block's
+    closing brace, so codegen cannot reference it afterwards. Emitting the
+    reference produced uncompilable C++ (#1577); silently dropping the edge
+    instead left the consumer unordered against its producer, which surfaces at
+    runtime as a stale read.
+
+    Codegen now rejects the program with an actionable ``pypto::ValueError``
+    rather than emitting either. Compiler-derived edges keep the tolerant
+    skip — see ``test_cross_scope_task_id_is_hoisted_for_set_dependencies``.
     """
 
     @pl.program
@@ -150,15 +172,9 @@ def test_task_id_binding_does_not_leak_past_pl_scope():
             b, _ = pl.submit(self.k2, x, deps=[scoped_tid])
             return b
 
-    code = _generate_orch_full_pipeline(P, allow_relaxed_verification=True)
-
-    # The producer tid is declared inside the inner PTO2_SCOPE block.
-    m = re.search(r"PTO2TaskId\s+(\w+)\s*=\s*task_0_outs\.task_id\(\);", code)
-    assert m, code
-    tid_name = m.group(1)
-    # It must NOT be referenced after its block closes — the binding is scoped
-    # out, so the only occurrence is its declaration (no dangling dep fill).
-    assert code.count(tid_name) == 1, f"TaskId local '{tid_name}' leaked past its pl.scope():\n{code}"
+    msg = _assert_dep_edge_rejected(P, "scoped_tid")
+    # The diagnostic also explains the fix.
+    assert "inside the scope that produces it" in msg, msg
 
 
 def test_cross_scope_task_id_is_hoisted_for_set_dependencies():
@@ -720,15 +736,17 @@ def test_compiler_auto_manual_scope_is_not_tied_to_function_name():
     assert f"{qk_tid.group(1)} = task_1_outs.task_id();" not in code, code
 
 
-def test_mixed_in_and_out_of_scope_deps_does_not_crash_codegen():
+def test_mixed_in_and_out_of_scope_deps_reports_user_error():
     """A deps= list mixing an in-scope TaskId with one scoped out of a closed
-    ``pl.scope()`` must not abort codegen.
+    ``pl.scope()`` is reported as a clean user error.
 
-    ``CountManualDeps`` skips the out-of-scope edge when sizing the dep stack
-    array, so the count is non-zero (the in-scope edge). ``EmitManualDeps`` must
-    skip the same out-of-scope edge rather than asserting on it — otherwise the
-    mixed case trips an INTERNAL_CHECK and crashes the compiler. The in-scope
-    edge is still wired; the out-of-scope edge is dropped.
+    The partially-satisfiable case must not degrade into either failure mode the
+    codegen has had historically: an ``INTERNAL_CHECK`` abort (compiler crash),
+    or silently wiring only the in-scope edge while dropping the other (the
+    consumer then races its out-of-scope producer). It raises a
+    ``pypto::ValueError`` naming the unsatisfiable edge — a ``ValueError`` in
+    Python, distinct from ``pypto.InternalError`` which derives from
+    ``RuntimeError``.
     """
 
     @pl.program
@@ -757,17 +775,141 @@ def test_mixed_in_and_out_of_scope_deps_does_not_crash_codegen():
             b, _ = pl.submit(self.k3, x, deps=[seed_tid, scoped_tid])
             return b
 
-    # Must not raise (regression: EmitManualDeps used to INTERNAL_CHECK here).
-    code = _generate_orch_full_pipeline(P, allow_relaxed_verification=True)
+    # The unsatisfiable edge is named, not the satisfiable ``seed_tid``.
+    msg = _assert_dep_edge_rejected(P, "scoped_tid")
+    # A user-facing diagnostic, not an internal-invariant abort.
+    assert "Internal error" not in msg, msg
 
-    # The in-scope edge is wired; the out-of-scope ``scoped_tid`` is dropped.
-    assert code.count("set_dependencies(") == 1, code
-    # ``seed_tid`` is a fresh direct-producer TaskId (issue #1966): unguarded insert.
-    assert not re.search(r"if \(seed_tid\w*\.is_valid\(\)\)", code), code
-    assert re.search(r"\] = seed_tid\w*;", code), code
-    m = re.search(r"PTO2TaskId\s+(\w+)\s*=\s*task_0_outs\.task_id\(\);", code)
-    assert m, code
-    assert code.count(m.group(1)) == 1, code
+
+def test_user_dep_edge_out_of_compiler_inserted_loop_scope_is_rejected():
+    """The boundary need not be user-written to swallow a ``deps=[...]`` edge.
+
+    ``MaterializeRuntimeScopes`` wraps every ``ForStmt`` body in its own AUTO
+    ``PTO2_SCOPE``, so a TaskId produced in the loop body and depended on after
+    the loop crosses a closed scope even though the source names no scope at
+    all. The loop-carry machinery does hoist a valid C++ ``PTO2TaskId`` to the
+    outer level, but the dep binding is not visible there, so the edge would be
+    dropped — reject instead.
+    """
+
+    @pl.program
+    class P:
+        @pl.function(type=pl.FunctionType.InCore)
+        def k1(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            return x
+
+        @pl.function(type=pl.FunctionType.InCore)
+        def k2(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            return x
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def main(
+            self,
+            x: pl.Tensor[[64], pl.FP32],
+            out: pl.Out[pl.Tensor[[64], pl.FP32]],
+        ) -> pl.Tensor[[64], pl.FP32]:
+            loop_tid = pl.system.task_invalid()
+            for _i in pl.range(2):
+                _a, loop_tid = pl.submit(self.k1, x)
+            b, _ = pl.submit(self.k2, x, deps=[loop_tid])
+            return b
+
+    msg = _assert_dep_edge_rejected(P, "loop_tid")
+    # The message points at loop bodies / branches as scope openers.
+    assert "pl.range" in msg, msg
+
+
+def test_spmd_grid_tid_dep_across_manual_scope_boundary_is_rejected():
+    """A captured ``with pl.spmd(N) as tid:`` grid TaskId depended on from the
+    auto region after the enclosing ``pl.manual_scope()`` is rejected.
+
+    The grid TaskId is a genuine whole-grid join (the runtime completes the slot
+    only after all N blocks retire), so the edge is meaningful — it just cannot
+    be wired from outside the scope that produced it. Silently dropping it left
+    the reader racing all N blocks.
+    """
+
+    @pl.program
+    class P:
+        @pl.function(type=pl.FunctionType.InCore)
+        def producer(
+            self,
+            a: pl.Tensor[[64, 64], pl.FP32],
+            out: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+        ) -> pl.Tensor[[64, 64], pl.FP32]:
+            t = pl.load(a, [0, 0], [64, 64])
+            return pl.store(pl.add(t, t), [0, 0], out)
+
+        @pl.function(type=pl.FunctionType.InCore)
+        def reader(
+            self,
+            a: pl.Tensor[[64, 64], pl.FP32],
+            out: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+        ) -> pl.Tensor[[64, 64], pl.FP32]:
+            t = pl.load(a, [0, 0], [64, 64])
+            return pl.store(pl.add(t, t), [0, 0], out)
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def main(
+            self,
+            x: pl.Tensor[[64, 64], pl.FP32],
+            scratch: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+            out: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+        ) -> pl.Tensor[[64, 64], pl.FP32]:
+            with pl.manual_scope():
+                with pl.spmd(4) as grid_tid:
+                    scratch = self.producer(x, scratch)
+            out, _ = pl.submit(self.reader, scratch, out, deps=[grid_tid])
+            return out
+
+    _assert_dep_edge_rejected(P, "grid_tid")
+
+
+def test_grid_tid_dep_inside_producing_manual_scope_still_wires():
+    """Control for the two rejections above: the same grid/reader pair kept
+    inside one ``pl.manual_scope()`` still emits the ``set_dependencies`` edge.
+
+    Pins that the new check rejects only genuinely unsatisfiable edges and does
+    not regress the supported in-scope wiring.
+    """
+
+    @pl.program
+    class P:
+        @pl.function(type=pl.FunctionType.InCore)
+        def producer(
+            self,
+            a: pl.Tensor[[64, 64], pl.FP32],
+            out: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+        ) -> pl.Tensor[[64, 64], pl.FP32]:
+            t = pl.load(a, [0, 0], [64, 64])
+            return pl.store(pl.add(t, t), [0, 0], out)
+
+        @pl.function(type=pl.FunctionType.InCore)
+        def reader(
+            self,
+            a: pl.Tensor[[64, 64], pl.FP32],
+            out: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+        ) -> pl.Tensor[[64, 64], pl.FP32]:
+            t = pl.load(a, [0, 0], [64, 64])
+            return pl.store(pl.add(t, t), [0, 0], out)
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def main(
+            self,
+            x: pl.Tensor[[64, 64], pl.FP32],
+            scratch: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+            out: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+        ) -> pl.Tensor[[64, 64], pl.FP32]:
+            with pl.manual_scope():
+                with pl.spmd(4) as grid_tid:
+                    scratch = self.producer(x, scratch)
+                out, _ = pl.submit(self.reader, scratch, out, deps=[grid_tid])
+            return out
+
+    code = _generate_orch_full_pipeline(P, allow_relaxed_verification=True)
+    assert re.search(r"PTO2TaskId grid_tid = task_0_outs\.task_id\(\);", code), code
+    assert re.search(r"\] = grid_tid;", code), code
+    assert ".set_dependencies(" in code, code
 
 
 def test_spmd_submit_emits_launch_spec_and_captures_task_id():

--- a/tests/ut/codegen/test_orchestration_task_deps.py
+++ b/tests/ut/codegen/test_orchestration_task_deps.py
@@ -1288,5 +1288,76 @@ def test_compiler_dep_carry_array_sized_by_outer_loop_trip_count():
     )
 
 
+def test_user_written_task_dummy_dep_across_closed_scope_is_rejected():
+    """A user ``pl.system.task_dummy(deps=[tid])`` is enforced like ``pl.submit``.
+
+    ``task_dummy`` is a user-facing DSL construct, and the parser stamps
+    ``attrs["dummy_task"]`` on it exactly as ``ExpandManualPhaseFence`` does on
+    the barriers it synthesises. Treating ``dummy_task`` as a compiler-authorship
+    marker would therefore silently drop this user edge, leaving the barrier with
+    no fanin and every consumer gated on it unordered — the failure this change
+    exists to prevent.
+    """
+
+    @pl.program
+    class P:
+        @pl.function(type=pl.FunctionType.InCore)
+        def k1(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            return x
+
+        @pl.function(type=pl.FunctionType.InCore)
+        def k2(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            return x
+
+        @pl.function(type=pl.FunctionType.Orchestration, auto_scope=False)
+        def main(
+            self,
+            x: pl.Tensor[[64], pl.FP32],
+            out: pl.Out[pl.Tensor[[64], pl.FP32]],
+        ) -> pl.Tensor[[64], pl.FP32]:
+            with pl.scope():
+                _a, scoped_tid = pl.submit(self.k1, x)
+            # The barrier's fanin names a TaskId whose scope has closed.
+            barrier = pl.system.task_dummy(deps=[scoped_tid])
+            b, _ = pl.submit(self.k2, x, deps=[barrier])
+            return b
+
+    _assert_dep_edge_rejected(P, "scoped_tid")
+
+
+def test_user_written_task_dummy_with_in_scope_dep_still_wires():
+    """Control for the rejection above: an in-scope ``task_dummy`` fanin wires.
+
+    Proves the enforcement rejects only genuinely unresolvable edges and does not
+    over-reject the supported ``pl.system.task_dummy`` path.
+    """
+
+    @pl.program
+    class P:
+        @pl.function(type=pl.FunctionType.InCore)
+        def k1(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            return x
+
+        @pl.function(type=pl.FunctionType.InCore)
+        def k2(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            return x
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            with pl.manual_scope():
+                _a, tid = pl.submit(self.k1, x)
+                barrier = pl.system.task_dummy(deps=[tid])
+                b, _ = pl.submit(self.k2, x, deps=[barrier])
+            return b
+
+    backend.reset_for_testing()
+    backend.set_backend_type(BackendType.Ascend910B)
+    pm = PassManager.get_strategy(OptimizationStrategy.Default)
+    code = _generate_orch_code(pm.run_passes(P))
+
+    assert "rt_submit_dummy_task(" in code, code
+    assert code.count("set_dependencies(") >= 2, code
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Problem

A user-written `deps=[tid]` whose TaskId was produced in a scope that has since
closed was **silently dropped** from the emitted `set_dependencies` call. The
consumer was left unordered against its producer, which surfaces at runtime as a
stale read with no diagnostic of any kind.

```python
with pl.manual_scope():
    with pl.spmd(4) as grid_tid:
        scratch = self.producer(x, scratch)
out, _ = pl.submit(self.reader, scratch, out, deps=[grid_tid])   # edge vanished
```

```cpp
PTO2_SCOPE(PTO2ScopeMode::MANUAL) {
    TaskOutputTensors task_0_outs = rt_submit_aiv_task(0, params_t0);
    PTO2TaskId grid_tid = task_0_outs.task_id();   // bound, then never used again
}

// Task 1: reader
Arg params_t1;
params_t1.add_input(ext_scratch);
rt_submit_aiv_task(1, params_t1);                  // no set_dependencies
```

## Root cause

The tolerant skip in `EmitManualDeps` was written for **compiler-derived** hazard
patches, which may legitimately name a TaskId from a closed scope.
`GetDependencyEdges` merged user and compiler edges into one `vector<VarPtr>` and
discarded provenance, so the skip swallowed user edges too.

## Change

Each edge is tagged with provenance (`DepEdge::user_written`). An unresolvable
**user** edge now raises a `pypto::ValueError` carrying the DSL source span;
compiler edges keep the tolerant skip.

```text
ValueError: Task dependency deps=[grid_tid] cannot be honored: its TaskId is
produced inside a scope that has already closed at this point, so the ordering
edge would be lost and the consumer could read stale data. Note that pl.range /
pl.parallel loop bodies and if/else branches each open their own scope, so this
fires even with no pl.scope() in the source. Either consume the TaskId inside the
scope that produces it (for example, keep producer and consumer in one
pl.manual_scope()), or hoist the producer out of the inner scope. For a TaskId
produced in a loop body, consume it in that same body or accumulate the ids into
an Array[N, TASK_ID] and depend on that after the loop.
  [kernel.py:75:17]
```

`CountManualDeps` (array sizing) and `EmitManualDeps` (array fill) now route
through one `ResolveDepEdgeBinding`, so they cannot disagree on which edges
survive — the class of bug the old split had — and the int-variant invariant
check is deduplicated.

## Scope is wider than spmd

The closed scope need not be user-written. `MaterializeRuntimeScopes` wraps every
`ForStmt` body and every `IfStmt` branch body in its own AUTO scope, so this also
covers ordinary code with no scope keyword in sight:

| shape | before | after |
| ----- | ------ | ----- |
| no boundary / enclosing → nested | edge emitted | edge emitted (unchanged) |
| `pl.submit` tid, for-body → after loop | silently dropped | `ValueError` |
| `pl.submit` tid, if-branch → after if | silently dropped | `ValueError` |
| `pl.submit` / `pl.at` tid, manual_scope → auto | silently dropped | `ValueError` |
| spmd grid tid, manual_scope → auto | silently dropped | `ValueError` |
| **compiler-derived** edge across closed scope | skipped | skipped (unchanged) |

One nuance worth review attention: `ExpandManualPhaseFence` synthesises a
`system.task_dummy` barrier under the same `manual_dep_edges` key. Classifying
purely by key would have raised a user-facing error naming a Var the user never
wrote, so a carrier marked `attrs["dummy_task"]` is treated as compiler-authored.

## Tests

Two existing tests pinned the drop and were rewritten:

- `test_task_id_binding_does_not_leak_past_pl_scope` →
  `test_user_dep_edge_across_closed_scope_is_rejected`. Its original intent
  (#1577: don't emit a dangling C++ identifier) still holds — rejecting satisfies
  it too.
- `test_mixed_in_and_out_of_scope_deps_does_not_crash_codegen` →
  `test_mixed_in_and_out_of_scope_deps_reports_user_error`. The anti-crash
  guarantee is preserved by asserting `"Internal error" not in msg`
  (`pypto.InternalError` derives from `RuntimeError`, so `pytest.raises(ValueError)`
  discriminates).

Three added: the compiler-inserted loop-scope case, the spmd grid case, and a
positive control proving in-scope wiring still emits `set_dependencies`.

## Not in scope

This is a diagnostic, not a fix — cross-scope `deps=` still isn't *supported*, you
just find out at compile time instead of debugging garbage output. The eventual
fix is to extend `PrepareCrossScopeTaskIdHoists` (which already LCA-hoists
compiler edges) to project `Submit::deps_` and accept `manual_dep_edges`, then
narrow this check to cases with no valid LCA. The loop / if variants look close
to free — `ptid__rv_v2` / `ptid__phi_v2` are already declared and assigned at the
right level today; only the binding registration is missing.

## Verification

- `tests/ut`: `8017 passed, 2 skipped`, plus one **pre-existing** unrelated
  failure on `main` — `test_benchmark_l3_ignores_prepare_setup_groups`, a
  collision between #2163 (added `prepare(persistent=...)`) and #2167 (added a
  test double without that kwarg). Not touched by this PR.
- clang-tidy clean; pre-commit clean (clang-format, cpplint, ruff, pyright,
  markdownlint, EN/zh-CN doc parity).
- Docs updated in both languages (`docs/{en,zh-cn}/dev/codegen/01-orchestration_codegen.md`).
