### PR TITLE
CI: point the pypto-lib model job at its flattened directories

### DIFF
--- a/.claude/skills/incore-profiling/incore_profile.py
+++ b/.claude/skills/incore-profiling/incore_profile.py
@@ -15,7 +15,7 @@ Typical usage:
     --build-dir build_output/Qwen3Decode_20260514_195003 --target a2a3
 
   python .claude/skills/incore-profiling/incore_profile.py \
-    --case models/qwen3/14b/qwen3_14b_decode.py --target a2a3 \
+    --case models/qwen3_14b/decode_fwd.py --target a2a3 \
     --task-submit --task-device auto \
     --run-env PTO2_RING_TASK_WINDOW=131072 \
     --run-env PTO2_RING_DEP_POOL=131072 \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -940,7 +940,7 @@ jobs:
         run: |
           source activate.sh
           task-submit --device "$DEVICE_ID" --timeout 3600 --max-time 1800 \
-            --run "source $GITHUB_WORKSPACE/lib-checkout/activate.sh && cd $GITHUB_WORKSPACE/pypto-lib && python models/qwen3/14b/decode_fwd.py -p a2a3 -d \$TASK_DEVICE"
+            --run "source $GITHUB_WORKSPACE/lib-checkout/activate.sh && cd $GITHUB_WORKSPACE/pypto-lib && python models/qwen3_14b/decode_fwd.py -p a2a3 -d \$TASK_DEVICE"
 
       # Prefill exercises the dynamic-shape host path that decode does not: its
       # token axis is a `pl.dynamic()` symbol, the per-layer temp is sized from
@@ -953,7 +953,7 @@ jobs:
         run: |
           source activate.sh
           task-submit --device "$DEVICE_ID" --timeout 3600 --max-time 1800 \
-            --run "source $GITHUB_WORKSPACE/lib-checkout/activate.sh && cd $GITHUB_WORKSPACE/pypto-lib && python models/qwen3/14b/prefill_fwd.py -p a2a3 -d \$TASK_DEVICE"
+            --run "source $GITHUB_WORKSPACE/lib-checkout/activate.sh && cd $GITHUB_WORKSPACE/pypto-lib && python models/qwen3_14b/prefill_fwd.py -p a2a3 -d \$TASK_DEVICE"
 
       # NOTE: Qwen3-14B decode performance monitoring (L2-swimlane makespan +
       # perf_guard) lives in the daily_ci.yml `qwen3-perf` job, not here. Per-PR
@@ -966,7 +966,7 @@ jobs:
         run: |
           source activate.sh
           task-submit --device "$DEVICE_ID" --timeout 3600 --max-time 1800 \
-            --run "source $GITHUB_WORKSPACE/lib-checkout/activate.sh && cd $GITHUB_WORKSPACE/pypto-lib && python models/deepseek/v4-flash/decode_attention_swa.py -p a2a3 -d \$TASK_DEVICE"
+            --run "source $GITHUB_WORKSPACE/lib-checkout/activate.sh && cd $GITHUB_WORKSPACE/pypto-lib && python models/deepseek_v4_flash_mtp/decode_attention_swa.py -p a2a3 -d \$TASK_DEVICE"
 
       - name: Run pypto-lib DeepSeek-V4-Flash decode_attention_hca example
         env:
@@ -974,7 +974,7 @@ jobs:
         run: |
           source activate.sh
           task-submit --device "$DEVICE_ID" --timeout 3600 --max-time 1800 \
-            --run "source $GITHUB_WORKSPACE/lib-checkout/activate.sh && cd $GITHUB_WORKSPACE/pypto-lib && python models/deepseek/v4-flash/decode_attention_hca.py -p a2a3 -d \$TASK_DEVICE"
+            --run "source $GITHUB_WORKSPACE/lib-checkout/activate.sh && cd $GITHUB_WORKSPACE/pypto-lib && python models/deepseek_v4_flash_mtp/decode_attention_hca.py -p a2a3 -d \$TASK_DEVICE"
 
       - name: Run pypto-lib DeepSeek-V4-Flash decode_attention_csa example
         env:
