### PR TITLE
ci: take ptoas off conda, flip the last job onto the bundle, and install with uv

### DIFF
--- a/.github/actions/setup-ci-job/action.yml
+++ b/.github/actions/setup-ci-job/action.yml
@@ -104,11 +104,18 @@ inputs:
       bundle that `pypto-toolchain` has selected on the host, which is
       byte-identical on every host and carries its own ccache and uv.
 
-      Default stays 'conda' so a runner that has not been provisioned yet keeps
-      working: the two can coexist while the fleet is migrated one label at a
-      time, and any job can be reverted on its own.
+      The default was 'conda' while the fleet was migrated a label at a time.
+      That is finished — every caller in this repo passes 'bundle' explicitly —
+      so the default follows, and a job added without this input lands on the
+      path CI actually exercises. Left as 'conda' it would have inherited a path
+      with no coverage that also demands CONDA_ROOT and a py310 env on the
+      runner, and the first symptom would have been a provisioning error on a
+      host that is otherwise fine.
+
+      'conda' still works and is still the way to revert a single job, but it is
+      now untested. Removing it altogether waits on conda leaving the runners.
     required: false
-    default: 'conda'
+    default: 'bundle'
   unset-ring:
     description: >-
       When 'true', activate.sh unsets PTO2_RING_* — the dist HCCL tests break with
@@ -145,7 +152,12 @@ runs:
         # an unknown value silently skips both and the first symptom is an
         # unrelated "activate.sh: No such file" ten minutes into the build.
         # Reject it here, where the message can still name the real cause.
-        case "${TOOLCHAIN_IN:-conda}" in
+        #
+        # Matched bare, with no shell-side default: the input carries one, so an
+        # empty value here means a caller passed `toolchain: ''`. Substituting a
+        # default for it would accept a spelling the `if:` gates below reject,
+        # which is the exact silent-skip this check exists to prevent.
+        case "$TOOLCHAIN_IN" in
           conda|bundle) ;;
           *)
             echo "::error::toolchain must be 'conda' or 'bundle', got '$TOOLCHAIN_IN'"
@@ -155,7 +167,7 @@ runs:
         # Prerequisites CI does not create, so they must already be there. The
         # codegen job needs no Ascend env, so CANN_ROOT is device-jobs-only.
         required=""
-        if [ "${TOOLCHAIN_IN:-conda}" = "conda" ]; then
+        if [ "$TOOLCHAIN_IN" = "conda" ]; then
           required="CONDA_ROOT"
         fi
         if [ "$NEEDS_DEVICE" = "true" ]; then

--- a/.github/actions/setup-ci-job/action.yml
+++ b/.github/actions/setup-ci-job/action.yml
@@ -32,12 +32,17 @@ description: >-
   install root in its own pypto-env.conf — both of which the tool resolves, and
   this action follows it there by asking the tool rather than by naming a path.
 
-  Beyond those, the host is expected to provide (by name, not by path): a conda
-  env `py310` under CONDA_ROOT, and task-submit / npu-smi / ccache / git / curl on
-  PATH. The `.env` makes the *locations* portable; these names are the
-  provisioning contract a runner has to satisfy to be usable at all. Note the CPU
-  runner (codegen-tests) now needs the `py310` env too — previously it used the
-  container's Python.
+  Beyond those, the host is expected to provide (by name, not by path):
+  task-submit / npu-smi / ccache / git / curl on PATH, and — on the conda path
+  only — a conda env `py310` under CONDA_ROOT. The `.env` makes the *locations*
+  portable; these names are the provisioning contract a runner has to satisfy to
+  be usable at all.
+
+  A bundle runner needs no conda whatsoever: CONDA_ROOT is read only inside the
+  `toolchain: conda` bootstrap step, and nothing else reaches for a conda prefix.
+  Keep it that way. A step that runs before the bootstrap has no activate.sh and
+  is tempted to find an interpreter on its own; conda is the wrong answer, and
+  the right one is to move the step after the bootstrap instead.
 
   The calling job must define PTOAS_ROOT, PTO_ISA_ROOT, PTOAS_VERSION,
   PTOAS_SHA256, the CMAKE_* and the non-path CCACHE_* (MAXSIZE / UMASK) environment
