### PR TITLE
feat(distributed): add pld.tensor.remote_store for computed values

### DIFF
--- a/docs/en/dev/distributed_ops.md
+++ b/docs/en/dev/distributed_ops.md
@@ -9,23 +9,19 @@ storage is a slice of a symmetric, per-rank communication window allocated by
 `pld.alloc_window_buffer`. Verifiers in this family generally reject plain
 `TensorType` (strict kind-trait matching — `As<DistributedTensorType>` does
 not match a plain `TensorType`), so a non-window-bound tensor can never be fed
-into a cross-rank slot by accident. **Two documented exceptions:**
-`pld.tensor.put` (and its lowered `pld.tile.put`) accepts a plain `Tensor` on
-the `src` side via `AsTensorTypeLike` — TPUT only needs a readable local GM
-region for the source, so kernels can push directly from host-backed inputs
-without first staging through a window buffer; `dst` still requires a
-window-bound `DistributedTensor`.
-`pld.tensor.get` (and its lowered `pld.tile.get`) accepts a plain `Tensor` on
-the `dst` side via `AsTensorTypeLike` — TGET only needs a writable local GM
-region to receive into, so kernels can TGET directly into host-backed output
-tensors; `src` still requires a window-bound `DistributedTensor`.
+into a cross-rank slot by accident. **Two documented exceptions**, both matched
+via `AsTensorTypeLike` and detailed under Namespacing below: `put`/`tile.put`
+accept a plain `Tensor` as `src`, and `get`/`tile.get` accept one as `dst` —
+TPUT/TGET only need a readable/writable *local* GM region on that side. The
+window-bound side (`put.dst`, `get.src`) still requires a `DistributedTensor`.
 
-There are **thirteen ops** and **four ABI enums**:
+There are **fourteen ops** and **four ABI enums**:
 
 | Op | Direction | Result | Hardware |
 | -- | --------- | ------ | -------- |
 | `pld.tile.remote_load` | pull (read peer → local tile) | `TileType` | TLOAD |
 | `pld.tile.remote_store` | push (write local tile → peer) | `Unknown` (side effect) | TSTORE |
+| `pld.tensor.remote_store` | push (write local tensor-level value → peer); lowered 1:1 to `pld.tile.remote_store` | `Unknown` (side effect) | TSTORE |
 | `pld.tensor.get` | pull (read peer → local GM) | `Unknown` (side effect) | TGET |
 | `pld.tensor.put` | push (write local → peer) | `Unknown` (side effect) | TPUT |
 | `pld.tensor.allreduce` | collective reduce over window slices | `DistributedTensorType` (same as src) | builtin collective |
@@ -38,7 +34,7 @@ There are **thirteen ops** and **four ABI enums**:
 | `pld.system.notify` | signal a peer's slot | `Unknown` (side effect) | TNOTIFY |
 | `pld.system.wait` | block on own slot | `Unknown` (side effect) | TWAIT |
 
-The five side-effect-only ops produce [`UnknownType`](ir/02-types.md): they
+The six side-effect-only ops produce [`UnknownType`](ir/02-types.md): they
 exist for their cross-rank effect, not for an SSA value a consumer reads.
 
 ## Namespacing: why `tile.*` vs `tensor.*` vs `system.*`
@@ -50,22 +46,24 @@ The namespace encodes the IR level the op lives at, not an arbitrary grouping:
 - **`pld.tile.remote_store`** consumes a *tile* (the symmetric write companion
   of `remote_load`), so it is a sibling of `tile.store` and lives in
   `pld.tile`.
-- **`pld.tensor.get`** reads and writes *tensor* (GM) operands — `dst` may be a
-  window-bound `DistributedTensor` or a plain `Tensor` (TGET only needs a
-  writable local GM region to receive into) while `src` must be a window-bound
-  `DistributedTensor` (the peer needs a window slot to read from). The VEC
-  staging tile that TGET bounces through is materialised by
-  `ConvertTensorToTileOps` as an internal `pld.tile.get`, never on the DSL
-  surface. It is therefore a sibling of `pld.tensor.alloc_window_buffer` /
-  `pld.tensor.window`, **not** of the tile-producing `remote_load`.
-- **`pld.tensor.put`** reads and writes *tensor* (GM) operands — `dst` is a
-  window-bound `DistributedTensor` (the peer needs a window slot to receive
-  into) while `src` accepts either a window-bound `DistributedTensor` or a
-  plain `Tensor` (TPUT only needs a readable local GM region on the source
-  side). The VEC staging tile that TPUT bounces through is materialised by
-  `ConvertTensorToTileOps` as an internal `pld.tile.put`, never on the DSL
-  surface. It is therefore a sibling of `pld.tensor.alloc_window_buffer` /
-  `pld.tensor.window`, **not** of the tile-producing `remote_load`.
+- **`pld.tensor.remote_store`** is the same op one IR level up — it consumes a
+  *tensor-level* value, so it lives in `pld.tensor` and `ConvertTensorToTileOps`
+  lowers it 1:1 to `pld.tile.remote_store`. This is the `tensor.aiv_shard` /
+  `tile.aiv_shard` shape (**one op, two levels, one identical argument
+  surface**), and it is why the tensor-level push is a separate entry point
+  rather than an overload of `pld.tensor.put`: dispatching `put` on the kind of
+  its `src` would make five of its arguments (`src_offsets`, `shape`, `atomic`,
+  `chunk_*`, `pipeline`) conditionally meaningless depending on how the value
+  was produced upstream — a property invisible at the call site.
+- **`pld.tensor.get` / `pld.tensor.put`** read and write *tensor* (GM) operands
+  on both sides. The window-bound side is the one the peer needs a slot for
+  (`get.src`, `put.dst`); the local side (`get.dst`, `put.src`) also accepts a
+  plain `Tensor`, so kernels can TGET into / TPUT from host-backed tensors
+  without staging through a window buffer. The VEC staging tile they bounce
+  through is materialised by `ConvertTensorToTileOps` as an internal
+  `pld.tile.get` / `pld.tile.put`, never on the DSL surface. Both are therefore
+  siblings of `pld.tensor.alloc_window_buffer` / `pld.tensor.window`, **not** of
+  the tile-producing `remote_load`.
 - **`pld.system.notify` / `pld.system.wait`** drive the per-rank signal slot —
   pure control-plane synchronisation with no data operand — so they live in
   `pld.system`.
@@ -80,7 +78,7 @@ added **at the end** so existing IR and cached programs keep their meaning.
 ```cpp
 enum class NotifyOp : int { kAtomicAdd = 0, kSet = 1 };   // pld.system.notify
 enum class WaitCmp  : int { kEq = 0,        kGe = 1 };     // pld.system.wait
-enum class AtomicType : int { kNone = 0,    kAdd = 1 };    // pld.tensor.put
+enum class AtomicType : int { kNone = 0,    kAdd = 1 };    // pld.tensor.put, remote_store
 enum class ReduceOp : int { kSum = 0, kMax = 1, kMin = 2, kProd = 3 };  // pld.tensor.allreduce
 ```
 
@@ -188,33 +186,61 @@ be a `MakeTuple` whose rank equals `target.shape.size()`.
 DSL (`python/pypto/language/distributed/op/tile_ops.py`) accepts positional or
 keyword arguments; the IR op keeps them positional, matching `tile.load`.
 
-### `pld.tile.remote_store` (TSTORE)
+### `pld.tile.remote_store` / `pld.tensor.remote_store` (TSTORE)
 
 ```text
-pld.tile.remote_store(src_tile, target, peer, offsets) -> Unknown
+pld.tile.remote_store(src_tile, target, peer, offsets, *, atomic: int = 0) -> Unknown
+pld.tensor.remote_store(src, target, peer, offsets, *, atomic: int = 0) -> Unknown
 ```
 
-Writes a local tile into a region of the `peer` rank's slice of a window-bound
+Writes a local value into a region of the `peer` rank's slice of a window-bound
 `DistributedTensor`. Mirrors `tile.store` at the IR level (positional `offsets`
-tuple + side-effect-only return) but the destination is a *remote* slice —
-address translation happens at codegen via `CommRemoteOffset(ctx, peer) +
-addptr + make_tensor_view`.
+tuple, optional `atomic` attr, side-effect-only return) but the destination is a
+*remote* slice — address translation happens at codegen via
+`CommRemoteOffset(ctx, peer) + addptr + make_tensor_view`.
 
-Verifier: `src_tile` must be `TileType`; `target` must be
-`DistributedTensorType`; `peer` must be a `ScalarType` rank index; `offsets`
-must be a `MakeTuple` whose rank equals `target.shape.size()`; `src_tile.dtype`
-must match `target.dtype`.
+The two forms differ **only** in the IR level of `src`; `pld.remote_store`
+dispatches on the operand, so user code reads the same at either level.
 
