### PR TITLE
docs(ir): fix stale MemRef and TileView examples

### DIFF
--- a/docs/en/dev/ir/01-hierarchy.md
+++ b/docs/en/dev/ir/01-hierarchy.md
@@ -439,18 +439,23 @@ The `kind_` field (`ForKind` enum) distinguishes sequential (`ForKind.Sequential
 Describes memory allocation metadata shared by tensors/tiles. The memory space is
 stored on `TileType.memory_space_` for tiles; `TensorType` is canonically DDR.
 
+`MemRef` is a `Var` subclass, so it is a first-class expression. A MemRef names
+an allocation (`base_`) and a byte range within it (`byte_offset_`, `size_`);
+aliasing is answered by `MemRef.same_allocation(a, b)` and `MemRef.may_alias(a, b)`.
+
 | Field | Type | Description |
 | ----- | ---- | ----------- |
-| `addr_` | ExprPtr | Base address |
-| `size_` | size_t | Size in bytes |
-| `id_` | uint64_t | Stable MemRef identifier |
+| `base_` | VarPtr | Allocation identity — the Ptr `Var` from `tile.alloc` / `tensor.alloc`. Two MemRefs alias only if they share it. |
+| `byte_offset_` | ExprPtr | Byte offset from `base_` (0 for a full alloc, a view offset otherwise) |
+| `size_` | uint64_t | Size in bytes of this region |
+| `is_pinned_` | bool | Author-declared allocation (`pl.MemRef("name")`), until `InitMemRef` resolves it |
+| `slot_count_` | uint64_t | Equally-sized slots the declaration holds (`pl.MemRef("name", slots=N)`); 1 when `slots` is omitted |
+| `slot_index_` | ExprPtr \| None | Which slot this MemRef denotes (`l0c[k]`); None until a slot is selected, and may be a runtime value |
 
 ```python
-memref = ir.MemRef(
-    ir.ConstInt(0x1000, DataType.INT64, span),
-    1024,  # bytes
-    0     # id
-)
+# base allocation name, byte offset within it, size in bytes
+memref = ir.MemRef("mem_left_0", 0, 1024)
+assert ir.MemRef.same_allocation(memref, memref)
 ```
 
 > **Note:** `ir.Mem` is a short alias for `ir.MemorySpace`.
@@ -461,15 +466,23 @@ Describes tile layout and access pattern:
 
 | Field | Type | Description |
 | ----- | ---- | ----------- |
-| `valid_shape` | list[ExprPtr] | Valid dimensions |
+| `valid_shape` | list[ExprPtr] | Valid dimensions (empty ⇒ full shape) |
 | `stride` | list[ExprPtr] | Stride per dimension |
 | `start_offset` | ExprPtr | Starting offset |
+| `blayout` | TileLayout | Block layout (default `row_major`) |
+| `slayout` | TileLayout | Scatter layout (default `none_box`) |
+| `fractal` | uint64_t | Fractal size in **bytes**, not elements (default 512) |
+| `pad` | PadValue | Pad mode for out-of-`valid_shape` access (default `null`) |
+| `compact` | CompactMode | Partial-tile compact mode (default `null`) |
 
 ```python
-tile_view = ir.TileView()
-tile_view.valid_shape = [ir.ConstInt(16, DataType.INT64, span)] * 2
-tile_view.stride = [ir.ConstInt(1, DataType.INT64, span), ir.ConstInt(16, DataType.INT64, span)]
-tile_view.start_offset = ir.ConstInt(0, DataType.INT64, span)
+# TileView is immutable: pass every field to the constructor.
+# valid_shape / stride / start_offset accept int or Expr.
+tile_view = ir.TileView(valid_shape=[8, 16], stride=[1, 16], start_offset=0)
+
+# Expr form, for symbolic dimensions
+rows = ir.Var("rows", ir.ScalarType(DataType.INT64), span)
+symbolic_view = ir.TileView(valid_shape=[rows, ir.ConstInt(16, DataType.INT64, span)])
 ```
 
 ## Function Node

--- a/docs/en/dev/ir/02-types.md
+++ b/docs/en/dev/ir/02-types.md
@@ -32,13 +32,15 @@ span = ir.Span.unknown()
 shape = [ir.ConstInt(10, DataType.INT64, span), ir.ConstInt(20, DataType.INT64, span)]
 tensor_type = ir.TensorType(shape, DataType.FP32)
 
-# Tensor with MemRef
-memref = ir.MemRef(ir.ConstInt(0x1000, DataType.INT64, span), 800, 0)
+# Tensor with MemRef: base allocation, byte offset within it, size in bytes
+memref = ir.MemRef("mem_ddr_0", 0, 800)
 tensor_with_memref = ir.TensorType(shape, DataType.FP32, memref)
 ```
 
-`TensorType.memory_space` is always `ir.Mem.DDR`. `MemRef` carries address,
-size, and id; memory space is not stored on `MemRef` itself.
+`TensorType.memory_space` is always `ir.Mem.DDR`. A `MemRef` names an
+allocation (`base_`) and a byte range within it (`byte_offset_`, `size_`);
+memory space is not stored on `MemRef` itself. See
+[MemRef](01-hierarchy.md#memref-memory-reference) for the full field list.
 
 ### DistributedTensorType
 
@@ -106,7 +108,7 @@ stride = [ir.ConstInt(1, DataType.INT64, span), ir.ConstInt(128, DataType.INT64,
 tensor_view = ir.TensorView(stride=stride, layout=ir.TensorLayout.ND)
 
 # Tensor with both MemRef and TensorView
-memref = ir.MemRef(ir.ConstInt(0x2000, DataType.INT64, span), 16384, 1)
+memref = ir.MemRef("mem_ddr_1", 0, 16384)
 tensor_with_both = ir.TensorType([128, 256], DataType.FP16, memref=memref, tensor_view=tensor_view)
 ```
 
@@ -181,13 +183,11 @@ shape_3d = [ir.ConstInt(4, DataType.INT64, span),
             ir.ConstInt(16, DataType.INT64, span)]
 tile_type_3d = ir.TileType(shape_3d, DataType.FP16)
 
-# Tile with MemRef and TileView
-memref = ir.MemRef(ir.ConstInt(0, DataType.INT64, span), 512, 0)
+# Tile with MemRef and TileView. TileView is immutable — every field is passed
+# to the constructor; valid_shape / stride / start_offset accept int or Expr.
+memref = ir.MemRef("mem_left_0", 0, 512)
 
-tile_view = ir.TileView()
-tile_view.valid_shape = [ir.ConstInt(16, DataType.INT64, span)] * 2
-tile_view.stride = [ir.ConstInt(1, DataType.INT64, span), ir.ConstInt(16, DataType.INT64, span)]
-tile_view.start_offset = ir.ConstInt(0, DataType.INT64, span)
+tile_view = ir.TileView(valid_shape=[8, 16], stride=[1, 16], start_offset=0)
 
 tile_with_view = ir.TileType(shape, DataType.FP16, memref, tile_view, ir.Mem.Left)
 ```
@@ -195,6 +195,10 @@ tile_with_view = ir.TileType(shape, DataType.FP16, memref, tile_view, ir.Mem.Lef
 `TileType.memory_space` is the source of truth for tile placement. If a
 `TileType` carries a `MemRef`, provide the tile memory space on the `TileType`
 itself.
+
+The `valid_shape` above is a genuine sub-region (`[8, 16]` of a `[16, 16]`
+tile). A `valid_shape` equal to the full shape is redundant, so the constructor
+clears it — see the canonicalization rules below.
 
 For Python DSL annotations, omitted `TileView` syntax is normalized to an
 implicit TileView derived from the tile shape and, when present, the tile
@@ -464,14 +468,11 @@ program = ir.Program([square_func, main_func], "math", span)
 ### Example 6: Memory Layout with TileType
 
 ```python
-# 32x32 tile in Left memory with custom stride
+# 32x32 tile in Left memory, viewing a 16x32 valid region with custom stride
 shape = [ir.ConstInt(32, DataType.INT64, span)] * 2
-memref = ir.MemRef(ir.ConstInt(0, DataType.INT64, span), 2048, 0)
+memref = ir.MemRef("mem_left_0", 0, 2048)
 
-tile_view = ir.TileView()
-tile_view.valid_shape = shape
-tile_view.stride = [ir.ConstInt(1, DataType.INT64, span), ir.ConstInt(32, DataType.INT64, span)]
-tile_view.start_offset = ir.ConstInt(0, DataType.INT64, span)
+tile_view = ir.TileView(valid_shape=[16, 32], stride=[1, 32], start_offset=0)
 
 tile_type = ir.TileType(shape, DataType.FP16, memref, tile_view, ir.Mem.Left)
 ```

--- a/docs/en/dev/ir/04-serialization.md
+++ b/docs/en/dev/ir/04-serialization.md
@@ -79,23 +79,21 @@ assert restored.kwargs["a_trans"] == True
 Hardware-specific memory allocation details are fully preserved:
 
 ```python
-# Create MemRef and TileView
-memref = ir.MemRef(
-    ir.ConstInt(0x1000, DataType.INT64, span),
-    512, 0
-)
+span = ir.Span.unknown()
 
-tile_view = ir.TileView()
-tile_view.valid_shape = [ir.ConstInt(16, DataType.INT64, span)] * 2
-tile_view.stride = [ir.ConstInt(1, DataType.INT64, span), ir.ConstInt(16, DataType.INT64, span)]
+# TileView is immutable — construct it with all values
+memref = ir.MemRef("mem_left_0", 0, 512)
+tile_view = ir.TileView(valid_shape=[8, 16], stride=[1, 16])
 
-# Create TileType with memory info
-tile_type = ir.TileType(shape, DataType.FP16, memref, tile_view, ir.Mem.Left)
+# Create TileType with memory info, and a Var that carries it
+tile_type = ir.TileType([16, 16], DataType.FP16, memref, tile_view, ir.Mem.Left)
+tile_var = ir.Var("t", tile_type, span)
 
 # Serialize and deserialize
 restored = ir.deserialize(ir.serialize(tile_var))
 assert restored.type.memory_space == ir.Mem.Left
 assert len(restored.type.tile_view.valid_shape) == 2
+assert restored.type.memref.size_ == 512
 ```
 
 ## MessagePack Format
@@ -126,7 +124,7 @@ assert len(restored.type.tile_view.valid_shape) == 2
 | **Span** | Map | `filename`, `begin_line`, `begin_column`, `end_line`, `end_column` |
 | **ScalarType** | Map | `type_kind: "ScalarType"`, `dtype: 19` |
 | **TensorType** | Map | `type_kind`, `dtype`, `shape`, optional `memref` |
-| **TileType** | Map | `type_kind`, `dtype`, `shape`, optional `memref`, optional `tile_view` |
+| **TileType** | Map | `type_kind`, `dtype`, `shape`, optional `memref`, optional `tile_view`, optional `memory_space` |
 | **Op/GlobalVar** | Map | `name`, `is_global_var` |
 
 ### MemRef and TileView Format
@@ -135,9 +133,13 @@ assert len(restored.type.tile_view.valid_shape) == 2
 // MemRef (optional field in TensorType/TileType)
 {
   "memref": {
-    "memory_space": 3,    // uint8: MemorySpace enum
-    "addr": {...},        // Expr node
-    "size": 512           // uint64
+    "base": "mem_left_0", // string: the base Ptr's name
+    "base_node": {...},   // Node: the base Ptr itself
+    "byte_offset": {...}, // Expr node
+    "size": 512,          // uint64
+    "is_pinned": true,    // bool,      omitted when false
+    "slot_count": 2,      // uint64,    omitted when 1
+    "slot_index": {...}   // Expr node, omitted when absent
   }
 }
 
@@ -155,6 +157,17 @@ assert len(restored.type.tile_view.valid_shape) == 2
   }
 }
 ```
+
+`base` and `base_node` both describe the allocation, and both are written.
+`base` is the name old blobs carry and old readers expect; `base_node` is the
+base `Ptr` as a real node, which is what preserves allocation identity —
+identity is `base_` *pointer* identity, and the node graph shares one object
+across every reference to it, including the alloc statement that defines the
+`Ptr`. Reconstructing a base from its name alone would give each MemRef a `Var`
+that is not the alloc's, and the address allocator could no longer match them.
+
+The memory space is **not** a `MemRef` field: it is serialized on `TileType`
+as `memory_space` (uint8), and `TensorType` is canonically DDR.
 
 Blobs written before the `compact` field was introduced omit that key and
 deserialize as `CompactMode.null`.

--- a/docs/zh/dev/ir/01-hierarchy.md
+++ b/docs/zh/dev/ir/01-hierarchy.md
@@ -394,18 +394,23 @@ for_stmt = ir.ForStmt(i, start, stop, step, [], body, [], span, ir.ForKind.Paral
 描述张量/Tile 共享的内存分配元数据。对于 Tile，内存空间保存在
 `TileType.memory_space_`；`TensorType` 的规范内存空间固定为 DDR。
 
+`MemRef` 是 `Var` 的子类，因而是一等表达式。一个 MemRef 标识一块分配
+(`base_`) 以及其中的一段字节区间 (`byte_offset_`、`size_`)；别名关系由
+`MemRef.same_allocation(a, b)` 和 `MemRef.may_alias(a, b)` 判定。
+
 | 字段 | 类型 | 说明 |
 | ---- | ---- | ---- |
-| `addr_` | ExprPtr | 基地址 |
-| `size_` | size_t | 大小（字节） |
-| `id_` | uint64_t | 稳定的 MemRef 标识符 |
+| `base_` | VarPtr | 分配身份标识 —— 来自 `tile.alloc` / `tensor.alloc` 的 Ptr `Var`。只有共享该字段的两个 MemRef 才可能别名。 |
+| `byte_offset_` | ExprPtr | 相对 `base_` 的字节偏移（整块分配为 0，视图则为其偏移） |
+| `size_` | uint64_t | 该区间的大小（字节） |
+| `is_pinned_` | bool | 用户显式声明的分配 (`pl.MemRef("name")`)，在 `InitMemRef` 解析之前为真 |
+| `slot_count_` | uint64_t | 该声明包含的等长 slot 数 (`pl.MemRef("name", slots=N)`)；省略 `slots` 时为 1 |
+| `slot_index_` | ExprPtr \| None | 该 MemRef 指向哪个 slot (`l0c[k]`)；未选定 slot 前为 None，且可以是运行期值 |
 
 ```python
-memref = ir.MemRef(
-    ir.ConstInt(0x1000, DataType.INT64, span),
-    1024,  # bytes
-    0     # id
-)
+# base allocation name, byte offset within it, size in bytes
+memref = ir.MemRef("mem_left_0", 0, 1024)
+assert ir.MemRef.same_allocation(memref, memref)
 ```
 
 > **注意：** `ir.Mem` 是 `ir.MemorySpace` 的简写别名。
@@ -416,15 +421,23 @@ memref = ir.MemRef(
 
 | 字段 | 类型 | 说明 |
 | ---- | ---- | ---- |
-| `valid_shape` | list[ExprPtr] | 有效维度 |
+| `valid_shape` | list[ExprPtr] | 有效维度（为空表示等同完整 shape） |
 | `stride` | list[ExprPtr] | 每维步长 |
 | `start_offset` | ExprPtr | 起始偏移量 |
+| `blayout` | TileLayout | 块布局 (block layout)，默认 `row_major` |
+| `slayout` | TileLayout | 散布布局 (scatter layout)，默认 `none_box` |
+| `fractal` | uint64_t | 分形 (fractal) 大小，单位是**字节**而非元素（默认 512） |
+| `pad` | PadValue | 访问越出 `valid_shape` 时的填充模式（默认 `null`） |
+| `compact` | CompactMode | 部分有效 Tile 的紧凑模式（默认 `null`） |
 
 ```python
-tile_view = ir.TileView()
-tile_view.valid_shape = [ir.ConstInt(16, DataType.INT64, span)] * 2
-tile_view.stride = [ir.ConstInt(1, DataType.INT64, span), ir.ConstInt(16, DataType.INT64, span)]
-tile_view.start_offset = ir.ConstInt(0, DataType.INT64, span)
+# TileView is immutable: pass every field to the constructor.
+# valid_shape / stride / start_offset accept int or Expr.
+tile_view = ir.TileView(valid_shape=[8, 16], stride=[1, 16], start_offset=0)
+
+# Expr form, for symbolic dimensions
+rows = ir.Var("rows", ir.ScalarType(DataType.INT64), span)
+symbolic_view = ir.TileView(valid_shape=[rows, ir.ConstInt(16, DataType.INT64, span)])
 ```
 
 ## Function 节点

--- a/docs/zh/dev/ir/02-types.md
+++ b/docs/zh/dev/ir/02-types.md
@@ -32,13 +32,15 @@ span = ir.Span.unknown()
 shape = [ir.ConstInt(10, DataType.INT64, span), ir.ConstInt(20, DataType.INT64, span)]
 tensor_type = ir.TensorType(shape, DataType.FP32)
 
-# Tensor with MemRef
-memref = ir.MemRef(ir.ConstInt(0x1000, DataType.INT64, span), 800, 0)
+# Tensor with MemRef: base allocation, byte offset within it, size in bytes
+memref = ir.MemRef("mem_ddr_0", 0, 800)
 tensor_with_memref = ir.TensorType(shape, DataType.FP32, memref)
 ```
 
-`TensorType.memory_space` 始终是 `ir.Mem.DDR`。`MemRef` 只保存地址、大小和
-id；内存空间不再存储在 `MemRef` 本身上。
+`TensorType.memory_space` 始终是 `ir.Mem.DDR`。`MemRef` 标识一块分配
+(`base_`) 以及其中的一段字节区间 (`byte_offset_`、`size_`)；内存空间不再
+存储在 `MemRef` 本身上。完整字段列表见
+[内存引用 (MemRef)](01-hierarchy.md#memref)。
 
 ### DistributedTensorType
 
@@ -104,7 +106,7 @@ stride = [ir.ConstInt(1, DataType.INT64, span), ir.ConstInt(128, DataType.INT64,
 tensor_view = ir.TensorView(stride=stride, layout=ir.TensorLayout.ND)
 
 # Tensor with both MemRef and TensorView
-memref = ir.MemRef(ir.ConstInt(0x2000, DataType.INT64, span), 16384, 1)
+memref = ir.MemRef("mem_ddr_1", 0, 16384)
 tensor_with_both = ir.TensorType([128, 256], DataType.FP16, memref=memref, tensor_view=tensor_view)
 ```
 
@@ -177,19 +179,21 @@ shape_3d = [ir.ConstInt(4, DataType.INT64, span),
             ir.ConstInt(16, DataType.INT64, span)]
 tile_type_3d = ir.TileType(shape_3d, DataType.FP16)
 
-# Tile with MemRef and TileView
-memref = ir.MemRef(ir.ConstInt(0, DataType.INT64, span), 512, 0)
+# Tile with MemRef and TileView. TileView is immutable — every field is passed
+# to the constructor; valid_shape / stride / start_offset accept int or Expr.
+memref = ir.MemRef("mem_left_0", 0, 512)
 
-tile_view = ir.TileView()
-tile_view.valid_shape = [ir.ConstInt(16, DataType.INT64, span)] * 2
-tile_view.stride = [ir.ConstInt(1, DataType.INT64, span), ir.ConstInt(16, DataType.INT64, span)]
-tile_view.start_offset = ir.ConstInt(0, DataType.INT64, span)
+tile_view = ir.TileView(valid_shape=[8, 16], stride=[1, 16], start_offset=0)
 
 tile_with_view = ir.TileType(shape, DataType.FP16, memref, tile_view, ir.Mem.Left)
 ```
 
 `TileType.memory_space` 才是 Tile 放置位置的唯一来源。如果 `TileType`
 携带 `MemRef`, 请在 `TileType` 自身上显式提供 tile 内存空间。
+
+上面的 `valid_shape` 是一个真正的子区域（`[16, 16]` Tile 中的 `[8, 16]`）。
+若 `valid_shape` 与完整 shape 相同则是冗余的，构造函数会将其清空 ——
+参见下文的规范化规则。
 
 对于 Python DSL 类型标注，省略的 `TileView` 语法会被规范化为一个隐式
 TileView：它由 tile shape 以及（如果存在）tile memory space 推导得到。
@@ -449,14 +453,11 @@ program = ir.Program([square_func, main_func], "math", span)
 ### 示例 6：使用 TileType 的内存布局
 
 ```python
-# 32x32 tile in Left memory with custom stride
+# 32x32 tile in Left memory, viewing a 16x32 valid region with custom stride
 shape = [ir.ConstInt(32, DataType.INT64, span)] * 2
-memref = ir.MemRef(ir.ConstInt(0, DataType.INT64, span), 2048, 0)
+memref = ir.MemRef("mem_left_0", 0, 2048)
 
-tile_view = ir.TileView()
-tile_view.valid_shape = shape
-tile_view.stride = [ir.ConstInt(1, DataType.INT64, span), ir.ConstInt(32, DataType.INT64, span)]
-tile_view.start_offset = ir.ConstInt(0, DataType.INT64, span)
+tile_view = ir.TileView(valid_shape=[16, 32], stride=[1, 32], start_offset=0)
 
 tile_type = ir.TileType(shape, DataType.FP16, memref, tile_view, ir.Mem.Left)
 ```

--- a/docs/zh/dev/ir/04-serialization.md
+++ b/docs/zh/dev/ir/04-serialization.md
@@ -79,23 +79,21 @@ assert restored.kwargs["a_trans"] == True
 硬件特定的内存分配详情被完整保留：
 
 ```python
-# Create MemRef and TileView
-memref = ir.MemRef(
-    ir.ConstInt(0x1000, DataType.INT64, span),
-    512, 0
-)
+span = ir.Span.unknown()
 
-tile_view = ir.TileView()
-tile_view.valid_shape = [ir.ConstInt(16, DataType.INT64, span)] * 2
-tile_view.stride = [ir.ConstInt(1, DataType.INT64, span), ir.ConstInt(16, DataType.INT64, span)]
+# TileView is immutable — construct it with all values
+memref = ir.MemRef("mem_left_0", 0, 512)
+tile_view = ir.TileView(valid_shape=[8, 16], stride=[1, 16])
 
-# Create TileType with memory info
-tile_type = ir.TileType(shape, DataType.FP16, memref, tile_view, ir.Mem.Left)
+# Create TileType with memory info, and a Var that carries it
+tile_type = ir.TileType([16, 16], DataType.FP16, memref, tile_view, ir.Mem.Left)
+tile_var = ir.Var("t", tile_type, span)
 
 # Serialize and deserialize
 restored = ir.deserialize(ir.serialize(tile_var))
 assert restored.type.memory_space == ir.Mem.Left
 assert len(restored.type.tile_view.valid_shape) == 2
+assert restored.type.memref.size_ == 512
 ```
 
 ## MessagePack 格式
@@ -126,7 +124,7 @@ assert len(restored.type.tile_view.valid_shape) == 2
 | **Span** | Map | `filename`, `begin_line`, `begin_column`, `end_line`, `end_column` |
 | **ScalarType** | Map | `type_kind: "ScalarType"`, `dtype: 19` |
 | **TensorType** | Map | `type_kind`, `dtype`, `shape`, 可选 `memref` |
-| **TileType** | Map | `type_kind`, `dtype`, `shape`, 可选 `memref`, 可选 `tile_view` |
+| **TileType** | Map | `type_kind`, `dtype`, `shape`, 可选 `memref`, 可选 `tile_view`, 可选 `memory_space` |
 | **Op/GlobalVar** | Map | `name`, `is_global_var` |
 
 ### MemRef 和 TileView 格式
@@ -135,9 +133,13 @@ assert len(restored.type.tile_view.valid_shape) == 2
 // MemRef (optional field in TensorType/TileType)
 {
   "memref": {
-    "memory_space": 3,    // uint8: MemorySpace enum
-    "addr": {...},        // Expr node
-    "size": 512           // uint64
+    "base": "mem_left_0", // string: the base Ptr's name
+    "base_node": {...},   // Node: the base Ptr itself
+    "byte_offset": {...}, // Expr node
+    "size": 512,          // uint64
+    "is_pinned": true,    // bool,      omitted when false
+    "slot_count": 2,      // uint64,    omitted when 1
+    "slot_index": {...}   // Expr node, omitted when absent
   }
 }
 
@@ -155,6 +157,16 @@ assert len(restored.type.tile_view.valid_shape) == 2
   }
 }
 ```
+
+`base` 和 `base_node` 都描述同一块分配，且两者都会写出。`base` 是旧 blob
+携带、旧读取端期待的名字；`base_node` 则是作为真实节点的 base `Ptr`，它才是
+保持分配身份的关键 —— 身份由 `base_` 的*指针*同一性决定，而节点图会在所有
+引用之间共享同一个对象，包括定义该 `Ptr` 的 alloc 语句。若仅凭名字重建
+base，每个 MemRef 会得到一个并非 alloc 所属的 `Var`，地址分配器就无法再把
+它们匹配到各自的分配上。
+
+内存空间**不是** `MemRef` 的字段：它序列化在 `TileType` 上，键为
+`memory_space`（uint8）；`TensorType` 的规范内存空间固定为 DDR。
 
 在引入 `compact` 字段之前写出的 blob 会省略该键，反序列化时按
 `CompactMode.null` 处理。


### PR DESCRIPTION
## Summary

Every Python example under `docs/{en,zh}/dev/ir/` that builds a `MemRef` or a `TileView` was written against an API that has since changed, so none of them ran. Copying one out of the docs is the normal way to learn these types, and doing so produced an `AttributeError` or a `TypeError` instead of IR. Nothing executes documentation snippets in CI, which is why the drift went unnoticed. After this change every snippet runs against a local build, and the `MemRef` reference table describes fields the class actually has.

Three independent breakages, all documentation-only — no source, test, or interface change, and no migration step:

- **`TileView` is immutable.** Its fields are read-only and every value passes through the constructor, so the documented build-then-mutate form raised `AttributeError: property of 'TileView' object has no setter`.
- **`MemRef` changed shape.** It names an allocation (`base_`) and a byte range within it (`byte_offset_`, `size_`). It has no `addr_` or `id_` field, and no overload takes a bare `ConstInt` first, so `ir.MemRef(ir.ConstInt(...), size, id)` raised `TypeError: __init__(): incompatible function arguments`.
- **The serialization example never ran at all**, even before the API drift: it serialized an undefined `tile_var`, used an undefined `shape` and `span`, and asserted `len(valid_shape) == 2` on a `valid_shape` equal to the full shape — which the `TileType` constructor clears, making it 0.

## Changes

- `docs/{en,zh}/dev/ir/02-types.md`: four `MemRef` call sites and two build-then-mutate `TileView` blocks rewritten. `MemRef` examples use the base-name form `ir.MemRef("mem_left_0", 0, 512)`, which maps one-to-one onto the fields the class has; `TileView` examples pass every field to the constructor. Each `valid_shape` is now a real sub-region, because one equal to the full shape is cleared and would vanish from the very example introducing it. Prose describing `MemRef` as carrying "address, size, and id" corrected, and pointed at the field table.
- `docs/{en,zh}/dev/ir/01-hierarchy.md`: the `MemRef` field table listed `addr_`, `size_`, and `id_` — two of which do not exist. Replaced with `base_`, `byte_offset_`, `size_`, `is_pinned_`, `slot_count_`, and `slot_index_`, plus a line on `MemRef` being a `Var` subclass and on the `same_allocation` / `may_alias` predicates. The `TileView` table gained the five fields it omitted: `blayout`, `slayout`, `fractal` (a size in **bytes**, not elements), `pad`, and `compact`.
- `docs/{en,zh}/dev/ir/04-serialization.md`: the example now defines `span`, builds a real `tile_var` from the `TileType`, and asserts on a genuine `[8, 16]` sub-region of a `[16, 16]` tile, so the round-trip assertion is meaningful rather than vacuous.

The DSL-annotation form `pl.MemRef(addr, size, id)` in `02-types.md` is deliberately unchanged: that is the parser's annotation surface and it is correct.

The Chinese mirrors carry byte-identical code blocks; only tables and prose are translated.

## What a reviewer should check

- The `MemRef` field table in `01-hierarchy.md` against `include/pypto/ir/memref.h:42-126`, and the `TileView` table against `include/pypto/ir/type.h:303-311`.
- That preferring `ir.MemRef("mem_left_0", 0, 512)` over the still-supported legacy `ir.MemRef(addr, size, id)` is the right call for IR-internals docs. The legacy form works, but it synthesizes a base name from `id` and reinforces the `addr_`/`id_` model this PR removes from the table.
- The deliberate use of a partial `valid_shape` in each example, which follows from `ClearRedundantFullValidShape` (`src/ir/type.cpp:53-57`).

## Verification

- `cmake --build build --parallel`: exit 0
- Every rewritten snippet executed against that build: 7/7 pass, including the serialize/deserialize round-trip. The pre-fix forms were confirmed to fail exactly as described (`AttributeError`, `TypeError`, and `len == 0`), so the examples exercise the current API rather than passing vacuously.
- `mkdocs build --strict`: exit 0, with no link warning for any changed file. This caught a defect mid-change: the Chinese cross-reference anchor was written `#内存引用-memref`, but python-markdown's ASCII slugify strips CJK, so the anchor that resolves is `#memref`.
- `pre-commit run --from-ref upstream/main --to-ref HEAD`: exit 0 — check-headers, check-english-only, check-docs-en-zh-parity, check-docs-nav, check-docs-symbol-coverage, check-no-broad-raises, check-op-name-literals, check-added-large-files, end-of-file-fixer, trailing-whitespace, markdownlint-cli2

## Follow-up not in this PR

Nothing executes doc snippets, which is why four broken blocks and a dead assert went unnoticed. A lint over opt-in-tagged Python blocks would close the class, but it needs a build in the pre-commit environment — which is exactly why `check_docs_symbol_coverage.py` parses `__all__` with `ast` instead of importing. Worth a separate discussion.

Separately, `mkdocs build` reports ~30 pre-existing broken CJK anchors across `docs/zh/` from the same ASCII-slugify behaviour. They are untouched here.