### PR TITLE
feat(codegen): validate carry op family

### DIFF
--- a/docs/en/dev/codegen/00-pto_codegen.md
+++ b/docs/en/dev/codegen/00-pto_codegen.md
@@ -140,7 +140,10 @@ print(pto_code)
 | `tile.slice(tile, [h, w], [row, col][, valid_shape=...])` | `pto.subview` (zero-copy view; `valid [...]` clause emitted only when `valid_shape` is supplied) |
 | `tile.assemble(target, source, [row, col])` | (optional) `pto.tmov target -> dst` + `pto.subview dst[row, col] sizes [src.rows, src.cols]` + `pto.tmov src -> dst_view` |
 | `tile.mul(lhs, rhs)` | `pto.tmul` |
-| `tile.add(a, b, c)` | `pto.taddc` (3-operand add) |
+| `tile.addc(src0, src1, carry)` | `pto.taddc` (`src0 + src1 + carry`) |
+| `tile.subc(src0, src1, carry)` | `pto.tsubc` (`src0 - src1 + carry`) |
+| `tile.addsc(src0, scalar, carry)` | `pto.taddsc` (`src0 + scalar + carry`) |
+| `tile.subsc(src0, scalar, carry)` | `pto.tsubsc` (`src0 - scalar + carry`) |
 | `tile.adds(tile, scalar)` | `pto.tadds` (tile + scalar) |
 | `tile.fillpad_expand(src, shape)` | `pto.tfillpad_expand ins(%src) outs(%dst)` (the `shape` tuple is type-deduction only; the larger `dst` and its pad come from the result type) |
 

--- a/docs/en/dev/codegen/00-pto_codegen.md
+++ b/docs/en/dev/codegen/00-pto_codegen.md
@@ -141,7 +141,10 @@ print(pto_code)
 | `tile.assemble(target, source, [row, col])` | (optional) `pto.tmov target -> dst` + `pto.subview dst[row, col] sizes [src.rows, src.cols]` + `pto.tmov src -> dst_view` |
 | `tile.set_validshape(tile, vr, vc)` | `pto.set_validshape`; a view operand is rejected (see below) |
 | `tile.mul(lhs, rhs)` | `pto.tmul` |
-| `tile.add(a, b, c)` | `pto.taddc` (3-operand add) |
+| `tile.addc(src0, src1, carry)` | `pto.taddc` (`src0 + src1 + carry`) |
+| `tile.subc(src0, src1, carry)` | `pto.tsubc` (`src0 - src1 + carry`) |
+| `tile.addsc(src0, scalar, carry)` | `pto.taddsc` (`src0 + scalar + carry`) |
+| `tile.subsc(src0, scalar, carry)` | `pto.tsubsc` (`src0 - scalar + carry`) |
 | `tile.adds(tile, scalar)` | `pto.tadds` (tile + scalar) |
 | `tile.fillpad_expand(src, shape)` | `pto.tfillpad_expand ins(%src) outs(%dst)` (the `shape` tuple is type-deduction only; the larger `dst` and its pad come from the result type) |
 

--- a/docs/en/dev/ptoas-op-status.md
+++ b/docs/en/dev/ptoas-op-status.md
@@ -109,10 +109,10 @@ for lowering/compiler plumbing, plus other dialects such as VPTO, VMI, and SIMT.
 | pto.tmaxs | TMAXS | tile | ✅ | ✅ | ❌ | ✅ | — |  |
 | pto.tmins | TMINS | tile | ✅ | ✅ | ❌ | ✅ | — |  |
 | pto.trems | TREMS | tile | ✅ | ✅ | ❌ | ❌ | — | path exists; historical ISA/semantic issue requires revalidation against the current pin |
-| pto.taddc | TADD + TADD | tile | ✅ | ✅ | ❌ | ❌ | — | path exists; historical ISA/semantic issue requires revalidation against the current pin |
-| pto.tsubc | TSUB + TADD | tile | ✅ | ✅ | ❌ | ❌ | — | path exists; historical ISA/semantic issue requires revalidation against the current pin |
-| pto.taddsc | TADDS + TADD | tile | ✅ | ✅ | ❌ | ❌ | — | path exists; historical ISA/semantic issue requires revalidation against the current pin |
-| pto.tsubsc | TSUBS + TADD | tile | ✅ | ✅ | ❌ | ❌ | — | path exists; historical ISA/semantic issue requires revalidation against the current pin |
+| pto.taddc | TADD + TADD | tile | ✅ | ✅ | ❌ | ✅ | — | verified on A2/A3 hardware, including overflow and valid_shape; A5 hardware verification pending |
+| pto.tsubc | TSUB + TADD | tile | ✅ | ✅ | ❌ | ✅ | — | verified on A2/A3 hardware, including borrow and valid_shape; A5 hardware verification pending |
+| pto.taddsc | TADDS + TADD | tile | ✅ | ✅ | ❌ | ✅ | — | verified on A2/A3 hardware, including overflow and valid_shape; A5 hardware verification pending |
+| pto.tsubsc | TSUBS + TADD | tile | ✅ | ✅ | ❌ | ✅ | — | verified on A2/A3 hardware, including borrow and valid_shape; A5 hardware verification pending |
 | pto.tabs | TABS | tile+tensor | ✅ | ✅ | ✅ | ✅ | — |  |
 | pto.tneg | TNEG | tile+tensor | ✅ | ✅ | ✅ | ✅ | — |  |
 | pto.texp | TEXP | tile+tensor | ✅ | ✅ | ✅ | ✅ | — |  |
@@ -274,5 +274,5 @@ for lowering/compiler plumbing, plus other dialects such as VPTO, VMI, and SIMT.
 | pto.tassign | TASSIGN | internal | ✅ | — | — | — | — | inactive backend hook; no standalone ST |
 
 **Stats**: 204 public/compatibility PTOAS ops; 113 have a pypto tile frontend and 75 have a tensor frontend;
-110 have same-name ST coverage (106 regular STs and 4 distributed STs); 62 lack same-name ST coverage
-(52 regular and 10 distributed); within these 204, another 32 ops are not suitable for standalone STs.
+114 have same-name ST coverage (110 regular STs and 4 distributed STs); 58 lack same-name ST coverage
+(48 regular and 10 distributed); within these 204, another 32 ops are not suitable for standalone STs.

--- a/docs/en/dev/ptoas-op-status.md
+++ b/docs/en/dev/ptoas-op-status.md
@@ -109,10 +109,10 @@ for lowering/compiler plumbing, plus other dialects such as VPTO, VMI, and SIMT.
 | pto.tmaxs | TMAXS | tile | ✅ | ✅ | ❌ | ✅ | — |  |
 | pto.tmins | TMINS | tile | ✅ | ✅ | ❌ | ✅ | — |  |
 | pto.trems | TREMS | tile | ✅ | ✅ | ❌ | ✅ | — | A2/A3 exact-op hardware ST passed for FP32 and INT32 scalar forms within `[-2^24, 2^24]`, including both INT32 boundaries, negative values, and tail valid shapes; A5 hardware pending |
-| pto.taddc | TADD + TADD | tile | ✅ | ✅ | ❌ | ❌ | — | path exists; historical ISA/semantic issue requires revalidation against the current pin |
-| pto.tsubc | TSUB + TADD | tile | ✅ | ✅ | ❌ | ❌ | — | path exists; historical ISA/semantic issue requires revalidation against the current pin |
-| pto.taddsc | TADDS + TADD | tile | ✅ | ✅ | ❌ | ❌ | — | path exists; historical ISA/semantic issue requires revalidation against the current pin |
-| pto.tsubsc | TSUBS + TADD | tile | ✅ | ✅ | ❌ | ❌ | — | path exists; historical ISA/semantic issue requires revalidation against the current pin |
+| pto.taddc | TADD + TADD | tile | ✅ | ✅ | ❌ | ✅ | — | verified on A2/A3 hardware, including overflow, full/tail valid shapes, and result/src0 alias and non-alias paths; A5 hardware verification pending |
+| pto.tsubc | TSUB + TADD | tile | ✅ | ✅ | ❌ | ✅ | — | verified on A2/A3 hardware, including borrow, full/tail valid shapes, and result/src0 alias and non-alias paths; A5 hardware verification pending |
+| pto.taddsc | TADDS + TADD | tile | ✅ | ✅ | ❌ | ✅ | — | A2/A3 hardware passes full, column-tail, and combined-tail shapes with result/src0 alias and non-alias paths; PTO ISA v0.57's full-column row-tail fast path is a strict expected failure; A5 hardware verification pending |
+| pto.tsubsc | TSUBS + TADD | tile | ✅ | ✅ | ❌ | ✅ | — | A2/A3 hardware passes full, column-tail, and combined-tail shapes with result/src0 alias and non-alias paths; PTO ISA v0.57's full-column row-tail fast path is a strict expected failure; A5 hardware verification pending |
 | pto.tabs | TABS | tile+tensor | ✅ | ✅ | ✅ | ✅ | — |  |
 | pto.tneg | TNEG | tile+tensor | ✅ | ✅ | ✅ | ✅ | — |  |
 | pto.texp | TEXP | tile+tensor | ✅ | ✅ | ✅ | ✅ | — |  |
@@ -274,6 +274,6 @@ for lowering/compiler plumbing, plus other dialects such as VPTO, VMI, and SIMT.
 | pto.tassign | TASSIGN | internal | ✅ | — | — | — | — | inactive backend hook; no standalone ST |
 
 **Stats**: 204 public/compatibility PTOAS ops; 113 have a pypto tile frontend and 75 have a tensor frontend
-(plus four non-tile/tensor `pl.prefetch.*` ops); 111 have same-name ST coverage
-(107 regular STs and 4 distributed STs); 61 lack same-name ST coverage (51 regular and 10 distributed);
+(plus four non-tile/tensor `pl.prefetch.*` ops); 115 have same-name ST coverage
+(111 regular STs and 4 distributed STs); 57 lack same-name ST coverage (47 regular and 10 distributed);
 within these 204, another 32 ops are not suitable for standalone STs.

--- a/docs/zh/dev/codegen/00-pto_codegen.md
+++ b/docs/zh/dev/codegen/00-pto_codegen.md
@@ -138,7 +138,10 @@ print(pto_code)
 | `tile.slice(tile, [h, w], [row, col][, valid_shape=...])` | `pto.subview`（零拷贝视图；仅在传入 `valid_shape` 时输出 `valid [...]` 子句） |
 | `tile.assemble(target, source, [row, col])` | （可选）`pto.tmov target -> dst` + `pto.subview dst[row, col] sizes [src.rows, src.cols]` + `pto.tmov src -> dst_view` |
 | `tile.mul(lhs, rhs)` | `pto.tmul` |
-| `tile.add(a, b, c)` | `pto.taddc` (三操作数加法) |
+| `tile.addc(src0, src1, carry)` | `pto.taddc`（`src0 + src1 + carry`） |
+| `tile.subc(src0, src1, carry)` | `pto.tsubc`（`src0 - src1 + carry`） |
+| `tile.addsc(src0, scalar, carry)` | `pto.taddsc`（`src0 + scalar + carry`） |
+| `tile.subsc(src0, scalar, carry)` | `pto.tsubsc`（`src0 - scalar + carry`） |
 | `tile.adds(tile, scalar)` | `pto.tadds` (Tile + 标量) |
 | `tile.fillpad_expand(src, shape)` | `pto.tfillpad_expand ins(%src) outs(%dst)`（`shape` 元组仅用于类型推导；更大的 `dst` 及其 pad 来自结果类型） |
 

--- a/docs/zh/dev/codegen/00-pto_codegen.md
+++ b/docs/zh/dev/codegen/00-pto_codegen.md
@@ -139,7 +139,10 @@ print(pto_code)
 | `tile.assemble(target, source, [row, col])` | （可选）`pto.tmov target -> dst` + `pto.subview dst[row, col] sizes [src.rows, src.cols]` + `pto.tmov src -> dst_view` |
 | `tile.set_validshape(tile, vr, vc)` | 发 `pto.set_validshape`；操作数是视图时报错（见下） |
 | `tile.mul(lhs, rhs)` | `pto.tmul` |
-| `tile.add(a, b, c)` | `pto.taddc` (三操作数加法) |
+| `tile.addc(src0, src1, carry)` | `pto.taddc`（`src0 + src1 + carry`） |
+| `tile.subc(src0, src1, carry)` | `pto.tsubc`（`src0 - src1 + carry`） |
+| `tile.addsc(src0, scalar, carry)` | `pto.taddsc`（`src0 + scalar + carry`） |
+| `tile.subsc(src0, scalar, carry)` | `pto.tsubsc`（`src0 - scalar + carry`） |
 | `tile.adds(tile, scalar)` | `pto.tadds` (Tile + 标量) |
 | `tile.fillpad_expand(src, shape)` | `pto.tfillpad_expand ins(%src) outs(%dst)`（`shape` 元组仅用于类型推导；更大的 `dst` 及其 pad 来自结果类型） |
 

--- a/docs/zh/dev/ptoas-op-status.md
+++ b/docs/zh/dev/ptoas-op-status.md
@@ -95,10 +95,10 @@ lowering/compiler plumbing 使用的额外内部 op 未纳入，也不列 VPTO�
 | pto.tmaxs | TMAXS | tile | ✅ | ✅ | ❌ | ✅ | — |  |
 | pto.tmins | TMINS | tile | ✅ | ✅ | ❌ | ✅ | — |  |
 | pto.trems | TREMS | tile | ✅ | ✅ | ❌ | ❌ | — | 已有链路；历史 ISA/语义问题，需按当前 pin 复验 |
-| pto.taddc | TADD + TADD | tile | ✅ | ✅ | ❌ | ❌ | — | 已有链路；历史 ISA/语义问题，需按当前 pin 复验 |
-| pto.tsubc | TSUB + TADD | tile | ✅ | ✅ | ❌ | ❌ | — | 已有链路；历史 ISA/语义问题，需按当前 pin 复验 |
-| pto.taddsc | TADDS + TADD | tile | ✅ | ✅ | ❌ | ❌ | — | 已有链路；历史 ISA/语义问题，需按当前 pin 复验 |
-| pto.tsubsc | TSUBS + TADD | tile | ✅ | ✅ | ❌ | ❌ | — | 已有链路；历史 ISA/语义问题，需按当前 pin 复验 |
+| pto.taddc | TADD + TADD | tile | ✅ | ✅ | ❌ | ✅ | — | A2/A3 真机已验证，覆盖溢出与 valid_shape；A5 真机待验证 |
+| pto.tsubc | TSUB + TADD | tile | ✅ | ✅ | ❌ | ✅ | — | A2/A3 真机已验证，覆盖借位与 valid_shape；A5 真机待验证 |
+| pto.taddsc | TADDS + TADD | tile | ✅ | ✅ | ❌ | ✅ | — | A2/A3 真机已验证，覆盖溢出与 valid_shape；A5 真机待验证 |
+| pto.tsubsc | TSUBS + TADD | tile | ✅ | ✅ | ❌ | ✅ | — | A2/A3 真机已验证，覆盖借位与 valid_shape；A5 真机待验证 |
 | pto.tabs | TABS | tile+tensor | ✅ | ✅ | ✅ | ✅ | — |  |
 | pto.tneg | TNEG | tile+tensor | ✅ | ✅ | ✅ | ✅ | — |  |
 | pto.texp | TEXP | tile+tensor | ✅ | ✅ | ✅ | ✅ | — |  |
@@ -260,5 +260,5 @@ lowering/compiler plumbing 使用的额外内部 op 未纳入，也不列 VPTO�
 | pto.tassign | TASSIGN | internal | ✅ | — | — | — | — | 失活 backend hook，不独立建 ST |
 
 **统计**：共 204 个 PTOAS 公共/兼容 op；pypto tile 前端 113 个，tensor 前端 75 个；
-同名 ST 覆盖 110 个（普通 ST 106，distributed ST 4）；无同名 ST 62 个
-（普通 52，distributed 10）；这 204 个中另有 32 个 op 不适合独立 ST。
+同名 ST 覆盖 114 个（普通 ST 110，distributed ST 4）；无同名 ST 58 个
+（普通 48，distributed 10）；这 204 个中另有 32 个 op 不适合独立 ST。

