### PR TITLE
refactor(lint): route operator-name literals through the registry getter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,6 +56,13 @@ repos:
           language_version: python3
           pass_filenames: false
 
+        - id: check-op-name-literals
+          name: check-op-name-literals
+          entry: python tests/lint/check_op_name_literals.py
+          language: python
+          language_version: python3
+          pass_filenames: false
+
     - repo: https://github.com/pre-commit/pre-commit-hooks
       rev: v4.6.0
       hooks:

--- a/python/pypto/debug/torch_codegen.py
+++ b/python/pypto/debug/torch_codegen.py
@@ -726,11 +726,14 @@ def _handle_tpop_from_aiv(_a: list[str], kw: dict[str, Any]) -> str:
     return f"_cross_core_rt.pop_from_aiv({_split_kwarg(kw)})"
 
 
+# Built through the registry getter, which raises on an unregistered name, so a renamed operator
+# fails at import. A bare literal here would instead drop silently out of the membership test in
+# _collect_cross_core_split_from_expr and route the call down the wrong codegen path.
 _CROSS_CORE_SPLIT_OPS = {
-    "tile.tpush_to_aiv",
-    "tile.tpush_to_aic",
-    "tile.tpop_from_aic",
-    "tile.tpop_from_aiv",
+    _ir.get_op("tile.tpush_to_aiv").name,
+    _ir.get_op("tile.tpush_to_aic").name,
+    _ir.get_op("tile.tpop_from_aic").name,
+    _ir.get_op("tile.tpop_from_aiv").name,
 }
 
 

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -500,6 +500,10 @@ _AT_STASH_KWARGS = {
 # would build IR that cannot be printed back.
 _TASK_DUMMY_ONLY_ATTRS = frozenset({"manual_dep_edges", "dummy_task"})
 
+# The op a bare ``predicate=None`` lowers to. Resolved through the registry getter so a rename
+# fails at import instead of silently dropping the hint from the error message below.
+_TASK_INVALID_OP = ir.get_op("system.task_invalid").name
+
 
 def _split_spmd_for_loop_name_hints(name_hint: str) -> tuple[str, str]:
     """Map one ``for i in pl.spmd(..., name_hint=...)`` hint to Spmd vs InCore names.
@@ -6782,7 +6786,7 @@ class ASTParser:
             got = type(predicate).__name__
             extra = (
                 " (to dispatch unconditionally, omit predicate= entirely)"
-                if isinstance(predicate, ir.Call) and predicate.op.name == "system.task_invalid"
+                if isinstance(predicate, ir.Call) and predicate.op.name == _TASK_INVALID_OP
                 else ""
             )
             raise ParserSyntaxError(

--- a/tests/lint/check_op_name_literals.py
+++ b/tests/lint/check_op_name_literals.py
@@ -1,0 +1,382 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""
+Script to check that operator-identity tests route operator names through the registry getter.
+
+``.claude/rules/operator-identity-checks.md`` requires an operator-name literal to reach a comparison
+via ``get_op(...)``, which raises on an unregistered name, rather than as a bare string. A bare
+``call.op.name == "tile.reshaep"`` silently evaluates to ``False``; the same literal written as
+``call.op.name == ir.get_op("tile.reshaep").name`` raises ``ValueError`` at the comparison site.
+
+In test code the silent form is worse than in product code. These comparisons sit inside list
+comprehensions and ``next(...)`` filters, so a stale name yields either an empty list that a
+``len(...) == 0`` assertion happily accepts, or a bare ``StopIteration`` that reads as a
+test-infrastructure fault rather than the rename it actually is.
+
+The check parses each file rather than scanning text, so prose in comments and docstrings is never
+flagged. Four shapes are reported, each anchored on something that provably holds operator names:
+
+1. *Direct comparison* -- ``call.op.name == "tile.load"``, ``!=``, and ``in`` / ``not in`` against a
+   set, tuple, or list literal.
+2. *Sequence comparison* -- ``[c.op.name for c in calls] == ["tile.load", "tile.slice"]``.
+3. *Bound-collection use* -- a name bound from an ``.op.name`` comprehension, then tested with
+   ``"tile.load" in names``, ``not in``, or ``names.count("tile.load")``. The ``not in`` form is the
+   worst of the family: a renamed operator makes the assertion pass vacuously.
+4. *Module-level operator-name collection* -- ``_REQUIRED_OPS = {"pld.system.rank", ...}``, the shape
+   the rule shows as the canonical anti-pattern, including when wrapped in a ``frozenset(...)``,
+   ``set(...)``, ``list(...)`` or ``tuple(...)`` builder.
+
+Scope and deliberate limits:
+
+* Only ``<expr>.op.name`` is treated as an operator-identity site. That is the exact form the rule
+  tabulates, and anchoring on it keeps the registry's own tests -- ``ir.get_op("tensor.add").name ==
+  "tensor.add"`` in ``tests/ut/ir/operators/test_op_registry.py`` -- from being flagged, since there
+  the literal already reaches the comparison through the getter.
+* Only *dotted* literals are reported. A callee name carries no dot (``"k1"``, ``"consumer"``,
+  ``"main_incore_1"``), and the rule explicitly excludes function names from conversion.
+* Shape 4 is the one heuristic here, so it is deliberately narrow: every element must be a string,
+  there must be at least two, and every first segment must name a real operator namespace. A
+  collection of unrelated dotted strings therefore does not trip it. Widen ``OP_NAMESPACES`` only
+  alongside a real namespace.
+* Shape 3 tracks its bindings per lexical scope. A ``names`` built from ``.op.name`` in one function
+  says nothing about a ``names`` built from something else in another, and rebinding shadows.
+* A literal passed into a helper that does the comparison -- ``_collect_call_args(func,
+  "tensor.muls")`` -- is *not* detected; that would need interprocedural analysis. Such sites are
+  still worth converting by hand.
+* Literals that are *constructed* rather than compared are exempt, per the rule: arguments to
+  ``ir.Op(...)``, ``get_op(...)``, ``create_op_call(...)``, and the name-keyed registry lookups.
+  ``@pytest.mark.parametrize("op_name", [...])`` lists that feed ``get_op(op_name)`` are likewise
+  left alone -- ``get_op`` already raises on a typo there.
+* The literal is not resolved against the live registry: pre-commit runs this in an isolated
+  interpreter with no built ``pypto_core`` extension. Whether each name is registered is exactly
+  what ``get_op`` verifies at runtime once the call site is converted.
+"""
+
+import argparse
+import ast
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# Sites that legitimately compare a bare literal. Scoped to the exact class or function -- not the
+# whole file -- so an unrelated bare comparison added to one of these files later is still reported.
+# Each entry is "<repo-relative path>::<dotted qualname prefix>".
+ALLOWLIST: frozenset[str] = frozenset()
+
+# Directories scanned, relative to the repo root.
+SCAN_ROOTS = ("tests", "python")
+
+# An operator name is a dotted lowercase path: "tile.load", "pld.tensor.window",
+# "builtin.tensor.allreduce". A callee name is a plain Python identifier and never matches.
+OP_NAME_RE = re.compile(r"^[a-z][a-z0-9_]*(?:\.[a-z][a-z0-9_]*)+$")
+
+# Leading segments that name a real operator namespace. Used only to keep the module-level
+# collection heuristic from firing on unrelated dotted strings.
+OP_NAMESPACES = frozenset({"tile", "tensor", "pld", "system", "array", "dist", "builtin"})
+
+# Calls whose string arguments name an operator to *build* or *look up* rather than to compare.
+EXEMPT_CALLS = frozenset({"Op", "get_op", "create_op_call", "is_op_registered", "get_op_memory_spec"})
+
+# Builders that wrap a collection literal without changing which literals it holds.
+COLLECTION_BUILDERS = frozenset({"frozenset", "set", "list", "tuple"})
+
+LITERAL_OPS = (ast.Eq, ast.NotEq)
+MEMBERSHIP_OPS = (ast.In, ast.NotIn)
+
+
+def get_git_tracked_files(root_dir: Path) -> list[Path]:
+    """Get list of git-tracked Python files under the scanned roots."""
+    try:
+        result = subprocess.run(
+            ["git", "ls-files", "--", *SCAN_ROOTS],
+            cwd=root_dir,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except subprocess.CalledProcessError as e:
+        print(f"Error: Failed to get git tracked files: {e}", file=sys.stderr)
+        sys.exit(1)
+    except FileNotFoundError:
+        print("Error: git command not found", file=sys.stderr)
+        sys.exit(1)
+
+    files = []
+    for line in result.stdout.splitlines():
+        path = root_dir / line
+        if line.endswith(".py") and path.is_file():
+            files.append(path)
+    return files
+
+
+def _is_op_name_access(node: ast.expr) -> bool:
+    """Whether *node* is an ``<expr>.op.name`` attribute access."""
+    return (
+        isinstance(node, ast.Attribute)
+        and node.attr == "name"
+        and isinstance(node.value, ast.Attribute)
+        and node.value.attr == "op"
+    )
+
+
+def _collection_elements(node: ast.expr) -> list[ast.expr] | None:
+    """Elements of a collection literal, seeing through one builder call.
+
+    ``frozenset({...})`` is the idiomatic way to spell an immutable module-level set -- and the form
+    this checker's own remediation message recommends -- so the literal inside it must be reachable.
+    """
+    if isinstance(node, ast.Call):
+        func = node.func
+        builder = func.id if isinstance(func, ast.Name) else getattr(func, "attr", "")
+        if builder in COLLECTION_BUILDERS and len(node.args) == 1 and not node.keywords:
+            node = node.args[0]
+    if isinstance(node, (ast.Set, ast.Tuple, ast.List)):
+        return list(node.elts)
+    return None
+
+
+def _op_name_literals(node: ast.expr) -> list[ast.Constant]:
+    """Return the dotted operator-name literal nodes *node* contributes, as a comparison operand.
+
+    Nodes rather than strings: the caller exempts constructor arguments by AST identity, so a literal
+    must stay distinguishable from an identically spelled one elsewhere on the same line.
+    """
+    elements = _collection_elements(node)
+    if elements is None:
+        elements = [node]
+    return [
+        e
+        for e in elements
+        if isinstance(e, ast.Constant) and isinstance(e.value, str) and OP_NAME_RE.match(e.value)
+    ]
+
+
+def _is_op_name_sequence(node: ast.expr) -> bool:
+    """Whether *node* is a comprehension whose elements are ``.op.name`` values."""
+    return isinstance(node, (ast.ListComp, ast.SetComp, ast.GeneratorExp)) and _is_op_name_access(node.elt)
+
+
+def _compare_violations(node: ast.Compare, op_name_vars: set[str]) -> list[ast.Constant]:
+    """Return the bare operator-name literals compared against operator names in *node*.
+
+    *op_name_vars* holds names bound from an ``.op.name`` comprehension, so a membership test
+    against one of them is an operator-identity check even though no ``.op.name`` is in sight.
+    """
+    # A Compare chains operands: `a < b < c` is left=a, comparators=[b, c], ops=[Lt, Lt]. Each op
+    # joins operands[i] and operands[i + 1], so a chain is checked pairwise rather than assuming
+    # the single-operator shape.
+    operands = [node.left, *node.comparators]
+    found: list[ast.Constant] = []
+
+    def holds_op_names(e: ast.expr) -> bool:
+        return (
+            _is_op_name_access(e)
+            or _is_op_name_sequence(e)
+            or (isinstance(e, ast.Name) and e.id in op_name_vars)
+        )
+
+    for i, op in enumerate(node.ops):
+        lhs, rhs = operands[i], operands[i + 1]
+        if isinstance(op, LITERAL_OPS):
+            # Either side may hold the operator names; `"tile.load" == c.op.name` is the same
+            # defect, and so is comparing a name sequence against a literal list.
+            if holds_op_names(lhs):
+                found.extend(_op_name_literals(rhs))
+            if holds_op_names(rhs):
+                found.extend(_op_name_literals(lhs))
+        elif isinstance(op, MEMBERSHIP_OPS):
+            # `"tile.load" in names` and `call.op.name in {...}` are both identity tests, but the
+            # literal sits on opposite sides, so each direction is checked separately.
+            if _is_op_name_access(lhs):
+                found.extend(_op_name_literals(rhs))
+            if holds_op_names(rhs):
+                found.extend(_op_name_literals(lhs))
+    return found
+
+
+def _iter_own_scope(node: ast.AST):
+    """Yield the nodes belonging to *node*'s own lexical scope, skipping nested scopes."""
+    for child in ast.iter_child_nodes(node):
+        if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef, ast.Lambda)):
+            continue
+        yield child
+        yield from _iter_own_scope(child)
+
+
+def _scope_op_name_vars(scope: ast.AST, inherited: set[str]) -> set[str]:
+    """Names bound to an ``.op.name`` sequence in *scope*, over the enclosing scope's bindings.
+
+    Bindings must not leak sideways: ``names`` holding operator names in one function says nothing
+    about a ``names`` built from file suffixes in another, and treating them alike would report a
+    violation on unrelated code. Rebinding a name to anything else therefore shadows it here.
+    """
+    bound = set(inherited)
+    for node in _iter_own_scope(scope):
+        if isinstance(node, ast.Assign):
+            targets, value = node.targets, node.value
+        elif isinstance(node, ast.AnnAssign) and node.value is not None:
+            targets, value = [node.target], node.value
+        else:
+            continue
+        for target in targets:
+            if not isinstance(target, ast.Name):
+                continue
+            if _is_op_name_sequence(value):
+                bound.add(target.id)
+            else:
+                bound.discard(target.id)
+    return bound
+
+
+def _count_call_violations(node: ast.Call, op_name_vars: set[str]) -> list[ast.Constant]:
+    """Literals passed to ``<op-name collection>.count(...)``."""
+    fn = node.func
+    if not (isinstance(fn, ast.Attribute) and fn.attr == "count" and node.args):
+        return []
+    if isinstance(fn.value, ast.Name) and fn.value.id in op_name_vars:
+        return _op_name_literals(node.args[0])
+    return []
+
+
+def _module_collection_violations(tree: ast.Module) -> list[ast.Constant]:
+    """Module-level collections built entirely from operator-name literals.
+
+    Narrow on purpose -- every element must be a string naming a real operator namespace, and there
+    must be at least two, so an unrelated set of dotted strings does not trip the check. A builder
+    call such as ``frozenset({...})`` is unwrapped first, since the literals it guards are exactly
+    as stale-able as those in a bare set.
+    """
+    out: list[ast.Constant] = []
+    for node in tree.body:
+        if isinstance(node, (ast.Assign, ast.AnnAssign)):
+            value = node.value
+        else:
+            continue
+        if value is None:
+            continue
+        elements = _collection_elements(value)
+        if elements is None or len(elements) < 2:
+            continue
+        literals: list[tuple[ast.Constant, str]] = []
+        for element in elements:
+            if isinstance(element, ast.Constant) and isinstance(element.value, str):
+                literals.append((element, element.value))
+        if len(literals) != len(elements):
+            continue
+        if all(OP_NAME_RE.match(text) and text.split(".")[0] in OP_NAMESPACES for _, text in literals):
+            out.extend(literal for literal, _ in literals)
+    return out
+
+
+def _exempt_literals(tree: ast.Module) -> set[int]:
+    """Ids of string constants that *construct* or *look up* an operator rather than compare one."""
+    exempt: set[int] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        fn = node.func
+        name = fn.attr if isinstance(fn, ast.Attribute) else (fn.id if isinstance(fn, ast.Name) else "")
+        if name in EXEMPT_CALLS:
+            for arg in node.args:
+                if isinstance(arg, ast.Constant):
+                    exempt.add(id(arg))
+    return exempt
+
+
+def find_violations(path: Path) -> list[tuple[int, str, str]]:
+    """Return (line_number, operator_name, enclosing qualname) for each bare literal in *path*."""
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8", errors="replace"))
+    except SyntaxError as e:
+        print(f"Error: Failed to parse {path}: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    # (literal node, enclosing qualname) so exemption below can match by AST identity.
+    found: list[tuple[ast.Constant, str]] = []
+
+    def walk(node: ast.AST, scope: tuple[str, ...], op_name_vars: set[str]) -> None:
+        for child in ast.iter_child_nodes(node):
+            if isinstance(child, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)):
+                walk(child, (*scope, child.name), _scope_op_name_vars(child, op_name_vars))
+                continue
+            if isinstance(child, ast.Compare):
+                found.extend(
+                    (literal, ".".join(scope)) for literal in _compare_violations(child, op_name_vars)
+                )
+            elif isinstance(child, ast.Call):
+                found.extend(
+                    (literal, ".".join(scope)) for literal in _count_call_violations(child, op_name_vars)
+                )
+            walk(child, scope, op_name_vars)
+
+    walk(tree, (), _scope_op_name_vars(tree, set()))
+    found.extend((literal, "<module>") for literal in _module_collection_violations(tree))
+
+    # Construction and name-keyed lookups are exempt per the rule. Matching the exact AST node keeps
+    # an exempt lookup from suppressing a real comparison of the same name on the same line, as in
+    # `assert call.op.name == "tile.load"; ir.get_op("tile.load")`.
+    exempt = _exempt_literals(tree)
+    violations: list[tuple[int, str, str]] = []
+    for literal, qualname in found:
+        text = literal.value
+        if id(literal) not in exempt and isinstance(text, str):
+            violations.append((literal.lineno, text, qualname))
+    return violations
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Check that operator-name literals reach comparisons through the registry getter."
+    )
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=Path(__file__).resolve().parents[2],
+        help="Repository root (defaults to the repo containing this script)",
+    )
+    args = parser.parse_args()
+    root_dir = args.root.resolve()
+
+    total = 0
+    for path in get_git_tracked_files(root_dir):
+        rel = path.relative_to(root_dir).as_posix()
+        if rel == f"tests/lint/{Path(__file__).name}":
+            continue
+        for lineno, op_name, qualname in find_violations(path):
+            site = f"{rel}::{qualname}"
+            if any(site == a or site.startswith(f"{a}.") for a in ALLOWLIST):
+                continue
+            print(f'{rel}:{lineno}: bare operator name "{op_name}" in {qualname or "<module>"}')
+            total += 1
+
+    if total:
+        print(
+            f"\nFound {total} bare operator-name literal comparison(s).\n"
+            "Route the literal through the registry getter, which raises on an unregistered name:\n"
+            '    call.op.name == "tile.load"       ->  call.op.name == ir.get_op("tile.load").name\n'
+            "For a name used more than once in a file, or inside a comprehension predicate, hoist a\n"
+            "module-level constant so the literal is validated once at import:\n"
+            '    _TILE_LOAD = ir.get_op("tile.load").name\n'
+            "    loads = [c for c in calls if c.op.name == _TILE_LOAD]\n"
+            "Build membership sets the same way, and keep the runtime check a name test:\n"
+            '    _LOAD_LIKE = frozenset({ir.get_op("tile.load").name, ir.get_op("tile.read").name})\n'
+            "Callee names carry no dot and are never reported. If a site genuinely must compare a\n"
+            f"bare literal, add its `<path>::<qualname>` to ALLOWLIST in {Path(__file__).name}.\n"
+            "See .claude/rules/operator-identity-checks.md.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print("All operator-name literals reach their comparison through the registry getter.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/ut/ir/core/test_distributed_intrinsics.py
+++ b/tests/ut/ir/core/test_distributed_intrinsics.py
@@ -34,7 +34,7 @@ def test_dist_make_tensor_call():
     rt_var = _make_var("rt")
     count = ir.ConstInt(1024, DataType.INT32, _span())
     call = ir.Call(op, [rt_var, count], _span())
-    assert call.op.name == "dist.make_tensor"
+    assert call.op.name == ir.get_op("dist.make_tensor").name
     assert len(call.args) == 2
 
 
@@ -44,7 +44,7 @@ def test_dist_tree_reduce_call():
     rt_var = _make_var("rt")
     leaves_var = _make_var("leaves")
     call = ir.Call(op, [rt_var, leaves_var], _span())
-    assert call.op.name == "dist.tree_reduce"
+    assert call.op.name == ir.get_op("dist.tree_reduce").name
     assert len(call.args) == 2
 
 
@@ -53,7 +53,7 @@ def test_dist_submit_worker_call():
     op = ir.Op("dist.submit_worker")
     rt_var = _make_var("rt")
     call = ir.Call(op, [rt_var], _span())
-    assert call.op.name == "dist.submit_worker"
+    assert call.op.name == ir.get_op("dist.submit_worker").name
 
 
 def test_dist_submit_orchestrator_call():
@@ -61,7 +61,7 @@ def test_dist_submit_orchestrator_call():
     op = ir.Op("dist.submit_orchestrator")
     rt_var = _make_var("rt")
     call = ir.Call(op, [rt_var], _span())
-    assert call.op.name == "dist.submit_orchestrator"
+    assert call.op.name == ir.get_op("dist.submit_orchestrator").name
 
 
 def test_dist_future_get_call():
@@ -69,7 +69,7 @@ def test_dist_future_get_call():
     op = ir.Op("dist.future_get")
     future_var = _make_var("future")
     call = ir.Call(op, [future_var], _span())
-    assert call.op.name == "dist.future_get"
+    assert call.op.name == ir.get_op("dist.future_get").name
     assert len(call.args) == 1
 
 

--- a/tests/ut/ir/operators/test_array_ops.py
+++ b/tests/ut/ir/operators/test_array_ops.py
@@ -100,7 +100,7 @@ def test_array_type_rejects_dynamic_extent():
 def test_array_create_op():
     call = ir_array.create(16, DataType.INT32)
     assert isinstance(call, ir.Call)
-    assert call.op.name == "array.create"
+    assert call.op.name == ir.get_op("array.create").name
     assert isinstance(call.type, ir.ArrayType)
     array_type = cast(ir.ArrayType, call.type)
     assert array_type.dtype == DataType.INT32
@@ -112,7 +112,7 @@ def test_array_get_element_op_returns_scalar():
     arr = ir_array.create(8, DataType.INT32)
     idx = ir.ConstInt(3, DataType.INT32, ir.Span.unknown())
     call = ir_array.get_element(arr, idx)
-    assert call.op.name == "array.get_element"
+    assert call.op.name == ir.get_op("array.get_element").name
     assert isinstance(call.type, ir.ScalarType)
     assert call.type.dtype == DataType.INT32
 
@@ -122,7 +122,7 @@ def test_array_update_element_op_returns_array():
     idx = ir.ConstInt(3, DataType.INT32, ir.Span.unknown())
     val = ir.ConstInt(42, DataType.INT32, ir.Span.unknown())
     call = ir_array.update_element(arr, idx, val)
-    assert call.op.name == "array.update_element"
+    assert call.op.name == ir.get_op("array.update_element").name
     array_type = cast(ir.ArrayType, call.type)
     assert array_type.dtype == DataType.INT32
     assert _extent(array_type) == 8

--- a/tests/ut/ir/operators/test_tensor_ops.py
+++ b/tests/ut/ir/operators/test_tensor_ops.py
@@ -24,6 +24,25 @@ import pytest
 from pypto import DataType, ir
 from pypto.ir.op import tensor
 
+_OP_TENSOR_CREATE = ir.get_op("tensor.create").name
+_OP_TENSOR_DIM = ir.get_op("tensor.dim").name
+_OP_TENSOR_EXPAND_CLONE = ir.get_op("tensor.expand_clone").name
+_OP_TENSOR_FMODS = ir.get_op("tensor.fmods").name
+_OP_TENSOR_GATHER = ir.get_op("tensor.gather").name
+_OP_TENSOR_GATHER_MASK = ir.get_op("tensor.gather_mask").name
+_OP_TENSOR_MAXIMUM = ir.get_op("tensor.maximum").name
+_OP_TENSOR_MINIMUM = ir.get_op("tensor.minimum").name
+_OP_TENSOR_READ = ir.get_op("tensor.read").name
+_OP_TENSOR_RESHAPE = ir.get_op("tensor.reshape").name
+_OP_TENSOR_RSQRT = ir.get_op("tensor.rsqrt").name
+_OP_TENSOR_SCATTER = ir.get_op("tensor.scatter").name
+_OP_TENSOR_SCATTER_MASK = ir.get_op("tensor.scatter_mask").name
+_OP_TENSOR_SCATTER_UPDATE = ir.get_op("tensor.scatter_update").name
+_OP_TENSOR_SET_VALIDSHAPE = ir.get_op("tensor.set_validshape").name
+_OP_TENSOR_SLICE = ir.get_op("tensor.slice").name
+_OP_TENSOR_TRANSPOSE = ir.get_op("tensor.transpose").name
+_OP_TENSOR_WRITE = ir.get_op("tensor.write").name
+
 
 def test_tensor_create():
     """Test tensor.create operation."""
@@ -31,7 +50,7 @@ def test_tensor_create():
     call = ir.op.tensor.create([4, 8], DataType.FP32)
 
     assert isinstance(call, ir.Call)
-    assert call.op.name == "tensor.create"
+    assert call.op.name == _OP_TENSOR_CREATE
 
     # Check result type
     result_type = call.type
@@ -54,7 +73,7 @@ def test_tensor_slice():
     call = ir.op.tensor.slice(tensor_var, [8, 16], [0, 0])
 
     assert isinstance(call, ir.Call)
-    assert call.op.name == "tensor.slice"
+    assert call.op.name == _OP_TENSOR_SLICE
 
     # Check result type
     result_type = call.type
@@ -81,7 +100,7 @@ def test_tensor_matmul():
     call = ir.op.tensor.matmul(lhs, rhs, out_dtype=DataType.FP32)
 
     assert isinstance(call, ir.Call)
-    assert call.op.name == "tensor.matmul"
+    assert call.op.name == ir.get_op("tensor.matmul").name
 
     # Check result type - should be [4, 16]
     result_type = call.type
@@ -132,7 +151,7 @@ def test_tensor_matmul_acc():
     call = ir.op.tensor.matmul_acc(acc, lhs, rhs)
 
     assert isinstance(call, ir.Call)
-    assert call.op.name == "tensor.matmul_acc"
+    assert call.op.name == ir.get_op("tensor.matmul_acc").name
 
     result_type = call.type
     assert isinstance(result_type, ir.TensorType)
@@ -225,7 +244,7 @@ def test_tensor_row_max():
     call = ir.op.tensor.row_max(tensor_var)
 
     assert isinstance(call, ir.Call)
-    assert call.op.name == "tensor.row_max"
+    assert call.op.name == ir.get_op("tensor.row_max").name
 
     # Check result type - should be [64, 1]
     result_type = call.type
@@ -248,7 +267,7 @@ def test_tensor_row_sum():
     call = ir.op.tensor.row_sum(tensor_var)
 
     assert isinstance(call, ir.Call)
-    assert call.op.name == "tensor.row_sum"
+    assert call.op.name == ir.get_op("tensor.row_sum").name
 
     # Check result type - should be [64, 1]
     result_type = call.type
@@ -268,7 +287,7 @@ def test_tensor_col_sum():
     call = ir.op.tensor.col_sum(tensor_var)
 
     assert isinstance(call, ir.Call)
-    assert call.op.name == "tensor.col_sum"
+    assert call.op.name == ir.get_op("tensor.col_sum").name
 
     # Output shape should be [1, 128] — the second-to-last dim collapses to 1.
     result_type = call.type
@@ -289,7 +308,7 @@ def test_tensor_row_prod():
     call = ir.op.tensor.row_prod(tensor_var)
 
     assert isinstance(call, ir.Call)
-    assert call.op.name == "tensor.row_prod"
+    assert call.op.name == ir.get_op("tensor.row_prod").name
 
     # Row reduction collapses the last axis (keepdim): [64, 128] -> [64, 1].
     result_type = call.type
@@ -312,7 +331,7 @@ def test_tensor_col_prod():
     call = ir.op.tensor.col_prod(tensor_var)
 
     assert isinstance(call, ir.Call)
-    assert call.op.name == "tensor.col_prod"
+    assert call.op.name == ir.get_op("tensor.col_prod").name
 
     # Column reduction collapses axis=-2 (keepdim): [64, 128] -> [1, 128].
     result_type = call.type
@@ -499,7 +518,7 @@ def test_tensor_row_argmax():
     call = ir.op.tensor.row_argmax(tensor_var)
 
     assert isinstance(call, ir.Call)
-    assert call.op.name == "tensor.row_argmax"
+    assert call.op.name == ir.get_op("tensor.row_argmax").name
 
     # Row reduction collapses the last axis (keepdim): [64, 128] -> [64, 1]; dtype -> int32.
     result_type = call.type
@@ -522,7 +541,7 @@ def test_tensor_row_argmin():
     call = ir.op.tensor.row_argmin(tensor_var)
 
     assert isinstance(call, ir.Call)
-    assert call.op.name == "tensor.row_argmin"
+    assert call.op.name == ir.get_op("tensor.row_argmin").name
     result_type = call.type
     assert isinstance(result_type, ir.TensorType)
     assert result_type.dtype == DataType.INT32
@@ -544,7 +563,7 @@ def test_tensor_col_argmax():
     call = ir.op.tensor.col_argmax(tensor_var)
 
     assert isinstance(call, ir.Call)
-    assert call.op.name == "tensor.col_argmax"
+    assert call.op.name == ir.get_op("tensor.col_argmax").name
 
     # Column reduction collapses axis=-2 (keepdim): [64, 128] -> [1, 128]; dtype -> int32.
     result_type = call.type
@@ -567,7 +586,7 @@ def test_tensor_col_argmin():
     call = ir.op.tensor.col_argmin(tensor_var)
 
     assert isinstance(call, ir.Call)
-    assert call.op.name == "tensor.col_argmin"
+    assert call.op.name == ir.get_op("tensor.col_argmin").name
     result_type = call.type
     assert isinstance(result_type, ir.TensorType)
     assert result_type.dtype == DataType.INT32
@@ -590,7 +609,7 @@ def test_tensor_col_max():
     call = ir.op.tensor.col_max(tensor_var)
 
     assert isinstance(call, ir.Call)
-    assert call.op.name == "tensor.col_max"
+    assert call.op.name == ir.get_op("tensor.col_max").name
 
     # Output shape should be [1, 128] — the second-to-last dim collapses to 1.
     result_type = call.type
@@ -612,7 +631,7 @@ def test_tensor_col_min():
     call = ir.op.tensor.col_min(tensor_var)
 
     assert isinstance(call, ir.Call)
-    assert call.op.name == "tensor.col_min"
+    assert call.op.name == ir.get_op("tensor.col_min").name
 
     # Output shape should be [1, 128] — the second-to-last dim collapses to 1.
     result_type = call.type
@@ -635,7 +654,7 @@ def test_tensor_exp():
     call = ir.op.tensor.exp(tensor_var)
 
     assert isinstance(call, ir.Call)
-    assert call.op.name == "tensor.exp"
+    assert call.op.name == ir.get_op("tensor.exp").name
 
     # Check result type - should preserve shape and dtype
     result_type = call.type
@@ -663,7 +682,7 @@ def test_tensor_log_contract_and_precision(dtype, high_precision):
     call = ir.op.tensor.log(tensor_var, high_precision=high_precision)
 
     assert isinstance(call, ir.Call)
-    assert call.op.name == "tensor.log"
+    assert call.op.name == ir.get_op("tensor.log").name
     result_type = call.type
     assert isinstance(result_type, ir.TensorType)
     assert result_type.dtype == dtype
@@ -702,7 +721,7 @@ def test_tensor_sin_creates_call():
     call = ir.op.tensor.sin(tensor_var)
 
     assert isinstance(call, ir.Call)
-    assert call.op.name == "tensor.sin"
+    assert call.op.name == ir.get_op("tensor.sin").name
 
     result_type = call.type
     assert isinstance(result_type, ir.TensorType)
@@ -721,7 +740,7 @@ def test_tensor_cos_creates_call():
     call = ir.op.tensor.cos(tensor_var)
 
     assert isinstance(call, ir.Call)
-    assert call.op.name == "tensor.cos"
+    assert call.op.name == ir.get_op("tensor.cos").name
 
     result_type = call.type
     assert isinstance(result_type, ir.TensorType)
@@ -781,7 +800,7 @@ def test_tensor_neg():
     call = ir.op.tensor.neg(tensor_var)
 
     assert isinstance(call, ir.Call)
-    assert call.op.name == "tensor.neg"
+    assert call.op.name == ir.get_op("tensor.neg").name
     result_type = call.type
     assert isinstance(result_type, ir.TensorType)
     assert result_type.dtype == DataType.FP16
@@ -818,7 +837,7 @@ def test_tensor_abs():
     call = ir.op.tensor.abs(tensor_var)
 
     assert isinstance(call, ir.Call)
-    assert call.op.name == "tensor.abs"
+    assert call.op.name == ir.get_op("tensor.abs").name
     result_type = call.type
     assert isinstance(result_type, ir.TensorType)
     assert result_type.dtype == DataType.BF16
@@ -854,7 +873,7 @@ def test_tensor_recip():
     call = ir.op.tensor.recip(tensor_var)
 
     assert isinstance(call, ir.Call)
-    assert call.op.name == "tensor.recip"
+    assert call.op.name == ir.get_op("tensor.recip").name
     result_type = call.type
     assert isinstance(result_type, ir.TensorType)
     assert result_type.dtype == DataType.FP16
@@ -886,7 +905,7 @@ def test_tensor_sqrt():
     call = ir.op.tensor.sqrt(tensor_var)
 
     assert isinstance(call, ir.Call)
-    assert call.op.name == "tensor.sqrt"
+    assert call.op.name == ir.get_op("tensor.sqrt").name
     result_type = call.type
     assert isinstance(result_type, ir.TensorType)
     assert result_type.dtype == DataType.FP16
@@ -928,7 +947,7 @@ def test_tensor_rsqrt():
     call = ir.op.tensor.rsqrt(tensor_var)
 
     assert isinstance(call, ir.Call)
-    assert call.op.name == "tensor.rsqrt"
+    assert call.op.name == _OP_TENSOR_RSQRT
     result_type = call.type
     assert isinstance(result_type, ir.TensorType)
     assert result_type.dtype == DataType.FP16
@@ -969,7 +988,7 @@ def test_tensor_rsqrt_high_precision_kwarg():
 
     call = ir.op.tensor.rsqrt(tensor_var, high_precision=True)
 
-    assert call.op.name == "tensor.rsqrt"
+    assert call.op.name == _OP_TENSOR_RSQRT
     kwargs = dict(call.kwargs)
     assert kwargs.get("high_precision") is True
 
@@ -988,7 +1007,7 @@ def test_tensor_cast():
     call = ir.op.tensor.cast(tensor_var, DataType.FP32)
 
     assert isinstance(call, ir.Call)
-    assert call.op.name == "tensor.cast"
+    assert call.op.name == ir.get_op("tensor.cast").name
 
     # Check result type - should preserve shape but change dtype
     result_type = call.type
@@ -1031,7 +1050,7 @@ def test_tensor_assemble():
     call = ir.op.tensor.assemble(target, source, [0, 0])
 
     assert isinstance(call, ir.Call)
-    assert call.op.name == "tensor.assemble"
+    assert call.op.name == ir.get_op("tensor.assemble").name
 
     # Check result type - should be target type
     result_type = call.type
@@ -1053,7 +1072,7 @@ def test_tensor_row_expand_mul():
     call = ir.op.tensor.row_expand_mul(tensor_var, row_var)
 
     assert isinstance(call, ir.Call)
-    assert call.op.name == "tensor.row_expand_mul"
+    assert call.op.name == ir.get_op("tensor.row_expand_mul").name
     result_type = call.type
     assert isinstance(result_type, ir.TensorType)
     assert result_type.dtype == DataType.FP16
@@ -1085,7 +1104,7 @@ def test_tensor_row_expand_max():
     tensor_var, row_var = _row_expand_pair()
     call = ir.op.tensor.row_expand_max(tensor_var, row_var)
     assert isinstance(call, ir.Call)
-    assert call.op.name == "tensor.row_expand_max"
+    assert call.op.name == ir.get_op("tensor.row_expand_max").name
     assert isinstance(call.type, ir.TensorType)
     assert len(call.type.shape) == 2
 
@@ -1095,7 +1114,7 @@ def test_tensor_row_expand_min():
     tensor_var, row_var = _row_expand_pair()
     call = ir.op.tensor.row_expand_min(tensor_var, row_var)
     assert isinstance(call, ir.Call)
-    assert call.op.name == "tensor.row_expand_min"
+    assert call.op.name == ir.get_op("tensor.row_expand_min").name
     assert isinstance(call.type, ir.TensorType)
     assert len(call.type.shape) == 2
 
@@ -1105,7 +1124,7 @@ def test_tensor_row_expand_expdif():
     tensor_var, row_var = _row_expand_pair()
     call = ir.op.tensor.row_expand_expdif(tensor_var, row_var)
     assert isinstance(call, ir.Call)
-    assert call.op.name == "tensor.row_expand_expdif"
+    assert call.op.name == ir.get_op("tensor.row_expand_expdif").name
     assert isinstance(call.type, ir.TensorType)
     assert len(call.type.shape) == 2
 
@@ -1115,7 +1134,7 @@ def test_tensor_col_expand_max():
     tensor_var, col_var = _col_expand_pair()
     call = ir.op.tensor.col_expand_max(tensor_var, col_var)
     assert isinstance(call, ir.Call)
-    assert call.op.name == "tensor.col_expand_max"
+    assert call.op.name == ir.get_op("tensor.col_expand_max").name
     assert isinstance(call.type, ir.TensorType)
     assert len(call.type.shape) == 2
 
@@ -1125,7 +1144,7 @@ def test_tensor_col_expand_min():
     tensor_var, col_var = _col_expand_pair()
     call = ir.op.tensor.col_expand_min(tensor_var, col_var)
     assert isinstance(call, ir.Call)
-    assert call.op.name == "tensor.col_expand_min"
+    assert call.op.name == ir.get_op("tensor.col_expand_min").name
     assert isinstance(call.type, ir.TensorType)
     assert len(call.type.shape) == 2
 
@@ -1135,7 +1154,7 @@ def test_tensor_col_expand_expdif():
     tensor_var, col_var = _col_expand_pair()
     call = ir.op.tensor.col_expand_expdif(tensor_var, col_var)
     assert isinstance(call, ir.Call)
-    assert call.op.name == "tensor.col_expand_expdif"
+    assert call.op.name == ir.get_op("tensor.col_expand_expdif").name
     assert isinstance(call.type, ir.TensorType)
     assert len(call.type.shape) == 2
 
@@ -1189,7 +1208,7 @@ def test_tensor_row_expand_div():
     call = ir.op.tensor.row_expand_div(tensor_var, row_var)
 
     assert isinstance(call, ir.Call)
-    assert call.op.name == "tensor.row_expand_div"
+    assert call.op.name == ir.get_op("tensor.row_expand_div").name
     result_type = call.type
     assert isinstance(result_type, ir.TensorType)
     assert result_type.dtype == DataType.FP16
@@ -1245,7 +1264,7 @@ def test_tensor_col_expand_mul():
     call = ir.op.tensor.col_expand_mul(tensor_var, col_var)
 
     assert isinstance(call, ir.Call)
-    assert call.op.name == "tensor.col_expand_mul"
+    assert call.op.name == ir.get_op("tensor.col_expand_mul").name
     result_type = call.type
     assert isinstance(result_type, ir.TensorType)
     assert result_type.dtype == DataType.FP16
@@ -1304,7 +1323,7 @@ def test_tensor_maximum():
     call = ir.op.tensor.maximum(var_a, var_b)
 
     assert isinstance(call, ir.Call)
-    assert call.op.name == "tensor.maximum"
+    assert call.op.name == _OP_TENSOR_MAXIMUM
 
 
 def test_tensor_maximum_scalar():
@@ -1315,7 +1334,7 @@ def test_tensor_maximum_scalar():
     var_a = ir.Var("a", type_a, span)
 
     call = ir.op.tensor.maximum(var_a, 0.5)
-    assert call.op.name == "tensor.maximum"
+    assert call.op.name == _OP_TENSOR_MAXIMUM
 
 
 def test_tensor_minimum():
@@ -1327,10 +1346,10 @@ def test_tensor_minimum():
     var_b = ir.Var("b", type_a, span)
 
     call_tt = ir.op.tensor.minimum(var_a, var_b)
-    assert call_tt.op.name == "tensor.minimum"
+    assert call_tt.op.name == _OP_TENSOR_MINIMUM
 
     call_ts = ir.op.tensor.minimum(var_a, 1.0)
-    assert call_ts.op.name == "tensor.minimum"
+    assert call_ts.op.name == _OP_TENSOR_MINIMUM
 
 
 def test_tensor_mul():
@@ -1349,7 +1368,7 @@ def test_tensor_mul():
     call = ir.op.tensor.mul(tensor_var, scalar_tensor_var)
 
     assert isinstance(call, ir.Call)
-    assert call.op.name == "tensor.mul"
+    assert call.op.name == ir.get_op("tensor.mul").name
 
 
 def test_tensor_add():
@@ -1366,7 +1385,7 @@ def test_tensor_add():
     call = ir.op.tensor.add(var_a, var_b)
 
     assert isinstance(call, ir.Call)
-    assert call.op.name == "tensor.add"
+    assert call.op.name == ir.get_op("tensor.add").name
 
 
 def test_tensor_sub():
@@ -1383,7 +1402,7 @@ def test_tensor_sub():
     call = ir.op.tensor.sub(var_a, var_b)
 
     assert isinstance(call, ir.Call)
-    assert call.op.name == "tensor.sub"
+    assert call.op.name == ir.get_op("tensor.sub").name
 
 
 def test_tensor_div_precision_kwarg_and_scalar_dispatch():
@@ -1399,7 +1418,7 @@ def test_tensor_div_precision_kwarg_and_scalar_dispatch():
 
     assert dict(default_call.kwargs) == {}
     assert dict(high_precision_call.kwargs) == {"high_precision": True}
-    assert scalar_call.op.name == "tensor.divs"
+    assert scalar_call.op.name == ir.get_op("tensor.divs").name
     assert dict(scalar_call.kwargs) == {}
     with pytest.raises(ValueError, match=r"requires a Tensor rhs"):
         ir.op.tensor.div(lhs, 2.0, high_precision=True)
@@ -1425,7 +1444,7 @@ def test_tensor_div_accepts_ptoas_dtype_union(dtype):
     call = tensor.div(lhs, rhs)
 
     assert isinstance(call, ir.Call)
-    assert call.op.name == "tensor.div"
+    assert call.op.name == ir.get_op("tensor.div").name
     assert isinstance(call.type, ir.TensorType)
     assert call.type.dtype == dtype
 
@@ -1525,17 +1544,17 @@ def test_tensor_fmod():
     # tensor-tensor -> tensor.fmod
     call = ir.op.tensor.fmod(var_a, var_b)
     assert isinstance(call, ir.Call)
-    assert call.op.name == "tensor.fmod"
+    assert call.op.name == ir.get_op("tensor.fmod").name
 
     # tensor-scalar via fmod auto-dispatch -> tensor.fmods
     call_scalar = ir.op.tensor.fmod(var_a, 3.0)
     assert isinstance(call_scalar, ir.Call)
-    assert call_scalar.op.name == "tensor.fmods"
+    assert call_scalar.op.name == _OP_TENSOR_FMODS
 
     # explicit fmods -> tensor.fmods
     call_fmods = ir.op.tensor.fmods(var_a, 3.0)
     assert isinstance(call_fmods, ir.Call)
-    assert call_fmods.op.name == "tensor.fmods"
+    assert call_fmods.op.name == _OP_TENSOR_FMODS
 
 
 def test_const_float():
@@ -1577,7 +1596,7 @@ def test_tensor_read():
     call = ir.op.tensor.read(tensor_var, [2, 3])
 
     assert isinstance(call, ir.Call)
-    assert call.op.name == "tensor.read"
+    assert call.op.name == _OP_TENSOR_READ
 
     # Result should be ScalarType with tensor's element dtype
     result_type = call.type
@@ -1599,7 +1618,7 @@ def test_tensor_read_with_expr_indices():
     call = ir.op.tensor.read(tensor_var, [idx_var])
 
     assert isinstance(call, ir.Call)
-    assert call.op.name == "tensor.read"
+    assert call.op.name == _OP_TENSOR_READ
     result_type = call.type
     assert isinstance(result_type, ir.ScalarType)
     assert result_type.dtype == DataType.FP16
@@ -1620,7 +1639,7 @@ def test_tensor_dim():
     call = ir.op.tensor.dim(tensor_var, 1)
 
     assert isinstance(call, ir.Call)
-    assert call.op.name == "tensor.dim"
+    assert call.op.name == _OP_TENSOR_DIM
 
     # Result should be ScalarType(INDEX) — tensor.dim returns machine-word index type
     result_type = call.type
@@ -1642,7 +1661,7 @@ def test_tensor_dim_negative_axis():
     call = ir.op.tensor.dim(tensor_var, -1)
 
     assert isinstance(call, ir.Call)
-    assert call.op.name == "tensor.dim"
+    assert call.op.name == _OP_TENSOR_DIM
     result_type = call.type
     assert isinstance(result_type, ir.ScalarType)
     assert result_type.dtype == DataType.INDEX
@@ -1657,7 +1676,7 @@ def test_tensor_create_dynamic_shape():
     call = ir.op.tensor.create([dim_n, 128], DataType.FP32)
 
     assert isinstance(call, ir.Call)
-    assert call.op.name == "tensor.create"
+    assert call.op.name == _OP_TENSOR_CREATE
     result_type = call.type
     assert isinstance(result_type, ir.TensorType)
     assert result_type.dtype == DataType.FP32
@@ -1709,7 +1728,7 @@ def test_tensor_reshape():
     call = ir.op.tensor.reshape(tensor_var, [32])
 
     assert isinstance(call, ir.Call)
-    assert call.op.name == "tensor.reshape"
+    assert call.op.name == _OP_TENSOR_RESHAPE
     result_type = call.type
     assert isinstance(result_type, ir.TensorType)
     assert result_type.dtype == DataType.FP32
@@ -1737,7 +1756,7 @@ def test_tensor_reshape_dynamic():
     call = ir.op.tensor.reshape(tensor_var, [dim_k])
 
     assert isinstance(call, ir.Call)
-    assert call.op.name == "tensor.reshape"
+    assert call.op.name == _OP_TENSOR_RESHAPE
     result_type = call.type
     assert isinstance(result_type, ir.TensorType)
 
@@ -1926,7 +1945,7 @@ def test_tensor_transpose():
     call = ir.op.tensor.transpose(tensor_var, 0, 2)
 
     assert isinstance(call, ir.Call)
-    assert call.op.name == "tensor.transpose"
+    assert call.op.name == _OP_TENSOR_TRANSPOSE
     result_type = call.type
     assert isinstance(result_type, ir.TensorType)
     assert result_type.dtype == DataType.FP32
@@ -1948,7 +1967,7 @@ def test_tensor_transpose_negative_axis():
     call = ir.op.tensor.transpose(tensor_var, -2, -1)
 
     assert isinstance(call, ir.Call)
-    assert call.op.name == "tensor.transpose"
+    assert call.op.name == _OP_TENSOR_TRANSPOSE
     result_type = call.type
     assert isinstance(result_type, ir.TensorType)
 
@@ -2164,7 +2183,7 @@ def test_tensor_slice_with_valid_shape():
     call = ir.op.tensor.slice(tensor_var, [8, 16], [0, 0], valid_shape=[4, 8])
 
     assert isinstance(call, ir.Call)
-    assert call.op.name == "tensor.slice"
+    assert call.op.name == _OP_TENSOR_SLICE
     result_type = call.type
     assert isinstance(result_type, ir.TensorType)
     assert result_type.dtype == DataType.FP16
@@ -2181,7 +2200,7 @@ def test_tensor_slice_drop_dims_rank_reduces():
 
     call = ir.op.tensor.slice(tensor_var, [1, 1, 64, 64], [3, 5, 0, 0], drop_dims=[0, 1])
 
-    assert call.op.name == "tensor.slice"
+    assert call.op.name == _OP_TENSOR_SLICE
     result_type = call.type
     assert isinstance(result_type, ir.TensorType)
     assert [d.value for d in result_type.shape if isinstance(d, ir.ConstInt)] == [64, 64]
@@ -2264,7 +2283,7 @@ def test_tensor_slice_with_pad_value():
     call = tensor.slice(tensor_var, [8, 16], [0, 0], valid_shape=[8, 4], pad_value=ir.PadValue.zero)
 
     assert isinstance(call, ir.Call)
-    assert call.op.name == "tensor.slice"
+    assert call.op.name == _OP_TENSOR_SLICE
     result_type = call.type
     assert isinstance(result_type, ir.TensorType)
     assert result_type.tensor_view is not None
@@ -2659,7 +2678,7 @@ def test_tensor_fillpad_clears_valid_shape():
     call = ir.op.tensor.fillpad(tensor_var, pad_value=ir.PadValue.min)
 
     assert isinstance(call, ir.Call)
-    assert call.op.name == "tensor.fillpad"
+    assert call.op.name == ir.get_op("tensor.fillpad").name
     result_type = call.type
     assert isinstance(result_type, ir.TensorType)
     assert result_type.dtype == DataType.FP32
@@ -2682,7 +2701,7 @@ def test_tensor_fillpad_expand():
     call = ir.op.tensor.fillpad_expand(tensor_var, [64, 128], pad_value=ir.PadValue.zero)
 
     assert isinstance(call, ir.Call)
-    assert call.op.name == "tensor.fillpad_expand"
+    assert call.op.name == ir.get_op("tensor.fillpad_expand").name
     result_type = call.type
     assert isinstance(result_type, ir.TensorType)
     assert result_type.dtype == DataType.FP32
@@ -2718,7 +2737,7 @@ def test_tensor_set_validshape():
     call = ir.op.tensor.set_validshape(tensor_var, 16, 24)
 
     assert isinstance(call, ir.Call)
-    assert call.op.name == "tensor.set_validshape"
+    assert call.op.name == _OP_TENSOR_SET_VALIDSHAPE
     result_type = call.type
     assert isinstance(result_type, ir.TensorType)
     assert result_type.dtype == DataType.FP32
@@ -2738,7 +2757,7 @@ def test_tensor_set_validshape_dynamic():
     call = ir.op.tensor.set_validshape(tensor_var, vr, vc)
 
     assert isinstance(call, ir.Call)
-    assert call.op.name == "tensor.set_validshape"
+    assert call.op.name == _OP_TENSOR_SET_VALIDSHAPE
     result_type = call.type
     assert isinstance(result_type, ir.TensorType)
     assert result_type.tensor_view is not None
@@ -2833,7 +2852,7 @@ def test_tensor_reshape_with_valid_shape():
     call = ir.op.tensor.reshape(tensor_var, [32], valid_shape=[16])
 
     assert isinstance(call, ir.Call)
-    assert call.op.name == "tensor.reshape"
+    assert call.op.name == _OP_TENSOR_RESHAPE
     result_type = call.type
     assert isinstance(result_type, ir.TensorType)
     assert result_type.dtype == DataType.FP32
@@ -3018,7 +3037,7 @@ def test_tensor_transpose_with_valid_shape():
     call = ir.op.tensor.transpose(tensor_var, 0, 1, valid_shape=[16, 8])
 
     assert isinstance(call, ir.Call)
-    assert call.op.name == "tensor.transpose"
+    assert call.op.name == _OP_TENSOR_TRANSPOSE
     result_type = call.type
     assert isinstance(result_type, ir.TensorType)
     assert result_type.dtype == DataType.FP32
@@ -3046,7 +3065,7 @@ class TestTensorScalarMemoryOps:
         call = tensor.read(tensor_var, [idx])
 
         assert isinstance(call, ir.Call)
-        assert call.op.name == "tensor.read"
+        assert call.op.name == _OP_TENSOR_READ
         assert isinstance(call.type, ir.ScalarType)
         assert call.type.dtype == DataType.FP32
 
@@ -3062,7 +3081,7 @@ class TestTensorScalarMemoryOps:
 
         call = tensor.read(tensor_var, [i, j])
 
-        assert call.op.name == "tensor.read"
+        assert call.op.name == _OP_TENSOR_READ
         assert isinstance(call.type, ir.ScalarType)
         assert call.type.dtype == DataType.FP32
 
@@ -3078,7 +3097,7 @@ class TestTensorScalarMemoryOps:
         call = tensor.write(tensor_var, [idx], value)
 
         assert isinstance(call, ir.Call)
-        assert call.op.name == "tensor.write"
+        assert call.op.name == _OP_TENSOR_WRITE
 
     def test_write_2d(self):
         """Test tensor.write with 2D indices."""
@@ -3093,7 +3112,7 @@ class TestTensorScalarMemoryOps:
 
         call = tensor.write(tensor_var, [i, j], value)
 
-        assert call.op.name == "tensor.write"
+        assert call.op.name == _OP_TENSOR_WRITE
 
     def test_read_type_mismatch(self):
         """Test tensor.read with wrong argument types raises error."""
@@ -3124,7 +3143,7 @@ def test_tensor_row_min(dtype):
     call = ir.op.tensor.row_min(tensor_var)
 
     assert isinstance(call, ir.Call)
-    assert call.op.name == "tensor.row_min"
+    assert call.op.name == ir.get_op("tensor.row_min").name
     result_type = call.type
     assert isinstance(result_type, ir.TensorType)
     assert result_type.dtype == dtype
@@ -3160,7 +3179,7 @@ def test_tensor_row_expand():
     call = ir.op.tensor.row_expand(tensor_var, row_var)
 
     assert isinstance(call, ir.Call)
-    assert call.op.name == "tensor.row_expand"
+    assert call.op.name == ir.get_op("tensor.row_expand").name
     result_type = call.type
     assert isinstance(result_type, ir.TensorType)
     assert result_type.dtype == DataType.FP16
@@ -3201,7 +3220,7 @@ def test_tensor_row_expand_add_accepts_ptoas_dtype_union(dtype):
     call = tensor.row_expand_add(tensor_var, row_var)
 
     assert isinstance(call, ir.Call)
-    assert call.op.name == "tensor.row_expand_add"
+    assert call.op.name == ir.get_op("tensor.row_expand_add").name
     assert isinstance(call.type, ir.TensorType)
     assert call.type.dtype == dtype
     assert [dim.value for dim in call.type.shape if isinstance(dim, ir.ConstInt)] == [64, 128]
@@ -3252,7 +3271,7 @@ def test_tensor_row_expand_sub():
     call = ir.op.tensor.row_expand_sub(tensor_var, row_var)
 
     assert isinstance(call, ir.Call)
-    assert call.op.name == "tensor.row_expand_sub"
+    assert call.op.name == ir.get_op("tensor.row_expand_sub").name
     result_type = call.type
     assert isinstance(result_type, ir.TensorType)
     assert result_type.dtype == DataType.FP16
@@ -3313,7 +3332,7 @@ def test_tensor_col_expand():
     call = ir.op.tensor.col_expand(tensor_var, col_var)
 
     assert isinstance(call, ir.Call)
-    assert call.op.name == "tensor.col_expand"
+    assert call.op.name == ir.get_op("tensor.col_expand").name
     result_type = call.type
     assert isinstance(result_type, ir.TensorType)
     assert result_type.dtype == DataType.FP16
@@ -3374,7 +3393,7 @@ def test_tensor_col_expand_div():
     call = ir.op.tensor.col_expand_div(tensor_var, col_var)
 
     assert isinstance(call, ir.Call)
-    assert call.op.name == "tensor.col_expand_div"
+    assert call.op.name == ir.get_op("tensor.col_expand_div").name
     result_type = call.type
     assert isinstance(result_type, ir.TensorType)
     assert result_type.dtype == DataType.FP16
@@ -3420,7 +3439,7 @@ def test_tensor_col_expand_sub():
     call = ir.op.tensor.col_expand_sub(tensor_var, col_var)
 
     assert isinstance(call, ir.Call)
-    assert call.op.name == "tensor.col_expand_sub"
+    assert call.op.name == ir.get_op("tensor.col_expand_sub").name
     result_type = call.type
     assert isinstance(result_type, ir.TensorType)
     assert result_type.dtype == DataType.FP16
@@ -3466,7 +3485,7 @@ def test_tensor_col_expand_add():
     call = ir.op.tensor.col_expand_add(tensor_var, col_var)
 
     assert isinstance(call, ir.Call)
-    assert call.op.name == "tensor.col_expand_add"
+    assert call.op.name == ir.get_op("tensor.col_expand_add").name
     result_type = call.type
     assert isinstance(result_type, ir.TensorType)
     assert result_type.dtype == DataType.FP16
@@ -3526,7 +3545,7 @@ def test_tensor_expands():
     call = ir.op.tensor.expands(tensor_var, scalar_var)
 
     assert isinstance(call, ir.Call)
-    assert call.op.name == "tensor.expands"
+    assert call.op.name == ir.get_op("tensor.expands").name
     result_type = call.type
     assert isinstance(result_type, ir.TensorType)
     assert result_type.dtype == DataType.FP32
@@ -3555,7 +3574,7 @@ def test_tensor_expand_clone_dim0():
     call = ir.op.tensor.expand_clone(input_var, target_var)
 
     assert isinstance(call, ir.Call)
-    assert call.op.name == "tensor.expand_clone"
+    assert call.op.name == _OP_TENSOR_EXPAND_CLONE
     result_type = call.type
     assert isinstance(result_type, ir.TensorType)
     assert result_type.dtype == DataType.FP32
@@ -3582,7 +3601,7 @@ def test_tensor_expand_clone_dim1():
     call = ir.op.tensor.expand_clone(input_var, target_var)
 
     assert isinstance(call, ir.Call)
-    assert call.op.name == "tensor.expand_clone"
+    assert call.op.name == _OP_TENSOR_EXPAND_CLONE
     result_type = call.type
     assert isinstance(result_type, ir.TensorType)
     assert result_type.dtype == DataType.FP32
@@ -3609,7 +3628,7 @@ def test_tensor_expand_clone_dim2():
     call = ir.op.tensor.expand_clone(input_var, target_var)
 
     assert isinstance(call, ir.Call)
-    assert call.op.name == "tensor.expand_clone"
+    assert call.op.name == _OP_TENSOR_EXPAND_CLONE
     result_type = call.type
     assert isinstance(result_type, ir.TensorType)
     assert result_type.dtype == DataType.FP32
@@ -3632,7 +3651,7 @@ def test_tensor_concat():
     call = tensor.concat(t0_var, t1_var)
 
     assert isinstance(call, ir.Call)
-    assert call.op.name == "tensor.concat"
+    assert call.op.name == ir.get_op("tensor.concat").name
     result_type = call.type
     assert isinstance(result_type, ir.TensorType)
     assert result_type.dtype == DataType.FP32
@@ -3691,7 +3710,7 @@ def test_tensor_scatter_update_2d():
     call = ir.op.tensor.scatter_update(input_var, -2, index_var, src_var)
 
     assert isinstance(call, ir.Call)
-    assert call.op.name == "tensor.scatter_update"
+    assert call.op.name == _OP_TENSOR_SCATTER_UPDATE
     result_type = call.type
     assert isinstance(result_type, ir.TensorType)
     assert result_type.dtype == DataType.FP16
@@ -3720,7 +3739,7 @@ def test_tensor_scatter_update_4d():
     call = ir.op.tensor.scatter_update(input_var, -2, index_var, src_var)
 
     assert isinstance(call, ir.Call)
-    assert call.op.name == "tensor.scatter_update"
+    assert call.op.name == _OP_TENSOR_SCATTER_UPDATE
     result_type = call.type
     assert isinstance(result_type, ir.TensorType)
     assert result_type.dtype == DataType.BF16
@@ -3944,7 +3963,7 @@ def test_tensor_sort32():
 
     call = ir.op.tensor.sort32(src, idx)
     assert isinstance(call, ir.Call)
-    assert call.op.name == "tensor.sort32"
+    assert call.op.name == ir.get_op("tensor.sort32").name
 
     result_type = call.type
     assert isinstance(result_type, ir.TensorType)
@@ -3975,7 +3994,7 @@ def test_tensor_mrgsort_format1():
 
     call = ir.op.tensor.mrgsort(src, block_len=64)
     assert isinstance(call, ir.Call)
-    assert call.op.name == "tensor.mrgsort_format1"
+    assert call.op.name == ir.get_op("tensor.mrgsort_format1").name
 
     result_type = call.type
     assert isinstance(result_type, ir.TensorType)
@@ -4006,7 +4025,7 @@ def test_tensor_mrgsort_format2():
 
     call = ir.op.tensor.mrgsort(*srcs)
     assert isinstance(call, ir.Call)
-    assert call.op.name == "tensor.mrgsort_format2"
+    assert call.op.name == ir.get_op("tensor.mrgsort_format2").name
 
     result_type = call.type
     assert isinstance(result_type, ir.TensorType)
@@ -4063,7 +4082,7 @@ def test_tensor_gather_basic():
     inp, idx = _make_gather_inputs()
     call = ir.op.tensor.gather(inp, dim=-1, index=idx)
     assert isinstance(call, ir.Call)
-    assert call.op.name == "tensor.gather"
+    assert call.op.name == _OP_TENSOR_GATHER
     result_type = call.type
     assert isinstance(result_type, ir.TensorType)
     assert result_type.dtype == DataType.FP32
@@ -4076,7 +4095,7 @@ def test_tensor_gather_dim_last_axis_positive():
     """dim=rank-1 is accepted as an alias for dim=-1."""
     inp, idx = _make_gather_inputs()
     call = ir.op.tensor.gather(inp, dim=1, index=idx)
-    assert call.op.name == "tensor.gather"
+    assert call.op.name == _OP_TENSOR_GATHER
 
 
 def test_tensor_gather_rejects_bad_dim():
@@ -4090,7 +4109,7 @@ def test_tensor_gather_accepts_int16_index_with_16bit_input():
     """INT16 index is accepted when the input is a 16-bit dtype (FP16/INT16)."""
     inp, idx = _make_gather_inputs(src_dtype=DataType.FP16, idx_dtype=DataType.INT16)
     call = ir.op.tensor.gather(inp, dim=-1, index=idx)
-    assert call.op.name == "tensor.gather"
+    assert call.op.name == _OP_TENSOR_GATHER
     assert isinstance(call.type, ir.TensorType)
     assert call.type.dtype == DataType.FP16
 
@@ -4153,7 +4172,7 @@ def test_tensor_gather_mask_p0101_halves_last_dim():
     inp = _make_gather_mask_input(rows=8, cols=64)
     call = ir.op.tensor.gather(inp, mask_pattern=1)
     assert isinstance(call, ir.Call)
-    assert call.op.name == "tensor.gather_mask"
+    assert call.op.name == _OP_TENSOR_GATHER_MASK
     rt = call.type
     assert isinstance(rt, ir.TensorType)
     assert rt.dtype == DataType.FP32
@@ -4184,7 +4203,7 @@ def test_tensor_gather_mask_output_dtype_reinterpret():
     """output_dtype reinterprets bits to a same-bit-width dtype."""
     inp = _make_gather_mask_input(rows=2, cols=32, dtype=DataType.FP32)
     call = ir.op.tensor.gather(inp, mask_pattern=2, output_dtype=DataType.UINT32)
-    assert call.op.name == "tensor.gather_mask"
+    assert call.op.name == _OP_TENSOR_GATHER_MASK
     rt = call.type
     assert isinstance(rt, ir.TensorType)
     assert rt.dtype == DataType.UINT32
@@ -4242,7 +4261,7 @@ def test_tensor_scatter_basic():
     inp, idx, src = _make_scatter_inputs()
     call = ir.op.tensor.scatter(inp, dim=-1, index=idx, src=src)
     assert isinstance(call, ir.Call)
-    assert call.op.name == "tensor.scatter"
+    assert call.op.name == _OP_TENSOR_SCATTER
     result_type = call.type
     assert isinstance(result_type, ir.TensorType)
     assert result_type.dtype == DataType.FP32
@@ -4264,7 +4283,7 @@ def test_tensor_scatter_positive_dim():
     """dim=1 is accepted as an alias for dim=-1 (rank-2 last axis)."""
     inp, idx, src = _make_scatter_inputs()
     call = ir.op.tensor.scatter(inp, dim=1, index=idx, src=src)
-    assert call.op.name == "tensor.scatter"
+    assert call.op.name == _OP_TENSOR_SCATTER
 
 
 def test_tensor_scatter_rejects_unsupported_dim():
@@ -4314,7 +4333,7 @@ def test_tensor_scatter_mask_p0101_doubles_last_dim():
     inp = ir.Var("inp", ir.TensorType([R, C], DataType.FP32), span)
     dst = ir.Var("dst", ir.TensorType([R, C2], DataType.FP32), span)
     call = ir.op.tensor.scatter(inp, mask_pattern=1, dst=dst)
-    assert call.op.name == "tensor.scatter_mask"
+    assert call.op.name == _OP_TENSOR_SCATTER_MASK
     rt = call.type
     assert isinstance(rt, ir.TensorType)
     assert rt.dtype == DataType.FP32
@@ -4328,7 +4347,7 @@ def test_tensor_scatter_mask_p1111_keeps_last_dim():
     inp = ir.Var("inp", ir.TensorType([R, C], DataType.FP32), span)
     dst = ir.Var("dst", ir.TensorType([R, C], DataType.FP32), span)
     call = ir.op.tensor.scatter(inp, mask_pattern=7, dst=dst)
-    assert call.op.name == "tensor.scatter_mask"
+    assert call.op.name == _OP_TENSOR_SCATTER_MASK
 
 
 def test_tensor_scatter_mask_rejects_bad_pattern():
@@ -4758,7 +4777,7 @@ def test_tensor_not():
     call = ir.op.tensor.not_(_bitwise_tensor_var([64, 128], dtype=DataType.INT16))
 
     assert isinstance(call, ir.Call)
-    assert call.op.name == "tensor.not"
+    assert call.op.name == ir.get_op("tensor.not").name
     result_type = call.type
     assert isinstance(result_type, ir.TensorType)
     assert result_type.dtype == DataType.INT16

--- a/tests/ut/ir/operators/test_tile_ops.py
+++ b/tests/ut/ir/operators/test_tile_ops.py
@@ -19,6 +19,14 @@ from pypto import DataType, ir
 from pypto.ir.op import tile
 from pypto.language.parser.diagnostics import InvalidOperationError
 
+_OP_TILE_EXTRACT = ir.get_op("tile.extract").name
+_OP_TILE_FILLPAD_EXPAND = ir.get_op("tile.fillpad_expand").name
+_OP_TILE_MSCATTER = ir.get_op("tile.mscatter").name
+_OP_TILE_ROW_EXPAND_ADD = ir.get_op("tile.row_expand_add").name
+_OP_TILE_SET_VALIDSHAPE = ir.get_op("tile.set_validshape").name
+_OP_TILE_SLICE = ir.get_op("tile.slice").name
+_OP_TILE_TRANSPOSE = ir.get_op("tile.transpose").name
+
 
 def _operand_dtype(expr: ir.Expr) -> DataType:
     """Return a constant operand's dtype, narrowing ``Expr`` for the type checker."""
@@ -153,7 +161,7 @@ class TestTileElementwiseOps:
 
         assert dict(default_call.kwargs) == {}
         assert dict(high_precision_call.kwargs) == {"high_precision": True}
-        assert scalar_call.op.name == "tile.divs"
+        assert scalar_call.op.name == ir.get_op("tile.divs").name
         assert dict(scalar_call.kwargs) == {}
         with pytest.raises(ValueError, match=r"requires a Tile rhs"):
             tile.div(lhs, 2.0, high_precision=True)
@@ -524,7 +532,7 @@ class TestTileUnaryOps:
         call = tile.sin(tile_var)
 
         assert isinstance(call, ir.Call)
-        assert call.op.name == "tile.sin"
+        assert call.op.name == ir.get_op("tile.sin").name
 
         result_type = call.type
         assert isinstance(result_type, ir.TileType)
@@ -540,7 +548,7 @@ class TestTileUnaryOps:
         call = tile.cos(tile_var)
 
         assert isinstance(call, ir.Call)
-        assert call.op.name == "tile.cos"
+        assert call.op.name == ir.get_op("tile.cos").name
 
         result_type = call.type
         assert isinstance(result_type, ir.TileType)
@@ -1441,7 +1449,7 @@ class TestTileBroadcastOps:
         )
 
         call = tile.row_expand_add(main, packed_row)
