### PR TITLE
fix(backend): probe ptoas.sh so v0.55+ uses its bundled CPython

### DIFF
--- a/python/pypto/backend/_ptoas_locate.py
+++ b/python/pypto/backend/_ptoas_locate.py
@@ -12,20 +12,18 @@
 import os
 import shutil
 
-# Probed in order under $PTOAS_ROOT — the release tarball layout changed at
-# v0.51 and the two entries are NOT interchangeable:
+# Probed in order under $PTOAS_ROOT — launcher first, the three entries are NOT
+# interchangeable:
 #
-# - up to v0.50, `<root>/ptoas` is a shell launcher that exports
-#   `LD_LIBRARY_PATH=<root>/lib` before exec'ing `<root>/bin/ptoas`. That bare
-#   binary has no RUNPATH, so invoking it directly dies with
-#   "libMLIR*.so: cannot open shared object file". The launcher must win.
-# - from v0.51, `<root>/ptoas` is a Python package *directory* (not executable),
-#   and `<root>/bin/ptoas` links self-sufficiently — so the probe falls through
-#   to it.
-#
-# Hence launcher-first: it is correct on both layouts, whereas `bin/ptoas`-first
-# silently breaks every pre-v0.51 toolchain.
-PTOAS_RELATIVE_PATHS = ("ptoas", "bin/ptoas")
+# - up to v0.50, `<root>/ptoas` is a shell launcher exporting
+#   `LD_LIBRARY_PATH=<root>/lib`; the bare `<root>/bin/ptoas` has no RUNPATH and
+#   dies with "libMLIR*.so: cannot open shared object file".
+# - from v0.51, `<root>/ptoas` is a Python package *directory* (not executable)
+#   and `<root>/bin/ptoas` links self-sufficiently.
+# - from v0.55 the release bundles its own CPython and only `<root>/ptoas.sh`
+#   selects it; `<root>/bin/ptoas` runs under the caller's `env python3` and
+#   fails with "this ptoas compiler archive requires CPython <x.y>".
+PTOAS_RELATIVE_PATHS = ("ptoas", "ptoas.sh", "bin/ptoas")
 
 
 def find_ptoas_binary() -> str | None:

--- a/python/pypto/backend/pto_backend.py
+++ b/python/pypto/backend/pto_backend.py
@@ -191,8 +191,9 @@ def _run_ptoas(
 ) -> None:
     """Run the ptoas tool to compile a .pto file to C++.
 
-    Locates ptoas via the PTOAS_ROOT env var (``$PTOAS_ROOT/ptoas``, falling back
-    to ``$PTOAS_ROOT/bin/ptoas`` for the v0.51+ layout) or PATH fallback.
+    Locates ptoas via the PTOAS_ROOT env var, probing ``$PTOAS_ROOT/ptoas``
+    (pre-v0.51 launcher), ``$PTOAS_ROOT/ptoas.sh`` (v0.55+ bundled-CPython
+    launcher) then ``$PTOAS_ROOT/bin/ptoas``, or PATH fallback.
 
     Args:
         pto_path: Path to the input .pto file

--- a/tests/ut/backend/test_ptoas_locate.py
+++ b/tests/ut/backend/test_ptoas_locate.py
@@ -12,12 +12,14 @@
 The release tarball layout changed at v0.51: ``<root>/ptoas`` went from being a
 shell launcher (which exports ``LD_LIBRARY_PATH=<root>/lib`` before exec'ing the
 bare ``<root>/bin/ptoas``) to being a Python package *directory*, leaving the now
-self-sufficient ``<root>/bin/ptoas`` as the only binary.
+self-sufficient ``<root>/bin/ptoas`` as the only binary. It changed again at
+v0.55, which bundles its own CPython behind a new ``<root>/ptoas.sh`` launcher.
 
-Discovery must therefore handle both layouts, must never mistake a *directory*
-named ``ptoas`` for the executable, and must keep launcher-first ordering — on
-pre-v0.51 the bare ``bin/ptoas`` has no RUNPATH and dies on its bundled MLIR
-shared objects.
+Discovery must therefore handle all three layouts, must never mistake a
+*directory* named ``ptoas`` for the executable, and must keep launcher-first
+ordering — on pre-v0.51 the bare ``bin/ptoas`` has no RUNPATH and dies on its
+bundled MLIR shared objects, and on v0.55+ it runs under the caller's interpreter
+instead of the bundled one.
 """
 
 from __future__ import annotations
