### PR TITLE
fix(ir): honor tensor.matmul transpose flags on 1D operands

### DIFF
--- a/python/pypto/ir/op/tensor_ops.py
+++ b/python/pypto/ir/op/tensor_ops.py
@@ -427,12 +427,18 @@ def matmul(
 ) -> Call:
     """Matrix multiplication with optional transpose.
 
+    A transpose flag swaps its own operand's two trailing axes, so that operand
+    must be at least 2D: ``a_trans`` with a 1D ``lhs`` (or ``b_trans`` with a 1D
+    ``rhs``) raises rather than being ignored. On the mixed mat-vec / vec-mat
+    forms the flag applies to the matrix side, so a ``lhs`` stored ``[K, M]``
+    with ``a_trans=True`` against a ``[K]`` ``rhs`` deduces ``[M]``.
+
     Args:
         lhs: Left-hand side tensor
         rhs: Right-hand side tensor
         out_dtype: Output data type (optional, inferred if not provided)
-        a_trans: Whether to transpose lhs
-        b_trans: Whether to transpose rhs
+        a_trans: Whether to transpose lhs (requires a 2D+ lhs)
+        b_trans: Whether to transpose rhs (requires a 2D+ rhs)
         c_matrix_nz: C matrix non-zero flag
         span: Optional source span for debugging (auto-captured if not provided)
 

--- a/python/pypto/language/op/tensor_ops.py
+++ b/python/pypto/language/op/tensor_ops.py
@@ -644,8 +644,8 @@ def matmul(
         lhs: Left-hand side tensor
         rhs: Right-hand side tensor
         out_dtype: Output data type (optional, inferred if not provided)
-        a_trans: Whether to transpose lhs
-        b_trans: Whether to transpose rhs
+        a_trans: Whether to transpose lhs (requires a 2D+ lhs)
+        b_trans: Whether to transpose rhs (requires a 2D+ rhs)
         c_matrix_nz: C matrix non-zero flag
 
     Returns:

--- a/python/pypto/language/op/unified_ops.py
+++ b/python/pypto/language/op/unified_ops.py
@@ -890,6 +890,12 @@ def matmul(
     tile level transposition is a *type* property, so passing any of them with a
     Tile operand raises rather than being dropped.
 
+    A transpose flag swaps its own operand's two trailing axes, so that operand
+    must be at least 2D — ``a_trans`` with a 1D ``lhs`` (or ``b_trans`` with a 1D
+    ``rhs``) raises rather than being ignored. On the mixed mat-vec / vec-mat
+    forms the flag applies to the matrix side: a ``lhs`` stored ``[K, M]`` with
+    ``a_trans=True`` against a ``[K]`` ``rhs`` deduces ``[M]``.
+
     ``out_dtype`` is likewise Tensor-only. ``tile.matmul``'s result dtype is
     fixed by the Cube accumulator (FP32 for float operands, INT32 for int), so
     the Tile path accepts ``out_dtype`` only when it already agrees with that

--- a/src/ir/op/tensor_ops/matmul.cpp
+++ b/src/ir/op/tensor_ops/matmul.cpp
@@ -53,6 +53,21 @@ T GetKwarg(const std::vector<std::pair<std::string, std::any>>& kwargs, const st
   throw ValueError("Missing kwarg: " + key);
 }
 
+namespace {
+
+/// Verify that the two contraction extents agree, when both are statically known.
+/// `context` names the failing form, e.g. "tensor.matmul requires matching inner dimensions".
+void CheckContractionExtents(const ExprPtr& k_lhs, const ExprPtr& k_rhs, const std::string& context) {
+  auto k_lhs_const = As<ConstInt>(k_lhs);
+  auto k_rhs_const = As<ConstInt>(k_rhs);
+  if (k_lhs_const && k_rhs_const) {
+    CHECK(k_lhs_const->value_ == k_rhs_const->value_)
+        << context << ", but got lhs K=" << k_lhs_const->value_ << " and rhs K=" << k_rhs_const->value_;
+  }
+}
+
+}  // namespace
+
 TypePtr DeduceTensorMatMulType(const std::vector<ExprPtr>& args,
                                const std::vector<std::pair<std::string, std::any>>& kwargs) {
   // tensor.matmul requires exactly 2 Expr arguments (lhs, rhs)
@@ -89,6 +104,16 @@ TypePtr DeduceTensorMatMulType(const std::vector<ExprPtr>& args,
   bool a_trans = GetKwarg<bool>(kwargs, "a_trans", false);
   bool b_trans = GetKwarg<bool>(kwargs, "b_trans", false);
 
+  // A transpose flag names an axis swap on its own operand, which only exists once
+  // that operand is 2D. Honoring it silently on a 1D operand would deduce a shape
+  // the caller never asked for, so reject it with an actionable message instead.
+  CHECK(!a_trans || lhs_shape.size() >= 2)
+      << "tensor.matmul: a_trans does not apply to a 1D lhs (a vector has no axes to swap); "
+      << "drop a_trans or pass a 2D lhs";
+  CHECK(!b_trans || rhs_shape.size() >= 2)
+      << "tensor.matmul: b_trans does not apply to a 1D rhs (a vector has no axes to swap); "
+      << "drop b_trans or pass a 2D rhs";
+
   // Compute output shape based on transpose flags
   // For 2D: lhs [M, K] x rhs [K, N] -> [M, N]
   // With transpose: lhs [K, M]^T x rhs [N, K]^T -> [M, N]
@@ -97,34 +122,23 @@ TypePtr DeduceTensorMatMulType(const std::vector<ExprPtr>& args,
 
   if (lhs_shape.size() == 1 && rhs_shape.size() == 1) {
     // Vector x vector (dot product): [K] x [K] -> scalar (0D tensor)
-    auto k_lhs_const = As<ConstInt>(lhs_shape[0]);
-    auto k_rhs_const = As<ConstInt>(rhs_shape[0]);
-    if (k_lhs_const && k_rhs_const) {
-      CHECK(k_lhs_const->value_ == k_rhs_const->value_)
-          << "tensor.matmul dot product requires matching dimensions, but got lhs K=" << k_lhs_const->value_
-          << " and rhs K=" << k_rhs_const->value_;
-    }
+    CheckContractionExtents(lhs_shape[0], rhs_shape[0],
+                            "tensor.matmul dot product requires matching dimensions");
     output_shape = {};
   } else if (lhs_shape.size() == 2 && rhs_shape.size() == 1) {
     // Matrix x vector: [M, K] x [K] -> [M]
-    auto k_lhs_const = As<ConstInt>(lhs_shape[1]);
-    auto k_rhs_const = As<ConstInt>(rhs_shape[0]);
-    if (k_lhs_const && k_rhs_const) {
-      CHECK(k_lhs_const->value_ == k_rhs_const->value_)
-          << "tensor.matmul requires matching inner dimensions, but got lhs K=" << k_lhs_const->value_
-          << " and rhs K=" << k_rhs_const->value_;
-    }
-    output_shape = {lhs_shape[0]};
+    // With a_trans the lhs is stored [K, M], so the contraction axis is dim 0.
+    ExprPtr m_dim = a_trans ? lhs_shape[1] : lhs_shape[0];
+    ExprPtr k_lhs = a_trans ? lhs_shape[0] : lhs_shape[1];
+    CheckContractionExtents(k_lhs, rhs_shape[0], "tensor.matmul requires matching inner dimensions");
+    output_shape = {m_dim};
   } else if (lhs_shape.size() == 1 && rhs_shape.size() == 2) {
     // Vector x matrix: [K] x [K, N] -> [N]
-    auto k_lhs_const = As<ConstInt>(lhs_shape[0]);
-    auto k_rhs_const = As<ConstInt>(rhs_shape[0]);
-    if (k_lhs_const && k_rhs_const) {
-      CHECK(k_lhs_const->value_ == k_rhs_const->value_)
-          << "tensor.matmul requires matching inner dimensions, but got lhs K=" << k_lhs_const->value_
-          << " and rhs K=" << k_rhs_const->value_;
-    }
-    output_shape = {rhs_shape[1]};
+    // With b_trans the rhs is stored [N, K], so the contraction axis is dim 1.
+    ExprPtr k_rhs = b_trans ? rhs_shape[1] : rhs_shape[0];
+    ExprPtr n_dim = b_trans ? rhs_shape[0] : rhs_shape[1];
+    CheckContractionExtents(lhs_shape[0], k_rhs, "tensor.matmul requires matching inner dimensions");
+    output_shape = {n_dim};
   } else if (lhs_shape.size() == 2 && rhs_shape.size() == 2) {
     // 2D x 2D matrix multiplication
     ExprPtr m_dim = a_trans ? lhs_shape[1] : lhs_shape[0];
@@ -133,13 +147,7 @@ TypePtr DeduceTensorMatMulType(const std::vector<ExprPtr>& args,
     ExprPtr n_dim = b_trans ? rhs_shape[0] : rhs_shape[1];
 
     // Verify K dimensions match (when statically known)
-    auto k_lhs_const = As<ConstInt>(k_lhs);
-    auto k_rhs_const = As<ConstInt>(k_rhs);
-    if (k_lhs_const && k_rhs_const) {
-      CHECK(k_lhs_const->value_ == k_rhs_const->value_)
-          << "tensor.matmul requires matching inner dimensions, but got lhs K=" << k_lhs_const->value_
-          << " and rhs K=" << k_rhs_const->value_;
-    }
+    CheckContractionExtents(k_lhs, k_rhs, "tensor.matmul requires matching inner dimensions");
 
     output_shape = {m_dim, n_dim};
   } else {
@@ -170,13 +178,8 @@ TypePtr DeduceTensorMatMulType(const std::vector<ExprPtr>& args,
     ExprPtr n_dim = b_trans ? rhs_shape[rhs_ndim - 2] : rhs_shape[rhs_ndim - 1];
 
     // Verify K dimensions match (when statically known)
-    auto k_lhs_const = As<ConstInt>(k_lhs);
-    auto k_rhs_const = As<ConstInt>(k_rhs);
-    if (k_lhs_const && k_rhs_const) {
-      CHECK(k_lhs_const->value_ == k_rhs_const->value_)
-          << "tensor.matmul requires matching inner dimensions for batched matmul, but got lhs K="
-          << k_lhs_const->value_ << " and rhs K=" << k_rhs_const->value_;
-    }
+    CheckContractionExtents(k_lhs, k_rhs,
+                            "tensor.matmul requires matching inner dimensions for batched matmul");
 
     output_shape.push_back(m_dim);
     output_shape.push_back(n_dim);

--- a/tests/ut/ir/operators/test_tensor_ops.py
+++ b/tests/ut/ir/operators/test_tensor_ops.py
@@ -44,6 +44,24 @@ _OP_TENSOR_TRANSPOSE = ir.get_op("tensor.transpose").name
 _OP_TENSOR_WRITE = ir.get_op("tensor.write").name
 
 
+def _tensor_var(name: str, shape: list[int], dtype: DataType = DataType.FP16) -> ir.Var:
+    """Build a Var of TensorType with the given static shape."""
+    span = ir.Span.unknown()
+    dims = [ir.ConstInt(d, DataType.INT32, span) for d in shape]
+    return ir.Var(name, ir.TensorType(dims, dtype), span)
+
+
+def _const_shape(call: ir.Call) -> list[int]:
+    """Return the deduced output shape of a tensor op call, requiring every dim static."""
+    result_type = call.type
+    assert isinstance(result_type, ir.TensorType)
+    dims = []
+    for dim in result_type.shape:
+        assert isinstance(dim, ir.ConstInt)
+        dims.append(dim.value)
+    return dims
+
+
 def test_tensor_create():
     """Test tensor.create operation."""
     # Create a 2D tensor [4, 8] with FP32
@@ -127,8 +145,63 @@ def test_tensor_matmul_with_transpose():
     call = ir.op.tensor.matmul(lhs, rhs, out_dtype=DataType.FP16, a_trans=True, b_trans=False)
 
     assert isinstance(call, ir.Call)
-    result_type = call.type
-    assert isinstance(result_type, ir.TensorType)
+    assert _const_shape(call) == [4, 4]
+
+
+def test_tensor_matmul_mat_vec_honors_a_trans():
+    """2D x 1D contracts over dim 0 of the lhs when a_trans is set."""
+    # lhs stored [K=128, M=64] with a_trans, rhs [K=128] -> [64]
+    call = ir.op.tensor.matmul(_tensor_var("a", [128, 64]), _tensor_var("b", [128]), a_trans=True)
+
+    assert _const_shape(call) == [64]
+
+
+def test_tensor_matmul_vec_mat_honors_b_trans():
+    """1D x 2D contracts over dim 1 of the rhs when b_trans is set."""
+    # lhs [K=64], rhs stored [N=128, K=64] with b_trans -> [128]
+    call = ir.op.tensor.matmul(_tensor_var("a", [64]), _tensor_var("b", [128, 64]), b_trans=True)
+
+    assert _const_shape(call) == [128]
+
+
+def test_tensor_matmul_mat_vec_a_trans_k_mismatch_fails():
+    """A transposed mat-vec whose K disagrees is rejected, not silently reshaped."""
+    # Real K is lhs dim 0 (128) under a_trans; rhs K is 64.
+    with pytest.raises(ValueError, match="lhs K=128 and rhs K=64"):
+        ir.op.tensor.matmul(_tensor_var("a", [128, 64]), _tensor_var("b", [64]), a_trans=True)
+
+
+def test_tensor_matmul_vec_mat_b_trans_k_mismatch_fails():
+    """A transposed vec-mat whose K disagrees is rejected, not silently reshaped."""
+    # Real K is rhs dim 1 (64) under b_trans; lhs K is 128.
+    with pytest.raises(ValueError, match="lhs K=128 and rhs K=64"):
+        ir.op.tensor.matmul(_tensor_var("a", [128]), _tensor_var("b", [128, 64]), b_trans=True)
+
+
+@pytest.mark.parametrize(
+    "lhs_shape, rhs_shape, kwargs, message",
+    [
+        ([64, 128], [128], {"b_trans": True}, "b_trans does not apply to a 1D rhs"),
+        ([64], [64, 128], {"a_trans": True}, "a_trans does not apply to a 1D lhs"),
+        ([64], [64], {"a_trans": True}, "a_trans does not apply to a 1D lhs"),
+        ([64], [64], {"b_trans": True}, "b_trans does not apply to a 1D rhs"),
+    ],
+)
+def test_tensor_matmul_rejects_transpose_on_1d_operand(lhs_shape, rhs_shape, kwargs, message):
+    """A vector has no axes to swap, so a transpose flag on it is a user error."""
+    with pytest.raises(ValueError, match=message):
+        ir.op.tensor.matmul(_tensor_var("a", lhs_shape), _tensor_var("b", rhs_shape), **kwargs)
+
+
+def test_tensor_matmul_mixed_1d_without_transpose_unchanged():
+    """The untransposed mat-vec / vec-mat / dot-product shapes are unaffected."""
+    mat_vec = ir.op.tensor.matmul(_tensor_var("a", [64, 128]), _tensor_var("b", [128]))
+    vec_mat = ir.op.tensor.matmul(_tensor_var("a", [128]), _tensor_var("b", [128, 64]))
+    dot = ir.op.tensor.matmul(_tensor_var("a", [64]), _tensor_var("b", [64]))
+
+    assert _const_shape(mat_vec) == [64]
+    assert _const_shape(vec_mat) == [64]
+    assert _const_shape(dot) == []
 
 
 def test_tensor_matmul_acc():


### PR DESCRIPTION
## Summary

`tensor.matmul` shape deduction read `a_trans` / `b_trans` in the 2D x 2D and ND
batched branches but hard-coded the contraction axis on the mixed 1D branches
(mat-vec and vec-mat). The result was wrong in both directions: a *correct*
transposed mat-vec was rejected with a bogus K mismatch, while an *incorrect*
one was accepted silently and returned the K extent as the output dim instead
of M or N.

This selects the contraction axis and the surviving dim through the flags on
the `2D x 1D` and `1D x 2D` arms, exactly as the 2D arm already does. It also
rejects a transpose flag applied to a 1D operand: a vector has no axes to swap,
so honoring the flag there would deduce a shape the caller never asked for.
That second half closes the `1D x 1D` case, which fixing the axis selection
alone would leave permissive.

Callers gain a working transposed mat-vec / vec-mat and lose a silent
wrong-shape result at the type-deduction boundary. There is no migration step:
untransposed mixed-rank deduction, 2D deduction, and batched deduction are
unchanged, and `tensor.matmul_acc` was never affected because it already
requires every operand to be at least 2D.

## Changes

- `src/ir/op/tensor_ops/matmul.cpp`: the `2D x 1D` arm now contracts over
  `lhs_shape[0]` and returns `lhs_shape[1]` under `a_trans`; the `1D x 2D` arm
  contracts over `rhs_shape[1]` and returns `rhs_shape[0]` under `b_trans`. A
  transpose flag on a 1D operand raises an actionable `ValueError` naming the
  offending flag and the remedy. The five copies of the static K-extent check
  collapse into one `CheckContractionExtents` helper, preserving each existing
  message byte-for-byte.
- `tests/ut/ir/operators/test_tensor_ops.py`: regression coverage for both
  honored-flag directions, both K-mismatch rejections, a parametrized
  vector-flag rejection over all four 1D combinations, and a guard that the
  untransposed mat-vec / vec-mat / dot-product shapes are unchanged.
  `test_tensor_matmul_with_transpose` previously asserted only that the result
  was a `TensorType`; it now asserts the deduced shape, so it can actually fail
  on this bug class.
- `python/pypto/language/op/unified_ops.py`,
  `python/pypto/language/op/tensor_ops.py`: document that a transpose flag
  requires a 2D+ operand and that the mixed forms apply it to the matrix side.

## Notes

The batched path was audited alongside this fix and needs no change: deduction
was checked against a numpy reference across all 24 rank/flag combinations
(2Dx2D, 3Dx3D, 3Dx2D, 2Dx3D, broadcast batch, 4Dx4D) with zero mismatches, and
K-mismatch rejection holds under every flag combination.

Mixed-rank matmul still cannot lower to tile ops — `ConvertTensorToTileOps`
routes rank<=2 to `tile.matmul`, which requires both operands 2D — so no
shipped kernel was miscompiling. `ND x 1D` remains rejected outright, which
numpy would accept; that is a pre-existing gap and fails loudly rather than
silently, so it is left as-is.

## Verification

Run by the push transaction against the pushed commit, on this rebased base:

- `cmake --build build --parallel`: exit 0, clean build
- `python -m pytest tests/ut/ir/operators/test_tensor_ops.py -q`: exit 0,
  405 passed
- `python -m pytest tests/ut -q -n auto --maxprocesses 8`: exit 0,
  9268 passed, 2 skipped

Additionally run locally before commit:

- `python tests/lint/check_english_only.py`: exit 0, 1179 passed
- `python tests/lint/check_headers.py`: exit 0, 1038 passed
- `python tests/lint/check_no_broad_raises.py`: exit 0
- `python tests/lint/check_op_name_literals.py`: exit 0