### PR TITLE
fix(parser): accept a TensorView bound to a variable in a tensor annotation

### DIFF
--- a/docs/en/dev/language/00-python_syntax.md
+++ b/docs/en/dev/language/00-python_syntax.md
@@ -54,24 +54,17 @@ t: pl.Tile[[16, 16], pl.FP16]
 
 ### Tensor Layout and View
 
-A third subscript element describes how the tensor is laid out — either a layout
-constant or a full `pl.TensorView`. Either may be written inline or bound to a
-variable in enclosing Python, which is how one view is shared across several
-parameters without repeating it:
+The third subscript element is a layout or a `pl.TensorView`, each written inline or
+held in a variable — bind it once to share one view across several parameters. A
+layout is shorthand for a stride-less view, so every form yields a `TensorView`.
+Same slot and spellings for `pl.DistributedTensor`.
 
 ```python
-MY_LAYOUT = pl.TensorLayout.NZ
 STRIDED = pl.TensorView(stride=[128, 1], layout=pl.TensorLayout.ND)
 
-a: pl.Tensor[[32, 64], pl.FP32, pl.NZ]        # layout, inline
-b: pl.Tensor[[32, 64], pl.FP32, MY_LAYOUT]    # layout, by variable
-c: pl.Tensor[[32, 64], pl.FP32, pl.TensorView(stride=[128, 1], layout=pl.TensorLayout.ND)]
-d: pl.Tensor[[32, 64], pl.FP32, STRIDED]      # view, by variable — same as c
+x: pl.Tensor[[32, 64], pl.FP32, pl.NZ]      # layout, inline
+y: pl.Tensor[[32, 64], pl.FP32, STRIDED]    # view, by variable
 ```
-
-A layout constant is shorthand for a stride-less view carrying that layout, so
-all four forms resolve to a `TensorView` on the resulting `TensorType`. The same
-slot and the same four spellings apply to `pl.DistributedTensor`.
 
 ### Memory References (MemRef)
 

--- a/docs/en/dev/language/00-python_syntax.md
+++ b/docs/en/dev/language/00-python_syntax.md
@@ -52,6 +52,27 @@ b: pl.Tensor[[n, m], pl.INT64]     # Symbolic shape
 t: pl.Tile[[16, 16], pl.FP16]
 ```
 
+### Tensor Layout and View
+
+A third subscript element describes how the tensor is laid out — either a layout
+constant or a full `pl.TensorView`. Either may be written inline or bound to a
+variable in enclosing Python, which is how one view is shared across several
+parameters without repeating it:
+
+```python
+MY_LAYOUT = pl.TensorLayout.NZ
+STRIDED = pl.TensorView(stride=[128, 1], layout=pl.TensorLayout.ND)
+
+a: pl.Tensor[[32, 64], pl.FP32, pl.NZ]        # layout, inline
+b: pl.Tensor[[32, 64], pl.FP32, MY_LAYOUT]    # layout, by variable
+c: pl.Tensor[[32, 64], pl.FP32, pl.TensorView(stride=[128, 1], layout=pl.TensorLayout.ND)]
+d: pl.Tensor[[32, 64], pl.FP32, STRIDED]      # view, by variable — same as c
+```
+
+A layout constant is shorthand for a stride-less view carrying that layout, so
+all four forms resolve to a `TensorView` on the resulting `TensorType`. The same
+slot and the same four spellings apply to `pl.DistributedTensor`.
+
 ### Memory References (MemRef)
 
 ```python