@@ -75,6 +77,23 @@ def test_package_dir_named_ptoas_is_skipped(tmp_path, monkeypatch):
     (root / "ptoas").mkdir(parents=True)
     (root / "ptoas" / "__init__.py").write_text("")
     expected = _make_executable(root / "bin" / "ptoas")
+    monkeypatch.setenv("PTOAS_ROOT", str(root))
+
+    assert find_ptoas_binary() == str(expected)
+
+
+def test_shell_launcher_wins_on_standalone_layout(tmp_path, monkeypatch):
+    """v0.55+ ships all three entries; ``ptoas.sh`` must win.
+
+    Only ``ptoas.sh`` selects the bundled CPython. ``bin/ptoas`` is a
+    ``#!/usr/bin/env python3`` script and fails with "this ptoas compiler archive
+    requires CPython <x.y>" whenever the caller's interpreter differs.
+    """
+    root = tmp_path / "ptoas-bin"
+    (root / "ptoas").mkdir(parents=True)
+    (root / "ptoas" / "__init__.py").write_text("")
+    expected = _make_executable(root / "ptoas.sh")
+    _make_executable(root / "bin" / "ptoas")
     monkeypatch.setenv("PTOAS_ROOT", str(root))
 
     assert find_ptoas_binary() == str(expected)


### PR DESCRIPTION
## Background

`PTOAS_ROOT=/usr/local/ptoas/0.57` (the version pinned in `toolchain/versions.env`) resolved to the wrong entry, and every function failed to compile with `this ptoas compiler archive requires CPython 3.11`.

The standalone release layout has changed twice:

| version | `<root>/ptoas` | `<root>/ptoas.sh` | `<root>/bin/ptoas` |
|---|---|---|---|
| ≤0.50 | bash launcher (file) | absent | bare ELF, no RUNPATH |
| 0.51–0.54 | Python package **dir** | absent | `#!/usr/bin/env python3` |
| 0.55+ | Python package **dir** | bash launcher | `#!/usr/bin/env python3` |

From v0.55 the archive bundles its own interpreter under `<root>/../runtimes/cpython-<x.y>`, reachable only via `ptoas.sh` (which sets `PTOAS_PYTHON`). `bin/ptoas`'s `env python3` picks up the *caller's* interpreter instead, so as soon as the archive's required CPython diverges from the caller's, every function fails.

`_ptoas_locate.py` probed only `("ptoas", "bin/ptoas")`. On 0.55+ the first entry is a directory, so discovery fell through to the broken `bin/ptoas`.

## Change

Insert `"ptoas.sh"` between the two existing probe entries, preserving the launcher-first ordering that pre-v0.51 needs (its bare `bin/ptoas` has no RUNPATH and dies on the bundled MLIR shared objects).

```diff
-PTOAS_RELATIVE_PATHS = ("ptoas", "bin/ptoas")
+PTOAS_RELATIVE_PATHS = ("ptoas", "ptoas.sh", "bin/ptoas")
```

## Validation

Resolution against every locally installed release, caller interpreter CPython 3.10:

| PTOAS_ROOT | resolved |
|---|---|
| 0.48 | `<root>/ptoas` |
| 0.50 | `<root>/ptoas` |
| 0.54 | `<root>/bin/ptoas` |
| 0.55 | `<root>/ptoas.sh` |
| 0.57 | `<root>/ptoas.sh` |
| 0.58 | `<root>/ptoas.sh` |

With the fix, a pypto-lib DeepSeek-V4 `decode_fwd` ep2 compile succeeds on the pinned v0.57; without it all 340 functions fail.

CI is unaffected: `setup-ci-job` installs the cp310 wheel into an isolated venv that has no `ptoas.sh`, so discovery still lands on `bin/ptoas`.
