### PR TITLE
docs(user): make manual examples actually write their outputs

### DIFF
--- a/docs/en/user/02-quickstart.md
+++ b/docs/en/user/02-quickstart.md
@@ -44,7 +44,7 @@ def add(
     out: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
 ):
     with pl.at(level=pl.Level.CORE_GROUP):
-        out = pl.add(a, b)
+        out = pl.assemble(out, pl.add(a, b), [0, 0])
     return out
 
 compiled = add.compile()
@@ -91,7 +91,7 @@ def add_then_square(
 ):
     with pl.at(level=pl.Level.CORE_GROUP):
         s = pl.add(a, b)
-        out = pl.mul(s, s)
+        out = pl.assemble(out, pl.mul(s, s), [0, 0])
     return out
 ```
 
@@ -115,7 +115,7 @@ def accumulate(
         t = pl.add(a, a)
         for i in pl.range(3):
             t = pl.add(t, a)      # carried across iterations
-        out = pl.mul(t, t)
+        out = pl.assemble(out, pl.mul(t, t), [0, 0])
     return out
 ```
 
@@ -143,7 +143,7 @@ def add_kernel(
     b: pl.Tensor[[128, 128], pl.FP32],
     out: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
 ):
-    out = pl.add(a, b)
+    out = pl.assemble(out, pl.add(a, b), [0, 0])
     return out
 
 @pl.jit

--- a/docs/en/user/03-programming-model.md
+++ b/docs/en/user/03-programming-model.md
@@ -40,7 +40,7 @@ def square_tensor(
     out: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
 ):
     # Tensor level: name the whole array. Placement and movement are the compiler's.
-    out = pl.mul(x, x)
+    out = pl.assemble(out, pl.mul(x, x), [0, 0])
     return out
 
 @pl.jit.incore

--- a/docs/en/user/language/01-functions.md
+++ b/docs/en/user/language/01-functions.md
@@ -35,7 +35,7 @@ def add_kernel(
     b: pl.Tensor[[128, 128], pl.FP32],
     out: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
 ):
-    out = pl.add(a, b)
+    out = pl.assemble(out, pl.add(a, b), [0, 0])
     return out
 
 @pl.jit
@@ -122,13 +122,13 @@ move them into a `@pl.jit.incore` sub-function.
 ```python
 @pl.jit
 def bad(x: pl.Tensor[[64, 64], pl.FP32], out: pl.Out[pl.Tensor[[64, 64], pl.FP32]]):
-    out = pl.add(x, x)        # ✗ Misplaced tensor op ... should be inside InCore block
+    out = pl.assemble(out, pl.add(x, x), [0, 0])        # ✗ Misplaced tensor op ... should be inside InCore block
     return out
 
 @pl.jit
 def good(x: pl.Tensor[[64, 64], pl.FP32], out: pl.Out[pl.Tensor[[64, 64], pl.FP32]]):
     with pl.at(level=pl.Level.CORE_GROUP):
-        out = pl.add(x, x)    # ✓
+        out = pl.assemble(out, pl.add(x, x), [0, 0])    # ✓
     return out
 ```
 

