### PR TITLE
test(st): right-size fp32 matmul golden tolerances

### DIFF
--- a/tests/st/runtime/ops/test_matmul.py
+++ b/tests/st/runtime/ops/test_matmul.py
@@ -30,6 +30,21 @@ from pypto.pypto_core import passes as _core_passes
 from pypto.pypto_core.passes import MemoryPlanner
 from pypto.runtime.runner import RunConfig
 
+# Tolerance for the plain FP32 matmul goldens below. The cube accumulates the K
+# reduction in a different order than torch's single-pass BLAS matmul, so results
+# drift by a few FP32 ULP *of the partial sums* — measured on 910B over 489 runs
+# of the cases below at K=64..128: median 1.1e-5, peak 3.4e-5 absolute. That
+# drift is set by the partial-sum magnitude, not by |result|, so on a
+# cancellation-heavy element — where `torch.isclose`'s `atol + rtol * |golden|`
+# bound collapses to roughly `atol` — it exceeds the 1e-5 default; this is what
+# made `test_matmul_mixed_add_btranspose` flake on a single element in 2048. Note
+# it needs NO K-split — a single full-K `TMATMUL` already shows it — so every
+# FP32 randn matmul here is exposed, not just the K-split cases PR #1945
+# right-sized. Against the 1e-4 floor that peak drift is 0.34x, i.e. ~3x margin
+# even where the golden is ~0 and rtol contributes nothing.
+_FP32_MATMUL_RTOL = 1e-4
+_FP32_MATMUL_ATOL = 1e-4
+
 
 def _planner_tag(planner: MemoryPlanner) -> str:
     return {
@@ -106,6 +121,9 @@ class TestMatmul(PTOTestCase):
 
     def __init__(self, m: int = 64, k: int = 64, n: int = 64, *, platform: str | None = None, config=None):
         super().__init__(config, platform=platform)
+        if config is None:
+            self.config.rtol = _FP32_MATMUL_RTOL
+            self.config.atol = _FP32_MATMUL_ATOL
         self.M = m
         self.K = k
         self.N = n
@@ -166,6 +184,9 @@ class TestMatmulBTranspose(PTOTestCase):
 
     def __init__(self, m: int = 64, k: int = 64, n: int = 64, *, platform: str | None = None, config=None):
         super().__init__(config, platform=platform)
+        if config is None:
+            self.config.rtol = _FP32_MATMUL_RTOL
+            self.config.atol = _FP32_MATMUL_ATOL
         self.M = m
         self.K = k
         self.N = n
@@ -227,6 +248,9 @@ class TestMatmulATranspose(PTOTestCase):
 
     def __init__(self, m: int = 64, k: int = 64, n: int = 64, *, platform: str | None = None, config=None):
         super().__init__(config, platform=platform)
+        if config is None:
+            self.config.rtol = _FP32_MATMUL_RTOL
+            self.config.atol = _FP32_MATMUL_ATOL
         self.M = m
         self.K = k
         self.N = n
@@ -288,6 +312,9 @@ class TestMatmulABTranspose(PTOTestCase):
 
     def __init__(self, m: int = 64, k: int = 64, n: int = 64, *, platform: str | None = None, config=None):
         super().__init__(config, platform=platform)
+        if config is None:
+            self.config.rtol = _FP32_MATMUL_RTOL
+            self.config.atol = _FP32_MATMUL_ATOL
         self.M = m
         self.K = k
         self.N = n
@@ -1419,6 +1446,9 @@ class TestMixedAddBTrans(PTOTestCase):
 
     def __init__(self, m: int = 16, k: int = 64, n: int = 128, *, platform: str | None = None, config=None):
         super().__init__(config, platform=platform)
+        if config is None:
+            self.config.rtol = _FP32_MATMUL_RTOL
+            self.config.atol = _FP32_MATMUL_ATOL
         self.M = m
         self.K = k
         self.N = n


### PR DESCRIPTION
## Summary

`test_matmul_mixed_add_btranspose[16-64-128-a2a3]` intermittently failed golden
validation on the real NPU with a single-element FP32 mismatch
(`Mismatched elements: 1/2048`, abs diff 1.26e-5 at a golden of -0.0488).

The 910B cube accumulates a matmul's K reduction in a different order than
torch's single-pass BLAS reference, so an FP32 golden comparison drifts by a few
ULP of the **partial sums** rather than of the result. Measured across 489 device
runs of these cases at K=64..128: median 1.1e-5, peak 3.4e-5 absolute. That
drift is set by the partial-sum magnitude and does not shrink with the result
magnitude, so on a cancellation-heavy element — where `torch.isclose`'s
`atol + rtol * |golden|` bound collapses to roughly `atol` — it exceeds the
threshold while every other element passes.

The five plain FP32 matmul cases now validate at `rtol=atol=1e-4`. Against that
`1e-4` floor the peak measured drift is 0.34x, leaving ~3x margin even on an
element whose golden is ~0 and where `rtol` contributes nothing. No product code
changes and no behavior change for users; this only widens test tolerances to the
drift the hardware legitimately produces.

## Changes

- `tests/st/runtime/ops/test_matmul.py`: add one shared
  `_FP32_MATMUL_RTOL`/`_FP32_MATMUL_ATOL` pair (1e-4) documenting the mechanism,
  and apply it in `TestMatmul`, `TestMatmulBTranspose`, `TestMatmulATranspose`,
  `TestMatmulABTranspose`, and `TestMixedAddBTrans`. Each override is guarded by
  `if config is None`, so a caller that passes an explicit `RunConfig` — the
  AutoL0, shared-KV, and a-transpose cases all do — keeps its own tolerance.

Two points that reviewers may want to weigh in on:

- **This is not a K-split case.** #1945 right-sized a set of FP32 matmul s-tests
  and justified it as "the device reduces the two K-halves in a different order".
  That mechanism is absent here: `choose_l0_tile(16, 64, 128)` at FP32 returns
  tile `(m=16, n=128, k=64)`, i.e. K-iters = 1, and the generated cube kernel is
  a single `TMATMUL` over the full K=64 in native `float`. The reduction-order
  drift comes from the cube's internal accumulation within one instruction, so
  the shared comment here describes that instead of reusing the K-split wording.
- **Scope is wider than the one test that flaked.** Because no K-split is
  required to produce ~1e-5 of drift, the non-transposed and transposed sibling
  cases are exposed too. Over 300 device runs they peaked at 0.835x of the old
  1e-5 threshold — closer to failing than the 0.654x peak of the case that
  actually flaked — so fixing only `TestMixedAddBTrans` would have left the more
  exposed cases behind.

## Verification

Run by the push transaction against the pushed commit `55e22f8`:

- `cmake --build build --parallel`: exit 0
- `ruff check .`: exit 0, all checks passed
- `ruff format --check .`: exit 0, already formatted
- `pyright`: exit 0, 0 errors, 0 warnings, 0 informations
- `python -m pytest tests/ut/ -n auto --maxprocesses 8`: exit 0, 9255 passed, 2 skipped
- `python -m pytest tests/st/runtime/ops/test_matmul.py --platform a2a3 --device 0`:
  exit 0, 58 passed, 171 deselected (real 910B)

Additional evidence gathered while diagnosing, on the real 910B. "Ratio" below is
the worst per-element `|diff| / (atol + rtol * |golden|)`, so >1 means the run
fails:

- 189 runs of the previously flaking case with fresh random data each: 0 failures
  at 1e-5; peak absolute drift 2.29e-5; worst ratio 0.654 at 1e-5, 0.065 at 1e-4.
- 300 runs of the four sibling cases: 0 failures at 1e-5; peak absolute drift
  3.43e-5; worst ratio 0.835 at 1e-5, 0.084 at 1e-4.
- The drift at the smallest-magnitude golden element is ~4.8% of the array's peak
  drift, so a failure needs a large drift to land on a near-zero element — which
  is why the observed CI rate was low rather than deterministic.