### PR TITLE
fix(runtime): split L3 swimlane graph and timing passes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -643,7 +643,10 @@ jobs:
           unset-ring: 'true'
 
       - name: Test distributed system tests
-        timeout-minutes: 15
+        # The step clock includes both task-submit queueing and the device run.
+        # Keep enough headroom for a typical ~10-minute suite after waiting for
+        # a two-card slot; --max-time below still caps device execution at 15m.
+        timeout-minutes: 30
         # Mechanism B (multi-card): borrow 2 NPUs via `task-submit --device auto
         # --device-num 2` for the whole pytest run; $TASK_DEVICE is the lent set
         # (comma-separated), passed to --device. The job no longer pins an

--- a/docs/en/dev/03-runtime-dfx.md
+++ b/docs/en/dev/03-runtime-dfx.md
@@ -65,7 +65,7 @@ program's tasks with another's names, silently and plausibly. A dispatch
 whose program cannot be resolved is converted with anonymous labels
 instead of guessed ones.
 
-## L2 swimlane runs the kernel twice (onboard)
+## Swimlane runs the workload twice (onboard)
 
 The swimlane converter joins per-task timing against a task graph that **only
 `deps.json` carries** — the device hot path no longer records per-task fanout,
@@ -74,8 +74,8 @@ dependency arrows. But dep_gen collection has high overhead that perturbs the
 very timing the swimlane measures. The two captures therefore come from separate
 runs (Simpler's documented "capture the graph once, time many times" workflow).
 
-So enabling `enable_l2_swimlane` on an **onboard** platform runs the kernel
-twice, transparently:
+For **onboard L2**, enabling `enable_l2_swimlane` runs the kernel twice,
+transparently:
 
 1. **Graph pass** — dep_gen only, producing `deps.json`. Runs in a **separate
    subprocess** (`python -m pypto.runtime._dep_gen_capture`). This is required,
@@ -96,7 +96,16 @@ explicitly changes nothing about the passes (the graph pass already produced
 hint. Simulator platforms (`*sim`) stay single-pass — swimlane conversion is
 skipped there regardless.
 
-The subprocess rebuilds the orchestration arguments two ways: from `golden.py`
+Distributed L3 uses the same graph/timing split without the L2 capture
+subprocess. The one-shot path creates a fresh Worker lifecycle for each pass.
+A prepared `DistributedWorker` keeps its resident handles and forked hierarchy,
+but enters two separate `Worker.run()` fences: dep-gen-only first, then
+swimlane with dep_gen forced off. Per-card dispatch counters restart for both
+passes, so graph and timing artefacts join in the same `rank{r}/d{k}` directory.
+Both passes execute the program; mutable arguments are not restored between
+them, matching the existing one-shot L3 replay semantics.
+
+The L2 subprocess rebuilds the orchestration arguments two ways: from `golden.py`
 when driven by the pytest harness (deterministic inputs → faithful graph), or
 from a recorded spec when driven by the compiled-program API
 (`execute_compiled`). The task graph can be routed by tensor *values*, not just
@@ -468,10 +477,11 @@ by walking `next_levels/`; `platform` and `distributed_config` default to the
 values recorded at compile time and can be overridden to replay on a different
 target / device set.
 
-**Limitation:** DFX flags (`--pmu`, `--swimlane`, `--dump-args`, …) are **not
-yet plumbed through the L3 dispatch path** — they apply to single-chip replay
-only. The L3 edit-and-rerun loop itself (correctness re-check after a `.pto`/cpp
-edit) is fully supported.
+L3 replay forwards runtime DFX fields from `RunConfig` through each chip
+dispatch. Artifacts are written under
+`dfx_outputs/rank{r}/d{k}/`; onboard swimlane uses the graph/timing two-pass
+protocol described above. The edit-and-rerun loop therefore supports both
+correctness re-checks and L3 runtime diagnostics.
 
 ## Related
 

--- a/docs/en/dev/05-runtime-ring-sizing.md
+++ b/docs/en/dev/05-runtime-ring-sizing.md
@@ -95,9 +95,10 @@ with compiled.prepare(prefill_cfg) as rt:              # setup once + prewarm
 compiled(a, b, c, config=RunConfig(platform="a2a3", ring_heap=8 * 1024 * 1024))
 ```
 
-On the L3 dispatch path only the `ring_*` fields of `RunConfig` are consumed;
-the compile-side and DFX fields are ignored (they are set at compile / prepare
-time, not per dispatch).
+The L3 dispatch path consumes both the `ring_*` fields and runtime DFX fields
+from `RunConfig`. DFX artifacts are namespaced under
+`<output_dir>/dfx_outputs/rank{r}/d{k}/`; see
+[Runtime DFX](03-runtime-dfx.md). Other compile-side fields are ignored.
 
 Set only the fields you want to override; the rest stay unset and fall back per
 the precedence above.

--- a/docs/zh/dev/03-runtime-dfx.md
+++ b/docs/zh/dev/03-runtime-dfx.md
@@ -58,7 +58,7 @@ comm-less 的（没有 `device=`）则按被分配到的芯片——这类 dispa
 program 的名字，既静默又看似合理。若某次 dispatch 的 program 无法解析，
 转换时使用匿名标签，而不是猜一个名字。
 
-## L2 泳道会把 kernel 跑两遍（onboard）
+## 泳道会把 workload 跑两遍（onboard）
 
 泳道转换器需要把每个 task 的耗时和一张**只有 `deps.json` 才携带的任务图**做
 join——device 热路径不再记录 per-task fanout，因此没有 dep_gen 抓取时，泳道会退化
@@ -66,7 +66,7 @@ join——device 热路径不再记录 per-task fanout，因此没有 dep_gen �
 耗时。所以这两份抓取来自两次独立运行（这正是 Simpler 文档描述的“抓一次图、计多次
 时”工作流）。
 
-于是在 **onboard** 平台上开启 `enable_l2_swimlane` 会透明地把 kernel 跑两遍：
+于是在 **onboard L2** 平台上开启 `enable_l2_swimlane` 会透明地把 kernel 跑两遍：
 
 1. **抓图趟** —— 仅开 dep_gen，产出 `deps.json`，在**独立子进程**里运行
    （`python -m pypto.runtime._dep_gen_capture`）。这是必须的、不只是为了整洁：
@@ -83,7 +83,14 @@ join——device 热路径不再记录 per-task fanout，因此没有 dep_gen �
 产出了 `deps.json`），只是让本次运行额外打印 `deps_viewer` 的渲染提示。仿真平台
 （`*sim`）保持单趟——那里本来就会跳过泳道转换。
 
-子进程用两种方式重建编排实参：被 pytest harness 驱动时从 `golden.py` 重新生成
+分布式 L3 使用相同的抓图/计时拆分，但不经过 L2 抓图子进程。one-shot
+路径为每趟创建新的 Worker 生命周期；prepared `DistributedWorker` 保留
+resident handle 和已 fork 的层级，但进入两个独立的 `Worker.run()` fence：
+先仅开 dep-gen，再开泳道并强制关闭 dep-gen。两趟都会重置每张卡的 dispatch
+计数，因此图和计时产物会合并到相同的 `rank{r}/d{k}` 目录。两趟都会实际
+执行程序，且不会在中间恢复可写参数，这与现有 one-shot L3 replay 语义一致。
+
+L2 子进程用两种方式重建编排实参：被 pytest harness 驱动时从 `golden.py` 重新生成
 （确定性输入 → 图忠实），被编译产物 API（`execute_compiled`）驱动时从记录下来的
 规格重建。任务图可能由张量**值**（而不只是 scalar）路由，例如 paged-attention 的
 `block_tables` / `seq_lens`，所以规格会尽量保留真实数据：host `torch.Tensor`
@@ -427,9 +434,9 @@ prog(a, b, c)
 重建 chip callables；`platform` 与 `distributed_config` 默认取编译时
 记录的值，可覆盖以在不同目标 / 设备集上重放。
 
-**限制**：DFX 标志（`--pmu`、`--swimlane`、`--dump-args` 等）**尚未
-透传到 L3 派发路径**——目前仅对单芯片重放生效。L3 的「改完再跑」循环
-本身（改 `.pto`/cpp 后的正确性复检）是完整支持的。
+L3 replay 会把 `RunConfig` 中的运行时 DFX 字段透传到每个芯片派发，产物写入
+`dfx_outputs/rank{r}/d{k}/`；onboard 泳道使用上文的抓图/计时两趟协议。
+因此「改完再跑」既支持正确性复检，也支持 L3 运行时诊断。
 
 ## 相关文档
 

--- a/docs/zh/dev/05-runtime-ring-sizing.md
+++ b/docs/zh/dev/05-runtime-ring-sizing.md
@@ -90,8 +90,9 @@ with compiled.prepare(prefill_cfg) as rt:              # 一次性 setup + 预�
 compiled(a, b, c, config=RunConfig(platform="a2a3", ring_heap=8 * 1024 * 1024))
 ```
 
-在 L3 派发路径上，仅消费 `RunConfig` 的 `ring_*` 字段；编译期字段与 DFX 字段会被
-忽略（它们在编译 / prepare 时设置，而非按派发设置）。
+L3 派发路径会消费 `RunConfig` 的 `ring_*` 字段和运行时 DFX 字段。DFX 产物按
+`<output_dir>/dfx_outputs/rank{r}/d{k}/` 隔离；详见
+[Runtime DFX](03-runtime-dfx.md)。其他编译期字段会被忽略。
 
 只设置你想覆盖的字段即可；其余字段保持未设置，并按上述优先级回退。
 

--- a/python/pypto/ir/distributed_compiled_program.py
+++ b/python/pypto/ir/distributed_compiled_program.py
@@ -308,8 +308,10 @@ class DistributedCompiledProgram:
         ``enable_dep_gen`` / ``enable_scope_stats`` / ``enable_l2_swimlane``) are
         written per dispatch under ``<output_dir>/dfx_outputs/rank{r}/d{k}/``
         (``d{k}`` is the card's k-th dispatch, so multiple dispatches to one card
-        keep separate artifacts; swimlane co-enables dep_gen and emits
-        ``merged_swimlane_*.json`` per dispatch, onboard only). Other compile-side
+        keep separate artifacts). Onboard swimlane runs a dep-gen-only graph
+        pass followed by a dep-gen-disabled timing pass and emits
+        ``merged_swimlane_*.json`` per dispatch. Both passes execute the program
+        and do not restore mutable arguments between them. Other compile-side
         fields are not consumed on the dispatch path.
         """
         from pypto.runtime.distributed_runner import execute_distributed  # noqa: PLC0415

--- a/python/pypto/runtime/bench.py
+++ b/python/pypto/runtime/bench.py
@@ -63,6 +63,17 @@ __all__ = ["BenchmarkStats", "TraceInvocation", "TraceSpan", "benchmark"]
 # ``Invocation`` types are mirrored into the pypto-owned ``TraceSpan`` /
 # ``TraceInvocation`` below so ``benchmark`` callers get the full per-launch
 # span tree without importing simpler types (see ``_parse_stats_from_strace``).
+#
+# Prepared onboard L3 swimlane executes each caller-visible launch twice. The
+# parent brackets the clean pass with these sentinels so the parser can discard
+# the dep-gen graph pass instead of reporting contaminated benchmark numbers.
+# Keep the values stable: pypto-lib's resident benchmark calls the same private
+# parser.
+_L3_SWIMLANE_PASS_PREFIX = "[pypto] l3_swimlane_pass="
+_L3_SWIMLANE_GRAPH_BEGIN = f"{_L3_SWIMLANE_PASS_PREFIX}graph event=begin"
+_L3_SWIMLANE_GRAPH_END = f"{_L3_SWIMLANE_PASS_PREFIX}graph event=end"
+_L3_SWIMLANE_TIMING_BEGIN = f"{_L3_SWIMLANE_PASS_PREFIX}timing event=begin"
+_L3_SWIMLANE_TIMING_END = f"{_L3_SWIMLANE_PASS_PREFIX}timing event=end"
 
 
 @dataclass
@@ -776,6 +787,37 @@ def _parse_l3_stats(invocations: Any, stats: BenchmarkStats, *, rounds: int, war
     return stats
 
 
+def _extract_l3_swimlane_timing(log_text: str) -> tuple[str, int | None]:
+    """Return only complete clean-pass regions from a two-pass L3 capture.
+
+    The sentinels are emitted by the parent around the blocking timing
+    ``Worker.run()`` call, so all child-process STRACE records between them
+    belong to the dep-gen-disabled pass. Substring splitting is deliberate:
+    concurrent processes can concatenate otherwise complete records onto one
+    physical line.
+
+    Returns ``(log_text, None)`` when no two-pass sentinel is present, otherwise
+    returns the filtered text and number of complete timing regions. Malformed
+    or incomplete sentinels return ``("", -1)`` so callers report no sample
+    instead of silently including graph-pass timing.
+    """
+    parts = log_text.split(_L3_SWIMLANE_TIMING_BEGIN)
+    if len(parts) == 1:
+        if _L3_SWIMLANE_PASS_PREFIX in log_text:
+            return "", -1
+        return log_text, None
+    if _L3_SWIMLANE_TIMING_END in parts[0]:
+        return "", -1
+
+    timing_regions: list[str] = []
+    for part in parts[1:]:
+        timing, end, outside = part.partition(_L3_SWIMLANE_TIMING_END)
+        if not end or _L3_SWIMLANE_TIMING_END in outside:
+            return "", -1
+        timing_regions.append(timing)
+    return "\n".join(timing_regions), len(timing_regions)
+
+
 def _parse_stats_from_strace(
     log_text: str, *, rounds: int, warmup: int, distributed: bool = False
 ) -> BenchmarkStats:
@@ -793,8 +835,10 @@ def _parse_stats_from_strace(
     (``<root>.runner_run.device_wall``) span durations (µs). The ``<root>`` span
     name is resolved per :func:`_span_names` (``run_prepared`` / ``simpler_run``).
 
-    L3 (``distributed=True``): delegates to :func:`_parse_l3_stats`, which folds
-    the per-rank chip-child markers into per-round aggregates (see that function).
+    L3 (``distributed=True``): prepared swimlane pass sentinels first restrict
+    the input to complete dep-gen-disabled timing regions, when present; then
+    :func:`_parse_l3_stats` folds the per-rank chip-child markers into per-round
+    aggregates (see that function).
     """
     # ``simpler`` is an optional runtime-provided package: present on devices
     # where the runtime is installed, absent on the lint / unit-test host. The
