### PR TITLE
test: Make guarded assertions fail instead of silently skipping

### DIFF
--- a/tests/ut/codegen/test_orchestration_returned_param_map.py
+++ b/tests/ut/codegen/test_orchestration_returned_param_map.py
@@ -242,6 +242,10 @@ _TASK_RE = re.compile(
 )
 _OP_RE = re.compile(r"\.add_(input|inout|output)\((\w+)\)")
 
+# A loop-tail carry rebind, e.g. "cur__rv_v3 = cur__ssa_v4;". Matches the bare assignment
+# only -- the "Tensor cur__rv_v3 = cur;" declaration above the loop is not a rebind.
+_CARRY_RE = re.compile(r"^\s*(\w+)__rv_v\d+\s*=\s*(\w+);\s*$", re.MULTILINE)
+
 
 def _orch_code(kernel) -> str:
     """Specialize + run the Default pipeline, then emit the orchestration C++ in-process.
@@ -318,13 +322,32 @@ class TestReturnedParamMapBinding:
         _assert_consumer_reads_producer_buffer(code)
 
         # The poisoned map also yields garbage into the loop carry: a k/v cache carry must
-        # never be re-bound from an unrelated scratch buffer.
-        for m in re.finditer(r"^\s*(\w+)__rv_v\d+\s*=\s*(\w+);\s*$", code, re.MULTILINE):
-            carry, src = m.group(1), m.group(2)
-            if carry in ("k_cache", "v_cache"):
-                assert src.startswith(("k_cache", "v_cache")), (
-                    f"GARBAGE LOOP CARRY: {carry!r} is yielded from {src!r} (line: {m.group(0).strip()})"
-                )
+        # never be re-bound from an unrelated scratch buffer. This is an ABSENCE check --
+        # correct codegen rebinds only 'cur', so the k/v branch below is expected not to be
+        # taken; the bug shows up as an EXTRA "v_cache__rv_vN = q_pad_inlineNN;" line.
+        carries = list(_CARRY_RE.finditer(code))
+
+        # Canary: the absence check above is only meaningful while _CARRY_RE still matches the
+        # carry rebinds it is meant to police. Without this, renaming the __rv_vN suffix in
+        # codegen would silently retire the check instead of failing here.
+        assert carries, (
+            "no '<name>__rv_vN = <src>;' loop-carry rebinds found in the generated orchestration "
+            "-- has the carry naming scheme changed? The k/v garbage-carry check below is dead "
+            f"until this scan is repaired.\n{code}"
+        )
+
+        # Stated as a direct absence, not a per-match branch, so the intent reads as one
+        # claim. Prefix-matched on both sides: an SSA- or index-suffixed carry base
+        # (v_cache__ssa_v1, v_cache_0) must not slip past as an exact-match miss.
+        garbage = [
+            m.group(0).strip()
+            for m in carries
+            if m.group(1).startswith(("k_cache", "v_cache"))
+            and not m.group(2).startswith(("k_cache", "v_cache"))
+        ]
+        assert not garbage, (
+            f"GARBAGE LOOP CARRY: a k/v cache carry is re-bound from an unrelated scratch buffer: {garbage}"
+        )
 
     def test_unconditional_param_write_binds_consumer_correctly(self):
         """Control (b) removed: same param writes without the runtime guard bind correctly."""

--- a/tests/ut/ir/transforms/test_equality.py
+++ b/tests/ut/ir/transforms/test_equality.py
@@ -406,11 +406,16 @@ class TestHashEqualityConsistency:
             ),
         ]
 
+        # These are bare fragments, so their vars are free -- there is no def point to
+        # remap them at, hence enable_auto_mapping (matching the rest of this file).
+        # Assert equality rather than branching on it: a structural_equal regression
+        # toward False would otherwise skip the hash check below and silence the very
+        # inconsistency this test exists to catch.
         for expr1, expr2 in test_cases:
-            if ir.structural_equal(expr1, expr2):
-                assert ir.structural_hash(expr1) == ir.structural_hash(expr2), (
-                    f"Equal expressions should have same hash: {expr1} vs {expr2}"
-                )
+            ir.assert_structural_equal(expr1, expr2, enable_auto_mapping=True)
+            assert ir.structural_hash(expr1, enable_auto_mapping=True) == ir.structural_hash(
+                expr2, enable_auto_mapping=True
+            ), f"Equal expressions should have same hash: {expr1} vs {expr2}"
 
     def test_deep_nested_consistency(self):
         """Test hash/equality consistency for deeply nested expressions."""

--- a/tests/ut/language/parser/test_parser_span_passing.py
+++ b/tests/ut/language/parser/test_parser_span_passing.py
@@ -24,6 +24,87 @@ def get_current_line():
     return -1
 
 
+def top_level_calls(func: ir.Function) -> list[ir.Call]:
+    """Return every ``AssignStmt``-bound ``Call`` in ``func``'s body, in source order.
+
+    Only the top level of the body is scanned -- these tests assert on the span of the
+    call the surface syntax binds directly, not on nested argument expressions.
+
+    Args:
+        func: The parsed function to scan.
+
+    Returns:
+        The bound ``Call`` expressions, in statement order.
+    """
+    body = func.body
+    assert isinstance(body, ir.SeqStmts)
+    return [
+        stmt.value
+        for stmt in body.stmts
+        if isinstance(stmt, ir.AssignStmt) and isinstance(stmt.value, ir.Call)
+    ]
+
+
+def find_unique_call(func: ir.Function, op_name: str) -> ir.Call:
+    """Return the single ``AssignStmt``-bound ``Call`` in ``func`` carrying ``op_name``.
+
+    Routing ``op_name`` through ``ir.get_op`` makes a stale operator name raise
+    instead of silently evaluating to ``False``. Asserting the match was found
+    is what keeps the span checks at the call site from being skipped outright
+    if the parser stops emitting ``op_name`` for the tested surface syntax --
+    without it, a dead search reports PASS while verifying nothing.
+
+    Args:
+        func: The parsed function to search.
+        op_name: Registered operator name the call is expected to carry.
+
+    Returns:
+        The matching ``Call`` expression.
+
+    Raises:
+        ValueError: If ``op_name`` is not a registered operator.
+    """
+    want = ir.get_op(op_name).name
+    calls = top_level_calls(func)
+    hits = [call for call in calls if call.op.name == want]
+
+    assert len(hits) == 1, (
+        f"Expected exactly one {op_name!r} call in {func.name!r}, got {len(hits)}; "
+        f"body contained {[call.op.name for call in calls]}"
+    )
+    return hits[0]
+
+
+def assert_span_at(
+    span: ir.Span, expected_line: int, expected_column: int | None = None, context: str = ""
+) -> None:
+    """Assert ``span`` is a valid, well-ordered range beginning at ``expected_line``.
+
+    Args:
+        span: The span to check.
+        expected_line: Line number the span must begin on.
+        expected_column: Exact begin column, or None to only require it is positive.
+        context: Optional label identifying the span, used in failure messages.
+    """
+    where = f" for {context}" if context else ""
+    assert span.is_valid(), f"Invalid span{where}"
+    assert span.begin_line == expected_line, (
+        f"Invalid begin line{where}: {span.begin_line} != {expected_line}"
+    )
+    if expected_column is None:
+        assert span.begin_column > 0, f"Invalid begin column{where}: {span.begin_column}"
+    else:
+        assert span.begin_column == expected_column, (
+            f"Invalid begin column{where}: {span.begin_column} != {expected_column}"
+        )
+    # Equivalent to "end line is later, or same line with a non-decreasing column",
+    # but stated unconditionally so the ordering check can never be skipped.
+    assert (span.end_line, span.end_column) >= (span.begin_line, span.begin_column), (
+        f"Span end precedes begin{where}: "
+        f"({span.end_line}, {span.end_column}) < ({span.begin_line}, {span.begin_column})"
+    )
+
+
 class TestParserSpanPassing:
     """Test that parser passes accurate span information to operations."""
 
@@ -44,32 +125,11 @@ class TestParserSpanPassing:
         assert isinstance(test_func, ir.Function)
         assert test_func.name == "test_func"
 
-        # Check that the function body contains statements with valid spans
-        body = test_func.body
-        assert isinstance(body, ir.SeqStmts)
-        assert len(body.stmts) > 0
-
-        # Find the assign statement containing the add operation
-        for stmt in body.stmts:
-            if isinstance(stmt, ir.AssignStmt):
-                value = stmt.value
-                if isinstance(value, ir.Call) and value.op.name == "tensor.add":
-                    # Verify span is valid and not unknown
-                    assert value.span.is_valid()
-                    # Check line number points to the operation call (line current_line + 7)
-                    assert value.span.begin_line == current_line + 7
-                    # Check column points to the operation (after "= ")
-                    assert value.span.begin_column > 0
-                    # Verify end position is set (parser should provide range)
-                    # End line should be same line or later
-                    assert value.span.end_line >= value.span.begin_line
-                    # If same line, end column should be after begin
-                    if value.span.end_line == value.span.begin_line:
-                        assert value.span.end_column >= value.span.begin_column
-                    break
+        add_call = find_unique_call(test_func, "tensor.add")
+        assert_span_at(add_call.span, current_line + 7)
 
     def test_parser_passes_span_to_tensor_mul(self):
-        """Parser should pass AST span to tensor.mul operation."""
+        """Parser should pass AST span to the tensor.muls operation a scalar rhs lowers to."""
 
         current_line = get_current_line()
 
@@ -79,19 +139,10 @@ class TestParserSpanPassing:
             return y
 
         assert isinstance(test_mul, ir.Function)
-        assert isinstance(test_mul.body, ir.SeqStmts)
 
-        # Check that operations have valid spans
-        for stmt in test_mul.body.stmts:
-            if isinstance(stmt, ir.AssignStmt):
-                value = stmt.value
-                if isinstance(value, ir.Call) and value.op.name == "tensor.muls":
-                    assert value.span.is_valid()
-                    assert value.span.begin_line == current_line + 4
-                    assert value.span.begin_column > 0
-                    assert value.span.end_line >= value.span.begin_line
-                    if value.span.end_line == value.span.begin_line:
-                        assert value.span.end_column >= value.span.begin_column
+        # A scalar rhs lowers to tensor.muls, not tensor.mul
+        mul_call = find_unique_call(test_mul, "tensor.muls")
+        assert_span_at(mul_call.span, current_line + 4)
 
     def test_parser_passes_span_to_tensor_create(self):
         """Parser should pass AST span to tensor.create operation."""
@@ -104,18 +155,9 @@ class TestParserSpanPassing:
             return x
 
         assert isinstance(test_create, ir.Function)
-        assert isinstance(test_create.body, ir.SeqStmts)
 
-        for stmt in test_create.body.stmts:
-            if isinstance(stmt, ir.AssignStmt):
-                value = stmt.value
-                if isinstance(value, ir.Call) and value.op.name == "tensor.create":
-                    assert value.span.is_valid()
-                    assert value.span.begin_line == current_line + 4
-                    assert value.span.begin_column == 46
-                    assert value.span.end_line >= value.span.begin_line
-                    if value.span.end_line == value.span.begin_line:
-                        assert value.span.end_column >= value.span.begin_column
+        create_call = find_unique_call(test_create, "tensor.create")
+        assert_span_at(create_call.span, current_line + 4, expected_column=46)
 
     def test_parser_span_accuracy_multiple_operations(self):
         """Test that parser assigns different spans to different operations."""
@@ -129,25 +171,14 @@ class TestParserSpanPassing:
             return z
 
         assert isinstance(test_multi, ir.Function)
-        assert isinstance(test_multi.body, ir.SeqStmts)
 
-        # Collect all Call spans
-        call_spans = []
-        for stmt in test_multi.body.stmts:
-            if isinstance(stmt, ir.AssignStmt) and isinstance(stmt.value, ir.Call):
-                call_spans.append((stmt.value.op.name, stmt.value.span))
+        # State the exact contract the zip below enforces, so an extra emitted call
+        # fails as a named length assertion rather than a bare zip ValueError.
+        calls = top_level_calls(test_multi)
+        assert len(calls) == 2, f"expected 2 calls, got {[call.op.name for call in calls]}"
 
-        # Should have at least 2 operations
-        assert len(call_spans) >= 2
-
-        # All spans should be valid with proper line/column info
-        for (op_name, span), offset in zip(call_spans, [4, 5]):
-            assert span.is_valid(), f"Invalid span for {op_name}"
-            assert span.begin_line == current_line + offset, f"Invalid line number for {op_name}"
-            assert span.begin_column == 42, f"Invalid column number for {op_name}"
-            assert span.end_line >= span.begin_line, f"Invalid end line for {op_name}"
-            if span.end_line == span.begin_line:
-                assert span.end_column >= span.begin_column, f"Invalid end column for {op_name}"
+        for call, offset in zip(calls, [4, 5], strict=True):
+            assert_span_at(call.span, current_line + offset, expected_column=42, context=call.op.name)
 
     def test_parser_passes_span_to_matmul(self):
         """Parser should pass AST span to tensor.matmul operation."""
@@ -163,18 +194,9 @@ class TestParserSpanPassing:
             return c
 
         assert isinstance(test_matmul, ir.Function)
-        assert isinstance(test_matmul.body, ir.SeqStmts)
 
-        for stmt in test_matmul.body.stmts:
-            if isinstance(stmt, ir.AssignStmt):
-                value = stmt.value
-                if isinstance(value, ir.Call) and value.op.name == "tensor.matmul":
-                    assert value.span.is_valid()
-                    assert value.span.begin_line == current_line + 7
-                    assert value.span.begin_column > 0
-                    assert value.span.end_line >= value.span.begin_line
-                    if value.span.end_line == value.span.begin_line:
-                        assert value.span.end_column >= value.span.begin_column
+        matmul_call = find_unique_call(test_matmul, "tensor.matmul")
+        assert_span_at(matmul_call.span, current_line + 7)
 
     def test_parser_passes_span_to_cast(self):
         """Parser should pass AST span to tensor.cast operation."""
@@ -187,18 +209,9 @@ class TestParserSpanPassing:
             return y
 
         assert isinstance(test_cast, ir.Function)
-        assert isinstance(test_cast.body, ir.SeqStmts)
 
-        for stmt in test_cast.body.stmts:
-            if isinstance(stmt, ir.AssignStmt):
-                value = stmt.value
-                if isinstance(value, ir.Call) and value.op.name == "tensor.cast":
-                    assert value.span.is_valid()
-                    assert value.span.begin_line == current_line + 4
-                    assert value.span.begin_column > 0
-                    assert value.span.end_line >= value.span.begin_line
-                    if value.span.end_line == value.span.begin_line:
-                        assert value.span.end_column >= value.span.begin_column
+        cast_call = find_unique_call(test_cast, "tensor.cast")
+        assert_span_at(cast_call.span, current_line + 4)
 
     def test_parser_passes_span_to_exp(self):
         """Parser should pass AST span to tensor.exp operation."""
@@ -211,18 +224,9 @@ class TestParserSpanPassing:
             return y
 
         assert isinstance(test_exp, ir.Function)
-        assert isinstance(test_exp.body, ir.SeqStmts)
 
-        for stmt in test_exp.body.stmts:
-            if isinstance(stmt, ir.AssignStmt):
-                value = stmt.value
-                if isinstance(value, ir.Call) and value.op.name == "tensor.exp":
-                    assert value.span.is_valid()
-                    assert value.span.begin_line == current_line + 4
-                    assert value.span.begin_column > 0
-                    assert value.span.end_line >= value.span.begin_line
-                    if value.span.end_line == value.span.begin_line:
-                        assert value.span.end_column >= value.span.begin_column
+        exp_call = find_unique_call(test_exp, "tensor.exp")
+        assert_span_at(exp_call.span, current_line + 4)
 
     def test_all_operations_have_valid_spans(self):
         """Comprehensive test that all operations get valid spans from parser."""
@@ -242,34 +246,12 @@ class TestParserSpanPassing:
             return e
 
         assert isinstance(test_comprehensive, ir.Function)
-        assert isinstance(test_comprehensive.body, ir.SeqStmts)
 
-        # Collect all operations and verify spans
-        operations_checked = 0
-        expected_lines = [7, 8, 9, 10, 11]
-        for stmt in test_comprehensive.body.stmts:
-            if isinstance(stmt, ir.AssignStmt) and isinstance(stmt.value, ir.Call):
-                span = stmt.value.span
-                op_name = stmt.value.op.name
+        calls = top_level_calls(test_comprehensive)
+        assert len(calls) == 5, f"expected 5 calls, got {[call.op.name for call in calls]}"
 
-                # Verify span validity
-                assert span.is_valid(), f"Invalid span for {op_name}"
-
-                # Verify line number
-                assert span.begin_line == current_line + expected_lines[operations_checked]
-
-                # Verify column number
-                assert span.begin_column > 0, f"Invalid column for {op_name}"
-
-                # Verify end position
-                assert span.end_line >= span.begin_line, f"Invalid end line for {op_name}"
-                if span.end_line == span.begin_line:
-                    assert span.end_column >= span.begin_column, f"Invalid end column for {op_name}"
-
-                operations_checked += 1
-
-        # Should have checked exactly 5 operations
-        assert operations_checked == 5
+        for call, offset in zip(calls, [7, 8, 9, 10, 11], strict=True):
+            assert_span_at(call.span, current_line + offset, context=call.op.name)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Eight test assertions sat inside a `for` + `if` guard with nothing requiring the branch to be taken. If the guard stopped matching, the loop body simply never ran and the test still reported PASS while verifying nothing.

**`tests/ut/language/parser/test_parser_span_passing.py`** — six tests asserted span line/column only inside `if value.op.name == "<op>"`. Corrupting all six op-name literals left the file at `8 passed`. The literal now routes through `ir.get_op(...).name` per `.claude/rules/operator-identity-checks.md`, the match is hoisted into `find_unique_call`, and the test asserts exactly one was found — reporting the op names actually present so a failure is self-diagnosing:

```
AssertionError: Expected exactly one 'tensor.muls' call in 'test_mul', got 0; body contained ['tensor.mul']
```

Note `get_op` alone does not close this: it catches a *renamed* op, but if the parser starts lowering the same surface syntax to a different registered op (`pl.mul(x, 2.0)` → `tensor.muls` vs `pl.mul(x, y)` → `tensor.mul`), the lookup still resolves and the guard silently misses. The assert-found is what closes it.

Also extracts `top_level_calls` and `assert_span_at`, shared by all eight tests, and states span end-ordering as an unconditional tuple comparison instead of a conditional assert.

**`tests/ut/ir/transforms/test_equality.py`** — `test_equal_implies_same_hash` gated its hash check on `if structural_equal(...)`, which was **already False for 4 of its 5 cases**. Bare fragments have free vars and need `enable_auto_mapping` — as `test_deep_nested_consistency` 25 lines below and the rest of the file already do. Self-contained functions remap at the def point and need no flag; these fragments have no def point. Now asserts through `ir.assert_structural_equal`, taking coverage from 1 live case to 5.

**`tests/ut/codegen/test_orchestration_returned_param_map.py`** — the k/v garbage-carry scan is an *absence* check and correctly finds nothing today (codegen emits one carry, `cur`), but a rename of the `__rv_vN` suffix would silently retire it. Adds a canary asserting the scan still matches, states the check as a direct absence rather than a per-match branch, and prefix-matches the carry base so an SSA- or index-suffixed name (`v_cache__ssa_v1`) cannot slip past as an exact miss.

## Testing

Verified by mutation — each of these now fails and previously passed:

| Mutation | Before | After |
| --- | --- | --- |
| Typo'd op literal | passed | fails (`ValueError` from `get_op`) |
| Parser drift, literal still valid | passed | fails (`got 0; body contained [...]`) |
| Genuinely unequal test-case pair | passed | fails |
| Codegen renames carry suffix | passed | fails (canary) |

- [x] Full unit suite: 7983 passed, 2 skipped (both pre-existing)
- [x] Code review completed
- [x] `ruff check` / `ruff format` / `pyright` clean
- [x] Test-only change — no production code, bindings, stubs, or docs affected