### PR TITLE
feat: add MXFP4 host-prequant support

### DIFF
--- a/docs/en/dev/ir/05-operators.md
+++ b/docs/en/dev/ir/05-operators.md
@@ -135,7 +135,7 @@ later unrolls the batched form into per-batch 2D ops.
 ### MX block-scale matmul (Ascend950)
 
 MX uses dedicated `LeftScale` / `RightScale` memory spaces and the `FP8E8M0`
-scale dtype. PyPTO supports the host-prequant MXFP8 path on Ascend950 through
+scale dtype. PyPTO supports host-prequant MXFP8 and an explicit FP4×FP8 conversion path on Ascend950 through
 the `matmul_mx` family. `InsertMxScaleAddr` (after `InferTileMemorySpace`)
 inserts the internal `tile.tget_scale_addr` bindings once operand memory
 spaces are resolved.
@@ -145,14 +145,15 @@ spaces are resolved.
 | `tile.load` of `pl.Tensor[..., pl.MX_A_ZZ \| pl.MX_B_NN]` | The source TensorLayout carries the MX scale GM layout. Dtype is FP8E8M0 or UINT8, `target_memory=Mat` is required, and strided sources are rejected. |
 | `tile.move(..., target_memory=LeftScale/RightScale)` | Mat-to-Scale move with hardware-fixed row/row/32 (left) or col/col/32 (right) layout; the source Mat tile and layout overrides must match exactly. |
 | `tile.create(..., target_memory=LeftScale/RightScale)` | Not supported; load MX scale data into Mat and then move it into scale memory. |
-| `tile.matmul_mx` / `pl.matmul_mx` | `Left, LeftScale, Right, RightScale → Acc`; data is `FP8E4M3FN` only; scale is `FP8E8M0`; physical `M % 16 == 0`, `K % 64 == 0`, `N % 32 == 0`; valid K must satisfy `ceil(validK/32) == ceil(physicalK/32)`. Alignment / scale-group checks run only for constant extents; symbolic dims skip the numeric checks and fall back to the declared scale tile geometry (later PTOAS still verifies). |
+| `tile.matmul_mx` / `pl.matmul_mx` | `Left, LeftScale, Right, RightScale → Acc`; both data operands reaching the op must be `FP8E4M3FN`, and scale is `FP8E8M0`. The supported FP4-input form is FP4 lhs × FP8 rhs with an explicit `pl.cast(fp4, pl.FP8E4M3FN)` before the op; native FP4×FP4 and FP8×FP4 are rejected. Physical M/K/N, valid K, and scale-group counts use the post-cast FP8 tile extents, never the packed x2 carrier shape. Physical `M % 16 == 0`, `K % 64 == 0`, and `N % 32 == 0`; valid K must satisfy `ceil(validK/32) == ceil(physicalK/32)`. Alignment / scale-group checks run only for constant extents; symbolic dims skip the numeric checks and fall back to the declared scale tile geometry (later PTOAS still verifies). |
 | `tile.matmul_mx_acc` / `pl.matmul_mx_acc` | `Acc, Left, LeftScale, Right, RightScale → Acc`; in-place through `set_output_reuses_input(0)`; accumulator physical and valid M/N must match the matmul output. |
 | `tile.matmul_mx_bias` / `pl.matmul_mx_bias` | `Left, LeftScale, Right, RightScale, Bias → Acc`; bias is `[1, N]` FP32. |
 | `tile.tget_scale_addr` | Compiler-generated A5 binding from `LeftScale↔Left` or `RightScale↔Right`; DPS in-place on `dst_scale`. Users write only the `matmul_mx` family. |
 
 The canonical shape is `M=128, K=64, N=64`, with FP8E4M3FN data,
 FP8E8M0 scales shaped `[128,2]` and `[2,64]`, and `mx_a_zz` / `mx_b_nn`
-host layouts. Align M↑16, K↑64, N↑32 (fp8).
+host layouts. The left input may originate as FP4 only when explicitly cast to FP8 first.
+Align M↑16, K↑64, and N↑32.
 
 MX tensor subviews are a legacy limitation. `tensor.slice`, `tensor.reshape`,
 `tensor.transpose`, `tensor.reinterpret_view`, and `tensor.view` reject
@@ -160,16 +161,23 @@ MX-layout sources because the hardware path cannot represent a subview base
 offset. `pld.tile.remote_load` also rejects MX layouts until its complete scale
 layout contract is implemented.
 
+FP4 Tensor/Tile shapes and `valid_shape` are logical nibble counts; the innermost extent must be positive and even, and slice origins cannot select a byte's second nibble.
+Torch/runtime carries `float4_e2m1fn_x2` in a physical x2 shape; JIT/compiled-call conversion avoids a persistent IR `storage_shape`.
+
+An explicit left-side FP4→FP8 tile cast is legalized on A5 as
+FP4→BF16→FP32→FP8E4M3FN. Scale values are unchanged because this is a numerical
+cast of the data operand. Native packed-FP4 matmul and MXFP4 quantization remain deferred.
+
 #### MX / Ascend950: pto-isa constraints
 
 | Constraint | Detail |
 | ---------- | ------ |
 | Distinct scale buffers | Cube does not fold scales into Left/Right data. `TileType::ScaleLeft` / `ScaleRight` sidecars map to PyPTO `LeftScale` / `RightScale`. |
-| Payload | Scale is `float8_e8m0_t` / `FP8E8M0`; MX data is **`FP8E4M3FN` only** (**rejects `FP8E5M2`**). Physical `K%64==0`, with `ceil(K/32)` scale groups and fractal 32. |
+| Payload | Scale is `float8_e8m0_t` / `FP8E8M0`; the emitted MX data pair is `FP8E4M3FN × FP8E4M3FN` (rejects `FP8E5M2` and native packed FP4). A logical FP4×FP8 input first casts the FP4 lhs to FP8. Physical K, valid K, and `ceil(K/32)` scale groups are measured on that post-cast FP8 tile, not the packed x2 carrier; physical `K%64==0` and fractal is 32. |
 | Layouts | `mx_a_zz` is row-major ZZ; `mx_b_nn` is col-major NN; loads use `TLoadMxCube*` (AZZ2ZZ). |
 | `TMov` `CommonCheckMX` | Allows UINT8 Mat → FP8E8M0 ScaleLeft/Right; canonical path: ui8 Mat reshape then ui8→f8 Scale. |
 | Bind then fill | Fill **after** `GetScaleAddr(Left/Right)`; writing the provisional alloc address is orphaned once rebound. |
-| Alignment | Physical `M%16==0`, `K%64==0`, and `N%32==0` (fp8); `DeduceTileMatMulMxType` enforces these for **constant** extents only. Symbolic dims skip numeric checks. |
+| Alignment | Post-cast FP8 tile extents require physical `M%16==0`, `K%64==0`, and `N%32==0`; `DeduceTileMatMulMxType` enforces these for **constant** extents only. Symbolic dims skip numeric checks. |
 
 #### MX / Ascend950: PTOAS constraints
 

--- a/docs/en/dev/passes/18-insert_mx_scale_addr.md
+++ b/docs/en/dev/passes/18-insert_mx_scale_addr.md
@@ -11,7 +11,7 @@ bound_scale = tile.tget_scale_addr(scale, data)
 matmul_mx(..., bound_scale, ...)
 ```
 
-`tile.tget_scale_addr` is intentionally absent from the public `pypto.language` API. Users write only the high-level `matmul_mx` family; the compiler derives the Left/Right side from the matmul operand slots. The low-level `ir.op.tile.tget_scale_addr` remains available for compiler construction and IR parsing. It accepts only the resolved pairs `(LeftScale, Left)` and `(RightScale, Right)`.
+`tile.tget_scale_addr` is intentionally absent from the public `pypto.language` API. Users write only the high-level `matmul_mx` family; the compiler derives the Left/Right side from the matmul operand slots. The low-level `ir.op.tile.tget_scale_addr` remains available for compiler construction and IR parsing. It accepts only the resolved pairs `(LeftScale, Left)` and `(RightScale, Right)`, with an `FP8E4M3FN` data tile. An FP4 lhs is cast to FP8 before reaching this pass.
 
 **Pipeline position**: Immediately after [`InferTileMemorySpace`](17-infer_tile_memory_space.md), before [`ResolveBackendOpLayouts`](19-resolve_backend_op_layouts.md).
 

--- a/docs/en/dev/ptoas-op-status.md
+++ b/docs/en/dev/ptoas-op-status.md
@@ -6,7 +6,7 @@ baseline is Little-oil/PTOAS `main`
 `d852dd2dba3e5bf7a69ce8324eb88afc336e8a33`: 189 public interfaces from the manual
 plus 15 source-only compatibility/tile interfaces still present in `PTOOps.td`, for a
 total of 204. Column statuses were checked against the **current PyPTO source** (last
-updated 2026-07-27). When an op is added or changed, update only its corresponding row.
+updated 2026-08-11). When an op is added or changed, update only its corresponding row.
 
 The matrix includes public/compatibility interfaces even when their PyPTO level is
 `internal`. Separately, it excludes 32 additional `PTOOps.td` ops that exist only
@@ -77,8 +77,8 @@ for lowering/compiler plumbing, plus other dialects such as VPTO, VMI, and SIMT.
 | pto.tmatmul | TMATMUL | tile+tensor | ✅ | ✅ | ✅ | ✅ | — |  |
 | pto.tmatmul.acc | TMATMUL_ACC | tile+tensor | ✅ | ✅ | ✅ | ✅ | — |  |
 | pto.tmatmul.bias | TMATMUL_BIAS | tile | ✅ | ✅ | ❌ | ✅ | — |  |
-| pto.tmatmul.mx | TMATMUL_MX | tile | ✅ | ✅ | ✅ | ❌ | — | NEW frontend+codegen (minimal MXFP8 host-prequant); see [operators MX constraints](ir/05-operators.md#mx--ascend950-pto-isa-constraints); device numerical follow-up #1975 |
-| pto.tmatmul.mx.acc | TMATMUL_MX (overload) | tile | ✅ | ✅ | ✅ | ❌ | — | NEW frontend+codegen (`tile.matmul_mx_acc`); ST pending |
+| pto.tmatmul.mx | TMATMUL_MX | tile | ✅ | ✅ | ✅ | ✅ | — | A5 MXFP8 host-prequant frontend+codegen+ST; FP4 input is limited to FP4×FP8 with an explicit lhs FP4→FP8 cast; native FP4×FP4 is deferred; see [operators MX constraints](ir/05-operators.md#mx--ascend950-pto-isa-constraints) |
+| pto.tmatmul.mx.acc | TMATMUL_MX (overload) | tile | ✅ | ✅ | ✅ | ✅ | — | A5 frontend+codegen+ST (`tile.matmul_mx_acc`) |
 | pto.tmatmul.mx.bias | TMATMUL_MX (overload) | tile | ✅ | ✅ | ✅ | ❌ | — | NEW frontend+codegen (`tile.matmul_mx_bias`); ST pending |
 | pto.tgemv | TGEMV | tile | ✅ | ✅ | ❌ | ❌ | — | path exists; historical ISA/semantic issue requires revalidation against the current pin |
 | pto.tgemv.acc | TGEMV_ACC | tile | ✅ | ✅ | ❌ | ❌ | — | path exists; historical ISA/semantic issue requires revalidation against the current pin |

--- a/docs/en/user/language/00-types.md
+++ b/docs/en/user/language/00-types.md
@@ -75,13 +75,29 @@ def scale_rows(
 | `pl.INDEX` | 64 | Index arithmetic — loop variables, dimensions |
 | `pl.TASK_ID` | — | Producer handle for a launched task |
 
-`dtype.get_byte()` returns the element size in bytes. Use it whenever a byte count is
-computed rather than written as a literal — a raw element count passed where bytes are
-expected is a silent under-allocation.
+`dtype.get_byte()` returns the byte-addressable element size, rounded up to one byte.
+Use it for byte-addressable dtypes whenever a byte count is computed rather than written
+as a literal. Do not use `logical_elements * dtype.get_byte()` for a 4-bit buffer: PyPTO
+packs every semantic 4-bit dtype two logical elements per byte, so the physical size is
+`ceil(logical_elements / 2)`.
 
 ```python
 nbytes = 256 * pl.FP32.get_byte()          # 1024, not 256
 ```
+
+FP4 shapes inside PyPTO IR are logical nibble shapes, and `valid_shape` uses the same
+logical units. At the Torch/runtime boundary, `torch.float4_e2m1fn_x2` uses a physical x2
+carrier shape: its last dimension contains one byte per two logical FP4 values. JIT expands
+that last dimension on entry, while compiled-call metadata and orchestration allocations
+contract it by two; no separate `storage_shape` is stored in `TensorType` or `TileType`. Packed
+FP4 requires a positive even logical last dimension, including static allocation and view
+shapes; dynamic widths are checked before conversion. A 4-bit slice origin must land on a byte
+boundary, so an odd linear nibble offset is rejected.
+
+End-to-end 4-bit execution is backend-gated. Ascend950 supports `pl.FP4`; `INT4`, `UINT4`,
+and `HF4` remain storage-accounted but are rejected by in-core codegen. Ascend910B/A2A3
+rejects every 4-bit in-core dtype because its isolated FP16↔INT4 conversion has no matching
+packed load/store carrier ABI.
 
 ### Container types
 
@@ -144,7 +160,11 @@ They are the one case where a layout marker on a `pl.Tensor` annotation is requi
 than discouraged. Current limitations: an MX `pl.load` must pass `target_memory=pl.Mem.Mat`
 explicitly, MX subviews (`slice`, `reshape`, `transpose`, `reinterpret_view`, `view`) and
 MX `remote_load` are rejected. The matmul itself is `pl.matmul_mx` and its `_acc` /
-`_bias` variants, which take a data tile and a scale tile per operand.
+`_bias` variants, which take a data tile and a scale tile per operand. Both data tiles reaching
+the op must be `FP8E4M3FN`. The supported FP4-input form is a left FP4 operand multiplied by a
+right FP8 operand: write `pl.cast(fp4_tile, pl.FP8E4M3FN)` before `matmul_mx`. On A5 the cast
+legalization pass expands that request to FP4→BF16→FP32→FP8E4M3FN. Native FP4×FP4 and the
+reverse FP8×FP4 form are not supported; MXFP4 quantization is not exposed yet.
 
 ### Dynamic shapes
 

--- a/docs/en/user/ops/01-catalog.md
+++ b/docs/en/user/ops/01-catalog.md
@@ -132,7 +132,7 @@ tile depend on the pad value; see
 | `matmul_bias` | `pl.` (t) | Multiply with a bias operand |
 | `batch_matmul` | `pl.` (t) | Batched multiply, **tile operands only**. For tensors call `pl.matmul` — rank > 2 dispatches to `tile.batch_matmul` during lowering |
 | `gemv` `gemv_acc` `gemv_bias` | `pl.` (t) | Matrix-vector forms |
-| `matmul_mx` `matmul_mx_acc` `matmul_mx_bias` | `pl.` (t) | MX block-scale multiply — each operand is an FP8E4M3FN data tile plus an FP8E8M0 scale tile |
+| `matmul_mx` `matmul_mx_acc` `matmul_mx_bias` | `pl.` (t) | A5 MX block-scale multiply — data tiles reaching the op must be FP8E4M3FN; the supported FP4-input form is FP4×FP8, with the FP4 lhs explicitly cast to FP8 first; native FP4×FP4 is unsupported |
 
 ## Gather, scatter, sort
 

--- a/docs/zh/dev/ir/05-operators.md
+++ b/docs/zh/dev/ir/05-operators.md
@@ -127,7 +127,7 @@ lhs/rhs 广播后的 batch 形状完全一致；matmul 的 (M, N) 必须与 acc 
 ### MX block-scale matmul（Ascend950）
 
 MX 使用独立的 `LeftScale` / `RightScale` 内存空间与 `FP8E8M0` scale
-dtype。PyPTO 在 Ascend950 上通过 `matmul_mx` 算子族支持 host-prequant MXFP8 路径。
+dtype。PyPTO 在 Ascend950 上通过 `matmul_mx` 算子族支持 host-prequant MXFP8，以及显式转换后的 FP4×FP8 路径。
 `InsertMxScaleAddr`（在 `InferTileMemorySpace` 之后）在操作数内存空间解析完成后插入内部 `tile.tget_scale_addr` 绑定。
 
 | IR / DSL | 说明 |
@@ -135,29 +135,33 @@ dtype。PyPTO 在 Ascend950 上通过 `matmul_mx` 算子族支持 host-prequant 
 | `tile.load` 读取 `pl.Tensor[..., pl.MX_A_ZZ \| pl.MX_B_NN]` | 源 TensorLayout 携带 MX scale GM layout。dtype 为 FP8E8M0 或 UINT8，必须指定 `target_memory=Mat`，且不支持 strided source。 |
 | `tile.move(..., target_memory=LeftScale/RightScale)` | Mat→Scale move；硬件 layout 固定为左侧 row/row/32、右侧 col/col/32，源 Mat tile 与 layout override 必须完全匹配。 |
 | `tile.create(..., target_memory=LeftScale/RightScale)` | 不支持；应先把 MX scale 数据加载到 Mat，再 move 到 scale 内存。 |
-| `tile.matmul_mx` / `pl.matmul_mx` | `Left, LeftScale, Right, RightScale → Acc`；data 仅支持 `FP8E4M3FN`，scale 为 `FP8E8M0`；physical `M % 16 == 0`、`K % 64 == 0`、`N % 32 == 0`；valid K 必须满足 `ceil(validK/32) == ceil(physicalK/32)`。对齐与 scale-group 数值检查仅作用于常量维；符号维跳过数值校验，回退到声明的 scale tile 几何（后续仍由 PTOAS 验证）。 |
+| `tile.matmul_mx` / `pl.matmul_mx` | `Left, LeftScale, Right, RightScale → Acc`；进入算子的两块 data operand 必须都是 `FP8E4M3FN`，scale 为 `FP8E8M0`。支持的 FP4 输入形式仅为左侧 FP4×右侧 FP8，且必须先显式写 `pl.cast(fp4, pl.FP8E4M3FN)`；原生 FP4×FP4 与反向 FP8×FP4 会被拒绝。Physical M/K/N、valid K 与 scale-group 数均以 cast 后进入算子的 FP8 tile extent 为准，不使用 packed x2 carrier shape。Physical `M % 16 == 0`、`K % 64 == 0`、`N % 32 == 0`；valid K 必须满足 `ceil(validK/32) == ceil(physicalK/32)`。对齐与 scale-group 数值检查仅作用于常量维；符号维跳过数值校验，回退到声明的 scale tile 几何（后续仍由 PTOAS 验证）。 |
 | `tile.matmul_mx_acc` / `pl.matmul_mx_acc` | `Acc, Left, LeftScale, Right, RightScale → Acc`；通过 `set_output_reuses_input(0)` 原地执行；accumulator 的 physical/valid M、N 必须与 matmul 输出一致。 |
 | `tile.matmul_mx_bias` / `pl.matmul_mx_bias` | `Left, LeftScale, Right, RightScale, Bias → Acc`；bias 为 `[1, N]` FP32。 |
 | `tile.tget_scale_addr` | 编译器生成的 A5 绑定，接受 `LeftScale↔Left` 或 `RightScale↔Right`；对 `dst_scale` 原地 DPS。用户只编写 `matmul_mx` 算子族。 |
 
-规范样例：`M=128,K=64,N=64`，A/B=`FP8E4M3FN`，scale=`FP8E8M0`（`[128,2]` / `[2,64]`），
-GM scale layout `mx_a_zz` / `mx_b_nn`（host ZZ/NN pack）；对齐 M↑16、K↑64、N↑32（fp8）。
+规范样例：`M=128,K=64,N=64`，进入算子的 A/B 均为 `FP8E4M3FN`，scale=`FP8E8M0`（`[128,2]` / `[2,64]`），
+GM scale layout `mx_a_zz` / `mx_b_nn`（host ZZ/NN pack）。左侧输入可来自 FP4，但必须先显式转为 FP8；对齐 M↑16、K↑64、N↑32。
 
 MX tensor subview 是当前遗留限制。由于硬件路径无法表达 subview base
 offset，`tensor.slice`、`tensor.reshape`、`tensor.transpose`、
 `tensor.reinterpret_view` 和 `tensor.view` 均拒绝 MX-layout source。
 在完整的 scale layout contract 实现前，`pld.tile.remote_load` 也拒绝 MX layout。
 
+FP4 Tensor/Tile shape 与 `valid_shape` 都以逻辑 nibble 计数；末维必须是正偶数，slice 的线性起点也不能落在一个字节的第二个 nibble。Torch/runtime 继续以物理 x2 shape 携带 `float4_e2m1fn_x2`，JIT/compiled-call 边界负责换算，因此 IR 不增加持久化 `storage_shape`。
+
+A5 会把左侧显式 FP4→FP8 tile cast 展开为 FP4→BF16→FP32→FP8E4M3FN。它是 data operand 的数值 cast，不修改 scale。原生 packed-FP4 矩阵乘与 MXFP4 quant 本次仍暂缓。
+
 #### MX / Ascend950：pto-isa 约束
 
 | 约束 | 要点 |
 | ---- | ---- |
 | 独立 scale buffer | Cube **不**把 scale 折进 Left/Right data；`TileType::ScaleLeft` / `ScaleRight`（L0A/L0B sidecar）↔ PyPTO `LeftScale` / `RightScale` |
-| payload | scale 为 `float8_e8m0_t` / `FP8E8M0`；本阶段 MX data **仅 `FP8E4M3FN`**（**拒绝 `FP8E5M2`**）；physical `K%64==0`，scale 组数 `ceil(K/32)`，fractal=32 |
+| payload | scale 为 `float8_e8m0_t` / `FP8E8M0`；实际发射的 MX data pair 为 `FP8E4M3FN × FP8E4M3FN`（拒绝 `FP8E5M2` 与原生 packed FP4）。逻辑 FP4×FP8 输入先把左侧 FP4 转为 FP8；physical K、valid K 与 `ceil(K/32)` scale 组数均以 cast 后的 FP8 tile 为准，而非 packed x2 carrier；physical `K%64==0`，fractal=32 |
 | layout | `mx_a_zz` → row-major ZZ；`mx_b_nn` → col-major NN；`TLoadMxCube*`（AZZ2ZZ 等） |
 | `TMov` `CommonCheckMX` | 允许 `uint8_t` Mat → `float8_e8m0` ScaleLeft/Right；canonical：ui8 Mat reshape 再 ui8→f8 Scale |
 | bind-then-fill | **先** `GetScaleAddr(Left/Right)` 再填 sidecar；写 provisional alloc 地址在 rebound 后无效 |
-| 对齐 | 与 ISA `tmatmul_mx` 一致：physical `M%16==0`、`K%64==0`、`N%32==0`（fp8）；`DeduceTileMatMulMxType` **仅对常量维**强制；符号维跳过数值检查 |
+| 对齐 | cast 后的 FP8 tile extent 要求 physical `M%16==0`、`K%64==0`、`N%32==0`；`DeduceTileMatMulMxType` **仅对常量维**强制；符号维跳过数值检查 |
 
 #### MX / Ascend950：PTOAS 约束
 

--- a/docs/zh/dev/passes/18-insert_mx_scale_addr.md
+++ b/docs/zh/dev/passes/18-insert_mx_scale_addr.md
@@ -11,7 +11,7 @@ bound_scale = tile.tget_scale_addr(scale, data)
 matmul_mx(..., bound_scale, ...)
 ```
 