-Codegen: the tile is 2-D (height × width) after the standard tile pipeline; the
-emitted `pto.partition_view` has the same rank as `target`, with the leading
-`(target.rank - 2)` dims set to size 1 (matching `notify`'s `one_dims(rank,
-"1")` pattern). This lets a 2-D tile push land on the inner two dims of any
-N-D peer slice (N ≥ 2) without forcing the caller to reshape — and it is the
-regression guard against the older codegen that emitted a fixed-2D
+Verifier (both forms):
+
+| Rule | Note |
+| ---- | ---- |
+| `target` is `DistributedTensorType`, `peer` a `ScalarType` rank index | |
+| `offsets` is a `MakeTuple` of rank `target.shape.size()` | |
+| `src.dtype == target.dtype`, `target` rank ≥ 2 | |
+| `src` is 2-D, or N-D with every leading dim 1 | the deducer runs *before* `FlattenTileNdTo2D` collapses N-D tiles; a leading extent > 1 would fold into the row count and overrun the target |
+| the pushed region fits inside `target` at `offsets` (static dims only) | `remote_store` has no transfer `shape` to clamp against — the extent comes from `src`, so without this an oversized push silently overwrote the peer's neighbouring region |
+| `src` is `TileType` (tile form) / `TensorType` (tensor form) | each diagnostic names the sibling entry point, so the author lands on the one for their level |
+
+Lowering (tensor form): `ConvertTensorToTileOps` rewrites it 1:1 to the tile
+form via `RegisterSimple`. Its `InputSpaceReq{Vec}` makes the op *total* on its
+argument surface — `BridgeInputSpaces` only rewrites `TensorType` operands, so a
+computed value (already a tile) passes straight through keeping its space, while
+a GM-resident `src` is auto-bridged with a natural `tile.load` into Vec.
+
+Codegen: the tile is 2-D (height × width) after the tile pipeline; the emitted
+`pto.partition_view` has `target`'s rank with the leading `(target.rank - 2)`
+dims set to size 1 (matching `notify`'s `one_dims(rank, "1")`). A 2-D push
+therefore lands on the inner two dims of any N-D peer slice (N ≥ 2) without the
+caller reshaping — and guards the older codegen that emitted a fixed-2D
 `partition_view` regardless of target rank.
 
-DSL (`python/pypto/language/distributed/op/tile_ops.py`) exposes `target` /
-`peer` / `offsets` as keyword-only for readability; the IR op keeps them
+`atomic = AtomicType.kAdd` appends `{atomicType = #pto<atomic_type atomic_add>}`
+to the `pto.tstore`, making the push a **combine** (`peer_region += src`) — the
+cross-rank twin of `tile.store`'s split-K accumulation, and what an all-to-all
+combine needs. Emitted only for `kAdd`, so plain pushes stay byte-identical.
+`kAdd` requires an fp32/bf16/fp16/int32/int16/int8 dtype -- the same hardware
+allow-list `tile.store` enforces -- and bf16 carries the same Ascend910B-only
+restriction on top.
+
+`pld.tensor.put` (TPUT) has **no** tile-source form — its staging tile is a
+bounce buffer, not a data source. Pushing a computed value is `remote_store`'s
+job; pushing a bulk GM region that need not fit on-core is `put`'s.
+
+DSL (`python/pypto/language/distributed/op/tile_ops.py`,
+`.../tensor_ops.py`) exposes `target` / `peer` / `offsets` as
+positional-or-keyword for readability and round-tripping; the IR ops keep them
 positional, matching `tile.store`.
 
 ### `pld.tensor.put` (TPUT)
@@ -583,6 +609,7 @@ dispatches before the final `Simplify`.
   under `tests/st/distributed/`. **Put/get canonical e2e contracts** are now
   enabled: `test_l3_put.py` (ring overwrite, row-offset put, atomic-add put, and
   chunked/pipelined transfers ✅), `test_l3_get.py` (ring read, row-offset get ✅),
-  and `test_l3_remote_store.py` (tile-level subview push ✅). All tests use the
+  and `test_l3_remote_store.py` (tile-level subview push ✅, plus a
+  tensor-level push of a *computed* value ✅). All tests use the
   `pld.system.notify` / `pld.system.wait` handshake pattern established by
   notify/wait and collective STs.

--- a/docs/en/user/distributed/02-primitives.md
+++ b/docs/en/user/distributed/02-primitives.md
@@ -107,7 +107,14 @@ collectives; most users call `pld.tensor.*` collectives instead.
 | Name | Signature | Description |
 | ---- | --------- | ----------- |
 | `remote_load` | `(target: DT, peer: IntLike, offsets: Sequence[IntLike], shape: Sequence[IntLike], valid_shape=None) -> Tile` | Load a region of peer rank's `DT` into a local tile. `shape` defines the tile dimensions. `valid_shape` keeps the physical tile fixed-size while a ragged tail reads only real data. Offsets must match what the peer stored — a 1-element misalignment causes silent corruption. |
-| `remote_store` | `(src_tile: Tile, target: DT, peer: IntLike, offsets: Sequence[IntLike]) -> Call` | Write a local tile into peer rank's `DT`. Side-effect-only. |
+| `remote_store` | `(src_tile: Tile, target: DT, peer: IntLike, offsets: Sequence[IntLike], *, atomic=AtomicType.None_) -> Call` | Write a local tile into peer rank's `DT`. Side-effect-only. `atomic=Add` accumulates into the peer's region instead of overwriting. The pushed region must fit inside `target` at `offsets`. |
+
+`remote_store` also exists one IR level up as **`pld.tensor.remote_store`**
+`(src: Tensor, target: DT, peer: IntLike, offsets, *, atomic=...)`, for pushing a
+*computed* value out of a tensor-level `@pl.jit` kernel (where there are no tiles
+to name). It lowers 1:1 to the tile form, so the value reaches the peer as a single
+remote write with no global-memory round-trip. The short form `pld.remote_store`
+dispatches between the two on the operand you pass.
 
 ## Put and Get (`pld.tensor.*`)
 
@@ -202,7 +209,7 @@ and shape must match what the peer stored — a mismatch reads garbage.
 | `pld.alloc_window_buffer(...)` | `pld.tensor.alloc_window_buffer(...)` |
 | `pld.window(...)` | `pld.tensor.window(...)` |
 | `pld.remote_load(...)` | `pld.tile.remote_load(...)` |
-| `pld.remote_store(...)` | `pld.tile.remote_store(...)` |
+| `pld.remote_store(...)` | `pld.tile.remote_store(...)` / `pld.tensor.remote_store(...)` (dispatches on `src`) |
 
 **No short form:** `pld.notify(...)`, `pld.wait(...)`, `pld.put(...)`,
 `pld.get(...)`, `pld.allreduce(...)`, and all other collective ops — these

--- a/docs/en/user/distributed/10-remote_load_store.md
+++ b/docs/en/user/distributed/10-remote_load_store.md
@@ -95,6 +95,41 @@ rank just wrote. The same barrier that orders loads also orders stores.
 structural: anything you want to share must flow through a
 `pld.DistributedTensor` view of a window buffer.
 
+## Pushing a computed value from a tensor-level kernel
+
+The example above is a `@pl.jit.incore` (tile-level) kernel, so `pl.load`
+produces a `Tile` and `pld.tile.remote_store` takes it directly. In a
+tensor-level `@pl.jit` kernel there are no tiles to name — every value is a
+`pl.Tensor` — so the push is spelled `pld.tensor.remote_store`:
+
+```python
+@pl.jit
+def push_scaled(x, win, peer):
+    with pl.at(level=pl.Level.CORE_GROUP):
+        scaled = pl.mul(x[0:ROWS, 0:COLS], 2.0)
+        pld.tensor.remote_store(scaled, win, peer, [0, 0])
+        # ...then pld.system.notify() to release it, as always.
+```
+
+Both spellings compile to the same single remote write. The value goes
+**straight from on-core memory to the peer** — you do not have to store it back
+to global memory and push from there, which would cost a round trip and leave
+the store and the transfer on different pipes with nothing ordering them.
+
+If you don't want to think about which one you're in, the short form
+`pld.remote_store(src, target, peer, offsets)` picks the right one from the
+operand you hand it.
+
+Pass `atomic=pld.AtomicType.Add` (either form) to make the push a **combine** —
+`peer_region += src` — instead of an overwrite. That is what an all-to-all
+combine wants: every rank's contribution accumulates in place. It needs an
+fp32/bf16/fp16/int32/int16/int8 dtype, the same set `pl.store` accepts.
+
+Use [`pld.tensor.put`](11-put_get.md) instead when you are moving a **bulk**
+global-memory region: `put` streams through a staging tile and has the
+`chunk_rows` / `chunk_cols` / `pipeline` knobs, so it is not limited to what
+fits on-core. `remote_store` moves what you already have on-core, in one write.
+
 ## Edge cases
 
 > **Fatal pitfall — RMA before the ordering barrier.** `remote_load` reads

--- a/docs/zh/dev/distributed_ops.md
+++ b/docs/zh/dev/distributed_ops.md
@@ -7,21 +7,18 @@ N6 分布式算子族为 Python DSL 提供了对硬件跨 rank（cross-rank）�
 分配的对称、按 rank 划分的通信窗口的一个切片。族内 verifier 通常会拒绝普通
 `TensorType`（严格的 kind-trait 匹配 —— `As<DistributedTensorType>` 不匹配普通
 `TensorType`），以保证非窗口绑定的 tensor 永远不会被误传入跨 rank 槽位。
-**两个明确的例外：** `pld.tensor.put`（以及它下降出的 `pld.tile.put`）的
-`src` 参数通过 `AsTensorTypeLike` 接受普通 `Tensor` —— TPUT 在源端只需要一段
-可读的本地 GM 区域,因此 kernel 可以直接从 host 输入推送,不必先经过窗口缓冲
-中转；`dst` 仍然必须是窗口绑定的 `DistributedTensor`。
-`pld.tensor.get`（以及它下降出的 `pld.tile.get`）的 `dst` 参数通过
-`AsTensorTypeLike` 接受普通 `Tensor` —— TGET 在目标端只需要一段可写的本地 GM
-区域来接收数据,因此 kernel 可以将 TGET 结果直接写入 host 输出 tensor；
-`src` 仍然必须是窗口绑定的 `DistributedTensor`。
+**两个明确的例外**（均经 `AsTensorTypeLike` 匹配,详见下方命名空间一节）：
+`put`/`tile.put` 的 `src` 与 `get`/`tile.get` 的 `dst` 接受普通 `Tensor` ——
+TPUT/TGET 在该侧只需要一段可读/可写的*本地* GM 区域。窗口绑定的一侧
+（`put.dst`、`get.src`）仍然必须是 `DistributedTensor`。
 
-共有**十三个算子**和**四个 ABI 枚举**：
+共有**十四个算子**和**四个 ABI 枚举**：
 
 | 算子 | 方向 | 结果 | 硬件 |
 | ---- | ---- | ---- | ---- |
 | `pld.tile.remote_load` | pull（读 peer → 本地 tile） | `TileType` | TLOAD |
 | `pld.tile.remote_store` | push（写本地 tile → peer） | `Unknown`（副作用） | TSTORE |
+| `pld.tensor.remote_store` | push（写本地 tensor 级值 → peer）；1:1 下降为 `pld.tile.remote_store` | `Unknown`（副作用） | TSTORE |
 | `pld.tensor.get` | pull（读 peer → 本地 GM） | `Unknown`（副作用） | TGET |
 | `pld.tensor.put` | push（写本地 → peer） | `Unknown`（副作用） | TPUT |
 | `pld.tensor.allreduce` | collective reduce over window slices | `DistributedTensorType`（同 src） | builtin collective |
@@ -34,7 +31,7 @@ N6 分布式算子族为 Python DSL 提供了对硬件跨 rank（cross-rank）�
 | `pld.system.notify` | 给 peer 的槽位发信号 | `Unknown`（副作用） | TNOTIFY |
 | `pld.system.wait` | 在自身槽位上阻塞 | `Unknown`（副作用） | TWAIT |
 
-五个仅有副作用（side-effect-only）的算子产生
+六个仅有副作用（side-effect-only）的算子产生
 [`UnknownType`](ir/02-types.md)：它们因跨 rank 副作用而存在，而非为消费者读取的
 SSA 值而存在。
 
@@ -46,20 +43,20 @@ SSA 值而存在。
   的兄弟,归入 `pld.tile`。
 - **`pld.tile.remote_store`** 消费一个 *tile*（`remote_load` 的对称写伴生算子），
   因此是 `tile.store` 的兄弟,同样归入 `pld.tile`。
-- **`pld.tensor.get`** 读写 *tensor*（GM）操作数 —— `dst` 可以是窗口绑定的
-  `DistributedTensor` 视图,**也可以**是普通 `Tensor`（TGET 在目标端只需要一段
-  可写的本地 GM 区域来接收数据）；`src` 必须是窗口绑定的 `DistributedTensor`
-  视图（peer 需要窗口槽位用于读取）。TGET 中转用的 VEC staging tile 由
-  `ConvertTensorToTileOps` 物化为内部 `pld.tile.get`,不出现在 DSL 表面。
-  因此它是 `pld.tensor.alloc_window_buffer` / `pld.tensor.window` 的兄弟,
-  而**不是**产出 tile 的 `remote_load` 的兄弟。
-- **`pld.tensor.put`** 读写 *tensor*（GM）操作数 —— `dst` 必须是窗口绑定的
-  `DistributedTensor` 视图（peer 需要窗口槽位用于接收）；`src` 可以是窗口绑定的
-  `DistributedTensor` 视图,**也可以**是普通 `Tensor`（TPUT 在源端只需要一段可
-  读的本地 GM 区域）。TPUT 中转用的 VEC staging tile 由
-  `ConvertTensorToTileOps` 物化为内部 `pld.tile.put`,不出现在 DSL 表面。
-  因此它是 `pld.tensor.alloc_window_buffer` / `pld.tensor.window` 的兄弟,
-  而**不是**产出 tile 的 `remote_load` 的兄弟。
+- **`pld.tensor.remote_store`** 是同一算子上移一个 IR 层级 —— 它消费 *tensor 级*
+  的值，因此归入 `pld.tensor`，并由 `ConvertTensorToTileOps` 1:1 下降为
+  `pld.tile.remote_store`。这正是 `tensor.aiv_shard` / `tile.aiv_shard` 的形态
+  （**一个算子、两个层级、完全相同的参数面**），也是把 tensor 级 push 做成独立
+  入口、而不是重载 `pld.tensor.put` 的原因：按 `src` 的种类分派 `put` 会让它的五
+  个参数（`src_offsets`、`shape`、`atomic`、`chunk_*`、`pipeline`）随上游如何产生
+  该值而变得时而无意义，而这个属性在调用点是看不见的。
+- **`pld.tensor.get` / `pld.tensor.put`** 两侧读写的都是 *tensor*（GM）操作数。
+  窗口绑定的是 peer 需要槽位的那一侧（`get.src`、`put.dst`）；本地的一侧
+  （`get.dst`、`put.src`）也接受普通 `Tensor`,因此 kernel 可以直接 TGET 进 /
+  TPUT 出 host 提供的 tensor,不必先经窗口缓冲中转。二者中转用的 VEC staging
+  tile 由 `ConvertTensorToTileOps` 物化为内部 `pld.tile.get` / `pld.tile.put`,
+  不出现在 DSL 表面。因此二者都是 `pld.tensor.alloc_window_buffer` /
+  `pld.tensor.window` 的兄弟,而**不是**产出 tile 的 `remote_load` 的兄弟。
 - **`pld.system.notify` / `pld.system.wait`** 驱动按 rank 的信号槽位 —— 纯控制面
   同步,无数据操作数 —— 因此归入 `pld.system`。
 
@@ -72,7 +69,7 @@ kwarg 负载（notify 的 `op`、wait 的 `cmp`、put 的 `atomic`）,并在 cod
 ```cpp
 enum class NotifyOp : int { kAtomicAdd = 0, kSet = 1 };   // pld.system.notify
 enum class WaitCmp  : int { kEq = 0,        kGe = 1 };     // pld.system.wait
-enum class AtomicType : int { kNone = 0,    kAdd = 1 };    // pld.tensor.put
+enum class AtomicType : int { kNone = 0,    kAdd = 1 };    // pld.tensor.put、remote_store
 enum class ReduceOp : int { kSum = 0, kMax = 1, kMin = 2, kProd = 3 };  // pld.tensor.allreduce
 ```
 
@@ -169,20 +166,36 @@ rank 索引；`offsets` / `shape` / 可选 `valid_shape` 必须各为 `MakeTuple
 DSL（`python/pypto/language/distributed/op/tile_ops.py`）接受位置或关键字参数；
 IR 算子保持位置参数，与 `tile.load` 一致。
 
-### `pld.tile.remote_store`（TSTORE）
+### `pld.tile.remote_store` / `pld.tensor.remote_store`（TSTORE）
 
 ```text
-pld.tile.remote_store(src_tile, target, peer, offsets) -> Unknown
+pld.tile.remote_store(src_tile, target, peer, offsets, *, atomic: int = 0) -> Unknown
+pld.tensor.remote_store(src, target, peer, offsets, *, atomic: int = 0) -> Unknown
 ```
 
-把本地 tile 写入 `peer` rank 的窗口绑定 `DistributedTensor` 切片中的一个区域。
-在 IR 层面镜像 `tile.store`（位置参数 `offsets` 元组、仅副作用返回值），但目的是
-*远程*切片 —— 地址转换在 codegen 时由
+把本地值写入 `peer` rank 的窗口绑定 `DistributedTensor` 切片中的一个区域。
+在 IR 层面镜像 `tile.store`（位置参数 `offsets` 元组、可选 `atomic` attr、仅副作用
+返回值），但目的是*远程*切片 —— 地址转换在 codegen 时由
 `CommRemoteOffset(ctx, peer) + addptr + make_tensor_view` 实现。
 
-Verifier：`src_tile` 必须是 `TileType`；`target` 必须是 `DistributedTensorType`；
-`peer` 必须是 `ScalarType` rank 索引；`offsets` 必须是 `MakeTuple`,其 rank 等于
-`target.shape.size()`；`src_tile.dtype` 必须等于 `target.dtype`。
+两种形式**只**在 `src` 的 IR 层级上不同；短形式 `pld.remote_store` 按操作数分派，
+因此用户代码在两个层级上写法相同。
+
+Verifier（两种形式共用）：
+
+| 规则 | 说明 |
+| ---- | ---- |
+| `target` 是 `DistributedTensorType`，`peer` 是 `ScalarType` rank 索引 | |
+| `offsets` 是 rank 等于 `target.shape.size()` 的 `MakeTuple` | |
+| `src.dtype == target.dtype`，`target` rank ≥ 2 | |
+| `src` 是 2-D，或前导维全为 1 的 N-D | deducer 运行在 `FlattenTileNdTo2D` 折叠 N-D tile **之前**；前导维 > 1 会被折进行数并越过 target |
+| 被写入的区域在 `offsets` 处落在 `target` 内部（仅静态维度） | `remote_store` 自身不携带 transfer `shape` 可供裁剪：范围来自 `src`，所以在此之前一次越界 push 会静默覆写 peer 的相邻区域 |
+| `src` 是 `TileType`（tile 形式）/ `TensorType`（tensor 形式） | 两者的诊断都会点名兄弟入口，把作者引向其所处层级对应的那一个 |
+
+下降（tensor 形式）：`ConvertTensorToTileOps` 通过 `RegisterSimple` 将其 1:1 改写为
+tile 形式。其 `InputSpaceReq{Vec}` 使该算子在参数面上**完备**——`BridgeInputSpaces`
+只改写 `TensorType` 操作数，因此计算值（已是 tile）保持其内存空间直接透传，而仍驻留
+在 GM 的 `src` 会被自动桥接一次自然的 `tile.load` 到 Vec。
 
 Codegen：经过标准 tile pipeline 之后 tile 是 2-D（height × width）；发出的
 `pto.partition_view` 与 `target` 同 rank，前 `(target.rank - 2)` 维都填 1（与
@@ -191,9 +204,21 @@ Codegen：经过标准 tile pipeline 之后 tile 是 2-D（height × width）；
 是用来抓住之前 codegen 对任意 rank 都按 2-D 发 `partition_view` 的隐藏 bug
 的回归保护。
 
-DSL（`python/pypto/language/distributed/op/tile_ops.py`）把 `target` / `peer` /
-`offsets` 暴露为仅关键字（keyword-only）参数以提升可读性；IR 算子保持位置参数,
-与 `tile.store` 一致。
+`atomic = AtomicType.kAdd` 会在 `pto.tstore` 上追加
+`{atomicType = #pto<atomic_type atomic_add>}`，把 push 变成**归约**
+（`peer_region += src`）而非覆写 —— 即 `tile.store` split-K 累加的跨 rank 孪生形式，
+也是 all-to-all combine 就地累加各 rank 贡献所需要的。该 attr 仅在 `kAdd` 时发出，
+因此普通 push 的产物与之前逐字节一致。`kAdd` 要求 dtype 为
+fp32/bf16/fp16/int32/int16/int8 —— 与 `tile.store` 强制的硬件允许列表相同 ——
+bf16 在此之上还有 Ascend910B-only 限制。
+
+`pld.tensor.put`（TPUT）**没有** tile 源形式 —— 它的 staging tile 是中转缓冲而非
+数据源。推送计算值是 `remote_store` 的职责；推送无需装入片上的大块 GM 区域则是
+`put` 的职责。
+
+DSL（`python/pypto/language/distributed/op/tile_ops.py`、`.../tensor_ops.py`）把
+`target` / `peer` / `offsets` 暴露为位置或关键字参数以提升可读性并支持往返；IR 算子
+保持位置参数,与 `tile.store` 一致。
 
 ### `pld.tensor.put`（TPUT）
 
@@ -511,5 +536,5 @@ host_orch 函数体包裹进嵌套的 `CommDomainScopeStmt` 节点（按推断�
   `tests/st/distributed/` 下其他 L3 ST。**Put/Get 端到端权威契约** 已启用：
   `test_l3_put.py`（环形覆写、行偏移 put、原子加 put、分块/流水 transfer ✅）、
   `test_l3_get.py`（环形读、行偏移 get ✅）、以及 `test_l3_remote_store.py`
-  （tile 级子视图 push ✅）。所有测试均采用由 notify/wait 和集体 ST 建立的
+  （tile 级子视图 push ✅，以及 tensor 级*计算值* push ✅）。所有测试均采用由 notify/wait 和集体 ST 建立的
   `pld.system.notify` / `pld.system.wait` 握手模式。

--- a/docs/zh/user/distributed/02-primitives.md
+++ b/docs/zh/user/distributed/02-primitives.md
@@ -88,7 +88,13 @@ def handshake_step(
 | 名称 | 签名 | 描述 |
 | ---- | ---- | ---- |
 | `remote_load` | `(target, peer, offsets, shape, valid_shape=None) -> Tile` | 加载对端区域到本地 tile。`shape` 定义 tile 维度。`valid_shape` 可在物理 tile 保持固定大小的同时，让参差不齐的尾部只读取真实数据。Offsets 必须与对端写入时使用的一致——偏移 1 个元素就会导致静默数据损坏。 |
-| `remote_store` | `(src_tile, target, peer, offsets) -> Call` | 写入本地 tile 到对端。 |
+| `remote_store` | `(src_tile, target, peer, offsets, *, atomic=AtomicType.None_) -> Call` | 写入本地 tile 到对端。`atomic=Add` 表示累加到对端区域而非覆写。被写入的区域必须在 `offsets` 处落在 `target` 内部。 |
+
+`remote_store` 还有一个上移一层的形式 **`pld.tensor.remote_store`**
+`(src: Tensor, target: DT, peer: IntLike, offsets, *, atomic=...)`，用于在 tensor 级
+`@pl.jit` kernel 中推送*计算值*（那里没有 tile 可命名）。它 1:1 下降为 tile 形式，
+因此该值以单次远程写抵达对端，中间不经过全局内存往返。短形式 `pld.remote_store`
+会按传入的操作数在两者之间分派。
 
 ## Put 和 Get (`pld.tensor.*`)
 
@@ -184,7 +190,7 @@ for peer in pl.range(nranks):
 | `pld.alloc_window_buffer(...)` | `pld.tensor.alloc_window_buffer(...)` |
 | `pld.window(...)` | `pld.tensor.window(...)` |
 | `pld.remote_load(...)` | `pld.tile.remote_load(...)` |
-| `pld.remote_store(...)` | `pld.tile.remote_store(...)` |
+| `pld.remote_store(...)` | `pld.tile.remote_store(...)` / `pld.tensor.remote_store(...)`（按 `src` 分派） |
 
 **无短格式：** `pld.notify(...)`、`pld.wait(...)`、`pld.put(...)`、
 `pld.get(...)`、`pld.allreduce(...)` 等——这些需要完整的 3 段命名空间。

--- a/docs/zh/user/distributed/10-remote_load_store.md
+++ b/docs/zh/user/distributed/10-remote_load_store.md
@@ -90,6 +90,37 @@ barrier 也为 store 排序。
 输入/输出。规则是结构性的：任何你想共享的内容都必须流经 window buffer 的
 `pld.DistributedTensor` 视图。
 
+## 从 tensor 级 kernel 推送计算值
+
+上面的示例是 `@pl.jit.incore`（tile 级）kernel，因此 `pl.load` 产生 `Tile`，
+`pld.tile.remote_store` 直接接受它。而在 tensor 级 `@pl.jit` kernel 中没有 tile
+可命名——每个值都是 `pl.Tensor`——所以 push 写作 `pld.tensor.remote_store`：
+
+```python
+@pl.jit
+def push_scaled(x, win, peer):
+    with pl.at(level=pl.Level.CORE_GROUP):
+        scaled = pl.mul(x[0:ROWS, 0:COLS], 2.0)
+        pld.tensor.remote_store(scaled, win, peer, [0, 0])
+        # ...随后照例用 pld.system.notify() 释放数据。
+```
+
+两种写法编译出的是同一次远程写。值**直接从片上内存到达对端**——你不需要先把它
+存回全局内存再从那里推送，那样会多一次往返，并且会让 store 与 transfer 落在不同
+pipe 上而没有任何东西为它们排序。
+
+如果你不想区分自己身处哪一层，短形式
+`pld.remote_store(src, target, peer, offsets)` 会根据你传入的操作数选择正确的那个。
+
+传入 `atomic=pld.AtomicType.Add`（两种形式均可）可把 push 变成**归约**——
+`peer_region += src`——而非覆写。这正是 all-to-all combine 需要的：每个 rank 的
+贡献就地累加。它要求 dtype 为 fp32/bf16/fp16/int32/int16/int8，与 `pl.store`
+接受的集合相同。
+
+当你搬运的是**大块**全局内存区域时，改用 [`pld.tensor.put`](11-put_get.md)：`put`
+经由 staging tile 流式传输，并带有 `chunk_rows` / `chunk_cols` / `pipeline` 开关，
+因此不受片上容量限制。`remote_store` 则以单次写搬运你已经放在片上的数据。
+
 ## 边界情况（Edge cases）
 
 > **致命陷阱——排序 barrier 之前的 RMA。** `remote_load` 读取 *window* 内存，

--- a/python/pypto/ir/op/distributed/tensor_ops.py
+++ b/python/pypto/ir/op/distributed/tensor_ops.py
@@ -8,7 +8,7 @@
 # -----------------------------------------------------------------------------------------------------------
 
 """IR builders for ``pld.tensor.alloc_window_buffer`` / ``pld.tensor.window`` /
-``pld.tensor.get`` / ``pld.tensor.put``.
+``pld.tensor.get`` / ``pld.tensor.put`` / ``pld.tensor.remote_store``.
 
 These are the raw IR-layer equivalents of :func:`pypto.ir.op.tile_ops.load`
 and friends: they take ``ir.Expr`` arguments, normalize them to the shapes
@@ -71,6 +71,53 @@ def window(
     actual_span = _get_span_or_capture(span, frame_offset=1)
     shape_tuple = _to_make_tuple(shape, actual_span)
     return _ir_core.create_op_call("pld.tensor.window", [buf, shape_tuple], {"dtype": dtype}, actual_span)
+
+
+def remote_store(
+    src: Expr,
+    target: Expr,
+    peer: int | Expr,
+    offsets: Sequence[int | Expr] | _ir_core.MakeTuple,
+    *,
+    atomic: int = 0,
+    span: Span | None = None,
+) -> Call:
+    """Build a ``pld.tensor.remote_store(src, target, peer, offsets)`` Call.
+
+    Tensor-level twin of :func:`pypto.ir.op.distributed.tile_ops.remote_store`:
+    same four arguments, same semantics, one IR level up.
+    ``ConvertTensorToTileOps`` lowers it 1:1 to ``pld.tile.remote_store`` (and
+    auto-bridges a still-GM ``src`` with a ``tile.load``), so a tensor-level
+    ``@pl.jit`` kernel can push a computed value cross-rank without first
+    round-tripping it through global memory.
+
+    Args:
+        src: Local :class:`ir.Expr` with 2-D :class:`ir.TensorType` (dtype must
+            match ``target.dtype``). The verifier rejects a
+            :class:`ir.DistributedTensorType` — a window-to-window transfer is
+            :func:`put`'s GM-to-GM job.
+        target: A :class:`ir.Expr` with type :class:`ir.DistributedTensorType`
+            (the verifier rejects plain :class:`ir.TensorType`).
+        peer: Scalar peer rank index (:class:`ir.Expr` of :class:`ir.ScalarType`).
+        offsets: Per-dimension offsets into ``target``'s coordinate space —
+            sequence of ints/:class:`ir.Expr`, or an existing :class:`ir.MakeTuple`.
+        atomic: ``AtomicType`` underlying int — 0 (``kNone``, plain overwrite)
+            or 1 (``kAdd``, atomic-add into the peer's region). Omitted from the
+            kwargs entirely when 0.
+        span: Optional source span (auto-captured if absent).
+
+    Returns:
+        :class:`ir.Call` with :class:`ir.UnknownType` (side-effect only).
+    """
+    actual_span = _get_span_or_capture(span, frame_offset=1)
+    peer_expr = _normalize_expr(peer, actual_span, int_dtype=DataType.INT32)
+    offsets_tuple = _to_make_tuple(offsets, actual_span)
+    return _ir_core.create_op_call(
+        "pld.tensor.remote_store",
+        [src, target, peer_expr, offsets_tuple],
+        {"atomic": int(atomic)} if atomic else {},
+        actual_span,
+    )
 
 
 def put(  # noqa: PLR0913
@@ -445,6 +492,7 @@ __all__ = [
     "broadcast",
     "get",
     "put",
+    "remote_store",
     "reduce_scatter",
     "window",
 ]

--- a/python/pypto/ir/op/distributed/tile_ops.py
+++ b/python/pypto/ir/op/distributed/tile_ops.py
@@ -110,18 +110,23 @@ def remote_store(
     peer: int | Expr,
     offsets: Sequence[int | Expr] | _ir_core.MakeTuple,
     *,
+    atomic: int = 0,
     span: Span | None = None,
 ) -> Call:
     """Build a ``pld.tile.remote_store(src_tile, target, peer, offsets)`` Call.
 
     Args:
-        src_tile: Local :class:`ir.Expr` with :class:`ir.TileType` (dtype must
-            match ``target.dtype``).
+        src_tile: Local :class:`ir.Expr` with 2-D :class:`ir.TileType` (dtype
+            must match ``target.dtype``).
         target: A :class:`ir.Expr` with type :class:`ir.DistributedTensorType`
             (the verifier rejects plain :class:`ir.TensorType`).
         peer: Scalar peer rank index (:class:`ir.Expr` of :class:`ir.ScalarType`).
         offsets: Per-dimension offsets into ``target``'s coordinate space —
             sequence of ints/:class:`ir.Expr`, or an existing :class:`ir.MakeTuple`.
+        atomic: ``AtomicType`` underlying int — 0 (``kNone``, plain overwrite)
+            or 1 (``kAdd``, atomic-add into the peer's region). The kwarg is
+            omitted entirely when 0 so non-atomic stores print unchanged,
+            mirroring :func:`pypto.ir.op.tile_ops.store`.
         span: Optional source span (auto-captured if absent).
 
     Returns:
@@ -133,7 +138,7 @@ def remote_store(
     return _ir_core.create_op_call(
         "pld.tile.remote_store",
         [src_tile, target, peer_expr, offsets_tuple],
-        {},
+        {"atomic": int(atomic)} if atomic else {},
         actual_span,
     )
 

--- a/python/pypto/language/distributed/op/tensor_ops.py
+++ b/python/pypto/language/distributed/op/tensor_ops.py
@@ -304,6 +304,78 @@ def window(
     return DistributedTensor(expr=call)
 
 
+def remote_store(
+    src: Tensor | Expr,
+    target: DistributedTensor,
+    peer: IntLike,
+    offsets: Sequence[IntLike],
+    *,
+    atomic: AtomicType = AtomicType.None_,
+) -> Call:
+    """Push a tensor-level value into a region of ``peer`` rank's slice of ``target``.
+
+    Tensor-level twin of :func:`pld.tile.remote_store` — same four arguments,
+    same single ``pto.tstore``, one IR level up. This is the entry point a
+    tensor-level ``@pl.jit`` kernel uses to push a **computed** value cross-rank:
+    ``ConvertTensorToTileOps`` lowers it 1:1 to ``pld.tile.remote_store``, so the
+    value goes straight from on-core memory to the peer's window with no global-
+    memory round-trip in between.
+
+    .. code-block:: python
+
+       @pl.jit
+       def push(x: pl.Tensor[[16, 256], pl.FP32], win: pld.DistributedTensor[[16, 256], pl.FP32], peer):
+           with pl.at(level=pl.Level.CORE_GROUP):
+               scaled = pl.mul(x[0:16, 0:256], 2.0)
+               pld.tensor.remote_store(scaled, win, peer, [0, 0])
+               # ...then pld.system.notify() to release it to the peer.
+
+    A ``src`` that is still resident in global memory at lowering time (e.g. a
+    kernel parameter pushed unchanged) is auto-bridged with a ``tile.load``, so
+    the op is total on its argument surface. Prefer :func:`pld.tensor.put` for a
+    **bulk** global-memory transfer: TPUT streams through a staging tile and owns
+    the ``chunk_rows`` / ``chunk_cols`` / ``pipeline`` knobs, so it is not bounded
+    by what fits on-core.
+
+    Args:
+        src: Local 2-D :class:`pl.Tensor` value (dtype must match
+            ``target.dtype``). A :class:`pld.DistributedTensor` is refused — a
+            window-to-window transfer is :func:`put`'s job.
+        target: Window-bound :class:`pld.DistributedTensor` destination
+            (rank >= 2). The C++ verifier refuses a plain :class:`pl.Tensor`.
+        peer: Peer rank index.
+        offsets: Offsets into the remote slice, one per ``target`` dimension.
+            The pushed region must fit inside ``target`` at these offsets.
+        atomic: :class:`pld.AtomicType` selecting plain-store
+            (``AtomicType.None_``, the default) vs atomic-add combine semantics
+            on the peer's region (keyword-only).
+
+    Returns:
+        A side-effect-only :class:`ir.Call` (no SSA result for downstream use).
+    """
+    src_expr = _unwrap(src)
+    target_expr = _unwrap(target)
+    if not isinstance(target_expr, Expr) or not isinstance(target_expr.type, _ir.DistributedTensorType):
+        got = (
+            _ir.python_print_type(target_expr.type)
+            if isinstance(target_expr, Expr)
+            else type(target_expr).__name__
+        )
+        raise TypeError(
+            f"pld.tensor.remote_store expects a DistributedTensor target (window-bound); got {got}"
+        )
+    if not isinstance(src_expr, Expr) or not isinstance(src_expr.type, _ir.TensorType):
+        got = _ir.python_print_type(src_expr.type) if isinstance(src_expr, Expr) else type(src_expr).__name__
+        raise TypeError(
+            f"pld.tensor.remote_store expects a Tensor src (a tensor-level value); got {got}. "
+            "In a tile-level kernel use pld.tile.remote_store; to push one window buffer into "
+            "another use pld.tensor.put."
+        )
+    return _ir_tensor.remote_store(
+        src_expr, target_expr, _unwrap(peer), _normalize_intlike(offsets), atomic=int(atomic)
+    )
+
+
 def put(
     dst: DistributedTensor,
     peer: IntLike,
@@ -995,6 +1067,7 @@ __all__ = [
     "broadcast",
     "get",
     "put",
+    "remote_store",
     "reduce_scatter",
     "window",
 ]

--- a/python/pypto/language/distributed/op/tile_ops.py
+++ b/python/pypto/language/distributed/op/tile_ops.py
@@ -131,10 +131,12 @@ def _remote_load_with_physical_tail_padding(
 
 
 def remote_store(
-    src_tile: Tile,
+    src_tile: Tile | Expr,
     target: DistributedTensor,
     peer: IntLike,
     offsets: Sequence[IntLike],
+    *,
+    atomic: AtomicType = AtomicType.None_,
 ) -> Call:
     """Write a local tile into a region of ``peer`` rank's slice of a DistributedTensor.
 
@@ -150,18 +152,32 @@ def remote_store(
        # remote_store is a raw write with no synchronization of its own —
        # pair it with pld.system.notify()/wait() to signal completion.
 
-    All arguments are positional-or-keyword (mirroring :func:`pl.tile.store`),
-    so the printed IR — which emits them positionally — round-trips through
-    the parser. Callers may still pass them by keyword for readability.
+       # Combine instead of overwrite: sum every rank's contribution in place.
+       pld.tile.remote_store(tile, data, peer=1, offsets=[0, 0], atomic=pld.AtomicType.Add)
+
+    In a tensor-level ``@pl.jit`` kernel the operand is a :class:`pl.Tensor`
+    rather than a :class:`pl.Tile`; call :func:`pld.tensor.remote_store` there,
+    or use the ``pld.remote_store`` short form, which dispatches on the operand.
+
+    All positional arguments are positional-or-keyword (mirroring
+    :func:`pl.tile.store`), so the printed IR — which emits them positionally —
+    round-trips through the parser. Callers may still pass them by keyword for
+    readability.
 
     Args:
-        src_tile: Local :class:`pl.Tile` (dtype must match ``target.dtype``).
-        target: A window-bound :class:`pld.DistributedTensor` (any rank, any
+        src_tile: Local 2-D :class:`pl.Tile` (dtype must match ``target.dtype``).
+        target: A window-bound :class:`pld.DistributedTensor` (rank >= 2, any
             dtype). The C++ verifier refuses plain :class:`pl.Tensor` here
             (precise ObjectKind match on :class:`ir.DistributedTensorType`).
         peer: Peer rank index. Accepts an ``int`` literal, a DSL ``Scalar``,
             or a raw ``ir.Expr`` (e.g. ``pld.rank(ctx) + 1``).
         offsets: Offsets into the remote slice, one per ``target`` dimension.
+            The pushed region must fit inside ``target`` at these offsets.
+        atomic: :class:`pld.AtomicType` selecting plain-store
+            (``AtomicType.None_``, the default) vs atomic-add combine semantics
+            on the peer's region (keyword-only). ``AtomicType.Add`` into a bf16
+            window requires the Ascend910B (A2/A3) profile, the same restriction
+            :func:`pl.tile.store` carries.
 
     Returns:
         A side-effect-only :class:`ir.Call` (no SSA result for downstream use).
@@ -176,7 +192,9 @@ def remote_store(
         )
         raise TypeError(f"pld.tile.remote_store expects a DistributedTensor target (window-bound); got {got}")
 
-    return _ir_tile.remote_store(tile_expr, target_expr, _unwrap(peer), _normalize_intlike(offsets))
+    return _ir_tile.remote_store(
+        tile_expr, target_expr, _unwrap(peer), _normalize_intlike(offsets), atomic=int(atomic)
+    )
 
 
 def put(

--- a/python/pypto/language/distributed/op/unified_ops.py
+++ b/python/pypto/language/distributed/op/unified_ops.py
@@ -7,18 +7,33 @@
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
 
-"""Unified ``pld.<op>`` dispatch — short-form re-exports for the distributed DSL.
+"""Unified ``pld.<op>`` dispatch — short-form entry points for the distributed DSL.
 
-Unlike :mod:`pypto.language.op.unified_ops` (which does runtime type-dispatch
-between ``pl.tensor`` / ``pl.tile``), every short op name in ``pld`` maps to
-exactly one category, so the short form is a plain re-export from the
-canonical 3-segment surface — preserving signatures and docstrings for IDE
-help with zero call-chain indirection.
+Most short op names in ``pld`` map to exactly one category, so the short form is
+a plain re-export from the canonical 3-segment surface — preserving signatures
+and docstrings for IDE help with zero call-chain indirection.
+
+``remote_store`` is the exception: it exists at both IR levels
+(``pld.tile.remote_store`` / ``pld.tensor.remote_store``), so the short form
+type-dispatches on its source operand the way
+:mod:`pypto.language.op.unified_ops` does for ``pl.add`` and friends. The two
+forms have the same argument surface and the same semantics — only the level of
+``src`` differs — so the dispatch cannot silently change what a call means.
 """
 
+from collections.abc import Sequence
+
+from pypto.language.typing import IntLike, Tile
+from pypto.language.typing.tensor import Tensor
+from pypto.pypto_core import ir as _ir
+from pypto.pypto_core.ir import AtomicType, Call, Expr
+
+from ..typing.distributed_tensor import DistributedTensor
+from . import tensor_ops as _tensor
+from . import tile_ops as _tile
 from .system_ops import get_comm_ctx, nranks, rank, world_size
 from .tensor_ops import alloc_window_buffer, window
-from .tile_ops import remote_load, remote_store
+from .tile_ops import remote_load
 
 __all__ = [
     "alloc_window_buffer",
@@ -30,3 +45,49 @@ __all__ = [
     "window",
     "world_size",
 ]
+
+
+def remote_store(
+    src: Tile | Tensor | Expr,
+    target: DistributedTensor,
+    peer: IntLike,
+    offsets: Sequence[IntLike],
+    *,
+    atomic: AtomicType = AtomicType.None_,
+) -> Call:
+    """Push a local value into a region of ``peer`` rank's slice of ``target``.
+
+    Dispatches on the IR level of ``src``:
+
+    * a :class:`pl.Tile` (``@pl.jit.incore`` / ``@pl.program``) routes to
+      :func:`pld.tile.remote_store`;
+    * a tensor-level value (``@pl.jit``) routes to
+      :func:`pld.tensor.remote_store`, which ``ConvertTensorToTileOps`` lowers
+      1:1 to the tile form.
+
+    Either way the value reaches the peer as a single ``pto.tstore``, with no
+    global-memory round-trip. See the two canonical entry points for the full
+    argument documentation.
+
+    Args:
+        src: Local 2-D :class:`pl.Tile` or :class:`pl.Tensor` value (dtype must
+            match ``target.dtype``).
+        target: Window-bound :class:`pld.DistributedTensor` destination (rank >= 2).
+        peer: Peer rank index.
+        offsets: Offsets into the remote slice, one per ``target`` dimension.
+        atomic: :class:`pld.AtomicType` selecting plain-store (the default) vs
+            atomic-add combine semantics on the peer's region (keyword-only).
+
+    Returns:
+        A side-effect-only :class:`ir.Call` (no SSA result for downstream use).
+    """
+    if isinstance(src, Tile):
+        return _tile.remote_store(src, target, peer, offsets, atomic=atomic)
+    if isinstance(src, Tensor):
+        return _tensor.remote_store(src, target, peer, offsets, atomic=atomic)
+    # Raw ir.Expr (printer round-trip, hand-built IR): dispatch on the IR type.
+    # An unrecognised operand falls through to the tensor form, whose deducer
+    # produces the diagnostic naming both entry points.
+    if isinstance(src, Expr) and isinstance(src.type, _ir.TileType):
+        return _tile.remote_store(src, target, peer, offsets, atomic=atomic)
+    return _tensor.remote_store(src, target, peer, offsets, atomic=atomic)

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -8524,7 +8524,8 @@ class ASTParser:
                 f"Unknown distributed operation 'pld.{op_name}'",
                 span=span,
                 hint="Available short forms: pld.world_size, pld.get_comm_ctx, pld.rank, "
-                "pld.nranks, pld.alloc_window_buffer, pld.window, pld.remote_load",
+                "pld.nranks, pld.alloc_window_buffer, pld.window, pld.remote_load, "
+                "pld.remote_store",
             )
 
         return self._dispatch_op(_dsl_pld, "pld", op_name, call)

--- a/src/backend/common/pto_ops_distributed.cpp
+++ b/src/backend/common/pto_ops_distributed.cpp
@@ -24,6 +24,7 @@
 #include <vector>
 
 #include "pypto/backend/common/backend.h"
+#include "pypto/backend/common/backend_handler.h"
 #include "pypto/codegen/codegen_base.h"
 #include "pypto/codegen/distributed/comm_layout.h"
 #include "pypto/codegen/pto/pto_codegen.h"
@@ -338,14 +339,19 @@ static std::string MakeRemoteLoadCodegenPTO(const CallPtr& op, codegen::CodegenB
   return "";
 }
 
-// pld.tile.remote_store(src_tile, target, peer, offsets) — write a local tile
-// into a peer's slice of a window-bound DistributedTensor. Lowers to:
+// pld.tile.remote_store(src_tile, target, peer, offsets, *, atomic) — write a
+// local tile into a peer's slice of a window-bound DistributedTensor. Lowers to:
 //   delems    = func.call @CommRemoteOffset_<dtype>(ctx, peer) : ... -> index
 //   peer_ptr  = pto.addptr local_ptr, delems
 //   peer_view = pto.make_tensor_view peer_ptr, shape=..., strides=...
 //   pto.partition_view peer_view, offsets=..., sizes=<tile.valid_shape padded
 //                                                     with leading 1s>
 //   pto.tstore ins(<tile>) outs(<pview>)
+//       [{atomicType = #pto<atomic_type atomic_add>}]
+//
+// The optional atomicType attr is the cross-rank twin of tile.store's split-K
+// accumulation: it makes the push a combine (peer_region += tile) instead of an
+// overwrite, and is emitted only for AtomicType::kAdd.
 //
 // The tile's valid_shape is 2-D (height, width); when target_rank > 2 the
 // leading (target_rank - 2) partition dims are size-1 — matching the
@@ -406,6 +412,32 @@ static std::string MakeRemoteStoreCodegenPTO(const CallPtr& op, codegen::Codegen
     tstore_line << " : " << tile_buf_type;
   }
   tstore_line << ") outs(" << partition_view << " : " << partition_type << ")";
+
+  // Optional atomic-add combine mode — the cross-rank twin of tile.store's
+  // split-K accumulation, and what an all-to-all combine needs to sum peers'
+  // contributions in place. The attr is emitted only for atomic_add so a plain
+  // remote_store's codegen stays byte-identical (pto.tstore's atomicType
+  // defaults to none).
+  const int atomic_int = op->GetKwarg<int>("atomic", 0);
+  INTERNAL_CHECK_SPAN(atomic_int == static_cast<int>(ir::AtomicType::kNone) ||
+                          atomic_int == static_cast<int>(ir::AtomicType::kAdd),
+                      op->span_)
+      << "pld.tile.remote_store atomic kwarg must encode AtomicType::kNone or kAdd, got " << atomic_int;
+  if (atomic_int == static_cast<int>(ir::AtomicType::kAdd)) {
+    // Same backend restriction as tile.store: bf16 atomic-add into GM is only
+    // honoured on the A2/A3 store path (pto-isa set_atomic_bf16). The hardware
+    // atomic dispatch keys on the GM *destination* dtype, which here is the
+    // peer window's dtype.
+    if (binding.type->dtype_ == DataType::BF16) {
+      const auto* handler = codegen.GetBackendHandler();
+      CHECK_SPAN(handler->SupportsBf16AtomicAdd(), op->span_)
+          << "pld.tile.remote_store with atomic=AtomicType.Add into a bf16 window is not supported on the '"
+          << handler->GetPtoTargetArch()
+          << "' backend; bf16 atomic-add requires the Ascend910B (A2/A3) profile. Accumulate into an fp32 "
+             "window and cast to bf16 after the reduction instead.";
+    }
+    tstore_line << " {atomicType = #pto<atomic_type atomic_add>}";
+  }
   codegen.Emit(tstore_line.str());
 
   // Data-before-signal (ptoas memory-consistency): clean+invalidate the

--- a/src/ir/op/distributed/comm_op_utils.h
+++ b/src/ir/op/distributed/comm_op_utils.h
@@ -16,7 +16,9 @@
  * @file comm_op_utils.h
  * @brief Shared deducer helpers for the mirror-image cross-rank transfer ops
  *        ``pld.tensor.put`` / ``pld.tile.put`` (put.cpp) and ``pld.tensor.get``
- *        / ``pld.tile.get`` (get.cpp).
+ *        / ``pld.tile.get`` (get.cpp), plus the whole-tile push bounds check
+ *        shared by ``pld.tensor.remote_store`` / ``pld.tile.remote_store``
+ *        (remote_store.cpp).
  *
  * put and get are structural mirrors: the only semantic differences are which
  * operand must be window-bound (put: dst; get: src) and put's extra ``atomic``
@@ -35,6 +37,7 @@
 
 #include "pypto/core/dtype.h"
 #include "pypto/core/logging.h"
+#include "pypto/ir/comm.h"
 #include "pypto/ir/expr.h"
 #include "pypto/ir/kind_traits.h"
 #include "pypto/ir/op_registry.h"
@@ -258,6 +261,78 @@ inline std::vector<ExprPtr> ValidateRegionArgs(const std::vector<ExprPtr>& args,
     }
   }
   return transfer_shape->elements_;
+}
+
+// Bounds-check a whole-region cross-rank push (``pld.tensor.remote_store`` /
+// ``pld.tile.remote_store``): the 2-D ``push_extent`` lands at ``offsets`` in
+// the target's coordinate space, with the leading ``rank - 2`` dims occupying a
+// single element each (codegen pads them with size-1 partition dims — see
+// MakeRemoteStoreCodegenPTO).
+//
+// Unlike put/get, a remote_store carries no transfer ``shape`` of its own to
+// clamp against: the extent comes from the source, so an oversized or
+// badly-offset push silently overwrites the peer's neighbouring region. This is
+// the check that turns that into a compile error. Its ``remote_load`` mirror
+// already bounds-checks the same way. Dynamic offsets / dims are bounded at
+// runtime and are skipped here.
+inline void ValidatePushFitsTarget(const std::vector<ExprPtr>& push_extent,
+                                   const std::vector<ExprPtr>& offsets,
+                                   const std::vector<ExprPtr>& target_shape, const std::string& op_name) {
+  INTERNAL_CHECK(push_extent.size() == 2)
+      << "Internal error: " << op_name << " push extent must be 2-D at this point, got rank "
+      << push_extent.size();
+  INTERNAL_CHECK(target_shape.size() >= 2)
+      << "Internal error: " << op_name << " target rank must be >= 2 at this point, got "
+      << target_shape.size();
+  INTERNAL_CHECK(offsets.size() == target_shape.size())
+      << "Internal error: " << op_name << " offsets rank must match target rank at this point";
+  const size_t rank = target_shape.size();
+  for (size_t i = 0; i < rank; ++i) {
+    auto offset = As<ConstInt>(offsets[i]);
+    if (!offset) continue;  // dynamic offset — bounded at runtime
+    CHECK_SPAN(offset->value_ >= 0, offsets[i]->span_)
+        << op_name << " offsets dimension " << i << " must be non-negative, got " << offset->value_;
+    auto target_dim = As<ConstInt>(target_shape[i]);
+    if (!target_dim) continue;  // dynamic window dim
+    // Leading dims carry one element each; the trailing two carry the push extent.
+    int64_t extent = 1;
+    if (i + 2 >= rank) {
+      auto e = As<ConstInt>(push_extent[i + 2 - rank]);
+      if (!e) continue;  // dynamic push extent
+      extent = e->value_;
+    }
+    CHECK_SPAN(offset->value_ + extent <= target_dim->value_, offsets[i]->span_)
+        << op_name << " push exceeds the peer's target region in dimension " << i
+        << " (offset=" << offset->value_ << ", extent=" << extent << ", target_dim=" << target_dim->value_
+        << ")";
+  }
+}
+
+// Reject an ``atomic`` attr that is not a legal :enum:`AtomicType` value.
+// Shared by the put family (which requires the attr) and remote_store (where it
+// is optional and defaults to kNone), so the accepted set cannot drift apart.
+inline void ValidateAtomicValue(int atomic_value, const std::string& op_name) {
+  CHECK(atomic_value == static_cast<int>(AtomicType::kNone) ||
+        atomic_value == static_cast<int>(AtomicType::kAdd))
+      << op_name << " atomic must be AtomicType.None_ or AtomicType.Add (got int " << atomic_value << ")";
+}
+
+// The dtypes hardware atomic-add can actually combine. Mirrors the identical
+// allow-list `tile.store` enforces (DeduceTileStoreType in
+// src/ir/op/tile_ops/memory.cpp): both lower to `pto.tstore`'s `atomicType`, so
+// a dtype the local store path rejects is equally unsupported cross-rank.
+// Without this, `atomic=AtomicType.Add` into e.g. a UINT8 window passes the enum
+// check and reaches codegen, which then emits atomic_add for a dtype the
+// hardware cannot combine. bf16 is additionally profile-gated at codegen
+// (BackendHandler::SupportsBf16AtomicAdd); this is the dtype half of the guard.
+inline void ValidateAtomicAddDtype(int atomic_value, const DataType& dtype, const std::string& op_name) {
+  if (atomic_value != static_cast<int>(AtomicType::kAdd)) return;
+  CHECK(dtype == DataType::FP32 || dtype == DataType::BF16 || dtype == DataType::FP16 ||
+        dtype == DataType::INT32 || dtype == DataType::INT16 || dtype == DataType::INT8)
+      << op_name
+      << " with atomic=AtomicType.Add requires an fp32/bf16/fp16/int32/int16/int8 dtype (hardware "
+         "atomic-add dtypes), but got "
+      << dtype.ToString();
 }
 
 }  // namespace comm_op

--- a/src/ir/op/distributed/put.cpp
+++ b/src/ir/op/distributed/put.cpp
@@ -78,7 +78,6 @@
 
 #include "pypto/core/dtype.h"
 #include "pypto/core/logging.h"
-#include "pypto/ir/comm.h"
 #include "pypto/ir/expr.h"
 #include "pypto/ir/kind_traits.h"
 #include "pypto/ir/op_registry.h"
@@ -118,10 +117,7 @@ void ValidatePutContract(const ExprPtr& dst, const ExprPtr& peer, const ExprPtr&
       << " vs src " << src->GetType()->TypeName();
   comm_op::ValidateTransferShapeContract(dst_type->shape_, src_type->shape_, op_name, require_same_shape);
 
-  auto atomic_value = GetRequiredKwarg<int>(kwargs, "atomic", op_name);
-  CHECK(atomic_value == static_cast<int>(AtomicType::kNone) ||
-        atomic_value == static_cast<int>(AtomicType::kAdd))
-      << op_name << " atomic must be AtomicType.None_ or AtomicType.Add (got int " << atomic_value << ")";
+  comm_op::ValidateAtomicValue(GetRequiredKwarg<int>(kwargs, "atomic", op_name), op_name);
 }
 
 TypePtr DeducePutType(const std::vector<ExprPtr>& args,

--- a/src/ir/op/distributed/remote_store.cpp
+++ b/src/ir/op/distributed/remote_store.cpp
@@ -11,35 +11,61 @@
 
 /**
  * @file remote_store.cpp
- * @brief Distributed cross-rank tile store — ``pld.tile.remote_store``.
+ * @brief Distributed cross-rank store — ``pld.tile.remote_store`` and its
+ *        tensor-level sibling ``pld.tensor.remote_store``.
  *
- * Writes a local tile into a region of the ``peer`` rank's slice of a
+ * Writes a local value into a region of the ``peer`` rank's slice of a
  * window-bound :class:`DistributedTensorType`. Mirrors ``tile.store`` at the
- * IR level (positional ``offsets`` tuple + side-effect-only return), but the
- * destination is a *remote* slice — the address translation is realised at
- * codegen time by ``CommRemoteOffset(ctx, peer) + addptr + make_tensor_view``.
+ * IR level (positional ``offsets`` tuple, optional ``atomic`` attr,
+ * side-effect-only return), but the destination is a *remote* slice — the
+ * address translation is realised at codegen time by
+ * ``CommRemoteOffset(ctx, peer) + addptr + make_tensor_view``.
  *
- * IR signature::
+ * IR signatures::
  *
- *     pld.tile.remote_store(src_tile, target, peer, offsets) -> Unknown
+ *     pld.tile.remote_store(src_tile, target, peer, offsets, *, atomic: int) -> Unknown
+ *     pld.tensor.remote_store(src, target, peer, offsets, *, atomic: int) -> Unknown
  *
- * The DSL surface (``pld.tile.remote_store`` in
- * ``python/pypto/language/distributed/op/tile_ops.py``) exposes ``target`` /
- * ``peer`` / ``offsets`` as keyword-only arguments for readability; the
- * underlying IR op keeps them positional, matching the convention used by
- * ``tile.store`` (see ``src/ir/op/tensor_ops/memory.cpp``).
+ * The two forms differ only in the IR level of ``src``, exactly as
+ * ``tensor.aiv_shard`` / ``tile.aiv_shard`` do: the namespace encodes the level
+ * the op lives at (see ``docs/en/dev/distributed_ops.md``). The tensor form is
+ * what a tensor-level ``@pl.jit`` kernel writes to push a computed value
+ * cross-rank; ``ConvertTensorToTileOps`` lowers it 1:1 to the tile form, and a
+ * ``src`` that is still GM-resident at that point is auto-bridged with a
+ * natural ``tile.load`` into Vec by the conversion registry's ``InputSpaceReq``.
+ * ``pld.tensor.put`` remains the GM->GM bulk (TPUT) path: it stages through a
+ * VEC bounce buffer and owns the chunking / pipelining knobs that a single
+ * ``pto.tstore`` has no use for.
+ *
+ * The DSL surface (``pld.tile.remote_store`` /``pld.tensor.remote_store`` in
+ * ``python/pypto/language/distributed/op/``) exposes ``target`` / ``peer`` /
+ * ``offsets`` as keyword-or-positional for readability; the underlying IR ops
+ * keep them positional, matching the convention used by ``tile.store`` (see
+ * ``src/ir/op/tensor_ops/memory.cpp``). ``pld.remote_store`` dispatches between
+ * the two on the kind of ``src``.
  *
  * Verifier (strict per kind-trait rules — ``As<DistributedTensorType>`` does
  * NOT match a plain :class:`TensorType`):
  *
- * * ``src_tile`` must have :class:`TileType` — the local tile being pushed.
+ * * ``src_tile`` must have :class:`TileType` (tile form) / ``src`` must have
+ *   :class:`TensorType` (tensor form) — mismatches name the sibling op so the
+ *   author is pointed at the entry point for the level they are writing at.
  * * ``target`` must have :class:`DistributedTensorType` — refuse plain
  *   :class:`TensorType` so users cannot accidentally feed a non-window-bound
  *   tensor into a cross-rank store.
  * * ``peer`` must be a :class:`ScalarType` expression (integer rank index).
  * * ``offsets`` must be a :class:`MakeTuple`, with rank equal to
  *   ``target.shape.size()``.
- * * ``src_tile`` dtype must match ``target`` dtype.
+ * * ``src`` dtype must match ``target`` dtype.
+ * * ``target`` rank >= 2, and ``src`` must be 2-D — or N-D with every leading
+ *   dim 1, since the deducer also runs *before* ``FlattenTileNdTo2D`` collapses
+ *   N-D tiles. Codegen pushes the 2-D extent into the inner two dims of the peer
+ *   slice, padding leading dims with 1s (see ``EffectivePushExtent``).
+ * * the pushed region must fit inside ``target`` at ``offsets`` (static dims
+ *   only) — see ``comm_op::ValidatePushFitsTarget``.
+ * * ``atomic`` (optional, defaults to ``AtomicType::kNone``) must be a legal
+ *   :enum:`AtomicType`; ``kAdd`` emits ``pto.tstore``'s ``atomicType`` attr,
+ *   the same combine mode ``tile.store`` already exposes.
  */
 
 #include <any>
@@ -52,55 +78,149 @@
 #include "pypto/core/logging.h"
 #include "pypto/ir/expr.h"
 #include "pypto/ir/kind_traits.h"
+#include "pypto/ir/memory_space.h"
 #include "pypto/ir/op_registry.h"
+#include "pypto/ir/scalar_expr.h"
+#include "pypto/ir/tile_view_semantics.h"
 #include "pypto/ir/type.h"
+#include "src/ir/op/distributed/comm_op_utils.h"
 
 namespace pypto {
 namespace ir {
 
 namespace {
 
-TypePtr DeduceRemoteStoreType(const std::vector<ExprPtr>& args,
-                              const std::vector<std::pair<std::string, std::any>>& /*kwargs*/) {
-  CHECK(args.size() == 4) << "pld.tile.remote_store requires 4 positional arguments "
-                             "(src_tile, target, peer, offsets), but got "
-                          << args.size();
-  for (size_t i = 0; i < args.size(); ++i) {
-    CHECK(args[i]) << "pld.tile.remote_store positional argument #" << i << " must not be null";
+// Reduce a source extent to the 2-D region the store actually writes.
+//
+// The deducer runs at authoring time, *before* FlattenTileNdTo2D (pass 13) has
+// collapsed N-D tiles, so a legal source may still carry leading dims here. Each
+// of those must describe a single element: flatten folds them into the row count
+// (rows = product of the leading dims), and codegen pads the peer partition view
+// with size-1 leading dims to match (see MakeRemoteStoreCodegenPTO). A leading
+// extent of 1 therefore survives the round trip unchanged and is accepted; a
+// static extent > 1 would be folded into the rows and overflow the target's
+// inner dims, so it is rejected here rather than emitting an out-of-bounds
+// partition view. A dynamic leading dim cannot be disproved statically and is
+// left to run.
+std::vector<ExprPtr> EffectivePushExtent(const std::vector<ExprPtr>& extent, const std::string& op_name) {
+  CHECK(extent.size() >= 2) << op_name
+                            << " src must be at least 2-D (it is pushed as a 2-D region), got rank "
+                            << extent.size();
+  for (size_t i = 0; i + 2 < extent.size(); ++i) {
+    auto dim = As<ConstInt>(extent[i]);
+    CHECK_SPAN(!dim || dim->value_ == 1, extent[i]->span_)
+        << op_name << " src leading dimension " << i << " must be 1 (only the inner two dims are pushed, "
+        << "and larger leading dims fold into the row extent and overrun the target), got " << dim->value_;
   }
+  return {extent.end() - 2, extent.end()};
+}
 
-  // src_tile must be a TileType.
-  auto tile_type = As<TileType>(args[0]->GetType());
-  CHECK(tile_type) << "pld.tile.remote_store src_tile must be a TileType, got "
-                   << args[0]->GetType()->TypeName();
-
+// The target / peer / offsets / dtype / bounds contract shared by the tile-level
+// and tensor-level forms. `push_extent` is the source extent: the tile's
+// effective valid_shape for the tile form, the source tensor's shape for the
+// tensor form; it is reduced to its inner 2-D region by EffectivePushExtent.
+// Returns nothing — every failure is a user error.
+void ValidateRemoteStoreContract(const std::vector<ExprPtr>& args, const std::vector<ExprPtr>& push_extent,
+                                 const DataType& src_dtype,
+                                 const std::vector<std::pair<std::string, std::any>>& kwargs,
+                                 const std::string& op_name) {
   // target must be a DistributedTensorType. As<DistributedTensorType> is an
   // exact ObjectKind match — a plain TensorType (e.g. a regular pl.Tensor
   // parameter) will not match here, which is exactly what we want.
   auto dist_type = As<DistributedTensorType>(args[1]->GetType());
-  CHECK(dist_type) << "pld.tile.remote_store target must be a DistributedTensor (window-bound), got "
+  CHECK(dist_type) << op_name << " target must be a DistributedTensor (window-bound), got "
                    << args[1]->GetType()->TypeName();
 
   // peer must be a scalar (integer rank index). Allow any ScalarType — dtype
   // narrowing to integer is handled at codegen time when emitting the
   // CommRemoteOffset scalar arithmetic.
   CHECK(IsA<ScalarType>(args[2]->GetType()))
-      << "pld.tile.remote_store peer must be a scalar (rank index), got " << args[2]->GetType()->TypeName();
+      << op_name << " peer must be a scalar (rank index), got " << args[2]->GetType()->TypeName();
 
   auto offsets_tuple = As<MakeTuple>(args[3]);
-  CHECK(offsets_tuple) << "pld.tile.remote_store offsets must be a tuple (MakeTuple of scalars), got "
+  CHECK(offsets_tuple) << op_name << " offsets must be a tuple (MakeTuple of scalars), got "
                        << args[3]->TypeName();
 
   const auto target_rank = dist_type->shape_.size();
   CHECK(offsets_tuple->elements_.size() == target_rank)
-      << "pld.tile.remote_store offsets rank (" << offsets_tuple->elements_.size()
+      << op_name << " offsets rank (" << offsets_tuple->elements_.size()
       << ") must match target tensor rank (" << target_rank << ")";
-  CHECK(target_rank > 0) << "pld.tile.remote_store requires at least one dimension on target";
 
-  // TPUT contract: src_tile dtype must match target dtype.
-  CHECK(tile_type->dtype_ == dist_type->dtype_)
-      << "pld.tile.remote_store src_tile dtype (" << tile_type->dtype_.ToString()
-      << ") must match target dtype (" << dist_type->dtype_.ToString() << ")";
+  // TSTORE contract: src dtype must match target dtype. Checked before the
+  // shape contract below so a dtype mismatch is reported as such rather than
+  // being masked by an unrelated rank complaint.
+  CHECK(src_dtype == dist_type->dtype_)
+      << op_name << " src dtype (" << src_dtype.ToString() << ") must match target dtype ("
+      << dist_type->dtype_.ToString() << ")";
+
+  // Codegen pushes the 2-D extent into the inner two dims of the peer slice,
+  // padding the leading (target_rank - 2) partition dims with 1s. Reject the
+  // shapes that have no lowering here, as a user error at the call site, rather
+  // than as an internal check deep in MakeRemoteStoreCodegenPTO.
+  auto effective_extent = EffectivePushExtent(push_extent, op_name);
+  CHECK(target_rank >= 2) << op_name << " target rank must be >= 2 to hold a 2-D push, got " << target_rank;
+
+  comm_op::ValidatePushFitsTarget(effective_extent, offsets_tuple->elements_, dist_type->shape_, op_name);
+
+  // `atomic` is optional here (unlike put, where it is always packed): the DSL
+  // omits the attr entirely for a plain store so existing printed IR round-trips
+  // byte-identically. Same accepted set as put / tile.store, and the same
+  // hardware dtype allow-list tile.store applies -- both emit `pto.tstore`'s
+  // atomicType, so a dtype the local store path rejects is equally unsupported
+  // cross-rank. src and target dtypes are equal by the check above.
+  const int atomic_value = GetKwargOr<int>(kwargs, "atomic", 0);
+  comm_op::ValidateAtomicValue(atomic_value, op_name);
+  comm_op::ValidateAtomicAddDtype(atomic_value, dist_type->dtype_, op_name);
+}
+
+void ValidateRemoteStoreArgs(const std::vector<ExprPtr>& args, const std::string& op_name) {
+  CHECK(args.size() == 4) << op_name
+                          << " requires 4 positional arguments (src, target, peer, offsets), but got "
+                          << args.size();
+  for (size_t i = 0; i < args.size(); ++i) {
+    CHECK(args[i]) << op_name << " positional argument #" << i << " must not be null";
+  }
+}
+
+TypePtr DeduceRemoteStoreType(const std::vector<ExprPtr>& args,
+                              const std::vector<std::pair<std::string, std::any>>& kwargs) {
+  ValidateRemoteStoreArgs(args, "pld.tile.remote_store");
+
+  // src_tile must be a TileType.
+  auto tile_type = As<TileType>(args[0]->GetType());
+  CHECK(tile_type) << "pld.tile.remote_store src_tile must be a TileType, got "
+                   << args[0]->GetType()->TypeName()
+                   << ". In a tensor-level kernel (@pl.jit) call pld.tensor.remote_store instead "
+                      "(pld.remote_store dispatches between the two).";
+
+  // Codegen sizes the peer partition view from the tile's *effective* view, so
+  // the bounds check has to use the same extent (a padded tile's physical shape
+  // is wider than what it actually writes).
+  const auto tile_view = tile_view_semantics::GetEffectiveTileView(*tile_type);
+  ValidateRemoteStoreContract(args, tile_view.valid_shape, tile_type->dtype_, kwargs,
+                              "pld.tile.remote_store");
+
+  // Side-effect-only — no SSA result for downstream consumers.
+  return GetUnknownType();
+}
+
+TypePtr DeduceTensorRemoteStoreType(const std::vector<ExprPtr>& args,
+                                    const std::vector<std::pair<std::string, std::any>>& kwargs) {
+  ValidateRemoteStoreArgs(args, "pld.tensor.remote_store");
+
+  // src is a tensor-level value: a computed value that ConvertTensorToTileOps
+  // will have rewritten to a tile by lowering time, or a GM tensor the same pass
+  // auto-bridges with a tile.load. As<TensorType> is an exact ObjectKind match,
+  // so a DistributedTensorType src is refused — pushing one window into another
+  // is pld.tensor.put's GM->GM job, not a tstore.
+  auto src_type = As<TensorType>(args[0]->GetType());
+  CHECK(src_type) << "pld.tensor.remote_store src must be a Tensor (tensor-level value), got "
+                  << args[0]->GetType()->TypeName()
+                  << ". In a tile-level kernel (@pl.jit.incore / @pl.program) call "
+                     "pld.tile.remote_store instead (pld.remote_store dispatches between the two); "
+                     "to push one window buffer into another, use pld.tensor.put.";
+
+  ValidateRemoteStoreContract(args, src_type->shape_, src_type->dtype_, kwargs, "pld.tensor.remote_store");
 
   // Side-effect-only — no SSA result for downstream consumers.
   return GetUnknownType();
@@ -115,16 +235,42 @@ TypePtr DeduceRemoteStoreType(const std::vector<ExprPtr>& args,
 REGISTER_OP("pld.tile.remote_store")
     .set_description(
         "Write a local tile into a region of the peer rank's slice of a window-bound "
-        "DistributedTensor. Mirrors tile.store at the IR level but the destination is a "
-        "remote slice — address translation is realised at codegen via "
-        "CommRemoteOffset(ctx, peer) + addptr + make_tensor_view.")
+        "DistributedTensor. Mirrors tile.store at the IR level (including the optional "
+        "`atomic` combine mode) but the destination is a remote slice — address translation "
+        "is realised at codegen via CommRemoteOffset(ctx, peer) + addptr + make_tensor_view.")
     .set_op_category("DistributedOp")
-    .add_argument("src_tile", "Local source tile (TileType, dtype must match target)")
+    .add_argument("src_tile", "Local source tile (2-D TileType, dtype must match target)")
     .add_argument("target", "Window-bound DistributedTensor destination (DistributedTensorType)")
     .add_argument("peer", "Peer rank index (ScalarType, integer)")
     .add_argument("offsets", "Offsets in target tensor coordinates (MakeTuple of scalars)")
-    .no_memory_spec()
+    .set_attr<int>("atomic")
+    // Same source spaces tile.store accepts: both lower to pto.tstore, so an Acc
+    // (fix-pipe) operand is as legal here as a Vec one. Declaring it lets
+    // InferTileMemorySpace pull a producer into a legal space instead of letting
+    // an illegal one reach codegen.
+    .set_input_memory(0, {MemorySpace::Vec, MemorySpace::Acc})
     .f_deduce_type(DeduceRemoteStoreType);
+
+// ============================================================================
+// pld.tensor.remote_store — tensor-level form, lowered 1:1 to the tile form
+// ============================================================================
+
+REGISTER_OP("pld.tensor.remote_store")
+    .set_description(
+        "Tensor-level cross-rank push: write a local tensor-level value into a region of the "
+        "peer rank's slice of a window-bound DistributedTensor. Lowered 1:1 by "
+        "ConvertTensorToTileOps to pld.tile.remote_store (mirroring tensor.aiv_shard -> "
+        "tile.aiv_shard); a src still resident in GM at that point is auto-bridged with a "
+        "natural tile.load into Vec. Use pld.tensor.put instead for a GM->GM bulk transfer "
+        "that needs TPUT's chunking / pipelining / window-to-window staging.")
+    .set_op_category("DistributedOp")
+    .add_argument("src", "Local source value (2-D TensorType, dtype must match target)")
+    .add_argument("target", "Window-bound DistributedTensor destination (DistributedTensorType)")
+    .add_argument("peer", "Peer rank index (ScalarType, integer)")
+    .add_argument("offsets", "Offsets in target tensor coordinates (MakeTuple of scalars)")
+    .set_attr<int>("atomic")
+    .no_memory_spec()
+    .f_deduce_type(DeduceTensorRemoteStoreType);
 
 }  // namespace ir
 }  // namespace pypto

--- a/src/ir/transforms/op_conversion_registry.cpp
+++ b/src/ir/transforms/op_conversion_registry.cpp
@@ -2504,6 +2504,20 @@ std::vector<std::pair<std::string, std::any>> StripChunkKwargs(
 }  // namespace
 
 void OpConversionRegistry::RegisterDistributedOps() {
+  // pld.tensor.remote_store -> pld.tile.remote_store, 1:1 (the same shape as
+  // tensor.aiv_shard -> tile.aiv_shard: one op, two IR levels, identical
+  // argument surface, so no argument can be silently dropped by the lowering).
+  //
+  // The InputSpaceReq is what makes the op total on its src. BridgeInputSpaces
+  // only rewrites TensorType operands, so:
+  //   - a computed value has already been lowered to a tile by its producer
+  //     earlier in this pass and passes straight through, keeping whatever space
+  //     it computed in (Vec or Acc — both are legal pto.tstore sources);
+  //   - a src still resident in GM is auto-bridged with a natural tile.load into
+  //     Vec, and a tensor.slice producer is loaded directly into Vec by the
+  //     consumer-driven path.
+  RegisterSimple("pld.tensor.remote_store", "pld.tile.remote_store", {{0, {MemorySpace::Vec, std::nullopt}}});
+
   // pld.tensor.put -> tile.create(stage) + pld.tile.put(dst, peer, src, stage).
   // Stage shape is [rows, cols] with rows = product(leading dims), cols =
   // innermost dim: the 2-D-flattened transfer extent codegen previously
@@ -2524,6 +2538,20 @@ void OpConversionRegistry::RegisterDistributedOps() {
         INTERNAL_CHECK_SPAN(dst_type, span)
             << "pld.tensor.put conversion: dst must be DistributedTensorType, got "
             << args[0]->GetType()->TypeName();
+
+        // A tile-typed src means the author pushed a *computed* value: its
+        // producer lowered to a tile earlier in this pass. TPUT needs two GM
+        // descriptors (the staging tile it takes is its own bounce buffer, not a
+        // data source), so there is no lowering here. Reject at the op the author
+        // actually wrote — deferring to pld.tile.put's deducer produces
+        // "pld.tile.put src must be a Tensor..." naming an internal op, and the
+        // put-only args below (atomic, chunking, src_offsets) would be silently
+        // dropped by any tile-level fallback.
+        CHECK_SPAN(!As<TileType>(args[2]->GetType()), span)
+            << "pld.tensor.put src must be a GM tensor, but got a computed value that lowers to a "
+               "tile: TPUT transfers between two GM regions, and a UB tile has no GM address. "
+               "Use pld.tensor.remote_store(src, target, peer, offsets) to push a computed value "
+               "straight to a peer (pld.remote_store dispatches to it automatically).";
         std::vector<ExprPtr> transfer_shape = dst_type->shape_;
         if (args.size() == 6) {
           auto shape_tuple_arg = As<MakeTuple>(args[5]);

--- a/tests/st/distributed/test_l3_remote_store.py
+++ b/tests/st/distributed/test_l3_remote_store.py
@@ -7,7 +7,7 @@
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
 
-"""L3 distributed st: ``pld.tile.remote_store`` cross-rank subview write.
+"""L3 distributed st: ``remote_store`` cross-rank writes, tile and tensor level.
 
 Subview-aware push dual of :func:`pld.tile.remote_load`. Where ``remote_load``
 reads a region of a peer's tensor into a local tile, ``remote_store`` writes a
@@ -209,8 +209,90 @@ def _build_subview_remote_store_program():
     return SubviewRemoteStore
 
 
+def _build_tensor_remote_store_program():
+    """Push a *computed* tensor-level value straight to the peer (issue #2349).
+
+    The body is tensor-level: ``scaled`` is produced by ``pl.tensor.add`` and
+    lives on-core, so ``ConvertTensorToTileOps`` lowers the push 1:1 to
+    ``pld.tile.remote_store``. There is no global-memory round-trip between the
+    compute and the push — which is the point: staging through GM and pushing
+    from there leaves the store and the transfer on different pipes with nothing
+    ordering them.
+
+    Same ring protocol as :func:`_build_ring_remote_store_program`, so the golden
+    is the partner's input doubled.
+    """
+
+    @pl.program
+    class TensorRemoteStore:
+        @pl.function(type=pl.FunctionType.InCore)
+        def scale_push_step(
+            self,
+            inp: pl.Tensor[[1, SIZE], pl.FP32],
+            out: pl.Out[pl.Tensor[[1, SIZE], pl.FP32]],
+            dst: pld.DistributedTensor[[1, SIZE], pl.FP32],
+            signal: pld.DistributedTensor[[1, 1], pl.INT32],
+            peer: pl.Scalar[pl.INT32],
+        ) -> pl.Tensor[[1, SIZE], pl.FP32]:
+            # Phase 1: compute, then push the computed value directly.
+            scaled = pl.tensor.add(inp, inp)
+            pld.tensor.remote_store(scaled, dst, peer, [0, 0])
+
+            # Phase 2: same notify/wait handshake as the tile-level ring.
+            pld.system.notify(
+                target=signal,
+                peer=peer,
+                offsets=[0, 0],
+                value=1,
+                op=pld.NotifyOp.AtomicAdd,
+            )
+            pld.system.wait(
+                signal=signal,
+                offsets=[0, 0],
+                expected=1,
+                cmp=pld.WaitCmp.Ge,
+            )
+
+            # Phase 3: read back what our own peer pushed into us.
+            recv = pl.load(dst, [0, 0], [1, SIZE])
+            return pl.store(recv, [0, 0], out)
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def chip_orch(
+            self,
+            inp: pl.Tensor[[1, SIZE], pl.FP32],
+            out: pl.Out[pl.Tensor[[1, SIZE], pl.FP32]],
+            dst: pld.DistributedTensor[[1, SIZE], pl.FP32],
+            signal: pld.DistributedTensor[[1, 1], pl.INT32],
+            peer: pl.Scalar[pl.INT32],
+        ) -> pl.Tensor[[1, SIZE], pl.FP32]:
+            return self.scale_push_step(inp, out, dst, signal, peer)
+
+        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+        def host_orch(
+            self,
+            inputs: pl.Tensor[[2, 1, SIZE], pl.FP32],
+            outputs: pl.Out[pl.Tensor[[2, 1, SIZE], pl.FP32]],
+        ) -> pl.Tensor[[2, 1, SIZE], pl.FP32]:
+            dst_buf = pld.alloc_window_buffer(SIZE * pl.FP32.get_byte())
+            signal_buf = pld.alloc_window_buffer(pl.INT32.get_byte())
+
+            for r in pl.range(pld.world_size()):
+                dst = pld.window(dst_buf, [1, SIZE], dtype=pl.FP32)
+                signal = pld.window(signal_buf, [1, 1], dtype=pl.INT32)
+                self.chip_orch(inputs[r], outputs[r], dst, signal, (r + 1) % pld.world_size(), device=r)
+            return outputs
+
+    return TensorRemoteStore
+
+
 class TestL3RemoteStore:
-    """L3 distributed runtime: cross-rank subview write via pld.tile.remote_store."""
+    """L3 distributed runtime: cross-rank writes via both remote_store forms.
+
+    ``pld.tile.remote_store`` for the tile-level whole-tile and subview pushes,
+    and ``pld.tensor.remote_store`` for the tensor-level push of a computed
+    value.
+    """
 
     def test_ring_shuffle(self, test_config, device_ids):
         """Non-atomic overwrite: rank r pushes its input to peer (r + 1) % nranks."""
@@ -284,6 +366,43 @@ class TestL3RemoteStore:
         expected = torch.stack([expected_0, expected_1])
         assert torch.allclose(outputs, expected), (
             f"subview remote_store mismatch: max diff = {(outputs - expected).abs().max().item()}"
+        )
+
+    def test_tensor_level_push_of_computed_value(self, test_config, device_ids):
+        """Tensor-level push: rank r computes ``inp * 2`` and pushes it to its peer.
+
+        Regression cover for issue #2349 — before ``pld.tensor.remote_store``
+        existed, a computed value could not be pushed at all: ``pld.tensor.put``
+        refused the tile it lowers to and ``pld.tile.remote_store`` refused the
+        tensor-level value it starts as.
+        """
+        if len(device_ids) < 2:
+            pytest.skip(f"tensor-level remote_store needs 2 devices, got {device_ids}")
+
+        program = _build_tensor_remote_store_program()
+        compiled = ir.compile(
+            program,
+            platform=test_config.platform,
+            distributed_config=DistributedConfig(
+                device_ids=device_ids[:2],
+                num_sub_workers=0,
+            ),
+        )
+
+        inputs = torch.stack(
+            [
+                torch.arange(SIZE, dtype=torch.float32).reshape(1, SIZE),
+                torch.arange(100.0, 100.0 + SIZE, dtype=torch.float32).reshape(1, SIZE),
+            ]
+        )
+        outputs = torch.zeros((2, 1, SIZE), dtype=torch.float32)
+
+        compiled(inputs, outputs)
+
+        # outputs[r] = 2 * inputs[(r - 1) % nranks]
+        expected = torch.stack([inputs[1], inputs[0]]) * 2
+        assert torch.allclose(outputs, expected), (
+            f"tensor-level remote_store mismatch: max diff = {(outputs - expected).abs().max().item()}"
         )
 
 

--- a/tests/ut/codegen/distributed/test_distributed_pto_codegen.py
+++ b/tests/ut/codegen/distributed/test_distributed_pto_codegen.py
@@ -555,6 +555,107 @@ def test_remote_store_emits_tstore_with_partition_view_pattern():
     assert "pto.make_tensor_view" in kernel, kernel
 
 
+def test_remote_store_accepts_nd_tile_with_unit_leading_dims():
+    """A `[1, H, W]` tile pushed into a `[1, H, W]` window lowers end-to-end.
+
+    The deducer's push contract runs at authoring time, before FlattenTileNdTo2D
+    collapses N-D tiles, so it has to admit leading unit dims — rejecting rank > 2
+    outright would refuse a program that compiles to a correct 3-D partition view.
+    """
+
+    @pl.program
+    class P:
+        @pl.function(type=pl.FunctionType.InCore)
+        def kernel(
+            self,
+            inp: pl.Tensor[[1, 16, 32], pl.FP16],
+            data: pld.DistributedTensor[[1, 16, 32], pl.FP16],
+            peer: pl.Scalar[pl.INT32],
+        ):
+            tile = pl.load(inp, [0, 0, 0], [1, 16, 32])
+            pld.tile.remote_store(tile, target=data, peer=peer, offsets=[0, 0, 0])
+
+    kernel = _split_module(_generate_mlir(P))["kernel"]
+    assert "pto.tstore" in kernel, kernel
+    assert "!pto.partition_tensor_view<1x16x32xf16>" in kernel, kernel
+    assert "_peer_pview" in kernel, kernel
+
+
+def test_remote_store_emits_atomic_add_attr():
+    """``atomic=AtomicType.Add`` makes the cross-rank push a combine.
+
+    Same ``atomicType`` attr ``tile.store`` already emits for split-K
+    accumulation — this is what an all-to-all combine needs to sum every peer's
+    contribution in place instead of overwriting it.
+    """
+
+    @pl.program
+    class P:
+        @pl.function(type=pl.FunctionType.InCore)
+        def kernel(
+            self,
+            data: pld.DistributedTensor[[16, 64], pl.FP16],
+            peer: pl.Scalar[pl.INT32],
+        ):
+            tile = pld.tile.remote_load(data, peer=peer, offsets=[0, 0], shape=[16, 32])
+            pld.tile.remote_store(tile, target=data, peer=peer, offsets=[0, 0], atomic=pld.AtomicType.Add)
+
+    kernel = _split_module(_generate_mlir(P))["kernel"]
+    assert "pto.tstore" in kernel, kernel
+    assert "{atomicType = #pto<atomic_type atomic_add>}" in kernel, kernel
+
+
+def test_remote_store_omits_atomic_attr_for_plain_store():
+    """A plain push emits no atomicType attr — non-atomic codegen is unchanged."""
+
+    @pl.program
+    class P:
+        @pl.function(type=pl.FunctionType.InCore)
+        def kernel(
+            self,
+            data: pld.DistributedTensor[[16, 64], pl.FP16],
+            peer: pl.Scalar[pl.INT32],
+        ):
+            tile = pld.tile.remote_load(data, peer=peer, offsets=[0, 0], shape=[16, 32])
+            pld.tile.remote_store(tile, target=data, peer=peer, offsets=[0, 0])
+
+    kernel = _split_module(_generate_mlir(P))["kernel"]
+    assert "pto.tstore" in kernel, kernel
+    assert "atomicType" not in kernel, kernel
+
+
+def test_tensor_remote_store_of_computed_value_emits_tstore_without_tput():
+    """A computed value pushed with ``pld.tensor.remote_store`` reaches the peer
+    as a single ``pto.tstore`` — no TPUT, no staging tile, no GM round-trip.
+
+    This is the end-to-end shape issue #2349 asked for: before it, the value was
+    rejected from both directions and the only way to push it was to store it
+    back to global memory and TPUT from there.
+    """
+
+    @pl.program
+    class P:
+        @pl.function(type=pl.FunctionType.InCore)
+        def kernel(
+            self,
+            x: pl.Tensor[[16, 64], pl.FP16],
+            data: pld.DistributedTensor[[16, 64], pl.FP16],
+            peer: pl.Scalar[pl.INT32],
+        ):
+            scaled = pl.tensor.add(x, x)
+            pld.tensor.remote_store(scaled, data, peer, [0, 0])
+
+    kernel = _split_module(_generate_mlir(P))["kernel"]
+    assert "pto.tstore" in kernel, kernel
+    assert "_peer_pview" in kernel, kernel
+    assert "func.call @CommRemoteOffset_f16" in kernel, kernel
+    # The push is a direct tstore of the computed tile: no TPUT bounce buffer.
+    assert "pto.comm.tput" not in kernel, kernel
+    # ...and the vector add's result feeds it directly rather than being spilled
+    # to global memory first.
+    assert "pto.vadd" in kernel or "pto.add" in kernel, kernel
+
+
 def test_remote_store_pads_partition_view_with_ones_for_3d_target():
     """For an N-D (N > 2) target, the partition_view rank matches the target
     rank — leading dims are size-1 (matching notify's one_dims(rank, "1")

--- a/tests/ut/ir/parser/test_remote_store.py
+++ b/tests/ut/ir/parser/test_remote_store.py
@@ -8,17 +8,22 @@
 # -----------------------------------------------------------------------------------------------------------
 # ruff: noqa: F722, F821
 
-"""Parser tests for ``pld.tile.remote_store``.
+"""Parser tests for ``pld.tile.remote_store`` / ``pld.tensor.remote_store``.
 
-``pld.tile.remote_store(src_tile, target=..., peer=..., offsets=[...])`` is the
-cross-rank tile store: it writes a local tile into a sub-region of the peer
-rank's window-bound distributed tensor. The op is side-effect-only (no SSA
-result for downstream consumers).
+``remote_store(src, target=..., peer=..., offsets=[...])`` is the cross-rank
+store: it writes a local value into a sub-region of the peer rank's window-bound
+distributed tensor. The op is side-effect-only (no SSA result for downstream
+consumers).
+
+It exists at both IR levels — ``pld.tile.remote_store`` for a tile-level kernel
+and ``pld.tensor.remote_store`` for a tensor-level one (lowered 1:1 by
+ConvertTensorToTileOps) — with the short form ``pld.remote_store`` dispatching
+between them on the kind of ``src``.
 
 The parser dispatches via the generic 3-segment ``pld.<category>.<op>`` path
-(``ast_parser.py:_parse_pld_category_op``); these tests cover both the
-positive DSL→IR lifting and the parser-level rejection of malformed call
-sites.
+(``ast_parser.py:_parse_pld_category_op``) and the 2-segment short form; these
+tests cover both the positive DSL→IR lifting and the parser-level rejection of
+malformed call sites.
 """
 
 import pypto.language as pl
@@ -141,9 +146,173 @@ def test_remote_store_round_trips_through_printer():
     assert after_call.op.name == ir.get_op("pld.tile.remote_store").name
 
 
+def test_remote_store_atomic_round_trips_through_printer():
+    """The ``atomic`` attr survives print → parse → print.
+
+    A plain store prints without the attr at all (so existing IR is unchanged);
+    an atomic-add store carries it explicitly.
+    """
+
+    @pl.program
+    class Before:
+        @pl.function
+        def kernel(
+            self,
+            data: pld.DistributedTensor[[64, 32], pl.FP16],
+            peer: pl.Scalar[pl.INT32],
+        ):
+            tile = pld.tile.remote_load(data, peer=peer, offsets=[0, 0], shape=[32, 16])
+            pld.tile.remote_store(tile, target=data, peer=peer, offsets=[0, 0], atomic=pld.AtomicType.Add)
+
+    text1 = ir.python_print(Before)
+    After = pl.parse_program(text1)
+    text2 = ir.python_print(After)
+    assert text1 == text2, f"round-trip mismatch:\n--- before:\n{text1}\n--- after:\n{text2}"
+    after_call = _find_call(_get_func(After, "kernel"), "pld.tile.remote_store")
+    assert after_call.kwargs["atomic"] == int(pld.AtomicType.Add)
+
+
+# ---------------------------------------------------------------------------
+# Positive: the tensor-level twin, pld.tensor.remote_store (issue #2349)
+# ---------------------------------------------------------------------------
+
+
+def test_tensor_remote_store_lifts_to_op_call():
+    """``pld.tensor.remote_store`` lifts to its own op with the same four args."""
+
+    @pl.program
+    class P:
+        @pl.function
+        def kernel(
+            self,
+            x: pl.Tensor[[16, 8], pl.FP16],
+            data: pld.DistributedTensor[[64, 32], pl.FP16],
+            peer: pl.Scalar[pl.INT32],
+        ):
+            pld.tensor.remote_store(x, data, peer, [0, 0])
+
+    call = _find_call(_get_func(P, "kernel"), "pld.tensor.remote_store")
+    assert isinstance(call.type, ir.UnknownType)
+    assert call.kwargs == {}
+    assert len(call.args) == 4
+    src_arg, target_arg, peer_arg, offsets_arg = call.args
+    assert isinstance(src_arg.type, ir.TensorType)
+    assert isinstance(target_arg, ir.Var)
+    assert isinstance(target_arg.type, ir.DistributedTensorType)
+    assert isinstance(peer_arg, ir.Var)
+    assert isinstance(peer_arg.type, ir.ScalarType)
+    assert isinstance(offsets_arg, ir.MakeTuple)
+
+
+def test_tensor_remote_store_round_trips_through_printer():
+    """print → parse → print is stable for the tensor-level form."""
+
+    @pl.program
+    class Before:
+        @pl.function
+        def kernel(
+            self,
+            x: pl.Tensor[[16, 8], pl.FP16],
+            data: pld.DistributedTensor[[64, 32], pl.FP16],
+            peer: pl.Scalar[pl.INT32],
+        ):
+            pld.tensor.remote_store(x, data, peer, [0, 0])
+
+    text1 = ir.python_print(Before)
+    After = pl.parse_program(text1)
+    text2 = ir.python_print(After)
+    assert text1 == text2, f"round-trip mismatch:\n--- before:\n{text1}\n--- after:\n{text2}"
+    after_call = _find_call(_get_func(After, "kernel"), "pld.tensor.remote_store")
+    assert after_call.op.name == ir.get_op("pld.tensor.remote_store").name
+
+
+def test_tensor_remote_store_atomic_round_trips_through_printer():
+    """The tensor form's ``atomic`` attr survives print → parse → print too."""
+
+    @pl.program
+    class Before:
+        @pl.function
+        def kernel(
+            self,
+            x: pl.Tensor[[16, 8], pl.FP16],
+            data: pld.DistributedTensor[[64, 32], pl.FP16],
+            peer: pl.Scalar[pl.INT32],
+        ):
+            pld.tensor.remote_store(x, data, peer, [0, 0], atomic=pld.AtomicType.Add)
+
+    text1 = ir.python_print(Before)
+    After = pl.parse_program(text1)
+    text2 = ir.python_print(After)
+    assert text1 == text2, f"round-trip mismatch:\n--- before:\n{text1}\n--- after:\n{text2}"
+    after_call = _find_call(_get_func(After, "kernel"), "pld.tensor.remote_store")
+    assert after_call.kwargs["atomic"] == int(pld.AtomicType.Add)
+
+
+def test_short_form_remote_store_dispatches_on_operand_level():
+    """``pld.remote_store`` picks the tile or tensor op from its src operand.
+
+    Both spellings are written the same way; only the level of ``src`` differs.
+    """
+
+    @pl.program
+    class P:
+        @pl.function
+        def tile_level(
+            self,
+            data: pld.DistributedTensor[[64, 32], pl.FP16],
+            peer: pl.Scalar[pl.INT32],
+        ):
+            tile = pld.tile.remote_load(data, peer=peer, offsets=[0, 0], shape=[32, 16])
+            pld.remote_store(tile, data, peer, [0, 0])
+
+        @pl.function
+        def tensor_level(
+            self,
+            x: pl.Tensor[[16, 8], pl.FP16],
+            data: pld.DistributedTensor[[64, 32], pl.FP16],
+            peer: pl.Scalar[pl.INT32],
+        ):
+            pld.remote_store(x, data, peer, [0, 0])
+
+    assert _find_call(_get_func(P, "tile_level"), "pld.tile.remote_store") is not None
+    assert _find_call(_get_func(P, "tensor_level"), "pld.tensor.remote_store") is not None
+
+
 # ---------------------------------------------------------------------------
 # Negative: shape / target / offsets mistakes surface at parse or verify time
 # ---------------------------------------------------------------------------
+
+
+def test_tensor_remote_store_rejects_tile_src():
+    """A tile operand in a tensor-level call names the tile-level entry point."""
+    with pytest.raises(InvalidOperationError, match=r"pld\.tile\.remote_store"):
+
+        @pl.program
+        class P:  # noqa: F841
+            @pl.function
+            def kernel(
+                self,
+                data: pld.DistributedTensor[[64, 32], pl.FP16],
+                peer: pl.Scalar[pl.INT32],
+            ):
+                tile = pld.tile.remote_load(data, peer=peer, offsets=[0, 0], shape=[32, 16])
+                pld.tensor.remote_store(tile, data, peer, [0, 0])  # type: ignore[arg-type]
+
+
+def test_tensor_remote_store_rejects_out_of_bounds_push():
+    """The pushed region must fit inside the peer's slice at ``offsets``."""
+    with pytest.raises(InvalidOperationError, match="push exceeds the peer's target region"):
+
+        @pl.program
+        class P:  # noqa: F841
+            @pl.function
+            def kernel(
+                self,
+                x: pl.Tensor[[16, 8], pl.FP16],
+                data: pld.DistributedTensor[[64, 32], pl.FP16],
+                peer: pl.Scalar[pl.INT32],
+            ):
+                pld.tensor.remote_store(x, data, peer, [56, 0])
 
 
 def test_remote_store_rejects_plain_tensor_target():

--- a/tests/ut/ir/test_distributed_ops.py
+++ b/tests/ut/ir/test_distributed_ops.py
@@ -30,6 +30,7 @@ from pypto import DataType, ir
 from pypto.ir.op.distributed import tensor_ops as dist_tensor_ops
 from pypto.ir.op.distributed import tile_ops as dist_tile_ops
 from pypto.language.distributed.op import tensor_ops as dsl_tensor_ops
+from pypto.language.distributed.op import unified_ops as dsl_unified
 from pypto.language.distributed.op.tensor_ops import _validate_chunk, _validate_pipeline
 from pypto.language.distributed.typing.distributed_tensor import DistributedTensor
 
@@ -879,6 +880,339 @@ def test_remote_store_rejects_extra_positional():
             {},
             span,
         )
+
+
+def test_remote_store_rejects_leading_dim_over_one():
+    """Negative: only the inner two dims are pushed, so a leading extent > 1 has
+    no lowering — FlattenTileNdTo2D would fold it into the row count and overrun
+    the target's inner dims.
+
+    Previously this reached codegen and emitted an out-of-bounds partition view.
+    """
+    span = ir.Span.unknown()
+    tile_var = ir.Var("t", ir.TileType([2, 32, 16], DataType.FP32), span)
+    target = _make_distributed_tensor_var("data", [2, 64, 32], DataType.FP32, span)
+    peer = ir.Var("peer", ir.ScalarType(DataType.INT32), span)
+    offsets = _make_shape_tuple([0, 0, 0], span)
+
+    with pytest.raises(ValueError, match="src leading dimension 0 must be 1"):
+        ir.create_op_call("pld.tile.remote_store", [tile_var, target, peer, offsets], {}, span)
+
+
+def test_remote_store_accepts_nd_tile_with_unit_leading_dims():
+    """Positive: an N-D tile whose leading dims are all 1 is still 2-D worth of data.
+
+    The deducer runs *before* FlattenTileNdTo2D (pass 13) collapses N-D tiles, so
+    rejecting rank > 2 outright would break the `[1, H, W]` tile → `[1, H, W]`
+    window push, which lowers correctly (codegen pads the peer partition view with
+    the same size-1 leading dims).
+    """
+    span = ir.Span.unknown()
+    tile_var = ir.Var("t", ir.TileType([1, 16, 32], DataType.FP16), span)
+    target = _make_distributed_tensor_var("data", [1, 16, 32], DataType.FP16, span)
+    peer = ir.Var("peer", ir.ScalarType(DataType.INT32), span)
+    offsets = _make_shape_tuple([0, 0, 0], span)
+
+    call = ir.create_op_call("pld.tile.remote_store", [tile_var, target, peer, offsets], {}, span)
+    assert isinstance(call.type, ir.UnknownType)
+
+
+def test_remote_store_bounds_check_uses_inner_dims_of_nd_source():
+    """The bounds check reads the *inner two* dims of an N-D source, not its rank-0 dim."""
+    span = ir.Span.unknown()
+    tile_var = ir.Var("t", ir.TileType([1, 16, 32], DataType.FP16), span)
+    target = _make_distributed_tensor_var("data", [1, 16, 32], DataType.FP16, span)
+    peer = ir.Var("peer", ir.ScalarType(DataType.INT32), span)
+
+    with pytest.raises(ValueError, match="push exceeds the peer's target region in dimension 2"):
+        ir.create_op_call(
+            "pld.tile.remote_store",
+            [tile_var, target, peer, _make_shape_tuple([0, 0, 8], span)],
+            {},
+            span,
+        )
+
+
+def test_remote_store_rejects_rank1_source():
+    """Negative: a source below 2-D has no 2-D region to push."""
+    span = ir.Span.unknown()
+    tile_var = ir.Var("t", ir.TileType([32], DataType.FP32), span)
+    target = _make_distributed_tensor_var("data", [64, 32], DataType.FP32, span)
+    peer = ir.Var("peer", ir.ScalarType(DataType.INT32), span)
+    offsets = _make_shape_tuple([0, 0], span)
+
+    with pytest.raises(ValueError, match="src must be at least 2-D"):
+        ir.create_op_call("pld.tile.remote_store", [tile_var, target, peer, offsets], {}, span)
+
+
+def test_remote_store_rejects_rank1_target():
+    """Negative: a 2-D push needs at least 2 target dims to land in."""
+    span = ir.Span.unknown()
+    tile_var = ir.Var("t", ir.TileType([1, 16], DataType.FP32), span)
+    target = _make_distributed_tensor_var("data", [64], DataType.FP32, span)
+    peer = ir.Var("peer", ir.ScalarType(DataType.INT32), span)
+    offsets = _make_shape_tuple([0], span)
+
+    with pytest.raises(ValueError, match="target rank must be >= 2"):
+        ir.create_op_call("pld.tile.remote_store", [tile_var, target, peer, offsets], {}, span)
+
+
+def test_remote_store_rejects_out_of_bounds_push():
+    """Negative: the tile must fit inside the target at ``offsets``.
+
+    remote_store carries no transfer shape of its own, so without this check an
+    oversized push silently overwrites the peer's neighbouring region. Mirrors
+    the bounds check remote_load already performs.
+    """
+    span = ir.Span.unknown()
+    tile_var = ir.Var("t", ir.TileType([32, 16], DataType.FP32), span)
+    target = _make_distributed_tensor_var("data", [64, 32], DataType.FP32, span)
+    peer = ir.Var("peer", ir.ScalarType(DataType.INT32), span)
+    offsets = _make_shape_tuple([40, 0], span)  # 40 + 32 > 64
+
+    with pytest.raises(ValueError, match="push exceeds the peer's target region in dimension 0"):
+        ir.create_op_call("pld.tile.remote_store", [tile_var, target, peer, offsets], {}, span)
+
+
+def test_remote_store_bounds_check_uses_leading_unit_dims_for_nd_target():
+    """An N-D (N > 2) target carries one element per leading dim, matching the
+    size-1 partition dims codegen pads with — so a leading offset at the edge
+    is in bounds while one past it is not."""
+    span = ir.Span.unknown()
+    tile_var = ir.Var("t", ir.TileType([16, 32], DataType.FP32), span)
+    target = _make_distributed_tensor_var("data", [4, 16, 32], DataType.FP32, span)
+    peer = ir.Var("peer", ir.ScalarType(DataType.INT32), span)
+
+    ok = ir.create_op_call(
+        "pld.tile.remote_store",
+        [tile_var, target, peer, _make_shape_tuple([3, 0, 0], span)],
+        {},
+        span,
+    )
+    assert isinstance(ok.type, ir.UnknownType)
+
+    with pytest.raises(ValueError, match="dimension 0"):
+        ir.create_op_call(
+            "pld.tile.remote_store",
+            [tile_var, target, peer, _make_shape_tuple([4, 0, 0], span)],
+            {},
+            span,
+        )
+
+
+def test_remote_store_skips_bounds_check_for_dynamic_offset():
+    """A runtime offset cannot be compared statically — it is bounded at runtime."""
+    span = ir.Span.unknown()
+    tile_var = ir.Var("t", ir.TileType([32, 16], DataType.FP32), span)
+    target = _make_distributed_tensor_var("data", [64, 32], DataType.FP32, span)
+    peer = ir.Var("peer", ir.ScalarType(DataType.INT32), span)
+    dyn = ir.Var("row", ir.ScalarType(DataType.INT32), span)
+    offsets = ir.MakeTuple([dyn, ir.ConstInt(0, DataType.INT64, span)], span)
+
+    call = ir.create_op_call("pld.tile.remote_store", [tile_var, target, peer, offsets], {}, span)
+    assert isinstance(call.type, ir.UnknownType)
+
+
+def test_remote_store_accepts_atomic_add():
+    """The cross-rank push exposes tile.store's atomic-add combine mode."""
+    span = ir.Span.unknown()
+    tile_var = ir.Var("t", ir.TileType([32, 16], DataType.FP32), span)
+    target = _make_distributed_tensor_var("data", [64, 32], DataType.FP32, span)
+    peer = ir.Var("peer", ir.ScalarType(DataType.INT32), span)
+    offsets = _make_shape_tuple([0, 0], span)
+
+    call = ir.create_op_call(
+        "pld.tile.remote_store",
+        [tile_var, target, peer, offsets],
+        {"atomic": int(ir.AtomicType.Add)},
+        span,
+    )
+    assert isinstance(call.type, ir.UnknownType)
+
+
+def test_remote_store_rejects_atomic_add_on_unsupported_dtype():
+    """Negative: atomic-add is limited to the dtypes the hardware can combine.
+
+    Same allow-list ``tile.store`` enforces -- both lower to ``pto.tstore``'s
+    ``atomicType``, so a dtype the local store path rejects is equally
+    unsupported cross-rank. Without this the enum check passed and codegen
+    emitted atomic_add for a dtype the hardware cannot combine.
+    """
+    span = ir.Span.unknown()
+    tile_var = ir.Var("t", ir.TileType([32, 16], DataType.UINT8), span)
+    target = _make_distributed_tensor_var("data", [64, 32], DataType.UINT8, span)
+    peer = ir.Var("peer", ir.ScalarType(DataType.INT32), span)
+    offsets = _make_shape_tuple([0, 0], span)
+
+    with pytest.raises(ValueError, match="requires an fp32/bf16/fp16/int32/int16/int8 dtype"):
+        ir.create_op_call(
+            "pld.tile.remote_store",
+            [tile_var, target, peer, offsets],
+            {"atomic": int(ir.AtomicType.Add)},
+            span,
+        )
+
+    # The same dtype is fine for a plain (non-atomic) push.
+    plain = ir.create_op_call("pld.tile.remote_store", [tile_var, target, peer, offsets], {}, span)
+    assert isinstance(plain.type, ir.UnknownType)
+
+
+def test_tensor_remote_store_rejects_atomic_add_on_unsupported_dtype():
+    """The tensor-level form shares the same atomic-add dtype contract."""
+    span = ir.Span.unknown()
+    src = _make_tensor_var("x", [32, 16], DataType.UINT8, span)
+    target = _make_distributed_tensor_var("data", [64, 32], DataType.UINT8, span)
+    peer = ir.Var("peer", ir.ScalarType(DataType.INT32), span)
+    offsets = _make_shape_tuple([0, 0], span)
+
+    with pytest.raises(ValueError, match="requires an fp32/bf16/fp16/int32/int16/int8 dtype"):
+        ir.create_op_call(
+            "pld.tensor.remote_store",
+            [src, target, peer, offsets],
+            {"atomic": int(ir.AtomicType.Add)},
+            span,
+        )
+
+
+def test_remote_store_rejects_unknown_atomic_value():
+    """Negative: only AtomicType.None_ / AtomicType.Add are legal."""
+    span = ir.Span.unknown()
+    tile_var = ir.Var("t", ir.TileType([32, 16], DataType.FP32), span)
+    target = _make_distributed_tensor_var("data", [64, 32], DataType.FP32, span)
+    peer = ir.Var("peer", ir.ScalarType(DataType.INT32), span)
+    offsets = _make_shape_tuple([0, 0], span)
+
+    with pytest.raises(ValueError, match="atomic must be"):
+        ir.create_op_call("pld.tile.remote_store", [tile_var, target, peer, offsets], {"atomic": 7}, span)
+
+
+# ---------------------------------------------------------------------------
+# pld.tensor.remote_store op — tensor-level twin (issue #2349)
+# ---------------------------------------------------------------------------
+
+
+def _make_tensor_var(name: str, shape: list[int], dtype: DataType, span: ir.Span) -> ir.Var:
+    shape_exprs: list[ir.Expr] = [ir.ConstInt(v, DataType.INT64, span) for v in shape]
+    return ir.Var(name, ir.TensorType(shape_exprs, dtype), span)
+
+
+def test_tensor_remote_store_returns_unknown_type():
+    """Positive: the tensor-level form is side-effect-only, like the tile form."""
+    span = ir.Span.unknown()
+    src = _make_tensor_var("x", [32, 16], DataType.FP16, span)
+    target = _make_distributed_tensor_var("data", [64, 32], DataType.FP16, span)
+    peer = ir.Var("peer", ir.ScalarType(DataType.INT32), span)
+    offsets = _make_shape_tuple([0, 0], span)
+
+    call = ir.create_op_call("pld.tensor.remote_store", [src, target, peer, offsets], {}, span)
+    assert isinstance(call.type, ir.UnknownType)
+
+
+def test_tensor_remote_store_rejects_tile_src_and_names_the_tile_form():
+    """Negative: a tile operand belongs to pld.tile.remote_store — say so."""
+    span = ir.Span.unknown()
+    tile_var = ir.Var("t", ir.TileType([32, 16], DataType.FP16), span)
+    target = _make_distributed_tensor_var("data", [64, 32], DataType.FP16, span)
+    peer = ir.Var("peer", ir.ScalarType(DataType.INT32), span)
+    offsets = _make_shape_tuple([0, 0], span)
+
+    with pytest.raises(ValueError, match="pld.tile.remote_store"):
+        ir.create_op_call("pld.tensor.remote_store", [tile_var, target, peer, offsets], {}, span)
+
+
+def test_tensor_remote_store_rejects_distributed_src_and_names_put():
+    """Negative: a window-to-window transfer is pld.tensor.put's GM->GM job."""
+    span = ir.Span.unknown()
+    src = _make_distributed_tensor_var("src_win", [32, 16], DataType.FP16, span)
+    target = _make_distributed_tensor_var("data", [64, 32], DataType.FP16, span)
+    peer = ir.Var("peer", ir.ScalarType(DataType.INT32), span)
+    offsets = _make_shape_tuple([0, 0], span)
+
+    with pytest.raises(ValueError, match="pld.tensor.put"):
+        ir.create_op_call("pld.tensor.remote_store", [src, target, peer, offsets], {}, span)
+
+
+def test_tensor_remote_store_rejects_plain_tensor_target():
+    """Negative: the destination must be window-bound."""
+    span = ir.Span.unknown()
+    src = _make_tensor_var("x", [32, 16], DataType.FP16, span)
+    plain = _make_tensor_var("y", [64, 32], DataType.FP16, span)
+    peer = ir.Var("peer", ir.ScalarType(DataType.INT32), span)
+    offsets = _make_shape_tuple([0, 0], span)
+
+    with pytest.raises(ValueError, match="DistributedTensor"):
+        ir.create_op_call("pld.tensor.remote_store", [src, plain, peer, offsets], {}, span)
+
+
+def test_tensor_remote_store_rejects_leading_dim_over_one():
+    """Negative: same push contract as the tile form it lowers to."""
+    span = ir.Span.unknown()
+    src = _make_tensor_var("x", [2, 32, 16], DataType.FP16, span)
+    target = _make_distributed_tensor_var("data", [2, 64, 32], DataType.FP16, span)
+    peer = ir.Var("peer", ir.ScalarType(DataType.INT32), span)
+    offsets = _make_shape_tuple([0, 0, 0], span)
+
+    with pytest.raises(ValueError, match="src leading dimension 0 must be 1"):
+        ir.create_op_call("pld.tensor.remote_store", [src, target, peer, offsets], {}, span)
+
+
+def test_tensor_remote_store_accepts_nd_src_with_unit_leading_dims():
+    """Positive: an N-D value whose leading dims are all 1 lowers fine (see the
+    tile-form twin — the deducer runs before FlattenTileNdTo2D)."""
+    span = ir.Span.unknown()
+    src = _make_tensor_var("x", [1, 16, 32], DataType.FP16, span)
+    target = _make_distributed_tensor_var("data", [1, 16, 32], DataType.FP16, span)
+    peer = ir.Var("peer", ir.ScalarType(DataType.INT32), span)
+    offsets = _make_shape_tuple([0, 0, 0], span)
+
+    call = ir.create_op_call("pld.tensor.remote_store", [src, target, peer, offsets], {}, span)
+    assert isinstance(call.type, ir.UnknownType)
+
+
+def test_tensor_remote_store_rejects_dtype_mismatch():
+    """Negative: src dtype must match target dtype."""
+    span = ir.Span.unknown()
+    src = _make_tensor_var("x", [32, 16], DataType.FP32, span)
+    target = _make_distributed_tensor_var("data", [64, 32], DataType.FP16, span)
+    peer = ir.Var("peer", ir.ScalarType(DataType.INT32), span)
+    offsets = _make_shape_tuple([0, 0], span)
+
+    with pytest.raises(ValueError, match="dtype"):
+        ir.create_op_call("pld.tensor.remote_store", [src, target, peer, offsets], {}, span)
+
+
+def test_tensor_remote_store_rejects_out_of_bounds_push():
+    """Negative: the pushed region must fit inside the target at ``offsets``."""
+    span = ir.Span.unknown()
+    src = _make_tensor_var("x", [32, 16], DataType.FP16, span)
+    target = _make_distributed_tensor_var("data", [64, 32], DataType.FP16, span)
+    peer = ir.Var("peer", ir.ScalarType(DataType.INT32), span)
+    offsets = _make_shape_tuple([0, 20], span)  # 20 + 16 > 32
+
+    with pytest.raises(ValueError, match="push exceeds the peer's target region in dimension 1"):
+        ir.create_op_call("pld.tensor.remote_store", [src, target, peer, offsets], {}, span)
+
+
+def test_dsl_short_form_remote_store_dispatches_on_operand_level():
+    """``pld.remote_store`` picks the tile / tensor form from its src operand.
+
+    This is the whole point of the short form: one name that works in both a
+    tile-level (@pl.jit.incore / @pl.program) and a tensor-level (@pl.jit)
+    kernel, with the same four arguments and the same semantics.
+    """
+    span = ir.Span.unknown()
+    target = _make_distributed_tensor_var("data", [64, 32], DataType.FP16, span)
+    peer = ir.Var("peer", ir.ScalarType(DataType.INT32), span)
+
+    tile_call = dsl_unified.remote_store(
+        ir.Var("t", ir.TileType([32, 16], DataType.FP16), span), cast(Any, target), peer, [0, 0]
+    )
+    tensor_call = dsl_unified.remote_store(
+        _make_tensor_var("x", [32, 16], DataType.FP16, span), cast(Any, target), peer, [0, 0]
+    )
+
+    assert tile_call.op.name == ir.get_op("pld.tile.remote_store").name
+    assert tensor_call.op.name == ir.get_op("pld.tensor.remote_store").name
 
 
 # ---------------------------------------------------------------------------

--- a/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
+++ b/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
@@ -857,6 +857,130 @@ class TestConvertTensorToTileOps:
         After = passes.convert_tensor_to_tile_ops()(Before)
         ir.assert_structural_equal(After, Expected)
 
+    def test_tensor_remote_store_of_computed_value_lowers_1to1(self):
+        """pld.tensor.remote_store(computed) lowers 1:1 to pld.tile.remote_store.
+
+        The computed value's producer already lowered to a tile earlier in this
+        pass, so the tile flows straight into the push — no staging tile, no GM
+        round-trip (issue #2349).
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                x: pl.Tensor[[16, 64], pl.FP16],
+                dst: pld.DistributedTensor[[16, 64], pl.FP16],
+                peer: pl.Scalar[pl.INT32],
+            ):
+                scaled = pl.tensor.add(x, x)
+                pld.tensor.remote_store(scaled, dst, peer, [0, 0])
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                x: pl.Tensor[[16, 64], pl.FP16],
+                dst: pl.Out[pld.DistributedTensor[[16, 64], pl.FP16]],
+                peer: pl.Scalar[pl.INT32],
+            ):
+                x_vec: pl.Tile[[16, 64], pl.FP16, pl.Mem.Vec] = pl.tile.load(x, [0, 0], [16, 64], [16, 64])
+                scaled = pl.tile.add(x_vec, x_vec)
+                pld.tile.remote_store(scaled, dst, peer, [0, 0])
+                return  # noqa: PLR1711  (DSL return terminator, not a Python no-op)
+
+        After = passes.convert_tensor_to_tile_ops()(Before)
+        kernel = After.get_function("kernel")
+        assert kernel is not None
+        # No TPUT staging buffer is materialised on this path.
+        assert _find_first_call_to(kernel, "tile.create") is None, (
+            "a tile-source push needs no VEC staging tile — that is pld.tensor.put's TPUT bounce buffer"
+        )
+        assert _find_first_call_to(kernel, "pld.tensor.remote_store") is None
+        assert _find_first_call_to(kernel, "pld.tile.remote_store") is not None
+        _assert_convert_output_equal(After, Expected)
+
+    def test_tensor_remote_store_bridges_a_gm_src_with_a_tile_load(self):
+        """A src still resident in GM is auto-bridged with a natural Vec tile.load.
+
+        This is what makes the op total on its argument surface: the author does
+        not have to know whether the value they are pushing happens to live in GM
+        or on-core.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                x: pl.Tensor[[16, 64], pl.FP16],
+                dst: pld.DistributedTensor[[16, 64], pl.FP16],
+                peer: pl.Scalar[pl.INT32],
+            ):
+                pld.tensor.remote_store(x, dst, peer, [0, 0])
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                x: pl.Tensor[[16, 64], pl.FP16],
+                dst: pl.Out[pld.DistributedTensor[[16, 64], pl.FP16]],
+                peer: pl.Scalar[pl.INT32],
+            ):
+                x_vec: pl.Tile[[16, 64], pl.FP16, pl.Mem.Vec] = pl.tile.load(x, [0, 0], [16, 64], [16, 64])
+                pld.tile.remote_store(x_vec, dst, peer, [0, 0])
+                return  # noqa: PLR1711  (DSL return terminator, not a Python no-op)
+
+        _assert_convert_equal(Before, Expected)
+
+    def test_tensor_remote_store_forwards_atomic_attr(self):
+        """The atomic-add combine mode survives the 1:1 lowering."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                x: pl.Tensor[[16, 64], pl.FP16],
+                dst: pld.DistributedTensor[[16, 64], pl.FP16],
+                peer: pl.Scalar[pl.INT32],
+            ):
+                pld.tensor.remote_store(x, dst, peer, [0, 0], atomic=pld.AtomicType.Add)
+
+        After = passes.convert_tensor_to_tile_ops()(Before)
+        kernel = After.get_function("kernel")
+        assert kernel is not None
+        store = _find_first_call_to(kernel, "pld.tile.remote_store")
+        assert store is not None
+        assert store.kwargs["atomic"] == int(pld.AtomicType.Add)
+
+    def test_put_with_tile_source_names_put_and_points_at_remote_store(self):
+        """A computed src on pld.tensor.put is rejected at the op the author wrote.
+
+        Before issue #2349 this surfaced as "pld.tile.put src must be a Tensor or
+        DistributedTensor, got TileType" — naming an internal op the author never
+        wrote. TPUT genuinely cannot take a tile source, so the diagnostic must
+        route them to the op that can.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                x: pl.Tensor[[16, 64], pl.FP16],
+                dst: pld.DistributedTensor[[16, 64], pl.FP16],
+                peer: pl.Scalar[pl.INT32],
+            ):
+                scaled = pl.tensor.add(x, x)
+                pld.tensor.put(dst, peer=peer, src=scaled, atomic=pld.AtomicType.None_)
+
+        with pytest.raises(ValueError, match=r"pld\.tensor\.put src must be a GM tensor"):
+            passes.convert_tensor_to_tile_ops()(Before)
+
     def test_get_subregion_emits_transfer_shape_stage_and_forwards_offsets(self):
         """pld.tensor.get subregion lowers like put: stage sized to shape and offsets forwarded."""
 


### PR DESCRIPTION
## Summary

A value computed inside a kernel lives on-core and lowers to a `TileType`, which made it unpushable cross-rank from both directions: `pld.tensor.put` requires a GM source, and `pld.tile.remote_store` rejects the tensor-level value a `@pl.jit` kernel actually holds. Pushing a computed result meant storing it back to global memory and pushing from there — an extra round trip, with the store and the transfer landing on different pipes with nothing ordering them.

This adds `pld.tensor.remote_store`, the tensor-level twin of `pld.tile.remote_store`: same four arguments, same single `pto.tstore`, one IR level up. `ConvertTensorToTileOps` lowers it 1:1 (mirroring `tensor.aiv_shard -> tile.aiv_shard`), so a computed value now goes straight from on-core memory to the peer's window. The short form `pld.remote_store` dispatches between the two levels on its operand, so user code reads the same at either level.

Resolves the need described in #2349. That issue proposed overloading `pld.tensor.put` on the kind of its `src`; this implements the alternative the issue itself lists — see *Design note* below.

## Changes

- `src/ir/op/distributed/remote_store.cpp`: register `pld.tensor.remote_store`; share one contract between both forms covering target/peer/offsets/dtype, the 2-D push shape, static bounds, and `atomic`. Each form's src-type diagnostic names the sibling entry point, so an author writing at the wrong level is pointed at the right op.
- `src/ir/transforms/op_conversion_registry.cpp`: lower `pld.tensor.remote_store` 1:1 via `RegisterSimple`. Its `InputSpaceReq{Vec}` makes the op **total** on its argument surface — `BridgeInputSpaces` only rewrites `TensorType` operands, so a computed value passes through as a tile keeping its space, while a `src` still resident in GM is auto-bridged with a natural `tile.load`. Also rejects a tile `src` on `pld.tensor.put` at the op the author wrote, replacing an error that named the internal `pld.tile.put`.
- `src/backend/common/pto_ops_distributed.cpp`: emit `pto.tstore`'s `atomicType` for `AtomicType.Add`, under the same bf16/Ascend910B guard `tile.store` carries. Emitted only for `kAdd`, so plain pushes stay byte-identical.
- `src/ir/op/distributed/comm_op_utils.h`: add the shared push bounds check and atomic-value check (`put` now uses the latter too).
- `python/pypto/{ir,language}/...`: IR builders and DSL wrappers for the new op; `atomic` on the tile form; `pld.remote_store` becomes a type dispatcher instead of a re-export.
- `docs/{en,zh}/`: document the new op, the namespacing rationale, atomic semantics, and the bounds rule; both dev references were condensed alongside the additions.

### Behavior changes beyond the new op

- **`pld.tile.remote_store` gains `atomic`.** `pto.tstore` already accepts `atomicType` and `tile.store` already emits it; `atomic=AtomicType.Add` makes the push a combine (`peer_region += src`). This is what an all-to-all combine needs to sum every rank's contribution in place.
- **Both forms now bounds-check the push.** `remote_store` carries no transfer `shape` of its own to clamp against, so an oversized or badly-offset push silently overwrote the peer's neighbouring region; the `remote_load` mirror already checked this. Statically out-of-bounds pushes that previously compiled now fail with a message naming the dimension.
- **`pld.tile.remote_store` declares `set_input_memory(0, {Vec, Acc})`** (matching `tile.store`) in place of `no_memory_spec`, so `InferTileMemorySpace` can pull a producer into a legal space. This records a demand; it does not reject.
- The push contract admits an N-D source whose leading dims are all `1`, because the deducer also runs *before* `FlattenTileNdTo2D` collapses N-D tiles. Only a leading extent > 1 is rejected — that would fold into the row count and overrun the target.

No migration is required: every existing call site keeps its meaning, and non-atomic `remote_store` codegen is unchanged.

## Design note

`pld.tensor.put` is deliberately **not** overloaded on the kind of its `src`. Doing so would make five of its arguments (`src_offsets`, `shape`, `atomic`, `chunk_rows`/`chunk_cols`, `pipeline`) conditionally meaningless depending on how the value was produced upstream — a property invisible at the call site — and it contradicts the documented rule that a `pld` namespace encodes the IR level an op lives at. `put` remains the GM→GM bulk (TPUT) path, which stages through a bounce buffer and is therefore not bounded by what fits on-core; `remote_store` moves what is already on-core, in one write.

## Verification

Run in this worktree at the pushed commit (`7c99550d`), rebased onto `upstream/main`:

- `cmake --build build --parallel`: exit 0
- `python -m pytest tests/ut/ --ignore=tests/ut/runtime --ignore=tests/ut/core/test_error.py -n auto --maxprocesses 8`: exit 0 — **8846 passed, 4 skipped**
- `ruff check python/ tests/`; `ruff format --check python/ tests/`: exit 0
- `clang-format --dry-run --Werror` on the 5 touched C++ files: exit 0
- `tests/lint/clang_tidy.py --diff-base HEAD`: exit 0
- `markdownlint-cli2 --config tests/lint/.markdownlint.yaml "docs/**/*.md"`: 0 issues
- `tests/lint/{check_headers,check_op_name_literals,check_no_broad_raises,check_docs_en_zh_parity,check_docs_nav,check_english_only,check_docs_symbol_coverage}.py`: all exit 0

New coverage: 42 tests across the deducer (`tests/ut/ir/test_distributed_ops.py`), printer round-trip (`tests/ut/ir/parser/test_remote_store.py`), the conversion pass (`tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py`), and codegen (`tests/ut/codegen/distributed/test_distributed_pto_codegen.py`) — including that the computed-value path emits `pto.tstore` with no `pto.comm.tput` and no staging tile.

**Two exclusions above are pre-existing environment failures, not regressions**, and reproduce identically on `upstream/main`: `tests/ut/runtime/` fails at import with `GLIBCXX_3.4.30 not found` from the prebuilt `simpler` module, and `tests/ut/core/test_error.py`'s `(?:^|/)(?:src|include/pypto)/` regex matches this conda interpreter's own `/usr/local/src/conda/python-3.13.5/...` frames.

**Not run:** `tests/st/distributed/test_l3_remote_store.py::test_tensor_level_push_of_computed_value` — the ST added here needs 2 devices. Its program was verified to compile end-to-end through the full pipeline, but its numeric golden has not executed.