### PR TITLE
refactor(parser): Remove the deprecated pl.Tensor[..., pl.DN] shorthand

### DIFF
--- a/docs/en/dev/passes/28-materialize_tensor_strides.md
+++ b/docs/en/dev/passes/28-materialize_tensor_strides.md
@@ -66,7 +66,7 @@ The pass is **idempotent**: re-running on already-materialized IR is a no-op, si
 
 ## Example
 
-**Before** — InCore param with empty-stride DN view (user-written `pl.Tensor[..., pl.DN]` without an explicit stride hint):
+**Before** — InCore param with empty-stride DN view (`pl.TensorView(layout=DN)` written without an explicit stride hint):
 
 ```python
 @pl.function(type=pl.FunctionType.InCore)

--- a/docs/en/user/01-language_guide.md
+++ b/docs/en/user/01-language_guide.md
@@ -60,11 +60,11 @@ b: pl.Tensor[[N, K], pl.FP32]
 ```
 
 ```python
-# ⚠️ Deprecated (RFC #1300 supplementary 1):
-b: pl.Tensor[[K, N], pl.FP32, pl.DN]   # → DeprecationWarning at parse time
+# ❌ Rejected (RFC #1300 supplementary 1):
+b: pl.Tensor[[K, N], pl.FP32, pl.DN]   # → ParserTypeError at parse time
 ```
 
-> **Why `pl.Tensor[..., pl.DN]` is deprecated.** Writing the DN
+> **Why `pl.Tensor[..., pl.DN]` is rejected.** Writing the DN
 > layout-only shorthand forces you to mentally hold two coordinate systems
 > at once (the IR-logical post-view shape and the runtime row-major shape).
 > Drop the layout marker and write the runtime shape — for matmul B^T,

--- a/docs/zh/dev/passes/28-materialize_tensor_strides.md
+++ b/docs/zh/dev/passes/28-materialize_tensor_strides.md
@@ -66,7 +66,7 @@ Pass **幂等** —— 在已物化的 IR 上重跑等于无操作（类型比�
 
 ## 示例
 
-**Before** —— InCore 形参带有空 stride 的 DN view（用户写的 `pl.Tensor[..., pl.DN]` 未给显式 stride 提示）：
+**Before** —— InCore 形参带有空 stride 的 DN view（写 `pl.TensorView(layout=DN)` 但未给显式 stride 提示）：
 
 ```python
 @pl.function(type=pl.FunctionType.InCore)

--- a/docs/zh/user/01-language_guide.md
+++ b/docs/zh/user/01-language_guide.md
@@ -57,11 +57,11 @@ b: pl.Tensor[[N, K], pl.FP32]
 ```
 
 ```python
-# ⚠️ 已弃用（RFC #1300 补充 1）：
-b: pl.Tensor[[K, N], pl.FP32, pl.DN]   # → 解析期触发 DeprecationWarning
+# ❌ 不支持（RFC #1300 补充 1）：
+b: pl.Tensor[[K, N], pl.FP32, pl.DN]   # → 解析期抛 ParserTypeError
 ```
 
-> **为什么弃用 `pl.Tensor[..., pl.DN]`。** layout-only 简写迫使用户脑子里同时持有两套坐标系（IR 逻辑后视图 shape 与 runtime 行优先 shape）—— 恰恰是 RFC #1300 想要消除的歧义。改用：去掉 layout 标记，写 runtime shape —— matmul B^T 场景给 `pl.matmul` 传 `b_trans=True`（或 `a_trans=True`），或自然 load 后用 `pl.tile.transpose_view(...)`（参见下文「数据搬运」）；DN-producing op 之后的 slice 自动继承父 layout。
+> **为什么不支持 `pl.Tensor[..., pl.DN]`。** layout-only 简写迫使用户脑子里同时持有两套坐标系（IR 逻辑后视图 shape 与 runtime 行优先 shape）—— 恰恰是 RFC #1300 想要消除的歧义。改用：去掉 layout 标记，写 runtime shape —— matmul B^T 场景给 `pl.matmul` 传 `b_trans=True`（或 `a_trans=True`），或自然 load 后用 `pl.tile.transpose_view(...)`（参见下文「数据搬运」）；DN-producing op 之后的 slice 自动继承父 layout。
 
 如需 NZ（硬件 tile layout），写 `pl.Tile[..., pl.NZ]` —— NZ 是 tile-only，不允许作为 TensorType annotation。`pl.NZ` 常量保留用于 tile annotation 和 IR 内部使用。
 

