### PR TITLE
fix(ir): Flatten a Call sitting directly in a YieldStmt value

### DIFF
--- a/docs/en/dev/passes/06-flatten_call_expr.md
+++ b/docs/en/dev/passes/06-flatten_call_expr.md
@@ -11,6 +11,7 @@ This pass ensures that call expressions do not appear in nested contexts by extr
 3. For loop ranges (start/stop/step) cannot be calls
 4. Binary/unary expression operands cannot be calls
 5. Return values cannot be calls
+6. Yield values cannot be calls
 
 **Requires**: `TypeChecked`, `SSAForm` properties. These properties are automatically verified at BASIC level once produced; use a `VerificationInstrument` via `PassContext` if you need required properties to be validated before running passes.
 
@@ -49,7 +50,10 @@ program_flat = flatten_pass(program)
 
 - Before AssignStmt/EvalStmt: Insert directly before
 - Before IfStmt/ForStmt: Insert as sibling statements in the enclosing `SeqStmts`
+- Before ReturnStmt/YieldStmt: Insert directly before. A yield is the trailing statement of its loop / branch body, so its temporaries land **inside** that body, where the yielded value is computed
 - Inside ScopeStmt (`pl.at()`): Temporaries are always inserted **inside** the scope body, preserving execution-context boundaries
+
+**Why ReturnStmt and YieldStmt matter.** Downstream passes and codegen rewrite operations by walking top-level `AssignStmt` / `EvalStmt`. A Call left directly in a `return` or `pl.yield_` is invisible to them: a `return call(...)` used to be silently dropped from orchestration codegen, and a `pl.yield_(pl.add(acc, row))` used to keep its `tensor.add` unconverted while `ConvertTensorToTileOps` lowered the surrounding operands to Tiles — surfacing much later as a tensor-level operator rejecting a `TileType` argument.
 
 ## Example
 

--- a/docs/zh/dev/passes/06-flatten_call_expr.md
+++ b/docs/zh/dev/passes/06-flatten_call_expr.md
@@ -11,6 +11,7 @@
 3. For 循环范围（start/stop/step）不能是调用
 4. 二元/一元表达式操作数不能是调用
 5. Return 值不能是调用
+6. Yield 值不能是调用
 
 **需要**：TypeChecked、SSAForm 属性 (Property)（通常由前序 Pass 产生；如需在执行前校验 required/produced，请在 `PassContext` 中启用 `VerificationInstrument`）。
 
@@ -49,7 +50,10 @@ program_flat = flatten_pass(program)
 
 - AssignStmt/EvalStmt 之前：直接插入在前面
 - 在 IfStmt/ForStmt 之前：作为外层 `SeqStmts` 中的同级语句插入
+- 在 ReturnStmt/YieldStmt 之前：直接插入在前面。yield 总是其循环 / 分支 body 的末尾语句，因此临时变量会落在该 body **内部** —— 也就是 yield 值真正被计算的地方
 - ScopeStmt 内部（`pl.at()`）：临时变量始终插入在 scope body **内部**，保持执行上下文边界
+
+**为什么 ReturnStmt 和 YieldStmt 也要处理。** 下游 pass 与 codegen 都是通过遍历顶层 `AssignStmt` / `EvalStmt` 来改写操作的。直接留在 `return` 或 `pl.yield_` 里的 Call 对它们不可见：`return call(...)` 曾经在 orchestration codegen 中被静默丢弃；而 `pl.yield_(pl.add(acc, row))` 曾经让其中的 `tensor.add` 得不到转换 —— 与此同时 `ConvertTensorToTileOps` 已把周围的操作数下降为 Tile，最终表现为很靠后的阶段里某个 tensor 层算子拒绝了 `TileType` 参数。
 
 ## 示例
 

