### PR TITLE
examples: distributed all-reduce tutorials (steps 08-11) + walkthroughs + CI P=4 legs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -489,7 +489,7 @@ jobs:
           python tests/docs/run_doc_examples.py --pages docs/en/user --check-parity -p a2a3sim
 
   examples-tests:
-    # The distributed examples ladder (doc-plan 02) — every example must compile
+    # The distributed examples ladder — every example must compile
     # AND run with a passing golden on the simulator (a2a3sim), so the teaching
     # material cannot silently rot.
     #
@@ -563,6 +563,19 @@ jobs:
           python examples/distributed/07_dynamic_rank_count.py -p a2a3sim -d 0,1,2
           echo "=== examples/distributed/07_dynamic_rank_count.py -d 0,1,2,3 ==="
           python examples/distributed/07_dynamic_rank_count.py -p a2a3sim -d 0,1,2,3
+          # Steps 08-11: the all-reduce comparisons are only observable
+          # at P=4 (P=2 collapses mesh/two-phase/ring into the same exchange); the
+          # reveal runs both modes.
+          echo "=== examples/distributed/08_allreduce_mesh.py -d 0,1,2,3 ==="
+          python examples/distributed/08_allreduce_mesh.py -p a2a3sim -d 0,1,2,3
+          echo "=== examples/distributed/09_allreduce_two_phase.py -d 0,1,2,3 ==="
+          python examples/distributed/09_allreduce_two_phase.py -p a2a3sim -d 0,1,2,3
+          echo "=== examples/distributed/10_allreduce_ring.py -d 0,1,2,3 ==="
+          python examples/distributed/10_allreduce_ring.py -p a2a3sim -d 0,1,2,3
+          echo "=== examples/distributed/11_allreduce_reveal.py -d 0,1,2,3 ==="
+          python examples/distributed/11_allreduce_reveal.py -p a2a3sim -d 0,1,2,3
+          echo "=== examples/distributed/11_allreduce_reveal.py --mode ring -d 0,1,2,3 ==="
+          python examples/distributed/11_allreduce_reveal.py -p a2a3sim -d 0,1,2,3 --mode ring
 
       # The teaching ladders. These carry the manual's beginner/intermediate/
       # advanced/utils citations, so leaving them unrun let the pages point at

--- a/docs/en/user/distributed/00-model.md
+++ b/docs/en/user/distributed/00-model.md
@@ -13,6 +13,13 @@
 
 The simplest distributed program — two ranks sum their data, both see the same result.
 
+> This is the **mesh all-reduce** pattern — stage in, barrier, read every
+> peer's slice and sum — which the [mesh allreduce walkthrough](13-allreduce_mesh.md)
+> builds step-by-step in the [tutorial ladder](05-tutorials.md). At two ranks
+> every algorithm collapses to this one exchange; the
+> [ring allreduce walkthrough](15-allreduce_ring.md) is the last manual step
+> before the builtin is revealed.
+
 ```python
 import pypto.language as pl
 import pypto.language.distributed as pld
@@ -207,6 +214,7 @@ InCore kernel (@pl.jit.incore)
 
 ## See Also
 
+- [05-tutorials](05-tutorials.md) — The step-by-step distributed tutorial ladder
 - [01-collectives](01-collectives.md) — Built-in collectives and their semantics
 - [02-primitives](02-primitives.md) — The substrate beneath the collectives
 - [03-execution](03-execution.md) — DistributedWorker lifecycle and production patterns

--- a/docs/en/user/distributed/01-collectives.md
+++ b/docs/en/user/distributed/01-collectives.md
@@ -225,7 +225,7 @@ build each collective by hand before the builtin is revealed:
 | Collective | Tutorial step | Hand-rolled first? |
 | ---------- | ------------- | ------------------ |
 | barrier | [09-barrier](09-barrier.md) | yes (step 04, then reveal) |
-| allreduce | planned — steps 08–11 | yes (mesh, two-phase, ring, then reveal) |
+| allreduce | [13-allreduce_mesh](13-allreduce_mesh.md) · [14-allreduce_two_phase](14-allreduce_two_phase.md) · [15-allreduce_ring](15-allreduce_ring.md) · [16-allreduce_reveal](16-allreduce_reveal.md) | yes (steps 08–11) |
 | broadcast | planned — step 12 | yes |
 | allgather | planned — step 13 | yes |
 | reduce_scatter | planned — step 14 | yes |

--- a/docs/en/user/distributed/01-collectives.md
+++ b/docs/en/user/distributed/01-collectives.md
@@ -40,14 +40,21 @@ data = pld.tensor.allreduce(data, op=pld.ReduceOp.Sum, core_num=4)
 - 2(P-1) steps: reduce-scatter + allgather
 - O(N/P) remote traffic per step — each rank reads one neighbour
 - Signal shape: `[2 × (NR − 1), NR]`
-- Requires compile-time-known NR — use a factory function pattern: an
-  outer Python function takes `nr`/`size`, derives `total_rounds =
-  2 * (nr - 1)`, and defines the `@pl.jit` functions inside its own body
-  so `[total_rounds, nr]` becomes a compile-time constant (the specializer
-  folds the closure constants into the generated program). See
+- Requires compile-time-known NR — use a factory function pattern **with the
+  `@pl.program` class form**: an outer Python function takes `nr`/`size`,
+  derives `total_rounds = 2 * (nr - 1)`, and defines the `@pl.program` class
+  inside its own body, so `[total_rounds, nr]` becomes a compile-time
+  constant. `@pl.program` / `@pl.function` snapshot the defining frame's
+  locals at decoration time, which is what makes those closure constants
+  resolve.
+- The `@pl.jit` family does **not** work for this: its constant folding reads
+  only the function's module globals (`__globals__`), never `__closure__`
+  (`python/pypto/jit/specializer.py`), so a factory closure constant
+  referenced in a HOST orchestrator body fails to resolve with
+  `Undefined variable`. See
   `collectives/test_l3_tensor_allreduce_ring_intrinsic.py` in [Runnable
-  Examples](#runnable-examples) — that test currently uses the equivalent
-  `@pl.program` class form.
+  Examples](#runnable-examples), which uses the `@pl.program` class form for
+  exactly this reason.
 - Best for large messages (>16 KiB) and high bandwidth
 
 | Aspect | Mesh | Ring |

--- a/docs/en/user/distributed/05-tutorials.md
+++ b/docs/en/user/distributed/05-tutorials.md
@@ -1,14 +1,16 @@
 # Distributed Tutorials
 
 The `pld` vocabulary taught step by step: a sixteen-step tutorial series, one
-concept per program. Seven runnable examples ship now — from "hello rank"
-through point-to-point moves and the dynamic rank count; steps 08–16 (the
-collectives) are planned.
+concept per program. Eleven runnable examples ship now — from "hello rank"
+through point-to-point moves, the dynamic rank count, and the all-reduce trio
+plus its reveal; steps 12–15 (the remaining collectives) and step 16
+(composition) are planned.
 
 > **Prerequisites:** the [Distributed Programming](../distributed/index.md)
 > chapter — read it once for the vocabulary, then come back here to build the
-> same ideas by hand. Hardware: two devices for steps 01–06, three or more for
-> step 07 (any rank count), four for the collective comparisons in steps 08–16.
+> same ideas by hand. Hardware: two devices for steps 01–06, any count ≥ 2 for
+> step 07 (three or more to see the ring differ from P=2), four for the
+> collective comparisons in steps 08–11.
 
 ## The idea
 
@@ -44,8 +46,8 @@ idea from the primitives before a builtin replaces it:
 ## Suggested reading order
 
 Read the steps in order — **01 → 02 → 03 → 04 → 05 → 06 → 07 → 08 → 09 → 10 →
-11 → 12 → 13 → 14 → 15 → 16**. Every page repeats this block. Steps 08–16 are
-planned; 01–07 ship in the first PR (below).
+11 → 12 → 13 → 14 → 15 → 16**. Every page repeats this block. Steps 01–11 ship
+now; 12–16 remain planned.
 
 ## The 16 steps
 
@@ -58,18 +60,18 @@ planned; 01–07 ship in the first PR (below).
 | 05 | `05_remote_load_store.py` | Tile-level RMA: `remote_load`/`remote_store`; one-step ring shift | ✅ shipped |
 | 06 | `06_put_get.py` | Tensor-level p2p: `put`/`get`; push vs pull | ✅ shipped |
 | 07 | `07_dynamic_rank_count.py` | Dynamic rank count: `pl.dynamic("NR")`; one source, any P | ✅ shipped |
-| 08 | `08_allreduce_mesh.py` | All-reduce v1 (mesh): every rank reads every peer, sums locally | planned |
-| 09 | `09_allreduce_two_phase.py` | All-reduce v2: reduce-scatter + all-gather | planned |
-| 10 | `10_allreduce_ring.py` | All-reduce v3 (ring): chunked around the ring | planned |
-| 11 | `11_allreduce_reveal.py` | **The reveal**: `pld.tensor.allreduce` (mesh + ring); diff the IR | planned |
+| 08 | `08_allreduce_mesh.py` | All-reduce v1 (mesh): every rank reads every peer, sums locally | ✅ shipped |
+| 09 | `09_allreduce_two_phase.py` | All-reduce v2: reduce-scatter + all-gather | ✅ shipped |
+| 10 | `10_allreduce_ring.py` | All-reduce v3 (ring): chunked around the ring | ✅ shipped |
+| 11 | `11_allreduce_reveal.py` | **The reveal**: `pld.tensor.allreduce` (mesh + ring); diff the IR | ✅ shipped |
 | 12 | `12_broadcast.py` | One-to-all; reveal `pld.tensor.broadcast` | planned |
 | 13 | `13_allgather.py` | All-to-all slices; reveal `pld.tensor.allgather` | planned |
 | 14 | `14_reduce_scatter.py` | All-to-chunks; reveal `pld.tensor.reduce_scatter` | planned |
 | 15 | `15_all_to_all.py` | Personalized exchange; reveal `pld.tensor.all_to_all` | planned |
 | 16 | `16_putting_it_together.py` | Compose `broadcast` + `allreduce` + `allgather` in one kernel | planned |
 
-Steps 08–16 are **planned** — they arrive in later PRs. The walkthroughs below
-(06–12) cover steps 01–07, which ship together.
+Steps 12–16 are **planned** — they arrive in later PRs. The walkthroughs below
+(06–16) cover steps 01–11.
 
 ## The abstractions map
 

--- a/docs/en/user/distributed/13-allreduce_mesh.md
+++ b/docs/en/user/distributed/13-allreduce_mesh.md
@@ -40,19 +40,26 @@ OK
 
 ## Walkthrough
 
-The program is built by a **rank-count factory**: `build_mesh_allreduce(nr)`
-folds `nr` into a `@pl.program` class, so the barrier signal `[nr, 1]` (one
-cell per rank) is a compile-time shape while the same source serves any world
-size via `-d`.
+The rank count is never a compile-time constant here. It is
+`NR = pl.dynamic("NR")` in the annotations and `pld.world_size()` in the host
+body, so one module-level `@pl.program` serves any world size picked with `-d`
+— no rank-count factory. This mirrors
+`tests/st/distributed/collectives/test_l3_allreduce.py`, the system test for
+this same collective.
 
 Steps 01-07 use the `@pl.jit` family, and the switch to the class form here is
-**required, not stylistic**. `@pl.program` / `@pl.function` snapshot the
-*defining* frame's locals at decoration time, so the factory's `nr` resolves
-both in the signatures and inside the HOST orchestrator body
-(`alloc_window_buffer([nr, 1], ...)`). `@pl.jit.host` re-specializes into
-`@pl.function` later, after that frame is gone, so a closure `nr` referenced in
-its body fails to resolve. Every rank-parametrized collective in
-`tests/st/distributed/` uses this same class-form factory.
+**required, not stylistic** — but the reason is the *dynamic* signal shape, not
+a compile-time one. `signal` is a window shaped `[pld.world_size(), 1]`, and
+`@pl.jit` must statically infer shape and dtype for every parameter it forwards
+to a dependency; it rejects this one with `missing inferred tensor metadata for
+parameter 'signal'`. `@pl.program` carries no such requirement. (`@pl.jit` is
+fine with distributed tensors as such — steps 03, 05, 06 and 07 all pass them
+— it is specifically a runtime-sized window dim it cannot type.)
+
+Steps 09 and 10 switch for a stronger reason: their chunk size `SIZE // nr` is
+a **tile shape**, and tile shapes must be known when the kernel is compiled, so
+those genuinely need a compile-time rank count and a factory. A signal row
+count is not a tile shape, which is why it can stay dynamic here.
 
 The kernel is the four phases every hand-rolled collective shares:
 
@@ -106,7 +113,7 @@ is exactly why the two-phase and ring variants exist.
 | Sum includes zeros at some ranks | Barrier missing/incorrect; read raced the store | Barrier (notify all / wait all) before Phase 3 |
 | Wrong result only at P=4 | P=2 hides the race (single peer) | Run P≥4; check the barrier covers every peer |
 | Same result on every rank but ≠ torch sum | Reduction order differs (not a bug) | Compare with a tolerance (the example already does) |
-| Compile error about a dynamic window shape | A `[nr, 1]` shape escaped the factory | Build via `build_mesh_allreduce(nr)` — `nr` must be a closure constant |
+| `missing inferred tensor metadata for parameter 'signal'` | The kernel was written with `@pl.jit`, which cannot type a window whose dim is `pld.world_size()` | Use the `@pl.program` class form (as here); `@pl.jit` needs every dep parameter statically shaped |
 | Golden fails with a huge diff | Slices summed in the wrong place (e.g. own slice counted twice) | Stage once; accumulate from your own slice, then peers |
 
 ## See also

--- a/docs/en/user/distributed/13-allreduce_mesh.md
+++ b/docs/en/user/distributed/13-allreduce_mesh.md
@@ -1,0 +1,111 @@
+# All-Reduce 1: Mesh — Every Rank Reads Every Peer
+
+The first collective of the ladder. Every rank contributes its slice; every
+rank ends with the element-wise **sum of all slices**. The mesh algorithm is
+the simplest spelling of that: one barrier, then each rank `remote_load`s
+every peer's slice and accumulates locally.
+
+> **Prerequisites:** [12-dynamic_rank_count](12-dynamic_rank_count.md). Four
+> sim devices recommended — at two ranks the three all-reduce variants of
+> steps 08-10 collapse into the same exchange, and their differences are only
+> observable at P=4.
+
+**Suggested reading order:** 01 → 02 → 03 → 04 → 05 → 06 → 07 → **08** — this page is step 08.
+
+## The idea
+
+All-reduce is the operation every collective comparison starts from: you have
+`P` ranks, each holding a slice; after the call every rank holds the reduction
+of *all* slices. Step 11 reveals the builtin; here you build it by hand, and
+the cost card you develop is the reason the builtin exists and what it chooses
+between.
+
+The mesh is the naive baseline: **every rank reads every peer**. That is
+O(P) remote traffic per rank — simple, round-heavy, and the yardstick the
+two-phase and ring steps are measured against.
+
+## Run it
+
+```bash
+# P=4 (the comparison steps require it) and P=2:
+python examples/distributed/08_allreduce_mesh.py -p a2a3sim -d 0,1,2,3
+python examples/distributed/08_allreduce_mesh.py -p a2a3sim -d 0,1
+```
+
+Expected output:
+
+```text
+OK
+```
+
+## Walkthrough
+
+The program is built by a **rank-count factory**: `build_mesh_allreduce(nr)`
+folds `nr` into a `@pl.program` class, so the barrier signal `[nr, 1]` (one
+cell per rank) is a compile-time shape while the same source serves any world
+size via `-d`. This is the documented pattern for collectives whose window
+shapes depend on the world size — see `01-collectives.md` Ring Mode; the ST
+tests use the same class-form factory.
+
+The kernel is the four phases every hand-rolled collective shares:
+
+```python
+# Phase 1 — stage this rank's slice into its window slot.
+local = pl.load(x, [0, 0], [1, SIZE])
+data = pl.store(local, [0, 0], data)
+
+# Phase 2 — barrier: notify every peer, wait on every peer slot.
+for peer in pl.range(nr):
+    if peer != my_rank:
+        pld.system.notify(signal, peer=peer, offsets=[my_rank, 0],
+                          value=1, op=pld.NotifyOp.AtomicAdd)
+for src in pl.range(nr):
+    if src != my_rank:
+        pld.system.wait(signal, offsets=[src, 0], expected=1, cmp=pld.WaitCmp.Ge)
+
+# Phase 3 — accumulate: start from our own slice, add every peer's slice.
+acc = pl.load(data, [0, 0], [1, SIZE])
+for peer in pl.range(nr):
+    if peer != my_rank:
+        recv = pld.tile.remote_load(data, peer=peer, offsets=[0, 0], shape=[1, SIZE])
+        acc = pl.add(acc, recv)
+
+# Phase 4 — stage-out: the accumulated result is this rank's output.
+y = pl.store(acc, [0, 0], y)
+```
+
+- **Phase 2 is the step-04 barrier, verbatim.** Each rank owns a dedicated row
+  (`offsets=[my_rank, 0]`); `AtomicAdd`/`Ge(1)` passes only once every peer has
+  staged. Without it, Phase 3 could `remote_load` a peer's slice before that
+  peer's store lands.
+- **Phase 3 is the mesh itself.** Start from your own slice, then `remote_load`
+  every other rank's slice and add. Note the symmetry: every rank does this,
+  so every rank ends with the same sum.
+
+**Cost card (per rank):** `(P-1) * N` bytes — one full slice per peer, read by
+every rank. Round-heavy: `P-1` remote reads plus one barrier. This O(P) traffic
+is exactly why the two-phase and ring variants exist.
+
+## Edge cases
+
+> **Fatal pitfall — a missing barrier lets the load race the store.** If you
+> drop Phase 2, a rank can read a peer's window slot before that peer's
+> `pl.store` has landed, mixing stale/zero data into the sum. The race is
+> timing-dependent, so it may pass at P=2 and fail at P=4. **Fix:** the
+> notify/wait handshake must complete before any `remote_load`.
+
+| Symptom | Likely cause | Fix |
+| ------- | ------------ | --- |
+| Sum includes zeros at some ranks | Barrier missing/incorrect; read raced the store | Barrier (notify all / wait all) before Phase 3 |
+| Wrong result only at P=4 | P=2 hides the race (single peer) | Run P≥4; check the barrier covers every peer |
+| Same result on every rank but ≠ torch sum | Reduction order differs (not a bug) | Compare with a tolerance (the example already does) |
+| Compile error about a dynamic window shape | A `[nr, 1]` shape escaped the factory | Build via `build_mesh_allreduce(nr)` — `nr` must be a closure constant |
+| Golden fails with a huge diff | Slices summed in the wrong place (e.g. own slice counted twice) | Stage once; accumulate from your own slice, then peers |
+
+## See also
+
+- [05-tutorials](05-tutorials.md) — the tutorial index (this step = row 08)
+- [01-collectives](01-collectives.md) §AllReduce — the reference for mesh mode
+- [09-barrier](09-barrier.md) — the notify/wait barrier reused here (step 04)
+- [10-remote_load_store](10-remote_load_store.md) — `remote_load` (step 05)
+- Next step: [14-allreduce_two_phase](14-allreduce_two_phase.md) — the same result in roughly half the traffic

--- a/docs/en/user/distributed/13-allreduce_mesh.md
+++ b/docs/en/user/distributed/13-allreduce_mesh.md
@@ -43,9 +43,16 @@ OK
 The program is built by a **rank-count factory**: `build_mesh_allreduce(nr)`
 folds `nr` into a `@pl.program` class, so the barrier signal `[nr, 1]` (one
 cell per rank) is a compile-time shape while the same source serves any world
