### PR TITLE
refactor(ir): Collapse InCoreScopeStmt::split_ to a single "no split" encoding

### DIFF
--- a/docs/en/dev/ir/01-hierarchy.md
+++ b/docs/en/dev/ir/01-hierarchy.md
@@ -203,7 +203,7 @@ field from the `Stmt` base class. See [Leading comments on statements](#leading-
 | **IfStmt** | `condition_`, `then_stmts_`, `else_stmts_`, `return_vars_` | Conditional branching |
 | **ForStmt** | `loop_var_` (DefField), `start_`, `stop_`, `step_`, `iter_args_` (DefField), `body_`, `return_vars_` (DefField), `kind_` | For loop with optional iteration args |
 | **WhileStmt** | `condition_`, `iter_args_` (DefField), `body_`, `return_vars_` (DefField) | While loop with condition and iteration args |
-| **InCoreScopeStmt** | `name_hint_`, `body_`, `split_` (optional) | InCore region; outlined to `Function(InCore)` |
+| **InCoreScopeStmt** | `name_hint_`, `body_`, `split_` (`SplitMode`, `None` = no split) | InCore region; outlined to `Function(InCore)` |
 | **ClusterScopeStmt** | `name_hint_`, `body_` | Cluster region; outlined to `Function(Group)` |
 | **HierarchyScopeStmt** | `name_hint_`, `body_`, `level_`, `role_` (optional) | Pipeline-stage region for a given Level/Role |
 | **SpmdScopeStmt** | `name_hint_`, `body_`, `core_num_` (integer-typed `Expr`), `sync_start_` | SPMD launch region; outlined to `Function(Spmd)` |

--- a/docs/en/dev/passes/08-outline_incore_scopes.md
+++ b/docs/en/dev/passes/08-outline_incore_scopes.md
@@ -200,11 +200,10 @@ passes.def("outline_incore_scopes", &pass::OutlineIncoreScopes, "Outline InCore 
 **Mutually exclusive AIV-split mechanisms**: a function-level AUTO split
 (`optimizations=[pl.split(mode)]`, carried as the scope's own `split_`) and
 explicit `pl.split_aiv` regions (`SplitAivScopeStmt`) cannot coexist on one
-scope. This pass rejects the combination (it bridges a single region's mode into
-a function-level representative `split`, which would silently collide with the
-user's `pl.split`). See
-[`LowerAutoVectorSplit`](19-lower_auto_vector_split.md) for how the surviving
-mechanism is lowered.
+scope (the outliner bridges a single region's mode into a function-level
+representative `split`, which would silently collide with the user's
+`pl.split`). See [`LowerAutoVectorSplit`](19-lower_auto_vector_split.md) for how
+the surviving mechanism is lowered.
 
 **Any** `pl.split(...)` is rejected, `SplitMode.NONE` included (RFC #1820). NONE
 carries no split of its own, but writing it on a scope that also holds regions
@@ -212,7 +211,17 @@ still reads as "auto and manual split mixed on one scope". The exemption that
 used to allow it existed only because the cross-core slot count had no carrier
 other than `pl.split(..., slot_num=N)`; it now has one —
 `optimizations=[pl.cross_core_slot(slot_num=N)]`, which is orthogonal to
-splitting and coexists with regions freely. The three states read distinctly:
+splitting and coexists with regions freely.
+
+**Where the rejection fires.** `InCoreScopeStmt::split_` has a single encoding of
+"no split" (`SplitMode::None`), so a literal `pl.split(pl.SplitMode.NONE)` is
+invisible to this pass — it looks identical to writing no `pl.split` at all. The
+**parser** therefore owns the rejection: it is the only layer that sees the
+literal the user wrote, and it rejects every mode, NONE included. This pass keeps
+the check for `split_ != SplitMode::None` as the backstop for IR that never went
+through the parser (deserialized `.pto`, programmatically built scopes).
+
+The three states read distinctly:
 
 | Annotation | Meaning |
 | ---------- | ------- |

--- a/docs/zh/dev/ir/01-hierarchy.md
+++ b/docs/zh/dev/ir/01-hierarchy.md
@@ -197,7 +197,7 @@ for_stmt = ir.ForStmt(i, start, stop, step, [sum_iter], body, [sum_final], span)
 | **IfStmt** | `condition_`, `then_stmts_`, `else_stmts_`, `return_vars_` | 条件分支 |
 | **ForStmt** | `loop_var_` (DefField), `start_`, `stop_`, `step_`, `iter_args_` (DefField), `body_`, `return_vars_` (DefField), `kind_` | 带可选迭代参数的 for 循环 |
 | **WhileStmt** | `condition_`, `iter_args_` (DefField), `body_`, `return_vars_` (DefField) | 带条件和迭代参数的 while 循环 |
-| **InCoreScopeStmt** | `name_hint_`, `body_`, `split_`（可选） | InCore 区域；由 `OutlineIncoreScopes` 提取为 `Function(InCore)` |
+| **InCoreScopeStmt** | `name_hint_`, `body_`, `split_`（`SplitMode`，`None` 表示不切分） | InCore 区域；由 `OutlineIncoreScopes` 提取为 `Function(InCore)` |
 | **ClusterScopeStmt** | `name_hint_`, `body_` | Cluster 区域；由 `OutlineClusterScopes` 提取为 `Function(Group)` |
 | **HierarchyScopeStmt** | `name_hint_`, `body_`, `level_`, `role_`（可选） | 给定 Level/Role 的流水线阶段区域 |
 | **SpmdScopeStmt** | `name_hint_`, `body_`, `core_num_`（整型 `Expr`）, `sync_start_` | SPMD 启动区域；提取为 `Function(Spmd)` |

--- a/docs/zh/dev/passes/08-outline_incore_scopes.md
+++ b/docs/zh/dev/passes/08-outline_incore_scopes.md
@@ -194,7 +194,7 @@ passes.def("outline_incore_scopes", &pass::OutlineIncoreScopes, "Outline InCore 
 
 **互斥的 AIV 拆分机制**：函数级 AUTO split（`optimizations=[pl.split(mode)]`，
 承载于作用域自身的 `split_`）与显式 `pl.split_aiv` 区域（`SplitAivScopeStmt`）不能在同一
-作用域共存。本 Pass 会拒绝该组合（它会把单个区域的模式桥接为函数级代表 `split`，从而与用户的
+作用域共存（outliner 会把单个区域的模式桥接为函数级代表 `split`，从而与用户的
 `pl.split` 静默冲突）。幸存机制如何下降见
 [`LowerAutoVectorSplit`](19-lower_auto_vector_split.md)。
 
@@ -202,7 +202,15 @@ passes.def("outline_incore_scopes", &pass::OutlineIncoreScopes, "Outline InCore 
 携带拆分，但把它写在同时持有区域的作用域上，读起来仍像"在一个作用域里混用了自动与手动
 拆分"。此前之所以对它豁免，只是因为跨核槽位数除了 `pl.split(..., slot_num=N)` 之外没有
 别的承载方式；现在它有了自己的条目——`optimizations=[pl.cross_core_slot(slot_num=N)]`，
-与拆分正交，可自由地与区域共存。三种标注由此语义分明：
+与拆分正交，可自由地与区域共存。
+
+**拒绝发生在哪一层**：`InCoreScopeStmt::split_` 对"不切分"只有一种编码
+（`SplitMode::None`），因此字面写出的 `pl.split(pl.SplitMode.NONE)` 对本 Pass 不可见
+——它与完全不写 `pl.split` 无法区分。于是该拒绝由 **parser** 负责：只有它能看到用户写下的
+字面量，且它会拒绝所有模式（含 NONE）。本 Pass 保留 `split_ != SplitMode::None` 的检查，
+作为未经 parser 的 IR（反序列化的 `.pto`、以编程方式构造的作用域）的兜底。
+
+三种标注由此语义分明：
 
 | 标注 | 含义 |
 | ---- | ---- |

--- a/include/pypto/ir/stmt.h
+++ b/include/pypto/ir/stmt.h
@@ -595,7 +595,7 @@ using WhileStmtPtr = std::shared_ptr<const WhileStmt>;
  *
  * **Class hierarchy** (issue #1047):
  * - `ScopeStmt` (abstract): common fields `name_hint_`, `body_`
- *   - `InCoreScopeStmt`: optional `split_`
+ *   - `InCoreScopeStmt`: required `split_` (`SplitMode::None` = no split)
  *   - `ClusterScopeStmt`: no extra fields
  *   - `HierarchyScopeStmt`: required `level_`, optional `role_`
  *   - `SpmdScopeStmt`: required `core_num_`, `sync_start_` (default false)
@@ -678,11 +678,21 @@ using ScopeStmtPtr = std::shared_ptr<const ScopeStmt>;
 /**
  * @brief InCore scope: AICore sub-graph region.
  *
- * Carries an optional `split` for cross-core transfer mode.
+ * Carries the cross-core transfer `split` mode. `SplitMode::None` — the default —
+ * is the single encoding of "no split"; there is no second, `nullopt` spelling
+ * (issue #2205). Two encodings of one semantic state broke print -> parse:
+ * the printer collapsed them (both emit no `optimizations=` entry) while
+ * structural equality kept them apart.
+ *
+ * Whether the user *literally wrote* `optimizations=[pl.split(pl.SplitMode.NONE)]`
+ * is a property of the source text, not of the IR, so it is checked where it is
+ * visible — the parser, which rejects it on a scope that also holds
+ * `pl.split_aiv` region(s). `OutlineIncoreScopes` keeps the same rejection for
+ * the modes that survive into the IR (`split_ != SplitMode::None`).
  */
 class InCoreScopeStmt : public ScopeStmt {
  public:
-  InCoreScopeStmt(std::optional<SplitMode> split, std::string name_hint, StmtPtr body, Span span,
+  InCoreScopeStmt(SplitMode split, std::string name_hint, StmtPtr body, Span span,
                   std::vector<std::string> leading_comments = {},
                   std::vector<std::pair<std::string, std::any>> attrs = {})
       : ScopeStmt(std::move(name_hint), std::move(body), std::move(span), std::move(leading_comments),
@@ -699,7 +709,7 @@ class InCoreScopeStmt : public ScopeStmt {
   }
 
  public:
-  std::optional<SplitMode> split_;  // Split mode (nullopt or None for no split)
+  SplitMode split_;  ///< Cross-core transfer split mode; None = no split
 };
 
 using InCoreScopeStmtPtr = std::shared_ptr<const InCoreScopeStmt>;

--- a/include/pypto/ir/transforms/utils/scope_outline_utils.h
+++ b/include/pypto/ir/transforms/utils/scope_outline_utils.h
@@ -874,9 +874,9 @@ class ScopeOutliner : public IRMutator {
 
     // Register the outlined function (propagate level/role from ScopeStmt, convert split/core_num to attrs)
     std::vector<std::pair<std::string, std::any>> outlined_attrs;
-    auto append_split_attr = [&](std::optional<SplitMode> split) {
-      if (split.has_value() && split.value() != SplitMode::None) {
-        outlined_attrs.emplace_back("split", static_cast<int>(split.value()));
+    auto append_split_attr = [&](SplitMode split) {
+      if (split != SplitMode::None) {
+        outlined_attrs.emplace_back("split", static_cast<int>(split));
       }
     };
     // Propagate the optional cross-core ring depth (pl.split(mode, slot_num=N))
@@ -903,7 +903,7 @@ class ScopeOutliner : public IRMutator {
     // carries no AUTO cross-core transfer split (``incore->split_``), which has
     // a separate meaning. The authoritative per-region mode is ``node->split_``
     // (consumed at pass 21).
-    auto append_split_aiv_attr = [&](std::optional<SplitMode> incore_split) {
+    auto append_split_aiv_attr = [&](SplitMode incore_split) {
       SplitAivModeSummaryFinder finder;
       finder.VisitStmt(op->body_);
       if (!finder.found) return;
@@ -916,12 +916,15 @@ class ScopeOutliner : public IRMutator {
       // indistinguishably into the function's split / split_aiv attrs (a single
       // pl.split_aiv region legitimately yields a derived function-level split).
       //
-      // ANY pl.split(...) is rejected, SplitMode::None included (RFC #1820).
-      // NONE carries no split of its own, but writing it here still reads as
-      // "auto and manual split mixed on one scope". The cross-core slot count
-      // that used to force the NONE spelling now has its own orthogonal entry,
-      // pl.cross_core_slot(slot_num=N), so nothing needs the exemption.
-      CHECK_SPAN(!incore_split.has_value(), op->span_)
+      // RFC #1820 additionally rejects a literal `pl.split(pl.SplitMode.NONE)`
+      // here: it carries no split of its own, but writing it still reads as "auto
+      // and manual split mixed on one scope". That spelling is invisible to this
+      // pass since #2205 collapsed InCoreScopeStmt's two encodings of "no split"
+      // into `SplitMode::None`, so the parser rejects it instead — where the
+      // literal is still visible (see `_reject_user_split_with_split_aiv_region`).
+      // This check remains the backstop for IR that never went through the parser
+      // (deserialized `.pto`, programmatically built scopes).
+      CHECK_SPAN(incore_split == SplitMode::None, op->span_)
           << "scope combines a function-level pl.split(...) (optimizations=[pl.split(...)]) with "
              "pl.split_aiv region(s); these are mutually exclusive AIV-split mechanisms. Remove "
              "optimizations=[pl.split(...)] or the pl.split_aiv region(s) — the function-level "
@@ -933,7 +936,7 @@ class ScopeOutliner : public IRMutator {
       // share one mode (``uniform_mode``). Differing sibling modes have no single
       // representative: leave the function-level mode unset — the authoritative
       // per-region mode rides ``node->split_`` (consumed at pass 21). No need to
-      // re-check incore_split here: the CHECK above guarantees it is unset.
+      // re-check incore_split here: the CHECK above guarantees it is None.
       if (finder.uniform_mode.has_value()) {
         outlined_attrs.emplace_back("split", static_cast<int>(finder.uniform_mode.value()));
       }

--- a/python/bindings/modules/ir.cpp
+++ b/python/bindings/modules/ir.cpp
@@ -1391,10 +1391,12 @@ void BindIR(nb::module_& m) {
       scope_attrs_doc);
 
   // InCoreScopeStmt
-  auto in_core_scope_stmt_class =
-      nb::class_<InCoreScopeStmt, ScopeStmt>(ir, "InCoreScopeStmt", "InCore scope: AICore sub-graph region");
-  in_core_scope_stmt_class.def(nb::init<std::optional<SplitMode>, std::string, const StmtPtr&, const Span&>(),
-                               nb::arg("split") = nb::none(), nb::arg("name_hint") = "", nb::arg("body"),
+  auto in_core_scope_stmt_class = nb::class_<InCoreScopeStmt, ScopeStmt>(
+      ir, "InCoreScopeStmt",
+      "InCore scope: AICore sub-graph region. split=SplitMode.NONE (the default) is "
+      "the single encoding of 'no split'.");
+  in_core_scope_stmt_class.def(nb::init<SplitMode, std::string, const StmtPtr&, const Span&>(),
+                               nb::arg("split") = SplitMode::None, nb::arg("name_hint") = "", nb::arg("body"),
                                nb::arg("span"), "Create an InCore scope statement");
   BindFields<InCoreScopeStmt>(in_core_scope_stmt_class);
   in_core_scope_stmt_class.def_prop_ro(

--- a/python/pypto/ir/builder.py
+++ b/python/pypto/ir/builder.py
@@ -259,7 +259,10 @@ class IRBuilder:
             span: Optional explicit span. If None, automatically captured.
             level: Hierarchy level (for ScopeKind.Hierarchy)
             role: Function role (for ScopeKind.Hierarchy)
-            split: Split mode for cross-core transfer (for InCore scopes)
+            split: Split mode. Required for ScopeKind.SplitAiv. For ScopeKind.InCore
+                it is the cross-core transfer mode, and omitting it is equivalent to
+                passing ``ir.SplitMode.NONE`` — the node has a single encoding of
+                "no split".
             name_hint: User-provided scope name hint (empty = auto-generate)
             core_num: SPMD block count for ScopeKind.Spmd scopes. Accepts a
                 Python ``int`` (auto-wrapped as ``ir.ConstInt``) or any

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -585,6 +585,15 @@ class ASTParser:
         # Track loop kinds for break/continue validation
         self._loop_kind_stack: list[str] = []
         self._scope_kind_stack: list[ir.ScopeKind] = []
+        # Set while parsing the body of an InCore scope the user declared with an
+        # explicit ``optimizations=[pl.split(MODE)]`` — MODE included when it is
+        # ``NONE``. ``InCoreScopeStmt.split_`` cannot answer this: it has a single
+        # encoding of "no split" (``SplitMode.NONE``), so a literal
+        # ``pl.split(pl.SplitMode.NONE)`` is indistinguishable there from writing
+        # no ``pl.split`` at all (issue #2205). The literal is only visible here,
+        # which is where the RFC #1820 mutual-exclusion rejection now lives.
+        # InCore scopes never nest (NoNestedInCore), so one slot suffices.
+        self._incore_user_split: ir.SplitMode | None = None
         # Active ``pl.split_aiv(mode=...)`` modes (innermost last). ``pl.aiv_shard`` /
         # ``pl.aic_gather`` inherit the split mode from this stack rather than
         # taking it as an argument.
@@ -712,6 +721,61 @@ class ASTParser:
     def _is_inside_scope(self, scope_kind: ir.ScopeKind) -> bool:
         """Return whether parsing is currently nested inside the given scope kind."""
         return scope_kind in self._scope_kind_stack
+
+    @contextmanager
+    def _incore_user_split_context(
+        self, scope_kind: "ir.ScopeKind", split_mode: "ir.SplitMode | None"
+    ) -> Iterator[None]:
+        """Record the enclosing InCore scope's *literal* ``pl.split(MODE)`` entry.
+
+        ``split_mode`` is the parsed ``optimizations=[pl.split(MODE)]`` entry, or
+        ``None`` when the user wrote no ``pl.split`` at all. Only the parser can
+        tell the two apart once ``MODE`` is ``NONE`` — see
+        :meth:`_reject_user_split_with_split_aiv_region`.
+
+        A no-op for every other scope kind: ``optimizations=[pl.split(...)]`` only
+        lowers onto an InCore scope, so another kind must neither set nor clear the
+        record of an enclosing one.
+        """
+        if scope_kind != ir.ScopeKind.InCore:
+            yield
+            return
+        previous = self._incore_user_split
+        self._incore_user_split = split_mode
+        try:
+            yield
+        finally:
+            self._incore_user_split = previous
+
+    def _reject_user_split_with_split_aiv_region(self, stmt: ast.For, hint: str) -> None:
+        """Reject ``pl.split_aiv`` inside an InCore scope declaring ``pl.split(...)``.
+
+        A function-level AUTO split (``optimizations=[pl.split(MODE)]``) and
+        explicit ``pl.split_aiv`` regions are mutually exclusive AIV-split
+        mechanisms: downstream lowering takes the per-region path and would
+        silently drop the function-level split. **Any** ``pl.split(...)`` is
+        rejected, ``pl.SplitMode.NONE`` included (RFC #1820) — NONE carries no
+        split of its own, but writing it still reads as "auto and manual split
+        mixed on one scope", and the cross-core slot count that once forced the
+        NONE spelling now has its own orthogonal ``pl.cross_core_slot(slot_num=N)``
+        entry.
+
+        ``OutlineIncoreScopes`` keeps the same rejection for the modes that reach
+        the IR, and remains the backstop for scopes that never went through this
+        parser. It cannot see a literal ``NONE``, so that spelling is caught here.
+        """
+        if self._incore_user_split is None:
+            return
+        raise ParserSyntaxError(
+            f"scope combines a function-level pl.split(pl.SplitMode.{self._incore_user_split.name}) "
+            "(optimizations=[pl.split(...)]) with a pl.split_aiv region; these are mutually "
+            "exclusive AIV-split mechanisms — the function-level split would be silently "
+            "dropped (the per-region split governs the lanes)",
+            span=self.span_tracker.get_span(stmt),
+            hint="Remove optimizations=[pl.split(...)] or the pl.split_aiv region. To pin a "
+            "custom cross-core slot count, use optimizations=[pl.cross_core_slot(slot_num=N)], "
+            f"which is orthogonal to splitting. {hint}",
+        )
 
     @contextmanager
     def _split_aiv_mode_context(self, mode: ir.SplitMode) -> Iterator[None]:
@@ -4169,7 +4233,10 @@ class ASTParser:
                     name_hint=incore_name_hint,
                     attrs=incore_attrs,
                 ):
-                    with self._scope_kind_context(ir.ScopeKind.InCore):
+                    with (
+                        self._scope_kind_context(ir.ScopeKind.InCore),
+                        self._incore_user_split_context(ir.ScopeKind.InCore, split_mode),
+                    ):
                         self.scope_manager.enter_scope("spmd_with_incore")
                         self._parse_body_siblings(stmt.body)
                         self._discard_tail_block_comments(stmt.body, upper_line=stmt.end_lineno)
@@ -4502,7 +4569,10 @@ class ASTParser:
                     name_hint=incore_name_hint,
                     attrs=incore_attrs,
                 ):
-                    with self._scope_kind_context(ir.ScopeKind.InCore):
+                    with (
+                        self._scope_kind_context(ir.ScopeKind.InCore),
+                        self._incore_user_split_context(ir.ScopeKind.InCore, split_mode),
+                    ):
                         # Bind `i = pl.tile.get_block_idx()` as the first
                         # statement of the outlined InCore body.
                         loop_var = self.builder.var(loop_var_name, ir.ScalarType(DataType.INDEX), span=span)
@@ -4548,6 +4618,10 @@ class ASTParser:
                 span=self.span_tracker.get_span(stmt),
                 hint=split_aiv_hint,
             )
+        # Placement check, like the nested-region one above: an enclosing InCore
+        # scope that declares its own optimizations=[pl.split(...)] already picked
+        # the AUTO split mechanism, which this region would silently override.
+        self._reject_user_split_with_split_aiv_region(stmt, split_aiv_hint)
         if not isinstance(stmt.target, ast.Name):
             raise ParserSyntaxError(
                 "for ... in pl.split_aiv(...) must use a single loop variable",
@@ -4751,7 +4825,10 @@ class ASTParser:
             manual=manual,
             attrs=attrs,
         ):
-            with self._scope_kind_context(scope_kind):
+            with (
+                self._scope_kind_context(scope_kind),
+                self._incore_user_split_context(scope_kind, split),
+            ):
                 self.scope_manager.enter_scope("scope")
                 self._parse_body_siblings(stmt.body)
                 self._discard_tail_block_comments(stmt.body, upper_line=stmt.end_lineno)

--- a/python/pypto/pypto_core/ir.pyi
+++ b/python/pypto/pypto_core/ir.pyi
@@ -2294,12 +2294,12 @@ class ScopeStmt(Stmt):
 class InCoreScopeStmt(ScopeStmt):
     """InCore scope: AICore sub-graph region."""
 
-    split: Final[SplitMode | None]
-    """Split mode for cross-core transfer (None or SplitMode.None for no split)."""
+    split: Final[SplitMode]
+    """Split mode for cross-core transfer (SplitMode.NONE = no split)."""
 
     def __init__(
         self,
-        split: SplitMode | None = None,
+        split: SplitMode = SplitMode.NONE,
         name_hint: str = "",
         *,
         body: Stmt,

--- a/src/ir/builder.cpp
+++ b/src/ir/builder.cpp
@@ -338,7 +338,10 @@ StmtPtr IRBuilder::EndScope(const Span& end_span) {
   ScopeStmtPtr scope_stmt;
   switch (scope_kind) {
     case ScopeKind::InCore:
-      scope_stmt = std::make_shared<const InCoreScopeStmt>(split, std::move(name_hint), body, combined_span,
+      // The builder's ``split`` is optional only in the "caller did not pass one"
+      // sense; the node itself has a single encoding of "no split" (issue #2205).
+      scope_stmt = std::make_shared<const InCoreScopeStmt>(split.value_or(SplitMode::None),
+                                                           std::move(name_hint), body, combined_span,
                                                            std::vector<std::string>{}, std::move(attrs));
       break;
     case ScopeKind::Cluster:

--- a/src/ir/serialization/type_deserializers.cpp
+++ b/src/ir/serialization/type_deserializers.cpp
@@ -789,7 +789,9 @@ static std::vector<std::pair<std::string, std::any>> DeserializeScopeAttrs(const
 static IRNodePtr DeserializeInCoreScopeStmt(const msgpack::object& fields_obj, msgpack::zone& zone,
                                             DeserializerContext& ctx) {
   auto span = ctx.DeserializeSpan(GET_FIELD_OBJ("span"));
-  auto split = DeserializeScopeSplit(fields_obj, ctx);
+  // A ``.pto`` written before issue #2205 may carry ``split: nil`` for "no split";
+  // it maps onto the single surviving encoding, ``SplitMode::None``.
+  auto split = DeserializeScopeSplit(fields_obj, ctx).value_or(SplitMode::None);
   auto name_hint = DeserializeScopeNameHint(fields_obj, ctx);
   auto body = std::static_pointer_cast<const Stmt>(ctx.DeserializeNode(GET_FIELD_OBJ("body"), zone));
   return std::make_shared<InCoreScopeStmt>(split, std::move(name_hint), body, span,

--- a/src/ir/transforms/python_printer.cpp
+++ b/src/ir/transforms/python_printer.cpp
@@ -99,7 +99,7 @@ class BlockIdxReadDetector : public IRVisitor {
 /// drops it.
 bool SpmdInlineBodyRebuildsCarrier(const InCoreScopeStmtPtr& incore) {
   if (!incore) return false;
-  const bool has_mode = incore->split_.has_value() && incore->split_.value() != SplitMode::None;
+  const bool has_mode = incore->split_ != SplitMode::None;
   if (has_mode || incore->HasAttr("slot_num")) return true;
   BlockIdxReadDetector detector;
   detector.VisitStmt(incore->body_);
@@ -422,7 +422,7 @@ class IRPythonPrinter : public IRVisitor {
   // holding pl.split_aiv regions). Emits nothing when the scope carries
   // neither. Used by the flattened spmd with-tid / for-loop forms; the
   // nested-scope forms round-trip via the InCoreScopeStmt printer.
-  void PrintScopeOptimizations(const std::optional<SplitMode>& split, const ScopeStmtPtr& slot_num_holder);
+  void PrintScopeOptimizations(SplitMode split, const ScopeStmtPtr& slot_num_holder);
 
   // Emit `` as <tid>`` if the scope carries ``kAttrTaskIdVar``. The caller is
   // responsible for placing the ``)`` before and the ``:\n`` after this call.
@@ -1833,15 +1833,13 @@ bool IRPythonPrinter::PrintScopeDepsAttr(const ScopeStmtPtr& op) {
   return PrintScopeVarListKwarg(op, kAttrManualDepEdges, "deps");
 }
 
-void IRPythonPrinter::PrintScopeOptimizations(const std::optional<SplitMode>& split,
-                                              const ScopeStmtPtr& slot_num_holder) {
-  const bool has_mode = split.has_value() && split.value() != SplitMode::None;
+void IRPythonPrinter::PrintScopeOptimizations(SplitMode split, const ScopeStmtPtr& slot_num_holder) {
+  const bool has_mode = split != SplitMode::None;
   const bool has_slot_num = slot_num_holder && slot_num_holder->HasAttr("slot_num");
   if (!has_mode && !has_slot_num) return;
   stream_ << ", optimizations=[";
   if (has_mode) {
-    stream_ << prefix_ << ".split(" << prefix_ << ".SplitMode." << SplitModeToPythonString(split.value())
-            << ")";
+    stream_ << prefix_ << ".split(" << prefix_ << ".SplitMode." << SplitModeToPythonString(split) << ")";
   }
   if (has_slot_num) {
     if (has_mode) stream_ << ", ";

--- a/tests/ut/ir/parser/test_at_optimizations.py
+++ b/tests/ut/ir/parser/test_at_optimizations.py
@@ -20,12 +20,15 @@ from typing import Protocol, cast
 
 import pypto.language as pl
 import pytest
+from pypto import passes
+from pypto.ir.instruments import make_roundtrip_instrument
 from pypto.language.parser.diagnostics import ParserSyntaxError
+from pypto.language.parser.text_parser import parse_program
 from pypto.pypto_core import ir
 
 
 class _HasSplit(Protocol):
-    split: ir.SplitMode | None
+    split: ir.SplitMode
 
 
 def _find_scope_stmt(stmt: ir.Stmt) -> ir.ScopeStmt | None:
@@ -85,7 +88,7 @@ def test_parse_optimizations_empty_list_is_plain_incore():
     scope = _find_scope_stmt(f.body)
     assert scope is not None
     assert scope.scope_kind == ir.ScopeKind.InCore
-    assert cast(_HasSplit, scope).split is None
+    assert cast(_HasSplit, scope).split == ir.SplitMode.NONE
 
 
 # ─── No DeprecationWarning for the optimizations= API ─────────────────────────
@@ -145,8 +148,13 @@ def test_unsupported_entry_errors():
             return y
 
 
-def test_split_none_in_list_is_explicit_nosplit():
-    """pl.split(SplitMode.NONE) is accepted and preserved explicitly."""
+def test_split_none_in_list_is_accepted_as_nosplit():
+    """pl.split(SplitMode.NONE) is accepted and lands on the scope as NONE.
+
+    ``SplitMode.NONE`` is the *only* encoding of "no split" on
+    ``InCoreScopeStmt.split_`` (issue #2205), so this is indistinguishable from
+    the scope in ``test_no_optimizations_leaves_split_unset`` — deliberately so.
+    """
 
     @pl.function
     def f(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
@@ -158,6 +166,44 @@ def test_split_none_in_list_is_explicit_nosplit():
     assert scope is not None
     assert scope.scope_kind == ir.ScopeKind.InCore
     assert cast(_HasSplit, scope).split == ir.SplitMode.NONE
+
+
+def test_split_none_scope_survives_print_reparse():
+    """A ``pl.split(pl.SplitMode.NONE)`` scope round-trips (issue #2205).
+
+    The printer emits no ``optimizations=`` entry for a NONE split, so a reparse
+    rebuilds a scope with no ``pl.split`` at all. That used to be a *different*
+    IR state — ``split_`` had two encodings of "no split", ``nullopt`` and
+    ``Some(None)`` — and structural equality rejected the pair, so the roundtrip
+    instrument failed the program after ``ConvertToSSA``. With one encoding the
+    two converge.
+    """
+
+    @pl.program
+    class Prog:
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def main(
+            self,
+            a: pl.Tensor[[512, 128], pl.FP32],
+            out: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
+        ) -> pl.Tensor[[512, 128], pl.FP32]:
+            with pl.at(
+                level=pl.Level.CORE_GROUP,
+                name_hint="k",
+                optimizations=[pl.split(pl.SplitMode.NONE)],
+            ):
+                t: pl.Tile[[128, 128], pl.FP32] = pl.load(a, [0, 0], [128, 128])
+                out = pl.store(t, [0, 0], out)
+            return out
+
+    printed = Prog.as_python()
+    assert "pl.split" not in printed
+    ir.assert_structural_equal(parse_program(printed), Prog)
+
+    # The instrument is what surfaced this in the wild: it prints and reparses
+    # after every pass and compares structurally.
+    with passes.PassContext([make_roundtrip_instrument()]):
+        passes.convert_to_ssa()(Prog)
 
 
 def test_split_factory_accepts_none_at_runtime():
@@ -236,7 +282,7 @@ def test_parse_optimizations_cross_core_slot_only():
     assert scope is not None
     assert scope.scope_kind == ir.ScopeKind.InCore
     assert scope.attrs.get("slot_num") == 4
-    assert cast(_HasSplit, scope).split is None
+    assert cast(_HasSplit, scope).split == ir.SplitMode.NONE
 
 
 def test_parse_optimizations_split_and_cross_core_slot():

--- a/tests/ut/ir/parser/test_parse_pl_at.py
+++ b/tests/ut/ir/parser/test_parse_pl_at.py
@@ -18,7 +18,7 @@ from pypto.pypto_core import ir
 
 
 class _HasSplit(Protocol):
-    split: ir.SplitMode | None
+    split: ir.SplitMode
 
 
 class _HasLevelRole(Protocol):

--- a/tests/ut/ir/transforms/test_outline_incore_scopes.py
+++ b/tests/ut/ir/transforms/test_outline_incore_scopes.py
@@ -13,6 +13,7 @@ import pypto
 import pypto.language as pl
 import pytest
 from pypto import DataType, ir, passes
+from pypto.language.parser.diagnostics.exceptions import ParserSyntaxError
 
 
 class TestOutlineIncoreScopes:
@@ -1478,44 +1479,75 @@ class TestOutlineNoDepArgs:
         mechanisms are mutually exclusive, and the function-level split would
         otherwise be silently dropped (the per-region split governs the lanes).
 
-        Detected at outline, where the scope's user split and the region are both
-        visible — post-outline they merge indistinguishably into the function's
-        split/split_aiv attrs (a single region legitimately derives a func split,
-        see test_outline_propagates_split_aiv_attr)."""
+        Detected by the *parser*, the only layer that sees the literal
+        ``pl.split(...)`` the user wrote — see
+        test_function_split_none_with_split_aiv_region_rejected for why that
+        matters, and ..._rejected_at_outline for the pass-level backstop."""
+        with pytest.raises(ParserSyntaxError, match="mutually exclusive"):
 
-        @pl.program
-        class Before:
-            @pl.function(type=pl.FunctionType.Orchestration)
-            def main(
-                self,
-                a: pl.Tensor[[512, 128], pl.FP32],
-                out: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
-            ) -> pl.Tensor[[512, 128], pl.FP32]:
-                with pl.at(
-                    level=pl.Level.CORE_GROUP,
-                    name_hint="k",
-                    optimizations=[pl.split(pl.SplitMode.UP_DOWN)],
-                ):
-                    for aiv_id in pl.split_aiv(2, mode=pl.SplitMode.NONE):
-                        offset = aiv_id * 128
-                        t: pl.Tile[[128, 128], pl.FP32] = pl.load(a, [offset, 0], [128, 128])
-                        out = pl.store(t, [offset, 0], out)
-                return out
-
-        ssa = passes.convert_to_ssa()(Before)
-        with pytest.raises(ValueError, match="mutually exclusive"):
-            passes.outline_incore_scopes()(ssa)
+            @pl.program
+            class Before:
+                @pl.function(type=pl.FunctionType.Orchestration)
+                def main(
+                    self,
+                    a: pl.Tensor[[512, 128], pl.FP32],
+                    out: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
+                ) -> pl.Tensor[[512, 128], pl.FP32]:
+                    with pl.at(
+                        level=pl.Level.CORE_GROUP,
+                        name_hint="k",
+                        optimizations=[pl.split(pl.SplitMode.UP_DOWN)],
+                    ):
+                        for aiv_id in pl.split_aiv(2, mode=pl.SplitMode.NONE):
+                            offset = aiv_id * 128
+                            t: pl.Tile[[128, 128], pl.FP32] = pl.load(a, [offset, 0], [128, 128])
+                            out = pl.store(t, [offset, 0], out)
+                    return out
 
     def test_function_split_none_with_split_aiv_region_rejected(self):
         """``optimizations=[pl.split(pl.SplitMode.NONE)]`` on a scope holding
         pl.split_aiv region(s) is rejected too (RFC #1820).
 
-        NONE carries no split of its own, so this combination used to be
-        exempted — but writing it still reads as "auto and manual split mixed on
-        one scope". The exemption existed only because the cross-core slot count
-        had no carrier other than ``pl.split(..., slot_num=N)``; it now has one
-        (see test_cross_core_slot_with_split_aiv_region_accepted), so the
-        exemption is gone."""
+        NONE carries no split of its own, but writing it still reads as "auto and
+        manual split mixed on one scope". The exemption that once existed was
+        only because the cross-core slot count had no carrier other than
+        ``pl.split(..., slot_num=N)``; it now has one (see
+        test_cross_core_slot_with_split_aiv_region_accepted).
+
+        This spelling is why the check lives in the parser. Since issue #2205
+        ``InCoreScopeStmt.split_`` has a single encoding of "no split"
+        (``SplitMode.NONE``), so by the time ``OutlineIncoreScopes`` runs a literal
+        ``pl.split(pl.SplitMode.NONE)`` is indistinguishable from no ``pl.split``
+        at all — the two encodings that used to distinguish them also broke
+        print -> parse round-tripping."""
+        with pytest.raises(ParserSyntaxError, match="mutually exclusive"):
+
+            @pl.program
+            class Before:
+                @pl.function(type=pl.FunctionType.Orchestration)
+                def main(
+                    self,
+                    a: pl.Tensor[[512, 128], pl.FP32],
+                    out: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
+                ) -> pl.Tensor[[512, 128], pl.FP32]:
+                    with pl.at(
+                        level=pl.Level.CORE_GROUP,
+                        name_hint="k",
+                        optimizations=[pl.split(pl.SplitMode.NONE)],
+                    ):
+                        for aiv_id in pl.split_aiv(2, mode=pl.SplitMode.UP_DOWN):
+                            offset = aiv_id * 128
+                            t: pl.Tile[[128, 128], pl.FP32] = pl.load(a, [offset, 0], [128, 128])
+                            out = pl.store(t, [offset, 0], out)
+                    return out
+
+    def test_function_split_with_split_aiv_region_rejected_at_outline(self):
+        """OutlineIncoreScopes is the backstop for IR that bypassed the parser.
+
+        Deserialized ``.pto`` and programmatically built scopes never hit the
+        parse-time check, so the pass still rejects any scope whose ``split_`` is
+        set (i.e. not ``SplitMode.NONE``) while its body holds a region. Stamping
+        the mode on with a mutator reproduces exactly that shape."""
 
         @pl.program
         class Before:
@@ -1525,30 +1557,31 @@ class TestOutlineNoDepArgs:
                 a: pl.Tensor[[512, 128], pl.FP32],
                 out: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
             ) -> pl.Tensor[[512, 128], pl.FP32]:
-                with pl.at(
-                    level=pl.Level.CORE_GROUP,
-                    name_hint="k",
-                    optimizations=[pl.split(pl.SplitMode.NONE)],
-                ):
+                with pl.at(level=pl.Level.CORE_GROUP, name_hint="k"):
                     for aiv_id in pl.split_aiv(2, mode=pl.SplitMode.UP_DOWN):
                         offset = aiv_id * 128
                         t: pl.Tile[[128, 128], pl.FP32] = pl.load(a, [offset, 0], [128, 128])
                         out = pl.store(t, [offset, 0], out)
                 return out
 
-        # Property verification stays ON; only the print->parse roundtrip is dropped.
-        # `Before` deliberately carries the invalid `split=SplitMode.NONE` on the scope
-        # that this test asserts the pass rejects, and the printer intentionally never
-        # emits a `pl.split(pl.SplitMode.NONE)` (see PrintScopeOptimizations in
-        # src/ir/transforms/python_printer.cpp), so the input cannot round-trip by
-        # design — ConvertToSSA would fail on "SplitMode optional presence mismatch"
-        # before reaching the pass under test. The underlying redundancy (split_ is
-        # optional AND SplitMode has a None member) is tracked by
-        # hw-native-sys/pypto#2205.
+        class _StampIncoreSplit(ir.IRMutator):
+            def visit_in_core_scope_stmt(self, op):
+                rewritten = super().visit_in_core_scope_stmt(op)
+                assert isinstance(rewritten, ir.InCoreScopeStmt)
+                return ir.InCoreScopeStmt(
+                    ir.SplitMode.UP_DOWN,
+                    rewritten.name_hint,
+                    body=rewritten.body,
+                    span=rewritten.span,
+                )
+
+        # `Before` is valid and round-trippable — the invalid combination is
+        # introduced only by the mutator below, after ConvertToSSA has run.
         with passes.PassContext([passes.VerificationInstrument(passes.VerificationMode.BEFORE_AND_AFTER)]):
             ssa = passes.convert_to_ssa()(Before)
+            stamped = _StampIncoreSplit().visit_program(ssa)
             with pytest.raises(ValueError, match="mutually exclusive"):
-                passes.outline_incore_scopes()(ssa)
+                passes.outline_incore_scopes()(stamped)
 
     def test_cross_core_slot_with_split_aiv_region_accepted(self):
         """``optimizations=[pl.cross_core_slot(slot_num=N)]`` coexists with

--- a/tests/ut/language/parser/test_scope_parsing.py
+++ b/tests/ut/language/parser/test_scope_parsing.py
@@ -743,7 +743,7 @@ class TestSpmdOptimizations:
         main_func = list(Prog.functions.values())[0]
         spmd = _unique_descendant(main_func.body, ir.SpmdScopeStmt)
         incore = _unique_descendant(spmd.body, ir.InCoreScopeStmt)
-        assert incore.split is None
+        assert incore.split == ir.SplitMode.NONE
 
     def test_for_spmd_cross_core_slot_sets_scope_attr(self):
         """``pl.cross_core_slot(slot_num=N)`` records ``slot_num`` on the inner
@@ -810,8 +810,8 @@ class TestSpmdOptimizations:
         """A bare slot count needs no split mode at all on the for-spmd form.
 
         The printer emits only the ``pl.cross_core_slot`` entry — it must not
-        fabricate a ``pl.split(pl.SplitMode.NONE)``, which ``OutlineIncoreScopes``
-        rejects on a scope holding ``pl.split_aiv`` regions.
+        fabricate a ``pl.split(pl.SplitMode.NONE)``, which the parser rejects on a
+        scope holding ``pl.split_aiv`` regions.
         """
 
         @pl.program
@@ -831,7 +831,7 @@ class TestSpmdOptimizations:
         main_func = list(Prog.functions.values())[0]
         spmd = _unique_descendant(main_func.body, ir.SpmdScopeStmt)
         incore = _unique_descendant(spmd.body, ir.InCoreScopeStmt)
-        assert incore.split is None
+        assert incore.split == ir.SplitMode.NONE
         assert incore.attrs.get("slot_num") == 8
         printed = Prog.as_python()
         assert "optimizations=[pl.cross_core_slot(slot_num=8)]" in printed
@@ -918,7 +918,7 @@ class TestSpmdOptimizations:
 
         main_func = list(Prog.functions.values())[0]
         incore = _unique_descendant(main_func.body, ir.InCoreScopeStmt)
-        assert incore.split is None
+        assert incore.split == ir.SplitMode.NONE
         assert incore.attrs.get("slot_num") == 8
         printed = Prog.as_python()
         assert "optimizations=[pl.cross_core_slot(slot_num=8)]" in printed
@@ -1042,7 +1042,7 @@ class TestSpmdOptimizations:
         main_func = list(Prog.functions.values())[-1]
         spmd = _unique_descendant(main_func.body, ir.SpmdScopeStmt)
         incore = _unique_descendant(spmd.body, ir.InCoreScopeStmt)
-        assert incore.split is None
+        assert incore.split == ir.SplitMode.NONE
         assert incore.attrs.get("slot_num") == 4
         # No round-trip assertion here: the plain with-form's printer emits the
         # wrapper as a nested `with pl.at(...)`, which no longer reparses as a

--- a/tests/ut/language/parser/test_split_aiv_parsing.py
+++ b/tests/ut/language/parser/test_split_aiv_parsing.py
@@ -175,7 +175,7 @@ class TestSplitAivBuildsNode:
         region = _unique_descendant(incore.body, ir.SplitAivScopeStmt)
         assert region.split == ir.SplitMode.LEFT_RIGHT
         # The synthesized InCore wrapper itself carries no split / split_aiv attr.
-        assert incore.split is None
+        assert incore.split == ir.SplitMode.NONE
         assert "split_aiv" not in incore.attrs
 
     def test_builds_node_none_mode(self):


### PR DESCRIPTION
## Summary

`InCoreScopeStmt::split_` was a `std::optional<SplitMode>`, so "no split" had **two** spellings — `nullopt` and `Some(SplitMode::None)`. The printer collapsed them (both emit no `optimizations=` entry) while structural equality kept them apart, so a scope carrying `Some(None)` could not survive print → parse:

```text
[RoundtripInstrument] Structural equality failed after pass 'ConvertToSSA'.
Error: Structural equality assertion failed at: ['main'].body[0].split
Reason: SplitMode optional presence mismatch
```

This makes the field a plain `SplitMode`, matching its sibling `SplitAivScopeStmt::split_`. `SplitMode::None` becomes the only encoding of "no split".

**Printer output is unchanged.** Both former states already printed nothing, and both now map to `None` — which is why this avoids the 7 failures that the "obvious" one-line fix (making `Some(None)` printable) produced, as measured in the issue.

## Relocating the RFC #1820 rejection

The redundancy was load-bearing in exactly one place: `OutlineIncoreScopes` rejects a scope combining `optimizations=[pl.split(...)]` with `pl.split_aiv` region(s), and RFC #1820 rejects `pl.SplitMode.NONE` there too.

Whether the user *wrote* that literal is a property of the **source text**, not of the IR — so the check moves to the parser, the only layer that can still see it. Tracking is exact (the parser's InCore scope stack), not an AST heuristic, and it now fires at program-definition time with a span pointing at the offending `pl.split_aiv` loop instead of 8 passes later.

`OutlineIncoreScopes` keeps the check for `split_ != SplitMode::None` as the backstop for IR that never went through the parser (deserialized `.pto`, programmatically built scopes).

## Changes

- **IR**: `InCoreScopeStmt::split_` → `SplitMode` (non-optional).
- **Boundaries normalize**: `IRBuilder::EndScope` and the `.pto` deserializer map an absent split onto `SplitMode::None`, so `.pto` files written before this change still load.
- **Printer**: `PrintScopeOptimizations` / `SpmdInlineBodyRebuildsCarrier` predicates become `split != None` — identical output.
- **Parser**: new mutual-exclusion rejection covering all three InCore-creating paths (`pl.at`, `with pl.spmd`, `for ... in pl.spmd`).
- **Bindings/stub**: `InCoreScopeStmt(split=SplitMode.NONE, ...)`; field is `Final[SplitMode]`.
- **Docs**: `ir/01-hierarchy.md` and `passes/08-outline_incore_scopes.md`, EN + ZH.

## Note for reviewers

This resolves the bypass that #2207 added in `test_outline_incore_scopes.py`, whose comment cited this issue by number as the reason the input could not round-trip. That comment and its `PassContext` narrowing are removed; the affected tests now assert the parse-time rejection instead.

## Testing

- [x] Full unit suite: **8311 passed**, 1 pre-existing env failure (`test_ir_trace.py::test_installed_console_script_preserves_main_exit_codes` — requires PyPTO pip-installed; untouched by this PR).
- [x] `pre-commit` clean (clang-format, cpplint, ruff, ruff-format, pyright, docs EN/ZH parity, markdownlint).
- [x] `clang-tidy` clean over the 99 source + 2 header files affected by the C++ change.
- [x] New regression test pins the print → parse round-trip for a `pl.split(pl.SplitMode.NONE)` scope, including under the roundtrip instrument that originally surfaced this.
- [x] New test covers the `OutlineIncoreScopes` backstop via a mutator-stamped scope.
- [x] Tests asserting `incore.split is None` updated to `== SplitMode.NONE` (the IR contract changed; these were pinning the old encoding).

## Related Issues

Fixes #2205