### PR TITLE
test(ir): Remove unnecessary VerificationLevel.NONE bypasses

### DIFF
--- a/tests/ut/ir/test_compile_pipeline.py
+++ b/tests/ut/ir/test_compile_pipeline.py
@@ -38,7 +38,7 @@ def test_run_pass_pipeline_orders_outer_before_extra_instruments():
         before_pass=lambda pass_obj, _program: seen.append(("extra", pass_obj.get_name())),
         name="extra",
     )
-    with passes.PassContext([outer_instrument], verification_level=passes.VerificationLevel.NONE):
+    with passes.PassContext([outer_instrument]):
         result = _run_pass_pipeline(
             _scalar_program(),
             operation="lower",

--- a/tests/ut/ir/transforms/test_declared_memref.py
+++ b/tests/ut/ir/transforms/test_declared_memref.py
@@ -72,11 +72,10 @@ def _run_full_pipeline(program: ir.Program, last_pass: str) -> ir.Program:
     manager = PassManager(OptimizationStrategy.Default)
     names = manager.pass_names
     stop = names.index(last_pass)
-    with passes.PassContext([], passes.VerificationLevel.NONE):
-        for pass_obj in manager.passes[: stop + 1]:
-            pipeline = passes.PassPipeline()
-            pipeline.add_pass(pass_obj)
-            program = pipeline.run(program)
+    for pass_obj in manager.passes[: stop + 1]:
+        pipeline = passes.PassPipeline()
+        pipeline.add_pass(pass_obj)
+        program = pipeline.run(program)
     return program
 
 

--- a/tests/ut/ir/verifier/test_perf_hint_tile_innermost_dim.py
+++ b/tests/ut/ir/verifier/test_perf_hint_tile_innermost_dim.py
@@ -29,8 +29,12 @@ def reset_backend_around_test():
 def _run_perf_hint_check(program: ir.Program) -> list[passes.Diagnostic]:
     """Run only the TileInnermostDimGranularity check and return its diagnostics.
 
-    The verifier reads the active backend from PassContext, so callers must
-    set up backend + context before invoking this helper.
+    The verifier early-returns without an active PassContext, so a context must
+    exist for the check to fire at all — it comes from the repo conftest's
+    autouse ``pass_verification_context``. The backend is resolved live, so
+    callers only need to select one (``_activate_a5`` / ``_activate_a3``) first.
+    This helper runs no pass pipeline, so the context's verification level never
+    applies — do not wrap calls in a verification-disabling context.
     """
     checks = passes.DiagnosticCheckSet()
     checks.insert(passes.DiagnosticCheck.TileInnermostDimGranularity)
@@ -254,8 +258,7 @@ def test_cube_memory_space_not_flagged_a5():
     """
     _activate_a5()
     program = _make_cube_matmul_program(8, pl.FP32)  # A-Mat innermost = 32B (< 128B)
-    with passes.PassContext([], verification_level=passes.VerificationLevel.NONE):
-        diags = _run_perf_hint_check(program)
+    diags = _run_perf_hint_check(program)
     perf_hints = [d for d in diags if d.severity == passes.DiagnosticSeverity.PerfHint]
     assert perf_hints == []
 
@@ -269,8 +272,7 @@ def test_message_includes_dtype_shape_memory_tuple_a5():
     """The hint echoes the (dtype[innermost], target_memory) tuple it evaluated."""
     _activate_a5()
     program = _make_load_program(16, pl.FP32)  # Vec load, 64B innermost
-    with passes.PassContext([], verification_level=passes.VerificationLevel.NONE):
-        diags = _run_perf_hint_check(program)
+    diags = _run_perf_hint_check(program)
     perf_hints = [d for d in diags if d.severity == passes.DiagnosticSeverity.PerfHint]
     assert len(perf_hints) >= 1
     msg = perf_hints[0].message
@@ -345,9 +347,8 @@ def test_dedup_collapses_repeated_site_a3():
             return pl.store(acc, [0, 0], out)
 
     pm = PassManager.get_strategy(OptimizationStrategy.Default)
-    with passes.PassContext([], verification_level=passes.VerificationLevel.NONE):
-        post = pm.run_passes(LoopLoadProg)
-        diags = _run_perf_hint_check(post)
+    post = pm.run_passes(LoopLoadProg)
+    diags = _run_perf_hint_check(post)
     perf_hints = [d for d in diags if d.severity == passes.DiagnosticSeverity.PerfHint]
     assert len(perf_hints) >= 1
     assert all(d.hint_code == "PH001" for d in perf_hints)


### PR DESCRIPTION
## Summary

Five `PassContext([], VerificationLevel.NONE)` sites across three test files disabled pass verification for tests that pass without it. Removing them puts these tests back under the repo conftest's default `BEFORE_AND_AFTER` property verification + print→parse roundtrip instruments.

Found by auditing every bypass site: each was neutralized so the ambient conftest context applies, then the affected file was re-run.

## Three of the five are coverage increases, not dead-code deletion

| Site | What the wrapper covered | Effect of removal |
| --- | --- | --- |
| `test_compile_pipeline.py:41` | `_run_pass_pipeline` | Level inherited from innermost context → flips `NONE` → `BASIC` |
| `test_declared_memref.py:70` (`_run_full_pipeline`) | Default strategy up to a named pass, for 7 callers | Inner context carried no instruments and shadowed the conftest's entirely; every pass those tests run is now verified |
| `test_perf_hint_tile_innermost_dim.py:346` | `pm.run_passes(LoopLoadProg)` + helper | Full Default pipeline now verified |

The remaining two perf-hint sites were true no-ops: `_run_perf_hint_check` calls `DiagnosticCheckRegistry.run_checks` directly and runs no pipeline, so the verification level was never consulted. A sibling test already called the same helper on the same program with no wrapper at all.

## Docstring correction

`_run_perf_hint_check`'s docstring previously read as an instruction to open a context. What actually matters is subtler and worth stating: `TileInnermostDimVerifier::Verify` early-returns when `PassContext::Current() == nullptr`, so without a context the check emits nothing and `assert perf_hints == []` would pass for the wrong reason. The conftest fixture is what keeps those negative assertions non-vacuous. The backend is also resolved live rather than snapshotted at context construction, so `_activate_a5()` inside the test body still takes effect.

## Testing

- 50/50 tests in the three files pass at every `PYPTO_VERIFY_LEVEL` (`none`, `basic`, `roundtrip`).
- `tests/ut/ir/verifier` + `tests/ut/ir/transforms` + `test_compile_pipeline.py`: 2590 passed.
- Full unit suite: 8458 passed, 2 skipped. The one failure (`test_ir_trace.py::test_installed_console_script_preserves_main_exit_codes`) is pre-existing and environmental — it needs PyPTO pip-installed, and reproduces identically with this diff reverted.
- The removals are measurably real, not silent no-ops: `test_declared_memref.py` goes 1.48s → 3.44s because the instruments now actually run.
- `ruff check` / `ruff format --check` clean.

## Scope

Twenty documented bypasses remain elsewhere and are untouched. Several are deliberately retained because they mask genuine open bugs — notably the dynamic-`core_num` printer roundtrip failure and MemoryReuse's `tile.move` `tile_view` mismatch, both of which reproduce under the production `Default` pipeline. This PR does not attempt those; it only removes the ones that were unnecessary. Every surviving bypass still carries an explanatory comment.