### PR TITLE
fix(language): forward pad_value through pl.slice

### DIFF
--- a/python/pypto/ir/utils.py
+++ b/python/pypto/ir/utils.py
@@ -10,9 +10,11 @@
 """Utility functions for IR construction."""
 
 import inspect
+import os
 from collections.abc import Iterator, Sequence
 from contextlib import contextmanager
 from contextvars import ContextVar
+from pathlib import Path
 
 from pypto.pypto_core import DataType
 from pypto.pypto_core import ir as _ir
@@ -200,6 +202,46 @@ def has_partial_valid_region(expr: _ir.Expr) -> bool:
     if view is None:
         view = getattr(expr_type, "tile_view", None)
     return view is not None and bool(view.valid_shape)
+
+
+# Directory holding the ``pypto`` package, with a trailing separator so the
+# match is on a path *component*. A frame whose file lives under it is library
+# code, never the call site a user-facing warning should name. Without the
+# separator a sibling like ``<parent>/pypto_kernels/k.py`` would prefix-match
+# ``<parent>/pypto`` and a real user frame would be skipped.
+_PYPTO_PACKAGE_PREFIX = f"{Path(__file__).resolve().parent.parent}{os.sep}"
+
+
+def caller_warning_stacklevel() -> int:
+    """``stacklevel`` naming the nearest frame outside the ``pypto`` package.
+
+    A literal ``stacklevel=2`` names the *immediate* caller, which is user code
+    only when the warning site is called directly. Reached through a wrapper —
+    ``pl.slice`` dispatching to ``tensor.slice``, say — that frame is library
+    code instead, and the damage is worse than a misleading filename: Python's
+    default filter dedupes on ``(text, category, lineno)`` recorded in the
+    frame at ``stacklevel``, so every user call site collapses onto one fixed
+    library line and only the first warning of many is ever shown.
+
+    Walking out to the first non-``pypto`` frame keeps one warning per real
+    call site through any depth of forwarding. Call it from the frame that
+    invokes :func:`warnings.warn`.
+
+    Returns:
+        A ``stacklevel`` for :func:`warnings.warn`, at least 1
+    """
+    frame = inspect.currentframe()
+    if frame is not None:
+        frame = frame.f_back  # the caller, i.e. the frame that will warn
+    level = 1
+    while frame is not None:
+        if not frame.f_code.co_filename.startswith(_PYPTO_PACKAGE_PREFIX):
+            return level
+        frame = frame.f_back
+        level += 1
+    # Every frame is library code (e.g. the DSL parser drives the wrapper with
+    # no user frame below it). Name the outermost one rather than a bare 1.
+    return max(level - 1, 1)
 
 
 def _to_int32_scalar(value: int | _ir.Expr, span: _ir.Span) -> _ir.Expr:

--- a/python/pypto/language/op/tensor_ops.py
+++ b/python/pypto/language/op/tensor_ops.py
@@ -124,7 +124,7 @@ __all__ = [
 ]
 
 from pypto.ir.op import tensor_ops as _ir_ops
-from pypto.ir.utils import _normalize_expr, has_partial_valid_region
+from pypto.ir.utils import _normalize_expr, caller_warning_stacklevel, has_partial_valid_region
 from pypto.pypto_core import DataType
 from pypto.pypto_core import ir as _ir_core
 from pypto.pypto_core.ir import AtomicType, Expr, MemorySpace, PadValue, PtrType, TensorLayout
@@ -473,7 +473,9 @@ def slice(
             f"If you intend to narrow the valid region later via "
             f"tensor.set_validshape, you can ignore this warning; otherwise "
             f"pass valid_shape=... to tensor.slice.",
-            stacklevel=2,
+            # Not a literal 2: pl.slice forwards here, and a fixed level would
+            # name the dispatcher and collapse every call site's warning.
+            stacklevel=caller_warning_stacklevel(),
         )
 
     tensor_expr = tensor.unwrap()