--- a/docs/zh/dev/language/00-python_syntax.md
+++ b/docs/zh/dev/language/00-python_syntax.md
@@ -52,6 +52,26 @@ b: pl.Tensor[[n, m], pl.INT64]     # Symbolic shape
 t: pl.Tile[[16, 16], pl.FP16]
 ```
 
+### 张量布局 (Layout) 和视图 (TensorView)
+
+下标的第三个元素描述张量的排布方式——既可以是布局 (layout) 常量，也可以是完整的
+`pl.TensorView`。两者都既能内联书写，也能绑定到外层 Python 的变量上；后者正是在多个
+参数间共享同一视图而无需重复书写的方式：
+
+```python
+MY_LAYOUT = pl.TensorLayout.NZ
+STRIDED = pl.TensorView(stride=[128, 1], layout=pl.TensorLayout.ND)
+
+a: pl.Tensor[[32, 64], pl.FP32, pl.NZ]        # 布局，内联
+b: pl.Tensor[[32, 64], pl.FP32, MY_LAYOUT]    # 布局，通过变量
+c: pl.Tensor[[32, 64], pl.FP32, pl.TensorView(stride=[128, 1], layout=pl.TensorLayout.ND)]
+d: pl.Tensor[[32, 64], pl.FP32, STRIDED]      # 视图，通过变量——与 c 等价
+```
+
+布局常量是"携带该布局的无 stride 视图"的简写，因此上述四种形式最终都会在生成的
+`TensorType` 上解析为一个 `TensorView`。同样的下标位置与四种写法也适用于
+`pl.DistributedTensor`。
+
 ### 内存引用 (MemRef)
 
 ```python

--- a/docs/zh/dev/language/00-python_syntax.md
+++ b/docs/zh/dev/language/00-python_syntax.md
@@ -54,23 +54,16 @@ t: pl.Tile[[16, 16], pl.FP16]
 
 ### 张量布局 (Layout) 和视图 (TensorView)
 
-下标的第三个元素描述张量的排布方式——既可以是布局 (layout) 常量，也可以是完整的
-`pl.TensorView`。两者都既能内联书写，也能绑定到外层 Python 的变量上；后者正是在多个
-参数间共享同一视图而无需重复书写的方式：
+下标第三个元素是布局 (layout) 或 `pl.TensorView`，两者均可内联书写或绑定到变量——
+绑定一次即可在多个参数间共享同一视图。布局是"无 stride 视图"的简写，因此各种写法
+最终都会解析为一个 `TensorView`。`pl.DistributedTensor` 的下标位置与写法相同。
 
 ```python
-MY_LAYOUT = pl.TensorLayout.NZ
 STRIDED = pl.TensorView(stride=[128, 1], layout=pl.TensorLayout.ND)
 
-a: pl.Tensor[[32, 64], pl.FP32, pl.NZ]        # 布局，内联
-b: pl.Tensor[[32, 64], pl.FP32, MY_LAYOUT]    # 布局，通过变量
-c: pl.Tensor[[32, 64], pl.FP32, pl.TensorView(stride=[128, 1], layout=pl.TensorLayout.ND)]
-d: pl.Tensor[[32, 64], pl.FP32, STRIDED]      # 视图，通过变量——与 c 等价
+x: pl.Tensor[[32, 64], pl.FP32, pl.NZ]      # 布局，内联
+y: pl.Tensor[[32, 64], pl.FP32, STRIDED]    # 视图，通过变量
 ```
-
-布局常量是"携带该布局的无 stride 视图"的简写，因此上述四种形式最终都会在生成的
-`TensorType` 上解析为一个 `TensorView`。同样的下标位置与四种写法也适用于
-`pl.DistributedTensor`。
 
 ### 内存引用 (MemRef)
 

