### PR TITLE
fix(dsl): Reject cross-path kwargs in unified ops instead of dropping them

### DIFF
--- a/docs/en/user/02-operation_reference.md
+++ b/docs/en/user/02-operation_reference.md
@@ -8,6 +8,14 @@ All operations are accessed via `import pypto.language as pl`.
 
 Auto-selects between tensor and tile implementation based on input type.
 
+**Path-specific kwargs raise rather than being dropped.** A few operations take a kwarg that only
+one level can honour — a tensor value has no layout, so `matmul` needs `a_trans` / `b_trans`
+flags, while at tile level transposition is a *type* property expressed with
+`pl.tile.transpose_view(...)`; conversely a tile's scratch buffer must be supplied by the caller,
+while the tensor path has the compiler allocate it. Passing such a kwarg with a non-default value
+to the wrong path raises `TypeError` naming the offending kwarg and the level-appropriate
+alternative. Passing the documented default (e.g. `b_trans=False`) is a no-op and stays accepted.
+
 | Name | Signature | Description |
 | ---- | --------- | ----------- |
 | `add` | `(lhs: T, rhs: T \| int \| float \| Scalar) -> T` | Element-wise addition |
@@ -33,20 +41,21 @@ Auto-selects between tensor and tile implementation based on input type.
 | `reshape` | `(input: T, shape: Sequence[IntLike]) -> T` | Reshape to new dimensions |
 | `transpose` | `(input: T, axis1: int, axis2: int) -> T` | Swap two axes |
 | `slice` | `(input: T, shape: Sequence[IntLike], offset: Sequence[IntLike]) -> T` | Slice with offset |
-| `matmul` | `(lhs: T, rhs: T, out_dtype=None, a_trans=False, b_trans=False, c_matrix_nz=False) -> T` | Matrix multiplication |
-| `matmul_acc` | `(acc: T, lhs: T, rhs: T, a_trans=False, b_trans=False) -> T` | Matrix multiply with accumulation: `acc += lhs @ rhs` |
-| `row_max` | `(input: T, tmp_tile: Tile \| None = None) -> T` | Row-wise max (tile path requires `tmp_tile`) |
-| `row_sum` | `(input: T, tmp_tile: Tile \| None = None) -> T` | Row-wise sum (tile path requires `tmp_tile`) |
-| `row_prod` | `(input: T, tmp_tile: Tile \| None = None) -> T` | Row-wise product (tile path requires `tmp_tile`) |
-| `col_sum` | `(input: T, tmp_tile: Tile \| None = None) -> T` | Column-wise sum. On Tile, passing `tmp_tile` activates binary-tree reduction; omitting it uses sequential reduction. Tensor input lowers to the sequential path. |
+| `matmul` | `(lhs: Tensor, rhs: Tensor, out_dtype=None, a_trans=False, b_trans=False, c_matrix_nz=False) -> Tensor` or `(lhs: Tile, rhs: Tile, out_dtype=None) -> Tile` | Matrix multiplication. `a_trans` / `b_trans` / `c_matrix_nz` are Tensor-only and raise on the Tile path — pass `pl.tile.transpose_view(operand)` instead. `tile.matmul`'s dtype is fixed by the Cube accumulator (FP32 for float operands, INT32 for int), so an `out_dtype` there is accepted only when it matches that deduction and otherwise raises; use `pl.cast` or let `pl.tile.store` narrow on the way to GM |
+| `matmul_acc` | `(acc: Tensor, lhs: Tensor, rhs: Tensor, a_trans=False, b_trans=False) -> Tensor` or `(acc: Tile, lhs: Tile, rhs: Tile) -> Tile` | Matrix multiply with accumulation: `acc += lhs @ rhs`. Same Tensor-only transpose-flag rule as `matmul` |
+| `row_max` | `(input: Tensor) -> Tensor` or `(input: Tile, tmp_tile: Tile) -> Tile` | Row-wise max. `tmp_tile` is required on the Tile path and rejected on the Tensor path (the scratch is allocated during lowering) |
+| `row_sum` | `(input: Tensor) -> Tensor` or `(input: Tile, tmp_tile: Tile) -> Tile` | Row-wise sum; same `tmp_tile` rule as `row_max` |
+| `row_min` | `(input: Tensor) -> Tensor` or `(input: Tile, tmp_tile: Tile) -> Tile` | Row-wise min; same `tmp_tile` rule as `row_max` |
+| `row_prod` | `(input: Tensor) -> Tensor` or `(input: Tile, tmp_tile: Tile) -> Tile` | Row-wise product; same `tmp_tile` rule as `row_max` |
+| `col_sum` | `(input: Tensor) -> Tensor` or `(input: Tile, tmp_tile: Tile \| None = None) -> Tile` | Column-wise sum. On Tile, passing `tmp_tile` activates binary-tree reduction; omitting it uses sequential reduction. Tensor input always lowers to the sequential path and rejects `tmp_tile`, since it could not select the requested strategy |
 | `col_max` | `(input: T) -> T` | Column-wise max |
 | `col_min` | `(input: T) -> T` | Column-wise min |
 | `col_prod` | `(input: T) -> T` | Column-wise product |
-| `row_argmax` | `(input: T, tmp_tile: Tile \| None = None) -> T` | Row-wise argmax (column index of per-row max, int32 output; tile path requires `tmp_tile`) |
-| `row_argmin` | `(input: T, tmp_tile: Tile \| None = None) -> T` | Row-wise argmin (column index of per-row min, int32 output; tile path requires `tmp_tile`) |
-| `col_argmax` | `(input: T, tmp_tile: Tile \| None = None) -> T` | Column-wise argmax (row index of per-column max, int32 output; tile path requires `tmp_tile`) |
-| `col_argmin` | `(input: T, tmp_tile: Tile \| None = None) -> T` | Column-wise argmin (row index of per-column min, int32 output; tile path requires `tmp_tile`) |
-| `rsqrt` | `(input: T, high_precision: bool = False) -> T` | Reciprocal square root; `high_precision=True` selects the high-precision path (tensor input only — tile callers must use `pl.tile.rsqrt(src, tmp=...)`) |
+| `row_argmax` | `(input: Tensor) -> Tensor` or `(input: Tile, tmp_tile: Tile) -> Tile` | Row-wise argmax (column index of per-row max, int32 output); same `tmp_tile` rule as `row_max` |
+| `row_argmin` | `(input: Tensor) -> Tensor` or `(input: Tile, tmp_tile: Tile) -> Tile` | Row-wise argmin (column index of per-row min, int32 output); same `tmp_tile` rule as `row_max` |
+| `col_argmax` | `(input: Tensor) -> Tensor` or `(input: Tile, tmp_tile: Tile) -> Tile` | Column-wise argmax (row index of per-column max, int32 output); same `tmp_tile` rule as `row_max` |
+| `col_argmin` | `(input: Tensor) -> Tensor` or `(input: Tile, tmp_tile: Tile) -> Tile` | Column-wise argmin (row index of per-column min, int32 output); same `tmp_tile` rule as `row_max` |
+| `rsqrt` | `(input: Tensor, high_precision: bool = False) -> Tensor` or `(input: Tile) -> Tile` | Reciprocal square root; `high_precision=True` selects the high-precision path and is Tensor-only. The tile form selects precision by *taking* a scratch tile, so tile callers use `pl.tile.rsqrt(tile, tmp)` and `high_precision=True` with a Tile raises |
 | `create_tile` | `(shape: Sequence[IntLike], dtype: DataType, target_memory: Mem = Mem.Vec, transpose: bool \| None = None, *, flat_layout: bool \| None = None) -> Tile` | Tile-only (promoted from `pl.tile.create`, same function object): create tile at specific memory space. See the `pl.tile.create` row for `transpose` / `flat_layout` |
 | `read` | `(src: T, offset: IntLike \| Sequence[IntLike]) -> Scalar` | Read scalar at indices (dispatched by source type). Sugar: `A[i, j]` |
 | `write` | `(dst: T, offset: IntLike \| Sequence[IntLike], value: Scalar) -> Expr` | Write scalar at indices (dispatched by destination type). Sugar: `A[i, j] = v` |

--- a/docs/zh/user/02-operation_reference.md
+++ b/docs/zh/user/02-operation_reference.md
@@ -8,6 +8,12 @@
 
 根据输入类型自动选择 tensor 或 tile 实现。
 
