### PR TITLE
fix(ir): track buffer roots through control flow

### DIFF
--- a/include/pypto/ir/transforms/utils/buffer_root_collector.h
+++ b/include/pypto/ir/transforms/utils/buffer_root_collector.h
@@ -13,6 +13,7 @@
 #define PYPTO_IR_TRANSFORMS_UTILS_BUFFER_ROOT_COLLECTOR_H_
 
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "pypto/ir/expr.h"
@@ -49,7 +50,7 @@ enum class AmbiguousRootPolicy {
  *
  * For a call's single (non-tuple) return value the owning root is selected by
  * matching the return type's shape+dtype against the callee's Out/InOut args
- * (see SelectReturnRoot), so a differently-typed InOut scratch is never
+ * (see SelectReturnRootInfo), so a differently-typed InOut scratch is never
  * mistaken for the real output buffer (issue #1564 / #1580). When that match is
  * ambiguous, the fallback is governed by @p ambiguous_policy (see
  * AmbiguousRootPolicy).
@@ -64,22 +65,40 @@ class BufferRootCollector : public IRVisitor {
   /// Var* -> owning buffer-root Var*. Populated by Initialize + VisitStmt.
   std::unordered_map<const Var*, const Var*> buffer_roots;
 
+  /// Vars whose value may refer to more than one owning buffer root because of
+  /// control flow. Consumers that derive dependencies must treat writes through
+  /// these vars conservatively; aliasing optimizations leave them unmapped.
+  std::unordered_set<const Var*> ambiguous_buffer_vars;
+
  protected:
+  void VisitStmt_(const IfStmtPtr& if_stmt) override;
   void VisitStmt_(const ForStmtPtr& for_stmt) override;
   void VisitStmt_(const WhileStmtPtr& while_stmt) override;
   void VisitStmt_(const AssignStmtPtr& assign) override;
 
  private:
+  using RootCandidates = std::vector<const Var*>;
+
+  struct RootInfo {
+    RootCandidates roots;
+    bool ambiguous;
+  };
+
   // A candidate output buffer: the resolved root of an Out/InOut arg, paired
   // with that arg's type so a single return value can be matched to the param
   // it actually aliases (see SelectReturnRoot).
   struct OutputRoot {
-    const Var* root;
+    RootInfo info;
     TypePtr type;
   };
 
-  [[nodiscard]] const Var* ResolveVar(const Var* var) const;
-  [[nodiscard]] const Var* ResolveExpr(const ExprPtr& expr) const;
+  [[nodiscard]] RootCandidates ResolveRootCandidates(const ExprPtr& expr) const;
+  [[nodiscard]] bool IsAmbiguous(const ExprPtr& expr) const;
+  void RecordRootCandidates(const VarPtr& var, const RootCandidates& roots, bool unresolved = false);
+  [[nodiscard]] std::vector<RootCandidates> InitializeLoopCarryRoots(
+      const std::vector<IterArgPtr>& iter_args);
+  void RecordLoopReturnRoots(const StmtPtr& body, const std::vector<VarPtr>& return_vars,
+                             const std::vector<RootCandidates>& init_roots, bool guaranteed_to_run);
   [[nodiscard]] std::vector<OutputRoot> CollectCallOutputRoots(const CallPtr& call) const;
 
   // Pick the buffer root for a call's single (non-tuple) return value. A
@@ -89,8 +108,8 @@ class BufferRootCollector : public IRVisitor {
   // Issue #1564: without this, the FP32 scratch was fused onto the BF16 output,
   // making tensor.create -> tensor.slice(output) alias and corrupt the result.
   // When no unambiguous match exists, the fallback follows ambiguous_policy_.
-  [[nodiscard]] const Var* SelectReturnRoot(const std::vector<OutputRoot>& out_roots,
-                                            const TypePtr& return_type) const;
+  [[nodiscard]] RootInfo SelectReturnRootInfo(const std::vector<OutputRoot>& out_roots,
+                                              const TypePtr& return_type) const;
 
   // Structural shape + dtype equality, ignoring memref / tensor_view: a return
   // value aliases its source buffer with the same logical shape and dtype.
@@ -98,7 +117,8 @@ class BufferRootCollector : public IRVisitor {
 
   ProgramPtr program_;
   AmbiguousRootPolicy ambiguous_policy_;
-  std::unordered_map<const Var*, std::vector<const Var*>> tuple_output_roots_;
+  std::unordered_map<const Var*, RootCandidates> root_candidates_;
+  std::unordered_map<const Var*, std::vector<RootInfo>> tuple_output_roots_;
 };
 
 }  // namespace buffer_root

--- a/include/pypto/ir/transforms/utils/transform_utils.h
+++ b/include/pypto/ir/transforms/utils/transform_utils.h
@@ -65,6 +65,15 @@ inline YieldStmtPtr GetLastYieldStmt(const StmtPtr& body) {
     if (seq->stmts_.empty()) return nullptr;
     return GetLastYieldStmt(seq->stmts_.back());
   }
+  // RuntimeScopeStmt and SplitAivScopeStmt are transparent to SSA. A valid
+  // control-flow yield may therefore be the trailing statement inside either
+  // scope, so use the same traversal as SSAVerifier::GetLastStmt.
+  if (auto scope = As<RuntimeScopeStmt>(body)) {
+    return GetLastYieldStmt(scope->body_);
+  }
+  if (auto scope = As<SplitAivScopeStmt>(body)) {
+    return GetLastYieldStmt(scope->body_);
+  }
   return As<YieldStmt>(body);
 }
 

--- a/src/ir/transforms/derive_call_directions_pass.cpp
+++ b/src/ir/transforms/derive_call_directions_pass.cpp
@@ -332,10 +332,12 @@ class CallDirectionMutator : public IRMutator {
  public:
   CallDirectionMutator(
       ProgramPtr program, const std::unordered_map<const Var*, const Var*>& buffer_roots,
+      const std::unordered_set<const Var*>& ambiguous_buffer_vars,
       const std::unordered_map<const Expr*, std::unordered_set<const Var*>>& first_writer_roots,
       const std::unordered_map<const Var*, ParamDirection>& enclosing_param_dir_by_root)
       : program_(std::move(program)),
         buffer_roots_(buffer_roots),
+        ambiguous_buffer_vars_(ambiguous_buffer_vars),
         first_writer_roots_(first_writer_roots),
         enclosing_param_dir_by_root_(enclosing_param_dir_by_root) {}
 
@@ -490,6 +492,14 @@ class CallDirectionMutator : public IRMutator {
           dirs.push_back(ArgDirection::InOut);
           continue;
         }
+        // A control-flow result may refer to different buffers on different
+        // paths (zero-trip loop, while, or differing if branches). A single
+        // canonical root cannot prove first-writer status, so retain the
+        // dependency conservatively.
+        if (auto var = AsVarLike(arg); var && ambiguous_buffer_vars_.count(var.get()) != 0) {
+          dirs.push_back(ArgDirection::InOut);
+          continue;
+        }
         // R-prior: a prior writer-unit in this scope already wrote to this root → InOut.
         if (root) {
           bool is_first_writer = first_writer_set != nullptr && first_writer_set->count(root) > 0;
@@ -543,6 +553,7 @@ class CallDirectionMutator : public IRMutator {
  private:
   ProgramPtr program_;
   const std::unordered_map<const Var*, const Var*>& buffer_roots_;
+  const std::unordered_set<const Var*>& ambiguous_buffer_vars_;
   const std::unordered_map<const Expr*, std::unordered_set<const Var*>>& first_writer_roots_;
   const std::unordered_map<const Var*, ParamDirection>& enclosing_param_dir_by_root_;
   int sequential_depth_ = 0;
@@ -586,8 +597,8 @@ Pass DeriveCallDirections() {
       PriorWriterCollector pw_collector(program, br_collector.buffer_roots);
       pw_collector.Run(func->body_);
 
-      CallDirectionMutator mutator(program, br_collector.buffer_roots, pw_collector.first_writer_roots,
-                                   enclosing_param_dir_by_root);
+      CallDirectionMutator mutator(program, br_collector.buffer_roots, br_collector.ambiguous_buffer_vars,
+                                   pw_collector.first_writer_roots, enclosing_param_dir_by_root);
       auto new_body = mutator.VisitStmt(func->body_);
 
       if (new_body.get() == func->body_.get()) continue;

--- a/src/ir/transforms/utils/buffer_root_collector.cpp
+++ b/src/ir/transforms/utils/buffer_root_collector.cpp
@@ -11,6 +11,7 @@
 
 #include "pypto/ir/transforms/utils/buffer_root_collector.h"
 
+#include <algorithm>
 #include <cstddef>
 #include <string>
 #include <utility>
@@ -41,36 +42,80 @@ BufferRootCollector::BufferRootCollector(ProgramPtr program, AmbiguousRootPolicy
 
 void BufferRootCollector::Initialize(const std::vector<VarPtr>& params) {
   for (const auto& param : params) {
-    buffer_roots[param.get()] = param.get();
+    RecordRootCandidates(param, {param.get()});
+  }
+}
+
+void BufferRootCollector::VisitStmt_(const IfStmtPtr& if_stmt) {
+  IRVisitor::VisitStmt_(if_stmt);
+  if (if_stmt->return_vars_.empty() || !if_stmt->else_body_.has_value()) return;
+
+  auto then_yield = transform_utils::GetLastYieldStmt(if_stmt->then_body_);
+  auto else_yield = transform_utils::GetLastYieldStmt(*if_stmt->else_body_);
+  if (!then_yield || !else_yield) return;
+
+  for (size_t i = 0;
+       i < if_stmt->return_vars_.size() && i < then_yield->value_.size() && i < else_yield->value_.size();
+       ++i) {
+    auto roots = ResolveRootCandidates(then_yield->value_[i]);
+    auto else_roots = ResolveRootCandidates(else_yield->value_[i]);
+    for (const Var* root : else_roots) {
+      if (std::find(roots.begin(), roots.end(), root) == roots.end()) roots.push_back(root);
+    }
+    const bool unresolved = roots.empty() || IsAmbiguous(then_yield->value_[i]) ||
+                            IsAmbiguous(else_yield->value_[i]) ||
+                            ResolveRootCandidates(then_yield->value_[i]).empty() || else_roots.empty();
+    RecordRootCandidates(if_stmt->return_vars_[i], roots, unresolved);
   }
 }
 
 void BufferRootCollector::VisitStmt_(const ForStmtPtr& for_stmt) {
-  for (size_t i = 0; i < for_stmt->iter_args_.size(); ++i) {
-    const auto& iter_arg = for_stmt->iter_args_[i];
-    const Var* root = ResolveExpr(iter_arg->initValue_);
-    if (root) {
-      buffer_roots[iter_arg.get()] = root;
-      if (i < for_stmt->return_vars_.size()) {
-        buffer_roots[for_stmt->return_vars_[i].get()] = root;
-      }
-    }
-  }
+  auto init_roots = InitializeLoopCarryRoots(for_stmt->iter_args_);
   IRVisitor::VisitStmt_(for_stmt);
+  RecordLoopReturnRoots(for_stmt->body_, for_stmt->return_vars_, init_roots,
+                        transform_utils::EvalConstTripCount(for_stmt) > 0);
 }
 
 void BufferRootCollector::VisitStmt_(const WhileStmtPtr& while_stmt) {
-  for (size_t i = 0; i < while_stmt->iter_args_.size(); ++i) {
-    const auto& iter_arg = while_stmt->iter_args_[i];
-    const Var* root = ResolveExpr(iter_arg->initValue_);
-    if (root) {
-      buffer_roots[iter_arg.get()] = root;
-      if (i < while_stmt->return_vars_.size()) {
-        buffer_roots[while_stmt->return_vars_[i].get()] = root;
+  auto init_roots = InitializeLoopCarryRoots(while_stmt->iter_args_);
+  IRVisitor::VisitStmt_(while_stmt);
+  // A while condition may be false before the first iteration, so both the
+  // initial and yielded roots remain possible.
+  RecordLoopReturnRoots(while_stmt->body_, while_stmt->return_vars_, init_roots,
+                        /*guaranteed_to_run=*/false);
+}
+
+std::vector<BufferRootCollector::RootCandidates> BufferRootCollector::InitializeLoopCarryRoots(
+    const std::vector<IterArgPtr>& iter_args) {
+  std::vector<RootCandidates> init_roots;
+  init_roots.reserve(iter_args.size());
+  for (const auto& iter_arg : iter_args) {
+    auto roots = ResolveRootCandidates(iter_arg->initValue_);
+    init_roots.push_back(roots);
+    RecordRootCandidates(iter_arg, roots, IsAmbiguous(iter_arg->initValue_));
+  }
+  return init_roots;
+}
+
+void BufferRootCollector::RecordLoopReturnRoots(const StmtPtr& body, const std::vector<VarPtr>& return_vars,
+                                                const std::vector<RootCandidates>& init_roots,
+                                                bool guaranteed_to_run) {
+  // Resolve after visiting the body so fresh-rebind assignments already have
+  // roots. An in-place yield of the IterArg still resolves to its init root.
+  auto yield = transform_utils::GetLastYieldStmt(body);
+  if (!yield) return;
+
+  for (size_t i = 0; i < return_vars.size() && i < yield->value_.size(); ++i) {
+    auto roots = ResolveRootCandidates(yield->value_[i]);
+    bool unresolved = roots.empty() || IsAmbiguous(yield->value_[i]);
+    if (!guaranteed_to_run && i < init_roots.size()) {
+      if (init_roots[i].empty()) unresolved = true;
+      for (const Var* root : init_roots[i]) {
+        if (std::find(roots.begin(), roots.end(), root) == roots.end()) roots.push_back(root);
       }
     }
+    RecordRootCandidates(return_vars[i], roots, unresolved);
   }
-  IRVisitor::VisitStmt_(while_stmt);
 }
 
 void BufferRootCollector::VisitStmt_(const AssignStmtPtr& assign) {
@@ -84,50 +129,76 @@ void BufferRootCollector::VisitStmt_(const AssignStmtPtr& assign) {
   if (auto call = transform_utils::AsCallOrSubmitView(assign->value_)) {
     const std::string& op_name = call->op_->name_;
     if (IsOp(call, "tensor.create") || IsOp(call, "tensor.slice")) {
-      buffer_roots[assign->var_.get()] = assign->var_.get();
+      RecordRootCandidates(assign->var_, {assign->var_.get()});
     } else if (IsOp(call, "tensor.assemble")) {
       if (call->args_.size() == 3) {
-        if (const Var* target_root = ResolveExpr(call->args_[0])) {
-          buffer_roots[assign->var_.get()] = target_root;
-        }
+        RecordRootCandidates(assign->var_, ResolveRootCandidates(call->args_[0]),
+                             IsAmbiguous(call->args_[0]));
       }
     } else if (!IsBuiltinOp(op_name)) {
       auto out_roots = CollectCallOutputRoots(call);
       if (As<TupleType>(call->GetType())) {
-        std::vector<const Var*> roots;
+        std::vector<RootInfo> roots;
         roots.reserve(out_roots.size());
-        for (const auto& entry : out_roots) roots.push_back(entry.root);
+        for (const auto& entry : out_roots) roots.push_back(entry.info);
         tuple_output_roots_[assign->var_.get()] = std::move(roots);
-      } else if (const Var* root = SelectReturnRoot(out_roots, call->GetType())) {
-        buffer_roots[assign->var_.get()] = root;
+      } else {
+        auto info = SelectReturnRootInfo(out_roots, call->GetType());
+        if (!info.roots.empty()) {
+          RecordRootCandidates(assign->var_, info.roots, info.ambiguous);
+        }
       }
     }
   } else if (auto tuple_get = As<TupleGetItemExpr>(assign->value_)) {
     if (auto tuple_var = AsVarLike(tuple_get->tuple_)) {
       auto it = tuple_output_roots_.find(tuple_var.get());
       if (it != tuple_output_roots_.end() && tuple_get->index_ < static_cast<int>(it->second.size()) &&
-          it->second[tuple_get->index_]) {
-        buffer_roots[assign->var_.get()] = it->second[tuple_get->index_];
+          !it->second[tuple_get->index_].roots.empty()) {
+        const auto& info = it->second[tuple_get->index_];
+        RecordRootCandidates(assign->var_, info.roots, info.ambiguous);
       }
     }
-  } else if (auto src_var = AsVarLike(assign->value_)) {
-    if (const Var* root = ResolveVar(src_var.get())) {
-      buffer_roots[assign->var_.get()] = root;
-    }
+  } else if (AsVarLike(assign->value_)) {
+    RecordRootCandidates(assign->var_, ResolveRootCandidates(assign->value_), IsAmbiguous(assign->value_));
   }
   IRVisitor::VisitStmt_(assign);
 }
 
-const Var* BufferRootCollector::ResolveVar(const Var* var) const {
-  auto it = buffer_roots.find(var);
-  return it != buffer_roots.end() ? it->second : nullptr;
+BufferRootCollector::RootCandidates BufferRootCollector::ResolveRootCandidates(const ExprPtr& expr) const {
+  auto var = AsVarLike(expr);
+  if (!var) return {};
+  auto it = root_candidates_.find(var.get());
+  return it != root_candidates_.end() ? it->second : RootCandidates{};
 }
 
-const Var* BufferRootCollector::ResolveExpr(const ExprPtr& expr) const {
-  if (auto var = AsVarLike(expr)) {
-    return ResolveVar(var.get());
+bool BufferRootCollector::IsAmbiguous(const ExprPtr& expr) const {
+  auto var = AsVarLike(expr);
+  return var && ambiguous_buffer_vars.count(var.get()) != 0;
+}
+
+void BufferRootCollector::RecordRootCandidates(const VarPtr& var, const RootCandidates& roots,
+                                               bool unresolved) {
+  if (!var) return;
+  RootCandidates unique;
+  unique.reserve(roots.size());
+  for (const Var* root : roots) {
+    if (root && std::find(unique.begin(), unique.end(), root) == unique.end()) unique.push_back(root);
   }
-  return nullptr;
+  if (unique.empty()) return;
+
+  root_candidates_[var.get()] = unique;
+  const bool ambiguous = unresolved || unique.size() > 1;
+  if (ambiguous) {
+    ambiguous_buffer_vars.insert(var.get());
+    if (ambiguous_policy_ == AmbiguousRootPolicy::kFirstOutput) {
+      buffer_roots[var.get()] = unique.front();
+    } else {
+      buffer_roots.erase(var.get());
+    }
+  } else {
+    ambiguous_buffer_vars.erase(var.get());
+    buffer_roots[var.get()] = unique.front();
+  }
 }
 
 std::vector<BufferRootCollector::OutputRoot> BufferRootCollector::CollectCallOutputRoots(
@@ -141,32 +212,30 @@ std::vector<BufferRootCollector::OutputRoot> BufferRootCollector::CollectCallOut
         callee->param_directions_[i] != ParamDirection::InOut) {
       continue;
     }
-    const Var* root = nullptr;
-    if (auto arg_var = AsVarLike(call->args_[i])) {
-      root = ResolveVar(arg_var.get());
-    }
-    roots.push_back(OutputRoot{root, call->args_[i]->GetType()});
+    roots.push_back(OutputRoot{RootInfo{ResolveRootCandidates(call->args_[i]), IsAmbiguous(call->args_[i])},
+                               call->args_[i]->GetType()});
   }
   return roots;
 }
 
-const Var* BufferRootCollector::SelectReturnRoot(const std::vector<OutputRoot>& out_roots,
-                                                 const TypePtr& return_type) const {
-  if (out_roots.empty()) return nullptr;
-  if (out_roots.size() == 1) return out_roots[0].root;
+BufferRootCollector::RootInfo BufferRootCollector::SelectReturnRootInfo(
+    const std::vector<OutputRoot>& out_roots, const TypePtr& return_type) const {
+  if (out_roots.empty()) return RootInfo{{}, false};
+  if (out_roots.size() == 1) return out_roots[0].info;
 
-  const Var* match = nullptr;
+  const OutputRoot* match = nullptr;
   bool ambiguous = false;
   for (const auto& candidate : out_roots) {
-    if (candidate.root && TypesMatchShapeDtype(candidate.type, return_type)) {
+    if (!candidate.info.roots.empty() && TypesMatchShapeDtype(candidate.type, return_type)) {
       if (match == nullptr) {
-        match = candidate.root;
-      } else if (match != candidate.root) {
+        match = &candidate;
+      } else if (match->info.roots != candidate.info.roots ||
+                 match->info.ambiguous != candidate.info.ambiguous) {
         ambiguous = true;
       }
     }
   }
-  if (match && !ambiguous) return match;
+  if (match && !ambiguous) return match->info;
   // No provable unambiguous type match (0 matches, or >1 distinct candidates).
   // The fallback depends on what the consumer needs when the owning buffer
   // can't be pinned down:
@@ -178,9 +247,9 @@ const Var* BufferRootCollector::SelectReturnRoot(const std::vector<OutputRoot>& 
   //                  so a later write to the returned var still promotes to
   //                  InOut; a null root would silently drop the WAW/InOut dep.
   if (ambiguous_policy_ == AmbiguousRootPolicy::kFirstOutput) {
-    return out_roots[0].root;
+    return out_roots[0].info;
   }
-  return nullptr;
+  return RootInfo{{}, false};
 }
 
 bool BufferRootCollector::TypesMatchShapeDtype(const TypePtr& a, const TypePtr& b) {

--- a/tests/ut/ir/transforms/test_derive_call_directions.py
+++ b/tests/ut/ir/transforms/test_derive_call_directions.py
@@ -349,6 +349,192 @@ class TestDeriveDirectionMatrix:
         After = passes.derive_call_directions()(Before)
         ir.assert_structural_equal(After, Expected)
 
+    def test_fresh_rebind_for_carry_tracks_yielded_buffer(self):
+        """A loop return follows the buffer yielded by a rebind carry.
+
+        The loop starts from ``initial`` but yields the distinct ``fresh``
+        allocation. The post-loop writer therefore follows the loop's prior
+        write to ``fresh`` and must be promoted to ``InOut``. Rooting the return
+        at ``initial`` incorrectly classifies it as a first writer.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                out: pl.Out[pl.Tensor[[64], pl.FP32]],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                t: pl.Tile[[64], pl.FP32] = pl.load(x, [0], [64])
+                ret: pl.Tensor[[64], pl.FP32] = pl.store(t, [0], out)
+                return ret
+
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                initial: pl.Tensor[[64], pl.FP32] = pl.create_tensor([64], dtype=pl.FP32)
+                for _i, (carried,) in pl.range(0, 4, 1, init_values=(initial,)):
+                    fresh: pl.Tensor[[64], pl.FP32] = pl.create_tensor([64], dtype=pl.FP32)
+                    fresh_result: pl.Tensor[[64], pl.FP32] = self.kernel(x, fresh)
+                    (carried_rv,) = pl.yield_(fresh_result)
+                result: pl.Tensor[[64], pl.FP32] = self.kernel(x, carried_rv)
+                return result
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore, level=pl.Level.CHIP_DIE, role=pl.Role.SubWorker)
+            def kernel(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                out: pl.Out[pl.Tensor[[64], pl.FP32]],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                t = pl.tile.load(x, [0], [64], [64], target_memory=pl.Mem.Vec)
+                ret = pl.tile.store(t, [0], out)
+                return ret
+
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                initial = pl.tensor.create([64], dtype=pl.FP32, layout=pl.TensorLayout.ND)
+                for _i, (carried,) in pl.range(0, 4, 1, init_values=(initial,)):
+                    fresh = pl.tensor.create([64], dtype=pl.FP32, layout=pl.TensorLayout.ND)
+                    fresh_result = self.kernel(
+                        x, fresh, attrs={"arg_directions": [pl.adir.input, pl.adir.inout]}
+                    )
+                    (carried_rv,) = pl.yield_(fresh_result)
+                result = self.kernel(x, carried_rv, attrs={"arg_directions": [pl.adir.input, pl.adir.inout]})
+                return result
+
+        After = passes.derive_call_directions()(Before)
+        ir.assert_structural_equal(After, Expected)
+
+    def test_fresh_rebind_while_carry_tracks_yielded_buffer(self):
+        """``WhileStmt`` return roots follow fresh yielded allocations too."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                out: pl.Out[pl.Tensor[[64], pl.FP32]],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                t: pl.Tile[[64], pl.FP32] = pl.load(x, [0], [64])
+                ret: pl.Tensor[[64], pl.FP32] = pl.store(t, [0], out)
+                return ret
+
+            @pl.function
+            def main(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                keep_going: pl.Scalar[pl.BOOL],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                initial: pl.Tensor[[64], pl.FP32] = pl.create_tensor([64], dtype=pl.FP32)
+                for (carried,) in pl.while_(init_values=(initial,)):
+                    pl.cond(keep_going)
+                    fresh: pl.Tensor[[64], pl.FP32] = pl.create_tensor([64], dtype=pl.FP32)
+                    fresh_result: pl.Tensor[[64], pl.FP32] = self.kernel(x, fresh)
+                    (carried_rv,) = pl.yield_(fresh_result)
+                result: pl.Tensor[[64], pl.FP32] = self.kernel(x, carried_rv)
+                return result
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore, level=pl.Level.CHIP_DIE, role=pl.Role.SubWorker)
+            def kernel(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                out: pl.Out[pl.Tensor[[64], pl.FP32]],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                t = pl.tile.load(x, [0], [64], [64], target_memory=pl.Mem.Vec)
+                ret = pl.tile.store(t, [0], out)
+                return ret
+
+            @pl.function
+            def main(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                keep_going: pl.Scalar[pl.BOOL],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                initial = pl.tensor.create([64], dtype=pl.FP32, layout=pl.TensorLayout.ND)
+                for (carried,) in pl.while_(init_values=(initial,)):
+                    pl.cond(keep_going)
+                    fresh = pl.tensor.create([64], dtype=pl.FP32, layout=pl.TensorLayout.ND)
+                    fresh_result = self.kernel(
+                        x, fresh, attrs={"arg_directions": [pl.adir.input, pl.adir.inout]}
+                    )
+                    (carried_rv,) = pl.yield_(fresh_result)
+                result = self.kernel(x, carried_rv, attrs={"arg_directions": [pl.adir.input, pl.adir.inout]})
+                return result
+
+        After = passes.derive_call_directions()(Before)
+        ir.assert_structural_equal(After, Expected)
+
+    def test_if_result_rebind_in_loop_is_conservative(self):
+        """A loop yield may carry an IfStmt result rooted in either branch.
+
+        The post-loop write cannot be classified as a first writer of one
+        arbitrarily selected branch root, so it must remain ``InOut``.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                out: pl.Out[pl.Tensor[[64], pl.FP32]],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                t: pl.Tile[[64], pl.FP32] = pl.load(x, [0], [64])
+                ret: pl.Tensor[[64], pl.FP32] = pl.store(t, [0], out)
+                return ret
+
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                initial: pl.Tensor[[64], pl.FP32] = pl.create_tensor([64], dtype=pl.FP32)
+                for i, (carried,) in pl.range(0, 4, 1, init_values=(initial,)):
+                    lhs: pl.Tensor[[64], pl.FP32] = pl.create_tensor([64], dtype=pl.FP32)
+                    rhs: pl.Tensor[[64], pl.FP32] = pl.create_tensor([64], dtype=pl.FP32)
+                    lhs_result: pl.Tensor[[64], pl.FP32] = self.kernel(x, lhs)
+                    rhs_result: pl.Tensor[[64], pl.FP32] = self.kernel(x, rhs)
+                    if i == 0:
+                        selected: pl.Tensor[[64], pl.FP32] = pl.yield_(lhs_result)
+                    else:
+                        selected: pl.Tensor[[64], pl.FP32] = pl.yield_(rhs_result)
+                    (carried_rv,) = pl.yield_(selected)
+                result: pl.Tensor[[64], pl.FP32] = self.kernel(x, carried_rv)
+                return result
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore, level=pl.Level.CHIP_DIE, role=pl.Role.SubWorker)
+            def kernel(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                out: pl.Out[pl.Tensor[[64], pl.FP32]],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                t = pl.tile.load(x, [0], [64], [64], target_memory=pl.Mem.Vec)
+                ret = pl.tile.store(t, [0], out)
+                return ret
+
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                initial = pl.tensor.create([64], dtype=pl.FP32, layout=pl.TensorLayout.ND)
+                for i, (carried,) in pl.range(0, 4, 1, init_values=(initial,)):
+                    lhs = pl.tensor.create([64], dtype=pl.FP32, layout=pl.TensorLayout.ND)
+                    rhs = pl.tensor.create([64], dtype=pl.FP32, layout=pl.TensorLayout.ND)
+                    lhs_result = self.kernel(x, lhs, attrs={"arg_directions": [pl.adir.input, pl.adir.inout]})
+                    rhs_result = self.kernel(x, rhs, attrs={"arg_directions": [pl.adir.input, pl.adir.inout]})
+                    if i == 0:
+                        selected = pl.yield_(lhs_result)
+                    else:
+                        selected = pl.yield_(rhs_result)
+                    (carried_rv,) = pl.yield_(selected)
+                result = self.kernel(x, carried_rv, attrs={"arg_directions": [pl.adir.input, pl.adir.inout]})
+                return result
+
+        After = passes.derive_call_directions()(Before)
+        ir.assert_structural_equal(After, Expected)
+
     def test_two_parallel_loops_promote_only_second(self):
         """Two consecutive ``pl.parallel`` loops writing the same root.
 

--- a/tests/ut/ir/transforms/test_fuse_create_assemble_to_slice.py
+++ b/tests/ut/ir/transforms/test_fuse_create_assemble_to_slice.py
@@ -537,6 +537,89 @@ class TestFuseCreateAssembleToSlice:
         expected = _run_prereqs_only(Expected)
         ir.assert_structural_equal(after, expected)
 
+    def test_zero_trip_rebind_does_not_alias_yield_root(self):
+        """A zero-trip loop returns its init buffer, not the body yield root.
+
+        Treating the return as an alias of ``fresh`` would make fusion delete
+        the required post-loop assemble even though ``fresh`` is never created.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def fill_row(
+                self,
+                x: pl.Tensor[[4, 8], pl.FP32],
+                out: pl.Out[pl.Tensor[[1, 8], pl.FP32]],
+            ) -> pl.Tensor[[1, 8], pl.FP32]:
+                row_tile: pl.Tile[[1, 8], pl.FP32] = pl.load(x, [0, 0], [1, 8])
+                out_1: pl.Tensor[[1, 8], pl.FP32] = pl.store(row_tile, [0, 0], out)
+                return out_1
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orch(
+                self,
+                x: pl.Tensor[[4, 8], pl.FP32],
+                out: pl.Out[pl.Tensor[[4, 8], pl.FP32]],
+            ) -> pl.Tensor[[4, 8], pl.FP32]:
+                initial: pl.Tensor[[1, 8], pl.FP32] = pl.create_tensor([1, 8], dtype=pl.FP32)
+                initial = self.fill_row(x, initial)
+                for _i, (carried,) in pl.range(0, 0, 1, init_values=(initial,)):
+                    fresh: pl.Tensor[[1, 8], pl.FP32] = pl.create_tensor([1, 8], dtype=pl.FP32)
+                    fresh = self.fill_row(x, fresh)
+                    (carried_rv,) = pl.yield_(fresh)
+                out = pl.assemble(out, carried_rv, [0, 0])
+                return out
+
+        after = _run_prereqs_and_fuse(Before)
+        expected = _run_prereqs_only(Before)
+        ir.assert_structural_equal(after, expected)
+
+    def test_dynamic_trip_rebind_does_not_alias_one_root(self):
+        """A dynamic range may return either its init or yielded buffer."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orch(
+                self,
+                trip_count: pl.Scalar[pl.INDEX],
+                out: pl.Out[pl.Tensor[[4, 8], pl.FP32]],
+            ) -> pl.Tensor[[4, 8], pl.FP32]:
+                initial: pl.Tensor[[1, 8], pl.FP32] = pl.create_tensor([1, 8], dtype=pl.FP32)
+                for _i, (carried,) in pl.range(0, trip_count, 1, init_values=(initial,)):
+                    fresh: pl.Tensor[[1, 8], pl.FP32] = pl.create_tensor([1, 8], dtype=pl.FP32)
+                    (carried_rv,) = pl.yield_(fresh)
+                out = pl.assemble(out, carried_rv, [0, 0])
+                return out
+
+        after = _run_prereqs_and_fuse(Before)
+        expected = _run_prereqs_only(Before)
+        ir.assert_structural_equal(after, expected)
+
+    def test_maybe_false_while_rebind_does_not_alias_yield_root(self):
+        """A while may return its init value without entering the body."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orch(
+                self,
+                keep_going: pl.Scalar[pl.BOOL],
+                out: pl.Out[pl.Tensor[[4, 8], pl.FP32]],
+            ) -> pl.Tensor[[4, 8], pl.FP32]:
+                initial: pl.Tensor[[1, 8], pl.FP32] = pl.create_tensor([1, 8], dtype=pl.FP32)
+                for (carried,) in pl.while_(init_values=(initial,)):
+                    pl.cond(keep_going)
+                    fresh: pl.Tensor[[1, 8], pl.FP32] = pl.create_tensor([1, 8], dtype=pl.FP32)
+                    (carried_rv,) = pl.yield_(fresh)
+                out = pl.assemble(out, carried_rv, [0, 0])
+                return out
+
+        after = _run_prereqs_and_fuse(Before)
+        expected = _run_prereqs_only(Before)
+        ir.assert_structural_equal(after, expected)
+
     def test_atomic_assemble_not_fused(self):
         """tensor.assemble with atomic=Add → not fused; the atomic assemble must survive.
 

--- a/tests/ut/ir/transforms/test_transform_utils.py
+++ b/tests/ut/ir/transforms/test_transform_utils.py
@@ -241,6 +241,21 @@ class TestGetLastYieldStmt:
         outer = ir.SeqStmts([inner_seq], _span())
         assert ir.get_last_yield_stmt(outer) is ys
 
+    @pytest.mark.parametrize(
+        "wrap",
+        [
+            lambda body: ir.RuntimeScopeStmt(manual=True, body=body, span=_span()),
+            lambda body: ir.SplitAivScopeStmt(ir.SplitMode.UP_DOWN, body=body, span=_span()),
+        ],
+        ids=["runtime-scope", "split-aiv-scope"],
+    )
+    def test_transparent_scope(self, wrap):
+        """SSA-transparent scopes do not hide a trailing control-flow yield."""
+        value = _var("value")
+        ys = ir.YieldStmt([value], _span())
+        scope = wrap(ir.SeqStmts([ys], _span()))
+        assert ir.get_last_yield_stmt(scope) is ys
+
 
 # ---------------------------------------------------------------------------
 # TestSubstituteExpr


### PR DESCRIPTION
## Summary

Track buffer provenance through loop and conditional control flow without asserting false aliases. Loop returns now preserve all possible init/yield roots when execution is not guaranteed, and IfStmt results merge branch provenance conservatively.

## Changes

- Follow trailing yields through SSA-transparent `RuntimeScopeStmt` and `SplitAivScopeStmt` wrappers.
- Track alternative buffer roots for zero/dynamic-trip `ForStmt`, maybe-false `WhileStmt`, and differing `IfStmt` branches.
- Keep ambiguous roots unmapped for aliasing optimizations such as `FuseCreateAssembleToSlice`.
- Conservatively derive `InOut` for writes through ambiguous control-flow results.
- Add regressions for zero/dynamic for-loops, while-loops, conditional results, and transparent scope traversal.

## Verification

- `CCACHE_DISABLE=1 cmake --build build --parallel 8`: passed
- Focused buffer-root / derive / fusion tests: 115 passed
- Affected transform tests: 397 passed
- Affected orchestration/distributed codegen tests: 97 passed
- `clang-format`, `ruff format`, `ruff check`, and `git diff --check`: passed
