### PR TITLE
docs(examples): restore the in-DSL if/else dynamic valid_shape pattern

### DIFF
--- a/examples/intermediate/06_dyn_valid_shape.py
+++ b/examples/intermediate/06_dyn_valid_shape.py
@@ -7,32 +7,44 @@
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
 
-"""Dynamic valid_shape examples.
+"""Dynamic valid_shape examples -- scalar, if/else, and loop patterns.
 
-Demonstrates a DSL pattern where the valid length of a tile is a runtime
-scalar (caller-provided) and used inside ``pl.load(..., valid_shape=...)``
-to bound the active region of the tile, then padded via
+A tile's *valid* region may be narrower than its physical shape.  Pass the
+valid extent to ``pl.load(..., valid_shape=...)`` and mask the remainder with
 ``pl.tile.fillpad``::
 
-    tile = pl.load(..., valid_shape=[rows, vlen])   # vlen is a runtime scalar
-    padded = pl.tile.fillpad(tile, pad_value=PadValue.min)
+    tile   = pl.load(..., valid_shape=[rows, vlen])
+    padded = pl.tile.fillpad(tile, pad_value=pl.PadValue.min)
 
-JIT note
---------
-The pre-JIT version of this example also showed the same pattern with
-``vlen`` selected via ``if/else`` (and inside a per-block loop).  In the
-@pl.jit world the specializer's alpha-renamer rewrites the rebinding of
-``vlen`` in the else-branch to a distinct alias, which then fails
-``ConvertToSSA`` ("used outside its defining scope").  The current
-recommended workaround is to push the per-call/per-iteration choice of
-``vlen`` to the *caller* and pass a single scalar parameter -- as shown
-below.  Restoring the in-DSL ``if/else`` pattern requires a JIT
-specializer fix (see the comments in ``examples/models/qwen3_jit/``).
+Where ``vlen`` comes from decides how much freedom it has at runtime.  The
+three kernels below cover the spectrum:
 
-Note: ``__main__`` runs ``lower`` only (no code generation or device execution).
-Full end-to-end execution is exercised under
+1. ``dyn_valid_shape`` -- ``vlen`` is a scalar *parameter*.
+2. ``dyn_valid_shape_if_else`` -- ``vlen`` is selected by an in-DSL
+   ``if``/``else`` from values read out of a config tensor.
+3. ``dyn_valid_shape_loop`` -- the ragged-tail idiom: loop over blocks and
+   take the partial length on the last iteration.
+
+Scalar parameters are specialization constants
+----------------------------------------------
+Under ``@pl.jit`` a scalar argument (``pl.INDEX``, ``pl.FP32``, ...) is a
+*specialization constant*: the specializer inlines its value at every use
+site, so ``dyn_valid_shape`` compiles a separate kernel per distinct ``vlen``
+and the generated ``pto.alloc_tile`` carries a constant ``valid_col``.  That
+is the right trade when the caller knows ``vlen`` at dispatch time -- it is
+the simplest form and it constant-folds cleanly.
+
+It also means an ``if``/``else`` over scalar *parameters* is resolved at
+specialization time, not at runtime.  For a branch that survives to the
+device, the selected values must be genuinely dynamic -- read them from a
+tensor, as kernels 2 and 3 do.  Those lower to a real ``scf.if`` whose result
+feeds the tile's ``valid_col``.
+
+Note: ``__main__`` runs ``lower`` only (no code generation or device
+execution).  Lowering is also exercised by
 ``tests/st/codegen/dsl/test_dyn_valid_shape_loop.py`` and
