### PR TITLE
fix(ir): preserve valid_shape on tensor elementwise ops

### DIFF
--- a/docs/en/dev/ir/05-operators.md
+++ b/docs/en/dev/ir/05-operators.md
@@ -369,6 +369,17 @@ effective `valid_shape` while dropping source alias, layout, stride, and padding
 metadata. This matches the existing Tile-scalar rule and keeps a ragged tail
 narrow through Tensor-to-Tile lowering.
 
+The ordinary arithmetic Tensor-tensor operators (`add`, `sub`, `mul`, `div`,
+`fmod`, `maximum`, and `minimum`) also preserve the effective `valid_shape`
+when both operands have identical physical shapes and their effective valid
+regions are provably equal. The same exact-region rule applies to `and`, `or`,
+`shl`, and `shr`. It needs no broadcast-axis mapping and agrees with the
+corresponding Tile result contract; the result remains fresh storage and
+therefore inherits no alias, layout, stride, or padding metadata. Comparison,
+XOR, `part_*`, broadcasting, different valid regions, and direct distributed
+window operands are not covered by this rule because their current lowering or
+combination contracts require separate handling.
+
 `pl.reinterpret_view(data, dtype, *, shape=None)` dispatches to the equivalent `pl.tensor` or `pl.tile` operator and returns the same kind. It is a zero-copy view over exactly the same bytes, so `dtype` must differ and be one of signed/unsigned 8/16/32/64-bit integers, FP16, BF16, or FP32. With no `shape`, ND/row-major scales the last axis and DN/col-major scales the penultimate axis by the source/target byte-width ratio. An explicit shape must be byte-equivalent and fully static unless it is provably identical to the auto-inferred shape; a partial `valid_shape` only permits that auto-equivalent shape. Zero/null padding metadata is preserved, while dtype-dependent max/min padding is cleared. The initial executable path supports packed ND in-core tensors and packed flat (`none_box`) row/col-major tiles; DN tensor inference is available but Tensor-to-Tile lowering rejects it, and orchestration tensors are unsupported.
 
 **Example:**

--- a/docs/en/dev/ir/05-operators.md
+++ b/docs/en/dev/ir/05-operators.md
@@ -363,11 +363,14 @@ UINT32 + INT32 → INT32 (signed precedence)
 
 `tensor.view` is a metadata-only zero-copy shape/layout reinterpret. It is registered as a `TensorOp` passthrough in `ConvertTensorToTileOps`; PTO in-core codegen lowers it to `pto.make_tensor_view` over the original base pointer. Targets require rank at least 1 (DN requires rank at least 2); orchestration shape reinterpret is ND-only and cannot also change layout. Shape reinterpretation of a partially valid source is limited to either a packed ND leading-dimension collapse to 2D or a contiguous-prefix linear collapse to `[1, product(shape)]`; both require an explicit target `valid_shape`. These forms preserve the source tensor kind and backing metadata.
 
-Tensor-scalar element-wise computation creates fresh storage but cannot create
-valid data in padding. Its result therefore preserves the tensor operand's
-effective `valid_shape` while dropping source alias, layout, stride, and padding
-metadata. This matches the existing Tile-scalar rule and keeps a ragged tail
-narrow through Tensor-to-Tile lowering.
+For plain `TensorType` operands, the supported Tensor-scalar arithmetic
+operators (`adds`, `subs`, `muls`, `divs`, `fmods`, and scalar `maximum` or
+`minimum`) and bitwise/shift operators (`ands`, `ors`, `shls`, and `shrs`)
+create fresh storage but cannot create valid data in padding. Their results
+therefore preserve the tensor operand's effective `valid_shape` while dropping
+source alias, layout, stride, and padding metadata. This matches the existing
+Tile-scalar rule and keeps a ragged tail narrow through Tensor-to-Tile lowering.
+Scalar comparison and XOR (`cmp` and `xors`) remain excluded.
 
 The ordinary arithmetic Tensor-tensor operators (`add`, `sub`, `mul`, `div`,
 `fmod`, `maximum`, and `minimum`) also preserve the effective `valid_shape`

--- a/docs/en/dev/ir/05-operators.md
+++ b/docs/en/dev/ir/05-operators.md
@@ -363,6 +363,12 @@ UINT32 + INT32 → INT32 (signed precedence)
 
 `tensor.view` is a metadata-only zero-copy shape/layout reinterpret. It is registered as a `TensorOp` passthrough in `ConvertTensorToTileOps`; PTO in-core codegen lowers it to `pto.make_tensor_view` over the original base pointer. Targets require rank at least 1 (DN requires rank at least 2); orchestration shape reinterpret is ND-only and cannot also change layout. Shape reinterpretation of a partially valid source is limited to either a packed ND leading-dimension collapse to 2D or a contiguous-prefix linear collapse to `[1, product(shape)]`; both require an explicit target `valid_shape`. These forms preserve the source tensor kind and backing metadata.
 
+Tensor-scalar element-wise computation creates fresh storage but cannot create
+valid data in padding. Its result therefore preserves the tensor operand's
+effective `valid_shape` while dropping source alias, layout, stride, and padding
+metadata. This matches the existing Tile-scalar rule and keeps a ragged tail
+narrow through Tensor-to-Tile lowering.
+
 `pl.reinterpret_view(data, dtype, *, shape=None)` dispatches to the equivalent `pl.tensor` or `pl.tile` operator and returns the same kind. It is a zero-copy view over exactly the same bytes, so `dtype` must differ and be one of signed/unsigned 8/16/32/64-bit integers, FP16, BF16, or FP32. With no `shape`, ND/row-major scales the last axis and DN/col-major scales the penultimate axis by the source/target byte-width ratio. An explicit shape must be byte-equivalent and fully static unless it is provably identical to the auto-inferred shape; a partial `valid_shape` only permits that auto-equivalent shape. Zero/null padding metadata is preserved, while dtype-dependent max/min padding is cleared. The initial executable path supports packed ND in-core tensors and packed flat (`none_box`) row/col-major tiles; DN tensor inference is available but Tensor-to-Tile lowering rejects it, and orchestration tensors are unsupported.
 
 **Example:**

--- a/docs/en/user/language/03-memory.md
+++ b/docs/en/user/language/03-memory.md
@@ -140,7 +140,7 @@ The padding value matters for reductions, and the failure is silent:
 
 ```python
 t = pl.load(x, [off, 0], [128, 128])
-t = pl.set_validshape(t, [rows_left, 128])     # only `rows_left` rows are real
+t = pl.set_validshape(t, rows_left, 128)       # only `rows_left` rows are real
 m = pl.row_max(t)                              # pad value decides what the tail contributes
 ```
 