-size via `-d`. This is the documented pattern for collectives whose window
-shapes depend on the world size — see `01-collectives.md` Ring Mode; the ST
-tests use the same class-form factory.
+size via `-d`.
+
+Steps 01-07 use the `@pl.jit` family, and the switch to the class form here is
+**required, not stylistic**. `@pl.program` / `@pl.function` snapshot the
+*defining* frame's locals at decoration time, so the factory's `nr` resolves
+both in the signatures and inside the HOST orchestrator body
+(`alloc_window_buffer([nr, 1], ...)`). `@pl.jit.host` re-specializes into
+`@pl.function` later, after that frame is gone, so a closure `nr` referenced in
+its body fails to resolve. Every rank-parametrized collective in
+`tests/st/distributed/` uses this same class-form factory.
 
 The kernel is the four phases every hand-rolled collective shares:
 
@@ -55,17 +62,17 @@ local = pl.load(x, [0, 0], [1, SIZE])
 data = pl.store(local, [0, 0], data)
 
 # Phase 2 — barrier: notify every peer, wait on every peer slot.
-for peer in pl.range(nr):
+for peer in pl.range(nranks):
     if peer != my_rank:
         pld.system.notify(signal, peer=peer, offsets=[my_rank, 0],
                           value=1, op=pld.NotifyOp.AtomicAdd)
-for src in pl.range(nr):
+for src in pl.range(nranks):
     if src != my_rank:
         pld.system.wait(signal, offsets=[src, 0], expected=1, cmp=pld.WaitCmp.Ge)
 
 # Phase 3 — accumulate: start from our own slice, add every peer's slice.
 acc = pl.load(data, [0, 0], [1, SIZE])
-for peer in pl.range(nr):
+for peer in pl.range(nranks):
     if peer != my_rank:
         recv = pld.tile.remote_load(data, peer=peer, offsets=[0, 0], shape=[1, SIZE])
         acc = pl.add(acc, recv)

--- a/docs/en/user/distributed/14-allreduce_two_phase.md
+++ b/docs/en/user/distributed/14-allreduce_two_phase.md
@@ -43,9 +43,13 @@ OK
 
 ## Walkthrough
 
-Same class-form factory as step 08, now with **two** windows (`data`
-for the staged inputs, `result` for the reduced chunks) and a **two-row
-signal** (`[2, nr]` — one row per barrier round):
+Same `@pl.program` class form as step 08, but now with a **rank-count
+factory** — step 08 needed none. The factory is what makes `nr` a compile-time
+constant, and this step is the first that requires one: the chunk size
+`SIZE // nr` is a **tile shape**, and tile shapes must be known when the kernel
+is compiled. There are also **two** windows now (`data` for the staged inputs,
+`result` for the reduced chunks) and a **two-row signal** (`[2, nr]` — one row
+per barrier round):
 
 ```python
 # Phase 1 — stage this rank's slice into its window slot.

--- a/docs/en/user/distributed/14-allreduce_two_phase.md
+++ b/docs/en/user/distributed/14-allreduce_two_phase.md
@@ -1,0 +1,108 @@
+# All-Reduce 2: Two-Phase — Reduce-Scatter Then All-Gather
+
+The same result as step 08, in roughly half the remote traffic. Instead of
+every rank reading every peer's *full* slice, split the slice into `P`
+chunks: first **reduce-scatter** so rank `r` owns the reduced chunk `r`, then
+**all-gather** so every rank collects every chunk.
+
+> **Prerequisites:** [13-allreduce_mesh](13-allreduce_mesh.md). Four sim
+> devices recommended (the traffic saving vs mesh is only observable at P≥4);
+> `SIZE` must divide evenly by the rank count.
+
+**Suggested reading order:** 01 → 02 → 03 → 04 → 05 → 06 → 07 → 08 → **09** — this page is step 09.
+
+## The idea
+
+Mesh transfers `(P-1) * N` bytes per rank because every rank reads every
+peer's *entire* slice. But the sum only needs `N` result values per rank — so
+most of what mesh moves is duplicate work. Two-phase restructures the same
+sum into two stages, each moving `N/P`-sized pieces:
+
+1. **Reduce-scatter (RS):** rank `r` is the *owner* of chunk `r`. Every rank
+   reads every peer's chunk `r` (a `N/P`-sized piece, not the full slice) and
+   sums locally. After this, rank `r` alone holds the reduced chunk `r`.
+2. **All-gather (AG):** every rank reads every peer's reduced chunk, one per
+   rank, and assembles the full result.
+
+Each stage moves `(P-1) * N/P` bytes, so the total is `2 * (P-1) / P * N` —
+roughly half of mesh's traffic, at the price of a second barrier.
+
+## Run it
+
+```bash
+# P=4 (the saving vs mesh shows here) and P=2:
+python examples/distributed/09_allreduce_two_phase.py -p a2a3sim -d 0,1,2,3
+python examples/distributed/09_allreduce_two_phase.py -p a2a3sim -d 0,1
+```
+
+Expected output:
+
+```text
+OK
+```
+
+## Walkthrough
+
+Same class-form factory as step 08, now with **two** windows (`data` for the
+staged inputs, `result` for the reduced chunks) and a **two-row signal**
+(`[2, nr]` — one row per barrier round):
+
+```python
+# Phase 1 — stage this rank's slice into its window slot.
+local = pl.load(x, [0, 0], [1, SIZE])
+data = pl.store(local, [0, 0], data)
+
+# Barrier A (signal row 0) — all inputs staged before the RS reads.
+# (notify all peers / wait all peers, as in step 08, but on row 0)
+
+# Phase 2 — reduce-scatter: rank r owns chunk r of the result.
+acc = pl.load(data, [0, my_rank * chunk], [1, chunk])
+for peer in pl.range(nranks):
+    if peer != my_rank:
+        recv = pld.tile.remote_load(data, peer=peer, offsets=[0, my_rank * chunk],
+                                    shape=[1, chunk])
+        acc = pl.add(acc, recv)
+result = pl.store(acc, [0, my_rank * chunk], result)
+
+# Barrier B (signal row 1) — all reduced chunks staged before the AG reads.
+
+# Phase 3 — all-gather: rank r reads every rank's reduced chunk.
+for c in pl.range(nranks):
+    recv = pld.tile.remote_load(result, peer=c, offsets=[0, c * chunk], shape=[1, chunk])
+    y = pl.store(recv, [0, c * chunk], y)
+```
+
+- **Chunk ownership.** The RS loop indexes every peer's window at
+  `[0, my_rank * chunk]` — each rank reads the *same* chunk (its own) from
+  every peer. After the loop, rank `r`'s `result` holds the reduced chunk `r`.
+- **The AG reads one chunk per peer** at `[0, c * chunk]` from peer `c` — the
+  pieces already reduced in the RS — and writes them into the output in order.
+- **Two barriers, two signal rows.** The `[2, nr]` signal gives each barrier
+  its own row, so the monotonic counters (`Ge(1)`) don't leak between rounds.
+
+**Cost card (per rank):** `2 * (P-1) / P * N` bytes — `(P-1)` reads of `N/P`
+bytes in the RS, `(P-1)` reads of `N/P` bytes in the AG. Roughly half of
+mesh's `(P-1) * N`, at the cost of one extra barrier round.
+
+## Edge cases
+
+> **Fatal pitfall — reusing one signal row for both barriers.** The counters
+> are monotonic: after barrier A, `Ge(1)` is already satisfied on that row, so
+> barrier B returns immediately and the AG reads can race the RS stores.
+> **Fix:** give each round its own row (the `[2, nr]` signal) — the same
+> discipline the ring step generalises to one row per round.
+
+| Symptom | Likely cause | Fix |
+| ------- | ------------ | --- |
+| AG reads stale chunk data | Both barriers used the same signal cell | One signal row per round (`[2, nr]`) |
+| Wrong result only at P≥4 | Chunk size mismatch (`SIZE % P != 0`) | Run P where `SIZE` divides evenly (2, 4) |
+| Result has chunk `r` in the wrong position | AG assembled chunks out of order | Read chunk `c` from peer `c`, write at `[0, c * chunk]` |
+| All ranks hold the RS result but not the sum | AG missing (only reduce-scatter ran) | Add the AG loop: every rank reads every reduced chunk |
+| Same result on every rank but ≠ torch sum | Reduction order differs (not a bug) | Compare with a tolerance |
+
+## See also
+
+- [05-tutorials](05-tutorials.md) — the tutorial index (this step = row 09)
+- [13-allreduce_mesh](13-allreduce_mesh.md) — the baseline this step improves (step 08)
+- [01-collectives](01-collectives.md) §AllReduce — reference (Mesh Mode, Ring Mode)
+- Next step: [15-allreduce_ring](15-allreduce_ring.md) — same bytes, constant per-step size

--- a/docs/en/user/distributed/14-allreduce_two_phase.md
+++ b/docs/en/user/distributed/14-allreduce_two_phase.md
@@ -43,9 +43,9 @@ OK
 
 ## Walkthrough
 
-Same class-form factory as step 08, now with **two** windows (`data` for the
-staged inputs, `result` for the reduced chunks) and a **two-row signal**
-(`[2, nr]` — one row per barrier round):
+Same class-form factory as step 08, now with **two** windows (`data`
+for the staged inputs, `result` for the reduced chunks) and a **two-row
+signal** (`[2, nr]` — one row per barrier round):
 
 ```python
 # Phase 1 — stage this rank's slice into its window slot.

--- a/docs/en/user/distributed/15-allreduce_ring.md
+++ b/docs/en/user/distributed/15-allreduce_ring.md
@@ -1,0 +1,120 @@
+# All-Reduce 3: Ring — Constant Per-Step Size
+
+The two-phase shape from step 09, but each rank only ever moves data with its
+**left neighbour**. Instead of reading `P-1` peers per stage, the chunks rotate
+around the ring: `2 * (P-1)` steps, each moving one `N/P`-sized chunk — so the
+per-step transfer stays `N/P` as `P` grows under weak scaling (for a fixed
+`N` the chunk shrinks instead). Synchronization is
+neighbour-local too: each rank notifies its **right** neighbour after a store
+and waits on its **left** neighbour before a read — no full barrier per round.
+
+> **Prerequisites:** [14-allreduce_two_phase](14-allreduce_two_phase.md).
+> Four sim devices recommended (the constant per-step size is only observable
+> at P≥4); `SIZE` must divide evenly by the rank count.
+
+**Suggested reading order:** 01 → … → 09 → **10** — this page is step 10.
+
+## The idea
+
+Two-phase halves mesh's traffic but still reads every peer per stage — O(P)
+peers, each a `N/P` chunk. The ring removes the "every peer" part: arrange the
+ranks in a circle and pass chunks to the **left neighbour**. The same
+reduce-scatter + all-gather split now takes `P-1` steps each:
+
+- **Reduce-scatter (P-1 steps):** in each step a chunk travels one hop and is
+  added at its destination. After `P-1` steps every rank holds the reduced
+  chunk it owns.
+- **All-gather (P-1 steps):** the reduced chunks keep circulating, and each
+  rank copies every chunk as it passes. After `P-1` more steps every rank has
+  the full result.
+
+Total bytes equal two-phase (`2 * (P-1) / P * N`), but each step moves only
+`N/P` — under weak scaling (a workload that grows with `P`) the per-step size
+stays constant as `P` grows, which is what keeps the ring efficient at large
+world sizes; for a fixed `N` the chunk would shrink instead.
+
+## Run it
+
+```bash
+# P=4 (the constant per-step size shows here) and P=2:
+python examples/distributed/10_allreduce_ring.py -p a2a3sim -d 0,1,2,3
+python examples/distributed/10_allreduce_ring.py -p a2a3sim -d 0,1
+```
+
+Expected output:
+
+```text
+OK
+```
+
+## Walkthrough
+
+The kernel is monolithic (one InCore function) and the signal generalises the
+two-phase idea: `[2 * (nr-1), nr]` — **one row per round**. The chunk index
+arithmetic is the heart of the schedule:
+
+```python
+left = (my_rank - 1 + nranks) % nranks      # never negative
+
+# Reduce-scatter: (nr-1) steps.
+for s in pl.range(nranks - 1):
+    step = s + 1
+    recv_add_idx = (my_rank - step - 1 + nranks) % nranks
+    left_send_idx = (left - step + nranks) % nranks
+    # Wait for the left neighbour's round-s chunk (signal row s), then:
+    pld.system.wait(signal, offsets=[s, left], expected=1, cmp=pld.WaitCmp.Ge)
+    recv = pld.tile.remote_load(scratch, peer=left,
+                                offsets=[0, left_send_idx * chunk_elems],
+                                shape=[1, chunk])
+    acc = pl.load(scratch, [0, recv_add_idx * chunk_elems], [1, chunk])
+    acc = pl.add(acc, recv)
+    scratch = pl.store(acc, [0, recv_add_idx * chunk_elems], scratch)
+    # The store stages next round's send: signal the right neighbour (row s+1).
+    pld.system.notify(signal, peer=right, offsets=[s + 1, my_rank],
+                      value=1, op=pld.NotifyOp.AtomicAdd)
+
+# All-gather: (nr-1) steps (rows nranks-1 .. 2*(nranks-1)-1), copying the
+# left neighbour's send chunk into the local chunk.
+```
+
+- **`left = (my_rank - 1 + nranks) % nranks`.** The `+ nranks` keeps the
+  dividend non-negative — a bare `(my_rank - 1) % nranks` yields `-1` at
+  rank 0 under truncating modulo (the step-06 lesson, now on the index side).
+- **Chunks rotate, not ranks.** In round `s`, the chunk you add from the left
+  and the chunk you forward both shift by one (`- step`), so every chunk
+  visits every rank exactly once per phase.
+- **Neighbour-ready handshakes, not barriers.** Each round gets its own signal
+  row — notify the **right** neighbour after a store, wait on the **left**
+  neighbour before a `remote_load`. The monotonic `Ge(1)` counters never leak
+  between rounds (the step-09 discipline, now at `2*(P-1)` rows), and only the
+  two adjacent ranks ever synchronize: O(P) signals **per rank** (O(P²)
+  system-wide) — versus the O(P²) per rank a full-mesh barrier per round would
+  cost.
+
+**Cost card (per rank):** `2 * (P-1) / P * N` total — the same as two-phase —
+but in `2*(P-1)` steps of `N/P` bytes each. Under weak scaling the per-step
+size stays **constant as P grows** — unlike mesh's `(P-1) * N` per step —
+which is the ring's reason to exist.
+
+## Edge cases
+
+> **Fatal pitfall — a negative left-neighbour index.** `(my_rank - 1) %
+> nranks` is `-1` at rank 0 under truncating modulo — an invalid peer the
+> `remote_load` then targets. **Fix:** always write
+> `(my_rank - 1 + nranks) % nranks` (at P=2 rank 0's left neighbour is rank 1;
+> the `+ nranks` keeps the dividend non-negative).
+
+| Symptom | Likely cause | Fix |
+| ------- | ------------ | --- |
+| Hang at P=2 | Negative dividend in the left-neighbour index | `(my_rank - 1 + nranks) % nranks` |
+| Wrong chunks in the result | Chunk index arithmetic off by one in a round | Trace `recv_add_idx` / `left_send_idx` for `s=0` on paper |
+| Two handshakes share a signal row | Row index reused across RS and AG | RS rows `0..P-2`, AG rows `P-1..2(P-1)-1` |
+| Result correct at P=2 only | P=2 has a single round, hiding rotation bugs | Run P=4 and check every chunk position |
+| Same result on every rank but ≠ torch sum | Reduction order differs (not a bug) | Compare with a tolerance |
+
+## See also
+
+- [05-tutorials](05-tutorials.md) — the tutorial index (this step = row 10)
+- [14-allreduce_two_phase](14-allreduce_two_phase.md) — the two-phase shape (step 09)
+- [01-collectives](01-collectives.md) §AllReduce — reference (Ring Mode, signal shape, `Sum`/`FP32`)
+- Next step: [16-allreduce_reveal](16-allreduce_reveal.md) — the builtin that picks mesh or ring for you

--- a/docs/en/user/distributed/15-allreduce_ring.md
+++ b/docs/en/user/distributed/15-allreduce_ring.md
@@ -64,11 +64,11 @@ for s in pl.range(nranks - 1):
     # Wait for the left neighbour's round-s chunk (signal row s), then:
     pld.system.wait(signal, offsets=[s, left], expected=1, cmp=pld.WaitCmp.Ge)
     recv = pld.tile.remote_load(scratch, peer=left,
-                                offsets=[0, left_send_idx * chunk_elems],
+                                offsets=[0, left_send_idx * chunk],
                                 shape=[1, chunk])
-    acc = pl.load(scratch, [0, recv_add_idx * chunk_elems], [1, chunk])
+    acc = pl.load(scratch, [0, recv_add_idx * chunk], [1, chunk])
     acc = pl.add(acc, recv)
-    scratch = pl.store(acc, [0, recv_add_idx * chunk_elems], scratch)
+    scratch = pl.store(acc, [0, recv_add_idx * chunk], scratch)
     # The store stages next round's send: signal the right neighbour (row s+1).
     pld.system.notify(signal, peer=right, offsets=[s + 1, my_rank],
                       value=1, op=pld.NotifyOp.AtomicAdd)

--- a/docs/en/user/distributed/16-allreduce_reveal.md
+++ b/docs/en/user/distributed/16-allreduce_reveal.md
@@ -59,10 +59,13 @@ y = pl.store(recv, [0, 0], y)
   takes `[nr, 1]`; ring takes `[2*(nr-1), nr]` — exactly the row-per-round
   signal step 10 taught. The factory folds both `nr` and `mode` in, so one
   source builds either variant (the class-form pattern from steps 08-10).
-- **What the builtin accepts (read this twice):** `pld.tensor.allreduce` takes
-  the full `ReduceOp` family (`Sum`/`Max`/`Min`/`Prod`) and `FP16`/`FP32` in
-  **both** modes — the mesh and ring ST suites run every operator and `FP16`
-  through the real pipelines.
+- **What the builtin accepts (read this twice):** `pld.tensor.allreduce` — the
+  **InCore composite** lowering used here — takes the full `ReduceOp` family
+  (`Sum`/`Max`/`Min`/`Prod`) and `FP16`/`FP32` in **both** modes — the mesh and
+  ring ST suites run every operator and `FP16` through the real pipelines.
+  A narrower `Sum`+`FP32`-only contract exists, but only on the separate
+  **HOST builtin** ring path (`builtin.tensor.allreduce_ring`, not used by
+  this tutorial) — see `01-collectives.md` §AllReduce.
 
 ### The IR diff (the teaching artifact)
 

