### PR TITLE
fix(ir): Stop stamping a NONE split attr on split_aiv functions

### DIFF
--- a/docs/en/dev/passes/08-outline_incore_scopes.md
+++ b/docs/en/dev/passes/08-outline_incore_scopes.md
@@ -261,3 +261,22 @@ The three states read distinctly:
 | `optimizations=[pl.split(MODE)]` | AUTO split — the compiler partitions the vector work |
 | `for aiv_id in pl.split_aiv(2, mode=...)` | Manual split — the author partitions it per region |
 | `optimizations=[pl.cross_core_slot(slot_num=N)]` | Neither — just sizes the cross-core pipe |
+
+**The function-level `split` attr has one encoding of "no split": an absent key.**
+When the outlined body holds `pl.split_aiv` regions, this pass bridges their mode
+onto the function only when all regions agree *and* that mode is a real split:
+
+| Regions in the body | Attrs stamped on the outlined function |
+| ------------------- | -------------------------------------- |
+| All `mode=UP_DOWN` (or all `LEFT_RIGHT`) | `{"split_aiv": True, "split": pl.SplitMode.UP_DOWN}` |
+| All `mode=NONE` | `{"split_aiv": True}` — no `split` key |
+| Differing modes | `{"split_aiv": True}` — no representative mode |
+
+`Function::GetSplitMode()` maps a stored `0` to `nullopt` exactly as it does an
+absent key, so a `split=SplitMode.NONE` entry was invisible to every consumer —
+and the parser drops it, which made print → parse lossy (`Kwargs size mismatch`).
+The authoritative per-region mode always rides `SplitAivScopeStmt::split_`, which
+[`LowerAutoVectorSplit`](20-lower_auto_vector_split.md) consumes. The printer
+applies the same rule as a backstop: it omits a `split` attr of `SplitMode.NONE`
+so IR that bypassed this pass (a pre-existing `.pto` blob, a programmatically
+built `Function`) still prints in the canonical, re-parsable form.

