### PR TITLE
fix(ir): Capture a rebound pl.Out tensor as an outlined param

### DIFF
--- a/docs/en/dev/passes/08-outline_incore_scopes.md
+++ b/docs/en/dev/passes/08-outline_incore_scopes.md
@@ -37,7 +37,8 @@ program_outlined = outline_pass(program)
 ## Algorithm
 
 1. **Scan for InCore Scopes**: Find all `InCoreScopeStmt` nodes in Opaque functions
-2. **Analyze Inputs**: Determine external variable references (variables defined outside scope, used inside)
+2. **Analyze Inputs**: Collect the scope's *live-in* set — variables the body reads
+   before it (re)defines them, so their incoming value comes from the caller
 3. **Analyze Outputs**: Determine internal definitions used after scope (variables defined inside, used outside)
 4. **Create Function**: Extract scope body into new `Function(scope_type=InCore)` with:
    - Parameters = input variables
@@ -47,6 +48,38 @@ program_outlined = outline_pass(program)
    - Call to outlined function with input arguments
    - AssignStmt for each output variable
 6. **Add to Program**: Add outlined function to program's function list
+
+**Live-in, not `uses \ defs`**: the input set is computed flow-sensitively
+(`UpwardExposedUseCollector`). A plain set difference is wrong for a captured
+tensor that the body reads *and* rebinds under the same name — the shape the
+parser emits for a `pl.Out` param before `ConvertToSSA` splits it:
+
+```python
+with pl.at(level=pl.Level.CORE_GROUP):
+    c = pl.store(t, [0, 0], c)   # one Var: read as the store target, then rebound
+```
+
+`c` is in both `var_uses` and `var_defs`, so the difference drops it from the
+parameter list and leaves the read dangling in the outlined body. Treating it as
+live-in makes it an `InOut` parameter, and the `tile.store` result binds a
+distinct Var (`c__store`) so the outlined body never rebinds its own parameter:
+
+```python
+def main_incore_0(a: Tensor[[128, 128], FP32], c: InOut[Tensor[[128, 128], FP32]]):
+    c__store = pl.tile.store(..., c)
+    return c                       # the param — store writes through it in place
+```
+
+On SSA input — the pass's declared `IRProperty::SSAForm` precondition — live-in
+and `uses \ defs` are identical, so this only changes behaviour for IR that
+reaches the pass without that precondition holding. A captured variable rebound
+by anything *other* than a `tile.store` cannot be expressed without real SSA
+construction and is rejected with an internal error naming `ConvertToSSA`.
+
+The distinct result Var is the InCore/Cluster/Spmd outcome. Hierarchy scopes
+skip the store-target export entirely (the buffer is already visible to the
+caller through its InOut parameter), so their body keeps the original rebind —
+the capture still becomes a parameter, which is the part that was broken.
 
 **Param-explicit returns**: the outlined function returns its
 own parameters, not SSA result vars, whenever a tensor output writes through

--- a/docs/zh/dev/passes/08-outline_incore_scopes.md
+++ b/docs/zh/dev/passes/08-outline_incore_scopes.md
@@ -37,7 +37,8 @@ program_outlined = outline_pass(program)
 ## 算法
 
 1. **扫描 InCore 作用域**：在 Opaque 函数中查找所有 `InCoreScopeStmt` 节点
-2. **分析输入**：确定外部变量引用（在作用域外定义、在作用域内使用的变量）
+2. **分析输入**：收集作用域的 *live-in*（活跃入口）集合——作用域体在（重新）定义
+   某变量之前就读取它，说明该变量的入口值来自调用方
 3. **分析输出**：确定在作用域之后仍被使用的内部定义（在作用域内定义、在作用域外使用的变量）
 4. **创建函数**：将作用域体提取为新的 `Function(scope_type=InCore)`，其中：
    - 参数 = 输入变量
@@ -47,6 +48,36 @@ program_outlined = outline_pass(program)
    - 带有输入参数的提取函数调用
    - 每个输出变量对应一个 AssignStmt
 6. **添加到程序**：将提取的函数添加到程序的函数列表中
