### PR TITLE
feat(codegen): validate shift op family

### DIFF
--- a/docs/en/dev/codegen/00-pto_codegen.md
+++ b/docs/en/dev/codegen/00-pto_codegen.md
@@ -146,6 +146,14 @@ print(pto_code)
 | `tile.shr(src, shift)` / `tile.shrs(src, scalar)` | `pto.tshr` / `pto.tshrs` |
 | `tile.fillpad_expand(src, shape)` | `pto.tfillpad_expand ins(%src) outs(%dst)` (the `shape` tuple is type-deduction only; the larger `dst` and its pad come from the result type) |
 
+Shift tiles use row-major layout and signed/unsigned 8-, 16-, or 32-bit
+elements. Tile-tile forms require equal element types and valid shapes. Scalar
+forms encode the count as a signless (PyPTO signed) integer with the same width
+as the tile; constants must be in `[0, width - 1]`. A2/A3 scalar shifts support
+16- and 32-bit elements, while 8-bit scalar shifts are A5-only. The pinned
+A2/A3 pto-isa currently has a `TShiftCheck` row/column comparison typo that
+blocks non-square valid regions for `TSHLS` and `TSHRS`.
+
 **`tile.slice` / `tile.assemble` lowering details.**  Both ops are lowered
 through `pto.subview`, which is a pure view alias of the source tile (no
 data movement, no extra `pto.alloc_tile`).  `pto.subview` requires the

--- a/docs/en/dev/codegen/00-pto_codegen.md
+++ b/docs/en/dev/codegen/00-pto_codegen.md
@@ -142,6 +142,8 @@ print(pto_code)
 | `tile.mul(lhs, rhs)` | `pto.tmul` |
 | `tile.add(a, b, c)` | `pto.taddc` (3-operand add) |
 | `tile.adds(tile, scalar)` | `pto.tadds` (tile + scalar) |
+| `tile.shl(src, shift)` / `tile.shls(src, scalar)` | `pto.tshl` / `pto.tshls` |
+| `tile.shr(src, shift)` / `tile.shrs(src, scalar)` | `pto.tshr` / `pto.tshrs` |
 | `tile.fillpad_expand(src, shape)` | `pto.tfillpad_expand ins(%src) outs(%dst)` (the `shape` tuple is type-deduction only; the larger `dst` and its pad come from the result type) |
 
 **`tile.slice` / `tile.assemble` lowering details.**  Both ops are lowered

--- a/docs/en/dev/ptoas-op-status.md
+++ b/docs/en/dev/ptoas-op-status.md
@@ -170,14 +170,14 @@ for lowering/compiler plumbing, plus other dialects such as VPTO, VMI, and SIMT.
 | pto.tand | TAND | tile | ✅ | ✅ | ❌ | ❌ | — | path exists; historical ISA/semantic issue requires revalidation against the current pin |
 | pto.tor | TOR | tile | ✅ | ✅ | ❌ | ❌ | — | path exists; historical ISA/semantic issue requires revalidation against the current pin |
 | pto.txor | TXOR | tile | ✅ | ✅ | ❌ | ❌ | — | path exists; historical ISA/semantic issue requires revalidation against the current pin |
-| pto.tshl | TSHL | tile | ✅ | ✅ | ❌ | ✅ | — | verified on A2/A3 hardware for signed/unsigned 16-bit counts including 0 and width-1; A5 hardware verification pending |
-| pto.tshr | TSHR | tile | ✅ | ✅ | ❌ | ✅ | — | verified on A2/A3 hardware for signed/unsigned 16-bit counts including 0 and width-1; A5 hardware verification pending |
+| pto.tshl | TSHL | tile | ✅ | ✅ | ❌ | ✅ | — | A2/A3 hardware evidence covers signed/unsigned 16-bit counts; active cases cover all signed/unsigned 8/16/32-bit widths, count boundaries, and full/row/column/combined valid shapes on A2/A3 and A5, with expanded hardware execution pending |
+| pto.tshr | TSHR | tile | ✅ | ✅ | ❌ | ✅ | — | A2/A3 hardware evidence covers signed arithmetic and unsigned logical 16-bit shifts; active cases cover all signed/unsigned 8/16/32-bit widths, count boundaries, and full/row/column/combined valid shapes on A2/A3 and A5, with expanded hardware execution pending |
 | pto.tnot | TNOT | tile | ✅ | ✅ | ❌ | ✅ | — |  |
 | pto.tands | TANDS | tile | ✅ | ✅ | ❌ | ❌ | — | path exists; historical ISA/semantic issue requires revalidation against the current pin |
 | pto.tors | TORS | tile | ✅ | ✅ | ❌ | ❌ | — | path exists; historical ISA/semantic issue requires revalidation against the current pin |
 | pto.txors | TXORS | tile | ✅ | ✅ | ❌ | ❌ | — | path exists; historical ISA/semantic issue requires revalidation against the current pin |
-| pto.tshls | TSHLS | tile | ✅ | ✅ | ❌ | ✅ | — | verified on A2/A3 hardware for signed 16-bit scalar counts 0 and width-1; explicit unsigned PTOAS scalar types remain unsupported |
-| pto.tshrs | TSHRS | tile | ✅ | ✅ | ❌ | ✅ | — | verified on A2/A3 hardware for signed 16-bit scalar counts 0 and width-1; explicit unsigned PTOAS scalar types remain unsupported |
+| pto.tshls | TSHLS | tile | ✅ | ✅ | ❌ | ❌ | — | active A5 cases cover signed/unsigned 8/16/32-bit tiles, scalar boundaries, and all valid-shape modes; A2/A3 supports 16/32-bit tiles but pinned pto-isa `TShiftCheck` compares dst valid rows with src valid columns, so only square-valid cases are executable until upstream is fixed |
+| pto.tshrs | TSHRS | tile | ✅ | ✅ | ❌ | ❌ | — | active A5 cases cover signed/unsigned 8/16/32-bit tiles, scalar boundaries, and all valid-shape modes; A2/A3 supports 16/32-bit tiles but pinned pto-isa `TShiftCheck` compares dst valid rows with src valid columns, so only square-valid cases are executable until upstream is fixed |
 | **Data Rearrangement (15)** |  |  |  |  |  |  |  |  |
 | pto.tconcat | TCONCAT | tile+tensor | ✅ | ✅ | ✅ | ✅ | — |  |
 | pto.tconcatidx | TCONCAT (indexed) | tile | ✅ | ❌ | ❌ | ❌ | — | MISSING: lacks a complete frontend/codegen/ST path |
@@ -274,5 +274,5 @@ for lowering/compiler plumbing, plus other dialects such as VPTO, VMI, and SIMT.
 | pto.tassign | TASSIGN | internal | ✅ | — | — | — | — | inactive backend hook; no standalone ST |
 
 **Stats**: 204 public/compatibility PTOAS ops; 113 have a pypto tile frontend and 75 have a tensor frontend;
-114 have same-name ST coverage (110 regular STs and 4 distributed STs); 58 lack same-name ST coverage
+112 have same-name ST coverage (108 regular STs and 4 distributed STs); 60 lack same-name ST coverage
 (48 regular and 10 distributed); within these 204, another 32 ops are not suitable for standalone STs.

--- a/docs/en/dev/ptoas-op-status.md
+++ b/docs/en/dev/ptoas-op-status.md
@@ -170,14 +170,14 @@ for lowering/compiler plumbing, plus other dialects such as VPTO, VMI, and SIMT.
 | pto.tand | TAND | tile | ✅ | ✅ | ❌ | ❌ | — | path exists; historical ISA/semantic issue requires revalidation against the current pin |
 | pto.tor | TOR | tile | ✅ | ✅ | ❌ | ❌ | — | path exists; historical ISA/semantic issue requires revalidation against the current pin |
 | pto.txor | TXOR | tile | ✅ | ✅ | ❌ | ❌ | — | path exists; historical ISA/semantic issue requires revalidation against the current pin |
-| pto.tshl | TSHL | tile | ✅ | ✅ | ❌ | ❌ | — | path exists; historical ISA/semantic issue requires revalidation against the current pin |
-| pto.tshr | TSHR | tile | ✅ | ✅ | ❌ | ❌ | — | path exists; historical ISA/semantic issue requires revalidation against the current pin |
+| pto.tshl | TSHL | tile | ✅ | ✅ | ❌ | ✅ | — | verified on A2/A3 hardware for signed/unsigned 16-bit counts including 0 and width-1; A5 hardware verification pending |
+| pto.tshr | TSHR | tile | ✅ | ✅ | ❌ | ✅ | — | verified on A2/A3 hardware for signed/unsigned 16-bit counts including 0 and width-1; A5 hardware verification pending |
 | pto.tnot | TNOT | tile | ✅ | ✅ | ❌ | ✅ | — |  |
 | pto.tands | TANDS | tile | ✅ | ✅ | ❌ | ❌ | — | path exists; historical ISA/semantic issue requires revalidation against the current pin |
 | pto.tors | TORS | tile | ✅ | ✅ | ❌ | ❌ | — | path exists; historical ISA/semantic issue requires revalidation against the current pin |
 | pto.txors | TXORS | tile | ✅ | ✅ | ❌ | ❌ | — | path exists; historical ISA/semantic issue requires revalidation against the current pin |
-| pto.tshls | TSHLS | tile | ✅ | ✅ | ❌ | ❌ | — | path exists; historical ISA/semantic issue requires revalidation against the current pin |
-| pto.tshrs | TSHRS | tile | ✅ | ✅ | ❌ | ❌ | — | path exists; historical ISA/semantic issue requires revalidation against the current pin |
+| pto.tshls | TSHLS | tile | ✅ | ✅ | ❌ | ✅ | — | verified on A2/A3 hardware for signed 16-bit scalar counts 0 and width-1; explicit unsigned PTOAS scalar types remain unsupported |
+| pto.tshrs | TSHRS | tile | ✅ | ✅ | ❌ | ✅ | — | verified on A2/A3 hardware for signed 16-bit scalar counts 0 and width-1; explicit unsigned PTOAS scalar types remain unsupported |
 | **Data Rearrangement (15)** |  |  |  |  |  |  |  |  |
 | pto.tconcat | TCONCAT | tile+tensor | ✅ | ✅ | ✅ | ✅ | — |  |
 | pto.tconcatidx | TCONCAT (indexed) | tile | ✅ | ❌ | ❌ | ❌ | — | MISSING: lacks a complete frontend/codegen/ST path |
