### PR TITLE
fix(ir): fold param dyn-dim reads on Orchestration promotion

### DIFF
--- a/docs/en/dev/passes/08-outline_incore_scopes.md
+++ b/docs/en/dev/passes/08-outline_incore_scopes.md
@@ -48,6 +48,32 @@ program_outlined = outline_pass(program)
    - Call to outlined function with input arguments
    - AssignStmt for each output variable
 6. **Add to Program**: Add outlined function to program's function list
+7. **Promote the parent**: an Opaque parent that outlined at least one scope becomes
+   `Orchestration` — and its param dyn-dim reads are folded first (below)
+
+**Param dyn-dim reads fold on promotion**: a tensor's declared extent *is* its
+runtime extent, so `pl.tensor.dim(a, 0)` on a param whose axis is a `pl.dynamic`
+symbol mints a *second* IR name for one quantity, and shapes built from the copy
+no longer compare equal to shapes built from the symbol. The DSL parser folds
+that read onto the symbol (`ASTParser._fold_tensor_dim`), but only in an
+Orchestration body — that is where Orchestration codegen defines the symbol from
+the param's task-arg descriptor, and where the fold is therefore sound. A body
+written as `Opaque` keeps the read, so this pass folds it at the moment it
+promotes the function, *before* outlining:
+
+```python
+# Opaque parent, as written                # after promotion
+m = pl.tensor.dim(a, 0)                    # (binding folded away)
+with pl.spmd(m // 16):                     with pl.spmd(M_DYN // 16):
+    ...                                        ...
+```
+
+Folding before the outliner runs means the promoted body reaches it in the same
+shape the parser hands an already-Orchestration function, so both paths produce
+identical IR. Without it the pass emits IR that no longer parses back to itself
+(the printed `tensor.dim` binding vanishes on reparse), breaking print→parse
+round-trip verification. Reads the parser would not fold are left alone: a
+constant extent, a runtime axis, or a symbol the signature does not declare.
 
 **Live-in, not `uses \ defs`**: the input set is computed flow-sensitively
 (`UpwardExposedUseCollector`). A plain set difference is wrong for a captured

--- a/docs/en/dev/passes/08-outline_incore_scopes.md
+++ b/docs/en/dev/passes/08-outline_incore_scopes.md
@@ -9,7 +9,10 @@ This pass transforms `InCoreScopeStmt` nodes into separate `Function(InCore)` de
 **Requirements**:
 
 - Input IR must be in SSA form (run ConvertToSSA first); SSAForm is preserved (produced) by this pass
-- Only processes Opaque functions (InCore functions are left unchanged)
+- Processes Opaque and Orchestration functions (InCore functions are left
+  unchanged). An Orchestration function carries InCore scopes when the parser
+  desugars a high-level construct such as `for i in pl.spmd(...)`; an Opaque
+  parent that outlines at least one scope is promoted to Orchestration
 
 **When to use**: Run after ConvertToSSA when you need to extract InCore computation regions into separate callable functions.
 
@@ -36,7 +39,8 @@ program_outlined = outline_pass(program)
 
 ## Algorithm
 
-1. **Scan for InCore Scopes**: Find all `InCoreScopeStmt` nodes in Opaque functions
+1. **Scan for InCore Scopes**: Find all `InCoreScopeStmt` nodes in Opaque and
+   Orchestration functions
 2. **Analyze Inputs**: Collect the scope's *live-in* set — variables the body reads
    before it (re)defines them, so their incoming value comes from the caller
 3. **Analyze Outputs**: Determine internal definitions used after scope (variables defined inside, used outside)
@@ -166,7 +170,7 @@ class Before:
 ```python
 @pl.program
 class After:
-    @pl.function  # Opaque function
+    @pl.function(type=pl.FunctionType.Orchestration)  # promoted from Opaque
     def main(self, x: Tensor[[64], FP32]) -> Tensor[[64], FP32]:
         y = x + 1
 

--- a/docs/zh/dev/passes/08-outline_incore_scopes.md
+++ b/docs/zh/dev/passes/08-outline_incore_scopes.md
@@ -9,7 +9,9 @@
 **前置条件**：
 
 - 输入 IR 必须为静态单赋值 (SSA) 形式（需先运行 ConvertToSSA）；该 Pass 保持（产生）SSAForm
-- 仅处理 Opaque 函数（InCore 函数保持不变）
+- 处理 Opaque 与 Orchestration 函数（InCore 函数保持不变）。当解析器将
+  `for i in pl.spmd(...)` 这类高层构造展开时，Orchestration 函数同样会携带
+  InCore 作用域；至少提取出一个作用域的 Opaque 父函数会被提升为 Orchestration
 
 **使用时机**：在 ConvertToSSA 之后运行，当需要将 InCore 计算区域提取为独立的可调用函数时使用。
 
@@ -36,7 +38,8 @@ program_outlined = outline_pass(program)
 
 ## 算法
 
-1. **扫描 InCore 作用域**：在 Opaque 函数中查找所有 `InCoreScopeStmt` 节点
+1. **扫描 InCore 作用域**：在 Opaque 与 Orchestration 函数中查找所有
+   `InCoreScopeStmt` 节点
 2. **分析输入**：收集作用域的 *live-in*（活跃入口）集合——作用域体在（重新）定义
    某变量之前就读取它，说明该变量的入口值来自调用方
 3. **分析输出**：确定在作用域之后仍被使用的内部定义（在作用域内定义、在作用域外使用的变量）
@@ -157,7 +160,7 @@ class Before:
 ```python
 @pl.program
 class After:
