### PR TITLE
feat(codegen): emit MLIR source locations in generated .pto

### DIFF
--- a/docs/en/dev/codegen/00-pto_codegen.md
+++ b/docs/en/dev/codegen/00-pto_codegen.md
@@ -438,6 +438,41 @@ pto.tmul ins(%tile_a_buf : !pto.tile_buf<...>,
 - Input operands resolved through variable name lookup
 - All `ins`/`outs` clauses include type annotations
 
+### Source Locations (`loc`)
+
+Every emitted **operation** carries a trailing MLIR location built from the IR
+`Span`, e.g. `pto.tadd ins(...) outs(...) loc("kernels/attn.py":41:9)`. ptoas
+propagates `loc()` verbatim into its diagnostics, so a verifier rejection names
+the user's `.py` line instead of a line in the generated `.pto` — a file that,
+under `@pl.jit`, the user never sees (spans there are already remapped from the
+synthesized `<jit:name>` text back to the real source).
+
+**Which span is used** — bound at two levels, the second refining the first:
+
+| Level | Bound in | Source |
+| ----- | -------- | ------ |
+| Statement (primary) | `PTOCodegen::VisitStmt` | `Stmt::span_` |
+| Call (refinement) | `PTOCodegen::VisitExpr_(CallPtr)` | `Call::span_`, only when nested inside the statement span |
+
+The containment test is what makes this correct. `Call::span_` is
+column-accurate when preserved, but passes that synthesize tile ops
+(`ConvertTensorToTileOps`) rebuild the `Call` carrying the enclosing
+*function*'s span while leaving the `AssignStmt`'s own span intact. Such a span
+begins before the statement, fails containment, and is discarded in favour of
+the statement span — otherwise most operations would report the `def` line.
+
+**No location is emitted for**: region braces, separators and block labels
+(`loc(...)` is legal only at the end of a complete operation, so these use
+`EmitStructural()` rather than `Emit()`); `arith.constant` in the constants
+section (deduplicated across uses, so no single span fits); and nodes whose span
+is unknown or has no filename.
+
+**Disabling** — `Generate(program, emit_tile_addr, emit_source_loc)`,
+`compile(..., emit_source_loc=...)`, or `PYPTO_EMIT_PTO_LOC=0`. The output is
+then byte-identical to the location-free form; this is the escape hatch for a
+ptoas build whose parser rejects a trailing location, since ptoas ships
+independently of PyPTO.
+
 ## Complete Example
 
 ### Input: PyPTO Program

--- a/docs/zh/dev/codegen/00-pto_codegen.md
+++ b/docs/zh/dev/codegen/00-pto_codegen.md
@@ -419,6 +419,36 @@ pto.tmul ins(%tile_a_buf : !pto.tile_buf<...>,
 - 输入操作数通过变量名查找解析
 - 所有 `ins`/`outs` 子句包含类型标注
 
+### 源码位置 (`loc`)
+
+每条生成的**操作**都会带上由 IR `Span` 构造的 MLIR 尾随位置, 例如
+`pto.tadd ins(...) outs(...) loc("kernels/attn.py":41:9)`。ptoas 会原样把
+`loc()` 传递到自己的诊断信息里, 因此校验失败时报告的是用户 `.py` 中的行, 而不是
+生成的 `.pto` 中的行 —— 在 `@pl.jit` 下用户根本看不到后者 (该路径上 span 已由
+解析器从合成的 `<jit:name>` 文本重映射回真实源文件)。
+
+**使用哪个 span** —— 在两个层级绑定, 后者细化前者:
+
+| 层级 | 绑定位置 | 来源 |
+| ---- | -------- | ---- |
+| 语句 (主) | `PTOCodegen::VisitStmt` | `Stmt::span_` |
+| Call (细化) | `PTOCodegen::VisitExpr_(CallPtr)` | `Call::span_`, 仅当它嵌套在语句 span 内 |
+
+包含性 (containment) 检查是正确性的关键。`Call::span_` 在被保留时精确到列, 但
+合成 tile 算子的 pass (`ConvertTensorToTileOps`) 会用所在**函数**的 span 重建
+`Call`, 同时保留 `AssignStmt` 自身的 span。这类 span 起始于语句之前, 包含性检查
+不通过, 于是被丢弃并回退到语句 span —— 否则大多数操作都会指向 `def` 行。
+
+**不带位置的内容**: 区域花括号、分隔符和基本块标签 (`loc(...)` 只在一条完整操作
+的末尾合法, 因此这些行走 `EmitStructural()` 而不是 `Emit()`); 常量段中的
+`arith.constant` (在所有使用点之间去重, 没有唯一正确的 span); 以及 span 未知或
+没有文件名的节点。
+
+**关闭方式** —— `Generate(program, emit_tile_addr, emit_source_loc)`、
+`compile(..., emit_source_loc=...)`, 或环境变量 `PYPTO_EMIT_PTO_LOC=0`。关闭后
+输出与不带位置的形式逐字节一致; 由于 ptoas 独立于 PyPTO 发布, 这是应对某个
+ptoas 版本解析器拒绝尾随位置时的应急开关。
+
 ## 完整示例
 
 ### 输入: PyPTO 程序

--- a/include/pypto/codegen/pto/pto_codegen.h
+++ b/include/pypto/codegen/pto/pto_codegen.h
@@ -115,9 +115,20 @@ class PTOCodegen : public CodegenBase {
    *        on `pto.alloc_tile` from the MemRef byte offset (ptoas
    *        --pto-level=level3). When false, omit `addr` so the ptoas PlanMemory
    *        pass allocates instead (--pto-level=level2).
+   * @param emit_source_loc When true (default), suffix every emitted operation
+   *        with an MLIR `loc("file":line:col)` derived from the IR Span, so
+   *        ptoas diagnostics name the user's source instead of a line in the
+   *        generated `.pto`. Three kinds of line are excluded by design: the
+   *        structural region braces and block labels emitted by
+   *        EmitStructural(), which MLIR forbids a trailing location on; the
+   *        `arith.constant` operations GetOrEmitConstant() writes to the
+   *        constants section, which are deduplicated across every use so no
+   *        single span fits them; and any operation whose span is unknown or
+   *        carries no filename. When false, emit no locations at all.
    * @return MLIR code as string
    */
-  std::string Generate(const ir::ProgramPtr& program, bool emit_tile_addr = true);
+  std::string Generate(const ir::ProgramPtr& program, bool emit_tile_addr = true,
+                       bool emit_source_loc = true);
 
   // CodegenBase interface (unified API for operator codegen callbacks)
   [[nodiscard]] std::string GetCurrentResultTarget() const override;
@@ -126,6 +137,18 @@ class PTOCodegen : public CodegenBase {
   [[nodiscard]] std::string GetTypeString(const DataType& dtype) const override;
   int64_t GetConstIntValue(const ir::ExprPtr& expr) const override;
   std::string GetVarName(const ir::VarPtr& var) const override;
+
+  /**
+   * @brief Emit one structural (non-operation) MLIR line
+   *
+   * MLIR's trailing `loc(...)` is only legal at the end of a complete
+   * operation. Region openers (`scf.for ... {`), separators (`} else {`,
+   * `} do {`), closers (`}`) and block labels (`^bb0(...):`) are not
+   * operations, so they must bypass the location suffix that Emit() appends.
+   *
+   * @param line Line of MLIR to emit verbatim (indented, no location)
+   */
+  void EmitStructural(const std::string& line);
 
   // PTO-specific helper methods for operator codegen functions
 
@@ -1033,6 +1056,51 @@ class PTOCodegen : public CodegenBase {
   /// When false, `pto.alloc_tile` omits the physical `addr` operand so the
   /// ptoas PlanMemory pass owns allocation (--pto-level=level2). Set by Generate.
   bool emit_tile_addr_ = true;
+
+  /// When false, no operation carries a trailing `loc(...)`. Set by Generate.
+  bool emit_source_loc_ = true;
+
+  /// Source span attached to the operations being emitted right now; null means
+  /// "no location", which makes Emit() behave exactly as it did before locations
+  /// existed. Points into IR-owned storage — see SpanScope.
+  const ir::Span* current_span_ = nullptr;
+
+  /**
+   * @brief RAII guard binding the source location of every op emitted while alive
+   *
+   * Set at two levels: once per statement (PTOCodegen::VisitStmt) and once more
+   * per Call when the Call's own span is a genuine refinement
+   * (PTOCodegen::VisitExpr_(CallPtr)). Restores the previous span on scope exit,
+   * so nesting composes.
+   *
+   * A null @p span leaves the enclosing scope's location in place, which lets
+   * callers express "refine only if the span is trustworthy" without an
+   * `std::optional<SpanScope>`.
+   */
+  class SpanScope {
+   public:
+    SpanScope(PTOCodegen* codegen, const ir::Span* span) : codegen_(codegen), saved_(codegen->current_span_) {
+      if (span != nullptr) codegen_->current_span_ = span;
+    }
+    ~SpanScope() { codegen_->current_span_ = saved_; }
+
+    /// `current_span_` is a non-owning pointer, so a temporary would dangle.
+    SpanScope(PTOCodegen* codegen, ir::Span&& span) = delete;
+    SpanScope(const SpanScope&) = delete;
+    SpanScope& operator=(const SpanScope&) = delete;
+
+   private:
+    PTOCodegen* codegen_;
+    const ir::Span* saved_;
+  };
+
+  /**
+   * @brief Trailing MLIR location for the currently bound span
+   *
+   * @return `" loc(\"file\":line:col)"`, or an empty string when locations are
+   *         disabled or no usable span is bound.
+   */
+  [[nodiscard]] std::string LocSuffix() const;
 
   /// Emit an arith binary op, return SSA result name
   std::string EmitArithBinaryOp(const std::string& mlir_op, const std::string& lhs, const std::string& rhs,

--- a/python/bindings/modules/codegen.cpp
+++ b/python/bindings/modules/codegen.cpp
@@ -43,10 +43,12 @@ void BindCodegen(nb::module_& m) {
       "annotations.")
       .def(nb::init<>(), "Create a PTO code generator (backend is always PTO)")
       .def("generate", &PTOCodegen::Generate, nb::arg("program"), nb::arg("emit_tile_addr") = true,
+           nb::arg("emit_source_loc") = true,
            "Generate PTO assembly from PyPTO IR Program. Returns PTO assembly code string (.pto format) with "
            "instructions like tmul, tadd, FOR/ENDFOR, etc. When emit_tile_addr=False, pto.alloc_tile omits "
            "the "
-           "physical addr operand so the ptoas PlanMemory pass allocates (--pto-level=level2).");
+           "physical addr operand so the ptoas PlanMemory pass allocates (--pto-level=level2). When "
+           "emit_source_loc=False, operations carry no trailing MLIR loc(\"file\":line:col).");
 
   // OrchestrationResult - result of orchestration code generation
   nb::class_<OrchestrationResult>(codegen_module, "OrchestrationResult",

--- a/python/pypto/backend/pto_backend.py
+++ b/python/pypto/backend/pto_backend.py
@@ -51,6 +51,27 @@ logger = logging.getLogger(__name__)
 
 _PTOAS_RELEASE_URL = "https://github.com/zhangstevenunity/PTOAS/releases"
 
+_EMIT_SOURCE_LOC_ENV = "PYPTO_EMIT_PTO_LOC"
+_FALSY_ENV_VALUES = frozenset({"0", "false", "no", "off"})
+
+
+def emit_source_loc_default() -> bool:
+    """Whether generated ``.pto`` operations carry a trailing MLIR ``loc(...)``.
+
+    ptoas propagates ``loc()`` verbatim into its diagnostics, so emitting spans
+    makes every ptoas rejection name the user's ``.py`` line instead of a line in
+    the generated artifact. On by default; ``PYPTO_EMIT_PTO_LOC=0`` turns it off.
+
+    The env var exists because ptoas ships independently of PyPTO: if a ptoas
+    build ever rejects a trailing location, users need a switch that does not
+    require rebuilding PyPTO. Read per call so tests can monkeypatch the
+    environment.
+
+    Returns:
+        True unless the environment disables source locations.
+    """
+    return os.environ.get(_EMIT_SOURCE_LOC_ENV, "1").strip().lower() not in _FALSY_ENV_VALUES
+
 
 class PartialCodegenError(RuntimeError):
     """Codegen failed after producing some output files."""
@@ -1242,6 +1263,7 @@ def generate(
     skip_ptoas: bool = False,
     *,
     memory_planner: _passes.MemoryPlanner | None = None,
+    emit_source_loc: bool | None = None,
 ) -> dict[str, str]:
     """Generate all PTO backend output files (kernels + orchestration + config).
 
@@ -1259,12 +1281,19 @@ def generate(
         output_dir: Base output directory (used for ptoas intermediates when skip_ptoas=False)
         skip_ptoas: When True, skip the ptoas compilation step and return raw MLIR
             content in result_files with .pto extension instead of compiled .cpp wrappers.
+        memory_planner: Who plans on-chip buffer memory. None uses ``MemoryPlanner.PYPTO``.
+        emit_source_loc: When True, suffix each emitted ``.pto`` operation with an
+            MLIR ``loc("file":line:col)`` from the IR Span so ptoas diagnostics
+            name the user's source. None reads the ``PYPTO_EMIT_PTO_LOC``
+            environment default (on).
 
     Returns:
         Dict mapping relative file paths to their content.
     """
     if memory_planner is None:
         memory_planner = _passes.MemoryPlanner.PYPTO
+    if emit_source_loc is None:
+        emit_source_loc = emit_source_loc_default()
 
     # Check for distributed functions (level >= HOST = Linqu level 3)
     has_distributed = any(
@@ -1274,7 +1303,11 @@ def generate(
 
     if has_distributed:
         return _generate_with_distributed(
-            transformed_program, output_dir, skip_ptoas, memory_planner=memory_planner
+            transformed_program,
+            output_dir,
+            skip_ptoas,
+            memory_planner=memory_planner,
+            emit_source_loc=emit_source_loc,
         )
 
     # L2-only program with multiple Orchestrations: emit each as a
@@ -1288,10 +1321,20 @@ def generate(
     )
     if orch_count > 1:
         return _generate_multi_chip(
-            transformed_program, output_dir, skip_ptoas, memory_planner=memory_planner
+            transformed_program,
+            output_dir,
+            skip_ptoas,
+            memory_planner=memory_planner,
+            emit_source_loc=emit_source_loc,
         )
 
-    return _generate_single_chip(transformed_program, output_dir, skip_ptoas, memory_planner=memory_planner)
+    return _generate_single_chip(
+        transformed_program,
+        output_dir,
+        skip_ptoas,
+        memory_planner=memory_planner,
+        emit_source_loc=emit_source_loc,
+    )
 
 
 def _generate_with_distributed(
@@ -1300,6 +1343,7 @@ def _generate_with_distributed(
     skip_ptoas: bool,
     *,
     memory_planner: _passes.MemoryPlanner = _passes.MemoryPlanner.PYPTO,
+    emit_source_loc: bool = True,
 ) -> dict[str, str]:
     """Generate artifacts for a distributed (L3+) program.
 
@@ -1327,7 +1371,11 @@ def _generate_with_distributed(
             chip_program = _ir_core.Program(chip_funcs, func.name, transformed_program.span)
             chip_subdir = os.path.join(output_dir, "next_levels", func.name)
             chip_files = _generate_single_chip(
-                chip_program, chip_subdir, skip_ptoas, memory_planner=memory_planner
+                chip_program,
+                chip_subdir,
+                skip_ptoas,
+                memory_planner=memory_planner,
+                emit_source_loc=emit_source_loc,
             )
             for path, content in chip_files.items():
                 result_files[f"next_levels/{func.name}/{path}"] = content
@@ -1519,6 +1567,7 @@ def _generate_multi_chip(
     skip_ptoas: bool = False,
     *,
     memory_planner: _passes.MemoryPlanner = _passes.MemoryPlanner.PYPTO,
+    emit_source_loc: bool = True,
 ) -> dict[str, str]:
     """Generate artifacts for an L2-only program with multiple Orchestrations.
 
@@ -1537,7 +1586,11 @@ def _generate_multi_chip(
         chip_program = _ir_core.Program(chip_funcs, func.name, transformed_program.span)
         chip_subdir = os.path.join(output_dir, "next_levels", func.name)
         chip_files = _generate_single_chip(
-            chip_program, chip_subdir, skip_ptoas, memory_planner=memory_planner
+            chip_program,
+            chip_subdir,
+            skip_ptoas,
+            memory_planner=memory_planner,
+            emit_source_loc=emit_source_loc,
         )
         for path, content in chip_files.items():
             result_files[f"next_levels/{func.name}/{path}"] = content
@@ -1550,6 +1603,7 @@ def _generate_single_chip(
     skip_ptoas: bool = False,
     *,
     memory_planner: _passes.MemoryPlanner = _passes.MemoryPlanner.PYPTO,
+    emit_source_loc: bool = True,
 ) -> dict[str, str]:
     """Generate artifacts for a single-chip (L0-L2) program.
 
@@ -1598,6 +1652,8 @@ def _generate_single_chip(
     # When ptoas owns memory planning, omit the physical `pto.alloc_tile addr`
     # so ptoas runs at --pto-level=level2 (which rejects any addr operand).
     emit_tile_addr = memory_planner != _passes.MemoryPlanner.PTOAS
+    # Source locations let ptoas name the user's .py line instead of a line in
+    # the generated artifact (which, under @pl.jit, the user never sees).
     units: list[_CodegenUnit] = []
 
     # Grouped functions: one MLIR module per group
@@ -1619,7 +1675,9 @@ def _generate_single_chip(
             grouped_program = _ir_core.Program(members, group_name, transformed_program.span)
             stage = StageRecord(name=f"kernel_codegen:{group_name}", start=time.perf_counter())
             ir_record = StageRecord(name="ir_to_mlir", start=time.perf_counter())
-            pto_code = _codegen_core.PTOCodegen().generate(grouped_program, emit_tile_addr=emit_tile_addr)
+            pto_code = _codegen_core.PTOCodegen().generate(
+                grouped_program, emit_tile_addr=emit_tile_addr, emit_source_loc=emit_source_loc
+            )
             ir_record.end = time.perf_counter()
             stage.children.append(ir_record)
             units.append(_CodegenUnit(group_name, pto_code, members, is_group=True, stage_record=stage))
@@ -1643,7 +1701,9 @@ def _generate_single_chip(
             single_program = _ir_core.Program([*peer_funcs, func], func.name, transformed_program.span)
             stage = StageRecord(name=f"kernel_codegen:{func.name}", start=time.perf_counter())
             ir_record = StageRecord(name="ir_to_mlir", start=time.perf_counter())
-            pto_code = _codegen_core.PTOCodegen().generate(single_program, emit_tile_addr=emit_tile_addr)
+            pto_code = _codegen_core.PTOCodegen().generate(
+                single_program, emit_tile_addr=emit_tile_addr, emit_source_loc=emit_source_loc
+            )
             ir_record.end = time.perf_counter()
             stage.children.append(ir_record)
             units.append(_CodegenUnit(func.name, pto_code, [func], is_group=False, stage_record=stage))

--- a/python/pypto/ir/compile.py
+++ b/python/pypto/ir/compile.py
@@ -196,6 +196,7 @@ def compile(  # noqa: PLR0913
     platform: str | None = None,
     distributed_config: Any = None,
     analyze_auto_scopes_for_deps: bool = False,
+    emit_source_loc: bool | None = None,
 ) -> "CompiledProgram | DistributedCompiledProgram":
     """Compile a Program through passes and codegen.
 
@@ -220,6 +221,11 @@ def compile(  # noqa: PLR0913
         backend_type: Backend type for passes and codegen (default: Ascend910B)
         skip_ptoas: Skip the ptoas compilation step and emit raw MLIR (.pto) files
             instead of compiled C++ kernel wrappers.
+        emit_source_loc: When True, each generated ``.pto`` operation carries an
+            MLIR ``loc("file":line:col)`` derived from the IR ``Span``, so a ptoas
+            diagnostic names the user's source line rather than a line in the
+            generated artifact. ``None`` (default) reads the
+            ``PYPTO_EMIT_PTO_LOC`` environment variable, which defaults to on.
         verification_level: Override verification level for this compilation via
             PassContext. None uses the default (Basic, or PYPTO_VERIFY_LEVEL env var).
         diagnostic_phase: Override the diagnostic phase gate for this compilation
@@ -343,6 +349,7 @@ def compile(  # noqa: PLR0913
                     output_dir,
                     skip_ptoas=skip_ptoas,
                     memory_planner=mplan,
+                    emit_source_loc=emit_source_loc,
                 )
         except PartialCodegenError as exc:
             _write_files(exc.files, output_dir)

--- a/python/pypto/pypto_core/codegen.pyi
+++ b/python/pypto/pypto_core/codegen.pyi
@@ -24,7 +24,7 @@ class PTOCodegen:
     def __init__(self) -> None:
         """Create a new PTO code generator."""
 
-    def generate(self, program: Program, emit_tile_addr: bool = True) -> str:
+    def generate(self, program: Program, emit_tile_addr: bool = True, emit_source_loc: bool = True) -> str:
         """Generate PTO assembly from PyPTO IR Program.
 
         Args:
@@ -33,6 +33,10 @@ class PTOCodegen:
                 on ``pto.alloc_tile`` (ptoas ``--pto-level=level3``). When False,
                 omit ``addr`` so the ptoas PlanMemory pass allocates instead
                 (``--pto-level=level2``).
+            emit_source_loc: When True (default), suffix every emitted operation
+                with an MLIR ``loc("file":line:col)`` taken from the IR ``Span``,
+                so ptoas diagnostics name the user's source instead of a line in
+                the generated ``.pto``. When False, emit no locations.
 
         Returns:
             PTO assembly code string (.pto format) with instructions like tmul, tadd, FOR/ENDFOR, etc.

--- a/src/codegen/pto/pto_codegen.cpp
+++ b/src/codegen/pto/pto_codegen.cpp
@@ -43,6 +43,7 @@
 #include "pypto/ir/op_registry.h"
 #include "pypto/ir/program.h"
 #include "pypto/ir/scalar_expr.h"
+#include "pypto/ir/span.h"
 #include "pypto/ir/stmt.h"
 #include "pypto/ir/tile_view_semantics.h"
 #include "pypto/ir/transforms/utils/memref_utils.h"
@@ -77,6 +78,58 @@ using ir::YieldStmtPtr;
 namespace transform_utils = ir::transform_utils;
 
 namespace {
+
+// Escape a source path for an MLIR `"..."` string literal. A path is an
+// arbitrary OS byte string — on POSIX every byte except `/` and NUL is legal, so
+// a quote, a backslash, or a raw control character in one must not be able to
+// break the module. MLIR's lexer accepts `\\`, `\"`, `\n`, `\t` and `\xx` hex
+// escapes, and rejects an unescaped control character inside a literal, so
+// anything outside printable ASCII is emitted as a hex escape.
+std::string EscapeMlirString(const std::string& str) {
+  static constexpr char kHexDigits[] = "0123456789ABCDEF";
+  std::string escaped;
+  escaped.reserve(str.size());
+  for (char c : str) {
+    const auto byte = static_cast<unsigned char>(c);
+    if (c == '\\' || c == '"') {
+      escaped.push_back('\\');
+      escaped.push_back(c);
+    } else if (c == '\n') {
+      escaped += "\\n";
+    } else if (c == '\t') {
+      escaped += "\\t";
+    } else if (byte < 0x20 || byte == 0x7F) {
+      escaped += "\\";
+      escaped.push_back(kHexDigits[byte >> 4]);
+      escaped.push_back(kHexDigits[byte & 0x0F]);
+    } else {
+      escaped.push_back(c);
+    }
+  }
+  return escaped;
+}
+
+// True when `inner` is a source range nested inside `outer` — the invariant a
+// sub-expression's span satisfies with respect to its enclosing statement's span.
+//
+// This is what rejects a Call span that a pass overwrote with a coarser one.
+// ConvertTensorToTileOps rebuilds every tile op it synthesizes with the enclosing
+// *function*'s span (convert_tensor_to_tile_ops_pass.cpp), which begins before the
+// statement and therefore fails containment — so the statement's own span, which
+// that rewrite preserved, is kept instead.
+bool SpanContains(const ir::Span* outer, const ir::Span& inner) {
+  if (!inner.is_valid() || inner.filename_.empty()) return false;
+  // No usable enclosing span means nothing contradicts the inner one.
+  if (outer == nullptr || !outer->is_valid() || outer->filename_.empty()) return true;
+  if (outer->filename_ != inner.filename_) return false;
+  // An unknown end line (-1) degenerates to a single-line range at the start.
+  const int outer_end = outer->end_line_ > 0 ? outer->end_line_ : outer->begin_line_;
+  const int inner_end = inner.end_line_ > 0 ? inner.end_line_ : inner.begin_line_;
+  // Both ends must sit inside the statement. Checking only the start would accept
+  // a rebuilt span that begins within the statement but runs past its last line,
+  // which is exactly the untrustworthy case this predicate exists to reject.
+  return inner.begin_line_ >= outer->begin_line_ && inner_end <= outer_end;
+}
 
 // Full-MemRef-identity key used by PTOAS memory-planner codegen to decide when
 // two tile variables denote the *same* buffer (and must share one tile_buf
@@ -541,8 +594,10 @@ const backend::BackendHandler* PTOCodegen::GetBackendHandler() const { return ba
 // Generate entry and GenerateFunction
 // ========================================================================
 
-std::string PTOCodegen::Generate(const ProgramPtr& program, bool emit_tile_addr) {
+std::string PTOCodegen::Generate(const ProgramPtr& program, bool emit_tile_addr, bool emit_source_loc) {
   emit_tile_addr_ = emit_tile_addr;
+  emit_source_loc_ = emit_source_loc;
+  current_span_ = nullptr;
   stream_.str("");
   stream_.clear();
   fs_.constants_section.str("");
@@ -1082,6 +1137,9 @@ void PTOCodegen::EmitMakeTensorViews(const FunctionPtr& func) {
     if (param->name_hint_ == "__gm_pipe_buffer") continue;         // GM slot buffer is a raw pointer
     if (fs_.ffts_workspace_vars.count(param.get()) > 0) continue;  // FFTS workspace stays a memref
 
+    // ptoas rejects a malformed view (bad strides / layout) on this line, so
+    // attribute it to the parameter that declared the tensor.
+    SpanScope param_loc(this, &param->span_);
     std::string tensor_view = fs_.tensor_to_view.at(GetVarKey(param));
     const size_t rank = tensor_type->shape_.size();
 
@@ -1136,8 +1194,7 @@ void PTOCodegen::EmitMakeTensorViews(const FunctionPtr& func) {
     // ``tensor_view_->stride`` is empty.
     auto emit_stride_mul = [&](const std::string& lhs, size_t dim_idx, size_t stride_slot) -> std::string {
       std::string mul_name = NewNamedTemp(param->name_hint_ + "_s" + std::to_string(stride_slot));
-      stream_ << GetIndent() << mul_name << " = arith.muli " << lhs << ", " << shape_dim_names[dim_idx]
-              << " : index\n";
+      Emit(mul_name + " = arith.muli " + lhs + ", " + shape_dim_names[dim_idx] + " : index");
       return mul_name;
     };
 
@@ -1204,24 +1261,27 @@ void PTOCodegen::EmitMakeTensorViews(const FunctionPtr& func) {
       }
     }
 
-    stream_ << GetIndent() << tensor_view << " = pto.make_tensor_view ";
-    stream_ << GetVarName(param);
+    // Buffer the statement so Emit() writes it as one line and can suffix the
+    // parameter's source location.
+    std::ostringstream view_line;
+    view_line << tensor_view << " = pto.make_tensor_view ";
+    view_line << GetVarName(param);
 
     // Emit shape (verbatim from IR — canonical).
-    stream_ << ", shape = [";
+    view_line << ", shape = [";
     for (size_t j = 0; j < rank; ++j) {
-      if (j > 0) stream_ << ", ";
-      stream_ << shape_dim_names[j];
+      if (j > 0) view_line << ", ";
+      view_line << shape_dim_names[j];
     }
-    stream_ << "],";
+    view_line << "],";
 
     // Emit strides.
-    stream_ << " strides = [";
+    view_line << " strides = [";
     for (size_t j = 0; j < rank; ++j) {
-      if (j > 0) stream_ << ", ";
-      stream_ << stride_names[j];
+      if (j > 0) view_line << ", ";
+      view_line << stride_names[j];
     }
-    stream_ << "]";
+    view_line << "]";
 
     std::string layout_str = "nd";
     switch (layout) {
@@ -1240,14 +1300,15 @@ void PTOCodegen::EmitMakeTensorViews(const FunctionPtr& func) {
       case ir::TensorLayout::ND:
         break;
     }
-    stream_ << " {layout = #pto.layout<" << layout_str << ">} : ";
+    view_line << " {layout = #pto.layout<" << layout_str << ">} : ";
 
-    stream_ << "!pto.tensor_view<";
+    view_line << "!pto.tensor_view<";
     for (size_t j = 0; j < rank; ++j) {
-      if (j > 0) stream_ << "x";
-      stream_ << "?";
+      if (j > 0) view_line << "x";
+      view_line << "?";
     }
-    stream_ << "x" << GetTypeString(tensor_type->dtype_) << ">\n";
+    view_line << "x" << GetTypeString(tensor_type->dtype_) << ">";
+    Emit(view_line.str());
   }
 }
 
@@ -1538,9 +1599,11 @@ void PTOCodegen::EmitMultiBufferRegionAllocs() {
     // point of describing the slots to it. Under the PyPTO planner no region is
     // planned at all (see PlanMultiBufferRegions). Both extents are always present —
     // planning rejects an allocation whose valid shape it cannot state statically.
-    stream_ << GetIndent() << region.region_ssa << " = pto.alloc_multi_tile"
-            << " valid_row = " << region.valid_row_ssa << " valid_col = " << region.valid_col_ssa << " : "
-            << region.mtb_type_str << "\n";
+    // Region declarations are synthesized from the whole allocation rather than
+    // one statement, so the base variable's span is the closest true source.
+    SpanScope base_loc(this, &base->span_);
+    Emit(region.region_ssa + " = pto.alloc_multi_tile valid_row = " + region.valid_row_ssa +
+         " valid_col = " + region.valid_col_ssa + " : " + region.mtb_type_str);
   }
 }
 
@@ -1811,18 +1874,23 @@ void PTOCodegen::EmitExtraAllocTiles() {
   // Regions first: every `pto.multi_tile_get` in the body reads one, so the
   // declaration has to dominate them all.
   EmitMultiBufferRegionAllocs();
+  // These allocations are hoisted out of the body (e.g. reshape outputs), so no
+  // single statement owns them; the function is the closest true source.
+  SpanScope func_loc(this, fs_.current_function ? &fs_.current_function->span_ : nullptr);
   for (const auto& alloc : fs_.extra_alloc_tiles) {
-    stream_ << GetIndent() << alloc.name << " = pto.alloc_tile";
+    std::ostringstream line;
+    line << alloc.name << " = pto.alloc_tile";
     if (emit_tile_addr_ && !alloc.addr_ssa.empty()) {
-      stream_ << " addr = " << alloc.addr_ssa;
+      line << " addr = " << alloc.addr_ssa;
     }
     if (!alloc.valid_row_ssa.empty()) {
-      stream_ << " valid_row = " << alloc.valid_row_ssa;
+      line << " valid_row = " << alloc.valid_row_ssa;
     }
     if (!alloc.valid_col_ssa.empty()) {
-      stream_ << " valid_col = " << alloc.valid_col_ssa;
+      line << " valid_col = " << alloc.valid_col_ssa;
     }
-    stream_ << " : " << alloc.type_string << "\n";
+    line << " : " << alloc.type_string;
+    Emit(line.str());
   }
 }
 
@@ -1838,6 +1906,11 @@ void PTOCodegen::VisitStmt(const ir::StmtPtr& stmt) {
   INTERNAL_CHECK_SPAN(!ir::As<ir::SplitAivScopeStmt>(stmt), stmt->span_)
       << "Internal error: SplitAivScopeStmt reached PTO codegen; it must be lowered and erased by "
          "LowerAutoVectorSplit (pass 20).";
+  // Primary location source: every op lowered under this statement is attributed
+  // to the statement's source line unless a nested Call refines it (see
+  // VisitExpr_(CallPtr)). The statement span is what passes reliably preserve —
+  // they frequently rebuild the Call underneath it with a coarser span.
+  SpanScope stmt_loc(this, &stmt->span_);
   ir::IRVisitor::VisitStmt(stmt);
 }
 
@@ -2016,6 +2089,10 @@ void PTOCodegen::VisitExpr_(const CallPtr& op) {
   if (op_info == nullptr) {
     ThrowNoCodegenForCall(op_name);
   }
+  // Refine to the Call's own (column-accurate) span when it is genuinely nested
+  // in the enclosing statement; otherwise keep the statement span, which is the
+  // trustworthy one for any Call a pass rebuilt.
+  SpanScope call_loc(this, SpanContains(current_span_, op->span_) ? &op->span_ : nullptr);
   std::string mlir_line = op_info->codegen_func(op, *this);
   if (!mlir_line.empty()) {
     Emit(mlir_line);
@@ -2040,7 +2117,23 @@ std::vector<ir::VarPtr> PTOCodegen::ResolveTupleResultElements(const ir::VarPtr&
   return collector.elements();
 }
 
-void PTOCodegen::Emit(const std::string& line) { stream_ << GetIndent() << line << "\n"; }
+void PTOCodegen::Emit(const std::string& line) { stream_ << GetIndent() << line << LocSuffix() << "\n"; }
+
+void PTOCodegen::EmitStructural(const std::string& line) { stream_ << GetIndent() << line << "\n"; }
+
+std::string PTOCodegen::LocSuffix() const {
+  if (!emit_source_loc_ || current_span_ == nullptr) return "";
+  const ir::Span& span = *current_span_;
+  // Without a filename there is nothing to attribute, and MLIR's FileLineColLoc
+  // needs non-negative coordinates. Emitting nothing leaves the op exactly as it
+  // was before locations existed (ptoas then reports the .pto line) — strictly
+  // better than a misleading `loc("":0:0)`.
+  if (span.filename_.empty() || !span.is_valid()) return "";
+  // is_valid() admits an unknown column (-1); MLIR does not.
+  const int column = span.begin_column_ > 0 ? span.begin_column_ : 1;
+  return " loc(\"" + EscapeMlirString(span.filename_) + "\":" + std::to_string(span.begin_line_) + ":" +
+         std::to_string(column) + ")";
+}
 
 std::string PTOCodegen::GetExprAsCode(const ExprPtr& expr) {
   if (auto var = As<ir::Var>(expr)) {

--- a/src/codegen/pto/pto_control_flow_codegen.cpp
+++ b/src/codegen/pto/pto_control_flow_codegen.cpp
@@ -222,19 +222,19 @@ void PTOCodegen::VisitStmt_(const IfStmtPtr& op) {
 
   if (op->return_vars_.empty()) {
     // Simple scf.if (no return values)
-    Emit("scf.if " + condition + " {");
+    EmitStructural("scf.if " + condition + " {");
     indent_level_++;
     VisitStmt(op->then_body_);
     indent_level_--;
 
     const auto& else_body = op->else_body_;
     if (else_body) {
-      Emit("} else {");
+      EmitStructural("} else {");
       indent_level_++;
       VisitStmt(*else_body);
       indent_level_--;
     }
-    Emit("}");
+    EmitStructural("}");
   } else {
     // Like loops, keep tile return values out of scf.if results. Pre-declare
     // tile buffers for return_vars using the canonical MemRef address (assigned
@@ -328,10 +328,10 @@ void PTOCodegen::VisitStmt_(const IfStmtPtr& op) {
     }
 
     if (!scf_return_names.empty()) {
-      Emit(JoinCommaSep(scf_return_names) + " = scf.if " + condition + " -> (" +
-           JoinCommaSep(scf_return_types) + ") {");
+      EmitStructural(JoinCommaSep(scf_return_names) + " = scf.if " + condition + " -> (" +
+                     JoinCommaSep(scf_return_types) + ") {");
     } else {
-      Emit("scf.if " + condition + " {");
+      EmitStructural("scf.if " + condition + " {");
     }
     indent_level_++;
 
@@ -472,14 +472,14 @@ void PTOCodegen::VisitStmt_(const IfStmtPtr& op) {
     emit_branch(op->then_body_, "then");
     indent_level_--;
 
-    Emit("} else {");
+    EmitStructural("} else {");
     indent_level_++;
     const auto& else_body = op->else_body_;
     INTERNAL_CHECK_SPAN(else_body.has_value(), op->span_)
         << "Internal error: IfStmt with return_vars has no else_body";
     emit_branch(*else_body, "else");
     indent_level_--;
-    Emit("}");
+    EmitStructural("}");
 
     // Bind in-place return vars (array / tensor) to the shared backing SSA both
     // branches mutated in place. Reads after the IfStmt then resolve to that
@@ -612,7 +612,7 @@ void PTOCodegen::VisitStmt_(const ForStmtPtr& op) {
 
   if (!has_scalar_iter_args) {
     // Simple scf.for (no iter_args, or all iter_args are non-scalar)
-    Emit("scf.for " + loop_var_name + " = " + start + " to " + stop + " step " + step + " {");
+    EmitStructural("scf.for " + loop_var_name + " = " + start + " to " + stop + " step " + step + " {");
     indent_level_++;
 
     fs_.yield_buffer.clear();
@@ -620,7 +620,7 @@ void PTOCodegen::VisitStmt_(const ForStmtPtr& op) {
     fs_.yield_buffer.clear();
 
     indent_level_--;
-    Emit("}");
+    EmitStructural("}");
   } else {
     // scf.for with scalar iter_args only
     std::vector<std::string> init_values;
@@ -654,9 +654,9 @@ void PTOCodegen::VisitStmt_(const ForStmtPtr& op) {
 
     // Emit: %ret0 = scf.for %i = %start to %stop step %step
     //           iter_args(%acc = %init) -> (type) {
-    Emit(JoinCommaSep(return_var_names) + " = scf.for " + loop_var_name + " = " + start + " to " + stop +
-         " step " + step + " iter_args(" + JoinPairs(iter_arg_names, " = ", init_values) + ") -> (" +
-         JoinCommaSep(iter_arg_types) + ") {");
+    EmitStructural(JoinCommaSep(return_var_names) + " = scf.for " + loop_var_name + " = " + start + " to " +
+                   stop + " step " + step + " iter_args(" + JoinPairs(iter_arg_names, " = ", init_values) +
+                   ") -> (" + JoinCommaSep(iter_arg_types) + ") {");
     indent_level_++;
 
     fs_.yield_buffer.clear();
@@ -691,7 +691,7 @@ void PTOCodegen::VisitStmt_(const ForStmtPtr& op) {
     fs_.yield_buffer.clear();
 
     indent_level_--;
-    Emit("}");
+    EmitStructural("}");
   }
 }
 
@@ -762,7 +762,7 @@ void PTOCodegen::VisitStmt_(const WhileStmtPtr& op) {
 
   if (!has_scalar_iter_args) {
     // Simple scf.while (no iter_args, or all iter_args are non-scalar)
-    Emit("scf.while : () -> () {");
+    EmitStructural("scf.while : () -> () {");
     indent_level_++;
 
     VisitExpr(op->condition_);
@@ -771,7 +771,7 @@ void PTOCodegen::VisitStmt_(const WhileStmtPtr& op) {
     Emit("scf.condition(" + cond + ")");
 
     indent_level_--;
-    Emit("} do {");
+    EmitStructural("} do {");
     indent_level_++;
 
     fs_.yield_buffer.clear();
@@ -781,7 +781,7 @@ void PTOCodegen::VisitStmt_(const WhileStmtPtr& op) {
     fs_.yield_buffer.clear();
 
     indent_level_--;
-    Emit("}");
+    EmitStructural("}");
   } else {
     // scf.while with scalar iter_args only
     std::vector<std::string> init_values;
@@ -827,8 +827,9 @@ void PTOCodegen::VisitStmt_(const WhileStmtPtr& op) {
     std::string types_str = "(" + JoinCommaSep(iter_arg_types) + ")";
 
     // Emit: %ret0, %ret1 = scf.while (%before0 = %init0, ...) : (types) -> (types) {
-    Emit(JoinCommaSep(return_var_names) + " = scf.while (" + JoinPairs(before_arg_names, " = ", init_values) +
-         ") : " + types_str + " -> " + types_str + " {");
+    EmitStructural(JoinCommaSep(return_var_names) + " = scf.while (" +
+                   JoinPairs(before_arg_names, " = ", init_values) + ") : " + types_str + " -> " + types_str +
+                   " {");
     indent_level_++;
 
     // Before region: register before-region args, evaluate condition
@@ -843,10 +844,10 @@ void PTOCodegen::VisitStmt_(const WhileStmtPtr& op) {
          JoinCommaSep(iter_arg_types));
 
     indent_level_--;
-    Emit("} do {");
+    EmitStructural("} do {");
 
     // After region: emit ^bb0 block header with typed arguments
-    Emit("^bb0(" + JoinPairs(after_arg_names, " : ", iter_arg_types) + "):");
+    EmitStructural("^bb0(" + JoinPairs(after_arg_names, " : ", iter_arg_types) + "):");
     indent_level_++;
 
     // Re-register iter_args with after-region SSA names
@@ -874,7 +875,7 @@ void PTOCodegen::VisitStmt_(const WhileStmtPtr& op) {
     fs_.yield_buffer.clear();
 
     indent_level_--;
-    Emit("}");
+    EmitStructural("}");
   }
 }
 

--- a/tests/st/runtime/cross_core/test_cross_core_grouped_tpop_tfree.py
+++ b/tests/st/runtime/cross_core/test_cross_core_grouped_tpop_tfree.py
@@ -26,6 +26,7 @@ frees.
 
 import importlib.util
 import os
+import re
 import shutil
 import sys
 import tempfile
@@ -103,6 +104,20 @@ def _resolve_backend_type(platform: str) -> BackendType:
         ) from exc
 
 
+_TRAILING_LOC_RE = re.compile(r'\s+loc\("(?:[^"\\]|\\.)*":\d+:\d+\)\s*$')
+
+
+def _op_text(line: str) -> str:
+    """Return one generated ``.pto`` line without its trailing MLIR location.
+
+    PTO codegen suffixes every operation with ``loc("file":line:col)``, so an
+    assertion that anchors on the end of an op must drop it first. Mirrors
+    ``tests/ut/_pto_loc_common.strip_loc``, duplicated because the UT helper is
+    not on the ST tree's import path.
+    """
+    return _TRAILING_LOC_RE.sub("", line).strip()
+
+
 def _rewrite_consecutive_tpop_tfree_pto(pto_path: Path) -> None:
     lines = pto_path.read_text(encoding="utf-8").splitlines()
 
@@ -120,7 +135,7 @@ def _rewrite_consecutive_tpop_tfree_pto(pto_path: Path) -> None:
 
     tpop_indices = [i for i in range(func_start, func_end) if "pto.tpop_from_aiv" in lines[i]]
     tfree_indices = [
-        i for i in range(func_start, func_end) if lines[i].strip() == "pto.tfree_from_aiv {split = 1}"
+        i for i in range(func_start, func_end) if _op_text(lines[i]) == "pto.tfree_from_aiv {split = 1}"
     ]
     assert len(tpop_indices) == 2, (
         f"Expected 2 tpop lines in reordered-artifact test, got {len(tpop_indices)}"
@@ -137,8 +152,8 @@ def _rewrite_consecutive_tpop_tfree_pto(pto_path: Path) -> None:
     pop0, alloc0, use0, free0, pop1, alloc1, use1, free1 = original_block
     assert use0.strip().startswith("pto.tmov ins("), use0
     assert use1.strip().startswith("pto.tmov ins("), use1
-    assert free0.strip() == "pto.tfree_from_aiv {split = 1}", free0
-    assert free1.strip() == "pto.tfree_from_aiv {split = 1}", free1
+    assert _op_text(free0) == "pto.tfree_from_aiv {split = 1}", free0
+    assert _op_text(free1) == "pto.tfree_from_aiv {split = 1}", free1
 
     consecutive_pop_then_free_block = [
         pop0,
@@ -152,8 +167,8 @@ def _rewrite_consecutive_tpop_tfree_pto(pto_path: Path) -> None:
     ]
     assert "pto.tpop_from_aiv" in consecutive_pop_then_free_block[0], consecutive_pop_then_free_block[0]
     assert "pto.tpop_from_aiv" in consecutive_pop_then_free_block[1], consecutive_pop_then_free_block[1]
-    assert consecutive_pop_then_free_block[-2].strip() == "pto.tfree_from_aiv {split = 1}"
-    assert consecutive_pop_then_free_block[-1].strip() == "pto.tfree_from_aiv {split = 1}"
+    assert _op_text(consecutive_pop_then_free_block[-2]) == "pto.tfree_from_aiv {split = 1}"
+    assert _op_text(consecutive_pop_then_free_block[-1]) == "pto.tfree_from_aiv {split = 1}"
 
     rewritten = (
         "\n".join(lines[: tpop_indices[0]] + consecutive_pop_then_free_block + lines[tfree_indices[1] + 1 :])

--- a/tests/ut/_pto_loc_common.py
+++ b/tests/ut/_pto_loc_common.py
@@ -1,0 +1,36 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Helpers for asserting on generated ``.pto`` lines that carry MLIR locations.
+
+PTO codegen suffixes every emitted operation with ``loc("file":line:col)`` (see
+``tests/ut/codegen/test_pto_codegen_source_loc.py``). Assertions that anchor to
+the *end* of an operation -- ``endswith(...)``, ``strip() == ...`` -- must drop
+that suffix first, or they assert on the source path of the test file.
+"""
+
+import re
+
+# Trailing ` loc("<path>":<line>:<col>)`; the path may contain escaped quotes.
+_TRAILING_LOC_RE = re.compile(r'\s+loc\("(?:[^"\\]|\\.)*":\d+:\d+\)\s*$')
+
+
+def strip_loc(line: str) -> str:
+    """Return ``line`` without its trailing MLIR location and surrounding space.
+
+    Safe to call on lines that carry no location -- they are returned stripped
+    of whitespace only, so a call site reads the same either way.
+
+    Args:
+        line: One line of generated ``.pto`` text.
+
+    Returns:
+        The operation text with any trailing ``loc(...)`` removed and both ends
+        whitespace-stripped.
+    """
+    return _TRAILING_LOC_RE.sub("", line).strip()

--- a/tests/ut/codegen/distributed/test_distributed_pto_codegen.py
+++ b/tests/ut/codegen/distributed/test_distributed_pto_codegen.py
@@ -43,6 +43,7 @@ import re
 import pypto.language as pl
 import pypto.language.distributed as pld
 import pytest
+from _pto_loc_common import strip_loc
 from pypto import DataType, backend, codegen, ir
 from pypto.backend import BackendType
 from pypto.ir.builder import IRBuilder
@@ -926,7 +927,7 @@ def test_wait_casts_loop_induction_expected_to_i32():
 
     mlir = _generate_mlir(P)
     twait_line = next(line for line in mlir.splitlines() if "pto.comm.twait(" in line)
-    assert twait_line.rstrip().endswith("i32) {cmp = #pto<wait_cmp ge>}"), twait_line
+    assert strip_loc(twait_line).endswith("i32) {cmp = #pto<wait_cmp ge>}"), twait_line
     body = mlir.split("func.func @kernel", 1)[1]
     assert "arith.index_cast" in body and "to i32" in body, body
 
@@ -951,7 +952,7 @@ def test_notify_casts_loop_induction_value_to_i32():
 
     mlir = _generate_mlir(P)
     tnotify_line = next(line for line in mlir.splitlines() if "pto.comm.tnotify(" in line)
-    assert tnotify_line.rstrip().endswith("i32) {notifyOp = #pto<notify_op set>}"), tnotify_line
+    assert strip_loc(tnotify_line).endswith("i32) {notifyOp = #pto<notify_op set>}"), tnotify_line
     body = mlir.split("func.func @kernel", 1)[1]
     assert "arith.index_cast" in body and "to i32" in body, body
 

--- a/tests/ut/codegen/test_array_codegen.py
+++ b/tests/ut/codegen/test_array_codegen.py
@@ -18,6 +18,7 @@ mutations land on the same backing storage.
 import pypto.language as pl
 import pytest
 from _orchestration_codegen_common import _finalize_handbuilt_for_codegen
+from _pto_loc_common import strip_loc
 from pypto import codegen, passes
 from pypto.pypto_core import DataType, ir
 
@@ -503,7 +504,7 @@ def test_incore_array_declare_set_get_lower_to_local_array():
     for ln in set_lines + get_lines:
         assert array_ssa in ln, ln
         assert ": !pto.local_array<8xi32>" in ln, ln
-    assert get_lines[0].rstrip().endswith("-> i32"), get_lines[0]
+    assert strip_loc(get_lines[0]).endswith("-> i32"), get_lines[0]
     # The get rvalue is the value operand of the second set.
     get_result = get_lines[0].split("=")[0].strip()
     assert get_result in set_lines[1], (get_lines[0], set_lines[1])

--- a/tests/ut/codegen/test_pto_codegen_ops.py
+++ b/tests/ut/codegen/test_pto_codegen_ops.py
@@ -20,6 +20,7 @@ import warnings
 
 import pypto.language as pl
 import pytest
+from _pto_loc_common import strip_loc
 from pypto import DataType, backend, codegen, ir
 from pypto.backend import BackendType
 from pypto.ir.pass_manager import OptimizationStrategy, PassManager
@@ -682,7 +683,7 @@ class TestB01PrecisionAndRowExpandAddCodegen:
         default_line = self._op_line(self._generate_mlir(DefaultProg), "pto.tdiv")
         high_precision_line = self._op_line(self._generate_mlir(HighPrecisionProg), "pto.tdiv")
         assert "precisionType" not in default_line
-        assert high_precision_line.endswith("{precisionType = #pto<div_precision high_precision>}")
+        assert strip_loc(high_precision_line).endswith("{precisionType = #pto<div_precision high_precision>}")
         assert ") outs(" in high_precision_line
         assert high_precision_line.index("outs(") < high_precision_line.index("precisionType")
 
@@ -699,7 +700,7 @@ class TestB01PrecisionAndRowExpandAddCodegen:
                 return result
 
         log_line = self._op_line(self._generate_mlir(LogProg), "pto.tlog")
-        assert log_line.endswith("{precisionType = #pto<log_precision high_precision>}")
+        assert strip_loc(log_line).endswith("{precisionType = #pto<log_precision high_precision>}")
 
     def test_trowexpandadd_emits_two_and_three_operand_forms(self):
         @pl.program
@@ -2456,7 +2457,9 @@ class TestSetValidShapeCodegen:
                 return pl.store(narrowed, [0, 0], dst)
 
         mlir = self._generate_mlir(Prog)
-        set_validshape_line = next(line.strip() for line in mlir.splitlines() if "pto.set_validshape" in line)
+        set_validshape_line = next(
+            strip_loc(line) for line in mlir.splitlines() if "pto.set_validshape" in line
+        )
         narrowed_alloc_lines = [
             line.strip() for line in mlir.splitlines() if "%narrowed" in line and "pto.alloc_tile" in line
         ]
@@ -3745,7 +3748,7 @@ class TestB03TriAndGatherCodegen:
     def _alloc_tile_type(cls, mlir: str, ssa: str) -> str:
         actual_ssa = cls._resolve_ssa(mlir, ssa)
         line = next(
-            line.strip()
+            strip_loc(line)
             for line in mlir.splitlines()
             if line.strip().startswith(f"{actual_ssa} = pto.alloc_tile")
         )
@@ -3768,7 +3771,7 @@ class TestB03TriAndGatherCodegen:
             if line.strip().startswith(f"{actual_result} = pto.partition_view")
         )
         assert line.startswith(f"{actual_result} = pto.partition_view {actual_source}, offsets = [")
-        assert line.endswith(f" -> {result_type}")
+        assert strip_loc(line).endswith(f" -> {result_type}")
 
     @classmethod
     def _assert_mgather(
@@ -3781,7 +3784,7 @@ class TestB03TriAndGatherCodegen:
         result_type: str,
         attributes: str,
     ) -> None:
-        line = next(line.strip() for line in mlir.splitlines() if "pto.mgather" in line)
+        line = next(strip_loc(line) for line in mlir.splitlines() if "pto.mgather" in line)
         actual_operands = [cls._resolve_ssa(mlir, operand) for operand in operands]
         actual_result = cls._resolve_ssa(mlir, result)
         expected = (
@@ -3806,7 +3809,7 @@ class TestB03TriAndGatherCodegen:
         mlir = self._generate_mlir(Prog)
         mask_ssa = self._resolve_ssa(mlir, "%mask")
         mask_type = self._alloc_tile_type(mlir, "%mask")
-        line = next(line.strip() for line in mlir.splitlines() if '"pto.ttri"' in line)
+        line = next(strip_loc(line) for line in mlir.splitlines() if '"pto.ttri"' in line)
         assert "%c1_i32 = arith.constant 1 : i32" in mlir
         assert line == (
             f'"pto.ttri"(%c1_i32, {mask_ssa}) {{upperOrLower = 1 : i32}} : (i32, {mask_type}) -> ()'
@@ -3863,7 +3866,7 @@ class TestB03TriAndGatherCodegen:
         src_ssa = self._resolve_ssa(mlir, "%src_tile")
         offset_ssa = self._resolve_ssa(mlir, "%offset_tile")
         gathered_ssa = self._resolve_ssa(mlir, "%gathered")
-        line = next(line.strip() for line in mlir.splitlines() if "pto.tgatherb" in line)
+        line = next(strip_loc(line) for line in mlir.splitlines() if "pto.tgatherb" in line)
         assert line == (
             f"pto.tgatherb ins({src_ssa}, {offset_ssa} : {src_type}, {offset_type}) "
             f"outs({gathered_ssa} : {gathered_type})"

--- a/tests/ut/codegen/test_pto_codegen_source_loc.py
+++ b/tests/ut/codegen/test_pto_codegen_source_loc.py
@@ -1,0 +1,334 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""MLIR source locations in generated .pto.
+
+PTO codegen suffixes every emitted operation with ``loc("file":line:col)`` taken
+from the IR ``Span``, so a ptoas verifier rejection names the user's source line
+instead of a line in the generated artifact (which, under ``@pl.jit``, the user
+never sees).
+
+Two properties matter and are both easy to regress:
+
+1. **Structural lines take no location.** MLIR's trailing ``loc(...)`` is legal
+   only at the end of a complete operation, so region braces and block labels
+   must not carry one -- otherwise the module stops parsing.
+2. **The location names the statement, not the ``def`` line.** Passes that
+   synthesize tile ops stamp the enclosing *function*'s span on the ``Call`` they
+   build while preserving the ``AssignStmt``'s own span, so codegen must prefer
+   the statement span unless the Call's span is genuinely nested inside it.
+"""
+
+import importlib.util
+import os
+import re
+import sys
+
+import pypto.language as pl
+import pytest
+from pypto import backend, codegen, ir
+from pypto.backend import BackendType
+from pypto.backend.pto_backend import emit_source_loc_default
+from pypto.ir.pass_manager import OptimizationStrategy, PassManager
+
+_THIS_FILE = os.path.abspath(__file__)
+
+with open(_THIS_FILE) as _source:
+    _SOURCE_LINES = _source.read().splitlines()
+
+# `loc("<path>":<line>:<col>)` at end of line; the path is greedy-free so an
+# escaped quote inside it would fail the match rather than silently pass.
+_LOC_RE = re.compile(r' loc\("((?:[^"\\]|\\.)*)":(\d+):(\d+)\)$')
+
+
+def _generate(program_cls, *, emit_source_loc: bool = True) -> str:
+    """Run the Default pipeline and PTO codegen over the first function."""
+    backend.reset_for_testing()
+    backend.set_backend_type(BackendType.Ascend910B)
+    optimized = PassManager.get_strategy(OptimizationStrategy.Default).run_passes(program_cls)
+    funcs = list(optimized.functions.values())
+    assert funcs, "Program has no functions"
+    single = ir.Program([funcs[0]], funcs[0].name, optimized.span)
+    return codegen.PTOCodegen().generate(single, emit_source_loc=emit_source_loc)
+
+
+def _is_structural(line: str) -> bool:
+    """True for region braces and block labels -- lines that are not operations."""
+    stripped = line.strip()
+    return stripped.endswith("{") or stripped in ("}", "} else {", "} do {") or stripped.startswith("^bb")
+
+
+def _is_operation(line: str) -> bool:
+    """True for emitted MLIR operations that should carry a location.
+
+    Excludes the constants section: ``arith.constant`` values are deduplicated
+    across every use, so no single span is the right one for them.
+    """
+    stripped = line.strip()
+    if not stripped or _is_structural(stripped) or stripped == "return":
+        return False
+    if "arith.constant" in stripped:
+        return False
+    return "pto." in stripped or "arith." in stripped
+
+
+@pl.program
+class ElementwiseProg:
+    @pl.function(type=pl.FunctionType.InCore)
+    def kernel_elementwise(
+        self,
+        a: pl.Tensor[[128, 128], pl.FP32],
+        b: pl.Tensor[[128, 128], pl.FP32],
+        out: pl.Tensor[[128, 128], pl.FP32],
+    ) -> pl.Tensor[[128, 128], pl.FP32]:
+        ta: pl.Tile[[128, 128], pl.FP32] = pl.load(a, [0, 0], [128, 128])
+        tb: pl.Tile[[128, 128], pl.FP32] = pl.load(b, [0, 0], [128, 128])
+        ts: pl.Tile[[128, 128], pl.FP32] = pl.add(ta, tb)
+        te: pl.Tile[[128, 128], pl.FP32] = pl.exp(ts)
+        updated: pl.Tensor[[128, 128], pl.FP32] = pl.store(te, [0, 0], out)
+        return updated
+
+
+# Source lines of the statements above, resolved once so the assertions stay
+# correct if the classes move within this file.
+_ADD_LINE = next(i for i, ln in enumerate(_SOURCE_LINES, 1) if "pl.add(ta, tb)" in ln)
+_EXP_LINE = next(i for i, ln in enumerate(_SOURCE_LINES, 1) if "pl.exp(ts)" in ln)
+
+
+@pl.program
+class MultiLineProg:
+    @pl.function(type=pl.FunctionType.InCore)
+    def kernel_multiline(
+        self,
+        a: pl.Tensor[[128, 128], pl.FP32],
+        b: pl.Tensor[[128, 128], pl.FP32],
+        out: pl.Tensor[[128, 128], pl.FP32],
+    ) -> pl.Tensor[[128, 128], pl.FP32]:
+        ta: pl.Tile[[128, 128], pl.FP32] = pl.load(a, [0, 0], [128, 128])
+        tb: pl.Tile[[128, 128], pl.FP32] = pl.load(b, [0, 0], [128, 128])
+        # MULTILINE_ADD_START
+        ts: pl.Tile[[128, 128], pl.FP32] = pl.add(
+            ta,
+            tb,
+        )
+        # MULTILINE_ADD_END
+        return pl.store(ts, [0, 0], out)
+
+
+# Inclusive source range of the multi-line `pl.add` statement above, resolved
+# from the markers so the assertion survives edits elsewhere in this file.
+_MULTILINE_ADD_RANGE = (
+    next(i for i, ln in enumerate(_SOURCE_LINES, 1) if "# MULTILINE_ADD_START" in ln) + 1,
+    next(i for i, ln in enumerate(_SOURCE_LINES, 1) if "# MULTILINE_ADD_END" in ln) - 1,
+)
+
+
+@pl.program
+class ControlFlowProg:
+    @pl.function(type=pl.FunctionType.InCore)
+    def kernel_loop(
+        self,
+        a: pl.Tensor[[256, 128], pl.FP32],
+        out: pl.Tensor[[256, 128], pl.FP32],
+    ) -> pl.Tensor[[256, 128], pl.FP32]:
+        acc: pl.Tensor[[256, 128], pl.FP32] = out
+        for i in pl.range(2):
+            ta: pl.Tile[[128, 128], pl.FP32] = pl.load(a, [i * 128, 0], [128, 128])
+            te: pl.Tile[[128, 128], pl.FP32] = pl.exp(ta)
+            acc = pl.store(te, [i * 128, 0], acc)
+        return acc
+
+
+class TestSourceLocEmission:
+    """Every emitted operation carries a location naming this test file."""
+
+    def test_every_operation_carries_a_loc(self):
+        mlir = _generate(ElementwiseProg)
+        ops = [ln for ln in mlir.splitlines() if _is_operation(ln)]
+        assert ops, f"no operations found in:\n{mlir}"
+        missing = [ln.strip() for ln in ops if not _LOC_RE.search(ln)]
+        assert not missing, f"operations without loc(): {missing}"
+
+    def test_loc_names_this_source_file(self):
+        mlir = _generate(ElementwiseProg)
+        for line in mlir.splitlines():
+            match = _LOC_RE.search(line)
+            if match is None:
+                continue
+            assert match.group(1) == _THIS_FILE, f"unexpected loc file in: {line.strip()}"
+            assert int(match.group(2)) > 0
+            assert int(match.group(3)) > 0
+
+    def test_loc_names_the_statement_not_the_def_line(self):
+        """Regression guard for the statement-span fallback.
+
+        ``ConvertTensorToTileOps`` rebuilds these tile ops carrying the enclosing
+        function's span. Reading ``Call::span_`` alone would report the ``def``
+        line for every one of them; codegen must fall back to the statement span.
+        """
+        mlir = _generate(ElementwiseProg)
+
+        def loc_line_of(op_name: str) -> int:
+            line = next(ln for ln in mlir.splitlines() if op_name in ln)
+            match = _LOC_RE.search(line)
+            assert match is not None, f"{op_name} carries no loc: {line.strip()}"
+            return int(match.group(2))
+
+        assert loc_line_of("pto.tadd") == _ADD_LINE
+        assert loc_line_of("pto.texp") == _EXP_LINE
+        # Distinct statements must not collapse onto one line.
+        assert loc_line_of("pto.tadd") != loc_line_of("pto.texp")
+
+    def test_structural_lines_carry_no_loc(self):
+        """A brace or block label with a trailing loc(...) is a parse error."""
+        mlir = _generate(ControlFlowProg)
+        structural = [ln for ln in mlir.splitlines() if _is_structural(ln)]
+        assert any("scf.for" in ln for ln in structural), f"no scf.for region in:\n{mlir}"
+        offenders = [ln.strip() for ln in structural if "loc(" in ln]
+        assert not offenders, f"structural lines must not carry loc(): {offenders}"
+
+    def test_constants_carry_no_loc(self):
+        """arith.constant is deduplicated across uses, so no span fits it."""
+        mlir = _generate(ElementwiseProg)
+        constants = [ln for ln in mlir.splitlines() if "arith.constant" in ln]
+        assert constants, f"no constants section in:\n{mlir}"
+        assert not [ln.strip() for ln in constants if "loc(" in ln]
+
+
+class TestSourceLocDisabled:
+    """emit_source_loc=False must reproduce the pre-location output exactly."""
+
+    @pytest.mark.parametrize("program_cls", [ElementwiseProg, ControlFlowProg])
+    def test_disabled_output_is_the_loc_stripped_output(self, program_cls):
+        with_loc = _generate(program_cls, emit_source_loc=True)
+        without_loc = _generate(program_cls, emit_source_loc=False)
+        assert "loc(" not in without_loc
+        stripped = "\n".join(_LOC_RE.sub("", ln) for ln in with_loc.splitlines())
+        assert stripped == without_loc.rstrip("\n")
+
+
+class TestUnknownSpan:
+    """A node with no usable span emits no location rather than a bogus one."""
+
+    def test_unknown_span_emits_no_loc(self):
+        span = ir.Span.unknown()
+        assert not span.is_valid() or not span.filename
+
+    def test_synthesized_ops_do_not_invent_a_location(self):
+        """Ops whose span is unknown are simply left unannotated."""
+        mlir = _generate(ElementwiseProg)
+        # A location is never emitted with an empty filename or a non-positive line.
+        assert 'loc("":' not in mlir
+        assert not re.search(r"loc\(\"[^\"]*\":-?0*:", mlir)
+        assert ":-1:" not in mlir
+
+
+class TestMultiLineStatements:
+    """A statement spanning several lines still resolves to one location."""
+
+    def test_multi_line_call_reports_the_statement_start_line(self):
+        """Locations stay within the statement that produced them.
+
+        A Call span is trusted only when it is nested inside the enclosing
+        statement's span — both ends, not just the start. A multi-line statement
+        is where those ends genuinely differ, so every operation it lowers to must
+        report a line inside the statement's own range.
+        """
+        mlir = _generate(MultiLineProg)
+        add_line = next(ln for ln in mlir.splitlines() if "pto.tadd" in ln)
+        match = _LOC_RE.search(add_line)
+        assert match is not None, f"pto.tadd carries no loc: {add_line.strip()}"
+        reported = int(match.group(2))
+        start, end = _MULTILINE_ADD_RANGE
+        assert start <= reported <= end, (
+            f"pto.tadd reports line {reported}, outside its statement range {start}-{end}"
+        )
+
+
+class TestPathEscaping:
+    """A source path is an arbitrary OS string; unescaped bytes break parsing."""
+
+    def test_special_characters_in_source_path_are_escaped(self, tmp_path):
+        """A quote, a backslash and a control character must all survive escaping.
+
+        MLIR rejects an unescaped quote or control character inside a string
+        literal, so any of them would make the whole module unparseable. POSIX
+        allows every byte except `/` and NUL in a path, so all three are reachable.
+        """
+        try:
+            src_dir = tmp_path / 'q"d\\ir\ttab'
+            src_dir.mkdir()
+        except OSError:  # filesystem rejects these bytes in names (e.g. Windows)
+            pytest.skip("filesystem does not allow quotes or control characters in path names")
+
+        module_path = src_dir / "kern.py"
+        module_path.write_text(
+            "import pypto.language as pl\n"
+            "\n"
+            "@pl.program\n"
+            "class P:\n"
+            "    @pl.function(type=pl.FunctionType.InCore)\n"
+            "    def k(self, a: pl.Tensor[[128, 128], pl.FP32],\n"
+            "          o: pl.Tensor[[128, 128], pl.FP32]) -> pl.Tensor[[128, 128], pl.FP32]:\n"
+            "        t: pl.Tile[[128, 128], pl.FP32] = pl.load(a, [0, 0], [128, 128])\n"
+            "        e: pl.Tile[[128, 128], pl.FP32] = pl.exp(t)\n"
+            "        u: pl.Tensor[[128, 128], pl.FP32] = pl.store(e, [0, 0], o)\n"
+            "        return u\n"
+        )
+
+        spec = importlib.util.spec_from_file_location("pypto_loc_escape_case", module_path)
+        assert spec is not None and spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[spec.name] = module
+        try:
+            spec.loader.exec_module(module)
+            mlir = _generate(module.P)
+        finally:
+            sys.modules.pop(spec.name, None)
+
+        texp_line = next(ln for ln in mlir.splitlines() if "pto.texp" in ln)
+        assert '\\"d' in texp_line, f"quote left unescaped in: {texp_line.strip()!r}"
+        assert "\\\\ir" in texp_line, f"backslash left unescaped in: {texp_line.strip()!r}"
+        assert "\\t" in texp_line, f"tab left unescaped in: {texp_line.strip()!r}"
+        # No raw control character reached the literal — that alone would make the
+        # module unparseable regardless of the visible escapes above.
+        assert "\t" not in texp_line, f"raw tab emitted in: {texp_line.strip()!r}"
+        # The escaped form still parses back out as a single location, and
+        # unescaping it recovers the exact path on disk.
+        match = _LOC_RE.search(texp_line)
+        assert match is not None
+        unescaped = match.group(1).replace('\\"', '"').replace("\\t", "\t").replace("\\\\", "\\")
+        assert unescaped == str(module_path)
+
+
+class TestEnvironmentDefault:
+    """PYPTO_EMIT_PTO_LOC is the no-rebuild kill switch for an ptoas that chokes."""
+
+    @pytest.mark.parametrize(
+        ("env_value", "expected"),
+        [
+            (None, True),
+            ("1", True),
+            ("true", True),
+            ("0", False),
+            ("false", False),
+            ("False", False),
+            ("off", False),
+            ("no", False),
+        ],
+    )
+    def test_env_var_controls_the_default(self, monkeypatch, env_value, expected):
+        if env_value is None:
+            monkeypatch.delenv("PYPTO_EMIT_PTO_LOC", raising=False)
+        else:
+            monkeypatch.setenv("PYPTO_EMIT_PTO_LOC", env_value)
+        assert emit_source_loc_default() is expected
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/ut/codegen/test_ptoas_planner_views.py
+++ b/tests/ut/codegen/test_ptoas_planner_views.py
@@ -24,6 +24,7 @@ import re
 
 import pypto.language as pl
 import pytest
+from _pto_loc_common import strip_loc
 from pypto import ir as _ir
 from pypto.backend import BackendType, reset_for_testing, set_backend_type
 from pypto.ir.pass_manager import OptimizationStrategy, PassManager
@@ -59,9 +60,14 @@ def _emit_incore_pto(program, planner: passes.MemoryPlanner) -> str:
 
 
 def _sole_line(mlir: str, needle: str) -> str:
+    """The unique line containing `needle`, without its trailing MLIR location.
+
+    `_result_type` / `_operand_type` slice from the end of the line, so the
+    `loc("file":line:col)` suffix codegen appends must come off here.
+    """
     lines = [ln for ln in mlir.splitlines() if needle in ln]
     assert len(lines) == 1, f"expected exactly one {needle!r} line, got {lines}:\n{mlir}"
-    return lines[0]
+    return strip_loc(lines[0])
 
 
 # ── reserve_buffer: base resolution deferred to ptoas ────────────────────────


### PR DESCRIPTION
## Summary

PTO codegen emitted no MLIR `loc()`, so when the ptoas verifier rejected an operation the only location it could report was a line in the generated `.pto` — a file the user never wrote, and never sees at all under `@pl.jit`. ptoas propagates MLIR locations verbatim into its diagnostics, so emitting the `Span` that every IR node already carries gives every ptoas error class source attribution without duplicating any of the backend's constraint knowledge into PyPTO. After this change a rejected op reports the user's `.py` line and column instead. Locations are on by default and can be turned off, in which case the emitted `.pto` is byte-identical to before.

The accuracy of the attribution rests on which span is used. The location is bound at two levels: the enclosing statement in `PTOCodegen::VisitStmt` is primary, and a `Call`'s own span refines it only when it is nested inside that statement's span. The containment test is what makes this correct — `ConvertTensorToTileOps` rebuilds the tile ops it synthesizes carrying the enclosing *function*'s span while preserving the `AssignStmt` span, so across two of this repository's own kernels (`test_pto_codegen_paged_attn.py`, `test_pto_codegen_ops.py`) only 17–35% of post-pass `Call` spans are still statement-nested. Reading `Call::span_` alone would report the `def` line for most operations.

## Changes

- `src/codegen/pto/pto_codegen.cpp`, `include/pypto/codegen/pto/pto_codegen.h`: add a `SpanScope` RAII guard and `LocSuffix()`; `Emit()` now appends `loc("file":line:col)`. Adds the statement-level and containment-checked Call-level binding described above. Unknown spans and spans without a filename emit nothing, leaving those operations exactly as before.
- `src/codegen/pto/pto_control_flow_codegen.cpp`: route the 18 region-brace, separator and block-label lines through a new `EmitStructural()`. MLIR's trailing location is legal only at the end of a complete operation, so annotating `scf.for … {`, `} else {`, `}` or `^bb0(…):` would make the module unparseable. `scf.yield`, `scf.condition`, `pto.tmov` and `pto.set_validshape` remain real operations and keep their locations.
- Prologue operations are covered as well: `pto.make_tensor_view` from the parameter span, `pto.alloc_multi_tile` from the base variable, and hoisted `pto.alloc_tile` from the function. `arith.constant` stays unannotated because the constants section is deduplicated across every use, so no single span fits it.
- `python/bindings/modules/codegen.cpp`, `python/pypto/pypto_core/codegen.pyi`, `python/pypto/backend/pto_backend.py`, `python/pypto/ir/compile.py`: thread the new `emit_source_loc` flag across the C++, binding and stub layers, add `compile(..., emit_source_loc=...)`, and read the `PYPTO_EMIT_PTO_LOC` environment default. ptoas ships independently of PyPTO, so this switch exists to recover from a ptoas build whose parser rejects a trailing location without requiring a PyPTO rebuild.
- `tests/ut/codegen/test_pto_codegen_source_loc.py`: new coverage for per-operation locations, the statement-not-`def`-line attribution, structural lines carrying no location, unannotated constants, source-path escaping, the byte-identical disabled output, and the environment matrix.
- `tests/ut/_pto_loc_common.py` and four existing test files: assertions that anchor on the end of an operation (`endswith`, `strip() ==`) and helpers that slice a type from the end of a line now drop the trailing location first.

## Behavior and interface notes

- Default output changes: generated `.pto` operations now carry a trailing location. Generated `.pto` grows by roughly 40% on the paged-attention kernels (about 112 bytes per operation, dominated by the absolute source path). Set `PYPTO_EMIT_PTO_LOC=0` or pass `emit_source_loc=False` to restore the previous output exactly.
- `PTOCodegen::Generate` and `codegen.PTOCodegen.generate` gain a third parameter, defaulted, so existing callers are unaffected.
- **ptoas acceptance is confirmed by CI.** This was developed without a `ptoas` binary available, so it could not be checked locally. It has since been covered on this PR: `system-tests`, `system-tests-direct`, `dist-system-tests`, `system-tests-a5sim` and `pypto-lib-model` all run with a real `PTOAS_ROOT` at the pinned ptoas (`PTOAS_VERSION=v0.54` in `toolchain/versions.env`) and all pass with locations enabled, on a2a3 device and the A5 simulator. Real kernels therefore assemble and run with the trailing `loc(...)` in place.
- Follow-up, not included: propagating the original op's span in `ConvertTensorToTileOps` instead of the shared function span would improve column accuracy here and every other span consumer. The containment rule above makes this change correct without it.

## Verification

- `cmake --build build --parallel`: exit 0, clean build.
- `python -m pytest tests/ut/ -n auto --maxprocesses 8 -q`: exit 0, 9273 passed, 2 skipped.
- `python -m pytest tests/ut/core/test_error.py -n auto --maxprocesses 8 -q`: exit 0, 41 passed.
- `ruff check .`: exit 0, all checks passed.
- `ruff format --check .`: exit 0, 964 files already formatted.
- `pyright`: exit 0, 0 errors, 0 warnings.
- `pre-commit run --all-files`: exit 0, all 17 hooks passed.
- `ctest --test-dir build`: exit 0, 1/1 passed.
- `python tests/lint/clang_tidy.py --diff-base upstream/main`: exit 0, all checks completed.
- Full CI on this PR head: every required check passed, including the five ptoas-backed system-test suites listed above.

All of the above ran in the working checkout at exactly the pushed commit, through the publication workflow's validation runner.