### PR TITLE
feat(distributed): add HOST-orchestrated builtin.tensor.all_to_all_v

### DIFF
--- a/docs/en/dev/distributed_ops.md
+++ b/docs/en/dev/distributed_ops.md
@@ -34,7 +34,7 @@ There are **thirteen ops** and **four ABI enums**:
 | `pld.tensor.reduce_scatter` | reduce and scatter chunks across ranks | `DistributedTensorType` (same as src) | builtin collective |
 | `pld.tensor.allgather` | gather data from all ranks via window | `DistributedTensorType` (same as src) | builtin collective |
 | `pld.tensor.all_to_all` | push-based symmetric personalized exchange — every rank pushes its per-destination chunks to every peer's window via `pld.tensor.put` (TPUT), returns window as result | `DistributedTensorType` (same as src) | composite / HOST builtin |
-| `pld.tensor.all_to_all_v` | variable-size all-to-all (MPI_Alltoallv) — pushes `min(send_counts[dest], MAX_RECV)` rows per destination into a flat 2D staging window, and publishes that clamped count into peer `recv_counts[my_rank, 0]` via `pld.system.notify` (Set) so the receiver can skip unwritten holes; returns window as result (same window-as-result pattern as symmetric `all_to_all`). Rows beyond a sender's count are not transferred, so those window rows keep their prior contents. InCore only — there is no HOST-orchestration lowering | `DistributedTensorType` (same as target) | composite InCore |
+| `pld.tensor.all_to_all_v` | variable-size all-to-all (MPI_Alltoallv) — pushes the full MAX_RECV-row block per destination into a flat 2D staging window (transfer size is the full per-destination capacity block), and publishes `min(send_counts[dest], MAX_RECV)` into peer `recv_counts[my_rank, 0]` via `pld.system.notify` (Set) so the receiver can skip rows beyond its count; returns window as result (same window-as-result pattern as symmetric `all_to_all`) | `DistributedTensorType` (same as target) | composite / HOST builtin |
 | `pld.system.notify` | signal a peer's slot | `Unknown` (side effect) | TNOTIFY |
 | `pld.system.wait` | block on own slot | `Unknown` (side effect) | TWAIT |
 
@@ -334,7 +334,7 @@ pld.tensor.all_to_all_v(
 ) -> DistributedTensorType(target)
 ```
 
-InCore-only variable-size all-to-all (MPI_Alltoallv). Flat 2D layouts:
+Variable-size all-to-all (MPI_Alltoallv). Flat 2D layouts:
 
 - `input` — Tensor or DistributedTensor `[NR*MAX_RECV, SIZE]`
 - `target` — DistributedTensor `[NR*MAX_RECV, SIZE]` (window-as-result)
@@ -343,11 +343,38 @@ InCore-only variable-size all-to-all (MPI_Alltoallv). Flat 2D layouts:
 - `recv_counts` — DistributedTensor INT32 `[NR, 1]` (InOut recvcounts)
 
 `MAX_RECV = target.shape[0] // NR`. Lowering reads `send_counts[dest]` at
-runtime, clamps to `MAX_RECV`, TPUTs that many rows into the peer window, and
-publishes the **clamped** count into peer `recv_counts[my_rank, 0]` via
-`pld.system.notify` (Set). After the barrier the receiver uses
-`recv_counts[src, 0]` to skip unwritten holes. Rows beyond the count are not
-transferred (window tails keep prior contents).
+runtime, clamps to `MAX_RECV`, and publishes the **clamped** count into peer
+`recv_counts[my_rank, 0]` via `pld.system.notify` (Set). The push itself
+always transfers the full `MAX_RECV`-row capacity block per destination —
+independent of the runtime count — so rows beyond a sender's actual count
+still cross the wire; after the barrier the receiver uses `recv_counts[src, 0]`
+to skip those rows (MPI_Alltoallv semantics apply to the logical result, not
+the wire transfer). On the InCore path the transfer is a compile-time-sized
+`pld.tile.put` (PTOAS requires static partition-view dims); on the HOST path
+the kernel derives `MAX_RECV` at entry from the runtime rank count
+(`target.shape[0] / nranks`), so it is always consistent with the devices
+actually running.
+
+**InCore composite** (`LowerCompositeOps`): the primitive above, decomposed
+into `pld.tile.put` + `pld.system.notify`/`wait` inside a chip kernel.
+
+**HOST builtin** (`LowerHostTensorCollectives`): the same 5-arg call, made
+from a `host_orch` function, lowers per-device to `builtin.tensor.all_to_all_v`
+— an in-kernel-TPUT AIV builtin following the same pattern as
+`builtin.tensor.all_to_all`. `input` and `send_counts` must both be
+window-bound `DistributedTensor`s at this layer (narrower than the composite's
+`AsTensorTypeLike`, forced by the HOST dispatch codegen, which only supports
+window-bound or tile args) — all five operands (`input`, `target`, `signal`,
+`send_counts`, `recv_counts`) must resolve to pairwise-distinct window
+allocations (aliasing any pair is a cross-process race: data-vs-data is a TPUT
+overwrite, data-vs-control is a notify/count write racing a kernel read,
+control-vs-control is a notify racing a count publish). The kernel derives
+`MAX_RECV` at entry as `target.shape[0] / nranks` (the runtime comm-domain
+size), so the block layout is always consistent with the devices actually
+running — no exact `signal.shape[0]` == device-count requirement and no
+per-`MAX_RECV` variant mangling. Not supported inside a `for`/`while` loop in
+`host_orch` (single-use signal protocol) — the same restriction
+`LowerCompositeOps` enforces on the InCore path.
 
 ### `pld.tensor.allreduce`
 
@@ -502,7 +529,8 @@ dispatches before the final `Simplify`.
   `test_l3_allreduce_ring.py` (hand-rolled ring RS+AG), `test_l3_host_tensor_allreduce.py`,
   `test_l3_host_tensor_allreduce_ring.py`,
   `test_l3_ep_dispatch_combine.py`, `test_l3_notify_wait.py`,
-  `test_l3_tensor_all_to_all_v_intrinsic.py`, and related L3 STs
+  `test_l3_tensor_all_to_all_v_intrinsic.py` (InCore composite),
+  `test_l3_host_tensor_all_to_all_v.py` (HOST builtin), and related L3 STs
   under `tests/st/distributed/`. **Put/get canonical e2e contracts** are now
   enabled: `test_l3_put.py` (ring overwrite, row-offset put, atomic-add put, and
   chunked/pipelined transfers ✅), `test_l3_get.py` (ring read, row-offset get ✅),