-    @pl.function  # Opaque function
+    @pl.function(type=pl.FunctionType.Orchestration)  # promoted from Opaque
     def main(self, x: Tensor[[64], FP32]) -> Tensor[[64], FP32]:
         y = x + 1
 

--- a/docs/zh/dev/passes/08-outline_incore_scopes.md
+++ b/docs/zh/dev/passes/08-outline_incore_scopes.md
@@ -48,6 +48,30 @@ program_outlined = outline_pass(program)
    - 带有输入参数的提取函数调用
    - 每个输出变量对应一个 AssignStmt
 6. **添加到程序**：将提取的函数添加到程序的函数列表中
+7. **提升父函数**：至少提取出一个作用域的 Opaque 父函数将变为 `Orchestration`——
+   并在此之前先折叠其参数动态维度读取（见下）
+
+**参数动态维度读取在提升时折叠**：tensor 声明的 extent *就是*它的运行期
+extent，因此对以 `pl.dynamic` 符号为某一轴的参数调用 `pl.tensor.dim(a, 0)`，会
+为同一个量再造出**第二个** IR 名字，由该副本构造的 shape 也就不再与由符号构造
+的 shape 结构相等。DSL 解析器会把该读取折叠到符号上
+（`ASTParser._fold_tensor_dim`），但仅限 Orchestration 函数体——只有在那里
+Orchestration codegen 才会从参数的 task-arg 描述符定义该符号，折叠才是可靠的。
+写成 `Opaque` 的函数体会保留该读取，因此本 pass 在提升该函数的那一刻、**在提取
+之前**完成折叠：
+
+```python
+# 写法为 Opaque 的父函数                      # 提升之后
+m = pl.tensor.dim(a, 0)                    # （绑定语句已折叠消失）
+with pl.spmd(m // 16):                     with pl.spmd(M_DYN // 16):
+    ...                                        ...
+```
+
+在提取器运行前折叠，意味着被提升的函数体进入提取器时，与解析器交给一个本就是
+Orchestration 的函数的形态完全一致，两条路径产出相同的 IR。若不折叠，本 pass 产
+出的 IR 将无法再解析回自身（打印出的 `tensor.dim` 绑定在重新解析时消失），从而
+破坏 print→parse 往返验证。解析器不会折叠的读取同样保持原样：常量 extent、运行期
+轴，或并非该签名所声明的符号。
 
 **使用 live-in 而非 `uses \ defs`**：输入集合按流敏感方式计算
 （`UpwardExposedUseCollector`）。对于「先读取、再以同名重新绑定」的被捕获

--- a/src/ir/transforms/outline_incore_scopes_pass.cpp
+++ b/src/ir/transforms/outline_incore_scopes_pass.cpp
@@ -11,14 +11,20 @@
 
 #include <memory>
 #include <string>
+#include <unordered_map>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 
 #include "pypto/core/error.h"
 #include "pypto/ir/expr.h"
 #include "pypto/ir/function.h"
+#include "pypto/ir/kind_traits.h"
+#include "pypto/ir/op_registry.h"
 #include "pypto/ir/program.h"
 #include "pypto/ir/stmt.h"
+#include "pypto/ir/transforms/base/mutator.h"
+#include "pypto/ir/transforms/base/visitor.h"
 #include "pypto/ir/transforms/pass_properties.h"
 #include "pypto/ir/transforms/passes.h"
 #include "pypto/ir/transforms/utils/mutable_copy.h"
