### PR TITLE
fix(parser): accept positional enum and numeric op arguments

### DIFF
--- a/docs/en/dev/language/00-python_syntax.md
+++ b/docs/en/dev/language/00-python_syntax.md
@@ -283,6 +283,20 @@ def func(t: pl.Tensor[[128, 128], pl.FP32], out: pl.Tensor[[128, 128], pl.FP32])
     ...
 ```
 
+**Enum op arguments:** Op wrappers have parameter slots that take a Python enum
+rather than an IR expression — `DataType`, `MemorySpace`, `TensorLayout`,
+`TileLayout`, `PadValue`, `ArgDirection`. These resolve identically whether
+written positionally or by keyword, both as literal attributes and as closure
+names, so the two lines below build the same call:
+
+```python
+p = pl.fillpad(t, pl.PadValue.min)              # positional
+p = pl.fillpad(t, pad_value=pl.PadValue.min)    # keyword
+```
+
+The same holds for the numeric sugars an op accepts in such a slot: `pl.fillpad`
+takes `0`, `0.0`, `math.inf`, and `-math.inf` in either position.
+
 ### Subscript Indexing
 
 `Tensor` and `Tile` subscripts use numpy/torch-style semantics:

--- a/docs/zh/dev/language/00-python_syntax.md
+++ b/docs/zh/dev/language/00-python_syntax.md
@@ -257,6 +257,19 @@ def func(t: pl.Tensor[[128, 128], pl.FP32], out: pl.Tensor[[128, 128], pl.FP32])
     ...
 ```
 
+**枚举类算子实参 (Enum op arguments):** 算子包装函数中有一类形参接收 Python
+枚举而非 IR 表达式 —— `DataType`、`MemorySpace`、`TensorLayout`、`TileLayout`、
+`PadValue`、`ArgDirection`。无论按位置传入还是按关键字传入，也无论写成字面属性
+还是闭包名称，它们的解析结果完全一致，因此下面两行构建出相同的调用:
+
+```python
+p = pl.fillpad(t, pl.PadValue.min)              # positional
+p = pl.fillpad(t, pad_value=pl.PadValue.min)    # keyword
+```
+
+算子在此类形参上接受的数值糖也同样如此: `pl.fillpad` 在两种位置上都接受 `0`、
+`0.0`、`math.inf` 和 `-math.inf`。
+
 ### 下标索引 (Subscript Indexing)
 
 `Tensor` 和 `Tile` 的下标采用 numpy/torch 风格的语义:

--- a/python/pypto/ir/op/_pad_value.py
+++ b/python/pypto/ir/op/_pad_value.py
@@ -17,7 +17,7 @@ with a clear hint so the user is never silently given a different value.
 
 import math
 
