### PR TITLE
chore(testing): Respect machine-local job limits

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -13,6 +13,15 @@ All rules for this project are located in the `.claude/rules/` directory. Please
 
 Refer to the individual rule files in `.claude/rules/` for specific guidance on project conventions, coding standards, and best practices.
 
+## Machine-Local Resource Limits
+
+Before compiling or running tests, source
+`.claude/skills/testing/load-env.sh`. Always pass the resulting
+`PYPTO_BUILD_JOBS` or `PYPTO_TEST_JOBS` explicitly; never use bare
+`--parallel`, `-j`, or pytest `-n auto`. The loader reads the ignored
+machine-local `testing.env` from the primary checkout, including when invoked
+from a linked worktree, and defaults unclassified machines to two jobs.
+
 ## Skills (`.claude/skills/`)
 
 Skills are workflow guides that help the main assistant perform specific tasks:

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -20,7 +20,9 @@ Before compiling or running tests, source
 `PYPTO_BUILD_JOBS` or `PYPTO_TEST_JOBS` explicitly; never use bare
 `--parallel`, `-j`, or pytest `-n auto`. The loader reads the ignored
 machine-local `testing.env` from the primary checkout, including when invoked
-from a linked worktree, and defaults unclassified machines to two jobs.
+from a linked worktree, and defaults unclassified machines to two jobs. These
+limits override conflicting command examples elsewhere, including the root
+`AGENTS.md` preferred commands.
 
 ## Skills (`.claude/skills/`)
 

--- a/.claude/rules/cross-layer-sync.md
+++ b/.claude/rules/cross-layer-sync.md
@@ -94,7 +94,8 @@ After cross-layer changes:
 - [ ] Type stub matches binding signature
 - [ ] Type hints are accurate
 - [ ] Docstrings present in binding and stub
-- [ ] Project builds (`cmake --build build --parallel`)
+- [ ] Resource limits loaded (`source .claude/skills/testing/load-env.sh`)
+- [ ] Project builds (`cmake --build build --parallel "$PYPTO_BUILD_JOBS"`)
 - [ ] Python can import and use the API
 - [ ] Type checker passes (mypy/pyright)
 

--- a/.claude/rules/plans-and-proposals.md
+++ b/.claude/rules/plans-and-proposals.md
@@ -120,13 +120,14 @@ New files:
 
 # ✅ Detailed
 "Implementation order:
+0. Load machine limits: `source .claude/skills/testing/load-env.sh`
 1. C++ header (`include/pypto/ir/stmt.h`): Declare `IsChunked()` — must come first
 2. C++ impl (`src/ir/stmt.cpp`): Implement `IsChunked()` — depends on step 1
-3. Build C++: `cmake --build build --parallel` — verify compilation before binding work
+3. Build C++: `cmake --build build --parallel "$PYPTO_BUILD_JOBS"` — verify compilation before binding work
 4. Python binding (`python/bindings/modules/ir.cpp`): Add `.def("is_chunked", ...)`
 5. Type stub (`python/pypto/pypto_core/ir.pyi`): Add `is_chunked()` signature
 6. Test (`tests/ut/ir/statements/test_for_stmt.py`): Add `test_is_chunked()`
-7. Build and test: `cmake --build build --parallel && cd build && ctest` — full verification
+7. Build and test: `cmake --build build --parallel "$PYPTO_BUILD_JOBS" && cd build && ctest` — full verification
 "
 ````
 

--- a/.claude/rules/plans-and-proposals.md
+++ b/.claude/rules/plans-and-proposals.md
@@ -127,7 +127,7 @@ New files:
 4. Python binding (`python/bindings/modules/ir.cpp`): Add `.def("is_chunked", ...)`
 5. Type stub (`python/pypto/pypto_core/ir.pyi`): Add `is_chunked()` signature
 6. Test (`tests/ut/ir/statements/test_for_stmt.py`): Add `test_is_chunked()`
