### PR TITLE
fix(distributed): close window-aliasing gap and O(N²) pass complexity in HOST collectives

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -234,6 +234,7 @@ set(PYPTO_SOURCES
     src/ir/transforms/utils/stmt_dependency_analysis.cpp
     src/ir/transforms/utils/transform_utils.cpp
     src/ir/transforms/utils/wrapper_call_utils.cpp
+    src/ir/transforms/utils/window_alias_utils.cpp
     src/ir/transforms/utils/window_externalization.cpp
     src/ir/transforms/visitor.cpp
 

--- a/docs/en/dev/passes/42-lower_host_tensor_collectives.md
+++ b/docs/en/dev/passes/42-lower_host_tensor_collectives.md
@@ -119,6 +119,20 @@ Ring allreduce currently supports only `ReduceOp.Sum` with `dtype=FP32`.
 with `mode="ring"`. Ring allreduce also supports at most 16 participating
 devices (`world_size <= 16`).
 
+All window operands of a HOST collective — data and signal alike — must
+resolve to pairwise distinct `WindowBuffer` allocations. Two `pld.window()`
+views over the same `alloc_window_buffer` are a cross-process data race under
+in-kernel TPUT/notify: data-vs-data is a reduce overwrite, data-vs-control
+races a notify/count write against a kernel read, and control-vs-control races
+a notify against a count publish. `LowerHostTensorCollectives` rejects any
+aliasing pair before emitting the builtin dispatch.
+
+`broadcast`'s `root` kwarg is additionally bounds-checked when the
+participating device count is statically known: on an explicit static device
+subset it must satisfy `root < participating device count`. The fully-dynamic
+"all device" domain cannot be checked at compile time (no device count is
+known there) — the same documented limitation as the signal-capacity check.
+
 `all_to_all_v`'s single-use Set(1)/wait≥1 signal cannot be reused across a
 `for`/`while` loop in `host_orch` — [`MaterializeCommDomainScopes`](41-materialize_comm_domain_scopes.md),
 which runs immediately before this pass, rejects that case up front (the same

--- a/docs/zh/dev/passes/42-lower_host_tensor_collectives.md
+++ b/docs/zh/dev/passes/42-lower_host_tensor_collectives.md
@@ -102,6 +102,17 @@ Ring allreduce 目前仅支持 `ReduceOp.Sum` 和 `dtype=FP32`。
 `mode="ring"` 下尚未支持。Ring allreduce 最多支持 16 个参与设备
 （`world_size <= 16`）。
 
+HOST collective 的所有 window 操作数——data 与 signal 都是如此——必须解析为两两不同的
+`WindowBuffer` 分配。同一个 `alloc_window_buffer` 上的两个 `pld.window()` view
+在 in-kernel TPUT/notify 下是跨进程数据竞争：data 对 data 是 reduce 覆盖，
+data 对 control 是 notify/count 写入与内核读取竞争，control 对 control 是
+notify 与 count 发布竞争。`LowerHostTensorCollectives` 在生成 builtin dispatch
+之前会拒绝任何别名对。
+
+当参与设备数静态可知时，还会额外校验 `broadcast` 的 `root` kwarg：在显式静态设备子集上，
+它必须满足 `root < participating device count`。完全动态的 "all device" 域在编译期无法
+校验（那里没有可用的设备数）——与 signal 容量检查存在相同的已记录限制。
+
 `all_to_all_v` 的单次使用 Set(1)/wait≥1 信号无法在 `host_orch` 的
 `for`/`while` 循环中复用——本 pass 之前紧邻运行的
 [`MaterializeCommDomainScopes`](41-materialize_comm_domain_scopes.md) 会提前

--- a/include/pypto/ir/transforms/utils/window_alias_utils.h
+++ b/include/pypto/ir/transforms/utils/window_alias_utils.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#ifndef PYPTO_IR_TRANSFORMS_UTILS_WINDOW_ALIAS_UTILS_H_
+#define PYPTO_IR_TRANSFORMS_UTILS_WINDOW_ALIAS_UTILS_H_
+
+#include <vector>
+
+#include "pypto/ir/program.h"
+#include "pypto/ir/span.h"
+
+namespace pypto {
+namespace ir {
+
+/// A window operand paired with a human-readable role name (e.g. "allreduce
+/// signal"), used to produce clear pairwise-aliasing diagnostics.
+struct NamedWindowBuffer {
+  WindowBufferPtr buffer;
+  const char* role;
+};
+
+/// Rejects any pair of the given named window buffers that alias the same
+/// allocation. A HOST collective's window operands are independently
+/// read/written across ranks inside one AIV kernel; any pairwise aliasing is
+/// a cross-process data race — data-vs-data is a TPUT/reduce overwrite,
+/// data-vs-control is a notify/count write racing a kernel read, and
+/// control-vs-control is a notify racing a count publish.
+void CheckPairwiseDistinctWindows(const std::vector<NamedWindowBuffer>& buffers, const Span& span,
+                                  const char* op_name);
+
+}  // namespace ir
+}  // namespace pypto
+
+#endif  // PYPTO_IR_TRANSFORMS_UTILS_WINDOW_ALIAS_UTILS_H_

--- a/python/pypto/language/distributed/op/tensor_ops.py
+++ b/python/pypto/language/distributed/op/tensor_ops.py
@@ -712,7 +712,8 @@ def barrier(
 
     Args:
         signal: Window-bound INT32 :class:`pld.DistributedTensor` whose
-            shape provides one cell per rank.
+            shape provides one cell per rank — rank-1 ``[world_size]`` or
+            rank-2 ``[world_size, 1]``.
 
     Returns:
         The rebound :class:`pld.DistributedTensor` view of ``signal``.
@@ -751,9 +752,16 @@ def broadcast(
             data.  Root must stage its data before the call; non-root slots
             are ignored on input.
         signal: Window-bound INT32 :class:`pld.DistributedTensor` for the
-            cross-rank barrier.  Reusable across calls — see
+            cross-rank barrier — rank-1 ``[world_size]`` or rank-2
+            ``[world_size, 1]``.  Reusable across calls — see
             :func:`allreduce` for the shared barrier protocol.
         root: Root rank index (int, keyword-only).  Must be non-negative.
+            On the HOST path with an explicit static device subset, ``root``
+            must also be a valid rank of that subset (``root <``
+            participating device count) — checked once the subset size is
+            known during ``LowerHostTensorCollectives``.  Not checked at
+            compile time for the fully-dynamic "all device" domain, since no
+            device count is known there.
 
     Returns:
         The rebound :class:`pld.DistributedTensor` view of ``target``.
@@ -796,7 +804,8 @@ def allgather(
             After the call, ``target[src, :]`` holds the chunk from rank
             ``src``.
         signal: Window-bound INT32 :class:`pld.DistributedTensor` barrier
-            tensor. Reusable across calls — see :func:`allreduce` for the
+            tensor — rank-1 ``[world_size]`` or rank-2 ``[world_size, 1]``.
+            Reusable across calls — see :func:`allreduce` for the
             shared barrier protocol.
 
     Returns:
@@ -833,7 +842,8 @@ def reduce_scatter(
         target: Window-bound :class:`pld.DistributedTensor` of shape
             [NR, SIZE].  Each rank stages all NR chunks, one per row.
         signal: Window-bound INT32 :class:`pld.DistributedTensor` for
-            the cross-rank barrier. Reusable across calls (2 credits per
+            the cross-rank barrier — rank-1 ``[world_size]`` or rank-2
+            ``[world_size, 1]``.  Reusable across calls (2 credits per
             call — ready + post-reduce) — see :func:`allreduce` for the
             shared barrier protocol.
         op: :class:`pld.ReduceOp` (keyword-only).  ``Sum`` only in
@@ -880,9 +890,10 @@ def all_to_all(
         target: :class:`pld.DistributedTensor` [NR, SIZE] window that receives
             the result in-place.  After the call,
             ``target[src, :]`` holds the chunk received from rank ``src``.
-        signal: :class:`pld.DistributedTensor` [NR, 1] INT32 barrier.
-            Reusable across calls — see :func:`allreduce` for the shared
-            barrier protocol.
+        signal: :class:`pld.DistributedTensor` [NR, 1] INT32 barrier —
+            rank-1 ``[world_size]`` or rank-2 ``[world_size, 1]``.  Reusable
+            across calls — see :func:`allreduce` for the shared barrier
+            protocol.
 
     Returns:
         The ``target`` :class:`pld.DistributedTensor` (window-as-result).

--- a/src/ir/transforms/lower_host_tensor_collectives_pass.cpp
+++ b/src/ir/transforms/lower_host_tensor_collectives_pass.cpp
@@ -10,7 +10,6 @@
  */
 
 #include <any>
-#include <array>
 #include <cstddef>
 #include <cstdint>
 #include <functional>
@@ -39,6 +38,7 @@
 #include "pypto/ir/transforms/pass_properties.h"
 #include "pypto/ir/transforms/passes.h"
 #include "pypto/ir/transforms/utils/mutable_copy.h"
+#include "pypto/ir/transforms/utils/window_alias_utils.h"
 #include "pypto/ir/type.h"
 
 namespace pypto {
@@ -103,13 +103,13 @@ static constexpr size_t kMaxSupportedRanks = 16;
 }
 
 [[nodiscard]] CommDomainScopeStmtPtr FindScopeForBuffers(
-    const std::vector<CommDomainScopeStmtPtr>& scope_stack, const std::vector<WindowBufferPtr>& buffers) {
+    const std::vector<CommDomainScopeStmtPtr>& scope_stack, const std::vector<NamedWindowBuffer>& buffers) {
   INTERNAL_CHECK(!buffers.empty()) << "LowerHostTensorCollectives: scope lookup needs at least one buffer";
   for (auto it = scope_stack.rbegin(); it != scope_stack.rend(); ++it) {
     const auto& scope = *it;
     bool all_present = true;
-    for (const auto& wb : buffers) {
-      if (!ScopeContainsSlot(scope, wb)) {
+    for (const auto& named : buffers) {
+      if (!ScopeContainsSlot(scope, named.buffer)) {
         all_present = false;
         break;
       }
@@ -117,6 +117,20 @@ static constexpr size_t kMaxSupportedRanks = 16;
     if (all_present) return scope;
   }
   return nullptr;
+}
+
+// broadcast's `root` kwarg selects a specific rank; the type deducer only
+// validates `root >= 0` (the participating device count isn't known there).
+// On an explicit static device subset, an out-of-range root would remote-load
+// from a rank outside the subset — check the upper bound here, where the
+// subset size is known. The fully-dynamic "all device" domain is left
+// unchecked (no compile-time device count to check against), same documented
+// limitation as CheckStaticSignalCapacity's dynamic-domain gap.
+void CheckBroadcastRootInRange(const CallPtr& call, size_t participating_devices) {
+  auto root_value = call->GetKwarg<int>("root");
+  CHECK_SPAN(root_value >= 0 && static_cast<size_t>(root_value) < participating_devices, call->span_)
+      << "pld.tensor.broadcast root (" << root_value << ") must be a valid rank in [0, "
+      << participating_devices << ") for this explicit device subset";
 }
 
 /// Validate a collective signal's shape against the participating device count.
@@ -363,19 +377,6 @@ void CheckAllReduceSignalCapacity(const CallPtr& call, const ExprPtr& signal_exp
                                   std::move(attrs), {ArgDirection::InOut, ArgDirection::InOut});
 }
 
-void CheckDistinctInputTargetWindows(const CallPtr& call, const char* op_name) {
-  // After MaterializeCommDomainScopes, window views carry WindowBuffer
-  // back-references. Same-expression aliasing is already rejected in the type
-  // deducers; this catches two distinct pld.window(...) views over one alloc.
-  auto input_wb = GetWindowBuffer(call->args_[0], "input");
-  auto target_wb = GetWindowBuffer(call->args_[1], "target");
-  CHECK_SPAN(input_wb.get() != target_wb.get(), call->span_)
-      << op_name
-      << " input and target must be different window allocations "
-         "(two pld.window views over the same alloc_window_buffer are a "
-         "cross-process data race under in-kernel TPUT)";
-}
-
 // pld.tensor.all_to_all_v's public deducer accepts a plain Tensor for `input`
 // and `send_counts` (AsTensorTypeLike) — legitimate on the InCore composite
 // path, where LowerCompositeOps consumes them directly. The HOST builtin path
@@ -394,45 +395,13 @@ void CheckHostWindowBoundArg(const ExprPtr& expr, const char* op_name, const cha
          "called from a HOST orchestrator; a plain Tensor or an unbound DistributedTensor "
          "parameter is only supported on the InCore composite path";
 }
-
-// all_to_all_v's five operands (input, target, signal, send_counts,
-// recv_counts) are independently read/written across ranks inside one AIV
-// kernel; any pairwise aliasing among them is a real cross-process race, not
-// just a style nit:
-//   - data (input/target) aliasing a control window (signal/send_counts/
-//     recv_counts): peer notify/count writes can clobber data this rank is
-//     still reading, or a data TPUT can clobber a control value.
-//   - signal aliasing recv_counts: the barrier's per-peer notify(Set, 1) can
-//     overwrite a just-published count, or a wait can be satisfied early
-//     against a value the count-publish rewrote.
-//   - send_counts aliasing signal or recv_counts: the kernel's local
-//     send_counts[dest] read can race a peer's cross-rank notify write
-//     landing in the same memory.
-// All 10 pairs across the 5 operands must be checked, not just the 4 pairs
-// that data-vs-data / control-vs-control discipline alone would cover.
-void CheckAllToAllVDistinctWindows(const CallPtr& call, const char* op_name) {
-  static constexpr std::array<std::pair<int, const char*>, 5> kOperands = {
-      {{0, "input"}, {1, "target"}, {2, "signal"}, {3, "send_counts"}, {4, "recv_counts"}}};
-  std::array<WindowBufferPtr, 5> buffers;
-  for (size_t i = 0; i < kOperands.size(); ++i) {
-    buffers[i] = GetWindowBuffer(call->args_[kOperands[i].first], kOperands[i].second);
-  }
-  for (size_t i = 0; i < buffers.size(); ++i) {
-    for (size_t j = i + 1; j < buffers.size(); ++j) {
-      CHECK_SPAN(buffers[i].get() != buffers[j].get(), call->span_)
-          << op_name << " " << kOperands[i].second << " and " << kOperands[j].second
-          << " must be different window allocations";
-    }
-  }
-}
-
 [[nodiscard]] CallPtr MakeBuiltinAllGather(const CallPtr& call, const ExprPtr& device) {
   // Emit namesake builtin: in-kernel TPUT push (this rank's chunk from the
   // `input` staging window into every peer's `target` window) + barrier
-  // (TNOTIFY / TWAIT), all in a single AIV kernel. `input` and `target`
-  // must be two DISTINCT windows. All chips must run concurrently — the
-  // host orchestrator submits asynchronously.
-  CheckDistinctInputTargetWindows(call, "pld.tensor.allgather");
+  // (TNOTIFY / TWAIT), all in a single AIV kernel. All window operands must
+  // be pairwise distinct (checked generically in LowerCollective via
+  // scope_buffers). All chips must run concurrently — the host orchestrator
+  // submits asynchronously.
   auto target_type = As<DistributedTensorType>(call->args_[1]->GetType());
   return MakeBuiltinCallWithAttrs(
       "builtin.tensor.allgather", call,
@@ -444,10 +413,10 @@ void CheckAllToAllVDistinctWindows(const CallPtr& call, const char* op_name) {
 [[nodiscard]] CallPtr MakeBuiltinAllToAll(const CallPtr& call, const ExprPtr& device) {
   // Emit namesake builtin: in-kernel TPUT push (this rank's chunks from the
   // `input` staging window into every peer's `target` window) + barrier
-  // (TNOTIFY / TWAIT), all in a single AIV kernel. `input` and `target` must
-  // be two DISTINCT windows. All chips must run concurrently — the host
-  // orchestrator submits asynchronously.
-  CheckDistinctInputTargetWindows(call, "pld.tensor.all_to_all");
+  // (TNOTIFY / TWAIT), all in a single AIV kernel. All window operands must
+  // be pairwise distinct (checked generically in LowerCollective via
+  // scope_buffers). All chips must run concurrently — the host orchestrator
+  // submits asynchronously.
   auto target_type = As<DistributedTensorType>(call->args_[1]->GetType());
   return MakeBuiltinCallWithAttrs(
       "builtin.tensor.all_to_all", call,
@@ -463,9 +432,8 @@ void CheckAllToAllVDistinctWindows(const CallPtr& call, const char* op_name) {
   // send_counts[dest] into peer `recv_counts[my_rank, 0]` + one barrier
   // (TNOTIFY / TWAIT), all in a single AIV kernel. All five operands (input,
   // target, signal, send_counts, recv_counts) must be pairwise-distinct
-  // windows. All chips must run concurrently — the host orchestrator submits
-  // asynchronously.
-  CheckAllToAllVDistinctWindows(call, "pld.tensor.all_to_all_v");
+  // windows (checked generically in LowerCollective via scope_buffers). All
+  // chips must run concurrently — the host orchestrator submits asynchronously.
   auto target_type = As<DistributedTensorType>(call->args_[1]->GetType());
   INTERNAL_CHECK_SPAN(target_type, call->span_)
       << "LowerHostTensorCollectives: pld.tensor.all_to_all_v target must be DistributedTensorType";
@@ -481,13 +449,23 @@ void CheckAllToAllVDistinctWindows(const CallPtr& call, const char* op_name) {
 struct HostCollectiveRule {
   const char* pld_name;
   using MakeBuiltinFn = std::function<CallPtr(const CallPtr&, const ExprPtr&)>;
-  using ScopeBuffersFn = std::function<std::vector<WindowBufferPtr>(const CallPtr&)>;
+  using ScopeBuffersFn = std::function<std::vector<NamedWindowBuffer>(const CallPtr&)>;
   using SignalExprFn = std::function<ExprPtr(const CallPtr&)>;
   using AliasSourceFn = std::function<std::optional<ExprPtr>(const CallPtr&)>;
+  // Optional extra static-domain check beyond the generic signal-capacity
+  // bound (CheckStaticSignalCapacity) — e.g. broadcast's root-in-range check.
+  // Empty for rules that don't need one.
+  using ExtraStaticCheckFn = std::function<void(const CallPtr&, size_t)>;
   MakeBuiltinFn make_builtin;
   ScopeBuffersFn scope_buffers;
   SignalExprFn signal_expr;
   AliasSourceFn alias_source;
+  ExtraStaticCheckFn extra_static_check;
+  // Args whose public deducer accepts a plain Tensor (the InCore composite
+  // path) but which the HOST builtin requires window-bound. Checked with
+  // CHECK_SPAN before GetWindowBuffer, so a plain Tensor reaching HOST
+  // lowering is a user error, not an INTERNAL_CHECK. (arg index, role)
+  std::vector<std::pair<size_t, const char*>> host_bound_args;
 };
 
 [[nodiscard]] const HostCollectiveRule* LookupHostCollectiveRule(const std::string& op_name) {
@@ -496,8 +474,10 @@ struct HostCollectiveRule {
           "pld.tensor.allreduce",
           &MakeBuiltinAllReduce,
           [](const CallPtr& call) {
-            return std::vector<WindowBufferPtr>{GetWindowBuffer(call->args_[0], "allreduce src"),
-                                                GetWindowBuffer(call->args_[1], "allreduce signal")};
+            return std::vector<NamedWindowBuffer>{
+                {GetWindowBuffer(call->args_[0], "allreduce src"), "src"},
+                {GetWindowBuffer(call->args_[1], "allreduce signal"), "signal"},
+            };
           },
           [](const CallPtr& call) { return call->args_[1]; },
           [](const CallPtr& call) -> std::optional<ExprPtr> { return call->args_[0]; },
@@ -506,7 +486,9 @@ struct HostCollectiveRule {
           "pld.tensor.barrier",
           &MakeBuiltinBarrier,
           [](const CallPtr& call) {
-            return std::vector<WindowBufferPtr>{GetWindowBuffer(call->args_[0], "barrier signal")};
+            return std::vector<NamedWindowBuffer>{
+                {GetWindowBuffer(call->args_[0], "barrier signal"), "signal"},
+            };
           },
           [](const CallPtr& call) { return call->args_[0]; },
           [](const CallPtr& call) -> std::optional<ExprPtr> { return call->args_[0]; },
@@ -515,18 +497,23 @@ struct HostCollectiveRule {
           "pld.tensor.broadcast",
           &MakeBuiltinBroadcast,
           [](const CallPtr& call) {
-            return std::vector<WindowBufferPtr>{GetWindowBuffer(call->args_[0], "broadcast target"),
-                                                GetWindowBuffer(call->args_[1], "broadcast signal")};
+            return std::vector<NamedWindowBuffer>{
+                {GetWindowBuffer(call->args_[0], "broadcast target"), "target"},
+                {GetWindowBuffer(call->args_[1], "broadcast signal"), "signal"},
+            };
           },
           [](const CallPtr& call) { return call->args_[1]; },
           [](const CallPtr& call) -> std::optional<ExprPtr> { return call->args_[0]; },
+          &CheckBroadcastRootInRange,
       },
       {
           "pld.tensor.reduce_scatter",
           &MakeBuiltinReduceScatter,
           [](const CallPtr& call) {
-            return std::vector<WindowBufferPtr>{GetWindowBuffer(call->args_[0], "reduce_scatter target"),
-                                                GetWindowBuffer(call->args_[1], "reduce_scatter signal")};
+            return std::vector<NamedWindowBuffer>{
+                {GetWindowBuffer(call->args_[0], "reduce_scatter target"), "target"},
+                {GetWindowBuffer(call->args_[1], "reduce_scatter signal"), "signal"},
+            };
           },
           [](const CallPtr& call) { return call->args_[1]; },
           [](const CallPtr& call) -> std::optional<ExprPtr> { return call->args_[0]; },
@@ -535,44 +522,48 @@ struct HostCollectiveRule {
           "pld.tensor.allgather",
           &MakeBuiltinAllGather,
           [](const CallPtr& call) {
-            return std::vector<WindowBufferPtr>{
-                GetWindowBuffer(call->args_[0], "allgather input"),
-                GetWindowBuffer(call->args_[1], "allgather target"),
-                GetWindowBuffer(call->args_[2], "allgather signal"),
+            return std::vector<NamedWindowBuffer>{
+                {GetWindowBuffer(call->args_[0], "allgather input"), "input"},
+                {GetWindowBuffer(call->args_[1], "allgather target"), "target"},
+                {GetWindowBuffer(call->args_[2], "allgather signal"), "signal"},
             };
           },
           [](const CallPtr& call) { return call->args_[2]; },
           [](const CallPtr& call) -> std::optional<ExprPtr> { return call->args_[1]; },
+          {},              // extra_static_check: none
+          {{0, "input"}},  // host_bound_args: local_data must be window-bound on HOST
       },
       {
           "pld.tensor.all_to_all",
           &MakeBuiltinAllToAll,
           [](const CallPtr& call) {
-            return std::vector<WindowBufferPtr>{
-                GetWindowBuffer(call->args_[0], "all_to_all input"),
-                GetWindowBuffer(call->args_[1], "all_to_all target"),
-                GetWindowBuffer(call->args_[2], "all_to_all signal"),
+            return std::vector<NamedWindowBuffer>{
+                {GetWindowBuffer(call->args_[0], "all_to_all input"), "input"},
+                {GetWindowBuffer(call->args_[1], "all_to_all target"), "target"},
+                {GetWindowBuffer(call->args_[2], "all_to_all signal"), "signal"},
             };
           },
           [](const CallPtr& call) { return call->args_[2]; },
           [](const CallPtr& call) -> std::optional<ExprPtr> { return call->args_[1]; },
+          {},              // extra_static_check: none
+          {{0, "input"}},  // host_bound_args: input must be window-bound on HOST
       },
       {
           "pld.tensor.all_to_all_v",
           &MakeBuiltinAllToAllV,
           [](const CallPtr& call) {
-            CheckHostWindowBoundArg(call->args_[0], "pld.tensor.all_to_all_v", "input");
-            CheckHostWindowBoundArg(call->args_[3], "pld.tensor.all_to_all_v", "send_counts");
-            return std::vector<WindowBufferPtr>{
-                GetWindowBuffer(call->args_[0], "all_to_all_v input"),
-                GetWindowBuffer(call->args_[1], "all_to_all_v target"),
-                GetWindowBuffer(call->args_[2], "all_to_all_v signal"),
-                GetWindowBuffer(call->args_[3], "all_to_all_v send_counts"),
-                GetWindowBuffer(call->args_[4], "all_to_all_v recv_counts"),
+            return std::vector<NamedWindowBuffer>{
+                {GetWindowBuffer(call->args_[0], "all_to_all_v input"), "input"},
+                {GetWindowBuffer(call->args_[1], "all_to_all_v target"), "target"},
+                {GetWindowBuffer(call->args_[2], "all_to_all_v signal"), "signal"},
+                {GetWindowBuffer(call->args_[3], "all_to_all_v send_counts"), "send_counts"},
+                {GetWindowBuffer(call->args_[4], "all_to_all_v recv_counts"), "recv_counts"},
             };
           },
           [](const CallPtr& call) { return call->args_[2]; },
           [](const CallPtr& call) -> std::optional<ExprPtr> { return call->args_[1]; },
+          {},                                  // extra_static_check: none
+          {{0, "input"}, {3, "send_counts"}},  // host_bound_args
       },
   };
   for (const auto& rule : kRules) {
@@ -595,6 +586,7 @@ StmtPtr EmitPerDeviceBuiltinCalls(const CallPtr& call, const HostCollectiveRule&
     } else {
       CheckStaticSignalCapacity(call, rule.signal_expr(call), scope->devices_.size());
     }
+    if (rule.extra_static_check) rule.extra_static_check(call, scope->devices_.size());
     std::vector<StmtPtr> stmts;
     stmts.reserve(scope->devices_.size());
     for (auto device : scope->devices_) {
@@ -675,7 +667,11 @@ class LowerHostTensorCollectivesMutator : public IRMutator {
     INTERNAL_CHECK(rule) << "LowerHostTensorCollectives: missing rule for " << call->op_->name_;
     INTERNAL_CHECK_SPAN(!scope_stack_.empty(), call->span_)
         << "LowerHostTensorCollectives: " << call->op_->name_ << " must appear inside a CommDomainScopeStmt";
+    for (const auto& [arg_idx, role] : rule->host_bound_args) {
+      CheckHostWindowBoundArg(call->args_[arg_idx], call->op_->name_.c_str(), role);
+    }
     auto buffers = rule->scope_buffers(call);
+    CheckPairwiseDistinctWindows(buffers, call->span_, call->op_->name_.c_str());
     auto scope = FindScopeForBuffers(scope_stack_, buffers);
     INTERNAL_CHECK_SPAN(scope, call->span_) << "LowerHostTensorCollectives: " << call->op_->name_
                                             << " window buffers must resolve to the same comm-domain scope";

--- a/src/ir/transforms/materialize_comm_domain_scopes_pass.cpp
+++ b/src/ir/transforms/materialize_comm_domain_scopes_pass.cpp
@@ -82,6 +82,7 @@ struct DeviceDescriptor {
   }
   bool operator<(const DeviceDescriptor& o) const {
     if (is_all != o.is_all) return is_all < o.is_all;
+    if (is_all) return false;  // all-device: subset is meaningless, matches operator==
     return subset < o.subset;
   }
 
@@ -589,7 +590,12 @@ FunctionPtr ProcessHostOrch(const FunctionPtr& func, const std::map<std::string,
   // Phase 6: cluster allocs into pending domain entries by merged descriptor
   // (alloc-order within a domain). Use a vector for deterministic order: scan
   // collector.allocs in source order and append to the first matching entry
-  // or create a new one.
+  // or create a new one. `desc_to_index` maps a merged descriptor to its
+  // `pending` slot (O(log domains) via DeviceDescriptor::operator<, per
+  // pass-complexity.md — a per-alloc linear scan of `pending` would make this
+  // Phase O(allocs^2) for programs with many distinct comm domains). Store
+  // indices, not pointers, into the map: `pending.push_back` may reallocate
+  // and invalidate any previously-taken `PendingDomain*`.
   struct PendingDomain {
     DeviceDescriptor desc;
     std::vector<WindowBufferPtr> slots;
@@ -597,24 +603,24 @@ FunctionPtr ProcessHostOrch(const FunctionPtr& func, const std::map<std::string,
     Span span;
   };
   std::vector<PendingDomain> pending;
+  std::map<DeviceDescriptor, size_t> desc_to_index;
   for (const auto& rec : collector.allocs) {
     DeviceDescriptor merged;
     for (const auto& d : rec->seen) merged.Merge(d);
-    PendingDomain* tgt = nullptr;
-    for (auto& g : pending) {
-      if (g.desc == merged) {
-        tgt = &g;
-        break;
-      }
-    }
-    if (!tgt) {
+    auto it = desc_to_index.find(merged);
+    size_t index;
+    if (it == desc_to_index.end()) {
+      index = pending.size();
+      desc_to_index.emplace(merged, index);
       pending.push_back({merged, {}, {}, rec->span});
-      tgt = &pending.back();
+    } else {
+      index = it->second;
     }
-    INTERNAL_CHECK_SPAN(tgt->names.insert(rec->name).second, rec->span)
+    PendingDomain& tgt = pending[index];
+    INTERNAL_CHECK_SPAN(tgt.names.insert(rec->name).second, rec->span)
         << "MaterializeCommDomainScopes: duplicate allocation name '" << rec->name
         << "' within the same comm domain";
-    tgt->slots.push_back(rec->wb);
+    tgt.slots.push_back(rec->wb);
   }
 
   // Phase 7: rewrite host_orch body so every reference to a pld.tensor.window result

--- a/src/ir/transforms/utils/window_alias_utils.cpp
+++ b/src/ir/transforms/utils/window_alias_utils.cpp
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include "pypto/ir/transforms/utils/window_alias_utils.h"
+
+#include <cstddef>
+#include <vector>
+
+#include "pypto/core/logging.h"
+#include "pypto/ir/span.h"
+
+namespace pypto {
+namespace ir {
+
+void CheckPairwiseDistinctWindows(const std::vector<NamedWindowBuffer>& buffers, const Span& span,
+                                  const char* op_name) {
+  for (size_t i = 0; i < buffers.size(); ++i) {
+    for (size_t j = i + 1; j < buffers.size(); ++j) {
+      CHECK_SPAN(buffers[i].buffer.get() != buffers[j].buffer.get(), span)
+          << op_name << " " << buffers[i].role << " and " << buffers[j].role
+          << " must be different window allocations (two pld.window views over the same "
+             "alloc_window_buffer are a cross-process data race under in-kernel TPUT/notify)";
+    }
+  }
+}
+
+}  // namespace ir
+}  // namespace pypto

--- a/tests/ut/ir/transforms/test_lower_host_tensor_collectives.py
+++ b/tests/ut/ir/transforms/test_lower_host_tensor_collectives.py
@@ -29,6 +29,12 @@ from pypto.language.parser.diagnostics import InvalidOperationError
 from pypto.pypto_core import backend as _backend
 from pypto.pypto_core import ir, passes
 
+# Builtin names are validated at import via the registry getter (raises on a
+# typo) and matched by name at runtime — see operator-identity-checks.md.
+_BUILTIN_BARRIER = ir.get_op("builtin.tensor.barrier").name
+_BUILTIN_BROADCAST = ir.get_op("builtin.tensor.broadcast").name
+_BUILTIN_REDUCE_SCATTER = ir.get_op("builtin.tensor.reduce_scatter").name
+
 
 @pytest.fixture(autouse=True)
 def _basic_verification_context():
@@ -690,6 +696,34 @@ def test_host_allreduce_rejects_unsupported_dtype_before_lowering():
                 return 0
 
 
+def test_host_allreduce_rejects_aliased_src_signal_windows():
+    """Two pld.window views over one alloc must fail at host lowering — the
+    generic pairwise-distinct check (CheckPairwiseDistinctWindows) applies to
+    every HOST collective's window operands, not just input/target pairs."""
+
+    @pl.program
+    class P:
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def chip_orch(self, data: pld.DistributedTensor[[256], pl.FP32]):
+            return data
+
+        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+        def host_orch(self):
+            buf = pld.alloc_window_buffer(256 * pl.FP32.get_byte())
+            data = pld.window(buf, [256], dtype=pl.FP32)
+            # signal aliases data's own window buffer (mismatched dtype view
+            # over the same allocation is exactly the race this check exists for).
+            signal = pld.window(buf, [256], dtype=pl.INT32)
+            for r in pl.range(pld.world_size()):
+                self.chip_orch(data, device=r)
+            pld.tensor.allreduce(data, signal, op=pld.ReduceOp.Sum)
+            return 0
+
+    program = passes.materialize_comm_domain_scopes()(P)
+    with pytest.raises(ValueError, match=r"src and signal must be different window allocations"):
+        passes.lower_host_tensor_collectives()(program)
+
+
 def test_host_barrier_lowers_to_builtin_world_size_loop():
     @pl.program
     class P:
@@ -720,6 +754,43 @@ def test_host_barrier_lowers_to_builtin_world_size_loop():
         arg_directions=[ir.ArgDirection.InOut],
         kwargs={},
     )
+
+
+def test_host_barrier_accepts_rank1_signal_through_lowering():
+    """Rank-1 [NR] must pass both the public deducer and the builtin
+    validator inside LowerHostTensorCollectives."""
+
+    @pl.program
+    class P:
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def chip_orch(
+            self, data: pld.DistributedTensor[[256], pl.FP32], sig: pld.DistributedTensor[[4], pl.INT32]
+        ):
+            return data
+
+        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+        def host_orch(self):
+            data_buf = pld.alloc_window_buffer(256 * pl.FP32.get_byte())
+            signal_buf = pld.alloc_window_buffer(4 * pl.INT32.get_byte())
+            data = pld.window(data_buf, [256], dtype=pl.FP32)
+            signal = pld.window(signal_buf, [4], dtype=pl.INT32)
+            for r in pl.range(pld.world_size()):
+                self.chip_orch(data, signal, device=r)
+            pld.tensor.barrier(signal)
+            return 0
+
+    program = passes.materialize_comm_domain_scopes()(P)
+    result = passes.lower_host_tensor_collectives()(program)
+    host = _get_func(result, "host_orch")
+    loops = _collect_for_stmts(host.body)
+    builtin_loops = [
+        loop
+        for loop in loops
+        if isinstance(loop.body, ir.EvalStmt)
+        and isinstance(loop.body.expr, ir.Call)
+        and loop.body.expr.op.name == _BUILTIN_BARRIER
+    ]
+    assert len(builtin_loops) == 1
 
 
 def test_host_broadcast_lowers_to_builtin_world_size_loop():
@@ -755,6 +826,43 @@ def test_host_broadcast_lowers_to_builtin_world_size_loop():
     )
 
 
+def test_host_broadcast_accepts_rank1_signal_through_lowering():
+    """Rank-1 [NR] must survive public + builtin validation on the HOST
+    broadcast path."""
+
+    @pl.program
+    class P:
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def chip_orch(
+            self, data: pld.DistributedTensor[[256], pl.FP32], sig: pld.DistributedTensor[[4], pl.INT32]
+        ):
+            return data
+
+        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+        def host_orch(self):
+            data_buf = pld.alloc_window_buffer(256 * pl.FP32.get_byte())
+            signal_buf = pld.alloc_window_buffer(4 * pl.INT32.get_byte())
+            data = pld.window(data_buf, [256], dtype=pl.FP32)
+            signal = pld.window(signal_buf, [4], dtype=pl.INT32)
+            for r in pl.range(pld.world_size()):
+                self.chip_orch(data, signal, device=r)
+            pld.tensor.broadcast(data, signal, root=0)
+            return 0
+
+    program = passes.materialize_comm_domain_scopes()(P)
+    result = passes.lower_host_tensor_collectives()(program)
+    host = _get_func(result, "host_orch")
+    loops = _collect_for_stmts(host.body)
+    builtin_loops = [
+        loop
+        for loop in loops
+        if isinstance(loop.body, ir.EvalStmt)
+        and isinstance(loop.body.expr, ir.Call)
+        and loop.body.expr.op.name == _BUILTIN_BROADCAST
+    ]
+    assert len(builtin_loops) == 1
+
+
 def test_host_reduce_scatter_lowers_to_builtin_world_size_loop():
     @pl.program
     class P:
@@ -786,6 +894,131 @@ def test_host_reduce_scatter_lowers_to_builtin_world_size_loop():
         kwargs={"op": int(pld.ReduceOp.Sum), "dtype": pl.FP32},
         attrs={"op": int(pld.ReduceOp.Sum), "dtype": pl.FP32},
     )
+
+
+def test_host_reduce_scatter_accepts_rank1_signal_through_lowering():
+    """Rank-1 [NR] must survive public + builtin validation on the HOST
+    reduce_scatter path."""
+
+    @pl.program
+    class P:
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def chip_orch(
+            self,
+            data: pld.DistributedTensor[[4, 256], pl.FP32],
+            sig: pld.DistributedTensor[[4], pl.INT32],
+        ):
+            return data
+
+        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+        def host_orch(self):
+            data_buf = pld.alloc_window_buffer(4 * 256 * pl.FP32.get_byte())
+            signal_buf = pld.alloc_window_buffer(4 * pl.INT32.get_byte())
+            data = pld.window(data_buf, [4, 256], dtype=pl.FP32)
+            signal = pld.window(signal_buf, [4], dtype=pl.INT32)
+            for r in pl.range(pld.world_size()):
+                self.chip_orch(data, signal, device=r)
+            pld.tensor.reduce_scatter(data, signal, op=pld.ReduceOp.Sum)
+            return 0
+
+    program = passes.materialize_comm_domain_scopes()(P)
+    result = passes.lower_host_tensor_collectives()(program)
+    host = _get_func(result, "host_orch")
+    loops = _collect_for_stmts(host.body)
+    builtin_loops = [
+        loop
+        for loop in loops
+        if isinstance(loop.body, ir.EvalStmt)
+        and isinstance(loop.body.expr, ir.Call)
+        and loop.body.expr.op.name == _BUILTIN_REDUCE_SCATTER
+    ]
+    assert len(builtin_loops) == 1
+
+
+def test_host_broadcast_rejects_aliased_target_signal_windows():
+    """target and signal sharing an allocation must fail — the broadcast TPUT
+    write into `target` races the notify/wait control path over `signal`."""
+
+    @pl.program
+    class P:
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def chip_orch(
+            self, data: pld.DistributedTensor[[256], pl.FP32], sig: pld.DistributedTensor[[4], pl.INT32]
+        ):
+            return data
+
+        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+        def host_orch(self):
+            buf = pld.alloc_window_buffer(256 * pl.FP32.get_byte())
+            data = pld.window(buf, [256], dtype=pl.FP32)
+            # signal aliases data's own window buffer.
+            signal = pld.window(buf, [4], dtype=pl.INT32)
+            for r in pl.range(pld.world_size()):
+                self.chip_orch(data, signal, device=r)
+            pld.tensor.broadcast(data, signal, root=0)
+            return 0
+
+    program = passes.materialize_comm_domain_scopes()(P)
+    with pytest.raises(ValueError, match=r"target and signal must be different window allocations"):
+        passes.lower_host_tensor_collectives()(program)
+
+
+def test_host_broadcast_rejects_out_of_range_root_on_explicit_device_subset():
+    """root=5 on an explicit 2-device static subset must fail — the type
+    deducer only checks root >= 0 (the participating device count isn't known
+    there); the upper bound is enforced once the static subset size is known."""
+
+    @pl.program
+    class P:
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def chip_orch(
+            self, data: pld.DistributedTensor[[256], pl.FP32], sig: pld.DistributedTensor[[4], pl.INT32]
+        ):
+            return data
+
+        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+        def host_orch(self):
+            data_buf = pld.alloc_window_buffer(256 * pl.FP32.get_byte())
+            signal_buf = pld.alloc_window_buffer(4 * pl.INT32.get_byte())
+            data = pld.window(data_buf, [256], dtype=pl.FP32)
+            signal = pld.window(signal_buf, [4], dtype=pl.INT32)
+            self.chip_orch(data, signal, device=0)
+            self.chip_orch(data, signal, device=1)
+            pld.tensor.broadcast(data, signal, root=5)
+            return 0
+
+    program = passes.materialize_comm_domain_scopes()(P)
+    with pytest.raises(ValueError, match=r"root \(5\) must be a valid rank in \[0, 2\)"):
+        passes.lower_host_tensor_collectives()(program)
+
+
+def test_host_reduce_scatter_rejects_aliased_target_signal_windows():
+    """target and signal sharing an allocation must fail — same discipline as
+    broadcast: the reduce TPUT write into `target` races the notify/wait
+    control path over `signal`."""
+
+    @pl.program
+    class P:
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def chip_orch(
+            self, data: pld.DistributedTensor[[4, 256], pl.FP32], sig: pld.DistributedTensor[[4], pl.INT32]
+        ):
+            return data
+
+        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+        def host_orch(self):
+            buf = pld.alloc_window_buffer(4 * 256 * pl.FP32.get_byte())
+            data = pld.window(buf, [4, 256], dtype=pl.FP32)
+            # signal aliases data's own window buffer.
+            signal = pld.window(buf, [4], dtype=pl.INT32)
+            for r in pl.range(pld.world_size()):
+                self.chip_orch(data, signal, device=r)
+            pld.tensor.reduce_scatter(data, signal, op=pld.ReduceOp.Sum)
+            return 0
+
+    program = passes.materialize_comm_domain_scopes()(P)
+    with pytest.raises(ValueError, match=r"target and signal must be different window allocations"):
+        passes.lower_host_tensor_collectives()(program)
 
 
 def test_host_allgather_lowers_to_namesake_builtin():
@@ -865,6 +1098,109 @@ def test_host_allgather_rejects_aliased_input_target_windows():
         passes.lower_host_tensor_collectives()(program)
 
 
+def test_host_allgather_rejects_aliased_input_signal_windows():
+    """input aliasing signal must fail too — the generic pairwise check covers
+    every pair of allgather's 3 window operands, not just input vs target
+    (which was already rejected before this generalization)."""
+
+    @pl.program
+    class P:
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def chip_orch(
+            self,
+            stage: pld.DistributedTensor[[1, 256], pl.FP32],
+            data: pld.DistributedTensor[[4, 256], pl.FP32],
+            sig: pld.DistributedTensor[[4], pl.INT32],
+        ):
+            return data
+
+        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+        def host_orch(self):
+            # signal_buf is sized to fit the [1, 256] FP32 view so the test
+            # exercises aliasing alone, not a view-vs-buffer footprint check.
+            signal_buf = pld.alloc_window_buffer(1 * 256 * pl.FP32.get_byte())
+            data_buf = pld.alloc_window_buffer(4 * 256 * pl.FP32.get_byte())
+            # stage aliases signal's own window buffer.
+            stage = pld.window(signal_buf, [1, 256], dtype=pl.FP32)
+            data = pld.window(data_buf, [4, 256], dtype=pl.FP32)
+            signal = pld.window(signal_buf, [4], dtype=pl.INT32)
+            for r in pl.range(pld.world_size()):
+                self.chip_orch(stage, data, signal, device=r)
+            data = pld.tensor.allgather(stage, data, signal)
+            return 0
+
+    program = passes.materialize_comm_domain_scopes()(P)
+    with pytest.raises(ValueError, match=r"input and signal must be different window allocations"):
+        passes.lower_host_tensor_collectives()(program)
+
+
+def test_host_allgather_rejects_aliased_target_signal_windows():
+    """target aliasing signal must fail too."""
+
+    @pl.program
+    class P:
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def chip_orch(
+            self,
+            stage: pld.DistributedTensor[[1, 256], pl.FP32],
+            data: pld.DistributedTensor[[4, 256], pl.FP32],
+            sig: pld.DistributedTensor[[4], pl.INT32],
+        ):
+            return data
+
+        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+        def host_orch(self):
+            stage_buf = pld.alloc_window_buffer(1 * 256 * pl.FP32.get_byte())
+            # signal_buf is sized to fit the [4, 256] FP32 view so the test
+            # exercises aliasing alone, not a view-vs-buffer footprint check.
+            signal_buf = pld.alloc_window_buffer(4 * 256 * pl.FP32.get_byte())
+            stage = pld.window(stage_buf, [1, 256], dtype=pl.FP32)
+            # data aliases signal's own window buffer.
+            data = pld.window(signal_buf, [4, 256], dtype=pl.FP32)
+            signal = pld.window(signal_buf, [4], dtype=pl.INT32)
+            for r in pl.range(pld.world_size()):
+                self.chip_orch(stage, data, signal, device=r)
+            data = pld.tensor.allgather(stage, data, signal)
+            return 0
+
+    program = passes.materialize_comm_domain_scopes()(P)
+    with pytest.raises(ValueError, match=r"target and signal must be different window allocations"):
+        passes.lower_host_tensor_collectives()(program)
+
+
+def test_host_allgather_rejects_plain_tensor_input():
+    """pld.tensor.allgather's public deducer accepts a plain Tensor for
+    `local_data` (legitimate on the InCore composite path), but the HOST
+    builtin requires it window-bound. This must surface as a CHECK_SPAN
+    ValueError, not an internal crash inside GetWindowBuffer."""
+
+    @pl.program
+    class P:
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def chip_orch(
+            self,
+            stage: pl.Tensor[[1, 256], pl.FP32],
+            data: pld.DistributedTensor[[4, 256], pl.FP32],
+            sig: pld.DistributedTensor[[4], pl.INT32],
+        ):
+            return data
+
+        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+        def host_orch(self, stage: pl.Tensor[[1, 256], pl.FP32]):
+            data_buf = pld.alloc_window_buffer(4 * 256 * pl.FP32.get_byte())
+            signal_buf = pld.alloc_window_buffer(4 * pl.INT32.get_byte())
+            data = pld.window(data_buf, [4, 256], dtype=pl.FP32)
+            signal = pld.window(signal_buf, [4], dtype=pl.INT32)
+            for r in pl.range(pld.world_size()):
+                self.chip_orch(stage, data, signal, device=r)
+            data = pld.tensor.allgather(stage, data, signal)
+            return 0
+
+    program = passes.materialize_comm_domain_scopes()(P)
+    with pytest.raises(ValueError, match=r"input must be a window-bound DistributedTensor"):
+        passes.lower_host_tensor_collectives()(program)
+
+
 def test_host_all_to_all_rejects_aliased_input_target_windows():
     """Two pld.window views over one alloc must fail at host lowering."""
 
@@ -893,6 +1229,105 @@ def test_host_all_to_all_rejects_aliased_input_target_windows():
 
     program = passes.materialize_comm_domain_scopes()(P)
     with pytest.raises(ValueError, match=r"different window allocations"):
+        passes.lower_host_tensor_collectives()(program)
+
+
+def test_host_all_to_all_rejects_aliased_input_signal_windows():
+    """input aliasing signal must fail too — same generalization as allgather."""
+
+    @pl.program
+    class P:
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def chip_orch(
+            self,
+            stage: pld.DistributedTensor[[4, 256], pl.FP32],
+            data: pld.DistributedTensor[[4, 256], pl.FP32],
+            sig: pld.DistributedTensor[[4], pl.INT32],
+        ):
+            return data
+
+        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+        def host_orch(self):
+            # signal_buf is sized to fit the [4, 256] FP32 view so the test
+            # exercises aliasing alone, not a view-vs-buffer footprint check.
+            signal_buf = pld.alloc_window_buffer(4 * 256 * pl.FP32.get_byte())
+            data_buf = pld.alloc_window_buffer(4 * 256 * pl.FP32.get_byte())
+            # stage aliases signal's own window buffer.
+            stage = pld.window(signal_buf, [4, 256], dtype=pl.FP32)
+            data = pld.window(data_buf, [4, 256], dtype=pl.FP32)
+            signal = pld.window(signal_buf, [4], dtype=pl.INT32)
+            for r in pl.range(pld.world_size()):
+                self.chip_orch(stage, data, signal, device=r)
+            data = pld.tensor.all_to_all(stage, data, signal)
+            return 0
+
+    program = passes.materialize_comm_domain_scopes()(P)
+    with pytest.raises(ValueError, match=r"input and signal must be different window allocations"):
+        passes.lower_host_tensor_collectives()(program)
+
+
+def test_host_all_to_all_rejects_aliased_target_signal_windows():
+    """target aliasing signal must fail too."""
+
+    @pl.program
+    class P:
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def chip_orch(
+            self,
+            stage: pld.DistributedTensor[[4, 256], pl.FP32],
+            data: pld.DistributedTensor[[4, 256], pl.FP32],
+            sig: pld.DistributedTensor[[4], pl.INT32],
+        ):
+            return data
+
+        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+        def host_orch(self):
+            stage_buf = pld.alloc_window_buffer(4 * 256 * pl.FP32.get_byte())
+            # signal_buf is sized to fit the [4, 256] FP32 view so the test
+            # exercises aliasing alone, not a view-vs-buffer footprint check.
+            signal_buf = pld.alloc_window_buffer(4 * 256 * pl.FP32.get_byte())
+            stage = pld.window(stage_buf, [4, 256], dtype=pl.FP32)
+            # data aliases signal's own window buffer.
+            data = pld.window(signal_buf, [4, 256], dtype=pl.FP32)
+            signal = pld.window(signal_buf, [4], dtype=pl.INT32)
+            for r in pl.range(pld.world_size()):
+                self.chip_orch(stage, data, signal, device=r)
+            data = pld.tensor.all_to_all(stage, data, signal)
+            return 0
+
+    program = passes.materialize_comm_domain_scopes()(P)
+    with pytest.raises(ValueError, match=r"target and signal must be different window allocations"):
+        passes.lower_host_tensor_collectives()(program)
+
+
+def test_host_all_to_all_rejects_plain_tensor_input():
+    """Same as the allgather case, for `input` (also Tensor | DistributedTensor
+    on the composite path, but window-bound-only at the HOST builtin layer)."""
+
+    @pl.program
+    class P:
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def chip_orch(
+            self,
+            stage: pl.Tensor[[4, 256], pl.FP32],
+            data: pld.DistributedTensor[[4, 256], pl.FP32],
+            sig: pld.DistributedTensor[[4], pl.INT32],
+        ):
+            return data
+
+        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+        def host_orch(self, stage: pl.Tensor[[4, 256], pl.FP32]):
+            data_buf = pld.alloc_window_buffer(4 * 256 * pl.FP32.get_byte())
+            signal_buf = pld.alloc_window_buffer(4 * pl.INT32.get_byte())
+            data = pld.window(data_buf, [4, 256], dtype=pl.FP32)
+            signal = pld.window(signal_buf, [4], dtype=pl.INT32)
+            for r in pl.range(pld.world_size()):
+                self.chip_orch(stage, data, signal, device=r)
+            data = pld.tensor.all_to_all(stage, data, signal)
+            return 0
+
+    program = passes.materialize_comm_domain_scopes()(P)
+    with pytest.raises(ValueError, match=r"input must be a window-bound DistributedTensor"):
         passes.lower_host_tensor_collectives()(program)
 
 
@@ -1283,7 +1718,9 @@ def test_host_all_to_all_v_rejects_aliased_input_signal_windows():
 
         @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
         def host_orch(self):
-            signal_buf = pld.alloc_window_buffer(4 * pl.INT32.get_byte())
+            # signal_buf is sized to fit the [8, 256] FP32 view so the test
+            # exercises aliasing alone, not a view-vs-buffer footprint check.
+            signal_buf = pld.alloc_window_buffer(8 * 256 * pl.FP32.get_byte())
             data_buf = pld.alloc_window_buffer(8 * 256 * pl.FP32.get_byte())
             counts_buf = pld.alloc_window_buffer(4 * pl.INT32.get_byte())
             recv_buf = pld.alloc_window_buffer(4 * pl.INT32.get_byte())

--- a/tests/ut/ir/transforms/test_materialize_comm_domain_scopes.py
+++ b/tests/ut/ir/transforms/test_materialize_comm_domain_scopes.py
@@ -1368,6 +1368,63 @@ def test_two_allocs_different_descriptors_two_groups():
     _assert_scope_fields(scopes[1], [2, 3], [_expected_slot("buf_b", _mul(256, 4))])
 
 
+def test_four_allocs_three_descriptors_three_groups():
+    """Regression for the Phase-6 clustering fix: a linear scan of `pending`
+    per alloc would still pass with two groups, but a third distinct
+    descriptor exercises the third `pending` slot the map-based lookup must
+    also resolve correctly (not just append-and-never-find). `buf_d` reuses
+    `buf_c`'s descriptor ({4, 5}) so `desc_to_index.find` must also succeed on
+    a *nonzero* index (index 2, not just index 0 as the two-group test above
+    already covers) and route `buf_d` into `pending[2]` instead of appending a
+    fourth, spurious domain."""
+
+    @pl.program
+    class P:
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def chip_orch_a(self, a: pld.DistributedTensor[[256], pl.FP32]):
+            return a
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def chip_orch_b(self, b: pld.DistributedTensor[[256], pl.FP32]):
+            return b
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def chip_orch_c(
+            self, c: pld.DistributedTensor[[256], pl.FP32], d: pld.DistributedTensor[[256], pl.FP32]
+        ):
+            return c
+
+        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+        def host_orch(self):
+            buf_a = pld.alloc_window_buffer(256 * pl.FP32.get_byte())
+            buf_b = pld.alloc_window_buffer(256 * pl.FP32.get_byte())
+            buf_c = pld.alloc_window_buffer(256 * pl.FP32.get_byte())
+            buf_d = pld.alloc_window_buffer(256 * pl.FP32.get_byte())
+            a = pld.window(buf_a, [256], dtype=pl.FP32)
+            b = pld.window(buf_b, [256], dtype=pl.FP32)
+            c = pld.window(buf_c, [256], dtype=pl.FP32)
+            d = pld.window(buf_d, [256], dtype=pl.FP32)
+            self.chip_orch_a(a, device=0)
+            self.chip_orch_a(a, device=1)
+            self.chip_orch_b(b, device=2)
+            self.chip_orch_b(b, device=3)
+            self.chip_orch_c(c, d, device=4)
+            self.chip_orch_c(c, d, device=5)
+            return 0
+
+    result = _apply(P)
+    host = _get_func(result, "host_orch")
+    scopes = _get_comm_domain_scopes(host)
+    assert len(scopes) == 3
+    _assert_scope_fields(scopes[0], [0, 1], [_expected_slot("buf_a", _mul(256, 4))])
+    _assert_scope_fields(scopes[1], [2, 3], [_expected_slot("buf_b", _mul(256, 4))])
+    _assert_scope_fields(
+        scopes[2],
+        [4, 5],
+        [_expected_slot("buf_c", _mul(256, 4)), _expected_slot("buf_d", _mul(256, 4))],
+    )
+
+
 # ---------------------------------------------------------------------------
 # Single alloc / multiple views share the same WindowBuffer instance
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

A review of the distributed collectives stack (allreduce, barrier, broadcast, reduce_scatter, allgather, all_to_all, and — after the rebase onto #2243 — all_to_all_v) surfaced one real correctness gap and one real complexity-budget violation, both silent today. This PR fixes both.

### 1. Window aliasing was unchecked for most HOST collectives — a real silent-corruption risk

Before this PR, `LowerHostTensorCollectives`'s `CheckDistinctInputTargetWindows` was wired into only 2 of 6 collectives (`allgather`, `all_to_all`), and even there it only checked `input` vs `target` — never vs `signal`. `allreduce`, `barrier`, `broadcast`, `reduce_scatter` had **no aliasing check at all**.

Concretely: nothing stopped a user from writing

```python
pld.tensor.allreduce(data, signal, op=pld.ReduceOp.Sum)
```

where `data` and `signal` are two different `pld.window()` views over the **same** `alloc_window_buffer`. That's a real cross-process race — the reduce's data write and the barrier's notify/wait control write land in the same memory — and it would compile cleanly and fail silently or corrupt data at runtime instead of raising a clear compile-time error.

**Fix**: `HostCollectiveRule::scope_buffers` already enumerates every window operand for every op (it existed to resolve the enclosing `CommDomainScopeStmt`) — this PR reuses that same list to run a new, generic `CheckPairwiseDistinctWindows` helper once, in `LowerCollective`, covering all 7 HOST collectives uniformly. One shared helper instead of one-off per-op checks that get missed. Rebased onto #2243, this also replaces #2243's bespoke `CheckAllToAllVDistinctWindows` with the same generic path — all 10 operand pairs of `all_to_all_v` (input/target/signal/send_counts/recv_counts) are now checked by the shared helper. The plain/unbound-tensor guard is folded into the same generic path: `HostCollectiveRule::host_bound_args` lists the args whose public deducer accepts a plain `Tensor` (allgather/all_to_all `input`, all_to_all_v `input` + `send_counts`), checked with `CHECK_SPAN` before window lookup — so a plain `Tensor` on the HOST path is a user error, not an internal one.

### 2. O(N²) pass complexity — a direct violation of this repo's own `pass-complexity.md`

`MaterializeCommDomainScopes`'s domain-clustering phase did a **linear scan of the `pending` domains list per allocation** to find a matching descriptor. For a program with many independently-scoped comm domains, this is O(allocations × domains) = O(N²).

**Fix**: `DeviceDescriptor` already has `operator<`, so this PR adds a `std::map<DeviceDescriptor, size_t>` index alongside `pending`, turning the lookup into O(log domains) — squarely within the project's own "ordered map/set lookups are fine" complexity allowance. No behavior change; a new 3-domain regression test pins the clustering order and exercises the map hit at a nonzero index. `DeviceDescriptor::operator<` is aligned with `operator==` for all-device descriptors (`subset` is meaningless when `is_all`), which the map makes load-bearing.

### 3. `broadcast`'s `root` was never bounds-checked against the device count

Only `root >= 0` was validated. `root=100` on a 4-rank job compiled cleanly and would fail at runtime as an out-of-bounds remote read. This PR adds a `root < participating_devices` check on the explicit static-device-subset domain (mirroring the existing signal-capacity check's scope — the fully-dynamic "all device" domain is left as a documented limitation, same as the existing signal-capacity gap there, since there's no compile-time device count to check against in that case).

## Signal / mode validation: superseded by main's lowering passes

The original version of this PR also unified signal-shape validation into the public deducers (a `CheckSignalDistributedTensor` helper called from every public op). Since then, main moved signal and `mode` validation into the lowering passes — `LowerHostTensorCollectives::IsRingAllReduce` (HOST) and `LowerCompositeOps` (InCore) — which enforce the same contract at lowering time for every collective. This PR was rebased onto that architecture and no longer duplicates the checks in the deducers.

## What's intentionally *not* in this PR

Several other findings were evaluated and deliberately deferred — a `CollectiveOpBuilder` abstraction (premature without an 8th collective) and a runtime-assert IR primitive for the dynamic-domain gaps mentioned above (real gap, but new IR/runtime infra, out of scope here). Happy to open tracking issues for these if useful.

## Test plan

- Window-aliasing rejection for all 7 HOST collectives via the generic pairwise path (data-vs-data, data-vs-signal, and control-vs-control pairs), plain-tensor HOST-input rejection for allgather/all_to_all/all_to_all_v, broadcast `root`-out-of-range rejection, and a 3-domain clustering regression for the complexity fix.
- Host-lowering signal success-path tests (rank-1 signals through the builtin validators).
- Agent gate `host_collectives_ut_sim` (sim Docker): the full `test_lower_host_tensor_collectives.py` + `test_materialize_comm_domain_scopes.py` + `test_host_orch_distributed.py` + `test_lower_composite_ops.py` suite — 258 tests pass.
- `pre-commit run --all-files`, `clang-format --dry-run --Werror`, and the repo lint scripts (en/zh parity, headers, English-only, no-broad-raises) clean on all touched files.


