### PR TITLE
feat(runtime): add bounded distributed dispatch handles

### DIFF
--- a/docs/en/dev/06-persistent-l3.md
+++ b/docs/en/dev/06-persistent-l3.md
@@ -17,13 +17,14 @@ The persistent path is opt-in. The default `prepare()` behavior is unchanged.
 
 ## Lifecycle
 
-The PyPTO worker starts one background dispatcher and sends requests to it
-through a Python queue. Every request executes inside its own Simpler
-`Worker.run()` completion fence. The first use of a generated CommDomain
-allocates its physical window; later calls receive a retained lease for the
-same handle. Closing the prepared worker stops the dispatcher and releases all
-retained domains. Request or domain-release errors are propagated to the
-caller instead of being silently discarded by the background thread.
+Each PyPTO submission builds its persistent orchestration synchronously in the
+calling thread and calls Simpler `Worker.submit()` directly. The returned
+`DistributedRunHandle` owns that request until its native completion fence and
+cleanup finish. The first use of a generated CommDomain allocates its physical
+window; later calls receive a retained lease for the same handle. Closing the
+prepared worker stops admission, drains every published handle, and then
+releases all retained domains. Request and domain-release errors are propagated
+to the caller.
 
 Generated HOST orchestration entries accept an internal `_domain_provider`
 keyword. Normal dispatch leaves it unset and continues to call
@@ -77,13 +78,17 @@ Domains are isolated by `(compiled program, generated domain name)`. Prefill's
 generated names match. All prepared programs still must satisfy the normal
 platform, runtime, and device-ID compatibility checks.
 
-Requests execute serially through one queue. Persistent mode does not make one
-worker execute multiple L3 DAGs concurrently.
+Graph construction remains serialized by `DistributedWorker.submit()` and
+Simpler. Once accepted, persistent runs follow the same bounded asynchronous
+dispatch contract as ordinary runs: up to two PyPTO metadata frames may be
+published, while the backend's negotiated depth determines how many device
+runs can actually overlap.
 
 ## Runtime dependency
 