--- a/docs/en/user/distributed/16-allreduce_reveal.md
+++ b/docs/en/user/distributed/16-allreduce_reveal.md
@@ -1,0 +1,111 @@
+# The Reveal: `pld.tensor.allreduce` in One Call
+
+You built all-reduce three ways by hand — mesh, two-phase, ring. Now the
+builtin: `pld.tensor.allreduce(data, signal, op=..., mode=...)` replaces the
+whole schedule with one call, and the IR diff shows what it lowers to: the
+hand-rolled pattern you wrote, or a better one.
+
+> **Prerequisites:** [13-allreduce_mesh](13-allreduce_mesh.md) ·
+> [14-allreduce_two_phase](14-allreduce_two_phase.md) ·
+> [15-allreduce_ring](15-allreduce_ring.md). Four sim devices recommended.
+
+**Suggested reading order:** 01 → … → 10 → **11** — this page is step 11.
+
+## The idea
+
+The reveal discipline, completed: step 04 revealed the barrier after you built
+it; this step reveals the collective after you built three of them. The point
+of the hand-rolled steps was not that you should write all-reduce by hand —
+it was that you should know *what the builtin chooses between*.
+
+`pld.tensor.allreduce` is the builtin for the whole ladder: it takes your
+window and signal, does the barrier + cross-rank reduce + store-back, and
+hands the reduced slice back. `mode=` picks the algorithm — `"mesh"` (default)
+or `"ring"`. The same golden as steps 08-10; none of the schedule.
+
+## Run it
+
+```bash
+# Both modes, at P=4 (and P=2):
+python examples/distributed/11_allreduce_reveal.py -p a2a3sim -d 0,1,2,3
+python examples/distributed/11_allreduce_reveal.py -p a2a3sim -d 0,1,2,3 --mode ring
+python examples/distributed/11_allreduce_reveal.py -p a2a3sim -d 0,1
+```
+
+Expected output:
+
+```text
+OK
+```
+
+## Walkthrough
+
+Your stage-in and stage-out stay; only the middle is replaced:
+
+```python
+# Phase 1 — stage this rank's slice into its window slot.
+local = pl.load(x, [0, 0], [1, SIZE])
+data = pl.store(local, [0, 0], data)
+
+# Phase 2 — the builtin: barrier + reduce + store-back, in one call.
+data = pld.tensor.allreduce(data, signal, op=pld.ReduceOp.Sum, mode=mode)
+
+# Phase 3 — stage-out: the reduced slice back to the local output.
+recv = pl.load(data, [0, 0], [1, SIZE])
+y = pl.store(recv, [0, 0], y)
+```
+
+- **The signal is yours, and its shape tells you which mode you're in.** Mesh
+  takes `[nr, 1]`; ring takes `[2*(nr-1), nr]` — exactly the row-per-round
+  signal step 10 taught. The factory folds both `nr` and `mode` in, so one
+  source builds either variant (the class-form pattern from steps 08-10).
+- **What the builtin accepts (read this twice):** `pld.tensor.allreduce` takes
+  the full `ReduceOp` family (`Sum`/`Max`/`Min`/`Prod`) and `FP16`/`FP32` in
+  **both** modes — the mesh and ring ST suites run every operator and `FP16`
+  through the real pipelines.
+
+### The IR diff (the teaching artifact)
+
+Compile with pass dumps enabled and diff the lowered IR of this step against
+your hand-rolled programs:
+
+- `--mode mesh` expands into **step 08's pattern**: a ready barrier on the
+  `[nr, 1]` signal, then `remote_load` + accumulate chunks — the mesh you
+  wrote, possibly chunked to UB-sized tiles.
+- `--mode ring` expands into **step 10's shape**: `2*(nr-1)` rounds on the
+  `[2*(nr-1), nr]` signal, chunked `N/P` transfers — but the builtin lowers
+  each round to a **full-mesh barrier** (`EmitNotifyAll`/`EmitWaitAll`), not
+  the neighbour-ready handshake you wrote in step 10. That difference is the
+  point of the diff: same schedule and chunks, different synchronization.
+
+Same golden, same signal conventions, same four-phase shape — the diff is
+"your schedule, expressed by the compiler", which is the whole teaching point.
+
+**Cost card (per rank):** whatever mode you picked — `(P-1) * N` (mesh) or
+`2 * (P-1) / P * N` in `N/P` steps (ring). The builtin chooses the algorithm;
+you still choose the mode.
+
+## Edge cases
+
+> **Fatal pitfall — the wrong signal shape for the mode.** `mode="ring"`
+> strictly validates the `[2*(nr-1), nr]` signal. Mesh validates that a static
+> column count is 1 — so a static ring-shaped signal is rejected — but it does
+> not validate the row count; it only reads the slots it indexes. **Fix:** keep
+> mesh → `[nr, 1]`, ring → `[2*(nr-1), nr]`, and don't share one signal window
+> across modes.
+
+| Symptom | Likely cause | Fix |
+| ------- | ------------ | --- |
+| Compile error about the signal shape | Ring-mode signal not `[2*(nr-1), nr]`, or a static non-`[·,1]` mesh signal | Mesh `[nr, 1]`, ring `[2*(nr-1), nr]` — one window per mode |
+| Builtin ring shows more sync cost than your hand-rolled ring | The builtin emits a full-mesh barrier per round (O(P²) per rank); your handshake is neighbour-local (O(P) per rank) | Hand-roll the ring (step 10) when per-round sync cost matters |
+| Same result on every rank but ≠ torch sum | Reduction order differs (not a bug) | Compare with a tolerance |
+| Result is your own slice, unreduced | The call result wasn't rebound (`data =`) | `data = pld.tensor.allreduce(data, signal, ...)` — in-place rebind |
+| Builtin slower than your hand-rolled mesh | Tiny payload: mesh is for small messages | Use ring for payloads ≳ 16 KiB (see `01-collectives.md`) |
+
+## See also
+
+- [05-tutorials](05-tutorials.md) — the tutorial index (this step = row 11)
+- [01-collectives](01-collectives.md) §AllReduce — the reference for both modes and the signal shapes
+- [13-allreduce_mesh](13-allreduce_mesh.md) / [15-allreduce_ring](15-allreduce_ring.md) — what each mode lowers to
+- [02-primitives](02-primitives.md) — the substrate the builtin is built from
+- Next: steps 12-16 in [05-tutorials](05-tutorials.md) cover the other collectives

--- a/docs/en/user/distributed/16-allreduce_reveal.md
+++ b/docs/en/user/distributed/16-allreduce_reveal.md
@@ -59,6 +59,13 @@ y = pl.store(recv, [0, 0], y)
   takes `[nr, 1]`; ring takes `[2*(nr-1), nr]` — exactly the row-per-round
   signal step 10 taught. The factory folds both `nr` and `mode` in, so one
   source builds either variant (the class-form pattern from steps 08-10).
+- **Why a factory here is not the steps 09/10 story.** Those two need a
+  compile-time `nr` because their chunk size `SIZE // nr` is a **tile shape**.
+  Here the builtin owns the chunking, so nothing is a tile shape sized by the
+  rank count, and `nr` could stay dynamic. What has to be fixed when the kernel
+  is traced is `mode`: it picks the lowering *and* the signal layout, and mesh
+  and ring are two different shapes rather than two extents of one. `nr` is
+  folded in beside it so a single source can spell both layouts.
 - **What the builtin accepts (read this twice):** `pld.tensor.allreduce` — the
   **InCore composite** lowering used here — takes the full `ReduceOp` family
   (`Sum`/`Max`/`Min`/`Prod`) and `FP16`/`FP32` in **both** modes — the mesh and

--- a/docs/zh/user/distributed/00-model.md
+++ b/docs/zh/user/distributed/00-model.md
@@ -11,6 +11,12 @@
 
 最简单的分布式程序——两个 rank 对各自数据求和，结果相同。
 
+> 这是 **mesh all-reduce** 模式——stage in、barrier、读取每个对端的 slice
+> 并求和——[教程阶梯](05-tutorials.md)中的
+> [mesh allreduce 教程](13-allreduce_mesh.md)逐步构建的正是它。在两个 rank
+> 时所有算法都坍缩为同一次交换；[ring allreduce 教程](15-allreduce_ring.md)
+> 是揭示内置原语之前的最后一个手工步骤。
+
 ```python
 import pypto.language as pl
 import pypto.language.distributed as pld
@@ -198,6 +204,7 @@ InCore kernel (@pl.jit.incore)
 
 ## 相关链接
 
+- [05-tutorials](05-tutorials.md) — 逐步的分布式教程阶梯
 - [01-collectives](01-collectives.md) — 内置集合通信及其语义
 - [02-primitives](02-primitives.md) — 集合通信的底层基础
 - [03-execution](03-execution.md) — DistributedWorker 生命周期和生产模式

--- a/docs/zh/user/distributed/01-collectives.md
+++ b/docs/zh/user/distributed/01-collectives.md
@@ -37,12 +37,17 @@ data = pld.tensor.allreduce(data, op=pld.ReduceOp.Sum, core_num=4)
 - 2(P-1) 步：reduce-scatter + allgather
 - 每步 O(N/P) 远程流量——每个 rank 读取一个邻居
 - Signal 形状：`[2 × (NR − 1), NR]`
-- 要求编译时已知 NR——使用工厂函数模式：外层 Python 函数接收 `nr`/`size`，
-  推导出 `total_rounds = 2 * (nr - 1)`，并在自己的函数体内定义
-  `@pl.jit` 函数，使 `[total_rounds, nr]` 成为编译期常量（specializer 会把
-  闭包常量折叠进生成的程序）。参见下方"可运行示例"一节中的
-  `collectives/test_l3_tensor_allreduce_ring_intrinsic.py`——该测试当前
-  使用等价的 `@pl.program` 类形式。
+- 要求编译时已知 NR——使用工厂函数模式，且必须搭配 **`@pl.program` 类形式**：
+  外层 Python 函数接收 `nr`/`size`，推导出 `total_rounds = 2 * (nr - 1)`，
+  并在自己的函数体内定义 `@pl.program` 类，使 `[total_rounds, nr]` 成为
+  编译期常量。`@pl.program` / `@pl.function` 会在装饰时捕获*定义处*帧的
+  局部变量，这正是那些闭包常量能够解析的原因。
+- `@pl.jit` 系列在这里**不可用**：它的常量折叠只读取函数的模块全局
+  （`__globals__`），从不读取 `__closure__`
+  （`python/pypto/jit/specializer.py`），因此在 HOST 编排体内引用的工厂
+  闭包常量会以 `Undefined variable` 失败。参见下方"可运行示例"一节中的
+  `collectives/test_l3_tensor_allreduce_ring_intrinsic.py`——该测试正是
+  出于这个原因使用 `@pl.program` 类形式。
 - 最适合大消息（>16 KiB）和高带宽
 
 | 方面 | Mesh | Ring |

--- a/docs/zh/user/distributed/01-collectives.md
+++ b/docs/zh/user/distributed/01-collectives.md
@@ -212,7 +212,7 @@ PyPTO 有三种方式运行集合通信——根据代码运行的位置以及�
 | 集合通信 | 教程步骤 | 先手工？ |
 | -------- | -------- | -------- |
 | barrier | [09-barrier](09-barrier.md) | 是（步骤 04，然后揭示） |
-| allreduce | 规划中——步骤 08–11 | 是（mesh、two-phase、ring，然后揭示） |
+| allreduce | [13-allreduce_mesh](13-allreduce_mesh.md) · [14-allreduce_two_phase](14-allreduce_two_phase.md) · [15-allreduce_ring](15-allreduce_ring.md) · [16-allreduce_reveal](16-allreduce_reveal.md) | 是（步骤 08–11） |
 | broadcast | 规划中——步骤 12 | 是 |
 | allgather | 规划中——步骤 13 | 是 |
 | reduce_scatter | 规划中——步骤 14 | 是 |

--- a/docs/zh/user/distributed/05-tutorials.md
+++ b/docs/zh/user/distributed/05-tutorials.md
@@ -1,12 +1,13 @@
 # 分布式教程（Distributed Tutorials）
 
-`pld` 词汇表按步骤讲解：一个十六步的教程系列，每步一个概念。七个可运行的
-示例现已交付——从 "hello rank" 到点对点移动与动态 rank 数量；步骤 08–16
-（集合通信）为规划中。
+`pld` 词汇表按步骤讲解：一个十六步的教程系列，每步一个概念。十一个可运行的
+示例现已交付——从 "hello rank" 到点对点移动、动态 rank 数量，以及 all-reduce
+三连与其揭示；步骤 12–15（其余集合通信）与步骤 16（组合）为规划中。
 
 > **前置条件：** 先通读[分布式编程](../distributed/index.md)章节——了解词汇，
 > 再回到这里亲手构建同样的概念。硬件：步骤 01–06 需要两个设备，步骤 07
-> 需要三个或更多（任意 rank 数量），步骤 08–16 的集合通信对比需要四个设备。
+> 需要任意 ≥ 2 的数量（三个或更多才能看到环与 P=2 的差异），步骤 08–11
+> 的集合通信对比需要四个设备。
 
 ## 思路（The idea）
 
@@ -37,8 +38,8 @@
 ## 建议阅读顺序（Suggested reading order）
 
 按顺序阅读这些步骤——**01 → 02 → 03 → 04 → 05 → 06 → 07 → 08 → 09 → 10 →
-11 → 12 → 13 → 14 → 15 → 16**。每个页面都会重复此顺序块。步骤 08–16 为规划中；
-01–07 在第一个 PR 中交付（见下文）。
+11 → 12 → 13 → 14 → 15 → 16**。每个页面都会重复此顺序块。步骤 01–11 现已交付；
+12–16 仍为规划中。
 
 ## 16 个步骤
 
@@ -51,18 +52,18 @@
 | 05 | `05_remote_load_store.py` | Tile 级 RMA：`remote_load`/`remote_store`；一步环形移位 | ✅ 已交付 |
 | 06 | `06_put_get.py` | Tensor 级 p2p：`put`/`get`；push 与 pull | ✅ 已交付 |
 | 07 | `07_dynamic_rank_count.py` | 动态 rank 数量：`pl.dynamic("NR")`；同一份源码，任意 P | ✅ 已交付 |
-| 08 | `08_allreduce_mesh.py` | All-reduce v1（mesh）：每个 rank 读取所有对端，本地求和 | 规划中 |
-| 09 | `09_allreduce_two_phase.py` | All-reduce v2：reduce-scatter + all-gather | 规划中 |
-| 10 | `10_allreduce_ring.py` | All-reduce v3（ring）：沿环分块 | 规划中 |
-| 11 | `11_allreduce_reveal.py` | **揭示**：`pld.tensor.allreduce`（mesh + ring）；对比 IR | 规划中 |
+| 08 | `08_allreduce_mesh.py` | All-reduce v1（mesh）：每个 rank 读取所有对端，本地求和 | ✅ 已交付 |
+| 09 | `09_allreduce_two_phase.py` | All-reduce v2：reduce-scatter + all-gather | ✅ 已交付 |
+| 10 | `10_allreduce_ring.py` | All-reduce v3（ring）：沿环分块 | ✅ 已交付 |
+| 11 | `11_allreduce_reveal.py` | **揭示**：`pld.tensor.allreduce`（mesh + ring）；对比 IR | ✅ 已交付 |
 | 12 | `12_broadcast.py` | 一对多；揭示 `pld.tensor.broadcast` | 规划中 |
 | 13 | `13_allgather.py` | 全对全切片；揭示 `pld.tensor.allgather` | 规划中 |
 | 14 | `14_reduce_scatter.py` | 全对分块；揭示 `pld.tensor.reduce_scatter` | 规划中 |
 | 15 | `15_all_to_all.py` | 个性化交换；揭示 `pld.tensor.all_to_all` | 规划中 |
 | 16 | `16_putting_it_together.py` | 在一个 kernel 中组合 `broadcast` + `allreduce` + `allgather` | 规划中 |
 
-步骤 08–16 为**规划中**——它们将在后续 PR 中交付。下面的教程页面（06–12）
-覆盖一起交付的步骤 01–07。
+步骤 12–16 为**规划中**——它们将在后续 PR 中交付。下面的教程页面（06–16）
+覆盖步骤 01–11。
 
 ## 抽象总览（The abstractions map）
 

--- a/docs/zh/user/distributed/13-allreduce_mesh.md
+++ b/docs/zh/user/distributed/13-allreduce_mesh.md
@@ -1,0 +1,105 @@
+# 全归约 1：Mesh——每个 rank 读取每个对端
+
+阶梯中的第一个集合通信（collective）。每个 rank 贡献自己的 slice；最终每个
+rank 都持有**所有 slice 的元素级求和**。mesh 算法是这一语义最简单的写法：
+一个 barrier，然后每个 rank `remote_load` 每个对端的 slice 并本地累加。
+
+> **前置条件：** [12-dynamic_rank_count](12-dynamic_rank_count.md)。建议使用
+> 4 个模拟设备——在 2 个 rank 时，步骤 08-10 的三种全归约变体会坍缩为同一次
+> 交换，它们的差异只有在 P=4 时才可观测。
+
+**建议阅读顺序（Suggested reading order）：** 01 → 02 → 03 → 04 → 05 → 06 → 07 → **08** — 本页为步骤 08。
+
+## 思路（The idea）
+
+全归约（all-reduce）是所有集合通信对比的起点：你有 `P` 个 rank，各持一个
+slice；调用结束后每个 rank 都持有*所有* slice 的归约结果。步骤 11 会揭示
+内置原语；这里你先手工构建它，而你建立的成本卡正是内置原语存在的原因以及
+它在什么之间做选择。
+
+mesh 是朴素基线：**每个 rank 读取每个对端**。每个 rank 有 O(P) 次远程流量
+——简单、round 密集，也是 two-phase 与 ring 步骤的度量基准。
+
+## 运行（Run it）
+
+```bash
+# P=4（对比步骤需要）与 P=2：
+python examples/distributed/08_allreduce_mesh.py -p a2a3sim -d 0,1,2,3
+python examples/distributed/08_allreduce_mesh.py -p a2a3sim -d 0,1
+```
+
+预期输出：
+
+```text
+OK
+```
+
+## 走读（Walkthrough）
+
+程序由**rank 数量工厂**构建：`build_mesh_allreduce(nr)` 把 `nr` 折叠进一个
+`@pl.program` 类，于是 barrier 信号 `[nr, 1]`（每 rank 一个单元）是编译期
+形状，而同一份源码通过 `-d` 服务任意 world 大小。这是窗口形状依赖 world 大小时
+的文档化模式——见 `01-collectives.md` Ring Mode；ST 测试也使用同样的
+class-form 工厂。
+
+kernel 是每个手工集合通信共有的四阶段：
+
+```python
+# Phase 1 — 把本 rank 的 slice 放入自己的窗口槽位。
+local = pl.load(x, [0, 0], [1, SIZE])
+data = pl.store(local, [0, 0], data)
+
+# Phase 2 — barrier：通知所有对端，等待所有对端槽位。
+for peer in pl.range(nr):
+    if peer != my_rank:
+        pld.system.notify(signal, peer=peer, offsets=[my_rank, 0],
+                          value=1, op=pld.NotifyOp.AtomicAdd)
+for src in pl.range(nr):
+    if src != my_rank:
+        pld.system.wait(signal, offsets=[src, 0], expected=1, cmp=pld.WaitCmp.Ge)
+
+# Phase 3 — 累加：从自己的 slice 开始，加上每个对端的 slice。
+acc = pl.load(data, [0, 0], [1, SIZE])
+for peer in pl.range(nr):
+    if peer != my_rank:
+        recv = pld.tile.remote_load(data, peer=peer, offsets=[0, 0], shape=[1, SIZE])
+        acc = pl.add(acc, recv)
+
+# Phase 4 — 写出：累加结果就是本 rank 的输出。
+y = pl.store(acc, [0, 0], y)
+```
+
+- **Phase 2 就是步骤 04 的 barrier。** 每个 rank 拥有专属行
+  （`offsets=[my_rank, 0]`）；`AtomicAdd`/`Ge(1)` 只在每个对端都完成 staging
+  后通过。没有它，Phase 3 可能在某个对端的 store 落地前就 `remote_load`
+  该对端的 slice。
+- **Phase 3 就是 mesh 本身。** 从自己的 slice 开始，再 `remote_load` 每个
+  其他 rank 的 slice 并相加。注意对称性：每个 rank 都这样做，因此每个 rank
+  得到相同的和。
+
+**成本卡（每 rank）：** `(P-1) * N` 字节——每个对端一个完整 slice，被每个
+rank 读取。round 密集：`P-1` 次远程读取加一个 barrier。正是这种 O(P) 流量
+催生了 two-phase 与 ring 变体。
+
+## 边界情况（Edge cases）
+
+> **致命陷阱——缺少 barrier 会让读取与 store 竞争。** 若去掉 Phase 2，某个
+> rank 可能在某个对端的 `pl.store` 落地前读取该对端的窗口槽位，把陈旧/零值
+> 混入求和。该竞争与时序相关，可能在 P=2 通过而在 P=4 失败。
+> **修复：** 任何 `remote_load` 之前必须完成 notify/wait 握手。
+
+| 现象 | 可能原因 | 修复 |
+| ---- | -------- | ---- |
+| 某些 rank 的和里含零 | barrier 缺失/错误；读取竞争了 store | Phase 3 前做 barrier（通知全部/等待全部） |
+| 只在 P=4 出错 | P=2 掩盖竞争（单一对端） | 用 P≥4 运行；检查 barrier 覆盖每个对端 |
+| 每个 rank 结果相同但与 torch 和不同 | 归约顺序不同（非 bug） | 用容差比较（示例已如此） |
+| 动态窗口形状的编译错误 | `[nr, 1]` 形状逃出了工厂 | 通过 `build_mesh_allreduce(nr)` 构建——`nr` 必须是闭包常量 |
+| golden 出现巨大差异 | slice 被求和在错误位置（如自己的 slice 被重复计算） | 只 staging 一次；从自己的 slice 开始再累加对端 |
+
+## 参见（See also）
+
+- [05-tutorials](05-tutorials.md) — 教程索引（本步骤 = 第 08 行）
+- [01-collectives](01-collectives.md) §AllReduce — mesh 模式参考
+- [09-barrier](09-barrier.md) — 这里复用的 notify/wait barrier（步骤 04）
+- [10-remote_load_store](10-remote_load_store.md) — `remote_load`（步骤 05）
+- 下一步：[14-allreduce_two_phase](14-allreduce_two_phase.md) — 同样的结果，流量约减半

--- a/docs/zh/user/distributed/13-allreduce_mesh.md
+++ b/docs/zh/user/distributed/13-allreduce_mesh.md
@@ -36,16 +36,23 @@ OK
 
 ## 走读（Walkthrough）
 
-程序由**rank 数量工厂**构建：`build_mesh_allreduce(nr)` 把 `nr` 折叠进一个
-`@pl.program` 类，于是 barrier 信号 `[nr, 1]`（每 rank 一个单元）是编译期
-形状，而同一份源码通过 `-d` 服务任意 world 大小。
+这里的 rank 数量始终**不是**编译期常量：它在注解中是
+`NR = pl.dynamic("NR")`，在 HOST 编排体内是 `pld.world_size()`。因此一个
+模块级 `@pl.program` 即可服务 `-d` 指定的任意 world 大小——不需要 rank
+数量工厂。这与本集合通信的系统测试
+`tests/st/distributed/collectives/test_l3_allreduce.py` 完全一致。
 
 步骤 01-07 使用 `@pl.jit` 系列；这里改用 class form 是**必需的，而非风格
-选择**。`@pl.program` / `@pl.function` 在装饰时捕获*定义处*帧的局部变量，
-因此工厂的 `nr` 在签名与 HOST 编排体内（`alloc_window_buffer([nr, 1], ...)`）
-都能解析；而 `@pl.jit.host` 会在该帧消失之后才重新特化为 `@pl.function`，
-其函数体中引用的闭包 `nr` 便无法解析。`tests/st/distributed/` 中每个按 rank
-参数化的集合通信都使用同样的 class-form 工厂。
+选择**——但原因是信号形状是*动态的*，而非编译期的。`signal` 是形状为
+`[pld.world_size(), 1]` 的窗口，而 `@pl.jit` 必须为它传给依赖函数的每个
+参数静态推断形状与 dtype，因此会报
+`missing inferred tensor metadata for parameter 'signal'`；`@pl.program`
+没有这一要求。（`@pl.jit` 本身并不排斥分布式张量——步骤 03、05、06、07
+都传递它们——它无法处理的是运行期决定的窗口维度。）
+
+步骤 09 与 10 改用 class form 的理由更强：它们的块大小 `SIZE // nr` 是
+**tile 形状**，而 tile 形状必须在 kernel 编译时已知，所以那里确实需要
+编译期 rank 数量与工厂。信号的行数不是 tile 形状，因此这里可以保持动态。
 
 kernel 是每个手工集合通信共有的四阶段：
 
