### PR TITLE
refactor(dsl): Unify load valid_shape naming

### DIFF
--- a/docs/en/dev/ir/05-operators.md
+++ b/docs/en/dev/ir/05-operators.md
@@ -105,6 +105,12 @@ REGISTER_OP("tensor.matmul")
     .f_deduce_type(DeduceMatMul);
 ```
 
+For 2D `tile.matmul`, the result keeps the physical `[M, N]` shape and
+derives its valid region from the corresponding output axes:
+`[lhs.valid_shape[0], rhs.valid_shape[1]]`. This preserves a static partial
+M or N extent through the matrix multiplication without shrinking the boxed
+accumulator tile.
+
 At the tile layer, `tile.batch_matmul` provides batched semantics for
 `TileType` operands. It accepts rank >= 2 tiles, broadcasts the leading batch
 dimensions, and keeps the same operand-only interface style as `tile.matmul`.

--- a/docs/en/dev/passes/13-flatten_tile_nd_to_2d.md
+++ b/docs/en/dev/passes/13-flatten_tile_nd_to_2d.md
@@ -50,7 +50,7 @@ Per-statement handling:
 
 | Tile op | Transformation |
 | ------- | -------------- |
-| `tile.load` (>2D) | Rebuild the result tile as 2D. For a natural NZ Mat load, also insert a shape-only 2D `tensor.view` on the source tensor, collapse leading offsets/shapes/valid_shapes to the 2D source window, and require that window to be row-major contiguous. Vec loads and transposed Mat loads keep the original rank>2 source window and only flatten the result tile |
+| `tile.load` (>2D) | Rebuild the result tile as 2D. For a natural NZ Mat load, also insert a shape-only 2D `tensor.view` on the source tensor, collapse leading offsets/shapes/valid_shape to the 2D source window, and require that window to be row-major contiguous. Vec loads and transposed Mat loads keep the original rank>2 source window and only flatten the result tile |
 | `tile.store` (rank>2 tensor) | Inject the original tensor-rank partition `shapes` as an extra 4th operand in the transformed IR so backend codegen can reconstruct the `partition_view`; the DSL source is unchanged. If the tile operand itself is still rank>2 (e.g. a user-written `tile.reshape` to 3D feeding `pl.assemble` into an N-D tensor view), insert a `tile.reshape` to flatten the tile operand to 2D first — the codegen requires a 2D tile while the original tile shape still flows through as the `shapes` partition operand |
 | `tile.store` (2D tensor) | Pass through unchanged |
 | `tile.create`/`tile.full` (>2D) | Rebuild with flattened 2D shape directly |
@@ -147,14 +147,14 @@ Hardware tiles map to fixed-size on-chip buffers, so every **physical** tile dim
 compile-time constant; the runtime extent lives in `TileView.valid_shape`. To process a dynamic
 dimension the user **writes the chunk loop themselves**: iterate the dynamic dim with `pl.range` in a
 static `CHUNK` step, and load each chunk as a static physical `[1, CHUNK, 512]` tile whose
-`valid_shapes` carries the runtime tail `min(CHUNK, s - c)`. The chunk size is the user's choice — it
+`valid_shape` carries the runtime tail `min(CHUNK, s - c)`. The chunk size is the user's choice — it
 strongly affects performance, so it is not auto-selected by the pass.
 
 ```python
-# User-written: chunk the dynamic S dim, clamp the tail in valid_shapes.
+# User-written: chunk the dynamic S dim, clamp the tail in valid_shape.
 for c, (o,) in pl.range(0, s_dim, CHUNK, init_values=(out,)):
     valid = pl.min(CHUNK, s_dim - c)
-    t = pl.load(x, [b, c, 0], [1, CHUNK, 512], valid_shapes=[1, valid, 512])
+    t = pl.load(x, [b, c, 0], [1, CHUNK, 512], valid_shape=[1, valid, 512])
     t = pl.cast(t, target_type=pl.FP32)
     o = pl.store(t, [b, c, 0], o)        # static physical [1, CHUNK, 512], dynamic valid
     pl.yield_(o)

--- a/docs/en/dev/passes/22-split_vector_kernel.md
+++ b/docs/en/dev/passes/22-split_vector_kernel.md
@@ -136,10 +136,13 @@ racing garbage rows into subblock 0's slot. The detection lever is
 Plain no-split `Acc -> Vec` pushes have a related C2V transport requirement.
 When the accumulator has a partial logical `valid_shape`, codegen temporarily
 widens both dimensions to the physical NZ box for `tpush`, then restores the
-logical shape. This prevents an incomplete FIFO slot from leaving stale data in
-the vector consumer while preserving the partial shape on `tpop` and downstream
-operations. Full-shape accumulators and no-split `Vec -> Mat` pushes are
-unchanged.
+logical shape. `ExpandMixedKernel` marks the paired `tpop_from_aic` so A2/A3
+also receives the full physical box; passing the partial extent to `tpop` would
+copy only part of the fixed-size GM slot and use the wrong NZ-to-ND conversion
+extent. The tpop result's IR type still carries the partial logical shape, so
+downstream allocations remain narrowed without applying `set_validshape` to the
+raw FIFO tile. Full-shape accumulators, A5, and no-split `Vec -> Mat` transfers
+are unchanged.
 
 ## Examples
 

--- a/docs/en/dev/passes/22-split_vector_kernel.md
+++ b/docs/en/dev/passes/22-split_vector_kernel.md
@@ -122,7 +122,7 @@ AIV, and `attrs["dual_aiv_dispatch"]` is true.
 The lane-1 replay zeroes its tile `valid_shape` so it produces no visible
 writes, but the AIC↔AIV `tpush` it keeps still moves data through the shared GM
 FIFO slot the single cube consumer pops in full. On the codegen side
-(`EmitSplitTpushTransportValidShape`, `pto_ops_common.cpp`) a no-split dual-AIV
+(`EmitTpushTransportValidShape`, `pto_ops_crosscore.cpp`) a no-split dual-AIV
 producer that narrowed its `valid_shape` with `set_validshape` must transport
 the **full column box**, or the consumer reads stale slot columns past
 `valid_col`. The no-split path widens **columns only and preserves the row
@@ -132,6 +132,14 @@ statically 0-row push moves no data), so it stays a true 0-row no-op rather than
 racing garbage rows into subblock 0's slot. The detection lever is
 `PTOCodegen::IsDualAivDispatchFunction()`, which reads this pass's
 `dual_aiv_dispatch` attribute.
+
+Plain no-split `Acc -> Vec` pushes have a related C2V transport requirement.
+When the accumulator has a partial logical `valid_shape`, codegen temporarily
+widens both dimensions to the physical NZ box for `tpush`, then restores the
+logical shape. This prevents an incomplete FIFO slot from leaving stale data in
+the vector consumer while preserving the partial shape on `tpop` and downstream
+operations. Full-shape accumulators and no-split `Vec -> Mat` pushes are
+unchanged.
 
 ## Examples
 

--- a/docs/zh/dev/ir/05-operators.md
+++ b/docs/zh/dev/ir/05-operators.md
@@ -105,6 +105,10 @@ REGISTER_OP("tensor.matmul")
     .f_deduce_type(DeduceMatMul);
 ```
 
+对于二维 `tile.matmul`，结果保留物理 `[M, N]` 形状，并从对应的输出轴推导有效区域：
+`[lhs.valid_shape[0], rhs.valid_shape[1]]`。因此静态的部分有效 M 或 N 范围可以穿过矩阵乘，
+同时不会缩小按硬件要求装箱的累加器 tile。
+
 在 tile 层，`tile.batch_matmul` 为 `TileType` 操作数提供批量语义。它接受 rank >= 2 的
 tile，广播前导批量维度，并保持与 `tile.matmul` 相同的纯操作数接口风格。如果批量操作数
 需要转置语义，可以通过两种等价方式表达：在输入上显式使用 `tile.transpose(...)`，或在

--- a/docs/zh/dev/passes/13-flatten_tile_nd_to_2d.md
+++ b/docs/zh/dev/passes/13-flatten_tile_nd_to_2d.md
@@ -49,7 +49,7 @@ program_2d = flatten_pass(program)
 
 | Tile 操作 | 变换方式 |
 | --------- | -------- |
-| `tile.load`（>2D） | 将结果 tile 重建为 2D。对于 natural NZ Mat load，还会在源张量上插入 shape-only 的 2D `tensor.view`，把 leading offsets/shapes/valid_shapes 折叠到 2D 源窗口，并要求该窗口按 row-major 连续可折叠。Vec load 和 transposed Mat load 保留原始 rank>2 源窗口，只展平结果 tile |
+| `tile.load`（>2D） | 将结果 tile 重建为 2D。对于 natural NZ Mat load，还会在源张量上插入 shape-only 的 2D `tensor.view`，把 leading offsets/shapes/valid_shape 折叠到 2D 源窗口，并要求该窗口按 row-major 连续可折叠。Vec load 和 transposed Mat load 保留原始 rank>2 源窗口，只展平结果 tile |
 | `tile.store`（rank>2 张量） | 在转换后 IR 中注入原始张量 rank 对应的分区 `shapes` 作为额外的第 4 个操作数，供后端 codegen 重建 `partition_view`；DSL 源码不变。若 tile 操作数本身仍是 rank>2(例如用户显式 `tile.reshape` 升到 3D 后再喂给 `pl.assemble` 写入 N-D 张量视图),pass 会先插入一个 `tile.reshape` 把 tile 操作数压回 2D —— codegen 要求 tile 必须是 2D,而原始 tile shape 仍由 `shapes` 分区操作数携带 |
 | `tile.store`（2D 张量） | 直接透传 |
 | `tile.create`/`tile.full`（>2D） | 直接使用展平的 2D 形状重建 |
@@ -128,14 +128,14 @@ class After:
 
 硬件 Tile 对应固定大小的片上缓冲，因此每个**物理** Tile 维度都必须是编译期常量；运行时实际范围保存在
 `TileView.valid_shape` 中。要处理动态维，用户**自己写分块循环**：用 `pl.range` 以静态 `CHUNK` 步进迭代
-动态维，每趟把这一块 load 成静态物理 `[1, CHUNK, 512]` 的 tile，并在 `valid_shapes` 里用
+动态维，每趟把这一块 load 成静态物理 `[1, CHUNK, 512]` 的 tile，并在 `valid_shape` 里用
 `min(CHUNK, s - c)` 夹住尾块。chunk 大小由用户决定 —— 它对性能影响显著，因此 Pass 不自动选取：
 
 ```python
-# 用户自己写：对动态 S 维分块，在 valid_shapes 里夹住尾块。
+# 用户自己写：对动态 S 维分块，在 valid_shape 里夹住尾块。
 for c, (o,) in pl.range(0, s_dim, CHUNK, init_values=(out,)):
     valid = pl.min(CHUNK, s_dim - c)
-    t = pl.load(x, [b, c, 0], [1, CHUNK, 512], valid_shapes=[1, valid, 512])
+    t = pl.load(x, [b, c, 0], [1, CHUNK, 512], valid_shape=[1, valid, 512])
     t = pl.cast(t, target_type=pl.FP32)
     o = pl.store(t, [b, c, 0], o)        # 物理静态 [1, CHUNK, 512]，valid 动态
     pl.yield_(o)

--- a/docs/zh/dev/passes/22-split_vector_kernel.md
+++ b/docs/zh/dev/passes/22-split_vector_kernel.md
@@ -107,13 +107,19 @@ per-lane 形态（由上游 `LowerAutoVectorSplit` + `ExpandMixedKernel` 达成�
 
 lane 1 重放将其 tile `valid_shape` 置零以不产生可见写入，但其保留的 AIC↔AIV `tpush`
 仍通过共享 GM FIFO 槽移动数据，由单一 cube 消费者整列弹出。在 codegen 侧
-（`EmitSplitTpushTransportValidShape`，`pto_ops_common.cpp`），用 `set_validshape`
+（`EmitTpushTransportValidShape`，`pto_ops_crosscore.cpp`），用 `set_validshape`
 收窄了 `valid_shape` 的无拆分双 AIV 生产者必须传输**整列 box**，否则消费者会读到
 `valid_col` 之后的陈旧槽列。无拆分路径**仅加宽列并保留行 `valid_shape`**：subblock 0
 的真实推送携带整列 box，而 subblock 1 的 `valid_shape=[0, 0]` 重放**完全不传输**
 （静态 0 行推送不移动数据），因此它保持真正的 0 行无操作，而非把垃圾行赛入 subblock 0
 的槽。检测开关是 `PTOCodegen::IsDualAivDispatchFunction()`，读取本 pass 的
 `dual_aiv_dispatch` 属性。
+
+普通无拆分 `Acc -> Vec` 推送也有相关的 C2V 传输要求。当累加器带有部分逻辑
+`valid_shape` 时，codegen 会在 `tpush` 前将两个维度临时加宽到物理 NZ box，并在推送后
+恢复逻辑形状。这样可避免不完整的 FIFO 槽让 vector 消费者保留陈旧数据，同时保证
+`tpop` 及下游操作仍使用部分逻辑形状。完整形状的累加器和无拆分 `Vec -> Mat` 推送不受
+影响。
 
 ## 示例
 

--- a/docs/zh/dev/passes/22-split_vector_kernel.md
+++ b/docs/zh/dev/passes/22-split_vector_kernel.md
@@ -117,9 +117,11 @@ lane 1 重放将其 tile `valid_shape` 置零以不产生可见写入，但其�
 
 普通无拆分 `Acc -> Vec` 推送也有相关的 C2V 传输要求。当累加器带有部分逻辑
 `valid_shape` 时，codegen 会在 `tpush` 前将两个维度临时加宽到物理 NZ box，并在推送后
-恢复逻辑形状。这样可避免不完整的 FIFO 槽让 vector 消费者保留陈旧数据，同时保证
-`tpop` 及下游操作仍使用部分逻辑形状。完整形状的累加器和无拆分 `Vec -> Mat` 推送不受
-影响。
+恢复逻辑形状。`ExpandMixedKernel` 会标记与之配对的 `tpop_from_aic`，使 A2/A3 也按
+完整物理 box 接收；若将部分范围传给 `tpop`，固定大小的 GM 槽只会复制一部分，并以错误
+范围执行 NZ 到 ND 的转换。tpop 结果的 IR 类型仍携带部分逻辑形状，因此下游分配保持收窄，
+且无需对原始 FIFO tile 调用 `set_validshape`。完整形状的累加器、A5 以及无拆分
+`Vec -> Mat` 传输不受影响。
 
 ## 示例
 

--- a/examples/kernels/09_dyn_valid_shape.py
+++ b/examples/kernels/09_dyn_valid_shape.py
@@ -10,11 +10,11 @@
 """Dynamic valid_shape examples.
 
 Demonstrates a DSL pattern where the valid length of a tile is a runtime
-scalar (caller-provided) and used inside ``pl.load(..., valid_shapes=...)``
+scalar (caller-provided) and used inside ``pl.load(..., valid_shape=...)``
 to bound the active region of the tile, then padded via
 ``pl.tile.fillpad``::
 
-    tile = pl.load(..., valid_shapes=[rows, vlen])   # vlen is a runtime scalar
+    tile = pl.load(..., valid_shape=[rows, vlen])   # vlen is a runtime scalar
     padded = pl.tile.fillpad(tile, pad_value=PadValue.min)
 
 JIT note
@@ -67,7 +67,7 @@ def dyn_valid_shape(
             data,
             [0, 0],
             [Q_TILE, BLOCK_COL],
-            valid_shapes=[Q_TILE, vlen],
+            valid_shape=[Q_TILE, vlen],
             target_memory=pl.MemorySpace.Vec,
         )
         s_padded = pl.tile.fillpad(s_tile, pad_value=pl.PadValue.min)

--- a/examples/kernels/12_matmul_valid_shape.py
+++ b/examples/kernels/12_matmul_valid_shape.py
@@ -20,7 +20,7 @@ N = 16
 
 
 @pl.jit
-def matmul_valid_shape(a: pl.Tensor, b: pl.Tensor, output: pl.Out[pl.Tensor]):
+def matmul_valid_shape(a: pl.Tensor, b: pl.Tensor, output: pl.InOut[pl.Tensor]):
     with pl.at(level=pl.Level.CORE_GROUP):
         a_mat: pl.Tile[
             [TILE_M, K],
@@ -42,7 +42,7 @@ def matmul_valid_shape(a: pl.Tensor, b: pl.Tensor, output: pl.Out[pl.Tensor]):
             pl.FP32,
             pl.Mem.Acc,
             pl.TileView(valid_shape=[VALID_M, N]),
-        ] = pl.matmul(a_left, b_right)
+        ] = pl.set_validshape(pl.matmul(a_left, b_right), VALID_M, N)
         pl.store(result, [0, 0], output)
     return output
 

--- a/examples/kernels/12_matmul_valid_shape.py
+++ b/examples/kernels/12_matmul_valid_shape.py
@@ -1,0 +1,60 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Matmul with a 16-row physical tile and five valid rows."""
+
+import pypto.language as pl
+import torch
+from pypto.runtime import RunConfig
+
+VALID_M = 5
+TILE_M = 16
+K = 16
+N = 16
+
+
+@pl.jit
+def matmul_valid_shape(a: pl.Tensor, b: pl.Tensor, output: pl.Out[pl.Tensor]):
+    with pl.at(level=pl.Level.CORE_GROUP):
+        a_mat: pl.Tile[
+            [TILE_M, K],
+            pl.FP32,
+            pl.Mem.Mat,
+            pl.TileView(valid_shape=[VALID_M, K]),
+        ] = pl.load(
+            a,
+            [0, 0],
+            [TILE_M, K],
+            valid_shape=[VALID_M, K],
+            target_memory=pl.Mem.Mat,
+        )
+        b_mat = pl.load(b, [0, 0], [K, N], target_memory=pl.Mem.Mat)
+        a_left = pl.move(a_mat, target_memory=pl.Mem.Left)
+        b_right = pl.move(b_mat, target_memory=pl.Mem.Right)
+        result: pl.Tile[
+            [TILE_M, N],
+            pl.FP32,
+            pl.Mem.Acc,
+            pl.TileView(valid_shape=[VALID_M, N]),
+        ] = pl.matmul(a_left, b_right)
+        pl.store(result, [0, 0], output)
+    return output
+
+
+if __name__ == "__main__":
+    cfg = RunConfig()
+    torch.manual_seed(0)
+    a = torch.randn(VALID_M, K, dtype=torch.float32)
+    b = torch.randn(K, N, dtype=torch.float32)
+    output = torch.zeros(TILE_M, N, dtype=torch.float32)
+    matmul_valid_shape(a, b, output, config=cfg)
+    expected = torch.zeros_like(output)
+    expected[:VALID_M] = torch.matmul(a, b)
+    assert torch.allclose(output, expected, rtol=1e-3, atol=1e-3)
+    print("OK")

--- a/examples/kernels/12_matmul_valid_shape.py
+++ b/examples/kernels/12_matmul_valid_shape.py
@@ -41,9 +41,9 @@ def matmul_valid_shape(a: pl.Tensor, b: pl.Tensor, output: pl.InOut[pl.Tensor]):
             [TILE_M, N],
             pl.FP32,
             pl.Mem.Acc,
-            pl.TileView(valid_shape=[VALID_M, N]),
-        ] = pl.set_validshape(pl.matmul(a_left, b_right), VALID_M, N)
-        pl.store(result, [0, 0], output)
+        ] = pl.matmul(a_left, b_right)
+        valid_result: pl.Tile[[VALID_M, N], pl.FP32, pl.Mem.Acc] = pl.slice(result, [VALID_M, N], [0, 0])
+        pl.store(valid_result, [0, 0], output)
     return output
 
 

--- a/examples/kernels/12_matmul_valid_shape.py
+++ b/examples/kernels/12_matmul_valid_shape.py
@@ -7,14 +7,14 @@
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
 
-"""Matmul with a 16-row physical tile and five valid rows."""
+"""Matmul with a 32-row physical tile and 16 valid rows."""
 
 import pypto.language as pl
 import torch
 from pypto.runtime import RunConfig
 
-VALID_M = 5
-TILE_M = 16
+VALID_M = 16
+TILE_M = 32
 K = 16
 N = 16
 
@@ -42,8 +42,7 @@ def matmul_valid_shape(a: pl.Tensor, b: pl.Tensor, output: pl.InOut[pl.Tensor]):
             pl.FP32,
             pl.Mem.Acc,
         ] = pl.matmul(a_left, b_right)
-        valid_result: pl.Tile[[VALID_M, N], pl.FP32, pl.Mem.Acc] = pl.slice(result, [VALID_M, N], [0, 0])
-        pl.store(valid_result, [0, 0], output)
+        pl.store(result, [0, 0], output)
     return output
 
 

--- a/examples/kernels/__init__.py
+++ b/examples/kernels/__init__.py
@@ -21,6 +21,7 @@ Kernel examples — single-kernel programs, ordered by complexity.
   09_dyn_valid_shape.py — dynamic valid_shape via if/else and loop patterns
   10_split_k.py        — split-K matmul (parallel K reduction, atomic-add)
   11_auto_tile_matmul.py — compiler-driven L0 matmul tiling (DDR/Mat-scratch x full-K/split-K)
+  12_matmul_valid_shape.py — matmul with a padded physical tile and static valid_shape
 """
 
 import importlib
@@ -37,6 +38,7 @@ _ALIASES = {
     "assemble": "08_assemble",
     "dyn_valid_shape": "09_dyn_valid_shape",
     "auto_tile_matmul": "11_auto_tile_matmul",
+    "matmul_valid_shape": "12_matmul_valid_shape",
 }
 
 for _alias, _numbered in _ALIASES.items():

--- a/examples/models/04_paged_attention.py
+++ b/examples/models/04_paged_attention.py
@@ -118,7 +118,7 @@ def kernel_softmax_prepare_unaligned(
     pl.Tensor[[16, 1], pl.FP32],
 ]:
     """Softmax prepare with unaligned valid_len: load, set_validshape, fillpad, scale, softmax (VECTOR)."""
-    s_tile = pl.load(sij, [0, 0], [16, 128], valid_shapes=[16, valid_len], target_memory=pl.MemorySpace.Vec)
+    s_tile = pl.load(sij, [0, 0], [16, 128], valid_shape=[16, valid_len], target_memory=pl.MemorySpace.Vec)
     s_padded = pl.tile.fillpad(s_tile, pad_value=pl.PadValue.min)
     scaled = pl.mul(s_padded, scale)
     tmp_tile = pl.create_tile([16, 128], dtype=pl.FP32, target_memory=pl.MemorySpace.Vec)
@@ -381,7 +381,7 @@ def build_paged_attention_unaligned_program(
 
     Unlike build_paged_attention_program which slices sij to [q_tile, valid_len],
     this variant passes the full sij tensor to kernel_softmax_prepare_unaligned
-    with valid_len as a scalar. The kernel uses pl.load(..., valid_shapes=...)
+    with valid_len as a scalar. The kernel uses pl.load(..., valid_shape=...)
     + fillpad to handle the unaligned region via pto.set_validshape.
     """
     query_rows = batch * num_heads

--- a/examples/models/05_paged_attention_batch.py
+++ b/examples/models/05_paged_attention_batch.py
@@ -162,7 +162,7 @@ def BuildBatchPagedAttentionProgram(
                     [b * q_tile, 0],
                     [q_tile, block_size],
                     target_memory=pl.MemorySpace.Vec,
-                    valid_shapes=[q_tile, valid_len],
+                    valid_shape=[q_tile, valid_len],
                 )
 
                 s_padded = pl.tile.fillpad(s_tile, pad_value=pl.PadValue.min)

--- a/examples/models/06_paged_attention_dynamic.py
+++ b/examples/models/06_paged_attention_dynamic.py
@@ -129,7 +129,7 @@ def build_dynamic_paged_attention_program(
             sij,
             [0, 0],
             [_Q_TILE, _BLOCK_SIZE],
-            valid_shapes=[_Q_TILE, valid_len],
+            valid_shape=[_Q_TILE, valid_len],
             target_memory=pl.MemorySpace.Vec,
         )
         s_padded = pl.tile.fillpad(s_tile, pad_value=pl.PadValue.min)

--- a/examples/models/07_paged_attention_multi_config.py
+++ b/examples/models/07_paged_attention_multi_config.py
@@ -104,7 +104,7 @@ def make_kernel_softmax_prepare(q_tile: int, block_size: int, n_unroll_q: int):
         """Two-pass softmax with partial-block support (VECTOR).
 
         Pass 1 finds global row_max, pass 2 computes exp+sum.
-        The last block (i == n_blocks - 1) uses valid_shapes + fillpad to mask
+        The last block (i == n_blocks - 1) uses valid_shape + fillpad to mask
         out invalid columns with -inf so they don't affect row_max or row_sum.
         Uses mi_out/li_out as GM scratch for cross-iteration state via store/load round-trips.
         """
@@ -118,7 +118,7 @@ def make_kernel_softmax_prepare(q_tile: int, block_size: int, n_unroll_q: int):
                 sij_buf,
                 [i * q_tile, 0],
                 [q_tile, block_size],
-                valid_shapes=[q_tile, valid_len],
+                valid_shape=[q_tile, valid_len],
                 target_memory=pl.MemorySpace.Vec,
             )
             s_tile_padded = pl.tile.fillpad(s_tile, pad_value=pl.PadValue.min)
@@ -161,7 +161,7 @@ def make_kernel_softmax_prepare(q_tile: int, block_size: int, n_unroll_q: int):
                 sij_buf,
                 [i * q_tile, 0],
                 [q_tile, block_size],
-                valid_shapes=[q_tile, valid_len_p2],
+                valid_shape=[q_tile, valid_len_p2],
                 target_memory=pl.MemorySpace.Vec,
             )
             s_tile_p2 = pl.tile.fillpad(s_tile_raw, pad_value=pl.PadValue.min)

--- a/examples/models/09_paged_attention_spmd.py
+++ b/examples/models/09_paged_attention_spmd.py
@@ -217,7 +217,7 @@ def build_paged_attention_spmd_program(
                         [b * q_tile, 0],
                         [q_tile, block_size],
                         target_memory=pl.MemorySpace.Vec,
-                        valid_shapes=[q_tile, valid_len],
+                        valid_shape=[q_tile, valid_len],
                     )
                     s_padded = pl.tile.fillpad(s_tile, pad_value=pl.PadValue.min)
                     scaled = pl.mul(s_padded, scale_value)

--- a/python/pypto/debug/torch_codegen.py
+++ b/python/pypto/debug/torch_codegen.py
@@ -446,9 +446,9 @@ def _pad_scalar(tensor, pad_mode):
     iinfo = torch.iinfo(tensor.dtype)
     return iinfo.min if pad_mode == "min" else iinfo.max
 
-def _mask_valid_region(tensor, shapes, valid_shapes):
+def _mask_valid_region(tensor, shapes, valid_shape):
     shapes_t = _coerce_shape(shapes)
-    valid_t = _coerce_shape(valid_shapes) if valid_shapes is not None else None
+    valid_t = _coerce_shape(valid_shape) if valid_shape is not None else None
     if valid_t is not None:
         if valid_t != shapes_t:
             masked = tensor.new_zeros(shapes_t)
@@ -459,7 +459,7 @@ def _mask_valid_region(tensor, shapes, valid_shapes):
         tensor._pypto_full_shape = shapes_t
     return tensor
 
-def _tile_load(tensor, offsets, shapes, valid_shapes=None):
+def _tile_load(tensor, offsets, shapes, valid_shape=None):
     offsets_t = _coerce_shape(offsets)
     shapes_t = _coerce_shape(shapes)
     slices = tuple(slice(o, o + s) for o, s in zip(offsets_t, shapes_t))