-        assert call.op.name == "tile.row_expand_add"
+        assert call.op.name == _OP_TILE_ROW_EXPAND_ADD
         assert len(call.args) == 2
 
     def test_tile_row_expand_add_rejects_invalid_packed_valid_width_and_tmp_type(self):
@@ -1526,7 +1534,7 @@ class TestTileBroadcastOps:
             ir.TileType([8, 1], DataType.FP32, tile_view=matching_row_view),
             span,
         )
-        assert tile.row_expand_add(main, matching_row).op.name == "tile.row_expand_add"
+        assert tile.row_expand_add(main, matching_row).op.name == _OP_TILE_ROW_EXPAND_ADD
 
         unrelated_row_view = ir.TileView(
             valid_shape=[other_rows, 1],
@@ -2443,7 +2451,7 @@ class TestTileSliceReshapeOps:
         call = tile.slice(tile_var, [8, 16], [0, 0])
 
         assert isinstance(call, ir.Call)
-        assert call.op.name == "tile.slice"
+        assert call.op.name == _OP_TILE_SLICE
         result_type = call.type
         assert isinstance(result_type, ir.TileType)
         assert result_type.dtype == DataType.FP16
@@ -2462,7 +2470,7 @@ class TestTileSliceReshapeOps:
         call = tile.slice(tile_var, [8, 16], [0, 0], valid_shape=[8, valid_n])
 
         assert isinstance(call, ir.Call)
-        assert call.op.name == "tile.slice"
+        assert call.op.name == _OP_TILE_SLICE
         result_type = call.type
         assert isinstance(result_type, ir.TileType)
         assert result_type.tile_view is not None
@@ -2555,7 +2563,7 @@ class TestTileSliceReshapeOps:
         call = tile.slice(tile_var, [8, 16], [0, 0], valid_shape=[8, 4], pad_value=ir.PadValue.zero)
 
         assert isinstance(call, ir.Call)
-        assert call.op.name == "tile.slice"
+        assert call.op.name == _OP_TILE_SLICE
         result_type = call.type
         assert isinstance(result_type, ir.TileType)
         assert result_type.tile_view is not None
@@ -2662,7 +2670,7 @@ class TestTileSliceReshapeOps:
         call = tile.reshape(tile_var, [8, 4])
 
         assert isinstance(call, ir.Call)
-        assert call.op.name == "tile.reshape"
+        assert call.op.name == ir.get_op("tile.reshape").name
         result_type = call.type
         assert isinstance(result_type, ir.TileType)
         assert result_type.dtype == DataType.FP32
@@ -2804,7 +2812,7 @@ class TestTileSliceReshapeOps:
         call = tile.fillpad_expand(src, [64, 128], pad_value=ir.PadValue.zero)
 
         assert isinstance(call, ir.Call)
-        assert call.op.name == "tile.fillpad_expand"
+        assert call.op.name == _OP_TILE_FILLPAD_EXPAND
         result_type = call.type
         assert isinstance(result_type, ir.TileType)
         assert result_type.dtype == DataType.FP32
@@ -2837,7 +2845,7 @@ class TestTileSliceReshapeOps:
         src = ir.Var("src", src_type, span)
 
         call = tile.fillpad_expand(src, [32, 32], pad_value=ir.PadValue.zero)
-        assert call.op.name == "tile.fillpad_expand"
+        assert call.op.name == _OP_TILE_FILLPAD_EXPAND
         result_type = call.type
         assert isinstance(result_type, ir.TileType)
         dim0 = result_type.shape[0]
@@ -2889,7 +2897,7 @@ class TestTileSliceReshapeOps:
         call = tile.transpose(tile_var, 0, 1)
 
         assert isinstance(call, ir.Call)
-        assert call.op.name == "tile.transpose"
+        assert call.op.name == _OP_TILE_TRANSPOSE
         result_type = call.type
         assert isinstance(result_type, ir.TileType)
         assert result_type.dtype == DataType.FP16
@@ -2910,7 +2918,7 @@ class TestTileSliceReshapeOps:
         call = tile.transpose(tile_var, -2, -1)
 
         assert isinstance(call, ir.Call)
-        assert call.op.name == "tile.transpose"
+        assert call.op.name == _OP_TILE_TRANSPOSE
         result_type = call.type
         assert isinstance(result_type, ir.TileType)
 
@@ -2948,7 +2956,7 @@ class TestTileSliceReshapeOps:
         call = tile.set_validshape(tile_var, 16, 24)
 
         assert isinstance(call, ir.Call)
-        assert call.op.name == "tile.set_validshape"
+        assert call.op.name == _OP_TILE_SET_VALIDSHAPE
         result_type = call.type
         assert isinstance(result_type, ir.TileType)
         assert result_type.dtype == DataType.FP32
@@ -2969,7 +2977,7 @@ class TestTileSliceReshapeOps:
         call = tile.set_validshape(tile_var, valid_rows, valid_cols)
 
         assert isinstance(call, ir.Call)
-        assert call.op.name == "tile.set_validshape"
+        assert call.op.name == _OP_TILE_SET_VALIDSHAPE
         result_type = call.type
         assert isinstance(result_type, ir.TileType)
         assert result_type.tile_view is not None
@@ -3249,7 +3257,7 @@ class TestTileBatchMatMulOps:
         call = tile.batch_matmul(lhs, rhs, span)
 
         assert isinstance(call, ir.Call)
-        assert call.op.name == "tile.batch_matmul"
+        assert call.op.name == ir.get_op("tile.batch_matmul").name
         result_type = call.type
         assert isinstance(result_type, ir.TileType)
         const_dims = [dim for dim in result_type.shape if isinstance(dim, ir.ConstInt)]
@@ -3347,7 +3355,7 @@ class TestTileBatchMatMulOps:
         call = tile.batch_matmul_acc(acc, lhs, rhs, span)
 
         assert isinstance(call, ir.Call)
-        assert call.op.name == "tile.batch_matmul_acc"
+        assert call.op.name == ir.get_op("tile.batch_matmul_acc").name
         result_type = call.type
         assert isinstance(result_type, ir.TileType)
         const_dims = [dim for dim in result_type.shape if isinstance(dim, ir.ConstInt)]
@@ -3412,7 +3420,7 @@ class TestTileBatchMatMulOps:
         call = tile.transpose(tile_var, 0, 2)
 
         assert isinstance(call, ir.Call)
-        assert call.op.name == "tile.transpose"
+        assert call.op.name == _OP_TILE_TRANSPOSE
         result_type = call.type
         assert isinstance(result_type, ir.TileType)
         assert len(result_type.shape) == 3
@@ -3433,7 +3441,7 @@ class TestTileBatchMatMulOps:
         call = tile.row_max(tile_var, tmp_tile)
 
         assert isinstance(call, ir.Call)
-        assert call.op.name == "tile.row_max"
+        assert call.op.name == ir.get_op("tile.row_max").name
         result_type = call.type
         assert isinstance(result_type, ir.TileType)
         assert len(result_type.shape) == 3
@@ -3455,7 +3463,7 @@ class TestTileBatchMatMulOps:
         call = tile.slice(tile_var, new_shape, offset)
 
         assert isinstance(call, ir.Call)
-        assert call.op.name == "tile.slice"
+        assert call.op.name == _OP_TILE_SLICE
         result_type = call.type
         assert isinstance(result_type, ir.TileType)
         assert len(result_type.shape) == 3
@@ -4795,7 +4803,7 @@ class TestTileAssembleOp:
         call = tile.assemble(target_var, source_var, [0, 0])
 
         assert isinstance(call, ir.Call)
-        assert call.op.name == "tile.assemble"
+        assert call.op.name == ir.get_op("tile.assemble").name
         result_type = call.type
         assert isinstance(result_type, ir.TileType)
         assert result_type.dtype == DataType.FP32
@@ -4839,7 +4847,7 @@ class TestTileExtractOp:
         call = tile.extract(src_var, 0, 0, shape=[64, 64], target_memory=ir.MemorySpace.Left)
 
         assert isinstance(call, ir.Call)
-        assert call.op.name == "tile.extract"
+        assert call.op.name == _OP_TILE_EXTRACT
         result_type = call.type
         assert isinstance(result_type, ir.TileType)
         assert result_type.dtype == DataType.FP16
@@ -4907,7 +4915,7 @@ class TestTileExtractOp:
 
         call = tile.extract(src_var, 0, 0, shape=[32, 32], target_memory=ir.MemorySpace.Mat)
 
-        assert call.op.name == "tile.extract"
+        assert call.op.name == _OP_TILE_EXTRACT
         result_type = call.type
         assert isinstance(result_type, ir.TileType)
         assert result_type.dtype == DataType.FP32
@@ -4924,7 +4932,7 @@ class TestTileExtractOp:
 
         call = tile.extract(src_var, row, col, shape=[16, 16], target_memory=ir.MemorySpace.Left)
 
-        assert call.op.name == "tile.extract"
+        assert call.op.name == _OP_TILE_EXTRACT
         result_type = call.type
         assert isinstance(result_type, ir.TileType)
         rows, cols = result_type.shape
@@ -5007,7 +5015,7 @@ class TestTileScatterUpdateOps:
         )
 
         assert isinstance(call, ir.Call)
