### PR TITLE
fix(jit): Carry a tensor annotation's layout slot through specialization

### DIFF
--- a/docs/en/dev/language/00-python_syntax.md
+++ b/docs/en/dev/language/00-python_syntax.md
@@ -66,6 +66,12 @@ x: pl.Tensor[[32, 64], pl.FP32, pl.NZ]      # layout, inline
 y: pl.Tensor[[32, 64], pl.FP32, STRIDED]    # view, by variable
 ```
 
+Under `@pl.jit` only the **layout** spelling is supported. Specialization
+regenerates each annotation from the shape/dtype/layout it recorded, and a
+`pl.TensorView` has no slot in that record — passing one raises a `TypeError`
+naming the parameter rather than dropping the stride. Declare such a kernel
+with `@pl.function`, which resolves the annotation directly.
+
 ### Memory References (MemRef)
 
 ```python

--- a/docs/en/user/01-language_guide.md
+++ b/docs/en/user/01-language_guide.md
@@ -31,7 +31,7 @@ Complete reference for the `pypto.language` (`pl`) module.
 ```python
 x: pl.Tensor[[64, 128], pl.FP32]        # 2D, 64×128, float32
 y: pl.Tensor[[256], pl.FP16]            # 1D, 256 elements, float16
-s: pl.Tensor[[64, 128], pl.UINT8, pl.MX_A_ZZ] # With a layout (see below)
+s: pl.Tensor[[64, 128], pl.UINT8, pl.MX_A_ZZ] # MX scale operand — see "Tensor Layouts"
 ```
 
 **`pl.Tile[[shape], dtype]`** — on-chip memory buffer (unified buffer by default).
@@ -53,6 +53,11 @@ Write your `pl.Tensor[...]` annotations using the **runtime row-major
 shape** without a layout marker. Layout is an IR-internal concern that
 passes derive from the ops actually producing/consuming views; you do
 not need to express it in the type annotation.
+
+The one exception is the **MX layouts** (`pl.MX_A_ZZ` / `pl.MX_B_NN`),
+which describe a scale operand's on-disk packing that no op can derive —
+they must be annotated, and their loads need `target_memory=pl.Mem.Mat`
+and a `pl.UINT8` / `pl.FP8E8M0` dtype.
 
 ```python
 # ✅ Recommended — source tensor shape, no layout marker:

--- a/docs/en/user/01-language_guide.md
+++ b/docs/en/user/01-language_guide.md
@@ -31,7 +31,7 @@ Complete reference for the `pypto.language` (`pl`) module.
 ```python
 x: pl.Tensor[[64, 128], pl.FP32]        # 2D, 64×128, float32
 y: pl.Tensor[[256], pl.FP16]            # 1D, 256 elements, float16
-z: pl.Tensor[[64, 128], pl.FP16, pl.NZ] # With NZ layout
+s: pl.Tensor[[64, 128], pl.UINT8, pl.MX_A_ZZ] # With a layout (see below)
 ```
 
 **`pl.Tile[[shape], dtype]`** — on-chip memory buffer (unified buffer by default).
@@ -74,7 +74,9 @@ b: pl.Tensor[[K, N], pl.FP32, pl.DN]   # → ParserTypeError at parse time
 
 For NZ (hardware-specific tile layout), use `pl.Tile[..., pl.NZ]` — NZ is
 tile-only, never a TensorType annotation. The `pl.NZ` constant remains
-available for tile annotations and IR-internal use.
+available for tile annotations and IR-internal use. The parser does not
+reject `pl.Tensor[..., pl.NZ]`, but the annotation cannot compile: ptoas
+fails it with `layout mismatch: user-specified layout=nz but inferred=nd`.
 
 If you need to write a DN tensor at the IR level (e.g. when constructing
 fixtures or round-tripping printed IR), prefer

--- a/docs/zh/dev/language/00-python_syntax.md
+++ b/docs/zh/dev/language/00-python_syntax.md
@@ -65,6 +65,11 @@ x: pl.Tensor[[32, 64], pl.FP32, pl.NZ]      # 布局，内联
 y: pl.Tensor[[32, 64], pl.FP32, STRIDED]    # 视图，通过变量
 ```
 
+在 `@pl.jit` 下只支持 **布局 (layout)** 这一种写法。特化会依据记录的
+shape/dtype/layout 重新生成注解，而 `pl.TensorView` 在该记录中没有对应字段——
+传入时会抛出 `TypeError` 并指明参数名，而不是丢弃 stride。这类 kernel 请改用
+`@pl.function`，它直接解析注解本身。
+
 ### 内存引用 (MemRef)
 
 ```python

--- a/docs/zh/user/01-language_guide.md
+++ b/docs/zh/user/01-language_guide.md
@@ -31,7 +31,7 @@
 ```python
 x: pl.Tensor[[64, 128], pl.FP32]        # 二维，64×128，float32
 y: pl.Tensor[[256], pl.FP16]            # 一维，256 个元素，float16
-s: pl.Tensor[[64, 128], pl.UINT8, pl.MX_A_ZZ] # 带布局（见下文）
+s: pl.Tensor[[64, 128], pl.UINT8, pl.MX_A_ZZ] # MX scale 操作数 —— 见「张量布局」
 ```
 
 **`pl.Tile[[shape], dtype]`** —— 片上内存缓冲区（默认统一缓冲区）。
@@ -50,6 +50,8 @@ idx: pl.Scalar[pl.INDEX]                # 索引标量
 ### 张量布局（TensorLayout）
 
 `pl.Tensor[...]` annotation 写 **runtime 行优先 shape**，不写 layout 标记。layout 是 IR 内部概念，由派生/消费视图的 op 推导，不需要在 annotation 上表达。
+
+唯一的例外是 **MX 布局**（`pl.MX_A_ZZ` / `pl.MX_B_NN`）：它描述 scale 操作数的落盘打包方式，任何 op 都推导不出来，因此必须显式标注；其 load 需要 `target_memory=pl.Mem.Mat` 且 dtype 为 `pl.UINT8` / `pl.FP8E8M0`。
 
 ```python
 # ✅ 推荐 —— 写源 tensor shape，不写 layout 标记：

--- a/docs/zh/user/01-language_guide.md
+++ b/docs/zh/user/01-language_guide.md
@@ -31,7 +31,7 @@
 ```python
 x: pl.Tensor[[64, 128], pl.FP32]        # 二维，64×128，float32
 y: pl.Tensor[[256], pl.FP16]            # 一维，256 个元素，float16
-z: pl.Tensor[[64, 128], pl.FP16, pl.NZ] # 带 NZ 布局
+s: pl.Tensor[[64, 128], pl.UINT8, pl.MX_A_ZZ] # 带布局（见下文）
 ```
 
 **`pl.Tile[[shape], dtype]`** —— 片上内存缓冲区（默认统一缓冲区）。
@@ -63,7 +63,7 @@ b: pl.Tensor[[K, N], pl.FP32, pl.DN]   # → 解析期抛 ParserTypeError
 
 > **为什么不支持 `pl.Tensor[..., pl.DN]`。** layout-only 简写迫使用户脑子里同时持有两套坐标系（IR 逻辑后视图 shape 与 runtime 行优先 shape）—— 恰恰是 RFC #1300 想要消除的歧义。改用：去掉 layout 标记，写 runtime shape —— matmul B^T 场景给 `pl.matmul` 传 `b_trans=True`（或 `a_trans=True`），或自然 load 后用 `pl.tile.transpose_view(...)`（参见下文「数据搬运」）；DN-producing op 之后的 slice 自动继承父 layout。
 
-如需 NZ（硬件 tile layout），写 `pl.Tile[..., pl.NZ]` —— NZ 是 tile-only，不允许作为 TensorType annotation。`pl.NZ` 常量保留用于 tile annotation 和 IR 内部使用。
+如需 NZ（硬件 tile layout），写 `pl.Tile[..., pl.NZ]` —— NZ 是 tile-only，不允许作为 TensorType annotation。`pl.NZ` 常量保留用于 tile annotation 和 IR 内部使用。解析器不会拒绝 `pl.Tensor[..., pl.NZ]`，但该注解无法编译：ptoas 会报 `layout mismatch: user-specified layout=nz but inferred=nd`。
 
 若需要在 IR 层面写 DN tensor（如测试 fixture 或 round-trip 打印的 IR），用 `pl.TensorView(stride=[...], layout=pl.TensorLayout.DN)` —— 强制写显式 stride，避免隐式坐标翻转的隐患。
 

