### PR TITLE
Advance the Simpler pin onto the Buffer device-memory API (port, not a bump)

### DIFF
--- a/python/pypto/backend/pto_backend.py
+++ b/python/pypto/backend/pto_backend.py
@@ -497,7 +497,7 @@ def _generate_arg_unpacking(func: _ir_core.Function, *, uses_spmd: bool = False)
         assert isinstance(param.type, _ir_core.TensorType)
         c_type = param.type.dtype.to_c_type_string()
         lines.append(f"    // Unpack tensor: {param_name}")
-        lines.append(f"    __gm__ Tensor* {param_name}_tensor = reinterpret_cast<__gm__ Tensor*>(args[{i}]);")
+        lines.append(f"    __gm__ ChipTensor* {param_name}_tensor = reinterpret_cast<__gm__ ChipTensor*>(args[{i}]);")
         if param_name == "__gm_pipe_buffer" and uses_spmd:
             lines.append("    // SPMD: shard GM pipe workspace by logical block_idx to avoid overlap.")
             lines.append("    int64_t __pypto_gm_block_num = static_cast<int64_t>(__pypto_spmd_block_num);")

--- a/python/pypto/runtime/_buffer_bridge.py
+++ b/python/pypto/runtime/_buffer_bridge.py
@@ -1,0 +1,151 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Shared plumbing for naming device memory to Simpler's Buffer-based APIs.
+
+pypto's public surface hands out integer device pointers (``DeviceTensor.data_ptr``),
+while Simpler's device-memory and task-arg APIs take ``Buffer`` objects. Both worker
+levels therefore need the same three things, and they need to agree:
+
+* a registry from ``(worker_id, ptr)`` back to the allocating ``Buffer`` — the pointer
+  alone cannot be re-wrapped, because a Buffer carries the identity a consumer keys on;
+* a POSIX-shm staging Buffer for host memory that a copy cannot name directly;
+* one conversion from :class:`DeviceTensor` to a wire ``Tensor``.
+
+L2 and L3 differ only in *how* they allocate (``malloc`` on a leaf worker vs
+``alloc_child_tensor`` on a chip worker), so only that part stays in each subclass.
+Keeping the rest here is what stops the two levels from drifting apart.
+"""
+
+from typing import Any
+
+
+class BufferBridge:
+    """Mixin: Buffer registry, shm staging, and DeviceTensor → wire ``Tensor``."""
+
+    def _init_buffer_bridge(self) -> None:
+        self._device_buffers: dict[tuple[int, int], Any] = {}
+        self._staging_buffers: dict[tuple[int, int], Any] = {}
+
+    # ------------------------------------------------------------------
+    # Device-buffer registry
+    # ------------------------------------------------------------------
+
+    def _register_device_buffer(self, worker_id: int, ptr: int, handle: Any) -> None:
+        self._device_buffers[(int(worker_id), int(ptr))] = handle
+
+    def _device_buffer_for(self, ptr: int, worker_id: int, api: str) -> Any:
+        handle = self._device_buffers.get((int(worker_id), int(ptr)))
+        if handle is None:
+            raise ValueError(f"{api}: 0x{int(ptr):x} was not allocated on worker {int(worker_id)} by this Worker")
+        return handle
+
+    def _pop_device_buffer(self, ptr: int, worker_id: int, api: str) -> Any:
+        handle = self._device_buffers.pop((int(worker_id), int(ptr)), None)
+        if handle is None:
+            raise ValueError(f"{api}: 0x{int(ptr):x} was not allocated on worker {int(worker_id)} by this Worker")
+        return handle
+
+    # ------------------------------------------------------------------
+    # Host staging
+    # ------------------------------------------------------------------
+
+    def _staging_buffer(self, worker_id: int, nbytes: int) -> Any:
+        """A worker-owned POSIX-shm Buffer used to move host bytes a copy cannot name.
+
+        Host memory allocated after the chip children forked cannot be named with
+        ``wrap_fork_inherited`` at all — the child has no mapping for it. ``create_buffer``
+        gives shared memory whose descriptor travels with the Tensor and which the
+        consumer materializes on first receipt, so one host memcpy buys reachability.
+
+        Cached per ``(worker_id, nbytes)``: sizes repeat every step, and keying on the
+        worker too keeps two chips' concurrent copies off one another's staging area.
+        Reuse is safe because the copy completes before the call returns.
+        """
+        import os  # noqa: PLC0415
+
+        if os.environ.get("PYPTO_STAGING_FRESH") == "1":
+            # Diagnostic escape hatch: one Buffer per copy, never reused. Reuse is only
+            # safe if the copy has fully drained by the time the call returns; if a
+            # pipelined run still references the staging area, reuse is a data race and
+            # this flag makes that visible instead of leaving it to inference.
+            return self._simpler_worker().create_buffer(int(nbytes))
+        key = (int(worker_id), int(nbytes))
+        buffer = self._staging_buffers.get(key)
+        if buffer is None:
+            buffer = self._simpler_worker().create_buffer(int(nbytes))
+            self._staging_buffers[key] = buffer
+        return buffer
+
+    @staticmethod
+    def _staging_view(buffer: Any, nbytes: int) -> Any:
+        import ctypes  # noqa: PLC0415
+
+        return (ctypes.c_char * int(nbytes)).from_buffer(buffer.shm.buf)
+
+    def _stage_host_to_buffer(self, worker_id: int, host_ptr: int, nbytes: int) -> Any:
+        import ctypes  # noqa: PLC0415
+
+        staging = self._staging_buffer(worker_id, nbytes)
+        ctypes.memmove(self._staging_view(staging, nbytes), int(host_ptr), int(nbytes))
+        return staging
+
+    def _stage_buffer_to_host(self, staging: Any, host_ptr: int, nbytes: int) -> None:
+        import ctypes  # noqa: PLC0415
+
+        ctypes.memmove(int(host_ptr), self._staging_view(staging, nbytes), int(nbytes))
+
+    def _release_staging_buffers(self) -> None:
+        """Close the shm staging Buffers while the worker is still alive.
+
+        Best-effort: one that refuses to close must not stop the rest of teardown, and
+        there is nothing the caller could do about it anyway.
+        """
+        for buffer in self._staging_buffers.values():
+            try:
+                buffer.close()
+            except Exception:  # noqa: BLE001 - teardown must not raise
+                pass
+        self._staging_buffers.clear()
+
+    # ------------------------------------------------------------------
+    # Task args
+    # ------------------------------------------------------------------
+
+    def device_tensor_arg(self, dt: Any) -> Any:
+        """Name a worker-resident :class:`DeviceTensor` as a Simpler wire ``Tensor``.
+
+        Replaces the retired ``Tensor.make(data=ptr, child_memory=True)``: ``make`` now
+        lives on ``ChipTensor``, and the wire ``Tensor`` is a view over a Buffer rather
+        than a raw address. The view comes from the Buffer that allocated the pointer,
+        which is also what makes "already on the device, skip H2D" structural instead of
+        a flag the caller has to remember to pass.
+        """
+        from .task_interface import torch_dtype_to_datatype  # noqa: PLC0415
+
+        if getattr(dt, "worker_id", None) is None:
+            raise ValueError(
+                "DeviceTensor reached a task-arg conversion without a worker_id, so the chip that "
+                "owns its pointer is unknown. Allocate it through alloc_tensor/alloc_stacked_tensor, "
+                "which record the owner."
+            )
+        buffer = self._device_buffer_for(int(dt.data_ptr), int(dt.worker_id), "device_tensor_arg")
+        try:
+            dtype = torch_dtype_to_datatype(dt.dtype)
+        except KeyError as exc:
+            raise ValueError(f"Unsupported DeviceTensor dtype: {dt.dtype}") from exc
+        return buffer.tensor(tuple(int(d) for d in dt.shape), dtype)
+
+    # ------------------------------------------------------------------
+    # Subclass hook
+    # ------------------------------------------------------------------
+
+    def _simpler_worker(self) -> Any:
+        """The underlying Simpler ``Worker``. Subclasses hold it under different names."""
+        raise NotImplementedError

--- a/python/pypto/runtime/builtins/collectives/all_to_all/templates/entry.cpp.in
+++ b/python/pypto/runtime/builtins/collectives/all_to_all/templates/entry.cpp.in
@@ -18,12 +18,12 @@
 namespace {
 
 template <typename DType>
-void submit_all_to_all_kernel(const L2TaskArgs &orch_args) {
+void submit_all_to_all_kernel(const ChipTaskArgs &orch_args) {
   const Tensor &input = orch_args.tensor(0).ref();
   const Tensor &target = orch_args.tensor(1).ref();
   const Tensor &signal = orch_args.tensor(2).ref();
 
-  L0TaskArgs params;
+  CoreTaskArgs params;
   params.add_input(input);
   params.add_inout(target);
   params.add_inout(signal);
@@ -37,18 +37,18 @@ void submit_all_to_all_kernel(const L2TaskArgs &orch_args) {
 extern "C" {
 
 __attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(
-    const L2TaskArgs &orch_args) {
+    const ChipTaskArgs &orch_args) {
   (void)orch_args;
   return PTO2OrchestrationConfig{
       .expected_arg_count = 5,
   };
 }
 
-__attribute__((visibility("default"))) void aicpu_orchestration_entry(const L2TaskArgs &orch_args) {
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipTaskArgs &orch_args) {
   submit_all_to_all_kernel<{{dtype_cpp}}>(orch_args);
 }
 
-__attribute__((visibility("default"))) void {{entry}}(const L2TaskArgs &orch_args) {
+__attribute__((visibility("default"))) void {{entry}}(const ChipTaskArgs &orch_args) {
   aicpu_orchestration_entry(orch_args);
 }
 

--- a/python/pypto/runtime/builtins/collectives/all_to_all/templates/entry.cpp.in
+++ b/python/pypto/runtime/builtins/collectives/all_to_all/templates/entry.cpp.in
@@ -19,9 +19,9 @@ namespace {
 
 template <typename DType>
 void submit_all_to_all_kernel(const ChipTaskArgs &orch_args) {
-  const Tensor &input = orch_args.tensor(0).ref();
-  const Tensor &target = orch_args.tensor(1).ref();
-  const Tensor &signal = orch_args.tensor(2).ref();
+  const ChipTensor &input = orch_args.tensor(0).ref();
+  const ChipTensor &target = orch_args.tensor(1).ref();
+  const ChipTensor &signal = orch_args.tensor(2).ref();
 
   CoreTaskArgs params;
   params.add_input(input);

--- a/python/pypto/runtime/builtins/collectives/all_to_all/templates/kernel.cpp.in
+++ b/python/pypto/runtime/builtins/collectives/all_to_all/templates/kernel.cpp.in
@@ -42,9 +42,9 @@ AICORE inline __gm__ T *CommRemotePtr(__gm__ CommContext *ctx, __gm__ T *local_p
 }  // namespace
 
 extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ int64_t *args) {
-  __gm__ Tensor *input_tensor = reinterpret_cast<__gm__ Tensor *>(args[0]);
-  __gm__ Tensor *target_tensor = reinterpret_cast<__gm__ Tensor *>(args[1]);
-  __gm__ Tensor *signal_tensor = reinterpret_cast<__gm__ Tensor *>(args[2]);
+  __gm__ ChipTensor *input_tensor = reinterpret_cast<__gm__ ChipTensor *>(args[0]);
+  __gm__ ChipTensor *target_tensor = reinterpret_cast<__gm__ ChipTensor *>(args[1]);
+  __gm__ ChipTensor *signal_tensor = reinterpret_cast<__gm__ ChipTensor *>(args[2]);
   int nranks = static_cast<int>(args[3]);
   __gm__ CommContext *comm_ctx = reinterpret_cast<__gm__ CommContext *>(args[4]);
 

--- a/python/pypto/runtime/builtins/collectives/all_to_all_v/templates/entry.cpp.in
+++ b/python/pypto/runtime/builtins/collectives/all_to_all_v/templates/entry.cpp.in
@@ -18,14 +18,14 @@
 namespace {
 
 template <typename DType>
-void submit_all_to_all_v_kernel(const L2TaskArgs &orch_args) {
+void submit_all_to_all_v_kernel(const ChipTaskArgs &orch_args) {
   const Tensor &input = orch_args.tensor(0).ref();
   const Tensor &target = orch_args.tensor(1).ref();
   const Tensor &signal = orch_args.tensor(2).ref();
   const Tensor &send_counts = orch_args.tensor(3).ref();
   const Tensor &recv_counts = orch_args.tensor(4).ref();
 
-  L0TaskArgs params;
+  CoreTaskArgs params;
   params.add_input(input);
   params.add_inout(target);
   params.add_inout(signal);
@@ -41,18 +41,18 @@ void submit_all_to_all_v_kernel(const L2TaskArgs &orch_args) {
 extern "C" {
 
 __attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(
-    const L2TaskArgs &orch_args) {
+    const ChipTaskArgs &orch_args) {
   (void)orch_args;
   return PTO2OrchestrationConfig{
       .expected_arg_count = 7,
   };
 }
 
-__attribute__((visibility("default"))) void aicpu_orchestration_entry(const L2TaskArgs &orch_args) {
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipTaskArgs &orch_args) {
   submit_all_to_all_v_kernel<{{dtype_cpp}}>(orch_args);
 }
 
-__attribute__((visibility("default"))) void {{entry}}(const L2TaskArgs &orch_args) {
+__attribute__((visibility("default"))) void {{entry}}(const ChipTaskArgs &orch_args) {
   aicpu_orchestration_entry(orch_args);
 }
 

--- a/python/pypto/runtime/builtins/collectives/all_to_all_v/templates/entry.cpp.in
+++ b/python/pypto/runtime/builtins/collectives/all_to_all_v/templates/entry.cpp.in
@@ -19,11 +19,11 @@ namespace {
 
 template <typename DType>
 void submit_all_to_all_v_kernel(const ChipTaskArgs &orch_args) {
-  const Tensor &input = orch_args.tensor(0).ref();
-  const Tensor &target = orch_args.tensor(1).ref();
-  const Tensor &signal = orch_args.tensor(2).ref();
-  const Tensor &send_counts = orch_args.tensor(3).ref();
-  const Tensor &recv_counts = orch_args.tensor(4).ref();
+  const ChipTensor &input = orch_args.tensor(0).ref();
+  const ChipTensor &target = orch_args.tensor(1).ref();
+  const ChipTensor &signal = orch_args.tensor(2).ref();
+  const ChipTensor &send_counts = orch_args.tensor(3).ref();
+  const ChipTensor &recv_counts = orch_args.tensor(4).ref();
 
   CoreTaskArgs params;
   params.add_input(input);

--- a/python/pypto/runtime/builtins/collectives/all_to_all_v/templates/kernel.cpp.in
+++ b/python/pypto/runtime/builtins/collectives/all_to_all_v/templates/kernel.cpp.in
@@ -42,11 +42,11 @@ AICORE inline __gm__ T *CommRemotePtr(__gm__ CommContext *ctx, __gm__ T *local_p
 }  // namespace
 
 extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ int64_t *args) {
-  __gm__ Tensor *input_tensor = reinterpret_cast<__gm__ Tensor *>(args[0]);
-  __gm__ Tensor *target_tensor = reinterpret_cast<__gm__ Tensor *>(args[1]);
-  __gm__ Tensor *signal_tensor = reinterpret_cast<__gm__ Tensor *>(args[2]);
-  __gm__ Tensor *send_counts_tensor = reinterpret_cast<__gm__ Tensor *>(args[3]);
-  __gm__ Tensor *recv_counts_tensor = reinterpret_cast<__gm__ Tensor *>(args[4]);
+  __gm__ ChipTensor *input_tensor = reinterpret_cast<__gm__ ChipTensor *>(args[0]);
+  __gm__ ChipTensor *target_tensor = reinterpret_cast<__gm__ ChipTensor *>(args[1]);
+  __gm__ ChipTensor *signal_tensor = reinterpret_cast<__gm__ ChipTensor *>(args[2]);
+  __gm__ ChipTensor *send_counts_tensor = reinterpret_cast<__gm__ ChipTensor *>(args[3]);
+  __gm__ ChipTensor *recv_counts_tensor = reinterpret_cast<__gm__ ChipTensor *>(args[4]);
   int nranks = static_cast<int>(args[5]);
   __gm__ CommContext *comm_ctx = reinterpret_cast<__gm__ CommContext *>(args[6]);
 

--- a/python/pypto/runtime/builtins/collectives/allgather/templates/entry.cpp.in
+++ b/python/pypto/runtime/builtins/collectives/allgather/templates/entry.cpp.in
@@ -19,9 +19,9 @@ namespace {
 
 template <typename DType>
 void submit_allgather_kernel(const ChipTaskArgs &orch_args) {
-  const Tensor &input = orch_args.tensor(0).ref();
-  const Tensor &target = orch_args.tensor(1).ref();
-  const Tensor &signal = orch_args.tensor(2).ref();
+  const ChipTensor &input = orch_args.tensor(0).ref();
+  const ChipTensor &target = orch_args.tensor(1).ref();
+  const ChipTensor &signal = orch_args.tensor(2).ref();
 
   CoreTaskArgs params;
   params.add_input(input);

--- a/python/pypto/runtime/builtins/collectives/allgather/templates/entry.cpp.in
+++ b/python/pypto/runtime/builtins/collectives/allgather/templates/entry.cpp.in
@@ -18,12 +18,12 @@
 namespace {
 
 template <typename DType>
-void submit_allgather_kernel(const L2TaskArgs &orch_args) {
+void submit_allgather_kernel(const ChipTaskArgs &orch_args) {
   const Tensor &input = orch_args.tensor(0).ref();
   const Tensor &target = orch_args.tensor(1).ref();
   const Tensor &signal = orch_args.tensor(2).ref();
 
-  L0TaskArgs params;
+  CoreTaskArgs params;
   params.add_input(input);
   params.add_inout(target);
   params.add_inout(signal);
@@ -37,18 +37,18 @@ void submit_allgather_kernel(const L2TaskArgs &orch_args) {
 extern "C" {
 
 __attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(
-    const L2TaskArgs &orch_args) {
+    const ChipTaskArgs &orch_args) {
   (void)orch_args;
   return PTO2OrchestrationConfig{
       .expected_arg_count = 5,
   };
 }
 
-__attribute__((visibility("default"))) void aicpu_orchestration_entry(const L2TaskArgs &orch_args) {
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipTaskArgs &orch_args) {
   submit_allgather_kernel<{{dtype_cpp}}>(orch_args);
 }
 
-__attribute__((visibility("default"))) void {{entry}}(const L2TaskArgs &orch_args) {
+__attribute__((visibility("default"))) void {{entry}}(const ChipTaskArgs &orch_args) {
   aicpu_orchestration_entry(orch_args);
 }
 

--- a/python/pypto/runtime/builtins/collectives/allgather/templates/kernel.cpp.in
+++ b/python/pypto/runtime/builtins/collectives/allgather/templates/kernel.cpp.in
@@ -42,9 +42,9 @@ AICORE inline __gm__ T *CommRemotePtr(__gm__ CommContext *ctx, __gm__ T *local_p
 }  // namespace
 
 extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ int64_t *args) {
-  __gm__ Tensor *input_tensor = reinterpret_cast<__gm__ Tensor *>(args[0]);
-  __gm__ Tensor *target_tensor = reinterpret_cast<__gm__ Tensor *>(args[1]);
-  __gm__ Tensor *signal_tensor = reinterpret_cast<__gm__ Tensor *>(args[2]);
+  __gm__ ChipTensor *input_tensor = reinterpret_cast<__gm__ ChipTensor *>(args[0]);
+  __gm__ ChipTensor *target_tensor = reinterpret_cast<__gm__ ChipTensor *>(args[1]);
+  __gm__ ChipTensor *signal_tensor = reinterpret_cast<__gm__ ChipTensor *>(args[2]);
   int nranks = static_cast<int>(args[3]);
   __gm__ CommContext *comm_ctx = reinterpret_cast<__gm__ CommContext *>(args[4]);
 

--- a/python/pypto/runtime/builtins/collectives/allreduce/templates/entry.cpp.in
+++ b/python/pypto/runtime/builtins/collectives/allreduce/templates/entry.cpp.in
@@ -26,8 +26,8 @@ enum class ReduceOp : int32_t {
 
 template <ReduceOp Op>
 void submit_allreduce_kernel(const ChipTaskArgs &orch_args) {
-  const Tensor &data = orch_args.tensor(0).ref();
-  const Tensor &signal = orch_args.tensor(1).ref();
+  const ChipTensor &data = orch_args.tensor(0).ref();
+  const ChipTensor &signal = orch_args.tensor(1).ref();
 
   CoreTaskArgs params;
   params.add_inout(data);

--- a/python/pypto/runtime/builtins/collectives/allreduce/templates/entry.cpp.in
+++ b/python/pypto/runtime/builtins/collectives/allreduce/templates/entry.cpp.in
@@ -25,11 +25,11 @@ enum class ReduceOp : int32_t {
 };
 
 template <ReduceOp Op>
-void submit_allreduce_kernel(const L2TaskArgs &orch_args) {
+void submit_allreduce_kernel(const ChipTaskArgs &orch_args) {
   const Tensor &data = orch_args.tensor(0).ref();
   const Tensor &signal = orch_args.tensor(1).ref();
 
-  L0TaskArgs params;
+  CoreTaskArgs params;
   params.add_inout(data);
   params.add_inout(signal);
   params.add_scalar(orch_args.scalar(0));  // nranks
@@ -45,21 +45,21 @@ void submit_allreduce_kernel(const L2TaskArgs &orch_args) {
 extern "C" {
 
 __attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(
-    const L2TaskArgs &orch_args) {
+    const ChipTaskArgs &orch_args) {
   (void)orch_args;
   return PTO2OrchestrationConfig{
       .expected_arg_count = 5,
   };
 }
 
-__attribute__((visibility("default"))) void aicpu_orchestration_entry(const L2TaskArgs &orch_args) {
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipTaskArgs &orch_args) {
   submit_allreduce_kernel<{{op_cpp}}>(orch_args);
 }
 
 // The sanitized builtin symbol is kept as an alias-like wrapper for easier
 // debugging of materialized sources; kernel_config.py still uses the standard
 // aicpu_orchestration_entry symbol expected by compile_and_assemble.
-__attribute__((visibility("default"))) void {{entry}}(const L2TaskArgs &orch_args) {
+__attribute__((visibility("default"))) void {{entry}}(const ChipTaskArgs &orch_args) {
   aicpu_orchestration_entry(orch_args);
 }
 

--- a/python/pypto/runtime/builtins/collectives/allreduce/templates/kernel.cpp.in
+++ b/python/pypto/runtime/builtins/collectives/allreduce/templates/kernel.cpp.in
@@ -47,8 +47,8 @@ AICORE inline __gm__ T *CommRemotePtr(__gm__ CommContext *ctx, __gm__ T *local_p
 }  // namespace
 
 extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ int64_t *args) {
-  __gm__ Tensor *data_tensor = reinterpret_cast<__gm__ Tensor *>(args[0]);
-  __gm__ Tensor *signal_tensor = reinterpret_cast<__gm__ Tensor *>(args[1]);
+  __gm__ ChipTensor *data_tensor = reinterpret_cast<__gm__ ChipTensor *>(args[0]);
+  __gm__ ChipTensor *signal_tensor = reinterpret_cast<__gm__ ChipTensor *>(args[1]);
   int nranks = static_cast<int>(args[2]);
   __gm__ CommContext *comm_ctx = reinterpret_cast<__gm__ CommContext *>(args[3]);
   int32_t block_idx = get_block_idx(args);

--- a/python/pypto/runtime/builtins/collectives/allreduce_ring/templates/entry.cpp.in
+++ b/python/pypto/runtime/builtins/collectives/allreduce_ring/templates/entry.cpp.in
@@ -23,8 +23,8 @@ enum class ReduceOp : int32_t {
 
 template <ReduceOp Op, typename DType>
 void submit_allreduce_ring_kernel(const ChipTaskArgs &orch_args) {
-  const Tensor &data = orch_args.tensor(0).ref();
-  const Tensor &signal = orch_args.tensor(1).ref();
+  const ChipTensor &data = orch_args.tensor(0).ref();
+  const ChipTensor &signal = orch_args.tensor(1).ref();
 
   CoreTaskArgs params;
   params.add_inout(data);

--- a/python/pypto/runtime/builtins/collectives/allreduce_ring/templates/entry.cpp.in
+++ b/python/pypto/runtime/builtins/collectives/allreduce_ring/templates/entry.cpp.in
@@ -22,11 +22,11 @@ enum class ReduceOp : int32_t {
 };
 
 template <ReduceOp Op, typename DType>
-void submit_allreduce_ring_kernel(const L2TaskArgs &orch_args) {
+void submit_allreduce_ring_kernel(const ChipTaskArgs &orch_args) {
   const Tensor &data = orch_args.tensor(0).ref();
   const Tensor &signal = orch_args.tensor(1).ref();
 
-  L0TaskArgs params;
+  CoreTaskArgs params;
   params.add_inout(data);
   params.add_inout(signal);
   params.add_scalar(orch_args.scalar(0));  // nranks
@@ -39,21 +39,21 @@ void submit_allreduce_ring_kernel(const L2TaskArgs &orch_args) {
 extern "C" {
 
 __attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(
-    const L2TaskArgs &orch_args) {
+    const ChipTaskArgs &orch_args) {
   (void)orch_args;
   return PTO2OrchestrationConfig{
       .expected_arg_count = 4,
   };
 }
 
-__attribute__((visibility("default"))) void aicpu_orchestration_entry(const L2TaskArgs &orch_args) {
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipTaskArgs &orch_args) {
   submit_allreduce_ring_kernel<{{op_cpp}}, {{dtype_cpp}}>(orch_args);
 }
 
 // The sanitized builtin symbol is kept as an alias-like wrapper for easier
 // debugging of materialized sources; kernel_config.py still uses the standard
 // aicpu_orchestration_entry symbol expected by compile_and_assemble.
-__attribute__((visibility("default"))) void {{entry}}(const L2TaskArgs &orch_args) {
+__attribute__((visibility("default"))) void {{entry}}(const ChipTaskArgs &orch_args) {
   aicpu_orchestration_entry(orch_args);
 }
 

--- a/python/pypto/runtime/builtins/collectives/allreduce_ring/templates/kernel.cpp.in
+++ b/python/pypto/runtime/builtins/collectives/allreduce_ring/templates/kernel.cpp.in
@@ -90,8 +90,8 @@ AICORE inline void RoundBarrier(__gm__ CommContext *ctx, __gm__ int32_t *signal_
 }  // namespace
 
 extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ int64_t *args) {
-  __gm__ Tensor *data_tensor = reinterpret_cast<__gm__ Tensor *>(args[0]);
-  __gm__ Tensor *signal_tensor = reinterpret_cast<__gm__ Tensor *>(args[1]);
+  __gm__ ChipTensor *data_tensor = reinterpret_cast<__gm__ ChipTensor *>(args[0]);
+  __gm__ ChipTensor *signal_tensor = reinterpret_cast<__gm__ ChipTensor *>(args[1]);
   int nranks = static_cast<int>(args[2]);
   __gm__ CommContext *comm_ctx = reinterpret_cast<__gm__ CommContext *>(args[3]);
 

--- a/python/pypto/runtime/builtins/collectives/barrier/templates/entry.cpp.in
+++ b/python/pypto/runtime/builtins/collectives/barrier/templates/entry.cpp.in
@@ -18,10 +18,10 @@
 namespace {
 
 template <typename DType>
-void submit_barrier_kernel(const L2TaskArgs &orch_args) {
+void submit_barrier_kernel(const ChipTaskArgs &orch_args) {
   const Tensor &signal = orch_args.tensor(0).ref();
 
-  L0TaskArgs params;
+  CoreTaskArgs params;
   params.add_inout(signal);
   params.add_scalar(orch_args.scalar(0));  // nranks
   params.add_scalar(orch_args.scalar(1));  // CommContext device pointer
@@ -33,21 +33,21 @@ void submit_barrier_kernel(const L2TaskArgs &orch_args) {
 extern "C" {
 
 __attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(
-    const L2TaskArgs &orch_args) {
+    const ChipTaskArgs &orch_args) {
   (void)orch_args;
   return PTO2OrchestrationConfig{
       .expected_arg_count = 3,
   };
 }
 
-__attribute__((visibility("default"))) void aicpu_orchestration_entry(const L2TaskArgs &orch_args) {
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipTaskArgs &orch_args) {
   submit_barrier_kernel<{{dtype_cpp}}>(orch_args);
 }
 
 // The sanitized builtin symbol is kept as an alias-like wrapper for easier
 // debugging of materialized sources; kernel_config.py still uses the standard
 // aicpu_orchestration_entry symbol expected by compile_and_assemble.
-__attribute__((visibility("default"))) void {{entry}}(const L2TaskArgs &orch_args) {
+__attribute__((visibility("default"))) void {{entry}}(const ChipTaskArgs &orch_args) {
   aicpu_orchestration_entry(orch_args);
 }
 

--- a/python/pypto/runtime/builtins/collectives/barrier/templates/entry.cpp.in
+++ b/python/pypto/runtime/builtins/collectives/barrier/templates/entry.cpp.in
@@ -19,7 +19,7 @@ namespace {
 
 template <typename DType>
 void submit_barrier_kernel(const ChipTaskArgs &orch_args) {
-  const Tensor &signal = orch_args.tensor(0).ref();
+  const ChipTensor &signal = orch_args.tensor(0).ref();
 
   CoreTaskArgs params;
   params.add_inout(signal);

--- a/python/pypto/runtime/builtins/collectives/barrier/templates/kernel.cpp.in
+++ b/python/pypto/runtime/builtins/collectives/barrier/templates/kernel.cpp.in
@@ -41,7 +41,7 @@ AICORE inline __gm__ T *CommRemotePtr(__gm__ CommContext *ctx, __gm__ T *local_p
 }  // namespace
 
 extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ int64_t *args) {
-  __gm__ Tensor *signal_tensor = reinterpret_cast<__gm__ Tensor *>(args[0]);
+  __gm__ ChipTensor *signal_tensor = reinterpret_cast<__gm__ ChipTensor *>(args[0]);
   int nranks = static_cast<int>(args[1]);
   __gm__ CommContext *comm_ctx = reinterpret_cast<__gm__ CommContext *>(args[2]);
 

--- a/python/pypto/runtime/builtins/collectives/broadcast/templates/entry.cpp.in
+++ b/python/pypto/runtime/builtins/collectives/broadcast/templates/entry.cpp.in
@@ -19,8 +19,8 @@ namespace {
 
 template <typename DType>
 void submit_broadcast_kernel(const ChipTaskArgs &orch_args) {
-  const Tensor &target = orch_args.tensor(0).ref();
-  const Tensor &signal = orch_args.tensor(1).ref();
+  const ChipTensor &target = orch_args.tensor(0).ref();
+  const ChipTensor &signal = orch_args.tensor(1).ref();
 
   CoreTaskArgs params;
   params.add_inout(target);

--- a/python/pypto/runtime/builtins/collectives/broadcast/templates/entry.cpp.in
+++ b/python/pypto/runtime/builtins/collectives/broadcast/templates/entry.cpp.in
@@ -18,11 +18,11 @@
 namespace {
 
 template <typename DType>
-void submit_broadcast_kernel(const L2TaskArgs &orch_args) {
+void submit_broadcast_kernel(const ChipTaskArgs &orch_args) {
   const Tensor &target = orch_args.tensor(0).ref();
   const Tensor &signal = orch_args.tensor(1).ref();
 
-  L0TaskArgs params;
+  CoreTaskArgs params;
   params.add_inout(target);
   params.add_inout(signal);
   params.add_scalar(orch_args.scalar(0));  // nranks
@@ -35,21 +35,21 @@ void submit_broadcast_kernel(const L2TaskArgs &orch_args) {
 extern "C" {
 
 __attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(
-    const L2TaskArgs &orch_args) {
+    const ChipTaskArgs &orch_args) {
   (void)orch_args;
   return PTO2OrchestrationConfig{
       .expected_arg_count = 4,
   };
 }
 
-__attribute__((visibility("default"))) void aicpu_orchestration_entry(const L2TaskArgs &orch_args) {
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipTaskArgs &orch_args) {
   submit_broadcast_kernel<{{dtype_cpp}}>(orch_args);
 }
 
 // The sanitized builtin symbol is kept as an alias-like wrapper for easier
 // debugging of materialized sources; kernel_config.py still uses the standard
 // aicpu_orchestration_entry symbol expected by compile_and_assemble.
-__attribute__((visibility("default"))) void {{entry}}(const L2TaskArgs &orch_args) {
+__attribute__((visibility("default"))) void {{entry}}(const ChipTaskArgs &orch_args) {
   aicpu_orchestration_entry(orch_args);
 }
 

--- a/python/pypto/runtime/builtins/collectives/broadcast/templates/kernel.cpp.in
+++ b/python/pypto/runtime/builtins/collectives/broadcast/templates/kernel.cpp.in
@@ -43,8 +43,8 @@ AICORE inline __gm__ T *CommRemotePtr(__gm__ CommContext *ctx, __gm__ T *local_p
 }  // namespace
 
 extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ int64_t *args) {
-  __gm__ Tensor *target_tensor = reinterpret_cast<__gm__ Tensor *>(args[0]);
-  __gm__ Tensor *signal_tensor = reinterpret_cast<__gm__ Tensor *>(args[1]);
+  __gm__ ChipTensor *target_tensor = reinterpret_cast<__gm__ ChipTensor *>(args[0]);
+  __gm__ ChipTensor *signal_tensor = reinterpret_cast<__gm__ ChipTensor *>(args[1]);
   int nranks = static_cast<int>(args[2]);
   __gm__ CommContext *comm_ctx = reinterpret_cast<__gm__ CommContext *>(args[3]);
 

--- a/python/pypto/runtime/builtins/collectives/reduce_scatter/templates/entry.cpp.in
+++ b/python/pypto/runtime/builtins/collectives/reduce_scatter/templates/entry.cpp.in
@@ -23,8 +23,8 @@ enum class ReduceOp : int32_t {
 
 template <ReduceOp Op, typename DType>
 void submit_reduce_scatter_kernel(const ChipTaskArgs &orch_args) {
-  const Tensor &target = orch_args.tensor(0).ref();
-  const Tensor &signal = orch_args.tensor(1).ref();
+  const ChipTensor &target = orch_args.tensor(0).ref();
+  const ChipTensor &signal = orch_args.tensor(1).ref();
 
   CoreTaskArgs params;
   params.add_inout(target);

--- a/python/pypto/runtime/builtins/collectives/reduce_scatter/templates/entry.cpp.in
+++ b/python/pypto/runtime/builtins/collectives/reduce_scatter/templates/entry.cpp.in
@@ -22,11 +22,11 @@ enum class ReduceOp : int32_t {
 };
 
 template <ReduceOp Op, typename DType>
-void submit_reduce_scatter_kernel(const L2TaskArgs &orch_args) {
+void submit_reduce_scatter_kernel(const ChipTaskArgs &orch_args) {
   const Tensor &target = orch_args.tensor(0).ref();
   const Tensor &signal = orch_args.tensor(1).ref();
 
-  L0TaskArgs params;
+  CoreTaskArgs params;
   params.add_inout(target);
   params.add_inout(signal);
   params.add_scalar(orch_args.scalar(0));  // nranks
@@ -39,21 +39,21 @@ void submit_reduce_scatter_kernel(const L2TaskArgs &orch_args) {
 extern "C" {
 
 __attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(
-    const L2TaskArgs &orch_args) {
+    const ChipTaskArgs &orch_args) {
   (void)orch_args;
   return PTO2OrchestrationConfig{
       .expected_arg_count = 4,
   };
 }
 
-__attribute__((visibility("default"))) void aicpu_orchestration_entry(const L2TaskArgs &orch_args) {
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipTaskArgs &orch_args) {
   submit_reduce_scatter_kernel<{{op_cpp}}, {{dtype_cpp}}>(orch_args);
 }
 
 // The sanitized builtin symbol is kept as an alias-like wrapper for easier
 // debugging of materialized sources; kernel_config.py still uses the standard
 // aicpu_orchestration_entry symbol expected by compile_and_assemble.
-__attribute__((visibility("default"))) void {{entry}}(const L2TaskArgs &orch_args) {
+__attribute__((visibility("default"))) void {{entry}}(const ChipTaskArgs &orch_args) {
   aicpu_orchestration_entry(orch_args);
 }
 

--- a/python/pypto/runtime/builtins/collectives/reduce_scatter/templates/kernel.cpp.in
+++ b/python/pypto/runtime/builtins/collectives/reduce_scatter/templates/kernel.cpp.in
@@ -42,8 +42,8 @@ AICORE inline __gm__ T *CommRemotePtr(__gm__ CommContext *ctx, __gm__ T *local_p
 }  // namespace
 
 extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ int64_t *args) {
-  __gm__ Tensor *target_tensor = reinterpret_cast<__gm__ Tensor *>(args[0]);
-  __gm__ Tensor *signal_tensor = reinterpret_cast<__gm__ Tensor *>(args[1]);
+  __gm__ ChipTensor *target_tensor = reinterpret_cast<__gm__ ChipTensor *>(args[0]);
+  __gm__ ChipTensor *signal_tensor = reinterpret_cast<__gm__ ChipTensor *>(args[1]);
   int nranks = static_cast<int>(args[2]);
   __gm__ CommContext *comm_ctx = reinterpret_cast<__gm__ CommContext *>(args[3]);
 

--- a/python/pypto/runtime/device_tensor.py
+++ b/python/pypto/runtime/device_tensor.py
@@ -42,13 +42,26 @@ class DeviceTensor:
         data_ptr: Device pointer in the owning Worker's address space.
         shape: Logical tensor shape (all dimensions positive).
         dtype: Element ``torch.dtype``.
+        worker_id: Chip that owns ``data_ptr``, when known. Each chip has its own
+            address space, so the pointer alone does not identify an allocation:
+            equal-sized shards allocated in the same order land on the *same*
+            numeric address on every chip. Simpler's Buffer-based task args have to
+            name the owning chip's Buffer, so the owner must travel with the handle.
+            Defaults to ``None`` for handles built by callers that never had one.
     """
 
     data_ptr: int
     shape: tuple[int, ...]
     dtype: torch.dtype