@@ -248,55 +253,6 @@ runs:
       shell: bash
       run: echo "CCACHE_NAMESPACE=pto-isa-${{ inputs.pto-isa-commit }}" >> "$GITHUB_ENV"
 
-    - name: Install ptoas (local cache)
-      # $PTOAS_CACHE_DIR (ci-cache/ptoas) comes from the derive step above.
-      if: ${{ inputs.install-toolchain == 'true' }}
-      shell: bash
-      run: |
-        # v0.55's standalone archive requires CPython 3.11, while PyPTO CI
-        # intentionally tests Python 3.10. Install the matching cp310 wheel into
-        # an isolated venv so PTOAS_ROOT/bin/ptoas keeps the existing contract.
-        PTOAS_ARCH="$(uname -m)"
-        PTOAS_PACKAGE_VERSION="${PTOAS_VERSION#v}"
-        PTOAS_WHEEL_NAME="ptoas-${PTOAS_PACKAGE_VERSION}-cp310-cp310-manylinux_2_34_${PTOAS_ARCH}.whl"
-        CACHE_WHEEL="$PTOAS_CACHE_DIR/$PTOAS_WHEEL_NAME"
-        # $PTOAS_CACHE_DIR is shared across concurrent jobs on the host (unlike the
-        # per-job pip dir), so two cache-miss jobs must not fight over one temp
-        # file: download into a per-job mktemp, verify it, then atomically rename
-        # into place (last writer wins — content is identical). A trap removes
-        # the temp if we die mid-download. CACHE_WHEEL therefore only ever holds
-        # a verified wheel; the final sha256 re-check guards a cache hit against a
-        # partial/corrupt file left by a crashed pre-atomic-rename run.
-        if [ ! -f "$CACHE_WHEEL" ]; then
-          echo "Cache miss — downloading ptoas ${PTOAS_VERSION} for ${PTOAS_ARCH}"
-          mkdir -p "$PTOAS_CACHE_DIR"
-          tmp_wheel="$(mktemp "$PTOAS_CACHE_DIR/.ptoas-${PTOAS_ARCH}.XXXXXX")"
-          trap 'rm -f "$tmp_wheel"' EXIT
-          curl --fail --location --retry 3 --retry-all-errors \
-            "https://github.com/hw-native-sys/PTOAS/releases/download/${PTOAS_VERSION}/${PTOAS_WHEEL_NAME}" \
-            -o "$tmp_wheel"
-          echo "${PTOAS_SHA256}  $tmp_wheel" | sha256sum -c -
-          mv -f "$tmp_wheel" "$CACHE_WHEEL"
-          trap - EXIT
-        else
-          echo "Cache hit — using $CACHE_WHEEL"
-        fi
-        echo "${PTOAS_SHA256}  $CACHE_WHEEL" | sha256sum -c -
-        PTOAS_CONDA_PREFIX="$CONDA_ROOT/envs/py310"
-        PTOAS_PYTHON="$PTOAS_CONDA_PREFIX/bin/python"
-        if [ ! -x "$PTOAS_PYTHON" ]; then
-          echo "::error::ptoas ${PTOAS_VERSION} requires the runner's py310 conda environment"
-          exit 1
-        fi
-        rm -rf "$PTOAS_ROOT"
-        "$PTOAS_PYTHON" -m venv "$PTOAS_ROOT" --system-site-packages
-        "$PTOAS_ROOT/bin/python" -m pip install "$CACHE_WHEEL"
-        # The bootstrap step below writes the same conda lib prefix into
-        # activate.sh. Apply it to this early probe too; otherwise older device
-        # hosts select /usr/lib64/libstdc++.so.6 and miss GLIBCXX_3.4.29.
-        LD_LIBRARY_PATH="$PTOAS_CONDA_PREFIX/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" \
-          "$PTOAS_ROOT/bin/ptoas" --version
-
     - name: Clone pto-isa
       if: ${{ inputs.install-toolchain == 'true' }}
       shell: bash
