### PR TITLE
fix(codegen): support rank-reducing tensor slices

### DIFF
--- a/include/pypto/ir/type_inference.h
+++ b/include/pypto/ir/type_inference.h
@@ -364,6 +364,29 @@ struct WindowReadValidShapeParams {
 std::vector<ExprPtr> InferWindowReadValidShape(const WindowReadValidShapeParams& params);
 
 /**
+ * @brief Derive the full-rank valid region of a tensor.slice window
+ *
+ * This is the shared tensor.slice validity rule used by type deduction and
+ * tensor-to-tile lowering before any ``drop_dims`` axes are erased. When the
+ * slice window uses the source rank, it intersects the requested valid region
+ * with the source validity. Lower-rank reinterpret views retain their explicit
+ * validity because their axes do not map directly to source coordinates.
+ *
+ * @param source_type Source tensor type
+ * @param full_shape Slice window shape before rank reduction
+ * @param offsets Slice window offsets in source coordinates
+ * @param requested_valid Explicit full-rank valid shape; empty means none
+ * @param clamp Whether the slice may clamp a window crossing the source edge
+ * @param span IR source location used in diagnostics
+ * @return Full-rank valid shape before applying ``drop_dims``
+ */
+std::vector<ExprPtr> InferTensorSliceFullValidShape(const TensorType& source_type,
+                                                    const std::vector<ExprPtr>& full_shape,
+                                                    const std::vector<ExprPtr>& offsets,
+                                                    const std::vector<ExprPtr>& requested_valid, bool clamp,
+                                                    const Span& span);
+
+/**
  * @brief Return the effective valid shape of a tensor type
  *
  * Falls back to the physical shape when no explicit valid shape is set, matching

--- a/src/codegen/tensor_op_codegen.cpp
+++ b/src/codegen/tensor_op_codegen.cpp
@@ -278,10 +278,11 @@ REGISTER_ORCHESTRATION_OP(tensor_write, ("tensor.write")) {
 }
 
 REGISTER_ORCHESTRATION_OP(tensor_slice, ("tensor.slice")) {
-  // tensor.slice(input, shape_tuple, offset_tuple[, valid_shape_tuple]) -> Generate array variables and call
-  // .view()
-  CHECK(op->args_.size() == 3 || op->args_.size() == 4)
-      << "tensor.slice requires 3 or 4 arguments (input, shape, offset[, valid_shape])";
+  // tensor.slice(input, shape_tuple, offset_tuple[, valid_shape_tuple[, drop_dims_tuple]])
+  // -> Generate a runtime view and, for rank-reducing scalar indices, reshape away
+  // the statically-unit axes recorded in drop_dims.
+  CHECK(op->args_.size() >= 3 && op->args_.size() <= 5)
+      << "tensor.slice requires 3 to 5 arguments (input, shape, offset[, valid_shape[, drop_dims]])";
 
   std::string input_name = codegen.TryGetVarName(op->args_[0]);
   CHECK(!input_name.empty()) << "tensor.slice input must be a variable";
@@ -333,6 +334,19 @@ REGISTER_ORCHESTRATION_OP(tensor_slice, ("tensor.slice")) {
     runtime_offsets.push_back("(" + logical_offset_var + " / 2)");
   }
 
+  std::vector<bool> drop_dims(ndim, false);
+  if (op->args_.size() == 5) {
+    auto drop_dims_tuple = As<MakeTuple>(op->args_[4]);
+    CHECK(drop_dims_tuple) << "tensor.slice drop_dims must be MakeTuple";
+    for (const auto& dim_expr : drop_dims_tuple->elements_) {
+      auto dim = As<ConstInt>(dim_expr);
+      CHECK(dim) << "tensor.slice drop_dims entries must be ConstInt";
+      CHECK(dim->value_ >= 0 && static_cast<size_t>(dim->value_) < ndim)
+          << "tensor.slice drop_dims entry out of range: " << dim->value_;
+      drop_dims[static_cast<size_t>(dim->value_)] = true;
+    }
+  }
+
   // Generate offset array (emitted first so the shape clamp below can read it).
   oss << "uint32_t " << result_var << "_offsets[" << ndim << "] = {";
   for (size_t i = 0; i < ndim; ++i) {
@@ -363,16 +377,50 @@ REGISTER_ORCHESTRATION_OP(tensor_slice, ("tensor.slice")) {
   }
   oss << "};\n";
 
-  if (op->args_.size() == 4) {
+  if (op->args_.size() >= 4) {
     auto valid_shape_tuple = As<MakeTuple>(op->args_[3]);
     CHECK(valid_shape_tuple) << "tensor.slice valid_shape must be MakeTuple";
-    CHECK(valid_shape_tuple->elements_.size() == ndim)
+    CHECK(valid_shape_tuple->elements_.empty() || valid_shape_tuple->elements_.size() == ndim)
         << "tensor.slice valid_shape must have same rank as shape";
   }
 
   // Runtime tensor views use shape+offset; valid_shape only affects IR metadata.
-  oss << "Tensor " << result_var << " = " << ext_input_name << ".view(" << result_var << "_shapes, "
-      << result_var << "_offsets);";
+  size_t drop_count = 0;
+  for (bool drop : drop_dims) drop_count += drop ? 1 : 0;
+  if (drop_count == 0) {
+    oss << "Tensor " << result_var << " = " << ext_input_name << ".view(" << result_var << "_shapes, "
+        << result_var << "_offsets);";
+  } else {
+    oss << "Tensor " << result_var << "_view = " << ext_input_name << ".view(" << result_var << "_shapes, "
+        << result_var << "_offsets);\n";
+    // A dynamically out-of-bounds scalar index clamps its dropped axis to
+    // zero. Preserve that full-view emptiness before removing the axis: the
+    // runtime intentionally leaves an empty view at the parent start offset
+    // with zero extent, so reviving non-zero shapes after rank reduction would
+    // make numel(), extent_elem(), and the address footprint disagree.
+    oss << "bool " << result_var << "_empty = " << result_var << "_view.numel() == 0;\n";
+    oss << "Tensor " << result_var << " = " << result_var << "_view;\n";
+    oss << result_var << ".ndims = " << (ndim - drop_count) << ";\n";
+    size_t dst_dim = 0;
+    for (size_t i = 0; i < ndim; ++i) {
+      if (drop_dims[i]) continue;
+      oss << result_var << ".shapes[" << dst_dim << "] = " << result_var << "_view.shapes[" << i << "];\n";
+      oss << result_var << ".strides[" << dst_dim << "] = " << result_var << "_view.strides[" << i << "];\n";
+      ++dst_dim;
+    }
+    // Tensor slice type deduction rejects dropping every axis, so shapes[0]
+    // always names a retained dimension. A zero there keeps numel() and the
+    // copied zero extent consistent without changing any non-empty view.
+    oss << "if (" << result_var << "_empty) " << result_var << ".shapes[0] = 0;\n";
+    oss << "uint64_t " << result_var << "_expected_stride = 1;\n";
+    oss << "bool " << result_var << "_contiguous = true;\n";
+    oss << "for (int32_t i = static_cast<int32_t>(" << result_var << ".ndims) - 1; i >= 0; --i) {\n";
+    oss << "  " << result_var << "_contiguous = " << result_var << "_contiguous && (" << result_var
+        << ".strides[i] == " << result_var << "_expected_stride);\n";
+    oss << "  " << result_var << "_expected_stride *= " << result_var << ".shapes[i];\n";
+    oss << "}\n";
+    oss << result_var << ".is_contiguous = " << result_var << "_empty || " << result_var << "_contiguous;";
+  }
   return oss.str();
 }
 

--- a/src/ir/op/tensor_ops/memory.cpp
+++ b/src/ir/op/tensor_ops/memory.cpp
@@ -208,6 +208,9 @@ TypePtr DeduceTensorSliceType(const std::vector<ExprPtr>& args,
   // against the full pre-reduction shape (each must be a static unit dim).
   const ExprPtr drop_dims_arg = args.size() == 5 ? args[4] : nullptr;
   const std::vector<int64_t> drop_dims = ParseSliceDropDims(drop_dims_arg, full_shape, "tensor.slice");
+  CHECK_SPAN(drop_dims.size() < full_shape.size(), args[0]->span_)
+      << "tensor.slice drop_dims cannot erase every dimension; keep one unit axis or use tensor.read "
+         "for a scalar result";
   const std::vector<ExprPtr> new_shape = ApplyDropDims(full_shape, drop_dims);
 
   // Optional pad_value kwarg. Absent means "not overridden": the source's pad
@@ -246,28 +249,9 @@ TypePtr DeduceTensorSliceType(const std::vector<ExprPtr>& args,
   // OptimizeOrchTensors materializes as strides (e.g. a 2D window over a 3D
   // parent); that form is not a plain rectangle, so it keeps the validity it was
   // given rather than being intersected against the wrong axes.
-  std::vector<ExprPtr> full_valid;
-  if (full_shape.size() == tensor_type->shape_.size() && offsets.size() == full_shape.size()) {
-    full_valid = InferWindowReadValidShape({
-        /*source_physical=*/tensor_type->shape_,
-        /*source_valid=*/GetEffectiveTensorValidShape(*tensor_type),
-        /*offsets=*/offsets,
-        /*window=*/full_shape,
-        /*requested_valid=*/requested_valid,
-        /*kind=*/WindowReadKind::kClampedWindow,
-        /*clamp=*/GetKwargOr<bool>(kwargs, "clamp", false),
-        /*op_name=*/"tensor.slice",
-        /*bounds_remedy=*/
-        "Pass clamp=True -- pl.slice(x, shape, offset, clamp=True) -- to narrow the valid region to "
-        "the source edge instead",
-        /*span=*/args[0]->span_,
-    });
-  } else {
-    CHECK_SPAN(requested_valid.empty() || requested_valid.size() == full_shape.size(), args[0]->span_)
-        << "tensor.slice requires valid_shape to have the same rank as shape, but got valid_shape rank "
-        << requested_valid.size() << " and shape rank " << full_shape.size();
-    full_valid = requested_valid.empty() ? full_shape : requested_valid;
-  }
+  const std::vector<ExprPtr> full_valid =
+      InferTensorSliceFullValidShape(*tensor_type, full_shape, offsets, requested_valid,
+                                     GetKwargOr<bool>(kwargs, "clamp", false), args[0]->span_);
   ValidateDropDimsValidExtents(drop_dims, full_valid, "tensor.slice", args[0]->span_);
   const std::vector<ExprPtr> valid_shape = ApplyDropDims(full_valid, drop_dims);
 

