### PR TITLE
fix(printer): Round-trip every builtin-op call attr instead of two

### DIFF
--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -491,6 +491,13 @@ _AT_STASH_KWARGS = {
     "dumps": "dumps_kw",
 }
 
+# Call attrs that never appear inside a printed ``attrs={...}`` dict. On
+# ``system.task_dummy`` they ride bespoke surfaces (``manual_dep_edges`` prints
+# as ``deps=[...]``; ``dummy_task`` is re-derived from the op), and the printer
+# rejects them on every other op. Accepting either from a generic attrs dict
+# would build IR that cannot be printed back.
+_TASK_DUMMY_ONLY_ATTRS = frozenset({"manual_dep_edges", "dummy_task"})
+
 
 def _split_spmd_for_loop_name_hints(name_hint: str) -> tuple[str, str]:
     """Map one ``for i in pl.spmd(..., name_hint=...)`` hint to Spmd vs InCore names.
@@ -7716,7 +7723,20 @@ class ASTParser:
                     "attrs keys must be string literals",
                     span=self.span_tracker.get_span(key_node) if key_node else None,
                 )
-            result[key_node.value] = self._parse_attr_value(method_name, key_node.value, value_node)
+            key = key_node.value
+            if key in _TASK_DUMMY_ONLY_ATTRS:
+                # The printer never emits these into ``attrs={...}``: on
+                # ``system.task_dummy`` they ride the bespoke ``deps=`` surface
+                # (and ``dummy_task`` is re-derived from the op), and on any
+                # other op the printer rejects them outright. Accepting one here
+                # would build IR that cannot be printed back.
+                raise ParserSyntaxError(
+                    f"attrs['{key}'] on call to '{method_name}' is not a writable attr; "
+                    "manual dependency edges are written as deps=[...] on "
+                    "pl.system.task_dummy or pl.submit",
+                    span=self.span_tracker.get_span(value_node),
+                )
+            result[key] = self._parse_attr_value(method_name, key, value_node)
         return result
 
     @staticmethod
@@ -8091,12 +8111,10 @@ class ASTParser:
         if deps:
             attrs.append(("manual_dep_edges", deps))
         # ``deps=`` and the op identity are the bespoke carriers for
-        # ``manual_dep_edges`` / ``dummy_task`` (both skipped by the printer's
-        # denylist and reconstructed above); recover every other key generically.
-        for key, value in (self._parse_op_attrs(call) or {}).items():
-            if key in {"dummy_task", "manual_dep_edges"}:
-                continue
-            attrs.append((key, value))
+        # ``manual_dep_edges`` / ``dummy_task``, reconstructed above; both are
+        # rejected inside a generic attrs dict, so everything left here is an
+        # ordinary attr to recover.
+        attrs.extend((self._parse_op_attrs(call) or {}).items())
         return ir.Call(base.op, base.args, base.kwargs, attrs, base.type, base.span)
 
     def _parse_array_op(self, op_name: str, call: ast.Call) -> ir.Expr:

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -7676,6 +7676,12 @@ class ASTParser:
         wrappers / IR builders take no attrs parameter, so the dispatch helpers
         parse it here and re-attach it via ``ir.set_call_attrs`` after building
         the call. Returns ``None`` when no ``attrs=`` kwarg is present.
+
+        Values are read by ``_parse_attr_value`` — the same open-world reader the
+        GlobalVar-call / Submit paths use — so every type the printer's
+        ``PrintAttrValue`` can emit round-trips. No key allowlist: the writer
+        (``print_serialized_attrs``) is a denylist, so a key without a bespoke
+        surface must be recoverable here or the round-trip silently loses it.
         """
         for keyword in call.keywords:
             if keyword.arg != "attrs":
@@ -7685,8 +7691,25 @@ class ASTParser:
                     "op attrs must be a dict literal",
                     span=self.span_tracker.get_span(keyword.value),
                 )
-            return self._parse_attrs_dict(keyword.value)
+            return self._parse_generic_attrs_dict(ast.unparse(call.func), keyword.value)
         return None
