### PR TITLE
feat(ir): add MX LeftScale/RightScale memspaces and scale load/move

### DIFF
--- a/docs/en/dev/07-memory-map.md
+++ b/docs/en/dev/07-memory-map.md
@@ -44,7 +44,7 @@ axis to draw and the tool refuses the dump with that explanation. Later dumps
 Panel scale is a memory space's capacity, which the dump does not record. The
 tool reads it off the backend's own SoC description — walking
 `Backend.soc` down to each `Core`'s `Mem` entries — so a backend that carries a
-space others do not (Ascend950 has `Bias`) still gets a real capacity instead of
+space others do not (Ascend950 has `Bias` / `LeftScale` / `RightScale`) still gets a real capacity instead of
 falling back to its own high-water mark and rendering that panel permanently
 full.
 

--- a/docs/en/dev/ir/02-types.md
+++ b/docs/en/dev/ir/02-types.md
@@ -119,7 +119,7 @@ tensor_with_both = ir.TensorType([128, 256], DataType.FP16, memref=memref, tenso
 **TensorView fields:**
 
 - `stride`: stride for each dimension
-- `layout`: `TensorLayout.ND` / `DN` / `NZ`
+- `layout`: `TensorLayout.ND` / `DN` / `NZ` / `MX_A_ZZ` / `MX_B_NN`
 - `valid_shape`: optional valid-region dimensions (empty means use full shape)
 - `pad`: `PadValue.null` (default) / `zero` / `max` / `min` — padding mode used
   when loads/slices read outside the `valid_shape`. Peer of `TileView.pad`;

--- a/docs/en/dev/ir/05-operators.md
+++ b/docs/en/dev/ir/05-operators.md
@@ -125,6 +125,46 @@ INT32 for integer inputs (mirroring `tile.matmul_acc`). At conversion time
 this batched path whenever any operand has rank > 2; `FlattenTileNdTo2D`
 later unrolls the batched form into per-batch 2D ops.
 
+### MX scale memory and data movement (Ascend950)
+
+MX uses dedicated `LeftScale` / `RightScale` memory spaces and `FP8E8M0` scale dtype.
+This change lands the **scale memspace + load/move** path (no matmul yet).
+
+| IR / DSL | Notes |
+| -------- | ----- |
+| `tile.load` of `pl.Tensor[..., pl.MX_A_ZZ \| pl.MX_B_NN]` | MX scale GM layouts are carried by the source TensorLayout. Dtype is FP8E8M0 or UINT8 and `target_memory=Mat` must be passed explicitly. Strided sources are rejected. |
+| `tile.move(..., target_memory=LeftScale/RightScale)` | Mat→Scale move with hardware-fixed row/row/32 (left) or col/col/32 (right) layout; the source Mat tile and layout overrides must match exactly |
+| `tile.create(..., target_memory=LeftScale/RightScale)` | Not supported; create scale data through MX load to Mat followed by move |
+
+MX tensor subviews are a known legacy limitation: `tensor.slice`, `tensor.reshape`,
+`tensor.transpose`, `tensor.reinterpret_view`, and `tensor.view` reject MX-layout
+sources because the current MX hardware path cannot represent a subview base offset.
+`pld.tile.remote_load` also rejects MX layouts until its complete scale layout
+contract is implemented.
+
+Canonical sample for scale tiles: scale=`FP8E8M0` with shapes `[M, ceil(K/32)]` / `[ceil(K/32), N]`,
+GM scale layouts `mx_a_zz` / `mx_b_nn` (host ZZ/NN pack); fractal=32.
+
+#### MX / Ascend950: pto-isa constraints
+
+| Constraint | Detail |
+| ---------- | ------ |
+| Distinct scale buffers | Cube does **not** fold scales into Left/Right data; `TileType::ScaleLeft` / `ScaleRight` (L0A/L0B sidecars) ↔ PyPTO `LeftScale` / `RightScale` |
+| Payload | Scale is `float8_e8m0_t` / `FP8E8M0`; physical scale groups `ceil(K/32)`, fractal=32 |
+| Layouts | `mx_a_zz` → row-major ZZ; `mx_b_nn` → col-major NN; `TLoadMxCube*` (AZZ2ZZ / …) |
+| `TMov` `CommonCheckMX` | Allows `uint8_t` Mat → `float8_e8m0` ScaleLeft/Right; canonical path: ui8 Mat reshape then ui8→f8 Scale |
+
+#### MX / Ascend950: PTOAS constraints
+
+| Constraint | Detail |
+| ---------- | ------ |
+| Single `loc=scaling` | No distinct left/right_scale locs yet; both PyPTO spaces lower to `loc=scaling`; EmitC recovers ScaleLeft/Right |
+| Dtype must be `!pto.f8E8M0` | `ui8` + `scaling` wrongly becomes Fixpipe `TileType::Scaling`; promote before entering LeftScale/RightScale |
+| No Mat↔Scaling `treshape` | Different locs; reshape stays in Mat (ui8), then `tmov` into scaling |
+| Shape-matched Mat→Scale `tmov` | Flat `[1,G]` must `treshape` to `[M,K/32]` (or B-side shape) first |
+| Order | PyPTO emits the Mat→scaling `tmov` in source order; PTOAS `PTOA5NormalizeTMovPass` can reorder bind-before-fill when `tget_scale_addr` is present |
+| `#pto.layout` / mx load | `mx_a_zz` / `mx_b_nn` / … |
+
 ## Python Usage
 
 ```python
@@ -545,6 +585,7 @@ workspace or silently turn a requested prefetch into a no-op. See
 | -------------- | -------- |
 | `src/ir/op/type_inference.cpp` | Shared type inference utilities |
 | `tensor_ops/elementwise.cpp` | TensorOp: add, sub, mul, div |
+| `tile_ops/matmul.cpp` | TileOp: matmul, gemv |
 | `tile_ops/memory.cpp` | TileOp: load, store, read, get_block_idx |
 | `tile_ops/elementwise.cpp` | TileOp: add, mul, div, adds, muls, etc. |
 | `tile_ops/reduction.cpp` | TileOp: sum (with axis, keepdim) |

--- a/docs/en/dev/passes/17-infer_tile_memory_space.md
+++ b/docs/en/dev/passes/17-infer_tile_memory_space.md
@@ -76,6 +76,10 @@ For each `ForStmt` with `return_vars_`, after visiting the body the analyzer cop
 | `HasRetargetableMemoryKwarg()` op (e.g. `tile.load`, `tile.create`) and resolver returned `None` (kwarg absent) | Phase-0 demand if it is `Vec` or `Mat`; otherwise input-inherit; else `Vec` |
 | `tile.*` op with `deduce_output_memory` returning `None` and not retargetable / not inherit | Input-inherit; else `Vec` |
 
+`tile.load` of a `TensorLayout.MX_A_ZZ` / `MX_B_NN` source must carry an
+explicit `target_memory=Mat`; type deduction rejects an omitted or different
+target before this pass runs.
+
 The "clamp to `{Vec, Mat}`" step on retargetable producers is deliberate: a DDR-facing `tile.load` cannot directly produce `Left`/`Right`/`Acc`/`Bias`, so even when downstream demand is one of those, the producer must stop at `Mat` (or `Vec`) and Phase 2 inserts a `tile.move` to reach the specialized space.
 
 The pass *never* overrides a present `target_memory` kwarg in Phase 1. If a user wrote `pl.load(..., target_memory=Mat)` and a downstream `matmul` demands `Left`, the load stays at `Mat` and a `tile.move` is inserted.

--- a/docs/zh/dev/07-memory-map.md
+++ b/docs/zh/dev/07-memory-map.md
@@ -40,7 +40,7 @@ MemRef 的 offset 都还是 0，没有地址轴可画，工具会带着这条说
 
 panel 的缩放基准是内存空间的容量，而 dump 里并不记录它。工具从 backend 自己的 SoC
 描述里读取——沿 `Backend.soc` 一路走到每个 `Core` 的 `Mem` 条目——因此某个 backend
-独有的空间（Ascend950 有 `Bias`）也能拿到真实容量，而不会回退成它自身的 high-water
+独有的空间（Ascend950 有 `Bias` / `LeftScale` / `RightScale`）也能拿到真实容量，而不会回退成它自身的 high-water
 mark、把该 panel 画成永远满的。
 
 用哪个 backend 按以下顺序决定：

--- a/docs/zh/dev/ir/02-types.md
+++ b/docs/zh/dev/ir/02-types.md
@@ -117,7 +117,7 @@ tensor_with_both = ir.TensorType([128, 256], DataType.FP16, memref=memref, tenso
 **TensorView 字段：**
 
 - `stride`：每个维度的步长
-- `layout`：`TensorLayout.ND` / `DN` / `NZ`
+- `layout`：`TensorLayout.ND` / `DN` / `NZ` / `MX_A_ZZ` / `MX_B_NN`
 - `valid_shape`：可选的有效区域维度（为空表示使用完整 shape）
 - `pad`：`PadValue.null`（默认）/ `zero` / `max` / `min`，用于访问超出
   `valid_shape` 部分时的填充模式。与 `TileView.pad` 对称；

--- a/docs/zh/dev/ir/05-operators.md
+++ b/docs/zh/dev/ir/05-operators.md
@@ -119,6 +119,45 @@ lhs/rhs 广播后的 batch 形状完全一致；matmul 的 (M, N) 必须与 acc 
 `tensor.matmul` / `tensor.matmul_acc` 在任一操作数 rank > 2 时分派到该批量路径；后续由
 `FlattenTileNdTo2D` 将其展开为逐 batch 的 2D 操作。
 
+### MX scale 内存与数据搬运（Ascend950）
+
+MX 使用独立的 `LeftScale` / `RightScale` 内存空间与 `FP8E8M0` scale dtype。
+本变更落地 **scale 内存空间 + load/move** 路径（尚不含 matmul）。
+
+| IR / DSL | 说明 |
+| -------- | ---- |
+| `tile.load` 读取 `pl.Tensor[..., pl.MX_A_ZZ \| pl.MX_B_NN]` | MX scale GM layout 由源 TensorLayout 携带。dtype 为 FP8E8M0 或 UINT8，且必须显式传入 `target_memory=Mat`；拒绝 strided source。 |
+| `tile.move(..., target_memory=LeftScale/RightScale)` | Mat→Scale move；layout 固定为左侧 row/row/32、右侧 col/col/32，源 Mat tile 和显式 override 都必须严格匹配 |
+| `tile.create(..., target_memory=LeftScale/RightScale)` | 不支持；应先通过 MX load 创建 Mat scale 数据，再 move 到 scale 空间 |
+
+MX tensor subview 是当前遗留限制：由于现有 MX 硬件路径无法表达 subview
+base offset，`tensor.slice`、`tensor.reshape`、`tensor.transpose`、
+`tensor.reinterpret_view` 和 `tensor.view` 均拒绝 MX-layout source。
+在完整的 scale layout contract 实现前，`pld.tile.remote_load` 也拒绝 MX layout。
+
+scale tile 规范样例：scale=`FP8E8M0`，形状 `[M, ceil(K/32)]` / `[ceil(K/32), N]`，
+GM scale layout `mx_a_zz` / `mx_b_nn`（host ZZ/NN pack）；fractal=32。
+
+#### MX / Ascend950：pto-isa 约束
+
+| 约束 | 要点 |
+| ---- | ---- |
+| 独立 scale buffer | Cube **不**把 scale 折进 Left/Right；`TileType::ScaleLeft` / `ScaleRight`（L0A/L0B sidecar）↔ PyPTO `LeftScale` / `RightScale` |
+| payload | scale 为 `float8_e8m0_t` / `FP8E8M0`；physical scale 组数 `ceil(K/32)`，fractal=32 |
+| layout | `mx_a_zz` → row-major ZZ；`mx_b_nn` → col-major NN；`TLoadMxCube*`（AZZ2ZZ 等） |
+| `TMov` `CommonCheckMX` | 允许 `uint8_t` Mat → `float8_e8m0` ScaleLeft/Right；canonical：ui8 Mat reshape 再 ui8→f8 Scale |
+
+#### MX / Ascend950：PTOAS 约束
+
+| 约束 | 要点 |
+| ---- | ---- |
+| 单一 `loc=scaling` | 尚无独立 left/right_scale loc；PyPTO 两侧都降到 `loc=scaling`，EmitC 再选 ScaleLeft/Right |
+| dtype 必须 `!pto.f8E8M0` | `ui8`+`scaling` 会错成 Fixpipe `TileType::Scaling`；进 Scale 前需提升为 FP8E8M0 |
+| 禁止 Mat↔Scaling `treshape` | 不同 loc；reshape 留在 Mat（ui8），再 `tmov` 进 scaling |
+| shape-matched Mat→Scale `tmov` | flat `[1,G]` 须先 `treshape` 到 `[M,K/32]`（或 B 侧 shape） |
+| 顺序 | PyPTO 按源序发 Mat→scaling `tmov`；存在 `tget_scale_addr` 时 PTOAS `PTOA5NormalizeTMovPass` 可做 bind-before-fill 重排 |
+| `#pto.layout` / mx load | `mx_a_zz` / `mx_b_nn` / … |
+
 ## Python 用法
 
 ```python
@@ -534,6 +573,7 @@ a5 或不提供 SDMA provider 的 runtime 上，启用该能力的 worker 会在
 | --------- | ---- |
 | `src/ir/op/type_inference.cpp` | 共享的类型推断工具 |
 | `tensor_ops/elementwise.cpp` | TensorOp: add, sub, mul, div |
+| `tile_ops/matmul.cpp` | TileOp：matmul、gemv |
 | `tile_ops/memory.cpp` | TileOp: load, store, read, get_block_idx |
 | `tile_ops/elementwise.cpp` | TileOp: add, mul, div, adds, muls 等 |
 | `tile_ops/reduction.cpp` | TileOp: sum（含 axis, keepdim） |

--- a/docs/zh/dev/passes/17-infer_tile_memory_space.md
+++ b/docs/zh/dev/passes/17-infer_tile_memory_space.md
@@ -80,6 +80,9 @@ program_inferred = infer_pass(program)
 
 阶段 1 **从不**覆盖已有的 `target_memory` kwarg。如果用户写了 `pl.load(..., target_memory=Mat)`，而下游 `matmul` 需要 `Left`，则 load 仍保持 `Mat`，并由后续插入 `tile.move`。
 
+源类型为 `TensorLayout.MX_A_ZZ` / `MX_B_NN` 的 `tile.load` 必须显式携带
+`target_memory=Mat`；如果省略或传入其他目标，类型推导会在本 pass 运行前报错。
+
 ### 阶段 2 — Move 收集（`MoveCollector`）
 
 再次遍历函数体。对每个其算子带 `input_constraints` 的 `Call`，检查每个受约束输入变量在 `var_memory_` 中的解析结果是否在允许列表内。任何不匹配都会记录为 `MoveKey = (producer_var, target_space)` 加入 `needed_moves_`，其中 `target_space` 取该输入槽允许列表的第一个。阶段 3 会在每个外层 `SeqStmts` 作用域（即每个插入点缓存作用域）内最多为每个唯一 key 物化一个 `tile.move`，因此同一 `(producer_var, target_space)` 仍可能在兄弟作用域（如 `then` / `else` 分支）中分别物化。

--- a/include/pypto/ir/memory_space.h
+++ b/include/pypto/ir/memory_space.h
@@ -28,17 +28,21 @@ namespace ir {
  * - Right: Right matrix operand buffer
  * - Acc: Accumulator buffer
  * - Bias: Bias buffer
+ * - LeftScale: L0A-side MX block-scale buffer (A5)
+ * - RightScale: L0B-side MX block-scale buffer (A5)
  * - ScalarLocal: On-core scalar register file / C stack (for ArrayType)
  */
 enum class MemorySpace {
-  DDR,          ///< DDR memory (off-chip)
-  Vec,          ///< Vector/unified buffer (on-chip)
-  Mat,          ///< Matrix/L1 buffer
-  Left,         ///< Left matrix operand buffer
-  Right,        ///< Right matrix operand buffer
-  Acc,          ///< Accumulator buffer
-  Bias,         ///< Bias buffer
-  ScalarLocal,  ///< On-core scalar register file / C stack (for ArrayType)
+  DDR = 0,          ///< DDR memory (off-chip)
+  Vec = 1,          ///< Vector/unified buffer (on-chip)
+  Mat = 2,          ///< Matrix/L1 buffer
+  Left = 3,         ///< Left matrix operand buffer
+  Right = 4,        ///< Right matrix operand buffer
+  Acc = 5,          ///< Accumulator buffer
+  Bias = 6,         ///< Bias buffer
+  ScalarLocal = 7,  ///< On-core scalar register file / C stack (for ArrayType)
+  LeftScale = 8,    ///< L0A-side MX block-scale buffer (A5)
+  RightScale = 9,   ///< L0B-side MX block-scale buffer (A5)
 };
 
 /**

--- a/include/pypto/ir/pipe.h
+++ b/include/pypto/ir/pipe.h
@@ -78,13 +78,14 @@ enum CoreType : int {
  * - Right (L0B): right matrix input buffer
  * - Acc (L0C): accumulator/output buffer
  * - Mat (L1): staging buffer
+ * - LeftScale / RightScale: L0A/L0B MX block-scale sidecars (A5)
  *
  * @param space Memory space to check
  * @return true if the memory space is used by the CUBE core
  */
 inline bool IsCubeMemorySpace(MemorySpace space) {
   return space == MemorySpace::Left || space == MemorySpace::Right || space == MemorySpace::Acc ||
-         space == MemorySpace::Mat;
+         space == MemorySpace::Mat || space == MemorySpace::LeftScale || space == MemorySpace::RightScale;
 }
 
 }  // namespace ir

--- a/include/pypto/ir/tile_view_semantics.h
+++ b/include/pypto/ir/tile_view_semantics.h
@@ -27,6 +27,9 @@
 
 namespace pypto::ir::tile_view_semantics {
 
+/// MX block-scale fractal size: one shared exponent per 32 elements (A5 ISA).
+inline constexpr int kMXScaleFractal = 32;
+
 /// Return whether two shape-like expression lists are statically identical.
 inline bool ShapeExprListsEquivalent(const std::vector<ExprPtr>& lhs, const std::vector<ExprPtr>& rhs) {
   if (lhs.size() != rhs.size()) {
@@ -71,6 +74,18 @@ inline TileView GetImplicitTileView(const std::vector<ExprPtr>& shape,
         break;
       case MemorySpace::Right:
         implicit_view.slayout = TileLayout::col_major;
+        break;
+      case MemorySpace::LeftScale:
+        // ISA TileLeftScale: RowMajor / RowMajor, MX scale fractal size 32.
+        implicit_view.blayout = TileLayout::row_major;
+        implicit_view.slayout = TileLayout::row_major;
+        implicit_view.fractal = kMXScaleFractal;
+        break;
+      case MemorySpace::RightScale:
+        // ISA TileRightScale: ColMajor / ColMajor, MX scale fractal size 32.
+        implicit_view.blayout = TileLayout::col_major;
+        implicit_view.slayout = TileLayout::col_major;
+        implicit_view.fractal = kMXScaleFractal;
         break;
       case MemorySpace::Acc:
         implicit_view.blayout = TileLayout::col_major;

--- a/include/pypto/ir/transforms/utils/attrs.h
+++ b/include/pypto/ir/transforms/utils/attrs.h
@@ -110,8 +110,8 @@ inline constexpr const char* kPipelineDoubleBufferCAttr = "pipeline_double_buffe
 /// iteration i's compute); compute intermediates of different stages may still
 /// coalesce, because forbidding *all* cross-stage reuse (depth = F) overflows the
 /// on-chip budget on real kernels (e.g. stage=4 RMSNorm). The L0 matmul spaces
-/// (Left/Right/Acc/Bias) are exempt entirely — they are matmul-managed and
-/// capacity-bound.
+/// (Left/Right/Acc/Bias/LeftScale/RightScale) are exempt entirely — they are
+/// matmul-managed and capacity-bound.
 ///
 /// Value encoding (``std::string`` — round-trip-safe via the existing
 /// python-printer / ast-parser string-attr codec, with no integer-width

--- a/include/pypto/ir/transforms/utils/tensor_view_semantics.h
+++ b/include/pypto/ir/transforms/utils/tensor_view_semantics.h
@@ -95,7 +95,7 @@ inline std::vector<ExprPtr> BuildLogicalStridesFromLayout(const std::vector<Expr
   size_t ndim = shape.size();
   if (ndim == 0) return {};
 
-  if (layout == TensorLayout::ND) {
+  if (layout == TensorLayout::ND || IsMxTensorLayout(layout)) {
     return BuildRowMajorStrides(shape);
   }
 
@@ -226,9 +226,9 @@ inline CanonicalCheckResult CheckCanonicalView(const std::vector<ExprPtr>& shape
 
   size_t n = shape.size();
 
-  if (layout == TensorLayout::ND) {
+  if (layout == TensorLayout::ND || IsMxTensorLayout(layout)) {
     if (!detail::IsConstOne(stride[n - 1])) {
-      return {false, "ND layout requires innermost stride to be ConstInt(1)"};
+      return {false, TensorLayoutToString(layout) + " layout requires innermost stride to be ConstInt(1)"};
     }
     // Outer-dim strided family: stride[k] >= stride[k+1] * shape[k+1].
     // Statically decidable cases enforce; symbolic cases pass under relaxed_symbolic.
@@ -237,12 +237,13 @@ inline CanonicalCheckResult CheckCanonicalView(const std::vector<ExprPtr>& shape
       auto cmp = detail::StaticGreaterEqual(stride[k], packed);
       if (cmp.has_value() && !*cmp) {
         std::ostringstream oss;
-        oss << "ND stride[" << k << "] is smaller than packed stride[" << (k + 1) << "] * shape[" << (k + 1)
-            << "]";
+        oss << TensorLayoutToString(layout) << " stride[" << k << "] is smaller than packed stride["
+            << (k + 1) << "] * shape[" << (k + 1) << "]";
         return {false, oss.str()};
       }
       if (!cmp.has_value() && !relaxed_symbolic) {
-        return {false, "ND outer-dim stride relation is symbolic and cannot be statically verified"};
+        return {false, TensorLayoutToString(layout) +
+                           " outer-dim stride relation is symbolic and cannot be statically verified"};
       }
     }
     return {true, ""};

--- a/include/pypto/ir/type.h
+++ b/include/pypto/ir/type.h
@@ -135,10 +135,17 @@ using ScalarTypePtr = std::shared_ptr<const ScalarType>;
  * - NZ: NZ layout
  */
 enum class TensorLayout {
-  ND,  ///< ND layout
-  DN,  ///< DN layout
-  NZ   ///< NZ layout
+  ND,       ///< ND layout
+  DN,       ///< DN layout
+  NZ,       ///< NZ layout
+  MX_A_ZZ,  ///< MX Left/A scale GM pack (ZZ)
+  MX_B_NN   ///< MX Right/B scale GM pack (NN)
 };
+
+/** True when layout selects the MX scale GM load path (TLoadMxCube*). */
+inline bool IsMxTensorLayout(TensorLayout layout) {
+  return layout == TensorLayout::MX_A_ZZ || layout == TensorLayout::MX_B_NN;
+}
 
 /**
  * @brief Convert TensorLayout enum to string

--- a/python/bindings/modules/ir.cpp
+++ b/python/bindings/modules/ir.cpp
@@ -359,6 +359,8 @@ void BindIR(nb::module_& m) {
       .value("ND", TensorLayout::ND, "ND layout")
       .value("DN", TensorLayout::DN, "DN layout")
       .value("NZ", TensorLayout::NZ, "NZ layout")
+      .value("MX_A_ZZ", TensorLayout::MX_A_ZZ, "MX Left/A scale GM pack (ZZ)")
+      .value("MX_B_NN", TensorLayout::MX_B_NN, "MX Right/B scale GM pack (NN)")
       .export_values();
 
   // PadValue enum - must be before both TensorView and TileView since both carry it
@@ -596,6 +598,8 @@ void BindIR(nb::module_& m) {
       .value("Right", MemorySpace::Right, "Right matrix operand buffer")
       .value("Acc", MemorySpace::Acc, "Accumulator buffer")
       .value("Bias", MemorySpace::Bias, "Bias buffer")
+      .value("LeftScale", MemorySpace::LeftScale, "L0A-side MX block-scale buffer (A5)")
+      .value("RightScale", MemorySpace::RightScale, "L0B-side MX block-scale buffer (A5)")
       .value("ScalarLocal", MemorySpace::ScalarLocal, "On-core scalar register file / C stack (ArrayType)")
       .export_values();
 

--- a/python/pypto/ir/op/tile_ops.py
+++ b/python/pypto/ir/op/tile_ops.py
@@ -28,6 +28,7 @@ from pypto.pypto_core.ir import (
     PadValue,
     ScalarType,
     Span,
+    TensorLayout,
     TileLayout,
 )
 
@@ -187,7 +188,8 @@ def load(
             the actual valid data region differs from the allocated tile size.
             Uses the same coordinate convention as shapes. This is a *request*: it
             narrows the tile, but cannot widen it past what the source has.
-        target_memory: Target memory space (MemorySpace.Vec default, or MemorySpace.Mat)
+        target_memory: Target memory space (MemorySpace.Vec default, or MemorySpace.Mat).
+            MX-layout tensors require an explicit MemorySpace.Mat.
         clamp: Sanction a read that runs off the end of the source. By default a
             load asserts that ``offsets + valid_shapes`` stays inside the source
             and is rejected when that provably fails; with ``clamp=True`` the
@@ -201,6 +203,16 @@ def load(
         >>> # 2D load
         >>> tile = load(tensor, offsets=[0, 0], shapes=[32, 32])
     """
+    tensor_view = getattr(tensor.type, "tensor_view", None)
+    source_layout = getattr(tensor_view, "layout", None)
+    is_mx = source_layout in (TensorLayout.MX_A_ZZ, TensorLayout.MX_B_NN)
+
+    if is_mx and target_memory != MemorySpace.Mat:
+        raise ValueError(
+            "tile.load of an MX-layout tensor requires explicit target_memory=MemorySpace.Mat "
+            f"(MX scale loads are L1/Mat only); got {target_memory}"
+        )
+
     # Validate target_memory: only Vec and Mat are allowed for load
     if target_memory not in (MemorySpace.Vec, MemorySpace.Mat):
         raise ValueError(
@@ -216,7 +228,6 @@ def load(
     kwargs: dict[str, Any] = {"target_memory": target_memory}
     if clamp:
         kwargs["clamp"] = True
-
     valid_shapes_tuple = shapes_tuple
     if valid_shapes is not None:
         valid_shapes_tuple = _to_make_tuple(valid_shapes, actual_span)
@@ -472,7 +483,8 @@ def move(
 
     Args:
         tile: Input tile (TileType)
-        target_memory: Target memory space (MemorySpace.Vec, .Mat, .Left, .Right)
+        target_memory: Target memory space (MemorySpace.Vec, .Mat, .Left, .Right,
+            .LeftScale, .RightScale)
         blayout: Optional block layout for the destination tile
         slayout: Optional scatter layout for the destination tile
         span: Optional source span for debugging (auto-captured if not provided)
@@ -481,8 +493,6 @@ def move(
         Call expression that returns a TileType in the target memory space
     """
     actual_span = _get_span_or_capture(span)
-    args = [tile]
-
     kwargs: dict[str, Any] = {
         "target_memory": target_memory,
     }
@@ -491,7 +501,7 @@ def move(
     if slayout is not None:
         kwargs["slayout"] = slayout
 
-    return _ir_core.create_op_call("tile.move", args, kwargs, actual_span)
+    return _ir_core.create_op_call("tile.move", [tile], kwargs, actual_span)
 
 
 def get_block_idx(span: Span | None = None) -> Call:

--- a/python/pypto/ir/type.py
+++ b/python/pypto/ir/type.py
@@ -35,10 +35,14 @@ from .utils import _normalize_expr, _normalize_shape
 _native_tensor_type_init = TensorType.__init__
 _native_tile_type_init = TileType.__init__
 
+# Longer prefixes first so mem_leftscale_ does not match mem_left_.
+# Names come from MemorySpaceToString().lower() (e.g. LeftScale -> leftscale).
 _MEMREF_NAME_PREFIX_TO_SPACE = {
     "mem_ddr_": MemorySpace.DDR,
     "mem_vec_": MemorySpace.Vec,
     "mem_mat_": MemorySpace.Mat,
+    "mem_leftscale_": MemorySpace.LeftScale,
+    "mem_rightscale_": MemorySpace.RightScale,
     "mem_left_": MemorySpace.Left,
     "mem_right_": MemorySpace.Right,
     "mem_acc_": MemorySpace.Acc,

--- a/python/pypto/language/__init__.py
+++ b/python/pypto/language/__init__.py
@@ -254,6 +254,8 @@ Ptr = PtrType
 ND = TensorLayout.ND
 DN = TensorLayout.DN
 NZ = TensorLayout.NZ
+MX_A_ZZ = TensorLayout.MX_A_ZZ
+MX_B_NN = TensorLayout.MX_B_NN
 
 # Re-export DataType constants for convenience
 FP4 = DataType.FP4
@@ -495,6 +497,8 @@ __all__ = [
     "ND",
     "DN",
     "NZ",
+    "MX_A_ZZ",
+    "MX_B_NN",
     "FP4",
     "FP8E4M3FN",
     "FP8E5M2",

--- a/python/pypto/language/op/tile_ops.py
+++ b/python/pypto/language/op/tile_ops.py
@@ -380,7 +380,8 @@ def load(
             coordinate system.
         shapes: Shape of the region to load in each dimension. Always in the
             source tensor's coordinate system.
-        target_memory: Target memory space (MemorySpace.Vec default, or MemorySpace.Mat)
+        target_memory: Target memory space (MemorySpace.Vec default, or MemorySpace.Mat).
+            MX-layout tensors require an explicit MemorySpace.Mat.
         valid_shapes: Valid shape of the tile in each dimension. When provided, sets
             TileView.valid_shape in the output TileType. When omitted, shapes is used
             as valid_shape. Uses the same coordinate convention as shapes. Narrows
@@ -600,14 +601,20 @@ def move(
 
     Args:
         tile: Input tile
-        target_memory: Target memory space (MemorySpace.Vec, .Mat, .Left, .Right)
+        target_memory: Target memory space (MemorySpace.Vec, .Mat, .Left, .Right,
+            .LeftScale, .RightScale)
         blayout: Optional block layout for the destination tile
         slayout: Optional scatter layout for the destination tile
 
     Returns:
         Tile wrapping the move operation
     """
-    call_expr = _ir_ops.move(tile.unwrap(), target_memory, blayout=blayout, slayout=slayout)
+    call_expr = _ir_ops.move(
+        tile.unwrap(),
+        target_memory,
+        blayout=blayout,
+        slayout=slayout,
+    )
     return Tile(expr=call_expr)
 
 

--- a/python/pypto/language/parser/type_resolver.py
+++ b/python/pypto/language/parser/type_resolver.py
@@ -61,6 +61,16 @@ def _implicit_tile_view_defaults(
         default_blayout = ir.TileLayout.col_major
         default_slayout = ir.TileLayout.row_major
         default_fractal = 1024
+    elif memory_space == ir.MemorySpace.LeftScale:
+        # ISA TileLeftScale: RowMajor / RowMajor, MX scale fractal size 32.
+        default_blayout = ir.TileLayout.row_major
+        default_slayout = ir.TileLayout.row_major
+        default_fractal = 32
+    elif memory_space == ir.MemorySpace.RightScale:
+        # ISA TileRightScale: ColMajor / ColMajor, MX scale fractal size 32.
+        default_blayout = ir.TileLayout.col_major
+        default_slayout = ir.TileLayout.col_major
+        default_fractal = 32
     return default_blayout, default_slayout, default_fractal
 
 
@@ -177,6 +187,8 @@ class TypeResolver:
         "ND": ir.TensorLayout.ND,
         "DN": ir.TensorLayout.DN,
         "NZ": ir.TensorLayout.NZ,
+        "MX_A_ZZ": ir.TensorLayout.MX_A_ZZ,
+        "MX_B_NN": ir.TensorLayout.MX_B_NN,
     }
 
     _MEMORY_SPACE_MAP: dict[str, "ir.MemorySpace"] = {
@@ -187,6 +199,8 @@ class TypeResolver:
         "Right": ir.MemorySpace.Right,
         "Acc": ir.MemorySpace.Acc,
         "Bias": ir.MemorySpace.Bias,
+        "LeftScale": ir.MemorySpace.LeftScale,
+        "RightScale": ir.MemorySpace.RightScale,
     }
 
     def __init__(
@@ -1315,7 +1329,7 @@ class TypeResolver:
         raise ParserTypeError(
             f"Cannot resolve layout: {ast.unparse(layout_node)}",
             span=span,
-            hint="Use pl.ND, pl.DN, or pl.NZ",
+            hint="Use pl.ND, pl.DN, pl.NZ, pl.MX_A_ZZ, or pl.MX_B_NN",
         )
 
     def validate_annotation_consistency(

--- a/python/pypto/pypto_core/ir.pyi
+++ b/python/pypto/pypto_core/ir.pyi
@@ -344,6 +344,12 @@ class TensorLayout(enum.Enum):
     NZ = ...
     """NZ layout."""
 
+    MX_A_ZZ = ...
+    """MX Left/A scale GM pack (ZZ)."""
+
+    MX_B_NN = ...
+    """MX Right/B scale GM pack (NN)."""
+
 class TileLayout(enum.Enum):
     """Tile layout enumeration (shared by blayout and slayout)."""
 
@@ -999,6 +1005,10 @@ class MemorySpace(enum.Enum):
 
     Bias = ...
     """Bias buffer."""
+    LeftScale = ...
+    """L0A-side MX block-scale buffer (A5)."""
+    RightScale = ...
+    """L0B-side MX block-scale buffer (A5)."""
 
     ScalarLocal = ...
     """On-core scalar register file / C stack (ArrayType)."""

--- a/python/pypto/tools/memory_map.py
+++ b/python/pypto/tools/memory_map.py
@@ -37,7 +37,7 @@ COMPUTE_FUNC_TYPES = frozenset({"AIC", "AIV", "InCore"})
 
 #: Left-to-right panel order. Spaces the backend reports but that are missing
 #: here are appended rather than dropped, so a new memory space still maps.
-SPACE_ORDER = ("Vec", "Mat", "Left", "Right", "Acc", "Bias")
+SPACE_ORDER = ("Vec", "Mat", "Left", "LeftScale", "Right", "RightScale", "Acc", "Bias")
 
 #: Used when the dump's target architecture cannot be determined.
 DEFAULT_BACKEND = "Ascend910B"
@@ -460,9 +460,9 @@ def backend_limits(backend_name: str) -> dict[str, int]:
     """Read the capacity of every on-chip memory space a backend describes.
 
     Walking the SoC rather than querying a fixed list of spaces means a backend
-    that carries an extra space (Ascend950 has ``Bias``) gets a real capacity
-    instead of falling back to its own high-water mark, which would render that
-    panel permanently full.
+    that carries an extra space (Ascend950 has ``Bias`` / ``LeftScale`` /
+    ``RightScale``) gets a real capacity instead of falling back to its own
+    high-water mark, which would render that panel permanently full.
 
     Args:
         backend_name: A :class:`BackendType` member name, e.g. ``"Ascend910B"``.

--- a/python/pypto/tools/templates/memory_map.html
+++ b/python/pypto/tools/templates/memory_map.html
@@ -33,7 +33,9 @@
     --sp-Vec:   #2a78d6;
     --sp-Mat:   #eb6834;
     --sp-Left:  #1baf7a;
+    --sp-LeftScale: #5ecfa3;
     --sp-Right: #eda100;
+    --sp-RightScale: #f0c45a;
     --sp-Acc:   #e87ba4;
     --sp-Bias:  #8a5cd0;
     /* Fallback for a space this template has no colour for. Every name in
@@ -54,7 +56,8 @@
       --line: #383937; --line-soft: #292a29;
       --ink: #f1f1ee; --ink-2: #b2b3ac; --ink-3: #82837d;
       --sp-Vec: #3987e5; --sp-Mat: #d95926; --sp-Left: #199e70;
-      --sp-Right: #c98500; --sp-Acc: #d55181; --sp-Bias: #9b71dd;
+      --sp-LeftScale: #4fc496; --sp-Right: #c98500; --sp-RightScale: #dbb34a;
+      --sp-Acc: #d55181; --sp-Bias: #9b71dd;
       --sp-unknown: #82837d;
       --tint: 20%;
     }
@@ -65,7 +68,8 @@
     --line: #383937; --line-soft: #292a29;
     --ink: #f1f1ee; --ink-2: #b2b3ac; --ink-3: #82837d;
     --sp-Vec: #3987e5; --sp-Mat: #d95926; --sp-Left: #199e70;
-    --sp-Right: #c98500; --sp-Acc: #d55181; --sp-Bias: #9b71dd;
+    --sp-LeftScale: #4fc496; --sp-Right: #c98500; --sp-RightScale: #dbb34a;
+    --sp-Acc: #d55181; --sp-Bias: #9b71dd;
     --sp-unknown: #82837d;
     --tint: 20%;
   }

--- a/src/backend/common/pto_ops_distributed.cpp
+++ b/src/backend/common/pto_ops_distributed.cpp
@@ -255,6 +255,12 @@ PeerViewInfo EmitCommRemoteView(const DistTensorBinding& target, const ExprPtr& 
     case ir::TensorLayout::NZ:
       layout_str = "nz";
       break;
+    case ir::TensorLayout::MX_A_ZZ:
+      layout_str = "mx_a_zz";
+      break;
+    case ir::TensorLayout::MX_B_NN:
+      layout_str = "mx_b_nn";
+      break;
     case ir::TensorLayout::ND:
       break;
   }

--- a/src/backend/common/pto_ops_memory.cpp
+++ b/src/backend/common/pto_ops_memory.cpp
@@ -114,6 +114,17 @@ static std::string MakeTileLoadCodegenPTO(const CallPtr& op, codegen::CodegenBas
   std::string tensor_view_type = codegen.GetTensorViewTypeString(tensor_type.get());
   std::string tile_buf_type = codegen.GetCurrentResultTileBufTypeString();
 
+  // PTOAS needs the MX layout on tload in addition to the source TensorView.
+  std::string pto_layout;
+  if (tensor_type->tensor_view_.has_value()) {
+    if (tensor_type->tensor_view_->layout == ir::TensorLayout::MX_A_ZZ) {
+      pto_layout = "mx_a_zz";
+    } else if (tensor_type->tensor_view_->layout == ir::TensorLayout::MX_B_NN) {
+      pto_layout = "mx_b_nn";
+    }
+  }
+  const bool is_mx_load = !pto_layout.empty();
+
   // RFC #1300 P7: the IR's offsets / shapes / valid_shapes are already in
   // canonical coordinates (matching the source TensorType's shape). There is
   // no implicit dn_swap here — earlier passes ensure all coordinate systems
@@ -129,6 +140,9 @@ static std::string MakeTileLoadCodegenPTO(const CallPtr& op, codegen::CodegenBas
   std::ostringstream tload_line;
   tload_line << "pto.tload ins(" << partition_view << " : " << partition_type << ") outs(";
   tload_line << tile_buf << " : " << tile_buf_type << ")";
+  if (is_mx_load) {
+    tload_line << " {layout = #pto.layout<" << pto_layout << ">}";
+  }
   codegen.Emit(tload_line.str());
 
   // No follow-up `pto.set_validshape` is emitted: every `pto.alloc_tile`
@@ -747,6 +761,12 @@ void RegisterMemoryOps(Backend& backend, const std::unordered_set<std::string>& 
         break;
       case ir::TensorLayout::NZ:
         layout_str = "nz";
+        break;
+      case ir::TensorLayout::MX_A_ZZ:
+        layout_str = "mx_a_zz";
+        break;
+      case ir::TensorLayout::MX_B_NN:
+        layout_str = "mx_b_nn";
         break;
       case ir::TensorLayout::ND:
         break;

--- a/src/backend/common/soc.cpp
+++ b/src/backend/common/soc.cpp
@@ -162,11 +162,13 @@ const SoC& Create950SoC() {
   static SoC soc = []() {
     // AIC (CUBE) core configuration
     Core aic_core(ir::CoreType::CUBE, {
-                                          Mem(ir::MemorySpace::Mat, 512ULL * 1024, 128),  // 512KB Mat
-                                          Mem(ir::MemorySpace::Left, 64ULL * 1024, 64),   // 64KB Left
-                                          Mem(ir::MemorySpace::Right, 64ULL * 1024, 64),  // 64KB Right
-                                          Mem(ir::MemorySpace::Acc, 256ULL * 1024, 128),  // 256KB Acc
-                                          Mem(ir::MemorySpace::Bias, 4ULL * 1024, 64)     // 4KB Bias
+                                          Mem(ir::MemorySpace::Mat, 512ULL * 1024, 128),     // 512KB Mat
+                                          Mem(ir::MemorySpace::Left, 64ULL * 1024, 64),      // 64KB Left
+                                          Mem(ir::MemorySpace::Right, 64ULL * 1024, 64),     // 64KB Right
+                                          Mem(ir::MemorySpace::Acc, 256ULL * 1024, 128),     // 256KB Acc
+                                          Mem(ir::MemorySpace::Bias, 4ULL * 1024, 64),       // 4KB Bias
+                                          Mem(ir::MemorySpace::LeftScale, 4ULL * 1024, 32),  // 4KB L0A scale
+                                          Mem(ir::MemorySpace::RightScale, 4ULL * 1024, 32)  // 4KB L0B scale
                                       });
 
     // AIV (VECTOR) core configuration.
@@ -188,7 +190,8 @@ const SoC& Create950SoC() {
     std::map<ir::MemorySpace, std::vector<ir::MemorySpace>> mem_graph;
     mem_graph[ir::MemorySpace::DDR] = {ir::MemorySpace::Vec, ir::MemorySpace::Mat};
     mem_graph[ir::MemorySpace::Vec] = {ir::MemorySpace::Mat, ir::MemorySpace::DDR};
-    mem_graph[ir::MemorySpace::Mat] = {ir::MemorySpace::Left, ir::MemorySpace::Right};
+    mem_graph[ir::MemorySpace::Mat] = {ir::MemorySpace::Left, ir::MemorySpace::Right,
+                                       ir::MemorySpace::LeftScale, ir::MemorySpace::RightScale};
     mem_graph[ir::MemorySpace::Acc] = {ir::MemorySpace::Vec, ir::MemorySpace::Mat, ir::MemorySpace::DDR};
 
     return SoC(die, 2, std::move(mem_graph));

--- a/src/codegen/pto/pto_codegen.cpp
+++ b/src/codegen/pto/pto_codegen.cpp
@@ -931,10 +931,10 @@ void PTOCodegen::EmitMakeTensorViews(const FunctionPtr& func) {
   // time codegen executes, so the IR's TensorView fields can be transcribed
   // verbatim.
   //
-  // The one exception is the ``[M, 1]`` column-vector special case: PTOAS
-  // *infers* DN for shape ``[M, 1]`` with degenerate strides regardless of
-  // the IR-declared layout, so the codegen forces DN + ``[1, M]`` strides
-  // here to match what PTOAS expects.
+  // The one exception is the ordinary ``[M, 1]`` column-vector special case:
+  // PTOAS *infers* DN for shape ``[M, 1]`` with degenerate strides regardless
+  // of an ND declaration, so codegen forces DN + ``[1, M]`` strides. MX
+  // layouts are explicit hardware contracts and bypass this legacy override.
   for (const auto& param : func->params_) {
     auto tensor_type = ir::AsTensorTypeLike(param->GetType());
     if (!tensor_type) continue;
@@ -963,7 +963,8 @@ void PTOCodegen::EmitMakeTensorViews(const FunctionPtr& func) {
     if (tensor_type->tensor_view_.has_value()) {
       layout = tensor_type->tensor_view_->layout;
     }
-    if (is_column_vector) layout = ir::TensorLayout::DN;
+    const bool force_column_vector_dn = is_column_vector && !IsMxTensorLayout(layout);
+    if (force_column_vector_dn) layout = ir::TensorLayout::DN;
 
     // Materialize one shape dimension as an MLIR SSA value.
     auto get_shape_dim_mlir = [&](size_t dim_idx) -> std::string {
@@ -1014,7 +1015,7 @@ void PTOCodegen::EmitMakeTensorViews(const FunctionPtr& func) {
       for (size_t j = 0; j < rank; ++j) {
         stride_names[j] = get_stride_mlir(strides[j]);
       }
-    } else if (is_column_vector) {
+    } else if (force_column_vector_dn) {
       // Forced-DN ``[..., M, 1]`` legacy stride pattern (PTOAS column-vector
       // convention): trailing pair degenerates to ``stride[rank-2]=1`` and
       // ``stride[rank-1]=shape[rank-1]=1``; outer dims walk row-major over the
@@ -1088,6 +1089,12 @@ void PTOCodegen::EmitMakeTensorViews(const FunctionPtr& func) {
         break;
       case ir::TensorLayout::NZ:
         layout_str = "nz";
+        break;
+      case ir::TensorLayout::MX_A_ZZ:
+        layout_str = "mx_a_zz";
+        break;
+      case ir::TensorLayout::MX_B_NN:
+        layout_str = "mx_b_nn";
         break;
       case ir::TensorLayout::ND:
         break;

--- a/src/codegen/pto/pto_type_utils.cpp
+++ b/src/codegen/pto/pto_type_utils.cpp
@@ -103,6 +103,10 @@ std::string MemorySpaceToMLIR(ir::MemorySpace space) {
     return "acc";
   } else if (space == ir::MemorySpace::Bias) {
     return "bias";
+  } else if (space == ir::MemorySpace::LeftScale || space == ir::MemorySpace::RightScale) {
+    // PTOAS v0.48 exposes a single MLIR loc `scaling` for scale / fixpipe buffers
+    // (TileType::ScaleLeft/ScaleRight are not yet distinct tile_buf locs).
+    return "scaling";
   } else {
     throw ValueError("Invalid MemorySpace value");
   }

--- a/src/ir/memref.cpp
+++ b/src/ir/memref.cpp
@@ -43,6 +43,10 @@ std::string MemorySpaceToString(MemorySpace space) {
       return "Acc";
     case MemorySpace::Bias:
       return "Bias";
+    case MemorySpace::LeftScale:
+      return "LeftScale";
+    case MemorySpace::RightScale:
+      return "RightScale";
     case MemorySpace::ScalarLocal:
       return "ScalarLocal";
     default:
@@ -58,6 +62,8 @@ MemorySpace StringToMemorySpace(const std::string& str) {
   if (str == "Right") return MemorySpace::Right;
   if (str == "Acc") return MemorySpace::Acc;
   if (str == "Bias") return MemorySpace::Bias;
+  if (str == "LeftScale") return MemorySpace::LeftScale;
+  if (str == "RightScale") return MemorySpace::RightScale;
   if (str == "ScalarLocal") return MemorySpace::ScalarLocal;
   throw pypto::ValueError("Unknown MemorySpace: " + str);
 }

--- a/src/ir/op/distributed/remote_load.cpp
+++ b/src/ir/op/distributed/remote_load.cpp
@@ -106,6 +106,8 @@ TypePtr DeduceRemoteLoadType(const std::vector<ExprPtr>& args,
   auto dist_type = As<DistributedTensorType>(args[0]->GetType());
   CHECK(dist_type) << "pld.tile.remote_load target must be a DistributedTensor (window-bound), got "
                    << args[0]->GetType()->TypeName();
+  CHECK_SPAN(!dist_type->tensor_view_ || !IsMxTensorLayout(dist_type->tensor_view_->layout), args[0]->span_)
+      << "pld.tile.remote_load does not support MX-layout tensors";
 
   // peer must be a scalar (integer rank index). Allow any ScalarType — dtype
   // narrowing to integer is handled at codegen time when emitting the
@@ -197,6 +199,9 @@ TypePtr DeduceRemoteLoadType(const std::vector<ExprPtr>& args,
         break;
       case TensorLayout::NZ:
         break;
+      case TensorLayout::MX_A_ZZ:
+      case TensorLayout::MX_B_NN:
+        INTERNAL_CHECK(false) << "MX layouts were rejected before remote-load layout deduction";
     }
   }
 

--- a/src/ir/op/tensor_ops/memory.cpp
+++ b/src/ir/op/tensor_ops/memory.cpp
@@ -166,6 +166,9 @@ TypePtr DeduceTensorSliceType(const std::vector<ExprPtr>& args,
   CHECK(tensor_type) << "tensor.slice requires first argument to be a TensorType or DistributedTensorType, "
                         "but got "
                      << args[0]->GetType()->TypeName();
+  CHECK_SPAN(!tensor_type->tensor_view_ || !IsMxTensorLayout(tensor_type->tensor_view_->layout),
+             args[0]->span_)
+      << "tensor.slice does not support MX-layout tensors";
 
   // Second argument must be TupleType (shape)
   auto shape_tuple_type = As<TupleType>(args[1]->GetType());

--- a/src/ir/op/tensor_ops/transform.cpp
+++ b/src/ir/op/tensor_ops/transform.cpp
@@ -147,6 +147,9 @@ TypePtr DeduceTensorReshapeType(const std::vector<ExprPtr>& args,
   auto tensor_type = As<TensorType>(args[0]->GetType());
   CHECK(tensor_type) << "tensor.reshape requires first argument to be a TensorType, but got "
                      << args[0]->GetType()->TypeName();
+  CHECK_SPAN(!tensor_type->tensor_view_ || !IsMxTensorLayout(tensor_type->tensor_view_->layout),
+             args[0]->span_)
+      << "tensor.reshape does not support MX-layout tensors";
 
   // Second argument must be TupleType (shape)
   auto shape_tuple_type = As<TupleType>(args[1]->GetType());
@@ -254,6 +257,9 @@ TypePtr DeduceTensorReinterpretViewType(const std::vector<ExprPtr>& args,
   auto tensor_type = As<TensorType>(args[0]->GetType());
   CHECK_SPAN(tensor_type, args[0]->span_)
       << kOpName << " requires data to be a TensorType, but got " << args[0]->GetType()->TypeName();
+  CHECK_SPAN(!tensor_type->tensor_view_ || !IsMxTensorLayout(tensor_type->tensor_view_->layout),
+             args[0]->span_)
+      << kOpName << " does not support MX-layout tensors";
   CHECK_SPAN(!tensor_type->shape_.empty(), args[0]->span_) << kOpName << " requires a tensor rank >= 1";
 
   const DataType target_dtype = GetRequiredKwarg<DataType>(kwargs, "dtype", kOpName);
@@ -314,6 +320,9 @@ TypePtr DeduceTensorTransposeType(const std::vector<ExprPtr>& args,
   auto tensor_type = As<TensorType>(args[0]->GetType());
   CHECK(tensor_type) << "tensor.transpose requires first argument to be a TensorType, but got "
                      << args[0]->GetType()->TypeName();
+  CHECK_SPAN(!tensor_type->tensor_view_ || !IsMxTensorLayout(tensor_type->tensor_view_->layout),
+             args[0]->span_)
+      << "tensor.transpose does not support MX-layout tensors";
 
   const auto& input_shape = tensor_type->shape_;
   size_t ndim = input_shape.size();
@@ -471,6 +480,8 @@ TypePtr DeduceTensorViewType(const std::vector<ExprPtr>& args,
   TensorLayout src_layout =
       src_type->tensor_view_.has_value() ? src_type->tensor_view_->layout : TensorLayout::ND;
   TensorLayout new_layout = requested_layout.value_or(src_layout);
+  CHECK_SPAN(!IsMxTensorLayout(src_layout) && !IsMxTensorLayout(new_layout), args[0]->span_)
+      << "tensor.view does not support MX layouts";
   CHECK(new_layout != TensorLayout::NZ)
       << "tensor.view: NZ layout is not allowed on TensorType (NZ is tile-only)";
   CHECK(src_layout != TensorLayout::NZ)

--- a/src/ir/op/tile_ops/memory.cpp
+++ b/src/ir/op/tile_ops/memory.cpp
@@ -38,6 +38,7 @@
 #include "pypto/ir/op_registry.h"
 #include "pypto/ir/scalar_expr.h"
 #include "pypto/ir/tile_view_semantics.h"
+#include "pypto/ir/transforms/utils/tensor_view_semantics.h"
 #include "pypto/ir/type.h"
 #include "pypto/ir/type_inference.h"
 
@@ -146,6 +147,34 @@ TypePtr DeduceTileLoadType(const std::vector<ExprPtr>& args,
       break;
     }
   }
+  const bool is_mx_load =
+      tensor_type->tensor_view_.has_value() && IsMxTensorLayout(tensor_type->tensor_view_->layout);
+  if (is_mx_load) {
+    CHECK(tensor_type->dtype_ == DataType::FP8E8M0 || tensor_type->dtype_ == DataType::UINT8)
+        << "The operator " << op_name << " of an MX-layout tensor requires FP8E8M0 or UINT8 dtype, but got "
+        << tensor_type->dtype_.ToString();
+    CHECK(tensor_type->shape_.size() == 2)
+        << "The operator " << op_name << " of an MX-layout tensor requires a 2D tensor, got rank "
+        << tensor_type->shape_.size();
+    CHECK(shapes_tuple->elements_.size() == 2)
+        << "The operator " << op_name << " of an MX-layout tensor requires a 2D load window, got rank "
+        << shapes_tuple->elements_.size();
+    CHECK(valid_shapes_tuple->elements_.size() == 2)
+        << "The operator " << op_name << " of an MX-layout tensor requires 2D valid_shapes, got rank "
+        << valid_shapes_tuple->elements_.size();
+    const TensorView& source_view = *tensor_type->tensor_view_;
+    const auto packed_stride =
+        tensor_view_semantics::BuildLogicalStridesFromLayout(tensor_type->shape_, source_view.layout);
+    CHECK(source_view.stride.empty() ||
+          tile_view_semantics::ShapeExprListsEquivalent(source_view.stride, packed_stride))
+        << "The operator " << op_name
+        << " of an MX-layout tensor only supports packed 2D sources; strided sources are not supported";
+    // MX cube scale loads are Mat-only (TLoadMxCube*) and require the caller to
+    // spell the target explicitly. The public load interface keeps its ordinary
+    // Vec default, so an omitted target fails instead of being silently changed.
+    CHECK(target_memory_opt.has_value() && *target_memory_opt == MemorySpace::Mat)
+        << "The operator " << op_name << " of an MX-layout tensor requires target_memory=MemorySpace.Mat";
+  }
   // Nz/Zn layout: only chosen when target_memory is known. If it is absent,
   // the default-constructed view is kept and InferTileMemorySpace rebuilds it
   // once the memory space is resolved.
@@ -158,7 +187,18 @@ TypePtr DeduceTileLoadType(const std::vector<ExprPtr>& args,
   bool source_is_dn =
       tensor_type->tensor_view_.has_value() && tensor_type->tensor_view_->layout == TensorLayout::DN;
   TileView tile_view;
-  if (target_memory_opt.has_value()) {
+  if (is_mx_load) {
+    // A5 TLoadMxCubeCheck: MX_A_* → row-major ZZ (SFractal=32); MX_B_* → col-major NN.
+    const bool is_mx_b = tensor_type->tensor_view_->layout == TensorLayout::MX_B_NN;
+    if (is_mx_b) {
+      tile_view.blayout = TileLayout::col_major;
+      tile_view.slayout = TileLayout::col_major;
+    } else {
+      tile_view.blayout = TileLayout::row_major;
+      tile_view.slayout = TileLayout::row_major;
+    }
+    tile_view.fractal = 32;
+  } else if (target_memory_opt.has_value()) {
     if (*target_memory_opt == MemorySpace::Mat) {
       tile_view.blayout = TileLayout::col_major;
       tile_view.slayout = TileLayout::row_major;
@@ -373,18 +413,36 @@ TypePtr DeduceTileMoveType(const std::vector<ExprPtr>& args,
   tile_view.blayout = source_view.blayout;
   tile_view.slayout = source_view.slayout;
 
-  // Hardcoded layout for Left/Right (hardware requirements)
+  // Hardcoded layout for Left/Right/scale (hardware requirements)
   if (space == MemorySpace::Left) {
     tile_view.blayout = TileLayout::col_major;  // L0A requires ColMajor block layout for TMATMUL
     tile_view.slayout = TileLayout::row_major;
   } else if (space == MemorySpace::Right) {
     tile_view.blayout = TileLayout::row_major;
     tile_view.slayout = TileLayout::col_major;
+  } else if (space == MemorySpace::LeftScale) {
+    tile_view.blayout = TileLayout::row_major;
+    tile_view.slayout = TileLayout::row_major;
+    tile_view.fractal = 32;
+  } else if (space == MemorySpace::RightScale) {
+    tile_view.blayout = TileLayout::col_major;
+    tile_view.slayout = TileLayout::col_major;
+    tile_view.fractal = 32;
   }
 
-  // Explicit kwargs override everything
-  tile_view.blayout = GetKwarg<TileLayout>(kwargs, "blayout", tile_view.blayout);
-  tile_view.slayout = GetKwarg<TileLayout>(kwargs, "slayout", tile_view.slayout);
+  // Ordinary destinations permit explicit layouts. Scale destinations have
+  // hardware-fixed layouts because PTOAS uses them to distinguish ScaleLeft
+  // from ScaleRight even though both lower to loc=scaling.
+  const TileLayout requested_blayout = GetKwarg<TileLayout>(kwargs, "blayout", tile_view.blayout);
+  const TileLayout requested_slayout = GetKwarg<TileLayout>(kwargs, "slayout", tile_view.slayout);
+  if (space == MemorySpace::LeftScale || space == MemorySpace::RightScale) {
+    CHECK(requested_blayout == tile_view.blayout && requested_slayout == tile_view.slayout)
+        << "The operator " << op_name
+        << " does not allow blayout/slayout to override the hardware-fixed layout for "
+        << MemorySpaceToString(space);
+  }
+  tile_view.blayout = requested_blayout;
+  tile_view.slayout = requested_slayout;
 
   // Keep original shape
   std::vector<ExprPtr> output_shape = input_shape;
@@ -397,6 +455,37 @@ TypePtr DeduceTileMoveType(const std::vector<ExprPtr>& args,
     tile_view.pad = source_view.pad;
   }
 
+  // MX LeftScale/RightScale must be !pto.f8E8M0 so EmitC maps loc=scaling → ScaleLeft
+  // (ui8+scaling wrongly becomes Fixpipe TileType::Scaling). Host-prequant may load UINT8.
+  DataType out_dtype = tile_type->dtype_;
+  if (space == MemorySpace::LeftScale || space == MemorySpace::RightScale) {
+    CHECK(input_shape.size() == 2) << "The operator " << op_name
+                                   << " into LeftScale/RightScale requires a 2D tile, got rank "
+                                   << input_shape.size();
+    CHECK(tile_type->memory_space_ == MemorySpace::Mat)
+        << "The operator " << op_name
+        << " into LeftScale/RightScale requires the input tile to be in Mat memory";
+    CHECK(out_dtype == DataType::UINT8 || out_dtype == DataType::FP8E8M0)
+        << "The operator " << op_name
+        << " into LeftScale/RightScale requires UINT8 or FP8E8M0 dtype, but got " << out_dtype.ToString();
+    const TileLayout required_layout =
+        space == MemorySpace::LeftScale ? TileLayout::row_major : TileLayout::col_major;
+    CHECK(source_view.blayout == required_layout && source_view.slayout == required_layout &&
+          source_view.fractal == 32)
+        << "The operator " << op_name << " into " << MemorySpaceToString(space)
+        << " requires the source Mat tile to use the matching "
+        << (space == MemorySpace::LeftScale ? "row/row/32" : "col/col/32") << " layout";
+    if (out_dtype == DataType::UINT8) {
+      out_dtype = DataType::FP8E8M0;
+    }
+  }
+
+  // Stamp memory_space_ only for MX scale destinations. Stamping Mat/Left/Right
+  // here skips InferTileMemorySpace's tile_view refresh to the destination's
+  // implicit layout and regresses existing Vec↔Mat / matmul / rmsnorm paths.
+  if (space == MemorySpace::LeftScale || space == MemorySpace::RightScale) {
+    return std::make_shared<TileType>(output_shape, out_dtype, std::nullopt, tile_view, space);
+  }
   // Return TileType with computed shape and same dtype (no explicit MemRef)
   return std::make_shared<TileType>(output_shape, tile_type->dtype_, std::nullopt, tile_view);
 }
@@ -456,6 +545,11 @@ TypePtr DeduceTileCreateTileType(const std::vector<ExprPtr>& args,
       break;
     }
   }
+  CHECK(!target_memory_opt.has_value() ||
+        (*target_memory_opt != MemorySpace::LeftScale && *target_memory_opt != MemorySpace::RightScale))
+      << "The operator " << op_name
+      << " does not support target_memory=LeftScale/RightScale; create the scale tile with tile.load "
+         "to Mat followed by tile.move";
 
   TileView tile_view;
   // `transpose=true` requests the transposed Mat (ZN) fractal layout
@@ -987,7 +1081,7 @@ REGISTER_OP("tile.mscatter")
 
 REGISTER_OP("tile.move")
     .set_op_category("TileOp")
-    .set_description("Move tile between memory levels (Vec/Mat/Left/Right)")
+    .set_description("Move tile between memory levels (Vec/Mat/Left/Right/LeftScale/RightScale)")
     .add_argument("tile", "Input tile (TileType)")
     .set_attr<MemorySpace>("target_memory")
     .set_attr<TileLayout>("blayout")

--- a/src/ir/serialization/deserializer.cpp
+++ b/src/ir/serialization/deserializer.cpp
@@ -304,6 +304,10 @@ class IRDeserializer::Impl : public detail::DeserializerContext {
           tensor_view.layout = TensorLayout::DN;
         } else if (layout_str == "NZ") {
           tensor_view.layout = TensorLayout::NZ;
+        } else if (layout_str == "MX_A_ZZ") {
+          tensor_view.layout = TensorLayout::MX_A_ZZ;
+        } else if (layout_str == "MX_B_NN") {
+          tensor_view.layout = TensorLayout::MX_B_NN;
         } else {
           CHECK(false) << "Unknown TensorLayout: " << layout_str;
         }

--- a/src/ir/transforms/memory_reuse_pass.cpp
+++ b/src/ir/transforms/memory_reuse_pass.cpp
@@ -1935,7 +1935,7 @@ std::map<VarPtr, VarPtr> IdentifyReuseOpportunities(
   // fit; the predicate is retained verbatim only as the never-worse-than-legacy floor.
   auto is_l0_space = [](MemorySpace s) {
     return s == MemorySpace::Left || s == MemorySpace::Right || s == MemorySpace::Acc ||
-           s == MemorySpace::Bias;
+           s == MemorySpace::Bias || s == MemorySpace::LeftScale || s == MemorySpace::RightScale;
   };
   // Capacity-gated (#1475): keep software-pipelined operands in separate buffers so the pipeline
   // stages double-buffer instead of serializing on a shared buffer. #1900's `pipeline_membership` tags

--- a/src/ir/type.cpp
+++ b/src/ir/type.cpp
@@ -153,6 +153,10 @@ std::string TensorLayoutToString(TensorLayout layout) {
       return "DN";
     case TensorLayout::NZ:
       return "NZ";
+    case TensorLayout::MX_A_ZZ:
+      return "MX_A_ZZ";
+    case TensorLayout::MX_B_NN:
+      return "MX_B_NN";
     default:
       throw TypeError("Unknown TensorLayout value: " + std::to_string(static_cast<int>(layout)));
   }
@@ -165,6 +169,10 @@ TensorLayout StringToTensorLayout(const std::string& str) {
     return TensorLayout::DN;
   } else if (str == "NZ") {
     return TensorLayout::NZ;
+  } else if (str == "MX_A_ZZ") {
+    return TensorLayout::MX_A_ZZ;
+  } else if (str == "MX_B_NN") {
+    return TensorLayout::MX_B_NN;
   }
   throw TypeError("Unknown TensorLayout string: " + str);
 }

--- a/tests/ut/backend/test_backend_950.py
+++ b/tests/ut/backend/test_backend_950.py
@@ -66,13 +66,17 @@ class TestBackend950MemorySize:
 
         # Test cases: (memory_type, expected_size_in_KB)
         # Based on Create950SoC() in soc.cpp:
-        #   AIC core: Mat=512KB, Left=64KB, Right=64KB, Acc=256KB, Bias=4KB
+        #   AIC core: Mat=512KB, Left=64KB, Right=64KB, Acc=256KB, Bias=4KB,
+        #            LeftScale=4KB, RightScale=4KB
         #   AIV core: Vec=240KB safe (248KB physical, capped per pto-isa#170)
         test_cases = [
             (ir.MemorySpace.Mat, 512),  # 512KB Mat per AIC core
             (ir.MemorySpace.Left, 64),  # 64KB Left per AIC core
             (ir.MemorySpace.Right, 64),  # 64KB Right per AIC core
             (ir.MemorySpace.Acc, 256),  # 256KB Acc per AIC core
+            (ir.MemorySpace.Bias, 4),  # 4KB Bias per AIC core
+            (ir.MemorySpace.LeftScale, 4),  # 4KB L0A MX scale sidecar
+            (ir.MemorySpace.RightScale, 4),  # 4KB L0B MX scale sidecar
             # Safe Vec UB is capped at 240KB (248KB physical) per pto-isa#170;
             # restore to 248 once PTO-ISA stops reserving the top ~8KB.
             (ir.MemorySpace.Vec, 240),  # 240KB safe Vec per AIV core (248KB physical)
@@ -117,6 +121,8 @@ class TestBackend950MemoryPath:
             # Mat connections
             (ir.MemorySpace.Mat, ir.MemorySpace.Left, [ir.MemorySpace.Mat, ir.MemorySpace.Left]),
             (ir.MemorySpace.Mat, ir.MemorySpace.Right, [ir.MemorySpace.Mat, ir.MemorySpace.Right]),
+            (ir.MemorySpace.Mat, ir.MemorySpace.LeftScale, [ir.MemorySpace.Mat, ir.MemorySpace.LeftScale]),
+            (ir.MemorySpace.Mat, ir.MemorySpace.RightScale, [ir.MemorySpace.Mat, ir.MemorySpace.RightScale]),
             # Acc connections
             (ir.MemorySpace.Acc, ir.MemorySpace.Mat, [ir.MemorySpace.Acc, ir.MemorySpace.Mat]),
             (ir.MemorySpace.Acc, ir.MemorySpace.DDR, [ir.MemorySpace.Acc, ir.MemorySpace.DDR]),

--- a/tests/ut/ir/operators/test_mx_ops.py
+++ b/tests/ut/ir/operators/test_mx_ops.py
@@ -1,0 +1,114 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Unit tests for MX scale load layouts and LeftScale/RightScale spaces."""
+
+import pypto.language as pl
+import pytest
+from pypto import ir
+from pypto.pypto_core import DataType
+
+
+class TestMxLoad:
+    def test_mx_layout_sets_fractal(self):
+        span = ir.Span.unknown()
+        tensor = ir.Var(
+            "t",
+            ir.TensorType(
+                [16, 2],
+                DataType.FP8E8M0,
+                tensor_view=ir.TensorView([], ir.TensorLayout.MX_A_ZZ),
+            ),
+            span,
+        )
+        call = ir.op.tile.load(
+            tensor,
+            [0, 0],
+            [16, 2],
+            target_memory=ir.MemorySpace.Mat,
+            span=span,
+        )
+        tile_type = call.type
+        assert isinstance(tile_type, ir.TileType)
+        assert tile_type.dtype == DataType.FP8E8M0
+        assert tile_type.tile_view is not None
+        assert tile_type.tile_view.fractal == 32
+
+    def test_regular_nd_load_does_not_select_mx_layout(self):
+        span = ir.Span.unknown()
+        tensor = ir.Var("t", ir.TensorType([16, 2], DataType.FP8E8M0), span)
+        call = ir.op.tile.load(tensor, [0, 0], [16, 2], target_memory=ir.MemorySpace.Mat, span=span)
+        tile_type = call.type
+        assert isinstance(tile_type, ir.TileType)
+        assert tile_type.tile_view is None or tile_type.tile_view.fractal != 32
+
+    def test_rejects_vec_target_with_mx_layout(self):
+        span = ir.Span.unknown()
+        tensor = ir.Var(
+            "t",
+            ir.TensorType(
+                [16, 2],
+                DataType.FP8E8M0,
+                tensor_view=ir.TensorView([], ir.TensorLayout.MX_A_ZZ),
+            ),
+            span,
+        )
+        with pytest.raises(ValueError, match="Mat|Vec"):
+            ir.op.tile.load(
+                tensor,
+                [0, 0],
+                [16, 2],
+                target_memory=ir.MemorySpace.Vec,
+                span=span,
+            )
+
+    def test_mx_layout_without_target_memory_is_rejected(self):
+        span = ir.Span.unknown()
+        tensor = ir.Var(
+            "t",
+            ir.TensorType(
+                [16, 2],
+                DataType.FP8E8M0,
+                tensor_view=ir.TensorView([], ir.TensorLayout.MX_A_ZZ),
+            ),
+            span,
+        )
+        offsets = ir.MakeTuple(
+            [ir.ConstInt(0, DataType.INDEX, span), ir.ConstInt(0, DataType.INDEX, span)], span
+        )
+        shapes = ir.MakeTuple(
+            [ir.ConstInt(16, DataType.INDEX, span), ir.ConstInt(2, DataType.INDEX, span)], span
+        )
+        with pytest.raises(ValueError, match="requires target_memory=MemorySpace.Mat"):
+            ir.create_op_call(
+                "tile.load",
+                [tensor, offsets, shapes, shapes],
+                {},
+                span,
+            )
+
+
+class TestDtypeAndMemorySpace:
+    def test_fp8e8m0_exists(self):
+        assert DataType.FP8E8M0.get_bit() == 8
+        assert DataType.FP8E8M0.to_string() == "fp8e8m0"
+        assert pl.FP8E8M0 == DataType.FP8E8M0
+
+    def test_left_right_scale_spaces(self):
+        assert ir.MemorySpace.LeftScale == pl.Mem.LeftScale
+        assert ir.MemorySpace.RightScale == pl.Mem.RightScale
+
+    def test_memory_space_serialized_values_are_stable(self):
+        assert ir.MemorySpace.ScalarLocal.value == 7
+        assert ir.MemorySpace.LeftScale.value == 8
+        assert ir.MemorySpace.RightScale.value == 9
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/ut/ir/operators/test_mx_scale_memspace.py
+++ b/tests/ut/ir/operators/test_mx_scale_memspace.py
@@ -1,0 +1,368 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Unit tests for MX LeftScale/RightScale memspace and MX-layout load/move IR."""
+
+import pypto
+import pypto.language as pl
+import pytest
+from pypto import DataType, backend, codegen, ir, passes
+from pypto.backend import BackendType
+from pypto.ir.op import tensor_ops as tensor
+from pypto.ir.op import tile_ops as tile
+from pypto.language.parser.diagnostics import InvalidOperationError
+
+
+@pytest.fixture(autouse=True)
+def _ascend950():
+    backend.reset_for_testing()
+    backend.set_backend_type(BackendType.Ascend950)
+    try:
+        yield
+    finally:
+        backend.reset_for_testing()
+
+
+def _const_shape(rows: int, cols: int):
+    span = ir.Span.unknown()
+    return [ir.ConstInt(rows, DataType.INDEX, span), ir.ConstInt(cols, DataType.INDEX, span)]
+
+
+def _tile_var(shape, dtype, *, memory=None, view=None, name="t"):
+    tt = ir.TileType(shape, dtype, None, view, memory)
+    return ir.Var(name, tt, ir.Span.unknown())
+
+
+def _mx_tensor_var(name, rows, cols, layout=ir.TensorLayout.MX_A_ZZ):
+    return ir.Var(
+        name,
+        ir.TensorType(
+            _const_shape(rows, cols),
+            DataType.FP8E8M0,
+            tensor_view=ir.TensorView([], layout),
+        ),
+        ir.Span.unknown(),
+    )
+
+
+class TestMxScaleMemSpaces:
+    def test_leftscale_move_layout_row_major_fractal32(self):
+        src = _tile_var(
+            _const_shape(16, 8),
+            DataType.UINT8,
+            memory=ir.MemorySpace.Mat,
+            view=ir.TileView(
+                blayout=ir.TileLayout.row_major,
+                slayout=ir.TileLayout.row_major,
+                fractal=32,
+            ),
+        )
+        call = tile.move(src, target_memory=ir.MemorySpace.LeftScale)
+        out = call.type
+        assert isinstance(out, ir.TileType)
+        assert out.memory_space == ir.MemorySpace.LeftScale
+        assert out.dtype == DataType.FP8E8M0  # ui8 promotes for loc=scaling
+        view = out.get_effective_tile_view()
+        assert view.blayout == ir.TileLayout.row_major
+        assert view.slayout == ir.TileLayout.row_major
+        assert view.fractal == 32
+
+    def test_rightscale_move_layout_col_major_fractal32(self):
+        src = _tile_var(
+            _const_shape(8, 16),
+            DataType.UINT8,
+            memory=ir.MemorySpace.Mat,
+            view=ir.TileView(
+                blayout=ir.TileLayout.col_major,
+                slayout=ir.TileLayout.col_major,
+                fractal=32,
+            ),
+        )
+        call = tile.move(src, target_memory=ir.MemorySpace.RightScale)
+        out = call.type
+        assert isinstance(out, ir.TileType)
+        assert out.memory_space == ir.MemorySpace.RightScale
+        assert out.dtype == DataType.FP8E8M0
+        view = out.get_effective_tile_view()
+        assert view.blayout == ir.TileLayout.col_major
+        assert view.slayout == ir.TileLayout.col_major
+        assert view.fractal == 32
+
+    def test_mx_layout_load_requires_explicit_mat(self):
+        tensor = _mx_tensor_var("s", 16, 8)
+        with pytest.raises(ValueError, match="requires explicit target_memory=MemorySpace.Mat"):
+            tile.load(tensor, [0, 0], [16, 8])
+
+    def test_mx_b_layout_load_col_major(self):
+        tensor = _mx_tensor_var("w_s", 8, 16, ir.TensorLayout.MX_B_NN)
+        call = tile.load(tensor, [0, 0], [8, 16], target_memory=ir.MemorySpace.Mat)
+        out = call.type
+        assert isinstance(out, ir.TileType)
+        assert out.memory_space == ir.MemorySpace.Mat
+        view = out.get_effective_tile_view()
+        assert view.blayout == ir.TileLayout.col_major
+        assert view.slayout == ir.TileLayout.col_major
+        assert view.fractal == 32
+
+    def test_mx_layout_rejects_vec_target(self):
+        tensor = _mx_tensor_var("s", 16, 8)
+        with pytest.raises(ValueError, match="Mat|Vec"):
+            tile.load(tensor, [0, 0], [16, 8], target_memory=ir.MemorySpace.Vec)
+
+    def test_mx_layout_rejects_non_2d_load_window(self):
+        tensor = _mx_tensor_var("s", 16, 8)
+        with pytest.raises(ValueError, match="2D load window"):
+            tile.load(tensor, [0], [16], target_memory=ir.MemorySpace.Mat)
+
+    def test_scale_move_rejects_non_scale_dtype(self):
+        src = _tile_var(
+            _const_shape(16, 8),
+            DataType.FP16,
+            memory=ir.MemorySpace.Mat,
+        )
+        with pytest.raises(ValueError, match="UINT8|FP8E8M0"):
+            tile.move(src, target_memory=ir.MemorySpace.LeftScale)
+
+    def test_scale_move_rejects_non_mat_input(self):
+        src = _tile_var(
+            _const_shape(16, 8),
+            DataType.FP8E8M0,
+            memory=ir.MemorySpace.Vec,
+        )
+        with pytest.raises(ValueError, match="Mat memory"):
+            tile.move(src, target_memory=ir.MemorySpace.LeftScale)
+
+    def test_scale_move_rejects_non_2d_input(self):
+        span = ir.Span.unknown()
+        src = _tile_var(
+            [ir.ConstInt(16, DataType.INDEX, span)],
+            DataType.FP8E8M0,
+            memory=ir.MemorySpace.Mat,
+        )
+        with pytest.raises(ValueError, match="2D tile"):
+            tile.move(src, target_memory=ir.MemorySpace.RightScale)
+
+    @pytest.mark.parametrize(
+        ("space", "view"),
+        [
+            (
+                ir.MemorySpace.LeftScale,
+                ir.TileView(
+                    blayout=ir.TileLayout.col_major,
+                    slayout=ir.TileLayout.col_major,
+                    fractal=32,
+                ),
+            ),
+            (
+                ir.MemorySpace.RightScale,
+                ir.TileView(
+                    blayout=ir.TileLayout.row_major,
+                    slayout=ir.TileLayout.row_major,
+                    fractal=32,
+                ),
+            ),
+            (
+                ir.MemorySpace.LeftScale,
+                ir.TileView(
+                    blayout=ir.TileLayout.row_major,
+                    slayout=ir.TileLayout.row_major,
+                    fractal=512,
+                ),
+            ),
+        ],
+    )
+    def test_scale_move_rejects_mismatched_source_layout(self, space, view):
+        src = _tile_var(
+            _const_shape(16, 8),
+            DataType.FP8E8M0,
+            memory=ir.MemorySpace.Mat,
+            view=view,
+        )
+        with pytest.raises(ValueError, match="matching.*layout"):
+            tile.move(src, target_memory=space)
+
+    @pytest.mark.parametrize(
+        ("space", "blayout", "slayout"),
+        [
+            (ir.MemorySpace.LeftScale, ir.TileLayout.col_major, ir.TileLayout.row_major),
+            (ir.MemorySpace.RightScale, ir.TileLayout.col_major, ir.TileLayout.row_major),
+        ],
+    )
+    def test_scale_move_rejects_layout_override(self, space, blayout, slayout):
+        src = _tile_var(_const_shape(16, 8), DataType.FP8E8M0, memory=ir.MemorySpace.Mat)
+        with pytest.raises(ValueError, match="hardware-fixed layout"):
+            tile.move(src, target_memory=space, blayout=blayout, slayout=slayout)
+
+    @pytest.mark.parametrize("space", [ir.MemorySpace.LeftScale, ir.MemorySpace.RightScale])
+    def test_tile_create_rejects_scale_memory(self, space):
+        with pytest.raises(ValueError, match="does not support target_memory=LeftScale/RightScale"):
+            tile.create([16, 8], DataType.FP8E8M0, target_memory=space)
+
+    def test_mx_load_rejects_strided_tensor_view(self):
+        shape = _const_shape(8, 8)
+        tensor = ir.Var(
+            "s",
+            ir.TensorType(
+                shape,
+                DataType.FP8E8M0,
+                tensor_view=ir.TensorView([16, 1], ir.TensorLayout.MX_A_ZZ),
+            ),
+            ir.Span.unknown(),
+        )
+        with pytest.raises(ValueError, match="packed 2D"):
+            tile.load(tensor, [0, 0], [8, 8], target_memory=ir.MemorySpace.Mat)
+
+    def test_tensor_slice_rejects_mx_source(self):
+        source = _mx_tensor_var("source", 16, 8)
+        with pytest.raises(ValueError, match="tensor.slice does not support MX-layout tensors"):
+            tensor.slice(source, [8, 8], [1, 0])
+
+    def test_mx_load_rejects_ssa_bound_slice_in_dsl(self):
+        with pytest.raises(InvalidOperationError, match="tensor.slice does not support MX-layout tensors"):
+
+            @pl.program
+            class Input:
+                @pl.function
+                def kernel(
+                    self,
+                    source: pl.Tensor[[16, 8], pl.FP8E8M0, pl.MX_A_ZZ],
+                ) -> pl.Tensor[[16, 8], pl.FP8E8M0, pl.MX_A_ZZ]:
+                    sliced = pl.slice(source, [8, 8], [1, 0])
+                    _scale = pl.load(sliced, [0, 0], [8, 8], target_memory=pl.Mem.Mat)
+                    return source
+
+    @pytest.mark.parametrize(
+        "make_view",
+        [
+            lambda source: tensor.reshape(source, [16, 8]),
+            lambda source: tensor.transpose(source, 0, 1),
+            lambda source: tensor.reinterpret_view(source, dtype=DataType.UINT8),
+            lambda source: tensor.view(source, layout=ir.TensorLayout.ND),
+        ],
+    )
+    def test_zero_copy_tensor_views_reject_mx_source(self, make_view):
+        source = _mx_tensor_var("source", 16, 8)
+        with pytest.raises(ValueError, match="does not support MX"):
+            make_view(source)
+
+    def test_mx_load_accepts_direct_orchestration_argument_precondition(self):
+        @pl.program
+        class Input:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                source: pl.Tensor[[8, 8], pl.FP8E8M0, pl.MX_A_ZZ],
+            ) -> pl.Tensor[[8, 8], pl.FP8E8M0, pl.MX_A_ZZ]:
+                _scale = pl.load(source, [0, 0], [8, 8], target_memory=pl.Mem.Mat)
+                return source
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orchestration(
+                self,
+                source: pl.Tensor[[8, 8], pl.FP8E8M0, pl.MX_A_ZZ],
+            ) -> pl.Tensor[[8, 8], pl.FP8E8M0, pl.MX_A_ZZ]:
+                result, _ = pl.submit(self.kernel, source)
+                return result
+
+        program = passes.convert_to_ssa()(Input)
+        orchestration = next(
+            function
+            for function in program.functions.values()
+            if function.func_type == pl.FunctionType.Orchestration
+        )
+        # Reaching the later core-type check proves the MX argument precondition
+        # accepted this packed, unsliced MX tensor.
+        with pytest.raises(pypto.InternalError, match="InferFunctionCoreType"):
+            codegen.generate_orchestration(program, orchestration)
+
+    def test_mx_load_accepts_materialized_packed_nd_tensor_view(self):
+        shape = _const_shape(8, 8)
+        tensor = ir.Var(
+            "s",
+            ir.TensorType(
+                shape,
+                DataType.FP8E8M0,
+                tensor_view=ir.TensorView([8, 1], ir.TensorLayout.MX_A_ZZ),
+            ),
+            ir.Span.unknown(),
+        )
+        call = tile.load(
+            tensor,
+            [0, 0],
+            [8, 8],
+            target_memory=ir.MemorySpace.Mat,
+        )
+        assert isinstance(call.type, ir.TileType)
+
+    def test_mx_load_pto_codegen_uses_packed_source_view(self):
+        span = ir.Span.unknown()
+        tensor_type = ir.TensorType(
+            _const_shape(16, 2),
+            DataType.FP8E8M0,
+            tensor_view=ir.TensorView([], ir.TensorLayout.MX_A_ZZ),
+        )
+        builder = ir.IRBuilder()
+        with builder.function("mx_load_codegen", type=ir.FunctionType.InCore) as function:
+            source = function.param("source", tensor_type)
+            scale = builder.let(
+                "scale",
+                tile.load(
+                    source,
+                    [0, 0],
+                    [16, 2],
+                    target_memory=ir.MemorySpace.Mat,
+                ),
+            )
+            function.return_type(scale.type)
+            builder.return_stmt(scale)
+
+        program = ir.Program([function.get_result()], "mx_load_codegen", span)
+        pto = codegen.PTOCodegen().generate(program)
+        assert pto.count("pto.make_tensor_view") == 1
+        assert "pto.make_tensor_view %arg0" in pto
+        assert "strides = [%c2_index, %c1_index] {layout = #pto.layout<mx_a_zz>}" in pto
+        assert "pto.tload" in pto
+
+    @pytest.mark.parametrize(
+        ("layout", "pto_layout"),
+        [
+            (ir.TensorLayout.MX_A_ZZ, "mx_a_zz"),
+            (ir.TensorLayout.MX_B_NN, "mx_b_nn"),
+        ],
+    )
+    def test_mx_column_vector_keeps_mx_layout(self, layout, pto_layout):
+        span = ir.Span.unknown()
+        tensor_type = ir.TensorType(
+            _const_shape(16, 1),
+            DataType.FP8E8M0,
+            tensor_view=ir.TensorView([], layout),
+        )
+        builder = ir.IRBuilder()
+        with builder.function("mx_column_load", type=ir.FunctionType.InCore) as function:
+            source = function.param("source", tensor_type)
+            scale = builder.let(
+                "scale",
+                tile.load(
+                    source,
+                    [0, 0],
+                    [16, 1],
+                    target_memory=ir.MemorySpace.Mat,
+                ),
+            )
+            function.return_type(scale.type)
+            builder.return_stmt(scale)
+
+        program = ir.Program([function.get_result()], "mx_column_load", span)
+        pto = codegen.PTOCodegen().generate(program)
+        assert f"{{layout = #pto.layout<{pto_layout}>}}" in pto
+        assert "{layout = #pto.layout<dn>}" not in pto
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/ut/ir/test_distributed_ops.py
+++ b/tests/ut/ir/test_distributed_ops.py
@@ -393,6 +393,27 @@ def test_remote_load_returns_tile_type_with_target_dtype():
     assert call.type.shape[0].value == 32
 
 
+@pytest.mark.parametrize("layout", [ir.TensorLayout.MX_A_ZZ, ir.TensorLayout.MX_B_NN])
+def test_remote_load_rejects_mx_layout(layout):
+    span = ir.Span.unknown()
+    shape_exprs = [ir.ConstInt(8, DataType.INT64, span), ir.ConstInt(8, DataType.INT64, span)]
+    view = ir.TensorView([], layout)
+    target = ir.Var(
+        "data",
+        ir.DistributedTensorType(shape_exprs, DataType.FP8E8M0, None, view),
+        span,
+    )
+    peer = ir.Var("peer", ir.ScalarType(DataType.INT32), span)
+
+    with pytest.raises(ValueError, match="does not support MX-layout tensors"):
+        ir.create_op_call(
+            "pld.tile.remote_load",
+            [target, peer, _make_shape_tuple([0, 0], span), _make_shape_tuple([8, 8], span)],
+            {},
+            span,
+        )
+
+
 def test_remote_load_infers_col_major_for_single_column_tile():
     """A [M, 1] remote Vec tile follows the standard implicit col-major layout."""
     span = ir.Span.unknown()

--- a/tests/ut/language/parser/test_type_resolver.py
+++ b/tests/ut/language/parser/test_type_resolver.py
@@ -1471,6 +1471,8 @@ class TestLayoutResolution:
         [
             ("pl.NZ", ir.TensorLayout.NZ),
             ("pl.ND", ir.TensorLayout.ND),
+            ("pl.MX_A_ZZ", ir.TensorLayout.MX_A_ZZ),
+            ("pl.MX_B_NN", ir.TensorLayout.MX_B_NN),
         ],
     )
     def test_resolve_tensor_with_layout(self, layout_str, expected_layout):
@@ -1682,6 +1684,8 @@ class TestLayoutIntegration:
         [
             (pl.ND, ir.TensorLayout.ND),
             (pl.NZ, ir.TensorLayout.NZ),
+            (pl.MX_A_ZZ, ir.TensorLayout.MX_A_ZZ),
+            (pl.MX_B_NN, ir.TensorLayout.MX_B_NN),
         ],
     )
     def test_parametrized_layout(self, layout, expected):

--- a/tests/ut/tools/test_memory_map.py
+++ b/tests/ut/tools/test_memory_map.py
@@ -189,7 +189,8 @@ def test_backend_limits_come_from_the_backend_interface():
 
 def test_backend_limits_cover_every_space_the_soc_describes():
     # Walking the SoC rather than a fixed space list is what keeps a backend
-    # that grew a space mapped: Ascend950 has Bias, Ascend910B does not.
+    # that grew a space mapped: Ascend950 has Bias/LeftScale/RightScale,
+    # Ascend910B does not.
     for name in memory_map.backend_names():
         instance = memory_map.backend_instance(name)
         expected = {
@@ -202,8 +203,11 @@ def test_backend_limits_cover_every_space_the_soc_describes():
         }
         assert memory_map.backend_limits(name) == expected
 
-    assert "Bias" in memory_map.backend_limits("Ascend950")
-    assert "Bias" not in memory_map.backend_limits("Ascend910B")
+    a5 = memory_map.backend_limits("Ascend950")
+    a2 = memory_map.backend_limits("Ascend910B")
+    for space in ("Bias", "LeftScale", "RightScale"):
+        assert space in a5
+        assert space not in a2
     # Every space a backend can report has a panel slot, so none falls back to
     # its own high-water mark and renders permanently full.
     for name in memory_map.backend_names():


### PR DESCRIPTION
## Summary
- Add Ascend950 MX scale memory spaces (`LeftScale` / `RightScale`) with matching SoC, reuse, bindings, and memory-map support.
- Represent MX GM scale data through the source tensor layout (`TensorLayout.MX_A_ZZ` / `MX_B_NN`). MX `tile.load` keeps the existing public API and requires explicit `target_memory=Mat`.
- Reuse the TensorView created by `EmitMakeTensorViews`; each MX tensor parameter now has one `pto.make_tensor_view`, while `pto.tload` retains its MX layout attribute.
- Validate Mat-to-scale moves against the source layout (`row/row/32` for `LeftScale`, `col/col/32` for `RightScale`) so byte-copy moves cannot silently retag incompatible data.
- Reject unsupported MX tensor subviews (`slice`, `reshape`, `transpose`, `reinterpret_view`, `view`) and MX `remote_load` as documented legacy limitations. No MX matmul support is included in this PR.

## Test plan
- [x] CMake build
- [x] MX load/move and distributed remote-load unit tests (154 passed)
- [x] TensorView serialization/parser/materialization regressions (261 passed)
- [x] Full unit suite exercised: 8320 passed, 2 skipped; remaining runtime/tool failures are local environment issues (missing installed runtime modules/stale external extension/console script)
- [x] Repository lint scripts, ruff check/format, pyright, clang-format, and `git diff --check`
- [ ] Full `pre-commit run --all-files`: hooks began successfully with direct networking, but the first-time pyright environment attempted a large Torch download and was intentionally skipped after equivalent local pyright passed
