### PR TITLE
fix(language): Bind pl.create_tile to one function in both namespaces

### DIFF
--- a/docs/en/user/02-operation_reference.md
+++ b/docs/en/user/02-operation_reference.md
@@ -47,7 +47,7 @@ Auto-selects between tensor and tile implementation based on input type.
 | `col_argmax` | `(input: T, tmp_tile: Tile \| None = None) -> T` | Column-wise argmax (row index of per-column max, int32 output; tile path requires `tmp_tile`) |
 | `col_argmin` | `(input: T, tmp_tile: Tile \| None = None) -> T` | Column-wise argmin (row index of per-column min, int32 output; tile path requires `tmp_tile`) |
 | `rsqrt` | `(input: T, high_precision: bool = False) -> T` | Reciprocal square root; `high_precision=True` selects the high-precision path (tensor input only — tile callers must use `pl.tile.rsqrt(src, tmp=...)`) |
-| `create` / `create_tile` | `(shape: Sequence[IntLike], dtype: DataType, target_memory: Mem) -> Tile` | Tile-only (promoted from `pl.tile.create`): create tile at specific memory space |
+| `create_tile` | `(shape: Sequence[IntLike], dtype: DataType, target_memory: Mem = Mem.Vec, transpose: bool \| None = None, *, flat_layout: bool \| None = None) -> Tile` | Tile-only (promoted from `pl.tile.create`, same function object): create tile at specific memory space. See the `pl.tile.create` row for `transpose` / `flat_layout` |
 | `read` | `(src: T, offset: IntLike \| Sequence[IntLike]) -> Scalar` | Read scalar at indices (dispatched by source type). Sugar: `A[i, j]` |
 | `write` | `(dst: T, offset: IntLike \| Sequence[IntLike], value: Scalar) -> Expr` | Write scalar at indices (dispatched by destination type). Sugar: `A[i, j] = v` |
 
@@ -113,7 +113,7 @@ Transfer data between memory hierarchy levels.
 | `read` | `(tile: Tile, indices: IntLike \| Sequence[IntLike]) -> Scalar` | Read scalar at indices. Sugar: `A[i, j]` |
 | `write` | `(tile: Tile, indices: IntLike \| Sequence[IntLike], value: Scalar \| Expr) -> Expr` | Write scalar at indices. Sugar: `A[i, j] = v` |
 | `move` | `(tile: Tile, target_memory: Mem) -> Tile` | Move tile between memory levels (including Vec→Vec) |
-| `create` | `(shape: Sequence[IntLike], dtype: DataType, target_memory: Mem = Mem.Vec) -> Tile` | Create tile at memory space |
+| `create` | `(shape: Sequence[IntLike], dtype: DataType, target_memory: Mem = Mem.Vec, transpose: bool \| None = None, *, flat_layout: bool \| None = None) -> Tile` | Create tile at memory space. `transpose=True` allocates the transposed Mat (ZN) fractal layout for a matmul `b_trans` B-operand — 2D and `target_memory=Mem.Mat` only. `flat_layout=True` (keyword-only) allocates a flat, non-fractal (`slayout=none_box`) L1 staging buffer — `Mem.Mat` only, mutually exclusive with `transpose` |
 | `full` | `(shape: list[int], dtype: DataType, value: int \| float) -> Tile` | Create tile filled with constant |
 | `random` | `(key0, key1, counter0, counter1, counter2, counter3: int \| Scalar, shape: Sequence[int], valid_shape: Sequence[int] \| None = None, dtype: DataType = UINT32, rounds: int = 10) -> Tile` | Fill a tile with counter-based (Philox/ChaCha-style) pseudo-random values from a 64-bit key + 128-bit counter. Deterministic: same seeds → same tile. Optional `valid_shape` (each dim `<= shape`) writes only the valid rows/cols, leaving the rest untouched. `dtype` ∈ {INT32, UINT32}; `rounds` ∈ {7, 10}. 2D shape only. **A5 only** (`pto.trandom`) |
 | `fillpad` | `(input: Tensor \| Tile, pad_value: PadValue \| int \| float = PadValue.zero) -> Tensor \| Tile` | Fill invalid view elements using the requested pad value; accepts the `PadValue.zero/max/min` enum or the literal sugars `0`, `0.0`, `math.inf`, `-math.inf` (other values raise). Tensor inputs lower to tile fillpad in InCore code |