+**路径专属的关键字参数会报错，而不会被静默丢弃。** 少数操作的某个关键字参数只有一个层级能够兑现：
+tensor 值不携带 layout，因此 `matmul` 需要 `a_trans` / `b_trans` 标志；而在 tile 层，转置是一个*类型*属性，
+用 `pl.tile.transpose_view(...)` 表达。反过来，tile 的临时缓冲区必须由调用方提供，tensor 路径则由编译器分配。
+把这类关键字参数以非默认值传给错误的路径会抛出 `TypeError`，并指明具体参数名与对应层级的替代写法。
+传入文档所述的默认值（例如 `b_trans=False`）是空操作，仍然接受。
+
 | 名称 | 签名 | 说明 |
 | ---- | ---- | ---- |
 | `add` | `(lhs: T, rhs: T \| int \| float \| Scalar) -> T` | 逐元素加法 |
@@ -33,20 +39,21 @@
 | `reshape` | `(input: T, shape: Sequence[IntLike]) -> T` | 变形为新维度 |
 | `transpose` | `(input: T, axis1: int, axis2: int) -> T` | 交换两个轴 |
 | `slice` | `(input: T, shape: Sequence[IntLike], offset: Sequence[IntLike]) -> T` | 带偏移的切片 |
-| `matmul` | `(lhs: T, rhs: T, out_dtype=None, a_trans=False, b_trans=False, c_matrix_nz=False) -> T` | 矩阵乘法 |
-| `matmul_acc` | `(acc: T, lhs: T, rhs: T, a_trans=False, b_trans=False) -> T` | 带累加的矩阵乘法：`acc += lhs @ rhs` |
-| `row_max` | `(input: T, tmp_tile: Tile \| None = None) -> T` | 行最大值（tile 路径需要 `tmp_tile`） |
-| `row_sum` | `(input: T, tmp_tile: Tile \| None = None) -> T` | 行求和（tile 路径需要 `tmp_tile`） |
-| `row_prod` | `(input: T, tmp_tile: Tile \| None = None) -> T` | 行乘积（tile 路径需要 `tmp_tile`） |
-| `col_sum` | `(input: T, tmp_tile: Tile \| None = None) -> T` | 列求和；Tile 上传入 `tmp_tile` 启用二叉树归约，省略时使用顺序归约；Tensor 输入下沉为顺序归约路径 |
+| `matmul` | `(lhs: Tensor, rhs: Tensor, out_dtype=None, a_trans=False, b_trans=False, c_matrix_nz=False) -> Tensor` 或 `(lhs: Tile, rhs: Tile, out_dtype=None) -> Tile` | 矩阵乘法。`a_trans` / `b_trans` / `c_matrix_nz` 仅 Tensor 可用，在 Tile 路径上会报错 —— 改为传入 `pl.tile.transpose_view(operand)`。`tile.matmul` 的输出 dtype 由 Cube 累加器固定（浮点输入为 FP32，整型输入为 INT32），因此 Tile 路径上的 `out_dtype` 只有与该推导一致时才接受，否则报错；需要其他 dtype 时用 `pl.cast`，或交给 `pl.tile.store` 在写回 GM 时收窄 |
+| `matmul_acc` | `(acc: Tensor, lhs: Tensor, rhs: Tensor, a_trans=False, b_trans=False) -> Tensor` 或 `(acc: Tile, lhs: Tile, rhs: Tile) -> Tile` | 带累加的矩阵乘法：`acc += lhs @ rhs`。转置标志的 Tensor 专属规则与 `matmul` 相同 |
+| `row_max` | `(input: Tensor) -> Tensor` 或 `(input: Tile, tmp_tile: Tile) -> Tile` | 行最大值。`tmp_tile` 在 Tile 路径上必填，在 Tensor 路径上会被拒绝（临时 tile 由下沉阶段分配） |
+| `row_sum` | `(input: Tensor) -> Tensor` 或 `(input: Tile, tmp_tile: Tile) -> Tile` | 行求和；`tmp_tile` 规则同 `row_max` |
+| `row_min` | `(input: Tensor) -> Tensor` 或 `(input: Tile, tmp_tile: Tile) -> Tile` | 行最小值；`tmp_tile` 规则同 `row_max` |
+| `row_prod` | `(input: Tensor) -> Tensor` 或 `(input: Tile, tmp_tile: Tile) -> Tile` | 行乘积；`tmp_tile` 规则同 `row_max` |
+| `col_sum` | `(input: Tensor) -> Tensor` 或 `(input: Tile, tmp_tile: Tile \| None = None) -> Tile` | 列求和；Tile 上传入 `tmp_tile` 启用二叉树归约，省略时使用顺序归约。Tensor 输入始终下沉为顺序归约路径，因此无法兑现所请求的策略，传入 `tmp_tile` 会被拒绝 |
 | `col_max` | `(input: T) -> T` | 列最大值 |
 | `col_min` | `(input: T) -> T` | 列最小值 |
 | `col_prod` | `(input: T) -> T` | 列乘积 |
-| `row_argmax` | `(input: T, tmp_tile: Tile \| None = None) -> T` | 行 argmax（每行最大值的列索引，int32 输出；tile 路径需要 `tmp_tile`） |
-| `row_argmin` | `(input: T, tmp_tile: Tile \| None = None) -> T` | 行 argmin（每行最小值的列索引，int32 输出；tile 路径需要 `tmp_tile`） |
-| `col_argmax` | `(input: T, tmp_tile: Tile \| None = None) -> T` | 列 argmax（每列最大值的行索引，int32 输出；tile 路径需要 `tmp_tile`） |
-| `col_argmin` | `(input: T, tmp_tile: Tile \| None = None) -> T` | 列 argmin（每列最小值的行索引，int32 输出；tile 路径需要 `tmp_tile`） |
-| `rsqrt` | `(input: T, high_precision: bool = False) -> T` | 倒数平方根；`high_precision=True` 选择高精度路径（仅对 Tensor 输入生效，Tile 路径需要改用 `pl.tile.rsqrt(src, tmp=...)`） |
+| `row_argmax` | `(input: Tensor) -> Tensor` 或 `(input: Tile, tmp_tile: Tile) -> Tile` | 行 argmax（每行最大值的列索引，int32 输出）；`tmp_tile` 规则同 `row_max` |
+| `row_argmin` | `(input: Tensor) -> Tensor` 或 `(input: Tile, tmp_tile: Tile) -> Tile` | 行 argmin（每行最小值的列索引，int32 输出）；`tmp_tile` 规则同 `row_max` |
+| `col_argmax` | `(input: Tensor) -> Tensor` 或 `(input: Tile, tmp_tile: Tile) -> Tile` | 列 argmax（每列最大值的行索引，int32 输出）；`tmp_tile` 规则同 `row_max` |
+| `col_argmin` | `(input: Tensor) -> Tensor` 或 `(input: Tile, tmp_tile: Tile) -> Tile` | 列 argmin（每列最小值的行索引，int32 输出）；`tmp_tile` 规则同 `row_max` |
+| `rsqrt` | `(input: Tensor, high_precision: bool = False) -> Tensor` 或 `(input: Tile) -> Tile` | 倒数平方根；`high_precision=True` 选择高精度路径，仅 Tensor 可用。tile 形式通过*传入*临时 tile 来选择精度，因此 tile 调用方应使用 `pl.tile.rsqrt(tile, tmp)`；对 Tile 传入 `high_precision=True` 会报错 |
 | `create_tile` | `(shape: Sequence[IntLike], dtype: DataType, target_memory: Mem = Mem.Vec, transpose: bool \| None = None, *, flat_layout: bool \| None = None) -> Tile` | 在指定内存空间创建 tile（tile-only，与 `pl.tile.create` 为同一个函数对象）。`transpose` / `flat_layout` 说明见下方 `pl.tile.create` 条目 |
 | `read` | `(src: T, offset: IntLike \| Sequence[IntLike]) -> Scalar` | 读取指定索引的标量（按源类型分发）。语法糖：`A[i, j]` |
 | `write` | `(dst: T, offset: IntLike \| Sequence[IntLike], value: Scalar) -> Expr` | 写入指定索引的标量（按目标类型分发）。语法糖：`A[i, j] = v` |

--- a/python/pypto/language/op/unified_ops.py
+++ b/python/pypto/language/op/unified_ops.py
@@ -95,7 +95,7 @@ __all__ = [
     "write",
 ]
 
-from pypto.ir.utils import _get_span_or_capture, resolve_cast_mode
+from pypto.ir.utils import _elem_dtype, _get_span_or_capture, resolve_cast_mode
 from pypto.pypto_core import DataType
 from pypto.pypto_core import ir as _ir_core
 from pypto.pypto_core.ir import PadValue