-7. Build and test: `cmake --build build --parallel "$PYPTO_BUILD_JOBS" && cd build && ctest` — full verification
+7. Build and test: `cmake --build build --parallel "$PYPTO_BUILD_JOBS" && cd build && ctest --parallel "$PYPTO_TEST_JOBS"` — full verification
 "
 ````
 

--- a/.claude/rules/worktree-builds.md
+++ b/.claude/rules/worktree-builds.md
@@ -16,17 +16,20 @@ Copying build artifacts from the main repo is fragile and error-prone:
 ## How to Build in a Worktree
 
 ```bash
+# Load limits from the primary checkout, with safe defaults when unclassified
+source .claude/skills/testing/load-env.sh
+
 # Configure build directory if it doesn't exist
 [ ! -f build/CMakeCache.txt ] && cmake -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo
 
 # Build
-cmake --build build --parallel
+cmake --build build --parallel "$PYPTO_BUILD_JOBS"
 
 # Set PYTHONPATH to worktree's python/
 export PYTHONPATH=$(pwd)/python:$PYTHONPATH
 
 # Run tests
-python -m pytest tests/ut/ -n auto --maxprocesses 8 -v
+python -m pytest tests/ut/ -n "$PYPTO_TEST_JOBS" -v
 ```
 
 ## When No C++ Changes Exist

--- a/.claude/skills/add-op/reference.md
+++ b/.claude/skills/add-op/reference.md
@@ -399,8 +399,11 @@ Add to the appropriate category table (TensorOp or TileOp section).
 ## 10. Build & Test Commands
 
 ```bash
+# Load machine-local resource limits
+source .claude/skills/testing/load-env.sh
+
 # Build after C++ changes
-cmake --build build --parallel
+cmake --build build --parallel "$PYPTO_BUILD_JOBS"
 
 # Run specific op tests
 export PYTHONPATH=$(pwd)/python:$PYTHONPATH
@@ -410,7 +413,7 @@ python3 -m pytest tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py -v -
 python3 -m pytest tests/ut/codegen/test_pto_codegen_ops.py -v -k "<op_name>"
 
 # Full test suite
-python3 -m pytest tests/ut/ -n auto --maxprocesses 8 -v
+python3 -m pytest tests/ut/ -n "$PYPTO_TEST_JOBS" -v
 
 # Pre-commit checks
 pre-commit run --all-files

--- a/.claude/skills/compare-codegen/SKILL.md
+++ b/.claude/skills/compare-codegen/SKILL.md
@@ -57,12 +57,12 @@ mkdir -p "$MAIN_OUTPUT" "$BRANCH_OUTPUT"
 Build (if needed) and run the test on the current branch:
 
 ```bash
-# Source test env if available
-[ -f .claude/skills/testing/testing.env ] && source .claude/skills/testing/testing.env
+# Load machine-local resource limits
+source .claude/skills/testing/load-env.sh
 
 # Build
 [ ! -f build/CMakeCache.txt ] && cmake -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo
-cmake --build build --parallel
+cmake --build build --parallel "$PYPTO_BUILD_JOBS"
 
 # Run test with save-kernels + dump-passes (full test run, not codegen-only)
 export PYTHONPATH=$(pwd)/python:$PYTHONPATH
@@ -80,16 +80,17 @@ Create a temporary worktree, build from scratch, run the same test:
 ```bash
 git fetch origin main
 WORKTREE_DIR=$(mktemp -d -p /tmp pypto-main-XXXXXX)
+RESOURCE_LOADER="$(pwd)/.claude/skills/testing/load-env.sh"
 git worktree add "$WORKTREE_DIR" origin/main
 
 pushd "$WORKTREE_DIR"
 
-# Source test env if available
-[ -f .claude/skills/testing/testing.env ] && source .claude/skills/testing/testing.env
+# Load limits from the primary checkout
+source "$RESOURCE_LOADER"
 
 # Build inside worktree
 cmake -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo
-cmake --build build --parallel
+cmake --build build --parallel "$PYPTO_BUILD_JOBS"
 
 # Run test
 export PYTHONPATH=$(pwd)/python:$PYTHONPATH

--- a/.claude/skills/testing/SKILL.md
+++ b/.claude/skills/testing/SKILL.md
@@ -10,46 +10,50 @@ You are a specialized testing agent. Build the project and run all tests to veri
 
 ## Environment Setup
 
-**If `.claude/skills/testing/testing.env` exists**: Source it before testing.
+Source the resource-limit loader before testing. It loads the ignored
+machine-local `testing.env` from the primary checkout, including from linked
+worktrees.
 
 ```bash
