### PR TITLE
perf(language): avoid a full-file AST parse per @pl.program class

### DIFF
--- a/python/pypto/language/parser/decorator.py
+++ b/python/pypto/language/parser/decorator.py
@@ -26,6 +26,7 @@ from .ast_parser import ASTParser
 from .comment_extractor import extract_line_comments
 from .diagnostics import ParserError, ParserSyntaxError, concise_error_message
 from .enum_utils import FUNCTION_TYPE_MAP, LEVEL_MAP, ROLE_MAP, SPLIT_MODE_MAP, extract_enum_value
+from .source_lookup import get_class_source_lines
 
 
 def _is_abstract_subworker_body(func_def: ast.FunctionDef) -> bool:
@@ -678,7 +679,7 @@ def _get_source_info(entity: Callable | type, entity_type: str) -> tuple[str, li
     """Get source file, source lines, and starting line for an entity.
 
     Tries multiple strategies:
-    1. Standard inspect.getsourcelines()
+    1. Standard inspect.getsourcelines() (classes take a cached fast path first)
     2. linecache fallback (handles IPython, pre-populated cache)
     3. sys.orig_argv for `python -c` invocations
     4. Clear error with actionable hint
@@ -703,7 +704,13 @@ def _get_source_info(entity: Callable | type, entity_type: str) -> tuple[str, li
     # Strategy 1: Standard inspect
     try:
         source_file = inspect.getfile(entity)
-        source_lines_raw, starting_line = inspect.getsourcelines(entity)
+        if isinstance(entity, type):
+            # inspect.getsourcelines() costs a full-file ast.parse per class on
+            # CPython < 3.13; this returns the same answer for one parse per
+            # file, and defers to inspect elsewhere. See parser/source_lookup.py.
+            source_lines_raw, starting_line = get_class_source_lines(entity)
+        else:
+            source_lines_raw, starting_line = inspect.getsourcelines(entity)
         return source_file, source_lines_raw, starting_line
     except (OSError, TypeError):
         pass

--- a/python/pypto/language/parser/source_lookup.py
+++ b/python/pypto/language/parser/source_lookup.py
@@ -1,0 +1,180 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Class source lookup for the DSL decorators.
+
+``inspect.getsourcelines`` has no fast path for a *class* before CPython 3.13
+(which added ``__firstlineno__``): ``inspect.findsource`` ``ast.parse``-es the
+**entire** containing file and walks the tree looking for a matching
+``__qualname__``. A module defining N classes therefore pays N full-file parses,
+so the cost of decorating them grows as O(N x file_size) — noticeable on
+``@pl.program``-heavy modules such as the test suite.
+
+This module resolves the same line number from a per-file index built with a
+*single* parse, then defers to ``inspect.getblock`` for the block extraction so
+the result stays identical to ``inspect.getsourcelines``. Anything the index
+cannot resolve returns ``None`` so callers fall back to ``inspect``, which
+remains the source of truth.
+
+On CPython 3.13+ the index is bypassed entirely. There every class carries its
+own ``__firstlineno__``, so ``inspect`` already resolves the line without
+parsing — and, unlike a qualname-keyed index, it tells apart two classes that
+share a ``__qualname__``. Deferring keeps that disambiguation exact instead of
+approximating it.
+"""
+
+import ast
+import inspect
+import linecache
+
+__all__ = ["get_class_source_lines"]
+
+
+class _ClassLineIndexer(ast.NodeVisitor):
+    """Index ``qualname -> 1-based first source line`` for every class in a module AST.
+
+    Mirrors CPython's ``inspect._ClassFinder`` bookkeeping so lookups agree with
+    ``inspect.findsource``: the ``<locals>`` marker for classes nested in
+    functions, the decorator line taking precedence over the ``class`` line, and
+    "first match in source order wins" when a qualname is defined more than once.
+    """
+
+    def __init__(self) -> None:
+        self._stack: list[str] = []
+        self.index: dict[str, int] = {}
+
+    def visit_FunctionDef(self, node: ast.FunctionDef | ast.AsyncFunctionDef) -> None:
+        self._stack.append(node.name)
+        self._stack.append("<locals>")
+        self.generic_visit(node)
+        self._stack.pop()
+        self._stack.pop()
+
+    visit_AsyncFunctionDef = visit_FunctionDef
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        self._stack.append(node.name)
+        first_line = node.decorator_list[0].lineno if node.decorator_list else node.lineno
+        # setdefault: generic_visit walks in source order, and CPython stops at
+        # the first qualname match, so an earlier definition must win.
+        self.index.setdefault(".".join(self._stack), first_line)
+        self.generic_visit(node)
+        self._stack.pop()
+
+
+# Per-file class-line index, keyed by source filename. Each value keeps the exact
+# ``lines`` list the index was built from, so staleness is an identity check.
+_CLASS_LINE_INDEX_CACHE: dict[str, tuple[list[str], dict[str, int]]] = {}
+
+
+def _class_line_index(source_file: str, lines: list[str]) -> dict[str, int]:
+    """Return the ``qualname -> first line`` index for ``source_file``, parsing once.
+
+    ``linecache`` hands back the *same* list object for a given cache entry and
+    builds a fresh one whenever the file is re-read (or a synthetic entry is
+    replaced), so holding a reference and comparing identity is both O(1) and
+    exact — no size/mtime heuristic can go stale behind it.
+
+    Args:
+        source_file: Filename the lines came from (linecache key)
+        lines: Full source lines of the file, as returned by linecache
+
+    Returns:
+        Mapping from class qualname to its 1-based first source line
+
+    Raises:
+        SyntaxError: If the file does not parse
+    """
+    cached = _CLASS_LINE_INDEX_CACHE.get(source_file)
+    if cached is not None and cached[0] is lines:
+        return cached[1]
+
+    indexer = _ClassLineIndexer()
+    indexer.visit(ast.parse("".join(lines)))
+    _CLASS_LINE_INDEX_CACHE[source_file] = (lines, indexer.index)
+    return indexer.index
+
+
+def _records_own_first_line(cls: type) -> bool:
+    """True when the runtime stamped ``cls`` with its own definition line.
+
+    CPython 3.13+ writes ``__firstlineno__`` into every class body's namespace.
+    Read it through ``vars`` exactly as ``inspect.findsource`` does: ``getattr``
+    would inherit a base class's line and silently mislocate a subclass.
+    """
+    try:
+        return "__firstlineno__" in vars(cls)
+    except TypeError:
+        return False
+
+
+def _indexed_class_source_lines(cls: type) -> tuple[list[str], int] | None:
+    """Resolve ``cls``'s source from the per-file index, or None to defer.
+
+    Args:
+        cls: Class to get source lines for
+
+    Returns:
+        Tuple of (source_lines, starting_line_1based) matching
+        ``inspect.getsourcelines``, or None when the caller must fall back to
+        ``inspect`` — either because the class is not in the index, or because
+        the runtime already resolves it correctly and without parsing
+    """
+    # A class carrying its own line number needs no index, and a qualname-keyed
+    # index would be *wrong* for it: two classes sharing a __qualname__ resolve
+    # to distinct lines that only __firstlineno__ can tell apart. Let inspect do
+    # it; the index exists solely for runtimes that would otherwise parse the
+    # whole file once per class.
+    if _records_own_first_line(cls):
+        return None
+
+    qualname = getattr(cls, "__qualname__", None)
+    if not qualname:
+        return None
+
+    try:
+        # Mirror inspect.findsource: getsourcefile() (not getfile) selects the
+        # .py that linecache is keyed on, and checkcache() drops a stale entry.
+        source_file = inspect.getsourcefile(cls)
+        if not source_file:
+            return None
+        linecache.checkcache(source_file)
+        module = inspect.getmodule(cls, source_file)
+        lines = linecache.getlines(source_file, module.__dict__ if module else None)
+        if not lines:
+            return None
+
+        starting_line = _class_line_index(source_file, lines).get(qualname)
+        if starting_line is None:
+            return None
+        return inspect.getblock(lines[starting_line - 1 :]), starting_line
+    except (OSError, TypeError, ValueError, SyntaxError, AttributeError):
+        # Any surprise (unparseable file, no getblock, exotic loader) falls back
+        # to inspect, which stays the source of truth for this lookup.
+        return None
+
+
+def get_class_source_lines(cls: type) -> tuple[list[str], int]:
+    """Drop-in ``inspect.getsourcelines`` for a class, without the per-class parse.
+
+    Args:
+        cls: Class to get source lines for
+
+    Returns:
+        Tuple of (source_lines, starting_line_1based), identical to what
+        ``inspect.getsourcelines(cls)`` returns
+
+    Raises:
+        OSError: If the source is unavailable, as ``inspect`` raises
+        TypeError: If ``cls`` is a built-in or otherwise has no source
+    """
+    indexed = _indexed_class_source_lines(cls)
+    if indexed is not None:
+        return indexed
+    return inspect.getsourcelines(cls)

--- a/tests/ut/language/parser/test_decorator.py
+++ b/tests/ut/language/parser/test_decorator.py
@@ -9,6 +9,8 @@
 
 """Unit tests for @pl.function, @pl.inline, and @pl.program decorators."""
 
+import ast
+import inspect
 import linecache
 import sys
 import textwrap
@@ -17,6 +19,7 @@ import pypto
 import pypto.language as pl
 import pytest
 from pypto import ir
+from pypto.language.parser import source_lookup
 from pypto.language.parser.diagnostics import ParserTypeError
 from pypto.language.parser.diagnostics.exceptions import (
     ParserSyntaxError,
@@ -2239,6 +2242,231 @@ class TestInlineFunctionControlFlow:
 
         assert len(YieldInlineLoop.functions) == 1
         ir.assert_structural_equal(YieldInlineLoop, Expected)
+
+
+# --- Fixtures for the class-source-lookup tests ------------------------------
+# These cover every branch of the qualname index: bare, decorated, class-nested,
+# function-local (`<locals>`), and shadowed definitions.
+
+
+def _identity_decorator(cls: type) -> type:
+    """Return the class unchanged, so the decorated shape stays a real class."""
+    return cls
+
+
+class _LookupPlain:
+    """Module-level class with a nested class."""
+
+    class Nested:
+        """Class-nested class -- qualname is `_LookupPlain.Nested`."""
+
+
+@_identity_decorator
+@_identity_decorator
+class _LookupDecorated:
+    """Decorated class -- lookup must start at the FIRST decorator line."""
+
+
+def _make_local_class() -> type:
+    """Return a function-local class, whose qualname carries a `<locals>` marker."""
+
+    class LocalInFunction:
+        """Defined inside a function."""
+
+    return LocalInFunction
+
+
+def _make_shadowed_classes() -> tuple[type, type]:
+    """Return two classes sharing one qualname, in definition order."""
+
+    class Shadowed:
+        WHICH = "first"
+
+    first = Shadowed
+
+    class Shadowed:  # noqa: F811 - deliberate duplicate qualname
+        WHICH = "second"
+
+    return first, Shadowed
+
+
+def _lookup_classes() -> list[type]:
+    """Every class shape the lookup must handle, including a shadowed qualname."""
+    first_shadowed, second_shadowed = _make_shadowed_classes()
+    return [
+        _LookupPlain,
+        _LookupPlain.Nested,
+        _LookupDecorated,
+        _make_local_class(),
+        first_shadowed,
+        second_shadowed,
+        TestClassSourceLookup,
+    ]
+
+
+# Whether this runtime actually consults the qualname index. CPython 3.13+ stamps
+# every class with `__firstlineno__`, so the parser defers to `inspect` there and
+# the index is never reached. Derived from real behaviour rather than a version
+# comparison, so it stays correct if the deferral rule changes.
+_INDEX_IN_USE = source_lookup._indexed_class_source_lines(_LookupPlain) is not None
+
+
+class TestClassSourceLookup:
+    """Source lookup for `@pl.program` classes.
+
+    Before CPython 3.13, `inspect.getsourcelines` on a class has no fast path: it
+    `ast.parse`s the whole containing file and walks the tree for a matching
+    qualname, so a module with N classes pays N full-file parses. The parser
+    resolves the line from a per-file index instead. From 3.13 on, every class
+    carries `__firstlineno__` and the parser defers to `inspect`, because only
+    that marker distinguishes two classes sharing a qualname.
+
+    These tests pin the contract that holds on *both* runtimes -- results
+    identical to `inspect` -- and, where the index is actually in use, that a
+    file is parsed only once.
+    """
+
+    def test_source_info_matches_inspect_for_every_class_shape(self):
+        """The parser's class lookup agrees with `inspect.getsourcelines` exactly.
+
+        Asserted end to end through `_get_source_info` so it holds on runtimes
+        that use the index and on those that defer to `inspect`.
+        """
+        for cls in _lookup_classes():
+            expected_lines, expected_start = inspect.getsourcelines(cls)
+            actual_lines, actual_start = source_lookup.get_class_source_lines(cls)
+
+            assert actual_start == expected_start, (
+                f"{cls.__qualname__}: start line {actual_start} != inspect's {expected_start}"
+            )
+            assert actual_lines == expected_lines, f"{cls.__qualname__}: source block differs from inspect's"
+
+    def test_defers_to_inspect_when_the_class_records_its_own_line(self):
+        """The index is bypassed exactly when the runtime stamps `__firstlineno__`.
+
+        That marker is what lets `inspect` tell apart two classes sharing a
+        qualname, which a qualname-keyed index cannot do -- so wherever it
+        exists, the lookup must stand aside.
+        """
+        for cls in _lookup_classes():
+            records_own_line = "__firstlineno__" in vars(cls)
+            deferred = source_lookup._indexed_class_source_lines(cls) is None
+            assert deferred == records_own_line, (
+                f"{cls.__qualname__}: deferred={deferred} but __firstlineno__={records_own_line}"
+            )
+
+    def test_defers_when_firstlineno_is_present_on_older_runtimes(self):
+        """A stamped `__firstlineno__` forces deferral even where it is not native.
+
+        Simulates the CPython 3.13+ contract on runtimes that lack it, so the
+        deferral branch is covered wherever this suite runs.
+        """
+
+        class Stamped:
+            pass
+
+        # Native state: only a runtime that stamps `__firstlineno__` skips the index.
+        assert source_lookup._records_own_first_line(Stamped) is (not _INDEX_IN_USE)
+        assert (source_lookup._indexed_class_source_lines(Stamped) is None) is (not _INDEX_IN_USE)
+
+        Stamped.__firstlineno__ = 1  # type: ignore[attr-defined]
+
+        assert source_lookup._records_own_first_line(Stamped) is True
+        assert source_lookup._indexed_class_source_lines(Stamped) is None
+
+    def test_decorated_class_starts_at_first_decorator(self):
+        """A stacked decorator resolves to the outermost decorator line, not `class`."""
+        expected_lines, expected_start = inspect.getsourcelines(_LookupDecorated)
+        actual_lines, actual_start = source_lookup.get_class_source_lines(_LookupDecorated)
+
+        assert actual_start == expected_start
+        assert actual_lines == expected_lines
+        assert actual_lines[0].lstrip().startswith("@_identity_decorator")
+
+    def test_index_keeps_the_first_of_two_same_qualname_classes(self):
+        """The index's tie-break matches `_ClassFinder`: first definition wins.
+
+        Exercises the index directly, so it documents that behaviour on every
+        runtime -- including those where `get_class_source_lines` defers and the
+        ambiguity is instead resolved by `__firstlineno__`.
+        """
+        source = "class Dup:\n    pass\n\n\nclass Dup:\n    pass\n"
+        indexer = source_lookup._ClassLineIndexer()
+        indexer.visit(ast.parse(source))
+
+        assert indexer.index["Dup"] == 1
+
+    @pytest.mark.skipif(not _INDEX_IN_USE, reason="runtime resolves classes via __firstlineno__")
+    def test_file_is_parsed_once_regardless_of_class_count(self, monkeypatch):
+        """N classes in one file cost one parse -- the O(N x file_size) regression."""
+        source_lookup._CLASS_LINE_INDEX_CACHE.clear()
+
+        parses = []
+        real_parse = ast.parse
+
+        def counting_parse(*args, **kwargs):
+            parses.append(args[0] if args else None)
+            return real_parse(*args, **kwargs)
+
+        monkeypatch.setattr(ast, "parse", counting_parse)
+
+        cases = [_LookupPlain, _LookupPlain.Nested, _LookupDecorated, _make_local_class()]
+        for cls in cases:
+            assert source_lookup._indexed_class_source_lines(cls) is not None
+
+        assert len(parses) == 1, f"expected 1 whole-file parse for {len(cases)} classes, got {len(parses)}"
+        assert len(source_lookup._CLASS_LINE_INDEX_CACHE) == 1
+
+    def test_index_refreshes_when_source_lines_are_replaced(self):
+        """A re-read file re-parses even when size, mtime and line count all match.
+
+        Both sources are 27 bytes over 3 lines with mtime `None`, so any
+        size/mtime/line-count stamp would serve a stale line number here.
+        """
+        filename = "<pypto_class_index_refresh_test>"
+        before: str = "class Alpha:\n    pass\n#pad\n"
+        after: str = "#pad\nclass Alpha:\n    pass\n"
+        assert len(before) == len(after)
+
+        try:
+            before_lines: list[str] = before.splitlines(keepends=True)
+            linecache.cache[filename] = (len(before), None, before_lines, filename)
+            assert source_lookup._class_line_index(filename, before_lines)["Alpha"] == 1
+
+            after_lines: list[str] = after.splitlines(keepends=True)
+            linecache.cache[filename] = (len(after), None, after_lines, filename)
+            assert source_lookup._class_line_index(filename, after_lines)["Alpha"] == 2
+        finally:
+            linecache.cache.pop(filename, None)
+            source_lookup._CLASS_LINE_INDEX_CACHE.pop(filename, None)
+
+    def test_local_program_keeps_file_accurate_spans(self):
+        """End-to-end: a function-local `@pl.program` still spans the real file lines."""
+        current_line = sys._getframe().f_lineno
+
+        @pl.program
+        class LocalProgram:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                y: pl.Tensor[[64], pl.FP32] = pl.add(x, 1.0)  # line current_line + 6
+                return y
+
+        main_func = LocalProgram.get_function("main")
+        assert main_func is not None
+
+        # A scalar rhs lowers to tensor.adds, not tensor.add.
+        add_op = ir.get_op("tensor.adds").name
+        calls = [
+            stmt.value
+            for stmt in _top_level_stmts(main_func.body)
+            if isinstance(stmt, ir.AssignStmt) and isinstance(stmt.value, ir.Call)
+        ]
+        hits = [call for call in calls if call.op.name == add_op]
+
+        assert len(hits) == 1, f"expected one {add_op} call, got {[c.op.name for c in calls]}"
+        assert hits[0].span.begin_line == current_line + 6, (
+            f"span line {hits[0].span.begin_line} != {current_line + 6}"
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- perf(language): avoid a full-file AST parse per @pl.program class