-        assert call.op.name == "tile.scatter_update"
+        assert call.op.name == ir.get_op("tile.scatter_update").name
         result_type = call.type
         assert isinstance(result_type, ir.TileType)
         assert result_type.dtype == dtype
@@ -5078,7 +5086,7 @@ class TestTileMscatterOps:
         call = tile.mscatter(src_var, idx_var, out_var)
 
         assert isinstance(call, ir.Call)
-        assert call.op.name == "tile.mscatter"
+        assert call.op.name == _OP_TILE_MSCATTER
         result_type = call.type
         assert isinstance(result_type, ir.TensorType)
         assert result_type.dtype == DataType.FP32
@@ -5099,7 +5107,7 @@ class TestTileMscatterOps:
         out_var = ir.Var("out", tensor_type, span)
 
         call = tile.mscatter(src_var, idx_var, out_var)
-        assert call.op.name == "tile.mscatter"
+        assert call.op.name == _OP_TILE_MSCATTER
         result_type = call.type
         assert isinstance(result_type, ir.TensorType)
         assert result_type.dtype == DataType.FP16
@@ -5260,7 +5268,7 @@ class TestTileScatterOps:
         )
 
         assert isinstance(call, ir.Call)
-        assert call.op.name == "tile.scatter"
+        assert call.op.name == ir.get_op("tile.scatter").name
         result_type = call.type
         assert isinstance(result_type, ir.TileType)
         assert result_type.dtype == dtype