--- a/docs/zh/dev/ir/05-operators.md
+++ b/docs/zh/dev/ir/05-operators.md
@@ -338,6 +338,11 @@ UINT32 + INT32 → INT32 (signed precedence)
 
 `tensor.view` 是只修改元数据的零拷贝 shape/layout 重新解释操作。它注册为 `TensorOp`，并在 `ConvertTensorToTileOps` 中作为 passthrough 处理；PTO in-core codegen 会将其降级为基于原始 base pointer 的 `pto.make_tensor_view`。目标 rank 至少为 1（DN 至少为 2）；编排层仅支持 ND shape 重新解释，且不能同时改变 layout。对部分有效的源张量进行 shape 重新解释时，仅支持把 packed ND 的 leading dimensions 折叠为 2D，或把连续前缀线性折叠为 `[1, product(shape)]`；两种形式都必须显式提供目标 `valid_shape`，并会保留源张量类型及其底层元数据。
 
+Tensor-scalar 逐元素计算会创建新存储，但不能把 padding 凭空变成有效数据。因此
+结果保留 Tensor 操作数的 effective `valid_shape`，同时丢弃源别名、layout、stride
+与 padding 元数据。这与已有的 Tile-scalar 规则一致，确保 ragged tail 经
+Tensor-to-Tile 下降后仍保持窄有效区。
+
 `pl.reinterpret_view(data, dtype, *, shape=None)` 会根据输入分派到等价的 `pl.tensor` 或 `pl.tile` 算子，并保持返回类型种类不变。它是覆盖完全相同字节的零拷贝视图，因此 `dtype` 必须不同，且仅支持有/无符号 8/16/32/64 位整数、FP16、BF16 与 FP32。省略 `shape` 时，ND/row-major 缩放最后一轴，DN/col-major 按源/目标字节宽度比例缩放倒数第二轴。显式 shape 必须字节数相等；除非能证明它与自动推导 shape 等价，否则必须完全静态。部分有效的 `valid_shape` 只能使用与自动推导结果等价的 shape。零值/null padding 元数据会保留，依赖 dtype 的 max/min padding 则会清除。初始可执行路径支持 packed ND in-core tensor 及 packed、flat（`none_box`）row/col-major tile；DN tensor 可做类型推导但 Tensor-to-Tile 下降会拒绝，编排层 tensor 暂不支持。
 
 **示例：**

--- a/docs/zh/dev/ir/05-operators.md
+++ b/docs/zh/dev/ir/05-operators.md
@@ -343,6 +343,14 @@ Tensor-scalar 逐元素计算会创建新存储，但不能把 padding 凭空变
 与 padding 元数据。这与已有的 Tile-scalar 规则一致，确保 ragged tail 经
 Tensor-to-Tile 下降后仍保持窄有效区。
 
+对于普通 Tensor-tensor 算术算子（`add`、`sub`、`mul`、`div`、`fmod`、
+`maximum` 和 `minimum`），当两个操作数的物理 shape 相同，且其 effective
+`valid_shape` 可证明相等时，结果同样保留该有效区域。`and`、`or`、`shl` 和
+`shr` 也采用这条 exact-region 规则。它不需要映射广播轴，并与相应 Tile
+结果契约一致；结果仍是新存储，因此不会继承别名、layout、stride 或 padding
+元数据。比较、XOR、`part_*`、广播、不同有效区域，以及直接使用 distributed
+window 的操作数不在这条规则范围内，因为它们当前的下降或合并契约需要单独处理。
+
 `pl.reinterpret_view(data, dtype, *, shape=None)` 会根据输入分派到等价的 `pl.tensor` 或 `pl.tile` 算子，并保持返回类型种类不变。它是覆盖完全相同字节的零拷贝视图，因此 `dtype` 必须不同，且仅支持有/无符号 8/16/32/64 位整数、FP16、BF16 与 FP32。省略 `shape` 时，ND/row-major 缩放最后一轴，DN/col-major 按源/目标字节宽度比例缩放倒数第二轴。显式 shape 必须字节数相等；除非能证明它与自动推导 shape 等价，否则必须完全静态。部分有效的 `valid_shape` 只能使用与自动推导结果等价的 shape。零值/null padding 元数据会保留，依赖 dtype 的 max/min padding 则会清除。初始可执行路径支持 packed ND in-core tensor 及 packed、flat（`none_box`）row/col-major tile；DN tensor 可做类型推导但 Tensor-to-Tile 下降会拒绝，编排层 tensor 暂不支持。
 
 **示例：**

--- a/docs/zh/dev/ir/05-operators.md
+++ b/docs/zh/dev/ir/05-operators.md
@@ -338,10 +338,13 @@ UINT32 + INT32 → INT32 (signed precedence)
 
 `tensor.view` 是只修改元数据的零拷贝 shape/layout 重新解释操作。它注册为 `TensorOp`，并在 `ConvertTensorToTileOps` 中作为 passthrough 处理；PTO in-core codegen 会将其降级为基于原始 base pointer 的 `pto.make_tensor_view`。目标 rank 至少为 1（DN 至少为 2）；编排层仅支持 ND shape 重新解释，且不能同时改变 layout。对部分有效的源张量进行 shape 重新解释时，仅支持把 packed ND 的 leading dimensions 折叠为 2D，或把连续前缀线性折叠为 `[1, product(shape)]`；两种形式都必须显式提供目标 `valid_shape`，并会保留源张量类型及其底层元数据。
 
-Tensor-scalar 逐元素计算会创建新存储，但不能把 padding 凭空变成有效数据。因此
-结果保留 Tensor 操作数的 effective `valid_shape`，同时丢弃源别名、layout、stride
-与 padding 元数据。这与已有的 Tile-scalar 规则一致，确保 ragged tail 经
-Tensor-to-Tile 下降后仍保持窄有效区。
+对于普通 `TensorType` 操作数，已支持的 Tensor-scalar 算术算子（`adds`、
+`subs`、`muls`、`divs`、`fmods` 以及 scalar `maximum` 或 `minimum`）和
+位运算/移位算子（`ands`、`ors`、`shls` 和 `shrs`）会创建新存储，但不能
+把 padding 凭空变成有效数据。因此结果保留 Tensor 操作数的 effective
+`valid_shape`，同时丢弃源别名、layout、stride 与 padding 元数据。这与已有的
+Tile-scalar 规则一致，确保 ragged tail 经 Tensor-to-Tile 下降后仍保持窄有效区。
+Scalar 比较与 XOR（`cmp` 和 `xors`）仍不在此规则的支持范围内。
 
 对于普通 Tensor-tensor 算术算子（`add`、`sub`、`mul`、`div`、`fmod`、
 `maximum` 和 `minimum`），当两个操作数的物理 shape 相同，且其 effective

