### PR TITLE
docs(ir): Document TileView::fractal as a byte size

### DIFF
--- a/docs/en/dev/codegen/00-pto_codegen.md
+++ b/docs/en/dev/codegen/00-pto_codegen.md
@@ -532,7 +532,7 @@ Generated `alloc_tile` operations derive dtype and dimensions from TileType meta
   v_col=32,            // Virtual column size (= cols)
   blayout=row_major,   // Block layout (from TileView, default: row_major)
   slayout=none_box,    // Scatter layout (from TileView, default: none_box)
-  fractal=512,         // Fractal size (from TileView, default: 512)
+  fractal=512,         // Fractal size in bytes, not elements (from TileView, default: 512)
   pad=0                // Pad mode as int (from TileView, default: 0/null)
 >
 ```

--- a/docs/zh/dev/codegen/00-pto_codegen.md
+++ b/docs/zh/dev/codegen/00-pto_codegen.md
@@ -521,7 +521,7 @@ tile_c = pl.mul(tile_a, tile_b)
   v_col=32,            // Virtual column size (= cols)
   blayout=row_major,   // Block layout (from TileView, default: row_major)
   slayout=none_box,    // Scatter layout (from TileView, default: none_box)
-  fractal=512,         // Fractal size (from TileView, default: 512)
+  fractal=512,         // Fractal size in bytes, not elements (from TileView, default: 512)
   pad=0                // Pad mode as int (from TileView, default: 0/null)
 >
 ```

--- a/include/pypto/ir/type.h
+++ b/include/pypto/ir/type.h
@@ -266,6 +266,17 @@ TileLayout StringToTileLayout(const std::string& str);
  * stride, start offset, block layout, scatter layout, fractal size,
  * and pad mode. This is used by TileType to track how a tile views
  * its underlying memory.