@@ -274,5 +274,5 @@ for lowering/compiler plumbing, plus other dialects such as VPTO, VMI, and SIMT.
 | pto.tassign | TASSIGN | internal | ✅ | — | — | — | — | inactive backend hook; no standalone ST |
 
 **Stats**: 204 public/compatibility PTOAS ops; 113 have a pypto tile frontend and 75 have a tensor frontend;
-110 have same-name ST coverage (106 regular STs and 4 distributed STs); 62 lack same-name ST coverage
-(52 regular and 10 distributed); within these 204, another 32 ops are not suitable for standalone STs.
+114 have same-name ST coverage (110 regular STs and 4 distributed STs); 58 lack same-name ST coverage
+(48 regular and 10 distributed); within these 204, another 32 ops are not suitable for standalone STs.

--- a/docs/zh/dev/codegen/00-pto_codegen.md
+++ b/docs/zh/dev/codegen/00-pto_codegen.md
@@ -144,6 +144,13 @@ print(pto_code)
 | `tile.shr(src, shift)` / `tile.shrs(src, scalar)` | `pto.tshr` / `pto.tshrs` |
 | `tile.fillpad_expand(src, shape)` | `pto.tfillpad_expand ins(%src) outs(%dst)`（`shape` 元组仅用于类型推导；更大的 `dst` 及其 pad 来自结果类型） |
 
+移位 tile 使用 row-major 布局及有/无符号 8、16 或 32 位元素。tile-tile
+形式要求元素类型和 valid shape 相同。scalar 形式将 count 编码为与 tile
+等宽的 signless（PyPTO 有符号）整数，常量范围必须为 `[0, width - 1]`。
+A2/A3 的 scalar 移位支持 16 和 32 位元素，8 位 scalar 移位仅 A5 支持。
+当前固定版本的 A2/A3 pto-isa 在 `TShiftCheck` 中存在 row/column 比较笔误，
+因此 `TSHLS` 和 `TSHRS` 的非正方形 valid region 会被阻塞。
+
 **`tile.slice` / `tile.assemble` 下沉细节。** 两个 op 都通过 `pto.subview`
 下沉，它是源 tile 的纯视图别名（不搬数据，也不会额外发 `pto.alloc_tile`）。
 `pto.subview` 要求结果 `tile_buf` 与源 `tile_buf` 在 `dtype`、`memory_space`、

--- a/docs/zh/dev/codegen/00-pto_codegen.md
+++ b/docs/zh/dev/codegen/00-pto_codegen.md
@@ -140,6 +140,8 @@ print(pto_code)
 | `tile.mul(lhs, rhs)` | `pto.tmul` |
 | `tile.add(a, b, c)` | `pto.taddc` (三操作数加法) |
 | `tile.adds(tile, scalar)` | `pto.tadds` (Tile + 标量) |
+| `tile.shl(src, shift)` / `tile.shls(src, scalar)` | `pto.tshl` / `pto.tshls` |
+| `tile.shr(src, shift)` / `tile.shrs(src, scalar)` | `pto.tshr` / `pto.tshrs` |
 | `tile.fillpad_expand(src, shape)` | `pto.tfillpad_expand ins(%src) outs(%dst)`（`shape` 元组仅用于类型推导；更大的 `dst` 及其 pad 来自结果类型） |
 
 **`tile.slice` / `tile.assemble` 下沉细节。** 两个 op 都通过 `pto.subview`

--- a/docs/zh/dev/ptoas-op-status.md
+++ b/docs/zh/dev/ptoas-op-status.md
@@ -156,14 +156,14 @@ lowering/compiler plumbing 使用的额外内部 op 未纳入，也不列 VPTO�
 | pto.tand | TAND | tile | ✅ | ✅ | ❌ | ❌ | — | 已有链路；历史 ISA/语义问题，需按当前 pin 复验 |
 | pto.tor | TOR | tile | ✅ | ✅ | ❌ | ❌ | — | 已有链路；历史 ISA/语义问题，需按当前 pin 复验 |
 | pto.txor | TXOR | tile | ✅ | ✅ | ❌ | ❌ | — | 已有链路；历史 ISA/语义问题，需按当前 pin 复验 |
-| pto.tshl | TSHL | tile | ✅ | ✅ | ❌ | ✅ | — | A2/A3 真机已验证有/无符号 16 位 shift count（含 0 和位宽边界）；A5 真机待验证 |
-| pto.tshr | TSHR | tile | ✅ | ✅ | ❌ | ✅ | — | A2/A3 真机已验证有/无符号 16 位 shift count（含 0 和位宽边界）；A5 真机待验证 |
+| pto.tshl | TSHL | tile | ✅ | ✅ | ❌ | ✅ | — | A2/A3 真机证据已覆盖有/无符号 16 位 count；现有用例覆盖 A2/A3 与 A5 的全部有/无符号 8/16/32 位类型、count 边界及 full/row/column/combined valid shape，扩展真机执行待完成 |
+| pto.tshr | TSHR | tile | ✅ | ✅ | ❌ | ✅ | — | A2/A3 真机证据已覆盖有符号算术右移和无符号逻辑右移的 16 位类型；现有用例覆盖 A2/A3 与 A5 的全部有/无符号 8/16/32 位类型、count 边界及 full/row/column/combined valid shape，扩展真机执行待完成 |
 | pto.tnot | TNOT | tile | ✅ | ✅ | ❌ | ✅ | — |  |
 | pto.tands | TANDS | tile | ✅ | ✅ | ❌ | ❌ | — | 已有链路；历史 ISA/语义问题，需按当前 pin 复验 |
 | pto.tors | TORS | tile | ✅ | ✅ | ❌ | ❌ | — | 已有链路；历史 ISA/语义问题，需按当前 pin 复验 |
 | pto.txors | TXORS | tile | ✅ | ✅ | ❌ | ❌ | — | 已有链路；历史 ISA/语义问题，需按当前 pin 复验 |
-| pto.tshls | TSHLS | tile | ✅ | ✅ | ❌ | ✅ | — | A2/A3 真机已验证有符号 16 位 scalar shift count（0 和位宽边界）；PTOAS 暂不支持显式无符号 scalar 类型 |
-| pto.tshrs | TSHRS | tile | ✅ | ✅ | ❌ | ✅ | — | A2/A3 真机已验证有符号 16 位 scalar shift count（0 和位宽边界）；PTOAS 暂不支持显式无符号 scalar 类型 |
+| pto.tshls | TSHLS | tile | ✅ | ✅ | ❌ | ❌ | — | A5 用例覆盖有/无符号 8/16/32 位 tile、scalar 边界和全部 valid-shape 模式；A2/A3 支持 16/32 位 tile，但固定版本 pto-isa 的 `TShiftCheck` 错将 dst valid rows 与 src valid columns 比较，上游修复前仅正方形 valid region 可执行 |
+| pto.tshrs | TSHRS | tile | ✅ | ✅ | ❌ | ❌ | — | A5 用例覆盖有/无符号 8/16/32 位 tile、scalar 边界和全部 valid-shape 模式；A2/A3 支持 16/32 位 tile，但固定版本 pto-isa 的 `TShiftCheck` 错将 dst valid rows 与 src valid columns 比较，上游修复前仅正方形 valid region 可执行 |
 | **数据重排（15）** |  |  |  |  |  |  |  |  |
 | pto.tconcat | TCONCAT | tile+tensor | ✅ | ✅ | ✅ | ✅ | — |  |
 | pto.tconcatidx | TCONCAT (indexed) | tile | ✅ | ❌ | ❌ | ❌ | — | MISSING：缺完整前端/codegen/ST 链路 |
@@ -260,5 +260,5 @@ lowering/compiler plumbing 使用的额外内部 op 未纳入，也不列 VPTO�
 | pto.tassign | TASSIGN | internal | ✅ | — | — | — | — | 失活 backend hook，不独立建 ST |
 
 **统计**：共 204 个 PTOAS 公共/兼容 op；pypto tile 前端 113 个，tensor 前端 75 个；
-同名 ST 覆盖 114 个（普通 ST 110，distributed ST 4）；无同名 ST 58 个
+同名 ST 覆盖 112 个（普通 ST 108，distributed ST 4）；无同名 ST 60 个
 （普通 48，distributed 10）；这 204 个中另有 32 个 op 不适合独立 ST。

--- a/docs/zh/dev/ptoas-op-status.md
+++ b/docs/zh/dev/ptoas-op-status.md
@@ -156,14 +156,14 @@ lowering/compiler plumbing 使用的额外内部 op 未纳入，也不列 VPTO�
 | pto.tand | TAND | tile | ✅ | ✅ | ❌ | ❌ | — | 已有链路；历史 ISA/语义问题，需按当前 pin 复验 |
 | pto.tor | TOR | tile | ✅ | ✅ | ❌ | ❌ | — | 已有链路；历史 ISA/语义问题，需按当前 pin 复验 |
 | pto.txor | TXOR | tile | ✅ | ✅ | ❌ | ❌ | — | 已有链路；历史 ISA/语义问题，需按当前 pin 复验 |
-| pto.tshl | TSHL | tile | ✅ | ✅ | ❌ | ❌ | — | 已有链路；历史 ISA/语义问题，需按当前 pin 复验 |
-| pto.tshr | TSHR | tile | ✅ | ✅ | ❌ | ❌ | — | 已有链路；历史 ISA/语义问题，需按当前 pin 复验 |
+| pto.tshl | TSHL | tile | ✅ | ✅ | ❌ | ✅ | — | A2/A3 真机已验证有/无符号 16 位 shift count（含 0 和位宽边界）；A5 真机待验证 |
+| pto.tshr | TSHR | tile | ✅ | ✅ | ❌ | ✅ | — | A2/A3 真机已验证有/无符号 16 位 shift count（含 0 和位宽边界）；A5 真机待验证 |
 | pto.tnot | TNOT | tile | ✅ | ✅ | ❌ | ✅ | — |  |
 | pto.tands | TANDS | tile | ✅ | ✅ | ❌ | ❌ | — | 已有链路；历史 ISA/语义问题，需按当前 pin 复验 |
 | pto.tors | TORS | tile | ✅ | ✅ | ❌ | ❌ | — | 已有链路；历史 ISA/语义问题，需按当前 pin 复验 |
 | pto.txors | TXORS | tile | ✅ | ✅ | ❌ | ❌ | — | 已有链路；历史 ISA/语义问题，需按当前 pin 复验 |
