### PR TITLE
fix(codegen): preserve shared tile buffer definition types

### DIFF
--- a/src/codegen/pto/pto_codegen.cpp
+++ b/src/codegen/pto/pto_codegen.cpp
@@ -2048,15 +2048,6 @@ void PTOCodegen::VisitStmt_(const AssignStmtPtr& op) {
       if (!fs_.current_result_buf.empty() && (is_set_validshape || fs_.current_result_buf != result_buf)) {
         BindVarToMlir(op->var_, fs_.current_result_buf);
       }
-      // Register per-variable tile_buf type from the variable's own TileType.
-      // This ensures that even when multiple variables share a MemRef, each
-      // variable's SSA value carries its correct typed annotation.
-      if (result_tile_type && !fs_.current_result_buf.empty() && fs_.current_result_buf == result_buf) {
-        std::string var_type_str = GetTileBufTypeStringFromTileType(result_tile_type);
-        if (!var_type_str.empty()) {
-          fs_.ssa_to_tile_buf_type[fs_.current_result_buf] = var_type_str;
-        }
-      }
       fs_.current_result_var.reset();
       fs_.current_result_buf.clear();
       fs_.current_result_tile_type = nullptr;

--- a/tests/ut/codegen/test_ptoas_planner_views.py
+++ b/tests/ut/codegen/test_ptoas_planner_views.py
@@ -70,6 +70,11 @@ def _sole_line(mlir: str, needle: str) -> str:
     return strip_loc(lines[0])
 
 
+def _tile_buf_types(op_line: str) -> list[str]:
+    """Return every tile_buf type annotation carried by one PTO operation."""
+    return re.findall(r"!pto\.tile_buf<[^>]+>", op_line)
+
+
 # ── reserve_buffer: base resolution deferred to ptoas ────────────────────────
 
 
@@ -134,7 +139,49 @@ def test_reserve_buffer_bakes_resolved_base_under_pypto_planner(planner):
         assert "base = 0" in line, line
 
 
-# ── reshape of a subview: def/use tile_buf types must agree ──────────────────
+# Shared in-place handle: the definition type is immutable
+
+
+@pl.program
+class InplaceFillPadProgram:
+    """Fill a dynamically valid tile in place, then consume its shared handle."""
+
+    @pl.function(type=pl.FunctionType.InCore)
+    def kernel(
+        self,
+        x: pl.Tensor[[16, 16], pl.FP32],
+        valid_rows: pl.Scalar[pl.INDEX],
+        valid_cols: pl.Scalar[pl.INDEX],
+        out: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+    ) -> pl.Tensor[[16, 16], pl.FP32]:
+        src: pl.Tile[[16, 16], pl.FP32] = pl.load(x, [0, 0], [16, 16], valid_shape=[valid_rows, valid_cols])
+        padded: pl.Tile[[16, 16], pl.FP32] = pl.tile.fillpad_inplace(src, pad_value=0)
+        return pl.store(padded, [0, 0], out)
+
+
+def test_inplace_alias_keeps_shared_handle_definition_type():
+    """An alias result must not re-type the already-defined shared tile_buf SSA.
+
+    PTOAS mode collapses ``src`` and ``padded`` onto one handle because
+    ``tile.fillpad_inplace`` reuses its input MemRef. The result TileType carries
+    new pad metadata, but MLIR SSA types are fixed by the original alloc_tile
+    definition, so every later use of that handle must retain the definition's
+    annotation.
+    """
+    mlir = _emit_pto(InplaceFillPadProgram, passes.MemoryPlanner.PTOAS)
+    alloc = _sole_line(mlir, "= pto.alloc_tile")
+    fillpad = _sole_line(mlir, "pto.tfillpad")
+    store = _sole_line(mlir, "pto.tstore")
+
+    alloc_types = _tile_buf_types(alloc)
+    fillpad_types = _tile_buf_types(fillpad)
+    store_types = _tile_buf_types(store)
+    assert len(alloc_types) == 1 and len(fillpad_types) == 2 and len(store_types) == 1, mlir
+    assert fillpad_types == [alloc_types[0], alloc_types[0]], f"{alloc}\n{fillpad}"
+    assert store_types == alloc_types, f"{alloc}\n{store}"
+
+
+# Reshape of a subview: def/use tile_buf types must agree
 
 PAD, VALID, D = 16, 5, 128
 


### PR DESCRIPTION
## Summary

Preserve the MLIR definition type of `tile_buf` handles shared by alias variables under the PTOAS memory planner. Previously, assignment codegen re-registered the alias variable's `TileType` after emitting an in-place operation, so later consumers could annotate one SSA handle with a type different from its `pto.alloc_tile` definition.

## Changes

- stop overwriting an already-defined result handle's recorded `tile_buf` type after PTO operation emission
- add an in-place `fillpad` regression that verifies alloc, fillpad, and store annotations use the same shared handle type

## Verification

- CMake build
- `tests/ut/codegen/test_ptoas_planner_views.py`: 17 passed
- `tests/ut/codegen/`: 850 passed, 2 skipped
- `ruff check`
- `ruff format --check`
- `clang-format --dry-run --Werror src/codegen/pto/pto_codegen.cpp`
- `git diff --check`