### PR TITLE
fix(examples): restore the batch paged attention example

### DIFF
--- a/examples/models/05_paged_attention_batch.py
+++ b/examples/models/05_paged_attention_batch.py
@@ -114,14 +114,15 @@ def BuildBatchPagedAttentionProgram(
                     [q_tile, head_dim],
                     target_memory=pl.MemorySpace.Mat,
                 )
-                kj_l1 = pl.load(
+                kj_nat = pl.load(
                     key_cache,
                     [kj_row, 0],
                     [block_size, head_dim],
                     target_memory=pl.MemorySpace.Mat,
                 )
+                kj_l1 = pl.tile.transpose_view(kj_nat)
                 qi_l0a = pl.move(qi_l1, target_memory=pl.MemorySpace.Left)
-                kj_l0b = pl.move(kj_l1, target_memory=pl.MemorySpace.Right, transpose=True)
+                kj_l0b = pl.move(kj_l1, target_memory=pl.MemorySpace.Right)
                 sij_l0c = pl.matmul(qi_l0a, kj_l0b)
                 sij_batch_new = pl.store(sij_l0c, [b * q_tile, 0], sij_batch)
             return sij_batch_new
@@ -260,7 +261,7 @@ def BuildBatchPagedAttentionProgram(
             for b in pl.range(batch_count):
                 dst_row = b * num_heads_param + q_offset
 
-                if is_first:
+                if is_first != 0:
                     mij_tile = pl.load(
                         mij_batch,
                         [b * q_tile, 0],
@@ -284,7 +285,7 @@ def BuildBatchPagedAttentionProgram(
                     li_batch = pl.store(lij_tile, [b * q_tile, 0], li_batch, [q_tile, 1])
                     oi_batch = pl.store(oi_new_tile, [b * q_tile, 0], oi_batch, [q_tile, head_dim])
 
-                    if is_last:
+                    if is_last != 0:
                         dst_tile = pl.row_expand_div(oi_new_tile, lij_tile)
                         out_tensor = pl.store(dst_tile, [dst_row, 0], out_tensor, [q_tile, head_dim])
                 else:
@@ -350,7 +351,7 @@ def BuildBatchPagedAttentionProgram(
                     oi_new_scaled = pl.row_expand_mul(oi_new_tile, beta_dn)
                     oi_updated = pl.add(oi_scaled, oi_new_scaled)
 
-                    if is_last:
+                    if is_last != 0:
                         dst_tile = pl.row_expand_div(oi_updated, li_updated_dn)
                         out_tensor = pl.store(dst_tile, [dst_row, 0], out_tensor, [q_tile, head_dim])
                     else:
@@ -392,15 +393,22 @@ def BuildBatchPagedAttentionProgram(
             """
             batch_cfg = pl.tensor.read(config, [0])
             num_heads_cfg = pl.tensor.read(config, [1])
-            head_dim_cfg = pl.tensor.read(config, [3])
             block_size_cfg = pl.tensor.read(config, [4])
             block_num_cfg = pl.tensor.read(config, [5])
 
             q_loop_cfg = (num_heads_cfg + q_tile - 1) // q_tile
 
-            # Compute max_bn across all batches (mirrors C++ max_bn loop)
-            max_bn = pl.yield_(0)
-            for b in pl.range(batch_cfg):
+            # Compute max_bn across all batches (mirrors C++ max_bn loop).
+            # The loop carries max_bn, so it must be seeded from a bound variable:
+            # batch 0 is peeled into the if/else phi and the loop starts at 1.
+            zero_bn_cfg: pl.Scalar[pl.INT64] = 0
+            if batch_cfg == 0:
+                max_bn: pl.Scalar[pl.INT64] = pl.yield_(zero_bn_cfg)
+            else:
+                first_seq = pl.tensor.read(context_lens, [0])
+                first_bn_cfg: pl.Scalar[pl.INT64] = (first_seq + block_size_cfg - 1) // block_size_cfg
+                max_bn: pl.Scalar[pl.INT64] = pl.yield_(first_bn_cfg)
+            for b in pl.range(1, batch_cfg):
                 cur_seq_b = pl.tensor.read(context_lens, [b])
                 bn_b = (cur_seq_b + block_size_cfg - 1) // block_size_cfg
                 max_bn = pl.max(max_bn, bn_b)  # type: ignore[reportArgumentType]
@@ -409,17 +417,17 @@ def BuildBatchPagedAttentionProgram(
                 q_offset = q_idx * q_tile
 
                 # Batch-sized accumulators (mirrors C++ oi_batch/li_batch/mi_batch)
-                oi_batch = pl.create_tensor([batch_cfg * q_tile, head_dim_cfg], dtype=pl.FP32)
-                li_batch = pl.create_tensor([batch_cfg * q_tile, 1], dtype=pl.FP32)
-                mi_batch = pl.create_tensor([batch_cfg * q_tile, 1], dtype=pl.FP32)
+                oi_batch = pl.create_tensor([batch_q_tile, head_dim], dtype=pl.FP32)
+                li_batch = pl.create_tensor([batch_q_tile, 1], dtype=pl.FP32)
+                mi_batch = pl.create_tensor([batch_q_tile, 1], dtype=pl.FP32)
 
                 for bn in pl.range(max_bn):
                     # Batch-sized intermediate tensors (mirrors C++ sij_b/pij_b/etc.)
-                    sij_b = pl.create_tensor([batch_cfg * q_tile, block_size_cfg], dtype=pl.FP32)
-                    pij_b = pl.create_tensor([batch_cfg * q_tile, block_size_cfg], dtype=pl.FP16)
-                    mij_b = pl.create_tensor([batch_cfg * q_tile, 1], dtype=pl.FP32)
-                    lij_b = pl.create_tensor([batch_cfg * q_tile, 1], dtype=pl.FP32)
-                    oi_new_b = pl.create_tensor([batch_cfg * q_tile, head_dim_cfg], dtype=pl.FP32)
+                    sij_b = pl.create_tensor([batch_q_tile, block_size], dtype=pl.FP32)
+                    pij_b = pl.create_tensor([batch_q_tile, block_size], dtype=pl.BF16)
+                    mij_b = pl.create_tensor([batch_q_tile, 1], dtype=pl.FP32)
+                    lij_b = pl.create_tensor([batch_q_tile, 1], dtype=pl.FP32)
+                    oi_new_b = pl.create_tensor([batch_q_tile, head_dim], dtype=pl.FP32)
 
                     # Stage 1: QK matmul (FUNC_QK_MATMUL, AIC / CUBE)
                     sij_b = self.KernelQkMatmul(


### PR DESCRIPTION
## Summary

`examples/models/05_paged_attention_batch.py` aborts before emitting any code and
has done so since #394 removed the `transpose` kwarg from `pl.move` on
2026-03-10 — one day after #388 added the example. It was then missed by the
#1883 migration that moved examples 04 and 06-09 onto `tile.transpose_view`,
because it was already failing on a different op and so never showed up in that
PR's blast radius. Six independent breakages had accumulated behind that first
error; fixing only the reported kwarg just surfaces the next one, so this PR
fixes all six. The example now compiles end to end, emitting four kernels, the
orchestration translation unit and four `.pto` files.

Nothing caught the rot, which is worth noting for reviewers: the only consumer
of `BuildBatchPagedAttentionProgram` is `BatchPagedAttentionTestCase` in
`tests/st/runtime/framework_and_models/test_batch_paged_attention.py`, whose
test is skipped, and the four active cases in that file build their own inline
programs. Their inline QK kernel already uses `tile.transpose_view` — the test
copies were migrated while the example was not.

## Changes

- `examples/models/05_paged_attention_batch.py`:
  - `pl.move(..., transpose=True)` becomes a natural load plus
    `pl.tile.transpose_view`, matching examples 04, 06 and 09.
  - `if is_first:` / `if is_last:` on a `Scalar[INT64]` become explicit `!= 0`
    comparisons, which the parser now requires.
  - `max_bn = pl.yield_(0)` never bound a variable outside an if/else, so the
    loop accumulating it referenced an undefined name. Batch 0 is peeled into an
    if/else phi and the loop starts at 1 — the idiom already used by
    `09_paged_attention_spmd.py`. Seeding the carry from a bound variable also
    avoids an internal error on a literal iter_arg init value.
  - The orchestration allocated intermediates from runtime `config` reads while
    every kernel declares static shapes, so the first kernel call failed to
    type-check. Shapes now come from the same build-time constants the kernels
    use, which drops the then-unused `head_dim_cfg` read.
  - `pij_b` was created `FP16` while all four kernels declare `BF16`, as the
    module docstring already documented.

## Behavior change

Trading the config-derived shapes for build-time constants means the
orchestration no longer sizes its intermediates from `config[3]`/`config[4]`;
the `config` reads that drive the loop bounds are unchanged. This matches
`09_paged_attention_spmd.py` and makes the orchestration consistent with the
statically typed kernels it calls. No library code changes, so nothing outside
this example is affected.

## Follow-ups (not in this PR)

- `test_batch_paged_attention` remains `@pytest.mark.skip(reason="Under
  debugging and fixing")`. Its `get_program()` works again now, but un-skipping
  it needs on-board hardware to validate, which this change was not able to do.
- The `max_bn` failure surfaced as `Internal error: ForStmt iter_arg initValue
  must be a variable` — an internal-error leak at codegen on a program the DSL
  accepts at trace time. Worked around in the example rather than fixed in the
  compiler.

## Verification

- `pre-commit run --files examples/models/05_paged_attention_batch.py`: exit 0 —
  check-headers, check-english-only, docs parity/nav/symbol-coverage,
  no-broad-raises, ruff check, ruff format and pyright all pass.
- `python -m pytest tests/ut -n auto --maxprocesses 8 -q`: exit 0 — 9187 passed,
  2 skipped, at the pushed head.
- `python examples/models/05_paged_attention_batch.py`: exit 0 — emits 4 kernels,
  the orchestration translation unit and 4 `.pto` files.