### PR TITLE
feat(recip): expose high-precision PTO mode

### DIFF
--- a/docs/en/user/ops/01-catalog.md
+++ b/docs/en/user/ops/01-catalog.md
@@ -39,7 +39,7 @@ See [Memory and Data Movement](../language/03-memory.md) for which moves are leg
 | Operator | Reach | What it does |
 | -------- | ----- | ------------ |
 | `add` `sub` `mul` `div` | `pl.` | Binary arithmetic; a Python number on the right selects the scalar-operand form |
-| `neg` `abs` `recip` | `pl.` | Unary negate, absolute value, reciprocal |
+| `neg` `abs` `recip` | `pl.` | Unary negate, absolute value, reciprocal. For FP16/FP32 reciprocal, `high_precision=True` selects the slower, higher-precision PTO path on A5 |
 | `rem` `rems` `fmod` `fmods` | `pl.` | Remainder and floating-point modulo, tensor and scalar forms |
 | `addc` `subc` `addsc` `subsc` | `pl.` (t) | Three-input add / subtract with carry operand |
 | `part_add` `part_mul` `part_max` `part_min` | `pl.` | Partial (segmented) arithmetic |

--- a/docs/zh/user/ops/01-catalog.md
+++ b/docs/zh/user/ops/01-catalog.md
@@ -35,7 +35,7 @@
 | 算子 | 可达 | 作用 |
 | ---- | ---- | ---- |
 | `add` `sub` `mul` `div` | `pl.` | 二元算术；右侧给 Python 数字会选中标量操作数形式 |
-| `neg` `abs` `recip` | `pl.` | 取负、绝对值、倒数 |
+| `neg` `abs` `recip` | `pl.` | 取负、绝对值、倒数；FP16/FP32 倒数设置 `high_precision=True` 时会在 A5 上选择速度较慢、精度较高的 PTO 路径 |
 | `rem` `rems` `fmod` `fmods` | `pl.` | 求余与浮点取模，张量与标量形式 |
 | `addc` `subc` `addsc` `subsc` | `pl.` (t) | 带进位操作数的三输入加 / 减 |
 | `part_add` `part_mul` `part_max` `part_min` | `pl.` | 分段算术 |

--- a/python/pypto/ir/op/tensor_ops.py
+++ b/python/pypto/ir/op/tensor_ops.py
@@ -1632,18 +1632,20 @@ def abs(input: Expr, span: Span | None = None) -> Call:
     return _ir_core.create_op_call("tensor.abs", [input], {}, actual_span)
 
 
-def recip(input: Expr, span: Span | None = None) -> Call:
+def recip(input: Expr, span: Span | None = None, *, high_precision: bool = False) -> Call:
     """Element-wise reciprocal (1/x) operation.
 
     Args:
         input: Input tensor
         span: Optional source span for debugging (auto-captured if not provided)
+        high_precision: Whether to select PTOAS's high-precision reciprocal mode (FP16/FP32 only)
 
     Returns:
         Call expression for element-wise reciprocal
     """
     actual_span = _get_span_or_capture(span)
-    return _ir_core.create_op_call("tensor.recip", [input], {}, actual_span)
+    kwargs: dict[str, Any] = {"high_precision": True} if high_precision else {}
+    return _ir_core.create_op_call("tensor.recip", [input], kwargs, actual_span)
 
 
 def sqrt(input: Expr, span: Span | None = None) -> Call:

--- a/python/pypto/ir/op/tile_ops.py
+++ b/python/pypto/ir/op/tile_ops.py
@@ -1645,18 +1645,20 @@ def cos(tile: Expr, span: Span | None = None) -> Call:
     return _ir_core.create_op_call("tile.cos", [tile], {}, actual_span)
 
 
