### PR TITLE
feat(runtime): correlate distributed dispatch traces

### DIFF
--- a/docs/en/user/distributed/03-execution.md
+++ b/docs/en/user/distributed/03-execution.md
@@ -73,6 +73,17 @@ Use `handle.result(timeout)` or its alias `handle.wait(timeout)` to wait and
 raise the cached dispatch error. `handle.done` reports terminal completion
 without blocking.
 
+For trace correlation, `handle.identity` returns a read-only
+`DistributedRunIdentity` containing the PyPTO `dispatch_id`, its bounded
+metadata `frame_id`, and the accepted Simpler `simpler_run_id`. The same values
+are attached to the `pypto_pipeline.submit`,
+`pypto_pipeline.native_acceptance`, and
+`pypto_pipeline.result_completion` `[STRACE]` spans. These run-level spans use
+zero for the downstream `dispatch_id`, `slot_id`, and `generation`; Simpler's
+spans carry the concrete native values under the same `run_id`. Diagnostic
+two-pass capture does not publish an asynchronous dispatch and therefore
+returns a completed handle whose identity is `None`.
+
 ```python
 with compiled.prepare() as rt:
     first = rt.submit(compiled, input_a, weight, output_a)

--- a/docs/zh/user/distributed/03-execution.md
+++ b/docs/zh/user/distributed/03-execution.md
@@ -65,6 +65,15 @@ worker 固定拥有两个可复用的分发元数据帧。前两次提交可以�
 使用 `handle.result(timeout)` 或其别名 `handle.wait(timeout)` 等待完成并抛出缓存的
 分发错误；`handle.done` 可无阻塞地报告是否已经结束。
 
+为了关联 trace，`handle.identity` 会返回只读的 `DistributedRunIdentity`，其中包含
+PyPTO `dispatch_id`、有界元数据 `frame_id`，以及 Simpler 接受该任务后分配的
+`simpler_run_id`。`pypto_pipeline.submit`、
+`pypto_pipeline.native_acceptance` 和
+`pypto_pipeline.result_completion` 三个 `[STRACE]` span 也携带相同的值。
+这些 run 层 span 的下游 `dispatch_id`、`slot_id` 和 `generation` 均为 0；Simpler
+span 会在同一个 `run_id` 下携带具体的 native 值。诊断用双遍采集不会发布异步任务，
+因此其已完成 handle 的 identity 为 `None`。
+
 ```python
 with compiled.prepare() as rt:
     first = rt.submit(compiled, input_a, weight, output_a)

--- a/python/pypto/runtime/__init__.py
+++ b/python/pypto/runtime/__init__.py
@@ -26,7 +26,12 @@ Example::
 
 from .bench import BenchmarkStats, TraceInvocation, TraceSpan, benchmark
 from .device_tensor import DeviceTensor, StackedDeviceTensor
-from .distributed_runner import DistributedRunHandle, DistributedWorker, execute_distributed_compiled
+from .distributed_runner import (
+    DistributedRunHandle,
+    DistributedRunIdentity,
+    DistributedWorker,
+    execute_distributed_compiled,
+)
 from .log_config import _ensure_configured as _ensure_log_configured
 from .log_config import configure_log
 from .log_config import current_level as log_level
