### PR TITLE
test(parser,arith): Assert parsed IR instead of "it did not raise"

### DIFF
--- a/tests/ut/ir/arith/test_canonical_simplify.py
+++ b/tests/ut/ir/arith/test_canonical_simplify.py
@@ -47,6 +47,16 @@ def assert_same_expr(expr: ir.Expr, expected: ir.Expr) -> None:
     )
 
 
+def assert_expr_equal(expr: ir.Expr, expected: ir.Expr) -> None:
+    """Assert that canonicalization produced exactly `expected`, operands included.
+
+    Prefer this over ``isinstance(expr, ir.Add)``-style checks: the node class
+    alone does not distinguish ``x * 2 + 2`` from ``x * 2 + 6``, so a rule that
+    canonicalizes to the wrong coefficients still passes a class check.
+    """
+    ir.assert_structural_equal(expr, expected)
+
+
 # Module-level shared instances
 simplifier = CanonicalSimplifier()
 x = make_var("x")
@@ -60,7 +70,9 @@ y = make_var("y")
 
 class TestBasics:
     def test_construction(self):
-        assert simplifier is not None
+        """A freshly constructed simplifier canonicalizes (not just constructs)."""
+        fresh = CanonicalSimplifier()
+        assert_is_const_int(fresh(ir.Add(ci(3), ci(5), INT, S)), 8)
 
     def test_identity_const(self):
         c = ci(42)
@@ -150,7 +162,7 @@ class TestCoefficientCollection:
     def test_zero_minus_x(self):
         """0 - x => -x"""
         result = simplifier(ir.Sub(ci(0), x, INT, S))
-        assert isinstance(result, ir.Neg), f"Expected Neg, got {type(result).__name__}"
+        assert_expr_equal(result, ir.Neg(x, INT, S))
 
 
 # ============================================================================
@@ -164,7 +176,7 @@ class TestMulDistribution:
     def test_mul_distribute(self):
         """(x + 1) * 2 => x * 2 + 2"""
         result = simplifier(ir.Mul(ir.Add(x, ci(1), INT, S), ci(2), INT, S))
-        assert isinstance(result, ir.Add), f"Expected Add, got {type(result).__name__}"
+        assert_expr_equal(result, ir.Add(ir.Mul(x, ci(2), INT, S), ci(2), INT, S))
 
     def test_mul_zero(self):
         """x * 0 => 0"""
@@ -179,12 +191,12 @@ class TestMulDistribution:
     def test_mul_neg_one(self):
         """x * (-1) => -x"""
         result = simplifier(ir.Mul(x, ci(-1), INT, S))
-        assert isinstance(result, ir.Neg), f"Expected Neg, got {type(result).__name__}"
+        assert_expr_equal(result, ir.Neg(x, INT, S))
 
     def test_distribute_left(self):
         """2 * (x + 3) => x * 2 + 6"""
         result = simplifier(ir.Mul(ci(2), ir.Add(x, ci(3), INT, S), INT, S))
-        assert isinstance(result, ir.Add), f"Expected Add, got {type(result).__name__}"
+        assert_expr_equal(result, ir.Add(ir.Mul(x, ci(2), INT, S), ci(6), INT, S))
 
 
 # ============================================================================
@@ -211,13 +223,20 @@ class TestFloorDiv:
         """(4*x + 6*y + 8) // 2 => 2*x + 3*y + 4"""
         inner = ir.Add(ir.Add(ir.Mul(x, ci(4), INT, S), ir.Mul(y, ci(6), INT, S), INT, S), ci(8), INT, S)
         result = simplifier(ir.FloorDiv(inner, ci(2), INT, S))
-        # Result should not contain FloorDiv
-        assert not isinstance(result, ir.FloorDiv), "Expected simplified, got FloorDiv"
+        assert_expr_equal(
+            result,
+            ir.Add(
+                ir.Add(ir.Mul(x, ci(2), INT, S), ir.Mul(y, ci(3), INT, S), INT, S),
+                ci(4),
+                INT,
+                S,
+            ),
+        )
 
     def test_div_by_scale_factor(self):
         """(x * 6) // 3 => x * 2"""
         result = simplifier(ir.FloorDiv(ir.Mul(x, ci(6), INT, S), ci(3), INT, S))
-        assert isinstance(result, ir.Mul), f"Expected Mul, got {type(result).__name__}"
+        assert_expr_equal(result, ir.Mul(x, ci(2), INT, S))
 
     def test_nested_div(self):
         """(x * 12) // 4 // 3 => x"""
@@ -317,7 +336,7 @@ class TestNeg:
     def test_neg_var(self):
         """-(x) stays as Neg(x)"""
         result = simplifier(ir.Neg(x, INT, S))
-        assert isinstance(result, ir.Neg), f"Expected Neg, got {type(result).__name__}"
+        assert_expr_equal(result, ir.Neg(x, INT, S))
 
     def test_neg_neg(self):
         """-(-(x)) => x"""
@@ -327,8 +346,7 @@ class TestNeg:
     def test_neg_sum(self):
         """-(x + 3) => -x - 3 (canonical: Neg(x) + (-3))"""
         result = simplifier(ir.Neg(ir.Add(x, ci(3), INT, S), INT, S))
-        # Should not still be a Neg of Add
-        assert not (isinstance(result, ir.Neg) and isinstance(result.operand, ir.Add))
+        assert_expr_equal(result, ir.Add(ir.Neg(x, INT, S), ci(-3), INT, S))
 
 
 # ============================================================================
@@ -384,7 +402,7 @@ class TestEdgeCases:
         lhs = ir.Mul(x, ci(1000000), INT, S)
         rhs = ir.Mul(x, ci(2000000), INT, S)
         result = simplifier(ir.Add(lhs, rhs, INT, S))
-        assert isinstance(result, ir.Mul), f"Expected Mul, got {type(result).__name__}"
+        assert_expr_equal(result, ir.Mul(x, ci(3000000), INT, S))
 
     def test_zero_const(self):
         """0 + 0 => 0"""

--- a/tests/ut/ir/arith/test_rewrite_simplify.py
+++ b/tests/ut/ir/arith/test_rewrite_simplify.py
@@ -47,6 +47,21 @@ def assert_same_expr(expr: ir.Expr, expected: ir.Expr) -> None:
     )
 
 
+def assert_expr_equal(expr: ir.Expr, expected: ir.Expr) -> None:
+    """Assert that a rewrite produced exactly `expected`, operands included.
+
+    Prefer this over ``isinstance(expr, ir.Min)``-style checks: the node class
+    alone does not distinguish ``min(x, y + z)`` from ``min(y, x + z)``, so a
+    rule that rewrites to the wrong operands still passes a class check.
+    """
+    ir.assert_structural_equal(expr, expected)
+
+
+def assert_unchanged(expr: ir.Expr, original: ir.Expr) -> None:
+    """Assert that a dormant rule left `original` structurally untouched."""
+    ir.assert_structural_equal(expr, original)
+
+
 # Module-level shared instances
 simplifier = RewriteSimplifier()
 x = make_var("x")
@@ -61,7 +76,9 @@ z = make_var("z")
 
 class TestBasics:
     def test_construction(self):
-        assert simplifier is not None
+        """A freshly constructed simplifier applies rules (not just constructs)."""
+        fresh = RewriteSimplifier()
+        assert_is_const_int(fresh(ir.Add(ci(3), ci(5), INT, S)), 8)
 
     def test_identity_const(self):
         c = ci(42)
@@ -136,7 +153,7 @@ class TestAddRules:
     def test_min_sub_add(self):
         """min(x - z, y) + z => min(x, y + z)"""
         result = simplifier(ir.Add(ir.Min(ir.Sub(x, z, INT, S), y, INT, S), z, INT, S))
-        assert isinstance(result, ir.Min)
+        assert_expr_equal(result, ir.Min(x, ir.Add(y, z, INT, S), INT, S))
 
     def test_max_min_sum(self):
         """max(x, y) + min(x, y) => x + y"""
@@ -187,7 +204,7 @@ class TestSubRules:
     def test_sub_const_cross(self):
         """(c1 - x) - (c2 - y) => (y - x) + (c1 - c2)"""
         result = simplifier(ir.Sub(ir.Sub(ci(10), x, INT, S), ir.Sub(ci(3), y, INT, S), INT, S))
-        assert isinstance(result, ir.Add)
+        assert_expr_equal(result, ir.Add(ir.Sub(y, x, INT, S), ci(7), INT, S))
 
     def test_sub_min_cancel(self):
         """min(x, y) - min(y, x) => 0"""
@@ -202,20 +219,19 @@ class TestSubRules:
     def test_sub_min_add_extract(self):
         """min(x+y, z) - x => min(y, z-x)"""
         result = simplifier(ir.Sub(ir.Min(ir.Add(x, y, INT, S), z, INT, S), x, INT, S))
-        assert isinstance(result, ir.Min)
+        assert_expr_equal(result, ir.Min(y, ir.Sub(z, x, INT, S), INT, S))
 
     def test_sub_floordiv_extended(self):
         """x - floordiv(x+y, c1)*c1 => floormod(x+y, c1) - y"""
         xy = ir.Add(x, y, INT, S)
         fd = ir.FloorDiv(xy, ci(4), INT, S)
         result = simplifier(ir.Sub(x, ir.Mul(fd, ci(4), INT, S), INT, S))
-        # Should contain floormod(x+y, 4)
-        assert isinstance(result, ir.Sub)
+        assert_expr_equal(result, ir.Sub(ir.FloorMod(xy, ci(4), INT, S), y, INT, S))
 
     def test_sub_canonicalize_nested(self):
         """x - (y - z) => (x + z) - y"""
         result = simplifier(ir.Sub(x, ir.Sub(y, z, INT, S), INT, S))