@@ -806,8 +850,15 @@ def _parse_stats_from_strace(
         parse_spans,
     )
 
+    timing_blocks: int | None = None
+    if distributed:
+        log_text, timing_blocks = _extract_l3_swimlane_timing(log_text)
+
     names = _span_names()
     stats = BenchmarkStats(rounds=rounds, warmup=warmup)
+    if timing_blocks is not None and timing_blocks != warmup + rounds:
+        stats.fallback_flattened = True
+        return stats
     # L3 forks one chip worker per rank, all sharing the capture fd; their
     # concurrent writes can interleave two complete ``[STRACE]`` records onto one
     # physical line. simpler's ``parse_spans`` reads at most one record per line

--- a/python/pypto/runtime/debug/replay.py
+++ b/python/pypto/runtime/debug/replay.py
@@ -214,8 +214,8 @@ def replay(
     print("[execute] running on device...")
     if is_l3:
         # L3: reconstruct the distributed program from the build dir and dispatch
-        # via simpler Worker(level=3). DFX flags on ``config`` are not yet plumbed
-        # through the distributed dispatch path (tracked separately).
+        # via simpler Worker(level=3); per-dispatch ring and DFX settings are
+        # forwarded through its CallConfig.
         from pypto.runtime.distributed_runner import (  # noqa: PLC0415
             execute_distributed_compiled,
         )

--- a/python/pypto/runtime/distributed_runner.py
+++ b/python/pypto/runtime/distributed_runner.py
@@ -447,9 +447,11 @@ def _make_call_config(
     / ``enable_scope_stats`` / ``enable_l2_swimlane``) are likewise read from
     *run_config* and written to the shared ``config`` the host_orch chip dispatch
     forwards to every ``orch.submit_next_level``; their artifacts land under
-    *dfx_base* (``<output_dir>/dfx_outputs``). ``enable_l2_swimlane`` co-enables
-    dep_gen so the converter can resolve task arrows / kernel names (see the
-    inline note on the single-pass timing trade-off vs the L2 two-pass).
+    *dfx_base* (``<output_dir>/dfx_outputs``). By default,
+    ``enable_l2_swimlane`` co-enables dep_gen so a single dispatch still has the
+    task graph needed by the converter. Onboard L3 callers use a two-pass
+    graph/timing protocol and set *co_enable_swimlane_dep_gen* false while
+    building the clean timing pass.
 
     Args:
         dc: The program's distributed configuration (baseline).
@@ -458,6 +460,9 @@ def _make_call_config(
         dfx_base: Directory under which DFX artifacts are written
             (``<output_dir>/dfx_outputs``). Required whenever *run_config*
             enables a DFX flag; created if missing.
+        co_enable_swimlane_dep_gen: Whether swimlane implicitly enables
+            dep_gen. The onboard graph pass and simulator single-pass use the
+            default; the onboard clean timing pass disables it.
 
     Returns:
         A fresh simpler ``CallConfig``.
@@ -484,12 +489,11 @@ def _make_call_config(
             call_config.enable_dump_args = dfx.enable_dump_args
             call_config.enable_pmu = dfx.enable_pmu
             # Swimlane needs ``deps.json`` so the converter can resolve task
-            # arrows / kernel names. The one-shot path runs a clean two-pass
-            # (pass 1 dep_gen → deps.json, pass 2 swimlane → clean records) and
-            # sets ``co_enable_swimlane_dep_gen=False`` on the timing pass so
-            # dep_gen does not perturb it. Everywhere else (the timing-pass-less
-            # single-pass: prepared worker, or sim where conversion is skipped)
-            # co-enable dep_gen so swimlane still has a graph in one dispatch.
+            # arrows / kernel names. Onboard one-shot and prepared paths run a
+            # clean two-pass (pass 1 dep_gen → deps.json, pass 2 swimlane → clean
+            # records) and set ``co_enable_swimlane_dep_gen=False`` on the timing
+            # pass so dep_gen does not perturb it. Simulator and direct
+            # single-pass builders keep the default co-enable behavior.
             # ``enable_l2_swimlane`` is an int (0/1/2), so the ``or``/``and`` chain
             # can yield an int; the ``CallConfig.enable_dep_gen`` pybind setter
             # only accepts ``bool``. Wrap in ``bool(...)`` to avoid a TypeError.
@@ -504,6 +508,60 @@ def _make_call_config(
             # overwrite each other — even when one card runs multiple dispatches.
             call_config.output_prefix = str(dfx_base)
     return call_config
+
+
+def _run_l3_swimlane_two_pass(
+    dc: DistributedConfig,
+    config: RunConfig,
+    dfx_base: Path,
+    run_pass: Callable[[Any], None],
+) -> None:
+    """Capture the L3 task graph, then run a dep-gen-free timing pass.
+
+    ``run_pass`` owns the execution lifecycle: the one-shot path creates a
+    fresh Worker for each call, while a prepared ``DistributedWorker`` reuses
+    its existing Worker and issues a new ``Worker.run()`` fence. Both paths
+    reset their per-card dispatch counters, so matching graph/timing dispatches
+    land in the same ``rank{r}/d{k}`` directory.
+
+    Both calls execute the program. As with the existing one-shot L3 protocol,
+    mutable arguments are not snapshotted or restored between passes.
+    """
+    import dataclasses  # noqa: PLC0415
+
+    from .bench import (  # noqa: PLC0415
+        _L3_SWIMLANE_GRAPH_BEGIN,
+        _L3_SWIMLANE_GRAPH_END,
+        _L3_SWIMLANE_TIMING_BEGIN,
+        _L3_SWIMLANE_TIMING_END,
+    )
+
+    print(
+        "[swimlane] L3 swimlane enabled -> running the dispatch twice "
+        "(dep_gen perturbs timing, so the graph and the timing are captured separately):"
+    )
+    print("[swimlane] run 1/2: capturing the per-dispatch task graph (deps.json); its timing is discarded.")
+    deps_cfg = dataclasses.replace(
+        config,
+        enable_l2_swimlane=False,
+        enable_dep_gen=True,
+        enable_pmu=0,
+        enable_scope_stats=False,
+        enable_dump_args=0,
+    )
+    print(_L3_SWIMLANE_GRAPH_BEGIN, file=sys.stderr, flush=True)
+    run_pass(_make_call_config(dc, deps_cfg, dfx_base=dfx_base))
+    print(_L3_SWIMLANE_GRAPH_END, file=sys.stderr, flush=True)
+
+    print("[swimlane] run 2/2: measuring clean per-task timing (these are the reported numbers).")
+    # ``benchmark`` and pypto-lib's resident benchmark capture fd 2 around the
+    # prepared worker. Bracketing the blocking timing run lets their shared
+    # parser retain its child-process STRACE records while discarding graph-pass
+    # records, even when each pass has a data-dependent dispatch count.
+    print(_L3_SWIMLANE_TIMING_BEGIN, file=sys.stderr, flush=True)
+    timing_cfg = dataclasses.replace(config, enable_dep_gen=False)
+    run_pass(_make_call_config(dc, timing_cfg, dfx_base=dfx_base, co_enable_swimlane_dep_gen=False))
+    print(_L3_SWIMLANE_TIMING_END, file=sys.stderr, flush=True)
 
 
 # A dispatch's DFX artifacts live at ``<dfx_base>/<rank label>/d{k}``. The
@@ -743,10 +801,11 @@ def _write_dispatch_name_map(disp_dir: Path, chip_dir: Path, cache: dict[str, di
 def _collect_l3_swimlane(output_dir: Path, platform: str) -> None:
     """Convert each dispatch's swimlane records into a ``merged_swimlane_*.json``.
 
-    The runtime writes ``rank{r}/d{k}/l2_swimlane_records.json`` +
-    ``rank{r}/d{k}/deps.json`` per dispatch (``_submit_chip`` namespaced the dir
-    by card *and* the card's k-th dispatch; dep_gen is co-enabled with
-    swimlane). Globbing ``rank*`` — rather than iterating a rank count — picks up
+    The runtime writes ``rank{r}/d{k}/deps.json`` in the graph pass and
+    ``rank{r}/d{k}/l2_swimlane_records.json`` in the clean timing pass
+    (``_submit_chip`` namespaces the directory by card *and* the card's k-th
+    dispatch, and both passes reset that counter). Globbing ``rank*`` — rather
+    than iterating a rank count — picks up
     whichever cards actually ran, so a comm-less / single-card L3 program (which never
     creates ``rank{0..n}``) still has its records converted. This best-effort
     post-pass runs the offline ``swimlane_converter`` once per dispatch dir. Each
@@ -1033,28 +1092,7 @@ def execute_distributed(
         # Two-pass for clean timing, mirroring the L2 swimlane workflow: dep_gen
         # collection perturbs timing, so the per-dispatch task graph and the kept
         # timing come from separate dispatches.
-        import dataclasses  # noqa: PLC0415
-
-        print(
-            "[swimlane] L3 swimlane enabled -> running the dispatch twice "
-            "(dep_gen perturbs timing, so the graph and the timing are captured separately):"
-        )
-        print(
-            "[swimlane] run 1/2: capturing the per-dispatch task graph (deps.json); its timing is discarded."
-        )
-        deps_cfg = dataclasses.replace(
-            config,
-            enable_l2_swimlane=False,
-            enable_dep_gen=True,
-            enable_pmu=0,
-            enable_scope_stats=False,
-            enable_dump_args=0,
-        )
-        _run_once(_make_call_config(dc, deps_cfg, dfx_base=dfx_base))
-
-        print("[swimlane] run 2/2: measuring clean per-task timing (these are the reported numbers).")
-        timing_cfg = dataclasses.replace(config, enable_dep_gen=False)
-        _run_once(_make_call_config(dc, timing_cfg, dfx_base=dfx_base, co_enable_swimlane_dep_gen=False))
+        _run_l3_swimlane_two_pass(dc, config, dfx_base, _run_once)
     else:
         _run_once(_make_call_config(dc, config, dfx_base=dfx_base))
 
@@ -1854,7 +1892,7 @@ class DistributedWorker(Worker):
     # ------------------------------------------------------------------
 
     def __call__(self, *args: Any, config: RunConfig | None = None) -> None:
-        """Dispatch one run on the primary compiled program, reusing all setup.
+        """Dispatch the primary compiled program, reusing all setup.
 
         Pass one argument per program parameter (in-place). Each argument is
         either:
@@ -1879,7 +1917,12 @@ class DistributedWorker(Worker):
         ``ring_dep_pool``, each a scalar or a per-ring list of 4 ints) size this
         dispatch's runtime ring buffers without
         touching the prepared program's shared config, so consecutive dispatches
-        can use different ring sizes. ``None`` reuses the program's baseline.
+        can use different ring sizes. Its runtime DFX fields are also applied per
+        dispatch. On onboard L3, ``enable_l2_swimlane`` executes the workload
+        twice on the same prepared worker: first with dep-gen only, then with
+        swimlane and dep-gen disabled. Mutable host/resident arguments are not
+        restored between those profiling passes and can therefore be updated
+        twice. ``None`` reuses the program's baseline.
         """
         if self._multi_program:
             raise TypeError(
@@ -1894,11 +1937,13 @@ class DistributedWorker(Worker):
         """Dispatch *compiled* on the shared Worker via its per-program state.
 
         ``config`` is an optional per-dispatch :class:`RunConfig` whose per-task
-        ring-sizing overrides size this dispatch's runtime ring buffers. When
-        given, a fresh ``CallConfig`` is built for this dispatch only (from the
-        program's ``aicpu_thread_num`` baseline plus the ring
-        overrides), leaving the prepared, shared ``call_config`` untouched. When
-        ``None``, the prepared baseline is reused with zero extra allocation.
+        ring sizing and runtime DFX fields apply to this dispatch. When given, a
+        fresh ``CallConfig`` is built from the program's ``aicpu_thread_num``
+        baseline, leaving the prepared shared config untouched. ``None`` reuses
+        that baseline with zero extra allocation. Onboard L3 swimlane capture
+        runs a dep-gen graph pass followed by a dep-gen-disabled timing pass on
+        the same prepared Worker; mutable arguments are not restored between
+        the two executions.
         """
         self._require_open("run")
         from pypto.ir.compiled_program import (  # noqa: PLC0415
@@ -1917,9 +1962,13 @@ class DistributedWorker(Worker):
         # CallConfig for this call only (the prepared, shared one is never
         # mutated). With no RunConfig the prepared baseline is reused as-is.
         call_config = state["call_config"]
+        dfx_base: Path | None = None
+        two_pass_swimlane = False
         if config is not None:
             dfx_base = compiled.output_dir / "dfx_outputs"
-            call_config = _make_call_config(compiled._distributed_config, config, dfx_base=dfx_base)
+            two_pass_swimlane = bool(config.enable_l2_swimlane) and not compiled.platform.endswith("sim")
+            if not two_pass_swimlane:
+                call_config = _make_call_config(compiled._distributed_config, config, dfx_base=dfx_base)
             # This worker reuses one output_dir across dispatches, so stale
             # ``rank*/d{k}`` dirs from an earlier, larger run must be cleared
             # before this run rewrites ``d0, d1, ...`` (see _clear_dfx_dispatch_dirs).
@@ -1961,16 +2010,19 @@ class DistributedWorker(Worker):
                 )
             tensors[info.name] = arg
 
-        self._dispatch_prepared(state, tensors, call_config)
+        if two_pass_swimlane:
+            assert config is not None
+            assert dfx_base is not None
+            _run_l3_swimlane_two_pass(
+                compiled._distributed_config,
+                config,
+                dfx_base,
+                lambda pass_config: self._dispatch_prepared(state, tensors, pass_config),
+            )
+        else:
+            self._dispatch_prepared(state, tensors, call_config)
 
         # Offline post-pass (reads the per-dispatch records on disk; no worker needed).
-        # Note: unlike the one-shot ``execute_distributed`` path, the prepared
-        # worker reuses its forked chip children across dispatches, so it cannot
-        # re-fork between a deps pass and a timing pass without tripping the
-        # per-child ``halHostRegister`` cap (rc 8). It therefore runs swimlane
-        # single-pass (dep_gen co-enabled), so the on-disk records include
-        # dep_gen collection overhead. Use ``execute_distributed`` (one-shot) for
-        # clean two-pass swimlane timing.
         if config is not None and config.enable_l2_swimlane:
             _collect_l3_swimlane(compiled.output_dir, compiled.platform)
 
@@ -2035,11 +2087,12 @@ class DistributedWorker(Worker):
         ``ValueError``.
 
         ``config`` is an optional per-dispatch :class:`RunConfig`; its per-task
-        ring-sizing overrides size this dispatch's runtime ring buffers without
-        touching the prepared program's shared config. In a multi-program worker
-        each program can therefore be dispatched with its own ring sizes (e.g.
-        a larger ``ring_task_window`` for prefill than for decode). ``None``
-        reuses the program's baseline.
+        ring sizing and runtime DFX fields apply without touching the prepared
+        program's shared config. In a multi-program worker each program can
+        therefore use its own ring sizes and diagnostics. On onboard L3,
+        ``enable_l2_swimlane`` executes a dep-gen graph pass followed by a
+        dep-gen-disabled timing pass; mutable arguments are not restored between
+        them. ``None`` reuses the program's baseline.
         """
         return self._run_compiled(compiled, *args, config=config)
 

--- a/python/pypto/runtime/distributed_runner.py
+++ b/python/pypto/runtime/distributed_runner.py
@@ -1920,9 +1920,9 @@ class DistributedWorker(Worker):
         can use different ring sizes. Its runtime DFX fields are also applied per
         dispatch. On onboard L3, ``enable_l2_swimlane`` executes the workload
         twice on the same prepared worker: first with dep-gen only, then with
-        swimlane and dep-gen disabled. Mutable host/resident arguments are not
-        restored between those profiling passes and can therefore be updated
-        twice. ``None`` reuses the program's baseline.
+        swimlane enabled and dep-gen disabled. Mutable host/resident arguments
+        are not restored between those profiling passes and can therefore be
+        updated twice. ``None`` reuses the program's baseline.
         """
         if self._multi_program:
             raise TypeError(

--- a/python/pypto/runtime/runner.py
+++ b/python/pypto/runtime/runner.py
@@ -105,12 +105,15 @@ class RunConfig:
             platforms, ``swimlane_converter`` then produces
             ``merged_swimlane_*.json`` alongside it. Because the converter joins
             the timing against a task graph that only ``deps.json`` carries,
-            enabling this on an onboard platform runs the kernel **twice**: a
-            first dep_gen pass to capture ``deps.json`` (run in a subprocess so
-            its device/SVM state is fully reclaimed before the timing pass — a
-            failed capture is logged, not fatal), then a clean in-process
-            swimlane pass (dep_gen off, since dep_gen collection perturbs the
-            timing). Simulator platforms (``*sim``) stay single-pass
+            enabling this on an onboard platform runs the workload **twice**: a
+            first dep_gen pass captures ``deps.json``, then a clean swimlane pass
+            runs with dep_gen off because collection perturbs timing. L2 runs
+            the graph pass in a subprocess so its device/SVM state is fully
+            reclaimed before the timing pass (a failed capture is logged, not
+            fatal). L3 one-shot uses separate Worker lifecycles; a prepared L3
+            worker uses two ``Worker.run()`` fences and keeps resident handles
+            alive. Both L3 passes execute the program without restoring mutable
+            arguments between them. Simulator platforms (``*sim``) stay single-pass
             and only emit ``l2_swimlane_records.json`` — the merged swimlane file
             is intentionally skipped because the simulator does not yet ship the
             task metadata the converter needs. Mirrors runtime's

--- a/tests/ut/runtime/test_benchmark.py
+++ b/tests/ut/runtime/test_benchmark.py
@@ -27,7 +27,15 @@ from unittest.mock import MagicMock, patch
 import pytest
 from pypto.ir import distributed_compiled_program as dcp_mod
 from pypto.runtime import RunConfig
-from pypto.runtime.bench import BenchmarkStats, _parse_stats_from_strace, benchmark
+from pypto.runtime.bench import (
+    _L3_SWIMLANE_GRAPH_BEGIN,
+    _L3_SWIMLANE_GRAPH_END,
+    _L3_SWIMLANE_TIMING_BEGIN,
+    _L3_SWIMLANE_TIMING_END,
+    BenchmarkStats,
+    _parse_stats_from_strace,
+    benchmark,
+)
 
 
 @pytest.fixture
@@ -272,6 +280,60 @@ def test_parse_l3_two_ranks_per_round_max(span_root):
     # Per-round max across ranks: round0 = max(10,20)=20; round1 = max(30,5)=30.
     assert stats.device_wall_us == [20.0, 30.0]
     assert stats.host_wall_us == [200.0, 300.0]
+
+
+def test_parse_l3_two_pass_swimlane_keeps_clean_timing_half(span_root):
+    """Prepared swimlane benchmark excludes every dep-gen graph pass."""
+    lines: list[str] = []
+    timings = {100: [99.0, 10.0, 30.0], 101: [99.0, 20.0, 5.0]}
+    invs = {100: 0, 101: 0}
+    for launch in range(3):  # one warmup + two measured launches
+        lines.append(_L3_SWIMLANE_GRAPH_BEGIN)
+        for pid in timings:
+            # Deliberately give the graph pass two dispatches and timing one.
+            # Boundary sentinels, rather than an unsafe "keep the latter half"
+            # count heuristic, must decide what survives.
+            lines += _launch_lines(invs[pid], span_root, host_us=900, device_us=900, pid=pid)
+            invs[pid] += 1
+            lines += _launch_lines(invs[pid], span_root, host_us=901, device_us=901, pid=pid)
+            invs[pid] += 1
+        lines.append(_L3_SWIMLANE_GRAPH_END)
+        timing_lines: list[str] = []
+        for pid, timing_us in timings.items():
+            clean_us = timing_us[launch]
+            timing_lines += _launch_lines(
+                invs[pid],
+                span_root,
+                host_us=clean_us * 10,
+                device_us=clean_us,
+                pid=pid,
+            )
+            invs[pid] += 1
+        # Model shared-fd writes that concatenate a pass sentinel and STRACE
+        # record onto one physical line; substring boundary extraction must
+        # still retain every clean record.
+        lines.append(_L3_SWIMLANE_TIMING_BEGIN + timing_lines[0])
+        lines.extend(timing_lines[1:-1])
+        lines.append(timing_lines[-1] + _L3_SWIMLANE_TIMING_END)
+
+    stats = _parse_stats_from_strace("\n".join(lines), rounds=2, warmup=1, distributed=True)
+
+    assert stats.fallback_flattened is False
+    assert stats.per_rank("device") == {100: [10.0, 30.0], 101: [20.0, 5.0]}
+    assert stats.device_wall_us == [20.0, 30.0]
+    assert all(inv.device_wall_us < 900 for inv in stats.invocations)
+
+
+def test_parse_l3_incomplete_timing_region_returns_no_contaminated_samples(span_root):
+    """An incomplete capture must not silently mix graph and timing passes."""
+    lines = [_L3_SWIMLANE_TIMING_BEGIN]
+    lines += _launch_lines(0, span_root, host_us=900, device_us=900, pid=100)
+
+    stats = _parse_stats_from_strace("\n".join(lines), rounds=1, warmup=0, distributed=True)
+
+    assert stats.fallback_flattened is True
+    assert stats.device_wall_us == []
+    assert stats.host_wall_us == []
 
 
 def test_parse_l3_ignores_prepare_time_prewarm_groups(span_root):

--- a/tests/ut/runtime/test_distributed_worker.py
+++ b/tests/ut/runtime/test_distributed_worker.py
@@ -222,7 +222,6 @@ class TestPreparedSwimlaneTwoPass:
         run_config = RunConfig(
             platform="a2a3",
             enable_l2_swimlane=1,  # pyright: ignore[reportArgumentType]
-            enable_dep_gen=True,
             enable_pmu=3,
             enable_scope_stats=True,
             enable_dump_args=2,

--- a/tests/ut/runtime/test_distributed_worker.py
+++ b/tests/ut/runtime/test_distributed_worker.py
@@ -34,6 +34,12 @@ from pypto.ir.distributed_compiled_program import DistributedConfig
 from pypto.pypto_core import DataType
 from pypto.pypto_core.ir import ParamDirection
 from pypto.runtime import DeviceTensor
+from pypto.runtime.bench import (
+    _L3_SWIMLANE_GRAPH_BEGIN,
+    _L3_SWIMLANE_GRAPH_END,
+    _L3_SWIMLANE_TIMING_BEGIN,
+    _L3_SWIMLANE_TIMING_END,
+)
 from pypto.runtime.distributed_runner import (
     DistributedWorker,
     _assemble_chip_callables,
@@ -187,6 +193,160 @@ class TestPerTaskRingSizing:
         # rt.run(...) honors the same per-dispatch ring sizing as rt(...).
         assert m["make_call_config"].call_count == 2
         assert m["make_call_config"].call_args.args[1] is rc
+        rt.close()
+
+
+class TestPreparedSwimlaneTwoPass:
+    """Prepared onboard L3 captures deps, then measures without dep_gen."""
+
+    _CALL_CONFIG_ARG = 5
+
+    def test_onboard_reuses_worker_for_graph_then_clean_timing(self, patched_setup, tmp_path, capsys):
+        m = patched_setup
+        compiled = _fake_compiled([_param("a", [16, 16])], [])
+        compiled.platform = "a2a3"
+        compiled.output_dir = tmp_path
+        rt = DistributedWorker(compiled)
+
+        # Ignore the baseline config constructed during prepare(); this test
+        # observes the two configs built for the caller-visible dispatch.
+        m["make_call_config"].reset_mock()
+        deps_call_config = MagicMock(name="DepsCallConfig")
+        timing_call_config = MagicMock(name="TimingCallConfig")
+        m["make_call_config"].side_effect = [deps_call_config, timing_call_config]
+        events: list[str] = []
+        m["dispatch"].side_effect = lambda *args: events.append(
+            "deps" if args[self._CALL_CONFIG_ARG] is deps_call_config else "timing"
+        )
+
+        run_config = RunConfig(
+            platform="a2a3",
+            enable_l2_swimlane=1,  # pyright: ignore[reportArgumentType]
+            enable_dep_gen=True,
+            enable_pmu=3,
+            enable_scope_stats=True,
+            enable_dump_args=2,
+        )
+        with (
+            patch(
+                "pypto.runtime.distributed_runner._clear_dfx_dispatch_dirs",
+                side_effect=lambda _path: events.append("clear"),
+            ) as clear,
+            patch(
+                "pypto.runtime.distributed_runner._collect_l3_swimlane",
+                side_effect=lambda _output, _platform: events.append("collect"),
+            ) as collect,
+        ):
+            rt(DeviceTensor(0x1000, (16, 16), torch.float32), config=run_config)
+
+        assert events == ["clear", "deps", "timing", "collect"]
+        assert m["dispatch"].call_count == 2
+        assert all(call.args[0] is m["worker"] for call in m["dispatch"].call_args_list)
+        assert m["construct"].call_count == 1
+        assert m["worker"].init.call_count == 1
+        clear.assert_called_once_with(tmp_path / "dfx_outputs")
+        collect.assert_called_once_with(tmp_path, "a2a3")
+
+        assert m["make_call_config"].call_count == 2
+        deps_build, timing_build = m["make_call_config"].call_args_list
+        deps_config = deps_build.args[1]
+        assert deps_config.enable_l2_swimlane is False
+        assert deps_config.enable_dep_gen is True
+        assert deps_config.enable_pmu == 0
+        assert deps_config.enable_scope_stats is False
+        assert deps_config.enable_dump_args == 0
+
+        timing_config = timing_build.args[1]
+        assert timing_config.enable_l2_swimlane == 1
+        assert timing_config.enable_dep_gen is False
+        assert timing_config.enable_pmu == 3
+        assert timing_config.enable_scope_stats is True
+        assert timing_config.enable_dump_args == 2
+        assert timing_build.kwargs["co_enable_swimlane_dep_gen"] is False
+        captured = capsys.readouterr()
+        assert [line for line in captured.err.splitlines() if "l3_swimlane_pass=" in line] == [
+            _L3_SWIMLANE_GRAPH_BEGIN,
+            _L3_SWIMLANE_GRAPH_END,
+            _L3_SWIMLANE_TIMING_BEGIN,
+            _L3_SWIMLANE_TIMING_END,
+        ]
+        rt.close()
+
+    def test_simulator_keeps_single_pass(self, patched_setup, tmp_path):
+        m = patched_setup
+        compiled = _fake_compiled([_param("a", [16, 16])], [])
+        compiled.output_dir = tmp_path
+        rt = DistributedWorker(compiled)
+
+        m["make_call_config"].reset_mock()
+        call_config = MagicMock(name="SimCallConfig")
+        m["make_call_config"].return_value = call_config
+        run_config = RunConfig(
+            platform="a2a3sim",
+            enable_l2_swimlane=1,  # pyright: ignore[reportArgumentType]
+        )
+        with patch("pypto.runtime.distributed_runner._collect_l3_swimlane") as collect:
+            rt(DeviceTensor(0x1000, (16, 16), torch.float32), config=run_config)
+
+        m["dispatch"].assert_called_once()
+        assert m["dispatch"].call_args.args[self._CALL_CONFIG_ARG] is call_config
+        m["make_call_config"].assert_called_once_with(
+            compiled._distributed_config,
+            run_config,
+            dfx_base=tmp_path / "dfx_outputs",
+        )
+        collect.assert_called_once_with(tmp_path, "a2a3sim")
+        rt.close()
+
+    def test_dep_gen_without_swimlane_keeps_single_pass(self, patched_setup, tmp_path):
+        m = patched_setup
+        compiled = _fake_compiled([_param("a", [16, 16])], [])
+        compiled.platform = "a2a3"
+        compiled.output_dir = tmp_path
+        rt = DistributedWorker(compiled)
+
+        m["make_call_config"].reset_mock()
+        run_config = RunConfig(platform="a2a3", enable_dep_gen=True)
+        with patch("pypto.runtime.distributed_runner._collect_l3_swimlane") as collect:
+            rt(DeviceTensor(0x1000, (16, 16), torch.float32), config=run_config)
+
+        m["dispatch"].assert_called_once()
+        m["make_call_config"].assert_called_once_with(
+            compiled._distributed_config,
+            run_config,
+            dfx_base=tmp_path / "dfx_outputs",
+        )
+        collect.assert_not_called()
+        rt.close()
+
+    def test_persistent_route_waits_for_graph_then_timing_requests(self, patched_setup, tmp_path):
+        m = patched_setup
+        compiled = _fake_compiled([_param("a", [16, 16])], [])
+        compiled.platform = "a2a3"
+        compiled.output_dir = tmp_path
+        rt = DistributedWorker(compiled)
+
+        # Exercise _dispatch_prepared's persistent branch without starting a
+        # background thread: each call into _dispatch_persistent is the
+        # synchronous request/fence used by the real dispatcher.
+        rt._persistent = True
+        m["make_call_config"].reset_mock()
+        deps_call_config = MagicMock(name="DepsCallConfig")
+        timing_call_config = MagicMock(name="TimingCallConfig")
+        m["make_call_config"].side_effect = [deps_call_config, timing_call_config]
+        with (
+            patch.object(rt, "_dispatch_persistent") as dispatch_persistent,
+            patch("pypto.runtime.distributed_runner._collect_l3_swimlane"),
+        ):
+            rt(
+                DeviceTensor(0x1000, (16, 16), torch.float32),
+                config=RunConfig(platform="a2a3", enable_l2_swimlane=True),
+            )
+
+        assert [call.args[2] for call in dispatch_persistent.call_args_list] == [
+            deps_call_config,
+            timing_call_config,
+        ]
         rt.close()
 
 
@@ -1738,6 +1898,29 @@ class TestMakeCallConfigDepGenType:
         run_config = RunConfig(enable_dump_args=1, enable_l2_swimlane=0)  # pyright: ignore[reportArgumentType]
         cfg = _make_call_config(DistributedConfig(), run_config, dfx_base=tmp_path / "dfx")
         assert cfg.enable_dep_gen is False
+
+    def test_clean_timing_suppresses_implicit_dep_gen(self, tmp_path, fake_simpler_task_interface):
+        run_config = RunConfig(enable_l2_swimlane=1)  # pyright: ignore[reportArgumentType]
+        cfg = _make_call_config(
+            DistributedConfig(),
+            run_config,
+            dfx_base=tmp_path / "dfx",
+            co_enable_swimlane_dep_gen=False,
+        )
+        assert cfg.enable_dep_gen is False
+
+    def test_explicit_dep_gen_still_wins_when_co_enable_is_off(self, tmp_path, fake_simpler_task_interface):
+        run_config = RunConfig(
+            enable_l2_swimlane=1,  # pyright: ignore[reportArgumentType]
+            enable_dep_gen=True,
+        )
+        cfg = _make_call_config(
+            DistributedConfig(),
+            run_config,
+            dfx_base=tmp_path / "dfx",
+            co_enable_swimlane_dep_gen=False,
+        )
+        assert cfg.enable_dep_gen is True
 
 
 class _PersistentDomainHandle:


### PR DESCRIPTION
## Summary
- Run onboard L3 swimlane capture in two passes for both one-shot and prepared/resident workers: a dep-gen graph pass without swimlane timing, followed by a clean L2 timing pass with dep-gen forced off.
- Reuse the resident worker across both passes and reset per-card dispatch numbering so each rank's first-pass `deps.json` and second-pass `l2_swimlane_records.json` merge into the same dispatch artifact.
- Add graph/timing pass markers and exclude graph-pass traces from distributed benchmark statistics, preventing dep-gen work from contaminating clean timing.
- Update the English and Chinese runtime DFX documentation.

## Testing
- `python -m pytest tests/ut/runtime/test_benchmark.py -q -k 'two_pass_swimlane or incomplete_timing or parse_l3_two_ranks_per_round_max or multi_dispatch_sums'` — 4 passed, 35 deselected.
- `python -m pytest tests/ut/runtime/test_distributed_worker.py -q -k 'two_pass or persistent_route or simulator_keeps_single_pass or dep_gen_without_swimlane'` — 3 passed, 126 deselected.
- `git diff --check` — passed.
- A2A3 hardware task `task_20260729_235326_89866513554` (`device=0,2,4,6`, `ep=4`, `tp=4`) — exit 0; `deps.json`, L2 swimlane records, and merged swimlanes were generated for rank0..3 in d0 and d1 (8/8 each).
- The hardware integration used the Simpler dep-gen fix from #1594 as a separate checkout; this PyPTO PR does not update the `runtime` submodule.
- In that clean timing pass, the four d1 host-runner start offsets were `0.475`, `2.995`, `0.000`, and `2.406 ms`; max-minus-min dispatch skew was `2.995 ms`.

## Related Issues
- Cross-repository Simpler fix: [hw-native-sys/simpler#1594](https://github.com/hw-native-sys/simpler/pull/1594).
- The `runtime` submodule intentionally remains identical to PyPTO `main`; Simpler evolves independently in its own repository.
