### PR TITLE
feat(distributed): add deferred task completion waits

### DIFF
--- a/docs/en/dev/distributed_ops.md
+++ b/docs/en/dev/distributed_ops.md
@@ -15,7 +15,7 @@ accept a plain `Tensor` as `src`, and `get`/`tile.get` accept one as `dst` —
 TPUT/TGET only need a readable/writable *local* GM region on that side. The
 window-bound side (`put.dst`, `get.src`) still requires a `DistributedTensor`.
 
-There are **fourteen ops** and **four ABI enums**:
+There are **fifteen ops** and **four ABI enums**:
 
 | Op | Direction | Result | Hardware |
 | -- | --------- | ------ | -------- |
@@ -33,8 +33,9 @@ There are **fourteen ops** and **four ABI enums**:
 | `pld.tensor.all_to_all_v` | variable-size all-to-all (MPI_Alltoallv) — pushes the full MAX_RECV-row block per destination into a flat 2D staging window (transfer size is the full per-destination capacity block), and publishes `min(send_counts[dest], MAX_RECV)` into peer `recv_counts[my_rank, 0]` via `pld.system.notify` (Set) so the receiver can skip rows beyond its count; returns window as result (same window-as-result pattern as symmetric `all_to_all`) | `DistributedTensorType` (same as target) | composite / HOST builtin |
 | `pld.system.notify` | signal a peer's slot | `Unknown` (side effect) | TNOTIFY |
 | `pld.system.wait` | block on own slot | `Unknown` (side effect) | TWAIT |
+| `pld.system.defer_wait` | defer this task's logical completion on a local counter | `Unknown` (side effect) | Simpler completion runtime (no PTOAS wait op) |
 
-The six side-effect-only ops produce [`UnknownType`](ir/02-types.md): they
+The seven side-effect-only ops produce [`UnknownType`](ir/02-types.md): they
 exist for their cross-rank effect, not for an SSA value a consumer reads.
 
 ## Namespacing: why `tile.*` vs `tensor.*` vs `system.*`
@@ -64,9 +65,10 @@ The namespace encodes the IR level the op lives at, not an arbitrary grouping:
   `pld.tile.get` / `pld.tile.put`, never on the DSL surface. Both are therefore
   siblings of `pld.tensor.alloc_window_buffer` / `pld.tensor.window`, **not** of
   the tile-producing `remote_load`.
-- **`pld.system.notify` / `pld.system.wait`** drive the per-rank signal slot —
-  pure control-plane synchronisation with no data operand — so they live in
-  `pld.system`.
+- **`pld.system.notify` / `pld.system.wait` / `pld.system.defer_wait`** drive
+  the per-rank signal slot — pure control-plane synchronisation with no data
+  operand — so they live in `pld.system`. `wait` blocks and later resumes its
+  kernel; `defer_wait` returns and transfers readiness to the scheduler TaskId.
 
 ## Core placement in a mixed kernel
 
@@ -108,13 +110,13 @@ the author's job; see `docs/en/user/language/04-scopes.md`.
 ## ABI enums (`include/pypto/ir/comm.h`)
 
 The four enums are an **append-only ABI**. Their underlying `int` values are
-serialised as the op's kwarg payload (`op` for notify, `cmp` for wait, `atomic`
+serialised as the op's kwarg payload (`op` for notify, `cmp` for wait/defer_wait, `atomic`
 for put) and cast back to the enum at codegen time. New variants may only be
 added **at the end** so existing IR and cached programs keep their meaning.
 
 ```cpp
 enum class NotifyOp : int { kAtomicAdd = 0, kSet = 1 };   // pld.system.notify
-enum class WaitCmp  : int { kEq = 0,        kGe = 1 };     // pld.system.wait
+enum class WaitCmp  : int { kEq = 0,        kGe = 1 };     // pld.system.wait / defer_wait
 enum class AtomicType : int { kNone = 0,    kAdd = 1 };    // pld.tensor.put, remote_store
 enum class ReduceOp : int { kSum = 0, kMax = 1, kMin = 2, kProd = 3 };  // pld.tensor.allreduce
 ```
@@ -124,7 +126,7 @@ enum class ReduceOp : int { kSum = 0, kMax = 1, kMin = 2, kProd = 3 };  // pld.t
 | `NotifyOp` | `kAtomicAdd` | atomically add `value` into the peer's signal slot |
 | `NotifyOp` | `kSet` | non-atomic store of `value` into the peer's signal slot |
 | `WaitCmp` | `kEq` | block until `*signal_slot == expected` |
-| `WaitCmp` | `kGe` | block until `*signal_slot >= expected` |
+| `WaitCmp` | `kGe` | wait, or defer task completion, until `*signal_slot >= expected` |
 | `AtomicType` | `kNone` | plain remote store — overwrite the peer's dst slice |
 | `AtomicType` | `kAdd` | atomically add the source data into the peer's dst slice |
 | `ReduceOp` | `kSum` | sum-reduce every participating rank's window slice |
@@ -598,9 +600,47 @@ predicate against `expected` (see `WaitCmp`).
 Verifier: `signal` must be `DistributedTensorType`; `expected` must be
 `ScalarType`; `offsets` must be a `MakeTuple` of rank equal to the signal rank.
 
