### PR TITLE
refactor(ir): Remove the DebugTileOptimization strategy

### DIFF
--- a/docs/en/dev/codegen/00-pto_codegen.md
+++ b/docs/en/dev/codegen/00-pto_codegen.md
@@ -107,16 +107,16 @@ class MyKernel:
         tile_c = pl.add(tile_a, tile_b)
         pl.store(tile_c, [0, 0], a)
 
-# Compile with PTO backend and DebugTileOptimization (debug only)
+# Compile with PTO backend
 output_dir = compile(
     MyKernel,
-    strategy=OptimizationStrategy.DebugTileOptimization,
+    strategy=OptimizationStrategy.Default,
     backend_type=BackendType.Ascend910B,
 )
 ```
 
 The `compile()` function automatically applies the selected optimization strategy and invokes the appropriate codegen based on `backend_type`.
-Use `Default` for normal PTO compilation; `DebugTileOptimization` is intended only for pass-pipeline debugging.
+`Default` is the only optimization strategy.
 
 ### Direct Codegen Access
 

--- a/docs/en/dev/passes/00-pass_manager.md
+++ b/docs/en/dev/passes/00-pass_manager.md
@@ -17,7 +17,7 @@ Framework for organizing and executing IR transformation passes on Programs with
 - **Property Tracking**: Passes declare required, produced, and invalidated properties
 - **Instrumentation**: PassContext holds PassInstruments that run before/after each pass
 - **Runtime Verification**: VerificationInstrument checks properties against actual IR
-- **Strategy-based Pipelines**: Pre-configured optimization levels (`Default`, `DebugTileOptimization`)
+- **Strategy-based Pipelines**: Pre-configured optimization levels (`Default`)
 - **Immutable Transformations**: Return new IR nodes, don't modify in place
 
 ## IRProperty System
@@ -396,7 +396,7 @@ with passes.PassContext([passes.VerificationInstrument(passes.VerificationMode.A
 
 ### Strategy Notes
 
-The PTO-oriented tile stage shared by `Default` and `DebugTileOptimization` is:
+The PTO-oriented tile stage of `Default` is:
 
 1. [`LowerCompositeOps`](12-lower_composite_ops.md)
 2. [`FlattenTileNdTo2D`](13-flatten_tile_nd_to_2d.md)
@@ -432,10 +432,6 @@ The PTO-oriented tile stage shared by `Default` and `DebugTileOptimization` is:
 32. [`MaterializeRuntimeScopes`](42-materialize_runtime_scopes.md) (inserts AUTO RuntimeScopeStmt so orchestration codegen emits PTO2_SCOPE 1:1)
 33. [`ClassifyIterArgCarry`](43-classify_iter_arg_carry.md) (stamps each ForStmt iter_arg as trivial alias / rebind carry, and sizes manual-scope TaskId fence arrays)
 34. [`InsertCommFence`](44-insert_comm_fence.md) (inserts a whole-tensor system.cacheinvalid + GM system.fence between each publishing write and the pld.system.notify that releases it; runs dead last so the inserted ops stay adjacent to their notify through codegen)
-
-`DebugTileOptimization` is a debug-only strategy for inspecting this tile stage
-without the tensor-only prefix passes. Use `Default` for normal compilation and
-for non-strategy-specific tests so the maintained pipeline stays covered.
 
 [`ResolveBackendOpLayouts`](18-resolve_backend_op_layouts.md) repairs
 backend-constrained elementwise tile ops using registered layout metadata.

--- a/docs/en/dev/passes/02-unroll_loops.md
+++ b/docs/en/dev/passes/02-unroll_loops.md
@@ -72,7 +72,7 @@ class After:
 
 ## Pipeline Position
 
-UnrollLoops runs **once** in `Default` and `DebugTileOptimization`, before control flow structuring:
+UnrollLoops runs **once** in `Default`, before control flow structuring:
 
 ```text
 UnrollLoops → CtrlFlowTransform → ConvertToSSA → FlattenCallExpr → OutlineHierarchyScopes → OutlineIncoreScopes → ...

--- a/docs/en/dev/passes/42-materialize_runtime_scopes.md
+++ b/docs/en/dev/passes/42-materialize_runtime_scopes.md
@@ -40,9 +40,9 @@ lets the output round-trip: the inserted `with pl.scope()` blocks parse back onl
 under `auto_scope=False` (the parser rejects hand-placed AUTO scopes in the
 default mode, where the compiler owns placement).
 
-**When to use**: last pass in the `Default` and `DebugTileOptimization`
-strategies, after the final `Simplify`. Running dead last means no other
-transform has to reason about the inserted scope wrappers.
+**When to use**: last pass in the `Default` strategy, after the final
+`Simplify`. Running dead last means no other transform has to reason about
+the inserted scope wrappers.
 
 **Scope**: only `Orchestration` functions are modified. InCore / AIC / AIV /
 Group / Spmd bodies are never scope-wrapped by codegen, so they are returned

--- a/docs/en/dev/passes/42-materialize_runtime_scopes.md
+++ b/docs/en/dev/passes/42-materialize_runtime_scopes.md
@@ -40,9 +40,11 @@ lets the output round-trip: the inserted `with pl.scope()` blocks parse back onl
 under `auto_scope=False` (the parser rejects hand-placed AUTO scopes in the
 default mode, where the compiler owns placement).
 