+
+    def _parse_generic_attrs_dict(self, method_name: str, node: ast.Dict) -> dict[str, object]:
+        """Read an open-world ``attrs={...}`` dict literal via ``_parse_attr_value``.
+
+        Only the string-literal-key invariant is enforced; each value's type is
+        inferred from syntax by ``_parse_attr_value``, whose matching writer is
+        ``PrintAttrValue`` in the C++ python printer.
+        """
+        result: dict[str, object] = {}
+        for key_node, value_node in zip(node.keys, node.values):
+            if not (isinstance(key_node, ast.Constant) and isinstance(key_node.value, str)):
+                raise ParserSyntaxError(
+                    "attrs keys must be string literals",
+                    span=self.span_tracker.get_span(key_node) if key_node else None,
+                )
+            result[key_node.value] = self._parse_attr_value(method_name, key_node.value, value_node)
+        return result
 
     @staticmethod
     def _attach_op_attrs(result: ir.Expr, attrs: dict[str, object] | None) -> ir.Expr:
@@ -8037,7 +8060,10 @@ class ASTParser:
                 "pl.system.task_dummy must not use positional arguments",
                 span=span,
             )
-        allowed_kwargs = {"deps"}
+        # ``attrs=`` is the machine-only round-trip surface, not a user API: the
+        # printer's denylist emits every non-bespoke attr into it, so rejecting
+        # it here would turn a printed attr into an unparseable program.
+        allowed_kwargs = {"deps", "attrs"}
         for kw in call.keywords:
             if kw.arg not in allowed_kwargs:
                 raise ParserTypeError(
@@ -8056,6 +8082,13 @@ class ASTParser:
         attrs: list[tuple[str, Any]] = [("dummy_task", True)]
         if deps:
             attrs.append(("manual_dep_edges", deps))
+        # ``deps=`` and the op identity are the bespoke carriers for
+        # ``manual_dep_edges`` / ``dummy_task`` (both skipped by the printer's
+        # denylist and reconstructed above); recover every other key generically.
+        for key, value in (self._parse_op_attrs(call) or {}).items():
+            if key in {"dummy_task", "manual_dep_edges"}:
+                continue
+            attrs.append((key, value))
         return ir.Call(base.op, base.args, base.kwargs, attrs, base.type, base.span)
 
     def _parse_array_op(self, op_name: str, call: ast.Call) -> ir.Expr:

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -7294,6 +7294,14 @@ class ASTParser:
                 "unsupported kind (expected all ints, all pl.adir.<name>, or all names)",
                 span=node_span,
             )
+        # ``pl.<DTYPE>`` -> DataType. The printer emits DataType attrs in this
+        # form (PrintAttrValue's DataType arm), and ``parse_expression`` has no
+        # way to represent a dtype, so resolve it before the generic fallback.
+        if isinstance(value_node, ast.Attribute):
+            try:
+                return self.type_resolver.resolve_dtype(value_node)
+            except ParserTypeError:
+                pass
         # Bare name -> Var; any other expression -> the parsed IR expression.
         return self.parse_expression(value_node)
 

