### PR TITLE
feat(runtime): configurable distributed worker startup timeout

### DIFF
--- a/docs/en/user/distributed/03-execution.md
+++ b/docs/en/user/distributed/03-execution.md
@@ -24,7 +24,7 @@ directly via `DistributedWorker(compiled)`, importable from
 
 | Method | Description |
 | ------ | ----------- |
-| `compiled.prepare(config=None, *, extra_compiled=(), persistent=False, reset_persistent_windows=None, callbacks=None, sub_worker_overrides=None)` | Create worker, fork chip processes, return `DistributedWorker`. Use as context manager. |
+| `compiled.prepare(config=None, *, extra_compiled=(), persistent=False, reset_persistent_windows=None, callbacks=None, sub_worker_overrides=None, startup_timeout_s=None)` | Create worker, fork chip processes, return `DistributedWorker`. Use as context manager. |
 | `rt(x, y, z)` | Single dispatch — coerces args, calls host_orch. |
 | `rt.run(compiled, x, y, z)` | Multi-program dispatch — selects the target program. |
 | `rt.alloc_tensor(shape, dtype, *, init=None)` | Allocate a worker-resident `DeviceTensor`. `init` copies from host (one-time H2D). |
@@ -49,6 +49,10 @@ directly via `DistributedWorker(compiled)`, importable from
   retained windows are zeroed between requests (a correctness-vs-overhead
   trade-off). See `docs/en/dev/06-persistent-l3.md`.
 - **`extra_compiled`** — see "Several Programs on One Worker" below.
+- **`startup_timeout_s`** — optionally overrides Simpler's positive finite
+  startup-readiness deadline for the forked worker hierarchy. Leave it as
+  `None` to keep Simpler's default; increase it for legitimately slow cold
+  starts rather than disabling the bound.
 
 ## DeviceTensor
 

--- a/docs/zh/user/distributed/03-execution.md
+++ b/docs/zh/user/distributed/03-execution.md
@@ -24,7 +24,7 @@ with compiled.prepare() as rt:
 
 | 方法 | 描述 |
 | ---- | ---- |
-| `compiled.prepare(config=None, *, extra_compiled=(), persistent=False, reset_persistent_windows=None, callbacks=None, sub_worker_overrides=None)` | 创建 worker、fork 芯片进程，返回 `DistributedWorker`。作为上下文管理器使用。 |
+| `compiled.prepare(config=None, *, extra_compiled=(), persistent=False, reset_persistent_windows=None, callbacks=None, sub_worker_overrides=None, startup_timeout_s=None)` | 创建 worker、fork 芯片进程，返回 `DistributedWorker`。作为上下文管理器使用。 |
 | `rt(x, y, z)` | 单次分发——转换参数，调用 host_orch。 |
 | `rt.run(compiled, x, y, z)` | 多程序分发——选择目标程序。 |
 | `rt.alloc_tensor(shape, dtype, *, init=None)` | 分配 worker 常驻的 `DeviceTensor`。`init` 从 host 拷贝（一次性 H2D）。 |
@@ -47,6 +47,9 @@ with compiled.prepare() as rt:
   搭配使用，后者决定保留的 window 是否在两次请求之间清零（正确性与
   开销的权衡）。见 `docs/en/dev/06-persistent-l3.md`。
 - **`extra_compiled`**——见下方"在同一个 worker 上运行多个程序"。
+- **`startup_timeout_s`**——可选地覆盖 Simpler 对 fork worker 层级报告
+  启动就绪状态所设置的正有限秒数期限。保持为 `None` 时使用 Simpler
+  默认值；对于确实较慢的冷启动，应增大该期限，而不是取消期限约束。
 
 ## DeviceTensor
 

--- a/python/pypto/ir/distributed_compiled_program.py
+++ b/python/pypto/ir/distributed_compiled_program.py
@@ -401,6 +401,7 @@ class DistributedCompiledProgram:
         reset_persistent_windows: bool | None = None,
         callbacks: dict[str, Callable[..., Any]] | None = None,
         sub_worker_overrides: dict[str, Callable[..., Any]] | None = None,
