### PR TITLE
test(st): Stabilize dbC Mat-scratch inputs

### DIFF
--- a/tests/st/runtime/ops/test_dbc2_double_buffer.py
+++ b/tests/st/runtime/ops/test_dbc2_double_buffer.py
@@ -200,11 +200,19 @@ class _DbcMatScratch(PTOTestCase):
         return f"dbc2_mat_scratch_{tag}_{self.M}x{self.K}x{self.N}"
 
     def define_tensors(self) -> list[TensorSpec]:
+        M, K, N, P = self.M, self.K, self.N, self.P
+
+        # Keep the chained BF16 result O(1) so the fixed absolute tolerance covers
+        # cancellation elements, and use local generators because the harness does
+        # not seed torch before materializing inputs.
+        def seeded(rows, cols, seed, scale=1.0):
+            return torch.randn(rows, cols, generator=torch.Generator().manual_seed(seed)) * scale
+
         return [
-            TensorSpec("a", [self.M, self.K], DataType.BF16, init_value=torch.randn),
-            TensorSpec("b", [self.K, self.N], DataType.BF16, init_value=torch.randn),
-            TensorSpec("e", [self.N, self.P], DataType.BF16, init_value=torch.randn),
-            TensorSpec("out", [self.M, self.P], DataType.FP32, is_output=True),
+            TensorSpec("a", [M, K], DataType.BF16, init_value=lambda: seeded(M, K, 1)),
+            TensorSpec("b", [K, N], DataType.BF16, init_value=lambda: seeded(K, N, 2, 1 / K**0.5)),
+            TensorSpec("e", [N, P], DataType.BF16, init_value=lambda: seeded(N, P, 3, 1 / N**0.5)),
+            TensorSpec("out", [M, P], DataType.FP32, is_output=True),
         ]
 
     def get_program(self) -> Any:


### PR DESCRIPTION
## Summary
- seed the Mat-scratch dbC operands with independent local generators
- scale the chained BF16 weights by their fan-in so the output remains O(1)
- retain the existing rtol/atol = 2e-2 comparison policy

## Motivation
PR #2277 exposed a one-element numerical flake in the otherwise unchanged PyPTO case. The test harness does not seed tensor materialization, and unscaled chained random matmuls occasionally produce cancellation-sensitive values. This adopts the deterministic input pattern already used by the equivalent chained Mat-scratch system test instead of loosening the tolerance.

## Testing
- worktree-local CMake build with top-level and nested parallelism capped at 2
- pre-commit run --files tests/st/runtime/ops/test_dbc2_double_buffer.py
- deterministic repeated input materialization under PyPTO and PTOAS
- host AutoTile structural validation under PyPTO and PTOAS
- device execution deferred to system-test CI