### PR TITLE
feat(jit): Add pl.RUNTIME for unspecialized scalars in signature-mode compile()

### DIFF
--- a/docs/en/user/00-getting_started.md
+++ b/docs/en/user/00-getting_started.md
@@ -125,7 +125,17 @@ throwaway `torch.empty(...)` buffers. Details:
   artifact is extent-independent, and `compile()` shares one cache entry with an
   equivalent `compile(sample_tensors)` call.
 - **Scalar parameters** carry no value in the signature — pass them as keyword
-  args, e.g. `kernel.compile(num_tokens=128)`.
+  args. A literal **specializes** the value into the artifact, e.g.
+  `kernel.compile(num_tokens=128)` compiles a kernel that only ever sees 128.
+  Pass `pl.RUNTIME` instead — `kernel.compile(num_tokens=pl.RUNTIME)` — to leave
+  the parameter **unspecialized**: it stays a real `pl.Scalar` parameter whose
+  value arrives at dispatch and, like a dynamic dim, drops out of the cache key,
+  so one artifact serves every value. Supply that value through the compiled
+  artifact — `compiled(...)` or a `worker.register(compiled)` handle — not by
+  calling the kernel eagerly: `kernel(x, out, 128)` re-specializes on 128 and
+  compiles a separate artifact. `pl.RUNTIME` also works as the signature default
+  (`num_tokens: pl.Scalar[pl.INT32] = pl.RUNTIME`), which makes the keyword
+  unnecessary at every `compile()` call site.
 - A **bare `pl.Tensor`** parameter (no shape) has nothing to read and raises a
   clear error; give it a full `pl.Tensor[[...], dtype]` annotation, or fall back
   to `compile(*sample_tensors)`.

--- a/docs/zh/user/00-getting_started.md
+++ b/docs/zh/user/00-getting_started.md
@@ -111,8 +111,15 @@ compiled = prefill_fwd.compile()
 - **静态维**（`HIDDEN`、`VOCAB` …）来自注解常量。
 - **动态维**（`pl.dynamic` / `bind_dynamic`）无需给值 —— 编译产物与具体 extent
   无关，`compile()` 与等价的 `compile(sample_tensors)` 共享同一 cache 条目。
-- **标量参数**在签名里没有值 —— 用关键字参数传入，例如
-  `kernel.compile(num_tokens=128)`。
+- **标量参数**在签名里没有值 —— 用关键字参数传入。传字面量会把该值**特化**进
+  产物，例如 `kernel.compile(num_tokens=128)` 编出的内核只认 128。改传
+  `pl.RUNTIME` —— `kernel.compile(num_tokens=pl.RUNTIME)` —— 则**不特化**：该参数
+  在生成的程序里仍是真正的 `pl.Scalar` 参数，值在 dispatch 时给出；它与动态维一样
+  不进 cache key，一份产物服务所有取值。该值要通过编译产物给出 —— `compiled(...)`
+  或 `worker.register(compiled)` 拿到的 handle —— 而不是直接调用内核：
+  `kernel(x, out, 128)` 会按 128 重新特化并编出另一份产物。`pl.RUNTIME` 也可以写成
+  签名默认值（`num_tokens: pl.Scalar[pl.INT32] = pl.RUNTIME`），这样每个 `compile()`
+  调用点都不必再传关键字。
 - **bare `pl.Tensor`**（无 shape）无从读取，会给出明确报错；请补全
   `pl.Tensor[[...], dtype]` 注解，或回退到 `compile(*sample_tensors)`。
 

--- a/python/pypto/jit/decorator.py
+++ b/python/pypto/jit/decorator.py
@@ -361,12 +361,19 @@ def _signature_scalar_value(
     name: str,
     param: inspect.Parameter,
     kwargs: dict[str, Any],
-) -> int | float | bool:
+) -> int | float | bool | None:
     """Resolve a scalar parameter's value for signature-mode specialization.
 
     Value comes from ``kwargs`` (by param name) or the signature default; a
     scalar with neither is an error (the signature carries no value).
+
+    Returns:
+        The literal to specialize into the compiled artifact, or ``None`` when
+        the caller passed ``pl.RUNTIME`` — the parameter then stays a runtime
+        ``pl.Scalar`` in the generated program instead of being baked in.
     """
+    from pypto.language.typing.scalar import RUNTIME  # noqa: PLC0415
+
     if name in kwargs:
         value = kwargs[name]
     elif param.default is not inspect.Parameter.empty:
@@ -375,11 +382,15 @@ def _signature_scalar_value(
         raise TypeError(
             f"@pl.jit function '{func_name}': scalar parameter '{name}' has no value. When "
             f"specializing from annotations, pass scalar values as keyword arguments, e.g. "
-            f"lower({name}=...) or compile({name}=...)."
+            f"lower({name}=...) or compile({name}=...). Pass '{name}=pl.RUNTIME' instead to "
+            f"leave it unspecialized (its value is supplied at dispatch)."
         )
+    if value is RUNTIME:
+        return None
     if not isinstance(value, (int, float, bool)):
         raise TypeError(
-            f"@pl.jit function '{func_name}': scalar parameter '{name}' must be an int/float/bool, "
+            f"@pl.jit function '{func_name}': scalar parameter '{name}' must be an int/float/bool "
+            f"(specializes the value into the artifact) or pl.RUNTIME (leaves it unspecialized), "
             f"got {type(value).__name__}."
         )
     return value
@@ -1327,8 +1338,12 @@ def _resolve_dep_call_metadata(
                 continue
             if caller_arg in all_tensor_meta:
                 dep_tensor_meta[dep_param] = all_tensor_meta[caller_arg]
-            elif caller_arg in caller_scalar_values:
-                dep_scalar_values[dep_param] = caller_scalar_values[caller_arg]
+            else:
+                # A scalar arg carries a value only when the caller specialized
+                # it; a ``pl.RUNTIME`` scalar has a dtype but no value. Forward
+                # each fact independently so the dtype survives either way.
+                if caller_arg in caller_scalar_values:
+                    dep_scalar_values[dep_param] = caller_scalar_values[caller_arg]
                 if caller_arg in caller_scalar_dtypes:
                     dep_scalar_dtypes[dep_param] = caller_scalar_dtypes[caller_arg]
     else:
@@ -1786,7 +1801,25 @@ class JITFunction:
         scalar_values: dict[str, int | float | bool] = {}
         scalar_dtypes: dict[str, DataType] = {}
 
+        from pypto.language.typing.scalar import RUNTIME  # noqa: PLC0415
+
         for name, value in arguments.items():
+            # ``pl.RUNTIME`` is a compile-time marker, not a value. This path
+            # binds real arguments (dispatch, or sample-argument compile), where
+            # an unrecognized object would otherwise slip through the
+            # int/float/bool filter below and fail much later with an opaque
+            # "must be real number" from the runtime. Note ``apply_defaults()``
+            # above materializes a ``= pl.RUNTIME`` signature default, so a plain
+            # ``kernel(a, c)`` call reaches here too.
+            if value is RUNTIME:
+                raise TypeError(
+                    f"@pl.jit function '{self.__name__}': parameter '{name}' received "
+                    f"pl.RUNTIME, which is a compile-time marker rather than a value. It is "
+                    f"only accepted by annotation-driven signature mode — call compile() or "
+                    f"lower() with no tensor arguments and pass it by keyword, e.g. "
+                    f"{self.__name__}.compile({name}=pl.RUNTIME). To run the kernel, pass "
+                    f"'{name}' its actual value."
+                )
             if _is_tensor(value):
                 tensor_meta[name] = _extract_tensor_meta(
                     value, entry_dyn_map.get(name), param_layouts.get(name)
@@ -1818,7 +1851,11 @@ class JITFunction:
         ``None`` in the cache key.
 
         Scalar parameters carry no value in the signature, so their values must
-        come from ``kwargs`` (or a signature default).
+        come from ``kwargs`` (or a signature default). A literal is specialized
+        into the artifact; ``pl.RUNTIME`` instead leaves the parameter
+        unspecialized — it is omitted from ``scalar_values`` (and therefore from
+        the cache key) and survives into the generated program as a real
+        ``pl.Scalar`` parameter, exactly like a dynamic dim extent.
 
         Raises:
             TypeError: if a tensor parameter has a bare ``pl.Tensor`` annotation
@@ -1893,7 +1930,13 @@ class JITFunction:
             if scalar_dtype is None and isinstance(annotation, DataType):
                 scalar_dtype = annotation
             if scalar_dtype is not None:
-                scalar_values[name] = _signature_scalar_value(self.__name__, name, param, kwargs)
+                value = _signature_scalar_value(self.__name__, name, param, kwargs)
+                # ``pl.RUNTIME`` -> no ``scalar_values`` entry. The specializer only
+                # substitutes names present in ``scalar_values``, so the parameter
+                # stays symbolic in the generated program; it also drops out of the
+                # cache key, so one artifact serves every runtime value.
+                if value is not None:
+                    scalar_values[name] = value
                 scalar_dtypes[name] = scalar_dtype
                 continue
 
@@ -2130,27 +2173,44 @@ class JITFunction:
         raises). Dynamic dims (``pl.dynamic`` / ``bind_dynamic``) need no value —
         the artifact is extent-independent. Scalar parameters have no value in
         the signature, so pass them as keyword args (or via a signature
-        default). This shares the same cache entry as an equivalent
-        ``compile(*sample_tensors)`` call.
+        default); a literal **specializes** that value into the artifact, while
+        ``pl.RUNTIME`` leaves the parameter **unspecialized** — it stays a real
+        ``pl.Scalar`` parameter supplied at dispatch and, like a dynamic dim,
+        drops out of the cache key. A signature-mode call shares a cache entry
+        with an equivalent ``compile(*sample_tensors)`` call whenever the two
+        agree on every specialized scalar; ``pl.RUNTIME`` is its own
+        specialization and is rejected on the sample-argument path, which always
+        specializes the scalar value it is handed.
 
         Example::
 
+            M = pl.dynamic("M")
+
             @pl.jit
-            def my_kernel(x, w, out):
+            def my_kernel(
+                x: pl.Tensor[[M, 4096], pl.BF16],
+                w: pl.Tensor[[4096, 4096], pl.BF16],
+                out: pl.Out[pl.Tensor[[M, 4096], pl.BF16]],
+                num_tokens: pl.Scalar[pl.INT32],
+            ):
                 ...
 
             worker = ChipWorker(config=RunConfig(platform="a2a3"))
 
             # From sample tensors (shape/dtype read; contents ignored):
-            compiled = my_kernel.compile(sample_x, sample_w, sample_out)
+            compiled = my_kernel.compile(sample_x, sample_w, sample_out, 128)
 
-            # Or straight from the (fully-annotated) signature — no tensors:
-            compiled = my_kernel.compile()
+            # Or straight from the (fully-annotated) signature — no tensors.
+            # num_tokens varies per launch, so keep it out of the artifact: its
+            # value is supplied on each dispatch through the compiled artifact
+            # (below), not by calling my_kernel(...) directly — an eager call
+            # re-specializes and compiles a separate artifact.
+            compiled = my_kernel.compile(num_tokens=pl.RUNTIME)
 
             w_dev = worker.alloc_tensor(real_w.shape, real_w.dtype, init=real_w)
             h = worker.register(compiled)
             for batch in stream:
-                h(batch.x, w_dev, batch.out)
+                h(batch.x, w_dev, batch.out, batch.num_tokens)
 
         Args:
             *args: Positional arguments matching the decorated function's
@@ -2159,7 +2219,9 @@ class JITFunction:
                 straight from the signature annotations instead.
             **kwargs: Keyword arguments. A ``config`` keyword, if present, is
                 a :class:`~pypto.runtime.runner.RunConfig`. In signature mode,
-                scalar parameter values are also passed here (by name).
+                scalar parameter values are also passed here (by name) — a
+                literal to specialize it, or ``pl.RUNTIME`` to leave it
+                unspecialized.
 
         Returns:
             The cached :class:`CompiledProgram` for this specialization.
@@ -2179,7 +2241,9 @@ class JITFunction:
         Args:
             *args: Positional sample arguments matching the decorated function.
                 Omit tensor samples to specialize from fully shaped annotations.
-            **kwargs: Keyword sample arguments and an optional ``config``.
+            **kwargs: Keyword sample arguments and an optional ``config``. In
+                signature mode a scalar parameter takes a literal (specialized
+                into the IR) or ``pl.RUNTIME`` (left unspecialized).
 
         Returns:
             The specialized :class:`ir.Program` after configured passes.

--- a/python/pypto/language/__init__.py
+++ b/python/pypto/language/__init__.py
@@ -235,6 +235,7 @@ from .parser.decorator import InlineFunction, function, inline, program
 from .parser.text_parser import loads, loads_program, parse, parse_program
 from .scope import ScopeMode, manual_scope, scope, spmd_submit, submit
 from .typing import (
+    RUNTIME,
     Array,
     AsyncEvent,
     AsyncSession,
@@ -313,6 +314,7 @@ __all__ = [
     "InOut",
     "IntLike",
     "Out",
+    "RUNTIME",
     "dynamic",
     "const",
     "range",

--- a/python/pypto/language/typing/__init__.py
+++ b/python/pypto/language/typing/__init__.py
@@ -24,7 +24,7 @@ from pypto.language.typing.dynamic import DynVar, dynamic
 from pypto.language.typing.memref import MemRef
 from pypto.language.typing.prefetch_handle import AsyncEvent, AsyncSession, PrefetchAsyncContext
 from pypto.language.typing.ptr import Ptr
-from pypto.language.typing.scalar import Scalar
+from pypto.language.typing.scalar import RUNTIME, RuntimeScalarMarker, Scalar
 from pypto.language.typing.tensor import Tensor
 from pypto.language.typing.tile import Tile
 from pypto.language.typing.tuple import Tuple
@@ -34,6 +34,7 @@ IntLike: TypeAlias = int | Scalar | Expr
 """Type alias for shape/offset parameters that accept int literals, Scalar DSL values, or raw Expr."""
 
 __all__ = [
+    "RUNTIME",
     "Array",
     "AsyncEvent",
     "AsyncSession",
@@ -44,6 +45,7 @@ __all__ = [
     "Out",
     "PrefetchAsyncContext",
     "Ptr",
+    "RuntimeScalarMarker",
     "Scalar",
     "Tensor",
     "Tile",

--- a/python/pypto/language/typing/scalar.py
+++ b/python/pypto/language/typing/scalar.py
@@ -262,4 +262,64 @@ class Scalar(metaclass=ScalarMeta):
         return cls.__getitem__(item)
 
 
-__all__ = ["Scalar"]
+class RuntimeScalarMarker(Scalar):
+    """Marker for a scalar parameter whose value is supplied at dispatch.
+
+    A ``pl.Scalar[dtype]`` annotation carries a type but no value, so
+    annotation-driven signature mode (``compile()`` / ``lower()`` with no
+    tensor arguments) needs one value per scalar parameter. Passing a literal
+    **specializes** that value into the compiled artifact; passing
+    :data:`RUNTIME` leaves the parameter **unspecialized** — it stays a real
+    ``pl.Scalar`` parameter in the generated program and its value is supplied
+    at dispatch, exactly like a ``pl.dynamic`` dimension extent. Unspecialized
+    scalars also drop out of the specialization cache key, so one artifact
+    serves every runtime value.
+
+    Subclasses :class:`Scalar` so that a type checker accepts it as the default
+    of a scalar parameter — ``n: pl.Scalar[dtype] = pl.RUNTIME`` — for the same
+    reason :class:`~pypto.language.typing.dynamic.DynVar` does: the marker
+    stands in wherever a ``Scalar`` is expected. It carries no dtype of its own;
+    the parameter's annotation supplies that.
+
+    Use the :data:`RUNTIME` singleton rather than instantiating this class.
+
+    Examples:
+        >>> import pypto.language as pl
+        >>>
+        >>> # num_tokens varies per step: keep it out of the artifact.
+        >>> compiled = prefill_fwd.compile(num_tokens=pl.RUNTIME)  # doctest: +SKIP
+    """
+
+    def __init__(self) -> None:
+        """Initialize the marker with no dtype and no wrapped expression.
+
+        Bypasses :meth:`Scalar.__init__`, which requires one of the two — this
+        marker deliberately has neither, and its dtype comes from the annotated
+        parameter it defaults.
+        """
+        self.dtype = None
+        self.expr = None
+        self._annotation_only = False
+
+    def unwrap(self) -> Expr:
+        """Reject use in an expression.
+
+        Raises:
+            RuntimeError: Always — the marker has no value to unwrap.
+        """
+        raise RuntimeError(
+            "pl.RUNTIME is a compile-time marker with no value. Pass it to compile() or "
+            "lower() to leave a scalar parameter unspecialized; it cannot take part in an "
+            "expression."
+        )
+
+    def __repr__(self) -> str:
+        """Return the marker's canonical spelling."""
+        return "pl.RUNTIME"
+
+
+RUNTIME = RuntimeScalarMarker()
+"""Singleton :class:`RuntimeScalarMarker` — see the class docstring."""
+
+
+__all__ = ["RUNTIME", "RuntimeScalarMarker", "Scalar"]

--- a/tests/ut/jit/test_jit_compile_extraction.py
+++ b/tests/ut/jit/test_jit_compile_extraction.py
@@ -14,6 +14,7 @@ runtime APIs directly.
 Closes hw-native-sys/pypto#1455.
 """
 
+import ctypes
 import importlib
 
 import pypto.language as pl
@@ -301,6 +302,41 @@ def sig_kernel(a: pl.Tensor[[_SIG_M, 128], pl.FP32], c: pl.Out[pl.Tensor[[_SIG_M
     return c
 
 
+# Runtime (unspecialized) scalar parameters in signature mode (issue #2283).
+# The scalar is consumed inside the incore dep, so these kernels also cover
+# scalar propagation across the JIT call graph.
+@jit.incore
+def _rt_add_scalar_incore(
+    a: pl.Tensor[[_SIG_M, 128], pl.FP32],
+    n: pl.Scalar[pl.FP32],
+    c: pl.Out[pl.Tensor[[_SIG_M, 128], pl.FP32]],
+):
+    tile = pl.load(a, [0, 0], [128, 128])
+    shifted = pl.add(tile, n)
+    pl.store(shifted, [0, 0], c)
+    return c
+
+
+@jit
+def rt_scalar_kernel(
+    a: pl.Tensor[[_SIG_M, 128], pl.FP32],
+    n: pl.Scalar[pl.FP32],
+    c: pl.Out[pl.Tensor[[_SIG_M, 128], pl.FP32]],
+):
+    c = _rt_add_scalar_incore(a, n, c)
+    return c
+
+
+@jit
+def rt_scalar_default_kernel(
+    a: pl.Tensor[[_SIG_M, 128], pl.FP32],
+    c: pl.Out[pl.Tensor[[_SIG_M, 128], pl.FP32]],
+    n: pl.Scalar[pl.FP32] = pl.RUNTIME,
+):
+    c = _rt_add_scalar_incore(a, n, c)
+    return c
+
+
 class TestCompileFromSignature:
     """``compile()`` with no positional args reads the shape/dtype contract
     straight from the kernel's own annotations — no throwaway ``torch.empty``
@@ -373,6 +409,85 @@ class TestCompileFromSignature:
         # Supplied via keyword: value flows into scalar_values.
         _, _, _, scalar_values, _, _ = scalar_sig_kernel._bind_args_from_signature({"n": 7})
         assert scalar_values == {"n": 7}
+
+    def test_runtime_scalar_left_unspecialized(self):
+        """``pl.RUNTIME`` keeps a scalar out of ``scalar_values`` (issue #2283):
+        the value is supplied at dispatch, not baked into the artifact. The
+        dtype is still recorded — only the value is withheld."""
+        _, _, _, scalar_values, scalar_dtypes, _ = rt_scalar_kernel._bind_args_from_signature(
+            {"n": pl.RUNTIME}
+        )
+        assert scalar_values == {}
+        assert scalar_dtypes == {"n": pl.FP32}
+
+    def test_runtime_scalar_keeps_symbolic_param_in_program(self):
+        """A ``pl.RUNTIME`` scalar survives specialization as a real parameter
+        reference — in the entry *and* in the incore dep it is forwarded to.
+        A literal is folded into a constant in both instead."""
+        _, _, tm_r, sv_r, sd_r, dyn_r = rt_scalar_kernel._bind_args_from_signature({"n": pl.RUNTIME})
+        prog_runtime = str(rt_scalar_kernel._compile_to_program(tm_r, sv_r, sd_r, dyn_r, pl))
+
+        _, _, tm_s, sv_s, sd_s, dyn_s = rt_scalar_kernel._bind_args_from_signature({"n": 7.0})
+        prog_specialized = str(rt_scalar_kernel._compile_to_program(tm_s, sv_s, sd_s, dyn_s, pl))
+
+        # Both keep 'n' in the entry *and* dep signatures — the parameter list
+        # comes from the annotations either way. What differs is every *use*:
+        # runtime forwards and consumes the symbol, specialized folds a constant.
+        assert prog_runtime.count("n: pl.Scalar[pl.FP32]") == 2
+        assert prog_specialized.count("n: pl.Scalar[pl.FP32]") == 2
+        assert "self._rt_add_scalar_incore(a, n, c)" in prog_runtime
+        assert "self._rt_add_scalar_incore(a, 7.0, c)" in prog_specialized
+        assert "pl.tile.adds(tile, n)" in prog_runtime
+        assert "pl.tile.adds(tile, 7.0)" in prog_specialized
+
+    def test_runtime_scalar_forwards_dtype_to_dep(self):
+        """A runtime scalar carries no value, but its dtype still reaches the dep
+        it is forwarded to."""
+        _, _, tm, sv, sd, dyn = rt_scalar_kernel._bind_args_from_signature({"n": pl.RUNTIME})
+        contexts = rt_scalar_kernel._build_contexts(tm, sv, sd, dyn)
+        dep_ctx = next(c for c in contexts if c.func_name == "_rt_add_scalar_incore")
+        assert dep_ctx.scalar_values == {}
+        assert dep_ctx.scalar_dtypes == {"n": pl.FP32}
+
+    def test_runtime_scalar_default_needs_no_keyword(self):
+        """``pl.RUNTIME`` as the signature default makes the parameter runtime
+        without the caller passing anything — through to the generated program
+        (the specializer drops Python defaults, so the marker never leaks)."""
+        _, _, tm, sv, sd, dyn = rt_scalar_default_kernel._bind_args_from_signature({})
+        assert sv == {}
+        assert sd == {"n": pl.FP32}
+
+        prog = str(rt_scalar_default_kernel._compile_to_program(tm, sv, sd, dyn, pl))
+        assert "n: pl.Scalar[pl.FP32]" in prog
+        assert "pl.RUNTIME" not in prog
+        assert "pl.tile.adds(tile, n)" in prog
+
+    def test_runtime_marker_rejected_on_the_dispatch_path(self):
+        """``pl.RUNTIME`` is a compile-time marker. Binding real arguments — a
+        dispatch call, or a sample-argument compile — must reject it by name
+        instead of letting it reach the runtime as a bogus scalar. The signature
+        default makes this reachable from a plain ``kernel(a, c)`` call."""
+        torch = pytest.importorskip("torch")
+
+        t = torch.zeros(256, 128, dtype=torch.float32)
+        with pytest.raises(TypeError, match=r"'n' received pl\.RUNTIME"):
+            rt_scalar_default_kernel._bind_args((t, t), {})
+        with pytest.raises(TypeError, match=r"'n' received pl\.RUNTIME"):
+            rt_scalar_kernel._bind_args((t, pl.RUNTIME, t), {})
+
+    def test_runtime_scalar_and_literal_do_not_share_cache(self):
+        """Specializing the value and leaving it runtime are different artifacts."""
+        from_runtime = rt_scalar_kernel.compile(n=pl.RUNTIME)
+        from_literal = rt_scalar_kernel.compile(n=7.0)
+        assert isinstance(from_runtime, CompiledProgram)
+        assert from_runtime is not from_literal
+        # Re-requesting the runtime specialization hits the same cache entry.
+        assert rt_scalar_kernel.compile(n=pl.RUNTIME) is from_runtime
+
+    def test_unsupported_scalar_value_points_at_runtime_marker(self):
+        """A value that is neither a literal nor ``pl.RUNTIME`` names both paths."""
+        with pytest.raises(TypeError, match=r"pl\.RUNTIME"):
+            rt_scalar_kernel._bind_args_from_signature({"n": ctypes.c_int32()})
 
     def test_keyword_tensor_samples_use_tensor_mode(self):
         """Passing sample tensors by keyword (no positional args) must still bind


### PR DESCRIPTION
Annotation-driven signature mode required every pl.Scalar parameter to carry an
int/float/bool, and specialized that value into the compiled artifact. A scalar
whose value varies per launch therefore could not use signature mode at all: the
only escape hatch was positional sample-arg mode, which forced the caller to
build throwaway meta tensors for every preceding tensor parameter just to reach
the scalar's slot, and relied on _bind_args' int/float/bool filter incidentally
skipping a ctypes placeholder.

The lowering pipeline already supported unspecialized scalars — the specializer
only substitutes names present in scalar_values, so a name it does not know
survives as a real pl.Scalar parameter. What was missing was a way to say so.

pl.RUNTIME is that marker:

    compiled = kernel.compile(num_tokens=pl.RUNTIME)

The scalar is omitted from scalar_values (and hence from the cache key, so one
artifact serves every value) while its dtype is still recorded. It also works as
a signature default. Because the marker is compile-time only, _bind_args now
rejects it by name rather than letting it reach the runtime as a bogus scalar.

Dep-level scalar dtype propagation is fixed to forward the dtype independently
of the value, so a runtime scalar keeps its dtype across the JIT call graph.

Closes #2283