@@ -982,7 +982,7 @@ jobs:
         run: |
           source activate.sh
           task-submit --device "$DEVICE_ID" --timeout 3600 --max-time 1800 \
-            --run "source $GITHUB_WORKSPACE/lib-checkout/activate.sh && cd $GITHUB_WORKSPACE/pypto-lib && python models/deepseek/v4-flash/decode_attention_csa.py -p a2a3 -d \$TASK_DEVICE"
+            --run "source $GITHUB_WORKSPACE/lib-checkout/activate.sh && cd $GITHUB_WORKSPACE/pypto-lib && python models/deepseek_v4_flash_mtp/decode_attention_csa.py -p a2a3 -d \$TASK_DEVICE"
 
       - name: Run pypto-lib DeepSeek-V4-Flash prefill_attention_csa example
         env:
@@ -990,7 +990,7 @@ jobs:
         run: |
           source activate.sh
           task-submit --device "$DEVICE_ID" --timeout 3600 --max-time 1800 \
-            --run "source $GITHUB_WORKSPACE/lib-checkout/activate.sh && cd $GITHUB_WORKSPACE/pypto-lib && python models/deepseek/v4-flash/prefill_attention_csa.py -p a2a3 -d \$TASK_DEVICE"
+            --run "source $GITHUB_WORKSPACE/lib-checkout/activate.sh && cd $GITHUB_WORKSPACE/pypto-lib && python models/deepseek_v4_flash_mtp/prefill_attention_csa.py -p a2a3 -d \$TASK_DEVICE"
 
       - name: Run pypto-lib DeepSeek-V4-Flash prefill_attention_hca example
         env:
@@ -998,7 +998,7 @@ jobs:
         run: |
           source activate.sh
           task-submit --device "$DEVICE_ID" --timeout 3600 --max-time 1800 \
-            --run "source $GITHUB_WORKSPACE/lib-checkout/activate.sh && cd $GITHUB_WORKSPACE/pypto-lib && python models/deepseek/v4-flash/prefill_attention_hca.py -p a2a3 -d \$TASK_DEVICE"
+            --run "source $GITHUB_WORKSPACE/lib-checkout/activate.sh && cd $GITHUB_WORKSPACE/pypto-lib && python models/deepseek_v4_flash_mtp/prefill_attention_hca.py -p a2a3 -d \$TASK_DEVICE"
 
       - name: Run pypto-lib DeepSeek-V4-Flash prefill_attention_swa example
         env:
@@ -1006,7 +1006,7 @@ jobs:
         run: |
           source activate.sh
           task-submit --device "$DEVICE_ID" --timeout 3600 --max-time 1800 \
-            --run "source $GITHUB_WORKSPACE/lib-checkout/activate.sh && cd $GITHUB_WORKSPACE/pypto-lib && python models/deepseek/v4-flash/prefill_attention_swa.py -p a2a3 -d \$TASK_DEVICE"
+            --run "source $GITHUB_WORKSPACE/lib-checkout/activate.sh && cd $GITHUB_WORKSPACE/pypto-lib && python models/deepseek_v4_flash_mtp/prefill_attention_swa.py -p a2a3 -d \$TASK_DEVICE"
 
       - name: Run pypto-lib DeepSeek-V4-Flash moe example
         env:
@@ -1014,7 +1014,7 @@ jobs:
         run: |
           source activate.sh
           task-submit --device "$DEVICE_ID" --device-num 2 --timeout 3600 --max-time 1800 \
-            --run "source $GITHUB_WORKSPACE/lib-checkout/activate.sh && cd $GITHUB_WORKSPACE/pypto-lib && python models/deepseek/v4-flash/moe.py -p a2a3 -d \$TASK_DEVICE --ep 2"
+            --run "source $GITHUB_WORKSPACE/lib-checkout/activate.sh && cd $GITHUB_WORKSPACE/pypto-lib && python models/deepseek_v4_flash_mtp/moe.py -p a2a3 -d \$TASK_DEVICE --ep 2"
 
       - name: Kill orphaned task-submit tasks
         if: always()

--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -197,7 +197,7 @@ jobs:
           for i in $(seq 1 5); do
             echo "=== qwen3 decode perf sample $i/5 ==="
             task-submit --device "$DEVICE_ID" --timeout 3600 --max-time 1800 \