@@ -5416,7 +5424,7 @@ class TestTileScatterMaskOps:
         )
 
         assert isinstance(call, ir.Call)
-        assert call.op.name == "tile.scatter_mask"
+        assert call.op.name == ir.get_op("tile.scatter_mask").name
         result_type = call.type
         assert isinstance(result_type, ir.TileType)
         const_dims = [dim.value for dim in result_type.shape if isinstance(dim, ir.ConstInt)]
@@ -5505,7 +5513,7 @@ class TestTileConcatOps:
         call = tile.concat(t0_var, t1_var)
 
         assert isinstance(call, ir.Call)
-        assert call.op.name == "tile.concat"
+        assert call.op.name == ir.get_op("tile.concat").name
         result_type = call.type
         assert isinstance(result_type, ir.TileType)
         assert result_type.dtype == DataType.FP32

--- a/tests/ut/ir/parser/test_alloc_window_buffer.py
+++ b/tests/ut/ir/parser/test_alloc_window_buffer.py
@@ -35,6 +35,8 @@ from pypto import DataType
 from pypto.language.parser.diagnostics import ParserSyntaxError
 from pypto.pypto_core import ir
 
+_OP_PLD_TENSOR_ALLOC_WINDOW_BUFFER = ir.get_op("pld.tensor.alloc_window_buffer").name
+
 
 def _get_host_orch(program: ir.Program, name: str = "host_orch") -> ir.Function:
     gvar = program.get_global_var(name)
@@ -47,7 +49,7 @@ def _find_alloc_assignment(func: ir.Function) -> ir.AssignStmt:
 
     def walk(stmt: ir.Stmt) -> ir.AssignStmt | None:
         if isinstance(stmt, ir.AssignStmt):
-            if isinstance(stmt.value, ir.Call) and stmt.value.op.name == "pld.tensor.alloc_window_buffer":
+            if isinstance(stmt.value, ir.Call) and stmt.value.op.name == _OP_PLD_TENSOR_ALLOC_WINDOW_BUFFER:
                 return stmt
         if isinstance(stmt, ir.SeqStmts):
             for s in stmt.stmts:
@@ -150,7 +152,7 @@ def test_alloc_window_buffer_returns_singleton_ptr_type():
 
     def walk(stmt: ir.Stmt) -> None:
         if isinstance(stmt, ir.AssignStmt) and isinstance(stmt.value, ir.Call):
-            if stmt.value.op.name == "pld.tensor.alloc_window_buffer":
+            if stmt.value.op.name == _OP_PLD_TENSOR_ALLOC_WINDOW_BUFFER:
                 allocs.append(stmt)
         if isinstance(stmt, ir.SeqStmts):
             for s in stmt.stmts:
@@ -179,7 +181,7 @@ def test_alloc_window_buffer_long_form():
     func = _get_host_orch(P)
     stmt = _find_alloc_assignment(func)
     assert isinstance(stmt.value, ir.Call)
-    assert stmt.value.op.name == "pld.tensor.alloc_window_buffer"
+    assert stmt.value.op.name == _OP_PLD_TENSOR_ALLOC_WINDOW_BUFFER
     assert stmt.value.kwargs["name"] == "buf"
 
 
@@ -270,7 +272,7 @@ def test_alloc_window_buffer_shaped_static():
     stmt = _find_alloc_assignment(func)
     assert isinstance(stmt.value, ir.Call)
     call = stmt.value
-    assert call.op.name == "pld.tensor.alloc_window_buffer"
+    assert call.op.name == _OP_PLD_TENSOR_ALLOC_WINDOW_BUFFER
     assert call.kwargs["name"] == "buf"
     assert "dtype" not in call.kwargs
     assert len(call.args) == 1
@@ -295,7 +297,7 @@ def test_alloc_window_buffer_shaped_long_form():
     stmt = _find_alloc_assignment(func)
     assert isinstance(stmt.value, ir.Call)
     call = stmt.value
-    assert call.op.name == "pld.tensor.alloc_window_buffer"
+    assert call.op.name == _OP_PLD_TENSOR_ALLOC_WINDOW_BUFFER
     assert call.kwargs["name"] == "buf"
     assert len(call.args) == 1
     # Static shape must fold to a single ConstInt byte-size arg.
@@ -352,7 +354,7 @@ def test_alloc_window_buffer_shaped_dynamic():
     stmt = _find_alloc_assignment(func)
     assert isinstance(stmt.value, ir.Call)
     call = stmt.value
-    assert call.op.name == "pld.tensor.alloc_window_buffer"
+    assert call.op.name == _OP_PLD_TENSOR_ALLOC_WINDOW_BUFFER
     assert call.kwargs["name"] == "buf"
     assert "dtype" not in call.kwargs
     assert len(call.args) == 1

--- a/tests/ut/ir/parser/test_get_op.py
+++ b/tests/ut/ir/parser/test_get_op.py
@@ -24,6 +24,8 @@ import pypto.language.distributed as pld
 import pytest
 from pypto.pypto_core import ir
 
+_OP_PLD_TENSOR_GET = ir.get_op("pld.tensor.get").name
+
 
 def _get_func(program: ir.Program, name: str) -> ir.Function:
     gvar = program.get_global_var(name)
@@ -60,7 +62,7 @@ def test_get_parses_to_side_effect_op():
         for stmt in _iter_stmts(func.body)
         if isinstance(stmt, ir.EvalStmt)
         and isinstance(stmt.expr, ir.Call)