+    worker_id: int | None
 
-    def __init__(self, data_ptr: int, shape: Sequence[int], dtype: torch.dtype) -> None:
+    def __init__(
+        self,
+        data_ptr: int,
+        shape: Sequence[int],
+        dtype: torch.dtype,
+        worker_id: int | None = None,
+    ) -> None:
         # bool is an int subclass — exclude it explicitly so True/False can't pose as a pointer or dim.
         if isinstance(data_ptr, bool) or not isinstance(data_ptr, int) or data_ptr <= 0:
             raise ValueError(f"DeviceTensor.data_ptr must be a positive int, got {data_ptr!r}")
@@ -63,9 +76,12 @@ class DeviceTensor:
         shape_t = raw_shape
         if not isinstance(dtype, torch.dtype):
             raise TypeError(f"DeviceTensor.dtype must be torch.dtype, got {type(dtype).__name__}")
+        if worker_id is not None and (isinstance(worker_id, bool) or not isinstance(worker_id, int) or worker_id < 0):
+            raise ValueError(f"DeviceTensor.worker_id must be a non-negative int or None, got {worker_id!r}")
         object.__setattr__(self, "data_ptr", data_ptr)
         object.__setattr__(self, "shape", shape_t)
         object.__setattr__(self, "dtype", dtype)
