### PR TITLE
docs(user): add the Distributed Programming chapter

### DIFF
--- a/docs/en/user/distributed/00-model.md
+++ b/docs/en/user/distributed/00-model.md
@@ -87,6 +87,26 @@ class HelloAllReduce:
         return outputs
 ```
 
+### Running It
+
+Save the class above and the driver below into the same file (`script.py`):
+
+```python
+import torch
+from pypto import ir
+from pypto.ir.distributed_compiled_program import DistributedConfig
+
+dc = DistributedConfig(device_ids=[0, 1])
+compiled = ir.compile(HelloAllReduce, platform="a2a3", distributed_config=dc)
+
+inputs = torch.randn(2, 1, SIZE)
+outputs = torch.zeros_like(inputs)
+compiled(inputs, outputs)   # blocks until both ranks finish
+```
+
+This is the "one-shot" dispatch pattern. See [03-execution](03-execution.md)
+for `DistributedWorker`, persistent workers, and multi-program dispatch.
+
 ### Expected Output
 
 `outputs[r] == sum(inputs[*])` for every rank `r`. For 2 ranks with inputs
@@ -98,9 +118,8 @@ class HelloAllReduce:
 python script.py
 ```
 
-No multi-process launcher is involved. `DistributedConfig(device_ids=[...])`
-tells the compiled program which devices to use; the runtime forks one worker
-process per device from this single Python process.
+No multi-process launcher is involved — the runtime forks one worker
+process per device (per `device_ids`) from this single Python process.
 
 ## What Is Distributed Programming in PyPTO?
 
@@ -151,7 +170,9 @@ buffers through `CommContext`.
 
 `alloc_window_buffer(size)` creates per-rank buffers. `window(buf, shape, dtype)`
 creates typed views. Buffers live for the duration of the host orchestrator call;
-there is no persistent IPC between orchestrator invocations.
+there is no persistent IPC between orchestrator invocations **by default** —
+see [03-execution](03-execution.md) § `persistent=True` to retain windows
+across dispatches.
 
 ### Control Plane vs Execution Plane
 
@@ -178,7 +199,7 @@ InCore kernel (@pl.function(type=InCore))
 | `NR = pl.dynamic("NR")` | The world size is not known at build time. `pl.dynamic` defers the dimension to runtime dispatch — the host binds it from `len(device_ids)`. |
 | `pl.InOut[pld.DistributedTensor[...]]` | `data` and `signal` are window-bound: every rank shares the same address space layout. `InOut` means the kernel both reads and writes them. |
 | `pld.get_comm_ctx(data)` | Lifts the window-bound tensor into a comm-domain handle. Every rank gets its own `ctx`, from which `rank()` and `nranks()` read per-rank values. |
-| `pld.system.notify(..., op=AtomicAdd)` | Each rank atomically adds 1 to every peer's signal slot. `AtomicAdd` is correct here because N ranks write the same slot (it's a global barrier). For a 1:1 handshake, use `Set` instead. |
+| `pld.system.notify(..., op=AtomicAdd)` | Each rank atomically adds 1 to every peer's signal slot. With `offsets=[my_rank, 0]`, each cell has exactly one writer, so `Set` would work identically here — `AtomicAdd` is shown because it's the same notify call every barrier in this doc uses. It's only required for a *shared*-cell barrier where multiple ranks write the same slot; see [02-primitives](02-primitives.md) § "The Barrier in Isolation" for the distinction. |
 | `pld.system.wait(..., cmp=Ge, expected=1)` | Blocks until the local signal slot reaches at least 1 — meaning all peer notifies have landed. |
 | `pld.tile.remote_load(...)` | Reads a **remote** slice of a `DistributedTensor` into a local tile. This is the tile-level cross-rank equivalent of `pl.tile.load`. |
 | `pl.add(acc, peer_tile)` | The local add loop sums all peer contributions. After the loop, `acc` holds `sum(inputs[*])`. |

--- a/docs/en/user/distributed/00-model.md
+++ b/docs/en/user/distributed/00-model.md
@@ -15,93 +15,88 @@ import pypto.language.distributed as pld
 NR = pl.dynamic("NR")
 SIZE = 256
 
-@pl.program
-class HelloAllReduce:
-    @pl.function(type=pl.FunctionType.InCore)
-    def reduce_step(
-        self,
-        inp: pl.Tensor[[1, SIZE], pl.FP32],
-        out: pl.Out[pl.Tensor[[1, SIZE], pl.FP32]],
-        data: pl.InOut[pld.DistributedTensor[[1, SIZE], pl.FP32]],
-        signal: pl.InOut[pld.DistributedTensor[[NR, 1], pl.INT32]],
-    ) -> pl.Tensor[[1, SIZE], pl.FP32]:
-        ctx = pld.get_comm_ctx(data)
-        my_rank = pld.rank(ctx)
-        nranks = pld.nranks(ctx)
+@pl.jit.incore
+def reduce_step(
+    inp: pl.Tensor[[1, SIZE], pl.FP32],
+    out: pl.Out[pl.Tensor[[1, SIZE], pl.FP32]],
+    data: pl.InOut[pld.DistributedTensor[[1, SIZE], pl.FP32]],
+    signal: pl.InOut[pld.DistributedTensor[[NR, 1], pl.INT32]],
+) -> pl.Tensor[[1, SIZE], pl.FP32]:
+    ctx = pld.get_comm_ctx(data)
+    my_rank = pld.rank(ctx)
+    nranks = pld.nranks(ctx)
 
-        # 1. Stage-in: copy local input into this rank's window slice.
-        local = pl.load(inp, [0, 0], [1, SIZE])
-        data = pl.store(local, [0, 0], data)
+    # 1. Stage-in: copy local input into this rank's window slice.
+    local = pl.load(inp, [0, 0], [1, SIZE])
+    data = pl.store(local, [0, 0], data)
 
-        # 2. Barrier: notify every peer, then wait on every peer.
-        for peer in pl.range(nranks):
-            if peer != my_rank:
-                pld.system.notify(
-                    signal, peer=peer, offsets=[my_rank, 0],
-                    value=1, op=pld.NotifyOp.AtomicAdd,
-                )
-        for src in pl.range(nranks):
-            if src != my_rank:
-                pld.system.wait(
-                    signal, offsets=[src, 0],
-                    expected=1, cmp=pld.WaitCmp.Ge,
-                )
+    # 2. Barrier: notify every peer, then wait on every peer.
+    for peer in pl.range(nranks):
+        if peer != my_rank:
+            pld.system.notify(
+                signal, peer=peer, offsets=[my_rank, 0],
+                value=1, op=pld.NotifyOp.AtomicAdd,
+            )
+    for src in pl.range(nranks):
+        if src != my_rank:
+            pld.system.wait(
+                signal, offsets=[src, 0],
+                expected=1, cmp=pld.WaitCmp.Ge,
+            )
 
-        # 3. Compute: accumulate every peer's slice.
-        acc = pl.load(data, [0, 0], [1, SIZE])
-        for peer in pl.range(nranks):
-            if peer != my_rank:
-                peer_tile = pld.tile.remote_load(
-                    data, peer=peer, offsets=[0, 0], shape=[1, SIZE]
-                )
-                acc = pl.add(acc, peer_tile)
+    # 3. Compute: accumulate every peer's slice.
+    acc = pl.load(data, [0, 0], [1, SIZE])
+    for peer in pl.range(nranks):
+        if peer != my_rank:
+            peer_tile = pld.tile.remote_load(
+                data, peer=peer, offsets=[0, 0], shape=[1, SIZE]
+            )
+            acc = pl.add(acc, peer_tile)
 
-        # 4. Stage-out: store the accumulator to local output.
-        return pl.store(acc, [0, 0], out)
+    # 4. Stage-out: store the accumulator to local output.
+    return pl.store(acc, [0, 0], out)
 
-    @pl.function(type=pl.FunctionType.Orchestration)
-    def chip_orch(
-        self,
-        inp: pl.Tensor[[1, SIZE], pl.FP32],
-        out: pl.Out[pl.Tensor[[1, SIZE], pl.FP32]],
-        data: pl.InOut[pld.DistributedTensor[[1, SIZE], pl.FP32]],
-        signal: pl.InOut[pld.DistributedTensor[[NR, 1], pl.INT32]],
-    ) -> pl.Tensor[[1, SIZE], pl.FP32]:
-        # Per-device orchestration wrapper — HOST dispatches this, not the
-        # InCore kernel directly.
-        return self.reduce_step(inp, out, data, signal)
+@pl.jit
+def chip_orch(
+    inp: pl.Tensor[[1, SIZE], pl.FP32],
+    out: pl.Out[pl.Tensor[[1, SIZE], pl.FP32]],
+    data: pl.InOut[pld.DistributedTensor[[1, SIZE], pl.FP32]],
+    signal: pl.InOut[pld.DistributedTensor[[NR, 1], pl.INT32]],
+) -> pl.Tensor[[1, SIZE], pl.FP32]:
+    # Per-device orchestration wrapper — HOST dispatches this, not the
+    # InCore kernel directly.
+    return reduce_step(inp, out, data, signal)
 
-    @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
-    def orchestrator(
-        self,
-        inputs: pl.Tensor[[NR, 1, SIZE], pl.FP32],
-        outputs: pl.Out[pl.Tensor[[NR, 1, SIZE], pl.FP32]],
-    ) -> pl.Tensor[[NR, 1, SIZE], pl.FP32]:
-        data_buf = pld.alloc_window_buffer(SIZE * pl.FP32.get_byte())
-        signal_buf = pld.alloc_window_buffer(pld.world_size() * pl.INT32.get_byte())
+@pl.jit.host
+def orchestrator(
+    inputs: pl.Tensor[[NR, 1, SIZE], pl.FP32],
+    outputs: pl.Out[pl.Tensor[[NR, 1, SIZE], pl.FP32]],
+) -> pl.Tensor[[NR, 1, SIZE], pl.FP32]:
+    data_buf = pld.alloc_window_buffer(SIZE * pl.FP32.get_byte())
+    signal_buf = pld.alloc_window_buffer(pld.world_size() * pl.INT32.get_byte())
 
-        for r in pl.range(pld.world_size()):
-            data = pld.window(data_buf, [1, SIZE], dtype=pl.FP32)
-            signal = pld.window(signal_buf, [pld.world_size(), 1], dtype=pl.INT32)
-            self.chip_orch(inputs[r], outputs[r], data, signal, device=r)
-        return outputs
+    for r in pl.range(pld.world_size()):
+        data = pld.window(data_buf, [1, SIZE], dtype=pl.FP32)
+        signal = pld.window(signal_buf, [pld.world_size(), 1], dtype=pl.INT32)
+        chip_orch(inputs[r], outputs[r], data, signal, device=r)
+    return outputs
 ```
 
 ### Running It
 
-Save the class above and the driver below into the same file (`script.py`):
+Save the functions above and the driver below into the same file (`script.py`):
 
 ```python
 import torch
-from pypto import ir
+from pypto.runtime import RunConfig
 from pypto.ir.distributed_compiled_program import DistributedConfig
 
 dc = DistributedConfig(device_ids=[0, 1])
-compiled = ir.compile(HelloAllReduce, platform="a2a3", distributed_config=dc)
+cfg = RunConfig(platform="a2a3", distributed_config=dc)
 
 inputs = torch.randn(2, 1, SIZE)
 outputs = torch.zeros_like(inputs)
-compiled(inputs, outputs)   # blocks until both ranks finish
+orchestrator(inputs, outputs, config=cfg)   # blocks until both ranks finish
 ```
 
 This is the "one-shot" dispatch pattern. See [03-execution](03-execution.md)
@@ -142,18 +137,17 @@ full API is at [01-collectives](01-collectives.md).
 The HOST function allocates window buffers, dispatches kernels, and manages
 the control plane:
 
-- Declared with `@pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)`
-  or `@pl.jit.host`
+- Declared with `@pl.jit.host`
 - Calls `alloc_window_buffer`, `window()`, and per-rank dispatch via `device=r`
 - Runs once per process — not on the NPU
-- Dispatches a per-device `@pl.function(type=pl.FunctionType.Orchestration)`
-  wrapper (not the `InCore` kernel directly) — see Per-Rank Dispatch below
+- Dispatches a per-device `@pl.jit` wrapper (not the `InCore` kernel directly)
+  — see Per-Rank Dispatch below
 
 ### InCore Kernel
 
 The InCore function runs on the NPU device:
 
-- Declared with `@pl.function(type=pl.FunctionType.InCore)`
+- Declared with `@pl.jit.incore`
 - Receives window-bound `DistributedTensor` arguments
 - Uses `notify`/`wait` for cross-rank sync, `remote_load`/`remote_store` for RMA
 - Never calls `alloc_window_buffer` or `world_size()`
@@ -161,8 +155,8 @@ The InCore function runs on the NPU device:
 ### Per-Rank Dispatch
 
 HOST never dispatches an `InCore` function directly. It dispatches a per-device
-`@pl.function(type=pl.FunctionType.Orchestration)` wrapper by setting `device=r`
-in the function call; that wrapper then calls the `InCore` kernel with no
+`@pl.jit` wrapper by setting `device=r` in the function call; that wrapper then
+calls the `InCore` kernel with no
 `device=` argument. Each rank sees its own view of the symmetric window
 buffers through `CommContext`.
 
@@ -177,19 +171,19 @@ across dispatches.
 ### Control Plane vs Execution Plane
 
 ```text
-HOST orchestrator (@pl.function(level=HOST, role=Orchestrator))
-  ├── alloc_window_buffer(...)        ← control plane: declare layout
-  ├── window(buf, shape, dtype)       ← control plane: create typed view
-  └── for r in ranks:                 ← dispatch loop
-        self.chip_orch(..., device=r) ← bridges to the per-device wrapper
+HOST orchestrator (@pl.jit.host)
+  ├── alloc_window_buffer(...)   ← control plane: declare layout
+  ├── window(buf, shape, dtype)  ← control plane: create typed view
+  └── for r in ranks:            ← dispatch loop
+        chip_orch(..., device=r) ← bridges to the per-device wrapper
 
-Orchestration wrapper (@pl.function(type=Orchestration))
-  └── self.reduce_step(...)          ← calls the InCore kernel, no device=
+Orchestration wrapper (@pl.jit)
+  └── reduce_step(...)           ← calls the InCore kernel, no device=
 
