### PR TITLE
fix(ir): carry a ragged valid shape across the AIV split boundary

### DIFF
--- a/docs/en/dev/codegen/00-pto_codegen.md
+++ b/docs/en/dev/codegen/00-pto_codegen.md
@@ -202,11 +202,18 @@ or call `set_validshape` on the source tile before taking the view.
 - If the pushed tile was allocated with dynamic `valid_row` / `valid_col` operands or updated by
   `tile.set_validshape`, `tpush` emits the same tile handle after its runtime valid shape has been
   updated. For split `tpush`, codegen temporarily uses the full physical transport box, then restores
-  the producer tile's logical valid shape; consumer-side dynamic tpop operands carry the logical
-  extents used by compute and store. A partial no-split Acc-to-Vec transfer also uses the full physical
-  box for both TPUSH and TPOP, because the Cube-to-Vector FIFO is physically box-strided, and restores
-  the logical valid shape immediately on each side of the transport.
-- When a tpop result `TileView.valid_shape` differs from the physical tile shape, PTO codegen emits PTOAS frontend operands as `%buf = pto.tpop_from_*(%valid_row, %valid_col) {[id = I, ]split = N} -> !pto.tile_buf<..., v_row=?, v_col=?, ...>`. This covers dynamic expressions and static non-full shapes such as `[0, 0]`; the operands carry the logical extents used by compute and store.
+  the producer tile's logical valid shape.
+- The Cube-to-Vector FIFO is physically box-strided at **every** split: the ISA builds the GM slot
+  view from the popped tile's compile-time rows/cols and the producer's box row pitch, then strides
+  that view with the tile's *runtime* `valid_col`. A partial valid shape on TPOP therefore collapses
+  the GM row gap and makes the consumer read one contiguous run instead of one box row per burst —
+  silent corruption of the *valid* region, since the ISA's matching assertion is compiled out in
+  release builds. So a partial Acc-to-Vec transfer uses the full physical box for both TPUSH and
+  TPOP, whether the transfer is no-split or `split = 1` / `split = 2`, and restores the logical valid
+  shape immediately on each side of the transport — on the consumer side through a metadata-only
+  `pto.treshape` (a frontend tpop result is not a locally bound PTOAS tile, so `pto.set_validshape`
+  cannot restore it in place).
+- When a tpop result `TileView.valid_shape` differs from the physical tile shape, PTO codegen emits PTOAS frontend operands as `%buf = pto.tpop_from_*(%valid_row, %valid_col) {[id = I, ]split = N} -> !pto.tile_buf<..., v_row=?, v_col=?, ...>`. This covers dynamic expressions and static non-full shapes such as `[0, 0]`; the operands carry the logical extents used by compute and store. The full-box Cube-to-Vector transport above overrides this for a statically-shaped, non-empty partial pop, because `pto.treshape` carries no valid-row/valid-col operands and so can only restore *static* logical extents.
 - For split consumers, `SplitVectorKernel` localizes those dynamic tpop
   valid-shape operands per subblock (for example global `[8, 16]` becomes
   `[8, 16]` then `[0, 16]` under up/down split of a `[16, 16]` tile).