-        and stmt.expr.op.name == "pld.tensor.get"
+        and stmt.expr.op.name == _OP_PLD_TENSOR_GET
     ]
 
     assert len(get_calls) == 1
@@ -100,7 +102,7 @@ def test_get_subregion_parses_to_six_arg_op():
         for stmt in _iter_stmts(func.body)
         if isinstance(stmt, ir.EvalStmt)
         and isinstance(stmt.expr, ir.Call)
-        and stmt.expr.op.name == "pld.tensor.get"
+        and stmt.expr.op.name == _OP_PLD_TENSOR_GET
     ]
 
     assert len(get_calls) == 1

--- a/tests/ut/ir/parser/test_put_op.py
+++ b/tests/ut/ir/parser/test_put_op.py
@@ -62,7 +62,7 @@ def test_put_parses_to_op_with_atomic_attr():
         for stmt in _iter_stmts(func.body)
         if isinstance(stmt, ir.EvalStmt)
         and isinstance(stmt.expr, ir.Call)
-        and stmt.expr.op.name == "pld.tensor.put"
+        and stmt.expr.op.name == ir.get_op("pld.tensor.put").name
     ]
     assert len(put_calls) == 1
     call = put_calls[0]

--- a/tests/ut/ir/parser/test_remote_load.py
+++ b/tests/ut/ir/parser/test_remote_load.py
@@ -360,7 +360,7 @@ def test_remote_load_short_form():
 
     func = _get_func(P, "kernel")
     call = _find_call(func, "pld.tile.remote_load")
-    assert call.op.name == "pld.tile.remote_load"
+    assert call.op.name == ir.get_op("pld.tile.remote_load").name
     assert isinstance(call.type, ir.TileType)
 
 

--- a/tests/ut/ir/parser/test_remote_store.py
+++ b/tests/ut/ir/parser/test_remote_store.py
@@ -138,7 +138,7 @@ def test_remote_store_round_trips_through_printer():
     # The call still lifts to the same op name post-parse.
     after_func = _get_func(After, "kernel")
     after_call = _find_call(after_func, "pld.tile.remote_store")
-    assert after_call.op.name == "pld.tile.remote_store"
+    assert after_call.op.name == ir.get_op("pld.tile.remote_store").name
 
 
 # ---------------------------------------------------------------------------

--- a/tests/ut/ir/parser/test_window_op.py
+++ b/tests/ut/ir/parser/test_window_op.py
@@ -60,7 +60,7 @@ def _find_alloc_var(func: ir.Function) -> ir.Var:
         if (
             isinstance(stmt, ir.AssignStmt)
             and isinstance(stmt.value, ir.Call)
-            and stmt.value.op.name == "pld.tensor.alloc_window_buffer"
+            and stmt.value.op.name == ir.get_op("pld.tensor.alloc_window_buffer").name
         ):
             return stmt.var
         if isinstance(stmt, ir.SeqStmts):
@@ -219,7 +219,7 @@ def test_window_long_form():
 
     func = _get_host_orch(P)
     call = _find_call(func, "pld.tensor.window")
-    assert call.op.name == "pld.tensor.window"
+    assert call.op.name == ir.get_op("pld.tensor.window").name
     assert isinstance(call.type, ir.DistributedTensorType)
 
 

--- a/tests/ut/ir/parser/test_world_size.py
+++ b/tests/ut/ir/parser/test_world_size.py
@@ -25,6 +25,8 @@ from pypto import DataType
 from pypto.language.parser.diagnostics import InvalidOperationError, ParserSyntaxError
 from pypto.pypto_core import ir
 
+_OP_PLD_SYSTEM_WORLD_SIZE = ir.get_op("pld.system.world_size").name
+
 
 def _get_func(program: ir.Program, name: str) -> ir.Function:
     gvar = program.get_global_var(name)
@@ -44,7 +46,7 @@ def _find_world_size_calls(func: ir.Function) -> list[ir.Call]:
     def visit_expr(expr: ir.Expr | None) -> None:
         if expr is None or not isinstance(expr, ir.Call):
             return
-        if expr.op.name == "pld.system.world_size":
+        if expr.op.name == _OP_PLD_SYSTEM_WORLD_SIZE:
             found.append(expr)
         for sub in expr.args:
             visit_expr(sub)
@@ -193,7 +195,7 @@ def test_world_size_call_used_as_size_in_alloc():
         for stmt in body.stmts
         if isinstance(stmt, ir.AssignStmt)
         and isinstance(stmt.value, ir.Call)
-        and stmt.value.op.name == "pld.tensor.alloc_window_buffer"
+        and stmt.value.op.name == ir.get_op("pld.tensor.alloc_window_buffer").name
         for c in [stmt.value]
     )
     assert alloc_call.args[0] is calls[0]
@@ -213,7 +215,7 @@ def test_long_form_world_size_call():
     func = _get_func(P, "host_orch")
     calls = _find_world_size_calls(func)
     assert len(calls) == 1
-    assert calls[0].op.name == "pld.system.world_size"
+    assert calls[0].op.name == _OP_PLD_SYSTEM_WORLD_SIZE
 
 
 if __name__ == "__main__":

--- a/tests/ut/ir/printing/test_split_aiv_roundtrip.py
+++ b/tests/ut/ir/printing/test_split_aiv_roundtrip.py
@@ -302,7 +302,7 @@ class _DropAivIdBinding(ir.IRMutator):
                 isinstance(first, ir.AssignStmt)
                 and isinstance(first.value, ir.Call)
                 and isinstance(first.value.op, ir.Op)
-                and first.value.op.name == "tile.get_subblock_idx"
+                and first.value.op.name == ir.get_op("tile.get_subblock_idx").name
             ):
                 new_body = ir.SeqStmts(list(body.stmts[1:]), body.span)
                 return ir.SplitAivScopeStmt(op.split, op.count, op.name_hint, body=new_body, span=op.span)

--- a/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
+++ b/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
@@ -212,7 +212,7 @@ class _StampExpectedMatBridgeLoads(ir.IRMutator):
         expr = super().visit_call(op)
         call = expr if isinstance(expr, ir.Call) else op
         if (
-            call.op.name == "tile.load"
+            call.op.name == ir.get_op("tile.load").name
             and isinstance(call.type, ir.TileType)
             and call.type.memory_space == MemorySpace.Mat
         ):

--- a/tests/ut/ir/transforms/test_convert_to_ssa_pass.py
+++ b/tests/ut/ir/transforms/test_convert_to_ssa_pass.py
@@ -958,7 +958,7 @@ class TestEdgeCases:
 
         def walk(stmt: ir.Stmt) -> None:
             if isinstance(stmt, ir.AssignStmt) and isinstance(stmt.value, ir.Call):
-                if stmt.value.op.name == "tensor.slice":
+                if stmt.value.op.name == ir.get_op("tensor.slice").name:
                     slice_calls.append(stmt.value)
             if isinstance(stmt, ir.SeqStmts):
                 for s in stmt.stmts:

--- a/tests/ut/ir/transforms/test_expand_mixed_kernel_a5.py
+++ b/tests/ut/ir/transforms/test_expand_mixed_kernel_a5.py
@@ -31,15 +31,15 @@ from pypto import ir, passes
 
 
 _AUTO_PIPE_SETUP_OPS = {
-    "system.reserve_buffer",
-    "system.import_peer_buffer",
-    "system.aic_initialize_pipe",
-    "system.aiv_initialize_pipe",
+    ir.get_op("system.reserve_buffer").name,
+    ir.get_op("system.import_peer_buffer").name,
+    ir.get_op("system.aic_initialize_pipe").name,
+    ir.get_op("system.aiv_initialize_pipe").name,
 }
 
 _AUTO_TFREE_OPS = {
-    "system.tfree_to_aic",
-    "system.tfree_to_aiv",
+    ir.get_op("system.tfree_to_aic").name,
+    ir.get_op("system.tfree_to_aiv").name,
 }
 
 
@@ -2434,10 +2434,10 @@ class TestAutoPipeSetup:
                 call = None
             if not isinstance(call, ir.Call):
                 continue
-            if call.op.name == "tile.tpop_from_aiv":
+            if call.op.name == ir.get_op("tile.tpop_from_aiv").name:
                 assert isinstance(stmt, ir.AssignStmt)
                 tpop_var = stmt.var
-            elif call.op.name == "system.tfree_to_aiv":
+            elif call.op.name == ir.get_op("system.tfree_to_aiv").name:
                 tfree_call = call
 
         assert tpop_var is not None

--- a/tests/ut/ir/transforms/test_flatten_tile_nd_to_2d.py
+++ b/tests/ut/ir/transforms/test_flatten_tile_nd_to_2d.py
@@ -20,6 +20,20 @@ from pypto.ir import IRBuilder
 from pypto.ir.op import tensor as tensor_ops
 from pypto.ir.op import tile as tile_ops
 
+_OP_TENSOR_VIEW = ir.get_op("tensor.view").name
+_OP_TILE_CREATE = ir.get_op("tile.create").name
+_OP_TILE_LOAD = ir.get_op("tile.load").name
+_OP_TILE_MOVE = ir.get_op("tile.move").name
+_OP_TILE_SLICE = ir.get_op("tile.slice").name
+_OP_TILE_TRANSPOSE = ir.get_op("tile.transpose").name
+_OP_TILE_ASSEMBLE = ir.get_op("tile.assemble").name
+_OP_TILE_BATCH_MATMUL = ir.get_op("tile.batch_matmul").name
+_OP_TILE_BATCH_MATMUL_ACC = ir.get_op("tile.batch_matmul_acc").name
+_OP_TILE_MATMUL = ir.get_op("tile.matmul").name
+_OP_TILE_MATMUL_ACC = ir.get_op("tile.matmul_acc").name
+_OP_TILE_RESHAPE = ir.get_op("tile.reshape").name
+_OP_TILE_STORE = ir.get_op("tile.store").name
+
 # ----------------------------------------------------------------------------
 # Helpers
 # ----------------------------------------------------------------------------
@@ -548,7 +562,7 @@ class TestFlattenTileNdTo2DDynamicValid:
         tile_calls = _tile_calls(after_func.body)
         assert tile_calls, "expected flattened tile ops in the rewritten body"
         assert all(len(cast(ir.TileType, call.type).shape) == 2 for call in tile_calls)
-        loads = [c for c in tile_calls if c.op.name == "tile.load"]
+        loads = [c for c in tile_calls if c.op.name == _OP_TILE_LOAD]
         assert loads, "expected a tile.load in the flattened body"
         load_type = cast(ir.TileType, loads[0].type)
         # Physical shape flattened to 2D and is fully static.
@@ -1400,12 +1414,12 @@ class TestFlattenTileNdTo2DBatchMatmul:
         func = self._flattened_incore(Before)
         calls = self._top_level_calls(func)
         assert [call.op.name for call in calls[:4]] == [
-            "tile.load",
-            "tile.load",
-            "tile.slice",
-            "tile.slice",
+            _OP_TILE_LOAD,
+            _OP_TILE_LOAD,
+            _OP_TILE_SLICE,
+            _OP_TILE_SLICE,
         ]
-        load_calls = [call for call in calls if call.op.name == "tile.load"]
+        load_calls = [call for call in calls if call.op.name == _OP_TILE_LOAD]
         assert len(load_calls) == 2
         assert [cast(ir.TileType, call.type).memory_space for call in load_calls] == [
             ir.MemorySpace.Vec,
@@ -1417,7 +1431,7 @@ class TestFlattenTileNdTo2DBatchMatmul:
             [2, 16, 128],
             [2, 128, 64],
         ]
-        slice_calls = [call for call in calls if call.op.name == "tile.slice"]
+        slice_calls = [call for call in calls if call.op.name == _OP_TILE_SLICE]
         assert [cast(ir.TileType, call.type).shape for call in slice_calls[:2]] == [[16, 128], [128, 64]]
 
     def test_batch_matmul_broadcasts_and_unrolls(self):
@@ -1783,8 +1797,8 @@ class TestFlattenTileNdTo2DBatchMatmul:
                 "out_shape": [2, 16, 64],
                 "lhs_transpose": False,
                 "rhs_transpose": False,
-                "expected_op_seq": ["tensor.view", "tile.load", "tensor.view", "tile.load"]
-                + ["tile.slice", "tile.slice", "tile.matmul", "tile.store"] * 2,
+                "expected_op_seq": [_OP_TENSOR_VIEW, _OP_TILE_LOAD, _OP_TENSOR_VIEW, _OP_TILE_LOAD]
+                + [_OP_TILE_SLICE, _OP_TILE_SLICE, _OP_TILE_MATMUL, _OP_TILE_STORE] * 2,
                 "expected_lhs_load_offsets": [[0, 0]],
                 "expected_rhs_load_offsets": [[0, 0]],
                 "expected_lhs_load_shapes": [[32, 128]],
@@ -1807,14 +1821,14 @@ class TestFlattenTileNdTo2DBatchMatmul:
                 "lhs_transpose": False,
                 "rhs_transpose": False,
                 "expected_op_seq": [
-                    "tensor.view",
-                    "tile.load",
-                    "tensor.view",
-                    "tile.load",
-                    "tile.slice",
-                    "tile.slice",
-                    "tile.matmul",
-                    "tile.store",
+                    _OP_TENSOR_VIEW,
+                    _OP_TILE_LOAD,
+                    _OP_TENSOR_VIEW,
+                    _OP_TILE_LOAD,
+                    _OP_TILE_SLICE,
+                    _OP_TILE_SLICE,
+                    _OP_TILE_MATMUL,
+                    _OP_TILE_STORE,
                 ],
                 "expected_lhs_load_offsets": [[0, 0]],
                 "expected_rhs_load_offsets": [[0, 0]],
@@ -1925,8 +1939,8 @@ class TestFlattenTileNdTo2DBatchMatmul:
         # recovered by row slices of those whole loads. The two whole loads
         # appear first (lhs then rhs), then the per-batch slices alternate
         # lhs, rhs, lhs, rhs, ...
-        load_calls = [call for call in calls if call.op.name == "tile.load"]
-        slice_calls = [call for call in calls if call.op.name == "tile.slice"]
+        load_calls = [call for call in calls if call.op.name == _OP_TILE_LOAD]
+        slice_calls = [call for call in calls if call.op.name == _OP_TILE_SLICE]
         lhs_load, rhs_load = load_calls[0], load_calls[1]
         actual_lhs_load_offsets = [self._tuple_const_values(lhs_load.args[1])]
         actual_rhs_load_offsets = [self._tuple_const_values(rhs_load.args[1])]
@@ -1951,7 +1965,7 @@ class TestFlattenTileNdTo2DBatchMatmul:
         assert actual_lhs_slice_shapes == case["expected_lhs_slice_shapes"]
         assert actual_rhs_slice_shapes == case["expected_rhs_slice_shapes"]
 
-        store_calls = [call for call in calls if call.op.name == "tile.store"]
+        store_calls = [call for call in calls if call.op.name == ir.get_op("tile.store").name]
         assert [self._tuple_const_values(call.args[1]) for call in store_calls] == case[
             "expected_store_offsets"
         ]
@@ -2117,16 +2131,16 @@ class TestFlattenTileNdTo2DBatchMatmul:
         # load and are sliced once at [0, 0] before the matmul + store. No
         # `tile.reshape` survives.
         assert op_names == [
-            "tensor.view",
-            "tile.load",
-            "tensor.view",
-            "tile.load",
-            "tile.slice",
-            "tile.slice",
-            "tile.matmul",
-            "tile.store",
+            _OP_TENSOR_VIEW,
+            _OP_TILE_LOAD,
+            _OP_TENSOR_VIEW,
+            _OP_TILE_LOAD,
+            _OP_TILE_SLICE,
+            _OP_TILE_SLICE,
+            _OP_TILE_MATMUL,
+            _OP_TILE_STORE,
         ]
-        assert "tile.reshape" not in op_names
+        assert _OP_TILE_RESHAPE not in op_names
 
     def test_rank3_mat_load_under_if_preserves_explicit_tile_view(self):
         """Regression for #1540: a rank>2 ``tile.load`` whose downstream
@@ -2201,7 +2215,7 @@ class TestFlattenTileNdTo2DBatchMatmul:
             for stmt in cast(ir.SeqStmts, after_func.body).stmts
             if isinstance(stmt, ir.AssignStmt)
             and isinstance(stmt.value, ir.Call)
-            and stmt.value.op.name == "tile.load"
+            and stmt.value.op.name == _OP_TILE_LOAD
             and cast(ir.TileType, stmt.value.type).get_effective_tile_view().slayout
             == ir.TileLayout.col_major
         ]
@@ -2288,7 +2302,7 @@ class TestFlattenTileNdTo2DBatchMatmul:
             for stmt in body.stmts
             if isinstance(stmt, ir.AssignStmt)
             and isinstance(stmt.value, ir.Call)
-            and stmt.value.op.name == "tile.load"
+            and stmt.value.op.name == _OP_TILE_LOAD
         )
         actual_type = cast(ir.TileType, flat_load.value.type)
 
@@ -2445,22 +2459,22 @@ class TestFlattenTileNdTo2DBatchMatmulAcc:
         names = [c.op.name for c in calls]
 
         # Both batch ops are fully unrolled.
-        assert "tile.batch_matmul" not in names
-        assert "tile.batch_matmul_acc" not in names
+        assert _OP_TILE_BATCH_MATMUL not in names
+        assert _OP_TILE_BATCH_MATMUL_ACC not in names
 
         # Two batches × {matmul, matmul_acc} = 2 + 2.
-        assert names.count("tile.matmul") == 2
-        assert names.count("tile.matmul_acc") == 2
+        assert names.count(_OP_TILE_MATMUL) == 2
+        assert names.count(_OP_TILE_MATMUL_ACC) == 2
 
         # General path still uses slice/assemble around per-batch matmul_acc.
-        assert "tile.slice" in names
-        assert "tile.assemble" in names
+        assert _OP_TILE_SLICE in names
+        assert _OP_TILE_ASSEMBLE in names
 
         # Core invariant (issue #1235): LowerBatchMatmulAcc no longer emits any
         # tile.move targeting Acc. The remaining moves (target=Vec) come from
         # LowerBatchMatmul staging per-batch matmul results, not from the
         # accumulator round-trip path.
-        move_targets = [c.kwargs.get("target_memory") for c in calls if c.op.name == "tile.move"]
+        move_targets = [c.kwargs.get("target_memory") for c in calls if c.op.name == _OP_TILE_MOVE]
         assert pl.MemorySpace.Acc not in move_targets, (
             f"FlattenTileNdTo2D must not emit tile.move(target_memory=Acc) on "
             f"the batch_matmul_acc accumulator — that belongs to "
@@ -2486,14 +2500,14 @@ class TestFlattenTileNdTo2DBatchMatmulAcc:
         names = [c.op.name for c in calls]
 
         # Sanity: batch ops still gone, slice/assemble preserved.
-        assert "tile.batch_matmul" not in names
-        assert "tile.batch_matmul_acc" not in names
-        assert "tile.slice" in names
-        assert "tile.assemble" in names
+        assert _OP_TILE_BATCH_MATMUL not in names
+        assert _OP_TILE_BATCH_MATMUL_ACC not in names
+        assert _OP_TILE_SLICE in names
+        assert _OP_TILE_ASSEMBLE in names
 
         # InferTileMemorySpace must have inserted at least one tile.move to Acc
         # to satisfy tile.matmul_acc's input_constraints[0] = {Acc}.
-        move_targets = [c.kwargs.get("target_memory") for c in calls if c.op.name == "tile.move"]
+        move_targets = [c.kwargs.get("target_memory") for c in calls if c.op.name == _OP_TILE_MOVE]
         assert pl.MemorySpace.Acc in move_targets, (
             f"InferTileMemorySpace should insert a Vec→Acc move on matmul_acc's "
             f"acc input. Got move_targets={move_targets}"
@@ -2532,13 +2546,13 @@ class TestFlattenTileNdTo2DBatchMatmulAcc:
         names = [c.op.name for c in calls]
 
         # batch_matmul_acc was unrolled into a single 2D matmul_acc (batch=1 fast path).
-        assert "tile.batch_matmul_acc" not in names
-        assert names.count("tile.matmul_acc") == 1
+        assert _OP_TILE_BATCH_MATMUL_ACC not in names
+        assert names.count(_OP_TILE_MATMUL_ACC) == 1
 
         # Core invariant: no Vec/Acc round-trip emitted by FlattenTileNdTo2D.
         # This is what previously triggered "cross-core move destination must
         # be Vec, Mat, Left, or Right, got Acc" in mixed CUBE/VECTOR kernels.
-        assert "tile.move" not in names, (
+        assert _OP_TILE_MOVE not in names, (
             f"FlattenTileNdTo2D must not emit tile.move around the singleton "
             f"batch matmul_acc accumulator. Got call sequence: {names}"
         )
@@ -2584,7 +2598,7 @@ class TestFlattenTileNdTo2DBatchMatmulAcc:
             for stmt in body.stmts
             if isinstance(stmt, ir.AssignStmt) and isinstance(stmt.value, ir.Call)
         ]
-        creates = [c for c in top_level if c.op.name == "tile.create"]
+        creates = [c for c in top_level if c.op.name == _OP_TILE_CREATE]
         assert len(creates) == 1, f"expected exactly one tile.create, got {len(creates)}"
         assert creates[0].kwargs.get("target_memory") == pl.MemorySpace.Acc, (
             f"InferTileMemorySpace should back-propagate the matmul_acc Acc "
@@ -2599,7 +2613,7 @@ class TestFlattenTileNdTo2DBatchMatmulAcc:
         # lhs/rhs operands to satisfy tile.matmul_acc's input_constraints[1,2];
         # those are unrelated to issue #1235.
         all_calls = self._collect_calls_recursive(fn.body)
-        all_move_targets = [c.kwargs.get("target_memory") for c in all_calls if c.op.name == "tile.move"]
+        all_move_targets = [c.kwargs.get("target_memory") for c in all_calls if c.op.name == _OP_TILE_MOVE]
         assert pl.MemorySpace.Acc not in all_move_targets, (
             f"the dummy create accumulator chain must not require any Vec→Acc "
             f"move after flatten+infer (back-propagation should land the create "
@@ -2650,8 +2664,8 @@ class TestNdTensorMatmulConversion:
             if isinstance(stmt, ir.AssignStmt) and isinstance(stmt.value, ir.Call):
                 names.append(stmt.value.op.name)
         # ND tensor.matmul should have become tile.batch_matmul (not tile.matmul).
-        assert "tile.batch_matmul" in names
-        assert "tile.matmul" not in names
+        assert _OP_TILE_BATCH_MATMUL in names
+        assert _OP_TILE_MATMUL not in names
 
     def test_nd_tensor_matmul_acc_dispatch_and_flatten(self):
         """tensor.matmul_acc with 2D × 3D operand emits tile.batch_matmul_acc, then flattens.
