### PR TITLE
fix(codegen): cast notify/wait scalar operands to i32 for PTOAS's AnySignlessInteger contract

### DIFF
--- a/src/backend/common/pto_ops_distributed.cpp
+++ b/src/backend/common/pto_ops_distributed.cpp
@@ -451,15 +451,20 @@ static std::string MakeNotifyCodegenPTO(const CallPtr& op, codegen::CodegenBase&
       binding.var->name_hint_ + "_peer", peer_view.ssa, peer_view.view_type_str, partition_type,
       GetIndexOffsetCodes(offsets_tuple->elements_, codegen), one_size_ssa, codegen);
 
-  // PTOAS contract: tnotify value's MLIR type must match the signal element
-  // type. Emit using the value's own ScalarType — mismatched IR-level dtypes
-  // surface here as a PTOAS verifier diagnostic rather than as silently
-  // garbled DMA.
+  // PTOAS's TNotifyOp declares `value` as AnySignlessInteger with an
+  // additional 32-bit-width verifier check (the comm ISA's signal slot is a
+  // fixed i32 register) — MLIR's IndexType does not satisfy that, so a
+  // pl.range loop induction variable (default dtype INDEX) used as `value`
+  // would otherwise reach PTOAS as `index` and fail to parse ("invalid kind
+  // of type specified"). Cast to i32 the same way pto_ops_datamove.cpp casts
+  // blockLen for its own "must be i32 per PTO ISA" operand; EmitCastToI32 is
+  // a no-op when the operand is already INT32.
   std::string value_ssa = codegen.GetExprAsCode(op->args_[3]);
   auto value_scalar = As<ir::ScalarType>(op->args_[3]->GetType());
   CHECK(value_scalar) << "pld.system.notify value must have ScalarType, got "
                       << op->args_[3]->GetType()->TypeName();
-  std::string value_type = codegen.GetTypeString(value_scalar->dtype_);
+  value_ssa = codegen.EmitCastToI32(op->args_[3], value_ssa);
+  std::string value_type = codegen.GetTypeString(DataType::INT32);
   // A notify publishes completion to a peer. Drain every local pipeline first
   // so the peer cannot observe the signal before preceding VEC work or GM
   // accesses are complete. PTOAS's TNOTIFY lowering only drains MTE2/MTE3,
