### PR TITLE
feat(codegen): support single-row GEMV on A2/A3

### DIFF
--- a/docs/en/dev/ir/05-operators.md
+++ b/docs/en/dev/ir/05-operators.md
@@ -183,6 +183,16 @@ layout contract is implemented.
 | `#pto.layout` / mx load | `mx_a_zz` / `mx_b_nn` / …; this stage uses **host ZZ/NN** (AZZ2ZZ). |
 | Coverage | `pto.tmatmul.mx` / `.acc` / `.bias` + `pto.tget_scale_addr`. |
 
+### Tile-only GEMV family (A2/A3)
+
+The tile-only GEMV family uses logical shape `[1, N]` but follows the Cube
+instruction's padded physical contract. Its Acc result has 16 physical rows,
+while its physical column count follows the RHS tile (and must satisfy the
+target's normal C0 alignment); the bias uses the same physical column count.
+Their `valid_shape` retains the logical `[K, N]`, `[1, N]`, and `[1, N]`
+regions. A single-row Mat load uses `blayout=row_major` and
+`slayout=none_box`, selecting PTO-ISA's row-vector extraction path.
+
 ## Python Usage
 
 ```python

--- a/docs/en/dev/ir/05-operators.md
+++ b/docs/en/dev/ir/05-operators.md
@@ -190,8 +190,18 @@ instruction's padded physical contract. Its Acc result has 16 physical rows,
 while its physical column count follows the RHS tile (and must satisfy the
 target's normal C0 alignment); the bias uses the same physical column count.
 Their `valid_shape` retains the logical `[K, N]`, `[1, N]`, and `[1, N]`
-regions. A single-row Mat load uses `blayout=row_major` and
+regions. The lhs must have exactly one physical and logical row. A single-row Mat load uses `blayout=row_major` and
 `slayout=none_box`, selecting PTO-ISA's row-vector extraction path.
+
+The rhs logical K must cover the lhs logical K. Supported dtype triples
+are `INT8 x INT8 -> INT32` and same-type `FP16`, `BF16`, or `FP32` inputs to
+`FP32`; `gemv_acc` uses that output dtype for `acc`, and `gemv_bias` requires
+the same output dtype for `bias`. The bias valid shape must cover the logical
+output shape `[1, N]`; its valid N may be wider when the physical N matches.
+
+`tile.gemv`, `tile.gemv_acc`, and `tile.gemv_bias` accept `acc_phase` as
+`"unspecified"` (the default), `"partial"`, or `"final"`. Use `"partial"`
+while more K chunks remain and `"final"` for the last chunk.
 
 ## Python Usage
 

--- a/docs/en/dev/ptoas-op-status.md
+++ b/docs/en/dev/ptoas-op-status.md
@@ -80,9 +80,9 @@ for lowering/compiler plumbing, plus other dialects such as VPTO, VMI, and SIMT.
 | pto.tmatmul.mx | TMATMUL_MX | tile | ✅ | ✅ | ✅ | ❌ | — | NEW frontend+codegen (minimal MXFP8 host-prequant); see [operators MX constraints](ir/05-operators.md#mx--ascend950-pto-isa-constraints); device numerical follow-up #1975 |
 | pto.tmatmul.mx.acc | TMATMUL_MX (overload) | tile | ✅ | ✅ | ✅ | ❌ | — | NEW frontend+codegen (`tile.matmul_mx_acc`); ST pending |
 | pto.tmatmul.mx.bias | TMATMUL_MX (overload) | tile | ✅ | ✅ | ✅ | ❌ | — | NEW frontend+codegen (`tile.matmul_mx_bias`); ST pending |
-| pto.tgemv | TGEMV | tile | ✅ | ✅ | ❌ | ❌ | — | path exists; historical ISA/semantic issue requires revalidation against the current pin |
-| pto.tgemv.acc | TGEMV_ACC | tile | ✅ | ✅ | ❌ | ❌ | — | path exists; historical ISA/semantic issue requires revalidation against the current pin |
-| pto.tgemv.bias | TGEMV_BIAS | tile | ✅ | ✅ | ❌ | ❌ | — | path exists; historical ISA/semantic issue requires revalidation against the current pin |
+| pto.tgemv | TGEMV | tile | ✅ | ✅ | ❌ | ✅ | — | A2/A3 task-submit ST passed; A5 hardware validation is pending |
+| pto.tgemv.acc | TGEMV_ACC | tile | ✅ | ✅ | ❌ | ✅ | — | A2/A3 task-submit ST passed; A5 hardware validation is pending |
+| pto.tgemv.bias | TGEMV_BIAS | tile | ✅ | ✅ | ❌ | ✅ | — | A2/A3 task-submit ST passed; A5 hardware validation is pending |
 | pto.tgemv.mx | TGEMV_MX | tile | ✅ | ❌ | ❌ | ❌ | — | MISSING: lacks a complete frontend/codegen/ST path |
 | pto.tgemv.mx.acc | TGEMV_MX (overload) | tile | ✅ | ❌ | ❌ | ❌ | — | MISSING: lacks a complete frontend/codegen/ST path |
 | pto.tgemv.mx.bias | TGEMV_MX (overload) | tile | ✅ | ❌ | ❌ | ❌ | — | MISSING: lacks a complete frontend/codegen/ST path |

--- a/docs/zh/dev/ir/05-operators.md
+++ b/docs/zh/dev/ir/05-operators.md
@@ -171,6 +171,15 @@ offset，`tensor.slice`、`tensor.reshape`、`tensor.transpose`、
 | `#pto.layout` / mx load | `mx_a_zz` / `mx_b_nn` / …；本阶段用 **host ZZ/NN**（AZZ2ZZ） |
 | 本阶段覆盖 | `pto.tmatmul.mx` / `.acc` / `.bias` + `pto.tget_scale_addr` |
 
+### 仅 Tile 的 GEMV 家族（A2/A3）
+
+仅 tile 的 GEMV 家族逻辑形状为 `[1, N]`，但物理形状遵循 Cube 指令的对齐契约：
+Acc 结果使用 16 个物理行，物理列数沿用 RHS tile（并须满足目标平台通常的
+C0 对齐要求），bias 使用相同的物理列数；
+各自的 `valid_shape` 仍保留逻辑 `[K, N]`、`[1, N]` 和 `[1, N]` 区域。
+单行 Mat load 使用 `blayout=row_major` 和 `slayout=none_box`，从而选择
+PTO-ISA 的行向量提取路径。
+
 ## Python 用法
 
 ```python

--- a/docs/zh/dev/ir/05-operators.md
+++ b/docs/zh/dev/ir/05-operators.md
@@ -177,8 +177,19 @@ offset，`tensor.slice`、`tensor.reshape`、`tensor.transpose`、
 Acc 结果使用 16 个物理行，物理列数沿用 RHS tile（并须满足目标平台通常的
 C0 对齐要求），bias 使用相同的物理列数；
 各自的 `valid_shape` 仍保留逻辑 `[K, N]`、`[1, N]` 和 `[1, N]` 区域。
+lhs 的物理行数和逻辑行数都必须恰好为 1。
 单行 Mat load 使用 `blayout=row_major` 和 `slayout=none_box`，从而选择
 PTO-ISA 的行向量提取路径。
+
+rhs 的逻辑 K 必须覆盖 lhs 的逻辑 K。支持的 dtype 三元组为
+`INT8 x INT8 -> INT32`，以及同类型 `FP16`、`BF16` 或 `FP32` 输入到
+`FP32`；`gemv_acc` 的 `acc` 使用对应输出 dtype，`gemv_bias` 的 `bias`
+也必须使用相同的输出 dtype，且 bias 的 valid shape 必须覆盖逻辑输出
+`[1, N]`；物理 N 一致时，bias 的 valid N 可以更宽。
+
+`tile.gemv`、`tile.gemv_acc` 和 `tile.gemv_bias` 的 `acc_phase` 可设为
+`"unspecified"`（默认值）、`"partial"` 或 `"final"`。后续仍有 K 分块时
+使用 `"partial"`，最后一个分块使用 `"final"`。
 
 ## Python 用法
 

--- a/docs/zh/dev/ptoas-op-status.md
+++ b/docs/zh/dev/ptoas-op-status.md
@@ -66,9 +66,9 @@ lowering/compiler plumbing 使用的额外内部 op 未纳入，也不列 VPTO�
 | pto.tmatmul.mx | TMATMUL_MX | tile | ✅ | ✅ | ✅ | ❌ | — | NEW frontend+codegen（最小 MXFP8 host-prequant）；见 [operators MX 约束](ir/05-operators.md#mx--ascend950pto-isa-约束)；设备数值 follow-up #1975 |
 | pto.tmatmul.mx.acc | TMATMUL_MX (overload) | tile | ✅ | ✅ | ✅ | ❌ | — | NEW frontend+codegen（`tile.matmul_mx_acc`）；ST 待补 |
 | pto.tmatmul.mx.bias | TMATMUL_MX (overload) | tile | ✅ | ✅ | ✅ | ❌ | — | NEW frontend+codegen（`tile.matmul_mx_bias`）；ST 待补 |
-| pto.tgemv | TGEMV | tile | ✅ | ✅ | ❌ | ❌ | — | 已有链路；历史 ISA/语义问题，需按当前 pin 复验 |
-| pto.tgemv.acc | TGEMV_ACC | tile | ✅ | ✅ | ❌ | ❌ | — | 已有链路；历史 ISA/语义问题，需按当前 pin 复验 |
-| pto.tgemv.bias | TGEMV_BIAS | tile | ✅ | ✅ | ❌ | ❌ | — | 已有链路；历史 ISA/语义问题，需按当前 pin 复验 |
+| pto.tgemv | TGEMV | tile | ✅ | ✅ | ❌ | ✅ | — | A2/A3 task-submit ST 已通过；A5 真机验证待补 |
+| pto.tgemv.acc | TGEMV_ACC | tile | ✅ | ✅ | ❌ | ✅ | — | A2/A3 task-submit ST 已通过；A5 真机验证待补 |
+| pto.tgemv.bias | TGEMV_BIAS | tile | ✅ | ✅ | ❌ | ✅ | — | A2/A3 task-submit ST 已通过；A5 真机验证待补 |
 | pto.tgemv.mx | TGEMV_MX | tile | ✅ | ❌ | ❌ | ❌ | — | MISSING：缺完整前端/codegen/ST 链路 |
 | pto.tgemv.mx.acc | TGEMV_MX (overload) | tile | ✅ | ❌ | ❌ | ❌ | — | MISSING：缺完整前端/codegen/ST 链路 |
 | pto.tgemv.mx.bias | TGEMV_MX (overload) | tile | ✅ | ❌ | ❌ | ❌ | — | MISSING：缺完整前端/codegen/ST 链路 |

--- a/python/pypto/ir/op/tile_ops.py
+++ b/python/pypto/ir/op/tile_ops.py
@@ -1931,52 +1931,80 @@ def batch_matmul_acc(
     return _ir_core.create_op_call("tile.batch_matmul_acc", [acc, lhs, rhs], {}, actual_span)
 
 
-def gemv(lhs: Expr, rhs: Expr, span: Span | None = None) -> Call:
+def gemv(lhs: Expr, rhs: Expr, span: Span | None = None, *, acc_phase: str = "unspecified") -> Call:
     """General Matrix-Vector multiplication: C[1,N] = A[1,K] @ B[K,N].
+
+    ``lhs`` must have exactly one physical and logical row. The rhs logical K
+    must cover the lhs logical K. Inputs must use the same INT8, FP16, BF16, or FP32
+    dtype; the output is INT32 for INT8 inputs and FP32 otherwise.
 
     Args:
         lhs: Row vector tile (TileType [1, K])
         rhs: Right-hand side tile (TileType [K, N])
+        acc_phase: Accumulation phase: ``"unspecified"``, ``"partial"``, or ``"final"``
         span: Optional source span for debugging (auto-captured if not provided)
 
     Returns:
         Call expression for GEMV
     """
     actual_span = _get_span_or_capture(span)
-    return _ir_core.create_op_call("tile.gemv", [lhs, rhs], {}, actual_span)
+    return _ir_core.create_op_call("tile.gemv", [lhs, rhs], {"acc_phase": acc_phase}, actual_span)
 
 
-def gemv_acc(acc: Expr, lhs: Expr, rhs: Expr, span: Span | None = None) -> Call:
+def gemv_acc(
+    acc: Expr,
+    lhs: Expr,
+    rhs: Expr,
+    span: Span | None = None,
+    *,
+    acc_phase: str = "unspecified",
+) -> Call:
     """GEMV with accumulation: C[1,N] += A[1,K] @ B[K,N].
+
+    ``acc`` must use the GEMV output dtype. The logical K extents and lhs/rhs
+    dtype requirements are identical to :func:`gemv`.
 
     Args:
         acc: Accumulator tile (TileType [1, N])
         lhs: Row vector tile (TileType [1, K])
         rhs: Right-hand side tile (TileType [K, N])
+        acc_phase: Accumulation phase: ``"unspecified"``, ``"partial"``, or ``"final"``
         span: Optional source span for debugging (auto-captured if not provided)
 
     Returns:
         Call expression for GEMV with accumulation
     """
     actual_span = _get_span_or_capture(span)
-    return _ir_core.create_op_call("tile.gemv_acc", [acc, lhs, rhs], {}, actual_span)
+    return _ir_core.create_op_call("tile.gemv_acc", [acc, lhs, rhs], {"acc_phase": acc_phase}, actual_span)
 
 
-def gemv_bias(lhs: Expr, rhs: Expr, bias: Expr, span: Span | None = None) -> Call:
+def gemv_bias(
+    lhs: Expr,
+    rhs: Expr,
+    bias: Expr,
+    span: Span | None = None,
+    *,
+    acc_phase: str = "unspecified",
+) -> Call:
     """GEMV with bias add: C[1,N] = A[1,K] @ B[K,N] + bias[1,N].
+
+    ``bias`` must use the GEMV output dtype and its valid shape must cover the
+    logical output shape ``[1, N]``. The logical K extents and lhs/rhs dtype
+    requirements are identical to :func:`gemv`.
 
     Args:
         lhs: Row vector tile (TileType [1, K])
         rhs: Right-hand side tile (TileType [K, N])
         bias: Bias tile (TileType [1, N]) with the accumulator dtype (FP32 for
             floating-point matrix operands, INT32 for integer matrix operands)
+        acc_phase: Accumulation phase: ``"unspecified"``, ``"partial"``, or ``"final"``
         span: Optional source span for debugging (auto-captured if not provided)
 
     Returns:
         Call expression for GEMV with bias
     """
     actual_span = _get_span_or_capture(span)
-    return _ir_core.create_op_call("tile.gemv_bias", [lhs, rhs, bias], {}, actual_span)
+    return _ir_core.create_op_call("tile.gemv_bias", [lhs, rhs, bias], {"acc_phase": acc_phase}, actual_span)
 
 
 # ============================================================================

--- a/python/pypto/language/op/tile_ops.py
+++ b/python/pypto/language/op/tile_ops.py
@@ -1298,48 +1298,62 @@ def matmul_mx_bias(lhs: Tile, lhs_scale: Tile, rhs: Tile, rhs_scale: Tile, bias:
     return Tile(expr=call_expr)
 
 
-def gemv(lhs: Tile, rhs: Tile) -> Tile:
+def gemv(lhs: Tile, rhs: Tile, acc_phase: str = "unspecified") -> Tile:
     """General Matrix-Vector multiplication: C[1,N] = A[1,K] @ B[K,N].
+
+    ``lhs`` must have exactly one physical and logical row. The rhs logical K
+    must cover the lhs logical K. Inputs must use the same INT8, FP16, BF16, or FP32
+    dtype; the output is INT32 for INT8 inputs and FP32 otherwise.
 
     Args:
         lhs: Row vector tile [1, K]
         rhs: Right-hand side tile [K, N]
+        acc_phase: Accumulation phase: ``"unspecified"``, ``"partial"``, or ``"final"``
 
     Returns:
         Tile wrapping the gemv operation
     """
-    call_expr = _ir_ops.gemv(lhs.unwrap(), rhs.unwrap())
+    call_expr = _ir_ops.gemv(lhs.unwrap(), rhs.unwrap(), acc_phase=acc_phase)
     return Tile(expr=call_expr)
 
 
-def gemv_acc(acc: Tile, lhs: Tile, rhs: Tile) -> Tile:
+def gemv_acc(acc: Tile, lhs: Tile, rhs: Tile, acc_phase: str = "unspecified") -> Tile:
     """GEMV with accumulation: C[1,N] += A[1,K] @ B[K,N].
+
+    ``acc`` must use the GEMV output dtype. The logical K extents and lhs/rhs
+    dtype requirements are identical to :func:`gemv`.
 
     Args:
         acc: Accumulator tile [1, N]
         lhs: Row vector tile [1, K]
         rhs: Right-hand side tile [K, N]
+        acc_phase: Accumulation phase: ``"unspecified"``, ``"partial"``, or ``"final"``
 
     Returns:
         Tile wrapping the gemv_acc operation
     """
-    call_expr = _ir_ops.gemv_acc(acc.unwrap(), lhs.unwrap(), rhs.unwrap())
+    call_expr = _ir_ops.gemv_acc(acc.unwrap(), lhs.unwrap(), rhs.unwrap(), acc_phase=acc_phase)
     return Tile(expr=call_expr)
 
 
-def gemv_bias(lhs: Tile, rhs: Tile, bias: Tile) -> Tile:
+def gemv_bias(lhs: Tile, rhs: Tile, bias: Tile, acc_phase: str = "unspecified") -> Tile:
     """GEMV with bias add: C[1,N] = A[1,K] @ B[K,N] + bias[1,N].
+
+    ``bias`` must use the GEMV output dtype and its valid shape must cover the
+    logical output shape ``[1, N]``. The logical K extents and lhs/rhs dtype
+    requirements are identical to :func:`gemv`.
 
     Args:
         lhs: Row vector tile [1, K]
         rhs: Right-hand side tile [K, N]
         bias: Bias tile [1, N] with the accumulator dtype (FP32 for
             floating-point matrix operands, INT32 for integer matrix operands)
+        acc_phase: Accumulation phase: ``"unspecified"``, ``"partial"``, or ``"final"``
 
     Returns:
         Tile wrapping the gemv_bias operation
     """
-    call_expr = _ir_ops.gemv_bias(lhs.unwrap(), rhs.unwrap(), bias.unwrap())
+    call_expr = _ir_ops.gemv_bias(lhs.unwrap(), rhs.unwrap(), bias.unwrap(), acc_phase=acc_phase)
     return Tile(expr=call_expr)
 
 

--- a/src/backend/common/pto_ops_elementwise.cpp
+++ b/src/backend/common/pto_ops_elementwise.cpp
@@ -174,6 +174,22 @@ static std::string MakeNaryCodegenPTO(const std::string& pto_op_name, size_t ari
   return "";
 }
 
+static std::string GemvAccPhaseAttr(const CallPtr& op) {
+  const auto acc_phase = op->GetKwarg<std::string>("acc_phase", "unspecified");
+  CHECK(acc_phase == "unspecified" || acc_phase == "partial" || acc_phase == "final")
+      << "GEMV acc_phase must be one of {unspecified, partial, final}, but got " << acc_phase;
+  if (acc_phase == "unspecified") return "";
+  return " {accPhase = #pto<acc_phase " + acc_phase + ">}";
+}
+
+static std::string MakeGemvCodegenPTO(const std::string& pto_op_name, size_t arity, const CallPtr& op,
+                                      codegen::CodegenBase& codegen_base) {
+  auto& codegen = AsPto(codegen_base);
+  CheckArity(op, pto_op_name, arity);
+  codegen.Emit(pto_op_name + " " + GenerateInsOutsClause(op, codegen) + GemvAccPhaseAttr(op));
+  return "";
+}
+
 static std::string MakeTileSelCodegenPTO(const CallPtr& op, codegen::CodegenBase& codegen_base) {
   auto& codegen = AsPto(codegen_base);
   CheckArity(op, "pto.tsel", 4);
@@ -659,9 +675,7 @@ static const SimpleOpEntry kSimpleOps[] = {
     // tile.matmul_acc / tile.gemv_acc / tile.matmul_mx_acc have custom codegen
     // (in-place accumulation: ptoas requires ins(acc) == outs).
     {"tile.matmul_bias",     "pto.tmatmul.bias",     3},
-    {"tile.gemv",            "pto.tgemv",            2},
     // tile.gemv_acc has custom codegen (in-place accumulation)
-    {"tile.gemv_bias",       "pto.tgemv.bias",       3},
     // Data movement/layout operations
     {"tile.concat",          "pto.tconcat",          2},
     // tile.move has custom codegen (no-op elision for same-space same-address moves)
@@ -982,7 +996,7 @@ void RegisterElementwiseOps(Backend& backend, const std::unordered_set<std::stri
       }
       acc_inst << ") outs(" << dst;
       if (!dst_type.empty()) acc_inst << " : " << dst_type;
-      acc_inst << ")";
+      acc_inst << ")" << GemvAccPhaseAttr(op);
       codegen.Emit(acc_inst.str());
       return "";
     };
@@ -1034,8 +1048,14 @@ void RegisterElementwiseOps(Backend& backend, const std::unordered_set<std::stri
   };
 
   reg("tile.matmul_acc", make_acc_codegen("pto.tmatmul.acc"));
+  reg("tile.gemv", [](const ir::CallPtr& op, codegen::CodegenBase& codegen) {
+    return MakeGemvCodegenPTO("pto.tgemv", 2, op, codegen);
+  });
   reg("tile.gemv_acc", make_acc_codegen("pto.tgemv.acc"));
   reg("tile.matmul_mx_acc", make_mx_acc_codegen("pto.tmatmul.mx.acc"));
+  reg("tile.gemv_bias", [](const ir::CallPtr& op, codegen::CodegenBase& codegen) {
+    return MakeGemvCodegenPTO("pto.tgemv.bias", 3, op, codegen);
+  });
 }
 }  // namespace backend
 }  // namespace pypto

--- a/src/ir/op/tile_ops/matmul.cpp
+++ b/src/ir/op/tile_ops/matmul.cpp
@@ -18,6 +18,7 @@
  */
 
 #include <any>
+#include <cstddef>
 #include <memory>
 #include <optional>
 #include <string>
@@ -267,6 +268,73 @@ TypePtr DeduceTileMatMulBiasType(const std::vector<ExprPtr>& args,
                                     std::nullopt, tile_view, MemorySpace::Acc);
 }
 
+namespace {
+
+TileTypePtr BuildGemvResultType(const TypePtr& inferred, const TileTypePtr& lhs_type,
+                                const TileTypePtr& rhs_type) {
+  auto inferred_type = As<TileType>(inferred);
+  INTERNAL_CHECK(inferred_type) << "Internal error: GEMV type inference must produce TileType";
+
+  auto physical_rows = std::make_shared<ConstInt>(16, DataType::INDEX, lhs_type->shape_[0]->span_);
+  std::vector<ExprPtr> output_shape = {physical_rows, rhs_type->shape_[1]};
+  const auto lhs_valid = GetValidShape(lhs_type);
+  const auto rhs_valid = GetValidShape(rhs_type);
+
+  TileView tile_view;
+  tile_view.blayout = TileLayout::col_major;
+  tile_view.slayout = TileLayout::row_major;
+  tile_view.fractal = 1024;
+  tile_view.valid_shape = {lhs_valid[0], rhs_valid[1]};
+  return std::make_shared<TileType>(output_shape, inferred_type->dtype_, std::nullopt, tile_view);
+}
+
+TypePtr DeduceTileGemvType(const std::vector<ExprPtr>& args,
+                           const std::vector<std::pair<std::string, std::any>>& kwargs,
+                           const std::string& op_name) {
+  TypePtr inferred = DeduceTileMatMulType(args, kwargs, op_name);
+  return BuildGemvResultType(inferred, As<TileType>(args[0]->GetType()), As<TileType>(args[1]->GetType()));
+}
+
+TypePtr DeduceTileGemvAccType(const std::vector<ExprPtr>& args,
+                              const std::vector<std::pair<std::string, std::any>>& kwargs,
+                              const std::string& op_name) {
+  CHECK(args.size() == 3) << "The operator " << op_name << " requires exactly 3 arguments, but got "
+                          << args.size();
+  auto acc_type = As<TileType>(args[0]->GetType());
+  CHECK(acc_type) << "The operator " << op_name << " requires first argument (acc) to be a TileType, but got "
+                  << args[0]->GetType()->TypeName();
+  CHECK(acc_type->shape_.size() == 2) << "The operator " << op_name << " requires acc to be 2D, but got "
+                                      << acc_type->shape_.size() << " dimensions";
+
+  std::vector<ExprPtr> product_args = {args[1], args[2]};
+  TypePtr product = DeduceTileMatMulType(product_args, kwargs, op_name);
+  auto expected_type =
+      BuildGemvResultType(product, As<TileType>(args[1]->GetType()), As<TileType>(args[2]->GetType()));
+
+  for (std::size_t axis = 0; axis < 2; ++axis) {
+    auto acc_extent = As<ConstInt>(acc_type->shape_[axis]);
+    auto expected_extent = As<ConstInt>(expected_type->shape_[axis]);
+    if (acc_extent && expected_extent) {
+      CHECK(acc_extent->value_ == expected_extent->value_)
+          << "The operator " << op_name << " requires accumulator physical shape "
+          << FormatShape(expected_type->shape_) << ", but got " << FormatShape(acc_type->shape_);
+    }
+  }
+  CHECK(acc_type->dtype_ == expected_type->dtype_)
+      << "The operator " << op_name << " requires accumulator dtype " << expected_type->dtype_.ToString()
+      << ", but got " << acc_type->dtype_.ToString();
+  return expected_type;
+}
+
+TypePtr DeduceTileGemvBiasType(const std::vector<ExprPtr>& args,
+                               const std::vector<std::pair<std::string, std::any>>& kwargs,
+                               const std::string& op_name) {
+  TypePtr inferred = DeduceTileMatMulBiasType(args, kwargs, op_name);
+  return BuildGemvResultType(inferred, As<TileType>(args[0]->GetType()), As<TileType>(args[1]->GetType()));
+}
+
+}  // namespace
+
 // ============================================================================
 // Registration Function for Block Matrix Multiplication Operations
 // ============================================================================
@@ -329,7 +397,7 @@ REGISTER_OP("tile.gemv")
     .set_output_memory(MemorySpace::Acc)
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
-      return DeduceTileMatMulType(args, kwargs, "tile.gemv");
+      return DeduceTileGemvType(args, kwargs, "tile.gemv");
     });
 
 REGISTER_OP("tile.gemv_acc")
@@ -346,7 +414,7 @@ REGISTER_OP("tile.gemv_acc")
     .set_output_reuses_input(0)
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
-      return DeduceTileMatMulAccType(args, kwargs, "tile.gemv_acc");
+      return DeduceTileGemvAccType(args, kwargs, "tile.gemv_acc");
     });
 
 REGISTER_OP("tile.gemv_bias")
@@ -362,7 +430,7 @@ REGISTER_OP("tile.gemv_bias")
     .set_output_memory(MemorySpace::Acc)
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
-      return DeduceTileMatMulBiasType(args, kwargs, "tile.gemv_bias");
+      return DeduceTileGemvBiasType(args, kwargs, "tile.gemv_bias");
     });
 
 }  // namespace ir

--- a/src/ir/op/tile_ops/matmul.cpp
+++ b/src/ir/op/tile_ops/matmul.cpp
@@ -270,15 +270,49 @@ TypePtr DeduceTileMatMulBiasType(const std::vector<ExprPtr>& args,
 
 namespace {
 
+void ValidateGemvAccPhase(const std::vector<std::pair<std::string, std::any>>& kwargs,
+                          const std::string& op_name) {
+  const auto acc_phase = GetKwargOr<std::string>(kwargs, "acc_phase", "unspecified");
+  CHECK(acc_phase == "unspecified" || acc_phase == "partial" || acc_phase == "final")
+      << "The operator " << op_name
+      << " requires acc_phase to be one of {unspecified, partial, final}, but got " << acc_phase;
+}
+
+DataType ValidateGemvInputDtypes(const TileTypePtr& lhs_type, const TileTypePtr& rhs_type,
+                                 const std::string& op_name) {
+  CHECK(lhs_type->dtype_ == rhs_type->dtype_)
+      << "The operator " << op_name << " requires identical lhs and rhs data types, but got "
+      << lhs_type->dtype_.ToString() << " and " << rhs_type->dtype_.ToString();
+
+  const auto input_dtype = lhs_type->dtype_;
+  CHECK(input_dtype == DataType::INT8 || input_dtype == DataType::FP16 || input_dtype == DataType::BF16 ||
+        input_dtype == DataType::FP32)
+      << "The operator " << op_name
+      << " supports only INT8 x INT8 -> INT32 and same-type FP16/BF16/FP32 inputs -> FP32, but got "
+      << input_dtype.ToString();
+  return input_dtype == DataType::INT8 ? DataType::INT32 : DataType::FP32;
+}
+
 TileTypePtr BuildGemvResultType(const TypePtr& inferred, const TileTypePtr& lhs_type,
                                 const TileTypePtr& rhs_type) {
   auto inferred_type = As<TileType>(inferred);
   INTERNAL_CHECK(inferred_type) << "Internal error: GEMV type inference must produce TileType";
 
-  auto physical_rows = std::make_shared<ConstInt>(16, DataType::INDEX, lhs_type->shape_[0]->span_);
-  std::vector<ExprPtr> output_shape = {physical_rows, rhs_type->shape_[1]};
+  auto lhs_physical_rows = As<ConstInt>(lhs_type->shape_[0]);
+  CHECK(lhs_physical_rows && lhs_physical_rows->value_ == 1)
+      << "GEMV requires lhs physical row extent to be exactly 1, but got shape "
+      << FormatShape(lhs_type->shape_);
+  auto output_physical_rows = std::make_shared<ConstInt>(16, DataType::INDEX, lhs_type->shape_[0]->span_);
+  std::vector<ExprPtr> output_shape = {output_physical_rows, rhs_type->shape_[1]};
   const auto lhs_valid = GetValidShape(lhs_type);
   const auto rhs_valid = GetValidShape(rhs_type);
+  auto logical_row = std::make_shared<ConstInt>(1, DataType::INDEX, lhs_valid[0]->span_);
+  CHECK(ProveValidExtentEqual(lhs_valid[0], logical_row) == ProofResult::kTrue)
+      << "GEMV requires lhs logical row extent to be exactly 1, but got valid_shape "
+      << FormatShape(lhs_valid);
+  CHECK(ProveValidExtentLessEqual(lhs_valid[1], rhs_valid[0]) != ProofResult::kFalse)
+      << "GEMV requires rhs logical K to cover lhs logical K, but got lhs K=" << PythonPrint(lhs_valid[1])
+      << " and rhs K=" << PythonPrint(rhs_valid[0]);
 
   TileView tile_view;
   tile_view.blayout = TileLayout::col_major;
@@ -291,13 +325,18 @@ TileTypePtr BuildGemvResultType(const TypePtr& inferred, const TileTypePtr& lhs_
 TypePtr DeduceTileGemvType(const std::vector<ExprPtr>& args,
                            const std::vector<std::pair<std::string, std::any>>& kwargs,
                            const std::string& op_name) {
+  ValidateGemvAccPhase(kwargs, op_name);
   TypePtr inferred = DeduceTileMatMulType(args, kwargs, op_name);
-  return BuildGemvResultType(inferred, As<TileType>(args[0]->GetType()), As<TileType>(args[1]->GetType()));
+  auto lhs_type = As<TileType>(args[0]->GetType());
+  auto rhs_type = As<TileType>(args[1]->GetType());
+  ValidateGemvInputDtypes(lhs_type, rhs_type, op_name);
+  return BuildGemvResultType(inferred, lhs_type, rhs_type);
 }
 
 TypePtr DeduceTileGemvAccType(const std::vector<ExprPtr>& args,
                               const std::vector<std::pair<std::string, std::any>>& kwargs,
                               const std::string& op_name) {
+  ValidateGemvAccPhase(kwargs, op_name);
   CHECK(args.size() == 3) << "The operator " << op_name << " requires exactly 3 arguments, but got "
                           << args.size();
   auto acc_type = As<TileType>(args[0]->GetType());
@@ -308,6 +347,7 @@ TypePtr DeduceTileGemvAccType(const std::vector<ExprPtr>& args,
 
   std::vector<ExprPtr> product_args = {args[1], args[2]};
   TypePtr product = DeduceTileMatMulType(product_args, kwargs, op_name);
+  ValidateGemvInputDtypes(As<TileType>(args[1]->GetType()), As<TileType>(args[2]->GetType()), op_name);
   auto expected_type =
       BuildGemvResultType(product, As<TileType>(args[1]->GetType()), As<TileType>(args[2]->GetType()));
 
@@ -323,14 +363,34 @@ TypePtr DeduceTileGemvAccType(const std::vector<ExprPtr>& args,
   CHECK(acc_type->dtype_ == expected_type->dtype_)
       << "The operator " << op_name << " requires accumulator dtype " << expected_type->dtype_.ToString()
       << ", but got " << acc_type->dtype_.ToString();
+  const auto acc_valid = GetValidShape(acc_type);
+  const auto expected_valid = GetValidShape(expected_type);
+  for (std::size_t axis = 0; axis < 2; ++axis) {
+    CHECK(ProveValidExtentEqual(acc_valid[axis], expected_valid[axis]) == ProofResult::kTrue)
+        << "The operator " << op_name << " requires accumulator valid_shape " << FormatShape(expected_valid)
+        << ", but got " << FormatShape(acc_valid);
+  }
   return expected_type;
 }
 
 TypePtr DeduceTileGemvBiasType(const std::vector<ExprPtr>& args,
                                const std::vector<std::pair<std::string, std::any>>& kwargs,
                                const std::string& op_name) {
+  ValidateGemvAccPhase(kwargs, op_name);
   TypePtr inferred = DeduceTileMatMulBiasType(args, kwargs, op_name);
-  return BuildGemvResultType(inferred, As<TileType>(args[0]->GetType()), As<TileType>(args[1]->GetType()));
+  auto lhs_type = As<TileType>(args[0]->GetType());
+  auto rhs_type = As<TileType>(args[1]->GetType());
+  auto bias_type = As<TileType>(args[2]->GetType());
+  const auto result_dtype = ValidateGemvInputDtypes(lhs_type, rhs_type, op_name);
+  CHECK(bias_type->dtype_ == result_dtype)
+      << "The operator " << op_name << " requires bias dtype " << result_dtype.ToString()
+      << " to match the accumulator output, but got " << bias_type->dtype_.ToString();
+  const auto bias_valid = GetValidShape(bias_type);
+  auto logical_row = std::make_shared<ConstInt>(1, DataType::INDEX, bias_valid[0]->span_);
+  CHECK(ProveValidExtentEqual(bias_valid[0], logical_row) == ProofResult::kTrue)
+      << "The operator " << op_name << " requires bias to have exactly one valid row, but got "
+      << PythonPrint(bias_valid[0]);
+  return BuildGemvResultType(inferred, lhs_type, rhs_type);
 }
 
 }  // namespace
@@ -392,6 +452,7 @@ REGISTER_OP("tile.gemv")
     .set_description("General Matrix-Vector multiplication: C[1,N] = A[1,K] @ B[K,N]")
     .add_argument("lhs", "Row vector tile (TileType, 2D [1, K])")
     .add_argument("rhs", "Right-hand side tile (TileType, 2D [K, N])")
+    .set_attr<std::string>("acc_phase")
     .set_input_memory(0, MemorySpace::Left)
     .set_input_memory(1, MemorySpace::Right)
     .set_output_memory(MemorySpace::Acc)
@@ -407,6 +468,7 @@ REGISTER_OP("tile.gemv_acc")
     .add_argument("acc", "Accumulator tile (TileType, 2D [1, N])")
     .add_argument("lhs", "Row vector tile (TileType, 2D [1, K])")
     .add_argument("rhs", "Right-hand side tile (TileType, 2D [K, N])")
+    .set_attr<std::string>("acc_phase")
     .set_input_memory(0, MemorySpace::Acc)
     .set_input_memory(1, MemorySpace::Left)
     .set_input_memory(2, MemorySpace::Right)
@@ -424,6 +486,7 @@ REGISTER_OP("tile.gemv_bias")
     .add_argument("lhs", "Row vector tile (TileType, 2D [1, K])")
     .add_argument("rhs", "Right-hand side tile (TileType, 2D [K, N])")
     .add_argument("bias", "Accumulator-typed bias tile (TileType, [1, N])")
+    .set_attr<std::string>("acc_phase")
     .set_input_memory(0, MemorySpace::Left)
     .set_input_memory(1, MemorySpace::Right)
     .set_input_memory(2, MemorySpace::Bias)

--- a/src/ir/op/tile_ops/memory.cpp
+++ b/src/ir/op/tile_ops/memory.cpp
@@ -185,8 +185,7 @@ TypePtr DeduceTileLoadType(const std::vector<ExprPtr>& args,
   // ``tile.load`` of a DN source produces the transposed (ZN) Mat layout.
   // A transposed matmul operand is realised by a zero-copy ``tile.transpose_view``
   // at the matmul site, not by the load.
-  bool source_is_dn =
-      tensor_type->tensor_view_.has_value() && tensor_type->tensor_view_->layout == TensorLayout::DN;
+  bool source_is_dn = tensor_type->tensor_view_.value_or(TensorView{}).layout == TensorLayout::DN;
   TileView tile_view;
   if (is_mx_load) {
     // A5 TLoadMxCubeCheck: MX_A_* → row-major ZZ (SFractal=32); MX_B_* → col-major NN.
@@ -205,6 +204,21 @@ TypePtr DeduceTileLoadType(const std::vector<ExprPtr>& args,
       tile_view.slayout = TileLayout::row_major;
       if (source_is_dn) {
         std::swap(tile_view.blayout, tile_view.slayout);
+      }
+      // A single-row 2-D Mat operand (cube GEMV lhs / bias) is an ND row
+      // vector, not the NZ fractal used by multi-row matmul operands. PTO-ISA
+      // declares it as Tile<Mat, 1, K, BLayout::RowMajor, ...,
+      // SLayout::NoneBox>; that pair routes the Mat->Left move through the
+      // rows==1 vector path instead of the regular extraction path, whose row
+      // alignment excludes M=1. In a rank-3+ Mat load, shape[0] is a batch
+      // dimension, so keep the canonical NZ view.
+      const auto& shape = shapes_tuple->elements_;
+      if (shape.size() == 2) {
+        const ExprPtr& row_dim = source_is_dn ? shape[1] : shape[0];
+        if (auto rows = As<ConstInt>(row_dim); rows && rows->value_ == 1) {
+          tile_view.blayout = TileLayout::row_major;
+          tile_view.slayout = TileLayout::none_box;
+        }
       }
     } else if (auto last_dim = As<ConstInt>(shapes_tuple->elements_.back());
                last_dim && last_dim->value_ == 1) {
@@ -579,14 +593,12 @@ TypePtr DeduceTileCreateTileType(const std::vector<ExprPtr>& args,
   // The transposed Mat (ZN) layout is a 2D L1 matmul-`b_trans` operand layout; it
   // is meaningless for a non-Mat space or a non-2D shape. Fail fast rather than
   // emit an invalid tile (mirrors tile.load's Mat-only transpose guard).
-  CHECK(!transpose_layout ||
-        (tile_shape.size() == 2 && target_memory_opt.has_value() && *target_memory_opt == MemorySpace::Mat))
+  CHECK(!transpose_layout || (tile_shape.size() == 2 && target_memory_opt == MemorySpace::Mat))
       << "The operator " << op_name
       << " supports transpose=true only for a 2D tile with target_memory=Mat (L1)";
   // flat_layout is a Mat (L1/cbuf) staging layout and mutually exclusive with the
   // transposed NZ layout.
-  CHECK(!flat_layout ||
-        (target_memory_opt.has_value() && *target_memory_opt == MemorySpace::Mat && !transpose_layout))
+  CHECK(!flat_layout || (target_memory_opt == MemorySpace::Mat && !transpose_layout))
       << "The operator " << op_name
       << " supports flat_layout=true only for target_memory=Mat (L1) without transpose";
 

--- a/tests/st/runtime/ops/test_gemv.py
+++ b/tests/st/runtime/ops/test_gemv.py
@@ -7,7 +7,7 @@
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
 
-"""Runtime tests for the tile-level Cube op matmul_bias.
+"""Runtime tests for the tile-level Cube ops matmul_bias and the GEMV family.
 
 matmul_bias: C[M,N] = A[M,K] @ B[K,N] + bias[1,N]. Operands load to Mat (L1);
 the layout passes (AutoTileMatmulL0 / CanonicalizeTileSlice) insert the L0
@@ -17,9 +17,12 @@ accumulator, narrowed valid_shape on the output rows (M) and the contraction
 (K), and a non-zero output row offset. Cube accumulation reorders the K
 reduction vs torch, so a relaxed FP32 tolerance is used.
 
-gemv / gemv_acc / gemv_bias are not covered yet: they need pto-isa support
-(gemv/gemv_bias hit the TExtract dstRow % 16 == 0 1-row constraint; gemv_acc
-needs acc->acc pto.tmov). Will be added once the ISA path is available.
+gemv / gemv_bias / gemv_acc are the M==1 specialization of the Cube matmul
+family: C[1,N] = A[1,K] @ B[K,N], optionally + bias[1,N] or accumulated into
+an existing result. Operands load to Mat (L1) and move to Left/Right; the
+single-row lhs uses PTO-ISA's Mat-to-Left vector path. Coverage includes
+several K/N shapes, FP16/BF16/FP32 inputs, narrowed contraction valid shapes,
+and exact base/bias/acc instruction forms.
 
 Scope is a2a3 only (``@pytest.mark.platforms("a2a3")``); a5 coverage is a
 separate PR.
@@ -42,7 +45,7 @@ VALID_M = 8
 _RTOL = 1e-3
 _ATOL = 1e-3
 
-_PL_DT = {DataType.FP32: pl.FP32, DataType.BF16: pl.BF16}
+_PL_DT = {DataType.FP32: pl.FP32, DataType.BF16: pl.BF16, DataType.FP16: pl.FP16}
 
 
 def _cfg() -> RunConfig:
@@ -188,6 +191,298 @@ class TestMatmulBias:
     @pytest.mark.platforms("a2a3")
     def test_tile_matmul_bias_offset(self, test_runner):
         result = test_runner.run(MatmulBiasTestCase(out_m=2 * M, off_row=M, config=_cfg()))
+        assert result.passed, f"Test failed: {result.error}"
+
+
+# ===========================================================================
+# gemv / gemv_bias (M == 1 matmul family)
+# ===========================================================================
+
+# The Cube GEMV lhs is extracted to Left through PTO-ISA's single-row vector
+# path. The physical K must occupy a whole 512-byte Cube block: K % 128 == 0
+# for FP32 and K % 256 == 0 for BF16/FP16. A narrowed contraction retains an
+# aligned physical K and changes only its valid extent.
+VALID_K = 64
+
+
+class GemvTestCase(PTOTestCase):
+    """C[1,N] = A[1,K] @ B[K,N], optionally + bias[1,N]."""
+
+    __test__ = False
+
+    def __init__(self, *, k=K, n=N, bias=False, narrow=None, ab_dtype=DataType.FP32, config=None):
+        super().__init__(config)
+        self._k, self._n = k, n
+        self._bias, self._narrow, self._ab = bias, narrow, ab_dtype
+
+    def get_name(self) -> str:
+        op = "gemv_bias" if self._bias else "gemv"
+        narrowed = f"_n{self._narrow}" if self._narrow else ""
+        return f"tile_{op}_1x{self._k}x{self._n}_{self._ab.value}{narrowed}"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        specs = [
+            TensorSpec("a", [1, self._k], self._ab, init_value=torch.randn),
+            TensorSpec("b", [self._k, self._n], self._ab, init_value=torch.randn),
+        ]
+        if self._bias:
+            specs.append(TensorSpec("bias", [1, self._n], DataType.FP32, init_value=torch.randn))
+        specs.append(TensorSpec("out", [1, self._n], DataType.FP32, is_output=True))
+        return specs
+
+    def get_program(self) -> Any:
+        k, n = self._k, self._n
+        ab = _PL_DT[self._ab]
+        a_valid = [1, VALID_K] if self._narrow == "K" else [1, k]
+        b_valid = [VALID_K, n] if self._narrow == "K" else [k, n]
+
+        if not self._bias:
+
+            @pl.program
+            class GemvProgram:
+                @pl.function(type=pl.FunctionType.InCore)
+                def kernel(
+                    self,
+                    a: pl.Tensor[[1, k], ab],
+                    b: pl.Tensor[[k, n], ab],
+                    out: pl.Out[pl.Tensor[[1, n], pl.FP32]],
+                ) -> pl.Tensor[[1, n], pl.FP32]:
+                    tile_a = pl.load(
+                        a,
+                        [0, 0],
+                        [1, k],
+                        valid_shapes=a_valid,
+                        target_memory=pl.MemorySpace.Mat,
+                    )
+                    tile_b = pl.load(
+                        b,
+                        [0, 0],
+                        [k, n],
+                        valid_shapes=b_valid,
+                        target_memory=pl.MemorySpace.Mat,
+                    )
+                    out = pl.store(pl.tile.gemv(tile_a, tile_b), [0, 0], out)
+                    return out
+
+                @pl.function(type=pl.FunctionType.Orchestration)
+                def orchestrator(
+                    self,
+                    a: pl.Tensor[[1, k], ab],
+                    b: pl.Tensor[[k, n], ab],
+                    out: pl.Out[pl.Tensor[[1, n], pl.FP32]],
+                ) -> pl.Tensor[[1, n], pl.FP32]:
+                    out = self.kernel(a, b, out)
+                    return out
+
+            return GemvProgram
+
+        @pl.program
+        class GemvBiasProgram:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                a: pl.Tensor[[1, k], ab],
+                b: pl.Tensor[[k, n], ab],
+                bias: pl.Tensor[[1, n], pl.FP32],
+                out: pl.Out[pl.Tensor[[1, n], pl.FP32]],
+            ) -> pl.Tensor[[1, n], pl.FP32]:
+                tile_a = pl.load(a, [0, 0], [1, k], valid_shapes=a_valid, target_memory=pl.MemorySpace.Mat)
+                tile_b = pl.load(
+                    b,
+                    [0, 0],
+                    [k, n],
+                    valid_shapes=b_valid,
+                    target_memory=pl.MemorySpace.Mat,
+                )
+                tile_bias = pl.load(
+                    bias,
+                    [0, 0],
+                    [1, n],
+                    valid_shapes=[1, n],
+                    target_memory=pl.MemorySpace.Mat,
+                )
+                result = pl.tile.gemv_bias(tile_a, tile_b, tile_bias)
+                out = pl.store(result, [0, 0], out)
+                return out
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orchestrator(
+                self,
+                a: pl.Tensor[[1, k], ab],
+                b: pl.Tensor[[k, n], ab],
+                bias: pl.Tensor[[1, n], pl.FP32],
+                out: pl.Out[pl.Tensor[[1, n], pl.FP32]],
+            ) -> pl.Tensor[[1, n], pl.FP32]:
+                out = self.kernel(a, b, bias, out)
+                return out
+
+        return GemvBiasProgram
+
+    def compute_expected(self, tensors: dict[str, torch.Tensor], params=None) -> None:
+        a = tensors["a"].to(torch.float32)
+        b = tensors["b"].to(torch.float32)
+        if self._narrow == "K":
+            result = torch.matmul(a[:, :VALID_K], b[:VALID_K, :])
+        else:
+            result = torch.matmul(a, b)
+        if self._bias:
+            result = result + tensors["bias"]
+        tensors["out"][:] = result
+
+
+# GEMV keeps the whole rhs resident in the 64-KiB Right buffer rather than
+# K-splitting it, so these K/N pairs stay within that capacity.
+_KN = [(128, 64), (256, 64), (128, 128)]
+
+
+class TestGemv:
+    """Cube gemv on A2/A3 across K/N, narrowed K, and floating input dtypes."""
+
+    @pytest.mark.platforms("a2a3")
+    @pytest.mark.parametrize("k,n", _KN, ids=[f"1x{k}x{n}" for k, n in _KN])
+    def test_tile_gemv(self, test_runner, k, n):
+        result = test_runner.run(GemvTestCase(k=k, n=n, config=_cfg()))
+        assert result.passed, f"Test failed: {result.error}"
+
+    @pytest.mark.platforms("a2a3")
+    def test_tile_gemv_narrow_k(self, test_runner):
+        result = test_runner.run(GemvTestCase(k=128, narrow="K", config=_cfg()))
+        assert result.passed, f"Test failed: {result.error}"
+
+    @pytest.mark.platforms("a2a3")
+    def test_tile_gemv_bf16(self, test_runner):
+        result = test_runner.run(GemvTestCase(k=256, n=64, ab_dtype=DataType.BF16, config=_cfg()))
+        assert result.passed, f"Test failed: {result.error}"
+
+    @pytest.mark.platforms("a2a3")
+    def test_tile_gemv_fp16(self, test_runner):
+        result = test_runner.run(GemvTestCase(k=256, n=64, ab_dtype=DataType.FP16, config=_cfg()))
+        assert result.passed, f"Test failed: {result.error}"
+
+
+class TestGemvBias:
+    """Cube gemv_bias on A2/A3 across K/N and a narrowed contraction."""
+
+    @pytest.mark.platforms("a2a3")
+    @pytest.mark.parametrize("k,n", _KN, ids=[f"1x{k}x{n}" for k, n in _KN])
+    def test_tile_gemv_bias(self, test_runner, k, n):
+        result = test_runner.run(GemvTestCase(k=k, n=n, bias=True, config=_cfg()))
+        assert result.passed, f"Test failed: {result.error}"
+
+    @pytest.mark.platforms("a2a3")
+    def test_tile_gemv_bias_narrow_k(self, test_runner):
+        result = test_runner.run(GemvTestCase(k=128, bias=True, narrow="K", config=_cfg()))
+        assert result.passed, f"Test failed: {result.error}"
+
+
+# ===========================================================================
+# gemv_acc (C[1,N] += A[1,K] @ B[K,N])
+# ===========================================================================
+
+
+class GemvAccTestCase(PTOTestCase):
+    """Accumulate two K chunks through one fresh gemv and one gemv_acc."""
+
+    __test__ = False
+    NUM_CHUNKS = 2
+
+    def __init__(self, *, k_chunk=128, n=N, narrow=None, config=None):
+        super().__init__(config)
+        self._k_chunk, self._n, self._narrow = k_chunk, n, narrow
+        self._k = k_chunk * self.NUM_CHUNKS
+
+    def get_name(self) -> str:
+        narrowed = f"_n{self._narrow}" if self._narrow else ""
+        return f"tile_gemv_acc_1x{self._k}x{self._n}_chunks{self.NUM_CHUNKS}{narrowed}"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("a", [1, self._k], DataType.FP32, init_value=torch.randn),
+            TensorSpec("b", [self._k, self._n], DataType.FP32, init_value=torch.randn),
+            TensorSpec("out", [1, self._n], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        k_chunk, n, k_total = self._k_chunk, self._n, self._k
+        valid_k = VALID_K if self._narrow == "K" else k_chunk
+        a_valid = [1, valid_k]
+        b_valid = [valid_k, n]
+
+        @pl.program
+        class GemvAccProgram:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                a: pl.Tensor[[1, k_total], pl.FP32],
+                b: pl.Tensor[[k_total, n], pl.FP32],
+                out: pl.Out[pl.Tensor[[1, n], pl.FP32]],
+            ) -> pl.Tensor[[1, n], pl.FP32]:
+                a0 = pl.load(a, [0, 0], [1, k_chunk], valid_shapes=a_valid, target_memory=pl.MemorySpace.Mat)
+                b0 = pl.load(
+                    b,
+                    [0, 0],
+                    [k_chunk, n],
+                    valid_shapes=b_valid,
+                    target_memory=pl.MemorySpace.Mat,
+                )
+                acc = pl.tile.gemv(a0, b0)
+
+                a1 = pl.load(
+                    a,
+                    [0, k_chunk],
+                    [1, k_chunk],
+                    valid_shapes=a_valid,
+                    target_memory=pl.MemorySpace.Mat,
+                )
+                b1 = pl.load(
+                    b,
+                    [k_chunk, 0],
+                    [k_chunk, n],
+                    valid_shapes=b_valid,
+                    target_memory=pl.MemorySpace.Mat,
+                )
+                acc = pl.tile.gemv_acc(acc, a1, b1)
+                out = pl.store(acc, [0, 0], out)
+                return out
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orchestrator(
+                self,
+                a: pl.Tensor[[1, k_total], pl.FP32],
+                b: pl.Tensor[[k_total, n], pl.FP32],
+                out: pl.Out[pl.Tensor[[1, n], pl.FP32]],
+            ) -> pl.Tensor[[1, n], pl.FP32]:
+                out = self.kernel(a, b, out)
+                return out
+
+        return GemvAccProgram
+
+    def compute_expected(self, tensors: dict[str, torch.Tensor], params=None) -> None:
+        a = tensors["a"].to(torch.float32)
+        b = tensors["b"].to(torch.float32)
+        result = torch.zeros(1, self._n)
+        for chunk in range(self.NUM_CHUNKS):
+            start = chunk * self._k_chunk
+            valid_k = VALID_K if self._narrow == "K" else self._k_chunk
+            result = result + torch.matmul(
+                a[:, start : start + valid_k],
+                b[start : start + valid_k, :],
+            )
+        tensors["out"][:] = result
+
+
+class TestGemvAcc:
+    """Cube gemv_acc on A2/A3 across N and a narrowed contraction."""
+
+    @pytest.mark.platforms("a2a3")
+    @pytest.mark.parametrize("n", [64, 128], ids=["n64", "n128"])
+    def test_tile_gemv_acc(self, test_runner, n):
+        result = test_runner.run(GemvAccTestCase(n=n, config=_cfg()))
+        assert result.passed, f"Test failed: {result.error}"
+
+    @pytest.mark.platforms("a2a3")
+    def test_tile_gemv_acc_narrow_k(self, test_runner):
+        result = test_runner.run(GemvAccTestCase(narrow="K", config=_cfg()))
         assert result.passed, f"Test failed: {result.error}"
 
 

--- a/tests/st/runtime/ops/test_gemv.py
+++ b/tests/st/runtime/ops/test_gemv.py
@@ -21,8 +21,12 @@ gemv / gemv_bias / gemv_acc are the M==1 specialization of the Cube matmul
 family: C[1,N] = A[1,K] @ B[K,N], optionally + bias[1,N] or accumulated into
 an existing result. Operands load to Mat (L1) and move to Left/Right; the
 single-row lhs uses PTO-ISA's Mat-to-Left vector path. Coverage includes
-several K/N shapes, FP16/BF16/FP32 inputs, narrowed contraction valid shapes,
-and exact base/bias/acc instruction forms.
+several K/N shapes, every A2/A3 datatype triple (INT8, FP16, BF16, FP32),
+contraction/output/combined valid-shape tails, and exact base/bias/acc
+instruction forms. AccPhase coverage includes standalone Final base/bias
+operations and a Partial base followed by a Final accumulate. A row tail is
+not applicable because the GEMV verifier requires the logical row extent to
+be exactly one.
 
 Scope is a2a3 only (``@pytest.mark.platforms("a2a3")``); a5 coverage is a
 separate PR.
@@ -39,13 +43,28 @@ from pypto.runtime.runner import RunConfig
 K = 64
 N = 64
 M = 16
-VALID_N = 32
+VALID_N = 30
 VALID_M = 8
 
 _RTOL = 1e-3
 _ATOL = 1e-3
 
-_PL_DT = {DataType.FP32: pl.FP32, DataType.BF16: pl.BF16, DataType.FP16: pl.FP16}
+_PL_DT = {
+    DataType.FP32: pl.FP32,
+    DataType.BF16: pl.BF16,
+    DataType.FP16: pl.FP16,
+    DataType.INT8: pl.INT8,
+}
+
+
+def _gemv_input(shape: list[int], dtype: DataType) -> torch.Tensor:
+    if dtype in (DataType.INT8, DataType.INT32):
+        return torch.randint(-4, 5, shape, dtype=dtype.torch_dtype)
+    return torch.randn(shape, dtype=dtype.torch_dtype)
+
+
+def _gemv_output_dtype(dtype: DataType) -> DataType:
+    return DataType.INT32 if dtype == DataType.INT8 else DataType.FP32
 
 
 def _cfg() -> RunConfig:
@@ -200,8 +219,8 @@ class TestMatmulBias:
 
 # The Cube GEMV lhs is extracted to Left through PTO-ISA's single-row vector
 # path. The physical K must occupy a whole 512-byte Cube block: K % 128 == 0
-# for FP32 and K % 256 == 0 for BF16/FP16. A narrowed contraction retains an
-# aligned physical K and changes only its valid extent.
+# for FP32, K % 256 == 0 for BF16/FP16, and K % 512 == 0 for INT8. A narrowed
+# contraction retains an aligned physical K and changes only its valid extent.
 VALID_K = 64
 
 
@@ -210,31 +229,62 @@ class GemvTestCase(PTOTestCase):
 
     __test__ = False
 
-    def __init__(self, *, k=K, n=N, bias=False, narrow=None, ab_dtype=DataType.FP32, config=None):
+    def __init__(
+        self,
+        *,
+        k=K,
+        n=N,
+        bias=False,
+        narrow=None,
+        ab_dtype=DataType.FP32,
+        acc_phase="unspecified",
+        config=None,
+    ):
         super().__init__(config)
         self._k, self._n = k, n
         self._bias, self._narrow, self._ab = bias, narrow, ab_dtype
+        self._acc_phase = acc_phase
 
     def get_name(self) -> str:
         op = "gemv_bias" if self._bias else "gemv"
         narrowed = f"_n{self._narrow}" if self._narrow else ""
-        return f"tile_{op}_1x{self._k}x{self._n}_{self._ab.value}{narrowed}"
+        phase = f"_{self._acc_phase}" if self._acc_phase != "unspecified" else ""
+        return f"tile_{op}_1x{self._k}x{self._n}_{self._ab.value}{narrowed}{phase}"
 
     def define_tensors(self) -> list[TensorSpec]:
+        out_dtype = _gemv_output_dtype(self._ab)
+        valid_n = VALID_N if self._narrow in ("N", "KN") else self._n
+        # N tails are compact in GM; padding belongs only to the aligned Mat/Right/Bias tiles.
         specs = [
-            TensorSpec("a", [1, self._k], self._ab, init_value=torch.randn),
-            TensorSpec("b", [self._k, self._n], self._ab, init_value=torch.randn),
+            TensorSpec("a", [1, self._k], self._ab, init_value=lambda: _gemv_input([1, self._k], self._ab)),
+            TensorSpec(
+                "b",
+                [self._k, valid_n],
+                self._ab,
+                init_value=lambda: _gemv_input([self._k, valid_n], self._ab),
+            ),
         ]
         if self._bias:
-            specs.append(TensorSpec("bias", [1, self._n], DataType.FP32, init_value=torch.randn))
-        specs.append(TensorSpec("out", [1, self._n], DataType.FP32, is_output=True))
+            specs.append(
+                TensorSpec(
+                    "bias",
+                    [1, valid_n],
+                    out_dtype,
+                    init_value=lambda: _gemv_input([1, valid_n], out_dtype),
+                )
+            )
+        specs.append(TensorSpec("out", [1, valid_n], out_dtype, is_output=True))
         return specs
 
     def get_program(self) -> Any:
         k, n = self._k, self._n
         ab = _PL_DT[self._ab]
-        a_valid = [1, VALID_K] if self._narrow == "K" else [1, k]
-        b_valid = [VALID_K, n] if self._narrow == "K" else [k, n]
+        out_dt = pl.INT32 if self._ab == DataType.INT8 else pl.FP32
+        valid_k = VALID_K if self._narrow in ("K", "KN") else k
+        valid_n = VALID_N if self._narrow in ("N", "KN") else n
+        acc_phase = self._acc_phase
+        a_valid = [1, valid_k]
+        b_valid = [valid_k, valid_n]
 
         if not self._bias:
 
@@ -244,33 +294,34 @@ class GemvTestCase(PTOTestCase):
                 def kernel(
                     self,
                     a: pl.Tensor[[1, k], ab],
-                    b: pl.Tensor[[k, n], ab],
-                    out: pl.Out[pl.Tensor[[1, n], pl.FP32]],
-                ) -> pl.Tensor[[1, n], pl.FP32]:
+                    b: pl.Tensor[[k, valid_n], ab],
+                    out: pl.Out[pl.Tensor[[1, valid_n], out_dt]],
+                ) -> pl.Tensor[[1, valid_n], out_dt]:
                     tile_a = pl.load(
                         a,
                         [0, 0],
                         [1, k],
-                        valid_shapes=a_valid,
+                        valid_shape=a_valid,
                         target_memory=pl.MemorySpace.Mat,
                     )
                     tile_b = pl.load(
                         b,
                         [0, 0],
                         [k, n],
-                        valid_shapes=b_valid,
+                        valid_shape=b_valid,
                         target_memory=pl.MemorySpace.Mat,
+                        clamp=True,
                     )
-                    out = pl.store(pl.tile.gemv(tile_a, tile_b), [0, 0], out)
+                    out = pl.store(pl.tile.gemv(tile_a, tile_b, acc_phase=acc_phase), [0, 0], out)
                     return out
 
                 @pl.function(type=pl.FunctionType.Orchestration)
                 def orchestrator(
                     self,
                     a: pl.Tensor[[1, k], ab],
-                    b: pl.Tensor[[k, n], ab],
-                    out: pl.Out[pl.Tensor[[1, n], pl.FP32]],
-                ) -> pl.Tensor[[1, n], pl.FP32]:
+                    b: pl.Tensor[[k, valid_n], ab],
+                    out: pl.Out[pl.Tensor[[1, valid_n], out_dt]],
+                ) -> pl.Tensor[[1, valid_n], out_dt]:
                     out = self.kernel(a, b, out)
                     return out
 
@@ -282,26 +333,28 @@ class GemvTestCase(PTOTestCase):
             def kernel(
                 self,
                 a: pl.Tensor[[1, k], ab],
-                b: pl.Tensor[[k, n], ab],
-                bias: pl.Tensor[[1, n], pl.FP32],
-                out: pl.Out[pl.Tensor[[1, n], pl.FP32]],
-            ) -> pl.Tensor[[1, n], pl.FP32]:
-                tile_a = pl.load(a, [0, 0], [1, k], valid_shapes=a_valid, target_memory=pl.MemorySpace.Mat)
+                b: pl.Tensor[[k, valid_n], ab],
+                bias: pl.Tensor[[1, valid_n], out_dt],
+                out: pl.Out[pl.Tensor[[1, valid_n], out_dt]],
+            ) -> pl.Tensor[[1, valid_n], out_dt]:
+                tile_a = pl.load(a, [0, 0], [1, k], valid_shape=a_valid, target_memory=pl.MemorySpace.Mat)
                 tile_b = pl.load(
                     b,
                     [0, 0],
                     [k, n],
-                    valid_shapes=b_valid,
+                    valid_shape=b_valid,
                     target_memory=pl.MemorySpace.Mat,
+                    clamp=True,
                 )
                 tile_bias = pl.load(
                     bias,
                     [0, 0],
                     [1, n],
-                    valid_shapes=[1, n],
+                    valid_shape=[1, valid_n],
                     target_memory=pl.MemorySpace.Mat,
+                    clamp=True,
                 )
-                result = pl.tile.gemv_bias(tile_a, tile_b, tile_bias)
+                result = pl.tile.gemv_bias(tile_a, tile_b, tile_bias, acc_phase=acc_phase)
                 out = pl.store(result, [0, 0], out)
                 return out
 
@@ -309,25 +362,29 @@ class GemvTestCase(PTOTestCase):
             def orchestrator(
                 self,
                 a: pl.Tensor[[1, k], ab],
-                b: pl.Tensor[[k, n], ab],
-                bias: pl.Tensor[[1, n], pl.FP32],
-                out: pl.Out[pl.Tensor[[1, n], pl.FP32]],
-            ) -> pl.Tensor[[1, n], pl.FP32]:
+                b: pl.Tensor[[k, valid_n], ab],
+                bias: pl.Tensor[[1, valid_n], out_dt],
+                out: pl.Out[pl.Tensor[[1, valid_n], out_dt]],
+            ) -> pl.Tensor[[1, valid_n], out_dt]:
                 out = self.kernel(a, b, bias, out)
                 return out
 
         return GemvBiasProgram
 
     def compute_expected(self, tensors: dict[str, torch.Tensor], params=None) -> None:
-        a = tensors["a"].to(torch.float32)
-        b = tensors["b"].to(torch.float32)
-        if self._narrow == "K":
-            result = torch.matmul(a[:, :VALID_K], b[:VALID_K, :])
+        out_dtype = _gemv_output_dtype(self._ab).torch_dtype
+        if self._ab == DataType.INT8:
+            a = tensors["a"].to(torch.int32)
+            b = tensors["b"].to(torch.int32)
         else:
-            result = torch.matmul(a, b)
+            a = tensors["a"].to(torch.float32)
+            b = tensors["b"].to(torch.float32)
+        valid_k = VALID_K if self._narrow in ("K", "KN") else self._k
+        valid_n = VALID_N if self._narrow in ("N", "KN") else self._n
+        result = torch.matmul(a[:, :valid_k], b[:valid_k, :valid_n])
         if self._bias:
-            result = result + tensors["bias"]
-        tensors["out"][:] = result
+            result = result + tensors["bias"][:, :valid_n]
+        tensors["out"][:] = result.to(out_dtype)
 
 
 # GEMV keeps the whole rhs resident in the 64-KiB Right buffer rather than
@@ -336,7 +393,7 @@ _KN = [(128, 64), (256, 64), (128, 128)]
 
 
 class TestGemv:
-    """Cube gemv on A2/A3 across K/N, narrowed K, and floating input dtypes."""
+    """Cube gemv on A2/A3 across K/N, valid-region tails, and supported input dtypes."""
 
     @pytest.mark.platforms("a2a3")
     @pytest.mark.parametrize("k,n", _KN, ids=[f"1x{k}x{n}" for k, n in _KN])
@@ -359,9 +416,25 @@ class TestGemv:
         result = test_runner.run(GemvTestCase(k=256, n=64, ab_dtype=DataType.FP16, config=_cfg()))
         assert result.passed, f"Test failed: {result.error}"
 
+    @pytest.mark.platforms("a2a3")
+    def test_tile_gemv_int8(self, test_runner):
+        result = test_runner.run(GemvTestCase(k=512, n=64, ab_dtype=DataType.INT8, config=_cfg()))
+        assert result.passed, f"Test failed: {result.error}"
+
+    @pytest.mark.platforms("a2a3")
+    def test_tile_gemv_final_phase(self, test_runner):
+        result = test_runner.run(GemvTestCase(k=128, n=64, acc_phase="final", config=_cfg()))
+        assert result.passed, f"Test failed: {result.error}"
+
+    @pytest.mark.platforms("a2a3")
+    @pytest.mark.parametrize("narrow", ["N", "KN"])
+    def test_tile_gemv_output_tail(self, test_runner, narrow):
+        result = test_runner.run(GemvTestCase(k=128, n=32, narrow=narrow, config=_cfg()))
+        assert result.passed, f"Test failed: {result.error}"
+
 
 class TestGemvBias:
-    """Cube gemv_bias on A2/A3 across K/N and a narrowed contraction."""
+    """Cube gemv_bias on A2/A3 across K/N, valid-region tails, and supported dtypes."""
 
     @pytest.mark.platforms("a2a3")
     @pytest.mark.parametrize("k,n", _KN, ids=[f"1x{k}x{n}" for k, n in _KN])
@@ -372,6 +445,24 @@ class TestGemvBias:
     @pytest.mark.platforms("a2a3")
     def test_tile_gemv_bias_narrow_k(self, test_runner):
         result = test_runner.run(GemvTestCase(k=128, bias=True, narrow="K", config=_cfg()))
+        assert result.passed, f"Test failed: {result.error}"
+
+    @pytest.mark.platforms("a2a3")
+    @pytest.mark.parametrize("ab_dtype", [DataType.BF16, DataType.FP16, DataType.INT8])
+    def test_tile_gemv_bias_dtype(self, test_runner, ab_dtype):
+        k = 512 if ab_dtype == DataType.INT8 else 256
+        result = test_runner.run(GemvTestCase(k=k, n=64, bias=True, ab_dtype=ab_dtype, config=_cfg()))
+        assert result.passed, f"Test failed: {result.error}"
+
+    @pytest.mark.platforms("a2a3")
+    def test_tile_gemv_bias_final_phase(self, test_runner):
+        result = test_runner.run(GemvTestCase(k=128, n=64, bias=True, acc_phase="final", config=_cfg()))
+        assert result.passed, f"Test failed: {result.error}"
+
+    @pytest.mark.platforms("a2a3")
+    @pytest.mark.parametrize("narrow", ["N", "KN"])
+    def test_tile_gemv_bias_output_tail(self, test_runner, narrow):
+        result = test_runner.run(GemvTestCase(k=128, n=32, bias=True, narrow=narrow, config=_cfg()))
         assert result.passed, f"Test failed: {result.error}"
 
 
@@ -386,93 +477,128 @@ class GemvAccTestCase(PTOTestCase):
     __test__ = False
     NUM_CHUNKS = 2
 
-    def __init__(self, *, k_chunk=128, n=N, narrow=None, config=None):
+    def __init__(
+        self,
+        *,
+        k_chunk=128,
+        n=N,
+        narrow=None,
+        ab_dtype=DataType.FP32,
+        phased=False,
+        config=None,
+    ):
         super().__init__(config)
         self._k_chunk, self._n, self._narrow = k_chunk, n, narrow
+        self._ab = ab_dtype
+        self._phased = phased
         self._k = k_chunk * self.NUM_CHUNKS
 
     def get_name(self) -> str:
         narrowed = f"_n{self._narrow}" if self._narrow else ""
-        return f"tile_gemv_acc_1x{self._k}x{self._n}_chunks{self.NUM_CHUNKS}{narrowed}"
+        phase = "_partial_final" if self._phased else ""
+        return (
+            f"tile_gemv_acc_1x{self._k}x{self._n}_{self._ab.value}_chunks{self.NUM_CHUNKS}{narrowed}{phase}"
+        )
 
     def define_tensors(self) -> list[TensorSpec]:
+        out_dtype = _gemv_output_dtype(self._ab)
+        valid_n = VALID_N if self._narrow in ("N", "KN") else self._n
+        # Keep the logical GM row stride while each on-chip rhs tile stays physically aligned.
         return [
-            TensorSpec("a", [1, self._k], DataType.FP32, init_value=torch.randn),
-            TensorSpec("b", [self._k, self._n], DataType.FP32, init_value=torch.randn),
-            TensorSpec("out", [1, self._n], DataType.FP32, is_output=True),
+            TensorSpec("a", [1, self._k], self._ab, init_value=lambda: _gemv_input([1, self._k], self._ab)),
+            TensorSpec(
+                "b",
+                [self._k, valid_n],
+                self._ab,
+                init_value=lambda: _gemv_input([self._k, valid_n], self._ab),
+            ),
+            TensorSpec("out", [1, valid_n], out_dtype, is_output=True),
         ]
 
     def get_program(self) -> Any:
         k_chunk, n, k_total = self._k_chunk, self._n, self._k
-        valid_k = VALID_K if self._narrow == "K" else k_chunk
+        ab = _PL_DT[self._ab]
+        out_dt = pl.INT32 if self._ab == DataType.INT8 else pl.FP32
+        valid_k = VALID_K if self._narrow in ("K", "KN") else k_chunk
+        valid_n = VALID_N if self._narrow in ("N", "KN") else n
+        first_phase = "partial" if self._phased else "unspecified"
+        last_phase = "final" if self._phased else "unspecified"
         a_valid = [1, valid_k]
-        b_valid = [valid_k, n]
+        b_valid = [valid_k, valid_n]
 
         @pl.program
         class GemvAccProgram:
             @pl.function(type=pl.FunctionType.InCore)
             def kernel(
                 self,
-                a: pl.Tensor[[1, k_total], pl.FP32],
-                b: pl.Tensor[[k_total, n], pl.FP32],
-                out: pl.Out[pl.Tensor[[1, n], pl.FP32]],
-            ) -> pl.Tensor[[1, n], pl.FP32]:
-                a0 = pl.load(a, [0, 0], [1, k_chunk], valid_shapes=a_valid, target_memory=pl.MemorySpace.Mat)
+                a: pl.Tensor[[1, k_total], ab],
+                b: pl.Tensor[[k_total, valid_n], ab],
+                out: pl.Out[pl.Tensor[[1, valid_n], out_dt]],
+            ) -> pl.Tensor[[1, valid_n], out_dt]:
+                a0 = pl.load(a, [0, 0], [1, k_chunk], valid_shape=a_valid, target_memory=pl.MemorySpace.Mat)
                 b0 = pl.load(
                     b,
                     [0, 0],
                     [k_chunk, n],
-                    valid_shapes=b_valid,
+                    valid_shape=b_valid,
                     target_memory=pl.MemorySpace.Mat,
+                    clamp=True,
                 )
-                acc = pl.tile.gemv(a0, b0)
+                acc = pl.tile.gemv(a0, b0, acc_phase=first_phase)
 
                 a1 = pl.load(
                     a,
                     [0, k_chunk],
                     [1, k_chunk],
-                    valid_shapes=a_valid,
+                    valid_shape=a_valid,
                     target_memory=pl.MemorySpace.Mat,
                 )
                 b1 = pl.load(
                     b,
                     [k_chunk, 0],
                     [k_chunk, n],
-                    valid_shapes=b_valid,
+                    valid_shape=b_valid,
                     target_memory=pl.MemorySpace.Mat,
+                    clamp=True,
                 )
-                acc = pl.tile.gemv_acc(acc, a1, b1)
+                acc = pl.tile.gemv_acc(acc, a1, b1, acc_phase=last_phase)
                 out = pl.store(acc, [0, 0], out)
                 return out
 
             @pl.function(type=pl.FunctionType.Orchestration)
             def orchestrator(
                 self,
-                a: pl.Tensor[[1, k_total], pl.FP32],
-                b: pl.Tensor[[k_total, n], pl.FP32],
-                out: pl.Out[pl.Tensor[[1, n], pl.FP32]],
-            ) -> pl.Tensor[[1, n], pl.FP32]:
+                a: pl.Tensor[[1, k_total], ab],
+                b: pl.Tensor[[k_total, valid_n], ab],
+                out: pl.Out[pl.Tensor[[1, valid_n], out_dt]],
+            ) -> pl.Tensor[[1, valid_n], out_dt]:
                 out = self.kernel(a, b, out)
                 return out
 
         return GemvAccProgram
 
     def compute_expected(self, tensors: dict[str, torch.Tensor], params=None) -> None:
-        a = tensors["a"].to(torch.float32)
-        b = tensors["b"].to(torch.float32)
-        result = torch.zeros(1, self._n)
+        out_dtype = _gemv_output_dtype(self._ab).torch_dtype
+        if self._ab == DataType.INT8:
+            a = tensors["a"].to(torch.int32)
+            b = tensors["b"].to(torch.int32)
+        else:
+            a = tensors["a"].to(torch.float32)
+            b = tensors["b"].to(torch.float32)
+        valid_n = VALID_N if self._narrow in ("N", "KN") else self._n
+        valid_k = VALID_K if self._narrow in ("K", "KN") else self._k_chunk
+        result = torch.zeros(1, valid_n, dtype=out_dtype)
         for chunk in range(self.NUM_CHUNKS):
             start = chunk * self._k_chunk
-            valid_k = VALID_K if self._narrow == "K" else self._k_chunk
             result = result + torch.matmul(
                 a[:, start : start + valid_k],
-                b[start : start + valid_k, :],
-            )
-        tensors["out"][:] = result
+                b[start : start + valid_k, :valid_n],
+            ).to(out_dtype)
+        tensors["out"][:] = result.to(out_dtype)
 
 
 class TestGemvAcc:
-    """Cube gemv_acc on A2/A3 across N and a narrowed contraction."""
+    """Cube gemv_acc on A2/A3 across N, valid-region tails, and supported dtypes."""
 
     @pytest.mark.platforms("a2a3")
     @pytest.mark.parametrize("n", [64, 128], ids=["n64", "n128"])
@@ -483,6 +609,24 @@ class TestGemvAcc:
     @pytest.mark.platforms("a2a3")
     def test_tile_gemv_acc_narrow_k(self, test_runner):
         result = test_runner.run(GemvAccTestCase(narrow="K", config=_cfg()))
+        assert result.passed, f"Test failed: {result.error}"
+
+    @pytest.mark.platforms("a2a3")
+    @pytest.mark.parametrize("ab_dtype", [DataType.BF16, DataType.FP16, DataType.INT8])
+    def test_tile_gemv_acc_dtype(self, test_runner, ab_dtype):
+        k_chunk = 512 if ab_dtype == DataType.INT8 else 256
+        result = test_runner.run(GemvAccTestCase(k_chunk=k_chunk, n=64, ab_dtype=ab_dtype, config=_cfg()))
+        assert result.passed, f"Test failed: {result.error}"
+
+    @pytest.mark.platforms("a2a3")
+    def test_tile_gemv_acc_partial_final_phases(self, test_runner):
+        result = test_runner.run(GemvAccTestCase(n=64, phased=True, config=_cfg()))
+        assert result.passed, f"Test failed: {result.error}"
+
+    @pytest.mark.platforms("a2a3")
+    @pytest.mark.parametrize("narrow", ["N", "KN"])
+    def test_tile_gemv_acc_output_tail(self, test_runner, narrow):
+        result = test_runner.run(GemvAccTestCase(n=32, narrow=narrow, config=_cfg()))
         assert result.passed, f"Test failed: {result.error}"
 
 

--- a/tests/ut/codegen/test_pto_codegen.py
+++ b/tests/ut/codegen/test_pto_codegen.py
@@ -399,6 +399,79 @@ def test_pto_codegen_matmul_acc_accepts_acc_valid_shape_containment():
     assert "pto.tmatmul.acc" in mlir_code
 
 
+def test_pto_codegen_gemv_family_uses_exact_ops_and_single_row_mat_layout():
+    """GEMV base/acc/bias must retain their canonical PTO ops and row-vector layout."""
+
+    @pl.program
+    class GemvCodegenProgram:
+        @pl.function(type=pl.FunctionType.InCore)
+        def base(
+            self,
+            a: pl.Tensor[[1, 128], pl.FP32],
+            b: pl.Tensor[[128, 128], pl.FP32],
+            out: pl.Out[pl.Tensor[[1, 64], pl.FP32]],
+        ) -> pl.Tensor[[1, 64], pl.FP32]:
+            lhs = pl.load(a, [0, 0], [1, 128], target_memory=pl.MemorySpace.Mat)
+            rhs = pl.load(b, [0, 0], [128, 128], valid_shapes=[128, 64], target_memory=pl.MemorySpace.Mat)
+            out = pl.store(pl.tile.gemv(lhs, rhs), [0, 0], out)
+            return out
+
+        @pl.function(type=pl.FunctionType.InCore)
+        def bias(
+            self,
+            a: pl.Tensor[[1, 128], pl.FP32],
+            b: pl.Tensor[[128, 128], pl.FP32],
+            bias: pl.Tensor[[1, 128], pl.FP32],
+            out: pl.Out[pl.Tensor[[1, 64], pl.FP32]],
+        ) -> pl.Tensor[[1, 64], pl.FP32]:
+            lhs = pl.load(a, [0, 0], [1, 128], target_memory=pl.MemorySpace.Mat)
+            rhs = pl.load(b, [0, 0], [128, 128], valid_shapes=[128, 64], target_memory=pl.MemorySpace.Mat)
+            bias_tile = pl.load(
+                bias, [0, 0], [1, 128], valid_shapes=[1, 64], target_memory=pl.MemorySpace.Mat
+            )
+            out = pl.store(pl.tile.gemv_bias(lhs, rhs, bias_tile), [0, 0], out)
+            return out
+
+        @pl.function(type=pl.FunctionType.InCore)
+        def acc(
+            self,
+            a: pl.Tensor[[1, 256], pl.FP32],
+            b: pl.Tensor[[256, 128], pl.FP32],
+            out: pl.Out[pl.Tensor[[1, 64], pl.FP32]],
+        ) -> pl.Tensor[[1, 64], pl.FP32]:
+            lhs0 = pl.load(a, [0, 0], [1, 128], target_memory=pl.MemorySpace.Mat)
+            rhs0 = pl.load(b, [0, 0], [128, 128], valid_shapes=[128, 64], target_memory=pl.MemorySpace.Mat)
+            result = pl.tile.gemv(lhs0, rhs0)
+            lhs1 = pl.load(a, [0, 128], [1, 128], target_memory=pl.MemorySpace.Mat)
+            rhs1 = pl.load(b, [128, 0], [128, 128], valid_shapes=[128, 64], target_memory=pl.MemorySpace.Mat)
+            result = pl.tile.gemv_acc(result, lhs1, rhs1)
+            out = pl.store(result, [0, 0], out)
+            return out
+
+    mlir_code = _generate_default_mlir(GemvCodegenProgram)
+
+    assert "pto.tgemv ins(" in mlir_code
+    assert "pto.tgemv.acc ins(" in mlir_code
+    assert "pto.tgemv.bias ins(" in mlir_code
+
+    row_mat_allocs = [
+        line for line in _get_alloc_tile_lines(mlir_code) if "loc=mat" in line and "rows=1," in line
+    ]
+    assert row_mat_allocs
+    assert all("blayout=row_major" in line and "slayout=none_box" in line for line in row_mat_allocs)
+
+    gemv_acc_allocs = [
+        line for line in _get_alloc_tile_lines(mlir_code) if "loc=acc" in line and "rows=16, cols=128" in line
+    ]
+    assert gemv_acc_allocs
+
+    acc_line = next(line for line in mlir_code.splitlines() if "pto.tgemv.acc ins(" in line)
+    acc_in = re.search(r"ins\((%[\w\d_]+)", acc_line)
+    acc_out = re.search(r"outs\((%[\w\d_]+)", acc_line)
+    assert acc_in is not None and acc_out is not None
+    assert acc_in.group(1) == acc_out.group(1), acc_line
+
+
 def test_pto_codegen_fillpad_shared_memref_uses_single_alloc_tile():
     """Test that shared MemRef tiles emit one alloc_tile and preserve merged TileView info."""
     span = ir.Span.unknown()

--- a/tests/ut/codegen/test_pto_codegen.py
+++ b/tests/ut/codegen/test_pto_codegen.py
@@ -408,43 +408,48 @@ def test_pto_codegen_gemv_family_uses_exact_ops_and_single_row_mat_layout():
         def base(
             self,
             a: pl.Tensor[[1, 128], pl.FP32],
-            b: pl.Tensor[[128, 128], pl.FP32],
+            b: pl.Tensor[[128, 64], pl.FP32],
             out: pl.Out[pl.Tensor[[1, 64], pl.FP32]],
         ) -> pl.Tensor[[1, 64], pl.FP32]:
             lhs = pl.load(a, [0, 0], [1, 128], target_memory=pl.MemorySpace.Mat)
-            rhs = pl.load(b, [0, 0], [128, 128], valid_shapes=[128, 64], target_memory=pl.MemorySpace.Mat)
-            out = pl.store(pl.tile.gemv(lhs, rhs), [0, 0], out)
+            rhs = pl.load(b, [0, 0], [128, 64], target_memory=pl.MemorySpace.Mat)
+            partial = pl.tile.gemv(lhs, rhs, acc_phase="partial")
+            out = pl.store(partial, [0, 0], out)
+            final = pl.tile.gemv(lhs, rhs, acc_phase="final")
+            out = pl.store(final, [0, 0], out)
             return out
 
         @pl.function(type=pl.FunctionType.InCore)
         def bias(
             self,
             a: pl.Tensor[[1, 128], pl.FP32],
-            b: pl.Tensor[[128, 128], pl.FP32],
-            bias: pl.Tensor[[1, 128], pl.FP32],
+            b: pl.Tensor[[128, 64], pl.FP32],
+            bias: pl.Tensor[[1, 64], pl.FP32],
             out: pl.Out[pl.Tensor[[1, 64], pl.FP32]],
         ) -> pl.Tensor[[1, 64], pl.FP32]:
             lhs = pl.load(a, [0, 0], [1, 128], target_memory=pl.MemorySpace.Mat)
-            rhs = pl.load(b, [0, 0], [128, 128], valid_shapes=[128, 64], target_memory=pl.MemorySpace.Mat)
-            bias_tile = pl.load(
-                bias, [0, 0], [1, 128], valid_shapes=[1, 64], target_memory=pl.MemorySpace.Mat
-            )
-            out = pl.store(pl.tile.gemv_bias(lhs, rhs, bias_tile), [0, 0], out)
+            rhs = pl.load(b, [0, 0], [128, 64], target_memory=pl.MemorySpace.Mat)
+            bias_tile = pl.load(bias, [0, 0], [1, 64], target_memory=pl.MemorySpace.Mat)
+            partial = pl.tile.gemv_bias(lhs, rhs, bias_tile, acc_phase="partial")
+            out = pl.store(partial, [0, 0], out)
+            final = pl.tile.gemv_bias(lhs, rhs, bias_tile, acc_phase="final")
+            out = pl.store(final, [0, 0], out)
             return out
 
         @pl.function(type=pl.FunctionType.InCore)
         def acc(
             self,
             a: pl.Tensor[[1, 256], pl.FP32],
-            b: pl.Tensor[[256, 128], pl.FP32],
+            b: pl.Tensor[[256, 64], pl.FP32],
             out: pl.Out[pl.Tensor[[1, 64], pl.FP32]],
         ) -> pl.Tensor[[1, 64], pl.FP32]:
             lhs0 = pl.load(a, [0, 0], [1, 128], target_memory=pl.MemorySpace.Mat)
-            rhs0 = pl.load(b, [0, 0], [128, 128], valid_shapes=[128, 64], target_memory=pl.MemorySpace.Mat)
+            rhs0 = pl.load(b, [0, 0], [128, 64], target_memory=pl.MemorySpace.Mat)
             result = pl.tile.gemv(lhs0, rhs0)
             lhs1 = pl.load(a, [0, 128], [1, 128], target_memory=pl.MemorySpace.Mat)
-            rhs1 = pl.load(b, [128, 0], [128, 128], valid_shapes=[128, 64], target_memory=pl.MemorySpace.Mat)
-            result = pl.tile.gemv_acc(result, lhs1, rhs1)
+            rhs1 = pl.load(b, [128, 0], [128, 64], target_memory=pl.MemorySpace.Mat)
+            result = pl.tile.gemv_acc(result, lhs1, rhs1, acc_phase="partial")
+            result = pl.tile.gemv_acc(result, lhs1, rhs1, acc_phase="final")
             out = pl.store(result, [0, 0], out)
             return out
 
@@ -453,6 +458,11 @@ def test_pto_codegen_gemv_family_uses_exact_ops_and_single_row_mat_layout():
     assert "pto.tgemv ins(" in mlir_code
     assert "pto.tgemv.acc ins(" in mlir_code
     assert "pto.tgemv.bias ins(" in mlir_code
+    for pto_op in ("pto.tgemv", "pto.tgemv.acc", "pto.tgemv.bias"):
+        op_lines = [line for line in mlir_code.splitlines() if f"{pto_op} ins(" in line]
+        for phase in ("partial", "final"):
+            attr = f"{{accPhase = #pto<acc_phase {phase}>}}"
+            assert any(attr in line for line in op_lines)
 
     row_mat_allocs = [
         line for line in _get_alloc_tile_lines(mlir_code) if "loc=mat" in line and "rows=1," in line
@@ -461,7 +471,7 @@ def test_pto_codegen_gemv_family_uses_exact_ops_and_single_row_mat_layout():
     assert all("blayout=row_major" in line and "slayout=none_box" in line for line in row_mat_allocs)
 
     gemv_acc_allocs = [
-        line for line in _get_alloc_tile_lines(mlir_code) if "loc=acc" in line and "rows=16, cols=128" in line
+        line for line in _get_alloc_tile_lines(mlir_code) if "loc=acc" in line and "rows=16, cols=64" in line
     ]
     assert gemv_acc_allocs
 

--- a/tests/ut/ir/operators/test_tile_ops.py
+++ b/tests/ut/ir/operators/test_tile_ops.py
@@ -2377,7 +2377,7 @@ class TestTileMatMulOps:
                 b: pl.Tensor[[64, 128], pl.FP32],
                 output: pl.Tensor[[1, 128], pl.FP32],
             ) -> pl.Tensor[[1, 128], pl.FP32]:
-                tile_acc: pl.Tile[[16, 32], pl.FP32] = pl.load(acc_in, [0, 0], [16, 32], valid_shapes=[1, 32])
+                tile_acc: pl.Tile[[16, 32], pl.FP32] = pl.load(acc_in, [0, 0], [16, 32], valid_shape=[1, 32])
                 tile_a: pl.Tile[[1, 16], pl.FP32] = pl.load(a, [0, 0], [1, 16])
                 tile_b: pl.Tile[[16, 32], pl.FP32] = pl.load(b, [0, 0], [16, 32])
                 tile_c: pl.Tile[[16, 32], pl.FP32] = pl.gemv_acc(tile_acc, tile_a, tile_b)
@@ -2442,6 +2442,167 @@ class TestTileMatMulOps:
             assert isinstance(call_type, ir.TileType)
             assert [d.value for d in call_type.shape if isinstance(d, ir.ConstInt)] == [16, 128]
             assert _valid_of(call_type) == [1, 48]
+
+    @pytest.mark.parametrize(
+        ("input_dtype", "output_dtype"),
+        [
+            (DataType.INT8, DataType.INT32),
+            (DataType.FP16, DataType.FP32),
+            (DataType.BF16, DataType.FP32),
+            (DataType.FP32, DataType.FP32),
+        ],
+    )
+    def test_tile_gemv_family_accepts_supported_dtype_triples(self, input_dtype, output_dtype):
+        span = ir.Span.unknown()
+        lhs = ir.Var(
+            "lhs",
+            ir.TileType([1, 128], input_dtype, tile_view=ir.TileView(valid_shape=[1, 64])),
+            span,
+        )
+        rhs = ir.Var(
+            "rhs",
+            ir.TileType([128, 128], input_dtype, tile_view=ir.TileView(valid_shape=[64, 48])),
+            span,
+        )
+        acc = ir.Var(
+            "acc",
+            ir.TileType([16, 128], output_dtype, tile_view=ir.TileView(valid_shape=[1, 48])),
+            span,
+        )
+        bias = ir.Var(
+            "bias",
+            ir.TileType([1, 128], output_dtype, tile_view=ir.TileView(valid_shape=[1, 48])),
+            span,
+        )
+
+        for call in (tile.gemv(lhs, rhs), tile.gemv_acc(acc, lhs, rhs), tile.gemv_bias(lhs, rhs, bias)):
+            result_type = call.type
+            assert isinstance(result_type, ir.TileType)
+            assert result_type.dtype == output_dtype
+
+    def test_tile_gemv_rejects_insufficient_rhs_logical_k(self):
+        span = ir.Span.unknown()
+        lhs = ir.Var(
+            "lhs",
+            ir.TileType([1, 128], DataType.FP32, tile_view=ir.TileView(valid_shape=[1, 96])),
+            span,
+        )
+        rhs = ir.Var(
+            "rhs",
+            ir.TileType([128, 128], DataType.FP32, tile_view=ir.TileView(valid_shape=[64, 48])),
+            span,
+        )
+
+        with pytest.raises(ValueError, match="rhs valid K to cover lhs valid K"):
+            tile.gemv(lhs, rhs)
+
+    def test_tile_gemv_rejects_unsupported_input_dtype(self):
+        span = ir.Span.unknown()
+        lhs = ir.Var("lhs", ir.TileType([1, 128], DataType.INT16), span)
+        rhs = ir.Var("rhs", ir.TileType([128, 128], DataType.INT16), span)
+
+        with pytest.raises(ValueError, match="supports only INT8"):
+            tile.gemv(lhs, rhs)
+
+    def test_tile_gemv_rejects_mixed_input_dtypes(self):
+        span = ir.Span.unknown()
+        lhs = ir.Var("lhs", ir.TileType([1, 128], DataType.FP16), span)
+        rhs = ir.Var("rhs", ir.TileType([128, 128], DataType.FP32), span)
+
+        with pytest.raises(ValueError, match="identical lhs and rhs data types"):
+            tile.gemv(lhs, rhs)
+
+    def test_tile_gemv_bias_rejects_input_dtype_bias(self):
+        span = ir.Span.unknown()
+        lhs = ir.Var("lhs", ir.TileType([1, 128], DataType.FP16), span)
+        rhs = ir.Var("rhs", ir.TileType([128, 128], DataType.FP16), span)
+        bias = ir.Var("bias", ir.TileType([1, 128], DataType.FP16), span)
+
+        with pytest.raises(ValueError, match="requires bias dtype fp32"):
+            tile.gemv_bias(lhs, rhs, bias)
+
+    def test_tile_gemv_acc_rejects_input_dtype_accumulator(self):
+        span = ir.Span.unknown()
+        lhs = ir.Var("lhs", ir.TileType([1, 128], DataType.FP16), span)
+        rhs = ir.Var("rhs", ir.TileType([128, 128], DataType.FP16), span)
+        acc = ir.Var("acc", ir.TileType([16, 128], DataType.FP16), span)
+
+        with pytest.raises(ValueError, match="requires accumulator dtype fp32"):
+            tile.gemv_acc(acc, lhs, rhs)
+
+    def test_tile_gemv_rejects_multiple_logical_lhs_rows(self):
+        span = ir.Span.unknown()
+        lhs = ir.Var(
+            "lhs",
+            ir.TileType([1, 128], DataType.FP32, tile_view=ir.TileView(valid_shape=[2, 64])),
+            span,
+        )
+        rhs = ir.Var(
+            "rhs",
+            ir.TileType([128, 128], DataType.FP32, tile_view=ir.TileView(valid_shape=[64, 48])),
+            span,
+        )
+
+        with pytest.raises(ValueError, match="logical row extent to be exactly 1"):
+            tile.gemv(lhs, rhs)
+
+    def test_tile_gemv_rejects_padded_physical_lhs_rows(self):
+        span = ir.Span.unknown()
+        lhs = ir.Var(
+            "lhs",
+            ir.TileType([16, 128], DataType.FP32, tile_view=ir.TileView(valid_shape=[1, 64])),
+            span,
+        )
+        rhs = ir.Var(
+            "rhs",
+            ir.TileType([128, 128], DataType.FP32, tile_view=ir.TileView(valid_shape=[64, 48])),
+            span,
+        )
+
+        with pytest.raises(ValueError, match="physical row extent to be exactly 1"):
+            tile.gemv(lhs, rhs)
+
+    def test_tile_gemv_bias_rejects_undersized_valid_shape(self):
+        span = ir.Span.unknown()
+        lhs = ir.Var(
+            "lhs",
+            ir.TileType([1, 128], DataType.FP32, tile_view=ir.TileView(valid_shape=[1, 64])),
+            span,
+        )
+        rhs = ir.Var(
+            "rhs",
+            ir.TileType([128, 128], DataType.FP32, tile_view=ir.TileView(valid_shape=[64, 48])),
+            span,
+        )
+        bias = ir.Var(
+            "bias",
+            ir.TileType([1, 128], DataType.FP32, tile_view=ir.TileView(valid_shape=[1, 32])),
+            span,
+        )
+
+        with pytest.raises(ValueError, match=r"bias valid N to cover output valid N=48"):
+            tile.gemv_bias(lhs, rhs, bias)
+
+    def test_tile_gemv_acc_rejects_mismatched_valid_shape(self):
+        span = ir.Span.unknown()
+        lhs = ir.Var(
+            "lhs",
+            ir.TileType([1, 128], DataType.FP32, tile_view=ir.TileView(valid_shape=[1, 64])),
+            span,
+        )
+        rhs = ir.Var(
+            "rhs",
+            ir.TileType([128, 128], DataType.FP32, tile_view=ir.TileView(valid_shape=[64, 48])),
+            span,
+        )
+        acc = ir.Var(
+            "acc",
+            ir.TileType([16, 128], DataType.FP32, tile_view=ir.TileView(valid_shape=[1, 32])),
+            span,
+        )
+
+        with pytest.raises(ValueError, match="accumulator valid_shape"):
+            tile.gemv_acc(acc, lhs, rhs)
 
 
 class TestTileTransformOps:
@@ -6312,7 +6473,7 @@ class TestDestinationSpaceLayoutDeduction:
         assert _valid_of(result_type) == [16, 16]
 
     def test_gemv_bias_uses_the_shared_product_geometry_contract(self):
-        """The shared biased-product deducer also preserves GEMV valid N."""
+        """Shared bias geometry preserves GEMV's padded Acc box and valid N."""
         lhs = _partial_tile([1, 64], [1, 48], name="lhs")
         rhs = _partial_tile([64, 32], [64, 16], name="rhs")
         bias = _partial_tile([1, 32], [1, 24], name="bias")
@@ -6320,7 +6481,7 @@ class TestDestinationSpaceLayoutDeduction:
         result_type = tile.gemv_bias(lhs, rhs, bias).type
 
         assert isinstance(result_type, ir.TileType)
-        assert [cast(ir.ConstInt, dim).value for dim in result_type.shape] == [1, 32]
+        assert [cast(ir.ConstInt, dim).value for dim in result_type.shape] == [16, 32]
         assert _valid_of(result_type) == [1, 16]
 
     def test_matmul_bias_rejects_insufficient_valid_bias_n(self):

--- a/tests/ut/ir/operators/test_tile_ops.py
+++ b/tests/ut/ir/operators/test_tile_ops.py
@@ -2357,7 +2357,7 @@ class TestTileMatMulOps:
             ) -> pl.Tensor[[1, 128], pl.FP32]:
                 tile_a: pl.Tile[[1, 16], pl.FP32] = pl.load(a, [0, 0], [1, 16])
                 tile_b: pl.Tile[[16, 32], pl.FP32] = pl.load(b, [0, 0], [16, 32])
-                tile_c: pl.Tile[[1, 32], pl.FP32] = pl.gemv(tile_a, tile_b)
+                tile_c: pl.Tile[[16, 32], pl.FP32] = pl.gemv(tile_a, tile_b)
                 result: pl.Tensor[[1, 128], pl.FP32] = pl.store(tile_c, [0, 0], output)
                 return result
 
@@ -2372,15 +2372,15 @@ class TestTileMatMulOps:
             @pl.function(type=pl.FunctionType.InCore)
             def main(
                 self,
-                acc_in: pl.Tensor[[1, 128], pl.FP32],
+                acc_in: pl.Tensor[[16, 128], pl.FP32],
                 a: pl.Tensor[[1, 64], pl.FP32],
                 b: pl.Tensor[[64, 128], pl.FP32],
                 output: pl.Tensor[[1, 128], pl.FP32],
             ) -> pl.Tensor[[1, 128], pl.FP32]:
-                tile_acc: pl.Tile[[1, 32], pl.FP32] = pl.load(acc_in, [0, 0], [1, 32])
+                tile_acc: pl.Tile[[16, 32], pl.FP32] = pl.load(acc_in, [0, 0], [16, 32], valid_shapes=[1, 32])
                 tile_a: pl.Tile[[1, 16], pl.FP32] = pl.load(a, [0, 0], [1, 16])
                 tile_b: pl.Tile[[16, 32], pl.FP32] = pl.load(b, [0, 0], [16, 32])
-                tile_c: pl.Tile[[1, 32], pl.FP32] = pl.gemv_acc(tile_acc, tile_a, tile_b)
+                tile_c: pl.Tile[[16, 32], pl.FP32] = pl.gemv_acc(tile_acc, tile_a, tile_b)
                 result: pl.Tensor[[1, 128], pl.FP32] = pl.store(tile_c, [0, 0], output)
                 return result
 
@@ -2403,12 +2403,45 @@ class TestTileMatMulOps:
                 tile_a: pl.Tile[[1, 16], pl.FP32] = pl.load(a, [0, 0], [1, 16])
                 tile_b: pl.Tile[[16, 32], pl.FP32] = pl.load(b, [0, 0], [16, 32])
                 tile_bias: pl.Tile[[1, 32], pl.FP32] = pl.load(bias, [0, 0], [1, 32])
-                tile_c: pl.Tile[[1, 32], pl.FP32] = pl.gemv_bias(tile_a, tile_b, tile_bias)
+                tile_c: pl.Tile[[16, 32], pl.FP32] = pl.gemv_bias(tile_a, tile_b, tile_bias)
                 result: pl.Tensor[[1, 128], pl.FP32] = pl.store(tile_c, [0, 0], output)
                 return result
 
         ir_str = str(Program)
         assert "tile.gemv_bias" in ir_str
+
+    def test_tile_gemv_physical_accumulator_and_logical_valid_shape(self):
+        """GEMV pads Acc rows to 16 while preserving the logical [1, N] extent."""
+        span = ir.Span.unknown()
+        lhs = ir.Var(
+            "lhs",
+            ir.TileType([1, 128], DataType.FP32, tile_view=ir.TileView(valid_shape=[1, 64])),
+            span,
+        )
+        rhs = ir.Var(
+            "rhs",
+            ir.TileType([128, 128], DataType.FP32, tile_view=ir.TileView(valid_shape=[64, 48])),
+            span,
+        )
+        bias = ir.Var(
+            "bias",
+            ir.TileType([1, 128], DataType.FP32, tile_view=ir.TileView(valid_shape=[1, 48])),
+            span,
+        )
+
+        result = tile.gemv(lhs, rhs)
+        result_type = result.type
+        assert isinstance(result_type, ir.TileType)
+        assert [d.value for d in result_type.shape if isinstance(d, ir.ConstInt)] == [16, 128]
+        assert _valid_of(result_type) == [1, 48]
+
+        acc_result = tile.gemv_acc(result, lhs, rhs)
+        bias_result = tile.gemv_bias(lhs, rhs, bias)
+        for call in (acc_result, bias_result):
+            call_type = call.type
+            assert isinstance(call_type, ir.TileType)
+            assert [d.value for d in call_type.shape if isinstance(d, ir.ConstInt)] == [16, 128]
+            assert _valid_of(call_type) == [1, 48]
 
 
 class TestTileTransformOps:

--- a/tests/ut/ir/transforms/test_auto_tile_matmul_l0.py
+++ b/tests/ut/ir/transforms/test_auto_tile_matmul_l0.py
@@ -879,10 +879,10 @@ class TestAutoTileMatmulL0MNTiling:
         assert "pl.tile.matmul_bias(" in printed
         assert "pl.tile.matmul_acc(" in printed
         assert "pl.tile.slice(bias_mat" not in printed
-        assert "pl.tile.load(bias," in printed
-        assert not re.search(
-            r"^\s*bias_mat:.*tile\.load\(bias, \[0, 0\], \[1, 512\]", printed, re.MULTILINE
-        ), "the original redundant full bias load must be removed"
+        assert re.search(r"pl\.tile\.load\(\s*bias,", printed)
+        assert not re.search(r"pl\.tile\.load\(\s*bias,\s*\[0, 0\],\s*\[1, 512\]", printed), (
+            "the original redundant full bias load must be removed"
+        )
         assert "pl.tile.move(" in printed and "target_memory=pl.Mem.Bias" in printed
         assert "pl.tile.extract(bias_mat" not in printed
         assert "target_memory=pl.Mem.Bias" in printed
@@ -1016,7 +1016,7 @@ class TestAutoTileMatmulL0MNTiling:
 
         After = passes.auto_tile_matmul_l0()(Before)
         printed = ir.python_print(After)
-        assert "pl.tile.load(bias, [0, 512], [1, 16], [1, 16]" in printed
+        assert re.search(r"pl\.tile\.load\(\s*bias,\s*\[0, 512\],\s*\[1, 16\],\s*\[1, 16\]", printed)
         assert "pl.tile.slice(bias_mat" not in printed
         assert "target_memory=pl.Mem.Bias" in printed
         assert "pl.tile.extract(bias_mat" not in printed
@@ -1101,7 +1101,9 @@ class TestAutoTileMatmulL0MNTiling:
 
         printed = ir.python_print(passes.auto_tile_matmul_l0()(Before))
         assert "pl.tile.matmul_bias(lhs_mat, rhs_mat, bias_mat)" not in printed
-        windows = [int(n) for n in re.findall(r"_bias_mat:.*tile\.load\(bias,.*\[1, (\d+)\]", printed)]
+        windows = [
+            int(n) for n in re.findall(r"pl\.tile\.load\(\s*bias,\s*\[[^]]+\],\s*\[1, (\d+)\]", printed)
+        ]
         assert windows and max(windows) <= 256
 
     def test_matmul_bias_nonfractal_mn_is_deferred(self):
@@ -3078,6 +3080,7 @@ class TestAutoTileMatmulL0ExistingPipelineDbC:
             def kernel(
                 self,
                 q: pl.Tensor[[16, 128], pl.BF16],
+                q_row: pl.Tensor[[1, 128], pl.BF16],
                 b: pl.Tensor[[128, 512], pl.BF16],
                 out: pl.Out[pl.Tensor[[16, 512], pl.FP32]],
             ) -> pl.Tensor[[16, 512], pl.FP32]:
@@ -3087,6 +3090,12 @@ class TestAutoTileMatmulL0ExistingPipelineDbC:
                 q_l0: pl.Tile[[16, 128], pl.BF16, pl.Mem.Left] = pl.tile.move(
                     q_mat, target_memory=pl.Mem.Left
                 )
+                q_row_mat: pl.Tile[[1, 128], pl.BF16, pl.Mem.Mat] = pl.tile.load(
+                    q_row, [0, 0], [1, 128], target_memory=pl.Mem.Mat
+                )
+                q_row_l0: pl.Tile[[1, 128], pl.BF16, pl.Mem.Left] = pl.tile.move(
+                    q_row_mat, target_memory=pl.Mem.Left
+                )
                 b_mat: pl.Tile[[128, 512], pl.BF16, pl.Mem.Mat] = pl.tile.load(
                     b, [0, 0], [128, 512], target_memory=pl.Mem.Mat
                 )
@@ -3094,7 +3103,7 @@ class TestAutoTileMatmulL0ExistingPipelineDbC:
                     b_l0: pl.Tile[[128, 128], pl.BF16, pl.Mem.Right] = pl.tile.extract(
                         b_mat, 0, ni, [128, 128], target_memory=pl.Mem.Right
                     )
-                    _other: pl.Tile[[16, 128], pl.FP32, pl.Mem.Acc] = pl.tile.gemv(q_l0, b_l0)
+                    _other: pl.Tile[[16, 128], pl.FP32, pl.Mem.Acc] = pl.tile.gemv(q_row_l0, b_l0)
                     c: pl.Tile[[16, 128], pl.FP32, pl.Mem.Acc] = pl.tile.matmul(q_l0, b_l0)
                     out_s: pl.Tensor[[16, 512], pl.FP32] = pl.store(c, [0, ni], out_i)
                     out_r = pl.yield_(out_s)
@@ -3534,7 +3543,7 @@ class TestAutoTileMatmulL0MatScratch:
 
         After = passes.auto_tile_matmul_l0()(Before)
         printed = ir.python_print(After)
-        assert re.search(r"^\s*bias_mat:.*tile\.load\(bias, \[0, 0\], \[1, 192\]", printed, re.MULTILINE)
+        assert re.search(r"pl\.tile\.load\(\s*bias,\s*\[0, 0\],\s*\[1, 192\]", printed)
         assert printed.count("pl.tile.matmul_bias(") == 1
         assert "pl.tile.matmul_acc(" in printed
         assert "pl.tile.assemble(" in printed

--- a/tests/ut/ir/transforms/test_expand_mixed_kernel_a5.py
+++ b/tests/ut/ir/transforms/test_expand_mixed_kernel_a5.py
@@ -430,11 +430,11 @@ def _make_cube_acc_before(cube_op: str):
             @pl.function(type=pl.FunctionType.InCore)
             def main_incore_0(
                 self,
-                a: pl.Tensor[[16, 128], pl.BF16],
+                a: pl.Tensor[[1, 128], pl.BF16],
                 b: pl.Tensor[[128, 128], pl.BF16],
-                out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
-            ) -> pl.Tensor[[16, 128], pl.FP32]:
-                a_mat = pl.load(a, [0, 0], [16, 128], target_memory=pl.MemorySpace.Mat)
+                out_0: pl.Out[pl.Tensor[[1, 128], pl.FP32]],
+            ) -> pl.Tensor[[1, 128], pl.FP32]:
+                a_mat = pl.load(a, [0, 0], [1, 128], target_memory=pl.MemorySpace.Mat)
                 a_left = pl.move(a_mat, target_memory=pl.MemorySpace.Left)
                 b_mat = pl.load(b, [0, 0], [128, 128], target_memory=pl.MemorySpace.Mat)
                 b_right = pl.move(b_mat, target_memory=pl.MemorySpace.Right)
@@ -448,7 +448,7 @@ def _make_cube_acc_before(cube_op: str):
                     blayout=pl.TileLayout.row_major,
                     slayout=pl.TileLayout.none_box,
                 )
-                out_0: pl.Tensor[[16, 128], pl.FP32] = pl.store(d_vec, [0, 0], out_0)
+                out_0: pl.Tensor[[1, 128], pl.FP32] = pl.store(d_vec, [0, 0], out_0)
                 return out_0
 
         return BeforeGemvAcc
@@ -515,11 +515,11 @@ def _make_cube_acc_expected(cube_op: str):
             @pl.function(type=pl.FunctionType.AIC)
             def main_incore_0_aic(
                 self,
-                a: pl.Tensor[[16, 128], pl.BF16],
+                a: pl.Tensor[[1, 128], pl.BF16],
                 b: pl.Tensor[[128, 128], pl.BF16],
-                out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
+                out_0: pl.Out[pl.Tensor[[1, 128], pl.FP32]],
             ):
-                a_mat = pl.load(a, [0, 0], [16, 128], target_memory=pl.MemorySpace.Mat)
+                a_mat = pl.load(a, [0, 0], [1, 128], target_memory=pl.MemorySpace.Mat)
                 a_left = pl.move(a_mat, target_memory=pl.MemorySpace.Left)
                 b_mat = pl.load(b, [0, 0], [128, 128], target_memory=pl.MemorySpace.Mat)
                 b_right = pl.move(b_mat, target_memory=pl.MemorySpace.Right)
@@ -532,23 +532,26 @@ def _make_cube_acc_expected(cube_op: str):
             @pl.function(type=pl.FunctionType.AIV)
             def main_incore_0_aiv(
                 self,
-                a: pl.Tensor[[16, 128], pl.BF16],
+                a: pl.Tensor[[1, 128], pl.BF16],
                 b: pl.Tensor[[128, 128], pl.BF16],
-                out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
-            ) -> pl.Tensor[[16, 128], pl.FP32]:
-                d_vec: pl.Tile[[16, 128], pl.FP32, pl.MemorySpace.Vec, pl.TileView()] = pl.tpop_from_aic(
-                    split=0
-                )
+                out_0: pl.Out[pl.Tensor[[1, 128], pl.FP32]],
+            ) -> pl.Tensor[[1, 128], pl.FP32]:
+                d_vec: pl.Tile[
+                    [16, 128],
+                    pl.FP32,
+                    pl.MemorySpace.Vec,
+                    pl.TileView(valid_shape=[1, 128]),
+                ] = pl.tpop_from_aic(split=0)
                 out_0_store = pl.store(d_vec, [0, 0], out_0)
                 return out_0_store
 
             @pl.function(type=pl.FunctionType.Group)
             def main_incore_0(
                 self,
-                a: pl.Tensor[[16, 128], pl.BF16],
+                a: pl.Tensor[[1, 128], pl.BF16],
                 b: pl.Tensor[[128, 128], pl.BF16],
-                out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
-            ) -> pl.Tensor[[16, 128], pl.FP32]:
+                out_0: pl.Out[pl.Tensor[[1, 128], pl.FP32]],
+            ) -> pl.Tensor[[1, 128], pl.FP32]:
                 self.main_incore_0_aic(a, b, out_0)
                 self.main_incore_0_aiv(a, b, out_0)
                 return out_0
@@ -570,11 +573,11 @@ def _make_gemv_expected():
         @pl.function(type=pl.FunctionType.AIC)
         def main_incore_0_aic(
             self,
-            a: pl.Tensor[[16, 128], pl.BF16],
+            a: pl.Tensor[[1, 128], pl.BF16],
             b: pl.Tensor[[128, 128], pl.BF16],
-            out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
+            out_0: pl.Out[pl.Tensor[[1, 128], pl.FP32]],
         ):
-            a_mat = pl.load(a, [0, 0], [16, 128], target_memory=pl.MemorySpace.Mat)
+            a_mat = pl.load(a, [0, 0], [1, 128], target_memory=pl.MemorySpace.Mat)
             a_left = pl.move(a_mat, target_memory=pl.MemorySpace.Left)
             b_mat = pl.load(b, [0, 0], [128, 128], target_memory=pl.MemorySpace.Mat)
             b_right = pl.move(b_mat, target_memory=pl.MemorySpace.Right)
@@ -584,21 +587,26 @@ def _make_gemv_expected():
         @pl.function(type=pl.FunctionType.AIV)
         def main_incore_0_aiv(
             self,
-            a: pl.Tensor[[16, 128], pl.BF16],
+            a: pl.Tensor[[1, 128], pl.BF16],
             b: pl.Tensor[[128, 128], pl.BF16],
-            out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
-        ) -> pl.Tensor[[16, 128], pl.FP32]:
-            c_vec: pl.Tile[[16, 128], pl.FP32, pl.MemorySpace.Vec, pl.TileView()] = pl.tpop_from_aic(split=0)
-            out_0_store: pl.Tensor[[16, 128], pl.FP32] = pl.store(c_vec, [0, 0], out_0)
+            out_0: pl.Out[pl.Tensor[[1, 128], pl.FP32]],
+        ) -> pl.Tensor[[1, 128], pl.FP32]:
+            c_vec: pl.Tile[
+                [16, 128],
+                pl.FP32,
+                pl.MemorySpace.Vec,
+                pl.TileView(valid_shape=[1, 128]),
+            ] = pl.tpop_from_aic(split=0)
+            out_0_store: pl.Tensor[[1, 128], pl.FP32] = pl.store(c_vec, [0, 0], out_0)
             return out_0_store
 
         @pl.function(type=pl.FunctionType.Group)
         def main_incore_0(
             self,
-            a: pl.Tensor[[16, 128], pl.BF16],
+            a: pl.Tensor[[1, 128], pl.BF16],
             b: pl.Tensor[[128, 128], pl.BF16],
-            out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
-        ) -> pl.Tensor[[16, 128], pl.FP32]:
+            out_0: pl.Out[pl.Tensor[[1, 128], pl.FP32]],
+        ) -> pl.Tensor[[1, 128], pl.FP32]:
             self.main_incore_0_aic(a, b, out_0)
             self.main_incore_0_aiv(a, b, out_0)
             return out_0
@@ -1509,11 +1517,11 @@ class TestCubeOpVariants:
             @pl.function(type=pl.FunctionType.InCore)
             def main_incore_0(
                 self,
-                a: pl.Tensor[[16, 128], pl.BF16],
+                a: pl.Tensor[[1, 128], pl.BF16],
                 b: pl.Tensor[[128, 128], pl.BF16],
-                out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
-            ) -> pl.Tensor[[16, 128], pl.FP32]:
-                a_mat = pl.load(a, [0, 0], [16, 128], target_memory=pl.MemorySpace.Mat)
+                out_0: pl.Out[pl.Tensor[[1, 128], pl.FP32]],
+            ) -> pl.Tensor[[1, 128], pl.FP32]:
+                a_mat = pl.load(a, [0, 0], [1, 128], target_memory=pl.MemorySpace.Mat)
                 a_left = pl.move(a_mat, target_memory=pl.MemorySpace.Left)
                 b_mat = pl.load(b, [0, 0], [128, 128], target_memory=pl.MemorySpace.Mat)
                 b_right = pl.move(b_mat, target_memory=pl.MemorySpace.Right)
@@ -1524,7 +1532,7 @@ class TestCubeOpVariants:
                     blayout=pl.TileLayout.row_major,
                     slayout=pl.TileLayout.none_box,
                 )
-                out_0: pl.Tensor[[16, 128], pl.FP32] = pl.store(c_vec, [0, 0], out_0)
+                out_0: pl.Tensor[[1, 128], pl.FP32] = pl.store(c_vec, [0, 0], out_0)
                 return out_0
 
         Expected = _make_gemv_expected()
@@ -1674,11 +1682,11 @@ class TestMultipleInCore:
             @pl.function(type=pl.FunctionType.InCore)
             def compute_b_incore_0(
                 self,
-                a: pl.Tensor[[16, 128], pl.BF16],
+                a: pl.Tensor[[1, 128], pl.BF16],
                 b: pl.Tensor[[128, 128], pl.BF16],
-                out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
-            ) -> pl.Tensor[[16, 128], pl.FP32]:
-                a_mat = pl.load(a, [0, 0], [16, 128], target_memory=pl.MemorySpace.Mat)
+                out_0: pl.Out[pl.Tensor[[1, 128], pl.FP32]],
+            ) -> pl.Tensor[[1, 128], pl.FP32]:
+                a_mat = pl.load(a, [0, 0], [1, 128], target_memory=pl.MemorySpace.Mat)
                 a_left = pl.move(a_mat, target_memory=pl.MemorySpace.Left)
                 b_mat = pl.load(b, [0, 0], [128, 128], target_memory=pl.MemorySpace.Mat)
                 b_right = pl.move(b_mat, target_memory=pl.MemorySpace.Right)
@@ -1689,7 +1697,7 @@ class TestMultipleInCore:
                     blayout=pl.TileLayout.row_major,
                     slayout=pl.TileLayout.none_box,
                 )
-                out_0: pl.Tensor[[16, 128], pl.FP32] = pl.store(c_vec, [0, 0], out_0)
+                out_0: pl.Tensor[[1, 128], pl.FP32] = pl.store(c_vec, [0, 0], out_0)
                 return out_0
 
         After = _expand(Before)
@@ -1737,11 +1745,11 @@ class TestMultipleInCore:
             @pl.function(type=pl.FunctionType.AIC)
             def compute_b_incore_0_aic(
                 self,
-                a: pl.Tensor[[16, 128], pl.BF16],
+                a: pl.Tensor[[1, 128], pl.BF16],
                 b: pl.Tensor[[128, 128], pl.BF16],
-                out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
+                out_0: pl.Out[pl.Tensor[[1, 128], pl.FP32]],
             ):
-                a_mat = pl.load(a, [0, 0], [16, 128], target_memory=pl.MemorySpace.Mat)
+                a_mat = pl.load(a, [0, 0], [1, 128], target_memory=pl.MemorySpace.Mat)
                 a_left = pl.move(a_mat, target_memory=pl.MemorySpace.Left)
                 b_mat = pl.load(b, [0, 0], [128, 128], target_memory=pl.MemorySpace.Mat)
                 b_right = pl.move(b_mat, target_memory=pl.MemorySpace.Right)
@@ -1751,23 +1759,26 @@ class TestMultipleInCore:
             @pl.function(type=pl.FunctionType.AIV)
             def compute_b_incore_0_aiv(
                 self,
-                a: pl.Tensor[[16, 128], pl.BF16],
+                a: pl.Tensor[[1, 128], pl.BF16],
                 b: pl.Tensor[[128, 128], pl.BF16],
-                out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
-            ) -> pl.Tensor[[16, 128], pl.FP32]:
-                c_vec: pl.Tile[[16, 128], pl.FP32, pl.MemorySpace.Vec, pl.TileView()] = pl.tpop_from_aic(
-                    split=0
-                )
+                out_0: pl.Out[pl.Tensor[[1, 128], pl.FP32]],
+            ) -> pl.Tensor[[1, 128], pl.FP32]:
+                c_vec: pl.Tile[
+                    [16, 128],
+                    pl.FP32,
+                    pl.MemorySpace.Vec,
+                    pl.TileView(valid_shape=[1, 128]),
+                ] = pl.tpop_from_aic(split=0)
                 out_0_store = pl.store(c_vec, [0, 0], out_0)
                 return out_0_store
 
             @pl.function(type=pl.FunctionType.Group)
             def compute_b_incore_0(
                 self,
-                a: pl.Tensor[[16, 128], pl.BF16],
+                a: pl.Tensor[[1, 128], pl.BF16],
                 b: pl.Tensor[[128, 128], pl.BF16],
-                out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
-            ) -> pl.Tensor[[16, 128], pl.FP32]:
+                out_0: pl.Out[pl.Tensor[[1, 128], pl.FP32]],
+            ) -> pl.Tensor[[1, 128], pl.FP32]:
                 self.compute_b_incore_0_aic(a, b, out_0)
                 self.compute_b_incore_0_aiv(a, b, out_0)
                 return out_0

--- a/tests/ut/ir/transforms/test_expand_mixed_kernel_a5.py
+++ b/tests/ut/ir/transforms/test_expand_mixed_kernel_a5.py
@@ -364,9 +364,12 @@ def _make_cube_bias_expected(cube_op: str):
                     slayout=pl.TileLayout.row_major,
                 )
                 pl.tpush_to_aic(bias_tile_nz, split=0)
-                c_vec: pl.Tile[[1, 128], pl.FP32, pl.MemorySpace.Vec, pl.TileView()] = pl.tpop_from_aic(
-                    split=0
-                )
+                c_vec: pl.Tile[
+                    [16, 128],
+                    pl.FP32,
+                    pl.MemorySpace.Vec,
+                    pl.TileView(valid_shape=[1, 128]),
+                ] = pl.tpop_from_aic(split=0)
                 out_0_store = pl.store(c_vec, [0, 0], out_0)
                 return out_0_store
 


### PR DESCRIPTION
## Summary

- select PTO-ISA's single-row Mat layout for GEMV lhs and bias loads
- model GEMV results as a 16-row physical Acc tile while preserving logical `[1, N]` validity
- add A2/A3 same-name ST coverage for `pto.tgemv`, `pto.tgemv.acc`, and `pto.tgemv.bias`, including FP16/BF16, narrow-K, bias, and accumulation cases
- document the physical/logical GEMV contract and update the verified operator-status rows

## Validation

- `ruff check` and `ruff format --check` on touched Python tests
- `clang-format --dry-run --Werror` on touched C++ files
- diff-scoped `clang-tidy --jobs=1` passed (remote host LLVM 18.1.8; project pin warning expects 21.1.0)
- focused UT/codegen: 11 passed, 604 deselected
- A2/A3 codegen-only ST: 13 passed; emitted 13 `.pto` files with 16-row Acc tiles and exact base/acc/bias ops
- A2/A3 hardware ST through one task-submit batch: 13/13 passed on device 1