+
+**使用 live-in 而非 `uses \ defs`**：输入集合按流敏感方式计算
+（`UpwardExposedUseCollector`）。对于「先读取、再以同名重新绑定」的被捕获
+tensor，简单的集合差是错误的——这正是 `ConvertToSSA` 拆分之前，解析器为
+`pl.Out` 参数生成的形态：
+
+```python
+with pl.at(level=pl.Level.CORE_GROUP):
+    c = pl.store(t, [0, 0], c)   # 同一个 Var：既作为 store 目标被读取，又被重新绑定
+```
+
+`c` 同时出现在 `var_uses` 与 `var_defs` 中，集合差会把它从参数表中剔除，导致
+外提函数体内的读取变成自由变量。将其视为 live-in 后，它成为 `InOut` 参数，而
+`tile.store` 的结果绑定到一个独立的 Var（`c__store`），因此外提函数体永远不会
+重新绑定自身的参数：
+
+```python
+def main_incore_0(a: Tensor[[128, 128], FP32], c: InOut[Tensor[[128, 128], FP32]]):
+    c__store = pl.tile.store(..., c)
+    return c                       # 返回参数——store 就地经由它写回
+```
+
+在 SSA 输入（即本 pass 声明的 `IRProperty::SSAForm` 前置条件）下，live-in 与
+`uses \ defs` 完全一致，因此该行为差异只出现在前置条件未满足就进入本 pass 的
+IR 上。若被捕获变量是被 `tile.store` 之外的方式重新绑定，则无法在不做真正 SSA
+构造的前提下表达，此时会抛出内部错误并提示先运行 `ConvertToSSA`。
+
+「绑定到独立 Var」是 InCore / Cluster / Spmd 的行为。Hierarchy 作用域会完全跳过
+store 目标导出（该缓冲区已经通过 InOut 参数对调用方可见），因此其函数体保留原有的
+重新绑定——被捕获变量仍然会成为参数，而这正是此前出问题的部分。
 
 **参数化显式返回**：只要某个 tensor 输出是经由参数回写
 的，外提函数就返回自身的参数而非 SSA 结果变量——store 目标输出直接返回对应