--- a/docs/en/user/language/02-control-flow.md
+++ b/docs/en/user/language/02-control-flow.md
@@ -48,7 +48,7 @@ def accumulate(
         t = pl.add(a, a)
         for i in pl.range(3):
             t = pl.add(t, a)      # carried across iterations
-        out = pl.mul(t, t)
+        out = pl.assemble(out, pl.mul(t, t), [0, 0])
     return out
 ```
 

--- a/docs/en/user/language/04-scopes.md
+++ b/docs/en/user/language/04-scopes.md
@@ -40,7 +40,7 @@ def scale(
     out: pl.Out[pl.Tensor[[256, 128], pl.FP32]],
 ):
     with pl.at(level=pl.Level.CORE_GROUP):
-        out = pl.mul(x, 2.0)
+        out = pl.assemble(out, pl.mul(x, 2.0), [0, 0])
     return out
 ```
 

--- a/docs/en/user/language/05-directives.md
+++ b/docs/en/user/language/05-directives.md
@@ -26,7 +26,7 @@ def probe(x: pl.Tensor[[64, 128], pl.FP32],
           out: pl.Out[pl.Tensor[[64, 128], pl.FP32]]):
     pl.static_print("x =", x)                      # prints at parse time
     pl.static_assert(x.shape[1] == 128, "expected 128 columns")
-    out = pl.mul(x, 2.0)
+    out = pl.assemble(out, pl.mul(x, 2.0), [0, 0])
     return out
 ```
 

--- a/docs/en/user/language/06-syntax.md
+++ b/docs/en/user/language/06-syntax.md
@@ -27,7 +27,7 @@ import pypto.language as pl
 def head(x: pl.Tensor[[128, 64], pl.FP32],
          out: pl.Out[pl.Tensor[[16, 64], pl.FP32]]):
     top = x[0:16, :]              # sugar for pl.slice(x, [16, 64], [0, 0])
-    out = pl.mul(top, 2.0)        # sugar-free: an explicit operator call
+    out = pl.assemble(out, pl.mul(top, 2.0), [0, 0])        # sugar-free: an explicit operator call
     return out
 ```
 

--- a/docs/en/user/tasks/00-model.md
+++ b/docs/en/user/tasks/00-model.md
@@ -29,8 +29,8 @@ That leads to the property this whole chapter exists for:
 import pypto.language as pl
 
 @pl.jit.incore
-def double(x: pl.Tensor[[256, 128], pl.FP32], out: pl.Out[pl.Tensor[[256, 128], pl.FP32]]):
-    out = pl.add(x, x)
+def twice(x: pl.Tensor[[256, 128], pl.FP32], out: pl.Out[pl.Tensor[[256, 128], pl.FP32]]):
+    out = pl.assemble(out, pl.add(x, x), [0, 0])
     return out
 
 @pl.jit
@@ -39,8 +39,8 @@ def two_stage(
     scratch: pl.Out[pl.Tensor[[256, 128], pl.FP32]],
     out: pl.Out[pl.Tensor[[256, 128], pl.FP32]],
 ):
-    scratch = double(x, scratch)        # writes scratch
-    out = double(scratch, out)          # reads scratch  -> ordered after the write
+    scratch = twice(x, scratch)        # writes scratch
+    out = twice(scratch, out)          # reads scratch  -> ordered after the write
     return scratch, out
 ```
 

--- a/docs/en/user/tasks/02-submit.md
+++ b/docs/en/user/tasks/02-submit.md
@@ -41,9 +41,9 @@ def two_stage(
     out: pl.Out[pl.Tensor[[256, 128], pl.FP32]],
 ):
     with pl.at(level=pl.Level.CORE_GROUP) as first:
-        scratch = pl.add(x, x)
+        scratch = pl.assemble(scratch, pl.add(x, x), [0, 0])
     with pl.at(level=pl.Level.CORE_GROUP, deps=[first]) as second:
-        out = pl.add(scratch, scratch)
+        out = pl.assemble(out, pl.add(scratch, scratch), [0, 0])
     return scratch, out
 ```
 

--- a/docs/zh/user/02-quickstart.md
+++ b/docs/zh/user/02-quickstart.md
@@ -39,7 +39,7 @@ def add(
     out: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
 ):
     with pl.at(level=pl.Level.CORE_GROUP):
-        out = pl.add(a, b)
+        out = pl.assemble(out, pl.add(a, b), [0, 0])
     return out
 
 compiled = add.compile()
@@ -84,7 +84,7 @@ def add_then_square(
 ):
     with pl.at(level=pl.Level.CORE_GROUP):
         s = pl.add(a, b)
-        out = pl.mul(s, s)
+        out = pl.assemble(out, pl.mul(s, s), [0, 0])
     return out
 ```
 
@@ -105,7 +105,7 @@ def accumulate(
         t = pl.add(a, a)
         for i in pl.range(3):
             t = pl.add(t, a)      # 跨迭代携带
-        out = pl.mul(t, t)
+        out = pl.assemble(out, pl.mul(t, t), [0, 0])
     return out
 ```
 
@@ -131,7 +131,7 @@ def add_kernel(
     b: pl.Tensor[[128, 128], pl.FP32],
     out: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
 ):
-    out = pl.add(a, b)
+    out = pl.assemble(out, pl.add(a, b), [0, 0])
     return out
 
 @pl.jit

--- a/docs/zh/user/03-programming-model.md
+++ b/docs/zh/user/03-programming-model.md
@@ -32,7 +32,7 @@ def square_tensor(
     out: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
 ):
     # 张量级：命名整个数组。放置与搬运是编译器的事。
-    out = pl.mul(x, x)
+    out = pl.assemble(out, pl.mul(x, x), [0, 0])
     return out
 
 @pl.jit.incore

--- a/docs/zh/user/language/01-functions.md
+++ b/docs/zh/user/language/01-functions.md
@@ -23,7 +23,7 @@ def add_kernel(
     b: pl.Tensor[[128, 128], pl.FP32],
     out: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
 ):
-    out = pl.add(a, b)
+    out = pl.assemble(out, pl.add(a, b), [0, 0])
     return out
 
 @pl.jit
@@ -99,13 +99,13 @@ def host_orch(
 ```python
 @pl.jit
 def bad(x: pl.Tensor[[64, 64], pl.FP32], out: pl.Out[pl.Tensor[[64, 64], pl.FP32]]):
-    out = pl.add(x, x)        # ✗ Misplaced tensor op ... should be inside InCore block
+    out = pl.assemble(out, pl.add(x, x), [0, 0])        # ✗ Misplaced tensor op ... should be inside InCore block
     return out
 
 @pl.jit
 def good(x: pl.Tensor[[64, 64], pl.FP32], out: pl.Out[pl.Tensor[[64, 64], pl.FP32]]):
     with pl.at(level=pl.Level.CORE_GROUP):
-        out = pl.add(x, x)    # ✓
+        out = pl.assemble(out, pl.add(x, x), [0, 0])    # ✓
     return out
 ```
 

--- a/docs/zh/user/language/02-control-flow.md
+++ b/docs/zh/user/language/02-control-flow.md
@@ -38,7 +38,7 @@ def accumulate(
         t = pl.add(a, a)
         for i in pl.range(3):
             t = pl.add(t, a)      # carried across iterations
-        out = pl.mul(t, t)
+        out = pl.assemble(out, pl.mul(t, t), [0, 0])
     return out
 ```
 

--- a/docs/zh/user/language/04-scopes.md
+++ b/docs/zh/user/language/04-scopes.md
@@ -32,7 +32,7 @@ def scale(
     out: pl.Out[pl.Tensor[[256, 128], pl.FP32]],
 ):
     with pl.at(level=pl.Level.CORE_GROUP):
-        out = pl.mul(x, 2.0)
+        out = pl.assemble(out, pl.mul(x, 2.0), [0, 0])
     return out
 ```
 

--- a/docs/zh/user/language/05-directives.md
+++ b/docs/zh/user/language/05-directives.md
@@ -22,7 +22,7 @@ def probe(x: pl.Tensor[[64, 128], pl.FP32],
           out: pl.Out[pl.Tensor[[64, 128], pl.FP32]]):
     pl.static_print("x =", x)                      # prints at parse time
     pl.static_assert(x.shape[1] == 128, "expected 128 columns")
-    out = pl.mul(x, 2.0)
+    out = pl.assemble(out, pl.mul(x, 2.0), [0, 0])
     return out
 ```
 

--- a/docs/zh/user/language/06-syntax.md
+++ b/docs/zh/user/language/06-syntax.md
@@ -23,7 +23,7 @@ import pypto.language as pl
 def head(x: pl.Tensor[[128, 64], pl.FP32],
          out: pl.Out[pl.Tensor[[16, 64], pl.FP32]]):
     top = x[0:16, :]              # sugar for pl.slice(x, [16, 64], [0, 0])
-    out = pl.mul(top, 2.0)        # sugar-free: an explicit operator call
+    out = pl.assemble(out, pl.mul(top, 2.0), [0, 0])        # sugar-free: an explicit operator call
     return out
 ```
 

--- a/docs/zh/user/tasks/00-model.md
+++ b/docs/zh/user/tasks/00-model.md
@@ -20,8 +20,8 @@
 import pypto.language as pl
 
 @pl.jit.incore
-def double(x: pl.Tensor[[256, 128], pl.FP32], out: pl.Out[pl.Tensor[[256, 128], pl.FP32]]):
-    out = pl.add(x, x)
+def twice(x: pl.Tensor[[256, 128], pl.FP32], out: pl.Out[pl.Tensor[[256, 128], pl.FP32]]):
+    out = pl.assemble(out, pl.add(x, x), [0, 0])
     return out
 
 @pl.jit
@@ -30,8 +30,8 @@ def two_stage(
     scratch: pl.Out[pl.Tensor[[256, 128], pl.FP32]],
     out: pl.Out[pl.Tensor[[256, 128], pl.FP32]],
 ):
-    scratch = double(x, scratch)        # writes scratch
-    out = double(scratch, out)          # reads scratch  -> ordered after the write
+    scratch = twice(x, scratch)        # writes scratch
+    out = twice(scratch, out)          # reads scratch  -> ordered after the write
     return scratch, out
 ```
 

--- a/docs/zh/user/tasks/02-submit.md
+++ b/docs/zh/user/tasks/02-submit.md
@@ -32,9 +32,9 @@ def two_stage(
     out: pl.Out[pl.Tensor[[256, 128], pl.FP32]],
 ):
     with pl.at(level=pl.Level.CORE_GROUP) as first:
-        scratch = pl.add(x, x)
+        scratch = pl.assemble(scratch, pl.add(x, x), [0, 0])
     with pl.at(level=pl.Level.CORE_GROUP, deps=[first]) as second:
-        out = pl.add(scratch, scratch)
+        out = pl.assemble(out, pl.add(scratch, scratch), [0, 0])
     return scratch, out
 ```
 


### PR DESCRIPTION
## The defect

Every complete example in the user manual wrote its result like this:

```python
with pl.at(level=pl.Level.CORE_GROUP):
    out = pl.add(a, b)      # compiles clean, writes nothing
```

This compiles without a warning and **leaves the output buffer as uninitialised memory**. A reader who copies the manual's very first example gets `NaN`, with no diagnostic from the parser, the passes, codegen, ptoas, or the runtime.

Writing an output tensor requires `pl.assemble` (tensor level) or `pl.store` (tile level). That is what all 184 write sites under `examples/` already do (`pl.store` ×156, `pl.assemble` ×28 — zero bare assignments), and what `docs/en/dev/language/00-python_syntax.md` describes ("a captured tensor that the scope body mutates via `pl.assemble`").

## Scope

15 assignments in EN, mirrored in ZH — 18 files, 36 lines. Present in every batch of the manual:

| Page | Sites |
| ---- | ----- |
| `02-quickstart.md` | 4 |
| `03-programming-model.md` | 1 |
| `language/01-functions.md` | 3 |
| `language/02-control-flow.md`, `04-scopes.md`, `05-directives.md`, `06-syntax.md` | 1 each |
| `tasks/00-model.md` | 1 |
| `tasks/02-submit.md` | 2 |

Also renames `tasks/00-model.md`'s kernel from `double` to `twice`. `double` is a C++ keyword, so codegen emitted `static __aicore__ void double(__gm__ float* v1, ...)` and device compilation died with `error: expected unqualified-id before 'float'` — an error that names neither the kernel nor the real cause.

## Why review missed it

Example verification only **compiled** each block. Compiling proves the DSL parses; it says nothing about whether the kernel writes its output. Both defects compile cleanly.

Verification now **runs** every complete example on `a2a3sim` and asserts each `pl.Out` buffer is neither NaN nor still all-zero:

```
11 runnable example(s), 0 failed
```

Distributed and dynamic-shape examples are skipped (they need multi-rank setup; the CI distributed job covers them). The misplaced-operator counter-example in `language/01-functions.md` was re-checked and still fails as the page claims.

## Checks

- 11/11 runnable examples execute correctly on the simulator (previously 10 of them produced NaN)
- `check_docs_symbol_coverage` / `check_docs_en_zh_parity` / `check_docs_nav` / `check_english_only`: exit 0
- markdownlint: 0 errors