### PR TITLE
feat(passes): bind valid_shape-only dynamic symbols as kernel arguments

### DIFF
--- a/.claude/rules/pass-doc-ordering.md
+++ b/.claude/rules/pass-doc-ordering.md
@@ -59,6 +59,7 @@ Developers read pass docs sequentially to understand the compilation pipeline. I
 | 44 | `44-materialize_runtime_scopes.md` | Runs after the final Simplify; inserts AUTO RuntimeScopeStmt so orchestration codegen emits PTO2_SCOPE 1:1 |
 | 45 | `45-classify_iter_arg_carry.md` | Classifies each Orchestration ForStmt iter_arg (trivial alias vs materialised rebind carry) and sizes manual-scope TaskId array carries; runs after MaterializeRuntimeScopes |
 | 46 | `46-insert_comm_fence.md` | Last pass (distributed: inserts a whole-tensor system.cacheinvalid + GM system.fence between each publishing write and the pld.system.notify that releases it; runs after all statement-reordering passes so the inserted ops stay adjacent to notify through codegen) |
+| 47 | `47-materialize_valid_shape_symbols.md` | Runs dead last; turns each device-kernel `valid_shape` symbol the kernel cannot bind (not a physical dim, not a scalar param) into a leading `Scalar[INDEX]` param fed from the call site's actual valid extent |
 | 91 | `91-utility_passes.md` | Not in Default strategy |
 | 99 | `99-verifier.md` | Infrastructure (not a pipeline pass) |
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,6 +171,7 @@ set(PYPTO_SOURCES
     src/ir/transforms/materialize_comm_domain_scopes_pass.cpp
     src/ir/transforms/lower_host_tensor_collectives_pass.cpp
     src/ir/transforms/materialize_dist_tensor_ctx_pass.cpp
+    src/ir/transforms/materialize_valid_shape_symbols_pass.cpp
     src/ir/transforms/optimize_orch_tensors_pass.cpp
     src/ir/transforms/derive_call_directions_pass.cpp
     src/ir/transforms/auto_derive_task_dependencies_pass.cpp

--- a/docs/en/dev/passes/47-materialize_valid_shape_symbols.md
+++ b/docs/en/dev/passes/47-materialize_valid_shape_symbols.md
@@ -1,0 +1,120 @@
+# MaterializeValidShapeSymbols Pass
+
+Turns each device-kernel `valid_shape` symbol that the kernel cannot bind into a
+leading `Scalar[INDEX]` parameter, fed the caller's actual extent at every call
+site.
+
+## Overview
+
+A `pl.dynamic()` symbol used in a parameter's `pl.TensorView(valid_shape=...)`
+has no value inside a precompiled kernel:
+
+```python
+VALID = pl.dynamic("VALID")
+
+@pl.function(type=pl.FunctionType.InCore)
+def softmax_prepare(
+    sij: pl.Tensor[[Q, BLK], pl.FP32,
+                   pl.TensorView(valid_shape=[Q, VALID], layout=pl.TensorLayout.ND)],
+    out: pl.Out[pl.Tensor[[Q, BLK], pl.FP32]],
+): ...
+```
+
+`VALID` is neither a physical tensor dimension — those the kernel wrapper
+recovers from the runtime tensor's `shapes[]` — nor a scalar parameter. The
+runtime `Tensor` carries no valid extent (see `runtime/src/common/task_interface/tensor.h`),
+so the value has to arrive as an argument. Before this pass existed, PTO codegen
+logged `Variable VALID not found in MLIR mapping` and kept going, emitting an
+operand-less `%0 = arith.minsi , %c128_index : index` that surfaced much later as
+an opaque ptoas `error: expected SSA operand`.
+
+The pass rewrites the program so the existing scalar-parameter path carries the
+value end to end:
+
+1. For every device kernel (`InCore` / `AIC` / `AIV` / `Spmd`), find the symbols
+   read by a parameter's declared `valid_shape` that are not bound by any tensor
+   parameter's physical shape and are not already scalar parameters.
+2. Insert those symbols as `ParamDirection::In` parameters **at the front** of the
+   signature. The symbol Var itself becomes the parameter — `DynVar.unwrap()`
+   already builds it as a `Scalar[INDEX]` Var shared by every annotation naming
+   it, so every occurrence binds at once with no type rewrite.
+3. For every `Call` / `Submit` of such a kernel, read each symbol's value out of
+   the actual argument's `valid_shape` at the declared position and prepend it.
+4. When call-site `arg_directions` are already resolved, prepend matching
+   `ArgDirection::Scalar` entries.
+
+It runs last in the `Default` strategy: it only extends signatures and call
+argument lists, and by that point both are final, so no later pass has to account
+for the added parameter.
+
+## Why the Parameters Go First
+
+A symbol is read by the very parameter annotation that names it. The text form
+declares parameters left to right and Python evaluates annotations in the
+enclosing scope, so an appended parameter prints a signature that uses `VALID`
+before declaring it — which does not re-parse:
+
+```python
+# does not re-parse: NameError at def time
+def kernel(a: pl.Tensor[..., pl.TensorView(valid_shape=[M, VALID])],
+           VALID: pl.Scalar[pl.INDEX]): ...
+```
+
+Leading placement fixes the ordering. Signature order is otherwise free: PTOParam
+dispatches args as `[tensors..., scalars...]` regardless of it (see
+`PTOCodegen::GenerateFunction`).
+
+Two supporting rules keep the printed form round-tripping:
+
+- The Python printer keeps the `pl.dynamic()` declaration for a **parameter** that
+  is read inside a parameter's **valid_shape**, so the annotation resolves at def
+  time. A body-local var in a valid_shape, and a parameter read as a *physical*
+  dim, both stay undeclared (issue #854).
+- The parser re-points that `DynVar` at the parameter as soon as the parameter is
+  declared, so later annotations read the parameter's Var rather than a second,
+  unbound Var of the same name.
+
+## Binding Rule and Its Limits
+
+A symbol is bound **positionally**: the declared slot must name the symbol on its
+own, and the call site reads the actual argument's `valid_shape` at that same
+position.
+
+| Declared | Actual | Result |
+| -------- | ------ | ------ |
+| `valid_shape=[Q, VALID]` | `valid_shape=[16, valid_len]` | `VALID := valid_len` |
+| `valid_shape=[Q, VALID * 2]` | `valid_shape=[16, n]` | rejected — cannot invert |
+| `VALID` in two params, actuals disagree | — | rejected — one symbol, two extents |
+
+Compound slots are rejected rather than inverted: a wrong valid extent silently
+reads or writes the wrong region. The remedy is to name the symbol bare in some
+parameter's `valid_shape`, or to pass the extent as a `pl.Scalar[pl.INDEX]`
+parameter and use it in `pl.load(..., valid_shape=[...])`.
+
+## Result
+
+```mlir
+func.func @softmax_prepare(%arg0: !pto.ptr<f32>, %arg1: !pto.ptr<f32>,
+                           %arg2: index, %arg3: index, %arg4: index) {
+  %0 = arith.minsi %arg2, %c128_index : index      // %arg2 == VALID
+  %t = pto.alloc_tile addr = %c0_i64 valid_row = %c16_index valid_col = %0 : ...
+```
+
+and orchestration passes the caller's extent at launch:
+
+```cpp
+params_t0.add_scalar(valid_len);
+```
+
+## Backstop
+
+`PTOCodegen::GetVarName` fails with an actionable `ValueError` naming the symbol
+and its originating parameter if any symbol still reaches codegen unbound — for
+instance under a custom pass list that omits this pass. It never emits an empty
+operand.
+
+## See Also
+
+- [43-materialize_dist_tensor_ctx.md](43-materialize_dist_tensor_ctx.md) — same
+  signature-and-call-site shape, for `CommCtxType`
+- [00-pass_manager.md](00-pass_manager.md) — pass ordering

--- a/docs/en/dev/passes/index.md
+++ b/docs/en/dev/passes/index.md
@@ -64,6 +64,7 @@ a pipeline pass at all.
 | 44 | [MaterializeRuntimeScopes](44-materialize_runtime_scopes.md) | Inserts AUTO `RuntimeScopeStmt` nodes so orchestration codegen emits `PTO2_SCOPE` 1:1 |
 | 45 | [ClassifyIterArgCarry](45-classify_iter_arg_carry.md) | Classifies each orchestration `ForStmt` iter_arg as a trivial alias or a materialised rebind carry |
 | 46 | [InsertCommFence](46-insert_comm_fence.md) | Inserts a whole-tensor `system.cacheinvalid` + GM `system.fence` between each publishing write and the `pld.system.notify` that releases it |
+| 47 | [MaterializeValidShapeSymbols](47-materialize_valid_shape_symbols.md) | Turns each device-kernel `valid_shape` symbol the kernel cannot bind into a leading `Scalar[INDEX]` parameter, fed the caller's actual valid extent |
 
 ## Outside the default pipeline
 

--- a/docs/zh/dev/passes/47-materialize_valid_shape_symbols.md
+++ b/docs/zh/dev/passes/47-materialize_valid_shape_symbols.md
@@ -1,0 +1,108 @@
+# MaterializeValidShapeSymbols Pass
+
+将设备 kernel 中无法绑定的 `valid_shape` 符号转换为前置的 `Scalar[INDEX]`
+参数，并在每个调用点传入调用方的实际有效范围（valid extent）。
+
+## 概述
+
+在参数的 `pl.TensorView(valid_shape=...)` 中使用的 `pl.dynamic()` 符号，在预编译
+kernel 内部没有取值：
+
+```python
+VALID = pl.dynamic("VALID")
+
+@pl.function(type=pl.FunctionType.InCore)
+def softmax_prepare(
+    sij: pl.Tensor[[Q, BLK], pl.FP32,
+                   pl.TensorView(valid_shape=[Q, VALID], layout=pl.TensorLayout.ND)],
+    out: pl.Out[pl.Tensor[[Q, BLK], pl.FP32]],
+): ...
+```
+
+`VALID` 既不是物理张量维度（那类符号由 kernel wrapper 从运行时 tensor 的
+`shapes[]` 还原），也不是标量参数。运行时 `Tensor` 并不携带有效范围信息（参见
+`runtime/src/common/task_interface/tensor.h`），因此该值必须以参数形式传入。在本
+pass 出现之前，PTO codegen 会打印 `Variable VALID not found in MLIR mapping` 并继续
+执行，生成缺少操作数的 `%0 = arith.minsi , %c128_index : index`，最终在很靠后的阶段
+表现为难以定位的 ptoas `error: expected SSA operand`。
+
+本 pass 将程序改写为复用既有的标量参数通路，端到端传递该值：
+
+1. 对每个设备 kernel（`InCore` / `AIC` / `AIV` / `Spmd`），找出参数声明的
+   `valid_shape` 中读取、且未被任何张量参数的物理 shape 绑定、也不是已有标量参数的
+   符号。
+2. 将这些符号以 `ParamDirection::In` 插入签名**最前面**。符号 Var 本身即成为参数
+   —— `DynVar.unwrap()` 已将其构造为 `Scalar[INDEX]` Var，并由所有引用它的注解共享，
+   因此一次插入即可绑定全部出现位置，无需重写类型。
+3. 对该 kernel 的每个 `Call` / `Submit`，从实参在对应声明位置的 `valid_shape` 中读取
+   取值并前置到参数列表。
+4. 若调用点的 `arg_directions` 已解析，则同步前置对应的 `ArgDirection::Scalar`。
+
+该 pass 在 `Default` 策略中最后运行：它只扩展签名与调用实参列表，而此时两者均已定型，
+因此后续 pass 无需感知新增参数。
+
+## 为何参数置于最前
+
+符号正是被命名它的那个参数注解所读取。文本形式按从左到右声明参数，而 Python 在外层
+作用域中求值注解，因此追加到末尾会打印出「先使用 `VALID`、后声明 `VALID`」的签名，
+无法重新解析：
+
+```python
+# 无法重新解析：def 时抛出 NameError
+def kernel(a: pl.Tensor[..., pl.TensorView(valid_shape=[M, VALID])],
+           VALID: pl.Scalar[pl.INDEX]): ...
+```
+
+前置放置解决了顺序问题。除此之外签名顺序是自由的：PTOParam 按
+`[tensors..., scalars...]` 分发实参，与签名顺序无关（参见
+`PTOCodegen::GenerateFunction`）。
+
+另有两条配套规则保证打印结果可往返（round-trip）：
+
+- Python printer 会为「被参数 **valid_shape** 读取的**参数**」保留 `pl.dynamic()`
+  声明，使注解在 def 时可解析。而 valid_shape 中的函数体局部变量、以及被当作**物理**
+  维度读取的参数，仍不生成声明（issue #854）。
+- Parser 在参数声明后立即将该 `DynVar` 重新指向该参数，使后续注解读取到参数的 Var，
+  而不是另一个同名且未绑定的 Var。
+
+## 绑定规则及其边界
+
+符号按**位置**绑定：声明位置必须单独命名该符号，调用点从实参 `valid_shape` 的同一
+位置读取取值。
+
+| 声明 | 实参 | 结果 |
+| ---- | ---- | ---- |
+| `valid_shape=[Q, VALID]` | `valid_shape=[16, valid_len]` | `VALID := valid_len` |
+| `valid_shape=[Q, VALID * 2]` | `valid_shape=[16, n]` | 拒绝 —— 无法求逆 |
+| `VALID` 出现在两个参数中且实参不一致 | — | 拒绝 —— 一个符号两个取值 |
+
+复合表达式选择拒绝而非求逆：错误的有效范围会静默地读写错误区域。解决办法是在某个参数的
+`valid_shape` 中单独命名该符号，或将其作为 `pl.Scalar[pl.INDEX]` 参数传入并在
+`pl.load(..., valid_shape=[...])` 中使用。
+
+## 结果
+
+```mlir
+func.func @softmax_prepare(%arg0: !pto.ptr<f32>, %arg1: !pto.ptr<f32>,
+                           %arg2: index, %arg3: index, %arg4: index) {
+  %0 = arith.minsi %arg2, %c128_index : index      // %arg2 == VALID
+  %t = pto.alloc_tile addr = %c0_i64 valid_row = %c16_index valid_col = %0 : ...
+```
+
+orchestration 在下发任务时传入调用方的取值：
+
+```cpp
+params_t0.add_scalar(valid_len);
+```
+
+## 兜底检查
+
+若仍有符号未绑定就到达 codegen（例如自定义 pass 列表省略了本 pass），
+`PTOCodegen::GetVarName` 会抛出可操作的 `ValueError`，指明符号名及其来源参数，
+绝不会输出空操作数。
+
+## 参见
+
+- [43-materialize_dist_tensor_ctx.md](43-materialize_dist_tensor_ctx.md) ——
+  针对 `CommCtxType` 的同类「签名 + 调用点」改写
+- [00-pass_manager.md](00-pass_manager.md) —— pass 顺序

--- a/docs/zh/dev/passes/index.md
+++ b/docs/zh/dev/passes/index.md
@@ -61,6 +61,7 @@ pass；`91` 及以后保留给"在多个位置运行的 pass"以及"根本不是
 | 44 | [MaterializeRuntimeScopes](44-materialize_runtime_scopes.md) | 插入 AUTO `RuntimeScopeStmt` 使编排 codegen 能 1:1 发射 `PTO2_SCOPE` |
 | 45 | [ClassifyIterArgCarry](45-classify_iter_arg_carry.md) | 把编排层 `ForStmt` 的每个 iter_arg 分类为平凡别名或需物化的重绑定携带 |
 | 46 | [InsertCommFence](46-insert_comm_fence.md) | 在每个发布性写入与释放它的 `pld.system.notify` 之间插入整张 tensor 的 `system.cacheinvalid` + GM `system.fence` |
+| 47 | [MaterializeValidShapeSymbols](47-materialize_valid_shape_symbols.md) | 将设备 kernel 中无法绑定的 `valid_shape` 符号转换为前置的 `Scalar[INDEX]` 参数，并传入调用方的实际有效范围 |
 
 ## 默认流水线之外
 

--- a/include/pypto/codegen/pto/pto_codegen.h
+++ b/include/pypto/codegen/pto/pto_codegen.h
@@ -150,6 +150,24 @@ class PTOCodegen : public CodegenBase {
    */
   void EmitStructural(const std::string& line);
 
+  /**
+   * @brief Resolve @p var to its MLIR SSA name, or "" when nothing binds it.
+   *
+   * The lenient counterpart to GetVarName, for the rare caller that can
+   * genuinely proceed without a binding. GetVarName is the default: an
+   * unresolvable symbol there is a user error, and emitting an empty operand
+   * would produce MLIR that only fails much later inside ptoas.
+   */
+  [[nodiscard]] std::string LookupVarName(const ir::VarPtr& var) const;
+
+  /**
+   * @brief Explain why @p var has no SSA binding, for the GetVarName failure.
+   *
+   * Names the parameter whose valid_shape introduced the symbol when the origin
+   * is known, so the diagnostic points at editable DSL source.
+   */
+  [[nodiscard]] std::string DescribeUnbindableSymbol(const ir::VarPtr& var) const;
+
   // PTO-specific helper methods for operator codegen functions
 
   /**
@@ -890,6 +908,11 @@ class PTOCodegen : public CodegenBase {
     std::string constants_indent;  ///< Fixed indent for constants_section (set once per function)
 
     std::map<const ir::Var*, std::string> var_to_mlir;
+    /// Symbols that appear ONLY in a tensor parameter's valid_shape, mapped to
+    /// that parameter's name. Such a symbol is bound at the call site, so a
+    /// precompiled kernel never receives it — read on the GetVarName failure
+    /// path to name the parameter the unbindable symbol came from.
+    std::map<const ir::Var*, std::string> valid_shape_symbol_origin;
     std::map<const ir::Var*, std::string> tensor_to_view;
     std::map<const ir::Var*, std::string> tensor_to_base_ptr;  ///< tensor var → base ptr SSA
     std::map<std::string, std::string>
@@ -987,6 +1010,7 @@ class PTOCodegen : public CodegenBase {
       constants_indent.clear();
 
       var_to_mlir.clear();
+      valid_shape_symbol_origin.clear();
       tensor_to_view.clear();
       tensor_to_base_ptr.clear();
       view_ssa_to_base_ptr.clear();

--- a/include/pypto/ir/transforms/pass_properties.h
+++ b/include/pypto/ir/transforms/pass_properties.h
@@ -53,6 +53,12 @@ inline const PassProperties kMaterializeDistTensorCtxProperties{
     .required = {IRProperty::CommDomainScopesMaterialized},
     .produced = {IRProperty::CommDomainScopesMaterialized}};
 
+// -- MaterializeValidShapeSymbols pass (runs last) ---------------------------
+//    Prepends a Scalar[INDEX] parameter per device-kernel valid_shape symbol that
+//    the kernel cannot bind, and passes the actual extent at every call site.
+//    Signature-and-call rewrite only; touches no structural property.
+inline const PassProperties kMaterializeValidShapeSymbolsProperties{};
+
 // -- MaterializeRuntimeScopes pass (runs last, after the final Simplify) ------
 //    Inserts explicit AUTO RuntimeScopeStmt nodes for the orchestration function
 //    body and for/if bodies so codegen emits PTO2_SCOPE 1:1 from the IR.

--- a/include/pypto/ir/transforms/passes.h
+++ b/include/pypto/ir/transforms/passes.h
@@ -252,6 +252,21 @@ Pass LowerHostTensorCollectives();
 Pass MaterializeDistTensorCtx();
 
 /**
+ * @brief Materialize a scalar parameter per unbindable device-kernel valid_shape symbol.
+ *
+ * A ``pl.dynamic()`` symbol named only in a parameter's
+ * ``pl.TensorView(valid_shape=...)`` is neither a physical tensor dimension (which
+ * the kernel wrapper recovers from the runtime tensor's ``shapes[]``) nor a scalar
+ * parameter, so a precompiled kernel has no value for it. This pass adds the
+ * symbol itself as a *leading* ``Scalar[INDEX]`` parameter and passes the caller's
+ * actual extent at every call/submit site, lowering the annotation form into the
+ * scalar-parameter form the backend already supports. The parameter leads because
+ * the text form declares parameters left to right, and the annotation that names
+ * the symbol has to resolve to it.
+ */
+Pass MaterializeValidShapeSymbols();
+
+/**
  * @brief Create a loop unrolling pass
  *
  * Expands ForStmt nodes with ForKind::Unroll into inlined copies of the loop

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -284,6 +284,7 @@ nav:
           - en/dev/passes/44-materialize_runtime_scopes.md
           - en/dev/passes/45-classify_iter_arg_carry.md
           - en/dev/passes/46-insert_comm_fence.md
+          - en/dev/passes/47-materialize_valid_shape_symbols.md
           - en/dev/passes/91-utility_passes.md
           - en/dev/passes/92-diagnostics.md
           - en/dev/passes/99-verifier.md

--- a/python/bindings/modules/passes.cpp
+++ b/python/bindings/modules/passes.cpp
@@ -565,6 +565,12 @@ void BindPass(nb::module_& m) {
              "Lower host-level pld.tensor.allreduce calls to builtin tensor collective dispatches.");
   passes.def("materialize_dist_tensor_ctx", &pass::MaterializeDistTensorCtx,
              "Materialize CommCtx parameters and arguments for DistributedTensor function parameters.");
+  passes.def("materialize_valid_shape_symbols", &pass::MaterializeValidShapeSymbols,
+             "Materialize a Scalar[INDEX] parameter per unbindable device-kernel valid_shape symbol.\n\n"
+             "A pl.dynamic() symbol named only in a parameter's pl.TensorView(valid_shape=...) is\n"
+             "neither a physical tensor dimension nor a scalar parameter, so a precompiled kernel\n"
+             "never receives it. Adds the symbol as a leading Scalar[INDEX] parameter and passes\n"
+             "the caller's actual extent at every call/submit site.");
   passes.def("stamp_tfree_split", &pass::StampTfreeSplit,
              "Copy each cross-core tpop's split/pipe-id onto its matching tfree op so codegen\n"
              "reads them from the op directly. Covers mixed-kernel and explicit AIC/AIV tfrees.");

--- a/python/pypto/ir/pass_manager.py
+++ b/python/pypto/ir/pass_manager.py
@@ -263,6 +263,13 @@ class PassManager:
             # adjacent to their notify through codegen; additive InCore-only
             # insertion that touches no property.
             passes.insert_comm_fence,
+            # Give every device-kernel valid_shape symbol that the kernel cannot
+            # bind (not a physical tensor dim, not a scalar param) a leading
+            # Scalar[INDEX] parameter, fed from the caller's actual valid extent.
+            # Runs dead last: it only extends signatures and call arg lists, and
+            # by here both are final, so no later pass has to account for the
+            # appended parameter.
+            passes.materialize_valid_shape_symbols,
         )
         return tensor_prefix_passes + tensor_only_passes + tile_pto_passes
 

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -29,6 +29,7 @@ from pypto.language.op import system_ops as _dsl_system
 from pypto.language.op import tensor_ops as _dsl_tensor
 from pypto.language.op import tile_ops as _dsl_tile
 from pypto.language.optimizations import SPLIT_SLOT_NUM_DEPRECATION
+from pypto.language.typing.dynamic import DynVar
 from pypto.pypto_core import DataType, ir
 from pypto.pypto_core import arith as _arith
 
@@ -268,6 +269,35 @@ def _get_source_valid_shape(source_type: ir.Type) -> list[ir.Expr] | None:
             return None
         return list(view.valid_shape)
     return None
+
+
+def _collect_type_symbol_ids(param_type: ir.Type) -> set[int]:
+    """Return ``id()`` of every Var read by a parameter type's shape metadata.
+
+    Used to detect a scalar parameter that shadows a ``pl.dynamic()`` symbol an
+    earlier parameter annotation already resolved, which cannot be rebound.
+    """
+    symbol_ids: set[int] = set()
+
+    def walk(expr: ir.Expr | None) -> None:
+        if expr is None:
+            return
+        if isinstance(expr, ir.Var):
+            symbol_ids.add(id(expr))
+            return
+        for attr in ("left", "right", "operand"):
+            operand = getattr(expr, attr, None)
+            if isinstance(operand, ir.Expr):
+                walk(operand)
+
+    if isinstance(param_type, ir.TensorType):
+        for dim in param_type.shape:
+            walk(dim)
+        view = param_type.tensor_view
+        if view is not None:
+            for dim in list(view.valid_shape) + list(view.stride):
+                walk(dim)
+    return symbol_ids
 
 
 def _shape_exprs_match(lhs: Sequence[ir.Expr], rhs: Sequence[ir.Expr]) -> bool:
@@ -826,6 +856,67 @@ class ASTParser:
             self._loop_kind_stack.pop()
             self._split_aiv_mode_stack.pop()
 
+    def _bind_dynvar_to_scalar_param(
+        self,
+        param_name: str,
+        param_type: ir.Type,
+        param_var: ir.Var,
+        param_span: ir.Span,
+        symbols_used_so_far: set[int],
+    ) -> None:
+        """Re-point a same-named ``pl.dynamic()`` symbol at this scalar parameter.
+
+        A ``pl.Scalar[pl.INDEX]`` parameter that shadows a ``pl.dynamic()`` symbol
+        of the same name IS that symbol. ``MaterializeValidShapeSymbols`` turns an
+        unbindable valid_shape symbol into a parameter, and the printer keeps its
+        ``pl.dynamic()`` declaration so the annotations naming it still resolve
+        (Python evaluates annotations in the enclosing scope, before parameters
+        exist). Without this, the annotation would read a second, unbound Var of
+        the same name.
+
+        Only ``INDEX`` scalars qualify: a ``DynVar`` is an INDEX-valued dimension,
+        so rebinding one to, say, a ``pl.Scalar[pl.FP32]`` parameter would put an
+        FP32 Var in a shape expression.
+
+        Annotations resolve in declaration order, so the parameter has to precede
+        every annotation that names it. When an earlier parameter's type already
+        read the symbol, rebinding now would leave that earlier type pointing at a
+        different Var — which later reads as an unbound symbol and materializes a
+        second, redundant argument. Reject that ordering instead.
+
+        Args:
+            param_name: Parameter name as written in the signature
+            param_type: Resolved parameter type
+            param_var: The Var just created for the parameter
+            param_span: Span of the parameter, for diagnostics
+            symbols_used_so_far: ``id()`` of every Var already read by an earlier
+                parameter's type annotation
+
+        Raises:
+            ParserTypeError: If an earlier parameter annotation already read the
+                shadowed symbol.
+        """
+        declared = self.expr_evaluator.closure_vars.get(param_name)
+        if not isinstance(declared, DynVar):
+            return
+        if not isinstance(param_type, ir.ScalarType) or param_type.dtype != DataType.INDEX:
+            return
+        previous = declared._ir_var
+        if previous is not None and id(previous) in symbols_used_so_far:
+            raise ParserTypeError(
+                f"Parameter '{param_name}' shadows the dynamic symbol '{param_name}', "
+                f"which an earlier parameter's type annotation already uses",
+                span=param_span,
+                hint=(
+                    f"Declare '{param_name}: pl.Scalar[pl.INDEX]' before the parameter whose "
+                    f"pl.TensorView(valid_shape=...) names it, so the annotation resolves to "
+                    f"the parameter"
+                ),
+            )
+        declared._ir_var = param_var
+        declared.expr = param_var
+        self.expr_evaluator.dynvar_cache[param_name] = param_var
+
     def parse_function(
         self,
         func_def: ast.FunctionDef,
@@ -889,6 +980,10 @@ class ASTParser:
             attrs=func_attrs,
             requires_runtime_binding=requires_runtime_binding,
         ) as f:
+            # Vars already read by an earlier parameter's type annotation, by id().
+            # A scalar parameter shadowing one of these arrives too late to bind it.
+            symbols_used_so_far: set[int] = set()
+
             # Parse parameters (skip 'self' if it's the first parameter without annotation)
             for arg in func_def.args.args:
                 param_name = arg.arg
@@ -909,6 +1004,11 @@ class ASTParser:
 
                 # Add parameter to function with direction
                 param_var = f.param(param_name, param_type, param_span, direction=param_direction)
+
+                self._bind_dynvar_to_scalar_param(
+                    param_name, param_type, param_var, param_span, symbols_used_so_far
+                )
+                symbols_used_so_far.update(_collect_type_symbol_ids(param_type))
 
                 # A bare ``pl.dynamic()`` Var in a tensor param's shape names that
                 # argument's runtime extent. Orchestration codegen defines exactly

--- a/python/pypto/pypto_core/passes.pyi
+++ b/python/pypto/pypto_core/passes.pyi
@@ -699,6 +699,16 @@ def lower_host_tensor_collectives() -> Pass:
 def materialize_dist_tensor_ctx() -> Pass:
     """Materialize CommCtx parameters and arguments for DistributedTensor function parameters."""
 
+def materialize_valid_shape_symbols() -> Pass:
+    """Materialize a Scalar[INDEX] parameter per unbindable device-kernel valid_shape symbol.
+
+    A ``pl.dynamic()`` symbol named only in a parameter's
+    ``pl.TensorView(valid_shape=...)`` is neither a physical tensor dimension nor a
+    scalar parameter, so a precompiled kernel never receives it. Adds the symbol
+    as a leading ``Scalar[INDEX]`` parameter and passes the caller's actual extent
+    at every call/submit site.
+    """
+
 def stamp_tfree_split() -> Pass:
     """Copy each cross-core tpop's split/pipe-id onto its matching tfree op.
 
@@ -971,6 +981,7 @@ __all__ = [
     "simplify",
     "lower_composite_ops",
     "materialize_dist_tensor_ctx",
+    "materialize_valid_shape_symbols",
     "flatten_call_expr",
     "inline_functions",
     "normalize_stmt_structure",

--- a/src/codegen/pto/pto_codegen.cpp
+++ b/src/codegen/pto/pto_codegen.cpp
@@ -46,11 +46,13 @@
 #include "pypto/ir/span.h"
 #include "pypto/ir/stmt.h"
 #include "pypto/ir/tile_view_semantics.h"
+#include "pypto/ir/transforms/utils/auto_name_utils.h"
 #include "pypto/ir/transforms/utils/memref_utils.h"
 #include "pypto/ir/transforms/utils/op_predicates.h"
 #include "pypto/ir/transforms/utils/transform_utils.h"
 #include "pypto/ir/transforms/utils/var_collectors.h"
 #include "pypto/ir/type.h"
+#include "pypto/ir/type_inference.h"
 
 namespace pypto {
 namespace codegen {
@@ -769,6 +771,35 @@ void PTOCodegen::GenerateFunction(const FunctionPtr& func) {
   // params on the MLIR signature (Site B further down) -- a single source of
   // truth keeps the two in lockstep.
   const std::vector<VarPtr> dyn_vars = CollectTensorShapeDynVars(func);
+
+  // Attribute every symbol that appears in a parameter's valid_shape but NOT in
+  // any physical shape to the parameter that declares it. Such a symbol gets no
+  // trailing %argN slot (CollectTensorShapeDynVars walks shape_ only) and is
+  // bound at the call site, so the kernel cannot materialize it. Recording the
+  // origin here lets GetVarName name the parameter if the symbol ever reaches
+  // an emitted expression.
+  {
+    std::set<const ir::Var*> shape_bound;
+    for (const auto& dyn_var : dyn_vars) shape_bound.insert(dyn_var.get());
+    for (const auto& param : func->params_) {
+      auto tensor_type = ir::AsTensorTypeLike(param->GetType());
+      if (!tensor_type) continue;
+      std::vector<VarPtr> valid_vars;
+      std::set<const ir::Var*> seen;
+      for (const auto& dim : ir::GetEffectiveTensorValidShape(*tensor_type)) {
+        CollectVarsFromShapeExprImpl(dim, seen, valid_vars);
+      }
+      // Report the author's parameter name, not its SSA-renamed form: the
+      // diagnostic points at DSL source the user can actually edit.
+      std::string param_name = ir::auto_name::GetCompatibleBaseName(param->name_hint_);
+      if (param_name.empty()) param_name = param->name_hint_;
+      for (const auto& valid_var : valid_vars) {
+        if (shape_bound.count(valid_var.get()) == 0) {
+          fs_.valid_shape_symbol_origin.emplace(valid_var.get(), param_name);
+        }
+      }
+    }
+  }
 
   // Reserve %argN names upfront so NewNamedTemp never collides with them
   for (size_t i = 0; i < func->params_.size(); i++) {
@@ -2054,7 +2085,7 @@ void PTOCodegen::VisitStmt_(const AssignStmtPtr& op) {
       // same shape the `s = pl.mul(...)`-style yield (no bare alias) already
       // gets. Under PyPTO (emit_tile_addr_) the baked address already aliases
       // the two allocs, so this is a no-op there and is left untouched.
-      const std::string rhs_ssa = GetVarName(rhs_var);
+      const std::string rhs_ssa = LookupVarName(rhs_var);
       if (!rhs_ssa.empty()) {
         BindVarToMlir(op->var_, rhs_ssa);
         return;
@@ -2191,7 +2222,7 @@ void PTOCodegen::BindVarToMemRef(const VarPtr& var, const ir::Var* base_ptr) {
   fs_.var_to_memref[GetVarKey(var)] = base_ptr;
 }
 
-std::string PTOCodegen::GetVarName(const VarPtr& var) const {
+std::string PTOCodegen::LookupVarName(const VarPtr& var) const {
   auto key = GetVarKey(var);
   auto it = fs_.var_to_mlir.find(key);
   if (it != fs_.var_to_mlir.end()) {
@@ -2212,8 +2243,34 @@ std::string PTOCodegen::GetVarName(const VarPtr& var) const {
       return mlir_name;
     }
   }
-  LOG_ERROR << "Variable " << var->name_hint_ << " not found in MLIR mapping";
   return "";
+}
+
+std::string PTOCodegen::DescribeUnbindableSymbol(const VarPtr& var) const {
+  auto origin = fs_.valid_shape_symbol_origin.find(GetVarKey(var));
+  if (origin != fs_.valid_shape_symbol_origin.end()) {
+    return "it appears only in the valid_shape of parameter '" + origin->second +
+           "', and MaterializeValidShapeSymbols did not turn it into a parameter (that pass runs "
+           "last in the Default strategy — a custom pass list that omits it leaves the symbol "
+           "unbound)";
+  }
+  return "it is not a physical tensor dimension, a scalar parameter, or a loop variable of this "
+         "kernel";
+}
+
+std::string PTOCodegen::GetVarName(const VarPtr& var) const {
+  // An unresolvable symbol must fail here. Emitting an empty operand instead
+  // produces MLIR that ptoas rejects with an opaque "expected SSA operand"
+  // several stages downstream, far from the annotation that caused it.
+  std::string name = LookupVarName(var);
+  CHECK_SPAN(!name.empty(), var->span_)
+      << "PTO codegen cannot materialize symbol '" << var->name_hint_ << "' in function '"
+      << (fs_.current_function ? fs_.current_function->name_ : "<unknown>")
+      << "': " << DescribeUnbindableSymbol(var)
+      << ". Pass the extent as a pl.Scalar[pl.INDEX] parameter and use it in "
+         "pl.load(..., valid_shape=[...]) instead of naming it in the parameter's "
+         "pl.TensorView(valid_shape=...) annotation.";
+  return name;
 }
 
 std::string PTOCodegen::NewTemp() {

--- a/src/ir/transforms/materialize_valid_shape_symbols_pass.cpp
+++ b/src/ir/transforms/materialize_valid_shape_symbols_pass.cpp
@@ -1,0 +1,352 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <cstddef>
+#include <map>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include "pypto/core/logging.h"
+#include "pypto/ir/expr.h"
+#include "pypto/ir/function.h"
+#include "pypto/ir/kind_traits.h"
+#include "pypto/ir/program.h"
+#include "pypto/ir/scalar_expr.h"
+#include "pypto/ir/span.h"
+#include "pypto/ir/transforms/base/mutator.h"
+#include "pypto/ir/transforms/pass_properties.h"
+#include "pypto/ir/transforms/passes.h"
+#include "pypto/ir/transforms/printer.h"
+#include "pypto/ir/type.h"
+#include "pypto/ir/type_inference.h"
+
+namespace pypto {
+namespace ir {
+
+namespace {
+
+/// A device kernel's valid_shape symbol that nothing in the kernel can bind,
+/// together with the declared parameter slots that name it.
+///
+/// `symbol` is the `pl.dynamic()` Var itself. `DynVar.unwrap()` already builds it
+/// as a `Scalar[INDEX]` Var shared by every annotation that mentions it, so
+/// appending it to `params_` binds every occurrence at once — no type rewrite.
+struct ValidShapeSymbol {
+  VarPtr symbol;
+  /// (tensor param index, position within that parameter's valid_shape). Every
+  /// entry names the symbol *bare*, so the call site reads the actual extent
+  /// straight out of the argument's valid_shape at the same position.
+  std::vector<std::pair<size_t, size_t>> slots;
+};
+
+struct FunctionValidShapePlan {
+  std::vector<ValidShapeSymbol> symbols;  ///< deterministic: declaration order
+};
+
+/// PTO codegen compiles these once and launches them from orchestration, so a
+/// symbol they do not receive as an argument has no value at run time.
+[[nodiscard]] bool IsDeviceKernel(const FunctionPtr& func) {
+  if (!func) return false;
+  switch (func->func_type_) {
+    case FunctionType::InCore:
+    case FunctionType::AIC:
+    case FunctionType::AIV:
+    case FunctionType::Spmd:
+      return true;
+    default:
+      return false;
+  }
+}
+
+/// Collect the Vars a shape/valid_shape expression reads, in first-seen order.
+void CollectShapeVars(const ExprPtr& expr, std::unordered_set<const Var*>* seen, std::vector<VarPtr>* out) {
+  if (!expr) return;
+  if (auto var = AsVarLike(expr)) {
+    if (seen->insert(var.get()).second) out->push_back(var);
+    return;
+  }
+  if (auto binary = As<BinaryExpr>(expr)) {
+    CollectShapeVars(binary->left_, seen, out);
+    CollectShapeVars(binary->right_, seen, out);
+    return;
+  }
+  if (auto unary = As<UnaryExpr>(expr)) {
+    CollectShapeVars(unary->operand_, seen, out);
+    return;
+  }
+  if (auto call = As<Call>(expr)) {
+    for (const auto& arg : call->args_) CollectShapeVars(arg, seen, out);
+    return;
+  }
+  if (auto tget = As<TupleGetItemExpr>(expr)) {
+    CollectShapeVars(tget->tuple_, seen, out);
+  }
+  // Constants and anything else contribute no symbol.
+}
+
+/// Symbols the kernel can already resolve: physical tensor dimensions (the
+/// wrapper recovers those from the runtime tensor's `shapes[]`) and its own
+/// scalar parameters.
+[[nodiscard]] std::unordered_set<const Var*> CollectBoundSymbols(const FunctionPtr& func) {
+  std::unordered_set<const Var*> bound;
+  for (const auto& param : func->params_) {
+    auto tensor_type = AsTensorTypeLike(param->GetType());
+    if (!tensor_type) {
+      bound.insert(param.get());
+      continue;
+    }
+    std::unordered_set<const Var*> seen;
+    std::vector<VarPtr> vars;
+    for (const auto& dim : tensor_type->shape_) CollectShapeVars(dim, &seen, &vars);
+    for (const auto& var : vars) bound.insert(var.get());
+  }
+  return bound;
+}
+
+/// The valid_shape the author declared on a parameter, or nullptr when the
+/// parameter is fully valid. Deliberately NOT GetEffectiveTensorValidShape:
+/// that substitutes the physical shape, whose symbols are already bound.
+[[nodiscard]] const std::vector<ExprPtr>* GetDeclaredValidShape(const ExprPtr& /*unused*/,
+                                                                const TensorTypePtr& tensor_type) {
+  if (!tensor_type->tensor_view_.has_value()) return nullptr;
+  const auto& valid_shape = tensor_type->tensor_view_->valid_shape;
+  if (valid_shape.empty()) return nullptr;
+  return &valid_shape;
+}
+
+[[nodiscard]] FunctionValidShapePlan BuildPlan(const FunctionPtr& func) {
+  FunctionValidShapePlan plan;
+  if (!IsDeviceKernel(func)) return plan;
+
+  const auto bound = CollectBoundSymbols(func);
+
+  // Pass 1: every parameter slot that names an unbound symbol *bare* is a place
+  // the call site can read the value from.
+  std::unordered_map<const Var*, size_t> symbol_index;
+  for (size_t i = 0; i < func->params_.size(); ++i) {
+    auto tensor_type = AsTensorTypeLike(func->params_[i]->GetType());
+    if (!tensor_type) continue;
+    const auto* valid_shape = GetDeclaredValidShape(func->params_[i], tensor_type);
+    if (valid_shape == nullptr) continue;
+    for (size_t d = 0; d < valid_shape->size(); ++d) {
+      auto var = AsVarLike((*valid_shape)[d]);
+      if (!var || bound.count(var.get()) != 0) continue;
+      auto it = symbol_index.find(var.get());
+      if (it == symbol_index.end()) {
+        symbol_index.emplace(var.get(), plan.symbols.size());
+        plan.symbols.push_back(ValidShapeSymbol{var, {{i, d}}});
+      } else {
+        plan.symbols[it->second].slots.emplace_back(i, d);
+      }
+    }
+  }
+
+  // Pass 2: a symbol reachable only through a compound slot has no bare slot to
+  // read, so the call site cannot invert it. Reject rather than emit a kernel
+  // whose valid extent is silently wrong.
+  for (size_t i = 0; i < func->params_.size(); ++i) {
+    auto tensor_type = AsTensorTypeLike(func->params_[i]->GetType());
+    if (!tensor_type) continue;
+    const auto* valid_shape = GetDeclaredValidShape(func->params_[i], tensor_type);
+    if (valid_shape == nullptr) continue;
+    for (const auto& dim : *valid_shape) {
+      if (AsVarLike(dim)) continue;  // bare symbols handled above
+      std::unordered_set<const Var*> seen;
+      std::vector<VarPtr> vars;
+      CollectShapeVars(dim, &seen, &vars);
+      for (const auto& var : vars) {
+        if (bound.count(var.get()) != 0) continue;
+        CHECK_SPAN(symbol_index.count(var.get()) != 0, func->params_[i]->span_)
+            << "MaterializeValidShapeSymbols: parameter '" << func->params_[i]->name_hint_ << "' of kernel '"
+            << func->name_ << "' uses symbol '" << var->name_hint_
+            << "' only inside the compound valid_shape expression '" << PythonPrint(dim)
+            << "', so its value cannot be read from the call site. Declare the symbol on its own in "
+               "some parameter's pl.TensorView(valid_shape=...), or pass the extent as a "
+               "pl.Scalar[pl.INDEX] parameter and use it in pl.load(..., valid_shape=[...]).";
+      }
+    }
+  }
+  return plan;
+}
+
+/// Add one `Scalar[INDEX]` parameter per unbindable symbol, in plan order.
+///
+/// The new parameters go at the FRONT. A symbol is read by the very parameter
+/// annotations that name it (`a: Tensor[..., valid_shape=[M, VALID]]`), and the
+/// text form declares parameters left to right — appending would print a
+/// signature that uses `VALID` before declaring it, which does not re-parse.
+/// Signature order is otherwise free: PTOParam dispatches args as
+/// [tensors..., scalars...] regardless of it (see PTOCodegen::GenerateFunction).
+[[nodiscard]] FunctionPtr ExtendFunctionSignature(const FunctionPtr& func,
+                                                  const FunctionValidShapePlan& plan) {
+  if (plan.symbols.empty()) return func;
+  std::vector<VarPtr> params;
+  std::vector<ParamDirection> dirs;
+  params.reserve(func->params_.size() + plan.symbols.size());
+  dirs.reserve(func->param_directions_.size() + plan.symbols.size());
+  for (const auto& symbol : plan.symbols) {
+    params.push_back(symbol.symbol);
+    dirs.push_back(ParamDirection::In);
+  }
+  params.insert(params.end(), func->params_.begin(), func->params_.end());
+  dirs.insert(dirs.end(), func->param_directions_.begin(), func->param_directions_.end());
+  return std::make_shared<Function>(func->name_, std::move(params), std::move(dirs), func->return_types_,
+                                    func->body_, func->span_, func->func_type_, func->level_, func->role_,
+                                    func->attrs_, func->requires_runtime_binding_);
+}
+
+/// Mirror ExtendFunctionSignature's leading insertion on the call's directions.
+[[nodiscard]] std::vector<ArgDirection> PrependScalarArgDirections(const std::vector<ArgDirection>& old_dirs,
+                                                                   size_t count) {
+  std::vector<ArgDirection> dirs(count, ArgDirection::Scalar);
+  dirs.insert(dirs.end(), old_dirs.begin(), old_dirs.end());
+  return dirs;
+}
+
+/// Rewrites every call/submit of a planned kernel to pass the actual extents.
+class MaterializeValidShapeSymbolsMutator : public IRMutator {
+ public:
+  MaterializeValidShapeSymbolsMutator(ProgramPtr program,
+                                      const std::unordered_map<std::string, FunctionValidShapePlan>& plans)
+      : program_(std::move(program)), plans_(plans) {}
+
+ protected:
+  ExprPtr VisitExpr_(const CallPtr& op) override {
+    auto base = IRMutator::VisitExpr_(op);
+    auto call = As<Call>(base);
+    if (!call) return base;
+    const auto* plan = LookupPlan(call->op_);
+    if (plan == nullptr) return call;
+
+    auto new_args = PrependValidShapeArgs(*plan, call->args_, call->span_);
+    auto attrs = call->attrs_;
+    if (call->HasArgDirections()) {
+      attrs = WithArgDirectionsAttr(
+          std::move(attrs), PrependScalarArgDirections(call->GetArgDirections(), plan->symbols.size()));
+    }
+    return std::make_shared<Call>(call->op_, std::move(new_args), call->kwargs_, std::move(attrs),
+                                  call->GetType(), call->span_);
+  }
+
+  // Submit is a sibling call-like kind (pl.submit inside pl.manual_scope); a
+  // kernel launched there needs the same trailing extents.
+  ExprPtr VisitExpr_(const SubmitPtr& op) override {
+    auto base = IRMutator::VisitExpr_(op);
+    auto submit = As<Submit>(base);
+    if (!submit) return base;
+    const auto* plan = LookupPlan(submit->op_);
+    if (plan == nullptr) return submit;
+
+    auto new_args = PrependValidShapeArgs(*plan, submit->args_, submit->span_);
+    auto attrs = submit->attrs_;
+    if (submit->HasArgDirections()) {
+      attrs = WithArgDirectionsAttr(
+          std::move(attrs), PrependScalarArgDirections(submit->GetArgDirections(), plan->symbols.size()));
+    }
+    return std::make_shared<Submit>(submit->op_, std::move(new_args), submit->deps_, submit->kwargs_,
+                                    std::move(attrs), submit->GetType(), submit->span_, submit->core_num_,
+                                    submit->sync_start_, submit->allow_early_resolve_, submit->predicate_);
+  }
+
+ private:
+  [[nodiscard]] const FunctionValidShapePlan* LookupPlan(const OpPtr& op) const {
+    auto gvar = As<GlobalVar>(op);
+    if (!gvar || !program_) return nullptr;
+    auto callee = program_->GetFunction(gvar->name_);
+    if (!callee) return nullptr;
+    auto it = plans_.find(callee->name_);
+    return it == plans_.end() ? nullptr : &it->second;
+  }
+
+  /// Read each symbol's value out of the matching actual argument's valid_shape,
+  /// and place the values at the front to mirror ExtendFunctionSignature.
+  [[nodiscard]] std::vector<ExprPtr> PrependValidShapeArgs(const FunctionValidShapePlan& plan,
+                                                           const std::vector<ExprPtr>& old_args,
+                                                           const Span& span) const {
+    std::vector<ExprPtr> leading;
+    leading.reserve(plan.symbols.size());
+    for (const auto& symbol : plan.symbols) {
+      ExprPtr value = nullptr;
+      for (const auto& [param_idx, dim_idx] : symbol.slots) {
+        // Submit passes a positional prefix of the callee params, so a slot past
+        // the supplied args has no actual to read.
+        CHECK_SPAN(param_idx < old_args.size(), span)
+            << "MaterializeValidShapeSymbols: call does not supply argument " << param_idx
+            << ", which declares valid_shape symbol '" << symbol.symbol->name_hint_ << "'";
+        auto tensor_type = AsTensorTypeLike(old_args[param_idx]->GetType());
+        CHECK_SPAN(tensor_type, span)
+            << "MaterializeValidShapeSymbols: argument " << param_idx << " for valid_shape symbol '"
+            << symbol.symbol->name_hint_ << "' must be a tensor, got "
+            << old_args[param_idx]->GetType()->TypeName();
+        const auto& actual_valid = GetEffectiveTensorValidShape(*tensor_type);
+        CHECK_SPAN(dim_idx < actual_valid.size(), span)
+            << "MaterializeValidShapeSymbols: argument " << param_idx << " has valid_shape rank "
+            << actual_valid.size() << ", too short to supply '" << symbol.symbol->name_hint_
+            << "' at position " << dim_idx;
+        const ExprPtr& candidate = actual_valid[dim_idx];
+        // The same symbol declared in two slots must be given one value; binding
+        // it from the first slot alone would silently drop the disagreement.
+        CHECK_SPAN(value == nullptr || AreExprsEqual(value, candidate), span)
+            << "MaterializeValidShapeSymbols: symbol '" << symbol.symbol->name_hint_
+            << "' is declared in more than one parameter's valid_shape, but this call supplies "
+               "different extents ('"
+            << PythonPrint(value) << "' and '" << PythonPrint(candidate)
+            << "'). Pass arguments whose valid_shape agrees at those positions.";
+        if (value == nullptr) value = candidate;
+      }
+      INTERNAL_CHECK_SPAN(value, span)
+          << "Internal error: valid_shape symbol '" << symbol.symbol->name_hint_ << "' has no source slot";
+      leading.push_back(value);
+    }
+    leading.insert(leading.end(), old_args.begin(), old_args.end());
+    return leading;
+  }
+
+  ProgramPtr program_;
+  const std::unordered_map<std::string, FunctionValidShapePlan>& plans_;
+};
+
+[[nodiscard]] ProgramPtr TransformProgram(const ProgramPtr& program) {
+  std::unordered_map<std::string, FunctionValidShapePlan> plans;
+  for (const auto& [gvar, func] : program->functions_) {
+    auto plan = BuildPlan(func);
+    if (!plan.symbols.empty()) plans.emplace(func->name_, std::move(plan));
+  }
+  if (plans.empty()) return program;
+
+  std::map<GlobalVarPtr, FunctionPtr, GlobalVarPtrLess> extended;
+  for (const auto& [gvar, func] : program->functions_) {
+    auto it = plans.find(func->name_);
+    extended[gvar] = (it == plans.end()) ? func : ExtendFunctionSignature(func, it->second);
+  }
+  auto with_signatures = std::make_shared<Program>(std::move(extended), program->name_, program->span_);
+
+  MaterializeValidShapeSymbolsMutator mutator(with_signatures, plans);
+  return mutator.VisitProgram(with_signatures);
+}
+
+}  // namespace
+
+namespace pass {
+
+Pass MaterializeValidShapeSymbols() {
+  auto pass_func = [](const ProgramPtr& program) -> ProgramPtr { return TransformProgram(program); };
+  return CreateProgramPass(pass_func, "MaterializeValidShapeSymbols",
+                           kMaterializeValidShapeSymbolsProperties);
+}
+
+}  // namespace pass
+}  // namespace ir
+}  // namespace pypto