@@ -135,6 +135,81 @@ def _raise_type_dispatch_error(op_name: str, *args: object) -> NoReturn:
             f"level — either all Tensor or all Tile"
         )
     raise TypeError(f"{qualified}: expected Tensor or Tile operands, got ({types})")
+
+
+# ---------------------------------------------------------------------------
+# Cross-path kwarg guards
+#
+# These wrappers accept the union of both levels' kwargs, so a kwarg that only
+# the *other* dispatch path can honour must raise rather than be dropped: a
+# silently discarded ``b_trans`` compiles wrong math, and a discarded scratch
+# tile leaves the caller's buffer dead while it still consumes UB budget.
+# Only a non-default value raises — spelling out the documented default keeps
+# working.
+# ---------------------------------------------------------------------------
+
+# Remedies for kwargs the Tile dispatch path cannot honour. Module constants so
+# the guarded call sites stay one line per kwarg.
+_TILE_TRANSPOSE_REMEDY = (
+    "At tile level a transposed operand is an explicit zero-copy view, not an op flag: "
+    "wrap the operand with pl.tile.transpose_view(...) and pass it directly."
+)
+_TILE_C_MATRIX_NZ_REMEDY = (
+    "The tile matmul result layout is fixed by its Acc tile type; there is no "
+    "tile-level equivalent of this tensor-level flag."
+)
+_TILE_RSQRT_PRECISION_REMEDY = (
+    "The tile form selects precision by taking a scratch tile: pl.tile.rsqrt(tile, tmp)."
+)
+
+
+def _reject_tmp_for_tensor(op_name: str, tmp: Any, param: str = "tmp") -> None:
+    """Guard the Tensor path of an op whose Tile form carries a scratch operand."""
+    if tmp is not None:
+        raise TypeError(
+            f"pl.{op_name}: Tensor inputs must not pass {param} — the scratch tile is "
+            f"allocated during Tensor-to-Tile lowering"
+        )
+
+
+def _reject_tile_unsupported(op_name: str, /, **flags: tuple[bool, str]) -> None:
+    """Guard the Tile path against Tensor-only flags it cannot honour.
+
+    Each entry maps a kwarg name to ``(is_non_default, remedy)``. ``op_name`` is
+    positional-only so it cannot collide with a guarded kwarg of the same name.
+    """
+    for name, (given, remedy) in flags.items():
+        if given:
+            raise TypeError(f"pl.{op_name}: '{name}' is not supported for Tile operands. {remedy}")
+
+
+def _check_tile_matmul_out_dtype(result: Tile, out_dtype: int | DataType | None) -> None:
+    """Accept a Tile-path ``out_dtype`` only when it matches the deduced dtype.
+
+    ``tile.matmul``'s result dtype is fixed by the Cube accumulator, so the only
+    honourable request is the one already satisfied. The deduced dtype is read
+    off the built call rather than re-deriving the C++ rule here.
+
+    The Tile ``@overload`` narrows ``out_dtype`` to ``DataType | None``, so a raw
+    ``int`` dtype code is already a static error; this still accepts one at
+    runtime and rejects it, because the DSL parser reaches this wrapper
+    dynamically. ``DataType`` exposes no Python int conversion, so an int cannot
+    be verified against the deduction — and skipping verification is the very
+    defect this guard exists to prevent.
+    """
+    if out_dtype is None:
+        return
+    # ``deduced`` is None only if the built call were not tile/tensor-typed, which
+    # tile.matmul never produces — the guard just avoids a nonsense "deduced as
+    # None" message if that ever changes.
+    deduced = _elem_dtype(result.unwrap())
+    if deduced is not None and (not isinstance(out_dtype, DataType) or out_dtype != deduced):
+        raise TypeError(
+            f"pl.matmul: out_dtype={out_dtype} is not supported for Tile operands — the Cube "
+            f"accumulator fixes the result dtype, deduced as {deduced} here. Convert the result "
+            f"explicitly with pl.cast(result, <dtype>), or let pl.tile.store narrow it on the "
+            f"way to GM."
+        )
 
 
 def _is_scalar_like(v: object) -> bool:
@@ -459,17 +534,24 @@ def sqrt(input: T) -> T:
     raise TypeError(f"pl.sqrt: expected Tensor or Tile, got {type(input).__name__}")
 
 
-def rsqrt(input: T, high_precision: bool = False) -> T:
+@overload
+def rsqrt(input: Tensor, high_precision: bool = ...) -> Tensor: ...
+@overload
+def rsqrt(input: Tile) -> Tile: ...
+def rsqrt(input, high_precision: bool = False):
     """Element-wise reciprocal square root, dispatched by input type.
 
-    ``high_precision`` applies to the tensor path where the compiler inserts
-    the scratch allocation. At the tile level, callers that need the high-
-    precision path must call ``pl.tile.rsqrt(src, tmp=...)`` directly since
-    buffer lifetimes are user-managed there.
+    ``high_precision`` is Tensor-only: the compiler allocates the scratch tile
+    during Tensor-to-Tile lowering. ``tile.rsqrt`` carries no such attribute —
+    precision is selected purely by *passing* that scratch tile — so tile
+    callers use ``pl.tile.rsqrt(tile, tmp)`` directly and passing
+    ``high_precision=True`` with a Tile raises rather than silently yielding the
+    low-precision path.
     """
     if isinstance(input, Tensor):
         return _tensor.rsqrt(input, high_precision=high_precision)
     if isinstance(input, Tile):
+        _reject_tile_unsupported("rsqrt", high_precision=(high_precision, _TILE_RSQRT_PRECISION_REMEDY))
         return _tile.rsqrt(input)
     raise TypeError(f"pl.rsqrt: expected Tensor or Tile, got {type(input).__name__}")
 
@@ -778,7 +860,7 @@ def matmul(
     c_matrix_nz: bool = ...,
 ) -> Tensor: ...
 @overload