-| pto.tshls | TSHLS | tile | ✅ | ✅ | ❌ | ❌ | — | 已有链路；历史 ISA/语义问题，需按当前 pin 复验 |
-| pto.tshrs | TSHRS | tile | ✅ | ✅ | ❌ | ❌ | — | 已有链路；历史 ISA/语义问题，需按当前 pin 复验 |
+| pto.tshls | TSHLS | tile | ✅ | ✅ | ❌ | ✅ | — | A2/A3 真机已验证有符号 16 位 scalar shift count（0 和位宽边界）；PTOAS 暂不支持显式无符号 scalar 类型 |
+| pto.tshrs | TSHRS | tile | ✅ | ✅ | ❌ | ✅ | — | A2/A3 真机已验证有符号 16 位 scalar shift count（0 和位宽边界）；PTOAS 暂不支持显式无符号 scalar 类型 |
 | **数据重排（15）** |  |  |  |  |  |  |  |  |
 | pto.tconcat | TCONCAT | tile+tensor | ✅ | ✅ | ✅ | ✅ | — |  |
 | pto.tconcatidx | TCONCAT (indexed) | tile | ✅ | ❌ | ❌ | ❌ | — | MISSING：缺完整前端/codegen/ST 链路 |
@@ -260,5 +260,5 @@ lowering/compiler plumbing 使用的额外内部 op 未纳入，也不列 VPTO�
 | pto.tassign | TASSIGN | internal | ✅ | — | — | — | — | 失活 backend hook，不独立建 ST |
 
 **统计**：共 204 个 PTOAS 公共/兼容 op；pypto tile 前端 113 个，tensor 前端 75 个；
-同名 ST 覆盖 110 个（普通 ST 106，distributed ST 4）；无同名 ST 62 个
-（普通 52，distributed 10）；这 204 个中另有 32 个 op 不适合独立 ST。
+同名 ST 覆盖 114 个（普通 ST 110，distributed ST 4）；无同名 ST 58 个
+（普通 48，distributed 10）；这 204 个中另有 32 个 op 不适合独立 ST。

--- a/python/pypto/ir/op/tile_ops.py
+++ b/python/pypto/ir/op/tile_ops.py
@@ -989,27 +989,48 @@ def shl(lhs: Expr, rhs: Expr, span: Span | None = None) -> Call:
     return _ir_core.create_op_call("tile.shl", [lhs, rhs], {}, actual_span)
 
 
+_SHIFT_SCALAR_DTYPE = {
+    DataType.INT8: DataType.INT8,
+    DataType.UINT8: DataType.INT8,
+    DataType.INT16: DataType.INT16,
+    DataType.UINT16: DataType.INT16,
+    DataType.INT32: DataType.INT32,
+    DataType.UINT32: DataType.INT32,
+}
+
+
+def _normalize_shift_scalar_operand(lhs: Expr, rhs: int | Expr, span: Span) -> Expr:
+    """Normalize an untyped shift count to PTOAS's signless same-width scalar."""
+    lhs_type = lhs.type
+    if isinstance(lhs_type, _ir_core.TileType):
+        scalar_dtype = _SHIFT_SCALAR_DTYPE.get(lhs_type.dtype)
+        if scalar_dtype is not None:
+            return _normalize_const_to_dtype(rhs, scalar_dtype, span)
+    return _normalize_scalar_operand(lhs, rhs, span)
+
+
 def shls(lhs: Expr, rhs: int | Expr, span: Span | None = None) -> Call:
     """Element-wise bitwise left shift of tile and scalar.
 
     Computes lhs << rhs element-wise. Maps to the TSHLS hardware intrinsic.
 
     Note:
-        The scalar shift amount must be zero or positive; negative values are
-        not supported by the hardware and will be rejected by codegen.
+        A constant shift amount must be in ``[0, bit_width - 1]``. PTOAS uses a
+        signless scalar count, so literals paired with unsigned tiles use the
+        signed integer dtype of the same width.
 
     Args:
         lhs: Tile (TileType)
-        rhs: Scalar shift amount; must be >= 0. A constant literal is re-stamped
-            to the lhs element dtype (the IR permits any integer width -- codegen
-            casts the shift count to i32); a typed Expr is used as-is
+        rhs: Scalar shift amount. A constant literal is re-stamped to the signed
+            integer dtype with the same width as the lhs; a typed Expr is used
+            as-is
         span: Optional source span for debugging (auto-captured if not provided)
 
     Returns:
         Call expression for element-wise bitwise left shift with scalar
     """
     actual_span = _get_span_or_capture(span)
-    rhs_expr = _normalize_scalar_operand(lhs, rhs, actual_span)
+    rhs_expr = _normalize_shift_scalar_operand(lhs, rhs, actual_span)
     return _ir_core.create_op_call("tile.shls", [lhs, rhs_expr], {}, actual_span)
 
 
@@ -1036,21 +1057,22 @@ def shrs(lhs: Expr, rhs: int | Expr, span: Span | None = None) -> Call:
     Computes lhs >> rhs element-wise. Maps to the TSHRS hardware intrinsic.
 
     Note:
-        The scalar shift amount must be zero or positive; negative values are
-        not supported by the hardware and will be rejected by codegen.
+        A constant shift amount must be in ``[0, bit_width - 1]``. PTOAS uses a
+        signless scalar count, so literals paired with unsigned tiles use the
+        signed integer dtype of the same width.
 
     Args:
         lhs: Tile (TileType)
