### PR TITLE
fix(codegen): size the GM pipe workspace for both rings of a bidirectional pipe

### DIFF
--- a/include/pypto/codegen/gm_pipe_layout.h
+++ b/include/pypto/codegen/gm_pipe_layout.h
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#ifndef PYPTO_CODEGEN_GM_PIPE_LAYOUT_H_
+#define PYPTO_CODEGEN_GM_PIPE_LAYOUT_H_
+
+#include <cstdint>
+
+#include "pypto/ir/transforms/utils/core_affinity.h"
+
+namespace pypto {
+namespace codegen {
+namespace gm_pipe {
+
+/// Layout rules for the GM ring buffers backing a cross-core (cube<->vector) pipe.
+///
+/// Two places must agree on these numbers: the orchestration analysis that sizes the injected
+/// `__gm_pipe_buffer` workspace, and the PTO codegen that assigns each frontend pipe its byte
+/// offset *within* that workspace. When they disagree, either the allocation is too small or two
+/// independent pipes overlap — both silent, both corrupting. Keep the rules here, once.
+
+/// Slots per ring, used when `initialize_pipe` carries no explicit `slot_num`.
+/// Mirrors cross_core_pipe.cpp's GetSlotNumForDirMask and PTOAS's own derivation.
+/// Returns 0 for a dir_mask that does not describe a GM-backed pipe.
+inline int SlotCountForDirMask(int dir_mask) {
+  const int bidirectional = ir::core_affinity::kDirMaskC2V | ir::core_affinity::kDirMaskV2C;
+  if (dir_mask == bidirectional) {
+    return 4;
+  }
+  if (dir_mask == ir::core_affinity::kDirMaskC2V || dir_mask == ir::core_affinity::kDirMaskV2C) {
+    return 8;
+  }
+  return 0;
+}
+
+/// Independent rings in the GM buffer. A bidirectional pipe is TWO rings laid out back to back:
+/// on a2a3 the C2V ring starts at the pipe's base and the V2C ring at base + slot_num * slot_size
+/// (pto-isa, `TPipe`). Returns 0 for a dir_mask that does not describe a GM-backed pipe.
+inline int RingCountForDirMask(int dir_mask) {
+  const int bidirectional = ir::core_affinity::kDirMaskC2V | ir::core_affinity::kDirMaskV2C;
+  if (dir_mask == bidirectional) {
+    return 2;
+  }
+  if (dir_mask == ir::core_affinity::kDirMaskC2V || dir_mask == ir::core_affinity::kDirMaskV2C) {
+    return 1;
+  }
+  return 0;
+}
+
+/// Slots per ring for a pipe, honouring an explicit `slot_num` (<= 0 means "not specified").
+/// Returns 0 when `dir_mask` is not a GM-backed pipe, whatever `slot_num` says — an explicit
+/// slot count must not paper over a direction mask we cannot lay out.
+inline int EffectiveSlotCount(int dir_mask, int slot_num) {
+  const int dir_slots = SlotCountForDirMask(dir_mask);
+  if (dir_slots <= 0) {
+    return 0;
+  }
+  return slot_num > 0 ? slot_num : dir_slots;
+}
+
+/// Total bytes one pipe occupies in the GM workspace: rings * slots * slot_size.
+/// Returns 0 for a dir_mask that does not describe a GM-backed pipe.
+inline int64_t FootprintBytes(int dir_mask, int slot_num, int slot_size) {
+  const int64_t slots = EffectiveSlotCount(dir_mask, slot_num);
+  const int64_t rings = RingCountForDirMask(dir_mask);
+  return slots * rings * static_cast<int64_t>(slot_size);
+}
+
+}  // namespace gm_pipe
+}  // namespace codegen
+}  // namespace pypto
+
+#endif  // PYPTO_CODEGEN_GM_PIPE_LAYOUT_H_

--- a/src/codegen/orchestration/orchestration_analysis.cpp
+++ b/src/codegen/orchestration/orchestration_analysis.cpp
@@ -23,6 +23,7 @@
 #include <utility>
 #include <vector>
 
+#include "pypto/codegen/gm_pipe_layout.h"
 #include "pypto/core/logging.h"
 #include "pypto/ir/expr.h"
 #include "pypto/ir/function.h"
