### PR TITLE
fix(ir): reject NZ layout on tensor types in MaterializeTensorStrides

### DIFF
--- a/docs/en/dev/passes/30-materialize_tensor_strides.md
+++ b/docs/en/dev/passes/30-materialize_tensor_strides.md
@@ -63,8 +63,11 @@ The pass is **idempotent**: re-running on already-materialized IR is a no-op, si
 | -------- | ------- |
 | Fill stride with packed canonical | `view.has_value() && view.stride.empty()` and `layout in {ND, DN}` |
 | Identity pass-through | `!view.has_value()` (bare tensor) |
-| Identity pass-through | `view.has_value() && !view.stride.empty()` (already explicit) |
-| Reject (`ValueError`) | `view.layout == NZ` on `TensorType` / `DistributedTensorType` (invalid IR — NZ is tile-only) |
+| Identity pass-through | `view.has_value() && !view.stride.empty()` and `layout in {ND, DN}` (already explicit) |
+| Reject (`ValueError`) | `view.layout == NZ` on `TensorType` / `DistributedTensorType`, with or without explicit stride (invalid IR — NZ is tile-only) |
+
+The rows are mutually exclusive: the NZ check runs first, so an explicit-stride
+NZ view is rejected rather than passed through.
 
 ## Example
 

--- a/docs/en/dev/passes/30-materialize_tensor_strides.md
+++ b/docs/en/dev/passes/30-materialize_tensor_strides.md
@@ -49,11 +49,13 @@ The pass uses an `IRMutator` with a Var-substitution cache, mirroring the patter
      - `VisitExpr_(CallPtr)`: rebuild via `OpRegistry` when registered, falling back to a direct `Call` constructor for `GlobalVar` calls / unregistered ops.
      - `VisitStmt_(AssignStmtPtr)`: rebuild RHS first; if the RHS Call's return type is more specific than the current LHS Var type, sync the Var.
 
-2. **Type rewriting** — `MaterializeType(type)`:
-   - `TensorType` / `DistributedTensorType` with `view.has_value() && view.stride.empty() && layout != NZ`: rebuild with `BuildLogicalStridesFromLayout(shape, layout)` filled in. The distributed wrapper and optional metadata (`memref`, `TensorView.pad`, `window_buffer`) are preserved. Other tensor shapes pass through unchanged (identity preserved).
-   - `TensorType` with `layout == NZ`: untouched (NZ on `TensorType` is invalid IR; the verifier flags it instead of `BuildLogicalStridesFromLayout` `CHECK`-failing).
-   - `TupleType`: recurse into element types; rebuild only if any sub-type changed.
+2. **Type rewriting** — `MaterializeType(type, span)`:
+   - `TensorType` / `DistributedTensorType` with `layout == NZ`: **rejected** with a `CHECK_SPAN` (user-facing `ValueError`), whether or not the stride is explicit. NZ is a fractal, tile-only layout with no logical-stride representation, so a tensor type carrying it is invalid IR — the same judgement `tensor.view`, `CheckCanonicalView` and the `TensorViewCanonical` verifier all make. The `span` argument (the `Var` / `IterArg` / `Call` / `Submit` / param / function node carrying the type) locates the offending annotation in the message.
+   - `TensorType` / `DistributedTensorType` with `view.has_value() && view.stride.empty()`: rebuild with `BuildLogicalStridesFromLayout(shape, layout)` filled in. The distributed wrapper and optional metadata (`memref`, `TensorView.pad`, `window_buffer`) are preserved. Other tensor shapes pass through unchanged (identity preserved).
+   - `TupleType`: recurse into element types (same `span`); rebuild only if any sub-type changed.
    - Anything else: pass through.
+
+The NZ rejection lives in the pass rather than being delegated to the paired verifier. Delegating made the rejection conditional on verification being enabled: under `PYPTO_VERIFY_LEVEL=none` the pass returned the malformed slot untouched while still declaring `TensorViewCanonical` as produced, and the invalid layout only resurfaced downstream as an opaque backend layout mismatch.
 
 The pass is **idempotent**: re-running on already-materialized IR is a no-op, since every type comparison short-circuits on identity and `MutableCopy` is skipped when nothing changed.
 