-`tile.tget_scale_addr` 有意不暴露在公共 `pypto.language` API 中。用户只编写高层 `matmul_mx` 算子族；编译器根据 matmul 操作数位置推导左右侧。低层 `ir.op.tile.tget_scale_addr` 仍供编译器构造与 IR 解析使用，且只接受已解析的 `(LeftScale, Left)` 与 `(RightScale, Right)` 配对。
+`tile.tget_scale_addr` 有意不暴露在公共 `pypto.language` API 中。用户只编写高层 `matmul_mx` 算子族；编译器根据 matmul 操作数位置推导左右侧。低层 `ir.op.tile.tget_scale_addr` 仍供编译器构造与 IR 解析使用，且只接受已解析的 `(LeftScale, Left)` 与 `(RightScale, Right)` 配对，data tile 必须为 `FP8E4M3FN`。左侧 FP4 输入会在进入本 pass 前先转换为 FP8。
 
 **流水线位置**：紧接在 [`InferTileMemorySpace`](17-infer_tile_memory_space.md) 之后，[`ResolveBackendOpLayouts`](19-resolve_backend_op_layouts.md) 之前。
 

--- a/docs/zh/dev/ptoas-op-status.md
+++ b/docs/zh/dev/ptoas-op-status.md
@@ -4,7 +4,7 @@
 行 = **最新 PTOAS 提供的公共及兼容 op**。接口基线为 Little-oil/PTOAS `main`
 `d852dd2dba3e5bf7a69ce8324eb88afc336e8a33`：manual 公共接口 189 个，加当前
 `PTOOps.td` 仍保留的 source-only 兼容/tile 接口 15 个，共 204 个。列状态按
-**PyPTO 当前源码**核实（最后更新 2026-07-27）。后续每加或修改一个 op，只更新本表对应行。
+**PyPTO 当前源码**核实（最后更新 2026-08-11）。后续每加或修改一个 op，只更新本表对应行。
 
 本表包含公共/兼容接口中 PyPTO 级别为 `internal` 的 op；另有 `PTOOps.td` 中 32 个仅供
 lowering/compiler plumbing 使用的额外内部 op 未纳入，也不列 VPTO、VMI、SIMT 等其他 dialect。
@@ -63,8 +63,8 @@ lowering/compiler plumbing 使用的额外内部 op 未纳入，也不列 VPTO�
 | pto.tmatmul | TMATMUL | tile+tensor | ✅ | ✅ | ✅ | ✅ | — |  |
 | pto.tmatmul.acc | TMATMUL_ACC | tile+tensor | ✅ | ✅ | ✅ | ✅ | — |  |
 | pto.tmatmul.bias | TMATMUL_BIAS | tile | ✅ | ✅ | ❌ | ✅ | — |  |
