### PR TITLE
fix(language): raise TypeError from every unified op argument guard

### DIFF
--- a/docs/en/dev/language/00-python_syntax.md
+++ b/docs/en/dev/language/00-python_syntax.md
@@ -393,6 +393,32 @@ pl.aiv_initialize_pipe(pl.const(0, pl.INT32), peer, dir_mask=2, slot_size=512, i
 pl.aic_initialize_pipe(pl.const(0, pl.INT32), buf, dir_mask=2, slot_size=512, slot_num=16, local_slot_num=4)
 ```
 
+#### Cross-path arguments on unified ops
+
+A unified `pl.<op>` accepts the union of both levels' arguments, so an argument
+only the *other* dispatch path can honour is **rejected, never dropped** — a
+silently discarded `b_trans` would compile wrong math. The same holds in
+reverse: the scratch operand a Tensor input must omit (`pl.row_max(tensor)`) is
+the one a Tile input must supply (`pl.row_max(tile, tmp_tile)`), because tile
+buffer lifetimes are user-managed.
+
+**Both directions raise `TypeError`** — these are wrong-arguments-for-this-overload
+errors that Python itself raises for an unexpected keyword or a missing
+required argument. Deeper validation reached through the wrapper (shape, dtype,
+bounds — anything a C++ `CHECK` rejects) still raises `ValueError`, so code
+guarding a whole call should catch both:
+
+```python
+pl.matmul(tile_a, tile_b, b_trans=True)   # TypeError — tile transpose is a view, not a flag
+pl.rsqrt(tile, high_precision=True)       # TypeError — tile precision is selected by passing tmp
+pl.div(tile, 2.0, high_precision=True)    # TypeError — high_precision needs a Tile rhs
+pl.row_max(tile)                          # TypeError — Tile inputs require tmp_tile
+pl.slice(tile, [64, 64], [64, 0])         # ValueError — window runs off the source tile
+```
+
+Inside a `@pl.function` body this distinction is invisible: the parser catches
+both and re-raises `InvalidOperationError` with the source span.
+
 ## Statements
 
 ### Assignment

--- a/docs/zh/dev/language/00-python_syntax.md
+++ b/docs/zh/dev/language/00-python_syntax.md
@@ -365,6 +365,30 @@ pl.aiv_initialize_pipe(pl.const(0, pl.INT32), peer, dir_mask=2, slot_size=512, i
 pl.aic_initialize_pipe(pl.const(0, pl.INT32), buf, dir_mask=2, slot_size=512, slot_num=16, local_slot_num=4)
 ```
 
+#### 统一算子的跨路径参数 (Cross-path arguments)
+
+统一算子 `pl.<op>` 接受两个层级参数的并集，因此只有*另一条*分发路径才能处理的
+参数会被**拒绝，而不会被丢弃**——被悄悄丢弃的 `b_trans` 会编译出错误的数学
+语义。反方向同样成立：Tensor 输入必须省略的临时操作数
+(`pl.row_max(tensor)`)，正是 Tile 输入必须提供的那一个
+(`pl.row_max(tile, tmp_tile)`)，因为 tile 缓冲区的生命周期由用户管理。
+
+**两个方向都抛出 `TypeError`**——它们属于"参数与该重载不匹配"这一类错误，
+即 Python 自身在遇到意外关键字参数或缺少必需参数时抛出的类型。通过该包装器
+到达更深层的校验 (形状、dtype、边界——任何由 C++ `CHECK` 拒绝的情况) 仍然抛出
+`ValueError`，因此保护整个调用的代码应当同时捕获两者:
+
+```python
+pl.matmul(tile_a, tile_b, b_trans=True)   # TypeError — tile 转置是视图，不是标志位
+pl.rsqrt(tile, high_precision=True)       # TypeError — tile 精度通过传入 tmp 选择
+pl.div(tile, 2.0, high_precision=True)    # TypeError — high_precision 需要 Tile rhs
+pl.row_max(tile)                          # TypeError — Tile 输入必须提供 tmp_tile
+pl.slice(tile, [64, 64], [64, 0])         # ValueError — 窗口越出源 tile 边界
+```
+
+在 `@pl.function` 函数体内这一区别是不可见的: 解析器会同时捕获两者，并重新
+抛出带有源码位置的 `InvalidOperationError`。
+
 ## 语句 (Statement)
 
 ### 赋值

--- a/python/pypto/ir/op/tensor_ops.py
+++ b/python/pypto/ir/op/tensor_ops.py
@@ -633,7 +633,9 @@ def div(
     rhs_type = rhs_expr.type
     if isinstance(rhs_type, ScalarType):
         if high_precision:
-            raise ValueError("tensor.div(high_precision=True) requires a Tensor rhs")
+            # TypeError, matching the unified pl.* guards: a kwarg this operand
+            # combination cannot honour is a wrong-arguments error, not a bad value.
+            raise TypeError("tensor.div(high_precision=True) requires a Tensor rhs")
         return _ir_core.create_op_call("tensor.divs", [lhs, rhs_expr], {}, actual_span)
     kwargs: dict[str, Any] = {"high_precision": True} if high_precision else {}
     return _ir_core.create_op_call("tensor.div", [lhs, rhs_expr], kwargs, actual_span)

--- a/python/pypto/ir/op/tile_ops.py
+++ b/python/pypto/ir/op/tile_ops.py
@@ -949,7 +949,9 @@ def div(
     rhs_expr = _normalize_scalar_operand(lhs, rhs, actual_span)
     if isinstance(rhs_expr.type, ScalarType):
         if high_precision:
-            raise ValueError("tile.div(high_precision=True) requires a Tile rhs")
+            # TypeError, matching the unified pl.* guards: a kwarg this operand
+            # combination cannot honour is a wrong-arguments error, not a bad value.
+            raise TypeError("tile.div(high_precision=True) requires a Tile rhs")
         return _ir_core.create_op_call("tile.divs", [lhs, rhs_expr], {}, actual_span)
     kwargs: dict[str, Any] = {"high_precision": True} if high_precision else {}
     return _ir_core.create_op_call("tile.div", [lhs, rhs_expr], kwargs, actual_span)

--- a/python/pypto/language/op/unified_ops.py
+++ b/python/pypto/language/op/unified_ops.py
@@ -146,6 +146,17 @@ def _raise_type_dispatch_error(op_name: str, *args: object) -> NoReturn:
 # tile leaves the caller's buffer dead while it still consumes UB budget.
 # Only a non-default value raises — spelling out the documented default keeps
 # working.
+#
+# **Every guard in this module raises ``TypeError``**, in both directions: an
+# argument the dispatched path cannot honour, and one it requires but did not
+# get. Both are "these arguments do not match this overload" — the class CPython
+# itself raises for an unexpected keyword or a missing required argument — not a
+# bad *value*. Deeper validation reached through these wrappers still raises
+# ``ValueError`` (``pypto::ValueError`` from a C++ ``CHECK`` is registered as a
+# Python ``ValueError`` subclass), so a direct-API caller guarding a whole call
+# should catch both; the split here is only about which layer rejected it.
+# The DSL path is unaffected either way: ``ast_parser`` catches ``(TypeError,
+# ValueError)`` and re-raises ``InvalidOperationError`` with a span.
 # ---------------------------------------------------------------------------
 
 # The ``@overload`` declarations mirror that rule with ``Literal[False]`` /
@@ -175,6 +186,40 @@ def _reject_tmp_for_tensor(op_name: str, tmp: Any, param: str = "tmp") -> None:
             f"pl.{op_name}: Tensor inputs must not pass {param} — the scratch tile is "
             f"allocated during Tensor-to-Tile lowering"
         )
+
+
+def _require_tmp_for_tile(op_name: str, tmp: Tile | None, requirement: str) -> Tile:
+    """Guard the Tile path of an op whose Tile form *requires* a scratch operand.
+
+    The mirror image of :func:`_reject_tmp_for_tensor`: tile buffer lifetimes are
+    user-managed, so the operand the Tensor path must omit is the same one the
+    Tile path cannot synthesize. Both directions raise ``TypeError`` — this is a
+    wrong-arguments-for-this-overload error, the same class CPython raises for a
+    missing required argument, not a bad *value*.
+
+    ``requirement`` completes the sentence "Tile inputs require ..." and carries
+    the per-op constraint on the scratch operand. Returns the operand so the call
+    site keeps the non-``None`` narrowing the inline ``is None`` check gave it.
+    """
+    if tmp is None:
+        raise TypeError(f"pl.{op_name}: Tile inputs require {requirement}")
+    return tmp
+
+
+# Scratch-operand requirements, shared by the ops that impose the same one.
+_TMP_ROW_REDUCTION_REQUIREMENT = (
+    "tmp_tile with the same dtype and rank as the input, and every dimension at least as large "
+    "as the corresponding input dimension"
+)
+_TMP_ROW_ARG_REDUCTION_REQUIREMENT = "tmp_tile with exactly the same shape and dtype as the input"
+_TMP_COL_ARG_REDUCTION_REQUIREMENT = (
+    "tmp_tile — the tile form takes caller-owned scratch, unlike pl.col_max / pl.col_min"
+)
+
+
+def _tmp_scratch_requirement(op_name: str) -> str:
+    """Requirement text for the bitwise ops, whose scratch operand is positional."""
+    return f"an explicit scratch tile — call pl.{op_name}(lhs, rhs, tmp) or pl.tile.{op_name}(lhs, rhs, tmp)"
 
 
 def _reject_tile_unsupported(op_name: str, /, **flags: tuple[bool, str]) -> None:
@@ -348,11 +393,11 @@ def div(lhs, rhs, high_precision: bool = False):
         return _tile.div(lhs, rhs, high_precision=high_precision)
     if isinstance(lhs, Tile) and isinstance(rhs, (int, float, Scalar, _ir_core.Expr)):
         if high_precision:
-            raise ValueError("pl.div: high_precision requires a Tile rhs")
+            raise TypeError("pl.div: high_precision requires a Tile rhs")
         return _tile.divs(lhs, rhs)
     if _is_scalar_like(lhs) and _is_scalar_like(rhs):
         if high_precision:
-            raise ValueError("pl.div: high_precision is only supported for Tensor or Tile division")
+            raise TypeError("pl.div: high_precision is only supported for Tensor or Tile division")
         return Scalar(expr=_to_scalar_expr(lhs) / _to_scalar_expr(rhs))
     _raise_type_dispatch_error("div", lhs, rhs)
 
@@ -604,8 +649,7 @@ def row_expand_add(lhs: Tile, rhs: Tile, tmp: Tile | None = None) -> Tile: ...
 def row_expand_add(lhs, rhs, tmp: Tile | None = None):
     """Row-wise broadcast addition; ``tmp`` is available only for Tile inputs."""
     if isinstance(lhs, Tensor) and isinstance(rhs, Tensor):
-        if tmp is not None:
-            raise ValueError("pl.row_expand_add: tmp is only supported for Tile inputs")
+        _reject_tmp_for_tensor("row_expand_add", tmp)
         return _tensor.row_expand_add(lhs, rhs)
     if isinstance(lhs, Tile) and isinstance(rhs, Tile):
         return _tile.row_expand_add(lhs, rhs, tmp)
@@ -808,7 +852,7 @@ def slice(
         return _tensor.slice(input, shape, offset, valid_shape, drop_dims, clamp=clamp)
     if isinstance(input, Tile):
         if clamp:
-            raise ValueError(
+            raise TypeError(
                 "pl.slice: clamp=True is not supported for a Tile. An on-chip window has no "
                 "clamping mechanism, so offset + shape must stay inside the source tile. "
                 "Clamp the read at the tensor boundary instead — pl.load(..., clamp=True) or "
@@ -1005,11 +1049,7 @@ def row_max(input, tmp_tile: Tile | None = None):
         _reject_tmp_for_tensor("row_max", tmp_tile, "tmp_tile")
         return _tensor.row_max(input)
     if isinstance(input, Tile):
-        if tmp_tile is None:
-            raise ValueError(
-                "row_max on Tile requires tmp_tile with the same dtype and rank and every dimension "
-                "at least as large as the input"
-            )
+        tmp_tile = _require_tmp_for_tile("row_max", tmp_tile, _TMP_ROW_REDUCTION_REQUIREMENT)
         return _tile.row_max(input, tmp_tile)
     raise TypeError(f"pl.row_max: expected Tensor or Tile, got {type(input).__name__}")
 
@@ -1030,11 +1070,7 @@ def row_sum(input, tmp_tile: Tile | None = None):
         _reject_tmp_for_tensor("row_sum", tmp_tile, "tmp_tile")
         return _tensor.row_sum(input)
     if isinstance(input, Tile):
-        if tmp_tile is None:
-            raise ValueError(
-                "row_sum on Tile requires tmp_tile with the same dtype and rank and every dimension "
-                "at least as large as the input"
-            )
+        tmp_tile = _require_tmp_for_tile("row_sum", tmp_tile, _TMP_ROW_REDUCTION_REQUIREMENT)
         return _tile.row_sum(input, tmp_tile)
     raise TypeError(f"pl.row_sum: expected Tensor or Tile, got {type(input).__name__}")
 
@@ -1055,11 +1091,7 @@ def row_min(input, tmp_tile: Tile | None = None):
         _reject_tmp_for_tensor("row_min", tmp_tile, "tmp_tile")
         return _tensor.row_min(input)
     if isinstance(input, Tile):
-        if tmp_tile is None:
-            raise ValueError(
-                "row_min on Tile requires tmp_tile with the same dtype and rank and every dimension "
-                "at least as large as the input"
-            )
+        tmp_tile = _require_tmp_for_tile("row_min", tmp_tile, _TMP_ROW_REDUCTION_REQUIREMENT)
         return _tile.row_min(input, tmp_tile)
     raise TypeError(f"pl.row_min: expected Tensor or Tile, got {type(input).__name__}")
 
@@ -1080,11 +1112,7 @@ def row_prod(input, tmp_tile: Tile | None = None):
         _reject_tmp_for_tensor("row_prod", tmp_tile, "tmp_tile")
         return _tensor.row_prod(input)
     if isinstance(input, Tile):
-        if tmp_tile is None:
-            raise ValueError(
-                "row_prod on Tile requires tmp_tile with the same dtype and rank and every dimension "
-                "at least as large as the input"
-            )
+        tmp_tile = _require_tmp_for_tile("row_prod", tmp_tile, _TMP_ROW_REDUCTION_REQUIREMENT)
         return _tile.row_prod(input, tmp_tile)
     raise TypeError(f"pl.row_prod: expected Tensor or Tile, got {type(input).__name__}")
 
@@ -1161,10 +1189,7 @@ def row_argmax(input, tmp_tile: Tile | None = None):
         _reject_tmp_for_tensor("row_argmax", tmp_tile, "tmp_tile")
         return _tensor.row_argmax(input)
     if isinstance(input, Tile):
-        if tmp_tile is None:
-            raise ValueError(
-                "row_argmax on Tile requires tmp_tile with exactly the same shape and dtype as the input"
-            )
+        tmp_tile = _require_tmp_for_tile("row_argmax", tmp_tile, _TMP_ROW_ARG_REDUCTION_REQUIREMENT)
         return _tile.row_argmax(input, tmp_tile)
     raise TypeError(f"pl.row_argmax: expected Tensor or Tile, got {type(input).__name__}")
 
@@ -1184,10 +1209,7 @@ def row_argmin(input, tmp_tile: Tile | None = None):
         _reject_tmp_for_tensor("row_argmin", tmp_tile, "tmp_tile")
         return _tensor.row_argmin(input)
     if isinstance(input, Tile):
-        if tmp_tile is None:
-            raise ValueError(
-                "row_argmin on Tile requires tmp_tile with exactly the same shape and dtype as the input"
-            )
+        tmp_tile = _require_tmp_for_tile("row_argmin", tmp_tile, _TMP_ROW_ARG_REDUCTION_REQUIREMENT)
         return _tile.row_argmin(input, tmp_tile)
     raise TypeError(f"pl.row_argmin: expected Tensor or Tile, got {type(input).__name__}")
 
@@ -1206,8 +1228,7 @@ def col_argmax(input, tmp_tile: Tile | None = None):
         _reject_tmp_for_tensor("col_argmax", tmp_tile, "tmp_tile")
         return _tensor.col_argmax(input)
     if isinstance(input, Tile):
-        if tmp_tile is None:
-            raise ValueError("col_argmax on Tile requires tmp_tile argument")
+        tmp_tile = _require_tmp_for_tile("col_argmax", tmp_tile, _TMP_COL_ARG_REDUCTION_REQUIREMENT)
         return _tile.col_argmax(input, tmp_tile)
     raise TypeError(f"pl.col_argmax: expected Tensor or Tile, got {type(input).__name__}")
 
@@ -1226,8 +1247,7 @@ def col_argmin(input, tmp_tile: Tile | None = None):
         _reject_tmp_for_tensor("col_argmin", tmp_tile, "tmp_tile")
         return _tensor.col_argmin(input)
     if isinstance(input, Tile):
-        if tmp_tile is None:
-            raise ValueError("col_argmin on Tile requires tmp_tile argument")
+        tmp_tile = _require_tmp_for_tile("col_argmin", tmp_tile, _TMP_COL_ARG_REDUCTION_REQUIREMENT)
         return _tile.col_argmin(input, tmp_tile)
     raise TypeError(f"pl.col_argmin: expected Tensor or Tile, got {type(input).__name__}")
 
@@ -1267,8 +1287,10 @@ def cast(
     if isinstance(input, Tile):
         return _tile.cast(input, target_type, mode)
     if _is_scalar_like(input):
+        # ``resolve_cast_mode`` runs first, so an invalid mode is still a ValueError;
+        # only a *valid* mode this path cannot honour reaches the TypeError below.
         if resolve_cast_mode(mode) != 2:
-            raise ValueError(f"cast: Scalar inputs do not support non-default mode, got mode={mode!r}")
+            raise TypeError(f"pl.cast: Scalar inputs do not support non-default mode, got mode={mode!r}")
         dtype = DataType(target_type) if isinstance(target_type, int) else target_type
         return Scalar(expr=_ir_core.cast(_to_scalar_expr(input), dtype))
     raise TypeError(f"pl.cast: expected Tensor, Tile, or Scalar, got {type(input).__name__}")
@@ -1376,11 +1398,7 @@ def xor(lhs, rhs, tmp=None):
         _reject_tmp_for_tensor("xor", tmp)
         return _tensor.xor(lhs, rhs)
     if isinstance(lhs, Tile):
-        if tmp is None:
-            raise TypeError(
-                "pl.xor: Tile inputs require an explicit scratch tile — "
-                "call pl.xor(lhs, rhs, tmp) or pl.tile.xor(lhs, rhs, tmp)"
-            )
+        tmp = _require_tmp_for_tile("xor", tmp, _tmp_scratch_requirement("xor"))
         if isinstance(rhs, Tile):
             return _tile.xor(lhs, rhs, tmp)
         if _is_scalar_like(rhs):
@@ -1401,11 +1419,7 @@ def xors(lhs, rhs, tmp=None):
         _reject_tmp_for_tensor("xors", tmp)
         return _tensor.xors(lhs, rhs)
     if isinstance(lhs, Tile):
-        if tmp is None:
-            raise TypeError(
-                "pl.xors: Tile inputs require an explicit scratch tile — "
-                "call pl.xors(lhs, rhs, tmp) or pl.tile.xors(lhs, rhs, tmp)"
-            )
+        tmp = _require_tmp_for_tile("xors", tmp, _tmp_scratch_requirement("xors"))
         return _tile.xors(lhs, rhs, tmp)
     _raise_type_dispatch_error("xors", lhs, rhs)
 

--- a/tests/ut/ir/operators/test_tensor_ops.py
+++ b/tests/ut/ir/operators/test_tensor_ops.py
@@ -1493,7 +1493,7 @@ def test_tensor_div_precision_kwarg_and_scalar_dispatch():
     assert dict(high_precision_call.kwargs) == {"high_precision": True}
     assert scalar_call.op.name == ir.get_op("tensor.divs").name
     assert dict(scalar_call.kwargs) == {}
-    with pytest.raises(ValueError, match=r"requires a Tensor rhs"):
+    with pytest.raises(TypeError, match=r"requires a Tensor rhs"):
         ir.op.tensor.div(lhs, 2.0, high_precision=True)
 
 

--- a/tests/ut/ir/operators/test_tile_ops.py
+++ b/tests/ut/ir/operators/test_tile_ops.py
@@ -163,7 +163,7 @@ class TestTileElementwiseOps:
         assert dict(high_precision_call.kwargs) == {"high_precision": True}
         assert scalar_call.op.name == ir.get_op("tile.divs").name
         assert dict(scalar_call.kwargs) == {}
-        with pytest.raises(ValueError, match=r"requires a Tile rhs"):
+        with pytest.raises(TypeError, match=r"requires a Tile rhs"):
             tile.div(lhs, 2.0, high_precision=True)
 
     def test_tile_div_rejects_integer_high_precision_template_gap(self):
@@ -5903,7 +5903,7 @@ class TestWindowReadValidRegion:
 
         # And the DSL rejects the flag itself rather than silently dropping it.
         tile_arg = pl.Tile(expr=src)
-        with pytest.raises(ValueError, match="clamp=True is not supported for a Tile"):
+        with pytest.raises(TypeError, match="clamp=True is not supported for a Tile"):
             pl.slice(tile_arg, [64, 64], [64, 0], clamp=True)
 
     def test_slice_drop_dims_rejected_when_axis_is_not_provably_valid(self):

--- a/tests/ut/language/test_unified_ops.py
+++ b/tests/ut/language/test_unified_ops.py
@@ -1377,7 +1377,7 @@ class TestUnifiedOpsTypeErrors:
         rhs = Tensor(expr=ir.Var("rhs", ir.TensorType([8, 1], DataType.FP32), span))
         tmp = Tile(expr=ir.Var("tmp", ir.TileType([8, 8], DataType.FP32), span))
 
-        with pytest.raises(ValueError, match="tmp is only supported for Tile"):
+        with pytest.raises(TypeError, match="Tensor inputs must not pass tmp"):
             unified_ops.row_expand_add(lhs, rhs, tmp)  # type: ignore[call-overload]
 
     def test_div_rejects_high_precision_for_scalar_paths(self):
@@ -1398,8 +1398,57 @@ class TestUnifiedOpsTypeErrors:
         ]
 
         for lhs, rhs in cases:
-            with pytest.raises(ValueError, match="high_precision"):
+            with pytest.raises(TypeError, match="high_precision"):
                 unified_ops.div(lhs, rhs, high_precision=True)  # type: ignore[call-overload]
+
+    @pytest.mark.parametrize(
+        "op_name",
+        [
+            "row_max",
+            "row_sum",
+            "row_min",
+            "row_prod",
+            "row_argmax",
+            "row_argmin",
+            "col_argmax",
+            "col_argmin",
+        ],
+    )
+    def test_reduction_requires_tmp_tile_for_tile_inputs(self, op_name):
+        """The scratch operand the Tensor path must omit is the one the Tile path must get.
+
+        Both directions raise ``TypeError``: a Tile cannot synthesize caller-owned
+        scratch, so omitting it is a wrong-arguments error, not a bad value.
+        """
+        span = ir.Span.unknown()
+        tile = Tile(expr=ir.Var("input", ir.TileType([8, 64], DataType.FP32), span))
+
+        with pytest.raises(TypeError, match="Tile inputs require tmp_tile"):
+            getattr(unified_ops, op_name)(tile)
+
+    @pytest.mark.parametrize("op_name", ["xor", "xors"])
+    def test_bitwise_requires_scratch_tile_for_tile_inputs(self, op_name):
+        """Same guard as the reductions, for the ops whose scratch operand is positional."""
+        span = ir.Span.unknown()
+        lhs = Tile(expr=ir.Var("lhs", ir.TileType([8, 64], DataType.INT32), span))
+
+        with pytest.raises(TypeError, match="Tile inputs require an explicit scratch tile"):
+            getattr(unified_ops, op_name)(lhs, 1)
+
+    def test_cast_rejects_non_default_mode_for_scalar(self):
+        """A *valid* mode the Scalar path cannot honour is a TypeError...
+
+        ...while a mode that is not a mode at all stays a ValueError from
+        ``resolve_cast_mode``, which runs first.
+        """
+        span = ir.Span.unknown()
+        scalar = Scalar(expr=ir.Var("s", ir.ScalarType(DataType.FP32), span))
+
+        with pytest.raises(TypeError, match="Scalar inputs do not support non-default mode"):
+            unified_ops.cast(scalar, DataType.INT32, mode="floor")
+
+        with pytest.raises(ValueError, match="Invalid rounding mode"):
+            unified_ops.cast(scalar, DataType.INT32, mode="not_a_mode")
 
     def test_matmul_invalid_lhs(self):
         with pytest.raises(TypeError, match="expected Tensor or Tile operands"):


### PR DESCRIPTION
## Summary

The unified `pl.*` wrappers accept the union of both dispatch levels' arguments, so a guard must reject any argument only the other path can honour rather than drop it. Those guards disagreed on which exception they raised. The shared `_reject_tmp_for_tensor` / `_reject_tile_unsupported` helpers raised `TypeError`, while five cross-path guards raised `ValueError` — and the mirror-image "Tile path requires a scratch operand" guards were split the same way, with eight reductions raising `ValueError` and `xor` / `xors` raising `TypeError` for the identical condition, inside the same functions that already raised `TypeError` for the Tensor direction.

The result was that `pl.rsqrt(tile, high_precision=True)` raised `TypeError` while `pl.div(tile, 2.0, high_precision=True)` raised `ValueError`, and `pl.row_max` raised `TypeError` when a Tensor passed `tmp_tile` but `ValueError` when a Tile omitted it. A caller writing `except TypeError` caught only half of them.

Every argument guard now raises `TypeError`, in both directions: an argument the dispatched path cannot honour, and one it requires but did not get. Both are wrong-arguments-for-this-overload errors — the class CPython itself raises for an unexpected keyword or a missing required argument.

Deeper validation still raises `ValueError`, because `pypto::ValueError` from a C++ `CHECK` is registered as a Python `ValueError` subclass. That floor is unchanged and is now documented: the remaining split marks *which layer* rejected the call rather than which guard happened to be written first, so `pl.slice(tile, ..., clamp=True)` raises `TypeError` while an out-of-bounds `pl.slice(tile, ...)` raises `ValueError`. Code guarding a whole call should catch both.

**Behavior change:** this changes the exception type of a public API. Callers catching `ValueError` around the five cross-path guards or the eight reduction scratch guards must catch `TypeError` instead. The DSL path is unaffected — the parser already catches both and re-raises `InvalidOperationError` with a span, so nothing changes inside a `@pl.function` body. No message text changes except the `pl.` prefix added to `cast` and to the reduction scratch guards, which lets the parser surface them without falling back to its generic prefix. No migration step beyond the `except` clause; no follow-up work implied.

## Changes

- `python/pypto/language/op/unified_ops.py`: five cross-path guards move to `TypeError` — `div`'s `high_precision` on the Tile+scalar and scalar+scalar paths, `slice`'s `clamp=True` on a Tile, `cast`'s non-default `mode` on a Scalar, and `row_expand_add`'s `tmp` on a Tensor, which now routes through the existing `_reject_tmp_for_tensor` instead of duplicating it. An invalid `cast` mode is still a `ValueError` from `resolve_cast_mode`, which runs first.
- `python/pypto/language/op/unified_ops.py`: new `_require_tmp_for_tile` mirrors `_reject_tmp_for_tensor` and replaces ten hand-written raises across the eight reductions plus `xor` / `xors`. It returns the operand so call sites keep the non-`None` narrowing the inline `is None` check gave them, and three shared requirement constants replace the copy-pasted message text.
- `python/pypto/ir/op/tensor_ops.py`, `python/pypto/ir/op/tile_ops.py`: the same `high_precision`-needs-a-matching-rhs guard one layer down moves to `TypeError`. Without this, `pl.div` would still report two different types depending on which operand level dispatched, since the Tensor path reaches this guard for a scalar rhs.
- `docs/en/dev/language/00-python_syntax.md`, `docs/zh/dev/language/00-python_syntax.md`: document the guard contract, the `ValueError` floor beneath it, and that the distinction is invisible inside a `@pl.function` body. Every exception type shown in the new examples was executed and confirmed rather than assumed.
- `tests/ut/language/test_unified_ops.py`, `tests/ut/ir/operators/test_tile_ops.py`, `tests/ut/ir/operators/test_tensor_ops.py`: retype five assertions and add coverage the scratch-operand guards never had — all eight reductions, `xor` / `xors`, and `cast`'s Scalar-mode guard, including the `ValueError` that a genuinely invalid mode still raises.

## Verification

Run at the pushed head (`43c4a857`), after rebase onto `upstream/main`:

- `cmake --build build --parallel`: passed
- `python -m pytest` on the three touched test files: passed
- `python -m pytest tests/ut/ -n auto`: 9434 passed, 3 skipped
- `pre-commit run --files <the eight changed paths>`: passed — `ruff check`, `ruff format`, `pyright`, `markdownlint-cli2`, `check-headers`, `check-english-only`, `check-docs-en-zh-parity`, `check-docs-nav`, `check-docs-symbol-coverage`, `check-no-broad-raises`, `check-op-name-literals`