@@ -471,8 +471,8 @@ def _tile_load(tensor, offsets, shapes, valid_shapes=None):
         pad_slices = tuple(slice(0, s) for s in actual_shape)
         padded[pad_slices] = tile
         tile = padded
-    # Use provided valid_shapes or fall back to the physical boundary; cap by actual data bounds.
-    v_shape = _coerce_shape(valid_shapes) if valid_shapes is not None else actual_shape
+    # Use provided valid_shape or fall back to the physical boundary; cap by actual data bounds.
+    v_shape = _coerce_shape(valid_shape) if valid_shape is not None else actual_shape
     v_shape = tuple(min(v, a) for v, a in zip(v_shape, actual_shape))
     return _mask_valid_region(tile, shapes_t, v_shape)
 
@@ -487,7 +487,7 @@ def _tile_store(tile, offsets, output_tensor, atomic=0):
         output_tensor[slices] = tile[valid_slices]
     return output_tensor
 
-def _tensor_slice(tensor, offsets, shapes, valid_shapes=None):
+def _tensor_slice(tensor, offsets, shapes, valid_shape=None):
     offsets_t = _coerce_shape(offsets)
     shapes_t = _coerce_shape(shapes)
     slices = tuple(slice(o, o + s) for o, s in zip(offsets_t, shapes_t))
@@ -499,8 +499,8 @@ def _tensor_slice(tensor, offsets, shapes, valid_shapes=None):
         pad_slices = tuple(slice(0, s) for s in sliced.shape)
         padded[pad_slices] = sliced
         sliced = padded
-    if valid_shapes is not None:
-        sliced._pypto_valid_shape = _coerce_shape(valid_shapes)
+    if valid_shape is not None:
+        sliced._pypto_valid_shape = _coerce_shape(valid_shape)
         sliced._pypto_full_shape = shapes_t
     return sliced
 
@@ -638,7 +638,7 @@ def _kw_dtype(kw: dict[str, Any]) -> str:
 
 
 def _handle_tile_load(a: list[str], kw: dict[str, Any]) -> str:
-    # args: [tensor, offsets_tuple, shapes_tuple, valid_shapes_tuple]
+    # args: [tensor, offsets_tuple, shapes_tuple, valid_shape_tuple]
     return f"_tile_load({a[0]}, {a[1]}, {a[2]}, {a[3]})"
 
 
@@ -662,7 +662,7 @@ def _handle_cmp(a: list[str], kw: dict[str, Any]) -> str:
 
 
 def _handle_slice(a: list[str], _kw: dict[str, Any]) -> str:
-    # args: [tensor, shapes, offsets] or [tensor, shapes, offsets, valid_shapes]
+    # args: [tensor, shapes, offsets] or [tensor, shapes, offsets, valid_shape]
     if len(a) >= 4:
         return f"_tensor_slice({a[0]}, {a[2]}, {a[1]}, {a[3]})"
     return f"_tensor_slice({a[0]}, {a[2]}, {a[1]})"