--- a/docs/zh/dev/passes/08-outline_incore_scopes.md
+++ b/docs/zh/dev/passes/08-outline_incore_scopes.md
@@ -248,3 +248,20 @@ passes.def("outline_incore_scopes", &pass::OutlineIncoreScopes, "Outline InCore 
 | `optimizations=[pl.split(MODE)]` | AUTO 拆分——由编译器划分向量计算 |
 | `for aiv_id in pl.split_aiv(2, mode=...)` | 手动拆分——由作者按区域划分 |
 | `optimizations=[pl.cross_core_slot(slot_num=N)]` | 都不是——仅决定跨核 pipe 的大小 |
+
+**函数级 `split` 属性对"不切分"只有一种编码：不存在该键。** 当被外提的函数体中含有
+`pl.split_aiv` 区域时，本 Pass 仅在所有区域模式一致 **且** 该模式是真实切分时，才把它
+提升为函数级属性：
+
+| 函数体中的区域 | 外提函数上标记的 attrs |
+| -------------- | ---------------------- |
+| 全部 `mode=UP_DOWN`（或全部 `LEFT_RIGHT`） | `{"split_aiv": True, "split": pl.SplitMode.UP_DOWN}` |
+| 全部 `mode=NONE` | `{"split_aiv": True}`——不带 `split` 键 |
+| 模式不一致 | `{"split_aiv": True}`——没有代表性模式 |
+
+`Function::GetSplitMode()` 把存储的 `0` 与缺失的键同样映射为 `nullopt`，因此
+`split=SplitMode.NONE` 这一项对所有消费方都不可见；而 parser 会在回读时丢弃它，导致
+print → parse 有损（`Kwargs size mismatch`）。权威的逐区域模式始终承载于
+`SplitAivScopeStmt::split_`，由 [`LowerAutoVectorSplit`](20-lower_auto_vector_split.md)
+消费。printer 以同一规则兜底：省略取值为 `SplitMode.NONE` 的 `split` 属性，使绕过本 Pass
+的 IR（此前写出的 `.pto`、以编程方式构造的 `Function`）依然以规范、可重新解析的形式打印。

--- a/include/pypto/ir/transforms/utils/scope_outline_utils.h
+++ b/include/pypto/ir/transforms/utils/scope_outline_utils.h
@@ -1129,11 +1129,19 @@ class ScopeOutliner : public IRMutator {
              "optimizations=[pl.cross_core_slot(slot_num=N)], which is orthogonal to splitting.";
       outlined_attrs.emplace_back("split_aiv", true);
       // Stamp a function-level representative ``split`` mode ONLY when all regions
-      // share one mode (``uniform_mode``). Differing sibling modes have no single
-      // representative: leave the function-level mode unset — the authoritative
-      // per-region mode rides ``node->split_`` (consumed at pass 20). No need to
-      // re-check incore_split here: the CHECK above guarantees it is None.
-      if (finder.uniform_mode.has_value()) {
+      // share one mode (``uniform_mode``) AND that mode is a real split. Differing
+      // sibling modes have no single representative: leave the function-level mode
+      // unset — the authoritative per-region mode rides ``node->split_`` (consumed
+      // at pass 20). No need to re-check incore_split here: the CHECK above
+      // guarantees it is None.
+      //
+      // ``SplitMode::None`` is excluded for the same reason the sibling
+      // ``append_split_attr`` excludes it: "no split" has ONE canonical encoding at
+      // the function-attr level — an absent key. ``Function::GetSplitMode`` maps a
+      // stored 0 to ``nullopt`` exactly as it does an absent key, so the entry is
+      // invisible to every consumer, while the parser drops it on the way back in —
+      // which made print -> parse lossy (``Kwargs size mismatch``).
+      if (finder.uniform_mode.has_value() && finder.uniform_mode.value() != SplitMode::None) {
         outlined_attrs.emplace_back("split", static_cast<int>(finder.uniform_mode.value()));
       }
     };

--- a/src/ir/transforms/python_printer.cpp
+++ b/src/ir/transforms/python_printer.cpp
@@ -2513,9 +2513,23 @@ void IRPythonPrinter::VisitFunction(const FunctionPtr& func) {
     // ``auto_scope`` rides in attrs_ but prints as a dedicated kwarg (and is
     // filtered from the attrs={...} dict). Absent ⇒ default True ⇒ not printed.
     bool auto_scope_off = !func->GetAttr<bool>("auto_scope", true);
-    auto is_filtered_attr_key = [](const std::string& k) { return k == "auto_scope"; };
+    // A ``split`` of ``SplitMode::None`` is filtered for a different reason: it is
+    // a non-canonical spelling of "no split" (``Function::GetSplitMode`` maps a
+    // stored 0 to ``nullopt``, exactly as an absent key does), and the parser drops
+    // it — so emitting it would make print -> parse lossy. No pass produces it; this
+    // only normalizes IR that bypassed them (a ``.pto`` blob written before
+    // OutlineIncoreScopes stopped stamping it, a programmatically built Function).
+    // The pointer form of ``any_cast`` keeps a mistyped attr failing at the
+    // existing print site rather than in this predicate, which also runs for the
+    // ``has_attrs`` test.
+    auto is_filtered_attr = [](const std::string& k, const std::any& v) {
+      if (k == "auto_scope") return true;
+      if (k != "split") return false;
+      const int* split_value = std::any_cast<int>(&v);
+      return split_value != nullptr && *split_value == static_cast<int>(SplitMode::None);
+    };
     bool has_attrs = std::any_of(func->attrs_.begin(), func->attrs_.end(),
-                                 [&](const auto& kv) { return !is_filtered_attr_key(kv.first); });
+                                 [&](const auto& kv) { return !is_filtered_attr(kv.first, kv.second); });
     auto print_func_attr_value = [&](const std::string& key, const std::any& value) {
       if (key == "split") {
         int split_value = AnyCast<int>(value, "func attr key: " + key);
@@ -2552,7 +2566,7 @@ void IRPythonPrinter::VisitFunction(const FunctionPtr& func) {
         stream_ << "attrs={";
         bool first_attr = true;
         for (const auto& [key, value] : func->attrs_) {
-          if (is_filtered_attr_key(key)) continue;
+          if (is_filtered_attr(key, value)) continue;
           if (!first_attr) stream_ << ", ";
           stream_ << std::quoted(key) << ": ";
           print_func_attr_value(key, value);

--- a/tests/ut/ir/printing/test_split_aiv_roundtrip.py
+++ b/tests/ut/ir/printing/test_split_aiv_roundtrip.py
@@ -354,5 +354,30 @@ def test_roundtrip_after_aiv_id_dce():
     ir.assert_structural_equal(prog, reparsed)
 
 
+def test_split_none_func_attr_is_not_printed():
+    """A function attr ``split=0`` is a non-canonical "no split" and must not print.
+
+    ``Function::GetSplitMode`` maps a stored 0 to ``None`` exactly as it does an
+    absent key, and the parser drops an explicit ``pl.SplitMode.NONE``, so printing
+    it would make print -> parse lossy. No pass produces this shape any more (the
+    outliner stopped stamping a NONE), which is why the Function is built directly
+    here — the printer must still normalize IR that bypassed the passes, such as a
+    ``.pto`` blob written before that change.
+    """
+    span = ir.Span.unknown()
+    func = ir.Function("f", [], [], ir.SeqStmts([], span), span, attrs={"split": 0})
+    assert dict(func.attrs) == {"split": 0}, "the Function must actually carry the attr"
+    assert func.split is None, "GetSplitMode already treats a stored 0 as unset"
+
+    text = ir.python_print(ir.Program([func], "P", span))
+
+    assert "SplitMode.NONE" not in text, text
+    # ``split`` was the only entry, so no empty ``attrs={}`` may be emitted either.
+    assert "attrs=" not in text, text
+    # A real mode is unaffected.
+    real = ir.Function("g", [], [], ir.SeqStmts([], span), span, attrs={"split": ir.SplitMode.UP_DOWN.value})
+    assert 'attrs={"split": pl.SplitMode.UP_DOWN}' in ir.python_print(ir.Program([real], "P", span))
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/ir/transforms/test_lower_auto_vector_split.py
+++ b/tests/ut/ir/transforms/test_lower_auto_vector_split.py
@@ -42,8 +42,7 @@ IR, so Before/Expected does not apply. Their ``Before`` programs are still DSL.
 
 ``_lower`` keeps the print->parse roundtrip instrument ON (see its docstring for
 why property verification is not), so the pass's output is asserted
-round-trippable on every test but one — ``test_outlined_region_still_lowers_and_stamps``,
-which opts out over an unrelated attr printer/parser gap documented at that test.
+round-trippable on every test.
 
 End-to-end DSL coverage of this authoring form lives in
 ``tests/st/codegen/torch/test_torch_codegen_cross_core.py``
@@ -2414,20 +2413,21 @@ def test_outlined_region_still_lowers_and_stamps():
     )
     pl.parse_program(ir.python_print(outlined))  # outlined program round-trips
 
-    # Still the one test that cannot use ``_lower``, but for a narrower and
-    # unrelated reason: a ``pl.split_aiv`` region with ``mode=NONE`` stamps the
-    # function attr ``split=pl.SplitMode.NONE``, and the parser drops an explicit
-    # NONE, so print->parse loses that attr and structural equality reports
-    # "Kwargs size mismatch". That is a printer/parser gap on the attr, present
-    # on the ConvertToSSA-prefixed path too and independent of this pass.
-    with passes.PassContext([]):
-        after = passes.lower_auto_vector_split()(outlined)
+    # Uses ``_lower`` like every other test here, so the roundtrip instrument
+    # guards this path too. It used to opt out: a ``mode=NONE`` region made
+    # OutlineIncoreScopes stamp ``split=pl.SplitMode.NONE`` on the function, and
+    # the parser drops an explicit NONE, so print->parse lost that attr and
+    # structural equality reported "Kwargs size mismatch". The outliner no longer
+    # stamps a NONE (absence is the canonical encoding of "no split"), so the
+    # lowered output — region erased — now round-trips exactly.
+    after = _lower(outlined)
 
     incore = [f for f in after.functions.values() if f.func_type == ir.FunctionType.InCore]
     assert len(incore) == 1, "OutlineIncoreScopes should have produced one InCore function"
     assert "pl.split_aiv" not in ir.python_print(after), "region must be erased"
-    for key, value in _REGION_ATTRS.items():
-        assert incore[0].attrs.get(key) == value, f"expected {key}={value}"
+    assert dict(incore[0].attrs) == _REGION_ATTRS, (
+        f"expected exactly {_REGION_ATTRS}, got {dict(incore[0].attrs)}"
+    )
 
 
 if __name__ == "__main__":

--- a/tests/ut/ir/transforms/test_outline_incore_scopes.py
+++ b/tests/ut/ir/transforms/test_outline_incore_scopes.py
@@ -1841,6 +1841,68 @@ class TestOutlineNoDepArgs:
             f"aiv_id must not be promoted to an outlined param, got params {param_names}"
         )
 
+    @staticmethod
+    def _outline_incore(program: ir.Program) -> ir.Function:
+        """Outline ``program`` and return its single InCore function."""
+        with passes.PassContext([]):
+            After = passes.outline_incore_scopes()(program)
+        return next(f for f in After.functions.values() if f.func_type == ir.FunctionType.InCore)
+
+    def test_split_aiv_none_region_stamps_no_function_level_split(self):
+        """A uniform ``mode=NONE`` region set stamps ``split_aiv`` alone.
+
+        "No split" has a single canonical encoding at the function-attr level: an
+        absent key. ``Function::GetSplitMode`` maps a stored 0 to ``None`` exactly
+        as it does an absent key, so an explicit ``split=SplitMode.NONE`` was
+        invisible to every consumer — while the parser dropped it on the way back
+        in, making print -> parse lossy (``Kwargs size mismatch``). Asserted as
+        exact dict equality: the defect was an EXTRA entry, which a per-key
+        ``.get()`` check would not have caught.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(
+                self,
+                a: pl.Tensor[[128, 128], pl.FP32],
+                c: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
+            ) -> pl.Tensor[[128, 128], pl.FP32]:
+                for aiv_id in pl.split_aiv(2, mode=pl.SplitMode.NONE):
+                    base = aiv_id * 64
+                    c = pl.store(pl.exp(pl.load(a, [base, 0], [64, 128])), [base, 0], c)
+                return c
+
+        outlined = self._outline_incore(Before)
+
+        assert dict(outlined.attrs) == {"split_aiv": True}
+        assert outlined.split is None
+
+    def test_split_aiv_up_down_region_stamps_function_level_split(self):
+        """Control for the NONE case: a real mode is still bridged to the function.
+
+        Pins that the NONE exclusion above is narrow — dropping a genuine
+        representative mode would silently strip the whole-function marker that
+        SplitVectorKernel keys on.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(
+                self,
+                a: pl.Tensor[[128, 128], pl.FP32],
+                c: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
+            ) -> pl.Tensor[[128, 128], pl.FP32]:
+                for aiv_id in pl.split_aiv(2, mode=pl.SplitMode.UP_DOWN):
+                    c = pl.store(pl.exp(pl.load(a, [0, 0], [128, 128])), [0, 0], c)
+                return c
+
+        outlined = self._outline_incore(Before)
+
+        assert dict(outlined.attrs) == {"split_aiv": True, "split": ir.SplitMode.UP_DOWN.value}
+        assert outlined.split == ir.SplitMode.UP_DOWN
+
 
 class TestOutlineReboundOutCapture:
     """A captured ``pl.Out`` tensor the scope rebinds under its own name.
@@ -1924,12 +1986,17 @@ class TestOutlineReboundOutCapture:
     def test_rebound_out_capture_in_split_aiv_region_reparses(self):
         """The originally-reported shape: the region form used to leave ``c`` free.
 
-        Asserts parseability only, not structural equality: a ``pl.split_aiv``
-        region with ``mode=NONE`` stamps the function attr
-        ``split=pl.SplitMode.NONE``, which the parser drops on the way back in.
-        That attr gap is unrelated to the capture fix (it reproduces on the
-        ConvertToSSA-prefixed path too) — see the sibling assertion in
-        ``test_lower_auto_vector_split.py::test_outlined_region_still_lowers_and_stamps``.
+        Asserts parseability only, not structural equality — but no longer over the
+        ``split=pl.SplitMode.NONE`` attr, which the outliner has stopped stamping.
+        What remains is the surviving region node itself: the parser wraps a
+        top-level ``pl.split_aiv`` in an ``InCoreScopeStmt`` whenever an InCore
+        scope is open, so re-parsing this *outlined* function (which the pass
+        declines to re-enter, being already InCore) re-introduces a
+        ``with pl.at(level=pl.Level.CORE_GROUP):`` the original does not have. That
+        is the separate ``pl.split_aiv``-inside-InCore gap, unrelated to the capture
+        fix. Once the region is erased the output does round-trip structurally —
+        asserted by ``test_lower_auto_vector_split.py::
+        test_outlined_region_still_lowers_and_stamps``.
         """
 
         @pl.program


### PR DESCRIPTION
## Summary
- stamp the function-level `split` attr in OutlineIncoreScopes only for a
real split mode, matching every sibling producer of that attr
- omit a `split` attr of `SplitMode::None` in the python printer, so IR that
bypassed the pass still prints in a re-parsable form
- re-enable the print -> parse roundtrip instrument on the outlined-region
lowering test and pin the stamped attrs with exact equality

## Motivation
`OutlineIncoreScopes::append_split_aiv_attr` bridged a uniform
`pl.split_aiv` region mode onto the outlined InCore function even when that
mode was `SplitMode::None`. Every other writer of the attr already guards
against None: the sibling `append_split_attr`, `WithSplitAttrs`,
`WithSplitAivAttrs`, the `.pto` legacy-field path, and both parser paths.

`Function::GetSplitMode` maps a stored 0 to `nullopt` exactly as it does an
absent key, so the entry was invisible to every consumer. The parser drops an
explicit `pl.SplitMode.NONE`, so the attr dict shrank across print -> parse
and `assert_structural_equal` reported `Kwargs size mismatch`. That blocked
the roundtrip instrument for any program containing a `mode=NONE` region.

Absence is now the single canonical encoding of "no split" at the
function-attr level. Behaviour is unchanged for `UP_DOWN`, `LEFT_RIGHT`, and
differing sibling modes, which already produced the same `GetSplitMode`
result before and after.

## Testing
- cmake --build build --parallel
- pre-commit run --all-files (15/15 hooks pass)
- python -m pytest tests/ut/ -n auto --maxprocesses 8 (9050 passed, 2
skipped; the single failure is the pre-existing `test_ir_trace`
console-script check that requires a pip-installed PyPTO)
- python -m pytest tests/st/codegen/dsl/test_split_aiv_none_codegen.py
tests/st/codegen/dsl/test_split_aiv_gather_row_codegen.py (4 passed)
- each new assertion was confirmed to fail with the two C++ changes reverted