--- a/docs/zh/user/language/03-memory.md
+++ b/docs/zh/user/language/03-memory.md
@@ -120,7 +120,7 @@ DDR ──────────► Vec ────────────�
 
 ```python
 t = pl.load(x, [off, 0], [128, 128])
-t = pl.set_validshape(t, [rows_left, 128])     # only `rows_left` rows are real
+t = pl.set_validshape(t, rows_left, 128)       # only `rows_left` rows are real
 m = pl.row_max(t)                              # pad value decides what the tail contributes
 ```
 

--- a/src/ir/op/tensor_ops/elementwise.cpp
+++ b/src/ir/op/tensor_ops/elementwise.cpp
@@ -55,6 +55,11 @@ static bool IsTSubsDataType(DataType dtype) {
 /// are valid.
 static std::optional<std::vector<ExprPtr>> GetMatchingElementwiseValidShape(
     const std::shared_ptr<const TensorType>& lhs, const std::shared_ptr<const TensorType>& rhs) {
+  // Direct distributed windows require a separate lowering contract.  AsTensorTypeLike
+  // deliberately accepts them, so recover the exact ObjectKind here before propagating
+  // metadata that is currently supported only for plain TensorType operands.
+  if (!As<TensorType>(lhs) || !As<TensorType>(rhs)) return std::nullopt;
+
   if (lhs->shape_.size() != rhs->shape_.size()) return std::nullopt;
   for (size_t i = 0; i < lhs->shape_.size(); ++i) {
     if (!DimensionsEqual(lhs->shape_[i], rhs->shape_[i])) return std::nullopt;
@@ -136,7 +141,7 @@ TypePtr DeduceTensorOpElementwiseScalarType(const std::vector<ExprPtr>& args,
     result_dtype = *promoted_dtype;
   }
 
-  if (preserve_valid_shape) {
+  if (preserve_valid_shape && As<TensorType>(args[0]->GetType())) {
     return MakeFreshTensorType(tensor_type1->shape_, result_dtype, GetValidShape(tensor_type1));
   }
   return std::make_shared<TensorType>(tensor_type1->shape_, result_dtype);

--- a/src/ir/op/tensor_ops/elementwise.cpp
+++ b/src/ir/op/tensor_ops/elementwise.cpp
@@ -20,6 +20,7 @@
 #include <any>
 #include <cstddef>
 #include <memory>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
@@ -45,9 +46,36 @@ static bool IsTSubsDataType(DataType dtype) {
          dtype == DataType::FP16 || dtype == DataType::FP32 || dtype == DataType::BF16;
 }
 
+/// Return the shared effective valid region for two identically shaped operands.
+///
+/// This deliberately does not infer a region through broadcasting or intersect
+/// different regions: those cases need axis-aware mapping before Tensor-to-Tile
+/// lowering. Exact-shape operands with provably equal regions need no mapping,
+/// and every element-wise result cell is valid iff the corresponding input cells
+/// are valid.
+static std::optional<std::vector<ExprPtr>> GetMatchingElementwiseValidShape(
+    const std::shared_ptr<const TensorType>& lhs, const std::shared_ptr<const TensorType>& rhs) {
+  if (lhs->shape_.size() != rhs->shape_.size()) return std::nullopt;
+  for (size_t i = 0; i < lhs->shape_.size(); ++i) {
+    if (!DimensionsEqual(lhs->shape_[i], rhs->shape_[i])) return std::nullopt;
+  }
+
+  auto lhs_valid_shape = GetValidShape(lhs);
+  auto rhs_valid_shape = GetValidShape(rhs);
+  INTERNAL_CHECK(lhs_valid_shape.size() == rhs_valid_shape.size())
+      << "Internal error: identically shaped tensors have different valid_shape ranks";
+  for (size_t i = 0; i < lhs_valid_shape.size(); ++i) {
+    if (ProveValidExtentEqual(lhs_valid_shape[i], rhs_valid_shape[i]) != ProofResult::kTrue) {
+      return std::nullopt;
+    }
+  }
+  return lhs_valid_shape;
+}
+
 TypePtr DeduceTensorOpElementwiseBinaryType(const std::vector<ExprPtr>& args,
                                             const std::vector<std::pair<std::string, std::any>>& kwargs,
-                                            const std::string& op_name) {
+                                            const std::string& op_name,
+                                            bool preserve_matching_valid_shape = true) {
   CHECK(args.size() == 2) << "The operator " << op_name << " requires exactly 2 arguments, but got "
                           << args.size();
 
@@ -74,12 +102,19 @@ TypePtr DeduceTensorOpElementwiseBinaryType(const std::vector<ExprPtr>& args,
                                   << FormatShape(tensor_type1->shape_) << " and "
                                   << FormatShape(tensor_type2->shape_);
 
+  if (preserve_matching_valid_shape) {
+    if (auto valid_shape = GetMatchingElementwiseValidShape(tensor_type1, tensor_type2)) {
+      return MakeFreshTensorType(broadcast_result.shape, *result_dtype, std::move(*valid_shape));
+    }
+  }
+
   return std::make_shared<TensorType>(broadcast_result.shape, *result_dtype);
 }
 
 TypePtr DeduceTensorOpElementwiseScalarType(const std::vector<ExprPtr>& args,
                                             const std::vector<std::pair<std::string, std::any>>& kwargs,
-                                            const std::string& op_name, bool preserve_lhs_dtype = false) {
+                                            const std::string& op_name, bool preserve_lhs_dtype = false,
+                                            bool preserve_valid_shape = true) {
   CHECK(args.size() == 2) << "The operator " << op_name << " requires exactly 2 arguments, but got "
                           << args.size();
 
@@ -93,16 +128,18 @@ TypePtr DeduceTensorOpElementwiseScalarType(const std::vector<ExprPtr>& args,
                       << " requires second argument to be a ScalarType, but got "
                       << args[1]->GetType()->TypeName();
 
-  if (preserve_lhs_dtype) {
-    return MakeFreshTensorType(tensor_type1->shape_, tensor_type1->dtype_, GetValidShape(tensor_type1));
+  DataType result_dtype = tensor_type1->dtype_;
+  if (!preserve_lhs_dtype) {
+    auto promoted_dtype = PromoteDataTypes(tensor_type1->dtype_, scalar_type2->dtype_);
+    CHECK(promoted_dtype) << "The operator " << op_name << " requires compatible data types, but got "
+                          << args[0]->GetType()->TypeName() << " and " << args[1]->GetType()->TypeName();
+    result_dtype = *promoted_dtype;
   }
 
-  // TensorType + ScalarType - result is TensorType with same shape as first argument
-  auto result_dtype = PromoteDataTypes(tensor_type1->dtype_, scalar_type2->dtype_);
-  CHECK(result_dtype) << "The operator " << op_name << " requires compatible data types, but got "
-                      << args[0]->GetType()->TypeName() << " and " << args[1]->GetType()->TypeName();
-
-  return MakeFreshTensorType(tensor_type1->shape_, *result_dtype, GetValidShape(tensor_type1));
+  if (preserve_valid_shape) {
+    return MakeFreshTensorType(tensor_type1->shape_, result_dtype, GetValidShape(tensor_type1));
+  }
+  return std::make_shared<TensorType>(tensor_type1->shape_, result_dtype);
 }
 
 // Bitwise and shift ops have no row/col-expand tile counterpart (there is no
@@ -131,7 +168,8 @@ static void CheckBitwiseShapesMatch(const std::shared_ptr<const TensorType>& lhs
 // shift count does not participate in the result type.
 TypePtr DeduceTensorOpBitwiseBinaryType(const std::vector<ExprPtr>& args,
                                         const std::vector<std::pair<std::string, std::any>>& kwargs,
-                                        const std::string& op_name, bool preserve_lhs_dtype) {
+                                        const std::string& op_name, bool preserve_lhs_dtype,
+                                        bool preserve_matching_valid_shape = true) {
   CHECK(args.size() == 2) << "The operator " << op_name << " requires exactly 2 arguments, but got "
                           << args.size();
 
@@ -153,13 +191,20 @@ TypePtr DeduceTensorOpBitwiseBinaryType(const std::vector<ExprPtr>& args,
 
   CheckBitwiseShapesMatch(tensor_type1, tensor_type2, op_name);
 
-  if (preserve_lhs_dtype) {
-    return std::make_shared<TensorType>(tensor_type1->shape_, tensor_type1->dtype_);
+  DataType result_dtype = tensor_type1->dtype_;
+  if (!preserve_lhs_dtype) {
+    auto promoted_dtype = PromoteDataTypes(tensor_type1->dtype_, tensor_type2->dtype_);
+    CHECK(promoted_dtype) << "The operator " << op_name << " requires compatible data types, but got "
+                          << tensor_type1->dtype_.ToString() << " and " << tensor_type2->dtype_.ToString();
+    result_dtype = *promoted_dtype;
   }
-  auto result_dtype = PromoteDataTypes(tensor_type1->dtype_, tensor_type2->dtype_);
-  CHECK(result_dtype) << "The operator " << op_name << " requires compatible data types, but got "
-                      << tensor_type1->dtype_.ToString() << " and " << tensor_type2->dtype_.ToString();
-  return std::make_shared<TensorType>(tensor_type1->shape_, *result_dtype);
+
+  if (preserve_matching_valid_shape) {
+    if (auto valid_shape = GetMatchingElementwiseValidShape(tensor_type1, tensor_type2)) {
+      return MakeFreshTensorType(tensor_type1->shape_, result_dtype, std::move(*valid_shape));
+    }
+  }
+  return std::make_shared<TensorType>(tensor_type1->shape_, result_dtype);
 }
 
 // Tensor-scalar bitwise/shift ops. Mirrors DeduceTileOpIntScalarBinaryType: the
@@ -177,8 +222,9 @@ TypePtr DeduceTensorOpBitwiseBinaryType(const std::vector<ExprPtr>& args,
 // a constant caught here would otherwise reach the hardware as garbage.
 TypePtr DeduceTensorOpBitwiseScalarType(const std::vector<ExprPtr>& args,
                                         const std::vector<std::pair<std::string, std::any>>& kwargs,
-                                        const std::string& op_name, bool is_shift = false) {
-  auto result_type = DeduceTensorOpElementwiseScalarType(args, kwargs, op_name, true);
+                                        const std::string& op_name, bool is_shift = false,
+                                        bool preserve_valid_shape = true) {
+  auto result_type = DeduceTensorOpElementwiseScalarType(args, kwargs, op_name, true, preserve_valid_shape);
   auto tensor_type = AsTensorTypeLike(args[0]->GetType());  // accepts a window (issue #1694)
   auto scalar_type = As<ScalarType>(args[1]->GetType());
   CHECK(tensor_type->dtype_.IsInt()) << "The operator " << op_name
@@ -312,7 +358,7 @@ REGISTER_OP("tensor.part_add")
     .add_argument("src1", "Second source tensor (TensorType)")
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
-      return DeduceTensorOpElementwiseBinaryType(args, kwargs, "tensor.part_add");
+      return DeduceTensorOpElementwiseBinaryType(args, kwargs, "tensor.part_add", false);
     });
 
 REGISTER_OP("tensor.part_mul")
@@ -322,7 +368,7 @@ REGISTER_OP("tensor.part_mul")
     .add_argument("src1", "Second source tensor (TensorType)")
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
-      return DeduceTensorOpElementwiseBinaryType(args, kwargs, "tensor.part_mul");
+      return DeduceTensorOpElementwiseBinaryType(args, kwargs, "tensor.part_mul", false);
     });
 
 REGISTER_OP("tensor.part_max")
@@ -332,7 +378,7 @@ REGISTER_OP("tensor.part_max")
     .add_argument("src1", "Second source tensor (TensorType)")
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
-      return DeduceTensorOpElementwiseBinaryType(args, kwargs, "tensor.part_max");
+      return DeduceTensorOpElementwiseBinaryType(args, kwargs, "tensor.part_max", false);
     });
 
 REGISTER_OP("tensor.part_min")
@@ -342,7 +388,7 @@ REGISTER_OP("tensor.part_min")
     .add_argument("src1", "Second source tensor (TensorType)")
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
-      return DeduceTensorOpElementwiseBinaryType(args, kwargs, "tensor.part_min");
+      return DeduceTensorOpElementwiseBinaryType(args, kwargs, "tensor.part_min", false);
     });
 
 REGISTER_OP("tensor.fmod")
@@ -406,9 +452,9 @@ REGISTER_OP("tensor.cmp")
       CHECK(args.size() == 2) << "The operator tensor.cmp requires exactly 2 arguments, but got "
                               << args.size();
       if (AsTensorTypeLike(args[1]->GetType())) {  // window operand routes to binary path (issue #1694)
-        return DeduceTensorOpElementwiseBinaryType(args, kwargs, "tensor.cmp");
+        return DeduceTensorOpElementwiseBinaryType(args, kwargs, "tensor.cmp", false);
       }
-      return DeduceTensorOpElementwiseScalarType(args, kwargs, "tensor.cmp");
+      return DeduceTensorOpElementwiseScalarType(args, kwargs, "tensor.cmp", false, false);
     });
 
 // ============================================================================
@@ -491,7 +537,7 @@ REGISTER_OP("tensor.xor")
     .add_argument("rhs", "Right-hand side tensor (TensorType, integer dtype)")
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
-      return DeduceTensorOpBitwiseBinaryType(args, kwargs, "tensor.xor", false);
+      return DeduceTensorOpBitwiseBinaryType(args, kwargs, "tensor.xor", false, false);
     });
 
 REGISTER_OP("tensor.xors")