-        rhs: Scalar shift amount; must be >= 0. A constant literal is re-stamped
-            to the lhs element dtype (the IR permits any integer width -- codegen
-            casts the shift count to i32); a typed Expr is used as-is
+        rhs: Scalar shift amount. A constant literal is re-stamped to the signed
+            integer dtype with the same width as the lhs; a typed Expr is used
+            as-is
         span: Optional source span for debugging (auto-captured if not provided)
 
     Returns:
         Call expression for element-wise bitwise right shift with scalar
     """
     actual_span = _get_span_or_capture(span)
-    rhs_expr = _normalize_scalar_operand(lhs, rhs, actual_span)
+    rhs_expr = _normalize_shift_scalar_operand(lhs, rhs, actual_span)
     return _ir_core.create_op_call("tile.shrs", [lhs, rhs_expr], {}, actual_span)
 
 

--- a/python/pypto/language/op/tile_ops.py
+++ b/python/pypto/language/op/tile_ops.py
@@ -2197,12 +2197,11 @@ def shls(lhs: Tile, rhs: int | Expr | Scalar) -> Tile:
     Computes lhs << rhs element-wise. Maps to the TSHLS hardware intrinsic.
 
     Note:
-        The scalar shift amount must be zero or positive; negative values are
-        not supported by the hardware and will be rejected by codegen.
+        A constant shift amount must be in ``[0, bit_width - 1]``.
 
     Args:
         lhs: Tile
-        rhs: Scalar shift amount; must be >= 0
+        rhs: Scalar shift amount
 
     Returns:
         Tile wrapping the shls operation
@@ -2234,12 +2233,11 @@ def shrs(lhs: Tile, rhs: int | Expr | Scalar) -> Tile:
     Computes lhs >> rhs element-wise. Maps to the TSHRS hardware intrinsic.
 
     Note:
-        The scalar shift amount must be zero or positive; negative values are
-        not supported by the hardware and will be rejected by codegen.
+        A constant shift amount must be in ``[0, bit_width - 1]``.
 
     Args:
         lhs: Tile
-        rhs: Scalar shift amount; must be >= 0
+        rhs: Scalar shift amount
 
     Returns:
         Tile wrapping the shrs operation

--- a/src/backend/common/pto_ops_elementwise.cpp
+++ b/src/backend/common/pto_ops_elementwise.cpp
@@ -88,6 +88,8 @@ static bool RequiresRowMajorLayout(std::string_view op_name) {
       "tile.fmods",
       "tile.maximums",
       "tile.lrelu",
+      "tile.shls",
+      "tile.shrs",
       // Ternary scalar ops (Tile x Scalar x Tile)
       "tile.addsc",
       "tile.subsc",

--- a/src/ir/op/tile_ops/elementwise.cpp
+++ b/src/ir/op/tile_ops/elementwise.cpp
@@ -73,6 +73,17 @@ static bool IsTSubsDataType(DataType dtype) {
          dtype == DataType::FP16 || dtype == DataType::FP32 || dtype == DataType::BF16;
 }
 
+static bool IsShiftDataType(DataType dtype) {
+  return dtype == DataType::INT8 || dtype == DataType::UINT8 || dtype == DataType::INT16 ||
+         dtype == DataType::UINT16 || dtype == DataType::INT32 || dtype == DataType::UINT32;
+}
+
+static bool IsShiftScalarDataType(DataType dtype) {
+  // PTOAS models scalar shift counts as signless integers. Explicit PyPTO
+  // unsigned scalar types lower to ui8/ui16/ui32 and are rejected by PTOAS.
+  return dtype == DataType::INT8 || dtype == DataType::INT16 || dtype == DataType::INT32;
+}
+
 static std::shared_ptr<TileType> MakePackedPredicateTileType(
     const std::vector<ExprPtr>& logical_shape, const std::shared_ptr<const TileType>& source_tile_type) {
   INTERNAL_CHECK(!logical_shape.empty())
@@ -187,35 +198,65 @@ TypePtr DeduceTileOpElementwiseBinaryType(const std::vector<ExprPtr>& args,
   return std::make_shared<TileType>(broadcast_result.shape, *result_dtype, std::nullopt, tile_view);
 }
 
-// Tile-tile shift ops (shl, shr): RHS is the shift amount, result type equals LHS tile type,
-// consistent with scalar variants (shls/shrs) which preserve the LHS tile dtype.
 TypePtr DeduceTileOpShiftBinaryType(const std::vector<ExprPtr>& args,
                                     const std::vector<std::pair<std::string, std::any>>& kwargs,
                                     const std::string& op_name) {
   CHECK(args.size() == 2) << "The operator " << op_name << " requires exactly 2 arguments, but got "
                           << args.size();
 
-  auto tile_type1 = As<TileType>(args[0]->GetType());
-  auto tile_type2 = As<TileType>(args[1]->GetType());
-  CHECK(tile_type1) << "The operator " << op_name << " requires first argument to be a TileType, but got "
-                    << args[0]->GetType()->TypeName();
-  CHECK(tile_type2) << "The operator " << op_name << " requires second argument to be a TileType, but got "
-                    << args[1]->GetType()->TypeName();
-  CHECK(tile_type1->dtype_.IsInt()) << "The operator " << op_name << " requires integer tile dtype, but got "
-                                    << tile_type1->dtype_.ToString();
-  CHECK(tile_type2->dtype_.IsInt()) << "The operator " << op_name
-                                    << " requires integer shift tile dtype, but got "
-                                    << tile_type2->dtype_.ToString();
+  auto src = As<TileType>(args[0]->GetType());
+  auto shift = As<TileType>(args[1]->GetType());
+  CHECK(src) << "The operator " << op_name << " requires first argument to be a TileType, but got "
+             << args[0]->GetType()->TypeName();
+  CHECK(shift) << "The operator " << op_name << " requires second argument to be a TileType, but got "
+               << args[1]->GetType()->TypeName();
+  CHECK(IsShiftDataType(src->dtype_))
+      << "The operator " << op_name
+      << " requires dtype in {INT8, UINT8, INT16, UINT16, INT32, UINT32}, but got " << src->dtype_.ToString();
+  CHECK(shift->dtype_ == src->dtype_)
+      << "The operator " << op_name << " requires src, shift, and dst to have the same dtype, but shift has "
+      << shift->dtype_.ToString() << " and src has " << src->dtype_.ToString();
 
-  auto broadcast_result = BroadcastShapes(tile_type1->shape_, tile_type2->shape_);
-  CHECK(broadcast_result.success) << "The operator " << op_name << " requires compatible shapes";
+  const auto src_valid_shape = GetValidShape(src);
+  const auto shift_valid_shape = GetValidShape(shift);
+  CHECK(shift_valid_shape.size() == src_valid_shape.size())
+      << "The operator " << op_name << " requires src, shift, and dst to have the same valid_shape rank";
+  for (size_t i = 0; i < src_valid_shape.size(); ++i) {
+    CHECK(ProveValidExtentEqual(src_valid_shape[i], shift_valid_shape[i]) == ProofResult::kTrue)
+        << "The operator " << op_name
+        << " requires src, shift, and dst to have the same valid_shape, but shift differs at dimension " << i;
+  }
 
-  // TODO(YunjiQin): assumes both src tiles have the same valid_shape; may need refinement
-  // for cases where lhs and rhs have different valid_shapes (e.g. after broadcasting).
   TileView tile_view;
-  tile_view.valid_shape = GetValidShape(tile_type1);
-  InheritTileViewLayout(tile_view, tile_type1);
-  return std::make_shared<TileType>(broadcast_result.shape, tile_type1->dtype_, std::nullopt, tile_view);
+  tile_view.valid_shape = src_valid_shape;
+  InheritTileViewLayout(tile_view, src);
+  return std::make_shared<TileType>(src->shape_, src->dtype_, std::nullopt, tile_view);
+}
+
+TypePtr DeduceTileOpShiftScalarType(const std::vector<ExprPtr>& args,
+                                    const std::vector<std::pair<std::string, std::any>>& kwargs,
+                                    const std::string& op_name) {
+  CHECK(args.size() == 2) << "The operator " << op_name << " requires exactly 2 arguments, but got "
+                          << args.size();
+
+  auto src = As<TileType>(args[0]->GetType());
+  auto shift = As<ScalarType>(args[1]->GetType());
+  CHECK(src) << "The operator " << op_name << " requires first argument to be a TileType, but got "
+             << args[0]->GetType()->TypeName();
+  CHECK(shift) << "The operator " << op_name << " requires second argument to be a ScalarType, but got "
+               << args[1]->GetType()->TypeName();
+  CHECK(IsShiftScalarDataType(src->dtype_))
+      << "The operator " << op_name << " requires tile/scalar dtype in {INT8, INT16, INT32}, but got "
+      << src->dtype_.ToString();
+  CHECK(shift->dtype_ == src->dtype_)
+      << "The operator " << op_name
+      << " requires src, scalar, and dst to have the same dtype, but scalar has " << shift->dtype_.ToString()
+      << " and src has " << src->dtype_.ToString();
+
+  TileView tile_view;
+  tile_view.valid_shape = GetValidShape(src);
+  InheritTileViewLayout(tile_view, src);
+  return std::make_shared<TileType>(src->shape_, src->dtype_, std::nullopt, tile_view);
 }
 
 TypePtr DeduceTileOpScalarBinaryType(const std::vector<ExprPtr>& args,
@@ -545,7 +586,7 @@ REGISTER_OP("tile.fmods")
 
 REGISTER_OP("tile.shl")
     .set_op_category("TileOp")
-    .set_description("Element-wise bitwise left shift of two tiles with broadcasting")
+    .set_description("Element-wise bitwise left shift using a same-dtype shift-count tile")
     .add_argument("lhs", "Left-hand side tile (TileType)")
     .add_argument("rhs", "Right-hand side tile (TileType)")
     .set_input_memory(0, MemorySpace::Vec)
@@ -565,12 +606,12 @@ REGISTER_OP("tile.shls")
     .set_output_memory(MemorySpace::Vec)
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
-      return DeduceTileOpIntScalarBinaryType(args, kwargs, "tile.shls");
+      return DeduceTileOpShiftScalarType(args, kwargs, "tile.shls");
     });
 
 REGISTER_OP("tile.shr")
     .set_op_category("TileOp")
-    .set_description("Element-wise bitwise right shift of two tiles with broadcasting")
+    .set_description("Element-wise bitwise right shift using a same-dtype shift-count tile")
     .add_argument("lhs", "Left-hand side tile (TileType)")
     .add_argument("rhs", "Right-hand side tile (TileType)")
     .set_input_memory(0, MemorySpace::Vec)
@@ -590,7 +631,7 @@ REGISTER_OP("tile.shrs")
     .set_output_memory(MemorySpace::Vec)
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
-      return DeduceTileOpIntScalarBinaryType(args, kwargs, "tile.shrs");
+      return DeduceTileOpShiftScalarType(args, kwargs, "tile.shrs");
     });
 
 REGISTER_OP("tile.maximums")

--- a/src/ir/op/tile_ops/elementwise.cpp
+++ b/src/ir/op/tile_ops/elementwise.cpp
@@ -78,12 +78,6 @@ static bool IsShiftDataType(DataType dtype) {
          dtype == DataType::UINT16 || dtype == DataType::INT32 || dtype == DataType::UINT32;
 }
 
-static bool IsShiftScalarDataType(DataType dtype) {
-  // PTOAS models scalar shift counts as signless integers. Explicit PyPTO
-  // unsigned scalar types lower to ui8/ui16/ui32 and are rejected by PTOAS.
-  return dtype == DataType::INT8 || dtype == DataType::INT16 || dtype == DataType::INT32;
-}
-
 static std::shared_ptr<TileType> MakePackedPredicateTileType(
     const std::vector<ExprPtr>& logical_shape, const std::shared_ptr<const TileType>& source_tile_type) {
   INTERNAL_CHECK(!logical_shape.empty())
@@ -245,13 +239,20 @@ TypePtr DeduceTileOpShiftScalarType(const std::vector<ExprPtr>& args,
              << args[0]->GetType()->TypeName();
   CHECK(shift) << "The operator " << op_name << " requires second argument to be a ScalarType, but got "
                << args[1]->GetType()->TypeName();
-  CHECK(IsShiftScalarDataType(src->dtype_))
-      << "The operator " << op_name << " requires tile/scalar dtype in {INT8, INT16, INT32}, but got "
-      << src->dtype_.ToString();
-  CHECK(shift->dtype_ == src->dtype_)
+  CHECK(IsShiftDataType(src->dtype_))
       << "The operator " << op_name
-      << " requires src, scalar, and dst to have the same dtype, but scalar has " << shift->dtype_.ToString()
-      << " and src has " << src->dtype_.ToString();
+      << " requires tile dtype in {INT8, UINT8, INT16, UINT16, INT32, UINT32}, but got "
+      << src->dtype_.ToString();
+  CHECK(shift->dtype_.IsSignedInt() && shift->dtype_.GetBit() == src->dtype_.GetBit())
+      << "The operator " << op_name
+      << " requires a signless scalar shift count with the same bit width as src, but scalar has "
+      << shift->dtype_.ToString() << " and src has " << src->dtype_.ToString();
+  if (auto constant = As<ConstInt>(args[1])) {
+    const int64_t shift_value = constant->value_;
+    CHECK(shift_value >= 0 && static_cast<uint64_t>(shift_value) < src->dtype_.GetBit())
+        << "The operator " << op_name << " requires a constant shift count in [0, "
+        << (src->dtype_.GetBit() - 1) << "], but got " << shift_value;
+  }
 
   TileView tile_view;
   tile_view.valid_shape = GetValidShape(src);

--- a/tests/st/runtime/ops/test_shift.py
+++ b/tests/st/runtime/ops/test_shift.py
@@ -1,0 +1,236 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Exact-op system tests for the tile shift families."""
+
+from typing import Any
+
+import pypto.language as pl
+import pytest
+import torch
+from harness.core.harness import DataType, PTOTestCase, TensorSpec
+
+M = 16
+N = 64
+VALID_SHAPE = (11, 47)
+
+_PL_DT = {
+    DataType.INT16: pl.INT16,
+    DataType.UINT16: pl.UINT16,
+}
+
+_WIDTH = {
+    DataType.INT16: 16,
+    DataType.UINT16: 16,
+}
+
+
+def _values(dtype: DataType) -> torch.Tensor:
+    width = _WIDTH[dtype]
+    if dtype == DataType.INT16:
+        values = [-32768, -17, -1, 0, 1, 17, 16383]
+    else:
+        values = [0, 1, 17, (1 << (width - 1)), (1 << width) - 1]
+    index = torch.arange(M * N, dtype=torch.int64).reshape(M, N).remainder(len(values))
+    result = torch.zeros((M, N), dtype=torch.int64)
+    for i, value in enumerate(values):
+        result[index == i] = value
+    return result.to(dtype.torch_dtype).contiguous()
+
+
+def _shift_counts(dtype: DataType) -> torch.Tensor:
+    width = _WIDTH[dtype]
+    values = [0, 1, width - 1]
+    index = torch.arange(M * N, dtype=torch.int64).reshape(M, N).remainder(len(values))
+    result = torch.zeros((M, N), dtype=torch.int64)
+    for i, value in enumerate(values):
+        result[index == i] = value
+    return result.to(dtype.torch_dtype).contiguous()
+
+
+def _make_program(op_name: str, dtype: DataType, scalar: int | None):
+    pl_dtype = _PL_DT[dtype]
+    valid = list(VALID_SHAPE)
+
+    if op_name == "shl":
+
+        @pl.program
+        class ShlProgram:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                src: pl.Tensor[[M, N], pl_dtype],
+                shift: pl.Tensor[[M, N], pl_dtype],
+                out: pl.InOut[pl.Tensor[[M, N], pl_dtype]],
+            ) -> pl.Tensor[[M, N], pl_dtype]:
+                src_tile = pl.load(src, [0, 0], [M, N], valid_shapes=valid)
+                shift_tile = pl.load(shift, [0, 0], [M, N], valid_shapes=valid)
+                return pl.store(pl.tile.shl(src_tile, shift_tile), [0, 0], out)
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orchestrator(
+                self,
+                src: pl.Tensor[[M, N], pl_dtype],
+                shift: pl.Tensor[[M, N], pl_dtype],
+                out: pl.InOut[pl.Tensor[[M, N], pl_dtype]],
+            ) -> pl.Tensor[[M, N], pl_dtype]:
+                return self.kernel(src, shift, out)
+
+        return ShlProgram
+
+    if op_name == "shr":
+
+        @pl.program
+        class ShrProgram:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                src: pl.Tensor[[M, N], pl_dtype],
+                shift: pl.Tensor[[M, N], pl_dtype],
+                out: pl.InOut[pl.Tensor[[M, N], pl_dtype]],
+            ) -> pl.Tensor[[M, N], pl_dtype]:
+                src_tile = pl.load(src, [0, 0], [M, N], valid_shapes=valid)
+                shift_tile = pl.load(shift, [0, 0], [M, N], valid_shapes=valid)
+                return pl.store(pl.tile.shr(src_tile, shift_tile), [0, 0], out)
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orchestrator(
+                self,
+                src: pl.Tensor[[M, N], pl_dtype],
+                shift: pl.Tensor[[M, N], pl_dtype],
+                out: pl.InOut[pl.Tensor[[M, N], pl_dtype]],
+            ) -> pl.Tensor[[M, N], pl_dtype]:
+                return self.kernel(src, shift, out)
+
+        return ShrProgram
+
+    assert scalar is not None
+
+    if op_name == "shls":
+
+        @pl.program
+        class ShlsProgram:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                src: pl.Tensor[[M, N], pl_dtype],
+                out: pl.InOut[pl.Tensor[[M, N], pl_dtype]],
+            ) -> pl.Tensor[[M, N], pl_dtype]:
+                src_tile = pl.load(src, [0, 0], [M, N], valid_shapes=valid)
+                return pl.store(pl.tile.shls(src_tile, scalar), [0, 0], out)
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orchestrator(
+                self,
+                src: pl.Tensor[[M, N], pl_dtype],
+                out: pl.InOut[pl.Tensor[[M, N], pl_dtype]],
+            ) -> pl.Tensor[[M, N], pl_dtype]:
+                return self.kernel(src, out)
+
+        return ShlsProgram
+
+    assert op_name == "shrs"
+
+    @pl.program
+    class ShrsProgram:
+        @pl.function(type=pl.FunctionType.InCore)
+        def kernel(
+            self,
+            src: pl.Tensor[[M, N], pl_dtype],
+            out: pl.InOut[pl.Tensor[[M, N], pl_dtype]],
+        ) -> pl.Tensor[[M, N], pl_dtype]:
+            src_tile = pl.load(src, [0, 0], [M, N], valid_shapes=valid)
+            return pl.store(pl.tile.shrs(src_tile, scalar), [0, 0], out)
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def orchestrator(
+            self,
+            src: pl.Tensor[[M, N], pl_dtype],
+            out: pl.InOut[pl.Tensor[[M, N], pl_dtype]],
+        ) -> pl.Tensor[[M, N], pl_dtype]:
+            return self.kernel(src, out)
+
+    return ShrsProgram
+
+
+class ShiftCase(PTOTestCase):
+    """One direct shift-instruction case."""
+
+    __test__ = False
+
+    def __init__(self, *, op_name: str, dtype: DataType, scalar: int | None = None):
+        super().__init__()
+        self.op_name = op_name
+        self.dtype = dtype
+        self.scalar = scalar
+
+    def get_name(self) -> str:
+        scalar_tag = f"_s{self.scalar}" if self.scalar is not None else ""
+        return f"tile_{self.op_name}_{self.dtype.value}_v{VALID_SHAPE[0]}x{VALID_SHAPE[1]}{scalar_tag}"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        specs = [TensorSpec("src", [M, N], self.dtype, init_value=lambda: _values(self.dtype))]
+        if self.scalar is None:
+            specs.append(
+                TensorSpec("shift", [M, N], self.dtype, init_value=lambda: _shift_counts(self.dtype))
+            )
+        specs.append(TensorSpec("out", [M, N], self.dtype, init_value=torch.zeros, is_output=True))
+        return specs
+
+    def get_program(self) -> Any:
+        return _make_program(self.op_name, self.dtype, self.scalar)
+
+    def compute_expected(self, tensors: dict[str, torch.Tensor], params=None) -> None:
+        rows, cols = VALID_SHAPE
+        width = _WIDTH[self.dtype]
+        src = tensors["src"][:rows, :cols].to(torch.int64)
+        shift: torch.Tensor | int
+        if self.scalar is None:
+            shift = tensors["shift"][:rows, :cols].to(torch.int64)
+        else:
+            shift = self.scalar
+
+        if self.op_name in {"shl", "shls"}:
+            mask = (1 << width) - 1
+            value = torch.bitwise_left_shift(src, shift) & mask
+            if self.dtype == DataType.INT16:
+                sign = 1 << (width - 1)
+                value = (value ^ sign) - sign
+        else:
+            if self.dtype == DataType.UINT16:
+                src = src & ((1 << width) - 1)
+            value = torch.bitwise_right_shift(src, shift)
+
+        expected = torch.zeros_like(tensors["out"])
+        expected[:rows, :cols] = value.to(self.dtype.torch_dtype)
+        tensors["out"][:] = expected
+
+
+_CASES = [
+    *[
+        pytest.param(op_name, dtype, None, id=f"t{op_name}-{dtype.value}-counts-0-1-15")
+        for op_name in ("shl", "shr")
+        for dtype in (DataType.INT16, DataType.UINT16)
+    ],
+    *[
+        pytest.param(op_name, DataType.INT16, scalar, id=f"t{op_name}-int16-s{scalar}")
+        for op_name in ("shls", "shrs")
+        for scalar in (0, 15)
+    ],
+]
+
+
+class TestShiftFamily:
+    """A2/A3 same-name coverage for four tile shift instructions."""
+
+    @pytest.mark.platforms("a2a3")
+    @pytest.mark.parametrize("op_name,dtype,scalar", _CASES)
+    def test_shift(self, test_runner, op_name, dtype, scalar):
+        result = test_runner.run(ShiftCase(op_name=op_name, dtype=dtype, scalar=scalar))
+        assert result.passed, f"Test failed: {result.error}"