+ *
+ * @note `fractal` is a size **in bytes**, not an element count. In a boxed
+ *       (NZ/ZN) layout the inner box is `M0 = 16` rows by
+ *       `fractal / dtype_bytes / M0` columns, so the same byte value describes
+ *       a different element geometry per dtype — see the `box_cols`
+ *       computation in `src/backend/common/pto_ops_datamove.cpp`. The two
+ *       matmul-path values are both 16x16 boxes: `512` (Mat/Left/Right
+ *       operand, 16x16 FP16) and `1024` (Acc accumulator, 16x16 FP32/INT32).
+ *       MX scale tiles (LeftScale/RightScale) instead carry `kMXScaleFractal`
+ *       = 32, the MX block size of one shared exponent per 32 elements; the
+ *       scale dtype is 1 byte, so bytes and elements coincide there.
  */
 struct TileView {
   std::vector<ExprPtr> valid_shape;            ///< Valid shape dimensions
@@ -273,7 +284,7 @@ struct TileView {
   ExprPtr start_offset;                        ///< Starting offset
   TileLayout blayout = TileLayout::row_major;  ///< Block layout
   TileLayout slayout = TileLayout::none_box;   ///< Scatter layout
-  uint64_t fractal = 512;                      ///< Fractal size
+  uint64_t fractal = 512;                      ///< Fractal size in bytes (not elements)
   PadValue pad = PadValue::null;               ///< Pad mode
 
   /**
@@ -289,7 +300,7 @@ struct TileView {
    * @param start_offset Starting offset
    * @param blayout Block layout
    * @param slayout Scatter layout
-   * @param fractal Fractal size
+   * @param fractal Fractal size in bytes (not elements)
    * @param pad Pad mode
    */
   TileView(std::vector<ExprPtr> valid_shape, std::vector<ExprPtr> stride, ExprPtr start_offset,
@@ -311,7 +322,7 @@ struct TileView {
    * @param start_offset Starting offset
    * @param blayout Block layout
    * @param slayout Scatter layout
-   * @param fractal Fractal size
+   * @param fractal Fractal size in bytes (not elements)
    * @param pad Pad mode
    */
   TileView(const std::vector<int64_t>& valid_shape, const std::vector<int64_t>& stride, ExprPtr start_offset,

--- a/python/bindings/modules/ir.cpp
+++ b/python/bindings/modules/ir.cpp
@@ -668,7 +668,12 @@ void BindIR(nb::module_& m) {
       .def_ro("start_offset", &TileView::start_offset, "Starting offset")
       .def_ro("blayout", &TileView::blayout, "Block layout")
       .def_ro("slayout", &TileView::slayout, "Scatter layout")
-      .def_ro("fractal", &TileView::fractal, "Fractal size")
+      .def_ro("fractal", &TileView::fractal,
+              "Fractal size in bytes (not elements). In a boxed (NZ/ZN) layout the inner box is "
+              "M0 = 16 rows by fractal / dtype_bytes / M0 cols; the two matmul-path values are "
+              "16x16 boxes: 512 (Mat/Left/Right operand, FP16) and 1024 (Acc accumulator, "
+              "FP32/INT32). MX scale tiles carry 32, the MX block size (1-byte scale dtype, so "
+              "bytes and elements coincide).")
       .def_ro("pad", &TileView::pad, "Pad mode")
       .def(
           "__eq__", [](const TileView& self, const TileView& other) { return self == other; },

--- a/python/bindings/modules/ir.cpp
+++ b/python/bindings/modules/ir.cpp
@@ -656,13 +656,15 @@ void BindIR(nb::module_& m) {
            nb::arg("start_offset") = ExprPtr{}, nb::arg("blayout") = TileLayout::row_major,
            nb::arg("slayout") = TileLayout::none_box, nb::arg("fractal") = static_cast<uint64_t>(512),
            nb::arg("pad") = PadValue::null,
-           "Create a tile view; all fields default to empty/null/row_major/none_box/512/null")
+           "Create a tile view; all fields default to empty/null/row_major/none_box/512/null. "
+           "fractal is a size in bytes, not elements.")
       .def(nb::init<const std::vector<int64_t>&, const std::vector<int64_t>&, ExprPtr, TileLayout, TileLayout,
                     uint64_t, PadValue>(),
            nb::arg("valid_shape"), nb::arg("stride"), nb::arg("start_offset"),
            nb::arg("blayout") = TileLayout::row_major, nb::arg("slayout") = TileLayout::none_box,
            nb::arg("fractal") = static_cast<uint64_t>(512), nb::arg("pad") = PadValue::null,
-           "Create a tile view with integer valid_shape and stride, auto-converted to ConstInt")
+           "Create a tile view with integer valid_shape and stride, auto-converted to ConstInt. "
+           "fractal is a size in bytes, not elements.")
       .def_ro("valid_shape", &TileView::valid_shape, "Valid shape dimensions")
       .def_ro("stride", &TileView::stride, "Stride for each dimension")
       .def_ro("start_offset", &TileView::start_offset, "Starting offset")

--- a/python/pypto/ir/builder.py
+++ b/python/pypto/ir/builder.py
@@ -699,7 +699,7 @@ class IRBuilder:
             start_offset: Starting offset (int or Expr)
             blayout: Block layout (default: row_major)
             slayout: Scatter layout (default: none_box)
-            fractal: Fractal size (default: 512)
+            fractal: Fractal size in bytes, not elements (default: 512)
             pad: Pad mode (default: null)
             span: Optional explicit span. If None, captured from call site.
 

--- a/python/pypto/pypto_core/ir.pyi
+++ b/python/pypto/pypto_core/ir.pyi
@@ -620,7 +620,15 @@ class TileView:
     """Scatter layout."""
 
     fractal: Final[int]
-    """Fractal size."""
+    """Fractal size in bytes (not elements).
+
+    In a boxed (NZ/ZN) layout the inner box is ``M0 = 16`` rows by
+    ``fractal / dtype_bytes / M0`` columns, so the same byte value describes a
+    different element geometry per dtype. The two matmul-path values are both
+    16x16 boxes: ``512`` (Mat/Left/Right operand, 16x16 FP16) and ``1024``
+    (Acc accumulator, 16x16 FP32/INT32). MX scale tiles (LeftScale/RightScale)
+    instead carry ``32``, the MX block size of one shared exponent per 32
+    elements; the scale dtype is 1 byte, so bytes and elements coincide there."""
 
     pad: Final[PadValue]
     """Pad mode."""
@@ -643,7 +651,7 @@ class TileView:
             start_offset: Starting offset (Expr/int/Scalar, int auto-converted to ConstInt; None allowed)
             blayout: Block layout (default: row_major)
             slayout: Scatter layout (default: none_box)
-            fractal: Fractal size (default: 512)
+            fractal: Fractal size in bytes, not elements (default: 512)
             pad: Pad mode (default: null)
         """
 

--- a/src/ir/op/tile_ops/batch_matmul.cpp
+++ b/src/ir/op/tile_ops/batch_matmul.cpp
@@ -129,7 +129,9 @@ TypePtr DeduceTileBatchMatMulType(const std::vector<ExprPtr>& args,
 
   // The matmul output tile uses the hardware's native accumulator layout:
   // - blayout=col_major, slayout=row_major: hardware's column-major block / row-major sub-block
-  // - fractal=1024: 32x32 sub-tile fractal size (standard for this hardware's matrix unit)
+  // - fractal=1024: inner box size in *bytes* — 16 rows x (1024 / dtype_bytes / 16) cols,
+  //   i.e. a 16x16 box for the 4-byte (FP32/INT32) accumulator (standard for this
+  //   hardware's matrix unit)
   TileView tile_view;
   tile_view.blayout = TileLayout::col_major;
   tile_view.slayout = TileLayout::row_major;
@@ -261,7 +263,8 @@ TypePtr DeduceTileBatchMatMulAccType(const std::vector<ExprPtr>& args,
   // Output shape = acc shape (in-place accumulation).
   std::vector<ExprPtr> output_shape = acc_shape;
 
-  // Acc layout (Nz) — same as 2D matmul_acc.
+  // Acc layout (Nz) — same as 2D matmul_acc; fractal is a byte size (see
+  // DeduceTileBatchMatMulType above).
   TileView tile_view;
   tile_view.blayout = TileLayout::col_major;
   tile_view.slayout = TileLayout::row_major;

--- a/src/ir/op/tile_ops/matmul.cpp
+++ b/src/ir/op/tile_ops/matmul.cpp
@@ -91,7 +91,8 @@ TypePtr DeduceTileMatMulType(const std::vector<ExprPtr>& args,
   // Output shape is [M, N]
   std::vector<ExprPtr> output_shape = {m_dim, n_dim};
 
-  // Acc layout: Nz
+  // Acc layout: Nz. fractal is the inner box size in *bytes* — 16 rows x
+  // (1024 / dtype_bytes / 16) cols, i.e. a 16x16 box for the 4-byte (FP32/INT32) accumulator.
   TileView tile_view;
   tile_view.blayout = TileLayout::col_major;
   tile_view.slayout = TileLayout::row_major;
@@ -180,7 +181,8 @@ TypePtr DeduceTileMatMulAccType(const std::vector<ExprPtr>& args,
   // Output shape is [M, N] (same as accumulator)
   std::vector<ExprPtr> output_shape = {m_dim_acc, n_dim_acc};
 
-  // Acc layout: Nz
+  // Acc layout: Nz. fractal is the inner box size in *bytes* — 16 rows x
+  // (1024 / dtype_bytes / 16) cols, i.e. a 16x16 box for the 4-byte (FP32/INT32) accumulator.
   TileView tile_view;
   tile_view.blayout = TileLayout::col_major;
   tile_view.slayout = TileLayout::row_major;


### PR DESCRIPTION
## Summary

`TileView::fractal` is a **byte** count, but `batch_matmul.cpp` documented it as an element count — "`fractal=1024`: 32x32 sub-tile fractal size". The two readings disagree: 1024 bytes of FP32 is a **16x16** box (`1024 / 4 / 16 = 16`), not 32x32.

The authoritative consumer divides by the element width to recover the geometry:

```cpp
// src/backend/common/pto_ops_datamove.cpp
// NZ fractal granularity: M0 = 16 rows; the C0 lane count along columns is
// fractal_bytes / dtype_bytes / M0 (both collapse to 16 for fp16/bf16).
box_cols = view_info.fractal / dtype_bytes / kNZFractalRows;
```

`docs/en/dev/passes/10-convert_tensor_to_tile_ops.md` likewise names the field `fractal_bytes`. The declaration itself said only "Fractal size" with no unit, so neither reading was anchored — a reader taking the matmul comment at face value computes the wrong box geometry.

## Changes

Comments and docstrings only — no behavior change.

- **`include/pypto/ir/type.h`** — state the unit on the field and on both `TileView` constructor `@param` docs, plus a note deriving the box geometry, the two matmul-path values (`512` Mat/Left/Right operand, `1024` Acc accumulator — both 16x16 boxes), and the MX scale value (`32`, where the 1-byte scale dtype makes bytes and elements coincide).
- **`src/ir/op/tile_ops/matmul.cpp` / `batch_matmul.cpp`** — replace the "32x32 sub-tile" reading with the byte reading; the accumulator is 4-byte (FP32/INT32).
- **`python/bindings/modules/ir.cpp`, `python/pypto/pypto_core/ir.pyi`, `python/pypto/ir/builder.py`** — carry the unit across all three layers per `cross-layer-sync.md`.
- **`docs/{en,zh}/dev/codegen/00-pto_codegen.md`** — fix the same unit-less wording.

## Testing

- [x] Full build clean (`cmake --build build`, 211/211)
- [x] `tests/ut/ir/core` + `tests/ut/ir/operators` — 1214 passed, 1 skipped
- [x] clang-tidy on the diff — clean
- [x] All 15 pre-commit hooks pass (clang-format, cpplint, ruff, pyright, markdownlint, en/zh doc parity)