--- a/docs/zh/dev/ptoas-op-status.md
+++ b/docs/zh/dev/ptoas-op-status.md
@@ -95,10 +95,10 @@ lowering/compiler plumbing 使用的额外内部 op 未纳入，也不列 VPTO�
 | pto.tmaxs | TMAXS | tile | ✅ | ✅ | ❌ | ✅ | — |  |
 | pto.tmins | TMINS | tile | ✅ | ✅ | ❌ | ✅ | — |  |
 | pto.trems | TREMS | tile | ✅ | ✅ | ❌ | ✅ | — | A2/A3 FP32 及 `[-2^24, 2^24]` 内的 INT32 scalar 同名真机 ST 已通过，覆盖 INT32 正负边界、负值与尾部 valid shape；A5 真机待验证 |
-| pto.taddc | TADD + TADD | tile | ✅ | ✅ | ❌ | ❌ | — | 已有链路；历史 ISA/语义问题，需按当前 pin 复验 |
-| pto.tsubc | TSUB + TADD | tile | ✅ | ✅ | ❌ | ❌ | — | 已有链路；历史 ISA/语义问题，需按当前 pin 复验 |
-| pto.taddsc | TADDS + TADD | tile | ✅ | ✅ | ❌ | ❌ | — | 已有链路；历史 ISA/语义问题，需按当前 pin 复验 |
-| pto.tsubsc | TSUBS + TADD | tile | ✅ | ✅ | ❌ | ❌ | — | 已有链路；历史 ISA/语义问题，需按当前 pin 复验 |
+| pto.taddc | TADD + TADD | tile | ✅ | ✅ | ❌ | ✅ | — | A2/A3 真机已验证，覆盖溢出、完整/尾部 valid shape 及 result/src0 复用与不复用路径；A5 真机待验证 |
+| pto.tsubc | TSUB + TADD | tile | ✅ | ✅ | ❌ | ✅ | — | A2/A3 真机已验证，覆盖借位、完整/尾部 valid shape 及 result/src0 复用与不复用路径；A5 真机待验证 |
+| pto.taddsc | TADDS + TADD | tile | ✅ | ✅ | ❌ | ✅ | — | A2/A3 真机的完整、列尾及行列组合尾部场景已通过，覆盖 result/src0 复用与不复用路径；PTO ISA v0.57 的全列行尾快速路径严格预期失败；A5 真机待验证 |
+| pto.tsubsc | TSUBS + TADD | tile | ✅ | ✅ | ❌ | ✅ | — | A2/A3 真机的完整、列尾及行列组合尾部场景已通过，覆盖 result/src0 复用与不复用路径；PTO ISA v0.57 的全列行尾快速路径严格预期失败；A5 真机待验证 |
 | pto.tabs | TABS | tile+tensor | ✅ | ✅ | ✅ | ✅ | — |  |
 | pto.tneg | TNEG | tile+tensor | ✅ | ✅ | ✅ | ✅ | — |  |
 | pto.texp | TEXP | tile+tensor | ✅ | ✅ | ✅ | ✅ | — |  |
@@ -260,6 +260,6 @@ lowering/compiler plumbing 使用的额外内部 op 未纳入，也不列 VPTO�
 | pto.tassign | TASSIGN | internal | ✅ | — | — | — | — | 失活 backend hook，不独立建 ST |
 
 **统计**：共 204 个 PTOAS 公共/兼容 op；pypto tile 前端 113 个，tensor 前端 75 个
-（另有 `pl.prefetch.*` 一族 4 个非 tile/tensor op）；同名 ST 覆盖 111 个
-（普通 ST 107，distributed ST 4）；无同名 ST 61 个（普通 51，distributed 10）；
+（另有 `pl.prefetch.*` 一族 4 个非 tile/tensor op）；同名 ST 覆盖 115 个
+（普通 ST 111，distributed ST 4）；无同名 ST 57 个（普通 47，distributed 10）；
 这 204 个中另有 32 个 op 不适合独立 ST。

--- a/python/pypto/debug/torch_codegen.py
+++ b/python/pypto/debug/torch_codegen.py
@@ -1140,9 +1140,9 @@ def _register_ops() -> None:  # noqa: PLR0915
 
     # tile ternary add/sub with carry
     m["tile.addc"] = lambda a, _kw: f"({a[0]} + {a[1]} + {a[2]})"
-    m["tile.subc"] = lambda a, _kw: f"({a[0]} - {a[1]} - {a[2]})"
+    m["tile.subc"] = lambda a, _kw: f"({a[0]} - {a[1]} + {a[2]})"
     m["tile.addsc"] = lambda a, _kw: f"({a[0]} + {a[1]} + {a[2]})"
-    m["tile.subsc"] = lambda a, _kw: f"({a[0]} - {a[1]} - {a[2]})"
+    m["tile.subsc"] = lambda a, _kw: f"({a[0]} - {a[1]} + {a[2]})"
 
     # --- Cross-core pipe ops ---
     m["tile.tpush_to_aiv"] = _handle_tpush_to_aiv

--- a/python/pypto/ir/op/tile_ops.py
+++ b/python/pypto/ir/op/tile_ops.py
@@ -1180,14 +1180,14 @@ def prelu(tile: Expr, slope: Expr, tmp: Expr, span: Span | None = None) -> Call:
 
 
 def addc(lhs: Expr, rhs: Expr, rhs2: Expr, span: Span | None = None) -> Call:
-    """Element-wise addition of three tiles.
+    """Element-wise carry addition of three tiles.
 
-    Computes lhs + rhs + rhs2 element-wise. Maps to the TADDC hardware intrinsic.
+    Computes ``src0 + src1 + carry`` element-wise. Maps to TADDC.
 
     Args:
-        lhs: Left-hand side tile (TileType)
-        rhs: Right-hand side tile (TileType)
-        rhs2: Third tile (TileType)
+        lhs: First source tile (TileType)
+        rhs: Second source tile (TileType)
+        rhs2: Per-element carry-in tile (TileType), normally containing 0 or 1
         span: Optional source span for debugging (auto-captured if not provided)
 
     Returns:
@@ -1198,14 +1198,14 @@ def addc(lhs: Expr, rhs: Expr, rhs2: Expr, span: Span | None = None) -> Call:
 
 
 def subc(lhs: Expr, rhs: Expr, rhs2: Expr, span: Span | None = None) -> Call:
-    """Element-wise subtraction of three tiles.
+    """Element-wise carry subtraction of three tiles.
 
-    Computes lhs - rhs - rhs2 element-wise. Maps to the TSUBC hardware intrinsic.
+    Computes ``src0 - src1 + carry`` element-wise. Maps to TSUBC.
 
     Args:
-        lhs: Left-hand side tile (TileType)
-        rhs: Right-hand side tile (TileType)
-        rhs2: Third tile (TileType)
+        lhs: Minuend tile (TileType)
+        rhs: Subtrahend tile (TileType)
+        rhs2: Per-element carry-in tile (TileType), normally containing 0 or 1
         span: Optional source span for debugging (auto-captured if not provided)
 
     Returns:
@@ -1216,14 +1216,14 @@ def subc(lhs: Expr, rhs: Expr, rhs2: Expr, span: Span | None = None) -> Call:
 
 
 def addsc(lhs: Expr, rhs: int | float | Expr, rhs2: Expr, span: Span | None = None) -> Call:
-    """Element-wise addition of tile, scalar, and tile.
+    """Element-wise scalar carry addition.
 
-    Computes lhs + rhs + rhs2 element-wise. Maps to the TADDSC hardware intrinsic.
+    Computes ``src0 + scalar + carry`` element-wise. Maps to TADDSC.
 
     Args:
-        lhs: Left-hand side tile (TileType)
-        rhs: Scalar (int/float/Expr with ScalarType)
-        rhs2: Third tile (TileType)
+        lhs: Source tile (TileType)
+        rhs: Scalar addend with the same dtype as ``lhs``
+        rhs2: Per-element carry-in tile (TileType), normally containing 0 or 1
         span: Optional source span for debugging (auto-captured if not provided)
 
     Returns:
@@ -1235,14 +1235,14 @@ def addsc(lhs: Expr, rhs: int | float | Expr, rhs2: Expr, span: Span | None = No
 
 
 def subsc(lhs: Expr, rhs: int | float | Expr, rhs2: Expr, span: Span | None = None) -> Call:
-    """Element-wise subtraction of tile, scalar, and tile.
+    """Element-wise scalar carry subtraction.
 
-    Computes lhs - rhs - rhs2 element-wise. Maps to the TSUBSC hardware intrinsic.
+    Computes ``src0 - scalar + carry`` element-wise. Maps to TSUBSC.
 
     Args:
-        lhs: Left-hand side tile (TileType)
-        rhs: Scalar (int/float/Expr with ScalarType)
-        rhs2: Third tile (TileType)
+        lhs: Minuend tile (TileType)
+        rhs: Scalar subtrahend with the same dtype as ``lhs``
+        rhs2: Per-element carry-in tile (TileType), normally containing 0 or 1
         span: Optional source span for debugging (auto-captured if not provided)
 
     Returns:

--- a/python/pypto/ir/op/tile_ops.py
+++ b/python/pypto/ir/op/tile_ops.py
@@ -1396,14 +1396,14 @@ def prelu(tile: Expr, slope: Expr, tmp: Expr, span: Span | None = None) -> Call:
 
 
 def addc(lhs: Expr, rhs: Expr, rhs2: Expr, span: Span | None = None) -> Call:
-    """Element-wise addition of three tiles.
+    """Element-wise carry addition of three tiles.
 
-    Computes lhs + rhs + rhs2 element-wise. Maps to the TADDC hardware intrinsic.
+    Computes ``src0 + src1 + carry`` element-wise. Maps to TADDC.
 
     Args:
-        lhs: Left-hand side tile (TileType)
-        rhs: Right-hand side tile (TileType)
-        rhs2: Third tile (TileType)
+        lhs: First source tile (TileType)
+        rhs: Second source tile (TileType)
+        rhs2: Per-element carry-in tile (TileType), normally containing 0 or 1
         span: Optional source span for debugging (auto-captured if not provided)
 
     Returns:
@@ -1414,14 +1414,14 @@ def addc(lhs: Expr, rhs: Expr, rhs2: Expr, span: Span | None = None) -> Call:
 
 
 def subc(lhs: Expr, rhs: Expr, rhs2: Expr, span: Span | None = None) -> Call:
-    """Element-wise subtraction of three tiles.
+    """Element-wise carry subtraction of three tiles.
 
-    Computes lhs - rhs - rhs2 element-wise. Maps to the TSUBC hardware intrinsic.
+    Computes ``src0 - src1 + carry`` element-wise. Maps to TSUBC.
 
     Args:
-        lhs: Left-hand side tile (TileType)
-        rhs: Right-hand side tile (TileType)
-        rhs2: Third tile (TileType)
+        lhs: Minuend tile (TileType)
+        rhs: Subtrahend tile (TileType)
+        rhs2: Per-element carry-in tile (TileType), normally containing 0 or 1
         span: Optional source span for debugging (auto-captured if not provided)
 
     Returns:
@@ -1432,14 +1432,14 @@ def subc(lhs: Expr, rhs: Expr, rhs2: Expr, span: Span | None = None) -> Call:
 
 
 def addsc(lhs: Expr, rhs: int | float | Expr, rhs2: Expr, span: Span | None = None) -> Call:
-    """Element-wise addition of tile, scalar, and tile.
+    """Element-wise scalar carry addition.
 
-    Computes lhs + rhs + rhs2 element-wise. Maps to the TADDSC hardware intrinsic.
+    Computes ``src0 + scalar + carry`` element-wise. Maps to TADDSC.
 
     Args:
-        lhs: Left-hand side tile (TileType)
-        rhs: Scalar (int/float/Expr with ScalarType)
-        rhs2: Third tile (TileType)
+        lhs: Source tile (TileType)
+        rhs: Scalar addend with the same dtype as ``lhs``
+        rhs2: Per-element carry-in tile (TileType), normally containing 0 or 1
         span: Optional source span for debugging (auto-captured if not provided)
 
     Returns:
@@ -1451,14 +1451,14 @@ def addsc(lhs: Expr, rhs: int | float | Expr, rhs2: Expr, span: Span | None = No
 
 
 def subsc(lhs: Expr, rhs: int | float | Expr, rhs2: Expr, span: Span | None = None) -> Call:
-    """Element-wise subtraction of tile, scalar, and tile.
+    """Element-wise scalar carry subtraction.
 
-    Computes lhs - rhs - rhs2 element-wise. Maps to the TSUBSC hardware intrinsic.
+    Computes ``src0 - scalar + carry`` element-wise. Maps to TSUBSC.
 
     Args:
-        lhs: Left-hand side tile (TileType)
-        rhs: Scalar (int/float/Expr with ScalarType)
-        rhs2: Third tile (TileType)
+        lhs: Minuend tile (TileType)
+        rhs: Scalar subtrahend with the same dtype as ``lhs``
+        rhs2: Per-element carry-in tile (TileType), normally containing 0 or 1
         span: Optional source span for debugging (auto-captured if not provided)
 
     Returns:

--- a/python/pypto/language/op/tile_ops.py
+++ b/python/pypto/language/op/tile_ops.py
@@ -2316,14 +2316,14 @@ def not_(tile: Tile) -> Tile:
 
 
 def addc(lhs: Tile, rhs: Tile, rhs2: Tile) -> Tile:
-    """Element-wise addition of three tiles.
+    """Element-wise carry addition of three tiles.
 
-    Computes lhs + rhs + rhs2 element-wise. Maps to the TADDC hardware intrinsic.
+    Computes ``src0 + src1 + carry`` element-wise. Maps to TADDC.
 
     Args:
-        lhs: Left-hand side tile
-        rhs: Right-hand side tile
-        rhs2: Third tile
+        lhs: First source tile
+        rhs: Second source tile
+        rhs2: Per-element carry-in tile, normally containing 0 or 1
 
     Returns:
         Tile wrapping the addc operation
@@ -2333,14 +2333,14 @@ def addc(lhs: Tile, rhs: Tile, rhs2: Tile) -> Tile:
 
 
 def subc(lhs: Tile, rhs: Tile, rhs2: Tile) -> Tile:
-    """Element-wise subtraction of three tiles.
+    """Element-wise carry subtraction of three tiles.
 
-    Computes lhs - rhs - rhs2 element-wise. Maps to the TSUBC hardware intrinsic.
+    Computes ``src0 - src1 + carry`` element-wise. Maps to TSUBC.
 
     Args:
-        lhs: Left-hand side tile
-        rhs: Right-hand side tile
-        rhs2: Third tile
+        lhs: Minuend tile
+        rhs: Subtrahend tile
+        rhs2: Per-element carry-in tile, normally containing 0 or 1
 
     Returns:
         Tile wrapping the subc operation
@@ -2350,14 +2350,14 @@ def subc(lhs: Tile, rhs: Tile, rhs2: Tile) -> Tile:
 
 
 def addsc(lhs: Tile, rhs: int | float | Expr | Scalar, rhs2: Tile) -> Tile:
-    """Element-wise addition of tile, scalar, and tile.
+    """Element-wise scalar carry addition.
 
-    Computes lhs + rhs + rhs2 element-wise. Maps to the TADDSC hardware intrinsic.
+    Computes ``src0 + scalar + carry`` element-wise. Maps to TADDSC.
 
     Args:
-        lhs: Left-hand side tile
-        rhs: Scalar value
-        rhs2: Third tile
+        lhs: Source tile
+        rhs: Scalar addend with the same dtype as ``lhs``
+        rhs2: Per-element carry-in tile, normally containing 0 or 1
 
     Returns:
         Tile wrapping the addsc operation
@@ -2368,14 +2368,14 @@ def addsc(lhs: Tile, rhs: int | float | Expr | Scalar, rhs2: Tile) -> Tile:
 
 
 def subsc(lhs: Tile, rhs: int | float | Expr | Scalar, rhs2: Tile) -> Tile:
-    """Element-wise subtraction of tile, scalar, and tile.
+    """Element-wise scalar carry subtraction.
 
-    Computes lhs - rhs - rhs2 element-wise. Maps to the TSUBSC hardware intrinsic.
+    Computes ``src0 - scalar + carry`` element-wise. Maps to TSUBSC.
 
     Args:
-        lhs: Left-hand side tile
-        rhs: Scalar value
-        rhs2: Third tile
+        lhs: Minuend tile
+        rhs: Scalar subtrahend with the same dtype as ``lhs``
+        rhs2: Per-element carry-in tile, normally containing 0 or 1
 
     Returns:
         Tile wrapping the subsc operation

--- a/python/pypto/language/op/tile_ops.py
+++ b/python/pypto/language/op/tile_ops.py
@@ -2824,14 +2824,14 @@ def not_(tile: Tile) -> Tile:
 
 
 def addc(lhs: Tile, rhs: Tile, rhs2: Tile) -> Tile:
-    """Element-wise addition of three tiles.
+    """Element-wise carry addition of three tiles.
 
-    Computes lhs + rhs + rhs2 element-wise. Maps to the TADDC hardware intrinsic.
+    Computes ``src0 + src1 + carry`` element-wise. Maps to TADDC.
 
     Args:
-        lhs: Left-hand side tile
-        rhs: Right-hand side tile
-        rhs2: Third tile
+        lhs: First source tile
+        rhs: Second source tile
+        rhs2: Per-element carry-in tile, normally containing 0 or 1
 
     Returns:
         Tile wrapping the addc operation
@@ -2841,14 +2841,14 @@ def addc(lhs: Tile, rhs: Tile, rhs2: Tile) -> Tile:
 
 
 def subc(lhs: Tile, rhs: Tile, rhs2: Tile) -> Tile:
-    """Element-wise subtraction of three tiles.
+    """Element-wise carry subtraction of three tiles.
 
-    Computes lhs - rhs - rhs2 element-wise. Maps to the TSUBC hardware intrinsic.
+    Computes ``src0 - src1 + carry`` element-wise. Maps to TSUBC.
 
     Args:
-        lhs: Left-hand side tile
-        rhs: Right-hand side tile
-        rhs2: Third tile
+        lhs: Minuend tile
+        rhs: Subtrahend tile
+        rhs2: Per-element carry-in tile, normally containing 0 or 1
 
     Returns:
         Tile wrapping the subc operation
@@ -2858,14 +2858,14 @@ def subc(lhs: Tile, rhs: Tile, rhs2: Tile) -> Tile:
 
 
 def addsc(lhs: Tile, rhs: int | float | Expr | Scalar, rhs2: Tile) -> Tile:
-    """Element-wise addition of tile, scalar, and tile.
+    """Element-wise scalar carry addition.
 
-    Computes lhs + rhs + rhs2 element-wise. Maps to the TADDSC hardware intrinsic.
+    Computes ``src0 + scalar + carry`` element-wise. Maps to TADDSC.
 
     Args:
-        lhs: Left-hand side tile
-        rhs: Scalar value
-        rhs2: Third tile
+        lhs: Source tile
+        rhs: Scalar addend with the same dtype as ``lhs``
+        rhs2: Per-element carry-in tile, normally containing 0 or 1
 
     Returns:
         Tile wrapping the addsc operation
@@ -2876,14 +2876,14 @@ def addsc(lhs: Tile, rhs: int | float | Expr | Scalar, rhs2: Tile) -> Tile:
 
 
 def subsc(lhs: Tile, rhs: int | float | Expr | Scalar, rhs2: Tile) -> Tile:
-    """Element-wise subtraction of tile, scalar, and tile.
+    """Element-wise scalar carry subtraction.
 
-    Computes lhs - rhs - rhs2 element-wise. Maps to the TSUBSC hardware intrinsic.
+    Computes ``src0 - scalar + carry`` element-wise. Maps to TSUBSC.
 
     Args:
-        lhs: Left-hand side tile
-        rhs: Scalar value
-        rhs2: Third tile
+        lhs: Minuend tile
+        rhs: Scalar subtrahend with the same dtype as ``lhs``
+        rhs2: Per-element carry-in tile, normally containing 0 or 1
 
     Returns:
         Tile wrapping the subsc operation

--- a/src/backend/common/pto_ops_elementwise.cpp
+++ b/src/backend/common/pto_ops_elementwise.cpp
@@ -73,6 +73,9 @@ static bool RequiresRowMajorLayout(std::string_view op_name) {
       "tile.shr",
       "tile.sub",
       "tile.xor",
+      // Ternary tile ops
+      "tile.addc",
+      "tile.subc",
       // Unary ops
       "tile.abs",
       "tile.exp",

--- a/src/backend/common/pto_ops_elementwise.cpp
+++ b/src/backend/common/pto_ops_elementwise.cpp
@@ -85,6 +85,9 @@ static bool RequiresRowMajorLayout(std::string_view op_name) {
       "tile.shr",
       "tile.sub",
       "tile.xor",
+      // Ternary tile ops
+      "tile.addc",
+      "tile.subc",
       // Unary ops
       "tile.abs",
       "tile.exp",

--- a/src/ir/op/tile_ops/elementwise.cpp
+++ b/src/ir/op/tile_ops/elementwise.cpp
@@ -68,6 +68,11 @@ static bool IsTDivDataType(DataType dtype) {
          dtype == DataType::FP32;
 }
 
+static bool IsCarryDataType(DataType dtype) {
+  return dtype == DataType::INT16 || dtype == DataType::INT32 || dtype == DataType::FP16 ||
+         dtype == DataType::FP32;
+}
+
 static bool IsTSubsDataType(DataType dtype) {
   return dtype == DataType::INT8 || dtype == DataType::INT16 || dtype == DataType::INT32 ||
          dtype == DataType::FP16 || dtype == DataType::FP32 || dtype == DataType::BF16;
@@ -709,7 +714,38 @@ TypePtr DeduceTileOpTernaryType(const std::vector<ExprPtr>& args,
   return std::make_shared<TileType>(broadcast_result.shape, *result_dtype, std::nullopt, tile_view);
 }
 
-// All three tiles are real inputs (addc, subc): promote dtype and broadcast shape across all three.
+static void CheckCarryTileMatches(const std::shared_ptr<const TileType>& reference,
+                                  const std::shared_ptr<const TileType>& candidate,
+                                  const std::string& candidate_name, const std::string& op_name) {
+  CHECK(candidate->dtype_ == reference->dtype_)
+      << "The operator " << op_name << " requires all tile operands and dst to have the same dtype, but "
+      << candidate_name << " has " << candidate->dtype_.ToString() << " and src0 has "
+      << reference->dtype_.ToString();
+
+  CHECK(candidate->shape_.size() == reference->shape_.size())
+      << "The operator " << op_name
+      << " requires all tile operands and dst to have the same physical shape rank";
+  for (size_t i = 0; i < reference->shape_.size(); ++i) {
+    CHECK(DimensionsEqual(reference->shape_[i], candidate->shape_[i]))
+        << "The operator " << op_name
+        << " requires all tile operands and dst to have the same physical shape, but " << candidate_name
+        << " differs at dimension " << i;
+  }
+
+  const auto reference_valid_shape = GetValidShape(reference);
+  const auto candidate_valid_shape = GetValidShape(candidate);
+  CHECK(candidate_valid_shape.size() == reference_valid_shape.size())
+      << "The operator " << op_name
+      << " requires all tile operands and dst to have the same valid_shape rank";
+  for (size_t i = 0; i < reference_valid_shape.size(); ++i) {
+    CHECK(ProveValidExtentEqual(reference_valid_shape[i], candidate_valid_shape[i]) == ProofResult::kTrue)
+        << "The operator " << op_name
+        << " requires all tile operands and dst to have the same valid_shape, but " << candidate_name
+        << " differs at dimension " << i;
+  }
+}
+
+// TADDC/TSUBC use one exact tile type for src0, src1, carry, and dst.
 TypePtr DeduceTileOpTriTileType(const std::vector<ExprPtr>& args,
                                 const std::vector<std::pair<std::string, std::any>>& kwargs,
                                 const std::string& op_name) {
@@ -726,25 +762,18 @@ TypePtr DeduceTileOpTriTileType(const std::vector<ExprPtr>& args,
   CHECK(tile_type3) << "The operator " << op_name << " requires third argument to be a TileType, but got "
                     << args[2]->GetType()->TypeName();
 
-  auto result_dtype12 = PromoteDataTypes(tile_type1->dtype_, tile_type2->dtype_);
-  CHECK(result_dtype12) << "The operator " << op_name << " requires compatible data types";
-  auto result_dtype = PromoteDataTypes(*result_dtype12, tile_type3->dtype_);
-  CHECK(result_dtype) << "The operator " << op_name << " requires compatible data types";
+  CHECK(IsCarryDataType(tile_type1->dtype_))
+      << "The operator " << op_name << " requires dtype in {INT16, INT32, FP16, FP32}, but got "
+      << tile_type1->dtype_.ToString();
+  CheckCarryTileMatches(tile_type1, tile_type2, "src1", op_name);
+  CheckCarryTileMatches(tile_type1, tile_type3, "carry", op_name);
 
-  auto broadcast12 = BroadcastShapes(tile_type1->shape_, tile_type2->shape_);
-  CHECK(broadcast12.success) << "The operator " << op_name << " requires compatible shapes";
-  auto broadcast_result = BroadcastShapes(broadcast12.shape, tile_type3->shape_);
-  CHECK(broadcast_result.success) << "The operator " << op_name << " requires compatible shapes";
-
-  // TODO(YunjiQin): assumes all src tiles have the same valid_shape; may need refinement
-  // for cases where tiles have different valid_shapes (e.g. after broadcasting).
   TileView tile_view;
   tile_view.valid_shape = GetValidShape(tile_type1);
   InheritTileViewLayout(tile_view, tile_type1);
-  return std::make_shared<TileType>(broadcast_result.shape, *result_dtype, std::nullopt, tile_view);
+  return std::make_shared<TileType>(tile_type1->shape_, tile_type1->dtype_, std::nullopt, tile_view);
 }
 
-// (Tile, Scalar, Tile) pattern (addsc, subsc): any scalar type, promote output from all three inputs.
 TypePtr DeduceTileOpTileScalarTileType(const std::vector<ExprPtr>& args,
                                        const std::vector<std::pair<std::string, std::any>>& kwargs,
                                        const std::string& op_name) {
@@ -777,6 +806,40 @@ TypePtr DeduceTileOpTileScalarTileType(const std::vector<ExprPtr>& args,
   tile_view.valid_shape = GetValidShape(tile_type1);
   InheritTileViewLayout(tile_view, tile_type1);
   return std::make_shared<TileType>(broadcast_result.shape, *result_dtype, std::nullopt, tile_view);
+}
+
+// TADDSC/TSUBSC use one exact dtype for src0, scalar, carry, and dst.
+TypePtr DeduceTileOpCarryScalarType(const std::vector<ExprPtr>& args,
+                                    const std::vector<std::pair<std::string, std::any>>& kwargs,
+                                    const std::string& op_name) {
+  CHECK(args.size() == 3) << "The operator " << op_name << " requires exactly 3 arguments, but got "
+                          << args.size();
+
+  auto tile_type1 = As<TileType>(args[0]->GetType());
+  CHECK(tile_type1) << "The operator " << op_name << " requires first argument to be a TileType, but got "
+                    << args[0]->GetType()->TypeName();
+
+  auto scalar_type = As<ScalarType>(args[1]->GetType());
+  CHECK(scalar_type) << "The operator " << op_name << " requires second argument to be a ScalarType, but got "
+                     << args[1]->GetType()->TypeName();
+
+  auto tile_type2 = As<TileType>(args[2]->GetType());
+  CHECK(tile_type2) << "The operator " << op_name << " requires third argument to be a TileType, but got "
+                    << args[2]->GetType()->TypeName();
+
+  CHECK(IsCarryDataType(tile_type1->dtype_))
+      << "The operator " << op_name << " requires dtype in {INT16, INT32, FP16, FP32}, but got "
+      << tile_type1->dtype_.ToString();
+  CHECK(scalar_type->dtype_ == tile_type1->dtype_)
+      << "The operator " << op_name
+      << " requires src0, scalar, carry, and dst to have the same dtype, but scalar has "
+      << scalar_type->dtype_.ToString() << " and src0 has " << tile_type1->dtype_.ToString();
+  CheckCarryTileMatches(tile_type1, tile_type2, "carry", op_name);
+
+  TileView tile_view;
+  tile_view.valid_shape = GetValidShape(tile_type1);
+  InheritTileViewLayout(tile_view, tile_type1);
+  return std::make_shared<TileType>(tile_type1->shape_, tile_type1->dtype_, std::nullopt, tile_view);
 }
 
 TypePtr DeduceTileOpXorScalarType(const std::vector<ExprPtr>& args,
@@ -859,10 +922,10 @@ REGISTER_OP("tile.prelu")
 
 REGISTER_OP("tile.addc")
     .set_op_category("TileOp")
-    .set_description("Element-wise addition of three tiles (lhs + rhs + rhs2) with broadcasting")
-    .add_argument("lhs", "Left-hand side tile (TileType)")
-    .add_argument("rhs", "Right-hand side tile (TileType)")
-    .add_argument("rhs2", "Third tile (TileType)")
+    .set_description("Element-wise carry addition (src0 + src1 + carry)")
+    .add_argument("src0", "First source tile (TileType)")
+    .add_argument("src1", "Second source tile (TileType)")
+    .add_argument("carry", "Carry-in tile containing per-element carry values (TileType)")
     .set_input_memory(0, MemorySpace::Vec)
     .set_input_memory(1, MemorySpace::Vec)
     .set_input_memory(2, MemorySpace::Vec)
@@ -874,10 +937,10 @@ REGISTER_OP("tile.addc")
 
 REGISTER_OP("tile.subc")
     .set_op_category("TileOp")
-    .set_description("Element-wise subtraction of three tiles (lhs - rhs - rhs2) with broadcasting")
-    .add_argument("lhs", "Left-hand side tile (TileType)")
-    .add_argument("rhs", "Right-hand side tile (TileType)")
-    .add_argument("rhs2", "Third tile (TileType)")
+    .set_description("Element-wise carry subtraction (src0 - src1 + carry)")
+    .add_argument("src0", "Minuend tile (TileType)")
+    .add_argument("src1", "Subtrahend tile (TileType)")
+    .add_argument("carry", "Carry-in tile containing per-element carry values (TileType)")
     .set_input_memory(0, MemorySpace::Vec)
     .set_input_memory(1, MemorySpace::Vec)
     .set_input_memory(2, MemorySpace::Vec)
@@ -889,30 +952,30 @@ REGISTER_OP("tile.subc")
 
 REGISTER_OP("tile.addsc")
     .set_op_category("TileOp")
-    .set_description("Element-wise addition of tile, scalar, and tile (lhs + scalar + rhs2)")
-    .add_argument("lhs", "Left-hand side tile (TileType)")
-    .add_argument("rhs", "Scalar (ScalarType)")
-    .add_argument("rhs2", "Third tile (TileType)")
+    .set_description("Element-wise scalar carry addition (src0 + scalar + carry)")
+    .add_argument("src0", "Source tile (TileType)")
+    .add_argument("scalar", "Scalar addend (ScalarType)")
+    .add_argument("carry", "Carry-in tile containing per-element carry values (TileType)")
     .set_input_memory(0, MemorySpace::Vec)
     .set_input_memory(2, MemorySpace::Vec)
     .set_output_memory(MemorySpace::Vec)
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
-      return DeduceTileOpTileScalarTileType(args, kwargs, "tile.addsc");
+      return DeduceTileOpCarryScalarType(args, kwargs, "tile.addsc");
     });
 
 REGISTER_OP("tile.subsc")
     .set_op_category("TileOp")
-    .set_description("Element-wise subtraction of tile, scalar, and tile (lhs - scalar - rhs2)")
-    .add_argument("lhs", "Left-hand side tile (TileType)")
-    .add_argument("rhs", "Scalar (ScalarType)")
-    .add_argument("rhs2", "Third tile (TileType)")
+    .set_description("Element-wise scalar carry subtraction (src0 - scalar + carry)")
+    .add_argument("src0", "Minuend tile (TileType)")
+    .add_argument("scalar", "Scalar subtrahend (ScalarType)")
+    .add_argument("carry", "Carry-in tile containing per-element carry values (TileType)")
     .set_input_memory(0, MemorySpace::Vec)
     .set_input_memory(2, MemorySpace::Vec)
     .set_output_memory(MemorySpace::Vec)
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
-      return DeduceTileOpTileScalarTileType(args, kwargs, "tile.subsc");
+      return DeduceTileOpCarryScalarType(args, kwargs, "tile.subsc");
     });
 
 REGISTER_OP("tile.lrelu")

--- a/src/ir/op/tile_ops/elementwise.cpp
+++ b/src/ir/op/tile_ops/elementwise.cpp
@@ -70,6 +70,11 @@ static bool IsTDivDataType(DataType dtype) {
          dtype == DataType::FP32;
 }
 
+static bool IsCarryDataType(DataType dtype) {
+  return dtype == DataType::INT16 || dtype == DataType::INT32 || dtype == DataType::FP16 ||
+         dtype == DataType::FP32;
+}
+
 static bool IsTSubsDataType(DataType dtype) {
   return dtype == DataType::INT8 || dtype == DataType::INT16 || dtype == DataType::INT32 ||
          dtype == DataType::FP16 || dtype == DataType::FP32 || dtype == DataType::BF16;
@@ -876,7 +881,38 @@ TypePtr DeduceTileOpTernaryType(const std::vector<ExprPtr>& args,
   return std::make_shared<TileType>(broadcast_result.shape, *result_dtype, std::nullopt, tile_view);
 }
 
-// All three tiles are real inputs (addc, subc): promote dtype and broadcast shape across all three.
+static void CheckCarryTileMatches(const std::shared_ptr<const TileType>& reference,
+                                  const std::shared_ptr<const TileType>& candidate,
+                                  const std::string& candidate_name, const std::string& op_name) {
+  CHECK(candidate->dtype_ == reference->dtype_)
+      << "The operator " << op_name << " requires all tile operands and dst to have the same dtype, but "
+      << candidate_name << " has " << candidate->dtype_.ToString() << " and src0 has "
+      << reference->dtype_.ToString();
+
+  CHECK(candidate->shape_.size() == reference->shape_.size())
+      << "The operator " << op_name
+      << " requires all tile operands and dst to have the same physical shape rank";
+  for (size_t i = 0; i < reference->shape_.size(); ++i) {
+    CHECK(DimensionsEqual(reference->shape_[i], candidate->shape_[i]))
+        << "The operator " << op_name
+        << " requires all tile operands and dst to have the same physical shape, but " << candidate_name
+        << " differs at dimension " << i;
+  }
+
+  const auto reference_valid_shape = GetValidShape(reference);
+  const auto candidate_valid_shape = GetValidShape(candidate);
+  CHECK(candidate_valid_shape.size() == reference_valid_shape.size())
+      << "The operator " << op_name
+      << " requires all tile operands and dst to have the same valid_shape rank";
+  for (size_t i = 0; i < reference_valid_shape.size(); ++i) {
+    CHECK(ProveValidExtentEqual(reference_valid_shape[i], candidate_valid_shape[i]) == ProofResult::kTrue)
+        << "The operator " << op_name
+        << " requires all tile operands and dst to have the same valid_shape, but " << candidate_name
+        << " differs at dimension " << i;
+  }
+}
+
+// TADDC/TSUBC use one exact tile type for src0, src1, carry, and dst.
 TypePtr DeduceTileOpTriTileType(const std::vector<ExprPtr>& args,
                                 const std::vector<std::pair<std::string, std::any>>& kwargs,
                                 const std::string& op_name) {
@@ -893,25 +929,18 @@ TypePtr DeduceTileOpTriTileType(const std::vector<ExprPtr>& args,
   CHECK(tile_type3) << "The operator " << op_name << " requires third argument to be a TileType, but got "
                     << args[2]->GetType()->TypeName();
 
-  auto result_dtype12 = PromoteDataTypes(tile_type1->dtype_, tile_type2->dtype_);
-  CHECK(result_dtype12) << "The operator " << op_name << " requires compatible data types";
-  auto result_dtype = PromoteDataTypes(*result_dtype12, tile_type3->dtype_);
-  CHECK(result_dtype) << "The operator " << op_name << " requires compatible data types";
+  CHECK(IsCarryDataType(tile_type1->dtype_))
+      << "The operator " << op_name << " requires dtype in {INT16, INT32, FP16, FP32}, but got "
+      << tile_type1->dtype_.ToString();
+  CheckCarryTileMatches(tile_type1, tile_type2, "src1", op_name);
+  CheckCarryTileMatches(tile_type1, tile_type3, "carry", op_name);
 
-  auto broadcast12 = BroadcastShapes(tile_type1->shape_, tile_type2->shape_);
-  CHECK(broadcast12.success) << "The operator " << op_name << " requires compatible shapes";
-  auto broadcast_result = BroadcastShapes(broadcast12.shape, tile_type3->shape_);
-  CHECK(broadcast_result.success) << "The operator " << op_name << " requires compatible shapes";
-
-  // TODO(YunjiQin): assumes all src tiles have the same valid_shape; may need refinement
-  // for cases where tiles have different valid_shape values (e.g. after broadcasting).
   TileView tile_view;
   tile_view.valid_shape = GetValidShape(tile_type1);
   InheritTileViewLayout(tile_view, tile_type1);
-  return std::make_shared<TileType>(broadcast_result.shape, *result_dtype, std::nullopt, tile_view);
+  return std::make_shared<TileType>(tile_type1->shape_, tile_type1->dtype_, std::nullopt, tile_view);
 }
 
-// (Tile, Scalar, Tile) pattern (addsc, subsc): any scalar type, promote output from all three inputs.
 TypePtr DeduceTileOpTileScalarTileType(const std::vector<ExprPtr>& args,
                                        const std::vector<std::pair<std::string, std::any>>& kwargs,
                                        const std::string& op_name) {
@@ -944,6 +973,40 @@ TypePtr DeduceTileOpTileScalarTileType(const std::vector<ExprPtr>& args,
   tile_view.valid_shape = GetValidShape(tile_type1);
   InheritTileViewLayout(tile_view, tile_type1);
   return std::make_shared<TileType>(broadcast_result.shape, *result_dtype, std::nullopt, tile_view);
+}
+
+// TADDSC/TSUBSC use one exact dtype for src0, scalar, carry, and dst.
+TypePtr DeduceTileOpCarryScalarType(const std::vector<ExprPtr>& args,
+                                    const std::vector<std::pair<std::string, std::any>>& kwargs,
+                                    const std::string& op_name) {
+  CHECK(args.size() == 3) << "The operator " << op_name << " requires exactly 3 arguments, but got "
+                          << args.size();
+
+  auto tile_type1 = As<TileType>(args[0]->GetType());
+  CHECK(tile_type1) << "The operator " << op_name << " requires first argument to be a TileType, but got "
+                    << args[0]->GetType()->TypeName();
+
+  auto scalar_type = As<ScalarType>(args[1]->GetType());
+  CHECK(scalar_type) << "The operator " << op_name << " requires second argument to be a ScalarType, but got "
+                     << args[1]->GetType()->TypeName();
+
+  auto tile_type2 = As<TileType>(args[2]->GetType());
+  CHECK(tile_type2) << "The operator " << op_name << " requires third argument to be a TileType, but got "
+                    << args[2]->GetType()->TypeName();
+
+  CHECK(IsCarryDataType(tile_type1->dtype_))
+      << "The operator " << op_name << " requires dtype in {INT16, INT32, FP16, FP32}, but got "
+      << tile_type1->dtype_.ToString();
+  CHECK(scalar_type->dtype_ == tile_type1->dtype_)
+      << "The operator " << op_name
+      << " requires src0, scalar, carry, and dst to have the same dtype, but scalar has "
+      << scalar_type->dtype_.ToString() << " and src0 has " << tile_type1->dtype_.ToString();
+  CheckCarryTileMatches(tile_type1, tile_type2, "carry", op_name);
+
+  TileView tile_view;
+  tile_view.valid_shape = GetValidShape(tile_type1);
+  InheritTileViewLayout(tile_view, tile_type1);
+  return std::make_shared<TileType>(tile_type1->shape_, tile_type1->dtype_, std::nullopt, tile_view);
 }
 
 TypePtr DeduceTileOpXorScalarType(const std::vector<ExprPtr>& args,
@@ -1092,14 +1155,17 @@ REGISTER_OP("tile.prelu")
 REGISTER_OP("tile.addc")
     .set_op_category("TileOp")
     .functional_execution_memory_access()
-    .set_description("Element-wise addition of three tiles (lhs + rhs + rhs2) with broadcasting")
-    .add_argument("lhs", "Left-hand side tile (TileType)")
-    .add_argument("rhs", "Right-hand side tile (TileType)")
-    .add_argument("rhs2", "Third tile (TileType)")
+    .set_description("Element-wise carry addition (src0 + src1 + carry)")
+    .add_argument("src0", "First source tile (TileType)")
+    .add_argument("src1", "Second source tile (TileType)")
+    .add_argument("carry", "Carry-in tile containing per-element carry values (TileType)")
     .set_input_memory(0, MemorySpace::Vec)
     .set_input_memory(1, MemorySpace::Vec)
     .set_input_memory(2, MemorySpace::Vec)
     .set_output_memory(MemorySpace::Vec)
+    // PTOAS lowers TADDC as TADD followed by TADD. The second step still
+    // reads carry, so dst may reuse src0 but must not overwrite carry.
+    .forbid_output_alias(2)
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
       return DeduceTileOpTriTileType(args, kwargs, "tile.addc");
@@ -1108,14 +1174,17 @@ REGISTER_OP("tile.addc")
 REGISTER_OP("tile.subc")
     .set_op_category("TileOp")
     .functional_execution_memory_access()
-    .set_description("Element-wise subtraction of three tiles (lhs - rhs - rhs2) with broadcasting")
-    .add_argument("lhs", "Left-hand side tile (TileType)")
-    .add_argument("rhs", "Right-hand side tile (TileType)")
-    .add_argument("rhs2", "Third tile (TileType)")
+    .set_description("Element-wise carry subtraction (src0 - src1 + carry)")
+    .add_argument("src0", "Minuend tile (TileType)")
+    .add_argument("src1", "Subtrahend tile (TileType)")
+    .add_argument("carry", "Carry-in tile containing per-element carry values (TileType)")
     .set_input_memory(0, MemorySpace::Vec)
     .set_input_memory(1, MemorySpace::Vec)
     .set_input_memory(2, MemorySpace::Vec)
     .set_output_memory(MemorySpace::Vec)
+    // PTOAS lowers TSUBC as TSUB followed by TADD. The second step still
+    // reads carry, so dst may reuse src0 but must not overwrite carry.
+    .forbid_output_alias(2)
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
       return DeduceTileOpTriTileType(args, kwargs, "tile.subc");
@@ -1124,31 +1193,37 @@ REGISTER_OP("tile.subc")
 REGISTER_OP("tile.addsc")
     .set_op_category("TileOp")
     .functional_execution_memory_access()
-    .set_description("Element-wise addition of tile, scalar, and tile (lhs + scalar + rhs2)")
-    .add_argument("lhs", "Left-hand side tile (TileType)")
-    .add_argument("rhs", "Scalar (ScalarType)")
-    .add_argument("rhs2", "Third tile (TileType)")
+    .set_description("Element-wise scalar carry addition (src0 + scalar + carry)")
+    .add_argument("src0", "Source tile (TileType)")
+    .add_argument("scalar", "Scalar addend (ScalarType)")
+    .add_argument("carry", "Carry-in tile containing per-element carry values (TileType)")
     .set_input_memory(0, MemorySpace::Vec)
     .set_input_memory(2, MemorySpace::Vec)
     .set_output_memory(MemorySpace::Vec)
+    // PTOAS lowers TADDSC as TADDS followed by TADD. The second step still
+    // reads carry, so dst may reuse src0 but must not overwrite carry.
+    .forbid_output_alias(2)
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
-      return DeduceTileOpTileScalarTileType(args, kwargs, "tile.addsc");
+      return DeduceTileOpCarryScalarType(args, kwargs, "tile.addsc");
     });
 
 REGISTER_OP("tile.subsc")
     .set_op_category("TileOp")
     .functional_execution_memory_access()
-    .set_description("Element-wise subtraction of tile, scalar, and tile (lhs - scalar - rhs2)")
-    .add_argument("lhs", "Left-hand side tile (TileType)")
-    .add_argument("rhs", "Scalar (ScalarType)")
-    .add_argument("rhs2", "Third tile (TileType)")
+    .set_description("Element-wise scalar carry subtraction (src0 - scalar + carry)")
+    .add_argument("src0", "Minuend tile (TileType)")
+    .add_argument("scalar", "Scalar subtrahend (ScalarType)")
+    .add_argument("carry", "Carry-in tile containing per-element carry values (TileType)")
     .set_input_memory(0, MemorySpace::Vec)
     .set_input_memory(2, MemorySpace::Vec)
     .set_output_memory(MemorySpace::Vec)
+    // PTOAS lowers TSUBSC as TSUBS followed by TADD. The second step still
+    // reads carry, so dst may reuse src0 but must not overwrite carry.
+    .forbid_output_alias(2)
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
-      return DeduceTileOpTileScalarTileType(args, kwargs, "tile.subsc");
+      return DeduceTileOpCarryScalarType(args, kwargs, "tile.subsc");
     });
 
 REGISTER_OP("tile.lrelu")

--- a/tests/st/runtime/ops/test_carry.py
+++ b/tests/st/runtime/ops/test_carry.py
@@ -1,0 +1,281 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Exact-op system tests for TADDC, TSUBC, TADDSC, and TSUBSC.
+
+Every op runs on the full PTOAS dtype union and on full, row-tail, column-tail,
+and combined-tail valid regions. The carry tile alternates between zero and one.
+Signed integer inputs include both limits so addition overflow and subtraction
+borrow/wrap behavior are checked; cells outside the valid region remain zero.
+"""
+
+from typing import Any
+
+import pypto.language as pl
+import pytest
+import torch
+from harness.core.harness import DataType, PTOTestCase, TensorSpec
+
+M = 16
+N = 64
+
+_PL_DT = {
+    DataType.FP16: pl.FP16,
+    DataType.FP32: pl.FP32,
+    DataType.INT16: pl.INT16,
+    DataType.INT32: pl.INT32,
+}
+_DTYPES = (DataType.INT16, DataType.INT32, DataType.FP16, DataType.FP32)
+_VALID_SHAPES = (
+    ((M, N), "full"),
+    ((11, N), "row-tail"),
+    ((M, 47), "column-tail"),
+    ((11, 47), "combined-tail"),
+)
+_OPS = ("addc", "subc", "addsc", "subsc")
+
+
+def _src0(dtype: DataType) -> torch.Tensor:
+    values = torch.arange(M * N, dtype=torch.int64).reshape(M, N).remainder(31) - 15
+    if dtype in {DataType.INT16, DataType.INT32}:
+        info = torch.iinfo(dtype.torch_dtype)
+        values[0, 0] = info.max  # carry = 0
+        values[0, 1] = info.max  # carry = 1
+        values[0, 2] = info.min  # carry = 0
+        values[0, 3] = info.min  # carry = 1
+    else:
+        values = values.to(torch.float32) / 4.0
+    return values.to(dtype.torch_dtype).contiguous()
+
+
+def _src1(dtype: DataType) -> torch.Tensor:
+    values = torch.arange(M * N, dtype=torch.int64).reshape(M, N).remainder(7) + 1
+    if dtype in {DataType.FP16, DataType.FP32}:
+        values = values.to(torch.float32) / 2.0
+    return values.to(dtype.torch_dtype).contiguous()
+
+
+def _carry(dtype: DataType) -> torch.Tensor:
+    values = torch.arange(M * N, dtype=torch.int64).reshape(M, N).remainder(2)
+    return values.to(dtype.torch_dtype).contiguous()
+
+
+def _make_program(
+    op_name: str,
+    dtype: DataType,
+    valid_shape: tuple[int, int],
+    scalar: int | float | None,
+):
+    pl_dtype = _PL_DT[dtype]
+    valid = list(valid_shape)
+
+    if op_name == "addc":
+
+        @pl.program
+        class TileAddcProgram:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                src0: pl.Tensor[[M, N], pl_dtype],
+                src1: pl.Tensor[[M, N], pl_dtype],
+                carry: pl.Tensor[[M, N], pl_dtype],
+                out: pl.InOut[pl.Tensor[[M, N], pl_dtype]],
+            ) -> pl.Tensor[[M, N], pl_dtype]:
+                src0_tile = pl.load(src0, [0, 0], [M, N], valid_shapes=valid)
+                src1_tile = pl.load(src1, [0, 0], [M, N], valid_shapes=valid)
+                carry_tile = pl.load(carry, [0, 0], [M, N], valid_shapes=valid)
+                result = pl.tile.addc(src0_tile, src1_tile, carry_tile)
+                return pl.store(result, [0, 0], out)
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orchestrator(
+                self,
+                src0: pl.Tensor[[M, N], pl_dtype],
+                src1: pl.Tensor[[M, N], pl_dtype],
+                carry: pl.Tensor[[M, N], pl_dtype],
+                out: pl.InOut[pl.Tensor[[M, N], pl_dtype]],
+            ) -> pl.Tensor[[M, N], pl_dtype]:
+                return self.kernel(src0, src1, carry, out)
+
+        return TileAddcProgram
+
+    if op_name == "subc":
+
+        @pl.program
+        class TileSubcProgram:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                src0: pl.Tensor[[M, N], pl_dtype],
+                src1: pl.Tensor[[M, N], pl_dtype],
+                carry: pl.Tensor[[M, N], pl_dtype],
+                out: pl.InOut[pl.Tensor[[M, N], pl_dtype]],
+            ) -> pl.Tensor[[M, N], pl_dtype]:
+                src0_tile = pl.load(src0, [0, 0], [M, N], valid_shapes=valid)
+                src1_tile = pl.load(src1, [0, 0], [M, N], valid_shapes=valid)
+                carry_tile = pl.load(carry, [0, 0], [M, N], valid_shapes=valid)
+                result = pl.tile.subc(src0_tile, src1_tile, carry_tile)
+                return pl.store(result, [0, 0], out)
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orchestrator(
+                self,
+                src0: pl.Tensor[[M, N], pl_dtype],
+                src1: pl.Tensor[[M, N], pl_dtype],
+                carry: pl.Tensor[[M, N], pl_dtype],
+                out: pl.InOut[pl.Tensor[[M, N], pl_dtype]],
+            ) -> pl.Tensor[[M, N], pl_dtype]:
+                return self.kernel(src0, src1, carry, out)
+
+        return TileSubcProgram
+
+    assert scalar is not None
+
+    if op_name == "addsc":
+
+        @pl.program
+        class TileAddscProgram:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                src0: pl.Tensor[[M, N], pl_dtype],
+                carry: pl.Tensor[[M, N], pl_dtype],
+                out: pl.InOut[pl.Tensor[[M, N], pl_dtype]],
+            ) -> pl.Tensor[[M, N], pl_dtype]:
+                src0_tile = pl.load(src0, [0, 0], [M, N], valid_shapes=valid)
+                carry_tile = pl.load(carry, [0, 0], [M, N], valid_shapes=valid)
+                result = pl.tile.addsc(src0_tile, scalar, carry_tile)
+                return pl.store(result, [0, 0], out)
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orchestrator(
+                self,
+                src0: pl.Tensor[[M, N], pl_dtype],
+                carry: pl.Tensor[[M, N], pl_dtype],
+                out: pl.InOut[pl.Tensor[[M, N], pl_dtype]],
+            ) -> pl.Tensor[[M, N], pl_dtype]:
+                return self.kernel(src0, carry, out)
+
+        return TileAddscProgram
+
+    assert op_name == "subsc"
+
+    @pl.program
+    class TileSubscProgram:
+        @pl.function(type=pl.FunctionType.InCore)
+        def kernel(
+            self,
+            src0: pl.Tensor[[M, N], pl_dtype],
+            carry: pl.Tensor[[M, N], pl_dtype],
+            out: pl.InOut[pl.Tensor[[M, N], pl_dtype]],
+        ) -> pl.Tensor[[M, N], pl_dtype]:
+            src0_tile = pl.load(src0, [0, 0], [M, N], valid_shapes=valid)
+            carry_tile = pl.load(carry, [0, 0], [M, N], valid_shapes=valid)
+            result = pl.tile.subsc(src0_tile, scalar, carry_tile)
+            return pl.store(result, [0, 0], out)
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def orchestrator(
+            self,
+            src0: pl.Tensor[[M, N], pl_dtype],
+            carry: pl.Tensor[[M, N], pl_dtype],
+            out: pl.InOut[pl.Tensor[[M, N], pl_dtype]],
+        ) -> pl.Tensor[[M, N], pl_dtype]:
+            return self.kernel(src0, carry, out)
+
+    return TileSubscProgram
+
+
+class CarryCase(PTOTestCase):
+    """One direct tile carry-in instruction case."""
+
+    __test__ = False
+
+    def __init__(
+        self,
+        *,
+        op_name: str,
+        dtype: DataType,
+        valid_shape: tuple[int, int],
+        scalar: int | float | None = None,
+    ):
+        super().__init__()
+        self.op_name = op_name
+        self.dtype = dtype
+        self.valid_shape = valid_shape
+        self.scalar = scalar
+
+    def get_name(self) -> str:
+        scalar_tag = f"_s{self.scalar}" if self.scalar is not None else ""
+        valid_tag = f"v{self.valid_shape[0]}x{self.valid_shape[1]}"
+        return f"tile_{self.op_name}_{self.dtype.value}_{valid_tag}{scalar_tag}"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        specs = [
+            TensorSpec("src0", [M, N], self.dtype, init_value=lambda: _src0(self.dtype)),
+        ]
+        if self.op_name in {"addc", "subc"}:
+            specs.append(TensorSpec("src1", [M, N], self.dtype, init_value=lambda: _src1(self.dtype)))
+        specs.extend(
+            [
+                TensorSpec("carry", [M, N], self.dtype, init_value=lambda: _carry(self.dtype)),
+                TensorSpec("out", [M, N], self.dtype, init_value=torch.zeros, is_output=True),
+            ]
+        )
+        return specs
+
+    def get_program(self) -> Any:
+        return _make_program(self.op_name, self.dtype, self.valid_shape, self.scalar)
+
+    def compute_expected(self, tensors: dict[str, torch.Tensor], params=None) -> None:
+        rows, cols = self.valid_shape
+        src0 = tensors["src0"][:rows, :cols]
+        carry = tensors["carry"][:rows, :cols]
+        expected = torch.zeros_like(tensors["out"])
+        if self.op_name == "addc":
+            value = src0 + tensors["src1"][:rows, :cols] + carry
+        elif self.op_name == "subc":
+            value = src0 - tensors["src1"][:rows, :cols] + carry
+        elif self.op_name == "addsc":
+            value = src0 + self.scalar + carry
+        else:
+            value = src0 - self.scalar + carry
+        expected[:rows, :cols] = value
+        tensors["out"][:] = expected
+
+
+_CASES = [
+    pytest.param(
+        op_name,
+        dtype,
+        valid_shape,
+        (1.5 if dtype in {DataType.FP16, DataType.FP32} else 1) if op_name.endswith("sc") else None,
+        id=f"t{op_name}-{dtype.value}-{valid_tag}",
+    )
+    for op_name in _OPS
+    for dtype in _DTYPES
+    for valid_shape, valid_tag in _VALID_SHAPES
+]
+
+
+class TestCarryFamily:
+    """A2/A3 exact-op coverage for the four carry-in instructions."""
+
+    @pytest.mark.platforms("a2a3")
+    @pytest.mark.parametrize("op_name,dtype,valid_shape,scalar", _CASES)
+    def test_carry(self, test_runner, op_name, dtype, valid_shape, scalar):
+        result = test_runner.run(
+            CarryCase(
+                op_name=op_name,
+                dtype=dtype,
+                valid_shape=valid_shape,
+                scalar=scalar,
+            )
+        )
+        assert result.passed, f"Test failed: {result.error}"

--- a/tests/st/runtime/ops/test_carry.py
+++ b/tests/st/runtime/ops/test_carry.py
@@ -1,0 +1,457 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Exact-op system tests for TADDC, TSUBC, TADDSC, and TSUBSC.
+
+Every op runs on the full PTOAS dtype union and on full, row-tail, column-tail,
+and combined-tail valid regions. Both result/src0-alias-eligible and forced
+non-alias paths execute on hardware. The carry tile alternates between zero and
+one. Signed integer inputs include both limits so addition overflow and
+subtraction borrow/wrap behavior are checked; cells outside the valid region
+remain zero.
+"""
+
+from typing import Any
+
+import pypto.language as pl
+import pytest
+import torch
+from harness.core.harness import DataType, PTOTestCase, TensorSpec
+
+M = 16
+N = 64
+
+_PL_DT = {
+    DataType.FP16: pl.FP16,
+    DataType.FP32: pl.FP32,
+    DataType.INT16: pl.INT16,
+    DataType.INT32: pl.INT32,
+}
+_DTYPES = (DataType.INT16, DataType.INT32, DataType.FP16, DataType.FP32)
+_VALID_SHAPES = (
+    ((M, N), "full"),
+    ((11, N), "row-tail"),
+    ((M, 47), "column-tail"),
+    ((11, 47), "combined-tail"),
+)
+_OPS = ("addc", "subc", "addsc", "subsc")
+_REUSE_MODES = ("alias", "nonalias")
+
+
+def _src0(dtype: DataType) -> torch.Tensor:
+    values = torch.arange(M * N, dtype=torch.int64).reshape(M, N).remainder(31) - 15
+    if dtype in {DataType.INT16, DataType.INT32}:
+        info = torch.iinfo(dtype.torch_dtype)
+        values[0, 0] = info.max  # carry = 0
+        values[0, 1] = info.max  # carry = 1
+        values[0, 2] = info.min  # carry = 0
+        values[0, 3] = info.min  # carry = 1
+    else:
+        values = values.to(torch.float32) / 4.0
+    return values.to(dtype.torch_dtype).contiguous()
+
+
+def _src1(dtype: DataType) -> torch.Tensor:
+    values = torch.arange(M * N, dtype=torch.int64).reshape(M, N).remainder(7) + 1
+    if dtype in {DataType.FP16, DataType.FP32}:
+        values = values.to(torch.float32) / 2.0
+    return values.to(dtype.torch_dtype).contiguous()
+
+
+def _carry(dtype: DataType) -> torch.Tensor:
+    values = torch.arange(M * N, dtype=torch.int64).reshape(M, N).remainder(2)
+    return values.to(dtype.torch_dtype).contiguous()
+
+
+def _make_program(
+    op_name: str,
+    dtype: DataType,
+    valid_shape: tuple[int, int],
+    scalar: int | float | None,
+    reuse_mode: str,
+):
+    pl_dtype = _PL_DT[dtype]
+    valid = list(valid_shape)
+
+    if reuse_mode == "nonalias":
+        return _make_nonalias_program(op_name, pl_dtype, valid, scalar)
+
+    if op_name == "addc":
+
+        @pl.program
+        class TileAddcProgram:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                src0: pl.Tensor[[M, N], pl_dtype],
+                src1: pl.Tensor[[M, N], pl_dtype],
+                carry: pl.Tensor[[M, N], pl_dtype],
+                out: pl.InOut[pl.Tensor[[M, N], pl_dtype]],
+            ) -> pl.Tensor[[M, N], pl_dtype]:
+                src0_tile = pl.load(src0, [0, 0], [M, N], valid_shape=valid)
+                src1_tile = pl.load(src1, [0, 0], [M, N], valid_shape=valid)
+                carry_tile = pl.load(carry, [0, 0], [M, N], valid_shape=valid)
+                result = pl.tile.addc(src0_tile, src1_tile, carry_tile)
+                return pl.store(result, [0, 0], out)
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orchestrator(
+                self,
+                src0: pl.Tensor[[M, N], pl_dtype],
+                src1: pl.Tensor[[M, N], pl_dtype],
+                carry: pl.Tensor[[M, N], pl_dtype],
+                out: pl.InOut[pl.Tensor[[M, N], pl_dtype]],
+            ) -> pl.Tensor[[M, N], pl_dtype]:
+                return self.kernel(src0, src1, carry, out)
+
+        return TileAddcProgram
+
+    if op_name == "subc":
+
+        @pl.program
+        class TileSubcProgram:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                src0: pl.Tensor[[M, N], pl_dtype],
+                src1: pl.Tensor[[M, N], pl_dtype],
+                carry: pl.Tensor[[M, N], pl_dtype],
+                out: pl.InOut[pl.Tensor[[M, N], pl_dtype]],
+            ) -> pl.Tensor[[M, N], pl_dtype]:
+                src0_tile = pl.load(src0, [0, 0], [M, N], valid_shape=valid)
+                src1_tile = pl.load(src1, [0, 0], [M, N], valid_shape=valid)
+                carry_tile = pl.load(carry, [0, 0], [M, N], valid_shape=valid)
+                result = pl.tile.subc(src0_tile, src1_tile, carry_tile)
+                return pl.store(result, [0, 0], out)
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orchestrator(
+                self,
+                src0: pl.Tensor[[M, N], pl_dtype],
+                src1: pl.Tensor[[M, N], pl_dtype],
+                carry: pl.Tensor[[M, N], pl_dtype],
+                out: pl.InOut[pl.Tensor[[M, N], pl_dtype]],
+            ) -> pl.Tensor[[M, N], pl_dtype]:
+                return self.kernel(src0, src1, carry, out)
+
+        return TileSubcProgram
+
+    assert scalar is not None
+
+    if op_name == "addsc":
+
+        @pl.program
+        class TileAddscProgram:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                src0: pl.Tensor[[M, N], pl_dtype],
+                carry: pl.Tensor[[M, N], pl_dtype],
+                out: pl.InOut[pl.Tensor[[M, N], pl_dtype]],
+            ) -> pl.Tensor[[M, N], pl_dtype]:
+                src0_tile = pl.load(src0, [0, 0], [M, N], valid_shape=valid)
+                carry_tile = pl.load(carry, [0, 0], [M, N], valid_shape=valid)
+                scalar_value: pl.Scalar[pl_dtype] = pl.cast(scalar, pl_dtype)
+                result = pl.tile.addsc(src0_tile, scalar_value, carry_tile)
+                return pl.store(result, [0, 0], out)
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orchestrator(
+                self,
+                src0: pl.Tensor[[M, N], pl_dtype],
+                carry: pl.Tensor[[M, N], pl_dtype],
+                out: pl.InOut[pl.Tensor[[M, N], pl_dtype]],
+            ) -> pl.Tensor[[M, N], pl_dtype]:
+                return self.kernel(src0, carry, out)
+
+        return TileAddscProgram
+
+    assert op_name == "subsc"
+
+    @pl.program
+    class TileSubscProgram:
+        @pl.function(type=pl.FunctionType.InCore)
+        def kernel(
+            self,
+            src0: pl.Tensor[[M, N], pl_dtype],
+            carry: pl.Tensor[[M, N], pl_dtype],
+            out: pl.InOut[pl.Tensor[[M, N], pl_dtype]],
+        ) -> pl.Tensor[[M, N], pl_dtype]:
+            src0_tile = pl.load(src0, [0, 0], [M, N], valid_shape=valid)
+            carry_tile = pl.load(carry, [0, 0], [M, N], valid_shape=valid)
+            scalar_value: pl.Scalar[pl_dtype] = pl.cast(scalar, pl_dtype)
+            result = pl.tile.subsc(src0_tile, scalar_value, carry_tile)
+            return pl.store(result, [0, 0], out)
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def orchestrator(
+            self,
+            src0: pl.Tensor[[M, N], pl_dtype],
+            carry: pl.Tensor[[M, N], pl_dtype],
+            out: pl.InOut[pl.Tensor[[M, N], pl_dtype]],
+        ) -> pl.Tensor[[M, N], pl_dtype]:
+            return self.kernel(src0, carry, out)
+
+    return TileSubscProgram
+
+
+def _make_nonalias_program(
+    op_name: str,
+    pl_dtype: Any,
+    valid: list[int],
+    scalar: int | float | None,
+):
+    """Keep src0 live after the carry op so its result cannot reuse src0 storage."""
+    if op_name == "addc":
+
+        @pl.program
+        class TileAddcNonaliasProgram:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                src0: pl.Tensor[[M, N], pl_dtype],
+                src1: pl.Tensor[[M, N], pl_dtype],
+                carry: pl.Tensor[[M, N], pl_dtype],
+                out: pl.InOut[pl.Tensor[[M, N], pl_dtype]],
+                src0_after: pl.InOut[pl.Tensor[[M, N], pl_dtype]],
+            ) -> tuple[pl.Tensor[[M, N], pl_dtype], pl.Tensor[[M, N], pl_dtype]]:
+                src0_tile = pl.load(src0, [0, 0], [M, N], valid_shape=valid)
+                src1_tile = pl.load(src1, [0, 0], [M, N], valid_shape=valid)
+                carry_tile = pl.load(carry, [0, 0], [M, N], valid_shape=valid)
+                result = pl.tile.addc(src0_tile, src1_tile, carry_tile)
+                out = pl.store(result, [0, 0], out)
+                src0_after = pl.store(src0_tile, [0, 0], src0_after)
+                return out, src0_after
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orchestrator(
+                self,
+                src0: pl.Tensor[[M, N], pl_dtype],
+                src1: pl.Tensor[[M, N], pl_dtype],
+                carry: pl.Tensor[[M, N], pl_dtype],
+                out: pl.InOut[pl.Tensor[[M, N], pl_dtype]],
+                src0_after: pl.InOut[pl.Tensor[[M, N], pl_dtype]],
+            ) -> tuple[pl.Tensor[[M, N], pl_dtype], pl.Tensor[[M, N], pl_dtype]]:
+                return self.kernel(src0, src1, carry, out, src0_after)
+
+        return TileAddcNonaliasProgram
+
+    if op_name == "subc":
+
+        @pl.program
+        class TileSubcNonaliasProgram:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                src0: pl.Tensor[[M, N], pl_dtype],
+                src1: pl.Tensor[[M, N], pl_dtype],
+                carry: pl.Tensor[[M, N], pl_dtype],
+                out: pl.InOut[pl.Tensor[[M, N], pl_dtype]],
+                src0_after: pl.InOut[pl.Tensor[[M, N], pl_dtype]],
+            ) -> tuple[pl.Tensor[[M, N], pl_dtype], pl.Tensor[[M, N], pl_dtype]]:
+                src0_tile = pl.load(src0, [0, 0], [M, N], valid_shape=valid)
+                src1_tile = pl.load(src1, [0, 0], [M, N], valid_shape=valid)
+                carry_tile = pl.load(carry, [0, 0], [M, N], valid_shape=valid)
+                result = pl.tile.subc(src0_tile, src1_tile, carry_tile)
+                out = pl.store(result, [0, 0], out)
+                src0_after = pl.store(src0_tile, [0, 0], src0_after)
+                return out, src0_after
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orchestrator(
+                self,
+                src0: pl.Tensor[[M, N], pl_dtype],
+                src1: pl.Tensor[[M, N], pl_dtype],
+                carry: pl.Tensor[[M, N], pl_dtype],
+                out: pl.InOut[pl.Tensor[[M, N], pl_dtype]],
+                src0_after: pl.InOut[pl.Tensor[[M, N], pl_dtype]],
+            ) -> tuple[pl.Tensor[[M, N], pl_dtype], pl.Tensor[[M, N], pl_dtype]]:
+                return self.kernel(src0, src1, carry, out, src0_after)
+
+        return TileSubcNonaliasProgram
+
+    assert scalar is not None
+
+    if op_name == "addsc":
+
+        @pl.program
+        class TileAddscNonaliasProgram:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                src0: pl.Tensor[[M, N], pl_dtype],
+                carry: pl.Tensor[[M, N], pl_dtype],
+                out: pl.InOut[pl.Tensor[[M, N], pl_dtype]],
+                src0_after: pl.InOut[pl.Tensor[[M, N], pl_dtype]],
+            ) -> tuple[pl.Tensor[[M, N], pl_dtype], pl.Tensor[[M, N], pl_dtype]]:
+                src0_tile = pl.load(src0, [0, 0], [M, N], valid_shape=valid)
+                carry_tile = pl.load(carry, [0, 0], [M, N], valid_shape=valid)
+                scalar_value: pl.Scalar[pl_dtype] = pl.cast(scalar, pl_dtype)
+                result = pl.tile.addsc(src0_tile, scalar_value, carry_tile)
+                out = pl.store(result, [0, 0], out)
+                src0_after = pl.store(src0_tile, [0, 0], src0_after)
+                return out, src0_after
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orchestrator(
+                self,
+                src0: pl.Tensor[[M, N], pl_dtype],
+                carry: pl.Tensor[[M, N], pl_dtype],
+                out: pl.InOut[pl.Tensor[[M, N], pl_dtype]],
+                src0_after: pl.InOut[pl.Tensor[[M, N], pl_dtype]],
+            ) -> tuple[pl.Tensor[[M, N], pl_dtype], pl.Tensor[[M, N], pl_dtype]]:
+                return self.kernel(src0, carry, out, src0_after)
+
+        return TileAddscNonaliasProgram
+
+    assert op_name == "subsc"
+
+    @pl.program
+    class TileSubscNonaliasProgram:
+        @pl.function(type=pl.FunctionType.InCore)
+        def kernel(
+            self,
+            src0: pl.Tensor[[M, N], pl_dtype],
+            carry: pl.Tensor[[M, N], pl_dtype],
+            out: pl.InOut[pl.Tensor[[M, N], pl_dtype]],
+            src0_after: pl.InOut[pl.Tensor[[M, N], pl_dtype]],
+        ) -> tuple[pl.Tensor[[M, N], pl_dtype], pl.Tensor[[M, N], pl_dtype]]:
+            src0_tile = pl.load(src0, [0, 0], [M, N], valid_shape=valid)
+            carry_tile = pl.load(carry, [0, 0], [M, N], valid_shape=valid)
+            scalar_value: pl.Scalar[pl_dtype] = pl.cast(scalar, pl_dtype)
+            result = pl.tile.subsc(src0_tile, scalar_value, carry_tile)
+            out = pl.store(result, [0, 0], out)
+            src0_after = pl.store(src0_tile, [0, 0], src0_after)
+            return out, src0_after
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def orchestrator(
+            self,
+            src0: pl.Tensor[[M, N], pl_dtype],
+            carry: pl.Tensor[[M, N], pl_dtype],
+            out: pl.InOut[pl.Tensor[[M, N], pl_dtype]],
+            src0_after: pl.InOut[pl.Tensor[[M, N], pl_dtype]],
+        ) -> tuple[pl.Tensor[[M, N], pl_dtype], pl.Tensor[[M, N], pl_dtype]]:
+            return self.kernel(src0, carry, out, src0_after)
+
+    return TileSubscNonaliasProgram
+
+
+class CarryCase(PTOTestCase):
+    """One direct tile carry-in instruction case."""
+
+    __test__ = False
+
+    def __init__(
+        self,
+        *,
+        op_name: str,
+        dtype: DataType,
+        valid_shape: tuple[int, int],
+        reuse_mode: str,
+        scalar: int | float | None = None,
+    ):
+        super().__init__()
+        self.op_name = op_name
+        self.dtype = dtype
+        self.valid_shape = valid_shape
+        self.reuse_mode = reuse_mode
+        self.scalar = scalar
+
+    def get_name(self) -> str:
+        scalar_tag = f"_s{self.scalar}" if self.scalar is not None else ""
+        valid_tag = f"v{self.valid_shape[0]}x{self.valid_shape[1]}"
+        return f"tile_{self.op_name}_{self.dtype.value}_{valid_tag}_{self.reuse_mode}{scalar_tag}"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        specs = [
+            TensorSpec("src0", [M, N], self.dtype, init_value=lambda: _src0(self.dtype)),
+        ]
+        if self.op_name in {"addc", "subc"}:
+            specs.append(TensorSpec("src1", [M, N], self.dtype, init_value=lambda: _src1(self.dtype)))
+        specs.extend(
+            [
+                TensorSpec("carry", [M, N], self.dtype, init_value=lambda: _carry(self.dtype)),
+                TensorSpec("out", [M, N], self.dtype, init_value=torch.zeros, is_output=True),
+            ]
+        )
+        if self.reuse_mode == "nonalias":
+            specs.append(TensorSpec("src0_after", [M, N], self.dtype, init_value=torch.zeros, is_output=True))
+        return specs
+
+    def get_program(self) -> Any:
+        return _make_program(self.op_name, self.dtype, self.valid_shape, self.scalar, self.reuse_mode)
+
+    def compute_expected(self, tensors: dict[str, torch.Tensor], params=None) -> None:
+        rows, cols = self.valid_shape
+        src0 = tensors["src0"][:rows, :cols]
+        carry = tensors["carry"][:rows, :cols]
+        expected = torch.zeros_like(tensors["out"])
+        if self.op_name == "addc":
+            value = src0 + tensors["src1"][:rows, :cols] + carry
+        elif self.op_name == "subc":
+            value = src0 - tensors["src1"][:rows, :cols] + carry
+        elif self.op_name == "addsc":
+            value = src0 + self.scalar + carry
+        else:
+            value = src0 - self.scalar + carry
+        expected[:rows, :cols] = value
+        tensors["out"][:] = expected
+        if self.reuse_mode == "nonalias":
+            src0_after = torch.zeros_like(tensors["src0_after"])
+            src0_after[:rows, :cols] = src0
+            tensors["src0_after"][:] = src0_after
+
+
+_CASES = [
+    pytest.param(
+        op_name,
+        dtype,
+        valid_shape,
+        (1.5 if dtype in {DataType.FP16, DataType.FP32} else 1) if op_name.endswith("sc") else None,
+        reuse_mode,
+        marks=(
+            pytest.mark.platform_xfail(
+                "a2a3",
+                reason=(
+                    "PTO ISA v0.57 TADDSC/TSUBSC full-column row-tail fast path computes incorrect results"
+                ),
+            )
+            if op_name in {"addsc", "subsc"} and valid_tag == "row-tail"
+            else ()
+        ),
+        id=f"t{op_name}-{dtype.value}-{valid_tag}-{reuse_mode}",
+    )
+    for op_name in _OPS
+    for dtype in _DTYPES
+    for valid_shape, valid_tag in _VALID_SHAPES
+    for reuse_mode in _REUSE_MODES
+]
+
+
+class TestCarryFamily:
+    """A2/A3 exact-op coverage for the four carry-in instructions."""
+
+    @pytest.mark.platforms("a2a3")
+    @pytest.mark.parametrize("op_name,dtype,valid_shape,scalar,reuse_mode", _CASES)
+    def test_carry(self, test_runner, op_name, dtype, valid_shape, scalar, reuse_mode):
+        result = test_runner.run(
+            CarryCase(
+                op_name=op_name,
+                dtype=dtype,
+                valid_shape=valid_shape,
+                reuse_mode=reuse_mode,
+                scalar=scalar,
+            )
+        )
+        assert result.passed, f"Test failed: {result.error}"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/ut/codegen/test_pto_codegen_ops.py
+++ b/tests/ut/codegen/test_pto_codegen_ops.py
@@ -547,6 +547,86 @@ class Test910BBlockOpsCodegen:
             validate_kernel_codegen(func_name, mlir_code)
 
 