@@ -55,6 +60,7 @@ __all__ = [
     "StackedDeviceTensor",
     "DistributedWorker",
     "DistributedRunHandle",
+    "DistributedRunIdentity",
     "RegistrationHandle",
     "RunConfig",
     "RunResult",

--- a/python/pypto/runtime/distributed_runner.py
+++ b/python/pypto/runtime/distributed_runner.py
@@ -103,7 +103,7 @@ def _emit_pipeline_span(
             f"run_id={identity.simpler_run_id or 0} dispatch_id=0 slot_id=0 generation=0 "
             f"pypto_dispatch_id={identity.dispatch_id} pypto_frame_id={identity.frame_id}"
         )
-        _emit_host_span(name, 0, 0, 0, timestamp_ns, duration_ns, attributes)
+        _emit_host_span(name, identity.simpler_run_id or 0, 0, 0, timestamp_ns, duration_ns, attributes)
     except Exception:  # noqa: BLE001 - diagnostics must not change dispatch outcome
         logger.debug("Could not emit PyPTO pipeline trace span", exc_info=True)
 

--- a/python/pypto/runtime/distributed_runner.py
+++ b/python/pypto/runtime/distributed_runner.py
@@ -62,6 +62,52 @@ _DTYPE_MAP: dict[str, tuple[type, torch.dtype]] = {
 _PERSISTENT_ZERO_CHUNK_BYTES = 1 << 20
 
 
+@dataclass(frozen=True)
+class DistributedRunIdentity:
+    """Stable correlation identity for one accepted distributed dispatch."""
+
+    dispatch_id: int
+    frame_id: int
+    simpler_run_id: int | None
+
+
+def _read_simpler_run_id(native_handle: Any) -> int | None:
+    """Read the run identity retained by Simpler's accepted handle."""
+    for name in ("run_id", "_run_id"):
+        try:
+            run_id = getattr(native_handle, name, None)
+        except Exception:  # noqa: BLE001 - correlation cannot change dispatch outcome
+            continue
+        if isinstance(run_id, int) and run_id > 0:
+            return run_id
+    return None
+
+
+def _emit_pipeline_span(
+    name: str,
+    identity: DistributedRunIdentity,
+    timestamp_ns: int,
+    duration_ns: int,
+) -> None:
+    """Emit one PyPTO lifecycle span through Simpler's shared host sink."""
+    try:
+        from _task_interface import (  # noqa: PLC0415  # pyright: ignore[reportMissingImports]
+            HOST_STRACE_ENABLED,
+            _emit_host_span,
+            _host_span_sink_available,
+        )
+
+        if not HOST_STRACE_ENABLED or not _host_span_sink_available():
+            return
+        attributes = (
+            f"run_id={identity.simpler_run_id or 0} dispatch_id=0 slot_id=0 generation=0 "
+            f"pypto_dispatch_id={identity.dispatch_id} pypto_frame_id={identity.frame_id}"
+        )
+        _emit_host_span(name, 0, 0, 0, timestamp_ns, duration_ns, attributes)
+    except Exception:  # noqa: BLE001 - diagnostics must not change dispatch outcome
+        logger.debug("Could not emit PyPTO pipeline trace span", exc_info=True)
+
+
 def _resolve_persistent_window_reset(persistent: bool, reset_persistent_windows: bool | None) -> bool:
     """Resolve the retained-window reset policy.
 
@@ -115,6 +161,11 @@ class DistributedRunHandle:
         self._native_handle = native_handle
         self._frame: _DispatchFrame | None = frame
         self._dispatch_id = dispatch_id
+        self._identity: DistributedRunIdentity | None = DistributedRunIdentity(
+            dispatch_id=dispatch_id,
+            frame_id=frame.slot_id,
+            simpler_run_id=_read_simpler_run_id(native_handle) if native_handle is not None else None,
+        )
         self._postprocess = postprocess
         self._cv = threading.Condition()
         self._wait_in_progress = False
@@ -141,12 +192,31 @@ class DistributedRunHandle:
         handle._native_handle = None
         handle._frame = None
         handle._dispatch_id = 0
+        handle._identity = None
         handle._postprocess = None
         handle._cv = threading.Condition()
         handle._wait_in_progress = False
         handle._terminal = True
         handle._error = error
         return handle
+
+    @property
+    def identity(self) -> DistributedRunIdentity | None:
+        """Read-only dispatch/frame identity linked to the accepted Simpler run."""
+        with self._cv:
+            return self._identity
+
+    def _accept_native_handle(self, native_handle: Any) -> None:
+        """Retain one accepted native handle and publish its correlation id."""
+        with self._cv:
+            identity = self._identity
+            assert identity is not None
+            self._native_handle = native_handle
+            self._identity = DistributedRunIdentity(
+                dispatch_id=identity.dispatch_id,
+                frame_id=identity.frame_id,
+                simpler_run_id=_read_simpler_run_id(native_handle),
+            )
 
     @property
     def done(self) -> bool:
@@ -221,6 +291,10 @@ class DistributedRunHandle:
             self._cv.notify_all()
         if worker is not None and frame is not None:
             worker._retire_dispatch_handle(self, frame, error)
+        identity = self.identity
+        if identity is not None:
+            completion_ns = time.monotonic_ns()
+            _emit_pipeline_span("pypto_pipeline.result_completion", identity, completion_ns, 0)
         if error is not None:
             raise error
 
@@ -1934,6 +2008,7 @@ class DistributedWorker(Worker):
     ) -> None:
         """Install or recover the native handle for one published frame."""
         accepted_before = self._accepted_native_handles()
+        acceptance_start_ns = time.monotonic_ns()
         native_handle: Any | None = None
         try:
             native_handle = self._submit_prepared_native(state, tensors, call_config, frame.keepalive)
@@ -1946,9 +2021,27 @@ class DistributedWorker(Worker):
                     self._persistent_error_reported = True
                 self._discard_unsubmitted_dispatch_handle(handle, frame)
             else:
-                handle._native_handle = native_handle
+                handle._accept_native_handle(native_handle)
+                acceptance_end_ns = time.monotonic_ns()
+                identity = handle.identity
+                assert identity is not None
+                _emit_pipeline_span(
+                    "pypto_pipeline.native_acceptance",
+                    identity,
+                    acceptance_start_ns,
+                    acceptance_end_ns - acceptance_start_ns,
+                )
             raise
-        handle._native_handle = native_handle
+        handle._accept_native_handle(native_handle)
+        acceptance_end_ns = time.monotonic_ns()
+        identity = handle.identity
+        assert identity is not None
+        _emit_pipeline_span(
+            "pypto_pipeline.native_acceptance",
+            identity,
+            acceptance_start_ns,
+            acceptance_end_ns - acceptance_start_ns,
+        )
 
     def _dispatch_prepared(
         self,
@@ -1965,6 +2058,15 @@ class DistributedWorker(Worker):
             [] if keepalive is None else keepalive,
         )
         native_handle.result()
+
+    @staticmethod
+    def _trace_submit_if_accepted(handle: DistributedRunHandle, start_ns: int) -> None:
+        """Record submit completion only after native ownership is published."""
+        identity = handle.identity
+        if identity is None or identity.simpler_run_id is None:
+            return
+        end_ns = time.monotonic_ns()
+        _emit_pipeline_span("pypto_pipeline.submit", identity, start_ns, end_ns - start_ns)
 
     # ------------------------------------------------------------------
     # Device memory primitives
@@ -2280,6 +2382,7 @@ class DistributedWorker(Worker):
                 f"got {len(args)}. Parameters: {[p.name for p in param_infos]}"
             )
 
+        submit_start_ns = time.monotonic_ns()
         frame, dispatch_id = self._acquire_dispatch_frame()
         try:
             call_config, dfx_base, two_pass_swimlane = self._prepare_dispatch_config(
@@ -2350,7 +2453,12 @@ class DistributedWorker(Worker):
                 self._discard_unsubmitted_dispatch_handle(handle, frame)
                 raise
 
-            self._submit_native_dispatch(handle, frame, state, tensors, call_config)
+            try:
+                self._submit_native_dispatch(handle, frame, state, tensors, call_config)
+            except BaseException:
+                self._trace_submit_if_accepted(handle, submit_start_ns)
+                raise
+            self._trace_submit_if_accepted(handle, submit_start_ns)
             return handle
         except BaseException:
             if frame.handle is None and frame.in_use:

--- a/tests/ut/runtime/test_distributed_worker.py
+++ b/tests/ut/runtime/test_distributed_worker.py
@@ -197,7 +197,7 @@ class TestAsyncDispatchHandle:
         assert emitted == [
             (
                 "pypto_pipeline.submit",
-                0,
+                83,
                 0,
                 0,
                 100,

--- a/tests/ut/runtime/test_distributed_worker.py
+++ b/tests/ut/runtime/test_distributed_worker.py
@@ -43,11 +43,13 @@ from pypto.runtime.bench import (
 )
 from pypto.runtime.distributed_runner import (
     DistributedRunHandle,
+    DistributedRunIdentity,
     DistributedWorker,
     _assemble_chip_callables,
     _clear_dfx_dispatch_dirs,
     _collect_l3_swimlane,
     _construct_worker,
+    _emit_pipeline_span,
     _make_call_config,
     _reset_dfx_dispatch_state,
     _submit_chip,
@@ -84,11 +86,13 @@ class _ControlledNativeHandle:
         self,
         error: BaseException | None = None,
         on_result: Callable[[], None] | None = None,
+        run_id: int | None = None,
     ) -> None:
         self._terminal = threading.Event()
         self.result_started = threading.Event()
         self.error = error
         self._on_result = on_result
+        self._run_id = run_id
 
     @property
     def done(self) -> bool:
@@ -178,6 +182,91 @@ class TestSetupOnce:
 
 
 class TestAsyncDispatchHandle:
+    def test_pipeline_span_uses_shared_strace_identity_grammar(self):
+        emitted: list[tuple[Any, ...]] = []
+        task_interface = SimpleNamespace(
+            HOST_STRACE_ENABLED=True,
+            _host_span_sink_available=lambda: True,
+            _emit_host_span=lambda *args: emitted.append(args),
+        )
+        identity = DistributedRunIdentity(dispatch_id=5, frame_id=1, simpler_run_id=83)
+
+        with patch.dict(sys.modules, {"_task_interface": task_interface}):
+            _emit_pipeline_span("pypto_pipeline.submit", identity, 100, 25)
+
+        assert emitted == [
+            (
+                "pypto_pipeline.submit",
+                0,
+                0,
+                0,
+                100,
+                25,
+                "run_id=83 dispatch_id=0 slot_id=0 generation=0 pypto_dispatch_id=5 pypto_frame_id=1",
+            )
+        ]
+
+    def test_pipeline_span_failure_does_not_escape(self):
+        task_interface = SimpleNamespace(
+            HOST_STRACE_ENABLED=True,
+            _host_span_sink_available=lambda: True,
+            _emit_host_span=MagicMock(side_effect=RuntimeError("trace sink failed")),
+        )
+
+        with patch.dict(sys.modules, {"_task_interface": task_interface}):
+            _emit_pipeline_span(
+                "pypto_pipeline.submit",
+                DistributedRunIdentity(dispatch_id=1, frame_id=0, simpler_run_id=2),
+                100,
+                25,
+            )
+
+    def test_handle_exposes_stable_dispatch_to_simpler_identity(self, patched_setup):
+        m = patched_setup
+        compiled = _fake_compiled([_param("a", [16, 16])], [])
+        native = _ControlledNativeHandle(run_id=41)
+        m["submit_dispatch"].return_value = native
+        rt = DistributedWorker(compiled)
+
+        handle = rt.submit(compiled, DeviceTensor(0x1000, (16, 16), torch.float32))
+
+        assert handle.identity == DistributedRunIdentity(dispatch_id=1, frame_id=0, simpler_run_id=41)
+        native.complete()
+        handle.result()
+        assert handle.identity == DistributedRunIdentity(dispatch_id=1, frame_id=0, simpler_run_id=41)
+        rt.close()
+
+    def test_submit_acceptance_and_completion_share_trace_identity(self, patched_setup):
+        m = patched_setup
+        compiled = _fake_compiled([_param("a", [16, 16])], [])
+        native = _ControlledNativeHandle(run_id=73)
+        m["submit_dispatch"].return_value = native
+        spans: list[tuple[str, DistributedRunIdentity, int, int]] = []
+        rt = DistributedWorker(compiled)
+
+        def record_span(
+            name: str,
+            identity: DistributedRunIdentity,
+            timestamp_ns: int,
+            duration_ns: int,
+        ) -> None:
+            spans.append((name, identity, timestamp_ns, duration_ns))
+
+        with patch("pypto.runtime.distributed_runner._emit_pipeline_span", side_effect=record_span):
+            handle = rt.submit(compiled, DeviceTensor(0x1000, (16, 16), torch.float32))
+            native.complete()
+            handle.result()
+
+        identity = DistributedRunIdentity(dispatch_id=1, frame_id=0, simpler_run_id=73)
+        assert [span[0] for span in spans] == [
+            "pypto_pipeline.native_acceptance",
+            "pypto_pipeline.submit",
+            "pypto_pipeline.result_completion",
+        ]
+        assert all(span[1] == identity for span in spans)
+        assert all(span[2] > 0 and span[3] >= 0 for span in spans)
+        rt.close()
+
     def test_submit_returns_handle_and_retires_frame_on_result(self, patched_setup):
         m = patched_setup
         compiled = _fake_compiled([_param("a", [16, 16])], [])
@@ -403,9 +492,10 @@ class TestAsyncDispatchHandle:
     def test_interrupted_native_handle_publication_keeps_frame_until_close(self, patched_setup):
         m = patched_setup
         compiled = _fake_compiled([_param("a", [16, 16])], [])
-        native = _ControlledNativeHandle()
+        native = _ControlledNativeHandle(run_id=91)
         m["worker"]._accepted_run_handles = set()
         m["worker"]._hierarchical_start_cv = threading.Condition()
+        spans: list[tuple[str, DistributedRunIdentity, int, int]] = []
 
         def interrupt_after_acceptance(*_args):
             with m["worker"]._hierarchical_start_cv:
@@ -415,11 +505,29 @@ class TestAsyncDispatchHandle:
         m["submit_dispatch"].side_effect = interrupt_after_acceptance
         rt = DistributedWorker(compiled)
 
-        with pytest.raises(KeyboardInterrupt, match="after native acceptance"):
+        def record_span(
+            name: str,
+            identity: DistributedRunIdentity,
+            timestamp_ns: int,
+            duration_ns: int,
+        ) -> None:
+            spans.append((name, identity, timestamp_ns, duration_ns))
+
+        with (
+            patch("pypto.runtime.distributed_runner._emit_pipeline_span", side_effect=record_span),
+            pytest.raises(KeyboardInterrupt, match="after native acceptance"),
+        ):
             rt.submit(compiled, DeviceTensor(0x1000, (16, 16), torch.float32))
 
         assert len(rt._active_dispatch_handles) == 1
         assert sum(frame.in_use for frame in rt._dispatch_frames) == 1
+        assert [span[0] for span in spans] == [
+            "pypto_pipeline.native_acceptance",
+            "pypto_pipeline.submit",
+        ]
+        assert all(
+            span[1] == DistributedRunIdentity(dispatch_id=1, frame_id=0, simpler_run_id=91) for span in spans
+        )
         closer = threading.Thread(target=rt.close)
         closer.start()
         assert native.result_started.wait(timeout=2)


### PR DESCRIPTION
## Summary

- add a read-only `DistributedRunIdentity` that maps each PyPTO dispatch/frame to its accepted Simpler run
- emit `pypto_pipeline.submit`, `pypto_pipeline.native_acceptance`, and `pypto_pipeline.result_completion` through the shared STRACE host sink
- carry the canonical run-level `run_id / dispatch_id / slot_id / generation` fields together with `pypto_dispatch_id / pypto_frame_id`
- keep tracing best-effort and preserve the existing two-frame capacity, wait, error, interruption-recovery, and cleanup semantics

## Dependency

This trace bridge is based on the bounded distributed dispatch handles merged in #2270. It remains compatible with the current runtime pin; span emission activates when the Simpler host-span API from hw-native-sys/simpler#1811 is available. This PR does not change the runtime gitlink.

## Validation

- worktree build: 255/255 targets
- `tests/ut/runtime/test_distributed_worker.py`: 156 passed
- `tests/ut/runtime`: 549 passed, 50 skipped
- full `tests/ut`: 9398 passed, 57 skipped, with one existing unrelated `test_declared_memref.py` printer failure reproducible on current main
- Ruff, format, Pyright, documentation parity/navigation/symbol coverage, Markdown, headers, broad-exception, and operator-name checks passed