--- a/src/ir/transforms/python_printer.cpp
+++ b/src/ir/transforms/python_printer.cpp
@@ -2871,10 +2871,57 @@ static std::unordered_map<const Var*, std::string> CollectDynVarMapping(const Pr
     }
   }
 
+  // A parameter whose name is ALSO read inside a parameter *type annotation*
+  // still needs its pl.dynamic() declaration: Python evaluates annotations in the
+  // enclosing scope, before any parameter exists, so without the declaration the
+  // printed signature raises NameError on re-parse. MaterializeValidShapeSymbols
+  // produces exactly this shape — the valid_shape symbol becomes a scalar
+  // parameter while the tensor parameter's annotation keeps naming it — and the
+  // parser re-unifies the two (see ast_parser's DynVar re-point on f.param).
+  // Collected separately from the pass above: that one dedups through seen_ptrs,
+  // which would swallow every repeat occurrence.
+  // Deliberately narrow (issue #854 keeps the other two cases undeclared):
+  //   * a body-local var read in a valid_shape stays undeclared — it is defined
+  //     in the body, so the annotation resolves against the local;
+  //   * a param read as a *physical* dim stays undeclared — orchestration codegen
+  //     defines those symbols from the runtime tensor's shapes[].
+  // Only a param read in a valid_shape has neither escape, which is exactly what
+  // MaterializeValidShapeSymbols produces.
+  std::unordered_set<const Var*> read_in_param_types;
+  {
+    std::unordered_set<const Var*> param_vars;
+    for (const auto& [gvar, func] : program->functions_) {
+      for (const auto& param : func->params_) param_vars.insert(param.get());
+    }
+    std::function<void(const ExprPtr&)> collect_reads = [&](const ExprPtr& expr) {
+      if (!expr) return;
+      if (auto var = As<Var>(expr)) {
+        if (param_vars.count(var.get()) > 0) read_in_param_types.insert(var.get());
+      } else if (auto bin = As<BinaryExpr>(expr)) {
+        collect_reads(bin->left_);
+        collect_reads(bin->right_);
+      } else if (auto unary = As<UnaryExpr>(expr)) {
+        collect_reads(unary->operand_);
+      }
+    };
+    for (const auto& [gvar, func] : program->functions_) {
+      for (const auto& param : func->params_) {
+        // AsTensorTypeLike, not As<TensorType>: DistributedTensorType has its own
+        // ObjectKind and carries valid_shape symbols the same way.
+        auto tensor_type = AsTensorTypeLike(param->GetType());
+        if (!tensor_type || !tensor_type->tensor_view_.has_value()) continue;
+        for (const auto& dim : tensor_type->tensor_view_->valid_shape) collect_reads(dim);
+      }
+    }
+  }
+
   // Filter out locally-defined vars and function params: they should not get