@@ -33,7 +34,6 @@
 #include "pypto/ir/stmt.h"
 #include "pypto/ir/transforms/base/visitor.h"
 #include "pypto/ir/transforms/utils/auto_name_utils.h"
-#include "pypto/ir/transforms/utils/core_affinity.h"
 #include "pypto/ir/transforms/utils/op_predicates.h"
 #include "pypto/ir/transforms/utils/return_lineage_utils.h"
 #include "pypto/ir/transforms/utils/transform_utils.h"
@@ -81,35 +81,9 @@ int GetOrCreateFuncId(const std::string& func_name, std::map<std::string, int>* 
   return (*func_name_to_id)[func_name];
 }
 
-namespace {
-
-// Slots per ring. Mirrors cross_core_pipe.cpp's GetSlotNumForDirMask and PTOAS's own
-// derivation; only used when initialize_pipe carries no explicit slot_num attribute.
-int GetGMPipeSlotCount(int dir_mask) {
-  const int bidirectional = core_affinity::kDirMaskC2V | core_affinity::kDirMaskV2C;
-  if (dir_mask == bidirectional) {
-    return 4;
-  }
-  if (dir_mask == core_affinity::kDirMaskC2V || dir_mask == core_affinity::kDirMaskV2C) {
-    return 8;
-  }
-  return 0;
-}
-
-// Number of independent rings in the GM workspace. A bidirectional pipe is TWO rings, laid
-// out back to back: on a2a3 the C2V ring starts at the workspace base and the V2C ring at
-// base + slot_num * slot_size. Sizing a bidirectional pipe as a single ring leaves the entire
-// V2C ring past the end of the allocation.
-int GetGMPipeRingCount(int dir_mask) {
-  const int bidirectional = core_affinity::kDirMaskC2V | core_affinity::kDirMaskV2C;
-  return dir_mask == bidirectional ? 2 : 1;
-}
-
-}  // namespace
-
 int64_t ComputeGMPipeWorkspaceElements(const ProgramPtr& program, const FunctionPtr& root_func) {
   std::map<std::pair<int, int>, int> slot_size_by_pipe;
-  std::map<std::pair<int, int>, int> slot_num_by_pipe;
+  std::map<std::pair<int, int>, int> slot_count_by_pipe;
 
   std::unordered_set<std::string> visited_funcs;
   std::function<void(const std::vector<StmtPtr>&)> scan_stmts;
@@ -129,12 +103,14 @@ int64_t ComputeGMPipeWorkspaceElements(const ProgramPtr& program, const Function
         const int slot_num = call->GetKwarg<int>("slot_num", 0);
         if (dir_mask > 0 && slot_size > 0) {
           const auto key = std::make_pair(pipe_id, dir_mask);
-          if (slot_num > 0) {
-            auto [nit, ninserted] = slot_num_by_pipe.emplace(key, slot_num);
-            CHECK(ninserted || nit->second == slot_num)
-                << "initialize_pipe for frontend pipe id " << pipe_id << " and dir_mask " << dir_mask
-                << " uses inconsistent slot_num values: " << nit->second << " and " << slot_num;
-          }
+          // Compare the *effective* slot count, so a call that omits slot_num and one that
+          // states the dir_mask default agree, and a call that omits it while another states a
+          // non-default value is caught rather than silently sized from the explicit one.
+          const int slot_count = codegen::gm_pipe::EffectiveSlotCount(dir_mask, slot_num);
+          auto [nit, ninserted] = slot_count_by_pipe.emplace(key, slot_count);
+          CHECK(ninserted || nit->second == slot_count)
+              << "initialize_pipe for frontend pipe id " << pipe_id << " and dir_mask " << dir_mask
+              << " uses inconsistent slot counts: " << nit->second << " and " << slot_count;
           auto [it, inserted] = slot_size_by_pipe.emplace(key, slot_size);
           CHECK(inserted || it->second == slot_size)
               << "initialize_pipe for frontend pipe id " << pipe_id << " and dir_mask " << dir_mask
@@ -177,14 +153,13 @@ int64_t ComputeGMPipeWorkspaceElements(const ProgramPtr& program, const Function
   int64_t total_bytes = 0;
   for (const auto& [key, slot_size] : slot_size_by_pipe) {
     const int dir_mask = key.second;
-    // Honour an explicit slot_num when the pipe carries one; otherwise fall back to the
-    // dir_mask-derived default that PTOAS would pick.
-    auto num_it = slot_num_by_pipe.find(key);
-    const int slot_count = num_it != slot_num_by_pipe.end() ? num_it->second : GetGMPipeSlotCount(dir_mask);
-    const int ring_count = GetGMPipeRingCount(dir_mask);
-    CHECK(slot_count > 0) << "initialize_pipe has invalid dir_mask for GM slot buffer: " << dir_mask;
-    const int64_t pipe_bytes =
-        static_cast<int64_t>(ring_count) * static_cast<int64_t>(slot_count) * static_cast<int64_t>(slot_size);
+    // The dir_mask must describe a GM-backed pipe before any explicit slot_num is honoured,
+    // so an unlayoutable direction is still rejected rather than sized from the override.
+    CHECK(codegen::gm_pipe::SlotCountForDirMask(dir_mask) > 0)
+        << "initialize_pipe has invalid dir_mask for GM slot buffer: " << dir_mask;
+    auto num_it = slot_count_by_pipe.find(key);
+    const int slot_count = num_it != slot_count_by_pipe.end() ? num_it->second : 0;
+    const int64_t pipe_bytes = codegen::gm_pipe::FootprintBytes(dir_mask, slot_count, slot_size);
     CHECK(total_bytes <= std::numeric_limits<int64_t>::max() - pipe_bytes)
         << "GM slot buffer size overflow while sizing frontend pipe id " << key.first;
     total_bytes += pipe_bytes;

--- a/src/codegen/orchestration/orchestration_analysis.cpp
+++ b/src/codegen/orchestration/orchestration_analysis.cpp
@@ -83,6 +83,8 @@ int GetOrCreateFuncId(const std::string& func_name, std::map<std::string, int>* 
 
 namespace {
 
+// Slots per ring. Mirrors cross_core_pipe.cpp's GetSlotNumForDirMask and PTOAS's own
+// derivation; only used when initialize_pipe carries no explicit slot_num attribute.
 int GetGMPipeSlotCount(int dir_mask) {
   const int bidirectional = core_affinity::kDirMaskC2V | core_affinity::kDirMaskV2C;
   if (dir_mask == bidirectional) {
@@ -94,10 +96,20 @@ int GetGMPipeSlotCount(int dir_mask) {
   return 0;
 }
 
+// Number of independent rings in the GM workspace. A bidirectional pipe is TWO rings, laid
+// out back to back: on a2a3 the C2V ring starts at the workspace base and the V2C ring at
+// base + slot_num * slot_size. Sizing a bidirectional pipe as a single ring leaves the entire
+// V2C ring past the end of the allocation.
+int GetGMPipeRingCount(int dir_mask) {
+  const int bidirectional = core_affinity::kDirMaskC2V | core_affinity::kDirMaskV2C;
+  return dir_mask == bidirectional ? 2 : 1;
+}
+
 }  // namespace
 
 int64_t ComputeGMPipeWorkspaceElements(const ProgramPtr& program, const FunctionPtr& root_func) {
   std::map<std::pair<int, int>, int> slot_size_by_pipe;
+  std::map<std::pair<int, int>, int> slot_num_by_pipe;
 
   std::unordered_set<std::string> visited_funcs;
   std::function<void(const std::vector<StmtPtr>&)> scan_stmts;
@@ -114,8 +126,15 @@ int64_t ComputeGMPipeWorkspaceElements(const ProgramPtr& program, const Function
         const int pipe_id = call->GetKwarg<int>("id", 0);
         const int dir_mask = call->GetKwarg<int>("dir_mask", 0);
         const int slot_size = call->GetKwarg<int>("slot_size", 0);
+        const int slot_num = call->GetKwarg<int>("slot_num", 0);
         if (dir_mask > 0 && slot_size > 0) {
           const auto key = std::make_pair(pipe_id, dir_mask);
+          if (slot_num > 0) {
+            auto [nit, ninserted] = slot_num_by_pipe.emplace(key, slot_num);
+            CHECK(ninserted || nit->second == slot_num)
+                << "initialize_pipe for frontend pipe id " << pipe_id << " and dir_mask " << dir_mask
+                << " uses inconsistent slot_num values: " << nit->second << " and " << slot_num;
+          }
           auto [it, inserted] = slot_size_by_pipe.emplace(key, slot_size);
           CHECK(inserted || it->second == slot_size)
               << "initialize_pipe for frontend pipe id " << pipe_id << " and dir_mask " << dir_mask
@@ -158,12 +177,17 @@ int64_t ComputeGMPipeWorkspaceElements(const ProgramPtr& program, const Function
   int64_t total_bytes = 0;
   for (const auto& [key, slot_size] : slot_size_by_pipe) {
     const int dir_mask = key.second;
-    const int slot_count = GetGMPipeSlotCount(dir_mask);
+    // Honour an explicit slot_num when the pipe carries one; otherwise fall back to the
+    // dir_mask-derived default that PTOAS would pick.
+    auto num_it = slot_num_by_pipe.find(key);
+    const int slot_count = num_it != slot_num_by_pipe.end() ? num_it->second : GetGMPipeSlotCount(dir_mask);
+    const int ring_count = GetGMPipeRingCount(dir_mask);
     CHECK(slot_count > 0) << "initialize_pipe has invalid dir_mask for GM slot buffer: " << dir_mask;
-    CHECK(total_bytes <= std::numeric_limits<int64_t>::max() -
-                             static_cast<int64_t>(slot_count) * static_cast<int64_t>(slot_size))
+    const int64_t pipe_bytes =
+        static_cast<int64_t>(ring_count) * static_cast<int64_t>(slot_count) * static_cast<int64_t>(slot_size);
+    CHECK(total_bytes <= std::numeric_limits<int64_t>::max() - pipe_bytes)
         << "GM slot buffer size overflow while sizing frontend pipe id " << key.first;
-    total_bytes += static_cast<int64_t>(slot_count) * static_cast<int64_t>(slot_size);
+    total_bytes += pipe_bytes;
   }
 
   if (total_bytes == 0) {

--- a/src/codegen/pto/pto_codegen.cpp
+++ b/src/codegen/pto/pto_codegen.cpp
@@ -32,6 +32,7 @@
 #include "pypto/backend/common/backend_config.h"
 #include "pypto/backend/common/backend_handler.h"
 #include "pypto/codegen/distributed/comm_layout.h"
+#include "pypto/codegen/gm_pipe_layout.h"
 #include "pypto/codegen/pto/pto_type_utils.h"
 #include "pypto/core/dtype.h"
 #include "pypto/core/logging.h"
@@ -44,7 +45,6 @@
 #include "pypto/ir/scalar_expr.h"
 #include "pypto/ir/stmt.h"
 #include "pypto/ir/tile_view_semantics.h"
-#include "pypto/ir/transforms/utils/core_affinity.h"
 #include "pypto/ir/transforms/utils/memref_utils.h"
 #include "pypto/ir/transforms/utils/op_predicates.h"
 #include "pypto/ir/transforms/utils/transform_utils.h"
@@ -334,17 +334,6 @@ std::vector<VarPtr> CollectTensorShapeDynVars(const FunctionPtr& func) {
   return dyn_vars;
 }
 
-int GetGMPipeSlotCount(int dir_mask) {
-  const int bidirectional = ir::core_affinity::kDirMaskC2V | ir::core_affinity::kDirMaskV2C;
-  if (dir_mask == bidirectional) {
-    return 4;
-  }
-  if (dir_mask == ir::core_affinity::kDirMaskC2V || dir_mask == ir::core_affinity::kDirMaskV2C) {
-    return 8;
-  }
-  return 0;
-}
-
 // In-place DPS ops that write into input 0 rather than a freshly-allocated
 // result tile:
 //   * scatter family (`set_output_reuses_input(0)`): a tscatter into a fresh
@@ -587,6 +576,7 @@ std::string PTOCodegen::Generate(const ProgramPtr& program, bool emit_tile_addr)
 
 void PTOCodegen::PrepareGMSlotBufferLayout(const ProgramPtr& program) {
   std::map<std::pair<int, int>, int> slot_size_by_pipe;
+  std::map<std::pair<int, int>, int> slot_count_by_pipe;
 
   std::function<void(const std::vector<StmtPtr>&)> scan_stmts;
   scan_stmts = [&](const std::vector<StmtPtr>& stmts) {
@@ -596,8 +586,14 @@ void PTOCodegen::PrepareGMSlotBufferLayout(const ProgramPtr& program) {
         const int pipe_id = call->GetKwarg<int>("id", 0);
         const int dir_mask = call->GetKwarg<int>("dir_mask", 0);
         const int slot_size = call->GetKwarg<int>("slot_size", 0);
+        const int slot_num = call->GetKwarg<int>("slot_num", 0);
         if (dir_mask > 0 && slot_size > 0) {
           const auto key = std::make_pair(pipe_id, dir_mask);
+          const int slot_count = gm_pipe::EffectiveSlotCount(dir_mask, slot_num);
+          auto [nit, ninserted] = slot_count_by_pipe.emplace(key, slot_count);
+          CHECK(ninserted || nit->second == slot_count)
+              << "initialize_pipe for frontend pipe id " << pipe_id << " and dir_mask " << dir_mask
+              << " uses inconsistent slot counts: " << nit->second << " and " << slot_count;
           auto [it, inserted] = slot_size_by_pipe.emplace(key, slot_size);
           CHECK(inserted || it->second == slot_size)
               << "initialize_pipe for frontend pipe id " << pipe_id << " and dir_mask " << dir_mask
@@ -624,15 +620,22 @@ void PTOCodegen::PrepareGMSlotBufferLayout(const ProgramPtr& program) {
     }
   }
 
+  // Each pipe's region must advance by its FULL footprint — both rings of a bidirectional pipe,
+  // and an explicit slot_num where given — or the next pipe's base lands inside this one. This
+  // has to stay in step with ComputeGMPipeWorkspaceElements, which sizes the whole workspace;
+  // both derive it from gm_pipe_layout.h.
   int64_t byte_offset = 0;
   for (const auto& [key, slot_size] : slot_size_by_pipe) {
     gm_slot_buffer_offsets_[key] = byte_offset;
     const int dir_mask = key.second;
-    const int slot_count = GetGMPipeSlotCount(dir_mask);
-    CHECK(slot_count > 0) << "initialize_pipe has invalid dir_mask for GM slot buffer: " << dir_mask;
-    CHECK(byte_offset <= std::numeric_limits<int64_t>::max() - static_cast<int64_t>(slot_count) * slot_size)
+    CHECK(gm_pipe::SlotCountForDirMask(dir_mask) > 0)
+        << "initialize_pipe has invalid dir_mask for GM slot buffer: " << dir_mask;
+    auto num_it = slot_count_by_pipe.find(key);
+    const int slot_count = num_it != slot_count_by_pipe.end() ? num_it->second : 0;
+    const int64_t pipe_bytes = gm_pipe::FootprintBytes(dir_mask, slot_count, slot_size);
+    CHECK(byte_offset <= std::numeric_limits<int64_t>::max() - pipe_bytes)
         << "GM slot buffer offset overflow while assigning frontend pipe id " << key.first;
-    byte_offset += static_cast<int64_t>(slot_count) * slot_size;
+    byte_offset += pipe_bytes;
   }
 }
 

--- a/tests/ut/codegen/test_orchestration_tensor_rw.py
+++ b/tests/ut/codegen/test_orchestration_tensor_rw.py
@@ -983,6 +983,86 @@ class TestTensorReadWriteOffsetCodegen:
             f"large=(1024*8+2048*8) / f32), got {shape_values}. Generated code:\n{code}"
         )
 
+    def test_gm_pipe_buffer_bidirectional_reserves_two_rings(self):
+        """A bidirectional pipe is TWO rings in GM, so its workspace is 2 * slot_num * slot_size.
+
+        The C2V ring lives at the workspace base and the V2C ring at
+        base + slot_num * slot_size (pto-isa `TPipe`, A2A3 GM layout). Sizing a
+        bidirectional pipe as a single ring leaves the whole V2C ring past the end
+        of the allocation.
+        """
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        @pl.program
+        class BidirGMPipeProgram:
+            @pl.function(type=pl.FunctionType.AIC)
+            def cube(self):
+                c2v_peer = pl.import_peer_buffer(name="bidir_c2v", peer_func="vector")
+                v2c_buf = pl.reserve_buffer(name="bidir_v2c", size=2048, base=pl.AUTO)
+                pl.aic_initialize_pipe(c2v_peer, v2c_buf, dir_mask=3, slot_size=512)
+
+            @pl.function(type=pl.FunctionType.AIV)
+            def vector(self):
+                c2v_buf = pl.reserve_buffer(name="bidir_c2v", size=2048, base=pl.AUTO)
+                v2c_peer = pl.import_peer_buffer(name="bidir_v2c", peer_func="cube")
+                pl.aiv_initialize_pipe(c2v_buf, v2c_peer, dir_mask=3, slot_size=512)
+
+            @pl.function(type=pl.FunctionType.Group)
+            def group(self):
+                self.cube()
+                self.vector()
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(self):
+                self.group()
+
+        transformed = PassManager.get_strategy(OptimizationStrategy.Default).run_passes(BidirGMPipeProgram)
+
+        code = _generate_orch_code(transformed)
+        shape_values = re.findall(r"gm_pipe_buffer_\d+_ci_shapes\[1\]\s*=\s*\{(\d+)\};", code)
+        # 2 rings * 4 slots * 512 B / sizeof(float) == 1024 elements.
+        assert shape_values == ["1024"], (
+            "Expected a bidirectional GM workspace of 2 * 4 * 512 B, got "
+            f"{shape_values} elements. Generated code:\n{code}"
+        )
+
+    def test_gm_pipe_buffer_honours_explicit_slot_num(self):
+        """Workspace sizing follows the slot_num the pipe was actually initialized with."""
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        @pl.program
+        class DeepGMPipeProgram:
+            @pl.function(type=pl.FunctionType.AIC)
+            def cube(self):
+                buf = pl.reserve_buffer(name="deep_v2c", size=8192, base=pl.AUTO)
+                pl.aic_initialize_pipe(pl.const(0, pl.INT32), buf, dir_mask=2, slot_size=512, slot_num=16)
+
+            @pl.function(type=pl.FunctionType.AIV)
+            def vector(self):
+                peer = pl.import_peer_buffer(name="deep_v2c", peer_func="cube")
+                pl.aiv_initialize_pipe(pl.const(0, pl.INT32), peer, dir_mask=2, slot_size=512, slot_num=16)
+
+            @pl.function(type=pl.FunctionType.Group)
+            def group(self):
+                self.cube()
+                self.vector()
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(self):
+                self.group()
+
+        transformed = PassManager.get_strategy(OptimizationStrategy.Default).run_passes(DeepGMPipeProgram)
+
+        code = _generate_orch_code(transformed)
+        shape_values = re.findall(r"gm_pipe_buffer_\d+_ci_shapes\[1\]\s*=\s*\{(\d+)\};", code)
+        # 1 ring * 16 slots * 512 B / sizeof(float) == 2048 elements; the dir_mask
+        # default of 8 slots would under-allocate by half.
+        assert shape_values == ["2048"], (
+            f"Expected slot_num=16 to be honoured when sizing, got {shape_values}. Generated code:\n{code}"
+        )
+
     def test_submit_dispatched_pipe_group_sizes_workspace_and_resolves_callees(self):
         """Submitted pipe kernels with different signatures share one Group ABI (#2097)."""
         backend.reset_for_testing()
@@ -1050,7 +1130,8 @@ class TestTensorReadWriteOffsetCodegen:
         code = result.code
 
         shape_values = re.findall(r"gm_pipe_buffer_\d+_ci_shapes\[1\]\s*=\s*\{(\d+)\};", code)
-        assert shape_values == ["512"], code
+        # dir_mask=3 is two rings: 2 * 4 slots * 512 B / sizeof(float) == 1024 elements.
+        assert shape_values == ["1024"], code
         assert "rt_submit_task" in code, code
         assert result.func_name_to_signature["cube_side"] == result.func_name_to_signature["vec_side"]
         expected_mixed = (

--- a/tests/ut/codegen/test_pto_codegen.py
+++ b/tests/ut/codegen/test_pto_codegen.py
@@ -3017,5 +3017,61 @@ def test_pto_codegen_tensor_view_shape_and_layout():
     assert any(f"pto.partition_view {view_ssa}" in line for line in lines)
 
 
+def test_gm_slot_buffer_regions_do_not_overlap_across_pipes():
+    """A second frontend pipe starts past the first pipe's FULL footprint.
+
+    PrepareGMSlotBufferLayout must advance by rings * slots * slot_size, the same rule
+    ComputeGMPipeWorkspaceElements uses to size the workspace. Pipe 0 here is bidirectional
+    (two rings) *and* carries an explicit slot_num, so a layout that counted one ring, or
+    that ignored slot_num, hands pipe 1 an addptr pointing inside pipe 0's region.
+    """
+    backend.reset_for_testing()
+    backend.set_backend_type(BackendType.Ascend910B)
+
+    @pl.program
+    class TwoPipeProgram:
+        @pl.function(type=pl.FunctionType.AIC)
+        def cube(
+            self,
+            q: pl.Tensor[[16, 16], pl.FP32],
+            __gm_pipe_buffer: pl.Out[pl.Tensor[[6144], pl.FP32]],
+        ):
+            c2v_peer_0 = pl.import_peer_buffer(name="p0_c2v", peer_func="vector")
+            v2c_buf_0 = pl.reserve_buffer(name="p0_v2c", size=8192, base=0x1000)
+            pl.aic_initialize_pipe(c2v_peer_0, v2c_buf_0, dir_mask=3, slot_size=1024, slot_num=8, id=0)
+            c2v_peer_1 = pl.import_peer_buffer(name="p1_c2v", peer_func="vector")
+            pl.aic_initialize_pipe(c2v_peer_1, pl.const(0, pl.INT32), dir_mask=1, slot_size=1024, id=1)
+            tile = pl.load(q, [0, 0], [16, 16], target_memory=pl.MemorySpace.Mat)
+            pl.tpush_to_aiv(tile, split=0, id=0)
+            pl.tpush_to_aiv(tile, split=0, id=1)
+
+        @pl.function(type=pl.FunctionType.AIV)
+        def vector(
+            self,
+            out: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+            __gm_pipe_buffer: pl.Out[pl.Tensor[[6144], pl.FP32]],
+        ) -> pl.Tensor[[16, 16], pl.FP32]:
+            c2v_buf_0 = pl.reserve_buffer(name="p0_c2v", size=8192, base=0x2000)
+            v2c_peer_0 = pl.import_peer_buffer(name="p0_v2c", peer_func="cube")
+            pl.aiv_initialize_pipe(c2v_buf_0, v2c_peer_0, dir_mask=3, slot_size=1024, slot_num=8, id=0)
+            c2v_buf_1 = pl.reserve_buffer(name="p1_c2v", size=8192, base=0x6000)
+            pl.aiv_initialize_pipe(c2v_buf_1, pl.const(0, pl.INT32), dir_mask=1, slot_size=1024, id=1)
+            t0 = pl.tpop_from_aic(shape=[16, 16], dtype=pl.FP32, split=0, id=0)
+            pl.tfree_to_aic(t0, split=0, id=0)
+            t1 = pl.tpop_from_aic(shape=[16, 16], dtype=pl.FP32, split=0, id=1)
+            pl.tfree_to_aic(t1, split=0, id=1)
+            return pl.store(t1, [0, 0], out)
+
+    mlir_code = _generate_mlir(TwoPipeProgram)
+    addptrs = [line for line in _get_mlir_lines(mlir_code) if "pto.addptr" in line]
+
+    # Pipe 0 sits at offset 0 (no addptr); pipe 1 starts after it, on both cores.
+    assert len(addptrs) == 2, f"Expected one GM pipe region addptr per core. Generated code:\n{mlir_code}"
+    # 2 rings * 8 slots * 1024 B = 16384 B = 4096 f32 elements. One ring would put pipe 1 at
+    # 2048, and ignoring slot_num as well would put it at 1024 — both inside pipe 0's region.
+    for line in addptrs:
+        assert "%c4096_index" in line, f"Pipe 1 must start past pipe 0's full two-ring footprint, got: {line}"
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## What

`Fixes #2269`. `ComputeGMPipeWorkspaceElements` sized the injected `__gm_pipe_buffer` as `slot_count * slot_size` — one ring's worth — and re-derived `slot_count` from `dir_mask`. Two changes:

1. Multiply by a new `GetGMPipeRingCount(dir_mask)` — 2 for bidirectional, 1 otherwise — so a bidirectional pipe gets `2 * slot_num * slot_size`, matching the A2A3 GM layout specified in pto-isa's `docs/HL_ptoisa_newfeature20260306_TPUSH_TPOP.md:169` and drawn at `:288` (C2V ring at offset 0, V2C ring at `slot_num * slot_size`).
2. Honour the `slot_num` kwarg on `initialize_pipe` when present, falling back to the `dir_mask` default when absent. Mismatched `slot_num` values for one pipe id are a `CHECK`, mirroring the existing `slot_size` consistency check.

| File | Change |
|---|---|
| `src/codegen/orchestration/orchestration_analysis.cpp` | Ring count × slot count × slot size; honour explicit `slot_num` |
| `tests/ut/codegen/test_orchestration_tensor_rw.py` | Two new tests; one existing expectation updated |

## Test changes

`test_submit_dispatched_pipe_group_sizes_workspace_and_resolves_callees` asserted `["512"]` elements for a `dir_mask=3, slot_size=512` pipe — one ring, i.e. the bug written down as an expectation. It becomes `["1024"]`. Two new tests pin the rule:

- `test_gm_pipe_buffer_bidirectional_reserves_two_rings` — `dir_mask=3, slot_size=512` → `2 * 4 * 512 B` = 1024 floats. Fails on `main` with 512.
- `test_gm_pipe_buffer_honours_explicit_slot_num` — `dir_mask=2, slot_size=512, slot_num=16` → `16 * 512 B` = 2048 floats. Fails on `main` with 1024, the `dir_mask` default of 8 slots.

## Behaviour

The GM workspace for bidirectional pipes doubles (4 KiB → 8 KiB per pipe at the default depth) and follows `slot_num` where given. No IR-structural change: the injected `__gm_pipe_buffer` parameter, its placement and the pass pipeline are untouched — only the element count on the orchestration-side `tensor.create`.

## Why this is worth landing on its own, and first

Today this is a latent sizing bug: the under-allocation is consistent with a matching pto-isa defect where the device never applies the per-direction ring offset either, so both rings really do live in the first half and the short allocation "fits". Fixing this side alone changes nothing observable — measured, the resulting corruption is bit-identical.

But the device-side fix (hw-native-sys/pto-isa#227, for hw-native-sys/pto-isa#226) puts the V2C ring at `base + slot_num * slot_size`, which with the current sizing is **past the end of the allocation**. So this must ship first. It is safe to merge ahead of the device change, and it is wrong on its own terms regardless — against a spec that predates both bugs.

Together the two fix a silent cross-core corruption on A2A3 hardware. Full analysis, minimal repro and the prior history (including hw-native-sys/pto-isa#195, which reported the device half in July and was withdrawn) are in hw-native-sys/pto-isa#226.

## A related inconsistency, deliberately left out

`BuildAutomaticPipeSetup` (`src/ir/transforms/utils/cross_core_pipe.cpp:348,352`) passes the raw `slot_num_override` to `CreateInitializePipe` while sizing the reserved buffer from `effective_slot_num`, so in the default case the emitted `initialize_pipe` carries no `slot_num` attribute even though a concrete depth was used. That is harmless — every consumer re-derives the same default from `dir_mask` — and orthogonal to this fix, which reads `slot_num` only when a pipe actually carries one. Passing `effective_slot_num` instead makes the attribute always explicit, but it adds a kwarg to every auto-generated pipe and so changes the expected IR in 12 structural-equality tests (`test_expand_mixed_kernel_a2a3.py`, `_a5.py`, `_split_aiv.py`). Happy to send that as a follow-up if you want the attribute made explicit.

## Validation

`tests/ut/codegen` + `tests/ut/ir/transforms`: **3195 passed**.

On hardware (Atlas A2/A3, fp32), with the pto-isa half applied, at the stock ring depth and with no DSL overrides: a GLA/ZeCO sequence-parallel forward that failed 5/12 configurations at C=16 and 6/12 at C=32 now passes **24/24** over C ∈ {16,32} × P ∈ {1,2,4} × N ∈ {2,4,8,16}, max abs error ≤ 3.1e-5; and a standalone cube↔vector loop repro goes from 12/21 corrupted dispatches to **21/21 clean**.
