### PR TITLE
fix(ir): Derive tile.move's result fractal from the destination space

### DIFF
--- a/docs/en/dev/ir/05-operators.md
+++ b/docs/en/dev/ir/05-operators.md
@@ -310,6 +310,7 @@ with ib.function("tensor_example") as f:
 | **Memory** | `tile.get_block_idx` | Get hardware block index (→ ScalarType(DataType::UINT64)) |
 | - | `tile.load` | TensorType → TileType (DDR to unified buffer) |
 | - | `tile.store` | TileType → TensorType (unified buffer to DDR) |
+| - | `tile.move` | Move a tile between memory spaces (`target_memory`) — see [Result view of tile.move](#result-view-of-tilemove) |
 | **Element-wise** | `tile.add/sub/mul/div` | Tile-Tile operations |
 | - | `tile.adds/subs/muls/divs` | Tile-Scalar operations. A **constant** scalar operand adopts the tile's element dtype (a bare int literal is otherwise parsed as `index`, which no `pto.t*s` op accepts) — except a float literal on an integer tile, which keeps FP32 so promotion is preserved. An explicit `pl.const(v, dtype)` is a deliberate annotation and is left as-is, as is any non-constant expression; a non-constant `index` scalar (loop var, `pl.dim`) is rejected — convert it with `pl.cast`. Same rule for `tensor.*s`. |
 | **Unary** | `tile.sqrt` | Element-wise square root |
@@ -325,6 +326,26 @@ with ib.function("tensor_example") as f:
 | - | `tile.scatter_mask` | Mask-pattern row-scatter: write each `src` row into the mask-marked columns of `dst` (DPS — `dst` is in/out). A PyPTO codegen form lowered to a `pto.tscatter` mask emission — **not** a distinct pto-isa instruction (unlike `tile.gather_mask`). See [Mask patterns](#mask-patterns). |
 
 `tile.reshape` preserves dtype, element count, and the source's valid region (see below); `tile.reinterpret_view(data, dtype, *, shape=None)` changes dtype while preserving exact byte size. Without `shape`, it scales the physically contiguous axis using the source/target dtype byte widths and tile layout. Under PTOAS memory planning, it lowers to the aliasing PTO `treshape` primitive for both same-shape and width-changing views.
+
+### Result view of `tile.move`
+
+The deduced result `TileView` splits by field:
+
+| Field | Source of the result value |
+| ----- | -------------------------- |
+| `blayout` / `slayout` | The source tile's effective view — a move preserves the logical layout — unless the destination is `Left` / `Right` / `LeftScale` / `RightScale` (hardware-fixed) or a `blayout` / `slayout` kwarg overrides it |
+| `fractal` | The **destination** space's boxing granularity, never the source's: `Acc` (L0C, NZ-boxed) is 1024, MX scale tiles are 32, everything else 512 |
+| `valid_shape` / `pad` | Carried over from the source |
+| `stride` / `start_offset` | Dropped — the destination is a dense buffer |
+
+`fractal` comes from the destination because it describes how the destination
+buffer is boxed; `tile_view_semantics::GetImplicitFractal` supplies it. It is
+also what makes a same-space, same-layout move canonical:
+`OpRegistry::Create` stamps `memory_space` onto the deduced type, so a result
+view matching the destination's implicit view collapses to `nullopt` — the same
+per-space implicit view
+[`InferTileMemorySpace`](../passes/17-infer_tile_memory_space.md) refreshes a
+retyped tile to.
 
 ### Reshape and the valid region
 

--- a/docs/zh/dev/ir/05-operators.md
+++ b/docs/zh/dev/ir/05-operators.md
@@ -302,6 +302,7 @@ with ib.function("tensor_example") as f:
 | **内存** | `tile.get_block_idx` | 获取 block 索引（返回 UINT64 标量） |
 | - | `tile.load` | TensorType → TileType（DDR 到统一缓冲区） |
 | - | `tile.store` | TileType → TensorType（统一缓冲区到 DDR） |
+| - | `tile.move` | 在 memory space 之间搬移 tile（`target_memory`）—— 见 [tile.move 的结果 view](#tilemove-的结果-view) |
 | **逐元素** | `tile.add/sub/mul/div` | Tile-Tile 操作 |
 | - | `tile.adds/subs/muls/divs` | Tile-Scalar 操作。**常量**标量操作数会采用 tile 的元素 dtype（裸整数字面量否则会被解析为 `index`，而任何 `pto.t*s` 算子都不接受它）——但整数 tile 上的浮点字面量仍保持 FP32，以保留类型提升语义。显式的 `pl.const(v, dtype)` 属于用户的有意标注，与任何非常量表达式一样保持不变；非常量的 `index` 标量（循环变量、`pl.dim`）会被拒绝——需用 `pl.cast` 转换。`tensor.*s` 同理。 |
 | **一元** | `tile.sqrt` | 逐元素平方根 |
@@ -317,6 +318,24 @@ with ib.function("tensor_example") as f:
 | - | `tile.scatter_mask` | 按掩码模式把 `src` 行写入 `dst` 中由掩码选中的列（DPS：`dst` 为 in/out）。这是 PyPTO codegen 层形式，下降为 `pto.tscatter` 掩码发射 —— **并非**独立的 pto-isa 指令（与 `tile.gather_mask` 不同）。掩码语义见[掩码模式](#掩码模式)。 |
 
 `tile.reshape` 保持 dtype、元素总数以及源的有效区域（见下）；`tile.reinterpret_view(data, dtype, *, shape=None)` 改变 dtype，但要求前后总字节数完全相同。省略 `shape` 时，它会根据源/目标 dtype 字节宽度和 tile layout 缩放物理连续轴。在 PTOAS 内存规划下，无论 shape 是否变化，都会下降为保持别名关系的 PTO `treshape` 原语。
+
+### tile.move 的结果 view
+
+推导出的结果 `TileView` 按字段分别取值：
+
+| 字段 | 结果值的来源 |
+| ---- | ------------ |
+| `blayout` / `slayout` | 源 tile 的 effective view —— move 保持逻辑 layout —— 除非目标是 `Left` / `Right` / `LeftScale` / `RightScale`（硬件固定），或由 `blayout` / `slayout` kwarg 覆盖 |
+| `fractal` | **目标** space 的分块（boxing）粒度，绝不取源的：`Acc`（L0C，NZ 分形）为 1024，MX scale tile 为 32，其余为 512 |
+| `valid_shape` / `pad` | 从源带过来 |
+| `stride` / `start_offset` | 丢弃 —— 目标是稠密缓冲区 |
+
+`fractal` 来自目标，因为它描述的是目标缓冲区如何分块，由
+`tile_view_semantics::GetImplicitFractal` 提供。它同时决定了「同 space、同 layout」的
+move 是否规范：`OpRegistry::Create` 会把 `memory_space` 打到推导出的类型上，因此当结果 view 与目标
+space 的 implicit view 一致时会折叠为 `nullopt` —— 这与
+[`InferTileMemorySpace`](../passes/17-infer_tile_memory_space.md) 为重新定型的 tile 刷新的
+per-space implicit view 是同一套。
 
 ### reshape 与有效区域（valid region）
 

--- a/include/pypto/ir/tile_view_semantics.h
+++ b/include/pypto/ir/tile_view_semantics.h
@@ -13,6 +13,7 @@
 #define PYPTO_IR_TILE_VIEW_SEMANTICS_H_
 
 #include <cstddef>
+#include <cstdint>
 #include <memory>
 #include <optional>
 #include <vector>
@@ -29,6 +30,9 @@ namespace pypto::ir::tile_view_semantics {
 
 /// MX block-scale fractal size: one shared exponent per 32 elements (A5 ISA).
 inline constexpr int kMXScaleFractal = 32;
+
+/// Acc (L0C) fractal size: the accumulator is NZ-boxed at 1024 bytes.
+inline constexpr uint64_t kAccFractal = 1024;
 
 /// Return whether two shape-like expression lists are statically identical.
 inline bool ShapeExprListsEquivalent(const std::vector<ExprPtr>& lhs, const std::vector<ExprPtr>& rhs) {
@@ -58,12 +62,33 @@ inline TileLayout InferImplicitTileLayoutFromShape(const std::vector<ExprPtr>& s
   return (cols_const->value_ == 1 && rows_const->value_ > 1) ? TileLayout::col_major : TileLayout::row_major;
 }
 
+/// Boxing granularity implied by a memory space. Unlike blayout/slayout it does
+/// not depend on the shape, so a caller that only needs the fractal (e.g. an op
+/// deducing a result that lands in `memory_space`) can skip building a whole
+/// TileView. GetImplicitTileView below delegates here so the two cannot drift.
+inline uint64_t GetImplicitFractal(const std::optional<MemorySpace>& memory_space) {
+  if (!memory_space.has_value()) {
+    return TileView{}.fractal;
+  }
+  switch (*memory_space) {
+    // MX scale tiles: one shared exponent per 32 elements.
+    case MemorySpace::LeftScale:
+    case MemorySpace::RightScale:
+      return kMXScaleFractal;
+    case MemorySpace::Acc:
+      return kAccFractal;
+    default:
+      return TileView{}.fractal;
+  }
+}
+
 /// Build the implicit TileView semantics represented by omitted Python syntax.
 inline TileView GetImplicitTileView(const std::vector<ExprPtr>& shape,
                                     const std::optional<MemorySpace>& memory_space = std::nullopt) {
   TileView implicit_view;
   implicit_view.valid_shape = shape;
   implicit_view.blayout = InferImplicitTileLayoutFromShape(shape);
+  implicit_view.fractal = GetImplicitFractal(memory_space);
 
   if (memory_space.has_value()) {
     switch (*memory_space) {
@@ -76,21 +101,18 @@ inline TileView GetImplicitTileView(const std::vector<ExprPtr>& shape,
         implicit_view.slayout = TileLayout::col_major;
         break;
       case MemorySpace::LeftScale:
-        // ISA TileLeftScale: RowMajor / RowMajor, MX scale fractal size 32.
+        // ISA TileLeftScale: RowMajor / RowMajor.
         implicit_view.blayout = TileLayout::row_major;
         implicit_view.slayout = TileLayout::row_major;
-        implicit_view.fractal = kMXScaleFractal;
         break;
       case MemorySpace::RightScale:
-        // ISA TileRightScale: ColMajor / ColMajor, MX scale fractal size 32.
+        // ISA TileRightScale: ColMajor / ColMajor.
         implicit_view.blayout = TileLayout::col_major;
         implicit_view.slayout = TileLayout::col_major;
-        implicit_view.fractal = kMXScaleFractal;
         break;
       case MemorySpace::Acc:
         implicit_view.blayout = TileLayout::col_major;
         implicit_view.slayout = TileLayout::row_major;
-        implicit_view.fractal = 1024;
         break;
       default:
         break;

--- a/src/ir/op/tile_ops/memory.cpp
+++ b/src/ir/op/tile_ops/memory.cpp
@@ -197,7 +197,7 @@ TypePtr DeduceTileLoadType(const std::vector<ExprPtr>& args,
       tile_view.blayout = TileLayout::row_major;
       tile_view.slayout = TileLayout::row_major;
     }
-    tile_view.fractal = 32;
+    tile_view.fractal = tile_view_semantics::kMXScaleFractal;
   } else if (target_memory_opt.has_value()) {
     if (*target_memory_opt == MemorySpace::Mat) {
       tile_view.blayout = TileLayout::col_major;
@@ -409,11 +409,17 @@ TypePtr DeduceTileMoveType(const std::vector<ExprPtr>& args,
 
   const TileView source_view = tile_view_semantics::GetEffectiveTileView(*tile_type);
 
+  // blayout/slayout follow the source — a move preserves the logical layout —
+  // but `fractal` is the destination buffer's boxing granularity, not a source
+  // property, so it comes from the destination space. See
+  // docs/en/dev/ir/05-operators.md "Result view of tile.move".
   TileView tile_view;
   tile_view.blayout = source_view.blayout;
   tile_view.slayout = source_view.slayout;
+  tile_view.fractal = tile_view_semantics::GetImplicitFractal(space);
 
-  // Hardcoded layout for Left/Right/scale (hardware requirements)
+  // Hardcoded layout for Left/Right/scale (hardware requirements; their fractal
+  // already comes from the destination-implicit seed above)
   if (space == MemorySpace::Left) {
     tile_view.blayout = TileLayout::col_major;  // L0A requires ColMajor block layout for TMATMUL
     tile_view.slayout = TileLayout::row_major;
@@ -421,13 +427,12 @@ TypePtr DeduceTileMoveType(const std::vector<ExprPtr>& args,
     tile_view.blayout = TileLayout::row_major;
     tile_view.slayout = TileLayout::col_major;
   } else if (space == MemorySpace::LeftScale) {
+    // fractal is already kMXScaleFractal via the destination-implicit seed above.
     tile_view.blayout = TileLayout::row_major;
     tile_view.slayout = TileLayout::row_major;
-    tile_view.fractal = 32;
   } else if (space == MemorySpace::RightScale) {
     tile_view.blayout = TileLayout::col_major;
     tile_view.slayout = TileLayout::col_major;
-    tile_view.fractal = 32;
   }
 
   // Ordinary destinations permit explicit layouts. Scale destinations have
@@ -471,7 +476,7 @@ TypePtr DeduceTileMoveType(const std::vector<ExprPtr>& args,
     const TileLayout required_layout =
         space == MemorySpace::LeftScale ? TileLayout::row_major : TileLayout::col_major;
     CHECK(source_view.blayout == required_layout && source_view.slayout == required_layout &&
-          source_view.fractal == 32)
+          source_view.fractal == tile_view_semantics::kMXScaleFractal)
         << "The operator " << op_name << " into " << MemorySpaceToString(space)
         << " requires the source Mat tile to use the matching "
         << (space == MemorySpace::LeftScale ? "row/row/32" : "col/col/32") << " layout";

--- a/tests/ut/ir/operators/test_tile_ops.py
+++ b/tests/ut/ir/operators/test_tile_ops.py
@@ -4086,6 +4086,51 @@ class TestTileCreateOp:
         assert tile_type.get_effective_tile_view().blayout == ir.TileLayout.row_major
 
 
+class TestTileMoveOp:
+    """Tests for tile.move result-view deduction."""
+
+    @staticmethod
+    def _tile_var(space):
+        return ir.Var("t_src", ir.TileType([16, 64], DataType.FP32, None, None, space), ir.Span.unknown())
+
+    @pytest.mark.parametrize(
+        ("space", "expected_fractal"),
+        [
+            (ir.MemorySpace.Vec, 512),
+            (ir.MemorySpace.Mat, 512),
+            (ir.MemorySpace.Acc, 1024),
+        ],
+    )
+    def test_same_space_move_deduces_destination_implicit_view(self, space, expected_fractal):
+        """`fractal` is the destination buffer's boxing granularity, not the
+        TileView default: Acc (L0C) is NZ-boxed at 1024. A move that changes
+        neither space nor layout must therefore deduce exactly the destination's
+        implicit view, which is stored canonically as None. With the default 512
+        an Acc result stays explicit — and since a pass-synthesized move's LHS
+        Var carries no view, the print->parse roundtrip breaks."""
+        call = tile.move(self._tile_var(space), target_memory=space)
+
+        assert isinstance(call.type, ir.TileType)
+        assert call.type.memory_space == space
+        assert call.type.tile_view is None
+        assert call.type.get_effective_tile_view().fractal == expected_fractal
+
+    def test_acc_to_vec_move_keeps_vec_fractal(self):
+        """Moving out of Acc must adopt Vec's granularity, not carry 1024 along:
+        the cube->vec pipe un-fractalizes the data during transfer."""
+        call = tile.move(
+            self._tile_var(ir.MemorySpace.Acc),
+            target_memory=ir.MemorySpace.Vec,
+            blayout=ir.TileLayout.row_major,
+            slayout=ir.TileLayout.none_box,
+        )
+
+        assert isinstance(call.type, ir.TileType)
+        assert call.type.get_effective_tile_view().fractal == 512
+        # row_major/none_box/512 *is* Vec's implicit view — stored canonically.
+        assert call.type.tile_view is None
+
+
 class TestTileScalarOps:
     """Tests for tile scalar read/write ops (tile.read / tile.write)."""
 

--- a/tests/ut/ir/operators/test_tile_ops.py
+++ b/tests/ut/ir/operators/test_tile_ops.py
@@ -4115,6 +4115,35 @@ class TestTileMoveOp:
         assert call.type.tile_view is None
         assert call.type.get_effective_tile_view().fractal == expected_fractal
 
+    @pytest.mark.parametrize(
+        ("source_space", "view_stored"),
+        [
+            # Mat's layout triple differs from Acc's only in fractal, so adopting
+            # the destination's 1024 lands exactly on Acc's implicit view.
+            (ir.MemorySpace.Mat, False),
+            # Vec's blayout/slayout follow the source, so the view stays explicit —
+            # but fractal is still the destination's.
+            (ir.MemorySpace.Vec, True),
+        ],
+    )
+    def test_move_into_acc_adopts_acc_fractal_from_non_acc_source(self, source_space, view_stored):
+        """A 512-fractal source moved into Acc must report Acc's 1024.
+
+        The same-space cases above cannot show this: an Acc source already has
+        fractal 1024, so they pass even if the result wrongly inherited it from
+        the source instead of taking it from the destination."""
+        source = self._tile_var(source_space)
+        source_type = source.type
+        assert isinstance(source_type, ir.TileType)
+        assert source_type.get_effective_tile_view().fractal == 512
+
+        call = tile.move(source, target_memory=ir.MemorySpace.Acc)
+
+        assert isinstance(call.type, ir.TileType)
+        assert call.type.memory_space == ir.MemorySpace.Acc
+        assert (call.type.tile_view is not None) == view_stored
+        assert call.type.get_effective_tile_view().fractal == 1024
+
     def test_acc_to_vec_move_keeps_vec_fractal(self):
         """Moving out of Acc must adopt Vec's granularity, not carry 1024 along:
         the cube->vec pipe un-fractalizes the data during transfer."""

--- a/tests/ut/ir/transforms/test_memory_reuse.py
+++ b/tests/ut/ir/transforms/test_memory_reuse.py
@@ -1970,13 +1970,22 @@ class TestYieldFixup:
         var_type = moves[0].var.type
         call_type = moves[0].value.type
         assert isinstance(var_type, ir.TileType) and isinstance(call_type, ir.TileType)
-        assert var_type.tile_view is None and call_type.tile_view is None, (
-            f"synthesized tile.move '{moves[0].var.name_hint}' must carry the canonical "
-            f"(absent) Acc view on both sides: var={var_type.tile_view} "
-            f"call={call_type.tile_view}\n{ir.python_print(After)}"
-        )
-        fractal = var_type.get_effective_tile_view().fractal
-        assert fractal == 1024, f"an Acc tile is NZ-boxed at 1024, got {fractal}"
+        # Compare the full tile semantics, not just view presence: a matching
+        # tile_view means nothing if the two sides disagree on memory_space,
+        # because the space is what the absent view resolves against.
+        for label, tile_type in (("var", var_type), ("call", call_type)):
+            assert tile_type.memory_space == ir.MemorySpace.Acc, (
+                f"synthesized tile.move {label} must stay in Acc, got "
+                f"{tile_type.memory_space}\n{ir.python_print(After)}"
+            )
+            assert tile_type.tile_view is None, (
+                f"synthesized tile.move {label} must carry the canonical (absent) Acc "
+                f"view, got {tile_type.tile_view}\n{ir.python_print(After)}"
+            )
+            fractal = tile_type.get_effective_tile_view().fractal
+            assert fractal == 1024, (
+                f"an Acc tile is NZ-boxed at 1024, {label} got {fractal}\n{ir.python_print(After)}"
+            )
 
 
 class TestControlFlow:

--- a/tests/ut/ir/transforms/test_memory_reuse.py
+++ b/tests/ut/ir/transforms/test_memory_reuse.py
@@ -870,6 +870,62 @@ def _collect_tile_memref_bases(program: ir.Program) -> dict[str, str]:
     return result
 
 
+def _collect_move_assign_stmts(program: ir.Program) -> list[ir.AssignStmt]:
+    """Return every ``x = tile.move(...)`` AssignStmt in the first function."""
+    result: list[ir.AssignStmt] = []
+    main_func = next(iter(program.functions.values()))
+    move_op_name = ir.get_op("tile.move").name
+
+    class _Collector(ir.IRVisitor):
+        def visit_assign_stmt(self, stmt):  # type: ignore[override]
+            if isinstance(stmt.value, ir.Call) and stmt.value.op.name == move_op_name:
+                result.append(stmt)
+            super().visit_assign_stmt(stmt)
+
+    visitor = _Collector()
+    visitor.visit_stmt(main_func.body)
+    return result
+
+
+def _divergent_acc_phi_program() -> ir.Program:
+    """A divergent Acc if-phi: ``then`` yields the pre-if seed ``pre``, ``else``
+    accumulates in place into ``prev``.
+
+    The accumulator coalescer must decline this shape (``pre`` runs
+    unconditionally, so retargeting it onto ``prev`` would clobber the
+    accumulator), leaving YieldFixup to reconcile the phi with a tile.move.
+    Shared by the tests that assert each half of that contract.
+    """
+
+    @pl.program
+    class Before:
+        @pl.function
+        def main(
+            self,
+            lhs: pl.Tensor[[16, 64], pl.BF16],
+            rhs: pl.Tensor[[64, 64], pl.BF16],
+            cond: pl.Scalar[pl.INDEX],
+            out: pl.Out[pl.Tensor[[16, 64], pl.FP32]],
+        ) -> pl.Tensor[[16, 64], pl.FP32]:
+            sa: pl.Tile[[16, 64], pl.BF16, pl.Mem.Mat] = pl.tile.load(
+                lhs, [0, 0], [16, 64], target_memory=pl.Mem.Mat
+            )
+            sb: pl.Tile[[64, 64], pl.BF16, pl.Mem.Mat] = pl.tile.load(
+                rhs, [0, 0], [64, 64], target_memory=pl.Mem.Mat
+            )
+            prev: pl.Tile[[16, 64], pl.FP32, pl.Mem.Acc] = pl.tile.matmul(sa, sb)  # the accumulator
+            pre: pl.Tile[[16, 64], pl.FP32, pl.Mem.Acc] = pl.tile.matmul(sa, sb)  # pre-if seed
+            if cond < 1:
+                phi: pl.Tile[[16, 64], pl.FP32, pl.Mem.Acc] = pl.yield_(pre)
+            else:
+                acc: pl.Tile[[16, 64], pl.FP32, pl.Mem.Acc] = pl.tile.matmul_acc(prev, sa, sb)
+                phi: pl.Tile[[16, 64], pl.FP32, pl.Mem.Acc] = pl.yield_(acc)
+            result: pl.Tensor[[16, 64], pl.FP32] = pl.store(phi, [0, 0], out)
+            return result
+
+    return Before
+
+
 class TestViewOps:
     """Tests for view operations (reshape) with memory reuse."""
 
@@ -1892,6 +1948,36 @@ class TestYieldFixup:
         After = _run_pipeline(Before)
         ir.assert_structural_equal(After, Expected)
 
+    def test_synthesized_acc_move_var_and_call_agree_on_tile_view(self):
+        """The move YieldFixup synthesizes to reconcile a divergent Acc phi must
+        type its LHS Var and its Call identically.
+
+        The Var's type is cloned from the move source (canonical Acc view, so
+        ``tile_view=None``) while the Call's type comes from ``tile.move``'s own
+        deduction. If the two disagree, the printer emits only the Var's
+        (view-less) annotation and the parser refills the view from the Call —
+        so the program no longer survives print->parse. The per-pass roundtrip
+        instrument in ``tests/ut/conftest.py`` catches that; this test pins the
+        underlying invariant so a failure names the actual defect.
+        """
+        After = _run_pipeline(_divergent_acc_phi_program())
+
+        moves = _collect_move_assign_stmts(After)
+        assert len(moves) == 1, (
+            f"expected YieldFixup to synthesize exactly one tile.move, got "
+            f"{len(moves)}:\n{ir.python_print(After)}"
+        )
+        var_type = moves[0].var.type
+        call_type = moves[0].value.type
+        assert isinstance(var_type, ir.TileType) and isinstance(call_type, ir.TileType)
+        assert var_type.tile_view is None and call_type.tile_view is None, (
+            f"synthesized tile.move '{moves[0].var.name_hint}' must carry the canonical "
+            f"(absent) Acc view on both sides: var={var_type.tile_view} "
+            f"call={call_type.tile_view}\n{ir.python_print(After)}"
+        )
+        fractal = var_type.get_effective_tile_view().fractal
+        assert fractal == 1024, f"an Acc tile is NZ-boxed at 1024, got {fractal}"
+
 
 class TestControlFlow:
     """Tests for correct lifetime analysis across control flow boundaries."""
@@ -2878,38 +2964,10 @@ class TestTopDownRetargeter:
         the coalescer must skip this phi (leaving it to YieldFixup) and keep
         ``pre`` and ``prev`` on distinct buffers.
         """
-
-        @pl.program
-        class Before:
-            @pl.function
-            def main(
-                self,
-                lhs: pl.Tensor[[16, 64], pl.BF16],
-                rhs: pl.Tensor[[64, 64], pl.BF16],
-                cond: pl.Scalar[pl.INDEX],
-                out: pl.Out[pl.Tensor[[16, 64], pl.FP32]],
-            ) -> pl.Tensor[[16, 64], pl.FP32]:
-                sa: pl.Tile[[16, 64], pl.BF16, pl.Mem.Mat] = pl.tile.load(
-                    lhs, [0, 0], [16, 64], target_memory=pl.Mem.Mat
-                )
-                sb: pl.Tile[[64, 64], pl.BF16, pl.Mem.Mat] = pl.tile.load(
-                    rhs, [0, 0], [64, 64], target_memory=pl.Mem.Mat
-                )
-                prev: pl.Tile[[16, 64], pl.FP32, pl.Mem.Acc] = pl.tile.matmul(sa, sb)  # the accumulator
-                pre: pl.Tile[[16, 64], pl.FP32, pl.Mem.Acc] = pl.tile.matmul(sa, sb)  # pre-if seed
-                if cond < 1:
-                    phi: pl.Tile[[16, 64], pl.FP32, pl.Mem.Acc] = pl.yield_(pre)
-                else:
-                    acc: pl.Tile[[16, 64], pl.FP32, pl.Mem.Acc] = pl.tile.matmul_acc(prev, sa, sb)
-                    phi: pl.Tile[[16, 64], pl.FP32, pl.Mem.Acc] = pl.yield_(acc)
-                result: pl.Tensor[[16, 64], pl.FP32] = pl.store(phi, [0, 0], out)
-                return result
-
-        # Verification off: the un-coalesced divergent Acc phi is the documented
-        # out-of-scope case (YieldFixup emits its usual move); we only assert the
-        # safety property — the pre-if seed was NOT retargeted onto the accumulator.
-        with passes.PassContext([], passes.VerificationLevel.NONE):
-            After = _run_pipeline(Before)
+        # The un-coalesced divergent Acc phi is the documented out-of-scope case
+        # (YieldFixup emits its usual move); we only assert the safety property —
+        # the pre-if seed was NOT retargeted onto the accumulator.
+        After = _run_pipeline(_divergent_acc_phi_program())
         bases = _collect_tile_memref_bases(After)
         assert bases["pre"] != bases["prev"], (
             f"pre-if seed must not be coalesced onto the accumulator buffer (clobber): "
@@ -2935,9 +2993,9 @@ class TestTopDownRetargeter:
         ``memory_reuse`` alone: the clobbering alias is a specific buffer layout
         that only surfaces after allocation, so it cannot be expressed through the
         high-level ``init_mem_ref`` path (which hands every tile a distinct base).
-        Verification off: the declined phi is reconciled by YieldFixup's usual
-        (legal, distinct-buffer) move — we assert only the safety property, that
-        ``seed`` was NOT retargeted onto the accumulator buffer.
+        The declined phi is reconciled by YieldFixup's usual (legal,
+        distinct-buffer) move — we assert only the safety property, that ``seed``
+        was NOT retargeted onto the accumulator buffer.
         """
 
         @pl.program
@@ -2991,8 +3049,7 @@ class TestTopDownRetargeter:
                 )
                 return result
 
-        with passes.PassContext([], passes.VerificationLevel.NONE):
-            After = passes.memory_reuse()(Before)
+        After = passes.memory_reuse()(Before)
         bases = _collect_tile_memref_bases(After)
         assert bases["seed"] != bases["prev"], (
             f"seed must not be coalesced onto the accumulator buffer when a later write-only op "


### PR DESCRIPTION
## Summary

`DeduceTileMoveType` copied `blayout`/`slayout` from the source tile's effective view but left `fractal` at the `TileView` default (512). For an `Acc` (L0C) destination — whose implicit fractal is 1024 — the deduced view matched neither the implicit view for no-space nor the one for `Acc`, so `CanonicalizeTileViewInPlace` could not collapse it to `nullopt` even after `OpRegistry::Create` stamps `memory_space` onto the type.

That made a pass-synthesized move self-inconsistent. `MemoryReuse`'s YieldFixup types the assigned `Var` by cloning the source (view absent) while the `Call` carried the explicit wrong-fractal view:

```text
after MemoryReuse : acc_mv  VAR tile_view=None   CALL tile_view=SET(fractal=512)
after print->parse: acc_mv  VAR tile_view=SET    CALL tile_view=SET(fractal=512)

RuntimeError: [RoundtripInstrument] Structural equality failed after pass 'MemoryReuse'.
  Error: Structural equality assertion failed at: ['main'].body[8].else_body[1].var
  Reason: TileType tile_view presence mismatch
```

The printer emits only the Var's annotation, and the parser refills the view from the Call (`ast_parser.py`: `merged_tv = ann_tv if ann_tv is not None else inf_tv`), so the program failed the print→parse roundtrip after `MemoryReuse`.

## Fix

`fractal` describes how the *destination* buffer is boxed, not a property carried from the source, so it is now seeded from the destination space via a new `tile_view_semantics::GetImplicitFractal` helper. `GetImplicitTileView` delegates to the same helper so the two cannot drift, which also lets the duplicated `fractal = 32` literals in the scale branches go.

Behavior across all source→destination pairs:

| destination | before | after |
| ----------- | ------ | ----- |
| `Vec`, `Mat`, `Left`, `Right` | 512 | 512 (unchanged) |
| `LeftScale` / `RightScale` | 32 | 32 (unchanged, now via the helper) |
| `Acc` | 512 (wrong) | 1024 |

`Acc→Vec` is unchanged at 512 — the cube→vec pipe un-fractalizes during transfer. `Vec→Acc` and `Right→Acc` now report 1024 instead of a wrong 512; their views were already explicit for other reasons, so only the number changed.

The fix is deliberately in the op's type deduction rather than in `MemoryReuse::CreateTileMove`. Typing the LHS Var from the op's deduction alone would have made both sides agree on `fractal=512` for an Acc tile, which breaks the same-address elision in `pto_ops_elementwise.cpp` (it compares `src_view.fractal == dst_view.fractal`, and the elision exists for #1310) and feeds a wrong fractal into the emitted tile-buffer type string via `pto_type_utils.cpp`.

## Testing

- [x] All tests pass — `tests/ut/`: 8552 passed, 2 skipped; `tests/st/codegen`: 42 passed
- [x] Code review completed
- [x] clang-tidy clean on the changed TU and header
- [x] Documentation updated (`docs/en` + `docs/zh`)

New coverage:

- `TestTileMoveOp` in `tests/ut/ir/operators/test_tile_ops.py` — parametrized over Vec/Mat/Acc pinning the destination fractal and that a same-space move's view is stored canonically as `None`, plus the `Acc→Vec` case.
- `test_synthesized_acc_move_var_and_call_agree_on_tile_view` in `tests/ut/ir/transforms/test_memory_reuse.py` — pins the underlying invariant so a regression names the actual defect instead of surfacing as an opaque roundtrip diff.

This also **removes two `PassContext([], VerificationLevel.NONE)` bypasses** in `TestTopDownRetargeter` that existed only to hide this roundtrip failure; those tests now run under full verification. The divergent-Acc-phi program they shared with the new test is extracted into `_divergent_acc_phi_program()`.