### PR TITLE
fix(ir): handle reference-valued attrs by type, not by key name

### DIFF
--- a/include/pypto/ir/expr.h
+++ b/include/pypto/ir/expr.h
@@ -891,6 +891,37 @@ inline constexpr const char* kAttrSyncStart = "sync_start";
 }
 
 /**
+ * @brief Invoke ``fn`` on every ``ExprPtr`` an attr value references.
+ *
+ * Dispatches on the value's stored TYPE, never on its key name. This is the
+ * same discipline the serializer (``serializer.cpp``, ``value.type() ==
+ * typeid(ExprPtr)``), the deserializer and the printer (``PrintAttrValue``)
+ * already use, and it is what makes attr edges self-maintaining: a newly
+ * invented attr key that happens to hold a ``Var`` is walked automatically, so
+ * it cannot open a blind spot in SSA renaming, liveness, DCE or ``UseAfterDef``.
+ *
+ * A key-name-gated walk cannot offer that. The three former walk sites
+ * (``VisitExpr_(CallPtr)``, ``VisitExpr_(SubmitPtr)``, ``VisitScopeAttrs``)
+ * each carried a different hand-maintained list, which is how ``kAttrDevice``
+ * came to be walked on a ``Call`` but not on a ``Submit``.
+ *
+ * Non-reference values (scalars, enums, ``vector<int32_t>``,
+ * ``vector<ArgDirection>``) are ignored: they name nothing.
+ */
+template <typename F>
+void ForEachAttrExpr(const std::any& value, F&& fn) {
+  if (const auto* var = std::any_cast<VarPtr>(&value)) {
+    if (*var) fn(ExprPtr(*var));
+  } else if (const auto* vars = std::any_cast<std::vector<VarPtr>>(&value)) {
+    for (const auto& v : *vars) {
+      if (v) fn(ExprPtr(v));
+    }
+  } else if (const auto* expr = std::any_cast<ExprPtr>(&value)) {
+    if (*expr) fn(*expr);
+  }
+}
+
+/**
  * @brief Reserved attr key for a dispatch predicate — ``predicate=(t[i] > 0)``.
  *
  * Value type: ``ExprPtr`` — the comparison Expr as written (e.g.

--- a/include/pypto/ir/kind_traits.h
+++ b/include/pypto/ir/kind_traits.h
@@ -12,9 +12,13 @@
 #ifndef PYPTO_IR_KIND_TRAITS_H_
 #define PYPTO_IR_KIND_TRAITS_H_
 
+#include <any>
 #include <cstddef>
 #include <memory>
+#include <optional>
 #include <type_traits>
+#include <utility>
+#include <vector>
 
 #include "pypto/ir/core.h"
 #include "pypto/ir/expr.h"
@@ -312,6 +316,61 @@ inline VarPtr AsVarLike(const ExprPtr& expr) {
     return std::static_pointer_cast<const Var>(expr);
   }
   return nullptr;
+}
+
+/**
+ * @brief Rewrite every ``ExprPtr`` an attr value references, by stored type.
+ *
+ * The rewriting counterpart of ``ForEachAttrExpr`` (``expr.h``): whatever that
+ * walk reports as a live reference, this one must rewrite, or substitution
+ * leaves the attr pointing at a pre-mutation ``Var``. Sharing one
+ * type-dispatched implementation is what keeps the two in step — the key lists
+ * they replaced had already drifted apart across ``IRMutator`` and the SSA
+ * pass's own ``SubstCallAttrs`` / ``SubstScopeAttrs``.
+ *
+ * The value's stored type is preserved: a ``VarPtr`` attr stays a ``VarPtr``
+ * and never widens to ``ExprPtr``. ``AsVarLike`` (not ``As<Var>``) keeps a
+ * remapped ``IterArg`` matching. Returns ``std::nullopt`` when nothing changed,
+ * so callers keep their copy-on-write short-circuit.
+ *
+ * @param value Attr value to rewrite.
+ * @param remap Callable mapping one ``ExprPtr`` to its replacement.
+ */
+template <typename F>
+std::optional<std::any> MapAttrExprs(const std::any& value, F&& remap) {
+  if (const auto* var = std::any_cast<VarPtr>(&value)) {
+    if (!*var) return std::nullopt;
+    auto next = AsVarLike(remap(ExprPtr(*var)));
+    if (!next || next.get() == var->get()) return std::nullopt;
+    return std::any(std::move(next));
+  }
+  if (const auto* vars = std::any_cast<std::vector<VarPtr>>(&value)) {
+    std::vector<VarPtr> next;
+    next.reserve(vars->size());
+    bool changed = false;
+    for (const auto& v : *vars) {
+      if (!v) {
+        next.push_back(v);
+        continue;
+      }
+      auto remapped = AsVarLike(remap(ExprPtr(v)));
+      if (!remapped) {
+        next.push_back(v);  // Should not happen; keep the original over corrupting the attr.
+        continue;
+      }
+      if (remapped.get() != v.get()) changed = true;
+      next.push_back(std::move(remapped));
+    }
+    if (!changed) return std::nullopt;
+    return std::any(std::move(next));
+  }
+  if (const auto* expr = std::any_cast<ExprPtr>(&value)) {
+    if (!*expr) return std::nullopt;
+    auto next = remap(*expr);
+    if (!next || next.get() == expr->get()) return std::nullopt;
+    return std::any(std::move(next));
+  }
+  return std::nullopt;
 }
 
 /**

--- a/python/pypto/language/parser/decorator.py
+++ b/python/pypto/language/parser/decorator.py
@@ -404,22 +404,110 @@ def _extract_function_auto_scope_from_decorator(node: ast.FunctionDef) -> bool |
     return None
 
 
-def _normalize_attrs(attrs: dict[str, Any]) -> dict[str, Any] | None:
-    """Normalize function attrs: convert SplitMode enums to int values for C++ storage.
+def _normalize_attrs(attrs: Any) -> dict[str, Any] | None:
+    """Normalize function attrs for C++ storage.
 
-    SplitMode.NONE entries are dropped (equivalent to no split).
+    ``SplitMode`` enums become their int value; ``SplitMode.NONE`` is dropped
+    (equivalent to no split, and the printer filters it for the same reason).
+
+    DSL wrapper values are unwrapped to the IR ``Expr`` they carry. The printer
+    emits that ``Expr`` in DSL spelling (e.g. ``pl.system.available_cluster_count()``),
+    so reparsing printed source evaluates the wrapper again — without this the
+    attr store rejects it as an unsupported kwarg type.
+
     Returns None if the result is empty.
+
+    Raises:
+        ParserSyntaxError: If ``attrs`` is not a dict, a key is not a string, or
+            a value references an SSA binding (see the ``StaticAttrs`` IR
+            property — a Function attr has no legal spelling for one).
     """
-    if not attrs:
-        return None
+    if not isinstance(attrs, dict):
+        raise ParserSyntaxError(
+            f"`@pl.function(attrs=...)` must be a dict, got {type(attrs).__name__}",
+            hint='Use a dict, e.g. attrs={"split": pl.SplitMode.UP_DOWN}.',
+        )
     result: dict[str, Any] = {}
     for key, value in attrs.items():
+        if not isinstance(key, str):
+            raise ParserSyntaxError(
+                f"`@pl.function(attrs=...)` keys must be strings, got {key!r}",
+                hint='Use string keys, e.g. attrs={"core_num": 8}.',
+            )
         if isinstance(value, ir.SplitMode):
             if value != ir.SplitMode.NONE:
                 result[key] = value.value
-        else:
-            result[key] = value
+            continue
+        if hasattr(value, "unwrap"):
+            # Annotation-only wrappers raise on unwrap, but not uniformly:
+            # Scalar/Ptr raise RuntimeError while Tensor/Tile/Array raise
+            # ValueError. Catch both so the actionable diagnostic is not
+            # bypassed by whichever wrapper the caller passed.
+            try:
+                value = value.unwrap()
+            except (RuntimeError, ValueError) as e:
+                raise ParserSyntaxError(
+                    f"@pl.function attr '{key}' is an annotation-only {type(value).__name__}",
+                    hint="Pass a value expression, not a type annotation.",
+                ) from e
+        _reject_ssa_referencing_attr(key, value)
+        result[key] = value
     return result or None
+
+
+def _reject_ssa_referencing_attr(key: str, value: Any) -> None:
+    """Reject a Function attr value that references an SSA binding.
+
+    The DSL-side half of the ``StaticAttrs`` IR property. A ``Var`` in a
+    function attr names something the function does not bind: a decorator is
+    evaluated before the body binds anything, and a launch-site value belongs
+    to the *calling* function. Such an attr is unprintable as a decorator and
+    invisible to every pass that walks the use-def chain, so it is rejected at
+    the source rather than surfacing later as a structural mismatch.
+    """
+    if isinstance(value, (list, tuple)):
+        offenders = [v for v in value if isinstance(v, ir.Expr)]
+    else:
+        offenders = [value] if isinstance(value, ir.Expr) else []
+    for expr in offenders:
+        if not _expr_references_ssa(expr):
+            continue
+        raise ParserSyntaxError(
+            f"@pl.function attr '{key}' references a variable, which a function attr cannot carry",
+            hint=(
+                "A decorator is evaluated before the body binds any name, so the reference has no "
+                "legal spelling. Pass the value at the launch site instead — e.g. "
+                "`with pl.spmd(n):` rather than `attrs={'core_num': n}`."
+            ),
+        )
+
+
+class _SsaRefFinder(ir.IRVisitor):
+    """Detects any Var-like reference inside an attr expression subtree.
+
+    ``Var`` and ``IterArg`` are overridden separately rather than through
+    ``visit_var_like`` because each carries its own ``ObjectKind`` and so
+    dispatches independently (see ``.claude/rules/ir-kind-traits.md``).
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.found = False
+
+    def visit_var(self, op: ir.Var) -> None:
+        self.found = True
+
+    def visit_iter_arg(self, op: Any) -> None:
+        self.found = True
+
+    def visit_mem_ref(self, op: Any) -> None:
+        self.found = True
+
+
+def _expr_references_ssa(expr: ir.Expr) -> bool:
+    finder = _SsaRefFinder()
+    finder.visit_expr(expr)
+    return finder.found
 
 
 # Function-attr key carrying the path to a hand-written external C++ kernel
@@ -855,7 +943,12 @@ def function(
             # object: reconstructing the dict from AST loses closure values,
             # DataType values, and every other non-literal expression. The
             # @pl.program walker reads this snapshot before building the IR.
-            f._pl_function_attrs = _normalize_attrs(attrs or {}) or {}  # type: ignore[attr-defined]
+            # Gate on `is not None`, not truthiness: a falsey non-dict such as
+            # `attrs=[]` or `attrs=""` must reach the validator rather than be
+            # silently treated as absent.
+            f._pl_function_attrs = (  # type: ignore[attr-defined]
+                _normalize_attrs(attrs) or {} if attrs is not None else {}
+            )
             # Stash the resolved external_source for the same reason: the value
             # is a runtime Path expression that cannot be re-read from the AST.
             if resolved_external_source is not None:
@@ -894,7 +987,7 @@ def function(
             )
 
             # Normalize attrs: convert enum values to ints for storage
-            func_attrs = _normalize_attrs(attrs) if attrs else None
+            func_attrs = _normalize_attrs(attrs) if attrs is not None else None
             # Fold auto_scope=False into attrs (absent ⇒ default True).
             if auto_scope is False:
                 func_attrs = {**(func_attrs or {}), "auto_scope": False}

--- a/src/ir/transforms/convert_to_ssa_pass.cpp
+++ b/src/ir/transforms/convert_to_ssa_pass.cpp
@@ -266,6 +266,11 @@ class SSAConverter {
     result->params_ = std::move(new_params);
     result->param_directions_ = std::move(new_dirs);
     result->body_ = std::move(new_body);
+    // A function attr may legally reference a parameter, and the parameters
+    // above were just re-versioned. Without this the attr keeps pointing at the
+    // pre-SSA Var and the UseAfterDef function-attr walk reports it undefined.
+    auto new_attrs = SubstCallAttrs(result->attrs_);
+    if (new_attrs.has_value()) result->attrs_ = std::move(*new_attrs);
     return result;
   }
 
@@ -351,42 +356,15 @@ class SSAConverter {
     bool changed = false;
     std::vector<std::pair<std::string, std::any>> out;
     out.reserve(attrs.size());
+    // Substitute by stored type, matching ``ForEachAttrExpr`` on the visitor
+    // side and ``MapAttrExprs`` in IRMutator. A key-gated version left any attr
+    // key nobody enumerated pointing at its pre-SSA Var.
     for (const auto& [k, v] : attrs) {
-      if (k == kAttrManualDepEdges || k == kAttrCompilerManualDepEdges || k == kAttrDumpVars) {
-        const auto* edges = std::any_cast<std::vector<VarPtr>>(&v);
-        if (edges) {
-          std::vector<VarPtr> new_edges;
-          new_edges.reserve(edges->size());
-          bool any = false;
-          for (const auto& e : *edges) {
-            if (!e) {
-              new_edges.push_back(e);
-              continue;
-            }
-            auto it = cur_.find(e.get());
-            if (it != cur_.end() && it->second.get() != e.get()) {
-              new_edges.push_back(it->second);
-              any = true;
-            } else {
-              new_edges.push_back(e);
-            }
-          }
-          if (any) {
-            changed = true;
-            out.emplace_back(k, std::any(std::move(new_edges)));
-            continue;
-          }
-        }
-      } else if (IsExprValuedCallAttr(k)) {
-        const auto* attr_expr = std::any_cast<ExprPtr>(&v);
-        if (attr_expr && *attr_expr) {
-          auto new_expr = SubstExpr(*attr_expr);
-          if (new_expr.get() != attr_expr->get()) {
-            changed = true;
-            out.emplace_back(k, std::any(std::move(new_expr)));
-            continue;
-          }
-        }
+      auto remapped = MapAttrExprs(v, [this](const ExprPtr& e) { return SubstExpr(e); });
+      if (remapped.has_value()) {
+        changed = true;
+        out.emplace_back(k, std::move(*remapped));
+        continue;
       }
       out.emplace_back(k, v);
     }
@@ -1001,59 +979,16 @@ class SSAConverter {
     bool changed = false;
     std::vector<std::pair<std::string, std::any>> out;
     out.reserve(attrs.size());
+    // Substitute by stored type. ``SubstScopeAttrs`` runs before the body is
+    // converted (see ConvertScope), so attr references resolve to the SSA
+    // versions visible at scope entry — the type dispatch changes which attrs
+    // are covered, not when.
     for (const auto& [k, v] : attrs) {
-      if (k == kAttrManualDepEdges || k == kAttrCompilerManualDepEdges || k == kAttrArgDirOverrideVars ||
-          k == kAttrDumpVars) {
-        const auto* edges = std::any_cast<std::vector<VarPtr>>(&v);
-        if (edges) {
-          std::vector<VarPtr> new_edges;
-          new_edges.reserve(edges->size());
-          bool any = false;
-          for (const auto& e : *edges) {
-            if (!e) {
-              new_edges.push_back(e);
-              continue;
-            }
-            auto it = cur_.find(e.get());
-            if (it != cur_.end() && it->second.get() != e.get()) {
-              new_edges.push_back(it->second);
-              any = true;
-            } else {
-              new_edges.push_back(e);
-            }
-          }
-          if (any) {
-            changed = true;
-            out.emplace_back(k, std::any(std::move(new_edges)));
-            continue;
-          }
-        }
-      } else if (k == kAttrTaskIdVar) {
-        const auto* var = std::any_cast<VarPtr>(&v);
-        if (var && *var) {
-          auto it = cur_.find(var->get());
-          if (it != cur_.end() && it->second.get() != var->get()) {
-            changed = true;
-            out.emplace_back(k, std::any(it->second));
-            continue;
-          }
-        }
-      } else if (k == kAttrPredicate) {
-        // ``with pl.spmd(..., predicate=(t[i] > 0)):`` — an ExprPtr, so
-        // substitute the whole subtree via SubstExpr rather than remapping a
-        // single Var (mirrors the kAttrDevice handling in SubstCallAttrs).
-        // Substituting here — before the body is converted, see ConvertScope —
-        // resolves the operand tensor to the SSA version visible at scope
-        // entry, which is the value the scheduler reads at the dispatch point.
-        const auto* pred = std::any_cast<ExprPtr>(&v);
-        if (pred && *pred) {
-          auto new_pred = SubstExpr(*pred);
-          if (new_pred.get() != pred->get()) {
-            changed = true;
-            out.emplace_back(k, std::any(std::move(new_pred)));
-            continue;
-          }
-        }
+      auto remapped = MapAttrExprs(v, [this](const ExprPtr& e) { return SubstExpr(e); });
+      if (remapped.has_value()) {
+        changed = true;
+        out.emplace_back(k, std::move(*remapped));
+        continue;
       }
       out.emplace_back(k, v);
     }

--- a/src/ir/transforms/mutator.cpp
+++ b/src/ir/transforms/mutator.cpp
@@ -166,10 +166,30 @@ FunctionPtr IRMutator::VisitFunction(const FunctionPtr& func) {
   auto new_body = VisitStmt(func->body_);
   bool body_changed = (new_body.get() != func->body_.get());
 
-  if (!params_changed && !return_types_changed && !body_changed) return func;
+  // A reference-valued function attr names a param, so remapping a param must
+  // rewrite the attr too — otherwise it dangles to the pre-substitution Var,
+  // which is the failure mode that made the Function-carried SPMD launch spec
+  // untenable. Runs after the param walk has primed var_remap_.
+  std::vector<std::pair<std::string, std::any>> new_attrs;
+  bool attrs_changed = false;
+  new_attrs.reserve(func->attrs_.size());
+  for (const auto& [k, v] : func->attrs_) {
+    auto remapped = MapAttrExprs(v, [this](const ExprPtr& e) { return ExprFunctor<ExprPtr>::VisitExpr(e); });
+    if (remapped.has_value()) {
+      attrs_changed = true;
+      new_attrs.emplace_back(k, std::move(*remapped));
+    } else {
+      new_attrs.emplace_back(k, v);
+    }
+  }
+
+  if (!params_changed && !return_types_changed && !body_changed && !attrs_changed) return func;
+  // ``new_attrs`` carries every key — remapped entries and untouched copies
+  // alike — so it can be moved unconditionally. A ternary against
+  // ``func->attrs_`` would deduce a const reference and silently copy instead.
   return std::make_shared<const Function>(func->name_, std::move(new_params), func->param_directions_,
                                           std::move(new_return_types), std::move(new_body), func->span_,
-                                          func->func_type_, func->level_, func->role_, func->attrs_);
+                                          func->func_type_, func->level_, func->role_, std::move(new_attrs));
 }
 
 ExprPtr IRMutator::VisitExpr(const ExprPtr& expr) { return ExprFunctor<ExprPtr>::VisitExpr(expr); }
@@ -365,61 +385,21 @@ ExprPtr IRMutator::VisitExpr_(const CallPtr& op) {
   std::vector<std::pair<std::string, std::any>> new_attrs;
   bool attrs_changed = false;
   new_attrs.reserve(op->attrs_.size());
+  // Remap by stored type, matching ``IRVisitor::VisitExpr_(CallPtr)``. The two
+  // must agree: anything the visitor reports as a live reference has to be
+  // rewritten here, or substitution leaves the attr pointing at the pre-mutation
+  // Var — e.g. the P==1 unroll folding ``r`` -> ``0`` rewrites the slice
+  // subscripts but leaves ``device=r`` dangling to the now-undefined loop var,
+  // and codegen emits an unbound index. A key-gated remap could not keep that
+  // promise for an attr key nobody thought to enumerate.
   for (const auto& [k, v] : op->attrs_) {
-    if (k == kAttrManualDepEdges || k == kAttrCompilerManualDepEdges || k == kAttrArgDirOverrideVars ||
-        k == kAttrDumpVars) {
-      const auto* edges = std::any_cast<std::vector<VarPtr>>(&v);
-      if (edges) {
-        std::vector<VarPtr> new_edges;
-        new_edges.reserve(edges->size());
-        bool any_changed = false;
-        for (const auto& e : *edges) {
-          if (!e) {
-            new_edges.push_back(e);
-            continue;
-          }
-          auto remapped = ExprFunctor<ExprPtr>::VisitExpr(e);
-          // Use AsVarLike so a remapped IterArg (loop-carried tensor) still
-          // matches — As<Var> is exact-kind only and would silently drop the
-          // remap, leaving a stale pointer in the attr.
-          auto remapped_var = AsVarLike(remapped);
-          if (!remapped_var) {
-            // Should not happen — Var/IterArg visits return Var-like. Fall
-            // back to original to avoid corrupting the attr.
-            new_edges.push_back(e);
-            continue;
-          }
-          if (remapped_var.get() != e.get()) {
-            any_changed = true;
-          }
-          new_edges.push_back(std::move(remapped_var));
-        }
-        if (any_changed) {
-          attrs_changed = true;
-          new_attrs.emplace_back(k, std::any(std::move(new_edges)));
-          continue;
-        }
-      }
-    } else if (IsExprValuedCallAttr(k)) {
-      // Expr-valued dispatch attrs (``device=`` selector, ``core_num`` launch
-      // width) hold a single ExprPtr over Vars defined elsewhere in this
-      // function, so they must be remapped alongside the args — otherwise a
-      // substitution (e.g. the P==1 unroll folding ``r`` -> ``0``) rewrites the
-      // slice subscripts but leaves ``device=r`` dangling to the now-undefined
-      // loop var, and codegen emits an unbound index -> NameError. Mirrors the
-      // SSA pass's SubstCallAttrs and ``Submit::core_num_`` below.
-      const auto* attr_expr = std::any_cast<ExprPtr>(&v);
-      if (attr_expr && *attr_expr) {
-        auto new_expr = ExprFunctor<ExprPtr>::VisitExpr(*attr_expr);
-        INTERNAL_CHECK_SPAN(new_expr, op->span_) << "Call '" << k << "' attribute mutated to null";
-        if (new_expr.get() != attr_expr->get()) {
-          attrs_changed = true;
-          new_attrs.emplace_back(k, std::any(std::move(new_expr)));
-          continue;
-        }
-      }
+    auto remapped = MapAttrExprs(v, [this](const ExprPtr& e) { return ExprFunctor<ExprPtr>::VisitExpr(e); });
+    if (remapped.has_value()) {
+      attrs_changed = true;
+      new_attrs.emplace_back(k, std::move(*remapped));
+    } else {
+      new_attrs.emplace_back(k, v);
     }
-    new_attrs.emplace_back(k, v);
   }
 
   if (!args_changed && !type_changed && !attrs_changed) return op;
@@ -503,40 +483,16 @@ ExprPtr IRMutator::VisitExpr_(const SubmitPtr& op) {
   std::vector<std::pair<std::string, std::any>> new_attrs;
   bool attrs_changed = false;
   new_attrs.reserve(op->attrs_.size());
+  // Remapped by stored type, matching ``IRVisitor::VisitExpr_(SubmitPtr)``.
+  // Previously this arm listed three keys while the Call arm listed a different
+  // set plus ``IsExprValuedCallAttr``, so an Expr-valued attr such as
+  // ``kAttrDevice`` was rewritten on a Call but left stale on a Submit.
   for (const auto& [k, v] : op->attrs_) {
-    if (k == kAttrArgDirOverrideVars || k == kAttrCompilerManualDepEdges || k == kAttrDumpVars) {
-      const auto* edges = std::any_cast<std::vector<VarPtr>>(&v);
-      if (edges) {
-        std::vector<VarPtr> new_edges;
-        new_edges.reserve(edges->size());
-        bool any_changed = false;
-        for (const auto& e : *edges) {
-          if (!e) {
-            new_edges.push_back(e);
-            continue;
-          }
-          auto remapped = ExprFunctor<ExprPtr>::VisitExpr(e);
-          // Use AsVarLike so a remapped IterArg (loop-carried tensor) still
-          // matches — As<Var> is exact-kind only and would silently drop the
-          // remap, leaving a stale pointer in the attr.
-          auto remapped_var = AsVarLike(remapped);
-          if (!remapped_var) {
-            // Should not happen — Var/IterArg visits return Var-like. Fall
-            // back to original to avoid corrupting the attr.
-            new_edges.push_back(e);
-            continue;
-          }
-          if (remapped_var.get() != e.get()) {
-            any_changed = true;
-          }
-          new_edges.push_back(std::move(remapped_var));
-        }
-        if (any_changed) {
-          attrs_changed = true;
-          new_attrs.emplace_back(k, std::any(std::move(new_edges)));
-          continue;
-        }
-      }
+    auto remapped = MapAttrExprs(v, [this](const ExprPtr& e) { return ExprFunctor<ExprPtr>::VisitExpr(e); });
+    if (remapped.has_value()) {
+      attrs_changed = true;
+      new_attrs.emplace_back(k, std::move(*remapped));
+      continue;
     }
     new_attrs.emplace_back(k, v);
   }
@@ -941,68 +897,17 @@ std::pair<std::vector<std::pair<std::string, std::any>>, bool> IRMutator::Mutate
   std::vector<std::pair<std::string, std::any>> new_attrs;
   new_attrs.reserve(attrs.size());
   bool any_changed = false;
+  // Remapped by stored type, matching ``IRVisitor::VisitScopeAttrs``. The old
+  // key list covered manual_dep_edges / compiler_manual_dep_edges /
+  // arg_direction_overrides_vars / dump_vars / task_id_var / predicate; any
+  // other reference-valued scope attr was walked by the visitor but never
+  // rewritten here.
   for (const auto& [k, v] : attrs) {
-    if (k == kAttrManualDepEdges || k == kAttrCompilerManualDepEdges || k == kAttrArgDirOverrideVars ||
-        k == kAttrDumpVars) {
-      const auto* edges = std::any_cast<std::vector<VarPtr>>(&v);
-      if (edges) {
-        std::vector<VarPtr> new_edges;
-        new_edges.reserve(edges->size());
-        bool edges_changed = false;
-        for (const auto& e : *edges) {
-          if (!e) {
-            new_edges.push_back(e);
-            continue;
-          }
-          auto remapped = ExprFunctor<ExprPtr>::VisitExpr(e);
-          auto remapped_var = AsVarLike(remapped);
-          if (!remapped_var) {
-            new_edges.push_back(e);
-            continue;
-          }
-          if (remapped_var.get() != e.get()) edges_changed = true;
-          new_edges.push_back(std::move(remapped_var));
-        }
-        if (edges_changed) {
-          any_changed = true;
-          new_attrs.emplace_back(k, std::any(std::move(new_edges)));
-          continue;
-        }
-      }
-    } else if (k == kAttrTaskIdVar) {
-      const auto* var = std::any_cast<VarPtr>(&v);
-      if (var && *var) {
-        auto remapped = ExprFunctor<ExprPtr>::VisitExpr(*var);
-        auto remapped_var = AsVarLike(remapped);
-        if (remapped_var && remapped_var.get() != var->get()) {
-          any_changed = true;
-          new_attrs.emplace_back(k, std::any(std::move(remapped_var)));
-          continue;
-        }
-      }
-    } else if (k == kAttrPredicate) {
-      // ``with pl.spmd(..., predicate=(t[i] > 0)):`` — an Expr tree, not a
-      // Var, so mutate the whole subtree (the operand tensor Var and its
-      // index Vars must follow any remapping the mutator is performing).
-      //
-      // No pipeline pass currently reaches this: the passes that run while the
-      // attr still exists (before OutlineSpmdScopes) either do not remap Vars
-      // inside it, or — like FlattenCallExpr — override the Spmd handler and
-      // copy attrs_ verbatim. ConvertToSSA has its own SubstScopeAttrs. This
-      // branch is therefore untested-by-construction, and kept for the same
-      // reason the sibling Var attrs above are handled here: any future
-      // IRMutator-based pass that renames Vars must not silently skip the
-      // predicate. Deleting it would make the predicate the one scope attr the
-      // generic mutator ignores.
-      const auto* pred = std::any_cast<ExprPtr>(&v);
-      if (pred && *pred) {
-        auto remapped = ExprFunctor<ExprPtr>::VisitExpr(*pred);
-        if (remapped && remapped.get() != pred->get()) {
-          any_changed = true;
-          new_attrs.emplace_back(k, std::any(std::move(remapped)));
-          continue;
-        }
-      }
+    auto remapped = MapAttrExprs(v, [this](const ExprPtr& e) { return ExprFunctor<ExprPtr>::VisitExpr(e); });
+    if (remapped.has_value()) {
+      any_changed = true;
+      new_attrs.emplace_back(k, std::move(*remapped));
+      continue;
     }
     new_attrs.emplace_back(k, v);
   }

--- a/src/ir/transforms/visitor.cpp
+++ b/src/ir/transforms/visitor.cpp
@@ -11,7 +11,6 @@
 
 #include "pypto/ir/transforms/base/visitor.h"
 
-#include <any>
 #include <cstddef>
 #include <vector>
 
@@ -38,6 +37,13 @@ void IRVisitor::VisitProgram(const ProgramPtr& program) {
 void IRVisitor::VisitFunction(const FunctionPtr& func) {
   for (auto& param : func->params_) {
     VisitExpr(param);
+  }
+  // Function attrs are evaluated where the parameters bind, so walk them after
+  // the params and before the body. Today every Function attr is static or a
+  // ConstInt, making this inert; it is what lets a reference-valued function
+  // attr be seen by def-use / liveness analyses at all (see RFC #2338).
+  for (const auto& [k, v] : func->attrs_) {
+    ForEachAttrExpr(v, [this](const ExprPtr& e) { VisitExpr(e); });
   }
   if (func->body_) {
     VisitStmt(func->body_);
@@ -79,25 +85,14 @@ void IRVisitor::VisitExpr_(const CallPtr& op) {
     INTERNAL_CHECK_SPAN(op->args_[i], op->span_) << "Call has null argument at index " << i;
     VisitExpr(op->args_[i]);
   }
-  // Var-typed attrs reference Vars defined elsewhere in the IR. Treat them as
-  // real uses so analyses such as the unused-variable check don't flag a Var
-  // referenced only via ``deps=[tid]`` or ``dumps=[t]`` / ``pl.dump_tag``.
-  // Expr-valued attrs (IsExprValuedCallAttr: ``device=``, ``core_num``) are real
-  // operands evaluated in this function's scope, so recurse into them too —
-  // otherwise a scalar assigned only to size an SPMD launch looks dead, gets
-  // eliminated, and leaves the attr dangling. Mirrors ``Submit::core_num_``
-  // below and the matching arm in ``IRMutator::VisitExpr_(CallPtr)``.
+  // Reference-typed attrs name Vars defined elsewhere in the IR — ``deps=[tid]``,
+  // ``dumps=[t]`` / ``pl.dump_tag``, ``device=``, an SPMD ``core_num``. They are
+  // real uses: without visiting them a scalar assigned only to size a launch
+  // looks dead, gets eliminated, and leaves the attr dangling. Dispatch on the
+  // stored type (see ``ForEachAttrExpr``) so a key nobody thought to enumerate
+  // is still walked.
   for (const auto& [k, v] : op->attrs_) {
-    if (k == kAttrManualDepEdges || k == kAttrCompilerManualDepEdges || k == kAttrDumpVars) {
-      const auto* edges = std::any_cast<std::vector<VarPtr>>(&v);
-      if (!edges) continue;
-      for (const auto& e : *edges) {
-        if (e) VisitExpr(e);
-      }
-    } else if (IsExprValuedCallAttr(k)) {
-      const auto* attr_expr = std::any_cast<ExprPtr>(&v);
-      if (attr_expr && *attr_expr) VisitExpr(*attr_expr);
-    }
+    ForEachAttrExpr(v, [this](const ExprPtr& e) { VisitExpr(e); });
   }
 }
 
@@ -128,18 +123,14 @@ void IRVisitor::VisitExpr_(const SubmitPtr& op) {
     INTERNAL_CHECK_SPAN(*op->predicate_, op->span_) << "Submit predicate is null";
     VisitExpr(*op->predicate_);
   }
-  // Var-typed attrs reference Vars defined elsewhere in the IR.
-  // IRMutator::VisitExpr_(SubmitPtr) already rewrites those Vars on
-  // substitution; the visitor must walk them too so unused-var / def-use /
-  // SSA-liveness analyses do not silently drop a Var that is referenced only
-  // through these attrs.
+  // Reference-typed attrs name Vars defined elsewhere in the IR.
+  // IRMutator::VisitExpr_(SubmitPtr) rewrites them on substitution; the visitor
+  // must walk them too so unused-var / def-use / SSA-liveness analyses do not
+  // silently drop a Var referenced only through an attr. Type-dispatched, so
+  // this arm no longer diverges from the Call arm the way the old key lists did
+  // (``kAttrDevice`` was walked on a Call but not here).
   for (const auto& [k, v] : op->attrs_) {
-    if (k != kAttrArgDirOverrideVars && k != kAttrCompilerManualDepEdges && k != kAttrDumpVars) continue;
-    const auto* edges = std::any_cast<std::vector<VarPtr>>(&v);
-    if (!edges) continue;
-    for (const auto& e : *edges) {
-      if (e) VisitExpr(e);
-    }
+    ForEachAttrExpr(v, [this](const ExprPtr& e) { VisitExpr(e); });
   }
 }
 
@@ -279,32 +270,21 @@ void IRVisitor::VisitStmt_(const WhileStmtPtr& op) {
   }
 }
 
-// Visit Var-typed entries in a ScopeStmt's ``attrs_``. Mirrors the Call.attrs
-// handling in VisitExpr_(CallPtr) so analyses (unused-var detection, SSA Var
-// liveness, etc.) see Var refs stashed on a ScopeStmt's ``manual_dep_edges`` /
-// ``task_id_var`` / ``arg_direction_overrides_vars`` / ``dump_vars`` attrs, plus
-// the Expr-valued ``predicate`` attr. Subclasses opt a key out via
-// ShouldVisitScopeAttr rather than by overriding this walk.
+// Visit reference-typed entries in a ScopeStmt's ``attrs_``. Mirrors the
+// Call.attrs handling in VisitExpr_(CallPtr) so analyses (unused-var detection,
+// SSA Var liveness, etc.) see Var refs stashed on a ScopeStmt's
+// ``manual_dep_edges`` / ``task_id_var`` / ``arg_direction_overrides_vars`` /
+// ``dump_vars`` attrs, plus whole-Expr attrs such as ``predicate`` (a comparison
+// over ``tensor.read`` whose operand tensor and index Vars are live SSA values
+// the outliner later moves onto ``Submit::predicate_``).
+//
+// Dispatch is on the stored type, so this walk covers any future
+// reference-valued scope attr without being edited. Subclasses still opt a key
+// out via ShouldVisitScopeAttr rather than by overriding this walk.
 void IRVisitor::VisitScopeAttrs(const ScopeStmtPtr& op) {
   for (const auto& [k, v] : op->attrs_) {
     if (!ShouldVisitScopeAttr(k)) continue;
-    if (k == kAttrManualDepEdges || k == kAttrArgDirOverrideVars || k == kAttrDumpVars) {
-      const auto* edges = std::any_cast<std::vector<VarPtr>>(&v);
-      if (!edges) continue;
-      for (const auto& e : *edges) {
-        if (e) VisitExpr(e);
-      }
-    } else if (k == kAttrTaskIdVar) {
-      const auto* var = std::any_cast<VarPtr>(&v);
-      if (var && *var) VisitExpr(*var);
-    } else if (k == kAttrPredicate) {
-      // ``with pl.spmd(..., predicate=(t[i] > 0)):`` — unlike the keys above
-      // this is a whole Expr tree (a comparison over ``tensor.read``), so
-      // recurse into it: the operand tensor and its index Vars are live SSA
-      // values the outliner later moves onto ``Submit::predicate_``.
-      const auto* pred = std::any_cast<ExprPtr>(&v);
-      if (pred && *pred) VisitExpr(*pred);
-    }
+    ForEachAttrExpr(v, [this](const ExprPtr& e) { VisitExpr(e); });
   }
 }
 

--- a/src/ir/verifier/verify_use_after_def.cpp
+++ b/src/ir/verifier/verify_use_after_def.cpp
@@ -244,6 +244,15 @@ class UseAfterDefPropertyVerifierImpl : public PropertyVerifier {
         }
       }
 
+      // Function attrs are evaluated where the parameters bind: a reference to
+      // a param is legal, a reference to anything else (a caller-local, as the
+      // old Function-carried SPMD launch spec did) is a use with no definition
+      // in this function and is reported here. This is why no separate
+      // "attrs must be static" property is needed.
+      for (const auto& [k, v] : func->attrs_) {
+        ForEachAttrExpr(v, [&checker](const ExprPtr& e) { checker.VisitExpr(e); });
+      }
+
       if (func->body_) checker.VisitStmt(func->body_);
     }
   }

--- a/tests/ut/ir/transforms/test_convert_to_ssa_pass.py
+++ b/tests/ut/ir/transforms/test_convert_to_ssa_pass.py
@@ -2463,5 +2463,80 @@ class TestSplitAivRegionTransparentToSSA:
         ir.assert_structural_equal(After, Expected)
 
 
+class TestArbitraryAttrKeyRemap:
+    """Attr substitution is keyed on the value's type, not on the attr name.
+
+    The walkers report every reference-valued attr as a live use, so every
+    substitution path must rewrite the same set. A key-gated substitution left
+    an attr under an unenumerated key pointing at its pre-SSA ``Var``, which
+    then fails ``UseAfterDef``.
+    """
+
+    @staticmethod
+    def _use_after_def(program):
+        props = passes.IRPropertySet()
+        props.insert(passes.IRProperty.UseAfterDef)
+        return [
+            d
+            for d in passes.PropertyVerifierRegistry.verify(props, program)
+            if d.severity == passes.DiagnosticSeverity.Error
+        ]
+
+    def test_call_attr_under_arbitrary_key_is_remapped(self):
+        """A Var under a key no walker list enumerates survives ConvertToSSA.
+
+        The reassignment below forces a new SSA version of ``acc``. A key-gated
+        substitution would leave the attr on the pre-SSA ``acc``, which
+        ``UseAfterDef`` then reports as undefined.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self, x: pl.Tensor[[64], pl.FP32], out: pl.Out[pl.Tensor[[64], pl.FP32]]
+            ) -> pl.Tensor[[64], pl.FP32]:
+                t = pl.load(x, [0], [64])
+                out = pl.store(t, [0], out)
+                return out
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self, x: pl.Tensor[[64], pl.FP32], out: pl.Out[pl.Tensor[[64], pl.FP32]]
+            ) -> pl.Tensor[[64], pl.FP32]:
+                out = self.kernel(x, out)
+                out = self.kernel(out, out)
+                return out
+
+        after = passes.convert_to_ssa()(Before)
+        assert self._use_after_def(after) == []
+
+        # Every Var referenced from a Call attr must be one the converted
+        # function actually binds — i.e. remapped alongside the args.
+        main = after.get_function("main")
+        assert main is not None
+        bound: set[int] = {id(p) for p in main.params}
+
+        class _Collect(ir.IRVisitor):
+            def __init__(self):
+                super().__init__()
+                self.attr_vars = []
+
+            def visit_assign_stmt(self, op):
+                bound.add(id(op.var))
+                super().visit_assign_stmt(op)
+
+            def visit_call(self, op):
+                for value in dict(op.attrs).values():
+                    if isinstance(value, ir.Var):
+                        self.attr_vars.append(value)
+                super().visit_call(op)
+
+        collector = _Collect()
+        collector.visit_function(main)
+        for var in collector.attr_vars:
+            assert id(var) in bound, f"Call attr references unbound Var {var.name_hint}"
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/ir/transforms/test_verify_use_after_def.py
+++ b/tests/ut/ir/transforms/test_verify_use_after_def.py
@@ -321,5 +321,72 @@ def test_valid_then_only_leak_visible_after_if():
     assert len(_errors(passes.PropertyVerifierRegistry.verify(_use_after_def_props(), program))) == 0
 
 
+# ---------------------------------------------------------------------------
+# Function attrs
+#
+# ``Function::attrs_`` is evaluated where the parameters bind, so a reference to
+# a parameter is a legal use and a reference to anything else has no definition
+# in this function. Covering both here is what makes a separate "function attrs
+# must be static" property unnecessary (RFC #2338).
+# ---------------------------------------------------------------------------
+
+
+def _func_with_attrs(attrs):
+    """Single-parameter function carrying ``attrs``, returning its parameter."""
+    span = ir.Span.unknown()
+    x = ir.Var("x", ir.ScalarType(DataType.INT64), span)
+    func = ir.Function(
+        "kernel",
+        [x],
+        [ir.ScalarType(DataType.INT64)],
+        ir.ReturnStmt([x], span),
+        span,
+        attrs=attrs(x),
+    )
+    return ir.Program([func], "prog", span)
+
+
+def test_function_attr_referencing_a_param_is_valid():
+    """A parameter is bound where function attrs are evaluated, so this is a real def."""
+    program = _func_with_attrs(lambda x: {"stationary": x})
+    assert len(_errors(passes.PropertyVerifierRegistry.verify(_use_after_def_props(), program))) == 0
+
+
+def test_function_attr_referencing_an_undefined_var_is_flagged():
+    """A caller-local in a function attr — the old Function-carried SPMD launch spec."""
+    span = ir.Span.unknown()
+    ghost = ir.Var("ghost", ir.ScalarType(DataType.INT32), span)
+    program = _func_with_attrs(lambda x: {"core_num": ghost})
+    errors = _errors(passes.PropertyVerifierRegistry.verify(_use_after_def_props(), program))
+    assert len(errors) == 1
+    assert "ghost" in errors[0].message
+
+
+def test_function_attr_var_list_is_walked():
+    """vector<VarPtr> attrs are walked element-wise, like Call attrs."""
+    span = ir.Span.unknown()
+    ghost = ir.Var("ghost", ir.ScalarType(DataType.INT32), span)
+    program = _func_with_attrs(lambda x: {"dump_vars": [x, ghost]})
+    errors = _errors(passes.PropertyVerifierRegistry.verify(_use_after_def_props(), program))
+    assert len(errors) == 1
+    assert "ghost" in errors[0].message
+
+
+def test_function_attr_expr_tree_is_walked():
+    """A whole Expr attr is recursed into, not just its root node."""
+    span = ir.Span.unknown()
+    ghost = ir.Var("ghost", ir.ScalarType(DataType.INT32), span)
+    program = _func_with_attrs(lambda x: {"core_num": ir.add(ghost, ir.ConstInt(1, DataType.INT32, span))})
+    errors = _errors(passes.PropertyVerifierRegistry.verify(_use_after_def_props(), program))
+    assert len(errors) == 1
+    assert "ghost" in errors[0].message
+
+
+def test_static_function_attrs_are_ignored():
+    """Scalars and strings name nothing, so they produce no diagnostics."""
+    program = _func_with_attrs(lambda x: {"core_num": 8, "tag": "abc", "flag": True})
+    assert len(_errors(passes.PropertyVerifierRegistry.verify(_use_after_def_props(), program))) == 0
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/language/parser/test_decorator.py
+++ b/tests/ut/language/parser/test_decorator.py
@@ -643,6 +643,110 @@ class TestProgramDecorator:
                 def kernel(self, x: pl.Tensor[[4], pl.FP16]) -> pl.Tensor[[4], pl.FP16]:
                     return x
 
+    def test_dsl_wrapper_attr_unwraps_and_round_trips(self):
+        """A DSL wrapper attr stores the IR Expr it carries, so printed source reparses.
+
+        The printer emits the value in DSL spelling
+        (``pl.system.available_cluster_count()``), which reparse evaluates back
+        into a ``Scalar`` wrapper — the attr store only accepts the ``Expr``.
+        """
+
+        @pl.program
+        class LaunchQueryProgram:
+            @pl.function(type=pl.FunctionType.Spmd, attrs={"core_num": pl.system.available_cluster_count()})
+            def kernel(self, x: pl.Tensor[[4], pl.FP16]) -> pl.Tensor[[4], pl.FP16]:
+                return x
+
+        func = LaunchQueryProgram.get_function("kernel")
+        assert func is not None
+        assert isinstance(dict(func.attrs)["core_num"], ir.Call)
+
+        printed = LaunchQueryProgram.as_python()
+        assert 'attrs={"core_num": pl.system.available_cluster_count()}' in printed
+        ir.assert_structural_equal(pl.parse_program(printed), LaunchQueryProgram)
+
+    def test_function_attr_referencing_a_var_is_rejected(self):
+        """A Var in a Function attr has no legal decorator spelling (StaticAttrs)."""
+        span = ir.Span.unknown()
+        n = ir.Var("n", ir.ScalarType(pl.INT32), span)
+        with pytest.raises(ParserSyntaxError, match="references a variable"):
+
+            @pl.program
+            class VarAttrProgram:
+                @pl.function(type=pl.FunctionType.Spmd, attrs={"core_num": n})
+                def kernel(self, x: pl.Tensor[[4], pl.FP16]) -> pl.Tensor[[4], pl.FP16]:
+                    return x
+
+    def test_function_attr_expression_over_a_var_is_rejected(self):
+        """The whole attr Expr tree is walked, not just its root node."""
+        span = ir.Span.unknown()
+        n = ir.Var("n", ir.ScalarType(pl.INT32), span)
+        core_num = ir.add(n, ir.ConstInt(1, pl.INT32, span))
+        with pytest.raises(ParserSyntaxError, match="references a variable"):
+
+            @pl.program
+            class VarExprAttrProgram:
+                @pl.function(type=pl.FunctionType.Spmd, attrs={"core_num": core_num})
+                def kernel(self, x: pl.Tensor[[4], pl.FP16]) -> pl.Tensor[[4], pl.FP16]:
+                    return x
+
+    def test_malformed_attrs_container_is_rejected(self):
+        """A non-dict attrs= and a non-string key both raise a parser error."""
+        with pytest.raises(ParserSyntaxError, match="must be a dict"):
+
+            @pl.program
+            class NonDictAttrs:
+                @pl.function(attrs=5)  # type: ignore[arg-type]  # deliberate: validates runtime rejection
+                def kernel(self, x: pl.Tensor[[4], pl.FP16]) -> pl.Tensor[[4], pl.FP16]:
+                    return x
+
+        with pytest.raises(ParserSyntaxError, match="keys must be strings"):
+
+            @pl.program
+            class NonStrKeyAttrs:
+                @pl.function(attrs={1: 2})  # type: ignore[arg-type]  # deliberate: validates runtime rejection
+                def kernel(self, x: pl.Tensor[[4], pl.FP16]) -> pl.Tensor[[4], pl.FP16]:
+                    return x
+
+    def test_falsey_non_dict_attrs_is_rejected(self):
+        """A falsey non-dict must reach the validator, not be read as absent.
+
+        The callers gate on ``attrs is not None`` rather than truthiness, so
+        ``attrs=[]`` cannot slip past ``_normalize_attrs`` as though no attrs
+        were supplied.
+        """
+        with pytest.raises(ParserSyntaxError, match="must be a dict"):
+
+            @pl.program
+            class EmptyListAttrs:
+                @pl.function(attrs=[])  # type: ignore[arg-type]  # deliberate: validates runtime rejection
+                def kernel(self, x: pl.Tensor[[4], pl.FP16]) -> pl.Tensor[[4], pl.FP16]:
+                    return x
+
+        with pytest.raises(ParserSyntaxError, match="must be a dict"):
+
+            @pl.program
+            class EmptyStrAttrs:
+                @pl.function(attrs="")  # type: ignore[arg-type]  # deliberate: validates runtime rejection
+                def kernel(self, x: pl.Tensor[[4], pl.FP16]) -> pl.Tensor[[4], pl.FP16]:
+                    return x
+
+    def test_annotation_only_wrapper_attr_is_rejected(self):
+        """Annotation-only wrappers raise ValueError or RuntimeError on unwrap.
+
+        ``Scalar``/``Ptr`` raise ``RuntimeError`` while ``Tensor``/``Tile``/
+        ``Array`` raise ``ValueError``; both must surface as the actionable
+        parser diagnostic rather than escaping raw.
+        """
+        for annotation in (pl.Scalar[pl.INT32], pl.Tensor[[4], pl.FP16]):
+            with pytest.raises(ParserSyntaxError, match="annotation-only"):
+
+                @pl.program
+                class AnnotationAttrs:
+                    @pl.function(attrs={"bad": annotation})
+                    def kernel(self, x: pl.Tensor[[4], pl.FP16]) -> pl.Tensor[[4], pl.FP16]:
+                        return x
+
     def test_empty_class_error(self):
         """Test that empty class raises error."""
         with pytest.raises(ParserSyntaxError):  # Should raise ParserSyntaxError


### PR DESCRIPTION
## Summary

An attr value that holds a `Var` or an `Expr` is an IR edge, but every walker
found those edges by matching attr **key names** against hardcoded lists. Six
such lists existed across `IRVisitor`, `IRMutator` and the SSA pass, and they
had drifted apart — so an edge under a key missing from the relevant list was
invisible to analysis, or visible but never rewritten under substitution. This
switches all of them to dispatch on the value's stored **type**, which is what
the serializer, deserializer and printer already did, so a newly invented attr
key is covered with no list to maintain. It also fixes a related DSL defect
where the compiler could not reparse its own printed output for an Expr-valued
function attr.

No IR representation change and no user-facing syntax change. Programs that
compile today keep compiling.

## Changes

- `include/pypto/ir/expr.h`: add `ForEachAttrExpr` — matches `VarPtr`,
  `vector<VarPtr>` and `ExprPtr`, ignores everything else.
- `include/pypto/ir/kind_traits.h`: add `MapAttrExprs`, its rewriting
  counterpart. Whatever the walk reports as a live reference, this rewrites.
  It preserves the value's stored type (a `VarPtr` attr never widens to
  `ExprPtr`) and uses `AsVarLike` so a remapped `IterArg` still matches.
- `src/ir/transforms/visitor.cpp`: `VisitExpr_(CallPtr)`, `VisitExpr_(SubmitPtr)`
  and `VisitScopeAttrs` each collapse to one type-dispatched call. This closes
  the `kAttrDevice`-on-`Submit` gap `expr.h` documented: `device` was walked on
  a `Call` but not on a `Submit`, because those lists were written separately.
- `src/ir/transforms/mutator.cpp`: the same three sites plus
  `IRMutator::VisitFunction` now remap through `MapAttrExprs`.
- `src/ir/transforms/convert_to_ssa_pass.cpp`: `SubstCallAttrs` and
  `SubstScopeAttrs` were key-gated too, so the SSA pass had the same hole
  independently of `IRMutator`; both are now type-dispatched. `ConvertFunction`
  additionally substitutes `attrs_` after re-versioning the parameters.
- `src/ir/verifier/verify_use_after_def.cpp`: walk `Function::attrs_` after the
  parameters register as definitions. Nothing walked function attrs before. A
  function attr is evaluated where the parameters bind, so a reference to a
  parameter is accepted and a reference to anything the function does not bind
  is reported — the failure mode that made a `Function`-carried SPMD launch
  spec untenable.
- `python/pypto/language/parser/decorator.py`: unwrap DSL wrapper values in
  `@pl.function(attrs=...)`. The printer emits an Expr-valued function attr in
  DSL spelling, so `pl.parse_program(P.as_python())` on a program carrying
  `attrs={"core_num": <Call>}` previously raised
  `Unsupported kwarg type for key: core_num` — the compiler could not read back
  its own output. Annotation-only wrappers are rejected with an actionable
  error (`Scalar`/`Ptr` raise `RuntimeError`, `Tensor`/`Tile`/`Array` raise
  `ValueError`; both are caught). Attrs-container validation added: `attrs=5`
  surfaced as `AttributeError` and `attrs={1: 2}` as `std::bad_cast`, and the
  callers gate on `is not None` so a falsey non-dict such as `attrs=[]` cannot
  pass as absent. A value referencing a variable is rejected, since a decorator
  is evaluated before the signature binds.

## Behavior notes

The walkers visit strictly more nodes, so a `Var` referenced only through an
attr counts as a use. That is the intended semantics — it is a real reference —
but such a variable is no longer reported as unused.

`Function::attrs_` values in the current tree are all static or `ConstInt`, so
the new function-attr walk and SSA substitution are inert on existing programs;
they exist so a reference stored there cannot be invisible or go stale.

Known limitation, out of scope here: a function attr referencing a parameter now
survives SSA correctly but still cannot round-trip, because the printer emits
function attrs into the decorator where the parameter name is not yet bound.
That is a DSL gap tracked in RFC #2338 (`pl.func_attr`), so the regression test
covers the reachable Call-attr path rather than asserting a round-trip this
change cannot deliver.

## Verification

- `cmake --build build --parallel`: exit 0.
- `python -m pytest tests/ut -q -n auto --maxprocesses 8`: exit 0 — 9328 passed,
  3 skipped. Run by the push transaction's validation runner against the exact
  commit pushed.
- Full CI green on `378ef657`: build, changes, clang-tidy, codegen-tests,
  dist-system-tests, examples-tests, pre-commit, pypto-lib-model, system-tests,
  system-tests-a5sim, system-tests-direct, toolchain, unit-tests.

New coverage: 5 tests in `tests/ut/ir/transforms/test_verify_use_after_def.py`
(param reference accepted; caller-local flagged; `vector<VarPtr>` walked
element-wise; `Expr` tree recursed into; static attrs ignored); 1 in
`tests/ut/ir/transforms/test_convert_to_ssa_pass.py` asserting every Var
reachable from a Call attr after ConvertToSSA is one the converted function
binds; and 6 in `tests/ut/language/parser/test_decorator.py` covering wrapper
unwrap round-trip, variable rejection, malformed containers, falsey non-dicts,
and annotation-only wrappers.