@@ -514,14 +519,18 @@ static std::string MakeWaitCodegenPTO(const CallPtr& op, codegen::CodegenBase& c
       EmitPartitionViewPTO(signal_var->name_hint_ + "_local", local_view, local_view_type, partition_type,
                            GetIndexOffsetCodes(offsets_tuple->elements_, codegen), one_size_ssa, codegen);
 
-  // PTOAS contract: twait expected value's MLIR type must match the signal
-  // element type. Emit using the expected value's own ScalarType — see notify
-  // codegen above for the rationale.
+  // PTOAS's TWaitOp declares `cmpValue` as AnySignlessInteger with an
+  // additional 32-bit-width verifier check — see notify codegen above for
+  // the full rationale. Cast to i32 so a pl.range loop induction variable
+  // (default dtype INDEX, e.g. `expected=step + 1`) doesn't reach PTOAS as
+  // `index` and fail with "invalid kind of type specified". EmitCastToI32
+  // is a no-op when the operand is already INT32.
   std::string expected_ssa = codegen.GetExprAsCode(op->args_[2]);
   auto expected_scalar = As<ir::ScalarType>(op->args_[2]->GetType());
   CHECK(expected_scalar) << "pld.system.wait expected must have ScalarType, got "
                          << op->args_[2]->GetType()->TypeName();
-  std::string expected_type = codegen.GetTypeString(expected_scalar->dtype_);
+  expected_ssa = codegen.EmitCastToI32(op->args_[2], expected_ssa);
+  std::string expected_type = codegen.GetTypeString(DataType::INT32);
   std::ostringstream twait;
   twait << "pto.comm.twait(" << partition_view << ", " << expected_ssa << " : " << partition_type << ", "
         << expected_type << ") {cmp = #pto<wait_cmp " << cmp_attr << ">}";

--- a/tests/ut/codegen/distributed/test_distributed_pto_codegen.py
+++ b/tests/ut/codegen/distributed/test_distributed_pto_codegen.py
@@ -904,6 +904,60 @@ def test_notify_value_type_matches_value_ir_dtype():
     assert "!pto.partition_tensor_view<1x1xi32>" in tnotify_line
 
 
+def test_wait_casts_loop_induction_expected_to_i32():
+    """A pl.range loop induction variable used as ``expected`` is cast to i32.
+
+    ``pl.range``'s induction variable defaults to DataType.INDEX; arithmetic
+    on it (``step + 1``) stays INDEX. PTOAS's TWaitOp declares ``cmpValue``
+    as AnySignlessInteger with a 32-bit-width verifier check, so an
+    uncast ``index`` operand fails to parse ("invalid kind of type
+    specified"). Regression for issue #2222.
+    """
+
+    @pl.program
+    class P:
+        @pl.function(type=pl.FunctionType.InCore)
+        def kernel(
+            self,
+            signal: pld.DistributedTensor[[16, 16], pl.INT32],
+        ):
+            for step in pl.range(4):
+                pld.system.wait(signal, offsets=[0, 0], expected=step + 1, cmp=pld.WaitCmp.Ge)
+
+    mlir = _generate_mlir(P)
+    twait_line = next(line for line in mlir.splitlines() if "pto.comm.twait(" in line)
+    assert twait_line.rstrip().endswith("i32) {cmp = #pto<wait_cmp ge>}"), twait_line
+    body = mlir.split("func.func @kernel", 1)[1]
+    assert "arith.index_cast" in body and "to i32" in body, body
+
+
+def test_notify_casts_loop_induction_value_to_i32():
+    """A pl.range loop induction variable used as ``value`` is cast to i32.
+
+    Same root cause as ``test_wait_casts_loop_induction_expected_to_i32``,
+    for TNotifyOp's ``value`` operand. Regression for issue #2222.
+    """
+
+    @pl.program
+    class P:
+        @pl.function(type=pl.FunctionType.InCore)
+        def kernel(
+            self,
+            signal: pld.DistributedTensor[[16, 16], pl.INT32],
+            peer: pl.Scalar[pl.INT32],
+        ):
+            for step in pl.range(4):
+                pld.system.notify(
+                    signal, peer=peer, offsets=[0, 0], value=step + 1, op=pld.NotifyOp.Set
+                )
+
+    mlir = _generate_mlir(P)
+    tnotify_line = next(line for line in mlir.splitlines() if "pto.comm.tnotify(" in line)
+    assert tnotify_line.rstrip().endswith("i32) {notifyOp = #pto<notify_op set>}"), tnotify_line
+    body = mlir.split("func.func @kernel", 1)[1]
+    assert "arith.index_cast" in body and "to i32" in body, body
+
+
 def test_get_comm_ctx_emits_no_mlir_aliases_ctx_arg():
     """``pld.system.get_comm_ctx(dist_t)`` is a pure SSA alias.
 

--- a/tests/ut/codegen/distributed/test_distributed_pto_codegen.py
+++ b/tests/ut/codegen/distributed/test_distributed_pto_codegen.py
@@ -947,9 +947,7 @@ def test_notify_casts_loop_induction_value_to_i32():
             peer: pl.Scalar[pl.INT32],
         ):
             for step in pl.range(4):
-                pld.system.notify(
-                    signal, peer=peer, offsets=[0, 0], value=step + 1, op=pld.NotifyOp.Set
-                )
+                pld.system.notify(signal, peer=peer, offsets=[0, 0], value=step + 1, op=pld.NotifyOp.Set)
 
     mlir = _generate_mlir(P)
     tnotify_line = next(line for line in mlir.splitlines() if "pto.comm.tnotify(" in line)


### PR DESCRIPTION
## Summary

Fixes #2222.

`pld.system.notify`'s `value` and `pld.system.wait`'s `expected` were emitted using the operand's own natural IR dtype, with no coercion. A `pl.range` loop induction variable defaults to `DataType::INDEX`, and arithmetic on it (`step + 1`) stays `INDEX` — `_normalize_expr`'s INT32 default only applies to bare Python `int` literals, not to already-constructed `ir.Expr` values, so nothing along the DSL → IR path corrects this. The result: the reusable epoch-barrier idiom (`expected=step + 1, cmp=Ge` inside a loop) compiles cleanly through pypto's entire pipeline, then fails only when PTOAS parses the emitted `.pto` text:

```
custom op 'pto.comm.twait' invalid kind of type specified
```

Root cause, traced from both ends of the pypto/PTOAS boundary:

- **pypto codegen** (`src/backend/common/pto_ops_distributed.cpp`): `MakeNotifyCodegenPTO`/`MakeWaitCodegenPTO` emitted `codegen.GetTypeString(scalar->dtype_)` verbatim — `INDEX → "index"`, `INT32 → "i32"`. Whether the emitted MLIR type was `index` or `i32` was pure luck of which dtype the operand happened to carry, not a deliberate contract.
- **PTOAS** (`PTOAS/include/PTO/IR/PTOOps.td`, `TNotifyOp`/`TWaitOp`): both declare this operand `AnySignlessInteger`, with a verifier additionally requiring exactly 32-bit width — MLIR's `IndexType` is not an `IntegerType`, so PTOAS's generated parser correctly rejects `index`. This is a documented, deliberate hardware contract (the comm ISA's compare/signal register is a fixed 32-bit value) — not a PTOAS bug, and should not be relaxed there.

**This is a pypto codegen gap, fixed entirely within pypto.** pypto already has the right tool for this, used today for the identical "must be i32 per PTO ISA" contract on `blockLen` in `pto_ops_datamove.cpp:817`: `PTOCodegen::EmitCastToI32` (casts via `arith.index_cast`/`arith.trunci`/`arith.extui`/`arith.extsi` as needed, and is a no-op if the operand is already `INT32`). This PR calls it from `MakeNotifyCodegenPTO`/`MakeWaitCodegenPTO` too, and updates the type annotation emitted alongside the operand to match (`DataType::INT32` instead of the operand's original dtype).

`TTestOp` (`pto.comm.ttest`) has the identical `AnySignlessInteger` constraint in PTOAS but pypto never emits it — nothing to fix there.

## Testing

- Added two regression tests in `tests/ut/codegen/distributed/test_distributed_pto_codegen.py`, mirroring the exact `pl.range` reproducer from #2222, one for `wait` and one for `notify`. Both assert the emitted MLIR casts the operand to i32 (`arith.index_cast ... to i32`) and that the `pto.comm.twait`/`pto.comm.tnotify` line's trailing type annotation is `i32`.
- Full local run of `tests/ut/codegen/distributed/test_distributed_pto_codegen.py`: 43/43 passed (41 pre-existing + 2 new).
- Full local run of `tests/ut`: 8272 passed, 41 skipped, 1 failed — the 1 failure (`test_installed_console_script_preserves_main_exit_codes`) is unrelated: it requires a `pip install -e .`-created console-script entry point that my ad-hoc CMake-only build doesn't produce, and reproduces identically on `origin/main` with no changes applied.
- `tests/st/codegen --codegen-only`: 35 passed, 4 failed — 2 failures are `PermissionError` on cleanup of pre-existing root-owned leftover directories from unrelated prior sessions on this shared machine; the other 2 are numeric-tolerance failures in `test_torch_codegen_paged_attention.py`, which contains zero distributed-op usage (`grep -c "pld\.\|distributed"` → 0) and is unaffected by this change. All 4 reproduce identically on `origin/main`.
- `clang-tidy` (scoped to the changed file via `--diff-base HEAD`): clean, no diagnostics.
- `tests/st/distributed` (the L3 runtime-execution suite) requires the separate `simpler` C++/nanobind runtime package built and installed, which is out of scope here — this fix is purely about emitted MLIR text (codegen), not runtime dispatch.

**Not verified on real NPU hardware.** Per this repo's own tooling, on-hardware verification (`host_collectives_st_npu`) is explicitly a maintainer/developer-only step, not something to attempt without hardware access. Recommend re-running the exact epoch-barrier-in-a-loop reproducer from #2222 on real `a2a3` hardware before merge.