@@ -98,7 +105,7 @@ rank 读取。round 密集：`P-1` 次远程读取加一个 barrier。正是这�
 | 某些 rank 的和里含零 | barrier 缺失/错误；读取竞争了 store | Phase 3 前做 barrier（通知全部/等待全部） |
 | 只在 P=4 出错 | P=2 掩盖竞争（单一对端） | 用 P≥4 运行；检查 barrier 覆盖每个对端 |
 | 每个 rank 结果相同但与 torch 和不同 | 归约顺序不同（非 bug） | 用容差比较（示例已如此） |
-| 动态窗口形状的编译错误 | `[nr, 1]` 形状逃出了工厂 | 通过 `build_mesh_allreduce(nr)` 构建——`nr` 必须是闭包常量 |
+| `missing inferred tensor metadata for parameter 'signal'` | kernel 写成了 `@pl.jit`，而它无法为维度是 `pld.world_size()` 的窗口定型 | 改用 `@pl.program` class form（如本例）；`@pl.jit` 要求每个依赖参数都是静态形状 |
 | golden 出现巨大差异 | slice 被求和在错误位置（如自己的 slice 被重复计算） | 只 staging 一次；从自己的 slice 开始再累加对端 |
 
 ## 参见（See also）

--- a/docs/zh/user/distributed/13-allreduce_mesh.md
+++ b/docs/zh/user/distributed/13-allreduce_mesh.md
@@ -38,9 +38,14 @@ OK
 
 程序由**rank 数量工厂**构建：`build_mesh_allreduce(nr)` 把 `nr` 折叠进一个
 `@pl.program` 类，于是 barrier 信号 `[nr, 1]`（每 rank 一个单元）是编译期
-形状，而同一份源码通过 `-d` 服务任意 world 大小。这是窗口形状依赖 world 大小时
-的文档化模式——见 `01-collectives.md` Ring Mode；ST 测试也使用同样的
-class-form 工厂。
+形状，而同一份源码通过 `-d` 服务任意 world 大小。
+
+步骤 01-07 使用 `@pl.jit` 系列；这里改用 class form 是**必需的，而非风格
+选择**。`@pl.program` / `@pl.function` 在装饰时捕获*定义处*帧的局部变量，
+因此工厂的 `nr` 在签名与 HOST 编排体内（`alloc_window_buffer([nr, 1], ...)`）
+都能解析；而 `@pl.jit.host` 会在该帧消失之后才重新特化为 `@pl.function`，
+其函数体中引用的闭包 `nr` 便无法解析。`tests/st/distributed/` 中每个按 rank
+参数化的集合通信都使用同样的 class-form 工厂。
 
 kernel 是每个手工集合通信共有的四阶段：
 
@@ -50,17 +55,17 @@ local = pl.load(x, [0, 0], [1, SIZE])
 data = pl.store(local, [0, 0], data)
 
 # Phase 2 — barrier：通知所有对端，等待所有对端槽位。
-for peer in pl.range(nr):
+for peer in pl.range(nranks):
     if peer != my_rank:
         pld.system.notify(signal, peer=peer, offsets=[my_rank, 0],
                           value=1, op=pld.NotifyOp.AtomicAdd)
-for src in pl.range(nr):
+for src in pl.range(nranks):
     if src != my_rank:
         pld.system.wait(signal, offsets=[src, 0], expected=1, cmp=pld.WaitCmp.Ge)
 
 # Phase 3 — 累加：从自己的 slice 开始，加上每个对端的 slice。
 acc = pl.load(data, [0, 0], [1, SIZE])
-for peer in pl.range(nr):
+for peer in pl.range(nranks):
     if peer != my_rank:
         recv = pld.tile.remote_load(data, peer=peer, offsets=[0, 0], shape=[1, SIZE])
         acc = pl.add(acc, recv)

--- a/docs/zh/user/distributed/14-allreduce_two_phase.md
+++ b/docs/zh/user/distributed/14-allreduce_two_phase.md
@@ -40,8 +40,8 @@ OK
 
 ## 走读（Walkthrough）
 