-def matmul(lhs: Tile, rhs: Tile) -> Tile: ...
+def matmul(lhs: Tile, rhs: Tile, out_dtype: DataType | None = ...) -> Tile: ...
 
 
 def matmul(
@@ -791,8 +873,15 @@ def matmul(
 ) -> T:
     """Matrix multiplication, dispatched by input type.
 
-    Tensor path accepts extra kwargs (out_dtype, a_trans, b_trans, c_matrix_nz).
-    Tile path ignores them.
+    ``a_trans`` / ``b_trans`` / ``c_matrix_nz`` are Tensor-only: a tensor value
+    carries no layout, so a flag is the only place the information can live. At
+    tile level transposition is a *type* property, so passing any of them with a
+    Tile operand raises rather than being dropped.
+
+    ``out_dtype`` is likewise Tensor-only. ``tile.matmul``'s result dtype is
+    fixed by the Cube accumulator (FP32 for float operands, INT32 for int), so
+    the Tile path accepts ``out_dtype`` only when it already agrees with that
+    deduction and raises otherwise.
 
     For Tensor inputs with rank > 2 on either operand, the call is lowered to
     ``tile.batch_matmul`` (with batch broadcasting) by ``ConvertTensorToTileOps``
@@ -803,7 +892,15 @@ def matmul(
     if isinstance(lhs, Tensor) and isinstance(rhs, Tensor):
         return _tensor.matmul(lhs, rhs, out_dtype, a_trans, b_trans, c_matrix_nz)
     if isinstance(lhs, Tile) and isinstance(rhs, Tile):
-        return _tile.matmul(lhs, rhs)
+        _reject_tile_unsupported(
+            "matmul",
+            a_trans=(a_trans, _TILE_TRANSPOSE_REMEDY),
+            b_trans=(b_trans, _TILE_TRANSPOSE_REMEDY),
+            c_matrix_nz=(c_matrix_nz, _TILE_C_MATRIX_NZ_REMEDY),
+        )
+        result = _tile.matmul(lhs, rhs)
+        _check_tile_matmul_out_dtype(result, out_dtype)
+        return result
     _raise_type_dispatch_error("matmul", lhs, rhs)
 
 
@@ -846,8 +943,10 @@ def matmul_acc(
 ) -> T:
     """Matrix multiplication with accumulation, dispatched by input type.
 
-    Tensor path accepts extra kwargs (a_trans, b_trans).
-    Tile path ignores them.
+    ``a_trans`` / ``b_trans`` are Tensor-only for the same reason as in
+    :func:`matmul` — at tile level transposition is a type property, not an op
+    flag — so passing either with Tile operands raises rather than being
+    dropped.
 
     For Tensor inputs with rank > 2 on any of acc/lhs/rhs, the call is lowered
     to ``tile.batch_matmul_acc`` (with batch broadcasting on lhs/rhs vs the
@@ -857,18 +956,29 @@ def matmul_acc(
     if isinstance(acc, Tensor) and isinstance(lhs, Tensor) and isinstance(rhs, Tensor):
         return _tensor.matmul_acc(acc, lhs, rhs, a_trans, b_trans)
     if isinstance(acc, Tile) and isinstance(lhs, Tile) and isinstance(rhs, Tile):
+        _reject_tile_unsupported(
+            "matmul_acc",
+            a_trans=(a_trans, _TILE_TRANSPOSE_REMEDY),
+            b_trans=(b_trans, _TILE_TRANSPOSE_REMEDY),
+        )
         return _tile.matmul_acc(acc, lhs, rhs)
     _raise_type_dispatch_error("matmul_acc", acc, lhs, rhs)
 
 
-def row_max(input: T, tmp_tile: Tile | None = None) -> T:
+@overload
+def row_max(input: Tensor) -> Tensor: ...
+@overload
+def row_max(input: Tile, tmp_tile: Tile) -> Tile: ...
+def row_max(input, tmp_tile: Tile | None = None):
     """Row-wise max reduction, dispatched by input type.
 
     For Tile inputs, ``tmp_tile`` is required and must have the same dtype and
     rank as the input, with every dimension at least as large as the input dimension.
-    For Tensor inputs, tmp_tile is ignored.
+    Tensor inputs must omit it — the scratch tile is allocated during
+    Tensor-to-Tile lowering — and passing one raises.
     """
     if isinstance(input, Tensor):
+        _reject_tmp_for_tensor("row_max", tmp_tile, "tmp_tile")
         return _tensor.row_max(input)
     if isinstance(input, Tile):
         if tmp_tile is None:
@@ -880,14 +990,20 @@ def row_max(input: T, tmp_tile: Tile | None = None) -> T:
     raise TypeError(f"pl.row_max: expected Tensor or Tile, got {type(input).__name__}")
 
 
-def row_sum(input: T, tmp_tile: Tile | None = None) -> T:
+@overload
+def row_sum(input: Tensor) -> Tensor: ...
+@overload
+def row_sum(input: Tile, tmp_tile: Tile) -> Tile: ...
+def row_sum(input, tmp_tile: Tile | None = None):
     """Row-wise sum reduction, dispatched by input type.
 
     For Tile inputs, ``tmp_tile`` is required and must have the same dtype and
     rank as the input, with every dimension at least as large as the input dimension.
-    For Tensor inputs, tmp_tile is ignored.
+    Tensor inputs must omit it — the scratch tile is allocated during
+    Tensor-to-Tile lowering — and passing one raises.
     """
     if isinstance(input, Tensor):
+        _reject_tmp_for_tensor("row_sum", tmp_tile, "tmp_tile")
         return _tensor.row_sum(input)
     if isinstance(input, Tile):
         if tmp_tile is None:
@@ -899,14 +1015,20 @@ def row_sum(input: T, tmp_tile: Tile | None = None) -> T:
     raise TypeError(f"pl.row_sum: expected Tensor or Tile, got {type(input).__name__}")
 
 
-def row_min(input: T, tmp_tile: Tile | None = None) -> T:
+@overload
+def row_min(input: Tensor) -> Tensor: ...
+@overload
+def row_min(input: Tile, tmp_tile: Tile) -> Tile: ...
+def row_min(input, tmp_tile: Tile | None = None):
     """Row-wise min reduction, dispatched by input type.
 
     For Tile inputs, ``tmp_tile`` is required and must have the same dtype and
     rank as the input, with every dimension at least as large as the input dimension.
-    For Tensor inputs, tmp_tile is ignored.
+    Tensor inputs must omit it — the scratch tile is allocated during
+    Tensor-to-Tile lowering — and passing one raises.
     """
     if isinstance(input, Tensor):
+        _reject_tmp_for_tensor("row_min", tmp_tile, "tmp_tile")
         return _tensor.row_min(input)
     if isinstance(input, Tile):
         if tmp_tile is None:
@@ -918,14 +1040,20 @@ def row_min(input: T, tmp_tile: Tile | None = None) -> T:
     raise TypeError(f"pl.row_min: expected Tensor or Tile, got {type(input).__name__}")
 
 
-def row_prod(input: T, tmp_tile: Tile | None = None) -> T:
+@overload
+def row_prod(input: Tensor) -> Tensor: ...
+@overload
+def row_prod(input: Tile, tmp_tile: Tile) -> Tile: ...
+def row_prod(input, tmp_tile: Tile | None = None):
     """Row-wise product reduction, dispatched by input type.
 
     For Tile inputs, ``tmp_tile`` is required and must have the same dtype and
     rank as the input, with every dimension at least as large as the input dimension.
-    For Tensor inputs, tmp_tile is ignored.
+    Tensor inputs must omit it — the scratch tile is allocated during
+    Tensor-to-Tile lowering — and passing one raises.
     """
     if isinstance(input, Tensor):
+        _reject_tmp_for_tensor("row_prod", tmp_tile, "tmp_tile")
         return _tensor.row_prod(input)
     if isinstance(input, Tile):
         if tmp_tile is None:
@@ -937,14 +1065,21 @@ def row_prod(input: T, tmp_tile: Tile | None = None) -> T:
     raise TypeError(f"pl.row_prod: expected Tensor or Tile, got {type(input).__name__}")
 
 
-def col_sum(input: T, tmp_tile: Tile | None = None) -> T:
+@overload
+def col_sum(input: Tensor) -> Tensor: ...
+@overload
+def col_sum(input: Tile, tmp_tile: Tile | None = ...) -> Tile: ...
+def col_sum(input, tmp_tile: Tile | None = None):
     """Column-wise sum reduction, dispatched by input type.
 
     For Tile inputs, passing ``tmp_tile`` activates the binary-tree reduction
-    path; omitting it uses the sequential path. For Tensor inputs, ``tmp_tile``
-    is ignored — the tensor-to-tile conversion lowers to the sequential path.
+    path; omitting it uses the sequential path. Tensor inputs must omit it: the
+    tensor-to-tile conversion always lowers to the sequential path and allocates
+    its own scratch, so a ``tmp_tile`` there could not select the requested
+    strategy and raises instead.
     """
     if isinstance(input, Tensor):
+        _reject_tmp_for_tensor("col_sum", tmp_tile, "tmp_tile")
         return _tensor.col_sum(input)
     if isinstance(input, Tile):
         return _tile.col_sum(input, tmp_tile)
@@ -987,13 +1122,19 @@ def col_prod(input: T) -> T:
     _raise_type_dispatch_error("col_prod", input)
 
 
-def row_argmax(input: T, tmp_tile: Tile | None = None) -> T:
+@overload
+def row_argmax(input: Tensor) -> Tensor: ...
+@overload
+def row_argmax(input: Tile, tmp_tile: Tile) -> Tile: ...
+def row_argmax(input, tmp_tile: Tile | None = None):
     """Row-wise argmax (per-row max index, int32), dispatched by input type.
 
     For Tile inputs, tmp_tile is required with exactly the same shape and dtype.
-    For Tensor inputs, tmp_tile is ignored.
+    Tensor inputs must omit it — the conversion injects the scratch tile — and
+    passing one raises.
     """
     if isinstance(input, Tensor):
+        _reject_tmp_for_tensor("row_argmax", tmp_tile, "tmp_tile")
         return _tensor.row_argmax(input)
     if isinstance(input, Tile):
         if tmp_tile is None:
@@ -1004,13 +1145,19 @@ def row_argmax(input: T, tmp_tile: Tile | None = None) -> T:
     raise TypeError(f"pl.row_argmax: expected Tensor or Tile, got {type(input).__name__}")
 
 
-def row_argmin(input: T, tmp_tile: Tile | None = None) -> T:
+@overload
+def row_argmin(input: Tensor) -> Tensor: ...
+@overload
+def row_argmin(input: Tile, tmp_tile: Tile) -> Tile: ...
+def row_argmin(input, tmp_tile: Tile | None = None):
     """Row-wise argmin (per-row min index, int32), dispatched by input type.
 
     For Tile inputs, tmp_tile is required with exactly the same shape and dtype.
-    For Tensor inputs, tmp_tile is ignored.
+    Tensor inputs must omit it — the conversion injects the scratch tile — and
+    passing one raises.
     """
     if isinstance(input, Tensor):
+        _reject_tmp_for_tensor("row_argmin", tmp_tile, "tmp_tile")
         return _tensor.row_argmin(input)
     if isinstance(input, Tile):
         if tmp_tile is None:
@@ -1021,13 +1168,18 @@ def row_argmin(input: T, tmp_tile: Tile | None = None) -> T:
     raise TypeError(f"pl.row_argmin: expected Tensor or Tile, got {type(input).__name__}")
 
 
-def col_argmax(input: T, tmp_tile: Tile | None = None) -> T:
+@overload
+def col_argmax(input: Tensor) -> Tensor: ...
+@overload
+def col_argmax(input: Tile, tmp_tile: Tile) -> Tile: ...
+def col_argmax(input, tmp_tile: Tile | None = None):
     """Column-wise argmax (per-column max index, int32), dispatched by input type.
 
-    For Tile inputs, tmp_tile is required (unlike col_max). For Tensor inputs,
-    the conversion injects the tmp tile.
+    For Tile inputs, tmp_tile is required (unlike col_max). Tensor inputs must
+    omit it — the conversion injects the tmp tile — and passing one raises.
     """
     if isinstance(input, Tensor):
+        _reject_tmp_for_tensor("col_argmax", tmp_tile, "tmp_tile")
         return _tensor.col_argmax(input)
     if isinstance(input, Tile):
         if tmp_tile is None:
@@ -1036,13 +1188,18 @@ def col_argmax(input: T, tmp_tile: Tile | None = None) -> T:
     raise TypeError(f"pl.col_argmax: expected Tensor or Tile, got {type(input).__name__}")
 
 
-def col_argmin(input: T, tmp_tile: Tile | None = None) -> T:
+@overload
+def col_argmin(input: Tensor) -> Tensor: ...
+@overload
+def col_argmin(input: Tile, tmp_tile: Tile) -> Tile: ...
+def col_argmin(input, tmp_tile: Tile | None = None):
     """Column-wise argmin (per-column min index, int32), dispatched by input type.
 
-    For Tile inputs, tmp_tile is required (unlike col_min). For Tensor inputs,
-    the conversion injects the tmp tile.
+    For Tile inputs, tmp_tile is required (unlike col_min). Tensor inputs must
+    omit it — the conversion injects the tmp tile — and passing one raises.
     """
     if isinstance(input, Tensor):
+        _reject_tmp_for_tensor("col_argmin", tmp_tile, "tmp_tile")
         return _tensor.col_argmin(input)
     if isinstance(input, Tile):
         if tmp_tile is None:
@@ -1119,17 +1276,9 @@ def cmp(lhs, rhs, cmp_type: int = 0):
 # lifetimes are user-managed there; the tensor forms do not, since the conversion
 # pass allocates it. That Tile-only trailing operand follows ``row_expand_add`` and
 # the ``row_*`` / ``col_*`` reduction family above, which take the same
-# ``tmp_tile: Tile | None = None`` and reject it on the Tensor path.
+# ``tmp_tile: Tile | None = None`` and reject it on the Tensor path via the shared
+# ``_reject_tmp_for_tensor`` guard.
 # ---------------------------------------------------------------------------
-
-
-def _reject_tmp_for_tensor(op_name: str, tmp: Any) -> None:
-    """Guard the Tensor path of an op whose Tile form carries a scratch operand."""
-    if tmp is not None:
-        raise TypeError(
-            f"pl.{op_name}: Tensor inputs must not pass tmp — the scratch tile is "
-            f"allocated during Tensor-to-Tile lowering"
-        )
 
 
 @overload

--- a/python/pypto/language/op/unified_ops.py
+++ b/python/pypto/language/op/unified_ops.py
@@ -16,7 +16,7 @@ or ``pl.tile.add``.
 """
 
 from collections.abc import Sequence
-from typing import Any, NoReturn, TypeVar, overload
+from typing import Any, Literal, NoReturn, TypeVar, overload
 
 __all__ = [
     "add",
@@ -147,6 +147,11 @@ def _raise_type_dispatch_error(op_name: str, *args: object) -> NoReturn:
 # Only a non-default value raises — spelling out the documented default keeps
 # working.
 # ---------------------------------------------------------------------------
+
+# The ``@overload`` declarations mirror that rule with ``Literal[False]`` /
+# ``None`` defaults on the path that cannot honour a kwarg: the documented
+# default still type-checks, while a non-default value is rejected statically as
+# well as at runtime.
 
 # Remedies for kwargs the Tile dispatch path cannot honour. Module constants so
 # the guarded call sites stay one line per kwarg.
@@ -537,7 +542,7 @@ def sqrt(input: T) -> T:
 @overload
 def rsqrt(input: Tensor, high_precision: bool = ...) -> Tensor: ...
 @overload
-def rsqrt(input: Tile) -> Tile: ...
+def rsqrt(input: Tile, high_precision: Literal[False] = ...) -> Tile: ...
 def rsqrt(input, high_precision: bool = False):
     """Element-wise reciprocal square root, dispatched by input type.
 
@@ -860,7 +865,14 @@ def matmul(
     c_matrix_nz: bool = ...,
 ) -> Tensor: ...
 @overload
-def matmul(lhs: Tile, rhs: Tile, out_dtype: DataType | None = ...) -> Tile: ...
+def matmul(
+    lhs: Tile,
+    rhs: Tile,
+    out_dtype: DataType | None = ...,
+    a_trans: Literal[False] = ...,
+    b_trans: Literal[False] = ...,
+    c_matrix_nz: Literal[False] = ...,
+) -> Tile: ...
 
 
 def matmul(
@@ -931,7 +943,13 @@ def matmul_acc(
     b_trans: bool = ...,
 ) -> Tensor: ...
 @overload
-def matmul_acc(acc: Tile, lhs: Tile, rhs: Tile) -> Tile: ...
+def matmul_acc(
+    acc: Tile,
+    lhs: Tile,
+    rhs: Tile,
+    a_trans: Literal[False] = ...,
+    b_trans: Literal[False] = ...,
+) -> Tile: ...
 
 
 def matmul_acc(
@@ -966,7 +984,7 @@ def matmul_acc(
 
 
 @overload
-def row_max(input: Tensor) -> Tensor: ...
+def row_max(input: Tensor, tmp_tile: None = ...) -> Tensor: ...
 @overload
 def row_max(input: Tile, tmp_tile: Tile) -> Tile: ...
 def row_max(input, tmp_tile: Tile | None = None):
@@ -991,7 +1009,7 @@ def row_max(input, tmp_tile: Tile | None = None):
 
 
 @overload
-def row_sum(input: Tensor) -> Tensor: ...
+def row_sum(input: Tensor, tmp_tile: None = ...) -> Tensor: ...
 @overload
 def row_sum(input: Tile, tmp_tile: Tile) -> Tile: ...
 def row_sum(input, tmp_tile: Tile | None = None):
@@ -1016,7 +1034,7 @@ def row_sum(input, tmp_tile: Tile | None = None):
 
 
 @overload
-def row_min(input: Tensor) -> Tensor: ...
+def row_min(input: Tensor, tmp_tile: None = ...) -> Tensor: ...
 @overload
 def row_min(input: Tile, tmp_tile: Tile) -> Tile: ...
 def row_min(input, tmp_tile: Tile | None = None):
@@ -1041,7 +1059,7 @@ def row_min(input, tmp_tile: Tile | None = None):
 
 
 @overload
-def row_prod(input: Tensor) -> Tensor: ...
+def row_prod(input: Tensor, tmp_tile: None = ...) -> Tensor: ...
 @overload
 def row_prod(input: Tile, tmp_tile: Tile) -> Tile: ...
 def row_prod(input, tmp_tile: Tile | None = None):
@@ -1066,7 +1084,7 @@ def row_prod(input, tmp_tile: Tile | None = None):
 
 
 @overload
-def col_sum(input: Tensor) -> Tensor: ...
+def col_sum(input: Tensor, tmp_tile: None = ...) -> Tensor: ...
 @overload
 def col_sum(input: Tile, tmp_tile: Tile | None = ...) -> Tile: ...
 def col_sum(input, tmp_tile: Tile | None = None):
@@ -1123,7 +1141,7 @@ def col_prod(input: T) -> T:
 
 
 @overload
-def row_argmax(input: Tensor) -> Tensor: ...
+def row_argmax(input: Tensor, tmp_tile: None = ...) -> Tensor: ...
 @overload
 def row_argmax(input: Tile, tmp_tile: Tile) -> Tile: ...
 def row_argmax(input, tmp_tile: Tile | None = None):
@@ -1146,7 +1164,7 @@ def row_argmax(input, tmp_tile: Tile | None = None):
 
 
 @overload
-def row_argmin(input: Tensor) -> Tensor: ...
+def row_argmin(input: Tensor, tmp_tile: None = ...) -> Tensor: ...
 @overload
 def row_argmin(input: Tile, tmp_tile: Tile) -> Tile: ...
 def row_argmin(input, tmp_tile: Tile | None = None):
@@ -1169,7 +1187,7 @@ def row_argmin(input, tmp_tile: Tile | None = None):
 
 
 @overload
-def col_argmax(input: Tensor) -> Tensor: ...
+def col_argmax(input: Tensor, tmp_tile: None = ...) -> Tensor: ...
 @overload
 def col_argmax(input: Tile, tmp_tile: Tile) -> Tile: ...
 def col_argmax(input, tmp_tile: Tile | None = None):
@@ -1189,7 +1207,7 @@ def col_argmax(input, tmp_tile: Tile | None = None):
 
 
 @overload
-def col_argmin(input: Tensor) -> Tensor: ...
+def col_argmin(input: Tensor, tmp_tile: None = ...) -> Tensor: ...
 @overload
 def col_argmin(input: Tile, tmp_tile: Tile) -> Tile: ...
 def col_argmin(input, tmp_tile: Tile | None = None):

--- a/tests/ut/language/parser/test_op_validation.py
+++ b/tests/ut/language/parser/test_op_validation.py
@@ -70,6 +70,47 @@ class TestWrapperErrorsThroughParser:
                 )
                 return result
 
+    def test_matmul_b_trans_on_tile_operands_raises_at_the_call_site(self):
+        """A Tensor-only matmul flag must not be silently dropped on the Tile path.
+
+        Regression for issue #2264: migrating a kernel's matmul operands from
+        Tensor to Tile (``pl.create_l1`` -> ``pl.create_tile``, tensor slice ->
+        ``pl.load``) changed the dispatch target while the
+        ``pl.matmul(..., b_trans=True)`` line was left untouched. The flag
+        stopped being honoured and, with a square B, compiled ``A @ B`` instead
+        of ``A @ B^T`` with no diagnostic at any stage.
+        """
+        with pytest.raises(InvalidOperationError) as exc_info:
+
+            @pl.function(auto_scope=False)
+            def main(
+                a: pl.Tensor[[32, 128], pl.BF16],
+                b: pl.Tensor[[128, 128], pl.BF16],
+                out: pl.Out[pl.Tensor[[32, 128], pl.FP32]],
+            ) -> pl.Tensor[[32, 128], pl.FP32]:
+                with pl.scope():
+                    at = pl.load(a, [0, 0], [32, 128], target_memory=pl.MemorySpace.Mat)
+                    bt = pl.load(b, [0, 0], [128, 128], target_memory=pl.MemorySpace.Mat)
+                    # The @overloads already reject this statically ("Argument of
+                    # type Tile cannot be assigned to parameter lhs of type
+                    # Tensor"); suppressed on purpose so the test can prove the
+                    # *runtime* now rejects it too, which is what #2264 was about.
+                    c: pl.Tile[[32, 128], pl.FP32, pl.MemorySpace.Acc] = pl.matmul(
+                        at,  # pyright: ignore[reportArgumentType]
+                        bt,  # pyright: ignore[reportArgumentType]
+                        b_trans=True,
+                        out_dtype=pl.FP32,
+                    )
+                    out = pl.store(c, [0, 0], out)
+                return out
+
+        msg = exc_info.value.message  # type: ignore[attr-defined]
+        assert "pl.matmul" in msg
+        assert "b_trans" in msg
+        # The error must name the tile-level alternative, not just refuse.
+        assert "transpose_view" in msg
+        assert exc_info.value.span is not None  # type: ignore[attr-defined]
+
 
 class TestSpanPropagatesIntoWrapperConstructedNodes:
     """Span pinned by parser surfaces on IR nodes constructed inside wrappers."""

--- a/tests/ut/language/parser/test_op_validation.py
+++ b/tests/ut/language/parser/test_op_validation.py
@@ -91,14 +91,14 @@ class TestWrapperErrorsThroughParser:
                 with pl.scope():
                     at = pl.load(a, [0, 0], [32, 128], target_memory=pl.MemorySpace.Mat)
                     bt = pl.load(b, [0, 0], [128, 128], target_memory=pl.MemorySpace.Mat)
-                    # The @overloads already reject this statically ("Argument of
-                    # type Tile cannot be assigned to parameter lhs of type
-                    # Tensor"); suppressed on purpose so the test can prove the
-                    # *runtime* now rejects it too, which is what #2264 was about.
+                    # The Tile @overload already rejects this statically
+                    # ("Literal[True] is not assignable to Literal[False]");
+                    # suppressed on purpose so the test can prove the *runtime*
+                    # now rejects it too, which is what #2264 was about.
                     c: pl.Tile[[32, 128], pl.FP32, pl.MemorySpace.Acc] = pl.matmul(
-                        at,  # pyright: ignore[reportArgumentType]
-                        bt,  # pyright: ignore[reportArgumentType]
-                        b_trans=True,
+                        at,
+                        bt,
+                        b_trans=True,  # pyright: ignore[reportArgumentType]
                         out_dtype=pl.FP32,
                     )
                     out = pl.store(c, [0, 0], out)

--- a/tests/ut/language/test_unified_ops.py
+++ b/tests/ut/language/test_unified_ops.py
@@ -1468,7 +1468,7 @@ class TestUnifiedOpsCrossPathKwargs:
         """Spelling out the defaults is a no-op and yields plain pl.tile.matmul IR."""
         lhs, rhs = _tile("lhs", [32, 128]), _tile("rhs", [128, 128])
 
-        unified = unified_ops.matmul(lhs, rhs, a_trans=False, b_trans=False, c_matrix_nz=False)  # type: ignore[call-overload]
+        unified = unified_ops.matmul(lhs, rhs, a_trans=False, b_trans=False, c_matrix_nz=False)
         explicit = pl.tile.matmul(lhs, rhs)
 
         ir.assert_structural_equal(unified.unwrap(), explicit.unwrap())
@@ -1535,7 +1535,7 @@ class TestUnifiedOpsCrossPathKwargs:
         acc = _tile("acc", [32, 128], DataType.FP32)
         lhs, rhs = _tile("lhs", [32, 128]), _tile("rhs", [128, 128])
 
-        unified = unified_ops.matmul_acc(acc, lhs, rhs, a_trans=False, b_trans=False)  # type: ignore[call-overload]
+        unified = unified_ops.matmul_acc(acc, lhs, rhs, a_trans=False, b_trans=False)
         explicit = pl.tile.matmul_acc(acc, lhs, rhs)
 
         ir.assert_structural_equal(unified.unwrap(), explicit.unwrap())
@@ -1553,6 +1553,15 @@ class TestUnifiedOpsCrossPathKwargs:
         t = _tile("t", [64, 64], DataType.FP32)
 
         unified = unified_ops.rsqrt(t)
+        explicit = pl.tile.rsqrt(t)
+
+        ir.assert_structural_equal(unified.unwrap(), explicit.unwrap())
+
+    def test_rsqrt_tile_accepts_explicit_default_high_precision(self):
+        """Spelling out the default is a no-op the overloads must also accept."""
+        t = _tile("t", [64, 64], DataType.FP32)
+
+        unified = unified_ops.rsqrt(t, high_precision=False)
         explicit = pl.tile.rsqrt(t)
 
         ir.assert_structural_equal(unified.unwrap(), explicit.unwrap())
@@ -1583,6 +1592,16 @@ class TestUnifiedOpsCrossPathKwargs:
         x = _tensor("x", [64, 64])
 
         unified = getattr(unified_ops, op_name)(x)
+        explicit = getattr(pl.tensor, op_name)(x)
+
+        ir.assert_structural_equal(unified.unwrap(), explicit.unwrap())
+
+    @pytest.mark.parametrize("op_name", _TMP_TILE_REDUCTIONS)
+    def test_reduction_tensor_path_accepts_explicit_none_tmp_tile(self, op_name):
+        """Passing the default explicitly stays legal — only a real tile raises."""
+        x = _tensor("x", [64, 64])
+
+        unified = getattr(unified_ops, op_name)(x, None)
         explicit = getattr(pl.tensor, op_name)(x)
 
         ir.assert_structural_equal(unified.unwrap(), explicit.unwrap())

--- a/tests/ut/language/test_unified_ops.py
+++ b/tests/ut/language/test_unified_ops.py
@@ -1416,5 +1416,189 @@ class TestUnifiedOpsTypeErrors:
             unified_ops.batch_matmul(1, 2)  # type: ignore
 
 
+# The unified wrappers accept the union of both levels' kwargs. A kwarg only the
+# *other* dispatch path can honour must raise instead of being dropped — a
+# discarded ``b_trans`` compiles wrong math, and a discarded scratch tile leaves
+# the caller's buffer dead while still consuming UB budget. Only a non-default
+# value raises; spelling out the documented default keeps working.
+_TMP_TILE_REDUCTIONS = [
+    "row_max",
+    "row_sum",
+    "row_min",
+    "row_prod",
+    "col_sum",
+    "row_argmax",
+    "row_argmin",
+    "col_argmax",
+    "col_argmin",
+]
+
+
+def _tile(name: str, shape: list[int], dtype: DataType = DataType.FP16) -> Tile:
+    return Tile(expr=ir.Var(name, ir.TileType(shape, dtype), ir.Span.unknown()))
+
+
+def _tensor(name: str, shape: list[int], dtype: DataType = DataType.FP32) -> Tensor:
+    return Tensor(expr=ir.Var(name, ir.TensorType(shape, dtype), ir.Span.unknown()))
+
+
+class TestUnifiedOpsCrossPathKwargs:
+    """Kwargs only one dispatch path can honour raise instead of being dropped."""
+
+    @pytest.mark.parametrize(
+        "kwarg,remedy",
+        [
+            ("a_trans", "transpose_view"),
+            ("b_trans", "transpose_view"),
+            ("c_matrix_nz", "Acc tile type"),
+        ],
+    )
+    def test_matmul_tile_rejects_tensor_only_flags(self, kwarg, remedy):
+        """Tensor-level matmul flags have no tile equivalent, so they must raise."""
+        lhs, rhs = _tile("lhs", [32, 128]), _tile("rhs", [128, 128])
+        with pytest.raises(TypeError) as exc_info:
+            unified_ops.matmul(lhs, rhs, **{kwarg: True})  # type: ignore[call-overload]
+
+        msg = str(exc_info.value)
+        assert f"'{kwarg}'" in msg
+        assert "not supported for Tile operands" in msg
+        assert remedy in msg
+
+    def test_matmul_tile_accepts_explicit_default_flags(self):
+        """Spelling out the defaults is a no-op and yields plain pl.tile.matmul IR."""
+        lhs, rhs = _tile("lhs", [32, 128]), _tile("rhs", [128, 128])
+
+        unified = unified_ops.matmul(lhs, rhs, a_trans=False, b_trans=False, c_matrix_nz=False)  # type: ignore[call-overload]
+        explicit = pl.tile.matmul(lhs, rhs)
+
+        ir.assert_structural_equal(unified.unwrap(), explicit.unwrap())
+
+    def test_matmul_tile_accepts_out_dtype_matching_deduction(self):
+        """tile.matmul deduces FP32 for float operands; asking for FP32 is honoured."""
+        lhs, rhs = _tile("lhs", [32, 128]), _tile("rhs", [128, 128])
+
+        unified = unified_ops.matmul(lhs, rhs, out_dtype=DataType.FP32)
+        explicit = pl.tile.matmul(lhs, rhs)
+
+        result_type = unified.unwrap().type
+        assert isinstance(result_type, ir.TileType)
+        assert result_type.dtype == DataType.FP32
+        ir.assert_structural_equal(unified.unwrap(), explicit.unwrap())
+
+    def test_matmul_tile_rejects_out_dtype_the_accumulator_cannot_produce(self):
+        """The Cube accumulator is fixed at FP32 here, so FP16 must raise, not drop."""
+        lhs, rhs = _tile("lhs", [32, 128]), _tile("rhs", [128, 128])
+        with pytest.raises(TypeError) as exc_info:
+            unified_ops.matmul(lhs, rhs, out_dtype=DataType.FP16)
+
+        msg = str(exc_info.value)
+        assert "out_dtype" in msg
+        assert "fp32" in msg  # names what it actually deduced
+        assert "pl.cast" in msg
+
+    def test_matmul_tile_rejects_unverifiable_int_out_dtype(self):
+        """A raw int dtype code cannot be compared against the deduction, so it raises.
+
+        ``DataType`` exposes no Python int conversion, so an int value cannot be
+        checked against what tile.matmul actually deduced — and skipping the
+        check is the silent drop this guard exists to prevent. The Tile overload
+        already rejects this statically (hence the suppression); the runtime
+        check still matters because the DSL parser reaches the wrapper
+        dynamically.
+        """
+        lhs, rhs = _tile("lhs", [32, 128]), _tile("rhs", [128, 128])
+        with pytest.raises(TypeError, match="out_dtype"):
+            unified_ops.matmul(lhs, rhs, out_dtype=51)  # pyright: ignore[reportArgumentType]
+
+    def test_matmul_tensor_still_honors_all_kwargs(self):
+        """The Tensor path is untouched — every kwarg still reaches tensor.matmul."""
+        # b_trans=True means rhs is [N, K], so [512, 128] against an lhs K of 128.
+        lhs, rhs = _tensor("lhs", [32, 128], DataType.BF16), _tensor("rhs", [512, 128], DataType.BF16)
+
+        unified = unified_ops.matmul(lhs, rhs, out_dtype=DataType.FP32, a_trans=False, b_trans=True)
+        explicit = pl.tensor.matmul(lhs, rhs, DataType.FP32, False, True)
+
+        ir.assert_structural_equal(unified.unwrap(), explicit.unwrap())
+
+    @pytest.mark.parametrize("kwarg", ["a_trans", "b_trans"])
+    def test_matmul_acc_tile_rejects_transpose_flags(self, kwarg):
+        acc = _tile("acc", [32, 128], DataType.FP32)
+        lhs, rhs = _tile("lhs", [32, 128]), _tile("rhs", [128, 128])
+        with pytest.raises(TypeError) as exc_info:
+            unified_ops.matmul_acc(acc, lhs, rhs, **{kwarg: True})  # type: ignore[call-overload]
+
+        msg = str(exc_info.value)
+        assert f"'{kwarg}'" in msg
+        assert "transpose_view" in msg
+
+    def test_matmul_acc_tile_accepts_explicit_default_flags(self):
+        acc = _tile("acc", [32, 128], DataType.FP32)
+        lhs, rhs = _tile("lhs", [32, 128]), _tile("rhs", [128, 128])
+
+        unified = unified_ops.matmul_acc(acc, lhs, rhs, a_trans=False, b_trans=False)  # type: ignore[call-overload]
+        explicit = pl.tile.matmul_acc(acc, lhs, rhs)
+
+        ir.assert_structural_equal(unified.unwrap(), explicit.unwrap())
+
+    def test_rsqrt_tile_rejects_high_precision(self):
+        """tile.rsqrt selects precision by taking a scratch tile, not by a flag."""
+        with pytest.raises(TypeError) as exc_info:
+            unified_ops.rsqrt(_tile("t", [64, 64], DataType.FP32), high_precision=True)  # type: ignore[call-overload]
+
+        msg = str(exc_info.value)
+        assert "'high_precision'" in msg
+        assert "pl.tile.rsqrt(tile, tmp)" in msg
+
+    def test_rsqrt_tile_default_still_lowers(self):
+        t = _tile("t", [64, 64], DataType.FP32)
+
+        unified = unified_ops.rsqrt(t)
+        explicit = pl.tile.rsqrt(t)
+
+        ir.assert_structural_equal(unified.unwrap(), explicit.unwrap())
+
+    def test_rsqrt_tensor_still_honors_high_precision(self):
+        x = _tensor("x", [64, 64])
+
+        unified = unified_ops.rsqrt(x, high_precision=True)
+        explicit = pl.tensor.rsqrt(x, high_precision=True)
+
+        ir.assert_structural_equal(unified.unwrap(), explicit.unwrap())
+
+    @pytest.mark.parametrize("op_name", _TMP_TILE_REDUCTIONS)
+    def test_reduction_tensor_path_rejects_tmp_tile(self, op_name):
+        """The conversion pass allocates the scratch, so a user tmp_tile must raise."""
+        x = _tensor("x", [64, 64])
+        tmp = _tile("tmp", [64, 64], DataType.FP32)
+        with pytest.raises(TypeError) as exc_info:
+            getattr(unified_ops, op_name)(x, tmp)  # type: ignore[call-overload]
+
+        msg = str(exc_info.value)
+        assert f"pl.{op_name}" in msg
+        assert "tmp_tile" in msg
+
+    @pytest.mark.parametrize("op_name", _TMP_TILE_REDUCTIONS)
+    def test_reduction_tensor_path_without_tmp_tile_unchanged(self, op_name):
+        """Omitting tmp_tile on the Tensor path still matches pl.tensor.<op>."""
+        x = _tensor("x", [64, 64])
+
+        unified = getattr(unified_ops, op_name)(x)
+        explicit = getattr(pl.tensor, op_name)(x)
+
+        ir.assert_structural_equal(unified.unwrap(), explicit.unwrap())
+
+    def test_col_sum_tile_path_still_selects_binary_tree(self):
+        """tmp_tile is honoured on the Tile path — it selects binary-tree reduction."""
+        t = _tile("t", [64, 64], DataType.FP32)
+        tmp = _tile("tmp", [64, 64], DataType.FP32)
+
+        unified = unified_ops.col_sum(t, tmp)
+        explicit = pl.tile.col_sum(t, tmp)
+
+        ir.assert_structural_equal(unified.unwrap(), explicit.unwrap())
+        # The binary-tree form is distinguishable from the sequential one.
+        assert not ir.structural_equal(unified.unwrap(), pl.tile.col_sum(t).unwrap())
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
Fixes #2264

## Problem

The unified `pl.*` wrappers dispatch on operand type and accept the **union** of both levels' kwargs. A kwarg that only the *other* path could honour was **silently discarded** — no error, no warning, no IR trace.

For `pl.matmul` this is a correctness bug. `pl.matmul(tile_a, tile_b, b_trans=True)` compiled `A @ B`:

- With a **square B** the shapes stayed consistent and the kernel computed the wrong math cleanly.
- With a **non-square B** it failed deep in C++ type deduction (`lhs K=512 and rhs K=128`) without ever naming `b_trans`.

That is how it was found in the wild — a kernel whose matmul operands were migrated from `Tensor` to `Tile` (`pl.create_l1` → `pl.create_tile`, tensor slice → `pl.load`) while the `pl.matmul(..., b_trans=True)` line was left untouched.

This is correct **IR design**, not an IR bug. A tensor value carries no layout, so a flag is the only place transposition can live; at tile level it is a *type* property expressed by the zero-copy `tile.transpose_view`, and `tile.matmul` maps 1:1 onto `pto.tmatmul`, which has no transpose attribute. PRs #1776 → #1866 → #1883 deliberately removed transpose parameters from the tile layer. The defect was that the frontend accepted a request it could not honour and stayed silent — the `@overload` declarations already encoded the right contract for `matmul`/`matmul_acc`; only the runtime failed to enforce it.

## Change

Twelve silent-drop sites now raise, each only on a **non-default** value — spelling out `b_trans=False` stays a no-op:

| Site | Dropped kwarg | New behaviour |
| --- | --- | --- |
| `matmul` / `matmul_acc` | `a_trans`, `b_trans`, `c_matrix_nz` | Raise on the Tile path, pointing at `pl.tile.transpose_view` |
| `matmul` | `out_dtype` | **Verified, not dropped** — see below |
| `rsqrt` | `high_precision` | Raise on the Tile path; `tile.rsqrt` selects precision by *taking* a scratch tile, not by an attribute |
| 9 reductions | `tmp_tile` | Raise on the Tensor path |

Reductions covered: `row_max`, `row_sum`, `row_min`, `row_prod`, `col_sum`, `row_argmax`, `row_argmin`, `col_argmax`, `col_argmin`. For `col_sum` the drop was **strategy-meaningful** — the requested binary-tree reduction (O(log M) depth, better FP accumulation) was discarded and the scratch tile allocated but never used. For the other eight the conversion pass synthesizes its own scratch, so results matched, but the user's tile was silently dead while still consuming UB budget. The in-file comment already *claimed* this family rejected it.

Ten functions that had no `@overload` declarations gain the split, so the static contract matches the runtime one. The existing `_reject_tmp_for_tensor` helper moves to a shared-guards section and takes the parameter name so the reductions reuse it for `tmp_tile`.

### `out_dtype` is verified rather than rejected outright

`tile.matmul` hardcodes its result dtype — FP32 for float operands, INT32 for int (`src/ir/op/tile_ops/matmul.cpp:88-89`) — in a 4-byte-fractal Acc (L0C) tile. **The hardware has no FP16 matmul output.**

Tensor-level `out_dtype=FP16` compiles because the narrowing is absorbed *downstream*, not by the matmul. The conversion rule discards the kwarg outright (`(void)kwargs;`, `src/ir/transforms/op_conversion_registry.cpp:1067`); `out_dtype` only sets the declared *tensor* type, and the conversion rides on the consuming store:

\`\`\`python
t__tile: pl.Tile[[32, 128], pl.FP32, pl.Mem.Acc] = pl.tile.matmul(a_mat, b_mat)   # always FP32
ret0__store: pl.Tensor[[32, 128], pl.FP16] = pl.tile.store(t__tile, [0, 0], ret0__out)
\`\`\`

So on the Tile path a matching `out_dtype` is a harmless redundant assertion and a mismatched one is unfulfillable. The guard compares against the dtype read off the **built call** rather than re-deriving the C++ rule in Python (which would silently rot), accepts the match, and raises otherwise naming \`pl.cast\`.

Auto-inserting a \`tile.cast\` was considered and rejected: cast is a Vec-unit op while matmul is Cube, so it would hide a real instruction plus a UB buffer behind a kwarg, against the tile layer's explicit-ops design.

## Before / after

\`\`\`python
at = pl.load(a, [0, 0], [32, 128], target_memory=pl.MemorySpace.Mat)
bt = pl.load(b, [0, 0], [128, 128], target_memory=pl.MemorySpace.Mat)
c = pl.matmul(at, bt, b_trans=True, out_dtype=pl.FP32)
\`\`\`

**Before** — no diagnostic at any stage, wrong math:

\`\`\`python
c: pl.Tile[[32, 128], pl.FP32, pl.Mem.Acc] = pl.tile.matmul(at, bt)
\`\`\`

**After:**

\`\`\`text
InvalidOperationError: pl.matmul: 'b_trans' is not supported for Tile operands.
At tile level a transposed operand is an explicit zero-copy view, not an op flag:
wrap the operand with pl.tile.transpose_view(...) and pass it directly.
\`\`\`

The suggested remedy compiles and yields the correct \`[32, 128]\` result:

\`\`\`python
c = pl.matmul(at, pl.tile.transpose_view(bt), out_dtype=pl.FP32)
# -> c: pl.Tile[[32, 128], pl.FP32, pl.Mem.Acc] = pl.tile.matmul(at, pl.tile.transpose_view(bt))
\`\`\`

## Compatibility

An AST sweep of \`tests/\`, \`examples/\`, and \`python/\` found only **two** Tile-path sites passing a Tensor-only kwarg — \`tests/st/runtime/ops/test_matmul.py:700,703\`, both \`out_dtype=pl.FP32\` on BF16 operands, i.e. exactly the dtype the accumulator deduces. Both keep working unchanged; I built that kernel directly to confirm it still lowers identically. The other 121 matching call sites are Tensor-path.

## Tests

- \`TestUnifiedOpsCrossPathKwargs\` in \`tests/ut/language/test_unified_ops.py\` — 33 tests covering every guard, the explicit-defaults no-op path, the matching/mismatched \`out_dtype\` split, and the Tensor path staying byte-identical to the explicit \`pl.tensor.*\` IR.
- Parser-level regression test in \`tests/ut/language/parser/test_op_validation.py\` reproducing the issue's Repro 1, asserting the message names \`b_trans\` and \`transpose_view\` and that the call-site span propagates.

Full unit suite: **8638 passed**. Docs updated in both \`docs/en\` and \`docs/zh\` with the per-path signatures and the general rule (and a previously missing \`row_min\` row).

## Scope

Silent-drop class only, per the issue's own "Suggested shape of the fix". Deliberately **not** included, each deserving its own review: the dead-end-to-end \`c_matrix_nz\` attr, the tensor-vs-tile \`out_dtype\` default divergence, and the five positional-misbind signature divergences (\`random\`, \`ir.transpose\`, \`ir.scatter_mask\`, \`scatter\`/\`gather\`, \`mrgsort\`).