### PR TITLE
docs: fix distributed-op docstrings and the ReduceOp type-stub

### DIFF
--- a/python/pypto/ir/distributed_compiled_program.py
+++ b/python/pypto/ir/distributed_compiled_program.py
@@ -100,7 +100,7 @@ class DistributedCompiledProgram:
 
     **Persistent dispatch** (repeated launches without re-registering)::
 
-        with DistributedWorker(compiled) as rt:
+        with compiled.prepare() as rt:
             for step in steps:
                 rt(host_x, host_out)
         # rt.close() on exit — releases buffers and shuts down workers

--- a/python/pypto/ir/distributed_compiled_program.py
+++ b/python/pypto/ir/distributed_compiled_program.py
@@ -58,13 +58,17 @@ if TYPE_CHECKING:
 class DistributedConfig:
     """Configuration for L3 distributed execution.
 
-    Fields:
+    Attributes:
         device_ids: List of NPU device indices to use. Defaults to ``[0]``
             (single-card). Pass ``[0, 1, 2, 3]`` for a 4-card ring. Must be
             a non-empty list of distinct ints.
-        num_sub_workers: Number of sub-workers per chip process. ``0`` (default)
-            means one sub-worker per chip process. Increase for multi-slice or
-            internal pipelining scenarios.
+        num_sub_workers: Number of sub-workers to request per chip process.
+            ``0`` (default) does not force a specific count — the runtime
+            instead uses ``max(num_sub_workers, len(sub_worker_fns))``, i.e.
+            exactly as many sub-workers as the program's declared sub-worker
+            functions. Set this explicitly only when requesting more
+            sub-workers than are declared, e.g. for multi-slice or internal
+            pipelining scenarios.
         runtime: Simpler runtime flavour. ``"tensormap_and_ringbuffer"`` (default)
             enables the tensor-map helpers and the ring-buffer DMA driver.
         aicpu_thread_num: Number of aiCPU threads allocated to the simpler

--- a/python/pypto/ir/distributed_compiled_program.py
+++ b/python/pypto/ir/distributed_compiled_program.py
@@ -58,8 +58,17 @@ if TYPE_CHECKING:
 class DistributedConfig:
     """Configuration for L3 distributed execution.
 
-    ``aicpu_thread_num=4`` matches the ``tensormap_and_ringbuffer`` runtime's
-    3-scheduler-plus-1-dispatcher layout.
+    Fields:
+        device_ids: List of NPU device indices to use. Defaults to ``[0]``
+            (single-card). Pass ``[0, 1, 2, 3]`` for a 4-card ring. Must be
+            a non-empty list of distinct ints.
+        num_sub_workers: Number of sub-workers per chip process. ``0`` (default)
+            means one sub-worker per chip process. Increase for multi-slice or
+            internal pipelining scenarios.
+        runtime: Simpler runtime flavour. ``"tensormap_and_ringbuffer"`` (default)
+            enables the tensor-map helpers and the ring-buffer DMA driver.
+        aicpu_thread_num: Number of aiCPU threads allocated to the simpler
+            runtime (3 schedulers + 1 dispatcher = 4 by default). Must be ≥ 1.
     """
 
     device_ids: list[int] = field(default_factory=lambda: [0])
@@ -83,6 +92,18 @@ class DistributedCompiledProgram:
     **Return** (program has a return value)::
 
         c = compiled(a, b)
+
+    **One-shot dispatch**::
+
+        compiled = ir.compile(MyProgram, platform="a2a3", distributed_config=dc)
+        compiled(inputs, outputs)   # blocks until all ranks finish
+
+    **Persistent dispatch** (repeated launches without re-registering)::
+
+        with DistributedWorker(compiled) as rt:
+            for step in steps:
+                rt(host_x, host_out)
+        # rt.close() on exit — releases buffers and shuts down workers
     """
 
     __test__ = False