--- a/src/ir/transforms/python_printer.cpp
+++ b/src/ir/transforms/python_printer.cpp
@@ -1033,13 +1033,23 @@ void IRPythonPrinter::VisitExpr_(const CallPtr& op) {
   // ``ast_parser._parse_op_attrs`` -> ``_parse_attr_value``. Keep this helper
   // available to the special call forms below so an early return cannot skip
   // the dict.
+  const bool is_task_dummy = IsOp(op, "system.task_dummy");
   auto print_serialized_attrs = [&](bool need_comma) {
     std::vector<const std::pair<std::string, std::any>*> serialized_attrs;
     for (const auto& kv : op->attrs_) {
-      // Bespoke surfaces, deliberately skipped here:
-      //  - manual_dep_edges -> printed as ``deps=[...]`` on system.task_dummy
-      //  - dummy_task       -> re-derived by the parser from the op itself
-      if (kv.first == kAttrManualDepEdges || kv.first == kAttrDummyTask) continue;
+      if (kv.first == kAttrManualDepEdges || kv.first == kAttrDummyTask) {
+        // Bespoke surfaces, but ONLY on ``system.task_dummy``: there
+        // ``manual_dep_edges`` prints as ``deps=[...]`` and ``dummy_task`` is
+        // re-derived by the parser from the op itself. On any other op neither
+        // surface exists, so skipping the key would be precisely the silent
+        // drop this denylist removes — fail loud instead. Manual dependency
+        // edges belong on ``Submit::deps_`` (ManualDepsOnSubmitOnly).
+        INTERNAL_CHECK_SPAN(is_task_dummy, op->span_)
+            << "Internal error: call to '" << op->op_->name_ << "' carries attrs[\"" << kv.first
+            << "\"], which has a DSL surface only on system.task_dummy; manual dependency edges "
+               "belong on Submit::deps_";
+        continue;
+      }
       serialized_attrs.push_back(&kv);
     }
     if (serialized_attrs.empty()) return;

--- a/src/ir/transforms/python_printer.cpp
+++ b/src/ir/transforms/python_printer.cpp
@@ -1018,18 +1018,24 @@ void IRPythonPrinter::VisitExpr_(const CallPtr& op) {
     stream_ << op_name << "(";
   }
 
-  // Serialize ONLY op-call attrs that genuinely need to survive print -> parse,
-  // via an explicit allowlist. Most attrs are re-derived by the parser or have
-  // bespoke syntax. ``pipeline_membership`` and the compiler-generated
-  // Tensor-to-Mat bridge provenance have neither and must survive until their
-  // downstream passes consume them. Keep this helper available to special call
-  // forms below so an early return cannot silently drop either attr.
+  // Serialize op-call attrs into a trailing machine-only ``attrs={...}`` dict
+  // via an open-world DENYLIST: EVERY key round-trips unless it already owns a
+  // bespoke surface. This mirrors the GlobalVar-call branch above and the
+  // Submit branch below, so the three call-like paths share one policy — a new
+  // attr on a builtin-op call can never be silently dropped on print -> parse.
+  // A value type without a codec fails loudly inside ``PrintAttrValue``
+  // (surfacing the gap) rather than vanishing. The matching reader is
+  // ``ast_parser._parse_op_attrs`` -> ``_parse_attr_value``. Keep this helper
+  // available to the special call forms below so an early return cannot skip
+  // the dict.
   auto print_serialized_attrs = [&](bool need_comma) {
     std::vector<const std::pair<std::string, std::any>*> serialized_attrs;
     for (const auto& kv : op->attrs_) {
-      if (kv.first == kPipelineMembershipAttr || kv.first == kCompilerTensorToTileMatBridgeAttr) {
-        serialized_attrs.push_back(&kv);
-      }
+      // Bespoke surfaces, deliberately skipped here:
+      //  - manual_dep_edges -> printed as ``deps=[...]`` on system.task_dummy
+      //  - dummy_task       -> re-derived by the parser from the op itself
+      if (kv.first == kAttrManualDepEdges || kv.first == kAttrDummyTask) continue;
+      serialized_attrs.push_back(&kv);
     }
     if (serialized_attrs.empty()) return;
 

--- a/src/ir/transforms/python_printer.cpp
+++ b/src/ir/transforms/python_printer.cpp
@@ -811,6 +811,11 @@ void IRPythonPrinter::PrintAttrValue(const std::any& value, const Span& span) {
     stream_ << std::quoted(std::any_cast<std::string>(value));
   } else if (t == typeid(double)) {
     stream_ << FormatFloatLiteral(std::any_cast<double>(value));
+  } else if (t == typeid(DataType)) {
+    // ``LowerHostTensorCollectives`` stamps a DataType attr on every
+    // ``builtin.tensor.<collective>`` call. Printed in the ``pl.<DTYPE>`` DSL
+    // form the dtype resolver reads back (ast_parser._parse_attr_value).
+    stream_ << prefix_ << "." << DataTypeToString(std::any_cast<DataType>(value));
   } else if (t == typeid(std::vector<ArgDirection>)) {
     const auto& dirs = std::any_cast<std::vector<ArgDirection>>(value);
     stream_ << "[";
@@ -852,7 +857,7 @@ void IRPythonPrinter::PrintAttrValue(const std::any& value, const Span& span) {
     // the source rather than masked by a dropped attr.
     INTERNAL_CHECK_SPAN(false, span)
         << "Internal error: no DSL attr-value codec for type '" << DemangleTypeName(t.name())
-        << "'. The python printer round-trips int/bool/str/double/vector<ArgDirection>/"
+        << "'. The python printer round-trips int/bool/str/double/DataType/vector<ArgDirection>/"
            "vector<int32_t>/vector<VarPtr>/VarPtr/ExprPtr attrs; add a PrintAttrValue arm, a "
            "matching _parse_attr_value case, and ConvertKwargsDict support for this type instead "
            "of dropping it.";

--- a/tests/ut/ir/printing/test_python_printer.py
+++ b/tests/ut/ir/printing/test_python_printer.py
@@ -1807,5 +1807,126 @@ def test_keyword_named_tensor_op_round_trips(dsl_name):
     ir.assert_structural_equal(Program, pl.parse_program(printed))
 
 
+def test_builtin_op_call_generic_attrs_roundtrip():
+    """Every non-bespoke attr on a builtin-op Call round-trips, not just two keys.
+
+    The builtin-op writer used to be a hardcoded 2-key allowlist
+    (``pipeline_membership`` / the Tensor-to-Mat bridge marker), so any other key
+    was silently dropped on print with no diagnostic. Writer and reader are now
+    the same open-world denylist/``PrintAttrValue`` pair the GlobalVar-call and
+    Submit branches use, so an arbitrary key of any codec-supported value type
+    survives print -> reparse.
+    """
+    source = textwrap.dedent("""\
+        @pl.program
+        class BuiltinOpAttrs:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                a: pl.Tensor[[128, 128], pl.FP32],
+                out: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
+            ) -> pl.Tensor[[128, 128], pl.FP32]:
+                t = pl.tile.load(
+                    a,
+                    [0, 0],
+                    [128, 128],
+                    [128, 128],
+                    target_memory=pl.Mem.Vec,
+                    attrs={
+                        "my_int_attr": 11,
+                        "my_float_attr": 2.5,
+                        "my_bool_attr": True,
+                        "my_str_attr": "hello",
+                        "pipeline_membership": "0:3",
+                        "dump_vars": [a],
+                    },
+                )
+                r = pl.tile.store(t, [0, 0], out)
+                return r
+    """)
+
+    program = pl.parse_program(source)
+    printed = python_print(program, format=False)
+    for key in ("my_int_attr", "my_float_attr", "my_bool_attr", "my_str_attr", "dump_vars"):
+        assert key in printed, printed
+
+    reparsed = pl.parse_program(printed)
+    ir.assert_structural_equal(program, reparsed)
+    assert python_print(reparsed, format=False) == printed
+
+    loads: list[ir.Call] = []
+
+    class _CollectLoads(ir.IRVisitor):
+        def visit_call(self, op):
+            if op.op.name == ir.get_op("tile.load").name:
+                loads.append(op)
+            super().visit_call(op)
+
+    _CollectLoads().visit_program(reparsed)
+    assert len(loads) == 1
+    attrs = dict(loads[0].attrs)
+    assert attrs["my_int_attr"] == 11
+    assert attrs["my_float_attr"] == 2.5
+    assert attrs["my_bool_attr"] is True
+    assert attrs["my_str_attr"] == "hello"
+    assert attrs["pipeline_membership"] == "0:3"
+    # The Var-list attr resolves back to the very same operand, by identity.
+    assert list(attrs["dump_vars"]) == [loads[0].args[0]]
+
+
+def test_task_dummy_extra_attr_roundtrips_alongside_deps():
+    """``system.task_dummy`` keeps its bespoke ``deps=`` surface AND an extra attr.
+
+    ``manual_dep_edges`` prints as ``deps=[...]`` and ``dummy_task`` is re-derived
+    from the op, so both stay out of the ``attrs={...}`` dict. Any third key must
+    still survive — the printer emits it, so the ``task_dummy`` parse path has to
+    accept ``attrs=`` rather than reject it as an unknown kwarg.
+    """
+    source = textwrap.dedent("""\
+        @pl.program
+        class TaskDummyAttrs:
+            @pl.function
+            def kernel(self) -> pl.Scalar[pl.TASK_ID]:
+                return pl.system.task_invalid()
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(self) -> pl.Scalar[pl.TASK_ID]:
+                with pl.manual_scope():
+                    tids = pl.array.create(4, pl.TASK_ID)
+                    barrier = pl.system.task_dummy(deps=[tids], attrs={"my_marker": 7})
+                    for p in pl.parallel(4):
+                        a, a_tid = pl.submit(self.kernel, deps=[barrier])
+                return pl.system.task_invalid()
+    """)
+
+    program = pl.parse_program(source)
+    printed = python_print(program, format=False)
+    assert "deps=[tids]" in printed, printed
+    assert 'attrs={"my_marker": 7}' in printed, printed
+    # dummy_task / manual_dep_edges keep their bespoke surfaces, so neither leaks
+    # into the generic dict.
+    assert "dummy_task" not in printed, printed
+    assert "manual_dep_edges" not in printed, printed
+
+    reparsed = pl.parse_program(printed)
+    ir.assert_structural_equal(program, reparsed)
+    assert python_print(reparsed, format=False) == printed
+
+    dummies: list[ir.Call] = []
+
+    class _CollectDummies(ir.IRVisitor):
+        def visit_call(self, op):
+            if op.op.name == ir.get_op("system.task_dummy").name:
+                dummies.append(op)
+            super().visit_call(op)
+
+    _CollectDummies().visit_program(reparsed)
+    assert len(dummies) == 1
+    attrs = dict(dummies[0].attrs)
+    assert attrs["my_marker"] == 7
+    assert attrs["dummy_task"] is True
+    assert len(list(attrs["manual_dep_edges"])) == 1
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/ir/printing/test_python_printer.py
+++ b/tests/ut/ir/printing/test_python_printer.py
@@ -11,12 +11,14 @@
 
 import textwrap
 
+import pypto
 import pypto.language as pl
 import pytest
 from pypto import DataType, ir
 from pypto.ir import MemorySpace
 from pypto.ir.op import tile
 from pypto.ir.printer import python_print
+from pypto.language.parser.diagnostics import ParserSyntaxError
 
 
 def test_python_print_basic_expressions():
@@ -1930,6 +1932,62 @@ def test_task_dummy_extra_attr_roundtrips_alongside_deps():
     assert attrs["my_marker"] == 7
     assert attrs["dummy_task"] is True
     assert len(list(attrs["manual_dep_edges"])) == 1
+
+
+def test_dep_edge_attrs_are_rejected_outside_task_dummy():
+    """`manual_dep_edges` / `dummy_task` are skipped ONLY on system.task_dummy.
+
+    Both keys are omitted from the printed ``attrs={...}`` dict because
+    task_dummy carries them on bespoke surfaces (``deps=[...]`` / re-derivation
+    from the op). No other op has those surfaces, so skipping the key there
+    would be exactly the silent drop the denylist exists to remove. The printer
+    must fail loud, and the parser must refuse to build such IR in the first
+    place.
+    """
+    source = textwrap.dedent("""\
+        @pl.program
+        class DepAttrOnPlainOp:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                a: pl.Tensor[[128, 128], pl.FP32],
+                out: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
+            ) -> pl.Tensor[[128, 128], pl.FP32]:
+                t = pl.tile.load(a, [0, 0], [128, 128], [128, 128], attrs={"manual_dep_edges": [a]})
+                r = pl.tile.store(t, [0, 0], out)
+                return r
+    """)
+    # Parser side: refuses to attach a dep-edge attr to a plain op call.
+    with pytest.raises(ParserSyntaxError, match="manual_dep_edges"):
+        pl.parse_program(source)
+
+    # Printer side: IR built directly (bypassing the parser) still fails loud
+    # instead of dropping the attr.
+    @pl.program
+    class Prog:
+        @pl.function(type=pl.FunctionType.InCore)
+        def kernel(
+            self,
+            a: pl.Tensor[[128, 128], pl.FP32],
+            out: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
+        ) -> pl.Tensor[[128, 128], pl.FP32]:
+            t = pl.tile.load(a, [0, 0], [128, 128])
+            r = pl.tile.store(t, [0, 0], out)
+            return r
+
+    class _StampDepEdges(ir.IRMutator):
+        def visit_call(self, op):
+            expr = super().visit_call(op)
+            call = expr if isinstance(expr, ir.Call) else op
+            if call.op.name != ir.get_op("tile.load").name:
+                return expr
+            attrs = dict(call.attrs)
+            attrs["manual_dep_edges"] = [call.args[0]]
+            return ir.Call(call.op, list(call.args), dict(call.kwargs), attrs, call.type, call.span)
+
+    stamped = _StampDepEdges().visit_program(Prog)
+    with pytest.raises(pypto.InternalError, match="system.task_dummy"):
+        python_print(stamped, format=False)
 
 
 if __name__ == "__main__":

--- a/tests/ut/ir/printing/test_python_printer.py
+++ b/tests/ut/ir/printing/test_python_printer.py
@@ -1837,6 +1837,7 @@ def test_builtin_op_call_generic_attrs_roundtrip():
                         "my_float_attr": 2.5,
                         "my_bool_attr": True,
                         "my_str_attr": "hello",
+                        "my_dtype_attr": pl.FP16,
                         "pipeline_membership": "0:3",
                         "dump_vars": [a],
                     },
@@ -1849,6 +1850,8 @@ def test_builtin_op_call_generic_attrs_roundtrip():
     printed = python_print(program, format=False)
     for key in ("my_int_attr", "my_float_attr", "my_bool_attr", "my_str_attr", "dump_vars"):
         assert key in printed, printed
+    # DataType attrs print in the ``pl.<DTYPE>`` form the dtype resolver reads back.
+    assert '"my_dtype_attr": pl.FP16' in printed, printed
 
     reparsed = pl.parse_program(printed)
     ir.assert_structural_equal(program, reparsed)
@@ -1869,6 +1872,7 @@ def test_builtin_op_call_generic_attrs_roundtrip():
     assert attrs["my_float_attr"] == 2.5
     assert attrs["my_bool_attr"] is True
     assert attrs["my_str_attr"] == "hello"
+    assert attrs["my_dtype_attr"] == DataType.FP16
     assert attrs["pipeline_membership"] == "0:3"
     # The Var-list attr resolves back to the very same operand, by identity.
     assert list(attrs["dump_vars"]) == [loads[0].args[0]]

--- a/tests/ut/ir/transforms/test_infer_tile_memory_space.py
+++ b/tests/ut/ir/transforms/test_infer_tile_memory_space.py
@@ -24,27 +24,6 @@ from pypto import backend, ir, passes
 from pypto.backend import BackendType
 
 
-def _verify_no_roundtrip() -> passes.PassContext:
-    """Ambient property verification, minus the print->parse roundtrip instrument.
-
-    A few tests below stamp compiler-internal attrs (``dump_vars``, residency
-    sentinels) onto calls to observe how the pass propagates them. Those attrs
-    have no DSL print/parse surface, so the roundtrip instrument installed by
-    ``tests/ut/conftest.py`` drops them and reports a spurious ``Kwargs size
-    mismatch``. BEFORE_AND_AFTER property verification is deliberately KEPT — only
-    the roundtrip is suppressed, and only for the single pass call that needs it.
-
-    Tracked by hw-native-sys/pypto#2204: builtin-op call attrs go through a 2-key
-    allowlist on print (and an int/float/bool/str-only reader on parse), while
-    GlobalVar/Submit attrs use a fail-loud denylist. Once those converge, this
-    helper and all four of its call sites can go away.
-
-    Returns:
-        A ``PassContext`` carrying only the BEFORE_AND_AFTER verification instrument.
-    """
-    return passes.PassContext([passes.VerificationInstrument(passes.VerificationMode.BEFORE_AND_AFTER)])
-
-
 @pytest.fixture(autouse=True)
 def _reset_backend():
     """Ensure no backend is configured so TileView inference is deterministic.
@@ -360,10 +339,7 @@ class TestInferTileMemorySpaceCubeOps:
                 )
 
         marked = _MarkMatmulDump().visit_program(Before)
-        # Builtin-call dump attrs are compiler-internal and have no DSL
-        # print/parse surface, so inspect the transformed IR directly.
-        with _verify_no_roundtrip():
-            after = passes.infer_tile_memory_space()(marked)
+        after = passes.infer_tile_memory_space()(marked)
         matmuls = []
 
         class _CollectMatmul(ir.IRVisitor):
@@ -412,10 +388,7 @@ class TestInferTileMemorySpaceCubeOps:
                 )
 
         marked = _MarkMatmulDump().visit_program(Before)
-        # Same compiler-internal `dump_vars` attr as the sibling test above: it has
-        # no DSL print/parse surface, so the roundtrip instrument is dropped here.
-        with _verify_no_roundtrip():
-            after = passes.infer_tile_memory_space()(marked)
+        after = passes.infer_tile_memory_space()(marked)
         matmuls = []
 
         class _CollectMatmul(ir.IRVisitor):
@@ -2411,10 +2384,7 @@ class RetargetedBridgeAttrs:
 
         before = _StampFirstLoad().visit_program(before)
         backend.set_backend_type(BackendType.Ascend910B)
-        # The sentinel is deliberately not a DSL-printable compiler attr, so
-        # disable the global print/parse instrument for this attr-lifetime test.
-        with _verify_no_roundtrip():
-            after = passes.infer_tile_memory_space()(before)
+        after = passes.infer_tile_memory_space()(before)
         load_attrs = []
 
         class _CollectLoadAttrs(ir.IRVisitor):
@@ -2467,10 +2437,7 @@ class MarkerOnlyScalarCall:
 
         before = _StampScalarCall().visit_program(before)
         backend.set_backend_type(BackendType.Ascend910B)
-        # Same non-DSL-printable sentinel attr as the sibling test above, so the
-        # print/parse instrument is dropped for this attr-lifetime check too.
-        with _verify_no_roundtrip():
-            after = passes.infer_tile_memory_space()(before)
+        after = passes.infer_tile_memory_space()(before)
         scalar_attrs = []
 
         class _CollectScalarAttrs(ir.IRVisitor):

--- a/tests/ut/ir/transforms/test_lower_host_tensor_collectives.py
+++ b/tests/ut/ir/transforms/test_lower_host_tensor_collectives.py
@@ -764,3 +764,44 @@ def test_host_all_to_all_lowers_to_namesake_builtin():
         ir.ArgDirection.InOut,
     ]
     assert call.kwargs["dtype"] == DataType.FP32
+
+
+def test_lowered_collective_is_printable_with_dtype_attr():
+    """The lowered ``builtin.tensor.*`` call must survive the python printer.
+
+    ``MakeBuiltinCallWithAttrs`` stamps a ``DataType``-valued ``dtype`` attr on
+    every lowered collective. The pass-dump instrument (``pass_manager.after_pass``)
+    prints the program after each pass, so a value type the printer has no codec
+    arm for aborts the whole compile with an ``InternalError`` — which is how this
+    surfaced in the distributed system tests. Printing here keeps the DataType
+    codec arm wired to the pass that actually produces it.
+    """
+
+    @pl.program
+    class P:
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def chip_orch(self, data: pld.DistributedTensor[[256], pl.FP32]):
+            return data
+
+        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+        def host_orch(self):
+            data_buf = pld.alloc_window_buffer(256 * pl.FP32.get_byte())
+            signal_buf = pld.alloc_window_buffer(4 * pl.INT32.get_byte())
+            data = pld.window(data_buf, [256], dtype=pl.FP32)
+            signal = pld.window(signal_buf, [4], dtype=pl.INT32)
+            for r in pl.range(pld.world_size()):
+                self.chip_orch(data, device=r)
+            pld.tensor.allreduce(data, signal, op=pld.ReduceOp.Sum)
+            return 0
+
+    program = cast(ir.Program, passes.materialize_comm_domain_scopes()(P))
+    result = cast(ir.Program, passes.lower_host_tensor_collectives()(program))
+
+    printed = ir.python_print(result, format=False)
+    assert "builtin.tensor.allreduce" in printed, printed
+    # The DataType attr renders in the ``pl.<DTYPE>`` DSL form, not dropped.
+    assert '"dtype": pl.FP32' in printed, printed
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
Fixes #2204

## Problem

The printer had **two Call branches with opposite attr policies**, and the parser mirrored the asymmetry:

| Path | Writer | Reader | Policy |
|---|---|---|---|
| `GlobalVar` Call / `Submit` | `PrintAttrValue` (denylist) | `_parse_attr_value` | open-world, fails loud |
| Builtin-op Call | `print_serialized_attrs` (2-key allowlist) | `_parse_attrs_dict` | closed-world, **silent drop** |

Attrs on a builtin-op (`OpExpr` callee) Call were matched against a hardcoded allowlist of `pipeline_membership` and `__compiler_tensor_to_tile_mat_bridge`; **every other key was discarded on print with no diagnostic**.

## Fix

Converge the builtin-op reader/writer pair onto the `GlobalVar` pair so all three call-like paths share one policy. Both sides are required — with only the printer changed, a widened attr prints but fails on re-parse.

- **`python_printer.cpp`** — `print_serialized_attrs` becomes a denylist, rendering every key through `PrintAttrValue`, which fails loud on a value type it cannot represent rather than dropping it.
- **`ast_parser.py`** — `_parse_op_attrs` reads values through `_parse_attr_value` (the open-world reader) instead of the constants-only `_parse_attrs_dict`. `_parse_attrs_dict` stays as the reader for `ForStmt` `attrs=`, whose writer genuinely *is* a scalar-only codec, so that pair remains symmetric.
- **`_parse_task_dummy`** — accepts `attrs=`, since the denylist can now emit a third key on a `system.task_dummy` call.

### Two latent gaps the flip exposed

The issue predicted the flip would "surface latent gaps in code paths the 3439-test probe did not reach". It did, and both are fixed here rather than papered over:

1. **`DataType` had no codec arm.** `LowerHostTensorCollectives` stamps `attrs={"op": <int>, "dtype": <DataType>}` on every lowered `builtin.tensor.<collective>` call. The allowlist silently dropped it; routing it through `PrintAttrValue` turned that into a loud `InternalError` and failed 15 distributed system tests. The abort came from the pass-dump callback (`pass_manager.after_pass`), which prints after every pass and never re-parses — so it aborted the compile itself. Added the `DataType` printer arm (`pl.<DTYPE>` form) and the matching reader case; `ConvertKwargsDict` already handled `DataType`.

2. **The denylist skip was itself a silent drop.** `manual_dep_edges` / `dummy_task` were skipped unconditionally, but only `system.task_dummy` can reconstruct them (`deps=[...]` / re-derivation from the op). On any other op the attr vanished — the exact defect this PR removes, reintroduced through the escape hatch. The skip is now gated on the op, failing loud elsewhere and naming `Submit::deps_` as the correct home; the parser refuses to build such IR from text at all.

## Payoff

Retires the `_verify_no_roundtrip()` helper added in #2207 and all four of its call sites in `test_infer_tile_memory_space.py`, exactly as that helper's docstring anticipated. Those tests now run under the full roundtrip instrument.

## Compatibility

Printed output for existing programs is unchanged — the two skipped keys are exactly the two that builtin-op calls carried beyond the old allowlist, so the flip only widens what *can* survive.

## Tests

- `test_builtin_op_call_generic_attrs_roundtrip` — a `tile.load` carrying `int` / `float` / `bool` / `str` / `DataType` / `pipeline_membership` / a `dump_vars` Var-list survives print → reparse, structurally equal and print-idempotent, with the Var-list resolving back to the same operand by identity.
- `test_task_dummy_extra_attr_roundtrips_alongside_deps` — `system.task_dummy` keeps its bespoke `deps=` surface *and* a third attr.
- `test_dep_edge_attrs_are_rejected_outside_task_dummy` — printer and parser both refuse dep-edge attrs on a non-`task_dummy` op.
- `test_lowered_collective_is_printable_with_dtype_attr` — guards the `DataType` gap at the pass that produces it. Its file installs an autouse fixture carrying only `BEFORE_AND_AFTER` verification, which is why nothing ever printed the lowered IR and the gap stayed latent.

Full unit suite: **8313 passed, 2 skipped**.