@@ -2706,20 +2720,20 @@ class TestNdTensorMatmulConversion:
 
         # After conversion: ND ops dispatch to the batch variants.
         names_convert = collect_names(after_convert)
-        assert "tile.batch_matmul" in names_convert
-        assert "tile.batch_matmul_acc" in names_convert
-        assert "tile.matmul" not in names_convert
-        assert "tile.matmul_acc" not in names_convert
+        assert _OP_TILE_BATCH_MATMUL in names_convert
+        assert _OP_TILE_BATCH_MATMUL_ACC in names_convert
+        assert _OP_TILE_MATMUL not in names_convert
+        assert _OP_TILE_MATMUL_ACC not in names_convert
 
         # After flatten: batch ops disappear; one per-batch tile.matmul (from
         # batch_matmul) and one per-batch tile.matmul_acc (from batch_matmul_acc)
         # remain (batch=1 fast path).
         after_flatten = passes.flatten_tile_nd_to_2d()(after_convert)
         names_flatten = collect_names(after_flatten)
-        assert "tile.batch_matmul" not in names_flatten
-        assert "tile.batch_matmul_acc" not in names_flatten
-        assert names_flatten.count("tile.matmul") == 1
-        assert names_flatten.count("tile.matmul_acc") == 1
+        assert _OP_TILE_BATCH_MATMUL not in names_flatten
+        assert _OP_TILE_BATCH_MATMUL_ACC not in names_flatten
+        assert names_flatten.count(_OP_TILE_MATMUL) == 1
+        assert names_flatten.count(_OP_TILE_MATMUL_ACC) == 1
 
 
 # ----------------------------------------------------------------------------
@@ -2824,7 +2838,7 @@ class TestFlattenTileNdTo2DMatLoadRoundtrip:
             for stmt in body.stmts
             if isinstance(stmt, ir.AssignStmt)
             and isinstance(stmt.value, ir.Call)
-            and stmt.value.op.name == "tile.load"
+            and stmt.value.op.name == _OP_TILE_LOAD
         )
         flat_var_type = cast(ir.TileType, flat_load.var.type)
         flat_call_type = cast(ir.TileType, flat_load.value.type)
@@ -2864,7 +2878,7 @@ class TestFlattenTileNdTo2DMatLoadRoundtrip:
             for stmt in body.stmts
             if isinstance(stmt, ir.AssignStmt)
             and isinstance(stmt.value, ir.Call)
-            and stmt.value.op.name == "tensor.view"
+            and stmt.value.op.name == _OP_TENSOR_VIEW
         )
         view_type = cast(ir.TensorType, view_stmt.var.type)
         assert view_type.shape == [32, 128]
@@ -2874,7 +2888,7 @@ class TestFlattenTileNdTo2DMatLoadRoundtrip:
             for stmt in body.stmts
             if isinstance(stmt, ir.AssignStmt)
             and isinstance(stmt.value, ir.Call)
-            and stmt.value.op.name == "tile.load"
+            and stmt.value.op.name == _OP_TILE_LOAD
         )
         load_call = cast(ir.Call, flat_load.value)
         load_source = cast(ir.Var, load_call.args[0])
@@ -2941,7 +2955,7 @@ class TestFlattenTileNdTo2DMatLoadRoundtrip:
             for stmt in body.stmts
             if isinstance(stmt, ir.AssignStmt)
             and isinstance(stmt.value, ir.Call)
-            and stmt.value.op.name == "tensor.view"
+            and stmt.value.op.name == _OP_TENSOR_VIEW
         )
         view_type = cast(ir.TensorType, view_stmt.var.type)
         assert isinstance(view_stmt.value, ir.Call)
@@ -3018,7 +3032,7 @@ class TestFlattenTileNdTo2DStandaloneTranspose:
 
         # Every emitted tile.transpose must be a genuine 2D transpose: the
         # input page [A=3, B=8] -> [B=8, A=3], so input/tmp ranks agree (2 == 2).
-        transposes = [c for c in calls if c.op.name == "tile.transpose"]
+        transposes = [c for c in calls if c.op.name == _OP_TILE_TRANSPOSE]
         assert len(transposes) == 2, f"expected 2 per-batch transposes, got {len(transposes)}"
         for t in transposes:
             in_type = cast(ir.TileType, t.args[0].type)
@@ -3031,7 +3045,7 @@ class TestFlattenTileNdTo2DStandaloneTranspose:
         # Non-padded path: exactly one tile.assemble per batch (no per-batch
         # padding copy), assembling each [8, 3] page into the merged flat output
         # [batch*B, A] = [2*8, 3] = [16, 3].
-        assembles = [c for c in calls if c.op.name == "tile.assemble"]
+        assembles = [c for c in calls if c.op.name == ir.get_op("tile.assemble").name]
         assert len(assembles) == 2
         final_out_type = cast(ir.TileType, assembles[-1].type)
         assert final_out_type.shape == [16, 3]
@@ -3068,7 +3082,7 @@ class TestFlattenTileNdTo2DStandaloneTranspose:
         assert after_func is not None
         calls = self._all_calls(after_func)
 
-        transposes = [c for c in calls if c.op.name == "tile.transpose"]
+        transposes = [c for c in calls if c.op.name == _OP_TILE_TRANSPOSE]
         assert len(transposes) == 1, f"expected 1 transpose, got {len(transposes)}"
         t = transposes[0]
         # Codegen-ready 4-arg form with a materialized scratch operand.
@@ -3081,7 +3095,7 @@ class TestFlattenTileNdTo2DStandaloneTranspose:
         assert res_type.shape == [8, 3]
 
         # The scratch is a freshly created tile (shape == source page).
-        creates = [c for c in calls if c.op.name == "tile.create"]
+        creates = [c for c in calls if c.op.name == _OP_TILE_CREATE]
         assert any(cast(ir.TileType, c.type).shape == [3, 8] for c in creates)
 
     def test_batch_axis_transpose_rejected(self):
@@ -3159,11 +3173,11 @@ def _collect_def_use(fn) -> tuple[set[int], set[int], list[tuple[ir.Var, str]]]:
         # AssignStmt / ReturnStmt / YieldStmt / EvalStmt.
         if isinstance(node, ir.AssignStmt):
             defined.add(node.var.unique_id)
-            if isinstance(node.value, ir.Call) and node.value.op.name == "tensor.view":
+            if isinstance(node.value, ir.Call) and node.value.op.name == _OP_TENSOR_VIEW:
                 src = node.value.args[0]
                 if isinstance(src, ir.Var):
                     view_sources[node.var.unique_id] = view_sources.get(src.unique_id, src.name_hint)
-            elif isinstance(node.value, ir.Call) and node.value.op.name == "tile.load":
+            elif isinstance(node.value, ir.Call) and node.value.op.name == _OP_TILE_LOAD:
                 src = node.value.args[0]
                 if isinstance(src, ir.Var):
                     loads.append((node.var, view_sources.get(src.unique_id, src.name_hint)))

--- a/tests/ut/ir/transforms/test_infer_tile_memory_space.py
+++ b/tests/ut/ir/transforms/test_infer_tile_memory_space.py
@@ -23,6 +23,10 @@ import pytest
 from pypto import backend, ir, passes
 from pypto.backend import BackendType
 
+_OP_TILE_GET_BLOCK_IDX = ir.get_op("tile.get_block_idx").name
+_OP_TILE_LOAD = ir.get_op("tile.load").name
+_OP_TILE_MATMUL = ir.get_op("tile.matmul").name
+
 
 @pytest.fixture(autouse=True)
 def _reset_backend():
@@ -325,7 +329,7 @@ class TestInferTileMemorySpaceCubeOps:
             def visit_call(self, op):
                 expr = super().visit_call(op)
                 call = expr if isinstance(expr, ir.Call) else op
-                if call.op.name != "tile.matmul":
+                if call.op.name != _OP_TILE_MATMUL:
                     return expr
                 attrs = dict(call.attrs)
                 attrs["dump_vars"] = [call.args[0]]
@@ -344,7 +348,7 @@ class TestInferTileMemorySpaceCubeOps:
 
         class _CollectMatmul(ir.IRVisitor):
             def visit_call(self, op):
-                if op.op.name == "tile.matmul":
+                if op.op.name == _OP_TILE_MATMUL:
                     matmuls.append(op)
                 super().visit_call(op)
 
@@ -374,7 +378,7 @@ class TestInferTileMemorySpaceCubeOps:
             def visit_call(self, op):
                 expr = super().visit_call(op)
                 call = expr if isinstance(expr, ir.Call) else op
-                if call.op.name != "tile.matmul":
+                if call.op.name != _OP_TILE_MATMUL:
                     return expr
                 attrs = dict(call.attrs)
                 attrs["dump_vars"] = [call.args[0]]
@@ -393,7 +397,7 @@ class TestInferTileMemorySpaceCubeOps:
 
         class _CollectMatmul(ir.IRVisitor):
             def visit_call(self, op):
-                if op.op.name == "tile.matmul":
+                if op.op.name == _OP_TILE_MATMUL:
                     matmuls.append(op)
                 super().visit_call(op)
 
@@ -2229,7 +2233,7 @@ class MarkedResidencyGate:
                 expr = super().visit_call(op)
                 call = expr if isinstance(expr, ir.Call) else op
                 if (
-                    call.op.name == "tile.load"
+                    call.op.name == _OP_TILE_LOAD
                     and isinstance(call.type, ir.TileType)
                     and call.type.memory_space == pl.MemorySpace.Mat
                 ):
@@ -2367,7 +2371,7 @@ class RetargetedBridgeAttrs:
                 nonlocal stamped
                 expr = super().visit_call(op)
                 call = expr if isinstance(expr, ir.Call) else op
-                if call.op.name == "tile.load" and not stamped:
+                if call.op.name == _OP_TILE_LOAD and not stamped:
                     stamped = True
                     attrs = dict(call.attrs)
                     attrs[marker] = True
@@ -2389,7 +2393,7 @@ class RetargetedBridgeAttrs:
 
         class _CollectLoadAttrs(ir.IRVisitor):
             def visit_call(self, op):
-                if op.op.name == "tile.load":
+                if op.op.name == _OP_TILE_LOAD:
                     load_attrs.append(dict(op.attrs))
                 super().visit_call(op)
 
@@ -2421,7 +2425,7 @@ class MarkerOnlyScalarCall:
             def visit_call(self, op):
                 expr = super().visit_call(op)
                 call = expr if isinstance(expr, ir.Call) else op
-                if call.op.name != "tile.get_block_idx":
+                if call.op.name != _OP_TILE_GET_BLOCK_IDX:
                     return expr
                 attrs = dict(call.attrs)
                 attrs[marker] = True
@@ -2442,7 +2446,7 @@ class MarkerOnlyScalarCall:
 
         class _CollectScalarAttrs(ir.IRVisitor):
             def visit_call(self, op):
-                if op.op.name == "tile.get_block_idx":
+                if op.op.name == _OP_TILE_GET_BLOCK_IDX:
                     scalar_attrs.append(dict(op.attrs))
                 super().visit_call(op)
 

--- a/tests/ut/ir/transforms/test_legalize_tile_cast.py
+++ b/tests/ut/ir/transforms/test_legalize_tile_cast.py
@@ -23,7 +23,7 @@ class _CastTargetCollector(ir.IRVisitor):
         self.pairs: list[tuple[str, str]] = []
 
     def visit_call(self, op: ir.Call) -> None:
-        if op.op.name == "tile.cast":
+        if op.op.name == ir.get_op("tile.cast").name:
             src_ty = op.args[0].type
             assert isinstance(src_ty, ir.TileType)
             src = str(src_ty.dtype)

--- a/tests/ut/ir/transforms/test_lower_composite_ops.py
+++ b/tests/ut/ir/transforms/test_lower_composite_ops.py
@@ -28,16 +28,19 @@ import pytest
 from pypto import ir, passes
 from pypto.language.parser.diagnostics.exceptions import ParserError
 
+_OP_PLD_TILE_REMOTE_LOAD = ir.get_op("pld.tile.remote_load").name
+_OP_TILE_LOAD = ir.get_op("tile.load").name
+
 # Primitive tile ops the decomposition is allowed to emit (besides framework
 # infrastructure ops like tile.load / tile.store / tile.move that wrap the
 # decomposed body).
 _DECOMP_PRIMITIVES = {
-    "tile.muls",
-    "tile.adds",
-    "tile.add",
-    "tile.sub",
-    "tile.mul",
-    "tile.cast",
+    ir.get_op("tile.muls").name,
+    ir.get_op("tile.adds").name,
+    ir.get_op("tile.add").name,
+    ir.get_op("tile.sub").name,
+    ir.get_op("tile.mul").name,
+    ir.get_op("tile.cast").name,
 }
 
 
@@ -481,17 +484,17 @@ _ALLREDUCE_REDUCE_CASES = [
 
 # Ops the chunked mesh decomposition must emit.
 _ALLREDUCE_REQUIRED_OPS = {
-    "pld.system.get_comm_ctx",
-    "pld.system.nranks",
-    "pld.system.rank",
-    "pld.system.notify",  # Ready and per-chunk read-complete barriers
-    "pld.system.wait",  # Ready and per-chunk read-complete barriers
-    "pld.tile.remote_load",  # Peer chunk load
-    "tile.fillpad_inplace",  # Zero ragged padding before accumulation
-    "tile.add",  # Accumulate peer chunks
-    "tile.load",  # Self chunk load + user-side load
-    "tile.set_validshape",  # Narrow the final ragged chunk
-    "tile.store",  # Per-chunk result + user-side store
+    ir.get_op("pld.system.get_comm_ctx").name,
+    ir.get_op("pld.system.nranks").name,
+    ir.get_op("pld.system.rank").name,
+    ir.get_op("pld.system.notify").name,  # Ready and per-chunk read-complete barriers
+    ir.get_op("pld.system.wait").name,  # Ready and per-chunk read-complete barriers
+    ir.get_op("pld.tile.remote_load").name,  # Peer chunk load
+    ir.get_op("tile.fillpad_inplace").name,  # Zero ragged padding before accumulation
+    ir.get_op("tile.add").name,  # Accumulate peer chunks
+    ir.get_op("tile.load").name,  # Self chunk load + user-side load
+    ir.get_op("tile.set_validshape").name,  # Narrow the final ragged chunk
+    ir.get_op("tile.store").name,  # Per-chunk result + user-side store
 }
 
 
@@ -1063,8 +1066,8 @@ def test_allreduce_mesh_lowering_preserves_partial_valid_shape():
 
     collector = CallCollector()
     collector.visit_program(After)
-    load = next(call for call in collector.calls if call.op.name == "tile.load")
-    remote_load = next(call for call in collector.calls if call.op.name == "pld.tile.remote_load")
+    load = next(call for call in collector.calls if call.op.name == _OP_TILE_LOAD)
+    remote_load = next(call for call in collector.calls if call.op.name == _OP_PLD_TILE_REMOTE_LOAD)
     load_shape = load.args[2]
     load_valid_shape = load.args[3]
     remote_shape = remote_load.args[3]
@@ -1614,11 +1617,11 @@ def test_allreduce_lowers_every_reduce_op(reduce_op, expected_tile_op):
 
 _BARRIER_NRANKS = 2
 _BARRIER_REQUIRED_OPS = {
-    "pld.system.get_comm_ctx",
-    "pld.system.nranks",
-    "pld.system.rank",
-    "pld.system.notify",
-    "pld.system.wait",
+    ir.get_op("pld.system.get_comm_ctx").name,
+    ir.get_op("pld.system.nranks").name,
+    ir.get_op("pld.system.rank").name,
+    ir.get_op("pld.system.notify").name,
+    ir.get_op("pld.system.wait").name,
 }
 
 
@@ -1681,13 +1684,13 @@ def test_barrier_lowering_is_idempotent():
 _BROADCAST_SIZE = 16
 _BROADCAST_NRANKS = 2
 _BROADCAST_REQUIRED_OPS = {
-    "pld.system.get_comm_ctx",
-    "pld.system.nranks",
-    "pld.system.rank",
-    "pld.system.notify",
-    "pld.system.wait",
-    "tile.create",
-    "pld.tile.get",
+    ir.get_op("pld.system.get_comm_ctx").name,
+    ir.get_op("pld.system.nranks").name,
+    ir.get_op("pld.system.rank").name,
+    ir.get_op("pld.system.notify").name,
+    ir.get_op("pld.system.wait").name,
+    ir.get_op("tile.create").name,
+    ir.get_op("pld.tile.get").name,
 }
 
 
@@ -1753,13 +1756,13 @@ def test_broadcast_lowering_is_idempotent():
 _ALLGATHER_SIZE = 16
 _ALLGATHER_NRANKS = 2
 _ALLGATHER_REQUIRED_OPS = {
-    "pld.system.get_comm_ctx",
-    "pld.system.nranks",
-    "pld.system.rank",
-    "pld.system.notify",
-    "pld.system.wait",
-    "pld.tile.put",
-    "tile.create",
+    ir.get_op("pld.system.get_comm_ctx").name,
+    ir.get_op("pld.system.nranks").name,
+    ir.get_op("pld.system.rank").name,
+    ir.get_op("pld.system.notify").name,
+    ir.get_op("pld.system.wait").name,
+    ir.get_op("pld.tile.put").name,
+    ir.get_op("tile.create").name,
 }
 
 
@@ -1831,15 +1834,15 @@ def test_allgather_lowering_is_idempotent():
 _REDUCE_SCATTER_SIZE = 16
 _REDUCE_SCATTER_NRANKS = 2
 _REDUCE_SCATTER_REQUIRED_OPS = {
-    "pld.system.get_comm_ctx",
-    "pld.system.nranks",
-    "pld.system.rank",
-    "pld.system.notify",
-    "pld.system.wait",
-    "pld.tile.remote_load",
-    "tile.add",
-    "tile.load",
-    "tile.store",
+    ir.get_op("pld.system.get_comm_ctx").name,
+    ir.get_op("pld.system.nranks").name,
+    ir.get_op("pld.system.rank").name,
+    ir.get_op("pld.system.notify").name,
+    ir.get_op("pld.system.wait").name,
+    ir.get_op("pld.tile.remote_load").name,
+    ir.get_op("tile.add").name,
+    ir.get_op("tile.load").name,
+    ir.get_op("tile.store").name,
 }
 
 

--- a/tests/ut/ir/transforms/test_lower_host_tensor_collectives.py
+++ b/tests/ut/ir/transforms/test_lower_host_tensor_collectives.py
@@ -469,11 +469,11 @@ def test_host_allreduce_resolves_non_innermost_comm_domain_scope():
         for loop in loops
         if isinstance(loop.body, ir.EvalStmt)
         and isinstance(loop.body.expr, ir.Call)
-        and loop.body.expr.op.name == "builtin.tensor.allreduce"
+        and loop.body.expr.op.name == ir.get_op("builtin.tensor.allreduce").name
     ]
     assert len(builtin_loops) == 1
     assert isinstance(builtin_loops[0].stop, ir.Call)
-    assert builtin_loops[0].stop.op.name == "pld.system.world_size"
+    assert builtin_loops[0].stop.op.name == ir.get_op("pld.system.world_size").name
 
 
 def test_host_allreduce_rejects_static_signal_smaller_than_explicit_device_count():

--- a/tests/ut/ir/transforms/test_materialize_comm_domain_scopes.py
+++ b/tests/ut/ir/transforms/test_materialize_comm_domain_scopes.py
@@ -56,6 +56,10 @@ import pytest
 from pypto.ir.op.distributed import tensor_ops as dist_tensor_ops
 from pypto.pypto_core import DataType, ir, passes
 