@@ -501,7 +547,7 @@ REGISTER_OP("tensor.xors")
     .add_argument("rhs", "Right-hand side scalar (ScalarType, integer dtype)")
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
-      return DeduceTensorOpBitwiseScalarType(args, kwargs, "tensor.xors");
+      return DeduceTensorOpBitwiseScalarType(args, kwargs, "tensor.xors", false, false);
     });
 
 // Shifts keep the lhs element type: the shift count never widens the result.

--- a/src/ir/op/tensor_ops/elementwise.cpp
+++ b/src/ir/op/tensor_ops/elementwise.cpp
@@ -94,7 +94,7 @@ TypePtr DeduceTensorOpElementwiseScalarType(const std::vector<ExprPtr>& args,
                       << args[1]->GetType()->TypeName();
 
   if (preserve_lhs_dtype) {
-    return std::make_shared<TensorType>(tensor_type1->shape_, tensor_type1->dtype_);
+    return MakeFreshTensorType(tensor_type1->shape_, tensor_type1->dtype_, GetValidShape(tensor_type1));
   }
 
   // TensorType + ScalarType - result is TensorType with same shape as first argument
@@ -102,7 +102,7 @@ TypePtr DeduceTensorOpElementwiseScalarType(const std::vector<ExprPtr>& args,
   CHECK(result_dtype) << "The operator " << op_name << " requires compatible data types, but got "
                       << args[0]->GetType()->TypeName() << " and " << args[1]->GetType()->TypeName();
 
-  return std::make_shared<TensorType>(tensor_type1->shape_, *result_dtype);
+  return MakeFreshTensorType(tensor_type1->shape_, *result_dtype, GetValidShape(tensor_type1));
 }
 
 // Bitwise and shift ops have no row/col-expand tile counterpart (there is no

--- a/tests/st/runtime/control_flow/test_assemble_narrow_valid.py
+++ b/tests/st/runtime/control_flow/test_assemble_narrow_valid.py
@@ -110,6 +110,23 @@ class AssembleSubscriptDstEqValidProgram:
         return output
 
 
+@pl.program
+class AssembleScalarElementwiseDstEqValidProgram:
+    """A scalar element-wise result keeps the narrowed source valid_shape."""
+
+    @pl.function(type=pl.FunctionType.Opaque)
+    def main(
+        self,
+        src: pl.Tensor[[SRC_ROWS, SRC_COLS_STATIC], pl.FP32],
+        output: pl.Out[pl.Tensor[[SRC_ROWS, SRC_COLS_VALID], pl.FP32]],
+    ) -> pl.Tensor[[SRC_ROWS, SRC_COLS_VALID], pl.FP32]:
+        with pl.at(level=pl.Level.CORE_GROUP):
+            narrowed = pl.set_validshape(src, SRC_ROWS, SRC_COLS_VALID)
+            incremented = pl.add(narrowed, 1.0)
+            output = pl.assemble(output, incremented, [0, 0])
+        return output
+
+
 def _make_src() -> torch.Tensor:
     """Build the source tensor.
 
@@ -140,6 +157,10 @@ def _expected_dst_eq_valid(src: torch.Tensor) -> torch.Tensor:
     region. If the runtime wrote ``static_shape`` cells, it would OOB the target.
     """
     return src[:, :SRC_COLS_VALID].clone()
+
+
+def _expected_scalar_elementwise(src: torch.Tensor) -> torch.Tensor:
+    return src[:, :SRC_COLS_VALID] + 1.0
 
 
 class _AssembleNarrowValidTestCase(PTOTestCase):
@@ -240,6 +261,19 @@ class TestAssembleNarrowValidShape:
                 AssembleSubscriptDstEqValidProgram,
                 [SRC_ROWS, SRC_COLS_VALID],
                 _expected_dst_eq_valid,
+                platform=platform,
+            )
+        )
+        assert result.passed, f"Test failed: {result.error}"
+
+    @pytest.mark.parametrize("platform", ONBOARD_PLATFORMS)
+    def test_assemble_scalar_elementwise_dst_eq_valid(self, test_runner, platform):
+        result = test_runner.run(
+            _AssembleNarrowValidTestCase(
+                "assemble_scalar_elementwise_dst_eq_valid",
+                AssembleScalarElementwiseDstEqValidProgram,
+                [SRC_ROWS, SRC_COLS_VALID],
+                _expected_scalar_elementwise,
                 platform=platform,
             )
         )