-        assert isinstance(result, ir.Sub)
+        assert_expr_equal(result, ir.Sub(ir.Add(x, z, INT, S), y, INT, S))
 
     def test_sub_structurally_equal_compound_subexprs(self):
         """e - (e - 1) => 1 where e is a compound Call appearing twice as
@@ -314,15 +330,16 @@ class TestFloorDivRules:
 
     def test_floordiv_self(self):
         """floordiv(x, x) => 1 is dormant in standalone mode (requires x != 0 proof)"""
-        result = simplifier(ir.FloorDiv(x, x, INT, S))
         # In standalone mode, TryCompare returns kUnknown so the rule doesn't fire
-        assert isinstance(result, ir.FloorDiv)
+        # and the expression must come back untouched.
+        result = simplifier(ir.FloorDiv(x, x, INT, S))
+        assert_unchanged(result, ir.FloorDiv(x, x, INT, S))
 
     def test_floordiv_mul_self(self):
         """floordiv(x * c1, x) => c1 is dormant in standalone mode (requires x != 0 proof)"""
-        result = simplifier(ir.FloorDiv(ir.Mul(x, ci(5), INT, S), x, INT, S))
         # In standalone mode, TryCompare returns kUnknown so the rule doesn't fire
-        assert isinstance(result, ir.FloorDiv)
+        result = simplifier(ir.FloorDiv(ir.Mul(x, ci(5), INT, S), x, INT, S))
+        assert_unchanged(result, ir.FloorDiv(ir.Mul(x, ci(5), INT, S), x, INT, S))
 
     def test_floordiv_nested_offset(self):
         """floordiv(floordiv(x, c1) + c2, c3) => floordiv(x + c1*c2, c1*c3)"""
@@ -362,15 +379,15 @@ class TestFloorModRules:
 
     def test_floormod_mul_var(self):
         """floormod(x * y, y) => 0 is dormant in standalone mode (requires y != 0 proof)"""
-        result = simplifier(ir.FloorMod(ir.Mul(x, y, INT, S), y, INT, S))
         # In standalone mode, TryCompare returns kUnknown so the rule doesn't fire
-        assert isinstance(result, ir.FloorMod)
+        result = simplifier(ir.FloorMod(ir.Mul(x, y, INT, S), y, INT, S))
+        assert_unchanged(result, ir.FloorMod(ir.Mul(x, y, INT, S), y, INT, S))
 
     def test_floormod_coeff_reduction(self):
         """floormod(x * c1, c2) => floormod(x * floormod(c1, c2), c2)"""
         # floormod(x*7, 3) => floormod(x*1, 3) => floormod(x, 3)
         result = simplifier(ir.FloorMod(ir.Mul(x, ci(7), INT, S), ci(3), INT, S))
-        assert isinstance(result, ir.FloorMod)
+        assert_expr_equal(result, ir.FloorMod(x, ci(3), INT, S))
 
 
 # ============================================================================
@@ -439,25 +456,23 @@ class TestMinMaxRules:
         """min(min(x, y), x) => min(x, y)"""
         inner = ir.Min(x, y, INT, S)
         result = simplifier(ir.Min(inner, x, INT, S))
-        assert isinstance(result, ir.Min)
+        assert_expr_equal(result, ir.Min(x, y, INT, S))
 
     def test_max_nested_collapse(self):
         """max(max(x, y), x) => max(x, y)"""
         inner = ir.Max(x, y, INT, S)
         result = simplifier(ir.Max(inner, x, INT, S))
-        assert isinstance(result, ir.Max)
+        assert_expr_equal(result, ir.Max(x, y, INT, S))
 
     def test_min_cross_distribution(self):
         """min(max(x,y), max(x,z)) => max(min(y,z), x)"""
         result = simplifier(ir.Min(ir.Max(x, y, INT, S), ir.Max(x, z, INT, S), INT, S))
-        assert isinstance(result, ir.Max)
-        assert isinstance(result.left, ir.Min)
+        assert_expr_equal(result, ir.Max(ir.Min(y, z, INT, S), x, INT, S))
 
     def test_max_cross_distribution(self):
         """max(min(x,y), min(x,z)) => min(max(y,z), x)"""
         result = simplifier(ir.Max(ir.Min(x, y, INT, S), ir.Min(x, z, INT, S), INT, S))
-        assert isinstance(result, ir.Min)
-        assert isinstance(result.left, ir.Max)
+        assert_expr_equal(result, ir.Min(ir.Max(y, z, INT, S), x, INT, S))
 
     def test_min_scaling(self):
         """min(x * 3, y * 3) => min(x, y) * 3"""
@@ -530,12 +545,12 @@ class TestComparisonRules:
         """x > y delegates to y < x (Gt -> Lt delegation)"""
         # x + y > x + z should simplify to z < y (via Lt delegation)
         result = simplifier(ir.Gt(ir.Add(x, y, INT, S), ir.Add(x, z, INT, S), DataType.BOOL, S))
-        assert isinstance(result, ir.Lt)
+        assert_expr_equal(result, ir.Lt(z, y, DataType.BOOL, S))
 
     def test_ge_delegation(self):
         """x >= y delegates to y <= x (Ge -> Le delegation)"""
         result = simplifier(ir.Ge(ir.Add(x, y, INT, S), ir.Add(x, z, INT, S), DataType.BOOL, S))
-        assert isinstance(result, ir.Le)
+        assert_expr_equal(result, ir.Le(z, y, DataType.BOOL, S))
 
     def test_lt_self_offset(self):
         """x < x + z => 0 < z"""
@@ -555,12 +570,18 @@ class TestComparisonRules:
     def test_lt_min_decompose(self):
         """min(x, y) < z => x < z || y < z"""
         result = simplifier(ir.Lt(ir.Min(x, y, INT, S), z, DataType.BOOL, S))
-        assert isinstance(result, ir.Or)
+        assert_expr_equal(
+            result,
+            ir.Or(ir.Lt(x, z, DataType.BOOL, S), ir.Lt(y, z, DataType.BOOL, S), DataType.BOOL, S),
+        )
 
     def test_lt_max_decompose(self):
         """max(x, y) < z => x < z && y < z"""
         result = simplifier(ir.Lt(ir.Max(x, y, INT, S), z, DataType.BOOL, S))
-        assert isinstance(result, ir.And)
+        assert_expr_equal(
+            result,
+            ir.And(ir.Lt(x, z, DataType.BOOL, S), ir.Lt(y, z, DataType.BOOL, S), DataType.BOOL, S),
+        )
 
     def test_le_sub_cancel(self):
         """x - y <= x - z => z <= y"""
@@ -605,7 +626,7 @@ class TestBooleanRules:
     def test_not_eq(self):
         """!(x == y) => x != y"""
         result = simplifier(ir.Not(ir.Eq(x, y, DataType.BOOL, S), DataType.BOOL, S))
-        assert isinstance(result, ir.Ne)
+        assert_expr_equal(result, ir.Ne(x, y, DataType.BOOL, S))
 
     def test_and_contradiction(self):
         """x && !x => false"""
@@ -678,7 +699,7 @@ class TestBooleanRules:
         lt1 = ir.Lt(x, y, DataType.BOOL, S)
         lt2 = ir.Lt(y, x, DataType.BOOL, S)
         result = simplifier(ir.Or(lt1, lt2, DataType.BOOL, S))
-        assert isinstance(result, ir.Ne)
+        assert_expr_equal(result, ir.Ne(x, y, DataType.BOOL, S))
 
 
 # ============================================================================
@@ -712,10 +733,23 @@ class TestConstraintAndSubstitution:
         simplifier.update(x, None)
 
     def test_enter_constraint(self):
+        """enter_constraint returns a recovery callable that restores prior state.
+
+        Standalone RewriteSimplifier has no bound analysis behind it, so the
+        constraint itself is inert — what must hold is that entering and
+        exiting leaves simplification behaviour byte-for-byte unchanged
+        (i.e. the constraint stack does not leak).
+        """
+        probe = ir.Add(ir.Sub(x, y, INT, S), y, INT, S)  # (x - y) + y => x
+        assert_same_expr(simplifier(probe), x)
+
         constraint = ir.Eq(x, y, DataType.BOOL, S)
         exit_fn = simplifier.enter_constraint(constraint)
         assert callable(exit_fn)
+        assert_same_expr(simplifier(probe), x)
+
         exit_fn()
+        assert_same_expr(simplifier(probe), x)
 
 
 # ============================================================================

--- a/tests/ut/language/parser/test_auto_scope_parsing.py
+++ b/tests/ut/language/parser/test_auto_scope_parsing.py
@@ -22,6 +22,11 @@ from pypto.ir.printer import python_print
 from pypto.language.parser.diagnostics import ParserSyntaxError
 
 
+def _flatten_seq(stmt) -> list:
+    """Return a body's statement list, treating a bare Stmt as a 1-element body."""
+    return list(stmt.stmts) if isinstance(stmt, ir.SeqStmts) else [stmt]
+
+
 def _first_runtime_scope(stmt):
     if isinstance(stmt, ir.RuntimeScopeStmt):
         return stmt
@@ -163,7 +168,16 @@ def test_loop_carried_yield_outside_scope_ok():
                 acc = pl.yield_(nxt)
             return acc
 
-    assert Prog.get_function("orch") is not None
+    orch = Prog.get_function("orch")
+    assert orch is not None
+
+    # The scope wraps the per-iteration work; the yield stays a direct for-body
+    # child (not swallowed into the scope).
+    for_stmt = next(s for s in _flatten_seq(orch.body) if isinstance(s, ir.ForStmt))
+    body_stmts = _flatten_seq(for_stmt.body)
+    assert isinstance(body_stmts[0], ir.ScopeStmt)
+    assert isinstance(body_stmts[-1], ir.YieldStmt)
+    assert len(for_stmt.iter_args) == 1
 
 
 def test_manual_scope_in_if_branch_registers_yield_var():

--- a/tests/ut/language/parser/test_closure_var_resolution.py
+++ b/tests/ut/language/parser/test_closure_var_resolution.py
@@ -19,6 +19,29 @@ from pypto import ir
 from pypto.language.parser.diagnostics import ParserTypeError, UndefinedVariableError
 
 
+def _first_call(func: ir.Function) -> ir.Call:
+    """Return the RHS of the function body's first binding, asserting it is a Call."""
+    body = func.body
+    stmts = list(body.stmts) if isinstance(body, ir.SeqStmts) else [body]
+    for stmt in stmts:
+        if isinstance(stmt, ir.AssignStmt):
+            assert isinstance(stmt.value, ir.Call), (
+                f"{stmt.var.name_hint} is {type(stmt.value).__name__}, expected Call"
+            )
+            return stmt.value
+    raise AssertionError("No binding found in function body")
+
+
+def _int_elements(expr: ir.Expr) -> list[int]:
+    """Flatten a MakeTuple of integer constants into plain ints."""
+    assert isinstance(expr, ir.MakeTuple), f"expected MakeTuple, got {type(expr).__name__}"
+    values = []
+    for element in expr.elements:
+        assert isinstance(element, ir.ConstInt), f"expected ConstInt element, got {type(element).__name__}"
+        values.append(element.value)
+    return values
+
+
 class TestClosureVarAsPositionalArg:
     """Closure variables used as positional arguments in function calls."""
 
@@ -35,7 +58,11 @@ class TestClosureVarAsPositionalArg:
             result: pl.Tensor[[128, 128], pl.FP32] = pl.tile.store(a, OFFSET, output_tensor=out)
             return result
 
-        assert isinstance(func, ir.Function)
+        # The list closure vars reach the load as tuple literals with their values
+        load = _first_call(func)
+        assert load.op.name == ir.get_op("tile.load").name
+        assert _int_elements(load.args[1]) == [0, 0]
+        assert _int_elements(load.args[2]) == [64, 64]
 
     def test_int_closure_var_as_positional_arg(self):
         """Int closure variable resolves to ConstInt in function body."""
@@ -46,7 +73,12 @@ class TestClosureVarAsPositionalArg:
             result: pl.Tensor[[128, 64], pl.FP32] = pl.transpose(x, axis1=0, axis2=AXIS)
             return result
 
-        assert isinstance(func, ir.Function)
+        transpose = _first_call(func)
+        assert transpose.op.name == ir.get_op("tensor.transpose").name
+        # axis2=AXIS resolved to the closure's value 1, not to axis1's 0
+        axis2 = transpose.args[2]
+        assert isinstance(axis2, ir.ConstInt)
+        assert axis2.value == 1
 
     def test_float_closure_var_as_positional_arg(self):
         """Float closure variable resolves to ConstFloat in function body."""
@@ -57,7 +89,9 @@ class TestClosureVarAsPositionalArg:
             result: pl.Tensor[[64], pl.FP32] = pl.mul(x, SCALE)
             return result
 
-        assert isinstance(func, ir.Function)
+        scale_arg = _first_call(func).args[1]
+        assert isinstance(scale_arg, ir.ConstFloat)
+        assert scale_arg.value == 2.0
 
     def test_bool_closure_var_as_positional_arg(self):
         """Bool closure variable resolves to ConstBool in function body."""
@@ -68,7 +102,10 @@ class TestClosureVarAsPositionalArg:
             result: pl.Tensor[[64], pl.FP32] = pl.mul(x, FLAG)
             return result
 
-        assert isinstance(func, ir.Function)
+        flag_arg = _first_call(func).args[1]
+        # Must stay a ConstBool — not silently widened to ConstInt(1)
+        assert isinstance(flag_arg, ir.ConstBool)
+        assert flag_arg.value is True
 
     def test_tuple_closure_var_as_positional_arg(self):
         """Tuple closure variable resolves to MakeTuple in function body."""
@@ -83,7 +120,10 @@ class TestClosureVarAsPositionalArg:
             result: pl.Tensor[[128, 128], pl.FP32] = pl.tile.store(a, OFFSET, output_tensor=out)
             return result
 
-        assert isinstance(func, ir.Function)
+        # Tuple closure vars resolve identically to list ones
+        load = _first_call(func)
+        assert _int_elements(load.args[1]) == [0, 0]
+        assert _int_elements(load.args[2]) == [64, 64]
 
     def test_nested_list_closure_var(self):
         """Nested list closure variable recursively converts to nested MakeTuple."""
@@ -97,7 +137,13 @@ class TestClosureVarAsPositionalArg:
             result: pl.Tensor[[128, 128], pl.FP32] = pl.tile.store(a, [0, 0], output_tensor=out)
             return result
 
-        assert isinstance(func, ir.Function)
+        # The outer list becomes a MakeTuple whose elements are themselves MakeTuples
+        offsets = _first_call(func).args[1]
+        assert isinstance(offsets, ir.MakeTuple)
+        rows = list(offsets.elements)
+        assert len(rows) == 2
+        assert _int_elements(rows[0]) == [0, 0]
+        assert _int_elements(rows[1]) == [64, 64]
 
     def test_dynvar_closure_var(self):
         """DynVar closure variable resolves to ir.Var with INDEX type."""
@@ -109,7 +155,14 @@ class TestClosureVarAsPositionalArg:
             result: pl.Tensor[[64], pl.FP32] = pl.mul(x, pl.cast(M, pl.INT32))  # type: ignore[arg-type]
             return result
 
-        assert isinstance(func, ir.Function)
+        cast = _first_call(func).args[1]
+        assert isinstance(cast, ir.Cast)
+        # The DynVar resolves to a Var named "M" carrying INDEX dtype
+        operand = cast.operand
+        assert isinstance(operand, ir.Var)
+        assert operand.name_hint == "M"
+        assert isinstance(operand.type, ir.ScalarType)
+        assert operand.type.dtype == pl.INDEX
 
 
 class TestClosureVarShadowing:
@@ -125,7 +178,14 @@ class TestClosureVarShadowing:
             result: pl.Tensor[[64], pl.FP32] = pl.mul(x_scale, x)
             return result
 
-        assert isinstance(func, ir.Function)
+        body = func.body
+        assert isinstance(body, ir.SeqStmts)
+        add_stmt, mul_stmt = (s for s in body.stmts if isinstance(s, ir.AssignStmt))
+
+        # `x_scale` in the mul refers to the DSL binding, not the 999.0 closure var
+        mul_call = mul_stmt.value
+        assert isinstance(mul_call, ir.Call)
+        assert mul_call.args[0] is add_stmt.var
 
 
 class TestClosureVarErrors:

--- a/tests/ut/language/parser/test_constant_folding.py
+++ b/tests/ut/language/parser/test_constant_folding.py
@@ -201,16 +201,23 @@ class TestMixedExpressionFallback:
             result = pl.mul(x, shifted)
             return result
 
-        assert isinstance(func, ir.Function)
         # The `idx + OFFSET` must remain an Add node, not folded
         body = func.body
         assert isinstance(body, ir.SeqStmts)
-        found_add = False
-        for stmt in body.stmts:
-            if isinstance(stmt, ir.AssignStmt) and isinstance(stmt.value, ir.Add):
-                found_add = True
-                break
-        assert found_add, "Expected an ir.Add node for dsl_var + closure_const"
+        assigns = [s for s in body.stmts if isinstance(s, ir.AssignStmt)]
+        by_name = {s.var.name_hint: s for s in assigns}
+
+        shifted = by_name["shifted"].value
+        assert isinstance(shifted, ir.Add), f"dsl_var + closure_const folded to {type(shifted).__name__}"
+        # ...and its operands are the DSL read on the left, the closure const on
+        # the right. The parser may wrap the read in a dtype-promoting Cast --
+        # that is literal-typing detail, not the folding behaviour under test.
+        lhs = shifted.left
+        if isinstance(lhs, ir.Cast):
+            lhs = lhs.operand
+        assert lhs is by_name["idx"].var
+        assert isinstance(shifted.right, ir.ConstInt)
+        assert shifted.right.value == 10
 
     def test_pure_dsl_binop_not_folded(self):
         """Operations on DSL-defined variables should not attempt folding."""
@@ -283,7 +290,8 @@ class TestDimensionEqualityAfterFolding:
             out = pl.assemble(out, result, [0, 0])
             return out
 
-        assert isinstance(func, ir.Function)
+        # `A // 2` and `B * 1` both fold to the literal 8, so both slices agree
+        _assert_all_slice_extents_are_constint(func, [1, 8])
 
 
 class TestScopeShadowingSafety:
@@ -410,7 +418,8 @@ class TestSymbolicShapeEquality:
                 chunk = a[:, k : k + C]
             return chunk
 
