### PR TITLE
fix(ir): Let a matmul operand wrapped in set_validshape load straight to Mat

### DIFF
--- a/docs/en/dev/passes/10-convert_tensor_to_tile_ops.md
+++ b/docs/en/dev/passes/10-convert_tensor_to_tile_ops.md
@@ -84,6 +84,8 @@ already rewritten in Phase 1 / 2a.
 
 When `tensor.slice` feeds into `tensor.matmul` or `tensor.matmul_acc`, the slice must produce a Mat-space tile instead of a Vec-space tile. The pass pre-scans for this pattern and emits a natural Mat `tile.load`; a transposed operand (`a_trans` for LHS, `b_trans` for RHS) gets a zero-copy `tile.transpose_view` at the matmul site.
 
+The demand is propagated **through** zero-copy metadata ops that declare `set_output_memory_inherit_input()` — `tensor.slice`, `tensor.view`, `tensor.reshape`, `tensor.reinterpret_view`, `tensor.set_validshape`. So an operand written as `pl.matmul(pl.set_validshape(a[:, :K], rows, K), b)` still loads straight to Mat. An op that aliases its input's storage but omits that declaration breaks the chain: the operand materializes in Vec and needs a `tile.move` to Mat, which is a vector→cube boundary that flips an otherwise pure-CUBE InCore scope to `MIXED` and makes [`ExpandMixedKernel`](20-expand_mixed_kernel.md) split it into an AIC/AIV pair.
+
 ## Transpose Lowering
 
 `tensor.transpose` lowers to a plain 3-arg **`tile.transpose(input, axis1, axis2)`**. The PTO `pto.ttrans` instruction needs a scratch workspace tile (same shape/dtype as the source), but that scratch is a pure codegen detail — not a semantic operand. [`FlattenTileNdTo2D`](13-flatten_tile_nd_to_2d.md) is the **sole owner** of scratch materialization: it emits the codegen-ready 4-arg form (`tile.create` + `tile.transpose(..., tmp)`) for both 2D and per-page >2D transposes, still before the memory allocator runs (so the scratch gets a real UB address). Keeping scratch out of the high-level op means `tensor.transpose` and the DSL `pl.tile.transpose(tile, axis1, axis2)` stay 1:1 with the semantic operation.

--- a/docs/zh/dev/passes/10-convert_tensor_to_tile_ops.md
+++ b/docs/zh/dev/passes/10-convert_tensor_to_tile_ops.md
@@ -79,6 +79,8 @@ InCore、Spmd、Group 函数在本阶段被跳过 —— 它们已在阶段一 /
 
 当 `tensor.slice` 的结果被 `tensor.matmul` 或 `tensor.matmul_acc` 使用时，slice 必须生成 Mat 空间的 tile 而非 Vec 空间。本 pass 预扫描此模式，生成自然的 Mat `tile.load`；转置操作数（LHS 用 `a_trans`，RHS 用 `b_trans`）在 matmul 处叠加零拷贝 `tile.transpose_view`。
 
+该需求会**穿过**声明了 `set_output_memory_inherit_input()` 的零拷贝元数据 op 继续向上传播 —— `tensor.slice`、`tensor.view`、`tensor.reshape`、`tensor.reinterpret_view`、`tensor.set_validshape`。因此 `pl.matmul(pl.set_validshape(a[:, :K], rows, K), b)` 这样的操作数仍然直接加载到 Mat。若某个别名输入存储的 op 漏掉该声明，传播链就会断开：操作数被物化到 Vec，再通过 `tile.move` 桥接到 Mat，而这是一个 vector→cube 边界，会把本应是纯 CUBE 的 InCore scope 判定为 `MIXED`，导致 [`ExpandMixedKernel`](20-expand_mixed_kernel.md) 将其拆分为 AIC/AIV 两个函数。
+
 ## Transpose 下沉
 
 `tensor.transpose` 下沉为一个 3-arg 的 **`tile.transpose(input, axis1, axis2)`**。PTO 后端的 `pto.ttrans` 指令需要一个 scratch 工作 tile（与源 tile 同 shape/同 dtype），但该 scratch 纯属 codegen 细节，并非语义操作数。[`FlattenTileNdTo2D`](13-flatten_tile_nd_to_2d.md) 是 scratch 物化的**唯一归属**：它为 2D 以及逐页 >2D 的 transpose 统一产出 codegen-ready 的 4-arg 形态（`tile.create` + `tile.transpose(..., tmp)`），且仍在内存分配器之前（scratch 仍能拿到真实 UB 地址）。把 scratch 从高层 op 中移除后，`tensor.transpose` 与 DSL `pl.tile.transpose(tile, axis1, axis2)` 都与语义操作保持 1:1。