+class TestCarryFamilyCodegen:
+    """Exact PTO emission for the four carry-family tile ops."""
+
+    def test_carry_ops_emit_three_inputs_and_tail_types(self):
+        @pl.program
+        class CarryPrograms:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel_addc(
+                self,
+                src0: pl.Tensor[[16, 16], pl.FP32],
+                src1: pl.Tensor[[16, 16], pl.FP32],
+                carry: pl.Tensor[[16, 16], pl.FP32],
+                out: pl.Tensor[[16, 16], pl.FP32],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                src0_tile = pl.load(src0, [0, 0], [16, 16], valid_shapes=[11, 13])
+                src1_tile = pl.load(src1, [0, 0], [16, 16], valid_shapes=[11, 13])
+                carry_tile = pl.load(carry, [0, 0], [16, 16], valid_shapes=[11, 13])
+                result = pl.tile.addc(src0_tile, src1_tile, carry_tile)
+                return pl.store(result, [0, 0], out)
+
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel_subc(
+                self,
+                src0: pl.Tensor[[16, 16], pl.FP32],
+                src1: pl.Tensor[[16, 16], pl.FP32],
+                carry: pl.Tensor[[16, 16], pl.FP32],
+                out: pl.Tensor[[16, 16], pl.FP32],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                src0_tile = pl.load(src0, [0, 0], [16, 16], valid_shapes=[11, 13])
+                src1_tile = pl.load(src1, [0, 0], [16, 16], valid_shapes=[11, 13])
+                carry_tile = pl.load(carry, [0, 0], [16, 16], valid_shapes=[11, 13])
+                result = pl.tile.subc(src0_tile, src1_tile, carry_tile)
+                return pl.store(result, [0, 0], out)
+
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel_addsc(
+                self,
+                src0: pl.Tensor[[16, 16], pl.FP32],
+                carry: pl.Tensor[[16, 16], pl.FP32],
+                out: pl.Tensor[[16, 16], pl.FP32],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                src0_tile = pl.load(src0, [0, 0], [16, 16], valid_shapes=[11, 13])
+                carry_tile = pl.load(carry, [0, 0], [16, 16], valid_shapes=[11, 13])
+                result = pl.tile.addsc(src0_tile, 1.5, carry_tile)
+                return pl.store(result, [0, 0], out)
+
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel_subsc(
+                self,
+                src0: pl.Tensor[[16, 16], pl.FP32],
+                carry: pl.Tensor[[16, 16], pl.FP32],
+                out: pl.Tensor[[16, 16], pl.FP32],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                src0_tile = pl.load(src0, [0, 0], [16, 16], valid_shapes=[11, 13])
+                carry_tile = pl.load(carry, [0, 0], [16, 16], valid_shapes=[11, 13])
+                result = pl.tile.subsc(src0_tile, 1.5, carry_tile)
+                return pl.store(result, [0, 0], out)
+
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+        optimized = PassManager.get_strategy(OptimizationStrategy.Default).run_passes(CarryPrograms)
+        expected_ops = {
+            "kernel_addc": "pto.taddc",
+            "kernel_subc": "pto.tsubc",
+            "kernel_addsc": "pto.taddsc",
+            "kernel_subsc": "pto.tsubsc",
+        }
+
+        for func in optimized.functions.values():
+            expected_op = expected_ops[func.name]
+            single = ir.Program([func], func.name, optimized.span)
+            mlir = codegen.PTOCodegen().generate(single)
+            op_line = next((line for line in mlir.splitlines() if expected_op in line), "")
+            assert op_line, f"{expected_op} not found in MLIR:\n{mlir}"
+            ins = op_line.split("ins(", 1)[1].split(")", 1)[0].split(":", 1)[0]
+            assert ins.count(",") == 2, f"{expected_op} must have three inputs: {op_line}"
+            assert "outs(" in op_line
+            assert "v_row=11" in op_line and "v_col=13" in op_line
+
+
 class TestRsqrtHighPrecisionCodegen:
     """Tests for the high-precision path of tile.rsqrt (2-arg form)."""
 

--- a/tests/ut/codegen/test_pto_codegen_ops.py
+++ b/tests/ut/codegen/test_pto_codegen_ops.py
@@ -555,6 +555,89 @@ class Test910BBlockOpsCodegen:
             validate_kernel_codegen(func_name, mlir_code)
 
 
+class TestCarryFamilyCodegen:
+    """Exact PTO emission for the four carry-family tile ops."""
+
+    def test_carry_ops_emit_three_inputs_and_tail_types(self):
+        @pl.program
+        class CarryPrograms:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel_addc(
+                self,
+                src0: pl.Tensor[[16, 16], pl.FP32],
+                src1: pl.Tensor[[16, 16], pl.FP32],
+                carry: pl.Tensor[[16, 16], pl.FP32],
+                out: pl.Tensor[[16, 16], pl.FP32],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                src0_tile = pl.load(src0, [0, 0], [16, 16], valid_shape=[11, 13])
+                src1_tile = pl.load(src1, [0, 0], [16, 16], valid_shape=[11, 13])
+                carry_tile = pl.load(carry, [0, 0], [16, 16], valid_shape=[11, 13])
+                result = pl.tile.addc(src0_tile, src1_tile, carry_tile)
+                return pl.store(result, [0, 0], out)
+
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel_subc(
+                self,
+                src0: pl.Tensor[[16, 16], pl.FP32],
+                src1: pl.Tensor[[16, 16], pl.FP32],
+                carry: pl.Tensor[[16, 16], pl.FP32],
+                out: pl.Tensor[[16, 16], pl.FP32],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                src0_tile = pl.load(src0, [0, 0], [16, 16], valid_shape=[11, 13])
+                src1_tile = pl.load(src1, [0, 0], [16, 16], valid_shape=[11, 13])
+                carry_tile = pl.load(carry, [0, 0], [16, 16], valid_shape=[11, 13])
+                result = pl.tile.subc(src0_tile, src1_tile, carry_tile)
+                return pl.store(result, [0, 0], out)
+
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel_addsc(
+                self,
+                src0: pl.Tensor[[16, 16], pl.FP32],
+                carry: pl.Tensor[[16, 16], pl.FP32],
+                out: pl.Tensor[[16, 16], pl.FP32],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                src0_tile = pl.load(src0, [0, 0], [16, 16], valid_shape=[11, 13])
+                carry_tile = pl.load(carry, [0, 0], [16, 16], valid_shape=[11, 13])
+                result = pl.tile.addsc(src0_tile, 1.5, carry_tile)
+                return pl.store(result, [0, 0], out)
+
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel_subsc(
+                self,
+                src0: pl.Tensor[[16, 16], pl.FP32],
+                carry: pl.Tensor[[16, 16], pl.FP32],
+                out: pl.Tensor[[16, 16], pl.FP32],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                src0_tile = pl.load(src0, [0, 0], [16, 16], valid_shape=[11, 13])
+                carry_tile = pl.load(carry, [0, 0], [16, 16], valid_shape=[11, 13])
+                result = pl.tile.subsc(src0_tile, 1.5, carry_tile)
+                return pl.store(result, [0, 0], out)
+
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+        optimized = PassManager.get_strategy(OptimizationStrategy.Default).run_passes(CarryPrograms)
+        expected_ops = {
+            "kernel_addc": "pto.taddc",
+            "kernel_subc": "pto.tsubc",
+            "kernel_addsc": "pto.taddsc",
+            "kernel_subsc": "pto.tsubsc",
+        }
+
+        for func in optimized.functions.values():
+            expected_op = expected_ops[func.name]
+            single = ir.Program([func], func.name, optimized.span)
+            mlir = codegen.PTOCodegen().generate(single)
+            op_line = next((line for line in mlir.splitlines() if expected_op in line), "")
+            assert op_line, f"{expected_op} not found in MLIR:\n{mlir}"
+            ins = op_line.split("ins(", 1)[1].split(")", 1)[0].split(":", 1)[0]
+            assert ins.count(",") == 2, f"{expected_op} must have three inputs: {op_line}"
+            assert "outs(" in op_line
+            expected_tail_types = 3 if func.name.endswith("sc") else 4
+            assert op_line.count("v_row=?, v_col=?") == expected_tail_types, (
+                f"{expected_op} inputs and output must share the dynamic tail type: {op_line}"
+            )
+
+
 class TestRsqrtHighPrecisionCodegen:
     """Tests for the high-precision path of tile.rsqrt (2-arg form)."""
 

--- a/tests/ut/debug/test_torch_codegen.py
+++ b/tests/ut/debug/test_torch_codegen.py
@@ -336,6 +336,51 @@ def test_tile_compute_ops():
     assert "torch.add(a, b)" in code
 
 
+@pytest.mark.parametrize(
+    ("op_name", "expected_expr"),
+    [
+        ("addc", "(a + b + carry)"),
+        ("subc", "(a - b + carry)"),
+        ("addsc", "(a + 2.0 + carry)"),
+        ("subsc", "(a - 2.0 + carry)"),
+    ],
+)
+def test_tile_carry_codegen_and_execution(op_name, expected_expr):
+    """Carry-in debug references use ``+ carry`` for add and subtract forms."""
+    a = _tile_var("a", [2, 2])
+    carry = _tile_var("carry", [2, 2])
+    out = _tile_var("out", [2, 2])
+    if op_name in {"addc", "subc"}:
+        b = _tile_var("b", [2, 2])
+        args: list[ir.Expr] = [a, b, carry]
+        params: list[ir.Var] = [a, b, carry]
+    else:
+        args = [a, _float(2.0), carry]
+        params = [a, carry]
+
+    call = _op_call(f"tile.{op_name}", args)
+    body = ir.SeqStmts(
+        [ir.AssignStmt(out, call, _span()), ir.ReturnStmt([out], _span())],
+        _span(),
+    )
+    func = _simple_function("carry_ref", params, body, [out.type])
+    code = torch_codegen(func)
+    assert expected_expr in code
+
+    ns: dict = {}
+    exec(code, ns)  # noqa: S102
+    a_value = torch.tensor([[5.0, -3.0], [8.0, 1.0]])
+    carry_value = torch.tensor([[0.0, 1.0], [1.0, 0.0]])
+    if op_name in {"addc", "subc"}:
+        b_value = torch.tensor([[2.0, 4.0], [-1.0, 3.0]])
+        actual = ns["carry_ref"](a_value, b_value, carry_value)
+        expected = a_value + b_value + carry_value if op_name == "addc" else a_value - b_value + carry_value
+    else:
+        actual = ns["carry_ref"](a_value, carry_value)
+        expected = a_value + 2.0 + carry_value if op_name == "addsc" else a_value - 2.0 + carry_value
+    assert torch.equal(actual, expected)
+
+
 # (op leaf, expected torch snippet) for the integer bitwise / shift family. The
 # reference map registers these for the `tensor` and `tile` prefixes from one shared
 # loop, so both namespaces are asserted below (issue #2216).

--- a/tests/ut/ir/operators/test_tile_ops.py
+++ b/tests/ut/ir/operators/test_tile_ops.py
@@ -3729,6 +3729,98 @@ class TestTileBitwiseArithmeticOps:
         ir_str = str(Program)
         assert "tile.subsc" in ir_str
 
+    @pytest.mark.parametrize("dtype", [DataType.INT16, DataType.INT32, DataType.FP16, DataType.FP32])
+    @pytest.mark.parametrize("op", [tile.addc, tile.subc])
+    def test_tile_carry_accepts_ptoas_dtype_union_and_preserves_view(self, dtype, op):
+        """TADDC/TSUBC keep the exact shared tile type, including valid extents and layout."""
+        span = ir.Span.unknown()
+        view = ir.TileView(
+            valid_shape=[7, 13],
+            blayout=ir.TileLayout.row_major,
+            slayout=ir.TileLayout.none_box,
+        )
+        tile_type = ir.TileType([8, 16], dtype, tile_view=view)
+        src0 = ir.Var("src0", tile_type, span)
+        src1 = ir.Var("src1", tile_type, span)
+        carry = ir.Var("carry", tile_type, span)
+
+        call = op(src0, src1, carry)
+
+        assert _tile_result_dtype(call) == dtype
+        assert call.type.shape == tile_type.shape
+        assert _valid_of(call.type) == [7, 13]
+        assert call.type.tile_view.blayout == ir.TileLayout.row_major
+
+    @pytest.mark.parametrize(
+        "dtype,literal",
+        [
+            (DataType.INT16, 1),
+            (DataType.INT32, 1),
+            (DataType.FP16, 1.5),
+            (DataType.FP32, 1.5),
+        ],
+    )
+    @pytest.mark.parametrize("op", [tile.addsc, tile.subsc])
+    def test_tile_scalar_carry_literal_uses_tile_dtype_and_preserves_view(self, dtype, literal, op):
+        """Literal scalar sugar is restamped to the shared PTOAS element dtype."""
+        span = ir.Span.unknown()
+        view = ir.TileView(
+            valid_shape=[5, 11],
+            blayout=ir.TileLayout.row_major,
+            slayout=ir.TileLayout.none_box,
+        )
+        tile_type = ir.TileType([8, 16], dtype, tile_view=view)
+        src0 = ir.Var("src0", tile_type, span)
+        carry = ir.Var("carry", tile_type, span)
+
+        call = op(src0, literal, carry)
+
+        assert _operand_dtype(call.args[1]) == dtype
+        assert _tile_result_dtype(call) == dtype
+        assert _valid_of(call.type) == [5, 11]
+
+    @pytest.mark.parametrize("op", [tile.addc, tile.subc])
+    def test_tile_carry_rejects_mixed_dtype_broadcast_and_valid_shape(self, op):
+        """Carry intrinsics do not provide dtype promotion or shape broadcasting."""
+        span = ir.Span.unknown()
+        full = ir.Var("full", ir.TileType([8, 16], DataType.FP32), span)
+        mixed = ir.Var("mixed", ir.TileType([8, 16], DataType.FP16), span)
+        broadcast = ir.Var("broadcast", ir.TileType([1, 16], DataType.FP32), span)
+        tail_view = ir.TileView(valid_shape=[7, 16])
+        tail = ir.Var("tail", ir.TileType([8, 16], DataType.FP32, tile_view=tail_view), span)
+
+        with pytest.raises(ValueError, match=r"same dtype"):
+            op(full, mixed, full)
+        with pytest.raises(ValueError, match=r"same physical shape"):
+            op(full, broadcast, full)
+        with pytest.raises(ValueError, match=r"same valid_shape"):
+            op(full, tail, full)
+
+    @pytest.mark.parametrize("op", [tile.addsc, tile.subsc])
+    def test_tile_scalar_carry_rejects_explicit_scalar_and_carry_mismatch(self, op):
+        """Typed scalar expressions and carry tiles must exactly match src0."""
+        span = ir.Span.unknown()
+        src0 = ir.Var("src0", ir.TileType([8, 16], DataType.INT32), span)
+        scalar = ir.ConstFloat(1.0, DataType.FP32, span)
+        mixed_carry = ir.Var("carry", ir.TileType([8, 16], DataType.FP32), span)
+
+        with pytest.raises(ValueError, match=r"same dtype"):
+            op(src0, scalar, src0)
+        with pytest.raises(ValueError, match=r"same dtype"):
+            op(src0, 1, mixed_carry)
+
+    @pytest.mark.parametrize("op", [tile.addc, tile.subc, tile.addsc, tile.subsc])
+    def test_tile_carry_rejects_unsupported_dtype(self, op):
+        """INT8 is outside the current A2/A3 and A5 carry-op dtype union."""
+        span = ir.Span.unknown()
+        value = ir.Var("value", ir.TileType([8, 16], DataType.INT8), span)
+
+        with pytest.raises(ValueError, match=r"INT16, INT32, FP16, FP32"):
+            if op in (tile.addsc, tile.subsc):
+                op(value, 1, value)
+            else:
+                op(value, value, value)
+
     def test_tile_lrelu(self):
         """Test tile.lrelu operator - element-wise leaky ReLU with scalar slope."""
 

--- a/tests/ut/ir/operators/test_tile_ops.py
+++ b/tests/ut/ir/operators/test_tile_ops.py
@@ -4728,6 +4728,98 @@ class TestTileBitwiseArithmeticOps:
         ir_str = str(Program)
         assert "tile.subsc" in ir_str
 
+    @pytest.mark.parametrize("dtype", [DataType.INT16, DataType.INT32, DataType.FP16, DataType.FP32])
+    @pytest.mark.parametrize("op", [tile.addc, tile.subc])
+    def test_tile_carry_accepts_ptoas_dtype_union_and_preserves_view(self, dtype, op):
+        """TADDC/TSUBC keep the exact shared tile type, including valid extents and layout."""
+        span = ir.Span.unknown()
+        view = ir.TileView(
+            valid_shape=[7, 13],
+            blayout=ir.TileLayout.row_major,
+            slayout=ir.TileLayout.none_box,
+        )
+        tile_type = ir.TileType([8, 16], dtype, tile_view=view)
+        src0 = ir.Var("src0", tile_type, span)
+        src1 = ir.Var("src1", tile_type, span)
+        carry = ir.Var("carry", tile_type, span)
+
+        call = op(src0, src1, carry)
+
+        assert _tile_result_dtype(call) == dtype
+        assert call.type.shape == tile_type.shape
+        assert _valid_of(call.type) == [7, 13]
+        assert call.type.tile_view.blayout == ir.TileLayout.row_major
+
+    @pytest.mark.parametrize(
+        "dtype,literal",
+        [
+            (DataType.INT16, 1),
+            (DataType.INT32, 1),
+            (DataType.FP16, 1.5),
+            (DataType.FP32, 1.5),
+        ],
+    )
+    @pytest.mark.parametrize("op", [tile.addsc, tile.subsc])
+    def test_tile_scalar_carry_literal_uses_tile_dtype_and_preserves_view(self, dtype, literal, op):
+        """Literal scalar sugar is restamped to the shared PTOAS element dtype."""
+        span = ir.Span.unknown()
+        view = ir.TileView(
+            valid_shape=[5, 11],
+            blayout=ir.TileLayout.row_major,
+            slayout=ir.TileLayout.none_box,
+        )
+        tile_type = ir.TileType([8, 16], dtype, tile_view=view)
+        src0 = ir.Var("src0", tile_type, span)
+        carry = ir.Var("carry", tile_type, span)
+
+        call = op(src0, literal, carry)
+
+        assert _operand_dtype(call.args[1]) == dtype
+        assert _tile_result_dtype(call) == dtype
+        assert _valid_of(call.type) == [5, 11]
+
+    @pytest.mark.parametrize("op", [tile.addc, tile.subc])
+    def test_tile_carry_rejects_mixed_dtype_broadcast_and_valid_shape(self, op):
+        """Carry intrinsics do not provide dtype promotion or shape broadcasting."""
+        span = ir.Span.unknown()
+        full = ir.Var("full", ir.TileType([8, 16], DataType.FP32), span)
+        mixed = ir.Var("mixed", ir.TileType([8, 16], DataType.FP16), span)
+        broadcast = ir.Var("broadcast", ir.TileType([1, 16], DataType.FP32), span)
+        tail_view = ir.TileView(valid_shape=[7, 16])
+        tail = ir.Var("tail", ir.TileType([8, 16], DataType.FP32, tile_view=tail_view), span)
+
+        with pytest.raises(ValueError, match=r"same dtype"):
+            op(full, mixed, full)
+        with pytest.raises(ValueError, match=r"same physical shape"):
+            op(full, broadcast, full)
+        with pytest.raises(ValueError, match=r"same valid_shape"):
+            op(full, tail, full)
+
+    @pytest.mark.parametrize("op", [tile.addsc, tile.subsc])
+    def test_tile_scalar_carry_rejects_explicit_scalar_and_carry_mismatch(self, op):
+        """Typed scalar expressions and carry tiles must exactly match src0."""
+        span = ir.Span.unknown()
+        src0 = ir.Var("src0", ir.TileType([8, 16], DataType.INT32), span)
+        scalar = ir.ConstFloat(1.0, DataType.FP32, span)
+        mixed_carry = ir.Var("carry", ir.TileType([8, 16], DataType.FP32), span)
+
+        with pytest.raises(ValueError, match=r"same dtype"):
+            op(src0, scalar, src0)
+        with pytest.raises(ValueError, match=r"same dtype"):
+            op(src0, 1, mixed_carry)
+
+    @pytest.mark.parametrize("op", [tile.addc, tile.subc, tile.addsc, tile.subsc])
+    def test_tile_carry_rejects_unsupported_dtype(self, op):
+        """INT8 is outside the current A2/A3 and A5 carry-op dtype union."""
+        span = ir.Span.unknown()
+        value = ir.Var("value", ir.TileType([8, 16], DataType.INT8), span)
+
+        with pytest.raises(ValueError, match=r"INT16, INT32, FP16, FP32"):
+            if op in (tile.addsc, tile.subsc):
+                op(value, 1, value)
+            else:
+                op(value, value, value)
+
     def test_tile_lrelu(self):
         """Test tile.lrelu operator - element-wise leaky ReLU with scalar slope."""
 

--- a/tests/ut/ir/transforms/test_memory_reuse.py
+++ b/tests/ut/ir/transforms/test_memory_reuse.py
@@ -3765,6 +3765,67 @@ class TestAscend910BLoadTpopHazard:
         )
 
 
+class TestCarryOutputAlias:
+    """Native carry ops remain safe when MemoryReuse aliases dst with src0."""
+
+    def test_all_carry_variants_reuse_their_dead_src0_buffer(self):
+        """TADDC/TSUBC/TADDSC/TSUBSC are per-element and support dst == src0."""
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(
+                self,
+                a: pl.Tensor[[8, 16], pl.FP32],
+                b: pl.Tensor[[8, 16], pl.FP32],
+                carry: pl.Tensor[[8, 16], pl.FP32],
+                out_addc: pl.Out[pl.Tensor[[8, 16], pl.FP32]],
+                out_subc: pl.Out[pl.Tensor[[8, 16], pl.FP32]],
+                out_addsc: pl.Out[pl.Tensor[[8, 16], pl.FP32]],
+                out_subsc: pl.Out[pl.Tensor[[8, 16], pl.FP32]],
+            ) -> pl.Tensor[[8, 16], pl.FP32]:
+                addc_src0: pl.Tile[[8, 16], pl.FP32, pl.MemorySpace.Vec] = pl.load(a, [0, 0], [8, 16])
+                addc_src1: pl.Tile[[8, 16], pl.FP32, pl.MemorySpace.Vec] = pl.load(b, [0, 0], [8, 16])
+                addc_carry: pl.Tile[[8, 16], pl.FP32, pl.MemorySpace.Vec] = pl.load(carry, [0, 0], [8, 16])
+                addc_dst: pl.Tile[[8, 16], pl.FP32, pl.MemorySpace.Vec] = pl.addc(
+                    addc_src0, addc_src1, addc_carry
+                )
+                _stored_addc: pl.Tensor[[8, 16], pl.FP32] = pl.store(addc_dst, [0, 0], out_addc)
+
+                subc_src0: pl.Tile[[8, 16], pl.FP32, pl.MemorySpace.Vec] = pl.load(a, [0, 0], [8, 16])
+                subc_src1: pl.Tile[[8, 16], pl.FP32, pl.MemorySpace.Vec] = pl.load(b, [0, 0], [8, 16])
+                subc_carry: pl.Tile[[8, 16], pl.FP32, pl.MemorySpace.Vec] = pl.load(carry, [0, 0], [8, 16])
+                subc_dst: pl.Tile[[8, 16], pl.FP32, pl.MemorySpace.Vec] = pl.subc(
+                    subc_src0, subc_src1, subc_carry
+                )
+                _stored_subc: pl.Tensor[[8, 16], pl.FP32] = pl.store(subc_dst, [0, 0], out_subc)
+
+                addsc_src0: pl.Tile[[8, 16], pl.FP32, pl.MemorySpace.Vec] = pl.load(a, [0, 0], [8, 16])
+                addsc_carry: pl.Tile[[8, 16], pl.FP32, pl.MemorySpace.Vec] = pl.load(carry, [0, 0], [8, 16])
+                addsc_dst: pl.Tile[[8, 16], pl.FP32, pl.MemorySpace.Vec] = pl.addsc(
+                    addsc_src0, 1.0, addsc_carry
+                )
+                _stored_addsc: pl.Tensor[[8, 16], pl.FP32] = pl.store(addsc_dst, [0, 0], out_addsc)
+
+                subsc_src0: pl.Tile[[8, 16], pl.FP32, pl.MemorySpace.Vec] = pl.load(a, [0, 0], [8, 16])
+                subsc_carry: pl.Tile[[8, 16], pl.FP32, pl.MemorySpace.Vec] = pl.load(carry, [0, 0], [8, 16])
+                subsc_dst: pl.Tile[[8, 16], pl.FP32, pl.MemorySpace.Vec] = pl.subsc(
+                    subsc_src0, 1.0, subsc_carry
+                )
+                result: pl.Tensor[[8, 16], pl.FP32] = pl.store(subsc_dst, [0, 0], out_subsc)
+                return result
+
+        after = _run_pipeline(Before)
+        bases = _collect_tile_memref_bases(after)
+        for op_name in ("addc", "subc", "addsc", "subsc"):
+            src0 = f"{op_name}_src0"
+            dst = f"{op_name}_dst"
+            assert src0 in bases and dst in bases, f"missing {op_name} tile vars; got {bases}"
+            assert bases[dst] == bases[src0], (
+                f"{op_name} dst should safely reuse dead src0, got dst={bases[dst]} src0={bases[src0]}"
+            )
+
+
 class TestForbidOutputAlias:
     """A tile.sel output must not alias its mask (arg 0) or tmp (arg 3) buffer.
 

--- a/tests/ut/ir/transforms/test_memory_reuse.py
+++ b/tests/ut/ir/transforms/test_memory_reuse.py
@@ -5126,6 +5126,67 @@ class TestAscend910BLoadTpopHazard:
         )
 
 
+class TestCarryOutputAlias:
+    """Native carry ops remain safe when MemoryReuse aliases dst with src0."""
+
+    def test_all_carry_variants_reuse_their_dead_src0_buffer(self):
+        """TADDC/TSUBC/TADDSC/TSUBSC are per-element and support dst == src0."""
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(
+                self,
+                a: pl.Tensor[[8, 16], pl.FP32],
+                b: pl.Tensor[[8, 16], pl.FP32],
+                carry: pl.Tensor[[8, 16], pl.FP32],
+                out_addc: pl.Out[pl.Tensor[[8, 16], pl.FP32]],
+                out_subc: pl.Out[pl.Tensor[[8, 16], pl.FP32]],
+                out_addsc: pl.Out[pl.Tensor[[8, 16], pl.FP32]],
+                out_subsc: pl.Out[pl.Tensor[[8, 16], pl.FP32]],
+            ) -> pl.Tensor[[8, 16], pl.FP32]:
+                addc_src0: pl.Tile[[8, 16], pl.FP32, pl.MemorySpace.Vec] = pl.load(a, [0, 0], [8, 16])
+                addc_src1: pl.Tile[[8, 16], pl.FP32, pl.MemorySpace.Vec] = pl.load(b, [0, 0], [8, 16])
+                addc_carry: pl.Tile[[8, 16], pl.FP32, pl.MemorySpace.Vec] = pl.load(carry, [0, 0], [8, 16])
+                addc_dst: pl.Tile[[8, 16], pl.FP32, pl.MemorySpace.Vec] = pl.addc(
+                    addc_src0, addc_src1, addc_carry
+                )
+                _stored_addc: pl.Tensor[[8, 16], pl.FP32] = pl.store(addc_dst, [0, 0], out_addc)
+
+                subc_src0: pl.Tile[[8, 16], pl.FP32, pl.MemorySpace.Vec] = pl.load(a, [0, 0], [8, 16])
+                subc_src1: pl.Tile[[8, 16], pl.FP32, pl.MemorySpace.Vec] = pl.load(b, [0, 0], [8, 16])
+                subc_carry: pl.Tile[[8, 16], pl.FP32, pl.MemorySpace.Vec] = pl.load(carry, [0, 0], [8, 16])
+                subc_dst: pl.Tile[[8, 16], pl.FP32, pl.MemorySpace.Vec] = pl.subc(
+                    subc_src0, subc_src1, subc_carry
+                )
+                _stored_subc: pl.Tensor[[8, 16], pl.FP32] = pl.store(subc_dst, [0, 0], out_subc)
+
+                addsc_src0: pl.Tile[[8, 16], pl.FP32, pl.MemorySpace.Vec] = pl.load(a, [0, 0], [8, 16])
+                addsc_carry: pl.Tile[[8, 16], pl.FP32, pl.MemorySpace.Vec] = pl.load(carry, [0, 0], [8, 16])
+                addsc_dst: pl.Tile[[8, 16], pl.FP32, pl.MemorySpace.Vec] = pl.addsc(
+                    addsc_src0, 1.0, addsc_carry
+                )
+                _stored_addsc: pl.Tensor[[8, 16], pl.FP32] = pl.store(addsc_dst, [0, 0], out_addsc)
+
+                subsc_src0: pl.Tile[[8, 16], pl.FP32, pl.MemorySpace.Vec] = pl.load(a, [0, 0], [8, 16])
+                subsc_carry: pl.Tile[[8, 16], pl.FP32, pl.MemorySpace.Vec] = pl.load(carry, [0, 0], [8, 16])
+                subsc_dst: pl.Tile[[8, 16], pl.FP32, pl.MemorySpace.Vec] = pl.subsc(
+                    subsc_src0, 1.0, subsc_carry
+                )
+                result: pl.Tensor[[8, 16], pl.FP32] = pl.store(subsc_dst, [0, 0], out_subsc)
+                return result
+
+        after = _run_pipeline(Before)
+        bases = _collect_tile_memref_bases(after)
+        for op_name in ("addc", "subc", "addsc", "subsc"):
+            src0 = f"{op_name}_src0"
+            dst = f"{op_name}_dst"
+            assert src0 in bases and dst in bases, f"missing {op_name} tile vars; got {bases}"
+            assert bases[dst] == bases[src0], (
+                f"{op_name} dst should safely reuse dead src0, got dst={bases[dst]} src0={bases[src0]}"
+            )
+
+
 class TestForbidOutputAlias:
     """Outputs must not alias operand buffers that the hardware still reads.
 
@@ -5133,6 +5194,84 @@ class TestForbidOutputAlias:
     operands whose lifetimes end at an op from operands safe for its output to
     overwrite.
     """
+
+    def test_carry_outputs_do_not_alias_carry(self):
+        """Carry ops may reuse src0, but their final TADD still reads carry."""
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(
+                self,
+                a: pl.Tensor[[8, 16], pl.FP32],
+                b: pl.Tensor[[8, 16], pl.FP32],
+                carry: pl.Tensor[[8, 16], pl.FP32],
+                out: pl.Out[pl.Tensor[[8, 16], pl.FP32]],
+            ) -> pl.Tensor[[8, 16], pl.FP32]:
+                addc_src0: pl.Tile[[8, 16], pl.FP32, pl.MemorySpace.Vec] = pl.load(a, [0, 0], [8, 16])
+                addc_src1: pl.Tile[[8, 16], pl.FP32, pl.MemorySpace.Vec] = pl.load(b, [0, 0], [8, 16])
+                addc_carry: pl.Tile[[8, 16], pl.FP32, pl.MemorySpace.Vec] = pl.load(carry, [0, 0], [8, 16])
+                addc_dst: pl.Tile[[8, 16], pl.FP32, pl.MemorySpace.Vec] = pl.addc(
+                    addc_src0, addc_src1, addc_carry
+                )
+                addc_keep_src0_live: pl.Tile[[8, 16], pl.FP32, pl.MemorySpace.Vec] = pl.add(
+                    addc_src0, addc_dst
+                )
+                addc_keep_sources_live: pl.Tile[[8, 16], pl.FP32, pl.MemorySpace.Vec] = pl.add(
+                    addc_src1, addc_keep_src0_live
+                )
+
+                subc_src0: pl.Tile[[8, 16], pl.FP32, pl.MemorySpace.Vec] = pl.load(a, [0, 0], [8, 16])
+                subc_src1: pl.Tile[[8, 16], pl.FP32, pl.MemorySpace.Vec] = pl.load(b, [0, 0], [8, 16])
+                subc_carry: pl.Tile[[8, 16], pl.FP32, pl.MemorySpace.Vec] = pl.load(carry, [0, 0], [8, 16])
+                subc_dst: pl.Tile[[8, 16], pl.FP32, pl.MemorySpace.Vec] = pl.subc(
+                    subc_src0, subc_src1, subc_carry
+                )
+                subc_keep_src0_live: pl.Tile[[8, 16], pl.FP32, pl.MemorySpace.Vec] = pl.add(
+                    subc_src0, subc_dst
+                )
+                subc_keep_sources_live: pl.Tile[[8, 16], pl.FP32, pl.MemorySpace.Vec] = pl.add(
+                    subc_src1, subc_keep_src0_live
+                )
+
+                addsc_src0: pl.Tile[[8, 16], pl.FP32, pl.MemorySpace.Vec] = pl.load(a, [0, 0], [8, 16])
+                addsc_carry: pl.Tile[[8, 16], pl.FP32, pl.MemorySpace.Vec] = pl.load(carry, [0, 0], [8, 16])
+                addsc_dst: pl.Tile[[8, 16], pl.FP32, pl.MemorySpace.Vec] = pl.addsc(
+                    addsc_src0, 1.0, addsc_carry
+                )
+                addsc_keep_src0_live: pl.Tile[[8, 16], pl.FP32, pl.MemorySpace.Vec] = pl.add(
+                    addsc_src0, addsc_dst
+                )
+
+                subsc_src0: pl.Tile[[8, 16], pl.FP32, pl.MemorySpace.Vec] = pl.load(b, [0, 0], [8, 16])
+                subsc_carry: pl.Tile[[8, 16], pl.FP32, pl.MemorySpace.Vec] = pl.load(carry, [0, 0], [8, 16])
+                subsc_dst: pl.Tile[[8, 16], pl.FP32, pl.MemorySpace.Vec] = pl.subsc(
+                    subsc_src0, 1.0, subsc_carry
+                )
+                subsc_keep_src0_live: pl.Tile[[8, 16], pl.FP32, pl.MemorySpace.Vec] = pl.add(
+                    subsc_src0, subsc_dst
+                )
+                combined_tile: pl.Tile[[8, 16], pl.FP32, pl.MemorySpace.Vec] = pl.add(
+                    addc_keep_sources_live, subc_keep_sources_live
+                )
+                combined_scalar: pl.Tile[[8, 16], pl.FP32, pl.MemorySpace.Vec] = pl.add(
+                    addsc_keep_src0_live, subsc_keep_src0_live
+                )
+                combined: pl.Tile[[8, 16], pl.FP32, pl.MemorySpace.Vec] = pl.add(
+                    combined_tile, combined_scalar
+                )
+                result: pl.Tensor[[8, 16], pl.FP32] = pl.store(combined, [0, 0], out)
+                return result
+
+        after = _run_pipeline(Before)
+        bases = _collect_tile_memref_bases(after)
+        for op_name in ("addc", "subc", "addsc", "subsc"):
+            dst = f"{op_name}_dst"
+            carry = f"{op_name}_carry"
+            assert dst in bases and carry in bases, f"missing {op_name} tile vars; got {bases}"
+            assert bases[dst] != bases[carry], (
+                f"tile.{op_name} output must not alias carry, but both bind to {bases[dst]}"
+            )
 
     def test_ci_output_does_not_alias_compiler_scratch(self):
         """With #2523 level3 ci scratch disabled, tile.ci stays 2-arg (no compiler tmp)."""


### PR DESCRIPTION
## Summary

This PR completes the B06 carry-op validation scope from #2166 for:

- `tile.addc(src0, src1, carry)` -> `src0 + src1 + carry`
- `tile.subc(src0, src1, carry)` -> `src0 - src1 + carry`
- `tile.addsc(src0, scalar, carry)` -> `src0 + scalar + carry`
- `tile.subsc(src0, scalar, carry)` -> `src0 - scalar + carry`

It aligns the C++ IR contracts, Python IR/DSL APIs, Torch debug backend, PTOAS codegen, MemoryReuse behavior, tests, and EN/ZH documentation with the current PTO-ISA semantics.

## Key changes

- enforce the supported `INT16`, `INT32`, `FP16`, and `FP32` dtype union and exact shape/valid-shape agreement
- emit the four canonical PTOAS operations with the correct operand order and row-major layout
- fix Torch debug `subc`/`subsc` semantics from `- carry` to `+ carry`, with executable regressions for all four operations
- allow legal `dst == src0` reuse for the carry family
- forbid `TADDSC`/`TSUBSC` output from reusing the still-live carry tile, matching their `TADDS/TSUBS + TADD` execution sequence
- verify forced non-alias execution by consuming and storing `src0` after the carry operation
- synchronize the English and Chinese status matrices and codegen documentation

## Test coverage

The A2/A3 same-name hardware matrix contains **128 cases**:

- 4 operations x 4 dtypes x 4 valid shapes x alias/non-alias
- valid shapes: full, row-tail, column-tail, and combined-tail
- integer overflow/borrow boundaries and carry values 0/1
- legal result/src0 reuse and forced non-alias/source-preservation paths

Results:

- **112 cases pass on A2/A3 hardware**
- **16 `TADDSC`/`TSUBSC` full-column row-tail cases are strict A2/A3 XFAILs** because PTO ISA v0.57's fast path reproducibly computes incorrect results across all four dtypes and both reuse modes
- the expectation is strict, so a future ISA fix becomes XPASS and fails CI until the marker is removed

A5 carry-specific hardware validation remains pending; A5 simulator and onboard regression jobs pass.

## Validation

- full CI: passed ([run 33380203534](https://github.com/hw-native-sys/pypto/actions/runs/33380203534))
- Docs: passed ([run 33380203519](https://github.com/hw-native-sys/pypto/actions/runs/33380203519))
- pre-commit: passed, including Ruff, Pyright, documentation parity, and repository policy checks
- clang-tidy, unit tests, codegen tests, system tests, distributed tests, examples, model tests, A5 simulator, and A5 onboard checks: passed
- final complete-diff review: passed