--- a/python/pypto/language/parser/type_resolver.py
+++ b/python/pypto/language/parser/type_resolver.py
@@ -10,7 +10,6 @@
 """Type annotation resolution for IR parsing."""
 
 import ast
-import warnings
 from collections.abc import Callable, Sequence
 from typing import TYPE_CHECKING, Any, cast
 
@@ -1350,33 +1349,41 @@ class TypeResolver:
             hint="Use pl.FP32, pl.INT32, or other supported dtype constants",
         )
 
-    def _warn_on_user_facing_dn_layout(self, layout: "ir.TensorLayout", type_name: str) -> None:
-        """Emit a ``DeprecationWarning`` when the user writes the layout-only DN
-        shorthand on a tensor type annotation (RFC #1300 supplementary 1).
+    def _reject_user_facing_dn_layout(
+        self, layout: "ir.TensorLayout", type_name: str, node: ast.expr
+    ) -> None:
+        """Reject the layout-only DN shorthand on a tensor type annotation.
 
-        Suppressed for ``ir.TensorLayout.ND`` (default, no-op marker) and for
-        explicit ``pl.TensorView(stride=..., layout=DN)`` forms (which carry
-        their own stride and don't rely on the shorthand's implicit coordinate
-        flip). Tile-side layouts are never seen here — Tile annotations route
-        through ``_resolve_tile_annotation_args``.
+        Writing ``pl.Tensor[..., pl.DN]`` requires the user to mentally hold two
+        coordinate systems at once (IR-logical post-view vs. runtime row-major),
+        which is exactly the ambiguity RFC #1300 removes — so the shorthand is
+        not accepted. The marker may also arrive through a variable
+        (``MY = ir.TensorLayout.DN; pl.Tensor[[64, 128], pl.FP32, MY]``), so the
+        message quotes the source spelling rather than assuming ``pl.DN``.
+
+        Only the bare layout marker is rejected. ``ir.TensorLayout.ND`` is the
+        default no-op marker, and an explicit ``pl.TensorView(stride=...,
+        layout=DN)`` carries its own stride, so neither relies on the implicit
+        coordinate flip. Tile-side layouts are never seen here — Tile
+        annotations route through ``_resolve_tile_annotation_args``.
+
+        Raises:
+            ParserTypeError: If ``layout`` is ``ir.TensorLayout.DN``
         """
         if layout != ir.TensorLayout.DN:
             return
-        warnings.warn(
-            f"pl.{type_name}[..., pl.DN] is deprecated (RFC #1300 supplementary 1). "
-            "Writing the DN layout-only shorthand requires the user to mentally hold "
-            "two coordinate systems at once (IR-logical post-view vs. runtime "
-            "row-major), which is exactly the ambiguity RFC #1300 aims to eliminate. "
-            "Three migration patterns cover every DN scenario without writing pl.DN:\n"
+        raise ParserTypeError(
+            f"pl.{type_name}[..., {ast.unparse(node)}] is not supported: the DN "
+            "layout-only shorthand forces two coordinate systems (IR-logical "
+            "post-view vs. runtime row-major) onto one annotation",
+            span=self._get_span(node),
+            hint="Three patterns cover every DN scenario without pl.DN:\n"
             "  * source tensor shape, no layout marker: pl.Tensor[[N, K], pl.FP32]\n"
             "  * derive DN at use site: xt = pl.transpose(x, -2, -1)  # ND -> DN\n"
             "  * inherit DN through slice/reshape from a DN-producing op\n"
-            "If you must express a strided-DN view (e.g. canonical pretty-print "
-            "round-trip), use pl.TensorView(stride=[...], layout=pl.TensorLayout.DN) "
-            "instead — it forces explicit stride and avoids the implicit-coord-flip "
-            "hazard.",
-            DeprecationWarning,
-            stacklevel=4,
+            "For a strided-DN view (e.g. canonical pretty-print round-trip), write "
+            "pl.TensorView(stride=[...], layout=pl.TensorLayout.DN) — it forces an "
+            "explicit stride and avoids the implicit-coord-flip hazard.",
         )
 
     def resolve_layout(self, layout_node: ast.expr) -> "ir.TensorLayout":
@@ -1552,7 +1559,8 @@ class TypeResolver:
             pl.Tensor[[32, 64], pl.FP32, my_layout]  # my_layout = ir.TensorLayout.NZ
 
         A layout is widened to a stride-less view carrying it, so every form
-        yields a view.
+        yields a view. ``pl.DN`` is the one layout the slot does not accept —
+        see ``_reject_user_facing_dn_layout``.
 
         Args:
             node: AST node in slot 3 of the annotation
@@ -1562,7 +1570,8 @@ class TypeResolver:
             ir.TensorView instance
 
         Raises:
-            ParserTypeError: If the node is neither a tensor view nor a layout
+            ParserTypeError: If the node is neither a tensor view nor a layout,
+                or if it is the bare ``pl.DN`` layout marker
         """
         if self._is_tensorview_node(node):
             return self._resolve_tensorview(node)
