### PR TITLE
test(ir): Narrow blanket pass-verification bypasses in transform tests

### DIFF
--- a/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
+++ b/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
@@ -4914,8 +4914,7 @@ class TestConvertCrossCoreSplitOps:
             attrs={"split": ir.SplitMode.UP_DOWN},
         )
         auto_program = ir.Program([auto_func], "auto", span)
-        with passes.PassContext([]):
-            auto_lowered = passes.lower_auto_vector_split()(auto_program)
+        auto_lowered = passes.lower_auto_vector_split()(auto_program)
         auto_call = _find_first_call_to(
             _require_function(auto_lowered, "split_auto"), ir.get_op("tile.aiv_shard").name
         )
@@ -4996,7 +4995,17 @@ class TestConvertCrossCoreSplitOps:
             attrs={"split": ir.SplitMode.UP_DOWN},
         )
         auto_program = ir.Program([auto_func], "auto", span)
-        with passes.PassContext([]):
+        # Property verification stays ON; only the print->parse roundtrip is dropped.
+        # LowerAutoVectorSplit halves the `tile.add` RESULT to the per-lane [128, 128]
+        # but leaves its operand `vec` at the full [256, 128] param width, so the pass
+        # output is not re-parsable ("annotation for 'vec_h' has shape dimension
+        # 0 = 128 but expression has shape dimension 0 = 256"). That is the same V->C
+        # boundary defect family documented in test_lower_auto_vector_split.py; this
+        # test only compares the resulting `tile.aic_gather` TYPE against the explicit
+        # path, which is unaffected. Tracked by hw-native-sys/pypto#2203 — re-enable
+        # the roundtrip once the pass shards or rejects a full-width source instead
+        # of silently halving only the result.
+        with passes.PassContext([passes.VerificationInstrument(passes.VerificationMode.BEFORE_AND_AFTER)]):
             auto_lowered = passes.lower_auto_vector_split()(auto_program)
         auto_call = _find_first_call_to(
             _require_function(auto_lowered, "split_auto"), ir.get_op("tile.aic_gather").name

--- a/tests/ut/ir/transforms/test_expand_mixed_kernel_split_aiv.py
+++ b/tests/ut/ir/transforms/test_expand_mixed_kernel_split_aiv.py
@@ -38,9 +38,14 @@ def _tile(shape, view=None, mem=None):
 
 
 def _expand(program):
-    """Run ExpandMixedKernel with verification/roundtrip disabled."""
-    with passes.PassContext([]):
-        return passes.expand_mixed_kernel()(program)
+    """Run ExpandMixedKernel under the ambient ``conftest`` verification context.
+
+    The hand-built post-InferTileMemorySpace programs below satisfy both
+    BEFORE_AND_AFTER property verification and the print->parse roundtrip, so
+    there is nothing to suppress — the instruments back up the structural
+    comparison each test already makes.
+    """
+    return passes.expand_mixed_kernel()(program)
 
 
 def _assert_no_free_var(program):

--- a/tests/ut/ir/transforms/test_infer_tile_memory_space.py
+++ b/tests/ut/ir/transforms/test_infer_tile_memory_space.py
@@ -24,6 +24,27 @@ from pypto import backend, ir, passes
 from pypto.backend import BackendType
 
 
+def _verify_no_roundtrip() -> passes.PassContext:
+    """Ambient property verification, minus the print->parse roundtrip instrument.
+
+    A few tests below stamp compiler-internal attrs (``dump_vars``, residency
+    sentinels) onto calls to observe how the pass propagates them. Those attrs
+    have no DSL print/parse surface, so the roundtrip instrument installed by
+    ``tests/ut/conftest.py`` drops them and reports a spurious ``Kwargs size
+    mismatch``. BEFORE_AND_AFTER property verification is deliberately KEPT — only
+    the roundtrip is suppressed, and only for the single pass call that needs it.
+
+    Tracked by hw-native-sys/pypto#2204: builtin-op call attrs go through a 2-key
+    allowlist on print (and an int/float/bool/str-only reader on parse), while
+    GlobalVar/Submit attrs use a fail-loud denylist. Once those converge, this
+    helper and all four of its call sites can go away.
+
+    Returns:
+        A ``PassContext`` carrying only the BEFORE_AND_AFTER verification instrument.
+    """
+    return passes.PassContext([passes.VerificationInstrument(passes.VerificationMode.BEFORE_AND_AFTER)])
+
+
 @pytest.fixture(autouse=True)
 def _reset_backend():
     """Ensure no backend is configured so TileView inference is deterministic.
@@ -341,7 +362,7 @@ class TestInferTileMemorySpaceCubeOps:
         marked = _MarkMatmulDump().visit_program(Before)
         # Builtin-call dump attrs are compiler-internal and have no DSL
         # print/parse surface, so inspect the transformed IR directly.
-        with passes.PassContext([]):
+        with _verify_no_roundtrip():
             after = passes.infer_tile_memory_space()(marked)
         matmuls = []
 
@@ -391,7 +412,9 @@ class TestInferTileMemorySpaceCubeOps:
                 )
 
         marked = _MarkMatmulDump().visit_program(Before)
-        with passes.PassContext([]):
+        # Same compiler-internal `dump_vars` attr as the sibling test above: it has
+        # no DSL print/parse surface, so the roundtrip instrument is dropped here.
+        with _verify_no_roundtrip():
             after = passes.infer_tile_memory_space()(marked)
         matmuls = []
 
@@ -2390,7 +2413,7 @@ class RetargetedBridgeAttrs:
         backend.set_backend_type(BackendType.Ascend910B)
         # The sentinel is deliberately not a DSL-printable compiler attr, so
         # disable the global print/parse instrument for this attr-lifetime test.
-        with passes.PassContext([]):
+        with _verify_no_roundtrip():
             after = passes.infer_tile_memory_space()(before)
         load_attrs = []
 
@@ -2444,7 +2467,9 @@ class MarkerOnlyScalarCall:
 
         before = _StampScalarCall().visit_program(before)
         backend.set_backend_type(BackendType.Ascend910B)
-        with passes.PassContext([]):
+        # Same non-DSL-printable sentinel attr as the sibling test above, so the
+        # print/parse instrument is dropped for this attr-lifetime check too.
+        with _verify_no_roundtrip():
             after = passes.infer_tile_memory_space()(before)
         scalar_attrs = []
 

--- a/tests/ut/ir/transforms/test_lower_composite_ops.py
+++ b/tests/ut/ir/transforms/test_lower_composite_ops.py
@@ -993,8 +993,7 @@ def test_allreduce_dynamic_partial_valid_shape_uses_bounded_physical_rectangle(
 
     # First pin the LowerCompositeOps contract directly: the source rectangle
     # stays statically bounded while only its valid width remains symbolic.
-    with passes.PassContext([]):
-        After = passes.lower_composite_ops()(Before)
+    After = passes.lower_composite_ops()(Before)
 
     class CallCollector(ir.IRVisitor):
         def __init__(self) -> None:

--- a/tests/ut/ir/transforms/test_outline_incore_scopes.py
+++ b/tests/ut/ir/transforms/test_outline_incore_scopes.py
@@ -1502,10 +1502,9 @@ class TestOutlineNoDepArgs:
                         out = pl.store(t, [offset, 0], out)
                 return out
 
-        with passes.PassContext([]):
-            ssa = passes.convert_to_ssa()(Before)
-            with pytest.raises(ValueError, match="mutually exclusive"):
-                passes.outline_incore_scopes()(ssa)
+        ssa = passes.convert_to_ssa()(Before)
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            passes.outline_incore_scopes()(ssa)
 
     def test_function_split_none_with_split_aiv_region_rejected(self):
         """``optimizations=[pl.split(pl.SplitMode.NONE)]`` on a scope holding
@@ -1537,7 +1536,16 @@ class TestOutlineNoDepArgs:
                         out = pl.store(t, [offset, 0], out)
                 return out
 
-        with passes.PassContext([]):
+        # Property verification stays ON; only the print->parse roundtrip is dropped.
+        # `Before` deliberately carries the invalid `split=SplitMode.NONE` on the scope
+        # that this test asserts the pass rejects, and the printer intentionally never
+        # emits a `pl.split(pl.SplitMode.NONE)` (see PrintScopeOptimizations in
+        # src/ir/transforms/python_printer.cpp), so the input cannot round-trip by
+        # design — ConvertToSSA would fail on "SplitMode optional presence mismatch"
+        # before reaching the pass under test. The underlying redundancy (split_ is
+        # optional AND SplitMode has a None member) is tracked by
+        # hw-native-sys/pypto#2205.
+        with passes.PassContext([passes.VerificationInstrument(passes.VerificationMode.BEFORE_AND_AFTER)]):
             ssa = passes.convert_to_ssa()(Before)
             with pytest.raises(ValueError, match="mutually exclusive"):
                 passes.outline_incore_scopes()(ssa)

--- a/tests/ut/ir/transforms/test_stamp_tfree_split.py
+++ b/tests/ut/ir/transforms/test_stamp_tfree_split.py
@@ -30,10 +30,14 @@ def _setup_backend():
 
 
 def _stamp(program) -> str:
-    """Run convert_to_ssa then stamp_tfree_split (no verification) and print."""
+    """Run convert_to_ssa then stamp_tfree_split and print the result.
+
+    Runs under the ambient ``conftest`` context (BEFORE_AND_AFTER property
+    verification + the print->parse roundtrip instrument), so the pass output is
+    checked for free, not just the one ``tfree`` line the asserts below grep for.
+    """
     ssa = passes.convert_to_ssa()(program)
-    with passes.PassContext([]):
-        after = passes.stamp_tfree_split()(ssa)
+    after = passes.stamp_tfree_split()(ssa)
     return python_print(after)
 
 


### PR DESCRIPTION
## Summary

`tests/ut/conftest.py` installs a `VerificationInstrument(BEFORE_AND_AFTER)` plus the print→parse roundtrip instrument for every unit test. A local `passes.PassContext([])` replaces that list with an empty one, silently disabling **both**. Six transform test files did this, mostly with no stated reason — two in a shared helper covering every test in the file.

I re-enabled verification at each site and kept only what actually turned out to be load-bearing.

**Five bypasses were entirely unnecessary** and are removed — those tests pass under full ambient verification. This matters most where the assertion was weak on its own: `test_stamp_tfree_split.py` greps a single printed line, and `test_expand_mixed_kernel_split_aiv.py`'s structural comparison now has the instruments behind it.

**Four are genuinely required — but all four failed on the roundtrip instrument only, never on property verification.** `PassContext([])` was suppressing twice what any of them needed. Each is narrowed to `PassContext([VerificationInstrument(BEFORE_AND_AFTER)])` and states its reason:

| Site | Reason | Issue |
| ---- | ------ | ----- |
| `test_infer_tile_memory_space.py` (4 sites, shared `_verify_no_roundtrip` helper) | Tests stamp compiler-internal attrs (`dump_vars`, residency sentinels) that have no DSL print/parse surface | #2204 |
| `test_outline_incore_scopes.py` | Input deliberately carries the invalid `split=SplitMode.NONE` the test asserts is rejected; the printer never emits it by design | #2205 |
| `test_convert_tensor_to_tile_ops.py` | `LowerAutoVectorSplit` emits IR whose node type contradicts its operands | #2203 |

## The defect this was hiding

The `test_convert_tensor_to_tile_ops.py` bypass was concealing a real pass defect. `LowerAutoVectorSplit` halves a vector op's **result** to the per-lane half but leaves its **operand** at full parameter width:

```text
Parse failed after pass 'LowerAutoVectorSplit'.
Type annotation for 'vec_h' has shape dimension 0 = 128 but expression has shape dimension 0 = 256
  9 | vec_h: pl.Tile[[128, 128], pl.FP32, pl.Mem.Vec] = pl.tile.add(vec, vec)   # vec is [256, 128]
```

This is the same V→C boundary bug family already documented at `test_lower_auto_vector_split.py:101`, which records a previous instance that a fully suppressed context concealed — so this is the second time this pattern has hidden this class of bug. Filed as #2203 rather than fixed here, because the fix needs a design call (insert a shard vs. reject the full-width source) that belongs to the pass owner.

## Scope

Test-only. No pass behaviour, no C++/binding/stub surface, no doc or pass-numbering changes.

Ten `PassContext([])` sites remain in `tests/` and are all intentionally out of scope: five have `PassContext` itself under test (no pass runs), and five are already-documented bypasses that genuinely need the blunt form — verified, they fail **property verification** too, not just the roundtrip, so the narrowing here does not apply to them.

## Testing

- [x] Full suite: 8088 passed, 2 skipped. The one failure (`test_benchmark_l3_ignores_prepare_setup_groups`) is pre-existing on `main` — confirmed identical with these changes stashed, and it touches neither the failing test nor the code it exercises.
- [x] All 6 modified files green (387 tests) under the stricter instruments, before and after rebase onto `upstream/main`.
- [x] Each of the 4 retained bypasses independently confirmed load-bearing, failing with exactly the error its comment claims.
- [x] `ruff check` / `ruff format --check` clean; pre-commit hooks pass.

## Related Issues

Documents #2203, #2204, #2205 at the point of suppression. None are fixed here — each bypass is a pointer to its tracking issue, so re-enabling the instrument is the regression test when the underlying gap is closed.
