### PR TITLE
Add per-dispatch benchmark timing and resolve callable names

### DIFF
--- a/docs/en/user/00-getting_started.md
+++ b/docs/en/user/00-getting_started.md
@@ -218,10 +218,16 @@ rank's dispatches within the round (a card runs its dispatches serially), so the
 are per-round-per-rank busy figures, **not** per-dispatch.
 
 `per_dispatch` is the un-fused view — it sums nothing. It keys on `(pid, slot)`,
-where `slot` is the dispatch's position within its rank's round; the round
-segmentation guarantees a constant dispatch count per rank per round, so slot `s`
-is the same dispatch in every round. A rank that issues several dispatches per
-round therefore keeps one series per dispatch instead of a single summed number.
+where `slot` is the dispatch's position within its rank's round. A rank that
+issues several dispatches per round therefore keeps one series per dispatch
+instead of a single summed number.
+
+A slot only identifies a dispatch if the rank issues the same callables in the
+same order every round. A constant dispatch count does not guarantee that, so
+the parse checks it: if any slot carried more than one task across the rounds,
+`stats.unstable_dispatch_slots` is set and the per-dispatch views report empty
+rather than averaging distinct kernels under the first round's label. Round
+boundaries are unaffected, so `per_rank` / `per_round` stay valid.
 `stats.dispatch_tasks()` labels each slot with the orchestration function it
 runs, and `stats.dispatch_groups()` returns the underlying `TraceInvocation` per
 round.

--- a/docs/en/user/00-getting_started.md
+++ b/docs/en/user/00-getting_started.md
@@ -210,13 +210,42 @@ walls. Query the four metrics uniformly:
 ```python
 stats.per_round("device" | "host" | "effective" | "union")  # -> [one value per round]
 stats.per_rank("device" | "host" | "effective")             # -> {pid: [one per round]}
+stats.per_dispatch("device" | "host" | "effective")         # -> {(pid, slot): [one per round]}
 ```
 