-  // pl.dynamic() declarations — only truly free dimension variables should.
+  // pl.dynamic() declarations — only truly free dimension variables should, plus
+  // the params that a parameter annotation reads (see read_in_param_types above).
   dyn_var_ptrs.erase(std::remove_if(dyn_var_ptrs.begin(), dyn_var_ptrs.end(),
-                                    [&defined_vars](const Var* v) { return defined_vars.count(v) > 0; }),
+                                    [&defined_vars, &read_in_param_types](const Var* v) {
+                                      return defined_vars.count(v) > 0 && read_in_param_types.count(v) == 0;
+                                    }),
                      dyn_var_ptrs.end());
 
   // Phase 2: Assign unique printed names, disambiguating collisions.

--- a/tests/ut/codegen/distributed/test_distributed_pto_codegen.py
+++ b/tests/ut/codegen/distributed/test_distributed_pto_codegen.py
@@ -189,8 +189,15 @@ def test_remote_load_without_valid_shape_uses_source_valid_extent():
     assert "sizes = [%c1_index, %c8_index]" in remote_partition, remote_partition
 
 
-def test_remote_load_rejects_type_only_dynamic_partition_extent():
-    """A repeated type-only symbol is not a runtime codegen binding."""
+def test_remote_load_binds_type_only_dynamic_partition_extent():
+    """A type-only symbol becomes a runtime argument instead of being rejected.
+
+    Was ``..._rejects_...``: a symbol named only in a valid_shape used to have no
+    binding, so codegen refused it. MaterializeValidShapeSymbols now prepends it as
+    a Scalar[INDEX] parameter fed from the call site, so the partition extent is a
+    real SSA value. The ``shape_anchor`` trick in the next test remains valid; it
+    is simply no longer the only way to supply the extent.
+    """
     n = pl.dynamic("REMOTE_VALID_N")
 
     @pl.program
