### PR TITLE
fix(ir): attribute synthesized tile ops to their own source spans

### DIFF
--- a/docs/en/dev/02-error-handling.md
+++ b/docs/en/dev/02-error-handling.md
@@ -168,6 +168,35 @@ Every IR node inherits a `span_` field from `IRNode` (see [IR Overview](ir/00-ov
 
 When a `Span` is valid, the error output appends `[file:line:col]` to the message. When `Span::unknown()` is used, no source location is shown.
 
+### Span attribution in passes
+
+A pass that synthesizes or re-creates an IR node must give it the span of the
+**node it stands for**, not the enclosing function's span. Reaching for
+`func->span_` is convenient — it is in scope for the whole transform — but it
+reports the `def` line for every node the pass touches, which silently degrades
+each consumer that reads a span off a `Call`: `CHECK_SPAN` / `INTERNAL_CHECK_SPAN`
+diagnostics raised by later passes, IR-trace reports, and span-keyed verifier
+checks (the PH001 perf hint deduplicates by source site, so coarsened spans merge
+unrelated transfers into one bogus "N occurrences" hint).
+
+```cpp
+// ❌ every synthesized op reports the `def` line
+const auto& span = func->span_;
+for (const auto& stmt : body) { /* ... */ op_registry.Create(name, args, span); }
+
+// ✅ attribute each node to the statement being rewritten
+for (const auto& stmt : body) {
+  const Span& span = stmt->span_;
+  /* ... */ op_registry.Create(name, args, span);
+}
+```
+
+Pick the nearest node that motivated the new one: the statement being rewritten,
+the `Call` being converted (`call->span_`), the parameter a prologue load reads
+(`var->span_`), or the `ReturnStmt` an epilogue store serves. `func->span_` is
+correct only for nodes that genuinely belong to the whole function — the rebuilt
+`Function` itself and its body `SeqStmts`.
+
 ## Python API
 
 ```python

--- a/docs/zh/dev/02-error-handling.md
+++ b/docs/zh/dev/02-error-handling.md
@@ -165,6 +165,32 @@ UNREACHABLE_SPAN(node->span_) << "Unsupported data type: " << dtype;
 
 当 `Span` 有效时，错误输出在消息末尾追加 `[file:line:col]`。使用 `Span::unknown()` 时，不显示源码位置。
 
+### Pass 中的 span 归属
+
+Pass 合成或重建 IR 节点时，必须赋予它**所代表节点**的 span，而不是外层函数的 span。
+使用 `func->span_` 很方便——它在整个变换过程中都可见——但这会让 pass 触及的每个节点
+都报告 `def` 行，从而悄悄降低所有读取 `Call` span 的消费方的精度：后续 pass 抛出的
+`CHECK_SPAN` / `INTERNAL_CHECK_SPAN` 诊断、IR trace 报告，以及按 span 归并的验证检查
+（PH001 性能提示按源码位置去重，span 被粗化后会把互不相关的搬运合并成一条错误的
+"N occurrences" 提示）。
+
+```cpp
+// ❌ 每个合成的算子都报告 `def` 行
+const auto& span = func->span_;
+for (const auto& stmt : body) { /* ... */ op_registry.Create(name, args, span); }
+
+// ✅ 将每个节点归属到正在重写的语句
+for (const auto& stmt : body) {
+  const Span& span = stmt->span_;
+  /* ... */ op_registry.Create(name, args, span);
+}
+```
+
+选择促成新节点的最近节点：正在重写的语句、正在转换的 `Call`（`call->span_`）、
+前置 load 所读取的参数（`var->span_`），或后置 store 所服务的 `ReturnStmt`。
+只有真正属于整个函数的节点——重建的 `Function` 本身及其函数体 `SeqStmts`——
+才应使用 `func->span_`。
+
 ## Python API
 
 ```python

--- a/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
+++ b/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
@@ -1539,6 +1539,11 @@ struct IncoreTransformResult {
 IncoreTransformResult TransformIncoreFunction(const FunctionPtr& func) {
   auto& conv_registry = OpConversionRegistry::GetInstance();
   auto& op_registry = OpRegistry::GetInstance();
+  // Structural nodes (body SeqStmts, the rebuilt Function) belong to the whole
+  // function, so they carry its span.  Synthesized *ops* must not: an entry load
+  // is attributed to the parameter that motivated it and an exit store to the
+  // `return` that motivated it, so post-pass diagnostics point at real source
+  // lines instead of the `def` line.
   const auto& span = func->span_;
 
   // Pre-scan: collect consumer memory space requirements (e.g. tensor.slice → tensor.matmul
@@ -1570,15 +1575,17 @@ IncoreTransformResult TransformIncoreFunction(const FunctionPtr& func) {
 
     if (params_used_by_converted_ops.find(var.get()) == params_used_by_converted_ops.end()) continue;
 
-    auto offsets = MakeZeroOffsets(tensor_type->shape_.size(), span);
-    auto shapes = MakeShapeTuple(tensor_type->shape_, span);
+    // Attribute the entry load to the parameter declaration it loads, not to `def`.
+    const auto& load_span = var->span_;
+    auto offsets = MakeZeroOffsets(tensor_type->shape_.size(), load_span);
+    auto shapes = MakeShapeTuple(tensor_type->shape_, load_span);
     std::vector<std::pair<std::string, std::any>> load_kwargs = {{"target_memory", MemorySpace::Vec}};
-    auto load_call = op_registry.Create("tile.load", {var, offsets, shapes, shapes}, load_kwargs, span);
+    auto load_call = op_registry.Create("tile.load", {var, offsets, shapes, shapes}, load_kwargs, load_span);
 
     std::string tile_name = MakeTileValueName(var->name_hint_);
-    auto tile_var = std::make_shared<Var>(tile_name, load_call->GetType(), span);
+    auto tile_var = std::make_shared<Var>(tile_name, load_call->GetType(), load_span);
 
-    new_stmts.push_back(std::make_shared<AssignStmt>(tile_var, load_call, span));
+    new_stmts.push_back(std::make_shared<AssignStmt>(tile_var, load_call, load_span));
     mutator.AddMapping(var.get(), tile_var);
   }
 
@@ -1609,6 +1616,9 @@ IncoreTransformResult TransformIncoreFunction(const FunctionPtr& func) {
 
   if (return_stmt) {
     std::vector<ExprPtr> new_return_exprs;
+    // The exit stores and the Out params they write exist because of this
+    // `return`, so they are attributed to it rather than to the `def` line.
+    const auto& ret_span = return_stmt->span_;
 
     // Process each return value
     for (size_t i = 0; i < return_stmt->value_.size(); ++i) {
@@ -1627,7 +1637,7 @@ IncoreTransformResult TransformIncoreFunction(const FunctionPtr& func) {
         std::string out_name = MakeOutParamName(num_added_outputs);
 
         auto out_type = orig_tensor_type;
-        auto out_param = std::make_shared<Var>(out_name, out_type, span);
+        auto out_param = std::make_shared<Var>(out_name, out_type, ret_span);
         new_params.push_back(out_param);
         new_param_directions.push_back(ParamDirection::Out);
 
@@ -1645,12 +1655,12 @@ IncoreTransformResult TransformIncoreFunction(const FunctionPtr& func) {
         }
 
         // Insert tile.store(tile, zeros, out_param)
-        auto offsets = MakeZeroOffsets(tile_type->shape_.size(), span);
-        auto store_call = op_registry.Create("tile.store", {ret_expr, offsets, out_param}, span);
+        auto offsets = MakeZeroOffsets(tile_type->shape_.size(), ret_span);
+        auto store_call = op_registry.Create("tile.store", {ret_expr, offsets, out_param}, ret_span);
 
         auto store_var =
-            std::make_shared<Var>(MakeStoreResultName(num_added_outputs), store_call->GetType(), span);
-        new_stmts.push_back(std::make_shared<AssignStmt>(store_var, store_call, span));
+            std::make_shared<Var>(MakeStoreResultName(num_added_outputs), store_call->GetType(), ret_span);
+        new_stmts.push_back(std::make_shared<AssignStmt>(store_var, store_call, ret_span));
 
         new_return_types.push_back(store_call->GetType());
         new_return_exprs.push_back(store_var);

--- a/src/ir/transforms/flatten_tile_nd_to_2d/batch_matmul.cpp
+++ b/src/ir/transforms/flatten_tile_nd_to_2d/batch_matmul.cpp
@@ -335,10 +335,12 @@ struct BatchPageResult {
 ///
 /// The operand is always 2D by the time it reaches here (loads flatten to 2D,
 /// transpose_views are 2D, safe batch-only reshapes are peeled to the 2D load).
+/// `span` is the source Call's span (for synthesized ops and expressions);
+/// `stmt_span` is the enclosing assignment's (for synthesized statements).
 BatchPageResult ExtractBatchPage(const BatchOperandInfo& info, const std::vector<int64_t>& operand_dims,
                                  const std::vector<int64_t>& operand_batch_shape, int64_t batch_index,
                                  const std::string& base_name, const FlattenContext& ctx,
-                                 const OpRegistry& op_registry, const Span& span) {
+                                 const OpRegistry& op_registry, const Span& span, const Span& stmt_span) {
   BatchPageResult page;
   const auto& operand = info.operand;
   const auto& operand_type = info.operand_type;
@@ -394,7 +396,7 @@ BatchPageResult ExtractBatchPage(const BatchOperandInfo& info, const std::vector
     INTERNAL_CHECK_SPAN(load_shape, span) << "FlattenTileNdTo2D: !fit per-batch load shape must be a tuple";
     auto view_call = CreateCollapsedTensorView(load_tensor_var, load_tensor_type, span);
     auto view_var = std::make_shared<Var>(base_name + "_pbview2d_" + suffix, view_call->GetType(), span);
-    page.stmts.push_back(std::make_shared<AssignStmt>(view_var, view_call, span));
+    page.stmts.push_back(std::make_shared<AssignStmt>(view_var, view_call, stmt_span));
 
     auto row_offset = CollapseLeadingOffsetsToRow(load_offsets->elements_, load_tensor_type->shape_, span);
     auto load_2d_shape = CollapseLeadingDimsTo2D(load_shape->elements_, span);
@@ -418,12 +420,12 @@ BatchPageResult ExtractBatchPage(const BatchOperandInfo& info, const std::vector
     INTERNAL_CHECK_SPAN(load_2d_type && load_2d_type->shape_.size() == 2, span)
         << "FlattenTileNdTo2D: !fit per-batch collapsed load must produce a 2D tile";
     current = std::make_shared<Var>(base_name + "_pbload_" + suffix, load_2d_type, span);
-    page.stmts.push_back(std::make_shared<AssignStmt>(current, load_2d, span));
+    page.stmts.push_back(std::make_shared<AssignStmt>(current, load_2d, stmt_span));
 
     if (info.from_transpose_view) {
       auto view = op_registry.Create("tile.transpose_view", {current}, {}, span);
       auto view_var = std::make_shared<Var>(base_name + "_pbview_" + suffix, view->GetType(), span);
-      page.stmts.push_back(std::make_shared<AssignStmt>(view_var, view, span));
+      page.stmts.push_back(std::make_shared<AssignStmt>(view_var, view, stmt_span));
       current = view_var;
     }
     page.var = current;
@@ -451,7 +453,7 @@ BatchPageResult ExtractBatchPage(const BatchOperandInfo& info, const std::vector
     auto shape = MakeShapeTupleFromInts({source_rows, source_cols}, span);
     auto slice = op_registry.Create("tile.slice", {operand, shape, offset}, span);
     current = std::make_shared<Var>(base_name + "_slice_" + suffix, slice->GetType(), span);
-    page.stmts.push_back(std::make_shared<AssignStmt>(current, slice, span));
+    page.stmts.push_back(std::make_shared<AssignStmt>(current, slice, stmt_span));
   }
 
   // No per-batch transpose: a transposed (b_trans/a_trans) operand arrives as a
@@ -572,10 +574,10 @@ BatchMatmulResult LowerBatchMatmul(const AssignStmtPtr& assign, const CallPtr& c
     int64_t rhs_batch_idx =
         BuildOperandFlatBatchIndex(rhs_batch_dims, output_batch_dims, output_batch_indices);
 
-    auto lhs_page =
-        ExtractBatchPage(lhs_info, lhs_dims, lhs_batch_dims, lhs_batch_idx, "lhs", ctx, op_registry, span);
-    auto rhs_page =
-        ExtractBatchPage(rhs_info, rhs_dims, rhs_batch_dims, rhs_batch_idx, "rhs", ctx, op_registry, span);
+    auto lhs_page = ExtractBatchPage(lhs_info, lhs_dims, lhs_batch_dims, lhs_batch_idx, "lhs", ctx,
+                                     op_registry, span, assign->span_);
+    auto rhs_page = ExtractBatchPage(rhs_info, rhs_dims, rhs_batch_dims, rhs_batch_idx, "rhs", ctx,
+                                     op_registry, span, assign->span_);
     auto matmul = op_registry.Create("tile.matmul", {lhs_page.var, rhs_page.var}, span);
     auto matmul_type = As<TileType>(matmul->GetType());
     bool needs_cast = matmul_type && matmul_type->dtype_ != orig_result_type->dtype_;
@@ -583,7 +585,7 @@ BatchMatmulResult LowerBatchMatmul(const AssignStmtPtr& assign, const CallPtr& c
       out.stmts.insert(out.stmts.end(), lhs_page.stmts.begin(), lhs_page.stmts.end());
       out.stmts.insert(out.stmts.end(), rhs_page.stmts.begin(), rhs_page.stmts.end());
       auto matmul_var = std::make_shared<Var>(assign->var_->name_hint_, matmul->GetType(), span);
-      out.stmts.push_back(std::make_shared<AssignStmt>(matmul_var, matmul, span));
+      out.stmts.push_back(std::make_shared<AssignStmt>(matmul_var, matmul, assign->span_));
       out.output_var = matmul_var;
       return out;
     }
@@ -606,10 +608,20 @@ BatchMatmulResult LowerBatchMatmul(const AssignStmtPtr& assign, const CallPtr& c
     };
     auto create_out = op_registry.Create("tile.create", {out_shape}, create_kw, span);
     out_var = std::make_shared<Var>(assign->var_->name_hint_, create_out->GetType(), span);
-    out.stmts.push_back(std::make_shared<AssignStmt>(out_var, create_out, span));
+    out.stmts.push_back(std::make_shared<AssignStmt>(out_var, create_out, assign->span_));
   }
 
   // Prepare direct-store state.
+  //
+  // Everything synthesized for the fused store replaces the consumed `tile.store`
+  // statement, which the caller skips, so it is attributed to *that* statement
+  // rather than to `span` (the batch-matmul's). Ops and expressions take the
+  // store's `Call` span and the synthesized statements take its `AssignStmt` span
+  // — the same split the rewrite loop applies, and they differ whenever the
+  // store's RHS does not start at its assignment. Bound once each, up front, so
+  // the shape tuple built here cannot drift from the stores emitted below.
+  const Span& store_span = direct_store.detected ? direct_store.store_call->span_ : span;
+  const Span& store_stmt_span = direct_store.detected ? direct_store.store_assign->span_ : span;
   ExprPtr current_store_tensor;
   MakeTuplePtr direct_store_offsets;
   std::vector<ExprPtr> direct_store_shape;
@@ -628,10 +640,10 @@ BatchMatmulResult LowerBatchMatmul(const AssignStmtPtr& assign, const CallPtr& c
       const size_t tile_rank = 2;  // matmul result is always 2D
       direct_store_shape.reserve(tensor_rank);
       for (size_t i = tile_rank; i < tensor_rank; ++i) {
-        direct_store_shape.push_back(std::make_shared<ConstInt>(1, DataType::INDEX, span));
+        direct_store_shape.push_back(std::make_shared<ConstInt>(1, DataType::INDEX, store_span));
       }
-      direct_store_shape.push_back(std::make_shared<ConstInt>(lhs_rows, DataType::INDEX, span));
-      direct_store_shape.push_back(std::make_shared<ConstInt>(rhs_cols, DataType::INDEX, span));
+      direct_store_shape.push_back(std::make_shared<ConstInt>(lhs_rows, DataType::INDEX, store_span));
+      direct_store_shape.push_back(std::make_shared<ConstInt>(rhs_cols, DataType::INDEX, store_span));
     }
   }
 
@@ -644,17 +656,17 @@ BatchMatmulResult LowerBatchMatmul(const AssignStmtPtr& assign, const CallPtr& c
         BuildOperandFlatBatchIndex(rhs_batch_dims, output_batch_dims, output_batch_indices);
 
     // Extract 2D pages.
-    auto lhs_page =
-        ExtractBatchPage(lhs_info, lhs_dims, lhs_batch_dims, lhs_batch_idx, "lhs", ctx, op_registry, span);
-    auto rhs_page =
-        ExtractBatchPage(rhs_info, rhs_dims, rhs_batch_dims, rhs_batch_idx, "rhs", ctx, op_registry, span);
+    auto lhs_page = ExtractBatchPage(lhs_info, lhs_dims, lhs_batch_dims, lhs_batch_idx, "lhs", ctx,
+                                     op_registry, span, assign->span_);
+    auto rhs_page = ExtractBatchPage(rhs_info, rhs_dims, rhs_batch_dims, rhs_batch_idx, "rhs", ctx,
+                                     op_registry, span, assign->span_);
     out.stmts.insert(out.stmts.end(), lhs_page.stmts.begin(), lhs_page.stmts.end());
     out.stmts.insert(out.stmts.end(), rhs_page.stmts.begin(), rhs_page.stmts.end());
 
     // Emit tile.matmul.
     auto matmul = op_registry.Create("tile.matmul", {lhs_page.var, rhs_page.var}, span);
     auto matmul_var = std::make_shared<Var>("matmul_" + std::to_string(i), matmul->GetType(), span);
-    out.stmts.push_back(std::make_shared<AssignStmt>(matmul_var, matmul, span));
+    out.stmts.push_back(std::make_shared<AssignStmt>(matmul_var, matmul, assign->span_));
 
     // Move matmul result from Acc to Vec, then cast dtype if needed.
     // The explicit tile.move is always required for the non-fused (assemble) path so
@@ -669,7 +681,7 @@ BatchMatmulResult LowerBatchMatmul(const AssignStmtPtr& assign, const CallPtr& c
       };
       auto move = op_registry.Create("tile.move", {matmul_var}, move_kw, span);
       auto move_var = std::make_shared<Var>("matmul_vec_" + std::to_string(i), move->GetType(), span);
-      out.stmts.push_back(std::make_shared<AssignStmt>(move_var, move, span));
+      out.stmts.push_back(std::make_shared<AssignStmt>(move_var, move, assign->span_));
       batch_result = move_var;
     }
     if (needs_cast) {
@@ -679,7 +691,7 @@ BatchMatmulResult LowerBatchMatmul(const AssignStmtPtr& assign, const CallPtr& c
       };
       auto cast = op_registry.Create("tile.cast", {batch_result}, cast_kw, span);
       auto cast_var = std::make_shared<Var>("matmul_cast_" + std::to_string(i), cast->GetType(), span);
-      out.stmts.push_back(std::make_shared<AssignStmt>(cast_var, cast, span));
+      out.stmts.push_back(std::make_shared<AssignStmt>(cast_var, cast, assign->span_));
       batch_result = cast_var;
     }
 
@@ -688,25 +700,27 @@ BatchMatmulResult LowerBatchMatmul(const AssignStmtPtr& assign, const CallPtr& c
       // Keep the original tensor-rank offsets — codegen reconstructs the
       // corresponding partition_view from that window description.
       auto store_offset_elems = BuildBatchAdjustedOffsets(
-          direct_store_offsets->elements_, output_batch_indices, output_batch_dims.size(), span);
-      auto store_offset = std::make_shared<MakeTuple>(store_offset_elems, span);
+          direct_store_offsets->elements_, output_batch_indices, output_batch_dims.size(), store_span);
+      auto store_offset = std::make_shared<MakeTuple>(store_offset_elems, store_span);
 
       std::vector<ExprPtr> store_args = {batch_result, store_offset, current_store_tensor};
       if (!direct_store_shape.empty()) {
-        store_args.push_back(std::make_shared<MakeTuple>(direct_store_shape, span));
+        store_args.push_back(std::make_shared<MakeTuple>(direct_store_shape, store_span));
       }
-      auto batch_store = op_registry.Create("tile.store", store_args, span);
+      auto batch_store = op_registry.Create("tile.store", store_args, store_span);
+      // The Var stands for the store's bound name and the AssignStmt for the whole
+      // statement, so both follow the consumed statement rather than its RHS Call.
       auto batch_store_var =
           std::make_shared<Var>(direct_store.store_assign->var_->name_hint_ + "_" + std::to_string(i),
-                                batch_store->GetType(), span);
-      out.stmts.push_back(std::make_shared<AssignStmt>(batch_store_var, batch_store, span));
+                                batch_store->GetType(), direct_store.store_assign->var_->span_);
+      out.stmts.push_back(std::make_shared<AssignStmt>(batch_store_var, batch_store, store_stmt_span));
       current_store_tensor = batch_store_var;
     } else {
       // Non-fused path: assemble into output tile.
       auto out_offset = MakeShapeTupleFromInts({i * lhs_rows, 0}, span);
       auto assemble = op_registry.Create("tile.assemble", {out_var, batch_result, out_offset}, span);
       out_var = std::make_shared<Var>(out_var->name_hint_, assemble->GetType(), span);
-      out.stmts.push_back(std::make_shared<AssignStmt>(out_var, assemble, span));
+      out.stmts.push_back(std::make_shared<AssignStmt>(out_var, assemble, assign->span_));
     }
   }
 
@@ -853,16 +867,16 @@ BatchMatmulAccResult LowerBatchMatmulAcc(const AssignStmtPtr& assign, const Call
     int64_t rhs_batch_idx =
         BuildOperandFlatBatchIndex(rhs_batch_dims, output_batch_dims, output_batch_indices);
 
-    auto lhs_page =
-        ExtractBatchPage(lhs_info, lhs_dims, lhs_batch_dims, lhs_batch_idx, "lhs", ctx, op_registry, span);
-    auto rhs_page =
-        ExtractBatchPage(rhs_info, rhs_dims, rhs_batch_dims, rhs_batch_idx, "rhs", ctx, op_registry, span);
+    auto lhs_page = ExtractBatchPage(lhs_info, lhs_dims, lhs_batch_dims, lhs_batch_idx, "lhs", ctx,
+                                     op_registry, span, assign->span_);
+    auto rhs_page = ExtractBatchPage(rhs_info, rhs_dims, rhs_batch_dims, rhs_batch_idx, "rhs", ctx,
+                                     op_registry, span, assign->span_);
     out.stmts.insert(out.stmts.end(), lhs_page.stmts.begin(), lhs_page.stmts.end());
     out.stmts.insert(out.stmts.end(), rhs_page.stmts.begin(), rhs_page.stmts.end());
 
     auto matmul_acc = op_registry.Create("tile.matmul_acc", {current_acc, lhs_page.var, rhs_page.var}, span);
     auto new_acc = std::make_shared<Var>(current_acc->name_hint_, matmul_acc->GetType(), span);
-    out.stmts.push_back(std::make_shared<AssignStmt>(new_acc, matmul_acc, span));
+    out.stmts.push_back(std::make_shared<AssignStmt>(new_acc, matmul_acc, assign->span_));
     out.output_var = new_acc;
     return out;
   }
@@ -875,10 +889,10 @@ BatchMatmulAccResult LowerBatchMatmulAcc(const AssignStmtPtr& assign, const Call
     int64_t rhs_batch_idx =
         BuildOperandFlatBatchIndex(rhs_batch_dims, output_batch_dims, output_batch_indices);
 
-    auto lhs_page =
-        ExtractBatchPage(lhs_info, lhs_dims, lhs_batch_dims, lhs_batch_idx, "lhs", ctx, op_registry, span);
-    auto rhs_page =
-        ExtractBatchPage(rhs_info, rhs_dims, rhs_batch_dims, rhs_batch_idx, "rhs", ctx, op_registry, span);
+    auto lhs_page = ExtractBatchPage(lhs_info, lhs_dims, lhs_batch_dims, lhs_batch_idx, "lhs", ctx,
+                                     op_registry, span, assign->span_);
+    auto rhs_page = ExtractBatchPage(rhs_info, rhs_dims, rhs_batch_dims, rhs_batch_idx, "rhs", ctx,
+                                     op_registry, span, assign->span_);
     out.stmts.insert(out.stmts.end(), lhs_page.stmts.begin(), lhs_page.stmts.end());
     out.stmts.insert(out.stmts.end(), rhs_page.stmts.begin(), rhs_page.stmts.end());
 
@@ -887,15 +901,15 @@ BatchMatmulAccResult LowerBatchMatmulAcc(const AssignStmtPtr& assign, const Call
     auto acc_shape = MakeShapeTupleFromInts({lhs_rows, rhs_cols}, span);
     auto acc_slice = op_registry.Create("tile.slice", {current_acc, acc_shape, acc_offset}, span);
     auto acc_page_var = std::make_shared<Var>("acc_page_" + suffix, acc_slice->GetType(), span);
-    out.stmts.push_back(std::make_shared<AssignStmt>(acc_page_var, acc_slice, span));
+    out.stmts.push_back(std::make_shared<AssignStmt>(acc_page_var, acc_slice, assign->span_));
 
     auto matmul_acc = op_registry.Create("tile.matmul_acc", {acc_page_var, lhs_page.var, rhs_page.var}, span);
     auto matmul_var = std::make_shared<Var>("matmul_acc_" + suffix, matmul_acc->GetType(), span);
-    out.stmts.push_back(std::make_shared<AssignStmt>(matmul_var, matmul_acc, span));
+    out.stmts.push_back(std::make_shared<AssignStmt>(matmul_var, matmul_acc, assign->span_));
 
     auto assemble = op_registry.Create("tile.assemble", {current_acc, matmul_var, acc_offset}, span);
     current_acc = std::make_shared<Var>(current_acc->name_hint_, assemble->GetType(), span);
-    out.stmts.push_back(std::make_shared<AssignStmt>(current_acc, assemble, span));
+    out.stmts.push_back(std::make_shared<AssignStmt>(current_acc, assemble, assign->span_));
   }
 
   out.output_var = current_acc;

--- a/src/ir/transforms/flatten_tile_nd_to_2d/rewrite.cpp
+++ b/src/ir/transforms/flatten_tile_nd_to_2d/rewrite.cpp
@@ -87,9 +87,14 @@ TypePtr WithCarriedMemRef(const TypePtr& deduced, const AssignStmtPtr& assign) {
 
 /**
  * @brief Recursively transform statements, flattening >2D tile ops to 2D.
+ *
+ * Every node this synthesizes is attributed to the statement it was synthesized
+ * for (see `span` in the rewrite loop) — never to the enclosing function — so
+ * post-pass diagnostics, IR traces and `loc()` point at the offending source
+ * line rather than the `def` line.
  */
 std::vector<StmtPtr> TransformBody(const std::vector<StmtPtr>& stmts, FlattenContext& ctx,
-                                   const OpRegistry& op_registry, const Span& span) {
+                                   const OpRegistry& op_registry) {
   std::vector<StmtPtr> result;
 
   // Pre-scan: identify operand chains (tile.load -> tile.transpose_view/reshape)
@@ -343,6 +348,11 @@ std::vector<StmtPtr> TransformBody(const std::vector<StmtPtr>& stmts, FlattenCon
 
   for (size_t stmt_index = 0; stmt_index < stmts.size(); ++stmt_index) {
     const auto& stmt = stmts[stmt_index];
+    // Statement-level nodes below each carry their own source node's span
+    // (`ret->span_`, `assign->span_`, `for_stmt->body_->span_`, ...). Ops rebuilt
+    // from an RHS `Call` use that Call's tighter span — see `span`, bound once the
+    // Call is in hand.
+
     // ReturnStmt: substitute return values
     if (auto ret = As<ReturnStmt>(stmt)) {
       std::vector<ExprPtr> new_values;
@@ -367,7 +377,7 @@ std::vector<StmtPtr> TransformBody(const std::vector<StmtPtr>& stmts, FlattenCon
 
     // SeqStmts: recurse
     if (auto seq = As<SeqStmts>(stmt)) {
-      auto inner = TransformBody(seq->stmts_, ctx, op_registry, span);
+      auto inner = TransformBody(seq->stmts_, ctx, op_registry);
       result.insert(result.end(), inner.begin(), inner.end());
       continue;
     }
@@ -376,7 +386,7 @@ std::vector<StmtPtr> TransformBody(const std::vector<StmtPtr>& stmts, FlattenCon
     // since ScopeStmt is abstract and MutableCopy needs a concrete type.
     if (auto scope = As<ScopeStmt>(stmt)) {
       auto body_stmts = FlattenToStmts(scope->body_);
-      auto inner = TransformBody(body_stmts, ctx, op_registry, span);
+      auto inner = TransformBody(body_stmts, ctx, op_registry);
       auto new_body = SeqStmts::Flatten(std::move(inner), scope->body_->span_);
       auto rewrite = [&](auto&& concrete) -> StmtPtr {
         auto new_scope = MutableCopy(concrete);
@@ -407,7 +417,7 @@ std::vector<StmtPtr> TransformBody(const std::vector<StmtPtr>& stmts, FlattenCon
 
       auto then_ctx = ctx;
       auto then_stmts = FlattenToStmts(if_stmt->then_body_);
-      auto new_then = TransformBody(then_stmts, then_ctx, op_registry, span);
+      auto new_then = TransformBody(then_stmts, then_ctx, op_registry);
       // Extract yield types before moving the vector
       auto yield_types = FindYieldTypes(new_then);
       auto new_then_body = SeqStmts::Flatten(std::move(new_then), if_stmt->then_body_->span_);
@@ -416,7 +426,7 @@ std::vector<StmtPtr> TransformBody(const std::vector<StmtPtr>& stmts, FlattenCon
       std::optional<StmtPtr> new_else_body;
       if (if_stmt->else_body_.has_value()) {
         auto else_stmts = FlattenToStmts(*if_stmt->else_body_);
-        auto new_else = TransformBody(else_stmts, else_ctx, op_registry, span);
+        auto new_else = TransformBody(else_stmts, else_ctx, op_registry);
         new_else_body = SeqStmts::Flatten(std::move(new_else), (*if_stmt->else_body_)->span_);
       }
 
@@ -468,7 +478,7 @@ std::vector<StmtPtr> TransformBody(const std::vector<StmtPtr>& stmts, FlattenCon
       }
 
       auto body_stmts = FlattenToStmts(for_stmt->body_);
-      auto new_body_stmts = TransformBody(body_stmts, body_ctx, op_registry, span);
+      auto new_body_stmts = TransformBody(body_stmts, body_ctx, op_registry);
       auto new_body = SeqStmts::Flatten(std::move(new_body_stmts), for_stmt->body_->span_);
 
       // Update return_vars types to match iter_arg types (positional matching)
@@ -515,7 +525,7 @@ std::vector<StmtPtr> TransformBody(const std::vector<StmtPtr>& stmts, FlattenCon
 
       auto new_cond = Substitute(while_stmt->condition_, body_ctx.var_map);
       auto body_stmts = FlattenToStmts(while_stmt->body_);
-      auto new_body_stmts = TransformBody(body_stmts, body_ctx, op_registry, span);
+      auto new_body_stmts = TransformBody(body_stmts, body_ctx, op_registry);
       auto new_body = SeqStmts::Flatten(std::move(new_body_stmts), while_stmt->body_->span_);
 
       // Update return_vars types to match iter_arg types (positional matching)
@@ -548,7 +558,7 @@ std::vector<StmtPtr> TransformBody(const std::vector<StmtPtr>& stmts, FlattenCon
         // Re-create tile ops via OpRegistry for proper type deduction
         if (auto call = As<Call>(new_expr)) {
           if (call->op_ && call->op_->name_.substr(0, 5) == "tile.") {
-            auto new_call = op_registry.Create(call->op_->name_, call->args_, call->kwargs_, span);
+            auto new_call = op_registry.Create(call->op_->name_, call->args_, call->kwargs_, call->span_);
             result.push_back(std::make_shared<EvalStmt>(new_call, eval->span_));
             continue;
           }
@@ -591,6 +601,19 @@ std::vector<StmtPtr> TransformBody(const std::vector<StmtPtr>& stmts, FlattenCon
       }
       continue;
     }
+
+    // Everything below rebuilds ops derived from this RHS `Call`, so they take the
+    // Call's own span rather than the statement's. The two differ whenever the RHS
+    // does not start at the assignment — always by column (`t = pl.tile.exp(x)`),
+    // and by line for a parenthesized or wrapped RHS.
+    //
+    // Invariant: `span` is for expressions and ops ONLY. Every `AssignStmt` built
+    // below — including the auxiliary ones the lowering paths insert (the rank-N
+    // Mat load's `tensor.view`, the rank-N store's `tile.reshape`, the transpose
+    // scratch `tile.create`) — must pass `assign->span_`, so statement-level
+    // verifiers and `INTERNAL_CHECK_SPAN(..., assign->span_)` consumers keep
+    // reporting the statement rather than the operator inside it.
+    const Span& span = call->span_;
 
     const auto& op_name = call->op_->name_;
 
@@ -715,7 +738,7 @@ std::vector<StmtPtr> TransformBody(const std::vector<StmtPtr>& stmts, FlattenCon
           auto view_call = CreateCollapsedTensorView(tensor, tensor_type, span);
           auto view_var =
               std::make_shared<Var>(assign->var_->name_hint_ + "_view2d", view_call->GetType(), span);
-          result.push_back(std::make_shared<AssignStmt>(view_var, view_call, span));
+          result.push_back(std::make_shared<AssignStmt>(view_var, view_call, assign->span_));
 
           auto row_offset = CollapseLeadingOffsetsToRow(offsets_tuple->elements_, tensor_type->shape_, span);
           sub_args[0] = view_var;
@@ -782,7 +805,7 @@ std::vector<StmtPtr> TransformBody(const std::vector<StmtPtr>& stmts, FlattenCon
         auto reshape_shape = MakeShapeTupleFromInts({merged, last}, span);
         auto reshape_call = op_registry.Create("tile.reshape", {new_args[0], reshape_shape}, span);
         auto flat_var = std::make_shared<Var>("flat_tile", reshape_call->GetType(), span);
-        result.push_back(std::make_shared<AssignStmt>(flat_var, reshape_call, span));
+        result.push_back(std::make_shared<AssignStmt>(flat_var, reshape_call, assign->span_));
         new_args[0] = flat_var;
       }
 
@@ -901,7 +924,7 @@ std::vector<StmtPtr> TransformBody(const std::vector<StmtPtr>& stmts, FlattenCon
         };
         auto scratch_create = op_registry.Create("tile.create", {scratch_shape}, scratch_kw, span);
         auto scratch_var = std::make_shared<Var>("transpose_tmp", scratch_create->GetType(), span);
-        result.push_back(std::make_shared<AssignStmt>(scratch_var, scratch_create, span));
+        result.push_back(std::make_shared<AssignStmt>(scratch_var, scratch_create, assign->span_));
 
         auto t_call =
             op_registry.Create("tile.transpose", {in, call->args_[1], call->args_[2], scratch_var}, span);
@@ -962,14 +985,15 @@ std::vector<StmtPtr> TransformBody(const std::vector<StmtPtr>& stmts, FlattenCon
 }  // namespace rewrite_internal
 
 FunctionPtr Rewrite(const FunctionPtr& func) {
-  const auto& span = func->span_;
   auto& op_registry = OpRegistry::GetInstance();
 
   rewrite_internal::FlattenContext ctx;
 
   auto body_stmts = FlattenToStmts(func->body_);
-  auto new_stmts = rewrite_internal::TransformBody(body_stmts, ctx, op_registry, span);
-  auto new_body = SeqStmts::Flatten(std::move(new_stmts), span);
+  auto new_stmts = rewrite_internal::TransformBody(body_stmts, ctx, op_registry);
+  // The body SeqStmts wrapper spans the whole function; the ops inside it carry
+  // their own statements' spans (see TransformBody).
+  auto new_body = SeqStmts::Flatten(std::move(new_stmts), func->span_);
 
   // return_types_ are unchanged: InCore functions return tensors (not tiles),
   // and this pass only flattens tile ops. Tensor types are never modified.

--- a/src/ir/transforms/flatten_tile_nd_to_2d/transpose.cpp
+++ b/src/ir/transforms/flatten_tile_nd_to_2d/transpose.cpp
@@ -114,7 +114,7 @@ NdTransposeResult LowerNdTranspose(const AssignStmtPtr& assign, const CallPtr& c
     auto reshape_shape = std::make_shared<MakeTuple>(Make2DShapeExprs(merged, last, span), span);
     auto reshape = op_registry.Create("tile.reshape", {operand, reshape_shape}, span);
     auto reshape_var = std::make_shared<Var>("trans_in_2d", reshape->GetType(), span);
-    out.stmts.push_back(std::make_shared<AssignStmt>(reshape_var, reshape, span));
+    out.stmts.push_back(std::make_shared<AssignStmt>(reshape_var, reshape, assign->span_));
     operand = reshape_var;
     operand_type = As<TileType>(operand->GetType());
   }
@@ -127,7 +127,7 @@ NdTransposeResult LowerNdTranspose(const AssignStmtPtr& assign, const CallPtr& c
   };
   auto create_out = op_registry.Create("tile.create", {out_shape}, create_kw, span);
   VarPtr out_var = std::make_shared<Var>(assign->var_->name_hint_, create_out->GetType(), span);
-  out.stmts.push_back(std::make_shared<AssignStmt>(out_var, create_out, span));
+  out.stmts.push_back(std::make_shared<AssignStmt>(out_var, create_out, assign->span_));
 
   // Pre-create one flat scratch pool [batch_count*A, B] sliced per batch.
   // pto.ttrans requires a scratch operand whose type matches the source page's;
@@ -148,7 +148,7 @@ NdTransposeResult LowerNdTranspose(const AssignStmtPtr& assign, const CallPtr& c
   };
   auto tmp_pool_create = op_registry.Create("tile.create", {tmp_pool_shape}, tmp_pool_kw, span);
   VarPtr tmp_pool_var = std::make_shared<Var>("trans_tmp_pool", tmp_pool_create->GetType(), span);
-  out.stmts.push_back(std::make_shared<AssignStmt>(tmp_pool_var, tmp_pool_create, span));
+  out.stmts.push_back(std::make_shared<AssignStmt>(tmp_pool_var, tmp_pool_create, assign->span_));
 
   auto axis0_expr = std::make_shared<ConstInt>(0, DataType::INDEX, span);
   auto axis1_expr = std::make_shared<ConstInt>(1, DataType::INDEX, span);
@@ -161,7 +161,7 @@ NdTransposeResult LowerNdTranspose(const AssignStmtPtr& assign, const CallPtr& c
     auto in_shape = MakeShapeTupleFromInts({a, b}, span);
     auto slice = op_registry.Create("tile.slice", {operand, in_shape, in_offset}, span);
     ExprPtr src_page = std::make_shared<Var>("trans_page_" + suffix, slice->GetType(), span);
-    out.stmts.push_back(std::make_shared<AssignStmt>(As<Var>(src_page), slice, span));
+    out.stmts.push_back(std::make_shared<AssignStmt>(As<Var>(src_page), slice, assign->span_));
 
     // Slice the i-th 2D scratch page [A, B] from the flat tmp pool (subview with
     // STATIC valid [A, B], matching the source page's type exactly).
@@ -169,19 +169,19 @@ NdTransposeResult LowerNdTranspose(const AssignStmtPtr& assign, const CallPtr& c
     auto tmp_shape = MakeShapeTupleFromInts({a, b}, span);
     auto tmp_slice = op_registry.Create("tile.slice", {tmp_pool_var, tmp_shape, tmp_offset}, span);
     ExprPtr scratch_page = std::make_shared<Var>("trans_tmp_" + suffix, tmp_slice->GetType(), span);
-    out.stmts.push_back(std::make_shared<AssignStmt>(As<Var>(scratch_page), tmp_slice, span));
+    out.stmts.push_back(std::make_shared<AssignStmt>(As<Var>(scratch_page), tmp_slice, assign->span_));
 
     // Transpose the page [A, B] -> [B, A]. Ranks match, CHECK passes.
     auto transpose =
         op_registry.Create("tile.transpose", {src_page, axis0_expr, axis1_expr, scratch_page}, span);
     auto transpose_var = std::make_shared<Var>("trans_" + suffix, transpose->GetType(), span);
-    out.stmts.push_back(std::make_shared<AssignStmt>(transpose_var, transpose, span));
+    out.stmts.push_back(std::make_shared<AssignStmt>(transpose_var, transpose, assign->span_));
 
     // Assemble the [B, A] result into the flat output at row offset i*B.
     auto out_offset = MakeShapeTupleFromInts({i * b, 0}, span);
     auto assemble = op_registry.Create("tile.assemble", {out_var, transpose_var, out_offset}, span);
     out_var = std::make_shared<Var>(out_var->name_hint_, assemble->GetType(), span);
-    out.stmts.push_back(std::make_shared<AssignStmt>(out_var, assemble, span));
+    out.stmts.push_back(std::make_shared<AssignStmt>(out_var, assemble, assign->span_));
   }
 
   out.output_var = out_var;

--- a/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
+++ b/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
@@ -5245,5 +5245,99 @@ class TestConvertCrossCoreSplitOps:
         ir.assert_structural_equal(explicit_call.type, auto_call.type)
 
 
+class TestSynthesizedOpSpans:
+    """Every Call the pass synthesizes carries a precise span, not the ``def`` line.
+
+    Downstream ``CHECK_SPAN`` diagnostics, IR-trace reports and (eventually) MLIR
+    ``loc()`` all read the span off the ``Call``. Stamping the enclosing
+    function's span on synthesized ops silently reports the ``def`` line for
+    every one of them, so the attribution is pinned here.
+    """
+
+    # A single-op InCore kernel: the pass synthesizes an entry tile.load for `x`
+    # and an exit tile.store for the returned tile, and converts tensor.exp.
+    _SOURCE = (
+        "@pl.program\n"
+        "class Before:\n"
+        "    @pl.function(type=pl.FunctionType.InCore)\n"
+        "    def kernel(self, x: pl.Tensor[[128, 128], pl.FP32]) -> pl.Tensor[[128, 128], pl.FP32]:\n"
+        "        t = pl.tensor.exp(x)\n"
+        "        return t\n"
+    )
+
+    @staticmethod
+    def _parse_before() -> ir.Program:
+        parsed = parse(TestSynthesizedOpSpans._SOURCE)
+        assert isinstance(parsed, ir.Program)
+        return parsed
+
+    @staticmethod
+    def _pos(span: ir.Span) -> tuple[int, int, int, int]:
+        """Full span position — the signature is one line, so the column matters."""
+        return (span.begin_line, span.begin_column, span.end_line, span.end_column)
+
+    @staticmethod
+    def _calls_by_op(func: ir.Function) -> dict[str, list[tuple[ir.Call, ir.Stmt]]]:
+        """Map op name -> [(call, enclosing stmt)] over a function body."""
+        found: dict[str, list[tuple[ir.Call, ir.Stmt]]] = {}
+
+        def walk(stmt: ir.Stmt) -> None:
+            if isinstance(stmt, ir.SeqStmts):
+                for inner in stmt.stmts:
+                    walk(inner)
+                return
+            value = None
+            if isinstance(stmt, ir.AssignStmt):
+                value = stmt.value
+            elif isinstance(stmt, ir.EvalStmt):
+                value = stmt.expr
+            if isinstance(value, ir.Call):
+                found.setdefault(value.op.name, []).append((value, stmt))
+            for attr in ("body", "then_body", "else_body"):
+                sub = getattr(stmt, attr, None)
+                if sub is not None:
+                    walk(sub)
+
+        walk(func.body)
+        return found
+
+    def test_entry_load_and_exit_store_do_not_carry_the_function_span(self):
+        """The synthesized entry ``tile.load`` / exit ``tile.store`` are attributed
+        to the parameter and the ``return`` that motivated them."""
+        after = passes.convert_tensor_to_tile_ops()(self._parse_before())
+        func = _require_function(after, "kernel")
+        calls = self._calls_by_op(func)
+
+        # The entry load is attributed to the parameter declaration it loads.
+        (load_call, load_stmt) = calls[ir.get_op("tile.load").name][0]
+        assert self._pos(load_call.span) == self._pos(func.params[0].span)
+        assert self._pos(load_call.span) != self._pos(func.span)
+        assert self._pos(load_call.span) == self._pos(load_stmt.span)
+
+        # The exit store is attributed to the `return` that motivated it.
+        (store_call, store_stmt) = calls[ir.get_op("tile.store").name][0]
+        assert self._pos(store_call.span) == self._pos(store_stmt.span)
+        assert self._pos(store_call.span) != self._pos(func.span)
+        assert store_call.span.begin_line > func.span.begin_line
+
+    def test_converted_body_op_keeps_its_own_statement_span(self):
+        """A converted ``tensor.*`` -> ``tile.*`` op keeps the source span of the
+        statement it came from."""
+        before = self._parse_before()
+        exp_before = _find_first_call_to(_require_function(before, "kernel"), ir.get_op("tensor.exp").name)
+        assert exp_before is not None
+
+        after = passes.convert_tensor_to_tile_ops()(before)
+        func = _require_function(after, "kernel")
+        (exp_after, exp_stmt) = self._calls_by_op(func)[ir.get_op("tile.exp").name][0]
+
+        # Unchanged from the tensor-level original, and still nested inside its
+        # own statement (the Call spans the RHS, the AssignStmt spans `t = ...`).
+        assert self._pos(exp_after.span) == self._pos(exp_before.span)
+        assert exp_stmt.span.begin_line <= exp_after.span.begin_line
+        assert exp_after.span.end_line <= exp_stmt.span.end_line
+        assert exp_after.span.begin_line > func.span.begin_line
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/ir/transforms/test_flatten_tile_nd_to_2d.py
+++ b/tests/ut/ir/transforms/test_flatten_tile_nd_to_2d.py
@@ -3361,5 +3361,394 @@ class TestFlattenTileNdTo2DSharedBatchMatmulOperand:
         passes.verify_properties(props, after, "test_shared_operand_with_nested_use_not_dropped")
 
 
+class TestFlattenTileNdTo2DSpans:
+    """Re-created tile ops keep the span of the statement they came from.
+
+    The pass rebuilds every tile op it touches through ``OpRegistry::Create``.
+    Handing those rebuilds the enclosing function's span would report the ``def``
+    line for the whole InCore body — degrading every later ``CHECK_SPAN``
+    diagnostic, IR-trace report and MLIR ``loc()``, and merging distinct source
+    sites in span-keyed consumers such as the PH001 perf hint.
+    """
+
+    @staticmethod
+    def _assigned_calls(func: ir.Function) -> list[tuple[ir.Call, ir.Stmt]]:
+        """Every ``AssignStmt``-bound ``Call`` in ``func``, paired with its statement."""
+        found: list[tuple[ir.Call, ir.Stmt]] = []
+
+        def walk(stmt: ir.Stmt) -> None:
+            if isinstance(stmt, ir.SeqStmts):
+                for inner in stmt.stmts:
+                    walk(inner)
+                return
+            if isinstance(stmt, ir.AssignStmt) and isinstance(stmt.value, ir.Call):
+                found.append((stmt.value, stmt))
+            for attr in ("body", "then_body", "else_body"):
+                sub = getattr(stmt, attr, None)
+                if sub is not None:
+                    walk(sub)
+
+        walk(func.body)
+        return found
+
+    def test_rebuilt_ops_keep_their_statement_span(self):
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                x: pl.Tensor[[2, 3, 4], pl.FP32],
+                out_0: pl.Out[pl.Tensor[[2, 3, 4], pl.FP32]],
+            ) -> pl.Tensor[[2, 3, 4], pl.FP32]:
+                x_tile: pl.Tile[[2, 3, 4], pl.FP32] = pl.tile.load(x, [0, 0, 0], [2, 3, 4])
+                a_tile: pl.Tile[[2, 3, 4], pl.FP32] = pl.tile.exp(x_tile)
+                b_tile: pl.Tile[[2, 3, 4], pl.FP32] = pl.tile.add(a_tile, x_tile)
+                out_0: pl.Tensor[[2, 3, 4], pl.FP32] = pl.tile.store(b_tile, [0, 0, 0], out_0)
+                return out_0
+
+            @pl.function
+            def main(self, x: pl.Tensor[[2, 3, 4], pl.FP32]) -> pl.Tensor[[2, 3, 4], pl.FP32]:
+                out_0: pl.Tensor[[2, 3, 4], pl.FP32] = pl.create_tensor([2, 3, 4], dtype=pl.FP32)
+                y: pl.Tensor[[2, 3, 4], pl.FP32] = self.main_incore_0(x, out_0)
+                return y
+
+        after = passes.flatten_tile_nd_to_2d()(Before)
+        fn = after.get_function("main_incore_0")
+        assert fn is not None
+
+        seen = [(call.op.name, call.span, stmt.span) for call, stmt in self._assigned_calls(fn)]
+        assert seen, "no tile Calls found after flatten"
+
+        for op_name, call_span, stmt_span in seen:
+            # Nested inside its own statement — and therefore not the `def` line,
+            # since every body statement sits strictly below the signature.
+            assert stmt_span.begin_line <= call_span.begin_line, (
+                f"{op_name} span {call_span} escapes its statement {stmt_span}"
+            )
+            assert call_span.end_line <= stmt_span.end_line, (
+                f"{op_name} span {call_span} escapes its statement {stmt_span}"
+            )
+            assert call_span.begin_line > fn.span.begin_line, (
+                f"{op_name} was stamped with the function span {fn.span}"
+            )
+
+        # The rewritten body ops land on distinct source lines rather than all
+        # collapsing onto one — the property span-keyed consumers depend on.
+        body_lines = {call_span.begin_line for _, call_span, _ in seen}
+        assert len(body_lines) == len(seen), f"tile ops share source lines: {sorted(body_lines)}"
+
+    def test_rebuilt_op_keeps_the_rhs_call_span_not_the_statement_span(self):
+        """A rebuilt op takes the RHS ``Call``'s span, not the ``AssignStmt``'s.
+
+        The two coincide only when the RHS starts at the assignment. Wrapping the
+        RHS in parentheses puts the Call on a *later line* than the statement, so
+        attributing rebuilt ops to the statement would move them off the operator
+        they came from.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                x: pl.Tensor[[2, 3, 4], pl.FP32],
+                out_0: pl.Out[pl.Tensor[[2, 3, 4], pl.FP32]],
+            ) -> pl.Tensor[[2, 3, 4], pl.FP32]:
+                x_tile: pl.Tile[[2, 3, 4], pl.FP32] = pl.tile.load(x, [0, 0, 0], [2, 3, 4])
+                a_tile: pl.Tile[[2, 3, 4], pl.FP32] = (
+                    # The Call starts here, one line below the assignment.
+                    pl.tile.exp(x_tile)
+                )
+                out_0: pl.Tensor[[2, 3, 4], pl.FP32] = pl.tile.store(a_tile, [0, 0, 0], out_0)
+                return out_0
+
+            @pl.function
+            def main(self, x: pl.Tensor[[2, 3, 4], pl.FP32]) -> pl.Tensor[[2, 3, 4], pl.FP32]:
+                out_0: pl.Tensor[[2, 3, 4], pl.FP32] = pl.create_tensor([2, 3, 4], dtype=pl.FP32)
+                y: pl.Tensor[[2, 3, 4], pl.FP32] = self.main_incore_0(x, out_0)
+                return y
+
+        before_fn = Before.get_function("main_incore_0")
+        assert before_fn is not None
+        exp_before, exp_stmt_before = next(
+            (call, stmt)
+            for call, stmt in self._assigned_calls(before_fn)
+            if call.op.name == ir.get_op("tile.exp").name
+        )
+        # The fixture only means anything if the two spans really differ by line.
+        assert exp_before.span.begin_line > exp_stmt_before.span.begin_line, (
+            "fixture must put the RHS Call on a later line than its AssignStmt"
+        )
+
+        after = passes.flatten_tile_nd_to_2d()(Before)
+        fn = after.get_function("main_incore_0")
+        assert fn is not None
+        exp_after, exp_stmt_after = next(
+            (call, stmt)
+            for call, stmt in self._assigned_calls(fn)
+            if call.op.name == ir.get_op("tile.exp").name
+        )
+
+        assert exp_after.span.begin_line == exp_before.span.begin_line, (
+            f"rebuilt tile.exp reported line {exp_after.span.begin_line}, expected the "
+            f"RHS Call's line {exp_before.span.begin_line} (statement is at "
+            f"{exp_stmt_before.span.begin_line})"
+        )
+        # The statement itself still carries the statement's own span.
+        assert exp_stmt_after.span.begin_line == exp_stmt_before.span.begin_line
+
+    def test_auxiliary_synthesized_statements_keep_the_assignment_span(self):
+        """Statements the lowering inserts alongside an op keep the assignment span.
+
+        A natural rank-N Mat ``tile.load`` lowers to ND2NZ, which needs a 2D source,
+        so the lowering materialises its own ``tensor.view`` statement. That
+        statement is not the operator — statement-level verifiers and
+        ``INTERNAL_CHECK_SPAN(..., assign->span_)`` consumers read it — so it must
+        report the assignment, even though the ``tensor.view`` *Call* inside it
+        correctly follows the load's RHS Call.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                lhs: pl.Tensor[[2, 16, 128], pl.FP16],
+                rhs: pl.Tensor[[2, 128, 64], pl.FP16],
+                out_0: pl.Out[pl.Tensor[[2, 16, 64], pl.FP32]],
+            ) -> pl.Tensor[[2, 16, 64], pl.FP32]:
+                lhs_tile: pl.Tile[[2, 16, 128], pl.FP16] = (
+                    # Keep this comment: it stops `ruff format` collapsing the
+                    # wrapper that puts the Call on a later line than its
+                    # assignment. The test asserts that premise below.
+                    pl.load(lhs, [0, 0, 0], [2, 16, 128], target_memory=pl.MemorySpace.Mat)
+                )
+                rhs_tile: pl.Tile[[2, 128, 64], pl.FP16] = pl.load(
+                    rhs, [0, 0, 0], [2, 128, 64], target_memory=pl.MemorySpace.Mat
+                )
+                mm_tile: pl.Tile[[2, 16, 64], pl.FP32] = pl.tile.batch_matmul(lhs_tile, rhs_tile)
+                out_0 = pl.store(mm_tile, [0, 0, 0], out_0)
+                return out_0
+
+            @pl.function
+            def main(
+                self,
+                lhs: pl.Tensor[[2, 16, 128], pl.FP16],
+                rhs: pl.Tensor[[2, 128, 64], pl.FP16],
+            ) -> pl.Tensor[[2, 16, 64], pl.FP32]:
+                out_0 = pl.create_tensor([2, 16, 64], dtype=pl.FP32)
+                y = self.main_incore_0(lhs, rhs, out_0)
+                return y
+
+        before_fn = Before.get_function("main_incore_0")
+        assert before_fn is not None
+        load_before, load_stmt_before = next(
+            (c, s) for c, s in self._assigned_calls(before_fn) if c.op.name == ir.get_op("tile.load").name
+        )
+        assert load_before.span.begin_line > load_stmt_before.span.begin_line, (
+            "fixture must put the load's RHS Call on a later line than its assignment"
+        )
+
+        after = passes.flatten_tile_nd_to_2d()(Before)
+        fn = after.get_function("main_incore_0")
+        assert fn is not None
+
+        views = [(c, s) for c, s in self._assigned_calls(fn) if c.op.name == ir.get_op("tensor.view").name]
+        assert views, "a natural rank-3 Mat load should materialise a tensor.view"
+        matched = [(c, s) for c, s in views if s.span.begin_line == load_stmt_before.span.begin_line]
+        assert matched, (
+            "no synthesized tensor.view statement reported the wrapped load's assignment line "
+            f"{load_stmt_before.span.begin_line}; got "
+            f"{sorted(s.span.begin_line for _, s in views)}"
+        )
+        for view_call, view_stmt in matched:
+            assert view_stmt.span.begin_line == load_stmt_before.span.begin_line, (
+                f"synthesized tensor.view statement reported line {view_stmt.span.begin_line}, "
+                f"expected the assignment's line {load_stmt_before.span.begin_line}"
+            )
+            assert view_call.span.begin_line == load_before.span.begin_line, (
+                f"synthesized tensor.view op reported line {view_call.span.begin_line}, "
+                f"expected the RHS Call's line {load_before.span.begin_line}"
+            )
+
+    def test_delegated_lowering_statements_keep_the_assignment_span(self):
+        """Statements the delegated lowering helpers emit keep the assignment span.
+
+        ``LowerBatchMatmul`` / ``LowerBatchMatmulAcc`` / ``ExtractBatchPage`` /
+        ``LowerNdTranspose`` receive the Call span for the ops they synthesize, but
+        each ``AssignStmt`` they emit is a statement and must report the source
+        assignment. This wraps the batch-matmul RHS so the two are on different
+        lines, then checks *every* statement the lowering produced — the helpers
+        emit slices, moves, casts, matmuls and assembles, so a single site slipping
+        back to the Call span is caught here rather than one review round at a time.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                lhs: pl.Tensor[[2, 16, 128], pl.FP16],
+                rhs: pl.Tensor[[2, 128, 64], pl.FP16],
+                out_0: pl.Out[pl.Tensor[[2, 16, 64], pl.FP32]],
+            ) -> pl.Tensor[[2, 16, 64], pl.FP32]:
+                lhs_tile: pl.Tile[[2, 16, 128], pl.FP16] = pl.load(
+                    lhs, [0, 0, 0], [2, 16, 128], target_memory=pl.MemorySpace.Mat
+                )
+                rhs_tile: pl.Tile[[2, 128, 64], pl.FP16] = pl.load(
+                    rhs, [0, 0, 0], [2, 128, 64], target_memory=pl.MemorySpace.Mat
+                )
+                mm_tile: pl.Tile[[2, 16, 64], pl.FP32] = (
+                    # Keep this comment: it stops `ruff format` collapsing the
+                    # wrapper that puts the Call on a later line than its
+                    # assignment. The test asserts that premise below.
+                    pl.tile.batch_matmul(lhs_tile, rhs_tile)
+                )
+                out_0 = pl.store(mm_tile, [0, 0, 0], out_0)
+                return out_0
+
+            @pl.function
+            def main(
+                self,
+                lhs: pl.Tensor[[2, 16, 128], pl.FP16],
+                rhs: pl.Tensor[[2, 128, 64], pl.FP16],
+            ) -> pl.Tensor[[2, 16, 64], pl.FP32]:
+                out_0 = pl.create_tensor([2, 16, 64], dtype=pl.FP32)
+                y = self.main_incore_0(lhs, rhs, out_0)
+                return y
+
+        before_fn = Before.get_function("main_incore_0")
+        assert before_fn is not None
+        mm_before, mm_stmt_before = next(
+            (c, s)
+            for c, s in self._assigned_calls(before_fn)
+            if c.op.name == ir.get_op("tile.batch_matmul").name
+        )
+        mm_call_line = mm_before.span.begin_line
+        mm_stmt_line = mm_stmt_before.span.begin_line
+        assert mm_call_line > mm_stmt_line, (
+            "fixture must put the batch_matmul RHS Call on a later line than its assignment"
+        )
+
+        after = passes.flatten_tile_nd_to_2d()(Before)
+        fn = after.get_function("main_incore_0")
+        assert fn is not None
+
+        # Statements the batch-matmul lowering emitted, identified by carrying a
+        # span from that source statement's line range.
+        lowered = [
+            (c, s) for c, s in self._assigned_calls(fn) if s.span.begin_line in (mm_stmt_line, mm_call_line)
+        ]
+        assert lowered, "batch_matmul lowering should emit statements"
+        offenders = [(c.op.name, s.span.begin_line) for c, s in lowered if s.span.begin_line != mm_stmt_line]
+        assert not offenders, (
+            f"these lowered statements reported the Call line {mm_call_line} instead of the "
+            f"assignment line {mm_stmt_line}: {offenders}"
+        )
+
+    def test_fused_batch_matmul_stores_keep_the_consumed_store_span(self):
+        """Per-batch stores fused into a batch_matmul keep the *store's* span.
+
+        ``LowerBatchMatmul`` folds a consuming ``tile.store`` into per-batch
+        stores and the caller then skips the original store statement, so the
+        skipped statement's location must survive on what replaces it —
+        attributing it to the matmul line would drop it for the whole fused path.
+
+        Within that, the op/statement split applies: synthesized ops and their
+        argument expressions (including the optional tensor-rank shape tuple and
+        each of its elements) follow the store's ``Call`` span, while synthesized
+        ``AssignStmt`` nodes follow its assignment. The fixture wraps the store's
+        RHS so the two are on different lines and the split is observable.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                lhs: pl.Tensor[[2, 16, 128], pl.FP16],
+                rhs: pl.Tensor[[2, 128, 64], pl.FP16],
+                out_0: pl.Out[pl.Tensor[[2, 16, 64], pl.FP32]],
+            ) -> pl.Tensor[[2, 16, 64], pl.FP32]:
+                lhs_tile: pl.Tile[[2, 16, 128], pl.FP16] = pl.load(
+                    lhs, [0, 0, 0], [2, 16, 128], target_memory=pl.MemorySpace.Mat
+                )
+                rhs_tile: pl.Tile[[2, 128, 64], pl.FP16] = pl.load(
+                    rhs, [0, 0, 0], [2, 128, 64], target_memory=pl.MemorySpace.Mat
+                )
+                mm_tile: pl.Tile[[2, 16, 64], pl.FP32] = pl.tile.batch_matmul(lhs_tile, rhs_tile)
+                out_0 = (
+                    # Keep this comment: it is what stops `ruff format` collapsing
+                    # the wrapper, which is what puts the store's Call on a later
+                    # line than its assignment. The test asserts that premise, so a
+                    # collapse fails loudly rather than silently passing.
+                    pl.store(mm_tile, [0, 0, 0], out_0)
+                )
+                return out_0
+
+            @pl.function
+            def main(
+                self,
+                lhs: pl.Tensor[[2, 16, 128], pl.FP16],
+                rhs: pl.Tensor[[2, 128, 64], pl.FP16],
+            ) -> pl.Tensor[[2, 16, 64], pl.FP32]:
+                out_0 = pl.create_tensor([2, 16, 64], dtype=pl.FP32)
+                y = self.main_incore_0(lhs, rhs, out_0)
+                return y
+
+        # Expected line comes from the pre-pass IR, so it is not derived from the
+        # pass output it is checking.
+        before_fn = Before.get_function("main_incore_0")
+        assert before_fn is not None
+        before_calls = self._assigned_calls(before_fn)
+        store_before, store_stmt_before = next(
+            (c, s) for c, s in before_calls if c.op.name == ir.get_op("tile.store").name
+        )
+        matmul_before = next(c for c, _ in before_calls if c.op.name == ir.get_op("tile.batch_matmul").name)
+        assert store_before.span.begin_line != matmul_before.span.begin_line, (
+            "fixture must put the store and the matmul on different lines"
+        )
+        # The op-vs-statement split is only observable when these differ.
+        assert store_before.span.begin_line > store_stmt_before.span.begin_line, (
+            "fixture must put the store's RHS Call on a later line than its assignment"
+        )
+
+        after = passes.flatten_tile_nd_to_2d()(Before)
+        fn = after.get_function("main_incore_0")
+        assert fn is not None
+
+        fused_stmts = [s for c, s in self._assigned_calls(fn) if c.op.name == ir.get_op("tile.store").name]
+        for stmt in fused_stmts:
+            assert stmt.span.begin_line == store_stmt_before.span.begin_line, (
+                f"fused store statement reported line {stmt.span.begin_line}, expected the "
+                f"consumed assignment's line {store_stmt_before.span.begin_line}"
+            )
+
+        fused_stores = [c for c, _ in self._assigned_calls(fn) if c.op.name == ir.get_op("tile.store").name]
+        assert len(fused_stores) == 2, f"expected one fused store per batch, got {len(fused_stores)}"
+        for store in fused_stores:
+            assert store.span.begin_line == store_before.span.begin_line, (
+                f"fused store reported line {store.span.begin_line}, expected the consumed "
+                f"store's line {store_before.span.begin_line} (matmul is at "
+                f"{matmul_before.span.begin_line})"
+            )
+
+            # A rank>2 target adds the optional tensor-rank shape tuple. Its
+            # elements are synthesized too, so they must not keep the matmul span
+            # while the tuple around them carries the store's.
+            assert len(store.args) == 4, (
+                f"rank-3 fused store should carry the optional shape tuple, got {len(store.args)} args"
+            )
+            shape_tuple = store.args[3]
+            assert isinstance(shape_tuple, ir.MakeTuple)
+            assert shape_tuple.span.begin_line == store_before.span.begin_line
+            assert shape_tuple.elements, "shape tuple must not be empty"
+            for element in shape_tuple.elements:
+                assert element.span.begin_line == store_before.span.begin_line, (
+                    f"fused store shape element reported line {element.span.begin_line}, "
+                    f"expected the consumed store's line {store_before.span.begin_line}"
+                )
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/ir/verifier/test_perf_hint_tile_innermost_dim.py
+++ b/tests/ut/ir/verifier/test_perf_hint_tile_innermost_dim.py
@@ -315,16 +315,20 @@ def _site_of(diag: passes.Diagnostic) -> tuple[str, int, int, str]:
 
 
 def test_dedup_collapses_repeated_site_a3():
-    """Repeated identical transfers at one source span collapse to a single hint
-    with an occurrence count (issue #1305 ask 4).
+    """Post-pipeline hits are keyed one-per-source-site (issue #1305 ask 4).
 
-    A per-iteration ``pl.load`` inside a ``pl.range`` loop expands, through the
-    default pipeline, into several identical GM<->Vec transfers that all carry
-    the originating source span. The verifier must collapse them into one
-    diagnostic with an ``(N occurrences ...)`` count rather than emit N separate
-    identical hints, and no two surviving hits may share a ``(file, line, col,
-    op)`` site. This is the post-pipeline shape the unit fixtures above (single
-    hand-built ops) cannot exercise, so the full pipeline is run here.
+    Runs the default pipeline over a loop kernel and asserts that both loads
+    survive as their own hit and that no two surviving hits share a
+    ``(file, line, col, op)`` site. This is the post-pipeline shape the unit
+    fixtures above (single hand-built ops) cannot exercise, so the full pipeline
+    is run here.
+
+    Both assertions are needed. ``pl.range`` is not unrolled, so the entry load
+    and the per-iteration load are one transfer each at two distinct source
+    lines. A pass that coarsened synthesized ops onto the enclosing function's
+    ``def`` span would merge them into a single bogus "2 occurrences at this
+    source location" hit for two unrelated loads — which the uniqueness check
+    alone would still accept, since one load site plus one store site is unique.
     """
     _activate_a3()
     rows, inner = 64, 64  # fp32 inner = 256B < 512B (a3) -> fires; rows give the loop distinct offsets
@@ -339,9 +343,6 @@ def test_dedup_collapses_repeated_site_a3():
         ) -> pl.Tensor[[16, inner], pl.FP32]:
             acc: pl.Tile[[16, inner], pl.FP32] = pl.load(x, [0, 0], [16, inner])
             for i in pl.range(4):
-                # Distinct offset per iteration (not loop-invariant, so it is not
-                # CSE'd) but identical shape/dtype/memory and source span — the
-                # exact "same site, same facts, many copies" case dedup targets.
                 t: pl.Tile[[16, inner], pl.FP32] = pl.load(x, [i * 16, 0], [16, inner])
                 acc = pl.add(acc, t)
             return pl.store(acc, [0, 0], out)
@@ -353,17 +354,18 @@ def test_dedup_collapses_repeated_site_a3():
     assert len(perf_hints) >= 1
     assert all(d.hint_code == "PH001" for d in perf_hints)
 
+    sites = [_site_of(d) for d in perf_hints]
+
+    # Both loads must survive as their own hit. Site uniqueness alone cannot see
+    # the coarsening regression: if the two loads shared the `def` span they
+    # would dedup into ONE tile.load hit, and a set of one load site plus one
+    # store site is still trivially unique. Pinning the count is what fails.
+    load_sites = {site for site in sites if site[3] == "tile.load"}
+    assert len(load_sites) == 2, f"expected the entry and per-iteration load as distinct sites: {sites}"
+
     # Dedup invariant: every surviving hit is at a distinct (file, line, col, op)
     # site — identical transfers were collapsed, not emitted repeatedly.
-    sites = [_site_of(d) for d in perf_hints]
     assert len(sites) == len(set(sites)), f"hits not deduplicated per site: {sites}"
-
-    # The repeated per-iteration load must have collapsed into one counted hit
-    # (the count text only appears when count > 1), proving the collapse path ran
-    # rather than the loads slipping through as separate identical hints.
-    collapsed = [d for d in perf_hints if "occurrences at this source location" in d.message]
-    messages = [d.message for d in perf_hints]
-    assert len(collapsed) >= 1, f"expected a collapsed '(N occurrences)' hit, got {messages}"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Two InCore lowering passes stamped the enclosing function's span on the tile ops
they synthesize, so those `Call` nodes reported the `def` line instead of the
statement they came from. `FlattenTileNdTo2D` is the dominant one — it hands
`func->span_` to `TransformBody` and reuses it for every node it re-creates, and
`ResolveBackendOpLayouts` then inherits the coarsened spans for the
`tile.reshape` ops it inserts. `ConvertTensorToTileOps` has the same defect on a
smaller scale, on the entry `tile.load` it synthesizes per converted tensor
parameter and the exit `tile.store` it synthesizes per returned tile.

Each synthesized op is now attributed to the node that motivated it: the
statement being rewritten, the parameter an entry load reads, or the `return` an
exit store serves. Only nodes that genuinely belong to the whole function (the
rebuilt `Function` and its body `SeqStmts`) keep the function span. Nothing
about IR structure, types, or op selection changes — only which source location
each op carries.

This matters beyond diagnostic quality. Every consumer that reads a span off a
`Call` was degraded: `CHECK_SPAN` / `INTERNAL_CHECK_SPAN` failures raised by any
later pass, IR trace reports, and MLIR `loc()` in the generated `.pto`. It also
produced an outright wrong result in one place — the PH001 perf hint
deduplicates by source site, so an entry load and a loop load on two different
source lines merged into a single `(2 occurrences at this source location)` hint
describing two unrelated transfers.

Measured over post-pipeline IR, counting `Call` spans nested inside their own
statement. `PagedAttention` was measured on both builds; the other two were
measured only after the fix.

| Program | Before | After |
| --- | --- | --- |
| `test_pto_codegen_paged_attn.py` `PagedAttention` | 34/99 | 99/99 |
| `test_pto_codegen_paged_attn.py` `UnalignedPagedAttention` | not measured | 20/20 |
| Tensor-level InCore kernel (entry-load / exit-store path) | not measured | 9/9 |

Per-pass measurement on `PagedAttention` locates the loss precisely: spans stay
100% precise through `ConvertTensorToTileOps`, drop to 2/46 at
`FlattenTileNdTo2D`, and lose a further 22 at `ResolveBackendOpLayouts`.

## Changes

- `src/ir/transforms/flatten_tile_nd_to_2d/rewrite.cpp`: the rewrite loop binds
  `span` from the statement it is rewriting, so every re-created op and the
  batch-matmul / transpose lowering helpers it delegates to inherit the precise
  location. The function-span parameter became unused and was removed;
  `Rewrite` still spans the body `SeqStmts` wrapper with the function span.
- `src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp`: the entry `tile.load`
  carries the parameter declaration's span; the exit `tile.store` and the `Out`
  param it writes carry the `return`'s span. Body-op conversion already threaded
  `call->span_` and is unchanged.
- `tests/ut/ir/transforms/test_flatten_tile_nd_to_2d.py`,
  `tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py`: regression tests
  pinning the attribution. Both were confirmed to fail against the pre-fix build.
- `tests/ut/ir/verifier/test_perf_hint_tile_innermost_dim.py`:
  `test_dedup_collapses_repeated_site_a3` asserted the `(N occurrences)` collapse
  that only the coarsened spans produced — its `pl.range(4)` loop is not
  unrolled, so there is one transfer per site and the collapse it observed was
  the two unrelated loads described above. That assertion is dropped; the test
  keeps its per-source-site distinctness check, which this fix is what makes
  meaningful. **Follow-up:** no test now covers the dedup collapse path itself. A
  `pl.unroll(4)` variant does exercise it correctly (4 genuinely identical loads
  at one source line collapse to one counted hit, entry load staying separate) if
  that coverage is wanted back.
- `docs/en/dev/02-error-handling.md`, `docs/zh/dev/02-error-handling.md`: a
  "Span attribution in passes" section documenting the rule, since the same
  `func->span_` shortcut is available in every pass.

## Verification

Run at the pushed head `b431a84`, after rebase onto `upstream/main`:

- `cmake --build build --parallel`: exit 0, no errors or warnings.
- `pytest tests/ut/ -n auto --maxprocesses 8`: exit 0, 9442 passed, 3 skipped.
- `ctest` (in `build/`): exit 0, 1/1 passed.
- `tests/lint/{check_headers,check_english_only,check_docs_en_zh_parity,check_docs_nav,check_op_name_literals,check_no_broad_raises,check_docs_symbol_coverage}.py`:
  exit 0 each.
- `clang-format --dry-run --Werror` on both changed `.cpp` files: exit 0.
- `ruff check tests/` and `ruff format --check`: exit 0, 89 files already formatted.

Regression coverage was validated in both directions: the two new span tests
were run against a build with the fix reverted and both failed, then passed with
it restored.