### PR TITLE
fix(codegen): clamp negative dynamic offsets in pto.partition_view

### DIFF
--- a/src/backend/common/pto_ops_shared.cpp
+++ b/src/backend/common/pto_ops_shared.cpp
@@ -105,16 +105,34 @@ std::string MakePartitionTensorViewType(const std::vector<std::string>& dims, co
 // emitted as index constants; loop vars are already index (EmitCastToIndex is
 // a no-op). Used for every pto.partition_view offset (load/store/remote_store/
 // notify/wait/put), so all paths coerce offsets identically.
+//
+// After coercion, every runtime offset is clamped to non-negative via
+// arith.maxsi(offset, 0). A negative offset (e.g. a ring-neighbour computation
+// that passes through -1 before a conditional adjust) would otherwise reach
+// PTOAS as a signed index value that partition_view does not handle, silently
+// dropping or misdirecting the access. ConstInt offsets are clamped at emit
+// time so compile-time provably-negative offsets also become safe codegen
+// (the verifier rejects those independently).
 std::vector<std::string> GetIndexOffsetCodes(const std::vector<ir::ExprPtr>& exprs,
                                              codegen::PTOCodegen& codegen) {
   std::vector<std::string> codes;
   codes.reserve(exprs.size());
   for (const auto& expr : exprs) {
+    std::string offset_idx;
     if (auto ci = As<ir::ConstInt>(expr)) {
-      codes.push_back(codegen.GetOrEmitConstant(ci->value_, DataType::INDEX));
+      // Clamp compile-time negative constants to zero at codegen time.
+      offset_idx = codegen.GetOrEmitConstant(std::max(ci->value_, static_cast<int64_t>(0)), DataType::INDEX);
     } else {
-      codes.push_back(codegen.EmitCastToIndex(expr, codegen.GetExprAsCode(expr)));
+      // For runtime expressions, insert an arith.maxsi(offset, 0) clamp so
+      // that a negative dynamic value cannot reach pto.partition_view, where
+      // it would silently misbehave.
+      auto raw_idx = codegen.EmitCastToIndex(expr, codegen.GetExprAsCode(expr));
+      auto zero_idx = codegen.GetOrEmitConstant(static_cast<int64_t>(0), DataType::INDEX);
+      auto clamped = codegen.NewTemp();
+      codegen.Emit(clamped + " = arith.maxsi " + raw_idx + ", " + zero_idx + " : index");
+      offset_idx = clamped;
     }
+    codes.push_back(std::move(offset_idx));
   }
   return codes;
 }

--- a/tests/ut/codegen/test_pto_codegen_ops.py
+++ b/tests/ut/codegen/test_pto_codegen_ops.py
@@ -936,6 +936,31 @@ class TestTileReadWriteOffsetCodegen:
         assert "arith.muli" in mlir, f"Expected arith.muli for 2D partial-constant index, got:\n{mlir}"
         assert "arith.addi" in mlir, f"Expected arith.addi for 2D partial-constant index, got:\n{mlir}"
 
+    def test_store_dynamic_offset_clamped_to_non_negative(self):
+        """pl.store with a dynamic offset emits arith.maxsi clamp against zero.
+
+        A runtime INT32 scalar used as a store offset (e.g. a rank-derived ring
+        index) could evaluate to a negative value.  The offset must be clamped
+        to non-negative before it reaches pto.partition_view, which does not
+        handle negative indices.  Regression for issue #2201.
+        """
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                src: pl.Tensor[[1, 8], pl.FP32],
+                config: pl.Tensor[[1], pl.INT32],
+                out: pl.Tensor[[1, 32], pl.FP32],
+            ) -> pl.Tensor[[1, 32], pl.FP32]:
+                offset: pl.Scalar[pl.INT32] = pl.read(config, [0])
+                ones: pl.Tile[[1, 8], pl.FP32] = pl.load(src, [0, 0], [1, 8])
+                return pl.store(ones, [0, offset], out)
+
+        mlir = self._generate_mlir(Prog)
+        assert "arith.maxsi" in mlir, f"Expected arith.maxsi clamp for dynamic store offset, got:\n{mlir}"
+
 
 class TestBroadcastOpsCodegen:
     """Tests for broadcast (expand) operations PTO code generation."""


### PR DESCRIPTION
## Summary

A runtime scalar used as a `tile.store` / `tile.load` offset (e.g. a rank-derived ring index computed through a negative intermediate before a conditional adjust) could evaluate negative and reach `pto.partition_view`, where PTOAS silently drops or misdirects the access. This was reported as [#2201](https://github.com/hw-native-sys/pypto/issues/2201) and confirmed in sim.

## Root cause

`GetIndexOffsetCodes` in `src/backend/common/pto_ops_shared.cpp` converts offset expressions to MLIR `index` values but did not guard against negative values. A `-8` offset (from `(my_rank - 1) * 8` when `my_rank = 0`) was passed straight into `pto.partition_view` without clamping.

## Fix

**`src/backend/common/pto_ops_shared.cpp`** — `GetIndexOffsetCodes`:
- For `ConstInt` offsets: clamp negative values to 0 at codegen time
- For runtime offsets: emit `arith.maxsi(offset, 0)` to guarantee non-negative

**`tests/ut/codegen/test_pto_codegen_ops.py`** — Regression test asserting `arith.maxsi` is emitted for a dynamic store offset.

The clamp applies to all `pto.partition_view` offset paths (load, store, remote_store, notify, wait, put) since `GetIndexOffsetCodes` is the single funnel.

## Test plan

- [x] Original MFE (negative offset, no conditional): `slot0 = 8.0` (was garbage)
- [x] Original MFE (negative + conditional adjust): `slot0 = 8.0` (was silently dropped)
- [x] New regression test: `test_store_dynamic_offset_clamped_to_non_negative`
- [x] Full UT suite: 7573 passed (1 pre-existing unrelated failure in `test_benchmark_l3_ignores_prepare_setup_groups`)
- [x] Full codegen suite: 650 passed
- [x] Tile ops suite: 157 passed
- [x] Pre-commit: all 14 hooks pass (ruff, clang-format, cpplint, pyright, etc.)