### PR TITLE
fix(language): de-duplicate the expand_clone export and test real promotion

### DIFF
--- a/python/pypto/language/op/__init__.py
+++ b/python/pypto/language/op/__init__.py
@@ -245,7 +245,6 @@ __all__ = [
     "col_expand_max",
     "col_expand_min",
     "col_expand_expdif",
-    "expand_clone",
     "expands",
     "neg",
     "read",

--- a/tests/ut/language/test_unified_ops.py
+++ b/tests/ut/language/test_unified_ops.py
@@ -1101,6 +1101,19 @@ class TestPromotedOps:
             f"names bound to different objects in pypto.language vs pypto.language.op: {divergent}"
         )
 
+    @pytest.mark.parametrize("module", [pl, language_op], ids=["pl", "pl.op"])
+    def test_all_lists_each_name_once(self, module):
+        """``__all__`` must not repeat a name.
+
+        ``pypto.language.op.__all__`` groups names by dispatch category
+        (unified / tile-only / tensor-only). A name listed under two groups is
+        invisible at runtime — ``from ... import *`` de-duplicates — but it
+        makes the groups drift, and lets a later edit delete one entry while
+        the name still looks unexported.
+        """
+        duplicates = sorted({name for name in module.__all__ if module.__all__.count(name) > 1})
+        assert not duplicates, f"{module.__name__}.__all__ lists these names more than once: {duplicates}"
+
     def test_create_tile_single_binding(self):
         """``create_tile`` is the ``tile_ops.create`` alias in both namespaces."""
         assert pl.create_tile is language_op.create_tile is tile_ops.create
@@ -1167,7 +1180,7 @@ class TestPromotedOps:
 
         @pl.function
         def explicit(a: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-            c: pl.Tensor[[64], pl.FP32] = pl.create_tensor([64], dtype=pl.FP32)
+            c: pl.Tensor[[64], pl.FP32] = pl.tensor.create([64], dtype=pl.FP32)
             return c
 
         ir.assert_structural_equal(unified, explicit)
@@ -1180,7 +1193,7 @@ class TestPromotedOps:
 
         @pl.function
         def explicit(a: pl.Tensor[[64, 128], pl.FP32]) -> pl.Scalar[pl.INT64]:
-            d: pl.Scalar[pl.INT64] = pl.dim(a, 0)
+            d: pl.Scalar[pl.INT64] = pl.tensor.dim(a, 0)
             return d
 
         ir.assert_structural_equal(unified, explicit)


### PR DESCRIPTION
Two small, independent export-hygiene fixes in the unified `pl.*` namespace, merged into one PR since each is a couple of lines.

## 1. `"expand_clone"` was listed twice in `pypto.language.op.__all__`

`__all__` groups names by dispatch category, and `"expand_clone"` appeared in both the **Unified dispatch** and the **Promoted tensor-only** section. `expand_clone` is defined in `tensor_ops.py` and has no unified Tensor/Tile dispatch path, so the unified-section entry was the stale one — removed.

```python
import pypto.language.op as plop
plop.__all__.count("expand_clone")   # before: 2   after: 1
```

Harmless at runtime (`from ... import *` de-duplicates), but it let the two grouped sections drift, and a duplicate makes it easy to delete one entry while believing the name is no longer exported.

Added `TestPromotedOps::test_all_lists_each_name_once`, parametrized over `pypto.language` and `pypto.language.op`, so a re-introduced duplicate fails a test. Verified it fails on an injected duplicate.

## 2. `test_promoted_create` / `test_promoted_dim` were tautological

Both tests are meant to prove a promoted op produces the same IR as its explicit form — the pattern established by `test_promoted_load_store`, which compares `pl.load` against `pl.tile.load`. But their `unified` and `explicit` bodies were byte-identical:

```python
def unified(a):  c = pl.create_tensor([64], dtype=pl.FP32); return c
def explicit(a): c = pl.create_tensor([64], dtype=pl.FP32); return c   # same call!
ir.assert_structural_equal(unified, explicit)   # passes even if the promotion were removed
```

`assert_structural_equal` was comparing a function with itself and could never fail, so the promotion each test is named for went untested. The explicit sides now call `pl.tensor.create` and `pl.tensor.dim`.

`test_promoted_dim` had the identical defect one test below `test_promoted_create` and is fixed in the same pass — an AST scan over `tests/ut/language/test_unified_ops.py` confirms these were the only two, and that none remain.

## Testing

- `pytest tests/ut/language/` — 1229 passed
- `ruff check` / `ruff format --check` / `pyright` — clean (full pre-commit hook suite passed)
- Confirmed the new `__all__` guard fails when a duplicate is re-introduced
- Confirmed `pl.create_tensor is tensor_ops.create` and `pl.dim is tensor_ops.dim`, so the two repaired tests now compare genuinely distinct call sites

No behavioural change to compiled output.