-与步骤 08 相同的 class-form 工厂，现在有**两个**窗口（`data` 存 staging 的
-输入，`result` 存归约后的块）和一个**两行信号**（`[2, nr]`——每轮 barrier
+与步骤 08 相同的 class-form 工厂，现在有**两个**窗口（`data` 存 staging
+的输入，`result` 存归约后的块）和一个**两行信号**（`[2, nr]`——每轮 barrier
 一行）：
 
 ```python

--- a/docs/zh/user/distributed/14-allreduce_two_phase.md
+++ b/docs/zh/user/distributed/14-allreduce_two_phase.md
@@ -40,9 +40,11 @@ OK
 
 ## 走读（Walkthrough）
 
-与步骤 08 相同的 class-form 工厂，现在有**两个**窗口（`data` 存 staging
-的输入，`result` 存归约后的块）和一个**两行信号**（`[2, nr]`——每轮 barrier
-一行）：
+与步骤 08 相同的 `@pl.program` class form，但这里多了一个 **rank 数量
+工厂**——步骤 08 并不需要它。工厂的作用是把 `nr` 变成编译期常量，而本步骤
+是第一个真正需要它的：块大小 `SIZE // nr` 是 **tile 形状**，而 tile 形状
+必须在 kernel 编译时已知。此外现在有**两个**窗口（`data` 存 staging 的输入，
+`result` 存归约后的块）和一个**两行信号**（`[2, nr]`——每轮 barrier 一行）：
 
 ```python
 # Phase 1 — 把本 rank 的 slice 放入自己的窗口槽位。

--- a/docs/zh/user/distributed/14-allreduce_two_phase.md
+++ b/docs/zh/user/distributed/14-allreduce_two_phase.md
@@ -1,0 +1,104 @@
+# 全归约 2：两阶段（Two-Phase）——先 Reduce-Scatter 再 All-Gather
+
+与步骤 08 相同的结果，远程流量约减半。不再让每个 rank 读取每个对端的*完整*
+slice，而是把 slice 切成 `P` 块：先做 **reduce-scatter**，让 rank `r` 持有
+归约后的块 `r`；再做 **all-gather**，让每个 rank 收集每一块。
+
+> **前置条件：** [13-allreduce_mesh](13-allreduce_mesh.md)。建议使用 4 个模拟
+> 设备（相对 mesh 的流量节省只在 P≥4 可观测）；`SIZE` 必须能被 rank 数量整除。
+
+**建议阅读顺序（Suggested reading order）：** 01 → 02 → 03 → 04 → 05 → 06 → 07 → 08 → **09** — 本页为步骤 09。
+
+## 思路（The idea）
+
+mesh 每 rank 传输 `(P-1) * N` 字节，因为每个 rank 读取每个对端的*整段*
+slice。但求和每 rank 只需要 `N` 个结果值——所以 mesh 移动的大部分是重复
+劳动。两阶段把同样的求和重构为两个阶段，每阶段只移动 `N/P` 大小的片段：
+
+1. **Reduce-scatter（RS）：** rank `r` 是块 `r` 的*拥有者*。每个 rank 读取
+   每个对端的块 `r`（一个 `N/P` 大小的片段，而非完整 slice）并本地求和。
+   之后，只有 rank `r` 持有归约后的块 `r`。
+2. **All-gather（AG）：** 每个 rank 读取每个对端归约后的块（每 rank 一块），
+   组装出完整结果。
+
+每阶段移动 `(P-1) * N/P` 字节，总流量为 `2 * (P-1) / P * N`——约为 mesh 的
+一半，代价是第二个 barrier。
+
+## 运行（Run it）
+
+```bash
+# P=4（相对 mesh 的节省在此显现）与 P=2：
+python examples/distributed/09_allreduce_two_phase.py -p a2a3sim -d 0,1,2,3
+python examples/distributed/09_allreduce_two_phase.py -p a2a3sim -d 0,1
+```
+
+预期输出：
+
+```text
+OK
+```
+
+## 走读（Walkthrough）
+
+与步骤 08 相同的 class-form 工厂，现在有**两个**窗口（`data` 存 staging 的
+输入，`result` 存归约后的块）和一个**两行信号**（`[2, nr]`——每轮 barrier
+一行）：
+
+```python
+# Phase 1 — 把本 rank 的 slice 放入自己的窗口槽位。
+local = pl.load(x, [0, 0], [1, SIZE])
+data = pl.store(local, [0, 0], data)
+
+# Barrier A（信号第 0 行）— 所有输入在 RS 读取前完成 staging。
+# （同步骤 08：通知全部/等待全部，但用第 0 行）
+
+# Phase 2 — reduce-scatter：rank r 拥有结果的块 r。
+acc = pl.load(data, [0, my_rank * chunk], [1, chunk])
+for peer in pl.range(nranks):
+    if peer != my_rank:
+        recv = pld.tile.remote_load(data, peer=peer, offsets=[0, my_rank * chunk],
+                                    shape=[1, chunk])
+        acc = pl.add(acc, recv)
+result = pl.store(acc, [0, my_rank * chunk], result)
+
+# Barrier B（信号第 1 行）— 所有归约块在 AG 读取前完成 staging。
+
+# Phase 3 — all-gather：rank r 读取每个 rank 的归约块。
+for c in pl.range(nranks):
+    recv = pld.tile.remote_load(result, peer=c, offsets=[0, c * chunk], shape=[1, chunk])
+    y = pl.store(recv, [0, c * chunk], y)
+```
+
+- **块所有权。** RS 循环在每个对端窗口的 `[0, my_rank * chunk]` 处读取——每个
+  rank 从每个对端读取*同一个*块（自己的块）。循环结束后，rank `r` 的
+  `result` 持有归约后的块 `r`。
+- **AG 每对端读一块**，从对端 `c` 的 `[0, c * chunk]` 处读取——即 RS 中已经
+  归约好的片段——并按序写入输出。
+- **两个 barrier，两行信号。** `[2, nr]` 信号给每个 barrier 自己的行，于是
+  单调计数器（`Ge(1)`）不会在轮次之间泄漏。
+
+**成本卡（每 rank）：** `2 * (P-1) / P * N` 字节——RS 中 `(P-1)` 次 `N/P`
+字节读取，AG 中 `(P-1)` 次 `N/P` 字节读取。约为 mesh 的 `(P-1) * N` 的一半，
+代价是多一轮 barrier。
+
+## 边界情况（Edge cases）
+
+> **致命陷阱——两个 barrier 复用同一行信号。** 计数器是单调的：barrier A
+> 之后该行 `Ge(1)` 已满足，barrier B 会立即返回，AG 读取可能与 RS 的 store
+> 竞争。**修复：** 给每轮自己的行（`[2, nr]` 信号）——ring 步骤会把这一
+> 纪律推广为每轮一行。
+
+| 现象 | 可能原因 | 修复 |
+| ---- | -------- | ---- |
+| AG 读到陈旧的块数据 | 两个 barrier 用了同一信号单元 | 每轮一行信号（`[2, nr]`） |
+| 只在 P≥4 出错 | 块大小不匹配（`SIZE % P != 0`） | 运行 `SIZE` 能整除的 P（2、4） |
+| 结果中块 `r` 位置错误 | AG 组装乱序 | 从对端 `c` 读块 `c`，写到 `[0, c * chunk]` |
+| 所有 rank 持有 RS 结果但非总和 | 缺 AG（只跑了 reduce-scatter） | 补 AG 循环：每 rank 读取每个归约块 |
+| 每个 rank 结果相同但与 torch 和不同 | 归约顺序不同（非 bug） | 用容差比较 |
+
+## 参见（See also）
+
+- [05-tutorials](05-tutorials.md) — 教程索引（本步骤 = 第 09 行）
+- [13-allreduce_mesh](13-allreduce_mesh.md) — 本步骤改进的基线（步骤 08）
+- [01-collectives](01-collectives.md) §AllReduce — 参考（Mesh Mode、Ring Mode）
+- 下一步：[15-allreduce_ring](15-allreduce_ring.md) — 同样字节数，每步大小恒定

--- a/docs/zh/user/distributed/15-allreduce_ring.md
+++ b/docs/zh/user/distributed/15-allreduce_ring.md
@@ -58,11 +58,11 @@ for s in pl.range(nranks - 1):
     # 等待左邻居第 s 轮的块（信号第 s 行），然后：
     pld.system.wait(signal, offsets=[s, left], expected=1, cmp=pld.WaitCmp.Ge)
     recv = pld.tile.remote_load(scratch, peer=left,
-                                offsets=[0, left_send_idx * chunk_elems],
+                                offsets=[0, left_send_idx * chunk],
                                 shape=[1, chunk])
-    acc = pl.load(scratch, [0, recv_add_idx * chunk_elems], [1, chunk])
+    acc = pl.load(scratch, [0, recv_add_idx * chunk], [1, chunk])
     acc = pl.add(acc, recv)
-    scratch = pl.store(acc, [0, recv_add_idx * chunk_elems], scratch)
+    scratch = pl.store(acc, [0, recv_add_idx * chunk], scratch)
     # 该 store 为下一轮准备好发送：通知右邻居（第 s+1 行）。
     pld.system.notify(signal, peer=right, offsets=[s + 1, my_rank],
                       value=1, op=pld.NotifyOp.AtomicAdd)

--- a/docs/zh/user/distributed/15-allreduce_ring.md
+++ b/docs/zh/user/distributed/15-allreduce_ring.md
@@ -1,0 +1,110 @@
+# 全归约 3：Ring——每步大小恒定
+
+步骤 09 的两阶段形态，但每个 rank 只与**左邻居**移动数据。不再每阶段读取
+`P-1` 个对端，而是让块绕环旋转：`2 * (P-1)` 步，每步移动一个 `N/P` 大小的
+块——在弱扩展下，无论 `P` 多大，每步传输都保持 `N/P`（固定 `N` 时块会缩小）。
+同步也是邻居局部的：每个
+rank 在 store 之后通知**右**邻居，在读取之前等待**左**邻居——每轮不再有
+全 mesh barrier。
+
+> **前置条件：** [14-allreduce_two_phase](14-allreduce_two_phase.md)。
+> 建议使用 4 个模拟设备（恒定的每步大小只在 P≥4 可观测）；`SIZE` 必须能被
+> rank 数量整除。
+
+**建议阅读顺序（Suggested reading order）：** 01 → … → 09 → **10** — 本页为步骤 10。
+
+## 思路（The idea）
+
+两阶段把 mesh 的流量减半，但仍每阶段读取每个对端——O(P) 个对端，每个
+`N/P` 块。ring 去掉"每个对端"这层：把 rank 排成一个环，把块传给**左邻居**。
+同样的 reduce-scatter + all-gather 拆分现在各需 `P-1` 步：
+
+- **Reduce-scatter（P-1 步）：** 每步一个块前进一跳并在目的地累加。`P-1`
+  步后每个 rank 持有它拥有的归约块。
+- **All-gather（P-1 步）：** 归约块继续绕环，每个 rank 在块经过时复制一份。
+  再 `P-1` 步后每个 rank 持有完整结果。
+
+总字节数与两阶段相同（`2 * (P-1) / P * N`），但每步只移动 `N/P`——在弱扩展
+（workload 随 P 增长）下，随着 `P` 增长每步大小保持恒定，这正是 ring 在大
+world 规模下依然高效的原因；固定 `N` 时分块反而会缩小。
+
+## 运行（Run it）
+
+```bash
+# P=4（恒定的每步大小在此显现）与 P=2：
+python examples/distributed/10_allreduce_ring.py -p a2a3sim -d 0,1,2,3
+python examples/distributed/10_allreduce_ring.py -p a2a3sim -d 0,1
+```
+
+预期输出：
+
+```text
+OK
+```
+
+## 走读（Walkthrough）
+
+kernel 是单体的（一个 InCore 函数），信号把两阶段的思路推广为
+`[2 * (nr-1), nr]`——**每轮一行**。块索引运算才是调度的核心：
+
+```python
+left = (my_rank - 1 + nranks) % nranks      # 永不取负
+
+# Reduce-scatter：(nr-1) 步。
+for s in pl.range(nranks - 1):
+    step = s + 1
+    recv_add_idx = (my_rank - step - 1 + nranks) % nranks
+    left_send_idx = (left - step + nranks) % nranks
+    # 等待左邻居第 s 轮的块（信号第 s 行），然后：
+    pld.system.wait(signal, offsets=[s, left], expected=1, cmp=pld.WaitCmp.Ge)
+    recv = pld.tile.remote_load(scratch, peer=left,
+                                offsets=[0, left_send_idx * chunk_elems],
+                                shape=[1, chunk])
+    acc = pl.load(scratch, [0, recv_add_idx * chunk_elems], [1, chunk])
+    acc = pl.add(acc, recv)
+    scratch = pl.store(acc, [0, recv_add_idx * chunk_elems], scratch)
+    # 该 store 为下一轮准备好发送：通知右邻居（第 s+1 行）。
+    pld.system.notify(signal, peer=right, offsets=[s + 1, my_rank],
+                      value=1, op=pld.NotifyOp.AtomicAdd)
+
+# All-gather：(nr-1) 步（行 nranks-1 .. 2*(nranks-1)-1），把左邻居的发送块
+# 复制进本地块。
+```
+
+- **`left = (my_rank - 1 + nranks) % nranks`。** `+ nranks` 保证被除数非负——
+  裸写 `(my_rank - 1) % nranks` 在 rank 0 处截断取模得 `-1`（步骤 06 的教训，
+  这次在索引一侧）。
+- **旋转的是块，不是 rank。** 第 `s` 轮里，你从左侧累加的块和你转发的块都
+  偏移一位（`- step`），于是每个块在每阶段恰好访问每个 rank 一次。
+- **邻居就绪握手，而非 barrier。** 每轮有自己的信号行——store 之后通知**右**
+  邻居，`remote_load` 之前等待**左**邻居。单调的 `Ge(1)` 计数器在轮次之间
+  永不泄漏（步骤 09 的纪律，现在有 `2*(P-1)` 行），且只有相邻的两个 rank
+  参与同步——**每 rank** O(P) 次信号（全系统 O(P²)）——而不是每轮全 mesh
+  barrier 的每 rank O(P²)。
+
+**成本卡（每 rank）：** 总计 `2 * (P-1) / P * N`——与两阶段相同——但分在
+`2*(P-1)` 步、每步 `N/P` 字节。在弱扩展（workload 随 P 增长）下，每步大小
+**随 P 增长保持恒定**——不像 mesh 每步 `(P-1) * N`——这正是 ring 存在的
+原因。
+
+## 边界情况（Edge cases）
+
+> **致命陷阱——左邻居索引取负。** `(my_rank - 1) % nranks` 在 rank 0 处截断
+> 取模得 `-1`：`remote_load` 会指向一个无效对端。**修复：** 始终写
+> `(my_rank - 1 + nranks) % nranks`（在 P=2 时 rank 0 的左邻居是 rank 1；
+> `+ nranks` 保证被除数非负）。
+
+| 现象 | 可能原因 | 修复 |
+| ---- | -------- | ---- |
+| P=2 挂起 | 左邻居索引的被除数为负 | `(my_rank - 1 + nranks) % nranks` |
+| 结果中的块错位 | 某轮的块索引运算差一位 | 在纸上为 `s=0` 追踪 `recv_add_idx` / `left_send_idx` |
+| 两个握手共用一行信号 | RS 与 AG 复用了行索引 | RS 行 `0..P-2`，AG 行 `P-1..2(P-1)-1` |
+| 只在 P=2 正确 | P=2 只有一轮，掩盖旋转 bug | 跑 P=4 并检查每个块位置 |
+| 每个 rank 结果相同但与 torch 和不同 | 归约顺序不同（非 bug） | 用容差比较 |
+
+## 参见（See also）
+
+- [05-tutorials](05-tutorials.md) — 教程索引（本步骤 = 第 10 行）
+- [14-allreduce_two_phase](14-allreduce_two_phase.md) — 两阶段形态（步骤 09）
+- [01-collectives](01-collectives.md) §AllReduce — 参考（Ring Mode、信号形状、`Sum`/`FP32`）
+- 下一步：[16-allreduce_reveal](16-allreduce_reveal.md) — 替你选择 mesh 或 ring 的内置原语

--- a/docs/zh/user/distributed/16-allreduce_reveal.md
+++ b/docs/zh/user/distributed/16-allreduce_reveal.md
@@ -1,0 +1,101 @@
+# 揭示（The Reveal）：`pld.tensor.allreduce` 一次调用
+
+你已手工把全归约做了三种——mesh、two-phase、ring。现在看内置原语：
+`pld.tensor.allreduce(data, signal, op=..., mode=...)` 用一次调用取代整个
+调度，而 IR diff 会展示它 lower 成什么：你写过的手工模式，或更好的一个。
+
+> **前置条件：** [13-allreduce_mesh](13-allreduce_mesh.md) ·
+> [14-allreduce_two_phase](14-allreduce_two_phase.md) ·
+> [15-allreduce_ring](15-allreduce_ring.md)。建议使用 4 个模拟设备。
+
+**建议阅读顺序（Suggested reading order）：** 01 → … → 10 → **11** — 本页为步骤 11。
+
+## 思路（The idea）
+
+揭示纪律到此完成：步骤 04 在你手工构建后揭示了 barrier；本步骤在你构建了
+三种全归约后揭示集合通信。手工步骤的意义不在于你应该手工写全归约——而在于
+你应该知道*内置原语在什么之间做选择*。
+
+`pld.tensor.allreduce` 是整个阶梯的内置原语：它接收你的窗口和信号，完成
+barrier + 跨 rank 归约 + 写回，并把归约后的 slice 交还给你。`mode=` 选择
+算法——`"mesh"`（默认）或 `"ring"`。golden 与步骤 08-10 相同；调度一概不见。
+
+## 运行（Run it）
+
+```bash
+# 两种模式，P=4（以及 P=2）：
+python examples/distributed/11_allreduce_reveal.py -p a2a3sim -d 0,1,2,3
+python examples/distributed/11_allreduce_reveal.py -p a2a3sim -d 0,1,2,3 --mode ring
+python examples/distributed/11_allreduce_reveal.py -p a2a3sim -d 0,1
+```
+
+预期输出：
+
+```text
+OK
+```
+
+## 走读（Walkthrough）
+
+你的 stage-in 与 stage-out 保留；只有中间被替换：
+
+```python
+# Phase 1 — 把本 rank 的 slice 放入自己的窗口槽位。
+local = pl.load(x, [0, 0], [1, SIZE])
+data = pl.store(local, [0, 0], data)
+
+# Phase 2 — 内置原语：barrier + 归约 + 写回，一次调用。
+data = pld.tensor.allreduce(data, signal, op=pld.ReduceOp.Sum, mode=mode)
+
+# Phase 3 — 写出：把归约后的 slice 写回本地输出。
+recv = pl.load(data, [0, 0], [1, SIZE])
+y = pl.store(recv, [0, 0], y)
+```
+
+- **信号是你的，其形状告诉你处于哪种模式。** mesh 用 `[nr, 1]`；ring 用
+  `[2*(nr-1), nr]`——正是步骤 10 教过的每轮一行信号。工厂把 `nr` 与 `mode`
+  都折叠进来，于是一份源码可构建任一变体（步骤 08-10 的 class-form 模式）。
+- **内置原语接受什么（请读两遍）：** `pld.tensor.allreduce` 在**两种模式**下
+  都接受完整 `ReduceOp` 家族（`Sum`/`Max`/`Min`/`Prod`）与 `FP16`/`FP32`——
+  mesh 与 ring 的 ST 套件都把每个算符与 `FP16` 跑过真实流水线。
+
+### IR diff（教学工件）
+
+用 pass dump 编译，并把本步骤的 lower 后 IR 与你的手工程序做 diff：
+
+- `--mode mesh` 展开为**步骤 08 的模式**：在 `[nr, 1]` 信号上的 ready
+  barrier，然后 `remote_load` + 累加块——你写过的 mesh，可能被分块成
+  UB 大小的 tile。
+- `--mode ring` 展开为**步骤 10 的形态**：`[2*(nr-1), nr]` 信号上的
+  `2*(nr-1)` 轮、`N/P` 分块传输——但内置原语把每一轮 lower 成**全 mesh
+  barrier**（`EmitNotifyAll`/`EmitWaitAll`），而不是你在步骤 10 手工写的
+  邻居就绪握手。这正是 diff 的教学点：同样的调度与分块，不同的同步方式。
+
+同样的 golden、同样的信号约定、同样的四阶段形态——diff 就是"你的调度，由
+编译器表达"，这正是整个教学点。
+
+**成本卡（每 rank）：** 取决于所选模式——`(P-1) * N`（mesh）或
+`2 * (P-1) / P * N`、`N/P` 每步（ring）。内置原语选择算法；你仍选择模式。
+
+## 边界情况（Edge cases）
+
+> **致命陷阱——信号形状与模式不匹配。** `mode="ring"` 会严格校验
+> `[2*(nr-1), nr]` 信号。mesh 只校验静态列数是否为 1——因此静态的 ring 形
+> 信号会被拒绝——但它不校验行数，只读取它索引到的槽位。**修复：** mesh →
+> `[nr, 1]`；ring → `[2*(nr-1), nr]`；不要让两种模式共享同一个信号 window。
+
+| 现象 | 可能原因 | 修复 |
+| ---- | -------- | ---- |
+| 关于信号形状的编译错误 | ring 模式的信号不是 `[2*(nr-1), nr]`，或 mesh 信号静态列数非 1 | mesh `[nr, 1]`，ring `[2*(nr-1), nr]`——每模式一个 window |
+| 内置 ring 比你的手工 ring 同步开销更大 | 内置每轮发全 mesh barrier（每 rank O(P²)）；你的握手是邻居局部的（每 rank O(P)） | 每轮同步开销重要时手工写 ring（步骤 10） |
+| 每个 rank 结果相同但与 torch 和不同 | 归约顺序不同（非 bug） | 用容差比较 |
+| 结果是你自己的 slice，未归约 | 调用结果未重新绑定（`data =`） | `data = pld.tensor.allreduce(data, signal, ...)`——就地重绑定 |
+| 内置原语比你的手工 mesh 慢 | 载荷过小：mesh 适合小消息 | 载荷 ≳ 16 KiB 用 ring（见 `01-collectives.md`） |
+
+## 参见（See also）
+
+- [05-tutorials](05-tutorials.md) — 教程索引（本步骤 = 第 11 行）
+- [01-collectives](01-collectives.md) §AllReduce — 两种模式与信号形状的参考
+- [13-allreduce_mesh](13-allreduce_mesh.md) / [15-allreduce_ring](15-allreduce_ring.md) — 每种模式 lower 成的样子
+- [02-primitives](02-primitives.md) — 内置原语所基于的底层
+- 下一步：[05-tutorials](05-tutorials.md) 中步骤 12-16 覆盖其余集合通信

--- a/docs/zh/user/distributed/16-allreduce_reveal.md
+++ b/docs/zh/user/distributed/16-allreduce_reveal.md
@@ -55,9 +55,13 @@ y = pl.store(recv, [0, 0], y)
 - **信号是你的，其形状告诉你处于哪种模式。** mesh 用 `[nr, 1]`；ring 用
   `[2*(nr-1), nr]`——正是步骤 10 教过的每轮一行信号。工厂把 `nr` 与 `mode`
   都折叠进来，于是一份源码可构建任一变体（步骤 08-10 的 class-form 模式）。
-- **内置原语接受什么（请读两遍）：** `pld.tensor.allreduce` 在**两种模式**下
-  都接受完整 `ReduceOp` 家族（`Sum`/`Max`/`Min`/`Prod`）与 `FP16`/`FP32`——
-  mesh 与 ring 的 ST 套件都把每个算符与 `FP16` 跑过真实流水线。
+- **内置原语接受什么（请读两遍）：** `pld.tensor.allreduce`——这里用到的
+  **InCore composite** lowering——在**两种模式**下都接受完整 `ReduceOp`
+  家族（`Sum`/`Max`/`Min`/`Prod`）与 `FP16`/`FP32`——mesh 与 ring 的 ST 套件
+  都把每个算符与 `FP16` 跑过真实流水线。另有一条更窄的
+  `Sum`+`FP32`-only 契约，但仅存在于本教程未使用的独立 **HOST builtin**
+  ring 路径（`builtin.tensor.allreduce_ring`）——参见
+  `01-collectives.md` §AllReduce。
 
 ### IR diff（教学工件）
 

--- a/docs/zh/user/distributed/16-allreduce_reveal.md
+++ b/docs/zh/user/distributed/16-allreduce_reveal.md
@@ -55,6 +55,12 @@ y = pl.store(recv, [0, 0], y)
 - **信号是你的，其形状告诉你处于哪种模式。** mesh 用 `[nr, 1]`；ring 用
   `[2*(nr-1), nr]`——正是步骤 10 教过的每轮一行信号。工厂把 `nr` 与 `mode`
   都折叠进来，于是一份源码可构建任一变体（步骤 08-10 的 class-form 模式）。
+- **这里用工厂的理由与步骤 09/10 不同。** 那两步需要编译期 `nr`，是因为其分块
+  大小 `SIZE // nr` 是 **tile 形状**。而这里分块由内置原语自己负责，没有任何
+  形状是按 rank 数量确定的 tile 形状，`nr` 完全可以保持动态。真正必须在 kernel
+  被 trace 时确定的是 `mode`：它同时决定展开出哪条 lowering 以及 kernel 上标注
+  的信号布局，而 mesh 与 ring 是两种不同的形状，并非同一形状的两种尺寸。把
+  `nr` 一并折叠进来，只是为了让一份源码能写出这两种布局。
 - **内置原语接受什么（请读两遍）：** `pld.tensor.allreduce`——这里用到的
   **InCore composite** lowering——在**两种模式**下都接受完整 `ReduceOp`
   家族（`Sum`/`Max`/`Min`/`Prod`）与 `FP16`/`FP32`——mesh 与 ring 的 ST 套件

--- a/examples/distributed/08_allreduce_mesh.py
+++ b/examples/distributed/08_allreduce_mesh.py
@@ -20,18 +20,21 @@ Concepts introduced:
     -> accumulate -> stage-out
   - the barrier before any remote read: the ``notify``/``wait`` handshake from
     step 04 guarantees no rank reads a peer that has not staged yet