--- a/python/pypto/ir/op/tile_ops.py
+++ b/python/pypto/ir/op/tile_ops.py
@@ -2719,7 +2719,14 @@ def _resolve_tpop_type(
     return None
 
 
-def tpush_to_aiv(tile: Expr, *, split: int, id: int | None = None, span: Span | None = None) -> Call:
+def tpush_to_aiv(
+    tile: Expr,
+    *,
+    split: int,
+    id: int | None = None,
+    _full_box_transport: bool = False,
+    span: Span | None = None,
+) -> Call:
     """Push tile data from AIC to AIV via cross-core pipe.
 
     Args:
@@ -2732,6 +2739,8 @@ def tpush_to_aiv(tile: Expr, *, split: int, id: int | None = None, span: Span | 
     kwargs = {"split": split}
     if id is not None:
         kwargs["id"] = id
+    if _full_box_transport:
+        kwargs["_full_box_transport"] = True
     return _ir_core.create_op_call("tile.tpush_to_aiv", [tile], kwargs, actual_span)
 
 
@@ -2786,6 +2795,7 @@ def tpop_from_aic(
     dtype: DataType | None = None,
     split: int = 0,
     id: int | None = None,
+    _full_box_transport: bool = False,
     span: Span | None = None,
 ) -> Call:
     """Pop tile data from AIC cross-core pipe into AIV.
@@ -2803,6 +2813,8 @@ def tpop_from_aic(
     kwargs = {"split": split}
     if id is not None:
         kwargs["id"] = id
+    if _full_box_transport:
+        kwargs["_full_box_transport"] = True
     if resolved_type is not None:
         op = _ir_core.get_op("tile.tpop_from_aic")
         return _ir_core.Call(op, [], kwargs, resolved_type, actual_span)

--- a/python/pypto/ir/op/tile_ops.py
+++ b/python/pypto/ir/op/tile_ops.py
@@ -164,7 +164,7 @@ def load(
     tensor: Expr,
     offsets: Sequence[int | Expr] | _ir_core.MakeTuple,
     shapes: Sequence[int | Expr] | _ir_core.MakeTuple,
-    valid_shapes: Sequence[int | Expr] | _ir_core.MakeTuple | None = None,
+    valid_shape: Sequence[int | Expr] | _ir_core.MakeTuple | None = None,
     target_memory: MemorySpace = MemorySpace.Vec,
     clamp: bool = False,
     span: Span | None = None,
@@ -182,7 +182,7 @@ def load(
             Always in the source tensor's coordinate system.
         shapes: Shape of the region to load in each dimension (sequence of scalars),
             or a MakeTuple. Always in the source tensor's coordinate system.
-        valid_shapes: Valid shape of the tile in each dimension (sequence of scalars), or a
+        valid_shape: Valid shape of the tile in each dimension (sequence of scalars), or a
             MakeTuple. When provided, sets TileView.valid_shape in the output TileType.
             When omitted, shapes is used as valid_shape. Useful for dynamic shapes where
             the actual valid data region differs from the allocated tile size.
@@ -191,7 +191,7 @@ def load(
         target_memory: Target memory space (MemorySpace.Vec default, or MemorySpace.Mat).
             MX-layout tensors require an explicit MemorySpace.Mat.
         clamp: Sanction a read that runs off the end of the source. By default a
-            load asserts that ``offsets + valid_shapes`` stays inside the source
+            load asserts that ``offsets + valid_shape`` stays inside the source
             and is rejected when that provably fails; with ``clamp=True`` the
             request is cut back to the source edge instead.
         span: Optional source span for debugging (auto-captured if not provided)
@@ -228,17 +228,21 @@ def load(
     kwargs: dict[str, Any] = {"target_memory": target_memory}
     if clamp:
         kwargs["clamp"] = True
-    valid_shapes_tuple = shapes_tuple
-    if valid_shapes is not None:
-        valid_shapes_tuple = _to_make_tuple(valid_shapes, actual_span)
-        if len(valid_shapes_tuple.elements) != len(shapes_tuple.elements):
-            raise ValueError(
-                f"valid_shapes and shapes must have same number of dimensions, "
-                f"got {len(valid_shapes_tuple.elements)} valid_shapes and {len(shapes_tuple.elements)} shapes"
-            )
 
+    valid_shape_tuple = shapes_tuple
+    if valid_shape is not None:
+        valid_shape_tuple = _to_make_tuple(valid_shape, actual_span)
+        if len(valid_shape_tuple.elements) != len(shapes_tuple.elements):
+            raise ValueError(
+                "valid_shape and shapes must have same number of dimensions, "
+                f"got {len(valid_shape_tuple.elements)} valid_shape dimensions "
+                f"and {len(shapes_tuple.elements)} shapes"
+            )
     return _ir_core.create_op_call(
-        "tile.load", [tensor, offsets_tuple, shapes_tuple, valid_shapes_tuple], kwargs, actual_span
+        "tile.load",
+        [tensor, offsets_tuple, shapes_tuple, valid_shape_tuple],
+        kwargs,
+        actual_span,
     )
 
 

--- a/python/pypto/language/op/system_ops.py
+++ b/python/pypto/language/op/system_ops.py
@@ -267,9 +267,17 @@ def cacheinvalid(
     return _ir_ops.cacheinvalid(tensor.unwrap(), shp, off, span=span)
 
 
-def tpush_to_aiv(tile: Tile, *, split: int, id: int | None = None, span: Span | None = None) -> Call:
+def tpush_to_aiv(
+    tile: Tile,
+    *,
+    split: int,
+    id: int | None = None,
+    _full_box_transport: bool = False,
+    span: Span | None = None,
+) -> Call:
     """Push tile data from AIC to AIV via cross-core pipe."""
-    return _ir_ops.tpush_to_aiv(tile.unwrap(), split=split, id=id, span=span)
+    kwargs = {"_full_box_transport": True} if _full_box_transport else {}
+    return _ir_ops.tpush_to_aiv(tile.unwrap(), split=split, id=id, span=span, **kwargs)
 
 
 def tpush_to_aic(tile: Tile, *, split: int, id: int | None = None, span: Span | None = None) -> Call:
@@ -297,6 +305,7 @@ def tpop_from_aic(
     dtype: DataType | None = None,
     split: int = 0,
     id: int | None = None,
+    _full_box_transport: bool = False,
     span: Span | None = None,
 ) -> Tile:
     """Pop tile data from AIC cross-core pipe into AIV.
@@ -308,7 +317,8 @@ def tpop_from_aic(
         id: Optional frontend pipe id. Omit to use PTOAS default id 0.
         span: Optional source span
     """
-    call = _ir_ops.tpop_from_aic(shape=shape, dtype=dtype, split=split, id=id, span=span)
+    kwargs = {"_full_box_transport": True} if _full_box_transport else {}
+    call = _ir_ops.tpop_from_aic(shape=shape, dtype=dtype, split=split, id=id, span=span, **kwargs)
     return Tile(expr=call)
 
 

--- a/python/pypto/language/op/system_ops.py
+++ b/python/pypto/language/op/system_ops.py
@@ -276,8 +276,13 @@ def tpush_to_aiv(
     span: Span | None = None,
 ) -> Call:
     """Push tile data from AIC to AIV via cross-core pipe."""
-    kwargs = {"_full_box_transport": True} if _full_box_transport else {}
-    return _ir_ops.tpush_to_aiv(tile.unwrap(), split=split, id=id, span=span, **kwargs)
+    return _ir_ops.tpush_to_aiv(
+        tile.unwrap(),
+        split=split,
+        id=id,
+        _full_box_transport=_full_box_transport,
+        span=span,
+    )
 
 
 def tpush_to_aic(tile: Tile, *, split: int, id: int | None = None, span: Span | None = None) -> Call:
@@ -317,8 +322,14 @@ def tpop_from_aic(
         id: Optional frontend pipe id. Omit to use PTOAS default id 0.
         span: Optional source span
     """
-    kwargs = {"_full_box_transport": True} if _full_box_transport else {}
-    call = _ir_ops.tpop_from_aic(shape=shape, dtype=dtype, split=split, id=id, span=span, **kwargs)
+    call = _ir_ops.tpop_from_aic(
+        shape=shape,
+        dtype=dtype,
+        split=split,
+        id=id,
+        _full_box_transport=_full_box_transport,
+        span=span,
+    )
     return Tile(expr=call)
 
 

--- a/python/pypto/language/op/tile_ops.py
+++ b/python/pypto/language/op/tile_ops.py
@@ -363,7 +363,7 @@ def load(
     tensor: Tensor,
     offsets: Sequence[IntLike],
     shapes: Sequence[IntLike],
-    valid_shapes: Sequence[IntLike] | None = None,
+    valid_shape: Sequence[IntLike] | None = None,
     target_memory: MemorySpace = MemorySpace.Vec,
     clamp: bool = False,
 ) -> Tile:
@@ -380,14 +380,14 @@ def load(
             coordinate system.
         shapes: Shape of the region to load in each dimension. Always in the
             source tensor's coordinate system.
-        target_memory: Target memory space (MemorySpace.Vec default, or MemorySpace.Mat).
-            MX-layout tensors require an explicit MemorySpace.Mat.
-        valid_shapes: Valid shape of the tile in each dimension. When provided, sets
+        valid_shape: Valid shape of the tile in each dimension. When provided, sets
             TileView.valid_shape in the output TileType. When omitted, shapes is used
             as valid_shape. Uses the same coordinate convention as shapes. Narrows
             the tile; cannot widen it past what the source has.
+        target_memory: Target memory space (MemorySpace.Vec default, or MemorySpace.Mat).
+            MX-layout tensors require an explicit MemorySpace.Mat.
         clamp: Sanction a read that runs off the end of the source. By default a
-            load asserts ``offsets + valid_shapes`` stays inside the source and is
+            load asserts ``offsets + valid_shape`` stays inside the source and is
             rejected when that provably fails; ``clamp=True`` cuts the request back
             to the source edge instead.
 
@@ -398,13 +398,13 @@ def load(
         >>> # 2D load
         >>> tile = load(tensor, offsets=[0, 0], shapes=[32, 32])
     """
-    if valid_shapes is None:
-        valid_shapes = shapes
+    if valid_shape is None:
+        valid_shape = shapes
     call_expr = _ir_ops.load(
         tensor.unwrap(),
         _normalize_intlike(offsets),
         _normalize_intlike(shapes),
-        _normalize_intlike(valid_shapes),
+        _normalize_intlike(valid_shape),
         target_memory,
         clamp=clamp,
     )

--- a/python/pypto/language/op/unified_ops.py
+++ b/python/pypto/language/op/unified_ops.py
@@ -1312,7 +1312,7 @@ def set_validshape(input, valid_rows, valid_cols):
 
     .. note::
         Internal API — intended for compiler-generated code. End users should
-        prefer ``pl.load(..., valid_shapes=...)`` plus ``pl.tile.fillpad``.
+        prefer ``pl.load(..., valid_shape=...)`` plus ``pl.tile.fillpad``.
     """
     if isinstance(input, Tensor):
         return _tensor.set_validshape(input, valid_rows, valid_cols)

--- a/python/pypto/runtime/device_runner.py
+++ b/python/pypto/runtime/device_runner.py
@@ -909,7 +909,7 @@ def validate_golden(
     Positions where the golden holds ``NaN`` are treated as *don't-care* and are
     excluded from the comparison. Tests use this to mark output regions that the
     kernel leaves undefined by contract — e.g. the area outside a tile's
-    ``valid_shapes``, or an oversized scratch buffer's unused tail. (The runtime
+    ``valid_shape``, or an oversized scratch buffer's unused tail. (The runtime
     no longer zero-fills pure-output buffers, so such regions hold pooled-allocator
     garbage rather than 0.) A golden with no ``NaN`` compares every element, so this
     is fully backward-compatible.

--- a/src/backend/common/pto_ops_crosscore.cpp
+++ b/src/backend/common/pto_ops_crosscore.cpp
@@ -18,6 +18,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <sstream>
 #include <string>
 #include <string_view>
@@ -26,6 +27,7 @@
 #include <vector>
 
 #include "pypto/backend/common/backend.h"
+#include "pypto/backend/common/backend_handler.h"
 #include "pypto/codegen/codegen_base.h"
 #include "pypto/codegen/pto/pto_codegen.h"
 #include "pypto/core/dtype.h"
@@ -75,12 +77,21 @@ static std::shared_ptr<const ir::TileType> GetTpushTileType(const ExprPtr& tile_
   return As<ir::TileType>(tile_expr->GetType());
 }
 
-static bool EmitSplitTpushTransportValidShape(const CallPtr& op, codegen::PTOCodegen& codegen,
-                                              const std::string& tile_buf, const std::string& tile_type,
-                                              int split) {
+static bool EmitTpushTransportValidShape(const CallPtr& op, codegen::PTOCodegen& codegen,
+                                         const std::string& tile_buf, const std::string& tile_type,
+                                         int split) {
+  auto source_tile_type = GetTpushTileType(op->args_[0]);
+  const auto source_memory = source_tile_type ? source_tile_type->GetMemorySpace() : std::nullopt;
+  const bool no_split_acc_to_vec = split == 0 && codegen.GetBackendHandler()->GetPtoTargetArch() == "a2a3" &&
+                                   op->op_->name_ == "tile.tpush_to_aiv" && source_memory.has_value() &&
+                                   *source_memory == ir::MemorySpace::Acc;
+
   // split == 0 normally means no cross-core split: the single consumer reads
   // exactly the producer's (possibly narrowed) valid_shape, so no full-box
-  // transport is needed. BUT the 910B no-split dual-AIV dispatch path
+  // transport is needed. Acc-to-Vec is an exception: the A2/A3 C2V pipe moves
+  // the accumulator's full physical NZ box, so a partial logical shape must be
+  // widened for transport or the consumer can retain stale local-buffer data.
+  // The 910B no-split dual-AIV dispatch path is another exception
   // (function attr `dual_aiv_dispatch`) runs the producer on TWO AIV subblocks
   // that share one FIFO slot while the single cube consumer pops the FULL
   // slot. If the producer narrowed its valid_shape (e.g. set_validshape on a
@@ -89,11 +100,10 @@ static bool EmitSplitTpushTransportValidShape(const CallPtr& op, codegen::PTOCod
   // still transport the full box, exactly as for split==1/2 — this extends
   // PR #1454's fix to the split==0 dual-dispatch case.
   const bool dual_aiv_no_split = (split == 0) && codegen.IsDualAivDispatchFunction();
-  if ((split == 0 && !dual_aiv_no_split) || tile_buf.empty() || tile_type.empty()) {
+  if ((split == 0 && !dual_aiv_no_split && !no_split_acc_to_vec) || tile_buf.empty() || tile_type.empty()) {
     return false;
   }
 
-  auto source_tile_type = GetTpushTileType(op->args_[0]);
   if (!source_tile_type || source_tile_type->shape_.size() < 2) {
     return false;
   }
@@ -213,7 +223,7 @@ static std::string MakeTpushCodegenPTO(const char* target, const CallPtr& op,
 
   std::string tile_buf = codegen.GetExprAsCode(op->args_[0]);
   std::string tile_type = codegen.GetExprTypeAnnotation(op->args_[0]);
-  const bool restore_valid_shape = EmitSplitTpushTransportValidShape(op, codegen, tile_buf, tile_type, split);
+  const bool restore_valid_shape = EmitTpushTransportValidShape(op, codegen, tile_buf, tile_type, split);
 
   std::ostringstream oss;
   oss << "pto.tpush_to_" << target << "(" << tile_buf;

--- a/src/backend/common/pto_ops_crosscore.cpp
+++ b/src/backend/common/pto_ops_crosscore.cpp
@@ -82,9 +82,11 @@ static bool EmitTpushTransportValidShape(const CallPtr& op, codegen::PTOCodegen&
                                          int split) {
   auto source_tile_type = GetTpushTileType(op->args_[0]);
   const auto source_memory = source_tile_type ? source_tile_type->GetMemorySpace() : std::nullopt;
-  const bool no_split_acc_to_vec = split == 0 && codegen.GetBackendHandler()->GetPtoTargetArch() == "a2a3" &&
-                                   op->op_->name_ == "tile.tpush_to_aiv" && source_memory.has_value() &&
-                                   *source_memory == ir::MemorySpace::Acc;
+  const bool marked_full_box_transport = op->GetKwarg<bool>("_full_box_transport", false);
+  const bool no_split_acc_to_vec =
+      split == 0 && codegen.GetBackendHandler()->GetPtoTargetArch() == "a2a3" &&
+      op->op_->name_ == "tile.tpush_to_aiv" &&
+      (marked_full_box_transport || (source_memory.has_value() && *source_memory == ir::MemorySpace::Acc));
 
   // split == 0 normally means no cross-core split: the single consumer reads
   // exactly the producer's (possibly narrowed) valid_shape, so no full-box
@@ -257,6 +259,19 @@ static std::string MakeTpopCodegenPTO(const char* target, const CallPtr& op,
   INTERNAL_CHECK_SPAN(!result_buf.empty(), op->span_) << op_name << " requires assignment target (tile_buf)";
   std::string result_type = codegen.GetCurrentResultTileBufTypeString();
   auto [valid_row, valid_col] = codegen.GetCurrentResultTpopValidShapeOperands();
+  const bool full_box_transport = split == 0 && std::string_view(target) == "aic" &&
+                                  codegen.GetBackendHandler()->GetPtoTargetArch() == "a2a3" &&
+                                  op->GetKwarg<bool>("_full_box_transport", false);
+  if (full_box_transport) {
+    // A2/A3 C2V uses a fixed-size GM slot.  A partial logical tpop would copy
+    // only part of the slot and make the NZ-to-ND conversion use that partial
+    // extent.  Omit the optional operands so the raw FIFO tile receives the
+    // full physical box; its IR type still carries the logical valid_shape for
+    // downstream allocations.  Do not set_validshape on the raw tpop tile:
+    // PTOAS rejects that operation on FIFO-backed values.
+    valid_row.clear();
+    valid_col.clear();
+  }
 
   std::ostringstream oss;
   oss << result_buf << " = pto.tpop_from_" << target;

--- a/src/backend/common/pto_ops_datamove.cpp
+++ b/src/backend/common/pto_ops_datamove.cpp
@@ -430,7 +430,7 @@ static std::string MakeGatherRowCodegenPTO(const CallPtr& op, codegen::CodegenBa
   // GM source window -> partition_view, then tload into the subview. The
   // partition carries the *transfer extent*, not the static window — same as
   // tile.load, which likewise builds its partition type and sizes from
-  // valid_shapes. GetDimStrings renders a non-ConstInt extent as `?`, which
+  // valid_shape. GetDimStrings renders a non-ConstInt extent as `?`, which
   // TLoadOp::verify accepts on the src partition shape.
   //
   // Narrowing the partition is LOAD-BEARING, not tidiness: on a2a3 the GM->L1

--- a/src/backend/common/pto_ops_memory.cpp
+++ b/src/backend/common/pto_ops_memory.cpp
@@ -89,15 +89,15 @@ static std::string MakeTileLoadCodegenPTO(const CallPtr& op, codegen::CodegenBas
   auto shapes_tuple = As<ir::MakeTuple>(op->args_[2]);
   INTERNAL_CHECK_SPAN(shapes_tuple, op->span_) << "tile.load third argument must be a tuple (shapes)";
 
-  // valid_shapes is optional: when omitted (callers built before the 4-arg
+  // valid_shape is optional: when omitted (callers built before the 4-arg
   // signature was introduced, or hand-written IR), fall back to shapes so the
   // partition_view covers the entire physical region — equivalent to the DSL
-  // behavior `pl.load(..., valid_shapes=None)`.
-  auto valid_shapes_tuple = shapes_tuple;
+  // behavior `pl.load(..., valid_shape=None)`.
+  auto valid_shape_tuple = shapes_tuple;
   if (op->args_.size() >= 4) {
-    valid_shapes_tuple = As<ir::MakeTuple>(op->args_[3]);
-    INTERNAL_CHECK_SPAN(valid_shapes_tuple, op->span_)
-        << "tile.load fourth argument must be a tuple (valid_shapes)";
+    valid_shape_tuple = As<ir::MakeTuple>(op->args_[3]);
+    INTERNAL_CHECK_SPAN(valid_shape_tuple, op->span_)
+        << "tile.load fourth argument must be a tuple (valid_shape)";
   }
 
   auto tensor_type = AsTensorTypeLike(tensor->GetType());
@@ -125,13 +125,13 @@ static std::string MakeTileLoadCodegenPTO(const CallPtr& op, codegen::CodegenBas
   }
   const bool is_mx_load = !pto_layout.empty();
 
-  // RFC #1300 P7: the IR's offsets / shapes / valid_shapes are already in
+  // RFC #1300 P7: the IR's offsets / shapes / valid_shape are already in
   // canonical coordinates (matching the source TensorType's shape). There is
   // no implicit dn_swap here — earlier passes ensure all coordinate systems
   // match before codegen.
-  std::vector<std::string> partition_dims = GetDimStrings(valid_shapes_tuple->elements_);
+  std::vector<std::string> partition_dims = GetDimStrings(valid_shape_tuple->elements_);
   std::vector<std::string> offset_codes = GetIndexOffsetCodes(offsets_tuple->elements_, codegen);
-  std::vector<std::string> size_codes = GetSizeCodes(valid_shapes_tuple->elements_, codegen);
+  std::vector<std::string> size_codes = GetSizeCodes(valid_shape_tuple->elements_, codegen);
 
   std::string partition_type = MakePartitionTensorViewType(partition_dims, dtype_str);
   std::string partition_view = EmitPartitionViewPTO(tensor->name_hint_, tensor_view, tensor_view_type,

--- a/src/ir/op/tile_ops/cross_core.cpp
+++ b/src/ir/op/tile_ops/cross_core.cpp
@@ -187,9 +187,13 @@ TypePtr DeduceSplitReshapeTensor(const std::vector<ExprPtr>& args,
 
   // Valid shape: TensorView::valid_shape if set, otherwise the static shape
   // (mirrors GetValidShape for tiles).
-  std::vector<ExprPtr> valid = (tensor_type->tensor_view_ && !tensor_type->tensor_view_->valid_shape.empty())
-                                   ? tensor_type->tensor_view_->valid_shape
-                                   : tensor_type->shape_;
+  std::vector<ExprPtr> valid = tensor_type->shape_;
+  if (const auto& tensor_view = tensor_type->tensor_view_; tensor_view.has_value()) {
+    const auto& view = tensor_view.value();
+    if (!view.valid_shape.empty()) {
+      valid = view.valid_shape;
+    }
+  }
   auto reshaped =
       ReshapeSplitAxis(tensor_type->shape_, std::move(valid), axis, halve, op_name, args[0]->span_);
 
@@ -229,6 +233,7 @@ REGISTER_OP("tile.tpush_to_aiv")
     .add_argument("tile", "Tile data to transfer")
     .set_attr<int>("split")
     .set_attr<int>("id")
+    .set_attr<bool>("_full_box_transport")
     .no_memory_spec()
     .f_deduce_type(DeduceUnknownType);
 
@@ -253,6 +258,7 @@ REGISTER_OP("tile.tpop_from_aic")
     .no_argument()
     .set_attr<int>("split")
     .set_attr<int>("id")
+    .set_attr<bool>("_full_box_transport")
     .no_memory_spec()
     .f_deduce_type(DeduceUnknownType);
 

--- a/src/ir/op/tile_ops/elementwise.cpp
+++ b/src/ir/op/tile_ops/elementwise.cpp
@@ -180,7 +180,7 @@ TypePtr DeduceTileOpElementwiseBinaryType(const std::vector<ExprPtr>& args,
                                   << FormatShape(tile_type2->shape_);
 
   // TODO(YunjiQin): assumes both src tiles have the same valid_shape; may need refinement
-  // for cases where lhs and rhs have different valid_shapes (e.g. after broadcasting).
+  // for cases where lhs and rhs have different valid_shape values (e.g. after broadcasting).
   TileView tile_view;
   tile_view.valid_shape = GetValidShape(tile_type1);
   InheritTileViewLayout(tile_view, tile_type1);
@@ -211,7 +211,7 @@ TypePtr DeduceTileOpShiftBinaryType(const std::vector<ExprPtr>& args,
   CHECK(broadcast_result.success) << "The operator " << op_name << " requires compatible shapes";
 
   // TODO(YunjiQin): assumes both src tiles have the same valid_shape; may need refinement
-  // for cases where lhs and rhs have different valid_shapes (e.g. after broadcasting).
+  // for cases where lhs and rhs have different valid_shape values (e.g. after broadcasting).
   TileView tile_view;
   tile_view.valid_shape = GetValidShape(tile_type1);
   InheritTileViewLayout(tile_view, tile_type1);
@@ -702,7 +702,7 @@ TypePtr DeduceTileOpTernaryType(const std::vector<ExprPtr>& args,
   CHECK(broadcast_result.success) << "The operator " << op_name << " requires compatible shapes";
 
   // TODO(YunjiQin): assumes both src tiles have the same valid_shape; may need refinement
-  // for cases where lhs and rhs have different valid_shapes (e.g. after broadcasting).
+  // for cases where lhs and rhs have different valid_shape values (e.g. after broadcasting).
   TileView tile_view;
   tile_view.valid_shape = GetValidShape(tile_type1);
   InheritTileViewLayout(tile_view, tile_type1);
@@ -737,7 +737,7 @@ TypePtr DeduceTileOpTriTileType(const std::vector<ExprPtr>& args,
   CHECK(broadcast_result.success) << "The operator " << op_name << " requires compatible shapes";
 
   // TODO(YunjiQin): assumes all src tiles have the same valid_shape; may need refinement
-  // for cases where tiles have different valid_shapes (e.g. after broadcasting).
+  // for cases where tiles have different valid_shape values (e.g. after broadcasting).
   TileView tile_view;
   tile_view.valid_shape = GetValidShape(tile_type1);
   InheritTileViewLayout(tile_view, tile_type1);
@@ -772,7 +772,7 @@ TypePtr DeduceTileOpTileScalarTileType(const std::vector<ExprPtr>& args,
   CHECK(broadcast_result.success) << "The operator " << op_name << " requires compatible shapes";
 
   // TODO(YunjiQin): assumes both src tiles have the same valid_shape; may need refinement
-  // for cases where lhs and rhs tiles have different valid_shapes (e.g. after broadcasting).
+  // for cases where lhs and rhs tiles have different valid_shape values (e.g. after broadcasting).
   TileView tile_view;
   tile_view.valid_shape = GetValidShape(tile_type1);
   InheritTileViewLayout(tile_view, tile_type1);
@@ -962,7 +962,7 @@ TypePtr DeduceTileSelType(const std::vector<ExprPtr>& args,
                                   << FormatShape(tile_type2->shape_);
 
   // TODO(YunjiQin): assumes both src tiles have the same valid_shape; may need refinement
-  // for cases where lhs and rhs have different valid_shapes (e.g. after broadcasting).
+  // for cases where lhs and rhs have different valid_shape values (e.g. after broadcasting).
   TileView tile_view;
   tile_view.valid_shape = GetValidShape(tile_type1);
   InheritTileViewLayout(tile_view, tile_type1);
@@ -1025,7 +1025,7 @@ TypePtr DeduceTileSelScalarType(const std::vector<ExprPtr>& args,
                                   << FormatShape(tile_type2->shape_);
 
   // TODO(YunjiQin): assumes both src tiles have the same valid_shape; may need refinement
-  // for cases where lhs and rhs have different valid_shapes (e.g. after broadcasting).
+  // for cases where lhs and rhs have different valid_shape values (e.g. after broadcasting).
   TileView tile_view;
   tile_view.valid_shape = GetValidShape(tile_type1);
   InheritTileViewLayout(tile_view, tile_type1);

--- a/src/ir/op/tile_ops/matmul.cpp
+++ b/src/ir/op/tile_ops/matmul.cpp
@@ -96,7 +96,9 @@ TypePtr DeduceTileMatMulType(const std::vector<ExprPtr>& args,
   tile_view.blayout = TileLayout::col_major;
   tile_view.slayout = TileLayout::row_major;
   tile_view.fractal = 1024;
-  tile_view.valid_shape = output_shape;
+  const auto lhs_valid_shape = GetValidShape(lhs_type);
+  const auto rhs_valid_shape = GetValidShape(rhs_type);
+  tile_view.valid_shape = {lhs_valid_shape[0], rhs_valid_shape[1]};
 
   return std::make_shared<TileType>(output_shape, result_dtype, std::nullopt, tile_view);
 }

--- a/src/ir/op/tile_ops/memory.cpp
+++ b/src/ir/op/tile_ops/memory.cpp
@@ -91,9 +91,9 @@ TypePtr DeduceTileGetSubblockIdxType(const std::vector<ExprPtr>& args,
 TypePtr DeduceTileLoadType(const std::vector<ExprPtr>& args,
                            const std::vector<std::pair<std::string, std::any>>& kwargs,
                            const std::string& op_name) {
-  // load signature: (tensor, offsets_tuple, shapes_tuple, valid_shapes_tuple)
+  // load signature: (tensor, offsets_tuple, shapes_tuple, valid_shape_tuple)
   CHECK(args.size() == 4) << "The operator " << op_name
-                          << " requires 4 arguments (tensor, offsets, shapes, valid_shapes), but got "
+                          << " requires 4 arguments (tensor, offsets, shapes, valid_shape), but got "
                           << args.size();
 
   // First argument must be a tensor-shaped source. AsTensorTypeLike accepts
@@ -117,21 +117,21 @@ TypePtr DeduceTileLoadType(const std::vector<ExprPtr>& args,
                       << " requires third argument to be a tuple (shapes), but got "
                       << args[2]->GetType()->TypeName();
 
-  // Fourth argument must be TupleType (valid_shapes)
-  auto valid_shapes_tuple = As<MakeTuple>(args[3]);
-  CHECK(valid_shapes_tuple) << "The operator " << op_name
-                            << " requires fourth argument to be a tuple (valid shapes), but got "
-                            << args[3]->GetType()->TypeName();
+  // Fourth argument must be TupleType (valid_shape)
+  auto valid_shape_tuple = As<MakeTuple>(args[3]);
+  CHECK(valid_shape_tuple) << "The operator " << op_name
+                           << " requires fourth argument to be a tuple (valid shape), but got "
+                           << args[3]->GetType()->TypeName();
 
-  // Verify offsets, shapes and valid_shapes have same number of dimensions
+  // Verify offsets, shapes and valid_shape have same number of dimensions
   CHECK(offsets_tuple->elements_.size() == shapes_tuple->elements_.size())
       << "The operator " << op_name
       << " requires offsets and shapes to have same number of dimensions, but got "
       << offsets_tuple->elements_.size() << " offsets and " << shapes_tuple->elements_.size() << " shapes";
-  CHECK(valid_shapes_tuple->elements_.size() == shapes_tuple->elements_.size())
+  CHECK(valid_shape_tuple->elements_.size() == shapes_tuple->elements_.size())
       << "The operator " << op_name
-      << " requires valid_shapes and shapes to have same number of dimensions, but got "
-      << valid_shapes_tuple->elements_.size() << " valid_shapes and " << shapes_tuple->elements_.size()
+      << " requires valid_shape and shapes to have the same number of dimensions, but got "
+      << valid_shape_tuple->elements_.size() << " valid_shape and " << shapes_tuple->elements_.size()
       << " shapes";
   CHECK(shapes_tuple->elements_.size() > 0)
       << "The operator " << op_name << " requires at least one dimension, but got empty shapes tuple";
@@ -218,20 +218,20 @@ TypePtr DeduceTileLoadType(const std::vector<ExprPtr>& args,
   // the destination tile may deliberately overhang the source (that is what makes
   // a ragged tail expressible), but the bytes actually read must exist and must
   // be real data. Intersecting with the source valid region enforces both, and
-  // rejects a valid_shapes request that provably reads past the source. clamp=True
+  // rejects a valid_shape request that provably reads past the source. clamp=True
   // narrows such a request to the source edge instead of rejecting it.
   //
   // As with tensor.slice, the rule needs the window to be a rectangle in source
   // coordinates. A lower-rank window (e.g. a 2D tile out of a 3D tensor) is a
   // reinterpreting read whose dim correspondence is not this rectangle, so it
-  // keeps the valid_shapes it was given.
+  // keeps the valid_shape it was given.
   if (tile_shape.size() == tensor_type->shape_.size()) {
     tile_view.valid_shape = InferWindowReadValidShape({
         /*source_physical=*/tensor_type->shape_,
         /*source_valid=*/GetEffectiveTensorValidShape(*tensor_type),
         /*offsets=*/offsets_tuple->elements_,
         /*window=*/tile_shape,
-        /*requested_valid=*/valid_shapes_tuple->elements_,
+        /*requested_valid=*/valid_shape_tuple->elements_,
         /*kind=*/WindowReadKind::kClampedWindow,
         /*clamp=*/GetKwargOr<bool>(kwargs, "clamp", false),
         /*op_name=*/op_name,
@@ -241,7 +241,7 @@ TypePtr DeduceTileLoadType(const std::vector<ExprPtr>& args,
         /*span=*/args[0]->span_,
     });
   } else {
-    tile_view.valid_shape = valid_shapes_tuple->elements_;
+    tile_view.valid_shape = valid_shape_tuple->elements_;
   }
 
   // Return TileType with same dtype as tensor and TileView containing valid_shape.
@@ -974,7 +974,7 @@ REGISTER_OP("tile.load")
         "shapes",
         "Shape of region to load in each dimension, in source tensor coordinates (TupleType of ScalarType)")
     .add_argument(
-        "valid_shapes",
+        "valid_shape",
         "Valid shape of tile in each dimension, in source tensor coordinates (TupleType of ScalarType). ")
     .set_attr<MemorySpace>("target_memory")
     .set_attr<bool>("clamp")

--- a/src/ir/op/tile_ops/memory.cpp
+++ b/src/ir/op/tile_ops/memory.cpp
@@ -159,9 +159,9 @@ TypePtr DeduceTileLoadType(const std::vector<ExprPtr>& args,
     CHECK(shapes_tuple->elements_.size() == 2)
         << "The operator " << op_name << " of an MX-layout tensor requires a 2D load window, got rank "
         << shapes_tuple->elements_.size();
-    CHECK(valid_shapes_tuple->elements_.size() == 2)
-        << "The operator " << op_name << " of an MX-layout tensor requires 2D valid_shapes, got rank "
-        << valid_shapes_tuple->elements_.size();
+    CHECK(valid_shape_tuple->elements_.size() == 2)
+        << "The operator " << op_name << " of an MX-layout tensor requires 2D valid_shape, got rank "
+        << valid_shape_tuple->elements_.size();
     const TensorView& source_view = *tensor_type->tensor_view_;
     const auto packed_stride =
         tensor_view_semantics::BuildLogicalStridesFromLayout(tensor_type->shape_, source_view.layout);

--- a/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
+++ b/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
@@ -657,13 +657,13 @@ class TensorToTileMutator : public TypePropagatingMutator {
 
     const auto& shape_arg = call->args_[1];
     const auto& offset_arg = call->args_[2];
-    ExprPtr valid_shapes = (call->args_.size() == 4) ? call->args_[3] : shape_arg;
+    ExprPtr valid_shape = (call->args_.size() == 4) ? call->args_[3] : shape_arg;
 
     // The consumer-driven load is always natural; a transposed (b_trans/a_trans)
     // operand gets a zero-copy tile.transpose_view at the matmul site instead.
     std::vector<std::pair<std::string, std::any>> load_kwargs = {{"target_memory", req.space}};
     auto load_call =
-        MarkCompilerMatBridge(op_registry_.Create("tile.load", {input, offset_arg, shape_arg, valid_shapes},
+        MarkCompilerMatBridge(op_registry_.Create("tile.load", {input, offset_arg, shape_arg, valid_shape},
                                                   load_kwargs, call->span_),
                               req.space);
 

--- a/src/ir/transforms/expand_mixed_kernel_pass.cpp
+++ b/src/ir/transforms/expand_mixed_kernel_pass.cpp
@@ -347,12 +347,18 @@ void CollectCVBoundaryMoves(const std::vector<StmtPtr>& stmts,
 // TPUSH / TPOP creation helpers
 // ============================================================================
 
-std::vector<std::pair<std::string, std::any>> MakeSplitKwargs(int split = 0) {
-  return {{"split", std::any(split)}};
+std::vector<std::pair<std::string, std::any>> MakeSplitKwargs(int split = 0,
+                                                              bool full_box_transport = false) {
+  std::vector<std::pair<std::string, std::any>> kwargs{{"split", std::any(split)}};
+  if (full_box_transport) {
+    kwargs.emplace_back("_full_box_transport", std::any(true));
+  }
+  return kwargs;
 }
 
-CallPtr CreateTpush(const std::string& op_name, const ExprPtr& tile, const Span& span, int split = 0) {
-  return OpRegistry::GetInstance().Create(op_name, {tile}, MakeSplitKwargs(split), span);
+CallPtr CreateTpush(const std::string& op_name, const ExprPtr& tile, const Span& span, int split = 0,
+                    bool full_box_transport = false) {
+  return OpRegistry::GetInstance().Create(op_name, {tile}, MakeSplitKwargs(split, full_box_transport), span);
 }
 
 CallPtr CreateTpop(const std::string& op_name, const TypePtr& result_type, const Span& span,
@@ -373,6 +379,22 @@ CallPtr CreateMove(const ExprPtr& tile, MemorySpace target_memory, const TypePtr
     kwargs.emplace_back("slayout", std::any(eff.slayout));
   }
   return std::make_shared<Call>(op, std::vector<ExprPtr>{tile}, std::move(kwargs), result_type, span);
+}
+
+bool NeedsFullBoxC2VTransport(const core_affinity::CVBoundaryMove& boundary) {
+  if (boundary.direction != CVDirection::CUBE_TO_VECTOR) {
+    return false;
+  }
+  auto source_type = std::dynamic_pointer_cast<const TileType>(boundary.source_tile->GetType());
+  if (!source_type) {
+    return false;
+  }
+  const auto source_memory = source_type->GetMemorySpace();
+  if (!source_memory.has_value() || *source_memory != MemorySpace::Acc) {
+    return false;
+  }
+  const auto source_view = tile_view_semantics::GetEffectiveTileView(*source_type);
+  return !tile_view_semantics::ShapeExprListsEquivalent(source_type->shape_, source_view.valid_shape);
 }
 
 // ============================================================================
@@ -707,6 +729,7 @@ std::vector<StmtPtr> BuildCoreBody(CoreSide side, const std::vector<StmtPtr>& st
         // names the other lane whenever this side is the producer.
         const MemorySpace xfer_ms = GetBoundaryTpopMemory(side);
         const int op_split = bm.op_driven ? bm.split : 0;
+        const bool full_box_transport = NeedsFullBoxC2VTransport(bm);
         if (bm.direction == push_direction) {
           ExprPtr push_source = bm.source_tile;
           // AIV V->C push: insert tile.move (tmov) to adapt the source into
@@ -749,7 +772,7 @@ std::vector<StmtPtr> BuildCoreBody(CoreSide side, const std::vector<StmtPtr>& st
             push_source = tmov_var;
           }
           result.push_back(std::make_shared<EvalStmt>(
-              CreateTpush(push_op, push_source, stmt->span_, op_split), stmt->span_));
+              CreateTpush(push_op, push_source, stmt->span_, op_split, full_box_transport), stmt->span_));
         } else {
           // Op-driven pop: the half/full shape comes from the op result type and
           // the memory from this side's transfer memory; the explicit follow-on
@@ -805,10 +828,13 @@ std::vector<StmtPtr> BuildCoreBody(CoreSide side, const std::vector<StmtPtr>& st
             }
           }
           tpop_var_remap[tpop_var.get()] = tpop_var;
-          // tile.move boundary tpops carry no split kwarg here (assigned later by
-          // SplitVectorKernel); op-driven tpops stamp the op's split now.
-          auto pop_kwargs =
-              bm.op_driven ? MakeSplitKwargs(op_split) : std::vector<std::pair<std::string, std::any>>{};
+          // tile.move boundary tpops normally carry no split kwarg here (it is
+          // assigned later by SplitVectorKernel).  The full-box transport marker
+          // is round-tripped through the DSL together with an explicit split=0;
+          // SplitVectorKernel still overwrites it when the function is split.
+          auto pop_kwargs = bm.op_driven || full_box_transport
+                                ? MakeSplitKwargs(op_split, full_box_transport)
+                                : std::vector<std::pair<std::string, std::any>>{};
           result.push_back(std::make_shared<AssignStmt>(
               tpop_var, CreateTpop(pop_op, tpop_result_type, stmt->span_, pop_kwargs), stmt->span_));
           if (needs_post_move) {

--- a/src/ir/transforms/flatten_tile_nd_to_2d/rewrite.cpp
+++ b/src/ir/transforms/flatten_tile_nd_to_2d/rewrite.cpp
@@ -695,19 +695,19 @@ std::vector<StmtPtr> TransformBody(const std::vector<StmtPtr>& stmts, FlattenCon
           auto shapes_tuple = As<MakeTuple>(sub_args[2]);
           INTERNAL_CHECK_SPAN(offsets_tuple && shapes_tuple, span)
               << "FlattenTileNdTo2D: tile.load offsets and shapes must be tuples";
-          auto valid_shapes_tuple = shapes_tuple;
+          auto valid_shape_tuple = shapes_tuple;
           if (sub_args.size() >= 4) {
-            valid_shapes_tuple = As<MakeTuple>(sub_args[3]);
-            INTERNAL_CHECK_SPAN(valid_shapes_tuple, span)
-                << "FlattenTileNdTo2D: tile.load valid_shapes must be a tuple";
+            valid_shape_tuple = As<MakeTuple>(sub_args[3]);
+            INTERNAL_CHECK_SPAN(valid_shape_tuple, span)
+                << "FlattenTileNdTo2D: tile.load valid_shape must be a tuple";
           }
           INTERNAL_CHECK_SPAN(offsets_tuple->elements_.size() == tensor_type->shape_.size() &&
                                   shapes_tuple->elements_.size() == tensor_type->shape_.size() &&
-                                  valid_shapes_tuple->elements_.size() == tensor_type->shape_.size(),
+                                  valid_shape_tuple->elements_.size() == tensor_type->shape_.size(),
                               span)
               << "FlattenTileNdTo2D: tile.load offset/shape ranks must match tensor rank";
           INTERNAL_CHECK_SPAN(tile_conversion_utils::IsRowMajorCollapseContiguous(
-                                  valid_shapes_tuple->elements_, tensor_type->shape_),
+                                  valid_shape_tuple->elements_, tensor_type->shape_),
                               span)
               << "FlattenTileNdTo2D: tile.load NZ 2D source-window collapse requires the valid "
                  "sub-box of the leading dims to be contiguous in row-major order";
@@ -723,12 +723,12 @@ std::vector<StmtPtr> TransformBody(const std::vector<StmtPtr>& stmts, FlattenCon
               std::vector<ExprPtr>{row_offset, offsets_tuple->elements_.back()}, span);
           sub_args[2] =
               std::make_shared<MakeTuple>(CollapseLeadingDimsTo2D(shapes_tuple->elements_, span), span);
-          auto flat_valid_shapes =
-              std::make_shared<MakeTuple>(CollapseLeadingDimsTo2D(valid_shapes_tuple->elements_, span), span);
+          auto flat_valid_shape =
+              std::make_shared<MakeTuple>(CollapseLeadingDimsTo2D(valid_shape_tuple->elements_, span), span);
           if (sub_args.size() >= 4) {
-            sub_args[3] = flat_valid_shapes;
+            sub_args[3] = flat_valid_shape;
           } else {
-            sub_args.push_back(flat_valid_shapes);
+            sub_args.push_back(flat_valid_shape);
           }
         }
 

--- a/src/ir/transforms/lower_auto_vector_split_pass.cpp
+++ b/src/ir/transforms/lower_auto_vector_split_pass.cpp
@@ -569,13 +569,13 @@ bool ReferencesLaneIndex(const std::vector<ExprPtr>& exprs,
 //
 // Only these args are consulted for a lane reference. A lane-derived scalar
 // anywhere ELSE in an addressing op — a shape, a valid_shape — does not localize
-// the window: ``tile.load(data, [0, 0], [64, 128], valid_shapes=[aiv_id + 1,
+// the window: ``tile.load(data, [0, 0], [64, 128], valid_shape=[aiv_id + 1,
 // 128])`` mentions aiv_id, yet both lanes still read the same base rows. Scanning
 // every arg would admit it and then trust its consumers as half-width.
 std::vector<ExprPtr> AddressArgs(const CallPtr& call) {
   const auto& args = call->args_;
   auto at = [&args](size_t i) -> ExprPtr { return i < args.size() ? args[i] : nullptr; };
-  if (IsOp(call, "tile.load")) return {at(1)};            // (tensor, offsets, shapes, valid_shapes)
+  if (IsOp(call, "tile.load")) return {at(1)};            // (tensor, offsets, shapes, valid_shape)
   if (IsOp(call, "tile.slice")) return {at(2)};           // (input, shape, offset, valid_shape, drop_dims)
   if (IsOp(call, "tile.extract")) return {at(1), at(2)};  // (src, index_row, index_col, shape)
   // (dst, src, dst_offset, src_offset, shapes[, valid_shape]) — DPS: the op reads

--- a/src/ir/transforms/op_conversion_registry.cpp
+++ b/src/ir/transforms/op_conversion_registry.cpp
@@ -450,10 +450,9 @@ void OpConversionRegistry::RegisterMemoryOps() {
           // pad_value on a tensor.slice over a TensorType input, the pad intent is
           // lost here — a follow-up tile.fillpad is the workaround until tile.load
           // grows its own pad_value kwarg.
-          auto valid_shapes = (args.size() == 4) ? args[3] : shape;
+          auto valid_shape = (args.size() == 4) ? args[3] : shape;
           std::vector<std::pair<std::string, std::any>> load_kwargs = {{"target_memory", MemorySpace::Vec}};
-          auto load_call =
-              op_reg.Create("tile.load", {input, offset, shape, valid_shapes}, load_kwargs, span);
+          auto load_call = op_reg.Create("tile.load", {input, offset, shape, valid_shape}, load_kwargs, span);
           return ConversionResult{load_call};
         }
 
@@ -739,15 +738,14 @@ void OpConversionRegistry::RegisterMemoryOps() {
         auto offsets = MakeZeroOffsets(tensor_type->shape_.size(), span);
         auto shapes = MakeShapeTuple(tensor_type->shape_, span);
 
-        std::vector<ExprPtr> valid_shape = tensor_type->shape_;
+        std::vector<ExprPtr> logical_valid_shape = tensor_type->shape_;
         if (tensor_type->tensor_view_.has_value() && !tensor_type->tensor_view_->valid_shape.empty()) {
-          valid_shape = tensor_type->tensor_view_->valid_shape;
+          logical_valid_shape = tensor_type->tensor_view_->valid_shape;
         }
-        auto valid_shapes = MakeShapeTuple(valid_shape, span);
+        auto valid_shape = MakeShapeTuple(logical_valid_shape, span);
 
         std::vector<std::pair<std::string, std::any>> load_kwargs = {{"target_memory", MemorySpace::Vec}};
-        auto load_call =
-            op_reg.Create("tile.load", {input, offsets, shapes, valid_shapes}, load_kwargs, span);
+        auto load_call = op_reg.Create("tile.load", {input, offsets, shapes, valid_shape}, load_kwargs, span);
         auto load_var = std::make_shared<Var>("fillpad_src", load_call->GetType(), span);
 
         std::vector<StmtPtr> prologue;
@@ -786,15 +784,14 @@ void OpConversionRegistry::RegisterMemoryOps() {
         // Load the (smaller) source tensor into a tile carrying its valid region.
         auto offsets = MakeZeroOffsets(tensor_type->shape_.size(), span);
         auto shapes = MakeShapeTuple(tensor_type->shape_, span);
-        std::vector<ExprPtr> valid_shape = tensor_type->shape_;
+        std::vector<ExprPtr> logical_valid_shape = tensor_type->shape_;
         if (tensor_type->tensor_view_.has_value() && !tensor_type->tensor_view_->valid_shape.empty()) {
-          valid_shape = tensor_type->tensor_view_->valid_shape;
+          logical_valid_shape = tensor_type->tensor_view_->valid_shape;
         }
-        auto valid_shapes = MakeShapeTuple(valid_shape, span);
+        auto valid_shape = MakeShapeTuple(logical_valid_shape, span);
 
         std::vector<std::pair<std::string, std::any>> load_kwargs = {{"target_memory", MemorySpace::Vec}};
-        auto load_call =
-            op_reg.Create("tile.load", {input, offsets, shapes, valid_shapes}, load_kwargs, span);
+        auto load_call = op_reg.Create("tile.load", {input, offsets, shapes, valid_shape}, load_kwargs, span);
         auto load_var = std::make_shared<Var>("fillpad_expand_src", load_call->GetType(), span);
 
         std::vector<StmtPtr> prologue;
@@ -928,13 +925,13 @@ void OpConversionRegistry::RegisterMemoryOps() {
 
         auto load_tensor_tile = [&](const ExprPtr& tensor, const ExprPtr& offsets,
                                     const std::vector<ExprPtr>& shape,
-                                    const std::vector<ExprPtr>& valid_shape, const std::string& name_hint,
-                                    std::vector<StmtPtr>& stmts) -> ExprPtr {
+                                    const std::vector<ExprPtr>& logical_valid_shape,
+                                    const std::string& name_hint, std::vector<StmtPtr>& stmts) -> ExprPtr {
           auto shapes = MakeShapeTuple(shape, span);
-          auto valid_shapes = MakeShapeTuple(valid_shape, span);
+          auto valid_shape = MakeShapeTuple(logical_valid_shape, span);
           std::vector<std::pair<std::string, std::any>> load_kwargs = {{"target_memory", MemorySpace::Vec}};
           auto load_call =
-              op_reg.Create("tile.load", {tensor, offsets, shapes, valid_shapes}, load_kwargs, span);
+              op_reg.Create("tile.load", {tensor, offsets, shapes, valid_shape}, load_kwargs, span);
           auto load_var = std::make_shared<Var>(name_hint, load_call->GetType(), span);
           stmts.push_back(std::make_shared<AssignStmt>(load_var, load_call, span));
           return load_var;

--- a/src/ir/transforms/optimize_orch_tensors_pass.cpp
+++ b/src/ir/transforms/optimize_orch_tensors_pass.cpp
@@ -306,8 +306,8 @@ class IterArgReuseOptimizer {
   // share storage (an accumulator); a plain load→store pair does not.
 
   /// Check that a tile.load call reads the full tensor — all offsets zero and
-  /// both `shapes` and `valid_shapes` match the tensor shape dimension-by-
-  /// dimension. `valid_shapes` differs from `shapes` for masked/padded loads,
+  /// both `shapes` and `valid_shape` match the tensor shape dimension-by-
+  /// dimension. `valid_shape` differs from `shapes` for masked/padded loads,
   /// which must NOT be treated as full loads.
   static bool IsFullTensorLoad(const CallPtr& load_call, const TensorTypePtr& tensor_type) {
     if (!load_call || load_call->args_.size() < 4 || !tensor_type) return false;

--- a/tests/st/codegen/dsl/test_flatten_dynamic_tile_3d.py
+++ b/tests/st/codegen/dsl/test_flatten_dynamic_tile_3d.py
@@ -14,7 +14,7 @@ A 3D+ tensor with a *dynamic* dimension that flows into a tile shape inside an
 flattened directly. The user handles it by **writing the chunk loop themselves**:
 they iterate the dynamic dimension with ``pl.range`` in a static ``CHUNK`` step
 and load each chunk as a static physical ``[1, CHUNK, 512]`` tile whose
-``valid_shapes`` carries the runtime tail ``min(CHUNK, s - c)``. The chunk size
+``valid_shape`` carries the runtime tail ``min(CHUNK, s - c)``. The chunk size
 is the user's choice (it strongly affects performance).
 
 ``FlattenTileNdTo2D`` then only needs to lower the per-chunk ``[1, CHUNK, 512]``
@@ -49,7 +49,7 @@ def cast_3d_dynamic(
 
     The user iterates the dynamic S dim in CHUNK steps and loads each chunk as a
     static ``[1, CHUNK, 512]`` tile, clamping the tail with
-    ``valid_shapes=[1, min(CHUNK, s - c), 512]`` so the last (partial) chunk does
+    ``valid_shape=[1, min(CHUNK, s - c), 512]`` so the last (partial) chunk does
     not read out of bounds.
     """
     b_dim = pl.tensor.dim(x, 0)
@@ -62,7 +62,7 @@ def cast_3d_dynamic(
             # (the LHS supplies the post-loop binding); bare pl.yield_ is rejected.
             for c, (o,) in pl.range(0, s_dim, CHUNK, init_values=(out,)):
                 valid = pl.min(CHUNK, s_dim - c)
-                t = pl.load(x, [b, c, 0], [1, CHUNK, 512], valid_shapes=[1, valid, 512])
+                t = pl.load(x, [b, c, 0], [1, CHUNK, 512], valid_shape=[1, valid, 512])
                 t = pl.cast(t, target_type=pl.FP32)
                 o = pl.store(t, [b, c, 0], o)
                 chunk_out = pl.yield_(o)  # noqa: F841 — parser requires the yield-LHS binding

--- a/tests/st/conftest.py
+++ b/tests/st/conftest.py
@@ -640,7 +640,7 @@ def _collect_test_case_from_item(item: pytest.Item, seen: dict[str, PTOTestCase]
     params, locals assigned earlier in the body, and the test module globals,
     then instantiates it exactly as the body would.  This reconstructs the case
     regardless of parametrize→__init__ name renames (``valid`` →
-    ``valid_shapes``), hard-coded literal args (``dtype=DataType.FP16``),
+    ``valid_shape``), hard-coded literal args (``dtype=DataType.FP16``),
     positional args, the class-as-parameter pattern (``op_cls(...)``), or a
     locally-built config (``cfg = RunConfig(...); run(Case(config=cfg))``) — so
     the case is pre-compiled and batched instead of falling to the per-case

--- a/tests/st/distributed/collectives/test_l3_tensor_allreduce_intrinsic.py
+++ b/tests/st/distributed/collectives/test_l3_tensor_allreduce_intrinsic.py
@@ -120,7 +120,7 @@ def _build_allreduce_program(
                     inp,
                     [0, col],
                     [stage_rows, stage_cols],
-                    valid_shapes=[1, valid],
+                    valid_shape=[1, valid],
                 )
                 data_iter = pl.store(local, [0, col], data_iter)
                 staged_data = pl.yield_(data_iter)
@@ -137,7 +137,7 @@ def _build_allreduce_program(
                     data,
                     [0, col],
                     [stage_rows, stage_cols],
-                    valid_shapes=[1, valid],
+                    valid_shape=[1, valid],
                 )
                 out_iter = pl.store(acc, [0, col], out_iter)
                 staged_out = pl.yield_(out_iter)

--- a/tests/st/distributed/collectives/test_l3_tensor_allreduce_ring_intrinsic.py
+++ b/tests/st/distributed/collectives/test_l3_tensor_allreduce_ring_intrinsic.py
@@ -127,7 +127,7 @@ def _build_ring_allreduce_program(
                     inp,
                     [0, col],
                     [stage_rows, stage_cols],
-                    valid_shapes=[1, valid],
+                    valid_shape=[1, valid],
                 )
                 data_iter = pl.store(local, [0, col], data_iter)
                 staged_data = pl.yield_(data_iter)
@@ -143,7 +143,7 @@ def _build_ring_allreduce_program(
                     data,
                     [0, col],
                     [stage_rows, stage_cols],
-                    valid_shapes=[1, valid],
+                    valid_shape=[1, valid],
                 )
                 out_iter = pl.store(acc, [0, col], out_iter)
                 staged_out = pl.yield_(out_iter)

--- a/tests/st/distributed/test_l3_host_tensor_allreduce.py
+++ b/tests/st/distributed/test_l3_host_tensor_allreduce.py
@@ -205,7 +205,7 @@ def _build_host_allreduce(
                     inp,
                     [0, col],
                     [stage_rows, stage_cols],
-                    valid_shapes=[1, valid],
+                    valid_shape=[1, valid],
                 )
                 data_iter = pl.store(local, [0, col], data_iter)
                 staged_data = pl.yield_(data_iter)
@@ -231,7 +231,7 @@ def _build_host_allreduce(
                     data,
                     [0, col],
                     [stage_rows, stage_cols],
-                    valid_shapes=[1, valid],
+                    valid_shape=[1, valid],
                 )
                 out_iter = pl.store(reduced, [0, col], out_iter)
                 staged_out = pl.yield_(out_iter)

--- a/tests/st/runtime/control_flow/test_dyn_orch_shape.py
+++ b/tests/st/runtime/control_flow/test_dyn_orch_shape.py
@@ -21,9 +21,9 @@ Scenarios:
 - Scenario 1 — fully dynamic MxN orch: both InCore and orchestration use
   ``pl.Tensor[[M, N], pl.FP32]``; validates ``from_task_arg()`` for
   external tensors with no static shape information in the orch signature.
-- Scenario 2 — dynamic orch + valid_shapes scalars: orchestration uses MxN
+- Scenario 2 — dynamic orch + valid_shape scalars: orchestration uses MxN
   dims; m, n scalars are read from an INT64 tensor via ``pl.tensor.read`` and
-  forwarded to the InCore kernel as valid_shapes.
+  forwarded to the InCore kernel as valid_shape.
 - Scenario 3 — mixed dynamic M / static cols: orchestration uses
   ``pl.Tensor[[M, cols], pl.FP32]`` (M dynamic, cols=16 static); InCore reads
   M via ``pl.tensor.dim`` and iterates in pairs.
@@ -291,7 +291,7 @@ class DynOrchTransposeAddTestCase(PTOTestCase):
 
 
 class DynOrchValidShapeAddTestCase(PTOTestCase):
-    """Test add with dynamic M×N orchestration and valid_shapes from a scalar tensor.
+    """Test add with dynamic M×N orchestration and valid_shape from a scalar tensor.
 
     Orchestration params a, b, c use dynamic M×N dims.  The scalars m, n are
     read at runtime from the INT64 tensor ``vs`` via ``pl.tensor.read``, which
@@ -346,9 +346,9 @@ class DynOrchValidShapeAddTestCase(PTOTestCase):
                 m: pl.Scalar[pl.INDEX],
                 n: pl.Scalar[pl.INDEX],
             ) -> pl.Tensor[[M, N], pl.FP32]:
-                """Add two tiles with dynamic valid_shapes [m, n]."""
-                a_tile = pl.load(a, [0, 0], [rows, cols], valid_shapes=[m, n])
-                b_tile = pl.load(b, [0, 0], [rows, cols], valid_shapes=[m, n])
+                """Add two tiles with dynamic valid_shape [m, n]."""
+                a_tile = pl.load(a, [0, 0], [rows, cols], valid_shape=[m, n])
+                b_tile = pl.load(b, [0, 0], [rows, cols], valid_shape=[m, n])
                 result = pl.add(a_tile, b_tile)
                 out = pl.store(result, [0, 0], c)
                 return out
@@ -371,7 +371,7 @@ class DynOrchValidShapeAddTestCase(PTOTestCase):
     def compute_expected(self, tensors, params=None):
         vr = int(tensors["vs"][0])
         vc = int(tensors["vs"][1])
-        # Only c[:vr, :vc] is written (valid_shapes-bounded store); outside that
+        # Only c[:vr, :vc] is written (valid_shape-bounded store); outside that
         # region is undefined-by-design -> mark NaN so validate_golden skips it.
         tensors["c"][:] = float("nan")
         tensors["c"][:vr, :vc] = tensors["a"][:vr, :vc] + tensors["b"][:vr, :vc]
@@ -782,7 +782,7 @@ class TestDynOrchShapeOperations:
     @pytest.mark.parametrize("platform", PLATFORMS)
     @pytest.mark.parametrize("shape,valid_shape", [((32, 32), (16, 16))])
     def test_dyn_orch_valid_shape_add(self, test_runner, shape, valid_shape, platform):
-        """Test add with dynamic M x N orchestration and valid_shapes from INT64 tensor."""
+        """Test add with dynamic M x N orchestration and valid_shape from INT64 tensor."""
         result = test_runner.run(DynOrchValidShapeAddTestCase(shape, valid_shape, platform=platform))
         assert result.passed, f"Test failed for shape {shape}, valid_shape {valid_shape}: {result.error}"
 

--- a/tests/st/runtime/control_flow/test_dyn_orch_shape.py
+++ b/tests/st/runtime/control_flow/test_dyn_orch_shape.py
@@ -291,9 +291,9 @@ class DynOrchTransposeAddTestCase(PTOTestCase):
 
 
 class DynOrchValidShapeAddTestCase(PTOTestCase):
-    """Test add with dynamic M×N orchestration and valid_shape from a scalar tensor.
+    """Test add with dynamic M x N orchestration and valid_shape from a scalar tensor.
 
-    Orchestration params a, b, c use dynamic M×N dims.  The scalars m, n are
+    Orchestration params a, b, c use dynamic M x N dims.  The scalars m, n are
     read at runtime from the INT64 tensor ``vs`` via ``pl.tensor.read``, which
     generates ``orch[idx].data<void>()`` scalar extraction in the C++ code.
     Expected result: c[:valid_rows, :valid_cols] = a + b, c elsewhere = 0.

--- a/tests/st/runtime/control_flow/test_dynamic_shape.py
+++ b/tests/st/runtime/control_flow/test_dynamic_shape.py
@@ -13,7 +13,7 @@ Runtime tests for dynamic shape kernels using the PyPTO frontend with PTO backen
 Three scenarios are covered, each parametrized over [(128, 128)]:
 - Dynamic M×N tensor shape dims: trailing index args in codegen, resolved at runtime
   from the concrete input tensors passed by the orchestration function.
-- Static R×C tensors with M, N scalar valid_shapes: shape baked in via closure
+- Static R×C tensors with M, N scalar valid_shape: shape baked in via closure
   variables captured by @pl.function; M and N read via pl.tensor.dim.
 - Dynamic M dim with scf.for loop (step=2, tile rows=2): col count from shape param.
 
@@ -105,11 +105,11 @@ class DynShapeAddTestCase(PTOTestCase):
 
 
 class ValidShapeAddTestCase(PTOTestCase):
-    """Test add kernel with static tensors where valid_shapes are read from an input tensor.
+    """Test add kernel with static tensors where valid_shape is read from an input tensor.
 
     Shape (rows, cols) is the full tile size; valid_shape (valid_rows, valid_cols)
     is the live data region passed at runtime via a [2] INT64 tensor. The kernel
-    loads with valid_shapes=[m, n] so elements outside the valid region are zero.
+    loads with valid_shape=[m, n] so elements outside the valid region are zero.
     Expected result: c[:valid_rows, :valid_cols] = a + b, c elsewhere = 0.
     """
 
@@ -158,9 +158,9 @@ class ValidShapeAddTestCase(PTOTestCase):
                 m: pl.Scalar[pl.INDEX],
                 n: pl.Scalar[pl.INDEX],
             ) -> pl.Tensor[[rows, cols], pl.FP32]:
-                """Add two tiles with dynamic valid_shapes [m, n]."""
-                a_tile = pl.load(a, [0, 0], [rows, cols], valid_shapes=[m, n])
-                b_tile = pl.load(b, [0, 0], [rows, cols], valid_shapes=[m, n])
+                """Add two tiles with dynamic valid_shape [m, n]."""
+                a_tile = pl.load(a, [0, 0], [rows, cols], valid_shape=[m, n])
+                b_tile = pl.load(b, [0, 0], [rows, cols], valid_shape=[m, n])
                 result = pl.add(a_tile, b_tile)
                 out = pl.store(result, [0, 0], c)
                 return out
@@ -183,7 +183,7 @@ class ValidShapeAddTestCase(PTOTestCase):
     def compute_expected(self, tensors, params=None):
         vr = tensors["valid_shape"][0]
         vc = tensors["valid_shape"][1]
-        # Only c[:vr, :vc] is written (valid_shapes-bounded store); outside that
+        # Only c[:vr, :vc] is written (valid_shape-bounded store); outside that
         # region is undefined-by-design -> mark NaN so validate_golden skips it.
         tensors["c"][:] = float("nan")
         tensors["c"][:vr, :vc] = tensors["a"][:vr, :vc] + tensors["b"][:vr, :vc]
@@ -277,7 +277,7 @@ class TestDynamicShapeOperations:
     @pytest.mark.parametrize("platform", PLATFORMS)
     @pytest.mark.parametrize("shape,valid_shape", [((128, 128), (64, 64))])
     def test_valid_shape_add(self, test_runner, shape, valid_shape, platform):
-        """Test add with static tensors and valid_shapes read from an input tensor."""
+        """Test add with static tensors and valid_shape read from an input tensor."""
         result = test_runner.run(ValidShapeAddTestCase(shape, valid_shape, platform=platform))
         assert result.passed, f"Test failed for shape {shape}, valid_shape {valid_shape}: {result.error}"
 

--- a/tests/st/runtime/control_flow/test_dynamic_shape.py
+++ b/tests/st/runtime/control_flow/test_dynamic_shape.py
@@ -11,9 +11,9 @@
 Runtime tests for dynamic shape kernels using the PyPTO frontend with PTO backend.
 
 Three scenarios are covered, each parametrized over [(128, 128)]:
-- Dynamic M×N tensor shape dims: trailing index args in codegen, resolved at runtime
+- Dynamic M x N tensor shape dims: trailing index args in codegen, resolved at runtime
   from the concrete input tensors passed by the orchestration function.
-- Static R×C tensors with M, N scalar valid_shape: shape baked in via closure
+- Static R x C tensors with M, N scalar valid_shape: shape baked in via closure
   variables captured by @pl.function; M and N read via pl.tensor.dim.
 - Dynamic M dim with scf.for loop (step=2, tile rows=2): col count from shape param.
 

--- a/tests/st/runtime/cross_core/test_sync_set_wait.py
+++ b/tests/st/runtime/cross_core/test_sync_set_wait.py
@@ -98,7 +98,7 @@ def sync_set_wait_odd_shape(
             transfer,
             [0, 0],
             [CUBE_PHYSICAL_ROWS, K],
-            valid_shapes=[ROWS, K],
+            valid_shape=[ROWS, K],
             target_memory=pl.Mem.Mat,
         )
         weight_mat: pl.Tile[[K, N], pl.FP32, pl.Mem.Mat] = pl.load(
@@ -144,7 +144,7 @@ def sync_set_wait_odd_last_axis(
                     input_tensor,
                     [0, 0],
                     [LR_ROWS, LR_LEFT_PHYSICAL_COLS],
-                    valid_shapes=[LR_ROWS, LR_LEFT_COLS],
+                    valid_shape=[LR_ROWS, LR_LEFT_COLS],
                 )
                 pl.store(left, [0, 0], transfer)
             else:
@@ -172,7 +172,7 @@ def sync_set_wait_odd_last_axis(
             transfer,
             [0, 0],
             [LR_CUBE_ROWS, LR_CUBE_COLS],
-            valid_shapes=[LR_ROWS, LR_COLS],
+            valid_shape=[LR_ROWS, LR_COLS],
             target_memory=pl.Mem.Mat,
         )
         weight_mat: pl.Tile[[LR_CUBE_COLS, LR_OUTPUT_COLS], pl.FP16, pl.Mem.Mat] = pl.load(

--- a/tests/st/runtime/framework_and_models/test_batch_paged_attention.py
+++ b/tests/st/runtime/framework_and_models/test_batch_paged_attention.py
@@ -317,7 +317,7 @@ class BatchSoftmaxPrepareTestCase(PTOTestCase):
                         sij_batch,
                         [b * q_tile, 0],
                         [q_tile, block_size],
-                        valid_shapes=[q_tile, valid_len],
+                        valid_shape=[q_tile, valid_len],
                         target_memory=pl.MemorySpace.Vec,
                     )
                     s_padded = pl.tile.fillpad(s_tile, pad_value=pl.PadValue.min)

--- a/tests/st/runtime/framework_and_models/test_paged_attention.py
+++ b/tests/st/runtime/framework_and_models/test_paged_attention.py
@@ -184,7 +184,7 @@ class SoftmaxPrepareTestCase(PTOTestCase):
 class SoftmaxPrepareUnalignedTestCase(PTOTestCase):
     """Test case for softmax_prepare with unaligned valid_len.
 
-    Uses pl.load(..., valid_shapes=[16, valid_len]) + fillpad(pad_value=min)
+    Uses pl.load(..., valid_shape=[16, valid_len]) + fillpad(pad_value=min)
     to handle non-block-aligned KV cache lengths. Columns beyond valid_len
     are padded with -inf before softmax.
     """

--- a/tests/st/runtime/ops/test_activation_ops.py
+++ b/tests/st/runtime/ops/test_activation_ops.py
@@ -56,7 +56,7 @@ class _ActBase(PTOTestCase):
         *,
         m=16,
         n=16,
-        valid_shapes=None,
+        valid_shape=None,
         dtype=DataType.FP32,
         out_m=None,
         out_n=None,
@@ -64,7 +64,7 @@ class _ActBase(PTOTestCase):
         config=None,
     ):
         super().__init__(config)
-        self._m, self._n, self._valid, self._dtype = m, n, valid_shapes, dtype
+        self._m, self._n, self._valid, self._dtype = m, n, valid_shape, dtype
         self._out_m, self._out_n, self._off = out_m or m, out_n or n, off
 
     def get_name(self) -> str:
@@ -73,7 +73,7 @@ class _ActBase(PTOTestCase):
         return f"tile_{self.op_name}_{self._m}x{self._n}_{self._dtype.value}{v}{o}"
 
     def define_tensors(self) -> list[TensorSpec]:
-        # The output's unwritten region (valid_shapes tail or the complement of an
+        # The output's unwritten region (valid_shape tail or the complement of an
         # offset store) is compared against golden zeros, so declare the output
         # InOut with a zero init: the runtime stages defined zeros (pure outputs
         # are no longer device-zeroed). The offset complement doubles as the
@@ -119,7 +119,7 @@ class TileReluTestCase(_ActBase):
             def kernel(
                 self, a: pl.Tensor[[m, n], dt], out: pl.InOut[pl.Tensor[[om, on], dt]]
             ) -> pl.Tensor[[om, on], dt]:
-                a_tile = pl.load(a, [0, 0], [m, n], valid_shapes=vshape)
+                a_tile = pl.load(a, [0, 0], [m, n], valid_shape=vshape)
                 out = pl.store(pl.tile.relu(a_tile), off, out)
                 return out
 
@@ -160,7 +160,7 @@ class TileLreluTestCase(_ActBase):
             def kernel(
                 self, a: pl.Tensor[[m, n], dt], out: pl.InOut[pl.Tensor[[om, on], dt]]
             ) -> pl.Tensor[[om, on], dt]:
-                a_tile = pl.load(a, [0, 0], [m, n], valid_shapes=vshape)
+                a_tile = pl.load(a, [0, 0], [m, n], valid_shape=vshape)
                 out = pl.store(pl.tile.lrelu(a_tile, slope), off, out)
                 return out
 
@@ -178,18 +178,18 @@ _LRELU_SLOPES = [0.0, 0.1, 1.0, -0.5, 2.0]
 
 
 class TestActivation:
-    """Tile-level relu/lrelu on a2a3 across shapes, valid_shapes, dtypes, offset, slope."""
+    """Tile-level relu/lrelu on a2a3 across shapes, valid_shape, dtypes, offset, slope."""
 
     @pytest.mark.platforms("a2a3")
     @pytest.mark.parametrize("label,m,n,valid", _SHAPE_CFGS, ids=[c[0] for c in _SHAPE_CFGS])
     def test_tile_relu(self, test_runner, label, m, n, valid):
-        result = test_runner.run(TileReluTestCase(m=m, n=n, valid_shapes=valid))
+        result = test_runner.run(TileReluTestCase(m=m, n=n, valid_shape=valid))
         assert result.passed, f"Test failed: {result.error}"
 
     @pytest.mark.platforms("a2a3")
     @pytest.mark.parametrize("label,m,n,valid", _SHAPE_CFGS, ids=[c[0] for c in _SHAPE_CFGS])
     def test_tile_lrelu(self, test_runner, label, m, n, valid):
-        result = test_runner.run(TileLreluTestCase(m=m, n=n, valid_shapes=valid))
+        result = test_runner.run(TileLreluTestCase(m=m, n=n, valid_shape=valid))
         assert result.passed, f"Test failed: {result.error}"
 
     @pytest.mark.platforms("a2a3")

--- a/tests/st/runtime/ops/test_argmax_reduction.py
+++ b/tests/st/runtime/ops/test_argmax_reduction.py
@@ -127,7 +127,7 @@ class TileRowArgmax(_ArgBase):
             def kernel(
                 self, a: pl.Tensor[[m, n], dt], out: pl.InOut[pl.Tensor[[m, 1], pl.INT32]]
             ) -> pl.Tensor[[m, 1], pl.INT32]:
-                t: pl.Tile[[m, n], dt] = pl.load(a, [0, 0], [m, n], valid_shapes=vshape)
+                t: pl.Tile[[m, n], dt] = pl.load(a, [0, 0], [m, n], valid_shape=vshape)
                 tmp: pl.Tile[[m, n], dt] = pl.tile.create([m, n], dtype=dt, target_memory=pl.MemorySpace.Vec)
                 r: pl.Tile[[m, 1], pl.INT32] = pl.tile.row_argmax(t, tmp)
                 return pl.store(r, [0, 0], out)
@@ -157,7 +157,7 @@ class TileRowArgmin(_ArgBase):
             def kernel(
                 self, a: pl.Tensor[[m, n], dt], out: pl.InOut[pl.Tensor[[m, 1], pl.INT32]]
             ) -> pl.Tensor[[m, 1], pl.INT32]:
-                t: pl.Tile[[m, n], dt] = pl.load(a, [0, 0], [m, n], valid_shapes=vshape)
+                t: pl.Tile[[m, n], dt] = pl.load(a, [0, 0], [m, n], valid_shape=vshape)
                 tmp: pl.Tile[[m, n], dt] = pl.tile.create([m, n], dtype=dt, target_memory=pl.MemorySpace.Vec)
                 r: pl.Tile[[m, 1], pl.INT32] = pl.tile.row_argmin(t, tmp)
                 return pl.store(r, [0, 0], out)
@@ -187,7 +187,7 @@ class TileColArgmax(_ArgBase):
             def kernel(
                 self, a: pl.Tensor[[m, n], dt], out: pl.InOut[pl.Tensor[[1, n], pl.INT32]]
             ) -> pl.Tensor[[1, n], pl.INT32]:
-                t: pl.Tile[[m, n], dt] = pl.load(a, [0, 0], [m, n], valid_shapes=vshape)
+                t: pl.Tile[[m, n], dt] = pl.load(a, [0, 0], [m, n], valid_shape=vshape)
                 tmp: pl.Tile[[m, n], dt] = pl.tile.create([m, n], dtype=dt, target_memory=pl.MemorySpace.Vec)
                 r: pl.Tile[[1, n], pl.INT32] = pl.tile.col_argmax(t, tmp)
                 return pl.store(r, [0, 0], out)
@@ -217,7 +217,7 @@ class TileColArgmin(_ArgBase):
             def kernel(
                 self, a: pl.Tensor[[m, n], dt], out: pl.InOut[pl.Tensor[[1, n], pl.INT32]]
             ) -> pl.Tensor[[1, n], pl.INT32]:
-                t: pl.Tile[[m, n], dt] = pl.load(a, [0, 0], [m, n], valid_shapes=vshape)
+                t: pl.Tile[[m, n], dt] = pl.load(a, [0, 0], [m, n], valid_shape=vshape)
                 tmp: pl.Tile[[m, n], dt] = pl.tile.create([m, n], dtype=dt, target_memory=pl.MemorySpace.Vec)
                 r: pl.Tile[[1, n], pl.INT32] = pl.tile.col_argmin(t, tmp)
                 return pl.store(r, [0, 0], out)

--- a/tests/st/runtime/ops/test_bitwise.py
+++ b/tests/st/runtime/ops/test_bitwise.py
@@ -59,7 +59,7 @@ class BitwiseNotTestCase(PTOTestCase):
         *,
         m=16,
         n=16,
-        valid_shapes=None,
+        valid_shape=None,
         dtype=DataType.INT16,
         out_m=None,
         out_n=None,
@@ -67,7 +67,7 @@ class BitwiseNotTestCase(PTOTestCase):
         config=None,
     ):
         super().__init__(config)
-        self._m, self._n, self._valid, self._dtype = m, n, valid_shapes, dtype
+        self._m, self._n, self._valid, self._dtype = m, n, valid_shape, dtype
         self._out_m, self._out_n, self._off = out_m or m, out_n or n, off
 
     def get_name(self) -> str:
@@ -94,7 +94,7 @@ class BitwiseNotTestCase(PTOTestCase):
             def kernel(
                 self, a: pl.Tensor[[m, n], dt], out: pl.InOut[pl.Tensor[[om, on], dt]]
             ) -> pl.Tensor[[om, on], dt]:
-                a_tile = pl.load(a, [0, 0], [m, n], valid_shapes=vshape)
+                a_tile = pl.load(a, [0, 0], [m, n], valid_shape=vshape)
                 out = pl.store(pl.tile.not_(a_tile), off, out)
                 return out
 
@@ -122,12 +122,12 @@ class BitwiseNotTestCase(PTOTestCase):
 
 
 class TestBitwise:
-    """Tile-level integer bitwise NOT on a2a3 across shapes, valid_shapes, dtypes, offset."""
+    """Tile-level integer bitwise NOT on a2a3 across shapes, valid_shape, dtypes, offset."""
 
     @pytest.mark.platforms("a2a3")
     @pytest.mark.parametrize("label,m,n,valid", _SHAPE_CFGS, ids=[c[0] for c in _SHAPE_CFGS])
     def test_tile_not(self, test_runner, label, m, n, valid):
-        result = test_runner.run(BitwiseNotTestCase(m=m, n=n, valid_shapes=valid))
+        result = test_runner.run(BitwiseNotTestCase(m=m, n=n, valid_shape=valid))
         assert result.passed, f"Test failed: {result.error}"
 
     @pytest.mark.platforms("a2a3")

--- a/tests/st/runtime/ops/test_col_expand_arith.py
+++ b/tests/st/runtime/ops/test_col_expand_arith.py
@@ -66,9 +66,9 @@ class _TileColExpandBase(PTOTestCase):
     __test__ = False
     op_name = ""
 
-    def __init__(self, *, m=M, n=N, valid_shapes=None, dtype=DataType.FP32, config=None, platform=None):
+    def __init__(self, *, m=M, n=N, valid_shape=None, dtype=DataType.FP32, config=None, platform=None):
         super().__init__(config, platform=platform)
-        self._m, self._n, self._valid, self._dtype = m, n, valid_shapes, dtype
+        self._m, self._n, self._valid, self._dtype = m, n, valid_shape, dtype
 
     def get_name(self) -> str:
         v = f"_v{self._valid[0]}x{self._valid[1]}" if self._valid else ""
@@ -89,7 +89,7 @@ class _TileColExpandBase(PTOTestCase):
         a, v = tensors["a"], tensors["v"]
         if self._valid:
             vm, vn = self._valid
-            # Region outside valid_shapes is undefined by contract — mark NaN so validate_golden skips it.
+            # Region outside valid_shape is undefined by contract — mark NaN so validate_golden skips it.
             res = torch.full_like(a, float("nan"))
             res[:vm, :vn] = self._ref(a[:vm, :vn], v[:, :vn])
         else:
@@ -119,8 +119,8 @@ class TileColExpandDivCase(_TileColExpandBase):
                 v: pl.Tensor[[1, n], dt],
                 out: pl.Out[pl.Tensor[[m, n], dt]],
             ) -> pl.Tensor[[m, n], dt]:
-                a_tile = pl.load(a, [0, 0], [m, n], valid_shapes=vshape)
-                v_tile = pl.load(v, [0, 0], [1, n], valid_shapes=[1, v_cols])
+                a_tile = pl.load(a, [0, 0], [m, n], valid_shape=vshape)
+                v_tile = pl.load(v, [0, 0], [1, n], valid_shape=[1, v_cols])
                 out_tile = pl.tile.col_expand_div(a_tile, v_tile)
                 return pl.store(out_tile, [0, 0], out)
 
@@ -158,8 +158,8 @@ class TileColExpandSubCase(_TileColExpandBase):
                 v: pl.Tensor[[1, n], dt],
                 out: pl.Out[pl.Tensor[[m, n], dt]],
             ) -> pl.Tensor[[m, n], dt]:
-                a_tile = pl.load(a, [0, 0], [m, n], valid_shapes=vshape)
-                v_tile = pl.load(v, [0, 0], [1, n], valid_shapes=[1, v_cols])
+                a_tile = pl.load(a, [0, 0], [m, n], valid_shape=vshape)
+                v_tile = pl.load(v, [0, 0], [1, n], valid_shape=[1, v_cols])
                 out_tile = pl.tile.col_expand_sub(a_tile, v_tile)
                 return pl.store(out_tile, [0, 0], out)
 
@@ -187,13 +187,13 @@ class TestTileColExpandArith:
     @pytest.mark.parametrize("platform", ONBOARD_PLATFORMS)
     @pytest.mark.parametrize("label,m,n,valid", _SHAPE_CFGS, ids=[c[0] for c in _SHAPE_CFGS])
     def test_tile_div(self, test_runner, platform, label, m, n, valid):
-        result = test_runner.run(TileColExpandDivCase(m=m, n=n, valid_shapes=valid, platform=platform))
+        result = test_runner.run(TileColExpandDivCase(m=m, n=n, valid_shape=valid, platform=platform))
         assert result.passed, f"Test failed: {result.error}"
 
     @pytest.mark.parametrize("platform", ONBOARD_PLATFORMS)
     @pytest.mark.parametrize("label,m,n,valid", _SHAPE_CFGS, ids=[c[0] for c in _SHAPE_CFGS])
     def test_tile_sub(self, test_runner, platform, label, m, n, valid):
-        result = test_runner.run(TileColExpandSubCase(m=m, n=n, valid_shapes=valid, platform=platform))
+        result = test_runner.run(TileColExpandSubCase(m=m, n=n, valid_shape=valid, platform=platform))
         assert result.passed, f"Test failed: {result.error}"
 
     @pytest.mark.parametrize("platform", ONBOARD_PLATFORMS)

--- a/tests/st/runtime/ops/test_div.py
+++ b/tests/st/runtime/ops/test_div.py
@@ -143,8 +143,8 @@ class TileDivCase(PTOTestCase):
                 rhs: pl.Tensor[[m, n], dtype],
                 out: pl.InOut[pl.Tensor[[m, n], dtype]],
             ) -> pl.Tensor[[m, n], dtype]:
-                lhs_tile: pl.Tile[[m, n], dtype] = pl.load(lhs, [0, 0], [m, n], valid_shapes=valid_shape)
-                rhs_tile: pl.Tile[[m, n], dtype] = pl.load(rhs, [0, 0], [m, n], valid_shapes=valid_shape)
+                lhs_tile: pl.Tile[[m, n], dtype] = pl.load(lhs, [0, 0], [m, n], valid_shape=valid_shape)
+                rhs_tile: pl.Tile[[m, n], dtype] = pl.load(rhs, [0, 0], [m, n], valid_shape=valid_shape)
                 result: pl.Tile[[m, n], dtype] = pl.tile.div(
                     lhs_tile, rhs_tile, high_precision=high_precision
                 )

--- a/tests/st/runtime/ops/test_fillpad.py
+++ b/tests/st/runtime/ops/test_fillpad.py
@@ -38,7 +38,7 @@ class FillpadZeroProgram:
         output: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
     ) -> pl.Tensor[[64, 64], pl.FP32]:
         tile: pl.Tile[[64, 64], pl.FP32] = pl.load(
-            input_tensor, offsets=[0, 0], shapes=[64, 64], valid_shapes=[48, 64]
+            input_tensor, offsets=[0, 0], shapes=[64, 64], valid_shape=[48, 64]
         )
         padded_tile: pl.Tile[[64, 64], pl.FP32] = pl.fillpad(tile, pad_value=pl.PadValue.zero)
         out: pl.Tensor[[64, 64], pl.FP32] = pl.store(padded_tile, offsets=[0, 0], output_tensor=output)
@@ -65,7 +65,7 @@ class FillpadMaxProgram:
         output: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
     ) -> pl.Tensor[[64, 64], pl.FP32]:
         tile: pl.Tile[[64, 64], pl.FP32] = pl.load(
-            input_tensor, offsets=[0, 0], shapes=[64, 64], valid_shapes=[48, 64]
+            input_tensor, offsets=[0, 0], shapes=[64, 64], valid_shape=[48, 64]
         )
         padded_tile: pl.Tile[[64, 64], pl.FP32] = pl.fillpad(tile, pad_value=pl.PadValue.max)
         out: pl.Tensor[[64, 64], pl.FP32] = pl.store(padded_tile, offsets=[0, 0], output_tensor=output)
@@ -92,7 +92,7 @@ class FillpadMinProgram:
         output: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
     ) -> pl.Tensor[[64, 64], pl.FP32]:
         tile: pl.Tile[[64, 64], pl.FP32] = pl.load(
-            input_tensor, offsets=[0, 0], shapes=[64, 64], valid_shapes=[48, 64]
+            input_tensor, offsets=[0, 0], shapes=[64, 64], valid_shape=[48, 64]
         )
         padded_tile: pl.Tile[[64, 64], pl.FP32] = pl.fillpad(tile, pad_value=pl.PadValue.min)
         out: pl.Tensor[[64, 64], pl.FP32] = pl.store(padded_tile, offsets=[0, 0], output_tensor=output)
@@ -119,7 +119,7 @@ class FillpadOddTailFP16Program:
         output: pl.Out[pl.Tensor[[1, 32], pl.FP16]],
     ) -> pl.Tensor[[1, 32], pl.FP16]:
         tile: pl.Tile[[1, 32], pl.FP16] = pl.load(
-            input_tensor, offsets=[0, 0], shapes=[1, 32], valid_shapes=[1, 17]
+            input_tensor, offsets=[0, 0], shapes=[1, 32], valid_shape=[1, 17]
         )
         padded_tile: pl.Tile[[1, 32], pl.FP16] = pl.fillpad(tile, pad_value=pl.PadValue.zero)
         return pl.store(padded_tile, offsets=[0, 0], output_tensor=output)

--- a/tests/st/runtime/ops/test_fillpad_expand.py
+++ b/tests/st/runtime/ops/test_fillpad_expand.py
@@ -116,7 +116,7 @@ class FillpadExpandNarrowValidFP32:
         input_tensor: pl.Tensor[[48, 64], pl.FP32],
         output: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
     ) -> pl.Tensor[[64, 64], pl.FP32]:
-        src: pl.Tile[[48, 64], pl.FP32] = pl.load(input_tensor, [0, 0], [48, 64], valid_shapes=[40, 50])
+        src: pl.Tile[[48, 64], pl.FP32] = pl.load(input_tensor, [0, 0], [48, 64], valid_shape=[40, 50])
         dst: pl.Tile[[64, 64], pl.FP32] = pl.tile.fillpad_expand(src, [64, 64], pad_value=pl.PadValue.zero)
         return pl.store(dst, [0, 0], output)
 
@@ -139,7 +139,7 @@ class FillpadExpandNarrowValidBothMinFP32:
         input_tensor: pl.Tensor[[64, 64], pl.FP32],
         output: pl.Out[pl.Tensor[[64, 128], pl.FP32]],
     ) -> pl.Tensor[[64, 128], pl.FP32]:
-        src: pl.Tile[[64, 64], pl.FP32] = pl.load(input_tensor, [0, 0], [64, 64], valid_shapes=[40, 50])
+        src: pl.Tile[[64, 64], pl.FP32] = pl.load(input_tensor, [0, 0], [64, 64], valid_shape=[40, 50])
         dst: pl.Tile[[64, 128], pl.FP32] = pl.tile.fillpad_expand(src, [64, 128], pad_value=pl.PadValue.min)
         return pl.store(dst, [0, 0], output)
 
@@ -162,7 +162,7 @@ class FillpadExpandTailValidFP32:
         input_tensor: pl.Tensor[[8, 16], pl.FP32],
         output: pl.Out[pl.Tensor[[16, 32], pl.FP32]],
     ) -> pl.Tensor[[16, 32], pl.FP32]:
-        src: pl.Tile[[8, 16], pl.FP32] = pl.load(input_tensor, [0, 0], [8, 16], valid_shapes=[8, 10])
+        src: pl.Tile[[8, 16], pl.FP32] = pl.load(input_tensor, [0, 0], [8, 16], valid_shape=[8, 10])
         dst: pl.Tile[[16, 32], pl.FP32] = pl.tile.fillpad_expand(src, [16, 32], pad_value=pl.PadValue.zero)
         return pl.store(dst, [0, 0], output)
 
@@ -204,7 +204,7 @@ class FillpadExpandNarrowValidFP16:
         input_tensor: pl.Tensor[[48, 64], pl.FP16],
         output: pl.Out[pl.Tensor[[64, 64], pl.FP16]],
     ) -> pl.Tensor[[64, 64], pl.FP16]:
-        src: pl.Tile[[48, 64], pl.FP16] = pl.load(input_tensor, [0, 0], [48, 64], valid_shapes=[40, 50])
+        src: pl.Tile[[48, 64], pl.FP16] = pl.load(input_tensor, [0, 0], [48, 64], valid_shape=[40, 50])
         dst: pl.Tile[[64, 64], pl.FP16] = pl.tile.fillpad_expand(src, [64, 64], pad_value=pl.PadValue.zero)
         return pl.store(dst, [0, 0], output)
 
@@ -225,7 +225,7 @@ class FillpadExpandRowINT32:
         input_tensor: pl.Tensor[[48, 64], pl.INT32],
         output: pl.Out[pl.Tensor[[64, 64], pl.INT32]],
     ) -> pl.Tensor[[64, 64], pl.INT32]:
-        src: pl.Tile[[48, 64], pl.INT32] = pl.load(input_tensor, [0, 0], [48, 64], valid_shapes=[40, 50])
+        src: pl.Tile[[48, 64], pl.INT32] = pl.load(input_tensor, [0, 0], [48, 64], valid_shape=[40, 50])
         dst: pl.Tile[[64, 64], pl.INT32] = pl.tile.fillpad_expand(src, [64, 64], pad_value=pl.PadValue.zero)
         return pl.store(dst, [0, 0], output)
 

--- a/tests/st/runtime/ops/test_fillpad_inplace.py
+++ b/tests/st/runtime/ops/test_fillpad_inplace.py
@@ -39,7 +39,7 @@ class FillpadInplaceZeroProgram:
         output: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
     ) -> pl.Tensor[[64, 64], pl.FP32]:
         tile: pl.Tile[[64, 64], pl.FP32] = pl.load(
-            input_tensor, offsets=[0, 0], shapes=[64, 64], valid_shapes=[48, 64]
+            input_tensor, offsets=[0, 0], shapes=[64, 64], valid_shape=[48, 64]
         )
         padded_tile: pl.Tile[[64, 64], pl.FP32] = pl.tile.fillpad_inplace(tile, pad_value=pl.PadValue.zero)
         out: pl.Tensor[[64, 64], pl.FP32] = pl.store(padded_tile, offsets=[0, 0], output_tensor=output)
@@ -66,7 +66,7 @@ class FillpadInplaceMaxProgram:
         output: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
     ) -> pl.Tensor[[64, 64], pl.FP32]:
         tile: pl.Tile[[64, 64], pl.FP32] = pl.load(
-            input_tensor, offsets=[0, 0], shapes=[64, 64], valid_shapes=[48, 64]
+            input_tensor, offsets=[0, 0], shapes=[64, 64], valid_shape=[48, 64]
         )
         padded_tile: pl.Tile[[64, 64], pl.FP32] = pl.tile.fillpad_inplace(tile, pad_value=pl.PadValue.max)
         out: pl.Tensor[[64, 64], pl.FP32] = pl.store(padded_tile, offsets=[0, 0], output_tensor=output)
@@ -93,7 +93,7 @@ class FillpadInplaceMinProgram:
         output: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
     ) -> pl.Tensor[[64, 64], pl.FP32]:
         tile: pl.Tile[[64, 64], pl.FP32] = pl.load(
-            input_tensor, offsets=[0, 0], shapes=[64, 64], valid_shapes=[48, 64]
+            input_tensor, offsets=[0, 0], shapes=[64, 64], valid_shape=[48, 64]
         )
         padded_tile: pl.Tile[[64, 64], pl.FP32] = pl.tile.fillpad_inplace(tile, pad_value=pl.PadValue.min)
         out: pl.Tensor[[64, 64], pl.FP32] = pl.store(padded_tile, offsets=[0, 0], output_tensor=output)

--- a/tests/st/runtime/ops/test_fmod.py
+++ b/tests/st/runtime/ops/test_fmod.py
@@ -51,8 +51,8 @@ class TileFmodProgram:
         rhs: pl.Tensor[[M, N], pl.FP32],
         out: pl.Out[pl.Tensor[[M, N], pl.FP32]],
     ) -> pl.Tensor[[M, N], pl.FP32]:
-        lhs_tile: pl.Tile[[M, N], pl.FP32] = pl.load(lhs, [0, 0], [M, N], valid_shapes=[M, N])
-        rhs_tile: pl.Tile[[M, N], pl.FP32] = pl.load(rhs, [0, 0], [M, N], valid_shapes=[M, N])
+        lhs_tile: pl.Tile[[M, N], pl.FP32] = pl.load(lhs, [0, 0], [M, N], valid_shape=[M, N])
+        rhs_tile: pl.Tile[[M, N], pl.FP32] = pl.load(rhs, [0, 0], [M, N], valid_shape=[M, N])
         out_tile: pl.Tile[[M, N], pl.FP32] = pl.tile.fmod(lhs_tile, rhs_tile)
         out = pl.store(out_tile, [0, 0], out)
         return out
@@ -79,7 +79,7 @@ def _make_tile_fmods_program(scalar: float):
             lhs: pl.Tensor[[M, N], pl.FP32],
             out: pl.Out[pl.Tensor[[M, N], pl.FP32]],
         ) -> pl.Tensor[[M, N], pl.FP32]:
-            lhs_tile: pl.Tile[[M, N], pl.FP32] = pl.load(lhs, [0, 0], [M, N], valid_shapes=[M, N])
+            lhs_tile: pl.Tile[[M, N], pl.FP32] = pl.load(lhs, [0, 0], [M, N], valid_shape=[M, N])
             out_tile: pl.Tile[[M, N], pl.FP32] = pl.tile.fmods(lhs_tile, scalar)
             out = pl.store(out_tile, [0, 0], out)
             return out

--- a/tests/st/runtime/ops/test_gemv.py
+++ b/tests/st/runtime/ops/test_gemv.py
@@ -106,10 +106,10 @@ class MatmulBiasTestCase(PTOTestCase):
                 bias: pl.Tensor[[1, n], pl.FP32],
                 out: pl.Out[pl.Tensor[[om, n], pl.FP32]],
             ) -> pl.Tensor[[om, n], pl.FP32]:
-                tile_a = pl.load(a, [0, 0], [m, k], valid_shapes=a_v, target_memory=pl.MemorySpace.Mat)
-                tile_b = pl.load(b, [0, 0], [k, n], valid_shapes=b_v, target_memory=pl.MemorySpace.Mat)
+                tile_a = pl.load(a, [0, 0], [m, k], valid_shape=a_v, target_memory=pl.MemorySpace.Mat)
+                tile_b = pl.load(b, [0, 0], [k, n], valid_shape=b_v, target_memory=pl.MemorySpace.Mat)
                 tile_bias = pl.load(
-                    bias, [0, 0], [1, n], valid_shapes=vn_bias, target_memory=pl.MemorySpace.Mat
+                    bias, [0, 0], [1, n], valid_shape=vn_bias, target_memory=pl.MemorySpace.Mat
                 )
                 out = pl.store(pl.tile.matmul_bias(tile_a, tile_b, tile_bias), off, out)
                 return out

--- a/tests/st/runtime/ops/test_log.py
+++ b/tests/st/runtime/ops/test_log.py
@@ -108,7 +108,7 @@ class TileLogCase(PTOTestCase):
                 src: pl.Tensor[[m, n], dtype],
                 out: pl.InOut[pl.Tensor[[m, n], dtype]],
             ) -> pl.Tensor[[m, n], dtype]:
-                src_tile: pl.Tile[[m, n], dtype] = pl.load(src, [0, 0], [m, n], valid_shapes=valid_shape)
+                src_tile: pl.Tile[[m, n], dtype] = pl.load(src, [0, 0], [m, n], valid_shape=valid_shape)
                 result: pl.Tile[[m, n], dtype] = pl.tile.log(src_tile, high_precision=high_precision)
                 return pl.store(result, [0, 0], out)
 

--- a/tests/st/runtime/ops/test_matmul.py
+++ b/tests/st/runtime/ops/test_matmul.py
@@ -1525,10 +1525,14 @@ class TestMatmulOperations:
         torch.manual_seed(0)
         a = torch.randn(5, 16, dtype=torch.float32)
         b = torch.randn(16, 16, dtype=torch.float32)
-        output = torch.zeros((16, 16), dtype=torch.float32)
+        sentinel = 17.0
+        output = torch.full((16, 16), sentinel, dtype=torch.float32)
+        expected = output.clone()
         matmul_valid_shape(a, b, output, config=test_config)
-        expected = torch.zeros_like(output)
         expected[:5] = torch.matmul(a, b)
+        assert torch.equal(output[5:], torch.full_like(output[5:], sentinel)), (
+            "rows outside valid_shape were modified"
+        )
         assert torch.allclose(output, expected, rtol=1e-3, atol=1e-3), (
             f"matmul_valid_shape failed: max diff = {(output - expected).abs().max().item()}"
         )

--- a/tests/st/runtime/ops/test_matmul.py
+++ b/tests/st/runtime/ops/test_matmul.py
@@ -1518,6 +1518,21 @@ class TestMatmulOperations:
             f"matmul_acc_64 failed: max diff = {(c - expected).abs().max().item()}"
         )
 
+    def test_matmul_valid_shape(self, test_config):
+        from examples.kernels.matmul_valid_shape import matmul_valid_shape  # noqa: PLC0415
+
+        matmul_valid_shape._cache.clear()
+        torch.manual_seed(0)
+        a = torch.randn(5, 16, dtype=torch.float32)
+        b = torch.randn(16, 16, dtype=torch.float32)
+        output = torch.zeros((16, 16), dtype=torch.float32)
+        matmul_valid_shape(a, b, output, config=test_config)
+        expected = torch.zeros_like(output)
+        expected[:5] = torch.matmul(a, b)
+        assert torch.allclose(output, expected, rtol=1e-3, atol=1e-3), (
+            f"matmul_valid_shape failed: max diff = {(output - expected).abs().max().item()}"
+        )
+
     @pytest.mark.platforms("a2a3", "a2a3sim")
     @pytest.mark.parametrize("platform", PLATFORMS)
     @pytest.mark.parametrize("planner", _AUTOL0_PLANNERS)

--- a/tests/st/runtime/ops/test_matmul.py
+++ b/tests/st/runtime/ops/test_matmul.py
@@ -1519,18 +1519,24 @@ class TestMatmulOperations:
         )
 
     def test_matmul_valid_shape(self, test_config):
-        from examples.kernels.matmul_valid_shape import matmul_valid_shape  # noqa: PLC0415
+        from examples.kernels.matmul_valid_shape import (  # noqa: PLC0415
+            TILE_M,
+            VALID_M,
+            K,
+            N,
+            matmul_valid_shape,
+        )
 
         matmul_valid_shape._cache.clear()
         torch.manual_seed(0)
-        a = torch.randn(5, 16, dtype=torch.float32)
-        b = torch.randn(16, 16, dtype=torch.float32)
+        a = torch.randn(VALID_M, K, dtype=torch.float32)
+        b = torch.randn(K, N, dtype=torch.float32)
         sentinel = 17.0
-        output = torch.full((16, 16), sentinel, dtype=torch.float32)
+        output = torch.full((TILE_M, N), sentinel, dtype=torch.float32)
         expected = output.clone()
         matmul_valid_shape(a, b, output, config=test_config)
-        expected[:5] = torch.matmul(a, b)
-        assert torch.equal(output[5:], torch.full_like(output[5:], sentinel)), (
+        expected[:VALID_M] = torch.matmul(a, b)
+        assert torch.equal(output[VALID_M:], torch.full_like(output[VALID_M:], sentinel)), (
             "rows outside valid_shape were modified"
         )
         assert torch.allclose(output, expected, rtol=1e-3, atol=1e-3), (

--- a/tests/st/runtime/ops/test_max_min.py
+++ b/tests/st/runtime/ops/test_max_min.py
@@ -50,8 +50,8 @@ class TileMaximumProgram:
         rhs: pl.Tensor[[M, N], pl.FP32],
         out: pl.Out[pl.Tensor[[M, N], pl.FP32]],
     ) -> pl.Tensor[[M, N], pl.FP32]:
-        lhs_tile: pl.Tile[[M, N], pl.FP32] = pl.load(lhs, [0, 0], [M, N], valid_shapes=[M, N])
-        rhs_tile: pl.Tile[[M, N], pl.FP32] = pl.load(rhs, [0, 0], [M, N], valid_shapes=[M, N])
+        lhs_tile: pl.Tile[[M, N], pl.FP32] = pl.load(lhs, [0, 0], [M, N], valid_shape=[M, N])
+        rhs_tile: pl.Tile[[M, N], pl.FP32] = pl.load(rhs, [0, 0], [M, N], valid_shape=[M, N])
         out_tile: pl.Tile[[M, N], pl.FP32] = pl.tile.maximum(lhs_tile, rhs_tile)
         out = pl.store(out_tile, [0, 0], out)
         return out
@@ -78,8 +78,8 @@ class TileMinimumProgram:
         rhs: pl.Tensor[[M, N], pl.FP32],
         out: pl.Out[pl.Tensor[[M, N], pl.FP32]],
     ) -> pl.Tensor[[M, N], pl.FP32]:
-        lhs_tile: pl.Tile[[M, N], pl.FP32] = pl.load(lhs, [0, 0], [M, N], valid_shapes=[M, N])
-        rhs_tile: pl.Tile[[M, N], pl.FP32] = pl.load(rhs, [0, 0], [M, N], valid_shapes=[M, N])
+        lhs_tile: pl.Tile[[M, N], pl.FP32] = pl.load(lhs, [0, 0], [M, N], valid_shape=[M, N])
+        rhs_tile: pl.Tile[[M, N], pl.FP32] = pl.load(rhs, [0, 0], [M, N], valid_shape=[M, N])
         out_tile: pl.Tile[[M, N], pl.FP32] = pl.tile.minimum(lhs_tile, rhs_tile)
         out = pl.store(out_tile, [0, 0], out)
         return out
@@ -106,7 +106,7 @@ def _make_tile_maximums_program(scalar: float):
             lhs: pl.Tensor[[M, N], pl.FP32],
             out: pl.Out[pl.Tensor[[M, N], pl.FP32]],
         ) -> pl.Tensor[[M, N], pl.FP32]:
-            lhs_tile: pl.Tile[[M, N], pl.FP32] = pl.load(lhs, [0, 0], [M, N], valid_shapes=[M, N])
+            lhs_tile: pl.Tile[[M, N], pl.FP32] = pl.load(lhs, [0, 0], [M, N], valid_shape=[M, N])
             out_tile: pl.Tile[[M, N], pl.FP32] = pl.tile.maximums(lhs_tile, scalar)
             out = pl.store(out_tile, [0, 0], out)
             return out
@@ -132,7 +132,7 @@ def _make_tile_minimums_program(scalar: float):
             lhs: pl.Tensor[[M, N], pl.FP32],
             out: pl.Out[pl.Tensor[[M, N], pl.FP32]],
         ) -> pl.Tensor[[M, N], pl.FP32]:
-            lhs_tile: pl.Tile[[M, N], pl.FP32] = pl.load(lhs, [0, 0], [M, N], valid_shapes=[M, N])
+            lhs_tile: pl.Tile[[M, N], pl.FP32] = pl.load(lhs, [0, 0], [M, N], valid_shape=[M, N])
             out_tile: pl.Tile[[M, N], pl.FP32] = pl.tile.minimums(lhs_tile, scalar)
             out = pl.store(out_tile, [0, 0], out)
             return out

--- a/tests/st/runtime/ops/test_part_ops.py
+++ b/tests/st/runtime/ops/test_part_ops.py
@@ -84,8 +84,8 @@ def _tile_part_add(v_rows: int, v_cols: int):
             src1: pl.Tensor[[M, N], pl.FP32],
             out: pl.Out[pl.Tensor[[M, N], pl.FP32]],
         ) -> pl.Tensor[[M, N], pl.FP32]:
-            t0: pl.Tile[[M, N], pl.FP32] = pl.load(src0, [0, 0], [M, N], valid_shapes=[M, N])
-            t1: pl.Tile[[M, N], pl.FP32] = pl.load(src1, [0, 0], [M, N], valid_shapes=[v_rows, v_cols])
+            t0: pl.Tile[[M, N], pl.FP32] = pl.load(src0, [0, 0], [M, N], valid_shape=[M, N])
+            t1: pl.Tile[[M, N], pl.FP32] = pl.load(src1, [0, 0], [M, N], valid_shape=[v_rows, v_cols])
             out_tile: pl.Tile[[M, N], pl.FP32] = pl.tile.part_add(t0, t1)
             out = pl.store(out_tile, [0, 0], out)
             return out
@@ -113,8 +113,8 @@ def _tile_part_mul(v_rows: int, v_cols: int):
             src1: pl.Tensor[[M, N], pl.FP32],
             out: pl.Out[pl.Tensor[[M, N], pl.FP32]],
         ) -> pl.Tensor[[M, N], pl.FP32]:
-            t0: pl.Tile[[M, N], pl.FP32] = pl.load(src0, [0, 0], [M, N], valid_shapes=[M, N])
-            t1: pl.Tile[[M, N], pl.FP32] = pl.load(src1, [0, 0], [M, N], valid_shapes=[v_rows, v_cols])
+            t0: pl.Tile[[M, N], pl.FP32] = pl.load(src0, [0, 0], [M, N], valid_shape=[M, N])
+            t1: pl.Tile[[M, N], pl.FP32] = pl.load(src1, [0, 0], [M, N], valid_shape=[v_rows, v_cols])
             out_tile: pl.Tile[[M, N], pl.FP32] = pl.tile.part_mul(t0, t1)
             out = pl.store(out_tile, [0, 0], out)
             return out
@@ -142,8 +142,8 @@ def _tile_part_max(v_rows: int, v_cols: int):
             src1: pl.Tensor[[M, N], pl.FP32],
             out: pl.Out[pl.Tensor[[M, N], pl.FP32]],
         ) -> pl.Tensor[[M, N], pl.FP32]:
-            t0: pl.Tile[[M, N], pl.FP32] = pl.load(src0, [0, 0], [M, N], valid_shapes=[M, N])
-            t1: pl.Tile[[M, N], pl.FP32] = pl.load(src1, [0, 0], [M, N], valid_shapes=[v_rows, v_cols])
+            t0: pl.Tile[[M, N], pl.FP32] = pl.load(src0, [0, 0], [M, N], valid_shape=[M, N])
+            t1: pl.Tile[[M, N], pl.FP32] = pl.load(src1, [0, 0], [M, N], valid_shape=[v_rows, v_cols])
             out_tile: pl.Tile[[M, N], pl.FP32] = pl.tile.part_max(t0, t1)
             out = pl.store(out_tile, [0, 0], out)
             return out
@@ -171,8 +171,8 @@ def _tile_part_min(v_rows: int, v_cols: int):
             src1: pl.Tensor[[M, N], pl.FP32],
             out: pl.Out[pl.Tensor[[M, N], pl.FP32]],
         ) -> pl.Tensor[[M, N], pl.FP32]:
-            t0: pl.Tile[[M, N], pl.FP32] = pl.load(src0, [0, 0], [M, N], valid_shapes=[M, N])
-            t1: pl.Tile[[M, N], pl.FP32] = pl.load(src1, [0, 0], [M, N], valid_shapes=[v_rows, v_cols])
+            t0: pl.Tile[[M, N], pl.FP32] = pl.load(src0, [0, 0], [M, N], valid_shape=[M, N])
+            t1: pl.Tile[[M, N], pl.FP32] = pl.load(src1, [0, 0], [M, N], valid_shape=[v_rows, v_cols])
             out_tile: pl.Tile[[M, N], pl.FP32] = pl.tile.part_min(t0, t1)
             out = pl.store(out_tile, [0, 0], out)
             return out

--- a/tests/st/runtime/ops/test_prod_reduction.py
+++ b/tests/st/runtime/ops/test_prod_reduction.py
@@ -511,7 +511,7 @@ class RowProd_ValidCol48_FP32:
         input_tensor: pl.Tensor[[32, 64], pl.FP32],
         output: pl.Out[pl.Tensor[[32, 1], pl.FP32]],
     ) -> pl.Tensor[[32, 1], pl.FP32]:
-        tile: pl.Tile[[32, 64], pl.FP32] = pl.load(input_tensor, [0, 0], [32, 64], valid_shapes=[32, 48])
+        tile: pl.Tile[[32, 64], pl.FP32] = pl.load(input_tensor, [0, 0], [32, 64], valid_shape=[32, 48])
         tmp: pl.Tile[[32, 64], pl.FP32] = pl.tile.create(
             [32, 64], dtype=pl.FP32, target_memory=pl.MemorySpace.Vec
         )
@@ -536,7 +536,7 @@ class RowProd_ValidCol50_FP32:
         input_tensor: pl.Tensor[[32, 64], pl.FP32],
         output: pl.Out[pl.Tensor[[32, 1], pl.FP32]],
     ) -> pl.Tensor[[32, 1], pl.FP32]:
-        tile: pl.Tile[[32, 64], pl.FP32] = pl.load(input_tensor, [0, 0], [32, 64], valid_shapes=[32, 50])
+        tile: pl.Tile[[32, 64], pl.FP32] = pl.load(input_tensor, [0, 0], [32, 64], valid_shape=[32, 50])
         tmp: pl.Tile[[32, 64], pl.FP32] = pl.tile.create(
             [32, 64], dtype=pl.FP32, target_memory=pl.MemorySpace.Vec
         )
@@ -561,7 +561,7 @@ class ColProd_ValidRow20_FP32:
         input_tensor: pl.Tensor[[32, 64], pl.FP32],
         output: pl.Out[pl.Tensor[[1, 64], pl.FP32]],
     ) -> pl.Tensor[[1, 64], pl.FP32]:
-        tile: pl.Tile[[32, 64], pl.FP32] = pl.load(input_tensor, [0, 0], [32, 64], valid_shapes=[20, 64])
+        tile: pl.Tile[[32, 64], pl.FP32] = pl.load(input_tensor, [0, 0], [32, 64], valid_shape=[20, 64])
         result: pl.Tile[[1, 64], pl.FP32] = pl.tile.col_prod(tile)
         return pl.store(result, [0, 0], output)
 

--- a/tests/st/runtime/ops/test_row_expand_add.py
+++ b/tests/st/runtime/ops/test_row_expand_add.py
@@ -163,12 +163,12 @@ class TileRowExpandAddCase(PTOTestCase):
                     row_vec: pl.Tensor[[m, row_cols], dtype],
                     out: pl.InOut[pl.Tensor[[m, n], dtype]],
                 ) -> pl.Tensor[[m, n], dtype]:
-                    src_tile: pl.Tile[[m, n], dtype] = pl.load(src, [0, 0], [m, n], valid_shapes=valid_shape)
+                    src_tile: pl.Tile[[m, n], dtype] = pl.load(src, [0, 0], [m, n], valid_shape=valid_shape)
                     row_tile: pl.Tile[[m, row_cols], dtype] = pl.load(
                         row_vec,
                         [0, 0],
                         [m, row_cols],
-                        valid_shapes=[valid_rows, row_cols],
+                        valid_shape=[valid_rows, row_cols],
                     )
                     tmp: pl.Tile[[tmp_m, tmp_n], tmp_dtype] = pl.tile.create(
                         [tmp_m, tmp_n], dtype=tmp_dtype, target_memory=pl.MemorySpace.Vec
@@ -196,12 +196,12 @@ class TileRowExpandAddCase(PTOTestCase):
                 row_vec: pl.Tensor[[m, row_cols], dtype],
                 out: pl.InOut[pl.Tensor[[m, n], dtype]],
             ) -> pl.Tensor[[m, n], dtype]:
-                src_tile: pl.Tile[[m, n], dtype] = pl.load(src, [0, 0], [m, n], valid_shapes=valid_shape)
+                src_tile: pl.Tile[[m, n], dtype] = pl.load(src, [0, 0], [m, n], valid_shape=valid_shape)
                 row_tile: pl.Tile[[m, row_cols], dtype] = pl.load(
                     row_vec,
                     [0, 0],
                     [m, row_cols],
-                    valid_shapes=[valid_rows, row_cols],
+                    valid_shape=[valid_rows, row_cols],
                 )
                 result: pl.Tile[[m, n], dtype] = pl.tile.row_expand_add(src_tile, row_tile)
                 return pl.store(result, [0, 0], out)

--- a/tests/st/runtime/ops/test_row_min.py
+++ b/tests/st/runtime/ops/test_row_min.py
@@ -123,7 +123,7 @@ class TileRowMinCase(PTOTestCase):
                 src: pl.Tensor[[m, n], dtype],
                 out: pl.InOut[pl.Tensor[[m, 1], dtype]],
             ) -> pl.Tensor[[m, 1], dtype]:
-                src_tile: pl.Tile[[m, n], dtype] = pl.load(src, [0, 0], [m, n], valid_shapes=valid_shape)
+                src_tile: pl.Tile[[m, n], dtype] = pl.load(src, [0, 0], [m, n], valid_shape=valid_shape)
                 tmp: pl.Tile[[tmp_m, tmp_n], dtype] = pl.tile.create(
                     [tmp_m, tmp_n], dtype=dtype, target_memory=pl.MemorySpace.Vec
                 )

--- a/tests/st/runtime/ops/test_subs.py
+++ b/tests/st/runtime/ops/test_subs.py
@@ -127,7 +127,7 @@ class TileSubsCase(PTOTestCase):
                 src: pl.Tensor[[m, n], dtype],
                 out: pl.InOut[pl.Tensor[[m, n], dtype]],
             ) -> pl.Tensor[[m, n], dtype]:
-                src_tile: pl.Tile[[m, n], dtype] = pl.load(src, [0, 0], [m, n], valid_shapes=valid_shape)
+                src_tile: pl.Tile[[m, n], dtype] = pl.load(src, [0, 0], [m, n], valid_shape=valid_shape)
                 result: pl.Tile[[m, n], dtype] = pl.tile.subs(src_tile, scalar)
                 return pl.store(result, [0, 0], out)
 
@@ -259,7 +259,7 @@ class TileSubsInt32ScalarCase(PTOTestCase):
                 src: pl.Tensor[[32, 64], pl.FP32],
                 out: pl.InOut[pl.Tensor[[32, 64], pl.FP32]],
             ) -> pl.Tensor[[32, 64], pl.FP32]:
-                src_tile: pl.Tile[[32, 64], pl.FP32] = pl.load(src, [0, 0], [32, 64], valid_shapes=[20, 47])
+                src_tile: pl.Tile[[32, 64], pl.FP32] = pl.load(src, [0, 0], [32, 64], valid_shape=[20, 47])
                 result: pl.Tile[[32, 64], pl.FP32] = pl.tile.subs(src_tile, pl.const(2, pl.INT32))
                 return pl.store(result, [0, 0], out)
 

--- a/tests/st/runtime/ops/test_unary_math.py
+++ b/tests/st/runtime/ops/test_unary_math.py
@@ -36,7 +36,7 @@ from harness.core.harness import DataType, PTOTestCase, TensorSpec
 
 _PL_DT = {DataType.FP32: pl.FP32, DataType.FP16: pl.FP16}
 
-# (label, m, n, valid_shapes) — the full shape/valid sweep (used by sqrt).
+# (label, m, n, valid_shape) — the full shape/valid sweep (used by sqrt).
 _SHAPE_CFGS = [
     ("16x16", 16, 16, None),
     ("32x64", 32, 64, None),
@@ -85,7 +85,7 @@ class _UnaryMathBase(PTOTestCase):
         *,
         m=16,
         n=16,
-        valid_shapes=None,
+        valid_shape=None,
         dtype=DataType.FP32,
         input_fn=None,
         out_m=None,
@@ -104,7 +104,7 @@ class _UnaryMathBase(PTOTestCase):
         if dtype == DataType.FP16 and config is None:
             self.config.rtol = 2e-3
             self.config.atol = 2e-3
-        self._m, self._n, self._valid, self._dtype = m, n, valid_shapes, dtype
+        self._m, self._n, self._valid, self._dtype = m, n, valid_shape, dtype
         self._input_fn = input_fn or _positive
         self._out_m, self._out_n, self._off = out_m or m, out_n or n, off
 
@@ -132,7 +132,7 @@ class _UnaryMathBase(PTOTestCase):
         r, c = self._off
         if self._valid:
             vm, vn = self._valid
-            # Region outside valid_shapes stays zero — matches the InOut zero-init staged to device.
+            # Region outside valid_shape stays zero — matches the InOut zero-init staged to device.
             res = torch.zeros_like(a)
             res[:vm, :vn] = self._ref(a[:vm, :vn])
         else:
@@ -158,7 +158,7 @@ class TileSinTestCase(_UnaryMathBase):
             def kernel(
                 self, a: pl.Tensor[[m, n], dt], out: pl.InOut[pl.Tensor[[om, on], dt]]
             ) -> pl.Tensor[[om, on], dt]:
-                a_tile = pl.load(a, [0, 0], [m, n], valid_shapes=vshape)
+                a_tile = pl.load(a, [0, 0], [m, n], valid_shape=vshape)
                 out = pl.store(pl.tile.sin(a_tile), off, out)
                 return out
 
@@ -189,7 +189,7 @@ class TileCosTestCase(_UnaryMathBase):
             def kernel(
                 self, a: pl.Tensor[[m, n], dt], out: pl.InOut[pl.Tensor[[om, on], dt]]
             ) -> pl.Tensor[[om, on], dt]:
-                a_tile = pl.load(a, [0, 0], [m, n], valid_shapes=vshape)
+                a_tile = pl.load(a, [0, 0], [m, n], valid_shape=vshape)
                 out = pl.store(pl.tile.cos(a_tile), off, out)
                 return out
 
@@ -220,7 +220,7 @@ class TileSqrtTestCase(_UnaryMathBase):
             def kernel(
                 self, a: pl.Tensor[[m, n], dt], out: pl.InOut[pl.Tensor[[om, on], dt]]
             ) -> pl.Tensor[[om, on], dt]:
-                a_tile = pl.load(a, [0, 0], [m, n], valid_shapes=vshape)
+                a_tile = pl.load(a, [0, 0], [m, n], valid_shape=vshape)
                 out = pl.store(pl.tile.sqrt(a_tile), off, out)
                 return out
 
@@ -235,24 +235,24 @@ class TileSqrtTestCase(_UnaryMathBase):
 
 
 class TestUnaryMath:
-    """Tile-level sin/cos/sqrt on a2a3 across shapes, valid_shapes, dtypes, offset, input ranges."""
+    """Tile-level sin/cos/sqrt on a2a3 across shapes, valid_shape, dtypes, offset, input ranges."""
 
     @pytest.mark.platforms("a2a3")
     @pytest.mark.parametrize("label,m,n,valid", _TRIG_SHAPE_CFGS, ids=[c[0] for c in _TRIG_SHAPE_CFGS])
     def test_tile_sin(self, test_runner, label, m, n, valid):
-        result = test_runner.run(TileSinTestCase(m=m, n=n, valid_shapes=valid))
+        result = test_runner.run(TileSinTestCase(m=m, n=n, valid_shape=valid))
         assert result.passed, f"Test failed: {result.error}"
 
     @pytest.mark.platforms("a2a3")
     @pytest.mark.parametrize("label,m,n,valid", _TRIG_SHAPE_CFGS, ids=[c[0] for c in _TRIG_SHAPE_CFGS])
     def test_tile_cos(self, test_runner, label, m, n, valid):
-        result = test_runner.run(TileCosTestCase(m=m, n=n, valid_shapes=valid))
+        result = test_runner.run(TileCosTestCase(m=m, n=n, valid_shape=valid))
         assert result.passed, f"Test failed: {result.error}"
 
     @pytest.mark.platforms("a2a3")
     @pytest.mark.parametrize("label,m,n,valid", _SHAPE_CFGS, ids=[c[0] for c in _SHAPE_CFGS])
     def test_tile_sqrt(self, test_runner, label, m, n, valid):
-        result = test_runner.run(TileSqrtTestCase(m=m, n=n, valid_shapes=valid))
+        result = test_runner.run(TileSqrtTestCase(m=m, n=n, valid_shape=valid))
         assert result.passed, f"Test failed: {result.error}"
 
     @pytest.mark.platforms("a2a3")

--- a/tests/st/runtime/ops/test_vector_misc.py
+++ b/tests/st/runtime/ops/test_vector_misc.py
@@ -57,7 +57,7 @@ class _ScalarOpBase(PTOTestCase):
         *,
         m=16,
         n=16,
-        valid_shapes=None,
+        valid_shape=None,
         dtype=DataType.FP32,
         rhs=2.0,
         out_m=None,
@@ -66,7 +66,7 @@ class _ScalarOpBase(PTOTestCase):
         config=None,
     ):
         super().__init__(config)
-        self._m, self._n, self._valid, self._dtype = m, n, valid_shapes, dtype
+        self._m, self._n, self._valid, self._dtype = m, n, valid_shape, dtype
         self._rhs, self._out_m, self._out_n, self._off = rhs, out_m or m, out_n or n, off
 
     def get_name(self) -> str:
@@ -91,7 +91,7 @@ class _ScalarOpBase(PTOTestCase):
         r, c = self._off
         if self._valid:
             vm, vn = self._valid
-            # Region outside valid_shapes stays zero — matches the InOut zero-init staged to device.
+            # Region outside valid_shape stays zero — matches the InOut zero-init staged to device.
             res = torch.zeros_like(a)
             res[:vm, :vn] = self._ref(a[:vm, :vn])
         else:
@@ -117,7 +117,7 @@ class TileMulsTestCase(_ScalarOpBase):
             def kernel(
                 self, a: pl.Tensor[[m, n], dt], out: pl.InOut[pl.Tensor[[om, on], dt]]
             ) -> pl.Tensor[[om, on], dt]:
-                a_tile = pl.load(a, [0, 0], [m, n], valid_shapes=vshape)
+                a_tile = pl.load(a, [0, 0], [m, n], valid_shape=vshape)
                 out = pl.store(pl.tile.muls(a_tile, rhs), off, out)
                 return out
 
@@ -148,7 +148,7 @@ class TileDivsTestCase(_ScalarOpBase):
             def kernel(
                 self, a: pl.Tensor[[m, n], dt], out: pl.InOut[pl.Tensor[[om, on], dt]]
             ) -> pl.Tensor[[om, on], dt]:
-                a_tile = pl.load(a, [0, 0], [m, n], valid_shapes=vshape)
+                a_tile = pl.load(a, [0, 0], [m, n], valid_shape=vshape)
                 out = pl.store(pl.tile.divs(a_tile, rhs), off, out)
                 return out
 
@@ -172,7 +172,7 @@ class ColExpandAddTestCase(PTOTestCase):
         *,
         m=16,
         n=16,
-        valid_shapes=None,
+        valid_shape=None,
         dtype=DataType.FP32,
         out_m=None,
         out_n=None,
@@ -180,7 +180,7 @@ class ColExpandAddTestCase(PTOTestCase):
         config=None,
     ):
         super().__init__(config)
-        self._m, self._n, self._valid, self._dtype = m, n, valid_shapes, dtype
+        self._m, self._n, self._valid, self._dtype = m, n, valid_shape, dtype
         self._out_m, self._out_n, self._off = out_m or m, out_n or n, off
 
     def get_name(self) -> str:
@@ -212,8 +212,8 @@ class ColExpandAddTestCase(PTOTestCase):
                 col_vec: pl.Tensor[[1, n], dt],
                 out: pl.InOut[pl.Tensor[[om, on], dt]],
             ) -> pl.Tensor[[om, on], dt]:
-                a_tile = pl.load(a, [0, 0], [m, n], valid_shapes=vshape)
-                col_tile = pl.load(col_vec, [0, 0], [1, n], valid_shapes=col_vshape)
+                a_tile = pl.load(a, [0, 0], [m, n], valid_shape=vshape)
+                col_tile = pl.load(col_vec, [0, 0], [1, n], valid_shape=col_vshape)
                 out = pl.store(pl.tile.col_expand_add(a_tile, col_tile), off, out)
                 return out
 
@@ -235,7 +235,7 @@ class ColExpandAddTestCase(PTOTestCase):
         r, c = self._off
         if self._valid:
             vm, vn = self._valid
-            # Region outside valid_shapes stays zero — matches the InOut zero-init staged to device.
+            # Region outside valid_shape stays zero — matches the InOut zero-init staged to device.
             res = torch.zeros_like(a)
             res[:vm, :vn] = a[:vm, :vn] + col[:, :vn]
         else:
@@ -254,13 +254,13 @@ class TestVectorMisc:
     @pytest.mark.platforms("a2a3")
     @pytest.mark.parametrize("label,m,n,valid", _SHAPE_CFGS, ids=[c[0] for c in _SHAPE_CFGS])
     def test_tile_muls(self, test_runner, label, m, n, valid):
-        result = test_runner.run(TileMulsTestCase(m=m, n=n, valid_shapes=valid, rhs=2.5))
+        result = test_runner.run(TileMulsTestCase(m=m, n=n, valid_shape=valid, rhs=2.5))
         assert result.passed, f"Test failed: {result.error}"
 
     @pytest.mark.platforms("a2a3")
     @pytest.mark.parametrize("label,m,n,valid", _SHAPE_CFGS, ids=[c[0] for c in _SHAPE_CFGS])
     def test_tile_divs(self, test_runner, label, m, n, valid):
-        result = test_runner.run(TileDivsTestCase(m=m, n=n, valid_shapes=valid, rhs=2.0))
+        result = test_runner.run(TileDivsTestCase(m=m, n=n, valid_shape=valid, rhs=2.0))
         assert result.passed, f"Test failed: {result.error}"
 
     @pytest.mark.platforms("a2a3")
@@ -293,7 +293,7 @@ class TestVectorMisc:
     @pytest.mark.platforms("a2a3")
     @pytest.mark.parametrize("label,m,n,valid", _SHAPE_CFGS, ids=[c[0] for c in _SHAPE_CFGS])
     def test_tile_col_expand_add(self, test_runner, label, m, n, valid):
-        result = test_runner.run(ColExpandAddTestCase(m=m, n=n, valid_shapes=valid))
+        result = test_runner.run(ColExpandAddTestCase(m=m, n=n, valid_shape=valid))
         assert result.passed, f"Test failed: {result.error}"
 
     @pytest.mark.platforms("a2a3")

--- a/tests/ut/codegen/test_dynamic_shape.py
+++ b/tests/ut/codegen/test_dynamic_shape.py
@@ -43,7 +43,7 @@ class AddKernelDynamic:
 
 @pl.program
 class AddKernelValidShape:
-    """Add kernel with static tensors but dynamic valid_shapes passed as scalars."""
+    """Add kernel with static tensors but dynamic valid_shape passed as scalars."""
 
     @pl.function(type=pl.FunctionType.InCore)
     def add_kernel(
@@ -55,8 +55,8 @@ class AddKernelValidShape:
         N: pl.Scalar[pl.INDEX],
     ) -> pl.Tensor[[128, 128], pl.FP32]:
         """Loads 128x128 tiles but marks only [M, N] as valid: result = a + b"""
-        a_tile = pl.load(a, [0, 0], [128, 128], valid_shapes=[M, N])
-        b_tile = pl.load(b, [0, 0], [128, 128], valid_shapes=[M, N])
+        a_tile = pl.load(a, [0, 0], [128, 128], valid_shape=[M, N])
+        b_tile = pl.load(b, [0, 0], [128, 128], valid_shape=[M, N])
         result = pl.add(a_tile, b_tile)
         out = pl.store(result, [0, 0], output)
         return out
@@ -64,7 +64,7 @@ class AddKernelValidShape:
 
 @pl.program
 class AddKernelValidShapeExpr:
-    """Add kernel with valid_shapes computed from a runtime expression (regression for #707)."""
+    """Add kernel with valid_shape computed from a runtime expression (regression for #707)."""
 
     @pl.function(type=pl.FunctionType.InCore)
     def add_kernel(
@@ -77,8 +77,8 @@ class AddKernelValidShapeExpr:
     ) -> pl.Tensor[[128, 128], pl.FP32]:
         """valid_shape elements come from pl.min(...) — i.e. ir::Call, not ir::Var."""
         valid_m = pl.min(M, N)
-        a_tile = pl.load(a, [0, 0], [128, 128], valid_shapes=[valid_m, N])
-        b_tile = pl.load(b, [0, 0], [128, 128], valid_shapes=[valid_m, N])
+        a_tile = pl.load(a, [0, 0], [128, 128], valid_shape=[valid_m, N])
+        b_tile = pl.load(b, [0, 0], [128, 128], valid_shape=[valid_m, N])
         result = pl.add(a_tile, b_tile)
         out = pl.store(result, [0, 0], output)
         return out
@@ -181,7 +181,7 @@ def test_add_kernel_dynamic_shape_pto_codegen():
 
 
 def test_add_kernel_valid_shape_pto_codegen():
-    """Test PTO codegen handles load with valid_shapes: tile allocated from shapes, M/N as index scalars."""
+    """Test PTO codegen handles load with valid_shape: tile allocated from shapes, M/N as index scalars."""
     backend.reset_for_testing()
     backend.set_backend_type(BackendType.Ascend910B)
     func = AddKernelValidShape.get_function("add_kernel")
@@ -200,7 +200,7 @@ def test_add_kernel_valid_shape_pto_codegen():
     assert "shape = [%c128_index, %c128_index]" in mlir_code
     assert "strides = [%c128_index, %c1_index]" in mlir_code
     assert "!pto.tensor_view<?x?xf32>" in mlir_code
-    # partition_view follows valid_shapes (dynamic %arg3, %arg4) so the DMA
+    # partition_view follows valid_shape (dynamic %arg3, %arg4) so the DMA
     # only fetches the valid region from GM. The partition_view type therefore
     # uses dynamic dims and its sizes use the valid_shape SSA values directly.
     assert "partition_tensor_view<?x?xf32>" in mlir_code

--- a/tests/ut/codegen/test_dynamic_valid_shape_if_else.py
+++ b/tests/ut/codegen/test_dynamic_valid_shape_if_else.py
@@ -22,7 +22,7 @@ if/else, then performing a single load+fillpad with that computed length:
       vlen = last_valid_len
   else:
       vlen = full_len
-  s_tile = pl.load(..., valid_shapes=[rows, vlen])
+  s_tile = pl.load(..., valid_shape=[rows, vlen])
   s_padded = pl.tile.fillpad(s_tile, pad_value=pl.PadValue.min)
 
 The tile buffer type is uniform (same v_row=?, v_col=?, pad=min) regardless
@@ -41,7 +41,7 @@ from pypto.ir.pass_manager import OptimizationStrategy, PassManager
 from pypto.pypto_core import codegen
 
 # ---------------------------------------------------------------------------
-# Program 1: Simple if/else with different valid_shapes (no loop)
+# Program 1: Simple if/else with different valid_shape values (no loop)
 # ---------------------------------------------------------------------------
 
 
@@ -68,7 +68,7 @@ class DynValidShapeIfElse:
         else:
             vlen: pl.Scalar[pl.INDEX] = full_len
         s_tile: pl.Tile[[64, 64], pl.FP32] = pl.load(
-            data, [0, 0], [64, 64], valid_shapes=[64, vlen], target_memory=pl.MemorySpace.Vec
+            data, [0, 0], [64, 64], valid_shape=[64, vlen], target_memory=pl.MemorySpace.Vec
         )
         s_padded: pl.Tile[[64, 64], pl.FP32] = pl.tile.fillpad(s_tile, pad_value=pl.PadValue.min)
         scaled: pl.Tile[[64, 64], pl.FP32] = pl.mul(s_padded, scale)
@@ -108,7 +108,7 @@ class DynValidShapeLoopIfElse:
             else:
                 vlen: pl.Scalar[pl.INDEX] = block_size
             s_tile: pl.Tile[[64, 64], pl.FP32] = pl.load(
-                sij_buf, [i * 64, 0], [64, 64], valid_shapes=[64, vlen], target_memory=pl.MemorySpace.Vec
+                sij_buf, [i * 64, 0], [64, 64], valid_shape=[64, vlen], target_memory=pl.MemorySpace.Vec
             )
             s_padded: pl.Tile[[64, 64], pl.FP32] = pl.tile.fillpad(s_tile, pad_value=pl.PadValue.min)
             scaled: pl.Tile[[64, 64], pl.FP32] = pl.mul(s_padded, scale)
@@ -202,7 +202,7 @@ def test_if_else_dyn_valid_shape_padded_alloc_has_pad_min(if_else_mlir: str):
 
 
 def test_loop_if_else_dyn_valid_shape_compiles(loop_mlir: str):
-    """Verify the loop + if/else pattern with dynamic valid_shapes compiles."""
+    """Verify the loop + if/else pattern with dynamic valid_shape compiles."""
     assert loop_mlir, "Generated MLIR code should not be empty"
 
 

--- a/tests/ut/codegen/test_pto_codegen.py
+++ b/tests/ut/codegen/test_pto_codegen.py
@@ -341,10 +341,10 @@ def test_pto_codegen_fillpad_shared_memref_uses_single_alloc_tile():
     result_var = ir.Var("result", ir.TensorType([128, 128], DataType.FP32), span)
     offsets = ir.MakeTuple([zero, zero], span)
     shapes = ir.MakeTuple([size, size], span)
-    valid_shapes = ir.MakeTuple([m_var, n_var], span)
+    valid_shape = ir.MakeTuple([m_var, n_var], span)
 
     load_call = ir.Call(
-        ir.Op("tile.load"), [input_tensor, offsets, shapes, valid_shapes], {}, load_tile_type, span
+        ir.Op("tile.load"), [input_tensor, offsets, shapes, valid_shape], {}, load_tile_type, span
     )
     fillpad_call = ir.Call(
         ir.Op("tile.fillpad"),
@@ -439,7 +439,7 @@ def test_pto_codegen_fillpad_inplace():
     shapes = ir.MakeTuple([size, size], span)
 
     # Intentionally use the 3-arg form to exercise the backend fallback when
-    # valid_shapes is omitted (equivalent to `pl.load(..., valid_shapes=None)`).
+    # valid_shape is omitted (equivalent to `pl.load(..., valid_shape=None)`).
     load_call = ir.Call(ir.Op("tile.load"), [input_tensor, offsets, shapes], {}, load_tile_type, span)
     fillpad_inplace_call = ir.Call(
         ir.Op("tile.fillpad_inplace"),

--- a/tests/ut/codegen/test_pto_codegen_cross_core.py
+++ b/tests/ut/codegen/test_pto_codegen_cross_core.py
@@ -706,7 +706,7 @@ class TestCrossCoreTpushTpopCodegen:
         to the box shape; consumer-side localisation through
         LocalizeValidDimForSplit clamps the logical valid_shape back to
         the truthful per-subblock extent. See
-        src/backend/common/pto_ops_common.cpp::EmitSplitTpushTransportValidShape.
+        src/backend/common/pto_ops_crosscore.cpp::EmitTpushTransportValidShape.
         """
         transport_valid_shape = ", %c16_index, %c16_index :"
         span = ir.Span.unknown()
@@ -819,6 +819,95 @@ class TestCrossCoreTpushTpopCodegen:
             f"Expected tpush to use the aliased source tile, got:\n{tpush_line}"
         )
 
+    @pytest.mark.parametrize(
+        ("backend_type", "normalize_transport"),
+        [(BackendType.Ascend910B, True), (BackendType.Ascend950, False)],
+        ids=["a2a3-full-box", "a5-logical-shape"],
+    )
+    def test_no_split_partial_acc_tpush_transport_by_backend(self, backend_type, normalize_transport):
+        """A2/A3 no-split Acc-to-Vec transport must carry the full physical box.
+
+        A partial accumulator result still occupies a full NZ box. Sending only
+        its logical valid columns leaves the C2V FIFO slot incomplete, so the
+        vector consumer can observe its previous local-buffer contents instead
+        of the matmul result. The transport temporarily widens the tile to its
+        physical shape and restores the logical valid shape after the push. A5
+        uses a different transport and keeps the logical shape unchanged.
+        """
+        span = ir.Span.unknown()
+        zero = ir.ConstInt(0, pl.INDEX, span)
+        rows = ir.ConstInt(16, pl.INDEX, span)
+        cols = ir.ConstInt(32, pl.INDEX, span)
+        valid_cols = ir.ConstInt(24, pl.INDEX, span)
+        source = ir.Var("source", ir.TensorType([16, 32], pl.FP32), span)
+
+        memref = ir.MemRef(ir.MemorySpace.Acc, ir.ConstInt(0, pl.INT64, span), 16 * 32 * 4, 0)
+        tile_view = ir.TileView(
+            valid_shape=[rows, valid_cols],
+            blayout=ir.TileLayout.col_major,
+            slayout=ir.TileLayout.row_major,
+            fractal=1024,
+        )
+        tile_type = ir.TileType([rows, cols], pl.FP32, memref, tile_view, ir.MemorySpace.Acc)
+        partial_acc = ir.Var("partial_acc", tile_type, span)
+        offsets = ir.MakeTuple([zero, zero], span)
+        shape = ir.MakeTuple([rows, cols], span)
+        valid_shape = ir.MakeTuple([rows, valid_cols], span)
+
+        body = ir.SeqStmts(
+            [
+                ir.AssignStmt(
+                    partial_acc,
+                    ir.Call(
+                        ir.Op("tile.load"),
+                        [source, offsets, shape, valid_shape],
+                        {"target_memory": ir.MemorySpace.Acc},
+                        tile_type,
+                        span,
+                    ),
+                    span,
+                ),
+                ir.EvalStmt(
+                    ir.Call(
+                        ir.Op("tile.tpush_to_aiv"),
+                        [partial_acc],
+                        {"split": 0},
+                        ir.UnknownType(),
+                        span,
+                    ),
+                    span,
+                ),
+            ],
+            span,
+        )
+        func = ir.Function(
+            "partial_acc_push",
+            [(source, ir.ParamDirection.In)],
+            [],
+            body,
+            span,
+            ir.FunctionType.AIC,
+        )
+
+        backend.reset_for_testing()
+        backend.set_backend_type(backend_type)
+        mlir_code = codegen.PTOCodegen().generate(ir.Program([func], "partial_acc_push_program", span))
+        lines = [line.strip() for line in mlir_code.splitlines()]
+        set_validshape_lines = [line for line in lines if "pto.set_validshape" in line]
+        tpush_index = next(i for i, line in enumerate(lines) if "pto.tpush_to_aiv" in line)
+
+        if not normalize_transport:
+            assert set_validshape_lines == []
+            return
+
+        assert len(set_validshape_lines) == 2, (
+            "Expected full-box transport normalization and logical restore, got:\n"
+            + "\n".join(set_validshape_lines)
+        )
+        assert ", %c16_index, %c32_index :" in set_validshape_lines[0]
+        assert ", %c16_index, %c24_index :" in set_validshape_lines[1]
+        assert lines.index(set_validshape_lines[0]) < tpush_index < lines.index(set_validshape_lines[1])
+
     def test_no_split_dual_aiv_tpush_widens_cols_preserves_rows(self):
         """No-split dual-AIV tpush widens COLUMNS to the box but PRESERVES rows.
 
@@ -834,7 +923,7 @@ class TestCrossCoreTpushTpopCodegen:
         stays a true 0-row no-op instead of racing garbage rows into subblock
         0's slot. Genuine split==1/2 paths widen both axes; plain split==0
         without ``dual_aiv_dispatch`` emits no transport at all. See
-        src/backend/common/pto_ops_common.cpp::EmitSplitTpushTransportValidShape.
+        src/backend/common/pto_ops_crosscore.cpp::EmitTpushTransportValidShape.
         """
         span = ir.Span.unknown()
         memory_space = ir.MemorySpace.Vec
@@ -958,10 +1047,10 @@ class TestCrossCoreTpushTpopCodegen:
         (0, 0). A col-widening transport for a 0-row push moves no data yet
         (on 910B) perturbs the shared-slot dual-AIV merge -- emitting one
         regressed the cross_core_v2c_nosplit golden. So when the producer's
-        transport rows are statically 0, EmitSplitTpushTransportValidShape
+        transport rows are statically 0, EmitTpushTransportValidShape
         skips the transport entirely; only the real, non-zero-row subblock-0
         push gets it. See
-        src/backend/common/pto_ops_common.cpp::EmitSplitTpushTransportValidShape.
+        src/backend/common/pto_ops_crosscore.cpp::EmitTpushTransportValidShape.
         """
         span = ir.Span.unknown()
         memory_space = ir.MemorySpace.Vec

--- a/tests/ut/codegen/test_pto_codegen_cross_core.py
+++ b/tests/ut/codegen/test_pto_codegen_cross_core.py
@@ -908,6 +908,62 @@ class TestCrossCoreTpushTpopCodegen:
         assert ", %c16_index, %c24_index :" in set_validshape_lines[1]
         assert lines.index(set_validshape_lines[0]) < tpush_index < lines.index(set_validshape_lines[1])
 
+    @pytest.mark.parametrize(
+        ("backend_type", "normalize_transport"),
+        [(BackendType.Ascend910B, True), (BackendType.Ascend950, False)],
+        ids=["a2a3-full-box", "a5-logical-shape"],
+    )
+    def test_no_split_partial_c2v_tpop_transport_by_backend(self, backend_type, normalize_transport):
+        """A2/A3 no-split C2V pop must receive the full physical box.
+
+        The A2/A3 pipe moves a fixed-size slot.  Passing the logical partial
+        shape to tpop copies only part of that slot and makes the NZ-to-ND
+        conversion use the wrong extent.  The raw FIFO tile cannot be narrowed
+        with set_validshape, so tpop receives the full box while the result's IR
+        type continues to carry the logical shape for downstream operations.
+        A5 keeps the logical tpop operands.
+        """
+        span = ir.Span.unknown()
+        rows = ir.ConstInt(16, pl.INDEX, span)
+        cols = ir.ConstInt(32, pl.INDEX, span)
+        valid_cols = ir.ConstInt(24, pl.INDEX, span)
+        tile_view = ir.TileView(
+            valid_shape=[rows, valid_cols],
+            blayout=ir.TileLayout.row_major,
+            slayout=ir.TileLayout.none_box,
+            fractal=512,
+        )
+        tile_type = ir.TileType([rows, cols], pl.FP32, None, tile_view, ir.MemorySpace.Vec)
+        popped = ir.Var("popped", tile_type, span)
+        body = ir.SeqStmts(
+            [
+                ir.AssignStmt(
+                    popped,
+                    ir.Call(
+                        ir.Op("tile.tpop_from_aic"),
+                        [],
+                        {"split": 0, "_full_box_transport": True},
+                        tile_type,
+                        span,
+                    ),
+                    span,
+                )
+            ],
+            span,
+        )
+        func = ir.Function("partial_c2v_pop", [], [], body, span, ir.FunctionType.AIV)
+
+        backend.reset_for_testing()
+        backend.set_backend_type(backend_type)
+        mlir_code = codegen.PTOCodegen().generate(ir.Program([func], "partial_c2v_pop_program", span))
+        tpop_line = next(line.strip() for line in mlir_code.splitlines() if "pto.tpop_from_aic" in line)
+
+        if normalize_transport:
+            assert "pto.tpop_from_aic {split = 0}" in tpop_line
+            assert "pto.set_validshape" not in mlir_code
+        else:
+            assert "pto.tpop_from_aic(%c16_index, %c24_index) {split = 0}" in tpop_line
+
     def test_no_split_dual_aiv_tpush_widens_cols_preserves_rows(self):
         """No-split dual-AIV tpush widens COLUMNS to the box but PRESERVES rows.
 

--- a/tests/ut/debug/test_torch_codegen.py
+++ b/tests/ut/debug/test_torch_codegen.py
@@ -286,14 +286,14 @@ def test_tile_load_store():
     tensor = _tensor_var("t", [256, 256])
     offsets = _make_tuple(_int(0), _int(0))
     shapes = _make_tuple(_int(64), _int(64))
-    valid_shapes = _make_tuple(_int(64), _int(64))
+    valid_shape = _make_tuple(_int(64), _int(64))
     tile = _tile_var("tile", [64, 64])
     output = _tensor_var("out", [256, 256])
     off2 = _make_tuple(_int(64), _int(0))
 
     load_call = _op_call(
         "tile.load",
-        [tensor, offsets, shapes, valid_shapes],
+        [tensor, offsets, shapes, valid_shape],
         {"target_memory": ir.MemorySpace.Vec},
     )
     store_call = _op_call("tile.store", [tile, off2, output])
@@ -1274,8 +1274,8 @@ def test_tensor_fillpad_min_uses_valid_shape():
     result = _tensor_var("result", [8, 64], DataType.FP32)
     shapes = _make_tuple(_int(8), _int(64))
     offsets = _make_tuple(_int(0), _int(0))
-    valid_shapes = _make_tuple(_int(8), _int(32))
-    sliced = _op_call("tensor.slice", [src, shapes, offsets, valid_shapes])
+    valid_shape = _make_tuple(_int(8), _int(32))
+    sliced = _op_call("tensor.slice", [src, shapes, offsets, valid_shape])
     padded = _op_call("tensor.fillpad", [sliced], {"pad_value": ir.PadValue.min})
     assign = ir.AssignStmt(result, padded, _span())
     ret = ir.ReturnStmt([result], _span())
@@ -1293,21 +1293,21 @@ def test_tensor_fillpad_min_uses_valid_shape():
 
 
 # ---------------------------------------------------------------------------
-# Test: valid_shapes masking in tile.load
+# Test: valid_shape masking in tile.load
 # ---------------------------------------------------------------------------
 
 
-def test_tile_load_valid_shapes_masks_invalid():
-    """tile.load should zero out data beyond valid_shapes."""
+def test_tile_load_valid_shape_masks_invalid():
+    """tile.load should zero out data beyond valid_shape."""
     tensor = _tensor_var("t", [8, 8])
     offsets = _make_tuple(_int(0), _int(0))
     shapes = _make_tuple(_int(8), _int(8))
-    valid_shapes = _make_tuple(_int(4), _int(4))
+    valid_shape = _make_tuple(_int(4), _int(4))
     tile = _tile_var("tile", [8, 8])
 
     call = _op_call(
         "tile.load",
-        [tensor, offsets, shapes, valid_shapes],
+        [tensor, offsets, shapes, valid_shape],
         {"target_memory": ir.MemorySpace.Vec},
     )
     assign = ir.AssignStmt(tile, call, _span())
@@ -1328,23 +1328,23 @@ def test_tile_load_valid_shapes_masks_invalid():
     assert result[7, 7] == 0.0
 
 
-def test_tile_load_passes_valid_shapes():
-    """tile.load codegen should pass valid_shapes as 4th arg to _tile_load."""
+def test_tile_load_passes_valid_shape():
+    """tile.load codegen should pass valid_shape as 4th arg to _tile_load."""
     tensor = _tensor_var("t", [64, 64])
     offsets = _make_tuple(_int(0), _int(0))
     shapes = _make_tuple(_int(32), _int(32))
-    valid_shapes = _make_tuple(_int(16), _int(16))
+    valid_shape = _make_tuple(_int(16), _int(16))
     tile = _tile_var("tile", [32, 32])
 
     call = _op_call(
         "tile.load",
-        [tensor, offsets, shapes, valid_shapes],
+        [tensor, offsets, shapes, valid_shape],
         {"target_memory": ir.MemorySpace.Vec},
     )
     assign = ir.AssignStmt(tile, call, _span())
     func = _simple_function("f", [tensor], assign)
     code = torch_codegen(func)
-    # Should pass all 4 args including valid_shapes
+    # Should pass all 4 args including valid_shape
     assert "_tile_load(t, (0, 0), (32, 32), (16, 16))" in code
 
 

--- a/tests/ut/ir/operators/test_tile_ops.py
+++ b/tests/ut/ir/operators/test_tile_ops.py
@@ -2022,6 +2022,17 @@ class TestTileBroadcastOps:
 class TestTileMatMulOps:
     """Test suite for tile-level matrix multiplication operators."""
 
+    def test_tile_matmul_propagates_output_valid_shape(self):
+        """Matmul derives its valid M/N from the corresponding operand axes."""
+        lhs = _partial_tile([32, 32], [16, 24], name="lhs")
+        rhs = _partial_tile([32, 48], [24, 32], name="rhs")
+
+        result_type = tile.matmul(lhs, rhs).type
+
+        assert isinstance(result_type, ir.TileType)
+        assert [dim.value for dim in result_type.shape if isinstance(dim, ir.ConstInt)] == [32, 48]
+        assert _valid_of(result_type) == [16, 32]
+
     def test_tile_matmul(self):
         """Test tile.matmul operator - matrix multiplication."""
 

--- a/tests/ut/ir/operators/test_tile_ops.py
+++ b/tests/ut/ir/operators/test_tile_ops.py
@@ -11,6 +11,7 @@
 
 import inspect
 import math
+from typing import Any, cast
 
 import pypto.language as pl
 import pytest
@@ -4006,7 +4007,7 @@ class TestTileLoadOp:
         tensor = ir.Var("a", ir.TensorType([64, 128], DataType.FP32), span)
         removed_plural = "valid_" + "shapes"
         with pytest.raises(TypeError, match=rf"unexpected keyword argument '{removed_plural}'"):
-            tile.load(tensor, [0, 0], [64, 128], **{removed_plural: [32, 128]})
+            cast(Any, tile.load)(tensor, [0, 0], [64, 128], **{removed_plural: [32, 128]})
 
     def test_load_without_valid_shape_sets_tileview_from_shapes(self):
         """When valid_shape is not provided, TileView.valid_shape equals shapes."""

--- a/tests/ut/ir/operators/test_tile_ops.py
+++ b/tests/ut/ir/operators/test_tile_ops.py
@@ -9,6 +9,7 @@
 
 """Unit tests for tile operations."""
 
+import inspect
 import math
 
 import pypto.language as pl
@@ -3992,10 +3993,23 @@ class TestTileScalarOperandDtype:
 
 
 class TestTileLoadOp:
-    """Tests for tile.load operation with valid_shapes and TileView."""
+    """Tests for tile.load operation with valid_shape and TileView."""
 
-    def test_load_without_valid_shapes_sets_tileview_from_shapes(self):
-        """When valid_shapes not provided, TileView.valid_shape equals shapes."""
+    def test_load_uses_singular_valid_shape_keyword(self):
+        params = inspect.signature(tile.load).parameters
+        removed_plural = "valid_" + "shapes"
+        assert "valid_shape" in params
+        assert removed_plural not in params
+
+    def test_load_rejects_removed_plural_keyword(self):
+        span = ir.Span.unknown()
+        tensor = ir.Var("a", ir.TensorType([64, 128], DataType.FP32), span)
+        removed_plural = "valid_" + "shapes"
+        with pytest.raises(TypeError, match=rf"unexpected keyword argument '{removed_plural}'"):
+            tile.load(tensor, [0, 0], [64, 128], **{removed_plural: [32, 128]})
+
+    def test_load_without_valid_shape_sets_tileview_from_shapes(self):
+        """When valid_shape is not provided, TileView.valid_shape equals shapes."""
         span = ir.Span.unknown()
         dim64 = ir.ConstInt(64, DataType.INT32, span)
         dim128 = ir.ConstInt(128, DataType.INT32, span)
@@ -4008,15 +4022,15 @@ class TestTileLoadOp:
         assert isinstance(tile_type, ir.TileType)
         assert len(tile_type.get_effective_tile_view().valid_shape) == 2
 
-    def test_load_with_static_valid_shapes_sets_tileview(self):
-        """When valid_shapes provided as static ints, TileView.valid_shape reflects it."""
+    def test_load_with_static_valid_shape_sets_tileview(self):
+        """When valid_shape is provided as static ints, TileView.valid_shape reflects it."""
         span = ir.Span.unknown()
         dim64 = ir.ConstInt(64, DataType.INT32, span)
         dim128 = ir.ConstInt(128, DataType.INT32, span)
         tensor_type = ir.TensorType([dim64, dim128], DataType.FP32)
         tensor = ir.Var("a", tensor_type, span)
 
-        call = tile.load(tensor, [0, 0], [128, 128], valid_shapes=[64, 128])
+        call = tile.load(tensor, [0, 0], [128, 128], valid_shape=[64, 128])
         tile_type = call.type
 
         assert isinstance(tile_type, ir.TileType)
@@ -4025,8 +4039,8 @@ class TestTileLoadOp:
         # tile shape should still be [128, 128]
         assert len(tile_type.shape) == 2
 
-    def test_load_with_dynamic_valid_shapes_sets_tileview(self):
-        """When valid_shapes provided as symbolic vars, TileView.valid_shape uses them."""
+    def test_load_with_dynamic_valid_shape_sets_tileview(self):
+        """When valid_shape is provided as symbolic vars, TileView.valid_shape uses them."""
         span = ir.Span.unknown()
         dim64 = ir.ConstInt(64, DataType.INT32, span)
         dim128 = ir.ConstInt(128, DataType.INT32, span)
@@ -4035,7 +4049,7 @@ class TestTileLoadOp:
         M = ir.Var("M", ir.ScalarType(DataType.INT64), span)
         N = ir.Var("N", ir.ScalarType(DataType.INT64), span)
 
-        call = tile.load(tensor, [0, 0], [64, 128], valid_shapes=[M, N])
+        call = tile.load(tensor, [0, 0], [64, 128], valid_shape=[M, N])
         tile_type = call.type
 
         assert isinstance(tile_type, ir.TileType)
@@ -4045,8 +4059,8 @@ class TestTileLoadOp:
         assert tile_type.tile_view.valid_shape[0] is M
         assert tile_type.tile_view.valid_shape[1] is N
 
-    def test_load_via_pl_load_with_valid_shapes(self):
-        """pl.load with valid_shapes propagates TileView to the output tile."""
+    def test_load_via_pl_load_with_valid_shape(self):
+        """pl.load with valid_shape propagates TileView to the output tile."""
 
         @pl.program
         class Prog:
@@ -4057,7 +4071,7 @@ class TestTileLoadOp:
                 M: pl.Scalar[pl.INT64],
                 N: pl.Scalar[pl.INT64],
             ) -> pl.Tile[[128, 128], pl.FP32]:
-                tile: pl.Tile[[128, 128], pl.FP32] = pl.load(a, [0, 0], [128, 128], valid_shapes=[M, N])
+                tile: pl.Tile[[128, 128], pl.FP32] = pl.load(a, [0, 0], [128, 128], valid_shape=[M, N])
                 return tile
 
         # Just verifying it builds without error
@@ -5228,19 +5242,19 @@ class TestWindowReadValidRegion:
         """A load can never report source padding as real data."""
         src = self._partial_tensor([64, 128], [40, 128])
 
-        call = tile.load(src, [0, 0], [64, 128], valid_shapes=[64, 128])
+        call = tile.load(src, [0, 0], [64, 128], valid_shape=[64, 128])
 
         # The request asked for all 64 rows; only 40 exist.
         assert _valid_of(call.type) == [40, 128]
 
     def test_load_rejects_a_request_that_reads_past_the_source(self):
-        """valid_shapes is what the DMA actually reads, so it must exist."""
+        """valid_shape is what the DMA actually reads, so it must exist."""
         span = ir.Span.unknown()
         tensor_var = ir.Var("a", ir.TensorType([100, 128], DataType.FP32), span)
 
         # Claiming 64 valid rows at offset 64 reads to row 128 of a 100-row tensor.
         with pytest.raises(ValueError, match="reads past the end of dimension 0"):
-            tile.load(tensor_var, [64, 0], [64, 128], valid_shapes=[64, 128])
+            tile.load(tensor_var, [64, 0], [64, 128], valid_shape=[64, 128])
 
     def test_load_tile_may_overhang_the_source(self):
         """The destination tile is an allocation, so only the read extent must fit."""
@@ -5248,7 +5262,7 @@ class TestWindowReadValidRegion:
         tensor_var = ir.Var("a", ir.TensorType([100, 128], DataType.FP32), span)
 
         # A 64-row tile at offset 64 overhangs, but only 36 rows are read.
-        call = tile.load(tensor_var, [64, 0], [64, 128], valid_shapes=[36, 128])
+        call = tile.load(tensor_var, [64, 0], [64, 128], valid_shape=[36, 128])
 
         result_type = call.type
         assert isinstance(result_type, ir.TileType)
@@ -5260,7 +5274,7 @@ class TestWindowReadValidRegion:
         span = ir.Span.unknown()
         tensor_var = ir.Var("a", ir.TensorType([100, 128], DataType.FP32), span)
 
-        call = tile.load(tensor_var, [64, 0], [64, 128], valid_shapes=[64, 128], clamp=True)
+        call = tile.load(tensor_var, [64, 0], [64, 128], valid_shape=[64, 128], clamp=True)
 
         # clamp(100 - 64, 0, 64) = 36, intersected with the 64-row request -> 36.
         assert _valid_of(call.type) == [36, 128]
@@ -5281,15 +5295,15 @@ class TestWindowReadValidRegion:
         reparsed = pl.parse(ir.python_print(prog))
         ir.assert_structural_equal(reparsed, prog)
 
-    def test_load_lower_rank_window_keeps_its_valid_shapes(self):
+    def test_load_lower_rank_window_keeps_its_valid_shape(self):
         """A 2D tile out of a 3D tensor is a reinterpreting read, not a rectangle."""
         span = ir.Span.unknown()
         tensor_var = ir.Var("a", ir.TensorType([4, 128, 64], DataType.FP32), span)
 
         # Window rank 2 over a rank-3 source: the rule does not apply, so the
-        # requested valid_shapes pass through untouched rather than being
+        # requested valid_shape passes through untouched rather than being
         # intersected against the wrong axes.
-        call = tile.load(tensor_var, [0, 0], [16, 64], valid_shapes=[16, 64])
+        call = tile.load(tensor_var, [0, 0], [16, 64], valid_shape=[16, 64])
 
         result_type = call.type
         assert isinstance(result_type, ir.TileType)
@@ -5306,7 +5320,7 @@ class TestWindowReadValidRegion:
         tensor_var = ir.Var("a", ir.TensorType([256, 128], DataType.FP32), span)
 
         with pytest.raises(ValueError, match="exceeds the window extent"):
-            tile.load(tensor_var, [0, 0], [64, 128], valid_shapes=[128, 128])
+            tile.load(tensor_var, [0, 0], [64, 128], valid_shape=[128, 128])
 
     def test_load_keeps_the_request_when_the_source_extent_is_undecidable(self):
         """An undecidable source extent is trusted, not folded into a runtime min.
@@ -5326,7 +5340,7 @@ class TestWindowReadValidRegion:
         view = ir.TensorView(stride=[], layout=ir.TensorLayout.ND, valid_shape=[16, src_valid])
         tensor_var = ir.Var("a", ir.TensorType([16, 128], DataType.FP32, tensor_view=view), span)
 
-        call = tile.load(tensor_var, [0, 0], [16, 128], valid_shapes=[16, valid_len])
+        call = tile.load(tensor_var, [0, 0], [16, 128], valid_shape=[16, valid_len])
 
         result_type = call.type
         assert isinstance(result_type, ir.TileType)
@@ -5334,13 +5348,13 @@ class TestWindowReadValidRegion:
         # The request survives verbatim -- no min() wrapped around SRC_VALID.
         assert result_type.tile_view.valid_shape[1] is valid_len
 
-    def test_load_symbolic_valid_shapes_survive_unchanged(self):
+    def test_load_symbolic_valid_shape_survives_unchanged(self):
         """A symbolic request is trusted: it is the caller's contract, not a guess."""
         span = ir.Span.unknown()
         tensor_var = ir.Var("a", ir.TensorType([64, 128], DataType.FP32), span)
         m = ir.Var("M", ir.ScalarType(DataType.INT64), span)
 
-        call = tile.load(tensor_var, [0, 0], [64, 128], valid_shapes=[m, 128])
+        call = tile.load(tensor_var, [0, 0], [64, 128], valid_shape=[m, 128])
 
         result_type = call.type
         assert isinstance(result_type, ir.TileType)

--- a/tests/ut/ir/parser/test_cross_function_call_return_type.py
+++ b/tests/ut/ir/parser/test_cross_function_call_return_type.py
@@ -337,7 +337,7 @@ def test_recursive_tuple_and_tile_return_metadata_are_substituted():
     class Prog:
         @pl.function(type=pl.FunctionType.InCore)
         def load_tile(self, arg: pl.Tensor[[n, 64], pl.FP32]):
-            tile = pl.load(arg, [0, 0], [n, 64], valid_shapes=[n - 1, 64])
+            tile = pl.load(arg, [0, 0], [n, 64], valid_shape=[n - 1, 64])
             status = pl.const(0, pl.INT64)
             return status, (tile,)
 

--- a/tests/ut/ir/transforms/test_flatten_tile_nd_to_2d.py
+++ b/tests/ut/ir/transforms/test_flatten_tile_nd_to_2d.py
@@ -476,7 +476,7 @@ def _incore_cast_chain(shapes: list, valid: list, tensor_shape: list) -> ir.Prog
     dynamic axis); ``valid`` is the per-dim valid extent (may hold ``ir.Var``
     entries for runtime-dynamic dimensions). Built via IRBuilder so the result is
     well-formed SSA. ``tile.load`` is the 4-arg form (physical ``shapes`` +
-    ``valid_shapes``) the user writes when chunking a dynamic dim themselves.
+    ``valid_shape``) the user writes when chunking a dynamic dim themselves.
     """
     span = ir.Span.unknown()
     tensor_shape_exprs = _shape_exprs(tensor_shape)
@@ -489,7 +489,7 @@ def _incore_cast_chain(shapes: list, valid: list, tensor_shape: list) -> ir.Prog
         x = f.param("x", in_type)
         out_p = f.param("out", out_type, direction=ir.ParamDirection.Out)
         f.return_type(out_type)
-        x_tile = ib.let("x_tile", tile_ops.load(x, zeros, shapes, valid_shapes=valid, span=span))
+        x_tile = ib.let("x_tile", tile_ops.load(x, zeros, shapes, valid_shape=valid, span=span))
         y_tile = ib.let("y_tile", tile_ops.cast(x_tile, DataType.FP32, span=span))
         out_r = ib.let("out_0", tile_ops.store(y_tile, zeros, out_p, span=span))
         ib.return_stmt(out_r)
@@ -522,7 +522,7 @@ def _tile_calls(node) -> list[ir.Call]:
 
 class TestFlattenTileNdTo2DDynamicValid:
     """The user chunks a dynamic dim themselves (a static physical ``shapes`` with
-    the runtime extent in ``valid_shapes``); FlattenTileNdTo2D lowers the >2D
+    the runtime extent in ``valid_shape``); FlattenTileNdTo2D lowers the >2D
     per-chunk tile to 2D while **preserving the dynamic ``valid_shape``** so the
     runtime tail survives (issue #1578)."""
 
@@ -2881,10 +2881,10 @@ class TestFlattenTileNdTo2DMatLoadRoundtrip:
         assert load_source.unique_id == view_stmt.var.unique_id
         offsets = cast(ir.MakeTuple, load_call.args[1])
         shapes = cast(ir.MakeTuple, load_call.args[2])
-        valid_shapes = cast(ir.MakeTuple, load_call.args[3])
+        valid_shape = cast(ir.MakeTuple, load_call.args[3])
         assert _const_int_values(offsets.elements) == [16, 0]
         assert _const_int_values(shapes.elements) == [16, 128]
-        assert _const_int_values(valid_shapes.elements) == [16, 128]
+        assert _const_int_values(valid_shape.elements) == [16, 128]
 
     @pytest.mark.parametrize("distributed", [False, True])
     def test_rank3_mat_load_preserves_partial_source_view(self, distributed: bool):

--- a/tests/ut/ir/transforms/test_lower_auto_vector_split.py
+++ b/tests/ut/ir/transforms/test_lower_auto_vector_split.py
@@ -2154,7 +2154,7 @@ def _lane_ref_in_non_address_arg_body(span, stmts, aiv_id, qk_h, data):
     just the address args would wrongly admit this."""
     valid = aiv_id + 1
     v = ir.Var("valid", valid.type, span)
-    load = T.load(data, [0, 0], [64, 128], valid_shapes=[v, 128], target_memory=MS.Vec, span=span)
+    load = T.load(data, [0, 0], [64, 128], valid_shape=[v, 128], target_memory=MS.Vec, span=span)
     t = ir.Var("t", load.type, span)
     stmts += [ir.AssignStmt(v, valid, span), ir.AssignStmt(t, load, span)]
     return t

--- a/tests/ut/ir/transforms/test_memory_reuse.py
+++ b/tests/ut/ir/transforms/test_memory_reuse.py
@@ -480,7 +480,7 @@ class TestFillpad:
                 output: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
             ) -> pl.Tensor[[64, 64], pl.FP32]:
                 tile_a: pl.Tile[[64, 64], pl.FP32, pl.MemorySpace.Vec] = pl.load(
-                    input_a, [0, 0], [64, 64], valid_shapes=[48, 64]
+                    input_a, [0, 0], [64, 64], valid_shape=[48, 64]
                 )
                 padded: pl.Tile[[64, 64], pl.FP32, pl.MemorySpace.Vec] = pl.fillpad(
                     tile_a, pad_value=pl.PadValue.max
@@ -535,14 +535,14 @@ class TestFillpad:
                 output_b: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
             ) -> pl.Tensor[[64, 64], pl.FP32]:
                 tile_a: pl.Tile[[64, 64], pl.FP32, pl.MemorySpace.Vec] = pl.load(
-                    input_a, [0, 0], [64, 64], valid_shapes=[48, 64]
+                    input_a, [0, 0], [64, 64], valid_shape=[48, 64]
                 )
                 padded_max: pl.Tile[[64, 64], pl.FP32, pl.MemorySpace.Vec] = pl.fillpad(
                     tile_a, pad_value=pl.PadValue.max
                 )
                 _res_a: pl.Tensor[[64, 64], pl.FP32] = pl.store(padded_max, [0, 0], output_a)
                 tile_b: pl.Tile[[64, 64], pl.FP32, pl.MemorySpace.Vec] = pl.load(
-                    input_a, [0, 0], [64, 64], valid_shapes=[48, 64]
+                    input_a, [0, 0], [64, 64], valid_shape=[48, 64]
                 )
                 padded_min: pl.Tile[[64, 64], pl.FP32, pl.MemorySpace.Vec] = pl.fillpad(
                     tile_b, pad_value=pl.PadValue.min
@@ -615,14 +615,14 @@ class TestFillpad:
                 output_b: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
             ) -> pl.Tensor[[64, 64], pl.FP32]:
                 tile_a: pl.Tile[[64, 64], pl.FP32, pl.MemorySpace.Vec] = pl.load(
-                    input_a, [0, 0], [64, 64], valid_shapes=[48, 64]
+                    input_a, [0, 0], [64, 64], valid_shape=[48, 64]
                 )
                 padded_a: pl.Tile[[64, 64], pl.FP32, pl.MemorySpace.Vec] = pl.fillpad(
                     tile_a, pad_value=pl.PadValue.max
                 )
                 _res_a: pl.Tensor[[64, 64], pl.FP32] = pl.store(padded_a, [0, 0], output_a)
                 tile_b: pl.Tile[[64, 64], pl.FP32, pl.MemorySpace.Vec] = pl.load(
-                    input_a, [0, 0], [64, 64], valid_shapes=[48, 64]
+                    input_a, [0, 0], [64, 64], valid_shape=[48, 64]
                 )
                 padded_b: pl.Tile[[64, 64], pl.FP32, pl.MemorySpace.Vec] = pl.fillpad(
                     tile_b, pad_value=pl.PadValue.max
@@ -704,11 +704,11 @@ class TestValidShapeDivergence:
                 output_b: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
             ) -> pl.Tensor[[64, 64], pl.FP32]:
                 tile_a: pl.Tile[[64, 64], pl.FP32, pl.MemorySpace.Vec] = pl.load(
-                    input_a, [0, 0], [64, 64], valid_shapes=[48, 64]
+                    input_a, [0, 0], [64, 64], valid_shape=[48, 64]
                 )
                 _res_a: pl.Tensor[[64, 64], pl.FP32] = pl.store(tile_a, [0, 0], output_a)
                 tile_b: pl.Tile[[64, 64], pl.FP32, pl.MemorySpace.Vec] = pl.load(
-                    input_a, [0, 0], [64, 64], valid_shapes=[32, 64]
+                    input_a, [0, 0], [64, 64], valid_shape=[32, 64]
                 )
                 result: pl.Tensor[[64, 64], pl.FP32] = pl.store(tile_b, [0, 0], output_b)
                 return result
@@ -761,11 +761,11 @@ class TestValidShapeDivergence:
                 output_b: pl.Out[pl.Tensor[[4, 64, 64], pl.FP32]],
             ) -> pl.Tensor[[4, 64, 64], pl.FP32]:
                 tile_a: pl.Tile[[4, 64, 64], pl.FP32, pl.MemorySpace.Vec] = pl.load(
-                    input_a, [0, 0, 0], [4, 64, 64], valid_shapes=[4, 48, 64]
+                    input_a, [0, 0, 0], [4, 64, 64], valid_shape=[4, 48, 64]
                 )
                 _res_a: pl.Tensor[[4, 64, 64], pl.FP32] = pl.store(tile_a, [0, 0, 0], output_a)
                 tile_b: pl.Tile[[4, 64, 64], pl.FP32, pl.MemorySpace.Vec] = pl.load(
-                    input_a, [0, 0, 0], [4, 64, 64], valid_shapes=[4, 32, 64]
+                    input_a, [0, 0, 0], [4, 64, 64], valid_shape=[4, 32, 64]
                 )
                 result: pl.Tensor[[4, 64, 64], pl.FP32] = pl.store(tile_b, [0, 0, 0], output_b)
                 return result
@@ -810,7 +810,7 @@ class TestValidShapeDivergence:
                 output_b: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
             ) -> pl.Tensor[[64, 64], pl.FP32]:
                 tile_a: pl.Tile[[64, 64], pl.FP32, pl.MemorySpace.Vec] = pl.load(
-                    input_a, [0, 0], [64, 64], valid_shapes=[48, 64]
+                    input_a, [0, 0], [64, 64], valid_shape=[48, 64]
                 )
                 _res_a: pl.Tensor[[64, 64], pl.FP32] = pl.store(tile_a, [0, 0], output_a)
                 tile_b: pl.Tile[[64, 64], pl.FP32, pl.MemorySpace.Vec] = pl.load(input_a, [0, 0], [64, 64])

--- a/tests/ut/ir/transforms/test_split_vector_kernel.py
+++ b/tests/ut/ir/transforms/test_split_vector_kernel.py
@@ -262,7 +262,7 @@ class TestSplitVectorKernelNoSplitA2A3:
         dim = ir.ConstInt(16, pl.INDEX, span)
         offsets = ir.MakeTuple([zero, zero], span)
         shapes = ir.MakeTuple([dim, dim], span)
-        valid_shapes = ir.MakeTuple([dim, dim], span)
+        valid_shape = ir.MakeTuple([dim, dim], span)
 
         data = ir.Var("data", ir.TensorType([16, 16], pl.FP32), span)
         out = ir.Var("out", ir.TensorType([16, 16], pl.FP32), span)
@@ -270,13 +270,13 @@ class TestSplitVectorKernelNoSplitA2A3:
         load_view = ir.TileView(valid_shape=[dim, dim])
         load_type = ir.TileType([16, 16], pl.FP32, None, load_view, ir.MemorySpace.Vec)
         loaded = ir.Var("loaded", load_type, span)
-        # Canonical 4-operand tile.load ([tensor, offsets, shapes, valid_shapes])
+        # Canonical 4-operand tile.load ([tensor, offsets, shapes, valid_shape])
         # with the full kwarg set the DSL/IR builder emits (target_memory +
         # transpose). Matching the canonical operand/kwarg arity is what lets the
         # hand-built body survive the print->parse roundtrip verifier.
         load_call = ir.Call(
             ir.Op("tile.load"),
-            [data, offsets, shapes, valid_shapes],
+            [data, offsets, shapes, valid_shape],
             {"target_memory": ir.MemorySpace.Vec},
             load_type,
             span,
@@ -349,7 +349,7 @@ class TestSplitVectorKernelNoSplitA2A3:
         sub = ir.ConstInt(8, pl.INDEX, span)
         offsets = ir.MakeTuple([zero, zero], span)
         shapes = ir.MakeTuple([dim, dim], span)
-        valid_shapes = ir.MakeTuple([dim, dim], span)
+        valid_shape = ir.MakeTuple([dim, dim], span)
         slice_shape = ir.MakeTuple([dim, sub], span)
 
         data = ir.Var("data", ir.TensorType([16, 16], pl.FP32), span)
@@ -366,7 +366,7 @@ class TestSplitVectorKernelNoSplitA2A3:
         # what the DSL/IR builder emits, so it needs no padding.
         load_call = ir.Call(
             ir.Op("tile.load"),
-            [data, offsets, shapes, valid_shapes],
+            [data, offsets, shapes, valid_shape],
             {"target_memory": ir.MemorySpace.Vec},
             load_type,
             span,
@@ -443,7 +443,7 @@ class TestSplitVectorKernelNoSplitA2A3:
         dim = ir.ConstInt(16, pl.INDEX, span)
         offsets = ir.MakeTuple([zero, zero], span)
         shapes = ir.MakeTuple([dim, dim], span)
-        valid_shapes = ir.MakeTuple([dim, dim], span)
+        valid_shape = ir.MakeTuple([dim, dim], span)
 
         data = ir.Var("data", ir.TensorType([16, 16], pl.FP32), span)
         out = ir.Var("out", ir.TensorType([16, 16], pl.FP32), span)
@@ -454,7 +454,7 @@ class TestSplitVectorKernelNoSplitA2A3:
         loaded = ir.Var("loaded", load_type, span)
         load_call = ir.Call(
             ir.Op("tile.load"),
-            [data, offsets, shapes, valid_shapes],
+            [data, offsets, shapes, valid_shape],
             {"target_memory": ir.MemorySpace.Vec},
             load_type,
             span,

--- a/tests/ut/ir/transforms/test_split_vector_kernel.py
+++ b/tests/ut/ir/transforms/test_split_vector_kernel.py
@@ -271,8 +271,8 @@ class TestSplitVectorKernelNoSplitA2A3:
         load_type = ir.TileType([16, 16], pl.FP32, None, load_view, ir.MemorySpace.Vec)
         loaded = ir.Var("loaded", load_type, span)
         # Canonical 4-operand tile.load ([tensor, offsets, shapes, valid_shape])
-        # with the full kwarg set the DSL/IR builder emits (target_memory +
-        # transpose). Matching the canonical operand/kwarg arity is what lets the
+        # with the target_memory kwarg used by this fixture. Matching the canonical
+        # operand and kwarg arity is what lets the
         # hand-built body survive the print->parse roundtrip verifier.
         load_call = ir.Call(
             ir.Op("tile.load"),

--- a/tests/ut/ir/transforms/test_verify_ssa_pass.py
+++ b/tests/ut/ir/transforms/test_verify_ssa_pass.py
@@ -789,7 +789,7 @@ class TestCompositeShapeDimVerification:
         """The inner var of a composite parameter dim is usable in the body.
 
         ``M`` appears inside the composite param dim ``M * 2`` and is also
-        referenced directly in the body (as a ``valid_shapes`` bound). The
+        referenced directly in the body (as a ``valid_shape`` bound). The
         recursive registration makes ``M`` visible in the outermost scope, so
         the body reference verifies cleanly.
         """
@@ -804,7 +804,7 @@ class TestCompositeShapeDimVerification:
                 a: pl.Tensor[[m * 2, n], pl.FP32],
                 output: pl.Tensor[[m * 2, n], pl.FP32],
             ) -> pl.Tensor[[m * 2, n], pl.FP32]:
-                a_tile = pl.load(a, [0, 0], [128, 128], valid_shapes=[m, n])
+                a_tile = pl.load(a, [0, 0], [128, 128], valid_shape=[m, n])
                 out = pl.store(a_tile, [0, 0], output)
                 return out
 

--- a/tests/ut/jit/test_matmul_valid_shape.py
+++ b/tests/ut/jit/test_matmul_valid_shape.py
@@ -78,27 +78,22 @@ def test_matmul_valid_shape_declares_inout_output(compiled_programs):
     assert entry.param_directions[-1] == ir.ParamDirection.InOut
 
 
-def test_matmul_valid_shape_store_keeps_logical_result_extent(compiled_programs):
-    """A physical 16x16 result stores only its five logically valid rows."""
+def test_matmul_valid_shape_stores_boxed_result(compiled_programs):
+    """The boxed 32x16 result stores only its 16 hardware-aligned valid rows."""
     _, post_pass, incore = compiled_programs
-    collector = _CallCollector({"tile.matmul", "tile.slice", "tile.store"})
+    collector = _CallCollector({"tile.matmul", "tile.store"})
     collector.visit_stmt(incore.body)
 
     assert len(collector.calls["tile.matmul"]) == 1
-    assert len(collector.calls["tile.slice"]) == 1
     assert len(collector.calls["tile.store"]) == 1
     matmul_call = collector.calls["tile.matmul"][0]
-    slice_call = collector.calls["tile.slice"][0]
     store_call = collector.calls["tile.store"][0]
 
     assert isinstance(matmul_call.type, ir.TileType)
     assert _const_values(matmul_call.type.shape) == [TILE_M, N]
-    assert isinstance(slice_call.type, ir.TileType)
-    assert _const_values(slice_call.type.shape) == [VALID_M, N]
-    assert _const_values(slice_call.type.get_effective_tile_view().valid_shape) == [VALID_M, N]
     stored_result_type = store_call.args[0].type
     assert isinstance(stored_result_type, ir.TileType)
-    assert _const_values(stored_result_type.shape) == [VALID_M, N]
+    assert _const_values(stored_result_type.shape) == [TILE_M, N]
     assert _const_values(stored_result_type.get_effective_tile_view().valid_shape) == [VALID_M, N]
 
     pto = codegen.PTOCodegen().generate(ir.Program([incore], incore.name, post_pass.span))

--- a/tests/ut/jit/test_matmul_valid_shape.py
+++ b/tests/ut/jit/test_matmul_valid_shape.py
@@ -9,11 +9,20 @@
 
 """Compile-level coverage for the matmul valid-shape example."""
 
+import importlib
+from typing import Any, cast
+
 import pypto.language as pl
 import pytest
-from examples.kernels.matmul_valid_shape import TILE_M, VALID_M, K, N, matmul_valid_shape
 from pypto import backend, codegen, ir
 from pypto.backend import BackendType
+
+_example = importlib.import_module("examples.kernels.12_matmul_valid_shape")
+TILE_M = cast(int, getattr(_example, "TILE_M"))
+VALID_M = cast(int, getattr(_example, "VALID_M"))
+K = cast(int, getattr(_example, "K"))
+N = cast(int, getattr(_example, "N"))
+matmul_valid_shape = cast(Any, getattr(_example, "matmul_valid_shape"))
 
 
 class _CallCollector(ir.IRVisitor):
@@ -72,18 +81,24 @@ def test_matmul_valid_shape_declares_inout_output(compiled_programs):
 def test_matmul_valid_shape_store_keeps_logical_result_extent(compiled_programs):
     """A physical 16x16 result stores only its five logically valid rows."""
     _, post_pass, incore = compiled_programs
-    collector = _CallCollector({"tile.matmul", "tile.store"})
+    collector = _CallCollector({"tile.matmul", "tile.slice", "tile.store"})
     collector.visit_stmt(incore.body)
 
     assert len(collector.calls["tile.matmul"]) == 1
+    assert len(collector.calls["tile.slice"]) == 1
     assert len(collector.calls["tile.store"]) == 1
     matmul_call = collector.calls["tile.matmul"][0]
+    slice_call = collector.calls["tile.slice"][0]
     store_call = collector.calls["tile.store"][0]
 
+    assert isinstance(matmul_call.type, ir.TileType)
     assert _const_values(matmul_call.type.shape) == [TILE_M, N]
+    assert isinstance(slice_call.type, ir.TileType)
+    assert _const_values(slice_call.type.shape) == [VALID_M, N]
+    assert _const_values(slice_call.type.get_effective_tile_view().valid_shape) == [VALID_M, N]
     stored_result_type = store_call.args[0].type
     assert isinstance(stored_result_type, ir.TileType)
-    assert _const_values(stored_result_type.shape) == [TILE_M, N]
+    assert _const_values(stored_result_type.shape) == [VALID_M, N]
     assert _const_values(stored_result_type.get_effective_tile_view().valid_shape) == [VALID_M, N]
 
     pto = codegen.PTOCodegen().generate(ir.Program([incore], incore.name, post_pass.span))

--- a/tests/ut/jit/test_matmul_valid_shape.py
+++ b/tests/ut/jit/test_matmul_valid_shape.py
@@ -55,8 +55,7 @@ def compiled_programs(request: pytest.FixtureRequest) -> tuple[ir.Program, ir.Pr
         per_func_dyn,
         pl,
     )
-    matmul_valid_shape._cache.clear()
-    post_pass = matmul_valid_shape.compile_for_test(*args)
+    post_pass = matmul_valid_shape.lower(*args)
     incore = next(
         function for function in post_pass.functions.values() if ir.is_incore_type(function.func_type)
     )

--- a/tests/ut/jit/test_matmul_valid_shape.py
+++ b/tests/ut/jit/test_matmul_valid_shape.py
@@ -1,0 +1,97 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Compile-level coverage for the matmul valid-shape example."""
+
+import pypto.language as pl
+import pytest
+from examples.kernels.matmul_valid_shape import TILE_M, VALID_M, K, N, matmul_valid_shape
+from pypto import backend, codegen, ir
+from pypto.backend import BackendType
+
+
+class _CallCollector(ir.IRVisitor):
+    """Collect calls to the requested built-in operations."""
+
+    def __init__(self, op_names: set[str]) -> None:
+        super().__init__()
+        self.calls: dict[str, list[ir.Call]] = {name: [] for name in op_names}
+
+    def visit_call(self, op: ir.Call) -> None:
+        if op.op.name in self.calls:
+            self.calls[op.op.name].append(op)
+        super().visit_call(op)
+
+
+def _const_values(expressions) -> list[int]:
+    """Return the integer values of a static IR shape."""
+    assert all(isinstance(expression, ir.ConstInt) for expression in expressions)
+    return [expression.value for expression in expressions]
+
+
+@pytest.fixture(scope="module")
+def compiled_programs(request: pytest.FixtureRequest) -> tuple[ir.Program, ir.Program, ir.Function]:
+    """Compile the example without executing it on hardware."""
+    torch = pytest.importorskip("torch")
+    backend.reset_for_testing()
+    backend.set_backend_type(BackendType.Ascend910B)
+    request.addfinalizer(backend.reset_for_testing)
+    args = (
+        torch.randn(VALID_M, K),
+        torch.randn(K, N),
+        torch.zeros(TILE_M, N),
+    )
+    _, _, tensor_meta, scalar_values, scalar_dtypes, per_func_dyn = matmul_valid_shape._bind_args(args, {})
+    pre_pass = matmul_valid_shape._compile_to_program(
+        tensor_meta,
+        scalar_values,
+        scalar_dtypes,
+        per_func_dyn,
+        pl,
+    )
+    matmul_valid_shape._cache.clear()
+    post_pass = matmul_valid_shape.compile_for_test(*args)
+    incore = next(
+        function for function in post_pass.functions.values() if ir.is_incore_type(function.func_type)
+    )
+    return pre_pass, post_pass, incore
+
+
+def test_matmul_valid_shape_declares_inout_output(compiled_programs):
+    """The partially stored output must declare its preserved tail as input state."""
+    pre_pass, _, _ = compiled_programs
+    entry = pre_pass.get_function("matmul_valid_shape")
+    assert entry.param_directions[-1] == ir.ParamDirection.InOut
+
+
+def test_matmul_valid_shape_store_keeps_logical_result_extent(compiled_programs):
+    """A physical 16x16 result stores only its five logically valid rows."""
+    _, post_pass, incore = compiled_programs
+    collector = _CallCollector({"tile.matmul", "tile.store"})
+    collector.visit_stmt(incore.body)
+
+    assert len(collector.calls["tile.matmul"]) == 1
+    assert len(collector.calls["tile.store"]) == 1
+    matmul_call = collector.calls["tile.matmul"][0]
+    store_call = collector.calls["tile.store"][0]
+
+    assert _const_values(matmul_call.type.shape) == [TILE_M, N]
+    stored_result_type = store_call.args[0].type
+    assert isinstance(stored_result_type, ir.TileType)
+    assert _const_values(stored_result_type.shape) == [TILE_M, N]
+    assert _const_values(stored_result_type.get_effective_tile_view().valid_shape) == [VALID_M, N]
+
+    pto = codegen.PTOCodegen().generate(ir.Program([incore], incore.name, post_pass.span))
+    tstore_lines = [line for line in pto.splitlines() if "pto.tstore" in line]
+    assert len(tstore_lines) == 1
+    assert f"partition_tensor_view<{VALID_M}x{N}xf32>" in tstore_lines[0]
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/ut/language/parser/test_subscript_syntax.py
+++ b/tests/ut/language/parser/test_subscript_syntax.py
@@ -239,7 +239,7 @@ class TestTileSubscript:
             x: pl.Tensor[[64, 128], pl.FP32],
             valid_cols: pl.Scalar[pl.INDEX],
         ) -> pl.Tensor[[64, 128], pl.FP32]:
-            t: pl.Tile[[64, 128], pl.FP32] = pl.load(x, [0, 0], [64, 128], valid_shapes=[64, valid_cols])
+            t: pl.Tile[[64, 128], pl.FP32] = pl.load(x, [0, 0], [64, 128], valid_shape=[64, valid_cols])
             sliced: pl.Tile[[64, 128], pl.FP32] = t[:, :]
             return pl.store(sliced, [0, 0], x)
 
@@ -265,7 +265,7 @@ class TestTileSubscript:
             x: pl.Tensor[[64, 128], pl.FP32],
             valid_cols: pl.Scalar[pl.INDEX],
         ) -> pl.Tensor[[64, 128], pl.FP32]:
-            t: pl.Tile[[64, 128], pl.FP32] = pl.load(x, [0, 0], [64, 128], valid_shapes=[64, valid_cols])
+            t: pl.Tile[[64, 128], pl.FP32] = pl.load(x, [0, 0], [64, 128], valid_shape=[64, valid_cols])
             sliced: pl.Tile[[64, 16], pl.FP32] = t[:, :16]
             return pl.store(sliced, [0, 0], x)
 


### PR DESCRIPTION
## Summary

- Rename the `tile.load` / `pl.load` keyword from `valid_shapes` to `valid_shape` and remove the old keyword without a compatibility alias.
- Migrate all repository call sites, diagnostics, tests, examples, and synchronized English/Chinese docs while preserving the fourth positional IR operand.
- Add a static matmul example using a 32x16 physical accumulator with a 16x16 valid region.
- Propagate the 2D `tile.matmul` output valid shape as `[lhs.valid_shape[0], rhs.valid_shape[1]]`, preserving the boxed physical `[M, N]` shape and allowing a public direct-store path.

## Testing

- [x] Incremental C++ build
- [x] Full unit suite: 8464 passed, 2 skipped
- [x] Focused direct-op and JIT matmul valid-shape coverage
- [x] Full Pyright: 0 errors
- [x] `ruff check .`
- [x] `ruff format --check .`
- [x] `clang-format --dry-run --Werror src/ir/op/tile_ops/matmul.cpp`
- [x] `git diff --check`
- [ ] GitHub Actions CI / hardware runtime validation (running)

## Compatibility

- The removed `valid_shapes` keyword intentionally has no alias or deprecation path.
- The fourth positional `tile.load` operand and serialized IR operand order are unchanged.