+### `pld.system.defer_wait` (Simpler deferred completion)
+
+Signature: `pld.system.defer_wait(signal, offsets, expected, *, cmp: int) -> Unknown`.
+
+Registers a local counter condition without `pto.comm.twait`. The kernel can retire and
+release its AIV, but Simpler delays the ordinary TaskId's completion until every condition
+is ready; the kernel is never resumed.
+
+V1 accepts a direct window-bound INT32 `DistributedTensor` parameter with ND/DN
+addressing, integer/index offsets and threshold, and only `WaitCmp::kGe`.
+Slices/views/SSA aliases, NZ layout, and rank-zero signals are rejected. Counter
+storage is INT32 but polling is unsigned `>=`: thresholds and published values must
+remain monotonic in `[0, INT32_MAX]`; `-1` appears as `UINT32_MAX` and falsely
+satisfies. One task may register at most 64 conditions, independent of the scheduler's
+64-concurrent-deferred-task limit.
+
+The scope outliner requires a dedicated top-level single-block pure-AIV `pl.at(CORE_GROUP)`
+waiter with no predicate or `allow_early_resolve=True`.
+Pure scalar work may occur between registrations, but `tensor.read`,
+payload/cache operations, and other communication cannot. A terminal waiter with no
+continuation may be submitted fire-and-forget and need not capture a TaskId. An
+unmarked direct `@pl.jit.incore` / AIV use is rejected because it bypasses the
+validated single-block task launch and runtime `AsyncCtx` contract. Programmatically
+constructed IR carrying the internal waiter marker is accepted only after the full
+body and orchestration call-site contract is revalidated.
+
+Continuation uses ordinary `deps=[wait_tid]`; there is no second dependency type.
+Simpler withholds the normal TaskId fanout until the counter is ready. Its standard
+task-start cache invalidation then runs on the normally dispatched consumer. The
+producer must still make payload writes visible before publishing the signal, and
+the waiter must remain ineligible for early resolve so consumer pickup cannot precede readiness.
+
+Codegen passes checked flattened offsets and raw dispatch arguments to an adapter that
+registers a counter `CompletionToken` in `AsyncCtx`. The legacy
+`pld.system.wait`/`pto.comm.twait` path is unchanged. See the
+[distributed primitives guide](../user/distributed/02-primitives.md#deferred-completion-release-the-core-keep-the-task-pending)
+for the complete programming contract and examples.
+
 ## Shared codegen infrastructure
 
-All five ops lower through PTO codegen helpers in
+The low-level RMA and synchronization ops lower through PTO codegen helpers in
 `src/backend/common/pto_ops_distributed.cpp` and `src/codegen/pto/pto_codegen.cpp`.
 The reusable pieces — shared so each op's lowering carries no bespoke peer
 arithmetic — are:
@@ -613,11 +653,13 @@ arithmetic — are:
 | `ResolveDistTensorBinding` | resolves a `DistributedTensor` arg to its codegen binding (type + window var) |
 | `AsTensorTypeLike` | kind-trait downcast accepting both `TensorType` and `DistributedTensorType` where a view's element/shape info is read uniformly |
 
-The local-vs-remote split is intentional: a *local* operand (e.g. `get`'s
-`dst`, `put`'s `src`, `wait`'s `signal`) reuses the tensor view already created by
-`EmitMakeTensorViews` with no peer arithmetic, while a *remote* operand (e.g.
+The local-vs-remote split is intentional: a *local* PTO operand (e.g. `get`'s
+`dst`, `put`'s `src`, `wait`'s `signal`) reuses the tensor view already created
+by `EmitMakeTensorViews` with no peer arithmetic, while a *remote* operand (e.g.
 `remote_load`'s `target`, `get`'s `src`, `put`'s `dst`) goes through
-`EmitCommRemoteView`.
+`EmitCommRemoteView`. `defer_wait` is also local, but its adapter receives the
+direct parameter base plus a checked flattened logical element offset rather
+than a PTO tensor view.
 
 ## Pipeline integration
 
@@ -651,6 +693,9 @@ dispatches before the final `Simplify`.
   enabled: `test_l3_put.py` (ring overwrite, row-offset put, atomic-add put, and
   chunked/pipelined transfers ✅), `test_l3_get.py` (ring read, row-offset get ✅),
   and `test_l3_remote_store.py` (tile-level subview push ✅, plus a
-  tensor-level push of a *computed* value ✅). All tests use the
-  `pld.system.notify` / `pld.system.wait` handshake pattern established by
-  notify/wait and collective STs.
+  tensor-level push of a *computed* value ✅). Deferred completion is covered by
+  `test_l3_deferred_completion.py`: A2/A3 AIV-saturation/core-release,
+  already-ready registration reuse, A5 cross-rank correctness, persistent
+  monotonic epochs, and ordinary TaskId dependency gating. Other communication
+  STs use the `pld.system.notify` / `pld.system.wait` handshake pattern
+  established by notify/wait and collective STs.

--- a/docs/en/user/distributed/02-primitives.md
+++ b/docs/en/user/distributed/02-primitives.md
@@ -23,7 +23,7 @@ lower-level primitives only when building a custom protocol.
 
 These are the lowest-level distributed primitives. Scope varies per op —
 `world_size` is host-only; `get_comm_ctx` works in both host orchestrator and
-InCore kernel code; `rank`, `nranks`, `notify`, and `wait` have codegen
+InCore kernel code; `rank`, `nranks`, `notify`, `wait`, and `defer_wait` have codegen
 support only in InCore kernel code (there is no host-orchestrator lowering
 for them).
 
@@ -35,6 +35,7 @@ for them).
 | `nranks` | `(ctx: Ctx) -> Scalar` | **InCore-only.** Number of ranks in this comm group (`INT32`). Lowers to a load of `CommContext::rankNum`. |
 | `notify` | `(target: DT, peer: IntLike, offsets: Sequence[IntLike], value: IntLike, *, op: NotifyOp) -> Call` | **InCore-only.** Cross-rank signal deposit. **Side-effect-only** — no return value. Lowers to `TNOTIFY`. |
 | `wait` | `(signal: DT, offsets: Sequence[IntLike], expected: IntLike, *, cmp: WaitCmp) -> Call` | **InCore-only.** Cross-rank wait. **Side-effect-only** — blocks until the local signal slot satisfies `cmp(expected)`. Lowers to `TWAIT`. |
+| `defer_wait` | `(signal: DT, offsets: Sequence[IntLike], expected: IntLike, *, cmp: WaitCmp) -> Call` | **Dedicated top-level `pl.at(CORE_GROUP)` waiter only.** Registers `signal[offsets] >= expected` as a completion condition and returns without spinning the AIV. The enclosing task's TaskId remains incomplete until the condition is ready. |
 
 ## Window Buffer Management (`pld.tensor.*`)
 
@@ -115,6 +116,118 @@ notify next to cube work.
 > value; after `wait` returns, the caller has observed the barrier. Do not
 > reuse the same signal buffer across back-to-back collectives — the protocol
 > uses monotonic counters that do not self-reset. Allocate a fresh buffer.
+
+## Deferred Completion: Release the Core, Keep the Task Pending
+
+`pld.system.wait` is a blocking `TWAIT`: the AIV stays in the kernel and the
+statements after the wait resume on that same AIV. `pld.system.defer_wait` has
+a different contract. It registers a counter condition with the runtime and
+returns; when the dedicated waiter kernel ends, its **physical AIV is free**, but
+the waiter's **logical TaskId is still incomplete**. The scheduler resolves that
+TaskId only after every registered condition is satisfied. The kernel is never
+resumed, so continuation work must be a separate task.
+
+```python
+# Each rank's publisher is independent: publish payload first, then the signal.
+with pl.at(level=pl.Level.CORE_GROUP, name_hint="publish"):
+    pld.tensor.remote_store(payload_value, peer_payload, peer, [0, 0])
+    pld.system.notify(
+        signal, peer=peer, offsets=[my_rank, 0],
+        value=epoch, op=pld.NotifyOp.Set,
+    )
+
+# Receiver: observe the peer publisher. There is deliberately no local
+# publisher -> waiter dependency; add deps only for real local ordering.
+with pl.at(
+    level=pl.Level.CORE_GROUP,
+    name_hint="payload_wait",
+    allow_early_resolve=False,
+) as wait_tid:
+    pld.system.defer_wait(
+        signal, offsets=[peer, 0], expected=epoch,
+        cmp=pld.WaitCmp.Ge,
+    )
+
+# The consumer is not dispatched until wait_tid is logically complete.
+with pl.at(
+    level=pl.Level.CORE_GROUP,
+    name_hint="consume_payload",
+    deps=[wait_tid],
+) as consume_tid:
+    payload_tile = pl.load(peer_payload, [0, 0], [1, WIDTH])
+    # ... consume payload_tile ...
+```
+
+An inline SPMD consumer uses the captured form as well:
+
+```python
+with pl.spmd(
+    NUM_BLOCKS,
+    name_hint="consume_payload_spmd",
+    deps=[wait_tid],
+) as consume_tid:
+    block = pl.get_block_idx()
+    # ... each AIV block reads its payload partition ...
+```
+
+There is no second dependency namespace for deferred completion. `deps` keeps
+its normal strict TaskId meaning: Simpler dynamically delays completion of the
+ordinary waiter TaskId after its AIV retires, so the existing dependency edge
+does not release the consumer until the registered counter is ready. The
+standard Simpler AICore executor already invalidates the entire data cache
+immediately after it picks up every task (before the optional speculative gate
+and before that task's kernel reads its inputs). The waiter is not eligible for
+early resolve, so its direct consumer is never pre-staged at that gate: it is
+picked up through the normal path only after the counter-backed TaskId
+completes. Its task-start invalidation therefore happens after readiness. On
+the producer side, all payload writes must still
+become visible **before** the notify is published; task-start invalidation
+cannot repair a notify-before-data bug.
+
+### Deferred-wait contract
+
+- Put `defer_wait` in a dedicated, top-level task
+  `with pl.at(level=pl.Level.CORE_GROUP) as wait_tid:` scope. This task-level
+  launch lets PyPTO validate single-block execution and provide the runtime
+  `AsyncCtx`. An unmarked direct `@pl.jit.incore` / AIV use is rejected because
+  it bypasses those contracts; programmatically constructed internal IR is accepted
+  only after PyPTO revalidates the complete waiter body and orchestration call site.
+- The waiter must be pure AIV, cannot have a dispatch predicate, and cannot use
+  `allow_early_resolve=True`. Pure scalar bookkeeping and control flow may run
+  between registrations, but `tensor.read`, payload/cache operations, and other
+  communication cannot continue after registration begins. This follows Simpler's own
+  early-dispatch contract: leaving the waiter at `False` disqualifies its direct
+  consumers from being pre-staged before the counter-backed TaskId completes.
+  A normal consumer may choose its own `allow_early_resolve` value; that value
+  governs pre-staging of the consumer's downstream tasks, not whether it may
+  bypass the waiter.
+- `signal` must be a direct, window-bound INT32 `DistributedTensor` parameter;
+  slices, views, and other aliases are not supported. V1 accepts only
+  `cmp=pld.WaitCmp.Ge`.
+- Conditions use monotonic uint32 polling (`counter >= expected`) over INT32
+  signal storage. Both `expected` and every published counter value must stay
+  nonnegative in `[0, INT32_MAX]`; for example, storing `-1` is observed as
+  `UINT32_MAX` and would satisfy every valid threshold. Dynamic expected values
+  are checked at runtime. Do not reset or move a counter backwards while an
+  older generation can still be pending, and do not rely on uint32 wraparound.
+- One waiter task may register at most 64 conditions. Separately, one runtime
+  scheduler may track at most 64 concurrently deferred tasks. These are two
+  different limits and neither is a physical-core count.
+- Connect continuation work with the same ordinary `deps=[..., wait_tid]`
+  accepted for any TaskId dependency. Deferred completion does not impose a
+  separate consumer kernel kind or dependency representation. A terminal
+  waiter with no continuation may submit that task scope fire-and-forget and
+  need not capture a TaskId.
+- If a producer never advances the counter to `expected`, the AIV is not
+  spinning, but the TaskId and every dependent consumer remain pending. The
+  protocol must still guarantee eventual notification.
+
+This mechanism is not asynchronous prefetch: `pl.prefetch.*` manages an SDMA
+data-movement session/event, whereas deferred completion gates a scheduler
+TaskId on a remote counter. It is also not host asynchronous execution—there
+is no Python future, host callback, or host thread waiting for the signal.
+Legacy `pld.system.wait` remains unchanged for code that must resume in the same
+kernel and still supports both `Eq` and `Ge`.
 
 ## Tile-Level RMA (`pld.tile.*`)
 
@@ -228,7 +341,7 @@ and shape must match what the peer stored — a mismatch reads garbage.
 | `pld.remote_load(...)` | `pld.tile.remote_load(...)` |
 | `pld.remote_store(...)` | `pld.tile.remote_store(...)` / `pld.tensor.remote_store(...)` (dispatches on `src`) |
 
-**No short form:** `pld.notify(...)`, `pld.wait(...)`, `pld.put(...)`,
+**No short form:** `pld.notify(...)`, `pld.wait(...)`, `pld.defer_wait(...)`, `pld.put(...)`,
 `pld.get(...)`, `pld.allreduce(...)`, and all other collective ops — these
 require the full 3-segment namespace.
 

--- a/docs/en/user/ops/01-catalog.md
+++ b/docs/en/user/ops/01-catalog.md
@@ -177,6 +177,7 @@ Push and pop must be **paired**, and each pop must be matched by a `tfree`. The 
 | Operator | Reach | What it does |
 | -------- | ----- | ------------ |
 | `submit` `spmd_submit` | `pl.` | Dispatch a kernel and capture its producer TaskId |
+| `deps=` | `pl.at`, captured inline `pl.spmd` | Add strict TaskId dependencies; deferred waiters use this same dependency path |
 | `no_dep` | `pl.` | Exclude one argument of one task from dependency tracking |
 | `dump_tag` | `pl.` | Mark a tensor for selective dump |
 
@@ -210,6 +211,7 @@ tutorial at [distributed/00-model.md](../distributed/00-model.md).
 | Get | `pld.tensor.get` | — | — | — | All GM dtypes | `src` must be window-bound. Supports chunked + pipelined staging. |
 | Notify | `pld.system.notify` | `AtomicAdd` / `Set` | — | — | — | Side-effect-only signal deposit. |
 | Wait | `pld.system.wait` | `Eq` / `Ge` | — | — | — | Side-effect-only signal block. |
+| Deferred Wait | `pld.system.defer_wait` | `Ge` only | — | — | INT32 signal | Register a monotonic counter condition without spinning the AIV; Simpler keeps the ordinary waiter TaskId incomplete and later work uses ordinary `deps=[wait_tid]`. |
 | Remote Load | `pld.tile.remote_load` | — | — | — | Any (tile) | Tile-level cross-rank load. |
 | Remote Store | `pld.tile.remote_store` | — | — | — | Any (tile) | Tile-level cross-rank store. |
 

--- a/docs/zh/dev/distributed_ops.md
+++ b/docs/zh/dev/distributed_ops.md
@@ -12,7 +12,7 @@ N6 分布式算子族为 Python DSL 提供了对硬件跨 rank（cross-rank）�
 TPUT/TGET 在该侧只需要一段可读/可写的*本地* GM 区域。窗口绑定的一侧
 （`put.dst`、`get.src`）仍然必须是 `DistributedTensor`。
 
-共有**十四个算子**和**四个 ABI 枚举**：
+共有**十五个算子**和**四个 ABI 枚举**：
 
 | 算子 | 方向 | 结果 | 硬件 |
 | ---- | ---- | ---- | ---- |
@@ -30,8 +30,9 @@ TPUT/TGET 在该侧只需要一段可读/可写的*本地* GM 区域。窗口绑
 | `pld.tensor.all_to_all_v` | 变长 all-to-all（MPI_Alltoallv）——按每个目标推送完整的 MAX_RECV 行容量块，写入平面 2D 暂存窗口（传输大小是每个目标完整的容量块），同时通过 `pld.system.notify`（Set）把 `min(send_counts[dest], MAX_RECV)` 发布到对端 `recv_counts[my_rank, 0]`，使接收方能跳过超出其计数的行；返回窗口作为结果（与对称 `all_to_all` 相同的窗口即结果模式） | `DistributedTensorType`（与 target 相同） | composite / HOST builtin |
 | `pld.system.notify` | 给 peer 的槽位发信号 | `Unknown`（副作用） | TNOTIFY |
 | `pld.system.wait` | 在自身槽位上阻塞 | `Unknown`（副作用） | TWAIT |
+| `pld.system.defer_wait` | 让本任务的逻辑完成等待本地 counter | `Unknown`（副作用） | Simpler completion runtime（无 PTOAS wait op） |
 
-六个仅有副作用（side-effect-only）的算子产生
+七个仅有副作用（side-effect-only）的算子产生
 [`UnknownType`](ir/02-types.md)：它们因跨 rank 副作用而存在，而非为消费者读取的
 SSA 值而存在。
 
@@ -57,8 +58,10 @@ SSA 值而存在。
   tile 由 `ConvertTensorToTileOps` 物化为内部 `pld.tile.get` / `pld.tile.put`,
   不出现在 DSL 表面。因此二者都是 `pld.tensor.alloc_window_buffer` /
   `pld.tensor.window` 的兄弟,而**不是**产出 tile 的 `remote_load` 的兄弟。
-- **`pld.system.notify` / `pld.system.wait`** 驱动按 rank 的信号槽位 —— 纯控制面
-  同步,无数据操作数 —— 因此归入 `pld.system`。
+- **`pld.system.notify` / `pld.system.wait` / `pld.system.defer_wait`** 驱动按
+  rank 的信号槽位 —— 纯控制面同步,无数据操作数 —— 因此归入 `pld.system`。
+  `wait` 阻塞后在原 kernel 内恢复；`defer_wait` 返回并把就绪判断转交给 scheduler
+  TaskId。
 
 ## 混合 kernel 中的核放置
 
@@ -95,12 +98,12 @@ no-duplicate 调用钉在 AIV 通路上；参见 `docs/zh/dev/ir/05-operators.md
 ## ABI 枚举（`include/pypto/ir/comm.h`）
 
 四个枚举是**仅追加（append-only）的 ABI**。它们的底层 `int` 值被序列化为算子的
-kwarg 负载（notify 的 `op`、wait 的 `cmp`、put 的 `atomic`）,并在 codegen 时转
+kwarg 负载（notify 的 `op`、wait/defer_wait 的 `cmp`、put 的 `atomic`）,并在 codegen 时转
 回枚举。新变体只能加在**末尾**,以保证已有 IR 和缓存程序的语义不变。
 
 ```cpp
 enum class NotifyOp : int { kAtomicAdd = 0, kSet = 1 };   // pld.system.notify
-enum class WaitCmp  : int { kEq = 0,        kGe = 1 };     // pld.system.wait
+enum class WaitCmp  : int { kEq = 0,        kGe = 1 };     // pld.system.wait / defer_wait
 enum class AtomicType : int { kNone = 0,    kAdd = 1 };    // pld.tensor.put、remote_store
 enum class ReduceOp : int { kSum = 0, kMax = 1, kMin = 2, kProd = 3 };  // pld.tensor.allreduce
 ```
@@ -110,7 +113,7 @@ enum class ReduceOp : int { kSum = 0, kMax = 1, kMin = 2, kProd = 3 };  // pld.t
 | `NotifyOp` | `kAtomicAdd` | 原子地把 `value` 加到 peer 的信号槽位 |
 | `NotifyOp` | `kSet` | 非原子地把 `value` 存入 peer 的信号槽位 |
 | `WaitCmp` | `kEq` | 阻塞直到 `*signal_slot == expected` |
-| `WaitCmp` | `kGe` | 阻塞直到 `*signal_slot >= expected` |
+| `WaitCmp` | `kGe` | 等待或延迟任务完成，直到 `*signal_slot >= expected` |
 | `AtomicType` | `kNone` | 普通远程写 —— 覆盖 peer 的 dst 切片 |
 | `AtomicType` | `kAdd` | 原子地把源数据加到 peer 的 dst 切片 |
 | `ReduceOp` | `kSum` | 对所有参与 rank 的窗口切片做求和规约 |
@@ -521,9 +524,43 @@ pld.system.wait(signal, offsets, expected, *, cmp: int) -> Unknown
 Verifier：`signal` 必须是 `DistributedTensorType`；`expected` 必须是
 `ScalarType`；`offsets` 必须是 rank 等于 signal rank 的 `MakeTuple`。
 
+### `pld.system.defer_wait`（Simpler 延迟完成）
+
+```text
+pld.system.defer_wait(signal, offsets, expected, *, cmp: int) -> Unknown
+```
+
+把本地 counter 条件注册后立即返回，不发出 `pto.comm.twait`。waiter kernel 可以结束并
+释放物理 AIV，但 Simpler 会延迟这个普通 TaskId 的完成，直到所有条件就绪；kernel
+不会被恢复。
+
+V1 只接受直接作为参数传入、绑定 window 的 INT32 `DistributedTensor`，采用 ND/DN
+寻址，offset 与 threshold 为整数/index，且仅支持 `WaitCmp::kGe`。slice/view/SSA alias、
+NZ layout 与零维 signal 都会被拒绝。storage 是 INT32，但按无符号 `>=` 轮询；threshold
+和发布值必须在 `[0, INT32_MAX]` 内单调前进，`-1` 会呈现为 `UINT32_MAX` 并错误满足。
+每个 task 最多注册 64 个条件；scheduler 同时最多跟踪 64 个延迟 task，这是另一限制。
+
+Scope outliner 要求 waiter 是专用、顶层、单 block 的 pure-AIV `pl.at(CORE_GROUP)`，
+不能带 predicate 或 `allow_early_resolve=True`。registration 之间可执行纯标量
+bookkeeping/control flow；一旦开始 registration，不能再执行 `tensor.read`、payload/cache
+操作或其他通信。没有 continuation 的末端 waiter 可以 fire-and-forget，无需捕获 TaskId。
+未标记而直接从 `@pl.jit.incore` / AIV 使用仍会被拒绝，因为它绕过了已验证的 single-block
+task launch 与 runtime `AsyncCtx` 契约。以编程方式构造且携带内部 waiter marker 的 IR，只有
+在完整 waiter body 与 orchestration call-site 契约重新验证通过后才会被接受。
+
+Continuation 继续使用普通 `deps=[wait_tid]`，不引入第二种依赖类型。Simpler 在 counter
+就绪前扣留普通 TaskId fanout，之后正常派发 consumer 并执行标准 task-start cache
+invalidation。producer 仍必须先让 payload 可见再发布 signal；waiter 也必须禁止 early
+resolve，避免 consumer 在 readiness 之前被取得。
+
+Codegen 把经过检查、展平的 offset 与原始 dispatch arguments 传给 wrapper adapter；
+adapter 取得 `AsyncCtx`、注册 counter `CompletionToken`，并 flush 注册或错误状态。旧的
+`pld.system.wait` / `pto.comm.twait` 路径保持不变。完整编程契约与示例见
+[分布式原语指南](../user/distributed/02-primitives.md#延迟完成释放物理核保留逻辑任务)。
+
 ## 共享 codegen 基础设施
 
-六个算子全部经由 `src/backend/common/pto_ops_distributed.cpp` 和
+底层 RMA 与同步算子经由 `src/backend/common/pto_ops_distributed.cpp` 和
 `src/codegen/pto/pto_codegen.cpp` 中的 PTO codegen 辅助函数下降。共享的可复用部件
 —— 使每个算子的下降都不携带专门的 peer 算术 —— 如下：
 
@@ -535,10 +572,12 @@ Verifier：`signal` 必须是 `DistributedTensorType`；`expected` 必须是
 | `ResolveDistTensorBinding` | 把 `DistributedTensor` 实参解析为其 codegen 绑定（类型 + 窗口变量） |
 | `AsTensorTypeLike` | kind-trait 向下转换,在统一读取视图 element/shape 信息处同时接受 `TensorType` 与 `DistributedTensorType` |
 
-本地与远程的拆分是有意的：*本地*操作数（如 `get` 的 `dst`、`put` 的 `src`、`wait` 的 `signal`）
-复用 `EmitMakeTensorViews` 已创建的 tensor view,无 peer 算术；而*远程*操作数
+本地与远程的拆分是有意的：*本地* PTO 操作数（如 `get` 的 `dst`、`put` 的
+`src`、`wait` 的 `signal`）复用 `EmitMakeTensorViews` 已创建的 tensor view,无
+peer 算术；而*远程*操作数
 （如 `remote_load` 的 `target`、`get` 的 `src`、`put` 的 `dst`）则经由
-`EmitCommRemoteView`。
+`EmitCommRemoteView`。`defer_wait` 同样是本地操作，但其 adapter 接收直接参数 base
+与经过检查、展平后的逻辑 element offset，而不是 PTO tensor view。
 
 ## 流水线集成
 
@@ -570,5 +609,8 @@ host_orch 函数体包裹进嵌套的 `CommDomainScopeStmt` 节点（按推断�
   `tests/st/distributed/` 下其他 L3 ST。**Put/Get 端到端权威契约** 已启用：
   `test_l3_put.py`（环形覆写、行偏移 put、原子加 put、分块/流水 transfer ✅）、
   `test_l3_get.py`（环形读、行偏移 get ✅）、以及 `test_l3_remote_store.py`
-  （tile 级子视图 push ✅，以及 tensor 级*计算值* push ✅）。所有测试均采用由 notify/wait 和集体 ST 建立的
+  （tile 级子视图 push ✅，以及 tensor 级*计算值* push ✅）。Deferred completion 由
+  `test_l3_deferred_completion.py` 覆盖：A2/A3 AIV 饱和与退核、counter 已就绪时的
+  注册复用、A5 跨 rank 正确性、持久窗口单调 epoch，以及普通 TaskId 依赖门控。
+  其他通信 ST 采用由 notify/wait 和集体 ST 建立的
   `pld.system.notify` / `pld.system.wait` 握手模式。

--- a/docs/zh/user/distributed/02-primitives.md
+++ b/docs/zh/user/distributed/02-primitives.md
@@ -28,6 +28,7 @@
 | `nranks` | `(ctx: Ctx) -> Scalar` | **仅限 InCore。** 通信组中 rank 数量。 |
 | `notify` | `(target, peer, offsets, value, *, op) -> Call` | **仅限 InCore。** 跨 rank 信号投递。仅副作用。 |
 | `wait` | `(signal, offsets, expected, *, cmp) -> Call` | **仅限 InCore。** 跨 rank 等待。仅副作用。 |
+| `defer_wait` | `(signal, offsets, expected, *, cmp) -> Call` | **仅限专用的顶层 `pl.at(CORE_GROUP)` waiter。** 注册 `signal[offsets] >= expected` 完成条件并返回，不让 AIV 自旋；条件满足前，所在任务的 TaskId 保持未完成。 |
 
 ## Window Buffer 管理 (`pld.tensor.*`)
 
@@ -96,6 +97,101 @@ def handshake_step(
 
 > **Buffer 重用安全：** Signal 使用单调计数器且不会自重置。不要在背靠背集合通信中
 > 重用同一 signal buffer。每次调用分配新 buffer。
+
+## 延迟完成：释放物理核，保留逻辑任务
+
+`pld.system.wait` 是阻塞式 `TWAIT`：AIV 留在 kernel 内，等待之后的语句继续在同一
+AIV 上执行。`pld.system.defer_wait` 的契约不同。它向 runtime 注册计数器条件后即
+返回；专用 waiter kernel 结束时，**物理 AIV 已释放**，但 waiter 的**逻辑 TaskId
+仍未完成**。只有全部注册条件都满足后，scheduler 才会解析该 TaskId。原 kernel
+不会恢复执行，因此 continuation 必须放在独立任务中。
+
+```python
+# 每个 rank 的 publisher 独立运行：先发布 payload，再发布 signal。
+with pl.at(level=pl.Level.CORE_GROUP, name_hint="publish"):
+    pld.tensor.remote_store(payload_value, peer_payload, peer, [0, 0])
+    pld.system.notify(
+        signal, peer=peer, offsets=[my_rank, 0],
+        value=epoch, op=pld.NotifyOp.Set,
+    )
+
+# Receiver：观察 peer publisher。这里有意不添加本地 publisher -> waiter 依赖；
+# 只有存在真实的本地顺序要求时才添加 deps。
+with pl.at(
+    level=pl.Level.CORE_GROUP,
+    name_hint="payload_wait",
+    allow_early_resolve=False,
+) as wait_tid:
+    pld.system.defer_wait(
+        signal, offsets=[peer, 0], expected=epoch,
+        cmp=pld.WaitCmp.Ge,
+    )
+
+# wait_tid 在逻辑上完成之后，consumer 才会被派发。
+with pl.at(
+    level=pl.Level.CORE_GROUP,
+    name_hint="consume_payload",
+    deps=[wait_tid],
+) as consume_tid:
+    payload_tile = pl.load(peer_payload, [0, 0], [1, WIDTH])
+    # ... consume payload_tile ...
+```
+
+内联 SPMD consumer 同样使用捕获形式：
+
+```python
+with pl.spmd(
+    NUM_BLOCKS,
+    name_hint="consume_payload_spmd",
+    deps=[wait_tid],
+) as consume_tid:
+    block = pl.get_block_idx()
+    # ... each AIV block reads its payload partition ...
+```
+
+延迟完成不引入第二套依赖命名空间。`deps` 仍表示普通的严格 TaskId 依赖：waiter 的
+AIV 结束后，Simpler 动态延迟这个普通 TaskId 的完成，因此已存在的依赖边要等注册的
+counter 达标后才会释放 consumer。Simpler 的标准 AICore executor 会在取得每个任务后
+立即失效整个 data cache；该操作位于可选的 speculative gate 之前，也位于任务 kernel
+读取输入之前。waiter 不允许 early resolve，因此其直接 consumer 不会被预放到这个 gate，
+而只会在 counter-backed TaskId 完成后通过普通路径被取得；该 consumer 的任务起始
+invalidation 因而发生在 readiness 之后。producer 端仍必须在发布 notify
+**之前**让所有 payload 写入可见；任务开始时的 cache invalidation 无法修复先 notify、
+后写数据的错误。
+
+### 延迟等待契约
+
+- 把 `defer_wait` 放在专用的顶层 task
+  `with pl.at(level=pl.Level.CORE_GROUP) as wait_tid:` 作用域内。该 task-level launch
+  让 PyPTO 能验证 single-block 执行并提供 runtime `AsyncCtx`。未标记而直接从
+  `@pl.jit.incore` / AIV 使用会因绕过这些契约而被拒绝；以编程方式构造的内部 IR 只有在
+  PyPTO 重新验证完整 waiter body 与 orchestration call site 后才会被接受。
+- Waiter 必须是 pure AIV，不能带 dispatch predicate，也不能使用
+  `allow_early_resolve=True`。registration 之间可以执行纯标量 bookkeeping 与控制流，但
+  registration 开始后不能继续做 `tensor.read`、payload/cache 操作或其他通信。这正是 Simpler 自身的 early-dispatch
+  契约：waiter 保持 `False` 会使其直接 consumer 不具备在 counter-backed TaskId 完成前
+  预派发的资格。普通 consumer 可以按需设置自己的 `allow_early_resolve`；该值控制的是
+  consumer 的下游任务能否预派发，而不是让当前 consumer 绕过 waiter。
+- `signal` 必须是直接作为参数传入、绑定 window 的 INT32 `DistributedTensor`；
+  v1 不支持 slice、view 或其他 alias，且仅接受 `cmp=pld.WaitCmp.Ge`。
+- 条件在 INT32 signal storage 上按单调 uint32 轮询（`counter >= expected`）。
+  `expected` 和每一个发布的 counter 值都必须保持非负并位于 `[0, INT32_MAX]`；例如写入
+  `-1` 会被观察成 `UINT32_MAX`，从而错误满足所有合法 threshold。动态 expected 值在
+  运行时检查。旧 generation 仍可能 pending 时，不要重置 counter 或让其后退，也不要
+  依赖 uint32 回绕。
+- 单个 waiter task 最多注册 64 个条件。另有一个独立限制：每个 runtime scheduler
+  最多同时跟踪 64 个延迟任务。这两个 64 含义不同，且都不是物理核数。
+- continuation 使用与任意 TaskId 相同的普通 `deps=[..., wait_tid]` 连接。延迟完成不要求
+  另一种 consumer kernel 类型或依赖表示。没有 continuation 的末端 waiter 可以在同一
+  task 作用域中 fire-and-forget，无需捕获 TaskId。
+- 如果 producer 永远没有把 counter 推进到 `expected`，AIV 虽不再自旋，TaskId 及
+  所有依赖它的 consumer 仍会一直 pending。协议仍必须保证 notify 最终到达。
+
+该机制不是异步预取：`pl.prefetch.*` 管理的是 SDMA 数据搬运 session/event，而延迟
+完成机制是在远程 counter 上门控 scheduler TaskId。它也不是 host 异步执行——没有
+Python future、host callback 或等待信号的 host thread。需要在同一个 kernel 中从
+等待点继续执行的代码仍使用原有 `pld.system.wait`；其行为不变，并继续支持 `Eq` 和
+`Ge`。
 
 ## Tile 级 RMA (`pld.tile.*`)
 
@@ -206,7 +302,7 @@ for peer in pl.range(nranks):
 | `pld.remote_load(...)` | `pld.tile.remote_load(...)` |
 | `pld.remote_store(...)` | `pld.tile.remote_store(...)` / `pld.tensor.remote_store(...)`（按 `src` 分派） |
 
-**无短格式：** `pld.notify(...)`、`pld.wait(...)`、`pld.put(...)`、
+**无短格式：** `pld.notify(...)`、`pld.wait(...)`、`pld.defer_wait(...)`、`pld.put(...)`、
 `pld.get(...)`、`pld.allreduce(...)` 等——这些需要完整的 3 段命名空间。
 
 ## 可运行示例

--- a/docs/zh/user/ops/01-catalog.md
+++ b/docs/zh/user/ops/01-catalog.md
@@ -166,6 +166,7 @@ push 与 pop 必须**配对**，且每次 pop 都必须有对应的 `tfree`。�
 | 算子 | 可达 | 作用 |
 | ---- | ---- | ---- |
 | `submit` `spmd_submit` | `pl.` | 派发 kernel 并捕获其生产者 TaskId |
+| `deps=` | `pl.at`、内联捕获形式 `pl.spmd` | 添加严格 TaskId 依赖；deferred waiter 使用同一条依赖路径 |
 | `no_dep` | `pl.` | 让单个任务的单个实参退出依赖跟踪 |
 | `dump_tag` | `pl.` | 标记张量做选择性 dump |
 
@@ -197,6 +198,7 @@ push 与 pop 必须**配对**，且每次 pop 都必须有对应的 `tfree`。�
 | Get | `pld.tensor.get` | — | — | — | 所有 GM dtype | `src` 必须是 window-bound。支持分块和流水线 staging。 |
 | Notify | `pld.system.notify` | `AtomicAdd` / `Set` | — | — | — | 仅副作用的信号投递。 |
 | Wait | `pld.system.wait` | `Eq` / `Ge` | — | — | — | 仅副作用的信号阻塞。 |
+| Deferred Wait | `pld.system.defer_wait` | 仅 `Ge` | — | — | INT32 signal | 注册单调 counter 条件而不让 AIV 自旋；Simpler 保持普通 waiter TaskId 未完成，后续工作使用普通 `deps=[wait_tid]`。 |
 | Remote Load | `pld.tile.remote_load` | — | — | — | 任意（tile） | Tile 级跨 rank 加载。 |
 | Remote Store | `pld.tile.remote_store` | — | — | — | 任意（tile） | Tile 级跨 rank 写入。 |
 

--- a/include/pypto/codegen/pto/pto_codegen.h
+++ b/include/pypto/codegen/pto/pto_codegen.h
@@ -484,6 +484,30 @@ class PTOCodegen : public CodegenBase {
   [[nodiscard]] std::string GetSdmaWorkspaceArgSSA() const { return fs_.sdma_workspace_arg_ssa; }
 
   /**
+   * @brief SSA name of the synthetic raw dispatch-args pointer parameter.
+   *
+   * Functions containing ``pld.system.defer_wait`` receive one hidden
+   * ``!pto.ptr<i64>`` parameter after dynamic dimensions and before other
+   * runtime-owned parameters. The kernel wrapper forwards its ``args`` pointer
+   * through this slot so deferred-completion lowering can reach the runtime's
+   * per-task AsyncCtx. Returns empty for functions without deferred waits.
+   */
+  [[nodiscard]] std::string GetDeferredCompletionRawArgsSSA() const {
+    return fs_.deferred_completion_raw_args_ssa;
+  }
+
+  /**
+   * @brief Register the module-level deferred counter-completion adapter.
+   *
+   * ``pld.system.defer_wait`` lowering calls this when it emits the adapter
+   * call. The declaration is emitted once at module scope and implemented by
+   * the generated C++ kernel wrapper.
+   *
+   * @return Stable adapter symbol name.
+   */
+  std::string RegisterDeferredCompletionAdapter();
+
+  /**
    * @brief SSA name of the synthetic SPMD block_idx param.
    *
    * When the current function uses tile.get_block_idx / tile.get_block_num,
@@ -702,6 +726,9 @@ class PTOCodegen : public CodegenBase {
    * @brief Collect deterministic GM slot buffer byte offsets for frontend pipe ids in a module.
    */
   void PrepareGMSlotBufferLayout(const ir::ProgramPtr& program);
+
+  /// Emit the external declaration implemented by the generated kernel wrapper.
+  void EmitDeferredCompletionAdapterDeclaration();
 
   /**
    * @brief Build variable identity to MemRef mapping from function body
@@ -946,6 +973,9 @@ class PTOCodegen : public CodegenBase {
     /// Empty when the current function does not use prefetch.make_context.
     std::string sdma_workspace_arg_ssa;
 
+    /// Raw runtime dispatch-args pointer used by deferred completion adapters.
+    std::string deferred_completion_raw_args_ssa;
+
     /// SSA names of the synthetic SPMD block_idx/block_num params, appended at
     /// the func.func signature tail. Empty when the current function does not
     /// use tile.get_block_idx / tile.get_block_num.
@@ -1013,6 +1043,7 @@ class PTOCodegen : public CodegenBase {
       ffts_workspace_vars.clear();
 
       sdma_workspace_arg_ssa.clear();
+      deferred_completion_raw_args_ssa.clear();
       spmd_block_idx_arg.clear();
       spmd_block_num_arg.clear();
       spmd_subblock_idx_arg.clear();
@@ -1030,6 +1061,9 @@ class PTOCodegen : public CodegenBase {
   std::ostringstream stream_;
   int indent_level_ = 0;
   std::map<std::pair<int, int>, int64_t> gm_slot_buffer_offsets_;
+
+  /// True when the module needs the wrapper-defined counter-completion adapter.
+  bool needs_deferred_completion_adapter_ = false;
 
   const backend::Backend* backend_;  ///< Backend instance for querying op info
 

--- a/include/pypto/ir/expr.h
+++ b/include/pypto/ir/expr.h
@@ -695,6 +695,16 @@ inline std::vector<std::pair<std::string, std::any>> WithArgDirectionOverridesAt
 inline constexpr const char* kAttrManualDepEdges = "manual_dep_edges";
 
 /**
+ * @brief Marks an outlined InCore function as a dedicated deferred waiter.
+ *
+ * Value type: ``bool``. ``ScopeOutliner`` sets this after validating the
+ * waiter-only structural contract. ``ExpandMixedKernel`` uses it for the
+ * final pure-AIV check. A caller captures the ordinary TaskId only when a
+ * later task needs to depend on the deferred completion.
+ */
+inline constexpr const char* kAttrDeferredCompletionWaiter = "deferred_completion_waiter";
+
+/**
  * @brief Reserved attr key marking an internal dependency-only TaskId call.
  *
  * Value type: ``bool``. Written by the manual phase-fence expansion pass on

--- a/include/pypto/ir/transforms/utils/scope_outline_utils.h
+++ b/include/pypto/ir/transforms/utils/scope_outline_utils.h
@@ -106,6 +106,232 @@ class PostStoreAliasCollector : public IRVisitor {
 };
 
 /**
+ * @brief Return whether @p body contains a deferred-completion registration.
+ *
+ * Keep the visitor private to this small shared query so scope outlining and
+ * late validation cannot drift into separate operator-detection rules.
+ */
+[[nodiscard]] inline bool ContainsDeferredWait(const StmtPtr& body) {
+  class Finder : public IRVisitor {
+   public:
+    bool found = false;
+
+   protected:
+    void VisitExpr_(const CallPtr& call) override {
+      if (IsOp(call, "pld.system.defer_wait")) found = true;
+      IRVisitor::VisitExpr_(call);
+    }
+  };
+
+  Finder finder;
+  finder.VisitStmt(body);
+  return finder.found;
+}
+
+/**
+ * @brief Validate the dedicated deferred-waiter kernel body contract.
+ *
+ * A waiter may use scalar expressions and sequential scalar control flow to
+ * compute/register conditions, but must not perform payload, cache, or other
+ * communication work.  Once a defer_wait registration has executed on a
+ * path, only more registrations or scalar bookkeeping may follow.  The
+ * registration upper bound is proved statically. Conditional registration
+ * (the common ``if peer != rank`` form) may execute zero times; Simpler accepts
+ * that as an already-complete waiter. Loops with an unknown trip count are
+ * rejected because they cannot prove the runtime's 64-condition limit.
+ */
+class DeferredWaitContractValidator {
+ public:
+  struct Result {
+    bool has_deferred_wait = false;
+    int64_t static_max_count = 0;
+    // True when this subtree is safe to execute after an earlier condition was
+    // registered. Control flow, pure scalar bookkeeping, and further
+    // registrations are safe; tensor reads and continuation work are not.
+    bool safe_after_registration = true;
+  };
+
+  static Result Validate(const StmtPtr& body, const Span& span) {
+    // Most InCore scopes are ordinary payload kernels. Keep the strict waiter
+    // validator off that hot path: first perform a side-effect-free recursive
+    // probe, then validate the complete scope only when it really contains a
+    // deferred registration.
+    if (!ContainsDeferredWait(body)) return {};
+
+    DeferredWaitContractValidator validator(span);
+    auto result = validator.ValidateStmt(body);
+    INTERNAL_CHECK_SPAN(result.has_deferred_wait, span)
+        << "Internal error: deferred-wait finder/validator disagreement";
+    CHECK_SPAN(result.static_max_count <= 64, span)
+        << "deferred waiter supports at most 64 conditions, but may statically register "
+        << result.static_max_count;
+    return result;
+  }
+
+ private:
+  explicit DeferredWaitContractValidator(Span span) : span_(std::move(span)) {}
+
+  Result ValidateStmt(const StmtPtr& stmt) const {
+    if (auto seq = As<SeqStmts>(stmt)) {
+      Result total;
+      bool registration_started = false;
+      for (const auto& child : seq->stmts_) {
+        auto child_result = ValidateStmt(child);
+        CHECK_SPAN(!registration_started || child_result.safe_after_registration, child->span_)
+            << "deferred waiter cannot execute tensor reads, payload, cache, communication, or "
+               "continuation work after pld.system.defer_wait registration begins";
+        registration_started = registration_started || child_result.has_deferred_wait;
+        Merge(&total, child_result);
+      }
+      return total;
+    }
+    if (auto eval = As<EvalStmt>(stmt)) {
+      return ValidateCall(As<Call>(eval->expr_), stmt->span_);
+    }
+    if (auto assign = As<AssignStmt>(stmt)) {
+      auto call = As<Call>(assign->value_);
+      if (call && IsOp(call, "pld.system.defer_wait")) {
+        CHECK_SPAN(false, stmt->span_)
+            << "pld.system.defer_wait is side-effect-only and must be used as a standalone statement";
+      }
+      CHECK_SPAN(!assign->var_ || !AsTensorTypeLike(assign->var_->GetType()), stmt->span_)
+          << "deferred waiter is registration-only and cannot create or update payload tensors";
+      auto effect = ValidateScalarExpr(assign->value_, stmt->span_, /*allow_tensor_read=*/true);
+      return Result{false, 0, effect == ScalarEffect::kPure};
+    }
+    if (auto ret = As<ReturnStmt>(stmt)) {
+      CHECK_SPAN(ret->value_.empty(), stmt->span_)
+          << "deferred waiter is registration-only and cannot return a value";
+      // Scope outlining appends an empty function return. It is structural,
+      // not continuation work, and remains safe after registrations.
+      return Result{false, 0, true};
+    }
+    if (auto loop = As<ForStmt>(stmt)) {
+      CHECK_SPAN(loop->kind_ == ForKind::Sequential || loop->kind_ == ForKind::Unroll, stmt->span_)
+          << "deferred waiter supports only sequential/unrolled scalar registration loops";
+      ValidateScalarExpr(loop->start_, stmt->span_, /*allow_tensor_read=*/false);
+      ValidateScalarExpr(loop->stop_, stmt->span_, /*allow_tensor_read=*/false);
+      ValidateScalarExpr(loop->step_, stmt->span_, /*allow_tensor_read=*/false);
+      auto body_result = ValidateStmt(loop->body_);
+      CHECK_SPAN(body_result.has_deferred_wait, stmt->span_)
+          << "deferred waiter loop must register at least one pld.system.defer_wait condition";
+      auto trip_count = transform_utils::EvalConstTripCount(loop);
+      CHECK_SPAN(trip_count > 0, stmt->span_)
+          << "deferred waiter registration loop must have a statically known positive trip count "
+             "so the 64-condition limit can be proved";
+      CHECK_SPAN(trip_count == 1 || body_result.safe_after_registration, stmt->span_)
+          << "deferred waiter loop may execute tensor reads or continuation work after registering its "
+             "first condition; loop bodies may contain only pure scalar bookkeeping, control flow, "
+             "and defer_wait registrations";
+      // Saturate just above the supported limit rather than multiplying
+      // unchecked: enormous constant bounds must fail the <=64 contract, not
+      // wrap int64_t and accidentally pass it.
+      body_result.static_max_count =
+          body_result.static_max_count > 64 / trip_count ? 65 : body_result.static_max_count * trip_count;
+      return body_result;
+    }
+    if (auto branch = As<IfStmt>(stmt)) {
+      ValidateScalarExpr(branch->condition_, stmt->span_, /*allow_tensor_read=*/false);
+      auto then_result = ValidateStmt(branch->then_body_);
+      auto else_result = branch->else_body_.has_value() ? ValidateStmt(*branch->else_body_) : Result{};
+      Result result;
+      result.has_deferred_wait = then_result.has_deferred_wait || else_result.has_deferred_wait;
+      result.static_max_count = std::max(then_result.static_max_count, else_result.static_max_count);
+      result.safe_after_registration =
+          then_result.safe_after_registration && else_result.safe_after_registration;
+      return result;
+    }
+    CHECK_SPAN(false, stmt ? stmt->span_ : span_)
+        << "deferred waiter body supports only scalar assignments/control flow and "
+           "pld.system.defer_wait registrations";
+    return {};
+  }
+
+  Result ValidateCall(const CallPtr& call, const Span& span) const {
+    CHECK_SPAN(call, span) << "deferred waiter contains a non-call side-effect statement";
+    if (IsOp(call, "pld.system.defer_wait")) {
+      INTERNAL_CHECK_SPAN(call->args_.size() == 3, span)
+          << "Internal error: pld.system.defer_wait argument count was not verified";
+      auto offsets = As<MakeTuple>(call->args_[1]);
+      INTERNAL_CHECK_SPAN(offsets, span) << "Internal error: pld.system.defer_wait offsets were not verified";
+      for (const auto& offset : offsets->elements_) {
+        ValidateScalarExpr(offset, span, /*allow_tensor_read=*/false);
+      }
+      ValidateScalarExpr(call->args_[2], span, /*allow_tensor_read=*/false);
+      return Result{true, 1, true};
+    }
+    CHECK_SPAN(false, span) << "deferred waiter is registration-only; unexpected operation '"
+                            << call->op_->name_ << "'";
+    return {};
+  }
+
+  enum class ScalarEffect {
+    kPure,
+    kTensorRead,
+  };
+
+  static ScalarEffect MergeScalarEffects(ScalarEffect lhs, ScalarEffect rhs) {
+    return lhs == ScalarEffect::kTensorRead || rhs == ScalarEffect::kTensorRead ? ScalarEffect::kTensorRead
+                                                                                : ScalarEffect::kPure;
+  }
+
+  ScalarEffect ValidateScalarExpr(const ExprPtr& expr, const Span& span, bool allow_tensor_read) const {
+    if (!expr) return ScalarEffect::kPure;
+    CHECK_SPAN(!AsTensorTypeLike(expr->GetType()), span)
+        << "deferred waiter scalar bookkeeping cannot produce a tensor value";
+    if (auto call = As<Call>(expr)) {
+      const bool permitted_anchor = allow_tensor_read && IsOp(call, "tensor.read");
+      // Fail closed: a scalar-returning GlobalVar or newly added op may still
+      // hide communication, a blocking wait, or payload effects. V1 needs only
+      // an explicit pre-registration tensor.read anchor; scalar arithmetic and
+      // casts are represented by their own IR expression nodes.
+      CHECK_SPAN(permitted_anchor, span)
+          << "deferred waiter scalar bookkeeping supports only a pre-registration tensor.read call; "
+             "unexpected operation '"
+          << call->op_->name_ << "'";
+      // The first tensor.read argument is the tensor source. Skip that
+      // position, not every ExprPtr that happens to alias it.
+      for (size_t i = 1; i < call->args_.size(); ++i) {
+        ValidateScalarExpr(call->args_[i], span, /*allow_tensor_read=*/false);
+      }
+      return ScalarEffect::kTensorRead;
+    }
+    if (auto binary = As<BinaryExpr>(expr)) {
+      auto lhs = ValidateScalarExpr(binary->left_, span, allow_tensor_read);
+      auto rhs = ValidateScalarExpr(binary->right_, span, allow_tensor_read);
+      return MergeScalarEffects(lhs, rhs);
+    }
+    if (auto unary = As<UnaryExpr>(expr)) {
+      return ValidateScalarExpr(unary->operand_, span, allow_tensor_read);
+    }
+    if (auto tuple = As<MakeTuple>(expr)) {
+      auto effect = ScalarEffect::kPure;
+      for (const auto& element : tuple->elements_) {
+        effect = MergeScalarEffects(effect, ValidateScalarExpr(element, span, allow_tensor_read));
+      }
+      return effect;
+    }
+    if (auto get = As<TupleGetItemExpr>(expr)) {
+      return ValidateScalarExpr(get->tuple_, span, allow_tensor_read);
+    }
+    if (AsVarLike(expr) || As<ConstInt>(expr) || As<ConstFloat>(expr) || As<ConstBool>(expr)) {
+      return ScalarEffect::kPure;
+    }
+    CHECK_SPAN(false, span) << "deferred waiter scalar bookkeeping contains unsupported expression '"
+                            << expr->TypeName() << "'";
+    return ScalarEffect::kPure;
+  }
+
+  static void Merge(Result* dst, const Result& src) {
+    dst->has_deferred_wait = dst->has_deferred_wait || src.has_deferred_wait;
+    dst->static_max_count += src.static_max_count;
+    dst->safe_after_registration = dst->safe_after_registration && src.safe_after_registration;
+  }
+
+  Span span_;
+};
+
+/**
  * @brief Summarize the SplitMode of the nested SplitAivScopeStmt regions.
  *
  * The explicit ``pl.split_aiv`` form is a first-class node in the InCore body,
@@ -494,6 +720,15 @@ class ScopeOutliner : public IRMutator {
    *      treated as outputs so the caller retains access.
    */
   [[nodiscard]] std::unordered_set<const Var*> ComputeFallbackUsedAfter(const ScopeStmtPtr& scope) const {
+    // A deferred-completion waiter is registration-only: its scalar
+    // bookkeeping and loop induction variables are local implementation
+    // details, never semantic outputs.  In particular, exporting all local
+    // definitions from a terminal waiter would try to return a loop variable
+    // outside the ForStmt that defines it.  OutlineScope validates the full
+    // waiter contract immediately after this fallback is computed, so no
+    // legitimate store/output can be hidden by returning an empty set here.
+    if (ContainsDeferredWait(scope->body_)) return {};
+
     StoreTargetCollector store_collector;
     store_collector.VisitStmt(scope->body_);
     std::unordered_set<const Var*> used_after;
@@ -724,6 +959,19 @@ class ScopeOutliner : public IRMutator {
     known_names_.insert(outlined_func_name);
     if (reserved_func_names_ != nullptr) {
       reserved_func_names_->insert(outlined_func_name);
+    }
+
+    auto deferred_wait = DeferredWaitContractValidator::Validate(op->body_, op->span_);
+    if (deferred_wait.has_deferred_wait) {
+      CHECK_SPAN(op->GetScopeKind() == ScopeKind::InCore, op->span_)
+          << "pld.system.defer_wait must be the body of a CORE_GROUP / InCore task";
+      CHECK_SPAN(!inside_nested_scope_body_, op->span_)
+          << "pld.system.defer_wait must be in a task-level pl.at(CORE_GROUP) scope; nesting the "
+             "waiter under pl.spmd or another task-launch scope is unsupported because the outer "
+             "launch owns dispatch predicate and early-resolve semantics";
+      CHECK_SPAN(!op->GetAttr<ExprPtr>(kAttrPredicate, nullptr), op->span_)
+          << "pld.system.defer_wait task cannot use a dispatch predicate; every submitted waiter "
+             "must register its completion condition";
     }
 
     // Definitions made by the scope body (before recursing) — the basis for the
@@ -1088,6 +1336,11 @@ class ScopeOutliner : public IRMutator {
         outlined_attrs.emplace_back("windowize", true);
       }
     };
+    auto append_deferred_completion_waiter_attr = [&]() {
+      if (deferred_wait.has_deferred_wait) {
+        outlined_attrs.emplace_back(kAttrDeferredCompletionWaiter, true);
+      }
+    };
     // Bridge the first-class SplitAivScopeStmt region into the function-level
     // AIV-split markers the downstream contract (passes 11-24) expects. The
     // explicit ``pl.split_aiv`` form is a node in the body, not a scope attr
@@ -1153,6 +1406,7 @@ class ScopeOutliner : public IRMutator {
       append_split_attr(incore->split_);
       append_slot_num_attr();
       append_windowize_attr();
+      append_deferred_completion_waiter_attr();
       append_split_aiv_attr(incore->split_);
     }
     std::optional<Level> outlined_level;
@@ -1222,6 +1476,10 @@ class ScopeOutliner : public IRMutator {
     // Threaded onto the synthesised Submit below — same hint as
     // ``pl.submit(..., allow_early_resolve=True)``.
     bool scope_allow_early_resolve = op->GetAttr<bool>("allow_early_resolve", false);
+    CHECK_SPAN(!deferred_wait.has_deferred_wait || !scope_allow_early_resolve, op->span_)
+        << "pl.at(...) containing pld.system.defer_wait cannot use "
+           "allow_early_resolve=True; the waiter's TaskId must remain unresolved until its "
+           "registered signal condition is satisfied";
     // Dispatch predicate (``with pl.spmd(..., predicate=(t[i] > 0)):``). Rides
     // on the scope from parse through SSA (which versions the Vars inside it);
     // moved onto ``Submit::predicate_`` below, after which the attr is gone —

--- a/python/pypto/backend/pto_backend.py
+++ b/python/pypto/backend/pto_backend.py
@@ -255,6 +255,7 @@ _KERNEL_HEADER = """\
 
 {subblock_override}#include <pto/pto-inst.hpp>
 #include "tensor.h"
+{deferred_completion_include}
 {spmd_override}
 
 #if defined(__CPU_SIM)
@@ -301,6 +302,104 @@ static inline void dsb(mem_dsb_t) {{
 
 using namespace pto;
 
+"""
+
+_DEFERRED_COMPLETION_ADAPTER = """\
+// --- Deferred completion adapter ---
+// ABI precondition: supported Simpler dispatchers provide kernel_entry with a
+// valid LocalContext whose AsyncCtx owns a live deferred-completion slab.
+// get_async_ctx intentionally follows that scheduler ABI directly.
+static __aicore__ void pypto_register_counter_completion(
+    __gm__ int64_t* raw_args,
+    __gm__ int32_t* counter_base,
+    int64_t element_offset,
+    int64_t expected)
+{
+    AsyncCtx ctx = get_async_ctx(raw_args);
+    if (!async_ctx_is_deferred(ctx)) {
+        // A supported dispatcher always supplies a live task token and slab.
+        // If the token is corrupted but the slab pointers remain coherent,
+        // publish a scheduler-visible error instead of returning as an
+        // ordinary completed task. defer_flush validates the token, so mark
+        // only this local AsyncCtx copy valid after recording the error.
+        if (ctx.completion_count != nullptr && ctx.completion_error_code != nullptr) {
+            *ctx.completion_count = 0;
+            *ctx.completion_error_code = PTO2_ERROR_ASYNC_COMPLETION_INVALID;
+            ctx.task_token.raw = 0;
+            pto2::detail::defer_flush(ctx);
+            return;
+        }
+#if defined(__CPU_SIM)
+        __builtin_trap();
+#else
+        trap();
+#endif
+    }
+
+    const bool slab_is_valid =
+        ctx.completion_count != nullptr &&
+        ctx.completion_error_code != nullptr &&
+        ctx.completion_entries != nullptr &&
+        ctx.completion_capacity > 0 &&
+        ctx.completion_capacity <= static_cast<uint32_t>(MAX_COMPLETIONS_PER_TASK);
+    if (!slab_is_valid) {
+        // A valid token with malformed slab metadata must never retire as a
+        // successful ordinary task. If the count/error cache line is usable,
+        // publish INVALID with a zero count; otherwise there is no safe path
+        // to notify the scheduler, so fail the kernel immediately.
+        if (ctx.completion_count != nullptr && ctx.completion_error_code != nullptr) {
+            *ctx.completion_count = 0;
+            *ctx.completion_error_code = PTO2_ERROR_ASYNC_COMPLETION_INVALID;
+            pto2::detail::defer_flush(ctx);
+            return;
+        }
+#if defined(__CPU_SIM)
+        __builtin_trap();
+#else
+        trap();
+#endif
+    }
+
+    constexpr int64_t kMaxExpected = 0x7fffffffLL;
+    if (counter_base == nullptr || element_offset < 0 || expected < 0 || expected > kMaxExpected) {
+        pto2::detail::defer_error(ctx, PTO2_ERROR_ASYNC_COMPLETION_INVALID);
+        pto2::detail::defer_flush(ctx);
+        return;
+    }
+
+    constexpr uint64_t kElementBytes = sizeof(int32_t);
+    constexpr uint64_t kMaxAddress = ~static_cast<uint64_t>(0);
+    const uint64_t base = reinterpret_cast<uint64_t>(counter_base);
+    const uint64_t offset = static_cast<uint64_t>(element_offset);
+    if ((base & (kElementBytes - 1u)) != 0u || offset > (kMaxAddress - base) / kElementBytes) {
+        pto2::detail::defer_error(ctx, PTO2_ERROR_ASYNC_COMPLETION_INVALID);
+        pto2::detail::defer_flush(ctx);
+        return;
+    }
+
+    CompletionToken token{
+        base + offset * kElementBytes,
+        static_cast<uint32_t>(expected),
+        COMPLETION_ENGINE_SDMA,
+        COMPLETION_TYPE_COUNTER,
+        0,
+    };
+    if (!register_completion_condition(ctx, token) &&
+        (ctx.completion_error_code == nullptr || *ctx.completion_error_code == PTO2_ERROR_NONE)) {
+        pto2::detail::defer_error(ctx, PTO2_ERROR_ASYNC_REGISTRATION_FAILED);
+    }
+    pto2::detail::defer_flush(ctx);
+}
+
+"""
+
+_DEFERRED_COMPLETION_INCLUDE = """\
+#if defined(__has_include)
+#if !__has_include("pto_async_kernel_api.h")
+#error "pld.system.defer_wait requires a Simpler runtime that provides pto_async_kernel_api.h"
+#endif
+#endif
+#include "pto_async_kernel_api.h"
 """
 
 
@@ -587,6 +686,7 @@ _SPMD_BLOCK_OPS = frozenset(
 )
 _SUBBLOCK_OPS = frozenset({_ir_core.get_op("tile.get_subblock_idx").name})
 _SDMA_WORKSPACE_OPS = frozenset({_ir_core.get_op("prefetch.make_context").name})
+_DEFERRED_COMPLETION_OPS = frozenset({_ir_core.get_op("pld.system.defer_wait").name})
 
 
 def _function_uses_ops(func: _ir_core.Function, op_names: frozenset[str]) -> bool:
@@ -632,6 +732,11 @@ def _uses_sdma_workspace(func: _ir_core.Function) -> bool:
     return _function_uses_ops(func, _SDMA_WORKSPACE_OPS)
 
 
+def _uses_deferred_completion(func: _ir_core.Function) -> bool:
+    """Return whether the wrapper must expose the scheduler AsyncCtx."""
+    return _function_uses_ops(func, _DEFERRED_COMPLETION_OPS)
+
+
 def _requires_dual_aiv_dispatch(func: _ir_core.Function) -> bool:
     """Return whether the function must be dispatched on both AIV lanes."""
     split_mode = getattr(func, "split", None)
@@ -668,6 +773,7 @@ def _generate_kernel_header(
     uses_spmd: bool | None = None,
     uses_subblock: bool | None = None,
     uses_sdma: bool | None = None,
+    uses_deferred_completion: bool | None = None,
 ) -> str:
     """Generate the wrapper header, including split lane overrides when needed."""
     fixed_subblock_id = _get_fixed_subblock_id(func)
@@ -708,12 +814,16 @@ def _generate_kernel_header(
         uses_subblock = _uses_dynamic_subblock_id(func)
     if uses_sdma is None:
         uses_sdma = _uses_sdma_workspace(func)
+    if uses_deferred_completion is None:
+        uses_deferred_completion = _uses_deferred_completion(func)
     needs_intrinsic = uses_spmd or uses_subblock or uses_sdma
     spmd_override = '#include "intrinsic.h"\n' if needs_intrinsic else ""
+    deferred_completion_include = _DEFERRED_COMPLETION_INCLUDE if uses_deferred_completion else ""
 
     return _KERNEL_HEADER.format(
         func_name=func.name,
         subblock_override=subblock_override,
+        deferred_completion_include=deferred_completion_include,
         spmd_override=spmd_override,
     )
 
@@ -735,11 +845,13 @@ def _generate_kernel_wrapper(
     uses_spmd = group_uses_spmd or func_uses_spmd
     func_uses_subblock = _uses_dynamic_subblock_id(func)
     func_uses_sdma = _uses_sdma_workspace(func)
+    func_uses_deferred_completion = _uses_deferred_completion(func)
     header = _generate_kernel_header(
         func,
         uses_spmd=uses_spmd,
         uses_subblock=func_uses_subblock,
         uses_sdma=func_uses_sdma,
+        uses_deferred_completion=func_uses_deferred_completion,
     )
     ptoas_body = _preprocess_ptoas_output(ptoas_code)
     unpacking_code, var_names = _generate_arg_unpacking(func, uses_spmd=uses_spmd)
@@ -786,10 +898,13 @@ def _generate_kernel_wrapper(
             "get_dma_workspace(args, DMA_WORKSPACE_SDMA));\n\n"
         )
 
-    # PTOCodegen appends the SDMA workspace after user-derived arguments, then
-    # the synthetic i32 identity params in canonical order (block_idx,
-    # block_num, subblock_idx). Mirror that exact order here.
+    # PTOCodegen appends raw dispatch args for deferred completion after
+    # user-derived arguments, then the SDMA workspace and synthetic i32
+    # identity params in canonical order (block_idx, block_num, subblock_idx).
+    # Mirror that exact order here.
     call_args_list = list(var_names)
+    if func_uses_deferred_completion:
+        call_args_list.append("args")
     if func_uses_sdma:
         call_args_list.append("__pypto_sdma_workspace")
     if func_uses_spmd:
@@ -813,7 +928,11 @@ def _generate_kernel_wrapper(
         "}\n"
     )
 
-    return f"{header}\n// --- ptoas-generated code ---\n{ptoas_body}\n{wrapper_func}"
+    deferred_completion_adapter = _DEFERRED_COMPLETION_ADAPTER if func_uses_deferred_completion else ""
+    return (
+        f"{header}\n{deferred_completion_adapter}"
+        f"// --- ptoas-generated code ---\n{ptoas_body}\n{wrapper_func}"
+    )
 
 
 def _format_signature(directions: list[str]) -> str:

--- a/python/pypto/ir/op/distributed/system_ops.py
+++ b/python/pypto/ir/op/distributed/system_ops.py
@@ -9,7 +9,7 @@
 
 """IR builders for distributed system-level ops (``pld.system.world_size``,
 ``pld.system.get_comm_ctx``, ``pld.system.rank`` / ``pld.system.nranks``,
-``pld.system.notify`` / ``pld.system.wait``).
+``pld.system.notify`` / ``pld.system.wait`` / ``pld.system.defer_wait``).
 
 Mirror of :mod:`pypto.ir.op.system_ops` for the distributed namespace —
 exposes the registered C++ ops as Python builders. The DSL layer in
@@ -116,4 +116,30 @@ def wait(
     )
 
 
-__all__ = ["get_comm_ctx", "notify", "nranks", "rank", "wait", "world_size"]
+def defer_wait(
+    signal: _ir_core.Expr,
+    offsets: Sequence[int | _ir_core.Expr] | _ir_core.MakeTuple,
+    expected: int | _ir_core.Expr,
+    cmp: WaitCmp,
+    *,
+    span: Span | None = None,
+) -> Call:
+    """Build a ``pld.system.defer_wait(signal, offsets, expected)`` Call.
+
+    Register a ``signal >= expected`` condition on the enclosing task without
+    blocking its device core. The task may finish executing, but its TaskId
+    remains incomplete until the condition is satisfied. The kernel is not
+    resumed afterward, so continuation work must live in a dependent task.
+
+    ``signal`` must be an INT32 window-bound DistributedTensor and ``cmp`` must
+    be :class:`ir.WaitCmp.Ge`. The result is an ``UnknownType`` Call.
+    """
+    actual_span = _get_span_or_capture(span, frame_offset=1)
+    offsets_tuple = _to_make_tuple(offsets, actual_span)
+    expected_expr = _normalize_expr(expected, actual_span, int_dtype=DataType.INT32)
+    return _ir_core.create_op_call(
+        "pld.system.defer_wait", [signal, offsets_tuple, expected_expr], {"cmp": int(cmp)}, actual_span
+    )
+
+
+__all__ = ["defer_wait", "get_comm_ctx", "notify", "nranks", "rank", "wait", "world_size"]

--- a/python/pypto/language/distributed/op/system_ops.py
+++ b/python/pypto/language/distributed/op/system_ops.py
@@ -19,7 +19,8 @@ cross-rank synchronisation primitives:
 * :func:`get_comm_ctx` — lift a :class:`pld.DistributedTensor` to its
   :class:`pld.CommCtx` handle. The op verifier (C++) refuses any argument
   that is not :class:`ir.DistributedTensorType`.
-* :func:`notify` / :func:`wait` — cross-rank TNOTIFY / TWAIT on a window-bound
+* :func:`notify` / :func:`wait` / :func:`defer_wait` — cross-rank notification,
+  blocking wait, and deferred task-completion registration on a window-bound
   signal matrix. Side-effect-only; the C++ verifier refuses a plain
   :class:`pl.Tensor` target.
 * :func:`rank` / :func:`nranks` — CommContext scalar reads (``INT32``). The
@@ -185,4 +186,28 @@ def wait(
     return _ir_system.wait(_unwrap(signal), _normalize_intlike(offsets), _unwrap(expected), cmp)
 
 
-__all__ = ["get_comm_ctx", "notify", "nranks", "rank", "wait", "world_size"]
+def defer_wait(
+    signal: Tensor,
+    offsets: Sequence[IntLike],
+    expected: IntLike,
+    *,
+    cmp: WaitCmp,
+) -> Call:
+    """Register a deferred completion condition on a local signal slot.
+
+    Unlike :func:`wait`, this operation does not block the device core and does
+    not resume the kernel when the condition becomes true. The enclosing task
+    may finish executing, while its TaskId remains incomplete until
+    ``signal[offsets] >= expected``. Continuation work must therefore be placed
+    in a dependent task.
+
+    Args:
+        signal: Window-bound INT32 :class:`pld.DistributedTensor` signal matrix.
+        offsets: Offsets into the local slice, one per ``signal`` dimension.
+        expected: Integer scalar threshold value to compare against.
+        cmp: Must be :class:`pld.WaitCmp.Ge` (keyword-only).
+    """
+    return _ir_system.defer_wait(_unwrap(signal), _normalize_intlike(offsets), _unwrap(expected), cmp)
+
+
+__all__ = ["defer_wait", "get_comm_ctx", "notify", "nranks", "rank", "wait", "world_size"]

--- a/src/backend/common/pto_ops_distributed.cpp
+++ b/src/backend/common/pto_ops_distributed.cpp
@@ -35,6 +35,7 @@
 #include "pypto/ir/kind_traits.h"
 #include "pypto/ir/scalar_expr.h"
 #include "pypto/ir/tile_view_semantics.h"
+#include "pypto/ir/transforms/utils/tensor_view_semantics.h"
 #include "pypto/ir/type.h"
 #include "src/backend/common/pto_ops_internal.h"
 
@@ -574,6 +575,199 @@ static std::string MakeWaitCodegenPTO(const CallPtr& op, codegen::CodegenBase& c
   return "";
 }
 
+// pld.system.defer_wait(signal, offsets, expected, *, cmp) — register a local
+// signal slot as this task's deferred completion condition. Unlike wait, this
+// does not emit pto.comm.twait and therefore does not occupy the AIV core while a
+// peer is still producing data. The generated kernel wrapper implements the
+// checked runtime adapter and forwards kernel_entry's raw args so it can reach
+// the scheduler-owned AsyncCtx.
+static std::string MakeDeferWaitCodegenPTO(const CallPtr& op, codegen::CodegenBase& codegen_base) {
+  auto& codegen = AsPto(codegen_base);
+  INTERNAL_CHECK_SPAN(op->args_.size() == 3, op->span_)
+      << "pld.system.defer_wait requires 3 arguments (signal, offsets, expected), got " << op->args_.size();
+
+  auto signal_var = AsVarLike(op->args_[0]);
+  INTERNAL_CHECK_SPAN(signal_var, op->span_) << "pld.system.defer_wait signal must be a Var-like expression";
+  auto dist_type = As<ir::DistributedTensorType>(signal_var->GetType());
+  CHECK_SPAN(dist_type, op->span_)
+      << "pld.system.defer_wait currently supports only a direct DistributedTensor function parameter; "
+         "tensor.slice/tensor.view and other signal aliases are not supported because their logical origin "
+         "is not encoded for deferred-completion lowering (got "
+      << signal_var->GetType()->TypeName() << ")";
+  INTERNAL_CHECK_SPAN(dist_type->dtype_ == DataType::INT32, op->span_)
+      << "pld.system.defer_wait signal dtype must be INT32, got " << dist_type->dtype_.ToString();
+
+  auto offsets_tuple = As<ir::MakeTuple>(op->args_[1]);
+  INTERNAL_CHECK_SPAN(offsets_tuple, op->span_) << "pld.system.defer_wait offsets must be MakeTuple";
+  const size_t rank = dist_type->shape_.size();
+  INTERNAL_CHECK_SPAN(offsets_tuple->elements_.size() == rank, op->span_)
+      << "pld.system.defer_wait offsets rank " << offsets_tuple->elements_.size()
+      << " does not match signal rank " << rank;
+
+  const int cmp_int = op->GetKwarg<int>("cmp", 0);
+  INTERNAL_CHECK_SPAN(cmp_int == static_cast<int>(ir::WaitCmp::kGe), op->span_)
+      << "pld.system.defer_wait only supports WaitCmp::kGe, got " << cmp_int;
+
+  // A direct parameter's wrapper pointer already includes Tensor.start_offset.
+  // TensorView does not carry a logical origin, however, so a tensor.slice (or
+  // any other rebinding whose value SSA differs from its backing pointer) cannot
+  // be flattened correctly here. Reject that shape until the IR represents the
+  // origin explicitly instead of silently registering a counter in another
+  // region of the allocation.
+  const std::string signal_base = codegen.GetTensorBasePtr(signal_var);
+  CHECK_SPAN(signal_base == codegen.GetVarName(signal_var), op->span_)
+      << "pld.system.defer_wait currently supports only a direct DistributedTensor function parameter; "
+         "tensor.slice/tensor.view and SSA-rebound signal aliases do not carry their logical base offset "
+         "into "
+         "the deferred-completion adapter";
+
+  // Compute a flat element offset from the signal's logical strides. The
+  // default pass pipeline materializes explicit TensorView strides; bare ND
+  // tensors remain implicit, so derive their canonical packed stride here.
+  // Passing base + element_offset separately avoids PTOAS's same-function
+  // pto.addptr consumer restriction for external func.call operands.
+  ir::TensorLayout layout = ir::TensorLayout::ND;
+  std::vector<ExprPtr> strides;
+  if (dist_type->tensor_view_.has_value()) {
+    layout = dist_type->tensor_view_->layout;
+    strides = dist_type->tensor_view_->stride;
+  }
+  if (strides.empty()) {
+    CHECK_SPAN(layout != ir::TensorLayout::NZ, op->span_)
+        << "pld.system.defer_wait does not support an NZ signal TensorView; use an ND/DN INT32 signal";
+    strides = ir::tensor_view_semantics::BuildLogicalStridesFromLayout(dist_type->shape_, layout);
+  }
+  INTERNAL_CHECK_SPAN(strides.size() == rank, op->span_)
+      << "pld.system.defer_wait signal stride rank " << strides.size() << " does not match signal rank "
+      << rank;
+
+  const std::vector<ExprPtr>& bounds =
+      dist_type->tensor_view_.has_value() && !dist_type->tensor_view_->valid_shape.empty()
+          ? dist_type->tensor_view_->valid_shape
+          : dist_type->shape_;
+  INTERNAL_CHECK_SPAN(bounds.size() == rank, op->span_)
+      << "pld.system.defer_wait signal bound rank " << bounds.size() << " does not match signal rank "
+      << rank;
+
+  const std::string zero = codegen.GetOrEmitConstant(static_cast<int64_t>(0), DataType::INDEX);
+  std::string element_offset = zero;
+  std::string any_coordinate_oob;
+  auto emit_coordinate_as_index = [&](const ExprPtr& coordinate) {
+    auto scalar_type = As<ScalarType>(coordinate->GetType());
+    INTERNAL_CHECK_SPAN(scalar_type, op->span_)
+        << "pld.system.defer_wait offset must have ScalarType, got " << coordinate->GetType()->TypeName();
+    std::string value = codegen.GetExprAsCode(coordinate);
+    const DataType dtype = scalar_type->dtype_;
+    if (!dtype.IsUnsignedInt()) {
+      return codegen.EmitCastToIndex(coordinate, value);
+    }
+
+    // MLIR's arith.index_cast accepts signless integers, not PyPTO's uiN
+    // dialect types. More importantly, casting the same-bitwidth iN bridge
+    // directly would sign-extend values with the high bit set (for example,
+    // UINT8 200 would become -56). Preserve unsigned coordinate semantics by
+    // zero-extending to i64 before converting to index. UINT64 cannot be
+    // widened; values above INT64_MAX retain their high bit and are rejected
+    // by the coordinate's negative/OOB guard below.
+    const std::string unsigned_type = codegen.GetTypeString(dtype);
+    const std::string signless_type = unsigned_type.substr(1);  // uiN -> iN
+    std::string signless = codegen.NewTemp();
+    codegen.Emit(signless + " = builtin.unrealized_conversion_cast " + value + " : " + unsigned_type +
+                 " to " + signless_type);
+    if (dtype.GetBit() < 64) {
+      std::string widened = codegen.NewTemp();
+      codegen.Emit(widened + " = arith.extui " + signless + " : " + signless_type + " to i64");
+      signless = std::move(widened);
+    }
+    std::string index = codegen.NewTemp();
+    codegen.Emit(index + " = arith.index_cast " + signless + " : i64 to index");
+    return index;
+  };
+  for (size_t i = 0; i < rank; ++i) {
+    const std::string offset = emit_coordinate_as_index(offsets_tuple->elements_[i]);
+    std::string bound;
+    if (auto constant = As<ir::ConstInt>(bounds[i])) {
+      bound = codegen.GetOrEmitConstant(constant->value_, DataType::INDEX);
+    } else {
+      bound = codegen.EmitCastToIndex(bounds[i], codegen.GetExprAsCode(bounds[i]));
+    }
+    std::string negative = codegen.NewTemp();
+    codegen.Emit(negative + " = arith.cmpi slt, " + offset + ", " + zero + " : index");
+    std::string past_end = codegen.NewTemp();
+    codegen.Emit(past_end + " = arith.cmpi sge, " + offset + ", " + bound + " : index");
+    std::string coordinate_oob = codegen.NewTemp();
+    codegen.Emit(coordinate_oob + " = arith.ori " + negative + ", " + past_end + " : i1");
+    if (any_coordinate_oob.empty()) {
+      any_coordinate_oob = std::move(coordinate_oob);
+    } else {
+      std::string combined_oob = codegen.NewTemp();
+      codegen.Emit(combined_oob + " = arith.ori " + any_coordinate_oob + ", " + coordinate_oob + " : i1");
+      any_coordinate_oob = std::move(combined_oob);
+    }
+
+    std::string stride;
+    if (auto constant = As<ir::ConstInt>(strides[i])) {
+      stride = codegen.GetOrEmitConstant(constant->value_, DataType::INDEX);
+    } else {
+      stride = codegen.EmitCastToIndex(strides[i], codegen.GetExprAsCode(strides[i]));
+    }
+    std::string term = codegen.NewTemp();
+    codegen.Emit(term + " = arith.muli " + offset + ", " + stride + " : index");
+    std::string next = codegen.NewTemp();
+    codegen.Emit(next + " = arith.addi " + element_offset + ", " + term + " : index");
+    element_offset = std::move(next);
+  }
+
+  INTERNAL_CHECK_SPAN(!any_coordinate_oob.empty(), op->span_)
+      << "pld.system.defer_wait signal must have rank >= 1";
+  const std::string invalid_offset = codegen.GetOrEmitConstant(static_cast<int64_t>(-1), DataType::INDEX);
+  std::string checked_element_offset = codegen.NewTemp();
+  codegen.Emit(checked_element_offset + " = arith.select " + any_coordinate_oob + ", " + invalid_offset +
+               ", " + element_offset + " : index");
+  std::string element_offset_i64 = codegen.NewTemp();
+  codegen.Emit(element_offset_i64 + " = arith.index_cast " + checked_element_offset + " : index to i64");
+
+  auto expected_scalar = As<ScalarType>(op->args_[2]->GetType());
+  INTERNAL_CHECK_SPAN(expected_scalar, op->span_)
+      << "pld.system.defer_wait expected must have ScalarType, got " << op->args_[2]->GetType()->TypeName();
+  INTERNAL_CHECK_SPAN(expected_scalar->dtype_.IsInt() || expected_scalar->dtype_ == DataType::INDEX,
+                      op->span_)
+      << "pld.system.defer_wait expected must be integer or index typed";
+  std::string expected_i64 = codegen.GetExprAsCode(op->args_[2]);
+  const DataType expected_dtype = expected_scalar->dtype_;
+  if (expected_dtype == DataType::INDEX) {
+    std::string casted = codegen.NewTemp();
+    codegen.Emit(casted + " = arith.index_cast " + expected_i64 + " : index to i64");
+    expected_i64 = std::move(casted);
+  } else if (expected_dtype == DataType::UINT64) {
+    std::string casted = codegen.NewTemp();
+    codegen.Emit(casted + " = builtin.unrealized_conversion_cast " + expected_i64 + " : ui64 to i64");
+    expected_i64 = std::move(casted);
+  } else if (expected_dtype != DataType::INT64) {
+    std::string source_type = codegen.GetTypeString(expected_dtype);
+    if (expected_dtype.IsUnsignedInt()) {
+      std::string signless = codegen.NewTemp();
+      const std::string signless_type = source_type.substr(1);  // uiN -> iN
+      codegen.Emit(signless + " = builtin.unrealized_conversion_cast " + expected_i64 + " : " + source_type +
+                   " to " + signless_type);
+      expected_i64 = std::move(signless);
+      source_type = signless_type;
+    }
+    std::string casted = codegen.NewTemp();
+    const std::string extension = expected_dtype.IsUnsignedInt() ? "arith.extui" : "arith.extsi";
+    codegen.Emit(casted + " = " + extension + " " + expected_i64 + " : " + source_type + " to i64");
+    expected_i64 = std::move(casted);
+  }
+
+  const std::string raw_args = codegen.GetDeferredCompletionRawArgsSSA();
+  INTERNAL_CHECK_SPAN(!raw_args.empty(), op->span_)
+      << "pld.system.defer_wait requires the hidden raw dispatch-args parameter";
+  const std::string adapter = codegen.RegisterDeferredCompletionAdapter();
+  codegen.Emit("func.call @" + adapter + "(" + raw_args + ", " + signal_base + ", " + element_offset_i64 +
+               ", " + expected_i64 + ") : (!pto.ptr<i64>, !pto.ptr<i32>, i64, i64) -> ()");
+  return "";
+}
+
 // pld.tile.put(dst, peer, src, stage[, dst_offsets, src_offsets, shape],
 //              *, atomic) - synchronous cross-rank bulk write of the local
 // slice `src` into the peer rank's slice of `dst`. `stage` is a VEC scratch
@@ -894,6 +1088,9 @@ void RegisterDistributedOps(Backend& backend, const std::unordered_set<std::stri
       [](const ir::CallPtr& op, codegen::CodegenBase& codegen) { return MakeNotifyCodegenPTO(op, codegen); });
   reg("pld.system.wait",
       [](const ir::CallPtr& op, codegen::CodegenBase& codegen) { return MakeWaitCodegenPTO(op, codegen); });
+  reg("pld.system.defer_wait", [](const ir::CallPtr& op, codegen::CodegenBase& codegen) {
+    return MakeDeferWaitCodegenPTO(op, codegen);
+  });
 
   // Distributed N7 ops — CommContext accessor lowering.
   //

--- a/src/codegen/pto/pto_codegen.cpp
+++ b/src/codegen/pto/pto_codegen.cpp
@@ -81,6 +81,11 @@ namespace transform_utils = ir::transform_utils;
 
 namespace {
 
+// Implemented by the generated kernel wrapper rather than by PTO MLIR. Keep
+// this name reserved in modules that use deferred completion so a user kernel
+// cannot silently collide with the private adapter declaration.
+constexpr const char* kDeferredCompletionAdapterName = "pypto_register_counter_completion";
+
 // Escape a source path for an MLIR `"..."` string literal. A path is an
 // arbitrary OS byte string — on POSIX every byte except `/` and NUL is legal, so
 // a quote, a backslash, or a raw control character in one must not be able to
@@ -490,6 +495,10 @@ class MemRefCollectorVisitor : public ir::IRVisitor {
   /// pointer to the emitted func.func signature.
   [[nodiscard]] bool UsesSdmaWorkspace() const { return uses_sdma_workspace_; }
 
+  /// Returns true when the visited body registers deferred task completion.
+  /// Drives the hidden raw dispatch-args pointer shared with the kernel wrapper.
+  [[nodiscard]] bool UsesDeferredCompletion() const { return uses_deferred_completion_; }
+
   /// Returns true when the visited body invokes tile.get_block_idx or
   /// tile.get_block_num. Drives PTOCodegen's decision to append two synthetic
   /// i32 params to the emitted func.func signature; the kernel wrapper
@@ -523,6 +532,9 @@ class MemRefCollectorVisitor : public ir::IRVisitor {
       if (!uses_sdma_workspace_ && ir::IsOp(op, "prefetch.make_context")) {
         uses_sdma_workspace_ = true;
       }
+      if (!uses_deferred_completion_ && ir::IsOp(op, "pld.system.defer_wait")) {
+        uses_deferred_completion_ = true;
+      }
       if (!uses_spmd_block_ops_ &&
           (ir::IsOp(op, "tile.get_block_idx") || ir::IsOp(op, "tile.get_block_num"))) {
         uses_spmd_block_ops_ = true;
@@ -545,6 +557,7 @@ class MemRefCollectorVisitor : public ir::IRVisitor {
   std::map<const ir::Var*, std::shared_ptr<const TileType>> memref_tile_types_;
   std::set<uint64_t> iter_arg_ids_;
   bool uses_sdma_workspace_ = false;
+  bool uses_deferred_completion_ = false;
   bool uses_spmd_block_ops_ = false;
   bool uses_subblock_op_ = false;
   std::set<const ir::Var*> ffts_workspace_vars_;
@@ -607,6 +620,7 @@ std::string PTOCodegen::Generate(const ProgramPtr& program, bool emit_tile_addr,
   fs_.body_section.str("");
   fs_.body_section.clear();
   gm_slot_buffer_offsets_.clear();
+  needs_deferred_completion_adapter_ = false;
   PrepareGMSlotBufferLayout(program);
 
   const std::string target_arch = backend_->GetHandler()->GetPtoTargetArch();
@@ -618,6 +632,16 @@ std::string PTOCodegen::Generate(const ProgramPtr& program, bool emit_tile_addr,
         << func->name_ << "' has type " << ir::FunctionTypeToString(func->func_type_);
     GenerateFunction(func);
   }
+
+  if (needs_deferred_completion_adapter_) {
+    for (const auto& [gvar, func] : program->functions_) {
+      CHECK_SPAN(func->name_ != kDeferredCompletionAdapterName, func->span_)
+          << "Function name '" << kDeferredCompletionAdapterName
+          << "' is reserved for PyPTO's deferred-completion runtime adapter";
+    }
+  }
+
+  EmitDeferredCompletionAdapterDeclaration();
 
   stream_ << "}\n";
   return stream_.str();
@@ -750,6 +774,17 @@ std::string PTOCodegen::EmitCommRemoteOffsetInline(const std::string& ctx_ssa, c
   return delems;
 }
 
+std::string PTOCodegen::RegisterDeferredCompletionAdapter() {
+  needs_deferred_completion_adapter_ = true;
+  return kDeferredCompletionAdapterName;
+}
+
+void PTOCodegen::EmitDeferredCompletionAdapterDeclaration() {
+  if (!needs_deferred_completion_adapter_) return;
+  stream_ << "  func.func private @" << kDeferredCompletionAdapterName
+          << "(!pto.ptr<i64>, !pto.ptr<i32>, i64, i64)\n";
+}
+
 void PTOCodegen::GenerateFunction(const FunctionPtr& func) {
   fs_.Reset();
   fs_.current_function = func;
@@ -810,11 +845,15 @@ void PTOCodegen::GenerateFunction(const FunctionPtr& func) {
     collector.VisitStmt(func->body_);
   }
   const bool uses_sdma_workspace = collector.UsesSdmaWorkspace();
+  const bool uses_deferred_completion = collector.UsesDeferredCompletion();
   const bool uses_spmd_params = collector.UsesSpmdBlockOps();
   const bool uses_subblock_param = collector.UsesSubblockOp();
   fs_.ffts_workspace_vars = collector.GetFFTSWorkspaceVars();
   if (uses_sdma_workspace) {
     fs_.used_ssa_names.insert("arg" + std::to_string(func->params_.size() + dyn_vars.size()));
+  }
+  if (uses_deferred_completion) {
+    fs_.used_ssa_names.insert("__pypto_deferred_raw_args");
   }
   if (uses_spmd_params) {
     fs_.used_ssa_names.insert("__pypto_spmd_block_idx");
@@ -968,6 +1007,17 @@ void PTOCodegen::GenerateFunction(const FunctionPtr& func) {
     std::string arg_name = "%arg" + std::to_string(next_arg_idx++);
     stream_ << ", " << arg_name << ": index";
     BindVarToMlir(dyn_var, arg_name);
+  }
+
+  // Deferred completion registration needs the scheduler-owned AsyncCtx,
+  // which is reachable only from kernel_entry's raw dispatch args. Keep this
+  // hidden ABI before other runtime-owned arguments; the Python wrapper mirrors
+  // the order exactly.
+  if (uses_deferred_completion) {
+    if (!first_param) stream_ << ", ";
+    first_param = false;
+    fs_.deferred_completion_raw_args_ssa = "%__pypto_deferred_raw_args";
+    stream_ << fs_.deferred_completion_raw_args_ssa << ": !pto.ptr<i64>";
   }
 
   // Append the hidden SDMA workspace pointer after user-derived arguments and

--- a/src/ir/op/distributed/system.cpp
+++ b/src/ir/op/distributed/system.cpp
@@ -11,17 +11,18 @@
 
 /**
  * @file system.cpp
- * @brief Distributed system-level synchronisation ops — pld.system.notify / pld.system.wait.
+ * @brief Distributed system-level synchronisation ops — notify, wait, and defer_wait.
  *
  * These ops drive cross-rank synchronisation against the per-rank signal slot
  * of a window-bound :class:`DistributedTensorType` (typically a 1-D INT32
- * "signal matrix"). Both are side-effect-only and produce :class:`UnknownType`
+ * "signal matrix"). All three are side-effect-only and produce :class:`UnknownType`
  * — there is no SSA result for downstream consumers to read.
  *
  * IR signatures:
  *
- *     pld.system.notify(target, peer, offsets, value, *, op: int)  -> Unknown
- *     pld.system.wait  (signal, offsets, expected,    *, cmp: int) -> Unknown
+ *     pld.system.notify    (target, peer, offsets, value, *, op: int)  -> Unknown
+ *     pld.system.wait      (signal, offsets, expected,    *, cmp: int) -> Unknown
+ *     pld.system.defer_wait(signal, offsets, expected,    *, cmp: int) -> Unknown
  *
  * The ``op`` / ``cmp`` integers are the underlying values of
  * :enum:`NotifyOp` / :enum:`WaitCmp` (see ``include/pypto/ir/comm.h``); the
@@ -44,6 +45,8 @@
 
 #include <any>
 #include <cstddef>
+#include <cstdint>
+#include <limits>
 #include <string>
 #include <utility>
 #include <vector>
@@ -129,6 +132,55 @@ TypePtr DeduceWaitType(const std::vector<ExprPtr>& args,
   return GetUnknownType();
 }
 
+TypePtr DeduceDeferWaitType(const std::vector<ExprPtr>& args,
+                            const std::vector<std::pair<std::string, std::any>>& kwargs) {
+  CHECK(args.size() == 3) << "pld.system.defer_wait requires exactly 3 positional arguments "
+                             "(signal, offsets, expected), but got "
+                          << args.size();
+  for (size_t i = 0; i < args.size(); ++i) {
+    CHECK(args[i]) << "pld.system.defer_wait positional argument #" << i << " must not be null";
+  }
+
+  auto dist_type = As<DistributedTensorType>(args[0]->GetType());
+  CHECK(dist_type) << "pld.system.defer_wait signal must be a DistributedTensor (window-bound), got "
+                   << args[0]->GetType()->TypeName();
+  CHECK(dist_type->dtype_ == DataType::INT32)
+      << "pld.system.defer_wait signal dtype must be INT32, got " << dist_type->dtype_.ToString();
+  CHECK_SPAN(!dist_type->shape_.empty(), args[0]->span_)
+      << "pld.system.defer_wait signal rank must be at least 1, got 0";
+
+  auto offsets_tuple = As<MakeTuple>(args[1]);
+  CHECK(offsets_tuple) << "pld.system.defer_wait offsets must be a tuple (MakeTuple of scalars), got "
+                       << args[1]->TypeName();
+  CheckOffsetsRankMatchesTarget(offsets_tuple, dist_type->shape_.size(), "pld.system.defer_wait");
+  for (size_t i = 0; i < offsets_tuple->elements_.size(); ++i) {
+    const auto offset_type = As<ScalarType>(offsets_tuple->elements_[i]->GetType());
+    CHECK_SPAN(offset_type && (offset_type->dtype_.IsInt() || offset_type->dtype_ == DataType::INDEX),
+               offsets_tuple->elements_[i]->span_)
+        << "pld.system.defer_wait offset " << i << " must be an integer or index scalar, got "
+        << (offset_type ? offset_type->dtype_.ToString()
+                        : offsets_tuple->elements_[i]->GetType()->TypeName());
+  }
+
+  auto expected_type = As<ScalarType>(args[2]->GetType());
+  CHECK_SPAN(expected_type && (expected_type->dtype_.IsInt() || expected_type->dtype_ == DataType::INDEX),
+             args[2]->span_)
+      << "pld.system.defer_wait expected must be an integer or index scalar, got "
+      << (expected_type ? expected_type->dtype_.ToString() : args[2]->GetType()->TypeName());
+  if (auto expected_const = As<ConstInt>(args[2])) {
+    CHECK(expected_const->value_ >= 0 &&
+          expected_const->value_ <= static_cast<int64_t>(std::numeric_limits<int32_t>::max()))
+        << "pld.system.defer_wait constant expected must be in [0, INT32_MAX], got "
+        << expected_const->value_;
+  }
+
+  auto cmp_value = GetRequiredKwarg<int>(kwargs, "cmp", "pld.system.defer_wait");
+  CHECK(cmp_value == static_cast<int>(WaitCmp::kGe))
+      << "pld.system.defer_wait only supports WaitCmp.Ge (got int " << cmp_value << ")";
+
+  return GetUnknownType();
+}
+
 }  // namespace
 
 // ============================================================================
@@ -185,6 +237,23 @@ REGISTER_OP("pld.system.wait")
     .set_attr<int>("cmp")
     .no_memory_spec()
     .f_deduce_type(DeduceWaitType);
+
+// ============================================================================
+// pld.system.defer_wait — register a task-completion condition without blocking
+// ============================================================================
+
+REGISTER_OP("pld.system.defer_wait")
+    .set_description(
+        "Register a deferred completion condition on a local INT32 signal slot. The enclosing task may "
+        "finish executing, but its TaskId remains incomplete until signal >= expected. This operation does "
+        "not resume the kernel after the condition becomes true.")
+    .set_op_category("DistributedOp")
+    .add_argument("signal", "Window-bound INT32 DistributedTensor signal matrix")
+    .add_argument("offsets", "Offsets in signal tensor coordinates (MakeTuple of integer/index scalars)")
+    .add_argument("expected", "Integer or index scalar threshold value")
+    .set_attr<int>("cmp")
+    .no_memory_spec()
+    .f_deduce_type(DeduceDeferWaitType);
 
 }  // namespace ir
 }  // namespace pypto

--- a/src/ir/transforms/expand_mixed_kernel_pass.cpp
+++ b/src/ir/transforms/expand_mixed_kernel_pass.cpp
@@ -88,6 +88,62 @@ using tpop_tfree::FinalizeTpopTfrees;
 // Use the shared utility; local alias preserves call sites.
 const auto& FlattenBody = transform_utils::FlattenToStmts;
 
+/// Validate that a deferred waiter is reached only through the task-level
+/// orchestration dispatch shape produced by ScopeOutliner. The marker is
+/// printable and therefore cannot be treated as provenance by itself.
+class DeferredWaiterCallSiteValidator : public IRVisitor {
+ public:
+  DeferredWaiterCallSiteValidator(const std::unordered_set<std::string>& waiter_names, FunctionPtr caller)
+      : waiter_names_(waiter_names), caller_(std::move(caller)) {}
+
+  [[nodiscard]] const std::unordered_set<std::string>& called_waiters() const { return called_waiters_; }
+
+ protected:
+  void VisitExpr_(const CallPtr& call) override {
+    if (IsWaiter(call->op_)) {
+      RecordCall(call->op_, call->GetAttr<bool>("allow_early_resolve", false), call->HasAttr(kAttrPredicate),
+                 call->HasAttr(kAttrCoreNum) || call->GetAttr<bool>(kAttrSyncStart, false), call->span_);
+    }
+    IRVisitor::VisitExpr_(call);
+  }
+
+  void VisitExpr_(const SubmitPtr& submit) override {
+    if (IsWaiter(submit->op_)) {
+      RecordCall(submit->op_, submit->allow_early_resolve_, submit->predicate_.has_value(),
+                 submit->core_num_.has_value() || submit->sync_start_, submit->span_);
+    }
+    IRVisitor::VisitExpr_(submit);
+  }
+
+ private:
+  [[nodiscard]] bool IsWaiter(const OpPtr& op) const {
+    auto global = As<GlobalVar>(op);
+    return global && waiter_names_.count(global->name_) != 0;
+  }
+
+  void RecordCall(const OpPtr& op, bool allow_early_resolve, bool predicate, bool has_launch_shape,
+                  const Span& span) {
+    auto global = As<GlobalVar>(op);
+    INTERNAL_CHECK_SPAN(global, span) << "Internal error: deferred waiter call target is not a GlobalVar";
+    CHECK_SPAN(caller_->func_type_ == FunctionType::Orchestration, span)
+        << "deferred waiter '" << global->name_
+        << "' must be dispatched directly from an Orchestration function via a task-level "
+           "pl.at(CORE_GROUP) scope";
+    CHECK_SPAN(!allow_early_resolve, span)
+        << "deferred waiter '" << global->name_ << "' cannot use allow_early_resolve=True";
+    CHECK_SPAN(!predicate, span) << "deferred waiter '" << global->name_
+                                 << "' cannot use a dispatch predicate";
+    CHECK_SPAN(!has_launch_shape, span)
+        << "deferred waiter '" << global->name_
+        << "' must be a single-block task and cannot use core_num or sync_start";
+    called_waiters_.insert(global->name_);
+  }
+
+  const std::unordered_set<std::string>& waiter_names_;
+  FunctionPtr caller_;
+  std::unordered_set<std::string> called_waiters_;
+};
+
 // ============================================================================
 // Explicit split-reshape op helpers (tile.aiv_shard / tile.aic_gather)
 // ============================================================================
@@ -1847,6 +1903,48 @@ namespace pass {
 
 Pass ExpandMixedKernel() {
   auto pass_func = [](const ProgramPtr& program) -> ProgramPtr {
+    // Audit every function before filtering to InCore below. A hand-authored
+    // AIV/AIC function, or a user-stamped marker without a validated waiter
+    // body and task-level call site, must not bypass the deferred contract.
+    std::unordered_set<std::string> deferred_waiter_names;
+    for (const auto& [gvar, func] : program->functions_) {
+      // Detect the real op independently of the printable compiler marker.
+      if (!outline_utils::ContainsDeferredWait(func->body_)) continue;
+      CHECK_SPAN(func->GetAttr<bool>(kAttrDeferredCompletionWaiter, false), func->span_)
+          << "pld.system.defer_wait in function '" << func->name_
+          << "' bypasses the deferred-waiter task contract. Use a task-level "
+             "`with pl.at(level=pl.Level.CORE_GROUP)` scope; capture its TaskId and use "
+             "`deps=[wait_tid]` only when a later consumer must be gated.";
+      CHECK_SPAN(func->func_type_ == FunctionType::InCore || func->func_type_ == FunctionType::AIV,
+                 func->span_)
+          << "deferred waiter '" << func->name_
+          << "' must be an outlined InCore function or its pure-AIV expanded form";
+      CHECK_SPAN(
+          !func->GetAttr<ExprPtr>(kAttrCoreNum, nullptr) && !func->GetAttr<bool>(kAttrSyncStart, false),
+          func->span_)
+          << "deferred waiter '" << func->name_
+          << "' must be a single-block task and cannot carry core_num or sync_start";
+      auto contract = outline_utils::DeferredWaitContractValidator::Validate(func->body_, func->span_);
+      INTERNAL_CHECK_SPAN(contract.has_deferred_wait, func->span_)
+          << "Internal error: deferred-wait finder/contract-validator disagreement";
+      deferred_waiter_names.insert(func->name_);
+    }
+
+    if (!deferred_waiter_names.empty()) {
+      std::unordered_set<std::string> called_waiters;
+      for (const auto& [gvar, func] : program->functions_) {
+        DeferredWaiterCallSiteValidator validator(deferred_waiter_names, func);
+        validator.VisitStmt(func->body_);
+        called_waiters.insert(validator.called_waiters().begin(), validator.called_waiters().end());
+      }
+      for (const auto& waiter_name : deferred_waiter_names) {
+        CHECK_SPAN(called_waiters.count(waiter_name) != 0, program->span_)
+            << "deferred waiter '" << waiter_name
+            << "' has no task-level Orchestration call site; a printable function attr alone is not a "
+               "valid deferred-completion contract";
+      }
+    }
+
     // Phase 1: Pre-scan — find InCore functions that have existing callers.
     std::unordered_set<std::string> incore_names;
     for (const auto& [gvar, func] : program->functions_) {
@@ -1892,6 +1990,14 @@ Pass ExpandMixedKernel() {
       std::unordered_map<const Stmt*, CoreAffinity> stmt_map;
       std::unordered_map<const Var*, CoreAffinity> var_affinity;
       auto combined = AnalyzeStmtsAffinity(stmts, stmt_map, var_affinity, tpop_defs);
+
+      const bool is_deferred_waiter = deferred_waiter_names.count(func->name_) != 0;
+
+      if (is_deferred_waiter) {
+        CHECK_SPAN(combined != CoreAffinity::CUBE && combined != CoreAffinity::MIXED, func->span_)
+            << "deferred waiter '" << func->name_
+            << "' must lower to a pure AIV kernel; AIC and mixed AIC/AIV waiters are not supported";
+      }
 
       // A function is mixed if combined affinity says so. Leaf boundary moves
       // (tile.move across the C/V divide) classify as MIXED via ClassifyCallAffinity,

--- a/tests/st/distributed/test_l3_deferred_completion.py
+++ b/tests/st/distributed/test_l3_deferred_completion.py
@@ -1,0 +1,270 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""L3 distributed ST for deferred task completion and task-start freshness.
+
+On A2/A3, each of two ranks fills every available AIV with a wait task before
+submitting the task that publishes to its peer. The simulator exposes 16 AIVs
+(``SIM_AUTO_BLOCKDIM=8``, two AIVs per block); full A2/A3 hardware exposes 48:
+
+* every waiter registers ``signal[0, 0] >= 1`` with
+  :func:`pld.system.defer_wait` and returns its physical core;
+* each consumer is gated by ordinary ``deps=[wait_tid]``; Simpler's standard
+  executor invalidates the data cache at every task start before reading payload;
+* only after all waiter/consumer pairs have been submitted does a publisher
+  write a rank-specific payload into the peer's window and notify its signal.
+
+Replacing the deferred wait with a blocking ``pld.system.wait`` in this
+saturation topology occupies every AIV core before the publisher can run and
+deadlocks. Completion therefore proves physical-core release as well as
+cross-rank liveness. Every consumer must read the peer's tag, which also checks
+that no consumer runs before counter readiness and that Simpler's standard
+task-start cache invalidation exposes the payload.
+
+This core count is intentionally distinct from Simpler's
+``MAX_ASYNC_WAITS=64`` scheduler-list capacity and its
+``MAX_COMPLETIONS_PER_TASK=64`` condition cap. The normal liveness test stays
+at the platform's AIV saturation point; it does not treat either unrelated
+runtime capacity as a core-release requirement.
+
+The persistent case runs the same compiled graph for monotonically increasing
+epochs with persistent-window reset explicitly disabled. The first payload
+lane and the signal both carry the epoch, so a consumer that observes stale
+payload or a waiter registration left behind by the prior call fails. A
+separate one-waiter case holds the epoch at one after priming the signal, which
+exercises registration and wait-table reuse when the counter is already ready.
+
+A smaller four-waiter A5 case checks the same cross-rank payload, completion
+dependency, and persistent-reset contract without making an A5 core-saturation
+claim.
+"""
+
+import sys
+
+import pypto.language as pl
+import pypto.language.distributed as pld
+import pytest
+import torch
+from pypto import ir
+from pypto.ir.distributed_compiled_program import DistributedConfig
+
+_N_RANKS = 2
+_A2A3_SIM_AIVS = 16
+_A2A3_ONBOARD_AIVS = 48
+_A5_SMOKE_WAITS = 4
+_PAYLOAD_WIDTH = 8  # 1x8 INT32 is the minimum 32-byte vector tile.
+
+
+def _build_deferred_completion_program(waiter_count: int):
+    """Build the deferred-wait graph for ``waiter_count`` registrations/rank."""
+
+    WAITER_COUNT = waiter_count  # noqa: N806 - closed over by IR shape annotations
+
+    @pl.program
+    class DeferredCompletion:
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def chip_orch(
+            self,
+            inp: pl.Tensor[[1, _PAYLOAD_WIDTH], pl.INT32],
+            out: pl.Out[pl.Tensor[[WAITER_COUNT, _PAYLOAD_WIDTH], pl.INT32]],
+            payload: pl.InOut[pld.DistributedTensor[[1, _PAYLOAD_WIDTH], pl.INT32]],
+            signal: pl.InOut[pld.DistributedTensor[[1, 1], pl.INT32]],
+            peer: pl.Scalar[pl.INT32],
+        ) -> pl.Tensor[[WAITER_COUNT, _PAYLOAD_WIDTH], pl.INT32]:
+            # Manual mode is load-bearing: the only waiter -> consumer edge is
+            # the explicit TaskId edge, while the later publisher must remain
+            # independent so released physical cores can make forward progress.
+            with pl.manual_scope():
+                for slot in pl.range(WAITER_COUNT):
+                    with pl.at(level=pl.Level.CORE_GROUP, name_hint="deferred_wait") as wait_tid:
+                        epoch: pl.Scalar[pl.INT32] = pl.read(inp, [0, 0])
+                        pld.system.defer_wait(
+                            signal=signal,
+                            offsets=[0, 0],
+                            expected=epoch,
+                            cmp=pld.WaitCmp.Ge,
+                        )
+
+                    with pl.at(
+                        level=pl.Level.CORE_GROUP,
+                        name_hint="completion_consumer",
+                        deps=[wait_tid],
+                    ) as _consumer_tid:
+                        received = pl.load(payload, [0, 0], [1, _PAYLOAD_WIDTH])
+                        out = pl.store(received, [slot, 0], out)
+
+                # Submitted last on purpose. A blocking version at
+                # the platform's AIV saturation count cannot reach this task
+                # after all AIV cores enter TWAIT; deferred waiters return
+                # their cores immediately.
+                with pl.at(level=pl.Level.CORE_GROUP, name_hint="delayed_publisher"):
+                    local_payload = pl.load(inp, [0, 0], [1, _PAYLOAD_WIDTH])
+                    pld.tile.remote_store(local_payload, target=payload, peer=peer, offsets=[0, 0])
+                    epoch: pl.Scalar[pl.INT32] = pl.read(inp, [0, 0])
+                    pld.system.notify(
+                        target=signal,
+                        peer=peer,
+                        offsets=[0, 0],
+                        value=epoch,
+                        op=pld.NotifyOp.Set,
+                    )
+            return out
+
+        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+        def host_orch(
+            self,
+            inputs: pl.Tensor[[_N_RANKS, 1, _PAYLOAD_WIDTH], pl.INT32],
+            outputs: pl.Out[pl.Tensor[[_N_RANKS, WAITER_COUNT, _PAYLOAD_WIDTH], pl.INT32]],
+        ) -> pl.Tensor[[_N_RANKS, WAITER_COUNT, _PAYLOAD_WIDTH], pl.INT32]:
+            payload_buf = pld.alloc_window_buffer(_PAYLOAD_WIDTH * pl.INT32.get_byte())
+            signal_buf = pld.alloc_window_buffer(pl.INT32.get_byte())
+
+            for rank in pl.range(pld.world_size()):
+                payload = pld.window(payload_buf, [1, _PAYLOAD_WIDTH], dtype=pl.INT32)
+                signal = pld.window(signal_buf, [1, 1], dtype=pl.INT32)
+                self.chip_orch(
+                    inputs[rank],
+                    outputs[rank],
+                    payload,
+                    signal,
+                    (rank + 1) % pld.world_size(),
+                    device=rank,
+                )
+            return outputs
+
+    return DeferredCompletion
+
+
+def _a2a3_saturation_waiters(platform: str) -> int:
+    """Return the AIV saturation point for the selected A2/A3 target."""
+    return _A2A3_SIM_AIVS if str(platform).endswith("sim") else _A2A3_ONBOARD_AIVS
+
+
+def _compile_two_rank(program, test_config, device_ids, output_dir):
+    """Compile one deferred-completion variant for exactly two ranks."""
+    if len(device_ids) < _N_RANKS:
+        pytest.skip(f"deferred completion needs {_N_RANKS} devices, got {device_ids}")
+    return ir.compile(
+        program,
+        output_dir=str(output_dir),
+        platform=test_config.platform,
+        distributed_config=DistributedConfig(
+            device_ids=device_ids[:_N_RANKS],
+            num_sub_workers=0,
+        ),
+    )
+
+
+def _expected(waiter_count: int, epoch: int) -> torch.Tensor:
+    """Return the current epoch followed by the peer's rank tag."""
+    expected = torch.empty((_N_RANKS, waiter_count, _PAYLOAD_WIDTH), dtype=torch.int32)
+    expected[0].fill_(2)
+    expected[1].fill_(1)
+    expected[:, :, 0].fill_(epoch)
+    return expected
+
+
+def _inputs(epoch: int = 1) -> torch.Tensor:
+    """Return a shared epoch lane followed by rank-specific payload lanes."""
+    inputs = torch.empty((_N_RANKS, 1, _PAYLOAD_WIDTH), dtype=torch.int32)
+    inputs[0].fill_(1)
+    inputs[1].fill_(2)
+    inputs[:, :, 0].fill_(epoch)
+    return inputs.share_memory_()
+
+
+def _assert_peer_tags(outputs: torch.Tensor, waiter_count: int, epoch: int = 1) -> None:
+    expected = _expected(waiter_count, epoch)
+    assert torch.equal(outputs, expected), (
+        "deferred-completion payload mismatch: "
+        f"got rank0={outputs[0].flatten().tolist()}, rank1={outputs[1].flatten().tolist()}"
+    )
+
+
+@pytest.mark.platforms("a2a3", "a2a3sim")
+def test_deferred_completion_releases_cores_and_reuses_wait_table(test_config, device_ids, tmp_path):
+    """An AIV-saturating wait set releases cores across monotonic epochs."""
+    waiter_count = _a2a3_saturation_waiters(test_config.platform)
+    program = _build_deferred_completion_program(waiter_count)
+    compiled = _compile_two_rank(program, test_config, device_ids, tmp_path / "liveness")
+    outputs = torch.full(
+        (_N_RANKS, waiter_count, _PAYLOAD_WIDTH),
+        -1,
+        dtype=torch.int32,
+    ).share_memory_()
+    # Prepared chip workers are forked by ``prepare``.  Create every shared
+    # host tensor first, then update the retained mapping in place per epoch.
+    inputs = _inputs()
+
+    with compiled.prepare(
+        config=test_config,
+        persistent=True,
+        reset_persistent_windows=False,
+    ) as worker:
+        for epoch in range(1, 4):
+            inputs[0].fill_(1)
+            inputs[1].fill_(2)
+            inputs[:, :, 0].fill_(epoch)
+            outputs.fill_(-1)
+            worker(inputs, outputs, config=test_config)
+            _assert_peer_tags(outputs, waiter_count, epoch)
+
+
+@pytest.mark.platforms("a2a3", "a2a3sim")
+def test_deferred_completion_reuses_already_ready_registration(test_config, device_ids, tmp_path):
+    """A primed counter completes later registrations and reuses wait slots."""
+    program = _build_deferred_completion_program(1)
+    compiled = _compile_two_rank(program, test_config, device_ids, tmp_path / "already_ready")
+    inputs = _inputs(epoch=1)
+    outputs = torch.full((_N_RANKS, 1, _PAYLOAD_WIDTH), -1, dtype=torch.int32).share_memory_()
+
+    with compiled.prepare(
+        config=test_config,
+        persistent=True,
+        reset_persistent_windows=False,
+    ) as worker:
+        # The first call primes signal=1 after registering against a fresh
+        # counter. The next two calls register against that already-ready
+        # value and exercise immediate completion plus wait-slot reuse. The
+        # repeated payload is intentional: freshness across generations is
+        # covered by the monotonic-epoch saturation case above.
+        for _ in range(3):
+            outputs.fill_(-1)
+            worker(inputs, outputs, config=test_config)
+            _assert_peer_tags(outputs, 1, epoch=1)
+
+
+@pytest.mark.platforms("a5", "a5sim")
+def test_deferred_completion_a5_cross_rank_correctness(test_config, device_ids, tmp_path):
+    """A small A5 case preserves correctness over two monotonic epochs without a window reset."""
+    program = _build_deferred_completion_program(_A5_SMOKE_WAITS)
+    compiled = _compile_two_rank(program, test_config, device_ids, tmp_path / "a5_correctness")
+    outputs = torch.full(
+        (_N_RANKS, _A5_SMOKE_WAITS, _PAYLOAD_WIDTH),
+        -1,
+        dtype=torch.int32,
+    ).share_memory_()
+    inputs = _inputs()
+
+    with compiled.prepare(
+        config=test_config,
+        persistent=True,
+        reset_persistent_windows=False,
+    ) as worker:
+        for epoch in range(1, 3):
+            inputs[0].fill_(1)
+            inputs[1].fill_(2)
+            inputs[:, :, 0].fill_(epoch)
+            outputs.fill_(-1)
+            worker(inputs, outputs, config=test_config)
+            _assert_peer_tags(outputs, _A5_SMOKE_WAITS, epoch)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", *sys.argv[1:]])

--- a/tests/ut/codegen/distributed/test_distributed_pto_codegen.py
+++ b/tests/ut/codegen/distributed/test_distributed_pto_codegen.py
@@ -10,7 +10,7 @@
 """PTO codegen tests for distributed N6 ops.
 
 Covers the InCore PTO codegen for ``pld.tile.remote_load``,
-``pld.system.notify`` and ``pld.system.wait``:
+``pld.system.notify``, ``pld.system.wait`` and ``pld.system.defer_wait``:
 
 - MaterializeDistTensorCtx adds one explicit CommContext IR parameter per
   ``DistributedTensor`` IR param; PTO codegen lowers each one to
@@ -50,6 +50,7 @@ from pypto.backend import BackendType
 from pypto.ir.builder import IRBuilder
 from pypto.ir.op.distributed import system_ops as dist_system
 from pypto.ir.pass_manager import OptimizationStrategy, PassManager
+from pypto.pypto_core import passes as _core_passes
 
 
 @pytest.fixture(autouse=True)
@@ -64,6 +65,27 @@ def _generate_mlir(program_cls) -> str:
     pm = PassManager.get_strategy(OptimizationStrategy.Default)
     optimized = pm.run_passes(program_cls)
     return codegen.PTOCodegen().generate(optimized)
+
+
+def _generate_outlined_waiter_mlir(program_cls) -> str:
+    """Run production waiter outlining before the fully instrumented pipeline.
+
+    Default orders hierarchy outlining before InCore outlining.  These focused
+    fixtures have no outer hierarchy, so a verification instrument would inspect
+    the still-nested distributed op too early.  Production programs reach the
+    same state after their enclosing hierarchy is outlined; make that validated
+    waiter + orchestration call-site state explicit here.
+    """
+    outlined = passes.outline_incore_scopes()(passes.convert_to_ssa()(program_cls))
+    pm = PassManager.get_strategy(OptimizationStrategy.Default)
+    optimized = pm.run_passes(outlined)
+    incore = [
+        func
+        for func in optimized.functions.values()
+        if func.func_type not in (pl.FunctionType.Orchestration, pl.FunctionType.Group)
+    ]
+    assert len(incore) == 1, f"expected one waiter kernel, got {[func.name for func in incore]}"
+    return codegen.PTOCodegen().generate(ir.Program(incore, incore[0].name, optimized.span))
 
 
 def test_ctx_arg_materialized_per_distributed_tensor():
@@ -96,6 +118,206 @@ def test_ctx_arg_materialized_per_distributed_tensor():
     # body uses bind to %argK references). Two DistributedTensors → two ptr
     # declarations.
     assert header.count("!pto.ptr<i64>") == 2, header
+
+
+def test_defer_wait_registers_strided_counter_without_blocking_twait():
+    """defer_wait forwards AsyncCtx ABI data and the exact logical element offset."""
+
+    @pl.program
+    class P:
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def main(
+            self,
+            signal: pld.DistributedTensor[
+                [4, 8],
+                pl.INT32,
+                pl.TensorView(stride=[16, 1], layout=pl.TensorLayout.ND),
+            ],
+            row: pl.Scalar[pl.INT32],
+            expected: pl.Scalar[pl.INT32],
+        ):
+            with pl.at(level=pl.Level.CORE_GROUP, name_hint="kernel"):
+                pld.system.defer_wait(
+                    signal,
+                    offsets=[row, 2],
+                    expected=expected,
+                    cmp=pld.WaitCmp.Ge,
+                )
+
+    mlir = _generate_outlined_waiter_mlir(P)
+    funcs = _split_module(mlir)
+    kernel = funcs["kernel"]
+    header = kernel.splitlines()[0]
+
+    assert "%__pypto_deferred_raw_args: !pto.ptr<i64>" in header, header
+    assert "pto.comm.twait" not in kernel
+    assert "arith.muli" in kernel
+    assert "%c16_index" in kernel
+    assert kernel.count("arith.cmpi slt") == 2
+    assert kernel.count("arith.cmpi sge") == 2
+    assert "arith.select" in kernel
+    assert "%cn1_index" in kernel
+    assert "arith.index_cast" in kernel and "index to i64" in kernel
+    assert "arith.extsi" in kernel and ": i32 to i64" in kernel
+    assert ("func.call @pypto_register_counter_completion(%__pypto_deferred_raw_args, %arg0, ") in kernel
+    assert ") : (!pto.ptr<i64>, !pto.ptr<i32>, i64, i64) -> ()" in kernel
+    assert (
+        mlir.count(
+            "func.func private @pypto_register_counter_completion(!pto.ptr<i64>, !pto.ptr<i32>, i64, i64)"
+        )
+        == 1
+    )
+
+
+def test_defer_wait_rejects_kernel_name_reserved_for_runtime_adapter():
+    """Fail before emitting two MLIR functions with the same adapter symbol."""
+
+    @pl.program
+    class P:
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def main(self, signal: pld.DistributedTensor[[1], pl.INT32]):
+            with pl.at(
+                level=pl.Level.CORE_GROUP,
+                name_hint="pypto_register_counter_completion",
+            ):
+                pld.system.defer_wait(
+                    signal,
+                    offsets=[0],
+                    expected=1,
+                    cmp=pld.WaitCmp.Ge,
+                )
+
+    with pytest.raises(ValueError, match="reserved for PyPTO's deferred-completion runtime adapter"):
+        _generate_outlined_waiter_mlir(P)
+
+
+def test_defer_wait_preserves_wide_dynamic_expected_for_runtime_range_check():
+    """A dynamic i64 expected value reaches the checked adapter without truncation."""
+
+    @pl.program
+    class P:
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def main(
+            self,
+            signal: pld.DistributedTensor[[8], pl.INT32],
+            expected: pl.Scalar[pl.INT64],
+        ):
+            with pl.at(level=pl.Level.CORE_GROUP, name_hint="kernel"):
+                pld.system.defer_wait(signal, offsets=[0], expected=expected, cmp=pld.WaitCmp.Ge)
+
+    kernel = _split_module(_generate_outlined_waiter_mlir(P))["kernel"]
+    assert "arith.trunci" not in kernel
+    assert re.search(
+        r"func\.call @pypto_register_counter_completion\("
+        r"%__pypto_deferred_raw_args, %arg0, %[A-Za-z0-9_.$]+, %arg1\)",
+        kernel,
+    )
+
+
+def test_defer_wait_zero_extends_unsigned_offset_before_index_cast():
+    """Unsigned coordinates keep their value when the source high bit is set."""
+
+    @pl.program
+    class P:
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def main(
+            self,
+            signal: pld.DistributedTensor[[256], pl.INT32],
+            offset: pl.Scalar[pl.UINT8],
+        ):
+            with pl.at(level=pl.Level.CORE_GROUP, name_hint="kernel"):
+                pld.system.defer_wait(
+                    signal,
+                    offsets=[offset],
+                    expected=1,
+                    cmp=pld.WaitCmp.Ge,
+                )
+
+    mlir = _generate_outlined_waiter_mlir(P)
+    kernel = _split_module(mlir)["kernel"]
+    assert "builtin.unrealized_conversion_cast" in kernel
+    assert ": ui8 to i8" in kernel
+    assert "arith.extui" in kernel and ": i8 to i64" in kernel
+    assert "arith.index_cast" in kernel and ": i64 to index" in kernel
+    assert "arith.index_cast" not in kernel.split(": ui8 to i8", 1)[0]
+
+
+def test_defer_wait_zero_extends_unsigned_expected_before_runtime_range_check():
+    """UINT32 values above INT32_MAX must not wrap negative before the adapter."""
+
+    @pl.program
+    class P:
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def main(
+            self,
+            signal: pld.DistributedTensor[[8], pl.INT32],
+            expected: pl.Scalar[pl.UINT32],
+        ):
+            with pl.at(level=pl.Level.CORE_GROUP, name_hint="kernel"):
+                pld.system.defer_wait(signal, offsets=[0], expected=expected, cmp=pld.WaitCmp.Ge)
+
+    kernel = _split_module(_generate_outlined_waiter_mlir(P))["kernel"]
+    assert "builtin.unrealized_conversion_cast" in kernel and ": ui32 to i32" in kernel
+    assert "arith.extui" in kernel and ": i32 to i64" in kernel
+    assert "arith.trunci" not in kernel
+
+
+def test_defer_wait_guards_dynamic_offsets_against_runtime_valid_shape():
+    """Each dynamic coordinate is checked against zero and the logical valid extent."""
+    valid_rows = pl.dynamic("DEFER_VALID_ROWS")
+
+    @pl.program
+    class P:
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def main(
+            self,
+            signal: pld.DistributedTensor[
+                [8, 4],
+                pl.INT32,
+                pl.TensorView(
+                    valid_shape=[valid_rows, 4],
+                    stride=[4, 1],
+                    layout=pl.TensorLayout.ND,
+                ),
+            ],
+            row: pl.Scalar[pl.INT32],
+        ):
+            with pl.at(level=pl.Level.CORE_GROUP, name_hint="kernel"):
+                pld.system.defer_wait(signal, offsets=[row, 0], expected=1, cmp=pld.WaitCmp.Ge)
+
+    # A type-only DynVar currently has no module-level declaration in printed
+    # IR, so use the normal structural verifier without RoundtripInstrument.
+    ctx = _core_passes.PassContext(
+        [_core_passes.VerificationInstrument(_core_passes.VerificationMode.BEFORE_AND_AFTER)]
+    )
+    with ctx:
+        kernel = _split_module(_generate_outlined_waiter_mlir(P))["kernel"]
+    assert re.search(r"arith\.cmpi slt, %[A-Za-z0-9_.$]+, %c0_index : index", kernel)
+    # The type-only valid_shape symbol is materialized as a dynamic index
+    # parameter; the upper-bound check must use it instead of physical shape 8.
+    assert re.search(r"arith\.cmpi sge, %[A-Za-z0-9_.$]+, %arg1 : index", kernel)
+    assert "arith.select" in kernel and "%cn1_index" in kernel
+
+
+def test_defer_wait_rejects_slice_alias_without_encoded_logical_origin():
+    """A slice must not silently register an address relative to its parent base."""
+
+    @pl.program
+    class P:
+        @pl.function(type=pl.FunctionType.InCore)
+        def kernel(self, signal: pld.DistributedTensor[[8], pl.INT32]):
+            pl.func_attr({"deferred_completion_waiter": True})
+            sub = pl.tensor.slice(signal, [4], [2])
+            pld.system.defer_wait(sub, offsets=[0], expected=1, cmp=pld.WaitCmp.Ge)
+
+    # ConvertTensorToTileOps turns the sliced alias into a Tile. Disable the
+    # print/parse round-trip instrument to verify the pass itself fails closed
+    # while rebuilding the op, before malformed IR can reach PTO lowering.
+    ctx = _core_passes.PassContext(
+        [_core_passes.VerificationInstrument(_core_passes.VerificationMode.BEFORE_AND_AFTER)]
+    )
+    with ctx, pytest.raises(ValueError, match=r"signal must be a DistributedTensor.*got TileType"):
+        _generate_mlir(P)
 
 
 def test_remote_load_ragged_tail_partitions_only_valid_extent():

--- a/tests/ut/codegen/test_pto_codegen.py
+++ b/tests/ut/codegen/test_pto_codegen.py
@@ -22,6 +22,7 @@ Tests verify:
 import re
 
 import pypto.language as pl
+import pypto.language.distributed as pld
 import pytest
 from pypto import DataType, backend, codegen, ir
 from pypto.backend import BackendType, pto_backend
@@ -1598,6 +1599,61 @@ class TestGenerateKernelWrapper:
         wrapper = _generate_kernel_wrapper(func, SAMPLE_PTOAS_OUTPUT)
         # Tensors-first: a=arg0, out=arg1, s=arg2
         assert "my_kernel(a, out, s);" in wrapper
+
+    def test_defer_wait_wrapper_forwards_raw_args_through_checked_adapter(self):
+        @pl.program
+        class DeferredWrapperProgram:
+            @pl.function(type=pl.FunctionType.InCore)
+            def deferred_kernel(
+                self,
+                signal: pld.DistributedTensor[[4, 8], pl.INT32],
+                expected: pl.Scalar[pl.INT32],
+            ):
+                # Backend-only fixture: outlining a validated ``pl.at`` waiter
+                # scope stamps this internal marker in production pipelines.
+                pl.func_attr({"deferred_completion_waiter": True})
+                pld.system.defer_wait(
+                    signal,
+                    offsets=[1, 2],
+                    expected=expected,
+                    cmp=pld.WaitCmp.Ge,
+                )
+
+        func = DeferredWrapperProgram.get_function("deferred_kernel")
+        assert func is not None
+        wrapper = _generate_kernel_wrapper(func, SAMPLE_PTOAS_OUTPUT)
+
+        assert '#include "pto_async_kernel_api.h"' in wrapper
+        assert '#if !__has_include("pto_async_kernel_api.h")' in wrapper
+        assert "requires a Simpler runtime that provides pto_async_kernel_api.h" in wrapper
+        assert "static __aicore__ void pypto_register_counter_completion(" in wrapper
+        assert "AsyncCtx ctx = get_async_ctx(raw_args);" in wrapper
+        assert "if (!async_ctx_is_deferred(ctx))" in wrapper
+        assert "const bool slab_is_valid =" in wrapper
+        assert "ctx.completion_count != nullptr" in wrapper
+        assert "ctx.completion_error_code != nullptr" in wrapper
+        assert "ctx.completion_entries != nullptr" in wrapper
+        assert "ctx.completion_capacity > 0" in wrapper
+        assert "ctx.completion_capacity <= static_cast<uint32_t>(MAX_COMPLETIONS_PER_TASK)" in wrapper
+        assert (
+            wrapper.index("if (!async_ctx_is_deferred(ctx))")
+            < wrapper.index("const bool slab_is_valid =")
+            < wrapper.index("expected < 0 || expected > kMaxExpected")
+        )
+        assert wrapper.count("*ctx.completion_count = 0;") == 2
+        assert "*ctx.completion_error_code = PTO2_ERROR_ASYNC_COMPLETION_INVALID;" in wrapper
+        assert "ctx.task_token.raw = 0;" in wrapper
+        assert "__builtin_trap();" in wrapper and "trap();" in wrapper
+        assert "expected < 0 || expected > kMaxExpected" in wrapper
+        assert wrapper.index("expected < 0 || expected > kMaxExpected") < wrapper.index(
+            "static_cast<uint32_t>(expected)"
+        )
+        assert "PTO2_ERROR_ASYNC_COMPLETION_INVALID" in wrapper
+        assert "register_completion_condition(ctx, token)" in wrapper
+        assert "PTO2_ERROR_ASYNC_REGISTRATION_FAILED" in wrapper
+        assert "pto2::detail::defer_flush(ctx);" in wrapper
+        assert ") + signal_tensor->start_offset;" in wrapper
+        assert "deferred_kernel(signal, expected, args);" in wrapper
 
     def test_ptoas_code_made_static(self):
         func = _make_func("my_kernel", [("a", "tensor"), ("s", "scalar"), ("out", "tensor")])

--- a/tests/ut/ir/parser/test_system_ops.py
+++ b/tests/ut/ir/parser/test_system_ops.py
@@ -9,8 +9,8 @@
 # ruff: noqa: F722, F821
 
 """Parser tests for ``pld.system.get_comm_ctx`` / ``pld.system.rank`` /
-``pld.system.nranks`` (and the matching unified short forms ``pld.get_comm_ctx``
-/ ``pld.rank`` / ``pld.nranks``).
+``pld.system.nranks`` (and their unified short forms) plus the canonical
+``pld.system.defer_wait`` form.
 
 These ops are called explicitly (no attribute-access sugar). Dispatch mirrors
 the rest of the ``pld.*`` surface — the canonical 3-segment form and the
@@ -59,9 +59,13 @@ def _find_calls_in_func(func: ir.Function, op_name: str) -> list[ir.Call]:
     def walk(stmt: ir.Stmt) -> None:
         if isinstance(stmt, ir.AssignStmt):
             visit(stmt.value)
+        if isinstance(stmt, ir.EvalStmt):
+            visit(stmt.expr)
         if isinstance(stmt, ir.SeqStmts):
             for s in stmt.stmts:
                 walk(s)
+        if isinstance(stmt, ir.ForStmt):
+            walk(stmt.body)
         if isinstance(stmt, ir.ReturnStmt):
             for v in stmt.value:
                 visit(v)
@@ -135,6 +139,82 @@ def test_long_form_system_ops():
     assert len(_find_calls_in_func(func, "pld.system.get_comm_ctx")) == 1
     assert len(_find_calls_in_func(func, "pld.system.rank")) == 1
     assert len(_find_calls_in_func(func, "pld.system.nranks")) == 1
+
+
+def test_defer_wait_long_form_parses_and_round_trips():
+    """The canonical deferred-wait spelling creates the registered IR op."""
+
+    @pl.program
+    class P:
+        @pl.function(type=pl.FunctionType.InCore)
+        def worker(self, signal: pld.DistributedTensor[[4], pl.INT32]):
+            pld.system.defer_wait(signal, offsets=[0], expected=1, cmp=pld.WaitCmp.Ge)
+
+    func = _get_func(P, "worker")
+    calls = _find_calls_in_func(func, ir.get_op("pld.system.defer_wait").name)
+    assert len(calls) == 1
+    assert isinstance(calls[0].type, ir.UnknownType)
+    assert calls[0].kwargs["cmp"] == int(ir.WaitCmp.Ge)
+
+    reparsed = pl.parse_program(str(P))
+    ir.assert_structural_equal(P, reparsed)
+
+
+def test_defer_wait_accepts_index_expected_and_round_trips():
+    """A ``pl.range`` induction variable is a valid INDEX threshold."""
+
+    @pl.program
+    class P:
+        @pl.function(type=pl.FunctionType.InCore)
+        def worker(self, signal: pld.DistributedTensor[[4], pl.INT32]):
+            for expected in pl.range(1, 4):
+                pld.system.defer_wait(signal, offsets=[0], expected=expected, cmp=pld.WaitCmp.Ge)
+
+    func = _get_func(P, "worker")
+    calls = _find_calls_in_func(func, ir.get_op("pld.system.defer_wait").name)
+    assert len(calls) == 1
+    assert isinstance(calls[0].args[2].type, ir.ScalarType)
+    assert calls[0].args[2].type.dtype == DataType.INDEX
+
+    reparsed = pl.parse_program(str(P))
+    ir.assert_structural_equal(P, reparsed)
+
+
+def test_defer_wait_rejects_float_offset():
+    """The parser surfaces the integer/index coordinate contract."""
+    with pytest.raises(InvalidOperationError, match="offset 0 must be an integer or index scalar"):
+
+        @pl.program
+        class P:  # noqa: F841
+            @pl.function(type=pl.FunctionType.InCore)
+            def worker(self, signal: pld.DistributedTensor[[4], pl.INT32]):
+                pld.system.defer_wait(signal, offsets=[0.5], expected=1, cmp=pld.WaitCmp.Ge)
+
+
+def test_defer_wait_rejects_float_expected():
+    """The parser rejects a non-integer dynamic threshold before lowering."""
+    with pytest.raises(InvalidOperationError, match="expected must be an integer or index scalar"):
+
+        @pl.program
+        class P:  # noqa: F841
+            @pl.function(type=pl.FunctionType.InCore)
+            def worker(
+                self,
+                signal: pld.DistributedTensor[[4], pl.INT32],
+                expected: pl.Scalar[pl.FP32],
+            ):
+                pld.system.defer_wait(signal, offsets=[0], expected=expected, cmp=pld.WaitCmp.Ge)
+
+
+def test_defer_wait_rejects_eq_comparison():
+    """The parser surfaces the verifier's monotonic-comparison contract."""
+    with pytest.raises(InvalidOperationError, match=r"only supports WaitCmp\.Ge"):
+
+        @pl.program
+        class P:  # noqa: F841
+            @pl.function(type=pl.FunctionType.InCore)
+            def worker(self, signal: pld.DistributedTensor[[4], pl.INT32]):
+                pld.system.defer_wait(signal, offsets=[0], expected=1, cmp=pld.WaitCmp.Eq)
 
 
 def test_rank_inline_nested_get_comm_ctx():

--- a/tests/ut/ir/test_distributed_ops.py
+++ b/tests/ut/ir/test_distributed_ops.py
@@ -27,6 +27,7 @@ from typing import Any, cast
 
 import pytest
 from pypto import DataType, ir
+from pypto.ir.op.distributed import system_ops as dist_system_ops
 from pypto.ir.op.distributed import tensor_ops as dist_tensor_ops
 from pypto.ir.op.distributed import tile_ops as dist_tile_ops
 from pypto.language.distributed.op import tensor_ops as dsl_tensor_ops
@@ -1377,6 +1378,108 @@ def test_wait_rejects_plain_tensor_signal():
             {"cmp": ir.WaitCmp.Eq},
             span,
         )
+
+
+def test_defer_wait_builder_returns_unknown_type():
+    """Deferred wait uses the public IR builder and remains side-effect-only."""
+    span = ir.Span.unknown()
+    signal = _make_distributed_tensor_var("signal", [4], DataType.INT32, span)
+
+    call = dist_system_ops.defer_wait(signal, [0], 1, ir.WaitCmp.Ge, span=span)
+
+    assert call.op.name == ir.get_op("pld.system.defer_wait").name
+    assert isinstance(call.type, ir.UnknownType)
+    assert isinstance(call.args[1], ir.MakeTuple)
+    assert call.kwargs["cmp"] == int(ir.WaitCmp.Ge)
+
+
+def test_defer_wait_accepts_index_offsets_and_expected():
+    """INDEX values from loop induction variables are valid counter coordinates and thresholds."""
+    span = ir.Span.unknown()
+    signal = _make_distributed_tensor_var("signal", [4], DataType.INT32, span)
+    offset = ir.Var("offset", ir.ScalarType(DataType.INDEX), span)
+    expected = ir.Var("expected", ir.ScalarType(DataType.INDEX), span)
+
+    call = dist_system_ops.defer_wait(signal, [offset], expected, ir.WaitCmp.Ge, span=span)
+
+    assert isinstance(call.type, ir.UnknownType)
+    assert call.args[1].elements[0] is offset
+    assert call.args[2] is expected
+
+
+def test_defer_wait_rejects_eq_comparison():
+    """Deferred completion v1 supports only monotonic greater-or-equal counters."""
+    span = ir.Span.unknown()
+    signal = _make_distributed_tensor_var("signal", [4], DataType.INT32, span)
+
+    with pytest.raises(ValueError, match=r"only supports WaitCmp\.Ge"):
+        dist_system_ops.defer_wait(signal, [0], 1, ir.WaitCmp.Eq, span=span)
+
+
+def test_defer_wait_rejects_rank_zero_signal():
+    """The backend needs at least one signal dimension to derive an element address."""
+    span = ir.Span.unknown()
+    signal = _make_distributed_tensor_var("signal", [], DataType.INT32, span)
+
+    with pytest.raises(ValueError, match="signal rank must be at least 1"):
+        dist_system_ops.defer_wait(signal, [], 1, ir.WaitCmp.Ge, span=span)
+
+
+def test_defer_wait_rejects_float_offset():
+    """Every signal coordinate must be integer/index typed, not merely scalar typed."""
+    span = ir.Span.unknown()
+    signal = _make_distributed_tensor_var("signal", [4], DataType.INT32, span)
+    offset = ir.ConstFloat(0.0, DataType.FP32, span)
+
+    with pytest.raises(ValueError, match="offset 0 must be an integer or index scalar"):
+        dist_system_ops.defer_wait(signal, [offset], 1, ir.WaitCmp.Ge, span=span)
+
+
+def test_defer_wait_rejects_float_expected():
+    """The runtime counter threshold accepts integer and INDEX scalars only."""
+    span = ir.Span.unknown()
+    signal = _make_distributed_tensor_var("signal", [4], DataType.INT32, span)
+    expected = ir.ConstFloat(1.0, DataType.FP32, span)
+
+    with pytest.raises(ValueError, match="expected must be an integer or index scalar"):
+        dist_system_ops.defer_wait(signal, [0], expected, ir.WaitCmp.Ge, span=span)
+
+
+@pytest.mark.parametrize(
+    ("expected", "dtype"),
+    [
+        (-1, DataType.INT64),
+        (2**31, DataType.INT64),
+        (-1, DataType.INDEX),
+        (2**31, DataType.INDEX),
+    ],
+)
+def test_defer_wait_rejects_out_of_range_constant_expected(expected: int, dtype: DataType):
+    """Statically known thresholds must fit the runtime's safe counter range."""
+    span = ir.Span.unknown()
+    signal = _make_distributed_tensor_var("signal", [4], DataType.INT32, span)
+    expected_expr = ir.ConstInt(expected, dtype, span)
+
+    with pytest.raises(ValueError, match=r"expected must be in \[0, INT32_MAX\]"):
+        dist_system_ops.defer_wait(signal, [0], expected_expr, ir.WaitCmp.Ge, span=span)
+
+
+def test_defer_wait_rejects_non_int32_signal():
+    """Runtime deferred counters are backed by INT32 signal slots."""
+    span = ir.Span.unknown()
+    signal = _make_distributed_tensor_var("signal", [4], DataType.FP32, span)
+
+    with pytest.raises(ValueError, match="signal dtype must be INT32"):
+        dist_system_ops.defer_wait(signal, [0], 1, ir.WaitCmp.Ge, span=span)
+
+
+def test_defer_wait_rejects_plain_tensor_signal():
+    """Deferred completion requires a window-bound DistributedTensor signal."""
+    span = ir.Span.unknown()
+    plain = ir.Var("x", ir.TensorType([ir.ConstInt(4, DataType.INT64, span)], DataType.INT32), span)
+
+    with pytest.raises(ValueError, match="DistributedTensor"):
+        dist_system_ops.defer_wait(plain, [0], 1, ir.WaitCmp.Ge, span=span)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/ut/ir/transforms/test_expand_mixed_kernel_a2a3.py
+++ b/tests/ut/ir/transforms/test_expand_mixed_kernel_a2a3.py
@@ -15,6 +15,7 @@ own a2a3 boundary behaviour without running InjectGMPipeBuffer.
 """
 
 import pypto.language as pl
+import pypto.language.distributed as pld
 import pytest
 from pypto import backend, ir, passes
 from pypto.backend import BackendType
@@ -61,6 +62,191 @@ def _op_name(stmt: ir.Stmt) -> str:
     if call is not None and isinstance(call.op, ir.Op):
         return call.op.name
     return ""
+
+
+def test_direct_incore_defer_wait_requires_task_level_waiter_contract():
+    """A direct InCore helper must not bypass task-level waiter validation."""
+
+    @pl.program
+    class Program:
+        @pl.function(type=pl.FunctionType.InCore)
+        def direct_wait(self, signal: pld.DistributedTensor[[1, 1], pl.INT32]):
+            pld.system.defer_wait(
+                signal,
+                offsets=[0, 0],
+                expected=1,
+                cmp=pld.WaitCmp.Ge,
+            )
+
+    with pytest.raises(ValueError, match="bypasses the deferred-waiter task contract"):
+        _run_pipeline(Program)
+
+
+def test_aiv_defer_wait_requires_task_level_waiter_contract():
+    """A specialized AIV kernel cannot bypass the InCore scope validator."""
+
+    @pl.program
+    class Program:
+        @pl.function(type=pl.FunctionType.AIV)
+        def direct_wait(self, signal: pld.DistributedTensor[[1, 1], pl.INT32]):
+            pld.system.defer_wait(
+                signal,
+                offsets=[0, 0],
+                expected=1,
+                cmp=pld.WaitCmp.Ge,
+            )
+
+    with pytest.raises(ValueError, match="bypasses the deferred-waiter task contract"):
+        _run_pipeline(Program)
+
+
+def test_forged_waiter_marker_without_task_level_call_site_is_rejected():
+    """The printable internal attr is not accepted as provenance on its own."""
+
+    @pl.program
+    class Program:
+        @pl.function(type=pl.FunctionType.InCore)
+        def direct_wait(self, signal: pld.DistributedTensor[[1, 1], pl.INT32]):
+            pl.func_attr({"deferred_completion_waiter": True})
+            pld.system.defer_wait(
+                signal,
+                offsets=[0, 0],
+                expected=1,
+                cmp=pld.WaitCmp.Ge,
+            )
+
+    with pytest.raises(ValueError, match="no task-level Orchestration call site"):
+        _run_pipeline(Program)
+
+
+def test_forged_waiter_plain_call_early_resolve_fails_closed():
+    """A plain GlobalVar call cannot smuggle an unsafe early-resolve attr."""
+
+    @pl.program
+    class Program:
+        @pl.function(type=pl.FunctionType.InCore)
+        def waiter(self, signal: pld.DistributedTensor[[1, 1], pl.INT32]):
+            pl.func_attr({"deferred_completion_waiter": True})
+            pld.system.defer_wait(signal, offsets=[0, 0], expected=1, cmp=pld.WaitCmp.Ge)
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def main(self, signal: pld.DistributedTensor[[1, 1], pl.INT32]):
+            self.waiter(signal, attrs={"allow_early_resolve": True})
+
+    with pytest.raises(ValueError, match="cannot use allow_early_resolve=True"):
+        _run_pipeline(Program)
+
+
+def test_forged_waiter_plain_call_core_num_fails_closed():
+    """A plain GlobalVar call cannot turn the waiter into an SPMD launch."""
+
+    @pl.program
+    class Program:
+        @pl.function(type=pl.FunctionType.InCore)
+        def waiter(self, signal: pld.DistributedTensor[[1, 1], pl.INT32]):
+            pl.func_attr({"deferred_completion_waiter": True})
+            pld.system.defer_wait(signal, offsets=[0, 0], expected=1, cmp=pld.WaitCmp.Ge)
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def main(self, signal: pld.DistributedTensor[[1, 1], pl.INT32]):
+            self.waiter(signal, attrs={"core_num": 2})
+
+    with pytest.raises(ValueError, match="single-block task"):
+        _run_pipeline(Program)
+
+
+def test_forged_waiter_plain_call_predicate_fails_closed():
+    """A printable waiter marker cannot bypass the no-predicate contract."""
+
+    @pl.program
+    class Program:
+        @pl.function(type=pl.FunctionType.InCore)
+        def waiter(self, signal: pld.DistributedTensor[[1, 1], pl.INT32]):
+            pl.func_attr({"deferred_completion_waiter": True})
+            pld.system.defer_wait(signal, offsets=[0, 0], expected=1, cmp=pld.WaitCmp.Ge)
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def main(
+            self,
+            signal: pld.DistributedTensor[[1, 1], pl.INT32],
+            gate: pl.Tensor[[1], pl.INT32],
+        ):
+            self.waiter(signal, attrs={"predicate": gate[0] > 0})
+
+    with pytest.raises(ValueError, match="cannot use a dispatch predicate"):
+        _run_pipeline(Program)
+
+
+def test_forged_waiter_plain_call_sync_start_fails_closed():
+    """A printable waiter marker cannot bypass the single-block contract."""
+
+    @pl.program
+    class Program:
+        @pl.function(type=pl.FunctionType.InCore)
+        def waiter(self, signal: pld.DistributedTensor[[1, 1], pl.INT32]):
+            pl.func_attr({"deferred_completion_waiter": True})
+            pld.system.defer_wait(signal, offsets=[0, 0], expected=1, cmp=pld.WaitCmp.Ge)
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def main(self, signal: pld.DistributedTensor[[1, 1], pl.INT32]):
+            self.waiter(signal, attrs={"sync_start": True})
+
+    with pytest.raises(ValueError, match="single-block task"):
+        _run_pipeline(Program)
+
+
+def test_valid_waiter_aiv_form_remains_valid_on_expand_rerun():
+    """The audit revalidates the marked AIV form produced by the first run."""
+
+    @pl.program
+    class Program:
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def main(self, signal: pld.DistributedTensor[[1, 1], pl.INT32]):
+            with pl.at(level=pl.Level.CORE_GROUP, name_hint="waiter"):
+                pld.system.defer_wait(
+                    signal,
+                    offsets=[0, 0],
+                    expected=1,
+                    cmp=pld.WaitCmp.Ge,
+                )
+
+    outlined = passes.outline_incore_scopes()(passes.convert_to_ssa()(Program))
+    expanded = passes.expand_mixed_kernel()(passes.infer_tile_memory_space()(outlined))
+    waiter = expanded.get_function("waiter")
+    assert waiter is not None
+    assert waiter.func_type == ir.FunctionType.AIV
+    assert waiter.attrs["deferred_completion_waiter"] is True
+
+    rerun = passes.expand_mixed_kernel()(expanded)
+    rerun_waiter = rerun.get_function("waiter")
+    assert rerun_waiter is not None
+    assert rerun_waiter.func_type == ir.FunctionType.AIV
+
+
+def test_validated_waiter_accepts_trailing_empty_return():
+    """Function normalization may append a no-value return terminator."""
+
+    @pl.program
+    class Program:
+        @pl.function(type=pl.FunctionType.InCore)
+        def waiter(self, signal: pld.DistributedTensor[[1, 1], pl.INT32]):
+            pl.func_attr({"deferred_completion_waiter": True})
+            pld.system.defer_wait(
+                signal,
+                offsets=[0, 0],
+                expected=1,
+                cmp=pld.WaitCmp.Ge,
+            )
+            return  # noqa: PLR1711 - explicit empty terminator is the test subject
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def main(self, signal: pld.DistributedTensor[[1, 1], pl.INT32]):
+            self.waiter(signal)
+
+    after = _run_pipeline(Program)
+    waiter = after.get_function("waiter")
+    assert waiter is not None
+    assert waiter.func_type == ir.FunctionType.AIV
 
 
 def test_hand_written_group_members_share_canonical_abi():

--- a/tests/ut/ir/transforms/test_outline_incore_scopes.py
+++ b/tests/ut/ir/transforms/test_outline_incore_scopes.py
@@ -11,6 +11,7 @@
 
 import pypto
 import pypto.language as pl
+import pypto.language.distributed as pld
 import pytest
 from pypto import DataType, ir, passes
 from pypto.ir.printer import python_print
@@ -898,6 +899,433 @@ class TestOutlineSubmitTaskId:
         tail = call.type.types[-1]
         assert isinstance(tail, ir.ScalarType)
         assert tail.dtype == DataType.TASK_ID
+
+    def test_deferred_wait_does_not_order_later_notify_behind_waiter(self):
+        """Signal control ops stay Input; notify has no waiter dependency.
+
+        The deferred waiter is logically live after its AIV kernel returns, so
+        a spurious waiter -> notifier edge would recreate the physical-core
+        saturation deadlock.  ``defer_wait`` and ``notify`` are side-effect ops
+        with no memory-write specification, hence both outlined signal params
+        derive as Input and a MANUAL scope leaves the later notifier unordered.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                signal: pld.DistributedTensor[[1, 1], pl.INT32],
+                peer: pl.Scalar[pl.INT32],
+                payload: pl.Tensor[[1], pl.INT32],
+            ):
+                with pl.manual_scope():
+                    with pl.at(level=pl.Level.CORE_GROUP, name_hint="deferred_wait") as wait_tid:
+                        pld.system.defer_wait(signal, offsets=[0, 0], expected=1, cmp=pld.WaitCmp.Ge)
+                    with pl.at(level=pl.Level.CORE_GROUP, name_hint="notifier"):
+                        pld.system.notify(
+                            signal,
+                            peer=peer,
+                            offsets=[0, 0],
+                            value=1,
+                            op=pld.NotifyOp.Set,
+                        )
+                    with pl.at(
+                        level=pl.Level.CORE_GROUP,
+                        name_hint="consumer",
+                        deps=[wait_tid],
+                    ):
+                        payload_value = pl.read(payload, [0])
+
+        after = passes.outline_incore_scopes()(passes.convert_to_ssa()(Before))
+        after = passes.derive_call_directions()(after)
+        after = passes.auto_derive_task_dependencies(analyze_auto_scopes=True)(after)
+
+        main = after.get_function("main")
+        assert main is not None
+        calls: list[ir.Call | ir.Submit] = []
+
+        class _Collector(ir.IRVisitor):
+            def visit_call(self, op):
+                if isinstance(op.op, ir.GlobalVar):
+                    calls.append(op)
+                super().visit_call(op)
+
+            def visit_submit(self, op):
+                calls.append(op)
+                super().visit_submit(op)
+
+        _Collector().visit_stmt(main.body)
+        assert len(calls) == 3
+        waiter, notifier, consumer = calls
+        assert isinstance(waiter, ir.Submit)
+        assert list(waiter.arg_directions) == [ir.ArgDirection.Input]
+        assert isinstance(notifier, ir.Call)
+        assert list(notifier.arg_directions) == [ir.ArgDirection.Input, ir.ArgDirection.Scalar]
+        assert "manual_dep_edges" not in notifier.attrs
+        assert "compiler_manual_dep_edges" not in notifier.attrs
+        assert isinstance(consumer, ir.Submit)
+        assert len(consumer.deps) == 1
+
+    def test_deferred_wait_rejects_allow_early_resolve(self):
+        """A deferred-completion TaskId cannot also opt into early resolve."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(self, signal: pld.DistributedTensor[[1, 1], pl.INT32]):
+                with pl.at(
+                    level=pl.Level.CORE_GROUP,
+                    name_hint="deferred_wait",
+                    allow_early_resolve=True,
+                ) as wait_tid:
+                    pld.system.defer_wait(signal, offsets=[0, 0], expected=1, cmp=pld.WaitCmp.Ge)
+
+        with pytest.raises(ValueError, match="defer_wait.*cannot use.*allow_early_resolve=True"):
+            passes.outline_incore_scopes()(passes.convert_to_ssa()(Before))
+
+    def test_terminal_deferred_waiter_needs_no_task_id_capture(self):
+        """A fire-and-forget terminal waiter is a valid ordinary task dispatch."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(self, signal: pld.DistributedTensor[[1, 1], pl.INT32]):
+                with pl.at(level=pl.Level.CORE_GROUP, name_hint="terminal_waiter"):
+                    pld.system.defer_wait(signal, offsets=[0, 0], expected=1, cmp=pld.WaitCmp.Ge)
+
+        after = passes.outline_incore_scopes()(passes.convert_to_ssa()(Before))
+        waiter = after.get_function("terminal_waiter")
+        assert waiter is not None
+        assert waiter.attrs["deferred_completion_waiter"] is True
+
+        main = after.get_function("main")
+        assert main is not None
+        calls: list[ir.Call] = []
+
+        class _CallCollector(ir.IRVisitor):
+            def visit_call(self, op):
+                if isinstance(op.op, ir.GlobalVar):
+                    calls.append(op)
+                super().visit_call(op)
+
+        _CallCollector().visit_stmt(main.body)
+        assert len(calls) == 1
+
+    def test_deferred_waiter_rejects_nested_early_resolve_launch(self):
+        """An outer launch must not silently own waiter scheduling semantics."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(self, signal: pld.DistributedTensor[[1, 1], pl.INT32]):
+                with pl.spmd(1, allow_early_resolve=True):
+                    with pl.at(level=pl.Level.CORE_GROUP, name_hint="nested_waiter"):
+                        pld.system.defer_wait(signal, offsets=[0, 0], expected=1, cmp=pld.WaitCmp.Ge)
+
+        with pytest.raises(ValueError, match="defer_wait must be in a task-level.*nesting.*unsupported"):
+            passes.outline_incore_scopes()(passes.convert_to_ssa()(Before))
+
+    def test_deferred_waiter_rejects_nested_predicated_launch(self):
+        """A predicated outer launch cannot carry a deferred waiter."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                signal: pld.DistributedTensor[[1, 1], pl.INT32],
+                gate: pl.Tensor[[1], pl.INT32],
+            ):
+                with pl.spmd(1, predicate=(gate[0] > 0)):
+                    with pl.at(level=pl.Level.CORE_GROUP, name_hint="nested_waiter"):
+                        pld.system.defer_wait(signal, offsets=[0, 0], expected=1, cmp=pld.WaitCmp.Ge)
+
+        with pytest.raises(ValueError, match="defer_wait must be in a task-level.*nesting.*unsupported"):
+            passes.outline_incore_scopes()(passes.convert_to_ssa()(Before))
+
+    def test_deferred_wait_consumer_may_allow_early_resolve(self):
+        """The hint is producer-side; it does not pre-stage this consumer."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                signal: pld.DistributedTensor[[1, 1], pl.INT32],
+                payload: pl.Tensor[[1], pl.INT32],
+            ):
+                with pl.at(level=pl.Level.CORE_GROUP) as wait_tid:
+                    pld.system.defer_wait(signal, offsets=[0, 0], expected=1, cmp=pld.WaitCmp.Ge)
+                with pl.at(
+                    level=pl.Level.CORE_GROUP,
+                    deps=[wait_tid],
+                    allow_early_resolve=True,
+                ):
+                    payload_value = pl.read(payload, [0])
+
+        after = passes.outline_incore_scopes()(passes.convert_to_ssa()(Before))
+        main = after.get_function("main")
+        assert main is not None
+        submits: list[ir.Submit] = []
+
+        class _SubmitCollector(ir.IRVisitor):
+            def visit_submit(self, op):
+                submits.append(op)
+                super().visit_submit(op)
+
+        _SubmitCollector().visit_stmt(main.body)
+        assert len(submits) == 2
+        assert submits[0].allow_early_resolve is False
+        assert submits[1].allow_early_resolve is True
+        assert len(submits[1].deps) == 1
+
+    def test_deferred_waiter_rejects_scalar_returning_helper_call(self):
+        """Scalar bookkeeping cannot hide arbitrary kernel side effects."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def scalar_helper(self, value: pl.Scalar[pl.INT32]) -> pl.Scalar[pl.INT32]:
+                return value
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                signal: pld.DistributedTensor[[1, 1], pl.INT32],
+                expected: pl.Scalar[pl.INT32],
+            ):
+                with pl.at(level=pl.Level.CORE_GROUP, name_hint="deferred_wait"):
+                    hidden: pl.Scalar[pl.INT32] = self.scalar_helper(expected)
+                    pld.system.defer_wait(signal, offsets=[0, 0], expected=hidden, cmp=pld.WaitCmp.Ge)
+
+        with pytest.raises(ValueError, match="supports only a pre-registration tensor.read"):
+            passes.outline_incore_scopes()(passes.convert_to_ssa()(Before))
+
+    def test_deferred_wait_accepts_static_conditional_registration_loop(self):
+        """The MoE waiter is bounded and consumers use ordinary deps unchanged."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                signal: pld.DistributedTensor[[8, 1], pl.INT32],
+                indices: pl.Tensor[[1, 1], pl.INT32],
+                payload: pl.Tensor[[64], pl.FP32],
+                out: pl.Out[pl.Tensor[[64], pl.FP32]],
+                my_rank: pl.Scalar[pl.INT32],
+                epoch: pl.Scalar[pl.INT32],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                with pl.at(level=pl.Level.CORE_GROUP, name_hint="dispatch_wait") as wait_tid:
+                    idx_anchor = pl.read(indices, [0, 0])
+                    for src in pl.range(8):
+                        if src != my_rank:
+                            pld.system.defer_wait(
+                                signal,
+                                offsets=[src, 0],
+                                expected=epoch,
+                                cmp=pld.WaitCmp.Ge,
+                            )
+                with pl.spmd(
+                    4,
+                    name_hint="dispatch_gather",
+                    deps=[wait_tid],
+                ) as _gather_tid:
+                    block = pl.tile.get_block_idx()
+                    offset = block * 16
+                    value = pl.load(payload, [offset], [16])
+                    out = pl.store(value, [offset], out)
+                return out
+
+        after = passes.outline_incore_scopes()(passes.convert_to_ssa()(Before))
+        waiter = after.get_function("dispatch_wait")
+        consumer = after.get_function("dispatch_gather")
+        assert waiter is not None
+        assert waiter.attrs["deferred_completion_waiter"] is True
+        assert consumer is not None
+
+        calls: list[ir.Call] = []
+
+        class _CallCollector(ir.IRVisitor):
+            def visit_call(self, op):
+                calls.append(op)
+                super().visit_call(op)
+
+        _CallCollector().visit_stmt(consumer.body)
+        assert all(call.op.name != ir.get_op("system.cacheinvalid").name for call in calls)
+
+        after = passes.outline_cluster_scopes()(after)
+        main = after.get_function("main")
+        assert main is not None
+        submits: list[ir.Submit] = []
+
+        class _SubmitCollector(ir.IRVisitor):
+            def visit_submit(self, op):
+                submits.append(op)
+                super().visit_submit(op)
+
+        _SubmitCollector().visit_stmt(main.body)
+        assert len(submits) == 2
+        assert len(submits[1].deps) == 1
+
+    def test_deferred_wait_accepts_pure_scalar_temporary_in_registration_loop(self):
+        """Hoisting pure expected-value arithmetic must not change legality."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                signal: pld.DistributedTensor[[4, 1], pl.INT32],
+                epoch: pl.Scalar[pl.INT32],
+            ):
+                with pl.at(level=pl.Level.CORE_GROUP, name_hint="waiter"):
+                    for src in pl.range(4):
+                        wanted = epoch * 4
+                        pld.system.defer_wait(
+                            signal,
+                            offsets=[src, 0],
+                            expected=wanted,
+                            cmp=pld.WaitCmp.Ge,
+                        )
+
+        after = passes.outline_incore_scopes()(passes.convert_to_ssa()(Before))
+        waiter = after.get_function("waiter")
+        assert waiter is not None
+        assert waiter.attrs["deferred_completion_waiter"] is True
+
+    def test_deferred_wait_rejects_tensor_read_in_registration_loop(self):
+        """A later iteration must not read tensor state after registration began."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                signal: pld.DistributedTensor[[2, 1], pl.INT32],
+                expected_values: pl.Tensor[[2], pl.INT32],
+            ):
+                with pl.at(level=pl.Level.CORE_GROUP):
+                    for src in pl.range(2):
+                        wanted = pl.read(expected_values, [src])
+                        pld.system.defer_wait(
+                            signal,
+                            offsets=[src, 0],
+                            expected=wanted,
+                            cmp=pld.WaitCmp.Ge,
+                        )
+
+        with pytest.raises(ValueError, match="loop may execute tensor reads.*after registering"):
+            passes.outline_incore_scopes()(passes.convert_to_ssa()(Before))
+
+    def test_deferred_wait_accepts_exactly_64_static_conditions(self):
+        """The runtime capacity is inclusive: 64 conditions are supported."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(self, signal: pld.DistributedTensor[[64, 1], pl.INT32]):
+                with pl.at(level=pl.Level.CORE_GROUP, name_hint="waiter"):
+                    for src in pl.range(64):
+                        pld.system.defer_wait(
+                            signal,
+                            offsets=[src, 0],
+                            expected=1,
+                            cmp=pld.WaitCmp.Ge,
+                        )
+
+        after = passes.outline_incore_scopes()(passes.convert_to_ssa()(Before))
+        waiter = after.get_function("waiter")
+        assert waiter is not None
+        assert waiter.attrs["deferred_completion_waiter"] is True
+
+    def test_deferred_wait_rejects_more_than_64_static_conditions(self):
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                signal: pld.DistributedTensor[[65, 1], pl.INT32],
+                my_rank: pl.Scalar[pl.INT32],
+            ):
+                with pl.at(level=pl.Level.CORE_GROUP) as wait_tid:
+                    for src in pl.range(65):
+                        if src != my_rank:
+                            pld.system.defer_wait(
+                                signal,
+                                offsets=[src, 0],
+                                expected=1,
+                                cmp=pld.WaitCmp.Ge,
+                            )
+                with pl.at(level=pl.Level.CORE_GROUP, deps=[wait_tid]):
+                    pl.system.cacheinvalid()
+
+        with pytest.raises(ValueError, match="at most 64 conditions"):
+            passes.outline_incore_scopes()(passes.convert_to_ssa()(Before))
+
+    def test_deferred_wait_rejects_dynamic_registration_loop(self):
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                signal: pld.DistributedTensor[[64, 1], pl.INT32],
+                limit: pl.Scalar[pl.INDEX],
+            ):
+                with pl.at(level=pl.Level.CORE_GROUP):
+                    for src in pl.range(limit):
+                        pld.system.defer_wait(
+                            signal,
+                            offsets=[src, 0],
+                            expected=1,
+                            cmp=pld.WaitCmp.Ge,
+                        )
+
+        with pytest.raises(ValueError, match="statically known positive trip count"):
+            passes.outline_incore_scopes()(passes.convert_to_ssa()(Before))
+
+    def test_deferred_wait_rejects_zero_trip_registration_loop(self):
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(self, signal: pld.DistributedTensor[[1, 1], pl.INT32]):
+                with pl.at(level=pl.Level.CORE_GROUP):
+                    for src in pl.range(0):
+                        pld.system.defer_wait(
+                            signal,
+                            offsets=[src, 0],
+                            expected=1,
+                            cmp=pld.WaitCmp.Ge,
+                        )
+
+        with pytest.raises(ValueError, match="statically known positive trip count"):
+            passes.outline_incore_scopes()(passes.convert_to_ssa()(Before))
+
+    def test_deferred_wait_rejects_nested_tensor_read_after_registration(self):
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                signal: pld.DistributedTensor[[1, 1], pl.INT32],
+                expected_values: pl.Tensor[[1], pl.INT32],
+                my_rank: pl.Scalar[pl.INT32],
+            ):
+                with pl.at(level=pl.Level.CORE_GROUP) as wait_tid:
+                    pld.system.defer_wait(
+                        signal,
+                        offsets=[0, 0],
+                        expected=1,
+                        cmp=pld.WaitCmp.Ge,
+                    )
+                    if my_rank >= 0:
+                        next_expected = pl.read(expected_values, [0])
+                with pl.at(level=pl.Level.CORE_GROUP, deps=[wait_tid]):
+                    pl.system.cacheinvalid()
+
+        with pytest.raises(ValueError, match="cannot execute tensor reads.*after.*registration"):
+            passes.outline_incore_scopes()(passes.convert_to_ssa()(Before))
 
 
 class TestOutlineSpmdScope:


### PR DESCRIPTION
## Summary

A blocking `pld.system.wait` occupies its AIV until a remote signal is ready. If a task graph fills the available AIVs with waiters before the publisher can run, those waiters can prevent forward progress.

This PR adds `pld.system.defer_wait`. A dedicated waiter task registers `signal >= expected` and returns from the kernel, allowing the physical AIV to be reused. Its scheduler `TaskId` remains incomplete until the condition is satisfied, so continuation tasks use the existing `deps=[wait_tid]` mechanism.

This reuses the deferred-completion API already available in the pinned Simpler runtime. It does not modify Simpler, change the runtime gitlink, or alter the existing blocking `pld.system.wait`.

## Changes

- Add the `pld.system.defer_wait` DSL and IR operation.
- Add argument, type, range, and comparison validation.
- Validate deferred waiters as dedicated pure-AIV tasks and reject unsafe continuation work inside the waiter kernel.
- Lower deferred registrations through a checked adapter to Simpler's `AsyncCtx`.
- Add the hidden raw dispatch context only to generated kernels that use deferred completion.
- Reuse ordinary `TaskId` dependencies; no new dependency type or `completion_deps` API is introduced.
- Add English and Chinese documentation.
- Add unit, simulator, and onboard coverage.

## Notes

- V1 supports `WaitCmp.Ge` on an INT32 distributed counter.
- A deferred waiter does not resume after the condition is satisfied; continuation work must be placed in a dependent task.
- Deferred counters use non-negative, monotonically increasing values.

## Verification

- Build and affected unit tests passed.
- The full unit suite introduced no new failures.
- A2/A3 and A5 simulator tests passed.
- A2/A3 onboard tests passed, including AIV saturation, repeated epochs, and already-ready counter reuse.