--- a/src/ir/op/tensor_ops/transform.cpp
+++ b/src/ir/op/tensor_ops/transform.cpp
@@ -781,12 +781,21 @@ TypePtr DeduceTensorSetValidShapeType(const std::vector<ExprPtr>& args,
 }
 
 // NOTE: Internal op for compiler-generated code only; should not be exposed to end users in future releases.
+// The result aliases the input's storage, so it inherits the input's memory
+// space — the same relation `tile.set_validshape` already declares. Without it,
+// ConvertTensorToTileOps cannot propagate a consumer's memory-space requirement
+// back through set_validshape to the load-like producer, so a matmul operand
+// wrapped in set_validshape is materialised in Vec and bridged to Mat with a
+// tile.move. That move is a vector->cube boundary, which flips an otherwise
+// pure-CUBE InCore scope to MIXED and makes ExpandMixedKernel split it into an
+// AIC/AIV pair (issue #2227).
 REGISTER_OP("tensor.set_validshape")
     .set_op_category("TensorOp")
     .set_description("Update valid-shape metadata of a tensor without data movement (internal)")
     .add_argument("tensor", "Input tensor (TensorType, 2D)")
     .add_argument("valid_rows", "Number of valid rows (ScalarType INDEX/INT64/UINT64)")
     .add_argument("valid_cols", "Number of valid columns (ScalarType INDEX/INT64/UINT64)")
+    .set_output_memory_inherit_input()
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
       return DeduceTensorSetValidShapeType(args, kwargs);

--- a/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
+++ b/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
@@ -1486,6 +1486,74 @@ class TestConvertTensorToTileOps:
         After = passes.convert_tensor_to_tile_ops()(Before)
         _assert_convert_output_equal(After, Expected)
 