@@ -473,6 +429,101 @@ runs:
             exit 1
           fi )
         echo "toolchain: $(source activate.sh >/dev/null 2>&1; g++-15 -dumpversion) / $(source activate.sh >/dev/null 2>&1; python3.10 -V 2>&1)"
+
+    - name: Install ptoas (local cache)
+      # $PTOAS_CACHE_DIR (ci-cache/ptoas) comes from the derive step above.
+      #
+      # Deliberately after both bootstrap steps. ptoas ships as a wheel now, so
+      # this needs a CPython 3.10 to install it into, and the only correct one is
+      # whichever activate.sh puts on PATH. Run before them, activate.sh does not
+      # exist yet — which is how this step came to reach straight into
+      # $CONDA_ROOT/envs/py310, giving every job a conda dependency, bundle ones
+      # included, that this action's own runner contract says may be absent.
+      if: ${{ inputs.install-toolchain == 'true' }}
+      shell: bash
+      working-directory: ${{ inputs.checkout-path }}
+      env:
+        CHECKOUT_PATH: ${{ inputs.checkout-path }}
+      run: |
+        # PTOAS_ROOT belongs to the calling job's env: block, so this action
+        # cannot assume it arrived. Checked before the `rm -rf` below, which
+        # unset would aim at nothing.
+        if [ -z "${PTOAS_ROOT:-}" ]; then
+          echo "::error::PTOAS_ROOT is not set — the calling job must define it"
+          exit 1
+        fi
+        # Non-empty is not enough for a `rm -rf`. Every caller points PTOAS_ROOT
+        # at <checkout>/ptoas-bin, and a value one component short of that —
+        # $GITHUB_WORKSPACE/st-checkout, or a sibling checkout sharing its
+        # prefix — would aim the delete at a checkout instead. Canonicalize both
+        # sides and require a strict descendant, so equality with the checkout
+        # dir, a prefix-sharing sibling, and any `..` escape are all rejected
+        # before anything is removed. realpath -m: neither path need exist yet.
+        checkout_dir="$(realpath -m "$GITHUB_WORKSPACE/$CHECKOUT_PATH")"
+        ptoas_root="$(realpath -m "$PTOAS_ROOT")"
+        case "$ptoas_root" in
+          "$checkout_dir"/?*) ;;
+          *)
+            echo "::error::PTOAS_ROOT must be a directory inside $checkout_dir"
+            echo "Got '$PTOAS_ROOT' (resolves to '$ptoas_root'). This step"
+            echo "recreates that directory from scratch, so it must be one this"
+            echo "action owns rather than the checkout itself."
+            exit 1
+            ;;
+        esac
+        # v0.55's standalone archive requires CPython 3.11, while PyPTO CI
+        # intentionally tests Python 3.10. Install the matching cp310 wheel into
+        # an isolated venv so PTOAS_ROOT/bin/ptoas keeps the existing contract.
+        PTOAS_ARCH="$(uname -m)"
+        PTOAS_PACKAGE_VERSION="${PTOAS_VERSION#v}"
+        PTOAS_WHEEL_NAME="ptoas-${PTOAS_PACKAGE_VERSION}-cp310-cp310-manylinux_2_34_${PTOAS_ARCH}.whl"
+        CACHE_WHEEL="$PTOAS_CACHE_DIR/$PTOAS_WHEEL_NAME"
+        # $PTOAS_CACHE_DIR is shared across concurrent jobs on the host (unlike the
+        # per-job pip dir), so two cache-miss jobs must not fight over one temp
+        # file: download into a per-job mktemp, verify it, then atomically rename
+        # into place (last writer wins — content is identical). A trap removes
+        # the temp if we die mid-download. CACHE_WHEEL therefore only ever holds
+        # a verified wheel; the final sha256 re-check guards a cache hit against a
+        # partial/corrupt file left by a crashed pre-atomic-rename run.
+        if [ ! -f "$CACHE_WHEEL" ]; then
+          echo "Cache miss — downloading ptoas ${PTOAS_VERSION} for ${PTOAS_ARCH}"
+          mkdir -p "$PTOAS_CACHE_DIR"
+          tmp_wheel="$(mktemp "$PTOAS_CACHE_DIR/.ptoas-${PTOAS_ARCH}.XXXXXX")"
+          trap 'rm -f "$tmp_wheel"' EXIT
+          curl --fail --location --retry 3 --retry-all-errors \
+            "https://github.com/hw-native-sys/PTOAS/releases/download/${PTOAS_VERSION}/${PTOAS_WHEEL_NAME}" \
+            -o "$tmp_wheel"
+          echo "${PTOAS_SHA256}  $tmp_wheel" | sha256sum -c -
+          mv -f "$tmp_wheel" "$CACHE_WHEEL"
+          trap - EXIT
+        else
+          echo "Cache hit — using $CACHE_WHEEL"
+        fi
+        echo "${PTOAS_SHA256}  $CACHE_WHEEL" | sha256sum -c -
+        # activate.sh gives both the interpreter and the LD_LIBRARY_PATH ptoas
+        # needs, for either toolchain. Sourced here rather than at the top of the
+        # step so a download failure stays a download failure.
+        source activate.sh
+        # The wheel is cp310-only: pip would reject it with "not a supported
+        # wheel on this platform", which does not say that the *environment* is
+        # the wrong version. Say it here instead.
+        py_version="$(python -c 'import sys; print("%d.%d" % sys.version_info[:2])')"
+        if [ "$py_version" != "3.10" ]; then
+          echo "::error::ptoas ${PTOAS_VERSION} ships a cp310 wheel, but this job's python is $py_version"
+          exit 1
+        fi
+        rm -rf "$PTOAS_ROOT"
+        # `python` is the job venv's. venv resolves a new environment's base from
+        # sys.base_prefix, so building one from inside the job venv layers ptoas
+        # on the toolchain underneath it — conda's py310 or the bundle's
+        # python3.10 — and --system-site-packages exposes that same prefix, which
+        # is what the conda-only form did explicitly.
+        python -m venv "$PTOAS_ROOT" --system-site-packages
+        "$PTOAS_ROOT/bin/python" -m pip install "$CACHE_WHEEL"
+        # activate.sh has already put the right libstdc++ first (conda's lib
+        # prefix, or the bundle's), so the probe no longer splices one in by
+        # hand. ptoas needs GLIBCXX_3.4.29; older device hosts stop at 3.4.28.
+        "$PTOAS_ROOT/bin/ptoas" --version
 
     - name: Show ccache stats (before)
       shell: bash

