### PR TITLE
fix: write recv_counts directly for self-send in all_to_all_v

### DIFF
--- a/python/pypto/runtime/builtins/collectives/all_to_all_v/templates/kernel.cpp.in
+++ b/python/pypto/runtime/builtins/collectives/all_to_all_v/templates/kernel.cpp.in
@@ -131,9 +131,18 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
     if (rows64 > max_recv) rows64 = max_recv;
     int32_t rows = static_cast<int32_t>(rows64);
 
-    __gm__ int32_t *remote_recv_slot = CommRemotePtr(comm_ctx, recv_counts_base + my_rank, dest);
-    pto::comm::Signal count_sig(remote_recv_slot);
-    pto::comm::TNOTIFY(count_sig, rows, pto::comm::NotifyOp::Set);
+    if (dest == my_rank) {
+      // Self-send: write recv_counts via compiler atomic builtin — a
+      // TNOTIFY to self may be dropped by the NPU interconnect on some
+      // hardware generations.  __atomic_store_n is a GCC/Clang builtin
+      // that the CCE compiler supports natively (no <atomic> needed),
+      // and it is address-space aware (works with __gm__ pointers).
+      __atomic_store_n(recv_counts_base + my_rank, rows, __ATOMIC_RELEASE);
+    } else {
+      __gm__ int32_t *remote_recv_slot = CommRemotePtr(comm_ctx, recv_counts_base + my_rank, dest);
+      pto::comm::Signal count_sig(remote_recv_slot);
+      pto::comm::TNOTIFY(count_sig, rows, pto::comm::NotifyOp::Set);
+    }
 
     int64_t src_row_offset = static_cast<int64_t>(dest) * max_recv * row_numel;
     int64_t dst_row_offset = static_cast<int64_t>(my_rank) * max_recv * row_numel;


### PR DESCRIPTION
On some NPU hardware generations, `TNOTIFY(Set)` to self may be dropped by the
interconnect.  The root cause is non-deterministic: `TNOTIFY` is fire-and-forget
with no completion signal — whether the self-write lands before the consumer
reads `recv_counts` depends on pipeline depth, self-loopback path timing, and
the fact that `dsb(DSB_DDR)` orders local stores but may not drain in-flight
self-destined remote writes (see #2295 for details).

This is the only builtin that must include self in its loop (the data-transfer
`TPUT` needs to copy the self-destination block from input to output).  Every
other builtin skips self entirely with `if (peer == my_rank) continue;` before
`TNOTIFY`.

**Fix**: adds a `dest == my_rank` guard that writes `recv_counts` via
`__atomic_store_n` with `__ATOMIC_RELEASE` — a synchronous store guaranteed to
complete before the next instruction, no interconnect involved.  The builtin is
address-space aware (works with `__gm__` pointers) and already used elsewhere
in the codebase (`comm_sim.cpp`, `sdma_completion_scheduler.h`, etc.).

**Test**: `tests/st/distributed/test_l3_host_tensor_all_to_all_v.py::`\
`TestL3HostTensorAllToAllV::test_host_tensor_all_to_all_v[2]`

Closes #2295.