+        startup_timeout_s: float | None = None,
     ) -> "DistributedWorker":
         """Prepare a reusable L3 execution handle (setup once, dispatch many).
 
@@ -455,6 +456,9 @@ class DistributedCompiledProgram:
                 raises ``ValueError``. In multi-program mode the callbacks apply
                 to every prepared program.
             sub_worker_overrides: Deprecated alias for ``callbacks``.
+            startup_timeout_s: Optional positive finite bound, in seconds, for
+                the forked worker hierarchy to report startup readiness. ``None``
+                keeps Simpler's default timeout.
 
         Returns:
             A :class:`DistributedWorker`; use it as a context manager or call
@@ -469,6 +473,7 @@ class DistributedCompiledProgram:
             reset_persistent_windows=reset_persistent_windows,
             callbacks=callbacks,
             sub_worker_overrides=sub_worker_overrides,
+            startup_timeout_s=startup_timeout_s,
         )
 
     @staticmethod

--- a/python/pypto/runtime/distributed_runner.py
+++ b/python/pypto/runtime/distributed_runner.py
@@ -16,6 +16,7 @@ import importlib.util
 import inspect
 import json
 import logging
+import math
 import queue
 import sys
 import threading
@@ -322,6 +323,12 @@ def _construct_worker(
     startup_timeout_s: float | None = None,
 ) -> Any:
     """Construct a simpler ``Worker(level=3)`` from the distributed config."""
+    if startup_timeout_s is not None and (not math.isfinite(startup_timeout_s) or startup_timeout_s <= 0):
+        raise ValueError(
+            "DistributedWorker startup_timeout_s must be a positive finite number of seconds, "
+            f"got {startup_timeout_s!r}"
+        )
+
     from simpler.worker import (  # noqa: PLC0415  # pyright: ignore[reportMissingImports]
         Worker,
     )

--- a/python/pypto/runtime/distributed_runner.py
+++ b/python/pypto/runtime/distributed_runner.py
@@ -319,20 +319,24 @@ def _construct_worker(
     runtime_name: str,
     num_sub: int,
     enable_sdma: bool = False,
+    startup_timeout_s: float | None = None,
 ) -> Any:
     """Construct a simpler ``Worker(level=3)`` from the distributed config."""
     from simpler.worker import (  # noqa: PLC0415  # pyright: ignore[reportMissingImports]
         Worker,
     )
 
-    return Worker(
-        level=3,
-        device_ids=dc.device_ids,
-        num_sub_workers=num_sub,
-        platform=platform,
-        runtime=runtime_name,
-        enable_sdma=enable_sdma,
-    )
+    worker_config: dict[str, Any] = {
+        "level": 3,
+        "device_ids": dc.device_ids,
+        "num_sub_workers": num_sub,
+        "platform": platform,
+        "runtime": runtime_name,
+        "enable_sdma": enable_sdma,
+    }
+    if startup_timeout_s is not None:
+        worker_config["startup_timeout_s"] = startup_timeout_s
+    return Worker(**worker_config)
 
 
 def _close_local_worker(w: Any) -> None:
@@ -1268,6 +1272,7 @@ class DistributedWorker(Worker):
         callbacks: dict[str, Callable[..., Any]] | None = None,
         sub_worker_overrides: dict[str, Callable[..., Any]] | None = None,
         inherited_host_tensors: Sequence[torch.Tensor] | None = None,
+        startup_timeout_s: float | None = None,
     ) -> None:
         super().__init__()  # initialize Worker ABC state (_owned_tensors)
         callbacks = _coalesce_callbacks(callbacks, sub_worker_overrides)
@@ -1390,6 +1395,7 @@ class DistributedWorker(Worker):
                 runtime_name,
                 num_sub,
                 enable_sdma=enable_sdma,
+                startup_timeout_s=startup_timeout_s,
             )
             self._validate_persistent_runtime_hooks()
             for prog, chip_callables, sub_worker_fns in loaded:

--- a/tests/ut/runtime/test_distributed_worker.py
+++ b/tests/ut/runtime/test_distributed_worker.py
@@ -946,6 +946,29 @@ class TestWorkerConstruction:
             enable_sdma=True,
         )
 
+    def test_forwards_startup_timeout_to_simpler_worker(self, monkeypatch):
+        worker_cls = MagicMock(name="simpler.Worker")
+        monkeypatch.setitem(sys.modules, "simpler.worker", SimpleNamespace(Worker=worker_cls))
+        dc = DistributedConfig(device_ids=[0, 1])
+
+        _construct_worker(
+            dc,
+            "a2a3",
+            "tensormap_and_ringbuffer",
+            3,
+            startup_timeout_s=1800.0,
+        )
+
+        assert worker_cls.call_args.kwargs["startup_timeout_s"] == 1800.0
+
+    def test_distributed_worker_forwards_startup_timeout(self, patched_setup):
+        compiled = _fake_compiled([_param("a", [8, 8])], [])
+
+        rt = DistributedWorker(compiled, startup_timeout_s=1800.0)
+
+        assert patched_setup["construct"].call_args.kwargs["startup_timeout_s"] == 1800.0
+        rt.close()
+
     def test_failure_preserves_primary_error_when_cleanup_retry_fails(self, patched_setup, caplog):
         worker = patched_setup["worker"]
         worker.init.side_effect = RuntimeError("init failed")
@@ -1325,6 +1348,14 @@ class TestMultiProgram:
             DistributedCompiledProgram.prepare(primary, persistent=True)
         assert fake_worker.call_args.kwargs["persistent"] is True
         assert fake_worker.call_args.kwargs["reset_persistent_windows"] is None
+
+    def test_prepare_forwards_startup_timeout(self):
+        from pypto.ir.distributed_compiled_program import DistributedCompiledProgram  # noqa: PLC0415
+
+        primary = _fake_compiled([_param("a", [4])], [])
+        with patch("pypto.runtime.distributed_runner.DistributedWorker") as fake_worker:
+            DistributedCompiledProgram.prepare(primary, startup_timeout_s=1800.0)
+        assert fake_worker.call_args.kwargs["startup_timeout_s"] == 1800.0
 
     def test_empty_sequence_raises(self, patched_setup):
         with pytest.raises(ValueError, match="at least one compiled program"):

--- a/tests/ut/runtime/test_distributed_worker.py
+++ b/tests/ut/runtime/test_distributed_worker.py
@@ -961,6 +961,26 @@ class TestWorkerConstruction:
 
         assert worker_cls.call_args.kwargs["startup_timeout_s"] == 1800.0
 
+    @pytest.mark.parametrize(
+        "startup_timeout_s",
+        [0.0, -1.0, float("inf"), float("-inf"), float("nan")],
+    )
+    def test_rejects_invalid_startup_timeout_before_worker_construction(self, monkeypatch, startup_timeout_s):
+        worker_cls = MagicMock(name="simpler.Worker")
+        monkeypatch.setitem(sys.modules, "simpler.worker", SimpleNamespace(Worker=worker_cls))
+        dc = DistributedConfig(device_ids=[0, 1])
+
+        with pytest.raises(ValueError, match="positive finite"):
+            _construct_worker(
+                dc,
+                "a2a3",
+                "tensormap_and_ringbuffer",
+                3,
+                startup_timeout_s=startup_timeout_s,
+            )
+
+        worker_cls.assert_not_called()
+
     def test_distributed_worker_forwards_startup_timeout(self, patched_setup):
         compiled = _fake_compiled([_param("a", [8, 8])], [])
 


### PR DESCRIPTION
## Summary

- Add an optional `startup_timeout_s` parameter to `DistributedCompiledProgram.prepare()` and `DistributedWorker`, threading a startup-readiness deadline through worker construction for the forked worker hierarchy.
- `None` (default) preserves Simpler's built-in deadline; a positive finite value overrides it for legitimately slow cold starts.
- Validate the override before `Worker` construction: non-positive, infinite, and NaN values are rejected with a clear `ValueError`.
- Document the setting in the distributed execution guide (English and Chinese).

## Testing

- `tests/ut/runtime/test_distributed_worker.py`: forwarding coverage for the helper, direct-worker, and `prepare()` paths, plus rejection cases for zero/negative/inf/NaN deadlines.