--- a/.github/actions/setup-ci-job/action.yml
+++ b/.github/actions/setup-ci-job/action.yml
@@ -444,7 +444,15 @@ runs:
         # composition (wrong venv, lost PATH order), and it is worth catching at
         # second ten rather than as a compile error at minute ten.
         ( source activate.sh
-          command -v python3.10 g++-15 ccache uv >/dev/null
+          # One name per iteration. `command -v a b c` returns 0 when ANY name
+          # resolves and non-zero only when they all fail, so the multi-name
+          # form this replaces asserted almost nothing — it passed on a bundle
+          # with no uv in it at all, since python3.10 alone satisfied it.
+          for tool in python3.10 g++-15 ccache uv; do
+            command -v "$tool" >/dev/null && continue
+            echo "::error::$tool is not on PATH after sourcing activate.sh"
+            exit 1
+          done
           python3.10 -c 'import sys; assert sys.version_info[:2]==(3,10)'
           gxx_version=$(g++-15 -dumpversion)
           gxx_major=${gxx_version%%.*}

--- a/.github/actions/setup-ci-job/action.yml
+++ b/.github/actions/setup-ci-job/action.yml
@@ -47,9 +47,16 @@ description: >-
   The calling job must define PTOAS_ROOT, PTO_ISA_ROOT, PTOAS_VERSION,
   PTOAS_SHA256, the CMAKE_* and the non-path CCACHE_* (MAXSIZE / UMASK) environment
   variables; they are read from the job environment here. CCACHE_NAMESPACE and
-  every cache path (CCACHE_DIR, PIP_CACHE_DIR, PTOAS_CACHE_DIR) are resolved and
-  exported by this action — they derive from CI_CACHE_ROOT and so cannot live in
-  the caller's static job-level `env:` block.
+  every cache path (CCACHE_DIR, PIP_CACHE_DIR, PTOAS_CACHE_DIR, UV_CACHE_DIR) are
+  resolved and exported by this action — they derive from CI_CACHE_ROOT and so
+  cannot live in the caller's static job-level `env:` block.
+
+  Which installer a job gets follows from its toolchain, and the bootstrap step
+  states it in PYPTO_USE_UV. The bundle carries uv, so bundle jobs build the venv
+  with `uv venv` and install with `uv pip`; that venv has no pip in it at all.
+  Conda jobs keep pip, since uv is not in the conda env. A step that runs after
+  this action and installs into the job venv must therefore not hardcode `pip` —
+  on a bundle job it is simply not there.
 
 inputs:
   checkout-path:
@@ -198,10 +205,18 @@ runs:
         # caller's job-level `env:`, which is static and cannot see this step.
         # These match the previous hardcoded ci-cache/{ccache,pip-*,ptoas} paths
         # byte for byte, so existing entries stay valid — no forced rebuild.
+        #
+        # UV_CACHE_DIR is deliberately NOT per-job the way PIP_CACHE_DIR is. The
+        # pip dirs are split because pip has no shared-umask knob and concurrent
+        # jobs end up fighting over file ownership; uv's cache is built for
+        # concurrent access, and sharing it is the point — a wheel any job has
+        # already downloaded is hardlinked into the next venv instead of being
+        # fetched and unpacked again.
         {
           echo "CCACHE_DIR=$CI_CACHE_ROOT/ccache"
           echo "PIP_CACHE_DIR=$CI_CACHE_ROOT/$PIP_CACHE_NAME"
           echo "PTOAS_CACHE_DIR=$CI_CACHE_ROOT/ptoas"
+          echo "UV_CACHE_DIR=$CI_CACHE_ROOT/uv"
         } >> "$GITHUB_ENV"
         echo "runner config OK (checked: CI_CACHE_ROOT $required)"
         # Identity and storage of the host we landed on, made visible in every log:
@@ -290,6 +305,10 @@ runs:
         # venv` reuse it and carry over old site-packages.
         rm -rf venv
         python -m venv venv --system-site-packages
+        # uv ships in the toolchain bundle, not in the conda env, so the conda
+        # path keeps installing with pip. Stated rather than defaulted: the
+        # build step below branches on it.
+        echo "PYPTO_USE_UV=false" >> "$GITHUB_ENV"
         # Bake the runner's roots in as literals rather than referencing
         # $CANN_ROOT/$CONDA_ROOT at source time: activate.sh is also sourced by
         # task-submit children, whose truncated env snapshot does not carry the
@@ -370,7 +389,14 @@ runs:
         # No --system-site-packages. Nothing outside the venv is depended on
         # now, which also retires the trap that flag created: with it, a failed
         # install in the venv was masked by a copy of pypto in the base env.
-        python3.10 -m venv venv
+        #
+        # `uv venv`, not `python3.10 -m venv`: the bundle carries uv, every
+        # install into this venv below goes through it, and skipping ensurepip
+        # is most of why it is quick. The venv therefore has no pip — which is
+        # the point, not an oversight. Anything reaching for `python -m pip`
+        # here is reaching for the wrong tool; use `uv pip`.
+        uv venv --python python3.10 venv
+        echo "PYPTO_USE_UV=true" >> "$GITHUB_ENV"
 
         # PYPTO_TOOLCHAIN is written in as a literal, exactly as the conda roots
         # were: activate.sh is also sourced by task-submit children, whose env
@@ -513,13 +539,25 @@ runs:
           exit 1
         fi
         rm -rf "$PTOAS_ROOT"
-        # `python` is the job venv's. venv resolves a new environment's base from
-        # sys.base_prefix, so building one from inside the job venv layers ptoas
-        # on the toolchain underneath it — conda's py310 or the bundle's
-        # python3.10 — and --system-site-packages exposes that same prefix, which
-        # is what the conda-only form did explicitly.
-        python -m venv "$PTOAS_ROOT" --system-site-packages
-        "$PTOAS_ROOT/bin/python" -m pip install "$CACHE_WHEEL"
+        # Both branches build the same thing: a venv layered on the toolchain
+        # underneath the job venv — conda's py310 or the bundle's python3.10 —
+        # with --system-site-packages exposing that same prefix, which is what
+        # the conda-only form this replaced did explicitly.
+        #
+        # They differ only in who builds it, and that is forced: on the bundle
+        # path the job venv is made by `uv venv` and has no pip, so neither
+        # `python -m venv` (which needs ensurepip to seed the child) nor
+        # `$PTOAS_ROOT/bin/python -m pip` is available to it. The base
+        # interpreter is named explicitly rather than left to uv's discovery,
+        # which would otherwise resolve against the active venv.
+        if [ "${PYPTO_USE_UV:-false}" = "true" ]; then
+          base_python="$(python -c 'import sys; print(sys.base_prefix)')/bin/python3.10"
+          uv venv --python "$base_python" --system-site-packages "$PTOAS_ROOT"
+          uv pip install --python "$PTOAS_ROOT/bin/python" "$CACHE_WHEEL"
+        else
+          python -m venv "$PTOAS_ROOT" --system-site-packages
+          "$PTOAS_ROOT/bin/python" -m pip install "$CACHE_WHEEL"
+        fi
         # activate.sh has already put the right libstdc++ first (conda's lib
         # prefix, or the bundle's), so the probe no longer splices one in by
         # hand. ptoas needs GLIBCXX_3.4.29; older device hosts stop at 3.4.28.
@@ -537,8 +575,24 @@ runs:
       run: |
         source activate.sh
         rm -rf ./build ./_skbuild ./runtime/build ./runtime/_skbuild
-        python -m pip install --upgrade pip
-        pip install scikit-build-core nanobind cmake ninja
+        # One installer per toolchain, chosen by the bootstrap step that built
+        # the venv: uv on the bundle path (it is in the bundle, and that venv has
+        # no pip at all), pip on the conda path. Every install below goes through
+        # this, so the two paths cannot drift in their flags.
+        #
+        # uv resolves the target environment from $VIRTUAL_ENV, which
+        # activate.sh has already exported by sourcing venv/bin/activate.
+        py_install() {
+          if [ "${PYPTO_USE_UV:-false}" = "true" ]; then
+            uv pip install "$@"
+          else
+            pip install "$@"
+          fi
+        }
+        if [ "${PYPTO_USE_UV:-false}" != "true" ]; then
+          python -m pip install --upgrade pip
+        fi
+        py_install scikit-build-core nanobind cmake ninja
         # torch first, and explicitly the CPU build. These are Ascend hosts, and
         # left to resolve `torch>=2.0.0` on its own pip now selects a version
         # whose aarch64 wheel drags in the entire CUDA stack — torch 427 MB,
@@ -561,15 +615,15 @@ runs:
         #
         # It is also a no-op on the conda path, where torch is already visible.
         TORCH_PIN='torch==2.10.0'
-        if ! pip install "$TORCH_PIN" --index-url https://download.pytorch.org/whl/cpu; then
+        if ! py_install "$TORCH_PIN" --index-url https://download.pytorch.org/whl/cpu; then
           echo "note: download.pytorch.org unreachable — falling back to PyPI"
-          pip install "$TORCH_PIN"
+          py_install "$TORCH_PIN"
         fi
-        pip install --no-build-isolation .[dev]
+        py_install --no-build-isolation '.[dev]'
         # simpler (./runtime) is only needed on the codegen -> device path; the
         # --codegen-only job skips it (install-toolchain=false).
         if [ "$INSTALL_TOOLCHAIN" = "true" ]; then
-          pip install --no-build-isolation ./runtime
+          py_install --no-build-isolation ./runtime
           # Fail fast if the venv can't import our freshly-built packages (catches
           # a stale conda shadow or a broken venv here, not 10 min later in the
           # test step). The conda py310 base env must NOT have pypto/simpler

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -469,6 +469,7 @@ jobs:
         with:
           checkout-path: examples-checkout
           needs-device: 'false'
+          toolchain: bundle
           pip-cache-name: pip-examples
           pto-isa-commit: ${{ needs.toolchain.outputs.pto_isa_commit }}
 

--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -183,7 +183,12 @@ jobs:
       - name: Install pypto-lib runner dependencies
         run: |
           source activate.sh
-          pip install nanobind torch
+          # uv, not pip: this job asks for toolchain: bundle, and that venv is
+          # built by `uv venv` and carries no pip. Both are already installed by
+          # setup-ci-job (torch at its pin); this stays as the job's own explicit
+          # statement of what the pypto-lib samples need, and is a no-op when the
+          # two agree.
+          uv pip install nanobind torch
 
       - name: Run Qwen3-14B decode perf samples (L2 swimlane, 5x)
         id: qwen3_perf_run

--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -184,11 +184,15 @@ jobs:
         run: |
           source activate.sh
           # uv, not pip: this job asks for toolchain: bundle, and that venv is
-          # built by `uv venv` and carries no pip. Both are already installed by
-          # setup-ci-job (torch at its pin); this stays as the job's own explicit
-          # statement of what the pypto-lib samples need, and is a no-op when the
-          # two agree.
-          uv pip install nanobind torch
+          # built by `uv venv` and carries no pip.
+          #
+          # torch is deliberately NOT named here, though the samples need it.
+          # setup-ci-job installs it at a pin and from the CPU index, and naming
+          # it again would either duplicate that pin — two places to keep in step
+          # on the next bump — or, bare as it was, let a future divergence
+          # resolve `torch` from PyPI, whose aarch64 wheel drags in the entire
+          # CUDA stack on an Ascend host. One owner for that decision.
+          uv pip install nanobind
 
       - name: Run Qwen3-14B decode perf samples (L2 swimlane, 5x)
         id: qwen3_perf_run


### PR DESCRIPTION
Two leftovers from the toolchain migration ([#2321](https://github.com/hw-native-sys/pypto/pull/2321)), both merge-order accidents rather than decisions. Same day, opposite directions.

## `distributed-examples` never got flipped

[#2317](https://github.com/hw-native-sys/pypto/pull/2317) added the job about an hour before #2321 merged, so it was never in that diff. It is the only one of the seven `setup-ci-job` call sites that passes no `toolchain`, so it has been taking the `conda` default ever since. It passes `toolchain: bundle` now — after which the action's default is the only conda consumer left in the repo.

## The ptoas step reached back into conda

The v0.57 bump ([#2291](https://github.com/hw-native-sys/pypto/pull/2291)) landed *after* the migration and rebuilt the step around a wheel, which needs a CPython 3.10 to install into. The step ran before either bootstrap step, so `activate.sh` did not exist yet and it had to find an interpreter on its own:

```bash
PTOAS_CONDA_PREFIX="$CONDA_ROOT/envs/py310"
PTOAS_PYTHON="$PTOAS_CONDA_PREFIX/bin/python"
...
"$PTOAS_PYTHON" -m venv "$PTOAS_ROOT" --system-site-packages
LD_LIBRARY_PATH="$PTOAS_CONDA_PREFIX/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" \
  "$PTOAS_ROOT/bin/ptoas" --version
```

So on all six bundle jobs the ptoas venv was built by conda's python and probed against conda's libstdc++, while the build next to it used the bundle — two toolchains in one job, and none of it reachable from the `toolchain` input. It works only because these runners still happen to carry conda.

It is also a live trap. The runner-config check requires `CONDA_ROOT` only when `toolchain` is `conda`, so a bundle runner that dropped conda — which the action's own contract permits — would fail with *"ptoas requires the runner's py310 conda environment"* rather than a straight missing-`CONDA_ROOT` error, forty lines into a step that has nothing to do with conda.

**Fix:** move the step after both bootstrap steps and `source activate.sh`. The interpreter and the `LD_LIBRARY_PATH` are then the job's own on either toolchain, and the hand-spliced conda lib prefix goes away. Nothing between the old and new positions depends on ptoas, and it still runs before the build.

The venv is created from the job venv. `venv` resolves a new environment's base from `sys.base_prefix`, so it layers on the toolchain underneath — conda's `py310`, or the bundle's `python3.10` — and `--system-site-packages` exposes that same prefix, which is what the conda-only form did explicitly.

## Aligned with pypto-lib

pypto-lib hit the identical wheel bump and converged on this shape in [pypto-lib#941](https://github.com/hw-native-sys/pypto-lib/pull/941). Two guards from it that this repo's copy lacked are adopted here:

- **`PTOAS_ROOT` must be a strict descendant of the checkout** before the `rm -rf` recreates it. Every caller satisfies this today (`<checkout>/ptoas-bin`); a value one component short would have aimed the delete at a checkout. `realpath -m` on both sides rejects equality, prefix-sharing siblings, and `..` escapes.
- **The interpreter is checked to be 3.10 up front.** pip rejects a cp310 wheel with "not a supported wheel on this platform", which reports a platform problem rather than a wrong-version environment.

## Result

`CONDA_ROOT` is now read in exactly one place: the `toolchain: conda` bootstrap step. The action's provisioning notes say so, and say what to do instead when a future pre-bootstrap step needs an interpreter — move it after the bootstrap, don't go looking for a conda env.

---

# Second commit: install with uv instead of pip

The bundle has carried uv since it was built, unused. Every install into a job venv now goes through it. uv resolves and unpacks in parallel and hardlinks from a shared cache, so the torch install that dominates setup drops from tens of seconds to roughly one on a warm cache — and it stays warm across jobs: unlike pip's cache, uv's is built for concurrent access, so all jobs share `$CI_CACHE_ROOT/uv` instead of taking a dir each (which is why `PIP_CACHE_DIR` is per-job and `UV_CACHE_DIR` is not).

## The part that is different, not just faster

The venv is created with `uv venv`, which skips ensurepip — **so the bundle venv has no pip in it at all.** A step that runs after this action and installs into the job venv must not hardcode `pip`. That is now stated in the action's contract and at the venv itself.

daily_ci's `qwen3-perf` was the one such caller and now uses `uv pip`. Both packages it names are already installed by `setup-ci-job`, so the step was a no-op either way — it stays as the job's own statement of what the pypto-lib samples need.

## Two paths, one set of flags

The conda path keeps pip, since uv is in the bundle and not in the conda env. The bootstrap step that builds the venv states which one the job got in `PYPTO_USE_UV`, and the build step routes every install through a single helper so the two cannot drift in their flags.

The ptoas step has to branch for the same reason: it builds a *nested* venv, and on the uv path neither `python -m venv` (which needs ensurepip to seed the child) nor `$PTOAS_ROOT/bin/python -m pip` is available. Its base interpreter is named explicitly there rather than left to uv's discovery, which would resolve against the active venv.

## No index override

uv does not read `pip.conf`, but these runners have none — pip prints `Looking in indexes` only for the single call that passes `--index-url` explicitly. Both tools already default to PyPI, so nothing changes about where packages come from.

## Verified, not assumed

Checked against a real uv before pushing, rather than paying a CI round-trip per assumption: that `uv venv` omits pip, that `sys.base_prefix` from inside it names the toolchain to layer the ptoas venv on, that `--system-site-packages` lands in `pyvenv.cfg`, and that `uv pip install` honours `VIRTUAL_ENV`, `--python`, `--no-build-isolation` and `--index-url`.