-[ -f .claude/skills/testing/testing.env ] && source .claude/skills/testing/testing.env
+source .claude/skills/testing/load-env.sh
 ```
 
-**If doesn't exist**: Skip and suggest creating one (see `testing.env.example`).
+If `testing.env` doesn't exist, the loader uses safe defaults and the agent
+should suggest creating one (see `testing.env.example`). Never infer the
+machine profile or job limits from the hostname or CPU count.
 
 ## Testing Workflow
 
 **When working in a git worktree**, always build and test from within the worktree — never copy `.so` files from the main repo. Create a build directory inside the worktree if one doesn't exist.
 
 ```bash
-# 1. Activate environment (if testing.env exists)
-[ -f .claude/skills/testing/testing.env ] && source .claude/skills/testing/testing.env
+# 1. Load machine-local environment and resource limits
+source .claude/skills/testing/load-env.sh
 
 # 2. Configure CMake if build is not configured (worktree, fresh clone)
 [ ! -f build/CMakeCache.txt ] && cmake -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo
 
-# 3. Build project (parallel)
-cmake --build build --parallel
+# 3. Build project with the machine-local parallelism limit
+cmake --build build --parallel "$PYPTO_BUILD_JOBS"
 
 # 4. Set PYTHONPATH
 export PYTHONPATH=$(pwd)/python:$PYTHONPATH
 
 # 5. Run tests
-python -m pytest tests/ut/ -n auto --maxprocesses 8 -v
+python -m pytest tests/ut/ -n "$PYPTO_TEST_JOBS" -v
 ```
 
 ## Test Commands
 
 ```bash
 # Run all tests
-python -m pytest tests/ut/ -n auto --maxprocesses 8 -v
+python -m pytest tests/ut/ -n "$PYPTO_TEST_JOBS" -v
 
 # Run specific test file
-python -m pytest tests/ut/core/test_error.py -n auto --maxprocesses 8 -v
+python -m pytest tests/ut/core/test_error.py -n "$PYPTO_TEST_JOBS" -v
 
 # Run specific test