--- a/docs/zh/user/02-operation_reference.md
+++ b/docs/zh/user/02-operation_reference.md
@@ -47,7 +47,7 @@
 | `col_argmax` | `(input: T, tmp_tile: Tile \| None = None) -> T` | 列 argmax（每列最大值的行索引，int32 输出；tile 路径需要 `tmp_tile`） |
 | `col_argmin` | `(input: T, tmp_tile: Tile \| None = None) -> T` | 列 argmin（每列最小值的行索引，int32 输出；tile 路径需要 `tmp_tile`） |
 | `rsqrt` | `(input: T, high_precision: bool = False) -> T` | 倒数平方根；`high_precision=True` 选择高精度路径（仅对 Tensor 输入生效，Tile 路径需要改用 `pl.tile.rsqrt(src, tmp=...)`） |
-| `create` / `create_tile` | `(shape: Sequence[IntLike], dtype: DataType, target_memory: Mem) -> Tile` | 在指定内存空间创建 tile（tile-only，对应 `pl.tile.create`） |
+| `create_tile` | `(shape: Sequence[IntLike], dtype: DataType, target_memory: Mem = Mem.Vec, transpose: bool \| None = None, *, flat_layout: bool \| None = None) -> Tile` | 在指定内存空间创建 tile（tile-only，与 `pl.tile.create` 为同一个函数对象）。`transpose` / `flat_layout` 说明见下方 `pl.tile.create` 条目 |
 | `read` | `(src: T, offset: IntLike \| Sequence[IntLike]) -> Scalar` | 读取指定索引的标量（按源类型分发）。语法糖：`A[i, j]` |
 | `write` | `(dst: T, offset: IntLike \| Sequence[IntLike], value: Scalar) -> Expr` | 写入指定索引的标量（按目标类型分发）。语法糖：`A[i, j] = v` |
 
@@ -113,7 +113,7 @@
 | `read` | `(tile: Tile, indices: IntLike \| Sequence[IntLike]) -> Scalar` | 读取指定索引的标量。语法糖：`A[i, j]` |
 | `write` | `(tile: Tile, indices: IntLike \| Sequence[IntLike], value: Scalar \| Expr) -> Expr` | 写入指定索引的标量。语法糖：`A[i, j] = v` |
 | `move` | `(tile: Tile, target_memory: Mem) -> Tile` | 在内存层级间移动 tile（包括 Vec→Vec 拷贝） |
-| `create` | `(shape: Sequence[IntLike], dtype: DataType, target_memory: Mem = Mem.Vec) -> Tile` | 在指定内存空间创建 tile |
+| `create` | `(shape: Sequence[IntLike], dtype: DataType, target_memory: Mem = Mem.Vec, transpose: bool \| None = None, *, flat_layout: bool \| None = None) -> Tile` | 在指定内存空间创建 tile。`transpose=True` 分配转置的 Mat（ZN）分形布局，用于 matmul `b_trans` 的 B 操作数——仅支持 2D 且 `target_memory=Mem.Mat`。`flat_layout=True`（仅关键字参数）分配扁平的非分形（`slayout=none_box`）L1 暂存缓冲区——仅支持 `Mem.Mat`，且与 `transpose` 互斥 |
 | `full` | `(shape: list[int], dtype: DataType, value: int \| float) -> Tile` | 创建用常量填充的 tile |
 | `random` | `(key0, key1, counter0, counter1, counter2, counter3: int \| Scalar, shape: Sequence[int], valid_shape: Sequence[int] \| None = None, dtype: DataType = UINT32, rounds: int = 10) -> Tile` | 用基于计数器的（Philox/ChaCha 风格）伪随机值填充 tile，种子为 64 位 key + 128 位 counter。确定性：相同种子产生相同 tile。可选 `valid_shape`（每维 `<= shape`）只写入有效行/列，其余保持不变。`dtype` ∈ {INT32, UINT32}；`rounds` ∈ {7, 10}。仅支持 2D shape。**仅 A5**（`pto.trandom`） |
 | `fillpad` | `(input: Tensor \| Tile, pad_value: PadValue \| int \| float = PadValue.zero) -> Tensor \| Tile` | 按指定 pad 值填充无效视图区域；接受 `PadValue.zero/max/min` 枚举，或字面量 `0`、`0.0`、`math.inf`、`-math.inf`（其他值会报错）；Tensor 输入会在 InCore 代码中下沉为 tile fillpad |