--- a/tests/st/runtime/ops/test_shift.py
+++ b/tests/st/runtime/ops/test_shift.py
@@ -16,27 +16,50 @@ import pytest
 import torch
 from harness.core.harness import DataType, PTOTestCase, TensorSpec
 
-M = 16
-N = 64
-VALID_SHAPE = (11, 47)
+M = 32
+N = 32
+
+_VALID_SHAPES = {
+    "full": (M, N),
+    "rows": (17, N),
+    "cols": (M, 23),
+    "combined": (17, 23),
+}
 
 _PL_DT = {
+    DataType.INT8: pl.INT8,
+    DataType.UINT8: pl.UINT8,
     DataType.INT16: pl.INT16,
     DataType.UINT16: pl.UINT16,
+    DataType.INT32: pl.INT32,
+    DataType.UINT32: pl.UINT32,
 }
 
 _WIDTH = {
+    DataType.INT8: 8,
+    DataType.UINT8: 8,
     DataType.INT16: 16,
     DataType.UINT16: 16,
+    DataType.INT32: 32,
+    DataType.UINT32: 32,
 }
+
+_SIGNED_DTYPES = {DataType.INT8, DataType.INT16, DataType.INT32}
+_ALL_DTYPES = tuple(_PL_DT)
+_A2A3_SCALAR_DTYPES = (
+    DataType.INT16,
+    DataType.UINT16,
+    DataType.INT32,
+    DataType.UINT32,
+)
 
 
 def _values(dtype: DataType) -> torch.Tensor:
     width = _WIDTH[dtype]
-    if dtype == DataType.INT16:
-        values = [-32768, -17, -1, 0, 1, 17, 16383]
+    if dtype in _SIGNED_DTYPES:
+        values = [-(1 << (width - 1)), -17, -1, 0, 1, 17, (1 << (width - 1)) - 1]
     else:
-        values = [0, 1, 17, (1 << (width - 1)), (1 << width) - 1]
+        values = [0, 1, 17, 1 << (width - 1), (1 << width) - 1]
     index = torch.arange(M * N, dtype=torch.int64).reshape(M, N).remainder(len(values))
     result = torch.zeros((M, N), dtype=torch.int64)
     for i, value in enumerate(values):
@@ -54,9 +77,9 @@ def _shift_counts(dtype: DataType) -> torch.Tensor:
     return result.to(dtype.torch_dtype).contiguous()
 
 
-def _make_program(op_name: str, dtype: DataType, scalar: int | None):
+def _make_program(op_name: str, dtype: DataType, scalar: int | None, valid_shape: tuple[int, int]):
     pl_dtype = _PL_DT[dtype]
-    valid = list(VALID_SHAPE)
+    valid = list(valid_shape)
 
     if op_name == "shl":
 
@@ -164,15 +187,26 @@ class ShiftCase(PTOTestCase):
 
     __test__ = False
 