--- a/src/ir/op/type_inference.cpp
+++ b/src/ir/op/type_inference.cpp
@@ -685,6 +685,34 @@ std::vector<ExprPtr> InferWindowReadValidShape(const WindowReadValidShapeParams&
   return result;
 }
 
+std::vector<ExprPtr> InferTensorSliceFullValidShape(const TensorType& source_type,
+                                                    const std::vector<ExprPtr>& full_shape,
+                                                    const std::vector<ExprPtr>& offsets,
+                                                    const std::vector<ExprPtr>& requested_valid, bool clamp,
+                                                    const Span& span) {
+  if (full_shape.size() == source_type.shape_.size() && offsets.size() == full_shape.size()) {
+    return InferWindowReadValidShape({
+        /*source_physical=*/source_type.shape_,
+        /*source_valid=*/GetEffectiveTensorValidShape(source_type),
+        /*offsets=*/offsets,
+        /*window=*/full_shape,
+        /*requested_valid=*/requested_valid,
+        /*kind=*/WindowReadKind::kClampedWindow,
+        /*clamp=*/clamp,
+        /*op_name=*/"tensor.slice",
+        /*bounds_remedy=*/
+        "Pass clamp=True -- pl.slice(x, shape, offset, clamp=True) -- to narrow the valid region to "
+        "the source edge instead",
+        /*span=*/span,
+    });
+  }
+
+  CHECK_SPAN(requested_valid.empty() || requested_valid.size() == full_shape.size(), span)
+      << "tensor.slice requires valid_shape to have the same rank as shape, but got valid_shape rank "
+      << requested_valid.size() << " and shape rank " << full_shape.size();
+  return requested_valid.empty() ? full_shape : requested_valid;
+}
+
 void ValidateDropDimsValidExtents(const std::vector<int64_t>& drop_dims,
                                   const std::vector<ExprPtr>& valid_shape, const std::string& op_name,
                                   const Span& span) {

--- a/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
+++ b/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
@@ -43,6 +43,7 @@
 #include "pypto/ir/transforms/utils/transform_utils.h"
 #include "pypto/ir/transforms/utils/var_collectors.h"
 #include "pypto/ir/type.h"
+#include "pypto/ir/type_inference.h"
 #include "pypto/ir/verifier/verifier.h"
 
 namespace pypto {
@@ -652,12 +653,33 @@ class TensorToTileMutator : public TypePropagatingMutator {
   StmtPtr HandleConsumerDrivenLoad(const AssignStmtPtr& op, const CallPtr& call,
                                    const ConsumerSpaceReq& req) {
     const auto& input = call->args_[0];
-    auto tensor_type = As<TensorType>(input->GetType());
+    auto tensor_type = AsTensorTypeLike(input->GetType());
     if (!tensor_type) return nullptr;
 
     const auto& shape_arg = call->args_[1];
     const auto& offset_arg = call->args_[2];
-    ExprPtr valid_shape = (call->args_.size() == 4) ? call->args_[3] : shape_arg;
+    auto shape_type = As<TupleType>(shape_arg->GetType());
+    auto offset_type = As<TupleType>(offset_arg->GetType());
+    INTERNAL_CHECK_SPAN(shape_type && offset_type, call->span_)
+        << "Internal error: tensor.slice shape and offset must be tuples during conversion";
+    auto full_shape = ExtractTupleElements(shape_arg, shape_type->types_.size());
+    auto offsets = ExtractTupleElements(offset_arg, offset_type->types_.size());
+    std::vector<ExprPtr> requested_valid;
+    if (call->args_.size() >= 4) {
+      auto valid_shape_tuple = As<MakeTuple>(call->args_[3]);
+      INTERNAL_CHECK_SPAN(valid_shape_tuple, call->span_)
+          << "Internal error: tensor.slice valid_shape must be a MakeTuple during conversion";
+      requested_valid = valid_shape_tuple->elements_;
+    }
+    auto valid_shape = MakeShapeTuple(
+        InferTensorSliceFullValidShape(*tensor_type, full_shape, offsets, requested_valid,
+                                       GetKwargOr<bool>(call->kwargs_, "clamp", false), call->span_),
+        call->span_);
+    auto drop_dims = ParseSliceDropDims(call->args_.size() == 5 ? call->args_[4] : nullptr, full_shape,
+                                        "tensor.slice conversion");
+    CHECK_SPAN(drop_dims.size() < full_shape.size(), call->span_)
+        << "tensor.slice conversion does not support rank-0 tiles; keep one unit axis or use tensor.read "
+           "for a scalar result";
 
     // The consumer-driven load is always natural; a transposed (b_trans/a_trans)
     // operand gets a zero-copy tile.transpose_view at the matmul site instead.
@@ -668,12 +690,25 @@ class TensorToTileMutator : public TypePropagatingMutator {
                               req.space);
 
     auto tile_name = MakeTileValueName(op->var_->name_hint_);
-    auto tile_var = std::make_shared<Var>(tile_name, load_call->GetType(), op->var_->span_);
+    if (drop_dims.empty()) {
+      auto tile_var = std::make_shared<Var>(tile_name, load_call->GetType(), op->var_->span_);
+      var_remap_[op->var_.get()] = tile_var;
+      auto result = MutableCopy(op);
+      result->var_ = tile_var;
+      result->value_ = load_call;
+      return result;
+    }
+
+    auto loaded_var = std::make_shared<Var>(tile_name + "_full_rank", load_call->GetType(), op->var_->span_);
+    auto reduced_shape = MakeShapeTuple(ApplyDropDims(full_shape, drop_dims), call->span_);
+    auto reshape_call = op_registry_.Create("tile.reshape", {loaded_var, reduced_shape}, {}, call->span_);
+    auto tile_var = std::make_shared<Var>(tile_name, reshape_call->GetType(), op->var_->span_);
     var_remap_[op->var_.get()] = tile_var;
-    auto result = MutableCopy(op);
-    result->var_ = tile_var;
-    result->value_ = load_call;
-    return result;
+    std::vector<StmtPtr> stmts = {
+        std::make_shared<AssignStmt>(loaded_var, load_call, op->span_),
+        std::make_shared<AssignStmt>(tile_var, reshape_call, op->span_),
+    };
+    return SeqStmts::Flatten(std::move(stmts), op->span_);
   }
 
   /// Auto-bridge TensorType args to the memory space required by input_reqs.

--- a/src/ir/transforms/op_conversion_registry.cpp
+++ b/src/ir/transforms/op_conversion_registry.cpp
@@ -421,12 +421,33 @@ void OpConversionRegistry::RegisterMemoryOps() {
       "tensor.slice",
       [](const std::vector<ExprPtr>& args, const std::vector<std::pair<std::string, std::any>>& kwargs,
          const Span& span) -> ConversionResult {
-        INTERNAL_CHECK_SPAN(args.size() == 3 || args.size() == 4, span)
-            << "tensor.slice conversion expects 3 or 4 args (tensor, shape, offset[, valid_shape])";
+        INTERNAL_CHECK_SPAN(args.size() >= 3 && args.size() <= 5, span)
+            << "tensor.slice conversion expects 3-5 args "
+               "(tensor, shape, offset[, valid_shape[, drop_dims]])";
         auto& op_reg = OpRegistry::GetInstance();
         const auto& input = args[0];
         const auto& shape = args[1];
         const auto& offset = args[2];
+        auto shape_type = As<TupleType>(shape->GetType());
+        INTERNAL_CHECK_SPAN(shape_type, span) << "tensor.slice shape must be a tuple";
+        auto full_shape = ExtractTupleElements(shape, shape_type->types_.size());
+        auto offset_type = As<TupleType>(offset->GetType());
+        INTERNAL_CHECK_SPAN(offset_type, span) << "tensor.slice offset must be a tuple";
+        auto offsets = ExtractTupleElements(offset, offset_type->types_.size());
+        auto drop_dims =
+            ParseSliceDropDims(args.size() == 5 ? args[4] : nullptr, full_shape, "tensor.slice conversion");
+        CHECK_SPAN(drop_dims.size() < full_shape.size(), span)
+            << "tensor.slice conversion does not support rank-0 tiles; keep one unit axis or use "
+               "tensor.read for a scalar result";
+        auto reduced_shape = MakeShapeTuple(ApplyDropDims(full_shape, drop_dims), span);
+
+        auto apply_drop_dims = [&](const ExprPtr& value) -> ConversionResult {
+          if (drop_dims.empty()) return ConversionResult{value};
+          auto loaded_var = std::make_shared<Var>("slice_load", value->GetType(), span);
+          std::vector<StmtPtr> prologue = {std::make_shared<AssignStmt>(loaded_var, value, span)};
+          auto reshape_call = op_reg.Create("tile.reshape", {loaded_var, reduced_shape}, {}, span);
+          return ConversionResult{std::move(prologue), reshape_call};
+        };
 
         // Extract pad_value kwarg (if any) to forward to the emitted tile.slice.
         std::vector<std::pair<std::string, std::any>> forward_kwargs;
@@ -451,18 +472,27 @@ void OpConversionRegistry::RegisterMemoryOps() {
           // pad_value on a tensor.slice over a TensorType input, the pad intent is
           // lost here — a follow-up tile.fillpad is the workaround until tile.load
           // grows its own pad_value kwarg.
-          auto valid_shape = (args.size() == 4) ? args[3] : shape;
+          std::vector<ExprPtr> requested_valid;
+          if (args.size() >= 4) {
+            auto valid_shape_tuple = As<MakeTuple>(args[3]);
+            INTERNAL_CHECK_SPAN(valid_shape_tuple, span)
+                << "tensor.slice valid_shape must be a MakeTuple during conversion";
+            requested_valid = valid_shape_tuple->elements_;
+          }
+          auto valid_shape = MakeShapeTuple(
+              InferTensorSliceFullValidShape(*tensor_type, full_shape, offsets, requested_valid,
+                                             GetKwargOr<bool>(kwargs, "clamp", false), span),
+              span);
           std::vector<std::pair<std::string, std::any>> load_kwargs = {{"target_memory", MemorySpace::Vec}};
           auto load_call = op_reg.Create("tile.load", {input, offset, shape, valid_shape}, load_kwargs, span);
-          return ConversionResult{load_call};
+          return apply_drop_dims(load_call);
         }
 
         if (tile_type) {
-          std::vector<ExprPtr> slice_args = {input, shape, offset};
-          if (args.size() == 4) {
-            slice_args.push_back(args[3]);
-          }
-          auto slice_call = op_reg.Create("tile.slice", slice_args, forward_kwargs, span);
+          // tile.slice natively understands valid_shape and drop_dims. Keep the
+          // full-rank window operands intact so it can validate against the
+          // source tile before reducing the result rank.
+          auto slice_call = op_reg.Create("tile.slice", args, forward_kwargs, span);
           return ConversionResult{slice_call};
         }
 

--- a/tests/ut/codegen/test_orchestration_codegen_more.py
+++ b/tests/ut/codegen/test_orchestration_codegen_more.py
@@ -352,6 +352,62 @@ class TestOrchestrationMore:
         assert "uint32_t chunk_offsets[2] = {0, 0};" in code
         assert "Tensor chunk = ext_data.view(chunk_shapes, chunk_offsets);" in code
 
+    def test_tensor_slice_with_drop_dims(self):
+        """A scalar-indexed tensor slice emits a view followed by rank reduction."""
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        @pl.program
+        class DropDimSliceProgram:
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orch_slice(
+                self,
+                data: pl.Tensor[[3, 64, 16], pl.FP32],
+            ) -> pl.Tensor[[3, 16], pl.FP32]:
+                chunk = data[:, 1, :]
+                return chunk
+
+        code = _generate_orch_code(DropDimSliceProgram)
+
+        assert "Tensor chunk_view = ext_data.view(chunk_shapes, chunk_offsets);" in code
+        assert "chunk.ndims = 2;" in code
+        assert "chunk.shapes[0] = chunk_view.shapes[0];" in code
+        assert "chunk.strides[0] = chunk_view.strides[0];" in code
+        assert "chunk.shapes[1] = chunk_view.shapes[2];" in code
+        assert "chunk.strides[1] = chunk_view.strides[2];" in code
+        assert "bool chunk_empty = chunk_view.numel() == 0;" in code
+        assert "if (chunk_empty) chunk.shapes[0] = 0;" in code
+        assert "chunk.is_contiguous = chunk_empty || chunk_contiguous;" in code
+
+    def test_tensor_slice_drop_dims_preserves_dynamic_empty_view(self):
+        """An out-of-bounds scalar index remains empty after its axis is removed."""
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        @pl.program
+        class DynamicDropDimSliceProgram:
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orch_slice(
+                self,
+                data: pl.Tensor[[3, 64, 16], pl.FP32],
+                index: pl.Scalar[pl.INDEX],
+            ) -> pl.Tensor[[3, 16], pl.FP32]:
+                chunk = data[:, index, :]
+                return chunk
+
+        code = _generate_orch_code(DynamicDropDimSliceProgram)
+
+        assert "uint32_t chunk_offsets[3] = {0, static_cast<uint32_t>(index), 0};" in code
+        assert (
+            "(chunk_offsets[1] >= ext_data.shapes[1] ? 0u : "
+            "std::min<uint32_t>(1, ext_data.shapes[1] - chunk_offsets[1]))" in code
+        )
+        empty_capture = code.index("bool chunk_empty = chunk_view.numel() == 0;")
+        rank_reduction = code.index("chunk.ndims = 2;")
+        assert empty_capture < rank_reduction
+        assert "if (chunk_empty) chunk.shapes[0] = 0;" in code
+        assert "chunk.is_contiguous = chunk_empty || chunk_contiguous;" in code
+
     def test_tensor_reshape_external_input(self):
         """tensor.reshape on an external orchestration input emits Tensor::reshape on ext_<name>."""
         backend.reset_for_testing()

--- a/tests/ut/ir/operators/test_tensor_ops.py
+++ b/tests/ut/ir/operators/test_tensor_ops.py
@@ -2310,6 +2310,14 @@ def test_tensor_slice_drop_dims_rejects_out_of_range():
         ir.op.tensor.slice(tensor_var, [1, 64], [0, 0], drop_dims=[2])
 
 
+def test_tensor_slice_drop_dims_rejects_rank_zero_result():
+    """drop_dims cannot create a rank-zero runtime tensor."""
+    span = ir.Span.unknown()
+    tensor_var = ir.Var("t", ir.TensorType([1, 1], DataType.FP32), span)
+    with pytest.raises(ValueError, match="cannot erase every dimension"):
+        ir.op.tensor.slice(tensor_var, [1, 1], [0, 0], drop_dims=[0, 1])
+
+
 def test_tensor_slice_empty_drop_dims_is_backward_compatible():
     """drop_dims=None / [] keeps the legacy 3-arg result type (no tensor_view)."""
     span = ir.Span.unknown()

--- a/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
+++ b/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
@@ -280,6 +280,16 @@ def _find_calls_to(func: ir.Function, op_name: str) -> list[ir.Call]:
     return finder.found
 
 
+def _tuple_int_values(expr: ir.Expr) -> list[int]:
+    """Return the static integer elements of a tuple expression."""
+    assert isinstance(expr, ir.MakeTuple)
+    values: list[int] = []
+    for element in expr.elements:
+        assert isinstance(element, ir.ConstInt)
+        values.append(element.value)
+    return values
+
+
 class _CallCounter(ir.IRVisitor):
     """Count Calls whose callee ``Op`` name appears in ``op_names``."""
 
@@ -541,6 +551,28 @@ class TestConvertTensorToTileOps:
         after = passes.convert_tensor_to_tile_ops()(before)
 
         ir.assert_structural_equal(after, before)
+
+    def test_tensor_slice_drop_dims_lowers_to_tile(self):
+        """Rank reduction preserves source validity and emits a separate reshape."""
+        ib = IRBuilder()
+        with ib.function("kernel", type=ir.FunctionType.InCore) as f:
+            source_view = ir.TensorView(valid_shape=[3, 12], layout=ir.TensorLayout.ND)
+            x = f.param(
+                "x",
+                ir.TensorType([3, 64], DataType.FP32, memref=None, tensor_view=source_view),
+            )
+            sliced = ib.let("sliced", tensor_ops.slice(x, [1, 64], [1, 0], drop_dims=[0]))
+            f.return_type(sliced.type)
+            ib.return_stmt(sliced)
+        before = ir.Program([f.get_result()], "TensorSliceDropDims", ir.Span.unknown())
+
+        after = passes.convert_tensor_to_tile_ops()(before)
+        text = ir.python_print(after)
+
+        assert "pl.tile.load(x, [1, 0], [1, 64], [1, 12]" in text
+        assert "pl.tile.reshape(" in text
+        assert ", [64])" in text
+        assert "pl.tile.reshape(pl.tile.load(" not in text
 
     def test_tensor_view_rejects_input_converted_to_tile(self):
         """A GM view cannot consume a producer that pass 12 lowers to Tile."""
@@ -3018,6 +3050,52 @@ class TestSliceMatmulConversion:
             preload=False,
         )
         _assert_convert_equal(before, expected)
+
+    def test_rank_reducing_slice_then_matmul_preserves_valid_shape(self):
+        """Consumer-driven Mat loads keep 5-arg validity and lower drop_dims."""
+        ib = IRBuilder()
+        with ib.function("kernel", type=ir.FunctionType.InCore) as f:
+            a = f.param("a", ir.TensorType([16, 64], DataType.BF16))
+            b = f.param("b", ir.TensorType([2, 64, 32], DataType.BF16))
+            b_slice = ib.let(
+                "b_slice",
+                tensor_ops.slice(
+                    b,
+                    [1, 64, 32],
+                    [1, 0, 0],
+                    valid_shape=[1, 64, 16],
+                    drop_dims=[0],
+                ),
+            )
+            result = ib.let("result", tensor_ops.matmul(a, b_slice))
+            f.return_type(result.type)
+            ib.return_stmt(result)
+        before = ir.Program([f.get_result()], "RankReducingSliceMatmul", ir.Span.unknown())
+
+        after = passes.convert_tensor_to_tile_ops()(before)
+        kernel = after.get_function("kernel")
+        assert kernel is not None
+
+        b_load = next(
+            load
+            for load in _find_calls_to(kernel, "tile.load")
+            if isinstance(load.args[0], ir.Var) and load.args[0].name_hint == "b"
+        )
+        assert _tuple_int_values(b_load.args[3]) == [1, 64, 16]
+        assert isinstance(b_load.type, ir.TileType)
+        assert b_load.type.memory_space == MemorySpace.Mat
+        assert dict(b_load.attrs).get(_MAT_BRIDGE_ATTR) is True
+
+        reshapes = _find_calls_to(kernel, "tile.reshape")
+        assert len(reshapes) == 1
+        reshape = reshapes[0]
+        assert isinstance(reshape.args[0], ir.Var)
+        assert _tuple_int_values(reshape.args[1]) == [64, 32]
+
+        matmul = _find_calls_to(kernel, "tile.matmul")
+        assert len(matmul) == 1
+        assert isinstance(matmul[0].args[1], ir.Var)
+        assert matmul[0].args[1].name_hint == "b_slice__tile"
 
     def test_slice_alias_then_matmul_routes_load_to_mat(self):
         """tensor.slice → SSA alias → tensor.matmul emits tile.load(Mat).


### PR DESCRIPTION
## Summary

- preserve `drop_dims` when `tensor.slice` is lowered to tile operations
- generate orchestration views for rank-reducing tensor slices
- compact shape/stride metadata without requiring contiguous storage
- add regression coverage for tensor-to-tile lowering and non-contiguous middle-axis rank reduction

## Motivation

The DeepSeek V4 DSpark draft backbone in hw-native-sys/pypto-lib#939 passes layer-isolated metadata views such as `swa_indices[layer]` into outlined kernels. Those scalar-indexed views are represented as five-operand `tensor.slice` calls. The conversion and orchestration codegen paths previously accepted only three or four operands, so the valid IR could not reach code generation.

## Validation

- `12 passed, 615 deselected` for focused drop-dimension, orchestration slice, and tensor operator tests
- rebuilt the aarch64 extension with two compile jobs
- compiled the full DeepSeek V4 DSpark draft backbone for A2/A3 EP=2 with PTOAS 0.57 (`CompiledProgram`)