-Both views aggregate **per rank per round**: each entry sums that rank's
-dispatches within the round (a card runs its dispatches serially), so they are
-per-round-per-rank figures, **not** per-dispatch. When a rank runs exactly one
-dispatch per round the sum is that single dispatch's value; for the individual
-dispatches in any case, read `stats.rounds_dispatches[k][pid]` (see below).
+`per_round` / `per_rank` aggregate **per rank per round**: each entry sums that
+rank's dispatches within the round (a card runs its dispatches serially), so they
+are per-round-per-rank busy figures, **not** per-dispatch.
+
+`per_dispatch` is the un-fused view — it sums nothing. It keys on `(pid, slot)`,
+where `slot` is the dispatch's position within its rank's round; the round
+segmentation guarantees a constant dispatch count per rank per round, so slot `s`
+is the same dispatch in every round. A rank that issues several dispatches per
+round therefore keeps one series per dispatch instead of a single summed number.
+`stats.dispatch_tasks()` labels each slot with the orchestration function it
+runs, and `stats.dispatch_groups()` returns the underlying `TraceInvocation` per
+round.
+
+```python
+stats.per_dispatch("device")   # {(4242, 0): [4.1, 3.8, ...], (4242, 1): [6.3, 6.5, ...]}
+stats.dispatch_tasks()         # {(4242, 0): "prefill_orch", (4242, 1): "decode_orch"}
+```
+
+The markers themselves carry no name — only `hid`, the ELF Build-ID of the
+callable's orchestration `.so` (still available as `TraceInvocation.task`). pypto
+recovers the name by recomputing that Build-ID over the same `.so` bytes it hands
+the runtime, and pairing it with that orchestration's generated name at assemble time
+(`TraceInvocation.task_name`). The label falls back to the raw hash when the
+pairing is unavailable: on `*sim` platforms (whose host seeds `hid` with the
+runtime `callable_id` instead of a Build-ID), or for a callable assembled in a
+different process.
+
+The mean-tree views are dispatch-aware too: on an L3 run
+`print_mean_tree()` renders **one tree per `(pid, slot)`** rather than one tree
+averaging a rank's different kernels together, and `pid=` / `slot=` narrow it to a
+single dispatch. `format_tree()`'s launch headers carry `round=` / `slot=` for the
+same reason. `mean_invocation()` returns a single tree, so it raises unless
+`pid=` / `slot=` select one dispatch.
 
 `effective` is the orch∪sched on-device window (per-card L2 Effective); `union`
 is the cross-rank host-timeline window (captures start skew — host-domain, so it

--- a/docs/zh/user/00-getting_started.md
+++ b/docs/zh/user/00-getting_started.md
@@ -188,12 +188,34 @@ simpler_run                71784.1us  ±6797.5  [66482.4..89832.6]
 ```python
 stats.per_round("device" | "host" | "effective" | "union")  # -> 每轮一个值
 stats.per_rank("device" | "host" | "effective")             # -> {pid: 每轮一个值}
+stats.per_dispatch("device" | "host" | "effective")         # -> {(pid, slot): 每轮一个值}
 ```
 
-这两个视图都是**按 rank 按轮**聚合的：每个值是该 rank 该轮内多次 dispatch 的
-**求和**（一张卡串行执行它的多次 dispatch），因此是"每 rank 每轮"的量，**不是**逐
-dispatch 的量。当某 rank 每轮恰好只有 1 次 dispatch 时，求和即那唯一一次 dispatch 的值；
-无论哪种情况，要看逐次 dispatch 明细都读 `stats.rounds_dispatches[k][pid]`（见下）。
+`per_round` / `per_rank` 是**按 rank 按轮**聚合的：每个值是该 rank 该轮内多次
+dispatch 的**求和**（一张卡串行执行它的多次 dispatch），因此是"每 rank 每轮"的忙时量，
+**不是**逐 dispatch 的量。
+
+`per_dispatch` 是**不做融合**的视图——它不求和。它以 `(pid, slot)` 为键，`slot` 是该次
+dispatch 在本 rank 该轮内的序号；轮次切分保证每 rank 每轮的 dispatch 数恒定，因此
+slot `s` 在每一轮都对应同一次 dispatch。这样一个 rank 每轮的多次 dispatch 会各自保留
+一条序列，而不是被加成一个数。`stats.dispatch_tasks()` 给出每个 slot 实际执行的编排函数
+名，`stats.dispatch_groups()` 返回其每轮的 `TraceInvocation`。
+
+```python
+stats.per_dispatch("device")   # {(4242, 0): [4.1, 3.8, ...], (4242, 1): [6.3, 6.5, ...]}
+stats.dispatch_tasks()         # {(4242, 0): "prefill_orch", (4242, 1): "decode_orch"}
+```
+
+marker 本身不带名字，只带 `hid` —— 该 callable 编排 `.so` 的 ELF Build-ID（仍可通过
+`TraceInvocation.task` 读到）。pypto 对交给 runtime 的同一份 `.so` 字节重算该 Build-ID，
+并在装配时与该编排生成的名字配对，从而还原名字（`TraceInvocation.task_name`）。配对不可得时
+退化为原始哈希：`*sim` 平台（其 host 用 runtime `callable_id` 而非 Build-ID 填充 `hid`），
+或该 callable 是在别的进程里装配的。
+
+均值树视图同样按 dispatch 区分：L3 下 `print_mean_tree()` **按 `(pid, slot)` 各输出一棵
+树**，不再把一个 rank 的不同 kernel 平均进同一棵树；`pid=` / `slot=` 可收窄到某一次
+dispatch。`format_tree()` 的 launch 表头也带上 `round=` / `slot=`。`mean_invocation()`
+只返回一棵树，因此除非用 `pid=` / `slot=` 选定单次 dispatch，否则会抛错。
 
 `effective` 是 orch∪sched 的设备执行窗口（每卡 L2 Effective）；`union` 是跨卡 host
 时间轴并集窗口（能反映起跑错位——host 域，含派发开销）。可导航的

--- a/docs/zh/user/00-getting_started.md
+++ b/docs/zh/user/00-getting_started.md
@@ -196,9 +196,13 @@ dispatch 的**求和**（一张卡串行执行它的多次 dispatch），因此�
 **不是**逐 dispatch 的量。
 
 `per_dispatch` 是**不做融合**的视图——它不求和。它以 `(pid, slot)` 为键，`slot` 是该次
-dispatch 在本 rank 该轮内的序号；轮次切分保证每 rank 每轮的 dispatch 数恒定，因此
-slot `s` 在每一轮都对应同一次 dispatch。这样一个 rank 每轮的多次 dispatch 会各自保留
-一条序列，而不是被加成一个数。`stats.dispatch_tasks()` 给出每个 slot 实际执行的编排函数
+dispatch 在本 rank 该轮内的序号。这样一个 rank 每轮的多次 dispatch 会各自保留一条序列，
+而不是被加成一个数。
+
+slot 要能代表某次 dispatch，前提是该 rank 每轮发出的 callable **顺序也相同**。dispatch
+数恒定并不保证这一点，因此解析时会校验：若某个 slot 在各轮中出现过不同的 task，则置位
+`stats.unstable_dispatch_slots`，逐 dispatch 视图返回空，而不是把不同 kernel 平均到
+第一轮的标签下。轮次边界不受影响，`per_rank` / `per_round` 仍然有效。`stats.dispatch_tasks()` 给出每个 slot 实际执行的编排函数
 名，`stats.dispatch_groups()` 返回其每轮的 `TraceInvocation`。
 
 ```python

--- a/python/pypto/runtime/bench.py
+++ b/python/pypto/runtime/bench.py
@@ -325,6 +325,14 @@ _METRIC_ATTR = {"device": "device_wall_us", "host": "host_wall_us", "effective":
 # Shown when no ``[STRACE]`` span tree was captured at all.
 _NO_TREE_MSG = "BenchmarkStats: no span tree captured (non-SIMPLER_HOST_STRACE build or *sim platform)"
 
+# Shown when the dispatch slots are not stable enough to group by (see
+# ``BenchmarkStats.unstable_dispatch_slots``).
+_UNSTABLE_SLOTS_MSG = (
+    "BenchmarkStats: per-dispatch view unavailable — a rank's dispatch order "
+    "varies between rounds, so a slot does not identify one callable. The "
+    "per-rank / per-round sums are unaffected."
+)
+
 # Max ``(pid, slot)`` groups listed inline by ``BenchmarkStats.__str__`` before
 # the tail is elided (the full set is always available via ``per_dispatch``).
 _STR_MAX_DISPATCHES = 8
@@ -459,6 +467,17 @@ class BenchmarkStats:
             :attr:`device_wall_us` / :attr:`host_wall_us` hold the pooled
             per-dispatch samples (warmup dropped per rank), :attr:`rounds_dispatches`
             is empty, and ``per_rank`` / ``per_round("union")`` return empty.
+        unstable_dispatch_slots: L3 only — ``True`` when some ``(pid, slot)``
+            carried more than one :attr:`TraceInvocation.task` across the measured
+            rounds, i.e. a rank issued a *constant number* of dispatches but not
+            always in the same order (round 0 ``A, B`` then round 1 ``B, A``).
+            The ordinal slot then does not identify a callable, so grouping by it
+            would average distinct kernels under the first round's label — the
+            very fusing the per-dispatch views exist to remove. They therefore
+            report empty (:meth:`dispatch_groups`, :meth:`per_dispatch`,
+            :meth:`dispatch_tasks`) and :meth:`format_mean_tree` explains why.
+            Round boundaries are unaffected, so :attr:`rounds_dispatches`,
+            :meth:`per_rank` and :meth:`per_round` stay valid and populated.
     """
 
     device_wall_us: list[float] = field(default_factory=list)
@@ -468,20 +487,23 @@ class BenchmarkStats:
     invocations: list[TraceInvocation] = field(default_factory=list)
     rounds_dispatches: list[dict[int, list[TraceInvocation]]] = field(default_factory=list)
     fallback_flattened: bool = False
+    unstable_dispatch_slots: bool = False
 
     def dispatch_groups(self) -> dict[tuple[int, int], list[TraceInvocation]]:
         """Per-dispatch invocation series: ``{(pid, slot): [round0, round1, ...]}``.
 
         *slot* is the dispatch's position within its rank's round (dispatches are
-        ordered by ``inv``, and the round segmentation guarantees a constant
-        dispatch count per rank per round, so slot ``s`` is the same dispatch in
-        every round). Keys are sorted by ``(pid, slot)``.
+        ordered by ``inv``). Keys are sorted by ``(pid, slot)``.
 
         This is the un-fused view: a rank issuing several dispatches per round
         gets one entry per dispatch instead of a single summed number. Derived
         from :attr:`rounds_dispatches`, so it is **L3 only** — returns ``{}`` for
-        L2 and for the flatten fallback.
+        L2 and for the flatten fallback, and also when
+        :attr:`unstable_dispatch_slots` says a slot does not identify one
+        callable across rounds.
         """
+        if self.unstable_dispatch_slots:
+            return {}
         out: dict[tuple[int, int], list[TraceInvocation]] = {}
         for ranks in self.rounds_dispatches:
             for pid, dispatches in ranks.items():
@@ -630,7 +652,14 @@ class BenchmarkStats:
         tree — narrowed by the optional *pid* / *slot* selectors. L2 and the
         flatten fallback have no dispatch grid, so they yield a single unlabeled
         group holding every measured launch.
+
+        Yields nothing when :attr:`unstable_dispatch_slots` is set: falling back
+        to the single unlabeled group there would blend a rank's distinct
+        callables into one tree, which is exactly what the flag exists to
+        prevent.
         """
+        if self.unstable_dispatch_slots:
+            return []
         groups = self.dispatch_groups()
         if not groups:
             if pid is not None or slot is not None:
@@ -701,6 +730,8 @@ class BenchmarkStats:
         """
         groups = self._mean_tree_groups(pid=pid, slot=slot)
         if not groups:
+            if self.unstable_dispatch_slots:
+                return _UNSTABLE_SLOTS_MSG
             if self.invocations:
                 return f"BenchmarkStats: no dispatch matches pid={pid} slot={slot}"
             return _NO_TREE_MSG
@@ -932,6 +963,21 @@ def _is_dispatch_invocation(inv: Any, host_name: str) -> bool:
     return any(span.depth == 0 and span.name == host_name for span in inv.spans)
 
 
+def _has_unstable_slots(rounds_dispatches: list[dict[int, list[TraceInvocation]]]) -> bool:
+    """Whether any ``(pid, slot)`` carried more than one task across the rounds.
+
+    See :attr:`BenchmarkStats.unstable_dispatch_slots`. First mismatch wins, so
+    this is O(total dispatches).
+    """
+    seen: dict[tuple[int, int], str] = {}
+    for ranks in rounds_dispatches:
+        for pid, dispatches in ranks.items():
+            for slot, dispatch in enumerate(dispatches):
+                if seen.setdefault((pid, slot), dispatch.task) != dispatch.task:
+                    return True
+    return False
+
+
 def _parse_l3_stats(invocations: Any, stats: BenchmarkStats, *, rounds: int, warmup: int) -> BenchmarkStats:
     """Aggregate L3 (distributed) ``[STRACE]`` markers into per-round stats.
 
@@ -1015,6 +1061,14 @@ def _parse_l3_stats(invocations: Any, stats: BenchmarkStats, *, rounds: int, war
             dispatches = [_mirror_invocation(inv) for inv in chunk]
             stats.invocations.extend(dispatches)
             stats.rounds_dispatches[k][pid] = dispatches
+
+    # A constant dispatch count per round fixes the round boundaries, but it does
+    # not make the ordinal slot a callable identity: a rank could issue A, B one
+    # round and B, A the next. Grouping those by slot would average distinct
+    # kernels under the first round's label, so flag it and let the per-dispatch
+    # views report empty instead. The per-rank sums are order-independent and
+    # stay valid.
+    stats.unstable_dispatch_slots = _has_unstable_slots(stats.rounds_dispatches)
 
     # Headline per round: max across ranks (slowest rank bounds the round).
     pr_dev = stats.per_rank("device")

--- a/python/pypto/runtime/bench.py
+++ b/python/pypto/runtime/bench.py
@@ -148,9 +148,22 @@ class TraceInvocation:
 
         This is the only per-callable identifier the ``[STRACE]`` markers carry;
         distinct ``hid`` values are distinct kernels/callables. It is an opaque
-        hash, **not** a human-readable kernel name (markers do not carry one).
+        hash — see :attr:`task_name` for the orchestration's readable name.
         """
         return self.hid
+
+    @property
+    def task_name(self) -> str:
+        """This dispatch's orchestration name, or its :attr:`task` hash.
+
+        The markers carry no name, so it is recovered by matching ``hid`` against
+        the ``hid → name`` pairings ``device_runner`` records when it
+        assembles each callable (the hid is the ELF Build-ID of the very
+        orchestration ``.so`` the runtime hashes). Degrades to the raw hash when
+        the callable was not assembled in this process, on ``*sim`` platforms, or
+        when the optional runtime is not installed — see :func:`_task_label`.
+        """
+        return _task_label(self.hid)
 
     @property
     def device_wall_us(self) -> float:
@@ -305,9 +318,84 @@ def _span_names() -> dict[str, str]:
 # Runtime log level that makes the ``LOG_INFO_V9`` ``[STRACE]`` markers visible.
 _STRACE_LOG_LEVEL = "v9"
 
-# Metric name → the per-dispatch :class:`TraceInvocation` attribute it sums over
-# (used by ``BenchmarkStats.per_rank`` / ``per_round``).
+# Metric name → the per-dispatch :class:`TraceInvocation` attribute it reads
+# (used by ``BenchmarkStats.per_dispatch`` / ``per_rank`` / ``per_round``).
 _METRIC_ATTR = {"device": "device_wall_us", "host": "host_wall_us", "effective": "effective_us"}
+
+# Shown when no ``[STRACE]`` span tree was captured at all.
+_NO_TREE_MSG = "BenchmarkStats: no span tree captured (non-SIMPLER_HOST_STRACE build or *sim platform)"
+
+# Max ``(pid, slot)`` groups listed inline by ``BenchmarkStats.__str__`` before
+# the tail is elided (the full set is always available via ``per_dispatch``).
+_STR_MAX_DISPATCHES = 8
+
+
+def _task_label(hid: str) -> str:
+    """*hid* resolved to its orchestration's name, or *hid* unchanged.
+
+    The ``[STRACE]`` markers identify a callable only by ``hid`` — the ELF
+    Build-ID of its orchestration ``.so``. ``device_runner`` records
+    ``hid → name`` for every callable it assembles, which covers any
+    program compiled in this process, so the lookup normally succeeds.
+
+    Falls back to the raw hash when it cannot: the callable was assembled in a
+    different process, the platform is ``*sim`` (its host seeds the marker hid
+    with the runtime ``callable_id`` instead of a Build-ID), or the optional
+    runtime package is not installed at all (``device_runner`` pulls in the
+    native ``_task_interface``, hence the guarded import).
+    """
+    try:
+        from .device_runner import callable_name  # noqa: PLC0415
+    except ImportError:
+        return hid
+    return callable_name(hid) or hid
+
+
+def _metric_attr(metric: str, *, caller: str) -> str:
+    """The :class:`TraceInvocation` attribute *metric* names, validated."""
+    attr = _METRIC_ATTR.get(metric)
+    if attr is None:
+        raise ValueError(f"{caller}: metric must be one of {sorted(_METRIC_ATTR)}, got {metric!r}")
+    return attr
+
+
+def _mean_of(invocations: Sequence["TraceInvocation"]) -> "TraceInvocation | None":
+    """A synthetic :class:`TraceInvocation` averaging *invocations* span-by-span.
+
+    Spans are matched by name; ``depth`` / ``attrs`` (hence
+    :attr:`TraceSpan.is_device`) come from the first invocation carrying the span.
+    ``inv`` is ``-1`` to mark the aggregate. ``None`` when *invocations* is empty.
+
+    Callers must only pass invocations of the **same** dispatch (same ``(pid,
+    slot)``): averaging distinct dispatches by span name fuses unrelated kernels
+    into one meaningless tree.
+    """
+    if not invocations:
+        return None
+    durs: dict[str, list[int]] = defaultdict(list)
+    tss: dict[str, list[int]] = defaultdict(list)
+    template: dict[str, TraceSpan] = {}
+    for inv in invocations:
+        for s in inv.spans:
+            durs[s.name].append(s.dur)
+            tss[s.name].append(s.ts)
+            template.setdefault(s.name, s)
+    spans = [
+        TraceSpan(
+            pid=t.pid,
+            tid=t.tid,
+            inv=-1,
+            hid=t.hid,
+            depth=t.depth,
+            name=name,
+            ts=round(statistics.fmean(tss[name])),
+            dur=round(statistics.fmean(durs[name])),
+            attrs=t.attrs,
+        )
+        for name, t in template.items()
+    ]
+    first = invocations[0]
+    return TraceInvocation(pid=first.pid, inv=-1, hid=first.hid, spans=spans)
 
 
 @dataclass
@@ -326,11 +414,18 @@ class BenchmarkStats:
     - **Stored headline** (list, length ``rounds``): :attr:`device_wall_us`,
       :attr:`host_wall_us`. Same as ``per_round("device")`` / ``per_round("host")``.
     - **Stored raw detail**: :attr:`rounds_dispatches` (the L3 ``round → rank →
-      [dispatch]`` grid, the single source for per-rank / effective / union
-      derivations) and :attr:`invocations` (the same dispatches flattened, for
-      tree rendering).
-    - **Derived summaries**: :meth:`per_round` / :meth:`per_rank` for the four
-      metrics ``device`` / ``host`` / ``effective`` / ``union``.
+      [dispatch]`` grid, the single source for per-dispatch / per-rank /
+      effective / union derivations) and :attr:`invocations` (the same dispatches
+      flattened, for tree rendering).
+    - **Derived summaries**: :meth:`per_dispatch` (no fusing — one series per
+      ``(pid, slot)`` dispatch), :meth:`per_rank` (that rank's dispatches summed
+      per round) and :meth:`per_round`, for the metrics ``device`` / ``host`` /
+      ``effective`` (plus ``union`` on ``per_round``).
+
+    A rank that dispatches more than once per round is **not** fused by
+    :meth:`per_dispatch` or by the mean-tree views (:meth:`format_mean_tree`
+    groups per dispatch by default); :meth:`per_rank` / :meth:`per_round`
+    deliberately do sum, as a rank's round busy-time.
 
     The min / median / mean / max / stdev helpers operate on
     :attr:`device_wall_us` — the on-NPU metric.
@@ -353,8 +448,10 @@ class BenchmarkStats:
             :class:`TraceInvocation` dispatches in round ``k`` (ordered by
             ``inv``). Each dispatch exposes :attr:`TraceInvocation.task` (the
             ``hid``) and :attr:`TraceInvocation.device_wall_us` / ``host_wall_us``
-            / ``effective_us``. It is the single source :meth:`per_rank` /
-            :meth:`per_round` derive from. Same objects as :attr:`invocations`.
+            / ``effective_us``. It is the single source :meth:`per_dispatch` /
+            :meth:`per_rank` / :meth:`per_round` derive from, and its dispatch
+            position is the ``slot`` those views key on. Same objects as
+            :attr:`invocations`.
             Length is ``rounds``; empty for L2 and the flatten fallback.
         fallback_flattened: L3 only — ``True`` when per-round segmentation was not
             possible (a rank's marker count was not divisible by
@@ -372,19 +469,63 @@ class BenchmarkStats:
     rounds_dispatches: list[dict[int, list[TraceInvocation]]] = field(default_factory=list)
     fallback_flattened: bool = False
 
+    def dispatch_groups(self) -> dict[tuple[int, int], list[TraceInvocation]]:
+        """Per-dispatch invocation series: ``{(pid, slot): [round0, round1, ...]}``.
+
+        *slot* is the dispatch's position within its rank's round (dispatches are
+        ordered by ``inv``, and the round segmentation guarantees a constant
+        dispatch count per rank per round, so slot ``s`` is the same dispatch in
+        every round). Keys are sorted by ``(pid, slot)``.
+
+        This is the un-fused view: a rank issuing several dispatches per round
+        gets one entry per dispatch instead of a single summed number. Derived
+        from :attr:`rounds_dispatches`, so it is **L3 only** — returns ``{}`` for
+        L2 and for the flatten fallback.
+        """
+        out: dict[tuple[int, int], list[TraceInvocation]] = {}
+        for ranks in self.rounds_dispatches:
+            for pid, dispatches in ranks.items():
+                for slot, dispatch in enumerate(dispatches):
+                    out.setdefault((pid, slot), []).append(dispatch)
+        return {key: out[key] for key in sorted(out)}
+
+    def dispatch_tasks(self) -> dict[tuple[int, int], str]:
+        """``{(pid, slot): name}`` — what each dispatch runs, for labelling slots.
+
+        The dispatch's :attr:`TraceInvocation.task_name` (its orchestration
+        name, or the raw ``hid`` hash when that cannot be resolved),
+        taken from its first measured round. ``{}`` for L2 / fallback. For the
+        wire identity itself use ``dispatch_groups()[key][0].task``.
+        """
+        return {key: group[0].task_name for key, group in self.dispatch_groups().items() if group}
+
+    def per_dispatch(self, metric: str = "device") -> dict[tuple[int, int], list[float]]:
+        """Per-dispatch, per-round summary (µs): ``{(pid, slot): [round0, ...]}``.
+
+        *metric* is one of ``"device"`` / ``"host"`` / ``"effective"``. Unlike
+        :meth:`per_rank`, nothing is summed — each entry is one dispatch's own
+        :attr:`TraceInvocation.device_wall_us` / ``host_wall_us`` /
+        ``effective_us``, so a rank's repeated or heterogeneous dispatches stay
+        separate. Pair with :meth:`dispatch_tasks` to label the slots.
+
+        Derived from :attr:`rounds_dispatches`, so it is **L3 only** — returns
+        ``{}`` for L2 and for the flatten fallback.
+        """
+        attr = _metric_attr(metric, caller="per_dispatch()")
+        return {key: [getattr(d, attr) for d in group] for key, group in self.dispatch_groups().items()}
+
     def per_rank(self, metric: str = "device") -> dict[int, list[float]]:
         """Per-rank, per-round summary (µs): ``{pid: [round0, round1, ...]}``.
 
         *metric* is one of ``"device"`` / ``"host"`` / ``"effective"`` — each
         round entry sums that rank's dispatches'
         :attr:`TraceInvocation.device_wall_us` / ``host_wall_us`` / ``effective_us``
-        (a card runs its dispatches serially). Derived from
-        :attr:`rounds_dispatches`, so it is **L3 only** — returns ``{}`` for L2
-        and for the flatten fallback.
+        (a card runs its dispatches serially), i.e. that rank's busy time for the
+        round. Use :meth:`per_dispatch` when you need the individual dispatches
+        rather than their sum. Derived from :attr:`rounds_dispatches`, so it is
+        **L3 only** — returns ``{}`` for L2 and for the flatten fallback.
         """
-        attr = _METRIC_ATTR.get(metric)
-        if attr is None:
-            raise ValueError(f"per_rank(): metric must be one of {sorted(_METRIC_ATTR)}, got {metric!r}")
+        attr = _metric_attr(metric, caller="per_rank()")
         n = len(self.rounds_dispatches)
         out: dict[int, list[float]] = {}
         for k, ranks in enumerate(self.rounds_dispatches):
@@ -444,13 +585,21 @@ class BenchmarkStats:
             us: Show durations in microseconds (default) or nanoseconds.
         """
         if not self.invocations:
-            return "BenchmarkStats: no span tree captured (non-SIMPLER_HOST_STRACE build or *sim platform)"
+            return _NO_TREE_MSG
         selected = (
             list(enumerate(self.invocations)) if launch is None else [(launch, self.invocations[launch])]
         )
+        # L3: label each launch with the (round, slot) it belongs to, so a rank's
+        # repeated dispatches are told apart in the flat ``invocations`` ordering.
+        where = self._dispatch_coords()
         out: list[str] = []
         for i, inv in selected:
-            out.append(f"launch[{i}] (pid={inv.pid} inv={inv.inv} hid={inv.hid}):")
+            coord = where.get(id(inv))
+            tag = f" round={coord[0]} slot={coord[1]}" if coord is not None else ""
+            name = inv.task_name
+            if name != inv.hid:  # resolved to a readable orchestration name
+                tag += f" task={name}"
+            out.append(f"launch[{i}] (pid={inv.pid} inv={inv.inv} hid={inv.hid}{tag}):")
             out.append(inv.format_tree(us=us))
         return "\n".join(out)
 
@@ -458,86 +607,152 @@ class BenchmarkStats:
         """Print :meth:`format_tree` to *file* (default stdout)."""
         print(self.format_tree(launch, us=us), file=file)
 
-    def mean_invocation(self) -> "TraceInvocation | None":
+    def _dispatch_coords(self) -> dict[int, tuple[int, int]]:
+        """``id(dispatch) -> (round, slot)`` for the L3 grid; ``{}`` otherwise.
+
+        :attr:`rounds_dispatches` holds the very same :class:`TraceInvocation`
+        objects as :attr:`invocations`, so identity is a valid key.
+        """
+        out: dict[int, tuple[int, int]] = {}
+        for k, ranks in enumerate(self.rounds_dispatches):
+            for dispatches in ranks.values():
+                for slot, dispatch in enumerate(dispatches):
+                    out[id(dispatch)] = (k, slot)
+        return out
+
+    def _mean_tree_groups(
+        self, *, pid: int | None = None, slot: int | None = None
+    ) -> list[tuple[str | None, list[TraceInvocation]]]:
+        """The ``(label, invocations)`` groups the mean-tree views average over.
+
+        L3 (:attr:`rounds_dispatches` populated): one group per ``(pid, slot)``
+        dispatch — so a rank's distinct dispatches are never averaged into one
+        tree — narrowed by the optional *pid* / *slot* selectors. L2 and the
+        flatten fallback have no dispatch grid, so they yield a single unlabeled
+        group holding every measured launch.
+        """
+        groups = self.dispatch_groups()
+        if not groups:
+            if pid is not None or slot is not None:
+                return []
+            return [(None, self.invocations)] if self.invocations else []
+        tasks = self.dispatch_tasks()
+        return [
+            (f"pid={key[0]} slot={key[1]} task={tasks[key]}", invs)
+            for key, invs in groups.items()
+            if (pid is None or key[0] == pid) and (slot is None or key[1] == slot)
+        ]
+
+    def mean_invocation(self, *, pid: int | None = None, slot: int | None = None) -> "TraceInvocation | None":
         """A synthetic :class:`TraceInvocation` whose every span's ``dur`` (and
-        ``ts``) is the mean across all measured launches (warmup excluded).
+        ``ts``) is the mean across the measured launches of **one** dispatch
+        (warmup excluded).
 
         Spans are matched by name; ``depth`` / ``attrs`` (hence
         :attr:`TraceSpan.is_device`) come from the first launch that carried the
         span. ``inv`` is ``-1`` to mark the aggregate. Returns ``None`` when no
         span tree was captured. Useful for rendering one noise-smoothed tree.
-        """
-        if not self.invocations:
-            return None
-        durs: dict[str, list[int]] = defaultdict(list)
-        tss: dict[str, list[int]] = defaultdict(list)
-        template: dict[str, TraceSpan] = {}
-        for inv in self.invocations:
-            for s in inv.spans:
-                durs[s.name].append(s.dur)
-                tss[s.name].append(s.ts)
-                template.setdefault(s.name, s)
-        spans = [
-            TraceSpan(
-                pid=t.pid,
-                tid=t.tid,
-                inv=-1,
-                hid=t.hid,
-                depth=t.depth,
-                name=name,
-                ts=round(statistics.fmean(tss[name])),
-                dur=round(statistics.fmean(durs[name])),
-                attrs=t.attrs,
-            )
-            for name, t in template.items()
-        ]
-        first = self.invocations[0]
-        return TraceInvocation(pid=first.pid, inv=-1, hid=first.hid, spans=spans)
 
-    def format_mean_tree(self, *, us: bool = True, spread: str = "stdev") -> str:
-        """Render a span tree whose every node's duration is the mean across all
+        Args:
+            pid: Restrict to this rank (L3). ``None`` means "any".
+            slot: Restrict to this dispatch slot within the round (L3).
+
+        Raises:
+            ValueError: The selectors do not narrow an L3 run down to a single
+                ``(pid, slot)`` dispatch. Averaging distinct dispatches by span
+                name would fuse unrelated kernels into one meaningless tree, so
+                pass ``pid=`` / ``slot=`` (see :meth:`dispatch_tasks` for the
+                available keys) or use :meth:`format_mean_tree`, which renders
+                every dispatch's tree.
+        """
+        groups = self._mean_tree_groups(pid=pid, slot=slot)
+        if not groups:
+            return None
+        if len(groups) > 1:
+            raise ValueError(
+                f"mean_invocation(): {len(groups)} dispatches match pid={pid} slot={slot} "
+                f"({sorted(self.dispatch_groups())}); averaging them by span name would fuse "
+                "distinct dispatches. Pass pid=/slot= to select one, or use format_mean_tree()."
+            )
+        return _mean_of(groups[0][1])
+
+    def format_mean_tree(
+        self,
+        *,
+        us: bool = True,
+        spread: str = "stdev",
+        pid: int | None = None,
+        slot: int | None = None,
+    ) -> str:
+        """Render a span tree whose every node's duration is the mean across the
         measured launches (warmup excluded), annotated with the per-node spread.
+
+        On an L3 run one tree is rendered **per dispatch** (``(pid, slot)``, see
+        :meth:`dispatch_groups`): a rank that dispatches several kernels per round
+        gets one tree each rather than a single tree averaging them together.
 
         Args:
             us: Show values in microseconds (default) or nanoseconds.
             spread: Spread shown after each node's mean — ``"stdev"`` (``±sd``,
                 default), ``"minmax"`` (``[min..max]``), ``"both"``, or
                 ``"none"``. Computed across the measured launches.
+            pid: Render only this rank's dispatches (L3).
+            slot: Render only this dispatch slot within the round (L3).
         """
-        mean_inv = self.mean_invocation()
-        if mean_inv is None:
-            return "BenchmarkStats: no span tree captured (non-SIMPLER_HOST_STRACE build or *sim platform)"
+        groups = self._mean_tree_groups(pid=pid, slot=slot)
+        if not groups:
+            if self.invocations:
+                return f"BenchmarkStats: no dispatch matches pid={pid} slot={slot}"
+            return _NO_TREE_MSG
 
-        durs: dict[str, list[int]] = defaultdict(list)
-        for inv in self.invocations:
-            for s in inv.spans:
-                durs[s.name].append(s.dur)
         scale = 1000.0 if us else 1.0
         unit = "us" if us else "ns"
-
-        def _value(span: TraceSpan) -> list[str]:
-            ds = durs[span.name]
-            cols = [f"{statistics.fmean(ds) / scale:.1f}{unit}"]
-            if spread in ("stdev", "both"):
-                sd = statistics.stdev(ds) / scale if len(ds) > 1 else 0.0
-                cols.append(f"±{sd:.1f}")
-            if spread in ("minmax", "both"):
-                cols.append(f"[{min(ds) / scale:.1f}..{max(ds) / scale:.1f}]")
-            return cols
-
         legend = "mean"
         if spread in ("stdev", "both"):
             legend += " ±stdev"
         if spread in ("minmax", "both"):
             legend += " [min..max]"
-        header = (
-            f"mean of {len(self.invocations)} launches (warmup {self.warmup} excluded); each node: {legend}:"
-        )
-        return f"{header}\n{mean_inv.format_tree(us=us, value_fn=_value)}"
 
-    def print_mean_tree(self, *, us: bool = True, spread: str = "stdev", file: Any = None) -> None:
+        out: list[str] = []
+        for label, invs in groups:
+            mean_inv = _mean_of(invs)
+            if mean_inv is None:
+                continue
+            durs: dict[str, list[int]] = defaultdict(list)
+            for inv in invs:
+                for s in inv.spans:
+                    durs[s.name].append(s.dur)
+
+            def _value(span: TraceSpan, durs: dict[str, list[int]] = durs) -> list[str]:
+                ds = durs[span.name]
+                cols = [f"{statistics.fmean(ds) / scale:.1f}{unit}"]
+                if spread in ("stdev", "both"):
+                    sd = statistics.stdev(ds) / scale if len(ds) > 1 else 0.0
+                    cols.append(f"±{sd:.1f}")
+                if spread in ("minmax", "both"):
+                    cols.append(f"[{min(ds) / scale:.1f}..{max(ds) / scale:.1f}]")
+                return cols
+
+            prefix = f"dispatch {label} — " if label is not None else ""
+            if out:
+                out.append("")
+            out.append(
+                f"{prefix}mean of {len(invs)} launches (warmup {self.warmup} excluded); each node: {legend}:"
+            )
+            out.append(mean_inv.format_tree(us=us, value_fn=_value))
+        return "\n".join(out)
+
+    def print_mean_tree(
+        self,
+        *,
+        us: bool = True,
+        spread: str = "stdev",
+        pid: int | None = None,
+        slot: int | None = None,
+        file: Any = None,
+    ) -> None:
         """Print :meth:`format_mean_tree` to *file* (default stdout)."""
-        print(self.format_mean_tree(us=us, spread=spread), file=file)
+        print(self.format_mean_tree(us=us, spread=spread, pid=pid, slot=slot), file=file)
 
     @property
     def device_us_min(self) -> float:
@@ -621,7 +836,30 @@ class BenchmarkStats:
             f"device_wall_us min={self.device_us_min:.1f} median={self.device_us_median:.1f} "
             f"mean={self.device_us_mean:.1f} max={self.device_us_max:.1f} "
             f"stdev={self.device_us_stdev:.1f}{suffix}"
+            f"{self._per_dispatch_line()}"
         )
+
+    def _per_dispatch_line(self) -> str:
+        """A trailing ``__str__`` line breaking the headline down per dispatch.
+
+        Only emitted when some rank dispatches more than once per round — the case
+        where the summed per-rank / per-round headline hides the individual
+        dispatches. Long dispatch sets are elided; :meth:`per_dispatch` has all of
+        them.
+        """
+        per_dispatch = self.per_dispatch("device")
+        if len(per_dispatch) <= len(self.per_rank("device")):
+            return ""  # at most one dispatch per rank: nothing is being fused
+        tasks = self.dispatch_tasks()
+        shown = list(per_dispatch.items())[:_STR_MAX_DISPATCHES]
+        cells = [
+            f"(pid={pid},slot={slot},task={tasks[pid, slot]})={statistics.fmean(vals):.1f}"
+            for (pid, slot), vals in shown
+        ]
+        elided = len(per_dispatch) - len(shown)
+        if elided:
+            cells.append(f"... +{elided} more")
+        return "\n  per-dispatch device mean us: " + "  ".join(cells)
 
 
 @contextmanager
@@ -978,10 +1216,12 @@ def benchmark(
     Returns:
         A :class:`BenchmarkStats` with the per-round ``device_wall_us`` /
         ``host_wall_us`` samples and aggregate helpers. For L3 the samples are
-        per-round maxima across ranks; per-rank / effective / union summaries are
-        derived on demand via :meth:`BenchmarkStats.per_rank` (``device`` /
-        ``host`` / ``effective``) and :meth:`BenchmarkStats.per_round` (those plus
-        ``union``), and the ``round → rank → [dispatch]`` grid is in
+        per-round maxima across ranks; summaries are derived on demand via
+        :meth:`BenchmarkStats.per_dispatch` (per ``(pid, slot)`` dispatch — nothing
+        summed), :meth:`BenchmarkStats.per_rank` (``device`` / ``host`` /
+        ``effective``, that rank's dispatches summed per round) and
+        :meth:`BenchmarkStats.per_round` (those plus ``union``), and the
+        ``round → rank → [dispatch]`` grid is in
         :attr:`BenchmarkStats.rounds_dispatches`.
 
     Raises:
@@ -1002,6 +1242,9 @@ def benchmark(
         that round's per-rank **summed** dispatch device walls — a proxy for round
         device time that excludes inter-dispatch idle gaps and cross-rank start
         skew (device clocks are per-invocation, so gaps/skew are unmeasurable).
+        A rank that dispatches more than once per round is therefore summed in the
+        headline; use :meth:`BenchmarkStats.per_dispatch` (and the per-dispatch
+        mean trees) to keep those dispatches apart.
         ``per_round("union")`` complements it with the cross-rank **host-timeline**
         union window (the ``<root>`` host clocks are ``CLOCK_MONOTONIC``,
         cross-process comparable), which *does* capture overlap / start skew but

--- a/python/pypto/runtime/device_runner.py
+++ b/python/pypto/runtime/device_runner.py
@@ -48,7 +48,7 @@ import torch
 
 from pypto._external_source import kernel_binary_cache_path
 
-from .elf_parser import extract_text_section
+from .elf_parser import elf_build_id_64, extract_text_section
 from .kernel_compiler import KernelCompiler
 from .task_interface import (
     CallConfig,  # pyright: ignore[reportAttributeAccessIssue]
@@ -477,6 +477,60 @@ def compile_single_orchestration(
 # compile_and_assemble
 # ---------------------------------------------------------------------------
 
+# ``hid`` (ELF Build-ID 64 of an orchestration ``.so``, lowercase hex) → that
+# orchestration's display name (see ``callable_display_name``). The runtime
+# identifies a callable in its ``[STRACE]`` timing markers by this hash alone (it
+# never emits a name), so recording the pairing at assemble time is what lets
+# ``pypto.runtime.benchmark`` label a measured dispatch readably. Process-wide and
+# append-only: ``hid`` is content-derived, so two entries can only collide when
+# the ``.so`` bytes are identical — in which case the name is identical too.
+_CALLABLE_NAMES: dict[str, str] = {}
+
+
+def callable_display_name(orchestration: dict[str, Any]) -> str:
+    """A human-readable, per-program name for an ``ORCHESTRATION`` manifest entry.
+
+    The manifest's ``function_name`` is the fixed AICPU entry symbol the runtime
+    dlsym's — ``aicpu_orchestration_entry`` for *every* program — so it cannot
+    tell two callables apart. The generated source file is named after the
+    orchestration itself (``orchestration/prefill_fwd.cpp``, and for an L3 build
+    its ``next_levels/<name>/`` directory matches), so its stem is the
+    distinguishing name. Falls back to ``function_name`` if ``source`` is absent.
+    """
+    source = orchestration.get("source")
+    return Path(source).stem if source else str(orchestration.get("function_name", ""))
+
+
+def register_callable_identity(orch_so: bytes, name: str) -> str:
+    """Record ``hid → name`` for an orchestration ``.so`` and return the hid.
+
+    *orch_so* must be the exact buffer handed to the runtime (the same bytes it
+    hashes in ``record_device_orch_callable``), so the computed hid matches the
+    ``hid=`` field of that callable's ``[STRACE]`` markers.
+
+    Args:
+        orch_so: Complete orchestration shared-object bytes.
+        name: Display name for the callable — see :func:`callable_display_name`.
+
+    Returns:
+        The callable's hid — :func:`~pypto.runtime.elf_parser.elf_build_id_64`
+        formatted as lowercase hex, matching the marker wire format.
+    """
+    hid = f"{elf_build_id_64(orch_so):x}"
+    _CALLABLE_NAMES.setdefault(hid, name)
+    return hid
+
+
+def callable_name(hid: str) -> str | None:
+    """The orchestration's display name for *hid*, or ``None`` if unknown.
+
+    Returns ``None`` when the callable was not assembled in this process, or on a
+    ``*sim`` platform: the sim host seeds the marker hid with the runtime's
+    ``callable_id`` rather than the ELF Build-ID, so marker hids do not match the
+    hashes recorded here.
+    """
+    return _CALLABLE_NAMES.get(hid.lower())
+
 
 def _missing_kernel_config_error(work_dir: Path) -> FileNotFoundError:
     """Explain why a build output has no runtime manifest."""
@@ -671,12 +725,18 @@ def compile_and_assemble(
 
     # Assemble ChipCallable
     orch_sig = orchestration.get("signature", [])
+    func_name = orchestration["function_name"]
     chip_callable = ChipCallable.build(
         signature=orch_sig,
-        func_name=orchestration["function_name"],
+        func_name=func_name,
         binary=orch_so_binary,
         children=kernel_binaries,
     )
+    # ``orch_so_binary`` is the buffer the runtime hashes into the ``hid=`` of this
+    # callable's [STRACE] markers; pair it with the per-program display name (NOT
+    # ``func_name``, the shared AICPU entry symbol) so benchmark timing can be
+    # attributed to a readable orchestration rather than an opaque hash.
+    register_callable_identity(orch_so_binary, callable_display_name(orchestration))
 
     return chip_callable, runtime_name, runtime_config
 

--- a/python/pypto/runtime/elf_parser.py
+++ b/python/pypto/runtime/elf_parser.py
@@ -7,7 +7,7 @@
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
 
-"""ELF / Mach-O object file parser for extracting .text sections.
+"""ELF / Mach-O object file parser for extracting .text sections and Build-IDs.
 
 Pure Python implementation — no external dependencies.
 """
@@ -24,11 +24,114 @@ ELFMAG1 = ord("E")
 ELFMAG2 = ord("L")
 ELFMAG3 = ord("F")
 
+# ELF class byte (e_ident[EI_CLASS]) for 64-bit objects.
+ELFCLASS64 = 2
+
+# Program-header type / note type for the GNU Build-ID note.
+PT_NOTE = 4
+NT_GNU_BUILD_ID = 3
+
 # Mach-O Magic Numbers
 MH_MAGIC_64 = 0xFEEDFACF
 
 # Mach-O Load Command types
 LC_SEGMENT_64 = 0x19
+
+# ELF64 header / program-header field offsets and sizes.
+_EHDR_SIZE = 64
+_EHDR_PHOFF = 0x20
+_EHDR_PHENTSIZE = 0x36
+_PHDR_SIZE = 56
+_PHDR_OFFSET = 8
+_PHDR_FILESZ = 32
+_NHDR_SIZE = 12
+
+# FNV-1a 64-bit parameters (mirrors runtime ``src/common/utils/fnv1a_64.h``).
+_FNV1A_64_OFFSET = 0xCBF29CE484222325
+_FNV1A_64_PRIME = 0x100000001B3
+_U64_MASK = 0xFFFFFFFFFFFFFFFF
+
+
+def fnv1a_64(data: bytes) -> int:
+    """FNV-1a 64-bit content hash of *data*.
+
+    Mirrors the runtime's ``simpler::common::utils::fnv1a_64``
+    (``src/common/utils/fnv1a_64.h``) so both sides agree bit-for-bit.
+    """
+    h = _FNV1A_64_OFFSET
+    for byte in data:
+        h = ((h ^ byte) * _FNV1A_64_PRIME) & _U64_MASK
+    return h
+
+
+def elf_build_id_64(data: bytes) -> int:
+    """The 64-bit identifier the runtime derives from an ELF64's GNU Build-ID.
+
+    The first 8 bytes of the ``NT_GNU_BUILD_ID`` note descriptor, read as a
+    little-endian ``uint64``; falls back to :func:`fnv1a_64` over the whole
+    buffer when *data* is not a well-formed ELF64 or carries no Build-ID (i.e.
+    was linked without ``--build-id``).
+
+    This mirrors the runtime's ``simpler::common::utils::elf_build_id_64``
+    (``src/common/utils/elf_build_id.h``) exactly, because the value it returns
+    for an orchestration ``.so`` is the ``hid=`` field of that callable's
+    ``[STRACE]`` timing markers. Computing it host-side is what lets pypto map a
+    marker back to the orchestration function name (see
+    ``pypto.runtime.device_runner.register_callable_identity``).
+
+    Args:
+        data: The complete object-file bytes (the same buffer the runtime hashes).
+
+    Returns:
+        The 64-bit callable identity. Never raises — malformed input degrades to
+        the FNV-1a fallback, matching the runtime.
+    """
+    if len(data) < _EHDR_SIZE:
+        return fnv1a_64(data)
+    if data[:4] != bytes((ELFMAG0, ELFMAG1, ELFMAG2, ELFMAG3)) or data[4] != ELFCLASS64:
+        return fnv1a_64(data)
+
+    (e_phoff,) = struct.unpack_from("<Q", data, _EHDR_PHOFF)
+    e_phentsize, e_phnum = struct.unpack_from("<HH", data, _EHDR_PHENTSIZE)
+    if e_phoff == 0 or e_phentsize < _PHDR_SIZE:
+        return fnv1a_64(data)
+    if e_phoff + e_phnum * e_phentsize > len(data):
+        return fnv1a_64(data)
+
+    for i in range(e_phnum):
+        phdr = e_phoff + i * e_phentsize
+        (p_type,) = struct.unpack_from("<I", data, phdr)
+        if p_type != PT_NOTE:
+            continue
+        (p_offset,) = struct.unpack_from("<Q", data, phdr + _PHDR_OFFSET)
+        (p_filesz,) = struct.unpack_from("<Q", data, phdr + _PHDR_FILESZ)
+        if p_offset + p_filesz > len(data):
+            continue  # Notes lie beyond the buffer we were given.
+        build_id = _find_build_id_note(data, p_offset, p_offset + p_filesz)
+        if build_id is not None:
+            return build_id
+
+    # No Build-ID found; the SO was likely linked without --build-id.
+    return fnv1a_64(data)
+
+
+def _find_build_id_note(data: bytes, start: int, end: int) -> int | None:
+    """Scan the ELF note entries in ``data[start:end]`` for a GNU Build-ID."""
+    note = start
+    while note + _NHDR_SIZE <= end:
+        namesz, descsz, ntype = struct.unpack_from("<III", data, note)
+        name = note + _NHDR_SIZE
+        desc = name + ((namesz + 3) & ~3)
+        nxt = desc + ((descsz + 3) & ~3)
+        if nxt > end:
+            return None  # Malformed note entry.
+        is_build_id = (
+            ntype == NT_GNU_BUILD_ID and namesz == 4 and data[name : name + 4] == b"GNU\x00" and descsz >= 8
+        )
+        if is_build_id:
+            return int(struct.unpack_from("<Q", data, desc)[0])
+        note = nxt
+    return None
 
 
 def extract_text_section(obj_input: str | Path | bytes) -> bytes:

--- a/tests/st/runtime/framework_and_models/test_benchmark_st.py
+++ b/tests/st/runtime/framework_and_models/test_benchmark_st.py
@@ -198,6 +198,17 @@ def test_benchmark_l3_surfaces_per_rank_timing(test_config, device_ids):
     assert not stats.all_zero_device, "device_wall_us must be > 0 on the default SIMPLER_HOST_STRACE build"
     assert stats.device_us_min > 0.0
 
+    # Per-dispatch view: this program issues exactly one child per rank per round,
+    # so every rank has slot 0 only and the un-fused series equals the summed
+    # per-rank one. A rank with >1 dispatch/round would differ (per_rank sums).
+    per_dispatch = stats.per_dispatch("device")
+    assert set(per_dispatch) == {(pid, 0) for pid in rank_dev}
+    for (pid, _slot), series in per_dispatch.items():
+        assert series == rank_dev[pid]
+    # Each dispatch renders its own mean tree (never averaged across dispatches).
+    for pid, slot in per_dispatch:
+        assert f"pid={pid} slot={slot}" in stats.format_mean_tree(pid=pid, slot=slot)
+
     # Per-card L2 Effective (orch union sched window): one series per rank, > 0, and
     # bounded by that rank's device wall (Effective ⊆ device_wall).
     assert set(rank_eff) == set(rank_dev)

--- a/tests/ut/runtime/test_benchmark.py
+++ b/tests/ut/runtime/test_benchmark.py
@@ -21,6 +21,7 @@ run everywhere without ``simpler``.
 """
 
 import os
+import struct
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -36,6 +37,7 @@ from pypto.runtime.bench import (
     _parse_stats_from_strace,
     benchmark,
 )
+from pypto.runtime.elf_parser import elf_build_id_64, fnv1a_64
 
 
 @pytest.fixture
@@ -417,6 +419,140 @@ def test_parse_l3_multi_dispatch_sums_within_round(span_root):
     assert stats.device_wall_us == [10.0, 10.0]
 
 
+def _l3_multi_dispatch_lines(span_root: str) -> list[str]:
+    """Markers for 2 rounds where rank 100 dispatches twice (hids a, b) per round.
+
+    rank 100: round0 = a(4us) + b(6us), round1 = a(3us) + b(7us).
+    rank 101: one dispatch/round (hid c): 5us then 8us.
+    """
+    lines: list[str] = []
+    lines += _launch_lines(0, span_root, host_us=1, device_us=4, pid=100, hid="a")
+    lines += _launch_lines(1, span_root, host_us=1, device_us=6, pid=100, hid="b")
+    lines += _launch_lines(2, span_root, host_us=1, device_us=3, pid=100, hid="a")
+    lines += _launch_lines(3, span_root, host_us=1, device_us=7, pid=100, hid="b")
+    lines += _launch_lines(0, span_root, host_us=1, device_us=5, pid=101, hid="c")
+    lines += _launch_lines(1, span_root, host_us=1, device_us=8, pid=101, hid="c")
+    return lines
+
+
+def test_parse_l3_per_dispatch_keeps_a_ranks_dispatches_separate(span_root):
+    """``per_dispatch`` does not fuse a rank's several dispatches per round.
+
+    ``per_rank`` sums rank 100's two dispatches into one per-round busy figure;
+    ``per_dispatch`` keys on ``(pid, slot)`` so each dispatch keeps its own series.
+    """
+    stats = _parse_stats_from_strace(
+        "\n".join(_l3_multi_dispatch_lines(span_root)), rounds=2, warmup=0, distributed=True
+    )
+
+    assert stats.fallback_flattened is False
+    # Un-fused: one series per (pid, slot), ordered by (pid, slot).
+    assert stats.per_dispatch("device") == {
+        (100, 0): [4.0, 3.0],
+        (100, 1): [6.0, 7.0],
+        (101, 0): [5.0, 8.0],
+    }
+    # Slots are identified by their task (callable hash).
+    assert stats.dispatch_tasks() == {(100, 0): "a", (100, 1): "b", (101, 0): "c"}
+    # The summed per-rank view is unchanged (4+6, 3+7).
+    assert stats.per_rank("device")[100] == [10.0, 10.0]
+    # Each (pid, slot) group holds one TraceInvocation per measured round.
+    groups = stats.dispatch_groups()
+    assert [d.device_wall_us for d in groups[100, 1]] == [6.0, 7.0]
+
+
+def test_per_dispatch_host_metric_and_bad_metric(span_root):
+    stats = _parse_stats_from_strace(
+        "\n".join(_l3_multi_dispatch_lines(span_root)), rounds=2, warmup=0, distributed=True
+    )
+    assert stats.per_dispatch("host") == {
+        (100, 0): [1.0, 1.0],
+        (100, 1): [1.0, 1.0],
+        (101, 0): [1.0, 1.0],
+    }
+    with pytest.raises(ValueError, match="per_dispatch\\(\\): metric must be one of"):
+        stats.per_dispatch("nope")
+
+
+def test_per_dispatch_empty_without_dispatch_grid():
+    """No L3 grid (L2 / flatten fallback) -> the per-dispatch views are empty."""
+    stats = BenchmarkStats(device_wall_us=[1.0], host_wall_us=[2.0], rounds=1, warmup=0)
+    assert stats.per_dispatch("device") == {}
+    assert stats.dispatch_groups() == {}
+    assert stats.dispatch_tasks() == {}
+
+
+def test_mean_tree_renders_one_tree_per_dispatch(span_root):
+    """The mean tree groups per ``(pid, slot)`` instead of averaging dispatches.
+
+    Rank 100's two dispatches (4/3us and 6/7us device) must show as 3.5us and
+    6.5us trees — a single fused tree would report their 5.0us average.
+    """
+    stats = _parse_stats_from_strace(
+        "\n".join(_l3_multi_dispatch_lines(span_root)), rounds=2, warmup=0, distributed=True
+    )
+
+    tree = stats.format_mean_tree(spread="none")
+    assert "dispatch pid=100 slot=0 task=a — mean of 2 launches" in tree
+    assert "dispatch pid=100 slot=1 task=b — mean of 2 launches" in tree
+    assert "dispatch pid=101 slot=0 task=c — mean of 2 launches" in tree
+    assert _row_present(tree, "device_wall [dev] 3.5us")  # (4+3)/2, not fused with slot 1
+    assert _row_present(tree, "device_wall [dev] 6.5us")  # (6+7)/2
+    assert not _row_present(tree, "device_wall [dev] 5.0us")  # the old fused average
+
+    # Selectors narrow the rendering to one dispatch.
+    one = stats.format_mean_tree(spread="none", pid=100, slot=1)
+    assert "slot=1" in one and "slot=0" not in one
+    assert _row_present(one, "device_wall [dev] 6.5us")
+    assert "no dispatch matches" in stats.format_mean_tree(pid=999)
+
+
+def test_mean_invocation_requires_a_single_dispatch(span_root):
+    """``mean_invocation`` refuses to average distinct dispatches together."""
+    stats = _parse_stats_from_strace(
+        "\n".join(_l3_multi_dispatch_lines(span_root)), rounds=2, warmup=0, distributed=True
+    )
+
+    with pytest.raises(ValueError, match="dispatches match pid=None slot=None"):
+        stats.mean_invocation()
+    # Narrowed to one dispatch -> the mean of just that dispatch's launches.
+    mean = stats.mean_invocation(pid=100, slot=1)
+    assert mean is not None
+    assert mean.device_wall_us == 6.5
+    assert stats.mean_invocation(pid=999) is None
+
+
+def test_format_tree_labels_round_and_slot(span_root):
+    """L3 launch headers carry the (round, slot) so repeats are distinguishable."""
+    stats = _parse_stats_from_strace(
+        "\n".join(_l3_multi_dispatch_lines(span_root)), rounds=2, warmup=0, distributed=True
+    )
+    header_lines = [line for line in stats.format_tree().splitlines() if line.startswith("launch[")]
+    assert any("round=0 slot=0" in line for line in header_lines)
+    assert any("round=0 slot=1" in line for line in header_lines)
+    assert any("round=1 slot=1" in line for line in header_lines)
+
+
+def test_str_breaks_down_fused_dispatches(span_root):
+    """``__str__`` adds a per-dispatch line when a rank dispatches more than once."""
+    stats = _parse_stats_from_strace(
+        "\n".join(_l3_multi_dispatch_lines(span_root)), rounds=2, warmup=0, distributed=True
+    )
+    text = str(stats)
+    assert "per-dispatch device mean us:" in text
+    assert "(pid=100,slot=0,task=a)=3.5" in text
+    assert "(pid=100,slot=1,task=b)=6.5" in text
+
+    # One dispatch per rank: nothing is fused, so no extra line.
+    single = _parse_stats_from_strace(
+        "\n".join(_launch_lines(0, span_root, host_us=1, device_us=5, pid=100)),
+        rounds=1,
+        warmup=0,
+        distributed=True,
+    )
+    assert "per-dispatch" not in str(single)
+
+
 def test_parse_l3_non_divisible_falls_back_to_flattened(span_root):
     """A non-deterministic dispatch shape (count not divisible by launches) flattens."""
     lines: list[str] = []
@@ -525,6 +661,135 @@ def test_parse_l3_degenerates_to_l2_for_single_rank(span_root):
     assert stats.fallback_flattened is False
     assert stats.device_wall_us == [10.0, 20.0]
     assert stats.per_rank("device") == {100: [10.0, 20.0]}
+
+
+# ---------------------------------------------------------------------------
+# Callable identity — resolving a marker ``hid`` to an orchestration name
+# ---------------------------------------------------------------------------
+
+# A real aarch64 .so's Build-ID and the 64-bit id the runtime derives from it
+# (the first 8 descriptor bytes read little-endian).
+_REAL_BUILD_ID = bytes.fromhex("ac6a376891802e4aa47c89a076b5e4b48a461a47")
+_REAL_BUILD_ID_64 = 0x4A2E809168376AAC
+
+
+def _elf64_with_build_id(build_id: bytes | None) -> bytes:
+    """A minimal ELF64 carrying one ``PT_NOTE`` segment (Build-ID when given).
+
+    Just enough header for ``elf_build_id_64`` to walk: an ELF64 header pointing
+    at a single program header, which points at the note payload.
+    """
+    if build_id is None:
+        note = b""
+    else:
+        note = struct.pack("<III", 4, len(build_id), 3) + b"GNU\x00" + build_id
+        note += b"\x00" * (-len(note) % 4)
+    phoff, note_off = 64, 120
+
+    ehdr = bytearray(64)
+    ehdr[0:4] = b"\x7fELF"
+    ehdr[4:7] = bytes((2, 1, 1))  # ELFCLASS64, little endian, version 1
+    struct.pack_into("<Q", ehdr, 0x20, phoff)  # e_phoff
+    struct.pack_into("<HH", ehdr, 0x36, 56, 1)  # e_phentsize, e_phnum
+
+    phdr = bytearray(56)
+    struct.pack_into("<I", phdr, 0, 4)  # p_type = PT_NOTE
+    struct.pack_into("<Q", phdr, 8, note_off)  # p_offset
+    struct.pack_into("<Q", phdr, 32, len(note))  # p_filesz
+
+    body = bytes(ehdr) + bytes(phdr)
+    return body.ljust(note_off, b"\x00") + note
+
+
+def test_elf_build_id_64_reads_the_gnu_build_id():
+    """``hid`` is the Build-ID's first 8 descriptor bytes, little-endian.
+
+    Pinned against a real ``.so``: ``readelf -n`` reports Build-ID
+    ``ac6a3768 91802e4a ...``, which the runtime turns into
+    ``0x4a2e809168376aac`` — the value that reaches the ``[STRACE]`` markers.
+    """
+    assert elf_build_id_64(_elf64_with_build_id(_REAL_BUILD_ID)) == _REAL_BUILD_ID_64
+
+
+def test_elf_build_id_64_falls_back_to_fnv1a():
+    """No Build-ID / not an ELF -> FNV-1a over the whole buffer, as the runtime does."""
+    not_elf = b"definitely not an ELF file"
+    assert elf_build_id_64(not_elf) == fnv1a_64(not_elf)
+    # Truncated input is degenerate, not an error.
+    assert elf_build_id_64(b"") == fnv1a_64(b"")
+    # Well-formed ELF whose note segment carries no Build-ID.
+    no_build_id = _elf64_with_build_id(None)
+    assert elf_build_id_64(no_build_id) == fnv1a_64(no_build_id)
+
+
+def test_callable_display_name_prefers_the_source_stem():
+    """The manifest's ``function_name`` cannot tell two callables apart.
+
+    Every generated ``ORCHESTRATION`` declares the same fixed AICPU entry symbol
+    (verified on a real v4-flash L3 build: both ``prefill_fwd`` and
+    ``lm_head_test`` carry ``function_name="aicpu_orchestration_entry"``), so the
+    per-program name has to come from the generated source file's stem.
+    """
+    dr = pytest.importorskip("pypto.runtime.device_runner")
+
+    entry = "aicpu_orchestration_entry"
+    assert (
+        dr.callable_display_name(
+            {
+                "source": "/b/_jit_l3/next_levels/prefill_fwd/orchestration/prefill_fwd.cpp",
+                "function_name": entry,
+            }
+        )
+        == "prefill_fwd"
+    )
+    assert (
+        dr.callable_display_name(
+            {
+                "source": "/b/_jit_l3/next_levels/lm_head_test/orchestration/lm_head_test.cpp",
+                "function_name": entry,
+            }
+        )
+        == "lm_head_test"
+    )
+    # No source in the manifest: fall back rather than losing the label entirely.
+    assert dr.callable_display_name({"function_name": entry}) == entry
+
+
+def test_register_callable_identity_maps_hid_to_name():
+    """``device_runner`` records hid -> orchestration name at assemble time."""
+    dr = pytest.importorskip("pypto.runtime.device_runner")
+
+    so = _elf64_with_build_id(_REAL_BUILD_ID)
+    hid = dr.register_callable_identity(so, "decode_orch")
+
+    assert hid == f"{_REAL_BUILD_ID_64:x}"  # marker wire format: lowercase hex
+    assert dr.callable_name(hid) == "decode_orch"
+    assert dr.callable_name(hid.upper()) == "decode_orch"  # lookup is case-insensitive
+    assert dr.callable_name("dead" * 4) is None  # never assembled here
+
+
+def test_dispatch_tasks_show_orchestration_names(span_root):
+    """A measured dispatch is labelled with its orchestration name, not the hash."""
+    dr = pytest.importorskip("pypto.runtime.device_runner")
+
+    hid = dr.register_callable_identity(_elf64_with_build_id(_REAL_BUILD_ID), "decode_orch")
+    lines = _launch_lines(0, span_root, host_us=1, device_us=4, pid=100, hid=hid)
+    lines += _launch_lines(1, span_root, host_us=1, device_us=6, pid=100, hid="feedface")
+
+    stats = _parse_stats_from_strace("\n".join(lines), rounds=1, warmup=0, distributed=True)
+
+    # Slot 0's hash resolves; slot 1 was never assembled here, so it stays raw.
+    assert stats.dispatch_tasks() == {(100, 0): "decode_orch", (100, 1): "feedface"}
+    dispatches = stats.rounds_dispatches[0][100]
+    assert dispatches[0].task == hid  # .task is still the wire identity
+    assert dispatches[0].task_name == "decode_orch"
+    assert dispatches[1].task_name == "feedface"
+
+    # Both the mean-tree group headers and the launch headers carry the name.
+    assert "dispatch pid=100 slot=0 task=decode_orch" in stats.format_mean_tree()
+    assert f"hid={hid} round=0 slot=0 task=decode_orch" in stats.format_tree()
+    # An unresolved hid is not annotated twice.
+    assert "task=feedface" not in stats.format_tree()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/ut/runtime/test_benchmark.py
+++ b/tests/ut/runtime/test_benchmark.py
@@ -461,6 +461,50 @@ def test_parse_l3_per_dispatch_keeps_a_ranks_dispatches_separate(span_root):
     assert [d.device_wall_us for d in groups[100, 1]] == [6.0, 7.0]
 
 
+def test_parse_l3_reordered_dispatches_disable_the_per_dispatch_views(span_root):
+    """A rank that swaps its dispatch order between rounds must not be grouped.
+
+    The dispatch *count* is constant (so the round boundaries hold), but rank 100
+    issues ``a, b`` in round 0 and ``b, a`` in round 1. Keying on the ordinal slot
+    would average two different callables together under round 0's label — the
+    fusing these views exist to remove — so the per-dispatch views report empty
+    while the order-independent per-rank sums stay valid.
+    """
+    lines: list[str] = []
+    # round 0: a(4us) then b(6us);  round 1: b(7us) then a(3us).
+    lines += _launch_lines(0, span_root, host_us=1, device_us=4, pid=100, hid="a")
+    lines += _launch_lines(1, span_root, host_us=1, device_us=6, pid=100, hid="b")
+    lines += _launch_lines(2, span_root, host_us=1, device_us=7, pid=100, hid="b")
+    lines += _launch_lines(3, span_root, host_us=1, device_us=3, pid=100, hid="a")
+
+    stats = _parse_stats_from_strace("\n".join(lines), rounds=2, warmup=0, distributed=True)
+
+    assert stats.fallback_flattened is False  # round segmentation is still sound
+    assert stats.unstable_dispatch_slots is True
+    assert stats.per_dispatch("device") == {}
+    assert stats.dispatch_groups() == {}
+    assert stats.dispatch_tasks() == {}
+    # Per-rank sums are order-independent, so they remain correct and populated.
+    assert stats.per_rank("device") == {100: [10.0, 10.0]}
+    assert stats.device_wall_us == [10.0, 10.0]
+    # The mean tree says why rather than blending the two callables into one tree.
+    tree = stats.format_mean_tree()
+    assert "per-dispatch view unavailable" in tree
+    assert "dispatch pid=" not in tree
+    assert stats.mean_invocation() is None
+    # __str__ drops its per-dispatch line rather than mislabelling the slots.
+    assert "per-dispatch" not in str(stats)
+
+
+def test_parse_l3_stable_slots_are_not_flagged(span_root):
+    """The same callables in the same order every round group as before."""
+    stats = _parse_stats_from_strace(
+        "\n".join(_l3_multi_dispatch_lines(span_root)), rounds=2, warmup=0, distributed=True
+    )
+    assert stats.unstable_dispatch_slots is False
+    assert set(stats.per_dispatch("device")) == {(100, 0), (100, 1), (101, 0)}
+
+
 def test_per_dispatch_host_metric_and_bad_metric(span_root):
     stats = _parse_stats_from_strace(
         "\n".join(_l3_multi_dispatch_lines(span_root)), rounds=2, warmup=0, distributed=True


### PR DESCRIPTION
## Summary

`BenchmarkStats` fused every dispatch a rank issued within a round, so a card
running several kernels per round could not be told apart:

- `per_rank` summed a rank's dispatches; the headline took the max of those sums
- `format_mean_tree` / `mean_invocation` averaged spans **by name across all
  invocations**, blending unrelated kernels into one meaningless tree

This adds an un-fused tier keyed by `(pid, slot)` — `slot` being a dispatch's
position within its rank's round. The round segmentation already guarantees a
constant dispatch count per rank per round, so slot `s` is the same dispatch in
every round and its cross-round series is meaningful.

- `per_dispatch(metric)` — one series per dispatch, nothing summed
- `dispatch_groups()` / `dispatch_tasks()` — the invocations and labels behind it
- `format_mean_tree()` renders **one tree per dispatch**, with `pid=` / `slot=`
  selectors; `mean_invocation()` now raises rather than silently blending them
- `format_tree()` launch headers carry `round=` / `slot=`; `__str__` gains a
  per-dispatch line only when a rank dispatches more than once

`per_rank` / `per_round` keep their summing semantics (a rank's round busy time)
and every previously stored field is unchanged, so existing consumers are
unaffected.

### Readable dispatch names

The `[STRACE]` markers identify a callable only by `hid` — the ELF Build-ID of
its orchestration `.so`. `elf_build_id_64` recomputes that host-side over the
same bytes handed to the runtime (mirroring the runtime's own helper), and
`compile_and_assemble` pairs it with the orchestration's generated name, so a
dispatch is labelled `prefill_fwd` rather than an opaque hash.

The name comes from the generated **source stem**, not
`ORCHESTRATION["function_name"]` — the latter is the fixed
`aicpu_orchestration_entry` symbol every program shares. Labels degrade to the
raw hash on `*sim` (whose host seeds `hid` with the callable id) or when the
callable was assembled in another process.

## Testing

- [x] Unit tests: 14 new cases covering the per-dispatch views, dispatch-grouped
      mean trees, Build-ID extraction (pinned against a real `.so`'s
      `readelf -n` value), the FNV-1a fallback, and the display-name derivation.
      `tests/ut/runtime` is green (534 passed).
- [x] On-device: 2-card v4-flash L3 prefill (which dispatches twice per rank per
      round). Slots split cleanly into `prefill_fwd` (~105 ms) and
      `lm_head_test` (~0.6 ms); each rank's slot sum matches its `per_rank`
      entry exactly; the breakdown exposes a 40% cross-card gap in the lm_head
      phase that the summed per-rank lines hid.
- [x] Lint: ruff, pyright, header / english-only / en-zh docs parity checks.
- [x] Documentation updated (`docs/en` and `docs/zh` getting-started).