--- a/python/pypto/jit/cache.py
+++ b/python/pypto/jit/cache.py
@@ -32,6 +32,7 @@ from pypto.pypto_core import DataType
 
 if TYPE_CHECKING:
     from pypto.ir.pass_manager import OptimizationStrategy
+    from pypto.pypto_core.ir import TensorLayout
     from pypto.pypto_core.passes import MemoryPlanner
 
 # Stable PyPTO version stamp included in every cache key so that upgrading
@@ -54,11 +55,17 @@ class TensorCacheInfo:
         name: Parameter name.
         shape: Shape tuple with None for dynamic dimensions.
         dtype: DataType of the tensor.
+        layout: Annotated tensor layout, or None when the annotation omits it.
+            Included because a layout may reach the annotation through a
+            closure variable (``L = pl.NZ; ... pl.Tensor[[...], pl.FP32, L]``),
+            leaving the source text — and thus ``source_hash`` — unchanged
+            while the compiled artifact differs.
     """
 
     name: str
     shape: tuple[int | None, ...]
     dtype: DataType
+    layout: "TensorLayout | None" = None
 
 
 @dataclass(frozen=True)
@@ -137,6 +144,7 @@ def make_cache_key(  # noqa: PLR0913 — args are the key's components, one per 
     analyze_auto_scopes_for_deps: bool = False,
     memory_planner: "MemoryPlanner | None" = None,
     enable_pypto_l0c_double_buffer: bool = False,
+    tensor_layouts: dict[str, "TensorLayout | None"] | None = None,
 ) -> CacheKey:
     """Build a cache key for a JIT call site.
 