-    def __init__(self, *, op_name: str, dtype: DataType, scalar: int | None = None):
+    def __init__(
+        self,
+        *,
+        op_name: str,
+        dtype: DataType,
+        valid_name: str,
+        valid_shape: tuple[int, int],
+        scalar: int | None = None,
+    ):
         super().__init__()
         self.op_name = op_name
         self.dtype = dtype
+        self.valid_name = valid_name
+        self.valid_shape = valid_shape
         self.scalar = scalar
 
     def get_name(self) -> str:
         scalar_tag = f"_s{self.scalar}" if self.scalar is not None else ""
-        return f"tile_{self.op_name}_{self.dtype.value}_v{VALID_SHAPE[0]}x{VALID_SHAPE[1]}{scalar_tag}"
+        rows, cols = self.valid_shape
+        return f"tile_{self.op_name}_{self.dtype.value}_{self.valid_name}_v{rows}x{cols}{scalar_tag}"
 
     def define_tensors(self) -> list[TensorSpec]:
         specs = [TensorSpec("src", [M, N], self.dtype, init_value=lambda: _values(self.dtype))]
@@ -184,10 +218,10 @@ class ShiftCase(PTOTestCase):
         return specs
 
     def get_program(self) -> Any:
-        return _make_program(self.op_name, self.dtype, self.scalar)
+        return _make_program(self.op_name, self.dtype, self.scalar, self.valid_shape)
 
     def compute_expected(self, tensors: dict[str, torch.Tensor], params=None) -> None:
-        rows, cols = VALID_SHAPE
+        rows, cols = self.valid_shape
         width = _WIDTH[self.dtype]
         src = tensors["src"][:rows, :cols].to(torch.int64)
         shift: torch.Tensor | int
@@ -199,11 +233,11 @@ class ShiftCase(PTOTestCase):
         if self.op_name in {"shl", "shls"}:
             mask = (1 << width) - 1
             value = torch.bitwise_left_shift(src, shift) & mask
-            if self.dtype == DataType.INT16:
+            if self.dtype in _SIGNED_DTYPES:
                 sign = 1 << (width - 1)
                 value = (value ^ sign) - sign
         else:
-            if self.dtype == DataType.UINT16:
+            if self.dtype not in _SIGNED_DTYPES:
                 src = src & ((1 << width) - 1)
             value = torch.bitwise_right_shift(src, shift)
 
@@ -212,25 +246,105 @@ class ShiftCase(PTOTestCase):
         tensors["out"][:] = expected
 
 
