### PR TITLE
docs(user): add the Performance & Benchmarking chapter

### DIFF
--- a/docs/en/user/performance/00-methodology.md
+++ b/docs/en/user/performance/00-methodology.md
@@ -122,7 +122,12 @@ class MatAdd:
         return pl.store(pl.add(ta, tb), [0, 0], c)
 
     @pl.function(type=pl.FunctionType.Orchestration)
-    def chip_orch(self, a, b, c):
+    def chip_orch(
+        self,
+        a: pl.Tensor[[ROWS, COLS], pl.FP32],
+        b: pl.Tensor[[ROWS, COLS], pl.FP32],
+        c: pl.Out[pl.Tensor[[ROWS, COLS], pl.FP32]],
+    ) -> pl.Tensor[[ROWS, COLS], pl.FP32]:
         return self.add_kernel(a, b, c)
 
 compiled = ir.compile(MatAdd, platform="a2a3sim")

--- a/docs/en/user/performance/00-methodology.md
+++ b/docs/en/user/performance/00-methodology.md
@@ -1,0 +1,162 @@
+# Performance Methodology
+
+The single-node and distributed tracks share the measurement loop below —
+pick the tool for the layer you suspect, then confirm the fix moved the
+number that mattered.
+
+## Decision Tree
+
+```text
+Performance below expectation
+├─ 1. Did the compiler already hint? → report/perf_hints.log (PH001 TileInnermostDimGranularity, ...)
+├─ 2. Which end-to-end segment?     → benchmark span tree (print_mean_tree), host vs device domain
+├─ 3. Inside a single kernel?       → in-core msprof op-simulator, instruction / cycle level
+├─ 4. Resources saturated or wasted? → memory map HTML, scope stats (heap / task_window / tensormap)
+└─ 5. Is scheduling serialized?     → dependency graph (enable_dep_gen), L2 swimlane
+```
+
+## Quick Start
+
+The `pypto-lib` golden harness offers an environment-variable-driven quick
+start (`PYPTO_BENCH=1 python my_kernel.py`) — see `pypto-lib`'s own
+documentation for that harness's env vars and defaults; they are not defined
+in this repository. This repo's own benchmarking contract is the
+programmatic API below.
+
+## Programmatic Benchmark API
+
+```python
+from pypto.runtime import benchmark
+
+compiled = ir.compile(MyProgram)
+stats = benchmark(compiled, args=(x, out), rounds=100, warmup=3)
+
+print(f"median: {stats.device_us_median:.1f} us")
+print(f"min:    {stats.device_us_min:.1f} us")
+print(f"max:    {stats.device_us_max:.1f} us")
+print(f"mean:   {stats.device_us_mean:.1f} us")
+print(f"stdev:  {stats.device_us_stdev:.1f} us")
+```
+
+### API Signature
+
+```python
+benchmark(
+    compiled,              # CompiledProgram (L2) or DistributedCompiledProgram (L3)
+    args,                  # tuple of dispatch arguments
+    *,                     # all remaining args are keyword-only
+    rounds: int = 100,
+    warmup: int = 3,
+    platform: str | None = None,   # target platform (L2 only)
+    device_id: int | None = None,  # NPU device index (L2 only)
+    config: RunConfig | None = None,
+    persistent: bool = False,               # retain CommDomains across dispatches (L3)
+    reset_persistent_windows: bool | None = None,  # zero retained windows before reuse
+) -> BenchmarkStats
+```
+
+### BenchmarkStats Fields
+
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| `device_wall_us` | `list[float]` | Per-round on-NPU device wall (us). L2: one per launch. L3: per-round max across ranks. |
+| `host_wall_us` | `list[float]` | Per-round host wall (us). Includes arg coercion and H2D overhead. |
+| `rounds` | `int` | Number of measured launches (warmup excluded). |
+| `warmup` | `int` | Number of leading launches discarded. |
+| `all_zero_device` | `bool` | `True` when every `device_wall_us` is `0` — typical on `*sim` platforms. |
+
+### Aggregates
+
+| Property | Description |
+| -------- | ----------- |
+| `stats.device_us_median` | Median `device_wall_us` (us). |
+| `stats.device_us_min` | Minimum `device_wall_us` (us). |
+| `stats.device_us_max` | Maximum `device_wall_us` (us). |
+| `stats.device_us_mean` | Arithmetic mean (us). |
+| `stats.device_us_stdev` | Standard deviation (us). |
+
+### Span Tree Rendering
+
+```python
+stats.print_tree()          # render one per-launch span tree to stdout
+stats.print_mean_tree()     # render mean-duration tree annotated with +/-stdev
+```
+
+Expected output for a single-launch L2 kernel:
+
+```text
+launch[0] (pid=1 inv=1 hid=0):
+simpler_run                                   10875.1us
+|- bind                                          29.6us
+|- runner_run                                 10786.3us
+|  `- device_wall [dev]                        9981.6us
+|     |- orch [dev]                               4.0us
+|     |- sched [dev]                            563.4us
+|     `- post_orch [dev]                          0.5us
+`- validate                                       5.5us
+```
+
+The **primary metric** is `device_wall [dev]` — the total on-NPU time.
+
+### Complete Example
+
+```python
+import torch
+import pypto.language as pl
+from pypto import ir
+from pypto.runtime import benchmark
+
+ROWS = COLS = 128
+
+@pl.program
+class MatAdd:
+    @pl.function(type=pl.FunctionType.InCore)
+    def add_kernel(
+        self,
+        a: pl.Tensor[[ROWS, COLS], pl.FP32],
+        b: pl.Tensor[[ROWS, COLS], pl.FP32],
+        c: pl.Out[pl.Tensor[[ROWS, COLS], pl.FP32]],
+    ) -> pl.Tensor[[ROWS, COLS], pl.FP32]:
+        ta = pl.load(a, [0, 0], [ROWS, COLS])
+        tb = pl.load(b, [0, 0], [ROWS, COLS])
+        return pl.store(pl.add(ta, tb), [0, 0], c)
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def chip_orch(self, a, b, c):
+        return self.add_kernel(a, b, c)
+
+compiled = ir.compile(MatAdd, platform="a2a3sim")
+a = torch.full((ROWS, COLS), 2.0)
+b = torch.full((ROWS, COLS), 3.0)
+c = torch.zeros((ROWS, COLS))
+
+stats = benchmark(compiled, args=(a, b, c), rounds=20, warmup=5, platform="a2a3sim")
+
+print(f"median: {stats.device_us_median:.1f} us")
+if stats.all_zero_device:
+    print("[sim] device_wall_us is all-zero — expected on simulator builds")
+```
+
+### Interpreting Variance
+
+- **Prefer median over mean** — median is robust to cold-start outliers
+- **Increase `warmup`** to absorb one-time setup (5-10 typical on hardware)
+- **Check `all_zero_device`** before interpreting results on simulator builds
+
+## Important Caveats
+
+> **`SIMPLER_HOST_STRACE` must be compiled into the runtime.** If the runtime
+> was built without this compile-time macro, `benchmark()` raises `RuntimeError`.
+>
+> **`*sim` platforms report 0 for device wall.** Check `stats.all_zero_device`
+> to detect this — if `True`, all `device_wall_us` samples are 0.
+>
+> **L3 requires shared-memory IO tensors.** Every host `torch.Tensor` passed
+> to `benchmark()` for a distributed program must call `.share_memory_()` before
+> the call.
+
+## See Also
+
+- [01-single-node](01-single-node.md) — Single-node performance techniques
+- [02-distributed](02-distributed.md) — Distributed performance and bus bandwidth
+- [03-cases](03-cases.md) — End-to-end worked examples

--- a/docs/en/user/performance/01-single-node.md
+++ b/docs/en/user/performance/01-single-node.md
@@ -121,9 +121,12 @@ accumulation.
 
 ### `target_memory`
 
-Select the on-chip memory space for a tile allocation (`MemorySpace.DDR`
-for off-chip, or `.Vec` / `.Mat` / `.Left` / `.Right` / `.Acc` for on-chip
-buffers).
+Select the on-chip memory space for a tile (`MemorySpace.DDR` for off-chip,
+or `.Vec` / `.Mat` / `.Left` / `.Right` / `.Acc` for on-chip buffers). Not
+every op accepts every space: `pl.load` (DDR to on-chip) only accepts `.Vec`
+or `.Mat` — it raises `ValueError` for the others. To land data in `.Left` /
+`.Right`, load into `.Vec` / `.Mat` first, then use `pl.move` to relocate it.
+`.Acc` is a matmul-accumulate output space, not a `load`/`move` destination.
 
 - **When:** Data placement optimization
 - **Cost:** On-chip spaces are faster but much smaller than DDR

--- a/docs/en/user/performance/01-single-node.md
+++ b/docs/en/user/performance/01-single-node.md
@@ -1,0 +1,216 @@
+# Single-Node Performance
+
+Every technique below states **when it applies, what it costs, how to
+enable it, and how to verify it took effect**.
+
+## Partitioning and Parallelism
+
+### `pl.split(SplitMode)`
+
+Split cross-core data transfer geometrically within a `CORE_GROUP` region —
+not a standalone call; it's passed into `pl.at(..., optimizations=[...])`.
+
+- **When:** A `CORE_GROUP` region's data needs partitioning across its cores
+- **Cost:** Requires split-compatible operations
+- **How:** `pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.split(pl.SplitMode.UP_DOWN)])` — modes are `NONE`, `UP_DOWN` (height halved), `LEFT_RIGHT` (width halved)
+- **Verify:** Compare against non-split baseline via benchmark
+
+### `pl.split_aiv`
+
+Split computation across AIV (vector) cores specifically.
+
+- **When:** Vector-heavy workloads benefit from AIV parallelism
+- **Cost:** AIV-only — incompatible with AIC units
+- **Verify:** Check that AIV cores are utilized in the memory map
+
+### `pl.spmd(N)`
+
+Single-program-multiple-data parallelism — launch N copies of the same kernel
+with different data shards.
+
+- **When:** Embarrassingly parallel workloads
+- **Cost:** N x memory footprint; workspace serialization for >1
+- **How:** `with pl.spmd(n):` or `for i in pl.spmd(n):`
+- **Verify:** Check benchmark scaling — near-linear speedup expected
+
+### `pl.cluster()`
+
+Group co-scheduled AIC (Cube) and AIV (Vector) kernels sharing physical
+cluster resources.
+
+- **When:** Workloads benefit from concurrent AIC + AIV execution
+- **Cost:** Requires cluster-compatible kernel pairs
+- **Verify:** L2 swimlane shows concurrent AIC/AIV execution
+
+### `pl.at(level=)`
+
+Mark a region of code for execution at a specific point in the hierarchy
+(`pl.Level.AIV`, `.AIC`, `.CORE_GROUP`, `.CHIP_DIE`, `.CHIP`, `.HOST`, ...) —
+this is where the region *executes*, not a memory tier.
+
+- **When:** Coordinating co-scheduled AIC/AIV work, or applying `pl.split`
+- **Cost:** The chosen level determines which `optimizations=` entries apply
+- **Verify:** L2 swimlane shows the region executing at the specified level
+
+## Pipelining and Unrolling
+
+### `pl.pipeline`
+
+Software pipeline a loop body to overlap compute across iterations.
+
+- **When:** Loop bodies with independent iterations
+- **Cost:** Increased register and buffer pressure
+- **How:** Wrap the loop body with `pl.pipeline`
+- **Verify:** Benchmark shows reduced per-iteration latency
+
+### `pl.unroll`
+
+Fully unroll a compile-time-known loop.
+
+- **When:** Small loop trip counts known at compile time
+- **Cost:** Larger binary — code size grows with unroll factor
+- **Verify:** Inspect unrolled code in the compiled artifact
+
+### Cross-Core Software Pipelining
+
+Use `pl.cross_core_slot(slot_num=)` to pipeline data across AICore
+computing units.
+
+- **When:** Ring-buffer or producer-consumer patterns across cores
+- **Cost:** Ring depth determines buffer size
+- **How:** Set `slot_num` to the ring depth
+- **Verify:** Swimlane shows pipelined execution with no idle gaps
+
+## Matmul Path
+
+### AutoTileMatmulL0
+
+The auto-tiling pass selects L0 matmul tile sizes.
+
+- **When:** All matmul operations (enabled by default)
+- **Cost:** Compile-time analysis — no runtime overhead
+- **Verify:** IR dump shows tiled matmul dimensions
+
+### `enable_pypto_l0c_double_buffer`
+
+Enable double-buffering for L0C output buffer.
+
+- **When:** Matmul-bound workloads where output write-back is a bottleneck
+- **Cost:** 2x L0C buffer allocation
+- **How:** `ir.compile(..., enable_pypto_l0c_double_buffer=True)`
+- **Verify:** Benchmark shows reduced sched time in span tree
+
+### `a_trans`/`b_trans`
+
+Transpose matmul operands in-place.
+
+- **When:** Memory layout doesn't match the matmul instruction's expected order
+- **Cost:** Potential additional transpose overhead
+- **Verify:** Benchmark both transposed and non-transposed
+
+### Split-K + Atomic Add
+
+Split the K-dimension of a matmul across multiple units with atomic
+accumulation.
+
+- **When:** Very large K dimensions exceed single-unit capacity
+- **Cost:** Atomic add introduces non-determinism (order of accumulation varies)
+- **Verify:** Accuracy check against golden; benchmark for throughput
+
+## Memory
+
+### `target_memory`
+
+Select the on-chip memory space for a tile allocation (`MemorySpace.DDR`
+for off-chip, or `.Vec` / `.Mat` / `.Left` / `.Right` / `.Acc` for on-chip
+buffers).
+
+- **When:** Data placement optimization
+- **Cost:** On-chip spaces are faster but much smaller than DDR
+- **How:** `pl.load(a, [0, 0], [rows, cols], target_memory=pl.MemorySpace.Vec)`
+- **Verify:** Memory map confirms allocation at the specified space
+
+### MemoryReuse vs `memory_planner=PTOAS`
+
+Memory planning strategies for allocating buffers.
+
+- **When:** MemoryReuse (default) — reuse buffers when live ranges don't overlap
+- **When:** `memory_planner=PTOAS` — delegate to the PTOAS memory planner
+- **Cost:** PTOAS planner is more aggressive but may increase compile time
+- **Verify:** Memory map shows buffer allocation and reuse
+
+### Persistent L3
+
+Keep L3 buffers resident across dispatches.
+
+- **When:** Multi-dispatch workloads with large working sets
+- **Cost:** Reduced L3 availability for other uses
+- **Verify:** Scope stats show persistent allocation
+
+## Scheduling
+
+### `predicate=`
+
+Skip tasks dynamically at the dispatch point.
+
+- **When:** Conditional execution paths
+- **Cost:** Negligible — predicate check at dispatch
+- **Verify:** Dependency graph shows skipped edges
+
+### `no_dep`
+
+Drop automatic dependency inference for a call site.
+
+- **When:** Two ops appear to overlap but are actually independent
+- **Cost:** Incorrect use causes race conditions
+- **Verify:** Dependency graph confirms no edge between the ops
+
+### `allow_early_resolve`
+
+Allow the scheduler to resolve a task early.
+
+- **When:** Output is produced before the task's full completion
+- **Cost:** Weaker ordering guarantees
+- **Verify:** Swimlane trace confirms early resolution
+
+### `manual_scope`
+
+Turn off automatic dependency tracking for a region.
+
+- **When:** Manual control over every dependency edge
+- **How:** `with pl.scope(mode=pl.ScopeMode.MANUAL):` or `with pl.manual_scope():`
+- **Cost:** All edges must be declared explicitly via `deps=`
+- **Verify:** Dependency graph matches the declared edges exactly
+
+### `task_dummy`
+
+Insert a no-op task as a fan-in point.
+
+- **When:** Multiple producers feed a single consumer with no data dependency
+- **How:** `barrier = pl.system.task_dummy(deps=[task_a, task_b])` — `deps` is required and keyword-only
+- **Verify:** Dependency graph shows the dummy task as a convergence node
+
+### Ring Sizing
+
+Tune ring-task window and heap sizes for the L2 scheduler.
+
+- **When:** Task-heavy workloads benefit from larger ring buffers
+- **How:** `RunConfig(ring_task_window=N, ring_heap=M)`
+- **Verify:** Scope stats show ring buffer utilization
+
+## Data Residency
+
+### `DeviceTensor`
+
+Keep tensors resident on the device across dispatches.
+
+- **When:** Weights, lookup tables, or other reusable data
+- **Cost:** Reduced device memory for other allocations
+- **How:** `rt.alloc_tensor(shape, dtype, init=host_data)`
+- **Verify:** H2D/D2H spans absent from second dispatch onward
+
+## See Also
+
+- [00-methodology](00-methodology.md) — Measurement loop and tools
+- [02-distributed](02-distributed.md) — Distributed performance techniques
+- [03-cases](03-cases.md) — End-to-end worked examples

--- a/docs/en/user/performance/02-distributed.md
+++ b/docs/en/user/performance/02-distributed.md
@@ -1,0 +1,187 @@
+# Distributed Performance
+
+Distributed (L3) programs add cross-rank concerns — bus bandwidth, collective
+choice, start skew — on top of everything in single-node performance.
+
+## L3 Distributed Benchmarking
+
+Distributed programs (`DistributedCompiledProgram`) use the same `benchmark()`
+API but have important differences in timing and preparation.
+
+### Preparation
+
+```python
+import torch
+from pypto.runtime import benchmark
+
+# Shared-memory host tensors — MUST call .share_memory_() before benchmark().
+host_x = torch.zeros((4, 1, 256), dtype=torch.float32).share_memory_()
+host_out = torch.zeros_like(host_x).share_memory_()
+
+stats = benchmark(compiled, (host_x, host_out), rounds=100, warmup=3)
+```
+
+### L3 Metrics
+
+| Metric | `per_round("...")` key | Description |
+| ------ | ---------------------- | ----------- |
+| device | `"device"` | Per-round max across ranks of each rank's summed dispatch device walls (us). |
+| host | `"host"` | Per-round max across ranks of host wall (us). |
+| effective | `"effective"` | Per-round max effective window (orch/sched union, us). |
+| union | `"union"` | Cross-rank host-timeline union: `max(host-end) - min(host-start)` across all ranks' dispatches (us). Captures overlap and start skew. L3 only. |
+
+```python
+# Per-rank breakdown (L3 only).
+ranks = stats.per_rank("device")  # {pid: [round0_us, round1_us, ...]}
+
+# Per-round aggregation.
+device = stats.per_round("device")    # list[float], length = rounds
+union  = stats.per_round("union")     # list[float], L3 only
+```
+
+### DFX Flag Availability
+
+`RunConfig(enable_l2_swimlane=True)` enables per-task timing inside the worker
+and propagates through L3 orchestration — swimlane traces appear in span-tree
+output even for distributed jobs.
+
+## Understanding Bus Bandwidth
+
+Bus bandwidth (`busbw`) is the standard metric for evaluating collective
+communication performance, adopted from the nccl-tests benchmark suite.
+It corrects for the fact that algorithms like AllReduce transfer different
+amounts of data across the interconnect than the algorithmic data size.
+
+### Formulas
+
+```text
+algbw = data_size / time              (algorithmic bandwidth)
+busbw = algbw x correction_factor     (interconnect-corrected bandwidth)
+```
+
+### Correction Factors
+
+| Operation | Correction Factor | Notes |
+| --------- | ----------------- | ----- |
+| AllReduce | `2(n-1)/n` | Two-way traffic (reduce + broadcast) scaled by rank count. Approaches 2 for large n. |
+| AllGather | `(n-1)/n` | Each rank receives n-1 chunks. |
+| ReduceScatter | `(n-1)/n` | Each rank sends n-1 chunks. |
+| All-to-All | `(n-1)/n` | Personalized exchange — same factor as AllGather/ReduceScatter. |
+| Broadcast | `1` | Root sends to n-1 ranks, but the link carries data once. |
+| Reduce | `1` | n-1 ranks send to root. |
+| Point-to-Point | `1` | Single-link transfer. |
+
+### Worked Example
+
+Hypothetical numbers to illustrate the formula (per v6 §8.1 item 5, real
+measured figures are backfilled once data accumulates) — 8 ranks, 1 GB
+AllReduce completing in 100 ms:
+
+```text
+algbw = 1 GB / 0.100 s = 10 GB/s
+busbw = 10 x 2(8-1)/8 = 10 x 14/8 = 17.5 GB/s
+```
+
+If your interconnect has a theoretical ceiling of 25 GB/s, then 17.5 GB/s is
+**70% utilization** — good for an initial implementation. 90%+ means you're
+near the hardware bandwidth ceiling.
+
+## Collective Algorithm Choice
+
+### Mesh vs Ring Trade-off
+
+| Aspect | Mesh | Ring |
+| ------ | ---- | ---- |
+| Remote traffic per step | O(N) | O(N/P) |
+| Barrier rounds | 1 | 2(P-1) |
+| Signal shape | `[NR, 1]` | `[2(NR-1), NR]` |
+| NR support | `pl.dynamic("NR")` | Compile-time static only |
+| Best for | Small messages | Large messages (>16 KiB) |
+
+**Rule of thumb:** Use mesh for small messages and low latency; switch to
+ring when bandwidth plateaus.
+
+### Overlapping Communication with Compute
+
+PyPTO's signal model allows overlapping communication and computation
+through pipelined notify/wait patterns:
+
+- Use non-blocking `notify` early in a loop iteration
+- Schedule compute work between `notify` and `wait`
+- The `wait` blocks only when the result is needed
+
+### Cross-Rank Start Skew
+
+The `union` metric captures cross-rank start skew — the difference between
+the earliest rank's dispatch start and the latest rank's dispatch end.
+High `union` relative to `device` indicates poor rank synchronisation.
+
+## Resident Shards
+
+Use `alloc_stacked_tensor` to keep model weights resident on each device:
+
+```python
+host_weights = torch.randn(4, 1024, 4096).share_memory_()
+with compiled.prepare() as rt:
+    stacked = rt.alloc_stacked_tensor(host_weights)
+    rt(x, stacked, out)
+    # Weights stay resident — no H2D on subsequent dispatches.
+```
+
+## Ring Sizing and Prewarm
+
+Tune ring-task window and heap sizes via `RunConfig`, passed to both
+`prepare()` and every dispatch call:
+
+```python
+from pypto.runtime import RunConfig
+
+compiled = ir.compile(MyRingProgram, platform="a2a3", distributed_config=dc)
+ring_config = RunConfig(ring_task_window=256, ring_heap=1024)
+worker = compiled.prepare(config=ring_config)
+worker(host_x, host_out, config=ring_config)  # same config on every dispatch
+```
+
+`prepare(config=...)` only prewarms the runtime-arena cache with that sizing
+so the **first** dispatch skips the ~800ms cold build — the config is not
+stored on the worker. Every dispatch must pass its own `config=` with the
+same `ring_task_window` / `ring_heap`, or the arena rebuilds (the cache is
+single-slot, so alternating sizings rebuilds on every switch).
+
+`ring_task_window` must be a power of 2 `>= 4` (or a 4-element list/tuple
+sizing rings 0..3 independently); `ring_heap` (in bytes) must be a power of
+2 `>= 1024`.
+
+## Sharing One Worker Across Programs
+
+A single `DistributedWorker` can dispatch multiple compiled programs,
+reusing its chip processes and comm setup:
+
+```python
+with compiled_a.prepare(extra_compiled=[compiled_b]) as rt:
+    rt.run(compiled_a, host_x, host_out)      # dispatch ProgramA
+    rt.run(compiled_b, host_x, host_out)      # dispatch ProgramB
+```
+
+Preparing more than one program puts the worker in multi-program mode, where
+the `rt(*args)` shortcut is ambiguous and raises `TypeError` — dispatch every
+program explicitly through `rt.run(...)`, including the primary one.
+
+## Important Caveats
+
+> **`*sim` platforms report 0 for device wall.** Simulator builds emit host
+> `[STRACE]` markers but not device-domain spans. Check
+> `stats.all_zero_device` to detect this.
+>
+> **L3 requires shared-memory IO tensors.** Every host `torch.Tensor` passed
+> to `benchmark()` for a distributed program must call `.share_memory_()` before
+> the call. Forgetting this causes a `TypeError` at dispatch time.
+>
+> **DFX flags are plumbed through L3.** `RunConfig(enable_l2_swimlane=True)`
+> enables per-task timing and swimlane traces propagate through L3 orchestration.
+
+## See Also
+
+- [00-methodology](00-methodology.md) — Measurement loop and tools
+- [01-single-node](01-single-node.md) — Single-node performance techniques
+- [03-cases](03-cases.md) — End-to-end worked examples

--- a/docs/en/user/performance/03-cases.md
+++ b/docs/en/user/performance/03-cases.md
@@ -1,0 +1,27 @@
+# Performance Cases
+
+Each case below follows the same pattern: **baseline → investigation →
+change → effect → verification**.
+
+> **Status:** Performance cases are planned but not yet written. Real measured
+> data across representative workloads has not yet been accumulated. The user
+> manual plan ([USER_MANUAL_PLAN_EN §8.1 item 5](https://github.com/hw-native-sys/pypto/issues/2120))
+> targets this page for methodology and relative trends in the first version,
+> with measured values backfilled once data accumulates.
+>
+> The single-node performance techniques in [01-single-node](01-single-node.md)
+> and distributed performance guidance in [02-distributed](02-distributed.md)
+> are available today.
+>
+> Planned cases:
+>
+> - **Single-node:** Tile dimension granularity, auto-tiling diagnostics, false
+>   task dependencies, ring-sizing arena rebuilds.
+> - **Distributed:** Mesh-to-ring collectives transition, resident shards vs
+>   H2D per-dispatch.
+
+## See Also
+
+- [00-methodology](00-methodology.md) — Measurement loop and tools
+- [01-single-node](01-single-node.md) — Single-node performance techniques
+- [02-distributed](02-distributed.md) — Distributed performance and bus bandwidth

--- a/docs/en/user/performance/index.md
+++ b/docs/en/user/performance/index.md
@@ -1,0 +1,31 @@
+# Performance
+
+PyPTO's performance work follows a **measure → locate → optimize → verify**
+loop, split into two tracks:
+
+| Track | Scope | Page |
+| ----- | ----- | ---- |
+| Shared methodology | Tools and measurement loop (both tracks) | [00-methodology](00-methodology.md) |
+| Single-node | Kernel, tile, pipelining, matmul, memory, scheduling | [01-single-node](01-single-node.md) |
+| Distributed | Collective cost, ring vs mesh, cross-rank skew, bus bandwidth | [02-distributed](02-distributed.md) |
+| Cases | End-to-end worked examples | [03-cases](03-cases.md) |
+
+> **Prerequisites:** distributed programming background for the distributed
+> track; [Getting Started](../00-getting_started.md) for a kernel-authoring
+> baseline.
+
+## Tool Matrix
+
+| Tool | Observes | Entry point |
+| ---- | -------- | ----------- |
+| Compile-time perf hints | Code patterns | `report/perf_hints.log` |
+| Benchmark span tree | End-to-end segmentation | `pypto.runtime.benchmark` → `stats.print_mean_tree(spread=...)` |
+| In-core msprof | Per-kernel cycles | op-simulator + Insight traces |
+| Memory map | On-chip buffers | `pypto.tools.memory_map` → HTML |
+| Scope stats | Runtime watermarks | `RunConfig(enable_scope_stats=True)` |
+| L2 swimlane / PMU / dep gen | Task scheduling | `RunConfig(enable_l2_swimlane / enable_pmu / enable_dep_gen)` |
+
+## See Also
+
+- [Getting Started](../00-getting_started.md) — `ir.compile()` and `RunConfig`
+- [Simpler Runtime](https://hw-native-sys.github.io/simpler/) — Scheduler internals

--- a/docs/zh/user/performance/00-methodology.md
+++ b/docs/zh/user/performance/00-methodology.md
@@ -89,13 +89,23 @@ ROWS = COLS = 128
 @pl.program
 class MatAdd:
     @pl.function(type=pl.FunctionType.InCore)
-    def add_kernel(self, a, b, c):
+    def add_kernel(
+        self,
+        a: pl.Tensor[[ROWS, COLS], pl.FP32],
+        b: pl.Tensor[[ROWS, COLS], pl.FP32],
+        c: pl.Out[pl.Tensor[[ROWS, COLS], pl.FP32]],
+    ) -> pl.Tensor[[ROWS, COLS], pl.FP32]:
         ta = pl.load(a, [0, 0], [ROWS, COLS])
         tb = pl.load(b, [0, 0], [ROWS, COLS])
         return pl.store(pl.add(ta, tb), [0, 0], c)
 
     @pl.function(type=pl.FunctionType.Orchestration)
-    def chip_orch(self, a, b, c):
+    def chip_orch(
+        self,
+        a: pl.Tensor[[ROWS, COLS], pl.FP32],
+        b: pl.Tensor[[ROWS, COLS], pl.FP32],
+        c: pl.Out[pl.Tensor[[ROWS, COLS], pl.FP32]],
+    ) -> pl.Tensor[[ROWS, COLS], pl.FP32]:
         return self.add_kernel(a, b, c)
 
 compiled = ir.compile(MatAdd, platform="a2a3sim")

--- a/docs/zh/user/performance/00-methodology.md
+++ b/docs/zh/user/performance/00-methodology.md
@@ -1,0 +1,120 @@
+# 性能方法论
+
+单节点和分布式两条轨道共享下面的测量循环——先选择怀疑瓶颈所在层级对应的
+工具，再确认改动确实改变了那个关键数字。
+
+## 决策树
+
+```text
+性能低于预期
+├─ 1. 编译器是否已提示？ → report/perf_hints.log
+├─ 2. 哪个端到端分段？   → benchmark span tree
+├─ 3. 单个 kernel 内部？  → in-core msprof op-simulator
+├─ 4. 资源饱和或浪费？   → memory map HTML, scope stats
+└─ 5. 调度被序列化？     → dependency graph, L2 swimlane
+```
+
+## 快速开始
+
+`pypto-lib` golden 框架提供一个环境变量驱动的快速开始方式
+（`PYPTO_BENCH=1 python my_kernel.py`）——该框架的环境变量和默认值
+见 `pypto-lib` 自己的文档，本仓库中未定义它们。本仓库自身的基准测试
+契约是下面的程序化 API。
+
+## 程序化 Benchmark API
+
+```python
+from pypto.runtime import benchmark
+
+compiled = ir.compile(MyProgram)
+stats = benchmark(compiled, args=(x, out), rounds=100, warmup=3)
+
+print(f"median: {stats.device_us_median:.1f} us")
+```
+
+### API 签名
+
+```python
+benchmark(
+    compiled,              # CompiledProgram 或 DistributedCompiledProgram
+    args,
+    *,
+    rounds: int = 100,
+    warmup: int = 3,
+    platform: str | None = None,   # 仅 L2
+    device_id: int | None = None,  # 仅 L2
+    config: RunConfig | None = None,
+    persistent: bool = False,               # 跨分发保留 CommDomain（L3）
+    reset_persistent_windows: bool | None = None,  # 复用前是否清零保留的 window
+) -> BenchmarkStats
+```
+
+### BenchmarkStats 字段
+
+| 字段 | 类型 | 描述 |
+| ---- | ---- | ---- |
+| `device_wall_us` | `list[float]` | 每轮 NPU 端设备墙钟（µs）。 |
+| `host_wall_us` | `list[float]` | 每轮 host 端墙钟（µs）。 |
+| `rounds` | `int` | 测量轮次（不含预热）。 |
+| `warmup` | `int` | 舍弃的前置轮次。 |
+| `all_zero_device` | `bool` | 所有采样为 0 时为 True。 |
+
+### 聚合值
+
+| 属性 | 描述 |
+| ---- | ---- |
+| `stats.device_us_median` | 中位数（µs）。 |
+| `stats.device_us_min` | 最小值（µs）。 |
+| `stats.device_us_max` | 最大值（µs）。 |
+| `stats.device_us_mean` | 算术平均（µs）。 |
+| `stats.device_us_stdev` | 标准差（µs）。 |
+
+### Span Tree 渲染
+
+```python
+stats.print_tree()
+stats.print_mean_tree()
+```
+
+### 完整示例
+
+```python
+import torch
+import pypto.language as pl
+from pypto import ir
+from pypto.runtime import benchmark
+
+ROWS = COLS = 128
+
+@pl.program
+class MatAdd:
+    @pl.function(type=pl.FunctionType.InCore)
+    def add_kernel(self, a, b, c):
+        ta = pl.load(a, [0, 0], [ROWS, COLS])
+        tb = pl.load(b, [0, 0], [ROWS, COLS])
+        return pl.store(pl.add(ta, tb), [0, 0], c)
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def chip_orch(self, a, b, c):
+        return self.add_kernel(a, b, c)
+
+compiled = ir.compile(MatAdd, platform="a2a3sim")
+a = torch.full((ROWS, COLS), 2.0)
+b = torch.full((ROWS, COLS), 3.0)
+c = torch.zeros((ROWS, COLS))
+
+stats = benchmark(compiled, args=(a, b, c), rounds=20, warmup=5, platform="a2a3sim")
+print(f"median: {stats.device_us_median:.1f} us")
+```
+
+## 重要注意事项
+
+> **`SIMPLER_HOST_STRACE` 必须编译到运行时中。**
+> **`*sim` 平台设备墙钟为 0。**
+> **L3 需要共享内存 IO tensor。**
+
+## 相关链接
+
+- [01-single-node](01-single-node.md) — 单节点性能技术
+- [02-distributed](02-distributed.md) — 分布式性能和总线带宽
+- [03-cases](03-cases.md) — 端到端工作示例

--- a/docs/zh/user/performance/01-single-node.md
+++ b/docs/zh/user/performance/01-single-node.md
@@ -81,8 +81,12 @@ SPMD 并行——启动 N 个相同 kernel 副本。
 
 ### `target_memory`
 
-为 tile 分配选择片上内存空间（`MemorySpace.DDR` 为片外；`.Vec`/`.Mat`/
-`.Left`/`.Right`/`.Acc` 为片上 buffer）。
+为 tile 选择片上内存空间（`MemorySpace.DDR` 为片外；`.Vec`/`.Mat`/
+`.Left`/`.Right`/`.Acc` 为片上 buffer）。并非每个 op 都接受所有空间：
+`pl.load`（DDR 到片上）只接受 `.Vec` 或 `.Mat`——其余值会抛出
+`ValueError`。要把数据放到 `.Left`/`.Right`，需先 load 到 `.Vec`/`.Mat`，
+再用 `pl.move` 搬运。`.Acc` 是 matmul 累加的输出空间，不是
+`load`/`move` 的目标。
 
 - **适用场景：** 数据放置优化
 - **成本：** 片上空间更快但远小于 DDR

--- a/docs/zh/user/performance/01-single-node.md
+++ b/docs/zh/user/performance/01-single-node.md
@@ -1,0 +1,141 @@
+# 单节点性能
+
+下面每项技术都说明**适用场景、成本、启用方式和验证方式**。
+
+## 分区与并行
+
+### `pl.split(SplitMode)`
+
+在 `CORE_GROUP` 区域内对跨核数据传输做几何切分——并非独立调用，而是
+传入 `pl.at(..., optimizations=[...])`。
+
+- **适用场景：** `CORE_GROUP` 区域的数据需要在其核心间切分
+- **成本：** 需要 split 兼容操作
+- **启用方式：** `pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.split(pl.SplitMode.UP_DOWN)])`——可选模式为 `NONE`、`UP_DOWN`（高度对半分）、`LEFT_RIGHT`（宽度对半分）
+- **验证方式：** 与非 split 基线 benchmark 对比
+
+### `pl.split_aiv`
+
+将计算分配到 AIV 核心。
+
+- **适用场景：** 向量密集型工作负载
+- **成本：** 仅 AIV
+- **验证方式：** 内存映射中确认 AIV 核心被使用
+
+### `pl.spmd(N)`
+
+SPMD 并行——启动 N 个相同 kernel 副本。
+
+- **适用场景：** 天然可并行的工作负载
+- **成本：** N 倍内存占用
+- **启用方式：** `with pl.spmd(n):` 或 `for i in pl.spmd(n):`
+- **验证方式：** Benchmark 显示近线性加速
+
+### `pl.cluster()`
+
+协同调度 AIC + AIV 共享物理集群资源。
+
+- **适用场景：** 受益于并发 AIC + AIV 执行
+- **成本：** 需要集群兼容的 kernel 对
+- **验证方式：** L2 swimlane 显示并发 AIC/AIV 执行
+
+## 流水线与展开
+
+### `pl.pipeline`
+
+跨迭代重叠计算的软件流水线。
+
+- **适用场景：** 迭代独立的循环体
+- **成本：** 增加寄存器和 buffer 压力
+- **启用方式：** 用 `pl.pipeline` 包裹循环体
+- **验证方式：** Benchmark 显示减少的每迭代延迟
+
+### `pl.unroll`
+
+完全展开编译时已知的循环。
+
+- **适用场景：** 编译时已知的小循环次数
+- **成本：** 更大的二进制文件
+- **验证方式：** 检查编译产物中的展开代码
+
+## Matmul 路径
+
+### AutoTileMatmulL0
+
+自动 tiling pass 选择 L0 matmul tile 大小。
+
+- **启用方式：** 默认开启
+- **成本：** 仅有编译时分析开销
+- **验证方式：** IR dump 显示 tiled matmul 维度
+
+### `enable_pypto_l0c_double_buffer`
+
+为 L0C 输出 buffer 启用双缓冲。
+
+- **适用场景：** Matmul 密集型工作负载
+- **成本：** 2x L0C buffer 分配
+- **启用方式：** `ir.compile(..., enable_pypto_l0c_double_buffer=True)`
+- **验证方式：** Benchmark 显示 sched 时间减少
+
+## 内存
+
+### `target_memory`
+
+为 tile 分配选择片上内存空间（`MemorySpace.DDR` 为片外；`.Vec`/`.Mat`/
+`.Left`/`.Right`/`.Acc` 为片上 buffer）。
+
+- **适用场景：** 数据放置优化
+- **成本：** 片上空间更快但远小于 DDR
+- **启用方式：** `pl.load(a, [0, 0], [rows, cols], target_memory=pl.MemorySpace.Vec)`
+- **验证方式：** 内存映射确认分配到指定空间
+
+### MemoryReuse vs `memory_planner=PTOAS`
+
+内存规划策略。
+
+- **MemoryReuse：** 默认——不重叠的生命周期重用 buffer
+- **PTOAS：** 更积极的规划，可能导致编译时间增加
+- **验证方式：** 内存映射显示分配和重用
+
+## 调度
+
+### `predicate=`
+
+在分发点动态跳过任务。
+
+- **适用场景：** 条件执行
+- **成本：** 可忽略
+- **验证方式：** 依赖图显示跳过的边
+
+### `no_dep`
+
+对调用点放弃自动依赖推断。
+
+- **适用场景：** 表面重叠但实际独立的操作
+- **成本：** 错误使用导致竞态条件
+- **验证方式：** 依赖图确认操作间无边
+
+### `manual_scope`
+
+关闭自动依赖跟踪。
+
+- **启用方式：** `with pl.scope(mode=pl.ScopeMode.MANUAL):`
+- **成本：** 必须显式声明所有边
+- **验证方式：** 依赖图精确匹配声明的边
+
+## 数据驻留
+
+### `DeviceTensor`
+
+在分发之间保持 tensor 驻留在设备上。
+
+- **适用场景：** 权重、查找表等可重用数据
+- **成本：** 减少设备内存
+- **启用方式：** `rt.alloc_tensor(shape, dtype, init=host_data)`
+- **验证方式：** 第二次分发起不存在 H2D/D2H span
+
+## 相关链接
+
+- [00-methodology](00-methodology.md) — 测量循环和工具
+- [02-distributed](02-distributed.md) — 分布式性能技术
+- [03-cases](03-cases.md) — 端到端工作示例

--- a/docs/zh/user/performance/02-distributed.md
+++ b/docs/zh/user/performance/02-distributed.md
@@ -1,0 +1,139 @@
+# 分布式性能
+
+分布式（L3）程序在单节点性能的基础上，还要处理跨 rank 的问题——总线带宽、
+集合通信选择、启动偏差。
+
+## L3 分布式基准测试
+
+分布式程序使用相同的 `benchmark()` API，但在计时和准备方面有重要差异。
+
+### 准备
+
+```python
+import torch
+from pypto.runtime import benchmark
+
+host_x = torch.zeros((4, 1, 256), dtype=torch.float32).share_memory_()
+host_out = torch.zeros_like(host_x).share_memory_()
+
+stats = benchmark(compiled, (host_x, host_out), rounds=100, warmup=3)
+```
+
+### L3 指标
+
+| 指标 | `per_round("...")` 键 | 描述 |
+| ---- | --------------------- | ---- |
+| device | `"device"` | 每轮跨 rank 最大设备墙钟（µs）。 |
+| host | `"host"` | 每轮跨 rank 最大 host 墙钟（µs）。 |
+| union | `"union"` | 跨 rank host 时间线并集（µs）。捕获重叠和启动偏差。 |
+
+```python
+ranks = stats.per_rank("device")  # {pid: [round0_us, ...]}
+device = stats.per_round("device")
+union  = stats.per_round("union")
+```
+
+## 理解总线带宽
+
+总线带宽（`busbw`）是评估集合通信性能的标准指标，源自 nccl-tests 基准测试套件。
+
+### 公式
+
+```text
+algbw = data_size / time
+busbw = algbw x correction_factor
+```
+
+### 修正因子
+
+| 操作 | 修正因子 | 说明 |
+| ---- | -------- | ---- |
+| AllReduce | `2(n-1)/n` | 双向流量（reduce + broadcast），大 n 时趋近 2。 |
+| AllGather | `(n-1)/n` | 每个 rank 接收 n-1 个 chunk。 |
+| ReduceScatter | `(n-1)/n` | 每个 rank 发送 n-1 个 chunk。 |
+| All-to-All | `(n-1)/n` | 个性化交换。 |
+| Broadcast | `1` | Root 发送给 n-1 个 rank。 |
+
+### 计算示例
+
+用于说明公式的假设数值（依据 v6 §8.1 第 5 项，真实测量数据会在积累后回填）——
+8 个 rank，1 GB AllReduce 在 100 ms 内完成：
+
+```text
+algbw = 1 GB / 0.100 s = 10 GB/s
+busbw = 10 x 2(8-1)/8 = 17.5 GB/s
+```
+
+## 集合通信算法选择
+
+### Mesh vs Ring 权衡
+
+| 方面 | Mesh | Ring |
+| ---- | ---- | ---- |
+| 每步远程流量 | O(N) | O(N/P) |
+| 屏障轮次 | 1 | 2(P-1) |
+| NR 支持 | `pl.dynamic("NR")` | 编译时静态 |
+| 最适合 | 小消息 | 大消息（>16 KiB） |
+
+### 通信与计算重叠
+
+PyPTO 的信号模型通过流水线化的 notify/wait 模式支持通信与计算重叠。
+
+### 跨 Rank 启动偏差
+
+`union` 指标捕获跨 rank 启动偏差。高 `union` 相对 `device` 表示 rank 同步不佳。
+
+## 驻留分片
+
+```python
+host_weights = torch.randn(4, 1024, 4096).share_memory_()
+with compiled.prepare() as rt:
+    stacked = rt.alloc_stacked_tensor(host_weights)
+    rt(x, stacked, out)
+```
+
+## Ring 大小与预热
+
+通过 `RunConfig` 调整 ring-task window 和 heap 大小，需要同时传给
+`prepare()` 和每次派发调用：
+
+```python
+from pypto.runtime import RunConfig
+
+compiled = ir.compile(MyRingProgram, platform="a2a3", distributed_config=dc)
+ring_config = RunConfig(ring_task_window=256, ring_heap=1024)
+worker = compiled.prepare(config=ring_config)
+worker(host_x, host_out, config=ring_config)  # 每次派发都传相同的 config
+```
+
+`prepare(config=...)` 仅用该配置预热运行时 arena 缓存，使**第一次**派发
+跳过约 800ms 的冷启动构建——该配置不会存储在 worker 上。每次派发都必须
+携带自己的 `config=`（使用相同的 `ring_task_window` / `ring_heap`），否则
+arena 会重建（缓存是单槽位的，交替使用不同大小会导致每次切换都重建）。
+
+`ring_task_window` 必须是 `>= 4` 的 2 的幂（或长度为 4 的 list/tuple，分别
+设置 ring 0..3）；`ring_heap`（以字节为单位）必须是 `>= 1024` 的 2 的幂。
+
+## 共享 Worker
+
+```python
+with compiled_a.prepare(extra_compiled=[compiled_b]) as rt:
+    rt.run(compiled_a, host_x, host_out)
+    rt.run(compiled_b, host_x, host_out)
+```
+
+准备多个程序会让 worker 进入多程序模式，此时 `rt(*args)` 快捷方式含义
+不明确会抛出 `TypeError`——包括主程序在内的每个程序都必须显式通过
+`rt.run(...)` 派发。
+
+## 重要注意事项
+
+> **`*sim` 平台设备墙钟为 0。**
+> **L3 需要共享内存 IO tensor。**
+> **DFX 标志通过 L3 管道传递。**
+
+## 相关链接
+
+- [00-methodology](00-methodology.md) — 测量循环和工具
+- [01-single-node](01-single-node.md) — 单节点性能技术
+- [03-cases](03-cases.md) — 端到端工作示例

--- a/docs/zh/user/performance/03-cases.md
+++ b/docs/zh/user/performance/03-cases.md
@@ -1,0 +1,22 @@
+# 性能案例
+
+下面每个案例都遵循相同的模式：**基线 → 调查 → 变更 → 效果 → 验证**。
+
+> **状态：** 性能案例已规划但尚未编写。代表性工作负载的真实测量数据尚
+> 未积累。用户手册计划 ([USER_MANUAL_PLAN_EN §8.1 item 5](https://github.com/hw-native-sys/pypto/issues/2120))
+> 目标是在第一版中提供方法论和相对趋势，待数据积累后回填测量值。
+>
+> 单节点性能技术（[01-single-node](01-single-node.md)）和分布式性能指南
+> （[02-distributed](02-distributed.md)）现已可用。
+>
+> 计划案例：
+>
+> - **单节点：** Tile 维度粒度、自动 Tiling 诊断、假任务依赖、Ring sizing
+>   竞技场重建。
+> - **分布式：** Mesh-to-ring 集合通信转换、驻留分片 vs 每分发 H2D。
+
+## 相关链接
+
+- [00-methodology](00-methodology.md) — 测量循环和工具
+- [01-single-node](01-single-node.md) — 单节点性能技术
+- [02-distributed](02-distributed.md) — 分布式性能和总线带宽

--- a/docs/zh/user/performance/index.md
+++ b/docs/zh/user/performance/index.md
@@ -1,0 +1,29 @@
+# 性能
+
+PyPTO 的性能工作遵循 **测量 → 定位 → 优化 → 验证** 循环，分为两个轨道：
+
+| 轨道 | 范围 | 页面 |
+| ---- | ---- | ---- |
+| 共享方法论 | 工具和测量循环（两个轨道通用） | [00-methodology](00-methodology.md) |
+| 单节点 | Kernel、tile、流水线、matmul、内存、调度 | [01-single-node](01-single-node.md) |
+| 分布式 | 集合通信成本、ring vs mesh、跨 rank 偏差、总线带宽 | [02-distributed](02-distributed.md) |
+| 案例 | 端到端工作示例 | [03-cases](03-cases.md) |
+
+> **前置知识：** 分布式轨道需要分布式编程基础；
+> kernel 编写基础见[入门指南](../00-getting_started.md)。
+
+## 工具矩阵
+
+| 工具 | 观测对象 | 入口点 |
+| ---- | -------- | ------ |
+| 编译时性能提示 | 代码模式 | `report/perf_hints.log` |
+| 基准测试 span tree | 端到端分段 | `pypto.runtime.benchmark` → `stats.print_mean_tree(spread=...)` |
+| In-core msprof | 每个 kernel 的周期数 | op-simulator + Insight traces |
+| 内存映射 | 片上缓冲区 | `pypto.tools.memory_map` → HTML |
+| Scope 统计 | 运行时水位 | `RunConfig(enable_scope_stats=True)` |
+| L2 swimlane / PMU / dep gen | 任务调度 | `RunConfig(enable_l2_swimlane / enable_pmu / enable_dep_gen)` |
+
+## 相关链接
+
+- [入门指南](../00-getting_started.md) — `ir.compile()` 和 `RunConfig`
+- [Simpler 运行时](https://hw-native-sys.github.io/simpler/) — 调度器内部机制

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -109,6 +109,7 @@ plugins:
             Code Generation: 代码生成
             Backend: 后端
             Debug: 调试
+            Performance: 性能
   # Renders `pl.*` / `pypto.runtime.*` API pages from source docstrings. No
   # generated pages are wired into the nav yet -- that lands with the Reference
   # chapter (see issue #2120); the handler is configured here so the contract
@@ -170,6 +171,12 @@ nav:
       - en/user/02-operation_reference.md
       - en/user/00-getting_started.md
       - en/user/03-torch_codegen_debug.md
+      - Performance:
+          - en/user/performance/index.md
+          - en/user/performance/00-methodology.md
+          - en/user/performance/01-single-node.md
+          - en/user/performance/02-distributed.md
+          - en/user/performance/03-cases.md
   - Reference:
       - en/reference/index.md
       - PTO ISA:


### PR DESCRIPTION
## Summary

Split out of #2162 (which is being broken into smaller PRs — see that
PR's description). Adds `docs/en/user/performance/` (+ full `docs/zh/`
mirror) and wires it into `mkdocs.yml` nav.

- **`index.md` / `00-methodology.md`** — A decision tree for where to
  look first (compiler hints, span tree, op-simulator, memory map,
  dependency graph) and the programmatic `benchmark()` API: signature,
  `BenchmarkStats` fields, aggregates, span-tree rendering.
- **`01-single-node.md`** — Single-node tuning: partitioning/
  parallelism, pipelining/unrolling, the matmul path, memory placement
  (`target_memory`, `MemorySpace`), scheduling controls.
- **`02-distributed.md`** — L3-specific performance: ring sizing and
  `RunConfig` prewarming, bus-bandwidth estimation.
- **`03-cases.md`** — End-to-end worked cases.

**Note:** this chapter cross-references a Distributed Programming
chapter that landed as a separate PR (#2219). Those specific links are
omitted here and will be added back once both PRs land — see #2162
for the full picture of how the pieces fit together.

## Verification

- `npx markdownlint-cli2 --config tests/lint/.markdownlint.yaml`
- `python3 tests/lint/check_docs_en_zh_parity.py`
- `python3 tests/lint/check_docs_nav.py`
- `pre-commit run --all-files`
- `mkdocs build --strict` (clean, no broken links)