@@ -28,6 +34,108 @@
 
 namespace pypto {
 namespace ir {
+
+namespace {
+
+/// The dyn-dim symbols this signature declares.
+///
+/// Mirrors ``ASTParser._param_dim_symbols`` (``python/pypto/language/parser/
+/// ast_parser.py``): a bare Var in a tensor param's shape names that argument's
+/// runtime extent, and Orchestration codegen defines exactly those symbols from
+/// the task-arg descriptors. ``AsVarLike`` rather than ``As<Var>`` so this
+/// matches the Python ``isinstance(extent, ir.Var)``, which also accepts the
+/// ``IterArg`` subclass.
+std::unordered_set<const Var*> CollectParamDimSymbols(const std::vector<VarPtr>& params) {
+  std::unordered_set<const Var*> symbols;
+  for (const auto& param : params) {
+    auto tensor_type = As<TensorType>(param->GetType());
+    if (!tensor_type) continue;
+    for (const auto& extent : tensor_type->shape_) {
+      if (auto sym = AsVarLike(extent)) symbols.insert(sym.get());
+    }
+  }
+  return symbols;
+}
+
+/// The extent ``assign``'s ``tensor.dim`` read already names, or null when the
+/// read is a genuine runtime read that must stay.
+///
+/// Mirrors ``ASTParser._fold_tensor_dim``: keep the two in step, since a shape
+/// this folds but the parser does not (or vice versa) is exactly the print/parse
+/// divergence the fold exists to prevent.
+ExprPtr FoldedDimExtent(const AssignStmtPtr& assign, const std::unordered_set<const Var*>& symbols) {
+  auto call = As<Call>(assign->value_);
+  if (!call || !IsOp(call, "tensor.dim") || call->args_.size() != 2) return nullptr;
+  auto axis_const = As<ConstInt>(call->args_[1]);
+  if (!axis_const) return nullptr;  // Runtime axis — not foldable.
+  auto tensor_type = As<TensorType>(call->args_[0]->GetType());
+  if (!tensor_type) return nullptr;
+  const auto rank = static_cast<int64_t>(tensor_type->shape_.size());
+  int64_t axis = axis_const->value_;
+  if (axis < 0) axis += rank;
+  // An out-of-range axis is the op's error to raise, not ours to fold.
+  if (axis < 0 || axis >= rank) return nullptr;
+  const auto& extent = tensor_type->shape_[axis];
+  auto sym = AsVarLike(extent);
+  // Only a symbol this signature declares: a local scalar in the shape may since
+  // have been reassigned, so it is left alone.
+  return (sym && symbols.count(sym.get()) > 0) ? extent : nullptr;
+}
+
+/// Drops each foldable ``tensor.dim`` binding and records its name -> extent.
+class DimReadFolder : public IRMutator {
+ public:
+  explicit DimReadFolder(std::unordered_set<const Var*> symbols) : symbols_(std::move(symbols)) {}
+
+  [[nodiscard]] const std::unordered_map<const Var*, ExprPtr>& fold_map() const { return fold_map_; }
+
+ protected:
+  StmtPtr VisitStmt_(const AssignStmtPtr& op) override {
+    if (auto extent = FoldedDimExtent(op, symbols_)) {
+      fold_map_[op->var_.get()] = extent;
+      // Empty SeqStmts is the statement-deletion idiom: the parent's
+      // SeqStmts::Flatten splices it out of the surrounding list.
+      return std::make_shared<SeqStmts>(std::vector<StmtPtr>{}, op->span_);
+    }
+    return IRMutator::VisitStmt_(op);
+  }
+
+ private:
+  std::unordered_set<const Var*> symbols_;
+  std::unordered_map<const Var*, ExprPtr> fold_map_;
+};
+
+/// Whether this body still carries an InCore scope — the same condition under
+/// which the pass below promotes an Opaque parent to Orchestration.
+class HasInCoreScope : public IRVisitor {
+ public:
+  bool found_ = false;
+
+ protected:
+  void VisitStmt_(const InCoreScopeStmtPtr& op) override {
+    found_ = true;
+    IRVisitor::VisitStmt_(op);
+  }
+};
+
+/// Establish the Orchestration normal form: a param's declared extent *is* its
+/// runtime extent, so a ``tensor.dim`` read of it mints a second IR name for one
+/// quantity, and shapes built from the copy no longer compare equal to shapes
+/// built from the symbol. The DSL parser folds such a read away, but only in an
+/// Orchestration body — a body parsed as Opaque and promoted by this pass would
+/// otherwise reach Orchestration still carrying the read, and would no longer
+/// parse back to itself.
+StmtPtr FoldParamDimReads(const std::vector<VarPtr>& params, const StmtPtr& body) {
+  auto symbols = CollectParamDimSymbols(params);
+  if (symbols.empty()) return body;
+  DimReadFolder folder(std::move(symbols));
+  auto folded = folder.VisitStmt(body);
+  if (folder.fold_map().empty()) return body;
+  // Definitions are dropped first, so substitution only ever rewrites uses.
+  return Substitute(folded, folder.fold_map());
+}
+
+}  // namespace
 
 namespace pass {
 
@@ -79,6 +187,25 @@ Pass OutlineIncoreScopes() {
         continue;
       }
 
+      // An Opaque body that carries an InCore scope is about to be promoted to
+      // Orchestration (see below). Fold its param dyn-dim reads first, so the
+      // outliner sees the same body the parser hands an already-Orchestration
+      // function — one runtime extent, one IR name, on both paths.
+      //
+      // The probe is not speculative: ScopeOutliner::VisitScopeKind outlines
+      // every InCoreScopeStmt it reaches unconditionally, so "body has an InCore
+      // scope" and the promotion condition below (`!outlined.empty()`) are the
+      // same predicate. An Opaque function that stays Opaque is never folded —
+      // it may be a callee (OutlineHierarchyScopes mints Opaque callees), whose
+      // symbol placeholder is not the caller's and may be reached with a
+      // statically-shaped actual.
+      StmtPtr source_body = func->body_;
+      if (func->func_type_ == FunctionType::Opaque) {
+        HasInCoreScope probe;
+        probe.VisitStmt(source_body);
+        if (probe.found_) source_body = FoldParamDimReads(func->params_, source_body);
+      }
+
       // Build symbol table for this function
       outline_utils::VarCollector type_collector;
       for (const auto& var : func->params_) {
@@ -86,13 +213,13 @@ Pass OutlineIncoreScopes() {
         type_collector.var_objects[var.get()] = var;
         type_collector.known_names.insert(var->name_hint_);
       }
-      type_collector.VisitStmt(func->body_);
+      type_collector.VisitStmt(source_body);
 
       // Outline InCore scopes in this function
       outline_utils::ScopeOutliner outliner(
           func->name_, type_collector.var_types, type_collector.var_objects, type_collector.known_names,
           ScopeKind::InCore, FunctionType::InCore, "_incore_", /*program=*/nullptr, reserved_func_names);
-      auto new_body = outliner.VisitStmt(func->body_);
+      auto new_body = outliner.VisitStmt(source_body);
 
       // Create new function with transformed body.
       // If any InCore scopes were outlined, promote Opaque -> Orchestration.

--- a/src/ir/transforms/outline_incore_scopes_pass.cpp
+++ b/src/ir/transforms/outline_incore_scopes_pass.cpp
@@ -85,27 +85,45 @@ ExprPtr FoldedDimExtent(const AssignStmtPtr& assign, const std::unordered_set<co
   return (sym && symbols.count(sym.get()) > 0) ? extent : nullptr;
 }
 
-/// Drops each foldable ``tensor.dim`` binding and records its name -> extent.
+/// Drops each foldable ``tensor.dim`` binding, rewriting its uses to the extent.
+///
+/// Folding is transitive: substituting one folded read into a local tensor's
+/// shape is what exposes a *later* read of that tensor, as in
+/// ``m = dim(a, 0); t = create([m, 128]); n = dim(t, 0)`` — once ``t`` is typed
+/// ``[M, 128]``, ``n`` names ``M`` too, and the parser folds it on reparse. A
+/// collect-then-substitute pair would miss ``n`` and leave exactly the roundtrip
+/// mismatch this fold exists to remove.
+///
+/// One forward traversal reaches that fixed point because the body is in SSA
+/// form, so every definition precedes its uses: the base mutator rewrites this
+/// statement's operands (and the Var refs inside their types) from the folds
+/// recorded so far, and the rewritten statement is what gets tested.
 class DimReadFolder : public IRMutator {
  public:
   explicit DimReadFolder(std::unordered_set<const Var*> symbols) : symbols_(std::move(symbols)) {}
 
-  [[nodiscard]] const std::unordered_map<const Var*, ExprPtr>& fold_map() const { return fold_map_; }
+  [[nodiscard]] bool folded_any() const { return folded_any_; }
 
  protected:
   StmtPtr VisitStmt_(const AssignStmtPtr& op) override {
-    if (auto extent = FoldedDimExtent(op, symbols_)) {
-      fold_map_[op->var_.get()] = extent;
+    auto rewritten = IRMutator::VisitStmt_(op);
+    auto assign = As<AssignStmt>(rewritten);
+    if (!assign) return rewritten;
+    if (auto extent = FoldedDimExtent(assign, symbols_)) {
+      // Overrides any old->fresh entry the base visit recorded for this LHS:
+      // the binding is going away, so its uses must reach the extent itself.
+      var_remap_[op->var_.get()] = extent;
+      folded_any_ = true;
       // Empty SeqStmts is the statement-deletion idiom: the parent's
       // SeqStmts::Flatten splices it out of the surrounding list.
       return std::make_shared<SeqStmts>(std::vector<StmtPtr>{}, op->span_);
     }
-    return IRMutator::VisitStmt_(op);
+    return rewritten;
   }
 
  private:
   std::unordered_set<const Var*> symbols_;
-  std::unordered_map<const Var*, ExprPtr> fold_map_;
+  bool folded_any_ = false;
 };
 
 /// Whether this body still carries an InCore scope — the same condition under
@@ -133,9 +151,7 @@ StmtPtr FoldParamDimReads(const std::vector<VarPtr>& params, const StmtPtr& body
   if (symbols.empty()) return body;
   DimReadFolder folder(std::move(symbols));
   auto folded = folder.VisitStmt(body);
-  if (folder.fold_map().empty()) return body;
-  // Definitions are dropped first, so substitution only ever rewrites uses.
-  return Substitute(folded, folder.fold_map());
+  return folder.folded_any() ? folded : body;
 }
 
 }  // namespace

--- a/src/ir/transforms/outline_incore_scopes_pass.cpp
+++ b/src/ir/transforms/outline_incore_scopes_pass.cpp
@@ -9,6 +9,7 @@
  * -----------------------------------------------------------------------------------------------------------
  */
 
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -22,6 +23,7 @@
 #include "pypto/ir/kind_traits.h"
 #include "pypto/ir/op_registry.h"
 #include "pypto/ir/program.h"
+#include "pypto/ir/scalar_expr.h"
 #include "pypto/ir/stmt.h"
 #include "pypto/ir/transforms/base/mutator.h"
 #include "pypto/ir/transforms/base/visitor.h"
@@ -30,6 +32,7 @@
 #include "pypto/ir/transforms/utils/mutable_copy.h"
 #include "pypto/ir/transforms/utils/scope_outline_utils.h"
 #include "pypto/ir/transforms/utils/transform_utils.h"
+#include "pypto/ir/type.h"
 #include "pypto/ir/verifier/verifier.h"
 
 namespace pypto {

--- a/tests/ut/codegen/test_orchestration_codegen_more.py
+++ b/tests/ut/codegen/test_orchestration_codegen_more.py
@@ -69,14 +69,12 @@ class TestOrchestrationMore:
                     out = pl.assemble(out, c_vec, [m0, 0])
                 return out
 
-        # VerificationLevel.NONE: a dynamic ``pl.spmd`` block count lands on the
-        # outlined Spmd function as a ``core_num`` attr that references a local
-        # defined in the *caller* Orchestration function. The printer emits that
-        # attr verbatim, but the roundtrip parser rejects the standalone function
-        # (the var is out of scope) — a known print/parse gap unrelated to the
-        # codegen ordering under test here.
-        with passes.PassContext([], passes.VerificationLevel.NONE):
-            program = PassManager.get_strategy(OptimizationStrategy.Default).run_passes(DynPipeProgram)
+        # Runs under the session's verification settings (roundtrip by default in
+        # this suite): a dynamic ``pl.spmd`` block count is the case where
+        # OutlineIncoreScopes promotes an Opaque body to Orchestration, so the
+        # ``m = pl.tensor.dim(a, 0)`` read must fold onto the param's dyn-dim
+        # symbol there — otherwise the printed IR no longer parses back to itself.
+        program = PassManager.get_strategy(OptimizationStrategy.Default).run_passes(DynPipeProgram)
         orch_func = next(
             f for f in program.functions.values() if f.func_type == ir.FunctionType.Orchestration
         )

--- a/tests/ut/ir/transforms/test_outline_incore_scopes.py
+++ b/tests/ut/ir/transforms/test_outline_incore_scopes.py
@@ -2085,5 +2085,156 @@ class TestOutlineReboundOutCapture:
         assert list(direct.param_directions) == list(via_ssa.param_directions)
 
 
+class TestPromotionFoldsParamDimReads:
+    """Promoting Opaque -> Orchestration folds ``tensor.dim`` on a param dyn-dim axis.
+
+    A tensor's declared extent *is* its runtime extent, so reading it back mints a
+    second scalar for one quantity. The DSL parser folds that read onto the symbol
+    the signature already names, but only in an Orchestration body. A body written
+    as Opaque keeps the read, so the promotion here must fold it — otherwise the IR
+    this pass emits no longer parses back to itself.
+    """
+
+    M_DYN = pl.dynamic("M_DYN")
+
+    @staticmethod
+    def _main_stmts(program: ir.Program) -> list[ir.Stmt]:
+        main = program.get_function("main")
+        assert main is not None
+        body = main.body
+        assert isinstance(body, ir.SeqStmts), f"expected a SeqStmts body, got {type(body).__name__}"
+        return list(body.stmts)
+
+    @staticmethod
+    def _dim_reads(stmts: list[ir.Stmt]) -> list[ir.Stmt]:
+        dim = ir.get_op("tensor.dim").name
+        return [
+            s
+            for s in stmts
+            if isinstance(s, ir.AssignStmt) and isinstance(s.value, ir.Call) and s.value.op.name == dim
+        ]
+
+    def test_promotion_matches_the_parser_folded_form(self):
+        """The promoted body equals what the parser produces for the same source.
+
+        ``Expected`` is the identical program declared Orchestration, where the
+        parser folds ``m`` at parse time. Both go through the same passes, so any
+        divergence is the promotion failing to establish the same normal form.
+        """
+        M_DYN = self.M_DYN
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.Opaque)
+            def main(
+                self,
+                a: pl.Tensor[[M_DYN, 128], pl.FP32],
+                out: pl.InOut[pl.Tensor[[M_DYN, 128], pl.FP32]],
+            ) -> pl.Tensor[[M_DYN, 128], pl.FP32]:
+                m = pl.tensor.dim(a, 0)
+                with pl.spmd(m // 16):
+                    i = pl.tile.get_block_idx()
+                    t: pl.Tile[[16, 128], pl.FP32] = pl.load(a, [i * 16, 0], [16, 128])
+                    out = pl.store(pl.add(t, t), [i * 16, 0], out)
+                return out
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                a: pl.Tensor[[M_DYN, 128], pl.FP32],
+                out: pl.InOut[pl.Tensor[[M_DYN, 128], pl.FP32]],
+            ) -> pl.Tensor[[M_DYN, 128], pl.FP32]:
+                m = pl.tensor.dim(a, 0)
+                with pl.spmd(m // 16):
+                    i = pl.tile.get_block_idx()
+                    t: pl.Tile[[16, 128], pl.FP32] = pl.load(a, [i * 16, 0], [16, 128])
+                    out = pl.store(pl.add(t, t), [i * 16, 0], out)
+                return out
+
+        with passes.PassContext([]):
+            After = passes.outline_incore_scopes()(passes.convert_to_ssa()(Before))
+            ExpectedAfter = passes.outline_incore_scopes()(passes.convert_to_ssa()(Expected))
+
+        assert self._dim_reads(self._main_stmts(After)) == []
+        ir.assert_structural_equal(After, ExpectedAfter)
+
+    def test_promotion_folds_symbol_used_inside_incore_body(self):
+        """A read consumed *inside* the scope folds too, and is captured as the symbol."""
+        M_DYN = self.M_DYN
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.Opaque)
+            def main(
+                self,
+                a: pl.Tensor[[M_DYN, 128], pl.FP32],
+                out: pl.InOut[pl.Tensor[[M_DYN, 128], pl.FP32]],
+            ) -> pl.Tensor[[M_DYN, 128], pl.FP32]:
+                m = pl.tensor.dim(a, 0)
+                with pl.spmd(m // 16):
+                    i = pl.tile.get_block_idx()
+                    lim = m - 16
+                    t: pl.Tile[[16, 128], pl.FP32] = pl.load(a, [pl.min(i * 16, lim), 0], [16, 128])
+                    out = pl.store(pl.add(t, t), [i * 16, 0], out)
+                return out
+
+        with passes.PassContext([]):
+            After = passes.outline_incore_scopes()(passes.convert_to_ssa()(Before))
+
+        assert self._dim_reads(self._main_stmts(After)) == []
+
+        # The extent crosses into the outlined kernel as a scalar parameter, and
+        # the caller passes the symbol itself rather than a copy of it.
+        incore = [f for f in After.functions.values() if f.func_type == ir.FunctionType.InCore]
+        assert len(incore) == 1, f"expected one outlined InCore function, got {len(incore)}"
+        assert isinstance(incore[0].params[0].type, ir.ScalarType)
+        assert incore[0].params[0].name_hint == "M_DYN"
+
+    def test_static_extent_dim_read_is_kept(self):
+        """A statically-shaped axis has no symbol to fold onto — the read must stay."""
+        M_DYN = self.M_DYN
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.Opaque)
+            def main(
+                self,
+                a: pl.Tensor[[M_DYN, 128], pl.FP32],
+                out: pl.InOut[pl.Tensor[[M_DYN, 128], pl.FP32]],
+            ) -> pl.Tensor[[M_DYN, 128], pl.FP32]:
+                cols = pl.tensor.dim(a, 1)  # 128 — a constant extent, not a symbol
+                with pl.spmd(cols // 16):
+                    i = pl.tile.get_block_idx()
+                    t: pl.Tile[[16, 128], pl.FP32] = pl.load(a, [i * 16, 0], [16, 128])
+                    out = pl.store(pl.add(t, t), [i * 16, 0], out)
+                return out
+
+        with passes.PassContext([]):
+            After = passes.outline_incore_scopes()(passes.convert_to_ssa()(Before))
+
+        assert len(self._dim_reads(self._main_stmts(After))) == 1
+
+    def test_opaque_without_incore_scope_keeps_dim_read(self):
+        """No InCore scope means no promotion — an Opaque body keeps its read."""
+        M_DYN = self.M_DYN
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.Opaque)
+            def main(self, a: pl.Tensor[[M_DYN, 128], pl.FP32]) -> pl.Scalar[pl.INDEX]:
+                m = pl.tensor.dim(a, 0)
+                return m
+
+        with passes.PassContext([]):
+            After = passes.outline_incore_scopes()(passes.convert_to_ssa()(Before))
+
+        main = After.get_function("main")
+        assert main is not None
+        assert main.func_type == ir.FunctionType.Opaque
+        assert len(self._dim_reads(self._main_stmts(After))) == 1
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/ir/transforms/test_outline_incore_scopes.py
+++ b/tests/ut/ir/transforms/test_outline_incore_scopes.py
@@ -13,7 +13,9 @@ import pypto
 import pypto.language as pl
 import pytest
 from pypto import DataType, ir, passes
+from pypto.ir.printer import python_print
 from pypto.language.parser.diagnostics.exceptions import ParserSyntaxError
+from pypto.language.parser.text_parser import parse as text_parse
 
 
 class TestOutlineIncoreScopes:
@@ -2159,6 +2161,42 @@ class TestPromotionFoldsParamDimReads:
 
         assert self._dim_reads(self._main_stmts(After)) == []
         ir.assert_structural_equal(After, ExpectedAfter)
+
+    def test_promotion_folds_transitive_dim_read(self):
+        """A read exposed *by* an earlier fold folds too, in the same pass.
+
+        Folding ``m`` retypes the local ``tmp`` from ``[m, 128]`` to ``[M_DYN, 128]``,
+        which makes ``n = tensor.dim(tmp, 0)`` foldable in turn. Missing that second
+        read leaves the printed IR parsing back to one statement fewer -- exactly the
+        roundtrip mismatch this fold exists to remove.
+        """
+        M_DYN = self.M_DYN
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.Opaque)
+            def main(
+                self,
+                a: pl.Tensor[[M_DYN, 128], pl.FP32],
+                out: pl.InOut[pl.Tensor[[M_DYN, 128], pl.FP32]],
+            ) -> pl.Tensor[[M_DYN, 128], pl.FP32]:
+                m = pl.tensor.dim(a, 0)
+                tmp: pl.Tensor[[M_DYN, 128], pl.FP32] = pl.create_tensor([m, 128], dtype=pl.FP32)
+                n = pl.tensor.dim(tmp, 0)
+                with pl.spmd(n // 16):
+                    i = pl.tile.get_block_idx()
+                    t: pl.Tile[[16, 128], pl.FP32] = pl.load(a, [i * 16, 0], [16, 128])
+                    out = pl.store(pl.add(t, t), [i * 16, 0], out)
+                return out
+
+        with passes.PassContext([]):
+            After = passes.outline_incore_scopes()(passes.convert_to_ssa()(Before))
+
+        assert self._dim_reads(self._main_stmts(After)) == []
+
+        # The invariant itself: the emitted IR parses back to itself.
+        printed = python_print(After, format=False)
+        ir.assert_structural_equal(After, text_parse(printed, filename="<roundtrip>"))
 
     def test_promotion_folds_symbol_used_inside_incore_body(self):
         """A read consumed *inside* the scope folds too, and is captured as the symbol."""


### PR DESCRIPTION
## Summary

`OutlineIncoreScopes` promotes an `Opaque` parent to `Orchestration` as soon as it outlines an InCore scope, but left the body in the shape the Opaque rules produced. The DSL parser folds `pl.tensor.dim(a, 0)` on a param's dynamic axis onto the symbol the signature already declares — a tensor's declared extent *is* its runtime extent, so reading it back mints a second IR name for one quantity — yet it only does so inside an `Orchestration` body. A body written as `Opaque` therefore kept the read, and after promotion the pass emitted IR that no longer parsed back to itself: the printed binding vanished on reparse and the SPMD header read `M_DYN // 16` instead of `m__ssa_v0 // 16`. Every dynamic `pl.spmd` program failed print/parse roundtrip verification at that pass with a 3-statements-versus-2 mismatch.

This folds those reads at the moment the function is promoted, before outlining, so the outliner sees the body the parser would have handed an already-`Orchestration` function and both paths yield identical IR. After it, a promoted `Orchestration` body no longer carries the redundant scalar binding, and the dynamic-`pl.spmd` pipeline survives roundtrip verification.

Concretely, for a `main` written as `Opaque` with `m = pl.tensor.dim(a, 0)` feeding `pl.spmd(m // 16)`:

```python
# emitted by the pass before                    # emitted now
m__ssa_v0: pl.Scalar[pl.INDEX] = \
    pl.tensor.dim(a__ssa_v0, 0)                 # (binding folded away)
with pl.spmd(m__ssa_v0 // 16, ...):             with pl.spmd(M_DYN // 16, ...):
```

## Changes

- `src/ir/transforms/outline_incore_scopes_pass.cpp`: fold param dyn-dim `tensor.dim` reads when an `Opaque` function is promoted to `Orchestration`. Four file-local helpers mirror the parser so the two normal forms cannot drift: `CollectParamDimSymbols` (mirrors `ASTParser._param_dim_symbols`), `FoldedDimExtent` (mirrors `_fold_tensor_dim` — constant axis, negative-axis normalization, out-of-range left for the op to reject, extent must be a symbol the signature declares), `DimReadFolder` (drops each matching binding via the empty-`SeqStmts` deletion idiom and records name → extent), and `HasInCoreScope` + `FoldParamDimReads` (gate and driver). Definitions are dropped before `Substitute` rewrites uses, so substitution never touches a binding's own LHS.

  The gate is exact rather than speculative: `ScopeOutliner::VisitScopeKind` outlines every `InCoreScopeStmt` it reaches unconditionally, so "body carries an InCore scope" and the promotion condition `!outlined.empty()` are one predicate. An `Opaque` function that stays `Opaque` is never folded — it may be a callee (`OutlineHierarchyScopes` mints `Opaque` callees) whose symbol placeholder is not the caller's and may be reached with a statically-shaped actual.

  Folding is **transitive**, and happens during the traversal rather than after it. Substituting one folded read into a local tensor's shape is what exposes a later read of that tensor — given `m = tensor.dim(a, 0)`, `t = create_tensor([m, 128])`, `n = tensor.dim(t, 0)`, folding `m` retypes `t` to `[M, 128]` and only then is `n` foldable. Each statement is therefore rewritten from the folds recorded so far and the *rewritten* statement is tested. Because the body is in SSA form every definition precedes its uses, so one forward pass reaches the fixed point for a chain of any depth, and the pass stays a single traversal instead of an iterate-until-stable loop (which would be O(depth × N) against this repository's O(N log N) cap).

- `tests/ut/ir/transforms/test_outline_incore_scopes.py`: new `TestPromotionFoldsParamDimReads` with five cases. The discriminating one runs the *same source* declared both `Opaque` and `Orchestration` through the same passes and asserts structural equality, so the promoted path is pinned to the parser's own normal form. `test_promotion_folds_transitive_dim_read` covers the chained case above and asserts the emitted IR parses back to itself. The rest cover a read consumed inside the scope (the extent crosses into the outlined kernel as a scalar param, and the caller passes the symbol), a constant extent that must stay a runtime read, and an `Opaque` function with no InCore scope that is not promoted and so keeps its read.

- `tests/ut/codegen/test_orchestration_codegen_more.py`: drop the `VerificationLevel.NONE` wrapper from `test_dynamic_gm_pipe_buffer_alloc_follows_its_size_local`, so the suite's autouse roundtrip instrument now covers that dynamic-`pl.spmd` program end to end. Its comment blamed a `core_num` decorator attr that is no longer emitted; it now records the actual invariant under test.

- `docs/en/dev/passes/08-outline_incore_scopes.md`, `docs/zh/dev/passes/08-outline_incore_scopes.md`: add the promotion step to the algorithm list and a subsection explaining the fold, why it runs before outlining, and which reads are deliberately left alone. A second commit also corrects pre-existing text the new step contradicted: the overview and algorithm step 1 claimed the pass processes only `Opaque` functions (it also processes `Orchestration` ones, which carry InCore scopes when the parser desugars `for i in pl.spmd(...)`), and the basic "After" example labelled the outlined parent `Opaque` although the pass promotes it — the shape the pass's own `test_outline_simple_incore_scope` already expects.

The second commit also adds three direct includes (`<cstdint>`, `pypto/ir/scalar_expr.h`, `pypto/ir/type.h`) that `clang-tidy`'s `misc-include-cleaner` requires for the new helpers' use of `int64_t`, `ConstInt`, and `TensorType`.

No interface change and no migration step. No new `IRProperty` or `PropertyVerifier` was added: the only downstream `tensor.dim` construction site (`op_conversion_registry.cpp`, `tensor.paged_gather` lowering) runs on tile/InCore bodies and reads a local operand, so it cannot reintroduce the shape into an `Orchestration` body.

## Verification

All commands ran at the pushed head `ef4ef664`, after rebase onto `main`:

- `cmake --build build --parallel`: exit 0
- `pytest tests/ut/ir/transforms/test_outline_incore_scopes.py tests/ut/codegen/test_orchestration_codegen_more.py -q` (`PYPTO_VERIFY_LEVEL=roundtrip`): exit 0 — 93 passed
- `pytest tests/ut -n auto --maxprocesses 8 -q` (`PYPTO_VERIFY_LEVEL=roundtrip`): exit 0 — 9192 passed, 2 skipped in 143.95s
- `python tests/lint/clang_tidy.py --jobs 8 --diff-base=upstream/main`: exit 0 — all checks completed, no diagnostics
- `pre-commit run --files <the five changed paths>`: exit 0 — 16 hooks, 15 passed and 1 skipped as not applicable

Additionally run in the working checkout:

- `ruff check src python tests docs`: exit 0 — all checks passed
- `ruff format --check python tests`: exit 0
- `python tests/lint/check_headers.py`: exit 0 — 1037 passed, 0 failed
- `python tests/lint/check_english_only.py`: exit 0 — 1178 passed, 0 failed
- `python tests/lint/check_docs_en_zh_parity.py`: exit 0 — 115 paired markdown paths
- `clang-format --dry-run --Werror src/ir/transforms/outline_incore_scopes_pass.cpp`: exit 0