-_CASES = [
-    *[
-        pytest.param(op_name, dtype, None, id=f"t{op_name}-{dtype.value}-counts-0-1-15")
-        for op_name in ("shl", "shr")
-        for dtype in (DataType.INT16, DataType.UINT16)
-    ],
-    *[
-        pytest.param(op_name, DataType.INT16, scalar, id=f"t{op_name}-int16-s{scalar}")
-        for op_name in ("shls", "shrs")
-        for scalar in (0, 15)
-    ],
+_TILE_CASES = [
+    pytest.param(op_name, dtype, valid_name, valid_shape, id=f"t{op_name}-{dtype.value}-{valid_name}")
+    for op_name in ("shl", "shr")
+    for dtype in _ALL_DTYPES
+    for valid_name, valid_shape in _VALID_SHAPES.items()
+]
+
+_A5_SCALAR_CASES = [
+    pytest.param(
+        op_name,
+        dtype,
+        valid_name,
+        valid_shape,
+        scalar,
+        id=f"t{op_name}-{dtype.value}-{valid_name}-s{scalar}",
+    )
+    for op_name in ("shls", "shrs")
+    for dtype in _ALL_DTYPES
+    for valid_name, valid_shape in _VALID_SHAPES.items()
+    for scalar in (0, _WIDTH[dtype] - 1)
+]
+
+# Pinned pto-isa a2/a3 TShiftCheck compares dst valid rows with src valid
+# columns. Until that upstream typo is fixed, only square valid regions can be
+# exercised by scalar shifts. The full and square-subview cases retain A2/A3
+# coverage without claiming the blocked row-only/col-only shapes pass.
+_A2A3_SAFE_VALID_SHAPES = {
+    "full": (M, N),
+    "square_combined": (17, 17),
+}
+
+_A2A3_SCALAR_CASES = [
+    pytest.param(
+        op_name,
+        dtype,
+        valid_name,
+        valid_shape,
+        scalar,
+        id=f"t{op_name}-{dtype.value}-{valid_name}-s{scalar}",
+    )
+    for op_name in ("shls", "shrs")
+    for dtype in _A2A3_SCALAR_DTYPES
+    for valid_name, valid_shape in _A2A3_SAFE_VALID_SHAPES.items()
+    for scalar in (0, _WIDTH[dtype] - 1)
 ]
 
 
-class TestShiftFamily:
-    """A2/A3 same-name coverage for four tile shift instructions."""
+class TestShiftTileFamily:
+    """A2/A3 and A5 coverage for tile-tile shifts."""
+
+    @pytest.mark.platforms("a2a3", "a5")
+    @pytest.mark.parametrize("op_name,dtype,valid_name,valid_shape", _TILE_CASES)
+    def test_shift(self, test_runner, op_name, dtype, valid_name, valid_shape):
+        result = test_runner.run(
+            ShiftCase(
+                op_name=op_name,
+                dtype=dtype,
+                valid_name=valid_name,
+                valid_shape=valid_shape,
+            )
+        )
+        assert result.passed, f"Test failed: {result.error}"
+
+
+class TestShiftScalarA5Family:
+    """A5 coverage for every scalar-shift width and valid-shape mode."""
+
+    @pytest.mark.platforms("a5")
+    @pytest.mark.parametrize("op_name,dtype,valid_name,valid_shape,scalar", _A5_SCALAR_CASES)
+    def test_shift(self, test_runner, op_name, dtype, valid_name, valid_shape, scalar):
+        result = test_runner.run(
+            ShiftCase(
+                op_name=op_name,
+                dtype=dtype,
+                valid_name=valid_name,
+                valid_shape=valid_shape,
+                scalar=scalar,
+            )
+        )
+        assert result.passed, f"Test failed: {result.error}"
+
+
+class TestShiftScalarA2A3Family:
+    """A2/A3 scalar coverage limited to shapes accepted by pinned pto-isa."""
 
     @pytest.mark.platforms("a2a3")
-    @pytest.mark.parametrize("op_name,dtype,scalar", _CASES)
-    def test_shift(self, test_runner, op_name, dtype, scalar):
-        result = test_runner.run(ShiftCase(op_name=op_name, dtype=dtype, scalar=scalar))
+    @pytest.mark.parametrize("op_name,dtype,valid_name,valid_shape,scalar", _A2A3_SCALAR_CASES)
+    def test_shift(self, test_runner, op_name, dtype, valid_name, valid_shape, scalar):
+        result = test_runner.run(
+            ShiftCase(
+                op_name=op_name,
+                dtype=dtype,
+                valid_name=valid_name,
+                valid_shape=valid_shape,
+                scalar=scalar,
+            )
+        )
         assert result.passed, f"Test failed: {result.error}"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/ut/codegen/test_pto_codegen.py
+++ b/tests/ut/codegen/test_pto_codegen.py
@@ -812,6 +812,52 @@ def test_pto_codegen_tile_int_literal_scalar_is_not_index():
     assert ", i32)" in tadds, f"scalar operand is not i32: {tadds}"
 
 
+@pytest.mark.parametrize(
+    "tile_dtype,scalar_type",
+    [
+        (pl.UINT8, "i8"),
+        (pl.UINT16, "i16"),
+        (pl.UINT32, "i32"),
+    ],
+)
+@pytest.mark.parametrize("op_name", ["shls", "shrs"])
+def test_pto_codegen_unsigned_tile_shift_uses_signless_same_width_scalar(tile_dtype, scalar_type, op_name):
+    """Unsigned tile shifts encode a signed same-width PTOAS scalar operand."""
+
+    if op_name == "shls":
+
+        @pl.program
+        class ShiftProgram:
+            @pl.function(type=pl.FunctionType.InCore)
+            def shift_test(
+                self,
+                src: pl.Tensor[[32, 32], tile_dtype],
+                out: pl.Tensor[[32, 32], tile_dtype],
+            ):
+                src_tile = pl.load(src, offsets=[0, 0], shapes=[32, 32])
+                result = pl.tile.shls(src_tile, 1)
+                pl.store(result, offsets=[0, 0], output_tensor=out)
+
+    else:
+
+        @pl.program
+        class ShiftProgram:
+            @pl.function(type=pl.FunctionType.InCore)
+            def shift_test(
+                self,
+                src: pl.Tensor[[32, 32], tile_dtype],
+                out: pl.Tensor[[32, 32], tile_dtype],
+            ):
+                src_tile = pl.load(src, offsets=[0, 0], shapes=[32, 32])
+                result = pl.tile.shrs(src_tile, 1)
+                pl.store(result, offsets=[0, 0], output_tensor=out)
+
+    lines = _get_mlir_lines(_generate_default_mlir(ShiftProgram))
+    shift = _single_line(lines, f"pto.t{op_name}")
+    assert "index" not in shift, f"scalar operand is still index: {shift}"
+    assert f", {scalar_type})" in shift, f"scalar operand is not {scalar_type}: {shift}"
+
+
 def test_pto_codegen_tensor_int_literal_scalar_is_not_index():
     """A tensor-level int literal must lower to an i32-operand tadds, never index.
 

--- a/tests/ut/ir/operators/test_tile_ops.py
+++ b/tests/ut/ir/operators/test_tile_ops.py
@@ -3574,7 +3574,7 @@ class TestTileBitwiseArithmeticOps:
 
         assert _tile_result_dtype(call) == dtype
         assert isinstance(call.type, ir.TileType)
-        assert call.type.shape == src.type.shape
+        assert call.type.shape == [8, 16]
         assert _valid_of(call.type) == [7, 13]
 
     @pytest.mark.parametrize("dtype", [DataType.INT8, DataType.INT16, DataType.INT32])

--- a/tests/ut/ir/operators/test_tile_ops.py
+++ b/tests/ut/ir/operators/test_tile_ops.py
@@ -3549,21 +3549,15 @@ class TestTileBitwiseArithmeticOps:
 
     @pytest.mark.parametrize(
         "dtype",
-        [
-            DataType.INT8,
-            DataType.UINT8,
-            DataType.INT16,
-            DataType.UINT16,
-            DataType.INT32,
-            DataType.UINT32,
-        ],
+        [DataType.INT8, DataType.UINT8, DataType.INT16, DataType.UINT16, DataType.INT32, DataType.UINT32],
     )
+    @pytest.mark.parametrize("valid_shape", [[8, 16], [7, 16], [8, 13], [7, 13]])
     @pytest.mark.parametrize("op", [tile.shl, tile.shr])
-    def test_shift_contract_binary_accepts_supported_widths_and_preserves_view(self, dtype, op):
-        """Tile shift ops preserve src type and require one shared valid region."""
+    def test_shift_contract_binary_accepts_supported_widths_and_preserves_view(self, dtype, valid_shape, op):
+        """Tile shifts preserve src type/layout across full/row/col/combined valid regions."""
         span = ir.Span.unknown()
         view = ir.TileView(
-            valid_shape=[7, 13],
+            valid_shape=valid_shape,
             blayout=ir.TileLayout.row_major,
             slayout=ir.TileLayout.none_box,
         )
@@ -3575,18 +3569,31 @@ class TestTileBitwiseArithmeticOps:
         assert _tile_result_dtype(call) == dtype
         assert isinstance(call.type, ir.TileType)
         assert call.type.shape == [8, 16]
-        assert _valid_of(call.type) == [7, 13]
+        assert _valid_of(call.type) == valid_shape
+        result_view = call.type.get_effective_tile_view()
+        assert result_view.blayout == ir.TileLayout.row_major
+        assert result_view.slayout == ir.TileLayout.none_box
 
-    @pytest.mark.parametrize("dtype", [DataType.INT8, DataType.INT16, DataType.INT32])
+    @pytest.mark.parametrize(
+        "dtype,scalar_dtype",
+        [
+            (DataType.INT8, DataType.INT8),
+            (DataType.UINT8, DataType.INT8),
+            (DataType.INT16, DataType.INT16),
+            (DataType.UINT16, DataType.INT16),
+            (DataType.INT32, DataType.INT32),
+            (DataType.UINT32, DataType.INT32),
+        ],
+    )
     @pytest.mark.parametrize("op", [tile.shls, tile.shrs])
-    def test_shift_contract_scalar_literal_matches_tile_dtype(self, dtype, op):
-        """Scalar literal sugar uses the exact tile dtype required by PTO-ISA."""
+    def test_shift_contract_scalar_literal_uses_signless_same_width_dtype(self, dtype, scalar_dtype, op):
+        """Scalar literal sugar uses PTOAS's signless count with the tile width."""
         span = ir.Span.unknown()
         src = ir.Var("src", ir.TileType([8, 16], dtype), span)
 
         call = op(src, 1)
 
-        assert _operand_dtype(call.args[1]) == dtype
+        assert _operand_dtype(call.args[1]) == scalar_dtype
         assert _tile_result_dtype(call) == dtype
 
     @pytest.mark.parametrize("op", [tile.shl, tile.shr])
@@ -3603,24 +3610,52 @@ class TestTileBitwiseArithmeticOps:
             op(full, broadcast)
 
     @pytest.mark.parametrize("op", [tile.shls, tile.shrs])
-    def test_shift_contract_scalar_rejects_explicit_dtype_mismatch(self, op):
-        """A typed scalar shift count must exactly match the source dtype."""
+    def test_shift_contract_scalar_rejects_width_mismatch(self, op):
+        """A typed scalar shift count must use the source element width."""
         span = ir.Span.unknown()
         src = ir.Var("src", ir.TileType([8, 16], DataType.INT16), span)
         shift = ir.ConstInt(1, DataType.INT32, span)
 
-        with pytest.raises(ValueError, match=r"same dtype"):
+        with pytest.raises(ValueError, match=r"same bit width"):
             op(src, shift)
 
     @pytest.mark.parametrize("dtype", [DataType.UINT8, DataType.UINT16, DataType.UINT32])
     @pytest.mark.parametrize("op", [tile.shls, tile.shrs])
-    def test_shift_contract_scalar_rejects_unsigned_ptoas_encoding_gap(self, dtype, op):
-        """PTOAS scalar operands cannot encode PyPTO's explicit unsigned scalar types."""
+    def test_shift_contract_scalar_rejects_explicit_unsigned_count(self, dtype, op):
+        """PTOAS accepts signless scalar operands, not explicit unsigned scalar types."""
+        span = ir.Span.unknown()
+        signed_dtype = {
+            DataType.UINT8: DataType.INT8,
+            DataType.UINT16: DataType.INT16,
+            DataType.UINT32: DataType.INT32,
+        }[dtype]
+        src = ir.Var("src", ir.TileType([8, 16], signed_dtype), span)
+        shift = ir.ConstInt(1, dtype, span)
+
+        with pytest.raises(ValueError, match=r"signless scalar shift count"):
+            op(src, shift)
+
+    @pytest.mark.parametrize("dtype", [DataType.INT8, DataType.UINT8, DataType.INT16, DataType.UINT16])
+    @pytest.mark.parametrize("op", [tile.shls, tile.shrs])
+    def test_shift_contract_scalar_accepts_legal_count_boundaries(self, dtype, op):
+        """Constant counts accept both legal endpoints, zero and width minus one."""
+        span = ir.Span.unknown()
+        src = ir.Var("src", ir.TileType([8, 16], dtype), span)
+        width = dtype.get_bit()
+
+        for count in (0, width - 1):
+            assert _tile_result_dtype(op(src, count)) == dtype
+
+    @pytest.mark.parametrize("dtype", [DataType.INT8, DataType.UINT16, DataType.INT32])
+    @pytest.mark.parametrize("op", [tile.shls, tile.shrs])
+    def test_shift_contract_scalar_rejects_counts_outside_legal_range(self, dtype, op):
+        """Constant counts reject negative values and the first value past the width."""
         span = ir.Span.unknown()
         src = ir.Var("src", ir.TileType([8, 16], dtype), span)
 
-        with pytest.raises(ValueError, match=r"INT8, INT16, INT32"):
-            op(src, 1)
+        for count in (-1, dtype.get_bit()):
+            with pytest.raises(ValueError, match=r"constant shift count in"):
+                op(src, count)
 
     @pytest.mark.parametrize("op", [tile.shl, tile.shr, tile.shls, tile.shrs])
     def test_shift_contract_rejects_unsupported_integer_width(self, op):
@@ -3829,13 +3864,13 @@ class TestTileBitwiseArithmeticOps:
 
 
 class TestTileScalarOperandDtype:
-    """A constant scalar operand of a tile x scalar op adopts the tile dtype.
+    """A constant scalar operand adopts the paired tile's PTOAS-compatible dtype.
 
     Regression: a DSL bare int literal is parsed to ``ConstInt(v, INDEX)``, and
     ``index`` is not a legal operand type for any ``pto.t*s`` instruction. The
     tile scalar wrappers must re-stamp such placeholders to the tile element
-    dtype (``_normalize_scalar_operand``), reject non-constant ``index`` values,
-    and leave already-typed / non-constant operands untouched.
+    dtype (or the same-width signed dtype for shift counts), reject non-constant
+    ``index`` values, and leave already-typed / non-constant operands untouched.
     """
 
     # Every tile x scalar wrapper that normalizes a constant operand. Each entry
@@ -3949,15 +3984,17 @@ class TestTileScalarOperandDtype:
             call = fn(self._int_tile(DataType.INT16), 255)
             assert _operand_dtype(call.args[1]) == DataType.INT16
 
-    def test_narrow_shift_literal_adopts_tile_dtype(self):
-        """Shift counts follow the tile dtype, including narrow int tiles.
-
-        The scalar follows the tile element type required by PTO-ISA/PTOAS.
-        """
-        for dtype in (DataType.INT8, DataType.INT16):
+    def test_narrow_shift_literal_adopts_signless_same_width_dtype(self):
+        """Shift counts use the signed same-width PTOAS scalar representation."""
+        for dtype, scalar_dtype in (
+            (DataType.INT8, DataType.INT8),
+            (DataType.UINT8, DataType.INT8),
+            (DataType.INT16, DataType.INT16),
+            (DataType.UINT16, DataType.INT16),
+        ):
             for fn in (tile.shls, tile.shrs):
                 call = fn(self._int_tile(dtype), 3)
-                assert _operand_dtype(call.args[1]) == dtype, f"{fn.__name__} on {dtype}"
+                assert _operand_dtype(call.args[1]) == scalar_dtype, f"{fn.__name__} on {dtype}"
 
     def test_ir_level_restamps_index_const(self):
         """A hand-built ConstInt(INDEX) operand (parser output) is re-stamped."""

--- a/tests/ut/ir/operators/test_tile_ops.py
+++ b/tests/ut/ir/operators/test_tile_ops.py
@@ -3456,13 +3456,13 @@ class TestTileBitwiseArithmeticOps:
             @pl.function(type=pl.FunctionType.InCore)
             def main(
                 self,
-                a: pl.Tensor[[128, 128], pl.UINT32],
+                a: pl.Tensor[[128, 128], pl.INT32],
                 scalar: pl.Scalar[pl.INT32],
-                output: pl.Tensor[[128, 128], pl.UINT32],
-            ) -> pl.Tensor[[128, 128], pl.UINT32]:
-                tile_a: pl.Tile[[16, 16], pl.UINT32] = pl.load(a, [0, 0], [16, 16])
-                tile_c: pl.Tile[[16, 16], pl.UINT32] = pl.shls(tile_a, scalar)
-                result: pl.Tensor[[128, 128], pl.UINT32] = pl.store(tile_c, [0, 0], output)
+                output: pl.Tensor[[128, 128], pl.INT32],
+            ) -> pl.Tensor[[128, 128], pl.INT32]:
+                tile_a: pl.Tile[[16, 16], pl.INT32] = pl.load(a, [0, 0], [16, 16])
+                tile_c: pl.Tile[[16, 16], pl.INT32] = pl.shls(tile_a, scalar)
+                result: pl.Tensor[[128, 128], pl.INT32] = pl.store(tile_c, [0, 0], output)
                 return result
 
         ir_str = str(Program)
@@ -3535,13 +3535,13 @@ class TestTileBitwiseArithmeticOps:
             @pl.function(type=pl.FunctionType.InCore)
             def main(
                 self,
-                a: pl.Tensor[[128, 128], pl.UINT32],
+                a: pl.Tensor[[128, 128], pl.INT32],
                 scalar: pl.Scalar[pl.INT32],
-                output: pl.Tensor[[128, 128], pl.UINT32],
-            ) -> pl.Tensor[[128, 128], pl.UINT32]:
-                tile_a: pl.Tile[[16, 16], pl.UINT32] = pl.load(a, [0, 0], [16, 16])
-                tile_c: pl.Tile[[16, 16], pl.UINT32] = pl.shrs(tile_a, scalar)
-                result: pl.Tensor[[128, 128], pl.UINT32] = pl.store(tile_c, [0, 0], output)
+                output: pl.Tensor[[128, 128], pl.INT32],
+            ) -> pl.Tensor[[128, 128], pl.INT32]:
+                tile_a: pl.Tile[[16, 16], pl.INT32] = pl.load(a, [0, 0], [16, 16])
+                tile_c: pl.Tile[[16, 16], pl.INT32] = pl.shrs(tile_a, scalar)
+                result: pl.Tensor[[128, 128], pl.INT32] = pl.store(tile_c, [0, 0], output)
                 return result
 
         ir_str = str(Program)

--- a/tests/ut/ir/operators/test_tile_ops.py
+++ b/tests/ut/ir/operators/test_tile_ops.py
@@ -3547,55 +3547,89 @@ class TestTileBitwiseArithmeticOps:
         ir_str = str(Program)
         assert "tile.shrs" in ir_str
 
-    def test_tile_shl_preserves_lhs_dtype(self):
-        """Regression: tile.shl result dtype must match LHS dtype, not the promoted type.
+    @pytest.mark.parametrize(
+        "dtype",
+        [
+            DataType.INT8,
+            DataType.UINT8,
+            DataType.INT16,
+            DataType.UINT16,
+            DataType.INT32,
+            DataType.UINT32,
+        ],
+    )
+    @pytest.mark.parametrize("op", [tile.shl, tile.shr])
+    def test_shift_contract_binary_accepts_supported_widths_and_preserves_view(self, dtype, op):
+        """Tile shift ops preserve src type and require one shared valid region."""
+        span = ir.Span.unknown()
+        view = ir.TileView(
+            valid_shape=[7, 13],
+            blayout=ir.TileLayout.row_major,
+            slayout=ir.TileLayout.none_box,
+        )
+        src = ir.Var("src", ir.TileType([8, 16], dtype, tile_view=view), span)
+        shift = ir.Var("shift", ir.TileType([10, 20], dtype, tile_view=view), span)
 
-        When lhs is UINT16 and rhs is UINT32, the result must be UINT16 (LHS dtype),
-        consistent with the scalar variant tile.shls which preserves the LHS tile dtype.
-        """
+        call = op(src, shift)
 
-        @pl.program
-        class Program:
-            @pl.function(type=pl.FunctionType.InCore)
-            def main(
-                self,
-                a: pl.Tensor[[128, 128], pl.UINT16],
-                b: pl.Tensor[[128, 128], pl.UINT32],
-                output: pl.Tensor[[128, 128], pl.UINT16],
-            ) -> pl.Tensor[[128, 128], pl.UINT16]:
-                tile_a: pl.Tile[[16, 16], pl.UINT16] = pl.load(a, [0, 0], [16, 16])
-                tile_b: pl.Tile[[16, 16], pl.UINT32] = pl.load(b, [0, 0], [16, 16])
-                tile_c: pl.Tile[[16, 16], pl.UINT16] = pl.shl(tile_a, tile_b)
-                result: pl.Tensor[[128, 128], pl.UINT16] = pl.store(tile_c, [0, 0], output)
-                return result
+        assert _tile_result_dtype(call) == dtype
+        assert isinstance(call.type, ir.TileType)
+        assert call.type.shape == src.type.shape
+        assert _valid_of(call.type) == [7, 13]
 
-        ir_str = str(Program)
-        assert "tile.shl" in ir_str
+    @pytest.mark.parametrize("dtype", [DataType.INT8, DataType.INT16, DataType.INT32])
+    @pytest.mark.parametrize("op", [tile.shls, tile.shrs])
+    def test_shift_contract_scalar_literal_matches_tile_dtype(self, dtype, op):
+        """Scalar literal sugar uses the exact tile dtype required by PTO-ISA."""
+        span = ir.Span.unknown()
+        src = ir.Var("src", ir.TileType([8, 16], dtype), span)
 
-    def test_tile_shr_preserves_lhs_dtype(self):
-        """Regression: tile.shr result dtype must match LHS dtype, not the promoted type.
+        call = op(src, 1)
 
-        When lhs is UINT16 and rhs is UINT32, the result must be UINT16 (LHS dtype),
-        consistent with the scalar variant tile.shrs which preserves the LHS tile dtype.
-        """
+        assert _operand_dtype(call.args[1]) == dtype
+        assert _tile_result_dtype(call) == dtype
 
-        @pl.program
-        class Program:
-            @pl.function(type=pl.FunctionType.InCore)
-            def main(
-                self,
-                a: pl.Tensor[[128, 128], pl.UINT16],
-                b: pl.Tensor[[128, 128], pl.UINT32],
-                output: pl.Tensor[[128, 128], pl.UINT16],
-            ) -> pl.Tensor[[128, 128], pl.UINT16]:
-                tile_a: pl.Tile[[16, 16], pl.UINT16] = pl.load(a, [0, 0], [16, 16])
-                tile_b: pl.Tile[[16, 16], pl.UINT32] = pl.load(b, [0, 0], [16, 16])
-                tile_c: pl.Tile[[16, 16], pl.UINT16] = pl.shr(tile_a, tile_b)
-                result: pl.Tensor[[128, 128], pl.UINT16] = pl.store(tile_c, [0, 0], output)
-                return result
+    @pytest.mark.parametrize("op", [tile.shl, tile.shr])
+    def test_shift_contract_binary_rejects_dtype_and_valid_shape_mismatch(self, op):
+        """PTO-ISA does not promote or broadcast shift-count tiles."""
+        span = ir.Span.unknown()
+        full = ir.Var("full", ir.TileType([8, 16], DataType.INT16), span)
+        mixed = ir.Var("mixed", ir.TileType([8, 16], DataType.UINT16), span)
+        broadcast = ir.Var("broadcast", ir.TileType([1, 16], DataType.INT16), span)
 
-        ir_str = str(Program)
-        assert "tile.shr" in ir_str
+        with pytest.raises(ValueError, match=r"same dtype"):
+            op(full, mixed)
+        with pytest.raises(ValueError, match=r"same valid_shape"):
+            op(full, broadcast)
+
+    @pytest.mark.parametrize("op", [tile.shls, tile.shrs])
+    def test_shift_contract_scalar_rejects_explicit_dtype_mismatch(self, op):
+        """A typed scalar shift count must exactly match the source dtype."""
+        span = ir.Span.unknown()
+        src = ir.Var("src", ir.TileType([8, 16], DataType.INT16), span)
+        shift = ir.ConstInt(1, DataType.INT32, span)
+
+        with pytest.raises(ValueError, match=r"same dtype"):
+            op(src, shift)
+
+    @pytest.mark.parametrize("dtype", [DataType.UINT8, DataType.UINT16, DataType.UINT32])
+    @pytest.mark.parametrize("op", [tile.shls, tile.shrs])
+    def test_shift_contract_scalar_rejects_unsigned_ptoas_encoding_gap(self, dtype, op):
+        """PTOAS scalar operands cannot encode PyPTO's explicit unsigned scalar types."""
+        span = ir.Span.unknown()
+        src = ir.Var("src", ir.TileType([8, 16], dtype), span)
+
+        with pytest.raises(ValueError, match=r"INT8, INT16, INT32"):
+            op(src, 1)
+
+    @pytest.mark.parametrize("op", [tile.shl, tile.shr, tile.shls, tile.shrs])
+    def test_shift_contract_rejects_unsupported_integer_width(self, op):
+        """INT64 is not implemented by the current PTO-ISA shift templates."""
+        span = ir.Span.unknown()
+        src = ir.Var("src", ir.TileType([8, 16], DataType.INT64), span)
+
+        with pytest.raises(ValueError, match=r"INT8.*INT32"):
+            op(src, 1) if op in (tile.shls, tile.shrs) else op(src, src)
 
     def test_tile_prelu(self):
         """Test tile.prelu operator - element-wise parametric ReLU with slope and tmp buffer."""
@@ -3918,9 +3952,7 @@ class TestTileScalarOperandDtype:
     def test_narrow_shift_literal_adopts_tile_dtype(self):
         """Shift counts follow the tile dtype, including narrow int tiles.
 
-        `DeduceTileOpIntScalarBinaryType` permits any integer width for the
-        shift operand ("codegen casts to i32"), and an i8/i16 shift count is
-        accepted end-to-end by ptoas, so narrowing here is safe.
+        The scalar follows the tile element type required by PTO-ISA/PTOAS.
         """
         for dtype in (DataType.INT8, DataType.INT16):
             for fn in (tile.shls, tile.shrs):


### PR DESCRIPTION
## Summary

- align `tile.shl`, `tile.shr`, `tile.shls`, and `tile.shrs` with the current PTO-ISA dtype, valid-region, scalar, and row-major layout contracts
- remove mixed-dtype promotion and shape broadcasting from exact tile shifts, preserve signed/unsigned 8/16/32-bit cross-architecture IR support, and reject unsigned scalar encodings that PTOAS cannot represent
- add focused type coverage plus same-name runtime ST, and record A2/A3 hardware evidence in both status matrices

## Validation

- complete local diff review: passed
- `git diff --check`: passed
- Ruff check and format check for changed Python files: passed
- serial CMake build and environment install on `/data/chenshenai/test2`: passed
- focused shift contract UT: 32 passed
- repository header, English-only, and docs parity checks: passed
- A2/A3 codegen-only with latest PTOAS assembly: 8 passed; generated `.pto` files contain exact `pto.tshl`, `pto.tshr`, `pto.tshls`, and `pto.tshrs` operand types and order
- A2/A3 task-submit hardware, one precompile worker and one 8-case batch: 8/8 passed on device 1

Runtime coverage includes left/right shifts, signed/unsigned 16-bit tile forms, zero/one/width-minus-one counts, scalar/tile forms, and narrowed `valid_shape`. A5 hardware validation remains pending and is documented in the status matrix.