-from pypto.pypto_core.ir import PadValue
+from pypto.pypto_core.ir import ConstFloat, ConstInt, PadValue
 
 _HINT = (
     "Use pl.PadValue.zero / pl.PadValue.max / pl.PadValue.min, "
@@ -33,11 +33,20 @@ def normalize_pad_value(pad_value: object) -> PadValue:
       * ``0`` / ``0.0`` — mapped to ``PadValue.zero``.
       * ``math.inf`` — mapped to ``PadValue.max``.
       * ``-math.inf`` — mapped to ``PadValue.min``.
+      * A ``ConstInt`` / ``ConstFloat`` wrapping one of those literals.
 
     ``PadValue.null`` is rejected because "no padding mode" is meaningless
     for an op that exists to write a fill value. Anything else (other
     numbers, ``NaN``, ``bool``, ``str``, ``None``, ...) also raises.
     """
+    # A literal written positionally inside a ``@pl.function`` body reaches the
+    # IR builders as a ``ConstInt`` / ``ConstFloat``: the DSL parser materializes
+    # positional constants into IR so they carry its chosen dtype. Unwrap here so
+    # ``fillpad(t, 0)`` normalizes like ``fillpad(t, pad_value=0)``, and so a
+    # rejected value is reported as the number the user wrote rather than as
+    # "ConstInt".
+    if isinstance(pad_value, (ConstInt, ConstFloat)):
+        pad_value = pad_value.value
     if isinstance(pad_value, PadValue):
         if pad_value == PadValue.null:
             raise ValueError(

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -67,6 +67,20 @@ if TYPE_CHECKING:
 # / tile_ops); also surfaced as the hint in _parse_pld_category_op.
 _PLD_CATEGORIES: frozenset[str] = frozenset({"system", "tensor", "tile"})
 
+# Enum values that op wrappers and printed ``attrs={...}`` dicts take verbatim.
+# ``parse_expression`` cannot represent these: it either rejects the standalone
+# attribute form outright or (for MemorySpace) lowers it to a ConstInt that the
+# IR builders then reject, so every path that reads such a value must recognize
+# it before falling back to expression parsing.
+_ENUM_VALUE_TYPES: tuple[type, ...] = (
+    DataType,
+    ir.MemorySpace,
+    ir.TensorLayout,
+    ir.TileLayout,
+    ir.PadValue,
+    ir.ArgDirection,
+)
+
 
 def _is_empty_body(body: list[ast.stmt]) -> bool:
     """True if a function body carries no statements beyond a signature marker.
@@ -7330,10 +7344,7 @@ class ASTParser:
         # them to ConstInt and silently changes the stored attr type.
         if isinstance(value_node, ast.Attribute):
             success, value = self.expr_evaluator.try_eval_expr(value_node)
-            if success and isinstance(
-                value,
-                (DataType, ir.MemorySpace, ir.TensorLayout, ir.TileLayout, ir.PadValue, ir.ArgDirection),
-            ):
+            if success and isinstance(value, _ENUM_VALUE_TYPES):
                 return value
 
             # Keep the dtype resolver's diagnostic for unknown ``pl.<DTYPE>``
@@ -7663,17 +7674,50 @@ class ASTParser:
     def _parse_op_positional_arg(self, arg: ast.expr) -> Any:
         """Parse a positional op argument.
 
+        Positional and keyword op arguments must agree: ``pl.fillpad(t,
+        pl.PadValue.zero)`` means exactly what ``pl.fillpad(t,
+        pad_value=pl.PadValue.zero)`` means. Wrappers have non-Expr parameter
+        slots (dtypes, memory spaces, pad modes) that ``parse_expression``
+        cannot represent, so those spellings are resolved here the same way
+        ``_parse_op_kwargs`` resolves them.
+
         For ``ast.Attribute`` nodes (e.g. ``pl.INDEX``, ``pl.FP32``), try
         dtype resolution first so wrappers receive a ``DataType`` for slots
-        like ``pl.cast(value, dtype)``. Falls through to ``parse_expression``
-        for everything else, which keeps Tensor/Tile/Scalar var lookups,
-        list literals, etc. on the existing path.
+        like ``pl.cast(value, dtype)``, then closure evaluation for enum and
+        numeric constants (``pl.PadValue.zero``, ``math.inf``) — neither of
+        which ``parse_expression`` accepts. ``ast.Name`` resolves enums from
+        the closure only when the name is not an IR variable; numeric closure
+        names stay on the existing path, which materializes them as
+        ``ConstInt`` / ``ConstFloat`` carrying the parser's chosen dtype.
+        Everything else falls through to ``parse_expression``, which keeps
+        Tensor/Tile/Scalar var lookups, list literals, etc. unchanged.
         """
         if isinstance(arg, ast.Attribute):
             try:
                 return self.type_resolver.resolve_dtype(arg)
             except ParserError:
                 pass
+            success, value = self.expr_evaluator.try_eval_expr(arg)
+            # bool subclasses int — a positional ``True`` is not a numeric
+            # constant slot, so leave it on the expression path.
+            if success and (
+                isinstance(value, _ENUM_VALUE_TYPES)
+                or (isinstance(value, (int, float)) and not isinstance(value, bool))
+            ):
+                return value
+        elif isinstance(arg, ast.Name) and self.scope_manager.lookup_var(arg.id) is None:
+            success, value = self.expr_evaluator.try_eval_expr(arg)
+            if success and isinstance(value, _ENUM_VALUE_TYPES):
+                return value
+        elif isinstance(arg, ast.UnaryOp) and isinstance(arg.op, ast.USub):
+            # ``-math.inf`` — parse_expression would descend into the operand
+            # and hit the standalone-attribute rejection. Only attributes are
+            # intercepted; ``-<name>`` and ``-<literal>`` keep their existing
+            # expression handling.
+            if isinstance(arg.operand, ast.Attribute):
+                success, value = self.expr_evaluator.try_eval_expr(arg.operand)
+                if success and isinstance(value, (int, float)) and not isinstance(value, bool):
+                    return -value
         return self.parse_expression(arg)
 
     def _parse_op_kwargs(self, call: ast.Call) -> dict[str, Any]:

--- a/tests/ut/language/test_fillpad_pad_value.py
+++ b/tests/ut/language/test_fillpad_pad_value.py
@@ -13,6 +13,11 @@ The hardware only supports ``PadValue.zero`` / ``max`` / ``min``. The DSL
 accepts the literal sugars ``0``, ``math.inf``, ``-math.inf`` as a friendlier
 form; everything else must raise so a user is never silently given a different
 fill value.
+
+``pad_value`` is an ordinary positional-or-keyword parameter, so every spelling
+must also work positionally: inside a ``@pl.function`` body the parser has to
+resolve the enum and the numeric sugars for a positional slot the same way it
+resolves them for ``pad_value=``.
 """
 
 import math
@@ -22,6 +27,10 @@ import pytest
 from pypto import ir
 from pypto.ir.op._pad_value import normalize_pad_value
 from pypto.language.parser.diagnostics.exceptions import InvalidOperationError
+
+# Module-level closure constant — exercises the bare-``Name`` positional path,
+# which resolves from the closure rather than from the IR variable scope.
+CLOSURE_PAD = pl.PadValue.max
 
 
 class TestNormalizePadValueAccepts:
@@ -68,6 +77,42 @@ class TestNormalizePadValueRejects:
             normalize_pad_value(value)
 
 
+class TestNormalizePadValueUnwrapsConstants:
+    """A positional literal reaches the IR builders as ``ConstInt`` / ``ConstFloat``.
+
+    The DSL parser materializes positional constants into IR so they carry its
+    chosen dtype, so ``fillpad(t, 0)`` hands ``normalize_pad_value`` an IR node
+    rather than a Python number. It must normalize identically to the bare
+    literal, and must report the *value* — not the node type — when rejecting.
+    """
+
+    @pytest.mark.parametrize(
+        "const,expected",
+        [
+            (ir.ConstInt(0, ir.DataType.INDEX, ir.Span.unknown()), ir.PadValue.zero),
+            (ir.ConstFloat(0.0, ir.DataType.FP32, ir.Span.unknown()), ir.PadValue.zero),
+            (ir.ConstFloat(math.inf, ir.DataType.FP32, ir.Span.unknown()), ir.PadValue.max),
+            (ir.ConstFloat(-math.inf, ir.DataType.FP32, ir.Span.unknown()), ir.PadValue.min),
+        ],
+    )
+    def test_accepts_wrapped_literals(self, const, expected):
+        assert normalize_pad_value(const) is expected
+
+    def test_rejects_wrapped_int_naming_the_value(self):
+        const = ir.ConstInt(7, ir.DataType.INDEX, ir.Span.unknown())
+        with pytest.raises(ValueError, match="got 7") as exc:
+            normalize_pad_value(const)
+        # The old message named the IR node type, which told the user nothing
+        # about the value they actually wrote.
+        assert "ConstInt" not in str(exc.value)
+
+    def test_rejects_wrapped_float_naming_the_value(self):
+        const = ir.ConstFloat(3.14, ir.DataType.FP32, ir.Span.unknown())
+        with pytest.raises(ValueError, match="got 3.14") as exc:
+            normalize_pad_value(const)
+        assert "ConstFloat" not in str(exc.value)
+
+
 class TestFillpadSugarMatchesEnum:
     """End-to-end: ``pl.fillpad`` with sugar IRs identically to the enum form."""
 
@@ -95,6 +140,201 @@ class TestFillpadSugarMatchesEnum:
                 return y
 
         ir.assert_structural_equal(Sugared, Expected)
+
+
+class TestFillpadPositionalPadValue:
+    """A positional ``pad_value`` IRs identically to the keyword spelling.
+
+    ``pad_value`` is positional-or-keyword, so ``pl.fillpad(x, PadValue.zero)``
+    must mean exactly what ``pl.fillpad(x, pad_value=PadValue.zero)`` means.
+    Each case uses a distinct class name: the DSL looks a program's source up by
+    class name, so reusing one name across cases would silently re-parse the
+    first body and make every assertion vacuous.
+    """
+
+    def test_positional_enum(self):
+        @pl.program
+        class PositionalEnum:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main(self, x: pl.Tensor[[8, 32], pl.FP32]) -> pl.Tensor[[8, 32], pl.FP32]:
+                y: pl.Tensor[[8, 32], pl.FP32] = pl.fillpad(x, pl.PadValue.zero)
+                return y
+
+        @pl.program
+        class KeywordEnum:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main(self, x: pl.Tensor[[8, 32], pl.FP32]) -> pl.Tensor[[8, 32], pl.FP32]:
+                y: pl.Tensor[[8, 32], pl.FP32] = pl.fillpad(x, pad_value=pl.PadValue.zero)
+                return y
+
+        ir.assert_structural_equal(PositionalEnum, KeywordEnum)
+
+    def test_positional_int_literal(self):
+        @pl.program
+        class PositionalZeroInt:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main(self, x: pl.Tensor[[8, 32], pl.FP32]) -> pl.Tensor[[8, 32], pl.FP32]:
+                y: pl.Tensor[[8, 32], pl.FP32] = pl.fillpad(x, 0)
+                return y
+
+        @pl.program
+        class KeywordZeroInt:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main(self, x: pl.Tensor[[8, 32], pl.FP32]) -> pl.Tensor[[8, 32], pl.FP32]:
+                y: pl.Tensor[[8, 32], pl.FP32] = pl.fillpad(x, pad_value=pl.PadValue.zero)
+                return y
+
+        ir.assert_structural_equal(PositionalZeroInt, KeywordZeroInt)
+
+    def test_positional_float_literal(self):
+        @pl.program
+        class PositionalZeroFloat:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main(self, x: pl.Tensor[[8, 32], pl.FP32]) -> pl.Tensor[[8, 32], pl.FP32]:
+                y: pl.Tensor[[8, 32], pl.FP32] = pl.fillpad(x, 0.0)
+                return y
+
+        @pl.program
+        class KeywordZeroFloat:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main(self, x: pl.Tensor[[8, 32], pl.FP32]) -> pl.Tensor[[8, 32], pl.FP32]:
+                y: pl.Tensor[[8, 32], pl.FP32] = pl.fillpad(x, pad_value=pl.PadValue.zero)
+                return y
+
+        ir.assert_structural_equal(PositionalZeroFloat, KeywordZeroFloat)
+
+    def test_positional_inf(self):
+        @pl.program
+        class PositionalInf:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main(self, x: pl.Tensor[[8, 32], pl.FP32]) -> pl.Tensor[[8, 32], pl.FP32]:
+                y: pl.Tensor[[8, 32], pl.FP32] = pl.fillpad(x, math.inf)
+                return y
+
+        @pl.program
+        class KeywordMax:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main(self, x: pl.Tensor[[8, 32], pl.FP32]) -> pl.Tensor[[8, 32], pl.FP32]:
+                y: pl.Tensor[[8, 32], pl.FP32] = pl.fillpad(x, pad_value=pl.PadValue.max)
+                return y
+
+        ir.assert_structural_equal(PositionalInf, KeywordMax)
+
+    def test_positional_negative_inf(self):
+        @pl.program
+        class PositionalNegInf:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main(self, x: pl.Tensor[[8, 32], pl.FP32]) -> pl.Tensor[[8, 32], pl.FP32]:
+                y: pl.Tensor[[8, 32], pl.FP32] = pl.fillpad(x, -math.inf)
+                return y
+
+        @pl.program
+        class KeywordMin:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main(self, x: pl.Tensor[[8, 32], pl.FP32]) -> pl.Tensor[[8, 32], pl.FP32]:
+                y: pl.Tensor[[8, 32], pl.FP32] = pl.fillpad(x, pad_value=pl.PadValue.min)
+                return y
+
+        ir.assert_structural_equal(PositionalNegInf, KeywordMin)
+
+    def test_positional_closure_name(self):
+        @pl.program
+        class PositionalClosureName:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main(self, x: pl.Tensor[[8, 32], pl.FP32]) -> pl.Tensor[[8, 32], pl.FP32]:
+                y: pl.Tensor[[8, 32], pl.FP32] = pl.fillpad(x, CLOSURE_PAD)
+                return y
+
+        @pl.program
+        class KeywordClosureName:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main(self, x: pl.Tensor[[8, 32], pl.FP32]) -> pl.Tensor[[8, 32], pl.FP32]:
+                y: pl.Tensor[[8, 32], pl.FP32] = pl.fillpad(x, pad_value=CLOSURE_PAD)
+                return y
+
+        ir.assert_structural_equal(PositionalClosureName, KeywordClosureName)
+
+    def test_positional_tile_fillpad(self):
+        @pl.program
+        class PositionalTileFillpad:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main(self, x: pl.Tensor[[8, 32], pl.FP32]) -> pl.Tensor[[8, 32], pl.FP32]:
+                out = pl.create_tensor([8, 32], pl.FP32)
+                t = pl.load(x, [0, 0], [8, 32], target_memory=pl.MemorySpace.Vec)
+                p = pl.tile.fillpad(t, pl.PadValue.min)
+                pl.store(p, [0, 0], out)
+                return out
+
+        @pl.program
+        class KeywordTileFillpad:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main(self, x: pl.Tensor[[8, 32], pl.FP32]) -> pl.Tensor[[8, 32], pl.FP32]:
+                out = pl.create_tensor([8, 32], pl.FP32)
+                t = pl.load(x, [0, 0], [8, 32], target_memory=pl.MemorySpace.Vec)
+                p = pl.tile.fillpad(t, pad_value=pl.PadValue.min)
+                pl.store(p, [0, 0], out)
+                return out
+
+        ir.assert_structural_equal(PositionalTileFillpad, KeywordTileFillpad)
+
+    def test_positional_fillpad_expand(self):
+        @pl.program
+        class PositionalExpand:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main(self, x: pl.Tensor[[8, 32], pl.FP32]) -> pl.Tensor[[16, 32], pl.FP32]:
+                y: pl.Tensor[[16, 32], pl.FP32] = pl.fillpad_expand(x, [16, 32], pl.PadValue.max)
+                return y
+
+        @pl.program
+        class KeywordExpand:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main(self, x: pl.Tensor[[8, 32], pl.FP32]) -> pl.Tensor[[16, 32], pl.FP32]:
+                y: pl.Tensor[[16, 32], pl.FP32] = pl.fillpad_expand(x, [16, 32], pad_value=pl.PadValue.max)
+                return y
+
+        ir.assert_structural_equal(PositionalExpand, KeywordExpand)
+
+
+class TestFillpadPositionalRejection:
+    """An invalid positional ``pad_value`` still raises, naming the value.
+
+    The pre-fix message reported the parser's IR node type ("got ConstInt"),
+    which named neither the value the user wrote nor anything actionable.
+    """
+
+    def test_positional_arbitrary_int_names_the_value(self):
+        with pytest.raises(InvalidOperationError, match="got 7") as exc:
+
+            @pl.program
+            class BadPositionalInt:
+                @pl.function(type=pl.FunctionType.InCore)
+                def main(self, x: pl.Tensor[[8, 32], pl.FP32]) -> pl.Tensor[[8, 32], pl.FP32]:
+                    y: pl.Tensor[[8, 32], pl.FP32] = pl.fillpad(x, 7)
+                    return y
+
+        assert "ConstInt" not in str(exc.value)
+
+    def test_positional_arbitrary_float_names_the_value(self):
+        with pytest.raises(InvalidOperationError, match="got 3.14") as exc:
+
+            @pl.program
+            class BadPositionalFloat:
+                @pl.function(type=pl.FunctionType.InCore)
+                def main(self, x: pl.Tensor[[8, 32], pl.FP32]) -> pl.Tensor[[8, 32], pl.FP32]:
+                    y: pl.Tensor[[8, 32], pl.FP32] = pl.fillpad(x, 3.14)
+                    return y
+
+        assert "ConstFloat" not in str(exc.value)
+
+    def test_positional_null_enum(self):
+        with pytest.raises(InvalidOperationError, match="fillpad pad_value"):
+
+            @pl.program
+            class BadPositionalNull:
+                @pl.function(type=pl.FunctionType.InCore)
+                def main(self, x: pl.Tensor[[8, 32], pl.FP32]) -> pl.Tensor[[8, 32], pl.FP32]:
+                    y: pl.Tensor[[8, 32], pl.FP32] = pl.fillpad(x, pl.PadValue.null)
+                    return y
 
 
 class TestFillpadEndToEndRejection:


### PR DESCRIPTION
## Summary

`pl.fillpad` declares `pad_value` as an ordinary positional-or-keyword parameter, but only the keyword spelling worked inside a `@pl.function` body. Both positional forms failed, for two unrelated reasons, and one of them reported the parser's IR node type instead of the value the user wrote. The underlying gap was not specific to fillpad: positional and keyword op arguments were resolved by different code paths, so *any* op parameter slot taking a Python enum rather than an IR expression rejected the positional spelling. After this change every spelling builds the same call, and a rejected pad value names the number the user wrote.

```python
p = pl.fillpad(t, pad_value=pl.PadValue.zero)   # worked before
p = pl.fillpad(t, pl.PadValue.zero)             # was: Standalone attribute access not supported
p = pl.fillpad(t, 0)                            # was: ... got ConstInt
pl.tile.create([8, 32], pl.FP32, pl.MemorySpace.Vec)   # was: expects MemorySpace, got incompatible type
```

## Changes

- `python/pypto/language/parser/ast_parser.py`: positional op arguments now resolve the way keyword op arguments already did. An attribute yields the enum types a wrapper takes verbatim (`DataType`, `MemorySpace`, `TensorLayout`, `TileLayout`, `PadValue`, `ArgDirection`) or a plain numeric constant such as `math.inf`; a bare name resolves an enum from the closure when it is not an IR variable; and `-<attribute>` negates so `-math.inf` reaches the wrapper. Numeric closure *names* deliberately stay on the existing path, which materializes them as `ConstInt` / `ConstFloat` carrying the parser's chosen dtype — that behavior is unchanged. The enum type tuple shared with the printed `attrs={...}` reader is hoisted into one module constant instead of being spelled twice.
- `python/pypto/ir/op/_pad_value.py`: `normalize_pad_value` unwraps a `ConstInt` / `ConstFloat`. The parser materializes a positional constant into IR so it carries a dtype, so `fillpad(t, 0)` arrived here as an IR node with no matching case. This also fixes the diagnostic: an invalid value now reports `got 7` rather than `got ConstInt`.
- `tests/ut/language/test_fillpad_pad_value.py`: covers every positional spelling (enum, `0`, `0.0`, `math.inf`, `-math.inf`, closure name) against its keyword equivalent via `assert_structural_equal`, plus `pl.tile.fillpad` and `pl.fillpad_expand`, the `ConstInt` / `ConstFloat` normalization cases, and the improved rejection messages.
- `docs/{en,zh}/dev/language/00-python_syntax.md`: documents the enum op-argument slots next to the existing closure-variable section, which listed only `int`, `float`, `bool`, `list`, `tuple`.

No interface or migration step: every previously accepted spelling keeps its exact behavior and IR, and the change only admits spellings that were hard errors before.

Note on the new tests: each case uses a distinct program class name because the DSL looks a program's source up by class name, so reusing one name across cases silently re-parses the first body and makes the assertions vacuous.

## Verification

Run at the pushed head, rebased onto `upstream/main`:

- `cmake --build build --parallel`: exit 0
- `python -m pytest tests/ut/ -n auto --maxprocesses 8`: exit 0 — 9204 passed, 2 skipped
- `pre-commit run --from-ref upstream/main --to-ref HEAD`: exit 0 — all hooks passed (check-headers, check-english-only, check-docs-en-zh-parity, check-docs-nav, check-docs-symbol-coverage, check-no-broad-raises, markdownlint-cli2, ruff check, ruff format, pyright)

The new tests were also confirmed to fail with only the two source files reverted, then pass again once restored, so they exercise the fix rather than passing vacuously.