--- a/include/pypto/ir/transforms/utils/scope_outline_utils.h
+++ b/include/pypto/ir/transforms/utils/scope_outline_utils.h
@@ -149,47 +149,217 @@ class SplitAivModeSummaryFinder : public IRVisitor {
  * the original IR uses EvalStmt (discarding the return value), this mutator
  * re-writes it as an AssignStmt so the return value is captured and can be
  * referenced in a subsequent ReturnStmt.
+ *
+ * Three input shapes are handled, all producing a single-assignment result:
+ *
+ * | Input                                    | Output                                     |
+ * | ---------------------------------------- | ------------------------------------------ |
+ * | ``EvalStmt(store(.., tgt))``             | ``AssignStmt(ret, store(.., tgt))``        |
+ * | ``AssignStmt(v, store(.., tgt))``, v≠tgt | keep, plus ``AssignStmt(ret, v)``          |
+ * | ``AssignStmt(tgt, store(.., tgt))``      | ``AssignStmt(ret, store(.., tgt))``        |
+ *
+ * The third row is the read-modify-write shape the parser emits for a captured
+ * ``pl.Out`` tensor before ConvertToSSA splits it (``c = pl.store(t, off, c)``).
+ * Keeping the original assignment there would rebind the outlined function's
+ * own parameter; binding the store result to ``ret`` instead leaves the body
+ * single-assignment. Later reads of the pre-store name still resolve to the
+ * parameter, which is correct: ``tile.store`` writes through its target in
+ * place, so both names denote the same buffer (the same reason OutlineScope
+ * returns the *param* rather than the store result — see #1702).
+ *
+ * When one target is stored to more than once, only the first store binds the
+ * declared ``ret`` Var; each subsequent one gets a fresh Var so the result
+ * never contains a duplicate definition.
  */
 class StoreEvalToAssignMutator : public IRMutator {
  public:
-  explicit StoreEvalToAssignMutator(const std::unordered_map<const Var*, VarPtr>& target_vars)
-      : target_vars_(target_vars) {}
+  /// @param target_vars  store target (body pointer) -> declared result Var
+  /// @param used_names   names already claimed in the outlined function, used
+  ///                     to mint collision-free Vars for repeated stores
+  StoreEvalToAssignMutator(const std::unordered_map<const Var*, VarPtr>& target_vars,
+                           std::unordered_set<std::string> used_names)
+      : target_vars_(target_vars), used_names_(std::move(used_names)) {}
 
  protected:
   StmtPtr VisitStmt_(const EvalStmtPtr& op) override {
-    auto call = std::dynamic_pointer_cast<const Call>(op->expr_);
-    if (!call) return op;
-    auto opnode = std::dynamic_pointer_cast<const Op>(call->op_);
-    if (!opnode || !IsOp(opnode, "tile.store")) {
-      return op;
-    }
-    if (call->args_.size() < 3) return op;
-    auto var = As<Var>(call->args_[2]);
-    if (!var) return op;
-    auto it = target_vars_.find(var.get());
-    if (it == target_vars_.end()) return op;
-    return std::make_shared<AssignStmt>(it->second, call, op->span_);
+    auto store = MatchTrackedStore(op->expr_);
+    if (!store) return op;
+    return std::make_shared<AssignStmt>(NextResultVar(*store), store->call, op->span_);
   }
 
   StmtPtr VisitStmt_(const AssignStmtPtr& op) override {
     // Handle SSA-converted stores: AssignStmt(buf_1, Call(tile.store, ..., buf_0))
     // The _store_ret var needs to be assigned the store result too.
-    auto call = std::dynamic_pointer_cast<const Call>(op->value_);
-    if (!call) return IRMutator::VisitStmt_(op);
-    auto opnode = std::dynamic_pointer_cast<const Op>(call->op_);
-    if (!opnode || !IsOp(opnode, "tile.store")) return IRMutator::VisitStmt_(op);
-    if (call->args_.size() < 3) return IRMutator::VisitStmt_(op);
-    auto var = As<Var>(call->args_[2]);
-    if (!var) return IRMutator::VisitStmt_(op);
-    auto it = target_vars_.find(var.get());
-    if (it == target_vars_.end()) return IRMutator::VisitStmt_(op);
+    auto store = MatchTrackedStore(op->value_);
+    if (!store) return IRMutator::VisitStmt_(op);
+    auto result_var = NextResultVar(*store);
+    if (op->var_.get() == store->target) {
+      // Read-modify-write under the target's own name: replace the assignment
+      // rather than appending to it, so the outlined body never rebinds the
+      // parameter this target becomes.
+      return std::make_shared<AssignStmt>(result_var, store->call, op->span_);
+    }
     // Keep original assignment (buf_1 = store(...)) and add _store_ret = buf_1
-    auto store_ret_assign = std::make_shared<AssignStmt>(it->second, op->var_, op->span_);
+    auto store_ret_assign = std::make_shared<AssignStmt>(result_var, op->var_, op->span_);
     return std::make_shared<SeqStmts>(std::vector<StmtPtr>{op, store_ret_assign}, op->span_);
   }
 
  private:
+  /// One ``tile.store`` whose target this mutator was asked to capture.
+  struct TrackedStore {
+    CallPtr call;            ///< the store call itself
+    const Var* target;       ///< store target (un-substituted body pointer)
+    VarPtr declared_result;  ///< the result Var declared for `target`
+  };
+
+  /// Match `value` against ``Call(tile.store, ..., target)`` for a tracked
+  /// `target`; nullopt for anything else. Both statement forms funnel through
+  /// here so they cannot drift apart on what counts as a store.
+  [[nodiscard]] std::optional<TrackedStore> MatchTrackedStore(const ExprPtr& value) const {
+    auto call = std::dynamic_pointer_cast<const Call>(value);
+    if (!IsOp(call, "tile.store") || call->args_.size() < 3) return std::nullopt;
+    auto target = As<Var>(call->args_[2]);
+    if (!target) return std::nullopt;
+    auto it = target_vars_.find(target.get());
+    if (it == target_vars_.end()) return std::nullopt;
+    return TrackedStore{call, target.get(), it->second};
+  }
+
+  /// Result Var for one store: the declared Var for the target's first store,
+  /// a fresh same-typed Var for every later one.
+  VarPtr NextResultVar(const TrackedStore& store) {
+    const VarPtr& declared = store.declared_result;
+    if (claimed_.insert(store.target).second) {
+      used_names_.insert(declared->name_hint_);
+      return declared;
+    }
+    std::string name = auto_name::GenerateFreshNameLike(declared->name_hint_, used_names_);
+    used_names_.insert(name);
+    return std::make_shared<Var>(name, declared->GetType(), declared->span_);
+  }
+
   std::unordered_map<const Var*, VarPtr> target_vars_;
+  std::unordered_set<std::string> used_names_;
+  std::unordered_set<const Var*> claimed_;
+};
+
+/**
+ * @brief Collect the *upward-exposed* uses of a subtree — variables read
+ *        before the subtree (re)defines them.
+ *
+ * This is the scope's live-in set: every such variable's incoming value is
+ * produced outside the scope, so it must become a parameter of the outlined
+ * function.
+ *
+ * It is strictly more precise than ``var_uses \ var_defs``, which is
+ * flow-insensitive: a tensor that is read *and then rebound under the same
+ * name* — the read-modify-write ``c = pl.store(t, off, c)`` the parser emits
+ * for a captured ``pl.Out`` param before ConvertToSSA splits it — lands in
+ * both sets, so the difference silently drops it from the parameter list and
+ * leaves the read dangling in the outlined body.
+ *
+ * On SSA input the two agree exactly: no Var is defined twice, so a variable
+ * defined inside the body can never also be read ahead of that definition.
+ * The traversal order deliberately mirrors ``VarDefUseCollector`` so the
+ * derived parameter order is unchanged; only *when* a definition is recorded
+ * differs (after the assigned value is visited, matching ``SSAVerifier``).
+ */
+class UpwardExposedUseCollector : public IRVisitor {
+ public:
+  /// Live-in variables in first-read order. Deliberately the only iterable
+  /// view: the membership set behind ``IsExternal`` is unordered, and the
+  /// derived parameter list must stay deterministic.
+  std::vector<const Var*> ordered;
+
+  /// True when `var`'s value on entry to the visited subtree comes from
+  /// outside it — i.e. the subtree captures rather than defines it.
+  [[nodiscard]] bool IsExternal(const Var* var) const { return live_in_.count(var) > 0; }
+
+ protected:
+  // Var and IterArg are handled by separate overrides rather than a shared
+  // ``VisitVarLike_``, mirroring VarDefUseCollector: neither may descend to the
+  // base visitor, because ``IRVisitor::VisitExpr_(IterArgPtr)`` walks the
+  // IterArg's ``initValue_``. That init value belongs to the *enclosing* loop
+  // header, not to whatever reads the IterArg — descending would capture an
+  // outer loop's seed tensor as an extra parameter of the outlined function.
+  void VisitExpr_(const VarPtr& op) override { RecordUse(op.get()); }
+  void VisitExpr_(const IterArgPtr& op) override { RecordUse(op.get()); }
+
+  void VisitStmt_(const AssignStmtPtr& op) override {
+    // The assigned value is evaluated before the target is bound.
+    if (op->value_) VisitExpr(op->value_);
+    Define(op->var_);
+  }
+
+  void VisitStmt_(const ForStmtPtr& op) override {
+    // iter_arg init values are evaluated in the enclosing scope.
+    for (const auto& ia : op->iter_args_) {
+      if (ia->initValue_) VisitExpr(ia->initValue_);
+    }
+    Define(op->loop_var_);
+    for (const auto& rv : op->return_vars_) Define(rv);
+    for (const auto& ia : op->iter_args_) Define(ia);
+    VisitExpr(op->start_);
+    VisitExpr(op->stop_);
+    VisitExpr(op->step_);
+    VisitStmt(op->body_);
+  }
+
+  void VisitStmt_(const WhileStmtPtr& op) override {
+    for (const auto& ia : op->iter_args_) {
+      if (ia->initValue_) VisitExpr(ia->initValue_);
+    }
+    for (const auto& rv : op->return_vars_) Define(rv);
+    for (const auto& ia : op->iter_args_) Define(ia);
+    VisitExpr(op->condition_);
+    VisitStmt(op->body_);
+  }
+
+  void VisitStmt_(const IfStmtPtr& op) override {
+    VisitExpr(op->condition_);
+    for (const auto& rv : op->return_vars_) Define(rv);
+    // Walk both arms from the same incoming state so a read on one arm is never
+    // masked by a write on the other, then join on *must*-definitions: a
+    // variable written by only one arm may still carry its incoming value.
+    const std::vector<const Var*> then_new = VisitBranchIsolated(op->then_body_);
+    if (!op->else_body_.has_value()) return;
+    const std::vector<const Var*> else_new = VisitBranchIsolated(*op->else_body_);
+    const std::unordered_set<const Var*> then_set(then_new.begin(), then_new.end());
+    for (const auto* var : else_new) {
+      if (then_set.count(var) > 0) Define(var);
+    }
+  }
+
+ private:
+  void RecordUse(const Var* var) {
+    if (var && defined_.count(var) == 0 && live_in_.insert(var).second) {
+      ordered.push_back(var);
+    }
+  }
+
+  void Define(const VarPtr& var) { Define(var.get()); }
+
+  void Define(const Var* var) {
+    if (var && defined_.insert(var).second) journal_.push_back(var);
+  }
+
+  /// Visit `body`, then roll back every definition it introduced and return
+  /// them. Undoing via the insertion journal (rather than copying ``defined_``
+  /// per arm) keeps the walk linear in the branch's own size; total work is
+  /// O(N * if-nesting depth), i.e. O(N) for the straight-line bodies that
+  /// dominate InCore scopes.
+  std::vector<const Var*> VisitBranchIsolated(const StmtPtr& body) {
+    const size_t mark = journal_.size();
+    VisitStmt(body);
+    std::vector<const Var*> introduced(journal_.begin() + static_cast<std::ptrdiff_t>(mark), journal_.end());
+    for (const auto* var : introduced) defined_.erase(var);
+    journal_.resize(mark);
+    return introduced;
+  }
+
+  std::unordered_set<const Var*> live_in_;  ///< membership view of `ordered`
+  std::unordered_set<const Var*> defined_;
+  std::vector<const Var*> journal_;  ///< insertion order, for branch rollback
 };
 
 /** @brief Visitor to build a symbol table mapping variable pointers to their types and Var objects. */
@@ -556,25 +726,54 @@ class ScopeOutliner : public IRMutator {
       reserved_func_names_->insert(outlined_func_name);
     }
 
-    // Analyze the scope body for inputs and outputs (before recursing).
-    // A single VarDefUseCollector replaces the old VarRefCollector + VarDefCollector pair.
+    // Definitions made by the scope body (before recursing) — the basis for the
+    // output set below, and for the rebind check that follows the input set.
     VarDefUseCollector body_collector;
     body_collector.VisitStmt(op->body_);
 
-    // Inputs: variables used but not defined in the scope.
-    // Iterate in first-encounter order to preserve the callee's parameter ordering.
+    // Store targets present in the scope body. Needed both for the captured
+    // read-modify-write check below and, further down, to decide whether a
+    // post-store alias's original target already appears in output_vars.
+    StoreTargetCollector store_collector;
+    store_collector.VisitStmt(op->body_);
+
+    // Inputs: the scope's live-in set — variables the body reads before it
+    // (re)defines them, so their incoming value comes from the caller.
+    // Deliberately NOT ``var_uses \ var_defs``; see UpwardExposedUseCollector
+    // for why that flow-insensitive difference drops a rebound capture.
+    //
+    // Iterate in first-read order to preserve the callee's parameter ordering.
     // var_objects_ is a pure identity symbol table (never rewritten with
     // renames), so obj_it->second is the same Var that appears in the body —
     // input_vars[i].get() is the body pointer, the key used for both the body
     // substitution and the call-site lookup below.
+    UpwardExposedUseCollector live_in;
+    live_in.VisitStmt(op->body_);
+
     std::vector<VarPtr> input_vars;
-    for (const Var* var_ptr : body_collector.var_uses_ordered) {
-      if (!body_collector.var_defs.count(var_ptr)) {
-        auto obj_it = var_objects_.find(var_ptr);
-        CHECK(obj_it != var_objects_.end())
-            << "Variable " << var_ptr->name_hint_ << " not found in var_objects";
-        input_vars.push_back(obj_it->second);
-      }
+    for (const Var* var_ptr : live_in.ordered) {
+      auto obj_it = var_objects_.find(var_ptr);
+      CHECK(obj_it != var_objects_.end())
+          << "Variable " << var_ptr->name_hint_ << " not found in var_objects";
+      input_vars.push_back(obj_it->second);
+    }
+
+    // A captured variable the body also rebinds is only representable in the
+    // outlined function when the rebind is a ``tile.store`` — that shape gets
+    // an InOut param plus a distinct result Var below (for Hierarchy scopes,
+    // only the InOut param: they skip the store-target export, so the body
+    // keeps the original rebind. Still correct — the capture is a parameter
+    // either way, which is what was broken). Anything else (e.g. a pre-SSA
+    // ``out = pl.assemble(out, ...)``) would need real SSA construction, so
+    // reject it here rather than emit a function that reassigns a variable it
+    // never declared. Unreachable on SSA input, where no live-in variable is
+    // ever assigned inside the body.
+    for (const Var* var_ptr : live_in.ordered) {
+      if (!body_collector.var_defs.count(var_ptr)) continue;
+      INTERNAL_CHECK_SPAN(store_collector.store_targets.count(var_ptr) > 0, op->span_)
+          << "Internal error: scope '" << outlined_func_name << "' captures '" << var_ptr->name_hint_
+          << "' and rebinds it under the same name without a tile.store. The outlining passes "
+             "require SSA form (IRProperty::SSAForm) — run ConvertToSSA first.";
     }
 
     // Outputs: variables defined in the scope AND used after it
@@ -589,12 +788,6 @@ class ScopeOutliner : public IRMutator {
     // to its store target so we don't export the same tensor twice.
     PostStoreAliasCollector post_store_collector;
     post_store_collector.VisitStmt(op->body_);
-
-    // Store targets present in the scope body — used to decide whether a
-    // post-store alias's original target will already appear in output_vars
-    // via the store-target-output pass below.
-    StoreTargetCollector store_collector;
-    store_collector.VisitStmt(op->body_);
 
     // Aliases deferred to the call-site emission: each pair maps a
     // scope-local SSA post-store alias (pointer identity in the scope body)
@@ -611,8 +804,7 @@ class ScopeOutliner : public IRMutator {
       auto alias_it = post_store_collector.alias_to_target.find(var_ptr);
       const Var* target_ptr =
           (alias_it != post_store_collector.alias_to_target.end()) ? alias_it->second : nullptr;
-      if (target_ptr && store_collector.store_targets.count(target_ptr) &&
-          !body_collector.var_defs.count(target_ptr)) {
+      if (target_ptr && store_collector.store_targets.count(target_ptr) && live_in.IsExternal(target_ptr)) {
         auto ext_it = var_objects_.find(target_ptr);
         CHECK(ext_it != var_objects_.end())
             << "Store target " << target_ptr->name_hint_ << " not found in var_objects";
@@ -641,10 +833,14 @@ class ScopeOutliner : public IRMutator {
     //   - body pointer (var_ptr) — kept in store_body_ptrs for the
     //     StoreEvalToAssignMutator, which matches against the un-substituted
     //     scope body where store targets retain their original pointers
+    //
+    // "External" is the live-in test, not ``!var_defs.count(...)``: a target
+    // the body rebinds under its own name (``c = pl.store(t, off, c)``) is
+    // still caller-owned, and dropping it here is what left the read dangling.
     std::unordered_map<const Var*, const Var*> store_body_ptrs;
     if (op->GetScopeKind() != ScopeKind::Hierarchy) {
       for (const Var* var_ptr : store_collector.store_targets) {
-        if (!body_collector.var_defs.count(var_ptr)) {
+        if (live_in.IsExternal(var_ptr)) {
           auto ext_it = var_objects_.find(var_ptr);
           CHECK(ext_it != var_objects_.end())
               << "Variable " << var_ptr->name_hint_ << " not found in var_objects";
@@ -766,7 +962,7 @@ class ScopeOutliner : public IRMutator {
           store_target_vars[body_it->second] = outlined_output_vars[idx];
         }
       }
-      StoreEvalToAssignMutator store_mutator(store_target_vars);
+      StoreEvalToAssignMutator store_mutator(store_target_vars, outlined_used_names);
       pre_sub_body = store_mutator.VisitStmt(pre_sub_body);
     }
 

--- a/tests/ut/ir/transforms/test_lower_auto_vector_split.py
+++ b/tests/ut/ir/transforms/test_lower_auto_vector_split.py
@@ -41,9 +41,9 @@ Negative tests keep ``pytest.raises``: a rejected transform produces no ``After`
 IR, so Before/Expected does not apply. Their ``Before`` programs are still DSL.
 
 ``_lower`` keeps the print->parse roundtrip instrument ON (see its docstring for
-why property verification is not), so the pass's output is asserted round-trippable
-on every test but one — ``test_outlined_region_still_lowers_and_stamps``, which
-opts out for an upstream reason documented at that test.
+why property verification is not), so the pass's output is asserted
+round-trippable on every test but one — ``test_outlined_region_still_lowers_and_stamps``,
+which opts out over an unrelated attr printer/parser gap documented at that test.
 
 End-to-end DSL coverage of this authoring form lives in
 ``tests/st/codegen/torch/test_torch_codegen_cross_core.py``
@@ -2400,15 +2400,27 @@ def test_outlined_region_still_lowers_and_stamps():
                 c = pl.store(pl.exp(pl.load(a, [base, 0], [64, 128])), [base, 0], c)
             return c
 
-    # This is the one test that cannot use ``_lower``: it must run with the
-    # roundtrip instrument OFF. OutlineIncoreScopes emits an InCore function that
-    # reads and writes ``c`` without declaring it a parameter
-    # (``def main_incore_0(a)`` with a free ``c``), so the outlined program does
-    # not survive print->parse ("Undefined variable 'c'") — verified BEFORE this
-    # pass runs. That is an OutlineIncoreScopes defect, not one of this pass; the
-    # region lowering below is what is under test here.
+    # ``c`` is a captured ``pl.Out`` tensor that the region rebinds under its own
+    # name. OutlineIncoreScopes captures it as an ``InOut`` param (it used to be
+    # left free, which is why this test could not reach the roundtrip instrument
+    # at all); assert that here, since the outlined program is the input this
+    # pass is under test on.
     with passes.PassContext([]):
         outlined = passes.outline_incore_scopes()(Canonical)
+    outlined_incore = [f for f in outlined.functions.values() if f.func_type == ir.FunctionType.InCore]
+    assert len(outlined_incore) == 1, "OutlineIncoreScopes should have produced one InCore function"
+    assert [p.name_hint for p in outlined_incore[0].params] == ["a", "c"], (
+        "the rebound pl.Out capture must be a parameter, not a free variable"
+    )
+    pl.parse_program(ir.python_print(outlined))  # outlined program round-trips
+
+    # Still the one test that cannot use ``_lower``, but for a narrower and
+    # unrelated reason: a ``pl.split_aiv`` region with ``mode=NONE`` stamps the
+    # function attr ``split=pl.SplitMode.NONE``, and the parser drops an explicit
+    # NONE, so print->parse loses that attr and structural equality reports
+    # "Kwargs size mismatch". That is a printer/parser gap on the attr, present
+    # on the ConvertToSSA-prefixed path too and independent of this pass.
+    with passes.PassContext([]):
         after = passes.lower_auto_vector_split()(outlined)
 
     incore = [f for f in after.functions.values() if f.func_type == ir.FunctionType.InCore]

--- a/tests/ut/ir/transforms/test_outline_incore_scopes.py
+++ b/tests/ut/ir/transforms/test_outline_incore_scopes.py
@@ -1842,5 +1842,181 @@ class TestOutlineNoDepArgs:
         )
 
 
+class TestOutlineReboundOutCapture:
+    """A captured ``pl.Out`` tensor the scope rebinds under its own name.
+
+    ``c = pl.store(t, off, c)`` is what the parser emits before ConvertToSSA
+    splits the read from the write, so ``c`` is one Var that is both read and
+    assigned inside the scope. The outlined function must capture it as an
+    ``InOut`` parameter and bind the store result to a *distinct* Var, so the
+    body neither leaves ``c`` free nor rebinds its own parameter.
+
+    These run the pass directly on parser output (no ConvertToSSA) — that is
+    precisely the input shape the flow-insensitive ``var_uses \\ var_defs``
+    partition mishandled.
+    """
+
+    @staticmethod
+    def _outlined(program: ir.Program) -> ir.Function:
+        incore = [f for f in program.functions.values() if f.func_type == ir.FunctionType.InCore]
+        assert len(incore) == 1, f"expected exactly one outlined InCore function, got {len(incore)}"
+        return incore[0]
+
+    @staticmethod
+    def _stmts(func: ir.Function) -> list[ir.Stmt]:
+        body = func.body
+        assert isinstance(body, ir.SeqStmts), f"expected a SeqStmts body, got {type(body).__name__}"
+        return list(body.stmts)
+
+    def test_rebound_out_capture_becomes_inout_param(self):
+        @pl.program
+        class Before:
+            @pl.function
+            def main(
+                self,
+                a: pl.Tensor[[128, 128], pl.FP32],
+                c: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
+            ) -> pl.Tensor[[128, 128], pl.FP32]:
+                with pl.at(level=pl.Level.CORE_GROUP):
+                    c = pl.store(pl.exp(pl.load(a, [0, 0], [128, 128])), [0, 0], c)
+                return c
+
+        with passes.PassContext([]):
+            After = passes.outline_incore_scopes()(Before)
+
+        outlined = self._outlined(After)
+        assert [p.name_hint for p in outlined.params] == ["a", "c"]
+        assert outlined.param_directions[1] == ir.ParamDirection.InOut
+
+        # The captured tensor is threaded through the call site, not dropped.
+        main = After.get_function("main")
+        assert main is not None
+        calls = [
+            s.value
+            for s in self._stmts(main)
+            if isinstance(s, ir.AssignStmt) and isinstance(s.value, ir.Call)
+        ]
+        assert len(calls) == 1, f"expected one outlined-kernel call in main, got {len(calls)}"
+        arg_names = [arg.name_hint for arg in calls[0].args if isinstance(arg, ir.Var)]
+        assert arg_names == ["a", "c"]
+
+    def test_rebound_out_capture_output_round_trips(self):
+        """The whole point: the outlined program survives print -> parse."""
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(
+                self,
+                a: pl.Tensor[[128, 128], pl.FP32],
+                c: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
+            ) -> pl.Tensor[[128, 128], pl.FP32]:
+                with pl.at(level=pl.Level.CORE_GROUP):
+                    c = pl.store(pl.exp(pl.load(a, [0, 0], [128, 128])), [0, 0], c)
+                return c
+
+        with passes.PassContext([]):
+            After = passes.outline_incore_scopes()(Before)
+
+        reparsed = pl.parse_program(ir.python_print(After))
+        ir.assert_structural_equal(reparsed, After)
+
+    def test_rebound_out_capture_in_split_aiv_region_reparses(self):
+        """The originally-reported shape: the region form used to leave ``c`` free.
+
+        Asserts parseability only, not structural equality: a ``pl.split_aiv``
+        region with ``mode=NONE`` stamps the function attr
+        ``split=pl.SplitMode.NONE``, which the parser drops on the way back in.
+        That attr gap is unrelated to the capture fix (it reproduces on the
+        ConvertToSSA-prefixed path too) — see the sibling assertion in
+        ``test_lower_auto_vector_split.py::test_outlined_region_still_lowers_and_stamps``.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(
+                self,
+                a: pl.Tensor[[128, 128], pl.FP32],
+                c: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
+            ) -> pl.Tensor[[128, 128], pl.FP32]:
+                for aiv_id in pl.split_aiv(2, mode=pl.SplitMode.NONE):
+                    base = aiv_id * 64
+                    c = pl.store(pl.exp(pl.load(a, [base, 0], [64, 128])), [base, 0], c)
+                return c
+
+        with passes.PassContext([]):
+            After = passes.outline_incore_scopes()(Before)
+
+        outlined = self._outlined(After)
+        assert [p.name_hint for p in outlined.params] == ["a", "c"]
+        pl.parse_program(ir.python_print(After))
+
+    def test_rebound_out_capture_body_is_single_assignment(self):
+        """Each store binds its own result Var; the parameter is never rebound."""
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(
+                self,
+                a: pl.Tensor[[128, 128], pl.FP32],
+                c: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
+            ) -> pl.Tensor[[128, 128], pl.FP32]:
+                with pl.at(level=pl.Level.CORE_GROUP):
+                    c = pl.store(pl.exp(pl.load(a, [0, 0], [64, 128])), [0, 0], c)
+                    c = pl.store(pl.exp(pl.load(a, [64, 0], [64, 128])), [64, 0], c)
+                return c
+
+        with passes.PassContext([]):
+            After = passes.outline_incore_scopes()(Before)
+
+        outlined = self._outlined(After)
+        param_c = outlined.params[1]
+        assigned = [s.var for s in self._stmts(outlined) if isinstance(s, ir.AssignStmt)]
+        assert len(assigned) == 2, f"expected two store results, got {len(assigned)}"
+        assert not any(v.same_as(param_c) for v in assigned), "must not rebind the InOut parameter"
+        assert not assigned[0].same_as(assigned[1]), "repeated stores need distinct result Vars"
+
+        # ...and the unchanged SSAForm verifier accepts the result.
+        with passes.PassContext([passes.VerificationInstrument(passes.VerificationMode.BEFORE)]):
+            passes.outline_cluster_scopes()(After)
+
+    def test_matches_the_convert_to_ssa_prefixed_result(self):
+        """Outlining parser output agrees with outlining its SSA form.
+
+        The pass declares ``IRProperty::SSAForm`` as a precondition; this pins
+        that honouring the rebound capture produces the same signature shape the
+        SSA path already produced, rather than a second, divergent lowering.
+        """
+
+        def build():
+            @pl.program
+            class Prog:
+                @pl.function
+                def main(
+                    self,
+                    a: pl.Tensor[[128, 128], pl.FP32],
+                    c: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
+                ) -> pl.Tensor[[128, 128], pl.FP32]:
+                    with pl.at(level=pl.Level.CORE_GROUP):
+                        c = pl.store(pl.exp(pl.load(a, [0, 0], [128, 128])), [0, 0], c)
+                    return c
+
+            return Prog
+
+        with passes.PassContext([]):
+            direct = self._outlined(passes.outline_incore_scopes()(build()))
+            via_ssa = self._outlined(passes.outline_incore_scopes()(passes.convert_to_ssa()(build())))
+
+        # ConvertToSSA versions the names (``c`` -> ``c__ssa_v0``), so compare
+        # the base names; the signature itself must otherwise be identical.
+        def base_names(func: ir.Function) -> list[str]:
+            return [p.name_hint.split("__ssa_v")[0] for p in func.params]
+
+        assert base_names(direct) == base_names(via_ssa) == ["a", "c"]
+        assert list(direct.param_directions) == list(via_ssa.param_directions)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

`OutlineIncoreScopes` emitted an InCore function that reads a captured `pl.Out` tensor without declaring it a parameter, so the outlined program no longer survived print→parse.

**Root cause.** `ScopeOutliner` partitioned scope-body variables with the flow-insensitive `var_uses \ var_defs`. A tensor that is read *and* rebound under the same name lands in both sets, so the difference dropped it from the parameter list. That is exactly what the parser emits for a captured `pl.Out` param before `ConvertToSSA` splits the read from the write — the LHS, the store destination, and the function parameter are literally one `Var`:

```python
for aiv_id in pl.split_aiv(2, mode=pl.SplitMode.NONE):
    c = pl.store(pl.exp(pl.load(a, [base, 0], [64, 128])), [base, 0], c)
```

The read then fell through to the regular-output path, whose substitution rewrote *every* occurrence — including the read — to a fresh `Var`:

```python
# before
def main_incore_0(a): ...  c = pl.tile.store(..., c) ...   # 'c' free
c = self.main_incore_0(a)                                  # 'c' dropped at the call site

# after
def main_incore_0(a, c: pl.InOut[...]):
    c__store = pl.tile.store(..., c)
    return c
c__ssa_v0 = self.main_incore_0(a, c)
```

**Fix.** Compute the scope's live-in set instead (`UpwardExposedUseCollector` — variables read before the body redefines them) and use it both for the parameter list and for the two "is this variable external?" guards. `StoreEvalToAssignMutator` now binds a read-modify-write store to a distinct result `Var`, so the outlined body never rebinds its own parameter; repeated stores to one target get distinct fresh `Var`s.

The result matches what the `ConvertToSSA`-prefixed path already produced (pinned by a test) and passes the **unchanged** SSAForm verifier — no verifier changes in this PR.

## Notes

- **No behavior change on SSA input.** Live-in and `var_uses \ var_defs` are identical there, and the traversal order deliberately mirrors `VarDefUseCollector` so outlined parameter order is unchanged.
- `Var` and `IterArg` get separate overrides rather than `VisitVarLike_` (mirroring `VarDefUseCollector`): the base `IterArg` handler descends into `initValue_`, which belongs to the enclosing loop header — descending captures an outer loop's seed tensor as a spurious parameter.
- A captured variable rebound by anything *other* than a `tile.store` needs real SSA construction, so it is rejected with an internal error pointing at `ConvertToSSA` rather than silently emitting a function that reassigns a variable it never declared. Unreachable on SSA input.
- `ScopeOutliner` is shared by the InCore, Cluster, Hierarchy and Spmd outliners; all four get the fix.
- `test_outlined_region_still_lowers_and_stamps` no longer documents the defect. It still opts out of the roundtrip instrument, but for an unrelated reason recorded there: a `mode=NONE` region stamps `split=pl.SplitMode.NONE`, which the parser drops on reparse (reproduces on the `ConvertToSSA`-prefixed path too).

## Testing

- New `TestOutlineReboundOutCapture` (5 tests): InOut capture + call-site threading, structural-equality round-trip, single-assignment body under repeated stores (plus SSAForm verification), the split_aiv region shape, and agreement with the SSA-prefixed result.
- Full suite: **8551 passed**. The one failure (`test_ir_trace.py::test_installed_console_script_preserves_main_exit_codes`) is environmental — the installed dist predates the `pypto-ir-trace` entry point; nothing here touches packaging.
- `clang-format`, `cpplint`, `ruff`, `pyright`, `markdownlint`, en↔zh doc parity: all clean.

## Documentation

`docs/{en,zh}/dev/passes/08-outline_incore_scopes.md` updated: inputs are now described as the live-in set, with the rebound-capture case, the resulting signature, and the Hierarchy-scope caveat.