--- a/python/pypto/language/op/__init__.py
+++ b/python/pypto/language/op/__init__.py
@@ -66,15 +66,16 @@ from .tensor_ops import (
 from .tensor_ops import ci as arange
 from .tensor_ops import create as create_tensor
 
-# Promoted tile-only ops (accessible as pl.load, etc.). ``abs``,
-# ``create_tile`` and the bitwise family are re-exported below from
-# ``unified_ops`` instead so the unified Tensor/Tile dispatch wins.
+# Promoted tile-only ops (accessible as pl.load, etc.). ``abs`` and the
+# bitwise family are re-exported below from ``unified_ops`` instead so the
+# unified Tensor/Tile dispatch wins.
 from .tile_ops import (
     addc,
     addsc,
     aic_gather,
     aiv_shard,
     cmps,
+    create_tile,
     gemv,
     gemv_acc,
     gemv_bias,
@@ -99,9 +100,11 @@ from .tile_ops import (
 )
 
 # Unified dispatch (overlapping ops). Imported AFTER tile_ops so the
-# unified versions override any same-named imports above (e.g. ``abs``,
-# ``create_tile``) — direct ``pl.abs(tensor)`` users get the unified
-# dispatch rather than the Tile-only path.
+# unified versions override any same-named imports above (e.g. ``abs``) —
+# direct ``pl.abs(tensor)`` users get the unified dispatch rather than the
+# Tile-only path. Only names that genuinely dispatch on Tensor/Tile belong
+# here: a pure forwarder would shadow the tile_ops version with a narrower
+# signature, and the parser resolves ``pl.<op>`` against this namespace.
 from .unified_ops import (
     abs,  # noqa: A004 (intentionally shadows builtin via DSL surface)
     add,
@@ -125,7 +128,6 @@ from .unified_ops import (
     col_prod,
     col_sum,
     concat,
-    create_tile,
     div,
     exp,
     expands,

--- a/python/pypto/language/op/unified_ops.py
+++ b/python/pypto/language/op/unified_ops.py
@@ -91,7 +91,6 @@ __all__ = [
     "shr",
     "shrs",
     "set_validshape",
-    "create_tile",
     "read",
     "write",
 ]
@@ -99,7 +98,7 @@ __all__ = [
 from pypto.ir.utils import _get_span_or_capture, resolve_cast_mode
 from pypto.pypto_core import DataType
 from pypto.pypto_core import ir as _ir_core
-from pypto.pypto_core.ir import MemorySpace, PadValue
+from pypto.pypto_core.ir import PadValue
 
 from ..typing import IntLike, Scalar, Tensor, Tile
 from . import tensor_ops as _tensor
@@ -1319,25 +1318,6 @@ def set_validshape(input, valid_rows, valid_cols):
     if isinstance(input, Tile):
         return _tile.set_validshape(input, valid_rows, valid_cols)
     raise TypeError(f"pl.set_validshape: expected Tensor or Tile, got {type(input).__name__}")
-
-
-# ---------------------------------------------------------------------------
-# Tile-only ops promoted to unified namespace
-# ---------------------------------------------------------------------------
-
-
-def create_tile(
-    shape: list[int],
-    dtype: DataType,
-    target_memory: MemorySpace = MemorySpace.Vec,
-) -> Tile:
-    """Create a tile at specific memory space.
-
-    ``target_memory`` defaults to ``Vec`` to match the underlying
-    ``tile.create`` wrapper — direct callers like
-    ``pl.create_tile(shape, dtype)`` (omitting target_memory) keep working.
-    """
-    return _tile.create(shape, dtype, target_memory)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/ut/language/test_unified_ops.py
+++ b/tests/ut/language/test_unified_ops.py
@@ -18,7 +18,7 @@ import pypto.language as pl
 import pypto.language.op as language_op
 import pytest
 from pypto import DataType, ir
-from pypto.language.op import unified_ops
+from pypto.language.op import tile_ops, unified_ops
 from pypto.language.typing import Scalar, Tensor, Tile
 
 
@@ -1076,6 +1076,88 @@ class TestPromotedOps:
         assert language_op.reinterpret_view is unified_ops.reinterpret_view
         assert "reinterpret_view" in pl.__all__
         assert "reinterpret_view" in language_op.__all__
+
+    def test_namespaces_agree_on_shared_names(self):
+        """A DSL name must resolve to one object in ``pl`` and ``pl.op``.
+
+        The parser resolves unified ``pl.<op>`` calls against
+        ``pypto.language.op``, while ``inspect.signature``, IDE autocomplete and
+        docstrings all show what ``pypto.language`` exports. A name bound to two
+        different functions makes the parser reject arguments the visible
+        signature advertises.
+        """
+        divergent = {
+            name: (
+                getattr(getattr(pl, name), "__module__", repr(getattr(pl, name))),
+                getattr(getattr(language_op, name), "__module__", repr(getattr(language_op, name))),
+            )
+            for name in dir(language_op)
+            if not name.startswith("_")
+            and hasattr(pl, name)
+            and getattr(pl, name) is not getattr(language_op, name)
+            and callable(getattr(language_op, name))
+        }
+        assert not divergent, (
+            f"names bound to different objects in pypto.language vs pypto.language.op: {divergent}"
+        )
+
+    def test_create_tile_single_binding(self):
+        """``create_tile`` is the ``tile_ops.create`` alias in both namespaces."""
+        assert pl.create_tile is language_op.create_tile is tile_ops.create
+        assert "create_tile" in pl.__all__
+        assert "create_tile" in language_op.__all__
+
+    def test_promoted_create_tile_transpose(self):
+        """``pl.create_tile(..., transpose=True)`` matches the explicit form.
+
+        ``transpose=True`` is Mat-only (L1) and 2D-only — it allocates the
+        transposed ZN fractal layout for a matmul ``b_trans`` B-operand.
+        """
+
+        @pl.function(type=pl.FunctionType.InCore)
+        def unified(src: pl.Tensor[[256, 128], pl.BF16]) -> pl.Tensor[[256, 128], pl.BF16]:
+            _t: pl.Tile[[16, 128], pl.BF16] = pl.create_tile(
+                [16, 128], dtype=pl.BF16, target_memory=pl.Mem.Mat, transpose=True
+            )
+            return src
+
+        @pl.function(type=pl.FunctionType.InCore)
+        def explicit(src: pl.Tensor[[256, 128], pl.BF16]) -> pl.Tensor[[256, 128], pl.BF16]:
+            _t: pl.Tile[[16, 128], pl.BF16] = pl.tile.create(
+                [16, 128], dtype=pl.BF16, target_memory=pl.Mem.Mat, transpose=True
+            )
+            return src
+
+        ir.assert_structural_equal(unified, explicit)
+        # The kwarg must take effect, not merely be accepted: transpose flips
+        # the sub-block layout to col_major (ZN).
+        assert "slayout=pl.TileLayout.col_major" in unified.as_python()
+
+    def test_promoted_create_tile_flat_layout(self):
+        """``pl.create_tile(..., flat_layout=True)`` matches the explicit form.
+
+        ``flat_layout`` is keyword-only and allocates a flat (non-fractal,
+        ``slayout=none_box``) L1 staging buffer.
+        """
+
+        @pl.function(type=pl.FunctionType.InCore)
+        def unified(src: pl.Tensor[[256, 128], pl.BF16]) -> pl.Tensor[[256, 128], pl.BF16]:
+            _t: pl.Tile[[16, 128], pl.BF16] = pl.create_tile(
+                [16, 128], dtype=pl.BF16, target_memory=pl.Mem.Mat, flat_layout=True
+            )
+            return src
+
+        @pl.function(type=pl.FunctionType.InCore)
+        def explicit(src: pl.Tensor[[256, 128], pl.BF16]) -> pl.Tensor[[256, 128], pl.BF16]:
+            _t: pl.Tile[[16, 128], pl.BF16] = pl.tile.create(
+                [16, 128], dtype=pl.BF16, target_memory=pl.Mem.Mat, flat_layout=True
+            )
+            return src
+
+        ir.assert_structural_equal(unified, explicit)
+        # The kwarg must take effect, not merely be accepted: flat_layout drops
+        # the fractal sub-block boxing.
+        assert "slayout=pl.TileLayout.none_box" in unified.as_python()
 
     def test_promoted_create(self):
         @pl.function


### PR DESCRIPTION
## Summary

`create_tile` resolved to two different functions:

| Namespace | Resolved to | Signature |
| --------- | ----------- | --------- |
| `pypto.language.create_tile` | `op/tile_ops.py` (`create_tile = create`) | `(shape, dtype, target_memory=Vec, transpose=None, *, flat_layout=None)` |
| `pypto.language.op.create_tile` | `op/unified_ops.py` | `(shape, dtype, target_memory=Vec)` |

The DSL parser resolves unified `pl.<op>` calls against `pypto.language.op`, so inside a `@pl.function` body it got the 3-parameter forwarder and rejected `transpose=` / `flat_layout=` — parameters that `inspect.signature`, IDE autocomplete and the docstring all advertise on the `pl.create_tile` a user can reach everywhere else.

The unified block is imported after `tile_ops` so genuine Tensor/Tile dispatchers (`abs`, the bitwise family) win. That rationale never applied here: `create_tile` is Tile-only — the Tensor counterpart is a separately named `create_tensor` — and `unified_ops.create_tile` performed no dispatch at all. It was a pure forwarder whose only effect was to narrow the signature.

**Fix:** delete the forwarder rather than widen it. Widening fixes today's symptom but leaves the duplicate definition in place, so the next parameter added to `tile_ops.create` reintroduces the identical bug. `tile_ops.create_tile` already aliases `create`, so the name stays exported from both namespaces.

### Changes

| File | Change |
| ---- | ------ |
| `python/pypto/language/op/unified_ops.py` | Remove the forwarder, its `__all__` entry, and the now-unused `MemorySpace` import |
| `python/pypto/language/op/__init__.py` | Import `create_tile` from `tile_ops`; correct both rationale comments |
| `tests/ut/language/test_unified_ops.py` | Namespace guard + single-binding test + `transpose` / `flat_layout` regressions |
| `docs/{en,zh}/user/02-operation_reference.md` | Real signature and `transpose` / `flat_layout` semantics |

`create_tile` was the only name exported under both namespaces that resolved to two different objects — this was isolated, not systemic. The `pld` / `pld.op` namespaces have no equivalent divergence.

## Testing

- [x] All tests pass — full `tests/ut`: 8579 passed, 2 skipped. The one failure, `test_ir_trace.py::test_installed_console_script_preserves_main_exit_codes`, asserts a `pypto-ir-trace` console script exists in the environment; it is byte-identical on `main` and unaffected by this change.
- [x] Code review completed
- [x] Documentation updated

`test_namespaces_agree_on_shared_names` asserts every callable exported from both `pypto.language` and `pypto.language.op` resolves to the same object, so any future shadow of this class fails loudly. It was verified to fail against the pre-fix state.

The two op regressions assert on the emitted layout (`slayout=col_major` / `none_box`) rather than only that the call parses, so they also catch the failure mode where a kwarg is accepted and then silently dropped.

## Related Issues

Fixes #2265