### PR TITLE
perf(runtime): upload stacked-tensor shards concurrently

### DIFF
--- a/python/pypto/runtime/distributed_runner.py
+++ b/python/pypto/runtime/distributed_runner.py
@@ -2259,6 +2259,9 @@ class DistributedWorker(Worker):
             raise TypeError(
                 f"alloc_stacked_tensor(host=...) expects a torch.Tensor, got {type(host).__name__}"
             )
+        # Ahead of every upload on purpose: `alloc_tensor` re-checks the host in
+        # `_prepare_init`, but only after its own device malloc, so N concurrent shards
+        # would each commit device memory before any of them surfaced this ValueError.
         self._require_copy_host_tensor(host, "alloc_stacked_tensor(host=...)")
         if host.ndim < 2:
             raise ValueError(
@@ -2279,12 +2282,6 @@ class DistributedWorker(Worker):
         for w in ids:
             if not 0 <= w < world:
                 raise ValueError(f"worker id {w} out of range [0, {world}) (world_size from device_ids)")
-
-        # Validate the stacked host before uploading anything: `alloc_tensor` only
-        # checks the host endpoint in `_prepare_init`, which runs after its device
-        # malloc, so N concurrent shards would each commit device memory first and
-        # surface an allocator failure instead of this ValueError.
-        self._require_copy_host_tensor(host, "alloc_stacked_tensor(host=...)")
 
         shards: list[DeviceTensor] = []
         try:

--- a/python/pypto/runtime/distributed_runner.py
+++ b/python/pypto/runtime/distributed_runner.py
@@ -24,6 +24,7 @@ import types
 import warnings
 import weakref
 from collections.abc import Callable, Sequence
+from concurrent.futures import ThreadPoolExecutor
 from contextlib import suppress
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -2281,15 +2282,34 @@ class DistributedWorker(Worker):
 
         shards: list[DeviceTensor] = []
         try:
-            for i, w in enumerate(ids):
-                shards.append(
-                    self.alloc_tensor(
-                        tuple(host.shape[1:]),
-                        host.dtype,
-                        init=host[i].contiguous(),
-                        worker_id=w,
-                    )
+            # Upload the shards concurrently: each one targets a different chip
+            # worker, so the H2D transfers overlap instead of running back-to-back
+            # at single-chip bandwidth (the device-memory bindings release the GIL,
+            # and Simpler serializes provenance-guarded device ops per worker).
+            def _upload_shard(i: int, w: int) -> DeviceTensor:
+                return self.alloc_tensor(
+                    tuple(host.shape[1:]),
+                    host.dtype,
+                    init=host[i].contiguous(),
+                    worker_id=w,
                 )
+
+            uploaded: dict[int, DeviceTensor] = {}
+            errors: list[Exception] = []
+            with ThreadPoolExecutor(max_workers=len(ids)) as pool:
+                futures = {pool.submit(_upload_shard, i, w): i for i, w in enumerate(ids)}
+                for future, index in futures.items():
+                    try:
+                        uploaded[index] = future.result()
+                    except Exception as exc:  # noqa: PERF203 -- one shard failing must not orphan the rest
+                        errors.append(exc)
+            if errors:
+                # A concurrent upload can fail anywhere in the group, so roll back
+                # by index rather than relying on the successes being a prefix.
+                for index, shard in uploaded.items():
+                    self.free_tensor(shard, worker_id=ids[index])
+                raise errors[0]
+            shards.extend(uploaded[index] for index in range(len(ids)))
         except Exception:
             # Roll back any shards already uploaded so a mid-loop failure
             # never leaks device memory.

--- a/python/pypto/runtime/distributed_runner.py
+++ b/python/pypto/runtime/distributed_runner.py
@@ -24,7 +24,7 @@ import types
 import warnings
 import weakref
 from collections.abc import Callable, Sequence
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import Future, ThreadPoolExecutor
 from contextlib import suppress
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -2280,6 +2280,12 @@ class DistributedWorker(Worker):
             if not 0 <= w < world:
                 raise ValueError(f"worker id {w} out of range [0, {world}) (world_size from device_ids)")
 
+        # Validate the stacked host before uploading anything: `alloc_tensor` only
+        # checks the host endpoint in `_prepare_init`, which runs after its device
+        # malloc, so N concurrent shards would each commit device memory first and
+        # surface an allocator failure instead of this ValueError.
+        self._require_copy_host_tensor(host, "alloc_stacked_tensor(host=...)")
+
         shards: list[DeviceTensor] = []
         try:
             # Upload the shards concurrently: each one targets a different chip
@@ -2294,18 +2300,30 @@ class DistributedWorker(Worker):
                     worker_id=w,
                 )
 
-            uploaded: dict[int, DeviceTensor] = {}
-            errors: list[Exception] = []
+            futures: dict[Future[DeviceTensor], int] = {}
+            errors: list[BaseException] = []
             with ThreadPoolExecutor(max_workers=len(ids)) as pool:
-                futures = {pool.submit(_upload_shard, i, w): i for i, w in enumerate(ids)}
-                for future, index in futures.items():
+                for i, w in enumerate(ids):
                     try:
-                        uploaded[index] = future.result()
-                    except Exception as exc:  # noqa: PERF203 -- one shard failing must not orphan the rest
+                        futures[pool.submit(_upload_shard, i, w)] = i
+                    except BaseException as exc:
+                        # Stop submitting, but still drain what is already running.
                         errors.append(exc)
+                        break
+
+            # Leaving the pool joined every submitted task, so this only collects
+            # results. Every future is drained even once the group has failed —
+            # dropping one would strand a live device buffer with no owner.
+            uploaded: dict[int, DeviceTensor] = {}
+            for future, index in futures.items():
+                try:
+                    uploaded[index] = future.result()
+                except BaseException as exc:
+                    errors.append(exc)
+
             if errors:
-                # A concurrent upload can fail anywhere in the group, so roll back
-                # by index rather than relying on the successes being a prefix.
+                # A concurrent group can fail anywhere, so the successes are not a
+                # prefix of `ids`: roll back by index, against the owning worker.
                 for index, shard in uploaded.items():
                     self.free_tensor(shard, worker_id=ids[index])
                 raise errors[0]

--- a/tests/ut/runtime/test_distributed_worker.py
+++ b/tests/ut/runtime/test_distributed_worker.py
@@ -120,6 +120,19 @@ class _FakeBuffer:
         return shapes, dtype
 
 
+def _alloc_by_worker(worker_mock, buffers):
+    """Make the fake allocator return a buffer chosen by ``worker_id``, not by call order.
+
+    A ``side_effect`` list is consumed in call order, which couples the fixture to the order
+    the shards happen to be uploaded in. Since `alloc_stacked_tensor` uploads the shards
+    concurrently, that order is not defined — and the real
+    ``alloc_child_tensor(worker_id, ...)`` returns the buffer belonging to the worker it is
+    asked about, so keying on the worker is also the more faithful fake.
+    """
+    worker_mock.alloc_child_tensor.side_effect = lambda worker_id, *args, **kwargs: buffers[worker_id]
+    return buffers
+
+
 @pytest.fixture
 def patched_setup():
     """Patch every setup helper so DistributedWorker() does no real work.
@@ -997,8 +1010,8 @@ class TestAllocStackedTensor:
     """``alloc_stacked_tensor`` uploads each leading-dim shard to its worker once."""
 
     def test_identity_uploads_shard_per_worker(self, patched_setup):
-        buffers = [_FakeBuffer(0xA000, 64), _FakeBuffer(0xB000, 64)]
-        patched_setup["worker"].alloc_child_tensor.side_effect = buffers
+        buffers = {0: _FakeBuffer(0xA000, 64), 1: _FakeBuffer(0xB000, 64)}
+        _alloc_by_worker(patched_setup["worker"], buffers)
         rt = DistributedWorker(_compiled_2cards())
         host = torch.arange(2 * 4 * 4, dtype=torch.float32).view(2, 4, 4).share_memory_()
 
@@ -1008,19 +1021,22 @@ class TestAllocStackedTensor:
         assert stacked.worker_ids == (0, 1)
         assert tuple(s.shape for s in stacked.shards) == ((4, 4), (4, 4))
         worker = patched_setup["worker"]
-        # shard 0 -> worker 0, shard 1 -> worker 1.
+        # shard 0 -> worker 0, shard 1 -> worker 1. The pairing is asserted; the order the
+        # two uploads are issued in is not, because they now run concurrently.
         nbytes = 4 * 4 * 4
         allocs = worker.alloc_child_tensor.call_args_list
-        assert [call.args[:2] for call in allocs] == [(0, (nbytes,)), (1, (nbytes,))]
-        assert [call.args[0] for call in worker.copy_to.call_args_list] == buffers
+        assert sorted(call.args[:2] for call in allocs) == [(0, (nbytes,)), (1, (nbytes,))]
+        assert sorted(call.args[0].base for call in worker.copy_to.call_args_list) == sorted(
+            buffer.base for buffer in buffers.values()
+        )
         # Tracked per (worker_id, ptr) for auto-free.
         assert (0, 0xA000) in rt._owned_tensors
         assert (1, 0xB000) in rt._owned_tensors
         rt.close()
 
     def test_registered_inherited_storage_uploads_without_shared_memory(self, patched_setup):
-        buffers = [_FakeBuffer(0xA000, 64), _FakeBuffer(0xB000, 64)]
-        patched_setup["worker"].alloc_child_tensor.side_effect = buffers
+        buffers = {0: _FakeBuffer(0xA000, 64), 1: _FakeBuffer(0xB000, 64)}
+        _alloc_by_worker(patched_setup["worker"], buffers)
         host = torch.arange(2 * 4 * 4, dtype=torch.float32).view(2, 4, 4)
         rt = DistributedWorker(_compiled_2cards(), inherited_host_tensors=[host])
 
@@ -1028,14 +1044,14 @@ class TestAllocStackedTensor:
 
         assert stacked.worker_ids == (0, 1)
         worker = patched_setup["worker"]
-        assert [call.args[0] for call in worker.copy_to.call_args_list] == buffers
+        assert sorted(call.args[0].base for call in worker.copy_to.call_args_list) == sorted(
+            buffer.base for buffer in buffers.values()
+        )
         rt.close()
 
     def test_permuted_worker_ids_place_shards(self, patched_setup):
-        patched_setup["worker"].alloc_child_tensor.side_effect = [
-            _FakeBuffer(0xA000, 64),
-            _FakeBuffer(0xB000, 64),
-        ]
+        buffers = {1: _FakeBuffer(0xA000, 64), 0: _FakeBuffer(0xB000, 64)}
+        _alloc_by_worker(patched_setup["worker"], buffers)
         rt = DistributedWorker(_compiled_2cards())
         host = torch.zeros(2, 4, 4, dtype=torch.float32).share_memory_()
 
@@ -1044,16 +1060,16 @@ class TestAllocStackedTensor:
         assert stacked.worker_ids == (1, 0)
         worker = patched_setup["worker"]
         nbytes = 4 * 4 * 4
-        # shard 0 -> worker 1, shard 1 -> worker 0.
+        # shard 0 -> worker 1, shard 1 -> worker 0: the placement, not the issue order.
         allocs = worker.alloc_child_tensor.call_args_list
-        assert [call.args[:2] for call in allocs] == [(1, (nbytes,)), (0, (nbytes,))]
+        assert sorted(call.args[:2] for call in allocs) == [(0, (nbytes,)), (1, (nbytes,))]
         assert (1, 0xA000) in rt._owned_tensors
         assert (0, 0xB000) in rt._owned_tensors
         rt.close()
 
     def test_free_stacked_tensor_releases_each_shard(self, patched_setup):
-        buffers = [_FakeBuffer(0xA000, 64), _FakeBuffer(0xB000, 64)]
-        patched_setup["worker"].alloc_child_tensor.side_effect = buffers
+        buffers = {1: _FakeBuffer(0xA000, 64), 0: _FakeBuffer(0xB000, 64)}
+        _alloc_by_worker(patched_setup["worker"], buffers)
         rt = DistributedWorker(_compiled_2cards())
         host = torch.zeros(2, 4, 4, dtype=torch.float32).share_memory_()
         stacked = rt.alloc_stacked_tensor(host, worker_ids=[1, 0])
@@ -1062,15 +1078,15 @@ class TestAllocStackedTensor:
         rt.free_stacked_tensor(stacked)
 
         worker = patched_setup["worker"]
-        worker.free.assert_any_call(buffers[0])
         worker.free.assert_any_call(buffers[1])
+        worker.free.assert_any_call(buffers[0])
         assert (1, 0xA000) not in rt._owned_tensors
         assert (0, 0xB000) not in rt._owned_tensors
         rt.close()
 
     def test_close_auto_frees_stacked_shards(self, patched_setup):
-        buffers = [_FakeBuffer(0xA000, 64), _FakeBuffer(0xB000, 64)]
-        patched_setup["worker"].alloc_child_tensor.side_effect = buffers
+        buffers = {0: _FakeBuffer(0xA000, 64), 1: _FakeBuffer(0xB000, 64)}
+        _alloc_by_worker(patched_setup["worker"], buffers)
         rt = DistributedWorker(_compiled_2cards())
         host = torch.zeros(2, 4, 4, dtype=torch.float32).share_memory_()
         rt.alloc_stacked_tensor(host)  # leak — close() must release both shards


### PR DESCRIPTION
## What

`DistributedWorker.alloc_stacked_tensor` uploads shard *i* to worker *i* in a serial loop, so a rank-stacked resident weight moves at single-chip H2D bandwidth no matter how many chips the group spans. Each shard targets a different chip worker and nothing orders them, so this drives them from a thread pool.

## What it is worth, measured end to end

Now measurable, because the pin advance exists: on #2355 (our port of it) and on **#2345**, which carries the same advance upstream and to which this PR applies with **zero conflicts** (two hunks, offsets only).

DeepSeek V4 Flash W8A8, 8 × 910B2, 346.6 GB of resident weights, warm kernel cache, `pypto-serving` `71fd275`, `pypto-lib` `f0d352e`, PTOAS v0.57 — single-variable A/B, only this PR's 46 lines differ within each pair:

| base | resident upload | `model loaded` | this PR buys |
|---|---|---|---|
| #2355 (advanced pin) | 66.5s (3 runs, ±0.6) → **23.4 / 23.8s** | 74.0s → **31.0 / 31.2s** | **2.84×** |
| #2345 (advanced pin, upstream) | 497.7s → **98.9s** | 518.1s → **119.3s** | **5.03×** |

The old pin reaches `model loaded` in 73.7s, so the pin itself is performance-neutral — the gain is this PR's, unlocked by the advance. Re-run on 2026-08-13 the #2355 row reproduces at 25.6s / 33.0s, i.e. within 8%.

The two bases differ that much because #2345's H2D path stages every copy through a fresh shm buffer plus a full host→host `memmove`, so this PR is partly parallelising an extra copy there; that is reported on #2345, and it is also why the ratio is *higher* on the slower base. Either way the concurrency is what this PR contributes.

**Please treat the absolutes as setup-dependent.** `pypto-serving`#134 measured the same class of host-copy cost at ~492s on this node and ~62s on another (page-cache state, mount and driver all matter), so the transferable claim is the concurrency ratio on a given machine, not the seconds.

**Merge order does not matter.** Without an advanced pin this change is a **no-op, not a regression**: Simpler serializes the native half of `malloc` / `copy_to` three times over, and any one of the three flattens the group no matter how the caller issues it —

- `_child_prov_lock`, a process-wide provenance lock held across the native call;
- the run-admission lock, taken by control commands through `_control_reservation`;
- the **GIL** — Simpler's bindings did not release it for those four entry points.

hw-native-sys/simpler#1702 (merged) removes all three, and both #2345's pin (`e4ab544a`) and #2355's (`8a82bf9e`) contain it. This PR will be rebased onto whichever lands.

## Withdrawn numbers

An earlier revision of this PR reported:

| | before | after |
|---|---:|---:|
| resident weight upload | 57.1s | 10.4s (6.0 → 33.2 GB/s) |
| engine startup | 82.0s | 35.1s |

and an isolated harness at threaded 28.2 / 17.1 GB/s vs serial 8.6 / 8.1 GB/s.

**Those figures are withdrawn** and are superseded by the table above. They were measured on a stack that combined the pre-refactor Simpler with an out-of-tree lock patch and a serving-side loader change; none of the three is what this PR ships against, and the combination no longer exists.

## Rollback semantics

The serial loop could roll back by zipping `shards` with `ids` positionally, because the successes were always a prefix. A concurrent failure can land anywhere in the group, so successes are collected by index and freed against their own worker before the first error is re-raised. The pre-existing `except` clause remains as the backstop for anything that fails after the group is complete; `shards` is either empty or complete when it runs, so nothing is freed twice.

Threads only call `alloc_tensor`, and each targets a distinct `worker_id`, so no new shared state is introduced on this path.

A correction worth flagging, since it was part of the original safety argument here: an earlier revision of this section claimed the `malloc` / `copy_to` bindings release the GIL. **They did not** — that is exactly the third serializer above, and simpler#1702 is what added `nb::call_guard<nb::gil_scoped_release>()` to those four entry points.

## One pinned behaviour changed, deliberately

`tests/ut/runtime/test_distributed_worker.py` set `alloc_child_tensor.side_effect` to a list, which a mock consumes in call order. That was exact while the shards uploaded sequentially and it is what fails once they upload concurrently: whichever thread calls first takes the buffer meant for worker 0, so both the pairing assertions and the recorded order became a coin flip. The fakes now hand out a buffer chosen by `worker_id`, which is also what the real `alloc_child_tensor(worker_id, ...)` does.

What callers can rely on is asserted and unchanged: `shards` and `worker_ids` keep the caller's order, each shard is allocated on its own worker, and `_owned_tensors` tracks the right `(worker_id, ptr)` pairs. What is gone is only "worker 0's allocation happens before worker 1's". **If you would rather keep that guarantee, the right fix is to drop the concurrency from this PR, not to keep the assertions** — a sequential upload is the behaviour they describe.

Two of the six touched tests were passing by luck rather than design (`test_permuted_worker_ids_place_shards`, `test_free_stacked_tensor_releases_each_shard`): their assertions rest on the same call-ordered fake, so they were already flaky under concurrency and would have failed intermittently. `TestCopyStackedFrom` is untouched on purpose — it reads the pairing from the object under test, so it is order-independent already.

## Validation

- `ruff check` passes; rebased onto current `main` with no conflicts.
- Full 43-layer DeepSeek V4 Flash W8A8 runs on 8 cards on both bases above: 346.6 GB uploaded, 0 faults, `model loaded`, unchanged generated output through prefill.
- One caveat on those runs, unrelated to this PR: decode stalls after the first token on both advanced pins — see #2354, which reproduces on #2345's head without any of our code.

