### PR TITLE
CI: follow pypto-lib's attention module renames

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -960,53 +960,53 @@ jobs:
       # CI only checks functional correctness; perf is noisy (~8.5% jitter) and
       # is sampled daily with multiple runs averaged to keep the signal stable.
 
-      - name: Run pypto-lib DeepSeek-V4-Flash decode_attention_swa example
+      - name: Run pypto-lib DeepSeek-V4-Flash decode_swa example
         env:
           PYTHONPATH: ${{ github.workspace }}/pypto-lib
         run: |
           source activate.sh
           task-submit --device "$DEVICE_ID" --timeout 3600 --max-time 1800 \
-            --run "source $GITHUB_WORKSPACE/lib-checkout/activate.sh && cd $GITHUB_WORKSPACE/pypto-lib && python models/deepseek_v4_flash_mtp/decode_attention_swa.py -p a2a3 -d \$TASK_DEVICE"
+            --run "source $GITHUB_WORKSPACE/lib-checkout/activate.sh && cd $GITHUB_WORKSPACE/pypto-lib && python models/deepseek_v4_flash_mtp/decode_swa.py -p a2a3 -d \$TASK_DEVICE"
 
-      - name: Run pypto-lib DeepSeek-V4-Flash decode_attention_hca example
+      - name: Run pypto-lib DeepSeek-V4-Flash decode_hca example
         env:
           PYTHONPATH: ${{ github.workspace }}/pypto-lib
         run: |
           source activate.sh
           task-submit --device "$DEVICE_ID" --timeout 3600 --max-time 1800 \
-            --run "source $GITHUB_WORKSPACE/lib-checkout/activate.sh && cd $GITHUB_WORKSPACE/pypto-lib && python models/deepseek_v4_flash_mtp/decode_attention_hca.py -p a2a3 -d \$TASK_DEVICE"
+            --run "source $GITHUB_WORKSPACE/lib-checkout/activate.sh && cd $GITHUB_WORKSPACE/pypto-lib && python models/deepseek_v4_flash_mtp/decode_hca.py -p a2a3 -d \$TASK_DEVICE"
 
-      - name: Run pypto-lib DeepSeek-V4-Flash decode_attention_csa example
+      - name: Run pypto-lib DeepSeek-V4-Flash decode_csa example
         env:
           PYTHONPATH: ${{ github.workspace }}/pypto-lib
         run: |
           source activate.sh
           task-submit --device "$DEVICE_ID" --timeout 3600 --max-time 1800 \
-            --run "source $GITHUB_WORKSPACE/lib-checkout/activate.sh && cd $GITHUB_WORKSPACE/pypto-lib && python models/deepseek_v4_flash_mtp/decode_attention_csa.py -p a2a3 -d \$TASK_DEVICE"
+            --run "source $GITHUB_WORKSPACE/lib-checkout/activate.sh && cd $GITHUB_WORKSPACE/pypto-lib && python models/deepseek_v4_flash_mtp/decode_csa.py -p a2a3 -d \$TASK_DEVICE"
 
-      - name: Run pypto-lib DeepSeek-V4-Flash prefill_attention_csa example
+      - name: Run pypto-lib DeepSeek-V4-Flash prefill_csa example
         env:
           PYTHONPATH: ${{ github.workspace }}/pypto-lib
         run: |
           source activate.sh
           task-submit --device "$DEVICE_ID" --timeout 3600 --max-time 1800 \
-            --run "source $GITHUB_WORKSPACE/lib-checkout/activate.sh && cd $GITHUB_WORKSPACE/pypto-lib && python models/deepseek_v4_flash_mtp/prefill_attention_csa.py -p a2a3 -d \$TASK_DEVICE"
+            --run "source $GITHUB_WORKSPACE/lib-checkout/activate.sh && cd $GITHUB_WORKSPACE/pypto-lib && python models/deepseek_v4_flash_mtp/prefill_csa.py -p a2a3 -d \$TASK_DEVICE"
 
-      - name: Run pypto-lib DeepSeek-V4-Flash prefill_attention_hca example
+      - name: Run pypto-lib DeepSeek-V4-Flash prefill_hca example
         env:
           PYTHONPATH: ${{ github.workspace }}/pypto-lib
         run: |
           source activate.sh
           task-submit --device "$DEVICE_ID" --timeout 3600 --max-time 1800 \
-            --run "source $GITHUB_WORKSPACE/lib-checkout/activate.sh && cd $GITHUB_WORKSPACE/pypto-lib && python models/deepseek_v4_flash_mtp/prefill_attention_hca.py -p a2a3 -d \$TASK_DEVICE"
+            --run "source $GITHUB_WORKSPACE/lib-checkout/activate.sh && cd $GITHUB_WORKSPACE/pypto-lib && python models/deepseek_v4_flash_mtp/prefill_hca.py -p a2a3 -d \$TASK_DEVICE"
 
-      - name: Run pypto-lib DeepSeek-V4-Flash prefill_attention_swa example
+      - name: Run pypto-lib DeepSeek-V4-Flash prefill_swa example
         env:
           PYTHONPATH: ${{ github.workspace }}/pypto-lib
         run: |
           source activate.sh
           task-submit --device "$DEVICE_ID" --timeout 3600 --max-time 1800 \
-            --run "source $GITHUB_WORKSPACE/lib-checkout/activate.sh && cd $GITHUB_WORKSPACE/pypto-lib && python models/deepseek_v4_flash_mtp/prefill_attention_swa.py -p a2a3 -d \$TASK_DEVICE"
+            --run "source $GITHUB_WORKSPACE/lib-checkout/activate.sh && cd $GITHUB_WORKSPACE/pypto-lib && python models/deepseek_v4_flash_mtp/prefill_swa.py -p a2a3 -d \$TASK_DEVICE"
 
       - name: Run pypto-lib DeepSeek-V4-Flash moe example
         env:


### PR DESCRIPTION
pypto-lib dropped the redundant attention segment from its six DeepSeek-V4
Flash variant modules: decode_attention_{csa,hca,swa}.py became
decode_{csa,hca,swa}.py and prefill_attention_{csa,hca,swa}.py became
prefill_{csa,hca,swa}.py. The six example steps here run those files by
path, so they fail on the renamed checkout.

- Point the six example paths at the new module names
- Rename the matching step titles

Pairs with hw-native-sys/pypto-lib#903.