--- a/python/pypto/language/parser/type_resolver.py
+++ b/python/pypto/language/parser/type_resolver.py
@@ -1470,6 +1470,11 @@ class TypeResolver:
         """
         if not isinstance(node, ast.Name):
             return None
+        # A bare layout name resolves as a layout, and did so before views were
+        # reachable by name — so keep that precedence and skip the evaluation,
+        # which is the expensive half of resolving this slot.
+        if node.id in self._LAYOUT_MAP:
+            return None
         success, value = self.expr_evaluator.try_eval_expr(node)
         if success and isinstance(value, ir.TensorView):
             return value

--- a/python/pypto/language/parser/type_resolver.py
+++ b/python/pypto/language/parser/type_resolver.py
@@ -506,22 +506,10 @@ class TypeResolver:
             if self._is_memref_node(third):
                 memref = self.resolve_memref(third)
                 return tensor_ctor(shape, dtype, memref, None)
-            if self._is_tensorview_node(third):
-                tensor_view = self._resolve_tensorview(third)
-                return tensor_ctor(shape, dtype, None, tensor_view)
-            layout = self.resolve_layout(third)
-            self._warn_on_user_facing_dn_layout(layout, type_name)
-            tensor_view = ir.TensorView([], layout)
-            return tensor_ctor(shape, dtype, None, tensor_view)
+            return tensor_ctor(shape, dtype, None, self._resolve_tensor_view_slot(third, type_name))
 
         # Tensor / DistributedTensor 4 args: [shape, dtype, layout_or_tensorview, memref]
-        third = slice_value.elts[2]
-        if self._is_tensorview_node(third):
-            tensor_view = self._resolve_tensorview(third)
-        else:
-            layout = self.resolve_layout(third)
-            self._warn_on_user_facing_dn_layout(layout, type_name)
-            tensor_view = ir.TensorView([], layout)
+        tensor_view = self._resolve_tensor_view_slot(slice_value.elts[2], type_name)
         memref_node = slice_value.elts[3]
         if not self._is_memref_node(memref_node):
             raise ParserTypeError(
@@ -1427,6 +1415,65 @@ class TypeResolver:
         return (isinstance(func, ast.Attribute) and func.attr == "TensorView") or (
             isinstance(func, ast.Name) and func.id == "TensorView"
         )
+
+    def _resolve_tensor_view_slot(self, node: ast.expr, type_name: str) -> "ir.TensorView":
+        """Resolve slot 3 of a Tensor / DistributedTensor annotation to an ir.TensorView.
+
+        The slot holds either a tensor view or a layout, and either may be
+        written inline or held in a variable::
+
+            pl.Tensor[[32, 64], pl.FP32, pl.TensorView(stride=[128, 1], ...)]
+            pl.Tensor[[32, 64], pl.FP32, STRIDED]  # STRIDED = pl.TensorView(...)
+            pl.Tensor[[32, 64], pl.FP32, pl.NZ]
+            pl.Tensor[[32, 64], pl.FP32, my_layout]  # my_layout = ir.TensorLayout.NZ
+
+        A layout is widened to a stride-less view carrying it, so every form
+        yields a view.
+
+        Args:
+            node: AST node in slot 3 of the annotation
+            type_name: "Tensor" or "DistributedTensor", for diagnostics
+
+        Returns:
+            ir.TensorView instance
+
+        Raises:
+            ParserTypeError: If the node is neither a tensor view nor a layout
+        """
+        if self._is_tensorview_node(node):
+            return self._resolve_tensorview(node)
+        from_var = self._resolve_tensorview_var_ref(node)
+        if from_var is not None:
+            return from_var
+        layout = self.resolve_layout(node)
+        self._warn_on_user_facing_dn_layout(layout, type_name)
+        return ir.TensorView([], layout)
+
+    def _resolve_tensorview_var_ref(self, node: ast.expr) -> "ir.TensorView | None":
+        """Resolve a TensorView referenced by name in a tensor annotation.
+
+        A view spelled out in full is long, and one shared by several parameters
+        would otherwise have to be repeated verbatim on each. Binding it once in
+        enclosing Python and referencing the name is the natural way to share it::
+
+            STRIDED = pl.TensorView(stride=[128, 1], layout=pl.TensorLayout.ND)
+            def kernel(self, data: pl.Tensor[[32, 64], pl.FP32, STRIDED], ...)
+
+        This mirrors the closure support ``resolve_layout`` already provides for
+        the layout that may occupy the same slot.
+
+        Args:
+            node: Candidate AST node from slot 3 of a tensor annotation
+
+        Returns:
+            The TensorView, or None if the node is not a TensorView reference
+        """
+        if not isinstance(node, ast.Name):
+            return None
+        success, value = self.expr_evaluator.try_eval_expr(node)
+        if success and isinstance(value, ir.TensorView):
+            return value
+        return None
 
     def _resolve_tensorview(self, node: ast.expr) -> "ir.TensorView":
         """Resolve a pl.TensorView(...) AST call to ir.TensorView.

