### PR TITLE
fix(codegen): compile loop carries seeded by a literal

### DIFF
--- a/docs/en/dev/codegen/01-orchestration_codegen.md
+++ b/docs/en/dev/codegen/01-orchestration_codegen.md
@@ -403,6 +403,15 @@ for (int64_t i = 0; i < 4; i += 1) {
 
 Iter_args are initialized before the loop. `YieldStmt` updates are emitted at the end of each iteration.
 
+An `IterArg::initValue_` is usually an SSA `Var`, but any expression is legal —
+a scalar carry seeded by a constant (`acc: pl.Scalar[pl.INT64] = 0` before the
+loop, which `Simplify` propagates into the loop, or an explicit
+`pl.range(..., init_values=(0,))`) arrives as a `ConstInt`. Codegen emits the
+init expression directly (`int64_t acc__rv_v1 = 0;`); a trivial carry — one the
+body never rebinds — aliases both names straight to that expression instead. The
+one path that still requires the init to *name* something is the `ArrayType`
+carry copy-in, which indexes it slot-by-slot.
+
 ### IfStmt
 
 ```python

--- a/docs/zh/dev/codegen/01-orchestration_codegen.md
+++ b/docs/zh/dev/codegen/01-orchestration_codegen.md
@@ -392,6 +392,13 @@ for (int64_t i = 0; i < 4; i += 1) {
 
 迭代参数在循环前初始化。`YieldStmt` 更新在每次迭代末尾发出。
 
+`IterArg::initValue_` 通常是一个 SSA `Var`，但任意表达式都是合法的 —— 由常量播种的标量
+循环携带值（循环前的 `acc: pl.Scalar[pl.INT64] = 0`，`Simplify` 会将其传播进循环；或者显式
+写出的 `pl.range(..., init_values=(0,))`）会以 `ConstInt` 的形式到达。codegen 直接发出该
+初始化表达式（`int64_t acc__rv_v1 = 0;`）；对于循环体从不重新绑定的平凡携带值，两个名字都
+直接别名到该表达式。唯一仍要求初始值必须*命名*某个对象的路径是 `ArrayType` 携带值的拷入，
+它需要逐槽位索引该初始值。
+
 ### IfStmt
 
 ```python

--- a/examples/models/05_paged_attention_batch.py
+++ b/examples/models/05_paged_attention_batch.py
@@ -399,16 +399,10 @@ def BuildBatchPagedAttentionProgram(
             q_loop_cfg = (num_heads_cfg + q_tile - 1) // q_tile
 
             # Compute max_bn across all batches (mirrors C++ max_bn loop).
-            # The loop carries max_bn, so it must be seeded from a bound variable:
-            # batch 0 is peeled into the if/else phi and the loop starts at 1.
-            zero_bn_cfg: pl.Scalar[pl.INT64] = 0
-            if batch_cfg == 0:
-                max_bn: pl.Scalar[pl.INT64] = pl.yield_(zero_bn_cfg)
-            else:
-                first_seq = pl.tensor.read(context_lens, [0])
-                first_bn_cfg: pl.Scalar[pl.INT64] = (first_seq + block_size_cfg - 1) // block_size_cfg
-                max_bn: pl.Scalar[pl.INT64] = pl.yield_(first_bn_cfg)
-            for b in pl.range(1, batch_cfg):
+            # A loop carry may be seeded straight from a literal; codegen emits
+            # the constant as the carry's initializer.
+            max_bn: pl.Scalar[pl.INT64] = 0
+            for b in pl.range(batch_cfg):
                 cur_seq_b = pl.tensor.read(context_lens, [b])
                 bn_b = (cur_seq_b + block_size_cfg - 1) // block_size_cfg
                 max_bn = pl.max(max_bn, bn_b)  # type: ignore[reportArgumentType]

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -1730,6 +1730,19 @@ class ASTParser:
                     and value_expr.type.dtype == DataType.INDEX
                 ):
                     override_type = resolved
+        # A bare int literal parses as an untyped placeholder (``ConstInt(v,
+        # INDEX)`` — see ``_normalize_scalar_operand``), so the scalar branch
+        # above would otherwise bind an annotated Var to a constant of a
+        # different dtype: ``acc: pl.Scalar[pl.INT64] = 0`` produced
+        # ``AssignStmt(Var[INT64], ConstInt[INDEX])``, violating
+        # AssignTypeSymmetry. The mismatch only surfaces much later — Simplify
+        # propagates the constant into a loop's ``iter_arg`` init, where
+        # TypeCheck compares it against the declared carry dtype. Re-stamp the
+        # placeholder to the annotated dtype instead. The dtype stays integral:
+        # ``validate_annotation_consistency`` already rejected an int literal
+        # under a float annotation (float literals never carry INDEX).
+        if isinstance(override_type, ir.ScalarType) and isinstance(value_expr, ir.ConstInt):
+            value_expr = ir.ConstInt(value_expr.value, override_type.dtype, value_expr.span)
         # If annotation syntax determines the result type more precisely than the
         # raw call inference, rebuild the Call with that type so structural
         # equality sees the same IR after print→parse.

--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -713,14 +713,20 @@ class OrchestrationStmtCodegen : public CodegenBase {
       const auto& return_var = for_stmt->return_vars_[i];
       const bool is_rebind = carry_plans[i].is_rebind;
       const int64_t array_size = carry_plans[i].array_size;
-      std::string init_var_name = TryGetVarName(iter_arg->initValue_);
-      INTERNAL_CHECK_SPAN(!init_var_name.empty(), for_stmt->span_)
-          << "Internal error: ForStmt iter_arg initValue must be a variable, got non-variable expr";
+      // An init value is usually an SSA Var, but a scalar carry seeded by a
+      // constant reaches codegen as a bare expression: Simplify propagates
+      // ``acc: pl.Scalar[pl.INT64] = 0`` into the iter_arg, and
+      // ``pl.range(..., init_values=(0,))`` writes the literal directly. Both
+      // are legal IR, so emit the init expression instead of demanding an
+      // identifier. Only the ArrayType copy-in below genuinely needs a name.
+      const std::string init_emit_name = TryGetVarName(iter_arg->initValue_);
+      const bool init_is_var = !init_emit_name.empty();
       // Function tensor params get rewritten to `ext_<name>` in the emitted C++,
       // so the bare emit name is not a valid identifier when the init value is
       // a param. Apply the same translation as everything else that names a
       // tensor in the emitted code.
-      init_var_name = GetExternalTensorName(init_var_name);
+      const std::string init_var_name =
+          init_is_var ? GetExternalTensorName(init_emit_name) : GenerateExprString(iter_arg->initValue_);
 
       if (array_size > 0) {
         // ARRAY CARRY PATH — allocate ``PTO2TaskId <name>[N]`` and init it.
@@ -810,6 +816,12 @@ class OrchestrationStmtCodegen : public CodegenBase {
         if (init_carry) {
           carry_name = init_carry->array_name;
         } else {
+          // The copy-in indexes the init slot-by-slot (``src[i]``), so this is
+          // the one carry path that needs the init to name a backing array
+          // rather than be an arbitrary expression.
+          INTERNAL_CHECK_SPAN(init_is_var, for_stmt->span_)
+              << "Internal error: ArrayType iter_arg init value must be a variable naming a backing "
+              << "array, got " << iter_arg->initValue_->TypeName();
           carry_name = ReserveSyntheticEmitName(return_var->name_hint_);
           EmitIndentedLine(cpp_dtype + " " + carry_name + "[" + std::to_string(N) + "];");
 

--- a/tests/ut/codegen/test_orchestration_misc.py
+++ b/tests/ut/codegen/test_orchestration_misc.py
@@ -975,6 +975,101 @@ class TestScalarCarryPhiCodegen:
             if "out_b" in lhs and "out_c" in rhs and "out_b" not in rhs:
                 raise AssertionError(f"Wrong phi: out_b assigned from out_c value (scrambled):\n  {stripped}")
 
+    def test_literal_seeded_scalar_carry_emits_constant_init(self):
+        """A scalar carry seeded by a literal must compile, not raise InternalError.
+
+        ``max_bn = 0`` before the loop is a constant binding, so Simplify
+        propagates the literal into the ForStmt's ``init_values``: the iter_arg
+        init reaches codegen as a ``ConstInt``, not a ``Var``. The carry
+        declaration must emit the constant directly (``int64_t <carry> = 0;``).
+        """
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        @pl.program
+        class LiteralSeededCarry:
+            @pl.function(type=pl.FunctionType.AIV)
+            def kernel_add(
+                self,
+                a: pl.Tensor[[16, 16], pl.FP32],
+                output: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                a_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(a, [0, 0], [16, 16])
+                result: pl.Tile[[16, 16], pl.FP32] = pl.add(a_tile, a_tile)
+                out: pl.Tensor[[16, 16], pl.FP32] = pl.store(result, [0, 0], output)
+                return out
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orch(
+                self,
+                a: pl.Tensor[[16, 16], pl.FP32],
+                lens: pl.Tensor[[8], pl.INT64],
+                d: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                max_bn: pl.Scalar[pl.INT64] = 0
+                for b in pl.range(8):
+                    bn_b = pl.tensor.read(lens, [b])
+                    max_bn = pl.max(max_bn, bn_b)
+                for _ in pl.range(max_bn):
+                    d = self.kernel_add(a, d)
+                return d
+
+        transformed = PassManager.get_strategy(OptimizationStrategy.Default).run_passes(LiteralSeededCarry)
+        code = _generate_orch_code(transformed)
+
+        carry_decl = re.search(r"int64_t (max_bn\w*) = 0;", code)
+        assert carry_decl, "literal-seeded scalar carry must declare ``int64_t <carry> = 0;``\n" + code
+        carry = carry_decl.group(1)
+        # The carry feeds the running max, the yield writes back into it, and the
+        # post-loop use reads it as the second loop's trip count.
+        assert f"std::max<int64_t>({carry}," in code, "loop body must read the carry\n" + code
+        assert re.search(rf"^\s*{carry} = \w+;$", code, re.MULTILINE), (
+            "yield must write back into the carry\n" + code
+        )
+        assert f"< {carry};" in code, "post-loop use must read the carry variable\n" + code
+
+    def test_literal_seeded_trivial_carry_aliases_to_constant(self):
+        """A never-rebound carry seeded by a literal aliases straight to the constant.
+
+        ``pl.range(..., init_values=(4,))`` with a yield that returns the iter_arg
+        unchanged is a trivial alias: codegen declares no carry variable and
+        every use of the loop's return var emits the literal.
+        """
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        @pl.program
+        class TrivialLiteralCarry:
+            @pl.function(type=pl.FunctionType.AIV)
+            def kernel_add(
+                self,
+                a: pl.Tensor[[16, 16], pl.FP32],
+                output: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                a_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(a, [0, 0], [16, 16])
+                result: pl.Tile[[16, 16], pl.FP32] = pl.add(a_tile, a_tile)
+                out: pl.Tensor[[16, 16], pl.FP32] = pl.store(result, [0, 0], output)
+                return out
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orch(
+                self,
+                a: pl.Tensor[[16, 16], pl.FP32],
+                d: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                for _k, (acc,) in pl.range(8, init_values=(4,)):
+                    d = self.kernel_add(a, d)
+                    acc_out: pl.Scalar[pl.INT64] = pl.yield_(acc)
+                for _ in pl.range(acc_out):
+                    d = self.kernel_add(a, d)
+                return d
+
+        transformed = PassManager.get_strategy(OptimizationStrategy.Default).run_passes(TrivialLiteralCarry)
+        code = _generate_orch_code(transformed)
+
+        assert "acc" not in code, "trivial literal carry must not declare a carry variable\n" + code
+        assert "< 4;" in code, "post-loop use of the trivial carry must emit the literal 4\n" + code
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/ir/transforms/test_verify_assign_type_symmetry.py
+++ b/tests/ut/ir/transforms/test_verify_assign_type_symmetry.py
@@ -84,6 +84,38 @@ def test_parsed_clean_program_passes():
     assert len(_verify(Program)) == 0
 
 
+def test_annotated_scalar_literal_matches_annotation_dtype():
+    """``acc: pl.Scalar[pl.INT64] = 0`` binds an INT64 constant, not an INDEX one.
+
+    A bare int literal parses as the untyped placeholder ``ConstInt(v, INDEX)``.
+    The annotation retypes the Var, so the parser must re-stamp the constant to
+    match — otherwise the AssignStmt is asymmetric, and the mismatch resurfaces
+    far downstream (Simplify propagates the constant into a loop's ``iter_arg``
+    init, where TypeCheck compares it against the declared carry dtype).
+    """
+
+    @pl.program
+    class Program:
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def orch(self, d: pl.Out[pl.Tensor[[4], pl.FP32]]) -> pl.Tensor[[4], pl.FP32]:
+            acc: pl.Scalar[pl.INT64] = 0
+            for _k in pl.range(4):
+                acc = acc + 1
+            return d
+
+    assert len(_verify(Program)) == 0
+
+    orch = next(f for f in Program.functions.values() if f.name == "orch")
+    body = orch.body
+    assert isinstance(body, ir.SeqStmts)
+    seed = body.stmts[0]
+    assert isinstance(seed, ir.AssignStmt)
+    assert isinstance(seed.value, ir.ConstInt)
+    seed_type = seed.value.type
+    assert isinstance(seed_type, ir.ScalarType)
+    assert seed_type.dtype == DataType.INT64
+
+
 # --------------------------------------------------------------------------- #
 # Negative cases — each field divergence is detected.
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Summary

An Orchestration loop that carries a scalar seeded from a constant failed to compile, aborting with `Internal error: ForStmt iter_arg initValue must be a variable, got non-variable expr`. Writing `acc: pl.Scalar[pl.INT64] = 0` before a `pl.range` loop that accumulates into `acc` is legal DSL and traces fine, so the failure surfaced only at codegen and named an IR-internal concept the user never wrote. Two independent defects combined to produce it, and both are fixed here. Loop carries can now be seeded from a literal directly, instead of peeling the first iteration into an `if`/`else` phi to bind a real variable.

## Changes

- `src/codegen/orchestration/`: orchestration codegen no longer requires an `IterArg::initValue_` to be a `Var`. The IR permits any expression there — `docs/en/dev/ir/02-types.md` uses a `ConstInt` init in its canonical loop example, and `Simplify` propagates a constant scalar binding into the iter_arg — so a legal program was reaching an `INTERNAL_CHECK`. The init expression is now emitted directly (`int64_t acc__rv_v1 = 0;`), and a carry the body never rebinds aliases straight to that expression. The one path that still needs the init to *name* something is the `ArrayType` carry copy-in, which indexes it slot-by-slot; that keeps an internal check with a specific message.
- `python/pypto/language/parser/`: an annotated scalar assignment no longer binds a Var to a constant of a different dtype. A bare int literal parses as the untyped placeholder `ConstInt(v, INDEX)`, so `acc: pl.Scalar[pl.INT64] = 0` produced `AssignStmt(Var[INT64], ConstInt[INDEX])` and violated `AssignTypeSymmetry`. The mismatch stayed invisible until `Simplify` moved the constant into a loop's iter_arg init, where `TypeCheck` reported a carry dtype mismatch. The parser now re-stamps the placeholder with the annotated dtype.
- `examples/models/05_paged_attention_batch.py`: drops the peel workaround and its comment, which stated that a loop carry "must be seeded from a bound variable". `max_bn` is now seeded from `0` and the loop runs over the full batch range. The two forms are equivalent (`bn_b >= 0`, so folding batch 0 into the `max` changes nothing).
- `tests/ut/`: three regression tests — a rebinding literal-seeded carry and a trivial (never-rebound) one in the orchestration codegen tests, and an `AssignTypeSymmetry` test pinning the annotated-literal dtype.
- `docs/`: the orchestration codegen doc states the `IterArg` init contract, in both `en` and `zh`.

Only the codegen defect is reachable without verification enabled, which is why the original report showed just the internal error. Both fixes are needed for the program to compile under the default `PYPTO_VERIFY_LEVEL=roundtrip` the test suite runs with.

No interface change and no migration step. The peel idiom remains valid; it is simply no longer required. `examples/models/09_paged_attention_spmd.py` still uses it and was left alone.

## Verification

- `cmake --build build --parallel && python -m pytest tests/ut/ -n auto --maxprocesses 8 -q`: exit 0 — 9499 passed, 3 skipped. Run by the push transaction's validation runner against the pushed commit.
- `ctest -j8` (in `build/`): exit 0 — 1/1 passed.
- `ruff check` and `ruff format --check` on the changed Python files: exit 0.
- `tests/lint/check_english_only.py`, `check_headers.py`, `check_no_broad_raises.py`, `check_op_name_literals.py`, `check_docs_nav.py`, `check_docs_en_zh_parity.py`: exit 0 each.
- End-to-end: `python examples/models/05_paged_attention_batch.py` compiles through the Default pipeline (Ascend910B) and emits `int64_t max_bn__rv_v2 = 0;` in the generated orchestration C++.