-InCore kernel (@pl.function(type=InCore))
-  ├── notify / wait                  ← execution plane: cross-rank sync
-  ├── remote_load                    ← execution plane: read peer data
-  └── store                          ← execution plane: write local output
+InCore kernel (@pl.jit.incore)
+  ├── notify / wait               ← execution plane: cross-rank sync
+  ├── remote_load                 ← execution plane: read peer data
+  └── store                       ← execution plane: write local output
 ```
 
 ## Line-by-Line Walkthrough
@@ -203,7 +197,7 @@ InCore kernel (@pl.function(type=InCore))
 | `pld.system.wait(..., cmp=Ge, expected=1)` | Blocks until the local signal slot reaches at least 1 — meaning all peer notifies have landed. |
 | `pld.tile.remote_load(...)` | Reads a **remote** slice of a `DistributedTensor` into a local tile. This is the tile-level cross-rank equivalent of `pl.tile.load`. |
 | `pl.add(acc, peer_tile)` | The local add loop sums all peer contributions. After the loop, `acc` holds `sum(inputs[*])`. |
-| `chip_orch` (`@pl.function(type=Orchestration)`) | HOST dispatches this per-device wrapper via `device=r`, not the `InCore` kernel directly. It then calls `reduce_step` with no `device=` argument. |
+| `chip_orch` (`@pl.jit`) | HOST dispatches this per-device wrapper via `device=r`, not the `InCore` kernel directly. It then calls `reduce_step` with no `device=` argument. |
 | `inputs[r]` / `outputs[r]` | Indexing drops the leading rank dimension, giving `reduce_step` the rank-2 `[1, SIZE]` shape it declares — `pl.slice` with an explicit shape would keep the dimension and produce a rank mismatch. |
 
 ## See Also

--- a/docs/en/user/distributed/00-model.md
+++ b/docs/en/user/distributed/00-model.md
@@ -1,0 +1,193 @@
+# Distributed Programming Model
+
+> **Prerequisites:** [Getting Started](../00-getting_started.md) — basic PyPTO
+> tensor/tile model. This guide uses the `pld` namespace
+> (`import pypto.language.distributed as pld`).
+
+## Quickstart: 2-Rank AllReduce
+
+The simplest distributed program — two ranks sum their data, both see the same result.
+
+```python
+import pypto.language as pl
+import pypto.language.distributed as pld
+
+NR = pl.dynamic("NR")
+SIZE = 256
+
+@pl.program
+class HelloAllReduce:
+    @pl.function(type=pl.FunctionType.InCore)
+    def reduce_step(
+        self,
+        inp: pl.Tensor[[1, SIZE], pl.FP32],
+        out: pl.Out[pl.Tensor[[1, SIZE], pl.FP32]],
+        data: pl.InOut[pld.DistributedTensor[[1, SIZE], pl.FP32]],
+        signal: pl.InOut[pld.DistributedTensor[[NR, 1], pl.INT32]],
+    ) -> pl.Tensor[[1, SIZE], pl.FP32]:
+        ctx = pld.get_comm_ctx(data)
+        my_rank = pld.rank(ctx)
+        nranks = pld.nranks(ctx)
+
+        # 1. Stage-in: copy local input into this rank's window slice.
+        local = pl.load(inp, [0, 0], [1, SIZE])
+        data = pl.store(local, [0, 0], data)
+
+        # 2. Barrier: notify every peer, then wait on every peer.
+        for peer in pl.range(nranks):
+            if peer != my_rank:
+                pld.system.notify(
+                    signal, peer=peer, offsets=[my_rank, 0],
+                    value=1, op=pld.NotifyOp.AtomicAdd,
+                )
+        for src in pl.range(nranks):
+            if src != my_rank:
+                pld.system.wait(
+                    signal, offsets=[src, 0],
+                    expected=1, cmp=pld.WaitCmp.Ge,
+                )
+
+        # 3. Compute: accumulate every peer's slice.
+        acc = pl.load(data, [0, 0], [1, SIZE])
+        for peer in pl.range(nranks):
+            if peer != my_rank:
+                peer_tile = pld.tile.remote_load(
+                    data, peer=peer, offsets=[0, 0], shape=[1, SIZE]
+                )
+                acc = pl.add(acc, peer_tile)
+
+        # 4. Stage-out: store the accumulator to local output.
+        return pl.store(acc, [0, 0], out)
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def chip_orch(
+        self,
+        inp: pl.Tensor[[1, SIZE], pl.FP32],
+        out: pl.Out[pl.Tensor[[1, SIZE], pl.FP32]],
+        data: pl.InOut[pld.DistributedTensor[[1, SIZE], pl.FP32]],
+        signal: pl.InOut[pld.DistributedTensor[[NR, 1], pl.INT32]],
+    ) -> pl.Tensor[[1, SIZE], pl.FP32]:
+        # Per-device orchestration wrapper — HOST dispatches this, not the
+        # InCore kernel directly.
+        return self.reduce_step(inp, out, data, signal)
+
+    @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+    def orchestrator(
+        self,
+        inputs: pl.Tensor[[NR, 1, SIZE], pl.FP32],
+        outputs: pl.Out[pl.Tensor[[NR, 1, SIZE], pl.FP32]],
+    ) -> pl.Tensor[[NR, 1, SIZE], pl.FP32]:
+        data_buf = pld.alloc_window_buffer(SIZE * pl.FP32.get_byte())
+        signal_buf = pld.alloc_window_buffer(pld.world_size() * pl.INT32.get_byte())
+
+        for r in pl.range(pld.world_size()):
+            data = pld.window(data_buf, [1, SIZE], dtype=pl.FP32)
+            signal = pld.window(signal_buf, [pld.world_size(), 1], dtype=pl.INT32)
+            self.chip_orch(inputs[r], outputs[r], data, signal, device=r)
+        return outputs
+```
+
+### Expected Output
+
+`outputs[r] == sum(inputs[*])` for every rank `r`. For 2 ranks with inputs
+`[[1, 2, 3]]` and `[[10, 20, 30]]`, both ranks see `[[11, 22, 33]]`.
+
+### Launch Command
+
+```bash
+python script.py
+```
+
+No multi-process launcher is involved. `DistributedConfig(device_ids=[...])`
+tells the compiled program which devices to use; the runtime forks one worker
+process per device from this single Python process.
+
+## What Is Distributed Programming in PyPTO?
+
+PyPTO's distributed model is **symmetric-memory + signals**. Each rank has a
+per-rank **window buffer** with symmetric address spaces across peers.
+Communication happens through one-sided `put`/`get`/`remote_load` plus
+**signal synchronisation** (`notify`/`wait`). A **comm domain** is a subset
+of ranks sharing a symmetric window pool; the full world is the default
+domain.
+
+Every allreduce, broadcast, and barrier the compiler lowers is a composition
+of these same primitives — the `pld.tensor.*` collectives (`allreduce`,
+`barrier`, etc.) are syntactic sugar over them, not a separate library. The
+full API is at [01-collectives](01-collectives.md).
+
+## The Model
+
+### HOST Orchestrator
+
+The HOST function allocates window buffers, dispatches kernels, and manages
+the control plane:
+
+- Declared with `@pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)`
+  or `@pl.jit.host`
+- Calls `alloc_window_buffer`, `window()`, and per-rank dispatch via `device=r`
+- Runs once per process — not on the NPU
+- Dispatches a per-device `@pl.function(type=pl.FunctionType.Orchestration)`
+  wrapper (not the `InCore` kernel directly) — see Per-Rank Dispatch below
+
+### InCore Kernel
+
+The InCore function runs on the NPU device:
+
+- Declared with `@pl.function(type=pl.FunctionType.InCore)`
+- Receives window-bound `DistributedTensor` arguments
+- Uses `notify`/`wait` for cross-rank sync, `remote_load`/`remote_store` for RMA
+- Never calls `alloc_window_buffer` or `world_size()`
+
+### Per-Rank Dispatch
+
+HOST never dispatches an `InCore` function directly. It dispatches a per-device
+`@pl.function(type=pl.FunctionType.Orchestration)` wrapper by setting `device=r`
+in the function call; that wrapper then calls the `InCore` kernel with no
+`device=` argument. Each rank sees its own view of the symmetric window
+buffers through `CommContext`.
+
+### Window Buffer Lifetime
+
+`alloc_window_buffer(size)` creates per-rank buffers. `window(buf, shape, dtype)`
+creates typed views. Buffers live for the duration of the host orchestrator call;
+there is no persistent IPC between orchestrator invocations.
+
+### Control Plane vs Execution Plane
+
+```text
+HOST orchestrator (@pl.function(level=HOST, role=Orchestrator))
+  ├── alloc_window_buffer(...)        ← control plane: declare layout
+  ├── window(buf, shape, dtype)       ← control plane: create typed view
+  └── for r in ranks:                 ← dispatch loop
+        self.chip_orch(..., device=r) ← bridges to the per-device wrapper
+
+Orchestration wrapper (@pl.function(type=Orchestration))
+  └── self.reduce_step(...)          ← calls the InCore kernel, no device=
+
+InCore kernel (@pl.function(type=InCore))
+  ├── notify / wait                  ← execution plane: cross-rank sync
+  ├── remote_load                    ← execution plane: read peer data
+  └── store                          ← execution plane: write local output
+```
+
+## Line-by-Line Walkthrough
+
+| What | Why |
+| ---- | --- |
+| `NR = pl.dynamic("NR")` | The world size is not known at build time. `pl.dynamic` defers the dimension to runtime dispatch — the host binds it from `len(device_ids)`. |
+| `pl.InOut[pld.DistributedTensor[...]]` | `data` and `signal` are window-bound: every rank shares the same address space layout. `InOut` means the kernel both reads and writes them. |
+| `pld.get_comm_ctx(data)` | Lifts the window-bound tensor into a comm-domain handle. Every rank gets its own `ctx`, from which `rank()` and `nranks()` read per-rank values. |
+| `pld.system.notify(..., op=AtomicAdd)` | Each rank atomically adds 1 to every peer's signal slot. `AtomicAdd` is correct here because N ranks write the same slot (it's a global barrier). For a 1:1 handshake, use `Set` instead. |
+| `pld.system.wait(..., cmp=Ge, expected=1)` | Blocks until the local signal slot reaches at least 1 — meaning all peer notifies have landed. |
+| `pld.tile.remote_load(...)` | Reads a **remote** slice of a `DistributedTensor` into a local tile. This is the tile-level cross-rank equivalent of `pl.tile.load`. |
+| `pl.add(acc, peer_tile)` | The local add loop sums all peer contributions. After the loop, `acc` holds `sum(inputs[*])`. |
+| `chip_orch` (`@pl.function(type=Orchestration)`) | HOST dispatches this per-device wrapper via `device=r`, not the `InCore` kernel directly. It then calls `reduce_step` with no `device=` argument. |
+| `inputs[r]` / `outputs[r]` | Indexing drops the leading rank dimension, giving `reduce_step` the rank-2 `[1, SIZE]` shape it declares — `pl.slice` with an explicit shape would keep the dimension and produce a rank mismatch. |
+
+## See Also
+
+- [01-collectives](01-collectives.md) — Built-in collectives and their semantics
+- [02-primitives](02-primitives.md) — The substrate beneath the collectives
+- [03-execution](03-execution.md) — DistributedWorker lifecycle and production patterns
+- [04-debugging](04-debugging.md) — Common failure patterns and diagnostic flags

--- a/docs/en/user/distributed/00-model.md
+++ b/docs/en/user/distributed/00-model.md
@@ -3,6 +3,11 @@
 > **Prerequisites:** [Getting Started](../00-getting_started.md) — basic PyPTO
 > tensor/tile model. This guide uses the `pld` namespace
 > (`import pypto.language.distributed as pld`).
+>
+> **DSL form:** this chapter authors programs with `@pl.jit` (plain Python
+> functions). `@pl.program`/`@pl.function` is the equivalent class-based form
+> used by the older tests under `tests/st/distributed/` — see the
+> [Language Guide](../01-language_guide.md) for the full `@pl.jit` family.
 
 ## Quickstart: 2-Rank AllReduce
 

--- a/docs/en/user/distributed/01-collectives.md
+++ b/docs/en/user/distributed/01-collectives.md
@@ -1,0 +1,178 @@
+# Collectives
+
+This page covers the five built-in collectives and when to use each algorithm.
+All collectives are **synchronous** across ranks — every rank must call the same
+collective with identically shaped signal tensors, or the program hangs or
+silently corrupts data.
+
+## AllReduce
+
+Every rank contributes its local data; every rank receives the summed
+result.
+
+```python
+# Host orchestrator — simplest form (compiler synthesizes signal).
+data = pld.tensor.allreduce(data, op=pld.ReduceOp.Sum)  # mesh mode, in-place
+
+# InCore kernel — explicit signal.
+data = pld.tensor.allreduce(data, signal, op=pld.ReduceOp.Sum, mode="mesh")
+data = pld.tensor.allreduce(data, signal, op=pld.ReduceOp.Sum, mode="ring")
+```
+
+### Mesh Mode
+
+- O(N) remote traffic per step — every rank reads every peer
+- One global barrier per call (AtomicAdd/Ge on `[NR, 1]` signal)
+- Works with `pl.dynamic("NR")`
+- Best for small messages and low latency
+
+### Ring Mode
+
+- 2(P-1) steps: reduce-scatter + allgather
+- O(N/P) remote traffic per step — each rank reads one neighbour
+- Signal shape: `[2 × (NR − 1), NR]`
+- Requires compile-time-known NR — use a factory function pattern
+- Best for large messages (>16 KiB) and high bandwidth
+
+| Aspect | Mesh | Ring |
+| ------ | ---- | ---- |
+| Remote traffic per step | O(N) — every rank reads every peer | O(N/P) — each rank reads one neighbour |
+| Barrier rounds | 1 (global AtomicAdd/Ge) | 2(P-1) — reduce-scatter + allgather phases |
+| Signal shape | `[NR, 1]` | `[2 × (NR − 1), NR]` |
+| Best for | Small messages, low latency | Large messages, high bandwidth |
+
+**Rule of thumb:** Use the default `mode="mesh"`. Switch to `mode="ring"` when
+your payload exceeds ~16 KiB and you see mesh bandwidth plateau.
+
+The host orchestrator form (`signal` omitted) is syntactic sugar — the compiler
+synthesizes a signal of `[world_size(), 1]` (mesh only).
+
+### Mutation
+
+`target: InOut` — data is both read (as the reduction input) and written (as
+the reduced result). All ranks must pass identically shaped `target` tensors.
+
+### Supported ReduceOp
+
+All four — `Sum`, `Max`, `Min`, `Prod` — on both the InCore composite and the
+HOST builtin path. `target`'s dtype must be `FP16` or `FP32`; this is a hard
+compile-time check, not just a storage-width constraint. Every rank must
+agree on the same `ReduceOp` and `mode`, on top of the identically-shaped
+signal tensors required of every collective.
+
+## Barrier
+
+Cross-rank barrier — blocks until all ranks arrive.
+
+```python
+# signal: pld.DistributedTensor[[NR, 1], pl.INT32], freshly allocated.
+signal = pld.tensor.barrier(signal)
+```
+
+Uses `Set(1)` + `Ge(1)` on the signal. Single-shot; allocate a fresh buffer
+before the next barrier.
+
+## Broadcast
+
+Broadcast root rank's data to all ranks.
+
+```python
+# Root stages data before the call.
+if my_rank == ROOT_RANK:
+    data = pl.store(local, [0, 0], data)
+data = pld.tensor.broadcast(data, signal, root=ROOT_RANK)
+# Every rank now holds root's data in data[0, 0:SIZE].
+```
+
+Root must stage data before the call; non-root slots are ignored on input.
+After the call, every rank holds root's data.
+
+## AllGather
+
+Push-based all-gather — every rank pushes its local chunk, every rank receives
+the full gathered matrix.
+
+```python
+# Stage buffer: this rank's [1, SIZE] chunk (push source).
+stage_buf = pld.alloc_window_buffer(SIZE * pl.FP32.get_byte())
+stage = pld.window(stage_buf, [1, SIZE], dtype=pl.FP32)
+stage = pl.store(local_input, [0, 0], stage)
+
+# Result buffer: gathered [NR, SIZE] (push target).
+data_buf = pld.alloc_window_buffer(NR * SIZE * pl.FP32.get_byte())
+data = pld.window(data_buf, [NR, SIZE], dtype=pl.FP32)
+sig_buf = pld.alloc_window_buffer(NR * pl.INT32.get_byte())
+sig = pld.window(sig_buf, [NR], dtype=pl.INT32)
+
+data = pld.tensor.allgather(stage, data, sig)
+# data[src, :] now holds rank src's chunk for every src.
+```
+
+`local_data` and `target` **must be different** window buffers. The stage buffer
+is the per-rank push source; the target buffer receives the gathered `[NR, SIZE]`
+result.
+
+## ReduceScatter
+
+Reduce-scatter: every rank stages all NR chunks, receives its own reduced chunk.
+
+```python
+# Signal for the barrier (1-D for host builtins).
+sig_buf = pld.alloc_window_buffer(NR * pl.INT32.get_byte())
+sig = pld.window(sig_buf, [NR], dtype=pl.INT32)
+
+# Stage all NR chunks into data[NR, SIZE].
+for j in pl.range(nranks):
+    data = pl.store(chunk_j, [j, 0], data)
+data = pld.tensor.reduce_scatter(data, sig, op=pld.ReduceOp.Sum)
+# data[my_rank, 0:SIZE] holds this rank's reduced chunk.
+```
+
+## AllToAll
+
+Personalized all-to-all exchange — every rank sends a distinct chunk to every
+peer and receives a distinct chunk from every peer.
+
+```python
+# Stage buffer: push source, [NR, SIZE] with per-destination chunks.
+stage_buf = pld.alloc_window_buffer(NR * SIZE * pl.FP32.get_byte())
+stage = pld.window(stage_buf, [NR, SIZE], dtype=pl.FP32)
+for dest in pl.range(nranks):
+    stage = pl.store(chunk_for_dest, [dest, 0], stage)
+
+# Result buffer: push target, [NR, SIZE].
+data_buf = pld.alloc_window_buffer(NR * SIZE * pl.FP32.get_byte())
+data = pld.window(data_buf, [NR, SIZE], dtype=pl.FP32)
+sig_buf = pld.alloc_window_buffer(NR * pl.INT32.get_byte())
+sig = pld.window(sig_buf, [NR], dtype=pl.INT32)
+
+data = pld.tensor.all_to_all(stage, data, sig)
+# data[src, :] holds the chunk received from rank src.
+```
+
+`input` and `target` must be **separate** window buffers.
+
+## InCore vs Host-Level Collectives
+
+PyPTO has three ways to run a collective — pick based on where your code
+runs and whether you need `mode="ring"`:
+
+| Aspect | InCore Hand-Rolled | InCore Composite | HOST Builtin |
+| ------ | ------------------ | ---------------- | ------------ |
+| **Where** | `@pl.function(type=InCore)` | `@pl.function(type=InCore)` | `@pl.function(level=HOST, role=Orchestrator)` |
+| **How** | Manual `notify`/`wait` + `remote_load` loops | `pld.tensor.allreduce(data, sig, ...)` called directly | `pld.tensor.allreduce(data, [sig,] ...)` called directly |
+| **Lowering** | You write the primitives | `LowerCompositeOps` | `LowerHostTensorCollectives` |
+| **Modes** | Whatever you implement | `mesh` and `ring` | `mesh` only |
+| **Signal shape** | Whatever you allocate | `[nranks, 1]` for mesh (rank count may be dynamic); `[2×(NR−1), NR]` for ring (`NR` must be a compile-time constant) | Rank-1 `[world_size]` or rank-2 `[world_size, 1]` — the compiler-synthesized signal is rank-2 |
+| **When** | Learning, custom protocols | Need `ring` mode, or already inside an InCore kernel | Day-to-day host-orchestrated collectives |
+
+Prefer HOST builtins for day-to-day host-orchestrated code — they handle
+signal allocation, barrier orchestration, and chunking automatically. Reach
+for the InCore composite specifically when you need `mode="ring"`, since the
+HOST builtin path only lowers `mesh`.
+
+## See Also
+
+- [00-model](00-model.md) — Quickstart and model vocabulary
+- [02-primitives](02-primitives.md) — The substrate beneath the collectives
+- [04-debugging](04-debugging.md) — Common failure patterns

--- a/docs/en/user/distributed/01-collectives.md
+++ b/docs/en/user/distributed/01-collectives.md
@@ -39,10 +39,12 @@ data = pld.tensor.allreduce(data, signal, op=pld.ReduceOp.Sum, mode="ring")
 - Signal shape: `[2 × (NR − 1), NR]`
 - Requires compile-time-known NR — use a factory function pattern: an
   outer Python function takes `nr`/`size`, derives `total_rounds =
