### PR TITLE
test(ir): Assert concrete exception types instead of Exception

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,6 +42,13 @@ repos:
           additional_dependencies: [pyyaml]
           pass_filenames: false
 
+        - id: check-no-broad-raises
+          name: check-no-broad-raises
+          entry: python tests/lint/check_no_broad_raises.py
+          language: python
+          language_version: python3
+          pass_filenames: false
+
     - repo: https://github.com/pre-commit/pre-commit-hooks
       rev: v4.6.0
       hooks:

--- a/docs/en/dev/02-error-handling.md
+++ b/docs/en/dev/02-error-handling.md
@@ -17,7 +17,7 @@ All exceptions inherit from `Error`, which captures the C++ stack trace at const
 
 ```text
 std::runtime_error
-  └── Error                  (base: auto stack trace capture)
+  └── Error                  (base: auto stack trace capture, → Python pypto.Error)
         ├── ValueError       (→ Python ValueError)
         ├── TypeError        (→ Python TypeError)
         ├── RuntimeError     (→ Python RuntimeError)
@@ -25,8 +25,18 @@ std::runtime_error
         ├── IndexError
         ├── AssertionError
         ├── InternalError    (→ Python RuntimeError — internal bugs)
-        └── VerificationError (carries vector<Diagnostic>)
+        └── VerificationError (carries vector<Diagnostic>, → Python pypto.Error)
 ```
+
+Subclasses without a dedicated translation fall back to `pypto.Error` — a real Python type, not a
+bare `Exception`, so `VerificationError` stays catchable by type. `pypto.Error` derives from
+`Exception`, so `except Exception` keeps working. Tests must assert the concrete type rather than
+`Exception`; `tests/lint/check_no_broad_raises.py` enforces this.
+
+**The Python mirror is flat, not nested.** Each row above maps to an *independent* Python type, so
+the C++ inheritance shown in the tree does not carry over: `pypto.InternalError` derives from
+Python's `RuntimeError`, not from `pypto.Error`. `except pypto.Error` therefore catches
+`VerificationError` but **not** `InternalError`. Catch `Exception` if you need both.
 
 `Error::GetFullMessage()` returns the error message plus a formatted C++ stack trace.
 

--- a/docs/zh/dev/02-error-handling.md
+++ b/docs/zh/dev/02-error-handling.md
@@ -17,7 +17,7 @@ PyPTO 的错误处理框架提供带 C++ 栈回溯的结构化异常、附带 IR
 
 ```text
 std::runtime_error
-  └── Error                  (基类：自动栈回溯捕获)
+  └── Error                  (基类：自动栈回溯捕获，→ Python pypto.Error)
         ├── ValueError       (→ Python ValueError)
         ├── TypeError        (→ Python TypeError)
         ├── RuntimeError     (→ Python RuntimeError)
@@ -25,8 +25,17 @@ std::runtime_error
         ├── IndexError
         ├── AssertionError
         ├── InternalError    (→ Python RuntimeError — 内部 bug)
-        └── VerificationError (携带 vector<Diagnostic>)
+        └── VerificationError (携带 vector<Diagnostic>，→ Python pypto.Error)
 ```
+
+没有专门映射的子类会回退到 `pypto.Error`——这是一个真实的 Python 类型，而非裸 `Exception`，
+因此 `VerificationError` 仍可按类型捕获。`pypto.Error` 继承自 `Exception`，所以 `except Exception`
+依然有效。测试必须断言具体的异常类型而非 `Exception`；`tests/lint/check_no_broad_raises.py` 会强制这一点。
+
+**Python 侧的映射是扁平的，而非嵌套的。** 上表中每一行都映射到一个*独立*的 Python 类型，因此
+上面树状图中的 C++ 继承关系并不会传递过来：`pypto.InternalError` 继承自 Python 的 `RuntimeError`，
+而不是 `pypto.Error`。所以 `except pypto.Error` 能捕获 `VerificationError`，但**捕获不到**
+`InternalError`。如果两者都需要捕获，请捕获 `Exception`。
 
 `Error::GetFullMessage()` 返回错误消息加上格式化的 C++ 栈回溯。
 

--- a/python/bindings/modules/error.cpp
+++ b/python/bindings/modules/error.cpp
@@ -67,10 +67,11 @@ void BindErrors(nb::module_& m) {
   static nb::exception<pypto::AssertionError> exc_assertion_error(m, "AssertionError", PyExc_AssertionError);
   static nb::exception<pypto::InternalError> exc_internal_error(m, "InternalError", PyExc_RuntimeError);
 
-  // Set __module__ to "pypto" so the exception displays as "pypto.InternalError" instead of
-  // "pypto.pypto_core.InternalError"
-  PyObject* internal_error_type = exc_internal_error.ptr();
-  PyObject_SetAttrString(internal_error_type, "__module__", PyUnicode_FromString("pypto"));
+  // Set __module__ to "pypto" so the exceptions display as "pypto.Error" / "pypto.InternalError"
+  // instead of "pypto.pypto_core.Error" / "pypto.pypto_core.InternalError"
+  nb::str module_name("pypto");
+  nb::setattr(exc_error.ptr(), "__module__", module_name);
+  nb::setattr(exc_internal_error.ptr(), "__module__", module_name);
 
   // Register exception translator to convert C++ exceptions to Python exceptions.
   // See UserErrorMessage() above for when the C++ stack trace is included in the message.
@@ -98,10 +99,12 @@ void BindErrors(nb::module_& m) {
     } catch (const pypto::InternalError& e) {
       PyErr_SetString(exc_internal_error.ptr(), e.GetFullMessage().c_str());
     } catch (const pypto::Error& e) {
-      // Catch base Error last as a fallback. VerificationError lands here too: its diagnostic
-      // report already pinpoints the offending IR, and the frames above the throw are always the
-      // same verifier-registry entry, so it follows the user-facing default.
-      PyErr_SetString(PyExc_Exception, UserErrorMessage(e).c_str());
+      // Catch base Error last as a fallback. Raising the registered `pypto.Error` rather than a bare
+      // `Exception` keeps subclasses without a dedicated branch above catchable by type; it derives
+      // from `Exception`, so `except Exception` still works. VerificationError lands here too: its
+      // diagnostic report already pinpoints the offending IR, and the frames above the throw are
+      // always the same verifier-registry entry, so it follows the user-facing trace default.
+      PyErr_SetString(exc_error.ptr(), UserErrorMessage(e).c_str());
     }
   });
 }