@@ -145,6 +153,9 @@ def make_cache_key(  # noqa: PLR0913 — args are the key's components, one per 
         param_names: Ordered list of all parameter names (preserves arg order).
         tensor_shapes: Concrete shape per tensor parameter name.
         tensor_dtypes: DataType per tensor parameter name.
+        tensor_layouts: Annotated layout per tensor parameter name, where the
+            annotation declares one. See :class:`TensorCacheInfo.layout` for
+            why the layout has to split the key on its own.
         dynamic_dims: Set of (param_name, dim_index) pairs that are dynamic.
             Dynamic dims are stored as None in the cache key so different
             concrete values for that dimension produce the same cache entry.
@@ -194,7 +205,14 @@ def make_cache_key(  # noqa: PLR0913 — args are the key's components, one per 
         keyed_shape = tuple(
             None if (name, i) in dynamic_dims else dim for i, dim in enumerate(concrete_shape)
         )
-        tensor_infos.append(TensorCacheInfo(name=name, shape=keyed_shape, dtype=tensor_dtypes[name]))
+        tensor_infos.append(
+            TensorCacheInfo(
+                name=name,
+                shape=keyed_shape,
+                dtype=tensor_dtypes[name],
+                layout=(tensor_layouts or {}).get(name),
+            )
+        )
 
     scalar_infos = []
     for name in param_names:

--- a/python/pypto/jit/cache.py
+++ b/python/pypto/jit/cache.py
@@ -145,6 +145,7 @@ def make_cache_key(  # noqa: PLR0913 — args are the key's components, one per 
     memory_planner: "MemoryPlanner | None" = None,
     enable_pypto_l0c_double_buffer: bool = False,
     tensor_layouts: dict[str, "TensorLayout | None"] | None = None,
+    dep_layouts: tuple[tuple[str, str, str], ...] = (),
 ) -> CacheKey:
     """Build a cache key for a JIT call site.
 
@@ -156,6 +157,11 @@ def make_cache_key(  # noqa: PLR0913 — args are the key's components, one per 
         tensor_layouts: Annotated layout per tensor parameter name, where the
             annotation declares one. See :class:`TensorCacheInfo.layout` for
             why the layout has to split the key on its own.
+        dep_layouts: ``(dep name, parameter, layout)`` triples for layouts the
+            reachable deps declare themselves. Same reasoning as
+            ``tensor_layouts``, one call deeper: they shape the generated dep
+            signatures but appear in no entry-parameter meta, and a postponed
+            annotation hides a rebind from ``source_hash``.
         dynamic_dims: Set of (param_name, dim_index) pairs that are dynamic.
             Dynamic dims are stored as None in the cache key so different
             concrete values for that dimension produce the same cache entry.
@@ -225,6 +231,7 @@ def make_cache_key(  # noqa: PLR0913 — args are the key's components, one per 
         ("analyze_auto_scopes_for_deps", analyze_auto_scopes_for_deps),
         ("memory_planner", None if memory_planner is None else str(memory_planner)),
         ("enable_pypto_l0c_double_buffer", enable_pypto_l0c_double_buffer),
+        ("dep_layouts", dep_layouts),
     )
     return (
         source_hash,

--- a/python/pypto/jit/decorator.py
+++ b/python/pypto/jit/decorator.py
@@ -189,6 +189,7 @@ def _build_tensor_meta(
     extents: Sequence[int],
     dtype: DataType,
     dyn_dims: dict[int, DynDim] | None = None,
+    layout: _ir.TensorLayout | None = None,
 ) -> TensorMeta:
     """Build a :class:`TensorMeta` from per-dim extents and a resolved dtype.
 
@@ -198,6 +199,10 @@ def _build_tensor_meta(
     Shared by the torch-tensor path (:func:`_extract_tensor_meta`, extent = the
     real tensor dim) and the signature path (:meth:`JITFunction._bind_args_from_signature`,
     extent = the static annotation dim or a placeholder for dynamic dims).
+
+    ``layout`` is the annotation's third slot. It never comes from a runtime
+    tensor — a torch tensor carries no PyPTO layout — so both paths read it
+    from the same place, the parameter's annotation.
     """
     dyn = dyn_dims or {}
     shape: list[ShapeDim] = []
@@ -208,15 +213,119 @@ def _build_tensor_meta(
             shape.append(extent)
         else:
             shape.append(DynDim(name=bound.name, literal=bound.literal, static_bound=extent))
-    return TensorMeta(shape=tuple(shape), dtype=dtype)
+    return TensorMeta(shape=tuple(shape), dtype=dtype, layout=layout)
 
 
 def _extract_tensor_meta(
     tensor: Any,
     dyn_dims: dict[int, DynDim] | None = None,
+    layout: _ir.TensorLayout | None = None,
 ) -> TensorMeta:
-    """Extract TensorMeta from a torch.Tensor (shape/dtype only — no data read)."""
-    return _build_tensor_meta(tensor.shape, _torch_dtype_to_pypto(tensor.dtype), dyn_dims)
+    """Extract TensorMeta from a torch.Tensor (shape/dtype only — no data read).
+
+    ``layout`` comes from the parameter's annotation, not the tensor: torch has
+    no notion of a PyPTO layout, so the annotation is the only source.
+    """
+    return _build_tensor_meta(tensor.shape, _torch_dtype_to_pypto(tensor.dtype), dyn_dims, layout)
+
+
+def _resolve_annotation(annotation: Any, ann_ns: dict[str, Any] | None) -> Any:
+    """Resolve one parameter annotation, evaluating the string form if needed.
+
+    ``from __future__ import annotations`` in the *user's* module leaves every
+    annotation as a string; ``ann_ns`` (from :func:`_func_name_lookup`) is the
+    namespace to evaluate it in.
+
+    Args:
+        annotation: Raw ``inspect.Parameter.annotation``
+        ann_ns: Namespace for string annotations, or None to leave them as-is
+
+    Returns:
+        The resolved annotation object, or the original string when it cannot
+        be evaluated
+    """
+    if not isinstance(annotation, str) or ann_ns is None:
+        return annotation
+    try:
+        # Trusted input: the kernel's own annotation source, evaluated in its
+        # own globals+closure namespace (same as Python would).
+        return eval(annotation, ann_ns)  # noqa: S307
+    except Exception:  # noqa: BLE001 - leave as string; callers treat it as "cannot infer"
+        return annotation
+
+
+def _annotation_namespace(func: Any, sig: inspect.Signature) -> dict[str, Any] | None:
+    """Namespace for resolving ``func``'s string annotations, or None if unneeded."""
+    if any(isinstance(p.annotation, str) for n, p in sig.parameters.items() if n != "self"):
+        return _func_name_lookup(func)
+    return None
+
+
+def _annotation_layout(annotation: Any, param_name: str, func_name: str) -> _ir.TensorLayout | None:
+    """Read the layout slot off an already-resolved tensor annotation.
+
+    ``pl.Tensor[[...], dtype, pl.NZ]`` evaluates to a ``Tensor`` instance whose
+    ``layout`` holds the third slot; the two-slot form leaves it None.
+
+    Args:
+        annotation: Resolved parameter annotation (any object — non-tensor
+            annotations simply carry no layout)
+        param_name: Parameter the annotation belongs to, for diagnostics
+        func_name: Enclosing kernel name, for diagnostics
+
+    Returns:
+        The annotated layout, or None when the annotation declares none
+
+    Raises:
+        TypeError: If the slot holds a ``pl.TensorView`` — specialization has
+            nowhere to carry it, and silently dropping it would mis-declare the
+            parameter
+    """
+    layout = getattr(annotation, "layout", None)
+    if layout is None or isinstance(layout, _ir.TensorLayout):
+        return layout
+    # ``Tensor.__getitem__`` routes any non-MemRef third element into ``layout``,
+    # so a pl.TensorView(...) lands here. TensorMeta has no field for it, and a
+    # dropped stride is silently wrong code — refuse instead. This is reachable
+    # from the DN rejection's own migration hint, so the message has to be plain.
+    raise TypeError(
+        f"@pl.jit function {func_name!r}: parameter {param_name!r} annotates a "
+        f"{type(layout).__name__} in its layout slot, which @pl.jit does not yet "
+        f"support — it would be dropped and the parameter compiled as ND. Use a "
+        f"plain layout (e.g. pl.NZ), or declare the kernel with @pl.function, "
+        f"which resolves the annotation directly."
+    )
+
+
+def _param_layouts(func: Any, func_name: str) -> dict[str, _ir.TensorLayout]:
+    """Map parameter name → annotated layout, for params that declare one.
+
+    The torch-argument path derives shape and dtype from the passed tensors, so
+    it never looks at annotations — but a layout has no runtime counterpart to
+    read, making the annotation its only source. This recovers it. Also used to
+    recover a dep function's own declarations, which no caller argument carries.
+
+    Args:
+        func: The Python function whose annotations to read
+        func_name: Name to use in diagnostics
+
+    Returns:
+        Layout per parameter name; parameters without one are absent
+    """
+    try:
+        sig = inspect.signature(func)
+    except (TypeError, ValueError):
+        return {}
+    ann_ns = _annotation_namespace(func, sig)
+
+    layouts: dict[str, _ir.TensorLayout] = {}
+    for name, param in sig.parameters.items():
+        if name == "self":
+            continue
+        layout = _annotation_layout(_resolve_annotation(param.annotation, ann_ns), name, func_name)
+        if layout is not None:
+            layouts[name] = layout
+    return layouts
 
 
 def _signature_tensor_meta(
@@ -224,13 +333,15 @@ def _signature_tensor_meta(
     dtype: DataType,
     dyn_for_param: dict[int, DynDim],
     dynvar_cls: type,
+    param_name: str = "",
+    func_name: str = "",
 ) -> TensorMeta:
     """Build TensorMeta from a shaped ``pl.Tensor[[...], dtype]`` annotation.
 
     Static dims use the annotation integer; dynamic dims (``pl.dynamic`` /
     ``bind_dynamic``) get a placeholder extent because the specialized program
     remains extent-independent. ``dynvar_cls`` is the lazily-imported ``DynVar``
-    type.
+    type. ``param_name`` / ``func_name`` only feed diagnostics.
     """
     shape = annotation.shape
     extents = [
@@ -241,7 +352,8 @@ def _signature_tensor_meta(
     for i, dim in enumerate(shape):
         if isinstance(dim, dynvar_cls) and i not in dyn_dims:
             dyn_dims[i] = DynDim(name=dim.name, literal=dim.name, static_bound=0)
-    return _build_tensor_meta(extents, dtype, dyn_dims)
+    layout = _annotation_layout(annotation, param_name, func_name)
+    return _build_tensor_meta(extents, dtype, dyn_dims, layout)
 
 
 def _signature_scalar_value(
@@ -662,7 +774,7 @@ def _subscript_slice_meta(
             extent = stop - start if isinstance(start, int) and isinstance(stop, int) else None
         dims.append(extent if extent is not None else parent)
     dims.extend(src_meta.shape[len(indices) :])  # trailing implicit ``:``
-    return TensorMeta(shape=tuple(dims), dtype=src_meta.dtype)
+    return TensorMeta(shape=tuple(dims), dtype=src_meta.dtype, layout=src_meta.layout)
 
 
 def _extract_dim_alias(value: ast.expr | None) -> tuple[str, int] | None:
@@ -991,6 +1103,12 @@ def _extract_local_tensor_metas(
         shape = _resolve_shape(shape_node)
         if shape is None:
             return None
+        # A reshape re-groups the dims a layout describes, so the source layout
+        # need not hold on the result — but claiming ND instead would be the
+        # same silent mis-declaration. Decline the meta and let _build_params
+        # raise its clear "missing type annotation" error.
+        if src_meta.layout not in (None, _ir.TensorLayout.ND):
+            return None
         return TensorMeta(shape=shape, dtype=src_meta.dtype)
 
     def _slice_meta(call: ast.Call) -> TensorMeta | None:
@@ -1015,7 +1133,7 @@ def _extract_local_tensor_metas(
             # consumes a narrowed view (see examples/models/04_paged_attention.py).
             # If the parent dim is itself a DynDim, it propagates through.
             dims.append(v if v is not None else parent_dim)
-        return TensorMeta(shape=tuple(dims), dtype=src_meta.dtype)
+        return TensorMeta(shape=tuple(dims), dtype=src_meta.dtype, layout=src_meta.layout)
 
     dep_io = _scan_dep_io(func, caller_func_type)
 
@@ -1202,6 +1320,9 @@ def _resolve_dep_call_metadata(
                     dep_tensor_meta[dep_param] = TensorMeta(
                         shape=base_meta.shape[caller_arg.drop :],
                         dtype=base_meta.dtype,
+                        # Layout describes the trailing dims, so dropping
+                        # leading ones leaves it intact.
+                        layout=base_meta.layout,
                     )
                 continue
             if caller_arg in all_tensor_meta:
@@ -1234,9 +1355,33 @@ def _resolve_dep_call_metadata(
             new_shape[i] = DynDim(name=dyn.name, literal=dyn.literal, static_bound=existing)
             changed = True
         if changed:
-            dep_tensor_meta[dep_param] = TensorMeta(shape=tuple(new_shape), dtype=meta.dtype)
+            dep_tensor_meta[dep_param] = TensorMeta(
+                shape=tuple(new_shape), dtype=meta.dtype, layout=meta.layout
+            )
+
+    _overlay_dep_declared_layouts(dep, dep_tensor_meta)
 
     return dep_tensor_meta, dep_scalar_values, dep_scalar_dtypes
+
+
+def _overlay_dep_declared_layouts(dep: JITFunction, dep_tensor_meta: dict[str, TensorMeta]) -> None:
+    """Fill in layouts a dep declares itself, in place.
+
+    Nothing on the caller side carries them — an argument's meta reflects the
+    *caller's* annotation — so without this a dep declaring
+    ``pl.Tensor[[...], pl.NZ]`` under a caller that declares none compiles as
+    ND, silently. The caller wins on conflict, matching how the DynDim overlay
+    only fills what the caller left plain.
+
+    Args:
+        dep: The dep whose own annotations to read
+        dep_tensor_meta: Per-parameter meta to update in place
+    """
+    for dep_param, dep_layout in _param_layouts(dep._func, dep.__name__).items():
+        meta = dep_tensor_meta.get(dep_param)
+        if meta is None or meta.layout is not None:
+            continue
+        dep_tensor_meta[dep_param] = TensorMeta(shape=meta.shape, dtype=meta.dtype, layout=dep_layout)
 
 
 # ---------------------------------------------------------------------------
@@ -1601,13 +1746,18 @@ class JITFunction:
             self._func, param_names, deps, callers_by_id, call_args_cache
         )
         entry_dyn_map = per_func_dyn_maps[id(self._func)]
+        # A layout has no runtime counterpart on a torch tensor, so it comes
+        # from the annotation even on this path.
+        param_layouts = _param_layouts(self._func, self.__name__)
         tensor_meta: dict[str, TensorMeta] = {}
         scalar_values: dict[str, int | float | bool] = {}
         scalar_dtypes: dict[str, DataType] = {}
 
         for name, value in arguments.items():
             if _is_tensor(value):
-                tensor_meta[name] = _extract_tensor_meta(value, entry_dyn_map.get(name))
+                tensor_meta[name] = _extract_tensor_meta(
+                    value, entry_dyn_map.get(name), param_layouts.get(name)
+                )
             elif isinstance(value, (int, float, bool)):
                 scalar_values[name] = value
 
@@ -1694,7 +1844,12 @@ class JITFunction:
                 if annotation.shape is None or annotation.dtype is None:
                     raise TypeError(bare_msg)
                 tensor_meta[name] = _signature_tensor_meta(
-                    annotation, annotation.dtype, entry_dyn_map.get(name, {}), DynVar
+                    annotation,
+                    annotation.dtype,
+                    entry_dyn_map.get(name, {}),
+                    DynVar,
+                    param_name=name,
+                    func_name=self.__name__,
                 )
                 continue
             if isinstance(annotation, type) and issubclass(annotation, Tensor):
@@ -1833,6 +1988,7 @@ class JITFunction:
             param_names=specialization.param_names,
             tensor_shapes={n: m.static_shape() for n, m in specialization.tensor_meta.items()},
             tensor_dtypes={n: m.dtype for n, m in specialization.tensor_meta.items()},
+            tensor_layouts={n: m.layout for n, m in specialization.tensor_meta.items()},
             dynamic_dims={
                 (n, i) for n, m in specialization.tensor_meta.items() for i in m.dynamic_dim_indices()
             },

--- a/python/pypto/jit/decorator.py
+++ b/python/pypto/jit/decorator.py
@@ -292,7 +292,7 @@ def _annotation_layout(annotation: Any, param_name: str, func_name: str) -> _ir.
         f"@pl.jit function {func_name!r}: parameter {param_name!r} annotates a "
         f"{type(layout).__name__} in its layout slot, which @pl.jit does not yet "
         f"support — it would be dropped and the parameter compiled as ND. Use a "
-        f"plain layout (e.g. pl.NZ), or declare the kernel with @pl.function, "
+        f"plain layout (e.g. pl.MX_A_ZZ), or declare the kernel with @pl.function, "
         f"which resolves the annotation directly."
     )
 
@@ -1554,6 +1554,7 @@ class JITFunction:
         ) = None
         self._cache: dict[CacheKey, Any] = {}  # CacheKey → CompiledProgram
         self._source_hash: str | None = None
+        self._dep_layouts: tuple[tuple[str, str, str], ...] | None = None
 
         # Preserve function metadata
         self.__name__ = func.__name__
@@ -1587,18 +1588,26 @@ class JITFunction:
         them in the key, rebinding ``L`` would hand the second call the first
         one's artifact.
 
+        Computed once and memoized: the key is rebuilt on every call including
+        cache hits, and re-deriving it runs ``inspect.signature`` (plus ``eval``
+        for postponed annotations) per dep. A dep's declarations cannot change
+        over this ``JITFunction``'s lifetime, so the cost is paid once — same
+        reasoning as ``_get_dep_graph`` / ``_get_source_hash``.
+
         Returns:
             Sorted ``(dep name, parameter, layout)`` triples — a stable,
             hashable component for the cache key
         """
-        deps, _, _, _ = self._get_dep_graph()
-        return tuple(
-            sorted(
-                (dep.__name__, param, str(layout))
-                for dep in deps
-                for param, layout in _param_layouts(dep._func, dep.__name__).items()
+        if self._dep_layouts is None:
+            deps, _, _, _ = self._get_dep_graph()
+            self._dep_layouts = tuple(
+                sorted(
+                    (dep.__name__, param, str(layout))
+                    for dep in deps
+                    for param, layout in _param_layouts(dep._func, dep.__name__).items()
+                )
             )
-        )
+        return self._dep_layouts
 
     def _get_dep_graph(
         self,

--- a/python/pypto/jit/decorator.py
+++ b/python/pypto/jit/decorator.py
@@ -1576,6 +1576,30 @@ class JITFunction:
     # Lazy dep discovery
     # ------------------------------------------------------------------
 
+    def _dep_declared_layouts(self) -> tuple[tuple[str, str, str], ...]:
+        """Layouts every reachable dep declares on its own parameters.
+
+        ``_overlay_dep_declared_layouts`` folds these into the generated dep
+        signatures, so they change the artifact — but they live outside the
+        entry's ``tensor_meta``, and a postponed annotation
+        (``pl.Tensor[..., L]`` with a module-level ``L``) keeps the source text,
+        and therefore ``source_hash``, identical when ``L`` is rebound. Without
+        them in the key, rebinding ``L`` would hand the second call the first
+        one's artifact.
+
+        Returns:
+            Sorted ``(dep name, parameter, layout)`` triples — a stable,
+            hashable component for the cache key
+        """
+        deps, _, _, _ = self._get_dep_graph()
+        return tuple(
+            sorted(
+                (dep.__name__, param, str(layout))
+                for dep in deps
+                for param, layout in _param_layouts(dep._func, dep.__name__).items()
+            )
+        )
+
     def _get_dep_graph(
         self,
     ) -> tuple[
@@ -1989,6 +2013,7 @@ class JITFunction:
             tensor_shapes={n: m.static_shape() for n, m in specialization.tensor_meta.items()},
             tensor_dtypes={n: m.dtype for n, m in specialization.tensor_meta.items()},
             tensor_layouts={n: m.layout for n, m in specialization.tensor_meta.items()},
+            dep_layouts=self._dep_declared_layouts(),
             dynamic_dims={
                 (n, i) for n, m in specialization.tensor_meta.items() for i in m.dynamic_dim_indices()
             },

--- a/python/pypto/jit/specializer.py
+++ b/python/pypto/jit/specializer.py
@@ -46,6 +46,7 @@ from typing import Any, cast
 from pypto._external_source import EXTERNAL_INCLUDE_DIRS_ATTR, encode_external_include_dirs
 from pypto.language.typing.array import Array as _LangArray
 from pypto.pypto_core import DataType
+from pypto.pypto_core.ir import TensorLayout
 
 # ---------------------------------------------------------------------------
 # Data structures
@@ -83,10 +84,16 @@ class TensorMeta:
         shape: Per-dim entries. Each entry is either a static ``int`` or a
             :class:`DynDim` capturing a JIT-time-bound dynamic dim.
         dtype: DataType resolved from the torch tensor.
+        layout: Layout the user wrote in the annotation's third slot
+            (``pl.Tensor[[...], dtype, pl.NZ]``), or None when the annotation
+            omits it. Carried so the regenerated ``@pl.function`` source keeps
+            the slot the user wrote — a dropped layout would silently downgrade
+            the parameter to ND.
     """
 
     shape: tuple[ShapeDim, ...]
     dtype: DataType
+    layout: TensorLayout | None = None
 
     def static_shape(self) -> tuple[int, ...]:
         """Concrete shape tuple — DynDim dims collapse to their static_bound."""
@@ -231,6 +238,34 @@ def _dtype_str(dt: DataType) -> str:
     if dt not in _DTYPE_TO_PL:
         raise ValueError(f"Unsupported DataType: {dt}")
     return _DTYPE_TO_PL[dt]
+
+
+# TensorLayout → pl.XXX string mapping, for regenerating an annotation's
+# third slot. ND is absent on purpose: it is the default the slot means when
+# omitted, so emitting it would only add noise.
+_LAYOUT_TO_PL: dict[TensorLayout, str] = {
+    TensorLayout.DN: "pl.DN",
+    TensorLayout.NZ: "pl.NZ",
+    TensorLayout.MX_A_ZZ: "pl.MX_A_ZZ",
+    TensorLayout.MX_B_NN: "pl.MX_B_NN",
+}
+
+
+def _layout_str(layout: TensorLayout) -> str | None:
+    """Render a layout to its ``pl.<NAME>`` annotation form.
+
+    Returns:
+        The ``pl.<NAME>`` source form, or None when the layout needs no slot
+        (ND — what an omitted slot already means).
+
+    Raises:
+        ValueError: If the layout has no DSL constant to render
+    """
+    if layout == TensorLayout.ND:
+        return None
+    if layout not in _LAYOUT_TO_PL:
+        raise ValueError(f"Unsupported TensorLayout: {layout}")
+    return _LAYOUT_TO_PL[layout]
 
 
 def _array_dtype_str(dt: DataType) -> str:
@@ -421,15 +456,25 @@ def _build_tensor_annotation(
     generated ``@pl.function`` source declares the same ``ir.ParamDirection``
     the user wrote.
 
+    A non-ND ``meta.layout`` is emitted as the third slot, so the layout the
+    user annotated survives into the generated source. Whether that layout is
+    legal in a bare slot is the type resolver's call, not ours — ``pl.DN``, for
+    instance, is rejected there with a migration hint.
+
     Returns:
         Annotation string such as ``pl.Tensor[[M, 128], pl.FP32]``,
+        ``pl.Tensor[[64, 128], pl.FP16, pl.NZ]``,
         ``pl.Out[pl.Tensor[[128, 128], pl.FP32]]``,
         ``pl.InOut[pl.Tensor[[128, 128], pl.FP32]]``, or
         ``pld.DistributedTensor[[256], pl.INT8]``.
     """
     dims = [d.name if isinstance(d, DynDim) else str(d) for d in meta.shape]
     head = "pld.DistributedTensor" if is_distributed else "pl.Tensor"
-    inner = f"{head}[[{', '.join(dims)}], {_dtype_str(meta.dtype)}]"
+    slots = [f"[{', '.join(dims)}]", _dtype_str(meta.dtype)]
+    layout_slot = _layout_str(meta.layout) if meta.layout is not None else None
+    if layout_slot is not None:
+        slots.append(layout_slot)
+    inner = f"{head}[{', '.join(slots)}]"
     if is_inout:
         return f"pl.InOut[{inner}]"
     return f"pl.Out[{inner}]" if is_out else inner
@@ -1424,6 +1469,32 @@ def _dfs_stmts(node: ast.AST) -> list[ast.stmt]:
     return result
 
 
+def _find_func_def(tree: ast.AST, func_name: str) -> ast.FunctionDef | None:
+    """The ``FunctionDef`` named ``func_name`` anywhere under ``tree``."""
+    return next((n for n in ast.walk(tree) if isinstance(n, ast.FunctionDef) and n.name == func_name), None)
+
+
+def _original_def_line(ctx: SpecializeContext) -> int | None:
+    """Line of the ``def`` inside a context's dedented source, 1-based.
+
+    ``ctx.orig_start_line`` points at the function's *first decorator*, so the
+    ``def`` itself sits some lines below it. Callers add
+    ``orig_start_line - 1`` to convert to an absolute file line.
+
+    Args:
+        ctx: The specialization context whose source to inspect
+
+    Returns:
+        The 1-based line of the ``def``, or None if the source cannot be parsed
+    """
+    try:
+        tree = ast.parse(textwrap.dedent(ctx.source))
+    except SyntaxError:
+        return None
+    node = _find_func_def(tree, ctx.func_name)
+    return None if node is None else node.lineno
+
+
 class Specializer:
     """Transform a collection of SpecializeContext objects into @pl.program source.
 
@@ -1565,10 +1636,23 @@ class Specializer:
             gen_func = gen_funcs.get(ctx.func_name)
             if ctx.orig_file is None or gen_func is None:
                 continue
+            # The signature line carries the parameter annotations, so an
+            # annotation-level parse error (e.g. a rejected layout) reports
+            # there — map it too, or such errors would point at the generated
+            # source instead of the user's file.
+            orig_def_line = _original_def_line(ctx)
+            if orig_def_line is not None:
+                out[gen_func.lineno] = (
+                    ctx.orig_file,
+                    orig_def_line + ctx.orig_start_line - 1,
+                    ctx.orig_col_offset,
+                )
             gen_stmts = _dfs_stmts(gen_func)
             # Reparsing the unparsed transform must preserve statement count and
-            # DFS order; if it somehow diverges, skip this function rather than
-            # emit a wrong mapping (its spans then fall back to generated coords).
+            # DFS order; if it somehow diverges, skip this function's *statement*
+            # mappings rather than emit wrong ones (those spans then fall back to
+            # generated coords). The signature entry above is independent of the
+            # body, so it stands either way.
             if len(gen_stmts) != len(orig_positions):
                 continue
             for gen_stmt, (orig_line, orig_col) in zip(gen_stmts, orig_positions, strict=True):
@@ -1586,9 +1670,8 @@ class Specializer:
         # Parse the source to AST
         src = textwrap.dedent(ctx.source)
         tree = ast.parse(src)
-        func_def = next(
-            n for n in ast.walk(tree) if isinstance(n, ast.FunctionDef) and n.name == ctx.func_name
-        )
+        func_def = _find_func_def(tree, ctx.func_name)
+        assert func_def is not None, f"specialize: no def named {ctx.func_name!r} in its own source"
 
         # Classify parameters
         out_params, inout_params, tensor_params, scalar_dtype_strs, distributed_params = _classify_params(

--- a/tests/ut/jit/test_cache.py
+++ b/tests/ut/jit/test_cache.py
@@ -17,7 +17,7 @@ from pypto.jit.cache import (
     make_cache_key,
 )
 from pypto.jit.decorator import _resolve_enable_pypto_l0c_double_buffer, _resolve_memory_planner
-from pypto.pypto_core import DataType, passes
+from pypto.pypto_core import DataType, ir, passes
 from pypto.pypto_core.passes import MemoryPlanner
 from pypto.runtime import RunConfig
 
@@ -64,6 +64,8 @@ class TestMakeCacheKey:
         analyze_auto_scopes_for_deps=False,
         memory_planner=None,
         enable_pypto_l0c_double_buffer=False,
+        tensor_layouts=None,
+        dep_layouts=(),
     ):
         return make_cache_key(
             source_hash=source_hash,
@@ -78,6 +80,8 @@ class TestMakeCacheKey:
             analyze_auto_scopes_for_deps=analyze_auto_scopes_for_deps,
             memory_planner=memory_planner,
             enable_pypto_l0c_double_buffer=enable_pypto_l0c_double_buffer,
+            tensor_layouts=tensor_layouts,
+            dep_layouts=dep_layouts,
         )
 
     def test_basic_key_structure(self):
@@ -99,6 +103,7 @@ class TestMakeCacheKey:
             ("analyze_auto_scopes_for_deps", False),
             ("memory_planner", None),
             ("enable_pypto_l0c_double_buffer", False),
+            ("dep_layouts", ()),
         )
 
     def test_tensor_shape_in_key(self):
@@ -215,6 +220,23 @@ class TestMakeCacheKey:
             tensor_shapes={"a": (8, 8)},
             tensor_dtypes={"a": DataType.FP32},
         )
+        assert k1 != k2
+
+    def test_different_tensor_layouts_cause_miss(self):
+        """A layout can reach the annotation through a variable, leaving the
+        source text — and so ``source_hash`` — identical. It must split the key
+        on its own."""
+        common = {"param_names": ["a"], "tensor_shapes": {"a": (8, 8)}, "tensor_dtypes": {"a": DataType.FP32}}
+        k1 = self._make_key(**common, tensor_layouts={"a": ir.TensorLayout.MX_A_ZZ})
+        k2 = self._make_key(**common, tensor_layouts={"a": ir.TensorLayout.MX_B_NN})
+        assert k1 != k2
+
+    def test_different_dep_layouts_cause_miss(self):
+        """Same, one call deeper: a layout a *dep* declares appears in no entry
+        parameter meta, so it needs its own key component."""
+        common = {"param_names": ["a"], "tensor_shapes": {"a": (8, 8)}, "tensor_dtypes": {"a": DataType.FP32}}
+        k1 = self._make_key(**common, dep_layouts=(("dep", "x", "TensorLayout.MX_A_ZZ"),))
+        k2 = self._make_key(**common, dep_layouts=(("dep", "x", "TensorLayout.MX_B_NN"),))
         assert k1 != k2
 
     def test_different_platforms_cause_miss(self):

--- a/tests/ut/jit/test_jit_compile_extraction.py
+++ b/tests/ut/jit/test_jit_compile_extraction.py
@@ -408,9 +408,9 @@ class TestCompileFromSignature:
 
 
 @jit
-def _nz_kernel(a: pl.Tensor[[64, 128], pl.FP16, pl.NZ], c: pl.Out[pl.Tensor[[64, 128], pl.FP16]]):
+def _mx_kernel(a: pl.Tensor[[64, 128], pl.UINT8, pl.MX_A_ZZ], c: pl.Out[pl.Tensor[[64, 128], pl.UINT8]]):
     M, N = a.shape
-    t = pl.load(a, [0, 0], [M, N])
+    t = pl.load(a, [0, 0], [M, N], target_memory=pl.Mem.Mat)
     pl.store(t, [0, 0], c)
     return c
 
@@ -428,9 +428,13 @@ class TestAnnotationLayoutReachesTheProgram:
 
     JIT specialization regenerates each annotation from ``TensorMeta`` rather
     than reusing the user's source. ``TensorMeta`` carried only shape and dtype,
-    so the slot was dropped: ``pl.NZ`` silently became ND, and ``pl.DN`` — which
+    so the slot was dropped: a layout silently became ND, and ``pl.DN`` — which
     the type resolver rejects — was never even seen, so it neither errored nor
     took effect.
+
+    The bar is parity with ``@pl.function``: whatever the bare slot means there,
+    it must mean here. Which layouts the *pipeline* then accepts is a separate,
+    path-independent question — see :class:`TestNzOnTensorIsNotJitSpecific`.
     """
 
     def _entry_param_type(self, kernel):
@@ -438,15 +442,16 @@ class TestAnnotationLayoutReachesTheProgram:
         program = kernel._compile_to_program(tm, sv, sd, dyn, pl)
         return list(program.functions.values())[0].params[0].type
 
-    def test_nz_layout_reaches_the_param_type(self):
-        param_type = self._entry_param_type(_nz_kernel)
+    def test_layout_reaches_the_param_type(self):
+        """MX_A_ZZ is a layout the pipeline genuinely accepts on a TensorType."""
+        param_type = self._entry_param_type(_mx_kernel)
         assert param_type.tensor_view is not None
-        assert param_type.tensor_view.layout == ir.TensorLayout.NZ
+        assert param_type.tensor_view.layout == ir.TensorLayout.MX_A_ZZ
 
     def test_unannotated_layout_stays_absent(self):
         """The plain two-slot form must not gain a view."""
-        _, _, tm, sv, sd, dyn = _nz_kernel._bind_args_from_signature({})
-        program = _nz_kernel._compile_to_program(tm, sv, sd, dyn, pl)
+        _, _, tm, sv, sd, dyn = _mx_kernel._bind_args_from_signature({})
+        program = _mx_kernel._compile_to_program(tm, sv, sd, dyn, pl)
         out_param = list(program.functions.values())[0].params[1]
         assert out_param.type.tensor_view is None
 
@@ -466,16 +471,16 @@ class TestAnnotationLayoutReachesTheProgram:
 
 
 @jit.incore
-def _nz_dep(a: pl.Tensor[[64, 128], pl.FP16, pl.NZ], c: pl.Out[pl.Tensor[[64, 128], pl.FP16]]):
+def _mx_dep(a: pl.Tensor[[64, 128], pl.UINT8, pl.MX_A_ZZ], c: pl.Out[pl.Tensor[[64, 128], pl.UINT8]]):
     M, N = a.shape
-    t = pl.load(a, [0, 0], [M, N])
+    t = pl.load(a, [0, 0], [M, N], target_memory=pl.Mem.Mat)
     pl.store(t, [0, 0], c)
     return c
 
 
 @jit
-def _calls_nz_dep(a: pl.Tensor[[64, 128], pl.FP16], c: pl.Out[pl.Tensor[[64, 128], pl.FP16]]):
-    c = _nz_dep(a, c)
+def _calls_mx_dep(a: pl.Tensor[[64, 128], pl.UINT8], c: pl.Out[pl.Tensor[[64, 128], pl.UINT8]]):
+    c = _mx_dep(a, c)
     return c
 
 
@@ -483,20 +488,20 @@ class TestDepDeclaredLayout:
     """A dep's own layout declaration has no caller-side counterpart.
 
     The caller's argument meta reflects the *caller's* annotation, so a dep
-    declaring ``pl.Tensor[[...], pl.NZ]`` while the entry declares none would
+    declaring ``pl.Tensor[[...], pl.MX_A_ZZ]`` while the entry declares none would
     otherwise compile as ND — the same silent downgrade, one call deeper.
     """
 
     def test_dep_layout_survives_when_caller_declares_none(self):
-        _, _, tm, sv, sd, dyn = _calls_nz_dep._bind_args_from_signature({})
-        program = _calls_nz_dep._compile_to_program(tm, sv, sd, dyn, pl)
+        _, _, tm, sv, sd, dyn = _calls_mx_dep._bind_args_from_signature({})
+        program = _calls_mx_dep._compile_to_program(tm, sv, sd, dyn, pl)
         views = [
             p.type.tensor_view
             for f in program.functions.values()
             for p in f.params
             if getattr(p.type, "tensor_view", None) is not None
         ]
-        assert any(v.layout == ir.TensorLayout.NZ for v in views)
+        assert any(v.layout == ir.TensorLayout.MX_A_ZZ for v in views)
 
 
 class TestUnsupportedLayoutSlot:
@@ -519,6 +524,55 @@ class TestUnsupportedLayoutSlot:
 
         with pytest.raises(TypeError, match="does not yet support"):
             kernel._bind_args_from_signature({})
+
+
+class TestNzOnTensorIsNotJitSpecific:
+    """``pl.NZ`` in a *tensor* annotation is rejected downstream on every path.
+
+    NZ describes a tile layout; on a TensorType it survives parsing but ptoas
+    later refuses it ("layout mismatch: user-specified layout=nz but
+    inferred=nd"). That is true of ``@pl.function`` too, so @pl.jit carrying the
+    layout through is parity, not a new defect — the alternative (dropping it)
+    is what silently produced an ND buffer from an NZ annotation.
+
+    This pins the shared behaviour so the propagation is not mistaken for a
+    claim that NZ tensors compile.
+    """
+
+    def test_nz_survives_specialization_unchanged(self):
+        """Pre-pass, the annotation is carried verbatim — same as @pl.function."""
+
+        @jit
+        def kernel(a: pl.Tensor[[64, 128], pl.FP16, pl.NZ], c: pl.Out[pl.Tensor[[64, 128], pl.FP16]]):
+            M, N = a.shape
+            t = pl.load(a, [0, 0], [M, N])
+            pl.store(t, [0, 0], c)
+            return c
+
+        _, _, tm, sv, sd, dyn = kernel._bind_args_from_signature({})
+        assert tm["a"].layout == ir.TensorLayout.NZ
+        program = kernel._compile_to_program(tm, sv, sd, dyn, pl)
+        view = list(program.functions.values())[0].params[0].type.tensor_view
+        assert view is not None and view.layout == ir.TensorLayout.NZ
+
+    def test_pl_function_carries_nz_the_same_way(self):
+        """The @pl.function path reaches the identical IR, confirming parity."""
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                a: pl.Tensor[[64, 128], pl.FP16, pl.NZ],
+                c: pl.Out[pl.Tensor[[64, 128], pl.FP16]],
+            ):
+                with pl.at(level=pl.Level.CORE_GROUP):
+                    t = pl.load(a, [0, 0], [64, 128])
+                    pl.store(t, [0, 0], c)
+                return c
+
+        view = list(Prog.functions.values())[0].params[0].type.tensor_view
+        assert view is not None and view.layout == ir.TensorLayout.NZ
 
 
 if __name__ == "__main__":

--- a/tests/ut/jit/test_jit_compile_extraction.py
+++ b/tests/ut/jit/test_jit_compile_extraction.py
@@ -21,6 +21,7 @@ import pytest
 from pypto.ir import OptimizationStrategy
 from pypto.ir.compiled_program import CompiledProgram
 from pypto.jit.decorator import jit
+from pypto.language.parser.diagnostics.exceptions import ParserTypeError
 from pypto.pypto_core import ir, passes
 from pypto.runtime.runner import RunConfig
 
@@ -404,6 +405,120 @@ class TestCompileFromSignature:
         assert tensor_meta["a"].dynamic_dim_indices() == {0}
         assert tensor_meta["a"].static_shape()[1] == 64
         assert tensor_meta["a"].dtype == pl.FP32
+
+
+@jit
+def _nz_kernel(a: pl.Tensor[[64, 128], pl.FP16, pl.NZ], c: pl.Out[pl.Tensor[[64, 128], pl.FP16]]):
+    M, N = a.shape
+    t = pl.load(a, [0, 0], [M, N])
+    pl.store(t, [0, 0], c)
+    return c
+
+
+@jit
+def _dn_kernel(a: pl.Tensor[[64, 128], pl.FP16, pl.DN], c: pl.Out[pl.Tensor[[64, 128], pl.FP16]]):
+    M, N = a.shape
+    t = pl.load(a, [0, 0], [M, N])
+    pl.store(t, [0, 0], c)
+    return c
+
+
+class TestAnnotationLayoutReachesTheProgram:
+    """The layout slot of a @pl.jit parameter annotation must reach the IR.
+
+    JIT specialization regenerates each annotation from ``TensorMeta`` rather
+    than reusing the user's source. ``TensorMeta`` carried only shape and dtype,
+    so the slot was dropped: ``pl.NZ`` silently became ND, and ``pl.DN`` — which
+    the type resolver rejects — was never even seen, so it neither errored nor
+    took effect.
+    """
+
+    def _entry_param_type(self, kernel):
+        _, _, tm, sv, sd, dyn = kernel._bind_args_from_signature({})
+        program = kernel._compile_to_program(tm, sv, sd, dyn, pl)
+        return list(program.functions.values())[0].params[0].type
+
+    def test_nz_layout_reaches_the_param_type(self):
+        param_type = self._entry_param_type(_nz_kernel)
+        assert param_type.tensor_view is not None
+        assert param_type.tensor_view.layout == ir.TensorLayout.NZ
+
+    def test_unannotated_layout_stays_absent(self):
+        """The plain two-slot form must not gain a view."""
+        _, _, tm, sv, sd, dyn = _nz_kernel._bind_args_from_signature({})
+        program = _nz_kernel._compile_to_program(tm, sv, sd, dyn, pl)
+        out_param = list(program.functions.values())[0].params[1]
+        assert out_param.type.tensor_view is None
+
+    def test_dn_layout_is_rejected(self):
+        """DN reaches the resolver now, so its rejection applies here too."""
+        with pytest.raises(ParserTypeError, match=r"pl\.Tensor\[\.\.\., pl\.DN\] is not supported"):
+            self._entry_param_type(_dn_kernel)
+
+    def test_dn_rejection_points_at_the_user_source(self):
+        """The span must name this test file, not the generated ``<jit:...>``."""
+        with pytest.raises(ParserTypeError) as exc_info:
+            self._entry_param_type(_dn_kernel)
+
+        span = exc_info.value.span
+        assert span is not None
+        assert span["filename"].endswith("test_jit_compile_extraction.py")
+
+
+@jit.incore
+def _nz_dep(a: pl.Tensor[[64, 128], pl.FP16, pl.NZ], c: pl.Out[pl.Tensor[[64, 128], pl.FP16]]):
+    M, N = a.shape
+    t = pl.load(a, [0, 0], [M, N])
+    pl.store(t, [0, 0], c)
+    return c
+
+
+@jit
+def _calls_nz_dep(a: pl.Tensor[[64, 128], pl.FP16], c: pl.Out[pl.Tensor[[64, 128], pl.FP16]]):
+    c = _nz_dep(a, c)
+    return c
+
+
+class TestDepDeclaredLayout:
+    """A dep's own layout declaration has no caller-side counterpart.
+
+    The caller's argument meta reflects the *caller's* annotation, so a dep
+    declaring ``pl.Tensor[[...], pl.NZ]`` while the entry declares none would
+    otherwise compile as ND — the same silent downgrade, one call deeper.
+    """
+
+    def test_dep_layout_survives_when_caller_declares_none(self):
+        _, _, tm, sv, sd, dyn = _calls_nz_dep._bind_args_from_signature({})
+        program = _calls_nz_dep._compile_to_program(tm, sv, sd, dyn, pl)
+        views = [
+            p.type.tensor_view
+            for f in program.functions.values()
+            for p in f.params
+            if getattr(p.type, "tensor_view", None) is not None
+        ]
+        assert any(v.layout == ir.TensorLayout.NZ for v in views)
+
+
+class TestUnsupportedLayoutSlot:
+    """A ``pl.TensorView`` in the slot must be refused, never dropped.
+
+    ``TensorMeta`` has nowhere to carry a view, and a dropped stride is silent
+    wrong code. The DN rejection's own hint points users at this spelling, so
+    the refusal has to be explicit rather than a quiet ND.
+    """
+
+    def test_tensorview_slot_raises(self):
+        strided = pl.TensorView(stride=[256, 1], layout=ir.TensorLayout.ND)
+
+        @jit
+        def kernel(a: pl.Tensor[[64, 128], pl.FP16, strided], c: pl.Out[pl.Tensor[[64, 128], pl.FP16]]):
+            M, N = a.shape
+            t = pl.load(a, [0, 0], [M, N])
+            pl.store(t, [0, 0], c)
+            return c
+
+        with pytest.raises(TypeError, match="does not yet support"):
+            kernel._bind_args_from_signature({})
 
 
 if __name__ == "__main__":

--- a/tests/ut/jit/test_jit_compile_extraction.py
+++ b/tests/ut/jit/test_jit_compile_extraction.py
@@ -571,8 +571,10 @@ class TestNzOnTensorIsNotJitSpecific:
                     pl.store(t, [0, 0], c)
                 return c
 
-        view = list(Prog.functions.values())[0].params[0].type.tensor_view
-        assert view is not None and view.layout == ir.TensorLayout.NZ
+        param_type = list(Prog.functions.values())[0].params[0].type
+        assert isinstance(param_type, ir.TensorType)
+        assert param_type.tensor_view is not None
+        assert param_type.tensor_view.layout == ir.TensorLayout.NZ
 
 
 if __name__ == "__main__":

--- a/tests/ut/jit/test_specializer.py
+++ b/tests/ut/jit/test_specializer.py
@@ -21,11 +21,13 @@ from pypto.jit.specializer import (
     Specializer,
     TensorMeta,
     _BodyTransformer,
+    _build_tensor_annotation,
     _classify_params,
     _collect_annotation_dynamic_dims,
     _collect_dynamic_dims,
     _collect_dynvar_names,
     _infer_return_type,
+    _layout_str,
     specialize,
 )
 from pypto.pypto_core import DataType, ir
@@ -1675,7 +1677,17 @@ class TestSpecializerInlineDeprecation:
 
 
 class TestSpecializerSourceMap:
-    """specialize() builds a generated→original line map (issue #1612)."""
+    """specialize() builds a generated→original line map (issue #1612).
+
+    The map covers each function's signature line plus its body statements. The
+    signature entry is what lets an annotation-level parse error (e.g. a
+    rejected layout) report against the user's file instead of the generated
+    source, so these tests assert on the two kinds separately.
+    """
+
+    #: Original file line of the ``def`` in each fixture below: the source
+    #: starts at the decorator (``orig_start_line``) with ``def`` one line down.
+    _DEF_LINE = 101
 
     def _meta(self) -> TensorMeta:
         return TensorMeta(shape=(32, 32), dtype=DataType.FP32)
@@ -1706,10 +1718,15 @@ class TestSpecializerSourceMap:
         spec.specialize()
         source_map = spec.source_map
 
-        assert source_map, "expected a non-empty source map"
-        assert all(f == "/real/kernel.py" for f, _, _ in source_map.values())
-        # Dedented body lines 3,4,5 + (orig_start_line - 1) = 102,103,104.
-        assert sorted(line for _, line, _ in source_map.values()) == [102, 103, 104]
+        # Exact multiset: the signature line at column 0 (so annotation errors
+        # land in the user's file) plus dedented body lines 3,4,5 +
+        # (orig_start_line - 1), each indented one level inside the function.
+        assert sorted(source_map.values()) == [
+            ("/real/kernel.py", self._DEF_LINE, 0),
+            ("/real/kernel.py", 102, 4),
+            ("/real/kernel.py", 103, 4),
+            ("/real/kernel.py", 104, 4),
+        ]
 
     def test_no_real_file_yields_empty_map(self):
         """Without on-disk source (orig_file=None), no mapping is produced."""
@@ -1758,8 +1775,9 @@ class TestSpecializerSourceMap:
         spec = Specializer("Gen", [ctx])
         spec.specialize()
         # The body collapses to a synthesized `pass`; it must not be mapped, and
-        # in particular must not point at the decorator line (100).
-        assert spec.source_map == {}
+        # in particular must not point at the decorator line (100). Only the
+        # signature line remains.
+        assert list(spec.source_map.values()) == [("/real/kernel.py", self._DEF_LINE, 0)]
 
 
 # ---------------------------------------------------------------------------
@@ -1975,6 +1993,65 @@ class TestArrayParamAnnotation:
         # `len(...)` is unavailable without builtins -> eval fails -> no Array
         # annotation is emitted for `x` (best-effort, no execution, no crash).
         assert "x: pl.Array" not in out
+
+
+class TestTensorLayoutAnnotation:
+    """The annotation's layout slot must survive specialization.
+
+    ``TensorMeta`` used to carry only shape and dtype, so ``pl.Tensor[[...],
+    dtype, pl.NZ]`` regenerated as a plain two-slot annotation — the layout was
+    dropped without a word and the parameter silently became ND.
+    """
+
+    def test_layout_str_renders_dsl_constant(self):
+        assert _layout_str(ir.TensorLayout.NZ) == "pl.NZ"
+        assert _layout_str(ir.TensorLayout.MX_A_ZZ) == "pl.MX_A_ZZ"
+
+    def test_layout_str_omits_nd(self):
+        """ND is what an absent slot already means — emitting it is noise."""
+        assert _layout_str(ir.TensorLayout.ND) is None
+
+    def test_annotation_carries_layout(self):
+        meta = TensorMeta((64, 128), DataType.FP16, layout=ir.TensorLayout.NZ)
+        assert _build_tensor_annotation(meta, is_out=False) == "pl.Tensor[[64, 128], pl.FP16, pl.NZ]"
+
+    def test_annotation_without_layout_unchanged(self):
+        """The two-slot form must stay byte-identical — no trailing slot."""
+        meta = TensorMeta((64, 128), DataType.FP16)
+        assert _build_tensor_annotation(meta, is_out=False) == "pl.Tensor[[64, 128], pl.FP16]"
+
+    def test_annotation_layout_survives_out_wrapper(self):
+        meta = TensorMeta((64, 128), DataType.FP16, layout=ir.TensorLayout.NZ)
+        assert _build_tensor_annotation(meta, is_out=True) == "pl.Out[pl.Tensor[[64, 128], pl.FP16, pl.NZ]]"
+
+    def test_annotation_layout_with_dynamic_dim(self):
+        """A DynDim shape and a layout coexist — both slots render."""
+        meta = TensorMeta(
+            (DynDim(name="M", literal="M", static_bound=64), 128),
+            DataType.FP16,
+            layout=ir.TensorLayout.NZ,
+        )
+        assert _build_tensor_annotation(meta, is_out=False) == "pl.Tensor[[M, 128], pl.FP16, pl.NZ]"
+
+    def test_specialized_source_keeps_layout(self):
+        """End to end: the generated @pl.function source carries the slot."""
+        ctx = _make_ctx(
+            source=textwrap.dedent(
+                """
+                def kernel(a: pl.Tensor, c: pl.Out[pl.Tensor]):
+                    return c
+                """
+            ),
+            param_names=["a", "c"],
+            tensor_meta={
+                "a": TensorMeta((64, 128), DataType.FP16, layout=ir.TensorLayout.NZ),
+                "c": TensorMeta((64, 128), DataType.FP16),
+            },
+        )
+        out = specialize("_T", [ctx])
+        assert "a: pl.Tensor[[64, 128], pl.FP16, pl.NZ]" in out
+        # The un-annotated param keeps the plain two-slot form.
+        assert "c: pl.Out[pl.Tensor[[64, 128], pl.FP16]]" in out
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

`@pl.jit` does not resolve the user's annotations. It records shape and dtype in `TensorMeta` and regenerates the annotation from that record, so the third subscript slot never survived:

```python
@jit
def k(a: pl.Tensor[[64, 128], pl.FP16, pl.NZ], ...): ...

# before:  param tensor_view = None          (NZ silently became ND)
# before:  pl.DN in the same position        (no error, and no DN either)
```

`_build_tensor_annotation` emitted only `pl.Tensor[[dims], dtype]`, and `grep -r layout python/pypto/jit/` matched nothing at all. Because the slot never reached the type resolver, the `pl.DN` rejection added in #2250 was unreachable from this path — writing `pl.DN` under `@pl.jit` neither errored nor produced DN.

## What changed

**Layout reaches the generated annotation.** `TensorMeta` gains a `layout`; both binding paths read it from the annotation (a torch tensor carries no PyPTO layout, so the annotation is the only source even on the tensor-argument path); `_build_tensor_annotation` emits the slot again. The DN rejection then comes from the resolver rather than a second copy of the policy here.

**Propagation follows tensor identity.** Layout rides along through the DynDim overlay, per-rank `x[r]` dispatch, `pl.slice`, and subscript views. `pl.reshape` declines the meta instead — it re-groups the dims a layout describes, and claiming ND would be the same silent mis-declaration.

**A dep's own declaration is honored.** No caller argument carries it, so a dep declaring `pl.Tensor[[...], pl.NZ]` under a caller that declares none was compiling as ND. Same overlay shape as the existing `dep_dyn_map` fill, caller wins on conflict.

**`pl.TensorView` in the slot now raises.** `Tensor.__getitem__` routes any non-`MemRef` third element into `layout`, so a view landed where `TensorMeta` has no field for it and its stride vanished. This is reachable directly from the DN rejection's own hint (which recommends `pl.TensorView(stride=..., layout=DN)`), so a user following that advice would have walked from a clear error into silent wrong code. It now fails with a message naming the parameter and pointing at `@pl.function`.

**Cache key.** A layout can enter the annotation through a closure variable (`L = pl.NZ; ... pl.Tensor[[...], pl.FP32, L]`), leaving the source text — and thus `source_hash` — unchanged while the artifact differs, so `TensorCacheInfo` carries it.

**Diagnostics.** The specializer source map now covers the signature line, so an annotation-level error reports against the user's `.py` instead of the generated `<jit:...>` source.

## Testing

- `tests/ut` — 8596 passed, 2 skipped
- `pyright python/pypto/jit/` — 0 errors
- `ruff check` / `ruff format --check` (pinned 0.14.8) — clean, no new findings vs. base
- Docs en/zh parity + English-only lint — pass

New coverage in `tests/ut/jit/`: layout rendering and the byte-identical two-slot path, layout with `pl.Out` and with a `DynDim` shape, end-to-end NZ reaching `tensor_view.layout`, DN rejected with its span pointing at the user's file, a dep's own declaration surviving, and the `pl.TensorView` refusal.

Two existing `TestSpecializerSourceMap` assertions were exact-equality over the whole map, which the new signature entry breaks. Both were narrowed to name the signature and statement entries explicitly — the multiset assertion is now stricter than before (it also pins columns, which it previously ignored).

## Related

Follows #2250, which added the `pl.Tensor[..., pl.DN]` rejection on the `@pl.function` path.