### PR TITLE
fix(test): Isolate ST logging and distributed execution

### DIFF
--- a/include/pypto/core/logging.h
+++ b/include/pypto/core/logging.h
@@ -36,6 +36,7 @@
 #include <iostream>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <sstream>
 #include <string>
 #include <unordered_map>
@@ -261,7 +262,7 @@ class LoggerManager {
   template <typename T>
   void Log(LogLevel l, const T& t, const T& t_rich) {
     std::scoped_lock lock(log_mtx);
-    if (l >= level) {
+    if (l >= GetLevel()) {
       if (std_enabled) {
         std_logger.Log(t_rich);
       }
@@ -281,6 +282,21 @@ class LoggerManager {
    * @param l New log level
    */
   static void ResetLevel(LogLevel l) { GetManager().level = l; }
+
+  /**
+   * @brief Get the effective log level for the calling thread
+   * @return Thread override when set, otherwise the process-global level
+   */
+  static LogLevel GetLevel() { return ThreadLevel().value_or(GetManager().level); }
+
+  /**
+   * @brief Override the log level for the calling thread
+   * @param l Thread-local log level threshold
+   */
+  static void SetThreadLevel(LogLevel l) { ThreadLevel() = l; }
+
+  /** @brief Remove the calling thread's log level override */
+  static void ClearThreadLevel() { ThreadLevel().reset(); }
 
   /**
    * @brief Enable or disable standard output logging
@@ -346,6 +362,11 @@ class LoggerManager {
   }
 
  private:
+  static std::optional<LogLevel>& ThreadLevel() {
+    static thread_local std::optional<LogLevel> level;
+    return level;
+  }
+
   /**
    * @brief Resolve the default log level for this process.
    *
@@ -416,7 +437,7 @@ class Logger {
    * @param line Line number (currently unused but available for future use)
    */
   Logger(LogLevel level_in, [[maybe_unused]] int line) : level(level_in) {
-    enable_log = LoggerManager::GetManager().level <= level;
+    enable_log = LoggerManager::GetLevel() <= level;
     if (enable_log) {
       static const char* MSG = "DIWEFVN";
       auto now = std::chrono::system_clock::now();
@@ -518,18 +539,18 @@ class Logger {
 #define LOG_EVENT LOG_LEVEL(pypto::LogLevel::EVENT)
 
 // Printf-style logging macros
-#define LOG_F(lvl, args...)                                                 \
-  do {                                                                      \
-    if (pypto::LoggerManager::GetManager().level <= pypto::LogLevel::lvl) { \
-      constexpr int default_buf_size = 1024;                                \
-      std::string buf(default_buf_size, '\0');                              \
-      int msg_length = std::snprintf(buf.data(), buf.size(), ##args) + 1;   \
-      if (msg_length > default_buf_size) {                                  \
-        buf.resize(msg_length, '\0');                                       \
-        std::snprintf(buf.data(), buf.size(), ##args);                      \
-      }                                                                     \
-      LOG_##lvl(buf.data());                                                \
-    }                                                                       \
+#define LOG_F(lvl, args...)                                               \
+  do {                                                                    \
+    if (pypto::LoggerManager::GetLevel() <= pypto::LogLevel::lvl) {       \
+      constexpr int default_buf_size = 1024;                              \
+      std::string buf(default_buf_size, '\0');                            \
+      int msg_length = std::snprintf(buf.data(), buf.size(), ##args) + 1; \
+      if (msg_length > default_buf_size) {                                \
+        buf.resize(msg_length, '\0');                                     \
+        std::snprintf(buf.data(), buf.size(), ##args);                    \
+      }                                                                   \
+      LOG_##lvl(buf.data());                                              \
+    }                                                                     \
   } while (false)
 
 #define LOG_DEBUG_F(fmt, args...) LOG_F(DEBUG, fmt, ##args)

--- a/python/bindings/modules/logging.cpp
+++ b/python/bindings/modules/logging.cpp
@@ -98,6 +98,9 @@ void BindLogging(nb::module_& m) {
   // Bind LoggerManager functions
   m.def("set_log_level", &LoggerManager::ResetLevel, nb::arg("level"),
         "Set the global log level threshold. Only messages at or above this level will be logged.");
+  m.def(
+      "_get_log_level", []() { return LoggerManager::GetManager().level; },
+      "Return the global log level threshold for internal state restoration.");
   m.def("log_debug", &log_debug, nb::arg("message"), "Log a message at the DEBUG level");
   m.def("log_info", &log_info, nb::arg("message"), "Log a message at the INFO level");
   m.def("log_warn", &log_warn, nb::arg("message"), "Log a message at the WARN level");

--- a/python/bindings/modules/logging.cpp
+++ b/python/bindings/modules/logging.cpp
@@ -98,9 +98,10 @@ void BindLogging(nb::module_& m) {
   // Bind LoggerManager functions
   m.def("set_log_level", &LoggerManager::ResetLevel, nb::arg("level"),
         "Set the global log level threshold. Only messages at or above this level will be logged.");
-  m.def(
-      "_get_log_level", []() { return LoggerManager::GetManager().level; },
-      "Return the global log level threshold for internal state restoration.");
+  m.def("_set_thread_log_level", &LoggerManager::SetThreadLevel, nb::arg("level"),
+        "Override the log level threshold for the calling thread.");
+  m.def("_clear_thread_log_level", &LoggerManager::ClearThreadLevel,
+        "Remove the calling thread's log level override.");
   m.def("log_debug", &log_debug, nb::arg("message"), "Log a message at the DEBUG level");
   m.def("log_info", &log_info, nb::arg("message"), "Log a message at the INFO level");
   m.def("log_warn", &log_warn, nb::arg("message"), "Log a message at the WARN level");

--- a/python/pypto/pypto_core/__init__.pyi
+++ b/python/pypto/pypto_core/__init__.pyi
@@ -18,6 +18,7 @@ from .logging import (
     Error,
     InternalError,
     LogLevel,
+    _get_log_level,
     check,
     internal_check,
     internal_check_span,
@@ -165,6 +166,7 @@ __all__ = [
     "InternalError",
     # Logging framework
     "LogLevel",
+    "_get_log_level",
     "set_log_level",
     "log_debug",
     "log_info",

--- a/python/pypto/pypto_core/__init__.pyi
+++ b/python/pypto/pypto_core/__init__.pyi
@@ -18,7 +18,6 @@ from .logging import (
     Error,
     InternalError,
     LogLevel,
-    _get_log_level,
     check,
     internal_check,
     internal_check_span,
@@ -29,6 +28,12 @@ from .logging import (
     log_info,
     log_warn,
     set_log_level,
+)
+from .logging import (
+    _clear_thread_log_level as _clear_thread_log_level,
+)
+from .logging import (
+    _set_thread_log_level as _set_thread_log_level,
 )
 
 class DataType:
@@ -166,7 +171,6 @@ __all__ = [
     "InternalError",
     # Logging framework
     "LogLevel",
-    "_get_log_level",
     "set_log_level",
     "log_debug",
     "log_info",

--- a/python/pypto/pypto_core/logging.pyi
+++ b/python/pypto/pypto_core/logging.pyi
@@ -40,8 +40,11 @@ class LogLevel(IntEnum):
 def set_log_level(level: LogLevel) -> None:
     """Set the global log level threshold. Only messages at or above this level will be logged."""
 
-def _get_log_level() -> LogLevel:
-    """Return the global log level threshold for internal state restoration."""
+def _set_thread_log_level(level: LogLevel) -> None:
+    """Override the log level threshold for the calling thread."""
+
+def _clear_thread_log_level() -> None:
+    """Remove the calling thread's log level override."""
 
 def log_debug(message: str) -> None:
     """Log a message at the DEBUG level"""

--- a/python/pypto/pypto_core/logging.pyi
+++ b/python/pypto/pypto_core/logging.pyi
@@ -40,6 +40,9 @@ class LogLevel(IntEnum):
 def set_log_level(level: LogLevel) -> None:
     """Set the global log level threshold. Only messages at or above this level will be logged."""
 
+def _get_log_level() -> LogLevel:
+    """Return the global log level threshold for internal state restoration."""
+
 def log_debug(message: str) -> None:
     """Log a message at the DEBUG level"""
 

--- a/tests/st/conftest.py
+++ b/tests/st/conftest.py
@@ -52,6 +52,7 @@ from harness.core.test_runner import (  # noqa: E402
     start_pipeline,
 )
 from pypto import LogLevel, set_log_level  # noqa: E402
+from pypto.pypto_core import _get_log_level  # noqa: E402
 from pypto.runtime.runner import RunConfig  # noqa: E402
 
 # Temp directories created for pre-compilation (when --save-kernels is not set).
@@ -480,7 +481,7 @@ def tensor_shape(request):
 
 # Skip markers
 def pytest_configure(config):
-    """Register custom markers and apply early global settings."""
+    """Register custom markers and apply early runtime settings."""
     config.addinivalue_line(
         "markers",
         "platforms(*ids): restrict the test to the given platform ids "
@@ -498,14 +499,6 @@ def pytest_configure(config):
         "ci.yml change.",
     )
 
-    # Set C++ log level as early as possible so it applies to collection too.
-    # Forked child processes inherit this setting via os.fork().
-    try:
-        level_name: str = config.getoption("--pypto-log-level")
-        set_log_level(LogLevel[level_name])
-    except (ValueError, KeyError):
-        pass  # option not yet registered (e.g. during --co --help)
-
     # Set PyPTO runtime log level (orthogonal to PyPTO C++ logger above).
     try:
         runtime_level = config.getoption("--runtime-log-level")
@@ -516,6 +509,30 @@ def pytest_configure(config):
             from pypto.runtime import configure_log  # noqa: PLC0415
 
             configure_log(runtime_level)  # ValueError propagates: invalid CLI value must fail fast
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_protocol(item, nextitem):
+    """Apply the requested C++ log level only while an ST item is running.
+
+    ``tests/st/conftest.py`` can be loaded in a mixed ST/UT session.  Changing
+    the process-global C++ logger in ``pytest_configure`` therefore suppressed
+    diagnostics expected by later unit tests.  Surround the complete pytest
+    protocol (fixture setup, test call, and teardown) so forked runtime workers
+    still inherit the requested level, then restore the exact previous value.
+    """
+    del nextitem
+    if not item.path.is_relative_to(_ST_DIR):
+        yield
+        return
+
+    previous_level = _get_log_level()
+    try:
+        level_name: str = item.config.getoption("--pypto-log-level")
+        set_log_level(LogLevel[level_name])
+        yield
+    finally:
+        set_log_level(previous_level)
 
 
 def pytest_itemcollected(item):

--- a/tests/st/conftest.py
+++ b/tests/st/conftest.py
@@ -51,8 +51,8 @@ from harness.core.test_runner import (  # noqa: E402
     shutdown_pipeline,
     start_pipeline,
 )
-from pypto import LogLevel, set_log_level  # noqa: E402
-from pypto.pypto_core import _get_log_level  # noqa: E402
+from pypto import LogLevel  # noqa: E402
+from pypto.pypto_core import _clear_thread_log_level, _set_thread_log_level  # noqa: E402
 from pypto.runtime.runner import RunConfig  # noqa: E402
 
 # Temp directories created for pre-compilation (when --save-kernels is not set).
@@ -499,7 +499,7 @@ def pytest_configure(config):
         "ci.yml change.",
     )
 
-    # Set PyPTO runtime log level (orthogonal to PyPTO C++ logger above).
+    # Set the PyPTO runtime log level independently of the per-ST-item C++ logger.
     try:
         runtime_level = config.getoption("--runtime-log-level")
     except KeyError:
@@ -519,20 +519,19 @@ def pytest_runtest_protocol(item, nextitem):
     the process-global C++ logger in ``pytest_configure`` therefore suppressed
     diagnostics expected by later unit tests.  Surround the complete pytest
     protocol (fixture setup, test call, and teardown) so forked runtime workers
-    still inherit the requested level, then restore the exact previous value.
+    still inherit the requested level, then clear the thread-local override.
     """
     del nextitem
     if not item.path.is_relative_to(_ST_DIR):
         yield
         return
 
-    previous_level = _get_log_level()
     try:
         level_name: str = item.config.getoption("--pypto-log-level")
-        set_log_level(LogLevel[level_name])
+        _set_thread_log_level(LogLevel[level_name])
         yield
     finally:
-        set_log_level(previous_level)
+        _clear_thread_log_level()
 
 
 def pytest_itemcollected(item):
@@ -861,26 +860,32 @@ def pytest_collection_finish(session: pytest.Session) -> None:
         f"\n[PyPTO] Pipeline: {len(test_cases)} test case(s); "
         f"compile_workers={max_workers}, execute_mode={execute_mode}, {device_info}"
     )
-    start_pipeline(
-        test_cases=test_cases,
-        cache_dir=cache_dir,
-        session_platform=session_platform,
-        dump_passes=dump_passes,
-        codegen_only=codegen_only,
-        compile_workers=max_workers,
-        device_pool=device_pool,
-        enable_l2_swimlane=enable_l2_swimlane,
-        enable_dump_args=enable_dump_args,
-        enable_pmu=enable_pmu,
-        enable_dep_gen=enable_dep_gen,
-        enable_scope_stats=enable_scope_stats,
-        analyze_auto_scopes_for_deps=analyze_auto_scopes_for_deps,
-        execute_mode=execute_mode,
-        task_max_time=task_max_time,
-        task_queue_timeout=task_queue_timeout,
-        task_submit_device=task_submit_device,
-        execute_batch_size=execute_batch_size,
-    )
+    pypto_log_level = LogLevel[session.config.getoption("--pypto-log-level")]
+    _set_thread_log_level(pypto_log_level)
+    try:
+        start_pipeline(
+            test_cases=test_cases,
+            cache_dir=cache_dir,
+            session_platform=session_platform,
+            dump_passes=dump_passes,
+            codegen_only=codegen_only,
+            pypto_log_level=pypto_log_level,
+            compile_workers=max_workers,
+            device_pool=device_pool,
+            enable_l2_swimlane=enable_l2_swimlane,
+            enable_dump_args=enable_dump_args,
+            enable_pmu=enable_pmu,
+            enable_dep_gen=enable_dep_gen,
+            enable_scope_stats=enable_scope_stats,
+            analyze_auto_scopes_for_deps=analyze_auto_scopes_for_deps,
+            execute_mode=execute_mode,
+            task_max_time=task_max_time,
+            task_queue_timeout=task_queue_timeout,
+            task_submit_device=task_submit_device,
+            execute_batch_size=execute_batch_size,
+        )
+    finally:
+        _clear_thread_log_level()
     print("[PyPTO] Pipeline scheduled — pytest item loop starting\n")
 
 

--- a/tests/st/distributed/conftest.py
+++ b/tests/st/distributed/conftest.py
@@ -1,0 +1,32 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Shared pytest behavior for distributed system tests."""
+
+from typing import Any
+
+import pytest
+from pypto.ir.distributed_compiled_program import DistributedCompiledProgram
+from pypto.runtime.distributed_runner import DistributedWorker
+
+
+@pytest.fixture(autouse=True)
+def disable_runtime_execution_in_codegen_only(request, monkeypatch) -> None:
+    """Let distributed tests compile, then skip at every public execution edge."""
+    if not request.config.getoption("--codegen-only"):
+        return
+
+    def skip_execution(*args: Any, **kwargs: Any) -> None:
+        del args, kwargs
+        pytest.skip("--codegen-only disables distributed runtime execution")
+
+    monkeypatch.setattr("pypto.runtime.runner.execute_compiled", skip_execution)
+    monkeypatch.setattr("pypto.runtime.distributed_runner.execute_distributed", skip_execution)
+    monkeypatch.setattr(DistributedCompiledProgram, "prepare", skip_execution)
+    monkeypatch.setattr(DistributedWorker, "__init__", skip_execution)

--- a/tests/st/distributed/conftest.py
+++ b/tests/st/distributed/conftest.py
@@ -12,8 +12,6 @@
 from typing import Any
 
 import pytest
-from pypto.ir.distributed_compiled_program import DistributedCompiledProgram
-from pypto.runtime.distributed_runner import DistributedWorker
 
 
 @pytest.fixture(autouse=True)
@@ -21,6 +19,9 @@ def disable_runtime_execution_in_codegen_only(request, monkeypatch) -> None:
     """Let distributed tests compile, then skip at every public execution edge."""
     if not request.config.getoption("--codegen-only"):
         return
+
+    from pypto.ir.distributed_compiled_program import DistributedCompiledProgram  # noqa: PLC0415
+    from pypto.runtime.distributed_runner import DistributedWorker  # noqa: PLC0415
 
     def skip_execution(*args: Any, **kwargs: Any) -> None:
         del args, kwargs

--- a/tests/st/distributed/test_l3_manual.py
+++ b/tests/st/distributed/test_l3_manual.py
@@ -80,21 +80,11 @@ class TestL3Manual:
     """Drive an L2 PyPTO build from a hand-written L3 using simpler directly."""
 
     def test_manual_l3(self, test_config, device_ids, tmp_path):
-        # Conftest's session fixture inserts ``simpler`` into ``sys.path``;
-        # importing inside the test guarantees the path is in place. Skipped
-        # automatically under --codegen-only since simpler isn't required there.
+        # Conftest's session fixture inserts ``simpler`` into ``sys.path``.
+        # Runtime imports stay below the compile-only exit because Simpler is
+        # neither configured nor required under --codegen-only.
         if not device_ids:
             pytest.skip("manual L3 test needs at least one device")
-
-        from simpler.task_interface import (  # noqa: PLC0415  # pyright: ignore[reportMissingImports]
-            CallConfig,
-            TaskArgs,
-            TensorArgType,
-        )
-        from simpler.worker import Worker  # noqa: PLC0415  # pyright: ignore[reportMissingImports]
-        from simpler_setup.torch_interop import (  # noqa: PLC0415  # pyright: ignore[reportMissingImports]
-            make_tensor_arg,
-        )
 
         # 1) Compile L2 only. The result is a CompiledProgram; ``output_dir``
         # itself is the chip's work dir (contains kernel_config.py, kernels/,
@@ -104,6 +94,18 @@ class TestL3Manual:
             L2OnlyAddProgram,
             output_dir=str(out_dir),
             platform=test_config.platform,
+        )
+        if test_config.codegen_only:
+            pytest.skip("--codegen-only disables distributed runtime execution")
+
+        from simpler.task_interface import (  # noqa: PLC0415  # pyright: ignore[reportMissingImports]
+            CallConfig,
+            TaskArgs,
+            TensorArgType,
+        )
+        from simpler.worker import Worker  # noqa: PLC0415  # pyright: ignore[reportMissingImports]
+        from simpler_setup.torch_interop import (  # noqa: PLC0415  # pyright: ignore[reportMissingImports]
+            make_tensor_arg,
         )
 
         # 2) Assemble the ChipCallable ourselves — the same call

--- a/tests/st/harness/core/test_runner.py
+++ b/tests/st/harness/core/test_runner.py
@@ -38,6 +38,7 @@ from typing import Any
 
 import pytest
 from pypto.backend import BackendType, reset_for_testing, set_backend_type
+from pypto.pypto_core import LogLevel, _set_thread_log_level
 from pypto.runtime import compile_program
 from pypto.runtime.golden_writer import (
     _data_dir_has_files,
@@ -949,6 +950,7 @@ def start_pipeline(  # noqa: PLR0913
     session_platform: str,
     dump_passes: bool,
     codegen_only: bool,
+    pypto_log_level: LogLevel,
     compile_workers: int,
     device_pool: "queue.Queue[int]",
     analyze_auto_scopes_for_deps: bool = False,
@@ -1027,7 +1029,12 @@ def start_pipeline(  # noqa: PLR0913
         n_exec = min(n_batches, _MAX_TASK_SUBMIT_INFLIGHT)
     else:
         n_exec = max(1, device_pool.qsize())
-    _execute_pool = ThreadPoolExecutor(max_workers=n_exec, thread_name_prefix="pypto-exec")
+    _execute_pool = ThreadPoolExecutor(
+        max_workers=n_exec,
+        thread_name_prefix="pypto-exec",
+        initializer=_set_thread_log_level,
+        initargs=(pypto_log_level,),
+    )
 
     groups: dict[BackendType, list[PTOTestCase]] = {}
     for tc in test_cases:
@@ -1037,7 +1044,12 @@ def start_pipeline(  # noqa: PLR0913
     for i, (backend_type, group) in enumerate(group_items):
         is_last = i == len(group_items) - 1
         set_backend_type(backend_type)
-        compile_pool = ThreadPoolExecutor(max_workers=compile_workers, thread_name_prefix="pypto-compile")
+        compile_pool = ThreadPoolExecutor(
+            max_workers=compile_workers,
+            thread_name_prefix="pypto-compile",
+            initializer=_set_thread_log_level,
+            initargs=(pypto_log_level,),
+        )
         _compile_pools.append(compile_pool)
         group_futs: list[Future] = []
         for tc in group:

--- a/tests/ut/core/test_logging.py
+++ b/tests/ut/core/test_logging.py
@@ -23,11 +23,13 @@ while capsys only captures Python's sys.stdout/sys.stderr.
 """
 
 import re
+import threading
 import time
 
 import pypto
 import pytest
 from pypto import LogLevel, set_log_level
+from pypto.pypto_core import _clear_thread_log_level, _set_thread_log_level
 
 
 class TestLogLevel:
@@ -229,6 +231,32 @@ class TestLogLevelFiltering:
         assert "Error" not in captured.err
         assert "Fatal" not in captured.err
         assert "Event" not in captured.err
+
+
+class TestThreadLogLevel:
+    """Test internal thread-scoped log-level overrides."""
+
+    def test_override_is_isolated_to_calling_thread(self, capfd):
+        """A worker override must not change the process-global threshold."""
+        set_log_level(LogLevel.INFO)
+
+        def log_from_worker() -> None:
+            _set_thread_log_level(LogLevel.ERROR)
+            try:
+                pypto.log_info("worker info filtered")
+                pypto.log_error("worker error visible")
+            finally:
+                _clear_thread_log_level()
+
+        worker = threading.Thread(target=log_from_worker)
+        worker.start()
+        worker.join()
+        pypto.log_info("main info visible")
+
+        captured = capfd.readouterr()
+        assert "worker info filtered" not in captured.err
+        assert "worker error visible" in captured.err
+        assert "main info visible" in captured.err
 
 
 class TestLoggingScenarios:


### PR DESCRIPTION
## Summary
- scope the PyPTO C++ log level to each ST item and restore the previous process-global level afterward
- make distributed --codegen-only runs compile artifacts but skip one-shot dispatch, prepared workers, and manual Simpler execution
- keep compile-time validation active by intercepting only runtime execution boundaries

## Testing
- cmake --build build --parallel 8
- full unit suite: 8720 passed, 2 skipped
- mixed ST and MemoryReuse regression: 2 passed
- distributed --codegen-only suite: 2 passed, 138 skipped
- Ruff, Pyright, clang-format, and git diff checks