-**When to use**: last pass in the `Default` strategy, after the final
-`Simplify`. Running dead last means no other transform has to reason about
-the inserted scope wrappers.
+**When to use**: in the `Default` strategy, immediately after the final
+`Simplify` and before
+[`ClassifyIterArgCarry`](43-classify_iter_arg_carry.md) and
+[`InsertCommFence`](44-insert_comm_fence.md). Running after every rewriting
+transform means none of them has to reason about the inserted scope wrappers.
 
 **Scope**: only `Orchestration` functions are modified. InCore / AIC / AIV /
 Group / Spmd bodies are never scope-wrapped by codegen, so they are returned

--- a/docs/en/dev/passes/43-classify_iter_arg_carry.md
+++ b/docs/en/dev/passes/43-classify_iter_arg_carry.md
@@ -24,8 +24,7 @@ to a fixed-extent `PTO2TaskId[N]` fence array. `N` is the constant trip count of
 the `pl.parallel` loop that owns the array; a `Sequential` loop threading that
 array through an inner `pl.parallel` inherits the inner extent.
 
-**When to use**: last pass in the `Default` and `DebugTileOptimization`
-strategies, immediately after
+**When to use**: last pass in the `Default` strategy, immediately after
 [`MaterializeRuntimeScopes`](42-materialize_runtime_scopes.md). Running last
 means the classified IR is exactly the IR codegen lowers.
 

--- a/docs/en/dev/passes/43-classify_iter_arg_carry.md
+++ b/docs/en/dev/passes/43-classify_iter_arg_carry.md
@@ -24,9 +24,11 @@ to a fixed-extent `PTO2TaskId[N]` fence array. `N` is the constant trip count of
 the `pl.parallel` loop that owns the array; a `Sequential` loop threading that
 array through an inner `pl.parallel` inherits the inner extent.
 
-**When to use**: last pass in the `Default` strategy, immediately after
-[`MaterializeRuntimeScopes`](42-materialize_runtime_scopes.md). Running last
-means the classified IR is exactly the IR codegen lowers.
+**When to use**: in the `Default` strategy, immediately after
+[`MaterializeRuntimeScopes`](42-materialize_runtime_scopes.md) and immediately
+before [`InsertCommFence`](44-insert_comm_fence.md). Running this late means the
+classified IR is exactly the IR codegen lowers — `InsertCommFence` only adds
+InCore fence ops and never touches Orchestration `ForStmt` iter_args.
 
 ## Alias classes
 