@@ -1570,7 +1579,7 @@ class TypeResolver:
         if from_var is not None:
             return from_var
         layout = self.resolve_layout(node)
-        self._warn_on_user_facing_dn_layout(layout, type_name)
+        self._reject_user_facing_dn_layout(layout, type_name, node)
         return ir.TensorView([], layout)
 
     def _resolve_tensorview_var_ref(self, node: ast.expr) -> "ir.TensorView | None":

--- a/python/pypto/language/parser/type_resolver.py
+++ b/python/pypto/language/parser/type_resolver.py
@@ -1386,11 +1386,31 @@ class TypeResolver:
             "explicit stride and avoids the implicit-coord-flip hazard.",
         )
 
-    def resolve_layout(self, layout_node: ast.expr) -> "ir.TensorLayout":
+    def _layout_choices_hint(self, dn_allowed: bool) -> str:
+        """Build the "valid layouts" hint for a layout slot.
+
+        A hint has to name only layouts the *failing slot* accepts. A bare
+        tensor-annotation slot rejects DN (see ``_reject_user_facing_dn_layout``),
+        so listing it there would send the user from one error straight into
+        another.
+
+        Args:
+            dn_allowed: Whether DN is legal in the slot being diagnosed
+
+        Returns:
+            Hint text listing the layouts that slot accepts
+        """
+        names = [name for name in self._LAYOUT_MAP if dn_allowed or name != "DN"]
+        return f"Use a valid layout: {', '.join(f'pl.{name}' for name in names)}"
+
+    def resolve_layout(self, layout_node: ast.expr, dn_allowed: bool = True) -> "ir.TensorLayout":
         """Resolve layout annotation to ir.TensorLayout.
 
         Args:
             layout_node: AST node representing layout (e.g., pl.NZ, NZ, or a variable)
+            dn_allowed: Whether the slot being resolved accepts DN. Only shapes the
+                "valid layouts" hint — a resolved DN is rejected by the caller that
+                forbids it, which can explain the migration in context.
 
         Returns:
             TensorLayout enum value
@@ -1399,6 +1419,7 @@ class TypeResolver:
             ParserTypeError: If layout cannot be resolved
         """
         span = self._get_span(layout_node)
+        choices = self._layout_choices_hint(dn_allowed)
 
         if isinstance(layout_node, ast.Attribute):
             layout_name = layout_node.attr
@@ -1407,7 +1428,7 @@ class TypeResolver:
             raise ParserTypeError(
                 f"Unknown layout: {layout_name}",
                 span=span,
-                hint=f"Use a valid layout: {', '.join(self._LAYOUT_MAP.keys())}",
+                hint=choices,
             )
 
         if isinstance(layout_node, ast.Name):