--- a/docs/en/dev/passes/20-lower_auto_vector_split.md
+++ b/docs/en/dev/passes/20-lower_auto_vector_split.md
@@ -315,6 +315,50 @@ as an internal assertion in PTO codegen (`SplitAivScopeStmt reached PTO codegen`
 (`split_axis_utils`); it is **not** called for `None` (the region path branches on
 `None` first — there is no axis to derive).
 
+## Partially-valid operands across the boundary
+
+A crossing value whose `valid_shape` is short of its physical box is a kernel's
+ragged tail. The Cube→Vector FIFO pins the transported **column** extent to the
+physical one and leaves the **row** extent free (derivation and ISA references:
+[PTO codegen](../codegen/00-pto_codegen.md)). A narrowing on the *split axis* is
+what makes an extent per-lane — lane `L` holds `clamp(V - L*half, 0, half)` — so
+which mode is ragged decides which field has to carry it:
+
+The table is the **shard's** (Cube→Vector) contract; `aic_gather` follows the
+geometric rule at the end of this section instead.
+
+| Ragged axis | Mode | Extent is | Carrier | Status |
+| ----------- | ---- | --------- | ------- | ------ |
+| rows (split axis) | `UpDown` | per-lane | TPOP `valid_row` operand (free field) | **supported** |
+| cols (non-split) | `UpDown` | shared, static | full-box transport + static `pto.treshape` | supported |
+| rows (non-split) | `LeftRight` | shared, static | TPOP `valid_row` operand | supported |
+| cols (split axis) | `LeftRight` | per-lane | none | **rejected** |
+| cols, runtime-valued | either | shared, dynamic | none (`treshape` takes no operands) | **rejected** |
+| rows per-lane **and** cols narrowed | `UpDown` | both | none (`treshape` rewrites both axes) | **rejected** |
+
+`ReshapeSplitAxis` can only ceil-halve the split-axis extent (the lane index is
+not part of an op's type function). `LocalizeExplicitBoundaryValid` repairs that
+guess here, where the region's `aiv_id` is in scope, and carries the per-lane
+extent to consumers that pass `valid_shape` through; one that reshapes the
+logical rectangle is rejected with its span. The AUTO arm applies the same *extent* repair through
+`LocalizeShardValidForLane`, but not the store guard below — its consumers are
+rebuilt by the halving walk rather than by this one.
+
+- **An empty lane's store is guarded.** A lane the ragged extent does not reach
+  has extent `0`, and a zero-row `TSTORE` is outside pto-isa's contract
+  (`TSTORE_IMPL` asserts `GetValidRow() > 0`). The store gets a runtime
+  `extent > 0` guard; `tpop` and `tfree` stay **unconditional** — both lanes
+  occupy a slot and both must release it.
+- **The gather is limited by geometry, not the DMA.** A V2C pop lands in an NZ
+  Mat tile (`TLoadGm2L1Nd2nz`), which reads no valid extent at all. What limits
+  `aic_gather` is placement: lane `l` sits at offset `l*half`, so the joined data
+  `[0, v0) ∪ [half, half + v1)` is a rectangle only when the bands abut. That
+  rule is enforced **in this pass**, not in the deducer, which runs before the
+  per-lane extents exist and could only judge the join on its own ceil-div guess.
+  A gather fed by a localized shard is typed exactly — the bands always abut, so
+  the joined extent is the pre-shard `V` — and only a partial that both lanes
+  share is rejected.
+
 ## Algorithm
 
 `LowerFunction` rewrites one mixed `InCore` function:

--- a/docs/zh/dev/codegen/00-pto_codegen.md
+++ b/docs/zh/dev/codegen/00-pto_codegen.md
@@ -195,11 +195,17 @@ tile 调用 `set_validshape`。
 - 如果被 push 的 tile 通过动态 `valid_row` / `valid_col` operand 分配，或经
   `tile.set_validshape` 更新，`tpush` 会发射已经更新运行时 valid shape 的同一个
   tile handle。对于 split `tpush`，codegen 会临时使用完整物理传输 box，随后恢复
-  producer tile 的逻辑 valid shape；消费侧动态 tpop operand 仍携带后续计算和 store
-  使用的逻辑范围。部分有效的无切分 Acc-to-Vec 传输也会让 TPUSH 和 TPOP 使用完整物理
-  box，因为 Cube-to-Vector FIFO 按物理 box stride 搬运；传输两侧随后立即恢复逻辑
-  valid shape。
-- 当 tpop 结果的 `TileView.valid_shape` 与物理 tile shape 不一致时，PTO codegen 会生成 PTOAS 前端操作数：`%buf = pto.tpop_from_*(%valid_row, %valid_col) {[id = I, ]split = N} -> !pto.tile_buf<..., v_row=?, v_col=?, ...>`。这同时覆盖动态表达式和 `[0, 0]` 这类静态非满形状；operand 携带后续计算和 store 使用的逻辑范围。
+  producer tile 的逻辑 valid shape。
+- Cube-to-Vector FIFO 在**任意** split 下都按物理 box stride 搬运：ISA 用被弹出
+  tile 的编译期 rows/cols 以及 producer 的 box 行间距构造 GM 槽位视图，再用该 tile
+  的*运行时* `valid_col` 去 stride 这个视图。因此 TPOP 上的部分 valid shape 会让 GM
+  行间隙塌缩为 0，消费侧读到的是一段连续数据而不是每次一行 box——这会静默破坏
+  *有效*区域的数据，因为 ISA 中对应的断言在 release 构建里被编译掉了。所以部分有效的
+  Acc-to-Vec 传输在无切分以及 `split = 1` / `split = 2` 下，TPUSH 和 TPOP 都使用完整
+  物理 box，并在传输两侧立即恢复逻辑 valid shape——消费侧通过纯元数据的
+  `pto.treshape` 恢复（前端 tpop 结果不是 PTOAS 的本地绑定 tile，`pto.set_validshape`
+  无法就地修改它）。
+- 当 tpop 结果的 `TileView.valid_shape` 与物理 tile shape 不一致时，PTO codegen 会生成 PTOAS 前端操作数：`%buf = pto.tpop_from_*(%valid_row, %valid_col) {[id = I, ]split = N} -> !pto.tile_buf<..., v_row=?, v_col=?, ...>`。这同时覆盖动态表达式和 `[0, 0]` 这类静态非满形状；operand 携带后续计算和 store 使用的逻辑范围。对于静态形状、非空的部分 pop，上述 Cube-to-Vector 完整 box 传输优先，因为 `pto.treshape` 不带 valid-row/valid-col operand，只能恢复*静态*逻辑范围。
 - 对于 split consumer，`SplitVectorKernel` 会按 subblock 本地化这些动态
   tpop valid-shape operand（例如 `[16, 16]` tile 做上下切分时，全局
   `[8, 16]` 会变成 `[8, 16]` 和 `[0, 16]`）。

--- a/docs/zh/dev/passes/20-lower_auto_vector_split.md
+++ b/docs/zh/dev/passes/20-lower_auto_vector_split.md
@@ -283,6 +283,44 @@ attrs，因此 [`ExpandMixedKernel`](21-expand_mixed_kernel.md) 凭该标记跳�
 `SplitDimension(mode)` 对 `UpDown` 返回 `0`，对 `LeftRight` 返回 `1`
 （`split_axis_utils`）；对 `None` **不调用**（区域路径先对 `None` 分支——无轴可推导）。
 
+## 跨边界的部分有效（partially-valid）操作数
+
+`valid_shape` 不足物理 box 的跨界值，正是 kernel 的 ragged 尾部。Cube→Vector FIFO
+把传输的**列** extent 钉死为物理值，而**行** extent 是自由的（推导与 ISA 依据见
+[PTO codegen](../codegen/00-pto_codegen.md)）。**切分轴**上的收窄会让 extent 变成逐
+lane 的——lane `L` 持有 `clamp(V - L*half, 0, half)`——因此哪种模式 ragged，就决定了
+由哪个字段来承载：
+
+下表是 **shard**（Cube→Vector）的契约；`aic_gather` 遵循本节末尾的几何规则。
+
+| 收窄的轴 | 模式 | extent 性质 | 载体 | 状态 |
+| -------- | ---- | ----------- | ---- | ---- |
+| 行（切分轴） | `UpDown` | 逐 lane | TPOP `valid_row` 操作数（自由字段） | **支持** |
+| 列（非切分轴） | `UpDown` | 两 lane 相同、静态 | 整 box 传输 + 静态 `pto.treshape` | 支持 |
+| 行（非切分轴） | `LeftRight` | 两 lane 相同、静态 | TPOP `valid_row` 操作数 | 支持 |
+| 列（切分轴） | `LeftRight` | 逐 lane | 无 | **拒绝** |
+| 列为运行期值 | 任意 | 两 lane 相同、动态 | 无（`treshape` 不带操作数） | **拒绝** |
+| 行逐 lane **且**列收窄 | `UpDown` | 两者 | 无（`treshape` 会同时重写两个轴） | **拒绝** |
+
+`ReshapeSplitAxis` 只能对切分轴做 ceil 折半，因为 lane 索引不属于 op 的类型函数。
+`LocalizeExplicitBoundaryValid` 在本 pass 修正该猜测——区域自身的
+`aiv_id = tile.get_subblock_idx()` 在作用域内——并把逐 lane extent 传给那些原样透传
+`valid_shape` 的消费者；若消费者会改变逻辑矩形（reduction、slice），则连同 span 一并
+报错。AUTO 分支通过 `LocalizeShardValidForLane` 施加同样的 *extent* 修正，但不含下面的
+store 保护——它的消费者由折半遍历重建，而非本遍历。
+
+- **空 lane 的 store 被保护。** ragged extent 覆盖不到的 lane，其 extent 为 `0`，而
+  零行 `TSTORE` 超出 pto-isa 契约（`TSTORE_IMPL` 断言 `GetValidRow() > 0`）。store
+  被加上运行时 `extent > 0` 判断；`tpop` 与 `tfree` 保持**无条件**——两个 lane 都占用
+  槽位且都必须释放。
+- **gather 的限制源自几何而非 DMA。** V2C 的 pop 落到 NZ Mat tile
+  （`TLoadGm2L1Nd2nz`），不读取任何 valid extent。真正限制 `aic_gather` 的是摆放：
+  lane `l` 位于偏移 `l*half`，拼合后的数据是 `[0, v0) ∪ [half, half + v1)`——只有两段
+  相邻时才是矩形。该规则在**本 pass** 而非类型推导中执行：推导发生在逐 lane extent 存在
+  之前，只能依据自己的 ceil 猜测来判断。由 localized shard 供给的 gather 会被精确定型
+  ——两段必然相邻，拼合 extent 即 shard 前的 `V`——只有两个 lane 共享的部分 extent 才会
+  被拒绝。
+
 ## 算法
 
 `LowerFunction` 改写一个混合 `InCore` 函数：

--- a/include/pypto/ir/transforms/utils/split_axis_utils.h
+++ b/include/pypto/ir/transforms/utils/split_axis_utils.h
@@ -19,7 +19,9 @@
 
 #include "pypto/ir/expr.h"
 #include "pypto/ir/function.h"
+#include "pypto/ir/span.h"
 #include "pypto/ir/stmt.h"
+#include "pypto/ir/type.h"
 
 namespace pypto {
 namespace ir {
@@ -165,6 +167,60 @@ std::vector<StmtPtr> ProcessStmts(const std::vector<StmtPtr>& stmts, SplitMode m
                                   int split_dim, std::unordered_map<const Var*, TileInfo>& tile_vars,
                                   bool is_aiv, const ExprPtr& subblock_idx,
                                   std::unordered_map<const Var*, VarPtr>& var_replacements);
+
+/**
+ * @brief Give each explicit-boundary ``tile.aiv_shard`` its TRUE per-lane valid
+ *        extent on the split axis, and carry that extent to its consumers.
+ *
+ * ``ReshapeSplitAxis`` (the op deducer) can only halve the split-axis valid
+ * extent with a ceil-div, because the lane index is not part of an op's type
+ * function. When the operand's split-axis extent does not cover its physical
+ * box, that guess is wrong for BOTH lanes: lane L holds
+ * ``clamp(V - L * half, 0, half)``, so a ``[16, 256]`` accumulator valid to 5
+ * rows must give lane 0 five rows and lane 1 none, not ``ceil(5 / 2) = 3`` each.
+ *
+ * A ``pl.split_aiv`` region body is the one place that guess can be repaired:
+ * the region's own ``aiv_id = tile.get_subblock_idx()`` binding is in scope, so
+ * the per-lane extent is materializable as an expression. The extent is then
+ * propagated to every consumer that passes it through unchanged, because the
+ * store is what finally reads it — and PTOAS offers no way to re-narrow a popped
+ * tile after the fact (``pto.set_validshape`` needs a locally bound source,
+ * which a frontend tpop result is not).
+ *
+ * Only the split axis is touched, and only when the operand is genuinely
+ * partial there; a fully-valid operand keeps the deducer's exact ``half``.
+ * A consumer that TRANSFORMS the extent (a reduction, a slice) rather than
+ * passing it through is reported as a user-facing limitation with its span.
+ *
+ * The walk descends into nested control flow, so a shard / consumer / store
+ * inside a loop or a branch is repaired exactly like a top-level one.
+ *
+ * @param stmts The region body statements (already half-width).
+ * @param split_dim The partitioned tile dimension (see SplitDimension).
+ * @param region_span Span of the enclosing region, for diagnostics.
+ * @return The rewritten statement list (input order preserved).
+ */
+std::vector<StmtPtr> LocalizeExplicitBoundaryValid(const std::vector<StmtPtr>& stmts, int split_dim,
+                                                   const Span& region_span);
+
+/**
+ * @brief Replace a shard result type's split-axis valid extent with the lane's own.
+ *
+ * ``ReshapeSplitAxis`` halves that extent with a ceil-div because an op's type
+ * function does not know the lane; wherever a subblock index IS in scope, this
+ * restores the truth ``clamp(V - idx * half, 0, half)``. Returns @p shard_type
+ * unchanged when the operand's split axis is fully valid (both lanes then hold
+ * exactly ``half``, which the deducer already produced) or when either type is
+ * not a rank-covering TileType.
+ *
+ * @param shard_type The deduced per-lane (halved) tile type.
+ * @param operand_type The pre-split tile type the shard reads.
+ * @param split_dim The partitioned tile dimension (see SplitDimension).
+ * @param subblock_idx The per-lane index expr; null leaves the type unchanged.
+ * @return The retyped shard type, or @p shard_type when no repair applies.
+ */
+TypePtr LocalizeShardValidForLane(const TypePtr& shard_type, const TypePtr& operand_type, int split_dim,
+                                  const ExprPtr& subblock_idx);
 
 }  // namespace split_axis
 }  // namespace ir

--- a/src/backend/common/pto_ops_crosscore.cpp
+++ b/src/backend/common/pto_ops_crosscore.cpp
@@ -263,10 +263,21 @@ static std::string MakeTpopCodegenPTO(const char* target, const CallPtr& op,
   std::string result_type = codegen.GetCurrentResultTileBufTypeString();
   auto [logical_row, logical_col] = codegen.GetCurrentResultTpopValidShapeOperands();
 
-  // PTO's no-split Cube->Vector FIFO copies the physical Acc box. Give TPOP
-  // that same full-box extent, then restore the logical result shape before
-  // any vector consumer sees it. Keep a statically empty replay empty: the
-  // dual-AIV no-split path uses such a replay only to balance the pipe.
+  // PTO's Cube->Vector FIFO copies the physical consumer box, at EVERY split.
+  // pto-isa builds the GM slot view from the popped tile's compile-time
+  // rows/cols and the producer's box row pitch (a2a3 TPush.hpp
+  // popVecTileFromGMFiFo: gmValidR/gmValidC = ConsM/ConsN, gmStrideR = ProdN),
+  // then strides that view with the tile's RUNTIME validCol (TLoadGm2ubNd2nd:
+  // lenBurst = validCol, but gmGap = gStride3 - gShape4). A narrowed validCol
+  // therefore collapses the GM gap to zero and the pop reads one contiguous
+  // run instead of one box row per burst -- silently, since the matching
+  // PTO_ASSERT(validCol == gShape4) is compiled out in release builds. Give
+  // TPOP the full-box extent, mirroring the producer-side widening in
+  // EmitTpushTransportValidShape, then restore the logical result shape before
+  // any vector consumer sees it. Keep a statically empty pop empty: the
+  // dual-AIV no-split path uses such a replay only to balance the pipe, and a
+  // split lane whose localized valid extent is statically 0 must likewise
+  // move nothing.
   auto result_tile_type = codegen.GetCurrentResultTileType();
   bool statically_empty = false;
   bool has_static_logical_shape = false;
@@ -281,10 +292,16 @@ static std::string MakeTpopCodegenPTO(const char* target, const CallPtr& op,
       }
     }
   }
-  const bool use_full_box = std::string_view(target) == "aic" && split == 0 && !logical_row.empty() &&
-                            !logical_col.empty() && has_static_logical_shape && !statically_empty &&
-                            result_tile_type && result_tile_type->GetMemorySpace() == ir::MemorySpace::Vec &&
-                            result_tile_type->shape_.size() >= 2;
+  // The physical box must be static too, not just the logical extent: the
+  // treshape below rebuilds the logical type from ConstInt dims, and a split
+  // tile CAN carry a dynamic physical extent (ReshapeSplitAxis lowers a dynamic
+  // split axis to floordiv(dim, 2)). Without this the pop would reach that
+  // INTERNAL_CHECK instead of falling back to the direct-TPOP path.
+  const bool use_full_box =
+      std::string_view(target) == "aic" && !logical_row.empty() && !logical_col.empty() &&
+      has_static_logical_shape && !statically_empty && result_tile_type &&
+      result_tile_type->GetMemorySpace() == ir::MemorySpace::Vec && result_tile_type->shape_.size() >= 2 &&
+      As<ir::ConstInt>(result_tile_type->shape_[0]) && As<ir::ConstInt>(result_tile_type->shape_[1]);
   std::string transport_row = logical_row;
   std::string transport_col = logical_col;
   if (use_full_box) {

--- a/src/ir/op/tile_ops/cross_core.cpp
+++ b/src/ir/op/tile_ops/cross_core.cpp
@@ -26,6 +26,7 @@
 #include "pypto/ir/scalar_expr.h"
 #include "pypto/ir/span.h"
 #include "pypto/ir/tile_view_semantics.h"
+#include "pypto/ir/transforms/printer.h"
 #include "pypto/ir/type.h"
 #include "pypto/ir/type_inference.h"
 
@@ -126,6 +127,153 @@ SplitReshaped ReshapeSplitAxis(std::vector<ExprPtr> shape, std::vector<ExprPtr> 
   return {std::move(shape), std::move(valid)};
 }
 
+// ============================================================================
+// Which partial valid_shapes the AIC/AIV boundary can actually carry
+// ============================================================================
+//
+// THE SHARD (Cube -> Vector). The C2V FIFO transports a physically box-strided
+// slot. pto-isa builds the GM slot view from the popped tile's COMPILE-TIME
+// rows/cols and the producer's box row pitch, then strides that view with the
+// tile's RUNTIME validCol (a2a3 tload_common.hpp TLoadGm2ubNd2nd:
+// lenBurst = validCol, but gmGap = gStride3 - gShape4). Requiring
+// "GM advance per burst == one producer-box row" gives
+//
+//     validCol * s + (ProdN - ConsN) * s == ProdN * s   =>   validCol == ConsN
+//
+// where ProdN cancels -- so the requirement is the SAME for UP_DOWN and
+// LEFT_RIGHT. The row field is free in both: the DMA always moves
+// nBurst == gShape3 == the physical row count, whatever validRow says.
+//
+// This derivation is the Vec/UB pop's, and does NOT carry over to the gather:
+// a V2C pop lands in an NZ Mat tile through TLoadGm2L1Nd2nz, which takes its
+// nValue/dValue from the GM tensor shape and reads neither validRow nor
+// validCol. The gather is constrained by geometry instead (see below).
+//
+// That leaves exactly one carrier for a narrowed COLUMN extent: transport the
+// full box and rebuild the logical extents afterwards with pto.treshape
+// (MakeTpopCodegenPTO in src/backend/common/pto_ops_crosscore.cpp). treshape
+// takes no operands, so it can only restore COMPILE-TIME STATIC extents, and it
+// rebuilds BOTH axes from one target type. Hence, per axis of the popped tile:
+//
+//   column full              -> rides the transport unchanged; the row field is
+//                               then free (static OR per-lane)
+//   column static narrowing  -> full-box transport + treshape, but only if the
+//                               row extent is static too
+//   column per-lane          -> no carrier  (LEFT_RIGHT narrows the split axis)
+//   column runtime-valued    -> no carrier
+//
+// A split-axis narrowing is what makes an extent per-lane: lane L holds
+// clamp(V - L*half, 0, half), so the two lanes differ whenever V < the physical
+// extent. On the shard (AIC -> AIV) that per-lane value is legal on the row
+// field and is materialized by LowerAutoVectorSplit.
+//
+// THE GATHER (Vector -> Cube) is limited by geometry, not by the DMA. Every V2C
+// transport places lane l at offset l*half, never compacted, so the gathered
+// real data is [0, v0) union [half, half + v1) -- a rectangle only when the two
+// bands abut (v0 == half) or lane 1 is empty (v1 == 0). Under the correct
+// per-lane extents that always holds and the gathered extent is v0 + v1 == V,
+// which is exactly what a shard-then-gather round trip must report. What has no
+// rectangle is a HAND-AUTHORED partial that both lanes share (v < half on each):
+// the deducer's 2*v would then claim the hole between the bands as real data.
+// Only that provable case is rejected here; a lane-dependent extent is the
+// compiler's own localized clamp and is left alone.
+//
+// Docs: docs/en/dev/codegen/00-pto_codegen.md,
+//       docs/en/dev/passes/20-lower_auto_vector_split.md
+bool IsFullExtent(const ExprPtr& valid_dim, const ExprPtr& dim) {
+  return ProveValidExtentEqual(valid_dim, dim) == ProofResult::kTrue;
+}
+
+std::string DescribeExtent(const ExprPtr& valid_dim, const ExprPtr& dim) {
+  return PythonPrint(valid_dim) + " of " + PythonPrint(dim);
+}
+
+// `split_axis` is 0 (UP_DOWN), 1 (LEFT_RIGHT), or -1 for the shape-preserving
+// split=0 crossing, which has no split axis and therefore no per-lane extent.
+void CheckSplitBoundaryCarriesValid(const std::string& op_name, const std::vector<ExprPtr>& shape,
+                                    const std::vector<ExprPtr>& valid, int split_axis, bool halve,
+                                    const Span& span) {
+  if (shape.size() != 2 || valid.size() != 2) {
+    return;
+  }
+  // (1) The gather is exempt from the column contract at EVERY split, including
+  // the shape-preserving split=0 crossing: a V2C pop lands in an NZ Mat tile
+  // through TLoadGm2L1Nd2nz, which reads neither validRow nor validCol, and it
+  // never takes the pto.treshape path (use_full_box is gated on the C2V pop).
+  //
+  // Its own rule — that the two lanes' bands must abut — is NOT checked here.
+  // This deducer runs before the per-lane extents exist, so the only extent it
+  // can see is its own lane-agnostic ceil-div guess; judging the join on that
+  // both misreports the extents and rejects shapes that are representable once
+  // the lanes are localized. LowerAutoVectorSplit owns that rule instead, where
+  // the true extents are known (split_axis_utils.cpp).
+  if (!halve) {
+    return;
+  }
+
+  // (2) The column field is the contested one. A full column extent needs no
+  // restore at all, which also leaves the row field free.
+  if (IsFullExtent(valid[1], shape[1])) {
+    return;
+  }
+
+  // (3) LEFT_RIGHT narrows the split axis, so the column extent is per-lane.
+  const bool column_is_per_lane = (split_axis == 1);
+  CHECK_SPAN(!column_is_per_lane, span)
+      << op_name << ": LEFT_RIGHT splits the column axis, but this tile's valid column extent ("
+      << DescribeExtent(valid[1], shape[1])
+      << ") does not cover the full box, so the two AIV lanes would hold different amounts of real "
+         "data. A per-lane column extent cannot cross this boundary: the Cube<->Vector FIFO pins the "
+         "transported column extent to the physical one, and the only way to restore a narrower "
+         "extent afterwards (pto.treshape) is compile-time static and so cannot express a per-lane "
+         "value.\n"
+      << "Author one of these instead:\n"
+      << "  * split the row axis: mode=pl.SplitMode.UP_DOWN (a per-lane ROW extent IS carried)\n"
+      << "  * make the columns fully valid before the crossing and let the padding be don't-care at "
+         "the store:\n"
+      << "        acc = pl.set_validshape(acc, <valid_rows>, " << PythonPrint(shape[1]) << ")\n"
+      << "        out[..., c0 : c0 + <half>] = shard   # c0 = aiv_id * <half>\n"
+      << "  * keep the ragged column tail in its own matmul outside the pl.split_aiv region";
+
+  // (4) The narrowed column extent must be rebuilt after the full-box transport,
+  // and pto.treshape can only rebuild static extents -- on BOTH axes at once.
+  const bool column_is_static = static_cast<bool>(As<ConstInt>(valid[1]));
+  CHECK_SPAN(column_is_static, span)
+      << op_name << ": this tile's valid column extent (" << DescribeExtent(valid[1], shape[1])
+      << ") is a runtime value narrower than the physical box. A narrowed column extent has to be "
+         "rebuilt after the boundary's full-box transport, and the only rebuild available "
+         "(pto.treshape) is compile-time static.\n"
+      << "Fix: make the columns fully valid before the crossing --\n"
+      << "        acc = pl.set_validshape(acc, <valid_rows>, " << PythonPrint(shape[1]) << ")\n"
+      << "    and store the full column box; the padded columns are don't-care.";
+
+  // A row extent that is per-lane (split-axis narrowing on an UP_DOWN shard) or
+  // runtime-valued cannot survive the static treshape that the narrowed column
+  // extent forces, because treshape rewrites both axes from one target type.
+  const bool row_is_per_lane = (split_axis == 0) && !IsFullExtent(valid[0], shape[0]);
+  const bool row_is_static = static_cast<bool>(As<ConstInt>(valid[0]));
+  CHECK_SPAN(!row_is_per_lane, span)
+      << op_name << ": UP_DOWN split with BOTH a per-lane row extent (" << DescribeExtent(valid[0], shape[0])
+      << ", so the lanes hold different row counts) and a "
+      << "narrowed column extent (" << DescribeExtent(valid[1], shape[1]) << ") is not supported. "
+      << "The per-lane row extent rides on the TPOP valid_row operand, but the narrowed column "
+         "extent can only be restored by pto.treshape, which rebuilds BOTH axes from one static "
+         "type and would overwrite that per-lane row.\n"
+      << "Fix: widen the columns before the crossing and store the full column box --\n"
+      << "        acc = pl.set_validshape(acc, " << PythonPrint(valid[0]) << ", " << PythonPrint(shape[1])
+      << ")\n"
+      << "        out[r0 : r0 + <half>, 0 : " << PythonPrint(shape[1]) << "] = shard";
+  CHECK_SPAN(row_is_static, span)
+      << op_name << ": this tile's valid row extent (" << DescribeExtent(valid[0], shape[0])
+      << ") is a runtime value and its valid column extent (" << DescribeExtent(valid[1], shape[1])
+      << ") is narrower than the physical box. The narrowed column extent forces a full-box "
+         "transport whose logical extents are rebuilt by the static pto.treshape, which cannot "
+         "express a runtime row extent.\n"
+      << "Fix: make the columns fully valid before the crossing --\n"
+      << "        acc = pl.set_validshape(acc, <valid_rows>, " << PythonPrint(shape[1]) << ")\n"
+      << "    and store the full column box; the padded columns are don't-care.";
+}
+
 // Deducer for the tile-level split-axis reshape ops tile.aiv_shard (full ->
 // half) and tile.aic_gather (half -> full). The single positional tile argument
 // is reshaped along the split axis selected by the "split" int attr.
@@ -156,6 +304,9 @@ TypePtr DeduceSplitReshape(const std::vector<ExprPtr>& args,
     // re-attached downstream.
     TileView no_split_view;
     no_split_view.valid_shape = GetValidShape(tile_type);
+    // No split axis, but the column field is still pinned by the FIFO transport.
+    CheckSplitBoundaryCarriesValid(op_name, tile_type->shape_, no_split_view.valid_shape,
+                                   /*split_axis=*/-1, halve, args[0]->span_);
     return std::make_shared<TileType>(tile_type->shape_, tile_type->dtype_, std::nullopt,
                                       std::move(no_split_view));
   }
@@ -164,6 +315,8 @@ TypePtr DeduceSplitReshape(const std::vector<ExprPtr>& args,
       << op_name << " requires a 2D tile, but got rank " << tile_type->shape_.size();
 
   const size_t axis = (split == 1) ? 0 : 1;
+  CheckSplitBoundaryCarriesValid(op_name, tile_type->shape_, GetValidShape(tile_type), static_cast<int>(axis),
+                                 halve, args[0]->span_);
   auto reshaped =
       ReshapeSplitAxis(tile_type->shape_, GetValidShape(tile_type), axis, halve, op_name, args[0]->span_);
 
@@ -223,6 +376,10 @@ TypePtr DeduceSplitReshapeTensor(const std::vector<ExprPtr>& args,
   std::vector<ExprPtr> valid = (tensor_type->tensor_view_ && !tensor_type->tensor_view_->valid_shape.empty())
                                    ? tensor_type->tensor_view_->valid_shape
                                    : tensor_type->shape_;
+  // Same boundary contract as the tile form this lowers to (pass 10), checked
+  // here so the diagnostic carries the author's own @pl.jit span.
+  CheckSplitBoundaryCarriesValid(op_name, tensor_type->shape_, valid, static_cast<int>(axis), halve,
+                                 args[0]->span_);
   auto reshaped =
       ReshapeSplitAxis(tensor_type->shape_, std::move(valid), axis, halve, op_name, args[0]->span_);
 

--- a/src/ir/transforms/lower_auto_vector_split_pass.cpp
+++ b/src/ir/transforms/lower_auto_vector_split_pass.cpp
@@ -340,9 +340,15 @@ std::vector<StmtPtr> LowerStmts(const std::vector<StmtPtr>& stmts, SplitMode mod
       if (RegionBodyHasExplicitBoundary(reg->body_)) {
         ValidateMixedExplicitRegion(region_stmts, reg->span_);
         ValidateTransposeSplitHazard(region_stmts, rdim, reg->span_);
-        // Unchanged apart from the placement stamp: the body is already
-        // half-width, but it is still region-placed, so pass 21 must be told.
-        for (auto& s : StampRegionPlacement(region_stmts)) result.push_back(s);
+        // The body is already half-width, but the boundary op's split-axis valid
+        // extent is still the deducer's lane-agnostic ceil-div guess. This region
+        // is where it can be repaired: the author's own aiv_id is in scope, so
+        // the lane's true extent is materializable (see
+        // split_axis::LocalizeExplicitBoundaryValid). A fully-valid split axis is
+        // returned untouched, so the common case is a no-op walk.
+        auto localized = split_axis::LocalizeExplicitBoundaryValid(region_stmts, rdim, reg->span_);
+        // Still region-placed, so pass 21 must be told.
+        for (auto& s : StampRegionPlacement(localized)) result.push_back(s);
         continue;
       }
 
@@ -398,7 +404,14 @@ std::vector<StmtPtr> LowerStmts(const std::vector<StmtPtr>& stmts, SplitMode mod
           // is also the C->V move's destination. Going through Create is what keeps
           // this AUTO path's IR identical to the explicit pl.aiv_shard form lowered
           // by ConvertTensorToTileOps: both get the space from the same declaration.
-          auto half_type = shard->GetType();
+          // The deducer can only ceil-halve the split-axis valid extent, because an
+          // op's type function does not know the lane. Here subblock_idx IS in
+          // scope, so give the result the lane's true extent — the same repair
+          // the explicit-region arm applies through
+          // LocalizeExplicitBoundaryValid. A fully-valid split axis is returned
+          // unchanged, so the common case keeps the deducer's exact type.
+          auto half_type = split_axis::LocalizeShardValidForLane(shard->GetType(), call->args_[0]->GetType(),
+                                                                 split_dim, subblock_idx);
           auto new_var = std::make_shared<Var>(assign->var_->name_hint_, half_type, assign->var_->span_);
           auto shard_typed =
               std::make_shared<Call>(shard->op_, shard->args_, shard->kwargs_, half_type, shard->span_);

--- a/src/ir/transforms/utils/dead_code_elimination.cpp
+++ b/src/ir/transforms/utils/dead_code_elimination.cpp
@@ -30,6 +30,7 @@
 #include "pypto/ir/transforms/utils/mutable_copy.h"
 #include "pypto/ir/transforms/utils/scope_outline_utils.h"
 #include "pypto/ir/transforms/utils/transform_utils.h"
+#include "pypto/ir/transforms/utils/var_collectors.h"
 #include "pypto/ir/type.h"
 
 namespace pypto {
@@ -307,10 +308,61 @@ std::vector<StmtPtr> FilterDeadCodeImpl(const std::vector<StmtPtr>& stmts,
   return result;
 }
 
+/// Control-flow binders carry types too, and an SSA binder is not an AssignStmt,
+/// so the per-assign type sweep below never sees it. A loop carry or branch
+/// result whose TileView::valid_shape is a per-lane extent over the region's
+/// subblock index would therefore leave that index looking unused. Seed those
+/// references as live roots.
+void MarkBinderTypeRefsLive(const std::vector<StmtPtr>& stmts, std::unordered_set<const Var*>& live) {
+  auto mark = [&live](const VarPtr& var) {
+    if (!var) {
+      return;
+    }
+    for (const Var* ref : var_collectors::CollectTypeVars(var->GetType())) {
+      live.insert(ref);
+    }
+  };
+  auto mark_all = [&mark](const auto& binders) {
+    for (const auto& binder : binders) {
+      mark(binder);
+    }
+  };
+  for (const auto& stmt : stmts) {
+    if (auto for_stmt = std::dynamic_pointer_cast<const ForStmt>(stmt)) {
+      mark_all(for_stmt->iter_args_);
+      mark_all(for_stmt->return_vars_);
+      MarkBinderTypeRefsLive(transform_utils::FlattenToStmts(for_stmt->body_), live);
+      continue;
+    }
+    if (auto while_stmt = std::dynamic_pointer_cast<const WhileStmt>(stmt)) {
+      mark_all(while_stmt->iter_args_);
+      mark_all(while_stmt->return_vars_);
+      MarkBinderTypeRefsLive(transform_utils::FlattenToStmts(while_stmt->body_), live);
+      continue;
+    }
+    if (auto if_stmt = std::dynamic_pointer_cast<const IfStmt>(stmt)) {
+      mark_all(if_stmt->return_vars_);
+      MarkBinderTypeRefsLive(transform_utils::FlattenToStmts(if_stmt->then_body_), live);
+      if (if_stmt->else_body_.has_value()) {
+        MarkBinderTypeRefsLive(transform_utils::FlattenToStmts(*if_stmt->else_body_), live);
+      }
+      continue;
+    }
+    if (auto seq = std::dynamic_pointer_cast<const SeqStmts>(stmt)) {
+      MarkBinderTypeRefsLive(seq->stmts_, live);
+      continue;
+    }
+    if (auto scope = std::dynamic_pointer_cast<const ScopeStmt>(stmt)) {
+      MarkBinderTypeRefsLive(transform_utils::FlattenToStmts(scope->body_), live);
+    }
+  }
+}
+
 std::vector<StmtPtr> EliminateDeadCodeCore(const std::vector<StmtPtr>& stmts,
                                            const RemovablePredicate& is_removable) {
   std::unordered_set<const Var*> live;
   FindLiveRootsRecursiveImpl(stmts, is_removable, live);
+  MarkBinderTypeRefsLive(stmts, live);
 
   std::vector<std::shared_ptr<const AssignStmt>> all_assigns;
   CollectAllAssignStmts(stmts, all_assigns);
@@ -323,7 +375,17 @@ std::vector<StmtPtr> EliminateDeadCodeCore(const std::vector<StmtPtr>& stmts,
   for (const auto& assign : all_assigns) {
     outline_utils::VarDefUseCollector collector;
     collector.VisitExpr(assign->value_);
-    assign_uses.emplace_back(std::move(collector.var_uses));
+    auto uses = std::move(collector.var_uses);
+    // A Var can also be referenced from a TYPE, not just from an expression: a
+    // tile's valid_shape may be a per-lane extent over the region's subblock
+    // index (split_axis::LocalizeExplicitBoundaryValid). Those are real uses —
+    // the use-after-def verifier already walks type expr fields
+    // (verify_use_after_def.cpp) — so missing them here would delete the
+    // subblock-index binding and leave the type dangling.
+    for (const Var* ref : var_collectors::CollectTypeVars(assign->var_->GetType())) {
+      uses.insert(ref);
+    }
+    assign_uses.emplace_back(std::move(uses));
   }
 
   bool changed = true;

--- a/src/ir/transforms/utils/split_axis_utils.cpp
+++ b/src/ir/transforms/utils/split_axis_utils.cpp
@@ -32,7 +32,9 @@
 #include "pypto/ir/scalar_expr.h"
 #include "pypto/ir/span.h"
 #include "pypto/ir/stmt.h"
+#include "pypto/ir/tile_view_semantics.h"
 #include "pypto/ir/transforms/base/visitor.h"
+#include "pypto/ir/transforms/printer.h"
 #include "pypto/ir/transforms/utils/auto_name_utils.h"
 #include "pypto/ir/transforms/utils/loop_state_repair.h"
 #include "pypto/ir/transforms/utils/mutable_copy.h"
@@ -132,10 +134,15 @@ ExprPtr LocalizeValidDimForSplit(const ExprPtr& valid_dim, const ExprPtr& origin
   }
 
   auto span = valid_dim->span_;
-  auto zero = MakeConstLike(valid_dim, 0, span);
   auto subblock_offset = MakeMul(subblock_idx, half_dim_size, span);
-  auto remaining = MakeSub(valid_dim, subblock_offset, span);
-  return MakeMax(MakeMin(remaining, half_dim_size, span), zero, span);
+  // Saturating subtract, NOT `max(valid - offset, 0)`: a valid extent can carry
+  // an UNSIGNED dtype (tile.set_validshape accepts UINT64), where `valid -
+  // offset` wraps to a huge value for the lane the extent does not reach and the
+  // clamp would then hand that lane a FULL half instead of nothing. Clamping the
+  // minuend first is correct for both signednesses.
+  auto reached = MakeMax(valid_dim, subblock_offset, span);
+  auto remaining = MakeSub(reached, subblock_offset, span);
+  return MakeMin(remaining, half_dim_size, span);
 }
 
 // Whether a tile.set_validshape split-axis operand must be localized to the
@@ -957,6 +964,436 @@ SubblockInjectionResult InjectSubblockIdxIntoStmts(const std::vector<StmtPtr>& r
   auto assign_stmt = std::make_shared<AssignStmt>(subblock_idx_var, subblock_call, span);
   body_stmts.insert(body_stmts.begin(), assign_stmt);
   return {subblock_idx_var, std::move(body_stmts), std::move(names)};
+}
+
+namespace {
+
+CallPtr AsCall(const ExprPtr& expr) { return std::dynamic_pointer_cast<const Call>(expr); }
+
+// Replace one axis of a TileType's valid_shape, preserving everything else about
+// the type (layout, memref, memory space) — the localization is metadata-only.
+TypePtr WithValidDim(const std::shared_ptr<const TileType>& tt, int dim, const ExprPtr& valid_dim) {
+  TileView tv = tile_view_semantics::GetEffectiveTileView(*tt);
+  INTERNAL_CHECK(dim >= 0 && dim < static_cast<int>(tv.valid_shape.size()))
+      << "Internal error: split dim " << dim << " out of range for a rank-" << tv.valid_shape.size()
+      << " valid_shape";
+  tv.valid_shape[dim] = valid_dim;
+  return std::make_shared<TileType>(tt->shape_, tt->dtype_, tt->memref_, std::move(tv), tt->memory_space_);
+}
+
+// A consumer PASSES THROUGH the split-axis extent when its result is the same
+// physical box as the operand and carries the operand's own (pre-localization)
+// valid extents — an elementwise op, a cast, a move. A consumer that reshapes
+// the logical rectangle (a reduction, a slice, an extract) reports a different
+// valid_shape, and rewriting its split-axis extent to the lane's would be a lie
+// about what it computes; those are rejected by the caller instead.
+bool PassesThroughValidShape(const std::shared_ptr<const TileType>& operand_before,
+                             const std::shared_ptr<const TileType>& result) {
+  if (!operand_before || !result) return false;
+  if (!tile_view_semantics::ShapeExprListsEquivalent(operand_before->shape_, result->shape_)) {
+    return false;
+  }
+  return tile_view_semantics::ShapeExprListsEquivalent(
+      tile_view_semantics::GetEffectiveTileView(*operand_before).valid_shape,
+      tile_view_semantics::GetEffectiveTileView(*result).valid_shape);
+}
+
+bool IsProvablyPositive(const ExprPtr& extent) {
+  auto c = std::dynamic_pointer_cast<const ConstInt>(extent);
+  return c != nullptr && c->value_ > 0;
+}
+
+// What a tracked (localized) var carries: the per-lane extent now on its split
+// axis, plus the type it had BEFORE localization, which is what a consumer's
+// deduced valid_shape is compared against to decide pass-through.
+struct LocalizedTile {
+  ExprPtr lane_extent;                     ///< clamp(V - idx*half, 0, half)
+  ExprPtr joined_extent;                   ///< V, the pre-shard extent a gather restores
+  std::shared_ptr<const TileType> before;  ///< the type before localization
+};
+
+}  // namespace
+
+TypePtr LocalizeShardValidForLane(const TypePtr& shard_type, const TypePtr& operand_type, int split_dim,
+                                  const ExprPtr& subblock_idx) {
+  auto shard = std::dynamic_pointer_cast<const TileType>(shard_type);
+  auto operand = std::dynamic_pointer_cast<const TileType>(operand_type);
+  if (!shard || !operand || !subblock_idx || split_dim < 0 ||
+      split_dim >= static_cast<int>(shard->shape_.size()) ||
+      split_dim >= static_cast<int>(operand->shape_.size())) {
+    return shard_type;
+  }
+  const auto operand_valid = tile_view_semantics::GetEffectiveTileView(*operand).valid_shape;
+  // A fully-valid split axis needs no repair: both lanes hold `half`, which is
+  // exactly what ReshapeSplitAxis already produced.
+  if (static_cast<int>(operand_valid.size()) <= split_dim ||
+      AreExprsEqual(operand_valid[split_dim], operand->shape_[split_dim])) {
+    return shard_type;
+  }
+  auto lane_extent = LocalizeValidDimForSplit(operand_valid[split_dim], operand->shape_[split_dim],
+                                              shard->shape_[split_dim], subblock_idx);
+  return WithValidDim(shard, split_dim, lane_extent);
+}
+
+namespace {
+
+/// Mutable state threaded through the (recursive) localization walk.
+struct LocalizeState {
+  std::unordered_map<const Var*, LocalizedTile> tracked;
+  std::unordered_map<const Var*, VarPtr> replacements;
+  ExprPtr lane_index;                                  ///< the region's aiv_id, resolved lazily
+  std::unordered_set<const Var*> chained_store_dests;  ///< region-wide, indexed once
+};
+
+std::vector<StmtPtr> LocalizeStmts(const std::vector<StmtPtr>& stmts, int split_dim, const Span& span,
+                                   LocalizeState& state);
+
+/// Recurse into a nested body, preserving its statement kind.
+StmtPtr LocalizeNestedBody(const StmtPtr& body, int split_dim, const Span& span, LocalizeState& state) {
+  if (!body) return body;
+  auto inner = LocalizeStmts(transform_utils::FlattenToStmts(body), split_dim, span, state);
+  if (inner.size() == 1) return inner[0];
+  return std::make_shared<SeqStmts>(inner, body->span_);
+}
+
+/// Whether another ``tile.store`` in this body writes THROUGH `var`, i.e. takes
+/// it as its destination tensor (arg 2) — a chained store.
+///
+/// This is the one read that makes the empty-lane guard unsafe, because it
+/// orders two stores against each other: skipping the first would leave the
+/// second writing through a tensor version that was never produced. Every other
+/// read of a store's SSA result is benign. It is a destination-passing alias of
+/// a tensor the region does not own, so a phi that carries it out of a branch,
+/// or the enclosing function threading it to a return, still denotes the SAME
+/// buffer — an empty lane that stored nothing leaves exactly the value any
+/// reader must see, and ExpandMixedKernel drops the alias from the AIV half.
+/// Indexed ONCE over the whole region, recursively: a chained store nested in a
+/// branch or a loop orders against an outer store just as a sibling one does, so
+/// a sibling-only scan would miss it and wrongly allow the empty-lane guard.
+/// Building the index up front also keeps the walk linear in the region size
+/// instead of quadratic in its store count (see `.claude/rules/pass-complexity.md`).
+///
+/// A store's own destination is an operand, never its SSA result, so a store can
+/// never place its own result in this set; no self-exclusion is needed.
+void CollectChainedStoreDestinations(const std::vector<StmtPtr>& stmts, std::unordered_set<const Var*>* out) {
+  for (const auto& s : stmts) {
+    if (auto for_stmt = std::dynamic_pointer_cast<const ForStmt>(s)) {
+      CollectChainedStoreDestinations(transform_utils::FlattenToStmts(for_stmt->body_), out);
+      continue;
+    }
+    if (auto while_stmt = std::dynamic_pointer_cast<const WhileStmt>(s)) {
+      CollectChainedStoreDestinations(transform_utils::FlattenToStmts(while_stmt->body_), out);
+      continue;
+    }
+    if (auto if_stmt = std::dynamic_pointer_cast<const IfStmt>(s)) {
+      CollectChainedStoreDestinations(transform_utils::FlattenToStmts(if_stmt->then_body_), out);
+      if (if_stmt->else_body_.has_value()) {
+        CollectChainedStoreDestinations(transform_utils::FlattenToStmts(*if_stmt->else_body_), out);
+      }
+      continue;
+    }
+    if (auto seq = std::dynamic_pointer_cast<const SeqStmts>(s)) {
+      CollectChainedStoreDestinations(seq->stmts_, out);
+      continue;
+    }
+    auto assign = std::dynamic_pointer_cast<const AssignStmt>(s);
+    auto call = assign ? AsCall(assign->value_) : nullptr;
+    if (!call || !IsOp(call, "tile.store") || call->args_.size() < 3) continue;
+    if (auto dest = AsVarLike(call->args_[2])) out->insert(dest.get());
+  }
+}
+
+/// A loop carry seeded by a localized (per-lane) tile would need its `IterArg`
+/// and the paired return var retyped to the lane's extent. Those are separate
+/// SSA definitions that this walk does not rebuild, so the carry would keep the
+/// deducer's lane-agnostic type while its init value carries the lane's — the
+/// silent-wrong-data shape this pass exists to remove. Refuse it explicitly
+/// instead, naming the authoring that avoids it.
+void RejectLocalizedCarry(const std::vector<IterArgPtr>& iter_args, const char* loop_form, const Span& span,
+                          const LocalizeState& state) {
+  for (const auto& iter_arg : iter_args) {
+    if (!iter_arg) continue;
+    auto init = AsVarLike(iter_arg->initValue_);
+    if (!init) continue;
+    auto replaced = state.replacements.find(init.get());
+    const Var* key = (replaced != state.replacements.end()) ? replaced->second.get() : init.get();
+    auto it = state.tracked.find(key);
+    if (it == state.tracked.end()) continue;
+    CHECK_SPAN(false, span)
+        << "pl.split_aiv: carrying a per-lane cross-core value across a " << loop_form
+        << " boundary is not supported. '" << iter_arg->name_hint_
+        << "' is seeded by a value whose split-axis extent differs per lane ("
+        << PythonPrint(it->second.lane_extent)
+        << "), but a loop carry is a separate binding that would keep the lane-agnostic extent.\n"
+        << "Author one of these instead:\n"
+        << "  * keep the shard and everything that consumes it inside the loop body\n"
+        << "  * make the split axis fully valid before the crossing (pl.set_validshape to the full "
+           "extent) and treat the padding as don't-care\n"
+        << "  * store the per-lane shard before the loop and reload it inside";
+  }
+}
+
+std::vector<StmtPtr> LocalizeStmts(const std::vector<StmtPtr>& stmts, int split_dim, const Span& span,
+                                   LocalizeState& state) {
+  std::vector<StmtPtr> result;
+  result.reserve(stmts.size());
+
+  for (const auto& stmt : stmts) {
+    // --- Control flow: the repair must reach as deep as the region does. ------
+    // A shard, a consumer or a store nested in a loop or a branch is ordinary
+    // authoring (a per-lane tail stored under `if`, a shard inside `pl.range`),
+    // and a flat walk would leave it on the deducer's lane-agnostic ceil(V/2).
+    if (auto for_stmt = std::dynamic_pointer_cast<const ForStmt>(stmt)) {
+      auto new_body = LocalizeNestedBody(for_stmt->body_, split_dim, span, state);
+      RejectLocalizedCarry(for_stmt->iter_args_, "pl.range", for_stmt->span_, state);
+      result.push_back(new_body == for_stmt->body_
+                           ? stmt
+                           : loop_repair::RebuildForStmt(for_stmt, for_stmt->iter_args_, new_body,
+                                                         for_stmt->return_vars_));
+      continue;
+    }
+    if (auto while_stmt = std::dynamic_pointer_cast<const WhileStmt>(stmt)) {
+      auto new_body = LocalizeNestedBody(while_stmt->body_, split_dim, span, state);
+      RejectLocalizedCarry(while_stmt->iter_args_, "pl.while_", while_stmt->span_, state);
+      if (new_body == while_stmt->body_) {
+        result.push_back(stmt);
+      } else {
+        auto new_while = MutableCopy(while_stmt);
+        new_while->body_ = new_body;
+        result.push_back(new_while);
+      }
+      continue;
+    }
+    if (auto if_stmt = std::dynamic_pointer_cast<const IfStmt>(stmt)) {
+      auto new_then = LocalizeNestedBody(if_stmt->then_body_, split_dim, span, state);
+      std::optional<StmtPtr> new_else = if_stmt->else_body_;
+      if (if_stmt->else_body_.has_value()) {
+        new_else = LocalizeNestedBody(*if_stmt->else_body_, split_dim, span, state);
+      }
+      result.push_back(std::make_shared<IfStmt>(if_stmt->condition_, new_then, new_else,
+                                                if_stmt->return_vars_, if_stmt->span_));
+      continue;
+    }
+    if (auto seq = std::dynamic_pointer_cast<const SeqStmts>(stmt)) {
+      for (auto& s : LocalizeStmts(seq->stmts_, split_dim, span, state)) result.push_back(s);
+      continue;
+    }
+
+    auto assign = std::dynamic_pointer_cast<const AssignStmt>(stmt);
+    auto call = assign ? AsCall(assign->value_) : nullptr;
+    if (!assign || !call || !call->op_) {
+      result.push_back(stmt);
+      continue;
+    }
+
+    if (IsOp(call, "tile.get_subblock_idx")) {
+      state.lane_index = assign->var_;
+      result.push_back(stmt);
+      continue;
+    }
+
+    // --- The boundary itself: repair the deducer's ceil-div guess. -----------
+    if (IsOp(call, "tile.aiv_shard") && !call->args_.empty()) {
+      auto operand = std::dynamic_pointer_cast<const TileType>(call->args_[0]->GetType());
+      auto shard = std::dynamic_pointer_cast<const TileType>(call->GetType());
+      if (!operand || !shard || split_dim < 0 || split_dim >= static_cast<int>(shard->shape_.size())) {
+        result.push_back(stmt);
+        continue;
+      }
+      const auto operand_valid = tile_view_semantics::GetEffectiveTileView(*operand).valid_shape;
+      // A fully-valid split axis needs no repair: both lanes hold `half`, which
+      // is exactly what ReshapeSplitAxis already produced.
+      if (static_cast<int>(operand_valid.size()) <= split_dim ||
+          AreExprsEqual(operand_valid[split_dim], operand->shape_[split_dim])) {
+        result.push_back(stmt);
+        continue;
+      }
+      INTERNAL_CHECK_SPAN(state.lane_index, call->span_)
+          << "Internal error: a pl.split_aiv region with a partially-valid split axis has no "
+             "tile.get_subblock_idx binding, so the per-lane extent cannot be materialized";
+      auto new_type = LocalizeShardValidForLane(shard, operand, split_dim, state.lane_index);
+      auto lane_extent =
+          tile_view_semantics::GetEffectiveTileView(*std::dynamic_pointer_cast<const TileType>(new_type))
+              .valid_shape[split_dim];
+      auto new_var = std::make_shared<Var>(assign->var_->name_hint_, new_type, assign->var_->span_);
+      auto new_call = std::make_shared<Call>(call->op_, call->args_, call->kwargs_, new_type, call->span_);
+      state.replacements[assign->var_.get()] = new_var;
+      state.tracked[new_var.get()] = LocalizedTile{lane_extent, operand_valid[split_dim], shard};
+      result.push_back(std::make_shared<AssignStmt>(new_var, new_call, assign->span_));
+      continue;
+    }
+
+    // --- Consumers: carry the per-lane extent, or say why we cannot. ---------
+    const LocalizedTile* source = nullptr;
+    for (const auto& arg : call->args_) {
+      auto arg_var = AsVarLike(arg);
+      if (!arg_var) continue;
+      auto replaced = state.replacements.find(arg_var.get());
+      const Var* key = (replaced != state.replacements.end()) ? replaced->second.get() : arg_var.get();
+      auto it = state.tracked.find(key);
+      if (it != state.tracked.end()) {
+        source = &it->second;
+        break;
+      }
+    }
+    // tile.aic_gather is the region's EXIT: it re-joins the two lanes' bands and
+    // hands a FULL tile back to the cube. This is the one place the join can be
+    // typed correctly, because it is the only place the lanes' TRUE extents are
+    // known.
+    //
+    // Under the per-lane clamp the bands always abut, so the joined extent is
+    // exactly the pre-shard V:
+    //
+    //   V >  half : lane 0 saturates to half, lane 1 holds V - half
+    //               -> [0, half) U [half, V) = [0, V)
+    //   V <= half : lane 0 holds V, lane 1 is empty
+    //               -> [0, V) U {} = [0, V)
+    //
+    // The deducer cannot compute that. It runs before the lanes exist and can
+    // only double its own lane-agnostic guess (2 * ceil(V / 2)), which claims
+    // the hole between the bands as real data. So restore V here.
+    if (IsOp(call, "tile.aic_gather")) {
+      auto gathered = std::dynamic_pointer_cast<const TileType>(call->GetType());
+      if (source != nullptr && gathered && split_dim < static_cast<int>(gathered->shape_.size())) {
+        auto joined_type = WithValidDim(gathered, split_dim, source->joined_extent);
+        auto new_var = std::make_shared<Var>(assign->var_->name_hint_, joined_type, assign->var_->span_);
+        auto new_call =
+            std::make_shared<Call>(call->op_, call->args_, call->kwargs_, joined_type, call->span_);
+        state.replacements[assign->var_.get()] = new_var;
+        // The result is a FULL tile again, so it leaves the per-lane dataflow.
+        result.push_back(std::make_shared<AssignStmt>(new_var, new_call, assign->span_));
+        continue;
+      }
+      // Nothing localized this operand, so a provable partial is one the author
+      // gave BOTH lanes: the bands do not abut and no valid_shape describes the
+      // union. This is the check the deducer used to make on a value it could
+      // not see the truth of.
+      auto operand = call->args_.empty()
+                         ? nullptr
+                         : std::dynamic_pointer_cast<const TileType>(call->args_[0]->GetType());
+      if (operand && split_dim < static_cast<int>(operand->shape_.size())) {
+        const auto operand_valid = tile_view_semantics::GetEffectiveTileView(*operand).valid_shape;
+        auto valid_const = split_dim < static_cast<int>(operand_valid.size())
+                               ? std::dynamic_pointer_cast<const ConstInt>(operand_valid[split_dim])
+                               : nullptr;
+        auto half_const = std::dynamic_pointer_cast<const ConstInt>(operand->shape_[split_dim]);
+        const bool provably_partial = valid_const && half_const && valid_const->value_ < half_const->value_;
+        const char* axis_name = (split_dim == 0) ? "row" : "column";
+        CHECK_SPAN(!provably_partial, call->span_)
+            << "pl.split_aiv: tile.aic_gather re-joins the two lanes positionally, but each lane's "
+               "valid "
+            << axis_name << " extent (" << valid_const->value_ << " of " << half_const->value_
+            << ") covers only part of its half, so the lanes contribute the disjoint bands [0, "
+            << valid_const->value_ << ") and [" << half_const->value_ << ", "
+            << (half_const->value_ + valid_const->value_)
+            << ") of the re-joined tile. No valid_shape describes that union.\n"
+            << "Author one of these instead:\n"
+            << "  * make each lane's half fully valid before the gather -- pl.fillpad(v) to fill the "
+               "padding with data, or pl.set_validshape(v, <full half extent>, ...) to declare it "
+               "data -- so the bands abut\n"
+            << "  * let the shard's own per-lane extent flow into the gather instead of overriding "
+               "it: a shard-then-gather round trip re-joins exactly the pre-shard extent";
+      }
+      result.push_back(stmt);
+      continue;
+    }
+    if (source == nullptr) {
+      result.push_back(stmt);
+      continue;
+    }
+
+    auto consumer_result = std::dynamic_pointer_cast<const TileType>(call->GetType());
+    if (!consumer_result) {
+      // Not a tile result (tile.store returns a Tensor, system.tfree returns
+      // nothing): the op reads the extent but does not carry it onward, which is
+      // exactly where the per-lane extent is meant to land.
+      //
+      // The store is the one consumer that must not see an EMPTY lane. When the
+      // ragged extent does not reach the second lane (V <= half) that lane's
+      // extent is 0, and a zero-row store is outside pto-isa's contract:
+      // TSTORE_IMPL asserts ``src.GetValidRow() > 0 && src.GetValidCol() > 0``
+      // (npu/a2a3/TStore.hpp) and PTOAS's PartitionViewOp rejects a statically
+      // non-positive size. A release build compiles the assert out and the DMA
+      // moves nothing, but a debug / CPU-sim / CA-model build traps. So guard
+      // the store on a non-empty lane. The tpop and the tfree stay
+      // UNCONDITIONAL: both lanes must still pop and free the slot or the pipe
+      // desynchronizes.
+      if (IsOp(call, "tile.store") && !IsProvablyPositive(source->lane_extent)) {
+        // The guard can be a plain IfStmt because a store's SSA result is a
+        // destination-passing alias (see CollectChainedStoreDestinations). Only a
+        // CHAINED store makes that unsafe — skipping the first store would leave
+        // the second writing through a tensor version that was never produced —
+        // and guarding it would need a return-carrying if (a phi over stored /
+        // not-stored). Report that shape instead of emitting an unguarded
+        // zero-row store.
+        CHECK_SPAN(state.chained_store_dests.count(assign->var_.get()) == 0, call->span_)
+            << "pl.split_aiv: a store whose result feeds another store cannot be guarded against an "
+               "empty lane. The split axis is only partially valid, so one lane's extent can be 0 at "
+               "runtime ("
+            << PythonPrint(source->lane_extent) << "), and a zero-row store is outside the ISA contract.\n"
+            << "Author one of these instead:\n"
+            << "  * write the per-lane shard to its destination with a single subscript assignment "
+               "inside the region\n"
+            << "  * make the split axis fully valid before the crossing (pl.set_validshape to the "
+               "full extent) so every lane is non-empty";
+        auto zero = std::make_shared<ConstInt>(0, GetScalarDtype(source->lane_extent), call->span_);
+        auto non_empty = MakeGt(source->lane_extent, zero, call->span_);
+        result.push_back(
+            std::make_shared<IfStmt>(non_empty, stmt, std::nullopt, std::vector<VarPtr>{}, call->span_));
+        continue;
+      }
+      result.push_back(stmt);
+      continue;
+    }
+
+    // A consumer that WIDENS the logical region back to the whole physical box
+    // (a set_validshape to the full extent) deliberately drops the per-lane
+    // extent — the author is declaring the padding to be data. Nothing to carry.
+    if (tile_view_semantics::ShapeExprListsEquivalent(
+            tile_view_semantics::GetEffectiveTileView(*consumer_result).valid_shape,
+            consumer_result->shape_)) {
+      result.push_back(stmt);
+      continue;
+    }
+    CHECK_SPAN(PassesThroughValidShape(source->before, consumer_result), call->span_)
+        << "pl.split_aiv: '" << call->op_->name_
+        << "' reshapes the logical valid region of a per-lane cross-core value, which is not "
+           "supported. The shard's split-axis extent differs per lane ("
+        << PythonPrint(source->lane_extent)
+        << "), and that extent can only be carried by ops that pass the valid_shape through "
+           "unchanged — the boundary offers no way to re-narrow a popped tile afterwards.\n"
+        << "Author one of these instead:\n"
+        << "  * do the reshaping compute on the CUBE side, before pl.aiv_shard\n"
+        << "  * make the split axis fully valid before the crossing "
+           "(pl.set_validshape to the full extent) and treat the padding as don't-care\n"
+        << "  * store the per-lane shard first, and reshape in a later kernel";
+    auto new_type = WithValidDim(consumer_result, split_dim, source->lane_extent);
+    auto new_var = std::make_shared<Var>(assign->var_->name_hint_, new_type, assign->var_->span_);
+    auto new_call = std::make_shared<Call>(call->op_, call->args_, call->kwargs_, new_type, call->span_);
+    state.replacements[assign->var_.get()] = new_var;
+    state.tracked[new_var.get()] = LocalizedTile{source->lane_extent, source->joined_extent, consumer_result};
+    result.push_back(std::make_shared<AssignStmt>(new_var, new_call, assign->span_));
+  }
+
+  return result;
+}
+
+}  // namespace
+
+std::vector<StmtPtr> LocalizeExplicitBoundaryValid(const std::vector<StmtPtr>& stmts, int split_dim,
+                                                   const Span& region_span) {
+  LocalizeState state;
+  CollectChainedStoreDestinations(stmts, &state.chained_store_dests);
+  auto result = LocalizeStmts(stmts, split_dim, region_span, state);
+
+  if (state.replacements.empty()) {
+    return result;
+  }
+  // One final substitution re-points every downstream use (including the ones
+  // inside nested control flow) at the retyped vars, mirroring how the AUTO
+  // halving path finishes in ProcessStmts.
+  StmtPtr body = (result.size() == 1) ? result[0] : std::make_shared<SeqStmts>(result, region_span);
+  return transform_utils::FlattenToStmts(transform_utils::Substitute(body, state.replacements));
 }
 
 namespace {

--- a/tests/st/codegen/dsl/test_split_aiv_ragged_split_axis_codegen.py
+++ b/tests/st/codegen/dsl/test_split_aiv_ragged_split_axis_codegen.py
@@ -1,0 +1,331 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""A partially-valid accumulator crossing ``pl.aiv_shard``: what the boundary carries.
+
+An accumulator whose valid region does not fill its physical box is the ragged
+tail of a real kernel (a vocab or sequence remainder). Which of those shapes the
+AIC/AIV boundary can carry follows from one fact about the Cube->Vector FIFO:
+pto-isa strides the GM slot view with the popped tile's RUNTIME ``validCol`` but
+takes the row count from the COMPILE-TIME box (``TLoadGm2ubNd2nd``:
+``lenBurst = validCol``, ``gmGap = gStride3 - gShape4``, ``nBurst = gShape3``).
+
+So the column field is spoken for and the row field is free:
+
+* UP_DOWN makes the ROW extent per-lane -> it rides on the TPOP ``valid_row``
+  operand, and this file guards that it does (and that the empty lane's store is
+  skipped, since a zero-row TSTORE is outside pto-isa's contract).
+* LEFT_RIGHT makes the COLUMN extent per-lane -> no carrier, so it must be
+  rejected with an actionable message rather than silently truncated.
+
+Before this was handled, both shapes silently truncated BOTH lanes to
+``ceil(V / 2)`` — the split deducer's lane-agnostic guess.
+"""
+
+import re
+import shutil
+from pathlib import Path
+
+import pypto.language as pl
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from pypto.runtime import RunConfig  # noqa: E402
+
+DUMP_DIR = Path(__file__).resolve().parents[4] / "build_output" / "split_aiv_ragged_split_axis"
+
+ROWS, COLS, K = 16, 256, 256
+HALF = ROWS // 2
+VALID_M = 5  # real accumulator rows: reaches lane 0 only
+VALID_N = 32  # real accumulator columns
+
+
+@pl.jit
+def ragged_rows(
+    a: pl.Tensor[[VALID_M, K], pl.BF16],
+    w: pl.Tensor[[COLS, K], pl.BF16],
+    out: pl.Out[pl.Tensor[[ROWS, COLS], pl.FP32]],
+) -> pl.Tensor[[ROWS, COLS], pl.FP32]:
+    """UP_DOWN over an accumulator valid to VALID_M of ROWS rows."""
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="ragged_rows"):
+        a_tile = pl.slice(a, [ROWS, K], [0, 0], valid_shape=[VALID_M, K])
+        acc = pl.matmul(a_tile, w[0:COLS, 0:K], b_trans=True, out_dtype=pl.FP32)
+        for aiv_id in pl.split_aiv(2, mode=pl.SplitMode.UP_DOWN):
+            shard = pl.aiv_shard(acc)
+            out[aiv_id * HALF : aiv_id * HALF + HALF, 0:COLS] = shard
+    return out
+
+
+@pl.jit
+def ragged_cols_left_right(
+    a: pl.Tensor[[ROWS, K], pl.BF16],
+    w: pl.Tensor[[VALID_N, K], pl.BF16],
+    out: pl.Out[pl.Tensor[[ROWS, COLS], pl.FP32]],
+) -> pl.Tensor[[ROWS, COLS], pl.FP32]:
+    """LEFT_RIGHT over an accumulator valid to VALID_N of COLS columns."""
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="ragged_cols"):
+        w_tile = pl.slice(w, [COLS, K], [0, 0], valid_shape=[VALID_N, K])
+        acc = pl.matmul(a[0:ROWS, 0:K], w_tile, b_trans=True, out_dtype=pl.FP32)
+        for aiv_id in pl.split_aiv(2, mode=pl.SplitMode.LEFT_RIGHT):
+            shard = pl.aiv_shard(acc)
+            out[0:ROWS, aiv_id * (COLS // 2) : aiv_id * (COLS // 2) + COLS // 2] = shard
+    return out
+
+
+@pl.jit
+def ragged_rows_and_cols(
+    a: pl.Tensor[[VALID_M, K], pl.BF16],
+    w: pl.Tensor[[VALID_N, K], pl.BF16],
+    out: pl.Out[pl.Tensor[[ROWS, COLS], pl.FP32]],
+) -> pl.Tensor[[ROWS, COLS], pl.FP32]:
+    """UP_DOWN with BOTH a per-lane row extent and a narrowed column extent."""
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="ragged_both"):
+        a_tile = pl.slice(a, [ROWS, K], [0, 0], valid_shape=[VALID_M, K])
+        w_tile = pl.slice(w, [COLS, K], [0, 0], valid_shape=[VALID_N, K])
+        acc = pl.matmul(a_tile, w_tile, b_trans=True, out_dtype=pl.FP32)
+        for aiv_id in pl.split_aiv(2, mode=pl.SplitMode.UP_DOWN):
+            shard = pl.aiv_shard(acc)
+            out[aiv_id * HALF : aiv_id * HALF + HALF, 0:COLS] = shard
+    return out
+
+
+@pl.jit
+def ragged_rows_nested(
+    a: pl.Tensor[[VALID_M, K], pl.BF16],
+    w: pl.Tensor[[COLS, K], pl.BF16],
+    out: pl.Out[pl.Tensor[[ROWS, COLS], pl.FP32]],
+) -> pl.Tensor[[ROWS, COLS], pl.FP32]:
+    """The same crossing, with the store nested in a branch.
+
+    The shard itself stays at region top level — both lanes must pop the slot —
+    but its consumer sits inside control flow that survives to pass 20 (a
+    ``pl.range`` with a small constant trip count would be unrolled away long
+    before then).
+    """
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="ragged_nested"):
+        a_tile = pl.slice(a, [ROWS, K], [0, 0], valid_shape=[VALID_M, K])
+        acc = pl.matmul(a_tile, w[0:COLS, 0:K], b_trans=True, out_dtype=pl.FP32)
+        for aiv_id in pl.split_aiv(2, mode=pl.SplitMode.UP_DOWN):
+            shard = pl.aiv_shard(acc)
+            if aiv_id == 0:
+                out[0:HALF, 0:COLS] = shard
+    return out
+
+
+@pl.jit
+def ragged_rows_with_compute(
+    a: pl.Tensor[[VALID_M, K], pl.BF16],
+    w: pl.Tensor[[COLS, K], pl.BF16],
+    out: pl.Out[pl.Tensor[[ROWS, COLS], pl.FP32]],
+) -> pl.Tensor[[ROWS, COLS], pl.FP32]:
+    """A vector op between the shard and its store, so the extent must PROPAGATE."""
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="ragged_compute"):
+        a_tile = pl.slice(a, [ROWS, K], [0, 0], valid_shape=[VALID_M, K])
+        acc = pl.matmul(a_tile, w[0:COLS, 0:K], b_trans=True, out_dtype=pl.FP32)
+        for aiv_id in pl.split_aiv(2, mode=pl.SplitMode.UP_DOWN):
+            shard = pl.aiv_shard(acc)
+            scaled = pl.exp(shard)
+            out[aiv_id * HALF : aiv_id * HALF + HALF, 0:COLS] = scaled
+    return out
+
+
+@pl.jit
+def hand_authored_partial_gather(
+    x: pl.Tensor[[ROWS, K], pl.BF16],
+    q: pl.Tensor[[ROWS, K], pl.BF16],
+    out: pl.Out[pl.Tensor[[ROWS, ROWS], pl.FP32]],
+) -> pl.Tensor[[ROWS, ROWS], pl.FP32]:
+    """Both lanes hold the SAME partial extent, so their bands do not abut."""
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="partial_gather", allow_early_resolve=True):
+        for aiv_id in pl.split_aiv(2, mode=pl.SplitMode.UP_DOWN):
+            lane = pl.slice(x, [HALF, K], [aiv_id * HALF, 0], valid_shape=[VALID_M, K])
+            joined = pl.aic_gather(lane)
+        out[0:ROWS, 0:ROWS] = pl.matmul(q, joined, b_trans=True, out_dtype=pl.FP32)
+    return out
+
+
+def _aiv_body(program_text: str) -> str:
+    """The lowered AIV half. The outlined name is <jit>_<name_hint>_aiv, so it is
+    matched by suffix rather than spelled out."""
+    match = re.search(r"def (\w+_aiv)\(", program_text)
+    assert match, program_text[:400]
+    return program_text.split(f"def {match.group(1)}")[1].split("\n    def ")[0]
+
+
+def _pto_aiv(pto_text: str) -> str:
+    """The AIV kernel body. Split on the DEFINITION, not the bare symbol — the
+    cube half references the vector kernel by name too."""
+    match = re.search(r"func\.func @(\w+_aiv)\(", pto_text)
+    assert match, pto_text[:400]
+    return pto_text.split(f"func.func @{match.group(1)}(")[1].split("func.func")[0]
+
+
+_PTO_CACHE: dict[str, str] = {}
+
+
+def _ragged_rows_pto() -> str:
+    """Codegen-only .pto for `ragged_rows`, emitted once and shared.
+
+    PTO codegen writes the .pto before the downstream kernel-compilation step
+    (simpler_setup), which is absent in a codegen-only CI env, so a post-codegen
+    failure is captured rather than raised. The result is cached because a second
+    compile into the same directory tries to LOAD it as a built artifact.
+    """
+    if "pto" in _PTO_CACHE:
+        return _PTO_CACHE["pto"]
+    if DUMP_DIR.exists():
+        shutil.rmtree(DUMP_DIR)
+    cfg = RunConfig(platform="a2a3", codegen_only=True, save_kernels=True, save_kernels_dir=str(DUMP_DIR))
+    error: Exception | None = None
+    try:
+        ragged_rows(*_ragged_rows_args(), config=cfg)
+    except Exception as e:  # noqa: BLE001 - see docstring
+        error = e
+    ptos = sorted(DUMP_DIR.rglob("*.pto"))
+    assert ptos, f"codegen emitted no .pto under {DUMP_DIR}; compile raised: {error!r}"
+    _PTO_CACHE["pto"] = ptos[0].read_text()
+    return _PTO_CACHE["pto"]
+
+
+def _ragged_rows_args():
+    return [
+        torch.randn(VALID_M, K, dtype=torch.bfloat16),
+        torch.randn(COLS, K, dtype=torch.bfloat16),
+        torch.empty(ROWS, COLS, dtype=torch.float32),
+    ]
+
+
+def test_ragged_rows_localize_to_a_per_lane_extent():
+    """Each lane gets clamp(V - lane*half, 0, half), not the deducer's ceil(V/2).
+
+    ceil(5 / 2) = 3 would drop rows 3 and 4 on lane 0 and fabricate three rows on
+    lane 1; the truth is 5 rows on lane 0 and none on lane 1.
+    """
+    aiv = _aiv_body(str(ragged_rows.lower(config=RunConfig(platform="a2a3"))))
+
+    assert "pl.tile.tpop_from_aic(split=1)" in aiv
+    # The per-lane extent is an expression over the region's own lane index.
+    assert re.search(r"valid_shape=\[pl\.max\(pl\.const\(5.*?\) - \w+ \* pl\.const\(8", aiv), aiv
+    assert "valid_shape=[3," not in aiv, f"ceil(V/2) must not survive:\n{aiv}"
+
+
+def test_ragged_rows_transport_keeps_the_full_column_box():
+    """The row extent rides on TPOP; the column extent stays the physical box.
+
+    A narrowed column would collapse the FIFO's GM row gap (gmGap = gStride3 -
+    gShape4) and mis-stride the pop, so a full column is what makes the per-lane
+    row extent carriable at all — and it needs no pto.treshape to restore.
+    """
+    pto = _ragged_rows_pto()
+    aiv = _pto_aiv(pto)
+
+    pop = next(line for line in aiv.splitlines() if "pto.tpop_from_aic" in line)
+    assert re.search(r"pto\.tpop_from_aic\(%\w+, %c256_index\) \{split = 1\}", pop), pop
+    assert "pto.treshape" not in aiv, f"a full column extent needs no restore:\n{aiv}"
+
+
+def test_empty_lane_skips_the_store_but_still_pops_and_frees():
+    """A zero-row TSTORE is outside pto-isa's contract, so the store is guarded.
+
+    The tpop and the tfree must stay UNCONDITIONAL: both lanes hold a slot and
+    must release it, or the FIFO credit protocol desynchronizes.
+    """
+    pto = _ragged_rows_pto()
+    aiv = _pto_aiv(pto)
+    lines = [line.strip() for line in aiv.splitlines()]
+
+    guard = next(i for i, line in enumerate(lines) if line.startswith("scf.if"))
+    store = next(i for i, line in enumerate(lines) if "pto.tstore" in line)
+    pop = next(i for i, line in enumerate(lines) if "pto.tpop_from_aic" in line)
+    free = next(i for i, line in enumerate(lines) if "pto.tfree_from_aic" in line)
+
+    assert guard < store, f"the store must sit inside the empty-lane guard:\n{aiv}"
+    assert pop < guard, f"the pop must precede (and sit outside) the guard:\n{aiv}"
+    assert free > store, f"the free must follow the store:\n{aiv}"
+    # Neither pop nor free may be nested in the guard.
+    assert not any(
+        "pto.tpop_from_aic" in line or "pto.tfree_from_aic" in line for line in lines[guard:store]
+    ), aiv
+
+
+def test_nested_control_flow_is_repaired_too():
+    """The repair must reach as deep as the region does.
+
+    A flat walk over the region body would leave a shard nested in a loop or a
+    branch on the deducer's ceil(V/2) — silently, since nothing downstream can
+    tell a lane-agnostic extent from a lane-aware one.
+    """
+    aiv = _aiv_body(str(ragged_rows_nested.lower(config=RunConfig(platform="a2a3"))))
+
+    lane = re.search(r"= pl\.tile\.get_subblock_idx\(\)", aiv)
+    assert lane, aiv
+    # The extent must be an expression over the lane index, not a constant.
+    assert re.search(r"valid_shape=\[[^\]]*aiv_id[^\]]*,", aiv), (
+        f"the nested consumer must still see a lane-aware extent:\n{aiv}"
+    )
+    assert "valid_shape=[3," not in aiv, f"ceil(V/2) must not survive nesting:\n{aiv}"
+
+
+def test_per_lane_extent_propagates_through_a_vector_consumer():
+    """An extent-preserving consumer carries the per-lane extent to the store.
+
+    The store is what finally reads it, so an op between the shard and the store
+    must pass it through — otherwise the store would write the deducer's
+    ceil(V/2) rows.
+    """
+    aiv = _aiv_body(str(ragged_rows_with_compute.lower(config=RunConfig(platform="a2a3"))))
+
+    exp_line = next((line for line in aiv.splitlines() if "pl.tile.exp(" in line), None)
+    assert exp_line is not None, aiv
+    # Both the shard and the op that consumes it carry a lane-aware extent.
+    assert aiv.count("aiv_id") >= 2, aiv
+    assert "valid_shape=[3," not in aiv, f"ceil(V/2) must not reach the consumer:\n{aiv}"
+
+
+def test_hand_authored_partial_gather_is_rejected_where_the_lanes_are_known():
+    """The band rule lives in lowering, where the lanes' TRUE extents are known.
+
+    The diagnostic must quote the author's own extents, not the deducer's
+    lane-agnostic guess.
+    """
+    with pytest.raises(ValueError) as exc:
+        hand_authored_partial_gather.lower(config=RunConfig(platform="a2a3"))
+
+    message = str(exc.value)
+    assert "tile.aic_gather re-joins the two lanes positionally" in message
+    assert f"({VALID_M} of {HALF})" in message, message
+    assert "pl.fillpad" in message
+
+
+def test_left_right_ragged_columns_are_rejected_with_a_dsl_fix():
+    """The column field is pinned by the transport, so a per-lane column has no carrier."""
+    with pytest.raises(ValueError) as exc:
+        ragged_cols_left_right.lower(config=RunConfig(platform="a2a3"))
+
+    message = str(exc.value)
+    assert "LEFT_RIGHT splits the column axis" in message
+    assert "valid column extent (32 of 256)" in message
+    # The diagnostic must hand the author a way out, not just a refusal.
+    assert "mode=pl.SplitMode.UP_DOWN" in message
+    assert "pl.set_validshape" in message
+
+
+def test_ragged_rows_with_narrowed_columns_are_rejected():
+    """treshape restores the column extent statically and would clobber the per-lane row."""
+    with pytest.raises(ValueError) as exc:
+        ragged_rows_and_cols.lower(config=RunConfig(platform="a2a3"))
+
+    message = str(exc.value)
+    assert "per-lane row extent" in message
+    assert "pl.set_validshape" in message
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/ut/codegen/test_pto_codegen_cross_core.py
+++ b/tests/ut/codegen/test_pto_codegen_cross_core.py
@@ -784,6 +784,110 @@ class TestCrossCoreTpushTpopCodegen:
             f"restoration must use a metadata-only treshape:\n{consumer_code}"
         )
 
+    def test_split_acc_to_vec_pop_uses_full_box_for_tpop(self):
+        """A split C2V pop transports the full per-lane box, not the logical valid box.
+
+        pto-isa builds the GM slot view of a Cube->Vector pop from the popped
+        tile's compile-time rows/cols and the producer's box row pitch, but
+        strides it with the tile's runtime validCol
+        (``gmGap = gStride3 - gShape4``, ``lenBurst = validCol``). A narrowed
+        validCol therefore collapses the GM gap to zero and the lane reads one
+        contiguous run instead of one box row per burst — silent data loss in
+        the *valid* region, since the matching PTO_ASSERT is compiled out in
+        release. This is the consumer-side counterpart of the producer-side
+        widening already asserted by
+        ``test_split_tpush_uses_full_box_transport_dims``.
+        """
+        span = ir.Span.unknown()
+        zero = ir.ConstInt(0, pl.INDEX, span)
+        rows = ir.ConstInt(16, pl.INDEX, span)
+        cols = ir.ConstInt(32, pl.INDEX, span)
+        half_rows = ir.ConstInt(8, pl.INDEX, span)
+        valid_cols = ir.ConstInt(24, pl.INDEX, span)
+        offsets = ir.MakeTuple([zero, zero], span)
+        shape = ir.MakeTuple([rows, cols], span)
+        valid_shape = ir.MakeTuple([rows, valid_cols], span)
+
+        src = ir.Var("src", ir.TensorType([16, 32], pl.FP32), span)
+        acc_memref = ir.MemRef(ir.MemorySpace.Acc, ir.ConstInt(0, pl.INT64, span), 16 * 32 * 4, 0)
+        acc_type = ir.TileType(
+            [rows, cols],
+            pl.FP32,
+            acc_memref,
+            ir.TileView(valid_shape=[rows, valid_cols]),
+            ir.MemorySpace.Acc,
+        )
+        acc_tile = ir.Var("acc_tile", acc_type, span)
+        load_call = ir.Call(
+            ir.Op("tile.load"),
+            [src, offsets, shape, valid_shape],
+            {"target_memory": ir.MemorySpace.Acc},
+            acc_type,
+            span,
+        )
+        push_call = ir.Call(
+            ir.Op("tile.tpush_to_aiv"),
+            [acc_tile],
+            {"split": 1},
+            ir.UnknownType(),
+            span,
+        )
+        producer = ir.Function(
+            "split_acc_producer",
+            [(src, ir.ParamDirection.In)],
+            [],
+            ir.SeqStmts(
+                [ir.AssignStmt(acc_tile, load_call, span), ir.EvalStmt(push_call, span)],
+                span,
+            ),
+            span,
+            ir.FunctionType.AIC,
+        )
+
+        # Per-lane consumer half of an UP_DOWN split: [8, 32] box, logical [8, 24].
+        vec_type = ir.TileType(
+            [half_rows, cols],
+            pl.FP32,
+            None,
+            ir.TileView(valid_shape=[half_rows, valid_cols]),
+            ir.MemorySpace.Vec,
+        )
+        popped = ir.Var("popped", vec_type, span)
+        pop_call = ir.Call(ir.Op("tile.tpop_from_aic"), [], {"split": 1}, vec_type, span)
+        consumer = ir.Function(
+            "split_vec_consumer",
+            [],
+            [],
+            ir.SeqStmts([ir.AssignStmt(popped, pop_call, span)], span),
+            span,
+            ir.FunctionType.AIV,
+        )
+
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+        mlir_code = codegen.PTOCodegen().generate(
+            ir.Program([producer, consumer], "split_acc_to_vec_program", span)
+        )
+        consumer_code = _extract_func_section(mlir_code, "split_vec_consumer")
+        consumer_lines = [line.strip() for line in consumer_code.splitlines()]
+
+        pop_index = next(i for i, line in enumerate(consumer_lines) if "pto.tpop_from_aic" in line)
+        assert any("pto.treshape" in line for line in consumer_lines), (
+            "a full-box split pop must expose its logical valid shape through pto.treshape:\n" + consumer_code
+        )
+        reshape_index = next(i for i, line in enumerate(consumer_lines) if "pto.treshape" in line)
+        assert "pto.tpop_from_aic(%c8_index, %c32_index) {split = 1}" in consumer_lines[pop_index], (
+            "a split C2V pop must transport the full per-lane box; a narrowed valid_col "
+            f"mis-strides the GM slot read:\n{consumer_code}"
+        )
+        transport = re.search(r"^(%\w+) = pto\.tpop_from_aic", consumer_lines[pop_index])
+        assert transport is not None
+        assert pop_index < reshape_index
+        assert f"pto.treshape {transport.group(1)}" in consumer_lines[reshape_index]
+        assert "rows=8, cols=32, v_row=8, v_col=24" in consumer_lines[reshape_index], (
+            f"the logical per-lane valid shape must be restored by treshape:\n{consumer_code}"
+        )
+
     @pytest.mark.parametrize(
         (
             "tpush_op_name",

--- a/tests/ut/ir/test_cross_core_ops.py
+++ b/tests/ut/ir/test_cross_core_ops.py
@@ -226,6 +226,98 @@ def test_aic_gather_doubles_split_axis():
     assert left_right.type.shape == [16, 128]
 
 
+def _tile(shape, valid=None, dtype=DataType.FP32):
+    """A 2D tile type, optionally with a partial valid_shape."""
+    view = ir.TileView(valid_shape=valid) if valid is not None else None
+    return ir.TileType(shape, dtype, None, view)
+
+
+def test_shard_allows_ragged_split_axis_when_columns_are_full():
+    """A per-lane ROW extent is carried by the boundary, so UP_DOWN raggedness is legal.
+
+    The deducer still reports the lane-agnostic ceil-div here; the true per-lane
+    extent is materialized later by LowerAutoVectorSplit, which is the only place
+    the subblock index is in scope.
+    """
+    span = ir.Span.unknown()
+    tile_var = ir.Var("t", _tile([16, 128], [5, 128]), span)
+
+    shard = ir.create_op_call("tile.aiv_shard", [tile_var], {"split": 1}, span)
+    assert isinstance(shard.type, ir.TileType)
+    assert shard.type.shape == [8, 128]
+
+
+def test_shard_rejects_ragged_split_axis_on_left_right():
+    """LEFT_RIGHT makes the COLUMN extent per-lane, and the FIFO pins that field."""
+    span = ir.Span.unknown()
+    tile_var = ir.Var("t", _tile([16, 128], [16, 32]), span)
+
+    with pytest.raises(ValueError, match="LEFT_RIGHT splits the column axis"):
+        ir.create_op_call("tile.aiv_shard", [tile_var], {"split": 2}, span)
+
+
+def test_shard_rejects_ragged_row_with_narrowed_columns():
+    """A per-lane row extent and a narrowed column extent cannot both be carried.
+
+    The row rides on the TPOP valid_row operand; the narrowed column can only be
+    restored by the static pto.treshape, which rebuilds both axes at once.
+    """
+    span = ir.Span.unknown()
+    tile_var = ir.Var("t", _tile([16, 128], [5, 32]), span)
+
+    with pytest.raises(ValueError, match="per-lane row extent"):
+        ir.create_op_call("tile.aiv_shard", [tile_var], {"split": 1}, span)
+
+
+def test_shard_rejects_runtime_valued_narrow_columns():
+    """pto.treshape carries no operands, so a runtime column extent has no carrier."""
+    span = ir.Span.unknown()
+    valid_col = ir.Var("valid_col", ir.ScalarType(DataType.INDEX), span)
+    tile_var = ir.Var("t", _tile([16, 128], [16, valid_col]), span)
+
+    with pytest.raises(ValueError, match="is a runtime value narrower than the physical box"):
+        ir.create_op_call("tile.aiv_shard", [tile_var], {"split": 1}, span)
+
+
+def test_shard_allows_static_narrow_columns():
+    """A static column narrowing is restorable by treshape after a full-box transport."""
+    span = ir.Span.unknown()
+    tile_var = ir.Var("t", _tile([16, 128], [16, 32]), span)
+
+    shard = ir.create_op_call("tile.aiv_shard", [tile_var], {"split": 1}, span)
+    assert isinstance(shard.type, ir.TileType)
+    assert shard.type.shape == [8, 128]
+
+
+def test_gather_defers_the_band_rule_to_lowering():
+    """The deducer does NOT judge whether the two lanes' bands abut.
+
+    It runs before the per-lane extents exist, so the only extent it can see is
+    its own lane-agnostic ceil-div guess. Judging the join on that both
+    misreports the numbers and rejects shapes that are representable once the
+    lanes are localized, so LowerAutoVectorSplit owns the rule (and types the
+    join exactly) instead. Guarded here so the check does not drift back.
+    """
+    span = ir.Span.unknown()
+    tile_var = ir.Var("t", _tile([8, 128], [5, 128]), span)
+
+    gathered = ir.create_op_call("tile.aic_gather", [tile_var], {"split": 1}, span)
+    assert isinstance(gathered.type, ir.TileType)
+    assert gathered.type.shape == [16, 128]
+
+
+def test_gather_allows_a_lane_dependent_split_axis():
+    """A lane-dependent extent is the compiler's own clamp: lane 0 saturates, so the
+    bands abut and the re-joined region is a rectangle. It must not be rejected."""
+    span = ir.Span.unknown()
+    lane_rows = ir.Var("lane_rows", ir.ScalarType(DataType.INDEX), span)
+    tile_var = ir.Var("t", _tile([8, 128], [lane_rows, 128]), span)
+
+    gathered = ir.create_op_call("tile.aic_gather", [tile_var], {"split": 1}, span)
+    assert isinstance(gathered.type, ir.TileType)
+    assert gathered.type.shape == [16, 128]
+
+
 def test_split_reshape_rejects_non_2d_tile():
     """aiv_shard / aic_gather require a 2D tile."""
     span = ir.Span.unknown()

--- a/tests/ut/ir/transforms/test_lower_auto_vector_split.py
+++ b/tests/ut/ir/transforms/test_lower_auto_vector_split.py
@@ -159,6 +159,52 @@ def test_c2v_boundary_becomes_aiv_shard_and_vector_region_is_halved():
     ir.assert_structural_equal(_lower(Before), Expected)
 
 
+def test_auto_c2v_boundary_localizes_a_ragged_split_axis():
+    """A ragged split axis gets the LANE's extent on the AUTO path too.
+
+    ``ReshapeSplitAxis`` can only ceil-halve the split-axis valid extent, because
+    an op's type function does not know the lane. Here ``subblock_idx`` is in
+    scope, so ``LocalizeShardValidForLane`` replaces that guess with the truth —
+    lane 0 holds 100 of its 64-row half (clamped to 64), lane 1 holds 36 —
+    instead of giving BOTH lanes ``ceil(100 / 2) = 50``.
+    """
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore, attrs={"split": pl.SplitMode.UP_DOWN})
+        def split_auto(
+            qk: pl.Tile[[128, 128], pl.FP32, pl.Mem.Mat, pl.TileView(valid_shape=[100, 128])],
+            out_0: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
+        ) -> pl.Tensor[[128, 128], pl.FP32]:
+            popped = pl.tile.move(qk, target_memory=pl.Mem.Vec)
+            out_store = pl.tile.store(popped, [0, 0], out_0)
+            return out_store
+
+    @pl.program
+    class Expected:
+        @pl.function(
+            type=pl.FunctionType.InCore,
+            attrs={"split": pl.SplitMode.UP_DOWN, "split_aiv": True},
+        )
+        def split_auto(
+            qk: pl.Tile[[128, 128], pl.FP32, pl.Mem.Mat, pl.TileView(valid_shape=[100, 128])],
+            out_0: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
+        ) -> pl.Tensor[[128, 128], pl.FP32]:
+            subblock_idx = pl.tile.get_subblock_idx()
+            popped: pl.Tile[
+                [64, 128],
+                pl.FP32,
+                pl.Mem.Vec,
+                pl.TileView(
+                    valid_shape=[pl.min(pl.max(100, subblock_idx * 64) - subblock_idx * 64, 64), 128]
+                ),
+            ] = pl.tile.aiv_shard(qk, split=1)
+            out_store = pl.tile.store(popped, [0 + subblock_idx * 64, 0], out_0)
+            return out_store
+
+    ir.assert_structural_equal(_lower(Before), Expected)
+
+
 def test_store_offset_at_nonzero_base_localizes_additively():
     """AdjustOffsets ADDS ``subblock_idx * half`` on the split axis rather than
     overwriting the offset: a store at base row 16 becomes ``16 + subblock_idx * 64``.

--- a/tests/ut/ir/transforms/test_split_vector_kernel.py
+++ b/tests/ut/ir/transforms/test_split_vector_kernel.py
@@ -1059,7 +1059,7 @@ class TestSplitVectorKernelStandaloneSetValidshape:
                     [8, 128],
                     pl.FP32,
                     pl.MemorySpace.Vec,
-                    pl.TileView(valid_shape=[pl.max(pl.min(5 - subblock_idx * 8, 8), 0), 64]),
+                    pl.TileView(valid_shape=[pl.min(pl.max(5, subblock_idx * 8) - subblock_idx * 8, 8), 64]),
                 ] = pl.tile.set_validshape(z_vec, 5, 64)
                 out_0_store: pl.Tensor[[16, 128], pl.FP32] = pl.store(
                     narrowed, [0 + subblock_idx * 8, 0], out_0


### PR DESCRIPTION
## Summary

A `valid_shape`-padded accumulator silently lost its real data crossing
`pl.aiv_shard`. On a `[16, 256]` accumulator valid to 5 rows, lane 0 dropped
rows 3-4 and lane 1 wrote two rows of padding over real output — wrong numbers,
no diagnostic, in both release and debug builds.

Two independent defects caused it. The Cube->Vector pop transported the wrong
geometry whenever the kernel was split, and the split-axis valid extent kept a
lane-agnostic `ceil(V / 2)` guess that is wrong for *both* lanes. Both are
fixed: a ragged row extent under `UP_DOWN` now crosses the boundary intact, and
the shapes that provably cannot cross are refused up front with a message naming
the DSL alternative, instead of producing silent garbage.

### Why the pop was wrong

PTO's C2V FIFO always copies the physical consumer box. pto-isa builds the GM
slot view from the popped tile's compile-time rows/cols and the producer's box
row pitch (a2a3 `TPush.hpp` `popVecTileFromGMFiFo`: `gmValidR`/`gmValidC` =
`ConsM`/`ConsN`, `gmStrideR = ProdN`), then strides that view with the tile's
*runtime* `validCol` (`TLoadGm2ubNd2nd`: `lenBurst = validCol`, `gmGap =
gStride3 - gShape4`). Requiring the GM advance per burst to equal one
producer-box row gives

```text
validCol*s + (ProdN - ConsN)*s == ProdN*s   =>   validCol == ConsN
```

so a narrowed `validCol` collapses the gap to zero and the pop reads one
contiguous run instead of one box row per burst. PyPTO widened the push to the
full box at every split but widened the pop only at `split == 0`, so both split
lanes mis-strided. The matching `PTO_ASSERT(validCol == gShape4)` is compiled
out in release builds, so nothing caught it.

### Why a ragged row is supported and a ragged column is refused

That derivation pins only the *column* field — `ProdN` cancels, leaving
`validCol == ConsN` whatever the split mode. The row field is free
(`nBurst = gShape3 = ConsM`). So a per-lane ROW extent rides across on the TPOP
`valid_row` operand, while a per-lane COLUMN extent has no carrier at all: the
only way to rebuild a narrowed column after the full-box transport,
`pto.treshape`, takes no operands and so can express only compile-time static
extents. The two split modes are geometrically symmetric; the transport is not.

## Changes

- `src/backend/common/pto_ops_crosscore.cpp`: widen the TPOP transport to the
  full box at **every** split, not only `split == 0`, matching the producer-side
  widening already done in `EmitTpushTransportValidShape`. A statically empty
  pop still moves nothing, so the dual-AIV pipe-balancing replay is unchanged.
- `src/ir/transforms/utils/split_axis_utils.{h,cpp}`: give each lane its true
  split-axis extent `clamp(V - L*half, 0, half)` and carry it to consumers that
  pass the extent through unchanged. Two new entry points —
  `LocalizeShardValidForLane` (a single shard result type) and
  `LocalizeExplicitBoundaryValid` (a whole `pl.split_aiv` region body). The walk
  descends into loops and branches, so a nested shard, consumer, or store is
  repaired exactly like a top-level one. An empty lane's `tile.store` is guarded
  behind `extent > 0` while its `tpop`/`tfree` stay unconditional, keeping the
  cross-core pipe balanced. The clamp is built as `min(max(V, off) - off, half)`
  rather than `max(min(V - off, half), 0)`, which wraps when the valid extent
  carries an unsigned dtype (`tile.set_validshape` accepts UINT64) and would
  then hand the empty lane a full half.
- `src/ir/transforms/lower_auto_vector_split_pass.cpp`: apply that localization
  on both arms — the AUTO C->V synthesis and the explicit-boundary region — and
  restore the pre-shard extent on `tile.aic_gather`, rejecting a
  provably-partial untracked operand there.
- `src/ir/op/tile_ops/cross_core.cpp`: reject at deduction what cannot cross,
  each message naming the DSL fix — a per-lane column extent under
  `LEFT_RIGHT`, a runtime-valued narrowed column, and `UP_DOWN` carrying both a
  per-lane row extent and a narrowed column. The gather's band rule moved *out*
  of the deducer: it runs before per-lane extents exist, so it judged the join
  on the `ceil` guess and misreported the author's own numbers.
- `src/ir/transforms/utils/dead_code_elimination.cpp`: count Vars referenced
  from a defined var's **type** as live. A localized extent is an expression
  over the region's subblock index, so without this the index binding is
  deleted and the type dangles.
- `docs/{en,zh}/dev/codegen/00-pto_codegen.md`,
  `docs/{en,zh}/dev/passes/20-lower_auto_vector_split.md`: document the
  transport rule, the support matrix, the gather geometry, and the empty-lane
  guard.

## Behavior change

Programs that were silently producing wrong data now either produce correct data
(ragged rows under `UP_DOWN`) or fail to compile with an actionable error
(ragged columns, and the mixed row+column case). Nothing that previously
compiled *and* produced correct results changes: a fully-valid split axis takes
the deducer's exact type as before, and the localization walk returns its input
untouched in that case.

## Verification

Run on this branch, at the machine-local 2-job limit.

- `cmake --build build --parallel 2` (RelWithDebInfo): exit 0, no errors or new
  warnings
- `pytest tests/ut/ -n 2`: **9689 passed, 3 skipped** in 325s
- `pytest tests/st/codegen/ -n 2`: **50 passed**
- `pre-commit run --files <15 changed paths>`: **all 17 hooks pass** —
  check-headers, check-english-only, check-docs-en-zh-parity, check-docs-nav,
  check-docs-symbol-coverage, check-no-broad-raises, check-op-name-literals,
  clang-format, cpplint, markdownlint-cli2, ruff check, ruff format, pyright.
  (`tests/lint/` holds `check_*.py` scripts rather than pytest tests, so
  pre-commit is what actually runs them.)
- `ruff check .`, `ruff format --check .`, `git diff --check`: clean

Revalidated at the pushed commit `5491838e`, rebased onto `main` at `a83d185c`:

- `cmake --build build --parallel 2`: exit 0
- focused — `test_cross_core_ops.py`, `test_pto_codegen_cross_core.py`,
  `test_lower_auto_vector_split.py`, `test_split_vector_kernel.py`:
  **166 passed**
- broader — `tests/ut/codegen`, `tests/ut/ir/transforms`: **3767 passed**
- `tests/st/codegen`: **50 passed**

Hardware, recorded earlier in this task on this change: an A2/A3 device with
random inputs reproduced the loss (224/235/223 of 512 elements wrong; then bad
row ids `[3, 4]`, bad col ids `[16..31]`) and confirmed both fixes, with the
ragged-column form rejected at compile time.

## Review hardening (folded into the same commit)

Found by review of this change and fixed in `5491838e`:

- recurse into `WhileStmt` bodies as well as `ForStmt`/`IfStmt`/`SeqStmts`
- index chained-store destinations **once, recursively** over the whole region
  (`CollectChainedStoreDestinations`). The previous sibling-only scan missed a
  chained store nested in a branch or loop, which would have let the empty-lane
  guard skip a store another store writes through; it was also O(S^2) in the
  region's store count
- require a static **physical** box, not just a static valid extent, before the
  full-box + `treshape` pop — a dynamic split axis lowers to `floordiv(dim, 2)`,
  so without this a dynamic-shaped tile hit an `INTERNAL_CHECK` instead of the
  direct-TPOP fallback
- seed DCE live roots from every control-flow **binder** type, not just the
  assign LHS (`MarkBinderTypeRefsLive`) — a binder is not an `AssignStmt`
- refuse a per-lane value carried across a `pl.range` / `pl.while_` boundary
- clang-tidy: add the direct `span.h` / `type.h` includes, drop a dead store

## Notes for review

- **One pinned test expectation changed**, in
  `tests/ut/ir/transforms/test_split_vector_kernel.py`. It asserted the old
  clamp form; the rewrite is the unsigned-underflow fix described above, not an
  accommodation. At `subblock_idx = 1` the old form yields a full half where the
  lane holds nothing.
- **One review thread is deliberately left open**
  ([retyping control-flow boundary variables](https://github.com/hw-native-sys/pypto/pull/2388#discussion_r3785873067)).
  The underlying defect is real and is now *refused* at compile time rather than
  supported: a per-lane value carried across a `pl.range` / `pl.while_` boundary
  would keep the lane-agnostic extent, so `RejectLocalizedCarry` stops it with a
  message naming the authorings that avoid it. Implementing the retype means
  changing SSA binder construction, and I could not build a kernel that
  exercises it — untested there means silent wrong data, which is what this PR
  exists to remove. Worth a deliberate follow-up with a test; flagging rather
  than guessing.
- `docs/en/dev/passes/20-lower_auto_vector_split.md` is 548 lines against the
  500-line guideline in `documentation-length.md` (509 before this change). It
  was condensed twice already; the sibling `00-pto_codegen.md` sits at 798.