-``tests/st/codegen/dsl/test_dynamic_valid_shape_if_else.py``.
+``tests/st/codegen/dsl/test_dynamic_valid_shape_if_else.py``; the generated
+PTO is asserted in ``tests/ut/codegen/test_dynamic_valid_shape_if_else.py``.
 
 Run:  python examples/intermediate/06_dyn_valid_shape.py
 """
@@ -48,6 +60,7 @@ import torch
 # Tile / tensor dimensions
 Q_TILE = 64
 BLOCK_COL = 64
+N_ROW = 128  # sij_buf rows = Q_TILE * max_blocks(2)
 
 
 @pl.jit
@@ -57,10 +70,11 @@ def dyn_valid_shape(
     vlen: pl.INDEX,
     output: pl.Out[pl.Tensor],
 ):
-    """Load with caller-provided valid_shape, fillpad, then scale.
+    """Load with a caller-provided valid_shape, fillpad, then scale.
 
-    The caller passes either the partial-block length or the full-block
-    length; the kernel does not need to branch internally.
+    ``vlen`` is a scalar parameter and therefore a specialization constant:
+    each distinct value compiles its own kernel with a constant ``valid_col``.
+    Use this form when the caller already knows the valid length.
     """
     with pl.at(level=pl.Level.CORE_GROUP):
         s_tile = pl.load(
@@ -76,17 +90,93 @@ def dyn_valid_shape(
     return output
 
 
+@pl.jit
+def dyn_valid_shape_if_else(
+    data: pl.Tensor,
+    cfg: pl.Tensor,
+    output: pl.Out[pl.Tensor],
+):
+    """Select the valid length with an in-DSL ``if``/``else``, then load+fillpad.
+
+    ``cfg`` holds ``[is_last, last_valid_len, full_len]``.  Reading them makes
+    them runtime values, so the branch is not folded away: it lowers to an
+    ``scf.if`` whose result becomes the tile's ``valid_col``.  The tile type is
+    uniform across both branches -- only the runtime valid length differs.
+    """
+    with pl.at(level=pl.Level.CORE_GROUP):
+        is_last = pl.read(cfg, [0])
+        last_valid_len = pl.read(cfg, [1])
+        full_len = pl.read(cfg, [2])
+        if is_last == 1:
+            vlen = last_valid_len
+        else:
+            vlen = full_len
+        s_tile = pl.load(
+            data,
+            [0, 0],
+            [Q_TILE, BLOCK_COL],
+            valid_shape=[Q_TILE, vlen],
+            target_memory=pl.MemorySpace.Vec,
+        )
+        s_padded = pl.tile.fillpad(s_tile, pad_value=pl.PadValue.min)
+        pl.store(s_padded, [0, 0], output)
+    return output
+
+
+@pl.jit
+def dyn_valid_shape_loop(
+    sij_buf: pl.Tensor,
+    cfg: pl.Tensor,
+    output: pl.Out[pl.Tensor],
+):
+    """Loop over blocks, taking the partial valid length on the last one.
+
+    ``cfg`` holds ``[n_blocks, last_valid_len, block_size]``.  The trip count
+    is a runtime value, so the loop lowers to an ``scf.for`` and the
+    per-iteration ``if``/``else`` to an ``scf.if`` nested inside it.  This is
+    the ragged-tail idiom used by the paged-attention kernels.
+    """
+    with pl.at(level=pl.Level.CORE_GROUP):
+        n_blocks = pl.cast(pl.read(cfg, [0]), pl.INDEX)
+        last_valid_len = pl.cast(pl.read(cfg, [1]), pl.INDEX)
+        block_size = pl.cast(pl.read(cfg, [2]), pl.INDEX)
+        for i in pl.range(n_blocks):
+            if i == n_blocks - 1:
+                vlen = last_valid_len
+            else:
+                vlen = block_size
+            s_tile = pl.load(
+                sij_buf,
+                [i * Q_TILE, 0],
+                [Q_TILE, BLOCK_COL],
+                valid_shape=[Q_TILE, vlen],
+                target_memory=pl.MemorySpace.Vec,
+            )
+            s_padded = pl.tile.fillpad(s_tile, pad_value=pl.PadValue.min)
+            pl.store(s_padded, [i * Q_TILE, 0], output)
+    return output
+
+
 if __name__ == "__main__":
     # Smoke test via lower (no code generation or device execution required).
-    # Same kernel, two different valid_shape values: full block (64) and
-    # partial last block (32). Both concrete vlen specializations run through
-    # the pass pipeline independently.
     data = torch.randn(Q_TILE, BLOCK_COL, dtype=torch.float32)
     out = torch.zeros(Q_TILE, BLOCK_COL, dtype=torch.float32)
 
+    # Same kernel, two vlen values: full block (64) and partial last block (32).
+    # Each is its own specialization and runs through the pipeline independently.
     prog_full = dyn_valid_shape.lower(data, 0.5, 64, out)
     print(f"dyn_valid_shape (full): {len(prog_full.functions)} fn(s)")
-
     prog_partial = dyn_valid_shape.lower(data, 0.5, 32, out)
     print(f"dyn_valid_shape (partial): {len(prog_partial.functions)} fn(s)")
+
+    # One specialization covers both branches: is_last is read at runtime.
+    cfg = torch.tensor([1, 48, BLOCK_COL], dtype=torch.int64)
+    prog_if_else = dyn_valid_shape_if_else.lower(data, cfg, out)
+    print(f"dyn_valid_shape_if_else: {len(prog_if_else.functions)} fn(s)")
+
+    sij_buf = torch.randn(N_ROW, BLOCK_COL, dtype=torch.float32)
+    loop_out = torch.zeros(N_ROW, BLOCK_COL, dtype=torch.float32)
+    loop_cfg = torch.tensor([2, 48, BLOCK_COL], dtype=torch.int64)
+    prog_loop = dyn_valid_shape_loop.lower(sij_buf, loop_cfg, loop_out)
+    print(f"dyn_valid_shape_loop: {len(prog_loop.functions)} fn(s)")
     print("OK")

--- a/examples/intermediate/__init__.py
+++ b/examples/intermediate/__init__.py
@@ -15,7 +15,7 @@ Intermediate examples — real-kernel patterns, ordered by complexity.
   03_normalization.py   — RMSNorm, LayerNorm
   04_matmul_acc.py      — cube unit matmul with K-dimension tiling/accumulation
   05_assemble.py        — tile assembly patterns (Acc->Mat, Vec->Vec)
-  06_dyn_valid_shape.py — dynamic valid_shape via if/else and loop patterns
+  06_dyn_valid_shape.py — dynamic valid_shape via scalar, if/else and loop patterns
 """
 
 import importlib

--- a/tests/st/codegen/dsl/test_dyn_valid_shape_loop.py
+++ b/tests/st/codegen/dsl/test_dyn_valid_shape_loop.py
@@ -7,60 +7,51 @@
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
 
-"""Lowering smoke tests for dynamic valid_shape (single-block @pl.jit kernel).
+"""Lowering smoke tests for the per-block loop + if/else valid_shape idiom.
 
-The pre-JIT version of this test exercised a per-block loop with an in-DSL
-``if/else`` that selected ``vlen`` per iteration.  In the @pl.jit world the
-specializer's alpha-renamer rewrites the rebinding of ``vlen`` in the
-else-branch to a distinct alias, which then fails ``ConvertToSSA`` ("used
-outside its defining scope").  The current recommended workaround --
-documented in ``examples/intermediate/06_dyn_valid_shape.py`` -- is to push the
-per-call/per-iteration choice of ``vlen`` to the caller and pass a single
-scalar parameter.
+``dyn_valid_shape_loop`` reads ``[n_blocks, last_valid_len, block_size]`` from
+a config tensor and loops over blocks, selecting the partial valid length on
+the last iteration.  All three values are runtime reads, so the loop lowers to
+an ``scf.for`` with a runtime trip count and the per-iteration ``if``/``else``
+to an ``scf.if`` nested inside it -- the ragged-tail idiom used by the
+paged-attention kernels.
 
-These tests verify that the JIT pipeline (specialize + full pass pipeline)
-succeeds for both vlen values that previously appeared inside the if/else:
+The cases below vary the config the single specialization runs with:
 
-  * full-block vlen (= BLOCK_COL): ``valid_shape`` matches the physical
-    tile shape; ``fillpad`` is a no-op.
-  * partial-block vlen (< BLOCK_COL): ``valid_shape`` < physical;
-    ``fillpad`` writes the padding region.
+  * ragged tail: last block partial (``last_valid_len < block_size``)
+  * uniform: every block full (``last_valid_len == block_size``), so the
+    per-iteration fillpad is a no-op
 """
 
 import pytest
 import torch
-from examples.intermediate.dyn_valid_shape import BLOCK_COL, Q_TILE, dyn_valid_shape
+from examples.intermediate.dyn_valid_shape import BLOCK_COL, N_ROW, dyn_valid_shape_loop
 
-# Original tests carried this constant for the multi-block tensor row count
-# (2 blocks of Q_TILE=64).  The single-block @pl.jit kernel is per-block, so
-# the constant only survives as a documentation marker.
-N_ROW = Q_TILE
+# sij_buf holds N_ROW rows = 2 blocks of Q_TILE.
+N_BLOCKS = 2
 
 
 class TestLoopDynValidShape:
-    """Lowering smoke for dynamic valid_shape across both block lengths.
+    """Lowering smoke for the loop + if/else valid_shape selection."""
 
-    The two cases mirror the two branches of the original in-DSL ``if/else``:
-    the partial-last-block path (``vlen < BLOCK_COL``) and the full-block
-    path (``vlen == BLOCK_COL``).
-    """
-
-    def test_partial_block(self):
-        """Partial vlen (48) -- mirrors the ``is_last`` branch of the old loop."""
-        data = torch.zeros((Q_TILE, BLOCK_COL), dtype=torch.float32)
-        out = torch.zeros((Q_TILE, BLOCK_COL), dtype=torch.float32)
-        program = dyn_valid_shape.lower(data, 2.0, 48, out)
+    def test_ragged_tail(self):
+        """Last block partial (48) -- the if/else takes its ``is_last`` branch."""
+        sij_buf = torch.zeros((N_ROW, BLOCK_COL), dtype=torch.float32)
+        out = torch.zeros((N_ROW, BLOCK_COL), dtype=torch.float32)
+        cfg = torch.tensor([N_BLOCKS, 48, BLOCK_COL], dtype=torch.int64)
+        program = dyn_valid_shape_loop.lower(sij_buf, cfg, out)
         # Post-pass program must be non-empty and well-formed.
         assert program is not None
         assert len(program.functions) >= 1, (
             f"expected >= 1 function in post-pass IR, got {len(program.functions)}"
         )
 
-    def test_full_block(self):
-        """Full vlen (= BLOCK_COL) -- mirrors the non-last branch of the old loop."""
-        data = torch.zeros((Q_TILE, BLOCK_COL), dtype=torch.float32)
-        out = torch.zeros((Q_TILE, BLOCK_COL), dtype=torch.float32)
-        program = dyn_valid_shape.lower(data, 2.0, BLOCK_COL, out)
+    def test_uniform_blocks(self):
+        """Every block full (= BLOCK_COL) -- fillpad is a no-op on all iterations."""
+        sij_buf = torch.zeros((N_ROW, BLOCK_COL), dtype=torch.float32)
+        out = torch.zeros((N_ROW, BLOCK_COL), dtype=torch.float32)
+        cfg = torch.tensor([N_BLOCKS, BLOCK_COL, BLOCK_COL], dtype=torch.int64)
+        program = dyn_valid_shape_loop.lower(sij_buf, cfg, out)
         assert program is not None
         assert len(program.functions) >= 1, (
             f"expected >= 1 function in post-pass IR, got {len(program.functions)}"

--- a/tests/st/codegen/dsl/test_dynamic_valid_shape_if_else.py
+++ b/tests/st/codegen/dsl/test_dynamic_valid_shape_if_else.py
@@ -7,52 +7,50 @@
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
 
-"""Lowering smoke tests for dynamic valid_shape branch selection.
+"""Lowering smoke tests for dynamic valid_shape selected by an in-DSL if/else.
 
-The pre-JIT version of this test exercised a single-call kernel that
-selected ``vlen`` via an in-DSL ``if/else`` based on an ``is_last`` flag.
-In the @pl.jit world the specializer's alpha-renamer rewrites the
-rebinding of ``vlen`` in the else-branch to a distinct alias, which then
-fails ``ConvertToSSA`` ("used outside its defining scope").  The current
-recommended workaround -- documented in
-``examples/intermediate/06_dyn_valid_shape.py`` -- is to push the
-``vlen`` selection to the caller.
+``dyn_valid_shape_if_else`` reads ``[is_last, last_valid_len, full_len]`` from
+a config tensor and picks the tile's valid length with an in-DSL ``if``/``else``.
+Because the three values are read at runtime rather than passed as scalar
+parameters, the branch is not folded at specialization time -- it lowers to an
+``scf.if`` whose result feeds the tile's ``valid_col``.
 
-These tests verify that the JIT pipeline succeeds for both branches of
-the original ``if/else``:
+One specialization covers both branches (only ``cfg`` contents differ), so
+these tests vary ``is_last`` to confirm the shared kernel lowers for either
+config:
 
-  * is_last=True  -> ``vlen = last_valid_len`` (partial)
-  * is_last=False -> ``vlen = full_len`` (full)
+  * is_last=1 -> ``vlen = last_valid_len`` (partial, ``vlen < BLOCK_COL``)
+  * is_last=0 -> ``vlen = full_len``       (full, fillpad is a no-op)
+
+The generated PTO is asserted in
+``tests/ut/codegen/test_dynamic_valid_shape_if_else.py``.
 """
 
 import pytest
 import torch
-from examples.intermediate.dyn_valid_shape import BLOCK_COL, Q_TILE, dyn_valid_shape
+from examples.intermediate.dyn_valid_shape import BLOCK_COL, Q_TILE, dyn_valid_shape_if_else
 
 
 class TestDynValidShapeIfElse:
-    """Lowering smoke for the two branches of the (now caller-side) if/else.
-
-    The original kernel computed ``vlen`` from an ``is_last`` flag inside
-    the kernel.  Each test below picks the same ``vlen`` value the kernel
-    would have used if the corresponding branch had been taken.
-    """
+    """Lowering smoke for both branches of the in-DSL if/else."""
 
     def test_last_block(self):
-        """is_last=True path: partial valid_len (48) -- vlen < physical."""
+        """is_last=1 path: partial valid_len (48) -- vlen < physical."""
         data = torch.zeros((Q_TILE, BLOCK_COL), dtype=torch.float32)
         out = torch.zeros((Q_TILE, BLOCK_COL), dtype=torch.float32)
-        program = dyn_valid_shape.lower(data, 2.0, 48, out)
+        cfg = torch.tensor([1, 48, BLOCK_COL], dtype=torch.int64)
+        program = dyn_valid_shape_if_else.lower(data, cfg, out)
         assert program is not None
         assert len(program.functions) >= 1, (
             f"expected >= 1 function in post-pass IR, got {len(program.functions)}"
         )
 
     def test_full_block(self):
-        """is_last=False path: full valid_len (= BLOCK_COL) -- fillpad no-op."""
+        """is_last=0 path: full valid_len (= BLOCK_COL) -- fillpad no-op."""
         data = torch.zeros((Q_TILE, BLOCK_COL), dtype=torch.float32)
         out = torch.zeros((Q_TILE, BLOCK_COL), dtype=torch.float32)
-        program = dyn_valid_shape.lower(data, 2.0, BLOCK_COL, out)
+        cfg = torch.tensor([0, 48, BLOCK_COL], dtype=torch.int64)
+        program = dyn_valid_shape_if_else.lower(data, cfg, out)
         assert program is not None
         assert len(program.functions) >= 1, (
             f"expected >= 1 function in post-pass IR, got {len(program.functions)}"

--- a/tests/ut/codegen/test_dynamic_valid_shape_if_else.py
+++ b/tests/ut/codegen/test_dynamic_valid_shape_if_else.py
@@ -27,11 +27,18 @@ if/else, then performing a single load+fillpad with that computed length:
 
 The tile buffer type is uniform (same v_row=?, v_col=?, pad=min) regardless
 of which branch executed. Only the runtime valid-shape value differs.
+
+The programs below are written with ``@pl.program`` and explicit
+``pl.Scalar[...]`` parameters. The final section covers the same pattern
+reached through ``@pl.jit``, where the specializer must leave the in-DSL
+``if``/``else`` intact for the branch to survive to an ``scf.if``.
 """
 
 # DSL function bodies are parsed as AST, not executed — suppress pyright errors
 # from type-checking annotations that reference module-level names.
 # pyright: reportUndefinedVariable=false
+
+import re
 
 import pypto.language as pl
 import pytest
@@ -214,6 +221,157 @@ def test_loop_if_else_dyn_valid_shape_has_scf_for(loop_mlir: str):
 def test_loop_if_else_dyn_valid_shape_has_scf_if(loop_mlir: str):
     """Verify the if/else generates scf.if in the MLIR output."""
     assert "scf.if" in loop_mlir, f"Expected scf.if in MLIR output:\n{loop_mlir}"
+
+
+# ---------------------------------------------------------------------------
+# The same patterns reached through @pl.jit
+# ---------------------------------------------------------------------------
+#
+# The JIT specializer rewrites the user's function into the @pl.program form
+# above. It must leave an in-DSL if/else that rebinds one name in both branches
+# alone: aliasing the else-branch binding to a distinct name (`vlen_v1`) would
+# make ConvertToSSA reject the read as "used outside its defining scope".
+# `tests/ut/jit/test_specializer.py::test_if_else_branch_rebind` guards the
+# rewrite at source level; these tests guard the whole path down to PTO.
+
+
+def _jit_device_mlir(jit_func, *args) -> str:
+    """Lower a @pl.jit kernel and run PTO codegen on its device function."""
+    backend.reset_for_testing()
+    backend.set_backend_type(BackendType.Ascend910B)
+
+    program = jit_func.lower(*args)
+    device_funcs = [f for f in program.functions.values() if f.func_type != ir.FunctionType.Orchestration]
+    assert len(device_funcs) == 1, (
+        f"expected exactly one device function, got {[f.name for f in device_funcs]}"
+    )
+    single_func_program = ir.Program([device_funcs[0]], device_funcs[0].name, program.span)
+    return codegen.PTOCodegen().generate(single_func_program)
+
+
+def _s_tile_alloc(mlir: str) -> str:
+    """Return the ``pto.alloc_tile`` line that allocates ``s_tile``."""
+    alloc_lines = [line.strip() for line in mlir.split("\n") if "pto.alloc_tile" in line]
+    s_tile_allocs = [line for line in alloc_lines if "s_tile" in line]
+    assert len(s_tile_allocs) >= 1, f"Expected s_tile alloc, got alloc_lines: {alloc_lines}"
+    return s_tile_allocs[0]
+
+
+def _valid_col_operand(alloc_line: str) -> str:
+    """Extract the ``valid_col`` operand from a ``pto.alloc_tile`` line."""
+    match = re.search(r"valid_col = (\S+)", alloc_line)
+    assert match is not None, f"No valid_col operand in alloc: {alloc_line}"
+    return match.group(1)
+
+
+@pytest.fixture(scope="module")
+def jit_if_else_mlir() -> str:
+    """Codegen the @pl.jit if/else kernel once for all tests in this module."""
+    torch = pytest.importorskip("torch")
+    from examples.intermediate.dyn_valid_shape import (  # noqa: PLC0415
+        BLOCK_COL,
+        Q_TILE,
+        dyn_valid_shape_if_else,
+    )
+
+    data = torch.zeros((Q_TILE, BLOCK_COL), dtype=torch.float32)
+    out = torch.zeros((Q_TILE, BLOCK_COL), dtype=torch.float32)
+    cfg = torch.tensor([1, 48, BLOCK_COL], dtype=torch.int64)
+    return _jit_device_mlir(dyn_valid_shape_if_else, data, cfg, out)
+
+
+@pytest.fixture(scope="module")
+def jit_loop_mlir() -> str:
+    """Codegen the @pl.jit loop + if/else kernel once for all tests in this module."""
+    torch = pytest.importorskip("torch")
+    from examples.intermediate.dyn_valid_shape import (  # noqa: PLC0415
+        BLOCK_COL,
+        N_ROW,
+        dyn_valid_shape_loop,
+    )
+
+    sij_buf = torch.zeros((N_ROW, BLOCK_COL), dtype=torch.float32)
+    out = torch.zeros((N_ROW, BLOCK_COL), dtype=torch.float32)
+    cfg = torch.tensor([2, 48, BLOCK_COL], dtype=torch.int64)
+    return _jit_device_mlir(dyn_valid_shape_loop, sij_buf, cfg, out)
+
+
+@pytest.fixture(scope="module")
+def jit_scalar_param_mlir() -> str:
+    """Codegen the @pl.jit scalar-parameter kernel (the specialized-constant form)."""
+    torch = pytest.importorskip("torch")
+    from examples.intermediate.dyn_valid_shape import (  # noqa: PLC0415
+        BLOCK_COL,
+        Q_TILE,
+        dyn_valid_shape,
+    )
+
+    data = torch.zeros((Q_TILE, BLOCK_COL), dtype=torch.float32)
+    out = torch.zeros((Q_TILE, BLOCK_COL), dtype=torch.float32)
+    return _jit_device_mlir(dyn_valid_shape, data, 2.0, 48, out)
+
+
+def test_jit_if_else_survives_specialization(jit_if_else_mlir: str):
+    """The in-DSL if/else must reach PTO as a real scf.if.
+
+    Regression guard: the specializer previously alpha-renamed the else-branch
+    rebinding of ``vlen``, which failed ConvertToSSA outright.
+    """
+    assert "scf.if" in jit_if_else_mlir, f"Expected scf.if in MLIR output:\n{jit_if_else_mlir}"
+
+
+def test_jit_if_else_valid_col_is_runtime(jit_if_else_mlir: str):
+    """The s_tile alloc's valid_col comes from the branch, not a folded constant.
+
+    ``cfg`` is read at runtime, so neither branch value is known at
+    specialization time and ``valid_col`` must be an SSA operand rather than a
+    ``%c<n>`` literal.
+    """
+    alloc = _s_tile_alloc(jit_if_else_mlir)
+    operand = _valid_col_operand(alloc)
+    assert not re.fullmatch(r"%c\d+(_\w+)?", operand), (
+        f"valid_col was constant-folded to {operand}; expected a runtime operand: {alloc}"
+    )
+    assert "v_col=?" in alloc, f"Expected dynamic v_col=? in s_tile alloc: {alloc}"
+
+
+def test_jit_if_else_has_fillpad_with_pad_min(jit_if_else_mlir: str):
+    """The padded tile keeps pad=3 (PadValue.min) through the JIT path."""
+    assert "pto.tfillpad" in jit_if_else_mlir, f"Expected pto.tfillpad in MLIR output:\n{jit_if_else_mlir}"
+    alloc_lines = [line.strip() for line in jit_if_else_mlir.split("\n") if "pto.alloc_tile" in line]
+    padded_allocs = [line for line in alloc_lines if "s_padded" in line]
+    assert len(padded_allocs) >= 1, f"Expected s_padded alloc, got alloc_lines: {alloc_lines}"
+    assert "pad=3>" in padded_allocs[0], f"Expected pad=3 (PadValue.min) in padded alloc: {padded_allocs[0]}"
+
+
+def test_jit_loop_has_scf_for_and_scf_if(jit_loop_mlir: str):
+    """The runtime trip count and the per-iteration branch both survive."""
+    assert "scf.for" in jit_loop_mlir, f"Expected scf.for in MLIR output:\n{jit_loop_mlir}"
+    assert "scf.if" in jit_loop_mlir, f"Expected scf.if in MLIR output:\n{jit_loop_mlir}"
+
+
+def test_jit_loop_valid_col_is_runtime(jit_loop_mlir: str):
+    """The per-iteration valid_col is the scf.if result, not a constant."""
+    alloc = _s_tile_alloc(jit_loop_mlir)
+    operand = _valid_col_operand(alloc)
+    assert not re.fullmatch(r"%c\d+(_\w+)?", operand), (
+        f"valid_col was constant-folded to {operand}; expected a runtime operand: {alloc}"
+    )
+
+
+def test_jit_scalar_param_valid_col_is_constant(jit_scalar_param_mlir: str):
+    """A scalar *parameter* is a specialization constant, so valid_col folds.
+
+    Counterpart to :func:`test_jit_if_else_valid_col_is_runtime`: the
+    specializer inlines scalar arguments at their use sites, so ``vlen=48``
+    reaches codegen as a literal and each distinct value compiles its own
+    kernel. Runtime selection requires reading the value from a tensor.
+    """
+    alloc = _s_tile_alloc(jit_scalar_param_mlir)
+    operand = _valid_col_operand(alloc)
+    assert re.fullmatch(r"%c48(_\w+)?", operand), (
+        f"expected valid_col folded to the constant 48, got {operand}: {alloc}"
+    )
 
 
 if __name__ == "__main__":

--- a/tests/ut/codegen/test_dynamic_valid_shape_if_else.py
+++ b/tests/ut/codegen/test_dynamic_valid_shape_if_else.py
@@ -38,6 +38,7 @@ reached through ``@pl.jit``, where the specializer must leave the in-DSL
 # from type-checking annotations that reference module-level names.
 # pyright: reportUndefinedVariable=false
 
+import importlib
 import re
 
 import pypto.language as pl
@@ -264,51 +265,50 @@ def _valid_col_operand(alloc_line: str) -> str:
     return match.group(1)
 
 
+def _dyn_valid_shape_example():
+    """Import the numbered example module.
+
+    The package registers an unnumbered ``dyn_valid_shape`` alias in
+    ``sys.modules``, but that alias exists only at runtime, so a static import
+    of it does not resolve. Import the real module name instead, as
+    ``tests/st/runtime/framework_and_models/test_paged_attention_spmd.py`` does.
+    """
+    return importlib.import_module("examples.intermediate.06_dyn_valid_shape")
+
+
 @pytest.fixture(scope="module")
 def jit_if_else_mlir() -> str:
     """Codegen the @pl.jit if/else kernel once for all tests in this module."""
     torch = pytest.importorskip("torch")
-    from examples.intermediate.dyn_valid_shape import (  # noqa: PLC0415
-        BLOCK_COL,
-        Q_TILE,
-        dyn_valid_shape_if_else,
-    )
+    example = _dyn_valid_shape_example()
 
-    data = torch.zeros((Q_TILE, BLOCK_COL), dtype=torch.float32)
-    out = torch.zeros((Q_TILE, BLOCK_COL), dtype=torch.float32)
-    cfg = torch.tensor([1, 48, BLOCK_COL], dtype=torch.int64)
-    return _jit_device_mlir(dyn_valid_shape_if_else, data, cfg, out)
+    data = torch.zeros((example.Q_TILE, example.BLOCK_COL), dtype=torch.float32)
+    out = torch.zeros((example.Q_TILE, example.BLOCK_COL), dtype=torch.float32)
+    cfg = torch.tensor([1, 48, example.BLOCK_COL], dtype=torch.int64)
+    return _jit_device_mlir(example.dyn_valid_shape_if_else, data, cfg, out)
 
 
 @pytest.fixture(scope="module")
 def jit_loop_mlir() -> str:
     """Codegen the @pl.jit loop + if/else kernel once for all tests in this module."""
     torch = pytest.importorskip("torch")
-    from examples.intermediate.dyn_valid_shape import (  # noqa: PLC0415
-        BLOCK_COL,
-        N_ROW,
-        dyn_valid_shape_loop,
-    )
+    example = _dyn_valid_shape_example()
 
-    sij_buf = torch.zeros((N_ROW, BLOCK_COL), dtype=torch.float32)
-    out = torch.zeros((N_ROW, BLOCK_COL), dtype=torch.float32)
-    cfg = torch.tensor([2, 48, BLOCK_COL], dtype=torch.int64)
-    return _jit_device_mlir(dyn_valid_shape_loop, sij_buf, cfg, out)
+    sij_buf = torch.zeros((example.N_ROW, example.BLOCK_COL), dtype=torch.float32)
+    out = torch.zeros((example.N_ROW, example.BLOCK_COL), dtype=torch.float32)
+    cfg = torch.tensor([2, 48, example.BLOCK_COL], dtype=torch.int64)
+    return _jit_device_mlir(example.dyn_valid_shape_loop, sij_buf, cfg, out)
 
 
 @pytest.fixture(scope="module")
 def jit_scalar_param_mlir() -> str:
     """Codegen the @pl.jit scalar-parameter kernel (the specialized-constant form)."""
     torch = pytest.importorskip("torch")
-    from examples.intermediate.dyn_valid_shape import (  # noqa: PLC0415
-        BLOCK_COL,
-        Q_TILE,
-        dyn_valid_shape,
-    )
+    example = _dyn_valid_shape_example()
 
-    data = torch.zeros((Q_TILE, BLOCK_COL), dtype=torch.float32)
-    out = torch.zeros((Q_TILE, BLOCK_COL), dtype=torch.float32)
-    return _jit_device_mlir(dyn_valid_shape, data, 2.0, 48, out)
+    data = torch.zeros((example.Q_TILE, example.BLOCK_COL), dtype=torch.float32)
+    out = torch.zeros((example.Q_TILE, example.BLOCK_COL), dtype=torch.float32)
+    return _jit_device_mlir(example.dyn_valid_shape, data, 2.0, 48, out)
 
 
 def test_jit_if_else_survives_specialization(jit_if_else_mlir: str):


### PR DESCRIPTION
## Summary

`examples/intermediate/06_dyn_valid_shape.py` and both of its system tests told
users that selecting a tile's valid length with an in-DSL `if`/`else` fails
`ConvertToSSA` with *"used outside its defining scope"*, and steered them to
hoist the choice to the caller. That limitation is gone — the JIT specializer's
`_BodyTransformer.visit_If` drops then-branch-introduced names before visiting
the else-branch, so the else-branch binding is a fresh local instead of a
cross-branch alias. The example now shows the natural pattern again, and the
`@pl.jit` path it depends on is covered by tests down to generated PTO.

No product code changes; this is examples, docs and tests only. Nothing a caller
depends on changes, and there is no migration step. The example's public names do
change: it now exports `dyn_valid_shape_if_else` and `dyn_valid_shape_loop`
alongside the existing `dyn_valid_shape`, and the two system tests were updated
to match.

The old note also missed a distinction worth documenting: under `@pl.jit` a
scalar **parameter** is a specialization constant, inlined at every use site. An
`if`/`else` over scalar parameters is therefore resolved at specialization time
and folds to a constant `valid_col`, one kernel per scalar tuple. Selecting a
branch at runtime requires reading the values from a tensor, which is what the
restored kernels do.

## Changes

- `examples/intermediate/06_dyn_valid_shape.py`: dropped the stale "JIT note"
  and its caller-side workaround, which also pointed at comments in
  `examples/models/qwen3_jit/` that do not exist. Restored two kernels beside
  the scalar-parameter one: `dyn_valid_shape_if_else` reads
  `[is_last, last_valid_len, full_len]` from a config tensor and picks `vlen`
  with `if`/`else`; `dyn_valid_shape_loop` loops with a runtime trip count and
  takes the partial length on the last block. Both lower to a real `scf.if`
  feeding the tile's `valid_col`. Documented the specialization-constant rule.
- `examples/intermediate/__init__.py`: package docstring line for `06` matches
  the restored contents.
- `tests/st/codegen/dsl/`: each test now exercises the kernel it is named for.
  The two files had drifted into near-duplicates that both called the
  scalar-parameter kernel, so neither covered the `if`/`else` or the loop. They
  stay lowering-only smoke tests.
- `tests/ut/codegen/test_dynamic_valid_shape_if_else.py`: six tests covering the
  `@pl.jit` path down to PTO — `scf.if` survives specialization, `valid_col` is a
  runtime operand rather than a folded `%c<n>` literal, `pad=3` is preserved, and
  `scf.for` plus `scf.if` both appear for the loop. A negative control pins the
  specialization-constant semantics by asserting the scalar-parameter form does
  fold to `%c48`.

Reverting `visit_If` fails all five runtime-branch tests, so the previously
missing coverage is what allowed the documentation to drift.

## Verification

- `cmake --build build --parallel`: exit 0
- `python -m pytest tests/ut/`: exit 0 — 9,219 passed, 2 skipped
- `python -m pytest tests/ut/codegen tests/ut/jit tests/lint -q`: exit 0 — 1,172 passed
- `python -m pytest tests/ut/codegen/test_dynamic_valid_shape_if_else.py -q`: exit 0 — 14 passed
- `python -m pytest tests/st/codegen/dsl -q`: exit 0 — 11 passed
- `ruff check examples/intermediate tests/ut/codegen tests/st/codegen/dsl`: exit 0 — all checks passed
- `ruff format --check examples/intermediate tests/ut/codegen tests/st/codegen/dsl`: exit 0 — 51 files already formatted
- `python examples/intermediate/06_dyn_valid_shape.py`: exit 0 — all four specializations lower

The system tests are lowering-only and run no device, so this change carries no
on-device numerical evidence.