-def recip(tile: Expr, span: Span | None = None) -> Call:
+def recip(tile: Expr, span: Span | None = None, *, high_precision: bool = False) -> Call:
     """Element-wise reciprocal (1/x) of a tile.
 
     Args:
         tile: Input tile (TileType)
         span: Optional source span for debugging (auto-captured if not provided)
+        high_precision: Whether to select PTOAS's high-precision reciprocal mode (FP16/FP32 only)
 
     Returns:
         Call expression for element-wise reciprocal
     """
     actual_span = _get_span_or_capture(span)
-    return _ir_core.create_op_call("tile.recip", [tile], {}, actual_span)
+    kwargs: dict[str, Any] = {"high_precision": True} if high_precision else {}
+    return _ir_core.create_op_call("tile.recip", [tile], kwargs, actual_span)
 
 
 def sqrt(tile: Expr, span: Span | None = None) -> Call:

--- a/python/pypto/language/op/tensor_ops.py
+++ b/python/pypto/language/op/tensor_ops.py
@@ -1728,17 +1728,18 @@ def abs(input: Tensor) -> Tensor:
     return Tensor(expr=call_expr)
 
 
-def recip(input: Tensor) -> Tensor:
+def recip(input: Tensor, high_precision: bool = False) -> Tensor:
     """Element-wise reciprocal (1/x) operation.
 
     Args:
         input: Input tensor
+        high_precision: Whether to select PTOAS's high-precision reciprocal mode (FP16/FP32 only)
 
     Returns:
         Tensor wrapping the recip operation
     """
     input_expr = input.unwrap()
-    call_expr = _ir_ops.recip(input_expr)
+    call_expr = _ir_ops.recip(input_expr, high_precision=high_precision)
     return Tensor(expr=call_expr)
 
 

--- a/python/pypto/language/op/tile_ops.py
+++ b/python/pypto/language/op/tile_ops.py
@@ -1118,16 +1118,17 @@ def rsqrt(tile: Tile, tmp: Tile | None = None) -> Tile:
     return Tile(expr=call_expr)
 
 
-def recip(tile: Tile) -> Tile:
+def recip(tile: Tile, high_precision: bool = False) -> Tile:
     """Element-wise reciprocal.
 
     Args:
         tile: Input tile
+        high_precision: Whether to select PTOAS's high-precision reciprocal mode (FP16/FP32 only)
 
     Returns:
         Tile wrapping the recip operation
     """
-    call_expr = _ir_ops.recip(tile.unwrap())
+    call_expr = _ir_ops.recip(tile.unwrap(), high_precision=high_precision)
     return Tile(expr=call_expr)
 
 

--- a/python/pypto/language/op/unified_ops.py
+++ b/python/pypto/language/op/unified_ops.py
@@ -566,12 +566,17 @@ def abs(input: T) -> T:
     raise TypeError(f"pl.abs: expected Tensor or Tile, got {type(input).__name__}")
 
 
-def recip(input: T) -> T:
-    """Element-wise reciprocal (1/x), dispatched by input type."""
+def recip(input: T, high_precision: bool = False) -> T:
+    """Element-wise reciprocal (1/x), dispatched by input type.
+
+    Args:
+        input: Input tensor or tile
+        high_precision: Whether to select PTOAS's high-precision reciprocal mode (FP16/FP32 only)
+    """
     if isinstance(input, Tensor):
-        return _tensor.recip(input)
+        return _tensor.recip(input, high_precision=high_precision)
     if isinstance(input, Tile):
-        return _tile.recip(input)
+        return _tile.recip(input, high_precision=high_precision)
     raise TypeError(f"pl.recip: expected Tensor or Tile, got {type(input).__name__}")
 
 