+        object.__setattr__(self, "worker_id", worker_id)
 
     @property
     def nbytes(self) -> int:
@@ -229,6 +245,7 @@ def alloc_device_tensor(
     dtype: torch.dtype,
     init: torch.Tensor | None = None,
     init_prep: Callable[[torch.Tensor], torch.Tensor] | None = None,
+    worker_id: int | None = None,
 ) -> DeviceTensor:
     """Allocate a device buffer and (optionally) upload host data.
 
@@ -286,7 +303,7 @@ def alloc_device_tensor(
                 )
             host = (init_prep or default_init_prep)(init)
             copy_to(ptr, host.data_ptr(), nbytes)
-        return DeviceTensor(ptr, shape_t, dtype)
+        return DeviceTensor(ptr, shape_t, dtype, worker_id)
     except Exception:
         free(ptr)
         raise

--- a/python/pypto/runtime/distributed_runner.py
+++ b/python/pypto/runtime/distributed_runner.py
@@ -30,6 +30,7 @@ from typing import TYPE_CHECKING, Any
 import numpy as np  # pyright: ignore[reportMissingImports]
 import torch
 
+from ._buffer_bridge import BufferBridge
 from .device_tensor import DeviceTensor, StackedDeviceTensor
 from .runtime_base import Worker
 
@@ -1005,7 +1006,15 @@ def _dispatch(
             world_size=device_nums,
         )
 
-    w.run(orch_fn)
+    # Simpler's make_tensor_arg memoizes host tensors on a worker, and the generated
+    # entry has none in scope — bind it for the duration of the submission.
+    from .tensor_arg import bind_worker, unbind_worker  # noqa: PLC0415
+
+    token = bind_worker(w)
+    try:
+        w.run(orch_fn)
+    finally:
+        unbind_worker(token)
 
 
 def execute_distributed(
@@ -1192,7 +1201,7 @@ def execute_distributed_compiled(
     return compiled(*args, config=config)
 
 
-class DistributedWorker(Worker):
+class DistributedWorker(BufferBridge, Worker):
     """L3 distributed execution handle: prepare once, dispatch many.
 
     Holds an initialized simpler ``Worker(level=3)`` plus all setup artifacts
@@ -1304,7 +1313,7 @@ class DistributedWorker(Worker):
         # (worker_id, device address) -> the Buffer handle Simpler minted for it. The
         # public surface here still speaks addresses, so this is what lets ``free`` and
         # ``copy_to`` hand back the identity Simpler expects.
-        self._device_buffers: dict[tuple[int, int], Any] = {}
+        self._init_buffer_bridge()
         self._buffer_owner_id: bytes | None = None
         self._buffer_id_seq = 0
         self._persistent = bool(persistent)
@@ -1619,6 +1628,11 @@ class DistributedWorker(Worker):
                         _domain_provider=domain_provider,
                     )
 
+                from .tensor_arg import bind_worker, unbind_worker  # noqa: PLC0415
+
+                # Bind the runner, not the raw Worker: DeviceTensor args resolve through
+                # its device-buffer registry, and the host branch reaches ``_w`` from it.
+                token = bind_worker(self)
                 try:
                     self._w.run(run_request)
                 except BaseException as exc:  # noqa: BLE001 - rethrown on caller thread
@@ -1629,6 +1643,8 @@ class DistributedWorker(Worker):
                 else:
                     request.keepalive.clear()
                     request.done.set()
+                finally:
+                    unbind_worker(token)
                 if request.error is not None:
                     break
         except BaseException as exc:  # noqa: BLE001 - observed by start/run/close
@@ -1744,9 +1760,10 @@ class DistributedWorker(Worker):
     def _host_buffer_for(self, host_ptr: int, nbytes: int, *, api: str, writing: bool) -> Any:
         """Name an inherited host range the way Simpler's L3 copy path requires.
 
-        The range must fall inside one tensor registered through
-        ``inherited_host_tensors``: the copy runs in a forked chip child, which can only
-        reach memory that existed at fork. Each range is wrapped on its own rather than
+        Returns ``None`` when the range is not inherited — the caller then stages the
+        bytes through :meth:`_staging_buffer` instead. Only memory that existed at fork
+        can be named this way: the copy runs in a forked chip child, which cannot reach a
+        mapping its parent made afterwards. Each range is wrapped on its own rather than
         offset into a whole-tensor Buffer, because a Buffer carries no offset — a shard's
         address is interior to its stacked tensor, so per-range wrapping is what keeps a
         shard copy from moving the whole stack.
@@ -1772,10 +1789,10 @@ class DistributedWorker(Worker):
                 access=AccessMode.READWRITE if is_shared else AccessMode.READ,
                 backend_kind=BackendKind.FORK_SHM if is_shared else BackendKind.FORK_COW,
             )
-        raise ValueError(
-            f"{api}: host range 0x{host_ptr:x}+{nbytes} is not inside any tensor registered through "
-            "inherited_host_tensors, so the forked chip child cannot read it."
-        )
+        return None
+
+    def _simpler_worker(self) -> Any:
+        return self._w
 
     def malloc(self, nbytes: int, *, worker_id: int = 0) -> int:
         """Allocate ``nbytes`` on chip *worker_id*; returns a device pointer."""
@@ -1783,15 +1800,13 @@ class DistributedWorker(Worker):
 
         self._require_open("malloc")
         handle = self._w.alloc_child_tensor(int(worker_id), (int(nbytes),), DataType.UINT8)
-        self._device_buffers[(int(worker_id), int(handle.base))] = handle
+        self._register_device_buffer(int(worker_id), int(handle.base), handle)
         return int(handle.base)
 
     def free(self, ptr: int, *, worker_id: int = 0) -> None:
         """Release a pointer previously returned by :meth:`malloc`."""
         self._require_open("free")
-        handle = self._device_buffers.pop((int(worker_id), int(ptr)), None)
-        if handle is None:
-            raise ValueError(f"free: 0x{int(ptr):x} was not allocated on worker {int(worker_id)} by this Worker")
+        handle = self._pop_device_buffer(int(ptr), int(worker_id), "free")
         self._w.free(handle)
 
     def committed_device_memory(self, worker_id: int = 0) -> int:
@@ -1805,17 +1820,13 @@ class DistributedWorker(Worker):
             return 0
         return int(self._w.committed_device_memory(worker_id))
 
-    def _device_buffer_for(self, ptr: int, worker_id: int, api: str) -> Any:
-        handle = self._device_buffers.get((int(worker_id), int(ptr)))
-        if handle is None:
-            raise ValueError(f"{api}: 0x{int(ptr):x} was not allocated on worker {int(worker_id)} by this Worker")
-        return handle
-
     def copy_to(self, dst_dev_ptr: int, src_host_ptr: int, nbytes: int, *, worker_id: int = 0) -> None:
         """H2D copy: ``nbytes`` from host *src_host_ptr* to device *dst_dev_ptr*."""
         self._require_open("copy_to")
         dst = self._device_buffer_for(dst_dev_ptr, worker_id, "copy_to")
         src = self._host_buffer_for(int(src_host_ptr), int(nbytes), api="copy_to", writing=False)
+        if src is None:
+            src = self._stage_host_to_buffer(worker_id, int(src_host_ptr), int(nbytes))
         self._w.copy_to(dst, src)
 
     def copy_from(self, dst_host_ptr: int, src_dev_ptr: int, nbytes: int, *, worker_id: int = 0) -> None:
@@ -1823,7 +1834,12 @@ class DistributedWorker(Worker):
         self._require_open("copy_from")
         src = self._device_buffer_for(src_dev_ptr, worker_id, "copy_from")
         dst = self._host_buffer_for(int(dst_host_ptr), int(nbytes), api="copy_from", writing=True)
-        self._w.copy_from(dst, src)
+        if dst is not None:
+            self._w.copy_from(dst, src)
+            return
+        staging = self._staging_buffer(worker_id, nbytes)
+        self._w.copy_from(staging, src)
+        self._stage_buffer_to_host(staging, int(dst_host_ptr), int(nbytes))
 
     # ``alloc_tensor`` / ``free_tensor`` are inherited from Worker ABC.
     # Only the two behaviours that genuinely differ from L2 are overridden below:
@@ -2176,6 +2192,7 @@ class DistributedWorker(Worker):
             # still admits these calls, and BEFORE we tear down the underlying
             # worker so the free path is still live.
             self._close_owned_tensors()
+            self._release_staging_buffers()
             self._closed = True
             # Mark every still-alive RegistrationHandle as closed so subsequent
             # handle(...) calls raise instead of dispatching to a torn-down runtime.

--- a/python/pypto/runtime/distributed_runner.py
+++ b/python/pypto/runtime/distributed_runner.py
@@ -1286,6 +1286,27 @@ class DistributedWorker(Worker):
                 )
         self._inherited_host_tensors = inherited
         self._inherited_host_storage_ptrs = {tensor.untyped_storage().data_ptr() for tensor in inherited}
+        # Simpler now names both ends of a device copy by Buffer identity rather than by
+        # raw address, and it will not infer how the host side is mapped: MAP_SHARED
+        # (``FORK_SHM``) may serve as an output, MAP_PRIVATE (``FORK_COW``) is read-only
+        # because a child's write would split the page into a copy the parent never sees.
+        # That classification is the caller's to make, so record it here, where the
+        # tensors are still in hand, as (start, end, is_shared) spans to resolve a bare
+        # address against later.
+        self._inherited_host_spans: tuple[tuple[int, int, bool], ...] = tuple(
+            (
+                tensor.data_ptr(),
+                tensor.data_ptr() + tensor.numel() * tensor.element_size(),
+                bool(tensor.is_shared()),
+            )
+            for tensor in inherited
+        )
+        # (worker_id, device address) -> the Buffer handle Simpler minted for it. The
+        # public surface here still speaks addresses, so this is what lets ``free`` and
+        # ``copy_to`` hand back the identity Simpler expects.
+        self._device_buffers: dict[tuple[int, int], Any] = {}
+        self._buffer_owner_id: bytes | None = None
+        self._buffer_id_seq = 0
         self._persistent = bool(persistent)
         self._reset_persistent_windows = reset_persistent_windows
         # ``orch.copy_to`` runs in each forked chip child and dereferences the
@@ -1711,15 +1732,67 @@ class DistributedWorker(Worker):
     # the private Orchestrator facade.
     # ------------------------------------------------------------------
 
+    def _next_buffer_identity(self) -> tuple[bytes, int]:
+        """Mint the (owner, id) pair Simpler uses to name a Buffer we wrap ourselves."""
+        from simpler.buffer import mint_owner_instance_id  # noqa: PLC0415 -- native ext
+
+        if self._buffer_owner_id is None:
+            self._buffer_owner_id = mint_owner_instance_id()
+        self._buffer_id_seq += 1
+        return self._buffer_owner_id, self._buffer_id_seq
+
+    def _host_buffer_for(self, host_ptr: int, nbytes: int, *, api: str, writing: bool) -> Any:
+        """Name an inherited host range the way Simpler's L3 copy path requires.
+
+        The range must fall inside one tensor registered through
+        ``inherited_host_tensors``: the copy runs in a forked chip child, which can only
+        reach memory that existed at fork. Each range is wrapped on its own rather than
+        offset into a whole-tensor Buffer, because a Buffer carries no offset — a shard's
+        address is interior to its stacked tensor, so per-range wrapping is what keeps a
+        shard copy from moving the whole stack.
+        """
+        from simpler.buffer import AccessMode, BackendKind, wrap_fork_inherited  # noqa: PLC0415
+
+        end = host_ptr + nbytes
+        for start, stop, is_shared in self._inherited_host_spans:
+            if host_ptr < start or end > stop:
+                continue
+            if writing and not is_shared:
+                raise ValueError(
+                    f"{api}: cannot write into a copy-on-write host mapping — a child's write would "
+                    "split the page into a private copy the parent never sees. Register the tensor "
+                    "with shared memory if it has to receive data."
+                )
+            owner, buffer_id = self._next_buffer_identity()
+            return wrap_fork_inherited(
+                host_ptr,
+                nbytes,
+                owner,
+                buffer_id,
+                access=AccessMode.READ_WRITE if is_shared else AccessMode.READ,
+                backend_kind=BackendKind.FORK_SHM if is_shared else BackendKind.FORK_COW,
+            )
+        raise ValueError(
+            f"{api}: host range 0x{host_ptr:x}+{nbytes} is not inside any tensor registered through "
+            "inherited_host_tensors, so the forked chip child cannot read it."
+        )
+
     def malloc(self, nbytes: int, *, worker_id: int = 0) -> int:
         """Allocate ``nbytes`` on chip *worker_id*; returns a device pointer."""
+        from simpler.task_interface import DataType  # noqa: PLC0415
+
         self._require_open("malloc")
-        return int(self._w.malloc(nbytes, worker_id))
+        handle = self._w.alloc_child_tensor(int(worker_id), (int(nbytes),), DataType.UINT8)
+        self._device_buffers[(int(worker_id), int(handle.base))] = handle
+        return int(handle.base)
 
     def free(self, ptr: int, *, worker_id: int = 0) -> None:
         """Release a pointer previously returned by :meth:`malloc`."""
         self._require_open("free")
-        self._w.free(ptr, worker_id)
+        handle = self._device_buffers.pop((int(worker_id), int(ptr)), None)
+        if handle is None:
+            raise ValueError(f"free: 0x{int(ptr):x} was not allocated on worker {int(worker_id)} by this Worker")
+        self._w.free(handle)
 
     def committed_device_memory(self, worker_id: int = 0) -> int:
         """Total device HBM (bytes) committed by chip *worker_id*'s ``MemoryAllocator``
@@ -1732,15 +1805,25 @@ class DistributedWorker(Worker):
             return 0
         return int(self._w.committed_device_memory(worker_id))
 
+    def _device_buffer_for(self, ptr: int, worker_id: int, api: str) -> Any:
+        handle = self._device_buffers.get((int(worker_id), int(ptr)))
+        if handle is None:
+            raise ValueError(f"{api}: 0x{int(ptr):x} was not allocated on worker {int(worker_id)} by this Worker")
+        return handle
+
     def copy_to(self, dst_dev_ptr: int, src_host_ptr: int, nbytes: int, *, worker_id: int = 0) -> None:
         """H2D copy: ``nbytes`` from host *src_host_ptr* to device *dst_dev_ptr*."""
         self._require_open("copy_to")
-        self._w.copy_to(dst_dev_ptr, src_host_ptr, nbytes, worker_id)
+        dst = self._device_buffer_for(dst_dev_ptr, worker_id, "copy_to")
+        src = self._host_buffer_for(int(src_host_ptr), int(nbytes), api="copy_to", writing=False)
+        self._w.copy_to(dst, src)
 
     def copy_from(self, dst_host_ptr: int, src_dev_ptr: int, nbytes: int, *, worker_id: int = 0) -> None:
         """D2H copy: ``nbytes`` from device *src_dev_ptr* back to host *dst_host_ptr*."""
         self._require_open("copy_from")
-        self._w.copy_from(dst_host_ptr, src_dev_ptr, nbytes, worker_id)
+        src = self._device_buffer_for(src_dev_ptr, worker_id, "copy_from")
+        dst = self._host_buffer_for(int(dst_host_ptr), int(nbytes), api="copy_from", writing=True)
+        self._w.copy_from(dst, src)
 
     # ``alloc_tensor`` / ``free_tensor`` are inherited from Worker ABC.
     # Only the two behaviours that genuinely differ from L2 are overridden below:

--- a/python/pypto/runtime/distributed_runner.py
+++ b/python/pypto/runtime/distributed_runner.py
@@ -1769,7 +1769,7 @@ class DistributedWorker(Worker):
                 nbytes,
                 owner,
                 buffer_id,