@@ -215,8 +222,15 @@ def test_remote_load_rejects_type_only_dynamic_partition_extent():
             )
             return pl.store(tile, [0, 0], out)
 
-    with pytest.raises(ValueError, match="depends on unbound symbol 'REMOTE_VALID_N'"):
-        _generate_mlir(P)
+    mlir = _generate_mlir(P)
+    assert "func.func @kernel" in mlir
+    # The symbol is a scalar parameter now, so the peer partition reads a real
+    # SSA value rather than an empty operand.
+    remote_partition = next(
+        line for line in mlir.splitlines() if "pto.partition_view" in line and "_peer" in line
+    )
+    assert re.search(r"sizes = \[%c1_index, %[A-Za-z0-9_.$]+\]", remote_partition), remote_partition
+    assert "sizes = [%c1_index, ]" not in remote_partition, remote_partition
 
 
 def test_remote_load_intersects_runtime_bound_dynamic_source_valid_extent():

--- a/tests/ut/codegen/test_dynamic_shape.py
+++ b/tests/ut/codegen/test_dynamic_shape.py
@@ -14,12 +14,14 @@
 # pyright: reportUndefinedVariable=false
 
 import pypto.language as pl
+import pytest
 from pypto import backend, codegen, ir
 from pypto.backend import BackendType
 from pypto.ir.pass_manager import OptimizationStrategy, PassManager
 
 M = pl.dynamic("M")
 N = pl.dynamic("N")