--- a/tests/ut/language/parser/test_type_resolver.py
+++ b/tests/ut/language/parser/test_type_resolver.py
@@ -1503,6 +1503,24 @@ class TestLayoutResolution:
         assert result.tensor_view is not None
         assert result.tensor_view.layout == ir.TensorLayout.NZ
 
+    def test_bare_layout_name_wins_over_shadowing_closure_view(self):
+        """`NZ` is the layout even when a closure variable of that name holds a view.
+
+        Layout names took precedence over closure variables before views were
+        reachable by name; resolving views by name must not change that.
+        """
+        resolver = _make_resolver(
+            closure_vars={"NZ": ir.TensorView(stride=[128, 1], layout=ir.TensorLayout.ND)}
+        )
+        node = ast.parse("pl.Tensor[[64, 128], pl.FP16, NZ]", mode="eval").body
+        result = resolver.resolve_type(node)
+
+        assert isinstance(result, ir.TensorType)
+        tv = result.tensor_view
+        assert tv is not None
+        assert tv.layout == ir.TensorLayout.NZ
+        assert len(tv.stride) == 0
+
     def test_resolve_layout_from_closure(self):
         """Layout from closure variable."""
         resolver = _make_resolver(closure_vars={"my_layout": ir.TensorLayout.NZ})

