### PR TITLE
fix(parser): emit 1-indexed character columns in Span

### DIFF
--- a/docs/en/dev/ir/07-parser.md
+++ b/docs/en/dev/ir/07-parser.md
@@ -130,6 +130,23 @@ return result  # OK
 - Each IR node includes `Span` with filename, line/column ranges
 - Enables debugging, error reporting, and source-to-IR mapping
 
+**Coordinate conversion** (`span_tracker.ast_column_to_span_column`): `ast` nodes
+and `ir.Span` use different column conventions, so the parser converts at the
+boundary:
+
+| Aspect | `ast` node | `ir.Span` |
+| ------ | ---------- | --------- |
+| Line | 1-indexed (`lineno`) | 1-indexed (`begin_line`) |
+| Column | **0**-indexed (`col_offset`) | **1**-indexed (`begin_column`) |
+| Column unit | UTF-8 **bytes** | **characters** |
+
+CPython makes the same shift when it turns an internal `col_offset` into the
+reported `SyntaxError.offset`. Both aspects matter: the `+1` keeps a left-margin
+node out of `Span::is_valid()`'s rejected `column <= 0` range, and the
+byte-to-character conversion keeps the column pointing at its token on lines
+containing non-ASCII text. The inverse conversion happens once on the consumer
+side, in `ErrorRenderer._caret_index`, before any column indexes a source line.
+
 **Source-map provenance** (`pl.parse(code, source_map=...)`): When `code` is
 *generated* from another source — as `@pl.jit` does, re-deriving a kernel into a
 `@pl.program` string via `ast.unparse` — a `generated_line → (orig_file,

--- a/docs/zh/dev/ir/07-parser.md
+++ b/docs/zh/dev/ir/07-parser.md
@@ -130,6 +130,21 @@ return result  # OK
 - 每个 IR 节点包含带有文件名、行/列范围的 `Span`
 - 支持调试、错误报告和源码到 IR 的映射
 
+**坐标转换 (coordinate conversion)**（`span_tracker.ast_column_to_span_column`）：
+`ast` 节点与 `ir.Span` 使用不同的列约定，因此解析器在边界处完成转换：
+
+| 维度 | `ast` 节点 | `ir.Span` |
+| ---- | ---------- | --------- |
+| 行 | 从 1 开始（`lineno`） | 从 1 开始（`begin_line`） |
+| 列 | 从 **0** 开始（`col_offset`） | 从 **1** 开始（`begin_column`） |
+| 列单位 | UTF-8 **字节** | **字符** |
+
+CPython 在把内部 `col_offset` 转换为对外报告的 `SyntaxError.offset` 时做的是同样的偏移。
+两个方面都很重要：`+1` 使位于行首的节点不落入 `Span::is_valid()` 拒绝的 `column <= 0`
+区间；字节到字符的转换则保证在包含非 ASCII 文本的行上，列仍然指向对应的 token。
+逆向转换只在消费侧发生一次 —— 位于 `ErrorRenderer._caret_index`，在任何列被用于索引
+源码行之前。
+
 **源码映射溯源 (source-map provenance)**（`pl.parse(code, source_map=...)`）：当 `code`
 是从其他源码*生成*的 —— 例如 `@pl.jit` 通过 `ast.unparse` 将 kernel 重新生成为
 `@pl.program` 字符串 —— 一个 `generated_line → (orig_file, orig_line, orig_col)`

--- a/include/pypto/ir/builder.h
+++ b/include/pypto/ir/builder.h
@@ -53,7 +53,7 @@ class IfStmtContext;
  * Example usage (C++):
  * @code
  * IRBuilder builder;
- * auto span = Span(__FILE__, __LINE__, 0);
+ * auto span = Span(__FILE__, __LINE__, 1);
  * builder.BeginFunction("my_func", span);
  * auto x = builder.FuncArg("x", ScalarType::Create(DataType::INT64), span);
  * builder.ReturnType(ScalarType::Create(DataType::INT64));

--- a/python/pypto/debug/torch_codegen.py
+++ b/python/pypto/debug/torch_codegen.py
@@ -1170,25 +1170,27 @@ class TorchCodegen(_ir.IRVisitor):
         """Build a stable key for nanobind-backed IR vars.
 
         IR callbacks may wrap the same underlying C++ Var with different Python
-        objects, so ``id(var)`` alone is not stable across visits. We key by
-        semantic fields that remain stable across wrappers.
-        """
-        span = getattr(var, "span", None)
-        span_key: tuple[Any, ...] | None = None
-        if span is not None and getattr(span, "is_valid", False):
-            span_key = (
-                getattr(span, "filename", ""),
-                int(getattr(span, "begin_line", 0)),
-                int(getattr(span, "begin_column", 0)),
-                int(getattr(span, "end_line", 0)),
-                int(getattr(span, "end_column", 0)),
-            )
+        objects, so ``id(var)`` alone is not stable across visits. ``Var`` carries
+        a ``unique_id`` for exactly this purpose -- a process-unique counter
+        assigned at construction, documented as the key to use when deduplicating
+        wrappers of the same underlying object. ``IterArg`` shares the counter.
 
+        Keying on it is both stricter and looser than the surrounding fields in
+        the ways we need: two wrappers of one Var always agree, and two distinct
+        Vars never collide, including when both carry ``Span.unknown()`` and the
+        same name and type -- a case name/type/span fields cannot separate.
+        """
+        unique_id = getattr(var, "unique_id", None)
+        if unique_id is not None:
+            return (type(var).__name__, int(unique_id))
+
+        # No identity available (a non-Var duck type): fall back to the
+        # descriptive fields rather than merging everything onto one key.
         var_type = getattr(var, "type", None)
         return (
             type(var).__name__,
             getattr(var, "name_hint", ""),
-            span_key,
+            id(var),
             str(var_type) if var_type is not None else "",
         )
 

--- a/python/pypto/language/parser/decorator.py
+++ b/python/pypto/language/parser/decorator.py
@@ -1232,8 +1232,10 @@ def program(cls: type | None = None, *, strict_ssa: bool = False) -> ir.Program 
             # Combine internal and external functions
             all_functions = functions + list(external_functions.values())
 
-            # Create Program with class name and span
-            program_span = ir.Span(source_file, starting_line, col_offset)
+            # Create Program with class name and span. ``col_offset`` is the
+            # class's indentation as a character count; Span columns are
+            # 1-indexed, so a class at the left margin starts at column 1.
+            program_span = ir.Span(source_file, starting_line, col_offset + 1)
             prog = ir.Program(all_functions, c.__name__, program_span)
 
             return prog

--- a/python/pypto/language/parser/diagnostics/renderer.py
+++ b/python/pypto/language/parser/diagnostics/renderer.py
@@ -145,6 +145,9 @@ class ErrorRenderer:
     def _extract_span_info(self, span) -> tuple[str, int, int]:
         """Extract filename, line, and column from a span (dict or object).
 
+        The returned column is the span's own 1-indexed column; use
+        :meth:`_caret_index` before indexing into a source line with it.
+
         Args:
             span: Span object or dictionary
 
@@ -160,6 +163,22 @@ class ErrorRenderer:
             line = getattr(span, "begin_line", getattr(span, "line", 0))
             column = getattr(span, "begin_column", getattr(span, "column", 0))
         return filename, line, column
+
+    @staticmethod
+    def _caret_index(column: int) -> int:
+        """Convert a 1-indexed ``Span`` column to a 0-based index into a source line.
+
+        ``Span`` columns are 1-indexed characters (``include/pypto/ir/span.h``);
+        every caret and padding calculation below indexes a Python ``str``, so
+        the conversion happens once, here.
+
+        Args:
+            column: 1-indexed span column (0 for "unknown")
+
+        Returns:
+            0-based character index, clamped at the start of the line
+        """
+        return max(0, column - 1)
 
     def _format_location(self, span) -> str:
         """Format a span as a file:line:column location string.
@@ -207,7 +226,7 @@ class ErrorRenderer:
         # Show previous definition code context
         prev_source = self._source_lines_for(prev_file, error.source_lines)
         if prev_source and prev_line <= len(prev_source):
-            lines.extend(self._render_previous_context(prev_source, prev_line, prev_col))
+            lines.extend(self._render_previous_context(prev_source, prev_line, self._caret_index(prev_col)))
 
         return lines
 
@@ -217,7 +236,7 @@ class ErrorRenderer:
         Args:
             source_lines: Full source code lines
             line_num: Line number of previous definition
-            column: Column number of previous definition
+            column: 0-based character index into the line (see _caret_index)
 
         Returns:
             List of formatted lines
@@ -256,7 +275,7 @@ class ErrorRenderer:
 
         Args:
             line_content: Source line content
-            column: Column position
+            column: 0-based character index into the line (see _caret_index)
             line_num_width: Width for line number alignment
 
         Returns:
@@ -365,7 +384,9 @@ class ErrorRenderer:
 
             if line_num == error_line:
                 lines.append(f"{formatted_line_num} {line_content}")
-                caret_line = self._render_caret_line(line_content, error_col, line_num_width, error.message)
+                caret_line = self._render_caret_line(
+                    line_content, self._caret_index(error_col), line_num_width, error.message
+                )
                 lines.append(caret_line)
             else:
                 lines.append(f"{formatted_line_num} {line_content}")
@@ -380,7 +401,7 @@ class ErrorRenderer:
 
         Args:
             source_line: Source code line
-            column: Column position (0-based)
+            column: 0-based character index into the line (see _caret_index)
             line_num_width: Width of line numbers for alignment
             message: Short error message to display
 

--- a/python/pypto/language/parser/span_tracker.py
+++ b/python/pypto/language/parser/span_tracker.py
@@ -25,6 +25,34 @@ active_source_map: ContextVar[dict[int, tuple[str, int, int]] | None] = ContextV
 )
 
 
+def ast_column_to_span_column(line: str | None, col_offset: int) -> int:
+    """Convert a 0-indexed AST ``col_offset`` to a 1-indexed ``Span`` column.
+
+    Two coordinate systems meet here. An ``ast`` node carries a 1-indexed
+    ``lineno`` but a 0-indexed ``col_offset``, and that offset counts **UTF-8
+    bytes** rather than characters -- a multi-byte character earlier on the line
+    shifts it right. ``ir.Span`` columns are 1-indexed *character* positions
+    (``include/pypto/ir/span.h``), which is what editors, ``Span::to_string()``
+    and the diagnostics renderer expect. CPython makes the same conversion when
+    it turns an internal ``col_offset`` into the reported ``SyntaxError.offset``.
+
+    Args:
+        line: The source line the offset refers to, used to translate the byte
+            offset into a character index. ``None`` when the line is not
+            available; the offset is then used as-is, which is exact for
+            ASCII-only lines.
+        col_offset: 0-indexed UTF-8 byte offset taken from an AST node.
+
+    Returns:
+        The 1-indexed character column to store in an ``ir.Span``.
+    """
+    if line is None:
+        return col_offset + 1
+    # ``errors="ignore"`` guards against an offset landing mid-sequence; valid
+    # AST offsets are always on a character boundary.
+    return len(line.encode("utf-8")[:col_offset].decode("utf-8", errors="ignore")) + 1
+
+
 class SpanTracker:
     """Tracks source locations from AST nodes to IR spans."""
 
@@ -42,7 +70,8 @@ class SpanTracker:
             source_file: Path to the source file
             source_lines: List of source code lines (dedented for parsing)
             line_offset: Line number offset to add to AST line numbers (for dedented code)
-            col_offset: Column offset to add to AST column numbers (for dedented code)
+            col_offset: Column offset in *characters* to add to AST column numbers,
+                restoring the indentation stripped before ``ast.parse``
             source_map: Optional generated-line → ``(orig_file, orig_line,
                 orig_col)`` map. When a node's emitted line is present, the span
                 is remapped to that original location (#1612). Defaults to the
@@ -57,6 +86,10 @@ class SpanTracker:
     def get_span(self, ast_node: ast.AST | None) -> ir.Span:
         """Extract span from AST node.
 
+        Columns are converted from the AST's 0-indexed byte offsets to the
+        1-indexed character columns ``ir.Span`` documents -- see
+        :func:`ast_column_to_span_column`.
+
         Args:
             ast_node: AST node with line/column information
 
@@ -66,7 +99,9 @@ class SpanTracker:
         if ast_node is None or not hasattr(ast_node, "lineno"):
             return ir.Span.unknown()
 
-        begin_line = getattr(ast_node, "lineno", 0) + self.line_offset
+        begin_lineno = getattr(ast_node, "lineno", 0)
+        end_lineno = getattr(ast_node, "end_lineno", 0)
+        begin_line = begin_lineno + self.line_offset
         remapped = self._remap(begin_line)
         if remapped is not None:
             return remapped
@@ -74,9 +109,9 @@ class SpanTracker:
         return ir.Span(
             self.source_file,
             begin_line,
-            getattr(ast_node, "col_offset", 0) + self.col_offset,
-            getattr(ast_node, "end_lineno", 0) + self.line_offset,
-            getattr(ast_node, "end_col_offset", 0) + self.col_offset,
+            self._span_column(begin_lineno, getattr(ast_node, "col_offset", 0)),
+            end_lineno + self.line_offset,
+            self._span_column(end_lineno, getattr(ast_node, "end_col_offset", 0)),
         )
 
     def get_multiline_span(self, start_node: ast.AST, end_node: ast.AST) -> ir.Span:
@@ -92,7 +127,9 @@ class SpanTracker:
         if not hasattr(start_node, "lineno") or not hasattr(end_node, "lineno"):
             return ir.Span.unknown()
 
-        begin_line = getattr(start_node, "lineno", 0) + self.line_offset
+        begin_lineno = getattr(start_node, "lineno", 0)
+        end_lineno = getattr(end_node, "end_lineno", 0)
+        begin_line = begin_lineno + self.line_offset
         remapped = self._remap(begin_line)
         if remapped is not None:
             return remapped
@@ -100,10 +137,32 @@ class SpanTracker:
         return ir.Span(
             self.source_file,
             begin_line,
-            getattr(start_node, "col_offset", 0) + self.col_offset,
-            getattr(end_node, "end_lineno", 0) + self.line_offset,
-            getattr(end_node, "end_col_offset", 0) + self.col_offset,
+            self._span_column(begin_lineno, getattr(start_node, "col_offset", 0)),
+            end_lineno + self.line_offset,
+            self._span_column(end_lineno, getattr(end_node, "end_col_offset", 0)),
         )
+
+    def _span_column(self, ast_lineno: int, col_offset: int) -> int:
+        """Convert an AST ``(lineno, col_offset)`` pair to a 1-indexed Span column.
+
+        ``self.col_offset`` (the indentation stripped before ``ast.parse``) is a
+        character count, so it is added after the byte-to-character conversion.
+
+        Args:
+            ast_lineno: 1-indexed AST line number, *before* ``line_offset`` is
+                applied -- it indexes into the dedented ``source_lines``.
+            col_offset: 0-indexed UTF-8 byte offset from the AST node.
+
+        Returns:
+            The 1-indexed character column in the original source file.
+        """
+        return ast_column_to_span_column(self._line_at(ast_lineno), col_offset) + self.col_offset
+
+    def _line_at(self, ast_lineno: int) -> str | None:
+        """Return the dedented source line for a 1-indexed AST line number, if known."""
+        if 1 <= ast_lineno <= len(self.source_lines):
+            return self.source_lines[ast_lineno - 1]
+        return None
 
     def _remap(self, begin_line: int) -> ir.Span | None:
         """Remap a generated begin line to an original-source span, or None.
@@ -112,6 +171,11 @@ class SpanTracker:
         (e.g. a synthesized statement) — the caller then emits the generated
         coordinates. The mapped span underlines from the statement's original
         start column (#1612: alpha-renaming makes exact end columns unreliable).
+
+        Map entries hold AST coordinates, so the column needs the same
+        0-to-1-indexed shift as any other span. No byte-to-character correction
+        is applied: an entry's column is a *statement* start, whose prefix is
+        pure ASCII indentation, so its byte and character offsets coincide.
         """
         if not self.source_map:
             return None
@@ -119,7 +183,8 @@ class SpanTracker:
         if mapped is None:
             return None
         orig_file, orig_line, orig_col = mapped
-        return ir.Span(orig_file, orig_line, orig_col, orig_line, orig_col)
+        column = ast_column_to_span_column(None, orig_col)
+        return ir.Span(orig_file, orig_line, column, orig_line, column)
 
 
-__all__ = ["SpanTracker", "active_source_map"]
+__all__ = ["SpanTracker", "active_source_map", "ast_column_to_span_column"]

--- a/python/pypto/language/parser/text_parser.py
+++ b/python/pypto/language/parser/text_parser.py
@@ -18,7 +18,22 @@ from pypto.pypto_core import ir
 
 from .diagnostics.exceptions import ParserError, ParserSyntaxError
 from .enum_utils import FUNCTION_TYPE_MAP, LEVEL_MAP, ROLE_MAP
-from .span_tracker import active_source_map
+from .span_tracker import active_source_map, ast_column_to_span_column
+
+
+def _span_column(source_lines: list[str], lineno: int, col_offset: int) -> int:
+    """Convert an AST ``col_offset`` on ``lineno`` to a 1-indexed ``Span`` column.
+
+    Args:
+        source_lines: Lines of the code being parsed, in AST coordinates.
+        lineno: 1-indexed AST line number the offset belongs to.
+        col_offset: 0-indexed UTF-8 byte offset from the AST node.
+
+    Returns:
+        The 1-indexed character column to store in an ``ir.Span``.
+    """
+    line = source_lines[lineno - 1] if 1 <= lineno <= len(source_lines) else None
+    return ast_column_to_span_column(line, col_offset)
 
 
 def _extract_exec_error_line(tb, filename: str) -> int | None:
@@ -112,10 +127,12 @@ def _validate_enum_kwarg(
 
     attr_name = value.attr
     if attr_name not in enum_map:
-        # Column: end_col_offset − len(attr) gives start of the attribute name
+        # Column: end_col_offset − len(attr) gives start of the attribute name.
+        # end_col_offset counts UTF-8 bytes, so the attribute's *byte* length is
+        # the right subtrahend — Python allows non-ASCII identifiers.
         line = getattr(value, "lineno", 0)
-        col = max(0, getattr(value, "end_col_offset", 0) - len(attr_name))
-        span = ir.Span(filename, line, col)
+        col = max(0, getattr(value, "end_col_offset", 0) - len(attr_name.encode("utf-8")))
+        span = ir.Span(filename, line, _span_column(source_lines, line, col))
         raise ParserSyntaxError(
             f"Unknown {enum_name} value: {attr_name}",
             span=span,
@@ -133,7 +150,7 @@ def _validate_enum_kwarg(
     if not valid_prefix:
         line = getattr(value, "lineno", 0)
         col = getattr(value, "col_offset", 0)
-        span = ir.Span(filename, line, col)
+        span = ir.Span(filename, line, _span_column(source_lines, line, col))
         raise ParserSyntaxError(
             f"Expected {qualified}.<name>",
             span=span,
@@ -249,7 +266,8 @@ def parse(
         # Convert exec-time errors to ParserSyntaxError with source location when possible.
         line_num = _extract_exec_error_line(e.__traceback__, filename)
         if line_num is not None:
-            span = ir.Span(filename, line_num, 0)
+            # Exact column unknown — point at the first column of the line.
+            span = ir.Span(filename, line_num, 1)
             raise ParserSyntaxError(
                 f"{type(e).__name__}: {e}",
                 span=span,

--- a/tests/ut/debug/test_torch_codegen.py
+++ b/tests/ut/debug/test_torch_codegen.py
@@ -1404,5 +1404,60 @@ def test_variable_name_uniquing():
     assert cg._unique_name("a") == "a_2"
 
 
+def test_var_semantic_key_separates_unknown_span_vars():
+    """Two distinct vars must not share a key, even with no source location.
+
+    The regression this guards: keying on name/type/span merged two unknown-span
+    vars that agreed on name and type, so ``_name_of`` handed them one generated
+    name and the emitted Torch code could merge their values.
+    """
+    type_ = ir.ScalarType(DataType.INT64)
+    a = ir.Var("x", type_, ir.Span.unknown())
+    b = ir.Var("x", type_, ir.Span.unknown())
+
+    assert TorchCodegen._var_semantic_key(a) != TorchCodegen._var_semantic_key(b)
+
+
+def test_var_semantic_key_carries_no_span_coordinates():
+    """The key must not embed span coordinates at all.
+
+    An unknown span used to contribute the sentinel ("", -1, -1, -1, -1), which
+    reads as a real source location. Identity now comes from ``unique_id``, so
+    no span tuple — real or sentinel — belongs in the key.
+    """
+    var = ir.Var("x", ir.ScalarType(DataType.INT64), ir.Span("f.py", 3, 7, 3, 9))
+
+    key = TorchCodegen._var_semantic_key(var)
+
+    assert ("f.py", 3, 7, 3, 9) not in key
+    assert ("", -1, -1, -1, -1) not in key
+    assert var.unique_id in key
+
+
+def test_var_semantic_key_is_stable_across_wrappers():
+    """Two Python wrappers of one underlying Var must agree.
+
+    This is the property the key exists for: ``id(var)`` is not stable across
+    visits, so a per-wrapper identity would split one variable into two names.
+    """
+    type_ = ir.ScalarType(DataType.INT64)
+    a = ir.Var("x", type_, ir.Span.unknown())
+    add = ir.Add(a, a, DataType.INT64, ir.Span.unknown())
+    left, right = add.left, add.right
+    assert isinstance(left, ir.Var) and isinstance(right, ir.Var)
+
+    assert TorchCodegen._var_semantic_key(left) == TorchCodegen._var_semantic_key(a)
+    assert TorchCodegen._var_semantic_key(right) == TorchCodegen._var_semantic_key(a)
+
+
+def test_var_semantic_key_distinguishes_spans():
+    """Same name and type, different vars -> different keys."""
+    type_ = ir.ScalarType(DataType.INT64)
+    a = ir.Var("x", type_, ir.Span("f.py", 1, 1, 1, 2))
+    b = ir.Var("x", type_, ir.Span("f.py", 9, 1, 9, 2))
+
+    assert TorchCodegen._var_semantic_key(a) != TorchCodegen._var_semantic_key(b)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/language/parser/test_diagnostics_renderer.py
+++ b/tests/ut/language/parser/test_diagnostics_renderer.py
@@ -20,6 +20,11 @@ def renderer() -> ErrorRenderer:
 
 
 def _make_error(message: str, line: str, column: int, hint: str | None = None) -> ParserSyntaxError:
+    """Build a rendered-error fixture.
+
+    ``column`` is a *span* column, i.e. 1-indexed, matching what the parser
+    emits. The renderer converts it to a 0-based string index internally.
+    """
     err = ParserSyntaxError(message, hint=hint)
     err.span = {"filename": "test.py", "begin_line": 1, "begin_column": column, "line": 1, "column": column}
     err.source_lines = [line]
@@ -62,7 +67,7 @@ class TestInlineMessage:
         """
         message = "For loop must use pl.range(), pl.parallel(), pl.unroll(), pl.pipeline(), or pl.while_()"
         line = " " * 10 + "pl.piepline(x):"
-        err = _make_error(message, line, column=10)
+        err = _make_error(message, line, column=11)  # 1-indexed: token at 0-based 10
         rendered = renderer.render(err)
 
         assert "For loop must use pl\n" not in rendered
@@ -73,7 +78,7 @@ class TestInlineMessage:
         """For short messages, the first real sentence is still used."""
         message = "Variable x not defined. Expected an assignment first."
         line = "x + 1"
-        err = _make_error(message, line, column=0)
+        err = _make_error(message, line, column=1)
         rendered = renderer.render(err)
 
         caret_row = next(row for row in rendered.split("\n") if "^" in row)
@@ -85,10 +90,47 @@ class TestInlineMessage:
         should be emitted in full (when short enough), not truncated."""
         message = "Missing argument for module.attr call"
         line = "module.attr()"
-        err = _make_error(message, line, column=0)
+        err = _make_error(message, line, column=1)
         rendered = renderer.render(err)
 
         assert "Missing argument for module.attr call" in rendered
+
+
+class TestCaretColumnConvention:
+    """The renderer consumes 1-indexed span columns (``include/pypto/ir/span.h``).
+
+    It converts once via ``_caret_index``; every caret/padding calculation
+    downstream is a 0-based index into the source line.
+    """
+
+    def test_caret_sits_under_the_token(self, renderer: ErrorRenderer):
+        line = "        y = pl.add(x, x)"
+        column = line.index("pl.add") + 1  # 1-indexed span column
+
+        rendered = renderer.render(_make_error("unknown op", line, column=column))
+
+        rows = rendered.split("\n")
+        caret_idx = next(i for i, row in enumerate(rows) if "^" in row)
+        source_row, caret_row = rows[caret_idx - 1], rows[caret_idx]
+
+        # Both rows carry the same gutter, so the caret must start at the very
+        # column the token occupies in the rendered source row above it.
+        assert caret_row.index("^") == source_row.index("pl.add"), (
+            f"caret misaligned\n{source_row}\n{caret_row}"
+        )
+        assert "^" * len("pl.add") in caret_row
+
+    def test_column_one_carets_the_first_character(self, renderer: ErrorRenderer):
+        rendered = renderer.render(_make_error("bad name", "module.attr()", column=1))
+
+        caret_row = next(row for row in rendered.split("\n") if "^" in row)
+        assert "^" * len("module.attr") in caret_row
+
+    def test_location_header_keeps_column_one(self, renderer: ErrorRenderer):
+        """Column 1 must survive into the header; only 0 ('unknown') is dropped."""
+        rendered = renderer.render(_make_error("bad name", "module.attr()", column=1))
+
+        assert "test.py:1:1" in rendered
 
 
 class TestRealFileSnippet:
@@ -107,9 +149,9 @@ class TestRealFileSnippet:
         err.span = {
             "filename": str(real),
             "begin_line": 2,
-            "begin_column": 0,
+            "begin_column": 1,
             "line": 2,
-            "column": 0,
+            "column": 1,
         }
         # Deliberately wrong/generated source lines: linecache must take priority.
         err.source_lines = ["t_v1 = pl.mul(t_v1, t_v1)"]
@@ -126,9 +168,9 @@ class TestRealFileSnippet:
         err.span = {
             "filename": "<jit:kernel>",
             "begin_line": 1,
-            "begin_column": 0,
+            "begin_column": 1,
             "line": 1,
-            "column": 0,
+            "column": 1,
         }
         err.source_lines = ["t_v1 = pl.mul(t_v1, t_v1)"]
 
@@ -150,9 +192,9 @@ class TestRealFileSnippet:
         err.span = {
             "filename": str(real),
             "begin_line": 2,
-            "begin_column": 0,
+            "begin_column": 1,
             "line": 2,
-            "column": 0,
+            "column": 1,
         }
         err.source_lines = None  # no captured source — only the remapped span
 

--- a/tests/ut/language/parser/test_error_cases.py
+++ b/tests/ut/language/parser/test_error_cases.py
@@ -496,7 +496,8 @@ class TestSourceLocationPreservation:
         assert span is not None, "ParserError must carry a span for location preservation"
         assert span["filename"], f"span filename must be non-empty, got {span['filename']!r}"
         assert span["begin_line"] > 0, f"span begin_line must be > 0, got {span['begin_line']}"
-        assert span["begin_column"] >= 0, f"span begin_column must be >= 0, got {span['begin_column']}"
+        # Span columns are 1-indexed, so 0 is not a legal column.
+        assert span["begin_column"] >= 1, f"span begin_column must be >= 1, got {span['begin_column']}"
 
     def test_unsupported_type_annotation_carries_span(self):
         """The exact failure mode reported in issue #1200."""

--- a/tests/ut/language/parser/test_parser_span_passing.py
+++ b/tests/ut/language/parser/test_parser_span_passing.py
@@ -157,7 +157,8 @@ class TestParserSpanPassing:
         assert isinstance(test_create, ir.Function)
 
         create_call = find_unique_call(test_create, "tensor.create")
-        assert_span_at(create_call.span, current_line + 4, expected_column=46)
+        # 1-indexed: `pl.create_tensor` sits at 0-based offset 46 on its line.
+        assert_span_at(create_call.span, current_line + 4, expected_column=47)
 
     def test_parser_span_accuracy_multiple_operations(self):
         """Test that parser assigns different spans to different operations."""
@@ -178,7 +179,8 @@ class TestParserSpanPassing:
         assert len(calls) == 2, f"expected 2 calls, got {[call.op.name for call in calls]}"
 
         for call, offset in zip(calls, [4, 5], strict=True):
-            assert_span_at(call.span, current_line + offset, expected_column=42, context=call.op.name)
+            # 1-indexed: `pl.mul` / `pl.add` sit at 0-based offset 42.
+            assert_span_at(call.span, current_line + offset, expected_column=43, context=call.op.name)
 
     def test_parser_passes_span_to_matmul(self):
         """Parser should pass AST span to tensor.matmul operation."""
@@ -252,6 +254,81 @@ class TestParserSpanPassing:
 
         for call, offset in zip(calls, [7, 8, 9, 10, 11], strict=True):
             assert_span_at(call.span, current_line + offset, context=call.op.name)
+
+
+class TestNonAsciiSourceColumns:
+    """Span columns count characters, so a multi-byte prefix must not shift them.
+
+    ``ast`` reports ``col_offset`` in UTF-8 bytes; feeding that through unchanged
+    pushes the column past its token by one per extra byte, misplacing the
+    diagnostics caret on any line containing non-ASCII text.
+    """
+
+    def test_multibyte_identifier_does_not_shift_column(self):
+        code = """
+@pl.program
+class Prog:
+    @pl.function
+    def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+        café_résultat: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
+        return café_résultat
+"""
+        prog = pl.parse(code)
+        assert isinstance(prog, ir.Program)
+
+        main = prog.get_function("main")
+        assert main is not None
+        call = find_unique_call(main, "tensor.add")
+        line = code.split("\n")[call.span.begin_line - 1]
+
+        byte_offset = len(line[: line.index("pl.add")].encode("utf-8"))
+        assert byte_offset > line.index("pl.add"), "test line must contain a multi-byte prefix"
+
+        assert line[call.span.begin_column - 1 :].startswith("pl.add"), (
+            f"column {call.span.begin_column} does not land on the token in {line!r}"
+        )
+
+
+class TestLeftMarginSpansAreValid:
+    """A node at the left margin must produce a valid span.
+
+    ``Span::is_valid()`` requires a positive column, and every consumer
+    (``CHECK_SPAN``/``INTERNAL_CHECK_SPAN`` messages, the verifier's diagnostic
+    formatter, ``OpRegistry``) drops the source location when it returns false.
+    While the parser emitted 0-indexed columns, a module-level ``@pl.program``
+    landed on column 0 and silently lost its location.
+    """
+
+    def test_module_level_program_span_is_valid(self):
+        code = """
+@pl.program
+class Prog:
+    @pl.function
+    def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+        y: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
+        return y
+"""
+        prog = pl.parse(code)
+        assert isinstance(prog, ir.Program)
+
+        assert prog.span.begin_column == 1, (
+            f"module-level @pl.program must start at column 1, got {prog.span.begin_column}"
+        )
+        assert prog.span.is_valid(), f"module-level program span must be valid, got {prog.span}"
+
+    def test_module_level_program_span_survives_to_string(self):
+        """``to_string()`` emits file:line:column, which tooling reads as 1-indexed."""
+        code = """
+@pl.program
+class Prog:
+    @pl.function
+    def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+        return x
+"""
+        prog = pl.parse(code)
+        assert isinstance(prog, ir.Program)
+
+        assert prog.span.to_string().endswith(":2:1")
 
 
 if __name__ == "__main__":

--- a/tests/ut/language/parser/test_span_tracker.py
+++ b/tests/ut/language/parser/test_span_tracker.py
@@ -46,7 +46,10 @@ class TestSpanTracker:
         assert isinstance(span, ir.Span)
         assert span.filename == source_file
         assert span.begin_line == 1
-        assert span.begin_column == 0
+        # ast col_offset 0 -> Span column 1: Span columns are 1-indexed, so a
+        # statement at the left margin starts at column 1, not 0.
+        assert span.begin_column == 1
+        assert span.is_valid()
 
     def test_get_span_none_node(self):
         """Test getting span from None node returns unknown span."""
@@ -108,6 +111,70 @@ class TestSpanTracker:
         assert span.filename == source_file
 
 
+class TestSpanTrackerColumnConvention:
+    """Columns are 1-indexed characters, matching ``include/pypto/ir/span.h``.
+
+    ``ast`` nodes carry a 0-indexed ``col_offset`` counted in UTF-8 *bytes*;
+    ``SpanTracker`` converts both aspects on the way into ``ir.Span``.
+    """
+
+    def test_left_margin_statement_is_column_one(self):
+        """col_offset 0 becomes column 1 — and the span is therefore valid.
+
+        Under the previous 0-indexed emission this span had column 0, which
+        ``Span::is_valid()`` rejects, silently dropping the location from every
+        diagnostic anchored on a left-margin node.
+        """
+        source = "x = 42"
+        tracker = SpanTracker("test.py", source.split("\n"))
+
+        span = tracker.get_span(ast.parse(source).body[0])
+
+        assert span.begin_column == 1
+        assert span.is_valid()
+
+    def test_column_matches_source_offset(self):
+        """The column round-trips to the token when read as a 1-indexed position."""
+        source = "y = foo(1)"
+        tracker = SpanTracker("test.py", source.split("\n"))
+
+        assign = ast.parse(source).body[0]
+        assert isinstance(assign, ast.Assign)
+        span = tracker.get_span(assign.value)
+
+        assert source[span.begin_column - 1 :].startswith("foo(1)")
+
+    def test_col_offset_is_indentation_aware(self):
+        """``col_offset`` (dedent compensation) is added on top of the 1-indexed column."""
+        source = "x = 42"
+        tracker = SpanTracker("test.py", source.split("\n"), col_offset=4)
+
+        span = tracker.get_span(ast.parse(source).body[0])
+
+        assert span.begin_column == 5  # 4 spaces of stripped indentation, then column 1
+
+    def test_multibyte_prefix_yields_character_column(self):
+        """A multi-byte character before the token must not shift the column.
+
+        ``ast`` reports ``col_offset`` in UTF-8 bytes, so a non-ASCII prefix
+        would otherwise push the column past the token it names.
+        """
+        source = "y = f('é', bar)"
+        tracker = SpanTracker("test.py", source.split("\n"))
+
+        assign = ast.parse(source).body[0]
+        assert isinstance(assign, ast.Assign)
+        call = assign.value
+        assert isinstance(call, ast.Call)
+        bar = call.args[1]
+        span = tracker.get_span(bar)
+
+        # 'é' is 2 bytes but 1 character: the byte offset would overshoot by one.
+        assert bar.col_offset == source.index("bar") + 1
+        assert span.begin_column == source.index("bar") + 1
+        assert source[span.begin_column - 1 :].startswith("bar")
+
+
 class TestSpanTrackerSourceMap:
     """Source-map remapping of spans to original source (issue #1612)."""
 
@@ -123,7 +190,8 @@ class TestSpanTrackerSourceMap:
 
         assert span.filename == "/real/kernel.py"
         assert span.begin_line == 5
-        assert span.begin_column == 8
+        # Map entries hold AST coordinates, so col 8 becomes 1-indexed column 9.
+        assert span.begin_column == 9
 
     def test_unmapped_line_keeps_generated_coords(self):
         """A node whose emitted line is absent from the map keeps generated coords."""

--- a/tests/ut/language/parser/test_text_parser.py
+++ b/tests/ut/language/parser/test_text_parser.py
@@ -24,11 +24,17 @@ def _span_begin(err: ParserError) -> tuple[int, int]:
     """Return (begin_line, begin_column) from a ParserError span.
 
     ``ParserError.span`` is stored as a dict of extracted coordinates (see
-    ``diagnostics/exceptions.py``).
+    ``diagnostics/exceptions.py``). Both coordinates are 1-indexed; use
+    :func:`_span_char_index` to slice a source line with the column.
     """
     sp = err.span
     assert sp is not None, "expected a span on the parser error"
     return sp["begin_line"], sp["begin_column"]
+
+
+def _span_char_index(begin_column: int) -> int:
+    """Convert a 1-indexed span column to a 0-based index into the source line."""
+    return begin_column - 1
 
 
 def _assert_caret_on_line(err: ParserError, expected_substring: str) -> None:
@@ -579,6 +585,30 @@ def bad(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
         assert err.span is not None
         assert err.span["column"] > 0  # Not column 0 — points at 'BadType'
 
+    def test_exec_error_column_points_at_non_ascii_attribute(self):
+        """The bad-attribute column must survive a non-ASCII identifier.
+
+        ``ast`` reports ``end_col_offset`` in UTF-8 bytes, so the attribute's
+        *byte* length is what locates its start. Subtracting the character
+        length instead lands inside the identifier whenever it contains
+        non-ASCII text, which Python permits in identifiers.
+        """
+        from pypto.language.parser.diagnostics import ParserSyntaxError  # noqa: PLC0415
+
+        code = """
+@pl.function(type=pl.FunctionType.Bad_é_Type)
+def bad(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+    return x
+"""
+        with pytest.raises(ParserSyntaxError) as exc_info:
+            pl.parse(code)
+        err = exc_info.value
+        assert err.span is not None
+        line = code.split("\n")[err.span["begin_line"] - 1]
+        assert line[err.span["begin_column"] - 1 :].startswith("Bad_é_Type"), (
+            f"column {err.span['begin_column']} does not land on the attribute in {line!r}"
+        )
+
     def test_exec_error_hint_lists_valid_values(self):
         """Hint message lists the valid enum values."""
         from pypto.language.parser.diagnostics import ParserSyntaxError  # noqa: PLC0415
@@ -776,7 +806,7 @@ class Prog:
         error_line = err.source_lines[begin_line - 1]
         assert "deps=" in error_line
         # The column must point exactly at the rejected `[seed_tid] + ...` value.
-        assert error_line[begin_column:].startswith("[seed_tid]")
+        assert error_line[_span_char_index(begin_column) :].startswith("[seed_tid]")
 
         # The rendered caret must sit under that same line.
         _assert_caret_on_line(err, expected_substring="deps=")
@@ -801,7 +831,7 @@ class Prog:
 
         error_line = err.source_lines[begin_line - 1]
         assert "this_op_does_not_exist" in error_line
-        assert error_line[begin_column:].startswith("pl.this_op_does_not_exist")
+        assert error_line[_span_char_index(begin_column) :].startswith("pl.this_op_does_not_exist")
 
         _assert_caret_on_line(err, expected_substring="this_op_does_not_exist")
 


### PR DESCRIPTION
- fix(parser): emit 1-indexed character columns in Span
- fix(debug): call Span.is_valid() in torch_codegen var key