+VALID_ONLY = pl.dynamic("VALID_ONLY")
 
 
 @pl.program
@@ -268,7 +270,88 @@ def test_add_kernel_loop_dynamic_pto_codegen():
     assert "offsets = [, " not in mlir_code
 
 
-if __name__ == "__main__":
-    import pytest
+@pl.program
+class AddKernelTypeOnlyValidShape:
+    """valid_shape names a dyn symbol that exists only in the annotation.
 
+    VALID_ONLY is not a physical dimension and not a scalar parameter, so nothing
+    in the kernel binds it as written. MaterializeValidShapeSymbols appends it as
+    a trailing Scalar[INDEX] parameter so the extent arrives at run time.
+    """
+
+    @pl.function(type=pl.FunctionType.InCore)
+    def add_kernel(
+        self,
+        a: pl.Tensor[
+            [M, N],
+            pl.FP32,
+            pl.TensorView(valid_shape=[M, VALID_ONLY], layout=pl.TensorLayout.ND),
+        ],
+        output: pl.Tensor[[M, N], pl.FP32],
+    ) -> pl.Tensor[[M, N], pl.FP32]:
+        """Loads the full tile; the load intersects with the source valid region."""
+        a_tile = pl.load(a, [0, 0], [128, 128], target_memory=pl.MemorySpace.Vec)
+        result = pl.exp(a_tile)
+        return pl.store(result, [0, 0], output)
+
+
+def test_type_only_valid_shape_symbol_becomes_a_kernel_argument():
+    """A valid_shape-only symbol must reach codegen as a real runtime argument.
+
+    Regression: codegen used to log 'not found in MLIR mapping' and continue,
+    emitting an operand-less `arith.minsi , %c128_index : index` that surfaced
+    much later as an opaque ptoas 'expected SSA operand' parse error.
+    """
+    backend.reset_for_testing()
+    backend.set_backend_type(BackendType.Ascend910B)
+    func = AddKernelTypeOnlyValidShape.get_function("add_kernel")
+    assert func is not None
+    program = ir.Program([func], "test_type_only_valid_shape", ir.Span.unknown())
+    optimized = PassManager.get_strategy(OptimizationStrategy.Default).run_passes(program)
+
+    gen = codegen.PTOCodegen()
+    mlir_code = gen.generate(optimized)
+
+    # VALID_ONLY is a scalar param, so it precedes the M/N dyn-dim args:
+    # [tensors..., scalars...] then the trailing dyn dims.
+    assert "%arg2: index, %arg3: index, %arg4: index" in mlir_code
+    # The load's valid extent is min(VALID_ONLY, 128) and both operands are real.
+    assert "arith.minsi %arg2, %c128_index" in mlir_code
+    # No operand may be blank -- that is the malformed form this guards against.
+    assert "arith.minsi ," not in mlir_code
+    assert "valid_col = %0" in mlir_code
+
+
+def test_valid_shape_symbol_only_in_compound_slot_is_rejected():
+    """A symbol reachable only through a compound slot cannot be read back.
+
+    The call site binds a symbol by reading the actual argument's valid_shape at
+    the same position, so the declared slot has to name the symbol on its own.
+    """
+    scaled = pl.dynamic("VALID_SCALED")
+
+    @pl.program
+    class P:
+        @pl.function(type=pl.FunctionType.InCore)
+        def kernel(
+            self,
+            a: pl.Tensor[
+                [M, N],
+                pl.FP32,
+                pl.TensorView(valid_shape=[M, scaled * 2], layout=pl.TensorLayout.ND),
+            ],
+            output: pl.Tensor[[M, N], pl.FP32],
+        ) -> pl.Tensor[[M, N], pl.FP32]:
+            a_tile = pl.load(a, [0, 0], [128, 128], target_memory=pl.MemorySpace.Vec)
+            return pl.store(a_tile, [0, 0], output)
+
+    func = P.get_function("kernel")
+    assert func is not None
+    program = ir.Program([func], "test_compound_valid_shape", ir.Span.unknown())
+    with pytest.raises(ValueError, match="VALID_SCALED") as exc_info:
+        PassManager.get_strategy(OptimizationStrategy.Default).run_passes(program)
+    assert "compound valid_shape expression" in str(exc_info.value)
+
+
+if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/ir/transforms/test_materialize_valid_shape_symbols.py
+++ b/tests/ut/ir/transforms/test_materialize_valid_shape_symbols.py
@@ -1,0 +1,209 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Unit tests for the MaterializeValidShapeSymbols pass."""
+
+# DSL function bodies are parsed as AST, not executed — suppress pyright errors
+# from type-checking annotations that reference module-level DynVar names.
+# pyright: reportUndefinedVariable=false, reportInvalidTypeForm=false
+
+import pypto.language as pl
+import pytest
+from pypto import ir
+from pypto.language.parser.diagnostics.exceptions import ParserTypeError
+from pypto.pypto_core import passes
+
+Q = pl.dynamic("Q")
+BLK = pl.dynamic("BLK")
+VALID = pl.dynamic("VALID")
+# Annotations are evaluated in the enclosing scope, so a symbol a signature names
+# has to be resolvable there — these two back the shadowing tests below.
+SHADOW_SCALE = pl.dynamic("SHADOW_SCALE")
+LATE_VALID = pl.dynamic("LATE_VALID")
+
+
+def _kernel_calls(func) -> list[ir.Call]:
+    """Every Call to a Function (not an operator) in ``func``'s body."""
+    calls: list[ir.Call] = []
+
+    class _CallCollector(ir.IRVisitor):
+        def visit_call(self, call):  # type: ignore[override]
+            if isinstance(call.op, ir.GlobalVar):
+                calls.append(call)
+            super().visit_call(call)
+
+    _CallCollector().visit_stmt(func.body)
+    return calls
+
+
+def _kernel_and_caller():
+    """An InCore kernel whose valid_shape names a symbol only the caller knows."""
+
+    @pl.function(type=pl.FunctionType.InCore)
+    def kernel(
+        sij: pl.Tensor[
+            [Q, BLK],
+            pl.FP32,
+            pl.TensorView(valid_shape=[Q, VALID], layout=pl.TensorLayout.ND),
+        ],
+        out: pl.Out[pl.Tensor[[Q, BLK], pl.FP32]],
+    ) -> pl.Tensor[[Q, BLK], pl.FP32]:
+        t = pl.load(sij, [0, 0], [16, 128], target_memory=pl.MemorySpace.Vec)
+        return pl.store(t, [0, 0], out)
+
+    @pl.program
+    class Prog:
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def main(
+            self,
+            sij: pl.Tensor[[Q, BLK], pl.FP32],
+            valid_len: pl.Scalar[pl.INDEX],
+            out: pl.Out[pl.Tensor[[Q, BLK], pl.FP32]],
+        ) -> pl.Tensor[[Q, BLK], pl.FP32]:
+            narrowed = pl.slice(sij, [16, 128], [0, 0], valid_shape=[16, valid_len])
+            return kernel(narrowed, out)
+
+    return Prog
+
+
+def test_symbol_becomes_leading_scalar_param_and_call_arg():
+    """The symbol is added as a parameter and fed the caller's actual extent."""
+    prog = _kernel_and_caller()
+    after = passes.materialize_valid_shape_symbols()(prog)
+
+    kernel = after.get_function("kernel")
+    assert kernel is not None
+    # Leading, because the tensor parameter's annotation names it and the text
+    # form declares parameters left to right.
+    assert kernel.params[0].name_hint == "VALID"
+    assert isinstance(kernel.params[0].type, ir.ScalarType)
+    assert kernel.params[0].type.dtype == pl.INDEX
+    # The tensor parameter's valid_shape now reads that very parameter.
+    sij_type = kernel.params[1].type
+    assert isinstance(sij_type, ir.TensorType)
+    assert sij_type.tensor_view is not None
+    assert sij_type.tensor_view.valid_shape[1].same_as(kernel.params[0])
+
+    # The caller passes the actual extent, ahead of the original arguments.
+    main = after.get_function("main")
+    assert main is not None
+    calls = _kernel_calls(main)
+    assert len(calls) == 1, f"expected one kernel call, got {len(calls)}"
+    args = list(calls[0].args)
+    assert len(args) == 3, f"expected valid_len + 2 original args, got {len(args)}"
+    valid_len_param = next(p for p in main.params if p.name_hint == "valid_len")
+    assert args[0].same_as(valid_len_param), "the extent must be the caller's scalar, first"
+
+
+def test_pass_is_idempotent():
+    """Re-running finds nothing left to bind."""
+    prog = _kernel_and_caller()
+    once = passes.materialize_valid_shape_symbols()(prog)
+    twice = passes.materialize_valid_shape_symbols()(once)
+    ir.assert_structural_equal(twice, once)
+
+
+def test_kernel_without_unbindable_symbol_is_untouched():
+    """A valid_shape built from a scalar parameter already binds; leave it alone."""
+
+    @pl.program
+    class Prog:
+        @pl.function(type=pl.FunctionType.InCore)
+        def kernel(
+            self,
+            sij: pl.Tensor[[Q, BLK], pl.FP32],
+            valid_len: pl.Scalar[pl.INDEX],
+            out: pl.Out[pl.Tensor[[Q, BLK], pl.FP32]],
+        ) -> pl.Tensor[[Q, BLK], pl.FP32]:
+            t = pl.load(sij, [0, 0], [16, 128], valid_shape=[16, valid_len])
+            return pl.store(t, [0, 0], out)
+
+    after = passes.materialize_valid_shape_symbols()(Prog)
+    ir.assert_structural_equal(after, Prog)
+
+
+def test_physical_dim_symbol_is_not_materialized():
+    """A symbol that is also a physical dimension is recoverable at run time."""
+
+    @pl.program
+    class Prog:
+        @pl.function(type=pl.FunctionType.InCore)
+        def kernel(
+            self,
+            sij: pl.Tensor[
+                [Q, BLK],
+                pl.FP32,
+                pl.TensorView(valid_shape=[Q, BLK], layout=pl.TensorLayout.ND),
+            ],
+            out: pl.Out[pl.Tensor[[Q, BLK], pl.FP32]],
+        ) -> pl.Tensor[[Q, BLK], pl.FP32]:
+            t = pl.load(sij, [0, 0], [16, 128], target_memory=pl.MemorySpace.Vec)
+            return pl.store(t, [0, 0], out)
+
+    after = passes.materialize_valid_shape_symbols()(Prog)
+    ir.assert_structural_equal(after, Prog)
+
+
+def test_non_index_scalar_param_does_not_capture_a_dynamic_symbol():
+    """Only INDEX scalars may absorb a same-named ``pl.dynamic()`` symbol.
+
+    A ``DynVar`` is an INDEX-valued dimension, so rebinding one to an FP32
+    parameter would put an FP32 Var into a shape expression.
+    """
+
+    @pl.program
+    class Prog:
+        @pl.function(type=pl.FunctionType.InCore)
+        def kernel(
+            self,
+            SHADOW_SCALE: pl.Scalar[pl.FP32],
+            sij: pl.Tensor[[Q, SHADOW_SCALE], pl.FP32],
+            out: pl.Out[pl.Tensor[[Q, BLK], pl.FP32]],
+        ) -> pl.Tensor[[Q, BLK], pl.FP32]:
+            t = pl.load(sij, [0, 0], [16, 128], target_memory=pl.MemorySpace.Vec)
+            return pl.store(t, [0, 0], out)
+
+    kernel = Prog.get_function("kernel")
+    assert kernel is not None
+    # The FP32 parameter and the dimension symbol stay distinct Vars.
+    sij_type = kernel.params[1].type
+    assert isinstance(sij_type, ir.TensorType)
+    assert not sij_type.shape[1].same_as(kernel.params[0])
+
+
+def test_scalar_param_after_the_annotation_that_uses_it_is_rejected():
+    """The shadowing parameter must precede the annotation that names it.
+
+    Annotations resolve in declaration order, so a later parameter cannot rebind
+    a symbol an earlier annotation already read; silently allowing it would
+    materialize a second, redundant extent argument.
+    """
+    with pytest.raises(ParserTypeError, match="LATE_VALID") as exc_info:
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                sij: pl.Tensor[
+                    [Q, BLK],
+                    pl.FP32,
+                    pl.TensorView(valid_shape=[Q, LATE_VALID], layout=pl.TensorLayout.ND),
+                ],
+                LATE_VALID: pl.Scalar[pl.INDEX],
+                out: pl.Out[pl.Tensor[[Q, BLK], pl.FP32]],
+            ) -> pl.Tensor[[Q, BLK], pl.FP32]:
+                t = pl.load(sij, [0, 0], [16, 128], target_memory=pl.MemorySpace.Vec)
+                return pl.store(t, [0, 0], out)
+
+    assert "earlier parameter" in str(exc_info.value)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/ut/ir/transforms/test_pass_manager.py
+++ b/tests/ut/ir/transforms/test_pass_manager.py
@@ -67,6 +67,7 @@ TENSOR_OPTIMIZATION_PASSES = [
     "MaterializeRuntimeScopes",
     "ClassifyIterArgCarry",
     "InsertCommFence",
+    "MaterializeValidShapeSymbols",
 ]
 
 


