### PR TITLE
test(ir): Pin transform tests with structural goldens, not IR substrings

### DIFF
--- a/tests/ut/ir/transforms/test_auto_tile_matmul_l0.py
+++ b/tests/ut/ir/transforms/test_auto_tile_matmul_l0.py
@@ -639,6 +639,22 @@ def _lower_to_tile_ops(program):
     return program
 
 
+def _assert_unchanged_by_pass(before, after):
+    """Assert ``AutoTileMatmulL0`` left ``before`` structurally unchanged.
+
+    ``after`` is the pass run over the lowered ``before``. The golden is a FRESH
+    prerequisite-only lowering of ``before``: the pass under test never runs on the
+    right-hand side, and the golden is not the same object the pass was handed, so
+    neither a rewrite nor an in-place mutation can cancel out on both sides.
+
+    Use this for the ``..._not_folded`` guards: they assert the pass *declines*
+    to rewrite, so the whole program is the oracle. A substring probe for one op
+    cannot distinguish those cases from each other -- every ``_not_folded`` body
+    prints both ``pl.tile.cast(`` and no ``pl.tile.assemble(``.
+    """
+    ir.assert_structural_equal(after, _lower_to_tile_ops(before))
+
+
 class TestAutoTileMatmulL0MNTiling:
     """M/N output tiling.
 
@@ -3243,10 +3259,12 @@ class TestAutoTileMatmulL0FitsL0cCastFold:
                 return out
 
         After = passes.auto_tile_matmul_l0()(_lower_to_tile_ops(Before))
-        printed = ir.python_print(After)
 
-        assert "pl.tile.cast(" in printed, "a non-matmul (store) consumer must keep the Vector cast"
-        assert "pl.tile.assemble(" not in printed, "the fold must not assemble into a Mat scratch"
+        # The pass must decline to rewrite anything: the Vector cast stays and no
+        # Mat-scratch assemble appears. Pinning the whole program (rather than
+        # grepping for those two ops) also catches an unrelated spurious rewrite.
+        # The positive counterpart is test_no_ksplit_cast_folds_to_full_window_assemble.
+        _assert_unchanged_by_pass(Before, After)
 
     def test_nondefault_round_mode_not_folded(self):
         """Guard: a fits-L0c chained cast with a directional round mode (e.g.
@@ -3274,10 +3292,10 @@ class TestAutoTileMatmulL0FitsL0cCastFold:
                 return out
 
         After = passes.auto_tile_matmul_l0()(_lower_to_tile_ops(Before))
-        printed = ir.python_print(After)
 
-        assert "pl.tile.cast(" in printed, "a non-default (floor) round mode must keep the Vector cast"
-        assert "pl.tile.assemble(" not in printed, "the floor cast must not fold into a Mat-scratch assemble"
+        # ``floor`` is unfoldable, so the whole chain must survive untouched --
+        # Vector cast kept, no Mat-scratch assemble, and no other rewrite either.
+        _assert_unchanged_by_pass(Before, After)
 
     def test_default_round_mode_not_folded(self):
         """Guard: the cast default mode is ``"round"`` (round-half-*away*), but FIXPIPE's
@@ -3305,10 +3323,10 @@ class TestAutoTileMatmulL0FitsL0cCastFold:
                 return out
 
         After = passes.auto_tile_matmul_l0()(_lower_to_tile_ops(Before))
-        printed = ir.python_print(After)
 
-        assert "pl.tile.cast(" in printed, "the default (round/ties-away) cast must keep the Vector cast"
-        assert "pl.tile.assemble(" not in printed, "the default cast must not fold into a Mat scratch"
+        # Default ``round`` (ties-away) is not FIXPIPE's ties-even, so the chain
+        # must survive untouched; only an explicit ``rint`` folds onto the cube.
+        _assert_unchanged_by_pass(Before, After)
 
     @pytest.mark.parametrize("backend", [BackendType.Ascend910B, BackendType.Ascend950])
     def test_cast_fold_lowers_cube_only_no_vector(self, backend):

--- a/tests/ut/ir/transforms/test_optimize_orch_tensors.py
+++ b/tests/ut/ir/transforms/test_optimize_orch_tensors.py
@@ -1488,16 +1488,125 @@ class Program:
                     score_out, topk_out = pl.yield_(score_rv, topk_next)
                 return score_out, topk_out
 
-        After = _run_to_optimize_orch_tensors(Before)
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def score_init(
+                self,
+                score: pl.Out[pl.Tensor[[4, 16], pl.FP32]],
+                t0: pl.Scalar[pl.INDEX],
+            ) -> pl.Tensor[[4, 16], pl.FP32]:
+                init_tile: pl.Tile[[2, 16], pl.FP32, pl.Mem.Vec] = pl.tile.full(
+                    [2, 16], dtype=pl.FP32, value=-1.0
+                )
+                score_next: pl.Tensor[[4, 16], pl.FP32] = pl.tile.store(init_tile, [t0, 0], score)
+                return score_next
 
-        printed_main = ir.python_print(_get_function(After, "main"))
-        assert "score_init__windowed" in printed_main
-        assert "score_init__windowed(score_iter__window" in printed_main
-        assert "score_writer__windowed" in printed_main
-        assert "score_writer__windowed(score_iter2__window" in printed_main
-        assert "topk_like(topk_iter, t0__ssa_v0, score_rv)" in printed_main
-        assert "topk_like__windowed" not in printed_main
-        assert "score_rv__window" not in printed_main
+            # Both score writers windowize: each writes a statically-shaped
+            # sub-region, so the row/col offset moves into the window.
+            @pl.function(type=pl.FunctionType.InCore)
+            def score_init__windowed(
+                self,
+                score: pl.Out[
+                    pl.Tensor[[2, 16], pl.FP32, pl.TensorView(stride=[16, 1], layout=pl.TensorLayout.ND)]
+                ],
+                t0: pl.Scalar[pl.INDEX],
+            ) -> pl.Tensor[[2, 16], pl.FP32, pl.TensorView(stride=[16, 1], layout=pl.TensorLayout.ND)]:
+                init_tile: pl.Tile[[2, 16], pl.FP32, pl.Mem.Vec] = pl.tile.full(
+                    [2, 16], dtype=pl.FP32, value=-1.0
+                )
+                score_next: pl.Tensor[
+                    [2, 16], pl.FP32, pl.TensorView(stride=[16, 1], layout=pl.TensorLayout.ND)
+                ] = pl.tile.store(init_tile, [0, 0], score)
+                return score_next
+
+            @pl.function(type=pl.FunctionType.InCore)
+            def score_writer(
+                self,
+                score: pl.Out[pl.Tensor[[4, 16], pl.FP32]],
+                t0: pl.Scalar[pl.INDEX],
+                cache0: pl.Scalar[pl.INDEX],
+            ) -> pl.Tensor[[4, 16], pl.FP32]:
+                score_tile: pl.Tile[[2, 4], pl.FP32, pl.Mem.Vec] = pl.tile.full(
+                    [2, 4], dtype=pl.FP32, value=1.0
+                )
+                score_next: pl.Tensor[[4, 16], pl.FP32] = pl.tile.store(score_tile, [t0, cache0], score)
+                return score_next
+
+            @pl.function(type=pl.FunctionType.InCore)
+            def score_writer__windowed(
+                self,
+                score: pl.Out[
+                    pl.Tensor[[2, 4], pl.FP32, pl.TensorView(stride=[16, 1], layout=pl.TensorLayout.ND)]
+                ],
+                t0: pl.Scalar[pl.INDEX],
+                cache0: pl.Scalar[pl.INDEX],
+            ) -> pl.Tensor[[2, 4], pl.FP32, pl.TensorView(stride=[16, 1], layout=pl.TensorLayout.ND)]:
+                score_tile: pl.Tile[[2, 4], pl.FP32, pl.Mem.Vec] = pl.tile.full(
+                    [2, 4], dtype=pl.FP32, value=1.0
+                )
+                score_next: pl.Tensor[
+                    [2, 4], pl.FP32, pl.TensorView(stride=[16, 1], layout=pl.TensorLayout.ND)
+                ] = pl.tile.store(score_tile, [0, 0], score)
+                return score_next
+
+            # topk_like READS score at a dynamic row and is NOT cloned: no
+            # topk_like__windowed exists and `score_rv` is passed whole. That
+            # asymmetry -- writers windowed, reader full -- is the fact under test.
+            @pl.function(type=pl.FunctionType.InCore)
+            def topk_like(
+                self,
+                topk: pl.Out[pl.Tensor[[4, 16], pl.INT32]],
+                t0: pl.Scalar[pl.INDEX],
+                score: pl.Tensor[[4, 16], pl.FP32],
+            ) -> pl.Tensor[[4, 16], pl.INT32]:
+                invalid: pl.Tile[[1, 16], pl.INT32, pl.Mem.Vec] = pl.tile.full(
+                    [1, 16], dtype=pl.INT32, value=-1
+                )
+                topk_init: pl.Tensor[[4, 16], pl.INT32] = pl.tile.store(invalid, [t0, 0], topk)
+                score_row: pl.Tile[[1, 16], pl.FP32, pl.Mem.Vec] = pl.tile.load(
+                    score, [t0, 0], [1, 16], [1, 16], target_memory=pl.Mem.Vec
+                )
+                idx_tile: pl.Tile[[1, 16], pl.INT32, pl.Mem.Vec] = pl.tile.cast(
+                    score_row, target_type=pl.INT32
+                )
+                topk_next: pl.Tensor[[4, 16], pl.INT32] = pl.tile.store(idx_tile, [t0, 0], topk_init)
+                return topk_next
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                score: pl.Out[pl.Tensor[[4, 16], pl.FP32]],
+                topk: pl.Out[pl.Tensor[[4, 16], pl.INT32]],
+            ) -> tuple[pl.Tensor[[4, 16], pl.FP32], pl.Tensor[[4, 16], pl.INT32]]:
+                for b, (score_iter, topk_iter) in pl.parallel(2, init_values=(score, topk)):
+                    t0: pl.Scalar[pl.INDEX] = b * 2
+                    score_win: pl.Tensor[[2, 16], pl.FP32] = pl.tensor.slice(score_iter, [2, 16], [t0, 0])
+                    init_windowed: pl.Tensor[
+                        [2, 16], pl.FP32, pl.TensorView(stride=[16, 1], layout=pl.TensorLayout.ND)
+                    ] = self.score_init__windowed(score_win, t0)
+                    score_init_next: pl.Tensor[[4, 16], pl.FP32] = pl.tensor.assemble(
+                        score_iter, init_windowed, [t0, 0]
+                    )
+                    for cb, (score_iter2,) in pl.parallel(4, init_values=(score_init_next,)):
+                        cache0: pl.Scalar[pl.INDEX] = cb * 4
+                        score2_win: pl.Tensor[[2, 4], pl.FP32] = pl.tensor.slice(
+                            score_iter2, [2, 4], [t0, cache0]
+                        )
+                        writer_windowed: pl.Tensor[
+                            [2, 4], pl.FP32, pl.TensorView(stride=[16, 1], layout=pl.TensorLayout.ND)
+                        ] = self.score_writer__windowed(score2_win, t0, cache0)
+                        score_next: pl.Tensor[[4, 16], pl.FP32] = pl.tensor.assemble(
+                            score_iter2, writer_windowed, [t0, cache0]
+                        )
+                        score_rv = pl.yield_(score_next)
+                    # Full `score_rv` handed to the reader -- no slice, no clone.
+                    topk_next: pl.Tensor[[4, 16], pl.INT32] = self.topk_like(topk_iter, t0, score_rv)
+                    score_out, topk_out = pl.yield_(score_rv, topk_next)
+                return score_out, topk_out
+
+        After = _run_to_optimize_orch_tensors(Before)
+        ir.assert_structural_equal(After, _run_prereqs_only(Expected))
 
     def test_dynamic_indexed_reader_after_loop_carried_writer_keeps_full_parent(self):
         @pl.program
@@ -1543,12 +1652,81 @@ class Program:
                 result: pl.Tensor[[4, 64], pl.FP32] = self.cache_read(out, cache_rv, block_table)
                 return cache_rv, result
 
-        After = _run_to_optimize_orch_tensors(Before)
+        @pl.program
+        class Expected:
+            # The static-slot writer IS windowized: slot 7 is a compile-time constant.
+            @pl.function(type=pl.FunctionType.InCore)
+            def cache_write(
+                self,
+                cache: pl.Out[pl.Tensor[[1024, 64], pl.FP32]],
+                data: pl.Tensor[[1, 64], pl.FP32],
+                slot: pl.Scalar[pl.INDEX],
+            ) -> pl.Tensor[[1024, 64], pl.FP32]:
+                src: pl.Tile[[1, 64], pl.FP32, pl.Mem.Vec] = pl.tile.load(
+                    data, [0, 0], [1, 64], [1, 64], target_memory=pl.Mem.Vec
+                )
+                result: pl.Tensor[[1024, 64], pl.FP32] = pl.tile.store(src, [slot, 0], cache)
+                return result
 
-        printed_main = ir.python_print(_get_function(After, "main"))
-        assert "cache_read(out__ssa_v0, cache_next__ssa_v0, block_table__ssa_v0)" in printed_main
-        assert "cache_read__windowed" not in printed_main
-        assert "pl.tensor.slice(cache_next__ssa_v0, " not in printed_main
+            @pl.function(type=pl.FunctionType.InCore)
+            def cache_write__windowed(
+                self,
+                cache: pl.Out[
+                    pl.Tensor[[1, 64], pl.FP32, pl.TensorView(stride=[64, 1], layout=pl.TensorLayout.ND)]
+                ],
+                data: pl.Tensor[[1, 64], pl.FP32],
+                slot: pl.Scalar[pl.INDEX],
+            ) -> pl.Tensor[[1, 64], pl.FP32, pl.TensorView(stride=[64, 1], layout=pl.TensorLayout.ND)]:
+                src: pl.Tile[[1, 64], pl.FP32, pl.Mem.Vec] = pl.tile.load(
+                    data, [0, 0], [1, 64], [1, 64], target_memory=pl.Mem.Vec
+                )
+                result: pl.Tensor[
+                    [1, 64], pl.FP32, pl.TensorView(stride=[64, 1], layout=pl.TensorLayout.ND)
+                ] = pl.tile.store(src, [0, 0], cache)
+                return result
+
+            # The reader is NOT windowized and keeps the FULL [1024, 64] parent: its
+            # row offset comes from a runtime block_table read, so no static window
+            # can cover it. This is the fact under test.
+            @pl.function(type=pl.FunctionType.InCore)
+            def cache_read(
+                self,
+                out: pl.Out[pl.Tensor[[4, 64], pl.FP32]],
+                cache: pl.Tensor[[1024, 64], pl.FP32],
+                block_table: pl.Tensor[[4], pl.INT32],
+            ) -> pl.Tensor[[4, 64], pl.FP32]:
+                for sb, (out_iter,) in pl.range(0, 4, init_values=(out,)):
+                    pbid_i32: pl.Scalar[pl.INT32] = pl.tensor.read(block_table, [sb])
+                    pbid: pl.Scalar[pl.INDEX] = pl.cast(pbid_i32, target_type=pl.INDEX)
+                    row: pl.Scalar[pl.INDEX] = pbid * 128
+                    cache_tile: pl.Tile[[1, 64], pl.FP32, pl.Mem.Vec] = pl.tile.load(
+                        cache, [row, 0], [1, 64], [1, 64], target_memory=pl.Mem.Vec
+                    )
+                    out_next: pl.Tensor[[4, 64], pl.FP32] = pl.tile.store(cache_tile, [sb, 0], out_iter)
+                    out_rv = pl.yield_(out_next)
+                return out_rv
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                cache: pl.Out[pl.Tensor[[1024, 64], pl.FP32]],
+                data: pl.Tensor[[1, 64], pl.FP32],
+                block_table: pl.Tensor[[4], pl.INT32],
+                out: pl.Out[pl.Tensor[[4, 64], pl.FP32]],
+            ) -> tuple[pl.Tensor[[1024, 64], pl.FP32], pl.Tensor[[4, 64], pl.FP32]]:
+                # The trip-count-1 loop of ``Before`` is gone -- UnrollLoops (a
+                # prerequisite pass) removes it before OptimizeOrchTensors runs.
+                cache_win: pl.Tensor[[1, 64], pl.FP32] = pl.tensor.slice(cache, [1, 64], [7, 0])
+                windowed: pl.Tensor[
+                    [1, 64], pl.FP32, pl.TensorView(stride=[64, 1], layout=pl.TensorLayout.ND)
+                ] = self.cache_write__windowed(cache_win, data, 7)
+                cache_next: pl.Tensor[[1024, 64], pl.FP32] = pl.tensor.assemble(cache, windowed, [7, 0])
+                # Full parent passed to the reader -- no slice, no windowed clone.
+                result: pl.Tensor[[4, 64], pl.FP32] = self.cache_read(out, cache_next, block_table)
+                return cache_next, result
+
+        After = _run_to_optimize_orch_tensors(Before)
+        ir.assert_structural_equal(After, _run_prereqs_only(Expected))
 
     def test_dynamic_reader_fallback_is_parent_local(self):
         @pl.program
@@ -1608,14 +1786,118 @@ class Program:
                 result: pl.Tensor[[4, 64], pl.FP32] = self.cache_read(out, cache_next, block_table)
                 return cache_next, other_next, result
 
-        After = _run_to_optimize_orch_tensors(Before)
+        @pl.program
+        class Expected:
+            # Both static-slot writers windowize independently...
+            @pl.function(type=pl.FunctionType.InCore)
+            def cache_write(
+                self,
+                cache: pl.Out[pl.Tensor[[1024, 64], pl.FP32]],
+                data: pl.Tensor[[1, 64], pl.FP32],
+                slot: pl.Scalar[pl.INDEX],
+            ) -> pl.Tensor[[1024, 64], pl.FP32]:
+                src: pl.Tile[[1, 64], pl.FP32, pl.Mem.Vec] = pl.tile.load(
+                    data, [0, 0], [1, 64], [1, 64], target_memory=pl.Mem.Vec
+                )
+                result: pl.Tensor[[1024, 64], pl.FP32] = pl.tile.store(src, [slot, 0], cache)
+                return result
 
-        printed_main = ir.python_print(_get_function(After, "main"))
-        assert "cache_read(out__ssa_v0, cache_next__ssa_v0, block_table__ssa_v0)" in printed_main
-        assert "cache_read__windowed" not in printed_main
-        assert "unrelated_write__windowed" in printed_main
-        assert "other__ssa_v0__window" in printed_main
-        assert "pl.tensor.slice(other__ssa_v0" in printed_main
+            @pl.function(type=pl.FunctionType.InCore)
+            def cache_write__windowed(
+                self,
+                cache: pl.Out[
+                    pl.Tensor[[1, 64], pl.FP32, pl.TensorView(stride=[64, 1], layout=pl.TensorLayout.ND)]
+                ],
+                data: pl.Tensor[[1, 64], pl.FP32],
+                slot: pl.Scalar[pl.INDEX],
+            ) -> pl.Tensor[[1, 64], pl.FP32, pl.TensorView(stride=[64, 1], layout=pl.TensorLayout.ND)]:
+                src: pl.Tile[[1, 64], pl.FP32, pl.Mem.Vec] = pl.tile.load(
+                    data, [0, 0], [1, 64], [1, 64], target_memory=pl.Mem.Vec
+                )
+                result: pl.Tensor[
+                    [1, 64], pl.FP32, pl.TensorView(stride=[64, 1], layout=pl.TensorLayout.ND)
+                ] = pl.tile.store(src, [0, 0], cache)
+                return result
+
+            @pl.function(type=pl.FunctionType.InCore)
+            def unrelated_write(
+                self,
+                other: pl.Out[pl.Tensor[[16, 64], pl.FP32]],
+                data: pl.Tensor[[1, 64], pl.FP32],
+            ) -> pl.Tensor[[16, 64], pl.FP32]:
+                src: pl.Tile[[1, 64], pl.FP32, pl.Mem.Vec] = pl.tile.load(
+                    data, [0, 0], [1, 64], [1, 64], target_memory=pl.Mem.Vec
+                )
+                result: pl.Tensor[[16, 64], pl.FP32] = pl.tile.store(src, [3, 0], other)
+                return result
+
+            @pl.function(type=pl.FunctionType.InCore)
+            def unrelated_write__windowed(
+                self,
+                other: pl.Out[
+                    pl.Tensor[[1, 64], pl.FP32, pl.TensorView(stride=[64, 1], layout=pl.TensorLayout.ND)]
+                ],
+                data: pl.Tensor[[1, 64], pl.FP32],
+            ) -> pl.Tensor[[1, 64], pl.FP32, pl.TensorView(stride=[64, 1], layout=pl.TensorLayout.ND)]:
+                src: pl.Tile[[1, 64], pl.FP32, pl.Mem.Vec] = pl.tile.load(
+                    data, [0, 0], [1, 64], [1, 64], target_memory=pl.Mem.Vec
+                )
+                result: pl.Tensor[
+                    [1, 64], pl.FP32, pl.TensorView(stride=[64, 1], layout=pl.TensorLayout.ND)
+                ] = pl.tile.store(src, [0, 0], other)
+                return result
+
+            # ...but the dynamic reader keeps the FULL [1024, 64] parent. The fallback
+            # is parent-LOCAL: windowizing `cache` does not spill over onto `other`,
+            # and the unrelated writer is windowized regardless. That is the fact
+            # under test, and only whole-program equality pins both halves at once.
+            @pl.function(type=pl.FunctionType.InCore)
+            def cache_read(
+                self,
+                out: pl.Out[pl.Tensor[[4, 64], pl.FP32]],
+                cache: pl.Tensor[[1024, 64], pl.FP32],
+                block_table: pl.Tensor[[4], pl.INT32],
+            ) -> pl.Tensor[[4, 64], pl.FP32]:
+                for sb, (out_iter,) in pl.range(0, 4, init_values=(out,)):
+                    pbid_i32: pl.Scalar[pl.INT32] = pl.tensor.read(block_table, [sb])
+                    pbid: pl.Scalar[pl.INDEX] = pl.cast(pbid_i32, target_type=pl.INDEX)
+                    row: pl.Scalar[pl.INDEX] = pbid * 128
+                    cache_tile: pl.Tile[[1, 64], pl.FP32, pl.Mem.Vec] = pl.tile.load(
+                        cache, [row, 0], [1, 64], [1, 64], target_memory=pl.Mem.Vec
+                    )
+                    out_next: pl.Tensor[[4, 64], pl.FP32] = pl.tile.store(cache_tile, [sb, 0], out_iter)
+                    out_rv = pl.yield_(out_next)
+                return out_rv
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                cache: pl.Out[pl.Tensor[[1024, 64], pl.FP32]],
+                other: pl.Out[pl.Tensor[[16, 64], pl.FP32]],
+                data: pl.Tensor[[1, 64], pl.FP32],
+                block_table: pl.Tensor[[4], pl.INT32],
+                out: pl.Out[pl.Tensor[[4, 64], pl.FP32]],
+            ) -> tuple[
+                pl.Tensor[[1024, 64], pl.FP32],
+                pl.Tensor[[16, 64], pl.FP32],
+                pl.Tensor[[4, 64], pl.FP32],
+            ]:
+                cache_win: pl.Tensor[[1, 64], pl.FP32] = pl.tensor.slice(cache, [1, 64], [7, 0])
+                cache_windowed: pl.Tensor[
+                    [1, 64], pl.FP32, pl.TensorView(stride=[64, 1], layout=pl.TensorLayout.ND)
+                ] = self.cache_write__windowed(cache_win, data, 7)
+                cache_next: pl.Tensor[[1024, 64], pl.FP32] = pl.tensor.assemble(cache, cache_windowed, [7, 0])
+                other_win: pl.Tensor[[1, 64], pl.FP32] = pl.tensor.slice(other, [1, 64], [3, 0])
+                other_windowed: pl.Tensor[
+                    [1, 64], pl.FP32, pl.TensorView(stride=[64, 1], layout=pl.TensorLayout.ND)
+                ] = self.unrelated_write__windowed(other_win, data)
+                other_next: pl.Tensor[[16, 64], pl.FP32] = pl.tensor.assemble(other, other_windowed, [3, 0])
+                # Full parent to the dynamic reader -- no slice, no windowed clone.
+                result: pl.Tensor[[4, 64], pl.FP32] = self.cache_read(out, cache_next, block_table)
+                return cache_next, other_next, result
+
+        After = _run_to_optimize_orch_tensors(Before)
+        ir.assert_structural_equal(After, _run_prereqs_only(Expected))
 
     def test_guarded_dynamic_indexed_reader_keeps_full_parent(self):
         @pl.program
@@ -1893,14 +2175,113 @@ class Program:
                 row: pl.Scalar[pl.INDEX] = 0
                 return self.qk_norm_like(q_out, k_out, q_rv, k_rv, row)
 
-        After = _run_to_optimize_orch_tensors(Before)
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def qk_norm_like(
+                self,
+                q_out: pl.Out[pl.Tensor[[16, 5120], pl.FP32]],
+                k_out: pl.Out[pl.Tensor[[16, 1024], pl.FP32]],
+                q_proj: pl.Tensor[[16, 5120], pl.FP32],
+                k_proj: pl.Tensor[[16, 1024], pl.FP32],
+                row: pl.Scalar[pl.INDEX],
+            ) -> tuple[pl.Tensor[[16, 5120], pl.FP32], pl.Tensor[[16, 1024], pl.FP32]]:
+                for h, (q_iter, k_iter) in pl.range(8, init_values=(q_out, k_out)):
+                    q0: pl.Scalar[pl.INDEX] = h * 640
+                    k0: pl.Scalar[pl.INDEX] = h * 128
+                    q_tile: pl.Tile[[16, 640], pl.FP32, pl.Mem.Vec] = pl.tile.load(
+                        q_proj, [row, q0], [16, 640], [16, 640], target_memory=pl.Mem.Vec
+                    )
+                    k_tile: pl.Tile[[16, 128], pl.FP32, pl.Mem.Vec] = pl.tile.load(
+                        k_proj, [row, k0], [16, 128], [16, 128], target_memory=pl.Mem.Vec
+                    )
+                    q_next: pl.Tensor[[16, 5120], pl.FP32] = pl.tile.store(q_tile, [row, q0], q_iter)
+                    k_next: pl.Tensor[[16, 1024], pl.FP32] = pl.tile.store(k_tile, [row, k0], k_iter)
+                    q_norm, k_norm = pl.yield_(q_next, k_next)
+                return q_norm, k_norm
 
-        printed_main = ir.python_print(_get_function(After, "main"))
-        assert "qk_norm_like__windowed" in printed_main
-        assert "pl.tensor.slice(q_proj" in printed_main
-        assert "pl.tensor.slice(k_proj" in printed_main
-        assert "pl.tensor.slice(q_rv" not in printed_main
-        assert "pl.tensor.slice(k_rv" not in printed_main
+            # The windowed clone reads at row 0: the window absorbed the row offset.
+            @pl.function(type=pl.FunctionType.InCore)
+            def qk_norm_like__windowed(
+                self,
+                q_out: pl.Out[
+                    pl.Tensor[[16, 5120], pl.FP32, pl.TensorView(stride=[5120, 1], layout=pl.TensorLayout.ND)]
+                ],
+                k_out: pl.Out[
+                    pl.Tensor[[16, 1024], pl.FP32, pl.TensorView(stride=[1024, 1], layout=pl.TensorLayout.ND)]
+                ],
+                q_proj: pl.Tensor[
+                    [16, 5120], pl.FP32, pl.TensorView(stride=[5120, 1], layout=pl.TensorLayout.ND)
+                ],
+                k_proj: pl.Tensor[
+                    [16, 1024], pl.FP32, pl.TensorView(stride=[1024, 1], layout=pl.TensorLayout.ND)
+                ],
+                row: pl.Scalar[pl.INDEX],
+            ) -> tuple[
+                pl.Tensor[[16, 5120], pl.FP32, pl.TensorView(stride=[5120, 1], layout=pl.TensorLayout.ND)],
+                pl.Tensor[[16, 1024], pl.FP32, pl.TensorView(stride=[1024, 1], layout=pl.TensorLayout.ND)],
+            ]:
+                for h, (q_iter, k_iter) in pl.range(8, init_values=(q_out, k_out)):
+                    q0: pl.Scalar[pl.INDEX] = h * 640
+                    k0: pl.Scalar[pl.INDEX] = h * 128
+                    q_tile: pl.Tile[[16, 640], pl.FP32, pl.Mem.Vec] = pl.tile.load(
+                        q_proj, [0, q0], [16, 640], [16, 640], target_memory=pl.Mem.Vec
+                    )
+                    k_tile: pl.Tile[[16, 128], pl.FP32, pl.Mem.Vec] = pl.tile.load(
+                        k_proj, [0, k0], [16, 128], [16, 128], target_memory=pl.Mem.Vec
+                    )
+                    q_next: pl.Tensor[
+                        [16, 5120], pl.FP32, pl.TensorView(stride=[5120, 1], layout=pl.TensorLayout.ND)
+                    ] = pl.tile.store(q_tile, [0, q0], q_iter)
+                    k_next: pl.Tensor[
+                        [16, 1024], pl.FP32, pl.TensorView(stride=[1024, 1], layout=pl.TensorLayout.ND)
+                    ] = pl.tile.store(k_tile, [0, k0], k_iter)
+                    q_norm, k_norm = pl.yield_(q_next, k_next)
+                return q_norm, k_norm
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                q_proj: pl.Tensor[[16, 5120], pl.FP32],
+                k_proj: pl.Tensor[[16, 1024], pl.FP32],
+                q_out: pl.Out[pl.Tensor[[16, 5120], pl.FP32]],
+                k_out: pl.Out[pl.Tensor[[16, 1024], pl.FP32]],
+            ) -> tuple[pl.Tensor[[16, 5120], pl.FP32], pl.Tensor[[16, 1024], pl.FP32]]:
+                # The pass-through trip-count-1 loop of ``Before`` is gone (prereqs),
+                # so `q_rv`/`k_rv` collapse to the visible loop-init parents. The
+                # input windows are therefore sliced off `q_proj`/`k_proj` -- the
+                # parent that is actually in scope -- which is the fact under test.
+                q_win: pl.Tensor[[16, 5120], pl.FP32] = pl.tensor.slice(q_proj, [16, 5120], [0, 0])
+                k_win: pl.Tensor[[16, 1024], pl.FP32] = pl.tensor.slice(k_proj, [16, 1024], [0, 0])
+                q_out_win: pl.Tensor[[16, 5120], pl.FP32] = pl.tensor.slice(q_out, [16, 5120], [0, 0])
+                k_out_win: pl.Tensor[[16, 1024], pl.FP32] = pl.tensor.slice(k_out, [16, 1024], [0, 0])
+                # Multi-return shape: one tuple temp, then per-element
+                # projection/assemble pairs interleaved -- mirrors the already
+                # converted golden in test_multi_out_final_store_rewrites_both_outputs.
+                windowed: pl.Tuple[
+                    pl.Tensor[
+                        [16, 5120], pl.FP32, pl.TensorView(stride=[5120, 1], layout=pl.TensorLayout.ND)
+                    ],
+                    pl.Tensor[
+                        [16, 1024], pl.FP32, pl.TensorView(stride=[1024, 1], layout=pl.TensorLayout.ND)
+                    ],
+                ] = self.qk_norm_like__windowed(q_out_win, k_out_win, q_win, k_win, 0)
+                q_w: pl.Tensor[
+                    [16, 5120], pl.FP32, pl.TensorView(stride=[5120, 1], layout=pl.TensorLayout.ND)
+                ] = windowed[0]
+                q_res: pl.Tensor[[16, 5120], pl.FP32] = pl.tensor.assemble(q_out, q_w, [0, 0])
+                k_w: pl.Tensor[
+                    [16, 1024], pl.FP32, pl.TensorView(stride=[1024, 1], layout=pl.TensorLayout.ND)
+                ] = windowed[1]
+                k_res: pl.Tensor[[16, 1024], pl.FP32] = pl.tensor.assemble(k_out, k_w, [0, 0])
+                res: pl.Tuple[pl.Tensor[[16, 5120], pl.FP32], pl.Tensor[[16, 1024], pl.FP32]] = [
+                    q_res,
+                    k_res,
+                ]
+                return res
+
+        After = _run_to_optimize_orch_tensors(Before)
+        ir.assert_structural_equal(After, _run_prereqs_only(Expected))
 
     def test_aggregate_output_diagonal_writes_stay_baseline(self):
         @pl.program
@@ -2075,25 +2456,23 @@ class Program:
                 header: pl.Tensor[[16, 256], pl.FP32],
                 out: pl.Out[pl.Tensor[[16, 256], pl.FP32]],
             ) -> pl.Tensor[[16, 256], pl.FP32]:
-                header__window: pl.Tensor[[16, 64], pl.FP32] = pl.tensor.slice(header, [16, 64], [0, 0])
-                data__window: pl.Tensor[[16, 256], pl.FP32] = pl.tensor.slice(data, [16, 256], [0, 0])
-                out__window: pl.Tensor[[16, 256], pl.FP32] = pl.tensor.slice(out, [16, 256], [0, 0])
-                result__windowed: pl.Tensor[
+                # Local names avoid the pass's own ``X__window`` spelling. Parsing
+                # accepts ``__``, but normalizing this golden through
+                # ``_run_prereqs_only`` does not: auto-naming raises "IR auto-name
+                # base cannot contain reserved delimiter '__'". Structural equality
+                # compares IR shape, not names, so shorter spellings match anyway.
+                # Slice order follows the pass's emission order (data, header, out).
+                data_win: pl.Tensor[[16, 256], pl.FP32] = pl.tensor.slice(data, [16, 256], [0, 0])
+                header_win: pl.Tensor[[16, 64], pl.FP32] = pl.tensor.slice(header, [16, 64], [0, 0])
+                out_win: pl.Tensor[[16, 256], pl.FP32] = pl.tensor.slice(out, [16, 256], [0, 0])
+                windowed: pl.Tensor[
                     [16, 256], pl.FP32, pl.TensorView(stride=[256, 1], layout=pl.TensorLayout.ND)
-                ] = self.aggregate_with_header__windowed(out__window, data__window, header__window, 0)
-                result: pl.Tensor[[16, 256], pl.FP32] = pl.tensor.assemble(out, result__windowed, [0, 0])
+                ] = self.aggregate_with_header__windowed(out_win, data_win, header_win, 0)
+                result: pl.Tensor[[16, 256], pl.FP32] = pl.tensor.assemble(out, windowed, [0, 0])
                 return result
 
         After = _run_to_optimize_orch_tensors(Before)
-        printed_main = ir.python_print(_get_function(After, "main"))
-        printed_windowed = ir.python_print(_get_function(After, "aggregate_with_header__windowed"))
-        assert "aggregate_with_header__windowed" in printed_main
-        assert "pl.tensor.slice(header" in printed_main
-        assert "[16, 64]" in printed_main
-        assert "pl.tensor.slice(data" in printed_main
-        assert "[16, 256]" in printed_main
-        assert "pl.tile.load(header" in printed_windowed
-        assert "[0, 0]" in printed_windowed
+        ir.assert_structural_equal(After, _run_prereqs_only(Expected))
 
     def test_direct_out_call_rewrites_to_windowed_clone(self):
         @pl.program

--- a/tests/ut/ir/transforms/test_paged_gather.py
+++ b/tests/ut/ir/transforms/test_paged_gather.py
@@ -13,14 +13,21 @@ The op lowers (in ConvertTensorToTileOps) into a fully-scalar per-row GM->on-chi
 load loop on the Cube core:
 
     acc = tile.create([max_indices, size], target_memory=Mat)
-    for i in range(rows):
+    for i in range(tensor.dim(indices, 0)):
         idx  = tensor.read(indices, [i])          # scalar GM read (pto.load_scalar)
         phys = block_table[idx // bs] * bs + idx % bs   # scalar
-        row  = tile.load(src, [phys, col_off], [1, size], target_memory=Mat)  # GM->L1
-        acc  = tile.assemble(acc, row, [i, 0])
+        acc  = tile.gather_row(acc, src, [i, 0], [phys, 0], [1, size])  # GM->L1
 
 Only the small index/page-table metadata is scalar-read from GM; the bulk KV
 data goes straight GM->L1 (never UB).
+
+Note the row is written *straight into* the accumulator sub-region by
+``tile.gather_row`` (pto.subview + GM->Mat pto.tload). There is deliberately no
+``tile.assemble``, which would lower to an unsupported MAT->MAT ``pto.tmov``.
+
+Tests compare whole programs against hand-written post-lowering goldens
+(``_build_expected`` / inline ``Expected``) rather than grepping printed IR, so
+the absent ops are pinned as strongly as the present ones.
 """
 
 import pypto.language as pl
@@ -75,57 +82,153 @@ def _build_program(
     return Program
 
 
-def _print_after_convert(program) -> str:
-    after = passes.convert_tensor_to_tile_ops()(program)
-    return ir.python_print(after)
+def _build_expected(
+    *,
+    space: pl.MemorySpace = pl.MemorySpace.Mat,
+    rows: int | pl.DynVar = 16,
+    max_indices: int = 16,
+    src_dtype: DataType = pl.FP16,
+):
+    """Hand-written post-lowering golden mirroring ``_build_program`` (non-transposed).
+
+    Written directly in the already-lowered form -- ``tile.create`` / ``tile.gather_row``
+    / ``tile.store`` -- so the pass under test never runs on this side. Building the
+    golden by running ``convert_tensor_to_tile_ops`` on it would make the comparison
+    self-referential: a regression would change both sides and the test would stay green.
+
+    Local names deliberately avoid the ``__`` spelling the pass emits, purely for
+    readability -- structural equality compares IR shape, not names. (Goldens that
+    ARE normalized by prerequisite passes, as in ``test_optimize_orch_tensors.py``,
+    must avoid ``__`` for a harder reason: auto-naming rejects it. This golden runs
+    through no passes at all, so the restriction does not apply here.)
+    """
+    out_shape = [max_indices, 128]
+
+    @pl.program
+    class Expected:
+        @pl.function(type=pl.FunctionType.InCore)
+        def kernel(
+            self,
+            src: pl.Tensor[[256, 128], src_dtype],
+            idx: pl.Tensor[[rows], pl.INT32],
+            bt: pl.Tensor[[8], pl.INT32],
+            ret_out: pl.Out[pl.Tensor[out_shape, src_dtype]],
+        ) -> pl.Tensor[out_shape, src_dtype]:
+            # Loop bound is the runtime index count; the accumulator stays static.
+            pg_rows: pl.Scalar[pl.INDEX] = pl.tensor.dim(idx, 0)
+            # Tile locals are left unannotated: a Tile annotation only accepts a
+            # literal ``pl.Mem.<space>``, not the ``space`` parameter. The memory
+            # space still reaches the IR through the ``target_memory`` kwarg.
+            acc = pl.tile.create(out_shape, dtype=src_dtype, target_memory=space)
+            for pg_i, (acc_iter,) in pl.range(pg_rows, init_values=(acc,)):
+                # Only index/page-table metadata is scalar-read from GM.
+                idx_raw: pl.Scalar[pl.INT32] = pl.tensor.read(idx, [pg_i])
+                pg_idx: pl.Scalar[pl.INDEX] = pl.cast(idx_raw, target_type=pl.INDEX)
+                pg_blk: pl.Scalar[pl.INDEX] = pg_idx // 128
+                pg_rem: pl.Scalar[pl.INDEX] = pg_idx % 128
+                pblk_raw: pl.Scalar[pl.INT32] = pl.tensor.read(bt, [pg_blk])
+                pg_pblk: pl.Scalar[pl.INDEX] = pl.cast(pblk_raw, target_type=pl.INDEX)
+                pg_phys: pl.Scalar[pl.INDEX] = pg_pblk * 128 + pg_rem
+                # Bulk KV goes GM->on-chip straight into the accumulator sub-region.
+                pg_row = pl.tile.gather_row(acc_iter, src, [pg_i, 0], [pg_phys, 0], [1, 128], transpose=False)
+                pg_res = pl.yield_(pg_row)
+            out_tile = pg_res
+            ret_store: pl.Tensor[out_shape, src_dtype] = pl.tile.store(out_tile, [0, 0], ret_out)
+            return ret_store
+
+        @pl.function
+        def main(
+            self,
+            src: pl.Tensor[[256, 128], src_dtype],
+            idx: pl.Tensor[[rows], pl.INT32],
+            bt: pl.Tensor[[8], pl.INT32],
+        ) -> pl.Tensor[out_shape, src_dtype]:
+            ret_out: pl.Tensor[out_shape, src_dtype] = pl.tensor.create(
+                out_shape, dtype=src_dtype, layout=pl.TensorLayout.ND
+            )
+            r: pl.Tensor[out_shape, src_dtype] = self.kernel(src, idx, bt, ret_out)
+            return r
+
+    return Expected
+
+
+def _convert(program):
+    """Run the pass under test -- ConvertTensorToTileOps lowers ``tensor.paged_gather``."""
+    return passes.convert_tensor_to_tile_ops()(program)
 
 
 def test_paged_gather_lowers_to_scalar_per_row_l1_loop():
-    """space=Mat lowers to a ForStmt of scalar index math + GM->L1 tile.load + assemble."""
-    text = _print_after_convert(_build_program())
+    """space=Mat lowers to a ForStmt of scalar index math + a GM->L1 per-row gather.
 
-    # Static L1 accumulator.
-    assert "pl.tile.create([16, 128]" in text
-    assert "target_memory=pl.Mem.Mat" in text
-    # Per-row loop over the runtime index count.
-    assert "for pg_i" in text
-    # Scalar GM reads for the index and the page table (pto.load_scalar at codegen).
-    assert "pl.tensor.read(idx, [pg_i])" in text
-    assert "pl.tensor.read(bt, [pg_blk])" in text
-    # Paged address math, all scalar.
-    assert "// 128" in text
-    assert "% 128" in text
-    # Bulk KV goes GM->L1 via a per-row tile.gather_row (pto.subview + GM->Mat
-    # pto.tload, no MAT->MAT pto.tmov): the row is written straight into the
-    # accumulator sub-region [pg_i, 0].
-    assert (
-        "pl.tile.gather_row(paged_gather_iter, src, [pg_i, 0], [pg_phys, 0], [1, 128], transpose=False)"
-        in text
-    )
-    # No tile.assemble (would lower to an unsupported MAT->MAT tmov) and the whole
-    # src is NOT preloaded into a Vec tile.
-    assert "pl.tile.assemble(" not in text
-    assert "target_memory=pl.Mem.Vec" not in text
+    The whole program is pinned, so this also covers what must NOT appear: no
+    ``tile.assemble`` (it would lower to an unsupported MAT->MAT tmov) and no Vec
+    tile (the bulk KV must never be preloaded into UB).
+    """
+    ir.assert_structural_equal(_convert(_build_program()), _build_expected())
 
 
 def test_paged_gather_transpose_swaps_output_and_load():
-    """is_trans=True swaps the output dims and loads each row transposed into L1."""
-    text = _print_after_convert(_build_program(is_trans=True))
-    # Accumulator is [size, max_indices] when transposed.
-    assert "pl.tile.create([128, 16]" in text
-    assert "transpose=True" in text
-    # Row written as a column at destination offset [0, i].
-    assert (
-        "pl.tile.gather_row(paged_gather_iter, src, [0, pg_i], [pg_phys, 0], [1, 128], transpose=True)"
-        in text
-    )
+    """is_trans=True swaps the output dims and loads each row transposed into L1.
+
+    Written inline rather than via ``_build_expected`` because the transposed form
+    differs in three places at once -- accumulator shape [size, max_indices], the
+    destination offset [0, i] instead of [i, 0], and ``transpose=True``.
+    """
+
+    @pl.program
+    class Expected:
+        @pl.function(type=pl.FunctionType.InCore)
+        def kernel(
+            self,
+            src: pl.Tensor[[256, 128], pl.FP16],
+            idx: pl.Tensor[[16], pl.INT32],
+            bt: pl.Tensor[[8], pl.INT32],
+            ret_out: pl.Out[pl.Tensor[[128, 16], pl.FP16]],
+        ) -> pl.Tensor[[128, 16], pl.FP16]:
+            pg_rows: pl.Scalar[pl.INDEX] = pl.tensor.dim(idx, 0)
+            # Accumulator is [size, max_indices] when transposed.
+            acc: pl.Tile[[128, 16], pl.FP16, pl.Mem.Mat] = pl.tile.create(
+                [128, 16], dtype=pl.FP16, target_memory=pl.Mem.Mat
+            )
+            for pg_i, (acc_iter,) in pl.range(pg_rows, init_values=(acc,)):
+                idx_raw: pl.Scalar[pl.INT32] = pl.tensor.read(idx, [pg_i])
+                pg_idx: pl.Scalar[pl.INDEX] = pl.cast(idx_raw, target_type=pl.INDEX)
+                pg_blk: pl.Scalar[pl.INDEX] = pg_idx // 128
+                pg_rem: pl.Scalar[pl.INDEX] = pg_idx % 128
+                pblk_raw: pl.Scalar[pl.INT32] = pl.tensor.read(bt, [pg_blk])
+                pg_pblk: pl.Scalar[pl.INDEX] = pl.cast(pblk_raw, target_type=pl.INDEX)
+                pg_phys: pl.Scalar[pl.INDEX] = pg_pblk * 128 + pg_rem
+                # Row written as a column at destination offset [0, i].
+                pg_row: pl.Tile[[128, 16], pl.FP16, pl.Mem.Mat] = pl.tile.gather_row(
+                    acc_iter, src, [0, pg_i], [pg_phys, 0], [1, 128], transpose=True
+                )
+                pg_res = pl.yield_(pg_row)
+            out_tile: pl.Tile[[128, 16], pl.FP16, pl.Mem.Mat] = pg_res
+            ret_store: pl.Tensor[[128, 16], pl.FP16] = pl.tile.store(out_tile, [0, 0], ret_out)
+            return ret_store
+
+        @pl.function
+        def main(
+            self,
+            src: pl.Tensor[[256, 128], pl.FP16],
+            idx: pl.Tensor[[16], pl.INT32],
+            bt: pl.Tensor[[8], pl.INT32],
+        ) -> pl.Tensor[[128, 16], pl.FP16]:
+            ret_out: pl.Tensor[[128, 16], pl.FP16] = pl.tensor.create(
+                [128, 16], dtype=pl.FP16, layout=pl.TensorLayout.ND
+            )
+            r: pl.Tensor[[128, 16], pl.FP16] = self.kernel(src, idx, bt, ret_out)
+            return r
+
+    ir.assert_structural_equal(_convert(_build_program(is_trans=True)), Expected)
 
 
 def test_paged_gather_space_vec():
     """space=Vec targets UB instead of L1 while keeping the same scalar per-row loop."""
-    text = _print_after_convert(_build_program(space=pl.MemorySpace.Vec))
-    assert "target_memory=pl.Mem.Vec" in text
-    assert "for pg_i" in text
+    ir.assert_structural_equal(
+        _convert(_build_program(space=pl.MemorySpace.Vec)),
+        _build_expected(space=pl.MemorySpace.Vec),
+    )
 
 
 def test_paged_gather_dynamic_row_count():
@@ -154,10 +257,9 @@ def test_paged_gather_dynamic_row_count():
             r = self.kernel(src, idx, bt)
             return r
 
-    text = _print_after_convert(Program)
-    # Static buffer (max_indices), dynamic loop bound (ROWS).
-    assert "pl.tile.create([64, 128]" in text
-    assert "ROWS" in text
+    # Static [64, 128] accumulator, dynamic loop bound taken from ROWS via
+    # tensor.dim -- both pinned structurally by the golden.
+    ir.assert_structural_equal(_convert(Program), _build_expected(rows=rows, max_indices=64))
 
 
 @pytest.mark.parametrize("is_trans", [False, True])


### PR DESCRIPTION
## Summary

Twelve tests across three transform test files used a printed-IR substring as their only oracle, leaving everything outside the grepped tokens unchecked. This replaces them with whole-program structural comparisons.

**`test_auto_tile_matmul_l0.py`** — the three `..._not_folded` guards each asserted the identical pair:

```python
assert "pl.tile.cast(" in printed
assert "pl.tile.assemble(" not in printed
```

Running each test's assertions against the other two tests' output shows all three pass on all three programs — one oracle guarding three distinct rejection reasons (non-matmul consumer / `mode="floor"` / default `mode="round"`), unable to tell them apart. All three are pure no-ops, so this adds `_assert_unchanged_by_pass` (mirroring the existing helper in `test_optimize_orch_tensors.py`) and pins the whole program.

**`test_optimize_orch_tensors.py`** — converts the five remaining substring tests to hand-written `Expected` goldens normalized by `_run_prereqs_only`.

Notably, `test_aggregate_output_preserves_existing_pure_input_window` already carried a complete 67-line `Expected` program that was **never referenced** — the test defined it and then fell through to substring asserts. Nothing flagged it (ruff does not warn on an unused local class). It is now wired up, with the two defects that had stalled it fixed: locals spelled with `__` (auto-naming rejects those during prerequisite normalization) and a slice order that did not match the pass's `data`/`header`/`out` emission order.

**`test_paged_gather.py`** — had no structural comparison at all. Adds a `_build_expected` golden builder mirroring `_build_program` and converts all four tests. These goldens run through no passes, so they are written directly in post-lowering form.

Negative facts previously approximated by `not in` greps — no windowed clone, no `assemble`, no Vec tile, no slice of a given parent — are now pinned by whole-program equality.

## Goldens are never self-referential

No golden is built by running the pass under test:

| File | Golden normalized by |
| ---- | -------------------- |
| `test_paged_gather.py` | nothing — written in post-lowering form |
| `test_optimize_orch_tensors.py` | pipeline prefix *before* `OptimizeOrchTensors` |
| `test_auto_tile_matmul_l0.py` | prerequisite lowering only, re-derived from `Before` |

## Drive-by fix

`test_paged_gather.py`'s module docstring described a `tile.load` + `tile.assemble` lowering, but the pass emits `tile.gather_row` and deliberately no `assemble` (which would lower to an unsupported MAT→MAT `pto.tmov`). The docstring stated the opposite of what the tests assert; corrected with the reason.

## Testing

- [x] `tests/ut/ir/transforms/` — 2583 passed
- [x] `tests/ut/` full sweep — 8547 passed, 2 skipped (1 pre-existing unrelated failure: `test_ir_trace.py` console-script smoke test needs `pip install -e .`; verified failing on a clean tree)
- [x] `ruff check` / `ruff format --check` clean
- [x] `tests/lint/` scripts pass
- [x] Goldens mutation-tested — every mutation is caught (flipping `transpose`, adding a spurious function, renaming a clone, making an unfoldable cast foldable)

## Related Issues

None.