--- a/src/backend/common/pto_ops_elementwise.cpp
+++ b/src/backend/common/pto_ops_elementwise.cpp
@@ -83,7 +83,6 @@ static bool RequiresRowMajorLayout(std::string_view op_name) {
       "tile.abs",
       "tile.exp",
       "tile.sqrt",
-      "tile.recip",
       "tile.not",
       "tile.prelu",
       "tile.relu",
@@ -265,7 +264,7 @@ static std::string MakeModalCodegenPTO(const std::string& pto_op_name, size_t ar
 
 // Emit the default PTO form without an explicit precision attribute, or append
 // the exact PTOAS enum attribute after outs(...) for high-precision mode.
-// Unlike cmp/cvt attributes, the tdiv/tlog assembly formats place their
+// Unlike cmp/cvt attributes, precision-op assembly formats place their
 // attr-dict after the complete ins()/outs() clause.
 static std::string MakePrecisionCodegenPTO(const std::string& pto_op_name, size_t arity,
                                            const char* attr_kind, const CallPtr& op,
@@ -612,7 +611,6 @@ static const SimpleOpEntry kSimpleOps[] = {
     {"tile.exp",             "pto.texp",             1},
     {"tile.sqrt",            "pto.tsqrt",            1},
     // tile.rsqrt is registered with a custom codegen handler below (supports 1 or 2 args).
-    {"tile.recip",           "pto.trecip",           1},
     {"tile.neg",             "pto.tneg",             1},
     {"tile.not",             "pto.tnot",             1},
     {"tile.relu",            "pto.trelu",            1},
@@ -756,6 +754,7 @@ void RegisterElementwiseOps(Backend& backend, const std::unordered_set<std::stri
   };
   register_precision_op("tile.div", "pto.tdiv", 2, "div_precision");
   register_precision_op("tile.log", "pto.tlog", 1, "log_precision");
+  register_precision_op("tile.recip", "pto.trecip", 1, "recip_precision");
 
   // tile.row_expand_add follows the PTOAS overloads with and without tmp.
   // Its row-sensitive layout contract is validated by the IR op: the generic

--- a/src/ir/op/tensor_ops/unary.cpp
+++ b/src/ir/op/tensor_ops/unary.cpp
@@ -82,6 +82,11 @@ TypePtr DeduceTensorRecipType(const std::vector<ExprPtr>& args,
       << "tensor.recip requires first argument to be a TensorType or DistributedTensorType, but got "
       << args[0]->GetType()->TypeName();
 
+  CHECK(!GetKwargOr<bool>(kwargs, "high_precision", false) || tensor_type->dtype_ == DataType::FP16 ||
+        tensor_type->dtype_ == DataType::FP32)
+      << "The operator tensor.recip supports high_precision only for FP16 or FP32 because the PTOAS "
+         "high-precision template does not implement other dtypes";
+
   // Reciprocal (1/x) always produces floating-point output
   DataType out_dtype = tensor_type->dtype_;
   if (!out_dtype.IsFloat()) {
@@ -293,6 +298,7 @@ REGISTER_OP("tensor.recip")
     .set_op_category("TensorOp")
     .set_description("Element-wise reciprocal (1/x) operation")
     .add_argument("input", "Input tensor (TensorType)")
+    .set_attr<bool>("high_precision")
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
       return DeduceTensorRecipType(args, kwargs);

--- a/src/ir/op/tile_ops/unary.cpp
+++ b/src/ir/op/tile_ops/unary.cpp
@@ -225,12 +225,19 @@ REGISTER_OP("tile.recip")
     .functional_execution_memory_access()
     .set_description("Reciprocal (1/x) of a tile (element-wise)")
     .add_argument("tile", "Input tile (TileType)")
+    .set_attr<bool>("high_precision")
     .set_input_memory(0, MemorySpace::Vec)
     .set_output_memory(MemorySpace::Vec)
     .not_inplace_safe()
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
-      return DeduceTileUnaryType(args, kwargs, "tile.recip");
+      auto result_type = DeduceTileUnaryType(args, kwargs, "tile.recip");
+      auto tile_type = As<TileType>(args[0]->GetType());
+      CHECK(!GetKwargOr<bool>(kwargs, "high_precision", false) || tile_type->dtype_ == DataType::FP16 ||
+            tile_type->dtype_ == DataType::FP32)
+          << "The operator tile.recip supports high_precision only for FP16 or FP32 because the PTOAS "
+             "high-precision template does not implement other dtypes";
+      return result_type;
     });
 
 REGISTER_OP("tile.sqrt")

--- a/tests/ut/codegen/test_pto_codegen_ops.py
+++ b/tests/ut/codegen/test_pto_codegen_ops.py
@@ -628,9 +628,9 @@ class TestRsqrtHighPrecisionCodegen:
 class TestB01PrecisionAndRowExpandAddCodegen:
     """Exact PTOAS forms added for the first op batch."""
 
-    def _generate_mlir(self, program_cls) -> str:
+    def _generate_mlir(self, program_cls, backend_type=BackendType.Ascend910B) -> str:
         backend.reset_for_testing()
-        backend.set_backend_type(BackendType.Ascend910B)
+        backend.set_backend_type(backend_type)
 
         optimized = PassManager.get_strategy(OptimizationStrategy.Default).run_passes(program_cls)
         funcs = list(optimized.functions.values())
@@ -702,6 +702,39 @@ class TestB01PrecisionAndRowExpandAddCodegen:
 
         log_line = self._op_line(self._generate_mlir(LogProg), "pto.tlog")
         assert strip_loc(log_line).endswith("{precisionType = #pto<log_precision high_precision>}")
+
+    def test_trecip_default_omits_and_high_precision_appends_exact_attr_on_a5(self):
+        @pl.program
+        class DefaultProg:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                src: pl.Tensor[[16, 16], pl.FP32],
+                out: pl.Tensor[[16, 16], pl.FP32],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                result: pl.Tensor[[16, 16], pl.FP32] = pl.recip(src)
+                return result
+
+        @pl.program
+        class HighPrecisionProg:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                src: pl.Tensor[[16, 16], pl.FP32],
+                out: pl.Tensor[[16, 16], pl.FP32],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                result: pl.Tensor[[16, 16], pl.FP32] = pl.recip(src, high_precision=True)
+                return result
+
+        backend_type = BackendType.Ascend950
+        default_line = self._op_line(self._generate_mlir(DefaultProg, backend_type), "pto.trecip")
+        high_precision_line = self._op_line(
+            self._generate_mlir(HighPrecisionProg, backend_type), "pto.trecip"
+        )
+        assert "precisionType" not in default_line
+        assert strip_loc(high_precision_line).endswith(
+            "{precisionType = #pto<recip_precision high_precision>}"
+        )
 
     def test_trowexpandadd_emits_two_and_three_operand_forms(self):
         @pl.program

--- a/tests/ut/ir/operators/test_tensor_ops.py
+++ b/tests/ut/ir/operators/test_tensor_ops.py
@@ -1058,22 +1058,26 @@ def test_tensor_abs_int_dtype():
 # =============================================================================
 
 
-def test_tensor_recip():
-    """Test tensor.recip operation."""
+@pytest.mark.parametrize("dtype", [DataType.FP16, DataType.FP32])
+@pytest.mark.parametrize("high_precision", [False, True])
+def test_tensor_recip_contract_and_precision(dtype, high_precision):
+    """Both reciprocal precision modes preserve each supported float dtype."""
     span = ir.Span.unknown()
     dim64 = ir.ConstInt(64, DataType.INT32, span)
     dim128 = ir.ConstInt(128, DataType.INT32, span)
-    tensor_type = ir.TensorType([dim64, dim128], DataType.FP16)
+    tensor_type = ir.TensorType([dim64, dim128], dtype)
     tensor_var = ir.Var("t", tensor_type, span)
 
-    call = ir.op.tensor.recip(tensor_var)
+    call = ir.op.tensor.recip(tensor_var, high_precision=high_precision)
 
     assert isinstance(call, ir.Call)
     assert call.op.name == ir.get_op("tensor.recip").name
     result_type = call.type
     assert isinstance(result_type, ir.TensorType)
-    assert result_type.dtype == DataType.FP16
+    assert result_type.dtype == dtype
     assert len(result_type.shape) == 2
+    expected_kwargs = {"high_precision": True} if high_precision else {}
+    assert dict(call.kwargs) == expected_kwargs
 
 
 def test_tensor_recip_int_promotes_to_fp32():
@@ -1088,6 +1092,16 @@ def test_tensor_recip_int_promotes_to_fp32():
     result_type = call.type
     assert isinstance(result_type, ir.TensorType)
     assert result_type.dtype == DataType.FP32
+
+
+@pytest.mark.parametrize("dtype", [DataType.INT32, DataType.BF16])
+def test_tensor_recip_rejects_unsupported_high_precision_dtype(dtype):
+    """The PTOAS high-precision reciprocal template only supports FP16 and FP32 inputs."""
+    span = ir.Span.unknown()
+    tensor_var = ir.Var("t", ir.TensorType([64, 128], dtype), span)
+
+    with pytest.raises(ValueError, match=r"high_precision only for FP16 or FP32"):
+        ir.op.tensor.recip(tensor_var, high_precision=True)
 
 
 def test_tensor_sqrt():
@@ -1664,6 +1678,7 @@ def test_tensor_precision_apis_keep_positional_span_compatibility():
     calls = (
         tensor.div(lhs, rhs, span),
         tensor.log(lhs, span),
+        tensor.recip(lhs, span),
     )
 
     assert all(call.span.filename == "tensor_precision_compat.py" for call in calls)

--- a/tests/ut/ir/operators/test_tile_ops.py
+++ b/tests/ut/ir/operators/test_tile_ops.py
@@ -246,6 +246,7 @@ class TestTileElementwiseOps:
         calls = (
             tile.div(lhs, rhs, span),
             tile.log(lhs, span),
+            tile.recip(lhs, span),
         )
 
         assert all(call.span.filename == "tile_precision_compat.py" for call in calls)
@@ -390,6 +391,29 @@ class TestTileUnaryOps:
         assert call.type.dtype == dtype
         expected_kwargs = {"high_precision": True} if high_precision else {}
         assert dict(call.kwargs) == expected_kwargs
+
+    @pytest.mark.parametrize("dtype", [DataType.FP16, DataType.FP32])
+    @pytest.mark.parametrize("high_precision", [False, True])
+    def test_tile_recip_contract_and_precision(self, dtype, high_precision):
+        """Both reciprocal precision modes preserve each supported float dtype."""
+        span = ir.Span.unknown()
+        src = ir.Var("src", ir.TileType([8, 8], dtype), span)
+
+        call = tile.recip(src, high_precision=high_precision)
+
+        assert isinstance(call.type, ir.TileType)
+        assert call.type.dtype == dtype
+        expected_kwargs = {"high_precision": True} if high_precision else {}
+        assert dict(call.kwargs) == expected_kwargs
+
+    @pytest.mark.parametrize("dtype", [DataType.INT32, DataType.BF16])
+    def test_tile_recip_rejects_unsupported_high_precision_dtype(self, dtype):
+        """The PTOAS high-precision reciprocal template only supports FP16 and FP32 inputs."""
+        span = ir.Span.unknown()
+        src = ir.Var("src", ir.TileType([8, 8], dtype), span)
+
+        with pytest.raises(ValueError, match=r"high_precision only for FP16 or FP32"):
+            tile.recip(src, high_precision=True)
 
     def test_tile_abs(self):
         """Test tile.abs operator - absolute value of all elements."""

--- a/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
+++ b/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
@@ -1196,10 +1196,16 @@ class TestConvertTensorToTileOps:
                 lambda ib, ins: ib.let("z", tensor_ops.log(ins[0], high_precision=True)),
                 "tile.log",
             ),
+            (
+                "recip",
+                [("x", [64], DataType.FP32)],
+                lambda ib, ins: ib.let("z", tensor_ops.recip(ins[0], high_precision=True)),
+                "tile.recip",
+            ),
         ],
     )
     def test_precision_kwargs_survive_tensor_to_tile_conversion(self, op_name, in_specs, body, tile_op_name):
-        """Non-broadcast tdiv and tlog conversions preserve high_precision."""
+        """Non-broadcast precision-op conversions preserve high_precision."""
         before = _make_before(
             in_specs=in_specs,
             out_shape=[64],

--- a/tests/ut/language/test_unified_ops.py
+++ b/tests/ut/language/test_unified_ops.py
@@ -186,15 +186,16 @@ class TestUnifiedTensorDispatch:
 
         ir.assert_structural_equal(unified, explicit)
 
-    def test_recip(self):
+    @pytest.mark.parametrize("high_precision", [False, True])
+    def test_recip(self, high_precision):
         @pl.function
         def unified(a: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-            c: pl.Tensor[[64], pl.FP32] = pl.recip(a)
+            c: pl.Tensor[[64], pl.FP32] = pl.recip(a, high_precision=high_precision)
             return c
 
         @pl.function
         def explicit(a: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-            c: pl.Tensor[[64], pl.FP32] = pl.tensor.recip(a)
+            c: pl.Tensor[[64], pl.FP32] = pl.tensor.recip(a, high_precision=high_precision)
             return c
 
         ir.assert_structural_equal(unified, explicit)
@@ -561,13 +562,14 @@ class TestUnifiedBlockDispatch:
 
         ir.assert_structural_equal(unified, explicit)
 
-    def test_recip(self):
+    @pytest.mark.parametrize("high_precision", [False, True])
+    def test_recip(self, high_precision):
         @pl.function
         def unified(
             t: pl.Tensor[[64, 64], pl.FP32], out: pl.Tensor[[64, 64], pl.FP32]
         ) -> pl.Tensor[[64, 64], pl.FP32]:
             a: pl.Tile[[64, 64], pl.FP32] = pl.tile.load(t, offsets=[0, 0], shapes=[64, 64])
-            b: pl.Tile[[64, 64], pl.FP32] = pl.recip(a)
+            b: pl.Tile[[64, 64], pl.FP32] = pl.recip(a, high_precision=high_precision)
             result: pl.Tensor[[64, 64], pl.FP32] = pl.tile.store(b, offsets=[0, 0], output_tensor=out)
             return result
 
@@ -576,7 +578,7 @@ class TestUnifiedBlockDispatch:
             t: pl.Tensor[[64, 64], pl.FP32], out: pl.Tensor[[64, 64], pl.FP32]
         ) -> pl.Tensor[[64, 64], pl.FP32]:
             a: pl.Tile[[64, 64], pl.FP32] = pl.tile.load(t, offsets=[0, 0], shapes=[64, 64])
-            b: pl.Tile[[64, 64], pl.FP32] = pl.tile.recip(a)
+            b: pl.Tile[[64, 64], pl.FP32] = pl.tile.recip(a, high_precision=high_precision)
             result: pl.Tensor[[64, 64], pl.FP32] = pl.tile.store(b, offsets=[0, 0], output_tensor=out)
             return result
 


### PR DESCRIPTION
## Summary

- expose `high_precision` through `pl.recip`, Tensor/Tile language APIs, and direct IR APIs while preserving the default empty-kwargs IR and positional `span` compatibility
- validate that high-precision reciprocal inputs are FP16 or FP32 and preserve the attribute through Tensor-to-Tile conversion
- emit the exact A5 PTOAS `recip_precision high_precision` attribute, with focused regression coverage and synchronized English/Chinese docs

### Usage example

```python
# Existing behavior remains the default.
y = pl.recip(x)

# FP16/FP32 input: opt in to the A5 high-precision implementation.
y_high_precision = pl.recip(x, high_precision=True)
```

## Testing

- fresh `RelWithDebInfo` CMake build
- focused reciprocal regression suite after rebasing onto latest `upstream/main`: 23 passed
- full unit suite: 9631 passed, 8 skipped
- native C++ suite: 1 passed
- all pre-commit hooks on changed files passed

Fixes #2373
