### PR TITLE
fix(codegen): clear inherited AI Core atomic mode

### DIFF
--- a/python/pypto/backend/pto_backend.py
+++ b/python/pypto/backend/pto_backend.py
@@ -803,6 +803,10 @@ def _generate_kernel_wrapper(
         'extern "C" __aicore__ __attribute__((always_inline)) '
         "void kernel_entry(__gm__ int64_t* args)\n"
         "{\n"
+        "#if !defined(__CPU_SIM) && !defined(__COSTMODEL)\n"
+        "    // Reset AI Core atomic mode inherited from a prior kernel.\n"
+        "    set_atomic_none();\n"
+        "#endif\n\n"
         f"{runtime_subblock_setup}"
         f"{spmd_args_setup}"
         f"{subblock_arg_setup}"

--- a/tests/ut/codegen/test_pto_codegen.py
+++ b/tests/ut/codegen/test_pto_codegen.py
@@ -1593,6 +1593,22 @@ class TestGenerateKernelWrapper:
         assert "#include <pto/pto-inst.hpp>" in wrapper
         assert '#include "tensor.h"' in wrapper
 
+    def test_clears_atomic_mode_before_argument_unpacking(self):
+        func = _make_func("my_kernel", [("a", "tensor"), ("s", "scalar"), ("out", "tensor")])
+        wrapper = _generate_kernel_wrapper(func, SAMPLE_PTOAS_OUTPUT)
+        entry = wrapper[wrapper.index("void kernel_entry(__gm__ int64_t* args)") :]
+
+        assert "AscendC::" not in wrapper
+        assert "kernel_operator_common_intf.h" not in wrapper
+        assert entry.count("set_atomic_none();") == 1
+        assert (
+            "#if !defined(__CPU_SIM) && !defined(__COSTMODEL)\n"
+            "    // Reset AI Core atomic mode inherited from a prior kernel.\n"
+            "    set_atomic_none();\n"
+            "#endif"
+        ) in entry
+        assert entry.index("set_atomic_none();") < entry.index("// Unpack tensor: a")
+
     def test_contains_forward_call(self):
         func = _make_func("my_kernel", [("a", "tensor"), ("s", "scalar"), ("out", "tensor")])
         wrapper = _generate_kernel_wrapper(func, SAMPLE_PTOAS_OUTPUT)
@@ -1648,7 +1664,7 @@ class TestGenerateKernelWrapper:
 
         wrapper = _generate_kernel_wrapper(func, SAMPLE_PTOAS_OUTPUT)
         assert "PYPTO_FIXED_SUBBLOCK_ID" not in wrapper
-        assert wrapper.count("#if !defined(__CPU_SIM)") == 2
+        assert wrapper.count("#if !defined(__CPU_SIM)\n") == 2
         assert '#if !defined(__CPU_SIM)\n#include "intrinsic.h"' in wrapper
         assert "[[block_local]] static int32_t pypto_runtime_subblock_id;" in wrapper
         assert '#include "intrinsic.h"' in wrapper


### PR DESCRIPTION
ATB _npu_matmul_add_fp32 can leave an AI Core in atomic-add mode. PyPTO wrappers previously entered the PTOAS body without clearing that per-core state, so an ordinary L0C-to-GM store could add into the existing output instead of overwriting it.

Emit the CCEC set_atomic_none() builtin as the first hardware-only operation in kernel_entry, before runtime identity setup and argument unpacking. Keep CPU simulation and cost-model output unchanged, and avoid coupling PyPTO to AscendC headers or SDK include layouts.

Add codegen coverage for the hardware guard, entry ordering, and dependency-free wrapper output.