--- a/python/pypto/language/distributed/op/system_ops.py
+++ b/python/pypto/language/distributed/op/system_ops.py
@@ -145,7 +145,8 @@ def notify(
        The first parameter is named ``target`` for legacy reasons (inherited
        from early signal protocol drafts).  The companion :func:`wait` names
        the same logical operand ``signal``.  Both refer to the signal
-       :class:`DistributedTensor` — always use positional args:
+       :class:`DistributedTensor` — pass the first operand positionally; the
+       remaining operands may be positional or keyword:
        ``notify(signal, peer=..., ...)``.
 
     Args:

--- a/python/pypto/language/distributed/op/system_ops.py
+++ b/python/pypto/language/distributed/op/system_ops.py
@@ -37,6 +37,7 @@ from collections.abc import Sequence
 
 from pypto.ir.op.distributed import system_ops as _ir_system
 from pypto.language.typing import IntLike, Scalar
+from pypto.language.typing.tensor import Tensor
 from pypto.pypto_core.ir import Call, NotifyOp, WaitCmp
 
 from ..typing.comm_ctx import CommCtx
@@ -121,7 +122,7 @@ def nranks(ctx: CommCtx) -> Scalar:
 
 
 def notify(
-    target: DistributedTensor,
+    target: Tensor,
     peer: IntLike,
     offsets: Sequence[IntLike],
     value: IntLike,
@@ -158,7 +159,7 @@ def notify(
 
 
 def wait(
-    signal: DistributedTensor,
+    signal: Tensor,
     offsets: Sequence[IntLike],
     expected: IntLike,
     *,

--- a/python/pypto/language/distributed/op/system_ops.py
+++ b/python/pypto/language/distributed/op/system_ops.py
@@ -53,6 +53,18 @@ def world_size() -> Scalar:
     return wrapping lets call sites compose naturally with Python operators
     (``pld.world_size() * 4``, ``pl.range(pld.world_size())``), which the
     parser's ``invoke_dsl`` unwraps back to the underlying Call.
+
+    .. warning::
+
+       This function is callable **only** inside HOST-level orchestration
+       (``level=pl.Level.HOST, role=pl.Role.Orchestrator``). Calling it
+       inside InCore (``type=pl.FunctionType.InCore``) raises a parser error.
+
+    .. seealso::
+
+       :func:`rank` and :func:`nranks` — the per-rank equivalents for InCore
+       kernels, called on a :class:`CommCtx` obtained via
+       :func:`get_comm_ctx`.
     """
     return Scalar(expr=_ir_system.world_size())
 
@@ -127,6 +139,14 @@ def notify(
     so the printed IR (which emits them positionally) round-trips through the
     parser; ``op`` stays keyword-only because it lowers to an IR attr (printed
     as ``op=<int>``), mirroring ``pld.tensor.window``'s ``dtype``.
+
+    .. note::
+
+       The first parameter is named ``target`` for legacy reasons (inherited
+       from early signal protocol drafts).  The companion :func:`wait` names
+       the same logical operand ``signal``.  Both refer to the signal
+       :class:`DistributedTensor` — always use positional args:
+       ``notify(signal, peer=..., ...)``.
 
     Args:
         target: Window-bound :class:`pld.DistributedTensor` signal matrix. The

--- a/python/pypto/language/distributed/op/system_ops.py
+++ b/python/pypto/language/distributed/op/system_ops.py
@@ -37,7 +37,6 @@ from collections.abc import Sequence
 
 from pypto.ir.op.distributed import system_ops as _ir_system
 from pypto.language.typing import IntLike, Scalar
-from pypto.language.typing.tensor import Tensor
 from pypto.pypto_core.ir import Call, NotifyOp, WaitCmp
 
 from ..typing.comm_ctx import CommCtx
@@ -122,7 +121,7 @@ def nranks(ctx: CommCtx) -> Scalar:
 
 
 def notify(
-    target: Tensor,
+    target: DistributedTensor,
     peer: IntLike,
     offsets: Sequence[IntLike],
     value: IntLike,
@@ -142,12 +141,9 @@ def notify(
 
     .. note::
 
-       The first parameter is named ``target`` for legacy reasons (inherited
-       from early signal protocol drafts).  The companion :func:`wait` names
-       the same logical operand ``signal``.  Both refer to the signal
-       :class:`DistributedTensor` — pass the first operand positionally; the
-       remaining operands may be positional or keyword:
-       ``notify(signal, peer=..., ...)``.
+       ``notify`` names this operand ``target``; the companion ``wait`` names
+       the same logical operand ``signal``. Both refer to the same
+       window-bound signal tensor.
 
     Args:
         target: Window-bound :class:`pld.DistributedTensor` signal matrix. The
@@ -162,7 +158,7 @@ def notify(
 
 
 def wait(
-    signal: Tensor,
+    signal: DistributedTensor,
     offsets: Sequence[IntLike],
     expected: IntLike,
     *,

--- a/python/pypto/language/distributed/op/tensor_ops.py
+++ b/python/pypto/language/distributed/op/tensor_ops.py
@@ -549,7 +549,10 @@ def allreduce(
     for each allreduce call. All allreduce calls in ``for`` and ``while``
     loops are rejected because the current signal protocol cannot provide a
     fresh signal for every dynamic iteration. A self-resetting variant is
-    blocked on a runtime fix — PTOAS issue #797.
+    blocked on a runtime fix — tracked in #2156 (that issue's affected areas
+    currently list allgather / reduce_scatter / all_to_all / all_to_all_v;
+    allreduce is not listed there yet but hits the identical signal-lifetime
+    constraint, using ``AtomicAdd(1)``/``WaitGe(1)``).
 
     .. seealso::
 
@@ -576,6 +579,10 @@ def allreduce(
     covers the target. The final chunk uses ``valid_shape`` so arbitrary element
     counts do not read or store past the end.
 
+    See ``docs/en/dev/distributed_ops.md`` and
+    ``docs/en/dev/passes/12-lower_composite_ops.md`` for the mesh partial-valid /
+    symbolic-extent target constraints (unchanged by this PR).
+
     **Mesh barrier protocol:** ``AtomicAdd(1) → WaitGe(1)`` is the ready wave.
     Every reduced chunk then performs ``AtomicAdd(1)`` and waits for the
     corresponding monotonic counter value before storing that chunk. By the
@@ -601,7 +608,10 @@ def allreduce(
     for each allreduce call. All allreduce calls in ``for`` and ``while``
     loops are rejected because the current signal protocol cannot provide a
     fresh signal for every dynamic iteration. A self-resetting variant is
-    blocked on a runtime fix — PTOAS issue #797.
+    blocked on a runtime fix — tracked in #2156 (that issue's affected areas
+    currently list allgather / reduce_scatter / all_to_all / all_to_all_v;
+    allreduce is not listed there yet but hits the identical signal-lifetime
+    constraint, using ``AtomicAdd(1)``/``WaitGe(1)``).
 
     Args:
         target: Window-bound :class:`pld.DistributedTensor` holding per-rank
@@ -734,14 +744,14 @@ def allgather(
 ) -> DistributedTensor:
     """All-gather: gather data from all ranks (push-based).
 
-    Unified 3-arg form: ``pld.tensor.allgather(input, target, signal)``.
-    ``input`` is this rank's single ``[1, SIZE]`` chunk; every rank pushes it
+    Unified 3-arg form: ``pld.tensor.allgather(local_data, target, signal)``.
+    ``local_data`` is this rank's single ``[1, SIZE]`` chunk; every rank pushes it
     into every peer's ``target`` row ``my_rank`` via TPUT, then synchronises
     with a notify/wait barrier.  Returns ``target`` in-place (window-as-result
     — same idiom as ``all_to_all`` / ``reduce_scatter`` / ``broadcast``).
 
-    ``input`` must be a DIFFERENT buffer from ``target`` — never pass the same
-    window for both.  On the HOST path ``input`` is a ``[1, SIZE]`` staging
+    ``local_data`` must be a DIFFERENT buffer from ``target`` — never pass the same
+    window for both.  On the HOST path ``local_data`` is a ``[1, SIZE]`` staging
     window populated by an earlier publish step; on the InCore path it is a
     plain :class:`pl.Tensor` ``[1, SIZE]`` — both are accepted.  HOST vs InCore
     is a function-context property resolved by the lowering passes.

--- a/python/pypto/language/distributed/op/tensor_ops.py
+++ b/python/pypto/language/distributed/op/tensor_ops.py
@@ -193,7 +193,7 @@ def alloc_window_buffer(  # type: ignore[no-redef]
     * **Shape+dtype convenience overload:**
       ``alloc_window_buffer(shape, *, dtype=..., name=...)`` — ``shape`` is a
       list / tuple of per-rank dimensions.  The byte size is computed
-      automatically as ``product(shape) × dtype.get_byte()`` and the call
+      automatically as ``product(shape) x dtype.get_byte()`` and the call
       normalizes to the canonical byte form.  ``dtype`` is required when
       ``shape`` is a sequence and rejected otherwise.
 
@@ -219,6 +219,17 @@ def alloc_window_buffer(  # type: ignore[no-redef]
         binds it to the LHS as a plain :class:`ir.Var`; passing that Var
         through :func:`window` materialises a :class:`DistributedTensor`
         view.
+
+    .. note::
+
+       This function is callable only inside HOST-level orchestration
+       (``level=pl.Level.HOST, role=pl.Role.Orchestrator``). Calling it
+       inside InCore (``type=pl.FunctionType.InCore``) raises a parser error.
+
+    .. seealso::
+
+       :func:`window` for creating typed DistributedTensor views over an
+       allocated buffer.
 
     Raises:
         ValueError: If ``name`` is empty (the parser must have injected it).
@@ -274,6 +285,11 @@ def window(
 
     Returns:
         A :class:`DistributedTensor` view of the given shape and dtype.
+
+    .. seealso::
+
+       :func:`alloc_window_buffer` for the two-phase ``alloc → window`` pattern.
+
     """
     buf_expr = _unwrap(buf)
     if not isinstance(buf_expr, Expr):
@@ -519,10 +535,33 @@ def allreduce(
         pub = pld.tensor.allreduce(pub, sig, op=pld.ReduceOp.Sum)
         pub = pld.tensor.allreduce(pub, sig, op=pld.ReduceOp.Sum, mode="ring")
 
+        # Mesh mode on the host orchestrator can omit the signal argument:
+        pub = pld.tensor.allreduce(pub, op=pld.ReduceOp.Sum)
+
+    **Signal shape:** host builtins accept rank-1 ``[world_size]`` or rank-2
+    ``[world_size, 1]`` (the compiler-synthesized signal is rank-2). InCore
+    composites take rank-2 ``[nranks, 1]`` for mesh -- the rank count may be
+    dynamic -- and ``[2*(NR-1), NR]`` for ring, where ``NR`` must be a
+    compile-time constant. Both are single-shot per call.
+
+    **Do not reuse the same signal buffer for a back-to-back allreduce**
+    — allocate a fresh signal buffer (``alloc_window_buffer`` + ``window``)
+    for each allreduce call. All allreduce calls in ``for`` and ``while``
+    loops are rejected because the current signal protocol cannot provide a
+    fresh signal for every dynamic iteration. A self-resetting variant is
+    blocked on a runtime fix — PTOAS issue #797.
+
+    .. seealso::
+
+        :func:`alloc_window_buffer` and :func:`window` for buffer allocation
+        and view creation.
+
+    .. rubric:: Implementation Notes
+
     LowerCompositeOps expands the explicit-signal InCore form into either:
     (a) a notify/wait ready barrier followed by UB-sized
     remote_load+accumulate/store chunks for ``mode="mesh"`` (default); or
-    (b) the NCCL-style 2(P−1)-step
+    (b) the NCCL-style 2(P-1)-step
     chunked reduce-scatter + allgather ring schedule for ``mode="ring"``.
     In both modes the kernel sees only the lowered primitives.
     Host-orchestrator code can omit ``signal``
@@ -531,26 +570,11 @@ def allreduce(
     (mesh mode only — ring mode on the HOST rail is delivered by a
     subsequent host builtin).
 
-    Mesh signal shape is ``[NR, 1]``; ring signal shape is
-    ``[2 * (NR − 1), NR]`` (one row per ring round). Both are single-shot
-    per call.
-
     Fully-valid packed mesh targets are viewed as one logical 1D stream and
     processed in chunks of at most 16 KiB. For statically known smaller targets,
     the physical chunk width shrinks to the smallest 32-byte-aligned width that
     covers the target. The final chunk uses ``valid_shape`` so arbitrary element
-    counts do not read or store past the end. Mesh lowering
-    also preserves a packed ND target ``TensorView.valid_shape`` when
-    its valid box can be represented by collapsing leading dimensions to one
-    2D rectangle and fits within one 16-KiB chunk, and reduces only that
-    rectangle with the established single-rectangle path. Oversized partial
-    rectangles, strided targets, DN partial views, and
-    non-representable partial boxes are rejected explicitly.
-    Any symbolic target or partial-valid extent that survives lowering must be
-    runtime-bound by a kernel scalar, loop variable, or physical tensor-shape
-    parameter; a symbol that appears only in type metadata is rejected during
-    PTO codegen. A fully dynamic physical target dimension is bound from that
-    tensor parameter.
+    counts do not read or store past the end.
 
     **Mesh barrier protocol:** ``AtomicAdd(1) → WaitGe(1)`` is the ready wave.
     Every reduced chunk then performs ``AtomicAdd(1)`` and waits for the
@@ -633,13 +657,16 @@ def barrier(
     """Cross-rank barrier synchronisation.
 
     Blocks until all ranks in the comm group have reached the barrier.
-    Uses a window-bound INT32 ``signal`` matrix for cross-rank
-    synchronisation (one slot per rank).  LowerCompositeOps expands this
+    Uses a window-bound INT32 ``signal`` tensor for cross-rank
+    synchronisation.  LowerCompositeOps expands this
     into a notify-all / wait-all sequence.
 
     .. code-block:: python
 
         sig = pld.tensor.barrier(sig)
+
+    **Signal shape:** host builtins require rank-1 ``[world_size]``. InCore
+    composites take rank-2 ``[nranks, 1]`` -- the rank count may be dynamic.
 
     **Signal buffer is single-shot per call.**  The lowering uses
     ``Set(1)`` + ``Ge(1)`` — cells go from 0 to 1.  Do not reuse the
@@ -668,8 +695,11 @@ def broadcast(
     """Broadcast root rank's data to all ranks.
 
     After this call returns, every rank's slice of ``target`` holds
-    root's data.  Uses a window-bound INT32 ``signal`` matrix for the
+    root's data.  Uses a window-bound INT32 ``signal`` tensor for the
     cross-rank barrier.
+
+    **Signal shape:** host builtins require rank-1 ``[world_size]``. InCore
+    composites take rank-2 ``[nranks, 1]`` -- the rank count may be dynamic.
 
     .. code-block:: python
 
@@ -716,6 +746,10 @@ def allgather(
     plain :class:`pl.Tensor` ``[1, SIZE]`` — both are accepted.  HOST vs InCore
     is a function-context property resolved by the lowering passes.
 
+    **Signal shape:** host builtins accept rank-1 ``[world_size]`` or rank-2
+    ``[world_size, 1]``. InCore composites take rank-2 ``[nranks, 1]`` -- the
+    rank count may be dynamic.
+
     Args:
         local_data: This rank's single chunk — ``[1, SIZE]`` :class:`pl.Tensor`
             (InCore) or ``[1, SIZE]`` :class:`pld.DistributedTensor` staging
@@ -751,6 +785,9 @@ def reduce_scatter(
             data = pl.store(chunk_j, [j, 0], data)
         data = pld.tensor.reduce_scatter(data, sig, op=pld.ReduceOp.Sum)
         # data[my_rank, 0:SIZE] now holds this rank's reduced chunk.
+
+    **Signal shape:** host builtins require rank-1 ``[world_size]``. InCore
+    composites take rank-2 ``[nranks, 1]`` -- the rank count may be dynamic.
 
     Args:
         target: Window-bound :class:`pld.DistributedTensor` of shape
@@ -790,6 +827,10 @@ def all_to_all(
     by an earlier InCore step) rather than the InCore composite's plain
     :class:`pl.Tensor` — both are accepted.
 
+    **Signal shape:** host builtins accept rank-1 ``[world_size]`` or rank-2
+    ``[world_size, 1]``. InCore composites take rank-2 ``[nranks, 1]`` -- the
+    rank count may be dynamic.
+
     Args:
         input: [NR, SIZE] Tensor or DistributedTensor with per-destination
             chunks, distinct from ``target``.  ``input[dest, :]`` is the
@@ -797,7 +838,9 @@ def all_to_all(
         target: :class:`pld.DistributedTensor` [NR, SIZE] window that receives
             the result in-place.  After the call,
             ``target[src, :]`` holds the chunk received from rank ``src``.
-        signal: :class:`pld.DistributedTensor` [NR, 1] INT32 barrier.
+        signal: Window-bound INT32 :class:`pld.DistributedTensor` barrier
+            tensor.  Rank-1 ``[world_size]`` or rank-2 ``[world_size, 1]``
+            for host builtins; rank-2 ``[nranks, 1]`` for InCore composites.
 
     Returns:
         The ``target`` :class:`pld.DistributedTensor` (window-as-result).

--- a/python/pypto/language/distributed/op/tile_ops.py
+++ b/python/pypto/language/distributed/op/tile_ops.py
@@ -145,8 +145,10 @@ def remote_store(
 
     .. code-block:: python
 
-       # Write a computed tile into peer rank 1's signal cell.
-       pld.tile.remote_store(tile, signal, peer=1, offsets=[0, 0])
+       # Write a computed tile into peer rank 1's data window.
+       pld.tile.remote_store(tile, data, peer=1, offsets=[0, 0])
+       # remote_store is a raw write with no synchronization of its own —
+       # pair it with pld.system.notify()/wait() to signal completion.
 
     All arguments are positional-or-keyword (mirroring :func:`pl.tile.store`),
     so the printed IR — which emits them positionally — round-trips through

--- a/python/pypto/language/distributed/op/tile_ops.py
+++ b/python/pypto/language/distributed/op/tile_ops.py
@@ -53,6 +53,13 @@ def remote_load(
     is a *remote* slice of a window-bound :class:`pld.DistributedTensor`.
     Address translation happens at codegen via ``CommRemoteOffset`` + addptr + make_tensor_view.
 
+    .. code-block:: python
+
+       # Barrier example — after notify/wait, all windows are visible.
+       peer_tile = pld.tile.remote_load(
+           data, peer=peer, offsets=[0, 0], shape=[1, SIZE]
+       )
+
     All arguments are positional-or-keyword (mirroring :func:`pl.tile.load`),
     so the printed IR — which emits them positionally — round-trips through
     the parser. Callers may still pass them by keyword for readability.
@@ -135,6 +142,11 @@ def remote_store(
     destination is a *remote* slice of a window-bound
     :class:`pld.DistributedTensor`. Address translation happens at codegen
     via ``CommRemoteOffset`` + addptr + make_tensor_view.
+
+    .. code-block:: python
+
+       # Write a computed tile into peer rank 1's signal cell.
+       pld.tile.remote_store(tile, signal, peer=1, offsets=[0, 0])
 
     All arguments are positional-or-keyword (mirroring :func:`pl.tile.store`),
     so the printed IR — which emits them positionally — round-trips through

--- a/python/pypto/language/dsl_api.py
+++ b/python/pypto/language/dsl_api.py
@@ -712,18 +712,13 @@ def spmd(
     ``range(n)``. Loop start is fixed at 0 and step at 1; each block gets an
     index ``i`` in ``[0, core_num)``.
 
-    .. rubric:: Three usage forms at a glance
+    **Three usage forms at a glance:**
 
-    ==============================  ===================================================
-    Form                             Description
-    ==============================  ===================================================
-    ``with pl.spmd(n):``             Dispatch or inline block (no captured TaskId).
-    ``for i in pl.spmd(n):``         Loop-style; ``i`` = per-block index, body
-                                    is auto-outlined to InCore.
-    ``with pl.spmd(n) as tid:``      Same body shapes as form 1, plus captured
-                                    producer TaskId in ``tid``.  Optionally pass
-                                    ``deps=[...]`` after ``n``.
-    ==============================  ===================================================
+    | Form | Description |
+    | --- | --- |
+    | `with pl.spmd(n):` | Dispatch or inline block (no captured TaskId). |
+    | `for i in pl.spmd(n):` | Loop-style; `i` = per-block index, body is auto-outlined to InCore. |
+    | `with pl.spmd(n) as tid:` | Same body as form 1, plus TaskId in `tid` (optionally pass `deps=[...]`). |
 
     Usage forms:
 

--- a/python/pypto/language/dsl_api.py
+++ b/python/pypto/language/dsl_api.py
@@ -712,6 +712,19 @@ def spmd(
     ``range(n)``. Loop start is fixed at 0 and step at 1; each block gets an
     index ``i`` in ``[0, core_num)``.
 
+    .. rubric:: Three usage forms at a glance
+
+    ==============================  ===================================================
+    Form                             Description
+    ==============================  ===================================================
+    ``with pl.spmd(n):``             Dispatch or inline block (no captured TaskId).
+    ``for i in pl.spmd(n):``         Loop-style; ``i`` = per-block index, body
+                                    is auto-outlined to InCore.
+    ``with pl.spmd(n) as tid:``      Same body shapes as form 1, plus captured
+                                    producer TaskId in ``tid``.  Optionally pass
+                                    ``deps=[...]`` after ``n``.
+    ==============================  ===================================================
+
     Usage forms:
 
     1. ``with pl.spmd(n):`` — body is either a *dispatch* body calling a

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -1845,11 +1845,27 @@ class ASTParser:
         Parser-only concerns (everything else delegates to the DSL wrapper /
         IR builder / C++ deducer via :func:`invoke_dsl`):
 
+        - HOST-only, like ``world_size`` (see ``_validate_pld_op_call``): the
+          window buffer is a host-orchestration resource, not lowerable inside
+          InCore / SPMD scopes.
         - LHS must be a single ``ast.Name``.
         - That name must be globally unique within the ``@pl.program``.
         - User can't pass ``name=`` (it's parser-injected from the LHS).
         """
         span = self.span_tracker.get_span(value)
+
+        in_device_scope = any(
+            self._is_inside_scope(kind) for kind in (ir.ScopeKind.InCore, ir.ScopeKind.Spmd)
+        )
+        if self._func_level != ir.Level.HOST or in_device_scope:
+            raise ParserSyntaxError(
+                "pld.system.alloc_window_buffer() can only be called in HOST orchestration "
+                "context (not inside InCore / SPMD scopes); "
+                f"current function level: {self._func_level}",
+                span=span,
+                hint="Use '@pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)' "
+                "on the enclosing function and call outside any nested device-side scope",
+            )
 
         if not isinstance(target, ast.Name):
             raise ParserSyntaxError(

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -1859,7 +1859,7 @@ class ASTParser:
         )
         if self._func_level != ir.Level.HOST or in_device_scope:
             raise ParserSyntaxError(
-                "pld.system.alloc_window_buffer() can only be called in HOST orchestration "
+                "pld.tensor.alloc_window_buffer() can only be called in HOST orchestration "
                 "context (not inside InCore / SPMD scopes); "
                 f"current function level: {self._func_level}",
                 span=span,

--- a/python/pypto/pypto_core/ir.pyi
+++ b/python/pypto/pypto_core/ir.pyi
@@ -2298,7 +2298,15 @@ class ReduceOp(enum.IntEnum):
     """Reduction operator for collective reductions — ``pld.tensor.allreduce`` and friends.
 
     Stored as ``int`` in op kwargs; the C++ deducer validates the int falls
-    within this enum's range.
+    within this enum's range. Support is per-operation, not uniform across
+    the enum:
+
+    .. note::
+
+       **Per-operation support:** ``pld.tensor.allreduce`` (both the InCore
+       composite and the HOST builtin) accepts all four values. Other
+       reducing collectives are narrower — ``pld.tensor.reduce_scatter``
+       accepts only :attr:`Sum` and rejects the rest at the deducer.
     """
 
     Sum = 0

--- a/python/pypto/runtime/bench.py
+++ b/python/pypto/runtime/bench.py
@@ -410,22 +410,23 @@ def _mean_of(invocations: Sequence["TraceInvocation"]) -> "TraceInvocation | Non
 class BenchmarkStats:
     """Aggregated per-launch timing from :func:`benchmark`.
 
-    .. rubric:: Quick-reference
+    **Quick-reference:**
 
-    ============================== =========================================================
-    Accessor                       Description
-    ============================== =========================================================
-    ``stats.device_us_median``     Median device wall (µs).
-    ``stats.device_us_min``        Minimum device wall (µs).
-    ``stats.device_us_max``        Maximum device wall (µs).
-    ``stats.device_us_mean``       Arithmetic mean device wall (µs).
-    ``stats.device_us_stdev``      Std-dev of device wall (µs).
-    ``stats.all_zero_device``      True if samples exist and every sample is 0 (e.g. sim builds).
-    ``stats.samples``              Alias for ``device_wall_us`` (the raw list).
-    ``stats.per_round("device")``  List[float]: device wall per round.
-    ``stats.per_rank("device")``   Dict[int, List[float]]: per-rank breakdown (L3).
-    ``stats.print_tree()``         Render per-dispatch span tree to stdout.
-    ============================== =========================================================
+    | Accessor | Description |
+    | --- | --- |
+    | `stats.device_us_median` | Median device wall (µs). |
+    | `stats.device_us_min` | Minimum device wall (µs). |
+    | `stats.device_us_max` | Maximum device wall (µs). |
+    | `stats.device_us_mean` | Arithmetic mean device wall (µs). |
+    | `stats.device_us_stdev` | Std-dev of device wall (µs). |
+    | `stats.all_zero_device` | True if samples exist and every sample is 0 (e.g. sim builds). |
+    | `stats.samples` | Alias for `device_wall_us` (the raw list). |
+    | `stats.per_round("device")` | List[float]: device wall per round. |
+    | `stats.per_rank("device")` | Dict[int, List[float]]: per-rank breakdown (L3). |
+    | `stats.per_dispatch("device")` | Dict[(pid, slot), List[float]]: per-dispatch (unsummed) view (L3). |
+    | `stats.dispatch_tasks()` | Dict[(pid, slot), str]: task name (or hash) labelling each dispatch slot. |
+    | `stats.unstable_dispatch_slots` | True if a rank's dispatch order varies between rounds (L3). |
+    | `stats.print_tree()` | Render per-dispatch span tree to stdout. |
 
     The min / median / mean / max / stdev helpers operate on
     ``device_wall_us`` — the on-NPU metric. ``host_wall_us`` samples are kept

--- a/python/pypto/runtime/bench.py
+++ b/python/pypto/runtime/bench.py
@@ -420,7 +420,7 @@ class BenchmarkStats:
     ``stats.device_us_max``        Maximum device wall (µs).
     ``stats.device_us_mean``       Arithmetic mean device wall (µs).
     ``stats.device_us_stdev``      Std-dev of device wall (µs).
-    ``stats.all_zero_device``      True if every sample is 0 (e.g. sim builds).
+    ``stats.all_zero_device``      True if samples exist and every sample is 0 (e.g. sim builds).
     ``stats.samples``              Alias for ``device_wall_us`` (the raw list).
     ``stats.per_round("device")``  List[float]: device wall per round.
     ``stats.per_rank("device")``   Dict[int, List[float]]: per-rank breakdown (L3).

--- a/python/pypto/runtime/bench.py
+++ b/python/pypto/runtime/bench.py
@@ -410,6 +410,23 @@ def _mean_of(invocations: Sequence["TraceInvocation"]) -> "TraceInvocation | Non
 class BenchmarkStats:
     """Aggregated per-launch timing from :func:`benchmark`.
 
+    .. rubric:: Quick-reference
+
+    ============================== =========================================================
+    Accessor                       Description
+    ============================== =========================================================
+    ``stats.device_us_median``     Median device wall (µs).
+    ``stats.device_us_min``        Minimum device wall (µs).
+    ``stats.device_us_max``        Maximum device wall (µs).
+    ``stats.device_us_mean``       Arithmetic mean device wall (µs).
+    ``stats.device_us_stdev``      Std-dev of device wall (µs).
+    ``stats.all_zero_device``      True if every sample is 0 (e.g. sim builds).
+    ``stats.samples``              Alias for ``device_wall_us`` (the raw list).
+    ``stats.per_round("device")``  List[float]: device wall per round.
+    ``stats.per_rank("device")``   Dict[int, List[float]]: per-rank breakdown (L3).
+    ``stats.print_tree()``         Render per-dispatch span tree to stdout.
+    ============================== =========================================================
+
     The min / median / mean / max / stdev helpers operate on
     ``device_wall_us`` — the on-NPU metric. ``host_wall_us`` samples are kept
     for context, but they include per-launch arg coercion + H2D and so are not

--- a/tests/ut/ir/parser/test_alloc_window_buffer.py
+++ b/tests/ut/ir/parser/test_alloc_window_buffer.py
@@ -84,6 +84,35 @@ def test_alloc_window_buffer_lhs_is_plain_ptr_var():
     assert var.name_hint == "buf"
 
 
+def test_alloc_window_buffer_rejected_outside_host_function():
+    """``pld.alloc_window_buffer()`` is host-only — calling it from a
+    CORE_GROUP-level function body is a parse error."""
+    with pytest.raises(ParserSyntaxError, match="HOST"):
+
+        @pl.program
+        class P:  # noqa: F841
+            @pl.function
+            def kernel(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                with pl.at(level=pl.Level.CORE_GROUP):
+                    buf = pld.alloc_window_buffer(1024)  # noqa: F841
+                return x
+
+
+def test_alloc_window_buffer_rejected_in_nested_device_scope_within_host_function():
+    """Even inside a HOST orchestrator, ``pld.alloc_window_buffer()`` must be
+    rejected when nested inside a device-side scope (InCore / SPMD), since
+    the call is not lowerable there."""
+    with pytest.raises(ParserSyntaxError, match="InCore"):
+
+        @pl.program
+        class P:  # noqa: F841
+            @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+            def host_orch(self):
+                with pl.at(level=pl.Level.CORE_GROUP):
+                    buf = pld.alloc_window_buffer(1024)  # noqa: F841
+                return 0
+
+
 def test_alloc_window_buffer_call_carries_name_kwarg():
     """The op call's kwargs carry the LHS-injected name. No dtype kwarg."""
 


### PR DESCRIPTION
## Summary

Split out of #2162 (which is being broken into smaller PRs — see that
PR's description). This piece is fully independent of the rest: pure
Python docstring / type-stub corrections found while writing the
distributed-programming and benchmarking user-manual chapters.

- **`ir.pyi`**: `ReduceOp`'s docstring claimed only `Sum` is operational
  and that `Max`/`Min`/`Prod` "raise a C++ deducer error if passed to
  any collective." That's wrong — `allreduce` accepts all four (both
  InCore and HOST paths); only `reduce_scatter` is actually `Sum`-only.
  Restated per-operation.
- **`tensor_ops.py`**: per-operation signal-shape docstrings. Previously
  uniform ("rank-1 or rank-2" for every collective) — actually only
  `allreduce`/`allgather`/`all_to_all` accept both ranks on the HOST
  builtin path; `barrier`/`broadcast`/`reduce_scatter` are rank-1-only.
- **`system_ops.py`, `tile_ops.py`, `dsl_api.py`, `bench.py`,
  `distributed_compiled_program.py`**: docstring completeness fixes —
  `DistributedConfig` field documentation, dispatch examples, the
  `spmd` three-form table, and a couple of missing code examples.

Addressed review feedback (see PR discussion) in a follow-up commit:
- Added real HOST-only parser enforcement for `alloc_window_buffer`
  (previously only claimed by the docstring), with tests.
- Fixed the `num_sub_workers=0` docstring to match actual runtime
  semantics (`max(num_sub_workers, len(sub_worker_fns))`).
- Corrected a wrong issue reference in the allreduce signal-reuse note.
- Added a pointer to where the mesh partial-valid / symbolic-extent
  constraints are documented (unchanged, just relocated out of this
  docstring).
- Converted two non-rendering RST tables to Markdown (the docs site
  renders docstrings as Markdown, not RST), extending the
  `BenchmarkStats` one to cover the per-dispatch API added by #2223.
- Fixed `DistributedConfig`'s docstring section header
  (`Fields:` → `Attributes:`) and stale `allgather` prose referring to
  a since-renamed parameter.
- Dropped an unverifiable "legacy reasons" history claim from `notify`'s
  docstring note.

`notify`/`wait`'s signal parameter type (`Tensor` vs. `DistributedTensor`)
was intentionally **not** narrowed here: doing so broke `pyright` on two
legitimate call sites where a loop-carried `DistributedTensor` value
loses its static type through `pl.range`/`pl.while_`. That's tracked
separately in #2234, along with the type-narrowing itself.

No behavior changes beyond the `alloc_window_buffer` scope check
(makes parse-time behavior match what was already enforced at runtime).

## Verification

- `python -c "import ast; ast.parse(...)"` on every changed file
- `pre-commit run --files <changed files>` (ruff check/format, pyright,
  headers) — all pass
- Full `pytest tests/ut` suite (8433 passed, 13 skipped, 0 failed) run
  via the `pypto3-hw-native-sys:sim` Docker image
- Manually rendered the two converted docstrings through
  `markdown.markdown(..., extensions=["tables"])` to confirm they now
  produce real `<table>` elements (previously collapsed to one
  paragraph under RST simple-table syntax)