-              --run "source $GITHUB_WORKSPACE/perf-checkout/activate.sh && cd $GITHUB_WORKSPACE/pypto-lib && python models/qwen3/14b/decode_fwd.py -p a2a3 -d \$TASK_DEVICE --enable-l2-swimlane --max-seq --seed 1234" \
+              --run "source $GITHUB_WORKSPACE/perf-checkout/activate.sh && cd $GITHUB_WORKSPACE/pypto-lib && python models/qwen3_14b/decode_fwd.py -p a2a3 -d \$TASK_DEVICE --enable-l2-swimlane --max-seq --seed 1234" \
               2>&1 | tee -a "$GITHUB_WORKSPACE/qwen3_perf.log" \
               || echo "WARN: perf sample $i exited non-zero"
           done

--- a/examples/models/qwen3_jit/config.py
+++ b/examples/models/qwen3_jit/config.py
@@ -10,7 +10,7 @@
 """Shape and tiling constants for Qwen3-32B single-layer decode.
 
 Centralised so every kernel file imports the same values. Mirrors the
-constants from the upstream ``qwen3_32b_decode.py`` reference."""
+constants from the upstream ``models/qwen3_32b/decode.py`` reference."""
 
 # ─── Model dimensions ───
 BATCH = 16

--- a/examples/models/qwen3_jit/qwen3_decode.py
+++ b/examples/models/qwen3_jit/qwen3_decode.py
@@ -18,7 +18,7 @@ Run with::
     python -m examples.models.qwen3_jit.qwen3_decode
 
 (For numerical validation against a PyTorch golden, see
-``qwen3_32b_decode.py`` from the upstream pypto-lib repository.)
+``models/qwen3_32b/decode.py`` from the upstream pypto-lib repository.)
 """
 
 import pypto.language as pl

--- a/tests/st/distributed/test_l3_ep_dispatch_combine.py
+++ b/tests/st/distributed/test_l3_ep_dispatch_combine.py
@@ -10,7 +10,7 @@
 """L3 distributed st: N-rank EP dispatch + local_expert + combine — 1:1 PyPTO
 port of ``runtime/examples/workers/l3/ep_dispatch_combine``.
 
-Runs at real DeepSeek-V4 FLASH MoE scale (pypto-lib/models/deepseek/v4):
+Runs at real DeepSeek-V4 FLASH MoE scale (pypto-lib/models/deepseek_v4_flash_mtp):
 T=128, TOPK=6, D=4096, L=16 local experts per rank, R=192 receive cap.
 
 This is a structural port of the C++ runtime example. The three AIV kernels
@@ -66,7 +66,7 @@ import torch
 from pypto import ir
 from pypto.ir.distributed_compiled_program import DistributedConfig
 
-# Real DeepSeek-V4 FLASH MoE shapes (pypto-lib/models/deepseek/v4) — must
+# Real DeepSeek-V4 FLASH MoE shapes (pypto-lib/models/deepseek_v4_flash_mtp) — must
 # mirror the runtime example's constants. ``N_RANKS`` is supplied per-test via
 # ``_build_ep_dispatch_combine_program(n_ranks)``; everything below is
 # rank-count-independent. T = DECODE_BATCH*DECODE_SEQ, TOPK = experts/tok,


### PR DESCRIPTION
pypto-lib replaced models/<family>/<variant>/ with one flat directory per
model build. The pypto-lib-model job clones pypto-lib's default branch with
no ref pin, so its kernel invocations break as soon as that rename lands.

- ci.yml runs the two Qwen3-14B entries from models/qwen3_14b and the seven
  DeepSeek-V4-Flash entries from models/deepseek_v4_flash_mtp.
- daily_ci.yml's Qwen3-14B decode perf sample follows the same path.
- The EP dispatch/combine st, the qwen3_jit example and its config, and the
  incore-profiling skill's --case example cite the new paths. Those are
  comments rather than resolved paths; the skill example now also names a
  real entry point, which qwen3_14b_decode.py was not.

Both workflows track pypto-lib tip, so this cannot be sequenced without a
window where one side is red. Land it alongside the pypto-lib rename.