### PR TITLE
fix(examples): use a real transpose in the parse_from_text demo

### DIFF
--- a/examples/utils/parse_from_text.py
+++ b/examples/utils/parse_from_text.py
@@ -85,8 +85,7 @@ import pypto.language as pl
 
 @pl.function
 def matrix_transpose(x: pl.Tensor[[64, 128], pl.FP16]) -> pl.Tensor[[128, 64], pl.FP16]:
-    # Example: simplified transpose operation
-    result: pl.Tensor[[128, 64], pl.FP16] = pl.slice(x, [128, 64], [1, 0])
+    result: pl.Tensor[[128, 64], pl.FP16] = pl.transpose(x, 0, 1)
     return result
 """
 


### PR DESCRIPTION
## Summary

`examples/utils/parse_from_text.py` aborted partway through with exit 1, so a
shipped example of `pl.parse()` / `pl.loads()` did not run. Its embedded
text-DSL program declared `matrix_transpose(x: Tensor[[64, 128]]) -> Tensor[[128, 64]]`
but implemented that as `pl.slice(x, [128, 64], [1, 0])`. A slice extent is
expressed in the source's coordinate space, so dimension 0 asked for
`1 + 128 = 129` elements of a 64-element axis, and the shared window-read bounds
check rejects it. The demo now performs an actual transpose and runs all seven
examples to completion.

The failure was not cosmetic: it landed in "Example 3: Load from file", the
third of seven, so examples 4-7 (control flow, error handling, dynamic kernel
generation, serialization) never executed.

No slice can produce the declared `[128, 64]` result from a `[64, 128]` source,
because a slice extent is capped by the source axis it reads — the declared
return type is reachable only through a transpose. `clamp=True`, which the
bounds-check diagnostic offers as a remedy, is not the fix here either: it keeps
the `[128, 64]` window but narrows the valid region to `[63, 64]`, leaving a
half-padded result that still is not a transpose.

## Changes

- `examples/utils/parse_from_text.py`: the `matrix_transpose` demo now calls
  `pl.transpose(x, 0, 1)`, which yields exactly the declared
  `Tensor[[128, 64], FP16]`, instead of a `pl.slice` window that ran off the end
  of dimension 0. The comment describing that slice as a "simplified transpose"
  is dropped, since the code now is one.

No library, IR, or API behavior changes — the edit is confined to the example's
embedded program text. No migration step and no follow-up are implied.

## Verification

All commands were run at the pushed head `2edba0e`, after rebase onto `main`:

- `cmake --build build --parallel`: exit 0
- `python examples/utils/parse_from_text.py`: exit 0 — all 7 examples complete
  ("All examples completed successfully!"); previously exit 1 at example 3
- `pre-commit run --files examples/utils/parse_from_text.py`: exit 0 — 16 hooks,
  12 passed and 4 skipped as not applicable to a Python file
- `python -m pytest tests/ut -n auto --maxprocesses 8 -q`: exit 0 — 9187 passed,
  2 skipped in 148.28s