-  2 * (nr - 1)`, and defines the `@pl.program` class inside its own body
-  so `[total_rounds, nr]` becomes a compile-time constant (see
+  2 * (nr - 1)`, and defines the `@pl.jit` functions inside its own body
+  so `[total_rounds, nr]` becomes a compile-time constant (the specializer
+  folds the closure constants into the generated program). See
   `collectives/test_l3_tensor_allreduce_ring_intrinsic.py` in [Runnable
-  Examples](#runnable-examples))
+  Examples](#runnable-examples) — that test currently uses the equivalent
+  `@pl.program` class form.
 - Best for large messages (>16 KiB) and high bandwidth
 
 | Aspect | Mesh | Ring |

--- a/docs/en/user/distributed/01-collectives.md
+++ b/docs/en/user/distributed/01-collectives.md
@@ -1,14 +1,14 @@
 # Collectives
 
-This page covers the five built-in collectives and when to use each algorithm.
+This page covers the six built-in collectives and when to use each algorithm.
 All collectives are **synchronous** across ranks — every rank must call the same
 collective with identically shaped signal tensors, or the program hangs or
 silently corrupts data.
 
 ## AllReduce
 
-Every rank contributes its local data; every rank receives the summed
-result.
+Every rank contributes its local data; every rank receives the reduced
+result (`op=` selects `Sum`, `Max`, `Min`, or `Prod`).
 
 ```python
 # Host orchestrator — simplest form (compiler synthesizes signal).
@@ -167,9 +167,12 @@ runs and whether you need `mode="ring"`:
 | **When** | Learning, custom protocols | Need `ring` mode, or already inside an InCore kernel | Day-to-day host-orchestrated collectives |
 
 Prefer HOST builtins for day-to-day host-orchestrated code — they handle
-signal allocation, barrier orchestration, and chunking automatically. Reach
-for the InCore composite specifically when you need `mode="ring"`, since the
-HOST builtin path only lowers `mesh`.
+barrier orchestration and chunking automatically. Only `allreduce` can also
+omit the signal argument (the compiler synthesizes one outside loops); the
+other five collectives (`barrier`, `broadcast`, `allgather`,
+`reduce_scatter`, `all_to_all`) always take an explicit, caller-allocated
+signal. Reach for the InCore composite specifically when you need
+`mode="ring"`, since the HOST builtin path only lowers `mesh`.
 
 ## See Also
 

--- a/docs/en/user/distributed/01-collectives.md
+++ b/docs/en/user/distributed/01-collectives.md
@@ -170,7 +170,7 @@ runs and whether you need `mode="ring"`:
 
 | Aspect | InCore Hand-Rolled | InCore Composite | HOST Builtin |
 | ------ | ------------------ | ---------------- | ------------ |
-| **Where** | `@pl.function(type=InCore)` | `@pl.function(type=InCore)` | `@pl.function(level=HOST, role=Orchestrator)` |
+| **Where** | `@pl.jit.incore` | `@pl.jit.incore` | `@pl.jit.host` |
 | **How** | Manual `notify`/`wait` + `remote_load` loops | `pld.tensor.allreduce(data, sig, ...)` called directly | `pld.tensor.allreduce(data, [sig,] ...)` called directly |
 | **Lowering** | You write the primitives | `LowerCompositeOps` | `LowerHostTensorCollectives` |
 | **Modes** | Whatever you implement | `mesh` and `ring` | `mesh` only |

--- a/docs/en/user/distributed/01-collectives.md
+++ b/docs/en/user/distributed/01-collectives.md
@@ -5,6 +5,12 @@ All collectives are **synchronous** across ranks — every rank must call the sa
 collective with identically shaped signal tensors, or the program hangs or
 silently corrupts data.
 
+> **Note:** the code blocks below are illustrative sketches — each shows
+> only the primitive calls relevant to that collective and omits setup
+> (`my_rank`/`nranks` derivation, buffer allocation, input staging). They
+> are not meant to run as-is. For runnable versions, see [Runnable
+> Examples](#runnable-examples) below.
+
 ## AllReduce
 
 Every rank contributes its local data; every rank receives the reduced
@@ -31,7 +37,12 @@ data = pld.tensor.allreduce(data, signal, op=pld.ReduceOp.Sum, mode="ring")
 - 2(P-1) steps: reduce-scatter + allgather
 - O(N/P) remote traffic per step — each rank reads one neighbour
 - Signal shape: `[2 × (NR − 1), NR]`
-- Requires compile-time-known NR — use a factory function pattern
+- Requires compile-time-known NR — use a factory function pattern: an
+  outer Python function takes `nr`/`size`, derives `total_rounds =
+  2 * (nr - 1)`, and defines the `@pl.program` class inside its own body
+  so `[total_rounds, nr]` becomes a compile-time constant (see
+  `collectives/test_l3_tensor_allreduce_ring_intrinsic.py` in [Runnable
+  Examples](#runnable-examples))
 - Best for large messages (>16 KiB) and high bandwidth
 
 | Aspect | Mesh | Ring |
@@ -173,6 +184,21 @@ other five collectives (`barrier`, `broadcast`, `allgather`,
 `reduce_scatter`, `all_to_all`) always take an explicit, caller-allocated
 signal. Reach for the InCore composite specifically when you need
 `mode="ring"`, since the HOST builtin path only lowers `mesh`.
+
+## Runnable Examples
+
+Every collective above has a runnable counterpart under
+`tests/st/distributed/` (paths below are relative to that directory):
+
+| Collective | InCore hand-rolled | InCore composite | HOST builtin |
+| ---------- | ------------------ | ---------------- | ------------ |
+| allreduce | `collectives/test_l3_allreduce.py` | `collectives/test_l3_tensor_allreduce_intrinsic.py` | `test_l3_host_tensor_allreduce.py` |
+| allreduce (ring) | `collectives/test_l3_allreduce_ring.py` | `collectives/test_l3_tensor_allreduce_ring_intrinsic.py` | n/a (mesh only) |
+| barrier | — | `collectives/test_l3_tensor_barrier_intrinsic.py` | `test_l3_host_tensor_barrier.py` |
+| broadcast | `collectives/test_l3_broadcast.py` | `collectives/test_l3_tensor_broadcast_intrinsic.py` | `test_l3_host_tensor_broadcast.py` |
+| allgather | `collectives/test_l3_allgather.py` | `collectives/test_l3_tensor_allgather_intrinsic.py` | `test_l3_host_tensor_allgather.py` |
+| reduce_scatter | `collectives/test_l3_reduce_scatter.py` | `collectives/test_l3_tensor_reduce_scatter_intrinsic.py` | `test_l3_host_tensor_reduce_scatter.py` |
+| all_to_all | `collectives/test_l3_all_to_all.py` | `collectives/test_l3_tensor_all_to_all_intrinsic.py` | `test_l3_host_tensor_all_to_all.py` |
 
 ## See Also
 

--- a/docs/en/user/distributed/02-primitives.md
+++ b/docs/en/user/distributed/02-primitives.md
@@ -3,6 +3,11 @@
 Most users call `pld.tensor.*` collectives directly — reach for these
 lower-level primitives only when building a custom protocol.
 
+> **Note:** the notify/wait, put/get, and remote-load/store code blocks
+> below are illustrative sketches — they omit `nranks`/`my_rank`
+> derivation and buffer setup and are not meant to run as-is. For
+> runnable versions, see [Runnable Examples](#runnable-examples) below.
+
 ## Types and Enums
 
 | Name | Values | Description |
@@ -107,7 +112,7 @@ collectives; most users call `pld.tensor.*` collectives instead.
 | `remote_load` | `(target: DT, peer: IntLike, offsets: Sequence[IntLike], shape: Sequence[IntLike], valid_shape=None) -> Tile` | Load a region of peer rank's `DT` into a local tile. `shape` defines the tile dimensions. `valid_shape` keeps the physical tile fixed-size while a ragged tail reads only real data. Offsets must match what the peer stored — a 1-element misalignment causes silent corruption. |
 | `remote_store` | `(src_tile: Tile, target: DT, peer: IntLike, offsets: Sequence[IntLike]) -> Call` | Write a local tile into peer rank's `DT`. Side-effect-only. |
 
-## Put and Get
+## Put and Get (`pld.tensor.*`)
 
 One-sided bulk transfer — rank A writes to or reads from rank B's window
 without rank B participating in the transfer (beyond the signal barrier).
@@ -205,6 +210,16 @@ and shape must match what the peer stored — a mismatch reads garbage.
 **No short form:** `pld.notify(...)`, `pld.wait(...)`, `pld.put(...)`,
 `pld.get(...)`, `pld.allreduce(...)`, and all other collective ops — these
 require the full 3-segment namespace.
+
+## Runnable Examples
+
+| Primitive | Test |
+| --------- | ---- |
+| notify / wait | `test_l3_notify_wait.py` |
+| put / get | `test_l3_put.py` / `test_l3_get.py` |
+| remote_store | `test_l3_remote_store.py` |
+
+(paths relative to `tests/st/distributed/`)
 
 ## See Also
 

--- a/docs/en/user/distributed/02-primitives.md
+++ b/docs/en/user/distributed/02-primitives.md
@@ -1,0 +1,205 @@
+# Primitives
+
+Most users call `pld.tensor.*` collectives directly — reach for these
+lower-level primitives only when building a custom protocol.
+
+## Types and Enums
+
+| Name | Values | Description |
+| ---- | ------ | ----------- |
+| `NotifyOp` | `AtomicAdd`, `Set` | Signal deposit mode. `AtomicAdd`: atomically increment the peer's signal slot (use for multi-rank barriers). `Set`: overwrite the peer's signal slot (use for 1:1 handshakes). |
+| `WaitCmp` | `Eq`, `Ge` | Wait predicate. `Eq`: block until signal slot equals expected value. `Ge`: block until signal slot >= expected value. |
+| `ReduceOp` | `Sum`, `Max`, `Min`, `Prod` | Reduction operator for collective operations. Support is per-operation: `allreduce` accepts all four; `reduce_scatter` accepts only `Sum` and rejects the rest at the deducer. |
+| `AtomicType` | `None_`, `Add` | Remote-store combine mode. `None_`: plain store. `Add`: atomically accumulate into peer's destination. |
+| `DistributedTensor` | — | A tensor view bound to a comm-domain window buffer. Every collective and RMA op requires this type on the window side. |
+| `CommCtx` | — | Communication context handle. Produced by `get_comm_ctx()`; consumed by `rank()` and `nranks()`. |
+
+## System Substrate (`pld.system.*`)
+
+These are the lowest-level distributed primitives. Host-only queries are valid only outside
+InCore scopes; the remaining ops work in both host orchestrator and InCore kernel code.
+
+| Name | Signature | Description |
+| ---- | --------- | ----------- |
+| `world_size` | `() -> Scalar` | **Host-only.** Number of ranks in the distributed execution. Returns `INT64`. |
+| `get_comm_ctx` | `(dist_tensor: DT) -> Ctx` | Lift a `DistributedTensor` to its `CommCtx` handle. The verifier rejects plain `pl.Tensor`. |
+| `rank` | `(ctx: Ctx) -> Scalar` | Local rank index (`INT32`). Lowers to a load of `CommContext::rankId`. |
+| `nranks` | `(ctx: Ctx) -> Scalar` | Number of ranks in this comm group (`INT32`). Lowers to a load of `CommContext::rankNum`. |
+| `notify` | `(target: DT, peer: IntLike, offsets: Sequence[IntLike], value: IntLike, *, op: NotifyOp) -> Call` | Cross-rank signal deposit. **Side-effect-only** — no return value. Lowers to `TNOTIFY`. |
+| `wait` | `(signal: DT, offsets: Sequence[IntLike], expected: IntLike, *, cmp: WaitCmp) -> Call` | Cross-rank wait. **Side-effect-only** — blocks until the local signal slot satisfies `cmp(expected)`. Lowers to `TWAIT`. |
+
+## Window Buffer Management (`pld.tensor.*`)
+
+`window` and `alloc_window_buffer` live in `pld.tensor.*`, not `pld.system.*`,
+even though they are as foundational as the substrate above.
+
+| Name | Signature | Description |
+| ---- | --------- | ----------- |
+| `window` | `(buf: Ptr, shape: Sequence[IntLike], *, dtype: DataType) -> DT` | Materialise a window-buffer `Ptr` as a `DistributedTensor` view. `buf` comes from `alloc_window_buffer`. |
+| `alloc_window_buffer` | `(size: IntLike, *, name: str = "") -> Ptr` | Allocate a per-rank HCCL window buffer. **Size is in bytes.** The `name` kwarg is injected by the parser from the LHS assignment — never pass it explicitly. |
+| `alloc_window_buffer` | `(shape: Sequence[IntLike], *, dtype: DataType, name: str = "") -> Ptr` | Convenience overload. `size = prod(shape) x dtype.get_byte()` computed automatically. |
+
+## Notify & Wait: The Signal Handshake
+
+The lowest-level synchronisation primitive. Each rank writes to a peer's
+signal cell, then blocks until its own cell has been written.
+
+```python
+@pl.program
+class SignalHandshake:
+    @pl.function(type=pl.FunctionType.InCore)
+    def handshake_step(
+        self,
+        out: pl.Out[pl.Tensor[[1, 1], pl.INT32]],
+        signal: pl.InOut[pld.DistributedTensor[[1, 1], pl.INT32]],
+        peer: pl.Scalar[pl.INT32],
+        tag: pl.Scalar[pl.INT32],
+    ) -> pl.Tensor[[1, 1], pl.INT32]:
+        # 1. Write our tag into the peer's signal cell.
+        pld.system.notify(
+            signal, peer=peer, offsets=[0, 0],
+            value=tag, op=pld.NotifyOp.Set,
+        )
+
+        # 2. Wait until our own cell has been written.
+        pld.system.wait(
+            signal=signal, offsets=[0, 0],
+            expected=1, cmp=pld.WaitCmp.Ge,
+        )
+
+        # 3. Read the received tag back out.
+        received = pl.load(signal, [0, 0], [1, 1])
+        out = pl.store(received, [0, 0], out)
+        return out
+```
+
+> The `wait` uses `Ge` with `expected=1`, which means the peer's `tag`
+> **must be >= 1**. Passing `tag=0` will cause a permanent hang.
+
+### Choosing NotifyOp and WaitCmp
+
+| Scenario | NotifyOp | WaitCmp | Why |
+| -------- | -------- | ------- | --- |
+| 1:1 exchange (one writer per slot) | `Set` | `Eq` or `Ge` | Atomic increment not needed — overwrite is clear and fast. |
+| N-to-1 barrier (many writers, one slot) | `AtomicAdd` | `Ge` | Every writer atomically adds its contribution. The sum increments monotonically; wait for the expected total. |
+| Multi-round protocol | `AtomicAdd` | `Ge` | The counter advances across rounds without reset — each round uses a fresh row or the caller re-allocates the buffer. |
+
+**Expected output** for 2 ranks: rank 0 writes tag=2, waits for tag 1 from rank 1:
+`outputs[0] == 1`. Rank 1 writes tag=1, waits for tag 2 from rank 0:
+`outputs[1] == 2`. Result: `outputs == [[1], [2]]`.
+
+> **Buffer re-use safety:** Signal cells are zero-initialised by
+> `alloc_window_buffer`. After `notify`, the signal cell holds the written
+> value; after `wait` returns, the caller has observed the barrier. Do not
+> reuse the same signal buffer across back-to-back collectives — the protocol
+> uses monotonic counters that do not self-reset. Allocate a fresh buffer.
+
+## Tile-Level RMA (`pld.tile.*`)
+
+Low-level cross-rank remote memory access. These are tile-level primitives used to build
+collectives; most users call `pld.tensor.*` collectives instead.
+
+| Name | Signature | Description |
+| ---- | --------- | ----------- |
+| `remote_load` | `(target: DT, peer: IntLike, offsets: Sequence[IntLike], shape: Sequence[IntLike], valid_shape=None) -> Tile` | Load a region of peer rank's `DT` into a local tile. `shape` defines the tile dimensions. `valid_shape` keeps the physical tile fixed-size while a ragged tail reads only real data. Offsets must match what the peer stored — a 1-element misalignment causes silent corruption. |
+| `remote_store` | `(src_tile: Tile, target: DT, peer: IntLike, offsets: Sequence[IntLike]) -> Call` | Write a local tile into peer rank's `DT`. Side-effect-only. |
+
+## Put and Get
+
+One-sided bulk transfer — rank A writes to or reads from rank B's window
+without rank B participating in the transfer (beyond the signal barrier).
+
+### Put (Write to Peer)
+
+| Name | Signature | Mutation | Description |
+| ---- | --------- | -------- | ----------- |
+| `put` | `(dst: DT, peer: IntLike, src: DT \| Tensor, dst_offsets=None, src_offsets=None, shape=None, *, atomic=AtomicType.None_, chunk_rows=0, chunk_cols=0, pipeline=False) -> Call` | `dst: InOut`, `src: In` | Write local `src` into peer rank's `dst`. `dst` **must** be window-bound; `src` may be plain `Tensor`. With no offsets/shape, writes the full local slice. `atomic=Add` accumulates instead of overwriting. |
+
+### Get (Read from Peer)
+
+| Name | Signature | Mutation | Description |
+| ---- | --------- | -------- | ----------- |
+| `get` | `(dst: DT \| Tensor, peer: IntLike, src: DT, dst_offsets=None, src_offsets=None, shape=None, *, chunk_rows=0, chunk_cols=0, pipeline=False) -> Call` | `dst: Out`, `src: In` | Read peer rank's `src` into local `dst`. `src` **must** be window-bound; `dst` may be plain `Tensor`. |
+
+### Chunking and Pipelining Constraints
+
+`chunk_rows`/`chunk_cols` (`0` = full extent) shrink the staging tile so a
+transfer larger than the on-chip staging budget still moves in one call,
+sliding through the smaller stage automatically.
+
+> **Fatal pitfall:** `pipeline=True` **requires both `chunk_rows > 0` and
+> `chunk_cols > 0`** — the double-buffering benefit only exists when the
+> transfer is actually chunked. Passing `pipeline=True` with either chunk
+> dimension left at `0` raises a `ValueError` before dispatch.
+
+A **dynamic** transfer extent (a runtime-sized `shape`, or a full-slice
+transfer where `dst`/`src`'s own dims are dynamic) must be bounded by a
+matching static chunk: a dynamic innermost dimension requires `chunk_cols`
+to be set, and a dynamic leading dimension requires `chunk_rows` to be set —
+the staging tile is allocated statically and can't size itself from a
+runtime value.
+
+## Writing Your Own Collective
+
+Every built-in collective is a composition of lower-level primitives. The
+mesh allreduce is: stage-in -> barrier -> remote-accumulate -> stage-out.
+
+### The Barrier in Isolation
+
+```python
+# signal: pld.DistributedTensor[[NR, 1], pl.INT32]
+for peer in pl.range(nranks):
+    if peer != my_rank:
+        pld.system.notify(
+            signal, peer=peer, offsets=[my_rank, 0],
+            value=1, op=pld.NotifyOp.AtomicAdd,
+        )
+for src in pl.range(nranks):
+    if src != my_rank:
+        pld.system.wait(
+            signal, offsets=[src, 0],
+            expected=1, cmp=pld.WaitCmp.Ge,
+        )
+```
+
+`AtomicAdd` is used because N ranks write the same signal cell — each adds
+1, so after all notifies land the cell reaches N-1 and every `WaitGe(1)`
+unblocks. With `Set` the last writer would overwrite earlier contributions.
+
+### Remote Accumulate
+
+```python
+acc = pl.load(data, [0, 0], [1, SIZE])
+for peer in pl.range(nranks):
+    if peer != my_rank:
+        peer_tile = pld.tile.remote_load(
+            data, peer=peer, offsets=[0, 0], shape=[1, SIZE]
+        )
+        acc = pl.add(acc, peer_tile)
+```
+
+`remote_load` reads the peer's window slice into a local tile. The offset
+and shape must match what the peer stored — a mismatch reads garbage.
+
+## 2-Segment vs 3-Segment Namespace
+
+| Short form (`pld.*`) | Full path |
+| -------------------- | --------- |
+| `pld.world_size()` | `pld.system.world_size()` |
+| `pld.rank(ctx)` | `pld.system.rank(ctx)` |
+| `pld.nranks(ctx)` | `pld.system.nranks(ctx)` |
+| `pld.get_comm_ctx(dt)` | `pld.system.get_comm_ctx(dt)` |
+| `pld.alloc_window_buffer(...)` | `pld.tensor.alloc_window_buffer(...)` |
+| `pld.window(...)` | `pld.tensor.window(...)` |
+| `pld.remote_load(...)` | `pld.tile.remote_load(...)` |
+| `pld.remote_store(...)` | `pld.tile.remote_store(...)` |
+
+**No short form:** `pld.notify(...)`, `pld.wait(...)`, `pld.put(...)`,
+`pld.get(...)`, `pld.allreduce(...)`, and all other collective ops — these
+require the full 3-segment namespace.
+
+## See Also
+
+- [01-collectives](01-collectives.md) — The collectives built on these primitives
+- [03-execution](03-execution.md) — DistributedWorker lifecycle and environment setup
+- [04-debugging](04-debugging.md) — Common failure patterns

--- a/docs/en/user/distributed/02-primitives.md
+++ b/docs/en/user/distributed/02-primitives.md
@@ -16,17 +16,20 @@ lower-level primitives only when building a custom protocol.
 
 ## System Substrate (`pld.system.*`)
 
-These are the lowest-level distributed primitives. Host-only queries are valid only outside
-InCore scopes; the remaining ops work in both host orchestrator and InCore kernel code.
+These are the lowest-level distributed primitives. Scope varies per op —
+`world_size` is host-only; `get_comm_ctx` works in both host orchestrator and
+InCore kernel code; `rank`, `nranks`, `notify`, and `wait` have codegen
+support only in InCore kernel code (there is no host-orchestrator lowering
+for them).
 
 | Name | Signature | Description |
 | ---- | --------- | ----------- |
 | `world_size` | `() -> Scalar` | **Host-only.** Number of ranks in the distributed execution. Returns `INT64`. |
-| `get_comm_ctx` | `(dist_tensor: DT) -> Ctx` | Lift a `DistributedTensor` to its `CommCtx` handle. The verifier rejects plain `pl.Tensor`. |
-| `rank` | `(ctx: Ctx) -> Scalar` | Local rank index (`INT32`). Lowers to a load of `CommContext::rankId`. |
-| `nranks` | `(ctx: Ctx) -> Scalar` | Number of ranks in this comm group (`INT32`). Lowers to a load of `CommContext::rankNum`. |
-| `notify` | `(target: DT, peer: IntLike, offsets: Sequence[IntLike], value: IntLike, *, op: NotifyOp) -> Call` | Cross-rank signal deposit. **Side-effect-only** — no return value. Lowers to `TNOTIFY`. |
-| `wait` | `(signal: DT, offsets: Sequence[IntLike], expected: IntLike, *, cmp: WaitCmp) -> Call` | Cross-rank wait. **Side-effect-only** — blocks until the local signal slot satisfies `cmp(expected)`. Lowers to `TWAIT`. |
+| `get_comm_ctx` | `(dist_tensor: DT) -> Ctx` | Lift a `DistributedTensor` to its `CommCtx` handle. Works in host orchestrator and InCore code. The verifier rejects plain `pl.Tensor`. |
+| `rank` | `(ctx: Ctx) -> Scalar` | **InCore-only.** Local rank index (`INT32`). Lowers to a load of `CommContext::rankId`. |
+| `nranks` | `(ctx: Ctx) -> Scalar` | **InCore-only.** Number of ranks in this comm group (`INT32`). Lowers to a load of `CommContext::rankNum`. |
+| `notify` | `(target: DT, peer: IntLike, offsets: Sequence[IntLike], value: IntLike, *, op: NotifyOp) -> Call` | **InCore-only.** Cross-rank signal deposit. **Side-effect-only** — no return value. Lowers to `TNOTIFY`. |
+| `wait` | `(signal: DT, offsets: Sequence[IntLike], expected: IntLike, *, cmp: WaitCmp) -> Call` | **InCore-only.** Cross-rank wait. **Side-effect-only** — blocks until the local signal slot satisfies `cmp(expected)`. Lowers to `TWAIT`. |
 
 ## Window Buffer Management (`pld.tensor.*`)
 
@@ -162,9 +165,14 @@ for src in pl.range(nranks):
         )
 ```
 
-`AtomicAdd` is used because N ranks write the same signal cell — each adds
-1, so after all notifies land the cell reaches N-1 and every `WaitGe(1)`
-unblocks. With `Set` the last writer would overwrite earlier contributions.
+With `offsets=[my_rank, 0]`, each rank owns a dedicated row — cell `[r, 0]`
+in every peer's window has exactly one writer, rank `r` itself, so `Set`
+would work identically here. `AtomicAdd` is shown because this is the same
+notify call every barrier in this doc uses; the "many writers, one slot"
+case that actually requires `AtomicAdd` is a *shared*-cell barrier (see the
+table above) — give every rank a distinct offset like this one only when you
+need to distinguish *which* peers have arrived, not just *whether* everyone
+has.
 
 ### Remote Accumulate
 

--- a/docs/en/user/distributed/02-primitives.md
+++ b/docs/en/user/distributed/02-primitives.md
@@ -53,32 +53,29 @@ The lowest-level synchronisation primitive. Each rank writes to a peer's
 signal cell, then blocks until its own cell has been written.
 
 ```python
-@pl.program
-class SignalHandshake:
-    @pl.function(type=pl.FunctionType.InCore)
-    def handshake_step(
-        self,
-        out: pl.Out[pl.Tensor[[1, 1], pl.INT32]],
-        signal: pl.InOut[pld.DistributedTensor[[1, 1], pl.INT32]],
-        peer: pl.Scalar[pl.INT32],
-        tag: pl.Scalar[pl.INT32],
-    ) -> pl.Tensor[[1, 1], pl.INT32]:
-        # 1. Write our tag into the peer's signal cell.
-        pld.system.notify(
-            signal, peer=peer, offsets=[0, 0],
-            value=tag, op=pld.NotifyOp.Set,
-        )
+@pl.jit.incore
+def handshake_step(
+    out: pl.Out[pl.Tensor[[1, 1], pl.INT32]],
+    signal: pl.InOut[pld.DistributedTensor[[1, 1], pl.INT32]],
+    peer: pl.Scalar[pl.INT32],
+    tag: pl.Scalar[pl.INT32],
+) -> pl.Tensor[[1, 1], pl.INT32]:
+    # 1. Write our tag into the peer's signal cell.
+    pld.system.notify(
+        signal, peer=peer, offsets=[0, 0],
+        value=tag, op=pld.NotifyOp.Set,
+    )
 
-        # 2. Wait until our own cell has been written.
-        pld.system.wait(
-            signal=signal, offsets=[0, 0],
-            expected=1, cmp=pld.WaitCmp.Ge,
-        )
+    # 2. Wait until our own cell has been written.
+    pld.system.wait(
+        signal=signal, offsets=[0, 0],
+        expected=1, cmp=pld.WaitCmp.Ge,
+    )
 
-        # 3. Read the received tag back out.
-        received = pl.load(signal, [0, 0], [1, 1])
-        out = pl.store(received, [0, 0], out)
-        return out
+    # 3. Read the received tag back out.
+    received = pl.load(signal, [0, 0], [1, 1])
+    out = pl.store(received, [0, 0], out)
+    return out
 ```
 
 > The `wait` uses `Ge` with `expected=1`, which means the peer's `tag`

--- a/docs/en/user/distributed/02-primitives.md
+++ b/docs/en/user/distributed/02-primitives.md
@@ -73,8 +73,8 @@ def handshake_step(
     )
 
     # 3. Read the received tag back out.
-    received = pl.load(signal, [0, 0], [1, 1])
-    out = pl.store(received, [0, 0], out)
+    received = pl.read(signal, [0, 0])
+    pl.write(out, [0, 0], received)
     return out
 ```
 

--- a/docs/en/user/distributed/03-execution.md
+++ b/docs/en/user/distributed/03-execution.md
@@ -10,19 +10,21 @@ Obtained via `compiled.prepare()`. Setup (fork, comm bootstrap, kernel assembly)
 happens once; dispatch happens many times.
 
 ```python
-from pypto.runtime import DistributedWorker
-
-with DistributedWorker(compiled) as rt:
+with compiled.prepare() as rt:
     rt(host_x, host_out)
     # ... more dispatches ...
 # rt.close() runs on exit — releases buffers and shuts down workers.
 ```
 
+`compiled.prepare()` returns a `DistributedWorker` (also constructible
+directly via `DistributedWorker(compiled)`, importable from
+`pypto.runtime`, but `prepare()` is the documented entry point).
+
 ### Methods
 
 | Method | Description |
 | ------ | ----------- |
-| `compiled.prepare(config=None, callbacks=None)` | Create worker, fork chip processes, return `DistributedWorker`. Use as context manager. |
+| `compiled.prepare(config=None, *, extra_compiled=(), persistent=False, reset_persistent_windows=None, callbacks=None, sub_worker_overrides=None)` | Create worker, fork chip processes, return `DistributedWorker`. Use as context manager. |
 | `rt(x, y, z)` | Single dispatch — coerces args, calls host_orch. |
 | `rt.run(compiled, x, y, z)` | Multi-program dispatch — selects the target program. |
 | `rt.alloc_tensor(shape, dtype, *, init=None)` | Allocate a worker-resident `DeviceTensor`. `init` copies from host (one-time H2D). |
@@ -32,6 +34,21 @@ with DistributedWorker(compiled) as rt:
 | `rt.copy_stacked_from(stacked, host_out)` | D2H read-back of every shard into `host_out` (shared-memory, allocated before `prepare()`). |
 | `rt.release_inherited_host_tensor_refs()` | Drop runtime-held host references in the parent process after fork. |
 | `rt.close()` | Release buffers, shut down chip workers. Called automatically as context manager. |
+
+### `prepare()` Parameters Worth Knowing
+
+- **`config`** — an optional `RunConfig` used *only* to pre-warm the
+  runtime arena cache for a given ring sizing, so the first dispatch
+  skips its ~800 ms cold build. It is **not retained**: every dispatch
+  still needs its own `config=`. The prewarm only pays off when the
+  *first* dispatch's sizing matches the pre-warmed one — see
+  `docs/en/dev/05-runtime-ring-sizing.md` § arena prewarm.
+- **`persistent=True`** — retains CommDomain windows for the worker's
+  entire lifetime instead of allocating/releasing them on every dispatch.
+  Pairs with **`reset_persistent_windows`**, which controls whether
+  retained windows are zeroed between requests (a correctness-vs-overhead
+  trade-off). See `docs/en/dev/06-persistent-l3.md`.
+- **`extra_compiled`** — see "Several Programs on One Worker" below.
 
 ## DeviceTensor
 
@@ -84,11 +101,17 @@ compiled(inputs, outputs)   # blocks until all ranks finish
 
 ### Persistent Worker (Repeated Dispatch)
 
+Reusing the same worker object across many dispatches — the default
+lifecycle for any `DistributedWorker`. (Not to be confused with the
+`persistent=True` CommDomain-window-retention flag above — that's an
+opt-in that skips per-dispatch window alloc/release; amortizing the
+fork/comm-bootstrap cost shown here happens regardless of `persistent=`.)
+
 ```python
 host_x = torch.zeros((4, 1, 256), dtype=torch.float32).share_memory_()
 host_out = torch.zeros_like(host_x).share_memory_()
 
-with DistributedWorker(compiled) as rt:
+with compiled.prepare() as rt:
     for step in steps:
         host_x.copy_(next_input(step))
         rt(host_x, host_out)
@@ -122,14 +145,9 @@ program explicitly through `rt.run(...)`, including the primary one.
 
 ## CLI Launch
 
-A distributed program launches the same way as a single-device one — plain
-`python script.py`. `DistributedConfig(device_ids=[...])` picks the rank
-count and devices; the runtime forks one worker process per device from this
-one Python process, so there is no separate multi-process launcher to invoke.
-
-```bash
-python script.py
-```
+Launching a distributed program is identical to launching a single-device
+one — see [00-model § Launch Command](00-model.md#launch-command): plain
+`python script.py`, no separate multi-process launcher.
 
 ## Environment Variables
 

--- a/docs/en/user/distributed/03-execution.md
+++ b/docs/en/user/distributed/03-execution.md
@@ -89,10 +89,11 @@ with compiled.prepare() as rt:
 ```python
 import torch
 from pypto.ir.distributed_compiled_program import DistributedConfig
-from pypto import ir
+from pypto.runtime import RunConfig
 
 dc = DistributedConfig(device_ids=[0, 1, 2, 3])
-compiled = ir.compile(HelloAllReduce, platform="a2a3", distributed_config=dc)
+cfg = RunConfig(platform="a2a3", distributed_config=dc)
+compiled = orchestrator.compile(config=cfg)   # reads shapes from orchestrator's own annotations
 
 inputs = torch.randn(4, 1, 256)
 outputs = torch.zeros_like(inputs)

--- a/docs/en/user/distributed/03-execution.md
+++ b/docs/en/user/distributed/03-execution.md
@@ -1,0 +1,165 @@
+# Execution
+
+A one-off compile-and-dispatch call is enough for a quick test. Production
+code instead amortizes setup — forking chip processes, assembling kernels —
+across many dispatches on a reusable `DistributedWorker`.
+
+## DistributedWorker
+
+Obtained via `compiled.prepare()`. Setup (fork, comm bootstrap, kernel assembly)
+happens once; dispatch happens many times.
+
+```python
+from pypto.runtime import DistributedWorker
+
+with DistributedWorker(compiled) as rt:
+    rt(host_x, host_out)
+    # ... more dispatches ...
+# rt.close() runs on exit — releases buffers and shuts down workers.
+```
+
+### Methods
+
+| Method | Description |
+| ------ | ----------- |
+| `compiled.prepare(config=None, callbacks=None)` | Create worker, fork chip processes, return `DistributedWorker`. Use as context manager. |
+| `rt(x, y, z)` | Single dispatch — coerces args, calls host_orch. |
+| `rt.run(compiled, x, y, z)` | Multi-program dispatch — selects the target program. |
+| `rt.alloc_tensor(shape, dtype, *, init=None)` | Allocate a worker-resident `DeviceTensor`. `init` copies from host (one-time H2D). |
+| `rt.free_tensor(tensor)` | Release a `DeviceTensor`. |
+| `rt.alloc_stacked_tensor(host_w)` | Shard host_w along dim 0 — shard `i` uploaded to card `i`. Returns `StackedDeviceTensor`. |
+| `rt.free_stacked_tensor(stacked)` | Release all shards of a `StackedDeviceTensor`. |
+| `rt.copy_stacked_from(stacked, host_out)` | D2H read-back of every shard into `host_out` (shared-memory, allocated before `prepare()`). |
+| `rt.release_inherited_host_tensor_refs()` | Drop runtime-held host references in the parent process after fork. |
+| `rt.close()` | Release buffers, shut down chip workers. Called automatically as context manager. |
+
+## DeviceTensor
+
+A worker-resident buffer that lives on the device across dispatches.
+When a `DeviceTensor` is passed as an argument to a compiled program,
+the runtime skips H2D/D2H copies — the device already has the data.
+
+```python
+import torch
+from pypto.runtime import DeviceTensor
+
+with compiled.prepare() as rt:
+    weight = rt.alloc_tensor((1024, 4096), torch.float16, init=host_weight)
+    rt(x, weight, out)   # dispatch via worker — no H2D/D2H
+```
+
+## StackedDeviceTensor
+
+Sharded across devices — obtained via `rt.alloc_stacked_tensor()`:
+
+```python
+# Host tensor sharded along dim 0 — shard[i] lives on card i.
+host_weights = torch.randn(4, 1024, 4096).share_memory_()  # 4 shards
+with compiled.prepare() as rt:
+    stacked = rt.alloc_stacked_tensor(host_weights)
+    rt(x, stacked, out)
+```
+
+> **Fatal pitfall:** `host_weights` must call `.share_memory_()` *before*
+> `prepare()`. The upload runs inside the already-forked chip worker, which
+> can only read host memory it inherited at fork — a plain `torch.Tensor`
+> raises `ValueError` at `alloc_stacked_tensor()`.
+
+## One-Shot vs Persistent Worker
+
+### One-Shot
+
+```python
+import torch
+from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto import ir
+
+dc = DistributedConfig(device_ids=[0, 1, 2, 3])
+compiled = ir.compile(HelloAllReduce, platform="a2a3", distributed_config=dc)
+
+inputs = torch.randn(4, 1, 256)
+outputs = torch.zeros_like(inputs)
+compiled(inputs, outputs)   # blocks until all ranks finish
+```
+
+### Persistent Worker (Repeated Dispatch)
+
+```python
+host_x = torch.zeros((4, 1, 256), dtype=torch.float32).share_memory_()
+host_out = torch.zeros_like(host_x).share_memory_()
+
+with DistributedWorker(compiled) as rt:
+    for step in steps:
+        host_x.copy_(next_input(step))
+        rt(host_x, host_out)
+        consume(host_out)
+```
+
+> **Fatal pitfall:** IO buffers passed to `DistributedWorker` must call
+> `.share_memory_()` before `prepare()`. If you forget, the runtime rejects
+> the buffer at dispatch time — the child processes cannot access the
+> parent's private memory.
+
+## Several Programs on One Worker
+
+A single `DistributedWorker` can dispatch multiple compiled programs:
+
+```python
+compiled_a = ir.compile(ProgramA, platform="a2a3", distributed_config=dc)
+compiled_b = ir.compile(ProgramB, platform="a2a3", distributed_config=dc)
+
+with compiled_a.prepare(extra_compiled=[compiled_b]) as rt:
+    rt.run(compiled_a, host_x, host_out)  # dispatch ProgramA
+    rt.run(compiled_b, host_x, host_out)  # dispatch ProgramB
+```
+
+The worker reuses its chip processes and comm setup — no fork penalty.
+`compiled_b` must be passed via `extra_compiled=` for `rt.run(compiled_b, ...)`
+to find it; passing an unregistered program raises `ValueError`. Preparing
+more than one program also puts the worker in multi-program mode, where the
+`rt(*args)` shortcut is ambiguous and raises `TypeError` — dispatch every
+program explicitly through `rt.run(...)`, including the primary one.
+
+## CLI Launch
+
+A distributed program launches the same way as a single-device one — plain
+`python script.py`. `DistributedConfig(device_ids=[...])` picks the rank
+count and devices; the runtime forks one worker process per device from this
+one Python process, so there is no separate multi-process launcher to invoke.
+
+```bash
+python script.py
+```
+
+## Environment Variables
+
+### Compile-Time Macros
+
+These are C preprocessor `#define` macros in `profiling_config.h`, **not environment variables**.
+They default to `1` (enabled) and are set at build time via CMake flags. Setting them as shell
+env vars has no effect.
+
+| Macro | Default | Effect |
+| ----- | ------- | ------ |
+| `SIMPLER_HOST_STRACE` | `1` (on) | Required at build time for `benchmark()` timing markers. Without it, `benchmark()` raises `RuntimeError`. |
+| `SIMPLER_DFX` | `1` (on) | Umbrella gate for device-side profiling (orchestrator/scheduler metrics, PMU counters, scope stats, swimlane trace). Sub-tier flags require this to be `1`. |
+
+### Runtime Environment Variable
+
+| Variable | Default | Effect |
+| -------- | ------- | ------ |
+| `SIMPLER_DEVICE_STRACE_ENABLE` | on (unset or non-`"0"`) | Runtime toggle for device-domain `[STRACE]` markers. Set to `0` to suppress device markers while keeping host markers. |
+
+### Benchmark Env Vars
+
+The `pypto-lib` golden benchmark harness reads `PYPTO_BENCH` /
+`PYPTO_BENCH_ROUNDS` / `PYPTO_BENCH_WARMUP` / `PYPTO_BENCH_RAW` — these are
+not defined or consumed anywhere in this repository. See `pypto-lib`'s own
+documentation for current defaults. `pypto.runtime.benchmark()` (this
+repo's own harness) is documented separately in the performance guide.
+
+## See Also
+
+- [00-model](00-model.md) — Quickstart and model vocabulary
+- [04-debugging](04-debugging.md) — Common failure patterns
+- [Getting Started](../00-getting_started.md) — Runtime setup

--- a/docs/en/user/distributed/04-debugging.md
+++ b/docs/en/user/distributed/04-debugging.md
@@ -51,11 +51,13 @@ SIMPLER_DEVICE_STRACE_ENABLE=0 python script.py
 ### Distributed DFX Entry Points
 
 - **L2 swimlane:** `RunConfig(enable_l2_swimlane=True)` — enables per-task timing
-  inside the worker, propagates through L3 orchestration. Output in span-tree.
+  inside the worker, propagates through L3 orchestration. Writes
+  `dfx_outputs/l2_swimlane_records.json` (onboard: merged into
+  `merged_swimlane_*.json` alongside the dependency graph below).
 - **Scope stats:** `RunConfig(enable_scope_stats=True)` — writes
   `dfx_outputs/scope_stats/scope_stats.jsonl` with task_window, heap, and tensormap watermarks.
-- **Dependency graph:** `RunConfig(enable_dep_gen=True)` — exports the task dependency
-  graph for scheduler analysis.
+- **Dependency graph:** `RunConfig(enable_dep_gen=True)` — writes
+  `dfx_outputs/deps.json`, the task dependency graph for scheduler analysis.
 
 ## See Also
 

--- a/docs/en/user/distributed/04-debugging.md
+++ b/docs/en/user/distributed/04-debugging.md
@@ -1,0 +1,63 @@
+# Debugging and Pitfalls
+
+Distributed bugs rarely leave a local stack trace — the symptom shows up on
+one rank while the cause is on another.
+
+## Common Failure Patterns
+
+| Symptom | Likely Cause | Fix |
+| ------- | ------------ | --- |
+| **All ranks hang** | Notify/wait ordering — a rank is waiting on a peer that hasn't notified yet | Ensure every rank calls `notify` before any rank calls `wait`. The notify loop should precede the wait loop. |
+| **Silent data corruption** | `remote_load` offsets or shape don't match what the peer stored | Verify offsets align with the peer's store offsets. A 1-element shift introduces a full row of garbage. |
+| **Signal cell never reaches expected value** | Wrong `NotifyOp`: used `Set` instead of `AtomicAdd` for a multi-participant barrier | Use `AtomicAdd` when N ranks contribute to the same slot; use `Set` for 1:1 exchanges. |
+| **Shape mismatch at compile time** | `NR` (world size) used in type annotations without `pl.dynamic` | Wrap runtime-resolved dims in `pl.dynamic("NR")`. The compiler needs the name to bind the runtime value. |
+| **`TypeError` raised at dispatch** | IO buffer not `.share_memory_()` before `prepare()` — the child processes cannot see a buffer allocated after the fork | Call `.share_memory_()` on every host tensor passed to the worker, before `prepare()`. |
+| **Allreduce rejected inside loop** | Signal protocol can't inject a fresh buffer per iteration | Allocate a fresh signal buffer for each allreduce call outside loops; allreduce inside `for`/`while` is currently rejected. |
+
+## Fatal Pitfalls
+
+> **Missing `.share_memory_()`:** IO buffers passed to `DistributedWorker` must
+> call `.share_memory_()` before `prepare()`. If you forget, the runtime raises
+> a `TypeError` at dispatch time — the child processes cannot access the parent's
+> private memory.
+>
+> **`alloc_window_buffer` given a rank count instead of bytes:** The `size`
+> argument to `alloc_window_buffer` is **in bytes**, not elements. Calling
+> `alloc_window_buffer(NR)` allocates `NR` bytes, not `NR * sizeof(element)`.
+> Use the shape+dtype overload: `alloc_window_buffer([NR, SIZE], dtype=pl.FP32)`.
+>
+> **`device_ids` disagreeing with `device=`:** `DistributedConfig.device_ids`
+> must match the device IDs used in the orchestrator's per-rank dispatch. A
+> mismatch — e.g. `device_ids=[0, 1]` but dispatching with `device=r` where
+> `r` iterates over `range(4)` — causes undefined behaviour.
+
+## Diagnostic Flags
+
+`SIMPLER_HOST_STRACE` and `SIMPLER_DFX` are **compile-time C preprocessor macros**
+(`#define` in `profiling_config.h`), not environment variables. Setting them as
+shell env vars (e.g. `SIMPLER_DFX=1 python script.py`) has **no effect** — they
+are baked in at build time. They default to `1` (enabled). Flipping them is a
+`simpler` runtime build-configuration change, not something set via a bare
+`cmake -D...` cache variable — see the `simpler` runtime's own build
+documentation for the current mechanism.
+
+Runtime environment variables:
+
+```bash
+# Toggle device-domain [STRACE] markers at runtime:
+SIMPLER_DEVICE_STRACE_ENABLE=0 python script.py
+```
+
+### Distributed DFX Entry Points
+
+- **L2 swimlane:** `RunConfig(enable_l2_swimlane=True)` — enables per-task timing
+  inside the worker, propagates through L3 orchestration. Output in span-tree.
+- **Scope stats:** `RunConfig(enable_scope_stats=True)` — writes
+  `dfx_outputs/scope_stats/scope_stats.jsonl` with task_window, heap, and tensormap watermarks.
+- **Dependency graph:** `RunConfig(enable_dep_gen=True)` — exports the task dependency
+  graph for scheduler analysis.
+
+## See Also
+
+- [00-model](00-model.md) — Quickstart and model vocabulary
+- [02-primitives](02-primitives.md) — The substrate beneath the collectives

--- a/docs/en/user/distributed/04-debugging.md
+++ b/docs/en/user/distributed/04-debugging.md
@@ -26,10 +26,17 @@ one rank while the cause is on another.
 > `alloc_window_buffer(NR)` allocates `NR` bytes, not `NR * sizeof(element)`.
 > Use the shape+dtype overload: `alloc_window_buffer([NR, SIZE], dtype=pl.FP32)`.
 >
-> **`device_ids` disagreeing with `device=`:** `DistributedConfig.device_ids`
-> must match the device IDs used in the orchestrator's per-rank dispatch. A
-> mismatch — e.g. `device_ids=[0, 1]` but dispatching with `device=r` where
-> `r` iterates over `range(4)` — causes undefined behaviour.
+> **Dispatch loop trip count disagreeing with `device_ids`:** `device_ids`
+> are physical card IDs (e.g. from `--device 4,5`) — they need not start at
+> 0 or be contiguous. `device=r` is a *logical* rank index, always
+> validated against `[0, world)` where `world = len(device_ids)`; the
+> runtime maps `rank r -> device_ids[r]`. What must hold is that the
+> dispatch loop's trip count equals `len(device_ids)` — automatic when you
+> write `for r in pl.range(pld.world_size())`. A mismatch — e.g.
+> `device_ids=[0, 1, 2, 3]` (4 cards) but a dispatch loop that only covers
+> `range(2)` — leaves 2 cards un-dispatched and causes undefined behaviour
+> (`MaterializeCommDomainScopes` requires the `device=r` loop range to be
+> `[0, N)`).
 
 ## Diagnostic Flags
 

--- a/docs/en/user/distributed/index.md
+++ b/docs/en/user/distributed/index.md
@@ -1,0 +1,57 @@
+# Distributed Programming
+
+PyPTO's distributed model is built on **symmetric memory and signals**:
+every rank sees the same window-buffer address across peers, reaches other
+ranks through one-sided `put`/`get`/`remote_load`, and coordinates through
+**signal synchronisation** (`notify`/`wait`). A **comm domain** is a subset
+of ranks sharing a symmetric window pool; the full world is the default
+domain.
+
+Every allreduce, broadcast, and barrier the compiler lowers is a composition
+of these same primitives — the `pld.tensor.*` collectives (`allreduce`,
+`barrier`, etc.) are syntactic sugar over them, not a separate library.
+
+## L2 vs L3
+
+| Layer | Scope | API namespace |
+| ----- | ----- | ------------- |
+| L2 | Single-device (one NPU chip) | `pl.*` |
+| L3 | Cross-rank (multiple NPUs or processes) | `pld.*` |
+
+> **PyPTO's L2/L3 vs simpler's L0–L6:** these two tiers are PyPTO's own
+> user-facing vocabulary, not simpler's numbering. Simpler uses a finer
+> seven-level hierarchy (L0 core → L1 die → L2 chip → L3 host → L4 pod →
+> L5 super-node → L6 cluster); PyPTO's "L2" spans simpler's L0–L2 (everything
+> on one chip), and PyPTO's "L3" spans simpler's L3 and up (everything across
+> chips). See simpler's
+> [Hierarchical Level Runtime](https://hw-native-sys.github.io/simpler/hierarchical-level-runtime/)
+> for the full model.
+
+The distributed chapter covers L3. L2 is covered in the
+[Language Guide](../01-language_guide.md).
+
+## Glossary
+
+| Term | Definition |
+| ---- | ---------- |
+| **Rank** | A single process or chip participating in a distributed program. Each rank has a unique rank index assigned at launch time. |
+| **Device** | One Ascend NPU chip (or die), identified by a `device_id`. One rank maps to one device. |
+| **Node** | A physical machine hosting one or more devices. |
+| **Window buffer** | A symmetric per-rank HCCL buffer. Ranks see peers through `CommContext.windowsIn[peer]`/`windowsOut[peer]`. |
+| **Comm domain** | A subset of ranks sharing a symmetric window pool. Default: the full world. |
+| **Signal** | A cross-rank synchronisation primitive. Notify/wait counters coordinate access to window buffers. |
+| **Orchestrator** | The HOST function that allocates window buffers and dispatches kernels to devices. |
+| **InCore kernel** | The device-side function that executes on the NPU. |
+
+## Reading Path
+
+1. **[00-model](00-model.md)** — Quickstart-first: run a 2-rank program, then the model vocabulary
+2. **[01-collectives](01-collectives.md)** — AllReduce, barrier, broadcast, allgather, reduce_scatter, all-to-all
+3. **[02-primitives](02-primitives.md)** — notify/wait, remote_load/remote_store, put/get, CommCtx
+4. **[03-execution](03-execution.md)** — DistributedWorker lifecycle, DeviceTensor, multi-program, env vars
+5. **[04-debugging](04-debugging.md)** — Common failure patterns and diagnostic flags
+
+## See Also
+
+- [Getting Started](../00-getting_started.md) — `ir.compile()`, `CompiledProgram`, `DeviceTensor`, `RunConfig`
+- [Simpler Runtime](https://hw-native-sys.github.io/simpler/) — Runtime internals (scheduler, graph building, tensormap)

--- a/docs/zh/user/distributed/00-model.md
+++ b/docs/zh/user/distributed/00-model.md
@@ -14,92 +14,87 @@ import pypto.language.distributed as pld
 NR = pl.dynamic("NR")
 SIZE = 256
 
-@pl.program
-class HelloAllReduce:
-    @pl.function(type=pl.FunctionType.InCore)
-    def reduce_step(
-        self,
-        inp: pl.Tensor[[1, SIZE], pl.FP32],
-        out: pl.Out[pl.Tensor[[1, SIZE], pl.FP32]],
-        data: pl.InOut[pld.DistributedTensor[[1, SIZE], pl.FP32]],
-        signal: pl.InOut[pld.DistributedTensor[[NR, 1], pl.INT32]],
-    ) -> pl.Tensor[[1, SIZE], pl.FP32]:
-        ctx = pld.get_comm_ctx(data)
-        my_rank = pld.rank(ctx)
-        nranks = pld.nranks(ctx)
+@pl.jit.incore
+def reduce_step(
+    inp: pl.Tensor[[1, SIZE], pl.FP32],
+    out: pl.Out[pl.Tensor[[1, SIZE], pl.FP32]],
+    data: pl.InOut[pld.DistributedTensor[[1, SIZE], pl.FP32]],
+    signal: pl.InOut[pld.DistributedTensor[[NR, 1], pl.INT32]],
+) -> pl.Tensor[[1, SIZE], pl.FP32]:
+    ctx = pld.get_comm_ctx(data)
+    my_rank = pld.rank(ctx)
+    nranks = pld.nranks(ctx)
 
-        # 1. Stage-in：将本地输入数据复制到本 rank 的 window 分片。
-        local = pl.load(inp, [0, 0], [1, SIZE])
-        data = pl.store(local, [0, 0], data)
+    # 1. Stage-in：将本地输入数据复制到本 rank 的 window 分片。
+    local = pl.load(inp, [0, 0], [1, SIZE])
+    data = pl.store(local, [0, 0], data)
 
-        # 2. Barrier：通知每个对端，然后等待每个对端。
-        for peer in pl.range(nranks):
-            if peer != my_rank:
-                pld.system.notify(
-                    signal, peer=peer, offsets=[my_rank, 0],
-                    value=1, op=pld.NotifyOp.AtomicAdd,
-                )
-        for src in pl.range(nranks):
-            if src != my_rank:
-                pld.system.wait(
-                    signal, offsets=[src, 0],
-                    expected=1, cmp=pld.WaitCmp.Ge,
-                )
+    # 2. Barrier：通知每个对端，然后等待每个对端。
+    for peer in pl.range(nranks):
+        if peer != my_rank:
+            pld.system.notify(
+                signal, peer=peer, offsets=[my_rank, 0],
+                value=1, op=pld.NotifyOp.AtomicAdd,
+            )
+    for src in pl.range(nranks):
+        if src != my_rank:
+            pld.system.wait(
+                signal, offsets=[src, 0],
+                expected=1, cmp=pld.WaitCmp.Ge,
+            )
 
-        # 3. 计算：累加每个对端的分片。
-        acc = pl.load(data, [0, 0], [1, SIZE])
-        for peer in pl.range(nranks):
-            if peer != my_rank:
-                peer_tile = pld.tile.remote_load(
-                    data, peer=peer, offsets=[0, 0], shape=[1, SIZE]
-                )
-                acc = pl.add(acc, peer_tile)
+    # 3. 计算：累加每个对端的分片。
+    acc = pl.load(data, [0, 0], [1, SIZE])
+    for peer in pl.range(nranks):
+        if peer != my_rank:
+            peer_tile = pld.tile.remote_load(
+                data, peer=peer, offsets=[0, 0], shape=[1, SIZE]
+            )
+            acc = pl.add(acc, peer_tile)
 
-        # 4. Stage-out：将累加器写入本地输出。
-        return pl.store(acc, [0, 0], out)
+    # 4. Stage-out：将累加器写入本地输出。
+    return pl.store(acc, [0, 0], out)
 
-    @pl.function(type=pl.FunctionType.Orchestration)
-    def chip_orch(
-        self,
-        inp: pl.Tensor[[1, SIZE], pl.FP32],
-        out: pl.Out[pl.Tensor[[1, SIZE], pl.FP32]],
-        data: pl.InOut[pld.DistributedTensor[[1, SIZE], pl.FP32]],
-        signal: pl.InOut[pld.DistributedTensor[[NR, 1], pl.INT32]],
-    ) -> pl.Tensor[[1, SIZE], pl.FP32]:
-        # 逐设备的编排包装函数——HOST 派发的是它，而不是直接派发 InCore kernel。
-        return self.reduce_step(inp, out, data, signal)
+@pl.jit
+def chip_orch(
+    inp: pl.Tensor[[1, SIZE], pl.FP32],
+    out: pl.Out[pl.Tensor[[1, SIZE], pl.FP32]],
+    data: pl.InOut[pld.DistributedTensor[[1, SIZE], pl.FP32]],
+    signal: pl.InOut[pld.DistributedTensor[[NR, 1], pl.INT32]],
+) -> pl.Tensor[[1, SIZE], pl.FP32]:
+    # 逐设备的编排包装函数——HOST 派发的是它，而不是直接派发 InCore kernel。
+    return reduce_step(inp, out, data, signal)
 
-    @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
-    def orchestrator(
-        self,
-        inputs: pl.Tensor[[NR, 1, SIZE], pl.FP32],
-        outputs: pl.Out[pl.Tensor[[NR, 1, SIZE], pl.FP32]],
-    ) -> pl.Tensor[[NR, 1, SIZE], pl.FP32]:
-        data_buf = pld.alloc_window_buffer(SIZE * pl.FP32.get_byte())
-        signal_buf = pld.alloc_window_buffer(pld.world_size() * pl.INT32.get_byte())
+@pl.jit.host
+def orchestrator(
+    inputs: pl.Tensor[[NR, 1, SIZE], pl.FP32],
+    outputs: pl.Out[pl.Tensor[[NR, 1, SIZE], pl.FP32]],
+) -> pl.Tensor[[NR, 1, SIZE], pl.FP32]:
+    data_buf = pld.alloc_window_buffer(SIZE * pl.FP32.get_byte())
+    signal_buf = pld.alloc_window_buffer(pld.world_size() * pl.INT32.get_byte())
 
-        for r in pl.range(pld.world_size()):
-            data = pld.window(data_buf, [1, SIZE], dtype=pl.FP32)
-            signal = pld.window(signal_buf, [pld.world_size(), 1], dtype=pl.INT32)
-            self.chip_orch(inputs[r], outputs[r], data, signal, device=r)
-        return outputs
+    for r in pl.range(pld.world_size()):
+        data = pld.window(data_buf, [1, SIZE], dtype=pl.FP32)
+        signal = pld.window(signal_buf, [pld.world_size(), 1], dtype=pl.INT32)
+        chip_orch(inputs[r], outputs[r], data, signal, device=r)
+    return outputs
 ```
 
 ### 运行程序
 
-将上面的类和下面的驱动代码保存到同一个文件（`script.py`）中：
+将上面的函数和下面的驱动代码保存到同一个文件（`script.py`）中：
 
 ```python
 import torch
-from pypto import ir
+from pypto.runtime import RunConfig
 from pypto.ir.distributed_compiled_program import DistributedConfig
 
 dc = DistributedConfig(device_ids=[0, 1])
-compiled = ir.compile(HelloAllReduce, platform="a2a3", distributed_config=dc)
+cfg = RunConfig(platform="a2a3", distributed_config=dc)
 
 inputs = torch.randn(2, 1, SIZE)
 outputs = torch.zeros_like(inputs)
-compiled(inputs, outputs)   # 阻塞直到两个 rank 都完成
+orchestrator(inputs, outputs, config=cfg)   # 阻塞直到两个 rank 都完成
 ```
 
 这是"one-shot"派发模式。`DistributedWorker`、持久 worker 和多程序派发见
@@ -136,17 +131,17 @@ PyPTO 的分布式模型采用**对称内存 + 信号**范式。每个 rank 有�
 
 HOST 函数分配 window buffer、分发 kernel 并管理控制平面：
 
-- 声明为 `@pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)` 或 `@pl.jit.host`
+- 声明为 `@pl.jit.host`
 - 调用 `alloc_window_buffer`、`window()`，通过 `device=r` 进行 per-rank 分发
 - 每个进程运行一次——不在 NPU 上执行
-- 派发的是逐设备的 `@pl.function(type=pl.FunctionType.Orchestration)` 包装函数
-  （而非直接派发 `InCore` kernel）——见下方 Per-Rank 分发
+- 派发的是逐设备的 `@pl.jit` 包装函数（而非直接派发 `InCore` kernel）——见下方
+  Per-Rank 分发
 
 ### InCore Kernel
 
 InCore 函数在 NPU 设备上运行：
 
-- 声明为 `@pl.function(type=pl.FunctionType.InCore)`
+- 声明为 `@pl.jit.incore`
 - 接收 window-bound 的 `DistributedTensor` 参数
 - 使用 `notify`/`wait` 进行跨 rank 同步，`remote_load`/`remote_store` 进行 RMA
 - 不调用 `alloc_window_buffer` 或 `world_size()`
@@ -154,8 +149,8 @@ InCore 函数在 NPU 设备上运行：
 ### Per-Rank 分发
 
 HOST 从不直接派发 `InCore` 函数。它通过设置 `device=r` 派发一个逐设备的
-`@pl.function(type=pl.FunctionType.Orchestration)` 包装函数；该包装函数再调用
-`InCore` kernel，且不带 `device=` 参数。每个 rank 通过 `CommContext` 看到
+`@pl.jit` 包装函数；该包装函数再调用 `InCore` kernel，且不带 `device=` 参数。
+每个 rank 通过 `CommContext` 看到
 自己的对称 window buffer 视图。
 
 ### Window Buffer 生命周期
@@ -168,19 +163,19 @@ HOST 从不直接派发 `InCore` 函数。它通过设置 `device=r` 派发一�
 ### 控制平面 vs 执行平面
 
 ```text
-HOST 编排器 (@pl.function(level=HOST, role=Orchestrator))
-  ├── alloc_window_buffer(...)        ← 控制平面：声明布局
-  ├── window(buf, shape, dtype)       ← 控制平面：创建类型化视图
-  └── for r in ranks:                 ← 分发循环
-        self.chip_orch(..., device=r) ← 桥接到逐设备包装函数
+HOST 编排器 (@pl.jit.host)
+  ├── alloc_window_buffer(...)   ← 控制平面：声明布局
+  ├── window(buf, shape, dtype)  ← 控制平面：创建类型化视图
+  └── for r in ranks:            ← 分发循环
+        chip_orch(..., device=r) ← 桥接到逐设备包装函数
 
-编排包装函数 (@pl.function(type=Orchestration))
-  └── self.reduce_step(...)          ← 调用 InCore kernel，不带 device=
+编排包装函数 (@pl.jit)
+  └── reduce_step(...)           ← 调用 InCore kernel，不带 device=
 
-InCore kernel (@pl.function(type=InCore))
-  ├── notify / wait                  ← 执行平面：跨 rank 同步
-  ├── remote_load                    ← 执行平面：读取对端数据
-  └── store                          ← 执行平面：写入本地输出
+InCore kernel (@pl.jit.incore)
+  ├── notify / wait               ← 执行平面：跨 rank 同步
+  ├── remote_load                 ← 执行平面：读取对端数据
+  └── store                       ← 执行平面：写入本地输出
 ```
 
 ## 逐行解读
@@ -194,7 +189,7 @@ InCore kernel (@pl.function(type=InCore))
 | `pld.system.wait(..., cmp=Ge, expected=1)` | 阻塞直到本地 signal slot 达到至少 1——表示所有对端的 notify 均已到达。 |
 | `pld.tile.remote_load(...)` | 读取对端 `DistributedTensor` 的远程分片到本地 tile。这是 `pl.tile.load` 的 tile 级别跨 rank 版本。 |
 | `pl.add(acc, peer_tile)` | 本地加法循环累加所有对端贡献。循环结束后 `acc` 持有 `sum(inputs[*])`。 |
-| `chip_orch`（`@pl.function(type=Orchestration)`） | HOST 通过 `device=r` 派发这个逐设备包装函数，而不是直接派发 `InCore` kernel；它再以不带 `device=` 的方式调用 `reduce_step`。 |
+| `chip_orch`（`@pl.jit`） | HOST 通过 `device=r` 派发这个逐设备包装函数，而不是直接派发 `InCore` kernel；它再以不带 `device=` 的方式调用 `reduce_step`。 |
 | `inputs[r]` / `outputs[r]` | 下标索引会去掉最前面的 rank 维度，得到 `reduce_step` 声明的二维 `[1, SIZE]` 形状——若改用带显式 shape 的 `pl.slice`，会保留该维度，导致形状不匹配。 |
 
 ## 相关链接

--- a/docs/zh/user/distributed/00-model.md
+++ b/docs/zh/user/distributed/00-model.md
@@ -85,6 +85,26 @@ class HelloAllReduce:
         return outputs
 ```
 
+### 运行程序
+
+将上面的类和下面的驱动代码保存到同一个文件（`script.py`）中：
+
+```python
+import torch
+from pypto import ir
+from pypto.ir.distributed_compiled_program import DistributedConfig
+
+dc = DistributedConfig(device_ids=[0, 1])
+compiled = ir.compile(HelloAllReduce, platform="a2a3", distributed_config=dc)
+
+inputs = torch.randn(2, 1, SIZE)
+outputs = torch.zeros_like(inputs)
+compiled(inputs, outputs)   # 阻塞直到两个 rank 都完成
+```
+
+这是"one-shot"派发模式。`DistributedWorker`、持久 worker 和多程序派发见
+[03-execution](03-execution.md)。
+
 ### 预期输出
 
 每个 rank `r` 的 `outputs[r] == sum(inputs[*])`。2 个 rank 输入分别为
@@ -96,9 +116,8 @@ class HelloAllReduce:
 python script.py
 ```
 
-不涉及任何多进程启动器。`DistributedConfig(device_ids=[...])` 告诉编译后的
-程序使用哪些设备；运行时会从这一个 Python 进程中为每个设备 fork 出一个
-worker 进程。
+不涉及任何多进程启动器——运行时会从这一个 Python 进程中为每个设备（按
+`device_ids`）fork 出一个 worker 进程。
 
 ## PyPTO 中的分布式编程是什么？
 
@@ -142,7 +161,9 @@ HOST 从不直接派发 `InCore` 函数。它通过设置 `device=r` 派发一�
 ### Window Buffer 生命周期
 
 `alloc_window_buffer(size)` 创建 per-rank buffer。`window(buf, shape, dtype)`
-创建类型化视图。Buffer 在 host 编排器调用期间存活。
+创建类型化视图。Buffer 在 host 编排器调用期间存活；**默认情况下**编排器
+调用之间没有持久化的 IPC——如需跨多次派发保留 window，见
+[03-execution](03-execution.md) 中的 `persistent=True` 选项。
 
 ### 控制平面 vs 执行平面
 
@@ -169,7 +190,7 @@ InCore kernel (@pl.function(type=InCore))
 | `NR = pl.dynamic("NR")` | world size 在构建时未知。`pl.dynamic` 将维度推迟到运行时分发——host 从 `len(device_ids)` 绑定。 |
 | `pl.InOut[pld.DistributedTensor[...]]` | `data` 和 `signal` 是 window-bound：每个 rank 共享相同的地址空间布局。`InOut` 表示 kernel 既读又写。 |
 | `pld.get_comm_ctx(data)` | 将 window-bound tensor 提升为通信域句柄。每个 rank 获得自己的 `ctx`，从中读取 `rank()` 和 `nranks()`。 |
-| `pld.system.notify(..., op=AtomicAdd)` | 每个 rank 原子地加 1 到每个对端的 signal slot。`AtomicAdd` 在此正确，因为 N 个 rank 写入同一个 slot（全局屏障）。1:1 握手请用 `Set`。 |
+| `pld.system.notify(..., op=AtomicAdd)` | 每个 rank 原子地加 1 到每个对端的 signal slot。使用 `offsets=[my_rank, 0]` 时，每个格子只有一个写者，因此这里用 `Set` 效果完全相同——展示 `AtomicAdd` 是因为本文档中每个 barrier 用的都是同一个 notify 调用。`AtomicAdd` 仅在*共享*格子的 barrier（多个 rank 写入同一个 slot）中才是必需的；区别见 02-primitives.md 中的"隔离的 Barrier"一节。 |
 | `pld.system.wait(..., cmp=Ge, expected=1)` | 阻塞直到本地 signal slot 达到至少 1——表示所有对端的 notify 均已到达。 |
 | `pld.tile.remote_load(...)` | 读取对端 `DistributedTensor` 的远程分片到本地 tile。这是 `pl.tile.load` 的 tile 级别跨 rank 版本。 |
 | `pl.add(acc, peer_tile)` | 本地加法循环累加所有对端贡献。循环结束后 `acc` 持有 `sum(inputs[*])`。 |

--- a/docs/zh/user/distributed/00-model.md
+++ b/docs/zh/user/distributed/00-model.md
@@ -1,0 +1,184 @@
+# 分布式编程模型
+
+> **前置知识：** [快速入门](../00-getting_started.md) — 基本 PyPTO tensor/tile 模型。
+> 本指南使用 `pld` 命名空间（`import pypto.language.distributed as pld`）。
+
+## 快速开始：2-Rank AllReduce
+
+最简单的分布式程序——两个 rank 对各自数据求和，结果相同。
+
+```python
+import pypto.language as pl
+import pypto.language.distributed as pld
+
+NR = pl.dynamic("NR")
+SIZE = 256
+
+@pl.program
+class HelloAllReduce:
+    @pl.function(type=pl.FunctionType.InCore)
+    def reduce_step(
+        self,
+        inp: pl.Tensor[[1, SIZE], pl.FP32],
+        out: pl.Out[pl.Tensor[[1, SIZE], pl.FP32]],
+        data: pl.InOut[pld.DistributedTensor[[1, SIZE], pl.FP32]],
+        signal: pl.InOut[pld.DistributedTensor[[NR, 1], pl.INT32]],
+    ) -> pl.Tensor[[1, SIZE], pl.FP32]:
+        ctx = pld.get_comm_ctx(data)
+        my_rank = pld.rank(ctx)
+        nranks = pld.nranks(ctx)
+
+        # 1. Stage-in：将本地输入数据复制到本 rank 的 window 分片。
+        local = pl.load(inp, [0, 0], [1, SIZE])
+        data = pl.store(local, [0, 0], data)
+
+        # 2. Barrier：通知每个对端，然后等待每个对端。
+        for peer in pl.range(nranks):
+            if peer != my_rank:
+                pld.system.notify(
+                    signal, peer=peer, offsets=[my_rank, 0],
+                    value=1, op=pld.NotifyOp.AtomicAdd,
+                )
+        for src in pl.range(nranks):
+            if src != my_rank:
+                pld.system.wait(
+                    signal, offsets=[src, 0],
+                    expected=1, cmp=pld.WaitCmp.Ge,
+                )
+
+        # 3. 计算：累加每个对端的分片。
+        acc = pl.load(data, [0, 0], [1, SIZE])
+        for peer in pl.range(nranks):
+            if peer != my_rank:
+                peer_tile = pld.tile.remote_load(
+                    data, peer=peer, offsets=[0, 0], shape=[1, SIZE]
+                )
+                acc = pl.add(acc, peer_tile)
+
+        # 4. Stage-out：将累加器写入本地输出。
+        return pl.store(acc, [0, 0], out)
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def chip_orch(
+        self,
+        inp: pl.Tensor[[1, SIZE], pl.FP32],
+        out: pl.Out[pl.Tensor[[1, SIZE], pl.FP32]],
+        data: pl.InOut[pld.DistributedTensor[[1, SIZE], pl.FP32]],
+        signal: pl.InOut[pld.DistributedTensor[[NR, 1], pl.INT32]],
+    ) -> pl.Tensor[[1, SIZE], pl.FP32]:
+        # 逐设备的编排包装函数——HOST 派发的是它，而不是直接派发 InCore kernel。
+        return self.reduce_step(inp, out, data, signal)
+
+    @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+    def orchestrator(
+        self,
+        inputs: pl.Tensor[[NR, 1, SIZE], pl.FP32],
+        outputs: pl.Out[pl.Tensor[[NR, 1, SIZE], pl.FP32]],
+    ) -> pl.Tensor[[NR, 1, SIZE], pl.FP32]:
+        data_buf = pld.alloc_window_buffer(SIZE * pl.FP32.get_byte())
+        signal_buf = pld.alloc_window_buffer(pld.world_size() * pl.INT32.get_byte())
+
+        for r in pl.range(pld.world_size()):
+            data = pld.window(data_buf, [1, SIZE], dtype=pl.FP32)
+            signal = pld.window(signal_buf, [pld.world_size(), 1], dtype=pl.INT32)
+            self.chip_orch(inputs[r], outputs[r], data, signal, device=r)
+        return outputs
+```
+
+### 预期输出
+
+每个 rank `r` 的 `outputs[r] == sum(inputs[*])`。2 个 rank 输入分别为
+`[[1, 2, 3]]` 和 `[[10, 20, 30]]`，两个 rank 均看到 `[[11, 22, 33]]`。
+
+### 启动命令
+
+```bash
+python script.py
+```
+
+不涉及任何多进程启动器。`DistributedConfig(device_ids=[...])` 告诉编译后的
+程序使用哪些设备；运行时会从这一个 Python 进程中为每个设备 fork 出一个
+worker 进程。
+
+## PyPTO 中的分布式编程是什么？
+
+PyPTO 的分布式模型采用**对称内存 + 信号**范式。每个 rank 有一个 per-rank
+**window buffer**，各对端的地址空间是对称的。通信通过单边
+`put`/`get`/`remote_load` 加**信号同步**（`notify`/`wait`）来完成。
+**通信域** 是共享对称 window pool 的 rank 子集；整个 world 为默认通信域。
+
+编译器 lowering 出的每个 allreduce、broadcast、barrier 都是这些相同原语的
+组合——`pld.tensor.*` 集合通信（`allreduce`、`barrier` 等）是它们的语法糖，
+而非另一套独立的库。完整 API 见 [01-collectives](01-collectives.md)。
+
+## 模型
+
+### HOST 编排器
+
+HOST 函数分配 window buffer、分发 kernel 并管理控制平面：
+
+- 声明为 `@pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)` 或 `@pl.jit.host`
+- 调用 `alloc_window_buffer`、`window()`，通过 `device=r` 进行 per-rank 分发
+- 每个进程运行一次——不在 NPU 上执行
+- 派发的是逐设备的 `@pl.function(type=pl.FunctionType.Orchestration)` 包装函数
+  （而非直接派发 `InCore` kernel）——见下方 Per-Rank 分发
+
+### InCore Kernel
+
+InCore 函数在 NPU 设备上运行：
+
+- 声明为 `@pl.function(type=pl.FunctionType.InCore)`
+- 接收 window-bound 的 `DistributedTensor` 参数
+- 使用 `notify`/`wait` 进行跨 rank 同步，`remote_load`/`remote_store` 进行 RMA
+- 不调用 `alloc_window_buffer` 或 `world_size()`
+
+### Per-Rank 分发
+
+HOST 从不直接派发 `InCore` 函数。它通过设置 `device=r` 派发一个逐设备的
+`@pl.function(type=pl.FunctionType.Orchestration)` 包装函数；该包装函数再调用
+`InCore` kernel，且不带 `device=` 参数。每个 rank 通过 `CommContext` 看到
+自己的对称 window buffer 视图。
+
+### Window Buffer 生命周期
+
+`alloc_window_buffer(size)` 创建 per-rank buffer。`window(buf, shape, dtype)`
+创建类型化视图。Buffer 在 host 编排器调用期间存活。
+
+### 控制平面 vs 执行平面
+
+```text
+HOST 编排器 (@pl.function(level=HOST, role=Orchestrator))
+  ├── alloc_window_buffer(...)        ← 控制平面：声明布局
+  ├── window(buf, shape, dtype)       ← 控制平面：创建类型化视图
+  └── for r in ranks:                 ← 分发循环
+        self.chip_orch(..., device=r) ← 桥接到逐设备包装函数
+
+编排包装函数 (@pl.function(type=Orchestration))
+  └── self.reduce_step(...)          ← 调用 InCore kernel，不带 device=
+
+InCore kernel (@pl.function(type=InCore))
+  ├── notify / wait                  ← 执行平面：跨 rank 同步
+  ├── remote_load                    ← 执行平面：读取对端数据
+  └── store                          ← 执行平面：写入本地输出
+```
+
+## 逐行解读
+
+| 代码 | 说明 |
+| ---- | ---- |
+| `NR = pl.dynamic("NR")` | world size 在构建时未知。`pl.dynamic` 将维度推迟到运行时分发——host 从 `len(device_ids)` 绑定。 |
+| `pl.InOut[pld.DistributedTensor[...]]` | `data` 和 `signal` 是 window-bound：每个 rank 共享相同的地址空间布局。`InOut` 表示 kernel 既读又写。 |
+| `pld.get_comm_ctx(data)` | 将 window-bound tensor 提升为通信域句柄。每个 rank 获得自己的 `ctx`，从中读取 `rank()` 和 `nranks()`。 |
+| `pld.system.notify(..., op=AtomicAdd)` | 每个 rank 原子地加 1 到每个对端的 signal slot。`AtomicAdd` 在此正确，因为 N 个 rank 写入同一个 slot（全局屏障）。1:1 握手请用 `Set`。 |
+| `pld.system.wait(..., cmp=Ge, expected=1)` | 阻塞直到本地 signal slot 达到至少 1——表示所有对端的 notify 均已到达。 |
+| `pld.tile.remote_load(...)` | 读取对端 `DistributedTensor` 的远程分片到本地 tile。这是 `pl.tile.load` 的 tile 级别跨 rank 版本。 |
+| `pl.add(acc, peer_tile)` | 本地加法循环累加所有对端贡献。循环结束后 `acc` 持有 `sum(inputs[*])`。 |
+| `chip_orch`（`@pl.function(type=Orchestration)`） | HOST 通过 `device=r` 派发这个逐设备包装函数，而不是直接派发 `InCore` kernel；它再以不带 `device=` 的方式调用 `reduce_step`。 |
+| `inputs[r]` / `outputs[r]` | 下标索引会去掉最前面的 rank 维度，得到 `reduce_step` 声明的二维 `[1, SIZE]` 形状——若改用带显式 shape 的 `pl.slice`，会保留该维度，导致形状不匹配。 |
+
+## 相关链接
+
+- [01-collectives](01-collectives.md) — 内置集合通信及其语义
+- [02-primitives](02-primitives.md) — 集合通信的底层基础
+- [03-execution](03-execution.md) — DistributedWorker 生命周期和生产模式
+- [04-debugging](04-debugging.md) — 常见故障模式和诊断标志

--- a/docs/zh/user/distributed/00-model.md
+++ b/docs/zh/user/distributed/00-model.md
@@ -2,6 +2,10 @@
 
 > **前置知识：** [快速入门](../00-getting_started.md) — 基本 PyPTO tensor/tile 模型。
 > 本指南使用 `pld` 命名空间（`import pypto.language.distributed as pld`）。
+>
+> **DSL 形式：** 本章使用 `@pl.jit`（普通 Python 函数）编写程序。
+> `@pl.program`/`@pl.function` 是等价的类形式，用于 `tests/st/distributed/` 下的
+> 旧测试——完整 `@pl.jit` 系列见[语言指南](../01-language_guide.md)。
 
 ## 快速开始：2-Rank AllReduce
 

--- a/docs/zh/user/distributed/01-collectives.md
+++ b/docs/zh/user/distributed/01-collectives.md
@@ -4,6 +4,10 @@
 每个 rank 必须以相同形状的 signal tensor 调用同一集合通信，否则程序会挂起
 或静默数据损坏。
 
+> **说明：** 以下代码块均为示意性片段——每段仅展示该集合通信相关的原语调用，
+> 省略了 `my_rank`/`nranks` 推导、buffer 分配、输入数据搬入等设置代码，并非
+> 可直接运行的程序。可运行版本见下方"可运行示例"一节。
+
 ## AllReduce
 
 每个 rank 提交其本地数据；每个 rank 接收规约结果（`op=` 选择 `Sum`、`Max`、
@@ -30,7 +34,11 @@ data = pld.tensor.allreduce(data, signal, op=pld.ReduceOp.Sum, mode="ring")
 - 2(P-1) 步：reduce-scatter + allgather
 - 每步 O(N/P) 远程流量——每个 rank 读取一个邻居
 - Signal 形状：`[2 × (NR − 1), NR]`
-- 要求编译时已知 NR——使用工厂函数模式
+- 要求编译时已知 NR——使用工厂函数模式：外层 Python 函数接收 `nr`/`size`，
+  推导出 `total_rounds = 2 * (nr - 1)`，并在自己的函数体内定义
+  `@pl.program` 类，使 `[total_rounds, nr]` 成为编译期常量（参见下方
+  "可运行示例"一节中的
+  `collectives/test_l3_tensor_allreduce_ring_intrinsic.py`）
 - 最适合大消息（>16 KiB）和高带宽
 
 | 方面 | Mesh | Ring |
@@ -168,6 +176,21 @@ PyPTO 有三种方式运行集合通信——根据代码运行的位置以及�
 其余五种集合通信（`barrier`、`broadcast`、`allgather`、`reduce_scatter`、
 `all_to_all`）始终需要调用方显式分配并传入 signal。当需要 `mode="ring"`
 时改用 InCore 组合调用，因为 Host 内置路径只 lowering `mesh`。
+
+## 可运行示例
+
+上面每种集合通信在 `tests/st/distributed/` 下都有可运行的对应测试
+（以下路径均相对该目录）：
+
+| 集合通信 | InCore 手写 | InCore 组合调用 | HOST 内置 |
+| -------- | ----------- | --------------- | --------- |
+| allreduce | `collectives/test_l3_allreduce.py` | `collectives/test_l3_tensor_allreduce_intrinsic.py` | `test_l3_host_tensor_allreduce.py` |
+| allreduce（ring） | `collectives/test_l3_allreduce_ring.py` | `collectives/test_l3_tensor_allreduce_ring_intrinsic.py` | 无（仅 mesh） |
+| barrier | — | `collectives/test_l3_tensor_barrier_intrinsic.py` | `test_l3_host_tensor_barrier.py` |
+| broadcast | `collectives/test_l3_broadcast.py` | `collectives/test_l3_tensor_broadcast_intrinsic.py` | `test_l3_host_tensor_broadcast.py` |
+| allgather | `collectives/test_l3_allgather.py` | `collectives/test_l3_tensor_allgather_intrinsic.py` | `test_l3_host_tensor_allgather.py` |
+| reduce_scatter | `collectives/test_l3_reduce_scatter.py` | `collectives/test_l3_tensor_reduce_scatter_intrinsic.py` | `test_l3_host_tensor_reduce_scatter.py` |
+| all_to_all | `collectives/test_l3_all_to_all.py` | `collectives/test_l3_tensor_all_to_all_intrinsic.py` | `test_l3_host_tensor_all_to_all.py` |
 
 ## 相关链接
 

--- a/docs/zh/user/distributed/01-collectives.md
+++ b/docs/zh/user/distributed/01-collectives.md
@@ -1,12 +1,13 @@
 # 集合通信
 
-本页介绍五种内置集合通信及算法选择。所有集合通信在各 rank 间**同步执行**——
+本页介绍六种内置集合通信及算法选择。所有集合通信在各 rank 间**同步执行**——
 每个 rank 必须以相同形状的 signal tensor 调用同一集合通信，否则程序会挂起
 或静默数据损坏。
 
 ## AllReduce
 
-每个 rank 提交其本地数据；每个 rank 接收求和结果。
+每个 rank 提交其本地数据；每个 rank 接收规约结果（`op=` 选择 `Sum`、`Max`、
+`Min` 或 `Prod`）。
 
 ```python
 # Host 编排器——最简形式（编译器合成 signal）。
@@ -74,57 +75,76 @@ buffer。
 将 root rank 的数据广播到所有 rank。
 
 ```python
+# Root 在调用前写入数据。
 if my_rank == ROOT_RANK:
     data = pl.store(local, [0, 0], data)
 data = pld.tensor.broadcast(data, signal, root=ROOT_RANK)
+# 调用后每个 rank 的 data[0, 0:SIZE] 都持有 root 的数据。
 ```
+
+Root 必须在调用前写入数据；非 root rank 的输入槽位会被忽略。调用结束后，
+每个 rank 都持有 root 的数据。
 
 ## AllGather
 
-推式 allgather。
+推式 all-gather——每个 rank 推送自己的本地分片，每个 rank 都收到完整的
+汇总矩阵。
 
 ```python
+# Stage buffer：本 rank 的 [1, SIZE] 分片（推送源）。
 stage_buf = pld.alloc_window_buffer(SIZE * pl.FP32.get_byte())
 stage = pld.window(stage_buf, [1, SIZE], dtype=pl.FP32)
 stage = pl.store(local_input, [0, 0], stage)
 
+# 结果 buffer：汇总后的 [NR, SIZE]（推送目标）。
 data_buf = pld.alloc_window_buffer(NR * SIZE * pl.FP32.get_byte())
 data = pld.window(data_buf, [NR, SIZE], dtype=pl.FP32)
 sig_buf = pld.alloc_window_buffer(NR * pl.INT32.get_byte())
 sig = pld.window(sig_buf, [NR], dtype=pl.INT32)
 
 data = pld.tensor.allgather(stage, data, sig)
+# 调用后 data[src, :] 持有 rank src 的分片，对所有 src 均成立。
 ```
 
-`local_data` 和 `target` **必须是不同的** window buffer。
+`local_data` 和 `target` **必须是不同的** window buffer。stage buffer 是
+每个 rank 的推送源；target buffer 接收汇总后的 `[NR, SIZE]` 结果。
 
 ## ReduceScatter
 
+Reduce-scatter：每个 rank 写入全部 NR 个分片，接收自己的规约结果分片。
+
 ```python
+# 屏障用 signal（host builtin 要求一维）。
 sig_buf = pld.alloc_window_buffer(NR * pl.INT32.get_byte())
 sig = pld.window(sig_buf, [NR], dtype=pl.INT32)
 
+# 将全部 NR 个分片写入 data[NR, SIZE]。
 for j in pl.range(nranks):
     data = pl.store(chunk_j, [j, 0], data)
 data = pld.tensor.reduce_scatter(data, sig, op=pld.ReduceOp.Sum)
+# data[my_rank, 0:SIZE] 持有本 rank 的规约结果分片。
 ```
 
 ## AllToAll
 
-个性化 all-to-all 交换。
+个性化 all-to-all 交换——每个 rank 向每个对端发送一个专属分片，并从每个
+对端接收一个专属分片。
 
 ```python
+# Stage buffer：推送源，[NR, SIZE]，每行是发往对应目标的分片。
 stage_buf = pld.alloc_window_buffer(NR * SIZE * pl.FP32.get_byte())
 stage = pld.window(stage_buf, [NR, SIZE], dtype=pl.FP32)
 for dest in pl.range(nranks):
     stage = pl.store(chunk_for_dest, [dest, 0], stage)
 
+# 结果 buffer：推送目标，[NR, SIZE]。
 data_buf = pld.alloc_window_buffer(NR * SIZE * pl.FP32.get_byte())
 data = pld.window(data_buf, [NR, SIZE], dtype=pl.FP32)
 sig_buf = pld.alloc_window_buffer(NR * pl.INT32.get_byte())
 sig = pld.window(sig_buf, [NR], dtype=pl.INT32)
 
 data = pld.tensor.all_to_all(stage, data, sig)
+# data[src, :] 持有从 rank src 收到的分片。
 ```
 
 `input` 和 `target` 必须是**不同的** window buffer。
@@ -143,9 +163,11 @@ PyPTO 有三种方式运行集合通信——根据代码运行的位置以及�
 | **Signal 形状** | 取决于自己的分配 | mesh 为 `[nranks, 1]`（rank 数量可为动态）；ring 为 `[2×(NR−1), NR]`（`NR` 必须是编译期常量） | 一维 `[world_size]` 或二维 `[world_size, 1]`——编译器合成的 signal 为二维 |
 | **适用场景** | 学习、自定义协议 | 需要 `ring` 模式，或已身处 InCore kernel 内部 | 日常的 host 编排集合通信 |
 
-日常 host 编排代码优先使用 Host 级别内置——它们自动处理 signal 分配、
-屏障编排和分块。当需要 `mode="ring"` 时改用 InCore 组合调用，因为 Host
-内置路径只 lowering `mesh`。
+日常 host 编排代码优先使用 Host 级别内置——它们自动处理屏障编排和分块。
+只有 `allreduce` 可以省略 signal 参数（编译器会在循环外自动合成一个）；
+其余五种集合通信（`barrier`、`broadcast`、`allgather`、`reduce_scatter`、
+`all_to_all`）始终需要调用方显式分配并传入 signal。当需要 `mode="ring"`
+时改用 InCore 组合调用，因为 Host 内置路径只 lowering `mesh`。
 
 ## 相关链接
 

--- a/docs/zh/user/distributed/01-collectives.md
+++ b/docs/zh/user/distributed/01-collectives.md
@@ -1,0 +1,154 @@
+# 集合通信
+
+本页介绍五种内置集合通信及算法选择。所有集合通信在各 rank 间**同步执行**——
+每个 rank 必须以相同形状的 signal tensor 调用同一集合通信，否则程序会挂起
+或静默数据损坏。
+
+## AllReduce
+
+每个 rank 提交其本地数据；每个 rank 接收求和结果。
+
+```python
+# Host 编排器——最简形式（编译器合成 signal）。
+data = pld.tensor.allreduce(data, op=pld.ReduceOp.Sum)  # mesh 模式，就地
+
+# InCore kernel——显式 signal。
+data = pld.tensor.allreduce(data, signal, op=pld.ReduceOp.Sum, mode="mesh")
+data = pld.tensor.allreduce(data, signal, op=pld.ReduceOp.Sum, mode="ring")
+```
+
+### Mesh 模式
+
+- 每步 O(N) 远程流量——每个 rank 读取所有对端
+- 每次调用一个全局屏障（AtomicAdd/Ge 在 `[NR, 1]` signal 上）
+- 支持 `pl.dynamic("NR")`
+- 最适合小消息和低延迟
+
+### Ring 模式
+
+- 2(P-1) 步：reduce-scatter + allgather
+- 每步 O(N/P) 远程流量——每个 rank 读取一个邻居
+- Signal 形状：`[2 × (NR − 1), NR]`
+- 要求编译时已知 NR——使用工厂函数模式
+- 最适合大消息（>16 KiB）和高带宽
+
+| 方面 | Mesh | Ring |
+| ---- | ---- | ---- |
+| 每步远程流量 | O(N) | O(N/P) |
+| 屏障轮次 | 1 | 2(P-1) |
+| Signal 形状 | `[NR, 1]` | `[2 × (NR − 1), NR]` |
+| 最适合 | 小消息，低延迟 | 大消息，高带宽 |
+
+**经验法则：** 默认使用 `mode="mesh"`。当负载超过约 16 KiB 且 mesh 带宽达到平台期时
+切换到 `mode="ring"`。
+
+Host 编排器形式（省略 `signal`）是语法糖——编译器合成 `[world_size(), 1]` 的
+signal（仅限 mesh）。
+
+### 变更
+
+`target: InOut` — 数据既被读取（作为规约输入）又被写入（作为规约结果）。所有 rank
+必须传入形状相同的 `target` tensor。
+
+### 支持的 ReduceOp
+
+全部四种——`Sum`、`Max`、`Min`、`Prod`——InCore 组合调用和 Host 内置路径均
+支持。`target` 的 dtype 必须是 `FP16` 或 `FP32`；这是编译期硬性检查，而非
+仅存储位宽的限制。除了本页开头要求的形状相同的 signal tensor 外，所有
+rank 还必须使用相同的 `ReduceOp` 和 `mode`。
+
+## Barrier
+
+跨 rank 屏障——阻塞直到所有 rank 到达。
+
+```python
+# signal: pld.DistributedTensor[[NR, 1], pl.INT32]，新分配的。
+signal = pld.tensor.barrier(signal)
+```
+
+在 signal 上使用 `Set(1)` + `Ge(1)`。单次使用；下一次 barrier 前需分配新
+buffer。
+
+## Broadcast
+
+将 root rank 的数据广播到所有 rank。
+
+```python
+if my_rank == ROOT_RANK:
+    data = pl.store(local, [0, 0], data)
+data = pld.tensor.broadcast(data, signal, root=ROOT_RANK)
+```
+
+## AllGather
+
+推式 allgather。
+
+```python
+stage_buf = pld.alloc_window_buffer(SIZE * pl.FP32.get_byte())
+stage = pld.window(stage_buf, [1, SIZE], dtype=pl.FP32)
+stage = pl.store(local_input, [0, 0], stage)
+
+data_buf = pld.alloc_window_buffer(NR * SIZE * pl.FP32.get_byte())
+data = pld.window(data_buf, [NR, SIZE], dtype=pl.FP32)
+sig_buf = pld.alloc_window_buffer(NR * pl.INT32.get_byte())
+sig = pld.window(sig_buf, [NR], dtype=pl.INT32)
+
+data = pld.tensor.allgather(stage, data, sig)
+```
+
+`local_data` 和 `target` **必须是不同的** window buffer。
+
+## ReduceScatter
+
+```python
+sig_buf = pld.alloc_window_buffer(NR * pl.INT32.get_byte())
+sig = pld.window(sig_buf, [NR], dtype=pl.INT32)
+
+for j in pl.range(nranks):
+    data = pl.store(chunk_j, [j, 0], data)
+data = pld.tensor.reduce_scatter(data, sig, op=pld.ReduceOp.Sum)
+```
+
+## AllToAll
+
+个性化 all-to-all 交换。
+
+```python
+stage_buf = pld.alloc_window_buffer(NR * SIZE * pl.FP32.get_byte())
+stage = pld.window(stage_buf, [NR, SIZE], dtype=pl.FP32)
+for dest in pl.range(nranks):
+    stage = pl.store(chunk_for_dest, [dest, 0], stage)
+
+data_buf = pld.alloc_window_buffer(NR * SIZE * pl.FP32.get_byte())
+data = pld.window(data_buf, [NR, SIZE], dtype=pl.FP32)
+sig_buf = pld.alloc_window_buffer(NR * pl.INT32.get_byte())
+sig = pld.window(sig_buf, [NR], dtype=pl.INT32)
+
+data = pld.tensor.all_to_all(stage, data, sig)
+```
+
+`input` 和 `target` 必须是**不同的** window buffer。
+
+## InCore 手写 vs Host 级别内置集合通信
+
+PyPTO 有三种方式运行集合通信——根据代码运行的位置以及是否需要
+`mode="ring"` 来选择：
+
+| 方面 | InCore 手写 | InCore 组合调用 | Host 级别内置 |
+| ---- | ----------- | --------------- | ------------- |
+| **位置** | `@pl.function(type=InCore)` | `@pl.function(type=InCore)` | `@pl.function(level=HOST, role=Orchestrator)` |
+| **实现** | 手写 `notify`/`wait` + `remote_load` 循环 | 直接调用 `pld.tensor.allreduce(data, sig, ...)` | 直接调用 `pld.tensor.allreduce(data, [sig,] ...)` |
+| **Lowering** | 自行实现原语 | `LowerCompositeOps` | `LowerHostTensorCollectives` |
+| **支持的模式** | 取决于自己的实现 | `mesh` 和 `ring` | 仅 `mesh` |
+| **Signal 形状** | 取决于自己的分配 | mesh 为 `[nranks, 1]`（rank 数量可为动态）；ring 为 `[2×(NR−1), NR]`（`NR` 必须是编译期常量） | 一维 `[world_size]` 或二维 `[world_size, 1]`——编译器合成的 signal 为二维 |
+| **适用场景** | 学习、自定义协议 | 需要 `ring` 模式，或已身处 InCore kernel 内部 | 日常的 host 编排集合通信 |
+
+日常 host 编排代码优先使用 Host 级别内置——它们自动处理 signal 分配、
+屏障编排和分块。当需要 `mode="ring"` 时改用 InCore 组合调用，因为 Host
+内置路径只 lowering `mesh`。
+
+## 相关链接
+
+- [00-model](00-model.md) — 快速开始和模型词汇
+- [02-primitives](02-primitives.md) — 集合通信的底层基础
+- [04-debugging](04-debugging.md) — 常见故障模式

--- a/docs/zh/user/distributed/01-collectives.md
+++ b/docs/zh/user/distributed/01-collectives.md
@@ -36,9 +36,10 @@ data = pld.tensor.allreduce(data, signal, op=pld.ReduceOp.Sum, mode="ring")
 - Signal 形状：`[2 × (NR − 1), NR]`
 - 要求编译时已知 NR——使用工厂函数模式：外层 Python 函数接收 `nr`/`size`，
   推导出 `total_rounds = 2 * (nr - 1)`，并在自己的函数体内定义
-  `@pl.program` 类，使 `[total_rounds, nr]` 成为编译期常量（参见下方
-  "可运行示例"一节中的
-  `collectives/test_l3_tensor_allreduce_ring_intrinsic.py`）
+  `@pl.jit` 函数，使 `[total_rounds, nr]` 成为编译期常量（specializer 会把
+  闭包常量折叠进生成的程序）。参见下方"可运行示例"一节中的
+  `collectives/test_l3_tensor_allreduce_ring_intrinsic.py`——该测试当前
+  使用等价的 `@pl.program` 类形式。
 - 最适合大消息（>16 KiB）和高带宽
 
 | 方面 | Mesh | Ring |

--- a/docs/zh/user/distributed/01-collectives.md
+++ b/docs/zh/user/distributed/01-collectives.md
@@ -164,7 +164,7 @@ PyPTO 有三种方式运行集合通信——根据代码运行的位置以及�
 
 | 方面 | InCore 手写 | InCore 组合调用 | Host 级别内置 |
 | ---- | ----------- | --------------- | ------------- |
-| **位置** | `@pl.function(type=InCore)` | `@pl.function(type=InCore)` | `@pl.function(level=HOST, role=Orchestrator)` |
+| **位置** | `@pl.jit.incore` | `@pl.jit.incore` | `@pl.jit.host` |
 | **实现** | 手写 `notify`/`wait` + `remote_load` 循环 | 直接调用 `pld.tensor.allreduce(data, sig, ...)` | 直接调用 `pld.tensor.allreduce(data, [sig,] ...)` |
 | **Lowering** | 自行实现原语 | `LowerCompositeOps` | `LowerHostTensorCollectives` |
 | **支持的模式** | 取决于自己的实现 | `mesh` 和 `ring` | 仅 `mesh` |

--- a/docs/zh/user/distributed/02-primitives.md
+++ b/docs/zh/user/distributed/02-primitives.md
@@ -45,27 +45,24 @@
 最底层的同步原语。每个 rank 写入对端信号槽，然后阻塞直到自己的槽被写入。
 
 ```python
-@pl.program
-class SignalHandshake:
-    @pl.function(type=pl.FunctionType.InCore)
-    def handshake_step(
-        self,
-        out: pl.Out[pl.Tensor[[1, 1], pl.INT32]],
-        signal: pl.InOut[pld.DistributedTensor[[1, 1], pl.INT32]],
-        peer: pl.Scalar[pl.INT32],
-        tag: pl.Scalar[pl.INT32],
-    ) -> pl.Tensor[[1, 1], pl.INT32]:
-        pld.system.notify(
-            signal, peer=peer, offsets=[0, 0],
-            value=tag, op=pld.NotifyOp.Set,
-        )
-        pld.system.wait(
-            signal=signal, offsets=[0, 0],
-            expected=1, cmp=pld.WaitCmp.Ge,
-        )
-        received = pl.load(signal, [0, 0], [1, 1])
-        out = pl.store(received, [0, 0], out)
-        return out
+@pl.jit.incore
+def handshake_step(
+    out: pl.Out[pl.Tensor[[1, 1], pl.INT32]],
+    signal: pl.InOut[pld.DistributedTensor[[1, 1], pl.INT32]],
+    peer: pl.Scalar[pl.INT32],
+    tag: pl.Scalar[pl.INT32],
+) -> pl.Tensor[[1, 1], pl.INT32]:
+    pld.system.notify(
+        signal, peer=peer, offsets=[0, 0],
+        value=tag, op=pld.NotifyOp.Set,
+    )
+    pld.system.wait(
+        signal=signal, offsets=[0, 0],
+        expected=1, cmp=pld.WaitCmp.Ge,
+    )
+    received = pl.load(signal, [0, 0], [1, 1])
+    out = pl.store(received, [0, 0], out)
+    return out
 ```
 
 > `wait` 使用 `Ge` 且 `expected=1`，对端的 `tag` **必须 >= 1**。传入 `tag=0`

--- a/docs/zh/user/distributed/02-primitives.md
+++ b/docs/zh/user/distributed/02-primitives.md
@@ -19,11 +19,11 @@
 | 名称 | 签名 | 描述 |
 | ---- | ---- | ---- |
 | `world_size` | `() -> Scalar` | **仅限 host。** 分布式执行中的 rank 数量。 |
-| `get_comm_ctx` | `(dist_tensor: DT) -> Ctx` | 提升为 `CommCtx` 句柄。 |
-| `rank` | `(ctx: Ctx) -> Scalar` | 本地 rank 索引。 |
-| `nranks` | `(ctx: Ctx) -> Scalar` | 通信组中 rank 数量。 |
-| `notify` | `(target, peer, offsets, value, *, op) -> Call` | 跨 rank 信号投递。仅副作用。 |
-| `wait` | `(signal, offsets, expected, *, cmp) -> Call` | 跨 rank 等待。仅副作用。 |
+| `get_comm_ctx` | `(dist_tensor: DT) -> Ctx` | 提升为 `CommCtx` 句柄。host 编排器和 InCore 代码均可用。 |
+| `rank` | `(ctx: Ctx) -> Scalar` | **仅限 InCore。** 本地 rank 索引。 |
+| `nranks` | `(ctx: Ctx) -> Scalar` | **仅限 InCore。** 通信组中 rank 数量。 |
+| `notify` | `(target, peer, offsets, value, *, op) -> Call` | **仅限 InCore。** 跨 rank 信号投递。仅副作用。 |
+| `wait` | `(signal, offsets, expected, *, cmp) -> Call` | **仅限 InCore。** 跨 rank 等待。仅副作用。 |
 
 ## Window Buffer 管理 (`pld.tensor.*`)
 
@@ -32,8 +32,9 @@
 
 | 名称 | 签名 | 描述 |
 | ---- | ---- | ---- |
-| `window` | `(buf: Ptr, shape, *, dtype) -> DT` | 物化为 `DistributedTensor` 视图。 |
-| `alloc_window_buffer` | `(size, *, name="") -> Ptr` | 分配 HCCL window buffer。**size 以字节为单位。** |
+| `window` | `(buf: Ptr, shape, *, dtype) -> DT` | 物化为 `DistributedTensor` 视图，`buf` 来自 `alloc_window_buffer`。 |
+| `alloc_window_buffer` | `(size, *, name="") -> Ptr` | 分配每 rank 一份的 HCCL window buffer。**size 以字节为单位。** `name` 由解析器从赋值左侧注入——不要手动传入。 |
+| `alloc_window_buffer` | `(shape, *, dtype, name="") -> Ptr` | 便捷重载：自动计算 `size = prod(shape) x dtype.get_byte()`。 |
 
 ## Notify & Wait：信号握手
 

--- a/docs/zh/user/distributed/02-primitives.md
+++ b/docs/zh/user/distributed/02-primitives.md
@@ -1,0 +1,172 @@
+# 原语
+
+大多数用户应直接调用 `pld.tensor.*` 集合通信——只有在构建自定义协议时
+才需要这些更底层的原语。
+
+## 类型与枚举
+
+| 名称 | 取值 | 描述 |
+| ---- | ---- | ---- |
+| `NotifyOp` | `AtomicAdd`, `Set` | 信号投递模式。`AtomicAdd`：原子递增对端信号槽（多 rank 屏障）。`Set`：覆盖对端信号槽（1:1 握手）。 |
+| `WaitCmp` | `Eq`, `Ge` | 等待谓词。`Eq`：等于时解除阻塞。`Ge`：大于等于时解除阻塞。 |
+| `ReduceOp` | `Sum`, `Max`, `Min`, `Prod` | 集合通信的规约算子。支持情况按操作而定：`allreduce` 支持全部四种；`reduce_scatter` 仅支持 `Sum`，其余在 deducer 阶段被拒绝。 |
+| `AtomicType` | `None_`, `Add` | 远程存储合并模式。`None_`：普通存储。`Add`：原子累加。 |
+| `DistributedTensor` | — | 绑定到通信域 window buffer 的 tensor 视图。 |
+| `CommCtx` | — | 通信上下文句柄。 |
+
+## 系统基础设施 (`pld.system.*`)
+
+| 名称 | 签名 | 描述 |
+| ---- | ---- | ---- |
+| `world_size` | `() -> Scalar` | **仅限 host。** 分布式执行中的 rank 数量。 |
+| `get_comm_ctx` | `(dist_tensor: DT) -> Ctx` | 提升为 `CommCtx` 句柄。 |
+| `rank` | `(ctx: Ctx) -> Scalar` | 本地 rank 索引。 |
+| `nranks` | `(ctx: Ctx) -> Scalar` | 通信组中 rank 数量。 |
+| `notify` | `(target, peer, offsets, value, *, op) -> Call` | 跨 rank 信号投递。仅副作用。 |
+| `wait` | `(signal, offsets, expected, *, cmp) -> Call` | 跨 rank 等待。仅副作用。 |
+
+## Window Buffer 管理 (`pld.tensor.*`)
+
+`window` 和 `alloc_window_buffer` 属于 `pld.tensor.*`，而非 `pld.system.*`，
+尽管它们和上面的基础设施同样底层。
+
+| 名称 | 签名 | 描述 |
+| ---- | ---- | ---- |
+| `window` | `(buf: Ptr, shape, *, dtype) -> DT` | 物化为 `DistributedTensor` 视图。 |
+| `alloc_window_buffer` | `(size, *, name="") -> Ptr` | 分配 HCCL window buffer。**size 以字节为单位。** |
+
+## Notify & Wait：信号握手
+
+最底层的同步原语。每个 rank 写入对端信号槽，然后阻塞直到自己的槽被写入。
+
+```python
+@pl.program
+class SignalHandshake:
+    @pl.function(type=pl.FunctionType.InCore)
+    def handshake_step(
+        self,
+        out: pl.Out[pl.Tensor[[1, 1], pl.INT32]],
+        signal: pl.InOut[pld.DistributedTensor[[1, 1], pl.INT32]],
+        peer: pl.Scalar[pl.INT32],
+        tag: pl.Scalar[pl.INT32],
+    ) -> pl.Tensor[[1, 1], pl.INT32]:
+        pld.system.notify(
+            signal, peer=peer, offsets=[0, 0],
+            value=tag, op=pld.NotifyOp.Set,
+        )
+        pld.system.wait(
+            signal=signal, offsets=[0, 0],
+            expected=1, cmp=pld.WaitCmp.Ge,
+        )
+        received = pl.load(signal, [0, 0], [1, 1])
+        out = pl.store(received, [0, 0], out)
+        return out
+```
+
+> `wait` 使用 `Ge` 且 `expected=1`，对端的 `tag` **必须 >= 1**。传入 `tag=0`
+> 会导致永久挂起。
+
+### 选择 NotifyOp 和 WaitCmp
+
+| 场景 | NotifyOp | WaitCmp | 原因 |
+| ---- | -------- | ------- | ---- |
+| 1:1 交换（每个槽一个写者） | `Set` | `Eq` 或 `Ge` | 不需要原子递增 |
+| N-to-1 屏障（多个写者一个槽） | `AtomicAdd` | `Ge` | 每个写者原子累加，等待总量 |
+| 多轮协议 | `AtomicAdd` | `Ge` | 计数跨轮推进 |
+
+> **Buffer 重用安全：** Signal 使用单调计数器且不会自重置。不要在背靠背集合通信中
+> 重用同一 signal buffer。每次调用分配新 buffer。
+
+## Tile 级 RMA (`pld.tile.*`)
+
+| 名称 | 签名 | 描述 |
+| ---- | ---- | ---- |
+| `remote_load` | `(target, peer, offsets, shape, valid_shape=None) -> Tile` | 加载对端区域到本地 tile。 |
+| `remote_store` | `(src_tile, target, peer, offsets) -> Call` | 写入本地 tile 到对端。 |
+
+## Put 和 Get
+
+单边批量传输。
+
+### Put（写入对端）
+
+```python
+# dst 必须为 window-bound
+pld.tensor.put(dst, peer=1, src=local_chunk, atomic=pld.AtomicType.Add)
+```
+
+### Get（从对端读取）
+
+```python
+# src 必须为 window-bound
+pld.tensor.get(dst, peer=1, src=peer_data)
+```
+
+### 分块与流水线约束
+
+`chunk_rows`/`chunk_cols`（`0` 表示完整范围）会缩小 staging tile，让超过
+片上 staging 预算的传输仍能一次调用完成，自动滑动通过较小的 stage。
+
+> **致命陷阱：** `pipeline=True` **要求 `chunk_rows > 0` 且 `chunk_cols > 0`
+> 同时成立**——双缓冲的收益只有在传输确实被分块时才存在。若 `pipeline=True`
+> 而任一 chunk 维度仍为 `0`，会在派发前抛出 `ValueError`。
+
+**动态**传输范围（运行时确定的 `shape`，或 `dst`/`src` 自身维度为动态的
+整片传输）必须由匹配的静态 chunk 限定：动态的最内层维度要求设置
+`chunk_cols`，动态的最外层维度要求设置 `chunk_rows`——staging tile 是静态
+分配的，无法按运行时值确定大小。
+
+## 编写自己的集合通信
+
+每个内置集合通信都是底层原语的组合。mesh allreduce 的模式为：
+stage-in → barrier → remote-accumulate → stage-out。
+
+### 隔离的 Barrier
+
+```python
+for peer in pl.range(nranks):
+    if peer != my_rank:
+        pld.system.notify(
+            signal, peer=peer, offsets=[my_rank, 0],
+            value=1, op=pld.NotifyOp.AtomicAdd,
+        )
+for src in pl.range(nranks):
+    if src != my_rank:
+        pld.system.wait(
+            signal, offsets=[src, 0],
+            expected=1, cmp=pld.WaitCmp.Ge,
+        )
+```
+
+### 远程累加
+
+```python
+acc = pl.load(data, [0, 0], [1, SIZE])
+for peer in pl.range(nranks):
+    if peer != my_rank:
+        peer_tile = pld.tile.remote_load(
+            data, peer=peer, offsets=[0, 0], shape=[1, SIZE]
+        )
+        acc = pl.add(acc, peer_tile)
+```
+
+## 2 段 vs 3 段命名空间
+
+| 短格式 (`pld.*`) | 完整路径 |
+| ---------------- | -------- |
+| `pld.world_size()` | `pld.system.world_size()` |
+| `pld.rank(ctx)` | `pld.system.rank(ctx)` |
+| `pld.nranks(ctx)` | `pld.system.nranks(ctx)` |
+| `pld.alloc_window_buffer(...)` | `pld.tensor.alloc_window_buffer(...)` |
+| `pld.window(...)` | `pld.tensor.window(...)` |
+| `pld.remote_load(...)` | `pld.tile.remote_load(...)` |
+| `pld.remote_store(...)` | `pld.tile.remote_store(...)` |
+
+**无短格式：** `pld.notify(...)`、`pld.wait(...)`、`pld.allreduce(...)` 等——
+这些需要完整的 3 段命名空间。
+
+## 相关链接
+
+- [01-collectives](01-collectives.md) — 基于这些原语构建的集合通信
+- [03-execution](03-execution.md) — DistributedWorker 生命周期
+- [04-debugging](04-debugging.md) — 常见故障模式

--- a/docs/zh/user/distributed/02-primitives.md
+++ b/docs/zh/user/distributed/02-primitives.md
@@ -60,8 +60,8 @@ def handshake_step(
         signal=signal, offsets=[0, 0],
         expected=1, cmp=pld.WaitCmp.Ge,
     )
-    received = pl.load(signal, [0, 0], [1, 1])
-    out = pl.store(received, [0, 0], out)
+    received = pl.read(signal, [0, 0])
+    pl.write(out, [0, 0], received)
     return out
 ```
 

--- a/docs/zh/user/distributed/02-primitives.md
+++ b/docs/zh/user/distributed/02-primitives.md
@@ -3,6 +3,10 @@
 大多数用户应直接调用 `pld.tensor.*` 集合通信——只有在构建自定义协议时
 才需要这些更底层的原语。
 
+> **说明：** 下面 notify/wait、put/get 以及 remote-load/store 的代码块均为
+> 示意性片段——省略了 `nranks`/`my_rank` 推导和 buffer 设置，并非可直接
+> 运行的程序。可运行版本见下方"可运行示例"一节。
+
 ## 类型与枚举
 
 | 名称 | 取值 | 描述 |
@@ -75,6 +79,10 @@ class SignalHandshake:
 | N-to-1 屏障（多个写者一个槽） | `AtomicAdd` | `Ge` | 每个写者原子累加，等待总量 |
 | 多轮协议 | `AtomicAdd` | `Ge` | 计数跨轮推进 |
 
+**2 个 rank 的预期输出：** rank 0 写入 tag=2，等待来自 rank 1 的 tag 1：
+`outputs[0] == 1`。rank 1 写入 tag=1，等待来自 rank 0 的 tag 2：
+`outputs[1] == 2`。结果：`outputs == [[1], [2]]`。
+
 > **Buffer 重用安全：** Signal 使用单调计数器且不会自重置。不要在背靠背集合通信中
 > 重用同一 signal buffer。每次调用分配新 buffer。
 
@@ -82,14 +90,19 @@ class SignalHandshake:
 
 | 名称 | 签名 | 描述 |
 | ---- | ---- | ---- |
-| `remote_load` | `(target, peer, offsets, shape, valid_shape=None) -> Tile` | 加载对端区域到本地 tile。 |
+| `remote_load` | `(target, peer, offsets, shape, valid_shape=None) -> Tile` | 加载对端区域到本地 tile。`shape` 定义 tile 维度。`valid_shape` 可在物理 tile 保持固定大小的同时，让参差不齐的尾部只读取真实数据。Offsets 必须与对端写入时使用的一致——偏移 1 个元素就会导致静默数据损坏。 |
 | `remote_store` | `(src_tile, target, peer, offsets) -> Call` | 写入本地 tile 到对端。 |
 
-## Put 和 Get
+## Put 和 Get (`pld.tensor.*`)
 
-单边批量传输。
+单边批量传输——rank A 写入或读取 rank B 的 window，rank B 无需参与传输
+（除了 signal 屏障）。
 
 ### Put（写入对端）
+
+| 名称 | 签名 | 变更 | 描述 |
+| ---- | ---- | ---- | ---- |
+| `put` | `(dst: DT, peer: IntLike, src: DT \| Tensor, dst_offsets=None, src_offsets=None, shape=None, *, atomic=AtomicType.None_, chunk_rows=0, chunk_cols=0, pipeline=False) -> Call` | `dst: InOut`，`src: In` | 将本地 `src` 写入对端 rank 的 `dst`。`dst` **必须**为 window-bound；`src` 可以是普通 `Tensor`。未指定 offsets/shape 时，写入完整的本地分片。`atomic=Add` 时累加而非覆盖。 |
 
 ```python
 # dst 必须为 window-bound
@@ -97,6 +110,10 @@ pld.tensor.put(dst, peer=1, src=local_chunk, atomic=pld.AtomicType.Add)
 ```
 
 ### Get（从对端读取）
+
+| 名称 | 签名 | 变更 | 描述 |
+| ---- | ---- | ---- | ---- |
+| `get` | `(dst: DT \| Tensor, peer: IntLike, src: DT, dst_offsets=None, src_offsets=None, shape=None, *, chunk_rows=0, chunk_cols=0, pipeline=False) -> Call` | `dst: Out`，`src: In` | 读取对端 rank 的 `src` 到本地 `dst`。`src` **必须**为 window-bound；`dst` 可以是普通 `Tensor`。 |
 
 ```python
 # src 必须为 window-bound
@@ -139,6 +156,14 @@ for src in pl.range(nranks):
         )
 ```
 
+使用 `offsets=[my_rank, 0]` 时，每个 rank 拥有专属的一行——每个对端
+window 中的 `[r, 0]` 格子只有一个写者，即 rank `r` 自己，因此这里用
+`Set` 效果完全相同。之所以展示 `AtomicAdd`，是因为本文档中每个 barrier
+使用的都是同一个 notify 调用；真正需要 `AtomicAdd` 的"多写者、一个槽位"
+场景是*共享格子*的 barrier（见上表）——只有在需要区分*哪些*对端已经到达，
+而不仅仅是*是否*所有对端都已到达时，才像这里一样给每个 rank 分配不同的
+offset。
+
 ### 远程累加
 
 ```python
@@ -158,13 +183,24 @@ for peer in pl.range(nranks):
 | `pld.world_size()` | `pld.system.world_size()` |
 | `pld.rank(ctx)` | `pld.system.rank(ctx)` |
 | `pld.nranks(ctx)` | `pld.system.nranks(ctx)` |
+| `pld.get_comm_ctx(dt)` | `pld.system.get_comm_ctx(dt)` |
 | `pld.alloc_window_buffer(...)` | `pld.tensor.alloc_window_buffer(...)` |
 | `pld.window(...)` | `pld.tensor.window(...)` |
 | `pld.remote_load(...)` | `pld.tile.remote_load(...)` |
 | `pld.remote_store(...)` | `pld.tile.remote_store(...)` |
 
-**无短格式：** `pld.notify(...)`、`pld.wait(...)`、`pld.allreduce(...)` 等——
-这些需要完整的 3 段命名空间。
+**无短格式：** `pld.notify(...)`、`pld.wait(...)`、`pld.put(...)`、
+`pld.get(...)`、`pld.allreduce(...)` 等——这些需要完整的 3 段命名空间。
+
+## 可运行示例
+
+| 原语 | 测试 |
+| ---- | ---- |
+| notify / wait | `test_l3_notify_wait.py` |
+| put / get | `test_l3_put.py` / `test_l3_get.py` |
+| remote_store | `test_l3_remote_store.py` |
+
+（路径均相对于 `tests/st/distributed/`）
 
 ## 相关链接
 

--- a/docs/zh/user/distributed/03-execution.md
+++ b/docs/zh/user/distributed/03-execution.md
@@ -10,19 +10,21 @@ fork chip 进程、组装 kernel——分摊到可复用的 `DistributedWorker` 
 分发可执行多次。
 
 ```python
-from pypto.runtime import DistributedWorker
-
-with DistributedWorker(compiled) as rt:
+with compiled.prepare() as rt:
     rt(host_x, host_out)
     # ... 更多分发 ...
 # rt.close() 在退出时自动执行——释放 buffer 并关闭 worker。
 ```
 
+`compiled.prepare()` 返回一个 `DistributedWorker`（也可以通过
+`DistributedWorker(compiled)` 直接构造，可从 `pypto.runtime` 导入，但
+`prepare()` 是文档约定的入口）。
+
 ### 方法
 
 | 方法 | 描述 |
 | ---- | ---- |
-| `compiled.prepare(config=None, callbacks=None)` | 创建 worker、fork 芯片进程，返回 `DistributedWorker`。作为上下文管理器使用。 |
+| `compiled.prepare(config=None, *, extra_compiled=(), persistent=False, reset_persistent_windows=None, callbacks=None, sub_worker_overrides=None)` | 创建 worker、fork 芯片进程，返回 `DistributedWorker`。作为上下文管理器使用。 |
 | `rt(x, y, z)` | 单次分发——转换参数，调用 host_orch。 |
 | `rt.run(compiled, x, y, z)` | 多程序分发——选择目标程序。 |
 | `rt.alloc_tensor(shape, dtype, *, init=None)` | 分配 worker 常驻的 `DeviceTensor`。`init` 从 host 拷贝（一次性 H2D）。 |
@@ -32,6 +34,19 @@ with DistributedWorker(compiled) as rt:
 | `rt.copy_stacked_from(stacked, host_out)` | 把每个分片 D2H 读回 `host_out`（共享内存，须在 `prepare()` 前分配）。 |
 | `rt.release_inherited_host_tensor_refs()` | fork 后释放运行时在父进程中持有的 host 引用。 |
 | `rt.close()` | 释放 buffer，关闭芯片 worker。作为上下文管理器时自动调用。 |
+
+### 值得了解的 `prepare()` 参数
+
+- **`config`**——可选的 `RunConfig`，仅用于按给定的 ring sizing 预热
+  runtime arena 缓存，使首次派发跳过约 800ms 的冷构建。它**不会被保留**：
+  每次派发仍需自己传入 `config=`。预热只有在*首次*派发的 sizing 与预热
+  时使用的一致时才有收益——见 `docs/en/dev/05-runtime-ring-sizing.md` 中
+  arena 预热一节。
+- **`persistent=True`**——在 worker 整个生命周期内保留 CommDomain
+  window，而不是每次派发都分配/释放。与 **`reset_persistent_windows`**
+  搭配使用，后者决定保留的 window 是否在两次请求之间清零（正确性与
+  开销的权衡）。见 `docs/en/dev/06-persistent-l3.md`。
+- **`extra_compiled`**——见下方"在同一个 worker 上运行多个程序"。
 
 ## DeviceTensor
 
@@ -83,11 +98,16 @@ compiled(inputs, outputs)   # 阻塞直到所有 rank 完成
 
 ### 持久 Worker（重复派发）
 
+在多次派发之间复用同一个 worker 对象——这是任何 `DistributedWorker` 的
+默认生命周期。（不要与上文的 `persistent=True` CommDomain-window 保留
+标志混淆——那是一个可选项，用于跳过每次派发的 window 分配/释放；本节
+展示的分摊 fork/通信引导开销，无论 `persistent=` 取值如何都会发生。）
+
 ```python
 host_x = torch.zeros((4, 1, 256), dtype=torch.float32).share_memory_()
 host_out = torch.zeros_like(host_x).share_memory_()
 
-with DistributedWorker(compiled) as rt:
+with compiled.prepare() as rt:
     for step in steps:
         host_x.copy_(next_input(step))
         rt(host_x, host_out)
@@ -119,14 +139,8 @@ worker 复用其芯片进程和通信设置——没有 fork 开销。`compiled_
 
 ## CLI 启动
 
-分布式程序的启动方式与单设备程序完全一样——直接 `python script.py`。
-`DistributedConfig(device_ids=[...])` 决定 rank 数量和使用的设备；运行时
-会从这一个 Python 进程中为每个设备 fork 出一个 worker 进程，因此不需要
-调用单独的多进程启动器。
-
-```bash
-python script.py
-```
+分布式程序的启动方式与单设备程序完全一样——见 [00-model](00-model.md)
+中的"启动命令"一节：直接 `python script.py`，不需要单独的多进程启动器。
 
 ## 环境变量
 

--- a/docs/zh/user/distributed/03-execution.md
+++ b/docs/zh/user/distributed/03-execution.md
@@ -86,10 +86,11 @@ with compiled.prepare() as rt:
 ```python
 import torch
 from pypto.ir.distributed_compiled_program import DistributedConfig
-from pypto import ir
+from pypto.runtime import RunConfig
 
 dc = DistributedConfig(device_ids=[0, 1, 2, 3])
-compiled = ir.compile(HelloAllReduce, platform="a2a3", distributed_config=dc)
+cfg = RunConfig(platform="a2a3", distributed_config=dc)
+compiled = orchestrator.compile(config=cfg)   # 从 orchestrator 自身的类型标注读取形状
 
 inputs = torch.randn(4, 1, 256)
 outputs = torch.zeros_like(inputs)

--- a/docs/zh/user/distributed/03-execution.md
+++ b/docs/zh/user/distributed/03-execution.md
@@ -14,37 +14,62 @@ from pypto.runtime import DistributedWorker
 
 with DistributedWorker(compiled) as rt:
     rt(host_x, host_out)
+    # ... 更多分发 ...
+# rt.close() 在退出时自动执行——释放 buffer 并关闭 worker。
 ```
 
 ### 方法
 
 | 方法 | 描述 |
 | ---- | ---- |
-| `compiled.prepare(config=None, callbacks=None)` | 创建 worker、fork 芯片进程，返回 `DistributedWorker`。 |
-| `rt(x, y, z)` | 单次分发。 |
-| `rt.run(compiled, x, y, z)` | 多程序分发。 |
-| `rt.alloc_tensor(shape, dtype, *, init=None)` | 分配设备驻留 `DeviceTensor`。 |
+| `compiled.prepare(config=None, callbacks=None)` | 创建 worker、fork 芯片进程，返回 `DistributedWorker`。作为上下文管理器使用。 |
+| `rt(x, y, z)` | 单次分发——转换参数，调用 host_orch。 |
+| `rt.run(compiled, x, y, z)` | 多程序分发——选择目标程序。 |
+| `rt.alloc_tensor(shape, dtype, *, init=None)` | 分配 worker 常驻的 `DeviceTensor`。`init` 从 host 拷贝（一次性 H2D）。 |
 | `rt.free_tensor(tensor)` | 释放 `DeviceTensor`。 |
-| `rt.alloc_stacked_tensor(host_w)` | 沿 dim 0 分片 host_w。 |
-| `rt.free_stacked_tensor(stacked)` | 释放所有分片。 |
-| `rt.copy_stacked_from(stacked, host_out)` | D2H 读回每个分片。 |
-| `rt.close()` | 释放 buffer，关闭芯片 worker。 |
+| `rt.alloc_stacked_tensor(host_w)` | 沿 dim 0 分片 `host_w`——分片 `i` 上传到卡 `i`。返回 `StackedDeviceTensor`。 |
+| `rt.free_stacked_tensor(stacked)` | 释放 `StackedDeviceTensor` 的所有分片。 |
+| `rt.copy_stacked_from(stacked, host_out)` | 把每个分片 D2H 读回 `host_out`（共享内存，须在 `prepare()` 前分配）。 |
+| `rt.release_inherited_host_tensor_refs()` | fork 后释放运行时在父进程中持有的 host 引用。 |
+| `rt.close()` | 释放 buffer，关闭芯片 worker。作为上下文管理器时自动调用。 |
 
 ## DeviceTensor
 
-设备驻留 buffer，跨分发存活。
+设备驻留 buffer，跨分发存活。当 `DeviceTensor` 作为参数传给已编译程序时，
+运行时会跳过 H2D/D2H 拷贝——设备上已经有数据。
 
 ```python
+import torch
+from pypto.runtime import DeviceTensor
+
 with compiled.prepare() as rt:
     weight = rt.alloc_tensor((1024, 4096), torch.float16, init=host_weight)
-    rt(x, weight, out)   # 无 H2D/D2H
+    rt(x, weight, out)   # 通过 worker 分发——无 H2D/D2H
 ```
+
+## StackedDeviceTensor
+
+跨设备分片——通过 `rt.alloc_stacked_tensor()` 获得：
+
+```python
+# Host 张量沿 dim 0 分片——分片[i] 存在卡 i 上。
+host_weights = torch.randn(4, 1024, 4096).share_memory_()  # 4 个分片
+with compiled.prepare() as rt:
+    stacked = rt.alloc_stacked_tensor(host_weights)
+    rt(x, stacked, out)
+```
+
+> **致命陷阱：** `host_weights` 必须在 `prepare()` **之前**调用
+> `.share_memory_()`。上传操作在已经 fork 出的芯片 worker 内部运行，
+> 该进程只能读取它在 fork 时继承到的 host 内存——传入普通
+> `torch.Tensor` 会在 `alloc_stacked_tensor()` 处抛出 `ValueError`。
 
 ## One-Shot vs 持久 Worker
 
 ### One-Shot
 
 ```python
+import torch
 from pypto.ir.distributed_compiled_program import DistributedConfig
 from pypto import ir
 
@@ -53,10 +78,10 @@ compiled = ir.compile(HelloAllReduce, platform="a2a3", distributed_config=dc)
 
 inputs = torch.randn(4, 1, 256)
 outputs = torch.zeros_like(inputs)
-compiled(inputs, outputs)
+compiled(inputs, outputs)   # 阻塞直到所有 rank 完成
 ```
 
-### 持久 Worker
+### 持久 Worker（重复派发）
 
 ```python
 host_x = torch.zeros((4, 1, 256), dtype=torch.float32).share_memory_()
@@ -69,8 +94,28 @@ with DistributedWorker(compiled) as rt:
         consume(host_out)
 ```
 
-> **致命陷阱：** 传入 `DistributedWorker` 的 IO buffer 在 `prepare()` 前必须调用
-> `.share_memory_()`。若忘记，运行时在分发时拒绝该 buffer。
+> **致命陷阱：** 传入 `DistributedWorker` 的 IO buffer 必须在 `prepare()`
+> 前调用 `.share_memory_()`。若忘记，运行时会在分发时拒绝该
+> buffer——子进程无法访问父进程的私有内存。
+
+## 在同一个 worker 上运行多个程序
+
+一个 `DistributedWorker` 可以分发多个已编译程序：
+
+```python
+compiled_a = ir.compile(ProgramA, platform="a2a3", distributed_config=dc)
+compiled_b = ir.compile(ProgramB, platform="a2a3", distributed_config=dc)
+
+with compiled_a.prepare(extra_compiled=[compiled_b]) as rt:
+    rt.run(compiled_a, host_x, host_out)  # 分发 ProgramA
+    rt.run(compiled_b, host_x, host_out)  # 分发 ProgramB
+```
+
+worker 复用其芯片进程和通信设置——没有 fork 开销。`compiled_b` 必须通过
+`extra_compiled=` 传入，`rt.run(compiled_b, ...)` 才能找到它；传入未注册的
+程序会抛出 `ValueError`。准备多个程序也会让 worker 进入多程序模式，此时
+`rt(*args)` 快捷方式含义不明确会抛出 `TypeError`——包括主程序在内的每个
+程序都必须显式通过 `rt.run(...)` 派发。
 
 ## CLI 启动
 
@@ -87,20 +132,31 @@ python script.py
 
 ### 编译时宏
 
-这些是 C 预处理器 `#define` 宏，**不是环境变量**。通过 CMake 标记设置。
+这些是 C 预处理器 `#define` 宏（定义在 `profiling_config.h`），**不是环境
+变量**。默认值为 `1`（开启），通过 CMake 编译参数设置；作为 shell 环境
+变量设置对其无效。
 
 | 宏 | 默认值 | 效果 |
 | -- | ------ | ---- |
-| `SIMPLER_HOST_STRACE` | `1`（开） | `benchmark()` 计时标记必需。 |
-| `SIMPLER_DFX` | `1`（开） | 设备端分析总开关。 |
+| `SIMPLER_HOST_STRACE` | `1`（开） | `benchmark()` 计时标记在编译期所必需。缺失时 `benchmark()` 会抛出 `RuntimeError`。 |
+| `SIMPLER_DFX` | `1`（开） | 设备端分析总开关（编排器/调度器指标、PMU 计数器、scope 统计、swimlane trace）。子开关都需要它为 `1`。 |
 
 ### 运行时环境变量
 
 | 变量 | 默认值 | 效果 |
 | ---- | ------ | ---- |
-| `SIMPLER_DEVICE_STRACE_ENABLE` | 开 | 运行时切换设备域 `[STRACE]` 标记。 |
+| `SIMPLER_DEVICE_STRACE_ENABLE` | 开（未设置或非 `"0"`） | 运行时切换设备域 `[STRACE]` 标记。设为 `0` 可在保留 host 标记的同时抑制设备标记。 |
+
+### 基准测试环境变量
+
+`pypto-lib` 的 golden 基准测试框架读取 `PYPTO_BENCH` /
+`PYPTO_BENCH_ROUNDS` / `PYPTO_BENCH_WARMUP` / `PYPTO_BENCH_RAW`——这些
+在本仓库中未定义也未被使用。其当前默认值见 `pypto-lib` 自身的文档。
+`pypto.runtime.benchmark()`（本仓库自己的基准测试工具）在性能指南中
+单独说明。
 
 ## 相关链接
 
 - [00-model](00-model.md) — 快速开始和模型词汇
 - [04-debugging](04-debugging.md) — 常见故障模式
+- [入门指南](../00-getting_started.md) — 运行时设置

--- a/docs/zh/user/distributed/03-execution.md
+++ b/docs/zh/user/distributed/03-execution.md
@@ -1,0 +1,106 @@
+# 执行
+
+一次性的编译并派发调用足以应付快速测试。生产代码则会将设置成本——
+fork chip 进程、组装 kernel——分摊到可复用的 `DistributedWorker` 上的多次
+派发中。
+
+## DistributedWorker
+
+通过 `compiled.prepare()` 获得。设置（fork、通信引导、kernel 组装）仅执行一次；
+分发可执行多次。
+
+```python
+from pypto.runtime import DistributedWorker
+
+with DistributedWorker(compiled) as rt:
+    rt(host_x, host_out)
+```
+
+### 方法
+
+| 方法 | 描述 |
+| ---- | ---- |
+| `compiled.prepare(config=None, callbacks=None)` | 创建 worker、fork 芯片进程，返回 `DistributedWorker`。 |
+| `rt(x, y, z)` | 单次分发。 |
+| `rt.run(compiled, x, y, z)` | 多程序分发。 |
+| `rt.alloc_tensor(shape, dtype, *, init=None)` | 分配设备驻留 `DeviceTensor`。 |
+| `rt.free_tensor(tensor)` | 释放 `DeviceTensor`。 |
+| `rt.alloc_stacked_tensor(host_w)` | 沿 dim 0 分片 host_w。 |
+| `rt.free_stacked_tensor(stacked)` | 释放所有分片。 |
+| `rt.copy_stacked_from(stacked, host_out)` | D2H 读回每个分片。 |
+| `rt.close()` | 释放 buffer，关闭芯片 worker。 |
+
+## DeviceTensor
+
+设备驻留 buffer，跨分发存活。
+
+```python
+with compiled.prepare() as rt:
+    weight = rt.alloc_tensor((1024, 4096), torch.float16, init=host_weight)
+    rt(x, weight, out)   # 无 H2D/D2H
+```
+
+## One-Shot vs 持久 Worker
+
+### One-Shot
+
+```python
+from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto import ir
+
+dc = DistributedConfig(device_ids=[0, 1, 2, 3])
+compiled = ir.compile(HelloAllReduce, platform="a2a3", distributed_config=dc)
+
+inputs = torch.randn(4, 1, 256)
+outputs = torch.zeros_like(inputs)
+compiled(inputs, outputs)
+```
+
+### 持久 Worker
+
+```python
+host_x = torch.zeros((4, 1, 256), dtype=torch.float32).share_memory_()
+host_out = torch.zeros_like(host_x).share_memory_()
+
+with DistributedWorker(compiled) as rt:
+    for step in steps:
+        host_x.copy_(next_input(step))
+        rt(host_x, host_out)
+        consume(host_out)
+```
+
+> **致命陷阱：** 传入 `DistributedWorker` 的 IO buffer 在 `prepare()` 前必须调用
+> `.share_memory_()`。若忘记，运行时在分发时拒绝该 buffer。
+
+## CLI 启动
+
+分布式程序的启动方式与单设备程序完全一样——直接 `python script.py`。
+`DistributedConfig(device_ids=[...])` 决定 rank 数量和使用的设备；运行时
+会从这一个 Python 进程中为每个设备 fork 出一个 worker 进程，因此不需要
+调用单独的多进程启动器。
+
+```bash
+python script.py
+```
+
+## 环境变量
+
+### 编译时宏
+
+这些是 C 预处理器 `#define` 宏，**不是环境变量**。通过 CMake 标记设置。
+
+| 宏 | 默认值 | 效果 |
+| -- | ------ | ---- |
+| `SIMPLER_HOST_STRACE` | `1`（开） | `benchmark()` 计时标记必需。 |
+| `SIMPLER_DFX` | `1`（开） | 设备端分析总开关。 |
+
+### 运行时环境变量
+
+| 变量 | 默认值 | 效果 |
+| ---- | ------ | ---- |
+| `SIMPLER_DEVICE_STRACE_ENABLE` | 开 | 运行时切换设备域 `[STRACE]` 标记。 |
+
+## 相关链接
+
+- [00-model](00-model.md) — 快速开始和模型词汇
+- [04-debugging](04-debugging.md) — 常见故障模式

--- a/docs/zh/user/distributed/04-debugging.md
+++ b/docs/zh/user/distributed/04-debugging.md
@@ -1,0 +1,53 @@
+# 调试与陷阱
+
+分布式 bug 很少留下本地堆栈——症状出现在某个 rank 上，而原因却在另一个
+rank 上。
+
+## 常见故障模式
+
+| 症状 | 可能原因 | 修复 |
+| ---- | -------- | ---- |
+| **所有 rank 挂起** | notify/wait 顺序错误 | 确保 notify 循环在 wait 循环之前。 |
+| **静默数据损坏** | `remote_load` offsets 或 shape 不匹配 | 验证 offsets 与对端的 store offsets 对齐。 |
+| **Signal cell 永不达到期望值** | 错误 `NotifyOp` | 多参与者屏障用 `AtomicAdd`；1:1 交换用 `Set`。 |
+| **编译时形状不匹配** | `NR` 未使用 `pl.dynamic` | 将运行时维度包裹在 `pl.dynamic("NR")` 中。 |
+| **派发时抛出 `TypeError`** | IO buffer 在 `prepare()` 前未调用 `.share_memory_()`——fork 出的子进程看不到 fork 之后分配的 buffer | 在 `prepare()` 之前对每个传给 worker 的 host tensor 调用 `.share_memory_()`。 |
+| **循环内 allreduce 被拒绝** | Signal 协议无法每轮注入新 buffer | 在循环外每次调用分配新 signal buffer。 |
+
+## 致命陷阱
+
+> **缺少 `.share_memory_()`：** 传入 `DistributedWorker` 的 IO buffer 在
+> `prepare()` 前必须调用 `.share_memory_()`。若忘记调用，运行时会在派发时
+> 抛出 `TypeError`——fork 出的子进程无法访问父进程私有的内存。
+>
+> **`alloc_window_buffer` 传入 rank 数量而非字节数：** `size` 参数以**字节**
+> 为单位。使用 shape+dtype 重载。
+>
+> **`device_ids` 与 `device=` 不匹配：** `DistributedConfig.device_ids` 必须
+> 与编排器中 per-rank 分发使用的 device ID 一致。例如 `device_ids=[0, 1]`
+> 却用 `device=r`（`r` 遍历 `range(4)`）派发，会导致未定义行为。
+
+## 诊断标志
+
+`SIMPLER_HOST_STRACE` 和 `SIMPLER_DFX` 是**编译时 C 预处理器宏**，设置为 shell
+环境变量**无效**——它们在编译期就已固定。默认开启。切换它们属于 `simpler`
+运行时的构建配置变更，而非一个简单的 `cmake -D...` 缓存变量——具体机制见
+`simpler` 运行时自己的构建文档。
+
+运行时环境变量：
+
+```bash
+# 切换设备域 [STRACE] 标记：
+SIMPLER_DEVICE_STRACE_ENABLE=0 python script.py
+```
+
+### 分布式 DFX 入口点
+
+- **L2 swimlane：** `RunConfig(enable_l2_swimlane=True)`
+- **Scope 统计：** `RunConfig(enable_scope_stats=True)`
+- **依赖图：** `RunConfig(enable_dep_gen=True)`
+
+## 相关链接
+
+- [00-model](00-model.md) — 快速开始和模型词汇
+- [02-primitives](02-primitives.md) — 集合通信的底层基础

--- a/docs/zh/user/distributed/04-debugging.md
+++ b/docs/zh/user/distributed/04-debugging.md
@@ -43,9 +43,14 @@ SIMPLER_DEVICE_STRACE_ENABLE=0 python script.py
 
 ### 分布式 DFX 入口点
 
-- **L2 swimlane：** `RunConfig(enable_l2_swimlane=True)`
-- **Scope 统计：** `RunConfig(enable_scope_stats=True)`
-- **依赖图：** `RunConfig(enable_dep_gen=True)`
+- **L2 swimlane：** `RunConfig(enable_l2_swimlane=True)`——在 worker 内部启用
+  逐任务计时，并透传到 L3 编排。写入 `dfx_outputs/l2_swimlane_records.json`
+  （onboard 场景会与下面的依赖图合并为 `merged_swimlane_*.json`）。
+- **Scope 统计：** `RunConfig(enable_scope_stats=True)`——写入
+  `dfx_outputs/scope_stats/scope_stats.jsonl`，包含 task_window、heap 和
+  tensormap 水位。
+- **依赖图：** `RunConfig(enable_dep_gen=True)`——写入 `dfx_outputs/deps.json`，
+  供调度器分析的任务依赖图。
 
 ## 相关链接
 

--- a/docs/zh/user/distributed/04-debugging.md
+++ b/docs/zh/user/distributed/04-debugging.md
@@ -23,9 +23,15 @@ rank 上。
 > **`alloc_window_buffer` 传入 rank 数量而非字节数：** `size` 参数以**字节**
 > 为单位。使用 shape+dtype 重载。
 >
-> **`device_ids` 与 `device=` 不匹配：** `DistributedConfig.device_ids` 必须
-> 与编排器中 per-rank 分发使用的 device ID 一致。例如 `device_ids=[0, 1]`
-> 却用 `device=r`（`r` 遍历 `range(4)`）派发，会导致未定义行为。
+> **分发循环的执行次数与 `device_ids` 不匹配：** `device_ids` 是物理卡 ID
+>（例如来自 `--device 4,5`），不要求从 0 开始或连续。`device=r` 则是一个
+> *逻辑* rank 索引，始终按 `[0, world)` 校验，其中
+> `world = len(device_ids)`；运行时按 `rank r -> device_ids[r]` 映射。真正
+> 重要的不变量是分发循环的执行次数等于 `len(device_ids)`——写成
+> `for r in pl.range(pld.world_size())` 时会自动满足。不匹配的例子：
+> `device_ids=[0, 1, 2, 3]`（4 张卡）但分发循环只覆盖 `range(2)`，会让
+> 2 张卡未被派发，导致未定义行为（`MaterializeCommDomainScopes` 要求
+> `device=r` 循环的范围必须是 `[0, N)`）。
 
 ## 诊断标志
 

--- a/docs/zh/user/distributed/index.md
+++ b/docs/zh/user/distributed/index.md
@@ -1,0 +1,52 @@
+# 分布式编程
+
+PyPTO 的分布式模型建立在**对称内存与信号**之上：每个 rank 在所有对端看到
+相同的 window buffer 地址，通过单边 `put`/`get`/`remote_load` 访问其他
+rank，并通过**信号同步**（`notify`/`wait`）进行协调。**通信域**是共享对称
+window pool 的 rank 子集；整个 world 为默认通信域。
+
+编译器 lowering 出的每个 allreduce、broadcast、barrier 都是这些相同原语的
+组合——`pld.tensor.*` 集合通信（`allreduce`、`barrier` 等）是它们的语法糖，
+而非另一套独立的库。
+
+## L2 vs L3
+
+| 层级 | 范围 | API 命名空间 |
+| ---- | ---- | ------------ |
+| L2 | 单设备（一个 NPU 芯片） | `pl.*` |
+| L3 | 跨 rank（多个 NPU 或进程） | `pld.*` |
+
+> **PyPTO 的 L2/L3 与 simpler 的 L0–L6：** 这两层是 PyPTO 自己的用户侧词汇，
+> 并非 simpler 的编号体系。simpler 使用更细的七层体系（L0 核心 → L1 die →
+> L2 芯片 → L3 主机 → L4 pod → L5 超节点 → L6 集群）；PyPTO 的 "L2" 对应
+> simpler 的 L0–L2（单芯片内的一切），PyPTO 的 "L3" 对应 simpler 的 L3
+> 及以上（跨芯片的一切）。完整模型见 simpler 的
+> [层级化 Level Runtime](https://hw-native-sys.github.io/simpler/hierarchical-level-runtime/)。
+
+分布式章节涵盖 L3。L2 内容见[语言指南](../01-language_guide.md)。
+
+## 术语表
+
+| 术语 | 定义 |
+| ---- | ---- |
+| **Rank** | 参与分布式程序的单个进程或芯片。每个 rank 在启动时分配唯一索引。 |
+| **Device** | 一个 Ascend NPU 芯片（或 die），由 `device_id` 标识。一个 rank 对应一个 device。 |
+| **Node** | 托管一个或多个设备的物理机器。 |
+| **Window buffer** | 对称 per-rank HCCL 缓冲区。Rank 通过对等端 `CommContext.windowsIn[peer]`/`windowsOut[peer]` 查看对等端。 |
+| **通信域** | 共享对称 window pool 的 rank 子集。默认：整个 world。 |
+| **信号** | 跨 rank 同步原语。notify/wait 计数器协调对 window buffer 的访问。 |
+| **编排器** | 分配 window buffer 并将 kernel 分发到设备的 HOST 函数。 |
+| **InCore kernel** | 在 NPU 上执行的设备端函数。 |
+
+## 阅读路径
+
+1. **[00-model](00-model.md)** — 快速开始优先：运行 2-rank 程序，然后了解模型词汇
+2. **[01-collectives](01-collectives.md)** — AllReduce、barrier、broadcast、allgather、reduce_scatter、all-to-all
+3. **[02-primitives](02-primitives.md)** — notify/wait、remote_load/remote_store、put/get、CommCtx
+4. **[03-execution](03-execution.md)** — DistributedWorker 生命周期、DeviceTensor、多程序、环境变量
+5. **[04-debugging](04-debugging.md)** — 常见故障模式和诊断标志
+
+## 相关链接
+
+- [入门指南](../00-getting_started.md) — `ir.compile()`、`CompiledProgram`、`DeviceTensor`、`RunConfig`
+- [Simpler 运行时](https://hw-native-sys.github.io/simpler/) — 运行时内部机制（调度器、图构建、tensormap）

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -109,6 +109,7 @@ plugins:
             Code Generation: 代码生成
             Backend: 后端
             Debug: 调试
+            Distributed: 分布式
   # Renders `pl.*` / `pypto.runtime.*` API pages from source docstrings. No
   # generated pages are wired into the nav yet -- that lands with the Reference
   # chapter (see issue #2120); the handler is configured here so the contract
@@ -170,6 +171,13 @@ nav:
       - en/user/02-operation_reference.md
       - en/user/00-getting_started.md
       - en/user/03-torch_codegen_debug.md
+      - Distributed:
+          - en/user/distributed/index.md
+          - en/user/distributed/00-model.md
+          - en/user/distributed/01-collectives.md
+          - en/user/distributed/02-primitives.md
+          - en/user/distributed/03-execution.md
+          - en/user/distributed/04-debugging.md
   - Reference:
       - en/reference/index.md
       - PTO ISA:


### PR DESCRIPTION
## Summary

Split out of #2162 (which is being broken into smaller PRs — see that
PR's description). Adds `docs/en/user/distributed/` (+ full `docs/zh/`
mirror) and wires it into `mkdocs.yml` nav.

- **`index.md`** — PyPTO's distributed model in one page: symmetric
  memory + signals, comm domains, and how PyPTO's simplified L2
  (single-chip) / L3 (cross-rank) vocabulary relates to the `simpler`
  runtime's own finer L0–L6 hierarchy.
- **`00-model.md`** — A minimal end-to-end `HelloAllReduce` walkthrough:
  host orchestrator, per-chip orchestration function, InCore kernel,
  window buffers, and the launch model (a distributed program launches
  as plain `python script.py` — PyPTO forks the per-chip workers
  internally).
- **`01-collectives.md`** — Every collective (`allreduce`, `barrier`,
  `broadcast`, `allgather`, `reduce_scatter`, `all_to_all`), the three
  execution paths (InCore hand-rolled, InCore composite, HOST builtin)
  and when to reach for each, supported `ReduceOp`/dtype per operation,
  worked examples.
- **`02-primitives.md`** — Lower-level building blocks: `notify`/`wait`
  handshakes, window buffer allocation, tile-level RMA, one-sided
  `put`/`get` with chunking/pipelining constraints, composing
  primitives into a hand-rolled collective.
- **`03-execution.md`** — `DistributedWorker` lifecycle,
  `DistributedConfig`, dispatch.
- **`04-debugging.md`** — Common failure modes with symptoms and fixes.

**Note:** this chapter cross-references a Performance chapter that is
being split out as a separate PR. Those specific links are omitted
here and will be added back once that PR (and this one) land — see
#2162 for the full picture of how the pieces fit together.

## Verification

- `npx markdownlint-cli2 --config tests/lint/.markdownlint.yaml`
- `python3 tests/lint/check_docs_en_zh_parity.py`
- `python3 tests/lint/check_docs_nav.py`
- `pre-commit run --all-files`
- `mkdocs build --strict` (clean, no broken links)