@@ -1422,19 +1443,19 @@ class TypeResolver:
                 raise ParserTypeError(
                     f"Layout variable '{layout_name}' must be a TensorLayout, got {type(value).__name__}",
                     span=span,
-                    hint=f"Use a valid layout: {', '.join(self._LAYOUT_MAP.keys())}",
+                    hint=choices,
                 )
 
             raise ParserTypeError(
                 f"Unknown layout: {layout_name}",
                 span=span,
-                hint=f"Use a valid layout: {', '.join(self._LAYOUT_MAP.keys())}",
+                hint=choices,
             )
 
         raise ParserTypeError(
             f"Cannot resolve layout: {ast.unparse(layout_node)}",
             span=span,
-            hint="Use pl.ND, pl.DN, pl.NZ, pl.MX_A_ZZ, or pl.MX_B_NN",
+            hint=choices,
         )
 
     def validate_annotation_consistency(
@@ -1578,7 +1599,7 @@ class TypeResolver:
         from_var = self._resolve_tensorview_var_ref(node)
         if from_var is not None:
             return from_var
-        layout = self.resolve_layout(node)
+        layout = self.resolve_layout(node, dn_allowed=False)
         self._reject_user_facing_dn_layout(layout, type_name, node)
         return ir.TensorView([], layout)
 

--- a/tests/ut/codegen/test_pto_codegen.py
+++ b/tests/ut/codegen/test_pto_codegen.py
@@ -2395,8 +2395,8 @@ class TestColumnVectorCodegen:
                 # Explicit DN view with the canonical-packed strides for shape
                 # [16, 1] (stride[-2]=1, stride[-1]=shape[-2]=16). Using the
                 # explicit TensorView form (RFC #1300 supplementary 1 escape
-                # hatch) instead of the deprecated pl.Tensor[..., pl.DN]
-                # shorthand. This test specifically verifies the
+                # hatch) — the pl.Tensor[..., pl.DN] shorthand is not
+                # accepted. This test specifically verifies the
                 # column-vector DN codegen path, so the DN view is the test
                 # subject — not a load-time alias.
                 col_vec: pl.Tensor[

--- a/tests/ut/language/parser/test_type_resolver.py
+++ b/tests/ut/language/parser/test_type_resolver.py
@@ -1622,6 +1622,38 @@ class TestLayoutResolution:
         with pytest.raises(ParserTypeError, match="must be a TensorLayout"):
             resolver.resolve_type(node)
 
+    def test_unknown_bare_layout_hint_omits_dn(self):
+        """A bad bare layout must not be told to try ``pl.DN`` — the slot rejects it.
+
+        The hint is the user's next move, so pointing at DN would walk them from
+        this error straight into the DN rejection.
+        """
+        resolver = _make_resolver()
+        node = ast.parse("pl.Tensor[[64, 128], pl.FP16, pl.INVALID]", mode="eval").body
+
+        with pytest.raises(ParserTypeError) as exc_info:
+            resolver.resolve_type(node)
+
+        hint = exc_info.value.hint
+        assert hint is not None
+        assert "pl.DN" not in hint
+        assert "pl.NZ" in hint
+
+    def test_unknown_tensorview_layout_hint_keeps_dn(self):
+        """Inside pl.TensorView(layout=...) DN is legal, so the hint still offers it."""
+        resolver = _make_resolver()
+        node = ast.parse(
+            "pl.Tensor[[64, 128], pl.FP16, pl.TensorView(stride=[128, 1], layout=pl.INVALID)]",
+            mode="eval",
+        ).body
+
+        with pytest.raises(ParserTypeError) as exc_info:
+            resolver.resolve_type(node)
+
+        hint = exc_info.value.hint
+        assert hint is not None
+        assert "pl.DN" in hint
+
     def test_resolve_layout_closure_tensorview_accepted(self):
         """A closure TensorView is a valid slot-3 value, not a rejected layout (issue #2211).
 
@@ -1749,7 +1781,7 @@ class TestLayoutIntegration:
         ],
     )
     def test_parametrized_layout(self, layout, expected):
-        """pytest.mark.parametrize with layout (non-deprecated layouts only)."""
+        """pytest.mark.parametrize with layout (every layout the bare slot accepts)."""
 
         @pl.function
         def func(
@@ -1765,7 +1797,7 @@ class TestLayoutIntegration:
             assert param_type.tensor_view is not None
             assert param_type.tensor_view.layout == expected
 
-    def test_function_with_dn_layout_rejected(self):
+    def test_function_with_dn_param_layout_rejected(self):
         """@pl.function rejects the ``pl.DN`` shorthand (RFC #1300 supplementary 1).
 
         Users should drop the marker, derive DN at use site via
@@ -1777,6 +1809,20 @@ class TestLayoutIntegration:
             @pl.function
             def func(
                 x: pl.Tensor[[16, 1], pl.FP16, pl.DN],
+            ) -> pl.Tensor[[16, 1], pl.FP16]:
+                return x
+
+    def test_function_with_dn_return_layout_rejected(self):
+        """The return annotation is checked too, not just the parameters.
+
+        A parameter carrying DN aborts decoration before the return annotation
+        is ever resolved, so that path needs its own case.
+        """
+        with pytest.raises(ParserTypeError, match=r"pl\.Tensor\[\.\.\., pl\.DN\] is not supported"):
+
+            @pl.function
+            def func(
+                x: pl.Tensor[[16, 1], pl.FP16],
             ) -> pl.Tensor[[16, 1], pl.FP16, pl.DN]:
                 return x
 

--- a/tests/ut/language/parser/test_type_resolver.py
+++ b/tests/ut/language/parser/test_type_resolver.py
@@ -1487,9 +1487,9 @@ class TestLayoutResolution:
     def test_resolve_tensor_with_layout(self, layout_str, expected_layout):
         """Tensor layout syntax preserves non-default layouts and canonicalizes ND.
 
-        ``pl.DN`` is covered separately by ``test_resolve_tensor_with_dn_layout_warns``
-        — it emits a ``DeprecationWarning`` (RFC #1300 supplementary 1) so we
-        verify that warning explicitly rather than swallowing it here.
+        ``pl.DN`` is covered separately by ``test_resolve_tensor_with_dn_layout_rejected``
+        — the layout-only shorthand is not an accepted annotation (RFC #1300
+        supplementary 1), so it cannot be parametrized alongside the valid ones.
         """
         resolver = _make_resolver()
         node = ast.parse(f"pl.Tensor[[64, 128], pl.FP16, {layout_str}]", mode="eval").body
@@ -1504,19 +1504,35 @@ class TestLayoutResolution:
             assert result.tensor_view is not None
             assert result.tensor_view.layout == expected_layout
 
-    def test_resolve_tensor_with_dn_layout_warns(self):
-        """``pl.Tensor[..., pl.DN]`` shorthand is deprecated (RFC #1300 supp. 1).
+    def test_resolve_tensor_with_dn_layout_rejected(self):
+        """``pl.Tensor[..., pl.DN]`` shorthand is rejected (RFC #1300 supp. 1).
 
-        The parser still resolves it to a DN-tagged TensorView for backward
-        compatibility, but emits a ``DeprecationWarning`` pointing users at
-        migration paths (drop the marker, use ``pl.transpose``, or write an
-        explicit ``pl.TensorView(stride=..., layout=DN)``).
+        The error points users at the migration paths (drop the marker, use
+        ``pl.transpose``, or write an explicit
+        ``pl.TensorView(stride=..., layout=DN)``).
         """
         resolver = _make_resolver()
         node = ast.parse("pl.Tensor[[64, 128], pl.FP16, pl.DN]", mode="eval").body
 
-        with pytest.warns(DeprecationWarning, match="pl.DN"):
-            result = resolver.resolve_type(node)
+        with pytest.raises(ParserTypeError, match=r"pl\.Tensor\[\.\.\., pl\.DN\] is not supported"):
+            resolver.resolve_type(node)
+
+    def test_resolve_tensor_with_dn_layout_via_variable_rejected(self):
+        """A DN layout held in a variable is rejected, quoted by its source spelling."""
+        resolver = _make_resolver({"MY_LAYOUT": ir.TensorLayout.DN})
+        node = ast.parse("pl.Tensor[[64, 128], pl.FP16, MY_LAYOUT]", mode="eval").body
+
+        with pytest.raises(ParserTypeError, match=r"pl\.Tensor\[\.\.\., MY_LAYOUT\] is not supported"):
+            resolver.resolve_type(node)
+
+    def test_resolve_tensor_with_dn_tensor_view_accepted(self):
+        """An explicit DN ``pl.TensorView`` stays valid — only the shorthand is gone."""
+        resolver = _make_resolver()
+        node = ast.parse(
+            "pl.Tensor[[64, 128], pl.FP16, pl.TensorView(stride=[1, 64], layout=pl.DN)]",
+            mode="eval",
+        ).body
+        result = resolver.resolve_type(node)
 
         assert isinstance(result, ir.TensorType)
         assert result.tensor_view is not None
@@ -1749,26 +1765,20 @@ class TestLayoutIntegration:
             assert param_type.tensor_view is not None
             assert param_type.tensor_view.layout == expected
 
-    def test_function_with_dn_layout_warns(self):
-        """@pl.function with ``pl.DN`` shorthand emits ``DeprecationWarning``.
+    def test_function_with_dn_layout_rejected(self):
+        """@pl.function rejects the ``pl.DN`` shorthand (RFC #1300 supplementary 1).
 
-        Backwards-compatible — the layout still resolves to DN — but the
-        shorthand is deprecated (RFC #1300 supplementary 1). Users should
-        drop the marker, derive DN at use site via ``pl.transpose``, or
-        write an explicit ``pl.TensorView(stride=..., layout=DN)``.
+        Users should drop the marker, derive DN at use site via
+        ``pl.transpose``, or write an explicit
+        ``pl.TensorView(stride=..., layout=DN)``.
         """
-        with pytest.warns(DeprecationWarning, match="pl.DN"):
+        with pytest.raises(ParserTypeError, match=r"pl\.Tensor\[\.\.\., pl\.DN\] is not supported"):
 
             @pl.function
             def func(
                 x: pl.Tensor[[16, 1], pl.FP16, pl.DN],
             ) -> pl.Tensor[[16, 1], pl.FP16, pl.DN]:
                 return x
-
-        param_type = func.params[0].type
-        assert isinstance(param_type, ir.TensorType)
-        assert param_type.tensor_view is not None
-        assert param_type.tensor_view.layout == ir.TensorLayout.DN
 
 
 class TestValidateAnnotationConsistency:


### PR DESCRIPTION
## Summary

**BREAKING CHANGE:** the DN layout-only shorthand on a tensor type annotation now raises `ParserTypeError` instead of emitting a `DeprecationWarning`.

```python
b: pl.Tensor[[K, N], pl.FP32, pl.DN]   # was: DeprecationWarning -> now: ParserTypeError
```

Writing `pl.Tensor[..., pl.DN]` forces the reader to hold two coordinate systems at once (IR-logical post-view shape vs. runtime row-major shape) — exactly the ambiguity RFC #1300 supplementary 1 set out to remove. The shorthand was deprecated for that reason; this removes it.

- `_warn_on_user_facing_dn_layout` -> `_reject_user_facing_dn_layout` in `python/pypto/language/parser/type_resolver.py`. The error carries a span and quotes the annotation's **source spelling**, so a layout passed through a variable (`MY = ir.TensorLayout.DN; pl.Tensor[..., MY]`) reports `MY` rather than a `pl.DN` the user never wrote.
- The hint lists the three migration patterns: drop the marker and write the runtime shape, derive DN at the use site via `pl.transpose`, or inherit it through a slice/reshape of a DN-producing op.
- Drops the now-unused `warnings` import.

## Scope — what is *not* affected

`TensorLayout.DN`, the `pl.DN` constant, and `pl.TensorView(stride=..., layout=DN)` all stay valid. Only the bare layout marker in slot 3 of a `Tensor` / `DistributedTensor` annotation is rejected — the explicit view carries its own stride and so has no implicit coordinate flip.

Print/reparse round-trip is unaffected: `IRPythonPrinter::PrintTensorView` only ever emits the full `pl.TensorView(stride=..., layout=...)` form, never the bare shorthand.

No production use of the shorthand remained in this repo or in `pypto-lib`.

## Testing

- [x] `tests/ut` full suite: 8426 passed, 2 skipped
- [x] `tests/ut/language/parser/test_type_resolver.py`: rewrote the two `pytest.warns` cases as `pytest.raises`; added coverage for the variable-held DN layout and a positive case locking in that `pl.TensorView(stride=..., layout=DN)` still resolves
- [x] ruff check / ruff format / pyright clean
- [x] Code review completed
- [x] Documentation updated — `docs/en|zh/user/01-language_guide.md` (Deprecated -> Rejected) and `docs/en|zh/dev/passes/28-materialize_tensor_strides.md` (example prose no longer refers to the removed spelling)