--- a/docs/en/dev/passes/39-materialize_comm_domain_scopes.md
+++ b/docs/en/dev/passes/39-materialize_comm_domain_scopes.md
@@ -64,7 +64,12 @@ For every host-orchestration function (`Function::level_ == Level::HOST` and
    descriptor to its underlying allocation.
 
 4. **Merge descriptors.** Per allocation, fold every recorded descriptor:
-   any `kAll` ⇒ `kAll`; otherwise union the subsets.
+   any `kAll` ⇒ `kAll`; otherwise union the subsets. A host-level collective's
+   signal (and, for `pld.tensor.all_to_all_v`, its `recv_counts`) carries no
+   `device=` of its own, so it inherits device coverage from the collective's
+   paired data/target allocation instead — a call may register more than one
+   such pairing sharing the same data allocation (`all_to_all_v` registers two:
+   one for `signal`, one for `recv_counts`).
 
 5. **Materialise `WindowBuffer`s.** For each allocation construct
    `WindowBuffer(base = ptr_var, size = size_expr, load_from_host = false,
@@ -100,6 +105,10 @@ The pass raises `pypto::ValueError` (carrying the alloc's span) if:
   or a recognised `pl.range` induction var.
 - Two allocations within the same comm domain share a `name_hint_` (the
   parser already enforces global uniqueness; the pass re-asserts).
+- A `pld.tensor.all_to_all_v` call sits inside a `for`/`while` loop in a HOST
+  orchestrator — its Set(1)/wait≥1 signal is single-use and cannot be reused
+  across dynamic invocations (same restriction `LowerCompositeOps` enforces on
+  the InCore path).
 
 ## Output invariants
 

--- a/docs/en/dev/passes/40-lower_host_tensor_collectives.md
+++ b/docs/en/dev/passes/40-lower_host_tensor_collectives.md
@@ -4,8 +4,8 @@
 
 `LowerHostTensorCollectives` rewrites host-orchestrator calls to
 `pld.tensor.allreduce`, `pld.tensor.barrier`, `pld.tensor.broadcast`,
-`pld.tensor.reduce_scatter`, `pld.tensor.allgather`, and
-`pld.tensor.all_to_all` into compiler-internal
+`pld.tensor.reduce_scatter`, `pld.tensor.allgather`,
+`pld.tensor.all_to_all`, and `pld.tensor.all_to_all_v` into compiler-internal
 builtin chip dispatches. It runs
 after [`MaterializeCommDomainScopes`](39-materialize_comm_domain_scopes.md), so
 each window-bound data tensor and explicit or synthesized signal tensor already has a
@@ -35,6 +35,7 @@ data = pld.tensor.broadcast(data, signal, root=0)
 data = pld.tensor.reduce_scatter(data, signal, op=pld.ReduceOp.Sum)
 data = pld.tensor.allgather(stage, data, signal)
 data = pld.tensor.all_to_all(stage, data, signal)
+data = pld.tensor.all_to_all_v(input, target, signal, send_counts, recv_counts)
 ```
 
 `pld.tensor.allreduce` dispatches on its `mode` kwarg: the default
@@ -42,25 +43,38 @@ data = pld.tensor.all_to_all(stage, data, signal)
 to `builtin.tensor.allreduce_ring`. Any other value is rejected as a user
 error.
 
-For `allgather` / `all_to_all`, `stage` (TPUT source) and `data` (result)
-must be two distinct windows. For `allgather` the `stage` window holds only
-this rank's single chunk and is `[1, SIZE]`; for `all_to_all` it carries one
-per-destination chunk per row and is `[NR, SIZE]`. In both cases `data` is the
-`[NR, SIZE]` result window peers push into.
+For `allgather` / `all_to_all` / `all_to_all_v`, `stage`/`input` (TPUT source)
+and `data`/`target` (result) must be two distinct windows. For `allgather` the
+`stage` window holds only this rank's single chunk and is `[1, SIZE]`; for
+`all_to_all` it carries one per-destination chunk per row and is
+`[NR, SIZE]`; for `all_to_all_v` it carries one `MAX_RECV`-row capacity block
+per destination and is `[NR*MAX_RECV, SIZE]`. In both `all_to_all` /
+`all_to_all_v` cases `data`/`target` is the peers'-push-in result window.
+`all_to_all_v` additionally requires `send_counts` (window-bound at this
+layer, LOCAL-only) and `recv_counts` (window-bound, published cross-rank via
+`pld.system.notify`) — all five window args must resolve into the same
+`CommDomainScopeStmt` and must be pairwise-distinct window allocations
+(aliasing any pair is a cross-process race, whether data-vs-data,
+data-vs-control, or control-vs-control).
 
 The pass emits the corresponding `builtin.tensor.*` dispatch per participating
 device (including `builtin.tensor.allreduce` /
 `builtin.tensor.allreduce_ring`, `builtin.tensor.barrier`,
 `builtin.tensor.broadcast`, `builtin.tensor.reduce_scatter`,
-`builtin.tensor.allgather`, and `builtin.tensor.all_to_all`). When the
-surrounding comm-domain scope has an explicit device list, the pass emits a
-`SeqStmts`; otherwise it emits a sequential `for r in
+`builtin.tensor.allgather`, `builtin.tensor.all_to_all`, and
+`builtin.tensor.all_to_all_v`). When the surrounding comm-domain scope has an
+explicit device list, the pass emits a `SeqStmts`; otherwise it emits a
+sequential `for r in
 pld.system.world_size()` loop.
 
 Each generated builtin call carries the collective-specific args and kwarg
 attributes from the source `pld.tensor.*` call.  Window-bound INOUT tensors
 are threaded through as-is; scalar kwarg values (`op`, `root`, `dtype`) are
-forwarded to the builtin.
+forwarded to the builtin. `all_to_all_v`'s `MAX_RECV` is not a lowering-time
+attribute: the HOST kernel derives it at entry as `target.shape[0] / nranks`
+(the runtime comm-domain size), so no per-`MAX_RECV` codegen variant mangling
+is needed and the block layout stays consistent with the devices actually
+running.
 
 Assignments preserve the user-facing rebind idiom by appending
 `<result> = <original expr>` after the generated builtin calls.
@@ -89,6 +103,15 @@ Ring allreduce currently supports only `ReduceOp.Sum` with `dtype=FP32`.
 `ReduceOp.Max`, `ReduceOp.Min`, `ReduceOp.Prod`, and `FP16` are not yet available
 with `mode="ring"`. Ring allreduce also supports at most 16 participating
 devices (`world_size <= 16`).
+
+`all_to_all_v`'s single-use Set(1)/wait≥1 signal cannot be reused across a
+`for`/`while` loop in `host_orch` — [`MaterializeCommDomainScopes`](39-materialize_comm_domain_scopes.md),
+which runs immediately before this pass, rejects that case up front (the same
+restriction `LowerCompositeOps` enforces on the InCore path). On an explicit
+static device subset, `all_to_all_v`'s signal `shape[0]` must exactly equal
+the subset size (not merely `>=`, as required for the other collectives),
+since `MAX_RECV` is derived as `target.shape[0] / signal.shape[0]` and an
+over-provisioned signal would silently mis-lower.
 
 ## Pass properties
 

--- a/docs/zh/dev/distributed_ops.md
+++ b/docs/zh/dev/distributed_ops.md
@@ -30,7 +30,7 @@ N6 分布式算子族为 Python DSL 提供了对硬件跨 rank（cross-rank）�
 | `pld.tensor.reduce_scatter` | 跨 rank 规约并分散 | `DistributedTensorType`（同 src） | builtin collective |
 | `pld.tensor.allgather` | 从所有 rank 收集数据到窗口 | `DistributedTensorType`（同 src） | builtin collective |
 | `pld.tensor.all_to_all` | 基于推送的对称个性化交换——每个 rank 通过 `pld.tensor.put`（TPUT）将自己的各目标 block 推送到每个对等方的窗口中，返回窗口作为结果 | `DistributedTensorType`（同 src） | composite / HOST builtin |
-| `pld.tensor.all_to_all_v` | 变长 all-to-all（MPI_Alltoallv）——按 `min(send_counts[dest], MAX_RECV)` 向每个目标推送对应行数，写入平面 2D 暂存窗口，同时通过 `pld.system.notify`（Set）把该钳制后的计数发布到对端 `recv_counts[my_rank, 0]`，使接收方能跳过未写入的空洞；返回窗口作为结果（与对称 `all_to_all` 相同的窗口即结果模式）。超出发送方计数的行不会传输，因此窗口中这些行保留原有内容。仅支持 InCore——没有 HOST 编排层的下降实现 | `DistributedTensorType`（与 target 相同） | composite InCore |
+| `pld.tensor.all_to_all_v` | 变长 all-to-all（MPI_Alltoallv）——按每个目标推送完整的 MAX_RECV 行容量块，写入平面 2D 暂存窗口（传输大小是每个目标完整的容量块），同时通过 `pld.system.notify`（Set）把 `min(send_counts[dest], MAX_RECV)` 发布到对端 `recv_counts[my_rank, 0]`，使接收方能跳过超出其计数的行；返回窗口作为结果（与对称 `all_to_all` 相同的窗口即结果模式） | `DistributedTensorType`（与 target 相同） | composite / HOST builtin |
 | `pld.system.notify` | 给 peer 的槽位发信号 | `Unknown`（副作用） | TNOTIFY |
 | `pld.system.wait` | 在自身槽位上阻塞 | `Unknown`（副作用） | TWAIT |
 
@@ -293,7 +293,7 @@ pld.tensor.all_to_all_v(
 ) -> DistributedTensorType(target)
 ```
 
-仅 InCore 的变长 all-to-all（MPI_Alltoallv）。平面 2D 布局：
+变长 all-to-all（MPI_Alltoallv）。平面 2D 布局：
 
 - `input` — Tensor 或 DistributedTensor `[NR*MAX_RECV, SIZE]`
 - `target` — DistributedTensor `[NR*MAX_RECV, SIZE]`（窗口即结果）
@@ -302,9 +302,31 @@ pld.tensor.all_to_all_v(
 - `recv_counts` — DistributedTensor INT32 `[NR, 1]`（InOut recvcounts）
 
 `MAX_RECV = target.shape[0] // NR`。降级在运行时读取 `send_counts[dest]`、钳制到
-`MAX_RECV`、按该行数 TPUT 到对端窗口，并把**钳制后**的计数通过
-`pld.system.notify`（Set）写入对端 `recv_counts[my_rank, 0]`。屏障之后接收方用
-`recv_counts[src, 0]` 跳过未写入的空洞。计数之外的行不传输（窗口尾部保留原有内容）。
+`MAX_RECV`，并把**钳制后**的计数通过 `pld.system.notify`（Set）写入对端
+`recv_counts[my_rank, 0]`。推送本身总是传输每个目标完整的 `MAX_RECV` 行容量
+块——与运行时计数无关——因此超出发送方实际计数的行也会经过链路传输；屏障之后
+接收方用 `recv_counts[src, 0]` 跳过这些行（MPI_Alltoallv 语义适用于逻辑结果，
+而非链路传输本身）。InCore 路径的传输是编译期定长的 `pld.tile.put`（PTOAS 要求
+静态 partition-view 维度）；HOST 路径的内核在入口根据运行时 rank 数推导
+`MAX_RECV`（`target.shape[0] / nranks`），因此始终与实际运行的设备数一致。
+
+**InCore composite**（`LowerCompositeOps`）：上述原语在芯片内核中被分解为
+`pld.tile.put` + `pld.system.notify`/`wait`。
+
+**HOST builtin**（`LowerHostTensorCollectives`）：同样的 5 参数调用，在
+`host_orch` 函数中发起时，会按设备下降为 `builtin.tensor.all_to_all_v`——
+一个内核内 TPUT 的 AIV builtin，遵循与 `builtin.tensor.all_to_all` 相同的模式。
+在这一层，`input` 与 `send_counts` 都必须是窗口绑定的 `DistributedTensor`（比
+composite 的 `AsTensorTypeLike` 更严格，这是 HOST 派发代码生成强制要求的——
+它只支持窗口绑定或 tile 参数）——五个操作数（`input`、`target`、`signal`、
+`send_counts`、`recv_counts`）必须两两解析到不同的窗口分配（任意一对发生别名
+都是跨进程竞争：data 与 data 之间是 TPUT 覆盖，data 与 control 之间是
+notify/count 写入与内核读取竞争，control 与 control 之间是 notify 与 count
+发布竞争）。内核在入口把 `MAX_RECV` 推导为 `target.shape[0] / nranks`（运行时
+通信域大小），因此块布局始终与实际运行的设备数一致——不再需要
+`signal.shape[0]` 与设备数**精确相等**的要求，也不再需要按 `MAX_RECV` 进行
+variant 混入。不支持在 `host_orch` 的 `for`/`while` 循环内调用（单次使用
+的信号协议）——与 `LowerCompositeOps` 在 InCore 路径上强制的限制相同。
 
 ### `pld.tensor.allreduce`
 
@@ -440,7 +462,8 @@ host_orch 函数体包裹进嵌套的 `CommDomainScopeStmt` 节点（按推断�
   `test_l3_allreduce_ring.py`（手写 ring RS+AG）、
   `test_l3_host_tensor_allreduce.py`、`test_l3_host_tensor_allreduce_ring.py`、
   `test_l3_ep_dispatch_combine.py`、`test_l3_notify_wait.py`、
-  `test_l3_tensor_all_to_all_v_intrinsic.py`，以及
+  `test_l3_tensor_all_to_all_v_intrinsic.py`（InCore composite）、
+  `test_l3_host_tensor_all_to_all_v.py`（HOST builtin），以及
   `tests/st/distributed/` 下其他 L3 ST。**Put/Get 端到端权威契约** 已启用：
   `test_l3_put.py`（环形覆写、行偏移 put、原子加 put、分块/流水 transfer ✅）、
   `test_l3_get.py`（环形读、行偏移 get ✅）、以及 `test_l3_remote_store.py`

--- a/docs/zh/dev/passes/39-materialize_comm_domain_scopes.md
+++ b/docs/zh/dev/passes/39-materialize_comm_domain_scopes.md
@@ -57,7 +57,11 @@ alloc / view / dispatch 点在此时仍然可见。放在较晚阶段还能让�
    每个位置参数若是已记录的 view Var，就向对应 alloc 追加该描述符。
 
 4. **合并描述符**。对每个 alloc 折叠记录到的所有描述符：任何 `kAll` ⇒ `kAll`；
-   否则取 subset 并集。
+   否则取 subset 并集。HOST 级 collective 的 signal（以及
+   `pld.tensor.all_to_all_v` 的 `recv_counts`）自身没有 `device=`，因此从
+   collective 配对的 data/target alloc 继承设备覆盖范围——一次调用可以注册
+   多个共享同一 data alloc 的配对（`all_to_all_v` 会注册两个：一个用于
+   `signal`，一个用于 `recv_counts`）。
 
 5. **构造 `WindowBuffer`**。对每个 alloc 构造
    `WindowBuffer(base = ptr_var, size = size_expr, load_from_host = false,
@@ -85,6 +89,9 @@ alloc / view / dispatch 点在此时仍然可见。放在较晚阶段还能让�
   归纳变量。
 - 同一 comm-domain scope 内 `name_hint_` 重名（parser 已在程序范围内做了唯一性
   校验，本 pass 再次断言）。
+- `pld.tensor.all_to_all_v` 调用位于 HOST orchestrator 的 `for`/`while`
+  循环内——其 Set(1)/wait≥1 信号是单次使用的，无法在动态调用间复用（与
+  `LowerCompositeOps` 在 InCore 路径上强制的限制相同）。
 
 ## 输出不变量
 

--- a/docs/zh/dev/passes/40-lower_host_tensor_collectives.md
+++ b/docs/zh/dev/passes/40-lower_host_tensor_collectives.md
@@ -4,8 +4,8 @@
 
 `LowerHostTensorCollectives` 将 host orchestrator 中的
 `pld.tensor.allreduce`、`pld.tensor.barrier`、`pld.tensor.broadcast`、
-`pld.tensor.reduce_scatter`、`pld.tensor.allgather` 和
-`pld.tensor.all_to_all` 调用改写为编译器内部的
+`pld.tensor.reduce_scatter`、`pld.tensor.allgather`、
+`pld.tensor.all_to_all` 和 `pld.tensor.all_to_all_v` 调用改写为编译器内部的
 builtin chip dispatch。它在 [`MaterializeCommDomainScopes`](39-materialize_comm_domain_scopes.md) 之后运行，
 因此 window 绑定的 data tensor 和用户显式传入或编译器合成的 signal tensor 已经带有
 `WindowBuffer` 反向引用，并属于推断出的通信域。
@@ -34,28 +34,39 @@ data = pld.tensor.broadcast(data, signal, root=0)
 data = pld.tensor.reduce_scatter(data, signal, op=pld.ReduceOp.Sum)
 data = pld.tensor.allgather(stage, data, signal)
 data = pld.tensor.all_to_all(stage, data, signal)
+data = pld.tensor.all_to_all_v(input, target, signal, send_counts, recv_counts)
 ```
 
 `pld.tensor.allreduce` 根据 `mode` kwarg 进行分发：默认 `mode="mesh"` 会 lower 到
 `builtin.tensor.allreduce`，而 `mode="ring"` 会 lower 到
 `builtin.tensor.allreduce_ring`。其他取值将作为用户错误被拒绝。
 
-对于 `allgather` / `all_to_all`，`stage`（TPUT 源）与 `data`（结果）
-必须是两个不同的 window。`allgather` 的 `stage` 只保存本 rank 的单个分片，
-形状为 `[1, SIZE]`；`all_to_all` 的 `stage` 每行携带一个按目的地划分的分片，
-形状为 `[NR, SIZE]`。两种情况下 `data` 都是 peer 推入的 `[NR, SIZE]` 结果窗口。
+对于 `allgather` / `all_to_all` / `all_to_all_v`，`stage`/`input`（TPUT 源）
+与 `data`/`target`（结果）必须是两个不同的 window。`allgather` 的 `stage`
+只保存本 rank 的单个分片，形状为 `[1, SIZE]`；`all_to_all` 的 `stage` 每行
+携带一个按目的地划分的分片，形状为 `[NR, SIZE]`；`all_to_all_v` 的 `input`
+每个目的地携带一个 `MAX_RECV` 行容量块，形状为 `[NR*MAX_RECV, SIZE]`。
+`all_to_all` / `all_to_all_v` 两种情况下 `data`/`target` 都是 peer 推入的
+结果窗口。`all_to_all_v` 还额外要求 `send_counts`（在这一层是窗口绑定的，
+仅本地使用）和 `recv_counts`（窗口绑定，通过 `pld.system.notify` 跨 rank
+发布）——五个窗口参数都必须位于同一个 `CommDomainScopeStmt` 中，并且必须
+两两互不相同（任意一对发生别名都是跨进程竞争，无论是 data 与 data、
+data 与 control，还是 control 与 control 之间）。
 
 本 pass 会为每个参与设备生成对应的 `builtin.tensor.*` 调用（如
 `builtin.tensor.allreduce`、`builtin.tensor.allreduce_ring`、
 `builtin.tensor.barrier`、`builtin.tensor.broadcast`、
 `builtin.tensor.reduce_scatter`、`builtin.tensor.allgather`、
-`builtin.tensor.all_to_all`）。若外层
+`builtin.tensor.all_to_all`、`builtin.tensor.all_to_all_v`）。若外层
 comm-domain scope 带有显式 device 列表，则生成 `SeqStmts`；否则生成顺序
 `for r in pld.system.world_size()` 循环。
 
 每个生成的 builtin call 携带来源 `pld.tensor.*` 调用中 collective 特定的
 参数和 kwarg 属性。窗口绑定的 INOUT tensor 原样传递；标量 kwarg 值
-（`op`、`root`、`dtype`）转发给 builtin。
+（`op`、`root`、`dtype`）转发给 builtin。`all_to_all_v` 的 `MAX_RECV` 不是
+lowering 时的属性：HOST 内核在入口把它推导为 `target.shape[0] / nranks`
+（运行时通信域大小），因此不再需要按 `MAX_RECV` 进行代码生成的 variant
+混入，块布局也始终与实际运行的设备数一致。
 
 若用户代码使用赋值形式，pass 会在生成的 builtin 调用之后追加
 `<result> = <original expr>`，保留 public API 的 rebind 语义。
@@ -77,6 +88,15 @@ Ring allreduce 目前仅支持 `ReduceOp.Sum` 和 `dtype=FP32`。
 `ReduceOp.Max`、`ReduceOp.Min`、`ReduceOp.Prod` 以及 `FP16` 在
 `mode="ring"` 下尚未支持。Ring allreduce 最多支持 16 个参与设备
 （`world_size <= 16`）。
+
+`all_to_all_v` 的单次使用 Set(1)/wait≥1 信号无法在 `host_orch` 的
+`for`/`while` 循环中复用——本 pass 之前紧邻运行的
+[`MaterializeCommDomainScopes`](39-materialize_comm_domain_scopes.md) 会提前
+拒绝这种情况（与 `LowerCompositeOps` 在 InCore 路径上强制的限制相同）。在显式
+静态 device 子集上，`all_to_all_v` 的 signal `shape[0]` 必须与子集大小
+**精确相等**（而非其他 collective 所要求的 `>=`），因为 `MAX_RECV` 是由
+`target.shape[0] / signal.shape[0]` 推导得出的，signal 过度分配会导致
+静默的错误降级。
 
 ## Pass 属性
 

--- a/python/pypto/ir/op/distributed/tensor_ops.py
+++ b/python/pypto/ir/op/distributed/tensor_ops.py
@@ -398,8 +398,10 @@ def all_to_all_v(
     per-source valid-row counts after the barrier (published via
     ``pld.system.notify`` as ``min(send_counts[dest], MAX_RECV)``). Powered by
     LowerCompositeOps into a 2-phase push-based decomposition (push → barrier),
-    returning the target window. The caller reads back from the window with
-    ``pl.load``, using ``recv_counts[src, 0]`` to skip unwritten holes.
+    returning the target window. Each push transfers a full MAX_RECV-row
+    capacity block regardless of the runtime count; the caller reads back
+    from the window with ``pl.load``, using ``recv_counts[src, 0]`` to know
+    how many of the physically-transferred rows are logically valid.
 
     ``send_counts`` is read at runtime, so the counts may be data-dependent;
     each count is clamped to the per-peer capacity ``MAX_RECV =

--- a/python/pypto/language/distributed/op/tensor_ops.py
+++ b/python/pypto/language/distributed/op/tensor_ops.py
@@ -886,9 +886,10 @@ def all_to_all_v(
     5-arg form: ``pld.tensor.all_to_all_v(input, target, signal, send_counts,
     recv_counts)``.
 
-    Each rank sends ``send_counts[dest]`` rows to peer ``dest`` — the counts are
-    read at runtime, so they may be data-dependent (e.g. MoE tokens per expert),
-    and only those rows cross the interconnect.  Mirrors the symmetric
+    Each rank pushes a full ``MAX_RECV``-row capacity block to peer ``dest``;
+    only ``send_counts[dest]`` of those rows are logically valid — the counts
+    are read at runtime, so they may be data-dependent (e.g. MoE tokens per
+    expert), but they do not change the transfer size.  Mirrors the symmetric
     ``pld.tensor.all_to_all`` otherwise: rows are pushed into a flat 2D staging
     window via ``pld.tile.put``, and the window is returned so the caller can
     read back via ``pl.load``.  There is no built-in read-back phase — the user
@@ -900,21 +901,24 @@ def all_to_all_v(
     [NR*MAX_RECV, SIZE] — the staging window that doubles as the result;
     rank ``src``'s rows land at ``src*MAX_RECV ...``.
 
-    ``MAX_RECV = target.shape[0] // NR`` is the compile-time per-peer
-    *capacity*, not the transfer size: it fixes the row-index arithmetic so a
-    receiver can locate each sender's block without knowing that sender's
-    count.  Counts are clamped to ``MAX_RECV``.  Rows beyond a sender's count
-    are never written, so those window rows keep their prior contents — as with
-    ``MPI_Alltoallv``, the untouched tail of the receive buffer is not zeroed.
-    Zero it yourself if the read-back path relies on it.
+    ``MAX_RECV = target.shape[0] // NR`` is both the compile-time per-peer
+    *capacity* and the fixed transfer size: it fixes the row-index arithmetic
+    so a receiver can locate each sender's block without knowing that
+    sender's count, and every push transfers exactly ``MAX_RECV`` rows
+    regardless of the runtime count.  Counts are clamped to ``MAX_RECV``.
+    Rows beyond a sender's count still physically cross the wire but are
+    logically invalid — as with ``MPI_Alltoallv``, the receiver must not read
+    past its published ``recv_counts`` entry; the tail is not zeroed, so
+    treat it as containing stale/undefined data, not zeros.
 
     During the same push, each rank also publishes
     ``min(send_counts[dest], MAX_RECV)`` into peer ``dest``'s
     ``recv_counts[my_rank, 0]`` via ``pld.system.notify`` (Set). After the
-    barrier, ``recv_counts[src, 0]`` tells this rank how many valid rows ``src``
-    wrote — use that count to skip the unwritten holes. This is the
-    MPI_Alltoallv recvcounts side (published value equals rows actually
-    transferred).
+    barrier, ``recv_counts[src, 0]`` tells this rank how many of the
+    physically-transferred rows from ``src`` are logically valid — use that
+    count to know where to stop reading. This is the MPI_Alltoallv recvcounts
+    side (published value is the clamped logical count, not the physical
+    transfer size).
 
     The barrier ``signal`` is single-use (same Set(1)/wait≥1 protocol as
     allreduce) and must not be reused inside a ``for``/``while`` loop.

--- a/python/pypto/runtime/builtins/collectives/all_to_all_v/__init__.py
+++ b/python/pypto/runtime/builtins/collectives/all_to_all_v/__init__.py
@@ -1,0 +1,9 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""All-to-all-v (variable-size) builtin source templates."""

--- a/python/pypto/runtime/builtins/collectives/all_to_all_v/templates/entry.cpp.in
+++ b/python/pypto/runtime/builtins/collectives/all_to_all_v/templates/entry.cpp.in
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+// Generated from {{template_package}}.
+
+#include <cstdint>
+
+#include "pto_orchestration_api.h"
+
+namespace {
+
+template <typename DType>
+void submit_all_to_all_v_kernel(const L2TaskArgs &orch_args) {
+  const Tensor &input = orch_args.tensor(0).ref();
+  const Tensor &target = orch_args.tensor(1).ref();
+  const Tensor &signal = orch_args.tensor(2).ref();
+  const Tensor &send_counts = orch_args.tensor(3).ref();
+  const Tensor &recv_counts = orch_args.tensor(4).ref();
+
+  L0TaskArgs params;
+  params.add_input(input);
+  params.add_inout(target);
+  params.add_inout(signal);
+  params.add_input(send_counts);
+  params.add_inout(recv_counts);
+  params.add_scalar(orch_args.scalar(0));  // nranks
+  params.add_scalar(orch_args.scalar(1));  // CommContext device pointer
+  rt_submit_aiv_task(0, params);
+}
+
+}  // namespace
+
+extern "C" {
+
+__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(
+    const L2TaskArgs &orch_args) {
+  (void)orch_args;
+  return PTO2OrchestrationConfig{
+      .expected_arg_count = 7,
+  };
+}
+
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const L2TaskArgs &orch_args) {
+  submit_all_to_all_v_kernel<{{dtype_cpp}}>(orch_args);
+}
+
+__attribute__((visibility("default"))) void {{entry}}(const L2TaskArgs &orch_args) {
+  aicpu_orchestration_entry(orch_args);
+}
+
+}  // extern "C"

--- a/python/pypto/runtime/builtins/collectives/all_to_all_v/templates/kernel.cpp.in
+++ b/python/pypto/runtime/builtins/collectives/all_to_all_v/templates/kernel.cpp.in
@@ -1,0 +1,182 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+// Generated from {{template_package}}.
+
+#include <cstdint>
+#include <pto/pto-inst.hpp>
+
+#include "platform_comm/comm_context.h"
+#include "pto/comm/comm_types.hpp"
+#include "pto/comm/pto_comm_inst.hpp"
+#include "tensor.h"
+
+#ifndef __gm__
+#define __gm__
+#endif
+
+#ifndef __aicore__
+#define __aicore__ [aicore]
+#endif
+
+namespace {
+
+static constexpr int64_t kTileCount = 256;
+static constexpr int kMaxSupportedRanks = 16;
+
+template <typename T>
+AICORE inline __gm__ T *CommRemotePtr(__gm__ CommContext *ctx, __gm__ T *local_ptr, int pe) {
+  uint64_t local_base = ctx->windowsIn[ctx->rankId];
+  uint64_t offset = reinterpret_cast<uint64_t>(local_ptr) - local_base;
+  return reinterpret_cast<__gm__ T *>(ctx->windowsIn[pe] + offset);
+}
+
+}  // namespace
+
+extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ int64_t *args) {
+  __gm__ Tensor *input_tensor = reinterpret_cast<__gm__ Tensor *>(args[0]);
+  __gm__ Tensor *target_tensor = reinterpret_cast<__gm__ Tensor *>(args[1]);
+  __gm__ Tensor *signal_tensor = reinterpret_cast<__gm__ Tensor *>(args[2]);
+  __gm__ Tensor *send_counts_tensor = reinterpret_cast<__gm__ Tensor *>(args[3]);
+  __gm__ Tensor *recv_counts_tensor = reinterpret_cast<__gm__ Tensor *>(args[4]);
+  int nranks = static_cast<int>(args[5]);
+  __gm__ CommContext *comm_ctx = reinterpret_cast<__gm__ CommContext *>(args[6]);
+
+  if (nranks <= 0 || nranks > kMaxSupportedRanks) {
+    pipe_barrier(PIPE_ALL);
+    return;
+  }
+
+  int my_rank = static_cast<int>(comm_ctx->rankId);
+
+  // MAX_RECV = target.shape[0] / nranks. target is 2D [NR*MAX_RECV, SIZE] and
+  // nranks is the comm-domain size (dispatch scalar 0), so the block geometry
+  // below is always consistent with the rank count this kernel actually runs
+  // on. Deriving it here instead of baking it at codegen time closes the
+  // dynamic-domain hazard where signal.shape[0] is not tied to the runtime
+  // world size (an over-provisioned signal would otherwise silently change
+  // the per-destination block size).
+  int64_t max_recv = static_cast<int64_t>(target_tensor->shapes[0]) / nranks;
+  if (max_recv <= 0) {
+    pipe_barrier(PIPE_ALL);
+    return;
+  }
+
+  // row_numel = SIZE (target is 2D [NR*MAX_RECV, SIZE]).
+  int64_t row_numel = 1;
+  for (uint32_t dim = 1; dim < target_tensor->ndims; ++dim) {
+    row_numel *= static_cast<int64_t>(target_tensor->shapes[dim]);
+  }
+  if (row_numel <= 0) {
+    pipe_barrier(PIPE_ALL);
+    return;
+  }
+
+  // `input` and `target` are two DISTINCT windows — same same-window-race
+  // rationale as the symmetric all_to_all kernel.
+  __gm__ {{dtype_cpp}} *input_local =
+      reinterpret_cast<__gm__ {{dtype_cpp}} *>(input_tensor->buffer.addr) + input_tensor->start_offset;
+  __gm__ {{dtype_cpp}} *target =
+      reinterpret_cast<__gm__ {{dtype_cpp}} *>(target_tensor->buffer.addr) + target_tensor->start_offset;
+  __gm__ int32_t *signal_base =
+      reinterpret_cast<__gm__ int32_t *>(signal_tensor->buffer.addr) + signal_tensor->start_offset;
+  __gm__ int32_t *send_counts_base =
+      reinterpret_cast<__gm__ int32_t *>(send_counts_tensor->buffer.addr) + send_counts_tensor->start_offset;
+  __gm__ int32_t *recv_counts_base =
+      reinterpret_cast<__gm__ int32_t *>(recv_counts_tensor->buffer.addr) + recv_counts_tensor->start_offset;
+
+  using ShapeDyn = pto::Shape<pto::DYNAMIC, pto::DYNAMIC, pto::DYNAMIC, pto::DYNAMIC, pto::DYNAMIC>;
+  using StrideDyn = pto::Stride<pto::DYNAMIC, pto::DYNAMIC, pto::DYNAMIC, pto::DYNAMIC, pto::DYNAMIC>;
+  using Global = pto::GlobalTensor<{{dtype_cpp}}, ShapeDyn, StrideDyn, pto::Layout::ND>;
+  using TileData = pto::Tile<pto::TileType::Vec, {{dtype_cpp}}, 1, kTileCount, pto::BLayout::RowMajor, -1, -1>;
+
+  int tile_cols = static_cast<int>(row_numel < kTileCount ? row_numel : kTileCount);
+  TileData send_tile(1, tile_cols);
+  TASSIGN(send_tile, 0x10000);
+
+  // ==================================================================
+  // Phase 1: per-destination push + inline count publish. Include self
+  // (dest == my_rank), matching HCCL identity / the InCore composite's
+  // EmitFor over [0, nranks) with no self-exclusion.
+  //
+  //   rows = min(send_counts[dest], max_recv)   -- runtime scalar, clamped
+  //          (no floor at 0 — matches LowerTensorAllToAllVRule's
+  //          MakeMin(cast(count, INDEX), max_recv) exactly, so HOST and
+  //          InCore agree bit-for-bit on a negative send_counts input)
+  //   TNOTIFY(recv_counts[dest]'s window, slot my_rank) = rows  (Set)
+  //   TPUT input[dest*max_recv : (dest+1)*max_recv, :]
+  //        -> target[my_rank*max_recv : (my_rank+1)*max_recv, :]
+  //
+  // The TPUT ALWAYS transfers the full max_recv-row block, regardless of
+  // `rows` — this reproduces LowerTensorAllToAllVRule exactly (its
+  // pld.tile.put transfer_shape is the compile-time {max_recv, SIZE}, never
+  // gated by the runtime count). Rows beyond a sender's `rows` therefore
+  // DO cross the interconnect (as whatever bytes happen to be in that
+  // capacity slot of `input`); the receiver skips them via recv_counts.
+  // This is intentional InCore/HOST parity, not a shortcut: it keeps the
+  // two lowering paths bit-for-bit identical on the wire and avoids a
+  // second, functionally divergent all_to_all_v implementation.
+  // ==================================================================
+  for (int dest = 0; dest < nranks; ++dest) {
+    int32_t raw_count = send_counts_base[dest];
+    int64_t rows64 = static_cast<int64_t>(raw_count);
+    if (rows64 > max_recv) rows64 = max_recv;
+    int32_t rows = static_cast<int32_t>(rows64);
+
+    __gm__ int32_t *remote_recv_slot = CommRemotePtr(comm_ctx, recv_counts_base + my_rank, dest);
+    pto::comm::Signal count_sig(remote_recv_slot);
+    pto::comm::TNOTIFY(count_sig, rows, pto::comm::NotifyOp::Set);
+
+    int64_t src_row_offset = static_cast<int64_t>(dest) * max_recv * row_numel;
+    int64_t dst_row_offset = static_cast<int64_t>(my_rank) * max_recv * row_numel;
+    __gm__ {{dtype_cpp}} *remote_block = CommRemotePtr(comm_ctx, target + dst_row_offset, dest);
+
+    // The per-destination block [max_recv, SIZE] is contiguous in the dense
+    // row-major [NR*max_recv, SIZE] layout, so it is flattened into one
+    // 1D-chunked TPUT loop (same tiling shape as symmetric all_to_all's
+    // single-row loop, generalized to max_recv*row_numel elements).
+    int64_t block_numel = max_recv * row_numel;
+    for (int64_t base = 0; base < block_numel; base += tile_cols) {
+      int64_t chunk64 = block_numel - base;
+      if (chunk64 > tile_cols) chunk64 = tile_cols;
+      int chunk = static_cast<int>(chunk64);
+      send_tile.ColMaskInternal = chunk;
+
+      ShapeDyn shape(1, 1, 1, 1, chunk);
+      StrideDyn stride(chunk, chunk, chunk, chunk, 1);
+      Global src_g(input_local + src_row_offset + base, shape, stride);
+      Global dst_g(remote_block + base, shape, stride);
+
+      pipe_barrier(PIPE_ALL);
+      pto::comm::TPUT(dst_g, src_g, send_tile);
+      pipe_barrier(PIPE_ALL);
+    }
+  }
+
+  // ==================================================================
+  // Phase 2: barrier — notify peers and wait for all (NotifyOp::Set).
+  // ==================================================================
+  pipe_barrier(PIPE_ALL);
+  dsb(DSB_DDR);
+  for (int peer = 0; peer < nranks; ++peer) {
+    if (peer == my_rank) continue;
+    __gm__ int32_t *remote_signal = CommRemotePtr(comm_ctx, signal_base + my_rank, peer);
+    pto::comm::Signal sig(remote_signal);
+    pto::comm::TNOTIFY(sig, static_cast<int32_t>(1), pto::comm::NotifyOp::Set);
+  }
+  for (int peer = 0; peer < nranks; ++peer) {
+    if (peer == my_rank) continue;
+    pto::comm::Signal sig(signal_base + peer);
+    pto::comm::TWAIT(sig, static_cast<int32_t>(1), pto::comm::WaitCmp::GE);
+  }
+
+  pipe_barrier(PIPE_ALL);
+}

--- a/python/pypto/runtime/builtins/collectives/all_to_all_v/templates/kernel_config.py.in
+++ b/python/pypto/runtime/builtins/collectives/all_to_all_v/templates/kernel_config.py.in
@@ -1,0 +1,27 @@
+# Kernel and Orchestration Configuration
+from pathlib import Path
+
+from simpler.task_interface import ArgDirection as _D
+
+_ROOT_DIR = Path(__file__).parent
+
+RUNTIME_CONFIG = {
+    "runtime": "tensormap_and_ringbuffer",
+    "aicpu_thread_num": 0,
+}
+
+ORCHESTRATION = {
+    "source": str(_ROOT_DIR / "orchestration" / "{{entry}}.cpp"),
+    "function_name": "aicpu_orchestration_entry",
+    "signature": [_D.IN, _D.OUT, _D.OUT, _D.IN, _D.OUT],
+}
+
+KERNELS = [
+    {
+        "func_id": 0,
+        "name": "{{kernel_name}}",
+        "source": str(_ROOT_DIR / "kernels" / "aiv" / "{{kernel_name}}.cpp"),
+        "core_type": "aiv",
+        "signature": [_D.IN, _D.OUT, _D.OUT, _D.IN, _D.OUT],
+    },
+]

--- a/src/codegen/distributed/distributed_ops_codegen.cpp
+++ b/src/codegen/distributed/distributed_ops_codegen.cpp
@@ -347,6 +347,22 @@ REGISTER_DISTRIBUTED_OP(builtin_tensor_all_to_all, "builtin.tensor.all_to_all") 
 }
 
 // ============================================================================
+// builtin.tensor.all_to_all_v: compiler-generated chip dispatch for pld.tensor.all_to_all_v.
+// ============================================================================
+REGISTER_DISTRIBUTED_OP(builtin_tensor_all_to_all_v, "builtin.tensor.all_to_all_v") {
+  auto* dist_codegen = dynamic_cast<DistributedCodegen*>(&codegen);
+  INTERNAL_CHECK(dist_codegen) << "builtin.tensor.all_to_all_v codegen requires DistributedCodegen";
+  const auto dtype = op->GetAttr<DataType>("dtype");
+  const std::string variant = op->op_->name_ + "__" + Fp32VariantSuffix(dtype);
+
+  if (dist_codegen->MarkBuiltinEmitted(variant)) {
+    dist_codegen->RecordBuiltinNextLevel(op, variant, {{"dtype_cpp", Fp32TypeCpp(dtype)}});
+  }
+  EmitBuiltinWindowCollectiveDispatch(*dist_codegen, op, variant);
+  return "";
+}
+
+// ============================================================================
 // tensor.slice — emit Python tensor indexing into ``tensors[...]``.
 //
 // IR form:

--- a/src/ir/op/distributed/collective.cpp
+++ b/src/ir/op/distributed/collective.cpp
@@ -30,6 +30,7 @@
  * The seven builtin.tensor.* ops are internal chip-dispatch targets emitted by the
  * host-orchestrator lowering pass (LowerHostTensorCollectives):
  * builtin.tensor.{allreduce,allreduce_ring,barrier,broadcast,reduce_scatter,allgather,all_to_all}.
+ * builtin.tensor.{allreduce,barrier,broadcast,reduce_scatter,allgather,all_to_all,all_to_all_v}.
  */
 
 #include <any>
@@ -654,18 +655,23 @@ TypePtr DeduceTensorAllToAllVType(const std::vector<ExprPtr>& args,
 REGISTER_OP("pld.tensor.all_to_all_v")
     .set_description(
         "All-to-all: variable-size personalized exchange (push-based, "
-        "window-as-result).  Each rank pushes ``send_counts[dest]`` rows — a "
-        "runtime, data-dependent count — to each peer via ``pld.tile.put``, "
-        "into a 2D staging window [NR*MAX_RECV, SIZE] addressed with flat "
-        "row-index arithmetic ``dest*MAX_RECV+r``.  MAX_RECV is the "
-        "compile-time per-peer capacity; counts above it are clamped.  Rows "
-        "beyond a sender's count are not transferred, so the corresponding "
-        "receive-window rows keep their prior contents (MPI_Alltoallv "
-        "semantics).  During the same push phase each rank also publishes "
+        "window-as-result).  Each rank pushes a full MAX_RECV-row capacity "
+        "block to each peer via ``pld.tile.put``, into a 2D staging window "
+        "[NR*MAX_RECV, SIZE] addressed with flat row-index arithmetic "
+        "``dest*MAX_RECV+r``; only ``send_counts[dest]`` of those rows — a "
+        "runtime, data-dependent count — are logically valid.  MAX_RECV is "
+        "the compile-time per-peer capacity; counts above it are clamped.  "
+        "The push always transfers the full MAX_RECV-row capacity block per "
+        "destination (a compile-time-sized ``pld.tile.put``, independent of "
+        "the runtime count) — rows beyond a sender's actual count still cross "
+        "the wire, but the receiver skips them using ``recv_counts`` "
+        "(MPI_Alltoallv semantics apply to the logical result, not the wire "
+        "transfer).  During the same push phase each rank also publishes "
         "``min(send_counts[dest], MAX_RECV)`` into peer ``dest``'s "
         "``recv_counts[my_rank, 0]`` via ``pld.system.notify`` (Set) — the "
-        "receive-side count vector (MPI_Alltoallv recvcounts; equal to rows "
-        "actually written) so the receiver can skip unwritten holes. "
+        "receive-side count vector (MPI_Alltoallv recvcounts) identifying how "
+        "many of the physically-transferred rows are logically valid, so the "
+        "receiver can skip the rest. "
         "Returns the target window so the caller can read back via "
         "``tile.load`` — same pattern as the symmetric "
         "``pld.tensor.all_to_all`` intrinsic.")
@@ -1019,6 +1025,160 @@ REGISTER_OP("builtin.tensor.all_to_all")
     .set_internal_only(true)
     .set_template_dir(":pypto.runtime.builtins.collectives.all_to_all")
     .f_deduce_type(DeduceBuiltinTensorAllToAllType);
+
+// ============================================================================
+// builtin.tensor.all_to_all_v — host dispatch for pld.tensor.all_to_all_v
+// ============================================================================
+
+namespace {
+
+TypePtr DeduceBuiltinTensorAllToAllVType(const std::vector<ExprPtr>& args,
+                                         const std::vector<std::pair<std::string, std::any>>& kwargs) {
+  constexpr const char* kOpName = "builtin.tensor.all_to_all_v";
+  CHECK(args.size() == 5) << kOpName
+                          << " requires exactly 5 positional arguments "
+                             "(input, target, signal, send_counts, recv_counts), but got "
+                          << args.size();
+  for (size_t i = 0; i < args.size(); ++i) {
+    CHECK(args[i]) << kOpName << " positional argument #" << i << " must not be null";
+  }
+  // input and target must be different windows (same-expression guard; two
+  // distinct pld.window(...) views over one alloc are caught later, at
+  // lowering time, by CheckDistinctInputTargetWindows against the
+  // materialized WindowBuffer — same discipline as builtin.tensor.all_to_all).
+  CHECK(args[0].get() != args[1].get())
+      << kOpName
+      << " input and target must be different windows, but the same expression was "
+         "passed for both";
+
+  // input: narrowed from the composite's AsTensorTypeLike (Tensor OR window)
+  // down to a STRICT window-bound DistributedTensor. EmitBuiltinWindowCollectiveDispatch
+  // only knows how to emit dispatch code for DistributedTensorType or TileType
+  // args — there is no supported arg kind for a plain TensorType at this
+  // layer. Mirrors the identical narrowing builtin.tensor.all_to_all already
+  // applies to its own `input`.
+  auto input_type = As<DistributedTensorType>(args[0]->GetType());
+  CHECK(input_type) << kOpName << " input must be a DistributedTensor (window-bound), got "
+                    << args[0]->GetType()->TypeName();
+  CHECK(input_type->shape_.size() == 2)
+      << kOpName << " input must be 2D [NR*MAX_RECV, SIZE], got " << input_type->shape_.size() << " dims";
+
+  auto target_type = As<DistributedTensorType>(args[1]->GetType());
+  CHECK(target_type) << kOpName << " target must be a DistributedTensor (window-bound), got "
+                     << args[1]->GetType()->TypeName();
+  CHECK(target_type->shape_.size() == 2)
+      << kOpName << " target must be 2D [NR*MAX_RECV, SIZE], got " << target_type->shape_.size() << " dims";
+  CheckDimAgreesIfStatic(target_type->shape_[0], input_type->shape_[0], kOpName, "target", "input");
+  CHECK(AreExprsEqual(target_type->shape_[1], input_type->shape_[1]))
+      << kOpName << " target SIZE must equal input SIZE";
+  CHECK(target_type->dtype_ == input_type->dtype_)
+      << kOpName << " target dtype " << target_type->dtype_.ToString() << " must match input dtype "
+      << input_type->dtype_.ToString();
+
+  // signal: 2D [NR, 1] only — the composite's own deducer already enforces
+  // this exact shape on the pld.tensor.all_to_all_v call this builtin is
+  // constructed from, so there is no 1D case to additionally support here,
+  // unlike builtin.tensor.all_to_all which pre-dates that constraint.
+  auto signal_type = As<DistributedTensorType>(args[2]->GetType());
+  CHECK(signal_type) << kOpName << " signal must be a DistributedTensor (window-bound), got "
+                     << args[2]->GetType()->TypeName();
+  CHECK(signal_type->dtype_ == DataType::INT32)
+      << kOpName << " signal must have INT32 element type, got dtype " << signal_type->dtype_.ToString();
+  CHECK(signal_type->shape_.size() == 2)
+      << kOpName << " signal must be 2D [NR, 1], got " << signal_type->shape_.size() << " dims";
+  {
+    auto signal_dim1 = As<ConstInt>(signal_type->shape_[1]);
+    CHECK(signal_dim1 && signal_dim1->value_ == 1)
+        << kOpName << " signal second dimension must be 1, got "
+        << (signal_dim1 ? std::to_string(signal_dim1->value_) : "<dynamic>");
+  }
+
+  auto target_dim0 = As<ConstInt>(target_type->shape_[0]);
+  CHECK(target_dim0) << kOpName << " target dim 0 (NR*MAX_RECV) must be a compile-time constant";
+  auto signal_dim0 = As<ConstInt>(signal_type->shape_[0]);
+  CHECK(signal_dim0) << kOpName << " signal dim 0 (NR) must be a compile-time constant";
+  CHECK(signal_dim0->value_ > 0) << kOpName << " signal dim 0 (NR) must be positive, got "
+                                 << signal_dim0->value_;
+  CHECK(target_dim0->value_ % signal_dim0->value_ == 0)
+      << kOpName << " signal dim 0 (" << signal_dim0->value_ << ") must divide target dim 0 ("
+      << target_dim0->value_ << ")";
+
+  // send_counts: narrowed from AsTensorTypeLike to a STRICT window-bound
+  // DistributedTensor — same codegen-forced rationale as `input` above.
+  // LOCAL-only: read by this rank, never cross-rank-notified into (unlike
+  // recv_counts).
+  auto counts_type = As<DistributedTensorType>(args[3]->GetType());
+  CHECK(counts_type) << kOpName << " send_counts must be a DistributedTensor (window-bound), got "
+                     << args[3]->GetType()->TypeName();
+  CHECK(counts_type->dtype_ == DataType::INT32)
+      << kOpName << " send_counts must have INT32 element type, got dtype " << counts_type->dtype_.ToString();
+  CHECK(counts_type->shape_.size() == 1 || counts_type->shape_.size() == 2)
+      << kOpName << " send_counts must be 1D [NR] or 2D [NR, 1], got " << counts_type->shape_.size()
+      << " dims";
+  if (counts_type->shape_.size() == 2) {
+    auto counts_dim1 = As<ConstInt>(counts_type->shape_[1]);
+    CHECK(counts_dim1 && counts_dim1->value_ == 1)
+        << kOpName << " send_counts second dimension must be 1, got "
+        << (counts_dim1 ? std::to_string(counts_dim1->value_) : "<dynamic>");
+  }
+  auto counts_dim0 = As<ConstInt>(counts_type->shape_[0]);
+  CHECK(counts_dim0) << kOpName << " send_counts dim 0 (NR) must be a compile-time constant";
+  CHECK(counts_dim0->value_ == signal_dim0->value_)
+      << kOpName << " send_counts dim 0 (" << counts_dim0->value_
+      << ") must equal signal dim 0 (NR = " << signal_dim0->value_ << ")";
+
+  auto recv_type = As<DistributedTensorType>(args[4]->GetType());
+  CHECK(recv_type) << kOpName << " recv_counts must be a DistributedTensor (window-bound), got "
+                   << args[4]->GetType()->TypeName();
+  CHECK(recv_type->dtype_ == DataType::INT32)
+      << kOpName << " recv_counts must have INT32 element type, got dtype " << recv_type->dtype_.ToString();
+  CHECK(recv_type->shape_.size() == 2)
+      << kOpName << " recv_counts must be 2D [NR, 1], got " << recv_type->shape_.size() << " dims";
+  {
+    auto recv_dim1 = As<ConstInt>(recv_type->shape_[1]);
+    CHECK(recv_dim1 && recv_dim1->value_ == 1)
+        << kOpName << " recv_counts second dimension must be 1, got "
+        << (recv_dim1 ? std::to_string(recv_dim1->value_) : "<dynamic>");
+  }
+  auto recv_dim0 = As<ConstInt>(recv_type->shape_[0]);
+  CHECK(recv_dim0) << kOpName << " recv_counts dim 0 (NR) must be a compile-time constant";
+  CHECK(recv_dim0->value_ == signal_dim0->value_)
+      << kOpName << " recv_counts dim 0 (" << recv_dim0->value_
+      << ") must equal signal dim 0 (NR = " << signal_dim0->value_ << ")";
+
+  auto dtype = GetRequiredKwarg<DataType>(kwargs, "dtype", kOpName);
+  CHECK(dtype == target_type->dtype_)
+      << kOpName << " dtype kwarg (" << dtype.ToString() << ") must match target dtype ("
+      << target_type->dtype_.ToString() << ")";
+  CheckSupportedFp32BuiltinVariant(dtype, kOpName);
+
+  return args[1]->GetType();
+}
+
+}  // namespace
+
+REGISTER_OP("builtin.tensor.all_to_all_v")
+    .set_description("Internal chip-dispatch builtin for pld.tensor.all_to_all_v.")
+    .set_op_category("DistributedOp")
+    .add_argument("input",
+                  "Window-bound DistributedTensor [NR*MAX_RECV, SIZE] — this rank's outgoing "
+                  "per-destination staging window (TPUT source only, never an incoming-push "
+                  "destination)")
+    .add_argument("target",
+                  "Window-bound DistributedTensor [NR*MAX_RECV, SIZE] result window (TPUT destination)")
+    .add_argument("signal", "Window-bound INT32 DistributedTensor [NR, 1] signal buffer (single-use barrier)")
+    .add_argument("send_counts",
+                  "Window-bound INT32 DistributedTensor [NR] or [NR, 1] — rows to send to each "
+                  "destination, read at runtime and clamped to MAX_RECV (Input, LOCAL only, never "
+                  "cross-rank-published)")
+    .add_argument("recv_counts",
+                  "Window-bound INT32 DistributedTensor [NR, 1] — after the barrier, "
+                  "recv_counts[src, 0] holds how many rows src sent to this rank (InOut)")
+    .set_attr<DataType>("dtype")
+    .no_memory_spec()
+    .set_internal_only(true)
+    .set_template_dir(":pypto.runtime.builtins.collectives.all_to_all_v")
+    .f_deduce_type(DeduceBuiltinTensorAllToAllVType);
 
 }  // namespace ir
 }  // namespace pypto

--- a/src/ir/transforms/lower_composite_ops_pass.cpp
+++ b/src/ir/transforms/lower_composite_ops_pass.cpp
@@ -1980,20 +1980,24 @@ ExprPtr LowerTensorAllToAllRule(const CallPtr& call, const std::vector<ExprPtr>&
 // ============================================================================
 // LowerTensorAllToAllVRule — pld.tensor.all_to_all_v (variable-size all-to-all)
 //
-// Variable-size all-to-all (MPI_Alltoallv pattern).  Each rank sends a
-// different, *runtime* number of rows to each peer: ``send_counts[dest]`` is
-// read from device data during the exchange and bounds that destination's push
-// loop, so only the rows that carry payload cross the interconnect.  The 5-arg
-// API signature (input, target, signal, send_counts, recv_counts) extends the
-// symmetric all_to_all's window-as-result pattern: the intrinsic returns
-// target, and the caller reads back from the window with tile.load.  During
-// the push phase each rank also publishes ``send_counts[dest]`` into peer
-// ``dest``'s ``recv_counts[my_rank, 0]`` via ``pld.system.notify`` (Set) —
-// MPI_Alltoallv recvcounts — so after the barrier the receiver can skip the
-// unwritten holes at the tail of each source's MAX_RECV slot.  Notify writes
-// a scalar INT32 cell (same path as the barrier signal), so ``recv_counts``
-// stays ``[NR, 1]`` and no post-convert ``tensor.create`` scratch is needed
-// (ConvertTensorToTileOps already ran before this pass).
+// Variable-size all-to-all (MPI_Alltoallv pattern).  Each rank pushes a full
+// MAX_RECV-row capacity block to every peer via a single static-shape
+// pld.tile.put per destination; only ``min(send_counts[dest], MAX_RECV)`` of
+// those rows are logically valid.  ``send_counts[dest]`` is a *runtime*,
+// data-dependent count read from device data during the exchange, but it
+// does not change the transfer size (PTOAS requires static partition-view
+// dims for pto.comm.tput).  The 5-arg API signature (input, target, signal,
+// send_counts, recv_counts) extends the symmetric all_to_all's
+// window-as-result pattern: the intrinsic returns target, and the caller
+// reads back from the window with tile.load.  During the push phase each
+// rank also publishes the *clamped* ``min(send_counts[dest], MAX_RECV)``
+// into peer ``dest``'s ``recv_counts[my_rank, 0]`` via ``pld.system.notify``
+// (Set) — MPI_Alltoallv recvcounts — so after the barrier the receiver knows
+// how many of the physically-transferred rows at the tail of each source's
+// MAX_RECV slot are logically valid. Notify writes a scalar INT32 cell (same
+// path as the barrier signal), so ``recv_counts`` stays ``[NR, 1]`` and no
+// post-convert ``tensor.create`` scratch is needed (ConvertTensorToTileOps
+// already ran before this pass).
 //
 // 2-phase push-based decomposition:
 //
@@ -2011,15 +2015,17 @@ ExprPtr LowerTensorAllToAllRule(const CallPtr& call, const std::vector<ExprPtr>&
 //     EmitBarrier() — AtomicAdd(+1) on every peer cell, then Wait(Ge 1)
 //     EmitEpilogueReset(-1) — subtracts the credit back to zero after the call
 //
-// MAX_RECV = target.shape[0] / NR (both must be compile-time constants) is the
-// per-peer *capacity*, not the transfer size: it fixes the flat row-index
-// arithmetic (dest*MAX_RECV+r) so a receiver can locate each sender's block
-// without knowing that sender's count.  Counts are clamped to MAX_RECV so an
-// out-of-range count cannot push past peer dest's capacity slice.  Rows beyond
-// a sender's count are never written, so those receive-window rows keep their
-// prior contents — the same guarantee MPI_Alltoallv gives for the untouched
-// tail of a receive buffer.  Valid rows for source src are therefore
-// recv_counts[src] (already clamped to MAX_RECV at publish time).
+// MAX_RECV = target.shape[0] / NR (both must be compile-time constants) is
+// both the per-peer *capacity* and the fixed transfer size: it fixes the flat
+// row-index arithmetic (dest*MAX_RECV+r) so a receiver can locate each
+// sender's block without knowing that sender's count, and it sizes every
+// pld.tile.put identically regardless of the runtime count.  Counts are
+// clamped to MAX_RECV so an out-of-range count cannot push past peer dest's
+// capacity slice.  Rows beyond a sender's actual count still physically cross
+// the wire, but are logically invalid — the receiver uses recv_counts[src]
+// (already clamped to MAX_RECV at publish time) to know how many leading rows
+// of source src's block to use, the same MPI_Alltoallv semantics applied to
+// the logical result rather than the wire transfer.
 // ============================================================================
 
 ExprPtr LowerTensorAllToAllVRule(const CallPtr& call, const std::vector<ExprPtr>& args, LoweringBuilder& b) {
@@ -2343,22 +2349,8 @@ class LowerCompositeOpsMutator : public IRMutator {
     return IsTensorCollective(call);
   }
 
-  // Collectives that only have an InCore lowering — i.e. no matching entry in
-  // LowerHostTensorCollectives' kRules table.  Deferring one of these from a
-  // HOST orchestrator would drop it between the two passes (this pass skips it,
-  // the host pass never recognises it) and leave the composite op unlowered all
-  // the way into codegen, so it is rejected up front instead.  Keep in sync
-  // with kRules in src/ir/transforms/lower_host_tensor_collectives_pass.cpp.
-  [[nodiscard]] static bool IsInCoreOnlyCollective(const CallPtr& call) {
-    return IsOp(call, "pld.tensor.all_to_all_v");
-  }
-
   [[nodiscard]] CompositeLoweringFn LookupRule(const CallPtr& call) const {
     if (skip_host_collectives_ && ShouldSkipHostCollective(call)) {
-      CHECK_SPAN(!IsInCoreOnlyCollective(call), call->span_)
-          << call->op_->name_
-          << " is not supported in a HOST orchestration function — it has no host-level "
-             "lowering. Call it from an InCore function instead.";
       return nullptr;
     }
     return call && call->op_ ? LookupCompositeRule(call->op_->name_) : nullptr;

--- a/src/ir/transforms/lower_host_tensor_collectives_pass.cpp
+++ b/src/ir/transforms/lower_host_tensor_collectives_pass.cpp
@@ -10,6 +10,7 @@
  */
 
 #include <any>
+#include <array>
 #include <cstddef>
 #include <cstdint>
 #include <functional>
@@ -304,6 +305,56 @@ void CheckDistinctInputTargetWindows(const CallPtr& call, const char* op_name) {
          "cross-process data race under in-kernel TPUT)";
 }
 
+// pld.tensor.all_to_all_v's public deducer accepts a plain Tensor for `input`
+// and `send_counts` (AsTensorTypeLike) — legitimate on the InCore composite
+// path, where LowerCompositeOps consumes them directly. The HOST builtin path
+// requires both to be window-bound (EmitBuiltinWindowCollectiveDispatch has no
+// dispatch arm for a plain Tensor), so a plain-Tensor value reaching here is
+// user-reachable HOST-specific input, not a compiler invariant violation.
+// A user-declared pld.DistributedTensor parameter is equally user-reachable
+// (window_buffer_ == nullopt until pld.tensor.window binds it) and must be
+// rejected the same way — reject both with a CHECK_SPAN (not GetWindowBuffer's
+// INTERNAL_CHECK_SPAN) before any window-buffer lookup is attempted.
+void CheckHostWindowBoundArg(const ExprPtr& expr, const char* op_name, const char* role) {
+  auto dist_type = As<DistributedTensorType>(expr->GetType());
+  CHECK_SPAN(dist_type != nullptr && dist_type->window_buffer_.has_value(), expr->span_)
+      << op_name << " " << role
+      << " must be a window-bound DistributedTensor (a view of an alloc_window_buffer) when "
+         "called from a HOST orchestrator; a plain Tensor or an unbound DistributedTensor "
+         "parameter is only supported on the InCore composite path";
+}
+
+// all_to_all_v's five operands (input, target, signal, send_counts,
+// recv_counts) are independently read/written across ranks inside one AIV
+// kernel; any pairwise aliasing among them is a real cross-process race, not
+// just a style nit:
+//   - data (input/target) aliasing a control window (signal/send_counts/
+//     recv_counts): peer notify/count writes can clobber data this rank is
+//     still reading, or a data TPUT can clobber a control value.
+//   - signal aliasing recv_counts: the barrier's per-peer notify(Set, 1) can
+//     overwrite a just-published count, or a wait can be satisfied early
+//     against a value the count-publish rewrote.
+//   - send_counts aliasing signal or recv_counts: the kernel's local
+//     send_counts[dest] read can race a peer's cross-rank notify write
+//     landing in the same memory.
+// All 10 pairs across the 5 operands must be checked, not just the 4 pairs
+// that data-vs-data / control-vs-control discipline alone would cover.
+void CheckAllToAllVDistinctWindows(const CallPtr& call, const char* op_name) {
+  static constexpr std::array<std::pair<int, const char*>, 5> kOperands = {
+      {{0, "input"}, {1, "target"}, {2, "signal"}, {3, "send_counts"}, {4, "recv_counts"}}};
+  std::array<WindowBufferPtr, 5> buffers;
+  for (size_t i = 0; i < kOperands.size(); ++i) {
+    buffers[i] = GetWindowBuffer(call->args_[kOperands[i].first], kOperands[i].second);
+  }
+  for (size_t i = 0; i < buffers.size(); ++i) {
+    for (size_t j = i + 1; j < buffers.size(); ++j) {
+      CHECK_SPAN(buffers[i].get() != buffers[j].get(), call->span_)
+          << op_name << " " << kOperands[i].second << " and " << kOperands[j].second
+          << " must be different window allocations";
+    }
+  }
+}
+
 [[nodiscard]] CallPtr MakeBuiltinAllGather(const CallPtr& call, const ExprPtr& device) {
   // Emit namesake builtin: in-kernel TPUT push (this rank's chunk from the
   // `input` staging window into every peer's `target` window) + barrier
@@ -332,6 +383,28 @@ void CheckDistinctInputTargetWindows(const CallPtr& call, const char* op_name) {
       {call->args_[0], call->args_[1], call->args_[2]},  // (input, target, signal)
       {{"dtype", target_type->dtype_}}, device, {{"dtype", target_type->dtype_}},
       {ArgDirection::Input, ArgDirection::InOut, ArgDirection::InOut});
+}
+
+[[nodiscard]] CallPtr MakeBuiltinAllToAllV(const CallPtr& call, const ExprPtr& device) {
+  // Emit namesake builtin: in-kernel TPUT push of the full per-destination
+  // MAX_RECV block (this rank's chunks from `input` into every peer's
+  // `target` window) + an inline cross-rank publish of the runtime-clamped
+  // send_counts[dest] into peer `recv_counts[my_rank, 0]` + one barrier
+  // (TNOTIFY / TWAIT), all in a single AIV kernel. All five operands (input,
+  // target, signal, send_counts, recv_counts) must be pairwise-distinct
+  // windows. All chips must run concurrently — the host orchestrator submits
+  // asynchronously.
+  CheckAllToAllVDistinctWindows(call, "pld.tensor.all_to_all_v");
+  auto target_type = As<DistributedTensorType>(call->args_[1]->GetType());
+  INTERNAL_CHECK_SPAN(target_type, call->span_)
+      << "LowerHostTensorCollectives: pld.tensor.all_to_all_v target must be DistributedTensorType";
+
+  return MakeBuiltinCallWithAttrs(
+      "builtin.tensor.all_to_all_v", call,
+      {call->args_[0], call->args_[1], call->args_[2], call->args_[3], call->args_[4]},
+      {{"dtype", target_type->dtype_}}, device, {{"dtype", target_type->dtype_}},
+      {ArgDirection::Input, ArgDirection::InOut, ArgDirection::InOut, ArgDirection::Input,
+       ArgDirection::InOut});
 }
 
 struct HostCollectiveRule {
@@ -413,6 +486,23 @@ struct HostCollectiveRule {
           [](const CallPtr& call) { return call->args_[2]; },
           [](const CallPtr& call) -> std::optional<ExprPtr> { return call->args_[1]; },
       },
+      {
+          "pld.tensor.all_to_all_v",
+          &MakeBuiltinAllToAllV,
+          [](const CallPtr& call) {
+            CheckHostWindowBoundArg(call->args_[0], "pld.tensor.all_to_all_v", "input");
+            CheckHostWindowBoundArg(call->args_[3], "pld.tensor.all_to_all_v", "send_counts");
+            return std::vector<WindowBufferPtr>{
+                GetWindowBuffer(call->args_[0], "all_to_all_v input"),
+                GetWindowBuffer(call->args_[1], "all_to_all_v target"),
+                GetWindowBuffer(call->args_[2], "all_to_all_v signal"),
+                GetWindowBuffer(call->args_[3], "all_to_all_v send_counts"),
+                GetWindowBuffer(call->args_[4], "all_to_all_v recv_counts"),
+            };
+          },
+          [](const CallPtr& call) { return call->args_[2]; },
+          [](const CallPtr& call) -> std::optional<ExprPtr> { return call->args_[1]; },
+      },
   };
   for (const auto& rule : kRules) {
     if (op_name == rule.pld_name) return &rule;
@@ -442,6 +532,10 @@ StmtPtr EmitPerDeviceBuiltinCalls(const CallPtr& call, const HostCollectiveRule&
     return std::make_shared<SeqStmts>(std::move(stmts), span, leading_comments);
   }
 
+  // NOTE: for the fully-dynamic all-device domain (devices_ empty), signal's
+  // compile-time shape[0] is trusted to equal the runtime world_size — PyPTO
+  // has no runtime-assert IR primitive today to check this at compile time
+  // (see KNOWN_ISSUES.md).
   auto loop_var = std::make_shared<Var>("r", std::make_shared<ScalarType>(DataType::INT64), call->span_);
   auto zero = std::make_shared<ConstInt>(0, DataType::INT64, call->span_);
   auto one = std::make_shared<ConstInt>(1, DataType::INT64, call->span_);

--- a/src/ir/transforms/materialize_comm_domain_scopes_pass.cpp
+++ b/src/ir/transforms/materialize_comm_domain_scopes_pass.cpp
@@ -65,6 +65,13 @@ namespace {
   return call && call->op_ && IsOp(call, "pld.tensor.allgather");
 }
 
+// pld.tensor.all_to_all_v(input, target, signal, send_counts, recv_counts)
+// also returns `target` in-place (args_[1]) — same aliasing discipline as
+// IsTensorAllToAll above.
+[[nodiscard]] bool IsTensorAllToAllV(const CallPtr& call) {
+  return call && call->op_ && IsOp(call, "pld.tensor.all_to_all_v");
+}
+
 /// Device coverage descriptor inferred from a dispatch ``device=`` expression.
 struct DeviceDescriptor {
   bool is_all = false;
@@ -272,8 +279,20 @@ class DispatchAnalyzer : public IRVisitor {
 
   void VisitStmt_(const ForStmtPtr& op) override {
     for_stack_.push_back(op);
+    ++repeating_scope_depth_;
     IRVisitor::VisitStmt_(op);
+    --repeating_scope_depth_;
     for_stack_.pop_back();
+  }
+
+  // WhileStmt carries no device-descriptor role (unlike ForStmt, which
+  // for_stack_ tracks for ResolveDeviceDescriptor), but it must still count
+  // toward repeating_scope_depth_ so the all_to_all_v loop-use guard in
+  // AnalyzeCollective rejects a call nested in a while loop too.
+  void VisitStmt_(const WhileStmtPtr& op) override {
+    ++repeating_scope_depth_;
+    IRVisitor::VisitStmt_(op);
+    --repeating_scope_depth_;
   }
 
   void AnalyzeDispatch(const CallPtr& op) {
@@ -359,6 +378,41 @@ class DispatchAnalyzer : public IRVisitor {
       collective_consumers.push_back({data_alloc, signal_alloc, op->span_});
       return;
     }
+
+    if (IsOp(op, "pld.tensor.all_to_all_v")) {
+      // 5-arg push-based form:
+      // pld.tensor.all_to_all_v(input, target, signal, send_counts, recv_counts)
+      // args[0] = input        (window-bound on HOST path; distinct from target)
+      // args[1] = target       (DistributedTensor, window-bound, window-as-result)
+      // args[2] = signal       (DistributedTensor, window-bound, barrier)
+      // args[3] = send_counts  (window-bound on HOST path; LOCAL only, never
+      //                          cross-rank-notified — no consumer entry,
+      //                          same rationale as `input` above)
+      // args[4] = recv_counts  (DistributedTensor, window-bound; published
+      //                          cross-rank via notify, so needs target's
+      //                          device coverage exactly like `signal` does)
+      INTERNAL_CHECK_SPAN(op->args_.size() == 5, op->span_)
+          << "MaterializeCommDomainScopes: pld.tensor.all_to_all_v expects exactly 5 args";
+      // LowerCompositeOps' CheckAllReduceLoopUse guards the InCore path but
+      // never runs for a HOST-orch call (LowerCompositeOps just defers it
+      // there). This is the HOST-side equivalent, using repeating_scope_depth_
+      // (tracked across both ForStmt and WhileStmt — see the VisitStmt_
+      // overrides above).
+      CHECK_SPAN(repeating_scope_depth_ == 0, op->span_)
+          << "pld.tensor.all_to_all_v is not supported inside a for/while loop in a HOST "
+             "orchestrator. The signal protocol is single-use and cannot reuse a signal "
+             "across dynamic invocations (same restriction LowerCompositeOps enforces on "
+             "the InCore path via CheckAllReduceLoopUse).";
+      auto* data_alloc = ResolveWindowAlloc(op->args_[1], "pld.tensor.all_to_all_v", "target");
+      auto* signal_alloc = ResolveWindowAlloc(op->args_[2], "pld.tensor.all_to_all_v", "signal");
+      auto* recv_counts_alloc = ResolveWindowAlloc(op->args_[4], "pld.tensor.all_to_all_v", "recv_counts");
+      // Two consumer entries sharing the same data_alloc: both signal and
+      // recv_counts need to inherit target's device coverage (Phase 3 loop
+      // below merges generically per entry).
+      collective_consumers.push_back({data_alloc, signal_alloc, op->span_});
+      collective_consumers.push_back({data_alloc, recv_counts_alloc, op->span_});
+      return;
+    }
   }
 
   void VisitExpr_(const CallPtr& op) override {
@@ -403,6 +457,9 @@ class DispatchAnalyzer : public IRVisitor {
     if (call && IsTensorAllGather(call) && call->args_.size() > 1) {
       return ResolveWindowRecord(As<Var>(call->args_[1]), visited);
     }
+    if (call && IsTensorAllToAllV(call) && call->args_.size() > 1) {
+      return ResolveWindowRecord(As<Var>(call->args_[1]), visited);
+    }
     return nullptr;
   }
 
@@ -410,6 +467,7 @@ class DispatchAnalyzer : public IRVisitor {
   const std::map<std::string, FunctionPtr>& chip_orchs_;
   const std::unordered_map<const Var*, ExprPtr>& var_defs_;
   std::vector<ForStmtPtr> for_stack_;
+  int repeating_scope_depth_ = 0;
 };
 
 /// A host-orchestration function in PyPTO is declared as either

--- a/tests/st/distributed/test_l3_host_tensor_all_to_all_v.py
+++ b/tests/st/distributed/test_l3_host_tensor_all_to_all_v.py
@@ -1,0 +1,258 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""L3 distributed ST: host-orchestrator ``pld.tensor.all_to_all_v`` builtin dispatch.
+
+Validates the HOST-level variable-size all-to-all (MPI_Alltoallv pattern) lowers
+through ``LowerHostTensorCollectives`` and produces correct rank-ordered
+personalized exchange via the hand-written ``builtin.tensor.all_to_all_v``
+kernel — the HOST-orchestrated counterpart of the InCore-only
+``test_l3_tensor_all_to_all_v_intrinsic.py``.
+
+The HOST lowering path detects ``pld.tensor.all_to_all_v`` in ``host_orch`` and
+lowers it to ``builtin.tensor.all_to_all_v`` per chip. The exchange uses a
+push-based TPUT pattern with FIVE window-bound resources:
+
+  1. **Stage** (``stage_step``): each rank writes its per-destination chunks
+     into ``input_buf`` — a window used ONLY as a TPUT source, never as an
+     incoming-push destination (same discipline as symmetric all_to_all's HOST
+     builtin).
+  2. **Fill counts** (``fill_counts_step``): each rank writes its own
+     per-destination send counts into ``counts_buf``. This staging step only
+     exists because the HOST builtin narrows ``send_counts`` from the InCore
+     composite's ``Tensor``-or-``DistributedTensor`` contract down to a strict
+     window-bound ``DistributedTensor`` — ``EmitBuiltinWindowCollectiveDispatch``
+     has no dispatch path for a plain ``Tensor`` arg. A real ergonomic cost of
+     the narrowing, not a test artifact.
+  3. **All-to-all-v** (``builtin.tensor.all_to_all_v``): the kernel pushes the
+     full ``MAX_RECV``-row capacity block per destination into ``data_buf``,
+     publishes the clamped ``min(send_counts[dest], MAX_RECV)`` into peer
+     ``recv_counts[my_rank, 0]`` via TNOTIFY, and synchronises with one
+     barrier.
+  4. **Consume** (``consume_step``): each rank reads ``recv_counts`` to learn
+     how many rows each source actually sent, then reads back only those valid
+     rows from ``data_buf``.
+
+``input_buf``, ``data_buf``, ``signal_buf``, ``counts_buf``, and ``recv_buf``
+must all be allocated inside the SAME host_orch comm-domain scope —
+``EmitBuiltinWindowCollectiveDispatch`` requires every window-bound arg of one
+builtin call to share a comm-domain handle.
+
+The HOST kernel derives ``MAX_RECV`` at entry from the runtime rank count
+(``target.shape[0] / nranks``), so the per-destination block size is always
+consistent with the devices actually running. The program is still built via
+a factory function per parametrized rank count (signal/counts shapes are
+per-rank-count), matching ``test_l3_tensor_all_to_all_v_intrinsic.py``'s
+pattern.
+
+ST coverage: P=2 and P=4 (skips when fewer devices are available).
+"""
+
+import sys
+
+import pypto.language as pl
+import pypto.language.distributed as pld
+import pytest
+import torch
+from pypto import ir
+from pypto.ir.distributed_compiled_program import DistributedConfig
+
+SIZE = 64
+MAX_RECV = 4
+
+
+def _build_host_all_to_all_v_program(n_ranks: int, max_recv: int):
+    """Build an N-rank HOST-orchestrated variable-size all-to-all program."""
+    nr = n_ranks
+    mr = max_recv
+    total = nr * mr
+
+    @pl.program
+    class HostTensorAllToAllV:
+        """N-rank HOST-orchestrated variable-size all-to-all program."""
+
+        @pl.function(type=pl.FunctionType.InCore)
+        def stage_step(
+            self,
+            inp: pl.Tensor[[total, SIZE], pl.FP32],
+            stage: pl.Out[pld.DistributedTensor[[total, SIZE], pl.FP32]],
+        ):
+            for row in pl.range(total):
+                chunk = pl.load(inp, [row, 0], [1, SIZE])
+                stage = pl.store(chunk, [row, 0], stage)
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def stage_orch(
+            self,
+            inp: pl.Tensor[[total, SIZE], pl.FP32],
+            stage: pl.Out[pld.DistributedTensor[[total, SIZE], pl.FP32]],
+        ):
+            self.stage_step(inp, stage)
+
+        @pl.function(type=pl.FunctionType.InCore)
+        def fill_counts_step(
+            self,
+            counts_row: pl.Tensor[[nr, 1], pl.INT32],
+            counts: pl.Out[pld.DistributedTensor[[nr, 1], pl.INT32]],
+        ):
+            # Scalar read/write — a [1,1] INT32 tile.load/store fails ptoas
+            # 32-byte row alignment (4 bytes); same pitfall the InCore
+            # all_to_all_v intrinsic ST avoids for recv_counts.
+            for d in pl.range(nr):
+                v = pl.read(counts_row, [d, 0])
+                pl.write(counts, [d, 0], v)
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def fill_counts_orch(
+            self,
+            counts_row: pl.Tensor[[nr, 1], pl.INT32],
+            counts: pl.Out[pld.DistributedTensor[[nr, 1], pl.INT32]],
+        ):
+            self.fill_counts_step(counts_row, counts)
+
+        @pl.function(type=pl.FunctionType.InCore)
+        def consume_step(
+            self,
+            data: pld.DistributedTensor[[total, SIZE], pl.FP32],
+            recv_counts: pld.DistributedTensor[[nr, 1], pl.INT32],
+            out: pl.Out[pl.Tensor[[total, SIZE], pl.FP32]],
+            recv_out: pl.Out[pl.Tensor[[nr, 1], pl.INT32]],
+        ) -> tuple[pl.Tensor[[total, SIZE], pl.FP32], pl.Tensor[[nr, 1], pl.INT32]]:
+            for src in pl.range(nr):
+                n_rows_i32 = pl.read(recv_counts, [src, 0])
+                pl.write(recv_out, [src, 0], n_rows_i32)
+                n_rows = pl.cast(n_rows_i32, pl.INDEX)
+                base = src * mr
+                for r in pl.range(n_rows):
+                    flat_row = base + r
+                    chunk = pl.load(data, [flat_row, 0], [1, SIZE])
+                    out = pl.store(chunk, [flat_row, 0], out)
+            return out, recv_out
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def consume_orch(
+            self,
+            data: pld.DistributedTensor[[total, SIZE], pl.FP32],
+            recv_counts: pld.DistributedTensor[[nr, 1], pl.INT32],
+            out: pl.Out[pl.Tensor[[total, SIZE], pl.FP32]],
+            recv_out: pl.Out[pl.Tensor[[nr, 1], pl.INT32]],
+        ) -> tuple[pl.Tensor[[total, SIZE], pl.FP32], pl.Tensor[[nr, 1], pl.INT32]]:
+            return self.consume_step(data, recv_counts, out, recv_out)
+
+        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+        def host_orch(
+            self,
+            inputs: pl.Tensor[[nr, total, SIZE], pl.FP32],
+            send_counts: pl.Tensor[[nr, nr, 1], pl.INT32],
+            outputs: pl.Out[pl.Tensor[[nr, total, SIZE], pl.FP32]],
+            recv_outputs: pl.Out[pl.Tensor[[nr, nr, 1], pl.INT32]],
+        ) -> tuple[pl.Tensor[[nr, total, SIZE], pl.FP32], pl.Tensor[[nr, nr, 1], pl.INT32]]:
+            input_buf = pld.alloc_window_buffer(total * SIZE * pl.FP32.get_byte())
+            data_buf = pld.alloc_window_buffer(total * SIZE * pl.FP32.get_byte())
+            signal_buf = pld.alloc_window_buffer(nr * pl.INT32.get_byte())
+            counts_buf = pld.alloc_window_buffer(nr * pl.INT32.get_byte())
+            recv_buf = pld.alloc_window_buffer(nr * pl.INT32.get_byte())
+
+            for r in pl.range(pld.world_size()):
+                stage = pld.window(input_buf, [total, SIZE], dtype=pl.FP32)
+                self.stage_orch(inputs[r], stage, device=r)
+
+            for r in pl.range(pld.world_size()):
+                counts = pld.window(counts_buf, [nr, 1], dtype=pl.INT32)
+                self.fill_counts_orch(send_counts[r], counts, device=r)
+
+            stage = pld.window(input_buf, [total, SIZE], dtype=pl.FP32)
+            data = pld.window(data_buf, [total, SIZE], dtype=pl.FP32)
+            signal = pld.window(signal_buf, [nr, 1], dtype=pl.INT32)
+            counts = pld.window(counts_buf, [nr, 1], dtype=pl.INT32)
+            recv = pld.window(recv_buf, [nr, 1], dtype=pl.INT32)
+            data = pld.tensor.all_to_all_v(stage, data, signal, counts, recv)
+
+            for r in pl.range(pld.world_size()):
+                self.consume_orch(data, recv, outputs[r], recv_outputs[r], device=r)
+
+            return outputs, recv_outputs
+
+    return HostTensorAllToAllV
+
+
+class TestL3HostTensorAllToAllV:
+    """L3 distributed runtime: HOST-level variable-size all-to-all via builtin dispatch."""
+
+    @pytest.mark.parametrize("n_ranks", [2, 4])
+    def test_host_tensor_all_to_all_v(self, test_config, device_ids, n_ranks):
+        """Compile and run host-level all_to_all_v for P in {2, 4}.
+
+        Each rank sends ``n_ranks - dest`` rows to each destination (variable,
+        runtime-dependent counts) — same golden pattern as the InCore-only ST
+        (``test_l3_tensor_all_to_all_v_intrinsic.py``).
+        """
+        if len(device_ids) < n_ranks:
+            pytest.skip(f"host all_to_all_v P={n_ranks} needs {n_ranks} devices, got {device_ids}")
+
+        nr = n_ranks
+        mr = MAX_RECV
+        total = nr * mr
+
+        program = _build_host_all_to_all_v_program(nr, mr)
+        compiled = ir.compile(
+            program,
+            platform=test_config.platform,
+            distributed_config=DistributedConfig(
+                device_ids=device_ids[:nr],
+                num_sub_workers=0,
+            ),
+        )
+
+        variant_dir = compiled.output_dir / "next_levels" / "builtin.tensor.all_to_all_v__fp32"
+        assert variant_dir.is_dir(), f"expected {variant_dir}"
+        assert (variant_dir / "kernel_config.py").is_file()
+
+        # Rank r sends to dest d: rows dest*mr+k for k=0..n_rows-1.
+        # Value = r*1000 + d*100 + k*10 + j%10 (same formula as the InCore ST).
+        # The TPUT transfers the full per-destination capacity block (max_recv
+        # rows, derived at kernel entry from the runtime nranks); rows beyond
+        # n_rows are sent as well — the receiver uses recv_counts to skip the
+        # unwritten window holes.
+        inputs = torch.zeros((nr, total, SIZE), dtype=torch.float32)
+        send_counts = torch.zeros((nr, nr, 1), dtype=torch.int32)
+        for r in range(nr):
+            for d in range(nr):
+                n_rows = nr - d  # variable send count, same golden formula as the InCore ST
+                send_counts[r, d, 0] = n_rows
+                base = d * mr
+                for k in range(n_rows):
+                    for j in range(SIZE):
+                        inputs[r, base + k, j] = float(r * 1000 + d * 100 + k * 10 + j % 10)
+
+        outputs = torch.zeros((nr, total, SIZE), dtype=torch.float32)
+        recv_outputs = torch.zeros((nr, nr, 1), dtype=torch.int32)
+
+        compiled(inputs, send_counts, outputs, recv_outputs)
+
+        # Rank rank receives from src the chunk that src sent to dest=rank.
+        for rank in range(nr):
+            for src in range(nr):
+                n_rows = int(send_counts[src, rank, 0].item())
+                assert int(recv_outputs[rank, src, 0].item()) == n_rows, (
+                    f"P={nr} rank={rank} src={src}: recv_counts="
+                    f"{int(recv_outputs[rank, src, 0].item())} != expected send_counts={n_rows}"
+                )
+                base = src * mr
+                for k in range(n_rows):
+                    expected_row = inputs[src, rank * mr + k, :]
+                    got_row = outputs[rank, base + k, :]
+                    assert torch.allclose(got_row, expected_row, atol=1e-5), (
+                        f"P={nr} rank={rank} src={src} row={k}: "
+                        f"max diff = {(got_row - expected_row).abs().max().item()}"
+                    )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", *sys.argv[1:]])

--- a/tests/ut/codegen/distributed/test_host_orch_distributed.py
+++ b/tests/ut/codegen/distributed/test_host_orch_distributed.py
@@ -1126,6 +1126,119 @@ def test_backend_materializes_all_to_all_next_level_files(tmp_path):
     )
 
 
+def test_backend_materializes_all_to_all_v_next_level_files(tmp_path):
+    @pl.program
+    class Prog:
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def chip_orch(
+            self,
+            inp: pld.DistributedTensor[[8, SIZE], pl.FP32],
+            data: pld.DistributedTensor[[8, SIZE], pl.FP32],
+            sig: pld.DistributedTensor[[4, 1], pl.INT32],
+            counts: pld.DistributedTensor[[4, 1], pl.INT32],
+            recv: pld.DistributedTensor[[4, 1], pl.INT32],
+        ):
+            return data
+
+        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+        def host_orch(self):
+            input_buf = pld.alloc_window_buffer(8 * SIZE * pl.FP32.get_byte())
+            data_buf = pld.alloc_window_buffer(8 * SIZE * pl.FP32.get_byte())
+            signal_buf = pld.alloc_window_buffer(4 * pl.INT32.get_byte())
+            counts_buf = pld.alloc_window_buffer(4 * pl.INT32.get_byte())
+            recv_buf = pld.alloc_window_buffer(4 * pl.INT32.get_byte())
+            inp = pld.window(input_buf, [8, SIZE], dtype=pl.FP32)
+            data = pld.window(data_buf, [8, SIZE], dtype=pl.FP32)
+            signal = pld.window(signal_buf, [4, 1], dtype=pl.INT32)
+            counts = pld.window(counts_buf, [4, 1], dtype=pl.INT32)
+            recv = pld.window(recv_buf, [4, 1], dtype=pl.INT32)
+            for r in pl.range(pld.world_size()):
+                self.chip_orch(inp, data, signal, counts, recv, device=r)
+            pld.tensor.all_to_all_v(inp, data, signal, counts, recv)
+            return 0
+
+    _assert_host_collective_next_level_files(
+        Prog,
+        tmp_path,
+        variant="builtin.tensor.all_to_all_v__fp32",
+        signature='"signature": [_D.IN, _D.OUT, _D.OUT, _D.IN, _D.OUT]',
+        kernel_snippet="TPUT",
+    )
+
+
+def test_host_all_to_all_v_builtin_variant_shared_across_max_recv():
+    """Two host_orch all_to_all_v calls with different MAX_RECV (2 vs 4) emit
+    ONE shared next-level variant: MAX_RECV is derived at kernel entry from
+    the runtime nranks (target.shape[0] / nranks, see kernel.cpp.in), so the
+    program-global variant key does not need to distinguish them — both call
+    sites instantiate the same ``__fp32`` kernel."""
+
+    @pl.program
+    class Prog:
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def chip_orch(
+            self,
+            inp: pld.DistributedTensor[[8, SIZE], pl.FP32],
+            data: pld.DistributedTensor[[8, SIZE], pl.FP32],
+            sig: pld.DistributedTensor[[4, 1], pl.INT32],
+            counts: pld.DistributedTensor[[4, 1], pl.INT32],
+            recv: pld.DistributedTensor[[4, 1], pl.INT32],
+        ):
+            return data
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def chip_orch2(
+            self,
+            inp: pld.DistributedTensor[[8, SIZE], pl.FP32],
+            data: pld.DistributedTensor[[8, SIZE], pl.FP32],
+            sig: pld.DistributedTensor[[2, 1], pl.INT32],
+            counts: pld.DistributedTensor[[2, 1], pl.INT32],
+            recv: pld.DistributedTensor[[2, 1], pl.INT32],
+        ):
+            return data
+
+        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+        def host_orch(self):
+            input_buf = pld.alloc_window_buffer(8 * SIZE * pl.FP32.get_byte())
+            data_buf = pld.alloc_window_buffer(8 * SIZE * pl.FP32.get_byte())
+            signal_buf = pld.alloc_window_buffer(4 * pl.INT32.get_byte())
+            counts_buf = pld.alloc_window_buffer(4 * pl.INT32.get_byte())
+            recv_buf = pld.alloc_window_buffer(4 * pl.INT32.get_byte())
+            inp = pld.window(input_buf, [8, SIZE], dtype=pl.FP32)
+            data = pld.window(data_buf, [8, SIZE], dtype=pl.FP32)
+            signal = pld.window(signal_buf, [4, 1], dtype=pl.INT32)
+            counts = pld.window(counts_buf, [4, 1], dtype=pl.INT32)
+            recv = pld.window(recv_buf, [4, 1], dtype=pl.INT32)
+            for r in pl.range(pld.world_size()):
+                self.chip_orch(inp, data, signal, counts, recv, device=r)
+            pld.tensor.all_to_all_v(inp, data, signal, counts, recv)
+
+            input_buf2 = pld.alloc_window_buffer(8 * SIZE * pl.FP32.get_byte())
+            data_buf2 = pld.alloc_window_buffer(8 * SIZE * pl.FP32.get_byte())
+            signal_buf2 = pld.alloc_window_buffer(2 * pl.INT32.get_byte())
+            counts_buf2 = pld.alloc_window_buffer(2 * pl.INT32.get_byte())
+            recv_buf2 = pld.alloc_window_buffer(2 * pl.INT32.get_byte())
+            inp2 = pld.window(input_buf2, [8, SIZE], dtype=pl.FP32)
+            data2 = pld.window(data_buf2, [8, SIZE], dtype=pl.FP32)
+            signal2 = pld.window(signal_buf2, [2, 1], dtype=pl.INT32)
+            counts2 = pld.window(counts_buf2, [2, 1], dtype=pl.INT32)
+            recv2 = pld.window(recv_buf2, [2, 1], dtype=pl.INT32)
+            for r in pl.range(pld.world_size()):
+                self.chip_orch2(inp2, data2, signal2, counts2, recv2, device=r)
+            pld.tensor.all_to_all_v(inp2, data2, signal2, counts2, recv2)
+            return 0
+
+    generated, cg = _lower_host_collectives(Prog)
+
+    assert 'callables["builtin.tensor.all_to_all_v__fp32"]' in generated, generated
+
+    specs = cg.get_builtin_next_level_specs()
+    variants = {spec.variant for spec in specs}
+    assert variants == {"builtin.tensor.all_to_all_v__fp32"}, specs
+    for spec in specs:
+        assert "max_recv_cpp" not in spec.template_vars, spec
+
+
 def _assert_host_collective_next_level_files(program_cls, tmp_path, variant, signature, kernel_snippet):
     program = passes.materialize_comm_domain_scopes()(program_cls)
     program = passes.lower_host_tensor_collectives()(program)
@@ -1156,6 +1269,7 @@ def _assert_host_collective_next_level_files(program_cls, tmp_path, variant, sig
         ("reduce_scatter", "builtin.tensor.reduce_scatter__sum__fp32"),
         ("allgather", "builtin.tensor.allgather__fp32"),
         ("all_to_all", "builtin.tensor.all_to_all__fp32"),
+        ("all_to_all_v", "builtin.tensor.all_to_all_v__fp32"),
     ],
 )
 def test_host_collective_builtin_template_package_exists(package_name, variant):

--- a/tests/ut/ir/test_distributed_ops.py
+++ b/tests/ut/ir/test_distributed_ops.py
@@ -359,6 +359,29 @@ def test_builtin_tensor_allreduce_template_resource_exists():
     assert (template_root / "templates" / "kernel_config.py.in").is_file()
 
 
+def test_builtin_tensor_all_to_all_v_is_internal_only():
+    span = ir.Span.unknown()
+    inp = _make_distributed_tensor_var("inp", [8, 64], DataType.FP32, span)
+    target = _make_distributed_tensor_var("target", [8, 64], DataType.FP32, span)
+    signal = _make_distributed_tensor_var("signal", [4, 1], DataType.INT32, span)
+    counts = _make_distributed_tensor_var("counts", [4, 1], DataType.INT32, span)
+    recv = _make_distributed_tensor_var("recv", [4, 1], DataType.INT32, span)
+    with pytest.raises(ValueError, match="internal-only"):
+        ir.create_op_call(
+            "builtin.tensor.all_to_all_v",
+            [inp, target, signal, counts, recv],
+            {"dtype": DataType.FP32},
+            span,
+        )
+
+
+def test_builtin_tensor_all_to_all_v_template_resource_exists():
+    template_root = resources.files("pypto.runtime.builtins.collectives.all_to_all_v")
+    assert (template_root / "templates" / "entry.cpp.in").is_file()
+    assert (template_root / "templates" / "kernel.cpp.in").is_file()
+    assert (template_root / "templates" / "kernel_config.py.in").is_file()
+
+
 # ---------------------------------------------------------------------------
 # pld.tile.remote_load op
 # ---------------------------------------------------------------------------

--- a/tests/ut/ir/transforms/test_lower_composite_ops.py
+++ b/tests/ut/ir/transforms/test_lower_composite_ops.py
@@ -735,10 +735,10 @@ def test_all_to_all_v_push_loop_is_bounded_by_runtime_send_counts():
     )
 
 
-def test_all_to_all_v_is_rejected_in_host_orchestrator():
-    """all_to_all_v is InCore-only: LowerHostTensorCollectives has no rule for
-    it, so deferring it from a HOST orchestrator would leave the composite op
-    unlowered all the way into codegen. It must be rejected up front."""
+def test_all_to_all_v_in_host_orchestrator_is_left_for_host_collective_lowering():
+    """Host-level all_to_all_v is lowered by LowerHostTensorCollectives (via its
+    builtin.tensor.all_to_all_v rule), not here — LowerCompositeOps must defer
+    it unchanged rather than reject it."""
     SIZE = _AAV_SIZE
     nr = _AAV_NRANKS
     total = _AAV_TOTAL
@@ -757,8 +757,12 @@ def test_all_to_all_v_is_rejected_in_host_orchestrator():
             data = pld.tensor.all_to_all_v(inp, data, signal, counts, recv_counts)  # type: ignore[arg-type]
             return 0
 
-    with pytest.raises(ValueError, match="not supported in a HOST orchestration function"):
-        passes.lower_composite_ops()(HostAllToAllV)
+    After = passes.lower_composite_ops()(HostAllToAllV)
+    op_names = set(_collect_op_names(After))
+
+    assert "pld.tensor.all_to_all_v" in op_names
+    assert "pld.system.notify" not in op_names
+    assert "pld.tile.put" not in op_names
 
 
 def test_allreduce_without_signal_is_rejected_outside_host_orchestrator():

--- a/tests/ut/ir/transforms/test_lower_host_tensor_collectives.py
+++ b/tests/ut/ir/transforms/test_lower_host_tensor_collectives.py
@@ -8,7 +8,17 @@
 # -----------------------------------------------------------------------------------------------------------
 # ruff: noqa: F722, F821
 
-"""Tests for ``LowerHostTensorCollectives``."""
+"""Tests for ``LowerHostTensorCollectives``.
+
+The lowering emits ``builtin.tensor.*`` internal ops that the public DSL cannot
+spell (the composite ``pld.tensor.*`` call is what gets lowered), so a whole-
+``@pl.program`` ``Expected`` cannot be parsed for these tests. As in the
+materialize_comm_domain_scopes module, the structural Before/Expected pattern
+is applied at the granularity of the pass's comparable output product — the
+emitted builtin dispatch — via :func:`_assert_builtin_dispatch`, which pins the
+full dispatch (world-size loop, every window-bound arg in order, arg
+directions, and the complete kwarg/attr dicts).
+"""
 
 from typing import cast
 
@@ -16,7 +26,7 @@ import pypto.language as pl
 import pypto.language.distributed as pld
 import pytest
 from pypto.language.parser.diagnostics import InvalidOperationError
-from pypto.pypto_core import DataType, ir, passes
+from pypto.pypto_core import ir, passes
 
 
 @pytest.fixture(autouse=True)
@@ -39,11 +49,6 @@ def _as_call(expr: ir.Expr) -> ir.Call:
 def _as_var(expr: ir.Expr) -> ir.Var:
     assert isinstance(expr, ir.Var)
     return expr
-
-
-def _eval_call(stmt: ir.Stmt) -> ir.Call:
-    assert isinstance(stmt, ir.EvalStmt)
-    return _as_call(stmt.expr)
 
 
 def _collect_for_stmts(stmt: ir.Stmt) -> list[ir.ForStmt]:
@@ -115,6 +120,94 @@ def _assert_alias_keeps_window_buffer(alias: ir.AssignStmt) -> None:
     assert lhs_type.window_buffer is rhs_type.window_buffer
 
 
+def _assert_builtin_dispatch(
+    host_body: ir.Stmt,
+    builtin_name: str,
+    *,
+    arg_names: list[str],
+    arg_directions: list[ir.ArgDirection],
+    kwargs: dict[str, object],
+    attrs: dict[str, object] | None = None,
+) -> ir.Call:
+    """Assert the host body dispatches ``builtin_name`` exactly once and pin the
+    full emitted structure of the dispatch.
+
+    This is the structural-comparison equivalent of the Before/Expected pattern
+    for ``LowerHostTensorCollectives``: the lowered output is a ``builtin.tensor.*``
+    internal op that the public DSL cannot spell (the composite ``pld.tensor.*``
+    call is what gets lowered), so no ``Expected`` program source can be parsed.
+    As in the materialize_comm_domain_scopes module, the pattern is applied at
+    the granularity of the pass's comparable output product — the builtin
+    dispatch. The helper pins:
+
+    * exactly one ``for r in pl.range(pld.system.world_size())`` loop whose body
+      is exactly the builtin EvalStmt (extra or missing surrounding statements
+      fail the match),
+    * every argument as the expected window-bound DistributedTensor, in order
+      (a reordered arg or a wrong window view for an arg fails),
+    * the exact arg directions, and
+    * the complete kwarg dict and attr set, with ``device`` bound to the loop
+      var.
+    """
+
+    op_name = ir.get_op(builtin_name).name
+    loops = _collect_for_stmts(host_body)
+    dispatch = [
+        loop
+        for loop in loops
+        if isinstance(loop.body, ir.EvalStmt)
+        and isinstance(loop.body.expr, ir.Call)
+        and loop.body.expr.op.name == op_name
+    ]
+    assert len(dispatch) == 1, f"expected exactly one {builtin_name} dispatch loop, found {len(dispatch)}"
+    loop = dispatch[0]
+
+    # The dispatch loop iterates exactly the distributed world size.
+    world_size_name = ir.get_op("pld.system.world_size").name
+    stop = loop.stop
+    if isinstance(stop, ir.Var):
+        # CSE / NormalizeStmtStructure can hoist the bound to a temp
+        # ``t = pld.system.world_size(); for r in pl.range(t):``.
+        stop = next(
+            (assign.value for assign in _collect_assign_stmts(host_body) if assign.var is stop),
+            stop,
+        )
+    assert isinstance(stop, ir.Call) and stop.op.name == world_size_name, (
+        "dispatch loop bound must be pld.system.world_size()"
+    )
+
+    body = loop.body
+    assert isinstance(body, ir.EvalStmt)
+    call = _as_call(body.expr)
+
+    # device attr is bound to the loop induction var
+    assert call.attrs["device"] is loop.loop_var
+
+    # every argument is the expected window-bound DistributedTensor, in order
+    assert len(call.args) == len(arg_names), f"expected {len(arg_names)} args, got {len(call.args)}"
+    for actual, expected in zip(call.args, arg_names):
+        var = _as_var(actual)
+        assert var.name_hint == expected, f"expected arg window var {expected!r}, got {var.name_hint!r}"
+        assert isinstance(var.type, ir.DistributedTensorType)
+        assert var.type.window_buffer is not None, f"arg {expected!r} must be window-bound"
+
+    assert list(call.arg_directions) == arg_directions
+    # arg_directions is mirrored in attrs
+    assert list(call.attrs["arg_directions"]) == arg_directions
+
+    # complete kwarg dict
+    assert dict(call.kwargs) == kwargs, f"kwargs mismatch: {dict(call.kwargs)} != {kwargs}"
+
+    # exact attr key set plus op-specific values (device / arg_directions above)
+    expected_attr_keys = {"device", "arg_directions", *(attrs or {})}
+    assert set(call.attrs.keys()) == expected_attr_keys, (
+        f"attr key mismatch: {set(call.attrs.keys())} != {expected_attr_keys}"
+    )
+    for key, value in (attrs or {}).items():
+        assert call.attrs[key] == value, f"attr {key!r} mismatch: {call.attrs[key]!r} != {value!r}"
+    return call
+
+
 def test_host_allreduce_lowers_to_builtin_world_size_loop():
     @pl.program
     class P:
@@ -137,26 +230,14 @@ def test_host_allreduce_lowers_to_builtin_world_size_loop():
     result = cast(ir.Program, passes.lower_host_tensor_collectives()(program))
     host = _get_func(result, "host_orch")
 
-    loops = _collect_for_stmts(host.body)
-    builtin_loops = [
-        loop
-        for loop in loops
-        if isinstance(loop.body, ir.EvalStmt)
-        and isinstance(loop.body.expr, ir.Call)
-        and loop.body.expr.op.name == "builtin.tensor.allreduce"
-    ]
-    assert len(builtin_loops) == 1
-
-    body = builtin_loops[0].body
-    assert isinstance(body, ir.EvalStmt)
-    call = body.expr
-    assert isinstance(call, ir.Call)
-    assert call.kwargs["op"] == int(pld.ReduceOp.Sum)
-    assert call.kwargs["dtype"] == pl.FP32
-    assert call.attrs["op"] == int(pld.ReduceOp.Sum)
-    assert call.attrs["dtype"] == pl.FP32
-    assert call.attrs["device"] is builtin_loops[0].loop_var
-    assert list(call.arg_directions) == [ir.ArgDirection.InOut, ir.ArgDirection.InOut]
+    _assert_builtin_dispatch(
+        host.body,
+        "builtin.tensor.allreduce",
+        arg_names=["data", "signal"],
+        arg_directions=[ir.ArgDirection.InOut, ir.ArgDirection.InOut],
+        kwargs={"op": int(pld.ReduceOp.Sum), "dtype": pl.FP32},
+        attrs={"op": int(pld.ReduceOp.Sum), "dtype": pl.FP32},
+    )
 
 
 def test_implicit_host_allreduce_synthesizes_signal_then_lowers():
@@ -180,20 +261,14 @@ def test_implicit_host_allreduce_synthesizes_signal_then_lowers():
     result = passes.lower_host_tensor_collectives()(program)
     host = _get_func(result, "host_orch")
 
-    loops = _collect_for_stmts(host.body)
-    builtin_loops = [
-        loop
-        for loop in loops
-        if isinstance(loop.body, ir.EvalStmt)
-        and isinstance(loop.body.expr, ir.Call)
-        and loop.body.expr.op.name == "builtin.tensor.allreduce"
-    ]
-    assert len(builtin_loops) == 1
-
-    call = _eval_call(builtin_loops[0].body)
-    assert len(call.args) == 2
-    assert _as_var(call.args[1]).name_hint == "__allreduce_signal_0"
-    assert list(call.arg_directions) == [ir.ArgDirection.InOut, ir.ArgDirection.InOut]
+    _assert_builtin_dispatch(
+        host.body,
+        "builtin.tensor.allreduce",
+        arg_names=["data", "__allreduce_signal_0"],
+        arg_directions=[ir.ArgDirection.InOut, ir.ArgDirection.InOut],
+        kwargs={"op": int(pld.ReduceOp.Sum), "dtype": pl.FP32},
+        attrs={"op": int(pld.ReduceOp.Sum), "dtype": pl.FP32},
+    )
 
 
 def test_return_implicit_host_allreduce_synthesizes_signal_then_lowers():
@@ -216,14 +291,6 @@ def test_return_implicit_host_allreduce_synthesizes_signal_then_lowers():
     result = cast(ir.Program, passes.lower_host_tensor_collectives()(program))
     host = _get_func(result, "host_orch")
 
-    loops = _collect_for_stmts(host.body)
-    builtin_loops = [
-        loop
-        for loop in loops
-        if isinstance(loop.body, ir.EvalStmt)
-        and isinstance(loop.body.expr, ir.Call)
-        and loop.body.expr.op.name == "builtin.tensor.allreduce"
-    ]
     returns = [
         stmt
         for stmt in _collect_assign_stmts(host.body)
@@ -231,11 +298,14 @@ def test_return_implicit_host_allreduce_synthesizes_signal_then_lowers():
     ]
     return_stmts = _collect_return_stmts(host.body)
 
-    assert len(builtin_loops) == 1
-    call = _eval_call(builtin_loops[0].body)
-    assert len(call.args) == 2
-    assert _as_var(call.args[1]).name_hint == "__allreduce_signal_0"
-    assert list(call.arg_directions) == [ir.ArgDirection.InOut, ir.ArgDirection.InOut]
+    _assert_builtin_dispatch(
+        host.body,
+        "builtin.tensor.allreduce",
+        arg_names=["data", "__allreduce_signal_0"],
+        arg_directions=[ir.ArgDirection.InOut, ir.ArgDirection.InOut],
+        kwargs={"op": int(pld.ReduceOp.Sum), "dtype": pl.FP32},
+        attrs={"op": int(pld.ReduceOp.Sum), "dtype": pl.FP32},
+    )
     assert len(returns) == 1
     _assert_alias_keeps_window_buffer(returns[0])
     assert len(return_stmts) == 1
@@ -266,14 +336,6 @@ def test_return_explicit_host_allreduce_lowers_with_user_signal():
     result = cast(ir.Program, passes.lower_host_tensor_collectives()(program))
     host = _get_func(result, "host_orch")
 
-    loops = _collect_for_stmts(host.body)
-    builtin_loops = [
-        loop
-        for loop in loops
-        if isinstance(loop.body, ir.EvalStmt)
-        and isinstance(loop.body.expr, ir.Call)
-        and loop.body.expr.op.name == "builtin.tensor.allreduce"
-    ]
     returns = [
         stmt
         for stmt in _collect_assign_stmts(host.body)
@@ -281,11 +343,14 @@ def test_return_explicit_host_allreduce_lowers_with_user_signal():
     ]
     return_stmts = _collect_return_stmts(host.body)
 
-    assert len(builtin_loops) == 1
-    call = _eval_call(builtin_loops[0].body)
-    assert len(call.args) == 2
-    assert _as_var(call.args[1]).name_hint == "signal"
-    assert list(call.arg_directions) == [ir.ArgDirection.InOut, ir.ArgDirection.InOut]
+    _assert_builtin_dispatch(
+        host.body,
+        "builtin.tensor.allreduce",
+        arg_names=["data", "signal"],
+        arg_directions=[ir.ArgDirection.InOut, ir.ArgDirection.InOut],
+        kwargs={"op": int(pld.ReduceOp.Sum), "dtype": pl.FP32},
+        attrs={"op": int(pld.ReduceOp.Sum), "dtype": pl.FP32},
+    )
     assert len(returns) == 1
     _assert_alias_keeps_window_buffer(returns[0])
     assert len(return_stmts) == 1
@@ -501,20 +566,13 @@ def test_host_barrier_lowers_to_builtin_world_size_loop():
     program = passes.materialize_comm_domain_scopes()(P)
     result = passes.lower_host_tensor_collectives()(program)
     host = _get_func(result, "host_orch")
-    loops = _collect_for_stmts(host.body)
-    builtin_loops = [
-        loop
-        for loop in loops
-        if isinstance(loop.body, ir.EvalStmt)
-        and isinstance(loop.body.expr, ir.Call)
-        and loop.body.expr.op.name == "builtin.tensor.barrier"
-    ]
-    assert len(builtin_loops) == 1
-    body = builtin_loops[0].body
-    assert isinstance(body, ir.EvalStmt)
-    call = body.expr
-    assert isinstance(call, ir.Call)
-    assert list(call.arg_directions) == [ir.ArgDirection.InOut]
+    _assert_builtin_dispatch(
+        host.body,
+        "builtin.tensor.barrier",
+        arg_names=["signal"],
+        arg_directions=[ir.ArgDirection.InOut],
+        kwargs={},
+    )
 
 
 def test_host_broadcast_lowers_to_builtin_world_size_loop():
@@ -540,21 +598,14 @@ def test_host_broadcast_lowers_to_builtin_world_size_loop():
     program = passes.materialize_comm_domain_scopes()(P)
     result = passes.lower_host_tensor_collectives()(program)
     host = _get_func(result, "host_orch")
-    loops = _collect_for_stmts(host.body)
-    builtin_loops = [
-        loop
-        for loop in loops
-        if isinstance(loop.body, ir.EvalStmt)
-        and isinstance(loop.body.expr, ir.Call)
-        and loop.body.expr.op.name == "builtin.tensor.broadcast"
-    ]
-    assert len(builtin_loops) == 1
-    body = builtin_loops[0].body
-    assert isinstance(body, ir.EvalStmt)
-    call = body.expr
-    assert isinstance(call, ir.Call)
-    assert list(call.arg_directions) == [ir.ArgDirection.InOut, ir.ArgDirection.InOut]
-    assert call.kwargs["root"] == 0
+    _assert_builtin_dispatch(
+        host.body,
+        "builtin.tensor.broadcast",
+        arg_names=["data", "signal"],
+        arg_directions=[ir.ArgDirection.InOut, ir.ArgDirection.InOut],
+        kwargs={"root": 0, "dtype": pl.FP32},
+        attrs={"root": 0, "dtype": pl.FP32},
+    )
 
 
 def test_host_reduce_scatter_lowers_to_builtin_world_size_loop():
@@ -580,21 +631,14 @@ def test_host_reduce_scatter_lowers_to_builtin_world_size_loop():
     program = passes.materialize_comm_domain_scopes()(P)
     result = passes.lower_host_tensor_collectives()(program)
     host = _get_func(result, "host_orch")
-    loops = _collect_for_stmts(host.body)
-    builtin_loops = [
-        loop
-        for loop in loops
-        if isinstance(loop.body, ir.EvalStmt)
-        and isinstance(loop.body.expr, ir.Call)
-        and loop.body.expr.op.name == "builtin.tensor.reduce_scatter"
-    ]
-    assert len(builtin_loops) == 1
-    body = builtin_loops[0].body
-    assert isinstance(body, ir.EvalStmt)
-    call = body.expr
-    assert isinstance(call, ir.Call)
-    assert list(call.arg_directions) == [ir.ArgDirection.InOut, ir.ArgDirection.InOut]
-    assert call.kwargs["op"] == int(pld.ReduceOp.Sum)
+    _assert_builtin_dispatch(
+        host.body,
+        "builtin.tensor.reduce_scatter",
+        arg_names=["data", "signal"],
+        arg_directions=[ir.ArgDirection.InOut, ir.ArgDirection.InOut],
+        kwargs={"op": int(pld.ReduceOp.Sum), "dtype": pl.FP32},
+        attrs={"op": int(pld.ReduceOp.Sum), "dtype": pl.FP32},
+    )
 
 
 def test_host_allgather_lowers_to_namesake_builtin():
@@ -629,25 +673,18 @@ def test_host_allgather_lowers_to_namesake_builtin():
     program = passes.materialize_comm_domain_scopes()(P)
     result = passes.lower_host_tensor_collectives()(program)
     host = _get_func(result, "host_orch")
-    loops = _collect_for_stmts(host.body)
-    builtin_loops = [
-        loop
-        for loop in loops
-        if isinstance(loop.body, ir.EvalStmt)
-        and isinstance(loop.body.expr, ir.Call)
-        and loop.body.expr.op.name == "builtin.tensor.allgather"
-    ]
-    assert len(builtin_loops) == 1
-    body = builtin_loops[0].body
-    assert isinstance(body, ir.EvalStmt)
-    call = body.expr
-    assert isinstance(call, ir.Call)
-    assert list(call.arg_directions) == [
-        ir.ArgDirection.Input,
-        ir.ArgDirection.InOut,
-        ir.ArgDirection.InOut,
-    ]
-    assert call.kwargs["dtype"] == DataType.FP32
+    _assert_builtin_dispatch(
+        host.body,
+        "builtin.tensor.allgather",
+        arg_names=["stage", "data", "signal"],
+        arg_directions=[
+            ir.ArgDirection.Input,
+            ir.ArgDirection.InOut,
+            ir.ArgDirection.InOut,
+        ],
+        kwargs={"dtype": pl.FP32},
+        attrs={"dtype": pl.FP32},
+    )
 
 
 def test_host_allgather_rejects_aliased_input_target_windows():
@@ -746,25 +783,417 @@ def test_host_all_to_all_lowers_to_namesake_builtin():
     result = passes.lower_host_tensor_collectives()(program)
     host = _get_func(result, "host_orch")
 
-    loops = _collect_for_stmts(host.body)
-    builtin_loops = [
-        loop
-        for loop in loops
-        if isinstance(loop.body, ir.EvalStmt)
-        and isinstance(loop.body.expr, ir.Call)
-        and loop.body.expr.op.name == "builtin.tensor.all_to_all"
-    ]
-    assert len(builtin_loops) == 1
-    body = builtin_loops[0].body
-    assert isinstance(body, ir.EvalStmt)
-    call = body.expr
-    assert isinstance(call, ir.Call)
-    assert list(call.arg_directions) == [
-        ir.ArgDirection.Input,
-        ir.ArgDirection.InOut,
-        ir.ArgDirection.InOut,
-    ]
-    assert call.kwargs["dtype"] == DataType.FP32
+    _assert_builtin_dispatch(
+        host.body,
+        "builtin.tensor.all_to_all",
+        arg_names=["stage", "data", "signal"],
+        arg_directions=[
+            ir.ArgDirection.Input,
+            ir.ArgDirection.InOut,
+            ir.ArgDirection.InOut,
+        ],
+        kwargs={"dtype": pl.FP32},
+        attrs={"dtype": pl.FP32},
+    )
+
+
+def test_host_all_to_all_v_rejects_aliased_input_target_windows():
+    """Two pld.window views over one alloc must fail at host lowering."""
+
+    @pl.program
+    class P:
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def chip_orch(
+            self,
+            inp: pld.DistributedTensor[[8, 256], pl.FP32],
+            data: pld.DistributedTensor[[8, 256], pl.FP32],
+            sig: pld.DistributedTensor[[4, 1], pl.INT32],
+            counts: pld.DistributedTensor[[4, 1], pl.INT32],
+            recv: pld.DistributedTensor[[4, 1], pl.INT32],
+        ):
+            return data
+
+        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+        def host_orch(self):
+            buf = pld.alloc_window_buffer(8 * 256 * pl.FP32.get_byte())
+            signal_buf = pld.alloc_window_buffer(4 * pl.INT32.get_byte())
+            counts_buf = pld.alloc_window_buffer(4 * pl.INT32.get_byte())
+            recv_buf = pld.alloc_window_buffer(4 * pl.INT32.get_byte())
+            inp = pld.window(buf, [8, 256], dtype=pl.FP32)
+            data = pld.window(buf, [8, 256], dtype=pl.FP32)
+            signal = pld.window(signal_buf, [4, 1], dtype=pl.INT32)
+            counts = pld.window(counts_buf, [4, 1], dtype=pl.INT32)
+            recv = pld.window(recv_buf, [4, 1], dtype=pl.INT32)
+            for r in pl.range(pld.world_size()):
+                self.chip_orch(inp, data, signal, counts, recv, device=r)
+            data = pld.tensor.all_to_all_v(inp, data, signal, counts, recv)
+            return 0
+
+    program = passes.materialize_comm_domain_scopes()(P)
+    with pytest.raises(ValueError, match=r"different window allocations"):
+        passes.lower_host_tensor_collectives()(program)
+
+
+def test_host_all_to_all_v_lowers_to_namesake_builtin():
+    @pl.program
+    class P:
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def chip_orch(
+            self,
+            inp: pld.DistributedTensor[[8, 256], pl.FP32],
+            data: pld.DistributedTensor[[8, 256], pl.FP32],
+            sig: pld.DistributedTensor[[4, 1], pl.INT32],
+            counts: pld.DistributedTensor[[4, 1], pl.INT32],
+            recv: pld.DistributedTensor[[4, 1], pl.INT32],
+        ):
+            return data
+
+        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+        def host_orch(self):
+            # `input_buf` (TPUT source) and `data_buf` (TPUT destination /
+            # result) must be two DISTINCT windows — same discipline as
+            # symmetric all_to_all (see kernel.cpp.in for the race
+            # explanation).
+            input_buf = pld.alloc_window_buffer(8 * 256 * pl.FP32.get_byte())
+            data_buf = pld.alloc_window_buffer(8 * 256 * pl.FP32.get_byte())
+            signal_buf = pld.alloc_window_buffer(4 * pl.INT32.get_byte())
+            counts_buf = pld.alloc_window_buffer(4 * pl.INT32.get_byte())
+            recv_buf = pld.alloc_window_buffer(4 * pl.INT32.get_byte())
+            inp = pld.window(input_buf, [8, 256], dtype=pl.FP32)
+            data = pld.window(data_buf, [8, 256], dtype=pl.FP32)
+            signal = pld.window(signal_buf, [4, 1], dtype=pl.INT32)
+            counts = pld.window(counts_buf, [4, 1], dtype=pl.INT32)
+            recv = pld.window(recv_buf, [4, 1], dtype=pl.INT32)
+            for r in pl.range(pld.world_size()):
+                self.chip_orch(inp, data, signal, counts, recv, device=r)
+            data = pld.tensor.all_to_all_v(inp, data, signal, counts, recv)
+            return 0
+
+    program = passes.materialize_comm_domain_scopes()(P)
+    result = passes.lower_host_tensor_collectives()(program)
+    host = _get_func(result, "host_orch")
+    _assert_builtin_dispatch(
+        host.body,
+        "builtin.tensor.all_to_all_v",
+        arg_names=["inp", "data", "signal", "counts", "recv"],
+        arg_directions=[
+            ir.ArgDirection.Input,
+            ir.ArgDirection.InOut,
+            ir.ArgDirection.InOut,
+            ir.ArgDirection.Input,
+            ir.ArgDirection.InOut,
+        ],
+        kwargs={"dtype": pl.FP32},
+        attrs={"dtype": pl.FP32},
+    )
+
+
+def test_host_all_to_all_v_rejects_plain_tensor_input():
+    """pld.tensor.all_to_all_v's public deducer accepts a plain Tensor for
+    `input` (legitimate on the InCore composite path), but the HOST builtin
+    requires it window-bound. This must surface as a CHECK_SPAN ValueError,
+    not an internal crash inside GetWindowBuffer."""
+
+    @pl.program
+    class P:
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def chip_orch(
+            self,
+            inp: pl.Tensor[[8, 256], pl.FP32],
+            data: pld.DistributedTensor[[8, 256], pl.FP32],
+            sig: pld.DistributedTensor[[4, 1], pl.INT32],
+            counts: pld.DistributedTensor[[4, 1], pl.INT32],
+            recv: pld.DistributedTensor[[4, 1], pl.INT32],
+        ):
+            return data
+
+        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+        def host_orch(self, inp: pl.Tensor[[8, 256], pl.FP32]):
+            data_buf = pld.alloc_window_buffer(8 * 256 * pl.FP32.get_byte())
+            signal_buf = pld.alloc_window_buffer(4 * pl.INT32.get_byte())
+            counts_buf = pld.alloc_window_buffer(4 * pl.INT32.get_byte())
+            recv_buf = pld.alloc_window_buffer(4 * pl.INT32.get_byte())
+            data = pld.window(data_buf, [8, 256], dtype=pl.FP32)
+            signal = pld.window(signal_buf, [4, 1], dtype=pl.INT32)
+            counts = pld.window(counts_buf, [4, 1], dtype=pl.INT32)
+            recv = pld.window(recv_buf, [4, 1], dtype=pl.INT32)
+            for r in pl.range(pld.world_size()):
+                self.chip_orch(inp, data, signal, counts, recv, device=r)
+            data = pld.tensor.all_to_all_v(inp, data, signal, counts, recv)
+            return 0
+
+    program = passes.materialize_comm_domain_scopes()(P)
+    with pytest.raises(ValueError, match=r"input must be a window-bound DistributedTensor"):
+        passes.lower_host_tensor_collectives()(program)
+
+
+def test_host_all_to_all_v_rejects_plain_tensor_send_counts():
+    """Same as above, for `send_counts` (also AsTensorTypeLike on the
+    composite path, but window-bound-only at the HOST builtin layer)."""
+
+    @pl.program
+    class P:
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def chip_orch(
+            self,
+            inp: pld.DistributedTensor[[8, 256], pl.FP32],
+            data: pld.DistributedTensor[[8, 256], pl.FP32],
+            sig: pld.DistributedTensor[[4, 1], pl.INT32],
+            counts: pl.Tensor[[4, 1], pl.INT32],
+            recv: pld.DistributedTensor[[4, 1], pl.INT32],
+        ):
+            return data
+
+        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+        def host_orch(self, counts: pl.Tensor[[4, 1], pl.INT32]):
+            input_buf = pld.alloc_window_buffer(8 * 256 * pl.FP32.get_byte())
+            data_buf = pld.alloc_window_buffer(8 * 256 * pl.FP32.get_byte())
+            signal_buf = pld.alloc_window_buffer(4 * pl.INT32.get_byte())
+            recv_buf = pld.alloc_window_buffer(4 * pl.INT32.get_byte())
+            inp = pld.window(input_buf, [8, 256], dtype=pl.FP32)
+            data = pld.window(data_buf, [8, 256], dtype=pl.FP32)
+            signal = pld.window(signal_buf, [4, 1], dtype=pl.INT32)
+            recv = pld.window(recv_buf, [4, 1], dtype=pl.INT32)
+            for r in pl.range(pld.world_size()):
+                self.chip_orch(inp, data, signal, counts, recv, device=r)
+            data = pld.tensor.all_to_all_v(inp, data, signal, counts, recv)
+            return 0
+
+    program = passes.materialize_comm_domain_scopes()(P)
+    with pytest.raises(ValueError, match=r"send_counts must be a window-bound DistributedTensor"):
+        passes.lower_host_tensor_collectives()(program)
+
+
+def test_host_all_to_all_v_rejects_unbound_distributed_input():
+    """A user-declared ``pld.DistributedTensor`` parameter has ``window_buffer_
+    == nullopt`` (never bound by ``pld.tensor.window``), so it passes a
+    kind-only type check and would crash inside ``GetWindowBuffer``. Passing
+    one as ``input`` must surface as the same documented CHECK_SPAN ValueError,
+    not an INTERNAL_CHECK_SPAN compiler-invariant failure."""
+
+    @pl.program
+    class P:
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def chip_orch(
+            self,
+            inp: pld.DistributedTensor[[8, 256], pl.FP32],
+            data: pld.DistributedTensor[[8, 256], pl.FP32],
+            sig: pld.DistributedTensor[[4, 1], pl.INT32],
+            counts: pld.DistributedTensor[[4, 1], pl.INT32],
+            recv: pld.DistributedTensor[[4, 1], pl.INT32],
+        ):
+            return data
+
+        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+        def host_orch(self, inp: pld.DistributedTensor[[8, 256], pl.FP32]):
+            data_buf = pld.alloc_window_buffer(8 * 256 * pl.FP32.get_byte())
+            signal_buf = pld.alloc_window_buffer(4 * pl.INT32.get_byte())
+            counts_buf = pld.alloc_window_buffer(4 * pl.INT32.get_byte())
+            recv_buf = pld.alloc_window_buffer(4 * pl.INT32.get_byte())
+            data = pld.window(data_buf, [8, 256], dtype=pl.FP32)
+            signal = pld.window(signal_buf, [4, 1], dtype=pl.INT32)
+            counts = pld.window(counts_buf, [4, 1], dtype=pl.INT32)
+            recv = pld.window(recv_buf, [4, 1], dtype=pl.INT32)
+            for r in pl.range(pld.world_size()):
+                self.chip_orch(inp, data, signal, counts, recv, device=r)
+            data = pld.tensor.all_to_all_v(inp, data, signal, counts, recv)
+            return 0
+
+    program = passes.materialize_comm_domain_scopes()(P)
+    with pytest.raises(ValueError, match=r"input must be a window-bound DistributedTensor"):
+        passes.lower_host_tensor_collectives()(program)
+
+
+def test_host_all_to_all_v_rejects_unbound_distributed_send_counts():
+    """Same as above, for `send_counts` (a user-declared DistributedTensor
+    parameter, unbound by any ``pld.tensor.window``)."""
+
+    @pl.program
+    class P:
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def chip_orch(
+            self,
+            inp: pld.DistributedTensor[[8, 256], pl.FP32],
+            data: pld.DistributedTensor[[8, 256], pl.FP32],
+            sig: pld.DistributedTensor[[4, 1], pl.INT32],
+            counts: pld.DistributedTensor[[4, 1], pl.INT32],
+            recv: pld.DistributedTensor[[4, 1], pl.INT32],
+        ):
+            return data
+
+        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+        def host_orch(self, counts: pld.DistributedTensor[[4, 1], pl.INT32]):
+            input_buf = pld.alloc_window_buffer(8 * 256 * pl.FP32.get_byte())
+            data_buf = pld.alloc_window_buffer(8 * 256 * pl.FP32.get_byte())
+            signal_buf = pld.alloc_window_buffer(4 * pl.INT32.get_byte())
+            recv_buf = pld.alloc_window_buffer(4 * pl.INT32.get_byte())
+            inp = pld.window(input_buf, [8, 256], dtype=pl.FP32)
+            data = pld.window(data_buf, [8, 256], dtype=pl.FP32)
+            signal = pld.window(signal_buf, [4, 1], dtype=pl.INT32)
+            recv = pld.window(recv_buf, [4, 1], dtype=pl.INT32)
+            for r in pl.range(pld.world_size()):
+                self.chip_orch(inp, data, signal, counts, recv, device=r)
+            data = pld.tensor.all_to_all_v(inp, data, signal, counts, recv)
+            return 0
+
+    program = passes.materialize_comm_domain_scopes()(P)
+    with pytest.raises(ValueError, match=r"send_counts must be a window-bound DistributedTensor"):
+        passes.lower_host_tensor_collectives()(program)
+
+
+def test_host_all_to_all_v_rejects_aliased_signal_recv_counts():
+    """signal and recv_counts are separate INT32 control windows — aliasing
+    them lets the barrier's notify(Set, 1) clobber a just-published count."""
+
+    @pl.program
+    class P:
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def chip_orch(
+            self,
+            inp: pld.DistributedTensor[[8, 256], pl.FP32],
+            data: pld.DistributedTensor[[8, 256], pl.FP32],
+            sig: pld.DistributedTensor[[4, 1], pl.INT32],
+            counts: pld.DistributedTensor[[4, 1], pl.INT32],
+        ):
+            return data
+
+        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+        def host_orch(self):
+            input_buf = pld.alloc_window_buffer(8 * 256 * pl.FP32.get_byte())
+            data_buf = pld.alloc_window_buffer(8 * 256 * pl.FP32.get_byte())
+            signal_buf = pld.alloc_window_buffer(4 * pl.INT32.get_byte())
+            counts_buf = pld.alloc_window_buffer(4 * pl.INT32.get_byte())
+            inp = pld.window(input_buf, [8, 256], dtype=pl.FP32)
+            data = pld.window(data_buf, [8, 256], dtype=pl.FP32)
+            signal = pld.window(signal_buf, [4, 1], dtype=pl.INT32)
+            counts = pld.window(counts_buf, [4, 1], dtype=pl.INT32)
+            for r in pl.range(pld.world_size()):
+                self.chip_orch(inp, data, signal, counts, device=r)
+            # recv_counts aliases signal's own window buffer.
+            recv = pld.window(signal_buf, [4, 1], dtype=pl.INT32)
+            data = pld.tensor.all_to_all_v(inp, data, signal, counts, recv)
+            return 0
+
+    program = passes.materialize_comm_domain_scopes()(P)
+    with pytest.raises(ValueError, match=r"signal and recv_counts must be different window allocations"):
+        passes.lower_host_tensor_collectives()(program)
+
+
+def test_host_all_to_all_v_rejects_aliased_send_counts_recv_counts():
+    """send_counts aliasing recv_counts lets the kernel's local count read
+    race a peer's cross-rank notify write into the same memory."""
+
+    @pl.program
+    class P:
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def chip_orch(
+            self,
+            inp: pld.DistributedTensor[[8, 256], pl.FP32],
+            data: pld.DistributedTensor[[8, 256], pl.FP32],
+            counts: pld.DistributedTensor[[4, 1], pl.INT32],
+        ):
+            return data
+
+        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+        def host_orch(self):
+            input_buf = pld.alloc_window_buffer(8 * 256 * pl.FP32.get_byte())
+            data_buf = pld.alloc_window_buffer(8 * 256 * pl.FP32.get_byte())
+            signal_buf = pld.alloc_window_buffer(4 * pl.INT32.get_byte())
+            recv_buf = pld.alloc_window_buffer(4 * pl.INT32.get_byte())
+            inp = pld.window(input_buf, [8, 256], dtype=pl.FP32)
+            data = pld.window(data_buf, [8, 256], dtype=pl.FP32)
+            signal = pld.window(signal_buf, [4, 1], dtype=pl.INT32)
+            recv = pld.window(recv_buf, [4, 1], dtype=pl.INT32)
+            for r in pl.range(pld.world_size()):
+                self.chip_orch(inp, data, recv, device=r)
+            # send_counts aliases recv_counts's own window buffer.
+            counts = pld.window(recv_buf, [4, 1], dtype=pl.INT32)
+            data = pld.tensor.all_to_all_v(inp, data, signal, counts, recv)
+            return 0
+
+    program = passes.materialize_comm_domain_scopes()(P)
+    with pytest.raises(ValueError, match=r"send_counts and recv_counts must be different window allocations"):
+        passes.lower_host_tensor_collectives()(program)
+
+
+def test_host_all_to_all_v_rejects_aliased_input_signal_windows():
+    """input is a data window and signal is a control window, but sharing an
+    allocation still races: a peer's notify(Set, 1) can clobber data this
+    rank is still TPUT-reading out of `input`."""
+
+    @pl.program
+    class P:
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def chip_orch(
+            self,
+            inp: pld.DistributedTensor[[8, 256], pl.FP32],
+            data: pld.DistributedTensor[[8, 256], pl.FP32],
+            sig: pld.DistributedTensor[[4, 1], pl.INT32],
+            counts: pld.DistributedTensor[[4, 1], pl.INT32],
+            recv: pld.DistributedTensor[[4, 1], pl.INT32],
+        ):
+            return data
+
+        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+        def host_orch(self):
+            signal_buf = pld.alloc_window_buffer(4 * pl.INT32.get_byte())
+            data_buf = pld.alloc_window_buffer(8 * 256 * pl.FP32.get_byte())
+            counts_buf = pld.alloc_window_buffer(4 * pl.INT32.get_byte())
+            recv_buf = pld.alloc_window_buffer(4 * pl.INT32.get_byte())
+            # input aliases signal's own window buffer.
+            inp = pld.window(signal_buf, [8, 256], dtype=pl.FP32)
+            data = pld.window(data_buf, [8, 256], dtype=pl.FP32)
+            signal = pld.window(signal_buf, [4, 1], dtype=pl.INT32)
+            counts = pld.window(counts_buf, [4, 1], dtype=pl.INT32)
+            recv = pld.window(recv_buf, [4, 1], dtype=pl.INT32)
+            for r in pl.range(pld.world_size()):
+                self.chip_orch(inp, data, signal, counts, recv, device=r)
+            data = pld.tensor.all_to_all_v(inp, data, signal, counts, recv)
+            return 0
+
+    program = passes.materialize_comm_domain_scopes()(P)
+    with pytest.raises(ValueError, match=r"input and signal must be different window allocations"):
+        passes.lower_host_tensor_collectives()(program)
+
+
+def test_host_all_to_all_v_rejects_aliased_target_recv_counts_windows():
+    """target is a data window and recv_counts is a control window, but
+    sharing an allocation still races: the cross-rank count publish can
+    clobber data a peer's TPUT is writing into `target`."""
+
+    @pl.program
+    class P:
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def chip_orch(
+            self,
+            inp: pld.DistributedTensor[[8, 256], pl.FP32],
+            data: pld.DistributedTensor[[8, 256], pl.FP32],
+            sig: pld.DistributedTensor[[4, 1], pl.INT32],
+            counts: pld.DistributedTensor[[4, 1], pl.INT32],
+            recv: pld.DistributedTensor[[4, 1], pl.INT32],
+        ):
+            return data
+
+        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+        def host_orch(self):
+            input_buf = pld.alloc_window_buffer(8 * 256 * pl.FP32.get_byte())
+            recv_buf = pld.alloc_window_buffer(4 * pl.INT32.get_byte())
+            signal_buf = pld.alloc_window_buffer(4 * pl.INT32.get_byte())
+            counts_buf = pld.alloc_window_buffer(4 * pl.INT32.get_byte())
+            inp = pld.window(input_buf, [8, 256], dtype=pl.FP32)
+            # target aliases recv_counts's own window buffer.
+            data = pld.window(recv_buf, [8, 256], dtype=pl.FP32)
+            signal = pld.window(signal_buf, [4, 1], dtype=pl.INT32)
+            counts = pld.window(counts_buf, [4, 1], dtype=pl.INT32)
+            recv = pld.window(recv_buf, [4, 1], dtype=pl.INT32)
+            for r in pl.range(pld.world_size()):
+                self.chip_orch(inp, data, signal, counts, recv, device=r)
+            data = pld.tensor.all_to_all_v(inp, data, signal, counts, recv)
+            return 0
+
+    program = passes.materialize_comm_domain_scopes()(P)
+    with pytest.raises(ValueError, match=r"target and recv_counts must be different window allocations"):
+        passes.lower_host_tensor_collectives()(program)
 
 
 def test_lowered_collective_is_printable_with_dtype_attr():
@@ -826,20 +1255,14 @@ def test_host_allreduce_ring_lowers_to_ring_builtin():
     result = cast(ir.Program, passes.lower_host_tensor_collectives()(program))
     host = _get_func(result, "host_orch")
 
-    loops = _collect_for_stmts(host.body)
-    builtin_loops = [
-        loop
-        for loop in loops
-        if isinstance(loop.body, ir.EvalStmt)
-        and isinstance(loop.body.expr, ir.Call)
-        and loop.body.expr.op.name == ir.get_op("builtin.tensor.allreduce_ring").name
-    ]
-    assert len(builtin_loops) == 1
-
-    call = _eval_call(builtin_loops[0].body)
-    assert call.kwargs["op"] == int(pld.ReduceOp.Sum)
-    assert call.kwargs["dtype"] == pl.FP32
-    assert list(call.arg_directions) == [ir.ArgDirection.InOut, ir.ArgDirection.InOut]
+    _assert_builtin_dispatch(
+        host.body,
+        "builtin.tensor.allreduce_ring",
+        arg_names=["data", "signal"],
+        arg_directions=[ir.ArgDirection.InOut, ir.ArgDirection.InOut],
+        kwargs={"op": int(pld.ReduceOp.Sum), "dtype": pl.FP32},
+        attrs={"op": int(pld.ReduceOp.Sum), "dtype": pl.FP32},
+    )
 
 
 def test_host_allreduce_rejects_unknown_mode():

--- a/tests/ut/ir/transforms/test_materialize_comm_domain_scopes.py
+++ b/tests/ut/ir/transforms/test_materialize_comm_domain_scopes.py
@@ -988,6 +988,138 @@ def test_explicit_allreduce_in_while_loop_is_rejected():
         _apply(P)
 
 
+def test_all_to_all_v_signal_and_recv_counts_inherit_data_comm_domain():
+    """signal and recv_counts (both device-descriptor-less) each register their
+    own CollectiveConsumer entry sharing all_to_all_v's target alloc, so both
+    inherit target's device coverage — send_counts does not (its coverage comes
+    from its own dispatch site, like symmetric all_to_all's `input`).
+
+    chip_orch deliberately does NOT take `signal`/`recv` as params (unlike the
+    lowering-rule tests) — if it did, the per-rank dispatch loop would give
+    them their own device descriptors directly, and this test would pass even
+    with the two new CollectiveConsumer entries removed. Matches
+    test_allreduce_signal_inherits_data_comm_domain's discipline of leaving
+    the signal-like arg out of the dispatch site so only the collective's own
+    inheritance mechanism can supply its coverage.
+    """
+
+    @pl.program
+    class P:
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def chip_orch(
+            self,
+            inp: pld.DistributedTensor[[8, 64], pl.FP32],
+            data: pld.DistributedTensor[[8, 64], pl.FP32],
+            counts: pld.DistributedTensor[[4, 1], pl.INT32],
+        ):
+            return data
+
+        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+        def host_orch(self):
+            input_buf = pld.alloc_window_buffer(8 * 64 * pl.FP32.get_byte())
+            data_buf = pld.alloc_window_buffer(8 * 64 * pl.FP32.get_byte())
+            signal_buf = pld.alloc_window_buffer(4 * pl.INT32.get_byte())
+            counts_buf = pld.alloc_window_buffer(4 * pl.INT32.get_byte())
+            recv_buf = pld.alloc_window_buffer(4 * pl.INT32.get_byte())
+            inp = pld.window(input_buf, [8, 64], dtype=pl.FP32)
+            data = pld.window(data_buf, [8, 64], dtype=pl.FP32)
+            counts = pld.window(counts_buf, [4, 1], dtype=pl.INT32)
+            for r in pl.range(pld.world_size()):
+                self.chip_orch(inp, data, counts, device=r)
+            signal = pld.window(signal_buf, [4, 1], dtype=pl.INT32)
+            recv = pld.window(recv_buf, [4, 1], dtype=pl.INT32)
+            pld.tensor.all_to_all_v(inp, data, signal, counts, recv)
+            return 0
+
+    result = _apply(P)
+    host = _get_func(result, "host_orch")
+    scopes = _get_comm_domain_scopes(host)
+    assert len(scopes) == 1
+    _assert_scope_fields(
+        scopes[0],
+        [],
+        [
+            _expected_slot("input_buf", _mul(8 * 64, 4)),
+            _expected_slot("data_buf", _mul(8 * 64, 4)),
+            _expected_slot("signal_buf", _mul(4, 4)),
+            _expected_slot("counts_buf", _mul(4, 4)),
+            _expected_slot("recv_buf", _mul(4, 4)),
+        ],
+    )
+
+
+def test_all_to_all_v_in_loop_is_rejected():
+    @pl.program
+    class P:
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def chip_orch(
+            self,
+            inp: pld.DistributedTensor[[8, 64], pl.FP32],
+            data: pld.DistributedTensor[[8, 64], pl.FP32],
+            sig: pld.DistributedTensor[[4, 1], pl.INT32],
+            counts: pld.DistributedTensor[[4, 1], pl.INT32],
+            recv: pld.DistributedTensor[[4, 1], pl.INT32],
+        ):
+            return data
+
+        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+        def host_orch(self):
+            input_buf = pld.alloc_window_buffer(8 * 64 * pl.FP32.get_byte())
+            data_buf = pld.alloc_window_buffer(8 * 64 * pl.FP32.get_byte())
+            signal_buf = pld.alloc_window_buffer(4 * pl.INT32.get_byte())
+            counts_buf = pld.alloc_window_buffer(4 * pl.INT32.get_byte())
+            recv_buf = pld.alloc_window_buffer(4 * pl.INT32.get_byte())
+            inp = pld.window(input_buf, [8, 64], dtype=pl.FP32)
+            data = pld.window(data_buf, [8, 64], dtype=pl.FP32)
+            signal = pld.window(signal_buf, [4, 1], dtype=pl.INT32)
+            counts = pld.window(counts_buf, [4, 1], dtype=pl.INT32)
+            recv = pld.window(recv_buf, [4, 1], dtype=pl.INT32)
+            for r in pl.range(pld.world_size()):
+                self.chip_orch(inp, data, signal, counts, recv, device=r)
+            for _ in pl.range(2):
+                data = pld.tensor.all_to_all_v(inp, data, signal, counts, recv)
+            return 0
+
+    with pytest.raises(ValueError, match="all_to_all_v is not supported inside a for/while loop"):
+        _apply(P)
+
+
+def test_all_to_all_v_in_while_loop_is_rejected():
+    @pl.program
+    class P:
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def chip_orch(
+            self,
+            inp: pld.DistributedTensor[[8, 64], pl.FP32],
+            data: pld.DistributedTensor[[8, 64], pl.FP32],
+            sig: pld.DistributedTensor[[4, 1], pl.INT32],
+            counts: pld.DistributedTensor[[4, 1], pl.INT32],
+            recv: pld.DistributedTensor[[4, 1], pl.INT32],
+        ):
+            return data
+
+        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+        def host_orch(self):
+            input_buf = pld.alloc_window_buffer(8 * 64 * pl.FP32.get_byte())
+            data_buf = pld.alloc_window_buffer(8 * 64 * pl.FP32.get_byte())
+            signal_buf = pld.alloc_window_buffer(4 * pl.INT32.get_byte())
+            counts_buf = pld.alloc_window_buffer(4 * pl.INT32.get_byte())
+            recv_buf = pld.alloc_window_buffer(4 * pl.INT32.get_byte())
+            inp = pld.window(input_buf, [8, 64], dtype=pl.FP32)
+            data = pld.window(data_buf, [8, 64], dtype=pl.FP32)
+            signal = pld.window(signal_buf, [4, 1], dtype=pl.INT32)
+            counts = pld.window(counts_buf, [4, 1], dtype=pl.INT32)
+            recv = pld.window(recv_buf, [4, 1], dtype=pl.INT32)
+            for r in pl.range(pld.world_size()):
+                self.chip_orch(inp, data, signal, counts, recv, device=r)
+            while True:
+                data = pld.tensor.all_to_all_v(inp, data, signal, counts, recv)
+            return 0
+
+    with pytest.raises(ValueError, match="all_to_all_v is not supported inside a for/while loop"):
+        _apply(P)
+
+
 def test_nested_explicit_allreduce_expression_is_rejected():
     @pl.program
     class P:


### PR DESCRIPTION
## Summary

Closes the last gap in host-orchestrator support for variable-size all-to-all. `pld.tensor.all_to_all_v` (variable-size all-to-all, MPI_Alltoallv pattern) merged as #2112, but only as an InCore composite — calling it from a `host_orch` function hit an explicit "not supported in a HOST orchestration function" rejection. This adds the missing HOST dispatch path, cloning the proven `builtin.tensor.all_to_all` pattern (#1997) across every layer:

- **Op registration** (`collective.cpp`): `builtin.tensor.all_to_all_v`, narrowing `input` and `send_counts` to strict window-bound `DistributedTensor` — forced by `EmitBuiltinWindowCollectiveDispatch`, which has no dispatch path for a plain `Tensor` arg at this layer (same narrowing the existing `builtin.tensor.all_to_all` already applies to its own `input`).
- **Lowering rule** (`lower_host_tensor_collectives_pass.cpp`): `MakeBuiltinAllToAllV`, deriving `MAX_RECV = target.shape[0] / signal.shape[0]` and forwarding it as a kwarg/attr alongside `dtype`.
- **Codegen** (`distributed_ops_codegen.cpp`): the variant string mangles both `max_recv` and `dtype` (`builtin.tensor.all_to_all_v__maxrecv<N>__fp32`) — `MAX_RECV` is baked into the kernel as a compile-time `constexpr`, and codegen's `MarkBuiltinEmitted`/`RecordBuiltinNextLevel` state is program-global, so two call sites with different `MAX_RECV` would otherwise silently mis-share one kernel instantiation.
- **Runtime templates**: new `all_to_all_v/` builtin package. The kernel always transfers the full `MAX_RECV`-row block per destination — matching `LowerTensorAllToAllVRule`'s compile-time `transfer_shape` exactly, for bit-for-bit InCore/HOST parity on the wire — and publishes the runtime-clamped count into peer `recv_counts` via `TNOTIFY` inline with the push.
- **Comm-domain analysis** (`materialize_comm_domain_scopes_pass.cpp`): device-coverage inheritance for both `signal` and `recv_counts` (two `CollectiveConsumer` entries sharing the same data alloc), plus a HOST-side loop-use guard (`repeating_scope_depth_`, tracked for both `ForStmt` and `WhileStmt`) mirroring the InCore path's `CheckAllReduceLoopUse` — the HOST path had **no** equivalent protection before this change, so a caller could previously reuse a single-use signal across loop iterations undetected.
- Removed the explicit `IsInCoreOnlyCollective` rejection in `LowerCompositeOps` now that a HOST rule exists for this op.
- Docs (EN+ZH): documents the new HOST path and corrects a pre-existing inaccuracy — the InCore lowering always transfers the full `MAX_RECV` block; only the *published count* was ever runtime-gated, not the transfer itself.

## Design notes for reviewers

- `send_counts` must be staged through a window buffer at the HOST layer even though it's logically pure-local, per-rank data (never cross-rank-published) — this is a real ergonomic cost of the narrowing above, not a bug. The new HOST system test documents this with an explicit `fill_counts_step`/`fill_counts_orch` staging pair.
- Kept the barrier as the existing single-use `Set(1)`/`wait≥1` protocol, matching every other HOST builtin and the InCore `all_to_all_v` rule this clones — the reusable credit-barrier rework (#2175) is unmerged and out of scope here.
- Kept FP32-only (`CheckSupportedFp32BuiltinVariant`), matching every HOST builtin except `allreduce`. Adding FP16 across all HOST builtins is a separate, broader gap.
- `all_to_all`/`allgather`/`barrier` share the same single-use-signal exposure to `host_orch` loops and have no equivalent guard today — pre-existing, out of scope for this PR.

## Test plan

- [x] Full C++ rebuild in the sim Docker image (`pypto3-hw-native-sys:sim`) — clean.
- [x] Full unit test suite: **8539 passed, 13 skipped, 0 failed** (includes new/updated tests across all 5 touched layers, zero regressions elsewhere).
- [x] `pre-commit run --all-files`: clean (headers, English-only, EN/ZH docs parity, docs-nav, clang-format, cpplint, markdownlint, ruff check/format, pyright).
- [x] **Distributed system tests not run in this environment.** `tests/st/distributed/test_l3_host_tensor_all_to_all_v.py` (new) plus the InCore/HOST `all_to_all` regression STs all hit `ImportError: cannot import name 'RunTiming' from '_task_interface'` — a pre-existing local-environment mismatch (the `runtime` submodule checkout is ahead of what the sim image's `simpler` runtime was built against), reproducing identically on unmodified, already-shipped sibling tests. Unrelated to this change, but means the actual distributed exchange logic has not been exercised end-to-end here.
- [x] NPU verification pending.