--- a/src/ir/transforms/flatten_call_expr_pass.cpp
+++ b/src/ir/transforms/flatten_call_expr_pass.cpp
@@ -42,6 +42,7 @@ namespace {
  * 3. For loop ranges (start/stop/step) cannot be calls
  * 4. Binary/unary expression operands cannot be calls
  * 5. Return values cannot be calls
+ * 6. Yield values cannot be calls
  *
  * Nested calls are extracted into temporary variables and inserted as
  * AssignStmt before the statement containing the nested call.
@@ -59,6 +60,7 @@ class FlattenCallExprMutator : public IRMutator {
   StmtPtr VisitStmt_(const ForStmtPtr& op) override;
   StmtPtr VisitStmt_(const WhileStmtPtr& op) override;
   StmtPtr VisitStmt_(const ReturnStmtPtr& op) override;
+  StmtPtr VisitStmt_(const YieldStmtPtr& op) override;
   StmtPtr VisitStmt_(const InCoreScopeStmtPtr& op) override;
   StmtPtr VisitStmt_(const ClusterScopeStmtPtr& op) override;
   StmtPtr VisitStmt_(const HierarchyScopeStmtPtr& op) override;
@@ -359,6 +361,41 @@ StmtPtr FlattenCallExprMutator::VisitStmt_(const ReturnStmtPtr& op) {
     // Extract any Call value into a temporary so codegen always sees the
     // dispatch as a real statement.
     if (As<Call>(visited)) {
+      visited = ExtractCallToTemp(visited);
+      changed = true;
+    } else if (visited.get() != value.get()) {
+      changed = true;
+    }
+    new_values.push_back(visited);
+  }
+
+  if (!changed) {
+    return op;
+  }
+  auto result = MutableCopy(op);
+  result->value_ = std::move(new_values);
+  return result;
+}
+
+StmtPtr FlattenCallExprMutator::VisitStmt_(const YieldStmtPtr& op) {
+  // Note: Don't clear pending_stmts_, preserve previous state so the enclosing
+  // SeqStmts visitor inserts our extracted temporaries before the YieldStmt.
+  // A yield is always the trailing statement of its loop / branch body, so the
+  // temporaries land inside that body, where the yielded value is computed.
+
+  std::vector<ExprPtr> new_values;
+  new_values.reserve(op->value_.size());
+  bool changed = false;
+
+  for (const auto& value : op->value_) {
+    auto visited = VisitExpr(value);
+
+    // Same rationale as the ReturnStmt case above: a `yield call(...)` reaches
+    // the rest of the pipeline as a YieldStmt-wrapped Call, and passes that walk
+    // top-level AssignStmt/EvalStmt to rewrite operations silently skip it. That
+    // leaves, for instance, a `tensor.add` carried by a loop unconverted by
+    // ConvertTensorToTileOps while its operands become Tiles (issue #2229).
+    if (As<Call>(visited) || As<Submit>(visited)) {
       visited = ExtractCallToTemp(visited);
       changed = true;
     } else if (visited.get() != value.get()) {

--- a/tests/ut/ir/transforms/test_flatten_call_expr_pass.py
+++ b/tests/ut/ir/transforms/test_flatten_call_expr_pass.py
@@ -1124,5 +1124,96 @@ class TestFlattenCallInReturn:
         ir.assert_structural_equal(After, NormalizeIR(Expected))
 
 
+class TestFlattenCallInYield:
+    """Tests for flattening Call expressions that appear directly inside YieldStmt.
+
+    Regression tests for issue #2229: `pl.yield_(some_call(...))` (no intermediate
+    variable) used to leave a YieldStmt-wrapped Call untouched. Passes that rewrite
+    operations walk top-level AssignStmt/EvalStmt, so they silently skipped it — a
+    `tensor.add` carried by a loop stayed `tensor.add` through
+    ConvertTensorToTileOps while its operands became Tiles, and the tensor-level
+    type check then rejected its own operand.
+    """
+
+    def test_single_call_in_for_yield(self):
+        """`pl.yield_(pl.add(acc, x))` binds the call to a temp before the yield."""
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                for _i, (acc,) in pl.range(1, 4, init_values=(x,)):
+                    total: pl.Tensor[[64], pl.FP32] = pl.yield_(pl.add(acc, x))
+                return total
+
+        @pl.program
+        class Expected:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                for _i, (acc,) in pl.range(1, 4, init_values=(x,)):
+                    t__tmp_v0: pl.Tensor[[64], pl.FP32] = pl.add(acc, x)
+                    total: pl.Tensor[[64], pl.FP32] = pl.yield_(t__tmp_v0)
+                return total
+
+        After = passes.flatten_call_expr()(Before)
+        ir.assert_structural_equal(After, NormalizeIR(Expected))
+
+    def test_nested_call_in_for_yield(self):
+        """A nested `pl.yield_(pl.mul(pl.add(...), 2.0))` extracts both calls."""
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                for _i, (acc,) in pl.range(1, 4, init_values=(x,)):
+                    total: pl.Tensor[[64], pl.FP32] = pl.yield_(pl.mul(pl.add(acc, x), 2.0))
+                return total
+
+        @pl.program
+        class Expected:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                for _i, (acc,) in pl.range(1, 4, init_values=(x,)):
+                    t__tmp_v0: pl.Tensor[[64], pl.FP32] = pl.add(acc, x)
+                    t__tmp_v1: pl.Tensor[[64], pl.FP32] = pl.mul(t__tmp_v0, 2.0)
+                    total: pl.Tensor[[64], pl.FP32] = pl.yield_(t__tmp_v1)
+                return total
+
+        After = passes.flatten_call_expr()(Before)
+        ir.assert_structural_equal(After, NormalizeIR(Expected))
+
+    def test_call_in_if_yield(self):
+        """An IfStmt yield gets the same treatment; temps stay inside their branch."""
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(
+                self, x: pl.Tensor[[64], pl.FP32], flag: pl.Scalar[pl.INT32]
+            ) -> pl.Tensor[[64], pl.FP32]:
+                if flag > 0:
+                    out: pl.Tensor[[64], pl.FP32] = pl.yield_(pl.add(x, 1.0))
+                else:
+                    out: pl.Tensor[[64], pl.FP32] = pl.yield_(pl.mul(x, 2.0))
+                return out
+
+        @pl.program
+        class Expected:
+            @pl.function
+            def main(
+                self, x: pl.Tensor[[64], pl.FP32], flag: pl.Scalar[pl.INT32]
+            ) -> pl.Tensor[[64], pl.FP32]:
+                if flag > 0:
+                    t__tmp_v0: pl.Tensor[[64], pl.FP32] = pl.add(x, 1.0)
+                    out: pl.Tensor[[64], pl.FP32] = pl.yield_(t__tmp_v0)
+                else:
+                    t__tmp_v1: pl.Tensor[[64], pl.FP32] = pl.mul(x, 2.0)
+                    out: pl.Tensor[[64], pl.FP32] = pl.yield_(t__tmp_v1)
+                return out
+
+        After = passes.flatten_call_expr()(Before)
+        ir.assert_structural_equal(After, NormalizeIR(Expected))
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Fixes #2229.

The reported symptom is real, but the cause is not where the issue points. `pl.add`'s dispatch is correct: at parse time both operands are `Tensor`-wrapped `tensor.slice` results, so `tensor.add` is the right choice and the `pl.Tensor[...]` annotations are accurate. The failure happens later, inside the pass pipeline (`ir/compile.py` -> `pm.run_passes`), not at parse time.

`FlattenCallExpr` enforces three-address form so no Call survives in a nested context, but its rewrite covers `ReturnStmt` and misses `YieldStmt`. The repro keeps the Call in the yield all the way to pass 10:

```python
# 00_frontend .. 10_after_OutlineClusterScopes — unchanged
for i__idx_v0, (acc,) in pl.range(1, 4, init_values=(first__ssa_v0,)):
    row__ssa_v0: pl.Tensor[[1, 64], pl.FP32] = pl.tensor.slice(data__ssa_v0, [1, 64], [i__idx_v0, 0])
    total: pl.Tensor[[1, 64], pl.FP32] = pl.yield_(pl.tensor.add(acc, row__ssa_v0))
```

Passes that rewrite operations walk top-level `AssignStmt` / `EvalStmt`, so `ConvertTensorToTileOps` never sees that call — it lowers the two `tensor.slice` operands to `tile.load` and leaves `tensor.add` in place:

```python
# 11_after_ConvertTensorToTileOps — before this PR
first__tile: pl.Tile[[1, 64], pl.FP32, pl.Mem.Vec] = pl.tile.load(...)
for i__idx_v0, (acc,) in pl.range(1, 4, init_values=(first__tile,)):
    row__tile: pl.Tile[[1, 64], pl.FP32, pl.Mem.Vec] = pl.tile.load(...)
    total: pl.Tile[[1, 64], pl.FP32, pl.Mem.Vec] = pl.yield_(pl.tensor.add(acc, row__tile))
```

The tensor-level type check then rejects its own operand several passes later. Binding the call to a variable first (`s = pl.add(acc, row)` then `pl.yield_(s)`) always compiled — the two spellings just were not equivalent.

`YieldStmt` now gets the same treatment `ReturnStmt` already has, whose comment describes this exact failure shape. A yield is the trailing statement of its loop / branch body, so the hoisted temporary lands inside that body, where the value is computed:

```python
# 07_after_FlattenCallExpr — with this PR
for i__idx_v0, (acc,) in pl.range(1, 4, init_values=(first__ssa_v0,)):
    row__ssa_v0: pl.Tensor[[1, 64], pl.FP32] = pl.tensor.slice(data__ssa_v0, [1, 64], [i__idx_v0, 0])
    t__tmp_v0: pl.Tensor[[1, 64], pl.FP32] = pl.tensor.add(acc, row__ssa_v0)
    total: pl.Tensor[[1, 64], pl.FP32] = pl.yield_(t__tmp_v0)
```

`ConvertTensorToTileOps` then lowers it to `tile.add` and the program compiles.

The fix is in the flatten pass rather than in each consumer: it restores the invariant the pass already declares, so every `AssignStmt`-oriented pass benefits at once instead of each needing to learn about yields.

## Changes

- `src/ir/transforms/flatten_call_expr_pass.cpp` — add `VisitStmt_(YieldStmtPtr)`, mirroring the `ReturnStmt` arm; hoists a Call or Submit yield value into a temporary
- `tests/ut/ir/transforms/test_flatten_call_expr_pass.py` — `TestFlattenCallInYield`: single call in a for-yield, nested calls in a for-yield, and an if-yield where temps must stay inside their branch
- `docs/{en,zh}/dev/passes/06-flatten_call_expr.md` — add yield values to the three-address-code constraint list and the extraction-location table, with the rationale for why `ReturnStmt`/`YieldStmt` need it

## Testing

- [x] Issue repro compiles; post-pass IR is identical to the bound-to-variable spelling apart from the temp name
- [x] All 3 new tests fail against the pre-fix build and pass after
- [x] `tests/ut/` — 8462 passed, 2 skipped
- [x] `tests/st/codegen/dsl` — 11 passed (end-to-end lowering of the issue repro was verified locally through both spellings; kept out of the committed suite since the unit tests already pin the invariant)
- [x] `ruff check` / `ruff format --check` clean on the changed files
- [x] Documentation updated (EN + zh)

## Follow-up (not in this PR)

`VerifyNoNestedCall` covers if/for/while and call arguments, but neither `ReturnStmt` nor `YieldStmt`. Extending it to both would turn this class of bug into a verifier error rather than a late type-check failure; left out here to keep the fix scoped.