### PR DESCRIPTION
## Summary

A `pl.dynamic()` symbol used only in a parameter's `pl.TensorView(valid_shape=...)` is neither a physical tensor dimension nor a scalar parameter, so a precompiled kernel has no value for it. PTO codegen logged `Variable <NAME> not found in MLIR mapping` and kept going, emitting an operand-less `%0 = arith.minsi , %c128_index : index` that surfaced far downstream as an opaque `ptoas compilation failed: error: expected SSA operand`. Such a kernel now compiles instead of being rejected: the symbol becomes a real runtime argument fed from the call site, and the IR the user writes is unchanged.

## Changes

- `src/ir/transforms/materialize_valid_shape_symbols_pass.cpp` (new): `MaterializeValidShapeSymbols` inserts each unbindable `valid_shape` symbol as a leading `Scalar[INDEX]` parameter on every device kernel and prepends the caller's actual valid extent at each `Call`/`Submit`. The symbol Var itself becomes the parameter, so every annotation naming it binds at once with no type rewrite. Binding is positional: a symbol reachable only through a compound slot (`valid_shape=[Q, VALID * 2]`), or given disagreeing extents by two parameters, is rejected with a specific message rather than inverted, because a wrong valid extent silently reads or writes the wrong region.
- `python/pypto/ir/pass_manager.py`: runs the pass last in the `Default` strategy, where signatures and call argument lists are already final, so no later pass has to account for the added parameter.
- `src/ir/transforms/python_printer.cpp` and `python/pypto/language/parser/ast_parser.py`: keep the new signature shape print/re-parse clean. Parameters are inserted first because the text form declares parameters left to right while Python evaluates annotations in the enclosing scope; the printer therefore retains the `pl.dynamic()` declaration for a parameter read inside a parameter's `valid_shape`, and the parser re-points that `DynVar` at the parameter once it is declared. A body-local var in a `valid_shape`, and a parameter read as a *physical* dim, both stay undeclared as before (the issue #854 behaviour is preserved).
- `src/codegen/pto/pto_codegen.cpp`: `GetVarName` now fails with a `ValueError` naming the symbol and the parameter it came from instead of returning an empty operand, so a malformed `.pto` operand cannot be emitted again.
- `docs/en/dev/passes/47-*.md`, `docs/zh/dev/passes/47-*.md`, index and `mkdocs.yml` nav entries, and `.claude/rules/pass-doc-ordering.md`.

### Behaviour change

A device kernel carrying such a symbol gains one leading `index` argument per symbol; orchestration supplies the value automatically, so callers need no change. A distributed codegen test that asserted the old rejection now asserts the binding (`test_remote_load_binds_type_only_dynamic_partition_extent`); the `shape_anchor` alternative it documents is unaffected.

## Verification

- `cmake --build build --parallel 32`: exit 0
- `python -m pytest tests/ut/ -n auto --maxprocesses 8`: `9265 passed, 2 skipped`
- `ruff check .`: exit 0, `All checks passed!`
- `ruff format --check .`: exit 0, `963 files already formatted`
- `pyright`: exit 0, `0 errors, 0 warnings, 0 informations`
- `pre-commit run --all-files`: all hooks passed
- `python -m pytest tests/ut/core/test_error.py -n auto --maxprocesses 8`: `41 passed`
- End-to-end compile through ptoas for a dynamic paged-attention kernel that previously failed to assemble, and `examples/models/06_paged_attention_dynamic.py` still compiles unchanged.

The first five ran in the push transaction's validation runner, pinned to the pushed head.