-  - the ``@pl.program`` class form + factory: the barrier signal is a per-rank
-    row matrix ``[nr, 1]`` and window shapes must be statically known, so a
-    rank-count factory builds a ``@pl.program`` class with ``nr`` folded in as
-    a compile-time constant — the way to keep "one source, any P" when a
-    window shape depends on the world size. Steps 01-07 use the ``@pl.jit``
-    family; the switch here is required, not stylistic: ``@pl.program`` /
-    ``@pl.function`` capture the *defining* frame's locals at decoration time
-    (so the factory's ``nr`` resolves inside the HOST orchestrator body),
-    while ``@pl.jit.host`` re-specializes into ``@pl.function`` later, after
-    that frame is gone — a closure ``nr`` referenced in its body then fails to
-    resolve. Every rank-parametrized collective in ``tests/st/distributed/``
-    uses this same class-form factory for the same reason.
+  - a rank count that stays *dynamic*: the barrier signal is a per-rank row
+    matrix, but its row count never becomes a compile-time constant. It is
+    ``NR = pl.dynamic("NR")`` in the annotations and ``pld.world_size()`` in
+    the host body, so one source serves any P — picked at run time with ``-d``,
+    with no rank-count factory. This mirrors
+    ``tests/st/distributed/collectives/test_l3_allreduce.py`` exactly.
+  - why this step leaves the ``@pl.jit`` family of steps 01-07: ``signal`` is a
+    window whose shape is the runtime expression ``[pld.world_size(), 1]``, and
+    ``@pl.jit`` must infer a static shape/dtype for every parameter it passes
+    to a dep — it rejects this one with "missing inferred tensor metadata for
+    parameter 'signal'". The ``@pl.program`` class form has no such
+    requirement, so the switch is forced by the *dynamic* signal shape, not by
+    a compile-time one. Steps 09 and 10 go further and do need a genuine
+    compile-time rank count, because their chunk size ``SIZE // nr`` is a
+    **tile shape**; a signal row count is not.
 
 This is the simplest of the three all-reduces (steps 08-10): one barrier, then
 every rank reads every peer. Its O(P) traffic is why the two-phase and ring
@@ -50,100 +53,85 @@ from pypto import ir
 from pypto.ir.distributed_compiled_program import DistributedConfig
 
 SIZE = 64
+NR = pl.dynamic("NR")
 
 
-def build_mesh_allreduce(nr: int):
-    """Build the mesh-allreduce program for a compile-time rank count ``nr``.
+@pl.program
+class MeshAllreduce:
+    @pl.function(type=pl.FunctionType.InCore)
+    def reduce_step(
+        self,
+        x: pl.Tensor[[1, SIZE], pl.FP32],
+        y: pl.Out[pl.Tensor[[1, SIZE], pl.FP32]],
+        data: pl.InOut[pld.DistributedTensor[[1, SIZE], pl.FP32]],
+        signal: pl.InOut[pld.DistributedTensor[[NR, 1], pl.INT32]],
+    ) -> pl.Tensor[[1, SIZE], pl.FP32]:
+        """Chip kernel: four-phase mesh allreduce — stage, barrier, accumulate, stage-out."""
+        ctx = pld.get_comm_ctx(data)
+        my_rank = pld.rank(ctx)
+        nranks = pld.nranks(ctx)
 
-    A factory rather than a module-level program because the barrier signal is
-    a per-rank row matrix ``[nr, 1]`` and window shapes must be statically
-    known: ``nr`` as a closure constant becomes a compile-time shape, so the
-    same source serves any world size (pick it with ``-d``).
+        # Phase 1 — stage this rank's slice into its window slot.
+        local = pl.load(x, [0, 0], [1, SIZE])
+        data = pl.store(local, [0, 0], data)
 
-    The class form is what makes that closure constant reachable: the
-    ``@pl.program`` decorator snapshots this factory frame's locals when it
-    runs, so ``nr`` resolves both in the signatures below and inside the HOST
-    orchestrator body (``alloc_window_buffer([nr, 1], ...)``).
-    """
+        # Phase 2 — barrier: notify every peer, wait on every peer slot.
+        # Each rank owns a dedicated row (offsets=[my_rank, 0]);
+        # AtomicAdd/Ge(1) means the wait only passes once every peer has
+        # staged its slice.
+        for peer in pl.range(nranks):
+            if peer != my_rank:
+                pld.system.notify(
+                    signal,
+                    peer=peer,
+                    offsets=[my_rank, 0],
+                    value=1,
+                    op=pld.NotifyOp.AtomicAdd,
+                )
+        for src in pl.range(nranks):
+            if src != my_rank:
+                pld.system.wait(
+                    signal,
+                    offsets=[src, 0],
+                    expected=1,
+                    cmp=pld.WaitCmp.Ge,
+                )
 
-    @pl.program
-    class MeshAllreduce:
-        @pl.function(type=pl.FunctionType.InCore)
-        def reduce_step(
-            self,
-            x: pl.Tensor[[1, SIZE], pl.FP32],
-            y: pl.Out[pl.Tensor[[1, SIZE], pl.FP32]],
-            data: pl.InOut[pld.DistributedTensor[[1, SIZE], pl.FP32]],
-            signal: pl.InOut[pld.DistributedTensor[[nr, 1], pl.INT32]],
-        ) -> pl.Tensor[[1, SIZE], pl.FP32]:
-            """Chip kernel: four-phase mesh allreduce — stage, barrier, accumulate, stage-out."""
-            ctx = pld.get_comm_ctx(data)
-            my_rank = pld.rank(ctx)
-            nranks = pld.nranks(ctx)
+        # Phase 3 — accumulate: start from our own slice, add every peer's slice.
+        acc = pl.load(data, [0, 0], [1, SIZE])
+        for peer in pl.range(nranks):
+            if peer != my_rank:
+                recv = pld.tile.remote_load(data, peer=peer, offsets=[0, 0], shape=[1, SIZE])
+                acc = pl.add(acc, recv)
 
-            # Phase 1 — stage this rank's slice into its window slot.
-            local = pl.load(x, [0, 0], [1, SIZE])
-            data = pl.store(local, [0, 0], data)
+        # Phase 4 — stage-out: the accumulated result is this rank's output.
+        return pl.store(acc, [0, 0], y)
 
-            # Phase 2 — barrier: notify every peer, wait on every peer slot.
-            # Each rank owns a dedicated row (offsets=[my_rank, 0]);
-            # AtomicAdd/Ge(1) means the wait only passes once every peer has
-            # staged its slice.
-            for peer in pl.range(nranks):
-                if peer != my_rank:
-                    pld.system.notify(
-                        signal,
-                        peer=peer,
-                        offsets=[my_rank, 0],
-                        value=1,
-                        op=pld.NotifyOp.AtomicAdd,
-                    )
-            for src in pl.range(nranks):
-                if src != my_rank:
-                    pld.system.wait(
-                        signal,
-                        offsets=[src, 0],
-                        expected=1,
-                        cmp=pld.WaitCmp.Ge,
-                    )
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def per_rank(
+        self,
+        x: pl.Tensor[[1, SIZE], pl.FP32],
+        y: pl.Out[pl.Tensor[[1, SIZE], pl.FP32]],
+        data: pl.InOut[pld.DistributedTensor[[1, SIZE], pl.FP32]],
+        signal: pl.InOut[pld.DistributedTensor[[NR, 1], pl.INT32]],
+    ) -> pl.Tensor[[1, SIZE], pl.FP32]:
+        """Per-device orchestration: one incore call, on this device."""
+        return self.reduce_step(x, y, data, signal)
 
-            # Phase 3 — accumulate: start from our own slice, add every peer's slice.
-            acc = pl.load(data, [0, 0], [1, SIZE])
-            for peer in pl.range(nranks):
-                if peer != my_rank:
-                    recv = pld.tile.remote_load(data, peer=peer, offsets=[0, 0], shape=[1, SIZE])
-                    acc = pl.add(acc, recv)
-
-            # Phase 4 — stage-out: the accumulated result is this rank's output.
-            return pl.store(acc, [0, 0], y)
-
-        @pl.function(type=pl.FunctionType.Orchestration)
-        def per_rank(
-            self,
-            x: pl.Tensor[[1, SIZE], pl.FP32],
-            y: pl.Out[pl.Tensor[[1, SIZE], pl.FP32]],
-            data: pl.InOut[pld.DistributedTensor[[1, SIZE], pl.FP32]],
-            signal: pl.InOut[pld.DistributedTensor[[nr, 1], pl.INT32]],
-        ) -> pl.Tensor[[1, SIZE], pl.FP32]:
-            """Per-device orchestration: one incore call, on this device."""
-            return self.reduce_step(x, y, data, signal)
-
-        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
-        def mesh_allreduce(
-            self,
-            x: pl.Tensor[[nr, 1, SIZE], pl.FP32],
-            y: pl.Out[pl.Tensor[[nr, 1, SIZE], pl.FP32]],
-        ) -> pl.Tensor[[nr, 1, SIZE], pl.FP32]:
-            """Host orchestrator: one shared data window + one shared signal window, one dispatch per rank."""
-            data_buf = pld.alloc_window_buffer([1, SIZE], dtype=pl.FP32)
-            signal_buf = pld.alloc_window_buffer([nr, 1], dtype=pl.INT32)
-            for r in pl.range(pld.world_size()):
-                data = pld.window(data_buf, [1, SIZE], dtype=pl.FP32)
-                signal = pld.window(signal_buf, [nr, 1], dtype=pl.INT32)
-                self.per_rank(x[r], y[r], data, signal, device=r)
-            return y
-
-    return MeshAllreduce
+    @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+    def mesh_allreduce(
+        self,
+        x: pl.Tensor[[NR, 1, SIZE], pl.FP32],
+        y: pl.Out[pl.Tensor[[NR, 1, SIZE], pl.FP32]],
+    ) -> pl.Tensor[[NR, 1, SIZE], pl.FP32]:
+        """Host orchestrator: one shared data window + one shared signal window, one dispatch per rank."""
+        data_buf = pld.alloc_window_buffer([1, SIZE], dtype=pl.FP32)
+        signal_buf = pld.alloc_window_buffer(pld.world_size() * pl.INT32.get_byte())
+        for r in pl.range(pld.world_size()):
+            data = pld.window(data_buf, [1, SIZE], dtype=pl.FP32)
+            signal = pld.window(signal_buf, [pld.world_size(), 1], dtype=pl.INT32)
+            self.per_rank(x[r], y[r], data, signal, device=r)
+        return y
 
 
 def expected_allreduce(inputs: torch.Tensor) -> torch.Tensor:
@@ -176,13 +164,12 @@ def main() -> int:
         raise SystemExit(f"need at least 2 devices, got {device_ids}")
 
     nr = len(device_ids)
-    program = build_mesh_allreduce(nr)
 
     x = torch.randn((nr, 1, SIZE), dtype=torch.float32)
     y = torch.zeros((nr, 1, SIZE), dtype=torch.float32)
 
     compiled = ir.compile(
-        program,
+        MeshAllreduce,
         platform=args.platform,
         distributed_config=DistributedConfig(
             device_ids=device_ids,

--- a/examples/distributed/08_allreduce_mesh.py
+++ b/examples/distributed/08_allreduce_mesh.py
@@ -1,0 +1,195 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+# -----------------------------------------------------------------------------------------------------------
+
+"""All-reduce v1 (mesh): every rank reads every peer's slice and sums locally.
+
+Concepts introduced:
+  - all-reduce semantics: every rank contributes its slice; every rank ends
+    with the element-wise reduction of ALL slices (here: Sum)
+  - mesh topology: each rank ``remote_load``s every peer's slice and
+    accumulates locally — O(P) reads, ``(P-1) * N`` bytes per rank, simple
+    and round-heavy
+  - the four phases every hand-rolled collective shares: stage-in -> barrier
+    -> accumulate -> stage-out
+  - the barrier before any remote read: the ``notify``/``wait`` handshake from
+    step 04 guarantees no rank reads a peer that has not staged yet
+  - the ``@pl.program`` class form + factory: the barrier signal is a per-rank
+    row matrix ``[nr, 1]`` and window shapes must be statically known, so a
+    rank-count factory builds a ``@pl.program`` class with ``nr`` folded in as
+    a compile-time constant — the documented way to keep "one source, any P"
+    when a window shape depends on the world size (see 01-collectives.md Ring
+    Mode; the ST tests use this same class-form factory)
+
+This is the simplest of the three all-reduces (steps 08-10): one barrier, then
+every rank reads every peer. Its O(P) traffic is why the two-phase and ring
+variants exist. The golden is the element-wise sum over all rank slices, per
+rank, compared with a tolerance — reduction order differs from torch.
+
+Run + walkthrough: see docs/en/user/distributed/13-allreduce_mesh.md
+"""
+
+import argparse
+
+import pypto.language as pl
+import pypto.language.distributed as pld
+import torch
+from pypto import ir
+from pypto.ir.distributed_compiled_program import DistributedConfig
+
+SIZE = 64
+
+
+def build_mesh_allreduce(nr: int):
+    """Build the mesh-allreduce program for a compile-time rank count ``nr``.
+
+    A factory rather than a module-level program because the barrier signal is
+    a per-rank row matrix ``[nr, 1]`` and window shapes must be statically
+    known: ``nr`` as a closure constant becomes a compile-time shape, so the
+    same source serves any world size (pick it with ``-d``).
+    """
+
+    @pl.program
+    class MeshAllreduce:
+        @pl.function(type=pl.FunctionType.InCore)
+        def reduce_step(
+            self,
+            x: pl.Tensor[[1, SIZE], pl.FP32],
+            y: pl.Out[pl.Tensor[[1, SIZE], pl.FP32]],
+            data: pl.InOut[pld.DistributedTensor[[1, SIZE], pl.FP32]],
+            signal: pl.InOut[pld.DistributedTensor[[nr, 1], pl.INT32]],
+        ) -> pl.Tensor[[1, SIZE], pl.FP32]:
+            """Chip kernel: four-phase mesh allreduce — stage, barrier, accumulate, stage-out."""
+            ctx = pld.get_comm_ctx(data)
+            my_rank = pld.rank(ctx)
+
+            # Phase 1 — stage this rank's slice into its window slot.
+            local = pl.load(x, [0, 0], [1, SIZE])
+            data = pl.store(local, [0, 0], data)
+
+            # Phase 2 — barrier: notify every peer, wait on every peer slot.
+            # Each rank owns a dedicated row (offsets=[my_rank, 0]);
+            # AtomicAdd/Ge(1) means the wait only passes once every peer has
+            # staged its slice.
+            for peer in pl.range(nr):
+                if peer != my_rank:
+                    pld.system.notify(
+                        signal,
+                        peer=peer,
+                        offsets=[my_rank, 0],
+                        value=1,
+                        op=pld.NotifyOp.AtomicAdd,
+                    )
+            for src in pl.range(nr):
+                if src != my_rank:
+                    pld.system.wait(
+                        signal,
+                        offsets=[src, 0],
+                        expected=1,
+                        cmp=pld.WaitCmp.Ge,
+                    )
+
+            # Phase 3 — accumulate: start from our own slice, add every peer's slice.
+            acc = pl.load(data, [0, 0], [1, SIZE])
+            for peer in pl.range(nr):
+                if peer != my_rank:
+                    recv = pld.tile.remote_load(data, peer=peer, offsets=[0, 0], shape=[1, SIZE])
+                    acc = pl.add(acc, recv)
+
+            # Phase 4 — stage-out: the accumulated result is this rank's output.
+            return pl.store(acc, [0, 0], y)
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def per_rank(
+            self,
+            x: pl.Tensor[[1, SIZE], pl.FP32],
+            y: pl.Out[pl.Tensor[[1, SIZE], pl.FP32]],
+            data: pl.InOut[pld.DistributedTensor[[1, SIZE], pl.FP32]],
+            signal: pl.InOut[pld.DistributedTensor[[nr, 1], pl.INT32]],
+        ) -> pl.Tensor[[1, SIZE], pl.FP32]:
+            """Per-device orchestration: one incore call, on this device."""
+            return self.reduce_step(x, y, data, signal)
+
+        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+        def mesh_allreduce(
+            self,
+            x: pl.Tensor[[nr, 1, SIZE], pl.FP32],
+            y: pl.Out[pl.Tensor[[nr, 1, SIZE], pl.FP32]],
+        ) -> pl.Tensor[[nr, 1, SIZE], pl.FP32]:
+            """Host orchestrator: one shared data window + one shared signal window, one dispatch per rank."""
+            data_buf = pld.alloc_window_buffer([1, SIZE], dtype=pl.FP32)
+            signal_buf = pld.alloc_window_buffer([nr, 1], dtype=pl.INT32)
+            for r in pl.range(pld.world_size()):
+                data = pld.window(data_buf, [1, SIZE], dtype=pl.FP32)
+                signal = pld.window(signal_buf, [nr, 1], dtype=pl.INT32)
+                self.per_rank(x[r], y[r], data, signal, device=r)
+            return y
+
+    return MeshAllreduce
+
+
+def expected_allreduce(inputs: torch.Tensor) -> torch.Tensor:
+    """Every rank receives the element-wise sum of all rank slices."""
+    reduced = inputs.sum(dim=0)
+    return torch.stack([reduced] * inputs.shape[0])
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="08_allreduce_mesh")
+    parser.add_argument(
+        "-p",
+        "--platform",
+        type=str,
+        default="a2a3sim",
+        choices=["a2a3", "a2a3sim", "a5", "a5sim"],
+    )
+    parser.add_argument(
+        "-d",
+        "--device",
+        type=str,
+        default="0,1,2,3",
+        help="comma-separated device ids (any count >= 2); run P>=4 to see mesh's O(P) traffic",
+    )
+    parser.add_argument("--compile-only", action="store_true", default=False)
+    args = parser.parse_args()
+
+    device_ids = [int(d) for d in args.device.split(",")]
+    if len(device_ids) < 2:
+        raise SystemExit(f"need at least 2 devices, got {device_ids}")
+
+    nr = len(device_ids)
+    program = build_mesh_allreduce(nr)
+
+    x = torch.randn((nr, 1, SIZE), dtype=torch.float32)
+    y = torch.zeros((nr, 1, SIZE), dtype=torch.float32)
+
+    compiled = ir.compile(
+        program,
+        platform=args.platform,
+        distributed_config=DistributedConfig(
+            device_ids=device_ids,
+            num_sub_workers=0,
+        ),
+    )
+    if args.compile_only:
+        print(f"compile_only done: {compiled.output_dir}")
+        return 0
+
+    compiled(x, y)
+
+    expected = expected_allreduce(x)
+    assert torch.allclose(y, expected, rtol=1e-5, atol=1e-5), (
+        f"mesh allreduce P={nr} mismatch: max diff = {(y - expected).abs().max().item()}"
+    )
+    print("OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/distributed/08_allreduce_mesh.py
+++ b/examples/distributed/08_allreduce_mesh.py
@@ -23,9 +23,15 @@ Concepts introduced:
   - the ``@pl.program`` class form + factory: the barrier signal is a per-rank
     row matrix ``[nr, 1]`` and window shapes must be statically known, so a
     rank-count factory builds a ``@pl.program`` class with ``nr`` folded in as
-    a compile-time constant — the documented way to keep "one source, any P"
-    when a window shape depends on the world size (see 01-collectives.md Ring
-    Mode; the ST tests use this same class-form factory)
+    a compile-time constant — the way to keep "one source, any P" when a
+    window shape depends on the world size. Steps 01-07 use the ``@pl.jit``
+    family; the switch here is required, not stylistic: ``@pl.program`` /
+    ``@pl.function`` capture the *defining* frame's locals at decoration time
+    (so the factory's ``nr`` resolves inside the HOST orchestrator body),
+    while ``@pl.jit.host`` re-specializes into ``@pl.function`` later, after
+    that frame is gone — a closure ``nr`` referenced in its body then fails to
+    resolve. Every rank-parametrized collective in ``tests/st/distributed/``
+    uses this same class-form factory for the same reason.
 
 This is the simplest of the three all-reduces (steps 08-10): one barrier, then
 every rank reads every peer. Its O(P) traffic is why the two-phase and ring
@@ -53,6 +59,11 @@ def build_mesh_allreduce(nr: int):
     a per-rank row matrix ``[nr, 1]`` and window shapes must be statically
     known: ``nr`` as a closure constant becomes a compile-time shape, so the
     same source serves any world size (pick it with ``-d``).
+
+    The class form is what makes that closure constant reachable: the
+    ``@pl.program`` decorator snapshots this factory frame's locals when it
+    runs, so ``nr`` resolves both in the signatures below and inside the HOST
+    orchestrator body (``alloc_window_buffer([nr, 1], ...)``).
     """
 
     @pl.program
@@ -68,6 +79,7 @@ def build_mesh_allreduce(nr: int):
             """Chip kernel: four-phase mesh allreduce — stage, barrier, accumulate, stage-out."""
             ctx = pld.get_comm_ctx(data)
             my_rank = pld.rank(ctx)
+            nranks = pld.nranks(ctx)
 
             # Phase 1 — stage this rank's slice into its window slot.
             local = pl.load(x, [0, 0], [1, SIZE])
@@ -77,7 +89,7 @@ def build_mesh_allreduce(nr: int):
             # Each rank owns a dedicated row (offsets=[my_rank, 0]);
             # AtomicAdd/Ge(1) means the wait only passes once every peer has
             # staged its slice.
-            for peer in pl.range(nr):
+            for peer in pl.range(nranks):
                 if peer != my_rank:
                     pld.system.notify(
                         signal,
@@ -86,7 +98,7 @@ def build_mesh_allreduce(nr: int):
                         value=1,
                         op=pld.NotifyOp.AtomicAdd,
                     )
-            for src in pl.range(nr):
+            for src in pl.range(nranks):
                 if src != my_rank:
                     pld.system.wait(
                         signal,
@@ -97,7 +109,7 @@ def build_mesh_allreduce(nr: int):
 
             # Phase 3 — accumulate: start from our own slice, add every peer's slice.
             acc = pl.load(data, [0, 0], [1, SIZE])
-            for peer in pl.range(nr):
+            for peer in pl.range(nranks):
                 if peer != my_rank:
                     recv = pld.tile.remote_load(data, peer=peer, offsets=[0, 0], shape=[1, SIZE])
                     acc = pl.add(acc, recv)

--- a/examples/distributed/09_allreduce_two_phase.py
+++ b/examples/distributed/09_allreduce_two_phase.py
@@ -1,0 +1,231 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+# -----------------------------------------------------------------------------------------------------------
+
+"""All-reduce v2 (two-phase): reduce-scatter then all-gather.
+
+Concepts introduced:
+  - the two-phase shape of every efficient all-reduce: first reduce-scatter
+    (each rank owns one chunk of the reduced result), then all-gather (every
+    rank collects every chunk) — roughly half of mesh's remote traffic:
+    ``2 * (P-1) / P * N`` bytes per rank vs mesh's ``(P-1) * N``
+  - chunk ownership: rank r reduces chunk r and stages it in its result
+    window; the all-gather then reads one chunk per peer
+  - two barriers, two rounds of the ``notify``/``wait`` handshake from step 04:
+    barrier A before any reduce-scatter read (all inputs staged), barrier B
+    before any all-gather read (all reduced chunks staged)
+  - the signal is a ``[2, nr]`` matrix — one row per barrier round (the ring
+    step will generalise this to one row per round)
+
+Same golden as step 08: every rank receives the element-wise sum of all rank
+slices, compared with a tolerance. Run at P>=4 to see the traffic difference
+from mesh (P=2 collapses the two algorithms into the same exchange).
+
+Run + walkthrough: see docs/en/user/distributed/14-allreduce_two_phase.md
+"""
+
+import argparse
+
+import pypto.language as pl
+import pypto.language.distributed as pld
+import torch
+from pypto import ir
+from pypto.ir.distributed_compiled_program import DistributedConfig
+
+SIZE = 64
+
+
+def build_two_phase_allreduce(nr: int):
+    """Build the two-phase allreduce program for a compile-time rank count ``nr``.
+
+    A rank-count factory (as in step 08) because the window shapes depend on
+    ``nr``: the signal is a ``[2, nr]`` per-rank-row matrix and chunk offsets
+    are ``nr``-sized — window shapes must be statically known, so ``nr`` is a
+    compile-time closure constant and the same source serves any P where
+    ``SIZE`` divides evenly (pick it with ``-d``).
+    """
+    if SIZE % nr != 0:
+        raise ValueError(f"SIZE={SIZE} must be divisible by the rank count, got {nr}")
+    chunk = SIZE // nr
+
+    @pl.program
+    class TwoPhaseAllreduce:
+        @pl.function(type=pl.FunctionType.InCore)
+        def reduce_step(
+            self,
+            x: pl.Tensor[[1, SIZE], pl.FP32],
+            y: pl.Out[pl.Tensor[[1, SIZE], pl.FP32]],
+            data: pl.InOut[pld.DistributedTensor[[1, SIZE], pl.FP32]],
+            result: pl.InOut[pld.DistributedTensor[[1, SIZE], pl.FP32]],
+            signal: pl.InOut[pld.DistributedTensor[[2, nr], pl.INT32]],
+        ) -> pl.Tensor[[1, SIZE], pl.FP32]:
+            """Chip kernel: stage, barrier, reduce-scatter, barrier, all-gather."""
+            ctx = pld.get_comm_ctx(data)
+            my_rank = pld.rank(ctx)
+            nranks = pld.nranks(ctx)
+
+            # Phase 1 — stage this rank's slice into its window slot.
+            local = pl.load(x, [0, 0], [1, SIZE])
+            data = pl.store(local, [0, 0], data)
+
+            # Barrier A (signal row 0) — all inputs staged before the RS reads.
+            for peer in pl.range(nranks):
+                if peer != my_rank:
+                    pld.system.notify(
+                        signal,
+                        peer=peer,
+                        offsets=[0, my_rank],
+                        value=1,
+                        op=pld.NotifyOp.AtomicAdd,
+                    )
+            for src in pl.range(nranks):
+                if src != my_rank:
+                    pld.system.wait(
+                        signal,
+                        offsets=[0, src],
+                        expected=1,
+                        cmp=pld.WaitCmp.Ge,
+                    )
+
+            # Phase 2 — reduce-scatter: rank r owns chunk r of the result.
+            acc = pl.load(data, [0, my_rank * chunk], [1, chunk])
+            for peer in pl.range(nranks):
+                if peer != my_rank:
+                    recv = pld.tile.remote_load(
+                        data,
+                        peer=peer,
+                        offsets=[0, my_rank * chunk],
+                        shape=[1, chunk],
+                    )
+                    acc = pl.add(acc, recv)
+            result = pl.store(acc, [0, my_rank * chunk], result)
+
+            # Barrier B (signal row 1) — all reduced chunks staged before the
+            # all-gather reads.
+            for peer in pl.range(nranks):
+                if peer != my_rank:
+                    pld.system.notify(
+                        signal,
+                        peer=peer,
+                        offsets=[1, my_rank],
+                        value=1,
+                        op=pld.NotifyOp.AtomicAdd,
+                    )
+            for src in pl.range(nranks):
+                if src != my_rank:
+                    pld.system.wait(
+                        signal,
+                        offsets=[1, src],
+                        expected=1,
+                        cmp=pld.WaitCmp.Ge,
+                    )
+
+            # Phase 3 — all-gather: rank r reads every rank's reduced chunk.
+            for c in pl.range(nranks):
+                recv = pld.tile.remote_load(
+                    result,
+                    peer=c,
+                    offsets=[0, c * chunk],
+                    shape=[1, chunk],
+                )
+                y = pl.store(recv, [0, c * chunk], y)
+
+            return y
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def per_rank(
+            self,
+            x: pl.Tensor[[1, SIZE], pl.FP32],
+            y: pl.Out[pl.Tensor[[1, SIZE], pl.FP32]],
+            data: pl.InOut[pld.DistributedTensor[[1, SIZE], pl.FP32]],
+            result: pl.InOut[pld.DistributedTensor[[1, SIZE], pl.FP32]],
+            signal: pl.InOut[pld.DistributedTensor[[2, nr], pl.INT32]],
+        ) -> pl.Tensor[[1, SIZE], pl.FP32]:
+            """Per-device orchestration: one incore call, on this device."""
+            return self.reduce_step(x, y, data, result, signal)
+
+        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+        def two_phase_allreduce(
+            self,
+            x: pl.Tensor[[nr, 1, SIZE], pl.FP32],
+            y: pl.Out[pl.Tensor[[nr, 1, SIZE], pl.FP32]],
+        ) -> pl.Tensor[[nr, 1, SIZE], pl.FP32]:
+            """Host orchestrator: shared data + result + signal windows, one dispatch per rank."""
+            data_buf = pld.alloc_window_buffer([1, SIZE], dtype=pl.FP32)
+            result_buf = pld.alloc_window_buffer([1, SIZE], dtype=pl.FP32)
+            signal_buf = pld.alloc_window_buffer([2, nr], dtype=pl.INT32)
+            for r in pl.range(pld.world_size()):
+                data = pld.window(data_buf, [1, SIZE], dtype=pl.FP32)
+                result = pld.window(result_buf, [1, SIZE], dtype=pl.FP32)
+                signal = pld.window(signal_buf, [2, nr], dtype=pl.INT32)
+                self.per_rank(x[r], y[r], data, result, signal, device=r)
+            return y
+
+    return TwoPhaseAllreduce
+
+
+def expected_allreduce(inputs: torch.Tensor) -> torch.Tensor:
+    """Every rank receives the element-wise sum of all rank slices."""
+    reduced = inputs.sum(dim=0)
+    return torch.stack([reduced] * inputs.shape[0])
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="09_allreduce_two_phase")
+    parser.add_argument(
+        "-p",
+        "--platform",
+        type=str,
+        default="a2a3sim",
+        choices=["a2a3", "a2a3sim", "a5", "a5sim"],
+    )
+    parser.add_argument(
+        "-d",
+        "--device",
+        type=str,
+        default="0,1,2,3",
+        help="comma-separated device ids (>= 2, dividing SIZE); P>=4 shows the saving vs mesh",
+    )
+    parser.add_argument("--compile-only", action="store_true", default=False)
+    args = parser.parse_args()
+
+    device_ids = [int(d) for d in args.device.split(",")]
+    if len(device_ids) < 2:
+        raise SystemExit(f"need at least 2 devices, got {device_ids}")
+
+    nr = len(device_ids)
+    program = build_two_phase_allreduce(nr)
+
+    x = torch.randn((nr, 1, SIZE), dtype=torch.float32)
+    y = torch.zeros((nr, 1, SIZE), dtype=torch.float32)
+
+    compiled = ir.compile(
+        program,
+        platform=args.platform,
+        distributed_config=DistributedConfig(
+            device_ids=device_ids,
+            num_sub_workers=0,
+        ),
+    )
+    if args.compile_only:
+        print(f"compile_only done: {compiled.output_dir}")
+        return 0
+
+    compiled(x, y)
+
+    expected = expected_allreduce(x)
+    assert torch.allclose(y, expected, rtol=1e-5, atol=1e-5), (
+        f"two-phase allreduce P={nr} mismatch: max diff = {(y - expected).abs().max().item()}"
+    )
+    print("OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/distributed/09_allreduce_two_phase.py
+++ b/examples/distributed/09_allreduce_two_phase.py
@@ -44,11 +44,14 @@ SIZE = 64
 def build_two_phase_allreduce(nr: int):
     """Build the two-phase allreduce program for a compile-time rank count ``nr``.
 
-    A rank-count factory (as in step 08) because the window shapes depend on
-    ``nr``: the signal is a ``[2, nr]`` per-rank-row matrix and chunk offsets
-    are ``nr``-sized — window shapes must be statically known, so ``nr`` is a
-    compile-time closure constant and the same source serves any P where
-    ``SIZE`` divides evenly (pick it with ``-d``).
+    A rank-count factory — the first step that needs one. Step 08 has none: its
+    signal row count stays ``pl.dynamic``. What forces a compile-time ``nr``
+    here is ``chunk = SIZE // nr``, used as a **tile shape** (the ``[1, chunk]``
+    on every ``pl.load`` / ``remote_load`` below), and tile shapes must be known
+    when the kernel is compiled. The ``[2, nr]`` signal then falls out of the
+    same constant for free — but a signal shape on its own would not have
+    required it. One source still serves any P that divides ``SIZE`` evenly
+    (pick it with ``-d``).
     """
     if SIZE % nr != 0:
         raise ValueError(f"SIZE={SIZE} must be divisible by the rank count, got {nr}")

--- a/examples/distributed/10_allreduce_ring.py
+++ b/examples/distributed/10_allreduce_ring.py
@@ -63,12 +63,11 @@ def build_ring_allreduce(nr: int):
             y: pl.Out[pl.Tensor[[1, SIZE], pl.FP32]],
             scratch: pl.InOut[pld.DistributedTensor[[1, SIZE], pl.FP32]],
             signal: pl.InOut[pld.DistributedTensor[[total_rounds, nr], pl.INT32]],
-            chunk_elems: pl.Scalar[pl.INDEX],
         ) -> pl.Tensor[[1, SIZE], pl.FP32]:
             """Monolithic ring allreduce: stage-in, RS loop, AG loop, stage-out.
 
             ``scratch`` holds ``nr`` chunks laid out flat in ``[1, SIZE]``;
-            chunk *c* starts at offset ``c * chunk_elems``. The signal carries
+            chunk *c* starts at offset ``c * chunk``. The signal carries
             ``2*(nr-1)`` rows, one per round, and is a neighbour-ready
             handshake: notify the *right* neighbour after a store, wait on the
             *left* neighbour before a ``remote_load`` (payload reads the left
@@ -85,8 +84,8 @@ def build_ring_allreduce(nr: int):
             # Phase 1 — stage-in: copy each local input chunk into scratch,
             # then tell the right neighbour the ring is ready (signal row 0).
             for c in pl.range(nranks):
-                src_tile = pl.load(x, [0, c * chunk_elems], [1, chunk])
-                scratch = pl.store(src_tile, [0, c * chunk_elems], scratch)
+                src_tile = pl.load(x, [0, c * chunk], [1, chunk])
+                scratch = pl.store(src_tile, [0, c * chunk], scratch)
             pld.system.notify(
                 signal,
                 peer=right,
@@ -116,12 +115,12 @@ def build_ring_allreduce(nr: int):
                 recv = pld.tile.remote_load(
                     scratch,
                     peer=left,
-                    offsets=[0, left_send_idx * chunk_elems],
+                    offsets=[0, left_send_idx * chunk],
                     shape=[1, chunk],
                 )
-                acc = pl.load(scratch, [0, recv_add_idx * chunk_elems], [1, chunk])
+                acc = pl.load(scratch, [0, recv_add_idx * chunk], [1, chunk])
                 acc = pl.add(acc, recv)
-                scratch = pl.store(acc, [0, recv_add_idx * chunk_elems], scratch)
+                scratch = pl.store(acc, [0, recv_add_idx * chunk], scratch)
 
                 # The store above stages the right neighbour's round-(rs_round+1)
                 # send: signal it on the next row.
@@ -152,10 +151,10 @@ def build_ring_allreduce(nr: int):
                 recv = pld.tile.remote_load(
                     scratch,
                     peer=left,
-                    offsets=[0, left_send_idx * chunk_elems],
+                    offsets=[0, left_send_idx * chunk],
                     shape=[1, chunk],
                 )
-                scratch = pl.store(recv, [0, recv_idx * chunk_elems], scratch)
+                scratch = pl.store(recv, [0, recv_idx * chunk], scratch)
 
                 # Pass the completion on to the right neighbour — except after
                 # the final round, whose row would exceed the signal's
@@ -171,8 +170,8 @@ def build_ring_allreduce(nr: int):
 
             # Phase 4 — stage-out: write the concatenated chunks to the output.
             for c in pl.range(nranks):
-                src_tile = pl.load(scratch, [0, c * chunk_elems], [1, chunk])
-                y = pl.store(src_tile, [0, c * chunk_elems], y)
+                src_tile = pl.load(scratch, [0, c * chunk], [1, chunk])
+                y = pl.store(src_tile, [0, c * chunk], y)
 
             return y
 
@@ -183,10 +182,9 @@ def build_ring_allreduce(nr: int):
             y: pl.Out[pl.Tensor[[1, SIZE], pl.FP32]],
             scratch: pl.InOut[pld.DistributedTensor[[1, SIZE], pl.FP32]],
             signal: pl.InOut[pld.DistributedTensor[[total_rounds, nr], pl.INT32]],
-            chunk_elems: pl.Scalar[pl.INDEX],
         ) -> pl.Tensor[[1, SIZE], pl.FP32]:
             """Per-device orchestration: one incore call, on this device."""
-            return self.ring_step(x, y, scratch, signal, chunk_elems)
+            return self.ring_step(x, y, scratch, signal)
 
         @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
         def ring_allreduce(
@@ -197,11 +195,10 @@ def build_ring_allreduce(nr: int):
             """Host orchestrator: shared scratch + signal windows, one dispatch per rank."""
             scratch_buf = pld.alloc_window_buffer([1, SIZE], dtype=pl.FP32)
             signal_buf = pld.alloc_window_buffer([total_rounds, nr], dtype=pl.INT32)
-            chunk_elems = SIZE // nr
-            for r in pl.range(nr):
+            for r in pl.range(pld.world_size()):
                 scratch = pld.window(scratch_buf, [1, SIZE], dtype=pl.FP32)
                 signal = pld.window(signal_buf, [total_rounds, nr], dtype=pl.INT32)
-                self.per_rank(x[r], y[r], scratch, signal, chunk_elems, device=r)
+                self.per_rank(x[r], y[r], scratch, signal, device=r)
             return y
 
     return RingAllreduce

--- a/examples/distributed/10_allreduce_ring.py
+++ b/examples/distributed/10_allreduce_ring.py
@@ -1,0 +1,268 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+# -----------------------------------------------------------------------------------------------------------
+
+"""All-reduce v3 (ring): chunked reduce-scatter + all-gather around the ring.
+
+Concepts introduced:
+  - the ring schedule: the same two-phase shape as step 09, but each rank only
+    ever talks to its left neighbour — one chunk of ``N/P`` elements per
+    step, for ``2 * (P-1)`` steps
+  - why the ring scales: the per-step transfer stays ``N/P`` no matter how
+    large P is, so the per-step size is constant as the world grows — same
+    total bytes as two-phase, in smaller, constant-size rounds
+  - a neighbour-ready handshake instead of a per-round barrier: the signal is
+    ``[2*(P-1), P]`` — one row per round — and each rank notifies its *right*
+    neighbour after a store and waits on its *left* neighbour before a
+    remote_load (step 09 used ``[2, P]`` full-mesh barriers; the ring has more
+    rounds but only ever synchronizes with the two adjacent ranks)
+  - chunk indices rotate around the ring: in round s, the chunk you send to
+    the right and receive from the left both shift by one
+
+Same golden as steps 08/09: every rank receives the element-wise sum of all
+rank slices, compared with a tolerance.
+
+Run + walkthrough: see docs/en/user/distributed/15-allreduce_ring.md
+"""
+
+import argparse
+
+import pypto.language as pl
+import pypto.language.distributed as pld
+import torch
+from pypto import ir
+from pypto.ir.distributed_compiled_program import DistributedConfig
+
+SIZE = 64
+
+
+def build_ring_allreduce(nr: int):
+    """Build the ring allreduce program for a compile-time rank count ``nr``.
+
+    A rank-count factory because the signal is ``[2*(nr-1), nr]`` (row per
+    round) and the chunk size is ``SIZE // nr`` — both must be statically
+    known, so ``nr`` is a compile-time closure constant (as in steps 08/09).
+    """
+    if SIZE % nr != 0:
+        raise ValueError(f"SIZE={SIZE} must be divisible by the rank count, got {nr}")
+    total_rounds = 2 * (nr - 1)
+    chunk = SIZE // nr
+
+    @pl.program
+    class RingAllreduce:
+        @pl.function(type=pl.FunctionType.InCore)
+        def ring_step(
+            self,
+            x: pl.Tensor[[1, SIZE], pl.FP32],
+            y: pl.Out[pl.Tensor[[1, SIZE], pl.FP32]],
+            scratch: pl.InOut[pld.DistributedTensor[[1, SIZE], pl.FP32]],
+            signal: pl.InOut[pld.DistributedTensor[[total_rounds, nr], pl.INT32]],
+            chunk_elems: pl.Scalar[pl.INDEX],
+        ) -> pl.Tensor[[1, SIZE], pl.FP32]:
+            """Monolithic ring allreduce: stage-in, RS loop, AG loop, stage-out.
+
+            ``scratch`` holds ``nr`` chunks laid out flat in ``[1, SIZE]``;
+            chunk *c* starts at offset ``c * chunk_elems``. The signal carries
+            ``2*(nr-1)`` rows, one per round, and is a neighbour-ready
+            handshake: notify the *right* neighbour after a store, wait on the
+            *left* neighbour before a ``remote_load`` (payload reads the left
+            neighbour; synchronization touches only both adjacent ranks).
+            ``alloc_window_buffer`` zero-initialises every cell, so per-cell
+            ``AtomicAdd(0->1)`` / ``WaitGe(1)`` is safe without a reset.
+            """
+            ctx = pld.get_comm_ctx(scratch)
+            my_rank = pld.rank(ctx)
+            nranks = pld.nranks(ctx)
+            left = (my_rank - 1 + nranks) % nranks
+            right = (my_rank + 1) % nranks
+
+            # Phase 1 — stage-in: copy each local input chunk into scratch,
+            # then tell the right neighbour the ring is ready (signal row 0).
+            for c in pl.range(nranks):
+                src_tile = pl.load(x, [0, c * chunk_elems], [1, chunk])
+                scratch = pl.store(src_tile, [0, c * chunk_elems], scratch)
+            pld.system.notify(
+                signal,
+                peer=right,
+                offsets=[0, my_rank],
+                value=1,
+                op=pld.NotifyOp.AtomicAdd,
+            )
+
+            # Phase 2 — reduce-scatter: (nr-1) ring steps. In step s the chunk
+            # we add from the left and the chunk we forward both rotate.
+            for s in pl.range(nranks - 1):
+                step = s + 1
+                recv_add_idx = (my_rank - step - 1 + nranks) % nranks
+                left_send_idx = (left - step + nranks) % nranks
+                rs_round = s
+
+                # Wait for the left neighbour's round-rs_round chunk (staged by
+                # its previous store, signalled on row rs_round).
+                pld.system.wait(
+                    signal,
+                    offsets=[rs_round, left],
+                    expected=1,
+                    cmp=pld.WaitCmp.Ge,
+                )
+
+                # Add the left neighbour's send chunk into our accumulator chunk.
+                recv = pld.tile.remote_load(
+                    scratch,
+                    peer=left,
+                    offsets=[0, left_send_idx * chunk_elems],
+                    shape=[1, chunk],
+                )
+                acc = pl.load(scratch, [0, recv_add_idx * chunk_elems], [1, chunk])
+                acc = pl.add(acc, recv)
+                scratch = pl.store(acc, [0, recv_add_idx * chunk_elems], scratch)
+
+                # The store above stages the right neighbour's round-(rs_round+1)
+                # send: signal it on the next row.
+                pld.system.notify(
+                    signal,
+                    peer=right,
+                    offsets=[rs_round + 1, my_rank],
+                    value=1,
+                    op=pld.NotifyOp.AtomicAdd,
+                )
+
+            # Phase 3 — all-gather: (nr-1) ring steps.
+            for s in pl.range(nranks - 1):
+                step = s + 1
+                recv_idx = (my_rank - step + nranks) % nranks
+                left_send_idx = (left - step + 1 + nranks) % nranks
+                ag_round = (nranks - 1) + s
+
+                # Wait for the left neighbour's chunk staged for this round.
+                pld.system.wait(
+                    signal,
+                    offsets=[ag_round, left],
+                    expected=1,
+                    cmp=pld.WaitCmp.Ge,
+                )
+
+                # Copy the left neighbour's send chunk into our local chunk.
+                recv = pld.tile.remote_load(
+                    scratch,
+                    peer=left,
+                    offsets=[0, left_send_idx * chunk_elems],
+                    shape=[1, chunk],
+                )
+                scratch = pl.store(recv, [0, recv_idx * chunk_elems], scratch)
+
+                # Pass the completion on to the right neighbour — except after
+                # the final round, whose row would exceed the signal's
+                # 2*(nr-1) rows.
+                if s < nranks - 2:
+                    pld.system.notify(
+                        signal,
+                        peer=right,
+                        offsets=[ag_round + 1, my_rank],
+                        value=1,
+                        op=pld.NotifyOp.AtomicAdd,
+                    )
+
+            # Phase 4 — stage-out: write the concatenated chunks to the output.
+            for c in pl.range(nranks):
+                src_tile = pl.load(scratch, [0, c * chunk_elems], [1, chunk])
+                y = pl.store(src_tile, [0, c * chunk_elems], y)
+
+            return y
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def per_rank(
+            self,
+            x: pl.Tensor[[1, SIZE], pl.FP32],
+            y: pl.Out[pl.Tensor[[1, SIZE], pl.FP32]],
+            scratch: pl.InOut[pld.DistributedTensor[[1, SIZE], pl.FP32]],
+            signal: pl.InOut[pld.DistributedTensor[[total_rounds, nr], pl.INT32]],
+            chunk_elems: pl.Scalar[pl.INDEX],
+        ) -> pl.Tensor[[1, SIZE], pl.FP32]:
+            """Per-device orchestration: one incore call, on this device."""
+            return self.ring_step(x, y, scratch, signal, chunk_elems)
+
+        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+        def ring_allreduce(
+            self,
+            x: pl.Tensor[[nr, 1, SIZE], pl.FP32],
+            y: pl.Out[pl.Tensor[[nr, 1, SIZE], pl.FP32]],
+        ) -> pl.Tensor[[nr, 1, SIZE], pl.FP32]:
+            """Host orchestrator: shared scratch + signal windows, one dispatch per rank."""
+            scratch_buf = pld.alloc_window_buffer([1, SIZE], dtype=pl.FP32)
+            signal_buf = pld.alloc_window_buffer([total_rounds, nr], dtype=pl.INT32)
+            chunk_elems = SIZE // nr
+            for r in pl.range(nr):
+                scratch = pld.window(scratch_buf, [1, SIZE], dtype=pl.FP32)
+                signal = pld.window(signal_buf, [total_rounds, nr], dtype=pl.INT32)
+                self.per_rank(x[r], y[r], scratch, signal, chunk_elems, device=r)
+            return y
+
+    return RingAllreduce
+
+
+def expected_allreduce(inputs: torch.Tensor) -> torch.Tensor:
+    """Every rank receives the element-wise sum of all rank slices."""
+    reduced = inputs.sum(dim=0)
+    return torch.stack([reduced] * inputs.shape[0])
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="10_allreduce_ring")
+    parser.add_argument(
+        "-p",
+        "--platform",
+        type=str,
+        default="a2a3sim",
+        choices=["a2a3", "a2a3sim", "a5", "a5sim"],
+    )
+    parser.add_argument(
+        "-d",
+        "--device",
+        type=str,
+        default="0,1,2,3",
+        help="comma-separated device ids (>= 2, dividing SIZE); P>=4 shows the constant per-step size",
+    )
+    parser.add_argument("--compile-only", action="store_true", default=False)
+    args = parser.parse_args()
+
+    device_ids = [int(d) for d in args.device.split(",")]
+    if len(device_ids) < 2:
+        raise SystemExit(f"need at least 2 devices, got {device_ids}")
+
+    nr = len(device_ids)
+    program = build_ring_allreduce(nr)
+
+    x = torch.randn((nr, 1, SIZE), dtype=torch.float32)
+    y = torch.zeros((nr, 1, SIZE), dtype=torch.float32)
+
+    compiled = ir.compile(
+        program,
+        platform=args.platform,
+        distributed_config=DistributedConfig(
+            device_ids=device_ids,
+            num_sub_workers=0,
+        ),
+    )
+    if args.compile_only:
+        print(f"compile_only done: {compiled.output_dir}")
+        return 0
+
+    compiled(x, y)
+
+    expected = expected_allreduce(x)
+    assert torch.allclose(y, expected, rtol=1e-5, atol=1e-5), (
+        f"ring allreduce P={nr} mismatch: max diff = {(y - expected).abs().max().item()}"
+    )
+    print("OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/distributed/10_allreduce_ring.py
+++ b/examples/distributed/10_allreduce_ring.py
@@ -45,9 +45,12 @@ SIZE = 64
 def build_ring_allreduce(nr: int):
     """Build the ring allreduce program for a compile-time rank count ``nr``.
 
-    A rank-count factory because the signal is ``[2*(nr-1), nr]`` (row per
-    round) and the chunk size is ``SIZE // nr`` — both must be statically
-    known, so ``nr`` is a compile-time closure constant (as in steps 08/09).
+    A rank-count factory for the same single reason as step 09:
+    ``chunk = SIZE // nr`` is a **tile shape** (the ``[1, chunk]`` on every load
+    below), and tile shapes must be known when the kernel is compiled. The
+    ``[2*(nr-1), nr]`` signal is then written from the same constant, but a
+    signal row count alone does not force it — step 08 keeps its rows dynamic
+    and needs no factory at all.
     """
     if SIZE % nr != 0:
         raise ValueError(f"SIZE={SIZE} must be divisible by the rank count, got {nr}")

--- a/examples/distributed/11_allreduce_reveal.py
+++ b/examples/distributed/11_allreduce_reveal.py
@@ -103,7 +103,7 @@ def build_reveal_allreduce(nr: int, mode: str):
             """Host orchestrator: shared data + signal windows, one dispatch per rank."""
             data_buf = pld.alloc_window_buffer([1, SIZE], dtype=pl.FP32)
             signal_buf = pld.alloc_window_buffer([sig_rows, sig_cols], dtype=pl.INT32)
-            for r in pl.range(nr):
+            for r in pl.range(pld.world_size()):
                 data = pld.window(data_buf, [1, SIZE], dtype=pl.FP32)
                 signal = pld.window(signal_buf, [sig_rows, sig_cols], dtype=pl.INT32)
                 self.per_rank(x[r], y[r], data, signal, device=r)

--- a/examples/distributed/11_allreduce_reveal.py
+++ b/examples/distributed/11_allreduce_reveal.py
@@ -1,0 +1,180 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+# -----------------------------------------------------------------------------------------------------------
+
+"""The reveal: ``pld.tensor.allreduce`` in one call, mesh or ring.
+
+Concepts introduced:
+  - the builtin: ``pld.tensor.allreduce(data, signal, op=..., mode=...)``
+    replaces the hand-rolled steps 08-10 with one call — the same golden, the
+    same signal conventions, none of the schedule
+  - ``mode="mesh"`` (default) / ``mode="ring"``: the same source picks the
+    algorithm; the IR diff (see the walkthrough) shows what each mode lowers
+    to — the hand-rolled mesh/ring pattern you wrote in steps 08/10, or a
+    better one
+  - what the builtin accepts: the full ``ReduceOp`` family (``Sum``/``Max``/
+    ``Min``/``Prod``) and ``FP16``/``FP32`` in both modes — ring keeps the
+    ``[2*(P-1), P]`` signal (the row-per-round signal step 10 taught), mesh
+    takes ``[P, 1]``
+  - stage-in / stage-out stay yours: the builtin only owns the barrier +
+    reduce + store-back; you still move data in and out of the window
+
+Same golden as steps 08-10: every rank receives the element-wise sum of all
+rank slices, compared with a tolerance. Run ``--mode mesh`` and ``--mode ring``
+at P>=4 and compare the lowered IR in the walkthrough.
+
+Run + walkthrough: see docs/en/user/distributed/16-allreduce_reveal.md
+"""
+
+import argparse
+
+import pypto.language as pl
+import pypto.language.distributed as pld
+import torch
+from pypto import ir
+from pypto.ir.distributed_compiled_program import DistributedConfig
+
+SIZE = 64
+
+
+def build_reveal_allreduce(nr: int, mode: str):
+    """Build the builtin allreduce program for a compile-time rank count ``nr``.
+
+    A rank-count factory (as in steps 08-10) because the signal shape depends
+    on both ``nr`` and the mode: mesh is ``[nr, 1]``, ring is ``[2*(nr-1), nr]``
+    (row per round). The mode is folded in as a closure constant, so one
+    source builds either variant.
+    """
+    total_rounds = 2 * (nr - 1)
+    if mode == "ring":
+        sig_rows, sig_cols = total_rounds, nr
+    elif mode == "mesh":
+        sig_rows, sig_cols = nr, 1
+    else:
+        raise ValueError(f"unsupported mode: {mode}")
+
+    @pl.program
+    class AllreduceReveal:
+        @pl.function(type=pl.FunctionType.InCore)
+        def reduce_step(
+            self,
+            x: pl.Tensor[[1, SIZE], pl.FP32],
+            y: pl.Out[pl.Tensor[[1, SIZE], pl.FP32]],
+            data: pl.InOut[pld.DistributedTensor[[1, SIZE], pl.FP32]],
+            signal: pl.InOut[pld.DistributedTensor[[sig_rows, sig_cols], pl.INT32]],
+        ) -> pl.Tensor[[1, SIZE], pl.FP32]:
+            """Chip kernel: stage-in, one builtin call, stage-out."""
+
+            # Phase 1 — stage this rank's slice into its window slot.
+            local = pl.load(x, [0, 0], [1, SIZE])
+            data = pl.store(local, [0, 0], data)
+
+            # Phase 2 — the builtin: barrier + reduce + store-back, in one
+            # call. mode is folded in by the factory (mesh default / ring).
+            data = pld.tensor.allreduce(data, signal, op=pld.ReduceOp.Sum, mode=mode)
+
+            # Phase 3 — stage-out: the reduced slice back to the local output.
+            recv = pl.load(data, [0, 0], [1, SIZE])
+            return pl.store(recv, [0, 0], y)
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def per_rank(
+            self,
+            x: pl.Tensor[[1, SIZE], pl.FP32],
+            y: pl.Out[pl.Tensor[[1, SIZE], pl.FP32]],
+            data: pl.InOut[pld.DistributedTensor[[1, SIZE], pl.FP32]],
+            signal: pl.InOut[pld.DistributedTensor[[sig_rows, sig_cols], pl.INT32]],
+        ) -> pl.Tensor[[1, SIZE], pl.FP32]:
+            """Per-device orchestration: one incore call, on this device."""
+            return self.reduce_step(x, y, data, signal)
+
+        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+        def allreduce_reveal(
+            self,
+            x: pl.Tensor[[nr, 1, SIZE], pl.FP32],
+            y: pl.Out[pl.Tensor[[nr, 1, SIZE], pl.FP32]],
+        ) -> pl.Tensor[[nr, 1, SIZE], pl.FP32]:
+            """Host orchestrator: shared data + signal windows, one dispatch per rank."""
+            data_buf = pld.alloc_window_buffer([1, SIZE], dtype=pl.FP32)
+            signal_buf = pld.alloc_window_buffer([sig_rows, sig_cols], dtype=pl.INT32)
+            for r in pl.range(nr):
+                data = pld.window(data_buf, [1, SIZE], dtype=pl.FP32)
+                signal = pld.window(signal_buf, [sig_rows, sig_cols], dtype=pl.INT32)
+                self.per_rank(x[r], y[r], data, signal, device=r)
+            return y
+
+    return AllreduceReveal
+
+
+def expected_allreduce(inputs: torch.Tensor) -> torch.Tensor:
+    """Every rank receives the element-wise sum of all rank slices."""
+    reduced = inputs.sum(dim=0)
+    return torch.stack([reduced] * inputs.shape[0])
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="11_allreduce_reveal")
+    parser.add_argument(
+        "-p",
+        "--platform",
+        type=str,
+        default="a2a3sim",
+        choices=["a2a3", "a2a3sim", "a5", "a5sim"],
+    )
+    parser.add_argument(
+        "-d",
+        "--device",
+        type=str,
+        default="0,1,2,3",
+        help="comma-separated device ids (any count >= 2)",
+    )
+    parser.add_argument(
+        "--mode",
+        type=str,
+        default="mesh",
+        choices=["mesh", "ring"],
+        help="builtin mode: mesh (default) or ring",
+    )
+    parser.add_argument("--compile-only", action="store_true", default=False)
+    args = parser.parse_args()
+
+    device_ids = [int(d) for d in args.device.split(",")]
+    if len(device_ids) < 2:
+        raise SystemExit(f"need at least 2 devices, got {device_ids}")
+
+    nr = len(device_ids)
+    program = build_reveal_allreduce(nr, args.mode)
+
+    x = torch.randn((nr, 1, SIZE), dtype=torch.float32)
+    y = torch.zeros((nr, 1, SIZE), dtype=torch.float32)
+
+    compiled = ir.compile(
+        program,
+        platform=args.platform,
+        distributed_config=DistributedConfig(
+            device_ids=device_ids,
+            num_sub_workers=0,
+        ),
+    )
+    if args.compile_only:
+        print(f"compile_only done: {compiled.output_dir}")
+        return 0
+
+    compiled(x, y)
+
+    expected = expected_allreduce(x)
+    assert torch.allclose(y, expected, rtol=1e-5, atol=1e-5), (
+        f"allreduce reveal ({args.mode}) P={nr} mismatch: max diff = {(y - expected).abs().max().item()}"
+    )
+    print("OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/distributed/11_allreduce_reveal.py
+++ b/examples/distributed/11_allreduce_reveal.py
@@ -44,12 +44,18 @@ SIZE = 64
 
 
 def build_reveal_allreduce(nr: int, mode: str):
-    """Build the builtin allreduce program for a compile-time rank count ``nr``.
+    """Build the builtin allreduce program for a rank count ``nr`` and ``mode``.
 
-    A rank-count factory (as in steps 08-10) because the signal shape depends
-    on both ``nr`` and the mode: mesh is ``[nr, 1]``, ring is ``[2*(nr-1), nr]``
-    (row per round). The mode is folded in as a closure constant, so one
-    source builds either variant.
+    A factory over ``(nr, mode)``, and for a different reason than steps 09/10:
+    the builtin owns the chunking, so no **tile shape** here depends on the
+    rank count — ``nr`` need not be compile-time at all (the ring layout, the
+    more constrained of the two, compiles and passes its golden with a
+    ``pl.dynamic`` rank count). What must be fixed when the kernel is traced is
+    ``mode``: it picks both the lowering ``pld.tensor.allreduce`` emits and the
+    signal layout the kernel is annotated with, and those are two different
+    shapes, not two extents of one — mesh ``[nr, 1]``, ring ``[2*(nr-1), nr]``
+    (row per round). Folding ``nr`` in beside it lets one source spell both
+    layouts and build either variant (pick it with ``--mode``).
     """
     total_rounds = 2 * (nr - 1)
     if mode == "ring":

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -263,6 +263,10 @@ nav:
           - en/user/distributed/10-remote_load_store.md
           - en/user/distributed/11-put_get.md
           - en/user/distributed/12-dynamic_rank_count.md
+          - en/user/distributed/13-allreduce_mesh.md
+          - en/user/distributed/14-allreduce_two_phase.md
+          - en/user/distributed/15-allreduce_ring.md
+          - en/user/distributed/16-allreduce_reveal.md
   - API Reference:
       - en/api/index.md
       - en/api/language.md


### PR DESCRIPTION
## Summary

Second PR of the distributed teaching ladder: the all-reduce in
depth. Four small, golden-validated programs (steps 08–11) build the
collective by hand three ways — mesh, two-phase, ring — and then reveal the
builtin, each with a walkthrough page (en + zh) and a CI P=4 leg so the
comparisons are actually observable.

> **Rebased on current `main` (2026-08-11) and review-fixed.** #2317 is merged
> (squash `016e69a8`); this branch is `main` + the steps 08–11 work, squashed
> into one commit (head `659def1e`). Review round addressed: the ring uses
> neighbour-ready handshakes instead of per-round full-mesh barriers (all
> `pl.store`s rebound), the reveal docs state the InCore composite accepts the
> full `ReduceOp` family + `FP16`/`FP32` in both modes (the `Sum`+`FP32` limit
> is the HOST-builtin ring path), and the quickstart/index wording is
> corrected. Ring + reveal re-sim-validated at P=2/P=4 on a2a3sim.

## Tutorial steps (this PR)

| Step | Program | Teaches |
| ---- | ------- | ------- |
| 08 | `08_allreduce_mesh.py` | All-reduce v1 (mesh): every rank reads every peer's slice and sums locally, behind a dedicated-row notify/wait barrier |
| 09 | `09_allreduce_two_phase.py` | All-reduce v2: reduce-scatter + all-gather (`SIZE // P` chunks, `SIZE % P == 0`) |
| 10 | `10_allreduce_ring.py` | All-reduce v3 (ring): chunked rotation around the ring, `2·(P−1)` rounds, neighbour-ready handshakes |
| 11 | `11_allreduce_reveal.py` | **The reveal**: `pld.tensor.allreduce` (mesh + ring modes); the walkthrough diffs the lowered IR against the hand-rolled versions |

Each program uses the class-form factory (`build_* (nr)` → `@pl.program`) so
the rank count folds into static window shapes — the same source serves any P
via `-d` (window shapes must be statically known; see the plan's implementation
note).

## Docs

- `docs/en+zh/user/distributed/13-allreduce_mesh.md` … `16-allreduce_reveal.md`
  — one walkthrough per step (The idea → Run it → Walkthrough → Edge cases →
  See also, cost card + three-column debugging table each; step 16 ships a
  guide to the IR diff as the teaching artifact).
- `docs/en+zh/user/distributed/05-tutorials.md` — steps 08–11 marked ✅ shipped;
  steps 12–15 (the remaining collectives) and step 16 (composition) remain
  planned.
- Cross-links: `01-collectives.md` §Runnable Examples (allreduce row → the four
  walkthroughs), `00-model.md` Quickstart ↔ the mesh walkthrough (the
  quickstart is the mesh pattern).
- `mkdocs.yml` — nav entries for 13–16.

## CI

- `examples-tests` (from #2317) gains the P=4 legs for steps 08–11 — mesh /
  two-phase / ring collapse to the same exchange at P=2, so the P=4 legs are
  where the comparisons are observable; step 11 runs both `--mode mesh` and
  `--mode ring`.
- Docs gates (nav / en-zh parity / pre-commit / `mkdocs build --strict`) green.

## Verification

- Steps 08–11 sim-validated on `a2a3sim` at P=2/3/4 (reveal in both modes),
  goldens vs torch with tolerance.
- Developer gate: 4-card NPU run
  (`-p a2a3 -d 0,1,2,3`) via `task-submit` where available; else 2-card +
  sim-P=4 evidence.