+_OP_PLD_TENSOR_ALLOC_WINDOW_BUFFER = ir.get_op("pld.tensor.alloc_window_buffer").name
+_OP_PLD_TENSOR_ALLREDUCE = ir.get_op("pld.tensor.allreduce").name
+_OP_PLD_TENSOR_WINDOW = ir.get_op("pld.tensor.window").name
+
 
 @pytest.fixture(autouse=True)
 def _basic_verification_context():
@@ -95,7 +99,7 @@ def _find_window_calls(func: ir.Function) -> list[ir.AssignStmt]:
 
     def walk(stmt: ir.Stmt) -> None:
         if isinstance(stmt, ir.AssignStmt):
-            if isinstance(stmt.value, ir.Call) and stmt.value.op.name == "pld.tensor.window":
+            if isinstance(stmt.value, ir.Call) and stmt.value.op.name == _OP_PLD_TENSOR_WINDOW:
                 found.append(stmt)
         if isinstance(stmt, ir.SeqStmts):
             for s in stmt.stmts:
@@ -318,7 +322,7 @@ def test_explicit_allreduce_assignment_keeps_user_signal():
         for stmt in stmts
         if isinstance(stmt, ir.AssignStmt)
         and isinstance(stmt.value, ir.Call)
-        and stmt.value.op.name == "pld.tensor.allreduce"
+        and stmt.value.op.name == _OP_PLD_TENSOR_ALLREDUCE
     ]
 
     assert synthetic_assigns == []
@@ -357,7 +361,7 @@ def test_implicit_allreduce_signal_is_materialized_in_data_comm_domain():
         for stmt in stmts
         if isinstance(stmt, ir.AssignStmt)
         and isinstance(stmt.value, ir.Call)
-        and stmt.value.op.name == "pld.tensor.window"
+        and stmt.value.op.name == _OP_PLD_TENSOR_WINDOW
         and stmt.var.name_hint.startswith("__allreduce_signal_")
     ]
     allreduces = [
@@ -365,7 +369,7 @@ def test_implicit_allreduce_signal_is_materialized_in_data_comm_domain():
         for stmt in stmts
         if isinstance(stmt, ir.AssignStmt)
         and isinstance(stmt.value, ir.Call)
-        and stmt.value.op.name == "pld.tensor.allreduce"
+        and stmt.value.op.name == _OP_PLD_TENSOR_ALLREDUCE
     ]
 
     assert len(signal_windows) == 1
@@ -407,7 +411,7 @@ def test_optional_signal_allreduce_round_trips_before_materialization():
         for stmt in _flatten_stmts(host.body)
         if isinstance(stmt, ir.AssignStmt)
         and isinstance(stmt.value, ir.Call)
-        and stmt.value.op.name == "pld.tensor.allreduce"
+        and stmt.value.op.name == _OP_PLD_TENSOR_ALLREDUCE
     ]
 
     assert "pld.tensor.allreduce(" in printed
@@ -443,14 +447,14 @@ def test_synthesize_allreduce_signals_normalizes_host_allreduce():
         for stmt in stmts
         if isinstance(stmt, ir.AssignStmt)
         and isinstance(stmt.value, ir.Call)
-        and stmt.value.op.name == "pld.tensor.allreduce"
+        and stmt.value.op.name == _OP_PLD_TENSOR_ALLREDUCE
     ]
     signal_windows = [
         stmt
         for stmt in stmts
         if isinstance(stmt, ir.AssignStmt)
         and isinstance(stmt.value, ir.Call)
-        and stmt.value.op.name == "pld.tensor.window"
+        and stmt.value.op.name == _OP_PLD_TENSOR_WINDOW
         and stmt.var.name_hint.startswith("__allreduce_signal_")
     ]
 
@@ -484,7 +488,7 @@ def test_synthesize_multicore_allreduce_signal_uses_core_lanes_and_bytes():
         for stmt in stmts
         if isinstance(stmt, ir.AssignStmt)
         and isinstance(stmt.value, ir.Call)
-        and stmt.value.op.name == ir.get_op("pld.tensor.window").name
+        and stmt.value.op.name == _OP_PLD_TENSOR_WINDOW
         and stmt.var.name_hint.startswith("__allreduce_signal_")
     )
     alloc_stmt = next(
@@ -492,7 +496,7 @@ def test_synthesize_multicore_allreduce_signal_uses_core_lanes_and_bytes():
         for stmt in stmts
         if isinstance(stmt, ir.AssignStmt)
         and isinstance(stmt.value, ir.Call)
-        and stmt.value.op.name == ir.get_op("pld.tensor.alloc_window_buffer").name
+        and stmt.value.op.name == _OP_PLD_TENSOR_ALLOC_WINDOW_BUFFER
         and stmt.var.name_hint.startswith("__allreduce_signal_buf_")
     )
     allreduce = next(
@@ -500,7 +504,7 @@ def test_synthesize_multicore_allreduce_signal_uses_core_lanes_and_bytes():
         for stmt in stmts
         if isinstance(stmt, ir.AssignStmt)
         and isinstance(stmt.value, ir.Call)
-        and stmt.value.op.name == ir.get_op("pld.tensor.allreduce").name
+        and stmt.value.op.name == _OP_PLD_TENSOR_ALLREDUCE
     )
 
     signal_type = window_stmt.var.type
@@ -547,7 +551,7 @@ def test_synthesized_allreduce_signal_round_trips_after_materialization():
         for stmt in stmts
         if isinstance(stmt, ir.AssignStmt)
         and isinstance(stmt.value, ir.Call)
-        and stmt.value.op.name == "pld.tensor.alloc_window_buffer"
+        and stmt.value.op.name == _OP_PLD_TENSOR_ALLOC_WINDOW_BUFFER
         and stmt.var.name_hint.startswith("__allreduce_signal_buf_")
     ]
     windows = [
@@ -555,7 +559,7 @@ def test_synthesized_allreduce_signal_round_trips_after_materialization():
         for stmt in stmts
         if isinstance(stmt, ir.AssignStmt)
         and isinstance(stmt.value, ir.Call)
-        and stmt.value.op.name == "pld.tensor.window"
+        and stmt.value.op.name == _OP_PLD_TENSOR_WINDOW
         and stmt.var.name_hint.startswith("__allreduce_signal_")
     ]
     allreduces = [
@@ -563,7 +567,7 @@ def test_synthesized_allreduce_signal_round_trips_after_materialization():
         for stmt in stmts
         if isinstance(stmt, ir.AssignStmt)
         and isinstance(stmt.value, ir.Call)
-        and stmt.value.op.name == "pld.tensor.allreduce"
+        and stmt.value.op.name == _OP_PLD_TENSOR_ALLREDUCE
     ]
 
     printed_ast = ast.parse(printed)
@@ -646,7 +650,7 @@ def test_implicit_allreduce_signal_names_are_program_unique():
         for stmt in _flatten_stmts(host.body)
         if isinstance(stmt, ir.AssignStmt)
         and isinstance(stmt.value, ir.Call)
-        and stmt.value.op.name == "pld.tensor.allreduce"
+        and stmt.value.op.name == _OP_PLD_TENSOR_ALLREDUCE
     ]
     world_size_vars = [
         stmt.var.name_hint
@@ -739,7 +743,7 @@ def test_synthesize_allreduce_signals_reserves_existing_alloc_names():
         for stmt in _flatten_stmts(_get_func(synthesized, "host_orch").body)
         if isinstance(stmt, ir.AssignStmt)
         and isinstance(stmt.value, ir.Call)
-        and stmt.value.op.name == "pld.tensor.alloc_window_buffer"
+        and stmt.value.op.name == _OP_PLD_TENSOR_ALLOC_WINDOW_BUFFER
     ]
 
     assert alloc_names == ["__allreduce_signal_buf_0", "__allreduce_signal_buf_1"]
@@ -810,7 +814,7 @@ def test_return_implicit_allreduce_is_lifted_for_host_lowering():
         for stmt in stmts
         if isinstance(stmt, ir.AssignStmt)
         and isinstance(stmt.value, ir.Call)
-        and stmt.value.op.name == "pld.tensor.allreduce"
+        and stmt.value.op.name == _OP_PLD_TENSOR_ALLREDUCE
     ]
     returns = [stmt for stmt in stmts if isinstance(stmt, ir.ReturnStmt)]
 
@@ -862,7 +866,7 @@ def test_return_explicit_allreduce_is_lifted_for_host_lowering():
         for stmt in stmts
         if isinstance(stmt, ir.AssignStmt)
         and isinstance(stmt.value, ir.Call)
-        and stmt.value.op.name == "pld.tensor.allreduce"
+        and stmt.value.op.name == _OP_PLD_TENSOR_ALLREDUCE
     ]
     returns = [stmt for stmt in stmts if isinstance(stmt, ir.ReturnStmt)]
 
@@ -899,7 +903,7 @@ def test_implicit_allreduce_eval_stmt_gets_signal():
         for stmt in stmts
         if isinstance(stmt, ir.EvalStmt)
         and isinstance(stmt.expr, ir.Call)
-        and stmt.expr.op.name == "pld.tensor.allreduce"
+        and stmt.expr.op.name == _OP_PLD_TENSOR_ALLREDUCE
     ]
 
     assert len(allreduces) == 1
@@ -946,7 +950,7 @@ def test_explicit_allreduce_eval_stmt_keeps_user_signal():
         for stmt in stmts
         if isinstance(stmt, ir.EvalStmt)
         and isinstance(stmt.expr, ir.Call)
-        and stmt.expr.op.name == "pld.tensor.allreduce"
+        and stmt.expr.op.name == _OP_PLD_TENSOR_ALLREDUCE
     ]
 
     assert synthetic_assigns == []

--- a/tests/ut/ir/transforms/test_memory_reuse.py
+++ b/tests/ut/ir/transforms/test_memory_reuse.py
@@ -23,6 +23,10 @@ from pypto.backend import BackendType
 from pypto.ir.op import tile
 from pypto.ir.pass_manager import OptimizationStrategy, PassManager
 
+# Tile-producing reads from GM. Built through the getter so a renamed operator fails at import
+# rather than silently dropping out of the membership test below.
+_LOAD_LIKE_OPS = frozenset({ir.get_op("tile.load").name, ir.get_op("tile.read").name})
+
 
 def _run_pipeline(program: ir.Program) -> ir.Program:
     """Run init_mem_ref + materialize_semantic_aliases + memory_reuse pipeline.
@@ -4342,7 +4346,7 @@ class TestPipelineStageSeparation:
                 var_type = stmt.var.type
                 if isinstance(var_type, ir.TileType) and var_type.memref is not None:
                     val = stmt.value
-                    is_load = isinstance(val, ir.Call) and val.op.name in ("tile.load", "tile.read")
+                    is_load = isinstance(val, ir.Call) and val.op.name in _LOAD_LIKE_OPS
                     defs.append((is_load, var_type.memref.base_.name_hint))
                 super().visit_assign_stmt(stmt)
 

--- a/tests/ut/language/parser/test_constant_folding.py
+++ b/tests/ut/language/parser/test_constant_folding.py
@@ -18,6 +18,11 @@ import pypto.language as pl
 import pytest
 from pypto.pypto_core import ir
 
+_OP_TENSOR_ADD = ir.get_op("tensor.add").name
+_OP_TENSOR_MULS = ir.get_op("tensor.muls").name
+_OP_TENSOR_SLICE = ir.get_op("tensor.slice").name
+_OP_TENSOR_SUB = ir.get_op("tensor.sub").name
+
 
 def _collect_call_args(func: ir.Function, op_name: str) -> list[list]:
     """Collect argument lists of all Calls matching *op_name* anywhere in the
@@ -60,7 +65,7 @@ class TestBinopConstantFolding:
             return result
 
         assert isinstance(func, ir.Function)