-python -m pytest tests/ut/core/test_error.py::TestErrorTypes::test_value_error_type -n auto --maxprocesses 8 -v
+python -m pytest tests/ut/core/test_error.py::TestErrorTypes::test_value_error_type -n "$PYPTO_TEST_JOBS" -v
 ```
 
 ## Test Structure
@@ -75,7 +79,7 @@ tests/ut/
 | Issue | Solution |
 | ----- | -------- |
 | `ImportError: No module named 'pypto_core'` | `export PYTHONPATH=$(pwd)/python:$PYTHONPATH` |
-| Tests fail after code changes | `cmake --build build --parallel` then re-run |
+| Tests fail after code changes | `cmake --build build --parallel "$PYPTO_BUILD_JOBS"` then re-run |
 | Tests in wrong location | Move to `tests/ut/` |
 | Build not configured (worktree/fresh clone) | `cmake -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo` |
 
@@ -108,9 +112,9 @@ tests/ut/
 
 ## Key Focus Areas
 
-1. **Environment**: Check for and source `.claude/skills/testing/testing.env` if it exists. If it doesn't exist, show a helpful tip about creating it.
+1. **Environment**: Source `.claude/skills/testing/load-env.sh`. If the machine-local config doesn't exist, use its safe defaults and show a helpful tip about creating it.
 2. **Build Setup**: If build is not configured (no `build/CMakeCache.txt`), run `cmake -B build` to configure before building.
-3. **Build**: Ensure project builds without errors or new warnings. Always use `--parallel`.
+3. **Build**: Ensure project builds without errors or new warnings. Always pass the explicit machine-local limit with `--parallel "$PYPTO_BUILD_JOBS"`; never use bare `--parallel` or derive the value from CPU count.
 4. **Python Path**: Set PYTHONPATH correctly
 5. **Test Execution**: Run all tests and analyze results
 6. **Coverage**: Verify new features have tests, bug fixes have regression tests
@@ -119,6 +123,7 @@ tests/ut/
 ## Remember
 
 - Always rebuild before running tests
+- Always use the explicit machine-local build and test job limits
 - Check both build and test output
 - Look for new warnings even if tests pass
 - Report both successes and failures clearly

--- a/.claude/skills/testing/load-env.sh
+++ b/.claude/skills/testing/load-env.sh
@@ -13,11 +13,40 @@ PYPTO_GIT_COMMON_DIR=$(git rev-parse --path-format=absolute --git-common-dir 2>/
 PYPTO_PRIMARY_WORKTREE=$(dirname "$PYPTO_GIT_COMMON_DIR")
 PYPTO_TESTING_ENV="$PYPTO_PRIMARY_WORKTREE/.claude/skills/testing/testing.env"
 
-[ -f "$PYPTO_TESTING_ENV" ] && source "$PYPTO_TESTING_ENV"
+if [ -f "$PYPTO_TESTING_ENV" ]; then
+    source "$PYPTO_TESTING_ENV" || return $?
+fi
 
 export PYPTO_MACHINE_PROFILE="${PYPTO_MACHINE_PROFILE:-unclassified}"
 export PYPTO_BUILD_JOBS="${PYPTO_BUILD_JOBS:-2}"
 export PYPTO_TEST_JOBS="${PYPTO_TEST_JOBS:-2}"
+
+case "$PYPTO_BUILD_JOBS" in
+    '' | *[!0-9]*)
+        echo "PYPTO_BUILD_JOBS must be a positive decimal integer, got: $PYPTO_BUILD_JOBS" >&2
+        unset PYPTO_GIT_COMMON_DIR PYPTO_PRIMARY_WORKTREE PYPTO_TESTING_ENV
+        return 1
+        ;;
+esac
+if [ "$PYPTO_BUILD_JOBS" -eq 0 ]; then
+    echo "PYPTO_BUILD_JOBS must be greater than zero" >&2
+    unset PYPTO_GIT_COMMON_DIR PYPTO_PRIMARY_WORKTREE PYPTO_TESTING_ENV
+    return 1
+fi
+
+case "$PYPTO_TEST_JOBS" in
+    '' | *[!0-9]*)
+        echo "PYPTO_TEST_JOBS must be a positive decimal integer, got: $PYPTO_TEST_JOBS" >&2
+        unset PYPTO_GIT_COMMON_DIR PYPTO_PRIMARY_WORKTREE PYPTO_TESTING_ENV
+        return 1
+        ;;
+esac
+if [ "$PYPTO_TEST_JOBS" -eq 0 ]; then
+    echo "PYPTO_TEST_JOBS must be greater than zero" >&2
+    unset PYPTO_GIT_COMMON_DIR PYPTO_PRIMARY_WORKTREE PYPTO_TESTING_ENV
+    return 1
+fi
+
 export CMAKE_BUILD_PARALLEL_LEVEL="$PYPTO_BUILD_JOBS"
 export MAKEFLAGS="-j$PYPTO_BUILD_JOBS"
 export MAX_JOBS="$PYPTO_BUILD_JOBS"

--- a/.claude/skills/testing/load-env.sh
+++ b/.claude/skills/testing/load-env.sh
@@ -1,0 +1,26 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+# Load resource limits from the primary checkout so linked worktrees share the
+# same machine profile. Unclassified machines use conservative defaults.
+PYPTO_GIT_COMMON_DIR=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null)
+PYPTO_PRIMARY_WORKTREE=$(dirname "$PYPTO_GIT_COMMON_DIR")
+PYPTO_TESTING_ENV="$PYPTO_PRIMARY_WORKTREE/.claude/skills/testing/testing.env"
+
+[ -f "$PYPTO_TESTING_ENV" ] && source "$PYPTO_TESTING_ENV"
+
+export PYPTO_MACHINE_PROFILE="${PYPTO_MACHINE_PROFILE:-unclassified}"
+export PYPTO_BUILD_JOBS="${PYPTO_BUILD_JOBS:-2}"
+export PYPTO_TEST_JOBS="${PYPTO_TEST_JOBS:-2}"
+export CMAKE_BUILD_PARALLEL_LEVEL="$PYPTO_BUILD_JOBS"
+export MAKEFLAGS="-j$PYPTO_BUILD_JOBS"
+export MAX_JOBS="$PYPTO_BUILD_JOBS"
+export PYTEST_XDIST_AUTO_NUM_WORKERS="$PYPTO_TEST_JOBS"
+
+unset PYPTO_GIT_COMMON_DIR PYPTO_PRIMARY_WORKTREE PYPTO_TESTING_ENV

--- a/.claude/skills/testing/testing.env.example
+++ b/.claude/skills/testing/testing.env.example
@@ -1,5 +1,6 @@
-# Machine-local test environment. Copy this file to testing.env and customize
-# it for the current machine. testing.env is ignored by Git.
+# Machine-local test environment. Copy this file to testing.env in the primary
+# checkout (not a linked worktree) and customize it for the current machine.
+# testing.env is ignored by Git.
 
 # Classify the machine explicitly; do not infer this from hostname or CPU count.
 export PYPTO_MACHINE_PROFILE="personal-pc"

--- a/.claude/skills/testing/testing.env.example
+++ b/.claude/skills/testing/testing.env.example
@@ -1,5 +1,21 @@
-# Environment activation commands for testing
-# Copy this file to testing.env and customize for your local environment
-# Example: conda activate pypto
+# Machine-local test environment. Copy this file to testing.env and customize
+# it for the current machine. testing.env is ignored by Git.
 
-conda activate pypto
+# Classify the machine explicitly; do not infer this from hostname or CPU count.
+export PYPTO_MACHINE_PROFILE="personal-pc"
+export PYPTO_BUILD_JOBS=2
+export PYPTO_TEST_JOBS=2
+
+# Keep implicit build and pytest parallelism within the same limits.
+export CMAKE_BUILD_PARALLEL_LEVEL="$PYPTO_BUILD_JOBS"
+export MAKEFLAGS="-j$PYPTO_BUILD_JOBS"
+export MAX_JOBS="$PYPTO_BUILD_JOBS"
+export PYTEST_XDIST_AUTO_NUM_WORKERS="$PYPTO_TEST_JOBS"
+
+# Example server overrides:
+# export PYPTO_MACHINE_PROFILE="server"
+# export PYPTO_BUILD_JOBS=16
+# export PYPTO_TEST_JOBS=8
+
+# Optional environment activation:
+# conda activate pypto


### PR DESCRIPTION
## Summary
- load machine-local build and test limits from an ignored per-host configuration
- share the primary checkout profile with linked worktrees
- replace automatic or unbounded parallelism in testing workflows with explicit limits
- default unclassified machines to two build jobs and two test workers

## Testing
- code review passed
- pre-commit hooks passed
- verified loader syntax with bash and zsh
- verified the personal-PC 2/2 profile loads from the primary checkout and a linked worktree
- compilation and unit tests skipped because this changes only agent rules and testing workflow documentation