--- a/python/pypto/__init__.py
+++ b/python/pypto/__init__.py
@@ -19,6 +19,7 @@ from typing import cast
 from . import compile_profiling, ir, language, runtime
 from .pypto_core import (
     DataType,
+    Error,
     InternalError,
     LogLevel,
     check,
@@ -69,6 +70,7 @@ __all__ = [
     "runtime",
     "testing",
     # Logging framework
+    "Error",
     "InternalError",
     "LogLevel",
     "set_log_level",

--- a/python/pypto/pypto_core/__init__.pyi
+++ b/python/pypto/pypto_core/__init__.pyi
@@ -15,6 +15,7 @@ This package provides Python bindings for the PyPTO C++ library.
 
 from . import arith, codegen, ir, passes, testing
 from .logging import (
+    Error,
     InternalError,
     LogLevel,
     check,
@@ -160,6 +161,7 @@ __all__ = [
     # Code generation
     "codegen",
     # Error classes
+    "Error",
     "InternalError",
     # Logging framework
     "LogLevel",

--- a/python/pypto/pypto_core/logging.pyi
+++ b/python/pypto/pypto_core/logging.pyi
@@ -19,8 +19,12 @@ class Error(Exception):
     `VerificationError` from the IR verifier.
     """
 
-class InternalError(Exception):
-    """Exception raised when an internal system error occurs"""
+class InternalError(RuntimeError):
+    """Exception raised when an internal system error occurs.
+
+    Registered against `PyExc_RuntimeError`, so it is a sibling of `Error` rather than a
+    subclass -- the C++ hierarchy does not carry over to Python.
+    """
 
 class LogLevel(IntEnum):
     """Enumeration of available log levels"""

--- a/python/pypto/pypto_core/logging.pyi
+++ b/python/pypto/pypto_core/logging.pyi
@@ -12,6 +12,13 @@ from enum import IntEnum
 
 from pypto.pypto_core.ir import Span
 
+class Error(Exception):
+    """Base class for PyPTO errors that have no more specific Python counterpart.
+
+    Raised for `pypto::Error` subclasses without a dedicated translation, notably
+    `VerificationError` from the IR verifier.
+    """
+
 class InternalError(Exception):
     """Exception raised when an internal system error occurs"""
 

--- a/src/ir/transforms/pass_context.cpp
+++ b/src/ir/transforms/pass_context.cpp
@@ -46,7 +46,12 @@ VerificationInstrument::VerificationInstrument(VerificationMode mode) : mode_(mo
 namespace {
 
 /**
- * @brief Verify properties and throw ValueError on errors (used by VerificationInstrument)
+ * @brief Verify properties and throw VerificationError on errors (used by VerificationInstrument)
+ *
+ * Throws the same type as PropertyVerifierRegistry::VerifyPropertiesOrThrow. Both report a failure
+ * of the *same* properties from the *same* registry, so they must not surface as different Python
+ * types -- otherwise the exception a caller sees depends on whether a VerificationInstrument
+ * happens to be installed (i.e. on PYPTO_VERIFY_LEVEL), which is a test-harness detail.
  */
 void VerifyOrThrowWithContext(const IRPropertySet& properties, const ProgramPtr& program,
                               const std::string& context_msg) {
@@ -61,7 +66,7 @@ void VerifyOrThrowWithContext(const IRPropertySet& properties, const ProgramPtr&
                                 [](const Diagnostic& d) { return d.severity == DiagnosticSeverity::Error; });
   if (has_errors) {
     std::string report = PropertyVerifierRegistry::GenerateReport(diagnostics);
-    throw pypto::ValueError(context_msg + ":\n" + report);
+    throw VerificationError(context_msg + ":\n" + report, std::move(diagnostics));
   }
 }
 

--- a/tests/lint/check_no_broad_raises.py
+++ b/tests/lint/check_no_broad_raises.py
@@ -1,0 +1,124 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""
+Script to check that tests assert concrete exception types.
+
+`pytest.raises(Exception)` discards the distinction PyPTO deliberately maintains across the
+C++/Python boundary: `CHECK` surfaces a user error (`ValueError`), `INTERNAL_CHECK` surfaces a
+compiler bug (`pypto.InternalError`), and the verifier raises `pypto.Error`. A test catching
+`Exception` still passes when a `CHECK` is silently downgraded to an `INTERNAL_CHECK` -- exactly
+the regression the rule in `.claude/rules/error-checking.md` exists to prevent.
+
+Note that ruff's B017 is not sufficient here: it exempts `pytest.raises(Exception, match=...)`,
+which was the overwhelming majority of historical occurrences.
+"""
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# Files that legitimately assert the exception *hierarchy* itself (e.g. "ValueError is catchable
+# as Exception"). For these the broad `Exception` is the property under test, not an omission.
+ALLOWLIST = frozenset(
+    {
+        "tests/ut/core/test_error.py",
+        "tests/ut/core/test_logging.py",
+    }
+)
+
+# Subtrees under tests/ that hold checker scripts rather than tests. They are not test code, and
+# their source legitimately spells out the forbidden pattern -- this file's own docstring does.
+EXCLUDED_PREFIXES = ("tests/lint/",)
+
+# Matches the context-manager and callable forms, a wrapped `pytest.raises(\n Exception`, and a
+# leading tuple entry (`pytest.raises((Exception, ...))`) -- a tuple led by Exception is exactly as
+# broad as Exception alone. A tuple of concrete types, e.g. `(ValueError, pypto.Error)`, is fine.
+BROAD_RAISES = re.compile(r"pytest\.raises\(\s*\(?\s*(Exception|BaseException)\b")
+
+
+def get_git_tracked_test_files(root_dir: Path) -> list[Path]:
+    """Get list of git-tracked Python files under tests/."""
+    try:
+        result = subprocess.run(
+            ["git", "ls-files", "--", "tests"],
+            cwd=root_dir,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except subprocess.CalledProcessError as e:
+        print(f"Error: Failed to get git tracked files: {e}", file=sys.stderr)
+        sys.exit(1)
+    except FileNotFoundError:
+        print("Error: git command not found", file=sys.stderr)
+        sys.exit(1)
+
+    files = []
+    for line in result.stdout.splitlines():
+        path = root_dir / line
+        if line.endswith(".py") and not line.startswith(EXCLUDED_PREFIXES) and path.is_file():
+            files.append(path)
+    return files
+
+
+def find_violations(path: Path) -> list[tuple[int, str, str]]:
+    """Return (line_number, exception_name, source_line) for each broad raises in `path`."""
+    text = path.read_text(encoding="utf-8", errors="replace")
+    lines = text.splitlines()
+    violations = []
+    for match in BROAD_RAISES.finditer(text):
+        lineno = text.count("\n", 0, match.start()) + 1
+        violations.append((lineno, match.group(1), lines[lineno - 1].strip()))
+    return violations
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Check that tests assert concrete exception types.")
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=Path(__file__).resolve().parents[2],
+        help="Repository root (defaults to the repo containing this script)",
+    )
+    args = parser.parse_args()
+    root_dir = args.root.resolve()
+
+    total = 0
+    for path in get_git_tracked_test_files(root_dir):
+        rel = path.relative_to(root_dir).as_posix()
+        if rel in ALLOWLIST:
+            continue
+        for lineno, exc_name, source in find_violations(path):
+            print(f"{rel}:{lineno}: pytest.raises({exc_name}) is too broad")
+            print(f"    {source}")
+            total += 1
+
+    if total:
+        print(
+            f"\nFound {total} over-broad exception assertion(s).\n"
+            "Assert the concrete type instead, keeping any existing `match=`:\n"
+            "    ValueError              -- a C++ CHECK (user error)\n"
+            "    pypto.InternalError     -- a C++ INTERNAL_CHECK (compiler bug)\n"
+            "    pypto.Error             -- VerificationError and other pypto::Error subclasses\n"
+            "    ParserSyntaxError, ParserTypeError, InvalidOperationError\n"
+            "                            -- from pypto.language.parser.diagnostics\n"
+            "If a test genuinely asserts the exception *hierarchy*, add its path to ALLOWLIST in\n"
+            f"{Path(__file__).name}.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print("All test files assert concrete exception types.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/lint/check_no_broad_raises.py
+++ b/tests/lint/check_no_broad_raises.py
@@ -9,39 +9,38 @@
 """
 Script to check that tests assert concrete exception types.
 
-`pytest.raises(Exception)` discards the distinction PyPTO deliberately maintains across the
-C++/Python boundary: `CHECK` surfaces a user error (`ValueError`), `INTERNAL_CHECK` surfaces a
-compiler bug (`pypto.InternalError`), and the verifier raises `pypto.Error`. A test catching
-`Exception` still passes when a `CHECK` is silently downgraded to an `INTERNAL_CHECK` -- exactly
-the regression the rule in `.claude/rules/error-checking.md` exists to prevent.
+Catching a bare ``Exception`` discards the distinction PyPTO deliberately maintains across the
+C++/Python boundary: ``CHECK`` surfaces a user error (``ValueError``), ``INTERNAL_CHECK`` surfaces a
+compiler bug (``pypto.InternalError``), and the verifier raises ``pypto.Error``. A test catching the
+base class still passes when a ``CHECK`` is silently downgraded to an ``INTERNAL_CHECK`` -- exactly
+the regression the rule in ``.claude/rules/error-checking.md`` exists to prevent.
 
-Note that ruff's B017 is not sufficient here: it exempts `pytest.raises(Exception, match=...)`,
-which was the overwhelming majority of historical occurrences.
+ruff's B017 is not a substitute: it exempts the ``match=`` form, which is the overwhelming majority
+of real occurrences, and neither ``B`` nor ``PT`` is in this repo's ruff ``select`` list.
+
+The check parses each file rather than scanning text, so prose in comments and docstrings is never
+flagged, and a broad type is caught anywhere in a tuple -- not just as its first element.
 """
 
 import argparse
-import re
+import ast
 import subprocess
 import sys
 from pathlib import Path
 
-# Files that legitimately assert the exception *hierarchy* itself (e.g. "ValueError is catchable
-# as Exception"). For these the broad `Exception` is the property under test, not an omission.
+# Tests that legitimately assert the exception *hierarchy* itself (e.g. "ValueError is catchable as
+# Exception"). Scoped to the exact class or function under test -- not the whole file -- so an
+# unrelated broad assertion added to one of these files later is still reported. Each entry is
+# "<repo-relative path>::<dotted qualname prefix>".
 ALLOWLIST = frozenset(
     {
-        "tests/ut/core/test_error.py",
-        "tests/ut/core/test_logging.py",
+        "tests/ut/core/test_error.py::TestErrorInheritance",
+        "tests/ut/core/test_logging.py::TestCheckFunctions.test_check_preserves_exception_hierarchy",
+        "tests/ut/core/test_logging.py::TestCheckFunctions.test_internal_check_preserves_exception_hierarchy",
     }
 )
 
-# Subtrees under tests/ that hold checker scripts rather than tests. They are not test code, and
-# their source legitimately spells out the forbidden pattern -- this file's own docstring does.
-EXCLUDED_PREFIXES = ("tests/lint/",)
-
-# Matches the context-manager and callable forms, a wrapped `pytest.raises(\n Exception`, and a
-# leading tuple entry (`pytest.raises((Exception, ...))`) -- a tuple led by Exception is exactly as
-# broad as Exception alone. A tuple of concrete types, e.g. `(ValueError, pypto.Error)`, is fine.
-BROAD_RAISES = re.compile(r"pytest\.raises\(\s*\(?\s*(Exception|BaseException)\b")
+BROAD_NAMES = frozenset({"Exception", "BaseException"})
 
 
 def get_git_tracked_test_files(root_dir: Path) -> list[Path]:
@@ -64,19 +63,58 @@ def get_git_tracked_test_files(root_dir: Path) -> list[Path]:
     files = []
     for line in result.stdout.splitlines():
         path = root_dir / line
-        if line.endswith(".py") and not line.startswith(EXCLUDED_PREFIXES) and path.is_file():
+        if line.endswith(".py") and path.is_file():
             files.append(path)
     return files
 
 
+def _is_raises_call(node: ast.Call, aliases: set[str]) -> bool:
+    """Whether *node* calls ``pytest.raises`` (or a name imported from pytest as ``raises``)."""
+    func = node.func
+    if isinstance(func, ast.Attribute) and func.attr == "raises":
+        return isinstance(func.value, ast.Name) and func.value.id == "pytest"
+    return isinstance(func, ast.Name) and func.id in aliases
+
+
+def _broad_names(expected: ast.expr) -> list[str]:
+    """Return the broad exception names used in a ``pytest.raises`` first argument."""
+    elements = expected.elts if isinstance(expected, ast.Tuple) else [expected]
+    return [e.id for e in elements if isinstance(e, ast.Name) and e.id in BROAD_NAMES]
+
+
+def _raises_aliases(tree: ast.Module) -> set[str]:
+    """Names bound by ``from pytest import raises [as X]`` at module level."""
+    return {
+        alias.asname or alias.name
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom) and node.module == "pytest"
+        for alias in node.names
+        if alias.name == "raises"
+    }
+
+
 def find_violations(path: Path) -> list[tuple[int, str, str]]:
-    """Return (line_number, exception_name, source_line) for each broad raises in `path`."""
-    text = path.read_text(encoding="utf-8", errors="replace")
-    lines = text.splitlines()
-    violations = []
-    for match in BROAD_RAISES.finditer(text):
-        lineno = text.count("\n", 0, match.start()) + 1
-        violations.append((lineno, match.group(1), lines[lineno - 1].strip()))
+    """Return (line_number, exception_name, enclosing qualname) for each broad raises in *path*."""
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8", errors="replace"))
+    except SyntaxError as e:
+        print(f"Error: Failed to parse {path}: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    aliases = _raises_aliases(tree)
+    violations: list[tuple[int, str, str]] = []
+
+    def walk(node: ast.AST, scope: tuple[str, ...]) -> None:
+        for child in ast.iter_child_nodes(node):
+            if isinstance(child, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)):
+                walk(child, (*scope, child.name))
+                continue
+            if isinstance(child, ast.Call) and _is_raises_call(child, aliases) and child.args:
+                for name in _broad_names(child.args[0]):
+                    violations.append((child.lineno, name, ".".join(scope)))
+            walk(child, scope)
+
+    walk(tree, ())
     return violations
 
 
@@ -94,11 +132,11 @@ def main() -> int:
     total = 0
     for path in get_git_tracked_test_files(root_dir):
         rel = path.relative_to(root_dir).as_posix()
-        if rel in ALLOWLIST:
-            continue
-        for lineno, exc_name, source in find_violations(path):
-            print(f"{rel}:{lineno}: pytest.raises({exc_name}) is too broad")
-            print(f"    {source}")
+        for lineno, exc_name, qualname in find_violations(path):
+            site = f"{rel}::{qualname}"
+            if any(site == a or site.startswith(f"{a}.") for a in ALLOWLIST):
+                continue
+            print(f"{rel}:{lineno}: pytest.raises({exc_name}) is too broad, in {qualname or '<module>'}")
             total += 1
 
     if total:
@@ -110,8 +148,9 @@ def main() -> int:
             "    pypto.Error             -- VerificationError and other pypto::Error subclasses\n"
             "    ParserSyntaxError, ParserTypeError, InvalidOperationError\n"
             "                            -- from pypto.language.parser.diagnostics\n"
-            "If a test genuinely asserts the exception *hierarchy*, add its path to ALLOWLIST in\n"
-            f"{Path(__file__).name}.",
+            "A tuple of concrete types, e.g. (ValueError, pypto.Error), is fine when a call can\n"
+            "legitimately raise either. If a test genuinely asserts the exception *hierarchy*, add\n"
+            f"its `<path>::<qualname>` to ALLOWLIST in {Path(__file__).name}.",
             file=sys.stderr,
         )
         return 1

--- a/tests/ut/codegen/distributed/test_distributed_pto_codegen.py
+++ b/tests/ut/codegen/distributed/test_distributed_pto_codegen.py
@@ -204,7 +204,7 @@ def test_remote_load_rejects_type_only_dynamic_partition_extent():
             )
             return pl.store(tile, [0, 0], out)
 
-    with pytest.raises(Exception, match="depends on unbound symbol 'REMOTE_VALID_N'"):
+    with pytest.raises(ValueError, match="depends on unbound symbol 'REMOTE_VALID_N'"):
         _generate_mlir(P)
 
 

--- a/tests/ut/codegen/test_codegen_preconditions.py
+++ b/tests/ut/codegen/test_codegen_preconditions.py
@@ -7,6 +7,7 @@
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
 
+import pypto
 import pypto.language as pl
 import pypto.language.distributed as pld
 import pytest
@@ -44,7 +45,7 @@ def test_distributed_codegen_requires_comm_domain_materialization_when_distribut
     # Deliberately omit MaterializeCommDomainScopes.
     program = passes.convert_to_ssa()(Input)
     cg = codegen.DistributedCodegen()
-    with pytest.raises(Exception, match="DistributedCodegen preconditions"):
+    with pytest.raises(pypto.InternalError, match="DistributedCodegen preconditions"):
         cg.generate(program)
 
 
@@ -86,7 +87,7 @@ def test_orchestration_codegen_precondition_entry_point():
             # convert_to_ssa). Codegen proceeds and fails at
             # InferFunctionCoreType because ExpandMixedKernel was not run —
             # proving the precondition did not block execution.
-            with pytest.raises(Exception, match="InferFunctionCoreType"):
+            with pytest.raises(pypto.InternalError, match="InferFunctionCoreType"):
                 codegen.generate_orchestration(program, func)
             return
     pytest.fail("No orchestration function found in program")
@@ -149,7 +150,7 @@ def test_orchestration_codegen_requires_return_params_explicit_for_multi_out_cal
     the result aliases.
     """
     program = _finalize(_MultiOutProgram)
-    with pytest.raises(Exception, match="ReturnParamsExplicit"):
+    with pytest.raises(pypto.Error, match="ReturnParamsExplicit"):
         codegen.generate_orchestration(program, _orch_func(program))
 
 

--- a/tests/ut/codegen/test_external_kernel.py
+++ b/tests/ut/codegen/test_external_kernel.py
@@ -22,6 +22,7 @@ from pathlib import Path
 import pypto.language as pl
 import pytest
 from pypto.ir.compile import compile as ir_compile
+from pypto.language.parser.diagnostics import ParserSyntaxError, ParserTypeError
 
 _KERNEL_SRC = '#include <cstdint>\nextern "C" void kernel_entry(int64_t* args) { (void)args; }\n'
 
@@ -138,7 +139,7 @@ def test_all_external_graph_emits_manifest_when_ptoas_is_skipped(tmp_path):
 def test_external_source_requires_aic_or_aiv(tmp_path):
     """external_source on a non-AIC/AIV function is rejected with a clear error."""
     cpp = _write_kernel(tmp_path)
-    with pytest.raises(Exception, match="external_source is only valid on FunctionType.AIC"):
+    with pytest.raises(ParserTypeError, match="external_source is only valid on FunctionType.AIC"):
 
         @pl.program
         class BadType:
@@ -162,7 +163,7 @@ def test_external_source_requires_aic_or_aiv(tmp_path):
 def test_external_kernel_requires_empty_body(tmp_path):
     """An external kernel with a non-``...`` body is rejected."""
     cpp = _write_kernel(tmp_path)
-    with pytest.raises(Exception, match="must have an empty"):
+    with pytest.raises(ParserSyntaxError, match="must have an empty"):
 
         @pl.program
         class BadBody:

--- a/tests/ut/codegen/test_external_kernel.py
+++ b/tests/ut/codegen/test_external_kernel.py
@@ -139,7 +139,7 @@ def test_all_external_graph_emits_manifest_when_ptoas_is_skipped(tmp_path):
 def test_external_source_requires_aic_or_aiv(tmp_path):
     """external_source on a non-AIC/AIV function is rejected with a clear error."""
     cpp = _write_kernel(tmp_path)
-    with pytest.raises(ParserTypeError, match="external_source is only valid on FunctionType.AIC"):
+    with pytest.raises(ParserTypeError, match=r"external_source is only valid on FunctionType\.AIC"):
 
         @pl.program
         class BadType:

--- a/tests/ut/codegen/test_orchestration_manual_scope.py
+++ b/tests/ut/codegen/test_orchestration_manual_scope.py
@@ -1109,7 +1109,7 @@ class TestManualScopeCodegen:
                 return out
 
         pm = PassManager.get_strategy(OptimizationStrategy.Default)
-        with pytest.raises(Exception, match="statically-known trip count"):
+        with pytest.raises(ValueError, match="statically-known trip count"):
             _generate_orch_code(pm.run_passes(Prog))
 
     def test_manual_scope_double_buffered_array_carry_above_legacy_16_cap(self):

--- a/tests/ut/codegen/test_pto_codegen_cross_core.py
+++ b/tests/ut/codegen/test_pto_codegen_cross_core.py
@@ -566,7 +566,9 @@ class TestCrossCoreTpushTpopCodegen:
 
         backend.reset_for_testing()
         backend.set_backend_type(BackendType.Ascend910B)
-        with pytest.raises(Exception, match="tpop valid_shape operand must be integer or index type, got i1"):
+        with pytest.raises(
+            ValueError, match="tpop valid_shape operand must be integer or index type, got i1"
+        ):
             codegen.PTOCodegen().generate(ir.Program([func], "dynamic_tpop_bool_row_program", span))
 
     @pytest.mark.parametrize(
@@ -1110,7 +1112,7 @@ class TestCrossCoreTpushTpopCodegen:
                 pl.tfree_to_aiv(received)
 
         with pytest.raises(
-            Exception,
+            ValueError,
             match=re.escape(
                 "system.tfree_to_aiv requires its tile argument to come from tile.tpop_from_aiv, "
                 "got tile.tpop_from_aic"
@@ -1140,7 +1142,7 @@ class TestCrossCoreTpushTpopCodegen:
                 pl.tfree_to_aiv(received, id=0)
 
         with pytest.raises(
-            Exception,
+            ValueError,
             match=re.escape(
                 "system.tfree_to_aiv pipe id 0 does not match originating tile.tpop_from_aiv pipe id 1"
             ),

--- a/tests/ut/codegen/test_pto_codegen_ops.py
+++ b/tests/ut/codegen/test_pto_codegen_ops.py
@@ -17,6 +17,7 @@ and verifies the generated orchestration code.
 
 import warnings
 
+import pypto
 import pypto.language as pl
 import pytest
 from pypto import DataType, backend, codegen, ir
@@ -2722,7 +2723,7 @@ class TestTileStoreAtomicCodegen:
             funcs = list(optimized.functions.values())
             target = next((f for f in funcs if ir.is_incore_type(f.func_type)), funcs[0])
             single = ir.Program([target], target.name, optimized.span)
-            with pytest.raises(Exception, match="bf16 atomic-add requires the Ascend910B"):
+            with pytest.raises(ValueError, match="bf16 atomic-add requires the Ascend910B"):
                 codegen.PTOCodegen().generate(single)
         finally:
             backend.reset_for_testing()
@@ -2818,7 +2819,7 @@ class TestTensorAssembleAtomicCodegen:
                 out = pl.assemble(out, target, [0, 0])
                 return out
 
-        with pytest.raises(Exception, match="global-memory destination"):
+        with pytest.raises(pypto.InternalError, match="global-memory destination"):
             self._generate_mlir(Prog)
 
 

--- a/tests/ut/core/test_error.py
+++ b/tests/ut/core/test_error.py
@@ -184,7 +184,7 @@ class TestStackTraceVisibility:
     )
     def test_user_error_omits_traceback_by_default(self, raise_fn: RaiseFn, no_backtrace_env: None):
         """A user error is just the message — internal frames are noise to the caller."""
-        with pytest.raises(Exception) as exc_info:
+        with pytest.raises((ValueError, TypeError, RuntimeError, IndexError)) as exc_info:
             raise_fn("user mistake")
 
         message = str(exc_info.value)
@@ -194,7 +194,7 @@ class TestStackTraceVisibility:
     @pytest.mark.parametrize("raise_fn", [testing.raise_internal_error, testing.raise_assertion_error])
     def test_bug_error_always_includes_traceback(self, raise_fn: RaiseFn, no_backtrace_env: None):
         """The INTERNAL_CHECK family signals a PyPTO bug — the trace is the primary artefact."""
-        with pytest.raises(Exception) as exc_info:
+        with pytest.raises((pypto.InternalError, AssertionError)) as exc_info:
             raise_fn("invariant broken")
 
         message = str(exc_info.value)
@@ -232,7 +232,7 @@ class TestStackTraceContents:
 
     def test_traceback_names_the_real_throw_site(self, no_backtrace_env: None):
         """The innermost frame must be the binding that threw."""
-        with pytest.raises(Exception) as exc_info:
+        with pytest.raises(pypto.InternalError) as exc_info:
             testing.raise_internal_error("invariant broken")
 
         files = _assert_has_trace(str(exc_info.value))
@@ -254,7 +254,7 @@ class TestStackTraceContents:
         built with debug info. Their presence is correct, so the assertion targets PyPTO sources
         rather than allowlisting the binding.
         """
-        with pytest.raises(Exception) as exc_info:
+        with pytest.raises(pypto.InternalError) as exc_info:
             testing.raise_internal_error("invariant broken")
 
         files = _assert_has_trace(str(exc_info.value))
@@ -263,7 +263,7 @@ class TestStackTraceContents:
 
     def test_traceback_omits_check_macro_infrastructure(self, no_backtrace_env: None):
         """The CHECK/INTERNAL_CHECK throw site in logging.h is noise, not a call-path frame."""
-        with pytest.raises(Exception) as exc_info:
+        with pytest.raises(pypto.InternalError) as exc_info:
             testing.raise_internal_error_with_span("boom", "kernel.py", 3, 5)
 
         files = _assert_has_trace(str(exc_info.value))

--- a/tests/ut/core/test_error.py
+++ b/tests/ut/core/test_error.py
@@ -21,6 +21,7 @@ import re
 import sys
 from collections.abc import Callable
 
+import pypto
 import pytest
 from pypto import testing
 
@@ -105,7 +106,7 @@ class TestErrorTypes:
 
     def test_generic_error_type(self):
         """Test that generic Error is raised with correct type."""
-        with pytest.raises(Exception) as exc_info:
+        with pytest.raises(pypto.Error) as exc_info:
             testing.raise_generic_error("test generic error")
 
         assert "test generic error" in str(exc_info.value)

--- a/tests/ut/ir/arith/test_const_fold.py
+++ b/tests/ut/ir/arith/test_const_fold.py
@@ -102,11 +102,11 @@ class TestFloorDivMod:
         assert result.value == 2  # floormod(-7, 3) = 2, NOT -1 (truncation)
 
     def test_floordiv_by_zero_raises(self):
-        with pytest.raises(Exception):
+        with pytest.raises(ValueError):
             fold_const(ir.FloorDiv(ci(5), ci(0), INT, S))
 
     def test_floormod_by_zero_raises(self):
-        with pytest.raises(Exception):
+        with pytest.raises(ValueError):
             fold_const(ir.FloorMod(ci(5), ci(0), INT, S))
 
 
@@ -485,7 +485,7 @@ class TestOverflowAndEdgeCases:
 
     def test_floordiv_int64_min_neg1_raises(self):
         """INT64_MIN // -1 overflows — should raise."""
-        with pytest.raises(Exception):
+        with pytest.raises(ValueError):
             fold_const(ir.FloorDiv(ci(INT64_MIN), ci(-1), INT, S))
 
     def test_pow_exponent_by_squaring(self):

--- a/tests/ut/ir/arith/test_int_operator.py
+++ b/tests/ut/ir/arith/test_int_operator.py
@@ -9,6 +9,7 @@
 
 """Tests for arith integer operator utilities (floordiv, floormod, GCD, LCM, ExtEuclid)."""
 
+import pypto
 import pytest
 from pypto.arith import extended_euclidean, floordiv, floormod, gcd, lcm
 
@@ -33,11 +34,11 @@ class TestFloorDiv:
         assert floordiv(0, 5) == 0
 
     def test_by_zero_raises(self):
-        with pytest.raises(Exception):
+        with pytest.raises(pypto.InternalError):
             floordiv(5, 0)
 
     def test_int64_min_div_neg1_raises(self):
-        with pytest.raises(Exception):
+        with pytest.raises(pypto.InternalError):
             floordiv(-(2**63), -1)
 
 
@@ -58,7 +59,7 @@ class TestFloorMod:
         assert floormod(6, 3) == 0
 
     def test_by_zero_raises(self):
-        with pytest.raises(Exception):
+        with pytest.raises(pypto.InternalError):
             floormod(5, 0)
 
 

--- a/tests/ut/ir/arith/test_modular_set.py
+++ b/tests/ut/ir/arith/test_modular_set.py
@@ -320,7 +320,7 @@ class TestModularSetConstraint:
 
 class TestModularSetValidation:
     def test_negative_coeff_raises(self):
-        with pytest.raises(Exception, match="non-negative"):
+        with pytest.raises(ValueError, match="non-negative"):
             analyzer.update(x, ModularSet(-2, 1))
 
 

--- a/tests/ut/ir/core/test_distributed_tensor_type.py
+++ b/tests/ut/ir/core/test_distributed_tensor_type.py
@@ -91,7 +91,7 @@ def test_assert_structural_equal_passes():
 def test_assert_structural_equal_diagnoses_class_mismatch():
     dt = DistributedTensorType([64], DataType.FP32)
     plain = TensorType([64], DataType.FP32)
-    with pytest.raises(Exception, match="Type name mismatch"):
+    with pytest.raises(ValueError, match="Type name mismatch"):
         assert_structural_equal(dt, plain)
 
 

--- a/tests/ut/ir/core/test_level_role_enums.py
+++ b/tests/ut/ir/core/test_level_role_enums.py
@@ -132,7 +132,7 @@ def test_structural_equal_with_level():
     f2 = _make_empty_func("a", level=ir.Level.HOST, role=ir.Role.SubWorker)
     f3 = _make_empty_func("a", level=ir.Level.POD, role=ir.Role.SubWorker)
     ir.assert_structural_equal(f1, f2)
-    with pytest.raises(Exception):
+    with pytest.raises(ValueError):
         ir.assert_structural_equal(f1, f3)
 
 
@@ -140,7 +140,7 @@ def test_structural_equal_none_vs_set():
     """structural_equal distinguishes None from set level."""
     f_none = _make_empty_func("a")
     f_set = _make_empty_func("a", level=ir.Level.HOST)
-    with pytest.raises(Exception):
+    with pytest.raises(ValueError):
         ir.assert_structural_equal(f_none, f_set)
 
 

--- a/tests/ut/ir/core/test_tuple_type.py
+++ b/tests/ut/ir/core/test_tuple_type.py
@@ -139,7 +139,7 @@ class TestTupleGetItemExpr:
         ir.TupleGetItemExpr(tuple_var, 1, span)
 
         # Out of bounds index should raise error
-        with pytest.raises(Exception):
+        with pytest.raises(ValueError):
             ir.TupleGetItemExpr(tuple_var, 2, span)
 
     def test_tuple_get_item_negative_index(self):
@@ -148,7 +148,7 @@ class TestTupleGetItemExpr:
         tuple_type = ir.TupleType([ir.ScalarType(DataType.INT64)])
         tuple_var = ir.Var("my_tuple", tuple_type, span)
 
-        with pytest.raises(Exception):
+        with pytest.raises(ValueError):
             ir.TupleGetItemExpr(tuple_var, -1, span)
 
     def test_tuple_get_item_wrong_type(self):
@@ -158,7 +158,7 @@ class TestTupleGetItemExpr:
         scalar_var = ir.Var("x", ir.ScalarType(DataType.INT64), span)
 
         # Should raise error when trying to access as tuple
-        with pytest.raises(Exception):
+        with pytest.raises(ValueError):
             ir.TupleGetItemExpr(scalar_var, 0, span)
 
     def test_nested_tuple_get_item(self):

--- a/tests/ut/ir/high_level/test_builder.py
+++ b/tests/ut/ir/high_level/test_builder.py
@@ -1352,7 +1352,7 @@ class TestIRBuilderProgram:
         """Test that getting an undeclared GlobalVar raises an error."""
         ib = IRBuilder()
 
-        with pytest.raises(Exception):  # Should raise RuntimeError
+        with pytest.raises(RuntimeError):  # Should raise RuntimeError
             with ib.program("test_program") as p:
                 # Try to get a GlobalVar that wasn't declared
                 p.get_global_var("nonexistent")

--- a/tests/ut/ir/operators/test_gather.py
+++ b/tests/ut/ir/operators/test_gather.py
@@ -86,19 +86,19 @@ class TestTileGatherIndexTypes:
         assert isinstance(call.type.shape[1], ir.ConstInt) and call.type.shape[1].value == 16
 
     def test_invalid_src_dtype_raises(self):
-        with pytest.raises(Exception, match="src dtype"):
+        with pytest.raises(ValueError, match="src dtype"):
             _gather(DataType.UINT8, DataType.INT32, DataType.INT32)
 
     @pytest.mark.parametrize("bad_idx_dtype", [DataType.FP32, DataType.INT8])
     def test_invalid_index_dtype_raises(self, bad_idx_dtype):
-        with pytest.raises(Exception, match="indices dtype"):
+        with pytest.raises(ValueError, match="indices dtype"):
             _gather(DataType.FP32, bad_idx_dtype, DataType.INT32)
 
     @pytest.mark.parametrize("wide_src_dtype", [DataType.FP32, DataType.INT32])
     def test_int16_index_requires_16bit_src(self, wide_src_dtype):
         # INT16 indices with a 32-bit src are unsafe on every target (tgather b32
         # reads them as u32), so the deducer rejects the combination outright.
-        with pytest.raises(Exception, match="16-bit src"):
+        with pytest.raises(ValueError, match="16-bit src"):
             _gather(wide_src_dtype, DataType.INT16, DataType.INT32)
 
     def test_non_tile_indices_raises(self):
@@ -106,7 +106,7 @@ class TestTileGatherIndexTypes:
         src = ir.Var("src", ir.TileType([1, 64], DataType.FP32), span)
         scalar_idx = ir.Var("idx", ir.ScalarType(DataType.INT32), span)
         tmp = ir.Var("tmp", ir.TileType([1, 64], DataType.INT32), span)
-        with pytest.raises(Exception, match="TileType"):
+        with pytest.raises(ValueError, match="TileType"):
             tile.gather(src, scalar_idx, tmp)
 
 

--- a/tests/ut/ir/operators/test_gather_compare.py
+++ b/tests/ut/ir/operators/test_gather_compare.py
@@ -19,6 +19,7 @@ Type contract (enforced by the op's type deduction):
 
 import pypto.language as pl
 import pytest
+from pypto.language.parser.diagnostics import InvalidOperationError
 
 _VALID_SRC_DTYPES = [pl.FP16, pl.FP32, pl.INT16, pl.INT32]
 _INVALID_SRC_DTYPES = [pl.UINT16, pl.UINT32, pl.UINT8, pl.INT64]
@@ -57,11 +58,11 @@ class TestTileGatherCompareTypes:
 
     @pytest.mark.parametrize("src_dtype", _INVALID_SRC_DTYPES)
     def test_invalid_src_dtype_raises(self, src_dtype):
-        with pytest.raises(Exception, match="src dtype"):
+        with pytest.raises(InvalidOperationError, match="src dtype"):
             _build_program(src_dtype=src_dtype)
 
     def test_kvalue_dtype_mismatch_raises(self):
-        with pytest.raises(Exception, match="kvalue dtype"):
+        with pytest.raises(InvalidOperationError, match="kvalue dtype"):
 
             @pl.program
             class Bad:
@@ -96,11 +97,11 @@ class TestTileGatherCompareCmpMode:
         assert "tile.gather_compare" in str(prog)
 
     def test_invalid_cmp_mode_string(self):
-        with pytest.raises(Exception, match="cmp_mode"):
+        with pytest.raises(InvalidOperationError, match="cmp_mode"):
             _build_program(cmp_mode="bogus")
 
     def test_invalid_cmp_mode_int(self):
-        with pytest.raises(Exception, match="cmp_mode"):
+        with pytest.raises(InvalidOperationError, match="cmp_mode"):
             _build_program(cmp_mode=99)
 
 
@@ -129,7 +130,7 @@ class TestTensorGatherCompareTypes:
 
     @pytest.mark.parametrize("src_dtype", _INVALID_SRC_DTYPES)
     def test_invalid_src_dtype_raises(self, src_dtype):
-        with pytest.raises(Exception, match="input dtype"):
+        with pytest.raises(InvalidOperationError, match="input dtype"):
             _build_tensor_compare_program(src_dtype=src_dtype)
 
     def test_compare_with_offset(self):
@@ -137,7 +138,7 @@ class TestTensorGatherCompareTypes:
         assert "tensor.gather_compare" in str(prog)
 
     def test_mutually_exclusive_index_and_compare(self):
-        with pytest.raises(Exception, match="mutually exclusive"):
+        with pytest.raises(InvalidOperationError, match="mutually exclusive"):
 
             @pl.program
             class Bad:
@@ -151,7 +152,7 @@ class TestTensorGatherCompareTypes:
                     return pl.tensor.gather(src, dim=-1, index=idx, kvalue=kv, cmp_mode="eq", out_cols=8)
 
     def test_mutually_exclusive_mask_and_compare(self):
-        with pytest.raises(Exception, match="mutually exclusive"):
+        with pytest.raises(InvalidOperationError, match="mutually exclusive"):
 
             @pl.program
             class Bad:

--- a/tests/ut/ir/operators/test_op_registry.py
+++ b/tests/ut/ir/operators/test_op_registry.py
@@ -135,13 +135,13 @@ def test_tensor_add_wrong_arg_count():
     var_a = ir.Var("a", tensor_type, span)
 
     # Too few arguments
-    with pytest.raises(Exception):
+    with pytest.raises(ValueError):
         ir.create_op_call("tensor.add", [var_a], span)
 
     # Too many arguments
     var_b = ir.Var("b", tensor_type, span)
     var_c = ir.Var("c", tensor_type, span)
-    with pytest.raises(Exception):
+    with pytest.raises(ValueError):
         ir.create_op_call("tensor.add", [var_a, var_b, var_c], span)
 
 
@@ -157,7 +157,7 @@ def test_tensor_add_wrong_type():
     tensor_type = ir.TensorType([dim8], DataType.FP32)
     var_tensor = ir.Var("t", tensor_type, span)
 
-    with pytest.raises(Exception):
+    with pytest.raises(ValueError):
         ir.create_op_call("tensor.add", [var_scalar, var_tensor], span)
 
 
@@ -179,7 +179,7 @@ def test_get_op():
     assert tensor_add_op.name == "tensor.add"
 
     # Non-existent operator should raise exception
-    with pytest.raises(Exception):
+    with pytest.raises(ValueError):
         ir.get_op("nonexistent.op")
 
 
@@ -363,7 +363,7 @@ def test_matmul_with_unknown_kwarg():
     # Unknown kwarg should raise ValueError
     kwargs = {"unknown_param": 123, "a_trans": False}
 
-    with pytest.raises(Exception) as exc_info:
+    with pytest.raises(ValueError) as exc_info:
         ir.create_op_call("tensor.matmul", [var_a, var_b], kwargs, span)
 
     # Check error message contains "unknown"
@@ -384,7 +384,7 @@ def test_matmul_with_wrong_type_kwarg():
         "a_trans": "true"  # Should be bool, not string
     }
 
-    with pytest.raises(Exception) as exc_info:
+    with pytest.raises(TypeError) as exc_info:
         ir.create_op_call("tensor.matmul", [var_a, var_b], kwargs, span)
 
     # Check error message indicates type mismatch

--- a/tests/ut/ir/operators/test_tensor_ops.py
+++ b/tests/ut/ir/operators/test_tensor_ops.py
@@ -2116,7 +2116,7 @@ def test_tensor_transpose_valid_shape_rank_mismatch_rejected():
     dim16 = ir.ConstInt(16, DataType.INT32, span)
     tensor_var = ir.Var("t", ir.TensorType([dim8, dim16], DataType.FP32), span)
 
-    with pytest.raises(Exception, match="valid_shape rank"):
+    with pytest.raises(ValueError, match="valid_shape rank"):
         tensor.transpose(tensor_var, 0, 1, valid_shape=[16])
 
 
@@ -2752,7 +2752,7 @@ def test_tensor_set_validshape_rejects_negative():
     tensor_type = ir.TensorType([dim32, dim32], DataType.FP32)
     tensor_var = ir.Var("t", tensor_type, span)
 
-    with pytest.raises(Exception, match="must be >= 0"):
+    with pytest.raises(ValueError, match="must be >= 0"):
         ir.op.tensor.set_validshape(tensor_var, -1, 16)
 
 
@@ -2763,7 +2763,7 @@ def test_tensor_set_validshape_rejects_exceeding_bound():
     tensor_type = ir.TensorType([dim32, dim32], DataType.FP32)
     tensor_var = ir.Var("t", tensor_type, span)
 
-    with pytest.raises(Exception, match="exceeds tensor bound"):
+    with pytest.raises(ValueError, match="exceeds tensor bound"):
         ir.op.tensor.set_validshape(tensor_var, 16, 64)
 
 
@@ -3962,7 +3962,7 @@ def test_tensor_sort32_wrong_dtype():
     src = ir.Var("src", ir.TensorType([d8, d32], DataType.INT32), span)
     idx = ir.Var("idx", ir.TensorType([d8, d32], DataType.INT32), span)
 
-    with pytest.raises(Exception, match=r"FP16 or FP32"):
+    with pytest.raises(ValueError, match=r"FP16 or FP32"):
         ir.op.tensor.sort32(src, idx)
 
 
@@ -3991,7 +3991,7 @@ def test_tensor_mrgsort_format1_invalid_block_len():
     d128 = ir.ConstInt(128, DataType.INT32, span)
     src = ir.Var("src", ir.TensorType([d1, d128], DataType.FP32), span)
 
-    with pytest.raises(Exception, match=r"multiple of 64"):
+    with pytest.raises(ValueError, match=r"multiple of 64"):
         ir.op.tensor.mrgsort(src, block_len=63)
 
 
@@ -4029,7 +4029,7 @@ def test_tensor_mrgsort_format2_dtype_mismatch():
     s2 = ir.Var("s2", src_fp32, span)
     s3 = ir.Var("s3", src_fp32, span)
 
-    with pytest.raises(Exception, match=r"matching dtype"):
+    with pytest.raises(ValueError, match=r"matching dtype"):
         ir.op.tensor.mrgsort(s0, s1, s2, s3)
 
 
@@ -4082,7 +4082,7 @@ def test_tensor_gather_dim_last_axis_positive():
 def test_tensor_gather_rejects_bad_dim():
     inp, idx = _make_gather_inputs()
     # rank=2, valid dims are -2..1. dim=2 is out of range.
-    with pytest.raises(Exception, match=r"dim"):
+    with pytest.raises(ValueError, match=r"dim"):
         ir.op.tensor.gather(inp, dim=2, index=idx)
 
 
@@ -4098,20 +4098,20 @@ def test_tensor_gather_accepts_int16_index_with_16bit_input():
 def test_tensor_gather_rejects_int16_index_with_32bit_input():
     """INT16 index with a 32-bit input is unsafe (tgather b32 reads it as u32)."""
     inp, idx = _make_gather_inputs(src_dtype=DataType.FP32, idx_dtype=DataType.INT16)
-    with pytest.raises(Exception, match=r"16-bit input"):
+    with pytest.raises(ValueError, match=r"16-bit input"):
         ir.op.tensor.gather(inp, dim=-1, index=idx)
 
 
 def test_tensor_gather_rejects_non_int_index_dtype():
     """A non-integer index dtype (FP32) is rejected outright."""
     inp, idx = _make_gather_inputs(idx_dtype=DataType.FP32)
-    with pytest.raises(Exception, match=r"index dtype INT32"):
+    with pytest.raises(ValueError, match=r"index dtype INT32"):
         ir.op.tensor.gather(inp, dim=-1, index=idx)
 
 
 def test_tensor_gather_rejects_unsupported_input_dtype():
     inp, idx = _make_gather_inputs(src_dtype=DataType.UINT32)
-    with pytest.raises(Exception, match=r"FP16, FP32, INT16, or INT32"):
+    with pytest.raises(ValueError, match=r"FP16, FP32, INT16, or INT32"):
         ir.op.tensor.gather(inp, dim=-1, index=idx)
 
 
@@ -4122,7 +4122,7 @@ def test_tensor_gather_rejects_rank_mismatch():
     K = ir.ConstInt(3, DataType.INT32, span)
     inp = ir.Var("inp", ir.TensorType([B, N], DataType.FP32), span)
     idx = ir.Var("idx", ir.TensorType([K], DataType.INT32), span)
-    with pytest.raises(Exception, match=r"rank"):
+    with pytest.raises(ValueError, match=r"rank"):
         ir.op.tensor.gather(inp, dim=-1, index=idx)
 
 
@@ -4134,7 +4134,7 @@ def test_tensor_gather_rejects_non_matching_outer_dim():
     K = ir.ConstInt(3, DataType.INT32, span)
     inp = ir.Var("inp", ir.TensorType([B, N], DataType.FP32), span)
     idx = ir.Var("idx", ir.TensorType([B2, K], DataType.INT32), span)
-    with pytest.raises(Exception, match=r"non-gather axes"):
+    with pytest.raises(ValueError, match=r"non-gather axes"):
         ir.op.tensor.gather(inp, dim=-1, index=idx)
 
 
@@ -4192,19 +4192,19 @@ def test_tensor_gather_mask_output_dtype_reinterpret():
 
 def test_tensor_gather_mask_rejects_bad_pattern():
     inp = _make_gather_mask_input()
-    with pytest.raises(Exception, match=r"mask_pattern in range"):
+    with pytest.raises(ValueError, match=r"mask_pattern in range"):
         ir.op.tensor.gather(inp, mask_pattern=0)
 
 
 def test_tensor_gather_mask_rejects_indivisible_cols():
     inp = _make_gather_mask_input(rows=2, cols=33)
-    with pytest.raises(Exception, match=r"divisible by 2"):
+    with pytest.raises(ValueError, match=r"divisible by 2"):
         ir.op.tensor.gather(inp, mask_pattern=1)
 
 
 def test_tensor_gather_mask_rejects_dtype_width_mismatch():
     inp = _make_gather_mask_input(rows=2, cols=32, dtype=DataType.FP16)
-    with pytest.raises(Exception, match=r"same bit width"):
+    with pytest.raises(ValueError, match=r"same bit width"):
         ir.op.tensor.gather(inp, mask_pattern=1, output_dtype=DataType.FP32)
 
 
@@ -4270,7 +4270,7 @@ def test_tensor_scatter_positive_dim():
 def test_tensor_scatter_rejects_unsupported_dim():
     """MVP only supports dim=-1 (last axis)."""
     inp, idx, src = _make_scatter_inputs()
-    with pytest.raises(Exception, match=r"dim=-1"):
+    with pytest.raises(ValueError, match=r"dim=-1"):
         ir.op.tensor.scatter(inp, dim=0, index=idx, src=src)
 
 
@@ -4281,7 +4281,7 @@ def test_tensor_scatter_rejects_dtype_mismatch():
     K = ir.ConstInt(4, DataType.INT32, span)
     N = ir.ConstInt(8, DataType.INT32, span)
     src_wrong = ir.Var("src_bad", ir.TensorType([K, N], DataType.FP16), span)
-    with pytest.raises(Exception, match=r"src dtype"):
+    with pytest.raises(ValueError, match=r"src dtype"):
         ir.op.tensor.scatter(inp, dim=-1, index=idx, src=src_wrong)
 
 
@@ -4301,7 +4301,7 @@ def test_tensor_scatter_rejects_index_size_mismatch(dtype, wrong_idx_dtype):
     K = ir.ConstInt(4, DataType.INT32, span)
     N = ir.ConstInt(8, DataType.INT32, span)
     idx_wrong = ir.Var("idx_bad", ir.TensorType([K, N], wrong_idx_dtype), span)
-    with pytest.raises(Exception, match=r"index dtype"):
+    with pytest.raises(ValueError, match=r"index dtype"):
         ir.op.tensor.scatter(inp, dim=-1, index=idx_wrong, src=src)
 
 
@@ -4337,7 +4337,7 @@ def test_tensor_scatter_mask_rejects_bad_pattern():
     C = ir.ConstInt(8, DataType.INT32, span)
     inp = ir.Var("inp", ir.TensorType([R, C], DataType.FP32), span)
     dst = ir.Var("dst", ir.TensorType([R, C], DataType.FP32), span)
-    with pytest.raises(Exception, match=r"mask_pattern in \[1, 7\]"):
+    with pytest.raises(ValueError, match=r"mask_pattern in \[1, 7\]"):
         ir.op.tensor.scatter(inp, mask_pattern=42, dst=dst)
 
 
@@ -4349,7 +4349,7 @@ def test_tensor_scatter_mask_rejects_col_expansion_mismatch():
     Cwrong = ir.ConstInt(24, DataType.INT32, span)
     inp = ir.Var("inp", ir.TensorType([R, C], DataType.FP32), span)
     dst = ir.Var("dst_bad", ir.TensorType([R, Cwrong], DataType.FP32), span)
-    with pytest.raises(Exception, match=r"mask_pattern=1"):
+    with pytest.raises(ValueError, match=r"mask_pattern=1"):
         ir.op.tensor.scatter(inp, mask_pattern=1, dst=dst)
 
 
@@ -4365,7 +4365,7 @@ def test_tensor_scatter_mask_rejects_dtype_mismatch():
     C2 = ir.ConstInt(16, DataType.INT32, span)
     inp = ir.Var("inp", ir.TensorType([R, C], DataType.FP16), span)
     dst = ir.Var("dst", ir.TensorType([R, C2], DataType.INT16), span)
-    with pytest.raises(Exception, match=r"same dtype"):
+    with pytest.raises(ValueError, match=r"same dtype"):
         ir.op.tensor.scatter(inp, mask_pattern=1, dst=dst)
 
 

--- a/tests/ut/ir/operators/test_tile_ops.py
+++ b/tests/ut/ir/operators/test_tile_ops.py
@@ -15,6 +15,7 @@ import pypto.language as pl
 import pytest
 from pypto import DataType, ir
 from pypto.ir.op import tile
+from pypto.language.parser.diagnostics import InvalidOperationError
 
 
 def _operand_dtype(expr: ir.Expr) -> DataType:
@@ -2790,7 +2791,7 @@ class TestTileSliceReshapeOps:
         tile_type = ir.TileType([dim16, dim16], DataType.FP32)
         tile_var = ir.Var("tile", tile_type, span)
 
-        with pytest.raises(Exception, match="must be >= 0"):
+        with pytest.raises(ValueError, match="must be >= 0"):
             tile.set_validshape(tile_var, -1, 8)
 
     def test_tile_set_validshape_rejects_exceeding_bound(self):
@@ -2801,7 +2802,7 @@ class TestTileSliceReshapeOps:
         tile_type = ir.TileType([dim16, dim16], DataType.FP32)
         tile_var = ir.Var("tile", tile_type, span)
 
-        with pytest.raises(Exception, match="exceeds tile bound"):
+        with pytest.raises(ValueError, match="exceeds tile bound"):
             tile.set_validshape(tile_var, 32, 8)
 
     def test_transform_operators_registered(self):
@@ -5002,7 +5003,7 @@ class TestTileStoreDistributedDest:
     def test_tile_store_rejects_non_tensor_dst(self):
         """Regression: a Tile destination is still rejected by the verifier."""
 
-        with pytest.raises(Exception, match="requires third argument to be a TensorType"):
+        with pytest.raises(InvalidOperationError, match="requires third argument to be a TensorType"):
 
             @pl.program
             class _Program:
@@ -5049,7 +5050,7 @@ class TestTileLoadDistributedSrc:
     def test_tile_load_rejects_non_tensor_src(self):
         """Regression: a non-tensor (Tile) source is still rejected."""
 
-        with pytest.raises(Exception, match="requires first argument to be a TensorType"):
+        with pytest.raises(InvalidOperationError, match="requires first argument to be a TensorType"):
 
             @pl.program
             class _Program:

--- a/tests/ut/ir/parser/test_alloc_window_buffer.py
+++ b/tests/ut/ir/parser/test_alloc_window_buffer.py
@@ -32,6 +32,7 @@ import pypto.language as pl
 import pypto.language.distributed as pld
 import pytest
 from pypto import DataType
+from pypto.language.parser.diagnostics import ParserSyntaxError
 from pypto.pypto_core import ir
 
 
@@ -155,7 +156,7 @@ def test_alloc_window_buffer_long_form():
 
 def test_alloc_window_buffer_rejects_non_name_lhs():
     """Tuple-unpacking / subscript / attribute LHS is rejected — name must be a bare identifier."""
-    with pytest.raises(Exception, match="must appear as the RHS of a simple assignment"):
+    with pytest.raises(ParserSyntaxError, match="must appear as the RHS of a simple assignment"):
 
         @pl.program
         class P:  # noqa: F841
@@ -166,7 +167,7 @@ def test_alloc_window_buffer_rejects_non_name_lhs():
 
 
 def test_alloc_window_buffer_rejects_duplicate_names():
-    with pytest.raises(Exception, match="already declared"):
+    with pytest.raises(ParserSyntaxError, match="already declared"):
 
         @pl.program
         class P:  # noqa: F841
@@ -179,7 +180,7 @@ def test_alloc_window_buffer_rejects_duplicate_names():
 
 def test_alloc_window_buffer_rejects_user_kwargs():
     """``dtype=`` is rejected on the scalar byte form — it is only valid with the shape form."""
-    with pytest.raises(Exception, match="dtype= is only valid when the first argument is a shape"):
+    with pytest.raises(ParserSyntaxError, match="dtype= is only valid when the first argument is a shape"):
 
         @pl.program
         class P:  # noqa: F841
@@ -191,7 +192,7 @@ def test_alloc_window_buffer_rejects_user_kwargs():
 
 def test_alloc_window_buffer_rejects_explicit_name_kwarg():
     """``name`` is parser-injected from the LHS and can't be passed explicitly."""
-    with pytest.raises(Exception, match="'name' kwarg cannot be passed explicitly"):
+    with pytest.raises(ParserSyntaxError, match="'name' kwarg cannot be passed explicitly"):
 
         @pl.program
         class P:  # noqa: F841
@@ -203,7 +204,7 @@ def test_alloc_window_buffer_rejects_explicit_name_kwarg():
 
 def test_alloc_window_buffer_rejects_bare_call_outside_assignment():
     """Without an assignment LHS there is no globally-unique name to bind to."""
-    with pytest.raises(Exception, match="must appear as the RHS of a simple assignment"):
+    with pytest.raises(ParserSyntaxError, match="must appear as the RHS of a simple assignment"):
 
         @pl.program
         class P:  # noqa: F841
@@ -215,7 +216,7 @@ def test_alloc_window_buffer_rejects_bare_call_outside_assignment():
 
 def test_alloc_window_buffer_rejects_list_without_dtype():
     """A list/tuple without ``dtype=`` is rejected — the shape form requires dtype."""
-    with pytest.raises(Exception, match="requires dtype="):
+    with pytest.raises(ParserSyntaxError, match="requires dtype="):
 
         @pl.program
         class P:  # noqa: F841
@@ -276,7 +277,7 @@ def test_alloc_window_buffer_shaped_long_form():
 
 def test_alloc_window_buffer_rejects_empty_shape():
     """An empty shape list is rejected with a clear error."""
-    with pytest.raises(Exception, match="shape must be non-empty"):
+    with pytest.raises(ParserSyntaxError, match="shape must be non-empty"):
 
         @pl.program
         class P:  # noqa: F841
@@ -288,7 +289,7 @@ def test_alloc_window_buffer_rejects_empty_shape():
 
 def test_alloc_window_buffer_rejects_non_positive_static_dim():
     """Zero and negative static dimensions are rejected with a clear error."""
-    with pytest.raises(Exception, match="all dimensions must be positive"):
+    with pytest.raises(ParserSyntaxError, match="all dimensions must be positive"):
 
         @pl.program
         class P:  # noqa: F841
@@ -297,7 +298,7 @@ def test_alloc_window_buffer_rejects_non_positive_static_dim():
                 buf = pld.alloc_window_buffer([0, 128], dtype=pl.FP32)  # noqa: F841
                 return buf
 
-    with pytest.raises(Exception, match="all dimensions must be positive"):
+    with pytest.raises(ParserSyntaxError, match="all dimensions must be positive"):
 
         @pl.program
         class P:  # noqa: F841

--- a/tests/ut/ir/parser/test_dispatch_device_kwarg.py
+++ b/tests/ut/ir/parser/test_dispatch_device_kwarg.py
@@ -26,6 +26,7 @@ inspect the resolved expression to derive the per-dispatch device subset:
 import pypto.language as pl
 import pypto.language.distributed as pld
 import pytest
+from pypto.language.parser.diagnostics import ParserTypeError
 from pypto.pypto_core import ir
 
 
@@ -188,7 +189,7 @@ def test_device_rejected_on_non_orchestrator_callee():
     """A callee that is not an Orchestrator (default ``Opaque`` /
     ``SubWorker``) does not accept ``device=``. Predicate is on ``role``,
     not ``func_type``."""
-    with pytest.raises(Exception, match="'device'"):
+    with pytest.raises(ParserTypeError, match="'device'"):
 
         @pl.program
         class P:  # noqa: F841

--- a/tests/ut/ir/parser/test_remote_load.py
+++ b/tests/ut/ir/parser/test_remote_load.py
@@ -25,6 +25,7 @@ sites. The unified short form ``pld.remote_load(...)`` is exercised in
 import pypto.language as pl
 import pypto.language.distributed as pld
 import pytest
+from pypto.language.parser.diagnostics import InvalidOperationError
 from pypto.pypto_core import ir
 
 
@@ -173,7 +174,7 @@ def test_remote_load_accepts_valid_shape_for_ragged_tail():
 
 
 def test_remote_load_rejects_zero_positional():
-    with pytest.raises(Exception, match="positional argument"):
+    with pytest.raises(InvalidOperationError, match="positional argument"):
 
         @pl.program
         class P:  # noqa: F841
@@ -190,7 +191,7 @@ def test_remote_load_rejects_zero_positional():
 def test_remote_load_rejects_too_many_positional():
     # The optional fifth argument is valid_shape; a sixth positional arg is
     # still rejected.
-    with pytest.raises(Exception, match="positional argument"):
+    with pytest.raises(InvalidOperationError, match="positional argument"):
 
         @pl.program
         class P:  # noqa: F841
@@ -225,7 +226,7 @@ def test_remote_load_accepts_positional_args():
 
 
 def test_remote_load_rejects_missing_peer():
-    with pytest.raises(Exception, match="required positional argument"):
+    with pytest.raises(InvalidOperationError, match="required positional argument"):
 
         @pl.program
         class P:  # noqa: F841
@@ -239,7 +240,7 @@ def test_remote_load_rejects_missing_peer():
 
 
 def test_remote_load_rejects_missing_offsets():
-    with pytest.raises(Exception, match="required positional argument"):
+    with pytest.raises(InvalidOperationError, match="required positional argument"):
 
         @pl.program
         class P:  # noqa: F841
@@ -254,7 +255,7 @@ def test_remote_load_rejects_missing_offsets():
 
 
 def test_remote_load_rejects_missing_shape():
-    with pytest.raises(Exception, match="required positional argument"):
+    with pytest.raises(InvalidOperationError, match="required positional argument"):
 
         @pl.program
         class P:  # noqa: F841
@@ -269,7 +270,7 @@ def test_remote_load_rejects_missing_shape():
 
 
 def test_remote_load_rejects_unknown_kwarg():
-    with pytest.raises(Exception, match="unexpected keyword argument"):
+    with pytest.raises(InvalidOperationError, match="unexpected keyword argument"):
 
         @pl.program
         class P:  # noqa: F841
@@ -292,7 +293,7 @@ def test_remote_load_rejects_unknown_kwarg():
 
 def test_remote_load_rejects_plain_tensor_target():
     """The parser refuses a ``pl.Tensor`` target — must be window-bound."""
-    with pytest.raises(Exception, match="DistributedTensor"):
+    with pytest.raises(InvalidOperationError, match="DistributedTensor"):
 
         @pl.program
         class P:  # noqa: F841
@@ -312,7 +313,7 @@ def test_remote_load_rejects_non_list_offsets():
     Mirrors ``pl.tile.load``: a non-iterable ``offsets`` is rejected by
     ``_normalize_intlike`` and surfaces as a ``pld.tile`` dispatch error.
     """
-    with pytest.raises(Exception, match="remote_load"):
+    with pytest.raises(InvalidOperationError, match="remote_load"):
 
         @pl.program
         class P:  # noqa: F841
@@ -328,7 +329,7 @@ def test_remote_load_rejects_non_list_offsets():
 
 def test_remote_load_rejects_unknown_subop():
     """``pld.tile.<other>`` is rejected at 3-segment dispatch."""
-    with pytest.raises(Exception, match="pld.tile"):
+    with pytest.raises(InvalidOperationError, match="pld.tile"):
 
         @pl.program
         class P:  # noqa: F841

--- a/tests/ut/ir/parser/test_remote_load.py
+++ b/tests/ut/ir/parser/test_remote_load.py
@@ -329,7 +329,7 @@ def test_remote_load_rejects_non_list_offsets():
 
 def test_remote_load_rejects_unknown_subop():
     """``pld.tile.<other>`` is rejected at 3-segment dispatch."""
-    with pytest.raises(InvalidOperationError, match="pld.tile"):
+    with pytest.raises(InvalidOperationError, match=r"pld\.tile"):
 
         @pl.program
         class P:  # noqa: F841

--- a/tests/ut/ir/parser/test_remote_store.py
+++ b/tests/ut/ir/parser/test_remote_store.py
@@ -164,7 +164,7 @@ def test_remote_store_rejects_plain_tensor_target():
 
 def test_remote_store_rejects_unknown_subop():
     """``pld.tile.<other>`` is rejected at 3-segment dispatch."""
-    with pytest.raises(InvalidOperationError, match="pld.tile"):
+    with pytest.raises(InvalidOperationError, match=r"pld\.tile"):
 
         @pl.program
         class P:  # noqa: F841

--- a/tests/ut/ir/parser/test_remote_store.py
+++ b/tests/ut/ir/parser/test_remote_store.py
@@ -24,6 +24,7 @@ sites.
 import pypto.language as pl
 import pypto.language.distributed as pld
 import pytest
+from pypto.language.parser.diagnostics import InvalidOperationError
 from pypto.pypto_core import ir
 
 
@@ -147,7 +148,7 @@ def test_remote_store_round_trips_through_printer():
 
 def test_remote_store_rejects_plain_tensor_target():
     """The parser refuses a ``pl.Tensor`` target — must be window-bound."""
-    with pytest.raises(Exception, match="DistributedTensor"):
+    with pytest.raises(InvalidOperationError, match="DistributedTensor"):
 
         @pl.program
         class P:  # noqa: F841
@@ -163,7 +164,7 @@ def test_remote_store_rejects_plain_tensor_target():
 
 def test_remote_store_rejects_unknown_subop():
     """``pld.tile.<other>`` is rejected at 3-segment dispatch."""
-    with pytest.raises(Exception, match="pld.tile"):
+    with pytest.raises(InvalidOperationError, match="pld.tile"):
 
         @pl.program
         class P:  # noqa: F841

--- a/tests/ut/ir/parser/test_system_ops.py
+++ b/tests/ut/ir/parser/test_system_ops.py
@@ -31,6 +31,7 @@ import pypto.language as pl
 import pypto.language.distributed as pld
 import pytest
 from pypto import DataType
+from pypto.language.parser.diagnostics import InvalidOperationError
 from pypto.pypto_core import ir
 
 
@@ -167,7 +168,7 @@ def test_rank_and_nranks_compose_in_expression():
 
 def test_get_comm_ctx_rejects_plain_tensor():
     """The C++ verifier refuses a plain ``pl.Tensor`` — precise ObjectKind match."""
-    with pytest.raises(Exception, match="DistributedTensor"):
+    with pytest.raises(InvalidOperationError, match="DistributedTensor"):
 
         @pl.program
         class P:  # noqa: F841
@@ -178,7 +179,7 @@ def test_get_comm_ctx_rejects_plain_tensor():
 
 def test_rank_rejects_non_comm_ctx_arg():
     """The C++ verifier refuses any non-CommCtx argument to pld.system.rank."""
-    with pytest.raises(Exception, match="CommCtx"):
+    with pytest.raises(InvalidOperationError, match="CommCtx"):
 
         @pl.program
         class P:  # noqa: F841
@@ -189,7 +190,7 @@ def test_rank_rejects_non_comm_ctx_arg():
 
 def test_unknown_system_op_rejected():
     """Unknown 3-segment ``pld.system.<foo>`` produces a clear parser error."""
-    with pytest.raises(Exception, match=r"pld\.system\.foo"):
+    with pytest.raises(InvalidOperationError, match=r"pld\.system\.foo"):
 
         @pl.program
         class P:  # noqa: F841

--- a/tests/ut/ir/parser/test_window_op.py
+++ b/tests/ut/ir/parser/test_window_op.py
@@ -25,6 +25,7 @@ from typing import cast
 import pypto.language as pl
 import pypto.language.distributed as pld
 import pytest
+from pypto.language.parser.diagnostics import InvalidOperationError, ParserSyntaxError
 from pypto.pypto_core import ir
 
 
@@ -143,7 +144,7 @@ def test_window_propagates_multi_dim_shape():
 
 def test_window_rejects_non_ptr_arg():
     """A non-Ptr-typed Var cannot stand in for a Ptr handle."""
-    with pytest.raises(Exception, match="Ptr handle"):
+    with pytest.raises(InvalidOperationError, match="Ptr handle"):
 
         @pl.program
         class P:  # noqa: F841
@@ -154,7 +155,7 @@ def test_window_rejects_non_ptr_arg():
 
 
 def test_window_rejects_unknown_kwarg():
-    with pytest.raises(Exception, match=r"unexpected keyword argument|does not accept kwarg"):
+    with pytest.raises(InvalidOperationError, match=r"unexpected keyword argument|does not accept kwarg"):
 
         @pl.program
         class P:  # noqa: F841
@@ -166,7 +167,7 @@ def test_window_rejects_unknown_kwarg():
 
 
 def test_window_rejects_missing_shape_arg():
-    with pytest.raises(Exception, match=r"missing.*positional argument|2 positional"):
+    with pytest.raises(InvalidOperationError, match=r"missing.*positional argument|2 positional"):
 
         @pl.program
         class P:  # noqa: F841
@@ -178,7 +179,7 @@ def test_window_rejects_missing_shape_arg():
 
 
 def test_window_rejects_missing_dtype_kwarg():
-    with pytest.raises(Exception, match="dtype"):
+    with pytest.raises(InvalidOperationError, match="dtype"):
 
         @pl.program
         class P:  # noqa: F841
@@ -224,7 +225,7 @@ def test_window_long_form():
 
 def test_alloc_names_globally_unique_across_functions():
     """A second function in the same @pl.program cannot reuse a buffer name."""
-    with pytest.raises(Exception, match="already declared"):
+    with pytest.raises(ParserSyntaxError, match="already declared"):
 
         @pl.program
         class P:  # noqa: F841

--- a/tests/ut/ir/parser/test_world_size.py
+++ b/tests/ut/ir/parser/test_world_size.py
@@ -22,6 +22,7 @@ import pypto.language as pl
 import pypto.language.distributed as pld
 import pytest
 from pypto import DataType
+from pypto.language.parser.diagnostics import InvalidOperationError, ParserSyntaxError
 from pypto.pypto_core import ir
 
 
@@ -118,7 +119,7 @@ def test_world_size_can_drive_pl_range_bound():
 
 
 def test_world_size_rejects_positional_args():
-    with pytest.raises(Exception, match=r"no positional arguments|takes 0 positional"):
+    with pytest.raises(InvalidOperationError, match=r"no positional arguments|takes 0 positional"):
 
         @pl.program
         class P:  # noqa: F841
@@ -129,7 +130,9 @@ def test_world_size_rejects_positional_args():
 
 
 def test_world_size_rejects_kwargs():
-    with pytest.raises(Exception, match=r"does not accept keyword arguments|unexpected keyword argument"):
+    with pytest.raises(
+        InvalidOperationError, match=r"does not accept keyword arguments|unexpected keyword argument"
+    ):
 
         @pl.program
         class P:  # noqa: F841
@@ -142,7 +145,7 @@ def test_world_size_rejects_kwargs():
 def test_world_size_rejected_outside_host_function():
     """``pld.world_size()`` is host-only — calling it from a CORE_GROUP-level
     function body is a parse error."""
-    with pytest.raises(Exception, match="HOST"):
+    with pytest.raises(ParserSyntaxError, match="HOST"):
 
         @pl.program
         class P:  # noqa: F841
@@ -157,7 +160,7 @@ def test_world_size_rejected_in_nested_device_scope_within_host_function():
     """Even inside a HOST orchestrator, ``pld.world_size()`` must be rejected
     when nested inside a device-side scope (InCore / SPMD), since
     the call is not lowerable there."""
-    with pytest.raises(Exception, match="InCore"):
+    with pytest.raises(ParserSyntaxError, match="InCore"):
 
         @pl.program
         class P:  # noqa: F841

--- a/tests/ut/ir/test_distributed_ops.py
+++ b/tests/ut/ir/test_distributed_ops.py
@@ -249,7 +249,7 @@ def test_tensor_allreduce_rejects_unknown_reduce_op_value():
     span = ir.Span.unknown()
     src = _make_distributed_tensor_var("src", [16], DataType.FP32, span)
     signal = _make_distributed_tensor_var("signal", [4], DataType.INT32, span)
-    with pytest.raises(ValueError, match="ReduceOp.Sum, Max, Min, or Prod"):
+    with pytest.raises(ValueError, match=r"ReduceOp\.Sum, Max, Min, or Prod"):
         ir.create_op_call(
             "pld.tensor.allreduce",
             [src, signal],

--- a/tests/ut/ir/test_distributed_ops.py
+++ b/tests/ut/ir/test_distributed_ops.py
@@ -84,7 +84,7 @@ def test_alloc_window_buffer_returns_ptr_type():
 def test_alloc_window_buffer_requires_non_empty_name():
     span = ir.Span.unknown()
     size = ir.ConstInt(4, DataType.INT64, span)
-    with pytest.raises(Exception, match="non-empty 'name'"):
+    with pytest.raises(ValueError, match="non-empty 'name'"):
         ir.create_op_call(
             "pld.tensor.alloc_window_buffer",
             [size],
@@ -146,7 +146,7 @@ def test_window_rejects_non_ptr_arg():
     tensor_type = ir.TensorType([ir.ConstInt(64, DataType.INT64, span)], DataType.FP32)
     bad = ir.Var("x", tensor_type, span)
     shape = _make_shape_tuple([64], span)
-    with pytest.raises(Exception, match="Ptr"):
+    with pytest.raises(ValueError, match="Ptr"):
         ir.create_op_call("pld.tensor.window", [bad, shape], {"dtype": DataType.FP32}, span)
 
 
@@ -154,7 +154,7 @@ def test_window_rejects_non_make_tuple_shape():
     span = ir.Span.unknown()
     base = ir.Var("buf", ir.PtrType(), span)
     bad_shape = ir.ConstInt(8, DataType.INT64, span)
-    with pytest.raises(Exception, match="shape tuple"):
+    with pytest.raises(ValueError, match="shape tuple"):
         ir.create_op_call("pld.tensor.window", [base, bad_shape], {"dtype": DataType.FP32}, span)
 
 
@@ -208,13 +208,13 @@ def test_world_size_returns_int64_scalar():
 
 def test_world_size_rejects_positional_args():
     span = ir.Span.unknown()
-    with pytest.raises(Exception, match="no positional arguments"):
+    with pytest.raises(ValueError, match="no positional arguments"):
         ir.create_op_call("pld.system.world_size", [ir.ConstInt(0, DataType.INT64, span)], {}, span)
 
 
 def test_world_size_rejects_kwargs():
     span = ir.Span.unknown()
-    with pytest.raises(Exception, match="no kwargs"):
+    with pytest.raises(ValueError, match="no kwargs"):
         ir.create_op_call("pld.system.world_size", [], {"foo": 1}, span)
 
 
@@ -249,7 +249,7 @@ def test_tensor_allreduce_rejects_unknown_reduce_op_value():
     span = ir.Span.unknown()
     src = _make_distributed_tensor_var("src", [16], DataType.FP32, span)
     signal = _make_distributed_tensor_var("signal", [4], DataType.INT32, span)
-    with pytest.raises(Exception, match="ReduceOp.Sum, Max, Min, or Prod"):
+    with pytest.raises(ValueError, match="ReduceOp.Sum, Max, Min, or Prod"):
         ir.create_op_call(
             "pld.tensor.allreduce",
             [src, signal],
@@ -303,7 +303,7 @@ def test_tensor_allreduce_rejects_plain_tensor_src():
     span = ir.Span.unknown()
     src = ir.Var("src", ir.TensorType([ir.ConstInt(16, DataType.INT64, span)], DataType.FP32), span)
     signal = _make_distributed_tensor_var("signal", [4], DataType.INT32, span)
-    with pytest.raises(Exception, match="DistributedTensor"):
+    with pytest.raises(ValueError, match="DistributedTensor"):
         dist_tensor_ops.allreduce(src, signal, op=ir.ReduceOp.Sum, span=span)
 
 
@@ -311,7 +311,7 @@ def test_tensor_allreduce_rejects_non_int32_signal():
     span = ir.Span.unknown()
     src = _make_distributed_tensor_var("src", [16], DataType.FP32, span)
     signal = _make_distributed_tensor_var("signal", [4], DataType.FP32, span)
-    with pytest.raises(Exception, match="signal must have INT32 element type"):
+    with pytest.raises(ValueError, match="signal must have INT32 element type"):
         dist_tensor_ops.allreduce(src, signal, op=ir.ReduceOp.Sum, span=span)
 
 
@@ -335,7 +335,7 @@ def test_tensor_allreduce_rejects_unsupported_target_dtype():
     span = ir.Span.unknown()
     src = _make_distributed_tensor_var("src", [16], DataType.BF16, span)
     signal = _make_distributed_tensor_var("signal", [4], DataType.INT32, span)
-    with pytest.raises(Exception, match="target dtype must be FP16 or FP32"):
+    with pytest.raises(ValueError, match="target dtype must be FP16 or FP32"):
         dist_tensor_ops.allreduce(src, signal, op=ir.ReduceOp.Sum, span=span)
 
 
@@ -343,7 +343,7 @@ def test_builtin_tensor_allreduce_is_internal_only():
     span = ir.Span.unknown()
     src = _make_distributed_tensor_var("src", [16], DataType.FP32, span)
     signal = _make_distributed_tensor_var("signal", [4], DataType.INT32, span)
-    with pytest.raises(Exception, match="internal-only"):
+    with pytest.raises(ValueError, match="internal-only"):
         ir.create_op_call(
             "builtin.tensor.allreduce",
             [src, signal],
@@ -439,7 +439,7 @@ def test_remote_load_four_arg_form_rejects_out_of_bounds_window():
     target = _make_distributed_tensor_var("data", [1, 17], DataType.FP32, span)
     peer = ir.Var("peer", ir.ScalarType(DataType.INT32), span)
 
-    with pytest.raises(Exception, match="reads past the end of dimension 1"):
+    with pytest.raises(ValueError, match="reads past the end of dimension 1"):
         ir.create_op_call(
             "pld.tile.remote_load",
             [target, peer, _make_shape_tuple([0, 0], span), _make_shape_tuple([1, 8192], span)],
@@ -520,7 +520,7 @@ def test_remote_load_rejects_mismatched_valid_shape_rank():
     target = _make_distributed_tensor_var("data", [64, 32], DataType.FP32, span)
     peer = ir.Var("peer", ir.ScalarType(DataType.INT32), span)
 
-    with pytest.raises(Exception, match="valid_shape rank"):
+    with pytest.raises(ValueError, match="valid_shape rank"):
         ir.create_op_call(
             "pld.tile.remote_load",
             [
@@ -541,7 +541,7 @@ def test_remote_load_rejects_negative_valid_shape():
     target = _make_distributed_tensor_var("data", [64], DataType.FP32, span)
     peer = ir.Var("peer", ir.ScalarType(DataType.INT32), span)
 
-    with pytest.raises(Exception, match="valid_shape 0 is provably negative"):
+    with pytest.raises(ValueError, match="valid_shape 0 is provably negative"):
         ir.create_op_call(
             "pld.tile.remote_load",
             [
@@ -563,7 +563,7 @@ def test_remote_load_rejects_non_integer_valid_shape():
     peer = ir.Var("peer", ir.ScalarType(DataType.INT32), span)
     float_valid_shape = ir.MakeTuple([ir.ConstFloat(1.0, DataType.FP32, span)], span)
 
-    with pytest.raises(Exception, match="valid_shape 0 must be an integer scalar"):
+    with pytest.raises(ValueError, match="valid_shape 0 must be an integer scalar"):
         ir.create_op_call(
             "pld.tile.remote_load",
             [target, peer, _make_shape_tuple([0], span), _make_shape_tuple([32], span), float_valid_shape],
@@ -584,7 +584,7 @@ def test_remote_load_rejects_plain_tensor_target():
     offsets = _make_shape_tuple([0], span)
     shape = _make_shape_tuple([32], span)
 
-    with pytest.raises(Exception, match="DistributedTensor"):
+    with pytest.raises(ValueError, match="DistributedTensor"):
         ir.create_op_call(
             "pld.tile.remote_load",
             [plain, peer, offsets, shape],
@@ -601,7 +601,7 @@ def test_remote_load_rejects_non_scalar_peer():
     offsets = _make_shape_tuple([0], span)
     shape = _make_shape_tuple([32], span)
 
-    with pytest.raises(Exception, match="peer must be a scalar"):
+    with pytest.raises(ValueError, match="peer must be a scalar"):
         ir.create_op_call(
             "pld.tile.remote_load",
             [target, bad_peer, offsets, shape],
@@ -618,7 +618,7 @@ def test_remote_load_rejects_mismatched_offsets_rank():
     bad_offsets = _make_shape_tuple([0], span)  # 1-D, but target is 2-D
     shape = _make_shape_tuple([32, 16], span)
 
-    with pytest.raises(Exception, match="offsets rank"):
+    with pytest.raises(ValueError, match="offsets rank"):
         ir.create_op_call(
             "pld.tile.remote_load",
             [target, peer, bad_offsets, shape],
@@ -635,7 +635,7 @@ def test_remote_load_rejects_mismatched_shape_rank():
     offsets = _make_shape_tuple([0, 0], span)
     bad_shape = _make_shape_tuple([16], span)  # 1-D, but target is 2-D
 
-    with pytest.raises(Exception, match="shape rank"):
+    with pytest.raises(ValueError, match="shape rank"):
         ir.create_op_call(
             "pld.tile.remote_load",
             [target, peer, offsets, bad_shape],
@@ -652,7 +652,7 @@ def test_remote_load_rejects_non_make_tuple_offsets():
     bad_offsets = ir.ConstInt(0, DataType.INT64, span)
     shape = _make_shape_tuple([32], span)
 
-    with pytest.raises(Exception, match="offsets must be a tuple"):
+    with pytest.raises(ValueError, match="offsets must be a tuple"):
         ir.create_op_call(
             "pld.tile.remote_load",
             [target, peer, bad_offsets, shape],
@@ -695,7 +695,7 @@ def test_remote_store_rejects_plain_tensor_target():
     peer = ir.Var("peer", ir.ScalarType(DataType.INT32), span)
     offsets = _make_shape_tuple([0], span)
 
-    with pytest.raises(Exception, match="DistributedTensor"):
+    with pytest.raises(ValueError, match="DistributedTensor"):
         ir.create_op_call(
             "pld.tile.remote_store",
             [tile_var, plain, peer, offsets],
@@ -712,7 +712,7 @@ def test_remote_store_rejects_non_scalar_peer():
     bad_peer = _make_shape_tuple([0, 0], span)  # MakeTuple, not a scalar
     offsets = _make_shape_tuple([0, 0], span)
 
-    with pytest.raises(Exception, match="peer must be a scalar"):
+    with pytest.raises(ValueError, match="peer must be a scalar"):
         ir.create_op_call(
             "pld.tile.remote_store",
             [tile_var, target, bad_peer, offsets],
@@ -729,7 +729,7 @@ def test_remote_store_rejects_mismatched_offsets_rank():
     peer = ir.Var("peer", ir.ScalarType(DataType.INT32), span)
     bad_offsets = _make_shape_tuple([0], span)  # 1-D, but target is 2-D
 
-    with pytest.raises(Exception, match="offsets rank"):
+    with pytest.raises(ValueError, match="offsets rank"):
         ir.create_op_call(
             "pld.tile.remote_store",
             [tile_var, target, peer, bad_offsets],
@@ -746,7 +746,7 @@ def test_remote_store_rejects_non_make_tuple_offsets():
     peer = ir.Var("peer", ir.ScalarType(DataType.INT32), span)
     bad_offsets = ir.ConstInt(0, DataType.INT64, span)
 
-    with pytest.raises(Exception, match="offsets must be a tuple"):
+    with pytest.raises(ValueError, match="offsets must be a tuple"):
         ir.create_op_call(
             "pld.tile.remote_store",
             [tile_var, target, peer, bad_offsets],
@@ -767,7 +767,7 @@ def test_remote_store_rejects_non_tile_src():
     peer = ir.Var("peer", ir.ScalarType(DataType.INT32), span)
     offsets = _make_shape_tuple([0], span)
 
-    with pytest.raises(Exception, match="src_tile must be a TileType"):
+    with pytest.raises(ValueError, match="src_tile must be a TileType"):
         ir.create_op_call(
             "pld.tile.remote_store",
             [not_a_tile, target, peer, offsets],
@@ -784,7 +784,7 @@ def test_remote_store_rejects_dtype_mismatch():
     peer = ir.Var("peer", ir.ScalarType(DataType.INT32), span)
     offsets = _make_shape_tuple([0], span)
 
-    with pytest.raises(Exception, match="dtype"):
+    with pytest.raises(ValueError, match="dtype"):
         ir.create_op_call(
             "pld.tile.remote_store",
             [tile_var, target, peer, offsets],
@@ -802,7 +802,7 @@ def test_remote_store_rejects_extra_positional():
     offsets = _make_shape_tuple([0, 0], span)
     extra_shapes = _make_shape_tuple([32, 16], span)
 
-    with pytest.raises(Exception, match="4 positional argument"):
+    with pytest.raises(ValueError, match="4 positional argument"):
         ir.create_op_call(
             "pld.tile.remote_store",
             [tile_var, target, peer, offsets, extra_shapes],
@@ -836,14 +836,14 @@ def test_get_comm_ctx_rejects_plain_tensor():
     span = ir.Span.unknown()
     shape: list[ir.Expr] = [ir.ConstInt(64, DataType.INT64, span)]
     plain = ir.Var("x", ir.TensorType(shape, DataType.FP32), span)
-    with pytest.raises(Exception, match="DistributedTensor"):
+    with pytest.raises(ValueError, match="DistributedTensor"):
         ir.create_op_call("pld.system.get_comm_ctx", [plain], {}, span)
 
 
 def test_get_comm_ctx_rejects_kwargs():
     span = ir.Span.unknown()
     target = _make_distributed_tensor_var("data", [64], DataType.FP32, span)
-    with pytest.raises(Exception, match="no kwargs"):
+    with pytest.raises(ValueError, match="no kwargs"):
         ir.create_op_call("pld.system.get_comm_ctx", [target], {"peer": 0}, span)
 
 
@@ -851,7 +851,7 @@ def test_get_comm_ctx_rejects_extra_positional():
     span = ir.Span.unknown()
     target = _make_distributed_tensor_var("data", [64], DataType.FP32, span)
     extra = ir.ConstInt(0, DataType.INT32, span)
-    with pytest.raises(Exception, match="exactly 1 positional"):
+    with pytest.raises(ValueError, match="exactly 1 positional"):
         ir.create_op_call("pld.system.get_comm_ctx", [target, extra], {}, span)
 
 
@@ -876,14 +876,14 @@ def test_comm_ctx_nranks_returns_int32_scalar():
 def test_comm_ctx_rank_rejects_non_comm_ctx_arg():
     span = ir.Span.unknown()
     not_ctx = ir.Var("n", ir.ScalarType(DataType.INT64), span)
-    with pytest.raises(Exception, match="CommCtx"):
+    with pytest.raises(ValueError, match="CommCtx"):
         ir.create_op_call("pld.system.rank", [not_ctx], {}, span)
 
 
 def test_comm_ctx_nranks_rejects_non_comm_ctx_arg():
     span = ir.Span.unknown()
     not_ctx = ir.Var("n", ir.ScalarType(DataType.INT64), span)
-    with pytest.raises(Exception, match="CommCtx"):
+    with pytest.raises(ValueError, match="CommCtx"):
         ir.create_op_call("pld.system.nranks", [not_ctx], {}, span)
 
 
@@ -917,7 +917,7 @@ def test_notify_rejects_plain_tensor_target():
     offsets = _make_shape_tuple([0], span)
     value = ir.Var("v", ir.ScalarType(DataType.INT32), span)
 
-    with pytest.raises(Exception, match="DistributedTensor"):
+    with pytest.raises(ValueError, match="DistributedTensor"):
         ir.create_op_call(
             "pld.system.notify",
             [plain, peer, offsets, value],
@@ -934,7 +934,7 @@ def test_notify_rejects_mismatched_offsets_rank():
     bad_offsets = _make_shape_tuple([0], span)  # 1-D, target is 2-D
     value = ir.Var("v", ir.ScalarType(DataType.INT32), span)
 
-    with pytest.raises(Exception, match="offsets rank"):
+    with pytest.raises(ValueError, match="offsets rank"):
         ir.create_op_call(
             "pld.system.notify",
             [target, peer, bad_offsets, value],
@@ -966,7 +966,7 @@ def test_wait_rejects_plain_tensor_signal():
     offsets = _make_shape_tuple([0], span)
     expected = ir.Var("e", ir.ScalarType(DataType.INT32), span)
 
-    with pytest.raises(Exception, match="DistributedTensor"):
+    with pytest.raises(ValueError, match="DistributedTensor"):
         ir.create_op_call(
             "pld.system.wait",
             [plain, offsets, expected],
@@ -1028,7 +1028,7 @@ def test_put_subregion_dynamic_shape_requires_chunk():
     dyn_shape = ir.MakeTuple([n, ir.ConstInt(64, DataType.INT64, span)], span)
 
     # Without chunk_rows → rejected (can't size the staging tile).
-    with pytest.raises(Exception, match="dynamic leading transfer dim needs a static chunk_rows"):
+    with pytest.raises(ValueError, match="dynamic leading transfer dim needs a static chunk_rows"):
         ir.create_op_call(
             "pld.tensor.put", [dst, peer, src, dst_offsets, src_offsets, dyn_shape], {"atomic": 0}, span
         )
@@ -1062,7 +1062,7 @@ def test_put_full_slice_dynamic_window_requires_chunk():
     src = _make_dynamic_window_var("src", n, span)  # same dynamic extent
 
     # Dynamic leading window dim, no chunk_rows → rejected.
-    with pytest.raises(Exception, match="dynamic leading transfer dim needs a static chunk_rows"):
+    with pytest.raises(ValueError, match="dynamic leading transfer dim needs a static chunk_rows"):
         ir.create_op_call("pld.tensor.put", [dst, peer, src], {"atomic": 0}, span)
 
     # With chunk_rows → accepted.
@@ -1071,7 +1071,7 @@ def test_put_full_slice_dynamic_window_requires_chunk():
 
     # Mismatched dynamic dst/src extents → rejected by the full-slice same-shape check.
     src_mismatch = _make_dynamic_window_var("src2", ir.Var("m", ir.ScalarType(DataType.INT32), span), span)
-    with pytest.raises(Exception, match="must have the same shape"):
+    with pytest.raises(ValueError, match="must have the same shape"):
         ir.create_op_call("pld.tensor.put", [dst, peer, src_mismatch], {"atomic": 0, "chunk_rows": 4}, span)
 
 
@@ -1131,9 +1131,9 @@ def test_negative_chunk_rejected_by_deducer():
     peer = ir.Var("peer", ir.ScalarType(DataType.INT32), span)
     src = _make_distributed_tensor_var("src", [16, 64], DataType.FP16, span)
 
-    with pytest.raises(Exception, match="chunk_rows must be non-negative"):
+    with pytest.raises(ValueError, match="chunk_rows must be non-negative"):
         ir.create_op_call("pld.tensor.put", [dst, peer, src], {"atomic": 0, "chunk_rows": -1}, span)
-    with pytest.raises(Exception, match="chunk_cols must be non-negative"):
+    with pytest.raises(ValueError, match="chunk_cols must be non-negative"):
         ir.create_op_call("pld.tensor.get", [dst, peer, src], {"chunk_cols": -1}, span)
 
     # 0 = full is accepted (no raise).
@@ -1173,7 +1173,7 @@ def test_pipeline_packs_attr_and_requires_chunk():
     assert call.kwargs["pipeline"] is True
 
     # Deducer rejects pipeline without both chunk dims.
-    with pytest.raises(Exception, match="pipeline=True requires both chunk_rows>0 and chunk_cols>0"):
+    with pytest.raises(ValueError, match="pipeline=True requires both chunk_rows>0 and chunk_cols>0"):
         ir.create_op_call(
             "pld.tensor.put", [dst, peer, src], {"atomic": 0, "pipeline": True, "chunk_rows": 4}, span
         )
@@ -1226,7 +1226,7 @@ def test_tile_put_rejects_non_2d_stage():
     src = _make_distributed_tensor_var("src", [1, 64], DataType.FP16, span)
     stage = _make_tile_var("stage", [1, 1, 64], DataType.FP16, span)
 
-    with pytest.raises(Exception, match="stage must be a 2D VEC staging tile"):
+    with pytest.raises(ValueError, match="stage must be a 2D VEC staging tile"):
         dist_tile_ops.put(dst, peer, src, stage, atomic=ir.AtomicType.None_, span=span)
 
 
@@ -1251,7 +1251,7 @@ def test_tile_put_rejects_stage_larger_than_transfer():
     # 128 cols > 64 transfer cols.
     stage = _make_tile_var("stage", [16, 128], DataType.FP16, span)
 
-    with pytest.raises(Exception, match="must fit within"):
+    with pytest.raises(ValueError, match="must fit within"):
         dist_tile_ops.put(dst, peer, src, stage, atomic=ir.AtomicType.None_, span=span)
 
 
@@ -1279,7 +1279,7 @@ def test_tile_put_rejects_second_stage_shape_mismatch():
     ping = _make_tile_var("ping", [4, 32], DataType.FP16, span)
     pong = _make_tile_var("pong", [8, 32], DataType.FP16, span)  # different rows
 
-    with pytest.raises(Exception, match="ping/pong staging tiles must have identical shape"):
+    with pytest.raises(ValueError, match="ping/pong staging tiles must have identical shape"):
         dist_tile_ops.put(dst, peer, src, ping, atomic=ir.AtomicType.None_, stage2=pong, span=span)
 
 
@@ -1292,7 +1292,7 @@ def test_tile_put_rejects_second_stage_dtype_mismatch():
     ping = _make_tile_var("ping", [4, 32], DataType.FP16, span)
     pong = _make_tile_var("pong", [4, 32], DataType.FP32, span)  # wrong dtype
 
-    with pytest.raises(Exception, match="stage2 dtype must match dst dtype"):
+    with pytest.raises(ValueError, match="stage2 dtype must match dst dtype"):
         dist_tile_ops.put(dst, peer, src, ping, atomic=ir.AtomicType.None_, stage2=pong, span=span)
 
 
@@ -1303,7 +1303,7 @@ def test_put_rejects_plain_tensor_dst():
     peer = ir.Var("peer", ir.ScalarType(DataType.INT32), span)
     src = _make_distributed_tensor_var("src", [16], DataType.FP16, span)
 
-    with pytest.raises(Exception, match="DistributedTensor"):
+    with pytest.raises(ValueError, match="DistributedTensor"):
         ir.create_op_call(
             "pld.tensor.put",
             [plain, peer, src],
@@ -1336,7 +1336,7 @@ def test_put_rejects_dtype_mismatch():
     peer = ir.Var("peer", ir.ScalarType(DataType.INT32), span)
     src = _make_distributed_tensor_var("src", [16], DataType.FP32, span)
 
-    with pytest.raises(Exception, match="element type"):
+    with pytest.raises(ValueError, match="element type"):
         ir.create_op_call(
             "pld.tensor.put",
             [dst, peer, src],
@@ -1352,7 +1352,7 @@ def test_put_rejects_shape_mismatch():
     peer = ir.Var("peer", ir.ScalarType(DataType.INT32), span)
     src = _make_distributed_tensor_var("src", [16, 32], DataType.FP16, span)
 
-    with pytest.raises(Exception, match="static shape"):
+    with pytest.raises(ValueError, match="static shape"):
         ir.create_op_call(
             "pld.tensor.put",
             [dst, peer, src],
@@ -1371,7 +1371,7 @@ def test_put_subregion_rejects_mismatched_offsets_rank():
     src_offsets = _make_shape_tuple([0, 0], span)
     shape = _make_shape_tuple([1, 64], span)
 
-    with pytest.raises(Exception, match="dst_offsets rank"):
+    with pytest.raises(ValueError, match="dst_offsets rank"):
         ir.create_op_call(
             "pld.tensor.put",
             [dst, peer, src, bad_dst_offsets, src_offsets, shape],
@@ -1390,7 +1390,7 @@ def test_put_subregion_rejects_negative_offsets():
     src_offsets = _make_shape_tuple([0, 0], span)
     shape = _make_shape_tuple([1, 64], span)
 
-    with pytest.raises(Exception, match="dst_offsets dimension 0 must be non-negative"):
+    with pytest.raises(ValueError, match="dst_offsets dimension 0 must be non-negative"):
         ir.create_op_call(
             "pld.tensor.put",
             [dst, peer, src, dst_offsets, src_offsets, shape],
@@ -1409,7 +1409,7 @@ def test_put_subregion_rejects_out_of_bounds_dst():
     src_offsets = _make_shape_tuple([0, 0], span)
     shape = _make_shape_tuple([2, 64], span)
 
-    with pytest.raises(Exception, match="dst subregion dimension 0 exceeds dst shape"):
+    with pytest.raises(ValueError, match="dst subregion dimension 0 exceeds dst shape"):
         ir.create_op_call(
             "pld.tensor.put",
             [dst, peer, src, dst_offsets, src_offsets, shape],
@@ -1428,7 +1428,7 @@ def test_put_subregion_rejects_out_of_bounds_src():
     src_offsets = _make_shape_tuple([15, 0], span)
     shape = _make_shape_tuple([2, 64], span)
 
-    with pytest.raises(Exception, match="src subregion dimension 0 exceeds src shape"):
+    with pytest.raises(ValueError, match="src subregion dimension 0 exceeds src shape"):
         ir.create_op_call(
             "pld.tensor.put",
             [dst, peer, src, dst_offsets, src_offsets, shape],
@@ -1444,7 +1444,7 @@ def test_put_rejects_non_scalar_peer():
     bad_peer = _make_distributed_tensor_var("p", [16], DataType.FP16, span)
     src = _make_distributed_tensor_var("src", [16], DataType.FP16, span)
 
-    with pytest.raises(Exception, match="scalar"):
+    with pytest.raises(ValueError, match="scalar"):
         ir.create_op_call(
             "pld.tensor.put",
             [dst, bad_peer, src],
@@ -1506,7 +1506,7 @@ def test_get_subregion_dynamic_shape_requires_chunk():
     dyn_shape = ir.MakeTuple([ir.ConstInt(16, DataType.INT64, span), m], span)
 
     # Without chunk_cols → rejected.
-    with pytest.raises(Exception, match="dynamic innermost transfer dim needs a static chunk_cols"):
+    with pytest.raises(ValueError, match="dynamic innermost transfer dim needs a static chunk_cols"):
         ir.create_op_call("pld.tensor.get", [dst, peer, src, dst_offsets, src_offsets, dyn_shape], {}, span)
 
     # With chunk_cols → accepted.
@@ -1528,7 +1528,7 @@ def test_get_full_slice_dynamic_window_requires_chunk():
     dst = _make_dynamic_window_var("dst", n, span)
     src = _make_dynamic_window_var("src", n, span)
 
-    with pytest.raises(Exception, match="dynamic leading transfer dim needs a static chunk_rows"):
+    with pytest.raises(ValueError, match="dynamic leading transfer dim needs a static chunk_rows"):
         ir.create_op_call("pld.tensor.get", [dst, peer, src], {}, span)
 
     call = ir.create_op_call("pld.tensor.get", [dst, peer, src], {"chunk_rows": 4}, span)
@@ -1580,7 +1580,7 @@ def test_tile_get_rejects_stage_dtype_mismatch():
     src = _make_distributed_tensor_var("src", [16, 64], DataType.FP16, span)
     stage = _make_tile_var("stage", [16, 64], DataType.FP32, span)
 
-    with pytest.raises(Exception, match="stage dtype must match dst dtype"):
+    with pytest.raises(ValueError, match="stage dtype must match dst dtype"):
         dist_tile_ops.get(dst, peer, src, stage, span=span)
 
 
@@ -1606,7 +1606,7 @@ def test_tile_get_rejects_stage_larger_than_transfer():
     # 32 rows > 16 transfer rows.
     stage = _make_tile_var("stage", [32, 64], DataType.FP16, span)
 
-    with pytest.raises(Exception, match="must fit within"):
+    with pytest.raises(ValueError, match="must fit within"):
         dist_tile_ops.get(dst, peer, src, stage, span=span)
 
 
@@ -1618,7 +1618,7 @@ def test_tile_get_rejects_non_2d_stage():
     src = _make_distributed_tensor_var("src", [1, 64], DataType.FP16, span)
     stage = _make_tile_var("stage", [1, 1, 64], DataType.FP16, span)
 
-    with pytest.raises(Exception, match="stage must be a 2D VEC staging tile"):
+    with pytest.raises(ValueError, match="stage must be a 2D VEC staging tile"):
         dist_tile_ops.get(dst, peer, src, stage, span=span)
 
 
@@ -1629,7 +1629,7 @@ def test_get_rejects_unexpected_kwargs():
     peer = ir.Var("peer", ir.ScalarType(DataType.INT32), span)
     src = _make_distributed_tensor_var("src", [16], DataType.FP16, span)
 
-    with pytest.raises(Exception, match="Unknown kwarg 'atomic'"):
+    with pytest.raises(ValueError, match="Unknown kwarg 'atomic'"):
         ir.create_op_call(
             "pld.tensor.get",
             [dst, peer, src],
@@ -1692,7 +1692,7 @@ def test_tile_get_rejects_second_stage_shape_mismatch():
     ping = _make_tile_var("ping", [4, 32], DataType.FP16, span)
     pong = _make_tile_var("pong", [4, 16], DataType.FP16, span)  # different cols
 
-    with pytest.raises(Exception, match="ping/pong staging tiles must have identical shape"):
+    with pytest.raises(ValueError, match="ping/pong staging tiles must have identical shape"):
         dist_tile_ops.get(dst, peer, src, ping, stage2=pong, span=span)
 
 
@@ -1703,7 +1703,7 @@ def test_get_rejects_plain_tensor_src():
     peer = ir.Var("peer", ir.ScalarType(DataType.INT32), span)
     plain = ir.Var("x", ir.TensorType([ir.ConstInt(16, DataType.INT64, span)], DataType.FP16), span)
 
-    with pytest.raises(Exception, match="DistributedTensor"):
+    with pytest.raises(ValueError, match="DistributedTensor"):
         ir.create_op_call(
             "pld.tensor.get",
             [dst, peer, plain],
@@ -1719,7 +1719,7 @@ def test_get_rejects_dtype_mismatch():
     peer = ir.Var("peer", ir.ScalarType(DataType.INT32), span)
     src = _make_distributed_tensor_var("src", [16], DataType.FP32, span)
 
-    with pytest.raises(Exception, match="element type"):
+    with pytest.raises(ValueError, match="element type"):
         ir.create_op_call(
             "pld.tensor.get",
             [dst, peer, src],
@@ -1735,7 +1735,7 @@ def test_get_rejects_shape_mismatch():
     peer = ir.Var("peer", ir.ScalarType(DataType.INT32), span)
     src = _make_distributed_tensor_var("src", [16, 32], DataType.FP16, span)
 
-    with pytest.raises(Exception, match="static shape"):
+    with pytest.raises(ValueError, match="static shape"):
         ir.create_op_call(
             "pld.tensor.get",
             [dst, peer, src],
@@ -1754,7 +1754,7 @@ def test_get_subregion_rejects_mismatched_offsets_rank():
     src_offsets = _make_shape_tuple([0, 0], span)
     shape = _make_shape_tuple([1, 64], span)
 
-    with pytest.raises(Exception, match="dst_offsets rank"):
+    with pytest.raises(ValueError, match="dst_offsets rank"):
         ir.create_op_call(
             "pld.tensor.get",
             [dst, peer, src, bad_dst_offsets, src_offsets, shape],
@@ -1773,7 +1773,7 @@ def test_get_subregion_rejects_negative_offsets():
     src_offsets = _make_shape_tuple([0, 0], span)
     shape = _make_shape_tuple([1, 64], span)
 
-    with pytest.raises(Exception, match="dst_offsets dimension 0 must be non-negative"):
+    with pytest.raises(ValueError, match="dst_offsets dimension 0 must be non-negative"):
         ir.create_op_call(
             "pld.tensor.get",
             [dst, peer, src, dst_offsets, src_offsets, shape],
@@ -1792,7 +1792,7 @@ def test_get_subregion_rejects_out_of_bounds_dst():
     src_offsets = _make_shape_tuple([0, 0], span)
     shape = _make_shape_tuple([2, 64], span)
 
-    with pytest.raises(Exception, match="dst subregion dimension 0 exceeds dst shape"):
+    with pytest.raises(ValueError, match="dst subregion dimension 0 exceeds dst shape"):
         ir.create_op_call(
             "pld.tensor.get",
             [dst, peer, src, dst_offsets, src_offsets, shape],
@@ -1811,7 +1811,7 @@ def test_get_subregion_rejects_out_of_bounds_src():
     src_offsets = _make_shape_tuple([15, 0], span)
     shape = _make_shape_tuple([2, 64], span)
 
-    with pytest.raises(Exception, match="src subregion dimension 0 exceeds src shape"):
+    with pytest.raises(ValueError, match="src subregion dimension 0 exceeds src shape"):
         ir.create_op_call(
             "pld.tensor.get",
             [dst, peer, src, dst_offsets, src_offsets, shape],
@@ -1827,7 +1827,7 @@ def test_get_rejects_rank_mismatch():
     peer = ir.Var("peer", ir.ScalarType(DataType.INT32), span)
     src = _make_distributed_tensor_var("src", [16, 64, 4], DataType.FP16, span)
 
-    with pytest.raises(Exception, match="rank"):
+    with pytest.raises(ValueError, match="rank"):
         ir.create_op_call(
             "pld.tensor.get",
             [dst, peer, src],
@@ -1843,7 +1843,7 @@ def test_get_rejects_non_positive_static_shape():
     peer = ir.Var("peer", ir.ScalarType(DataType.INT32), span)
     src = _make_distributed_tensor_var("src", [16, 0], DataType.FP16, span)
 
-    with pytest.raises(Exception, match="positive"):
+    with pytest.raises(ValueError, match="positive"):
         ir.create_op_call(
             "pld.tensor.get",
             [dst, peer, src],
@@ -1859,7 +1859,7 @@ def test_get_rejects_non_scalar_peer():
     bad_peer = _make_distributed_tensor_var("p", [16], DataType.FP16, span)
     src = _make_distributed_tensor_var("src", [16], DataType.FP16, span)
 
-    with pytest.raises(Exception, match="scalar"):
+    with pytest.raises(ValueError, match="scalar"):
         ir.create_op_call(
             "pld.tensor.get",
             [dst, bad_peer, src],

--- a/tests/ut/ir/transforms/test_allocate_memory_addr_pass.py
+++ b/tests/ut/ir/transforms/test_allocate_memory_addr_pass.py
@@ -9,6 +9,7 @@
 
 import re
 
+import pypto
 import pypto.language as pl
 import pytest
 from pypto import ir, passes
@@ -520,7 +521,7 @@ def test_allocated_memory_addr_verifier_errors_when_vec_exceeds_safe_cap():
         pipeline = passes.PassPipeline()
         pipeline.add_pass(passes.allocate_memory_addr())
         with passes.PassContext([passes.VerificationInstrument(passes.VerificationMode.AFTER)]):
-            with pytest.raises(ValueError, match=r"Vec buffer usage .* exceeds platform limit"):
+            with pytest.raises(pypto.Error, match=r"Vec buffer usage .* exceeds platform limit"):
                 pipeline.run(program)
     finally:
         reset_for_testing()

--- a/tests/ut/ir/transforms/test_allocate_memory_addr_pass.py
+++ b/tests/ut/ir/transforms/test_allocate_memory_addr_pass.py
@@ -168,7 +168,7 @@ def test_allocate_memory_addr_rejects_overlapping_reserve_buffer_ranges():
     with pytest.raises(
         # Message is now emitted by the shared reserve_buffer_utils resolver (used by both
         # AllocateMemoryAddr and MemoryReuse), so match the pass-agnostic substring.
-        Exception,
+        pypto.InternalError,
         match=re.escape("overlapping reserve_buffer ranges"),
     ):
         program = passes.init_mem_ref()(Before)

--- a/tests/ut/ir/transforms/test_classify_iter_arg_carry.py
+++ b/tests/ut/ir/transforms/test_classify_iter_arg_carry.py
@@ -244,7 +244,7 @@ def test_manual_scope_parallel_dynamic_trip_count_rejected():
                         out, prev_tid = pl.submit(self.kern, x, out, row, col, deps=[prev_tid])
             return out
 
-    with pytest.raises(Exception, match="statically-known trip count"):
+    with pytest.raises(ValueError, match="statically-known trip count"):
         PassManager.get_strategy(OptimizationStrategy.Default).run_passes(Prog)
 
 

--- a/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
+++ b/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
@@ -11,6 +11,7 @@
 
 from collections.abc import Callable
 
+import pypto
 import pypto.language as pl
 import pypto.language.distributed as pld
 import pytest
@@ -2267,7 +2268,7 @@ class TestNestedControlFlow:
         func = ir.Function("incore", [x_param], [tensor_type], body, span, ir.FunctionType.InCore)
         prog = ir.Program([func], "test_program", span)
 
-        with pytest.raises(Exception, match="has no registered tile conversion"):
+        with pytest.raises(pypto.InternalError, match="has no registered tile conversion"):
             passes.convert_tensor_to_tile_ops()(prog)
 
     def test_iter_arg_init_from_tensor_param_gets_preloaded(self):
@@ -3084,7 +3085,7 @@ class TestScatterUpdateConversion:
                 result: pl.Tensor[[128, 256], pl.FP16] = self.main_incore_0(index, src)
                 return result
 
-        with pytest.raises(Exception, match="i16 flat-index limit"):
+        with pytest.raises(ValueError, match="i16 flat-index limit"):
             passes.convert_tensor_to_tile_ops()(Before)
 
     def test_scatter_update_rejects_4d(self):
@@ -3111,7 +3112,7 @@ class TestScatterUpdateConversion:
                 result: pl.Tensor[[4, 4, 1, 64], pl.FP32] = self.main_incore_0(index, src)
                 return result
 
-        with pytest.raises(Exception, match="only 2D input/src is currently supported"):
+        with pytest.raises(ValueError, match="only 2D input/src is currently supported"):
             passes.convert_tensor_to_tile_ops()(Before)
 
 

--- a/tests/ut/ir/transforms/test_convert_to_ssa_pass.py
+++ b/tests/ut/ir/transforms/test_convert_to_ssa_pass.py
@@ -15,6 +15,7 @@ self-contained programs, so the default strict-identity mode (with DefField
 auto-mapping at def sites) is sufficient.
 """
 
+import pypto
 import pypto.language as pl
 import pypto.language.distributed as pld
 import pytest
@@ -1887,7 +1888,7 @@ class TestMidBodyYieldGuard:
         program = ir.Program([func], "test_program", span)
 
         ctx = passes.PassContext([], passes.VerificationLevel.NONE)
-        with ctx, pytest.raises(Exception, match="YieldStmt at position"):
+        with ctx, pytest.raises(pypto.InternalError, match="YieldStmt at position"):
             passes.convert_to_ssa()(program)
 
     def test_function_body_with_mid_body_yield_rejected(self):
@@ -1910,7 +1911,7 @@ class TestMidBodyYieldGuard:
         program = ir.Program([func], "test_program", span)
 
         ctx = passes.PassContext([], passes.VerificationLevel.NONE)
-        with ctx, pytest.raises(Exception, match="YieldStmt at position"):
+        with ctx, pytest.raises(pypto.InternalError, match="YieldStmt at position"):
             passes.convert_to_ssa()(program)
 
 

--- a/tests/ut/ir/transforms/test_derive_call_directions.py
+++ b/tests/ut/ir/transforms/test_derive_call_directions.py
@@ -35,6 +35,7 @@ ill-formed IR, so they assert on the raised error rather than on an ``Expected``
 program.
 """
 
+import pypto
 import pypto.language as pl
 import pytest
 from pypto import DataType, ir, passes
@@ -1640,13 +1641,13 @@ class TestVerifyNegative:
     def test_input_with_output_rejected(self):
         # Position 0 is callee In; using Output there must fail.
         prog = self._build_program([ir.ArgDirection.Output, ir.ArgDirection.OutputExisting])
-        with pytest.raises(Exception, match=r"(?i)arg_direction|CallDirectionsResolved"):  # noqa: PT011
+        with pytest.raises(pypto.Error, match=r"(?i)arg_direction|CallDirectionsResolved"):
             _verify_call_directions(prog)
 
     def test_out_with_input_rejected(self):
         # Position 1 is callee Out; using Input there must fail.
         prog = self._build_program([ir.ArgDirection.Input, ir.ArgDirection.Input])
-        with pytest.raises(Exception, match=r"(?i)arg_direction|CallDirectionsResolved"):  # noqa: PT011
+        with pytest.raises(pypto.Error, match=r"(?i)arg_direction|CallDirectionsResolved"):
             _verify_call_directions(prog)
 
 
@@ -2433,7 +2434,7 @@ class TestVerifyWrapperDirections:
                 r = self.group(x, dst, attrs={"arg_directions": [pl.adir.input, pl.adir.input]})
                 return r
 
-        with pytest.raises(Exception, match="stale param_directions_"):
+        with pytest.raises(pypto.Error, match="stale param_directions_"):
             _verify_call_directions(Stale)
 
     def test_materialized_group_directions_accepted(self):

--- a/tests/ut/ir/transforms/test_equality.py
+++ b/tests/ut/ir/transforms/test_equality.py
@@ -1524,10 +1524,10 @@ class TestGetItemNavigation:
         x = ir.Var("x", ir.ScalarType(dtype), span)
         body = ir.SeqStmts([ir.AssignStmt(x, ir.ConstInt(1, dtype, span), span)], span)
 
-        with pytest.raises(Exception):
+        with pytest.raises(IndexError):
             _ = body[5]
 
-        with pytest.raises(Exception):
+        with pytest.raises(IndexError):
             _ = body[-5]
 
     def test_path_is_copy_pasteable(self):

--- a/tests/ut/ir/transforms/test_expand_mixed_kernel_a5.py
+++ b/tests/ut/ir/transforms/test_expand_mixed_kernel_a5.py
@@ -20,6 +20,7 @@ Backend setup (Ascend950) is handled by the directory-level ``conftest.py``.
 
 import re
 
+import pypto
 import pypto.language as pl
 import pytest
 from pypto import ir, passes
@@ -1906,7 +1907,7 @@ class TestPropertyVerification:
         prop_set = passes.IRPropertySet()
         prop_set.insert(passes.IRProperty.MixedKernelExpanded)
 
-        with pytest.raises(Exception, match=re.escape("tile.tpop_from_aiv result in MemorySpace::Mat")):
+        with pytest.raises(pypto.Error, match=re.escape("tile.tpop_from_aiv result in MemorySpace::Mat")):
             passes.verify_properties(prop_set, BadProgram, "test")
 
     def test_verifier_rejects_aiv_tpop_from_aic_into_mat(self):
@@ -1921,7 +1922,7 @@ class TestPropertyVerification:
         prop_set = passes.IRPropertySet()
         prop_set.insert(passes.IRProperty.MixedKernelExpanded)
 
-        with pytest.raises(Exception, match=re.escape("tile.tpop_from_aic result in MemorySpace::Vec")):
+        with pytest.raises(pypto.Error, match=re.escape("tile.tpop_from_aic result in MemorySpace::Vec")):
             passes.verify_properties(prop_set, BadProgram, "test")
 
     def test_verifier_rejects_cross_core_missing_pipe_setup(self):
@@ -1947,7 +1948,7 @@ class TestPropertyVerification:
         prop_set.insert(passes.IRProperty.MixedKernelExpanded)
 
         with pytest.raises(
-            Exception,
+            pypto.Error,
             match=re.escape("uses cross-core tile ops but has no 'system.aic_initialize_pipe' call"),
         ):
             passes.verify_properties(prop_set, BadProgram, "test")
@@ -1967,7 +1968,7 @@ class TestPropertyVerification:
         prop_set.insert(passes.IRProperty.MixedKernelExpanded)
 
         with pytest.raises(
-            Exception,
+            pypto.Error,
             match=re.escape("uses tile.tpop_from_aic but has no matching 'system.tfree_to_aic' call"),
         ):
             passes.verify_properties(prop_set, BadProgram, "test")
@@ -2071,7 +2072,7 @@ class TestPropertyVerification:
         prop_set.insert(passes.IRProperty.MixedKernelExpanded)
 
         with pytest.raises(
-            Exception,
+            pypto.Error,
             match=re.escape(
                 "Function 'cube_consumer' has fewer 'system.reserve_buffer' calls than initialized pipe "
                 "directions require"
@@ -2098,7 +2099,7 @@ class TestPropertyVerification:
         prop_set.insert(passes.IRProperty.MixedKernelExpanded)
 
         with pytest.raises(
-            Exception,
+            pypto.Error,
             match=re.escape(
                 "has 'system.tfree_to_aic' without a matching outstanding tpop on the same tile value"
             ),
@@ -2125,7 +2126,7 @@ class TestPropertyVerification:
         prop_set.insert(passes.IRProperty.MixedKernelExpanded)
 
         with pytest.raises(
-            Exception,
+            pypto.Error,
             match=re.escape("uses cross-core tile ops but has no 'system.aiv_initialize_pipe' call"),
         ):
             passes.verify_properties(prop_set, BadProgram, "test")

--- a/tests/ut/ir/transforms/test_flatten_tile_nd_to_2d.py
+++ b/tests/ut/ir/transforms/test_flatten_tile_nd_to_2d.py
@@ -12,6 +12,7 @@
 from collections.abc import Callable, Sequence
 from typing import cast
 
+import pypto
 import pypto.language as pl
 import pytest
 from pypto import DataType, ir, passes
@@ -1068,7 +1069,7 @@ class TestFlattenTileNdTo2DPassProperties:
         )
         props = passes.IRPropertySet()
         props.insert(passes.IRProperty.TileOps2D)
-        with pytest.raises(Exception, match="TileOps2D"):
+        with pytest.raises(pypto.Error, match="TileOps2D"):
             passes.verify_properties(props, Unflatten, "test_verifier_fails")
 
     def test_verifier_allows_rank_raising_reinterpret_view(self):

--- a/tests/ut/ir/transforms/test_gather_row.py
+++ b/tests/ut/ir/transforms/test_gather_row.py
@@ -34,6 +34,7 @@ from pypto.ir.op import tile_ops as _ir_tile_ops
 from pypto.ir.pass_manager import OptimizationStrategy, PassManager
 from pypto.language.op import tensor_ops as _dsl_tensor_ops
 from pypto.language.op import tile_ops as _dsl_tile_ops
+from pypto.language.parser.diagnostics import InvalidOperationError
 
 
 def _build_program(
@@ -185,7 +186,7 @@ def test_tile_gather_row_dsl_interface_roundtrips():
 
 def test_gather_row_rejects_dtype_mismatch():
     """acc and src must share dtype (matmul operand integrity)."""
-    with pytest.raises(Exception, match="share dtype"):
+    with pytest.raises(InvalidOperationError, match="share dtype"):
 
         @pl.program
         class Program:
@@ -259,7 +260,7 @@ def test_gather_row_valid_shape_roundtrips():
 
 def test_gather_row_rejects_valid_shape_exceeding_shapes():
     """A provable valid_shape > shapes is rejected at type deduction."""
-    with pytest.raises(Exception, match="provably exceeds physical shape extent"):
+    with pytest.raises(InvalidOperationError, match="provably exceeds physical shape extent"):
 
         @pl.program
         class Program:
@@ -279,7 +280,7 @@ def test_gather_row_rejects_valid_shape_rank_mismatch(valid_shape):
     type but wrong for an explicit operand — without the rank check it would reach
     the backend and trip an INTERNAL_CHECK instead of telling the user.
     """
-    with pytest.raises(Exception, match="valid_shape to have the same rank as shapes"):
+    with pytest.raises(InvalidOperationError, match="valid_shape to have the same rank as shapes"):
 
         @pl.program
         class Program:
@@ -320,7 +321,7 @@ def test_gather_row_rejects_non_integer_valid_shape():
     rejecting it, so without an explicit dtype check `valid_shape=[1.5, 128]`
     would pass deduction.
     """
-    with pytest.raises(Exception, match="valid_shape\\[0\\] to be an integer extent"):
+    with pytest.raises(InvalidOperationError, match="valid_shape\\[0\\] to be an integer extent"):
 
         @pl.program
         class Program:
@@ -340,7 +341,7 @@ def test_gather_row_rejects_dynamic_shapes_at_trace_time():
     (rather than in the backend) is what makes the error land on the pl.gather_row
     line.
     """
-    with pytest.raises(Exception, match="Pass a dynamic row count through valid_shape instead"):
+    with pytest.raises(InvalidOperationError, match="Pass a dynamic row count through valid_shape instead"):
 
         @pl.program
         class Program:
@@ -361,7 +362,9 @@ def test_gather_row_rejects_dynamic_valid_shape_with_transpose():
     *column* extent on a boxed NZ tile — unverified on device, so it is rejected
     rather than silently emitted.
     """
-    with pytest.raises(Exception, match="does not support a dynamic valid_shape together with transpose"):
+    with pytest.raises(
+        InvalidOperationError, match="does not support a dynamic valid_shape together with transpose"
+    ):
 
         @pl.program
         class Program:
@@ -379,7 +382,7 @@ def test_gather_row_rejects_dynamic_valid_shape_with_transpose():
 
 def test_create_l1_rejects_non_positive_shape():
     """create_l1 shape dims must be positive compile-time ConstInt."""
-    with pytest.raises(Exception, match="positive compile-time ConstInt"):
+    with pytest.raises(InvalidOperationError, match="positive compile-time ConstInt"):
 
         @pl.program
         class Program:
@@ -392,7 +395,9 @@ def test_create_l1_rejects_non_positive_shape():
 
 def test_tile_create_transpose_rejects_non_mat():
     """tile.create transpose=True is a Mat-only (L1) layout; a non-Mat space is rejected."""
-    with pytest.raises(Exception, match="transpose=true only for a 2D tile with target_memory=Mat"):
+    with pytest.raises(
+        InvalidOperationError, match="transpose=true only for a 2D tile with target_memory=Mat"
+    ):
 
         @pl.program
         class Program:

--- a/tests/ut/ir/transforms/test_init_memref.py
+++ b/tests/ut/ir/transforms/test_init_memref.py
@@ -25,6 +25,7 @@ expressed via the DSL:
 
 from typing import cast
 
+import pypto
 import pypto.language as pl
 import pytest
 from pypto import ir, passes
@@ -841,7 +842,7 @@ class TestEdgeCases:
         func = ir.Function("test_func", [], [dynamic_tile_type], body, span)
         program = ir.Program([func], "test_program", span)
 
-        with pytest.raises(Exception, match="InitMemRef requires static shape"):
+        with pytest.raises(pypto.InternalError, match="InitMemRef requires static shape"):
             passes.init_mem_ref()(program)
 
 

--- a/tests/ut/ir/transforms/test_legalize_tile_cast.py
+++ b/tests/ut/ir/transforms/test_legalize_tile_cast.py
@@ -207,7 +207,7 @@ def test_a5_uint32_to_fp32_rejects_narrowing_bridge():
             out_t: pl.Tensor[[16, 16], pl.FP32] = pl.store(c, [0, 0], out)
             return out_t
 
-    with pytest.raises(Exception) as excinfo:
+    with pytest.raises(ValueError) as excinfo:
         _run(Before, BackendType.Ascend950)
     assert "cast" in str(excinfo.value).lower()
 

--- a/tests/ut/ir/transforms/test_lower_composite_ops.py
+++ b/tests/ut/ir/transforms/test_lower_composite_ops.py
@@ -643,7 +643,7 @@ def test_allreduce_without_signal_is_rejected_outside_host_orchestrator():
             acc = pl.load(data, [0, 0], [1, SIZE])
             return pl.store(acc, [0, 0], out)
 
-    with pytest.raises(Exception, match="requires an explicit signal outside host orchestrator"):
+    with pytest.raises(ValueError, match="requires an explicit signal outside host orchestrator"):
         passes.lower_composite_ops()(MissingSignal)
 
 
@@ -660,7 +660,7 @@ def test_allreduce_eval_stmt_without_signal_is_rejected_outside_host_orchestrato
             pld.tensor.allreduce(data, op=pld.ReduceOp.Sum)
             return data
 
-    with pytest.raises(Exception, match="requires an explicit signal outside host orchestrator"):
+    with pytest.raises(ValueError, match="requires an explicit signal outside host orchestrator"):
         passes.lower_composite_ops()(MissingSignalEval)
 
 
@@ -703,7 +703,7 @@ def test_allreduce_in_for_loop_is_rejected():
                 data = pld.tensor.allreduce(data, signal, op=pld.ReduceOp.Sum)
             return data
 
-    with pytest.raises(Exception, match="allreduce is not supported inside a for/while loop"):
+    with pytest.raises(ValueError, match="allreduce is not supported inside a for/while loop"):
         passes.lower_composite_ops()(LoopAllreduce)
 
 
@@ -723,7 +723,7 @@ def test_allreduce_in_while_loop_is_rejected():
                 data = pld.tensor.allreduce(data, signal, op=pld.ReduceOp.Sum)
             return data
 
-    with pytest.raises(Exception, match="allreduce is not supported inside a for/while loop"):
+    with pytest.raises(ValueError, match="allreduce is not supported inside a for/while loop"):
         passes.lower_composite_ops()(LoopAllreduce)
 
 
@@ -959,7 +959,7 @@ def test_allreduce_rejects_oversized_partial_valid_shape():
             data = pld.tensor.allreduce(data, signal, op=pld.ReduceOp.Sum)
             return data
 
-    with pytest.raises(Exception, match="partial valid_shape must fit within one 16384-byte mesh chunk"):
+    with pytest.raises(ValueError, match="partial valid_shape must fit within one 16384-byte mesh chunk"):
         passes.lower_composite_ops()(Before)
 
 
@@ -1067,7 +1067,7 @@ def test_allreduce_mesh_lowering_rejects_noncontiguous_partial_valid_shape():
             data = pld.tensor.allreduce(data, signal, op=pld.ReduceOp.Sum)
             return data
 
-    with pytest.raises(Exception, match="valid_shape cannot be represented by a single 2D view"):
+    with pytest.raises(ValueError, match="valid_shape cannot be represented by a single 2D view"):
         passes.lower_composite_ops()(Before)
 
 
@@ -1095,7 +1095,7 @@ def test_allreduce_mesh_lowering_rejects_strided_target_collapse():
             data = pld.tensor.allreduce(data, signal, op=pld.ReduceOp.Sum)
             return data
 
-    with pytest.raises(Exception, match="requires a packed source"):
+    with pytest.raises(ValueError, match="requires a packed source"):
         passes.lower_composite_ops()(Before)
 
 
@@ -1151,7 +1151,7 @@ def test_allreduce_mesh_lowering_rejects_fully_valid_dn_target():
         ]:
             return pld.tensor.allreduce(data, signal)
 
-    with pytest.raises(Exception, match="only supports ND layout"):
+    with pytest.raises(ValueError, match="only supports ND layout"):
         passes.lower_composite_ops()(Before)
 
 
@@ -1179,7 +1179,7 @@ def test_allreduce_mesh_lowering_rejects_partial_dn_target_collapse():
             data = pld.tensor.allreduce(data, signal, op=pld.ReduceOp.Sum)
             return data
 
-    with pytest.raises(Exception, match="only supports ND layout"):
+    with pytest.raises(ValueError, match="only supports ND layout"):
         passes.lower_composite_ops()(Before)
 
 
@@ -2044,7 +2044,7 @@ def test_ring_allreduce_rejects_noncontiguous_partial_valid_box():
         ]:
             return pld.tensor.allreduce(data, signal, mode="ring")
 
-    with pytest.raises(Exception, match="contiguous row-major prefix"):
+    with pytest.raises(ValueError, match="contiguous row-major prefix"):
         passes.lower_composite_ops()(Before)
 
 
@@ -2071,7 +2071,7 @@ def test_ring_allreduce_rejects_strided_target():
         ]:
             return pld.tensor.allreduce(data, signal, mode="ring")
 
-    with pytest.raises(Exception, match="requires a packed source"):
+    with pytest.raises(ValueError, match="requires a packed source"):
         passes.lower_composite_ops()(Before)
 
 
@@ -2098,7 +2098,7 @@ def test_ring_allreduce_rejects_dn_target():
         ]:
             return pld.tensor.allreduce(data, signal, mode="ring")
 
-    with pytest.raises(Exception, match="only supports ND layout"):
+    with pytest.raises(ValueError, match="only supports ND layout"):
         passes.lower_composite_ops()(Before)
 
 

--- a/tests/ut/ir/transforms/test_lower_host_tensor_collectives.py
+++ b/tests/ut/ir/transforms/test_lower_host_tensor_collectives.py
@@ -15,6 +15,7 @@ from typing import cast
 import pypto.language as pl
 import pypto.language.distributed as pld
 import pytest
+from pypto.language.parser.diagnostics import InvalidOperationError
 from pypto.pypto_core import DataType, ir, passes
 
 
@@ -428,7 +429,7 @@ def test_host_allreduce_rejects_static_signal_smaller_than_explicit_device_count
             return 0
 
     program = passes.materialize_comm_domain_scopes()(P)
-    with pytest.raises(Exception, match=r"signal shape\[0\].*participating device count"):
+    with pytest.raises(ValueError, match=r"signal shape\[0\].*participating device count"):
         passes.lower_host_tensor_collectives()(program)
 
 
@@ -452,12 +453,12 @@ def test_host_allreduce_rejects_rank2_signal_with_dynamic_second_extent():
             return 0
 
     program = passes.materialize_comm_domain_scopes()(P)
-    with pytest.raises(Exception, match=r"rank-2 signal shape\[1\] must be the constant 1"):
+    with pytest.raises(ValueError, match=r"rank-2 signal shape\[1\] must be the constant 1"):
         passes.lower_host_tensor_collectives()(program)
 
 
 def test_host_allreduce_rejects_unsupported_dtype_before_lowering():
-    with pytest.raises(Exception, match="target dtype must be FP16 or FP32"):
+    with pytest.raises(InvalidOperationError, match="target dtype must be FP16 or FP32"):
 
         @pl.program
         class P:
@@ -676,7 +677,7 @@ def test_host_allgather_rejects_aliased_input_target_windows():
             return 0
 
     program = passes.materialize_comm_domain_scopes()(P)
-    with pytest.raises(Exception, match=r"different window allocations"):
+    with pytest.raises(ValueError, match=r"different window allocations"):
         passes.lower_host_tensor_collectives()(program)
 
 
@@ -707,7 +708,7 @@ def test_host_all_to_all_rejects_aliased_input_target_windows():
             return 0
 
     program = passes.materialize_comm_domain_scopes()(P)
-    with pytest.raises(Exception, match=r"different window allocations"):
+    with pytest.raises(ValueError, match=r"different window allocations"):
         passes.lower_host_tensor_collectives()(program)
 
 

--- a/tests/ut/ir/transforms/test_materialize_comm_domain_scopes.py
+++ b/tests/ut/ir/transforms/test_materialize_comm_domain_scopes.py
@@ -49,6 +49,7 @@ import ast
 import textwrap
 from typing import cast
 
+import pypto
 import pypto.language as pl
 import pypto.language.distributed as pld
 import pytest
@@ -909,7 +910,7 @@ def test_implicit_allreduce_in_loop_is_rejected():
                 data = pld.tensor.allreduce(data, op=pld.ReduceOp.Sum)
             return data
 
-    with pytest.raises(Exception, match="allreduce is not supported inside a for/while loop"):
+    with pytest.raises(ValueError, match="allreduce is not supported inside a for/while loop"):
         _apply(P)
 
 
@@ -930,7 +931,7 @@ def test_implicit_allreduce_in_while_loop_is_rejected():
                 data = pld.tensor.allreduce(data, op=pld.ReduceOp.Sum)
             return data
 
-    with pytest.raises(Exception, match="allreduce is not supported inside a for/while loop"):
+    with pytest.raises(ValueError, match="allreduce is not supported inside a for/while loop"):
         _apply(P)
 
 
@@ -953,7 +954,7 @@ def test_explicit_allreduce_in_loop_is_rejected():
                 data = pld.tensor.allreduce(data, signal, op=pld.ReduceOp.Sum)
             return data
 
-    with pytest.raises(Exception, match="allreduce is not supported inside a for/while loop"):
+    with pytest.raises(ValueError, match="allreduce is not supported inside a for/while loop"):
         _apply(P)
 
 
@@ -976,7 +977,7 @@ def test_explicit_allreduce_in_while_loop_is_rejected():
                 data = pld.tensor.allreduce(data, signal, op=pld.ReduceOp.Sum)
             return data
 
-    with pytest.raises(Exception, match="allreduce is not supported inside a for/while loop"):
+    with pytest.raises(ValueError, match="allreduce is not supported inside a for/while loop"):
         _apply(P)
 
 
@@ -998,7 +999,7 @@ def test_nested_explicit_allreduce_expression_is_rejected():
             wrapped = (pld.tensor.allreduce(data, signal, op=pld.ReduceOp.Sum),)
             return wrapped
 
-    with pytest.raises(Exception, match="must be a direct assignment"):
+    with pytest.raises(ValueError, match="must be a direct assignment"):
         _apply(P)
 
 
@@ -1018,7 +1019,7 @@ def test_nested_implicit_allreduce_expression_is_rejected():
             wrapped = (pld.tensor.allreduce(data, op=pld.ReduceOp.Sum),)
             return wrapped
 
-    with pytest.raises(Exception, match="must be a direct assignment"):
+    with pytest.raises(ValueError, match="must be a direct assignment"):
         _apply(P)
 
 
@@ -1256,7 +1257,7 @@ def test_dead_alloc_no_window_materialisation_raises():
             buf = pld.alloc_window_buffer(256 * pl.FP32.get_byte())  # noqa: F841  # never windowed
             return 0
 
-    with pytest.raises(Exception, match=r"no pld\.tensor\.window materialisation"):
+    with pytest.raises(pypto.InternalError, match=r"no pld\.tensor\.window materialisation"):
         _apply(P)
 
 
@@ -1274,7 +1275,7 @@ def test_dead_alloc_no_dispatch_raises():
             _ = pld.window(buf, [256], dtype=pl.FP32)
             return 0
 
-    with pytest.raises(Exception, match="not consumed by any chip_orch dispatch"):
+    with pytest.raises(pypto.InternalError, match="not consumed by any chip_orch dispatch"):
         _apply(P)
 
 
@@ -1306,7 +1307,7 @@ def test_non_unit_step_device_loop_raises():
                 self.chip_orch(data, device=r)
             return 0
 
-    with pytest.raises(Exception, match="non-unit-step loop is not supported"):
+    with pytest.raises(pypto.InternalError, match="non-unit-step loop is not supported"):
         _apply(P)
 
 

--- a/tests/ut/ir/transforms/test_materialize_runtime_scopes.py
+++ b/tests/ut/ir/transforms/test_materialize_runtime_scopes.py
@@ -25,6 +25,7 @@ import pytest
 from pypto import backend, ir, passes
 from pypto.backend import BackendType
 from pypto.ir.pass_manager import OptimizationStrategy, PassManager
+from pypto.language.parser.diagnostics import ParserSyntaxError
 
 
 @pytest.fixture(autouse=True)
@@ -517,7 +518,7 @@ def test_opt_out_scopes_survive_full_pipeline():
 def test_hand_placed_auto_scope_rejected_in_default_mode():
     # In the default auto_scope=True mode the compiler owns AUTO placement, so a
     # hand-placed `with pl.scope()` is rejected (set auto_scope=False instead).
-    with pytest.raises(Exception):  # noqa: B017 — parser raises ParserSyntaxError
+    with pytest.raises(ParserSyntaxError):
 
         @pl.program
         class _Prog:

--- a/tests/ut/ir/transforms/test_materialize_tensor_strides_pass.py
+++ b/tests/ut/ir/transforms/test_materialize_tensor_strides_pass.py
@@ -326,7 +326,8 @@ def test_nz_on_tensor_rejected_by_paired_verifier():
     # NZ on a TensorType is invalid IR. The pass leaves the slot untouched
     # rather than CHECK-failing inside BuildLogicalStridesFromLayout — but
     # because the pass produces TensorViewCanonical, PassPipeline runs the
-    # paired verifier, which surfaces the bug as a thrown ValueError.
+    # paired verifier, which surfaces the bug as a thrown VerificationError
+    # (pypto.Error on the Python side).
     @pl.program
     class Before:
         @pl.function

--- a/tests/ut/ir/transforms/test_materialize_tensor_strides_pass.py
+++ b/tests/ut/ir/transforms/test_materialize_tensor_strides_pass.py
@@ -27,6 +27,7 @@ Tests follow the Before/Expected ``@pl.program`` pattern: the pass runs on
 from collections.abc import Sequence
 from typing import cast
 
+import pypto
 import pypto.language as pl
 import pypto.language.distributed as pld
 import pytest
@@ -335,7 +336,7 @@ def test_nz_on_tensor_rejected_by_paired_verifier():
         ):
             pl.const(0, pl.INT64)
 
-    with pytest.raises(ValueError, match="NZ layout"):
+    with pytest.raises(pypto.Error, match="NZ layout"):
         _materialize(Before)
 
 
@@ -349,7 +350,7 @@ def test_nz_on_distributed_tensor_rejected_by_paired_verifier():
         ):
             pl.const(0, pl.INT64)
 
-    with pytest.raises(ValueError, match="NZ layout"):
+    with pytest.raises(pypto.Error, match="NZ layout"):
         _materialize(Before)
 
 

--- a/tests/ut/ir/transforms/test_normalize_stmt_structure_pass.py
+++ b/tests/ut/ir/transforms/test_normalize_stmt_structure_pass.py
@@ -25,6 +25,7 @@ directly. A final raw-IR test exercises a structurally-invalid mid-body
 ``YieldStmt`` that the DSL parser likewise cannot emit.
 """
 
+import pypto
 import pypto.language as pl
 import pytest
 from pypto import DataType, ir, passes
@@ -370,7 +371,7 @@ def test_no_redundant_blocks_rejects_mid_body_yield():
     program = ir.Program([func], "test_program", span)
 
     verify_pass = passes.run_verifier()
-    with pytest.raises(Exception, match="YieldStmt before the terminating position"):
+    with pytest.raises(pypto.Error, match="YieldStmt before the terminating position"):
         verify_pass(program)
 
 

--- a/tests/ut/ir/transforms/test_outline_cluster_scopes.py
+++ b/tests/ut/ir/transforms/test_outline_cluster_scopes.py
@@ -9,6 +9,7 @@
 
 """Unit tests for OutlineClusterScopes pass."""
 
+import pypto
 import pypto.language as pl
 import pytest
 from pypto import ir, passes
@@ -771,7 +772,7 @@ class TestOutlineClusterScopes:
         props = passes.IRPropertySet()
         props.insert(passes.IRProperty.ClusterOutlined)
 
-        with pytest.raises(Exception, match="Verification failed"):
+        with pytest.raises(pypto.Error, match="Verification failed"):
             passes.verify_properties(props, Program, "OutlineClusterScopes")
 
 

--- a/tests/ut/ir/transforms/test_outline_hierarchy_scopes.py
+++ b/tests/ut/ir/transforms/test_outline_hierarchy_scopes.py
@@ -23,6 +23,7 @@ documented semantics (``docs/en/dev/passes/07-outline_hierarchy_scopes.md`` and
 ``convert_to_ssa`` so SSA naming/phi insertion matches the pass output.
 """
 
+import pypto
 import pypto.language as pl
 import pytest
 from pypto import ir, passes
@@ -608,7 +609,7 @@ class TestHierarchyOutlinedVerifier:
         program = passes.convert_to_ssa()(Input)
 
         # verify_properties should throw because Hierarchy scope remains.
-        with pytest.raises(Exception, match="Hierarchy ScopeStmt"):
+        with pytest.raises(pypto.Error, match="Hierarchy ScopeStmt"):
             passes.verify_properties(self._hierarchy_outlined_props(), program, "test")
 
     def test_program_without_hierarchy_passes_verification(self):

--- a/tests/ut/ir/transforms/test_outline_incore_scopes.py
+++ b/tests/ut/ir/transforms/test_outline_incore_scopes.py
@@ -9,6 +9,7 @@
 
 """Unit tests for OutlineIncoreScopes pass."""
 
+import pypto
 import pypto.language as pl
 import pytest
 from pypto import DataType, ir, passes
@@ -1006,7 +1007,7 @@ class TestSplitIncoreOrchVerifier:
         program = passes.convert_to_ssa()(Input)
 
         # verify_properties should throw because InCore scope remains in Opaque function
-        with pytest.raises(Exception, match="InCore ScopeStmt"):
+        with pytest.raises(pypto.Error, match="InCore ScopeStmt"):
             passes.verify_properties(self._split_incore_orch_props(), program, "test")
 
     def test_compute_op_in_orchestration_does_not_fail(self):

--- a/tests/ut/ir/transforms/test_paged_gather.py
+++ b/tests/ut/ir/transforms/test_paged_gather.py
@@ -28,6 +28,7 @@ import pytest
 from pypto import DataType, ir, passes
 from pypto.backend import BackendType, is_backend_configured, set_backend_type
 from pypto.ir.pass_manager import OptimizationStrategy, PassManager
+from pypto.language.parser.diagnostics import InvalidOperationError
 
 
 def _build_program(
@@ -174,7 +175,7 @@ def test_paged_gather_survives_full_pipeline(is_trans):
 
 def test_paged_gather_rejects_non_2d_src():
     """src must be 2D."""
-    with pytest.raises(Exception, match="2D src"):
+    with pytest.raises(InvalidOperationError, match="2D src"):
 
         @pl.program
         class Program:
@@ -190,7 +191,7 @@ def test_paged_gather_rejects_non_2d_src():
 
 def test_paged_gather_rejects_non_int32_indices():
     """indices must be INT32."""
-    with pytest.raises(Exception, match="indices dtype"):
+    with pytest.raises(InvalidOperationError, match="indices dtype"):
 
         @pl.program
         class Program:

--- a/tests/ut/ir/transforms/test_pass_pipeline.py
+++ b/tests/ut/ir/transforms/test_pass_pipeline.py
@@ -9,6 +9,7 @@
 
 """Unit tests for PassPipeline and PassContext."""
 
+import pypto
 import pypto.language as pl
 import pytest
 from pypto import DataType, ir, passes
@@ -164,7 +165,7 @@ class TestPassContext:
         with passes.PassContext([passes.VerificationInstrument(passes.VerificationMode.BEFORE)]):
             # Same Var assigned twice — genuine SSA violation
             program = _make_ssa_violating_program()
-            with pytest.raises(Exception, match="Pre-verification failed"):
+            with pytest.raises(pypto.Error, match="Pre-verification failed"):
                 passes.outline_incore_scopes()(program)
 
     def test_before_mode_succeeds_when_property_holds(self):
@@ -196,7 +197,7 @@ class TestPassContext:
         with passes.PassContext([passes.VerificationInstrument(passes.VerificationMode.BEFORE_AND_AFTER)]):
             # Same Var assigned twice — genuine SSA violation
             program = _make_ssa_violating_program()
-            with pytest.raises(Exception, match="Pre-verification failed"):
+            with pytest.raises(pypto.Error, match="Pre-verification failed"):
                 passes.outline_incore_scopes()(program)
 
     def test_pipeline_with_context(self):
@@ -403,7 +404,7 @@ class TestVerifyProperties:
         props = passes.IRPropertySet()
         props.insert(passes.IRProperty.SSAForm)
 
-        with pytest.raises(Exception, match="Verification failed"):
+        with pytest.raises(pypto.Error, match="Verification failed"):
             passes.verify_properties(props, program, "TestPass")
 
 

--- a/tests/ut/ir/transforms/test_serialization.py
+++ b/tests/ut/ir/transforms/test_serialization.py
@@ -955,7 +955,7 @@ class TestRobustness:
         """Test that deserializing invalid data raises an error."""
         invalid_data = b"invalid msgpack data"
 
-        with pytest.raises(ValueError):  # Should raise some kind of error
+        with pytest.raises(ValueError):  # deserializer CHECK -> pypto::ValueError
             ir.deserialize(invalid_data)
 
     def test_deserialize_nonexistent_file(self):

--- a/tests/ut/ir/transforms/test_stamp_tfree_split.py
+++ b/tests/ut/ir/transforms/test_stamp_tfree_split.py
@@ -80,7 +80,7 @@ def test_tfree_id_mismatch_raises():
             t: pl.Tile[[16, 16], pl.FP32, pl.MemorySpace.Vec] = pl.tpop_from_aic(split=1, id=3)
             pl.tfree_to_aic(t, id=0)
 
-    with pytest.raises(Exception, match="does not match originating"):
+    with pytest.raises(ValueError, match="does not match originating"):
         _stamp(Prog)
 
 
@@ -94,7 +94,7 @@ def test_tfree_direction_mismatch_raises():
             t: pl.Tile[[16, 16], pl.FP32, pl.MemorySpace.Vec] = pl.tpop_from_aic(split=0)
             pl.tfree_to_aiv(t)
 
-    with pytest.raises(Exception, match="requires its tile argument to come from"):
+    with pytest.raises(ValueError, match="requires its tile argument to come from"):
         _stamp(Prog)
 
 

--- a/tests/ut/ir/transforms/test_stmt_dependency_analysis.py
+++ b/tests/ut/ir/transforms/test_stmt_dependency_analysis.py
@@ -16,6 +16,7 @@ Covers:
   variables (RFC #1026 Phase 1, issue #1027).
 """
 
+import pypto
 import pypto.language as pl
 import pytest
 from pypto import ir, passes
@@ -172,7 +173,7 @@ class TestStmtDependencyGraph:
 
 def _assert_violation(body, program, expected_var: str) -> None:
     """The discipline check must raise, and the error message must name the var."""
-    with pytest.raises(Exception, match="InOutUseDiscipline") as excinfo:
+    with pytest.raises(pypto.Error, match="InOutUseDiscipline") as excinfo:
         dep_analysis.check_inout_use_discipline(body, program)
     assert f"'{expected_var}'" in str(excinfo.value)
 
@@ -412,7 +413,7 @@ class TestInOutUseDiscipline:
                 y: pl.Tensor[[64], pl.FP32] = pl.add(x, x)  # VIOLATION
                 return y
 
-        with pytest.raises(Exception, match="InOutUseDiscipline"):
+        with pytest.raises(pypto.Error, match="InOutUseDiscipline"):
             dep_analysis.build_stmt_dependency_graph(_seq_body(P, "main"), P)
 
 

--- a/tests/ut/ir/transforms/test_type_check_pass.py
+++ b/tests/ut/ir/transforms/test_type_check_pass.py
@@ -9,6 +9,7 @@
 
 """Unit tests for type checking via run_verifier()."""
 
+import pypto
 import pytest
 from pypto import DataType, ir, passes
 
@@ -76,7 +77,7 @@ def test_type_check_for_type_mismatch():
 
     # Run type checking via run_verifier - should raise on type mismatch errors
     verify_pass = passes.run_verifier()
-    with pytest.raises(Exception, match="Dtype mismatch in ForStmt"):
+    with pytest.raises(pypto.Error, match="Dtype mismatch in ForStmt"):
         verify_pass(program)
 
 
@@ -101,7 +102,7 @@ def test_type_check_if_type_mismatch():
 
     # Run type checking via run_verifier - should raise on type mismatch error
     verify_pass = passes.run_verifier()
-    with pytest.raises(Exception, match="Dtype mismatch in IfStmt"):
+    with pytest.raises(pypto.Error, match="Dtype mismatch in IfStmt"):
         verify_pass(program)
 
 
@@ -143,7 +144,7 @@ def test_type_check_tensor_shape_mismatch():
 
     # Run type checking via run_verifier - should raise on shape mismatch error
     verify_pass = passes.run_verifier()
-    with pytest.raises(Exception, match="Shape dimension mismatch in ForStmt"):
+    with pytest.raises(pypto.Error, match="Shape dimension mismatch in ForStmt"):
         verify_pass(program)
 
 
@@ -176,7 +177,7 @@ def test_type_check_dimension_count_mismatch():
 
     # Run type checking via run_verifier - should raise on dimension mismatch error
     verify_pass = passes.run_verifier()
-    with pytest.raises(Exception, match="mismatch in IfStmt"):
+    with pytest.raises(pypto.Error, match="mismatch in IfStmt"):
         verify_pass(program)
 
 
@@ -211,7 +212,7 @@ def test_type_check_tile_shape_mismatch():
 
     # Run type checking via run_verifier - should raise on shape mismatch error
     verify_pass = passes.run_verifier()
-    with pytest.raises(Exception, match="mismatch in IfStmt"):
+    with pytest.raises(pypto.Error, match="mismatch in IfStmt"):
         verify_pass(program)
 
 
@@ -270,7 +271,7 @@ def test_type_check_if_condition_must_be_bool():
     program = ir.Program([func], "test_program", span)
 
     verify_pass = passes.run_verifier()
-    with pytest.raises(Exception, match="IfStmt condition dtype must be BOOL"):
+    with pytest.raises(pypto.Error, match="IfStmt condition dtype must be BOOL"):
         verify_pass(program)
 
 
@@ -291,7 +292,7 @@ def test_type_check_while_condition_must_be_bool():
     program = ir.Program([func], "test_program", span)
 
     verify_pass = passes.run_verifier()
-    with pytest.raises(Exception, match="WhileStmt condition dtype must be BOOL"):
+    with pytest.raises(pypto.Error, match="WhileStmt condition dtype must be BOOL"):
         verify_pass(program)
 
 

--- a/tests/ut/ir/transforms/test_unroll_loops_pass.py
+++ b/tests/ut/ir/transforms/test_unroll_loops_pass.py
@@ -18,6 +18,7 @@ import pypto.language as pl
 import pytest
 from pypto import ir, passes
 from pypto.ir.printer import python_print
+from pypto.language.parser.diagnostics import ParserSyntaxError
 
 
 def _unroll_and_ssa(program):
@@ -239,7 +240,7 @@ class TestUnrollLimits:
                     x = pl.add(x, 1.0)
                 return x
 
-        with pytest.raises(Exception, match="exceeds maximum allowed"):
+        with pytest.raises(ValueError, match="exceeds maximum allowed"):
             passes.unroll_loops()(Before)
 
 
@@ -248,7 +249,7 @@ class TestParserValidation:
 
     def test_unroll_with_init_values_rejected(self):
         """pl.unroll() cannot be combined with init_values."""
-        with pytest.raises(Exception, match="cannot be combined with init_values"):
+        with pytest.raises(ParserSyntaxError, match="cannot be combined with init_values"):
 
             @pl.program
             class _:

--- a/tests/ut/ir/transforms/test_verifier.py
+++ b/tests/ut/ir/transforms/test_verifier.py
@@ -9,6 +9,7 @@
 
 """Unit tests for PropertyVerifierRegistry-based verification."""
 
+import pypto
 import pytest
 from pypto import DataType, ir, passes
 from pypto.ir import builder
@@ -100,7 +101,7 @@ def test_registry_verify_or_throw_with_error():
     program = _make_ssa_violating_program()
 
     props = passes.get_default_verify_properties()
-    with pytest.raises(Exception, match="IR Verification Report"):
+    with pytest.raises(pypto.Error, match="IR Verification Report"):
         passes.PropertyVerifierRegistry.verify_or_throw(props, program)
 
 
@@ -360,7 +361,7 @@ def test_verification_instrument_checks_structural_before_pass():
     """
     program = _make_nested_seq_stmt_program(nested=True)
 
-    with pytest.raises(Exception, match="Pre-verification failed"):
+    with pytest.raises(pypto.Error, match="Pre-verification failed"):
         with passes.PassContext([passes.VerificationInstrument(passes.VerificationMode.BEFORE_AND_AFTER)]):
             passes.normalize_stmt_structure()(program)
 

--- a/tests/ut/ir/transforms/test_verify_hard_syncall_occupancy.py
+++ b/tests/ut/ir/transforms/test_verify_hard_syncall_occupancy.py
@@ -24,6 +24,7 @@ at compile time.
 Tests drive the full Default pipeline on Ascend910B (48 VECTOR / 24 CUBE cores).
 """
 
+import pypto
 import pypto.language as pl
 import pytest
 from pypto import backend
@@ -615,7 +616,7 @@ class TestHardSyncallOccupancy:
 
     def test_partial_aiv_occupancy_rejected(self):
         """pl.spmd(24) < 48 AIV cores + hard aiv_only barrier is rejected at compile time."""
-        with pytest.raises(Exception, match="fill all 48 AIV cores"):
+        with pytest.raises(pypto.Error, match="fill all 48 AIV cores"):
             _run(_aiv_program(24))
 
     def test_full_aiv_occupancy_accepted(self):
@@ -624,12 +625,12 @@ class TestHardSyncallOccupancy:
 
     def test_over_aiv_occupancy_rejected(self):
         """pl.spmd(96) > 48 AIV cores is rejected (hard barrier needs exactly-full occupancy)."""
-        with pytest.raises(Exception, match="fill all 48 AIV cores"):
+        with pytest.raises(pypto.Error, match="fill all 48 AIV cores"):
             _run(_aiv_program(96))
 
     def test_full_aiv_occupancy_without_sync_start_rejected(self):
         """pl.spmd(48) at full occupancy but without sync_start is rejected (blocks not co-resident)."""
-        with pytest.raises(Exception, match="sync_start=True"):
+        with pytest.raises(pypto.Error, match="sync_start=True"):
             _run(_aiv_program_no_sync(48))
 
     def test_soft_form_not_checked(self):
@@ -646,22 +647,22 @@ class TestHardSyncallOccupancy:
 
     def test_mixed_partial_occupancy_rejected(self):
         """Mixed kernel + hard mix barrier at pl.spmd(12) < 24 core-groups is rejected."""
-        with pytest.raises(Exception, match="core-groups"):
+        with pytest.raises(pypto.Error, match="core-groups"):
             _run(_mixed_program(12))
 
     def test_mixed_full_occupancy_without_sync_start_rejected(self):
         """Mixed kernel at full 24 core-groups but without sync_start is rejected."""
-        with pytest.raises(Exception, match="sync_start=True"):
+        with pytest.raises(pypto.Error, match="sync_start=True"):
             _run(_mixed_program_no_sync(24))
 
     def test_standalone_default_mix_barrier_rejected(self):
         """A pure-AIV kernel with the default (mix) hard barrier can never complete (no AIC)."""
-        with pytest.raises(Exception, match="can never complete"):
+        with pytest.raises(pypto.Error, match="can never complete"):
             _run(_aiv_default_mix_program(48))
 
     def test_spmd_submit_partial_occupancy_rejected(self):
         """pl.spmd_submit(core_num=24) carries the block count on the Submit — still checked."""
-        with pytest.raises(Exception, match="fill all 48 AIV cores"):
+        with pytest.raises(pypto.Error, match="fill all 48 AIV cores"):
             _run(_spmd_submit_program(24))
 
     def test_spmd_submit_full_occupancy_accepted(self):
@@ -670,12 +671,12 @@ class TestHardSyncallOccupancy:
 
     def test_spmd_submit_full_occupancy_without_sync_start_rejected(self):
         """pl.spmd_submit(core_num=48) at full occupancy but without sync_start is rejected."""
-        with pytest.raises(Exception, match="sync_start=True"):
+        with pytest.raises(pypto.Error, match="sync_start=True"):
             _run(_spmd_submit_program_no_sync(48))
 
     def test_cluster_spmd_partial_occupancy_rejected(self):
         """pl.cluster()-nested pl.spmd(24) (a Group with core_num) is checked and rejected."""
-        with pytest.raises(Exception, match="fill all 48 AIV cores"):
+        with pytest.raises(pypto.Error, match="fill all 48 AIV cores"):
             _run(_cluster_spmd_program(24))
 
     def test_cluster_spmd_full_occupancy_accepted(self):
@@ -684,7 +685,7 @@ class TestHardSyncallOccupancy:
 
     def test_cluster_spmd_full_occupancy_without_sync_start_rejected(self):
         """pl.cluster()-nested pl.spmd(48) at full occupancy but without sync_start is rejected."""
-        with pytest.raises(Exception, match="sync_start=True"):
+        with pytest.raises(pypto.Error, match="sync_start=True"):
             _run(_cluster_spmd_program_no_sync(48))
 
     def test_aiv_query_width_accepted(self):
@@ -693,12 +694,12 @@ class TestHardSyncallOccupancy:
 
     def test_aiv_query_width_without_sync_start_rejected(self):
         """Occupancy from the query still does not imply co-residency."""
-        with pytest.raises(Exception, match="sync_start=True"):
+        with pytest.raises(pypto.Error, match="sync_start=True"):
             _run(_aiv_query_program_no_sync())
 
     def test_aiv_launch_with_cluster_query_rejected(self):
         """available_cluster_count() sizes an AIV-only launch to the AIC count — rejected."""
-        with pytest.raises(Exception, match=r"available_cluster_count\(\).*available_aiv_count\(\)"):
+        with pytest.raises(pypto.Error, match=r"available_cluster_count\(\).*available_aiv_count\(\)"):
             _run(_aiv_wrong_query_program())
 
     def test_mixed_query_width_accepted(self):
@@ -707,7 +708,7 @@ class TestHardSyncallOccupancy:
 
     def test_mixed_launch_with_aiv_query_rejected(self):
         """available_aiv_count() sizes a mixed launch to the AIV count — rejected."""
-        with pytest.raises(Exception, match=r"available_aiv_count\(\).*available_cluster_count\(\)"):
+        with pytest.raises(pypto.Error, match=r"available_aiv_count\(\).*available_cluster_count\(\)"):
             _run(_mixed_wrong_query_program())
 
 

--- a/tests/ut/ir/transforms/test_verify_ssa_pass.py
+++ b/tests/ut/ir/transforms/test_verify_ssa_pass.py
@@ -9,6 +9,7 @@
 
 """Unit tests for SSA verification via run_verifier()."""
 
+import pypto
 import pypto.language as pl
 import pytest
 from pypto import DataType, ir, passes
@@ -114,7 +115,7 @@ def test_verify_ssa_missing_yield():
     program = ir.Program([func], "test_program", span)
 
     verify_pass = passes.run_verifier()
-    with pytest.raises(Exception, match="must have YieldStmt"):
+    with pytest.raises(pypto.Error, match="must have YieldStmt"):
         verify_pass(program)
 
 
@@ -137,7 +138,7 @@ def test_verify_ssa_missing_else():
     program = ir.Program([func], "test_program", span)
 
     verify_pass = passes.run_verifier()
-    with pytest.raises(Exception, match="must have else branch"):
+    with pytest.raises(pypto.Error, match="must have else branch"):
         verify_pass(program)
 
 
@@ -281,7 +282,7 @@ class TestScopeViolation:
         program = ir.Program([func], "test_program", span)
 
         verify_pass = passes.run_verifier()
-        with pytest.raises(Exception, match="used outside its defining scope"):
+        with pytest.raises(pypto.Error, match="used outside its defining scope"):
             verify_pass(program)
 
     def test_var_from_then_branch_used_after_if(self):
@@ -304,7 +305,7 @@ class TestScopeViolation:
         program = ir.Program([func], "test_program", span)
 
         verify_pass = passes.run_verifier()
-        with pytest.raises(Exception, match=r"used before definition|used outside its defining scope"):
+        with pytest.raises(pypto.Error, match=r"used before definition|used outside its defining scope"):
             verify_pass(program)
 
     def test_iter_arg_used_outside_loop(self):
@@ -338,7 +339,7 @@ class TestScopeViolation:
         program = ir.Program([func], "test_program", span)
 
         verify_pass = passes.run_verifier()
-        with pytest.raises(Exception, match=r"used before definition|used outside its defining scope"):
+        with pytest.raises(pypto.Error, match=r"used before definition|used outside its defining scope"):
             verify_pass(program)
 
     def test_loop_var_used_outside_loop(self):
@@ -369,7 +370,7 @@ class TestScopeViolation:
         program = ir.Program([func], "test_program", span)
 
         verify_pass = passes.run_verifier()
-        with pytest.raises(Exception, match=r"used before definition|used outside its defining scope"):
+        with pytest.raises(pypto.Error, match=r"used before definition|used outside its defining scope"):
             verify_pass(program)
 
     def test_if_return_var_not_visible_in_condition(self):
@@ -393,7 +394,7 @@ class TestScopeViolation:
         program = ir.Program([func], "test_program", span)
 
         verify_pass = passes.run_verifier()
-        with pytest.raises(Exception, match=r"used before definition|used outside its defining scope"):
+        with pytest.raises(pypto.Error, match=r"used before definition|used outside its defining scope"):
             verify_pass(program)
 
 
@@ -431,7 +432,7 @@ class TestCardinalityChecks:
         program = ir.Program([func], "test_program", span)
 
         verify_pass = passes.run_verifier()
-        with pytest.raises(Exception, match=r"(iter_args count.*return_vars count|size mismatch)"):
+        with pytest.raises(pypto.Error, match=r"(iter_args count.*return_vars count|size mismatch)"):
             verify_pass(program)
 
     def test_for_yield_count_mismatch(self):
@@ -466,7 +467,7 @@ class TestCardinalityChecks:
         program = ir.Program([func], "test_program", span)
 
         verify_pass = passes.run_verifier()
-        with pytest.raises(Exception, match=r"(YieldStmt value count.*iter_args count|size mismatch)"):
+        with pytest.raises(pypto.Error, match=r"(YieldStmt value count.*iter_args count|size mismatch)"):
             verify_pass(program)
 
     def test_if_yield_count_mismatch(self):
@@ -490,7 +491,7 @@ class TestCardinalityChecks:
         program = ir.Program([func], "test_program", span)
 
         verify_pass = passes.run_verifier()
-        with pytest.raises(Exception, match=r"(YieldStmt value count.*return_vars count|size mismatch)"):
+        with pytest.raises(pypto.Error, match=r"(YieldStmt value count.*return_vars count|size mismatch)"):
             verify_pass(program)
 
     # The next four tests construct IR directly via `ir.ForStmt` / `ir.WhileStmt`
@@ -534,7 +535,7 @@ class TestCardinalityChecks:
         program = ir.Program([func], "test_program", span)
 
         verify_pass = passes.run_verifier()
-        with pytest.raises(Exception, match="YieldStmt before the terminating position"):
+        with pytest.raises(pypto.Error, match="YieldStmt before the terminating position"):
             verify_pass(program)
 
     def test_while_mid_body_yield(self):
@@ -562,7 +563,7 @@ class TestCardinalityChecks:
         program = ir.Program([func], "test_program", span)
 
         verify_pass = passes.run_verifier()
-        with pytest.raises(Exception, match="YieldStmt before the terminating position"):
+        with pytest.raises(pypto.Error, match="YieldStmt before the terminating position"):
             verify_pass(program)
 
     def test_if_then_mid_body_yield(self):
@@ -589,7 +590,7 @@ class TestCardinalityChecks:
         program = ir.Program([func], "test_program", span)
 
         verify_pass = passes.run_verifier()
-        with pytest.raises(Exception, match="YieldStmt before the terminating position"):
+        with pytest.raises(pypto.Error, match="YieldStmt before the terminating position"):
             verify_pass(program)
 
     def test_if_else_mid_body_yield(self):
@@ -616,7 +617,7 @@ class TestCardinalityChecks:
         program = ir.Program([func], "test_program", span)
 
         verify_pass = passes.run_verifier()
-        with pytest.raises(Exception, match="YieldStmt before the terminating position"):
+        with pytest.raises(pypto.Error, match="YieldStmt before the terminating position"):
             verify_pass(program)
 
 

--- a/tests/ut/language/parser/test_auto_scope_parsing.py
+++ b/tests/ut/language/parser/test_auto_scope_parsing.py
@@ -19,6 +19,7 @@ import pypto.language as pl
 import pytest
 from pypto import ir
 from pypto.ir.printer import python_print
+from pypto.language.parser.diagnostics import ParserSyntaxError
 
 
 def _first_runtime_scope(stmt):
@@ -112,7 +113,7 @@ def test_manual_scope_alias_parses_to_same_ir():
 
 
 def test_scope_rejects_positional_args():
-    with pytest.raises(Exception):  # noqa: B017 — parser raises ParserSyntaxError
+    with pytest.raises(ParserSyntaxError):
 
         @pl.program
         class _Prog:
@@ -124,7 +125,7 @@ def test_scope_rejects_positional_args():
 
 
 def test_auto_scope_rejected_in_default_mode():
-    with pytest.raises(Exception):  # noqa: B017 — AUTO scope requires auto_scope=False
+    with pytest.raises(ParserSyntaxError):  # AUTO scope requires auto_scope=False
 
         @pl.program
         class _Prog:
@@ -199,7 +200,7 @@ def test_manual_scope_in_if_branch_registers_yield_var():
 
 
 def test_auto_scope_rejected_inside_manual_scope():
-    with pytest.raises(Exception):  # noqa: B017 — runtime forbids AUTO nested in MANUAL
+    with pytest.raises(ParserSyntaxError):  # runtime forbids AUTO nested in MANUAL
 
         @pl.program
         class _Prog:

--- a/tests/ut/language/parser/test_call_arg_directions_dsl.py
+++ b/tests/ut/language/parser/test_call_arg_directions_dsl.py
@@ -30,6 +30,7 @@ import pypto.language as pl
 import pytest
 from pypto import ir, passes
 from pypto.language.arg_direction import DIRECTION_TO_NAME, NAME_TO_DIRECTION
+from pypto.language.parser.diagnostics import InvalidOperationError, ParserSyntaxError, ParserTypeError
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -263,7 +264,7 @@ class Prog:
         r: pl.Tensor[[64], pl.FP32] = self.kernel(x, attrs={"arg_directions": [pl.adir.bogus]})
         return r
 """
-        with pytest.raises(Exception, match="bogus"):
+        with pytest.raises(ParserSyntaxError, match="bogus"):
             pl.parse(code)
 
     def test_attrs_kwarg_size_mismatch_rejected(self):
@@ -291,7 +292,7 @@ class Prog:
         r: pl.Tensor[[64], pl.FP32] = self.kernel(x, dst, attrs={"arg_directions": [pl.adir.input]})
         return r
 """
-        with pytest.raises(Exception, match=r"(?i)length|match"):
+        with pytest.raises(ParserTypeError, match=r"(?i)length|match"):
             pl.parse(code)
 
     def test_attrs_kwarg_non_bespoke_key_round_trips(self):
@@ -339,7 +340,7 @@ class Prog:
         r: pl.Tensor[[64], pl.FP32] = self.kernel(x, foo=1)
         return r
 """
-        with pytest.raises(Exception, match="foo"):
+        with pytest.raises(ParserTypeError, match="foo"):
             pl.parse(code)
 
     def test_per_argument_wrapper_form_no_longer_supported(self):
@@ -362,7 +363,7 @@ class Prog:
 """
         # The parser routes ``pl.adir.input(x)`` through the generic op-call
         # path, where it is rejected as an unsupported function call.
-        with pytest.raises(Exception):  # noqa: B017, PT011
+        with pytest.raises(InvalidOperationError):
             pl.parse(code)
 
     def test_marker_alias_resolves_to_enum_value(self):

--- a/tests/ut/language/parser/test_control_flow.py
+++ b/tests/ut/language/parser/test_control_flow.py
@@ -12,7 +12,7 @@
 import pypto.language as pl
 import pytest
 from pypto import ir
-from pypto.language.parser.diagnostics import InvalidOperationError
+from pypto.language.parser.diagnostics import InvalidOperationError, ParserSyntaxError
 
 
 class TestForLoops:
@@ -402,7 +402,7 @@ class TestParallelForLoops:
 
     def test_invalid_iterator_rejected(self):
         """Test that invalid iterator (not range or parallel) is rejected."""
-        with pytest.raises(Exception):
+        with pytest.raises(ParserSyntaxError):
 
             @pl.function
             def bad_func(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:

--- a/tests/ut/language/parser/test_decorator.py
+++ b/tests/ut/language/parser/test_decorator.py
@@ -1503,7 +1503,7 @@ class TestCrossFunctionDynamicShapeSubstitution:
         M = pl.dynamic("M")
         N = pl.dynamic("N")
 
-        with pytest.raises(Exception, match="conflicting bindings"):
+        with pytest.raises(ParserSyntaxError, match="conflicting bindings"):
 
             @pl.program
             class ShapeMismatch:

--- a/tests/ut/language/parser/test_manual_scope_parsing.py
+++ b/tests/ut/language/parser/test_manual_scope_parsing.py
@@ -74,7 +74,7 @@ class TestManualScopeParsing:
         assert scope.manual is True
 
     def test_parse_manual_scope_rejects_arguments(self):
-        with pytest.raises(Exception):  # noqa: B017 — parser raises ParserSyntaxError
+        with pytest.raises(ParserSyntaxError):
 
             @pl.program
             class _Prog:
@@ -185,7 +185,7 @@ class Prog:
 
     def test_plain_call_rejects_deps_kwarg(self):
         """``deps=`` on a plain ``self.kernel(...)`` call is rejected — use pl.submit."""
-        with pytest.raises(Exception):  # noqa: B017 — parser raises ParserTypeError
+        with pytest.raises(ParserTypeError):
 
             @pl.program
             class _Prog:
@@ -257,7 +257,7 @@ class Prog:
         assert edges[0].type.dtype == pl.TASK_ID
 
     def test_submit_as_bare_expression_is_rejected(self):
-        with pytest.raises(Exception):  # noqa: B017 — parser raises ParserSyntaxError
+        with pytest.raises(ParserSyntaxError):
 
             @pl.program
             class _Prog:
@@ -438,7 +438,7 @@ class Prog:
 
     def test_pl_at_as_on_non_at_scope_is_rejected(self):
         """``as`` is only meaningful on ``pl.at(...)``; other constructs reject it."""
-        with pytest.raises(Exception):  # noqa: B017 — parser raises ParserSyntaxError
+        with pytest.raises(ParserSyntaxError):
 
             @pl.program
             class _Prog:
@@ -449,7 +449,7 @@ class Prog:
 
     def test_submit_nested_result_tuple_is_rejected(self):
         """pl.submit result targets must be plain names — no nested tuples."""
-        with pytest.raises(Exception):  # noqa: B017 — parser raises ParserSyntaxError
+        with pytest.raises(ParserSyntaxError):
 
             @pl.program
             class _Prog:

--- a/tests/ut/language/parser/test_task_id_dsl.py
+++ b/tests/ut/language/parser/test_task_id_dsl.py
@@ -230,7 +230,7 @@ class TestDepsKwargAcceptsTaskId:
 
     def test_deps_rejects_tensor_var(self):
         """Tensor variables are not accepted in ``deps=[...]``."""
-        with pytest.raises(Exception):  # noqa: B017 — ParserTypeError
+        with pytest.raises(ParserTypeError):
 
             @pl.program
             class _Prog:
@@ -252,7 +252,7 @@ class TestDepsKwargAcceptsTaskId:
 
     def test_deps_rejects_non_task_id_scalar(self):
         """``deps=[int_scalar]`` (a non-TaskId scalar) errors."""
-        with pytest.raises(Exception):  # noqa: B017 — ParserTypeError
+        with pytest.raises(ParserTypeError):
 
             @pl.program
             class _Prog:

--- a/tests/ut/language/parser/test_type_resolver.py
+++ b/tests/ut/language/parser/test_type_resolver.py
@@ -1315,7 +1315,7 @@ class TestDynamicShapeEdgeCases:
         """User typos variable name — should get a clear error."""
         shape = [128, 64]  # noqa: F841 — intentionally unused; typo below
 
-        with pytest.raises(NameError, match="shaep|Cannot resolve|Unknown|undefined"):
+        with pytest.raises(NameError, match=r"shaep|Cannot resolve|Unknown|undefined"):
 
             @pl.function
             def func(x: pl.Tensor[shaep, pl.FP32]) -> pl.Tensor[shaep, pl.FP32]:  # noqa: F821
@@ -1325,7 +1325,7 @@ class TestDynamicShapeEdgeCases:
         """User accidentally passes a string as shape."""
         shape = "128x64"
 
-        with pytest.raises(ParserTypeError, match="must be a list or tuple|Failed to evaluate"):
+        with pytest.raises(ParserTypeError, match=r"must be a list or tuple|Failed to evaluate"):
 
             @pl.function
             def func(x: pl.Tensor[shape, pl.FP32]) -> pl.Tensor[shape, pl.FP32]:
@@ -1335,7 +1335,7 @@ class TestDynamicShapeEdgeCases:
         """User accidentally uses floats in shape."""
         shape = [128.0, 64.0]
 
-        with pytest.raises(ParserTypeError, match="must be int|element"):
+        with pytest.raises(ParserTypeError, match=r"must be int|element"):
 
             @pl.function
             def func(x: pl.Tensor[shape, pl.FP32]) -> pl.Tensor[shape, pl.FP32]:

--- a/tests/ut/language/parser/test_type_resolver.py
+++ b/tests/ut/language/parser/test_type_resolver.py
@@ -1315,7 +1315,7 @@ class TestDynamicShapeEdgeCases:
         """User typos variable name — should get a clear error."""
         shape = [128, 64]  # noqa: F841 — intentionally unused; typo below
 
-        with pytest.raises(Exception, match="shaep|Cannot resolve|Unknown|undefined"):
+        with pytest.raises(NameError, match="shaep|Cannot resolve|Unknown|undefined"):
 
             @pl.function
             def func(x: pl.Tensor[shaep, pl.FP32]) -> pl.Tensor[shaep, pl.FP32]:  # noqa: F821
@@ -1325,7 +1325,7 @@ class TestDynamicShapeEdgeCases:
         """User accidentally passes a string as shape."""
         shape = "128x64"
 
-        with pytest.raises(Exception, match="must be a list or tuple|Failed to evaluate"):
+        with pytest.raises(ParserTypeError, match="must be a list or tuple|Failed to evaluate"):
 
             @pl.function
             def func(x: pl.Tensor[shape, pl.FP32]) -> pl.Tensor[shape, pl.FP32]:
@@ -1335,7 +1335,7 @@ class TestDynamicShapeEdgeCases:
         """User accidentally uses floats in shape."""
         shape = [128.0, 64.0]
 
-        with pytest.raises(Exception, match="must be int|element"):
+        with pytest.raises(ParserTypeError, match="must be int|element"):
 
             @pl.function
             def func(x: pl.Tensor[shape, pl.FP32]) -> pl.Tensor[shape, pl.FP32]:

--- a/tests/ut/language/test_pipeline_kwarg.py
+++ b/tests/ut/language/test_pipeline_kwarg.py
@@ -19,6 +19,7 @@ from typing import cast
 import pypto.language as pl
 import pytest
 from pypto import ir
+from pypto.language.parser.diagnostics import ParserSyntaxError
 
 
 def _outer_for(program: ir.Program) -> ir.ForStmt:
@@ -112,7 +113,7 @@ class TestPipelineKwargRejection:
     """The parser must reject invalid pl.pipeline calls with clear errors."""
 
     def test_missing_stage_rejected(self):
-        with pytest.raises(Exception, match=r"pl\.pipeline\(\) requires stage="):
+        with pytest.raises(ParserSyntaxError, match=r"pl\.pipeline\(\) requires stage="):
 
             @pl.program
             class _P:
@@ -123,7 +124,7 @@ class TestPipelineKwargRejection:
                     return x
 
     def test_stage_zero_rejected(self):
-        with pytest.raises(Exception, match=r"pl\.pipeline\(\) stage must be >= 1"):
+        with pytest.raises(ParserSyntaxError, match=r"pl\.pipeline\(\) stage must be >= 1"):
 
             @pl.program
             class _P:
@@ -134,7 +135,7 @@ class TestPipelineKwargRejection:
                     return x
 
     def test_stage_negative_rejected(self):
-        with pytest.raises(Exception, match=r"pl\.pipeline\(\) stage must be >= 1"):
+        with pytest.raises(ParserSyntaxError, match=r"pl\.pipeline\(\) stage must be >= 1"):
 
             @pl.program
             class _P:
@@ -146,7 +147,7 @@ class TestPipelineKwargRejection:
 
     def test_stage_runtime_value_rejected(self):
         """Non-constant ``stage`` is rejected by the parser (must be a literal int)."""
-        with pytest.raises(Exception, match=r"stage must be a compile-time constant"):
+        with pytest.raises(ParserSyntaxError, match=r"stage must be a compile-time constant"):
 
             @pl.program
             class _P:
@@ -159,7 +160,7 @@ class TestPipelineKwargRejection:
                     return x
 
     def test_stage_on_range_rejected(self):
-        with pytest.raises(Exception, match=r"stage= is only supported on pl\.pipeline"):
+        with pytest.raises(ParserSyntaxError, match=r"stage= is only supported on pl\.pipeline"):
 
             @pl.program
             class _P:
@@ -170,7 +171,7 @@ class TestPipelineKwargRejection:
                     return x
 
     def test_stage_on_unroll_rejected(self):
-        with pytest.raises(Exception, match=r"stage= is only supported on pl\.pipeline"):
+        with pytest.raises(ParserSyntaxError, match=r"stage= is only supported on pl\.pipeline"):
 
             @pl.program
             class _P:


### PR DESCRIPTION
## Summary

Tests catching bare `Exception` discard the distinction PyPTO deliberately maintains across the C++/Python boundary: `CHECK` surfaces a user error (`ValueError`), `INTERNAL_CHECK` surfaces a compiler bug (`pypto.InternalError`). A test asserting a user-facing rejection still passed if the code was changed to raise an unrelated type whose message happened to match — including a `CHECK` silently downgraded to an `INTERNAL_CHECK`, which is exactly the regression `.claude/rules/error-checking.md` exists to prevent.

**Narrows 303 of 316 `pytest.raises(Exception, ...)` sites** to the type each site actually raises, keeping every existing `match=`. The 13 remaining are in `test_error.py` / `test_logging.py`, which assert the exception *hierarchy* itself (`test_value_error_is_exception`, `test_check_preserves_exception_hierarchy`) — narrowing those would delete their purpose, so they are allowlisted.

Types were **not** inferred from the `match=` strings. `pytest.raises` was instrumented to record the concrete type actually caught at each call site during full-suite runs under **every** `PYPTO_VERIFY_LEVEL` (`roundtrip` / `basic` / `none`); every narrowed type is identical across all three. As a cross-check, the recorded types independently reproduced all 9 pre-existing `# noqa: B017 — parser raises ParserSyntaxError` annotations.

## Two implementation defects fixed

**1. `pypto::Error` subclasses lost their type crossing into Python.** The fallback branch of the exception translator raised a bare `PyExc_Exception` rather than the already-registered `pypto.Error`, so `VerificationError` was not catchable by type from Python at all. It now raises `exc_error`. Backward-compatible — `pypto.Error` derives from `Exception`, so `except Exception` is unaffected. This is what blocked 19 sites from being narrowable.

Also switches the `__module__` fix-up to `nb::setattr`, fixing a reference leak (`PyObject_SetAttrString` does not steal the `PyUnicode_FromString` reference).

**2. The same verification failure surfaced as two different Python types.** `VerifyOrThrowWithContext` threw `pypto::ValueError` while `PropertyVerifierRegistry::VerifyPropertiesOrThrow` threw `VerificationError` — for a failure of the *same* properties from the *same* registry. Which one a caller saw depended on whether a `VerificationInstrument` was installed, i.e. on `PYPTO_VERIFY_LEVEL` — a test-harness detail leaking into the public API. Both now throw `VerificationError`.

> [!IMPORTANT]
> **Public API change:** pre-verification failures now raise `pypto.Error` instead of `ValueError`, so `except ValueError` no longer catches them. 37 assertions updated to a uniform `pypto.Error`.

## Regression guard

Adds `tests/lint/check_no_broad_raises.py`, wired into pre-commit. ruff's `B017` is insufficient: it exempts `pytest.raises(Exception, match=...)`, which was 268 of the 316 occurrences, and neither `B` nor `PT` is in the repo's ruff `select` list. The check also catches the wrapped and leading-tuple forms, and it found 7 multi-line sites a line-based grep had missed.

## Testing

| `PYPTO_VERIFY_LEVEL` | Result |
| --- | --- |
| `roundtrip` (default) | 8088 passed, 2 skipped |
| `basic` | 8088 passed, 2 skipped |
| `none` | 8086 passed, 2 skipped, 2 failed (pre-existing) |

- [x] Full suite green at the default level
- [x] Build clean, zero warnings; `clang-format` clean
- [x] `check_headers`, `check_english_only`, `check_docs_en_zh_parity`, `check_docs_nav`, `ruff check`, `ruff format`, `pyright` all pass
- [x] Docs updated in `docs/en/` and `docs/zh/`, including a note that the Python exception mirror is **flat** (`pypto.InternalError` is not a subclass of `pypto.Error`)

Verified that the strengthening works: simulating a `CHECK` → `INTERNAL_CHECK` downgrade passes silently under `pytest.raises(Exception, match=...)` and fails under the narrowed assertion.

### Known unrelated failures

Two `PYPTO_VERIFY_LEVEL=none` failures in `test_materialize_tensor_strides_pass.py` are **pre-existing** — reproduced on the unmodified files. Those tests rely on the paired verifier running, so under `none` nothing raises at all (`DID NOT RAISE`, independent of the asserted type). `test_benchmark_l3_ignores_prepare_setup_groups` fails on pristine `upstream/main` (`prepare() got an unexpected keyword argument 'persistent'`) and is untouched by this PR.