@@ -62,7 +64,7 @@ The pass is **idempotent**: re-running on already-materialized IR is a no-op, si
 | Fill stride with packed canonical | `view.has_value() && view.stride.empty()` and `layout in {ND, DN}` |
 | Identity pass-through | `!view.has_value()` (bare tensor) |
 | Identity pass-through | `view.has_value() && !view.stride.empty()` (already explicit) |
-| Identity pass-through | `view.layout == NZ` on `TensorType` (verifier rejects this separately) |
+| Reject (`ValueError`) | `view.layout == NZ` on `TensorType` / `DistributedTensorType` (invalid IR — NZ is tile-only) |
 
 ## Example
 
@@ -100,13 +102,15 @@ See `BuildLogicalStridesFromLayout` in [`tensor_view_semantics.h`](../../../../i
 | ------ | ------- |
 | `ND` | `stride[n-1] = 1; stride[k] = stride[k+1] * shape[k+1]` for `k = n-2 .. 0` |
 | `DN` (`n ≥ 2`) | `stride[n-2] = 1`; `stride[n-1] = shape[n-2]`; `stride[n-3] = shape[n-2] * shape[n-1]`; `stride[k] = stride[k+1] * shape[k+1]` for `k = n-4 .. 0` |
-| `NZ` | not representable as flat strides (fractal, tile-only) — `BuildLogicalStridesFromLayout` `CHECK`-fails |
+| `NZ` | not representable as flat strides (fractal, tile-only) — rejected by the pass before `BuildLogicalStridesFromLayout` is reached |
 
 `MakeIndexMul` folds `ConstInt * ConstInt` (with `__builtin_mul_overflow` guard so an overflow falls back to a symbolic `Mul` rather than silently wrapping) and the multiplicative identity, so symbolic dims are preserved as `Mul` expressions while static chains collapse to a single `ConstInt`.
 
 ## Verifier interaction
 
 Because the pass declares `produced = {... ∪ TensorViewCanonical}`, `PassPipeline` automatically runs the registry's `TensorViewCanonical` verifier after the pass. The registry default is the **strict-mode** verifier (RFC #1300 §2.4 codegen-entry contract): it rejects `view.has_value() && stride.empty()` since this pass is responsible for materializing those slots. Bare `TensorType` (`!view.has_value()`) is still accepted — implicit ND-packed is canonical by construction. The same verifier is callable directly via `passes.verify_tensor_view_canonical(program, require_materialized=True)`; pass `require_materialized=False` for the weak mode used during the parse-time / early-pass window before materialization runs.
+
+The verifier is a paired check, not the sole enforcement point. Verification is configurable (`PYPTO_VERIFY_LEVEL` / `PassContext`) and may be off, so every invariant the pass claims to produce is established by the pass itself — the NZ rejection above included. The verifier then re-checks it, catching regressions in this pass and in anything downstream that rewrites tensor types.
 
 ## Related
 

--- a/docs/zh/dev/passes/30-materialize_tensor_strides.md
+++ b/docs/zh/dev/passes/30-materialize_tensor_strides.md
@@ -49,11 +49,13 @@ Pass 使用带 Var 替换缓存的 `IRMutator`，结构与 `InferTileMemorySpace
      - `VisitExpr_(CallPtr)`：注册 op 走 `OpRegistry` 重建；`GlobalVar` 调用 / 未注册 op 走直接 `Call` 构造路径。
      - `VisitStmt_(AssignStmtPtr)`：先重建 RHS；若 RHS Call 的返回类型比 LHS Var 当前类型更显式（已物化），同步 LHS Var。
 
-2. **类型重写** —— `MaterializeType(type)`：
-   - `TensorType` / `DistributedTensorType` 满足 `view.has_value() && view.stride.empty() && layout != NZ`：用 `BuildLogicalStridesFromLayout(shape, layout)` 重建，并保留 distributed wrapper 与可选元数据（`memref`、`TensorView.pad`、`window_buffer`）。其他 tensor 形态原样返回（保持指针身份）。
-   - `TensorType` 且 `layout == NZ`：原样返回（NZ 在 `TensorType` 上属于非法 IR；交由 verifier 报错而非在这里 `BuildLogicalStridesFromLayout` `CHECK`-fail）。
-   - `TupleType`：递归处理元素类型；任一子类型变化时重建。
+2. **类型重写** —— `MaterializeType(type, span)`：
+   - `TensorType` / `DistributedTensorType` 且 `layout == NZ`：无论 stride 是否显式，一律用 `CHECK_SPAN` **拒绝**（用户可见的 `ValueError`）。NZ 是分形、仅 tile 使用的 layout，无法用 logical stride 表达，因此携带它的 tensor 类型属于非法 IR —— `tensor.view`、`CheckCanonicalView` 与 `TensorViewCanonical` verifier 的判定与此一致。`span` 参数（携带该类型的 `Var` / `IterArg` / `Call` / `Submit` / 形参 / 函数节点）用于在报错信息中定位出问题的标注。
+   - `TensorType` / `DistributedTensorType` 满足 `view.has_value() && view.stride.empty()`：用 `BuildLogicalStridesFromLayout(shape, layout)` 重建，并保留 distributed wrapper 与可选元数据（`memref`、`TensorView.pad`、`window_buffer`）。其他 tensor 形态原样返回（保持指针身份）。
+   - `TupleType`：递归处理元素类型（沿用同一个 `span`）；任一子类型变化时重建。
    - 其它：原样返回。
+
+NZ 的拒绝逻辑放在 pass 内部，而不是交给配对的 verifier。交给 verifier 会让这条拒绝取决于验证是否开启：在 `PYPTO_VERIFY_LEVEL=none` 下，pass 会原样返回这个非法槽位，却仍然声明产出 `TensorViewCanonical`，非法 layout 只会在下游以晦涩的后端 layout mismatch 形式重新冒出来。
 
 Pass **幂等** —— 在已物化的 IR 上重跑等于无操作（类型比较走指针身份就短路；无变化时 `MutableCopy` 也被跳过）。
 
@@ -62,7 +64,7 @@ Pass **幂等** —— 在已物化的 IR 上重跑等于无操作（类型比�
 | 用 packed canonical 填入 stride | `view.has_value() && view.stride.empty()` 且 `layout in {ND, DN}` |
 | 原样直通 | `!view.has_value()`（裸 tensor） |
 | 原样直通 | `view.has_value() && !view.stride.empty()`（已显式） |
-| 原样直通 | `view.layout == NZ`（由 verifier 单独拒绝） |
+| 拒绝（`ValueError`） | `TensorType` / `DistributedTensorType` 上 `view.layout == NZ`（非法 IR —— NZ 仅 tile 使用） |
 
 ## 示例
 
@@ -100,13 +102,15 @@ ND 情况下公式退化为标准行主序 packed stride。
 | ------ | ---- |
 | `ND` | `stride[n-1] = 1; stride[k] = stride[k+1] * shape[k+1]`，`k = n-2 .. 0` |
 | `DN`（`n ≥ 2`） | `stride[n-2] = 1`；`stride[n-1] = shape[n-2]`；`stride[n-3] = shape[n-2] * shape[n-1]`；`stride[k] = stride[k+1] * shape[k+1]`，`k = n-4 .. 0` |
-| `NZ` | 无法用 flat stride 表达（分形，仅 tile 使用）—— `BuildLogicalStridesFromLayout` `CHECK`-fail |
+| `NZ` | 无法用 flat stride 表达（分形，仅 tile 使用）—— 在到达 `BuildLogicalStridesFromLayout` 之前就被本 Pass 拒绝 |
 
 `MakeIndexMul` 对 `ConstInt * ConstInt` 做常量折叠（带 `__builtin_mul_overflow` 守卫，溢出时回退到符号 `Mul` 而不是静默 wrap），并消除 `× 1` 单位元；这样符号维保留为 `Mul` 表达式，静态常量链折叠为单个 `ConstInt`。
 
 ## 与 verifier 的协同
 
 由于 Pass 声明 `produced = {... ∪ TensorViewCanonical}`，`PassPipeline` 在 Pass 完成后自动调用 registry 中的 `TensorViewCanonical` verifier。registry 默认是**严格模式** verifier（RFC #1300 §2.4 codegen 入口契约）：它拒绝 `view.has_value() && stride.empty()` —— 因为本 Pass 就是负责物化这些 stride 的。裸 `TensorType`（`!view.has_value()`）仍然接受 —— 隐式 ND-packed 自然 canonical。同一 verifier 也可通过 `passes.verify_tensor_view_canonical(program, require_materialized=True)` 显式调用；传 `require_materialized=False` 切换到弱模式（用于物化之前的解析期 / 前期 pass 窗口）。
+
+verifier 是配对复核，而不是唯一的强制点。验证本身可配置（`PYPTO_VERIFY_LEVEL` / `PassContext`），随时可能关闭，因此 Pass 声明产出的每条不变量都由 Pass 自己建立 —— 上面的 NZ 拒绝也在其中。verifier 随后再复核一遍，用于捕捉本 Pass 以及下游任何改写 tensor 类型的代码引入的回归。
 
 ## 相关
 

--- a/docs/zh/dev/passes/30-materialize_tensor_strides.md
+++ b/docs/zh/dev/passes/30-materialize_tensor_strides.md
@@ -63,8 +63,10 @@ Pass **幂等** —— 在已物化的 IR 上重跑等于无操作（类型比�
 | ---- | -------- |
 | 用 packed canonical 填入 stride | `view.has_value() && view.stride.empty()` 且 `layout in {ND, DN}` |
 | 原样直通 | `!view.has_value()`（裸 tensor） |
-| 原样直通 | `view.has_value() && !view.stride.empty()`（已显式） |
-| 拒绝（`ValueError`） | `TensorType` / `DistributedTensorType` 上 `view.layout == NZ`（非法 IR —— NZ 仅 tile 使用） |
+| 原样直通 | `view.has_value() && !view.stride.empty()` 且 `layout in {ND, DN}`（已显式） |
+| 拒绝（`ValueError`） | `TensorType` / `DistributedTensorType` 上 `view.layout == NZ`，无论 stride 是否显式（非法 IR —— NZ 仅 tile 使用） |
+
+各行互斥：NZ 检查先执行，因此显式 stride 的 NZ view 会被拒绝，而不是原样直通。
 
 ## 示例
 

--- a/src/ir/transforms/materialize_tensor_strides_pass.cpp
+++ b/src/ir/transforms/materialize_tensor_strides_pass.cpp
@@ -37,12 +37,13 @@
 #include <utility>
 #include <vector>
 
-#include "pypto/core/logging.h"  // INTERNAL_CHECK; transitively pulls in error.h
+#include "pypto/core/logging.h"  // CHECK_SPAN / INTERNAL_CHECK; transitively pulls in error.h
 #include "pypto/ir/expr.h"
 #include "pypto/ir/function.h"
 #include "pypto/ir/kind_traits.h"
 #include "pypto/ir/op_registry.h"
 #include "pypto/ir/program.h"
+#include "pypto/ir/span.h"
 #include "pypto/ir/stmt.h"
 #include "pypto/ir/transforms/base/mutator.h"
 #include "pypto/ir/transforms/pass_properties.h"
@@ -56,13 +57,38 @@ namespace ir {
 
 namespace {
 
+/// Reject an NZ view carried by a tensor-like type.
+///
+/// NZ is a fractal, tile-only layout with no logical-stride representation, so
+/// a TensorType / DistributedTensorType carrying it is invalid IR — the same
+/// judgement ``tensor.view``, ``CheckCanonicalView`` and the
+/// ``TensorViewCanonical`` verifier all make. Rejecting it here rather than
+/// passing it through keeps the pass honest about the ``TensorViewCanonical``
+/// property it declares as produced: delegating the rejection to the verifier
+/// means the malformed slot survives whenever verification is disabled
+/// (``PYPTO_VERIFY_LEVEL=none``), only to resurface much later as an opaque
+/// backend layout mismatch.
+///
+/// This is a user error, not a pass invariant: nothing in the pipeline mints
+/// an NZ TensorType, but a ``pl.Tensor[..., pl.NZ]`` annotation survives
+/// parsing, so the message names the authoring fix.
+void CheckNoNzOnTensorType(const TensorView& view, const Span& span) {
+  CHECK_SPAN(view.layout != TensorLayout::NZ, span)
+      << "MaterializeTensorStrides: NZ layout is tile-only and not allowed on a tensor type. "
+      << "Annotate the tensor as pl.ND or pl.DN, and produce NZ on a Tile instead.";
+}
+
 /// Rewrite a TensorType (or recursively a TupleType containing TensorTypes)
 /// so that any ``view.has_value() && view.stride.empty()`` slot is filled
 /// with a packed canonical stride per ``BuildLogicalStridesFromLayout``.
 ///
 /// Returns the input TypePtr unchanged when no rewrite is needed (so callers
 /// can identity-compare to skip downstream Var/Call rebuilds).
-TypePtr MaterializeType(const TypePtr& type) {
+///
+/// ``span`` locates the IR node carrying the type (Var / IterArg / Call /
+/// Submit / function param / function return) and is only read when the type
+/// is rejected.
+TypePtr MaterializeType(const TypePtr& type, const Span& span) {
   if (!type) return type;
 
   if (auto dist_type = As<DistributedTensorType>(type)) {
@@ -70,10 +96,10 @@ TypePtr MaterializeType(const TypePtr& type) {
       return type;
     }
     const TensorView& view = *dist_type->tensor_view_;
+    // Checked before the stride short-circuit below, mirroring the verifier's
+    // ordering: an NZ view is invalid whether or not its stride is explicit.
+    CheckNoNzOnTensorType(view, span);
     if (!view.stride.empty()) {
-      return type;
-    }
-    if (view.layout == TensorLayout::NZ) {
       return type;
     }
     auto materialized_stride =
@@ -90,13 +116,9 @@ TypePtr MaterializeType(const TypePtr& type) {
       return type;
     }
     const TensorView& view = *tensor_type->tensor_view_;
+    CheckNoNzOnTensorType(view, span);
     if (!view.stride.empty()) {
       // Already explicit.
-      return type;
-    }
-    if (view.layout == TensorLayout::NZ) {
-      // NZ on TensorType is rejected by the verifier; do not attempt to
-      // materialize because BuildLogicalStridesFromLayout would CHECK-fail.
       return type;
     }
     auto materialized_stride =
@@ -111,7 +133,7 @@ TypePtr MaterializeType(const TypePtr& type) {
     new_elems.reserve(tuple_type->types_.size());
     bool changed = false;
     for (const auto& sub : tuple_type->types_) {
-      auto new_sub = MaterializeType(sub);
+      auto new_sub = MaterializeType(sub, span);
       if (new_sub.get() != sub.get()) changed = true;
       new_elems.push_back(std::move(new_sub));
     }
@@ -139,7 +161,7 @@ class MaterializeTensorStridesMutator : public IRMutator {
     if (it != var_cache_.end()) {
       return it->second;
     }
-    auto new_type = MaterializeType(op->GetType());
+    auto new_type = MaterializeType(op->GetType(), op->span_);
     if (new_type.get() == op->GetType().get()) {
       var_cache_[op] = op;
       return op;
@@ -155,7 +177,7 @@ class MaterializeTensorStridesMutator : public IRMutator {
       return it->second;
     }
     auto new_init = IRMutator::VisitExpr(op->initValue_);
-    auto new_type = MaterializeType(op->GetType());
+    auto new_type = MaterializeType(op->GetType(), op->span_);
     bool init_changed = new_init.get() != op->initValue_.get();
     bool type_changed = new_type.get() != op->GetType().get();
     if (!init_changed && !type_changed) {
@@ -181,7 +203,7 @@ class MaterializeTensorStridesMutator : public IRMutator {
       new_args.push_back(std::move(new_arg));
     }
 
-    auto new_return_type = MaterializeType(op->GetType());
+    auto new_return_type = MaterializeType(op->GetType(), op->span_);
     bool type_changed = new_return_type.get() != op->GetType().get();
 
     // ``manual_dep_edges`` / ``compiler_manual_dep_edges`` carry VarPtrs that
@@ -257,7 +279,7 @@ class MaterializeTensorStridesMutator : public IRMutator {
     auto base = IRMutator::VisitExpr_(op);
     auto submit = As<Submit>(base);
     if (!submit) return base;
-    auto new_return_type = MaterializeType(submit->GetType());
+    auto new_return_type = MaterializeType(submit->GetType(), submit->span_);
     if (new_return_type.get() == submit->GetType().get()) return submit;
     // MaterializeType recurses the TupleType, materializing each leading
     // return TensorType and leaving the trailing Scalar[TASK_ID] untouched.
@@ -315,7 +337,7 @@ FunctionPtr TransformFunction(const FunctionPtr& func) {
   new_params.reserve(func->params_.size());
   std::unordered_map<VarPtr, VarPtr> param_substitutions;
   for (const auto& old_param : func->params_) {
-    auto new_type = MaterializeType(old_param->GetType());
+    auto new_type = MaterializeType(old_param->GetType(), old_param->span_);
     if (new_type.get() == old_param->GetType().get()) {
       new_params.push_back(old_param);
       continue;
@@ -331,7 +353,7 @@ FunctionPtr TransformFunction(const FunctionPtr& func) {
   std::vector<TypePtr> new_return_types;
   new_return_types.reserve(func->return_types_.size());
   for (const auto& rt : func->return_types_) {
-    auto new_rt = MaterializeType(rt);
+    auto new_rt = MaterializeType(rt, func->span_);
     if (new_rt.get() != rt.get()) returns_changed = true;
     new_return_types.push_back(std::move(new_rt));
   }

--- a/tests/ut/ir/transforms/test_materialize_tensor_strides_pass.py
+++ b/tests/ut/ir/transforms/test_materialize_tensor_strides_pass.py
@@ -24,6 +24,7 @@ Tests follow the Before/Expected ``@pl.program`` pattern: the pass runs on
 ``Before``.
 """
 
+import re
 from collections.abc import Sequence
 from typing import cast
 
@@ -339,8 +340,12 @@ def test_nz_on_tensor_rejected_by_pass():
         ):
             pl.const(0, pl.INT64)
 
-    with pytest.raises(ValueError, match="NZ layout"):
+    with pytest.raises(ValueError, match="NZ layout") as excinfo:
         _materialize(Before)
+    # The pass threads the carrying node's Span into CHECK_SPAN so the message
+    # points at the offending annotation. Assert the location is present, not
+    # just the text — otherwise dropping the span would go unnoticed.
+    assert re.search(r"\[[^]\s]+:\d+:\d+\]", str(excinfo.value)), str(excinfo.value)
 
 
 def test_nz_on_distributed_tensor_rejected_by_pass():

--- a/tests/ut/ir/transforms/test_materialize_tensor_strides_pass.py
+++ b/tests/ut/ir/transforms/test_materialize_tensor_strides_pass.py
@@ -27,7 +27,6 @@ Tests follow the Before/Expected ``@pl.program`` pattern: the pass runs on
 from collections.abc import Sequence
 from typing import cast
 
-import pypto
 import pypto.language as pl
 import pypto.language.distributed as pld
 import pytest
@@ -318,16 +317,19 @@ def test_strided_dn_subview_unchanged():
 
 
 # ============================================================================
-# NZ on TensorType is left untouched (verifier rejects it; pass doesn't crash)
+# NZ on TensorType is rejected by the pass itself
 # ============================================================================
+#
+# NZ is a fractal, tile-only layout with no logical-stride representation, so
+# a TensorType carrying it is invalid IR. The pass rejects it directly instead
+# of leaving the slot untouched for the paired TensorViewCanonical verifier:
+# delegating meant the malformed slot survived silently whenever verification
+# was disabled (``PYPTO_VERIFY_LEVEL=none``), even though the pass declares
+# TensorViewCanonical as produced. The rejection is a CHECK, so it surfaces as
+# a ValueError at every verification level.
 
 
-def test_nz_on_tensor_rejected_by_paired_verifier():
-    # NZ on a TensorType is invalid IR. The pass leaves the slot untouched
-    # rather than CHECK-failing inside BuildLogicalStridesFromLayout — but
-    # because the pass produces TensorViewCanonical, PassPipeline runs the
-    # paired verifier, which surfaces the bug as a thrown VerificationError
-    # (pypto.Error on the Python side).
+def test_nz_on_tensor_rejected_by_pass():
     @pl.program
     class Before:
         @pl.function
@@ -337,11 +339,11 @@ def test_nz_on_tensor_rejected_by_paired_verifier():
         ):
             pl.const(0, pl.INT64)
 
-    with pytest.raises(pypto.Error, match="NZ layout"):
+    with pytest.raises(ValueError, match="NZ layout"):
         _materialize(Before)
 
 
-def test_nz_on_distributed_tensor_rejected_by_paired_verifier():
+def test_nz_on_distributed_tensor_rejected_by_pass():
     @pl.program
     class Before:
         @pl.function
@@ -351,8 +353,42 @@ def test_nz_on_distributed_tensor_rejected_by_paired_verifier():
         ):
             pl.const(0, pl.INT64)
 
-    with pytest.raises(pypto.Error, match="NZ layout"):
+    with pytest.raises(ValueError, match="NZ layout"):
         _materialize(Before)
+
+
+def test_nz_with_explicit_stride_rejected_by_pass():
+    # An explicit stride does not make NZ valid on a TensorType. The check runs
+    # before the "already explicit, nothing to materialize" short-circuit, so
+    # this slot cannot slip through the pass claiming TensorViewCanonical.
+    @pl.program
+    class Before:
+        @pl.function
+        def f(
+            self,
+            x: pl.Tensor[[8, 16], pl.FP32, pl.TensorView(stride=[16, 1], layout=pl.TensorLayout.NZ)],
+        ):
+            pl.const(0, pl.INT64)
+
+    with pytest.raises(ValueError, match="NZ layout"):
+        _materialize(Before)
+
+
+def test_nz_rejected_under_verification_disabled():
+    # Regression guard for the delegation bug: with no VerificationInstrument
+    # installed, nothing but the pass itself can reject the invalid slot.
+    @pl.program
+    class Before:
+        @pl.function
+        def f(
+            self,
+            x: pl.Tensor[[8, 16], pl.FP32, pl.TensorView(stride=[], layout=pl.TensorLayout.NZ)],
+        ):
+            pl.const(0, pl.INT64)
+
+    with _passes.PassContext([], _passes.VerificationLevel.NONE):
+        with pytest.raises(ValueError, match="NZ layout"):
+            _materialize(Before)
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary

`MaterializeTensorStrides` declares `TensorViewCanonical` among its produced
properties, but when it met an NZ `TensorView` on a `TensorType` /
`DistributedTensorType` it returned the malformed slot untouched and left the
rejection to the paired verifier. That made a pass invariant conditional on a
verification setting: with `PYPTO_VERIFY_LEVEL=none` no verifier runs, so the
invalid layout survived the pass silently and only resurfaced downstream as an
opaque ptoas layout mismatch (`user-specified layout=nz but inferred=nd`)
against a line in a generated `.pto` the user never wrote. The pass now rejects
NZ itself, so a `pl.Tensor[..., pl.NZ]` annotation fails at every verification
level with a source-located `ValueError` instead of flowing through.

NZ is a fractal, tile-only layout with no logical-stride representation, so a
tensor type carrying it is invalid IR — the judgement `tensor.view`,
`CheckCanonicalView`, and the `TensorViewCanonical` verifier already share.
Verification is configurable, so every invariant a pass claims to produce
belongs in the pass; the verifier stays as the paired re-check that catches
regressions here and in anything downstream that rewrites tensor types.

## Changes

- `src/ir/transforms/materialize_tensor_strides_pass.cpp`: `MaterializeType`
  rejects an NZ view with `CHECK_SPAN` instead of returning it unchanged, and
  takes a `Span` from the IR node carrying the type (`Var`, `IterArg`, `Call`,
  `Submit`, function param, function return) so the message points at the
  user's annotation. The check runs *before* the "stride already explicit"
  short-circuit, mirroring the verifier's ordering — an NZ view is invalid
  whether or not its stride is materialised, and letting one through would
  leave the pass claiming a property the IR does not satisfy.
- `tests/ut/ir/transforms/test_materialize_tensor_strides_pass.py`: the two
  `..._rejected_by_paired_verifier` tests become `..._rejected_by_pass` and
  expect `ValueError` rather than `pypto.Error`, since a `CHECK` surfaces as a
  builtin `ValueError`. Two cases are added: an NZ view with explicit stride,
  and an explicit `VerificationLevel.NONE` context that guards against the
  delegation regressing. The first test also asserts a source-location token in
  the diagnostic, so the `Span` reaching `CHECK_SPAN` is covered rather than
  only the message text.
- `docs/en/dev/passes/30-materialize_tensor_strides.md`,
  `docs/zh/dev/passes/30-materialize_tensor_strides.md`: a rejection row
  replaces the NZ pass-through row, the explicit-stride pass-through row is
  qualified with `layout in {ND, DN}` so the rows are mutually exclusive, and a
  note records that the verifier is a paired re-check rather than the sole
  enforcement point.

### Behavior change

A `pl.Tensor[..., pl.NZ]` (or `pld.DistributedTensor[..., pl.NZ]`) annotation
that reached this pass previously continued and failed later in ptoas; it now
fails in the pass:

```text
MaterializeTensorStrides: NZ layout is tile-only and not allowed on a tensor
type. Annotate the tensor as pl.ND or pl.DN, and produce NZ on a Tile instead.
[<string>:8:17]
```

Under the default `PYPTO_VERIFY_LEVEL=roundtrip` this IR was already rejected
by the verifier, so the change is the error's origin, span, and wording rather
than whether valid programs compile.

### Deliberately out of scope

The annotation still survives parsing. Rejecting NZ at the type resolver would
be the earliest fix, but it changes behavior pinned by the JIT specializer,
type-resolver, and MemRef parsing suites, and `tests/ut/jit/` documents the
carry-through as intentional parity — dropping the layout is what silently
produced an ND buffer from an NZ annotation. That remains a separate design
decision.

## Verification

- `cmake --build build --parallel 2`: exit 0
- `pytest tests/ut/`: exit 0 — 9640 passed, 3 skipped
- `pytest tests/ut/ir/transforms/test_materialize_tensor_strides_pass.py` at
  `PYPTO_VERIFY_LEVEL` `none`, `basic`, `roundtrip`: exit 0 — 20 passed each.
  Before this change the two renamed tests failed under `none` with
  `Failed: DID NOT RAISE <class 'pypto.Error'>`.
- `tests/lint/clang_tidy.py --diff-base HEAD`: exit 0 on the changed
  translation unit
- `tests/lint/check_docs_en_zh_parity.py`, `check_no_broad_raises.py`,
  `check_english_only.py`, `check_headers.py`, `check_op_name_literals.py`,
  `check_docs_nav.py`: exit 0