-This implementation does not modify Simpler. Each queued request uses the
-public `Worker.run()` completion boundary. PyPTO detaches retained CommDomains
+This implementation does not modify Simpler. Each request uses the public
+`Worker.submit()` boundary, and its native handle remains attached to PyPTO's
+bounded dispatch handle until completion. PyPTO detaches retained CommDomains
 from Simpler's per-run release set and releases them when the prepared worker
 closes. That retention currently depends on Simpler's private Worker-level
 live-domain registry and active run-resource journal (`_live_domains` and

--- a/docs/en/user/distributed/03-execution.md
+++ b/docs/en/user/distributed/03-execution.md
@@ -27,6 +27,7 @@ directly via `DistributedWorker(compiled)`, importable from
 | `compiled.prepare(config=None, *, extra_compiled=(), persistent=False, reset_persistent_windows=None, callbacks=None, sub_worker_overrides=None, startup_timeout_s=None)` | Create worker, fork chip processes, return `DistributedWorker`. Use as context manager. |
 | `rt(x, y, z)` | Single dispatch — coerces args, calls host_orch. |
 | `rt.run(compiled, x, y, z)` | Multi-program dispatch — selects the target program. |
+| `rt.submit(compiled, x, y, z)` | Bounded asynchronous dispatch — returns a `DistributedRunHandle`. |
 | `rt.alloc_tensor(shape, dtype, *, init=None)` | Allocate a worker-resident `DeviceTensor`. `init` copies from host (one-time H2D). |
 | `rt.free_tensor(tensor)` | Release a `DeviceTensor`. |
 | `rt.alloc_stacked_tensor(host_w)` | Shard host_w along dim 0 — shard `i` uploaded to card `i`. Returns `StackedDeviceTensor`. |
@@ -53,6 +54,38 @@ directly via `DistributedWorker(compiled)`, importable from
   startup-readiness deadline for the forked worker hierarchy. Leave it as
   `None` to keep Simpler's default; increase it for legitimately slow cold
   starts rather than disabling the bound.
+
+### Bounded Asynchronous Dispatch
+
+`DistributedWorker.submit(compiled, *args)` returns a
+`DistributedRunHandle` after Simpler accepts the dispatch. When the backend
+supports asynchronous execution, the caller can prepare host work for the next
+request while the current request is still running. `run()` and `rt(...)`
+remain blocking compatibility wrappers.
+
+The worker owns exactly two reusable dispatch metadata frames. The first two
+submissions may be in flight together; a third `submit()` waits for the oldest
+handle before it constructs or publishes another dispatch. Each handle
+snapshots its runtime configuration and retains its arguments and generated
+task metadata until completion.
+
+Use `handle.result(timeout)` or its alias `handle.wait(timeout)` to wait and
+raise the cached dispatch error. `handle.done` reports terminal completion
+without blocking.
+
+```python
+with compiled.prepare() as rt:
+    first = rt.submit(compiled, input_a, weight, output_a)
+    second = rt.submit(compiled, input_b, weight, output_b)
+    first.result()
+    second.result()
+```
+
+Overlapping dispatches require distinct mutable input and output buffers. Do
+not modify or release those buffers before the corresponding `result()`
+returns. Read-only resident weights may be shared. Closing the worker drains
+all accepted handles in FIFO order. Diagnostic two-pass swimlane capture stays
+synchronous and returns an already-completed handle.
 
 ## DeviceTensor
 

--- a/docs/zh/dev/06-persistent-l3.md
+++ b/docs/zh/dev/06-persistent-l3.md
@@ -17,12 +17,12 @@ with decode.prepare(persistent=True) as worker:
 
 ## 生命周期
 
-PyPTO worker 会启动一个后台 dispatcher，并通过 Python Queue 向它发送请求。
-每个请求都在独立的 Simpler `Worker.run()` completion fence 中执行。首次使用某个
-generated CommDomain 时会申请物理 window，后续调用则获得同一个 handle 的
-retained lease。关闭 prepared worker 时，dispatcher 停止并释放所有保留的
-domain。请求或 domain 释放过程中发生的错误会抛给调用方，而不会被后台线程
-静默丢弃。
+每次 PyPTO 提交都会在调用线程中同步构建持久 orchestration，并直接调用 Simpler
+`Worker.submit()`。返回的 `DistributedRunHandle` 会持有该请求，直到 native
+completion fence 和清理全部结束。首次使用某个 generated CommDomain 时会申请物理
+window，后续调用则获得同一个 handle 的 retained lease。关闭 prepared worker 时
+会先停止接收新请求、排空所有已发布 handle，再释放全部 retained domain。请求和
+domain 释放错误都会抛给调用方。
 
 生成的 HOST orchestration entry 接受内部参数 `_domain_provider`。普通 dispatch
 不传该参数，仍然调用 `orch.allocate_domain`；持久 dispatch 则传入一个按 compiled
@@ -68,13 +68,16 @@ Domain 按 `(compiled program, generated domain name)` 隔离。因此，即使 
 decode 都生成了 `comm_d0`，它们仍然使用不同的物理 domain。所有 prepared
 program 仍须满足原有的 platform、runtime 和 device ID 兼容性检查。
 
-请求通过一个 Queue 串行执行。持久模式不会让同一个 worker 并发执行多个 L3 DAG。
+`DistributedWorker.submit()` 和 Simpler 仍会串行构建 graph。请求被接受后，持久
+模式与普通模式遵循相同的有界异步分发约定：PyPTO 最多发布两个 metadata frame，
+实际可重叠的 device run 数量由 backend 协商出的 depth 决定。
 
 ## Runtime 依赖
 
-该实现不修改 Simpler。每个 Queue 请求都使用公开的 `Worker.run()` completion
-boundary。PyPTO 会让 retained CommDomain 脱离 Simpler 的 per-run release set，
-并在 prepared worker 关闭时统一释放。目前该保留机制仍依赖 Simpler 私有的
-Worker 级 live-domain registry 和当前 run-resource journal（`_live_domains` 和
+该实现不修改 Simpler。每个请求都使用公开的 `Worker.submit()` boundary，其
+native handle 会一直挂在 PyPTO 的有界 dispatch handle 上直到完成。PyPTO 会让
+retained CommDomain 脱离 Simpler 的 per-run release set，并在 prepared worker
+关闭时统一释放。目前该保留机制仍依赖 Simpler 私有的 Worker 级 live-domain
+registry 和当前 run-resource journal（`_live_domains` 和
 `_building_run_resources.live_domains`）；后续应由公开的 retention API 封装该
 lifecycle。

--- a/docs/zh/user/distributed/03-execution.md
+++ b/docs/zh/user/distributed/03-execution.md
@@ -27,6 +27,7 @@ with compiled.prepare() as rt:
 | `compiled.prepare(config=None, *, extra_compiled=(), persistent=False, reset_persistent_windows=None, callbacks=None, sub_worker_overrides=None, startup_timeout_s=None)` | 创建 worker、fork 芯片进程，返回 `DistributedWorker`。作为上下文管理器使用。 |
 | `rt(x, y, z)` | 单次分发——转换参数，调用 host_orch。 |
 | `rt.run(compiled, x, y, z)` | 多程序分发——选择目标程序。 |
+| `rt.submit(compiled, x, y, z)` | 有界异步分发——返回 `DistributedRunHandle`。 |
 | `rt.alloc_tensor(shape, dtype, *, init=None)` | 分配 worker 常驻的 `DeviceTensor`。`init` 从 host 拷贝（一次性 H2D）。 |
 | `rt.free_tensor(tensor)` | 释放 `DeviceTensor`。 |
 | `rt.alloc_stacked_tensor(host_w)` | 沿 dim 0 分片 `host_w`——分片 `i` 上传到卡 `i`。返回 `StackedDeviceTensor`。 |
@@ -50,6 +51,31 @@ with compiled.prepare() as rt:
 - **`startup_timeout_s`**——可选地覆盖 Simpler 对 fork worker 层级报告
   启动就绪状态所设置的正有限秒数期限。保持为 `None` 时使用 Simpler
   默认值；对于确实较慢的冷启动，应增大该期限，而不是取消期限约束。
+
+### 有界异步分发
+
+`DistributedWorker.submit(compiled, *args)` 在 Simpler 接受分发后返回
+`DistributedRunHandle`。后端支持异步执行时，调用方可以在当前请求仍在执行时准备
+下一请求的 host 工作。`run()` 和 `rt(...)` 仍是阻塞兼容接口。
+
+worker 固定拥有两个可复用的分发元数据帧。前两次提交可以同时处于执行中；第三次
+`submit()` 会先等待最老的 handle，再构造和发布新的分发。每个 handle 会快照本次
+运行配置，并把参数和生成的任务元数据保留到完成。
+
+使用 `handle.result(timeout)` 或其别名 `handle.wait(timeout)` 等待完成并抛出缓存的
+分发错误；`handle.done` 可无阻塞地报告是否已经结束。
+
+```python
+with compiled.prepare() as rt:
+    first = rt.submit(compiled, input_a, weight, output_a)
+    second = rt.submit(compiled, input_b, weight, output_b)
+    first.result()
+    second.result()
+```
+
+重叠分发必须使用不同的可变输入和输出 buffer；对应的 `result()` 返回前不得修改或
+释放这些 buffer。只读常驻权重可以共享。关闭 worker 时会按 FIFO 顺序排空所有已接受
+的 handle。诊断用双遍 swimlane 采集仍保持同步，并返回一个已经完成的 handle。
 
 ## DeviceTensor
 

--- a/python/pypto/runtime/__init__.py
+++ b/python/pypto/runtime/__init__.py
@@ -26,7 +26,7 @@ Example::
 
 from .bench import BenchmarkStats, TraceInvocation, TraceSpan, benchmark
 from .device_tensor import DeviceTensor, StackedDeviceTensor
-from .distributed_runner import DistributedWorker, execute_distributed_compiled
+from .distributed_runner import DistributedRunHandle, DistributedWorker, execute_distributed_compiled
 from .log_config import _ensure_configured as _ensure_log_configured
 from .log_config import configure_log
 from .log_config import current_level as log_level
@@ -54,6 +54,7 @@ __all__ = [
     "DeviceTensor",
     "StackedDeviceTensor",
     "DistributedWorker",
+    "DistributedRunHandle",
     "RegistrationHandle",
     "RunConfig",
     "RunResult",

--- a/python/pypto/runtime/distributed_runner.py
+++ b/python/pypto/runtime/distributed_runner.py
@@ -17,9 +17,9 @@ import inspect
 import json
 import logging
 import math
-import queue
 import sys
 import threading
+import time
 import types
 import warnings
 import weakref
@@ -60,7 +60,6 @@ _DTYPE_MAP: dict[str, tuple[type, torch.dtype]] = {
 
 
 _PERSISTENT_ZERO_CHUNK_BYTES = 1 << 20
-_PERSISTENT_STOP = object()
 
 
 def _resolve_persistent_window_reset(persistent: bool, reset_persistent_windows: bool | None) -> bool:
@@ -85,15 +84,153 @@ def _resolve_persistent_window_reset(persistent: bool, reset_persistent_windows:
 
 
 @dataclass
-class _PersistentRequest:
-    """One caller-visible dispatch handled by the persistent L3 dispatcher."""
+class _DispatchFrame:
+    """One of two reusable, pre-fork dispatch metadata frames."""
 
-    state: dict[str, Any]
-    tensors: dict[str, Any]
-    call_config: Any
+    slot_id: int
+    in_use: bool = False
+    tensors: dict[str, Any] = field(default_factory=dict)
     keepalive: list[Any] = field(default_factory=list)
-    done: threading.Event = field(default_factory=threading.Event)
-    error: BaseException | None = None
+    handle: DistributedRunHandle | None = None
+
+
+class DistributedRunHandle:
+    """Completion handle returned by :meth:`DistributedWorker.submit`.
+
+    The handle keeps its worker, immutable dispatch configuration, argument
+    references, generated task arguments, and one bounded metadata frame alive
+    until terminal completion. Waiting is idempotent and every waiter observes
+    the same cached outcome.
+    """
+
+    def __init__(
+        self,
+        worker: DistributedWorker,
+        native_handle: Any | None,
+        frame: _DispatchFrame,
+        dispatch_id: int,
+        postprocess: Callable[[], None] | None = None,
+    ) -> None:
+        self._worker: DistributedWorker | None = worker
+        self._native_handle = native_handle
+        self._frame: _DispatchFrame | None = frame
+        self._dispatch_id = dispatch_id
+        self._postprocess = postprocess
+        self._cv = threading.Condition()
+        self._wait_in_progress = False
+        self._terminal = False
+        self._error: BaseException | None = None
+
+    @staticmethod
+    def _deadline(timeout: float | None) -> float | None:
+        if timeout is None:
+            return None
+        value = float(timeout)
+        if value < 0 or not math.isfinite(value):
+            raise ValueError("DistributedRunHandle timeout must be a non-negative finite number of seconds")
+        return time.monotonic() + value
+
+    @classmethod
+    def _completed(
+        cls,
+        worker: DistributedWorker,
+        error: BaseException | None = None,
+    ) -> DistributedRunHandle:
+        handle = cls.__new__(cls)
+        handle._worker = worker
+        handle._native_handle = None
+        handle._frame = None
+        handle._dispatch_id = 0
+        handle._postprocess = None
+        handle._cv = threading.Condition()
+        handle._wait_in_progress = False
+        handle._terminal = True
+        handle._error = error
+        return handle
+
+    @property
+    def done(self) -> bool:
+        """Whether the dispatch and its result publication are terminal."""
+        with self._cv:
+            if self._terminal:
+                return True
+            if self._wait_in_progress:
+                return False
+        try:
+            self.result(timeout=0.0)
+        except TimeoutError:
+            return False
+        except BaseException:  # noqa: BLE001 - a failed dispatch is terminal
+            return True
+        return True
+
+    def result(self, timeout: float | None = None) -> None:
+        """Wait for completion and raise the cached dispatch error, if any.
+
+        Args:
+            timeout: Maximum wait in seconds. ``None`` waits without a deadline.
+
+        Raises:
+            TimeoutError: The dispatch did not complete before ``timeout``.
+            ValueError: ``timeout`` is negative or non-finite.
+            BaseException: The cached native or result-publication failure.
+        """
+        deadline = self._deadline(timeout)
+        with self._cv:
+            while not self._terminal and self._wait_in_progress:
+                remaining = None if deadline is None else deadline - time.monotonic()
+                if remaining is not None and remaining <= 0:
+                    raise TimeoutError("DistributedRunHandle.result() timed out")
+                self._cv.wait(timeout=remaining)
+            if self._terminal:
+                if self._error is not None:
+                    raise self._error
+                return
+            self._wait_in_progress = True
+
+        error: BaseException | None = None
+        try:
+            remaining = None if deadline is None else max(0.0, deadline - time.monotonic())
+            native_handle = self._native_handle
+            if native_handle is None:
+                raise RuntimeError("DistributedRunHandle lost its native handle before completion")
+            native_handle.result(timeout=remaining)
+        except TimeoutError:
+            with self._cv:
+                self._wait_in_progress = False
+                self._cv.notify_all()
+            raise
+        except BaseException as exc:  # noqa: BLE001 - cached for every waiter
+            error = exc
+        if error is None and self._postprocess is not None:
+            try:
+                self._postprocess()
+            except BaseException as exc:  # noqa: BLE001 - terminal post-processing outcome
+                error = exc
+
+        worker = self._worker
+        frame = self._frame
+        with self._cv:
+            self._error = error
+            self._terminal = True
+            self._wait_in_progress = False
+            self._native_handle = None
+            self._postprocess = None
+            self._frame = None
+            self._worker = None
+            self._cv.notify_all()
+        if worker is not None and frame is not None:
+            worker._retire_dispatch_handle(self, frame, error)
+        if error is not None:
+            raise error
+
+    def wait(self, timeout: float | None = None) -> None:
+        """Wait for completion as an alias for :meth:`result`.
+
+        Args:
+            timeout: Maximum wait in seconds. ``None`` waits without a deadline.
+        """
+        self.result(timeout)
 
 
 class _RetainedDomainLease:
@@ -565,7 +702,7 @@ def _run_l3_swimlane_two_pass(
 
     ``run_pass`` owns the execution lifecycle: the one-shot path creates a
     fresh Worker for each call, while a prepared ``DistributedWorker`` reuses
-    its existing Worker and issues a new ``Worker.run()`` fence. Both paths
+    its existing Worker and waits on a submitted run handle. Both paths
     reset their per-card dispatch counters, so matching graph/timing dispatches
     land in the same ``rank{r}/d{k}`` directory.
 
@@ -968,23 +1105,16 @@ def _is_simpler_tensor(arg: Any) -> bool:
     return isinstance(arg, Tensor)
 
 
-def _dispatch(
-    w: Any,
+def _make_dispatch_orchestration(
     entry_fn: Any,
     tensors: dict[str, Any],
     chip_cids: dict[str, Any],
     sub_ids: dict[str, Any],
     call_config: Any,
     device_nums: int,
-) -> None:
-    """Build the orchestration closure and run it once on ``w``.
-
-    The simpler ``Worker.run`` returns ``None`` (per-run timing is read from
-    the runtime's ``[STRACE]`` log markers, simpler PR #1177).
-    """
-    # Fresh _keep per dispatch: it pins per-call TaskArgs alive for the run.
-    _keep: list[Any] = []
-
+    keepalive: list[Any],
+) -> Callable[..., None]:
+    """Build one orchestration closure over a handle-owned metadata frame."""
     # ``world_size`` is the only worker-level scalar the entry needs; codegen
     # binds ``pld.system.world_size()`` to this kwarg uniformly across comm
     # and comm-less paths.
@@ -1012,11 +1142,58 @@ def _dispatch(
             tensors=tensors,
             callables=chip_cids,
             sub_ids=sub_ids,
-            _keep=_keep,
+            _keep=keepalive,
             world_size=device_nums,
         )
 
-    w.run(orch_fn)
+    return orch_fn
+
+
+def _submit_dispatch(
+    w: Any,
+    entry_fn: Any,
+    tensors: dict[str, Any],
+    chip_cids: dict[str, Any],
+    sub_ids: dict[str, Any],
+    call_config: Any,
+    device_nums: int,
+    keepalive: list[Any],
+) -> Any:
+    """Submit one orchestration closure and return Simpler's run handle."""
+    orch_fn = _make_dispatch_orchestration(
+        entry_fn,
+        tensors,
+        chip_cids,
+        sub_ids,
+        call_config,
+        device_nums,
+        keepalive,
+    )
+    return w.submit(orch_fn)
+
+
+def _dispatch(
+    w: Any,
+    entry_fn: Any,
+    tensors: dict[str, Any],
+    chip_cids: dict[str, Any],
+    sub_ids: dict[str, Any],
+    call_config: Any,
+    device_nums: int,
+) -> None:
+    """Blocking compatibility composition of submit plus result."""
+    keepalive: list[Any] = []
+    native_handle = _submit_dispatch(
+        w,
+        entry_fn,
+        tensors,
+        chip_cids,
+        sub_ids,
+        call_config,
+        device_nums,
+        keepalive,
+    )
+    native_handle.result()
 
 
 def execute_distributed(
@@ -1309,12 +1486,16 @@ class DistributedWorker(Worker):
             if self._persistent and self._reset_persistent_windows
             else None
         )
-        self._persistent_requests: queue.Queue[_PersistentRequest | object] | None = None
-        self._persistent_thread: threading.Thread | None = None
-        self._persistent_ready: threading.Event | None = None
         self._persistent_error: BaseException | None = None
         self._persistent_error_reported = False
-        self._persistent_terminal_request: _PersistentRequest | None = None
+        self._persistent_domains_by_program: dict[str, dict[str, tuple[tuple[Any, ...], Any]]] = {}
+        self._dispatch_submit_mu = threading.Lock()
+        self._dispatch_cv = threading.Condition()
+        self._dispatch_frames = [_DispatchFrame(slot_id) for slot_id in range(2)]
+        self._active_dispatch_handles: set[DistributedRunHandle] = set()
+        self._next_dispatch_id = 1
+        self._accepting_dispatches = False
+        self._closing = False
 
         programs = list(compiled) if isinstance(compiled, Sequence) else [compiled]
         if not programs:
@@ -1368,12 +1549,15 @@ class DistributedWorker(Worker):
                     loaded_subs, prog_callbacks, _load_required_callbacks(prog.output_dir)
                 )
                 num_sub = max(num_sub, prog._distributed_config.num_sub_workers, len(sub_worker_fns))
-                base_tensors: dict[str, Any] = {}
-                if alloc_fn is not None:
-                    alloc_fn(base_tensors)
+                base_tensor_frames: list[dict[str, Any]] = []
+                for _frame in self._dispatch_frames:
+                    base_tensors: dict[str, Any] = {}
+                    if alloc_fn is not None:
+                        alloc_fn(base_tensors)
+                    base_tensor_frames.append(base_tensors)
                 self._states[prog] = {
                     "entry_fn": entry_fn,
-                    "base_tensors": base_tensors,
+                    "base_tensor_frames": tuple(base_tensor_frames),
                     "call_config": _make_call_config(prog._distributed_config),
                     "param_infos": tuple(prog._get_metadata()[0]),
                     "device_nums": len(prog._distributed_config.device_ids),
@@ -1425,8 +1609,6 @@ class DistributedWorker(Worker):
             # ``Worker.init()`` eagerly starts the chip/sub-worker hierarchy, so
             # the device-memory API is ready before the first dispatch without a
             # separate call into Simpler's private startup implementation.
-            if self._persistent:
-                self._start_persistent_dispatcher()
         except BaseException:  # noqa: BLE001 - partially built Workers still require cleanup
             if self._w is not None:
                 _close_local_worker_after_error(self._w, "DistributedWorker construction")
@@ -1434,6 +1616,7 @@ class DistributedWorker(Worker):
 
         self._closed = False
         self._close_complete = False
+        self._accepting_dispatches = True
         # Live RegistrationHandles so close() can mark them closed. WeakSet
         # so handles that drop out of scope first don't pin DistributedWorker.
         self._handles: weakref.WeakSet[Any] = weakref.WeakSet()
@@ -1464,6 +1647,101 @@ class DistributedWorker(Worker):
                 f"{runtime_name!r} != {prog_runtime!r}"
             )
         return runtime_name
+
+    def _acquire_dispatch_frame(self) -> tuple[_DispatchFrame, int]:
+        """Reserve one of two metadata frames, draining the oldest on pressure."""
+        while True:
+            with self._dispatch_cv:
+                if not self._accepting_dispatches:
+                    raise RuntimeError("DistributedWorker.submit() called while the worker is closing")
+                frame = next((candidate for candidate in self._dispatch_frames if not candidate.in_use), None)
+                if frame is not None:
+                    frame.in_use = True
+                    dispatch_id = self._next_dispatch_id
+                    self._next_dispatch_id += 1
+                    return frame, dispatch_id
+                if not self._active_dispatch_handles:
+                    raise RuntimeError(
+                        "DistributedWorker dispatch frames are occupied without owning handles"
+                    )
+                oldest = min(self._active_dispatch_handles, key=lambda handle: handle._dispatch_id)
+            try:
+                oldest.result()
+            except BaseException:  # noqa: BLE001 - the handle owner still observes its cached outcome
+                pass
+
+    def _release_unpublished_dispatch_frame(self, frame: _DispatchFrame) -> None:
+        """Return a frame whose submission failed before handle publication."""
+        with self._dispatch_cv:
+            frame.tensors.clear()
+            frame.keepalive.clear()
+            frame.handle = None
+            frame.in_use = False
+            self._dispatch_cv.notify_all()
+
+    def _discard_unsubmitted_dispatch_handle(
+        self,
+        handle: DistributedRunHandle,
+        frame: _DispatchFrame,
+    ) -> None:
+        """Discard a provisional handle after submission failed before acceptance."""
+        with self._dispatch_cv:
+            self._active_dispatch_handles.discard(handle)
+            if frame.handle is handle:
+                frame.handle = None
+        self._release_unpublished_dispatch_frame(frame)
+
+    def _accepted_native_handles(self) -> set[Any] | None:
+        """Snapshot Simpler's accepted set for interruption recovery."""
+        handles = getattr(self._w, "_accepted_run_handles", None)
+        lifecycle_cv = getattr(self._w, "_hierarchical_start_cv", None)
+        if not isinstance(handles, set) or lifecycle_cv is None:
+            return None
+        with lifecycle_cv:
+            return set(handles)
+
+    def _recover_accepted_native_handle(self, before: set[Any] | None) -> Any | None:
+        """Recover the sole handle accepted while one serialized submit ran."""
+        if before is None:
+            return None
+        after = self._accepted_native_handles()
+        if after is None:
+            return None
+        accepted = after - before
+        if len(accepted) != 1:
+            return None
+        return next(iter(accepted))
+
+    def _retire_dispatch_handle(
+        self,
+        handle: DistributedRunHandle,
+        frame: _DispatchFrame,
+        error: BaseException | None,
+    ) -> None:
+        """Release one terminal handle's frame and publish persistent failure."""
+        if error is not None and self._persistent and self._persistent_error is None:
+            self._persistent_error = error
+            self._persistent_error_reported = True
+        with self._dispatch_cv:
+            self._active_dispatch_handles.discard(handle)
+            if frame.handle is handle:
+                frame.tensors.clear()
+                frame.keepalive.clear()
+                frame.handle = None
+                frame.in_use = False
+            self._dispatch_cv.notify_all()
+
+    @staticmethod
+    def _remember_close_error(
+        first_error: BaseException | None,
+        error: BaseException,
+    ) -> BaseException:
+        """Retain the first close failure and chain one teardown failure."""
+        if first_error is None:
+            return error
+        if first_error.__context__ is None:
+            first_error.__context__ = error
+        return first_error
 
     @staticmethod
     def _persistent_domain_spec(kwargs: dict[str, Any]) -> tuple[Any, ...]:
@@ -1559,153 +1837,83 @@ class DistributedWorker(Worker):
             names = ", ".join(repr(handle.name) for handle in not_freed)
             raise RuntimeError(f"persistent CommDomain release did not free: {names}")
 
-    def _persistent_worker_main(self) -> None:
-        """Fence each request with ``Worker.run`` while retaining CommDomains."""
-        assert self._persistent_requests is not None
-        assert self._persistent_ready is not None
-        domains_by_program: dict[str, dict[str, tuple[tuple[Any, ...], Any]]] = {}
-        self._persistent_ready.set()
-        try:
-            while True:
-                item = self._persistent_requests.get()
-                if item is _PERSISTENT_STOP:
-                    break
-                assert isinstance(item, _PersistentRequest)
-                request = item
-                program_id = str(request.state["persistent_id"])
+    def _submit_persistent(
+        self,
+        state: dict[str, Any],
+        tensors: dict[str, Any],
+        call_config: Any,
+        keepalive: list[Any],
+    ) -> Any:
+        """Submit one persistent request directly through Simpler."""
+        self._raise_persistent_error()
+        domains_by_program = self._persistent_domains_by_program
+        program_id = str(state["persistent_id"])
 
-                def run_request(orch: Any, _args: Any, _config: Any) -> None:
-                    def domain_provider(**kwargs: Any) -> _RetainedDomainLease:
-                        generated_name = str(kwargs["name"])
-                        program_domains = domains_by_program.setdefault(program_id, {})
-                        spec = self._persistent_domain_spec(kwargs)
-                        existing = program_domains.get(generated_name)
-                        if existing is None:
-                            runtime_kwargs = dict(kwargs)
-                            runtime_kwargs["name"] = f"{program_id}:{generated_name}"
-                            handle = orch.allocate_domain(**runtime_kwargs)
-                            self._detach_persistent_domain(handle)
-                            program_domains[generated_name] = (spec, handle)
-                        else:
-                            prior_spec, handle = existing
-                            if spec != prior_spec:
-                                raise ValueError(
-                                    f"persistent CommDomain {generated_name!r} changed specification "
-                                    f"for program {program_id}"
-                                )
-                        return _RetainedDomainLease(handle)
-
-                    program_domains = domains_by_program.get(program_id)
-                    if program_domains and self._reset_persistent_windows:
-                        self._reset_persistent_domains(orch, program_domains)
-                    _reset_dfx_dispatch_state(orch, request.state["chip_cids"])
-                    request.state["entry_fn"](
-                        orch,
-                        None,
-                        request.call_config,
-                        tensors=request.tensors,
-                        callables=request.state["chip_cids"],
-                        sub_ids=request.state["sub_ids"],
-                        _keep=request.keepalive,
-                        world_size=request.state["device_nums"],
-                        _domain_provider=domain_provider,
-                    )
-
-                try:
-                    self._w.run(run_request)
-                except BaseException as exc:  # noqa: BLE001 - rethrown on caller thread
-                    request.error = exc
-                    self._persistent_error = exc
-                    self._persistent_error_reported = False
-                    self._persistent_terminal_request = request
+        def run_request(
+            orch: Any,
+            _args: Any,
+            _config: Any,
+        ) -> None:
+            def domain_provider(**kwargs: Any) -> _RetainedDomainLease:
+                generated_name = str(kwargs["name"])
+                program_domains = domains_by_program.setdefault(program_id, {})
+                spec = self._persistent_domain_spec(kwargs)
+                existing = program_domains.get(generated_name)
+                if existing is None:
+                    runtime_kwargs = dict(kwargs)
+                    runtime_kwargs["name"] = f"{program_id}:{generated_name}"
+                    handle = orch.allocate_domain(**runtime_kwargs)
+                    self._detach_persistent_domain(handle)
+                    program_domains[generated_name] = (spec, handle)
                 else:
-                    request.keepalive.clear()
-                    request.done.set()
-                if request.error is not None:
-                    break
-        except BaseException as exc:  # noqa: BLE001 - observed by start/run/close
+                    prior_spec, handle = existing
+                    if spec != prior_spec:
+                        raise ValueError(
+                            f"persistent CommDomain {generated_name!r} changed specification "
+                            f"for program {program_id}"
+                        )
+                return _RetainedDomainLease(handle)
+
+            program_domains = domains_by_program.get(program_id)
+            if program_domains and self._reset_persistent_windows:
+                self._reset_persistent_domains(orch, program_domains)
+            _reset_dfx_dispatch_state(orch, state["chip_cids"])
+            state["entry_fn"](
+                orch,
+                None,
+                call_config,
+                tensors=tensors,
+                callables=state["chip_cids"],
+                sub_ids=state["sub_ids"],
+                _keep=keepalive,
+                world_size=state["device_nums"],
+                _domain_provider=domain_provider,
+            )
+
+        try:
+            return self._w.submit(run_request)
+        except Exception as exc:
             self._persistent_error = exc
-            self._persistent_error_reported = False
-            terminal = self._persistent_terminal_request
-            if terminal is not None and terminal.error is None:
-                terminal.error = exc
-        finally:
-            # A normally returned Worker.run() has completed every cleanup
-            # cursor step, including ``retire_domains``. Only then is the
-            # handle's captured owner guaranteed to free synchronously. On any
-            # request/finalization error, keep the global live-domain claim
-            # untouched and let Worker.close() perform its whole-tree sweep.
-            if self._persistent_error is None:
-                try:
-                    self._release_persistent_domains(domains_by_program)
-                except BaseException as exc:  # noqa: BLE001 - surfaced by close
-                    self._persistent_error = exc
-                    self._persistent_error_reported = False
-            terminal = self._persistent_terminal_request
-            if terminal is not None:
-                terminal.keepalive.clear()
-                terminal.done.set()
+            self._persistent_error_reported = True
+            raise
 
     def _raise_persistent_error(self) -> None:
-        """Raise the background failure and mark it as delivered to a caller."""
+        """Raise the terminal persistent failure and mark it as delivered."""
         if self._persistent_error is not None:
             self._persistent_error_reported = True
             raise self._persistent_error
 
-    def _start_persistent_dispatcher(self) -> None:
-        """Start the background request dispatcher and wait until it is ready."""
-        self._persistent_requests = queue.Queue(maxsize=1)
-        self._persistent_ready = threading.Event()
-        self._persistent_thread = threading.Thread(
-            target=self._persistent_worker_main,
-            name="pypto-persistent-l3",
-        )
-        self._persistent_thread.start()
-        self._persistent_ready.wait()
-        if self._persistent_error is not None:
-            self._persistent_thread.join()
-            self._raise_persistent_error()
-
-    def _dispatch_persistent(self, state: dict[str, Any], tensors: dict[str, Any], call_config: Any) -> None:
-        """Submit one request and synchronously propagate its completion status."""
-        requests = self._persistent_requests
-        thread = self._persistent_thread
-        if requests is None or thread is None:
-            raise RuntimeError("persistent distributed dispatcher is not running")
-        self._raise_persistent_error()
-        request = _PersistentRequest(state=state, tensors=tensors, call_config=call_config)
-        requests.put(request)
-        while not request.done.wait(timeout=0.1):
-            if not thread.is_alive():
-                self._raise_persistent_error()
-                raise RuntimeError("persistent distributed dispatcher exited before completing the request")
-        if request.error is not None:
-            if request.error is self._persistent_error:
-                self._persistent_error_reported = True
-            raise request.error
-        self._raise_persistent_error()
-
-    def _stop_persistent_dispatcher(self) -> None:
-        """Stop the background run and raise an unreported terminal failure."""
-        requests = self._persistent_requests
-        thread = self._persistent_thread
-        if requests is None or thread is None:
-            return
-        if thread.is_alive():
-            requests.put(_PERSISTENT_STOP)
-        thread.join()
-        self._persistent_requests = None
-        self._persistent_thread = None
-        if self._persistent_error is not None and not self._persistent_error_reported:
-            self._persistent_error_reported = True
-            raise self._persistent_error
-
-    def _dispatch_prepared(self, state: dict[str, Any], tensors: dict[str, Any], call_config: Any) -> None:
-        """Dispatch through either the ordinary or persistent prepared path."""
+    def _submit_prepared_native(
+        self,
+        state: dict[str, Any],
+        tensors: dict[str, Any],
+        call_config: Any,
+        keepalive: list[Any],
+    ) -> Any:
+        """Submit through either the ordinary or persistent prepared path."""
         if self._persistent:
-            self._dispatch_persistent(state, tensors, call_config)
-            return
-        _dispatch(
+            return self._submit_persistent(state, tensors, call_config, keepalive)
+        return _submit_dispatch(
             self._w,
             state["entry_fn"],
             tensors,
@@ -1713,7 +1921,50 @@ class DistributedWorker(Worker):
             state["sub_ids"],
             call_config,
             state["device_nums"],
+            keepalive,
         )
+
+    def _submit_native_dispatch(
+        self,
+        handle: DistributedRunHandle,
+        frame: _DispatchFrame,
+        state: dict[str, Any],
+        tensors: dict[str, Any],
+        call_config: Any,
+    ) -> None:
+        """Install or recover the native handle for one published frame."""
+        accepted_before = self._accepted_native_handles()
+        native_handle: Any | None = None
+        try:
+            native_handle = self._submit_prepared_native(state, tensors, call_config, frame.keepalive)
+        except BaseException as exc:
+            if native_handle is None:
+                native_handle = self._recover_accepted_native_handle(accepted_before)
+            if native_handle is None:
+                if self._persistent and self._persistent_error is None:
+                    self._persistent_error = exc
+                    self._persistent_error_reported = True
+                self._discard_unsubmitted_dispatch_handle(handle, frame)
+            else:
+                handle._native_handle = native_handle
+            raise
+        handle._native_handle = native_handle
+
+    def _dispatch_prepared(
+        self,
+        state: dict[str, Any],
+        tensors: dict[str, Any],
+        call_config: Any,
+        keepalive: list[Any] | None = None,
+    ) -> None:
+        """Blocking compatibility composition used by diagnostic two-pass runs."""
+        native_handle = self._submit_prepared_native(
+            state,
+            tensors,
+            call_config,
+            [] if keepalive is None else keepalive,
+        )
+        native_handle.result()
 
     # ------------------------------------------------------------------
     # Device memory primitives
@@ -1983,7 +2234,8 @@ class DistributedWorker(Worker):
         twice on the same prepared worker: first with dep-gen only, then with
         swimlane enabled and dep-gen disabled. Mutable host/resident arguments
         are not restored between those profiling passes and can therefore be
-        updated twice. ``None`` reuses the program's baseline.
+        updated twice. ``None`` snapshots the program's baseline for this
+        dispatch.
         """
         if self._multi_program:
             raise TypeError(
@@ -1992,21 +2244,22 @@ class DistributedWorker(Worker):
             )
         return self._run_compiled(self._compiled, *args, config=config)
 
-    def _run_compiled(
+    def _submit_compiled(
         self, compiled: DistributedCompiledProgram, *args: Any, config: RunConfig | None = None
-    ) -> None:
-        """Dispatch *compiled* on the shared Worker via its per-program state.
+    ) -> DistributedRunHandle:
+        """Submit *compiled* on the shared Worker via one bounded frame.
 
         ``config`` is an optional per-dispatch :class:`RunConfig` whose per-task
         ring sizing and runtime DFX fields apply to this dispatch. When given, a
         fresh ``CallConfig`` is built from the program's ``aicpu_thread_num``
-        baseline, leaving the prepared shared config untouched. ``None`` reuses
-        that baseline with zero extra allocation. Onboard L3 swimlane capture
+        baseline, leaving the prepared shared config untouched. ``None`` also
+        builds a fresh baseline snapshot so an in-flight dispatch never shares
+        mutable configuration with its successor. Onboard L3 swimlane capture
         runs a dep-gen graph pass followed by a dep-gen-disabled timing pass on
         the same prepared Worker; mutable arguments are not restored between
         the two executions.
         """
-        self._require_open("run")
+        self._require_open("submit")
         from pypto.ir.compiled_program import (  # noqa: PLC0415
             _validate_device_tensor,
             _validate_stacked_tensor,
@@ -2015,28 +2268,9 @@ class DistributedWorker(Worker):
         state = self._states.get(compiled)
         if state is None:
             raise ValueError(
-                "DistributedWorker.run(compiled, ...) requires a DistributedCompiledProgram "
+                "DistributedWorker.submit/run requires a DistributedCompiledProgram "
                 "registered when this worker was constructed."
             )
-
-        # Per-task ring sizing: a per-dispatch RunConfig yields a fresh
-        # CallConfig for this call only (the prepared, shared one is never
-        # mutated). With no RunConfig the prepared baseline is reused as-is.
-        call_config = state["call_config"]
-        dfx_base: Path | None = None
-        two_pass_swimlane = False
-        if config is not None:
-            dfx_base = compiled.output_dir / "dfx_outputs"
-            two_pass_swimlane = bool(config.enable_l2_swimlane) and not compiled.platform.endswith("sim")
-            if not two_pass_swimlane:
-                call_config = _make_call_config(compiled._distributed_config, config, dfx_base=dfx_base)
-            # This worker reuses one output_dir across dispatches, so stale
-            # ``rank*/d{k}`` dirs from an earlier, larger run must be cleared
-            # before this run rewrites ``d0, d1, ...`` (see _clear_dfx_dispatch_dirs).
-            from .runner import _DfxOpts  # noqa: PLC0415
-
-            if _DfxOpts.from_run_config(config).any():
-                _clear_dfx_dispatch_dirs(dfx_base)
 
         param_infos = state["param_infos"]
         n_params = len(param_infos)
@@ -2046,46 +2280,115 @@ class DistributedWorker(Worker):
                 f"got {len(args)}. Parameters: {[p.name for p in param_infos]}"
             )
 
-        tensors: dict[str, Any] = dict(state["base_tensors"])
-        for info, arg in zip(param_infos, args, strict=True):
-            if info.shape is None:
-                # Scalar parameter (e.g. seq_len): forwarded as-is to the entry.
-                tensors[info.name] = arg
-                continue
-            if isinstance(arg, StackedDeviceTensor):
-                _validate_stacked_tensor(arg, info)
-            elif isinstance(arg, DeviceTensor):
-                _validate_device_tensor(arg, info)
-            elif isinstance(arg, torch.Tensor):
-                if not arg.is_shared():
-                    raise TypeError(
-                        f"Parameter {info.name!r}: a host torch.Tensor passed to a DistributedWorker "
-                        "must be shared memory allocated BEFORE prepare() (call .share_memory_() and "
-                        "reuse the same buffer across dispatches), so the forked chip worker can see it."
-                    )
-            elif not _is_simpler_tensor(arg):
-                raise TypeError(
-                    f"DistributedWorker parameter {info.name!r} got {type(arg).__name__}; expected a "
-                    f"shared-memory torch.Tensor, a worker-resident DeviceTensor, a "
-                    f"StackedDeviceTensor, or a simpler Tensor."
-                )
-            tensors[info.name] = arg
-
-        if two_pass_swimlane:
-            assert config is not None
-            assert dfx_base is not None
-            _run_l3_swimlane_two_pass(
-                compiled._distributed_config,
+        frame, dispatch_id = self._acquire_dispatch_frame()
+        try:
+            call_config, dfx_base, two_pass_swimlane = self._prepare_dispatch_config(
+                compiled,
                 config,
-                dfx_base,
-                lambda pass_config: self._dispatch_prepared(state, tensors, pass_config),
             )
-        else:
-            self._dispatch_prepared(state, tensors, call_config)
 
-        # Offline post-pass (reads the per-dispatch records on disk; no worker needed).
-        if config is not None and config.enable_l2_swimlane:
-            _collect_l3_swimlane(compiled.output_dir, compiled.platform)
+            tensors = frame.tensors
+            tensors.clear()
+            tensors.update(state["base_tensor_frames"][frame.slot_id])
+            frame.keepalive.clear()
+            frame.keepalive.extend((compiled, call_config, config, *args))
+            for info, arg in zip(param_infos, args, strict=True):
+                if info.shape is None:
+                    # Scalar parameter (e.g. seq_len): forwarded as-is to the entry.
+                    tensors[info.name] = arg
+                    continue
+                if isinstance(arg, StackedDeviceTensor):
+                    _validate_stacked_tensor(arg, info)
+                elif isinstance(arg, DeviceTensor):
+                    _validate_device_tensor(arg, info)
+                elif isinstance(arg, torch.Tensor):
+                    if not arg.is_shared():
+                        raise TypeError(
+                            f"Parameter {info.name!r}: a host torch.Tensor passed to a DistributedWorker "
+                            "must be shared memory allocated BEFORE prepare() (call .share_memory_() and "
+                            "reuse the same buffer across dispatches), so the forked chip worker can see it."
+                        )
+                elif not _is_simpler_tensor(arg):
+                    raise TypeError(
+                        f"DistributedWorker parameter {info.name!r} got {type(arg).__name__}; expected a "
+                        f"shared-memory torch.Tensor, a worker-resident DeviceTensor, a "
+                        f"StackedDeviceTensor, or a simpler Tensor."
+                    )
+                tensors[info.name] = arg
+
+            if two_pass_swimlane:
+                assert config is not None
+                assert dfx_base is not None
+                _run_l3_swimlane_two_pass(
+                    compiled._distributed_config,
+                    config,
+                    dfx_base,
+                    lambda pass_config: self._dispatch_prepared(
+                        state,
+                        tensors,
+                        pass_config,
+                        frame.keepalive,
+                    ),
+                )
+                _collect_l3_swimlane(compiled.output_dir, compiled.platform)
+                self._release_unpublished_dispatch_frame(frame)
+                return DistributedRunHandle._completed(self)
+
+            postprocess: Callable[[], None] | None = None
+            if config is not None and config.enable_l2_swimlane:
+
+                def collect_swimlane() -> None:
+                    _collect_l3_swimlane(compiled.output_dir, compiled.platform)
+
+                postprocess = collect_swimlane
+            handle = DistributedRunHandle(self, None, frame, dispatch_id, postprocess)
+            try:
+                frame.handle = handle
+                with self._dispatch_cv:
+                    self._active_dispatch_handles.add(handle)
+            except BaseException:
+                self._discard_unsubmitted_dispatch_handle(handle, frame)
+                raise
+
+            self._submit_native_dispatch(handle, frame, state, tensors, call_config)
+            return handle
+        except BaseException:
+            if frame.handle is None and frame.in_use:
+                self._release_unpublished_dispatch_frame(frame)
+            raise
+
+    def _prepare_dispatch_config(
+        self,
+        compiled: DistributedCompiledProgram,
+        config: RunConfig | None,
+    ) -> tuple[Any, Path | None, bool]:
+        """Snapshot one dispatch's runtime config after capacity admission."""
+        if config is None:
+            return _make_call_config(compiled._distributed_config), None, False
+
+        dfx_base = compiled.output_dir / "dfx_outputs"
+        two_pass_swimlane = bool(config.enable_l2_swimlane) and not compiled.platform.endswith("sim")
+        call_config = None
+        if not two_pass_swimlane:
+            call_config = _make_call_config(compiled._distributed_config, config, dfx_base=dfx_base)
+
+        # This worker reuses one output_dir across dispatches, so stale
+        # ``rank*/d{k}`` dirs from an earlier, larger run must be cleared before
+        # this run rewrites ``d0, d1, ...``.
+        from .runner import _DfxOpts  # noqa: PLC0415
+
+        if _DfxOpts.from_run_config(config).any():
+            # Every dispatch writes below the same output directory. Finish
+            # earlier work before clearing or repopulating those paths.
+            self._drain_dispatch_handles()
+            _clear_dfx_dispatch_dirs(dfx_base)
+        return call_config, dfx_base, two_pass_swimlane
+
+    def _run_compiled(
+        self, compiled: DistributedCompiledProgram, *args: Any, config: RunConfig | None = None
+    ) -> None:
+        """Blocking compatibility wrapper around :meth:`_submit_compiled`."""
+        self.submit(compiled, *args, config=config).result()
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -2095,37 +2398,80 @@ class DistributedWorker(Worker):
         if self._closed:
             raise RuntimeError(f"DistributedWorker.{op}() called after close()")
 
+    def _drain_dispatch_handles(self) -> BaseException | None:
+        """Finalize every published dispatch in FIFO order."""
+        first_error: BaseException | None = None
+        while True:
+            with self._dispatch_cv:
+                if not self._active_dispatch_handles:
+                    return first_error
+                handle = min(self._active_dispatch_handles, key=lambda item: item._dispatch_id)
+            try:
+                handle.result()
+            except BaseException as exc:  # noqa: BLE001 - close continues bounded cleanup
+                if first_error is None:
+                    first_error = exc
+
     def close(self) -> None:
         """Release runtime resources, retrying incomplete Worker cleanup."""
-        if self._close_complete:
-            return
-        first_attempt = not self._closed
-        if first_attempt:
-            # Auto-free any DeviceTensors the caller forgot. Run BEFORE we set
-            # ``_closed`` so the per-op ``_require_open`` guard inside ``free``
-            # still admits these calls, and BEFORE we tear down the underlying
-            # worker so the free path is still live.
-            self._close_owned_tensors()
-            self._closed = True
-            # Mark every still-alive RegistrationHandle as closed so subsequent
-            # handle(...) calls raise instead of dispatching to a torn-down runtime.
-            for handle in list(self._handles):
-                handle._mark_closed()
-            self._handles.clear()
-        try:
+        # Serialize the admission transition with submit() and prevent two
+        # callers from running teardown concurrently.
+        with self._dispatch_submit_mu:
+            if self._close_complete or self._closing:
+                return
+            self._closing = True
+            first_attempt = not self._closed
             if first_attempt:
-                self._stop_persistent_dispatcher()
-        finally:
+                with self._dispatch_cv:
+                    self._accepting_dispatches = False
+                    self._dispatch_cv.notify_all()
+
+        try:
+            first_error: BaseException | None = None
+            if first_attempt:
+                if self._persistent_error is not None and not self._persistent_error_reported:
+                    first_error = self._remember_close_error(first_error, self._persistent_error)
+                    self._persistent_error_reported = True
+
+                drain_error = self._drain_dispatch_handles()
+                if drain_error is not None:
+                    first_error = self._remember_close_error(first_error, drain_error)
+
+                # A failed native run may have abandoned its per-run finalizer. In
+                # that case keep retained domains globally reachable for the
+                # underlying Worker's whole-tree cleanup.
+                if self._persistent and self._persistent_error is None:
+                    try:
+                        self._release_persistent_domains(self._persistent_domains_by_program)
+                    except BaseException as exc:  # noqa: BLE001 - preserve primary error and continue
+                        first_error = self._remember_close_error(first_error, exc)
+
+                # DeviceTensor frees use the still-live simpler control path.
+                try:
+                    self._close_owned_tensors()
+                except BaseException as exc:  # noqa: BLE001 - underlying worker still must close
+                    first_error = self._remember_close_error(first_error, exc)
+
+                self._closed = True
+                for handle in list(self._handles):
+                    handle._mark_closed()
+                self._handles.clear()
             try:
                 self._w.close()
-                # Recent Simpler versions keep a cleanup journal when close()
-                # fails. Only mark cleanup complete after that journal drains,
-                # so a later close() can retry the underlying Worker.
+            except BaseException as exc:  # noqa: BLE001 - report after local teardown
+                first_error = self._remember_close_error(first_error, exc)
+            else:
                 self._close_complete = True
             finally:
                 self._inherited_host_tensors = ()
                 self._inherited_host_storage_ptrs.clear()
                 self._persistent_zero = None
+                self._persistent_domains_by_program.clear()
+            if first_error is not None:
+                raise first_error
+        finally:
+            with self._dispatch_submit_mu:
+                self._closing = False
 
     def __enter__(self) -> DistributedWorker:
         return self
@@ -2137,6 +2483,31 @@ class DistributedWorker(Worker):
     # Explicit dispatch — mirror ChipWorker's run / register surface so
     # library code can use one method name across L2 / L3.
     # ------------------------------------------------------------------
+
+    def submit(
+        self,
+        compiled: DistributedCompiledProgram,
+        *args: Any,
+        config: RunConfig | None = None,
+    ) -> DistributedRunHandle:
+        """Submit *compiled* and return before device completion when supported.
+
+        The returned handle owns one of two bounded metadata frames plus all
+        argument and configuration lifetimes. A third submission waits for the
+        oldest handle before reusing a frame. Diagnostic two-pass swimlane
+        capture remains a synchronous fallback and returns a completed handle.
+
+        Args:
+            compiled: A program registered when this worker was constructed.
+            *args: In-place program arguments. Mutable arguments must not be
+                reused or modified until the returned handle completes.
+            config: Optional per-dispatch runtime configuration.
+
+        Returns:
+            A handle that owns the dispatch lifetime and cached outcome.
+        """
+        with self._dispatch_submit_mu:
+            return self._submit_compiled(compiled, *args, config=config)
 
     def run(
         self,
@@ -2160,9 +2531,9 @@ class DistributedWorker(Worker):
         therefore use its own ring sizes and diagnostics. On onboard L3,
         ``enable_l2_swimlane`` executes a dep-gen graph pass followed by a
         dep-gen-disabled timing pass; mutable arguments are not restored between
-        them. ``None`` reuses the program's baseline.
+        them. ``None`` snapshots the program's baseline for this dispatch.
         """
-        return self._run_compiled(compiled, *args, config=config)
+        return self.submit(compiled, *args, config=config).result()
 
     def register(self, compiled: DistributedCompiledProgram) -> RegistrationHandle:
         """Pre-register *compiled* on this DistributedWorker.

--- a/tests/st/distributed/test_l3_device_tensor.py
+++ b/tests/st/distributed/test_l3_device_tensor.py
@@ -12,14 +12,16 @@
 The L3 analogue of ``tests/st/runtime/framework_and_models/test_device_tensor.py``: prepare a
 reusable handle once, upload a static weight to a worker-resident DeviceTensor
 via ``rt.alloc_tensor`` (once), then dispatch multiple times reusing both the
-handle (no re-setup) and the resident weight.
+handle (no re-setup) and the resident weight. Three dispatches use distinct
+mutable IO buffers: the first two occupy the bounded asynchronous metadata
+frames, and the third waits for the oldest frame before reuse.
 
 Per-call IO uses shared-memory host tensors allocated **before** ``prepare()``
 and reused in place — the forked chip worker reads/writes them through the
 inherited shared mapping, so the output is read straight back from ``host_out``
 (no ``copy_from``). Only the weight is device-resident
-(``Tensor.child_memory=True``). This mirrors the runtime's
-``child_memory`` example.
+(``Tensor.child_memory=True``). This mirrors the runtime's ``child_memory``
+example while exercising the public asynchronous dispatch contract.
 
 Computation: ``f = a + b``, with ``b`` resident across both dispatches.
 """
@@ -71,17 +73,17 @@ class L3AddProgram:
 
 
 class TestL3DeviceTensorReuse:
-    """prepare() once, allocate resident weight once, dispatch many."""
+    """Prepare once, retain one weight, and submit through two bounded frames."""
 
     def test_resident_weight_reused_across_dispatches(self, test_config, device_ids):
-        """``f = a + b`` over two dispatches; ``b`` uploaded once and reused.
+        """``f = a + b`` over three bounded submissions; ``b`` is uploaded once.
 
         Verifies that:
         1. ``rt.alloc_tensor(init=host_b)`` populates a resident buffer
            (otherwise the kernel would compute ``a + 0``).
-        2. The resident weight (``child_memory=True``) survives across both
-           ``rt(...)`` dispatches without re-upload.
-        3. The handle reuses its Worker — setup is not repeated per call.
+        2. Two submissions can own distinct mutable IO frames concurrently.
+        3. A third submission drains the oldest frame before bounded reuse.
+        4. The resident weight survives every dispatch without re-upload.
         """
         if not device_ids:
             pytest.skip("L3 DeviceTensor test needs at least one device")
@@ -98,20 +100,30 @@ class TestL3DeviceTensorReuse:
 
         # Shared-memory host buffers MUST be allocated before prepare() so the
         # forked chip worker inherits their mappings: host_b is the resident
-        # weight's upload source; host_a / host_out are the per-call IO buffers
-        # (reused in place across dispatches).
-        host_a = torch.zeros((128, 128), dtype=torch.float32).share_memory_()
-        host_out = torch.zeros((128, 128), dtype=torch.float32).share_memory_()
+        # weight's upload source. Every overlapping dispatch owns a distinct
+        # mutable input/output pair until its handle publishes completion.
+        host_inputs = [
+            torch.full((128, 128), value, dtype=torch.float32).share_memory_() for value in (2.0, 7.0, 11.0)
+        ]
+        host_outputs = [torch.zeros((128, 128), dtype=torch.float32).share_memory_() for _ in host_inputs]
         host_b = torch.full((128, 128), 3.0, dtype=torch.float32).share_memory_()
 
         with compiled.prepare() as rt:
             weight = rt.alloc_tensor((128, 128), torch.float32, init=host_b)  # uploaded once
             try:
-                for host_a_val, expect_val in ((2.0, 5.0), (7.0, 10.0)):
-                    host_a.fill_(host_a_val)  # refresh per-call input in place
-                    host_out.zero_()
-                    rt(host_a, weight, host_out)  # reuses Worker + resident weight
+                first = rt.submit(compiled, host_inputs[0], weight, host_outputs[0])
+                second = rt.submit(compiled, host_inputs[1], weight, host_outputs[1])
+                # Both metadata frames are now owned. This call waits for the
+                # oldest handle before it constructs and publishes dispatch 3.
+                third = rt.submit(compiled, host_inputs[2], weight, host_outputs[2])
 
+                for handle, host_out, expect_val in zip(
+                    (first, second, third),
+                    host_outputs,
+                    (5.0, 10.0, 14.0),
+                    strict=True,
+                ):
+                    handle.result()
                     expected = torch.full((128, 128), expect_val, dtype=torch.float32)
                     torch.testing.assert_close(host_out, expected, rtol=1e-5, atol=1e-5)
             finally:

--- a/tests/ut/runtime/test_distributed_worker.py
+++ b/tests/ut/runtime/test_distributed_worker.py
@@ -12,16 +12,17 @@
 Runs without a device or the ``simpler`` package by patching the module-level
 setup helpers in :mod:`pypto.runtime.distributed_runner`, so construction does
 no real compile/fork. The tests cover both ordinary prepared dispatch and the
-persistent contract: one ``Worker.run`` fence per request, retained per-program
-domains, and a complete synchronous cleanup boundary for every caller-visible
-request.
+persistent contract: bounded asynchronous submission, retained per-program
+domains, handle-owned input lifetimes, and complete cleanup before publication.
 """
 
+import gc
 import importlib.util
 import json
 import sys
 import threading
 import weakref
+from collections.abc import Callable
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
 from typing import Any
@@ -41,6 +42,7 @@ from pypto.runtime.bench import (
     _L3_SWIMLANE_TIMING_END,
 )
 from pypto.runtime.distributed_runner import (
+    DistributedRunHandle,
     DistributedWorker,
     _assemble_chip_callables,
     _clear_dfx_dispatch_dirs,
@@ -66,6 +68,46 @@ def _fake_compiled(param_infos, output_indices):
     return compiled
 
 
+class _ImmediateNativeHandle:
+    """Minimal Simpler RunHandle stand-in used by prepared-worker tests."""
+
+    done = True
+
+    def result(self, timeout=None):
+        del timeout
+
+
+class _ControlledNativeHandle:
+    """RunHandle stand-in with an explicit terminal-completion gate."""
+
+    def __init__(
+        self,
+        error: BaseException | None = None,
+        on_result: Callable[[], None] | None = None,
+    ) -> None:
+        self._terminal = threading.Event()
+        self.result_started = threading.Event()
+        self.error = error
+        self._on_result = on_result
+
+    @property
+    def done(self) -> bool:
+        return self._terminal.is_set()
+
+    def complete(self, error: BaseException | None = None) -> None:
+        self.error = error
+        self._terminal.set()
+
+    def result(self, timeout=None):
+        self.result_started.set()
+        if not self._terminal.wait(timeout):
+            raise TimeoutError("native handle timed out")
+        if self._on_result is not None:
+            self._on_result()
+        if self.error is not None:
+            raise self.error
+
+
 @pytest.fixture
 def patched_setup():
     """Patch every setup helper so DistributedWorker() does no real work.
@@ -78,6 +120,7 @@ def patched_setup():
     worker._live_domains = {}
     worker._building_run_resources = None
     worker.malloc.return_value = 0xDEAD0000
+    worker.submit.side_effect = lambda fn: (fn(worker._orch, None, None), _ImmediateNativeHandle())[1]
 
     mod = "pypto.runtime.distributed_runner"
     chip_callables = ({"chip_orch": object()}, "rt_name", False)
@@ -90,6 +133,7 @@ def patched_setup():
         patch(f"{mod}._register_callables", return_value=({}, {"chip_orch": 0})) as register,
         patch(f"{mod}._make_call_config", return_value=MagicMock(name="CallConfig")) as make_call_config,
         patch(f"{mod}._dispatch") as dispatch,
+        patch(f"{mod}._submit_dispatch", return_value=_ImmediateNativeHandle()) as submit_dispatch,
     ):
         yield {
             "worker": worker,
@@ -101,6 +145,7 @@ def patched_setup():
             "register": register,
             "make_call_config": make_call_config,
             "dispatch": dispatch,
+            "submit_dispatch": submit_dispatch,
         }
 
 
@@ -125,39 +170,295 @@ class TestSetupOnce:
         rt(a, b)
 
         # Setup still once; dispatch ran per call.
-        assert m["dispatch"].call_count == 3
+        assert m["submit_dispatch"].call_count == 3
         m["assemble"].assert_called_once()
         m["construct"].assert_called_once()
         assert m["worker"].init.call_count == 1
         rt.close()
 
 
+class TestAsyncDispatchHandle:
+    def test_submit_returns_handle_and_retires_frame_on_result(self, patched_setup):
+        m = patched_setup
+        compiled = _fake_compiled([_param("a", [16, 16])], [])
+        native = _ControlledNativeHandle()
+        m["submit_dispatch"].return_value = native
+        rt = DistributedWorker(compiled)
+
+        handle = rt.submit(compiled, DeviceTensor(0x1000, (16, 16), torch.float32))
+
+        assert isinstance(handle, DistributedRunHandle)
+        assert handle.done is False
+        assert len(rt._active_dispatch_handles) == 1
+        native.complete()
+        handle.result()
+        assert handle.done is True
+        assert not rt._active_dispatch_handles
+        assert all(not frame.in_use for frame in rt._dispatch_frames)
+        rt.close()
+
+    def test_timeout_keeps_frame_owned_until_later_completion(self, patched_setup):
+        m = patched_setup
+        compiled = _fake_compiled([_param("a", [16, 16])], [])
+        native = _ControlledNativeHandle()
+        m["submit_dispatch"].return_value = native
+        rt = DistributedWorker(compiled)
+        handle = rt.submit(compiled, DeviceTensor(0x1000, (16, 16), torch.float32))
+
+        with pytest.raises(TimeoutError):
+            handle.result(timeout=0.0)
+        assert handle.done is False
+        assert any(frame.in_use for frame in rt._dispatch_frames)
+        with pytest.raises(ValueError, match="non-negative finite"):
+            handle.result(timeout=-1.0)
+
+        native.complete()
+        handle.result()
+        assert all(not frame.in_use for frame in rt._dispatch_frames)
+        rt.close()
+
+    def test_handle_keeps_input_alive_until_completion(self, patched_setup):
+        m = patched_setup
+        compiled = _fake_compiled([_param("a", [16, 16])], [])
+        native = _ControlledNativeHandle()
+        m["submit_dispatch"].return_value = native
+        rt = DistributedWorker(compiled)
+        arg = torch.zeros((16, 16), dtype=torch.float32).share_memory_()
+        arg_ref = weakref.ref(arg)
+
+        handle = rt.submit(compiled, arg)
+        m["submit_dispatch"].reset_mock()
+        del arg
+        gc.collect()
+        assert arg_ref() is not None
+
+        native.complete()
+        handle.result()
+        gc.collect()
+        assert arg_ref() is None
+        rt.close()
+
+    def test_third_submit_drains_oldest_before_allocating_metadata(self, patched_setup):
+        m = patched_setup
+        compiled = _fake_compiled([_param("a", [16, 16])], [])
+        natives = [_ControlledNativeHandle() for _ in range(3)]
+        m["submit_dispatch"].side_effect = natives
+        rt = DistributedWorker(compiled)
+        arg = DeviceTensor(0x1000, (16, 16), torch.float32)
+        first = rt.submit(compiled, arg)
+        second = rt.submit(compiled, arg)
+        assert m["make_call_config"].call_count == 3  # prepare + two accepted dispatches
+
+        third_result: list[DistributedRunHandle] = []
+        third_error: list[BaseException] = []
+
+        def submit_third() -> None:
+            try:
+                third_result.append(rt.submit(compiled, arg))
+            except BaseException as exc:  # noqa: BLE001 - asserted below
+                third_error.append(exc)
+
+        caller = threading.Thread(target=submit_third)
+        caller.start()
+        assert natives[0].result_started.wait(timeout=2)
+        # Backpressure happens before a CallConfig or frame-local tensor map is
+        # created for the third dispatch.
+        assert m["make_call_config"].call_count == 3
+        assert not third_result
+
+        natives[0].complete()
+        caller.join(timeout=2)
+        assert not caller.is_alive()
+        assert not third_error
+        assert len(third_result) == 1
+        assert first.done is True
+        assert m["make_call_config"].call_count == 4
+
+        natives[1].complete()
+        natives[2].complete()
+        second.result()
+        third_result[0].result()
+        rt.close()
+
+    def test_backpressure_does_not_rethrow_an_older_handle_error(self, patched_setup):
+        m = patched_setup
+        compiled = _fake_compiled([_param("a", [16, 16])], [])
+        natives = [_ControlledNativeHandle() for _ in range(3)]
+        m["submit_dispatch"].side_effect = natives
+        rt = DistributedWorker(compiled)
+        arg = DeviceTensor(0x1000, (16, 16), torch.float32)
+        first = rt.submit(compiled, arg)
+        second = rt.submit(compiled, arg)
+
+        natives[0].complete(RuntimeError("first dispatch failed"))
+        third = rt.submit(compiled, arg)
+
+        with pytest.raises(RuntimeError, match="first dispatch failed"):
+            first.result()
+        natives[1].complete()
+        natives[2].complete()
+        second.result()
+        third.result()
+        rt.close()
+
+    def test_in_flight_dispatches_use_distinct_host_scratch(self, patched_setup):
+        m = patched_setup
+        allocated: list[object] = []
+
+        def alloc_intermediates(tensors):
+            scratch = object()
+            allocated.append(scratch)
+            tensors["scratch"] = scratch
+
+        m["load_entry"].return_value = (MagicMock(name="entry_fn"), alloc_intermediates)
+        compiled = _fake_compiled([_param("a", [16, 16])], [])
+        natives = [_ControlledNativeHandle(), _ControlledNativeHandle()]
+        m["submit_dispatch"].side_effect = natives
+        rt = DistributedWorker(compiled)
+        arg = DeviceTensor(0x1000, (16, 16), torch.float32)
+
+        first = rt.submit(compiled, arg)
+        second = rt.submit(compiled, arg)
+
+        assert len(allocated) == 2
+        first_tensors = m["submit_dispatch"].call_args_list[0].args[2]
+        second_tensors = m["submit_dispatch"].call_args_list[1].args[2]
+        assert first_tensors["scratch"] is allocated[0]
+        assert second_tensors["scratch"] is allocated[1]
+        natives[0].complete()
+        natives[1].complete()
+        first.result()
+        second.result()
+        rt.close()
+
+    def test_dfx_submit_waits_for_earlier_dispatch(self, patched_setup, tmp_path):
+        m = patched_setup
+        compiled = _fake_compiled([_param("a", [16, 16])], [])
+        compiled.output_dir = tmp_path
+        natives = [_ControlledNativeHandle(), _ImmediateNativeHandle()]
+        m["submit_dispatch"].side_effect = natives
+        rt = DistributedWorker(compiled)
+        arg = DeviceTensor(0x1000, (16, 16), torch.float32)
+        first = rt.submit(compiled, arg)
+        submitted: list[DistributedRunHandle] = []
+
+        with patch("pypto.runtime.distributed_runner._clear_dfx_dispatch_dirs") as clear:
+            caller = threading.Thread(
+                target=lambda: submitted.append(
+                    rt.submit(compiled, arg, config=RunConfig(platform="a2a3sim", enable_dep_gen=True))
+                )
+            )
+            caller.start()
+            assert natives[0].result_started.wait(timeout=2)
+            clear.assert_not_called()
+            assert m["submit_dispatch"].call_count == 1
+
+            natives[0].complete()
+            caller.join(timeout=2)
+            assert not caller.is_alive()
+            clear.assert_called_once_with(tmp_path / "dfx_outputs")
+
+        first.result()
+        submitted[0].result()
+        rt.close()
+
+    def test_failed_handle_recycles_frame_and_caches_error(self, patched_setup):
+        m = patched_setup
+        compiled = _fake_compiled([_param("a", [16, 16])], [])
+        failed = _ControlledNativeHandle()
+        m["submit_dispatch"].return_value = failed
+        rt = DistributedWorker(compiled)
+        handle = rt.submit(compiled, DeviceTensor(0x1000, (16, 16), torch.float32))
+        failed.complete(RuntimeError("dispatch failed"))
+
+        with pytest.raises(RuntimeError, match="dispatch failed"):
+            handle.result()
+        with pytest.raises(RuntimeError, match="dispatch failed"):
+            handle.result()
+        assert all(not frame.in_use for frame in rt._dispatch_frames)
+        rt.close()
+
+    def test_close_drains_outstanding_handle_before_worker_close(self, patched_setup):
+        m = patched_setup
+        compiled = _fake_compiled([_param("a", [16, 16])], [])
+        native = _ControlledNativeHandle()
+        m["submit_dispatch"].return_value = native
+        rt = DistributedWorker(compiled)
+        rt.submit(compiled, DeviceTensor(0x1000, (16, 16), torch.float32))
+
+        closed = threading.Event()
+        closer = threading.Thread(target=lambda: (rt.close(), closed.set()))
+        closer.start()
+        assert native.result_started.wait(timeout=2)
+        assert not closed.is_set()
+        m["worker"].close.assert_not_called()
+
+        native.complete()
+        closer.join(timeout=2)
+        assert closed.is_set()
+        m["worker"].close.assert_called_once_with()
+        with pytest.raises(RuntimeError, match="after close"):
+            rt.submit(compiled, DeviceTensor(0x1000, (16, 16), torch.float32))
+
+    def test_interrupted_native_handle_publication_keeps_frame_until_close(self, patched_setup):
+        m = patched_setup
+        compiled = _fake_compiled([_param("a", [16, 16])], [])
+        native = _ControlledNativeHandle()
+        m["worker"]._accepted_run_handles = set()
+        m["worker"]._hierarchical_start_cv = threading.Condition()
+
+        def interrupt_after_acceptance(*_args):
+            with m["worker"]._hierarchical_start_cv:
+                m["worker"]._accepted_run_handles.add(native)
+            raise KeyboardInterrupt("interrupted after native acceptance")
+
+        m["submit_dispatch"].side_effect = interrupt_after_acceptance
+        rt = DistributedWorker(compiled)
+
+        with pytest.raises(KeyboardInterrupt, match="after native acceptance"):
+            rt.submit(compiled, DeviceTensor(0x1000, (16, 16), torch.float32))
+
+        assert len(rt._active_dispatch_handles) == 1
+        assert sum(frame.in_use for frame in rt._dispatch_frames) == 1
+        closer = threading.Thread(target=rt.close)
+        closer.start()
+        assert native.result_started.wait(timeout=2)
+        assert closer.is_alive()
+
+        native.complete()
+        closer.join(timeout=2)
+        assert not closer.is_alive()
+        assert not rt._active_dispatch_handles
+        assert all(not frame.in_use for frame in rt._dispatch_frames)
+        m["worker"].close.assert_called_once_with()
+
+
 class TestPerTaskRingSizing:
     """A per-dispatch ``RunConfig`` sizes that dispatch's runtime ring buffers.
 
     ``_make_call_config`` runs once at construction to build the program's
-    shared baseline. With no per-dispatch ``config`` that baseline is reused
-    (no rebuild); a ``RunConfig`` triggers a fresh rebuild from the program's
-    ``DistributedConfig`` plus the ring overrides, for this dispatch only.
+    prewarm baseline. Every accepted asynchronous dispatch receives a fresh
+    snapshot; a ``RunConfig`` adds that dispatch's overrides.
     """
 
-    # ``_dispatch(w, entry_fn, tensors, chip_cids, sub_ids, call_config, ...)``
+    # ``_submit_dispatch(w, entry_fn, tensors, chip_cids, sub_ids, call_config, ...)``
     _CALL_CONFIG_ARG = 5
 
-    def test_no_config_reuses_prepared_baseline(self, patched_setup):
+    def test_no_config_snapshots_prepared_baseline(self, patched_setup):
         m = patched_setup
         compiled = _fake_compiled([_param("a", [16, 16])], [])
         rt = DistributedWorker(compiled)
         # Construction builds the baseline exactly once.
         assert m["make_call_config"].call_count == 1
         baseline = m["make_call_config"].return_value
+        fresh = MagicMock(name="FreshCallConfig")
+        m["make_call_config"].return_value = fresh
 
         rt(DeviceTensor(0x1000, (16, 16), torch.float32))
 
-        # No per-dispatch config → baseline reused, no rebuild, and the prepared
-        # config is what reaches _dispatch.
-        assert m["make_call_config"].call_count == 1
-        assert m["dispatch"].call_args.args[self._CALL_CONFIG_ARG] is baseline
+        assert m["make_call_config"].call_count == 2
+        assert fresh is not baseline
+        assert m["submit_dispatch"].call_args.args[self._CALL_CONFIG_ARG] is fresh
         rt.close()
 
     def test_per_dispatch_config_rebuilds_call_config(self, patched_setup):
@@ -177,7 +478,9 @@ class TestPerTaskRingSizing:
         assert rebuild.args[0] is compiled._distributed_config
         assert rebuild.args[1] is rc
         # The freshly built config (not None) is what reaches _dispatch.
-        assert m["dispatch"].call_args.args[self._CALL_CONFIG_ARG] is m["make_call_config"].return_value
+        assert (
+            m["submit_dispatch"].call_args.args[self._CALL_CONFIG_ARG] is m["make_call_config"].return_value
+        )
         rt.close()
 
     def test_run_method_forwards_per_dispatch_config(self, patched_setup):
@@ -215,9 +518,10 @@ class TestPreparedSwimlaneTwoPass:
         timing_call_config = MagicMock(name="TimingCallConfig")
         m["make_call_config"].side_effect = [deps_call_config, timing_call_config]
         events: list[str] = []
-        m["dispatch"].side_effect = lambda *args: events.append(
-            "deps" if args[self._CALL_CONFIG_ARG] is deps_call_config else "timing"
-        )
+        m["submit_dispatch"].side_effect = lambda *args: (
+            events.append("deps" if args[self._CALL_CONFIG_ARG] is deps_call_config else "timing"),
+            _ImmediateNativeHandle(),
+        )[1]
 
         run_config = RunConfig(
             platform="a2a3",
@@ -239,8 +543,8 @@ class TestPreparedSwimlaneTwoPass:
             rt(DeviceTensor(0x1000, (16, 16), torch.float32), config=run_config)
 
         assert events == ["clear", "deps", "timing", "collect"]
-        assert m["dispatch"].call_count == 2
-        assert all(call.args[0] is m["worker"] for call in m["dispatch"].call_args_list)
+        assert m["submit_dispatch"].call_count == 2
+        assert all(call.args[0] is m["worker"] for call in m["submit_dispatch"].call_args_list)
         assert m["construct"].call_count == 1
         assert m["worker"].init.call_count == 1
         clear.assert_called_once_with(tmp_path / "dfx_outputs")
@@ -287,8 +591,8 @@ class TestPreparedSwimlaneTwoPass:
         with patch("pypto.runtime.distributed_runner._collect_l3_swimlane") as collect:
             rt(DeviceTensor(0x1000, (16, 16), torch.float32), config=run_config)
 
-        m["dispatch"].assert_called_once()
-        assert m["dispatch"].call_args.args[self._CALL_CONFIG_ARG] is call_config
+        m["submit_dispatch"].assert_called_once()
+        assert m["submit_dispatch"].call_args.args[self._CALL_CONFIG_ARG] is call_config
         m["make_call_config"].assert_called_once_with(
             compiled._distributed_config,
             run_config,
@@ -309,7 +613,7 @@ class TestPreparedSwimlaneTwoPass:
         with patch("pypto.runtime.distributed_runner._collect_l3_swimlane") as collect:
             rt(DeviceTensor(0x1000, (16, 16), torch.float32), config=run_config)
 
-        m["dispatch"].assert_called_once()
+        m["submit_dispatch"].assert_called_once()
         m["make_call_config"].assert_called_once_with(
             compiled._distributed_config,
             run_config,
@@ -326,15 +630,18 @@ class TestPreparedSwimlaneTwoPass:
         rt = DistributedWorker(compiled)
 
         # Exercise _dispatch_prepared's persistent branch without starting a
-        # background thread: each call into _dispatch_persistent is the
-        # synchronous request/fence used by the real dispatcher.
+        # background thread: the two-pass fallback still fences both requests.
         rt._persistent = True
         m["make_call_config"].reset_mock()
         deps_call_config = MagicMock(name="DepsCallConfig")
         timing_call_config = MagicMock(name="TimingCallConfig")
         m["make_call_config"].side_effect = [deps_call_config, timing_call_config]
         with (
-            patch.object(rt, "_dispatch_persistent") as dispatch_persistent,
+            patch.object(
+                rt,
+                "_submit_persistent",
+                return_value=_ImmediateNativeHandle(),
+            ) as submit_persistent,
             patch("pypto.runtime.distributed_runner._collect_l3_swimlane"),
         ):
             rt(
@@ -342,7 +649,7 @@ class TestPreparedSwimlaneTwoPass:
                 config=RunConfig(platform="a2a3", enable_l2_swimlane=True),
             )
 
-        assert [call.args[2] for call in dispatch_persistent.call_args_list] == [
+        assert [call.args[2] for call in submit_persistent.call_args_list] == [
             deps_call_config,
             timing_call_config,
         ]
@@ -388,13 +695,18 @@ class TestArenaPrewarm:
 
 class TestPerCallValidation:
     def test_accepts_device_tensor(self, patched_setup):
+        submitted_tensors: dict[str, Any] = {}
+
+        def submit_dispatch(*args):
+            submitted_tensors.update(args[2])
+            return _ImmediateNativeHandle()
+
+        patched_setup["submit_dispatch"].side_effect = submit_dispatch
         compiled = _fake_compiled([_param("a", [128, 128]), _param("b", [128, 128])], [])
         rt = DistributedWorker(compiled)
         rt(DeviceTensor(0x1000, (128, 128), torch.float32), DeviceTensor(0x2000, (128, 128), torch.float32))
-        patched_setup["dispatch"].assert_called_once()
-        # The merged tensors dict (5th positional arg of _dispatch) carries the inputs by name.
-        tensors = patched_setup["dispatch"].call_args.args[2]
-        assert set(tensors) == {"a", "b"}
+        patched_setup["submit_dispatch"].assert_called_once()
+        assert set(submitted_tensors) == {"a", "b"}
         rt.close()
 
     def test_accepts_shared_host_torch_tensor(self, patched_setup):
@@ -402,7 +714,7 @@ class TestPerCallValidation:
         rt = DistributedWorker(compiled)
         host_a = torch.zeros(128, 128, dtype=torch.float32).share_memory_()
         rt(host_a, DeviceTensor(0x2000, (128, 128), torch.float32))
-        patched_setup["dispatch"].assert_called_once()
+        patched_setup["submit_dispatch"].assert_called_once()
         rt.close()
 
     def test_rejects_non_shared_host_torch_tensor(self, patched_setup):
@@ -453,12 +765,18 @@ class TestPerCallValidation:
     def test_scalar_param_forwarded_as_is(self, patched_setup):
         # Scalar params (shape=None, e.g. seq_len) bypass tensor validation and
         # are forwarded verbatim to the entry — common in serving dispatch.
+        submitted_tensors: dict[str, Any] = {}
+
+        def submit_dispatch(*args):
+            submitted_tensors.update(args[2])
+            return _ImmediateNativeHandle()
+
+        patched_setup["submit_dispatch"].side_effect = submit_dispatch
         scalar = _ParamInfo(name="seq_len", direction=ParamDirection.In, shape=None, dtype=DataType.FP32)
         compiled = _fake_compiled([scalar, _param("kv", [16, 16])], [])
         rt = DistributedWorker(compiled)
         rt(7, DeviceTensor(0x1000, (16, 16), torch.float32))
-        tensors = patched_setup["dispatch"].call_args.args[2]
-        assert tensors["seq_len"] == 7
+        assert submitted_tensors["seq_len"] == 7
         rt.close()
 
     def test_rejects_wrong_arg_count(self, patched_setup):
@@ -774,6 +1092,32 @@ class TestLifecycle:
         rt.close()  # cleanup completed, so further calls are no-ops
         assert worker.close.call_count == 2
 
+    def test_concurrent_close_runs_teardown_once(self, patched_setup):
+        compiled = _fake_compiled([_param("a", [16, 16])], [])
+        rt = DistributedWorker(compiled)
+        worker = patched_setup["worker"]
+        close_started = threading.Event()
+        allow_close = threading.Event()
+
+        def worker_close() -> None:
+            close_started.set()
+            assert allow_close.wait(timeout=2)
+
+        worker.close.side_effect = worker_close
+        first = threading.Thread(target=rt.close)
+        second = threading.Thread(target=rt.close)
+        first.start()
+        assert close_started.wait(timeout=2)
+        second.start()
+        second.join(timeout=2)
+        assert not second.is_alive()
+        worker.close.assert_called_once_with()
+
+        allow_close.set()
+        first.join(timeout=2)
+        assert not first.is_alive()
+        assert rt._close_complete is True
+
     def test_context_manager_closes(self, patched_setup):
         compiled = _fake_compiled([_param("a", [16, 16])], [])
         with DistributedWorker(compiled) as rt:
@@ -1020,8 +1364,8 @@ class TestWorkerConstruction:
 class TestExplicitDispatchAPI:
     """The new ``run`` / ``register`` surface that mirrors ChipWorker.
 
-    DistributedWorker.run() is an alias for ``__call__`` (existing dispatch
-    path). register() returns a :class:`RegistrationHandle` whose call
+    DistributedWorker.run() and ``__call__`` are blocking submit/result
+    compositions. register() returns a :class:`RegistrationHandle` whose call
     delegates to run().
     """
 
@@ -1034,7 +1378,7 @@ class TestExplicitDispatchAPI:
         a = torch.zeros(4).share_memory_()
         b = torch.zeros(4).share_memory_()
         rt.run(compiled, a, b)
-        patched_setup["dispatch"].assert_called_once()
+        patched_setup["submit_dispatch"].assert_called_once()
 
         # register() returns a usable handle.
         rt2 = DistributedWorker(compiled)
@@ -1076,9 +1420,9 @@ class TestExplicitDispatchAPI:
         b = torch.zeros(4).share_memory_()
 
         h = rt.register(compiled)
-        patched_setup["dispatch"].reset_mock()
+        patched_setup["submit_dispatch"].reset_mock()
         h(a, b)
-        patched_setup["dispatch"].assert_called_once()
+        patched_setup["submit_dispatch"].assert_called_once()
         rt.close()
 
     def test_close_marks_handle_closed(self, patched_setup):
@@ -1218,9 +1562,9 @@ class TestMultiProgram:
         b = torch.zeros(8).share_memory_()
 
         rt.run(prog_b, b)
-        assert m["dispatch"].call_args.args[1] is entry_b
+        assert m["submit_dispatch"].call_args.args[1] is entry_b
         rt.run(prog_a, a)
-        assert m["dispatch"].call_args.args[1] is entry_a
+        assert m["submit_dispatch"].call_args.args[1] is entry_a
         rt.close()
 
     def test_num_sub_workers_is_max_across_programs(self, patched_setup):
@@ -1263,7 +1607,7 @@ class TestMultiProgram:
         rt = DistributedWorker([prog])
         assert rt._multi_program is False
         rt(torch.zeros(4).share_memory_())
-        patched_setup["dispatch"].assert_called_once()
+        patched_setup["submit_dispatch"].assert_called_once()
         rt.close()
 
     def test_call_raises_in_multi_program_mode(self, patched_setup):
@@ -1276,6 +1620,13 @@ class TestMultiProgram:
 
     def test_shared_device_tensor_across_programs(self, patched_setup):
         m = patched_setup
+        submitted_tensors: list[dict[str, Any]] = []
+
+        def submit_dispatch(*args):
+            submitted_tensors.append(dict(args[2]))
+            return _ImmediateNativeHandle()
+
+        m["submit_dispatch"].side_effect = submit_dispatch
         # Both programs take a same-shaped KV param; one resident DeviceTensor
         # is dispatched through both (the serving KV-cache sharing contract).
         prog_a = _fake_compiled([_param("kv", [16, 16])], [])
@@ -1286,9 +1637,9 @@ class TestMultiProgram:
         rt.run(prog_a, kv)
         rt.run(prog_b, kv)
 
-        assert m["dispatch"].call_count == 2
-        for call in m["dispatch"].call_args_list:
-            assert call.args[2]["kv"] is kv  # same pointer in both tensor maps
+        assert m["submit_dispatch"].call_count == 2
+        for tensors in submitted_tensors:
+            assert tensors["kv"] is kv  # same pointer in both tensor maps
         rt.close()
 
     def test_register_each_program_returns_handle(self, patched_setup):
@@ -1309,9 +1660,9 @@ class TestMultiProgram:
 
         # Each handle dispatches its own program's state.
         h_a(torch.zeros(4).share_memory_())
-        assert m["dispatch"].call_args.args[1] is entry_a
+        assert m["submit_dispatch"].call_args.args[1] is entry_a
         h_b(torch.zeros(8).share_memory_())
-        assert m["dispatch"].call_args.args[1] is entry_b
+        assert m["submit_dispatch"].call_args.args[1] is entry_b
 
         # close() marks every program's handle closed and tears down the one worker.
         rt.close()
@@ -2230,7 +2581,14 @@ class TestPersistentDistributedWorker:
         m = patched_setup
         m["worker"]._live_domains = {}
         orch = _PersistentOrch(m["worker"])
-        m["worker"].run.side_effect = orch.run
+        submit_threads: list[int] = []
+
+        def worker_submit(fn):
+            submit_threads.append(threading.get_ident())
+            orch.run(fn)
+            return _ImmediateNativeHandle()
+
+        m["worker"].submit.side_effect = worker_submit
         seen_handles: list[Any] = []
         window_size = (1 << 20) + 17
         m["load_entry"].return_value = (_persistent_entry(window_size, seen_handles), None)
@@ -2251,7 +2609,8 @@ class TestPersistentDistributedWorker:
         rt(arg)
         rt.close()
 
-        assert m["worker"].run.call_count == 2
+        assert m["worker"].submit.call_count == 2
+        assert submit_threads == [threading.get_ident(), threading.get_ident()]
         assert [call["name"] for call in orch.allocate_calls] == ["p0:comm_d0"]
         assert len(seen_handles) == 2
         assert seen_handles[0] is seen_handles[1]
@@ -2264,18 +2623,58 @@ class TestPersistentDistributedWorker:
             (1, 17),
         ]
         # A retained domain survives both request run-fences and is released
-        # once when the persistent dispatcher closes.
+        # once when the persistent worker closes.
         assert handle.release_count == 1
         assert handle.close_sweep_count == 0
         assert handle.backend_release_count == 1
         assert handle.freed
         assert m["worker"]._live_domains == {}
 
+    def test_warm_domain_supports_two_bounded_handles_and_single_close_release(self, patched_setup):
+        m = patched_setup
+        m["worker"]._live_domains = {}
+        orch = _PersistentOrch(m["worker"])
+        first_native = _ControlledNativeHandle()
+        second_native = _ControlledNativeHandle()
+        natives = [_ImmediateNativeHandle(), first_native, second_native]
+
+        def worker_submit(fn):
+            orch.run(fn)
+            return natives.pop(0)
+
+        m["worker"].submit.side_effect = worker_submit
+        seen_handles: list[Any] = []
+        m["load_entry"].return_value = (_persistent_entry(64, seen_handles), None)
+        compiled = _fake_compiled([_param("a", [16, 16])], [])
+        arg = DeviceTensor(0x1000, (16, 16), torch.float32)
+        rt = DistributedWorker(compiled, persistent=True)
+
+        rt(arg)
+        rt.submit(compiled, arg)
+        rt.submit(compiled, arg)
+        domain = orch.handles[0]
+        assert len(rt._active_dispatch_handles) == 2
+        assert len(orch.allocate_calls) == 1
+        assert seen_handles == [domain, domain, domain]
+
+        closer = threading.Thread(target=rt.close)
+        closer.start()
+        assert first_native.result_started.wait(timeout=2)
+        first_native.complete()
+        assert second_native.result_started.wait(timeout=2)
+        second_native.complete()
+        closer.join(timeout=2)
+
+        assert not closer.is_alive()
+        assert domain.release_count == 1
+        assert domain.backend_release_count == 1
+        assert domain.freed
+
     def test_reused_domain_skips_window_reset_when_disabled(self, patched_setup):
         m = patched_setup
         m["worker"]._live_domains = {}
         orch = _PersistentOrch(m["worker"])
-        m["worker"].run.side_effect = orch.run
+        m["worker"].submit.side_effect = lambda fn: (orch.run(fn), _ImmediateNativeHandle())[1]
         seen_handles: list[Any] = []
         m["load_entry"].return_value = (_persistent_entry(64, seen_handles), None)
         compiled = _fake_compiled([_param("a", [16, 16])], [])
@@ -2290,7 +2689,7 @@ class TestPersistentDistributedWorker:
         assert len(orch.allocate_calls) == 1
         assert seen_handles[0] is seen_handles[1]
         assert orch.copy_calls == []
-        assert m["worker"].run.call_count == 2
+        assert m["worker"].submit.call_count == 2
 
     def test_task_args_stay_alive_through_request_drain(self, patched_setup):
         m = patched_setup
@@ -2323,9 +2722,14 @@ class TestPersistentDistributedWorker:
             assert task_args_ref is not None
             assert task_args_ref() is not None
 
-        # The request-owned keepalive stays populated until Worker.run's
-        # completion fence and cleanup return.
-        m["worker"].run.side_effect = lambda fn: orch.run(fn, before_retire=assert_task_args_alive)
+        native = _ControlledNativeHandle(on_result=assert_task_args_alive)
+
+        def worker_submit(fn):
+            orch.run(fn, before_retire=assert_task_args_alive)
+            native.complete()
+            return native
+
+        m["worker"].submit.side_effect = worker_submit
         m["load_entry"].return_value = (entry, None)
         compiled = _fake_compiled([_param("a", [16, 16])], [])
 
@@ -2333,8 +2737,8 @@ class TestPersistentDistributedWorker:
         rt(DeviceTensor(0x1000, (16, 16), torch.float32))
 
         assert task_args_ref is not None
-        # Once the synchronous request boundary has drained, the keepalive is
-        # cleared instead of retaining every request for the worker lifetime.
+        # Once the caller waits the handle, its bounded frame releases the
+        # request keepalive instead of retaining it for the worker lifetime.
         assert task_args_ref() is None
         rt.close()
 
@@ -2342,7 +2746,7 @@ class TestPersistentDistributedWorker:
         m = patched_setup
         m["worker"]._live_domains = {}
         orch = _PersistentOrch(m["worker"])
-        m["worker"].run.side_effect = orch.run
+        m["worker"].submit.side_effect = lambda fn: (orch.run(fn), _ImmediateNativeHandle())[1]
         seen_a: list[Any] = []
         seen_b: list[Any] = []
         m["load_entry"].side_effect = [
@@ -2365,7 +2769,7 @@ class TestPersistentDistributedWorker:
         rt.run(compiled_a, arg)
         rt.close()
 
-        assert m["worker"].run.call_count == 3
+        assert m["worker"].submit.call_count == 3
         assert [call["name"] for call in orch.allocate_calls] == ["p0:comm_d0", "p1:comm_d0"]
         assert seen_a[0] is seen_a[1]
         assert seen_a[0] is not seen_b[0]
@@ -2384,7 +2788,7 @@ class TestPersistentDistributedWorker:
         m = patched_setup
         m["worker"]._live_domains = {}
         orch = _PersistentOrch(m["worker"])
-        m["worker"].run.side_effect = orch.run
+        m["worker"].submit.side_effect = lambda fn: (orch.run(fn), _ImmediateNativeHandle())[1]
         m["load_entry"].return_value = (_persistent_entry(64, []), None)
         compiled = _fake_compiled([_param("a", [16, 16])], [])
         rt = DistributedWorker(compiled, persistent=True)
@@ -2407,7 +2811,7 @@ class TestPersistentDistributedWorker:
     def test_unfreed_domain_release_reaches_close(self, patched_setup):
         m = patched_setup
         orch = _PersistentOrch(m["worker"])
-        m["worker"].run.side_effect = orch.run
+        m["worker"].submit.side_effect = lambda fn: (orch.run(fn), _ImmediateNativeHandle())[1]
         m["load_entry"].return_value = (_persistent_entry(64, []), None)
         compiled = _fake_compiled([_param("a", [16, 16])], [])
         rt = DistributedWorker(compiled, persistent=True)
@@ -2429,7 +2833,7 @@ class TestPersistentDistributedWorker:
         m = patched_setup
         m["worker"]._live_domains = {}
         orch = _PersistentOrch(m["worker"])
-        m["worker"].run.side_effect = orch.run
+        m["worker"].submit.side_effect = lambda fn: (orch.run(fn), _ImmediateNativeHandle())[1]
 
         def failing_entry(
             orch,
@@ -2477,12 +2881,12 @@ class TestPersistentDistributedWorker:
         assert handle.backend_release_count == 1
         assert handle.freed
         assert m["worker"]._live_domains == {}
-        assert m["worker"].run.call_count == 1
+        assert m["worker"].submit.call_count == 1
 
     def test_abandoned_run_keeps_domain_reachable_for_worker_close(self, patched_setup):
         m = patched_setup
         orch = _PersistentOrch(m["worker"])
-        m["worker"].run.side_effect = orch.run_with_abandoned_finalization
+        m["worker"].submit.side_effect = orch.run_with_abandoned_finalization
         m["load_entry"].return_value = (_persistent_entry(64, []), None)
         compiled = _fake_compiled([_param("a", [16, 16])], [])
         rt = DistributedWorker(compiled, persistent=True)
@@ -2506,22 +2910,18 @@ class TestPersistentDistributedWorker:
         assert handle.freed
         assert m["worker"]._live_domains == {}
 
-    def test_dispatch_error_waits_for_request_worker_cleanup(self, patched_setup):
+    def test_native_failure_waits_for_handle_finalization(self, patched_setup):
         m = patched_setup
         m["worker"]._live_domains = {}
-        orch = _PersistentOrch(m["worker"])
-        request_finalizer_started = threading.Event()
-        allow_request_finalizer_to_finish = threading.Event()
+        native = _ControlledNativeHandle()
 
-        def wait_for_request_finalizer() -> None:
-            # Model the interval between orchestration failing and this
-            # request's Worker.run fence/cleanup finally completing.
-            request_finalizer_started.set()
-            assert allow_request_finalizer_to_finish.wait(timeout=2)
+        def worker_submit(fn):
+            del fn
+            return native
 
-        m["worker"].run.side_effect = lambda fn: orch.run(fn, on_error=wait_for_request_finalizer)
+        m["worker"].submit.side_effect = worker_submit
 
-        def failing_entry(
+        def persistent_entry(
             orch,
             _args,
             config,
@@ -2534,9 +2934,8 @@ class TestPersistentDistributedWorker:
             _domain_provider=None,
         ):
             del orch, _args, config, tensors, callables, sub_ids, _keep, world_size, _domain_provider
-            raise RuntimeError("persistent dispatch failed before cleanup")
 
-        m["load_entry"].return_value = (failing_entry, None)
+        m["load_entry"].return_value = (persistent_entry, None)
         compiled = _fake_compiled([_param("a", [16, 16])], [])
         rt = DistributedWorker(compiled, persistent=True)
         caller_done = threading.Event()
@@ -2552,12 +2951,11 @@ class TestPersistentDistributedWorker:
 
         caller = threading.Thread(target=call_worker)
         caller.start()
-        assert request_finalizer_started.wait(timeout=2)
-        # A failing entry may already have submitted device work. Its caller
-        # must not observe completion while Worker.run is still finalizing it.
+        assert native.result_started.wait(timeout=2)
+        # A native failure is not published while its handle is still running.
         assert not caller_done.is_set()
 
-        allow_request_finalizer_to_finish.set()
+        native.complete(RuntimeError("persistent dispatch failed before cleanup"))
         caller.join(timeout=2)
         assert not caller.is_alive()
         assert caller_done.is_set()


### PR DESCRIPTION
## Summary

- add `DistributedWorker.submit()` and public `DistributedRunHandle` while keeping `run()` and `__call__()` blocking
- bound dispatch metadata to two reusable frames; a third submission drains the oldest handle before reuse
- retain per-dispatch arguments, `CallConfig`, generated task metadata, and native handles through terminal completion
- allocate HOST intermediates per frame so two in-flight dispatches do not share mutable scratch
- serialize DFX submissions, isolate backpressure errors, and make `close()` safe for concurrent callers
- submit persistent orchestration directly from the caller through Simpler `Worker.submit()`, retaining CommDomains without a Python dispatcher queue or background thread
- publish provisional dispatch ownership before native submission and recover an accepted Simpler handle across interruption so its frame cannot be released early

## Dependency

This is Q1 in the worker asynchronous pipeline stack. It is rebased on current PyPTO `main` (`df3ac122`) and uses the existing `runtime` gitlink at `3165cc89`; this PR does not change the runtime submodule. Serving integration, end-to-end queue semantics, and cross-layer performance acceptance remain outside this PR.

## Validation

- rebuilt the worktree bindings and reinstalled the editable package
- `tests/ut/runtime/test_distributed_worker.py`: 144 passed
- `tests/ut/runtime`: 587 passed
- full `tests/ut`: 9389 passed, 3 skipped
- full `pre-commit run --all-files`: passed, including Ruff, Pyright, Markdown, C/C++, headers, English-only, docs en/zh parity/navigation/symbol coverage, broad-exception, and operator-name checks
