### PR TITLE
fix(codegen): dispatch dual_aiv_dispatch AIV kernels on both vector lanes

### DIFF
--- a/docs/en/dev/codegen/01-orchestration_codegen.md
+++ b/docs/en/dev/codegen/01-orchestration_codegen.md
@@ -222,6 +222,22 @@ The codegen determines whether to submit to AIC (CUBE) or AIV (VECTOR) based on 
 | `Left`, `Right`, `Acc`, `Mat` | CUBE (AIC) | `rt_submit_aic_task` |
 | `Vec` (default) | VECTOR (AIV) | `rt_submit_aiv_task` |
 
+**Exception — dual-AIV kernels.** An AIV kernel stamped `dual_aiv_dispatch` (any
+`split_aiv` kernel; see [`SplitVectorKernel`](../passes/23-split_vector_kernel.md))
+must run on **both** vector lanes of a cluster — a `pl.split_aiv` region hands each
+lane disjoint work selected by `aiv_id`. `rt_submit_aiv_task` fills only the AIV0
+slot, so the runtime schedules an *AIV-shape* task — one AIV core per block: the second
+lane never launches, and the lone lane that does reads a `get_sub_block_id()` that the
+runtime documents as **meaningless** for a single-AIV task. The scheduler seeds that value
+per core from the core's fixed position in its cluster, so `aiv_id` becomes that position
+rather than a per-block lane id. Such a kernel is therefore submitted as a two-lane
+`MixedKernels` + `rt_submit_task` instead (see [Group Functions (Mixed Kernels)](#group-functions-mixed-kernels)),
+whatever the dispatch path (direct call, `Spmd` wrapper, or AIV-only `Group`). Two active
+AIV slots make it a MIX-shape task, so the scheduler places both lanes of one cluster under
+the same `block_idx` and gives them `sub_block_id` 0 and 1; the cluster's AIC core is simply
+unused. A plain (non-`dual_aiv_dispatch`) vector kernel keeps `rt_submit_aiv_task`, which
+dispatches across independent AIV cores.
+
 ### Tuple Handling
 
 Tuple-returning calls use unique keys (`_tc_N`) to track elements:
@@ -253,6 +269,16 @@ Arg params_t0;
 MixedKernels mixed_0 = {aic_id, aiv_id, INVALID_KERNEL_ID};
 rt_submit_task(mixed_0, params_t0);
 ```
+
+The three slots are `{aic_kernel_id, aiv0_kernel_id, aiv1_kernel_id}`; `INVALID_KERNEL_ID`
+marks a slot inactive. The AIV1 slot repeats the AIV kernel id when the AIV function
+carries `dual_aiv_dispatch` — so both vector lanes run:
+
+| Kernel | `MixedKernels` |
+| ------ | -------------- |
+| Mixed, single AIV lane | `{aic_id, aiv_id, INVALID_KERNEL_ID}` |
+| Mixed, `dual_aiv_dispatch` | `{aic_id, aiv_id, aiv_id}` |
+| Vector-only, `dual_aiv_dispatch` | `{INVALID_KERNEL_ID, aiv_id, aiv_id}` |
 
 ## Operation Mappings
 

--- a/docs/zh/dev/codegen/01-orchestration_codegen.md
+++ b/docs/zh/dev/codegen/01-orchestration_codegen.md
@@ -215,6 +215,20 @@ IR 层，只服务于在该属性建立**之前**运行的那些 pass。
 | `Left`、`Right`、`Acc`、`Mat` | CUBE (AIC) | `rt_submit_aic_task` |
 | `Vec`（默认） | VECTOR (AIV) | `rt_submit_aiv_task` |
 
+**例外 —— 双 AIV 核函数。** 带 `dual_aiv_dispatch` 标记的 AIV 核函数（即任何 `split_aiv`
+核函数，参见 [`SplitVectorKernel`](../passes/23-split_vector_kernel.md)）必须在一个 cluster 的
+**两个**向量核上同时运行 —— `pl.split_aiv` 区域通过 `aiv_id` 给每条 lane 分派互不相交的工作。
+而 `rt_submit_aiv_task` 只填 AIV0 槽位，运行时会把它调度为 *AIV 形状*的任务 —— 每个 block 一个
+AIV 核：第二条 lane 根本不会启动，而唯一启动的那条读到的 `get_sub_block_id()`，运行时明确说明在
+单 AIV 任务下**没有意义**。该值由调度器按每个核在其 cluster 中的固定位置写入，因此 `aiv_id` 拿到的
+是这个物理位置，而不是逐 block 的 lane 编号。
+因此这类核函数一律改用双 lane 的 `MixedKernels` + `rt_submit_task` 提交（参见
+[Group 函数（混合核）](#group-函数混合核)），无论走哪条分派路径（直接调用、`Spmd` 包装器，
+还是纯 AIV 的 `Group`）。两个激活的 AIV 槽位使其成为 MIX 形状的任务，于是调度器把同一个 cluster
+的两条 lane 放在相同的 `block_idx` 下，并分别赋予 `sub_block_id` 0 和 1；该 cluster 的 AIC 核心
+闲置不用。普通（不带 `dual_aiv_dispatch`）的向量核函数仍走 `rt_submit_aiv_task`，在相互独立的
+AIV 核心上分派。
+
 ### 元组处理
 
 元组返回的调用使用唯一键（`_tc_N`）追踪元素：
@@ -246,6 +260,16 @@ Arg params_t0;
 MixedKernels mixed_0 = {aic_id, aiv_id, INVALID_KERNEL_ID};
 rt_submit_task(mixed_0, params_t0);
 ```
+
+三个槽位依次是 `{aic_kernel_id, aiv0_kernel_id, aiv1_kernel_id}`，`INVALID_KERNEL_ID` 表示该槽位
+未激活。当 AIV 函数带有 `dual_aiv_dispatch` 时，AIV1 槽位重复填入同一个 AIV kernel id —— 于是两条
+向量 lane 都会运行：
+
+| 核函数 | `MixedKernels` |
+| ------ | -------------- |
+| 混合核，单条 AIV lane | `{aic_id, aiv_id, INVALID_KERNEL_ID}` |
+| 混合核，`dual_aiv_dispatch` | `{aic_id, aiv_id, aiv_id}` |
+| 纯向量核，`dual_aiv_dispatch` | `{INVALID_KERNEL_ID, aiv_id, aiv_id}` |
 
 ## 操作映射
 

--- a/include/pypto/codegen/orchestration/orchestration_codegen.h
+++ b/include/pypto/codegen/orchestration/orchestration_codegen.h
@@ -54,7 +54,9 @@ struct OrchestrationResult {
  * - aicpu_orchestration_entry(const L2TaskArgs& orch_args)
  * - orch_args.tensor(i).ref() for ND external tensors, make_tensor for internal tensors
  * - PTOParam + rt_submit_*_task for task submission (rt_submit_aic_task /
- *   rt_submit_aiv_task for single-core kernels; rt_submit_task for mixed kernels)
+ *   rt_submit_aiv_task for single-core kernels; rt_submit_task for mixed kernels
+ *   and for a single AIV kernel stamped `dual_aiv_dispatch`, which must occupy
+ *   both vector lanes of one cluster)
  * - No manual dependency management (runtime handles automatically)
  *
  * @param program The IR Program (used to resolve callee functions and validate references)

--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -2741,46 +2741,84 @@ class OrchestrationStmtCodegen : public CodegenBase {
     return plan;
   }
 
+  /// A submit expression plus the lines that must precede it (emitted by
+  /// ``TaskDispatchPlan::Emit`` between the ``add_*`` params and the launch spec).
+  struct SubmitEmission {
+    std::string expr;
+    std::vector<std::string> pre_lines;
+  };
+
+  /// Build the submit for a task that dispatches ONE kernel function — a direct
+  /// call, a Spmd wrapper, or an AIV-only Group.
+  ///
+  /// An AIV kernel stamped `dual_aiv_dispatch` must run on BOTH vector lanes of a
+  /// cluster: a `pl.split_aiv` region hands each lane disjoint work selected by
+  /// `aiv_id`. `rt_submit_aiv_task` fills only the AIV0 slot, so the mask carries one
+  /// core bit and the runtime schedules an AIV-shape task: one AIV core per block.
+  /// The second lane never launches, and the lone lane that does reads a
+  /// `get_sub_block_id()` the runtime documents as meaningless for a single-AIV task
+  /// (runtime `common/intrinsic.h`) — the scheduler seeds it per core from that core's
+  /// fixed position in its cluster, so `aiv_id` is that position rather than a
+  /// per-block lane id. Half the work is then silently dropped (issue #2006).
+  ///
+  /// Emit an explicit `MixedKernels{INVALID, id, id}` instead: two active AIV slots
+  /// make it a MIX-shape task, so the scheduler places both lanes of one cluster
+  /// under the same block_idx and gives them sub_block_id 0 and 1. The cluster's AIC
+  /// core is simply unused. Non-dual-AIV kernels keep `rt_submit_{aic,aiv}_task`,
+  /// which dispatches across independent cores.
+  SubmitEmission BuildSingleKernelSubmit(CoreType core_type, const FunctionPtr& kernel_func, int func_id,
+                                         const std::string& task_var) {
+    if (core_type == CoreType::VECTOR && RequiresDualAivDispatch(kernel_func)) {
+      const std::string mixed_var = "mixed_" + std::to_string(task_counter_);
+      const std::string id = std::to_string(func_id);
+      return {"rt_submit_task(" + mixed_var + ", " + task_var + ")",
+              {"MixedKernels " + mixed_var + " = {INVALID_KERNEL_ID, " + id + ", " + id + "};"}};
+    }
+    return {CoreTypeToSubmitPrefix(core_type) + std::to_string(func_id) + ", " + task_var + ")", {}};
+  }
+
   TaskDispatchPlan BuildDirectCallDispatchPlan(const CallPtr& call, const FunctionPtr& callee_func,
                                                const std::string& callee_name, CoreType core_type,
                                                int func_id, std::vector<ParamEntry>&& params,
                                                bool capture_plain_task_id) {
     std::string task_var = CurrentTaskVarName();
-    std::string submit_expr =
-        CoreTypeToSubmitPrefix(core_type) + std::to_string(func_id) + ", " + task_var + ")";
+    auto submit = BuildSingleKernelSubmit(core_type, callee_func, func_id, task_var);
     auto [launch_core_num, launch_sync_start] = EffectiveLaunchSpec(call, callee_func);
-    TaskDispatchPlan plan =
-        BuildTaskDispatchPlan("// Task " + std::to_string(task_counter_) + ": " + callee_name, call,
-                              std::move(params), launch_core_num, launch_sync_start, submit_expr,
-                              ShouldCaptureTaskOutputs(call, capture_plain_task_id));
+    TaskDispatchPlan plan = BuildTaskDispatchPlan(
+        "// Task " + std::to_string(task_counter_) + ": " + callee_name, call, std::move(params),
+        launch_core_num, launch_sync_start, submit.expr,
+        ShouldCaptureTaskOutputs(call, capture_plain_task_id), std::move(submit.pre_lines));
     // Direct calls historically emit set_dependencies before the launch spec.
     plan.deps_before_launch = true;
     return plan;
   }
 
+  /// ``kernel_func`` is the AIC/AIV kernel the wrapper dispatches (``spmd_func`` is
+  /// the Spmd wrapper itself, which carries the launch spec but no core attrs).
   TaskDispatchPlan BuildSpmdCallDispatchPlan(const CallPtr& call, const FunctionPtr& spmd_func,
-                                             const std::string& callee_name, CoreType core_type, int func_id,
+                                             const FunctionPtr& kernel_func, const std::string& callee_name,
+                                             CoreType core_type, int func_id,
                                              std::vector<ParamEntry>&& params, bool capture_plain_task_id) {
     std::string task_var = CurrentTaskVarName();
     auto [launch_core_num, launch_sync_start] = EffectiveLaunchSpec(call, spmd_func);
-    std::string submit_expr =
-        CoreTypeToSubmitPrefix(core_type) + std::to_string(func_id) + ", " + task_var + ")";
+    auto submit = BuildSingleKernelSubmit(core_type, kernel_func, func_id, task_var);
     return BuildTaskDispatchPlan("// Spmd " + spmd_func->name_ + ": " + callee_name, call, std::move(params),
-                                 launch_core_num, launch_sync_start, submit_expr,
-                                 ShouldCaptureTaskOutputs(call, capture_plain_task_id));
+                                 launch_core_num, launch_sync_start, submit.expr,
+                                 ShouldCaptureTaskOutputs(call, capture_plain_task_id),
+                                 std::move(submit.pre_lines));
   }
 
   TaskDispatchPlan BuildAivOnlyGroupDispatchPlan(const CallPtr& call, const FunctionPtr& launch_func,
-                                                 const std::string& group_name, int aiv_id,
-                                                 std::vector<ParamEntry>&& params,
+                                                 const std::string& group_name, const FunctionPtr& aiv_func,
+                                                 int aiv_id, std::vector<ParamEntry>&& params,
                                                  bool capture_plain_task_id) {
     std::string task_var = CurrentTaskVarName();
     auto [launch_core_num, launch_sync_start] = EffectiveLaunchSpec(call, launch_func);
-    std::string submit_expr =
-        CoreTypeToSubmitPrefix(CoreType::VECTOR) + std::to_string(aiv_id) + ", " + task_var + ")";
+    auto submit = BuildSingleKernelSubmit(CoreType::VECTOR, aiv_func, aiv_id, task_var);
     return BuildTaskDispatchPlan("// Group " + group_name + ": AIV-only SPMD", call, std::move(params),
-                                 launch_core_num, launch_sync_start, submit_expr,
-                                 ShouldCaptureTaskOutputs(call, capture_plain_task_id));
+                                 launch_core_num, launch_sync_start, submit.expr,
+                                 ShouldCaptureTaskOutputs(call, capture_plain_task_id),
+                                 std::move(submit.pre_lines));
   }
 
   TaskDispatchPlan BuildMixedGroupDispatchPlan(const CallPtr& call, const FunctionPtr& launch_func,
@@ -3226,8 +3264,8 @@ class OrchestrationStmtCodegen : public CodegenBase {
     auto params = BuildWrapperReorderedParams(call, spmd_func, info.inner_call);
     RecordKernelSignature(callee_name, params);
 
-    BuildSpmdCallDispatchPlan(call, spmd_func, callee_name, core_type, func_id, std::move(params),
-                              capture_plain_task_id)
+    BuildSpmdCallDispatchPlan(call, spmd_func, info.inner_callee, callee_name, core_type, func_id,
+                              std::move(params), capture_plain_task_id)
         .Emit(*this);
   }
 
@@ -3238,10 +3276,10 @@ class OrchestrationStmtCodegen : public CodegenBase {
 
     auto info = FindGroupCallees(group_func);
 
-    // AIV-only Group: pure vector SPMD kernel (no AIC callee).
-    // Dispatch as a single AIV task with core_num/sync_start from the Group.
-    // Use rt_submit_aiv_task which dispatches across independent AIV cores,
-    // unlike rt_submit_task (MixedKernels) which dispatches full clusters.
+    // AIV-only Group: pure vector SPMD kernel (no AIC callee), dispatched with
+    // core_num/sync_start from the Group. BuildSingleKernelSubmit picks the
+    // submit: rt_submit_aiv_task (independent AIV cores) for a plain kernel, or a
+    // both-lanes MixedKernels for a `dual_aiv_dispatch` one.
     if (info.aic_name.empty() && !info.aiv_name.empty()) {
       FunctionPtr aiv_func = program_->GetFunction(info.aiv_name);
       INTERNAL_CHECK(aiv_func != nullptr) << "Internal error: AIV function '" << info.aiv_name
@@ -3256,7 +3294,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
       auto params = BuildWrapperReorderedParams(call, group_func, info.inner_call, bridge);
       RecordKernelSignature(info.aiv_name, params);
 
-      BuildAivOnlyGroupDispatchPlan(call, launch_func, group_name, aiv_id, std::move(params),
+      BuildAivOnlyGroupDispatchPlan(call, launch_func, group_name, aiv_func, aiv_id, std::move(params),
                                     capture_plain_task_id)
           .Emit(*this);
       return;

--- a/tests/st/codegen/dsl/test_split_aiv_none_codegen.py
+++ b/tests/st/codegen/dsl/test_split_aiv_none_codegen.py
@@ -11,14 +11,19 @@
 region nested inside a ``pl.pipeline`` loop.
 
 A NONE region keeps its tiles full-width (no halving) and dispatches both AIV
-lanes via ``aiv_id``. This test compiles such a kernel all the way through PTO
-codegen (``RunConfig(codegen_only=True)``, no device) and asserts a ``.pto`` is
-emitted — guarding both that the lowering survives to codegen and that the nested
-region + in-region vector MemRef (the pipeline accumulator) is registered for
-MLIR emission (a regression that previously crashed ``pto_codegen`` with
-"no MLIR mapping for MemRef").
+lanes via ``aiv_id``. These tests compile such a kernel all the way through PTO
+codegen (``RunConfig(codegen_only=True)``, no device) and assert:
+
+* a ``.pto`` is emitted — guarding both that the lowering survives to codegen and
+  that the nested region + in-region vector MemRef (the pipeline accumulator) is
+  registered for MLIR emission (a regression that previously crashed
+  ``pto_codegen`` with "no MLIR mapping for MemRef");
+* the orchestration submit actually launches **both** AIV lanes (issue #2006 — it
+  used to emit a single-AIV ``rt_submit_aiv_task``, silently dropping one lane's
+  share of the output).
 """
 
+import re
 import shutil
 from pathlib import Path
 
@@ -51,8 +56,15 @@ def split_aiv_none_pipe(
     return c
 
 
-def test_none_region_in_pipeline_compiles_to_pto():
-    """The nested NONE region compiles through PTO codegen and emits a .pto."""
+@pytest.fixture(scope="module")
+def compiled() -> Exception | None:
+    """Compile the kernel once (codegen only) into DUMP_DIR; return any late error.
+
+    PTO codegen writes its artifacts before the downstream kernel-compilation step
+    (simpler_setup), which is absent in the codegen-only CI env. Capture any such
+    post-codegen failure — the guards below are on the emitted files, which
+    materialize first.
+    """
     if DUMP_DIR.exists():
         shutil.rmtree(DUMP_DIR)
 
@@ -62,21 +74,54 @@ def test_none_region_in_pipeline_compiles_to_pto():
         save_kernels=True,
         save_kernels_dir=str(DUMP_DIR),
     )
-    # PTO codegen writes the .pto before the downstream kernel-compilation step
-    # (simpler_setup), which is absent in the codegen-only CI env. Capture any
-    # such post-codegen failure — the guard below is on the emitted .pto, which
-    # materializes first.
-    compile_error: Exception | None = None
     try:
         split_aiv_none_pipe(torch.randn(T, N), torch.empty(T, N), config=cfg)
-    except Exception as e:  # noqa: BLE001 - see comment above
-        compile_error = e
+    except Exception as e:  # noqa: BLE001 - see docstring
+        return e
+    return None
 
+
+def test_none_region_in_pipeline_compiles_to_pto(compiled):
+    """The nested NONE region compiles through PTO codegen and emits a .pto."""
     ptos = sorted(DUMP_DIR.rglob("*.pto"))
     assert ptos, (
         f"codegen emitted no .pto under {DUMP_DIR} for a NONE split_aiv region; "
-        f"compile raised before .pto materialized: {compile_error!r}"
+        f"compile raised before .pto materialized: {compiled!r}"
     )
+
+
+def test_none_region_dispatches_both_aiv_lanes(compiled):
+    """The orchestration must launch the kernel on BOTH AIV lanes.
+
+    A NONE region is task-parallel: each lane runs the full body on the disjoint
+    half selected by ``aiv_id``. ``rt_submit_aiv_task`` fills only the AIV0 slot, so
+    the runtime schedules a single-AIV task — the second lane never launches, and
+    the lone lane that does reads a ``get_sub_block_id()`` the runtime leaves
+    undefined for single-AIV tasks. Half the output is then silently never written
+    (issue #2006). The submit must be a two-lane ``MixedKernels`` (AIV0 + AIV1, no
+    AIC), which the runtime schedules as a full cluster with sub_block_id 0 / 1.
+    """
+    orch = sorted(DUMP_DIR.rglob("orchestration/*.cpp"))
+    assert orch, (
+        f"codegen emitted no orchestration .cpp under {DUMP_DIR}; "
+        f"compile raised before it materialized: {compiled!r}"
+    )
+    code = orch[0].read_text()
+
+    mixed = re.search(r"MixedKernels \w+ = \{INVALID_KERNEL_ID, (\d+), \1\};", code)
+    assert mixed, code
+    assert "rt_submit_task(" in code, code
+
+    # The single-AIV submit would run one lane per block and drop the other. Scope the
+    # negative to *this* kernel id: a plain vector kernel in the same orchestration is
+    # entitled to rt_submit_aiv_task (it keeps its independent-AIV parallelism).
+    kernel_id = mixed.group(1)
+    single_aiv_submits = [
+        call
+        for call in re.findall(r"rt_submit_aiv_task\([^;]*\)", code)
+        if re.search(rf"\b{kernel_id}\b", call)
+    ]
+    assert not single_aiv_submits, single_aiv_submits
 
 
 if __name__ == "__main__":

--- a/tests/ut/codegen/test_orchestration_codegen_more.py
+++ b/tests/ut/codegen/test_orchestration_codegen_more.py
@@ -1991,6 +1991,59 @@ class TestOrchestrationMore:
         assert "M" in tmp_shapes.group(1) and "N" in tmp_shapes.group(1), tmp_shapes.group(1)
         assert m_decl.start() < tmp_shapes.start(), code
 
+    def test_dual_aiv_vector_kernel_dispatches_both_lanes(self):
+        """A pure-vector ``pl.split_aiv`` kernel must launch on BOTH AIV lanes.
+
+        A ``split_aiv`` region is task-parallel: each lane runs the full body on
+        disjoint work selected by ``aiv_id``. SplitVectorKernel stamps the kernel
+        ``dual_aiv_dispatch``, and dispatch must honour it.
+
+        ``rt_submit_aiv_task`` fills only the AIV0 slot, so the runtime schedules a
+        single-AIV task: the second lane never launches, and the lone lane that does
+        reads a ``get_sub_block_id()`` that is then its fixed cluster position, not a
+        per-block lane id — silently dropping half the work (issue #2006). The submit
+        must therefore be a two-lane ``MixedKernels`` (AIV0 + AIV1, no AIC), which the
+        runtime schedules as a full cluster with sub_block_id 0 / 1 per lane.
+        """
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        @pl.program
+        class SplitAivNoneProgram:
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                a: pl.Tensor[[128, 64], pl.FP32],
+                out: pl.Out[pl.Tensor[[128, 64], pl.FP32]],
+            ) -> pl.Tensor[[128, 64], pl.FP32]:
+                # 2 blocks x 2 AIV lanes = 4 lanes, each owning a disjoint [32, 64] slice.
+                for blk in pl.spmd(2):
+                    for aiv in pl.split_aiv(2, mode=pl.SplitMode.NONE):
+                        lane = blk * 2 + aiv
+                        t = pl.load(a, [lane * 32, 0], [32, 64])
+                        out = pl.store(pl.add(t, t), [lane * 32, 0], out)
+                return out
+
+        pm = PassManager.get_strategy(OptimizationStrategy.Default)
+        # Narrow the autouse instrument set to property verification: post-outline IR
+        # whose core-function body directly holds a SplitAivScopeStmt does not survive
+        # print -> parse (the reparse synthesizes an InCoreScopeStmt around it). That
+        # gap is in the parser, not in dispatch, so it must not gate this test.
+        with passes.PassContext([passes.VerificationInstrument(passes.VerificationMode.BEFORE_AND_AFTER)]):
+            transformed = pm.run_passes(SplitAivNoneProgram)
+
+        aiv_funcs = [f for f in transformed.functions.values() if f.func_type == ir.FunctionType.AIV]
+        assert len(aiv_funcs) == 1, [f.name for f in transformed.functions.values()]
+        assert aiv_funcs[0].attrs.get("dual_aiv_dispatch") is True, dict(aiv_funcs[0].attrs)
+
+        code = _generate_orch_code(transformed)
+
+        # Both AIV slots carry the kernel id; the AIC slot is inactive.
+        assert "MixedKernels mixed_0 = {INVALID_KERNEL_ID, 0, 0};" in code, code
+        assert "rt_submit_task(mixed_0, params_t0);" in code, code
+        # The single-AIV submit would run one lane per block and drop the other.
+        assert "rt_submit_aiv_task" not in code, code
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
Fixes #2006

A `pl.split_aiv` region is task-parallel: both AIV lanes run the body on disjoint
work selected by `aiv_id`. SplitVectorKernel stamps such an AIV kernel
`dual_aiv_dispatch`, but only the mixed-kernel Group submit honoured it. The three
single-kernel dispatch paths — direct call, Spmd wrapper, and AIV-only Group — all
built their submit through `CoreTypeToSubmitPrefix()`, which unconditionally yields
`rt_submit_aiv_task` for VECTOR.

`rt_submit_aiv_task` fills only the AIV0 slot of MixedKernels, so the active mask
carries one core bit and the runtime schedules an AIV-shape task: one AIV core per
block. The second lane never launches, and the lone lane that does reads a
`get_sub_block_id()` the runtime documents as meaningless for a single-AIV task
(runtime `common/intrinsic.h`); the scheduler seeds that value per core from the
core's fixed position in its cluster, so `aiv_id` is that position rather than a
per-block lane id. Half the work is silently dropped — the destination rows come
back as exact zeros, with no error, no NaN, and a block-parity pattern for which
lane survives. A pure-vector kernel (no cube work) hits this on the Spmd-wrapper path.

Route the three single-kernel paths through a shared `BuildSingleKernelSubmit()`,
which emits `MixedKernels{INVALID_KERNEL_ID, id, id}` + `rt_submit_task` for a
`dual_aiv_dispatch` VECTOR kernel. Two active AIV slots make it a MIX-shape task, so
the scheduler places both lanes of one cluster under the same block_idx and gives them
sub_block_id 0 and 1; the cluster's AIC core is unused. No runtime change is needed.

A plain vector kernel carries no `dual_aiv_dispatch` and keeps `rt_submit_aiv_task`,
so it retains its full independent-AIV parallelism; mixed kernels are untouched.

The existing NONE-region codegen ST compiled this exact shape but only asserted a
.pto was emitted, which is why the defect shipped; it now also asserts the submit
launches both lanes.

Supersedes #2012, which was opened against a month-old main and no longer applies.
Two parts of it are deliberately left out here:

- Its print->parse commit is obsolete. #2298 has since made *absence* the canonical
  encoding of `SplitMode::NONE` at the function-attr level, solving the same problem
  the opposite way.
- Its parser change — treating a core function body as an implicit InCore scope so a
  bare `pl.split_aiv` is emitted in place — is a semantic decision that belongs in its
  own PR. main now pins the opposite behaviour: `test_scope_nested_region_rejected`
  requires a top-level region in an InCore body to be wrapped and then rejected by
  LowerAutoVectorSplit. Without that change, post-outline IR whose core-function body
  directly holds a `SplitAivScopeStmt` still does not survive print -> parse, so the
  new UT narrows its instrument set to property verification (the pattern already used
  by `test_materialize_comm_domain_scopes`). That gap is in the parser, not in dispatch.

Verified on an Ascend 910B (a2a3), runtime 3165cc89 / pto-isa 83d01313 / ptoas v0.57,
with a probe kernel that writes each lane's observed `block_idx` and `block_num`:

  before: 16 of 32 lanes never written — [1, 2, 5, 6, 9, 10, ...] (block-parity)
  after:  32 of 32 lanes written, block_idx == lane // 2 for every lane

and with the issue's reproducer, whose split_aiv arm goes from 64/128 wrong items
(max_err 4.18) to bit-exact. Note that arm must be run first and alone: when the
plain-spmd control arm runs before it in the same process, the reused output device
buffer still holds the control arm's correct rows and the dropped lanes read back
correct, masking the defect entirely.

Testing:
- cmake --build build --parallel
- python -m pytest tests/ut/ (9633 passed, 8 skipped)
- on-board python -m pytest tests/st/runtime/cross_core/ --forked --platform=a2a3
  (49 passed, 3 skipped, 1 xpassed)