-                access=AccessMode.READ_WRITE if is_shared else AccessMode.READ,
+                access=AccessMode.READWRITE if is_shared else AccessMode.READ,
                 backend_kind=BackendKind.FORK_SHM if is_shared else BackendKind.FORK_COW,
             )
         raise ValueError(

--- a/python/pypto/runtime/runner.py
+++ b/python/pypto/runtime/runner.py
@@ -733,12 +733,14 @@ def _coerced_to_orch_args(
     """
     from .device_runner import (  # noqa: PLC0415
         ChipStorageTaskArgs,  # pyright: ignore[reportAttributeAccessIssue]
-        make_tensor_arg,  # pyright: ignore[reportAttributeAccessIssue]
         scalar_to_uint64,  # pyright: ignore[reportAttributeAccessIssue]
     )
-    from .task_interface import (  # noqa: PLC0415
-        device_tensor_to_tensor,  # pyright: ignore[reportAttributeAccessIssue]
-    )
+
+    # Both tensor branches go through pypto's own converter, which resolves the bound
+    # worker: Simpler's ``make_tensor_arg`` needs it (it memoizes the host tensor as a
+    # FORK_SHM handle on a worker) and a DeviceTensor needs its allocating Buffer. That
+    # is the same path L3's generated orchestration uses, so the two levels cannot drift.
+    from .tensor_arg import make_tensor_arg  # noqa: PLC0415
 
     orch_args = ChipStorageTaskArgs()
     for i, arg in enumerate(coerced):
@@ -756,7 +758,7 @@ def _coerced_to_orch_args(
             orch_args.add_tensor(make_tensor_arg(arg))
         elif isinstance(arg, DeviceTensor):
             try:
-                orch_args.add_tensor(device_tensor_to_tensor(arg))
+                orch_args.add_tensor(make_tensor_arg(arg))
             except ValueError as e:
                 raise ValueError(f"At position {i}: {e}") from e
         elif isinstance(arg, _SimpleCData):

--- a/python/pypto/runtime/runtime_base.py
+++ b/python/pypto/runtime/runtime_base.py
@@ -201,6 +201,7 @@ class Worker(ABC):
             dtype=dtype,
             init=init,
             init_prep=self._prepare_init,
+            worker_id=worker_id,
         )
         self._owned_tensors.add((worker_id, t.data_ptr))
         return t

--- a/python/pypto/runtime/tensor_arg.py
+++ b/python/pypto/runtime/tensor_arg.py
@@ -17,12 +17,32 @@ This pypto-owned wrapper widens that conversion to also accept worker-resident
 pre-uploaded device buffers — mirroring the L2 path in
 :func:`pypto.runtime.runner.execute_compiled`.
 
-Host ``torch.Tensor`` arguments are delegated unchanged to simpler's
-``make_tensor_arg``; only the device-resident branches are added here.
+Host ``torch.Tensor`` arguments are delegated to simpler's ``make_tensor_arg``,
+which since the Buffer refactor takes ``(worker, tensor)`` — it memoizes the
+tensor as a ``FORK_SHM`` handle *on* the worker. The generated code has no worker
+in scope, so the caller binds one for the duration of the entry call through
+:func:`bind_worker`; only the device-resident branches are otherwise added here.
 """
 
+import contextvars
 from functools import cache
 from typing import Any
+
+_CURRENT_WORKER: contextvars.ContextVar[Any] = contextvars.ContextVar("pypto_l3_worker", default=None)
+
+
+def bind_worker(worker: Any) -> Any:
+    """Make *worker* the target of host-tensor arg conversion; returns a reset token.
+
+    A ContextVar rather than an attribute so nested or concurrent submissions each
+    see their own worker, and so an exception on the entry path cannot leave a stale
+    worker bound for the next request.
+    """
+    return _CURRENT_WORKER.set(worker)
+
+
+def unbind_worker(token: Any) -> None:
+    _CURRENT_WORKER.reset(token)
 
 
 @cache
@@ -70,6 +90,26 @@ def make_tensor_arg(arg: Any) -> Any:
 
     if isinstance(arg, task_interface.Tensor):
         return arg
+    holder = _CURRENT_WORKER.get()
     if isinstance(arg, device_tensor.DeviceTensor):
-        return task_interface.device_tensor_to_tensor(arg)
-    return task_interface.make_tensor_arg(arg)
+        convert = getattr(holder, "device_tensor_arg", None)
+        if convert is None:
+            raise RuntimeError(
+                "make_tensor_arg received a DeviceTensor but the bound submitter cannot name device "
+                "memory. A Simpler wire Tensor is a view over the owning chip's Buffer, so the "
+                "conversion needs the runtime that allocated it (DistributedWorker)."
+            )
+        return convert(arg)
+    # A runner binds itself (it owns the device-buffer registry); the plain
+    # non-persistent path binds a Simpler Worker directly.
+    worker = getattr(holder, "_w", holder)
+    if worker is None:
+        raise RuntimeError(
+            "make_tensor_arg received a host torch.Tensor with no worker bound. Simpler's "
+            "make_tensor_arg memoizes the tensor as a FORK_SHM handle on a specific worker, so "
+            "one has to be in scope: build task args inside a `with ChipWorker(...):` block at "
+            "L2, or let DistributedWorker's submission path bind itself at L3. Building them "
+            "before the worker exists — as execute_compiled's one-shot path still does — cannot "
+            "work under the Buffer ABI."
+        )
+    return task_interface.make_tensor_arg(worker, arg)

--- a/python/pypto/runtime/worker.py
+++ b/python/pypto/runtime/worker.py
@@ -47,6 +47,7 @@ from typing import TYPE_CHECKING, Any
 
 from .runner import RunConfig
 from .runtime_base import Worker
+from ._buffer_bridge import BufferBridge
 
 if TYPE_CHECKING:
     from pypto.ir.compiled_program import CallArg, CompiledProgram
@@ -99,7 +100,7 @@ _ACTIVE_WORKERS: contextvars.ContextVar[tuple[ChipWorker, ...]] = contextvars.Co
 _DEFAULT_RUNTIME = "tensormap_and_ringbuffer"
 
 
-class ChipWorker(Worker):
+class ChipWorker(BufferBridge, Worker):
     """L2 single-chip execution handle, bound to one ``(platform, device_id, runtime)``.
 
     A ``ChipWorker`` auto-initializes device state in ``__init__`` so that an
@@ -160,6 +161,7 @@ class ChipWorker(Worker):
         self._runtime = runtime
         self._enable_sdma = bool(enable_sdma)
         self._token: contextvars.Token | None = None
+        self._arg_token: Any = None
 
         self._impl = _get_simpler_worker_cls()(
             level=level,
@@ -168,6 +170,7 @@ class ChipWorker(Worker):
             runtime=runtime,
             enable_sdma=self._enable_sdma,
         )
+        self._init_buffer_bridge()
         self._initialized = False
         # Maps id(chip_callable) -> handle returned by simpler Worker.register()
         # (an opaque ``CallableHandle`` since runtime #891; typed ``Any`` to
@@ -215,6 +218,9 @@ class ChipWorker(Worker):
         # cid registrations / tear down the impl so the underlying free path
         # is still live.
         self._close_owned_tensors()
+        # Same ordering argument for the shm staging Buffers: closing them needs a live
+        # worker, so it happens before ``_impl.close()``.
+        self._release_staging_buffers()
         # Drop per-handle host-side state before tearing down the device so
         # the underlying ChipWorker.finalize() doesn't observe stale
         # registrations on a re-init(). ``unregister`` accepts the opaque
@@ -261,12 +267,32 @@ class ChipWorker(Worker):
         self._require_initialized("malloc")
         if not isinstance(nbytes, int) or nbytes <= 0:
             raise ValueError(f"nbytes must be a positive int, got {nbytes!r}")
-        return self._impl.malloc(nbytes, worker_id)
+        self._require_leaf_worker(worker_id, "malloc")
+        # Simpler's leaf ``malloc`` returns a Buffer and no longer takes a worker id.
+        # Keep handing the caller an int so pypto's public surface is unchanged, and
+        # remember the Buffer: the pointer alone cannot be re-wrapped later.
+        handle = self._impl.malloc(int(nbytes))
+        self._register_device_buffer(int(worker_id), int(handle.base), handle)
+        return int(handle.base)
+
+    def _simpler_worker(self) -> Any:
+        return self._impl
+
+    @staticmethod
+    def _require_leaf_worker(worker_id: int, api: str) -> None:
+        """A ChipWorker drives one chip, so ``worker_id`` can only be 0.
+
+        It stays in the signature because the Worker ABC declares it; a non-zero value
+        used to be silently forwarded to Simpler, which no longer takes one at all.
+        """
+        if int(worker_id) != 0:
+            raise ValueError(f"{api}: ChipWorker drives a single chip; worker_id must be 0, got {worker_id}")
 
     def free(self, ptr: int, *, worker_id: int = 0) -> None:
         """Release a pointer previously returned by :meth:`malloc`."""
         self._require_initialized("free")
-        self._impl.free(ptr, worker_id)
+        self._require_leaf_worker(worker_id, "free")
+        self._impl.free(self._pop_device_buffer(int(ptr), int(worker_id), "free"))
 
     def copy_to(
         self,
@@ -283,7 +309,13 @@ class ChipWorker(Worker):
         this call returns.
         """
         self._require_initialized("copy_to")
-        self._impl.copy_to(dst_dev_ptr, src_host_ptr, nbytes, worker_id)
+        self._require_leaf_worker(worker_id, "copy_to")
+        # Both sides must be Buffers now. A leaf worker has no forked children, but the
+        # host side still has to be nameable, so it goes through shm staging — one
+        # memcpy, and the same code path L3 uses for post-fork host memory.
+        dst = self._device_buffer_for(int(dst_dev_ptr), int(worker_id), "copy_to")
+        src = self._stage_host_to_buffer(int(worker_id), int(src_host_ptr), int(nbytes))
+        self._impl.copy_to(dst, src)
 
     def copy_from(
         self,
@@ -295,7 +327,11 @@ class ChipWorker(Worker):
     ) -> None:
         """D2H copy: ``nbytes`` bytes from device *src_dev_ptr* back to host *dst_host_ptr*."""
         self._require_initialized("copy_from")
-        self._impl.copy_from(dst_host_ptr, src_dev_ptr, nbytes, worker_id)
+        self._require_leaf_worker(worker_id, "copy_from")
+        src = self._device_buffer_for(int(src_dev_ptr), int(worker_id), "copy_from")
+        staging = self._staging_buffer(int(worker_id), int(nbytes))
+        self._impl.copy_from(staging, src)
+        self._stage_buffer_to_host(staging, int(dst_host_ptr), int(nbytes))
 
     # ``alloc_tensor`` / ``free_tensor`` are inherited from Worker (ABC).
     # L2 uses the default ``_prepare_init`` (a defensive contiguous CPU copy);
@@ -538,10 +574,22 @@ class ChipWorker(Worker):
         if not self._initialized:
             self.init()
         self._token = _ACTIVE_WORKERS.set(stack + (self,))
+        # Simpler's task-arg conversion is worker-scoped now: a host tensor is memoized
+        # as a FORK_SHM handle on a specific worker, and a DeviceTensor resolves through
+        # the Buffer that allocated it. Bind this worker for the block so the shared
+        # converter works at L2 exactly as it does for L3's generated orchestration.
+        from .tensor_arg import bind_worker  # noqa: PLC0415
+
+        self._arg_token = bind_worker(self)
         return self
 
     def __exit__(self, *_exc: Any) -> None:
         assert self._token is not None
+        from .tensor_arg import unbind_worker  # noqa: PLC0415
+
+        if getattr(self, "_arg_token", None) is not None:
+            unbind_worker(self._arg_token)
+            self._arg_token = None
         _ACTIVE_WORKERS.reset(self._token)
         self._token = None
         self.close()

--- a/src/codegen/distributed/distributed_codegen.cpp
+++ b/src/codegen/distributed/distributed_codegen.cpp
@@ -1064,9 +1064,12 @@ void DistributedCodegen::EmitCallToWorker(const ir::CallPtr& call, const ir::Fun
         tag = ParamDirectionToTensorArgType(callee->param_directions_[i]);
       }
       const std::string handle_var = HandleVarForScope(ScopeForWindowBuffer(window_buffer));
-      emitter_.EmitLine(ta_var + ".add_tensor(Tensor.make(data=" + handle_var + "[" + rank_expr +
-                        "].buffer_ptrs[\"" + name + "\"], shapes=" + shape + ", dtype=" + dtype_enum +
-                        ", child_memory=True), " + tag + ")");
+      // The domain hands each named window slice over as a VMM_WINDOW Buffer owned by
+      // that chip, so the task arg is a view of it. This replaces the retired
+      // ``Tensor.make(data=<ptr>, child_memory=True)`` raw-address form: chip ownership
+      // now rides in the Buffer instead of being implied by the dispatch.
+      emitter_.EmitLine(ta_var + ".add_tensor(" + handle_var + "[" + rank_expr + "].buffers[\"" + name +
+                        "\"].tensor(" + shape + ", " + dtype_enum + "), " + tag + ")");
       continue;
     }
 

--- a/src/codegen/distributed/distributed_ops_codegen.cpp
+++ b/src/codegen/distributed/distributed_ops_codegen.cpp
@@ -165,9 +165,9 @@ void EmitBuiltinWindowCollectiveDispatch(DistributedCodegen& codegen, const Call
       const std::string shape = codegen.FormatShapeTuple(dist_type->shape_);
       const std::string dtype_enum =
           "DataType." + DistributedCodegen::DataTypeToSimplerEnum(dist_type->dtype_);
-      codegen.Emit(ta_var + ".add_tensor(Tensor.make(data=" + arg_handle + "[" + rank_expr +
-                   "].buffer_ptrs[\"" + name + "\"], shapes=" + shape + ", dtype=" + dtype_enum +
-                   ", child_memory=True), " + tag + ")");
+      // Same as the orchestration path: a view of the domain's per-chip window Buffer.
+      codegen.Emit(ta_var + ".add_tensor(" + arg_handle + "[" + rank_expr + "].buffers[\"" + name +
+                   "\"].tensor(" + shape + ", " + dtype_enum + "), " + tag + ")");
       continue;
     }
     if (ir::As<ir::TileType>(call->args_[i]->GetType())) {
@@ -203,7 +203,7 @@ void EmitBuiltinWindowCollectiveDispatch(DistributedCodegen& codegen, const Call
 // as part of the ``orch.allocate_domain(buffers=[CommBufferSpec(...), ...])``
 // spec list wrapping the host_orch body. The host_orch.py module never needs
 // to reach for the IR-level alloc op again — chip dispatch reads the device
-// pointer from ``__comm_d0[r].buffer_ptrs["<name>"]`` instead. Returning
+// pointer from ``__comm_d0[r].buffers["<name>"]`` instead. Returning
 // empty signals the surrounding ``AssignStmt`` visitor to drop the line.
 // ============================================================================
 REGISTER_DISTRIBUTED_OP(pld_tensor_alloc_window_buffer, "pld.tensor.alloc_window_buffer") {
@@ -217,7 +217,7 @@ REGISTER_DISTRIBUTED_OP(pld_tensor_alloc_window_buffer, "pld.tensor.alloc_window
 //
 // ``pld.tensor.window`` materialises a window-bound view at IR construction
 // time; ``MaterializeCommDomainScopes`` rewires every dispatch site so the per-rank
-// device pointer is read from ``__comm_d0[r].buffer_ptrs["<name>"]`` at
+// device pointer is read from ``__comm_d0[r].buffers["<name>"]`` at
 // chip-arg emission time. The host_orch.py module never calls back into
 // the IR window op.
 // ============================================================================

--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -190,7 +190,7 @@ std::string GenerateMakeTensorExternal(const std::string& var_name, int orch_ind
                                        [[maybe_unused]] const TensorTypePtr& tensor_type,
                                        [[maybe_unused]] const CodegenBase& codegen) {
   std::ostringstream oss;
-  oss << "    const Tensor& ext_" << var_name << " = orch_args.tensor(" << orch_index << ").ref();\n";
+  oss << "    const ChipTensor& ext_" << var_name << " = orch_args.tensor(" << orch_index << ").ref();\n";
   return oss.str();
 }
 
@@ -843,7 +843,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
         // the enclosing scope so a task / method-receiver placed AFTER the block
         // resolves it (issue #1713; see EmitMutableTensorCarryDecl). Non-Tensor
         // (e.g. Sequential TaskId scalar) carries keep their in-block decl.
-        if (cpp_type == "Tensor") {
+        if (cpp_type == "ChipTensor") {
           EmitMutableTensorCarryDecl(carry_name, init_var_name);
         } else {
           EmitIndentedLine(cpp_type + " " + carry_name + " = " + init_var_name + ";");
@@ -1132,7 +1132,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
     for (const auto& rv : if_stmt->return_vars_) {
       const std::string emit_name = ReserveVarEmitName(rv.get());
       const std::string cpp_type = GetCppType(rv->GetType());
-      if (cpp_type == "Tensor") {
+      if (cpp_type == "ChipTensor") {
         INTERNAL_CHECK_SPAN(!tensor_phi_init.empty(), if_stmt->span_)
             << "Internal error: IfStmt return_var '" << rv->name_hint_
             << "' is a Tensor but no in-scope Tensor was found to use as the "
@@ -1383,7 +1383,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
         // alias the carry's later value.
         const bool carry_collapse_ok =
             hoisted_carry_names_.count(value_expr) == 0 || IsAtManualScopeBodyIndent();
-        if (cpp_type == "Tensor" && manual_local_names_ != nullptr && IsEnclosingScopeValid(value_expr) &&
+        if (cpp_type == "ChipTensor" && manual_local_names_ != nullptr && IsEnclosingScopeValid(value_expr) &&
             !IsMutableTensorNameInCurrentScope(value_expr) && !IsMutableTensorNameInCurrentScope(var_name) &&
             carry_collapse_ok) {
           emit_name_map_[assign->var_.get()] = value_expr;
@@ -1602,10 +1602,10 @@ class OrchestrationStmtCodegen : public CodegenBase {
       if (scalar_type->dtype_ == DataType::TASK_ID) return "PTO2TaskId";
       return scalar_type->dtype_.ToCTypeString();
     }
-    // TensorType: use ``Tensor`` so default-constructible declarations are
+    // TensorType: use ``ChipTensor`` so default-constructible declarations are
     // legal (C++ rejects ``auto x;`` without init). Yield/Assign downstream
     // will rebind it.
-    if (AsTensorTypeLike(type)) return "Tensor";
+    if (AsTensorTypeLike(type)) return "ChipTensor";
     if (As<CommCtxType>(type)) return "uint64_t";
     // ArrayType has split declaration syntax (``dtype name[N]``) — there's no
     // single "type expression" that names a C array. Callers that need to
@@ -3020,7 +3020,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
     EmitIndentedLine(alloc.str());
 
     for (size_t i = 0; i < emit_names.size(); i++) {
-      EmitIndentedLine("const Tensor& " + emit_names[i] + " = " + alloc_var + ".get_ref(" +
+      EmitIndentedLine("const ChipTensor& " + emit_names[i] + " = " + alloc_var + ".get_ref(" +
                        std::to_string(i) + ");");
     }
   }
@@ -3374,7 +3374,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
     if (mutable_alias) {
       EmitIndentedLine(alias_name + " = " + out_name + ";");
     } else {
-      EmitIndentedLine("const Tensor& " + alias_name + " = " + out_name + ";");
+      EmitIndentedLine("const ChipTensor& " + alias_name + " = " + out_name + ";");
     }
   }
 
@@ -3399,7 +3399,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
   }
 
   void RegisterMutableTensorName(const std::string& cpp_type, const std::string& emit_name) {
-    if (cpp_type == "Tensor") {
+    if (cpp_type == "ChipTensor") {
       mutable_tensor_name_scopes_.back().insert(emit_name);
     }
   }
@@ -3434,16 +3434,16 @@ class OrchestrationStmtCodegen : public CodegenBase {
   /// Caller guarantees the decl type is ``Tensor``.
   void EmitMutableTensorCarryDecl(const std::string& name, const std::string& init_expr) {
     if (scope_hoist_sink_ != nullptr && IsAtManualScopeBodyIndent() && IsEnclosingScopeValid(init_expr)) {
-      scope_hoist_sink_->push_back(IndentAtLevel(scope_hoist_indent_level_) + "Tensor " + name + " = " +
+      scope_hoist_sink_->push_back(IndentAtLevel(scope_hoist_indent_level_) + "ChipTensor " + name + " = " +
                                    init_expr + ";\n");
       RegisterMutableTensorNameInEnclosingScope(name);
       hoisted_carry_names_.insert(name);
       if (manual_local_names_ != nullptr) manual_local_names_->erase(name);
       if (enclosing_manual_local_names_ != nullptr) enclosing_manual_local_names_->insert(name);
     } else {
-      EmitIndentedLine("Tensor " + name + " = " + init_expr + ";");
+      EmitIndentedLine("ChipTensor " + name + " = " + init_expr + ";");
 
-      RegisterMutableTensorName("Tensor", name);
+      RegisterMutableTensorName("ChipTensor", name);
     }
   }
 
@@ -3804,7 +3804,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
         if (IsMutableTensorNameInCurrentScope(elem_name)) {
           EmitIndentedLine(elem_name + " = " + source + ";");
         } else {
-          EmitIndentedLine("const Tensor& " + elem_name + " = " + source + ";");
+          EmitIndentedLine("const ChipTensor& " + elem_name + " = " + source + ";");
         }
       }
     }

--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -161,7 +161,7 @@ std::string GenerateScalarUnpack(const std::string& var_name, int scalar_index,
 std::string GenerateConfigFunction(int expected_arg_count) {
   std::ostringstream oss;
   oss << "__attribute__((visibility(\"default\")))\n";
-  oss << "PTO2OrchestrationConfig aicpu_orchestration_config(const L2TaskArgs& orch_args) {\n";
+  oss << "PTO2OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs& orch_args) {\n";
   oss << "    (void)orch_args;\n";
   oss << "    return PTO2OrchestrationConfig{\n";
   oss << "        .expected_arg_count = " << expected_arg_count << ",\n";
@@ -2307,7 +2307,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
   // Speculative early-dispatch opt-in (pl.submit(..., allow_early_resolve=True)).
   // The flag rides on the Submit and is surfaced as the ``allow_early_resolve``
   // Call attr by SubmitToCallView; a plain submit / call lacks it, so this is a
-  // no-op there. Emitted on the producer task's L0TaskArgs before its rt_submit_* —
+  // no-op there. Emitted on the producer task's CoreTaskArgs before its rt_submit_* —
   // see simpler#1065 ("codegen-side emission of set_allow_early_resolve()").
   void EmitEarlyResolveHint(const std::string& task_var, const CallPtr& call) {
     if (call->GetAttr<bool>("allow_early_resolve", false)) {
@@ -2662,7 +2662,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
 
   /// Emit the per-task ``Arg`` declaration. Dependency edges (if any) are
   /// attached separately by ``EmitManualDeps`` via ``set_dependencies``.
-  void EmitTaskParamsDecl(const std::string& task_var) { EmitIndentedLine("L0TaskArgs " + task_var + ";"); }
+  void EmitTaskParamsDecl(const std::string& task_var) { EmitIndentedLine("CoreTaskArgs " + task_var + ";"); }
 
   struct TaskDispatchPlan {
     std::string comment;
@@ -4194,7 +4194,7 @@ OrchestrationResult GenerateOrchestration(const ir::ProgramPtr& program, const i
   oss << GenerateConfigFunction(expected_arg_count);
 
   oss << "__attribute__((visibility(\"default\")))\n";
-  oss << "void aicpu_orchestration_entry(const L2TaskArgs& orch_args) {\n";
+  oss << "void aicpu_orchestration_entry(const ChipTaskArgs& orch_args) {\n";
 
   // Selective vs. full tensor dump is no longer requested from the orch body.
   // simpler#953 removed the ``enable_dump_tensor_selective()`` toggle: the

--- a/src/codegen/tensor_op_codegen.cpp
+++ b/src/codegen/tensor_op_codegen.cpp
@@ -371,7 +371,7 @@ REGISTER_ORCHESTRATION_OP(tensor_slice, ("tensor.slice")) {
   }
 
   // Runtime tensor views use shape+offset; valid_shape only affects IR metadata.
-  oss << "Tensor " << result_var << " = " << ext_input_name << ".view(" << result_var << "_shapes, "
+  oss << "ChipTensor " << result_var << " = " << ext_input_name << ".view(" << result_var << "_shapes, "
       << result_var << "_offsets);";
   return oss.str();
 }
@@ -414,7 +414,7 @@ REGISTER_ORCHESTRATION_OP(tensor_reshape, ("tensor.reshape")) {
   }
 
   // Runtime Tensor::reshape requires the source to be contiguous; valid_shape only affects IR metadata.
-  oss << "Tensor " << result_var << " = " << ext_input_name << ".reshape(" << result_var << "_shapes, "
+  oss << "ChipTensor " << result_var << " = " << ext_input_name << ".reshape(" << result_var << "_shapes, "
       << ndim << ");";
   return oss.str();
 }
@@ -478,7 +478,7 @@ REGISTER_ORCHESTRATION_OP(tensor_transpose, ("tensor.transpose")) {
   std::string result_var = codegen.GetCurrentResultTarget();
 
   std::ostringstream oss;
-  oss << "Tensor " << result_var << " = " << ext_input_name << ".transpose(" << axis1 << ", " << axis2
+  oss << "ChipTensor " << result_var << " = " << ext_input_name << ".transpose(" << axis1 << ", " << axis2
       << ");";
   return oss.str();
 }
@@ -535,13 +535,13 @@ REGISTER_ORCHESTRATION_OP(tensor_view, ("tensor.view")) {
       oss << EmitRuntimeTensorShapeDim(shape_dim, input_type->dtype_, i, ndim, codegen);
     }
     oss << "};\n";
-    oss << "Tensor " << result_var << " = " << ext_input_name << ".reshape(" << result_var << "_shapes, "
+    oss << "ChipTensor " << result_var << " = " << ext_input_name << ".reshape(" << result_var << "_shapes, "
         << ndim << ");";
     return oss.str();
   }
 
   if (target_layout == src_layout) {
-    oss << "Tensor " << result_var << " = " << ext_input_name << ";";
+    oss << "ChipTensor " << result_var << " = " << ext_input_name << ";";
   } else {
     int64_t ndim = static_cast<int64_t>(input_type->shape_.size());
     INTERNAL_CHECK_SPAN(ndim >= 2, op->span_)
@@ -550,7 +550,7 @@ REGISTER_ORCHESTRATION_OP(tensor_view, ("tensor.view")) {
     CHECK_SPAN(input_type->dtype_ != DataType::FP4, op->span_)
         << "tensor.view cannot move the packed FP4 last axis during an Orchestration layout change because "
            "the runtime Tensor carries physical x2 elements; lower the view through PTO in-core codegen";
-    oss << "Tensor " << result_var << " = " << ext_input_name << ".transpose(" << (ndim - 2) << ", "
+    oss << "ChipTensor " << result_var << " = " << ext_input_name << ".transpose(" << (ndim - 2) << ", "
         << (ndim - 1) << ");";
   }
 

--- a/src/ir/transforms/expand_mixed_kernel_pass.cpp
+++ b/src/ir/transforms/expand_mixed_kernel_pass.cpp
@@ -1466,7 +1466,7 @@ bool FunctionCallsFunction(const FunctionPtr& func, const std::string& callee_na
 // Hand-written Group ABI normalization
 // ============================================================================
 
-/// Runtime MixedKernels subslots share one L0TaskArgs payload. Auto-expanded
+/// Runtime MixedKernels subslots share one CoreTaskArgs payload. Auto-expanded
 /// Groups already satisfy that contract because both member calls forward the
 /// complete Group signature. A hand-written Group may call AIC/AIV functions
 /// with different subsets, however, so normalize both members to the Group ABI

--- a/tests/ut/codegen/_orchestration_codegen_common.py
+++ b/tests/ut/codegen/_orchestration_codegen_common.py
@@ -138,7 +138,7 @@ def _out_of_scope_tensor_refs(code: str) -> list[str]:
     Numeric literals (``= 0;``), casts, and scalar locals carry neither marker,
     so they never yield false positives.
     """
-    decl_re = re.compile(r"\b(?:const\s+Tensor\s*&|Tensor|TaskOutputTensors|Arg)\s+(\w+)")
+    decl_re = re.compile(r"\b(?:const\s+ChipTensor\s*&|ChipTensor|TaskOutputTensors|Arg)\s+(\w+)")
     declared_anywhere = set(decl_re.findall(code))
     # An SSA-versioned tensor temp is unambiguously a tensor regardless of whether
     # its declaration still exists, so an out-of-scope reference to one is always
@@ -153,7 +153,7 @@ def _out_of_scope_tensor_refs(code: str) -> list[str]:
         line = raw.strip()
         # Declarations and uses are each emitted on their own line (never sharing
         # a line with a scope brace), so resolve them against the current scope
-        # set first. Declarations are recorded before uses so a ``const Tensor& Y
+        # set first. Declarations are recorded before uses so a ``const ChipTensor& Y
         # = X`` line registers Y while still checking the RHS read of X.
         for m in decl_re.finditer(line):
             scopes[-1].add(m.group(1))

--- a/tests/ut/codegen/distributed/test_host_orch_distributed.py
+++ b/tests/ut/codegen/distributed/test_host_orch_distributed.py
@@ -14,8 +14,9 @@ Covers four orthogonal pieces of the host_orch emit:
 1. Programs with at least one comm domain wrap the body in
    ``with orch.allocate_domain(name=..., workers=..., window_size=...,
    buffers=[CommBufferSpec(...)]) as __comm_d0:``.
-2. DistributedTensor formal → ``add_tensor(Tensor.make(data=__comm_d0[<r>]
-   .buffer_ptrs["<name>"], shapes=..., dtype=..., child_memory=True), ...)``.
+2. DistributedTensor formal → ``add_tensor(__comm_d0[<r>].buffers["<name>"]
+   .tensor(<shapes>, <dtype>), ...)`` — the window VA is
+   domain-owned and chip-local, so the owning rank travels with it.
 3. Explicit CommCtx scalar:
    ``add_scalar(__comm_d0[<r>].device_ctx)`` placed AFTER all tensor adds,
    in IR-arg order (matching the materialized incore function signature).
@@ -90,7 +91,7 @@ def _lower_host_collectives(program):
 
 # ---------------------------------------------------------------------------
 # Positive: DistributedTensor formals + device= → with orch.allocate_domain
-# + Tensor.make + add_scalar(ctx) + worker= + world_size lowering
+# + window Buffer .tensor() + add_scalar(ctx) + worker= + world_size lowering
 # ---------------------------------------------------------------------------
 
 
@@ -127,15 +128,14 @@ def test_dist_tensor_formal_emits_continuous_tensor_make():
 
     # for r in range(..., world_size, ...):  ← world_size lowering in loop bound.
     assert re.search(r"for \w+ in range\(.*\bworld_size\b.*\):", code), code
-    # Tensor.make for the DistributedTensor formal — keyed on
+    # window Buffer view for the DistributedTensor formal — keyed on
     # the alloc op's LHS name_hint (``data_buf``).
     assert re.search(
-        r'Tensor\.make\(data=__comm_d0\[\w+\]\.buffer_ptrs\["data_buf"\],'
-        r" shapes=\(64,\), dtype=DataType\.FLOAT32, child_memory=True\)",
+        r'__comm_d0\[\w+\]\.buffers\["data_buf"\]\.tensor\(\(64,\), DataType\.FLOAT32\)',
         code,
     ), code
     # Trailing per-DistributedTensor ctx scalar — same rank index as
-    # the Tensor.make above.
+    # the window Buffer view above.
     assert re.search(r"\.add_scalar\(__comm_d0\[\w+\]\.device_ctx\)", code), code
     assert "pld.system.get_comm_ctx" not in code, code
     # ``device=r`` → rank-pinned dispatch routes through ``_submit_chip`` (which
@@ -168,10 +168,9 @@ def test_two_dist_tensor_formals_emit_two_explicit_ctx_scalars():
 
     code = _lower(Prog)
 
-    # Two Tensor.make lines — one per DistributedTensor formal.
+    # Two window Buffer view lines — one per DistributedTensor formal.
     cont_makes = re.findall(
-        r'Tensor\.make\(data=__comm_d0\[\w+\]\.buffer_ptrs\["([^"]+)"\],'
-        r" shapes=(\([^)]*\)), dtype=DataType\.([A-Z0-9]+),",
+        r'__comm_d0\[\w+\]\.buffers\["([^"]+)"\]\.tensor\((\([^)]*\)), DataType\.([A-Z0-9]+)\)',
         code,
     )
     assert len(cont_makes) == 2, code
@@ -240,7 +239,7 @@ def test_const_device_kwarg_renders_literal_worker():
 
     code = _lower(Prog)
     assert re.search(r"_submit_chip\(orch, callables\[\"chip_orch\"\],.*config, 0\)", code), code
-    assert "__comm_d0[0].buffer_ptrs" in code, code
+    assert "__comm_d0[0].buffers[" in code, code
     assert "__comm_d0[0].device_ctx" in code, code
 
 
@@ -289,7 +288,7 @@ def test_comm_group_program_emits_domain_provider_with_block():
     # All buffer / device_ctx lookups go through the handle; the legacy
     # ``contexts`` parameter must not appear anywhere.
     assert "contexts[" not in code, code
-    assert re.search(r"__comm_d0\[\w+\]\.buffer_ptrs", code), code
+    assert re.search(r"__comm_d0\[\w+\]\.buffers\[", code), code
 
 
 def test_comm_buffer_specs_align_each_physical_allocation():
@@ -364,10 +363,10 @@ def test_comm_less_dispatch_routes_through_submit_chip_unplaced():
     code = _lower(Prog)
     # The dispatch shape stays intact; the comm-less path routes through
     # ``_submit_chip(..., None)`` and emits no wrapper, no ctx-scalar /
-    # Tensor.make / handle subscript, and no ``worker=`` kwarg.
+    # window Buffer view / handle subscript, and no ``worker=`` kwarg.
     assert re.search(r"_submit_chip\(orch, callables\[\"chip_orch\"\],.*config, None\)", code), code
     assert "worker=" not in code, code
-    assert "Tensor.make" not in code, code
+    assert ".buffers[" not in code, code
     assert "__comm_d0[" not in code, code
     assert "allocate_domain" not in code, code
     assert "with orch" not in code, code
@@ -514,14 +513,14 @@ def test_two_groups_emit_nested_allocate_domain():
     assert d1_indent > d0_indent, (d0_line, d1_line)
 
     # Each dispatch's DistributedTensor arg routes through the right handle.
-    # group A dispatches: Tensor.make(... __comm_d0[...].buffer_ptrs["buf_a"] ...)
+    # group A dispatches: __comm_d0[...].buffers["buf_a"].tensor(...)
     # and add_scalar(__comm_d0[...].device_ctx).
     assert re.search(
-        r'Tensor\.make\(data=__comm_d0\[\w+\]\.buffer_ptrs\["buf_a"\],',
+        r'__comm_d0\[\w+\]\.buffers\["buf_a"\]\.tensor\(',
         code,
     ), code
     assert re.search(
-        r'Tensor\.make\(data=__comm_d1\[\w+\]\.buffer_ptrs\["buf_b"\],',
+        r'__comm_d1\[\w+\]\.buffers\["buf_b"\]\.tensor\(',
         code,
     ), code
     # The trailing per-tensor ctx scalar uses the matching handle too.
@@ -561,10 +560,10 @@ def test_two_groups_handle_routing_is_per_dispatch_not_state_bleed():
 
     code = _lower(Prog)
 
-    # Each dispatch site emits one Tensor.make line; the handle
+    # Each dispatch site emits one window Buffer view; the handle
     # prefix uniquely identifies the group.
     cont_makes = re.findall(
-        r'Tensor\.make\(data=(__comm_d\d+)\[\w+\]\.buffer_ptrs\["([^"]+)"\],',
+        r'(__comm_d\d+)\[\w+\]\.buffers\["([^"]+)"\]\.tensor\(',
         code,
     )
     assert cont_makes == [
@@ -787,9 +786,9 @@ def test_implicit_host_allreduce_builtin_codegen_materializes_signal():
     generated, cg = _lower_host_collectives(Prog)
 
     assert 'callables["builtin.tensor.allreduce__sum__fp32"]' in generated, generated
-    assert 'buffer_ptrs["__allreduce_signal_buf_0"]' in generated, generated
-    assert 'buffer_ptrs["data_buf"]' in generated, generated
-    assert 'buffer_ptrs["signal_buf"]' not in generated, generated
+    assert 'buffers["__allreduce_signal_buf_0"]' in generated, generated
+    assert 'buffers["data_buf"]' in generated, generated
+    assert 'buffers["signal_buf"]' not in generated, generated
     assert "orch.submit_next_level" in generated, generated
     assert ".add_scalar(__comm_d0[" in generated and "].domain_size)" in generated, generated
     assert "data = data" not in generated, generated

--- a/tests/ut/codegen/test_orchestration_codegen.py
+++ b/tests/ut/codegen/test_orchestration_codegen.py
@@ -73,7 +73,7 @@ class TestOrchestration:
             extern "C" {
 
             __attribute__((visibility("default")))
-            PTO2OrchestrationConfig aicpu_orchestration_config(const L2TaskArgs& orch_args) {
+            PTO2OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs& orch_args) {
                 (void)orch_args;
                 return PTO2OrchestrationConfig{
                     .expected_arg_count = 3,
@@ -81,7 +81,7 @@ class TestOrchestration:
             }
 
             __attribute__((visibility("default")))
-            void aicpu_orchestration_entry(const L2TaskArgs& orch_args) {
+            void aicpu_orchestration_entry(const ChipTaskArgs& orch_args) {
                 // External tensors
                 const Tensor& ext_a = orch_args.tensor(0).ref();
                 const Tensor& ext_b = orch_args.tensor(1).ref();
@@ -94,14 +94,14 @@ class TestOrchestration:
                     const Tensor& c = alloc_0.get_ref(0);
 
                     // Task 0: kernel_add
-                    L0TaskArgs params_t0;
+                    CoreTaskArgs params_t0;
                     params_t0.add_input(ext_a);
                     params_t0.add_input(ext_b);
                     params_t0.add_output(c);
                     rt_submit_aiv_task(0, params_t0);
 
                     // Task 1: kernel_add
-                    L0TaskArgs params_t1;
+                    CoreTaskArgs params_t1;
                     params_t1.add_input(c);
                     params_t1.add_input(ext_b);
                     params_t1.add_output(ext_d);
@@ -522,7 +522,7 @@ class TestOrchestration:
             extern "C" {
 
             __attribute__((visibility("default")))
-            PTO2OrchestrationConfig aicpu_orchestration_config(const L2TaskArgs& orch_args) {
+            PTO2OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs& orch_args) {
                 (void)orch_args;
                 return PTO2OrchestrationConfig{
                     .expected_arg_count = 3,
@@ -530,7 +530,7 @@ class TestOrchestration:
             }
 
             __attribute__((visibility("default")))
-            void aicpu_orchestration_entry(const L2TaskArgs& orch_args) {
+            void aicpu_orchestration_entry(const ChipTaskArgs& orch_args) {
                 // External tensors
                 const Tensor& ext_a = orch_args.tensor(0).ref();
                 const Tensor& ext_b = orch_args.tensor(1).ref();
@@ -552,35 +552,35 @@ class TestOrchestration:
                     const Tensor& g = alloc_0.get_ref(3);
 
                     // Task 0: kernel_add
-                    L0TaskArgs params_t0;
+                    CoreTaskArgs params_t0;
                     params_t0.add_input(ext_a);
                     params_t0.add_input(ext_b);
                     params_t0.add_output(c);
                     rt_submit_aiv_task(0, params_t0);
 
                     // Task 1: kernel_add_scalar
-                    L0TaskArgs params_t1;
+                    CoreTaskArgs params_t1;
                     params_t1.add_input(c);
                     params_t1.add_output(d);
                     params_t1.add_scalar(to_u64(1.000000f));
                     rt_submit_aiv_task(1, params_t1);
 
                     // Task 2: kernel_add_scalar
-                    L0TaskArgs params_t2;
+                    CoreTaskArgs params_t2;
                     params_t2.add_input(c);
                     params_t2.add_output(e);
                     params_t2.add_scalar(to_u64(2.000000f));
                     rt_submit_aiv_task(1, params_t2);
 
                     // Task 3: kernel_mul
-                    L0TaskArgs params_t3;
+                    CoreTaskArgs params_t3;
                     params_t3.add_input(d);
                     params_t3.add_input(e);
                     params_t3.add_output(g);
                     rt_submit_aiv_task(2, params_t3);
 
                     // Task 4: kernel_add
-                    L0TaskArgs params_t4;
+                    CoreTaskArgs params_t4;
                     params_t4.add_input(g);
                     params_t4.add_input(c);
                     params_t4.add_output(ext_f);
@@ -1560,7 +1560,7 @@ class TestOrchestration:
             extern "C" {
 
             __attribute__((visibility("default")))
-            PTO2OrchestrationConfig aicpu_orchestration_config(const L2TaskArgs& orch_args) {
+            PTO2OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs& orch_args) {
                 (void)orch_args;
                 return PTO2OrchestrationConfig{
                     .expected_arg_count = 7,
@@ -1568,7 +1568,7 @@ class TestOrchestration:
             }
 
             __attribute__((visibility("default")))
-            void aicpu_orchestration_entry(const L2TaskArgs& orch_args) {
+            void aicpu_orchestration_entry(const ChipTaskArgs& orch_args) {
                 // External tensors
                 const Tensor& ext_mij = orch_args.tensor(0).ref();
                 const Tensor& ext_lij = orch_args.tensor(1).ref();
@@ -1581,7 +1581,7 @@ class TestOrchestration:
                 PTO2_SCOPE() {
 
                     // Task 0: online_update
-                    L0TaskArgs params_t0;
+                    CoreTaskArgs params_t0;
                     params_t0.add_input(ext_mij);
                     params_t0.add_input(ext_lij);
                     params_t0.add_input(ext_oi_new);

--- a/tests/ut/codegen/test_orchestration_codegen.py
+++ b/tests/ut/codegen/test_orchestration_codegen.py
@@ -83,15 +83,15 @@ class TestOrchestration:
             __attribute__((visibility("default")))
             void aicpu_orchestration_entry(const ChipTaskArgs& orch_args) {
                 // External tensors
-                const Tensor& ext_a = orch_args.tensor(0).ref();
-                const Tensor& ext_b = orch_args.tensor(1).ref();
-                const Tensor& ext_d = orch_args.tensor(2).ref();
+                const ChipTensor& ext_a = orch_args.tensor(0).ref();
+                const ChipTensor& ext_b = orch_args.tensor(1).ref();
+                const ChipTensor& ext_d = orch_args.tensor(2).ref();
 
                 PTO2_SCOPE() {
                     uint32_t c_ci_shapes[2] = {16, 16};
                     TensorCreateInfo c_ci(c_ci_shapes, 2, DataType::FLOAT32);
                     TaskOutputTensors alloc_0 = alloc_tensors(c_ci);
-                    const Tensor& c = alloc_0.get_ref(0);
+                    const ChipTensor& c = alloc_0.get_ref(0);
 
                     // Task 0: kernel_add
                     CoreTaskArgs params_t0;
@@ -532,9 +532,9 @@ class TestOrchestration:
             __attribute__((visibility("default")))
             void aicpu_orchestration_entry(const ChipTaskArgs& orch_args) {
                 // External tensors
-                const Tensor& ext_a = orch_args.tensor(0).ref();
-                const Tensor& ext_b = orch_args.tensor(1).ref();
-                const Tensor& ext_f = orch_args.tensor(2).ref();
+                const ChipTensor& ext_a = orch_args.tensor(0).ref();
+                const ChipTensor& ext_b = orch_args.tensor(1).ref();
+                const ChipTensor& ext_f = orch_args.tensor(2).ref();
 
                 PTO2_SCOPE() {
                     uint32_t c_ci_shapes[2] = {16, 16};
@@ -546,10 +546,10 @@ class TestOrchestration:
                     uint32_t g_ci_shapes[2] = {16, 16};
                     TensorCreateInfo g_ci(g_ci_shapes, 2, DataType::FLOAT32);
                     TaskOutputTensors alloc_0 = alloc_tensors(c_ci, d_ci, e_ci, g_ci);
-                    const Tensor& c = alloc_0.get_ref(0);
-                    const Tensor& d = alloc_0.get_ref(1);
-                    const Tensor& e = alloc_0.get_ref(2);
-                    const Tensor& g = alloc_0.get_ref(3);
+                    const ChipTensor& c = alloc_0.get_ref(0);
+                    const ChipTensor& d = alloc_0.get_ref(1);
+                    const ChipTensor& e = alloc_0.get_ref(2);
+                    const ChipTensor& g = alloc_0.get_ref(3);
 
                     // Task 0: kernel_add
                     CoreTaskArgs params_t0;
@@ -773,13 +773,13 @@ class TestOrchestration:
 
         # All orch params are external tensors:
         # mij=0, lij=1, oi_new=2, mi_in=3, li_in=4, oi_in=5, dst_in=6, final=7
-        assert "const Tensor& ext_mi_in = orch_args.tensor(3).ref()" in code
-        assert "const Tensor& ext_li_in = orch_args.tensor(4).ref()" in code
-        assert "const Tensor& ext_oi_in = orch_args.tensor(5).ref()" in code
-        assert "const Tensor& ext_dst_in = orch_args.tensor(6).ref()" in code
+        assert "const ChipTensor& ext_mi_in = orch_args.tensor(3).ref()" in code
+        assert "const ChipTensor& ext_li_in = orch_args.tensor(4).ref()" in code
+        assert "const ChipTensor& ext_oi_in = orch_args.tensor(5).ref()" in code
+        assert "const ChipTensor& ext_dst_in = orch_args.tensor(6).ref()" in code
 
         # Final return tensor is external
-        assert "const Tensor& ext_final = orch_args.tensor(7).ref()" in code
+        assert "const ChipTensor& ext_final = orch_args.tensor(7).ref()" in code
 
         # Two tasks: online_update + kernel_add
         assert code.count("rt_submit_aiv_task") == 2
@@ -864,7 +864,7 @@ class TestOrchestration:
         assert "params_t0.add_inout(ext_inout_t)" in code
 
         # Each tuple result is the in-place arg it writes, so it remaps to that
-        # arg (no per-output ``const Tensor&`` alias is minted). The consumer
+        # arg (no per-output ``const ChipTensor&`` alias is minted). The consumer
         # ``combine`` reads ta/tb/tc — each result mapped to its OWN arg, NOT
         # shifted onto inout_t (issue #1573).
         ia = code.index("params_t1.add_input(ext_ta)")
@@ -874,7 +874,7 @@ class TestOrchestration:
         # The scrambled (shifted-by-one) mapping must NOT appear: combine must
         # not read inout_t, and no const-ref output alias is emitted.
         assert "add_input(ext_inout_t)" not in code
-        assert all(f"const Tensor& o{i}" not in code for i in (1, 2, 3)), code
+        assert all(f"const ChipTensor& o{i}" not in code for i in (1, 2, 3)), code
 
     @staticmethod
     def _manual_cross_scope_code(create_inside: bool) -> str:
@@ -951,22 +951,22 @@ class TestOrchestration:
         manual_open = code.index("PTO2_SCOPE(PTO2ScopeMode::MANUAL)")
         manual_close = code.index("}", manual_open)
         # The buffer AND the alloc handle backing it are declared in the
-        # enclosing scope, ahead of the block — if only ``const Tensor& buf`` were
+        # enclosing scope, ahead of the block — if only ``const ChipTensor& buf`` were
         # hoisted while ``TaskOutputTensors alloc_0 = ...`` stayed inside, ``buf``
         # would reference an out-of-scope handle and the .cpp would not compile.
         assert code.index("TaskOutputTensors alloc_") < manual_open, code
         assert code.index("alloc_tensors(") < manual_open, code
-        decl = code.index("const Tensor& buf = ")
+        decl = code.index("const ChipTensor& buf = ")
         assert decl < manual_open, code
         # The after-scope consumer reads ``buf`` directly — no const-ref alias
         # is minted for the producer's SSA output.
         assert "add_input(buf)" in code[manual_close:], code
-        assert "const Tensor& buf__" not in code, code
+        assert "const ChipTensor& buf__" not in code, code
 
     def test_manual_scope_tensor_created_before_read_after(self):
         """Regression for #1697: a tensor created BEFORE a ``pl.manual_scope``,
         written by a submit inside it, and read by a task after it. The output
-        previously minted ``const Tensor& buf__ssa_v1 = buf;`` at the deep block
+        previously minted ``const ChipTensor& buf__ssa_v1 = buf;`` at the deep block
         indent; the after-scope ``add_input(buf__ssa_v1)`` then named an
         out-of-scope identifier and the orchestration ``.cpp`` failed to compile.
         The output is now remapped to read ``buf`` directly."""
@@ -991,7 +991,7 @@ class TestOrchestration:
         ``fresh_carry`` selects which lowering shape the loop carry takes:
           * False — the carry threads the before-scope tensor in place, so the
             post-loop ``score = score_rv`` rebind lowers to a catch-all
-            ``Tensor score__ssa_v1 = score;`` copy emitted at the deep block
+            ``ChipTensor score__ssa_v1 = score;`` copy emitted at the deep block
             indent; the after-scope ``pl.reshape`` reader then named the
             out-of-scope ``score__ssa_v1``.
           * True — the loop yields a freshly created tensor each iteration
@@ -1082,7 +1082,7 @@ class TestOrchestration:
         (a method-receiver use the old ``add_*``-only scope checker missed).
 
         The post-loop ``score = score_rv`` rebind lowered to a catch-all
-        ``Tensor score__ssa_v1 = score;`` copy at the deep block indent; the
+        ``ChipTensor score__ssa_v1 = score;`` copy at the deep block indent; the
         after-scope ``score_flat = score__ssa_v1.reshape(...)`` then named an
         out-of-scope identifier and the ``.cpp`` failed to C++-compile. The copy
         is now collapsed onto the enclosing ``score``."""
@@ -1100,8 +1100,8 @@ class TestOrchestration:
         ``pl.manual_scope`` (the loop yields a freshly created tensor each
         iteration, so OptimizeOrchTensors Pattern-5 externalizes the windowed
         write) read by a kernel after the scope. Codegen minted a mutable carry
-        ``Tensor acc_rv = acc;`` inside the block plus a chained
-        ``Tensor acc__ssa_v1 = acc_rv;`` post-loop copy; the after-scope
+        ``ChipTensor acc_rv = acc;`` inside the block plus a chained
+        ``ChipTensor acc__ssa_v1 = acc_rv;`` post-loop copy; the after-scope
         ``add_input`` named the out-of-scope chain.
 
         The carry decl is now hoisted to the enclosing scope and the chained copy
@@ -1111,12 +1111,12 @@ class TestOrchestration:
         # The windowed externalization actually fired (exercises Pattern-5).
         assert "produce__windowed" in code, code
         manual_open = code.index("PTO2_SCOPE(PTO2ScopeMode::MANUAL)")
-        # The mutable carry for ``acc`` (``Tensor acc_rv = acc;``) is hoisted AHEAD
+        # The mutable carry for ``acc`` (``ChipTensor acc_rv = acc;``) is hoisted AHEAD
         # of the manual block header (declared in the enclosing scope). Anchor the
         # match to the ``acc`` carry initialised from ``acc`` so an unrelated
         # ``_rv`` temp emitted earlier can't be picked by mistake.
         carry_decls = list(
-            re.finditer(r"^\s*Tensor\s+(acc\w*_rv\w*)\s*=\s*acc;", code[:manual_open], flags=re.MULTILINE)
+            re.finditer(r"^\s*ChipTensor\s+(acc\w*_rv\w*)\s*=\s*acc;", code[:manual_open], flags=re.MULTILINE)
         )
         assert len(carry_decls) == 1, code[:manual_open]
         carry_name = carry_decls[0].group(1)
@@ -1180,7 +1180,7 @@ class TestOrchestration:
         # decl stays in place (a `Tensor <carry> = <init>;` exists) and is
         # reassigned in the loop.
         assert "PTO2_SCOPE(PTO2ScopeMode::MANUAL)" not in code, code
-        assert re.search(r"^\s*Tensor\s+\w*_rv\w*\s*=\s*\w+;", code, flags=re.MULTILINE), code
+        assert re.search(r"^\s*ChipTensor\s+\w*_rv\w*\s*=\s*\w+;", code, flags=re.MULTILINE), code
 
     def test_manual_scope_windowed_submit_read_after_reshape(self):
         """Regression for #1713 (the issue's headline shape): a tensor created
@@ -1262,7 +1262,7 @@ class TestOrchestration:
         carry taken INSIDE the loop body (a deeper indent than the manual-scope
         body) must NOT collapse onto the hoisted carry — otherwise a reader of
         the copy placed before the loop's yield rebind would alias the carry's
-        later value. The copy keeps a distinct ``Tensor snap = <carry>;`` decl.
+        later value. The copy keeps a distinct ``ChipTensor snap = <carry>;`` decl.
 
         (The post-loop ``acc = acc_rv`` rebind, at the manual-scope body indent,
         still collapses — exercised by the other #1713 tests; this guards the
@@ -1334,11 +1334,11 @@ class TestOrchestration:
             if f.func_type == ir.FunctionType.Orchestration and f.name == "main"
         )
         assert _out_of_scope_tensor_refs(code) == [], code
-        # The in-loop snapshot is materialised as its own ``Tensor snap = ...;``
+        # The in-loop snapshot is materialised as its own ``ChipTensor snap = ...;``
         # value and read as ``add_input(snap)`` — NOT collapsed onto the carry,
         # so the later ``<carry> = ...;`` yield rebind cannot change what the
         # snapshot reader sees.
-        assert re.search(r"^\s*Tensor\s+snap\s*=\s*\w+;", code, flags=re.MULTILINE), code
+        assert re.search(r"^\s*ChipTensor\s+snap\s*=\s*\w+;", code, flags=re.MULTILINE), code
         assert "add_input(snap)" in code, code
 
     def test_manual_scope_ifstmt_phi_read_after(self):
@@ -1400,14 +1400,14 @@ class TestOrchestration:
             if f.func_type == ir.FunctionType.Orchestration and f.name == "main"
         )
         # The IfStmt actually produced a Tensor phi placeholder (exercises the path).
-        assert re.search(r"Tensor\s+\w+__phi_v\d+\s*=", code), code
+        assert re.search(r"ChipTensor\s+\w+__phi_v\d+\s*=", code), code
         # No identifier names an out-of-scope name (including the after-scope read).
         assert _out_of_scope_tensor_refs(code) == [], code
         # The phi decl is hoisted AHEAD of the manual block header; the branch
         # ``<phi> = ...;`` merges stay inside the block (resolving through the
         # enclosing frame).
         manual_open = code.index("PTO2_SCOPE(PTO2ScopeMode::MANUAL)")
-        phi_decl = re.search(r"^\s*Tensor\s+(\w+__phi_v\d+)\s*=", code[:manual_open], flags=re.MULTILINE)
+        phi_decl = re.search(r"^\s*ChipTensor\s+(\w+__phi_v\d+)\s*=", code[:manual_open], flags=re.MULTILINE)
         assert phi_decl, code[:manual_open]
         phi_name = phi_decl.group(1)
         # The after-scope consumer reads the hoisted phi directly (in scope).
@@ -1442,11 +1442,11 @@ class TestOrchestration:
 
         code = _generate_orch_code(TensorCreateProgram)
 
-        # tensor.create generates TensorCreateInfo; const Tensor& binding emitted at submit site
+        # tensor.create generates TensorCreateInfo; const ChipTensor& binding emitted at submit site
         # FP16 = DataType::FLOAT16
         assert "uint32_t buf_ci_shapes[2] = {32, 32};" in code
         assert "TensorCreateInfo buf_ci(buf_ci_shapes, 2, DataType::FLOAT16)" in code
-        assert "const Tensor& buf = " in code
+        assert "const ChipTensor& buf = " in code
         assert "make_tensor_external(nullptr, buf_ci_shapes, 2, DataType::FLOAT16)" not in code
 
     def test_tensor_create_with_manual_dep(self):
@@ -1570,13 +1570,13 @@ class TestOrchestration:
             __attribute__((visibility("default")))
             void aicpu_orchestration_entry(const ChipTaskArgs& orch_args) {
                 // External tensors
-                const Tensor& ext_mij = orch_args.tensor(0).ref();
-                const Tensor& ext_lij = orch_args.tensor(1).ref();
-                const Tensor& ext_oi_new = orch_args.tensor(2).ref();
-                const Tensor& ext_mi = orch_args.tensor(3).ref();
-                const Tensor& ext_li = orch_args.tensor(4).ref();
-                const Tensor& ext_oi = orch_args.tensor(5).ref();
-                const Tensor& ext_dst = orch_args.tensor(6).ref();
+                const ChipTensor& ext_mij = orch_args.tensor(0).ref();
+                const ChipTensor& ext_lij = orch_args.tensor(1).ref();
+                const ChipTensor& ext_oi_new = orch_args.tensor(2).ref();
+                const ChipTensor& ext_mi = orch_args.tensor(3).ref();
+                const ChipTensor& ext_li = orch_args.tensor(4).ref();
+                const ChipTensor& ext_oi = orch_args.tensor(5).ref();
+                const ChipTensor& ext_dst = orch_args.tensor(6).ref();
 
                 PTO2_SCOPE() {
 

--- a/tests/ut/codegen/test_orchestration_codegen_more.py
+++ b/tests/ut/codegen/test_orchestration_codegen_more.py
@@ -1385,7 +1385,7 @@ class TestOrchestrationMore:
         assert t2_alloc_line > n_line, "t2 alloc must come after n definition"
 
     def test_scalar_taskarg(self):
-        """Scalar params get L2TaskArgs scalar slots (0-indexed) via from_u64<T>()."""
+        """Scalar params get ChipTaskArgs scalar slots (0-indexed) via from_u64<T>()."""
         backend.reset_for_testing()
         backend.set_backend_type(BackendType.Ascend910B)
 
@@ -1834,7 +1834,7 @@ class TestOrchestrationMore:
 
         Canonical order::
 
-          L0TaskArgs → params → dump → MixedKernels → launch_spec → set_dependencies → submit
+          CoreTaskArgs → params → dump → MixedKernels → launch_spec → set_dependencies → submit
 
         Guards against unintentional reorder in ``TaskDispatchPlan::Emit``.
         """
@@ -1884,19 +1884,19 @@ class TestOrchestrationMore:
         assert "params_t0.launch_spec." in code, code
         assert "rt_submit_task(mixed_0" in code, code
 
-        # MixedKernels must appear after L0TaskArgs (params/dump block ends with
+        # MixedKernels must appear after CoreTaskArgs (params/dump block ends with
         # add_* calls; MixedKernels comes next in the old canonical order).
-        assert "L0TaskArgs params_t0;" in code, code
-        l0_index = code.index("L0TaskArgs params_t0;")
+        assert "CoreTaskArgs params_t0;" in code, code
+        l0_index = code.index("CoreTaskArgs params_t0;")
         mixed_index = code.index("MixedKernels mixed_0")
         launch_index = code.index("params_t0.launch_spec.")
         submit_index = code.index("rt_submit_task(mixed_0")
-        assert l0_index < mixed_index, "MixedKernels must appear after L0TaskArgs"
+        assert l0_index < mixed_index, "MixedKernels must appear after CoreTaskArgs"
         assert mixed_index < launch_index, "MixedKernels must appear before launch_spec"
         assert launch_index < submit_index, "launch_spec must appear before submit"
 
     def test_direct_call_with_deps_emission_order(self):
-        """Direct-call path with deps: L0TaskArgs → deps array → set_dependencies → submit.
+        """Direct-call path with deps: CoreTaskArgs → deps array → set_dependencies → submit.
 
         The dependent task (params_t1) carries the deps. Guards the canonical
         order for ``pl.submit(..., deps=[...])`` so a future change to
@@ -1922,14 +1922,14 @@ class TestOrchestrationMore:
         code = _generate_orch_code(transformed)
 
         # Task 0 (no deps) and Task 1 (carries deps) must both be present.
-        assert "L0TaskArgs params_t0;" in code, code
+        assert "CoreTaskArgs params_t0;" in code, code
         assert "params_t1.set_dependencies(" in code, code
         assert "rt_submit_aiv_task(" in code, code
 
-        l0_t0 = code.index("L0TaskArgs params_t0;")
+        l0_t0 = code.index("CoreTaskArgs params_t0;")
         deps_t1 = code.index("params_t1.set_dependencies(")
         submit_t1 = code.rindex("rt_submit_aiv_task(")
-        assert l0_t0 < deps_t1, "L0TaskArgs must appear before set_dependencies"
+        assert l0_t0 < deps_t1, "CoreTaskArgs must appear before set_dependencies"
         assert deps_t1 < submit_t1, "set_dependencies must appear before submit"
 
     def test_dyn_dim_symbol_is_defined_from_the_declaring_argument(self):

--- a/tests/ut/codegen/test_orchestration_codegen_more.py
+++ b/tests/ut/codegen/test_orchestration_codegen_more.py
@@ -80,7 +80,7 @@ class TestOrchestrationMore:
         code = _generate_orch_code(Fp4SliceProgram)
         assert "uint32_t chunk_offsets[2] = {0, 4};" in code
         assert "std::min<uint32_t>(4, ext_data.shapes[1] - chunk_offsets[1])" in code
-        assert "Tensor chunk = ext_data.view(chunk_shapes, chunk_offsets);" in code
+        assert "ChipTensor chunk = ext_data.view(chunk_shapes, chunk_offsets);" in code
 
     def test_fp4_slice_dynamic_offset_checks_alignment_before_conversion(self):
         """Dynamic packed-axis offsets are checked before conversion to carrier units."""
@@ -139,9 +139,9 @@ class TestOrchestrationMore:
 
         code = _generate_orch_code(Fp4ShapeViewProgram)
         assert "uint32_t reshaped_shapes[2] = {4, 16};" in code
-        assert "Tensor reshaped = ext_data.reshape(reshaped_shapes, 2);" in code
+        assert "ChipTensor reshaped = ext_data.reshape(reshaped_shapes, 2);" in code
         assert "uint32_t viewed_shapes[2] = {2, 32};" in code
-        assert "Tensor viewed = reshaped.reshape(viewed_shapes, 2);" in code
+        assert "ChipTensor viewed = reshaped.reshape(viewed_shapes, 2);" in code
 
     def test_fp4_transpose_keeps_packed_axis_fixed(self):
         """Swapping non-packed axes is representable; moving the packed axis is not."""
@@ -159,7 +159,7 @@ class TestOrchestrationMore:
                 return transposed
 
         code = _generate_orch_code(Fp4NonPackedTransposeProgram)
-        assert "Tensor transposed = ext_data.transpose(0, 1);" in code
+        assert "ChipTensor transposed = ext_data.transpose(0, 1);" in code
 
         @pl.program
         class Fp4PackedTransposeProgram:
@@ -312,7 +312,7 @@ class TestOrchestrationMore:
             in code
         )
         assert "uint32_t chunk_offsets[2] = {static_cast<uint32_t>((i * 16)), 0};" in code
-        assert "Tensor chunk = ext_data.view(chunk_shapes, chunk_offsets);" in code
+        assert "ChipTensor chunk = ext_data.view(chunk_shapes, chunk_offsets);" in code
 
         # tensor.read now goes through get_tensor_data<T>() so the runtime owns
         # access validation/synchronization, instead of bypassing it with a raw
@@ -350,7 +350,7 @@ class TestOrchestrationMore:
             in code
         )
         assert "uint32_t chunk_offsets[2] = {0, 0};" in code
-        assert "Tensor chunk = ext_data.view(chunk_shapes, chunk_offsets);" in code
+        assert "ChipTensor chunk = ext_data.view(chunk_shapes, chunk_offsets);" in code
 
     def test_tensor_reshape_external_input(self):
         """tensor.reshape on an external orchestration input emits Tensor::reshape on ext_<name>."""
@@ -372,7 +372,7 @@ class TestOrchestrationMore:
         # Shape array emitted with the result variable name as prefix.
         assert "uint32_t r_shapes[2] = {16, 16};" in code
         # Reshape lowers to runtime Tensor::reshape on the external tensor handle.
-        assert "Tensor r = ext_data.reshape(r_shapes, 2);" in code
+        assert "ChipTensor r = ext_data.reshape(r_shapes, 2);" in code
 
     def test_tensor_reshape_after_slice(self):
         """slice -> reshape chain: reshape input is a local Tensor (no ext_ prefix)."""
@@ -400,10 +400,10 @@ class TestOrchestrationMore:
             "(chunk_offsets[2] >= ext_data.shapes[2] ? 0u : std::min<uint32_t>(16, ext_data.shapes[2] - chunk_offsets[2]))};"  # noqa: E501
             in code
         )
-        assert "Tensor chunk = ext_data.view(chunk_shapes, chunk_offsets);" in code
+        assert "ChipTensor chunk = ext_data.view(chunk_shapes, chunk_offsets);" in code
         # reshape emits its shape array and calls .reshape on the local Tensor (no ext_ prefix).
         assert "uint32_t r_shapes[2] = {16, 16};" in code
-        assert "Tensor r = chunk.reshape(r_shapes, 2);" in code
+        assert "ChipTensor r = chunk.reshape(r_shapes, 2);" in code
 
     def test_tensor_transpose_external_input(self):
         """tensor.transpose on an external orchestration input emits Tensor::transpose on ext_<name>."""
@@ -423,7 +423,7 @@ class TestOrchestrationMore:
         code = _generate_orch_code(TransposeExternalProgram)
 
         # transpose lowers to runtime Tensor::transpose on the external tensor handle.
-        assert "Tensor t = ext_data.transpose(0, 1);" in code
+        assert "ChipTensor t = ext_data.transpose(0, 1);" in code
 
     def test_tensor_transpose_negative_axis(self):
         """tensor.transpose with negative axis indices is normalized at codegen time."""
@@ -443,7 +443,7 @@ class TestOrchestrationMore:
         code = _generate_orch_code(TransposeNegativeProgram)
 
         # -1 / -2 on a 3D tensor should normalize to axes 2 and 1 respectively.
-        assert "Tensor t = ext_data.transpose(2, 1);" in code
+        assert "ChipTensor t = ext_data.transpose(2, 1);" in code
 
     def test_tensor_transpose_after_slice(self):
         """slice -> transpose chain: transpose input is a local Tensor (no ext_ prefix)."""
@@ -464,9 +464,9 @@ class TestOrchestrationMore:
         code = _generate_orch_code(TransposeAfterSliceProgram)
 
         # slice still emits view on the external tensor.
-        assert "Tensor chunk = ext_data.view(chunk_shapes, chunk_offsets);" in code
+        assert "ChipTensor chunk = ext_data.view(chunk_shapes, chunk_offsets);" in code
         # transpose calls .transpose on the local Tensor (no ext_ prefix).
-        assert "Tensor t = chunk.transpose(1, 2);" in code
+        assert "ChipTensor t = chunk.transpose(1, 2);" in code
 
     def test_tensor_view_cross_flip_lowers_to_transpose(self):
         """Cross-layout flip (ND→DN) lowers to runtime Tensor::transpose on the
@@ -487,7 +487,7 @@ class TestOrchestrationMore:
 
         # Cross-layout flip swaps the trailing pair via runtime Tensor::transpose
         # on the external tensor handle (start_offset preserved).
-        assert "Tensor b_dn = ext_b.transpose(0, 1);" in code
+        assert "ChipTensor b_dn = ext_b.transpose(0, 1);" in code
         # The deleted pre-#808 fields must never be emitted.
         assert "raw_shapes" not in code
         assert "is_raw_eq_shapes" not in code
@@ -508,7 +508,7 @@ class TestOrchestrationMore:
 
         code = _generate_orch_code(program)
 
-        assert "Tensor b_same = ext_b;" in code
+        assert "ChipTensor b_same = ext_b;" in code
         assert ".transpose(" not in code
 
     def test_tensor_view_shape_reinterpret_runs_through_default_pipeline(self):
@@ -535,7 +535,7 @@ class TestOrchestrationMore:
         shape_decl = re.search(r"uint32_t (\w+)_shapes\[2\] = \{4, 8\};", code)
         assert shape_decl is not None, code
         viewed_name = shape_decl.group(1)
-        reshape_line = next(line for line in code.splitlines() if f"Tensor {viewed_name} =" in line)
+        reshape_line = next(line for line in code.splitlines() if f"ChipTensor {viewed_name} =" in line)
         assert f".reshape({viewed_name}_shapes, 2);" in reshape_line
 
     def test_tensor_view_shape_layout_combination_rejected(self):
@@ -805,7 +805,7 @@ class TestOrchestrationMore:
 
         # TensorCreateInfo declarations exist (exactly once each)
         # a_acc is a return value → external (orch_args.tensor(i).ref())
-        assert code.count("const Tensor& ext_a_acc = orch_args.tensor(1).ref()") == 1
+        assert code.count("const ChipTensor& ext_a_acc = orch_args.tensor(1).ref()") == 1
         assert code.count("TensorCreateInfo b_acc_ci(") == 1
 
         # For loop exists with correct structure
@@ -862,7 +862,7 @@ class TestOrchestrationMore:
         code = _generate_orch_code(transformed)
 
         assert "alloc_tensors(acc_ci)" in code
-        assert "const Tensor& acc = alloc_0.get_ref(0);" in code
+        assert "const ChipTensor& acc = alloc_0.get_ref(0);" in code
         assert "make_tensor_external(nullptr" not in code
         assert "acc__loop_state" not in code
         assert "params_t1.add_input(acc);" in code
@@ -952,9 +952,9 @@ class TestOrchestrationMore:
 
         code = _generate_orch_code(transformed)
 
-        assert "Tensor row = ext_out.view(row_shapes, row_offsets);" in code
+        assert "ChipTensor row = ext_out.view(row_shapes, row_offsets);" in code
         assert "params_t0.add_inout(row)" in code
-        assert "Tensor row = make_tensor(" not in code
+        assert "ChipTensor row = make_tensor(" not in code
         assert "memcpy(" not in code
         assert "ext_out = out;" not in code
 
@@ -996,9 +996,9 @@ class TestOrchestrationMore:
         code = _generate_orch_code(transformed)
 
         assert "TensorCreateInfo row_ci(row_ci_shapes, 2, DataType::FLOAT32);" in code
-        assert "const Tensor& row = " in code
+        assert "const ChipTensor& row = " in code
         assert "make_tensor_external(nullptr, row_ci_shapes, 2, DataType::FLOAT32)" not in code
-        assert "Tensor row = ext_out.view(row_shapes, row_offsets);" not in code
+        assert "ChipTensor row = ext_out.view(row_shapes, row_offsets);" not in code
 
     def test_tensor_assemble_slice_source_does_not_require_view_fast_path(self):
         """tensor.assemble should stay codegenable when the source is not a rewritten tensor.create."""
@@ -1023,8 +1023,8 @@ class TestOrchestrationMore:
 
         code = _generate_orch_code(transformed)
 
-        assert "Tensor chunk = ext_x.view(chunk_shapes, chunk_offsets);" in code
-        assert "Tensor chunk = ext_out.view(chunk_shapes, chunk_offsets);" not in code
+        assert "ChipTensor chunk = ext_x.view(chunk_shapes, chunk_offsets);" in code
+        assert "ChipTensor chunk = ext_out.view(chunk_shapes, chunk_offsets);" not in code
 
     def test_param_with_numeric_suffix(self):
         """Regression test for issue #573: params with numeric suffixes must not be collapsed.
@@ -1083,7 +1083,7 @@ class TestOrchestrationMore:
         assert "expected_arg_count = 3" in code
 
         # Tuple-return elements must not be collapsed into a single alias
-        assert "Tensor& out =" not in code
+        assert "ChipTensor& out =" not in code
 
     def test_repeated_auto_output_buffers_get_unique_names(self):
         """Repeated auto-generated output buffers should keep distinct emitted names."""
@@ -1126,11 +1126,11 @@ class TestOrchestrationMore:
         assert "params_t0.add_output(ret0__out)" in code
         assert "params_t1.add_output(ret0__out_1)" in code
         # ``first`` is kernel_add's in-place output buffer ret0__out, so it
-        # remaps to ret0__out (no ``const Tensor& first = ...`` alias is minted);
+        # remaps to ret0__out (no ``const ChipTensor& first = ...`` alias is minted);
         # the second call reads that buffer directly.
         assert "params_t1.add_input(ret0__out)" in code
-        assert "const Tensor& first" not in code
-        assert "const Tensor& second" not in code
+        assert "const ChipTensor& first" not in code
+        assert "const ChipTensor& second" not in code
 
     def test_unused_alias_not_emitted(self):
         """Alias for a kernel result that is never consumed downstream should be omitted."""
@@ -1164,7 +1164,7 @@ class TestOrchestrationMore:
         code = _generate_orch_code(transformed)
 
         assert "rt_submit_" in code
-        assert "const Tensor& result" not in code
+        assert "const ChipTensor& result" not in code
 
     def test_multi_scope_alloc_tensors_batching(self):
         """Each scope (function body, for body) batches its own alloc_tensors independently."""
@@ -1219,9 +1219,9 @@ class TestOrchestrationMore:
         assert "alloc_0 = alloc_tensors(" in code
         assert "alloc_1 = alloc_tensors(" in code
         # Verify bindings from each alloc
-        assert "const Tensor& t1 = alloc_0.get_ref(0);" in code
-        assert "const Tensor& t2 = alloc_0.get_ref(1);" in code
-        assert "const Tensor& tmp = alloc_1.get_ref(0);" in code
+        assert "const ChipTensor& t1 = alloc_0.get_ref(0);" in code
+        assert "const ChipTensor& t2 = alloc_0.get_ref(1);" in code
+        assert "const ChipTensor& tmp = alloc_1.get_ref(0);" in code
 
     def test_alloc_tensors_splits_at_16(self):
         """More than 16 create_tensor in one scope are split into multiple alloc_tensors calls."""

--- a/tests/ut/codegen/test_orchestration_manual_scope.py
+++ b/tests/ut/codegen/test_orchestration_manual_scope.py
@@ -107,7 +107,7 @@ class TestManualScopeCodegen:
         code = _generate_orch_code(transformed)
 
         assert code.count("params_t0.add_scalar(signal_ctx);") == 1, code
-        assert "const Tensor& y = task_0_outs.get_ref(0);" in code, code
+        assert "const ChipTensor& y = task_0_outs.get_ref(0);" in code, code
         assert "params_t1.add_input(y);" in code, code
         assert "signal_ctx.get_ref" not in code, code
 

--- a/tests/ut/codegen/test_orchestration_manual_scope.py
+++ b/tests/ut/codegen/test_orchestration_manual_scope.py
@@ -186,7 +186,7 @@ class TestManualScopeCodegen:
         # attached with a single ``set_dependencies(arr, count)`` call. Both
         # entries are unconditionally filled (plain TaskId bindings, not
         # iter-arg carries, so no is_valid() guard).
-        assert "L0TaskArgs params_t2;" in code
+        assert "CoreTaskArgs params_t2;" in code
         assert "PTO2TaskId params_t2_deps[2];" in code
         assert "params_t2_deps[params_t2_deps_count++] = a_tid;" in code
         assert "params_t2_deps[params_t2_deps_count++] = b_tid;" in code
@@ -1316,7 +1316,7 @@ class TestManualScopeCodegen:
             out, _       = pl.submit(self.stage2, scratch, out, row, col, deps=[tid])
 
         Expected codegen for the dep chain:
-            L0TaskArgs params_t1;
+            CoreTaskArgs params_t1;
             PTO2TaskId params_t1_deps[1];
             uint32_t params_t1_deps_count = 0;
             params_t1_deps[params_t1_deps_count++] = <producer TaskId>;
@@ -1510,7 +1510,7 @@ class TestManualScopeCodegen:
         # this is what the bug used to silently drop. Without these lines the
         # inner ``rt_submit_*_task`` would have no explicit fence on the outer
         # task and the regression would re-emerge.
-        assert "L0TaskArgs params_t1;" in code, code
+        assert "CoreTaskArgs params_t1;" in code, code
         assert "PTO2TaskId params_t1_deps[1];" in code, code
         # ``outer_tid`` is a fresh direct-producer TaskId declared in the outer
         # C++ scope (issue #1966): its cross-scope dep insert is unguarded.

--- a/tests/ut/codegen/test_orchestration_misc.py
+++ b/tests/ut/codegen/test_orchestration_misc.py
@@ -68,8 +68,8 @@ class TestTupleLineagePointerKeying:
     propagated onto the other tuple's consumers. In the DeepSeek-V4 KV compressor
     this made the ``kv_state`` / ``score_state`` return aliases reuse the
     externalized ``kv_cache`` / ``kv`` window reshape names, so the generated
-    orchestration C++ declared those names twice (``Tensor X = ...`` then
-    ``const Tensor& X = ...``) and failed to compile with ``conflicting
+    orchestration C++ declared those names twice (``ChipTensor X = ...`` then
+    ``const ChipTensor& X = ...``) and failed to compile with ``conflicting
     declaration``.
     """
 
@@ -112,7 +112,7 @@ class TestTupleLineagePointerKeying:
 
         # No declared name may appear twice (the conflicting-declaration bug).
         declared = re.findall(
-            r"^\s*(?:const\s+Tensor&|Tensor|PTO2TaskId|auto)\s+([A-Za-z_]\w*)\s*=",
+            r"^\s*(?:const\s+ChipTensor&|ChipTensor|PTO2TaskId|auto)\s+([A-Za-z_]\w*)\s*=",
             code,
             flags=re.MULTILINE,
         )
@@ -121,8 +121,8 @@ class TestTupleLineagePointerKeying:
 
         # Each consumer must reshape from its OWN tuple's element, not a stale /
         # undeclared getitem name. Before the fix, ``fa`` read undeclared ``a0``.
-        assert "Tensor fa = rsh0.reshape" in code, code
-        assert "Tensor fb = rsh1.reshape" in code, code
+        assert "ChipTensor fa = rsh0.reshape" in code, code
+        assert "ChipTensor fb = rsh1.reshape" in code, code
         assert "a0.reshape" not in code and "b0.reshape" not in code, code
 
 
@@ -867,7 +867,7 @@ class TestTupleReturnNameHintCollision:
         # tmp_first and tmp_second share the name_hint "ret__tmp_v0"; the tuple
         # metadata must still attach each call's elements to that call. Each
         # element is the in-place Out arg of its call, so it remaps to that arg
-        # (no ``const Tensor& first_a = ...`` alias is minted). The consumer
+        # (no ``const ChipTensor& first_a = ...`` alias is minted). The consumer
         # reading first_a/second_a/first_b/second_b therefore reads call_a's
         # outs then call_b's outs, in order — not cross-contaminated.
         i_a1 = code.index("// Task 2: kernel_consume")
@@ -879,10 +879,10 @@ class TestTupleReturnNameHintCollision:
         assert a1 < a2 < b1 < b2, code
         # No per-element const-ref alias survives the remap.
         for name in ("first_a", "second_a", "first_b", "second_b"):
-            assert f"const Tensor& {name} " not in code, code
+            assert f"const ChipTensor& {name} " not in code, code
 
         declared_names = re.findall(
-            r"^\s*(?:const\s+Tensor&|Tensor)\s+([A-Za-z_]\w*)\s*=",
+            r"^\s*(?:const\s+ChipTensor&|ChipTensor)\s+([A-Za-z_]\w*)\s*=",
             code,
             flags=re.MULTILINE,
         )
@@ -896,13 +896,13 @@ class TestScalarCarryPhiCodegen:
     """Regression tests for scalar loop carries in orchestration codegen."""
 
     def test_scalar_carry_phi_not_emitted_as_tensor(self):
-        """Regression for #1580: Scalar loop carry must not be aliased as const Tensor&.
+        """Regression for #1580: Scalar loop carry must not be aliased as const ChipTensor&.
 
         When a Scalar variable is defined before a pl.parallel loop and then
         reused (reassigned) inside it, alongside Tensor carries, ConvertToSSA
         promotes the scalar into the parallel-loop carry tuple.  The orchestration
         codegen must emit the Scalar carry phi as ``int64_t = 0`` (untraced scalar
-        default), NOT as ``const Tensor& = <carry_var>`` (type mismatch that causes
+        default), NOT as ``const ChipTensor& = <carry_var>`` (type mismatch that causes
         a C++ compile error).
         """
         backend.reset_for_testing()
@@ -939,7 +939,7 @@ class TestScalarCarryPhiCodegen:
 
                 # The parallel loop carries global_c_idx (Scalar) mixed with
                 # Tensor carries out_b, out_c.  Before the fix, the Scalar carry
-                # phi was emitted as ``const Tensor&`` causing a C++ compile error.
+                # phi was emitted as ``const ChipTensor&`` causing a C++ compile error.
                 for batch_idx in pl.parallel(0, N // TILE):
                     with pl.at(level=pl.Level.CORE_GROUP, name_hint="scope_b"):
                         for inner in pl.range(TILE):
@@ -953,12 +953,12 @@ class TestScalarCarryPhiCodegen:
         code = _generate_orch_code(transformed)
 
         # The Scalar carry phi must be emitted as int64_t = 0 (untraced scalar
-        # default), never as const Tensor& = <carry> (type mismatch / #1580).
+        # default), never as const ChipTensor& = <carry> (type mismatch / #1580).
         assert "int64_t global_c_idx__rv" in code, (
-            "global_c_idx carry phi should be emitted as int64_t, not const Tensor&\n" + code
+            "global_c_idx carry phi should be emitted as int64_t, not const ChipTensor&\n" + code
         )
-        assert "const Tensor& global_c_idx" not in code, (
-            "global_c_idx must not be aliased as const Tensor& (scalar/tensor type mismatch)\n" + code
+        assert "const ChipTensor& global_c_idx" not in code, (
+            "global_c_idx must not be aliased as const ChipTensor& (scalar/tensor type mismatch)\n" + code
         )
 
         # out_b and out_c Tensor carries must each alias to their own carry.

--- a/tests/ut/codegen/test_orchestration_returned_param_map.py
+++ b/tests/ut/codegen/test_orchestration_returned_param_map.py
@@ -243,7 +243,7 @@ _TASK_RE = re.compile(
 _OP_RE = re.compile(r"\.add_(input|inout|output)\((\w+)\)")
 
 # A loop-tail carry rebind, e.g. "cur__rv_v3 = cur__ssa_v4;". Matches the bare assignment
-# only -- the "Tensor cur__rv_v3 = cur;" declaration above the loop is not a rebind.
+# only -- the "ChipTensor cur__rv_v3 = cur;" declaration above the loop is not a rebind.
 _CARRY_RE = re.compile(r"^\s*(\w+)__rv_v\d+\s*=\s*(\w+);\s*$", re.MULTILINE)
 
 

--- a/tests/ut/codegen/test_orchestration_returned_param_map.py
+++ b/tests/ut/codegen/test_orchestration_returned_param_map.py
@@ -232,11 +232,11 @@ def guarded_one_trip(
 # Helpers: compile (no device) and read the emitted orchestration back as a string.
 # ---------------------------------------------------------------------------------------------
 
-# "// Group out_proj: ..." introduces a task; "L0TaskArgs params_tN;" declares its arg list and
+# "// Group out_proj: ..." introduces a task; "CoreTaskArgs params_tN;" declares its arg list and
 # the add_input/add_inout/add_output calls fill that list in order.
 _TASK_RE = re.compile(
     r"^\s*//\s*(?:Group|Spmd)\s+(?P<hdr>[^\n]*?)\s*:\s*(?P<tail>[^\n]*)$\n"
-    r"\s*L0TaskArgs\s+(?P<params>\w+);\n"
+    r"\s*CoreTaskArgs\s+(?P<params>\w+);\n"
     r"(?P<ops>(?:\s*(?P=params)\.add_\w+\([^\n]*\n)+)",
     re.MULTILINE,
 )

--- a/tests/ut/codegen/test_orchestration_tensor_rw.py
+++ b/tests/ut/codegen/test_orchestration_tensor_rw.py
@@ -330,7 +330,7 @@ class TestTensorReadWriteOffsetCodegen:
         assert "kv_proj__windowed" in code, code
 
         declared_names = re.findall(
-            r"^\s*(?:const\s+Tensor&|Tensor|PTO2TaskId|auto)\s+([A-Za-z_]\w*)\s*=",
+            r"^\s*(?:const\s+ChipTensor&|ChipTensor|PTO2TaskId|auto)\s+([A-Za-z_]\w*)\s*=",
             code,
             flags=re.MULTILINE,
         )
@@ -339,9 +339,9 @@ class TestTensorReadWriteOffsetCodegen:
             f"generated C++ redeclared names {sorted(duplicate_declarations)}:\n{code}"
         )
 
-        mutable_tensor_names = set(re.findall(r"^\s*Tensor\s+([A-Za-z_]\w*)\s*=", code, flags=re.MULTILINE))
+        mutable_tensor_names = set(re.findall(r"^\s*ChipTensor\s+([A-Za-z_]\w*)\s*=", code, flags=re.MULTILINE))
         const_alias_names = set(
-            re.findall(r"^\s*const\s+Tensor&\s+([A-Za-z_]\w*)\s*=", code, flags=re.MULTILINE)
+            re.findall(r"^\s*const\s+ChipTensor&\s+([A-Za-z_]\w*)\s*=", code, flags=re.MULTILINE)
         )
         assert not (mutable_tensor_names & const_alias_names), code
 
@@ -736,7 +736,7 @@ class TestTensorReadWriteOffsetCodegen:
         # If the codegen emits an explicit SSA alias for the SPMD result,
         # it must bind to ext_out and never to ext_scratch.
         out_alias_lines = [
-            line for line in code.splitlines() if line.lstrip().startswith("const Tensor& out__")
+            line for line in code.splitlines() if line.lstrip().startswith("const ChipTensor& out__")
         ]
         for line in out_alias_lines:
             assert "ext_out" in line and "ext_scratch" not in line, (
@@ -825,7 +825,7 @@ class TestTensorReadWriteOffsetCodegen:
             )
 
         # Any explicit SSA alias for the result must bind to ext_out as well.
-        alias_lines = [line for line in code.splitlines() if line.lstrip().startswith("const Tensor& out")]
+        alias_lines = [line for line in code.splitlines() if line.lstrip().startswith("const ChipTensor& out")]
         for line in alias_lines:
             assert "ext_pre" not in line and "ext_post" not in line, (
                 f"SPMD return alias bound to the wrong output:\n{line}\n\nFull code:\n{code}"

--- a/tests/ut/codegen/test_pto_codegen.py
+++ b/tests/ut/codegen/test_pto_codegen.py
@@ -1241,17 +1241,17 @@ class TestGenerateArgUnpacking:
     def test_tensor_only(self):
         func = _make_func("test_fn", [("a", "tensor"), ("b", "tensor"), ("out", "tensor")])
         code, names = _generate_arg_unpacking(func)
-        assert "reinterpret_cast<__gm__ Tensor*>(args[0])" in code
-        assert "reinterpret_cast<__gm__ Tensor*>(args[1])" in code
-        assert "reinterpret_cast<__gm__ Tensor*>(args[2])" in code
+        assert "reinterpret_cast<__gm__ ChipTensor*>(args[0])" in code
+        assert "reinterpret_cast<__gm__ ChipTensor*>(args[1])" in code
+        assert "reinterpret_cast<__gm__ ChipTensor*>(args[2])" in code
         assert names == ["a", "b", "out"]
 
     def test_mixed_tensor_scalar(self):
         func = _make_func("test_fn", [("input", "tensor"), ("scale", "scalar"), ("output", "tensor")])
         code, names = _generate_arg_unpacking(func)
         # Tensors-first: input=args[0], output=args[1], scale=args[2]
-        assert "reinterpret_cast<__gm__ Tensor*>(args[0])" in code
-        assert "reinterpret_cast<__gm__ Tensor*>(args[1])" in code
+        assert "reinterpret_cast<__gm__ ChipTensor*>(args[0])" in code
+        assert "reinterpret_cast<__gm__ ChipTensor*>(args[1])" in code
         assert "scale_conv.u64 = args[2];" in code
         assert "float scale = scale_conv.val;" in code
         assert names == ["input", "output", "scale"]


### PR DESCRIPTION
> [!IMPORTANT]
> **Update 2026-08-13 — this PR is being superseded in part, and reduced on purpose.**
> #2345 does the same pin advance (it moves `runtime` to `e4ab544a`, 16 commits *ahead* of the `8a82bf9e` used here) and covers the same renames, emitters and the `tests/ut/runtime` rewrite this PR lists as a gap. So the port below is no longer the contribution.
> What survives is one measured thing: **#2345's H2D path copies, and this one does not.** Once #2345 merges, this PR will be reduced to the `copy_to` / `copy_from` in-place host-buffer naming (see *What is still worth merging* below) rather than rebased whole.
> Still a draft, but no longer because of us: #2354 reproduces on #2345's own head with our code absent, so the decode stall is a blocker for that PR too.

Advances pypto's `runtime/` (Simpler) pin onto the Buffer device-memory API and ports pypto across it.

### What is still worth merging

`DistributedWorker.copy_to` in #2345 stages every H2D through a freshly created POSIX-shm Buffer plus a full host→host `ctypes.memmove` of the payload, and `alloc_tensor` is `malloc` + `copy_to`, so all 346.6 GB of DeepSeek V4's resident weights pay an extra copy. This PR instead *names* the mapping the caller already holds — `wrap_fork_inherited(ptr, nbytes, …)` per shard, with the backend classified by the caller (`FORK_SHM` when `tensor.is_shared()`, `FORK_COW` read-only otherwise, per the capability matrix in `src/common/task_interface/buffer.h`) — and stages through shm **only** for host memory allocated after the fork, which cannot be named at all.

Measured 2026-08-13, one node, one session, single-variable: `pypto-serving` `71fd275`, `pypto-lib` `f0d352e`, PTOAS v0.57 both sides, 8 × 910B2, `--dp 8 --ep 8`, warm kernel cache, 346.6 GB resident:

| stack | resident upload | `model loaded` |
|---|---|---|
| #2345 alone | 497.7s | 518.1s |
| #2345 + #2292 | 98.9s | 119.3s |
| **this PR + #2292** | **25.6s** | **33.0s** |
| this PR alone | 66.5s | 74.0s |

**These absolutes are setup-dependent and should not be quoted as properties of either branch.** `pypto-serving`#134 measured the same class of host-copy cost at ~492s on this node and ~62s on another (page-cache state, mount, driver all matter — see that PR's discussion). What transfers is the mechanism and the direction: one extra full copy of the whole weight set, removed rather than parallelised. On a setup where the copy is cheap the gap will be much smaller.

497.7s is essentially the pre-`pypto-serving`#134 number (492.8s) *on this node*, i.e. here #2345 gives back the win of the loader change that maps the prepacked sidecar `MAP_SHARED` precisely so the upload need not copy. Cold runs agree independently: isolating the upload as `kernel-cache STORED` → `resident main weights uploaded` (both stacks pay the same ~150s of kernel compile) gives ~484.6s on #2345 vs ~20.6s here, with `model loaded` 731.3s vs 263.4s. Reported on #2345 with the code pointers.

### Why the pin had to move

Simpler #1702 removed the last of three serializers on the device-memory path (process-wide `_child_prov_lock`, run admission, and the GIL on the four bindings). pypto pinned `3165cc89`, which predates it, so #2292's concurrent shard upload was a **no-op** on that pin. #2345 now carries the pin advance instead; #2292 applies to its head with zero conflicts (two hunks, offsets only) and is worth 5.03× there (497.7 → 98.9s) versus 2.84× on this pin — it parallelises the extra memcpy too, which is why the copy still has to go.

| DeepSeek V4 Flash W8A8, 8 cards, 346.6 GB, warm cache | without #2292 | with #2292 |
|---|---|---|
| resident-weight upload | 66.5s (3 runs, ±0.6) | **23.4s / 23.8s** |
| `model loaded` total | 74.0s | **31.0s / 31.2s** |
| effective bandwidth | 5.2 GB/s | **14.8 GB/s** |

The old pin reaches `model loaded` in 73.7s, so the pin itself is performance-neutral — the 2.84× is #2292's, unlocked by the pin.

### What the port turned out to be

Not a bump. Seven layers, each found only by running the next step — recorded here because #2345 solves the same problems and the traps are worth having written down:

1. `L2TaskArgs` → `ChipTaskArgs` (Simpler #1681) — 74 sites in codegen and the collectives templates.
2. `Tensor` → `ChipTensor` at chip level, including every AIV kernel's `__gm__` preamble. Note the trap: `simpler.task_interface` exports **both** names — the plain `Tensor` is #1729's wire ABI and stays valid, so `Tensor.make(...)` on the Python path must *not* be renamed.
3. `AccessMode.READWRITE`, not `READ_WRITE`.
4. Host memory allocated **after** the fork cannot be named with `wrap_fork_inherited` at all; it stages through `create_buffer` (POSIX shm).
5. `make_tensor_arg` now takes `(worker, tensor)`; generated code has no worker in scope, so the submitter binds one via ContextVar.
6. `Tensor.make` is gone — a `DeviceTensor` is named from its allocating Buffer, which forces the owning chip onto the handle (equal-sized shards share the same numeric address on every chip).
7. Comm windows moved from `ctx.buffer_ptrs[name]` (addresses) to `ctx.buffers[name]` (Buffers).

### Verified

- 8-chip hardware check: shard uploads through the Buffer API, bogus free refused, write into a COW mapping refused, registry frees — 4/4.
- DeepSeek V4: 346.6 GB uploaded, 0 faults, `model loaded`, prefill produces a token.
- `tests/ut/{codegen,ir,language,jit,debug}`: 8441 passed, 2 skipped.

### Known gaps

- **#2354** (the decode stall) — now attributed to the ABI adoption itself, not to this port: it reproduces on #2345's head with our code absent, 3 runs, same `stuck_task_id=4294967357`.
- ~44 `tests/ut/runtime` tests still mock the old contract (`malloc(nbytes, worker_id) -> int`, `Tensor.make(child_memory=True)`). #2345 rewrites these, which is one reason to reduce this PR rather than rebase it.
- `execute_compiled`'s one-shot path builds task args before its worker exists, which the Buffer ABI cannot support; it now raises with an explanation. Fixing it has to decide what the two-pass DFX path does.