--- a/tests/st/runtime/control_flow/test_assemble_narrow_valid.py
+++ b/tests/st/runtime/control_flow/test_assemble_narrow_valid.py
@@ -127,6 +127,25 @@ class AssembleScalarElementwiseDstEqValidProgram:
         return output
 
 
+@pl.program
+class AssembleBinaryElementwiseDstEqValidProgram:
+    """A binary result keeps the matching valid_shape of both operands."""
+
+    @pl.function(type=pl.FunctionType.Opaque)
+    def main(
+        self,
+        lhs: pl.Tensor[[SRC_ROWS, SRC_COLS_STATIC], pl.FP32],
+        rhs: pl.Tensor[[SRC_ROWS, SRC_COLS_STATIC], pl.FP32],
+        output: pl.Out[pl.Tensor[[SRC_ROWS, SRC_COLS_VALID], pl.FP32]],
+    ) -> pl.Tensor[[SRC_ROWS, SRC_COLS_VALID], pl.FP32]:
+        with pl.at(level=pl.Level.CORE_GROUP):
+            lhs_narrow = pl.set_validshape(lhs, SRC_ROWS, SRC_COLS_VALID)
+            rhs_narrow = pl.set_validshape(rhs, SRC_ROWS, SRC_COLS_VALID)
+            summed = pl.add(lhs_narrow, rhs_narrow)
+            output = pl.assemble(output, summed, [0, 0])
+        return output
+
+
 def _make_src() -> torch.Tensor:
     """Build the source tensor.
 
@@ -199,6 +218,31 @@ class _AssembleNarrowValidTestCase(PTOTestCase):
 
     def compute_expected(self, tensors: dict[str, torch.Tensor], params=None) -> None:
         tensors["output"][:] = self._expected_fn(self._src)
+
+
+class _AssembleBinaryNarrowValidTestCase(PTOTestCase):
+    """Runtime fixture for two equally narrowed Tensor operands."""
+
+    def __init__(self, *, platform: str | None = None, config=None):
+        super().__init__(config, platform=platform)
+        self._lhs = _make_src()
+        self._rhs = _make_src() * 0.5
+
+    def get_name(self) -> str:
+        return "assemble_binary_elementwise_dst_eq_valid"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("lhs", [SRC_ROWS, SRC_COLS_STATIC], DataType.FP32, init_value=self._lhs),
+            TensorSpec("rhs", [SRC_ROWS, SRC_COLS_STATIC], DataType.FP32, init_value=self._rhs),
+            TensorSpec("output", [SRC_ROWS, SRC_COLS_VALID], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        return AssembleBinaryElementwiseDstEqValidProgram
+
+    def compute_expected(self, tensors: dict[str, torch.Tensor], params=None) -> None:
+        tensors["output"][:] = self._lhs[:, :SRC_COLS_VALID] + self._rhs[:, :SRC_COLS_VALID]
 
 
 class TestAssembleNarrowValidShape:
@@ -277,6 +321,11 @@ class TestAssembleNarrowValidShape:
                 platform=platform,
             )
         )
+        assert result.passed, f"Test failed: {result.error}"
+
+    @pytest.mark.parametrize("platform", ONBOARD_PLATFORMS)
+    def test_assemble_binary_elementwise_dst_eq_valid(self, test_runner, platform):
+        result = test_runner.run(_AssembleBinaryNarrowValidTestCase(platform=platform))
         assert result.passed, f"Test failed: {result.error}"
 
 

--- a/tests/ut/ir/operators/test_tensor_ops.py
+++ b/tests/ut/ir/operators/test_tensor_ops.py
@@ -461,6 +461,21 @@ def test_tensor_unary_preserves_symbolic_valid_shape():
     assert valid[1] == vlen  # the symbolic extent is carried through unchanged
 
 
+@pytest.mark.parametrize("op_name", ["adds", "subs", "muls", "divs", "maximum", "minimum"])
+def test_tensor_scalar_elementwise_preserves_partial_valid_shape(op_name):
+    """Fresh scalar-elementwise results keep content validity, not source alias metadata."""
+    partial = _partial_tensor_var([32, 256], [28, 250])
+
+    result_type = getattr(ir.op.tensor, op_name)(partial, 1.0).type
+
+    assert isinstance(result_type, ir.TensorType)
+    assert result_type.tensor_view is not None
+    assert _const_int_values(result_type.tensor_view.valid_shape) == [28, 250]
+    assert result_type.tensor_view.stride == []
+    assert result_type.tensor_view.layout == ir.TensorLayout.ND
+    assert result_type.tensor_view.pad == ir.PadValue.null
+
+
 def test_tensor_cast_preserves_valid_shape_and_changes_dtype():
     """tensor.cast changes only the element type; the valid region is untouched."""
     call = ir.op.tensor.cast(_partial_tensor_var([64, 128], [64, 40]), target_type=DataType.FP16)
@@ -4841,6 +4856,23 @@ def test_tensor_bitwise_scalar(builder_name, op_name):
     # re-stamped to the tensor's dtype rather than promoting the result.
     assert result_type.dtype == DataType.INT16
     assert _const_int_values(result_type.shape) == [64, 128]
+
+
+@pytest.mark.parametrize(("builder_name", "op_name"), _BITWISE_SCALAR_OPS)
+def test_tensor_bitwise_scalar_preserves_partial_valid_shape(builder_name, op_name):
+    """The dtype-preserving scalar path must also keep content validity."""
+    span = ir.Span.unknown()
+    view = ir.TensorView(layout=ir.TensorLayout.ND, valid_shape=[60, 120])
+    lhs = ir.Var("lhs", ir.TensorType([64, 128], DataType.INT16, tensor_view=view), span)
+
+    call = getattr(ir.op.tensor, builder_name)(lhs, 4)
+
+    assert call.op.name == op_name
+    result_type = call.type
+    assert isinstance(result_type, ir.TensorType)
+    assert result_type.dtype == DataType.INT16
+    assert result_type.tensor_view is not None
+    assert _const_int_values(result_type.tensor_view.valid_shape) == [60, 120]
 
 
 @pytest.mark.parametrize(("builder_name", "expected_op"), _BITWISE_SCALAR_DISPATCH)

--- a/tests/ut/ir/operators/test_tensor_ops.py
+++ b/tests/ut/ir/operators/test_tensor_ops.py
@@ -476,6 +476,86 @@ def test_tensor_scalar_elementwise_preserves_partial_valid_shape(op_name):
     assert result_type.tensor_view.pad == ir.PadValue.null
 
 
+@pytest.mark.parametrize("op_name", ["add", "sub", "mul", "div", "fmod", "maximum", "minimum"])
+def test_tensor_binary_elementwise_preserves_matching_partial_valid_shape(op_name):
+    """Identically shaped operands with the same real data region keep that region."""
+    lhs = _partial_tensor_var([32, 256], [28, 250], name="lhs")
+    rhs = _partial_tensor_var([32, 256], [28, 250], name="rhs")
+
+    result_type = getattr(ir.op.tensor, op_name)(lhs, rhs).type
+
+    assert isinstance(result_type, ir.TensorType)
+    assert result_type.tensor_view is not None
+    assert _const_int_values(result_type.tensor_view.valid_shape) == [28, 250]
+    assert result_type.tensor_view.stride == []
+    assert result_type.tensor_view.layout == ir.TensorLayout.ND
+    assert result_type.tensor_view.pad == ir.PadValue.null
+
+
+def test_tensor_binary_elementwise_preserves_matching_symbolic_valid_shape():
+    """A shared runtime tail extent remains attached to a binary result."""
+    span = ir.Span.unknown()
+    valid_rows = ir.Var("valid_rows", ir.ScalarType(DataType.INDEX), span)
+    shape = [ir.ConstInt(32, DataType.INDEX, span), ir.ConstInt(256, DataType.INDEX, span)]
+
+    def partial(name: str) -> ir.Var:
+        view = ir.TensorView(layout=ir.TensorLayout.ND, valid_shape=[valid_rows, shape[1]])
+        return ir.Var(name, ir.TensorType(shape, DataType.FP32, tensor_view=view), span)
+
+    result_type = ir.op.tensor.add(partial("lhs"), partial("rhs")).type
+
+    assert isinstance(result_type, ir.TensorType)
+    assert result_type.tensor_view is not None
+    assert result_type.tensor_view.valid_shape[0] is valid_rows
+    assert isinstance(result_type.tensor_view.valid_shape[1], ir.ConstInt)
+    assert result_type.tensor_view.valid_shape[1].value == 256
+
+
+@pytest.mark.parametrize("case", ["broadcast", "different_valid", "unproven_symbolic"])
+def test_tensor_binary_elementwise_does_not_infer_unproven_valid_shape(case):
+    """Only an exact, provably equal effective region may be propagated."""
+    span = ir.Span.unknown()
+    lhs = _partial_tensor_var([32, 256], [28, 250], name="lhs")
+    if case == "broadcast":
+        rhs = _partial_tensor_var([32, 1], [28, 1], name="rhs")
+    elif case == "different_valid":
+        rhs = _partial_tensor_var([32, 256], [27, 250], name="rhs")
+    else:
+        lhs_rows = ir.Var("lhs_rows", ir.ScalarType(DataType.INDEX), span)
+        rhs_rows = ir.Var("rhs_rows", ir.ScalarType(DataType.INDEX), span)
+        lhs = _partial_tensor_var([32, 256], [lhs_rows, 250], name="lhs")
+        rhs = _partial_tensor_var([32, 256], [rhs_rows, 250], name="rhs")
+
+    result_type = ir.op.tensor.add(lhs, rhs).type
+
+    assert isinstance(result_type, ir.TensorType)
+    assert result_type.tensor_view is None
+
+
+@pytest.mark.parametrize("op_name", ["part_add", "part_mul", "part_max", "part_min"])
+def test_tensor_part_ops_keep_their_existing_valid_shape_contract(op_name):
+    """Partial-combine operators need a separate dominance/union rule."""
+    lhs = _partial_tensor_var([32, 256], [28, 250], name="lhs")
+    rhs = _partial_tensor_var([32, 256], [28, 250], name="rhs")
+
+    result_type = getattr(ir.op.tensor, op_name)(lhs, rhs).type
+
+    assert isinstance(result_type, ir.TensorType)
+    assert result_type.tensor_view is None
+
+
+@pytest.mark.parametrize("rhs_kind", ["tensor", "scalar"])
+def test_tensor_cmp_does_not_claim_partial_valid_shape_before_lowering_support(rhs_kind):
+    """Comparison lowering currently materializes full one/zero value tiles."""
+    lhs = _partial_tensor_var([32, 256], [28, 250], name="lhs")
+    rhs = _partial_tensor_var([32, 256], [28, 250], name="rhs") if rhs_kind == "tensor" else 0.0
+
+    result_type = ir.op.tensor.cmp(lhs, rhs, cmp_type=0).type
+
+    assert isinstance(result_type, ir.TensorType)
+    assert result_type.tensor_view is None
+
+
 def test_tensor_cast_preserves_valid_shape_and_changes_dtype():
     """tensor.cast changes only the element type; the valid region is untouched."""
     call = ir.op.tensor.cast(_partial_tensor_var([64, 128], [64, 40]), target_type=DataType.FP16)
@@ -2471,11 +2551,11 @@ def test_tensor_slice_pad_without_valid_shape_warns():
 # ---------------------------------------------------------------------------
 
 
-def _partial_tensor_var(shape, valid_shape, pad=ir.PadValue.null, name="t"):
+def _partial_tensor_var(shape, valid_shape, pad=ir.PadValue.null, name="t", dtype=DataType.FP32):
     """Build a tensor Var whose tensor_view narrows it to `valid_shape`."""
     span = ir.Span.unknown()
     view = ir.TensorView(stride=[], layout=ir.TensorLayout.ND, valid_shape=valid_shape, pad=pad)
-    return ir.Var(name, ir.TensorType(shape, DataType.FP32, tensor_view=view), span)
+    return ir.Var(name, ir.TensorType(shape, dtype, tensor_view=view), span)
 
 
 def _valid_of(result_type):
@@ -4824,6 +4904,20 @@ _BITWISE_SCALAR_DISPATCH = [
     ("shr", "tensor.shrs"),
 ]
 
+_BITWISE_BINARY_VALID_SHAPE_OPS = [
+    ("and_", "tensor.and"),
+    ("or_", "tensor.or"),
+    ("shl", "tensor.shl"),
+    ("shr", "tensor.shr"),
+]
+
+_BITWISE_SCALAR_VALID_SHAPE_OPS = [
+    ("ands", "tensor.ands"),
+    ("ors", "tensor.ors"),
+    ("shls", "tensor.shls"),
+    ("shrs", "tensor.shrs"),
+]
+
 
 @pytest.mark.parametrize(("builder_name", "op_name"), _BITWISE_BINARY_OPS)
 def test_tensor_bitwise_binary(builder_name, op_name):
@@ -4839,6 +4933,32 @@ def test_tensor_bitwise_binary(builder_name, op_name):
     assert isinstance(result_type, ir.TensorType)
     assert result_type.dtype == DataType.INT32
     assert _const_int_values(result_type.shape) == [64, 128]
+
+
+@pytest.mark.parametrize(("builder_name", "op_name"), _BITWISE_BINARY_VALID_SHAPE_OPS)
+def test_tensor_bitwise_binary_preserves_matching_partial_valid_shape(builder_name, op_name):
+    """Exact-shape integer operands keep their shared partial region."""
+    lhs = _partial_tensor_var([64, 128], [60, 120], name="lhs", dtype=DataType.INT32)
+    rhs = _partial_tensor_var([64, 128], [60, 120], name="rhs", dtype=DataType.INT32)
+
+    call = getattr(tensor, builder_name)(lhs, rhs)
+    assert call.op.name == op_name
+    result_type = call.type
+
+    assert isinstance(result_type, ir.TensorType)
+    assert result_type.tensor_view is not None
+    assert _const_int_values(result_type.tensor_view.valid_shape) == [60, 120]
+
+
+def test_tensor_xor_does_not_claim_partial_valid_shape_before_scratch_support():
+    """XOR lowering creates a full-valid scratch tile on current backends."""
+    lhs = _partial_tensor_var([64, 128], [60, 120], name="lhs", dtype=DataType.INT32)
+    rhs = _partial_tensor_var([64, 128], [60, 120], name="rhs", dtype=DataType.INT32)
+
+    result_type = tensor.xor(lhs, rhs).type
+
+    assert isinstance(result_type, ir.TensorType)
+    assert result_type.tensor_view is None
 
 
 @pytest.mark.parametrize(("builder_name", "op_name"), _BITWISE_SCALAR_OPS)
@@ -4858,7 +4978,7 @@ def test_tensor_bitwise_scalar(builder_name, op_name):
     assert _const_int_values(result_type.shape) == [64, 128]
 
 
-@pytest.mark.parametrize(("builder_name", "op_name"), _BITWISE_SCALAR_OPS)
+@pytest.mark.parametrize(("builder_name", "op_name"), _BITWISE_SCALAR_VALID_SHAPE_OPS)
 def test_tensor_bitwise_scalar_preserves_partial_valid_shape(builder_name, op_name):
     """The dtype-preserving scalar path must also keep content validity."""
     span = ir.Span.unknown()
@@ -4873,6 +4993,16 @@ def test_tensor_bitwise_scalar_preserves_partial_valid_shape(builder_name, op_na
     assert result_type.dtype == DataType.INT16
     assert result_type.tensor_view is not None
     assert _const_int_values(result_type.tensor_view.valid_shape) == [60, 120]
+
+
+def test_tensor_xors_does_not_claim_partial_valid_shape_before_scratch_support():
+    """Scalar XOR shares the full-valid automatic scratch limitation."""
+    lhs = _partial_tensor_var([64, 128], [60, 120], name="lhs", dtype=DataType.INT16)
+
+    result_type = ir.op.tensor.xors(lhs, 4).type
+
+    assert isinstance(result_type, ir.TensorType)
+    assert result_type.tensor_view is None
 
 
 @pytest.mark.parametrize(("builder_name", "expected_op"), _BITWISE_SCALAR_DISPATCH)

--- a/tests/ut/ir/operators/test_tensor_ops.py
+++ b/tests/ut/ir/operators/test_tensor_ops.py
@@ -556,6 +556,34 @@ def test_tensor_cmp_does_not_claim_partial_valid_shape_before_lowering_support(r
     assert result_type.tensor_view is None
 
 
+@pytest.mark.parametrize("op_name", ["adds", "ands", "shls"])
+def test_tensor_scalar_elementwise_does_not_preserve_distributed_valid_shape(op_name):
+    """Direct distributed windows need a separate valid-shape lowering contract."""
+    window = _partial_distributed_tensor_var([32, 256], [28, 250], dtype=DataType.INT32)
+
+    result_type = getattr(ir.op.tensor, op_name)(window, 1).type
+
+    assert isinstance(result_type, ir.TensorType)
+    assert not isinstance(result_type, ir.DistributedTensorType)
+    assert result_type.tensor_view is None
+
+
+@pytest.mark.parametrize("op_name", ["add", "and_", "shl"])
+@pytest.mark.parametrize("distributed_side", ["lhs", "rhs"])
+def test_tensor_binary_elementwise_does_not_preserve_distributed_valid_shape(op_name, distributed_side):
+    """Matching distributed windows remain excluded for arithmetic, bitwise, and shift ops."""
+    make_lhs = _partial_distributed_tensor_var if distributed_side == "lhs" else _partial_tensor_var
+    make_rhs = _partial_distributed_tensor_var if distributed_side == "rhs" else _partial_tensor_var
+    lhs = make_lhs([32, 256], [28, 250], name="lhs", dtype=DataType.INT32)
+    rhs = make_rhs([32, 256], [28, 250], name="rhs", dtype=DataType.INT32)
+
+    result_type = getattr(ir.op.tensor, op_name)(lhs, rhs).type
+
+    assert isinstance(result_type, ir.TensorType)
+    assert not isinstance(result_type, ir.DistributedTensorType)
+    assert result_type.tensor_view is None
+
+
 def test_tensor_cast_preserves_valid_shape_and_changes_dtype():
     """tensor.cast changes only the element type; the valid region is untouched."""
     call = ir.op.tensor.cast(_partial_tensor_var([64, 128], [64, 40]), target_type=DataType.FP16)
@@ -2556,6 +2584,13 @@ def _partial_tensor_var(shape, valid_shape, pad=ir.PadValue.null, name="t", dtyp
     span = ir.Span.unknown()
     view = ir.TensorView(stride=[], layout=ir.TensorLayout.ND, valid_shape=valid_shape, pad=pad)
     return ir.Var(name, ir.TensorType(shape, dtype, tensor_view=view), span)
+
+
+def _partial_distributed_tensor_var(shape, valid_shape, name="t", dtype=DataType.FP32):
+    """Build a direct distributed-window Var with a partial valid region."""
+    span = ir.Span.unknown()
+    view = ir.TensorView(stride=[], layout=ir.TensorLayout.ND, valid_shape=valid_shape)
+    return ir.Var(name, ir.DistributedTensorType(shape, dtype, None, view), span)
 
 
 def _valid_of(result_type):


### PR DESCRIPTION
Elementwise ops allocate fresh storage, so they must not turn padding into valid data. This PR only cherry-picks the two latest commits from `nalinaly/pypto` onto current `upstream/main`; it does not include the other fork-only work.

## Changes

1. **Tensor-scalar elementwise** inherit the operand's effective `valid_shape` via `MakeFreshTensorType`, and drop source alias / layout / stride / padding metadata. Covers the usual promotion path and the dtype-preserving bitwise/shift path.
2. **Tensor-tensor elementwise** keep that exact valid region when both operands share the same physical shape and their effective `valid_shape`s are provably equal. Arithmetic and the already-verified bitwise/shift ops are included.
3. **Conservative exclusions** where the current lowering contract is incomplete: `cmp`, `xor`/`xors`, `part_*`, broadcast, unequal valid regions, and direct distributed windows. Also stop the first commit from propagating a partial valid region through scalar `cmp`/`xors`.

Docs (zh/en) and IR / A3 narrow-write tests are updated with the new contract.

## Test plan

- [x] Cherry-pick onto `upstream/main@0e25b5e0` applied cleanly
- [x] Tensor IR unit tests (438) passed on the source tree
- [x] A3 narrow-write system tests (6) passed
- [x] `inductor_pto` dynamic-boundary cases: 9/9 on `a2a3sim` and `a5sim`
- [x] Full pre-commit passed
- [x] Rebuilt and installed under CANN 9.2; `build/package` so SHA256 matched

## Commits

- `0f0793f7` → cherry-picked as `b0fa7d2f` — 修复：Tensor 标量逐元素运算保留 valid_shape
- `8ead22af` → cherry-picked as `892d9efc` — 修复：Tensor 二元逐元素运算保留精确有效区