-| pto.tmatmul.mx | TMATMUL_MX | tile | ✅ | ✅ | ✅ | ❌ | — | NEW frontend+codegen（最小 MXFP8 host-prequant）；见 [operators MX 约束](ir/05-operators.md#mx--ascend950pto-isa-约束)；设备数值 follow-up #1975 |
-| pto.tmatmul.mx.acc | TMATMUL_MX (overload) | tile | ✅ | ✅ | ✅ | ❌ | — | NEW frontend+codegen（`tile.matmul_mx_acc`）；ST 待补 |
+| pto.tmatmul.mx | TMATMUL_MX | tile | ✅ | ✅ | ✅ | ✅ | — | A5 MXFP8 host-prequant frontend+codegen+ST；FP4 输入仅支持左侧 FP4×右侧 FP8，且必须显式做 FP4→FP8 cast；原生 FP4×FP4 暂缓；见 [operators MX 约束](ir/05-operators.md#mx--ascend950pto-isa-约束) |
+| pto.tmatmul.mx.acc | TMATMUL_MX (overload) | tile | ✅ | ✅ | ✅ | ✅ | — | A5 frontend+codegen+ST（`tile.matmul_mx_acc`） |
 | pto.tmatmul.mx.bias | TMATMUL_MX (overload) | tile | ✅ | ✅ | ✅ | ❌ | — | NEW frontend+codegen（`tile.matmul_mx_bias`）；ST 待补 |
 | pto.tgemv | TGEMV | tile | ✅ | ✅ | ❌ | ❌ | — | 已有链路；历史 ISA/语义问题，需按当前 pin 复验 |
 | pto.tgemv.acc | TGEMV_ACC | tile | ✅ | ✅ | ❌ | ❌ | — | 已有链路；历史 ISA/语义问题，需按当前 pin 复验 |

--- a/docs/zh/user/language/00-types.md
+++ b/docs/zh/user/language/00-types.md
@@ -63,11 +63,15 @@ def scale_rows(
 | `pl.INDEX` | 64 | 索引运算 —— 循环变量、维度 |
 | `pl.TASK_ID` | — | 已派发任务的生产者句柄 |
 
-`dtype.get_byte()` 返回元素的字节数。只要字节数是算出来的而不是写死的字面量，就用它 —— 把元素个数传到期望字节数的地方是一次**静默的欠分配**。
+`dtype.get_byte()` 返回向上取整后的可按字节寻址元素大小。对于按字节寻址的 dtype，只要字节数是算出来的而不是写死的字面量，就用它。4-bit buffer 不能使用 `logical_elements * dtype.get_byte()`：PyPTO 会把所有语义 4-bit dtype 按每字节两个逻辑元素打包，物理大小为 `ceil(logical_elements / 2)`。
 
 ```python
 nbytes = 256 * pl.FP32.get_byte()          # 1024, not 256
 ```
+
+PyPTO IR 中的 FP4 shape 是以 nibble 计数的逻辑 shape，`valid_shape` 也使用相同单位。Torch/runtime 边界上的 `torch.float4_e2m1fn_x2` 使用物理 x2 carrier shape：末维的每个元素是一字节、承载两个逻辑 FP4。JIT 在入口展开末维，compiled-call metadata 与 orchestration allocation 将末维除以二；`TensorType` 和 `TileType` 不保存单独的 `storage_shape`。Packed FP4 的逻辑末维必须是正偶数，静态 allocation/view shape 同样受此约束，动态宽度会在换算前检查。4-bit slice 起点必须落在字节边界；线性 nibble offset 为奇数时会直接报错。
+
+4-bit 端到端执行按后端做能力检查。Ascend950 支持 `pl.FP4`；`INT4`、`UINT4`、`HF4` 虽使用统一存储计数，但 in-core codegen 会拒绝。Ascend910B/A2A3 会拒绝所有 4-bit in-core dtype，因为它只有孤立的 FP16↔INT4 转换，没有配套的 packed load/store carrier ABI。
 
 ### 容器类型
 
@@ -109,7 +113,7 @@ view = pl.TensorView(stride=[1024, 1], layout=pl.TensorLayout.ND, valid_shape=[1
 
 只要给了 `stride`、`valid_shape`、`pad` 三者之一，`layout=` 就是必填的。`pl.TensorLayout` 是这些布局常量所属的枚举 —— `pl.ND` 就是 `pl.TensorLayout.ND`。
 
-剩下两个布局常量是 `pl.MX_A_ZZ` 与 `pl.MX_B_NN`。它们标注 Ascend950 上 MX（microscaling）操作数的 **GM scale 张量** —— `MX_A_ZZ` 对应左/A 侧 scale pack，`MX_B_NN` 对应右/B 侧 —— 使 Mat 到 scale 的 `pl.move` 能校验源布局，而不是把不兼容的数据按字节拷进 `LeftScale` / `RightScale`。这是唯一一处**要求**在 `pl.Tensor` 注解上写布局标记、而非不建议写的场景。当前限制：MX 的 `pl.load` 必须显式传 `target_memory=pl.Mem.Mat`；MX 子视图（`slice`、`reshape`、`transpose`、`reinterpret_view`、`view`）与 MX `remote_load` 会被拒绝。矩阵乘本身是 `pl.matmul_mx` 及其 `_acc` / `_bias` 变体，每个操作数各接一块数据 tile 和一块 scale tile。
+剩下两个布局常量是 `pl.MX_A_ZZ` 与 `pl.MX_B_NN`。它们标注 Ascend950 上 MX（microscaling）操作数的 **GM scale 张量** —— `MX_A_ZZ` 对应左/A 侧 scale pack，`MX_B_NN` 对应右/B 侧 —— 使 Mat 到 scale 的 `pl.move` 能校验源布局，而不是把不兼容的数据按字节拷进 `LeftScale` / `RightScale`。这是唯一一处**要求**在 `pl.Tensor` 注解上写布局标记、而非不建议写的场景。当前限制：MX 的 `pl.load` 必须显式传 `target_memory=pl.Mem.Mat`；MX 子视图（`slice`、`reshape`、`transpose`、`reinterpret_view`、`view`）与 MX `remote_load` 会被拒绝。矩阵乘本身是 `pl.matmul_mx` 及其 `_acc` / `_bias` 变体，每个操作数各接一块 data tile 和一块 scale tile。进入算子的两块 data tile 必须都是 `FP8E4M3FN`。支持的 FP4 输入形式仅为左侧 FP4×右侧 FP8，并且必须在 `matmul_mx` 前显式写 `pl.cast(fp4_tile, pl.FP8E4M3FN)`；A5 的 cast legalization pass 会将其展开为 FP4→BF16→FP32→FP8E4M3FN。原生 FP4×FP4 与反向 FP8×FP4 均不支持，MXFP4 quant 前端本次仍未开放。
 
 ### 动态 shape
 

--- a/docs/zh/user/ops/01-catalog.md
+++ b/docs/zh/user/ops/01-catalog.md
@@ -124,7 +124,7 @@
 | `matmul_bias` | `pl.` (t) | 带 bias 操作数的乘法 |
 | `batch_matmul` | `pl.` (t) | 批量矩阵乘，**只接受 tile 操作数**。张量请调 `pl.matmul` —— rank > 2 会在降级时派发到 `tile.batch_matmul` |
 | `gemv` `gemv_acc` `gemv_bias` | `pl.` (t) | 矩阵-向量形式 |
-| `matmul_mx` `matmul_mx_acc` `matmul_mx_bias` | `pl.` (t) | MX 块缩放矩阵乘 —— 每个操作数由一块 FP8E4M3FN 数据 tile 和一块 FP8E8M0 scale tile 组成 |
+| `matmul_mx` `matmul_mx_acc` `matmul_mx_bias` | `pl.` (t) | A5 MX 块缩放矩阵乘 —— 进入算子的两块 data tile 必须为 FP8E4M3FN；支持的 FP4 输入形式仅为 FP4×FP8，且左侧 FP4 必须先显式 cast 为 FP8；不支持原生 FP4×FP4 |
 
 ## Gather、Scatter、排序
 

--- a/include/pypto/backend/950/backend_950_handler.h
+++ b/include/pypto/backend/950/backend_950_handler.h
@@ -40,6 +40,9 @@ class Ascend950Handler : public BackendHandler {
   [[nodiscard]] std::string GetLaunchSpecCoreCountMethod() const override { return "set_core_num"; }
   [[nodiscard]] std::string GetDefaultSimPlatform() const override { return "a5sim"; }
   [[nodiscard]] std::vector<std::string> GetExtraPtoasFlags() const override { return {"--pto-arch", "a5"}; }
+  [[nodiscard]] bool SupportsIncoreDataType(const DataType& dtype) const override {
+    return dtype.GetBit() != 4 || dtype == DataType::FP4;
+  }
 
   [[nodiscard]] bool RequiresGMPipeBuffer() const override { return false; }
   [[nodiscard]] bool RequiresSplitLoadTpopWorkaround() const override { return false; }

--- a/include/pypto/backend/common/backend_handler.h
+++ b/include/pypto/backend/common/backend_handler.h
@@ -167,6 +167,19 @@ class BackendHandler {
    */
   [[nodiscard]] virtual std::vector<std::string> GetExtraPtoasFlags() const = 0;
 
+  /**
+   * @brief Whether a dtype has an end-to-end in-core storage and PTO ABI on
+   *        this backend.
+   *
+   * Semantic 4-bit dtypes are packed in PyPTO's memory accounting, but that
+   * alone does not make them executable. Backends opt in only after their
+   * load/store and instruction ABI is available. Byte-addressable dtypes keep
+   * their existing support path.
+   */
+  [[nodiscard]] virtual bool SupportsIncoreDataType(const DataType& dtype) const {
+    return dtype.GetBit() != 4;
+  }
+
   // ---------------------------------------------------------------------------
   // Pass behavioural hooks
   // ---------------------------------------------------------------------------

--- a/include/pypto/codegen/codegen_base.h
+++ b/include/pypto/codegen/codegen_base.h
@@ -12,6 +12,7 @@
 #ifndef PYPTO_CODEGEN_CODEGEN_BASE_H_
 #define PYPTO_CODEGEN_CODEGEN_BASE_H_
 
+#include <cstddef>
 #include <cstdint>
 #include <string>
 
@@ -152,6 +153,17 @@ class CodegenBase : public ir::IRVisitor {
     }
     return "static_cast<uint32_t>((" + default_dim_expr + ") * (" + scale_expr + "))";
   }
+
+  /**
+   * @brief Convert one logical IR tensor extent to its runtime carrier extent.
+   *
+   * Runtime FP4 tensors use one x2 carrier element per byte, while IR shapes
+   * count logical nibbles. Only the innermost dimension is packed; all other
+   * dtypes and dimensions preserve their logical extent. Dynamic FP4 extents
+   * are asserted positive and even before conversion.
+   */
+  [[nodiscard]] virtual std::string GetRuntimeTensorShapeDim(const DataType& dtype, size_t axis, size_t ndim,
+                                                             const std::string& logical_dim_expr) const;
 
   /**
    * @brief Get the runtime DataType enum string for generated code

--- a/include/pypto/ir/storage_size.h
+++ b/include/pypto/ir/storage_size.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#ifndef PYPTO_IR_STORAGE_SIZE_H_
+#define PYPTO_IR_STORAGE_SIZE_H_
+
+#include <cstdint>
+#include <limits>
+#include <optional>
+
+#include "pypto/core/dtype.h"
+
+namespace pypto::ir::storage_size {
+
+/// Physical storage width of one logical element.
+///
+/// Every semantic 4-bit dtype uses packed nibble storage. Other sub-byte
+/// dtypes, notably BOOL, remain byte-addressable to preserve their existing
+/// buffer ABI.
+inline uint64_t GetStorageBitWidth(const DataType& dtype) {
+  return dtype.GetBit() == 4 ? 4 : static_cast<uint64_t>(dtype.GetByte()) * 8;
+}
+
+/// Bytes occupied by ``logical_elements`` contiguous logical elements.
+/// Invalid dtypes and multiplication overflow return nullopt.
+inline std::optional<uint64_t> StaticStorageBytes(uint64_t logical_elements, const DataType& dtype) {
+  const uint64_t storage_bits = GetStorageBitWidth(dtype);
+  if (storage_bits == 0 || logical_elements > std::numeric_limits<uint64_t>::max() / storage_bits) {
+    return std::nullopt;
+  }
+  const uint64_t total_bits = logical_elements * storage_bits;
+  return total_bits / 8 + static_cast<uint64_t>(total_bits % 8 != 0);
+}
+
+/// Byte offset of a statically known logical element offset.
+///
+/// A packed-nibble origin cannot be represented by MemRef's byte_offset field,
+/// so odd nibble offsets return nullopt rather than being rounded.
+inline std::optional<uint64_t> StaticLogicalOffsetToByte(uint64_t logical_offset, const DataType& dtype) {
+  const uint64_t storage_bits = GetStorageBitWidth(dtype);
+  if (storage_bits == 0 || logical_offset > std::numeric_limits<uint64_t>::max() / storage_bits) {
+    return std::nullopt;
+  }
+  const uint64_t bit_offset = logical_offset * storage_bits;
+  if (bit_offset % 8 != 0) return std::nullopt;
+  return bit_offset / 8;
+}
+
+}  // namespace pypto::ir::storage_size
+
+#endif  // PYPTO_IR_STORAGE_SIZE_H_

--- a/include/pypto/ir/tile_view_semantics.h
+++ b/include/pypto/ir/tile_view_semantics.h
@@ -24,6 +24,7 @@
 #include "pypto/ir/memory_space.h"
 #include "pypto/ir/scalar_expr.h"
 #include "pypto/ir/span.h"
+#include "pypto/ir/storage_size.h"
 #include "pypto/ir/type.h"
 
 namespace pypto::ir::tile_view_semantics {
@@ -62,10 +63,10 @@ inline std::optional<BoxedTileAlignment> GetBoxedTileAlignment(const TileView& v
       }
       return std::nullopt;
     case 512: {
-      constexpr int64_t kAlignedBytes = 32;
-      const int64_t element_bytes = static_cast<int64_t>(dtype.GetByte());
-      if (element_bytes <= 0 || kAlignedBytes % element_bytes != 0) return std::nullopt;
-      const int64_t packed_extent = kAlignedBytes / element_bytes;
+      constexpr int64_t kAlignedBits = int64_t{32} * 8;
+      const int64_t storage_bits = static_cast<int64_t>(storage_size::GetStorageBitWidth(dtype));
+      if (storage_bits <= 0 || kAlignedBits % storage_bits != 0) return std::nullopt;
+      const int64_t packed_extent = kAlignedBits / storage_bits;
       if (view.slayout == TileLayout::row_major) {
         return BoxedTileAlignment{/*rows=*/16, /*cols=*/packed_extent};
       }

--- a/include/pypto/ir/transforms/utils/l0c_footprint.h
+++ b/include/pypto/ir/transforms/utils/l0c_footprint.h
@@ -23,6 +23,7 @@
 #include "pypto/ir/kind_traits.h"
 #include "pypto/ir/memory_space.h"
 #include "pypto/ir/scalar_expr.h"
+#include "pypto/ir/storage_size.h"
 #include "pypto/ir/type.h"
 
 namespace pypto::ir::utils {
@@ -105,11 +106,7 @@ inline std::optional<uint64_t> StaticPhysicalAllocationBytes(const ShapedTypePtr
     if (elements > std::numeric_limits<uint64_t>::max() / extent) return std::nullopt;
     elements *= extent;
   }
-  const uint64_t element_bytes = type->dtype_.GetByte();
-  if (element_bytes == 0 || elements > std::numeric_limits<uint64_t>::max() / element_bytes) {
-    return std::nullopt;
-  }
-  return elements * element_bytes;
+  return storage_size::StaticStorageBytes(elements, type->dtype_);
 }
 
 }  // namespace pypto::ir::utils

--- a/include/pypto/ir/transforms/utils/memref_utils.h
+++ b/include/pypto/ir/transforms/utils/memref_utils.h
@@ -17,6 +17,7 @@
 #include <cctype>
 #include <cstddef>
 #include <cstdint>
+#include <limits>
 #include <map>
 #include <memory>
 #include <optional>
@@ -34,6 +35,7 @@
 #include "pypto/ir/scalar_expr.h"
 #include "pypto/ir/span.h"
 #include "pypto/ir/stmt.h"
+#include "pypto/ir/storage_size.h"
 #include "pypto/ir/transforms/utils/transform_utils.h"
 #include "pypto/ir/type.h"
 
@@ -339,9 +341,13 @@ inline ExprPtr MulByteOffsets(const ExprPtr& lhs, const ExprPtr& rhs) {
 }
 
 /// Compute byte offset for a slice operation.
-/// byte_offset = (o0 * s1 * ... * sN + o1 * s2 * ... * sN + ... + oN) * elem_bytes
+/// byte_offset = (o0 * s1 * ... * sN + o1 * s2 * ... * sN + ... + oN) * storage_bits / 8
+///
+/// MemRef carries a byte offset rather than a nibble offset. Packed 4-bit
+/// slices therefore require a static, byte-aligned logical origin in v1.
 inline ExprPtr ComputeSliceByteOffset(const std::vector<ExprPtr>& offsets,
-                                      const std::vector<ExprPtr>& parent_shape, uint64_t elem_bytes) {
+                                      const std::vector<ExprPtr>& parent_shape, const DataType& dtype,
+                                      const Span& span) {
   INTERNAL_CHECK(offsets.size() == parent_shape.size())
       << "Internal error: slice offset rank (" << offsets.size() << ") must match parent shape rank ("
       << parent_shape.size() << ")";
@@ -356,9 +362,29 @@ inline ExprPtr ComputeSliceByteOffset(const std::vector<ExprPtr>& offsets,
     result = AddByteOffsets(result, MulByteOffsets(offsets[i], stride));
   }
 
-  auto elem_size_expr =
-      std::make_shared<ConstInt>(static_cast<int64_t>(elem_bytes), DataType::INDEX, Span::unknown());
-  return MulByteOffsets(result, elem_size_expr);
+  const uint64_t storage_bits = storage_size::GetStorageBitWidth(dtype);
+  INTERNAL_CHECK_SPAN(storage_bits > 0, span)
+      << "Internal error: slice dtype has no storage width: " << dtype.ToString();
+  if (storage_bits % 8 == 0) {
+    auto elem_size_expr =
+        std::make_shared<ConstInt>(static_cast<int64_t>(storage_bits / 8), DataType::INDEX, Span::unknown());
+    return MulByteOffsets(result, elem_size_expr);
+  }
+
+  auto logical_offset = As<ConstInt>(result);
+  CHECK_SPAN(logical_offset, span)
+      << "Packed 4-bit slice offsets must be compile-time constants because MemRef cannot represent "
+         "a dynamic nibble offset";
+  CHECK_SPAN(logical_offset->value_ >= 0, span)
+      << "Packed 4-bit slice offsets must be non-negative, but got logical offset " << logical_offset->value_;
+  const auto byte_offset =
+      storage_size::StaticLogicalOffsetToByte(static_cast<uint64_t>(logical_offset->value_), dtype);
+  CHECK_SPAN(byte_offset.has_value(), span)
+      << "Packed 4-bit slice origins must be byte-aligned; logical linear offset " << logical_offset->value_
+      << " selects the second nibble of a byte";
+  CHECK_SPAN(*byte_offset <= static_cast<uint64_t>(std::numeric_limits<int64_t>::max()), span)
+      << "Packed 4-bit slice byte offset overflows int64";
+  return std::make_shared<ConstInt>(static_cast<int64_t>(*byte_offset), DataType::INDEX, Span::unknown());
 }
 
 /// Compute additional byte offset for a view operation.
@@ -384,8 +410,7 @@ inline ExprPtr ComputeViewByteOffset(const CallPtr& call, const TypePtr& parent_
       offsets.push_back(call->args_[offset_arg_idx]);
     }
 
-    uint64_t elem_bytes = (shaped->dtype_.GetBit() + 7) / 8;
-    return ComputeSliceByteOffset(offsets, shaped->shape_, elem_bytes);
+    return ComputeSliceByteOffset(offsets, shaped->shape_, shaped->dtype_, call->span_);
   }
 
   // Non-slice view ops (reshape, transpose, extract):

--- a/python/pypto/backend/pto_backend.py
+++ b/python/pypto/backend/pto_backend.py
@@ -42,6 +42,7 @@ from pypto.backend._ptoas_locate import PTOAS_RELATIVE_PATHS as _PTOAS_RELATIVE_
 from pypto.backend._ptoas_locate import find_ptoas_binary as _find_ptoas_binary
 from pypto.backend._ptoas_preprocess import preprocess_ptoas_output as _preprocess_ptoas_output
 from pypto.compile_profiling import CompileProfiler, StageRecord
+from pypto.pypto_core import DataType
 from pypto.pypto_core import backend as _backend_core
 from pypto.pypto_core import codegen as _codegen_core
 from pypto.pypto_core import ir as _ir_core
@@ -350,10 +351,16 @@ def _invert_var_mul_or_floordiv_const(
 
 
 def _invert_shape_dim_for_var(
-    dim_expr: object, target_var: _ir_core.Var, tensor_name: str, dim_idx: int
+    dim_expr: object,
+    target_var: _ir_core.Var,
+    tensor_name: str,
+    dim_idx: int,
+    logical_scale: int = 1,
 ) -> str | None:
     """Return a C expression recovering target_var from shapes[dim_idx], or None if non-invertible."""
     shape_expr = f"static_cast<int64_t>({tensor_name}_tensor->shapes[{dim_idx}])"
+    if logical_scale != 1:
+        shape_expr = f"({shape_expr} * {logical_scale})"
     if isinstance(dim_expr, _ir_core.Var) and dim_expr.same_as(target_var):
         return shape_expr
     if isinstance(dim_expr, _ir_core.Add):
@@ -413,7 +420,19 @@ def _append_dynamic_dim_unpacking(
 
     for dyn_var in dyn_var_order:
         var_ref, source_tensor, source_dim_idx, source_expr = dyn_var_best[dyn_var.unique_id]
-        value_expr = _invert_shape_dim_for_var(source_expr, var_ref, source_tensor, source_dim_idx)
+        source_param = next(param for param in tensor_params if param.name_hint == source_tensor)
+        source_type = source_param.type
+        assert isinstance(source_type, _ir_core.TensorType)
+        logical_scale = (
+            2 if source_type.dtype == DataType.FP4 and source_dim_idx == len(source_type.shape) - 1 else 1
+        )
+        value_expr = _invert_shape_dim_for_var(
+            source_expr,
+            var_ref,
+            source_tensor,
+            source_dim_idx,
+            logical_scale=logical_scale,
+        )
         if value_expr is None:
             raise ValueError(
                 f"Cannot recover dynamic dimension '{dyn_var.name_hint}' for kernel wrapper "

--- a/python/pypto/ir/compiled_program.py
+++ b/python/pypto/ir/compiled_program.py
@@ -20,7 +20,7 @@ torch tensors::
 
 import ctypes
 import os
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -111,6 +111,33 @@ def _to_torch_dtype(dtype: DataType) -> torch.dtype | None:
     return _DATATYPE_TO_TORCH.get(str(dtype))
 
 
+def _to_runtime_shape(shape: list[int], dtype: DataType) -> list[int]:
+    """Convert logical IR shape to the runtime carrier shape.
+
+    Only packed FP4 differs: Torch/runtime use one x2 element per byte while
+    PyPTO IR counts logical nibbles. The conversion remains at the call ABI
+    boundary, so no persistent storage_shape is needed in IR types.
+    """
+    runtime_shape = list(shape)
+    if dtype == DataType.FP4 and runtime_shape[-1] != -1:
+        # Static FP4 shape validity is centralized in ShapedType construction.
+        runtime_shape[-1] //= 2
+    return runtime_shape
+
+
+def _validate_fp4_carrier_shape(shape: Sequence[int], info: "_ParamInfo") -> None:
+    """Validate the runtime x2 carrier shape for one FP4 parameter."""
+    if info.dtype != DataType.FP4:
+        return
+    if not shape:
+        raise TypeError(f"Packed FP4 parameter {info.name!r} must have rank >= 1")
+    if shape[-1] <= 0:
+        raise TypeError(
+            f"Packed FP4 parameter {info.name!r} requires a positive runtime x2 carrier last dimension; "
+            f"got shape {tuple(shape)}"
+        )
+
+
 @dataclass
 class _ParamInfo:
     """Metadata for a single orchestration function parameter."""
@@ -182,7 +209,8 @@ def _extract_func_param_infos(func: Function) -> tuple[list[_ParamInfo], list[in
 
         if isinstance(param_type, ShapedType):
             dtype = param_type.dtype
-            shape = [dim.value if isinstance(dim, ConstInt) else -1 for dim in param_type.shape]
+            logical_shape = [dim.value if isinstance(dim, ConstInt) else -1 for dim in param_type.shape]
+            shape = _to_runtime_shape(logical_shape, dtype)
         elif isinstance(param_type, ScalarType):
             dtype = param_type.dtype
         else:
@@ -257,6 +285,7 @@ def _validate_device_tensor(arg: DeviceTensor, info: _ParamInfo) -> None:
                     f"Parameter {info.name!r} expects shape {tuple(info.shape)}; "
                     f"got DeviceTensor shape {arg.shape}"
                 )
+    _validate_fp4_carrier_shape(arg.shape, info)
     expected_dtype = _to_torch_dtype(info.dtype)
     if expected_dtype is not None and arg.dtype != expected_dtype:
         raise TypeError(
@@ -288,6 +317,7 @@ def _validate_stacked_tensor(arg: StackedDeviceTensor, info: _ParamInfo) -> None
                     f"Parameter {info.name!r} expects shape {tuple(info.shape)}; "
                     f"got StackedDeviceTensor full_shape {arg.full_shape}"
                 )
+    _validate_fp4_carrier_shape(arg.full_shape, info)
     expected_dtype = _to_torch_dtype(info.dtype)
     if expected_dtype is not None and arg.dtype != expected_dtype:
         raise TypeError(
@@ -388,6 +418,8 @@ def _coerce_args(  # noqa: PLR0912 — branches for in-place vs return + scalar/
                 )
             if isinstance(arg, DeviceTensor):
                 _validate_device_tensor(arg, info)
+            else:
+                _validate_fp4_carrier_shape(arg.shape, info)
             coerced.append(arg)
 
     return coerced, return_style

--- a/python/pypto/jit/decorator.py
+++ b/python/pypto/jit/decorator.py
@@ -226,7 +226,21 @@ def _extract_tensor_meta(
     ``layout`` comes from the parameter's annotation, not the tensor: torch has
     no notion of a PyPTO layout, so the annotation is the only source.
     """
-    return _build_tensor_meta(tensor.shape, _torch_dtype_to_pypto(tensor.dtype), dyn_dims, layout)
+    dtype = _torch_dtype_to_pypto(tensor.dtype)
+    extents = list(tensor.shape)
+    if dtype == DataType.FP4:
+        if not extents:
+            raise TypeError("Packed torch.float4_e2m1fn_x2 tensors must have rank >= 1")
+        if extents[-1] <= 0:
+            raise TypeError(
+                "Packed torch.float4_e2m1fn_x2 tensors require a positive runtime x2 carrier last "
+                f"dimension; got shape {tuple(extents)}"
+            )
+        # Torch exposes one x2 carrier per byte. PyPTO IR and PTO-ISA count
+        # logical FP4 nibbles, so expand only at this API boundary and keep the
+        # storage shape out of TensorType/TileType.
+        extents[-1] *= 2
+    return _build_tensor_meta(extents, dtype, dyn_dims, layout)
 
 
 def _resolve_annotation(annotation: Any, ann_ns: dict[str, Any] | None) -> Any:

--- a/python/pypto/language/op/tile_ops.py
+++ b/python/pypto/language/op/tile_ops.py
@@ -1247,6 +1247,10 @@ def matmul_bias(lhs: Tile, rhs: Tile, bias: Tile) -> Tile:
 def matmul_mx(lhs: Tile, lhs_scale: Tile, rhs: Tile, rhs_scale: Tile) -> Tile:
     """MX block-scale matrix multiplication.
 
+    Both data tiles passed to this operation must be FP8E4M3FN. For the
+    supported FP4 x FP8 input form, explicitly cast the FP4 lhs to FP8E4M3FN
+    before calling this operation; native FP4 x FP4 is not supported.
+
     Args:
         lhs: Left-hand side data tile (FP8E4M3FN)
         lhs_scale: Left-hand side scale tile (FP8E8M0)
@@ -1262,6 +1266,9 @@ def matmul_mx(lhs: Tile, lhs_scale: Tile, rhs: Tile, rhs_scale: Tile) -> Tile:
 
 def matmul_mx_acc(acc: Tile, lhs: Tile, lhs_scale: Tile, rhs: Tile, rhs_scale: Tile) -> Tile:
     """MX block-scale matmul with accumulation.
+
+    Data operands follow :func:`matmul_mx`: an FP4 lhs must first be cast to
+    FP8E4M3FN, and the operation itself receives two FP8E4M3FN tiles.
 
     Args:
         acc: Accumulator tile
@@ -1281,6 +1288,9 @@ def matmul_mx_acc(acc: Tile, lhs: Tile, lhs_scale: Tile, rhs: Tile, rhs_scale: T
 
 def matmul_mx_bias(lhs: Tile, lhs_scale: Tile, rhs: Tile, rhs_scale: Tile, bias: Tile) -> Tile:
     """MX block-scale matmul with bias.
+
+    Data operands follow :func:`matmul_mx`: an FP4 lhs must first be cast to
+    FP8E4M3FN, and the operation itself receives two FP8E4M3FN tiles.
 
     Args:
         lhs: Left-hand side data tile (FP8E4M3FN)

--- a/python/pypto/runtime/golden_writer.py
+++ b/python/pypto/runtime/golden_writer.py
@@ -455,6 +455,10 @@ def _torch_dtype_str(dtype: torch.dtype) -> str:
         torch.int64: "torch.int64",
         torch.bool: "torch.bool",
     }
+    for optional_name in ("float8_e4m3fn", "float8_e8m0fnu", "float4_e2m1fn_x2"):
+        optional_dtype = getattr(torch, optional_name, None)
+        if isinstance(optional_dtype, torch.dtype):
+            _map[optional_dtype] = f"torch.{optional_name}"
     result = _map.get(dtype)
     if result is None:
         raise ValueError(f"Unsupported dtype {dtype!r} in TensorSpec")

--- a/src/backend/common/pto_ops_datamove.cpp
+++ b/src/backend/common/pto_ops_datamove.cpp
@@ -35,6 +35,7 @@
 #include "pypto/ir/expr.h"
 #include "pypto/ir/kind_traits.h"
 #include "pypto/ir/scalar_expr.h"
+#include "pypto/ir/storage_size.h"
 #include "pypto/ir/tile_view_semantics.h"
 #include "pypto/ir/transforms/utils/memref_utils.h"
 #include "pypto/ir/type.h"
@@ -1107,7 +1108,7 @@ void RegisterDataMoveOps(Backend& backend, const std::unordered_set<std::string>
     auto col_offset_const = ir::As<ir::ConstInt>(offset_tuple->elements_[1]);
     mat_info.const_offset = row_offset_const != nullptr && col_offset_const != nullptr;
 
-    // A subview's address is base + (row * source_cols + col) * element_bytes.
+    // A subview's address is base + (row * source_cols + col) * storage_bits / 8.
     // Record whether that address is provably 32-byte aligned for every runtime
     // offset. A dynamic row remains safe when the physical row stride is a
     // multiple of 32 bytes; a dynamic column is conservatively unknown.
@@ -1122,20 +1123,30 @@ void RegisterDataMoveOps(Backend& backend, const std::unordered_set<std::string>
         source_base_mod_32 = source_byte_offset->value_ % 32;
       }
     }
-    const int64_t element_bytes = static_cast<int64_t>(source_tile_type->dtype_.GetByte());
+    const int64_t storage_bits =
+        static_cast<int64_t>(ir::storage_size::GetStorageBitWidth(source_tile_type->dtype_));
     int64_t local_offset_mod_32 = -1;
-    if (col_offset_const != nullptr && element_bytes > 0) {
+    if (col_offset_const != nullptr && storage_bits > 0) {
+      auto mod_256 = [](int64_t value) {
+        const int64_t result = value % 256;
+        return result < 0 ? result + 256 : result;
+      };
+      auto logical_to_byte_mod_32 = [&](int64_t logical_mod_256) {
+        const int64_t bit_offset_mod_256 = (mod_256(logical_mod_256) * mod_256(storage_bits)) % 256;
+        return bit_offset_mod_256 % 8 == 0 ? bit_offset_mod_256 / 8 : int64_t{-1};
+      };
       if (row_offset_const != nullptr) {
         if (mat_info.source_cols > 0 || row_offset_const->value_ == 0) {
-          const int64_t row_bytes_mod =
-              ((row_offset_const->value_ % 32) * (mat_info.source_cols % 32) * (element_bytes % 32)) % 32;
-          const int64_t col_bytes_mod = ((col_offset_const->value_ % 32) * (element_bytes % 32)) % 32;
-          local_offset_mod_32 = (row_bytes_mod + col_bytes_mod) % 32;
+          const int64_t linear_mod_256 = (mod_256(row_offset_const->value_) * mod_256(mat_info.source_cols) +
+                                          mod_256(col_offset_const->value_)) %
+                                         256;
+          local_offset_mod_32 = logical_to_byte_mod_32(linear_mod_256);
         }
       } else if (mat_info.source_cols > 0) {
-        const int64_t row_stride_bytes_mod = (mat_info.source_cols % 32) * (element_bytes % 32) % 32;
-        const int64_t col_bytes_mod = ((col_offset_const->value_ % 32) * (element_bytes % 32)) % 32;
-        if (row_stride_bytes_mod == 0) local_offset_mod_32 = col_bytes_mod;
+        const int64_t row_stride_bit_mod_256 = (mod_256(mat_info.source_cols) * mod_256(storage_bits)) % 256;
+        if (row_stride_bit_mod_256 == 0) {
+          local_offset_mod_32 = logical_to_byte_mod_32(mod_256(col_offset_const->value_));
+        }
       }
     }
     if (source_base_mod_32 >= 0 && local_offset_mod_32 >= 0) {

--- a/src/codegen/codegen_base.cpp
+++ b/src/codegen/codegen_base.cpp
@@ -11,6 +11,7 @@
 
 #include "pypto/codegen/codegen_base.h"
 
+#include <cstddef>
 #include <string>
 
 #include "pypto/core/dtype.h"
@@ -129,11 +130,20 @@ std::string CodegenBase::GetRuntimeDataTypeString(const DataType& dtype) const {
   if (dtype == DataType::FP8E4M3FN) return "DataType::FP8E4M3FN";
   if (dtype == DataType::FP8E5M2) return "DataType::FP8E5M2";
   if (dtype == DataType::FP8E8M0) return "DataType::FP8E8M0";
+  if (dtype == DataType::FP4) return "DataType::FP4E2M1";
   // INDEX is a semantic type in the IR; the runtime represents it as INT64
   if (dtype == DataType::INDEX) return "DataType::INT64";
   if (dtype == DataType::INT64) return "DataType::INT64";
   if (dtype == DataType::UINT64) return "DataType::UINT64";
   return "DataType::UNKNOWN";
+}
+
+std::string CodegenBase::GetRuntimeTensorShapeDim(const DataType& dtype, size_t axis, size_t ndim,
+                                                  const std::string& logical_dim_expr) const {
+  if (dtype != DataType::FP4 || axis + 1 != ndim) return logical_dim_expr;
+  return "([&]() -> uint32_t { const int64_t fp4_logical_dim = static_cast<int64_t>(" + logical_dim_expr +
+         "); always_assert(fp4_logical_dim > 0 && (fp4_logical_dim & 1u) == 0u); return "
+         "static_cast<uint32_t>(fp4_logical_dim / 2); }())";
 }
 
 }  // namespace codegen

--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -244,6 +244,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
                                     std::unordered_map<const Var*, std::string> param_to_emit_name,
                                     std::set<std::string> param_name_set,
                                     std::map<std::string, int> param_name_to_orch_index,
+                                    std::map<std::string, int64_t> packed_fp4_axis,
                                     std::unordered_map<std::string, std::string> dist_param_to_ctx_param)
       : program_(prog),
         func_name_to_id_(func_ids),
@@ -253,6 +254,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
         emit_name_map_(std::move(param_to_emit_name)),
         param_name_set_(std::move(param_name_set)),
         param_name_to_orch_index_(std::move(param_name_to_orch_index)),
+        packed_fp4_axis_(std::move(packed_fp4_axis)),
         dist_param_to_ctx_param_(std::move(dist_param_to_ctx_param)) {
     declared_var_names_ = param_name_set_;
     CollectCompilerDepTaskIds(program_);
@@ -459,12 +461,20 @@ class OrchestrationStmtCodegen : public CodegenBase {
     return CodegenBase::TryGetVarName(expr);
   }
   [[nodiscard]] std::string GetTensorShapeDim(const std::string& name, int64_t axis) const override {
+    std::string physical_dim;
     auto it = param_name_to_orch_index_.find(name);
     if (it != param_name_to_orch_index_.end()) {
-      return "(int64_t)orch_args.tensor(" + std::to_string(it->second) + ").ref().shapes[" +
-             std::to_string(axis) + "]";
+      physical_dim = "(int64_t)orch_args.tensor(" + std::to_string(it->second) + ").ref().shapes[" +
+                     std::to_string(axis) + "]";
+    } else {
+      physical_dim = "(int64_t)" + name + ".shapes[" + std::to_string(axis) + "]";
     }
-    return "(int64_t)" + name + ".shapes[" + std::to_string(axis) + "]";
+    auto packed = packed_fp4_axis_.find(name);
+    if (packed != packed_fp4_axis_.end() && packed->second == axis) {
+      return "([&]() -> int64_t { const int64_t fp4_carrier_dim = " + physical_dim +
+             "; always_assert(fp4_carrier_dim > 0); return fp4_carrier_dim * 2; }())";
+    }
+    return physical_dim;
   }
 
   [[nodiscard]] std::string GetTensorCreateSizeExpr(const std::string& result_var,
@@ -1156,6 +1166,11 @@ class OrchestrationStmtCodegen : public CodegenBase {
 
   void VisitStmt_(const AssignStmtPtr& assign) override {
     std::string var_name = ReserveVarEmitName(assign->var_.get());
+    if (auto tensor_type = AsTensorTypeLike(assign->var_->GetType())) {
+      if (tensor_type->dtype_ == DataType::FP4) {
+        packed_fp4_axis_[var_name] = static_cast<int64_t>(tensor_type->shape_.size() - 1);
+      }
+    }
 
     // Funnel Submit through the existing Call codepath via the synthetic
     // SubmitToCallView adapter (deps_ → attrs[manual_dep_edges]). The IR
@@ -1792,7 +1807,6 @@ class OrchestrationStmtCodegen : public CodegenBase {
     INTERNAL_CHECK_SPAN(tensor_ty, param->span_)
         << "Submit synthesised output for callee '" << callee_func->name_ << "' param[" << param_idx
         << "] must have TensorType, got " << param->GetType()->TypeName();
-
     const size_t ndim = tensor_ty->shape_.size();
     std::string ci_var =
         "params_t" + std::to_string(task_counter_) + "_synth_out_" + std::to_string(param_idx);
@@ -1803,9 +1817,16 @@ class OrchestrationStmtCodegen : public CodegenBase {
         if (i > 0) shapes << ", ";
         std::string dim_str = GenerateExprString(tensor_ty->shape_[i]);
         if (As<ConstInt>(tensor_ty->shape_[i])) {
-          shapes << dim_str;
+          if (tensor_ty->dtype_ == DataType::FP4 && i + 1 == ndim) {
+            shapes << GetConstIntValue(tensor_ty->shape_[i]) / 2;
+          } else {
+            shapes << dim_str;
+          }
         } else {
-          shapes << "static_cast<uint32_t>(" << dim_str << ")";
+          if (tensor_ty->dtype_ != DataType::FP4 || i + 1 != ndim) {
+            dim_str = "static_cast<uint32_t>(" + dim_str + ")";
+          }
+          shapes << GetRuntimeTensorShapeDim(tensor_ty->dtype_, i, ndim, dim_str);
         }
       }
       shapes << "};";
@@ -3946,6 +3967,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
   std::set<std::string> declared_var_names_;
   std::set<std::string> param_name_set_;
   std::map<std::string, int> param_name_to_orch_index_;
+  std::map<std::string, int64_t> packed_fp4_axis_;
   CodeEmitter emitter_;
   CodeEmitter* active_emitter_ = &emitter_;
   std::string current_result_var_;
@@ -4091,6 +4113,7 @@ OrchestrationResult GenerateOrchestration(const ir::ProgramPtr& program, const i
   std::unordered_map<const Var*, std::string> emit_name_map;
   std::set<std::string> param_name_set;
   std::map<std::string, int> param_name_to_orch_index;
+  std::map<std::string, int64_t> packed_fp4_axis;
   int tensor_param_count = 0;
   struct ScalarParamInfo {
     std::string emit_name;
@@ -4111,8 +4134,11 @@ OrchestrationResult GenerateOrchestration(const ir::ProgramPtr& program, const i
     std::string emit_name = GetSSABaseName(var->name_hint_);
     emit_name_map[var.get()] = emit_name;
     param_name_set.insert(emit_name);
-    if (AsTensorTypeLike(var->GetType())) {
+    if (auto tensor_type = AsTensorTypeLike(var->GetType())) {
       param_name_to_orch_index[emit_name] = tensor_param_count;
+      if (tensor_type->dtype_ == DataType::FP4) {
+        packed_fp4_axis[emit_name] = static_cast<int64_t>(tensor_type->shape_.size() - 1);
+      }
       tensor_param_count++;
       orchestration_signature.emplace_back(ParamDirectionToRuntimeName(func->param_directions_[param_idx]));
       if (As<DistributedTensorType>(var->GetType())) {
@@ -4150,7 +4176,7 @@ OrchestrationResult GenerateOrchestration(const ir::ProgramPtr& program, const i
   OrchestrationStmtCodegen stmt_codegen(program, &func_name_to_id, &func_name_to_core_type,
                                         &func_name_to_signature, &next_func_id, std::move(emit_name_map),
                                         std::move(param_name_set), std::move(param_name_to_orch_index),
-                                        std::move(dist_param_to_ctx_param));
+                                        std::move(packed_fp4_axis), std::move(dist_param_to_ctx_param));
   stmt_codegen.SetCallTupleElements(info_collector.call_tuple_elements);
   stmt_codegen.SetTupleVarToKey(info_collector.tuple_var_to_key);
   stmt_codegen.SetEffectiveUses(std::move(use_collector.var_uses));

--- a/src/codegen/pto/pto_codegen.cpp
+++ b/src/codegen/pto/pto_codegen.cpp
@@ -1162,9 +1162,17 @@ void PTOCodegen::EmitMakeTensorViews(const FunctionPtr& func) {
   // PTOAS *infers* DN for shape ``[M, 1]`` with degenerate strides regardless
   // of an ND declaration, so codegen forces DN + ``[1, M]`` strides. MX
   // layouts are explicit hardware contracts and bypass this legacy override.
+  ir::var_collectors::VarDefUseCollector body_vars;
+  if (func->body_) body_vars.VisitStmt(func->body_);
+
   for (const auto& param : func->params_) {
     auto tensor_type = ir::AsTensorTypeLike(param->GetType());
     if (!tensor_type) continue;
+    // Core-group outlining keeps the complete public signature on both the
+    // AIC and AIV functions.  Do not materialize a view for a tensor that the
+    // outlined body does not reference: PTOAS cannot infer a non-ND layout for
+    // such an unused view (notably the MX scale tensors on the AIV cast side).
+    if (body_vars.var_uses.count(param.get()) == 0) continue;
     if (param->name_hint_ == "__gm_pipe_buffer") continue;         // GM slot buffer is a raw pointer
     if (fs_.ffts_workspace_vars.count(param.get()) > 0) continue;  // FFTS workspace stays a memref
 
@@ -1379,12 +1387,30 @@ PTOCodegen::AllocTileFields PTOCodegen::ComputeAllocTileFields(
     return wide;
   };
 
+  // FP4 Vec tile_bufs use PTOAS's physical x2-carrier coordinates along the
+  // BLayout packed axis. PyPTO keeps logical nibble shapes internally; matrix
+  // spaces are excluded because TMATMUL_MX has its own logical-dimension ABI.
+  const auto memory_space = tile_type->GetMemorySpace();
+  const auto tile_view = ir::tile_view_semantics::GetEffectiveTileView(*tile_type);
+  const bool packed_fp4_vec =
+      tile_type->dtype_ == DataType::FP4 && memory_space.has_value() && *memory_space == ir::MemorySpace::Vec;
+  const size_t packed_dim = tile_view.blayout == ir::TileLayout::col_major ? 0 : 1;
+
   // Lower a single valid_shape dim expression to an `index` SSA value.
-  auto lower_dim = [&](const ir::ExprPtr& expr) -> std::string {
+  auto lower_dim = [&](const ir::ExprPtr& expr, size_t dim) -> std::string {
     if (!expr) return "";
     if (auto ci = As<ir::ConstInt>(expr)) {
-      return GetOrEmitConstant(ci->value_, DataType::INDEX);
+      int64_t value = ci->value_;
+      if (packed_fp4_vec && dim == packed_dim) {
+        CHECK(value > 0 && value % 2 == 0)
+            << "FP4 Vec valid_shape packed dimension must be a positive even logical extent for PTOAS, got "
+            << value;
+        value /= 2;
+      }
+      return GetOrEmitConstant(value, DataType::INDEX);
     }
+    CHECK(!(packed_fp4_vec && dim == packed_dim)) << "Dynamic FP4 Vec valid_shape on the packed dimension is "
+                                                     "not supported; provide a static even extent";
     return cast_to_index(GetExprAsCode(expr), expr);
   };
 
@@ -1404,10 +1430,10 @@ PTOCodegen::AllocTileFields PTOCodegen::ComputeAllocTileFields(
     if (dims->size() == 1) {
       // Match ExtractTileTypeInfo: 1-D tile maps to rows=1, cols=shape[0].
       fields.valid_row_ssa = GetOrEmitConstant(static_cast<int64_t>(1), DataType::INDEX);
-      fields.valid_col_ssa = lower_dim((*dims)[0]);
+      fields.valid_col_ssa = lower_dim((*dims)[0], 1);
     } else {
-      if (dims->size() >= 1) fields.valid_row_ssa = lower_dim((*dims)[0]);
-      if (dims->size() >= 2) fields.valid_col_ssa = lower_dim((*dims)[1]);
+      if (dims->size() >= 1) fields.valid_row_ssa = lower_dim((*dims)[0], 0);
+      if (dims->size() >= 2) fields.valid_col_ssa = lower_dim((*dims)[1], 1);
     }
   }
 
@@ -2190,7 +2216,23 @@ std::string PTOCodegen::GetExprAsCode(const ExprPtr& expr) {
   return "";
 }
 
-std::string PTOCodegen::GetTypeString(const DataType& dtype) const { return DataTypeToMLIR(dtype); }
+std::string PTOCodegen::GetTypeString(const DataType& dtype) const {
+  const auto* handler = GetBackendHandler();
+  INTERNAL_CHECK(handler) << "PTOCodegen requires a backend handler";
+  if (!handler->SupportsIncoreDataType(dtype)) {
+    const std::string arch = handler->GetPtoTargetArch();
+    if (arch == "a2a3" && dtype.GetBit() == 4) {
+      CHECK(false) << "The 4-bit dtype " << dtype.ToString()
+                   << " is not supported for end-to-end in-core codegen on backend 'a2a3'. "
+                      "A2/A3 exposes only an isolated FP16<->INT4 conversion, while direct packed "
+                      "4-bit load/store and carrier ABI are unavailable";
+    }
+    CHECK(false) << "The 4-bit dtype " << dtype.ToString()
+                 << " is not supported for end-to-end in-core codegen on backend '" << arch
+                 << "'; A5 currently supports only FP4 among 4-bit dtypes";
+  }
+  return DataTypeToMLIR(dtype);
+}
 
 const ir::Var* PTOCodegen::GetVarKey(const VarPtr& var) const {
   INTERNAL_CHECK(var != nullptr) << "Internal error: variable key requested for null Var";

--- a/src/codegen/pto/pto_type_utils.cpp
+++ b/src/codegen/pto/pto_type_utils.cpp
@@ -161,6 +161,15 @@ TileTypeComponents ExtractTileTypeInfo(const ir::TileType& tile_type, const std:
   TileTypeComponents c;
   c.dtype_str = dtype_str_override.empty() ? DataTypeToMLIR(tile_type.dtype_) : dtype_str_override;
 
+  // Effective view encodes implicit defaults for the memory space (Mat/Right/Acc),
+  // so read it before lowering the shape. PTOAS represents FP4 Vec tiles in
+  // physical x2-carrier coordinates: the packed BLayout axis is half the PyPTO
+  // logical nibble extent. Matrix spaces deliberately keep their logical MX
+  // dimensions because PTOAS/TMATMUL_MX use a separate packed-matrix contract.
+  ir::TileView view = ir::tile_view_semantics::GetEffectiveTileView(tile_type);
+  const bool packed_fp4_vec =
+      tile_type.dtype_ == DataType::FP4 && tile_type.GetMemorySpace() == ir::MemorySpace::Vec;
+
   if (tile_type.shape_.size() >= 2) {
     if (auto c0 = As<ir::ConstInt>(tile_type.shape_[0])) c.rows = c0->value_;
     if (auto c1 = As<ir::ConstInt>(tile_type.shape_[1])) c.cols = c1->value_;
@@ -169,6 +178,13 @@ TileTypeComponents ExtractTileTypeInfo(const ir::TileType& tile_type, const std:
       c.rows = 1;
       c.cols = c0->value_;
     }
+  }
+  if (packed_fp4_vec) {
+    int64_t* packed_dim = view.blayout == ir::TileLayout::col_major ? &c.rows : &c.cols;
+    CHECK(*packed_dim > 0 && *packed_dim % 2 == 0)
+        << "FP4 Vec tile packed dimension must be a positive even logical extent for PTOAS, got "
+        << *packed_dim;
+    *packed_dim /= 2;
   }
   // Valid extent is always conveyed dynamically via `valid_row` / `valid_col`
   // operands on `pto.alloc_tile`; the type string therefore always reads
@@ -179,10 +195,6 @@ TileTypeComponents ExtractTileTypeInfo(const ir::TileType& tile_type, const std:
   c.v_row_dynamic = true;
   c.v_col_dynamic = true;
 
-  // Effective view encodes implicit defaults for the memory space (Mat/Right/Acc),
-  // so reading via GetEffectiveTileView preserves layout after the constructor's
-  // canonicalization elides views that match the implicit semantics.
-  ir::TileView view = ir::tile_view_semantics::GetEffectiveTileView(tile_type);
   c.blayout = view.blayout;
   c.slayout = view.slayout;
   c.fractal = view.fractal;

--- a/src/codegen/tensor_op_codegen.cpp
+++ b/src/codegen/tensor_op_codegen.cpp
@@ -9,7 +9,6 @@
  * -----------------------------------------------------------------------------------------------------------
  */
 
-#include <cctype>
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
@@ -19,6 +18,7 @@
 #include <memory>
 #include <sstream>
 #include <string>
+#include <vector>
 
 #include "pypto/codegen/codegen_base.h"
 #include "pypto/codegen/orchestration_op_registry.h"
@@ -70,6 +70,16 @@ static std::string EmitAsUint32(const ExprPtr& expr, CodegenBase& codegen) {
   return "static_cast<uint32_t>(" + str + ")";
 }
 
+static std::string EmitRuntimeTensorShapeDim(const ExprPtr& expr, const DataType& dtype, size_t axis,
+                                             size_t ndim, CodegenBase& codegen) {
+  if (dtype == DataType::FP4 && axis + 1 == ndim) {
+    if (auto extent = As<ConstInt>(expr)) return std::to_string(extent->value_ / 2);
+  }
+  std::string logical_dim = codegen.GenerateExprString(expr);
+  if (dtype != DataType::FP4 || axis + 1 != ndim) logical_dim = EmitAsUint32(expr, codegen);
+  return codegen.GetRuntimeTensorShapeDim(dtype, axis, ndim, logical_dim);
+}
+
 REGISTER_ORCHESTRATION_OP(tensor_create, ("tensor.create")) {
   // tensor.create emits TensorCreateInfo for runtime memory allocation via alloc_tensors().
   // The batched alloc_tensors call and const Tensor& binding are emitted by
@@ -84,12 +94,21 @@ REGISTER_ORCHESTRATION_OP(tensor_create, ("tensor.create")) {
   oss << "uint32_t " << result_var << "_ci_shapes[" << ndim << "] = {";
   for (size_t i = 0; i < ndim; ++i) {
     if (i > 0) oss << ", ";
-    std::string dim_expr = EmitAsUint32(result_type->shape_[i], codegen);
+    const std::string ir_dim_expr = codegen.GenerateExprString(result_type->shape_[i]);
+    std::string dim_expr = ir_dim_expr;
+    if ((result_type->dtype_ != DataType::FP4 || i + 1 != ndim) && !As<ConstInt>(result_type->shape_[i])) {
+      dim_expr = "static_cast<uint32_t>(" + dim_expr + ")";
+    }
     // Backends may override tensor.create shape without mutating IR.
     if (ndim == 1 && i == 0) {
       dim_expr = codegen.GetTensorCreateSizeExpr(result_var, dim_expr);
     }
-    oss << dim_expr;
+    auto const_extent = As<ConstInt>(result_type->shape_[i]);
+    if (result_type->dtype_ == DataType::FP4 && i + 1 == ndim && const_extent && dim_expr == ir_dim_expr) {
+      oss << const_extent->value_ / 2;
+    } else {
+      oss << codegen.GetRuntimeTensorShapeDim(result_type->dtype_, i, ndim, dim_expr);
+    }
   }
   oss << "};\n";
 
@@ -270,6 +289,9 @@ REGISTER_ORCHESTRATION_OP(tensor_slice, ("tensor.slice")) {
   std::string ext_input_name = codegen.GetExternalTensorName(input_name);
   std::string result_var = codegen.GetCurrentResultTarget();
 
+  auto input_type = AsTensorTypeLike(op->args_[0]->GetType());
+  CHECK(input_type) << "tensor.slice input must be TensorType or DistributedTensorType";
+
   // Extract shape elements from MakeTuple
   auto shape_tuple = As<MakeTuple>(op->args_[1]);
   CHECK(shape_tuple) << "tensor.slice shape must be MakeTuple";
@@ -279,13 +301,43 @@ REGISTER_ORCHESTRATION_OP(tensor_slice, ("tensor.slice")) {
   CHECK(offset_tuple) << "tensor.slice offset must be MakeTuple";
 
   size_t ndim = shape_tuple->elements_.size();
+  CHECK(offset_tuple->elements_.size() == ndim) << "tensor.slice offset must have same rank as shape";
   std::ostringstream oss;
+
+  std::vector<std::string> runtime_offsets;
+  runtime_offsets.reserve(ndim);
+  for (size_t i = 0; i < ndim; ++i) {
+    const auto& offset = offset_tuple->elements_[i];
+    if (input_type->dtype_ != DataType::FP4 || i + 1 != ndim) {
+      runtime_offsets.push_back(EmitAsUint32(offset, codegen));
+      continue;
+    }
+
+    if (auto const_offset = As<ConstInt>(offset)) {
+      CHECK_SPAN(const_offset->value_ >= 0, op->span_)
+          << "tensor.slice packed FP4 last-axis offset must be non-negative, but got "
+          << const_offset->value_;
+      CHECK_SPAN(const_offset->value_ % 2 == 0, op->span_)
+          << "tensor.slice packed FP4 last-axis offset must be byte-aligned (even), but got "
+          << const_offset->value_;
+      runtime_offsets.push_back(std::to_string(const_offset->value_ / 2));
+      continue;
+    }
+
+    // Dynamic FP4 offsets remain legal, but must select the first nibble of a
+    // carrier byte. Evaluate once, assert alignment at runtime, then convert
+    // from logical nibble units to physical x2 carrier units.
+    const std::string logical_offset_var = result_var + "_logical_fp4_offset";
+    oss << "uint32_t " << logical_offset_var << " = " << EmitAsUint32(offset, codegen) << ";\n";
+    oss << "always_assert((" << logical_offset_var << " & 1u) == 0u);\n";
+    runtime_offsets.push_back("(" + logical_offset_var + " / 2)");
+  }
 
   // Generate offset array (emitted first so the shape clamp below can read it).
   oss << "uint32_t " << result_var << "_offsets[" << ndim << "] = {";
   for (size_t i = 0; i < ndim; ++i) {
     if (i > 0) oss << ", ";
-    oss << EmitAsUint32(offset_tuple->elements_[i], codegen);
+    oss << runtime_offsets[i];
   }
   oss << "};\n";
 
@@ -305,7 +357,8 @@ REGISTER_ORCHESTRATION_OP(tensor_slice, ("tensor.slice")) {
     // unsigned, so an offset past the source extent would underflow and let std::min return
     // the original (over-extent) size — defeating the clamp. The ternary keeps it at 0.
     oss << "(" << result_var << "_offsets[" << i << "] >= " << ext_input_name << ".shapes[" << i
-        << "] ? 0u : std::min<uint32_t>(" << EmitAsUint32(shape_tuple->elements_[i], codegen) << ", "
+        << "] ? 0u : std::min<uint32_t>("
+        << EmitRuntimeTensorShapeDim(shape_tuple->elements_[i], input_type->dtype_, i, ndim, codegen) << ", "
         << ext_input_name << ".shapes[" << i << "] - " << result_var << "_offsets[" << i << "]))";
   }
   oss << "};\n";
@@ -335,6 +388,9 @@ REGISTER_ORCHESTRATION_OP(tensor_reshape, ("tensor.reshape")) {
   std::string ext_input_name = codegen.GetExternalTensorName(input_name);
   std::string result_var = codegen.GetCurrentResultTarget();
 
+  auto input_type = AsTensorTypeLike(op->args_[0]->GetType());
+  CHECK(input_type) << "tensor.reshape input must be TensorType or DistributedTensorType";
+
   // Extract shape elements from MakeTuple
   auto shape_tuple = As<MakeTuple>(op->args_[1]);
   CHECK(shape_tuple) << "tensor.reshape shape must be MakeTuple";
@@ -346,7 +402,7 @@ REGISTER_ORCHESTRATION_OP(tensor_reshape, ("tensor.reshape")) {
   oss << "uint32_t " << result_var << "_shapes[" << ndim << "] = {";
   for (size_t i = 0; i < ndim; ++i) {
     if (i > 0) oss << ", ";
-    oss << EmitAsUint32(shape_tuple->elements_[i], codegen);
+    oss << EmitRuntimeTensorShapeDim(shape_tuple->elements_[i], input_type->dtype_, i, ndim, codegen);
   }
   oss << "};\n";
 
@@ -404,6 +460,10 @@ REGISTER_ORCHESTRATION_OP(tensor_transpose, ("tensor.transpose")) {
   CHECK(axis2 >= 0 && axis2 < ndim) << "tensor.transpose axis2 out of range: " << axis2_const->value_
                                     << " for " << ndim << "D tensor";
   CHECK(axis1 != axis2) << "tensor.transpose axis1 and axis2 must be different, got " << axis1;
+  CHECK_SPAN(input_type->dtype_ != DataType::FP4 || (axis1 != ndim - 1 && axis2 != ndim - 1), op->span_)
+      << "tensor.transpose cannot move the packed FP4 last axis in Orchestration functions because the "
+         "runtime Tensor carries physical x2 elements; keep the last axis fixed or transpose inside an "
+         "InCore function";
 
   // If the optional valid_shape operand is present, validate its structure even though it is
   // intentionally not emitted at the orchestration layer (mirrors tensor.reshape / tensor.slice).
@@ -472,7 +532,7 @@ REGISTER_ORCHESTRATION_OP(tensor_view, ("tensor.view")) {
       ExprPtr shape_dim =
           shape_tuple ? shape_tuple->elements_[i]
                       : std::make_shared<TupleGetItemExpr>(op->args_[1], static_cast<int>(i), op->span_);
-      oss << EmitAsUint32(shape_dim, codegen);
+      oss << EmitRuntimeTensorShapeDim(shape_dim, input_type->dtype_, i, ndim, codegen);
     }
     oss << "};\n";
     oss << "Tensor " << result_var << " = " << ext_input_name << ".reshape(" << result_var << "_shapes, "
@@ -487,6 +547,9 @@ REGISTER_ORCHESTRATION_OP(tensor_view, ("tensor.view")) {
     INTERNAL_CHECK_SPAN(ndim >= 2, op->span_)
         << "Internal error: tensor.view cross-layout flip reached codegen with rank=" << ndim
         << "; DeduceTensorViewType is supposed to reject cross-layout flips below rank 2";
+    CHECK_SPAN(input_type->dtype_ != DataType::FP4, op->span_)
+        << "tensor.view cannot move the packed FP4 last axis during an Orchestration layout change because "
+           "the runtime Tensor carries physical x2 elements; lower the view through PTO in-core codegen";
     oss << "Tensor " << result_var << " = " << ext_input_name << ".transpose(" << (ndim - 2) << ", "
         << (ndim - 1) << ");";
   }

--- a/src/ir/op/tile_ops/matmul_mx.cpp
+++ b/src/ir/op/tile_ops/matmul_mx.cpp
@@ -22,6 +22,7 @@
 #include <utility>
 #include <vector>
 
+#include "pypto/core/dtype.h"
 #include "pypto/core/logging.h"
 #include "pypto/ir/expr.h"
 #include "pypto/ir/kind_traits.h"
@@ -34,6 +35,8 @@
 
 namespace pypto {
 namespace ir {
+
+static bool IsSupportedMxDataType(const DataType& dtype) { return dtype == DataType::FP8E4M3FN; }
 
 // Static-dim checks only: when either side is symbolic (non-ConstInt), the match
 // is skipped. Full PTOAS alignment (M%16 / K%64 / N%32 / ceil(K/32) groups) is
@@ -96,12 +99,18 @@ TypePtr DeduceTileMatMulMxType(const std::vector<ExprPtr>& args,
                   << args[2]->GetType()->TypeName();
   CHECK(lhs_type->shape_.size() == 2 && rhs_type->shape_.size() == 2)
       << "The operator " << op_name << " requires 2D lhs/rhs tiles";
-  CHECK(lhs_type->dtype_ == DataType::FP8E4M3FN)
+  CHECK(IsSupportedMxDataType(lhs_type->dtype_))
       << "The operator " << op_name << " requires lhs dtype FP8E4M3FN, but got "
-      << lhs_type->dtype_.ToString();
-  CHECK(rhs_type->dtype_ == DataType::FP8E4M3FN)
+      << lhs_type->dtype_.ToString()
+      << (lhs_type->dtype_ == DataType::FP4
+              ? "; native FP4 matmul is not supported, so cast the FP4 lhs to FP8E4M3FN with pl.cast first"
+              : "");
+  CHECK(IsSupportedMxDataType(rhs_type->dtype_))
       << "The operator " << op_name << " requires rhs dtype FP8E4M3FN, but got "
-      << rhs_type->dtype_.ToString();
+      << rhs_type->dtype_.ToString()
+      << (rhs_type->dtype_ == DataType::FP4
+              ? "; native FP4 matmul is not supported, so cast the FP4 rhs to FP8E4M3FN with pl.cast first"
+              : "");
 
   ExprPtr m_phys = lhs_type->shape_[0];
   ExprPtr k_phys_lhs = lhs_type->shape_[1];
@@ -125,9 +134,11 @@ TypePtr DeduceTileMatMulMxType(const std::vector<ExprPtr>& args,
         << " requires physical M divisible by 16 (ISA/PTOAS tmatmul_mx), but got M=" << m_phys_c->value_;
   }
   if (n_phys_c) {
-    CHECK(n_phys_c->value_ > 0 && n_phys_c->value_ % 32 == 0)
-        << "The operator " << op_name
-        << " requires physical N divisible by 32 (ISA/PTOAS tmatmul_mx fp8), but got N=" << n_phys_c->value_;
+    constexpr int64_t n_align = 32;
+    CHECK(n_phys_c->value_ > 0 && n_phys_c->value_ % n_align == 0)
+        << "The operator " << op_name << " requires physical N divisible by " << n_align << " for "
+        << rhs_type->dtype_.ToString()
+        << " (ISA/PTOAS tmatmul_mx 32-byte row), but got N=" << n_phys_c->value_;
   }
   if (k_phys_lhs_c && k_phys_rhs_c) {
     CHECK(k_phys_lhs_c->value_ == k_phys_rhs_c->value_)
@@ -364,7 +375,7 @@ TypePtr DeduceTileTGetScaleAddrType(const std::vector<ExprPtr>& args,
   CHECK(dst_type->dtype_ == DataType::FP8E8M0)
       << "The operator " << op_name << " requires dst_scale dtype FP8E8M0, but got "
       << dst_type->dtype_.ToString();
-  CHECK(src_type->dtype_ == DataType::FP8E4M3FN)
+  CHECK(IsSupportedMxDataType(src_type->dtype_))
       << "The operator " << op_name << " requires src dtype FP8E4M3FN, but got "
       << src_type->dtype_.ToString();
   CHECK(dst_type->shape_.size() == 2 && src_type->shape_.size() == 2)

--- a/src/ir/transforms/flatten_tile_nd_to_2d/rewrite_utils.cpp
+++ b/src/ir/transforms/flatten_tile_nd_to_2d/rewrite_utils.cpp
@@ -9,7 +9,6 @@
  * -----------------------------------------------------------------------------------------------------------
  */
 
-#include <algorithm>
 #include <cstddef>
 #include <cstdint>
 #include <limits>
@@ -29,6 +28,7 @@
 #include "pypto/ir/scalar_expr.h"
 #include "pypto/ir/span.h"
 #include "pypto/ir/stmt.h"
+#include "pypto/ir/storage_size.h"
 #include "pypto/ir/transforms/utils/tensor_view_semantics.h"
 #include "pypto/ir/transforms/utils/tile_conversion_utils.h"
 #include "pypto/ir/transforms/utils/transform_utils.h"
@@ -225,10 +225,11 @@ std::optional<uint64_t> OperandWholeBytes(const TileTypePtr& original_type) {
   for (const auto& d : original_type->shape_) {
     auto ci = As<ConstInt>(d);
     if (!ci || ci->value_ < 0) return std::nullopt;
-    elems *= static_cast<uint64_t>(ci->value_);
+    const uint64_t extent = static_cast<uint64_t>(ci->value_);
+    if (extent != 0 && elems > std::numeric_limits<uint64_t>::max() / extent) return std::nullopt;
+    elems *= extent;
   }
-  const uint64_t bytes_per = std::max<uint64_t>(1, original_type->dtype_.GetBit() / 8);
-  return elems * bytes_per;
+  return storage_size::StaticStorageBytes(elems, original_type->dtype_);
 }
 
 /// Whether both operands' whole tiles fit Mat together, so each can be brought

--- a/src/ir/transforms/init_memref.cpp
+++ b/src/ir/transforms/init_memref.cpp
@@ -38,6 +38,7 @@
 #include "pypto/ir/scalar_expr.h"
 #include "pypto/ir/span.h"
 #include "pypto/ir/stmt.h"
+#include "pypto/ir/storage_size.h"
 #include "pypto/ir/transforms/base/mutator.h"
 #include "pypto/ir/transforms/base/visitor.h"
 #include "pypto/ir/transforms/pass_context.h"
@@ -144,12 +145,8 @@ std::optional<uint64_t> StaticSliceViewSpanBytes(const CallPtr& call, const Shap
     }
   }
 
-  const uint64_t element_bytes = view->dtype_.GetByte();
-  if (element_bytes == 0 || max_linear_offset == std::numeric_limits<uint64_t>::max() ||
-      max_linear_offset + 1 > std::numeric_limits<uint64_t>::max() / element_bytes) {
-    return std::nullopt;
-  }
-  return (max_linear_offset + 1) * element_bytes;
+  if (max_linear_offset == std::numeric_limits<uint64_t>::max()) return std::nullopt;
+  return storage_size::StaticStorageBytes(max_linear_offset + 1, view->dtype_);
 }
 
 // ============================================================================

--- a/src/ir/transforms/loop_invariant_mat_residency.cpp
+++ b/src/ir/transforms/loop_invariant_mat_residency.cpp
@@ -37,6 +37,7 @@
 #include "pypto/ir/program.h"
 #include "pypto/ir/scalar_expr.h"
 #include "pypto/ir/stmt.h"
+#include "pypto/ir/storage_size.h"
 #include "pypto/ir/transforms/base/mutator.h"
 #include "pypto/ir/transforms/base/visitor.h"
 #include "pypto/ir/transforms/pass_context.h"
@@ -164,16 +165,15 @@ struct LoopResidencyInfo {
 
 std::optional<uint64_t> StaticTileBytes(const TileTypePtr& tile) {
   if (!tile) return std::nullopt;
-  uint64_t bytes = tile->dtype_.GetByte();
-  if (bytes == 0) return std::nullopt;
+  uint64_t elements = 1;
   for (const auto& dim : tile->shape_) {
     auto extent = As<ConstInt>(dim);
     if (!extent || extent->value_ <= 0) return std::nullopt;
     const auto value = static_cast<uint64_t>(extent->value_);
-    if (value != 0 && bytes > std::numeric_limits<uint64_t>::max() / value) return std::nullopt;
-    bytes *= value;
+    if (value != 0 && elements > std::numeric_limits<uint64_t>::max() / value) return std::nullopt;
+    elements *= value;
   }
-  return bytes;
+  return storage_size::StaticStorageBytes(elements, tile->dtype_);
 }
 
 class LoopResidencyInventory : public IRVisitor {

--- a/src/ir/transforms/op_conversion_registry.cpp
+++ b/src/ir/transforms/op_conversion_registry.cpp
@@ -36,6 +36,7 @@
 #include "pypto/ir/scalar_expr.h"
 #include "pypto/ir/span.h"
 #include "pypto/ir/stmt.h"
+#include "pypto/ir/storage_size.h"
 #include "pypto/ir/transforms/printer.h"
 #include "pypto/ir/transforms/utils/tile_conversion_utils.h"
 #include "pypto/ir/type.h"
@@ -708,12 +709,12 @@ void OpConversionRegistry::RegisterMemoryOps() {
             }
           }
           if (all_const) {
-            uint64_t tile_bytes = static_cast<uint64_t>(total_elements) * dtype.GetBit() / 8;
+            auto tile_bytes = storage_size::StaticStorageBytes(static_cast<uint64_t>(total_elements), dtype);
             const auto* be = backend::GetBackend();
-            if (be) {
+            if (be && tile_bytes.has_value()) {
               uint64_t mem_size = be->GetMemSize(target_mem);
-              INTERNAL_CHECK_SPAN(mem_size == 0 || tile_bytes <= mem_size, span)
-                  << "tensor.create: tile size (" << tile_bytes << " bytes) exceeds buffer capacity ("
+              INTERNAL_CHECK_SPAN(mem_size == 0 || *tile_bytes <= mem_size, span)
+                  << "tensor.create: tile size (" << *tile_bytes << " bytes) exceeds buffer capacity ("
                   << mem_size << " bytes) for memory space " << static_cast<int>(target_mem) << " at "
                   << span.to_string();
             }

--- a/src/ir/type.cpp
+++ b/src/ir/type.cpp
@@ -50,6 +50,25 @@ std::optional<MemorySpace> ValidateTileMemorySpaceConsistency(const std::optiona
   return memory_space;
 }
 
+void ValidatePackedFp4Shape(const DataType& dtype, const std::vector<ExprPtr>& shape) {
+  if (dtype != DataType::FP4) return;
+  CHECK(!shape.empty()) << "Packed FP4 shaped types must have rank >= 1";
+  auto packed_extent = As<ConstInt>(shape.back());
+  if (!packed_extent) return;
+  CHECK(packed_extent->value_ > 0 && packed_extent->value_ % 2 == 0)
+      << "Packed FP4 shaped types require a positive even logical last dimension, but got "
+      << packed_extent->value_;
+}
+
+std::vector<ExprPtr> MakeShapeExprs(const std::vector<int64_t>& shape) {
+  std::vector<ExprPtr> result;
+  result.reserve(shape.size());
+  for (int64_t dim : shape) {
+    result.push_back(std::make_shared<ConstInt>(dim, DataType::INDEX, Span::unknown()));
+  }
+  return result;
+}
+
 void ClearRedundantFullValidShape(std::vector<ExprPtr>& valid_shape, const std::vector<ExprPtr>& shape) {
   if (!valid_shape.empty() && AreExprVectorsEqual(valid_shape, shape)) {
     valid_shape.clear();
@@ -144,7 +163,7 @@ size_t Hash(const TileView& tv) {
 }
 
 ShapedType::ShapedType(DataType dtype, std::vector<ExprPtr> shape)
-    : dtype_(dtype), shape_(std::move(shape)), memref_(std::nullopt) {}
+    : ShapedType(dtype, std::move(shape), std::optional<MemRefPtr>{}) {}
 
 std::string TensorLayoutToString(TensorLayout layout) {
   switch (layout) {
@@ -223,11 +242,7 @@ CompactMode StringToCompactMode(const std::string& str) {
 }
 
 ShapedType::ShapedType(DataType dtype, const std::vector<int64_t>& shape, std::optional<MemRefPtr> memref)
-    : dtype_(dtype), memref_(std::move(memref)) {
-  for (int64_t dim : shape) {
-    shape_.push_back(std::make_shared<ConstInt>(dim, DataType::INDEX, Span::unknown()));
-  }
-}
+    : ShapedType(dtype, MakeShapeExprs(shape), std::move(memref)) {}
 
 TensorView::TensorView(const std::vector<int64_t>& stride_ints, TensorLayout layout_,
                        const std::vector<int64_t>& valid_shape_ints, PadValue pad_)
@@ -258,10 +273,12 @@ TileView::TileView(const std::vector<int64_t>& valid_shape_ints, const std::vect
 }
 
 ShapedType::ShapedType(DataType dtype, std::vector<ExprPtr> shape, MemRefPtr memref)
-    : dtype_(dtype), shape_(std::move(shape)), memref_(std::move(memref)) {}
+    : ShapedType(dtype, std::move(shape), std::optional<MemRefPtr>{std::move(memref)}) {}
 
 ShapedType::ShapedType(DataType dtype, std::vector<ExprPtr> shape, std::optional<MemRefPtr> memref)
-    : dtype_(dtype), shape_(std::move(shape)), memref_(std::move(memref)) {}
+    : dtype_(dtype), shape_(std::move(shape)), memref_(std::move(memref)) {
+  ValidatePackedFp4Shape(dtype_, shape_);
+}
 
 TensorType::TensorType(std::vector<ExprPtr> shape, DataType dtype, std::optional<MemRefPtr> memref,
                        std::optional<TensorView> tensor_view)

--- a/tests/st/harness/core/harness.py
+++ b/tests/st/harness/core/harness.py
@@ -88,6 +88,9 @@ class DataType(Enum):
     BF16 = "bf16"
     FP32 = "fp32"
     FP16 = "fp16"
+    FP8E4M3FN = "fp8e4m3fn"
+    FP8E8M0 = "fp8e8m0"
+    FP4 = "fp4"
     INT32 = "int32"
     UINT32 = "uint32"
     INT16 = "int16"
@@ -113,7 +116,18 @@ class DataType(Enum):
             DataType.INT64: torch.int64,
             DataType.BOOL: torch.bool,
         }
-        return mapping[self]
+        if self in mapping:
+            return mapping[self]
+
+        optional_name = {
+            DataType.FP8E4M3FN: "float8_e4m3fn",
+            DataType.FP8E8M0: "float8_e8m0fnu",
+            DataType.FP4: "float4_e2m1fn_x2",
+        }[self]
+        optional_dtype = getattr(torch, optional_name, None)
+        if not isinstance(optional_dtype, torch.dtype):
+            raise ValueError(f"PyTorch does not provide the dtype torch.{optional_name}")
+        return optional_dtype
 
 
 @dataclass

--- a/tests/st/harness/test_dtype.py
+++ b/tests/st/harness/test_dtype.py
@@ -1,0 +1,35 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Device-free tests for dtype conversion in the system-test harness."""
+
+import pytest
+import torch
+
+from harness.core.harness import DataType
+
+
+@pytest.mark.parametrize(
+    ("member", "torch_name"),
+    [
+        ("FP8E4M3FN", "float8_e4m3fn"),
+        ("FP8E8M0", "float8_e8m0fnu"),
+        ("FP4", "float4_e2m1fn_x2"),
+    ],
+)
+def test_mx_dtype_maps_to_torch(member, torch_name):
+    """Harness MX enum values map to the matching optional torch dtype."""
+    dtype = getattr(torch, torch_name, None)
+    if not isinstance(dtype, torch.dtype):
+        pytest.skip(f"torch.{torch_name} is unavailable")
+    assert getattr(DataType, member).torch_dtype is dtype
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/st/runtime/ops/test_matmul_mx.py
+++ b/tests/st/runtime/ops/test_matmul_mx.py
@@ -7,22 +7,32 @@
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
 
-"""On-board A5 runtime test for MX matmul.
+"""A5 runtime tests for host-prequantized MX matmul.
 
-The codegen unit tests verify the emitted ``tmatmul_mx`` and
-``tget_scale_addr`` instructions. This test additionally executes the base and
-accumulating forms on real Ascend950 hardware and compares their FP32 outputs
-with torch.
+Native packed-FP4 matmul is intentionally outside the supported surface. The
+FP4×FP8 case explicitly casts its FP4 lhs to FP8E4M3FN before validating both
+``matmul_mx`` and ``matmul_mx_acc`` against an FP32 torch golden. A homogeneous
+MXFP8 case remains as the instruction baseline.
 """
+
+from typing import Any
 
 import pypto.language as pl
 import pytest
 import torch
+from harness.core.harness import DataType, PTOTestCase, TensorSpec
+from pypto.runtime.runner import RunConfig
 
-M, K, N = 16, 64, 32
+_REQUIRED_TORCH_DTYPES = ("float4_e2m1fn_x2", "float8_e4m3fn", "float8_e8m0fnu")
+if not all(hasattr(torch, name) for name in _REQUIRED_TORCH_DTYPES):
+    pytest.skip("torch MXFP4/MXFP8/E8M0 dtypes required", allow_module_level=True)
+
+M, K, N = 64, 128, 128
 MX_GROUP_SIZE = 32
 SCALE_BLOCK_SIZE = 16
 SCALE_C0_SIZE = 2
+
+_MX_DATA_DTYPES = (DataType.FP4, DataType.FP8E4M3FN)
 
 
 def _pack_a_scale(scale_codes: torch.Tensor) -> torch.Tensor:
@@ -35,6 +45,22 @@ def _pack_a_scale(scale_codes: torch.Tensor) -> torch.Tensor:
             m // SCALE_BLOCK_SIZE,
             SCALE_BLOCK_SIZE,
             k_groups // SCALE_C0_SIZE,
+            SCALE_C0_SIZE,
+        )
+        .permute(0, 2, 1, 3)
+        .contiguous()
+        .reshape(m, k_groups)
+    )
+
+
+def _unpack_a_scale(packed_codes: torch.Tensor) -> torch.Tensor:
+    """Restore MX_A_ZZ physical scale bytes to logical [M, K/32]."""
+    m, k_groups = packed_codes.shape
+    return (
+        packed_codes.reshape(
+            m // SCALE_BLOCK_SIZE,
+            k_groups // SCALE_C0_SIZE,
+            SCALE_BLOCK_SIZE,
             SCALE_C0_SIZE,
         )
         .permute(0, 2, 1, 3)
@@ -61,13 +87,42 @@ def _pack_b_scale(scale_codes: torch.Tensor) -> torch.Tensor:
     )
 
 
+def _unpack_b_scale(packed_codes: torch.Tensor) -> torch.Tensor:
+    """Restore MX_B_NN physical scale bytes to logical [K/32, N]."""
+    k_groups, n = packed_codes.shape
+    return (
+        packed_codes.reshape(
+            n // SCALE_BLOCK_SIZE,
+            k_groups // SCALE_C0_SIZE,
+            SCALE_BLOCK_SIZE,
+            SCALE_C0_SIZE,
+        )
+        .permute(1, 3, 0, 2)
+        .contiguous()
+        .reshape(k_groups, n)
+    )
+
+
+def _decode_fp4_data(data: torch.Tensor, rows: int, cols: int) -> torch.Tensor:
+    """Decode a physical x2 FP4 tensor into its logical float64 matrix."""
+    packed = data.contiguous().view(torch.uint8).reshape(rows, cols // 2)
+    codes = torch.empty((rows, cols), dtype=torch.long)
+    codes[:, 0::2] = (packed & 0x0F).to(torch.long)
+    codes[:, 1::2] = ((packed >> 4) & 0x0F).to(torch.long)
+    values = torch.tensor(
+        [0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0, -0.0, -0.5, -1.0, -1.5, -2.0, -3.0, -4.0, -6.0],
+        dtype=torch.float64,
+    )
+    return values[codes]
+
+
 def _matmul_mx_golden(
     a: torch.Tensor,
     a_scale_codes: torch.Tensor,
     b: torch.Tensor,
     b_scale_codes: torch.Tensor,
 ) -> torch.Tensor:
-    """Compute MXFP8 matmul with logical per-32-element E8M0 scales."""
+    """Compute MX matmul from decoded values and logical per-group E8M0 scales."""
     k_group = torch.arange(K) // MX_GROUP_SIZE
     a_scale = torch.pow(2.0, a_scale_codes.to(torch.float64) - 127)
     b_scale = torch.pow(2.0, b_scale_codes.to(torch.float64) - 127)
@@ -76,73 +131,204 @@ def _matmul_mx_golden(
     return torch.matmul(a_scaled, b_scaled).to(torch.float32)
 
 
-@pl.jit
-def matmul_mx_onboard(
-    a: pl.Tensor[[M, K], pl.FP8E4M3FN],
-    a_scale: pl.Tensor[[M, K // 32], pl.FP8E8M0, pl.MX_A_ZZ],
-    b: pl.Tensor[[K, N], pl.FP8E4M3FN],
-    b_scale: pl.Tensor[[K // 32, N], pl.FP8E8M0, pl.MX_B_NN],
-    out: pl.Out[pl.Tensor[[M, N], pl.FP32]],
-    out_acc: pl.Out[pl.Tensor[[M, N], pl.FP32]],
-):
-    """Run base and accumulating MX matmul with shared GM operands."""
-    with pl.at(level=pl.Level.CORE_GROUP):
-        lhs = pl.move(
-            pl.load(a, [0, 0], [M, K], target_memory=pl.Mem.Mat),
-            target_memory=pl.Mem.Left,
-        )
-        lhs_scale = pl.move(
-            pl.load(a_scale, [0, 0], [M, K // 32], target_memory=pl.Mem.Mat),
-            target_memory=pl.Mem.LeftScale,
-        )
-        rhs = pl.move(
-            pl.load(b, [0, 0], [K, N], target_memory=pl.Mem.Mat),
-            target_memory=pl.Mem.Right,
-        )
-        rhs_scale = pl.move(
-            pl.load(b_scale, [0, 0], [K // 32, N], target_memory=pl.Mem.Mat),
-            target_memory=pl.Mem.RightScale,
-        )
-        base = pl.matmul_mx(lhs, lhs_scale, rhs, rhs_scale)
-        out = pl.store(base, [0, 0], out)
-        accumulated = pl.matmul_mx_acc(base, lhs, lhs_scale, rhs, rhs_scale)
-        out_acc = pl.store(accumulated, [0, 0], out_acc)
-    return out, out_acc
+class MatmulMxTestCase(PTOTestCase):
+    """One host-prequantized MX dtype combination with base+acc outputs."""
 
+    __test__ = False
 
-@pytest.mark.platforms("a5")
-class TestMatmulMxOnBoard:
-    """Numerical execution coverage for the Ascend950-only MX matmul path."""
+    @staticmethod
+    def _make_fp4_data(shape: tuple[int, int], generator: torch.Generator) -> torch.Tensor:
+        """Create signed finite FP4 data in torch's physical x2 representation."""
+        _, cols = shape
+        assert cols % 2 == 0
+        codes = torch.randint(0, 16, shape, generator=generator).to(torch.uint8)
+        codes.reshape(-1)[:16] = torch.arange(16, dtype=torch.uint8)
+        assert torch.any(codes < 8)
+        assert torch.any(codes >= 8)
+        packed = ((codes[:, 1::2] & 0x0F) << 4) | (codes[:, 0::2] & 0x0F)
+        return packed.contiguous().view(torch.float4_e2m1fn_x2)
 
-    def test_matmul_mx_onboard(self, test_config):
-        matmul_mx_onboard._cache.clear()
+    @staticmethod
+    def _make_fp8_data(shape: tuple[int, int], generator: torch.Generator) -> torch.Tensor:
+        """Create finite E4M3 data."""
+        return torch.randint(-2, 3, shape, generator=generator).to(torch.float8_e4m3fn)
 
-        generator = torch.Generator().manual_seed(19)
-        a = torch.randint(-2, 3, (M, K), generator=generator).to(torch.float8_e4m3fn)
-        b = torch.randint(-2, 3, (K, N), generator=generator).to(torch.float8_e4m3fn)
+    @staticmethod
+    def _make_case_inputs(lhs_fp4: bool) -> tuple[torch.Tensor, ...]:
+        """Build deterministic host-prequantized inputs for one dtype combination."""
+        generator = torch.Generator().manual_seed(23 + lhs_fp4 * 7)
+        make_data = MatmulMxTestCase._make_fp4_data if lhs_fp4 else MatmulMxTestCase._make_fp8_data
+        a = make_data((M, K), generator)
+        b = MatmulMxTestCase._make_fp8_data((K, N), generator)
 
-        # E8M0 codes [126, 130) represent reproducible random scales in
-        # {0.5, 1, 2, 4}. Keep logical scales for the golden and pass packed
-        # physical buffers to the kernel.
         a_scale_codes = torch.randint(126, 130, (M, K // MX_GROUP_SIZE), generator=generator).to(torch.uint8)
         b_scale_codes = torch.randint(126, 130, (K // MX_GROUP_SIZE, N), generator=generator).to(torch.uint8)
         assert torch.unique(a_scale_codes).numel() > 1
         assert torch.unique(b_scale_codes).numel() > 1
         a_scale = _pack_a_scale(a_scale_codes).view(torch.float8_e8m0fnu)
         b_scale = _pack_b_scale(b_scale_codes).view(torch.float8_e8m0fnu)
+        return a, a_scale, b, b_scale
 
+    @staticmethod
+    def _build_mxfp8_program():
+        """Build the homogeneous MXFP8×MXFP8 base+acc baseline."""
+
+        @pl.program
+        class MatmulMxHomogeneousProgram:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                a: pl.Tensor[[M, K], pl.FP8E4M3FN],
+                a_scale: pl.Tensor[[M, K // 32], pl.FP8E8M0, pl.MX_A_ZZ],
+                b: pl.Tensor[[K, N], pl.FP8E4M3FN],
+                b_scale: pl.Tensor[[K // 32, N], pl.FP8E8M0, pl.MX_B_NN],
+                out: pl.Out[pl.Tensor[[M, N], pl.FP32]],
+                out_acc: pl.Out[pl.Tensor[[M, N], pl.FP32]],
+            ) -> tuple[pl.Tensor[[M, N], pl.FP32], pl.Tensor[[M, N], pl.FP32]]:
+                lhs = pl.move(
+                    pl.load(a, [0, 0], [M, K], target_memory=pl.Mem.Mat),
+                    target_memory=pl.Mem.Left,
+                )
+                lhs_scale = pl.move(
+                    pl.load(a_scale, [0, 0], [M, K // 32], target_memory=pl.Mem.Mat),
+                    target_memory=pl.Mem.LeftScale,
+                )
+                rhs = pl.move(
+                    pl.load(b, [0, 0], [K, N], target_memory=pl.Mem.Mat),
+                    target_memory=pl.Mem.Right,
+                )
+                rhs_scale = pl.move(
+                    pl.load(b_scale, [0, 0], [K // 32, N], target_memory=pl.Mem.Mat),
+                    target_memory=pl.Mem.RightScale,
+                )
+                base = pl.matmul_mx(lhs, lhs_scale, rhs, rhs_scale)
+                out = pl.store(base, [0, 0], out)
+                accumulated = pl.matmul_mx_acc(base, lhs, lhs_scale, rhs, rhs_scale)
+                out_acc = pl.store(accumulated, [0, 0], out_acc)
+                return out, out_acc
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orchestrator(
+                self,
+                a: pl.Tensor[[M, K], pl.FP8E4M3FN],
+                a_scale: pl.Tensor[[M, K // 32], pl.FP8E8M0, pl.MX_A_ZZ],
+                b: pl.Tensor[[K, N], pl.FP8E4M3FN],
+                b_scale: pl.Tensor[[K // 32, N], pl.FP8E8M0, pl.MX_B_NN],
+                out: pl.Out[pl.Tensor[[M, N], pl.FP32]],
+                out_acc: pl.Out[pl.Tensor[[M, N], pl.FP32]],
+            ) -> tuple[pl.Tensor[[M, N], pl.FP32], pl.Tensor[[M, N], pl.FP32]]:
+                out, out_acc = self.kernel(a, a_scale, b, b_scale, out, out_acc)
+                return out, out_acc
+
+        return MatmulMxHomogeneousProgram
+
+    @staticmethod
+    def _build_fp4_fp8_program():
+        """Build MXFP4×MXFP8 base+acc coverage with an explicit lhs cast."""
+
+        @pl.program
+        class MatmulMxFp4Fp8Program:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                a: pl.Tensor[[M, K], pl.FP4],
+                a_scale: pl.Tensor[[M, K // 32], pl.FP8E8M0, pl.MX_A_ZZ],
+                b: pl.Tensor[[K, N], pl.FP8E4M3FN],
+                b_scale: pl.Tensor[[K // 32, N], pl.FP8E8M0, pl.MX_B_NN],
+                out: pl.Out[pl.Tensor[[M, N], pl.FP32]],
+                out_acc: pl.Out[pl.Tensor[[M, N], pl.FP32]],
+            ) -> tuple[pl.Tensor[[M, N], pl.FP32], pl.Tensor[[M, N], pl.FP32]]:
+                lhs_fp8 = pl.cast(pl.load(a, [0, 0], [M, K]), pl.FP8E4M3FN)
+                lhs_mat = pl.move(lhs_fp8, target_memory=pl.Mem.Mat)
+                lhs = pl.move(lhs_mat, target_memory=pl.Mem.Left)
+                lhs_scale = pl.move(
+                    pl.load(a_scale, [0, 0], [M, K // 32], target_memory=pl.Mem.Mat),
+                    target_memory=pl.Mem.LeftScale,
+                )
+                rhs = pl.move(
+                    pl.load(b, [0, 0], [K, N], target_memory=pl.Mem.Mat),
+                    target_memory=pl.Mem.Right,
+                )
+                rhs_scale = pl.move(
+                    pl.load(b_scale, [0, 0], [K // 32, N], target_memory=pl.Mem.Mat),
+                    target_memory=pl.Mem.RightScale,
+                )
+                base = pl.matmul_mx(lhs, lhs_scale, rhs, rhs_scale)
+                out = pl.store(base, [0, 0], out)
+                accumulated = pl.matmul_mx_acc(base, lhs, lhs_scale, rhs, rhs_scale)
+                out_acc = pl.store(accumulated, [0, 0], out_acc)
+                return out, out_acc
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orchestrator(
+                self,
+                a: pl.Tensor[[M, K], pl.FP4],
+                a_scale: pl.Tensor[[M, K // 32], pl.FP8E8M0, pl.MX_A_ZZ],
+                b: pl.Tensor[[K, N], pl.FP8E4M3FN],
+                b_scale: pl.Tensor[[K // 32, N], pl.FP8E8M0, pl.MX_B_NN],
+                out: pl.Out[pl.Tensor[[M, N], pl.FP32]],
+                out_acc: pl.Out[pl.Tensor[[M, N], pl.FP32]],
+            ) -> tuple[pl.Tensor[[M, N], pl.FP32], pl.Tensor[[M, N], pl.FP32]]:
+                out, out_acc = self.kernel(a, a_scale, b, b_scale, out, out_acc)
+                return out, out_acc
+
+        return MatmulMxFp4Fp8Program
+
+    def __init__(self, lhs_dtype: DataType, rhs_dtype: DataType):
+        if lhs_dtype not in _MX_DATA_DTYPES or rhs_dtype != DataType.FP8E4M3FN:
+            raise ValueError(
+                "Supported MX matmul pairs are FP8E4M3FN×FP8E4M3FN and "
+                f"FP4×FP8E4M3FN with an explicit lhs cast; got {lhs_dtype}, {rhs_dtype}"
+            )
+        super().__init__(RunConfig(rtol=0.0, atol=0.0), platform="a5")
+        self._lhs_dtype = lhs_dtype
+        self._rhs_dtype = rhs_dtype
+        self._lhs_fp4 = lhs_dtype == DataType.FP4
+
+    def get_name(self) -> str:
+        return f"matmul_mx_{self._lhs_dtype.value}_x_{self._rhs_dtype.value}_base_acc"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        a, a_scale, b, b_scale = self._make_case_inputs(self._lhs_fp4)
+        return [
+            TensorSpec("a", list(a.shape), self._lhs_dtype, init_value=a),
+            TensorSpec("a_scale", list(a_scale.shape), DataType.FP8E8M0, init_value=a_scale),
+            TensorSpec("b", list(b.shape), self._rhs_dtype, init_value=b),
+            TensorSpec("b_scale", list(b_scale.shape), DataType.FP8E8M0, init_value=b_scale),
+            TensorSpec("out", [M, N], DataType.FP32, is_output=True),
+            TensorSpec("out_acc", [M, N], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        if self._lhs_fp4:
+            return self._build_fp4_fp8_program()
+        return self._build_mxfp8_program()
+
+    def compute_expected(self, tensors: dict[str, torch.Tensor], params=None) -> None:
+        a = _decode_fp4_data(tensors["a"], M, K) if self._lhs_fp4 else tensors["a"].to(torch.float64)
+        b = tensors["b"].to(torch.float64)
+        a_scale_codes = _unpack_a_scale(tensors["a_scale"].view(torch.uint8))
+        b_scale_codes = _unpack_b_scale(tensors["b_scale"].view(torch.uint8))
         base = _matmul_mx_golden(a, a_scale_codes, b, b_scale_codes)
-        out = torch.zeros_like(base)
-        out_acc = torch.zeros_like(base)
+        tensors["out"][:] = base
+        tensors["out_acc"][:] = 2 * base
 
-        if test_config.codegen_only:
-            matmul_mx_onboard.compile(a, a_scale, b, b_scale, out, out_acc, config=test_config)
-            return
 
-        matmul_mx_onboard(a, a_scale, b, b_scale, out, out_acc, config=test_config)
+@pytest.mark.platforms("a5")
+class TestMatmulMx:
+    """Numerical execution coverage for the supported A5 MX dtype pairs."""
 
-        torch.testing.assert_close(out, base, rtol=0, atol=0)
-        torch.testing.assert_close(out_acc, 2 * base, rtol=0, atol=0)
+    @pytest.mark.parametrize(
+        ("lhs_dtype", "rhs_dtype"),
+        [
+            pytest.param(DataType.FP8E4M3FN, DataType.FP8E4M3FN, id="mxfp8-x-mxfp8"),
+            pytest.param(DataType.FP4, DataType.FP8E4M3FN, id="mxfp4-x-mxfp8"),
+        ],
+    )
+    def test_matmul_mx_base_and_acc(self, test_runner, lhs_dtype, rhs_dtype):
+        case = MatmulMxTestCase(lhs_dtype, rhs_dtype)
+        result = test_runner.run(case)
+        assert result.passed, f"Test failed: {result.error}"
 
 
 if __name__ == "__main__":

--- a/tests/ut/codegen/test_golden_writer.py
+++ b/tests/ut/codegen/test_golden_writer.py
@@ -14,6 +14,7 @@ from pypto.runtime.golden_writer import (
     _extract_callable_expr,
     _extract_closure_constants,
     _extract_compute_golden,
+    _torch_dtype_str,
     generate_golden_source,
     write_golden,
 )
@@ -24,6 +25,18 @@ torch = pytest.importorskip("torch")
 
 def _dummy_golden(tensors, params=None):
     tensors["out"][:] = tensors["a"] * 3
+
+
+@pytest.mark.parametrize(
+    "dtype_name",
+    ["float8_e4m3fn", "float8_e8m0fnu", "float4_e2m1fn_x2"],
+)
+def test_torch_dtype_str_supports_mx_dtypes(dtype_name):
+    """Optional torch MX dtypes retain their qualified names in golden.py."""
+    dtype = getattr(torch, dtype_name, None)
+    if not isinstance(dtype, torch.dtype):
+        pytest.skip(f"torch.{dtype_name} is unavailable")
+    assert _torch_dtype_str(dtype) == f"torch.{dtype_name}"  # pyright: ignore[reportArgumentType]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/ut/codegen/test_mx_ops_codegen.py
+++ b/tests/ut/codegen/test_mx_ops_codegen.py
@@ -7,7 +7,7 @@
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
 
-"""Codegen smoke tests for MXFP8 matmul_mx path (extends MX scale load/move coverage)."""
+"""Codegen smoke tests for MXFP8 matmul and explicit FP4-to-FP8 legalization."""
 
 import pypto.language as pl
 import pytest
@@ -15,6 +15,13 @@ from pypto import ir
 from pypto.backend import BackendType, reset_for_testing, set_backend_type
 from pypto.ir.pass_manager import OptimizationStrategy, PassManager
 from pypto.pypto_core import codegen, passes
+
+
+@pytest.fixture(autouse=True)
+def _reset_backend_after_test():
+    """Do not leak an explicitly selected backend into later test modules."""
+    yield
+    reset_for_testing()
 
 
 def _run_default_pipeline(program, backend_type=BackendType.Ascend950):
@@ -25,9 +32,9 @@ def _run_default_pipeline(program, backend_type=BackendType.Ascend950):
         return PassManager.get_strategy(OptimizationStrategy.Default).run_passes(program)
 
 
-def _emit_incore_mlir(program) -> str:
-    """Run Default pipeline on Ascend950 and concatenate AIC/AIV MLIR."""
-    optimized = _run_default_pipeline(program)
+def _emit_incore_mlir(program, backend_type=BackendType.Ascend950) -> str:
+    """Run Default pipeline and concatenate AIC/AIV MLIR."""
+    optimized = _run_default_pipeline(program, backend_type)
     parts: list[str] = []
     for func in optimized.functions.values():
         if func.func_type in (pl.FunctionType.Orchestration, pl.FunctionType.Group):
@@ -102,6 +109,64 @@ class TestMxMatmulCodegen:
         lines = mlir.splitlines()
         first_tget = next(i for i, line in enumerate(lines) if "pto.tget_scale_addr" in line)
         assert any("pto.tmov" in line and "scaling" in line for i, line in enumerate(lines) if i < first_tget)
+
+    def test_mxfp4_times_mxfp8_uses_explicit_lhs_cast(self):
+        @pl.program
+        class Program:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main(
+                self,
+                a: pl.Tensor[[128, 64], pl.FP4],
+                a_s: pl.Tensor[[128, 2], pl.FP8E8M0, pl.MX_A_ZZ],
+                b: pl.Tensor[[64, 64], pl.FP8E4M3FN],
+                b_s: pl.Tensor[[2, 64], pl.FP8E8M0, pl.MX_B_NN],
+                out: pl.Tensor[[128, 64], pl.FP32],
+            ):
+                ta = pl.cast(pl.load(a, [0, 0], [128, 64]), pl.FP8E4M3FN)
+                tas = pl.load(a_s, [0, 0], [128, 2], target_memory=pl.Mem.Mat)
+                tb = pl.load(b, [0, 0], [64, 64], target_memory=pl.Mem.Mat)
+                tbs = pl.load(b_s, [0, 0], [2, 64], target_memory=pl.Mem.Mat)
+                la = pl.move(ta, target_memory=pl.Mem.Left)
+                las = pl.move(tas, target_memory=pl.Mem.LeftScale)
+                rb = pl.move(tb, target_memory=pl.Mem.Right)
+                rbs = pl.move(tbs, target_memory=pl.Mem.RightScale)
+                pl.store(pl.matmul_mx(la, las, rb, rbs), [0, 0], out)
+
+        mlir = _emit_incore_mlir(Program)
+        assert mlir.count("pto.tcvt") == 3
+        assert "dtype=!pto.f4E2M1x2, rows=128, cols=32" in mlir
+        assert "pto.tmatmul.mx" in mlir
+        assert mlir.count("pto.tget_scale_addr") == 2
+
+    @pytest.mark.parametrize("dtype", [pl.FP4, pl.INT4, pl.UINT4, pl.HF4])
+    def test_a2a3_rejects_all_four_bit_incore_abis(self, dtype):
+        @pl.program
+        class Program:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main(
+                self,
+                src: pl.Tensor[[16, 64], dtype],
+                out: pl.Tensor[[16, 64], dtype],
+            ):
+                pl.store(pl.load(src, [0, 0], [16, 64]), [0, 0], out)
+
+        with pytest.raises(ValueError, match=r"4-bit dtype.*not supported.*a2a3.*load/store.*ABI"):
+            _emit_incore_mlir(Program, BackendType.Ascend910B)
+
+    @pytest.mark.parametrize("dtype", [pl.INT4, pl.UINT4, pl.HF4])
+    def test_a5_rejects_non_fp4_four_bit_incore_abis(self, dtype):
+        @pl.program
+        class Program:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main(
+                self,
+                src: pl.Tensor[[16, 64], dtype],
+                out: pl.Tensor[[16, 64], dtype],
+            ):
+                pl.store(pl.load(src, [0, 0], [16, 64]), [0, 0], out)
+
+        with pytest.raises(ValueError, match=r"4-bit dtype.*not supported.*a5.*only FP4"):
+            _emit_incore_mlir(Program)
 
     def test_matmul_mx_acc_ins_equals_outs(self):
         @pl.program

--- a/tests/ut/codegen/test_orchestration_codegen_more.py
+++ b/tests/ut/codegen/test_orchestration_codegen_more.py
@@ -29,6 +29,167 @@ from pypto.pypto_core import DataType, ir
 class TestOrchestrationMore:
     """Orchestration codegen — additional core cases (continued)."""
 
+    def test_fp4_runtime_shapes_use_x2_carrier_only_at_abi_boundary(self):
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend950)
+        logical_k = pl.dynamic("FP4_LOGICAL_K")
+
+        @pl.program
+        class Fp4CarrierProgram:
+            @pl.function(type=pl.FunctionType.InCore)
+            def copy(
+                self,
+                src: pl.Tensor[[8, logical_k], pl.FP4],
+                out: pl.Out[pl.Tensor[[8, logical_k], pl.FP4]],
+            ) -> pl.Tensor[[8, logical_k], pl.FP4]:
+                tile = pl.load(src, [0, 0], [8, logical_k])
+                return pl.store(tile, [0, 0], out)
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                src: pl.Tensor[[8, logical_k], pl.FP4],
+            ) -> pl.Tensor[[8, logical_k], pl.FP4]:
+                width = pl.tensor.dim(src, 1)
+                out = pl.create_tensor([8, width], dtype=pl.FP4)
+                return self.copy(src, out)
+
+        code = _generate_orch_code(Fp4CarrierProgram)
+        assert "const int64_t fp4_carrier_dim = (int64_t)orch_args.tensor(0).ref().shapes[1];" in code
+        assert "always_assert(fp4_carrier_dim > 0);" in code
+        assert "const int64_t fp4_logical_dim = static_cast<int64_t>" in code
+        assert "always_assert(fp4_logical_dim > 0 && (fp4_logical_dim & 1u) == 0u);" in code
+        assert "static_cast<uint32_t>(fp4_logical_dim / 2)" in code
+        assert "DataType::FP4E2M1" in code
+
+    def test_fp4_slice_uses_x2_carrier_shape_and_offset(self):
+        """FP4 slice metadata passed to runtime Tensor::view is in carrier units."""
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend950)
+
+        @pl.program
+        class Fp4SliceProgram:
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                data: pl.Tensor[[8, 16], pl.FP4],
+            ) -> pl.Tensor[[1, 8], pl.FP4]:
+                chunk: pl.Tensor[[1, 8], pl.FP4] = pl.slice(data, [1, 8], [0, 8])
+                return chunk
+
+        code = _generate_orch_code(Fp4SliceProgram)
+        assert "uint32_t chunk_offsets[2] = {0, 4};" in code
+        assert "std::min<uint32_t>(4, ext_data.shapes[1] - chunk_offsets[1])" in code
+        assert "Tensor chunk = ext_data.view(chunk_shapes, chunk_offsets);" in code
+
+    def test_fp4_slice_dynamic_offset_checks_alignment_before_conversion(self):
+        """Dynamic packed-axis offsets are checked before conversion to carrier units."""
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend950)
+
+        @pl.program
+        class Fp4DynamicSliceProgram:
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                data: pl.Tensor[[8, 16], pl.FP4],
+                logical_offset: pl.Scalar[pl.INDEX],
+            ) -> pl.Tensor[[1, 8], pl.FP4]:
+                chunk: pl.Tensor[[1, 8], pl.FP4] = pl.slice(data, [1, 8], [0, logical_offset])
+                return chunk
+
+        code = _generate_orch_code(Fp4DynamicSliceProgram)
+        assert "uint32_t chunk_logical_fp4_offset = static_cast<uint32_t>(logical_offset);" in code
+        assert "always_assert((chunk_logical_fp4_offset & 1u) == 0u);" in code
+        assert "uint32_t chunk_offsets[2] = {0, (chunk_logical_fp4_offset / 2)};" in code
+
+    def test_fp4_slice_rejects_odd_packed_axis_offset(self):
+        """A constant odd offset starts on the unrepresentable second nibble."""
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend950)
+
+        @pl.program
+        class Fp4OddSliceProgram:
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                data: pl.Tensor[[8, 16], pl.FP4],
+            ) -> pl.Tensor[[1, 8], pl.FP4]:
+                chunk: pl.Tensor[[1, 8], pl.FP4] = pl.slice(data, [1, 8], [0, 7])
+                return chunk
+
+        with pytest.raises(ValueError, match="packed FP4 last-axis offset must be byte-aligned"):
+            _generate_orch_code(Fp4OddSliceProgram)
+
+    def test_fp4_reshape_and_view_use_x2_carrier_last_dimension(self):
+        """Both shape-reinterpret paths preserve physical carrier element counts."""
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend950)
+
+        @pl.program
+        class Fp4ShapeViewProgram:
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                data: pl.Tensor[[8, 16], pl.FP4],
+            ) -> pl.Tensor[[2, 64], pl.FP4]:
+                reshaped: pl.Tensor[[4, 32], pl.FP4] = pl.reshape(data, [4, 32])
+                viewed: pl.Tensor[[2, 64], pl.FP4] = pl.tensor.view(reshaped, [2, 64])
+                return viewed
+
+        code = _generate_orch_code(Fp4ShapeViewProgram)
+        assert "uint32_t reshaped_shapes[2] = {4, 16};" in code
+        assert "Tensor reshaped = ext_data.reshape(reshaped_shapes, 2);" in code
+        assert "uint32_t viewed_shapes[2] = {2, 32};" in code
+        assert "Tensor viewed = reshaped.reshape(viewed_shapes, 2);" in code
+
+    def test_fp4_transpose_keeps_packed_axis_fixed(self):
+        """Swapping non-packed axes is representable; moving the packed axis is not."""
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend950)
+
+        @pl.program
+        class Fp4NonPackedTransposeProgram:
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                data: pl.Tensor[[2, 4, 16], pl.FP4],
+            ) -> pl.Tensor[[4, 2, 16], pl.FP4]:
+                transposed: pl.Tensor[[4, 2, 16], pl.FP4] = pl.transpose(data, axis1=0, axis2=1)
+                return transposed
+
+        code = _generate_orch_code(Fp4NonPackedTransposeProgram)
+        assert "Tensor transposed = ext_data.transpose(0, 1);" in code
+
+        @pl.program
+        class Fp4PackedTransposeProgram:
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                data: pl.Tensor[[2, 4, 16], pl.FP4],
+            ) -> pl.Tensor[[2, 16, 4], pl.FP4]:
+                transposed: pl.Tensor[[2, 16, 4], pl.FP4] = pl.transpose(data, axis1=1, axis2=2)
+                return transposed
+
+        with pytest.raises(ValueError, match="cannot move the packed FP4 last axis"):
+            _generate_orch_code(Fp4PackedTransposeProgram)
+
+    def test_fp4_view_rejects_layout_flip_across_packed_axis(self):
+        """ND/DN layout flips swap the trailing pair and cannot preserve FP4 packing."""
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend950)
+
+        ib = IRBuilder()
+        with ib.function("orch_fp4_view", type=ir.FunctionType.Orchestration) as f:
+            data = f.param("data", ir.TensorType([8, 16], DataType.FP4))
+            data_dn = ib.let("data_dn", tensor_ops.view(data, layout=ir.TensorLayout.DN))
+            f.return_type(data_dn.type)
+            ib.return_stmt(data_dn)
+        program = ir.Program([f.get_result()], "test_fp4_view_layout_flip", ir.Span.unknown())
+
+        with pytest.raises(ValueError, match="cannot move the packed FP4 last axis"):
+            _generate_orch_code(program)
+
     def test_dynamic_gm_pipe_buffer_alloc_follows_its_size_local(self):
         """A dynamically-sized injected GM pipe buffer must not be hoisted above
         the body-local it is sized by (issue #1768).

--- a/tests/ut/codegen/test_pto_codegen.py
+++ b/tests/ut/codegen/test_pto_codegen.py
@@ -1275,6 +1275,18 @@ class TestGenerateArgUnpacking:
         # dynamic dims appended after tensor params
         assert names == ["a__ssa_v0", "b__ssa_v0", "output__ssa_v0", "TH", "TW"]
 
+    def test_dynamic_fp4_last_dim_expands_runtime_x2_carrier(self):
+        span = ir.Span.unknown()
+        logical_k = ir.Var("LOGICAL_K", ir.ScalarType(DataType.INDEX), span)
+        rows = ir.ConstInt(16, DataType.INDEX, span)
+        ib = IRBuilder()
+        with ib.function("fp4_dynamic", type=ir.FunctionType.InCore) as f:
+            f.param("x", ir.TensorType([rows, logical_k], DataType.FP4))
+
+        code, names = _generate_arg_unpacking(f.get_result())
+        assert "int64_t LOGICAL_K = (static_cast<int64_t>(x_tensor->shapes[1]) * 2);" in code
+        assert names == ["x", "LOGICAL_K"]
+
     def test_dynamic_tensor_deduplicates_vars(self):
         # TH and TW each appear in a__ssa_v0, b__ssa_v0, and output__ssa_v0 but should be extracted only once
         func = _get_dyn_incore_func()

--- a/tests/ut/ir/operators/test_mx_ops.py
+++ b/tests/ut/ir/operators/test_mx_ops.py
@@ -110,30 +110,26 @@ class TestDtypeAndMemorySpace:
         assert ir.MemorySpace.RightScale.value == 9
 
 
+class TestPackedFp4Shape:
+    @pytest.mark.parametrize("type_constructor", [ir.TensorType, ir.TileType, ir.DistributedTensorType])
+    @pytest.mark.parametrize("shape", [[], [8, 0], [8, 15]])
+    def test_rejects_non_positive_or_odd_static_last_dimension(self, type_constructor, shape):
+        with pytest.raises(ValueError, match=r"positive even logical last dimension|rank >= 1"):
+            type_constructor(shape, DataType.FP4)
+
+    def test_accepts_symbolic_last_dimension(self):
+        span = ir.Span.unknown()
+        logical_width = ir.Var("logical_width", ir.ScalarType(DataType.INDEX), span)
+        tensor_type = ir.TensorType([ir.ConstInt(8, DataType.INDEX, span), logical_width], DataType.FP4)
+        assert tensor_type.dtype == DataType.FP4
+
+
 def _tile(name, shape, dtype, *, valid_shape=None, memory=None):
     span = ir.Span.unknown()
     view = None
     if valid_shape is not None:
         view = ir.TileView(valid_shape=valid_shape, stride=[])
     return ir.Var(name, ir.TileType(shape, dtype, tile_view=view, memory_space=memory), span)
-
-
-def _mx_operands(span, *, m=16, k=64, n=32, valid=None):
-    """Build a valid MX operand set; optional valid=(m_v, k_v, n_v)."""
-    if valid is None:
-        lhs = ir.Var("lhs", ir.TileType([m, k], DataType.FP8E4M3FN), span)
-        lhs_scale = ir.Var("lhs_scale", ir.TileType([m, k // 32], DataType.FP8E8M0), span)
-        rhs = ir.Var("rhs", ir.TileType([k, n], DataType.FP8E4M3FN), span)
-        rhs_scale = ir.Var("rhs_scale", ir.TileType([k // 32, n], DataType.FP8E8M0), span)
-        return lhs, lhs_scale, rhs, rhs_scale
-    m_v, k_v, n_v = valid
-    sk = (k + 31) // 32
-    sk_v = (k_v + 31) // 32
-    lhs = _tile("lhs", [m, k], DataType.FP8E4M3FN, valid_shape=[m_v, k_v])
-    lhs_scale = _tile("lhs_scale", [m, sk], DataType.FP8E8M0, valid_shape=[m_v, sk_v])
-    rhs = _tile("rhs", [k, n], DataType.FP8E4M3FN, valid_shape=[k_v, n_v])
-    rhs_scale = _tile("rhs_scale", [sk, n], DataType.FP8E8M0, valid_shape=[sk_v, n_v])
-    return lhs, lhs_scale, rhs, rhs_scale
 
 
 class TestMatmulMxRegistry:
@@ -157,9 +153,27 @@ class TestMatmulMxRegistry:
 
 
 class TestMatmulMxTypes:
+    @staticmethod
+    def _mx_operands(span, *, m=16, k=64, n=32, valid=None, dtype=DataType.FP8E4M3FN):
+        """Build a valid MX operand set; optional valid=(m_v, k_v, n_v)."""
+        if valid is None:
+            lhs = ir.Var("lhs", ir.TileType([m, k], dtype), span)
+            lhs_scale = ir.Var("lhs_scale", ir.TileType([m, k // 32], DataType.FP8E8M0), span)
+            rhs = ir.Var("rhs", ir.TileType([k, n], dtype), span)
+            rhs_scale = ir.Var("rhs_scale", ir.TileType([k // 32, n], DataType.FP8E8M0), span)
+            return lhs, lhs_scale, rhs, rhs_scale
+        m_v, k_v, n_v = valid
+        sk = (k + 31) // 32
+        sk_v = (k_v + 31) // 32
+        lhs = _tile("lhs", [m, k], dtype, valid_shape=[m_v, k_v])
+        lhs_scale = _tile("lhs_scale", [m, sk], DataType.FP8E8M0, valid_shape=[m_v, sk_v])
+        rhs = _tile("rhs", [k, n], dtype, valid_shape=[k_v, n_v])
+        rhs_scale = _tile("rhs_scale", [sk, n], DataType.FP8E8M0, valid_shape=[sk_v, n_v])
+        return lhs, lhs_scale, rhs, rhs_scale
+
     def test_type_deduction_and_variants(self):
         span = ir.Span.unknown()
-        lhs, lhs_scale, rhs, rhs_scale = _mx_operands(span)
+        lhs, lhs_scale, rhs, rhs_scale = self._mx_operands(span)
         call = ir.op.tile.matmul_mx(lhs, lhs_scale, rhs, rhs_scale, span)
         call_type = call.type
         assert isinstance(call_type, ir.TileType)
@@ -176,10 +190,21 @@ class TestMatmulMxTypes:
         bias_call = ir.op.tile.matmul_mx_bias(lhs, lhs_scale, rhs, rhs_scale, bias, span)
         assert bias_call.op.name == ir.get_op("tile.matmul_mx_bias").name
 
+    def test_rejects_native_mxfp4_and_requires_cast(self):
+        span = ir.Span.unknown()
+        fp4_operands = self._mx_operands(span, n=64, dtype=DataType.FP4)
+        with pytest.raises(ValueError, match=r"requires lhs dtype FP8E4M3FN.*pl.cast"):
+            ir.op.tile.matmul_mx(*fp4_operands, span)
+
+        lhs, lhs_scale, _, _ = self._mx_operands(span, n=64)
+        _, _, rhs_fp4, rhs_scale = self._mx_operands(span, n=64, dtype=DataType.FP4)
+        with pytest.raises(ValueError, match=r"requires rhs dtype FP8E4M3FN.*pl.cast"):
+            ir.op.tile.matmul_mx(lhs, lhs_scale, rhs_fp4, rhs_scale, span)
+
     def test_rejects_wrong_dtypes_and_alignment(self):
         span = ir.Span.unknown()
         # data must be FP8E4M3FN
-        with pytest.raises(ValueError, match="FP8E4M3FN"):
+        with pytest.raises(ValueError, match="requires lhs dtype FP8E4M3FN") as exc_info:
             ir.op.tile.matmul_mx(
                 ir.Var("lhs", ir.TileType([16, 64], DataType.FP8E5M2), span),
                 ir.Var("ls", ir.TileType([16, 2], DataType.FP8E8M0), span),
@@ -187,19 +212,27 @@ class TestMatmulMxTypes:
                 ir.Var("rs", ir.TileType([2, 32], DataType.FP8E8M0), span),
                 span,
             )
+        assert "native FP4" not in str(exc_info.value)
+
+        lhs, lhs_scale, _, rhs_scale = self._mx_operands(span)
+        rhs_fp8e5m2 = ir.Var("rhs", ir.TileType([64, 32], DataType.FP8E5M2), span)
+        with pytest.raises(ValueError, match="requires rhs dtype FP8E4M3FN") as exc_info:
+            ir.op.tile.matmul_mx(lhs, lhs_scale, rhs_fp8e5m2, rhs_scale, span)
+        assert "native FP4" not in str(exc_info.value)
+
         # scale must be FP8E8M0
-        lhs, _, rhs, rhs_scale = _mx_operands(span)
+        lhs, _, rhs, rhs_scale = self._mx_operands(span)
         with pytest.raises(ValueError, match="FP8E8M0"):
             ir.op.tile.matmul_mx(
                 lhs, ir.Var("ls", ir.TileType([16, 2], DataType.FP16), span), rhs, rhs_scale, span
             )
-        # M%16 / K%64 / N%32
+        # M%16 / K%64 / N%32 (FP8)
         with pytest.raises(ValueError, match="divisible by 16"):
-            ir.op.tile.matmul_mx(*_mx_operands(span, m=8), span)
+            ir.op.tile.matmul_mx(*self._mx_operands(span, m=8), span)
         with pytest.raises(ValueError, match="divisible by 64"):
-            ir.op.tile.matmul_mx(*_mx_operands(span, k=96), span)
-        with pytest.raises(ValueError, match="divisible by 32"):
-            ir.op.tile.matmul_mx(*_mx_operands(span, n=16), span)
+            ir.op.tile.matmul_mx(*self._mx_operands(span, k=96), span)
+        with pytest.raises(ValueError, match=r"physical N divisible by 32 for fp8e4m3fn"):
+            ir.op.tile.matmul_mx(*self._mx_operands(span, n=16), span)
 
     @pytest.mark.parametrize(
         ("rhs_k", "rhs_scale_groups", "error"),
@@ -236,13 +269,13 @@ class TestMatmulMxTypes:
     def test_valid_shape_contract(self):
         span = ir.Span.unknown()
         # valid K not multiple of 32 is OK when scale-group count matches physical K
-        call = ir.op.tile.matmul_mx(*_mx_operands(span, valid=(16, 48, 32)), span)
+        call = ir.op.tile.matmul_mx(*self._mx_operands(span, valid=(16, 48, 32)), span)
         call_type = call.type
         assert isinstance(call_type, ir.TileType)
         assert call_type.dtype == DataType.FP32
 
         # propagate contracted M/N valid into Acc output
-        call = ir.op.tile.matmul_mx(*_mx_operands(span, valid=(8, 64, 16)), span)
+        call = ir.op.tile.matmul_mx(*self._mx_operands(span, valid=(8, 64, 16)), span)
         call_type = call.type
         assert isinstance(call_type, ir.TileType)
         valid_rows, valid_cols = call_type.get_effective_tile_view().valid_shape
@@ -257,7 +290,7 @@ class TestMatmulMxTypes:
             ir.op.tile.matmul_mx(lhs, lhs_scale, rhs, rhs_scale, span)
 
         with pytest.raises(ValueError, match="physical cols"):
-            lhs, _, rhs, rhs_scale = _mx_operands(span)
+            lhs, _, rhs, rhs_scale = self._mx_operands(span)
             ir.op.tile.matmul_mx(
                 lhs, ir.Var("ls", ir.TileType([16, 1], DataType.FP8E8M0), span), rhs, rhs_scale, span
             )
@@ -270,16 +303,16 @@ class TestMatmulMxTypes:
             ir.op.tile.matmul_mx(lhs, lhs_scale, rhs, rhs_scale, span)
 
         with pytest.raises(ValueError, match="positive valid K"):
-            ir.op.tile.matmul_mx(*_mx_operands(span, valid=(16, 0, 32)), span)
+            ir.op.tile.matmul_mx(*self._mx_operands(span, valid=(16, 0, 32)), span)
 
         # ceil(validK/32) must equal ceil(physicalK/32) (PTOAS matmul_mx vs tget)
         with pytest.raises(ValueError, match="scale-group count"):
-            ir.op.tile.matmul_mx(*_mx_operands(span, valid=(16, 31, 32)), span)
+            ir.op.tile.matmul_mx(*self._mx_operands(span, valid=(16, 31, 32)), span)
 
         # acc valid_shape must match MX output valid M/N
         acc = _tile("acc", [16, 32], DataType.FP32, valid_shape=[16, 32])
         with pytest.raises(ValueError, match="acc valid rows"):
-            ir.op.tile.matmul_mx_acc(acc, *_mx_operands(span, valid=(8, 64, 16)), span)
+            ir.op.tile.matmul_mx_acc(acc, *self._mx_operands(span, valid=(8, 64, 16)), span)
 
     @pytest.mark.parametrize(
         ("index", "name", "shape", "dtype", "valid_shape"),
@@ -292,7 +325,7 @@ class TestMatmulMxTypes:
     )
     def test_rejects_rank_mismatched_operand_valid_shape(self, index, name, shape, dtype, valid_shape):
         span = ir.Span.unknown()
-        operands = list(_mx_operands(span))
+        operands = list(self._mx_operands(span))
         operands[index] = _tile(name, shape, dtype, valid_shape=valid_shape)
 
         with pytest.raises(ValueError, match=r"valid_shape rank \(1\) must match.*rank \(2\)"):
@@ -300,7 +333,7 @@ class TestMatmulMxTypes:
 
     def test_rejects_rank_mismatched_acc_and_bias_valid_shape(self):
         span = ir.Span.unknown()
-        operands = _mx_operands(span)
+        operands = self._mx_operands(span)
 
         with pytest.raises(ValueError, match=r"valid_shape rank \(1\) must match.*rank \(2\)"):
             ir.op.tile.matmul_mx_acc(_tile("acc", [16, 32], DataType.FP32, valid_shape=[16]), *operands, span)
@@ -310,7 +343,7 @@ class TestMatmulMxTypes:
 
     def test_rejects_bias_valid_mismatch(self):
         span = ir.Span.unknown()
-        lhs, lhs_scale, rhs, rhs_scale = _mx_operands(span, valid=(8, 64, 16))
+        lhs, lhs_scale, rhs, rhs_scale = self._mx_operands(span, valid=(8, 64, 16))
         bias = _tile("bias", [1, 32], DataType.FP32, valid_shape=[1, 32])
         with pytest.raises(ValueError, match="bias valid cols"):
             ir.op.tile.matmul_mx_bias(lhs, lhs_scale, rhs, rhs_scale, bias, span)
@@ -326,6 +359,10 @@ class TestTGetScaleAddr:
         assert isinstance(call_type, ir.TileType)
         assert call_type.memory_space == ir.MemorySpace.RightScale
 
+        fp4_src = _tile("fp4_rb", [64, 32], DataType.FP4, memory=ir.MemorySpace.Right)
+        with pytest.raises(ValueError, match="requires src dtype FP8E4M3FN"):
+            ir.op.tile.tget_scale_addr(dst, fp4_src, span)
+
         with pytest.raises(ValueError, match="LeftScale↔Left|RightScale↔Right"):
             ir.op.tile.tget_scale_addr(
                 _tile("las", [16, 2], DataType.FP8E8M0, memory=ir.MemorySpace.LeftScale),
@@ -338,7 +375,7 @@ class TestTGetScaleAddr:
                 _tile("la", [16, 64], DataType.FP8E4M3FN, memory=ir.MemorySpace.Left),
                 span,
             )
-        with pytest.raises(ValueError, match="FP8E4M3FN"):
+        with pytest.raises(ValueError, match="requires src dtype FP8E4M3FN"):
             ir.op.tile.tget_scale_addr(
                 _tile("las", [16, 2], DataType.FP8E8M0, memory=ir.MemorySpace.LeftScale),
                 _tile("la", [16, 64], DataType.FP16, memory=ir.MemorySpace.Left),

--- a/tests/ut/ir/test_compiled_program.py
+++ b/tests/ut/ir/test_compiled_program.py
@@ -135,6 +135,23 @@ def _make_program_with_scalar() -> ir.Program:
     return ir.Program([orch], "ScalarProgram", span)
 
 
+def _make_fp4_output_program() -> ir.Program:
+    span = ir.Span.unknown()
+    logical_type = ir.TensorType([8, 16], DataType.FP4)
+    src = ir.Var("src", logical_type, span)
+    out = ir.Var("out", logical_type, span)
+    params = [(src, ir.ParamDirection.In), (out, ir.ParamDirection.Out)]
+    orch = ir.Function(
+        "orchestrator",
+        params,
+        [logical_type],
+        ir.SeqStmts([], span),
+        span,
+        ir.FunctionType.Orchestration,
+    )
+    return ir.Program([orch], "Fp4OutputProgram", span)
+
+
 class TestCompiledProgramBackwardCompat:
     """Verify CompiledProgram behaves like a path string for backward compat."""
 
@@ -197,6 +214,12 @@ class TestExtractParamInfos:
         infos, _, _ = _extract_param_infos(prog)
         assert infos[0].shape == [128, 128]
         assert infos[0].dtype == DataType.FP32
+
+    def test_fp4_metadata_uses_torch_x2_carrier_shape(self):
+        infos, out_idx, _ = _extract_param_infos(_make_fp4_output_program())
+        assert [info.shape for info in infos] == [[8, 8], [8, 8]]
+        assert all(info.dtype == DataType.FP4 for info in infos)
+        assert out_idx == [1]
 
     def test_return_types(self):
         prog = _make_program_with_orchestration(has_return=True)
@@ -329,6 +352,19 @@ class TestBuildFullArgs:
         assert out.shape == (128, 128)
         assert out.dtype == torch.float32
         assert torch.all(out == 0)
+
+    @pytest.mark.skipif(
+        not hasattr(torch, "float4_e2m1fn_x2"),
+        reason="torch.float4_e2m1fn_x2 required",
+    )
+    def test_allocates_fp4_output_with_physical_x2_shape(self):
+        infos, output_indices, _ = _extract_param_infos(_make_fp4_output_program())
+        src = torch.zeros((8, 8), dtype=torch.float4_e2m1fn_x2)
+        full_args = _build_full_args((src,), infos, output_indices)
+        out = full_args[1]
+        assert isinstance(out, torch.Tensor)
+        assert out.shape == (8, 8)
+        assert out.dtype == torch.float4_e2m1fn_x2
 
 
 class TestCompileReturnsCompiledProgram:

--- a/tests/ut/ir/transforms/test_init_memref.py
+++ b/tests/ut/ir/transforms/test_init_memref.py
@@ -546,6 +546,64 @@ class TestSliceView:
         After = passes.init_mem_ref()(Before)
         ir.assert_structural_equal(After, Expected)
 
+    @pytest.mark.parametrize("dtype", [pl.FP4, pl.INT4, pl.UINT4, pl.HF4])
+    def test_four_bit_dtypes_share_packed_allocation_accounting(self, dtype):
+        """All semantic 4-bit dtypes occupy one byte per two logical elements."""
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(
+                self,
+                input_a: pl.Tensor[[8, 16], dtype],
+                output: pl.Out[pl.Tensor[[8, 16], dtype]],
+            ) -> pl.Tensor[[8, 16], dtype]:
+                tile_a = pl.load(input_a, [0, 0], [8, 16])
+                return pl.store(tile_a, [0, 0], output)
+
+        printed = ir.python_print(passes.init_mem_ref()(Before))
+        zero = r"(?:0|pl\.const\(0, pl\.INT64\))"
+        assert re.search(rf'input_a: .*pl\.MemRef\("mem_ddr_0", {zero}, 64\)', printed), printed
+        assert re.search(rf'output: .*pl\.MemRef\("mem_ddr_1", {zero}, 64\)', printed), printed
+        assert re.search(rf"tile_a: .*pl\.MemRef\(mem_vec_\d+, {zero}, 64\)", printed), printed
+        assert "pl.tile.alloc(pl.Mem.Vec, 64)" in printed
+
+    def test_fp4_slice_uses_packed_byte_offset_and_span(self):
+        @pl.program
+        class Before:
+            @pl.function
+            def main(
+                self,
+                input_a: pl.Tensor[[8, 16], pl.FP4],
+                output: pl.Out[pl.Tensor[[1, 16], pl.FP4]],
+            ) -> pl.Tensor[[1, 16], pl.FP4]:
+                tile_a = pl.load(input_a, [0, 0], [8, 16])
+                row = pl.tile.slice(tile_a, [1, 16], [1, 0])
+                return pl.store(row, [0, 0], output)
+
+        printed = ir.python_print(passes.init_mem_ref()(Before))
+        assert "pl.tile.alloc(pl.Mem.Vec, 64)" in printed
+        assert re.search(
+            r"row: .*pl\.MemRef\(mem_vec_\d+, (?:8|pl\.const\(8, pl\.INT64\)), 8\)",
+            printed,
+        ), printed
+
+    def test_fp4_slice_rejects_second_nibble_origin(self):
+        @pl.program
+        class Before:
+            @pl.function
+            def main(
+                self,
+                input_a: pl.Tensor[[8, 16], pl.FP4],
+                output: pl.Out[pl.Tensor[[1, 14], pl.FP4]],
+            ) -> pl.Tensor[[1, 14], pl.FP4]:
+                tile_a = pl.load(input_a, [0, 0], [8, 16])
+                tail = pl.tile.slice(tile_a, [1, 14], [0, 1])
+                return pl.store(tail, [0, 0], output)
+
+        with pytest.raises(ValueError, match="Packed 4-bit slice origins must be byte-aligned"):
+            passes.init_mem_ref()(Before)
+
 
 class TestYieldMemRef:
     """MemRef propagation through yield in ForStmt and IfStmt."""

--- a/tests/ut/ir/transforms/test_legalize_tile_cast.py
+++ b/tests/ut/ir/transforms/test_legalize_tile_cast.py
@@ -14,6 +14,8 @@ import pytest
 from pypto import backend, ir, passes
 from pypto.backend import BackendType
 
+_TILE_CAST = ir.get_op("tile.cast").name
+
 
 class _CastTargetCollector(ir.IRVisitor):
     """Record each tile.cast's (src_dtype, target_type) in visitation order."""
@@ -23,7 +25,7 @@ class _CastTargetCollector(ir.IRVisitor):
         self.pairs: list[tuple[str, str]] = []
 
     def visit_call(self, op: ir.Call) -> None:
-        if op.op.name == ir.get_op("tile.cast").name:
+        if op.op.name == _TILE_CAST:
             src_ty = op.args[0].type
             assert isinstance(src_ty, ir.TileType)
             src = str(src_ty.dtype)
@@ -77,6 +79,50 @@ def test_a5_int32_to_fp16_becomes_fp32_bridge():
     after = _run(Before, BackendType.Ascend950)
     pairs = _cast_pairs(after)
     assert pairs == [("int32", "fp32"), ("fp32", "fp16")], pairs
+
+
+def test_a5_explicit_fp4_to_fp8_cast_becomes_three_native_hops():
+    """The public FP4→FP8 cast expands in LegalizeTileCast and preserves valid_shape."""
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore)
+        def kernel(
+            self,
+            x: pl.Tensor[[16, 64], pl.FP4],
+            out: pl.Out[pl.Tensor[[16, 64], pl.FP8E4M3FN]],
+        ) -> pl.Tensor[[16, 64], pl.FP8E4M3FN]:
+            t = pl.load(x, [0, 0], [16, 64], valid_shape=[8, 48])
+            c = pl.cast(t, pl.FP8E4M3FN)
+            return pl.store(c, [0, 0], out)
+
+    after = _run(Before, BackendType.Ascend950)
+    assert _cast_pairs(after) == [
+        ("fp4", "bfloat16"),
+        ("bfloat16", "fp32"),
+        ("fp32", "fp8e4m3fn"),
+    ]
+
+    class _ValidShapeCollector(ir.IRVisitor):
+        def __init__(self) -> None:
+            super().__init__()
+            self.shapes: list[tuple[int, int]] = []
+
+        def visit_call(self, op: ir.Call) -> None:
+            if op.op.name == _TILE_CAST:
+                tile_type = op.type
+                assert isinstance(tile_type, ir.TileType)
+                valid = tile_type.get_effective_tile_view().valid_shape
+                assert len(valid) == 2
+                rows, cols = valid
+                assert isinstance(rows, ir.ConstInt)
+                assert isinstance(cols, ir.ConstInt)
+                self.shapes.append((rows.value, cols.value))
+            super().visit_call(op)
+
+    collector = _ValidShapeCollector()
+    collector.visit_program(after)
+    assert collector.shapes == [(8, 48), (8, 48), (8, 48)]
 
 
 def test_a2a3_int32_to_fp16_stays_native():

--- a/tests/ut/jit/test_decorator.py
+++ b/tests/ut/jit/test_decorator.py
@@ -27,6 +27,7 @@ from pypto.jit.decorator import (
     _discover_deps,
     _extract_call_args_for_dep,
     _extract_local_tensor_metas,
+    _extract_tensor_meta,
     _resolve_dep_call_metadata,
     _rewrite_jit_error,
     _run_config_compile_kwargs,
@@ -59,6 +60,25 @@ class TestJitDecoration:
             return a
 
         assert my_kernel.__name__ == "my_kernel"
+
+    def test_torch_fp4_x2_shape_becomes_logical_ir_shape(self):
+        torch = pytest.importorskip("torch")
+        fp4_dtype = getattr(torch, "float4_e2m1fn_x2", None)
+        if fp4_dtype is None:
+            pytest.skip("torch.float4_e2m1fn_x2 required")
+        packed = torch.empty((128, 32), dtype=fp4_dtype)
+        meta = _extract_tensor_meta(packed)
+        assert meta.dtype == DataType.FP4
+        assert meta.static_shape() == (128, 64)
+
+    def test_torch_fp4_x2_rejects_empty_packed_dimension(self):
+        torch = pytest.importorskip("torch")
+        fp4_dtype = getattr(torch, "float4_e2m1fn_x2", None)
+        if fp4_dtype is None:
+            pytest.skip("torch.float4_e2m1fn_x2 required")
+        packed = torch.empty((128, 0), dtype=fp4_dtype)
+        with pytest.raises(TypeError, match="positive runtime x2 carrier last dimension"):
+            _extract_tensor_meta(packed)
 
     def test_jit_incore_creates_jitfunction(self):
         @jit.incore


### PR DESCRIPTION
Compared with main, this change:
- accounts FP4, INT4, UINT4, and HF4 storage as packed nibbles across allocation, MemRef/view offsets, and residency/capacity calculations
- maps Torch/runtime FP4 x2 carrier shapes at JIT, compiled-call, tensor-create, and orchestration ABI boundaries while keeping IR shapes in logical nibble units
- centralizes the static FP4 shape contract in ShapedType: rank must be nonzero and the innermost logical extent must be positive and even
- enables Ascend950 FP4 Vec lowering and temporarily legalizes explicit FP4 -> BF16 -> FP32 -> FP8E4M3FN tile casts for the supported FP4-lhs MX path; this temporary conversion will be replaced once bitwise FP4 -> FP8 conversion is supported
- extends MX type inference, backend capability checks, codegen, golden generation, harness dtype support, and A5 base/acc system coverage, including signed FP4 nibble values
- updates English and Chinese language/operator documentation and marks matmul_mx base/acc system coverage complete

Use case:
- The AscendC recipe recommends Hybrid MXFP8-MXFP4 for DeepSeek-V4 Pro on Ascend 950PR/DT to reduce the storage and memory-bandwidth cost of its large MoE. In each transformer layer and the MTP MoE, the routed experts' w1/w3 gate-up and w2 down-projection weights are statically quantized to packed E2M1 MXFP4 (two values per byte), with one E8M0 scale per group of 32 weight elements; shared-expert weights remain MXFP8 W8A8. At runtime, BF16 token activations are dynamically quantized per 32 hidden elements to E4M3 MXFP8 with E8M0 scales, then run a W4A8 grouped matmul for the fused gate/up projection, SwiGLU plus MXFP8 requantization, and a second W4A8 grouped matmul for the down projection, producing BF16 or the requested final output dtype. Other selected Linear paths use MXFP8, which forms the hybrid scheme. This PR provides the prerequisite packed-FP4 host, storage, and ABI support; native FP8 x MXFP4 grouped matmul remains a current limitation below.

Current limitations:
- tile.matmul_mx still receives FP8E4M3FN data operands; an FP4 lhs must be explicitly cast before FP4 x FP8 execution
- the matrix-multiplication operation of MXFP4 x MXFP4 natively supported by the current hardware is not yet supported
- packed FP4 logical innermost dimensions must be positive and even
- dynamic FP4 Vec valid_shape on the packed axis is not supported
- packed FP4 slice origins must be byte-aligned, and orchestration transpose/view cannot move the packed axis
- INT4, UINT4, and HF4 are storage-accounted but are not end-to-end Ascend950 in-core types; Ascend910B has no packed 4-bit load/store carrier ABI
- MXFP4 quantization remains deferred