+    def test_set_validshape_operand_loads_straight_to_mat(self):
+        """A matmul operand wrapped in tensor.set_validshape still loads straight to Mat (#2227).
+
+        ``tensor.set_validshape`` is pure metadata over the input's storage, so the
+        matmul's Mat requirement must propagate back through it to the load-like
+        producer. Without that back-propagation the operand materialises in Vec and
+        needs a tile.move to Mat — a vector->cube boundary that flips the otherwise
+        pure-CUBE InCore scope to MIXED, making ExpandMixedKernel split it into an
+        AIC/AIV pair.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                a_src: pl.Tensor[[16, 64], pl.BF16],
+                b: pl.Tensor[[64, 64], pl.BF16],
+            ) -> pl.Tensor[[16, 64], pl.FP32]:
+                a: pl.Tensor[[16, 64], pl.BF16] = pl.slice(a_src, [16, 64], [0, 0])
+                av: pl.Tensor[[16, 64], pl.BF16] = pl.set_validshape(a, 8, 64)
+                y: pl.Tensor[[16, 64], pl.FP32] = pl.matmul(av, b, out_dtype=pl.FP32)
+                return y
+
+            @pl.function
+            def main(
+                self,
+                a_src: pl.Tensor[[16, 64], pl.BF16],
+                b: pl.Tensor[[64, 64], pl.BF16],
+            ) -> pl.Tensor[[16, 64], pl.FP32]:
+                y: pl.Tensor[[16, 64], pl.FP32] = self.main_incore_0(a_src, b)
+                return y
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                a_src: pl.Tensor[[16, 64], pl.BF16],
+                b: pl.Tensor[[64, 64], pl.BF16],
+                ret0_out: pl.Out[pl.Tensor[[16, 64], pl.FP32]],
+            ) -> pl.Tensor[[16, 64], pl.FP32]:
+                # Consumer-driven: the Mat demand reaches the slice THROUGH
+                # set_validshape, so no Vec load + tile.move(Mat) bridge appears.
+                a_mat: pl.Tile[[16, 64], pl.BF16, pl.MemorySpace.Mat] = pl.load(
+                    a_src, [0, 0], [16, 64], [16, 64], target_memory=pl.MemorySpace.Mat
+                )
+                av_mat = pl.tile.set_validshape(a_mat, 8, 64)
+                b_mat: pl.Tile[[64, 64], pl.BF16, pl.MemorySpace.Mat] = pl.load(
+                    b, [0, 0], [64, 64], [64, 64], target_memory=pl.MemorySpace.Mat
+                )
+                y_tile: pl.Tile[[16, 64], pl.FP32, pl.MemorySpace.Acc] = pl.tile.matmul(av_mat, b_mat)
+                out_store: pl.Tensor[[16, 64], pl.FP32] = pl.store(y_tile, [0, 0], ret0_out)
+                return out_store
+
+            @pl.function
+            def main(
+                self,
+                a_src: pl.Tensor[[16, 64], pl.BF16],
+                b: pl.Tensor[[64, 64], pl.BF16],
+            ) -> pl.Tensor[[16, 64], pl.FP32]:
+                ret0_out: pl.Tensor[[16, 64], pl.FP32] = pl.create_tensor([16, 64], dtype=pl.FP32)
+                y: pl.Tensor[[16, 64], pl.FP32] = self.main_incore_0(a_src, b, ret0_out)
+                return y
+
+        After = passes.convert_tensor_to_tile_ops()(Before)
+        _assert_convert_output_equal(After, Expected)
+
     def test_shared_kv_one_load_two_matmuls_b_trans(self):
         """A single sliced KV feeding a b_trans=True and a b_trans=False matmul lowers
         to ONE GM->L1 load + ONE zero-copy tile.transpose_view view, not two loads (#1776).


### PR DESCRIPTION
## Summary

Fixes #2227.

`tensor.set_validshape` is pure metadata over its input's storage, but it was the only such tensor-level op missing `set_output_memory_inherit_input()`. `tensor.slice`, `tensor.view`, `tensor.reshape` and `tensor.reinterpret_view` all declare it, and so does its own lowered form `tile.set_validshape`.

`ConvertTensorToTileOps` (`ConsumerSpaceCollector::PropagateThroughInheritInputOps`) walks exactly that declaration to push a consumer's memory-space requirement back to the load-like producer. With the edge missing, the Mat demand from `tensor.matmul` stopped at the `set_validshape`, so the A operand was materialised in Vec and bridged to Mat with a `tile.move`:

```python
# before (after ConvertTensorToTileOps)
t__tile   = pl.tile.load(a, [0, 0], [16, 256], [16, 256], target_memory=pl.Mem.Vec)
t__tile_1 = pl.tile.set_validshape(t__tile, 8, 256)
l_mat     = pl.tile.move(t__tile_1, target_memory=pl.Mem.Mat)   # vector -> cube boundary

# after
t__tile   = pl.tile.load(a, [0, 0], [16, 256], [16, 256], target_memory=pl.Mem.Mat)
t__tile_1 = pl.tile.set_validshape(t__tile, 8, 256)
```

That `tile.move` is a C/V boundary, so `CoreAffinity` rolls the enclosing InCore scope up as `MIXED` and `ExpandMixedKernel` splits a scope containing nothing but a matmul and its store into an AIC/AIV pair. Note this is upstream of `core_affinity.cpp` / `InferTileMemorySpace`, where the issue's initial diagnosis pointed — the divergence is already present in the pass-11 dump.

With the declaration restored the IR matches the no-`set_validshape` baseline except for the extra `tile.set_validshape` on the Mat tile, and the valid shape rides along into the `Left` extract (`valid_shape=[8, 64]`).

## Changes

- `src/ir/op/tensor_ops/transform.cpp` — add `.set_output_memory_inherit_input()` to `REGISTER_OP("tensor.set_validshape")`
- `tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py` — regression test `test_set_validshape_operand_loads_straight_to_mat`
- `docs/{en,zh}/dev/passes/10-convert_tensor_to_tile_ops.md` — document which metadata ops the Mat demand propagates through, and the consequence of omitting the declaration

## Testing

- [x] Issue repro: `probe_mm_probe_mm` is `FunctionType.AIC` with and without `--valid` (was `Group{AIC, AIV}` with `--valid`)
- [x] ptoas compiles the resulting kernel (`PTOAS_ROOT=/usr/local/ptoas/0.54`)
- [x] `tests/ut/` — 8443 passed, 2 skipped
- [x] pypto-lib `models/qwen3/14b/decode_fwd.py -p a2a3sim` compiles; all projection kernels remain `AIC`
- [x] pypto-lib `models/qwen3/14b/decode_layer_a8w8.py -p a2a3sim` (16 `set_validshape`-wrapped matmul operands) compiles, 45 functions, unchanged
- [x] Documentation updated (EN + zh)