-        assert isinstance(func, ir.Function)
+        # `k + C - k` simplifies to the literal C, so both slices keep shape [8, 64]
+        _assert_all_slice_extents_are_constint(func, [8, C])
 
     def test_symbolic_cancellation_in_broadcast_sub(self):
         """``pl.sub`` of two slices whose extents simplify to the same constant
@@ -429,7 +438,8 @@ class TestSymbolicShapeEquality:
                 out = pl.sub(lo, hi)
             return out
 
-        assert isinstance(func, ir.Function)
+        # Both extents cancel to the literal HALF, so the operands broadcast
+        _assert_all_slice_extents_are_constint(func, [1, HALF])
 
 
 if __name__ == "__main__":

--- a/tests/ut/language/parser/test_control_flow.py
+++ b/tests/ut/language/parser/test_control_flow.py
@@ -257,8 +257,10 @@ class TestComplexControlFlow:
         assert len(loops) == 2, "the two loops must stay siblings, not nest"
         _assert_range(loops[0], start=0, stop=5, step=1)
         _assert_range(loops[1], start=0, stop=3, step=1)
-        # Second loop consumes the first loop's result as its init value.
-        assert loops[1].iter_args[0].name_hint == "acc2"
+        # Second loop consumes the first loop's result as its init value -- check the
+        # data-flow edge itself, since the iter-arg's name alone would also accept
+        # `init` or any other same-typed value.
+        assert loops[1].iter_args[0].initValue is loops[0].return_vars[0]
 
     def test_loop_without_iter_args(self):
         """Test loop without iter_args."""
@@ -494,10 +496,22 @@ def _assert_range(for_stmt: ir.ForStmt, start: int, stop: int, step: int) -> Non
         assert bound.value == expected, f"{name} is {bound.value}, expected {expected}"
 
 
-def _assert_var_named(expr: ir.Expr, name: str) -> None:
-    """Assert `expr` is a Var reference bound to `name`."""
-    assert isinstance(expr, ir.Var), f"expected Var {name!r}, got {type(expr).__name__}"
-    assert expr.name_hint == name, f"expected Var {name!r}, got {expr.name_hint!r}"
+def _find_binding(body: ir.Stmt, name: str) -> ir.AssignStmt:
+    """Return the AssignStmt in `body` that binds `name`."""
+    for stmt in _top_level_stmts(body):
+        if isinstance(stmt, ir.AssignStmt) and stmt.var.name_hint == name:
+            return stmt
+    raise AssertionError(f"No binding for {name!r} found in body")
+
+
+def _assert_var_is(expr: ir.Expr, definition: ir.AssignStmt) -> None:
+    """Assert `expr` is the very Var bound by `definition`.
+
+    Matching on ``name_hint`` alone would also accept a fresh, unbound Var that
+    merely shares the name -- i.e. a use that no longer refers to its definition.
+    """
+    assert isinstance(expr, ir.Var), f"expected Var, got {type(expr).__name__}"
+    assert expr is definition.var, f"operand {expr.name_hint!r} is not the Var bound at its definition"
 
 
 def _assert_body_kinds(body: ir.Stmt, *kinds: type) -> None:
@@ -745,7 +759,7 @@ class TestWhileLoops:
 
         # Condition is `i < n`, with `n` the Scalar parameter
         assert isinstance(while_stmt.condition, ir.Lt)
-        _assert_var_named(while_stmt.condition.left, "i")
+        _assert_var_is(while_stmt.condition.left, _find_binding(while_tensors.body, "i"))
         assert while_stmt.condition.right is while_tensors.params[0]
 
         # Body holds both assignments: the counter bump and the tensor accumulate
@@ -768,7 +782,7 @@ class TestWhileLoops:
 
         # Outer condition is `x < n`, with `n` the Scalar parameter
         assert isinstance(outer_while.condition, ir.Lt)
-        _assert_var_named(outer_while.condition.left, "x")
+        _assert_var_is(outer_while.condition.left, _find_binding(nested_while.body, "x"))
         assert outer_while.condition.right is nested_while.params[0]
 
         # Outer body: `y = 0`, the nested loop, then `x = x + 1`
@@ -779,7 +793,7 @@ class TestWhileLoops:
 
         # Inner condition is exactly `y < 3`
         assert isinstance(inner_while.condition, ir.Lt)
-        _assert_var_named(inner_while.condition.left, "y")
+        _assert_var_is(inner_while.condition.left, _find_binding(outer_while.body, "y"))
         assert isinstance(inner_while.condition.right, ir.ConstInt)
         assert inner_while.condition.right.value == 3
         _assert_body_kinds(inner_while.body, ir.AssignStmt)
@@ -812,7 +826,7 @@ class TestWhileLoops:
 
         # The while condition closes over the enclosing loop variable: `x < i`
         assert isinstance(while_stmt.condition, ir.Lt)
-        _assert_var_named(while_stmt.condition.left, "x")
+        _assert_var_is(while_stmt.condition.left, _find_binding(for_stmt.body, "x"))
         assert while_stmt.condition.right is for_stmt.loop_var
         _assert_body_kinds(while_stmt.body, ir.AssignStmt)
 

--- a/tests/ut/language/parser/test_control_flow.py
+++ b/tests/ut/language/parser/test_control_flow.py
@@ -50,7 +50,11 @@ class TestForLoops:
 
             return out1
 
-        assert isinstance(multi_iter, ir.Function)
+        for_stmt = _find_for_stmt(multi_iter)
+        _assert_range(for_stmt, start=0, stop=5, step=1)
+        assert len(for_stmt.iter_args) == 2
+        assert len(for_stmt.return_vars) == 2
+        _assert_body_kinds(for_stmt.body, ir.AssignStmt, ir.AssignStmt, ir.YieldStmt)
 
     def test_for_loop_with_range_params(self):
         """Test for loop with start, stop, step parameters."""
@@ -65,7 +69,9 @@ class TestForLoops:
 
             return result
 
-        assert isinstance(range_params, ir.Function)
+        for_stmt = _find_for_stmt(range_params)
+        _assert_range(for_stmt, start=0, stop=10, step=2)
+        assert len(for_stmt.iter_args) == 1
 
     def test_nested_for_loops(self):
         """Test nested for loops."""
@@ -83,7 +89,14 @@ class TestForLoops:
 
             return outer_out
 
-        assert isinstance(nested_loops, ir.Function)
+        outer = _find_for_stmt(nested_loops)
+        _assert_range(outer, start=0, stop=3, step=1)
+        _assert_body_kinds(outer.body, ir.ForStmt, ir.YieldStmt)
+
+        inner = _top_level_stmts(outer.body)[0]
+        assert isinstance(inner, ir.ForStmt), "outer loop body must open with the nested loop"
+        _assert_range(inner, start=0, stop=2, step=1)
+        assert len(inner.iter_args) == 1
 
     def test_for_loop_with_operations(self):
         """Test for loop with tensor operations."""
@@ -98,7 +111,10 @@ class TestForLoops:
 
             return result
 
-        assert isinstance(loop_ops, ir.Function)
+        for_stmt = _find_for_stmt(loop_ops)
+        _assert_range(for_stmt, start=0, stop=4, step=1)
+        assert len(for_stmt.iter_args) == 1
+        _assert_body_kinds(for_stmt.body, ir.AssignStmt, ir.YieldStmt)
 
 
 class TestIfStatements:
@@ -126,7 +142,15 @@ class TestIfStatements:
 
             return result
 
-        assert isinstance(if_in_loop, ir.Function)
+        for_stmt = _find_for_stmt(if_in_loop)
+        _assert_range(for_stmt, start=0, stop=5, step=1)
+        _assert_body_kinds(for_stmt.body, ir.IfStmt, ir.YieldStmt)
+
+        if_stmt = _top_level_stmts(for_stmt.body)[0]
+        assert isinstance(if_stmt, ir.IfStmt)
+        assert isinstance(if_stmt.condition, ir.Eq), "condition `i == 0` must parse to Eq"
+        assert if_stmt.else_body is not None, "else branch must be preserved"
+        assert len(if_stmt.return_vars) == 1
 
     def test_if_yield_type_annotation_preserved(self):
         """Test that type annotations on yield assignments are preserved in IR (issue #185)."""
@@ -199,7 +223,16 @@ class TestComplexControlFlow:
 
             return out1
 
-        assert isinstance(complex_flow, ir.Function)
+        for_stmt = _find_for_stmt(complex_flow)
+        _assert_range(for_stmt, start=0, stop=10, step=1)
+        assert len(for_stmt.iter_args) == 2
+        assert len(for_stmt.return_vars) == 2
+        _assert_body_kinds(for_stmt.body, ir.IfStmt, ir.YieldStmt)
+
+        if_stmt = _top_level_stmts(for_stmt.body)[0]
+        assert isinstance(if_stmt, ir.IfStmt)
+        assert if_stmt.else_body is not None
+        assert len(if_stmt.return_vars) == 2, "both branches yield two values"
 
     def test_sequential_loops(self):
         """Test sequential (not nested) for loops."""
@@ -220,7 +253,12 @@ class TestComplexControlFlow:
 
             return result2
 
-        assert isinstance(sequential_loops, ir.Function)
+        loops = _find_all_for_stmts(sequential_loops)
+        assert len(loops) == 2, "the two loops must stay siblings, not nest"
+        _assert_range(loops[0], start=0, stop=5, step=1)
+        _assert_range(loops[1], start=0, stop=3, step=1)
+        # Second loop consumes the first loop's result as its init value.
+        assert loops[1].iter_args[0].name_hint == "acc2"
 
     def test_loop_without_iter_args(self):
         """Test loop without iter_args."""
@@ -237,7 +275,11 @@ class TestComplexControlFlow:
                     result = temp
             return result
 
-        assert isinstance(loop_without_iter_args, ir.Function)
+        for_stmt = _find_for_stmt(loop_without_iter_args)
+        _assert_range(for_stmt, start=0, stop=3, step=1)
+        assert len(for_stmt.iter_args) == 0
+        assert len(for_stmt.return_vars) == 0
+        _assert_body_kinds(for_stmt.body, ir.IfStmt)
 
 
 class TestParallelForLoops:
@@ -270,7 +312,11 @@ class TestParallelForLoops:
                 result = temp
             return result
 
-        assert isinstance(parallel_no_iter, ir.Function)
+        for_stmt = _find_for_stmt(parallel_no_iter)
+        assert for_stmt.kind == ir.ForKind.Parallel
+        _assert_range(for_stmt, start=0, stop=3, step=1)
+        assert len(for_stmt.iter_args) == 0
+        assert len(for_stmt.return_vars) == 0
 
     def test_parallel_for_loop_with_range_params(self):
         """Test parallel for loop with start, stop, step parameters."""
@@ -285,7 +331,10 @@ class TestParallelForLoops:
 
             return result
 
-        assert isinstance(parallel_range, ir.Function)
+        for_stmt = _find_for_stmt(parallel_range)
+        assert for_stmt.kind == ir.ForKind.Parallel
+        _assert_range(for_stmt, start=0, stop=10, step=2)
+        assert len(for_stmt.iter_args) == 1
 
     def test_parallel_for_produces_parallel_kind(self):
         """Test that pl.parallel() produces ForKind.Parallel in the IR."""
@@ -423,6 +472,42 @@ def _find_for_stmt(func: ir.Function) -> ir.ForStmt:
     raise AssertionError("No ForStmt found in function body")
 
 
+def _top_level_stmts(stmt: ir.Stmt) -> list[ir.Stmt]:
+    """Return the statement list of a body, treating a bare Stmt as a 1-element body."""
+    return list(stmt.stmts) if isinstance(stmt, ir.SeqStmts) else [stmt]
+
+
+def _find_all_for_stmts(func: ir.Function) -> list[ir.ForStmt]:
+    """Helper to extract every top-level ForStmt from a function body, in order."""
+    return [s for s in _top_level_stmts(func.body) if isinstance(s, ir.ForStmt)]
+
+
+def _assert_range(for_stmt: ir.ForStmt, start: int, stop: int, step: int) -> None:
+    """Assert a ForStmt's constant loop bounds.
+
+    Pins the parsed ``pl.range(...)`` arguments; ``isinstance(stmt, ir.ForStmt)``
+    alone does not distinguish ``range(0, 10, 2)`` from ``range(10)``.
+    """
+    for name, expected in (("start", start), ("stop", stop), ("step", step)):
+        bound = getattr(for_stmt, name)
+        assert isinstance(bound, ir.ConstInt), f"{name} is {type(bound).__name__}, expected a constant"
+        assert bound.value == expected, f"{name} is {bound.value}, expected {expected}"
+
+
+def _assert_var_named(expr: ir.Expr, name: str) -> None:
+    """Assert `expr` is a Var reference bound to `name`."""
+    assert isinstance(expr, ir.Var), f"expected Var {name!r}, got {type(expr).__name__}"
+    assert expr.name_hint == name, f"expected Var {name!r}, got {expr.name_hint!r}"
+
+
+def _assert_body_kinds(body: ir.Stmt, *kinds: type) -> None:
+    """Assert the exact statement kinds making up a loop/branch body, in order."""
+    actual = [type(s) for s in _top_level_stmts(body)]
+    assert actual == list(kinds), (
+        f"body is {[k.__name__ for k in actual]}, expected {[k.__name__ for k in kinds]}"
+    )
+
+
 def _find_while_stmt(func: ir.Function) -> ir.WhileStmt:
     """Helper to find WhileStmt in function body."""
     stmt = func.body
@@ -508,10 +593,12 @@ class TestScalarRange:
                 y: pl.Tensor[[64], pl.FP32] = pl.add(x, 1.0)
             return y
 
-        assert isinstance(scalar_expr_stop, ir.Function)
         for_stmt = _find_for_stmt(scalar_expr_stop)
-        # stop should be a Mul expression (n * 2)
+        # stop should be exactly `n * 2`, not merely "some Mul"
         assert isinstance(for_stmt.stop, ir.Mul)
+        assert for_stmt.stop.left is scalar_expr_stop.params[0]
+        assert isinstance(for_stmt.stop.right, ir.ConstInt)
+        assert for_stmt.stop.right.value == 2
 
     def test_scalar_complex_expression_as_stop(self):
         """Test pl.range(n * 2 + 1) where n is a Scalar[INT64] parameter."""
@@ -524,10 +611,16 @@ class TestScalarRange:
                 y: pl.Tensor[[64], pl.FP32] = pl.add(x, 1.0)
             return y
 
-        assert isinstance(scalar_complex_expr, ir.Function)
         for_stmt = _find_for_stmt(scalar_complex_expr)
-        # stop should be an Add expression ((n * 2) + 1)
-        assert isinstance(for_stmt.stop, ir.Add)
+        # stop should be exactly `(n * 2) + 1`, preserving precedence
+        stop = for_stmt.stop
+        assert isinstance(stop, ir.Add)
+        assert isinstance(stop.right, ir.ConstInt)
+        assert stop.right.value == 1
+        assert isinstance(stop.left, ir.Mul)
+        assert stop.left.left is scalar_complex_expr.params[0]
+        assert isinstance(stop.left.right, ir.ConstInt)
+        assert stop.left.right.value == 2
 
     def test_scalar_floordiv_expression_as_stop(self):
         """Test pl.range(n // 4) where n is a Scalar[INT64] parameter."""
@@ -540,10 +633,12 @@ class TestScalarRange:
                 y: pl.Tensor[[64], pl.FP32] = pl.add(x, 1.0)
             return y
 
-        assert isinstance(scalar_floordiv_expr, ir.Function)
         for_stmt = _find_for_stmt(scalar_floordiv_expr)
-        # stop should be a FloorDiv expression (n // 4)
+        # stop should be exactly `n // 4`
         assert isinstance(for_stmt.stop, ir.FloorDiv)
+        assert for_stmt.stop.left is scalar_floordiv_expr.params[0]
+        assert isinstance(for_stmt.stop.right, ir.ConstInt)
+        assert for_stmt.stop.right.value == 4
 
     def test_scalar_range_with_iter_args(self):
         """Test pl.range(n, init_values=(init,)) where n is a Scalar[INT64] parameter."""
@@ -646,16 +741,15 @@ class TestWhileLoops:
                 acc = pl.add(acc, x)
             return acc
 
-        assert isinstance(while_tensors, ir.Function)
-
-        # Find the while statement
         while_stmt = _find_while_stmt(while_tensors)
-        assert isinstance(while_stmt, ir.WhileStmt)
 
-        # Body should contain assignments
-        assert while_stmt.body is not None
-        if isinstance(while_stmt.body, ir.SeqStmts):
-            assert len(while_stmt.body.stmts) >= 1
+        # Condition is `i < n`, with `n` the Scalar parameter
+        assert isinstance(while_stmt.condition, ir.Lt)
+        _assert_var_named(while_stmt.condition.left, "i")
+        assert while_stmt.condition.right is while_tensors.params[0]
+
+        # Body holds both assignments: the counter bump and the tensor accumulate
+        _assert_body_kinds(while_stmt.body, ir.AssignStmt, ir.AssignStmt)
 
     def test_nested_while_loops(self):
         """Test nested while loops."""
@@ -670,25 +764,25 @@ class TestWhileLoops:
                 x = x + 1
             return x
 
-        assert isinstance(nested_while, ir.Function)
-
-        # Find the outer while statement
         outer_while = _find_while_stmt(nested_while)
-        assert isinstance(outer_while, ir.WhileStmt)
 
-        # Find inner while statement in the outer while's body
-        inner_while = None
-        if isinstance(outer_while.body, ir.SeqStmts):
-            for stmt in outer_while.body.stmts:
-                if isinstance(stmt, ir.WhileStmt):
-                    inner_while = stmt
-                    break
+        # Outer condition is `x < n`, with `n` the Scalar parameter
+        assert isinstance(outer_while.condition, ir.Lt)
+        _assert_var_named(outer_while.condition.left, "x")
+        assert outer_while.condition.right is nested_while.params[0]
 
-        assert inner_while is not None, "Expected nested WhileStmt in outer while body"
+        # Outer body: `y = 0`, the nested loop, then `x = x + 1`
+        _assert_body_kinds(outer_while.body, ir.AssignStmt, ir.WhileStmt, ir.AssignStmt)
+
+        inner_while = _top_level_stmts(outer_while.body)[1]
         assert isinstance(inner_while, ir.WhileStmt)
 
-        # Inner condition should compare y < 3
+        # Inner condition is exactly `y < 3`
         assert isinstance(inner_while.condition, ir.Lt)
+        _assert_var_named(inner_while.condition.left, "y")
+        assert isinstance(inner_while.condition.right, ir.ConstInt)
+        assert inner_while.condition.right.value == 3
+        _assert_body_kinds(inner_while.body, ir.AssignStmt)
 
     def test_while_inside_for_loop(self):
         """Test while loop nested inside a for loop."""
@@ -706,22 +800,21 @@ class TestWhileLoops:
 
             return sum_out
 
-        assert isinstance(while_in_for, ir.Function)
-
-        # Find the for statement
         for_stmt = _find_for_stmt(while_in_for)
-        assert isinstance(for_stmt, ir.ForStmt)
+        _assert_range(for_stmt, start=0, stop=5, step=1)
+        assert len(for_stmt.iter_args) == 1
 
-        # Find while statement inside the for loop body
-        while_stmt = None
-        if isinstance(for_stmt.body, ir.SeqStmts):
-            for stmt in for_stmt.body.stmts:
-                if isinstance(stmt, ir.WhileStmt):
-                    while_stmt = stmt
-                    break
+        # For body: `x = 0`, the while loop, `new_sum = ...`, then the yield
+        _assert_body_kinds(for_stmt.body, ir.AssignStmt, ir.WhileStmt, ir.AssignStmt, ir.YieldStmt)
 
-        assert while_stmt is not None, "Expected WhileStmt in for loop body"
+        while_stmt = _top_level_stmts(for_stmt.body)[1]
         assert isinstance(while_stmt, ir.WhileStmt)
+
+        # The while condition closes over the enclosing loop variable: `x < i`
+        assert isinstance(while_stmt.condition, ir.Lt)
+        _assert_var_named(while_stmt.condition.left, "x")
+        assert while_stmt.condition.right is for_stmt.loop_var
+        _assert_body_kinds(while_stmt.body, ir.AssignStmt)
 
     def test_for_inside_while_loop(self):
         """Test for loop nested inside a while loop."""

--- a/tests/ut/language/parser/test_decorator.py
+++ b/tests/ut/language/parser/test_decorator.py
@@ -25,6 +25,33 @@ from pypto.language.parser.diagnostics.exceptions import (
 )
 
 
+def _top_level_stmts(body: ir.Stmt) -> list[ir.Stmt]:
+    """Return a body's statement list, treating a bare Stmt as a 1-element body."""
+    return list(body.stmts) if isinstance(body, ir.SeqStmts) else [body]
+
+
+def _body_assigns(func: ir.Function) -> list[ir.AssignStmt]:
+    """Return the function body's top-level AssignStmts, in source order."""
+    return [s for s in _top_level_stmts(func.body) if isinstance(s, ir.AssignStmt)]
+
+
+def _int_elements(expr: ir.Expr) -> list[int]:
+    """Flatten a MakeTuple of integer constants into plain ints."""
+    assert isinstance(expr, ir.MakeTuple), f"expected MakeTuple, got {type(expr).__name__}"
+    values = []
+    for element in expr.elements:
+        assert isinstance(element, ir.ConstInt), f"expected ConstInt element, got {type(element).__name__}"
+        values.append(element.value)
+    return values
+
+
+def _call_of(stmt: ir.AssignStmt) -> ir.Call:
+    """Assert a binding's RHS is a Call and return it."""
+    value = stmt.value
+    assert isinstance(value, ir.Call), f"{stmt.var.name_hint} is {type(value).__name__}, expected Call"
+    return value
+
+
 class TestFunctionDecorator:
     """Tests for @pl.function decorator."""
 
@@ -80,7 +107,11 @@ class TestFunctionDecorator:
             result: pl.Tensor[[64, 128], pl.FP32] = pl.create_tensor([64, 128], dtype=pl.FP32)
             return result
 
-        assert isinstance(create_tensor, ir.Function)
+        create_stmt = _body_assigns(create_tensor)[0]
+        assert _call_of(create_stmt).op.name == ir.get_op("tensor.create").name
+        result_type = create_stmt.var.type
+        assert isinstance(result_type, ir.TensorType)
+        assert result_type.dtype == pypto.DataType.FP32
 
     def test_function_with_binary_ops(self):
         """Test function with binary operations."""
@@ -91,7 +122,12 @@ class TestFunctionDecorator:
             result: pl.Tensor[[64], pl.FP32] = pl.add(pl.mul(x, 2.0), pl.create_tensor([64], dtype=pl.FP32))
             return result
 
-        assert isinstance(binary_ops, ir.Function)
+        # The nested calls stay nested as Call operands of the outer add
+        add_call = _call_of(_body_assigns(binary_ops)[0])
+        assert add_call.op.name == ir.get_op("tensor.add").name
+        lhs, rhs = add_call.args
+        assert isinstance(lhs, ir.Call) and lhs.op.name == ir.get_op("tensor.muls").name
+        assert isinstance(rhs, ir.Call) and rhs.op.name == ir.get_op("tensor.create").name
 
     def test_function_with_list_arguments(self):
         """Test function that uses list arguments."""
@@ -102,7 +138,11 @@ class TestFunctionDecorator:
             result: pl.Tensor[[32, 64], pl.FP32] = pl.slice(x, [32, 64], [0, 0])
             return result
 
-        assert isinstance(with_lists, ir.Function)
+        # Both list literals reach the op as MakeTuple args, in the order written
+        slice_call = _call_of(_body_assigns(with_lists)[0])
+        assert slice_call.op.name == ir.get_op("tensor.slice").name
+        assert _int_elements(slice_call.args[1]) == [32, 64]
+        assert _int_elements(slice_call.args[2]) == [0, 0]
 
     def test_function_with_eval_stmt(self):
         """Test parsing evaluation statements into EvalStmt."""
@@ -179,7 +219,10 @@ class TestFunctionDecorator:
             result: pl.Tensor[[64], pl.FP32] = pl.add(x, -1.5)
             return result
 
-        assert isinstance(with_negatives, ir.Function)
+        # The unary minus is folded into the literal, not left as a Neg node
+        scalar_arg = _call_of(_body_assigns(with_negatives)[0]).args[1]
+        assert isinstance(scalar_arg, ir.ConstFloat)
+        assert scalar_arg.value == -1.5
 
 
 class TestScalarParameters:
@@ -332,7 +375,17 @@ class TestTensorReadParsing:
                 _ = pl.tensor.read(t, [i])
             return out
 
-        assert isinstance(read_in_loop, ir.Function)
+        # The read's index is the enclosing loop variable, not a copy or a constant
+        for_stmt = next(s for s in _top_level_stmts(read_in_loop.body) if isinstance(s, ir.ForStmt))
+        read_stmt = next(s for s in _top_level_stmts(for_stmt.body) if isinstance(s, ir.AssignStmt))
+        read_call = _call_of(read_stmt)
+        assert read_call.op.name == ir.get_op("tensor.read").name
+        indices = read_call.args[1]
+        assert isinstance(indices, ir.MakeTuple)
+        # Compare by identity: ``Expr.__eq__`` builds an IR ``Eq`` node, so ``==``
+        # on Expr lists reports equality even for distinct nodes.
+        assert len(indices.elements) == 1
+        assert indices.elements[0] is for_stmt.loop_var
 
 
 class TestTupleReturnType:
@@ -484,7 +537,11 @@ class TestProgramDecorator:
                 result: pl.Tensor[[1], pl.INT32] = pl.add(n, one)
                 return result
 
-        assert isinstance(RecursiveTest, ir.Program)
+        # A single-method program keeps exactly that one function, `self` stripped
+        assert [f.name for f in RecursiveTest.functions] == ["factorial"]
+        factorial = RecursiveTest.get_function("factorial")
+        assert factorial is not None
+        assert [p.name_hint for p in factorial.params] == ["n"]
 
     def test_transitive_calls(self):
         """Test transitive calls where A calls B calls C."""

--- a/tests/ut/language/parser/test_error_cases.py
+++ b/tests/ut/language/parser/test_error_cases.py
@@ -23,6 +23,45 @@ from pypto.language.parser.diagnostics import (
 from pypto.language.parser.diagnostics.renderer import ErrorRenderer
 
 
+def _top_level_stmts(body: pypto.ir.Stmt) -> list[pypto.ir.Stmt]:
+    """Return a body's statement list, treating a bare Stmt as a 1-element body."""
+    return list(body.stmts) if isinstance(body, pypto.ir.SeqStmts) else [body]
+
+
+def _stmt_kinds(body: pypto.ir.Stmt) -> list[type]:
+    """Return the statement classes making up a function/loop body, in order."""
+    return [type(s) for s in _top_level_stmts(body)]
+
+
+def _shape_of(param: pypto.ir.Var) -> list[int]:
+    """Return a tensor parameter's static shape as plain ints."""
+    param_type = param.type
+    assert isinstance(param_type, pypto.ir.TensorType), (
+        f"expected a tensor parameter, got {type(param_type).__name__}"
+    )
+    dims = []
+    for dim in param_type.shape:
+        assert isinstance(dim, pypto.ir.ConstInt), f"dynamic dim: {type(dim).__name__}"
+        dims.append(dim.value)
+    return dims
+
+
+def _find_for_stmt(func: pypto.ir.Function) -> pypto.ir.ForStmt:
+    """Extract the first top-level ForStmt from a function body."""
+    for stmt in _top_level_stmts(func.body):
+        if isinstance(stmt, pypto.ir.ForStmt):
+            return stmt
+    raise AssertionError("No ForStmt found in function body")
+
+
+def _find_if_stmt(body: pypto.ir.Stmt) -> pypto.ir.IfStmt:
+    """Extract the first top-level IfStmt from a body."""
+    for stmt in _top_level_stmts(body):
+        if isinstance(stmt, pypto.ir.IfStmt):
+            return stmt
+    raise AssertionError("No IfStmt found in body")
+
+
 class TestErrorCases:
     """Tests for parser error handling and validation."""
 
@@ -43,8 +82,10 @@ class TestErrorCases:
             result: pl.Tensor[[64], pl.FP32] = pl.mul(x, 2.0)
             return result
 
-        # Should still parse successfully
-        assert isinstance(no_return_type, pypto.ir.Function)
+        # Parses successfully, and the body is preserved
+        assert _stmt_kinds(no_return_type.body) == [pypto.ir.AssignStmt, pypto.ir.ReturnStmt]
+        # With no annotation the function declares no return type
+        assert no_return_type.return_types == []
 
     def test_undefined_variable_reference(self):
         """Test error when referencing undefined variable."""
@@ -168,7 +209,16 @@ class TestSSAValidation:
             # Can return result because it was yielded from loop
             return result
 
-        assert isinstance(scope_test, pypto.ir.Function)
+        # The yielded value escapes the loop as its return var, and that is
+        # exactly what the function returns.
+        for_stmt = _find_for_stmt(scope_test)
+        assert len(for_stmt.return_vars) == 1
+        return_stmt = _top_level_stmts(scope_test.body)[-1]
+        assert isinstance(return_stmt, pypto.ir.ReturnStmt)
+        # Compare by identity: ``Expr.__eq__`` builds an IR ``Eq`` node, so ``==``
+        # on Expr lists reports equality even for distinct nodes.
+        assert len(return_stmt.value) == 1
+        assert return_stmt.value[0] is for_stmt.return_vars[0]
 
 
 class TestEdgeCases:
@@ -181,7 +231,12 @@ class TestEdgeCases:
         def minimal(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
             return x
 
-        assert isinstance(minimal, pypto.ir.Function)
+        # A bare `return x` body is a single ReturnStmt handing back the parameter
+        assert _stmt_kinds(minimal.body) == [pypto.ir.ReturnStmt]
+        return_stmt = minimal.body
+        assert isinstance(return_stmt, pypto.ir.ReturnStmt)
+        assert len(return_stmt.value) == 1
+        assert return_stmt.value[0] is minimal.params[0]
 
     def test_single_dimension_tensor(self):
         """Test tensor with single dimension."""
@@ -191,7 +246,8 @@ class TestEdgeCases:
             result: pl.Tensor[[128], pl.FP32] = pl.mul(x, 2.0)
             return result
 
-        assert isinstance(single_dim, pypto.ir.Function)
+        assert _shape_of(single_dim.params[0]) == [128]
+        assert _stmt_kinds(single_dim.body) == [pypto.ir.AssignStmt, pypto.ir.ReturnStmt]
 
     def test_three_dimension_tensor(self):
         """Test tensor with three dimensions."""
@@ -202,7 +258,8 @@ class TestEdgeCases:
         ) -> pl.Tensor[[64, 128, 256], pl.FP32]:
             return x
 
-        assert isinstance(three_dim, pypto.ir.Function)
+        assert _shape_of(three_dim.params[0]) == [64, 128, 256]
+        assert _stmt_kinds(three_dim.body) == [pypto.ir.ReturnStmt]
 
     def test_loop_with_range_one(self):
         """Test loop that executes only once."""
@@ -214,7 +271,11 @@ class TestEdgeCases:
 
             return result
 
-        assert isinstance(one_iteration, pypto.ir.Function)
+        # pl.range(1) means start=0, stop=1, step=1 — a single iteration
+        for_stmt = _find_for_stmt(one_iteration)
+        assert isinstance(for_stmt.start, pypto.ir.ConstInt) and for_stmt.start.value == 0
+        assert isinstance(for_stmt.stop, pypto.ir.ConstInt) and for_stmt.stop.value == 1
+        assert isinstance(for_stmt.step, pypto.ir.ConstInt) and for_stmt.step.value == 1
 
     def test_loop_with_start_stop_step(self):
         """Test loop with start, stop, and step parameters."""
@@ -227,7 +288,11 @@ class TestEdgeCases:
 
             return result
 
-        assert isinstance(custom_range, pypto.ir.Function)
+        # pl.range(2, 10, 2) must keep all three bounds distinct
+        for_stmt = _find_for_stmt(custom_range)
+        assert isinstance(for_stmt.start, pypto.ir.ConstInt) and for_stmt.start.value == 2
+        assert isinstance(for_stmt.stop, pypto.ir.ConstInt) and for_stmt.stop.value == 10
+        assert isinstance(for_stmt.step, pypto.ir.ConstInt) and for_stmt.step.value == 2
 
     def test_function_with_many_variables(self):
         """Test function with many local variables."""
@@ -246,7 +311,8 @@ class TestEdgeCases:
             v10: pl.Tensor[[64], pl.FP32] = pl.add(v9, 10.0)
             return v10
 
-        assert isinstance(many_vars, pypto.ir.Function)
+        # All ten bindings survive as distinct statements — none collapsed or dropped
+        assert _stmt_kinds(many_vars.body) == [pypto.ir.AssignStmt] * 10 + [pypto.ir.ReturnStmt]
 
     def test_different_shape_tensors(self):
         """Test function with tensors of different shapes."""
@@ -293,7 +359,16 @@ class TestAnnotationConsistency:
             result: pl.Tensor[[64], pl.FP32] = pl.tile.store(x_tile, [0], output_tensor=x)
             return result
 
-        assert isinstance(correct, pypto.ir.Function)
+        # The matching annotations are adopted as the bound variables' types:
+        # tile.load yields a Tile, tile.store yields a Tensor.
+        load_stmt, store_stmt = _top_level_stmts(correct.body)[:2]
+        assert isinstance(load_stmt, pypto.ir.AssignStmt)
+        assert isinstance(load_stmt.var.type, pypto.ir.TileType)
+        assert load_stmt.var.type.dtype == pl.FP32
+
+        assert isinstance(store_stmt, pypto.ir.AssignStmt)
+        assert isinstance(store_stmt.var.type, pypto.ir.TensorType)
+        assert store_stmt.var.type.dtype == pl.FP32
 
 
 class TestScalarTypeErrors:
@@ -344,7 +419,11 @@ class TestConditionMustBeBool:
                 result: pl.Tensor[[64], pl.FP32] = x
             return result
 
-        assert isinstance(ok_if, pypto.ir.Function)
+        # `True` is accepted and preserved as a BOOL constant condition
+        if_stmt = _find_if_stmt(ok_if.body)
+        assert isinstance(if_stmt.condition, pypto.ir.ConstBool)
+        assert if_stmt.condition.value is True
+        assert if_stmt.else_body is not None
 
     def test_if_with_comparison_accepted(self):
         """Test that comparison condition (BOOL-typed) is accepted."""
@@ -361,7 +440,12 @@ class TestConditionMustBeBool:
                 result = pl.yield_(val)
             return result
 
-        assert isinstance(ok_cmp, pypto.ir.Function)
+        # `i > 0` is BOOL-typed and reaches the IR as a Gt comparison
+        for_stmt = _find_for_stmt(ok_cmp)
+        if_stmt = _find_if_stmt(for_stmt.body)
+        assert isinstance(if_stmt.condition, pypto.ir.Gt)
+        assert if_stmt.condition.left is for_stmt.loop_var
+        assert if_stmt.else_body is not None
 
     def test_pl_cond_with_int_literal_rejected(self):
         """Test that `pl.cond(1)` inside `pl.while_()` is rejected (same check as natural while)."""

--- a/tests/ut/language/parser/test_error_wrapping.py
+++ b/tests/ut/language/parser/test_error_wrapping.py
@@ -17,6 +17,7 @@ tracebacks.
 
 import pypto.language as pl
 import pytest
+from pypto import ir
 from pypto.language.parser.diagnostics import (
     InvalidOperationError,
     ParserError,
@@ -159,7 +160,12 @@ class TestTypeMismatchReassignment:
             t = pl.mul(t, 2.0)  # same type, should succeed
             return t
 
-        assert func is not None
+        # Both bindings survive, and the rebinding keeps the original type
+        body = func.body
+        assert isinstance(body, ir.SeqStmts)
+        create_stmt, mul_stmt = (s for s in body.stmts if isinstance(s, ir.AssignStmt))
+        assert isinstance(create_stmt.var.type, ir.TensorType)
+        assert ir.structural_equal(mul_stmt.var.type, create_stmt.var.type)
 
     def test_reassign_different_shape_raises(self):
         """Reassigning with a different tensor shape raises ParserTypeError."""

--- a/tests/ut/language/parser/test_flash_attention.py
+++ b/tests/ut/language/parser/test_flash_attention.py
@@ -15,6 +15,29 @@ import pytest
 from pypto import ir
 
 
+def _top_level_stmts(body: ir.Stmt) -> list[ir.Stmt]:
+    """Return a body's statement list, treating a bare Stmt as a 1-element body."""
+    return list(body.stmts) if isinstance(body, ir.SeqStmts) else [body]
+
+
+def _op_names(func: ir.Function) -> list[str]:
+    """Return the operator name of every top-level Call binding, in order."""
+    names = []
+    for stmt in _top_level_stmts(func.body):
+        if isinstance(stmt, ir.AssignStmt) and isinstance(stmt.value, ir.Call):
+            names.append(stmt.value.op.name)
+    return names
+
+
+def _static_shape(type_: "ir.TensorType | ir.TileType") -> list[int]:
+    """Return a Tensor/Tile type's static shape as plain ints."""
+    dims = []
+    for dim in type_.shape:
+        assert isinstance(dim, ir.ConstInt), f"expected a static dim, got {type(dim).__name__}"
+        dims.append(dim.value)
+    return dims
+
+
 @pl.function
 def flash_attn(
     q_13: pl.Tensor[[64, 128], pl.FP16],
@@ -182,7 +205,15 @@ class TestFlashAttention:
 
             return attn_out
 
-        assert isinstance(multi_iter_attn, ir.Function)
+        # Both accumulators survive as separate carries with their own shapes
+        for_stmt = next(s for s in _top_level_stmts(multi_iter_attn.body) if isinstance(s, ir.ForStmt))
+        assert len(for_stmt.iter_args) == 2
+        assert len(for_stmt.return_vars) == 2
+        attn_arg, scale_arg = for_stmt.iter_args
+        assert isinstance(attn_arg.type, ir.TensorType)
+        assert _static_shape(attn_arg.type) == [64, 128]
+        assert isinstance(scale_arg.type, ir.TensorType)
+        assert _static_shape(scale_arg.type) == [64, 1]
 
     def test_flash_attention_ops(self):
         """Test individual operations used in flash attention."""
@@ -214,7 +245,19 @@ class TestFlashAttention:
 
             return result
 
-        assert isinstance(test_ops, ir.Function)
+        # Every op in the flash-attention chain lowered, in source order
+        assert _op_names(test_ops) == [
+            ir.get_op(name).name
+            for name in (
+                "tensor.cast",
+                "tensor.muls",
+                "tensor.row_max",
+                "tensor.sub",
+                "tensor.exp",
+                "tensor.row_sum",
+                "tensor.div",
+            )
+        ]
 
 
 class TestParserRobustness:
@@ -229,7 +272,9 @@ class TestParserRobustness:
         ) -> pl.Tensor[[1024, 2048, 512], pl.FP32]:
             return x
 
-        assert isinstance(large_shapes, ir.Function)
+        param_type = large_shapes.params[0].type
+        assert isinstance(param_type, ir.TensorType)
+        assert _static_shape(param_type) == [1024, 2048, 512]
 
     def test_many_parameters(self):
         """Test function with many parameters."""
@@ -275,7 +320,13 @@ class TestParserRobustness:
 
             return ir_out
 
-        assert isinstance(deep_nesting, ir.Function)
+        # The four nesting levels (for > for > if > if) all survive parsing
+        outer_for = next(s for s in _top_level_stmts(deep_nesting.body) if isinstance(s, ir.ForStmt))
+        inner_for = next(s for s in _top_level_stmts(outer_for.body) if isinstance(s, ir.ForStmt))
+        outer_if = next(s for s in _top_level_stmts(inner_for.body) if isinstance(s, ir.IfStmt))
+        inner_if = next(s for s in _top_level_stmts(outer_if.then_body) if isinstance(s, ir.IfStmt))
+        assert outer_if.else_body is not None
+        assert inner_if.else_body is not None
 
     def test_long_function(self):
         """Test function with many statements."""
@@ -294,7 +345,8 @@ class TestParserRobustness:
             v10: pl.Tensor[[64], pl.FP32] = pl.add(v9, 1.0)
             return v10
 
-        assert isinstance(long_function, ir.Function)
+        # All ten statements survive — none merged or dropped
+        assert _op_names(long_function) == [ir.get_op("tensor.adds").name] * 10
 
 
 if __name__ == "__main__":

--- a/tests/ut/language/parser/test_op_validation.py
+++ b/tests/ut/language/parser/test_op_validation.py
@@ -123,6 +123,11 @@ class TestDirectWrapperCallsStillWork:
         s2 = Scalar(expr=_ir.ConstInt(4, DataType.INT32, _ir.Span.unknown()))
         result = pl.add(s1, s2)
         assert isinstance(result, Scalar)
+        # Lowered through Scalar.__add__ to an IR Add over the two constants
+        expr = result.expr
+        assert isinstance(expr, _ir.Add)
+        assert isinstance(expr.left, _ir.ConstInt) and expr.left.value == 3
+        assert isinstance(expr.right, _ir.ConstInt) and expr.right.value == 4
 
 
 class TestFullPythonCallingConvention:

--- a/tests/ut/language/parser/test_printer_integration.py
+++ b/tests/ut/language/parser/test_printer_integration.py
@@ -331,8 +331,6 @@ class TestWhileLoopRoundTrip:
                 x = x + 1
             return x
 
-        # Verify key structural elements
-        assert isinstance(original, ir.Function)
         # Find the while statement
         body = original.body
         while_stmt = None
@@ -346,8 +344,14 @@ class TestWhileLoopRoundTrip:
 
         assert while_stmt is not None
         # Natural syntax has no iter_args initially (ConvertToSSA adds them)
+        assert len(while_stmt.iter_args) == 0
         # Condition should be a comparison
         assert isinstance(while_stmt.condition, ir.Lt)
+
+        # The structure must survive a print -> reparse round trip unchanged
+        reparsed = pl.parse(original.as_python())
+        assert isinstance(reparsed, ir.Function)
+        ir.assert_structural_equal(reparsed, original)
 
     def test_while_with_tensor_operations_round_trip(self):
         """Test while loop with tensor operations."""

--- a/tests/ut/language/parser/test_scope_parsing.py
+++ b/tests/ut/language/parser/test_scope_parsing.py
@@ -1606,6 +1606,9 @@ class TestSpmdInlineWithForm:
             if isinstance(s.value, ir.Call) and s.value.op.name == "system.task_invalid"
         ]
         assert not placeholders, "plain inline form must not emit a task_invalid placeholder"
+        # ...but the scope itself must still be there — an empty body would also
+        # trivially have no placeholders.
+        assert _descendants(main_func.body, ir.SpmdScopeStmt)
 
     def test_inline_with_spmd_split_wraps_incore_with_split(self):
         """``optimizations=[pl.split(...)]`` on the inline plain form sets split_ on the

--- a/tests/ut/language/parser/test_span_tracker.py
+++ b/tests/ut/language/parser/test_span_tracker.py
@@ -54,8 +54,11 @@ class TestSpanTracker:
 
         span = tracker.get_span(None)
 
-        # Should return unknown span
+        # Should return the unknown span, not a span into "test.py"
         assert isinstance(span, ir.Span)
+        assert not span.is_valid()
+        assert span.filename == ""
+        assert span.begin_line == -1
 
     def test_get_multiline_span(self):
         """Test getting span covering multiple lines."""

--- a/tests/ut/language/parser/test_static_operations.py
+++ b/tests/ut/language/parser/test_static_operations.py
@@ -20,6 +20,13 @@ from pypto.language.parser.diagnostics import (
 )
 
 
+def _stmt_kinds(func: ir.Function) -> list[type]:
+    """Return the statement classes making up a function body, in order."""
+    body = func.body
+    stmts = list(body.stmts) if isinstance(body, ir.SeqStmts) else [body]
+    return [type(s) for s in stmts]
+
+
 class TestStaticPrint:
     """Tests for pl.static_print() parse-time printing."""
 
@@ -185,7 +192,8 @@ class TestStaticAssert:
             pl.static_assert(True)
             return x
 
-        assert isinstance(func, ir.Function)
+        # The assertion is consumed at parse time — it leaves no runtime statement
+        assert _stmt_kinds(func) == [ir.ReturnStmt]
 
     def test_static_assert_false_fails(self):
         """Test that static_assert(False) raises ParserError."""
@@ -215,7 +223,7 @@ class TestStaticAssert:
             pl.static_assert(1)
             return x
 
-        assert isinstance(func, ir.Function)
+        assert _stmt_kinds(func) == [ir.ReturnStmt]
 
     def test_static_assert_zero_int_fails(self):
         """Test that static_assert(0) fails."""
@@ -236,7 +244,8 @@ class TestStaticAssert:
             pl.static_assert(N > 32)
             return x
 
-        assert isinstance(func, ir.Function)
+        # `N > 32` was evaluated against the closure at parse time and dropped
+        assert _stmt_kinds(func) == [ir.ReturnStmt]
 
     def test_static_assert_closure_var_fails(self):
         """Test static_assert fails when closure variable condition is false."""
@@ -304,6 +313,8 @@ def func(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
 """
         func = pl.parse(code)
         assert isinstance(func, ir.Function)
+        # Same as the decorator path: evaluated at parse time, absent from the IR
+        assert _stmt_kinds(func) == [ir.ReturnStmt]
 
     def test_static_assert_via_text_parser_fails(self):
         """Test that static_assert failure works with pl.parse()."""

--- a/tests/ut/language/parser/test_submit_predicate.py
+++ b/tests/ut/language/parser/test_submit_predicate.py
@@ -257,7 +257,12 @@ def test_predicate_operand_without_tracked_producer_allowed():
     # ``rc_in`` is a function parameter, not a submit result — nothing to prove,
     # so the deps= contract check stays out of the way.
     prog = _program("rc_in[0, 0] > 0", deps_src="[]")
-    assert isinstance(_main_submits(prog)[1].predicate, ir.Gt)
+    predicate = _main_submits(prog)[1].predicate
+    assert isinstance(predicate, ir.Gt)
+    # The predicate still reads rc_in[0, 0] and compares against 0
+    assert _pred_read(predicate).op.name == ir.get_op("tensor.read").name
+    assert [c.value for c in _pred_indices(predicate)] == [0, 0]
+    assert _pred_const(predicate).value == 0
 
 
 def test_non_literal_target_rejected():
@@ -280,8 +285,10 @@ def test_predicate_must_be_a_comparison():
 
 def test_no_predicate_leaves_fields_default():
     prog = _program("rc[0, 0] > 0")
-    gate_sub = _main_submits(prog)[0]
+    gate_sub, expert_sub = _main_submits(prog)
+    # Only the submit that was given predicate= carries one
     assert gate_sub.predicate is None
+    assert isinstance(expert_sub.predicate, ir.Gt)
 
 
 def test_print_parse_round_trip():
@@ -315,7 +322,11 @@ def test_unsigned_and_subbyte_operand_rejected(dtype):
 @pytest.mark.parametrize("dtype", ["pl.INT8", "pl.INT16", "pl.INT32", "pl.INT64"])
 def test_signed_integer_operands_accepted(dtype):
     prog = _program("rc[0, 0] > 0", rc_dtype=dtype)
-    assert isinstance(_main_submits(prog)[1].predicate, ir.Gt)
+    predicate = _main_submits(prog)[1].predicate
+    assert isinstance(predicate, ir.Gt)
+    # Accepted for every signed width, with operand and target intact
+    assert [c.value for c in _pred_indices(predicate)] == [0, 0]
+    assert _pred_const(predicate).value == 0
 
 
 def test_negative_constant_index_rejected():
@@ -487,7 +498,10 @@ def test_scope_predicate_plain_with_form():
 """
     )
     (scope,) = _spmd_scopes(prog)
-    assert isinstance(dict(scope.attrs.items())["predicate"], ir.Gt)
+    predicate = dict(scope.attrs.items())["predicate"]
+    assert isinstance(predicate, ir.Gt)
+    assert [c.value for c in _pred_indices(predicate)] == [0, 0]
+    assert _pred_const(predicate).value == 0
 
 
 def test_scope_predicate_for_form():
@@ -506,7 +520,10 @@ def test_scope_predicate_for_form():
 """
     )
     (scope,) = _spmd_scopes(prog)
-    assert isinstance(dict(scope.attrs.items())["predicate"], ir.Gt)
+    predicate = dict(scope.attrs.items())["predicate"]
+    assert isinstance(predicate, ir.Gt)
+    assert [c.value for c in _pred_indices(predicate)] == [0, 0]
+    assert _pred_const(predicate).value == 0
 
 
 def test_scope_predicate_operand_producer_must_be_in_deps():

--- a/tests/ut/language/parser/test_subscript_syntax.py
+++ b/tests/ut/language/parser/test_subscript_syntax.py
@@ -425,7 +425,26 @@ class TestTupleSubscript:
                 acc_out: pl.Tensor[[1], pl.FP32] = pl.yield_(new_acc)
             return acc_out
 
-        assert isinstance(tuple_access, ir.Function)
+        # The `for i, (acc,)` unpacking still yields one loop var plus one carry,
+        # and the slice offset is the loop var itself.
+        body = tuple_access.body
+        assert isinstance(body, ir.SeqStmts)
+        for_stmt = next(s for s in body.stmts if isinstance(s, ir.ForStmt))
+        assert len(for_stmt.iter_args) == 1
+        assert len(for_stmt.return_vars) == 1
+
+        loop_body = for_stmt.body
+        assert isinstance(loop_body, ir.SeqStmts)
+        slice_call = next(
+            s.value for s in loop_body.stmts if isinstance(s, ir.AssignStmt) and isinstance(s.value, ir.Call)
+        )
+        assert slice_call.op.name == ir.get_op("tensor.slice").name
+        offsets = slice_call.args[2]
+        assert isinstance(offsets, ir.MakeTuple)
+        # Compare by identity: ``Expr.__eq__`` builds an IR ``Eq`` node, so ``==``
+        # on Expr lists reports equality even for distinct nodes.
+        assert len(offsets.elements) == 1
+        assert offsets.elements[0] is for_stmt.loop_var
 
 
 class TestTensorSubscriptWrite:

--- a/tests/ut/language/parser/test_tuple_syntax.py
+++ b/tests/ut/language/parser/test_tuple_syntax.py
@@ -34,7 +34,7 @@ def _assert_same_exprs(actual: Sequence[ir.Expr], expected: Sequence[ir.Expr]) -
     """
     actual, expected = list(actual), list(expected)
     assert len(actual) == len(expected), f"expected {len(expected)} elements, got {len(actual)}"
-    for i, (got, want) in enumerate(zip(actual, expected)):
+    for i, (got, want) in enumerate(zip(actual, expected, strict=True)):
         assert got is want, f"element {i}: {got} is not the expected {want}"
 
 
@@ -112,7 +112,7 @@ class TestTupleLiteralParsing:
         (binding,) = _assign_stmts(func)
         elements = list(_make_tuple(binding).elements)
         assert len(elements) == 3
-        for element, expected in zip(elements, (1, 2, 3)):
+        for element, expected in zip(elements, (1, 2, 3), strict=True):
             assert isinstance(element, ir.ConstInt)
             assert element.value == expected
 

--- a/tests/ut/language/parser/test_tuple_syntax.py
+++ b/tests/ut/language/parser/test_tuple_syntax.py
@@ -8,9 +8,70 @@
 # -----------------------------------------------------------------------------------------------------------
 """Tests for tuple literal and subscript syntax in parser."""
 
+from collections.abc import Sequence
+
 import pypto.language as pl
 import pytest
-from pypto import ir
+from pypto import DataType, ir
+
+
+def _assign_stmts(func: ir.Function) -> list[ir.AssignStmt]:
+    """Return the function body's top-level AssignStmts, in source order."""
+    body = func.body
+    stmts = list(body.stmts) if isinstance(body, ir.SeqStmts) else [body]
+    assigns = [s for s in stmts if isinstance(s, ir.AssignStmt)]
+    assert assigns, "expected at least one binding in the function body"
+    return assigns
+
+
+def _assert_same_exprs(actual: Sequence[ir.Expr], expected: Sequence[ir.Expr]) -> None:
+    """Assert two expression lists hold the same nodes, compared by identity.
+
+    ``Expr.__eq__`` is overloaded to build an IR ``Eq`` node rather than return a
+    bool, so ``actual == expected`` on lists of ``Expr`` reports equality even
+    when the elements differ (a truthy ``Eq`` node). Identity is what these tests
+    mean anyway: the parser must reuse the very same ``Var``, not a copy.
+    """
+    actual, expected = list(actual), list(expected)
+    assert len(actual) == len(expected), f"expected {len(expected)} elements, got {len(actual)}"
+    for i, (got, want) in enumerate(zip(actual, expected)):
+        assert got is want, f"element {i}: {got} is not the expected {want}"
+
+
+def _make_tuple(stmt: ir.AssignStmt) -> ir.MakeTuple:
+    """Assert a binding's RHS is a tuple literal and return it."""
+    value = stmt.value
+    assert isinstance(value, ir.MakeTuple), (
+        f"{stmt.var.name_hint} is {type(value).__name__}, expected MakeTuple"
+    )
+    return value
+
+
+def _get_item(stmt: ir.AssignStmt) -> ir.TupleGetItemExpr:
+    """Assert a binding's RHS is a tuple subscript and return it."""
+    value = stmt.value
+    assert isinstance(value, ir.TupleGetItemExpr), (
+        f"{stmt.var.name_hint} is {type(value).__name__}, expected TupleGetItemExpr"
+    )
+    return value
+
+
+def _scalar_dtype(stmt: ir.AssignStmt) -> DataType:
+    """Assert a binding's inferred type is a scalar and return its dtype."""
+    var_type = stmt.var.type
+    assert isinstance(var_type, ir.ScalarType), (
+        f"{stmt.var.name_hint} has type {type(var_type).__name__}, expected ScalarType"
+    )
+    return var_type.dtype
+
+
+def _tuple_type(stmt: ir.AssignStmt) -> ir.TupleType:
+    """Assert a binding's inferred type is a TupleType and return it."""
+    var_type = stmt.var.type
+    assert isinstance(var_type, ir.TupleType), (
+        f"{stmt.var.name_hint} has type {type(var_type).__name__}, expected TupleType"
+    )
+    return var_type
 
 
 class TestTupleLiteralParsing:
@@ -23,9 +84,9 @@ class TestTupleLiteralParsing:
         def func():
             _ = ()
 
-        # Verify function was created
-        assert func is not None
-        assert isinstance(func, ir.Function)
+        (binding,) = _assign_stmts(func)
+        assert len(_make_tuple(binding).elements) == 0
+        assert list(_tuple_type(binding).types) == []
 
     def test_parse_tuple_with_two_elements(self):
         """Test parsing tuple with two elements."""
@@ -34,8 +95,12 @@ class TestTupleLiteralParsing:
         def func(x: pl.Tensor[[10], pl.FP32], y: pl.Scalar[pl.INT64]):
             _ = (x, y)
 
-        assert func is not None
-        assert isinstance(func, ir.Function)
+        (binding,) = _assign_stmts(func)
+        # Elements are the parameters themselves, in order
+        _assert_same_exprs(_make_tuple(binding).elements, func.params)
+        element_types = list(_tuple_type(binding).types)
+        assert isinstance(element_types[0], ir.TensorType)
+        assert isinstance(element_types[1], ir.ScalarType)
 
     def test_parse_tuple_with_constants(self):
         """Test parsing tuple with constant values."""
@@ -44,8 +109,12 @@ class TestTupleLiteralParsing:
         def func():
             _ = (1, 2, 3)
 
-        assert func is not None
-        assert isinstance(func, ir.Function)
+        (binding,) = _assign_stmts(func)
+        elements = list(_make_tuple(binding).elements)
+        assert len(elements) == 3
+        for element, expected in zip(elements, (1, 2, 3)):
+            assert isinstance(element, ir.ConstInt)
+            assert element.value == expected
 
     def test_parse_nested_tuple(self):
         """Test parsing nested tuples."""
@@ -55,8 +124,14 @@ class TestTupleLiteralParsing:
             inner = (x, x)
             _ = (inner, x)
 
-        assert func is not None
-        assert isinstance(func, ir.Function)
+        inner_stmt, outer_stmt = _assign_stmts(func)
+        _assert_same_exprs(_make_tuple(inner_stmt).elements, [func.params[0], func.params[0]])
+
+        # The outer literal references the inner binding, not a re-spliced copy
+        outer_elements = list(_make_tuple(outer_stmt).elements)
+        _assert_same_exprs(outer_elements, [inner_stmt.var, func.params[0]])
+        # ...and the nesting shows up in the inferred type
+        assert isinstance(list(_tuple_type(outer_stmt).types)[0], ir.TupleType)
 
     def test_parse_singleton_tuple(self):
         """Test parsing single element tuple."""
@@ -65,8 +140,10 @@ class TestTupleLiteralParsing:
         def func(x: pl.Scalar[pl.INT64]):
             _ = (x,)
 
-        assert func is not None
-        assert isinstance(func, ir.Function)
+        (binding,) = _assign_stmts(func)
+        # A trailing comma must build a 1-tuple, not unwrap to the bare element
+        _assert_same_exprs(_make_tuple(binding).elements, [func.params[0]])
+        assert len(list(_tuple_type(binding).types)) == 1
 
 
 class TestTupleSubscriptParsing:
@@ -81,8 +158,19 @@ class TestTupleSubscriptParsing:
             _first = my_tuple[0]
             _second = my_tuple[1]
 
-        assert func is not None
-        assert isinstance(func, ir.Function)
+        tuple_stmt, first_stmt, second_stmt = _assign_stmts(func)
+
+        first = _get_item(first_stmt)
+        assert first.index == 0
+        assert first.tuple is tuple_stmt.var
+
+        second = _get_item(second_stmt)
+        assert second.index == 1
+        assert second.tuple is tuple_stmt.var
+
+        # Each projection carries the corresponding element type
+        assert _scalar_dtype(first_stmt) == pl.INT64
+        assert _scalar_dtype(second_stmt) == pl.FP32
 
     def test_parse_nested_subscript(self):
         """Test parsing nested tuple subscript."""
@@ -94,8 +182,21 @@ class TestTupleSubscriptParsing:
             _first = nested[0]
             _inner_second = nested[0][1]
 
-        assert func is not None
-        assert isinstance(func, ir.Function)
+        _, nested_stmt, first_stmt, inner_second_stmt = _assign_stmts(func)
+
+        # nested[0] projects the inner tuple, so its type is still a tuple
+        first = _get_item(first_stmt)
+        assert first.index == 0
+        assert first.tuple is nested_stmt.var
+        assert isinstance(first_stmt.var.type, ir.TupleType)
+
+        # nested[0][1] chains a second projection down to a scalar
+        inner_second = _get_item(inner_second_stmt)
+        assert inner_second.index == 1
+        inner_tuple = inner_second.tuple
+        assert isinstance(inner_tuple, ir.TupleGetItemExpr)
+        assert inner_tuple.index == 0
+        assert _scalar_dtype(inner_second_stmt) == pl.INT64
 
 
 class TestTupleRoundTrip:
@@ -110,8 +211,14 @@ class TestTupleRoundTrip:
             _first = my_tuple[0]
             _second = my_tuple[1]
 
-        assert func is not None
-        assert isinstance(func, ir.Function)
+        tuple_stmt, first_stmt, second_stmt = _assign_stmts(func)
+
+        # Round trip: what goes into the literal comes back out of the subscripts
+        _assert_same_exprs(_make_tuple(tuple_stmt).elements, func.params)
+        assert _get_item(first_stmt).index == 0
+        assert _get_item(second_stmt).index == 1
+        assert _scalar_dtype(first_stmt) == pl.INT64
+        assert _scalar_dtype(second_stmt) == pl.FP32
 
     def test_tuple_in_operations(self):
         """Test using tuple elements in operations."""
@@ -126,8 +233,14 @@ class TestTupleRoundTrip:
             _first = first
             _second = second
 
-        assert func is not None
-        assert isinstance(func, ir.Function)
+        stmts = _assign_stmts(func)
+        by_name = {s.var.name_hint: s for s in stmts}
+
+        assert _get_item(by_name["first"]).index == 0
+        assert _get_item(by_name["second"]).index == 1
+        # Re-binding a projected element forwards the same value, not a fresh read
+        assert by_name["_first"].value is by_name["first"].var
+        assert by_name["_second"].value is by_name["second"].var
 
 
 if __name__ == "__main__":

--- a/tests/ut/language/parser/test_type_resolver.py
+++ b/tests/ut/language/parser/test_type_resolver.py
@@ -45,6 +45,22 @@ _NON_DEFAULT_TILEVIEW_ANNOTATION = (
 )
 
 
+def _static_shape(type_: "ir.TensorType | ir.TileType") -> list[int]:
+    """Return a Tensor/Tile type's static shape as plain ints."""
+    dims = []
+    for dim in type_.shape:
+        assert isinstance(dim, ir.ConstInt), f"expected a static dim, got {type(dim).__name__}"
+        dims.append(dim.value)
+    return dims
+
+
+def _body_assigns(func: ir.Function) -> list[ir.AssignStmt]:
+    """Return the function body's top-level AssignStmts, in source order."""
+    body = func.body
+    stmts = list(body.stmts) if isinstance(body, ir.SeqStmts) else [body]
+    return [s for s in stmts if isinstance(s, ir.AssignStmt)]
+
+
 def _make_resolver(
     closure_vars: dict | None = None, scope_lookup: "Callable[[str], Any | None] | None" = None
 ) -> TypeResolver:
@@ -584,7 +600,12 @@ class TestDynamicShapeResolution:
         node = ast.parse("pl.Tile[[N, 64], pl.FP32]", mode="eval").body
         result = resolver.resolve_type(node)
         assert isinstance(result, ir.TileType)
+        # Dim 0 is the dynamic N; dim 1 stays the static 64
         assert isinstance(result.shape[0], ir.Var)
+        assert result.shape[0].name_hint == "N"
+        assert isinstance(result.shape[1], ir.ConstInt)
+        assert result.shape[1].value == 64
+        assert result.dtype == DataType.FP32
 
     # --- Error cases ---
 
@@ -1162,7 +1183,18 @@ class TestClosureVarsInFunctionBody:
             result: pl.Tensor[tensor_shape, dtype] = pl.tile.store(a, offsets=[0, 0], output_tensor=out)
             return result
 
-        assert isinstance(func, ir.Function)
+        # Closure shape/dtype flow into both the params and the in-body annotations
+        for param in func.params:
+            assert isinstance(param.type, ir.TensorType)
+            assert _static_shape(param.type) == [128, 128]
+            assert param.type.dtype == DataType.FP32
+
+        tile_stmt, store_stmt = _body_assigns(func)
+        assert isinstance(tile_stmt.var.type, ir.TileType)
+        assert _static_shape(tile_stmt.var.type) == [64, 64]
+        assert tile_stmt.var.type.dtype == DataType.FP32
+        assert isinstance(store_stmt.var.type, ir.TensorType)
+        assert _static_shape(store_stmt.var.type) == [128, 128]
 
     def test_shapes_kwarg_from_variable(self):
         """User passes shapes= kwarg as a closure variable (t.py pattern)."""
@@ -1176,7 +1208,10 @@ class TestClosureVarsInFunctionBody:
             result: pl.Tensor[[128, 128], pl.FP32] = pl.tile.store(a, offsets=[0, 0], output_tensor=out)
             return result
 
-        assert isinstance(func, ir.Function)
+        # The shapes= kwarg resolved to the closure's [32, 32], sizing the loaded tile
+        tile_stmt = _body_assigns(func)[0]
+        assert isinstance(tile_stmt.var.type, ir.TileType)
+        assert _static_shape(tile_stmt.var.type) == [32, 32]
 
     def test_int_kwarg_from_closure(self):
         """User passes an int kwarg (like axis) from closure."""
@@ -1189,7 +1224,12 @@ class TestClosureVarsInFunctionBody:
             result: pl.Tensor[[128, 64], pl.FP32] = pl.transpose(x, axis1=0, axis2=swap_axis)
             return result
 
-        assert isinstance(func, ir.Function)
+        # axis2 picked up the closure's 1, not a default or axis1's 0
+        call = _body_assigns(func)[0].value
+        assert isinstance(call, ir.Call)
+        axis2 = call.args[2]
+        assert isinstance(axis2, ir.ConstInt)
+        assert axis2.value == 1
 
     def test_dtype_kwarg_from_closure(self):
         """User passes dtype= kwarg from closure variable."""
@@ -1200,7 +1240,13 @@ class TestClosureVarsInFunctionBody:
             result: pl.Tensor[[64, 64], pl.FP16] = pl.cast(x, target_type=out_dtype)
             return result
 
-        assert isinstance(func, ir.Function)
+        # The dtype= closure var drove the cast's result type to FP16
+        cast_stmt = _body_assigns(func)[0]
+        assert isinstance(cast_stmt.var.type, ir.TensorType)
+        assert cast_stmt.var.type.dtype == DataType.FP16
+        param_type = func.params[0].type
+        assert isinstance(param_type, ir.TensorType)
+        assert param_type.dtype == DataType.FP32
 
     def test_full_parametrized_kernel(self):
         """Realistic pattern: fully parametrized kernel (the t.py use case)."""
@@ -1238,7 +1284,19 @@ class TestClosureVarsInFunctionBody:
                 result: pl.Tensor[shape, dtype] = pl.tile.store(a, offsets=[0, 0], output_tensor=out)
                 return result
 
-        assert isinstance(Prog, ir.Program)
+        # Closure shapes resolve the same way inside @pl.program methods
+        compute = Prog.get_function("compute")
+        assert compute is not None
+
+        tensor_types = [p.type for p in compute.params if isinstance(p.type, ir.TensorType)]
+        assert len(tensor_types) == 2
+        for tensor_type in tensor_types:
+            assert _static_shape(tensor_type) == [128, 128]
+            assert tensor_type.dtype == DataType.FP32
+
+        tile_stmt = _body_assigns(compute)[0]
+        assert isinstance(tile_stmt.var.type, ir.TileType)
+        assert _static_shape(tile_stmt.var.type) == [64, 64]
 
 
 class TestDynamicShapeEdgeCases:
@@ -1327,7 +1385,11 @@ class TestDynamicShapeEdgeCases:
             result: pl.Tensor[[128, 128], pl.FP32] = pl.tile.store(a, offsets=[0, 0], output_tensor=out)
             return result
 
-        assert isinstance(func, ir.Function)
+        # The variable-as-shape annotation sized the tile to [32, 32]
+        tile_stmt = _body_assigns(func)[0]
+        assert isinstance(tile_stmt.var.type, ir.TileType)
+        assert _static_shape(tile_stmt.var.type) == [32, 32]
+        assert tile_stmt.var.type.dtype == DataType.FP32
 
     def test_shape_variable_not_defined_raises_error(self):
         """User typos variable name — should get a clear error."""
@@ -1457,6 +1519,9 @@ class TestLayoutResolution:
 
         assert isinstance(result, ir.TensorType)
         assert result.tensor_view is None
+        # Omitting the layout must not disturb the shape or dtype
+        assert _static_shape(result) == [64, 128]
+        assert result.dtype == DataType.FP16
 
     def test_resolve_tensor_layout_invalid(self):
         """Invalid layout raises ParserTypeError."""
@@ -1752,7 +1817,10 @@ class TestTensorViewResolution:
         result = resolver.resolve_type(node)
 
         assert isinstance(result, ir.TensorType)
+        # An all-default TensorView canonicalizes away entirely
         assert result.tensor_view is None
+        assert _static_shape(result) == [64, 128]
+        assert result.dtype == DataType.FP32
 
     def test_resolve_tensor_with_tensorview_valid_shape(self):
         """TensorView with valid_shape creates correct tensor_view."""
@@ -1921,8 +1989,16 @@ class TestTensorViewResolution:
         result = resolver.resolve_type(node)
 
         assert isinstance(result, ir.TensorType)
+        # The all-default TensorView canonicalizes away, but the MemRef survives
         assert result.tensor_view is None
         assert result.memref is not None
+        # byte_offset_ is a ConstInt Expr, so `== 0` would build a truthy Eq node
+        # rather than compare -- read through .value.
+        assert isinstance(result.memref.byte_offset_, ir.ConstInt)
+        assert result.memref.byte_offset_.value == 0
+        assert result.memref.size_ == 256  # a plain int, so `==` is a real compare
+        assert _static_shape(result) == [64, 128]
+        assert result.dtype == DataType.FP32
 
 
 class TestTensorViewIntegration:


### PR DESCRIPTION
## Summary

Replaces unit-test assertions that **could not fail** with ones that pin the behaviour each test's name and docstring already claim. 19 test files; **no production code changed**.

**Arith simplifier** (`tests/ut/ir/arith/`, 31 tests) — these asserted only the top-level node class, so a rule rewriting to the wrong operands still passed:

```python
# before — passes even if the rule produces min(y, x + z)
def test_min_sub_add(self):
    """min(x - z, y) + z => min(x, y + z)"""
    result = simplifier(ir.Add(ir.Min(ir.Sub(x, z, INT, S), y, INT, S), z, INT, S))
    assert isinstance(result, ir.Min)

# after — pins the documented rewrite
    ir.assert_structural_equal(result, ir.Min(x, ir.Add(y, z, INT, S), INT, S))
```

Dormant-rule tests (e.g. `floordiv(x, x)` in standalone mode) now assert the expression came back *structurally untouched*, not merely that it is still a `FloorDiv`.

**DSL parser** (`tests/ut/language/parser/`, 86 tests) — the pattern was `@pl.function` followed by `assert isinstance(f, ir.Function)`, a tautology since the decorator either returns an `ir.Function` or raises:

```python
# before
    assert isinstance(range_params, ir.Function)

# after
    for_stmt = _find_for_stmt(range_params)
    _assert_range(for_stmt, start=0, stop=10, step=2)
    assert len(for_stmt.iter_args) == 1
```

Now asserted: loop bounds and `ForKind`, iter-arg/return-var counts, body statement sequences, resolved closure-var constants (`ConstInt`/`ConstFloat`/`ConstBool`/nested `MakeTuple`), tuple `MakeTuple`/`TupleGetItemExpr` structure, and that `pl.static_assert` leaves no runtime statement.

## Two traps worth knowing about

- **`Expr.__eq__` is overloaded** to build an IR `Eq` node rather than return a bool, so `list(elements) == [expected_var]` reports equality *even for distinct nodes* (`[a] == [b]` is `True`), and raises a confusing `TypeError` for Tensor-typed operands. Expression operands are compared by identity instead. The same trap applies to `ConstInt`-valued fields, so `MemRef.byte_offset_` is read through `.value`.
- **`test_while_structural_equality_after_print` never printed or re-parsed** despite its name — it only checked the condition was `Lt`. It now performs the round trip it claims.

## Testing

- [x] Simplifier output was compared against each docstring's documented rewrite **before** pinning it — all matched, so no behaviour is being retro-fitted to match the implementation.
- [x] Mutation-checked that the new assertions actually fail: swapped operands (`min(x, y+z)` → `min(y, x+z)`), wrong loop step (`step=2` → `1`), and reversed tuple elements each produce a clean failure. All passed under the old `isinstance` checks.
- [x] Full unit suite: **8088 passed, 2 skipped**. The one failure, `test_benchmark_l3_ignores_prepare_setup_groups`, is pre-existing on `main` (a test double's `prepare()` lacks the `persistent`/`reset_persistent_windows` kwargs `bench.py` passes) — confirmed by reproducing it with these changes stashed.
- [x] `pre-commit run --files <changed>`: all hooks pass (ruff check, ruff format, pyright, headers, english-only).

## Note on style

Per-file private helpers are duplicated across parser test files rather than extracted to a shared module, matching this repo's existing self-contained-test-file convention (`_find_for_stmt` and `assert_is_const_int` were already duplicated before this change). Happy to extract them into a shared `tests/ut/language/parser/` helper module if reviewers would prefer that instead.