--- a/tests/ut/language/parser/test_type_resolver.py
+++ b/tests/ut/language/parser/test_type_resolver.py
@@ -25,7 +25,7 @@ from pypto.language.parser.type_resolver import TypeResolver
 from pypto.language.typing.dynamic import DynVar
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Sequence
 
 
 _DEFAULT_TILEVIEW_ANNOTATIONS_WITH_MEMORY = [
@@ -51,6 +51,15 @@ def _make_resolver(
     """Create a TypeResolver with ExprEvaluator from closure_vars."""
     ev = ExprEvaluator(closure_vars=closure_vars or {})
     return TypeResolver(expr_evaluator=ev, scope_lookup=scope_lookup)
+
+
+def _const_ints(exprs: "Sequence[ir.Expr]") -> list[int]:
+    """Extract the compile-time integer values from a list of IR expressions."""
+    values = []
+    for expr in exprs:
+        assert isinstance(expr, ir.ConstInt), f"expected ConstInt, got {type(expr).__name__}"
+        values.append(expr.value)
+    return values
 
 
 class TestTypeResolver:
@@ -1512,6 +1521,23 @@ class TestLayoutResolution:
         with pytest.raises(ParserTypeError, match="must be a TensorLayout"):
             resolver.resolve_type(node)
 
+    def test_resolve_layout_closure_tensorview_accepted(self):
+        """A closure TensorView is a valid slot-3 value, not a rejected layout (issue #2211).
+
+        Sibling of test_resolve_layout_closure_invalid_type: slot 3 takes either a
+        TensorLayout or a TensorView, so only the former's rejection is a real error.
+        """
+        resolver = _make_resolver(
+            closure_vars={"my_view": ir.TensorView(stride=[128, 1], layout=ir.TensorLayout.ND)}
+        )
+        node = ast.parse("pl.Tensor[[64, 128], pl.FP16, my_view]", mode="eval").body
+        result = resolver.resolve_type(node)
+
+        assert isinstance(result, ir.TensorType)
+        tv = result.tensor_view
+        assert tv is not None
+        assert _const_ints(tv.stride) == [128, 1]
+
     def test_resolve_tensor_layout_with_dynamic_shape(self):
         """Layout works with dynamic shapes."""
         resolver = _make_resolver(closure_vars={"M": DynVar("M")})
@@ -1923,6 +1949,85 @@ class TestTensorViewResolution:
         assert isinstance(result, ir.TensorType)
         assert result.tensor_view is None
         assert result.memref is not None
+
+    def test_tensorview_from_closure(self):
+        """A variable holding an ir.TensorView is accepted in slot 3 (issue #2211)."""
+        strided = ir.TensorView(stride=[128, 1], layout=ir.TensorLayout.ND)
+        resolver = _make_resolver(closure_vars={"STRIDED": strided})
+        node = ast.parse("pl.Tensor[[32, 64], pl.FP32, STRIDED]", mode="eval").body
+        result = resolver.resolve_type(node)
+
+        assert isinstance(result, ir.TensorType)
+        tv = result.tensor_view
+        assert tv is not None
+        assert tv.layout == ir.TensorLayout.ND
+        assert _const_ints(tv.stride) == [128, 1]
+
+    def test_tensorview_from_closure_matches_inline(self):
+        """The closure form resolves identically to the same view written inline."""
+        strided = ir.TensorView(stride=[128, 1], layout=ir.TensorLayout.ND)
+        inline_src = "pl.Tensor[[32, 64], pl.FP32, pl.TensorView(stride=[128, 1], layout=pl.TensorLayout.ND)]"
+
+        from_closure = _make_resolver(closure_vars={"STRIDED": strided}).resolve_type(
+            ast.parse("pl.Tensor[[32, 64], pl.FP32, STRIDED]", mode="eval").body
+        )
+        from_inline = _make_resolver().resolve_type(ast.parse(inline_src, mode="eval").body)
+        assert isinstance(from_closure, ir.TensorType)
+        assert isinstance(from_inline, ir.TensorType)
+
+        span = ir.Span.unknown()
+        assert ir.structural_equal(
+            ir.Var("value", from_closure, span),
+            ir.Var("value", from_inline, span),
+            enable_auto_mapping=True,
+        )
+
+    def test_tensorview_from_closure_not_aliased_between_annotations(self):
+        """One closure view reused by several annotations must not alias between them.
+
+        TensorType stores the view by value, so mutating one resolved type's view
+        must leave the other — and the closure variable itself — untouched.
+        """
+        strided = ir.TensorView(stride=[128, 1], layout=ir.TensorLayout.ND)
+        resolver = _make_resolver(closure_vars={"STRIDED": strided})
+        ann = ast.parse("pl.Tensor[[32, 64], pl.FP32, STRIDED]", mode="eval").body
+
+        first = resolver.resolve_type(ann)
+        second = resolver.resolve_type(ann)
+        assert isinstance(first, ir.TensorType)
+        assert isinstance(second, ir.TensorType)
+        first_view, second_view = first.tensor_view, second.tensor_view
+        assert first_view is not None
+        assert second_view is not None
+
+        first_view.layout = ir.TensorLayout.NZ
+        assert second_view.layout == ir.TensorLayout.ND
+        assert strided.layout == ir.TensorLayout.ND
+
+    def test_tensorview_from_closure_four_args(self):
+        """A closure TensorView also works in the 4-arg [.., view, memref] form."""
+        strided = ir.TensorView(stride=[128, 1], layout=ir.TensorLayout.ND)
+        resolver = _make_resolver(closure_vars={"STRIDED": strided})
+        node = ast.parse("pl.Tensor[[32, 64], pl.FP32, STRIDED, pl.MemRef(0, 256, 1)]", mode="eval").body
+        result = resolver.resolve_type(node)
+
+        assert isinstance(result, ir.TensorType)
+        assert result.memref is not None
+        tv = result.tensor_view
+        assert tv is not None
+        assert _const_ints(tv.stride) == [128, 1]
+
+    def test_tensorview_from_closure_distributed_tensor(self):
+        """DistributedTensor shares the slot-3 resolution path."""
+        strided = ir.TensorView(stride=[128, 1], layout=ir.TensorLayout.ND)
+        resolver = _make_resolver(closure_vars={"STRIDED": strided})
+        node = ast.parse("pl.DistributedTensor[[32, 64], pl.FP32, STRIDED]", mode="eval").body
+        result = resolver.resolve_type(node)
+
+        assert isinstance(result, ir.DistributedTensorType)
+        tv = result.tensor_view
+        assert tv is not None
+        assert _const_ints(tv.stride) == [128, 1]
 
 
 class TestTensorViewIntegration:


### PR DESCRIPTION
Fixes #2211

## Problem

Slot 3 of `pl.Tensor[shape, dtype, <slot3>]` accepts **either** a `TensorLayout` **or** a `TensorView`. Variable references worked for the layout but not for the view:

| Slot 3 written as | Before | After |
| ----------------- | ------ | ----- |
| `pl.NZ` (inline layout) | works | works |
| `my_layout` (variable holding `ir.TensorLayout`) | works | works |
| `pl.TensorView(...)` (inline call) | works | works |
| `STRIDED` (variable holding `ir.TensorView`) | **rejected** | works |

`_is_tensorview_node` tests for an `ast.Call`, so a bare `ast.Name` never reached `_resolve_tensorview`. It fell through to `resolve_layout`, whose `ast.Name` branch admits only `ir.TensorLayout`, producing:

```
Error: Layout variable 'STRIDED' must be a TensorLayout, got TensorView
   = help: Use a valid layout: ND, DN, NZ
```

This was an asymmetry, not a deliberate restriction. It matters because a `TensorView` annotation is long, and when one strided view applies to several parameters it had to be repeated verbatim on each — the natural aliasing workaround was the rejected one.

## Fix

Slot 3 now resolves through a single `_resolve_tensor_view_slot` helper shared by the 3-arg and 4-arg annotation forms, which previously duplicated the layout-vs-view branch. Resolution order:

1. inline `pl.TensorView(...)` call
2. a variable holding an `ir.TensorView` (new)
3. the layout path, unchanged

Because the view check runs *before* the layout fallback and only matches an actual `ir.TensorView`, an invalid slot-3 value still raises exactly the error it did before.

This mirrors the closure support `resolve_layout` already provides for the layout occupying the same slot, and follows the precedent of #791 (resolving bare names back to a `MemRef` in `pl.Tile` annotations).

`TensorType::tensor_view_` is a `std::optional<TensorView>` — stored by value — so a view shared by several annotations is copied into each and never aliased between them. A test pins this.

## Tests

Added to `tests/ut/language/parser/test_type_resolver.py`:

- `test_tensorview_from_closure` — the issue's case
- `test_tensorview_from_closure_matches_inline` — structurally identical to the inline spelling
- `test_tensorview_from_closure_not_aliased_between_annotations` — mutating one resolved view leaves the other and the closure variable untouched
- `test_tensorview_from_closure_four_args` — `[.., view, memref]` form
- `test_tensorview_from_closure_distributed_tensor` — `pl.DistributedTensor` shares the path
- `test_resolve_layout_closure_tensorview_accepted` — sibling of the existing `test_resolve_layout_closure_invalid_type`, asserting a `TensorView` is *not* rejected as a layout

The existing `test_resolve_layout_closure_invalid_type` (which passes the string `"NZ"`) still passes unchanged.

## Verification

- Issue reproduction now prints `parsed OK`, and the resulting program is `assert_structural_equal` to the inline-spelling control.
- `tests/ut/language/parser/test_type_resolver.py`: 169 passed.
- Full suite: **8306 passed**, 2 skipped. The single failure (`test_ir_trace.py::test_installed_console_script_preserves_main_exit_codes`) is a pre-existing environment precondition — it asserts a pip-installed `pypto-ir-trace` console script and is unrelated to this change.
- All repo lint checks and pre-commit hooks pass (ruff, pyright, markdownlint, docs en/zh parity).

## Docs

Added a "Tensor Layout and View" subsection to `docs/en/dev/language/00-python_syntax.md` and its zh mirror, documenting all four slot-3 spellings. Every example in it was executed against the parser to confirm it resolves.