### PR TITLE
fix(ir): Deduce tile result views against the destination memory space

### DIFF
--- a/docs/en/dev/ir/02-types.md
+++ b/docs/en/dev/ir/02-types.md
@@ -202,6 +202,14 @@ memory space. Redundant explicit defaults such as `pl.TileView()` are treated
 as semantically equivalent to the omitted form and may print back in canonical
 syntax.
 
+Because the implicit view depends on the memory space, the `TileType`
+constructor collapses a view to `nullopt` only against the space it is given.
+An `f_deduce_type` that produces a tile in a known space **must pass that space
+to the constructor** — deducing against `nullopt` and letting
+`OpRegistry::Create` stamp the space afterwards re-canonicalizes the view
+against a different implicit layout, so the result would depend on whether the
+view happened to collapse (i.e. on `valid_shape` and `pad`).
+
 ### ArrayType
 
 On-core fixed-size homogeneous 1-D array. Lives on the scalar register file /

--- a/docs/en/dev/ir/02-types.md
+++ b/docs/en/dev/ir/02-types.md
@@ -202,13 +202,12 @@ memory space. Redundant explicit defaults such as `pl.TileView()` are treated
 as semantically equivalent to the omitted form and may print back in canonical
 syntax.
 
-Because the implicit view depends on the memory space, the `TileType`
-constructor collapses a view to `nullopt` only against the space it is given.
-An `f_deduce_type` that produces a tile in a known space **must pass that space
-to the constructor** — deducing against `nullopt` and letting
-`OpRegistry::Create` stamp the space afterwards re-canonicalizes the view
-against a different implicit layout, so the result would depend on whether the
-view happened to collapse (i.e. on `valid_shape` and `pad`).
+The implicit view depends on the memory space, so the constructor collapses a
+view to `nullopt` only against the space it is given. An `f_deduce_type`
+producing a tile in a known space **must pass that space** — deducing against
+`nullopt` and letting `OpRegistry::Create` stamp it afterwards canonicalizes
+twice, against two different implicit layouts, making the result depend on
+whether the view happened to collapse (i.e. on `valid_shape` and `pad`).
 
 ### ArrayType
 

--- a/docs/en/dev/ir/05-operators.md
+++ b/docs/en/dev/ir/05-operators.md
@@ -333,26 +333,21 @@ The deduced result `TileView` splits by field:
 
 | Field | Source of the result value |
 | ----- | -------------------------- |
-| `blayout` / `slayout` | The **destination** space's implicit layout wherever that space has one of its own (`Mat`, `Acc`, `Left`, `Right`, `LeftScale`, `RightScale`). For the flat spaces (`Vec`, `Bias`, …), whose implicit layout is the space-agnostic one, the source tile's effective layout carries over. A `blayout` / `slayout` kwarg overrides either |
+| `blayout` / `slayout` | The **destination** space's implicit layout wherever it has one of its own (`Mat`, `Acc`, `Left`, `Right`, `LeftScale`, `RightScale`); for the flat spaces (`Vec`, `Bias`, …) the source tile's effective layout carries over. A `blayout` / `slayout` kwarg overrides either |
 | `fractal` | The **destination** space's boxing granularity, never the source's: `Acc` (L0C, NZ-boxed) is 1024, MX scale tiles are 32, everything else 512 |
 | `valid_shape` / `pad` | Carried over from the source |
 | `stride` / `start_offset` | Dropped — the destination is a dense buffer |
 
-The whole layout comes from the destination because it describes how the
-destination buffer is boxed; `tile_view_semantics::GetImplicitTileLayout`
-supplies it (delegating the fractal to `GetImplicitFractal`). `Right` is the one
-destination that still needs a local override: L0B requires `blayout=row_major`
-even for an `[N, 1]` shape, whose implicit `blayout` is `col_major`.
+The layout comes from the destination because it describes how that buffer is
+boxed; `tile_view_semantics::GetImplicitTileLayout` supplies it. `Right` needs a
+local override — L0B requires `blayout=row_major` even for an `[N, 1]` shape,
+whose implicit `blayout` is `col_major`.
 