-        mul_calls = _collect_call_args(func, "tensor.muls")
+        mul_calls = _collect_call_args(func, _OP_TENSOR_MULS)
         assert len(mul_calls) == 1
         scalar_arg = mul_calls[0][1]
         assert isinstance(scalar_arg, ir.ConstInt), (
@@ -79,7 +84,7 @@ class TestBinopConstantFolding:
             return result
 
         assert isinstance(func, ir.Function)
-        mul_calls = _collect_call_args(func, "tensor.muls")
+        mul_calls = _collect_call_args(func, _OP_TENSOR_MULS)
         assert len(mul_calls) == 1
         scalar_arg = mul_calls[0][1]
         assert isinstance(scalar_arg, ir.ConstInt), (
@@ -98,7 +103,7 @@ class TestBinopConstantFolding:
             return result
 
         assert isinstance(func, ir.Function)
-        mul_calls = _collect_call_args(func, "tensor.muls")
+        mul_calls = _collect_call_args(func, _OP_TENSOR_MULS)
         assert len(mul_calls) == 1
         scalar_arg = mul_calls[0][1]
         assert isinstance(scalar_arg, ir.ConstInt)
@@ -115,7 +120,7 @@ class TestBinopConstantFolding:
             return result
 
         assert isinstance(func, ir.Function)
-        mul_calls = _collect_call_args(func, "tensor.muls")
+        mul_calls = _collect_call_args(func, _OP_TENSOR_MULS)
         assert len(mul_calls) == 1
         scalar_arg = mul_calls[0][1]
         assert isinstance(scalar_arg, ir.ConstInt)
@@ -133,7 +138,7 @@ class TestBinopConstantFolding:
             return result
 
         assert isinstance(func, ir.Function)
-        mul_calls = _collect_call_args(func, "tensor.muls")
+        mul_calls = _collect_call_args(func, _OP_TENSOR_MULS)
         assert len(mul_calls) == 1
         scalar_arg = mul_calls[0][1]
         assert isinstance(scalar_arg, ir.ConstInt)
@@ -150,7 +155,7 @@ class TestBinopConstantFolding:
             return result
 
         assert isinstance(func, ir.Function)
-        mul_calls = _collect_call_args(func, "tensor.muls")
+        mul_calls = _collect_call_args(func, _OP_TENSOR_MULS)
         assert len(mul_calls) == 1
         scalar_arg = mul_calls[0][1]
         assert isinstance(scalar_arg, ir.ConstFloat), (
@@ -172,7 +177,7 @@ class TestUnaryopConstantFolding:
             return result
 
         assert isinstance(func, ir.Function)
-        mul_calls = _collect_call_args(func, "tensor.muls")
+        mul_calls = _collect_call_args(func, _OP_TENSOR_MULS)
         assert len(mul_calls) == 1
         scalar_arg = mul_calls[0][1]
         # After folding, -42 should become a single ConstInt(-42) or Neg(ConstInt(42)).
@@ -236,8 +241,8 @@ class TestMixedExpressionFallback:
             for stmt in body.stmts
             if isinstance(stmt, ir.AssignStmt) and isinstance(stmt.value, ir.Call)
         ]
-        assert "tensor.add" in call_ops
-        assert "tensor.sub" in call_ops
+        assert _OP_TENSOR_ADD in call_ops
+        assert _OP_TENSOR_SUB in call_ops
 
 
 class TestDimensionEqualityAfterFolding:
@@ -317,7 +322,7 @@ class TestScopeShadowingSafety:
         assert isinstance(func, ir.Function)
         body = func.body
         assert isinstance(body, ir.SeqStmts)
-        mul_calls = _collect_call_args(func, "tensor.muls")
+        mul_calls = _collect_call_args(func, _OP_TENSOR_MULS)
         assert len(mul_calls) == 1
         scalar_arg = mul_calls[0][1]
         # Look through the explicit cast to the folded-or-not expression.
@@ -344,7 +349,7 @@ class TestScopeShadowingSafety:
             return result
 
         assert isinstance(func, ir.Function)
-        mul_calls = _collect_call_args(func, "tensor.muls")
+        mul_calls = _collect_call_args(func, _OP_TENSOR_MULS)
         assert len(mul_calls) == 1
         scalar_arg = mul_calls[0][1]
         # Look through the explicit cast: idx + M must remain an Add node,
@@ -357,7 +362,7 @@ class TestScopeShadowingSafety:
 
 def _assert_all_slice_extents_are_constint(func: ir.Function, expected_dims: list[int]) -> None:
     """Verify every ``tensor.slice`` call in *func* has shape_tuple = expected_dims."""
-    slice_calls = _collect_call_args(func, "tensor.slice")
+    slice_calls = _collect_call_args(func, _OP_TENSOR_SLICE)
     assert slice_calls, "expected tensor.slice calls to be emitted"
     for args in slice_calls:
         extent = args[1]  # tensor.slice(tensor, shape_tuple, offset_tuple)

--- a/tests/ut/language/parser/test_manual_scope_parsing.py
+++ b/tests/ut/language/parser/test_manual_scope_parsing.py
@@ -18,6 +18,9 @@ from pypto.language.parser.diagnostics.exceptions import (
     UnsupportedFeatureError,
 )
 
+_OP_ARRAY_CREATE = ir.get_op("array.create").name
+_OP_ARRAY_UPDATE_ELEMENT = ir.get_op("array.update_element").name
+
 
 def _first_runtime_scope(stmt):
     """Return the first RuntimeScopeStmt found in a stmt subtree (DFS), or None."""
@@ -331,7 +334,7 @@ class Prog:
         # First stmt: placeholder for t1.
         assert isinstance(stmts[0], ir.AssignStmt)
         assert isinstance(stmts[0].value, ir.Call)
-        assert stmts[0].value.op.name == "system.task_invalid"
+        assert stmts[0].value.op.name == ir.get_op("system.task_invalid").name
         # Second stmt: the first pl.at scope. Its ``task_id_var`` attr must
         # point at the same Var bound by the placeholder above (otherwise the
         # outliner couldn't unify the synthesised ``TupleGetItem`` binding
@@ -728,8 +731,8 @@ class TestSubmitDepsPerElementAndComprehension:
         assert edge.type.dtype == pl.TASK_ID
         # The synthesizer must emit one array.create + 3 array.update_element
         # calls *before* the consumer kernel call. Look for them by op name.
-        create_calls = [c for c in calls if c.op.name == "array.create"]
-        update_calls = [c for c in calls if c.op.name == "array.update_element"]
+        create_calls = [c for c in calls if c.op.name == _OP_ARRAY_CREATE]
+        update_calls = [c for c in calls if c.op.name == _OP_ARRAY_UPDATE_ELEMENT]
         assert len(create_calls) >= 1  # one for the user `tids` plus the synth buffer
         # Two `tids[n] = t` writes (from the producer loop) plus 3 from the synthesizer.
         assert len(update_calls) >= 3
@@ -953,7 +956,7 @@ class TestSubmitDepsPerElementAndComprehension:
         synth_creates = [
             c
             for c in calls
-            if c.op.name == "array.create"
+            if c.op.name == _OP_ARRAY_CREATE
             # locally-bound _submit_deps_buf would be the array.create's LHS;
             # the user wrote no array.create themselves here.
         ]
@@ -1085,8 +1088,8 @@ class TestSubmitDepsPerElementAndComprehension:
         for s in stmts[:scope2_idx]:
             if isinstance(s, ir.AssignStmt) and isinstance(s.value, ir.Call):
                 prior_calls.append(s.value)
-        synth_creates = [c for c in prior_calls if c.op.name == "array.create"]
-        synth_updates = [c for c in prior_calls if c.op.name == "array.update_element"]
+        synth_creates = [c for c in prior_calls if c.op.name == _OP_ARRAY_CREATE]
+        synth_updates = [c for c in prior_calls if c.op.name == _OP_ARRAY_UPDATE_ELEMENT]
         # Two array.create calls before scope2: the user's `tids` and the synth.
         # Two array.update_element calls: `tids[0] = t1` (user) + synthesized fill.
         assert len(synth_creates) == 2

--- a/tests/ut/language/parser/test_op_validation.py
+++ b/tests/ut/language/parser/test_op_validation.py
@@ -25,6 +25,12 @@ from pypto.language.typing import Scalar
 from pypto.pypto_core import DataType
 from pypto.pypto_core import ir as _ir
 
+# A `pl.add` / `pl.cast` wrapper lowers to the tensor or the tile form depending on the operand
+# kind, so these tests accept either. Built through the getter so a renamed operator fails at
+# import rather than silently emptying the collected-call list.
+_ADD_OPS = frozenset({ir.get_op("tensor.add").name, ir.get_op("tile.add").name})
+_CAST_OPS = frozenset({ir.get_op("tensor.cast").name, ir.get_op("tile.cast").name})
+
 
 class TestWrapperErrorsThroughParser:
     """Wrapper errors surface as InvalidOperationError with op name + span."""
@@ -140,7 +146,7 @@ class TestSpanPropagatesIntoWrapperConstructedNodes:
                 super().visit_call(op)
 
         _Collect().visit_program(Prog)
-        add_calls = [c for c in found_calls if c.op.name in ("tensor.add", "tile.add")]
+        add_calls = [c for c in found_calls if c.op.name in _ADD_OPS]
         assert add_calls, "expected at least one tensor.add or tile.add Call in IR"
 
         for call in add_calls:
@@ -204,9 +210,9 @@ class TestFullPythonCallingConvention:
 
         class _Collect(ir.IRVisitor):
             def visit_call(self, op):
-                if op.op.name == "tile.load":
+                if op.op.name == ir.get_op("tile.load").name:
                     load_calls.append(op)
-                elif op.op.name == "tile.add":
+                elif op.op.name == ir.get_op("tile.add").name:
                     add_calls.append(op)
                 super().visit_call(op)
 
@@ -235,7 +241,7 @@ class TestFullPythonCallingConvention:
 
         class _Collect(ir.IRVisitor):
             def visit_call(self, op):
-                if op.op.name in ("tensor.cast", "tile.cast"):
+                if op.op.name in _CAST_OPS:
                     cast_calls.append(op)
                 super().visit_call(op)
 

--- a/tests/ut/language/parser/test_printer_integration.py
+++ b/tests/ut/language/parser/test_printer_integration.py
@@ -178,7 +178,7 @@ class TestCastModeRoundTrip:
         # Call with int mode
         call = op.tensor.cast(tensor_var, DataType.FP32, mode=2, span=span)
         assert isinstance(call, ir.Call)
-        assert call.op.name == "tensor.cast"
+        assert call.op.name == ir.get_op("tensor.cast").name
 
     def test_cast_mode_round_trip(self):
         """Test parse → print → re-parse round-trip with mode='round'."""

--- a/tests/ut/language/parser/test_scope_parsing.py
+++ b/tests/ut/language/parser/test_scope_parsing.py
@@ -18,6 +18,9 @@ from pypto.language.parser.ast_parser import ASTParser
 from pypto.language.parser.diagnostics.exceptions import ParserSyntaxError
 from pypto.language.parser.text_parser import parse_program
 
+_OP_SYSTEM_TASK_INVALID = ir.get_op("system.task_invalid").name
+_OP_TILE_GET_BLOCK_IDX = ir.get_op("tile.get_block_idx").name
+
 
 def _descendants(node, cls):
     """Collect every descendant of ``node`` (inclusive) that is an instance of ``cls``."""
@@ -286,7 +289,7 @@ class TestSpmdForLoop:
         assert isinstance(first_stmt, ir.AssignStmt)
         call = first_stmt.value
         assert isinstance(call, ir.Call)
-        assert call.op.name == "tile.get_block_idx"
+        assert call.op.name == _OP_TILE_GET_BLOCK_IDX
         assert first_stmt.var.name_hint == "i"
 
     def test_for_spmd_accepts_core_num_kwarg(self):
@@ -695,7 +698,7 @@ class TestSpmdOptimizations:
         assert isinstance(first_stmt, ir.AssignStmt)
         call = first_stmt.value
         assert isinstance(call, ir.Call) and isinstance(call.op, ir.Op)
-        assert call.op.name == "tile.get_block_idx"
+        assert call.op.name == _OP_TILE_GET_BLOCK_IDX
 
     def test_for_spmd_qualified_split_sets_inner_incore_split(self):
         """``pl.optimizations.split(...)`` is accepted on the for-form."""
@@ -1242,7 +1245,7 @@ class TestSpmdScopeTaskId:
         return (
             isinstance(stmt, ir.AssignStmt)
             and isinstance(stmt.value, ir.Call)
-            and stmt.value.op.name == "system.task_invalid"
+            and stmt.value.op.name == _OP_SYSTEM_TASK_INVALID
         )
 
     def _build(self):
@@ -1299,7 +1302,7 @@ class TestSpmdScopeTaskId:
         # User-written get_block_idx is the first body stmt (NOT a synthesized loop var).
         first = stmts[0]
         assert isinstance(first, ir.AssignStmt)
-        assert isinstance(first.value, ir.Call) and first.value.op.name == "tile.get_block_idx"
+        assert isinstance(first.value, ir.Call) and first.value.op.name == _OP_TILE_GET_BLOCK_IDX
         assert len(stmts) > 1, "inline body should carry multiple statements"
 
     def test_as_tid_deps_sets_manual_dep_edges(self):
@@ -1578,7 +1581,7 @@ class TestSpmdInlineWithForm:
         first = stmts[0]
         assert isinstance(first, ir.AssignStmt)
         assert isinstance(first.value, ir.Call)
-        assert first.value.op.name == "tile.get_block_idx"
+        assert first.value.op.name == _OP_TILE_GET_BLOCK_IDX
         assert len(stmts) > 1, "inline body should carry multiple statements"
 
     def test_inline_with_spmd_no_placeholder_before_scope(self):
@@ -1603,7 +1606,7 @@ class TestSpmdInlineWithForm:
         placeholders = [
             s
             for s in _descendants(main_func.body, ir.AssignStmt)
-            if isinstance(s.value, ir.Call) and s.value.op.name == "system.task_invalid"
+            if isinstance(s.value, ir.Call) and s.value.op.name == _OP_SYSTEM_TASK_INVALID
         ]
         assert not placeholders, "plain inline form must not emit a task_invalid placeholder"
         # ...but the scope itself must still be there — an empty body would also

--- a/tests/ut/language/parser/test_split_aiv_parsing.py
+++ b/tests/ut/language/parser/test_split_aiv_parsing.py
@@ -23,6 +23,8 @@ import pytest
 from pypto import ir
 from pypto.language.parser.diagnostics.exceptions import InvalidOperationError, ParserSyntaxError
 
+_OP_TILE_GET_SUBBLOCK_IDX = ir.get_op("tile.get_subblock_idx").name
+
 
 def _count_descendants(node, cls):
     count = 0
@@ -147,7 +149,7 @@ class TestSplitAivBuildsNode:
         first_stmt = _first_body_stmt(region)
         assert isinstance(first_stmt, ir.AssignStmt)
         assert isinstance(first_stmt.value, ir.Call)
-        assert first_stmt.value.op.name == "tile.get_subblock_idx"
+        assert first_stmt.value.op.name == _OP_TILE_GET_SUBBLOCK_IDX
         assert first_stmt.var.name_hint == "aiv_id"
 
     def test_top_level_wrapped_in_incore(self):
@@ -205,7 +207,7 @@ class TestSplitAivBuildsNode:
         first_stmt = _first_body_stmt(region)
         assert isinstance(first_stmt, ir.AssignStmt)
         assert isinstance(first_stmt.value, ir.Call)
-        assert first_stmt.value.op.name == "tile.get_subblock_idx"
+        assert first_stmt.value.op.name == _OP_TILE_GET_SUBBLOCK_IDX
         assert first_stmt.var.name_hint == "aiv_id"
 
     def test_none_mode_print_roundtrips(self):

--- a/tests/ut/language/parser/test_submit_predicate.py
+++ b/tests/ut/language/parser/test_submit_predicate.py
@@ -33,6 +33,8 @@ from pypto.language.parser.diagnostics.exceptions import (
     UnsupportedFeatureError,
 )
 
+_OP_TENSOR_READ = ir.get_op("tensor.read").name
+
 
 def _flatten(stmt):
     if isinstance(stmt, ir.SeqStmts):
@@ -65,7 +67,7 @@ def _pred_read(p) -> ir.Call:
         return e
 
     def is_read(e):
-        return isinstance(e, ir.Call) and e.op.name == "tensor.read"
+        return isinstance(e, ir.Call) and e.op.name == _OP_TENSOR_READ
 
     lhs, rhs = strip_cast(p.left), strip_cast(p.right)
     read = lhs if is_read(lhs) else rhs
@@ -149,7 +151,7 @@ def test_predicate_populates_submit_fields():
     pred = expert_sub.predicate
     assert isinstance(pred, ir.Gt)
     read = _pred_read(pred)
-    assert read.op.name == "tensor.read"
+    assert read.op.name == _OP_TENSOR_READ
     assert isinstance(read.args[0], ir.Var)  # operand tensor
     assert len(_pred_indices(pred)) == 2  # one index per rank-2 axis
     assert _pred_const(pred).value == 0
@@ -205,7 +207,7 @@ def test_reversed_operand_order_is_normalized():
     # `0 < rc[0,0]` keeps its written `Lt` kind in the IR; orchestration codegen
     # flips it to the runtime's `operand OP target` orientation (GT).
     assert isinstance(expert_sub.predicate, ir.Lt)
-    assert _pred_read(expert_sub.predicate).op.name == "tensor.read"
+    assert _pred_read(expert_sub.predicate).op.name == _OP_TENSOR_READ
     assert _pred_const(expert_sub.predicate).value == 0
 
 
@@ -456,7 +458,7 @@ def test_scope_predicate_lands_on_scope_attrs():
     assert isinstance(predicate, ir.Gt)
     assert _pred_const(predicate).value == 0
     # Reuses tensor.read rather than a bespoke encoding.
-    assert _pred_read(predicate).op.name == "tensor.read"
+    assert _pred_read(predicate).op.name == _OP_TENSOR_READ
     assert [c.value for c in _pred_indices(predicate)] == [0, 0]
 
 

--- a/tests/ut/language/parser/test_subscript_syntax.py
+++ b/tests/ut/language/parser/test_subscript_syntax.py
@@ -18,6 +18,8 @@ from pypto import ir
 from pypto.language.parser.diagnostics import ParserTypeError
 from pypto.language.parser.diagnostics.exceptions import UnsupportedFeatureError
 
+_OP_TILE_SLICE = ir.get_op("tile.slice").name
+
 
 class TestTensorSubscript:
     """Tests for tensor subscript syntax: A[i, j], A[0:16, :]."""
@@ -220,7 +222,7 @@ class TestTileSubscript:
         slice_stmt = slice_tile_dynamic.body.stmts[1]
         assert isinstance(slice_stmt, ir.AssignStmt)
         assert isinstance(slice_stmt.value, ir.Call)
-        assert slice_stmt.value.op.name == "tile.slice"
+        assert slice_stmt.value.op.name == _OP_TILE_SLICE
         assert len(slice_stmt.value.args) == 4
 
         shape_tuple = slice_stmt.value.args[1]
@@ -249,7 +251,7 @@ class TestTileSubscript:
         slice_stmt = slice_tile_full.body.stmts[1]
         assert isinstance(slice_stmt, ir.AssignStmt)
         assert isinstance(slice_stmt.value, ir.Call)
-        assert slice_stmt.value.op.name == "tile.slice"
+        assert slice_stmt.value.op.name == _OP_TILE_SLICE
         assert len(slice_stmt.value.args) == 4
 
         valid_shape_tuple = slice_stmt.value.args[3]
@@ -275,7 +277,7 @@ class TestTileSubscript:
         slice_stmt = slice_tile_capped.body.stmts[1]
         assert isinstance(slice_stmt, ir.AssignStmt)
         assert isinstance(slice_stmt.value, ir.Call)
-        assert slice_stmt.value.op.name == "tile.slice"
+        assert slice_stmt.value.op.name == _OP_TILE_SLICE
         assert len(slice_stmt.value.args) == 4
 
         shape_tuple = slice_stmt.value.args[1]
@@ -303,7 +305,7 @@ class TestTileSubscript:
         slice_stmt = slice_tile_clamped.body.stmts[1]
         assert isinstance(slice_stmt, ir.AssignStmt)
         assert isinstance(slice_stmt.value, ir.Call)
-        assert slice_stmt.value.op.name == "tile.slice"
+        assert slice_stmt.value.op.name == _OP_TILE_SLICE
         assert len(slice_stmt.value.args) == 3
 
         shape_tuple = slice_stmt.value.args[1]
@@ -484,7 +486,7 @@ class TestTensorSubscriptWrite:
         assemble_stmt = write_const.body.stmts[0]
         assert isinstance(assemble_stmt, ir.AssignStmt)
         assert isinstance(assemble_stmt.value, ir.Call)
-        assert assemble_stmt.value.op.name == "tensor.assemble"
+        assert assemble_stmt.value.op.name == ir.get_op("tensor.assemble").name
 
         offset_tuple = assemble_stmt.value.args[2]
         assert isinstance(offset_tuple, ir.MakeTuple)
@@ -789,7 +791,7 @@ class TestTileSubscriptWrite:
         assemble_stmt = write_tile.body.stmts[1]
         assert isinstance(assemble_stmt, ir.AssignStmt)
         assert isinstance(assemble_stmt.value, ir.Call)
-        assert assemble_stmt.value.op.name == "tile.assemble"
+        assert assemble_stmt.value.op.name == ir.get_op("tile.assemble").name
 
         offset_tuple = assemble_stmt.value.args[2]
         assert isinstance(offset_tuple, ir.MakeTuple)

--- a/tests/ut/language/parser/test_task_id_dsl.py
+++ b/tests/ut/language/parser/test_task_id_dsl.py
@@ -16,6 +16,9 @@ from pypto import ir
 from pypto.language.parser.diagnostics import ParserTypeError
 from pypto.pypto_core import DataType
 
+_OP_SYSTEM_TASK_DUMMY = ir.get_op("system.task_dummy").name
+_OP_SYSTEM_TASK_INVALID = ir.get_op("system.task_invalid").name
+
 
 def _first_runtime_scope(stmt):
     if isinstance(stmt, ir.RuntimeScopeStmt):
@@ -74,7 +77,7 @@ class TestTaskIdNamespace:
         scope = _first_runtime_scope(fn.body)
         assert scope is not None
         # The ``prev_tid = None`` assignment lowers to a system.task_invalid Call.
-        invalid_calls = [c for c in _calls_in(scope.body) if c.op.name == "system.task_invalid"]
+        invalid_calls = [c for c in _calls_in(scope.body) if c.op.name == _OP_SYSTEM_TASK_INVALID]
         assert len(invalid_calls) == 1
         assert isinstance(invalid_calls[0].type, ir.ScalarType)
         assert invalid_calls[0].type.dtype == DataType.TASK_ID
@@ -127,7 +130,7 @@ class TestTaskDummyParsing:
         assert fn is not None
         scope = _first_runtime_scope(fn.body)
         assert scope is not None
-        dummy_call = next(c for c in _calls_in(scope.body) if c.op.name == "system.task_dummy")
+        dummy_call = next(c for c in _calls_in(scope.body) if c.op.name == _OP_SYSTEM_TASK_DUMMY)
         attrs = dict(dummy_call.attrs)
         assert attrs["dummy_task"] is True
         edges = attrs["manual_dep_edges"]
@@ -160,7 +163,7 @@ class TestTaskDummyParsing:
         assert fn is not None
         scope = _first_runtime_scope(fn.body)
         assert scope is not None
-        dummy_call = next(c for c in _calls_in(scope.body) if c.op.name == "system.task_dummy")
+        dummy_call = next(c for c in _calls_in(scope.body) if c.op.name == _OP_SYSTEM_TASK_DUMMY)
         dummy_edges = dict(dummy_call.attrs)["manual_dep_edges"]
         assert len(dummy_edges) == 1
         assert isinstance(dummy_edges[0].type, ir.ScalarType)

--- a/tests/ut/language/test_unified_ops.py
+++ b/tests/ut/language/test_unified_ops.py
@@ -1216,7 +1216,7 @@ class TestPromotedSinCos:
         assert isinstance(result, Tensor)
         call = result.unwrap()
         assert isinstance(call, ir.Call)
-        assert call.op.name == "tensor.sin"
+        assert call.op.name == ir.get_op("tensor.sin").name
         result_type = call.type
         assert isinstance(result_type, ir.TensorType)
         assert result_type.dtype == DataType.FP32
@@ -1229,7 +1229,7 @@ class TestPromotedSinCos:
         assert isinstance(result, Tensor)
         call = result.unwrap()
         assert isinstance(call, ir.Call)
-        assert call.op.name == "tensor.cos"
+        assert call.op.name == ir.get_op("tensor.cos").name
         result_type = call.type
         assert isinstance(result_type, ir.TensorType)
         assert result_type.dtype == DataType.FP32
@@ -1290,7 +1290,7 @@ class TestPromotedTileSinCos:
         assert isinstance(result, Tile)
         call = result.unwrap()
         assert isinstance(call, ir.Call)
-        assert call.op.name == "tile.sin"
+        assert call.op.name == ir.get_op("tile.sin").name
         result_type = call.type
         assert isinstance(result_type, ir.TileType)
         assert result_type.dtype == DataType.FP32
@@ -1303,7 +1303,7 @@ class TestPromotedTileSinCos:
         assert isinstance(result, Tile)
         call = result.unwrap()
         assert isinstance(call, ir.Call)
-        assert call.op.name == "tile.cos"
+        assert call.op.name == ir.get_op("tile.cos").name
         result_type = call.type
         assert isinstance(result_type, ir.TileType)
         assert result_type.dtype == DataType.FP32


### PR DESCRIPTION
## Summary

`.claude/rules/operator-identity-checks.md` requires an operator-name literal to reach a comparison through `get_op(...)`, which raises on an unregistered name, rather than as a bare string. A bare `call.op.name == "tile.reshaep"` silently evaluates to `False`; routed through the getter the same typo raises `ValueError` at the comparison site. 369 bare literals across 34 files still did the unrouted comparison, so renaming an operator today can silently drop coverage or take a wrong branch instead of failing.

This converts all of them and adds a pre-commit gate so the count cannot grow back. All 145 distinct names resolve against the live registry, so no operator needed registering and no site needed the rule's documented fallback. There is no behavior change for compiled programs: every converted expression evaluates to the same operator name it did before. The observable difference is at import and comparison time — a stale name now raises instead of quietly comparing unequal.

Two of the converted sites were actively silent rather than merely fragile:

- **`python/pypto/debug/torch_codegen.py`** — `_CROSS_CORE_SPLIT_OPS` was four bare literals behind `if op_name in _CROSS_CORE_SPLIT_OPS`. Renaming `tile.tpop_from_aiv` would drop that op's handler and send the call down the fallback codegen path with nothing failing.
- **`tests/ut/ir/transforms/test_flatten_tile_nd_to_2d.py`** — twelve `assert "tile.batch_matmul" not in names` assertions pass *vacuously* once the operator is renamed, surviving as green coverage of nothing.

## Changes

- **`tests/lint/check_op_name_literals.py`** (new) — AST-based gate, wired into `.pre-commit-config.yaml` beside `check-no-broad-raises`. It parses rather than greps, so prose in comments and docstrings is never flagged. It reports four shapes: direct `==`/`!=`, `in`/`not in` against a collection literal, a sequence compare against a `.op.name` comprehension, and a module-level operator-name collection.
- **32 test files** — 364 literals routed through the getter. A name used once in a file is inlined as `ir.get_op("x").name`; a name used twice or more gets a module-level `_OP_*` constant, so the literal is validated once at import instead of being re-resolved at every comparison.
- **`python/pypto/debug/torch_codegen.py`**, **`python/pypto/language/parser/ast_parser.py`** — 5 literals in product code, including the silent membership branch above.

Literals by shape: 244 direct `==`/`!=`, 6 collection membership, 55 module-level collection elements, 64 sequence-compare / bound-list membership / `.count(...)` arguments.

The gate was hardened during review; three reported defects were each reproduced before being fixed, and each ships with a regression case. `frozenset(...)` / `set(...)` / `list(...)` / `tuple(...)` builders are unwrapped before the literal scan, so the immutable form this checker's own remediation message recommends is covered. Bound-collection tracking is per lexical scope with shadowing on reassignment, so a `names` holding operator names in one function cannot cause a false positive in another. Exemptions match the exact `ast.Constant` node, so a construction literal cannot suppress a real comparison of the same name on the same line.

**Scope the gate deliberately excludes.** Callee names carry no dot and are never reported, keeping `"k1"`, `"consumer"` and `"main_incore_1"` out of scope as the rule requires. Construction and name-keyed lookups (`ir.Op(...)`, `get_op(...)`, `create_op_call(...)`) are exempt, as are `@pytest.mark.parametrize` lists feeding `get_op(op_name)` — the getter already raises on a typo there. Two blind spots are documented in the checker's module docstring: dispatch tables whose *keys* are operator-name literals (e.g. `_OP_MAP` in `torch_codegen.py`), and a literal passed into a helper that performs the comparison internally. The known instances of the latter are converted here; neither is detectable without widening the heuristic or adding interprocedural analysis, so both are left for a separate decision.

No IR, API, or migration impact, and no follow-up is required by this range.

## Verification

All commands ran in the transaction's validation runner at the pushed head `cb4f3001`, which refuses to run unless `HEAD` matches the prepared commit and the checkout is clean before and after:

- `python -m pytest tests/ut -n auto --maxprocesses 8 -q`: exit 0 — 9187 passed, 2 skipped in 144.04s (both skips pre-existing)
- `ruff check tests python`: exit 0
- `ruff format --check tests python`: exit 0
- `python tests/lint/check_op_name_literals.py`: exit 0
- `python tests/lint/check_no_broad_raises.py`: exit 0
- `python tests/lint/check_headers.py`: exit 0 — 1037 files
- `python tests/lint/check_english_only.py`: exit 0

Run separately against the same tree:

- `python tests/lint/check_docs_en_zh_parity.py`, `check_docs_nav.py`, `check_docs_symbol_coverage.py`: exit 0
- Gate self-test — 20 cases: all four shapes flagged, the three review-reported defects each reproduced-then-fixed, and nine false-positive guards silent (callee names, already-routed literals, already-routed `frozenset`, the registry's own `get_op(x).name == x` tests, construction calls, `@pytest.mark.parametrize` lists feeding `get_op`, non-operator dotted strings, mixed-type collections, single-element collections)