--- a/docs/en/user/01-language_guide.md
+++ b/docs/en/user/01-language_guide.md
@@ -639,7 +639,9 @@ output_dir = ir.compile(
 
 ### Optimization Pipeline
 
-The `Default` strategy runs these passes in order:
+The `Default` strategy runs the following main stages in order. This is a
+summary, not the full recipe — see the [pass documentation](../dev/passes/00-pass_manager.md)
+for every pass and its exact position:
 
 1. **UnrollLoops** — unroll loop iterations
 2. **CtrlFlowTransform** — rewrite control flow to structured IR

--- a/docs/en/user/01-language_guide.md
+++ b/docs/en/user/01-language_guide.md
@@ -621,7 +621,7 @@ from pypto.backend import BackendType
 output_dir = ir.compile(
     program,
     output_dir=None,                           # auto-generated if None
-    strategy=ir.OptimizationStrategy.Default,  # or DebugTileOptimization
+    strategy=ir.OptimizationStrategy.Default,  # the only optimization strategy
     dump_passes=True,                          # dump IR snapshots under output_dir/passes_dump/
     backend_type=BackendType.Ascend910B,
 )
@@ -630,7 +630,7 @@ output_dir = ir.compile(
 | Parameter | Options | Description |
 | --------- | ------- | ----------- |
 | `program` | `ir.Program` | Required program object (from `@pl.program` or equivalent) |
-| `strategy` | `OptimizationStrategy.Default`, `DebugTileOptimization` | `Default` = full tensor-oriented pipeline. `DebugTileOptimization` = debug-only PTO tile pipeline without tensor-only passes |
+| `strategy` | `OptimizationStrategy.Default` | `Default` = full tensor-oriented pipeline (the only strategy) |
 | `backend_type` | `BackendType.Ascend910B`, `BackendType.Ascend950` | Target hardware for passes and codegen (`import BackendType` from `pypto.backend`) |
 | `dump_passes` | `True`/`False` | If `True`, write IR snapshots under `<output_dir>/passes_dump/` after each pass (default `True`) |
 | `skip_ptoas` | `True`/`False` | Skip the ptoas step; emit raw `.pto` (MLIR) instead of compiled C++ wrappers (default `False`) |

--- a/docs/zh/dev/codegen/00-pto_codegen.md
+++ b/docs/zh/dev/codegen/00-pto_codegen.md
@@ -105,16 +105,16 @@ class MyKernel:
         tile_c = pl.add(tile_a, tile_b)
         pl.store(tile_c, [0, 0], a)
 
-# Compile with PTO backend and DebugTileOptimization (debug only)
+# Compile with PTO backend
 output_dir = compile(
     MyKernel,
-    strategy=OptimizationStrategy.DebugTileOptimization,
+    strategy=OptimizationStrategy.Default,
     backend_type=BackendType.Ascend910B,
 )
 ```
 
 `compile()` 函数会自动应用选定的优化策略, 并根据 `backend_type` 调用相应的代码生成器。
-正常的 PTO 编译应使用 `Default`；`DebugTileOptimization` 只用于调试 pass 流水线。
+`Default` 是唯一的优化策略。
 
 ### 直接访问代码生成器
 

--- a/docs/zh/dev/passes/00-pass_manager.md
+++ b/docs/zh/dev/passes/00-pass_manager.md
@@ -17,7 +17,7 @@
 - **属性跟踪**：Pass 声明所需、产生和失效的属性
 - **插桩**：PassContext 持有 PassInstrument，在每个 Pass 执行前/后运行
 - **运行时验证**：VerificationInstrument 根据实际 IR 检查属性
-- **基于策略的流水线**：预配置的优化级别（`Default`、`DebugTileOptimization`）
+- **基于策略的流水线**：预配置的优化级别（`Default`）
 - **不可变变换**：返回新的 IR 节点，不就地修改
 
 ## IRProperty 系统
@@ -396,7 +396,7 @@ with passes.PassContext([passes.VerificationInstrument(passes.VerificationMode.A
 
 ### 策略补充说明
 
-`Default` 和 `DebugTileOptimization` 共享的 PTO tile 阶段顺序为：
+`Default` 的 PTO tile 阶段顺序为：
 
 1. [`LowerCompositeOps`](12-lower_composite_ops.md)
 2. [`FlattenTileNdTo2D`](13-flatten_tile_nd_to_2d.md)
@@ -432,10 +432,6 @@ with passes.PassContext([passes.VerificationInstrument(passes.VerificationMode.A
 32. [`MaterializeRuntimeScopes`](42-materialize_runtime_scopes.md)（插入 AUTO RuntimeScopeStmt，使 orchestration codegen 1:1 emit PTO2_SCOPE）
 33. [`ClassifyIterArgCarry`](43-classify_iter_arg_carry.md)（把每个 ForStmt iter_arg 标注为平凡别名 / 重绑定 carry，并为 manual-scope TaskId fence 数组定尺）
 34. [`InsertCommFence`](44-insert_comm_fence.md)（在每个发布性写入与释放它的 pld.system.notify 之间插入整张 tensor 的 system.cacheinvalid + GM system.fence；跑在最后，使插入的 op 一路到 codegen 都紧邻其 notify）
-
-`DebugTileOptimization` 只是用于排查 PTO tile 阶段的调试策略，会跳过
-tensor-only 前缀 pass。正常编译和非 strategy 专项测试都应优先使用
-`Default`，以保证主维护流水线持续被覆盖。
 
 [`ResolveBackendOpLayouts`](18-resolve_backend_op_layouts.md) 会根据
 backend 注册的 layout 元数据修复受约束的逐元素 tile 操作。对于当前 PTO

--- a/docs/zh/dev/passes/02-unroll_loops.md
+++ b/docs/zh/dev/passes/02-unroll_loops.md
@@ -74,7 +74,7 @@ class After:
 
 ## 流水线位置
 
-UnrollLoops 在 `Default` 和 `DebugTileOptimization` 中都只**运行一次**，位于控制流结构化之前：
+UnrollLoops 在 `Default` 中只**运行一次**，位于控制流结构化之前：
 
 ```text
 UnrollLoops → CtrlFlowTransform → ConvertToSSA → FlattenCallExpr → OutlineHierarchyScopes → OutlineIncoreScopes → ...

--- a/docs/zh/dev/passes/42-materialize_runtime_scopes.md
+++ b/docs/zh/dev/passes/42-materialize_runtime_scopes.md
@@ -35,8 +35,10 @@ parser 直接物化进 IR。这是控制 scope 粒度（ring 隔离）、MANUAL 
 `auto_scope=False` 下才能解析回来（parser 在默认模式下拒绝手写 AUTO scope，
 默认模式由编译器决定放置）。
 
-**何时使用**：在 `Default` 策略中作为最后一个 pass 运行，位于最终的 `Simplify`
-之后。放在最末意味着其它任何 transform 都无需处理被插入的 scope 包裹。
+**何时使用**：在 `Default` 策略中紧跟最终的 `Simplify` 之后运行，位于
+[`ClassifyIterArgCarry`](43-classify_iter_arg_carry.md) 与
+[`InsertCommFence`](44-insert_comm_fence.md) 之前。跑在所有改写型 transform
+之后意味着它们都无需处理被插入的 scope 包裹。
 
 **作用范围**：仅修改 `Orchestration` 函数。InCore / AIC / AIV / Group / Spmd
 的函数体从不会被 codegen 包裹 scope，因此原样返回。

--- a/docs/zh/dev/passes/42-materialize_runtime_scopes.md
+++ b/docs/zh/dev/passes/42-materialize_runtime_scopes.md
@@ -35,9 +35,8 @@ parser 直接物化进 IR。这是控制 scope 粒度（ring 隔离）、MANUAL 
 `auto_scope=False` 下才能解析回来（parser 在默认模式下拒绝手写 AUTO scope，
 默认模式由编译器决定放置）。
 
-**何时使用**：在 `Default` 与 `DebugTileOptimization` 策略中作为最后一个 pass
-运行，位于最终的 `Simplify` 之后。放在最末意味着其它任何 transform 都无需处理
-被插入的 scope 包裹。
+**何时使用**：在 `Default` 策略中作为最后一个 pass 运行，位于最终的 `Simplify`
+之后。放在最末意味着其它任何 transform 都无需处理被插入的 scope 包裹。
 
 **作用范围**：仅修改 `Orchestration` 函数。InCore / AIC / AIV / Group / Spmd
 的函数体从不会被 codegen 包裹 scope，因此原样返回。

--- a/docs/zh/dev/passes/43-classify_iter_arg_carry.md
+++ b/docs/zh/dev/passes/43-classify_iter_arg_carry.md
@@ -23,9 +23,11 @@ orchestration codegen 直接读取，不再自行推导。
 count；若一个 `Sequential` 循环把该数组穿过内层 `pl.parallel` 向外传递，则继承内层
 的 extent。
 
-**何时运行**：`Default` 策略的最后一个 pass，紧跟在
-[`MaterializeRuntimeScopes`](42-materialize_runtime_scopes.md) 之后。跑在最后
-意味着被分类的 IR 与 codegen 实际降级的 IR 完全一致。
+**何时运行**：在 `Default` 策略中紧跟
+[`MaterializeRuntimeScopes`](42-materialize_runtime_scopes.md) 之后、
+[`InsertCommFence`](44-insert_comm_fence.md) 之前运行。跑得这么靠后意味着被分类
+的 IR 与 codegen 实际降级的 IR 完全一致 —— `InsertCommFence` 只会追加 InCore 的
+fence 算子，不会改动 Orchestration `ForStmt` 的 iter_arg。
 
 ## 别名等价类（alias class）
 

--- a/docs/zh/dev/passes/43-classify_iter_arg_carry.md
+++ b/docs/zh/dev/passes/43-classify_iter_arg_carry.md
@@ -23,9 +23,9 @@ orchestration codegen 直接读取，不再自行推导。
 count；若一个 `Sequential` 循环把该数组穿过内层 `pl.parallel` 向外传递，则继承内层
 的 extent。
 
-**何时运行**：`Default` 与 `DebugTileOptimization` 策略的最后一个 pass，紧跟在
-[`MaterializeRuntimeScopes`](42-materialize_runtime_scopes.md) 之后。跑在最后意味着
-被分类的 IR 与 codegen 实际降级的 IR 完全一致。
+**何时运行**：`Default` 策略的最后一个 pass，紧跟在
+[`MaterializeRuntimeScopes`](42-materialize_runtime_scopes.md) 之后。跑在最后
+意味着被分类的 IR 与 codegen 实际降级的 IR 完全一致。
 
 ## 别名等价类（alias class）
 

--- a/docs/zh/user/01-language_guide.md
+++ b/docs/zh/user/01-language_guide.md
@@ -597,7 +597,7 @@ from pypto.backend import BackendType
 output_dir = ir.compile(
     program,
     output_dir=None,                           # 为 None 时自动生成
-    strategy=ir.OptimizationStrategy.Default,  # 或 DebugTileOptimization
+    strategy=ir.OptimizationStrategy.Default,  # 唯一的优化策略
     dump_passes=True,                          # 将 IR 快照写入 output_dir/passes_dump/
     backend_type=BackendType.Ascend910B,
 )
@@ -606,7 +606,7 @@ output_dir = ir.compile(
 | 参数 | 选项 | 说明 |
 | ---- | ---- | ---- |
 | `program` | `ir.Program` | 必填，待编译的程序对象（来自 `@pl.program` 等） |
-| `strategy` | `OptimizationStrategy.Default`、`DebugTileOptimization` | `Default` = 完整 tensor 导向流水线。`DebugTileOptimization` = 仅用于调试的 PTO tile 流水线，不包含 tensor-only pass |
+| `strategy` | `OptimizationStrategy.Default` | `Default` = 完整 tensor 导向流水线（唯一策略） |
 | `backend_type` | `BackendType.Ascend910B`、`BackendType.Ascend950` | Pass 与代码生成的目标硬件（从 `pypto.backend` 导入 `BackendType`） |
 | `dump_passes` | `True`/`False` | 为 `True` 时在每个 pass 后将 IR 快照写入 `<output_dir>/passes_dump/`（默认 `True`） |
 | `skip_ptoas` | `True`/`False` | 跳过 ptoas；只生成原始 `.pto`（MLIR），不生成已编译的 C++ 包装代码（默认 `False`） |

--- a/docs/zh/user/01-language_guide.md
+++ b/docs/zh/user/01-language_guide.md
@@ -615,7 +615,8 @@ output_dir = ir.compile(
 
 ### 优化流水线
 
-`Default` 策略按顺序运行以下 pass：
+`Default` 策略按顺序运行以下主要阶段。这里只是摘要，并非完整流水线 ——
+完整的 pass 列表及其确切位置见 [pass 文档](../dev/passes/00-pass_manager.md)：
 
 1. **UnrollLoops** —— 展开循环迭代
 2. **CtrlFlowTransform** —— 将控制流改写为结构化 IR

--- a/python/pypto/ir/pass_manager.py
+++ b/python/pypto/ir/pass_manager.py
@@ -12,7 +12,7 @@
 import os
 import re
 from collections.abc import Callable
-from enum import Enum
+from enum import Enum, unique
 
 from pypto.compile_profiling import CompileProfiler
 from pypto.pypto_core import ir as core_ir
@@ -85,11 +85,11 @@ def _format_warnings(
 PassFactory = Callable[[], passes.Pass]
 
 
+@unique
 class OptimizationStrategy(Enum):
     """Enumeration of optimization strategies."""
 
     Default = "Default"  # Full tensor-oriented PTO pipeline
-    DebugTileOptimization = "DebugTileOptimization"  # Debug-only PTO tile pipeline
 
 
 class PassDumpLevel(Enum):
@@ -149,6 +149,8 @@ class PassManager:
         analyze_auto_scopes_for_deps: bool,
     ) -> tuple[PassFactory, ...]:
         """Build the immutable pass-factory recipe for an optimization strategy."""
+        if strategy != OptimizationStrategy.Default:
+            raise ValueError(f"Unsupported optimization strategy: {strategy!r}")
         tensor_prefix_passes: tuple[PassFactory, ...] = (
             # Eliminate FunctionType.Inline functions by splicing their bodies at
             # every call site. Runs FIRST so no downstream pass observes Inline
@@ -254,11 +256,7 @@ class PassManager:
             # insertion that touches no property.
             passes.insert_comm_fence,
         )
-        if strategy == OptimizationStrategy.Default:
-            return tensor_prefix_passes + tensor_only_passes + tile_pto_passes
-        if strategy == OptimizationStrategy.DebugTileOptimization:
-            return tensor_prefix_passes + tile_pto_passes
-        raise ValueError(f"Unsupported optimization strategy: {strategy!r}")
+        return tensor_prefix_passes + tensor_only_passes + tile_pto_passes
 
     @classmethod
     def get_strategy(

--- a/python/pypto/ir/pass_manager.py
+++ b/python/pypto/ir/pass_manager.py
@@ -239,8 +239,9 @@ class PassManager:
             passes.simplify,
             # Insert explicit AUTO RuntimeScopeStmt nodes (function body + for/if
             # bodies) into Orchestration functions so codegen emits PTO2_SCOPE
-            # 1:1 from the IR. Runs dead last, after the final Simplify, so no
-            # other transform has to reason about the inserted scope wrappers.
+            # 1:1 from the IR. Runs after the final Simplify and after every
+            # rewriting transform, so none of them has to reason about the
+            # inserted scope wrappers.
             passes.materialize_runtime_scopes,
             # Classify each Orchestration ForStmt iter_arg as a trivial alias or a
             # materialised rebind carry (and size manual-scope TaskId array

--- a/python/pypto/jit/cache.py
+++ b/python/pypto/jit/cache.py
@@ -155,9 +155,9 @@ def make_cache_key(  # noqa: PLR0913 — args are the key's components, one per 
         strategy: Optimization strategy applied during compilation (an
             ``OptimizationStrategy`` member, or ``None`` for the JIT default).
             Included in the key because the strategy changes the compiled
-            artifact; without it, calling the same kernel with two strategies
-            (an A/B comparison) would return the first-compiled artifact for
-            both.
+            artifact; without it, calling the same kernel with ``None`` and
+            with an explicit strategy would return the first-compiled artifact
+            for both.
         distributed_config: Optional ``DistributedConfig`` forwarded to
             ``ir.compile()`` on the ``@pl.jit.host`` path. Included in the key
             because it is baked into the resulting

--- a/python/pypto/jit/cache.py
+++ b/python/pypto/jit/cache.py
@@ -152,12 +152,14 @@ def make_cache_key(  # noqa: PLR0913 — args are the key's components, one per 
         platform: Target platform string (e.g. "a2a3sim"). Included in the key
             because compiled artifacts are platform-specific; a cache entry
             compiled for one platform must not be reused for another.
-        strategy: Optimization strategy applied during compilation (an
-            ``OptimizationStrategy`` member, or ``None`` for the JIT default).
+        strategy: Optimization strategy applied during compilation, as an
+            ``OptimizationStrategy`` member. ``None`` is a distinct key value
+            for callers that omit the argument entirely; the JIT never passes
+            it, because ``JITFunction._resolve_compiled()`` normalizes a call
+            without a ``RunConfig`` to ``OptimizationStrategy.Default``.
             Included in the key because the strategy changes the compiled
-            artifact; without it, calling the same kernel with ``None`` and
-            with an explicit strategy would return the first-compiled artifact
-            for both.
+            artifact; without it, artifacts compiled under different strategy
+            values would share one cache entry.
         distributed_config: Optional ``DistributedConfig`` forwarded to
             ``ir.compile()`` on the ``@pl.jit.host`` path. Included in the key
             because it is baked into the resulting

--- a/python/pypto/jit/decorator.py
+++ b/python/pypto/jit/decorator.py
@@ -1883,7 +1883,8 @@ class JITFunction:
         (``strategy``, ``dump_passes``, diagnostics, ...) are forwarded to
         ``ir.compile()`` via :func:`_run_config_compile_kwargs`, and its
         runtime fields drive on-device execution.  ``strategy`` also takes
-        part in the cache key so two strategies never share a cache entry.
+        part in the cache key so artifacts compiled under different strategy
+        values never share a cache entry.
 
         Args:
             *args: Positional arguments matching the decorated function's params.

--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -85,13 +85,13 @@ struct IterArgCarryPlan {
 using namespace pypto::ir;  // NOLINT(build/namespaces)
 
 CoreType InferFunctionCoreType(const FunctionPtr& func) {
-  // After ExpandMixedKernel runs (part of every Default / DebugTileOptimization
-  // pipeline), every InCore function reaching codegen has been split into AIC,
-  // AIV, or Group / Spmd wrappers. The two callers of this function
-  // (GenerateFunctionCallCode and GenerateSpmdCallCode) both filter Spmd /
-  // Group out before invoking it. Tests that bypass the pipeline must declare
-  // their kernels with the appropriate AIC / AIV type explicitly so codegen
-  // sees the concrete core type without re-deriving from body memory spaces.
+  // After ExpandMixedKernel runs (part of the Default pipeline), every InCore
+  // function reaching codegen has been split into AIC, AIV, or Group / Spmd
+  // wrappers. The two callers of this function (GenerateFunctionCallCode and
+  // GenerateSpmdCallCode) both filter Spmd / Group out before invoking it.
+  // Tests that bypass the pipeline must declare their kernels with the
+  // appropriate AIC / AIV type explicitly so codegen sees the concrete core
+  // type without re-deriving from body memory spaces.
   switch (func->func_type_) {
     case FunctionType::AIC:
       return CoreType::CUBE;

--- a/tests/st/README.md
+++ b/tests/st/README.md
@@ -152,7 +152,7 @@ The test framework provides extensive configuration through pytest command-line 
 | ------ | ------- | ----------- |
 | `--platform` | `a2a3` | Comma-separated allowlist of target platforms. Each runtime test case is parametrized over `a2a3`, `a5`, `a2a3sim`, `a5sim`; only variants whose id appears here run. |
 | `--device` | `0` | Device ID for hardware tests (0, 1, 2, ...) |
-| `--strategy` | `Default` | PyPTO optimization strategy: `Default` or `DebugTileOptimization` |
+| `--strategy` | `Default` | PyPTO optimization strategy (`Default` is the only supported value) |
 | `--save-kernels` | `False` | Save generated kernels and artifacts to disk |
 | `--kernels-dir` | `build_output/{testName}_{timestamp}/` | Custom output directory for saved kernels |
 | `--dump-passes` | `False` | Dump intermediate IR after each compiler pass |
@@ -257,25 +257,16 @@ pytest tests/st/ -v --forked --codegen-only --save-kernels
 
 ### Using Optimization Strategies
 
-PyPTO supports different optimization strategies. Select at runtime:
+`OptimizationStrategy.Default` is currently the only strategy, so `--strategy`
+needs no explicit value:
 
 ```bash
-# Use Default optimization strategy (default)
-pytest tests/st/ -v --forked
-
-# Combine with other options
 pytest tests/st/ -v --forked --save-kernels --dump-passes
 ```
 
-You can also override the strategy in individual test cases by implementing the `get_strategy()` method:
-
-```python
-from pypto.ir.pass_manager import OptimizationStrategy
-
-class MyTest(PTOTestCase):
-    def get_strategy(self):
-        return OptimizationStrategy.DebugTileOptimization
-```
+A test case can pin its strategy by implementing `get_strategy()`; the hook
+exists so a future strategy can be opted into per test without touching the
+harness.
 
 ### Parameterized Testing
 

--- a/tests/ut/conftest.py
+++ b/tests/ut/conftest.py
@@ -42,9 +42,9 @@ def default_pass_manager():
     """Return the default-strategy PassManager.
 
     Use this in tests that want to run the production pipeline without
-    constructing the manager inline. Strategy-specific tests (covering
-    ``DebugTileOptimization`` etc.) should keep building the manager
-    themselves so the choice stays visible at the test site.
+    constructing the manager inline. Strategy-specific tests should keep
+    building the manager themselves so the choice stays visible at the
+    test site.
     """
     return PassManager.get_strategy(OptimizationStrategy.Default)
 

--- a/tests/ut/ir/transforms/test_pass_manager.py
+++ b/tests/ut/ir/transforms/test_pass_manager.py
@@ -89,7 +89,9 @@ class TestPassManagerBasics:
     def test_pass_manager_rejects_unknown_strategy(self):
         """An unsupported strategy value raises instead of silently running Default."""
         with pytest.raises(ValueError, match="Unsupported optimization strategy"):
-            ir.PassManager.get_strategy("NotAStrategy")
+            # Deliberately ill-typed: the guard exists for values the type system
+            # rules out, so exercising it requires stepping outside the annotation.
+            ir.PassManager.get_strategy("NotAStrategy")  # type: ignore[arg-type]
 
     def test_auto_scope_deps_switch_forwarded_to_pass_factory(self, monkeypatch):
         """PassManager forwards the high-level AUTO-scope deps switch."""

--- a/tests/ut/ir/transforms/test_pass_manager.py
+++ b/tests/ut/ir/transforms/test_pass_manager.py
@@ -11,10 +11,8 @@
 
 import os
 
-import pypto.language as pl
 import pytest
-from pypto import DataType, backend, ir, passes
-from pypto.backend import BackendType
+from pypto import DataType, ir, passes
 
 TENSOR_ONLY_PASSES = [
     "OutlineHierarchyScopes",
@@ -69,69 +67,6 @@ TENSOR_OPTIMIZATION_PASSES = [
     "InsertCommFence",
 ]
 
-DEBUG_TILE_OPTIMIZATION_PASSES = [
-    "InlineFunctions",
-    "UnrollLoops",
-    "CtrlFlowTransform",
-    "ConvertToSSA",
-    "Simplify",
-    "NormalizeStmtStructure",
-    "FlattenCallExpr",
-    "LowerCompositeOps",
-    "FlattenTileNdTo2D",
-    "LegalizeTileCast",
-    "AutoTileMatmulL0",
-    "CanonicalizeTileSlice",
-    "InferTileMemorySpace",
-    "ResolveBackendOpLayouts",
-    "LowerAutoVectorSplit",
-    "ExpandMixedKernel",
-    "InjectGMPipeBuffer",
-    "SplitVectorKernel",
-    "StampTfreeSplit",
-    "NormalizeReturnOrder",
-    "SkewCrossCorePipeline",
-    "LowerPipelineLoops",
-    "CanonicalizeIOOrder",
-    "MaterializeTensorStrides",
-    "InitMemRef",
-    "MaterializeSemanticAliases",
-    "MemoryReuse",
-    "AllocateMemoryAddr",
-    "FoldNoOpReshape",
-    "FuseCreateAssembleToSlice",
-    "DeriveCallDirections",
-    "AutoDeriveTaskDependencies",
-    "ExpandManualPhaseFence",
-    "SynthesizeAllReduceSignals",
-    "MaterializeCommDomainScopes",
-    "LowerHostTensorCollectives",
-    "MaterializeDistTensorCtx",
-    "Simplify",
-    "MaterializeRuntimeScopes",
-    "ClassifyIterArgCarry",
-    "InsertCommFence",
-]
-
-
-def _build_tile_only_program():
-    @pl.program
-    class TileOnlyProgram:
-        @pl.function(type=pl.FunctionType.InCore)
-        def kernel(
-            self,
-            a: pl.Tensor[[16, 16], pl.FP32],
-            b: pl.Tensor[[16, 16], pl.FP32],
-            out: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
-        ) -> pl.Tensor[[16, 16], pl.FP32]:
-            tile_a = pl.load(a, [0, 0], [16, 16])
-            tile_b = pl.load(b, [0, 0], [16, 16])
-            result = pl.add(tile_a, tile_b)
-            out = pl.store(result, [0, 0], out)
-            return out
-
-    return TileOnlyProgram
-
 
 class TestOptimizationStrategy:
     """Test OptimizationStrategy enum."""
@@ -139,15 +74,6 @@ class TestOptimizationStrategy:
     def test_optimization_strategy_values(self):
         """Test that all optimization strategies exist."""
         assert ir.OptimizationStrategy.Default is not None
-        assert ir.OptimizationStrategy.DebugTileOptimization is not None
-
-    def test_optimization_strategy_values_are_different(self):
-        """Test that optimization strategies have different values."""
-        strategies = [
-            ir.OptimizationStrategy.Default,
-            ir.OptimizationStrategy.DebugTileOptimization,
-        ]
-        assert len(strategies) == len(set(strategies))
 
 
 class TestPassManagerBasics:
@@ -160,13 +86,10 @@ class TestPassManagerBasics:
         assert pm.strategy == ir.OptimizationStrategy.Default
         assert pm.pass_names == TENSOR_OPTIMIZATION_PASSES
 
-    def test_pass_manager_get_strategy_debug_tile_optimization(self):
-        """Test getting DebugTileOptimization strategy PassManager."""
-        pm = ir.PassManager.get_strategy(ir.OptimizationStrategy.DebugTileOptimization)
-        assert pm is not None
-        assert pm.strategy == ir.OptimizationStrategy.DebugTileOptimization
-        assert pm.pass_names == DEBUG_TILE_OPTIMIZATION_PASSES
-        assert not set(TENSOR_ONLY_PASSES).intersection(pm.pass_names)
+    def test_pass_manager_rejects_unknown_strategy(self):
+        """An unsupported strategy value raises instead of silently running Default."""
+        with pytest.raises(ValueError, match="Unsupported optimization strategy"):
+            ir.PassManager.get_strategy("NotAStrategy")
 
     def test_auto_scope_deps_switch_forwarded_to_pass_factory(self, monkeypatch):
         """PassManager forwards the high-level AUTO-scope deps switch."""
@@ -228,19 +151,6 @@ class TestPassManagerExecution:
         assert pm.strategy == ir.OptimizationStrategy.Default
         assert result is not program
         assert func.name == "test_func"
-
-    def test_tile_strategies_run_on_tile_only_program(self):
-        """Test tile-only strategies on an already-tiled program."""
-        program = _build_tile_only_program()
-
-        backend.reset_for_testing()
-        backend.set_backend_type(BackendType.Ascend910B)
-        tile_result = ir.PassManager.get_strategy(ir.OptimizationStrategy.DebugTileOptimization).run_passes(
-            program
-        )
-
-        assert isinstance(tile_result, ir.Program)
-        assert tile_result.name == program.name
 
 
 class TestPassManagerMultipleInstances:

--- a/tests/ut/jit/test_cache.py
+++ b/tests/ut/jit/test_cache.py
@@ -288,26 +288,6 @@ class TestMakeCacheKey:
         )
         assert k_none != k_named
 
-    def test_different_strategy_causes_miss(self):
-        """Same shapes/dtypes compiled with different strategies must not collide.
-
-        Keeps an A/B comparison honest: calling one kernel with two
-        strategies must compile twice, not serve the first artifact twice.
-        """
-        k_default = self._make_key(
-            param_names=["a"],
-            tensor_shapes={"a": (8, 8)},
-            tensor_dtypes={"a": DataType.FP32},
-            strategy=OptimizationStrategy.Default,
-        )
-        k_debug = self._make_key(
-            param_names=["a"],
-            tensor_shapes={"a": (8, 8)},
-            tensor_dtypes={"a": DataType.FP32},
-            strategy=OptimizationStrategy.DebugTileOptimization,
-        )
-        assert k_default != k_debug
-
     def test_same_strategy_is_cache_hit(self):
         k1 = self._make_key(
             param_names=["a"],

--- a/tests/ut/jit/test_decorator.py
+++ b/tests/ut/jit/test_decorator.py
@@ -2244,14 +2244,14 @@ class TestCompileKwargForwarding:
         """Compile-side RunConfig fields map onto the ir.compile() parameter names."""
         artifacts_dir = tmp_path / "jit_artifacts"
         cfg = RunConfig(
-            strategy=OptimizationStrategy.DebugTileOptimization,
+            strategy=OptimizationStrategy.Default,
             dump_passes=True,
             compile_profiling=True,
             save_kernels_dir=str(artifacts_dir),
             analyze_auto_scopes_for_deps=True,
         )
         kwargs = _run_config_compile_kwargs(cfg)
-        assert kwargs["strategy"] == OptimizationStrategy.DebugTileOptimization
+        assert kwargs["strategy"] == OptimizationStrategy.Default
         assert kwargs["dump_passes"] is True
         assert kwargs["profiling"] is True  # mapped from RunConfig.compile_profiling
         assert kwargs["output_dir"] == str(artifacts_dir)  # from RunConfig.save_kernels_dir
@@ -2436,7 +2436,7 @@ class TestCompileKwargForwarding:
 
         dc = DistributedConfig(device_ids=[0, 1])
         cfg = RunConfig(
-            strategy=OptimizationStrategy.DebugTileOptimization,
+            strategy=OptimizationStrategy.Default,
             dump_passes=True,
             compile_profiling=True,
             distributed_config=dc,
@@ -2455,7 +2455,7 @@ class TestCompileKwargForwarding:
             **_run_config_compile_kwargs(cfg),
         )
         assert result == "fake-compiled-program"
-        assert captured["strategy"] == OptimizationStrategy.DebugTileOptimization
+        assert captured["strategy"] == OptimizationStrategy.Default
         assert captured["dump_passes"] is True
         assert captured["profiling"] is True
         assert captured["platform"] == "a2a3sim"

--- a/tests/ut/jit/test_jit_compile_extraction.py
+++ b/tests/ut/jit/test_jit_compile_extraction.py
@@ -161,30 +161,22 @@ class TestLowerReturnsProgram:
         assert seen_passes
         assert not (tmp_path / "perf_hints.log").exists()
 
-    def test_lower_honors_strategy_through_real_pass_execution(self):
+    def test_lower_runs_the_configured_strategy_pipeline(self):
         torch = pytest.importorskip("torch")
         x = torch.zeros(16, 16)
         seen_default: list[str] = []
-        seen_debug: list[str] = []
         default_instrument = passes.CallbackInstrument(
             before_pass=lambda pass_obj, _program: seen_default.append(pass_obj.get_name()),
             name="default",
         )
-        debug_instrument = passes.CallbackInstrument(
-            before_pass=lambda pass_obj, _program: seen_debug.append(pass_obj.get_name()),
-            name="debug",
-        )
         with passes.PassContext([default_instrument]):
-            add_kernel.lower(x, x, torch.empty_like(x))
-        with passes.PassContext([debug_instrument]):
             add_kernel.lower(
                 x,
                 x,
                 torch.empty_like(x),
-                config=RunConfig(strategy=OptimizationStrategy.DebugTileOptimization),
+                config=RunConfig(strategy=OptimizationStrategy.Default),
             )
         assert "ConvertTensorToTileOps" in seen_default
-        assert "ConvertTensorToTileOps" not in seen_debug
 
     def test_lower_supports_signature_and_keyword_modes(self):
         torch = pytest.importorskip("torch")


### PR DESCRIPTION
## Summary

`DebugTileOptimization` existed only to inspect the PTO tile stage without the tensor-only prefix passes. Nothing in the repo compiled with it, and keeping a second recipe meant every pipeline change had to be mirrored in two places and in two doc paragraphs (EN + ZH).

`Default` is now the only `OptimizationStrategy`.

- **`python/pypto/ir/pass_manager.py`** — drop the enum member; collapse the two-branch recipe in `_get_pass_factories` to a single return. The strategy guard moves to the top of the function so an unsupported value still raises `ValueError` instead of silently running `Default`, and short-circuits before the pass-factory tuples are built. The enum is marked `@unique` so duplicate values fail at class-creation time.
- **Tests** — removed the cases whose premise was a two-strategy A/B comparison: the JIT cache-key miss test, the tile-only pipeline run, and the strategy-name assertions. Surviving coverage: `test_none_strategy_differs_from_named_strategy` still proves `strategy` participates in the JIT cache key, and a new `test_pass_manager_rejects_unknown_strategy` covers the validation path.
- **Docs** — EN and ZH updated in lockstep (`00-pass_manager`, `00-pto_codegen`, `01-language_guide`, and the `02` / `42` / `43` pass docs), plus `tests/st/README.md` and the `InferFunctionCoreType` comment in `orchestration_codegen.cpp`.
- Reworded the "two strategies / A/B comparison" docstrings in `jit/cache.py` and `jit/decorator.py`, which described a workflow that no longer exists.

The `strategy` knob itself is kept on `ir.compile()` / `RunConfig` / `PassManager.get_strategy()` / the ST `--strategy` CLI as an extension point; `tests/st/conftest.py` already declared `choices=["Default"]`.

Repo-wide grep for `DebugTileOptimization` returns zero hits.

## Testing

- [x] Full unit suite from the worktree build: **8533 passed, 2 skipped** (both pre-existing/environmental)
- [x] `cmake --build build --parallel` clean; modified C++ file force-recompiled with zero warnings
- [x] clang-tidy on the C++ diff: clean
- [x] ruff (F/E9) on all changed Python files: clean
- [x] `tests/lint/` scripts: EN/ZH doc parity (97 pairs), doc nav, English-only, headers, no-broad-raises — all pass
- [x] Code review completed
- [x] Documentation updated