--- a/python/pypto/language/op/tile_ops.py
+++ b/python/pypto/language/op/tile_ops.py
@@ -165,7 +165,12 @@ __all__ = [
 ]
 
 from pypto.ir.op import tile_ops as _ir_ops
-from pypto.ir.utils import _get_span_or_capture, _normalize_expr, has_partial_valid_region
+from pypto.ir.utils import (
+    _get_span_or_capture,
+    _normalize_expr,
+    caller_warning_stacklevel,
+    has_partial_valid_region,
+)
 from pypto.pypto_core import DataType
 from pypto.pypto_core import ir as _ir_core
 from pypto.pypto_core.ir import (
@@ -1930,7 +1935,9 @@ def slice(
             f"If you intend to narrow the valid region later via "
             f"tile.set_validshape, you can ignore this warning; otherwise "
             f"pass valid_shape=... to tile.slice.",
-            stacklevel=2,
+            # Not a literal 2: pl.slice forwards here, and a fixed level would
+            # name the dispatcher and collapse every call site's warning.
+            stacklevel=caller_warning_stacklevel(),
         )
 
     tile_expr = tile.unwrap()

--- a/python/pypto/language/op/unified_ops.py
+++ b/python/pypto/language/op/unified_ops.py
@@ -831,6 +831,7 @@ def slice(
     offset: Sequence[IntLike],
     valid_shape: Sequence[IntLike] | None = None,
     drop_dims: Sequence[int | _ir_core.Expr] | None = None,
+    pad_value: PadValue | int | float | None = None,
     clamp: bool = False,
 ) -> T:
     """Slice operation, dispatched by input type.
@@ -842,6 +843,14 @@ def slice(
     reduction); each must be a static unit dim of ``shape`` that is still fully
     valid after that intersection. ``None`` / ``[]`` drops nothing.
 
+    ``pad_value`` sets the padding mode for elements outside the effective valid
+    region, on either path. ``None`` carries the source's mode through. Accepts
+    ``PadValue.zero`` / ``PadValue.max`` / ``PadValue.min``, or the literal
+    sugars ``0``, ``math.inf``, ``-math.inf`` (same spelling as :func:`fillpad`).
+    It only bites when the valid region is smaller than ``shape`` — which an
+    explicit ``valid_shape``, a partially-valid source, or (Tensor-only)
+    ``clamp=True`` can each bring about; passing it otherwise warns.
+
     ``clamp`` sanctions a window that runs off the end of the source: by default
     the slice asserts ``offset + shape`` stays inside the source and is rejected
     when that provably fails, whereas ``clamp=True`` lets the window overhang and
@@ -849,7 +858,7 @@ def slice(
     Tensor — an on-chip tile window has nothing that could clamp it.
     """
     if isinstance(input, Tensor):
-        return _tensor.slice(input, shape, offset, valid_shape, drop_dims, clamp=clamp)
+        return _tensor.slice(input, shape, offset, valid_shape, drop_dims, pad_value, clamp=clamp)
     if isinstance(input, Tile):
         if clamp:
             raise TypeError(
@@ -858,7 +867,7 @@ def slice(
                 "Clamp the read at the tensor boundary instead — pl.load(..., clamp=True) or "
                 "pl.slice(tensor, ..., clamp=True) — and slice the resulting tile in bounds."
             )
-        return _tile.slice(input, shape, offset, valid_shape, drop_dims)
+        return _tile.slice(input, shape, offset, valid_shape, drop_dims, pad_value)
     raise TypeError(f"pl.slice: expected Tensor or Tile, got {type(input).__name__}")
 
 

--- a/tests/ut/language/test_unified_ops.py
+++ b/tests/ut/language/test_unified_ops.py
@@ -14,6 +14,11 @@ using the explicit ``pl.tensor.X`` / ``pl.tile.X`` API — then asserts
 they produce structurally equal IR.
 """
 
+import os
+import pathlib
+import warnings
+
+import pypto.ir.utils as pypto_ir_utils
 import pypto.language as pl
 import pypto.language.op as language_op
 import pytest
@@ -1679,6 +1684,203 @@ class TestUnifiedOpsCrossPathKwargs:
         ir.assert_structural_equal(unified.unwrap(), explicit.unwrap())
         # The binary-tree form is distinguishable from the sequential one.
         assert not ir.structural_equal(unified.unwrap(), pl.tile.col_sum(t).unwrap())
+
+
+class TestUnifiedSlicePadValue:
+    """``pl.slice`` forwards ``pad_value``, which both dispatch paths honour.
+
+    ``clamp`` is the only slice kwarg one path cannot honour; ``pad_value``
+    exists at both levels, so it is plain forwarding rather than a cross-path
+    guard. Each test pairs the structural match against the explicit call with
+    a negative assertion that the no-``pad_value`` IR differs — otherwise the
+    match would stay green if both sides dropped the kwarg.
+    """
+
+    def _pad_of(self, value: Tensor | Tile) -> ir.PadValue:
+        """Padding mode recorded on a sliced value's view."""
+        value_type = value.unwrap().type
+        view = getattr(value_type, "tensor_view", None)
+        if view is None:
+            view = getattr(value_type, "tile_view", None)
+        assert view is not None, "a narrowed slice must carry a view"
+        return view.pad
+
+    def test_tensor_path_forwards_pad_value(self):
+        x = _tensor("x", [16, 32])
+
+        unified = unified_ops.slice(x, [8, 32], [0, 0], valid_shape=[8, 8], pad_value=ir.PadValue.min)
+        explicit = pl.tensor.slice(x, [8, 32], [0, 0], valid_shape=[8, 8], pad_value=ir.PadValue.min)
+
+        ir.assert_structural_equal(unified.unwrap(), explicit.unwrap())
+        assert self._pad_of(unified) == ir.PadValue.min
+        unpadded = pl.tensor.slice(x, [8, 32], [0, 0], valid_shape=[8, 8])
+        assert not ir.structural_equal(unified.unwrap(), unpadded.unwrap())
+
+    def test_tile_path_forwards_pad_value(self):
+        t = _tile("t", [16, 32])
+
+        unified = unified_ops.slice(t, [8, 32], [0, 0], valid_shape=[8, 8], pad_value=ir.PadValue.min)
+        explicit = pl.tile.slice(t, [8, 32], [0, 0], valid_shape=[8, 8], pad_value=ir.PadValue.min)
+
+        ir.assert_structural_equal(unified.unwrap(), explicit.unwrap())
+        assert self._pad_of(unified) == ir.PadValue.min
+        unpadded = pl.tile.slice(t, [8, 32], [0, 0], valid_shape=[8, 8])
+        assert not ir.structural_equal(unified.unwrap(), unpadded.unwrap())
+
+    def test_literal_sugar_forwards(self):
+        """The ``0`` / ``inf`` sugars resolve on the unified path too."""
+        x = _tensor("x", [16, 32])
+
+        unified = unified_ops.slice(x, [8, 32], [0, 0], valid_shape=[8, 8], pad_value=0)
+        explicit = pl.tensor.slice(x, [8, 32], [0, 0], valid_shape=[8, 8], pad_value=ir.PadValue.zero)
+
+        ir.assert_structural_equal(unified.unwrap(), explicit.unwrap())
+        assert self._pad_of(unified) == ir.PadValue.zero
+
+    def test_pad_value_binds_sixth_positional(self):
+        """Positional order matches ``pl.tensor.slice`` — pad_value precedes clamp."""
+        x = _tensor("x", [16, 32])
+
+        unified = unified_ops.slice(x, [8, 32], [0, 0], [8, 8], None, ir.PadValue.max)
+        explicit = pl.tensor.slice(x, [8, 32], [0, 0], [8, 8], None, ir.PadValue.max)
+
+        ir.assert_structural_equal(unified.unwrap(), explicit.unwrap())
+        assert self._pad_of(unified) == ir.PadValue.max
+
+    def test_pad_value_rides_alongside_clamp(self):
+        """clamp narrows the valid region, so pad_value has something to paint."""
+        x = _tensor("x", [16, 32])
+
+        unified = unified_ops.slice(x, [16, 32], [8, 0], pad_value=ir.PadValue.max, clamp=True)
+        explicit = pl.tensor.slice(x, [16, 32], [8, 0], pad_value=ir.PadValue.max, clamp=True)
+
+        ir.assert_structural_equal(unified.unwrap(), explicit.unwrap())
+        assert self._pad_of(unified) == ir.PadValue.max
+
+    @pytest.mark.parametrize("kind", ["tensor", "tile"])
+    def test_omitted_pad_value_is_unchanged(self, kind):
+        """The default stays byte-identical to the pre-``pad_value`` behaviour."""
+        # One shared source Var — structural equality matches Vars by pointer.
+        if kind == "tensor":
+            src: Tensor | Tile = _tensor("x", [16, 32])
+            explicit = pl.tensor.slice(src, [8, 32], [0, 0], valid_shape=[8, 8])
+        else:
+            src = _tile("t", [16, 32])
+            explicit = pl.tile.slice(src, [8, 32], [0, 0], valid_shape=[8, 8])
+
+        unified = unified_ops.slice(src, [8, 32], [0, 0], valid_shape=[8, 8])
+        with_none = unified_ops.slice(src, [8, 32], [0, 0], valid_shape=[8, 8], pad_value=None)
+
+        ir.assert_structural_equal(unified.unwrap(), explicit.unwrap())
+        ir.assert_structural_equal(with_none.unwrap(), explicit.unwrap())
+
+    @pytest.mark.parametrize("kind", ["tensor", "tile"])
+    def test_pad_value_without_narrowing_still_warns(self, kind):
+        """The underlying no-op warning is not swallowed by the dispatcher."""
+        src: Tensor | Tile = _tensor("x", [16, 32]) if kind == "tensor" else _tile("t", [16, 32])
+
+        with pytest.warns(UserWarning, match="pad_value has no effect"):
+            unified_ops.slice(src, [8, 32], [0, 0], pad_value=ir.PadValue.min)
+
+    @pytest.mark.parametrize("kind", ["tensor", "tile"])
+    def test_warning_names_the_caller_not_the_dispatcher(self, kind):
+        """The warning must point at user code, not at ``unified_ops``.
+
+        ``pytest.warns`` checks neither filename nor lineno, so it cannot catch
+        this; the assertion has to read the record.
+        """
+        src: Tensor | Tile = _tensor("x", [16, 32]) if kind == "tensor" else _tile("t", [16, 32])
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            unified_ops.slice(src, [8, 32], [0, 0], pad_value=ir.PadValue.min)
+
+        assert len(caught) == 1
+        assert caught[0].filename == __file__
+
+    @pytest.mark.parametrize("kind", ["tensor", "tile"])
+    def test_each_call_site_warns_under_the_default_filter(self, kind):
+        """Distinct call sites must not collapse into a single warning.
+
+        The default filter dedupes on ``(text, category, lineno)`` in the frame
+        named by ``stacklevel``. A dispatcher-fixed stacklevel would key every
+        call site to one library line, showing the first and silently dropping
+        the rest.
+        """
+        src: Tensor | Tile = _tensor("x", [16, 32]) if kind == "tensor" else _tile("t", [16, 32])
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("default")
+            unified_ops.slice(src, [8, 32], [0, 0], pad_value=ir.PadValue.min)
+            unified_ops.slice(src, [8, 32], [0, 0], pad_value=ir.PadValue.min)
+            unified_ops.slice(src, [8, 32], [0, 0], pad_value=ir.PadValue.min)
+
+        assert len(caught) == 3, "each distinct call site must surface its own warning"
+
+    def test_pad_value_reaches_the_parser_path(self):
+        """A DSL body reaches the wrapper dynamically — pad_value must survive that."""
+
+        @pl.function
+        def unified(x: pl.Tensor[[16, 32], pl.FP32]) -> pl.Tensor[[16, 32], pl.FP32]:
+            narrowed = pl.slice(x, [8, 32], [0, 0], valid_shape=[8, 8], pad_value=pl.PadValue.min)
+            return pl.fillpad_expand(narrowed, [16, 32])
+
+        @pl.function
+        def explicit(x: pl.Tensor[[16, 32], pl.FP32]) -> pl.Tensor[[16, 32], pl.FP32]:
+            narrowed = pl.tensor.slice(x, [8, 32], [0, 0], valid_shape=[8, 8], pad_value=pl.PadValue.min)
+            return pl.fillpad_expand(narrowed, [16, 32])
+
+        ir.assert_structural_equal(unified, explicit)
+
+        @pl.function
+        def unpadded(x: pl.Tensor[[16, 32], pl.FP32]) -> pl.Tensor[[16, 32], pl.FP32]:
+            narrowed = pl.tensor.slice(x, [8, 32], [0, 0], valid_shape=[8, 8])
+            return pl.fillpad_expand(narrowed, [16, 32])
+
+        assert not ir.structural_equal(unified, unpadded)
+
+    def test_sibling_directory_is_not_mistaken_for_library_code(self):
+        """A user path that merely *starts with* the package dir is user code.
+
+        ``<parent>/pypto_kernels/k.py`` prefix-matches ``<parent>/pypto``, so a
+        bare ``startswith`` on the package directory would skip a real user
+        frame and walk on to name someone else's. The match has to be on a path
+        component.
+        """
+        pkg_dir = pathlib.Path(pypto_ir_utils.__file__).resolve().parent.parent
+        sibling = f"{pkg_dir}_kernels{os.sep}k.py"
+
+        namespace = {"probe": pypto_ir_utils.caller_warning_stacklevel}
+        exec(compile("def warn_site():\n    return probe()\n", sibling, "exec"), namespace)  # noqa: S102
+
+        # The frame that would call warnings.warn is itself user code, so the
+        # level naming it is 1 — not 2, which would name this test instead.
+        assert namespace["warn_site"]() == 1
+
+    def test_pad_value_reaches_the_parser_path_for_tiles(self):
+        """The Tile forward is reached dynamically through the parser too."""
+
+        @pl.function
+        def unified(x: pl.Tensor[[16, 32], pl.FP32]) -> pl.Tensor[[16, 32], pl.FP32]:
+            t = pl.load(x, [0, 0], [16, 32], target_memory=pl.MemorySpace.Vec)
+            narrowed = pl.slice(t, [8, 32], [0, 0], valid_shape=[8, 8], pad_value=pl.PadValue.min)
+            return pl.store(pl.fillpad_expand(narrowed, [16, 32]), [0, 0], x)
+
+        @pl.function
+        def explicit(x: pl.Tensor[[16, 32], pl.FP32]) -> pl.Tensor[[16, 32], pl.FP32]:
+            t = pl.load(x, [0, 0], [16, 32], target_memory=pl.MemorySpace.Vec)
+            narrowed = pl.tile.slice(t, [8, 32], [0, 0], valid_shape=[8, 8], pad_value=pl.PadValue.min)
+            return pl.store(pl.fillpad_expand(narrowed, [16, 32]), [0, 0], x)
+
+        ir.assert_structural_equal(unified, explicit)
+
+        @pl.function
+        def unpadded(x: pl.Tensor[[16, 32], pl.FP32]) -> pl.Tensor[[16, 32], pl.FP32]:
+            t = pl.load(x, [0, 0], [16, 32], target_memory=pl.MemorySpace.Vec)
+            narrowed = pl.tile.slice(t, [8, 32], [0, 0], valid_shape=[8, 8])
+            return pl.store(pl.fillpad_expand(narrowed, [16, 32]), [0, 0], x)
+
+        assert not ir.structural_equal(unified, unpadded)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

`pl.tensor.slice` and `pl.tile.slice` both accept `pad_value`, but the unified `pl.slice` dispatcher never declared it, so the parameter was unreachable through the facade on either path — `pl.slice(x, shape, offset, pad_value=0)` raised `TypeError: slice() got an unexpected keyword argument 'pad_value'`, and callers had to drop to the level-specific spelling to set a padding mode. `pl.slice` now declares and forwards it.

This needs no cross-path guard. Unlike `clamp`, which only a Tensor can honour, `pad_value` exists at both levels, so forwarding is the whole fix.

Forwarding alone would have degraded a diagnostic, so the second half of the change repairs that — see below. Callers that omit `pad_value` are unaffected, and the Tensor-only `clamp` rejection on the Tile path is unchanged.

## Changes

- `python/pypto/language/op/unified_ops.py` — `pl.slice` declares `pad_value` and forwards it on both dispatch branches, in the same positional slot both callees already use: after `drop_dims`, before the Tensor-only `clamp`. An AST sweep of `tests/`, `examples/`, `python/`, and `docs/` found all 253 existing `pl.slice` call sites pass exactly three positional arguments, and the three that use `clamp` spell it as a keyword, so moving `clamp` one slot rebinds nothing.

- `python/pypto/ir/utils.py` — new `caller_warning_stacklevel()`, which walks out to the first stack frame outside the `pypto` package.

- `python/pypto/language/op/tensor_ops.py`, `python/pypto/language/op/tile_ops.py` — the two `slice` "pad_value has no effect" warnings take their `stacklevel` from that helper instead of a literal `2`.

  A literal `2` names the *immediate* caller, which was always user code before — and is the dispatcher once `pl.slice` forwards. The consequence is worse than a misleading filename: Python's default filter dedupes on `(text, category, lineno)` recorded in the frame named by `stacklevel`, so a fixed library line collapses every distinct call site onto one record. Measured on the unfixed branch, three distinct user call sites produced **1** warning instead of 3 — a kernel with twenty misused `pl.slice` calls would have seen one warning pointing into `unified_ops.py` and nineteen silent drops. Walking to the first non-`pypto` frame restores one warning per real call site and stays correct through any depth of forwarding.

- `tests/ut/language/test_unified_ops.py` — `TestUnifiedSlicePadValue` (15 tests): forwarding on both paths, the `0`/`inf` literal sugars, positional binding, `pad_value` alongside `clamp`, `None`/omitted staying byte-identical to the previous IR, and both DSL-parser paths (the parser reaches the wrapper dynamically, so kwarg resolution is a separate risk from the direct call).

  Every forwarding test pairs its structural match against the explicit `pl.tensor.*` / `pl.tile.*` call with a negative assertion that the no-`pad_value` IR differs, so the test fails rather than passing vacuously if both sides drop the kwarg. Two tests cover the warning defect specifically — attribution and per-call-site dedup — because `pytest.warns` checks neither `filename` nor `lineno` and installs `simplefilter("always")`, which defeats the dedup it needs to observe. Both were confirmed to fail against a reverted `stacklevel=2`.

## Verification

Run against the pushed commit `12e1cfcd`, rebased onto `main`:

- `ruff check` (5 changed files): exit 0, all checks passed
- `ruff format --check` (5 changed files): exit 0, already formatted
- `cmake --build build --parallel`: exit 0
- `pytest tests/ut/language/test_unified_ops.py`: exit 0, 160 passed
- `pytest tests/ut/ -n auto --maxprocesses 8`: exit 0, **9511 passed, 3 skipped** in 2:40

Separately, the two warning-regression tests were run against a reverted
`stacklevel=2` to confirm they are not vacuous: 4 failed, with the dedup test
reporting `assert 1 == 3`.

No behaviour change for existing callers, no interface removal, and no
migration step.