-`tile.move` stamps the destination `memory_space` onto the deduced type itself,
-so the view is canonicalized once, against the space it is actually a view of —
-a result view matching the destination's implicit view collapses to `nullopt`,
-the same per-space implicit view
+`tile.move` stamps the destination `memory_space` itself (see the `TileType`
+contract in [Types](02-types.md#tiletype)), so a result view matching the
+destination's implicit view collapses to `nullopt` — the same per-space view
 [`InferTileMemorySpace`](../passes/17-infer_tile_memory_space.md) refreshes a
-retyped tile to. Deducing against `nullopt` and leaving `OpRegistry::Create` to
-stamp the space would canonicalize twice, against two different implicit
-layouts — see the `TileType` contract in
-[Types](02-types.md#tiletype-and-tileview).
+retyped tile to.
 
 ### Reshape and the valid region
 

--- a/docs/en/dev/ir/05-operators.md
+++ b/docs/en/dev/ir/05-operators.md
@@ -315,7 +315,7 @@ with ib.function("tensor_example") as f:
 | - | `tile.adds/subs/muls/divs` | Tile-Scalar operations. A **constant** scalar operand adopts the tile's element dtype (a bare int literal is otherwise parsed as `index`, which no `pto.t*s` op accepts) — except a float literal on an integer tile, which keeps FP32 so promotion is preserved. An explicit `pl.const(v, dtype)` is a deliberate annotation and is left as-is, as is any non-constant expression; a non-constant `index` scalar (loop var, `pl.dim`) is rejected — convert it with `pl.cast`. Same rule for `tensor.*s`. |
 | **Unary** | `tile.sqrt` | Element-wise square root |
 | **Transform** | `tile.slice` | Extract a sub-tile with static shape, optional dynamic valid_shape, and optional `drop_dims` (numpy-style rank reduction over static unit axes; result clamped to a 2D minimum) |
-| - | `tile.extract` | Extract a sub-tile from `src` at `(index_row, index_col)` — ISA TEXTRACT Variant 1 (Mat→Left/Right, Acc→Mat) |
+| - | `tile.extract` | Extract a sub-tile from `src` at `(index_row, index_col)` — ISA TEXTRACT Variant 1 (Mat→Left/Right, Acc→Mat). The result's layout comes from `target_memory`'s implicit view, except `Left`/`Right`, which take the TEXTRACT-side L0 formats (these differ from `tile.move`'s TMOV-side ones) |
 | - | `tile.reshape` | Reshape tile to new dimensions (element count must match). Carries the source's `valid_shape` through without widening it — see [Reshape and the valid region](#reshape-and-the-valid-region) |
 | - | `tile.reinterpret_view` | Zero-copy view with a different dtype and the same exact bytes; optional shape uses layout-aware inference (packed flat tiles only) |
 | - | `tile.transpose` | Swap two axes of a tile |
@@ -333,19 +333,26 @@ The deduced result `TileView` splits by field:
 
 | Field | Source of the result value |
 | ----- | -------------------------- |
-| `blayout` / `slayout` | The source tile's effective view — a move preserves the logical layout — unless the destination is `Left` / `Right` / `LeftScale` / `RightScale` (hardware-fixed) or a `blayout` / `slayout` kwarg overrides it |
+| `blayout` / `slayout` | The **destination** space's implicit layout wherever that space has one of its own (`Mat`, `Acc`, `Left`, `Right`, `LeftScale`, `RightScale`). For the flat spaces (`Vec`, `Bias`, …), whose implicit layout is the space-agnostic one, the source tile's effective layout carries over. A `blayout` / `slayout` kwarg overrides either |
 | `fractal` | The **destination** space's boxing granularity, never the source's: `Acc` (L0C, NZ-boxed) is 1024, MX scale tiles are 32, everything else 512 |
 | `valid_shape` / `pad` | Carried over from the source |
 | `stride` / `start_offset` | Dropped — the destination is a dense buffer |
 
-`fractal` comes from the destination because it describes how the destination
-buffer is boxed; `tile_view_semantics::GetImplicitFractal` supplies it. It is
-also what makes a same-space, same-layout move canonical:
-`OpRegistry::Create` stamps `memory_space` onto the deduced type, so a result
-view matching the destination's implicit view collapses to `nullopt` — the same
-per-space implicit view
+The whole layout comes from the destination because it describes how the
+destination buffer is boxed; `tile_view_semantics::GetImplicitTileLayout`
+supplies it (delegating the fractal to `GetImplicitFractal`). `Right` is the one
+destination that still needs a local override: L0B requires `blayout=row_major`
+even for an `[N, 1]` shape, whose implicit `blayout` is `col_major`.
+
+`tile.move` stamps the destination `memory_space` onto the deduced type itself,
+so the view is canonicalized once, against the space it is actually a view of —
+a result view matching the destination's implicit view collapses to `nullopt`,
+the same per-space implicit view
 [`InferTileMemorySpace`](../passes/17-infer_tile_memory_space.md) refreshes a
-retyped tile to.
+retyped tile to. Deducing against `nullopt` and leaving `OpRegistry::Create` to
+stamp the space would canonicalize twice, against two different implicit
+layouts — see the `TileType` contract in
+[Types](02-types.md#tiletype-and-tileview).
 
 ### Reshape and the valid region
 

--- a/docs/zh/dev/ir/02-types.md
+++ b/docs/zh/dev/ir/02-types.md
@@ -196,6 +196,12 @@ TileView：它由 tile shape 以及（如果存在）tile memory space 推导得
 像 `pl.TileView()` 这样的冗余显式默认写法，会与省略写法被视为语义等价，
 并且在 printer 输出时可能统一成规范形式。
 
+由于隐式 view 依赖 memory space，`TileType` 构造函数只会针对传入的 space
+把 view 折叠成 `nullopt`。因此，凡是能确定结果 space 的 `f_deduce_type`，
+**都必须把该 space 传给构造函数**：若先针对 `nullopt` 推导、再由
+`OpRegistry::Create` 补盖 space，view 会被按另一套隐式 layout 重新规范化，
+结果 layout 将取决于 view 是否恰好折叠（即取决于 `valid_shape` 与 `pad`）。
+
 ### ArrayType
 
 片上定长同构 1-D 数组,存放于标量寄存器堆 / C 栈(memory space `ScalarLocal`)。

--- a/docs/zh/dev/ir/02-types.md
+++ b/docs/zh/dev/ir/02-types.md
@@ -196,11 +196,10 @@ TileView：它由 tile shape 以及（如果存在）tile memory space 推导得
 像 `pl.TileView()` 这样的冗余显式默认写法，会与省略写法被视为语义等价，
 并且在 printer 输出时可能统一成规范形式。
 
-由于隐式 view 依赖 memory space，`TileType` 构造函数只会针对传入的 space
-把 view 折叠成 `nullopt`。因此，凡是能确定结果 space 的 `f_deduce_type`，
-**都必须把该 space 传给构造函数**：若先针对 `nullopt` 推导、再由
-`OpRegistry::Create` 补盖 space，view 会被按另一套隐式 layout 重新规范化，
-结果 layout 将取决于 view 是否恰好折叠（即取决于 `valid_shape` 与 `pad`）。
+隐式 view 依赖 memory space，构造函数只会针对传入的 space 把 view 折叠成
+`nullopt`。凡能确定结果 space 的 `f_deduce_type`，**都必须把该 space 传进来**：
+若先针对 `nullopt` 推导、再由 `OpRegistry::Create` 补盖 space，就会按两套不同的
+隐式 layout 规范化两次，结果取决于 view 是否恰好折叠（即 `valid_shape` 与 `pad`）。
 
 ### ArrayType
 

--- a/docs/zh/dev/ir/05-operators.md
+++ b/docs/zh/dev/ir/05-operators.md
@@ -307,7 +307,7 @@ with ib.function("tensor_example") as f:
 | - | `tile.adds/subs/muls/divs` | Tile-Scalar 操作。**常量**标量操作数会采用 tile 的元素 dtype（裸整数字面量否则会被解析为 `index`，而任何 `pto.t*s` 算子都不接受它）——但整数 tile 上的浮点字面量仍保持 FP32，以保留类型提升语义。显式的 `pl.const(v, dtype)` 属于用户的有意标注，与任何非常量表达式一样保持不变；非常量的 `index` 标量（循环变量、`pl.dim`）会被拒绝——需用 `pl.cast` 转换。`tensor.*s` 同理。 |
 | **一元** | `tile.sqrt` | 逐元素平方根 |
 | **变换** | `tile.slice` | 提取子 tile，静态 shape，可选动态 valid_shape |
-| - | `tile.extract` | 从 `src` 在 `(index_row, index_col)` 处提取子 tile —— ISA TEXTRACT Variant 1（Mat→Left/Right，Acc→Mat） |
+| - | `tile.extract` | 从 `src` 在 `(index_row, index_col)` 处提取子 tile —— ISA TEXTRACT Variant 1（Mat→Left/Right，Acc→Mat）。结果 layout 取自 `target_memory` 的隐式 view；`Left`/`Right` 例外，使用 TEXTRACT 侧的 L0 格式（与 `tile.move` 的 TMOV 侧不同） |
 | - | `tile.reshape` | 重塑 tile 维度（元素总数须一致）。会把源的 `valid_shape` 带到结果上，且绝不扩大 —— 见[reshape 与有效区域（valid region）](#reshape-与有效区域valid-region) |
 | - | `tile.reinterpret_view` | 以不同 dtype 对完全相同的字节做零拷贝视图；可选 shape 默认按 layout 推导（仅支持紧密、非分形 tile） |
 | - | `tile.transpose` | 交换 tile 的两个轴 |
@@ -325,17 +325,22 @@ with ib.function("tensor_example") as f:
 
 | 字段 | 结果值的来源 |
 | ---- | ------------ |
-| `blayout` / `slayout` | 源 tile 的 effective view —— move 保持逻辑 layout —— 除非目标是 `Left` / `Right` / `LeftScale` / `RightScale`（硬件固定），或由 `blayout` / `slayout` kwarg 覆盖 |
+| `blayout` / `slayout` | 凡目标 space 自带 layout（`Mat`、`Acc`、`Left`、`Right`、`LeftScale`、`RightScale`），一律取**目标**的 implicit layout；对 implicit layout 与 space 无关的扁平 space（`Vec`、`Bias` 等），则沿用源 tile 的 effective layout。两者都可由 `blayout` / `slayout` kwarg 覆盖 |
 | `fractal` | **目标** space 的分块（boxing）粒度，绝不取源的：`Acc`（L0C，NZ 分形）为 1024，MX scale tile 为 32，其余为 512 |
 | `valid_shape` / `pad` | 从源带过来 |
 | `stride` / `start_offset` | 丢弃 —— 目标是稠密缓冲区 |
 
-`fractal` 来自目标，因为它描述的是目标缓冲区如何分块，由
-`tile_view_semantics::GetImplicitFractal` 提供。它同时决定了「同 space、同 layout」的
-move 是否规范：`OpRegistry::Create` 会把 `memory_space` 打到推导出的类型上，因此当结果 view 与目标
-space 的 implicit view 一致时会折叠为 `nullopt` —— 这与
+整个 layout 都来自目标，因为它描述的是目标缓冲区如何分块，由
+`tile_view_semantics::GetImplicitTileLayout` 提供（其中 fractal 委托给
+`GetImplicitFractal`）。`Right` 是唯一仍需就地覆盖的目标：L0B 要求
+`blayout=row_major`，而 `[N, 1]` 形状的 implicit `blayout` 是 `col_major`。
+
+`tile.move` 自己把目标 `memory_space` 打到推导出的类型上，因此 view 只会针对「它实际所属的
+space」规范化一次 —— 当结果 view 与目标 space 的 implicit view 一致时折叠为 `nullopt`，这与
 [`InferTileMemorySpace`](../passes/17-infer_tile_memory_space.md) 为重新定型的 tile 刷新的
-per-space implicit view 是同一套。
+per-space implicit view 是同一套。若先针对 `nullopt` 推导、再由 `OpRegistry::Create` 补盖
+space，就会按两套不同的 implicit layout 规范化两次 —— 参见
+[类型](02-types.md#tiletype-and-tileview) 中的 `TileType` 契约。
 
 ### reshape 与有效区域（valid region）
 

--- a/docs/zh/dev/ir/05-operators.md
+++ b/docs/zh/dev/ir/05-operators.md
@@ -325,22 +325,20 @@ with ib.function("tensor_example") as f:
 
 | 字段 | 结果值的来源 |
 | ---- | ------------ |
-| `blayout` / `slayout` | 凡目标 space 自带 layout（`Mat`、`Acc`、`Left`、`Right`、`LeftScale`、`RightScale`），一律取**目标**的 implicit layout；对 implicit layout 与 space 无关的扁平 space（`Vec`、`Bias` 等），则沿用源 tile 的 effective layout。两者都可由 `blayout` / `slayout` kwarg 覆盖 |
+| `blayout` / `slayout` | 凡目标 space 自带 layout（`Mat`、`Acc`、`Left`、`Right`、`LeftScale`、`RightScale`），取**目标**的 implicit layout；扁平 space（`Vec`、`Bias` 等）则沿用源 tile 的 effective layout。两者都可由 `blayout` / `slayout` kwarg 覆盖 |
 | `fractal` | **目标** space 的分块（boxing）粒度，绝不取源的：`Acc`（L0C，NZ 分形）为 1024，MX scale tile 为 32，其余为 512 |
 | `valid_shape` / `pad` | 从源带过来 |
 | `stride` / `start_offset` | 丢弃 —— 目标是稠密缓冲区 |
 
-整个 layout 都来自目标，因为它描述的是目标缓冲区如何分块，由
-`tile_view_semantics::GetImplicitTileLayout` 提供（其中 fractal 委托给
-`GetImplicitFractal`）。`Right` 是唯一仍需就地覆盖的目标：L0B 要求
+layout 来自目标，因为它描述的是目标缓冲区如何分块，由
+`tile_view_semantics::GetImplicitTileLayout` 提供。`Right` 仍需就地覆盖：L0B 要求
 `blayout=row_major`，而 `[N, 1]` 形状的 implicit `blayout` 是 `col_major`。
 
-`tile.move` 自己把目标 `memory_space` 打到推导出的类型上，因此 view 只会针对「它实际所属的
-space」规范化一次 —— 当结果 view 与目标 space 的 implicit view 一致时折叠为 `nullopt`，这与
-[`InferTileMemorySpace`](../passes/17-infer_tile_memory_space.md) 为重新定型的 tile 刷新的
-per-space implicit view 是同一套。若先针对 `nullopt` 推导、再由 `OpRegistry::Create` 补盖
-space，就会按两套不同的 implicit layout 规范化两次 —— 参见
-[类型](02-types.md#tiletype-and-tileview) 中的 `TileType` 契约。
+`tile.move` 自己把目标 `memory_space` 打到推导出的类型上（参见
+[类型](02-types.md#tiletype) 中的 `TileType` 契约），因此当结果 view 与目标 space 的
+implicit view 一致时会折叠为 `nullopt` —— 这与
+[`InferTileMemorySpace`](../passes/17-infer_tile_memory_space.md) 为重新定型的 tile
+刷新的 per-space implicit view 是同一套。
 
 ### reshape 与有效区域（valid region）
 

--- a/include/pypto/ir/tile_view_semantics.h
+++ b/include/pypto/ir/tile_view_semantics.h
@@ -82,43 +82,76 @@ inline uint64_t GetImplicitFractal(const std::optional<MemorySpace>& memory_spac
   }
 }
 
-/// Build the implicit TileView semantics represented by omitted Python syntax.
-inline TileView GetImplicitTileView(const std::vector<ExprPtr>& shape,
-                                    const std::optional<MemorySpace>& memory_space = std::nullopt) {
-  TileView implicit_view;
-  implicit_view.valid_shape = shape;
-  implicit_view.blayout = InferImplicitTileLayoutFromShape(shape);
-  implicit_view.fractal = GetImplicitFractal(memory_space);
+/// The layout half of a TileView: the fields determined by (shape, memory
+/// space) rather than by the data the tile holds. Kept separate from TileView so
+/// a caller needing only the layout can skip building (and copying) a whole view.
+struct TileLayoutSpec {
+  TileLayout blayout = TileLayout::row_major;
+  TileLayout slayout = TileLayout::none_box;
+  uint64_t fractal = TileView{}.fractal;
+};
+
+inline bool operator==(const TileLayoutSpec& lhs, const TileLayoutSpec& rhs) {
+  return lhs.blayout == rhs.blayout && lhs.slayout == rhs.slayout && lhs.fractal == rhs.fractal;
+}
+inline bool operator!=(const TileLayoutSpec& lhs, const TileLayoutSpec& rhs) { return !(lhs == rhs); }
+
+/// The layout a tile of @p shape implicitly carries when it lives in
+/// @p memory_space -- the single source of truth for the space->layout table.
+/// An absent space yields the space-agnostic (flat) layout. Delegates the
+/// fractal to GetImplicitFractal so the two cannot drift.
+inline TileLayoutSpec GetImplicitTileLayout(const std::vector<ExprPtr>& shape,
+                                            const std::optional<MemorySpace>& memory_space = std::nullopt) {
+  TileLayoutSpec layout;
+  layout.blayout = InferImplicitTileLayoutFromShape(shape);
+  layout.fractal = GetImplicitFractal(memory_space);
 
   if (memory_space.has_value()) {
     switch (*memory_space) {
       case MemorySpace::Mat:
       case MemorySpace::Left:
-        implicit_view.blayout = TileLayout::col_major;
-        implicit_view.slayout = TileLayout::row_major;
+        layout.blayout = TileLayout::col_major;
+        layout.slayout = TileLayout::row_major;
         break;
       case MemorySpace::Right:
-        implicit_view.slayout = TileLayout::col_major;
+        layout.slayout = TileLayout::col_major;
         break;
       case MemorySpace::LeftScale:
         // ISA TileLeftScale: RowMajor / RowMajor.
-        implicit_view.blayout = TileLayout::row_major;
-        implicit_view.slayout = TileLayout::row_major;
+        layout.blayout = TileLayout::row_major;
+        layout.slayout = TileLayout::row_major;
         break;
       case MemorySpace::RightScale:
         // ISA TileRightScale: ColMajor / ColMajor.
-        implicit_view.blayout = TileLayout::col_major;
-        implicit_view.slayout = TileLayout::col_major;
+        layout.blayout = TileLayout::col_major;
+        layout.slayout = TileLayout::col_major;
         break;
       case MemorySpace::Acc:
-        implicit_view.blayout = TileLayout::col_major;
-        implicit_view.slayout = TileLayout::row_major;
+        layout.blayout = TileLayout::col_major;
+        layout.slayout = TileLayout::row_major;
         break;
       default:
         break;
     }
   }
 
+  return layout;
+}
+
+/// Overwrite only @p view's layout fields, leaving valid_shape / stride /
+/// start_offset / pad (which describe the data, not the memory) untouched.
+inline void SetTileLayout(TileView& view, const TileLayoutSpec& layout) {
+  view.blayout = layout.blayout;
+  view.slayout = layout.slayout;
+  view.fractal = layout.fractal;
+}
+
+/// Build the implicit TileView semantics represented by omitted Python syntax.
+inline TileView GetImplicitTileView(const std::vector<ExprPtr>& shape,
+                                    const std::optional<MemorySpace>& memory_space = std::nullopt) {
+  TileView implicit_view;
+  implicit_view.valid_shape = shape;
+  SetTileLayout(implicit_view, GetImplicitTileLayout(shape, memory_space));
   return implicit_view;
 }
 

--- a/src/ir/op/tile_ops/batch_matmul.cpp
+++ b/src/ir/op/tile_ops/batch_matmul.cpp
@@ -31,6 +31,7 @@
 #include "pypto/ir/memory_space.h"
 #include "pypto/ir/op_registry.h"
 #include "pypto/ir/scalar_expr.h"
+#include "pypto/ir/tile_view_semantics.h"
 #include "pypto/ir/type.h"
 #include "pypto/ir/type_inference.h"
 
@@ -127,17 +128,16 @@ TypePtr DeduceTileBatchMatMulType(const std::vector<ExprPtr>& args,
   auto result_dtype =
       (lhs_type->dtype_.IsFloat() && rhs_type->dtype_.IsFloat()) ? DataType::FP32 : DataType::INT32;
 
-  // The matmul output tile uses the hardware's native accumulator layout:
-  // - blayout=col_major, slayout=row_major: hardware's column-major block / row-major sub-block
-  // - fractal=1024: inner box size in *bytes* — 16 rows x (1024 / dtype_bytes / 16) cols,
-  //   i.e. a 16x16 box for the 4-byte (FP32/INT32) accumulator (standard for this
-  //   hardware's matrix unit)
+  // The matmul output tile uses the hardware's native accumulator layout
+  // (col_major block / row_major sub-block), which is exactly Acc's implicit
+  // layout — take it from there rather than restating the triple. fractal is the
+  // inner box size in *bytes* — 16 rows x (1024 / dtype_bytes / 16) cols, i.e. a
+  // 16x16 box for the 4-byte (FP32/INT32) accumulator.
   TileView tile_view;
-  tile_view.blayout = TileLayout::col_major;
-  tile_view.slayout = TileLayout::row_major;
-  tile_view.fractal = 1024;
+  tile_view_semantics::SetTileLayout(
+      tile_view, tile_view_semantics::GetImplicitTileLayout(output_shape, MemorySpace::Acc));
   tile_view.valid_shape = output_shape;
-  return std::make_shared<TileType>(output_shape, result_dtype, std::nullopt, tile_view);
+  return std::make_shared<TileType>(output_shape, result_dtype, std::nullopt, tile_view, MemorySpace::Acc);
 }
 
 /**
@@ -266,11 +266,10 @@ TypePtr DeduceTileBatchMatMulAccType(const std::vector<ExprPtr>& args,
   // Acc layout (Nz) — same as 2D matmul_acc; fractal is a byte size (see
   // DeduceTileBatchMatMulType above).
   TileView tile_view;
-  tile_view.blayout = TileLayout::col_major;
-  tile_view.slayout = TileLayout::row_major;
-  tile_view.fractal = 1024;
+  tile_view_semantics::SetTileLayout(
+      tile_view, tile_view_semantics::GetImplicitTileLayout(output_shape, MemorySpace::Acc));
   tile_view.valid_shape = output_shape;
-  return std::make_shared<TileType>(output_shape, result_dtype, std::nullopt, tile_view);
+  return std::make_shared<TileType>(output_shape, result_dtype, std::nullopt, tile_view, MemorySpace::Acc);
 }
 
 // ============================================================================

--- a/src/ir/op/tile_ops/matmul.cpp
+++ b/src/ir/op/tile_ops/matmul.cpp
@@ -30,6 +30,7 @@
 #include "pypto/ir/memory_space.h"
 #include "pypto/ir/op_registry.h"
 #include "pypto/ir/scalar_expr.h"
+#include "pypto/ir/tile_view_semantics.h"
 #include "pypto/ir/type.h"
 #include "pypto/ir/type_inference.h"
 
@@ -91,15 +92,16 @@ TypePtr DeduceTileMatMulType(const std::vector<ExprPtr>& args,
   // Output shape is [M, N]
   std::vector<ExprPtr> output_shape = {m_dim, n_dim};
 
-  // Acc layout: Nz. fractal is the inner box size in *bytes* — 16 rows x
-  // (1024 / dtype_bytes / 16) cols, i.e. a 16x16 box for the 4-byte (FP32/INT32) accumulator.
+  // Acc layout (Nz), taken from the destination space's implicit layout rather
+  // than a hand-written triple. fractal is the inner box size in *bytes* — 16
+  // rows x (1024 / dtype_bytes / 16) cols, i.e. a 16x16 box for the 4-byte
+  // (FP32/INT32) accumulator.
   TileView tile_view;
-  tile_view.blayout = TileLayout::col_major;
-  tile_view.slayout = TileLayout::row_major;
-  tile_view.fractal = 1024;
+  tile_view_semantics::SetTileLayout(
+      tile_view, tile_view_semantics::GetImplicitTileLayout(output_shape, MemorySpace::Acc));
   tile_view.valid_shape = output_shape;
 
-  return std::make_shared<TileType>(output_shape, result_dtype, std::nullopt, tile_view);
+  return std::make_shared<TileType>(output_shape, result_dtype, std::nullopt, tile_view, MemorySpace::Acc);
 }
 
 TypePtr DeduceTileMatMulAccType(const std::vector<ExprPtr>& args,
@@ -181,15 +183,13 @@ TypePtr DeduceTileMatMulAccType(const std::vector<ExprPtr>& args,
   // Output shape is [M, N] (same as accumulator)
   std::vector<ExprPtr> output_shape = {m_dim_acc, n_dim_acc};
 
-  // Acc layout: Nz. fractal is the inner box size in *bytes* — 16 rows x
-  // (1024 / dtype_bytes / 16) cols, i.e. a 16x16 box for the 4-byte (FP32/INT32) accumulator.
+  // Acc layout (Nz) — as in tile.matmul, from the destination's implicit layout.
   TileView tile_view;
-  tile_view.blayout = TileLayout::col_major;
-  tile_view.slayout = TileLayout::row_major;
-  tile_view.fractal = 1024;
+  tile_view_semantics::SetTileLayout(
+      tile_view, tile_view_semantics::GetImplicitTileLayout(output_shape, MemorySpace::Acc));
   tile_view.valid_shape = output_shape;
 
-  return std::make_shared<TileType>(output_shape, result_dtype, std::nullopt, tile_view);
+  return std::make_shared<TileType>(output_shape, result_dtype, std::nullopt, tile_view, MemorySpace::Acc);
 }
 
 TypePtr DeduceTileMatMulBiasType(const std::vector<ExprPtr>& args,
@@ -254,9 +254,15 @@ TypePtr DeduceTileMatMulBiasType(const std::vector<ExprPtr>& args,
   CHECK(result_dtype) << "The operator " << op_name << " requires compatible bias data type, but got "
                       << lhs_rhs_dtype->ToString() << " and " << bias_type->dtype_.ToString();
 
+  // Acc layout (Nz) — as in tile.matmul. This deducer previously left the view at
+  // the struct default (row_major/none_box) and reached the Acc layout only
+  // because a fully-valid view collapses to nullopt and the registry's
+  // memory-space stamp re-canonicalized it against Acc's implicit view.
   TileView tile_view;
+  tile_view_semantics::SetTileLayout(
+      tile_view, tile_view_semantics::GetImplicitTileLayout(output_shape, MemorySpace::Acc));
   tile_view.valid_shape = output_shape;
-  return std::make_shared<TileType>(output_shape, *result_dtype, std::nullopt, tile_view);
+  return std::make_shared<TileType>(output_shape, *result_dtype, std::nullopt, tile_view, MemorySpace::Acc);
 }
 
 // ============================================================================

--- a/src/ir/op/tile_ops/memory.cpp
+++ b/src/ir/op/tile_ops/memory.cpp
@@ -409,30 +409,38 @@ TypePtr DeduceTileMoveType(const std::vector<ExprPtr>& args,
 
   const TileView source_view = tile_view_semantics::GetEffectiveTileView(*tile_type);
 
-  // blayout/slayout follow the source — a move preserves the logical layout —
-  // but `fractal` is the destination buffer's boxing granularity, not a source
-  // property, so it comes from the destination space. See
+  // A move retargets the tile, so where the destination has a layout of its own
+  // (Mat/Acc/L0/scale are boxed) that layout -- not the source's -- is what the
+  // result carries.  Seeding blayout/slayout from the source instead recovered
+  // the destination layout only as a side effect of canonicalizing against
+  // nullopt here and re-canonicalizing against the real space in
+  // OpRegistry::Create, which only fires when the view collapses (valid_shape ==
+  // shape and pad null) -- so the result layout silently depended on the tile's
+  // valid extent.
+  //
+  // Where the destination's layout coincides with the space-agnostic one (Vec
+  // and the other flat spaces) that double canonicalization was a no-op, so
+  // those keep the source's blayout/slayout: a Mat->Vec move deliberately
+  // carries the source's layout today.  fractal is never inherited -- it is the
+  // destination buffer's boxing granularity.  See
   // docs/en/dev/ir/05-operators.md "Result view of tile.move".
-  TileView tile_view;
-  tile_view.blayout = source_view.blayout;
-  tile_view.slayout = source_view.slayout;
-  tile_view.fractal = tile_view_semantics::GetImplicitFractal(space);
+  const auto dst_layout = tile_view_semantics::GetImplicitTileLayout(input_shape, space);
+  const bool destination_dictates_layout =
+      dst_layout != tile_view_semantics::GetImplicitTileLayout(input_shape, std::nullopt);
 
-  // Hardcoded layout for Left/Right/scale (hardware requirements; their fractal
-  // already comes from the destination-implicit seed above)
-  if (space == MemorySpace::Left) {
-    tile_view.blayout = TileLayout::col_major;  // L0A requires ColMajor block layout for TMATMUL
-    tile_view.slayout = TileLayout::row_major;
-  } else if (space == MemorySpace::Right) {
+  TileView tile_view;
+  tile_view_semantics::SetTileLayout(tile_view, dst_layout);
+  if (!destination_dictates_layout) {
+    tile_view.blayout = source_view.blayout;
+    tile_view.slayout = source_view.slayout;
+  }
+
+  // Right is the one destination whose ISA layout is not its implicit one: L0B
+  // requires a RowMajor block layout for TMATMUL even on an [N,1] shape, whose
+  // implicit blayout is col_major.  Left and the scale spaces need no override --
+  // GetImplicitTileLayout already returns their ISA layouts.
+  if (space == MemorySpace::Right) {
     tile_view.blayout = TileLayout::row_major;
-    tile_view.slayout = TileLayout::col_major;
-  } else if (space == MemorySpace::LeftScale) {
-    // fractal is already kMXScaleFractal via the destination-implicit seed above.
-    tile_view.blayout = TileLayout::row_major;
-    tile_view.slayout = TileLayout::row_major;
-  } else if (space == MemorySpace::RightScale) {
-    tile_view.blayout = TileLayout::col_major;
-    tile_view.slayout = TileLayout::col_major;
   }
 
   // Ordinary destinations permit explicit layouts. Scale destinations have
@@ -485,14 +493,9 @@ TypePtr DeduceTileMoveType(const std::vector<ExprPtr>& args,
     }
   }
 
-  // Stamp memory_space_ only for MX scale destinations. Stamping Mat/Left/Right
-  // here skips InferTileMemorySpace's tile_view refresh to the destination's
-  // implicit layout and regresses existing Vec↔Mat / matmul / rmsnorm paths.
-  if (space == MemorySpace::LeftScale || space == MemorySpace::RightScale) {
-    return std::make_shared<TileType>(output_shape, out_dtype, std::nullopt, tile_view, space);
-  }
-  // Return TileType with computed shape and same dtype (no explicit MemRef)
-  return std::make_shared<TileType>(output_shape, tile_type->dtype_, std::nullopt, tile_view);
+  // Stamp memory_space_ for every destination so the view is canonicalized once,
+  // against the space it is actually a view of (same contract as tile.load).
+  return std::make_shared<TileType>(output_shape, out_dtype, std::nullopt, tile_view, space);
 }
 
 TypePtr DeduceTileAllocType(const std::vector<ExprPtr>& args,
@@ -595,18 +598,16 @@ TypePtr DeduceTileCreateTileType(const std::vector<ExprPtr>& args,
   if (flat_layout) {
     creation_space = MemorySpace::Mat;
   } else if (target_memory_opt.has_value() && *target_memory_opt == MemorySpace::Acc) {
-    tile_view.blayout = TileLayout::col_major;
-    tile_view.slayout = TileLayout::row_major;
-    tile_view.fractal = 1024;
+    // Acc's boxed NZ layout, stamped so the view is canonicalized against the
+    // space it is a view of rather than against nullopt (see 02-types.md).
+    tile_view_semantics::SetTileLayout(
+        tile_view, tile_view_semantics::GetImplicitTileLayout(tile_shape, MemorySpace::Acc));
+    creation_space = MemorySpace::Acc;
   } else if (transpose_layout) {
     tile_view.blayout = TileLayout::row_major;
     tile_view.slayout = TileLayout::col_major;
-  } else if (tile_shape.size() == 2) {
-    auto rows_const = As<ConstInt>(tile_shape[0]);
-    auto cols_const = As<ConstInt>(tile_shape[1]);
-    if (rows_const && cols_const && rows_const->value_ > 1 && cols_const->value_ == 1) {
-      tile_view.blayout = TileLayout::col_major;
-    }
+  } else {
+    tile_view.blayout = tile_view_semantics::InferImplicitTileLayoutFromShape(tile_shape);
   }
   tile_view.valid_shape = tile_shape;
   return std::make_shared<TileType>(tile_shape, dtype, std::nullopt, tile_view, creation_space);

--- a/src/ir/op/tile_ops/transform.cpp
+++ b/src/ir/op/tile_ops/transform.cpp
@@ -81,19 +81,6 @@ int64_t ComputeShapeProduct(const std::vector<ExprPtr>& shape) {
   return product;
 }
 
-TileLayout InferTileLayoutFromShape(const std::vector<ExprPtr>& shape) {
-  if (shape.size() != 2) {
-    return TileLayout::row_major;
-  }
-
-  auto rows_const = As<ConstInt>(shape[0]);
-  auto cols_const = As<ConstInt>(shape[1]);
-  if (!rows_const || !cols_const) {
-    return TileLayout::row_major;
-  }
-  return (cols_const->value_ == 1 && rows_const->value_ > 1) ? TileLayout::col_major : TileLayout::row_major;
-}
-
 /**
  * @brief Validate that all elements of a TupleType are ScalarType with an index-like dtype
  *
@@ -257,7 +244,7 @@ TypePtr DeduceTileSliceType(const std::vector<ExprPtr>& args,
     tile_view.fractal = src_v.fractal;
     tile_view.pad = src_v.pad;
   } else {
-    tile_view.blayout = InferTileLayoutFromShape(new_shape);
+    tile_view.blayout = tile_view_semantics::InferImplicitTileLayoutFromShape(new_shape);
   }
   tile_view.valid_shape = valid_shape;
 
@@ -340,7 +327,7 @@ TypePtr DeduceTileReshapeType(const std::vector<ExprPtr>& args,
                                source_view.blayout == TileLayout::row_major, args[0]->span_, "tile.reshape");
   tile_view.pad = source_view.pad;
 
-  tile_view.blayout = InferTileLayoutFromShape(new_shape);
+  tile_view.blayout = tile_view_semantics::InferImplicitTileLayoutFromShape(new_shape);
 
   return std::make_shared<TileType>(new_shape, tile_type->dtype_, std::nullopt, tile_view);
 }
@@ -751,27 +738,33 @@ TypePtr DeduceTileExtractType(const std::vector<ExprPtr>& args,
       "ISA TEXTRACT bounds are hard, so the window must fit inside the source tile",
       /*span=*/args[0]->span_,
   });
-  tile_view.blayout = InferTileLayoutFromShape(dst_shape);
+  // The destination memory dictates the layout, so seed from its implicit view.
+  // The default mirrors `set_output_memory_from_kwarg("target_memory", Vec)`
+  // registered below; since this deducer now always stamps the space itself,
+  // that registry fallback is unreachable for tile.extract and the two only have
+  // to agree on the default.
+  const MemorySpace target = GetKwargOr<MemorySpace>(kwargs, "target_memory", MemorySpace::Vec);
+
+  tile_view_semantics::SetTileLayout(tile_view,
+                                     tile_view_semantics::GetImplicitTileLayout(dst_shape, target));
 
   // Override blayout/slayout for L0-resident destinations to match the
   // architectural layouts the A2/A3 `pto.textract` codegen verifier
-  // expects.  Mat/other targets keep the inferred default.  These
+  // expects.  Mat/other targets keep the destination's implicit layout.  These
   // hardcoded layouts mirror the L0A/L0B formats the hardware imposes on
   // TEXTRACT outputs (and differ from `tile.move`'s TMOV-side L0 formats).
-  for (const auto& [k, v] : kwargs) {
-    if (k != "target_memory") continue;
-    auto target = AnyCast<MemorySpace>(v, "kwarg key: target_memory");
-    if (target == MemorySpace::Left) {
-      tile_view.blayout = TileLayout::row_major;
-      tile_view.slayout = TileLayout::row_major;
-    } else if (target == MemorySpace::Right) {
-      tile_view.blayout = TileLayout::row_major;
-      tile_view.slayout = TileLayout::col_major;
-    }
-    break;
+  if (target == MemorySpace::Left) {
+    tile_view.blayout = TileLayout::row_major;
+    tile_view.slayout = TileLayout::row_major;
+  } else if (target == MemorySpace::Right) {
+    tile_view.blayout = TileLayout::row_major;
+    tile_view.slayout = TileLayout::col_major;
   }
 
-  return std::make_shared<TileType>(dst_shape, src_type->dtype_, std::nullopt, tile_view);
+  // Canonicalize the view once, against the space it is actually a view of --
+  // not against nullopt, which would let OpRegistry::Create re-interpret a
+  // collapsed view under a different space's implicit layout.
+  return std::make_shared<TileType>(dst_shape, src_type->dtype_, std::nullopt, tile_view, target);
 }
 
 REGISTER_OP("tile.extract")

--- a/tests/ut/ir/operators/test_tile_ops.py
+++ b/tests/ut/ir/operators/test_tile_ops.py
@@ -33,10 +33,14 @@ def _tile_result_dtype(call: ir.Call) -> DataType:
     return result_type.dtype
 
 
-def _partial_tile(shape, valid_shape, pad=ir.PadValue.null, name="src"):
-    """A tile Var whose tile_view narrows it to `valid_shape`."""
+def _partial_tile(shape, valid_shape, pad=ir.PadValue.null, name="src", **view_kwargs):
+    """A tile Var whose tile_view narrows it to `valid_shape`.
+
+    Extra keyword arguments (blayout, slayout, fractal) are forwarded to the
+    TileView, for callers that need a source with a specific layout.
+    """
     span = ir.Span.unknown()
-    view = ir.TileView(valid_shape=valid_shape, stride=[], start_offset=None, pad=pad)
+    view = ir.TileView(valid_shape=valid_shape, stride=[], start_offset=None, pad=pad, **view_kwargs)
     return ir.Var(name, ir.TileType(shape, DataType.FP32, tile_view=view), span)
 
 
@@ -4130,23 +4134,18 @@ class TestTileMoveOp:
         assert call.type.tile_view is None
         assert call.type.get_effective_tile_view().fractal == expected_fractal
 
-    @pytest.mark.parametrize(
-        ("source_space", "view_stored"),
-        [
-            # Mat's layout triple differs from Acc's only in fractal, so adopting
-            # the destination's 1024 lands exactly on Acc's implicit view.
-            (ir.MemorySpace.Mat, False),
-            # Vec's blayout/slayout follow the source, so the view stays explicit —
-            # but fractal is still the destination's.
-            (ir.MemorySpace.Vec, True),
-        ],
-    )
-    def test_move_into_acc_adopts_acc_fractal_from_non_acc_source(self, source_space, view_stored):
-        """A 512-fractal source moved into Acc must report Acc's 1024.
+    @pytest.mark.parametrize("source_space", [ir.MemorySpace.Mat, ir.MemorySpace.Vec])
+    def test_move_into_acc_adopts_acc_layout_from_non_acc_source(self, source_space):
+        """A 512-fractal source moved into Acc must report Acc's full NZ view.
 
-        The same-space cases above cannot show this: an Acc source already has
-        fractal 1024, so they pass even if the result wrongly inherited it from
-        the source instead of taking it from the destination."""
+        The same-space cases above cannot show this: an Acc source already
+        carries Acc's layout, so they pass even if the result wrongly inherited
+        it from the source instead of taking it from the destination.
+
+        Acc dictates blayout/slayout as well as fractal — a tile living in L0C is
+        NZ-boxed whatever it was moved from — so the deduced view is exactly
+        Acc's implicit view and is stored canonically as None, for any source.
+        """
         source = self._tile_var(source_space)
         source_type = source.type
         assert isinstance(source_type, ir.TileType)
@@ -4156,8 +4155,13 @@ class TestTileMoveOp:
 
         assert isinstance(call.type, ir.TileType)
         assert call.type.memory_space == ir.MemorySpace.Acc
-        assert (call.type.tile_view is not None) == view_stored
-        assert call.type.get_effective_tile_view().fractal == 1024
+        assert call.type.tile_view is None
+        eff = call.type.get_effective_tile_view()
+        assert (eff.blayout, eff.slayout, eff.fractal) == (
+            ir.TileLayout.col_major,
+            ir.TileLayout.row_major,
+            1024,
+        )
 
     def test_acc_to_vec_move_keeps_vec_fractal(self):
         """Moving out of Acc must adopt Vec's granularity, not carry 1024 along:
@@ -5459,6 +5463,198 @@ class TestWindowReadValidRegion:
 
         # rows: clamp(40 - 16, 0, 32) = 24;  cols: clamp(100 - 64, 0, 32) = 32
         assert _valid_of(call.type) == [24, 32]
+
+
+class TestDestinationSpaceLayoutDeduction:
+    """A retargeting op's result layout comes from the DESTINATION memory space.
+
+    tile.move / tile.extract used to deduce the result view against a nullopt
+    memory space and let OpRegistry::Create stamp the real space by rebuilding
+    the TileType -- which re-ran CanonicalizeTileViewInPlace against a different
+    implicit view. Since the collapse to nullopt only fires when the view is
+    fully valid and unpadded, the destination layout silently depended on the
+    tile's valid extent: a fully-valid Vec->Mat move got Mat's boxed NZ layout,
+    while the same move on a ragged tile kept Vec's flat row_major/none_box.
+
+    The layout must depend only on (shape, destination space).
+    """
+
+    # Destination space -> the (blayout, slayout, fractal) a tile living there
+    # must carry. Acc is the one destination with a non-default fractal, so it
+    # also pins that fractal comes from the destination and is never inherited.
+    _BOXED_DESTINATIONS = [
+        (ir.MemorySpace.Mat, ir.TileLayout.col_major, ir.TileLayout.row_major, 512),
+        (ir.MemorySpace.Left, ir.TileLayout.col_major, ir.TileLayout.row_major, 512),
+        (ir.MemorySpace.Right, ir.TileLayout.row_major, ir.TileLayout.col_major, 512),
+        (ir.MemorySpace.Acc, ir.TileLayout.col_major, ir.TileLayout.row_major, 1024),
+    ]
+
+    @staticmethod
+    def _layout_of(result_type):
+        eff = result_type.get_effective_tile_view()
+        return (eff.blayout, eff.slayout, eff.fractal)
+
+    # --- tile.move ----------------------------------------------------------
+
+    @pytest.mark.parametrize("space,blayout,slayout,fractal", _BOXED_DESTINATIONS)
+    def test_move_layout_is_independent_of_the_source_valid_extent(self, space, blayout, slayout, fractal):
+        """A narrower valid_shape must not change where the result's layout comes from."""
+        span = ir.Span.unknown()
+        full = ir.Var("full", ir.TileType([64, 64], DataType.FP32), span)
+        ragged = _partial_tile([64, 64], [64, 48])
+
+        full_layout = self._layout_of(tile.move(full, target_memory=space).type)
+        ragged_layout = self._layout_of(tile.move(ragged, target_memory=space).type)
+
+        assert full_layout == ragged_layout == (blayout, slayout, fractal)
+
+    @pytest.mark.parametrize("space,blayout,slayout,fractal", _BOXED_DESTINATIONS)
+    def test_move_layout_is_independent_of_the_source_pad(self, space, blayout, slayout, fractal):
+        """pad is the other reason a view cannot collapse -- same rule applies."""
+        padded = _partial_tile([64, 64], [64, 64], pad=ir.PadValue.zero)
+
+        assert self._layout_of(tile.move(padded, target_memory=space).type) == (blayout, slayout, fractal)
+
+    def test_move_narrowing_the_source_still_narrows_the_result(self):
+        """Fixing the layout must not drop the valid extent the move carries over."""
+        ragged = _partial_tile([64, 64], [64, 48])
+
+        assert _valid_of(tile.move(ragged, target_memory=ir.MemorySpace.Mat).type) == [64, 48]
+
+    def test_move_to_right_keeps_row_major_for_a_column_vector(self):
+        """L0B needs a RowMajor block layout even where the implicit one is col_major.
+
+        A `[N, 1]` shape infers blayout=col_major, so `Right` is the one
+        destination that still needs an explicit override on top of its implicit
+        layout -- this is the case that justifies keeping it.
+        """
+        span = ir.Span.unknown()
+        col_vector = ir.Var("v", ir.TileType([64, 1], DataType.FP32), span)
+
+        assert self._layout_of(tile.move(col_vector, target_memory=ir.MemorySpace.Right).type) == (
+            ir.TileLayout.row_major,
+            ir.TileLayout.col_major,
+            512,
+        )
+
+    @pytest.mark.parametrize("space", [d[0] for d in _BOXED_DESTINATIONS])
+    def test_move_stamps_the_destination_memory_space(self, space):
+        """The deduced type is a view OF the destination, so it must say so."""
+        result_type = tile.move(_partial_tile([64, 64], [64, 48]), target_memory=space).type
+
+        assert isinstance(result_type, ir.TileType)
+        assert result_type.memory_space == space
+
+    # Vec and Bias share the space-agnostic implicit layout, so they take the
+    # source-inherited seed. `destination_dictates_layout` compares layouts
+    # rather than naming Vec, so pin both: a future change to either entry in
+    # GetImplicitTileLayout must not silently flip this.
+    @pytest.mark.parametrize("space", [ir.MemorySpace.Vec, ir.MemorySpace.Bias])
+    @pytest.mark.parametrize("valid", [None, [64, 48]], ids=["full-valid", "part-valid"])
+    def test_move_to_a_flat_space_inherits_the_source_layout(self, space, valid):
+        """A flat destination keeps the source's blayout/slayout, whatever its extent."""
+        src = _partial_tile(
+            [64, 64],
+            valid or [64, 64],
+            blayout=ir.TileLayout.col_major,
+            slayout=ir.TileLayout.row_major,
+        )
+
+        assert self._layout_of(tile.move(src, target_memory=space).type) == (
+            ir.TileLayout.col_major,
+            ir.TileLayout.row_major,
+            512,
+        )
+
+    def test_move_explicit_layout_kwargs_still_win(self):
+        """blayout/slayout are user overrides and outrank the destination default."""
+        ragged = _partial_tile([64, 64], [64, 48])
+
+        call = tile.move(
+            ragged,
+            target_memory=ir.MemorySpace.Mat,
+            blayout=ir.TileLayout.row_major,
+            slayout=ir.TileLayout.col_major,
+        )
+
+        assert self._layout_of(call.type)[:2] == (ir.TileLayout.row_major, ir.TileLayout.col_major)
+
+    # --- tile.extract -------------------------------------------------------
+
+    @pytest.mark.parametrize(
+        "space,blayout,slayout,fractal",
+        [
+            # L0 destinations use the TEXTRACT-side formats, not tile.move's TMOV ones.
+            (ir.MemorySpace.Left, ir.TileLayout.row_major, ir.TileLayout.row_major, 512),
+            (ir.MemorySpace.Right, ir.TileLayout.row_major, ir.TileLayout.col_major, 512),
+            (ir.MemorySpace.Mat, ir.TileLayout.col_major, ir.TileLayout.row_major, 512),
+            (ir.MemorySpace.Vec, ir.TileLayout.row_major, ir.TileLayout.none_box, 512),
+            # Acc is reachable via LowerPipelineLoops; the deducer has no Acc
+            # branch of its own, so this pins that the Acc NZ view (including
+            # fractal 1024) comes from the destination's implicit view.
+            (ir.MemorySpace.Acc, ir.TileLayout.col_major, ir.TileLayout.row_major, 1024),
+        ],
+    )
+    def test_extract_layout_is_independent_of_the_source_valid_extent(self, space, blayout, slayout, fractal):
+        """Whether the window lands on source padding must not flip the layout."""
+        span = ir.Span.unknown()
+        full = ir.Var("full", ir.TileType([64, 256], DataType.FP32), span)
+        ragged = _partial_tile([64, 256], [64, 100])
+
+        # Same window; over the ragged source it straddles the valid edge (cols
+        # 64..96 vs valid 100 -> 32) versus (cols 96..128 -> 4), so the ragged
+        # result cannot collapse to an implicit view.
+        full_layout = self._layout_of(tile.extract(full, 0, 96, shape=[32, 32], target_memory=space).type)
+        ragged_layout = self._layout_of(tile.extract(ragged, 0, 96, shape=[32, 32], target_memory=space).type)
+
+        assert full_layout == ragged_layout == (blayout, slayout, fractal)
+
+    @pytest.mark.parametrize(
+        "space",
+        [ir.MemorySpace.Left, ir.MemorySpace.Right, ir.MemorySpace.Mat, ir.MemorySpace.Vec],
+    )
+    def test_extract_stamps_the_destination_memory_space(self, space):
+        """Same contract as tile.load: the type names the space it is a view of."""
+        span = ir.Span.unknown()
+        src = ir.Var("src", ir.TileType([64, 256], DataType.FP32), span)
+
+        result_type = tile.extract(src, 0, 0, shape=[32, 32], target_memory=space).type
+
+        assert isinstance(result_type, ir.TileType)
+        assert result_type.memory_space == space
+
+    # --- matmul family ------------------------------------------------------
+
+    def test_matmul_family_carries_the_acc_layout_and_space(self):
+        """Every matmul deducer must state the Acc NZ view, not reach it by accident.
+
+        These ops declare `set_output_memory(MemorySpace::Acc)`, and
+        `tile.matmul_bias` in particular used to leave the view at the struct
+        default (row_major/none_box/512) and land on the Acc layout only because a
+        fully-valid view collapses to nullopt and the registry's memory-space
+        stamp re-canonicalized it against Acc's implicit view.
+        """
+        span = ir.Span.unknown()
+        lhs = ir.Var("lhs", ir.TileType([16, 32], DataType.FP16), span)
+        rhs = ir.Var("rhs", ir.TileType([32, 64], DataType.FP16), span)
+        acc = ir.Var("acc", ir.TileType([16, 64], DataType.FP32), span)
+        bias = ir.Var("bias", ir.TileType([1, 64], DataType.FP32), span)
+        b_lhs = ir.Var("b_lhs", ir.TileType([4, 16, 32], DataType.FP16), span)
+        b_rhs = ir.Var("b_rhs", ir.TileType([4, 32, 64], DataType.FP16), span)
+        b_acc = ir.Var("b_acc", ir.TileType([4, 16, 64], DataType.FP32), span)
+
+        acc_nz = (ir.TileLayout.col_major, ir.TileLayout.row_major, 1024)
+        for name, call in (
+            ("matmul", tile.matmul(lhs, rhs)),
+            ("matmul_acc", tile.matmul_acc(acc, lhs, rhs)),
+            ("matmul_bias", tile.matmul_bias(lhs, rhs, bias)),
+            ("batch_matmul", tile.batch_matmul(b_lhs, b_rhs)),
+            ("batch_matmul_acc", tile.batch_matmul_acc(b_acc, b_lhs, b_rhs)),
+        ):
+            result_type = call.type
+            assert isinstance(result_type, ir.TileType), name
+            assert result_type.memory_space == ir.MemorySpace.Acc, name
+            assert self._layout_of(result_type) == acc_nz, name
 
 
 class TestWriteValidRegionUnion:


### PR DESCRIPTION
## Summary

`tile.move` and `tile.extract` built their result `TileType` with
`memory_space = nullopt`, so the `TileType` constructor canonicalized the deduced
`tile_view` against the **space-agnostic** implicit view. `OpRegistry::Create`
(`src/ir/op_registry.cpp:193`) then stamped the real space by *rebuilding* the
type from the already-canonicalized view — running canonicalization a second
time, against a **different** implicit view.

A view only collapses when `valid_shape == shape` and `pad` is null, so the
result's layout silently depended on the tile's valid extent. Two `pl.move(...,
target_memory=Mat)` calls differing only in the source's `valid_shape`:

```python
t = pl.load(x, [0, 0], [64, 64])                         # valid == shape
m = pl.move(t, target_memory=pl.MemorySpace.Mat)
#   m: pl.Tile[[64,64], pl.FP16, pl.Mem.Mat]
#   effective blayout=col_major slayout=row_major        <- Mat NZ (boxed)

t = pl.load(x, [0, 0], [64, 64], valid_shapes=[64, 48])  # ragged tail
m = pl.move(t, target_memory=pl.MemorySpace.Mat)
#   m: pl.Tile[[64,64], pl.FP16, pl.Mem.Mat,
#              pl.TileView(valid_shape=[64,48], blayout=row_major, slayout=none_box)]
#   effective blayout=row_major slayout=none_box         <- Vec flat, on an L1 tile
```

`tile.extract` shows the same split for `target_memory=Mat`/`Acc`, which also
makes its own comment ("Mat/other targets keep the inferred default") false — the
inferred default is discarded on the fully-valid path.

`tile.load` already did this correctly, and documents the contract at
`src/ir/op/tile_ops/memory.cpp`: pass the space so "the constructed type is
internally coherent (tile_view layout and memory_space agree)".

## Fix

Each deducer seeds its layout from the destination space's implicit layout and
stamps that space itself, so the view is canonicalized **once**, against the
space it is actually a view of. Flat destinations (`Vec`, `Bias`) keep the
source's `blayout`/`slayout` — their implicit layout *is* the space-agnostic one,
so that direction was never affected.

`Right` keeps a local override: L0B requires `blayout=row_major` even for an
`[N, 1]` shape, whose implicit `blayout` is `col_major`. `Left` and the scale
spaces no longer need one — the implicit table already returns their ISA layouts.

### Relationship to #2248

This extends #2248 from `fractal` to the whole layout. That change moved
`fractal` to the destination on the grounds that it "describes how the
destination buffer is boxed, not a property carried from the source" —
`blayout`/`slayout` describe the same thing. Deriving only `fractal` left a
`Vec→Acc` move reporting `slayout=none_box` alongside Acc's 1024-byte box size,
i.e. an L0C tile claiming to be unboxed:

| `pl.move(vec_tile, Acc)` | blayout/slayout | fractal |
| --- | --- | --- |
| before #2248 | `row_major/none_box` (source) | 512 (default) |
| after #2248 | `row_major/none_box` (source) | 1024 (destination) |
| this PR | `col_major/row_major` (destination) | 1024 (destination) |

`test_move_into_acc_adopts_acc_fractal_from_non_acc_source` is updated
accordingly (and renamed `..._layout_...`): the result is now exactly Acc's
implicit view for **any** source, so it collapses to `None` rather than staying
explicit. Its two sibling tests already asserted that collapse is the desired end
state.

Full source→destination matrix after this PR:

```
   Vec -> Vec      None      (row_major, none_box, 512)
   Vec -> Mat      None      (col_major, row_major, 512)
   Vec -> Acc      None      (col_major, row_major, 1024)
   Mat -> Vec      explicit  (col_major, row_major, 512)
   Mat -> Mat      None      (col_major, row_major, 512)
   Mat -> Acc      None      (col_major, row_major, 1024)
   Acc -> Vec      explicit  (col_major, row_major, 512)
   Acc -> Mat      None      (col_major, row_major, 512)
   Acc -> Acc      None      (col_major, row_major, 1024)
```

## Also swept onto the same source of truth

`tile.matmul`, `tile.matmul_acc`, `tile.matmul_bias`, `tile.batch_matmul`,
`tile.batch_matmul_acc` and `tile.create`'s `Acc` branch hand-wrote the Acc NZ
triple and built against `nullopt` despite declaring
`set_output_memory(MemorySpace::Acc)`. They now derive it from
`GetImplicitTileLayout` and stamp `Acc`. `tile.matmul_bias` set **no** layout at
all and reached Acc's only through the same laundering.

Adds `TileLayoutSpec` / `GetImplicitTileLayout` / `SetTileLayout` to
`tile_view_semantics.h` so the space→layout table has one definition and callers
needing only the layout skip the `valid_shape` copy. Fractal is delegated to
#2248's `GetImplicitFractal` so the two cannot drift. Removes `transform.cpp`'s
verbatim duplicate of `InferImplicitTileLayoutFromShape`.

## Testing

- [x] `tests/ut/` — 8611 passed, 2 skipped, 1 failed. The failure,
      `test_ir_trace.py::test_installed_console_script_preserves_main_exit_codes`,
      is environmental (asserts a pip-installed `pypto-ir-trace` console script)
      and fails identically on an unmodified tree.
- [x] clang-tidy on the diff — clean
- [x] All 15 pre-commit hooks (clang-format, cpplint, ruff, pyright,
      markdownlint, en/zh doc parity)
- [x] Documentation updated (`docs/{en,zh}/dev/ir/02-types.md` for the
      constructor contract, `05-operators.md` for the now-stale `tile.move`
      result-view table)

New coverage — `TestDestinationSpaceLayoutDeduction` (29 cases): the effective
layout is a function of `(shape, destination space)` alone, independent of the
source's `valid_shape` and `pad`, with the narrowed valid extent still carried
through, the space stamped, the flat-space carve-out pinned for both `Vec` and
`Bias`, `blayout`/`slayout` kwarg overrides still winning, the `[N,1]` `Right`
case that justifies the last override, and the matmul family's Acc layout.
Reverting the fix fails 4 of them.

## Known follow-ups (not in this PR)

- `tile.aic_gather` (`src/ir/op/tile_ops/cross_core.cpp:153`) has a fixed `Mat`
  output but still deduces against `nullopt`, so it keeps the extent-dependence
  this PR removes elsewhere.
- `Right`'s ISA `blayout` could move into `GetImplicitTileLayout` to delete the
  last local override, but that changes what every other consumer of the implicit
  table sees for an `[N,1]` Right tile, including `InferTileMemorySpace`.
- `Mat→Vec` / `Acc→Vec` still carry a boxed layout onto a flat UB tile — the same
  incoherence in the other direction, pinned by existing tests and left alone.