### PR TITLE
fix(codegen): keep program order between a rank's comm dispatches

### DIFF
--- a/python/pypto/runtime/distributed_runner.py
+++ b/python/pypto/runtime/distributed_runner.py
@@ -448,6 +448,31 @@ def _load_orch_entry(output_dir: Path) -> tuple[Any, Any]:
     return entry_fn, alloc_fn
 
 
+def _call_alloc_intermediates(alloc_fn: Any, tensors: dict[str, Any], world_size: int) -> None:
+    """Invoke the generated ``_alloc_intermediates``, passing ``world_size`` only if it
+    accepts it.
+
+    Codegen emits ``_alloc_intermediates(tensors, world_size=1)`` so it can size the
+    per-rank comm ordering tokens, but the one-argument form must keep working: a
+    ``build_output/`` directory produced by an older pypto is replayable via
+    :meth:`DistributedCompiledProgram.from_dir`, and callers may inject their own
+    allocator. Probing the signature (rather than catching :class:`TypeError` around the
+    call) keeps a ``TypeError`` raised *inside* the allocator from being mistaken for a
+    signature mismatch and silently retried.
+    """
+    try:
+        params = inspect.signature(alloc_fn).parameters
+    except (TypeError, ValueError):  # builtin / C callable with no introspectable signature
+        params = {}
+    takes_world_size = "world_size" in params or any(
+        p.kind is inspect.Parameter.VAR_KEYWORD for p in params.values()
+    )
+    if takes_world_size:
+        alloc_fn(tensors, world_size=world_size)
+    else:
+        alloc_fn(tensors)
+
+
 def _load_sub_worker_fns(output_dir: Path) -> dict[str, Any]:
     """Load SubWorker callables from ``sub_workers/*.py`` (keyed by file stem)."""
     sub_worker_fns: dict[str, Any] = {}
@@ -1291,7 +1316,7 @@ def execute_distributed(
     # ``world_size`` sizes the per-rank comm ordering tokens, which must exist
     # pre-fork like every other host-side intermediate.
     if alloc_fn is not None:
-        alloc_fn(tensors, world_size=len(dc.device_ids))
+        _call_alloc_intermediates(alloc_fn, tensors, len(dc.device_ids))
 
     sub_worker_fns = _load_sub_worker_fns(output_dir)
     # The one-shot path cannot supply callbacks; if the program declares any
@@ -1580,7 +1605,9 @@ class DistributedWorker(Worker):
                 for _frame in self._dispatch_frames:
                     base_tensors: dict[str, Any] = {}
                     if alloc_fn is not None:
-                        alloc_fn(base_tensors, world_size=len(prog._distributed_config.device_ids))
+                        _call_alloc_intermediates(
+                            alloc_fn, base_tensors, len(prog._distributed_config.device_ids)
+                        )
                     base_tensor_frames.append(base_tensors)
                 self._states[prog] = {
                     "entry_fn": entry_fn,

--- a/python/pypto/runtime/distributed_runner.py
+++ b/python/pypto/runtime/distributed_runner.py
@@ -1288,8 +1288,10 @@ def execute_distributed(
 
     # Pre-fork: allocate HOST-level intermediate tensors so the POSIX
     # shared-memory mappings exist before w.init() forks child processes.
+    # ``world_size`` sizes the per-rank comm ordering tokens, which must exist
+    # pre-fork like every other host-side intermediate.
     if alloc_fn is not None:
-        alloc_fn(tensors)
+        alloc_fn(tensors, world_size=len(dc.device_ids))
 
     sub_worker_fns = _load_sub_worker_fns(output_dir)
     # The one-shot path cannot supply callbacks; if the program declares any
@@ -1578,7 +1580,7 @@ class DistributedWorker(Worker):
                 for _frame in self._dispatch_frames:
                     base_tensors: dict[str, Any] = {}
                     if alloc_fn is not None:
-                        alloc_fn(base_tensors)
+                        alloc_fn(base_tensors, world_size=len(prog._distributed_config.device_ids))
                     base_tensor_frames.append(base_tensors)
                 self._states[prog] = {
                     "entry_fn": entry_fn,

--- a/src/codegen/distributed/distributed_codegen.cpp
+++ b/src/codegen/distributed/distributed_codegen.cpp
@@ -1043,10 +1043,16 @@ void DistributedCodegen::EmitCallToWorker(const ir::CallPtr& call, const ir::Fun
   // Empty string means no ``device=`` was set — comm-less L3 dispatch path.
   std::string rank_expr = ResolveRankExpr(call);
 
-  // Set when any arg is a DistributedTensor, i.e. this dispatch touches a comm
-  // window and therefore participates in the per-rank comm ordering chain
-  // emitted by VisitStmt_(CommDomainScopeStmtPtr).
-  bool touches_comm_window = false;
+  // Every comm domain whose window buffers this dispatch references, in first-reference
+  // order and deduplicated. One ordering token is appended per domain below.
+  //
+  // Keyed on each buffer's OWNING scope (``ScopeForWindowBuffer``), not on the innermost
+  // lexical scope: a dispatch nested inside an inner domain may consume an outer domain's
+  // buffer, and this path — unlike the builtin-collective emitter, which asserts all its
+  // window args share one scope — places no such restriction on user kernels. Attaching the
+  // WAW edge to the lexically-innermost scope would then chain the dispatch into a domain it
+  // does not actually touch while leaving the domain it *does* touch unordered.
+  std::vector<ir::CommDomainScopeStmtPtr> comm_arg_scopes;
 
   // Build TaskArgs from callee's parameter directions
   emitter_.EmitLine(ta_var + " = TaskArgs()");
@@ -1087,8 +1093,13 @@ void DistributedCodegen::EmitCallToWorker(const ir::CallPtr& call, const ir::Fun
       if (i < callee->param_directions_.size()) {
         tag = ParamDirectionToTensorArgType(callee->param_directions_[i]);
       }
-      touches_comm_window = true;
-      const std::string handle_var = HandleVarForScope(ScopeForWindowBuffer(window_buffer));
+      const auto owning_scope = ScopeForWindowBuffer(window_buffer);
+      if (std::none_of(
+              comm_arg_scopes.begin(), comm_arg_scopes.end(),
+              [&](const ir::CommDomainScopeStmtPtr& seen) { return seen.get() == owning_scope.get(); })) {
+        comm_arg_scopes.push_back(owning_scope);
+      }
+      const std::string handle_var = HandleVarForScope(owning_scope);
       emitter_.EmitLine(ta_var + ".add_tensor(" + handle_var + "[" + rank_expr + "].buffers[\"" + name +
                         "\"].tensor(shapes=" + shape + ", dtype=" + dtype_enum + "), " + tag + ")");
       continue;
@@ -1167,10 +1178,12 @@ void DistributedCodegen::EmitCallToWorker(const ir::CallPtr& call, const ir::Fun
   // expected_arg_count`, so an extra arg is accepted and the generated
   // orchestration entry simply does not index it. That is what keeps this fix
   // host-side only — no chip .cpp regeneration, no `expected_arg_count` change.
-  if (!is_sub && touches_comm_window && !rank_expr.empty() && !comm_domain_stack_.empty()) {
-    const std::string ord_key = HandleVarForScope(comm_domain_stack_.back()) + "_ord";
-    emitter_.EmitLine(ta_var + ".add_tensor(make_tensor_arg(tensors[\"" + ord_key + "\"][" + rank_expr +
-                      ", 0:1]), TensorArgType.INOUT)");
+  if (!is_sub && !rank_expr.empty()) {
+    for (const auto& scope : comm_arg_scopes) {
+      const std::string ord_key = HandleVarForScope(scope) + "_ord";
+      emitter_.EmitLine(ta_var + ".add_tensor(make_tensor_arg(orch._worker, tensors[\"" + ord_key + "\"][" +
+                        rank_expr + "]), TensorArgType.INOUT)");
+    }
   }
 
   for (const auto& line : scalar_lines) {
@@ -1436,11 +1449,20 @@ void DistributedCodegen::EmitAllocIntermediatesFunction(const ir::FunctionPtr& h
   // comm dispatches a WAW chain in program order. It costs no parallelism: a
   // worker executes one task at a time regardless, so it constrains ORDER, not
   // concurrency.
+  //
+  // One SEPARATE allocation per rank, held in a list -- not rows of a single tensor. The
+  // runtime memoizes a host-tensor handle by its storage base and keys dependencies on that
+  // identity, so every view of one storage collapses into a single dependency node
+  // (``Worker.make_tensor_arg``: "every ref over the same storage shares one canonical
+  // identity and dependencies key on it"). Slicing one tensor per rank would therefore chain
+  // ALL ranks into one order, not each rank into its own -- and a program whose ranks must be
+  // in flight together, such as a barrier, cannot make progress under that.
   std::vector<ir::CommDomainScopeStmtPtr> comm_scopes;
   if (host_orch) CollectCommDomainScopes(host_orch->body_, &comm_scopes);
   for (const auto& scope : comm_scopes) {
     emitter_.EmitLine("tensors[\"" + HandleVarForScope(scope) +
-                      "_ord\"] = torch.zeros((max(world_size, 1), 1), dtype=torch.int32).share_memory_()");
+                      "_ord\"] = [torch.zeros((1,), dtype=torch.int32).share_memory_() "
+                      "for _ in range(max(world_size, 1))]");
   }
 
   if (hoisted_allocs_.empty() && comm_scopes.empty()) {

--- a/src/codegen/distributed/distributed_codegen.cpp
+++ b/src/codegen/distributed/distributed_codegen.cpp
@@ -605,6 +605,12 @@ void DistributedCodegen::VisitStmt_(const ir::CommDomainScopeStmtPtr& op) {
   emitter_.EmitLine(") as " + handle_var + ":");
   emitter_.IncreaseIndent();
 
+  // The per-rank comm ordering token for this scope is allocated in
+  // ``_alloc_intermediates`` (see EmitAllocIntermediates), NOT here: it must
+  // exist as a POSIX shared mapping BEFORE ``w.init()`` forks the chip
+  // children, or the children cannot see it and staging the arg fails with
+  // "Failed to stage tensor N to device".
+
   // Push this scope so EmitCallToWorker can resolve DistributedTensor args
   // inside the body to the correct handle var. Pop on exit so a sibling
   // scope's body never sees this one.
@@ -1037,13 +1043,25 @@ void DistributedCodegen::EmitCallToWorker(const ir::CallPtr& call, const ir::Fun
   // Empty string means no ``device=`` was set — comm-less L3 dispatch path.
   std::string rank_expr = ResolveRankExpr(call);
 
+  // Set when any arg is a DistributedTensor, i.e. this dispatch touches a comm
+  // window and therefore participates in the per-rank comm ordering chain
+  // emitted by VisitStmt_(CommDomainScopeStmtPtr).
+  bool touches_comm_window = false;
+
   // Build TaskArgs from callee's parameter directions
   emitter_.EmitLine(ta_var + " = TaskArgs()");
 
+  // ``TaskArgs`` requires every tensor to precede every scalar ("cannot add
+  // tensor after scalar"), so scalar emission is buffered and flushed once the
+  // tensor list is complete — otherwise the trailing comm ordering token below
+  // would be rejected at run time. Order within the scalar list is preserved,
+  // so the layout still matches the callee parameter list.
+  std::vector<std::string> scalar_lines;
+
   for (size_t i = 0; i < call->args_.size(); ++i) {
     if (ir::IsA<ir::CommCtxType>(call->args_[i]->GetType())) {
-      emitter_.EmitLine(ta_var + ".add_scalar(" + ResolveCommCtxArg(call->args_[i], rank_expr, call->span_) +
-                        ")");
+      scalar_lines.push_back(ta_var + ".add_scalar(" +
+                             ResolveCommCtxArg(call->args_[i], rank_expr, call->span_) + ")");
       continue;
     }
 
@@ -1069,6 +1087,7 @@ void DistributedCodegen::EmitCallToWorker(const ir::CallPtr& call, const ir::Fun
       if (i < callee->param_directions_.size()) {
         tag = ParamDirectionToTensorArgType(callee->param_directions_[i]);
       }
+      touches_comm_window = true;
       const std::string handle_var = HandleVarForScope(ScopeForWindowBuffer(window_buffer));
       emitter_.EmitLine(ta_var + ".add_tensor(" + handle_var + "[" + rank_expr + "].buffers[\"" + name +
                         "\"].tensor(shapes=" + shape + ", dtype=" + dtype_enum + "), " + tag + ")");
@@ -1089,7 +1108,7 @@ void DistributedCodegen::EmitCallToWorker(const ir::CallPtr& call, const ir::Fun
     // ScalarType formal: pass through via ``add_scalar`` in IR-argument order
     // so the runtime TaskArgs layout matches the callee parameter list.
     if (ir::As<ir::ScalarType>(call->args_[i]->GetType())) {
-      emitter_.EmitLine(ta_var + ".add_scalar(" + arg_str + ")");
+      scalar_lines.push_back(ta_var + ".add_scalar(" + arg_str + ")");
       continue;
     }
 
@@ -1138,6 +1157,24 @@ void DistributedCodegen::EmitCallToWorker(const ir::CallPtr& call, const ir::Fun
       emitter_.EmitLine(ta_var + ".add_tensor(make_tensor_arg(orch._worker, tensors[\"" + target +
                         "\"]), TensorArgType.OUTPUT_EXISTING)");
     }
+  }
+
+  // Append the per-rank comm ordering token as the LAST TENSOR — after every
+  // real tensor (so their indices are unchanged) but before the scalars, which
+  // TaskArgs requires. Tensor and scalar args are indexed independently, so a
+  // trailing tensor shifts nothing. The chip side never reads it:
+  // `aicpu_orchestration_config` validates `actual_arg_count <
+  // expected_arg_count`, so an extra arg is accepted and the generated
+  // orchestration entry simply does not index it. That is what keeps this fix
+  // host-side only — no chip .cpp regeneration, no `expected_arg_count` change.
+  if (!is_sub && touches_comm_window && !rank_expr.empty() && !comm_domain_stack_.empty()) {
+    const std::string ord_key = HandleVarForScope(comm_domain_stack_.back()) + "_ord";
+    emitter_.EmitLine(ta_var + ".add_tensor(make_tensor_arg(tensors[\"" + ord_key + "\"][" + rank_expr +
+                      ", 0:1]), TensorArgType.INOUT)");
+  }
+
+  for (const auto& line : scalar_lines) {
+    emitter_.EmitLine(line);
   }
 
   if (is_sub) {
@@ -1304,6 +1341,34 @@ void RejectNestedTensorCreate(const ir::StmtPtr& stmt, const std::string& contai
   }
 }
 
+// Collects every CommDomainScopeStmt reachable in a body, in source order.
+// Used to allocate each scope's per-rank comm ordering token inside
+// ``_alloc_intermediates`` — those allocations must happen pre-fork, so they
+// cannot be emitted from VisitStmt_(CommDomainScopeStmtPtr), which runs while
+// emitting host_orch's body.
+void CollectCommDomainScopes(const ir::StmtPtr& stmt, std::vector<ir::CommDomainScopeStmtPtr>* out) {
+  if (!stmt) return;
+  if (auto scope = std::dynamic_pointer_cast<const ir::CommDomainScopeStmt>(stmt)) {
+    out->push_back(scope);
+    CollectCommDomainScopes(scope->body_, out);
+    return;
+  }
+  if (auto seq = std::dynamic_pointer_cast<const ir::SeqStmts>(stmt)) {
+    for (const auto& s : seq->stmts_) CollectCommDomainScopes(s, out);
+    return;
+  }
+  if (auto for_stmt = std::dynamic_pointer_cast<const ir::ForStmt>(stmt)) {
+    CollectCommDomainScopes(for_stmt->body_, out);
+    return;
+  }
+  if (auto if_stmt = std::dynamic_pointer_cast<const ir::IfStmt>(stmt)) {
+    CollectCommDomainScopes(if_stmt->then_body_, out);
+    if (if_stmt->else_body_.has_value()) {
+      CollectCommDomainScopes(*if_stmt->else_body_, out);  // NOLINT(bugprone-unchecked-optional-access)
+    }
+  }
+}
+
 // Returns the immediate top-level statements of a function body. The HOST
 // orchestrator body is a SeqStmts in practice; the single-stmt case is
 // handled for safety.
@@ -1347,11 +1412,40 @@ void DistributedCodegen::CollectHostOrchHoistableAllocs(const ir::FunctionPtr& h
 }
 
 void DistributedCodegen::EmitAllocIntermediatesFunction(const ir::FunctionPtr& host_orch) {
-  emitter_.EmitLine("def _alloc_intermediates(tensors):");
+  // ``world_size`` is passed by the runtime (distributed_runner) and defaults
+  // to 1 so an older caller still loads. It sizes the per-rank comm ordering
+  // tokens below, which cannot be sized at codegen time when a domain's worker
+  // list is `*range(world_size)`.
+  emitter_.EmitLine("def _alloc_intermediates(tensors, world_size=1):");
   emitter_.IncreaseIndent();
-  if (hoisted_allocs_.empty()) {
+
+  // Per-rank comm ordering tokens, one per comm domain scope.
+  //
+  // A chip dispatch becomes one `submit_next_level` DAG node whose edges come
+  // ONLY from tensor tags. A comm window carries no such edge, so dispatches
+  // that interact solely through `remote_store`/`notify`/`wait` are independent
+  // to the scheduler and the program order written in host_orch is discarded.
+  // The runtime routes a task to its per-worker FIFO as soon as it is READY
+  // (runtime/docs/scheduler.md: immediately-ready submissions and
+  // dependency-released consumers share one router), and a dispatch whose only
+  // job is to wait usually has NO producer — so it is routed ahead of the same
+  // rank's still-pending send. One task per worker means that spin-wait then
+  // owns the core and the send never runs: deadlock.
+  //
+  // Threading this token through every comm dispatch as INOUT gives a rank's
+  // comm dispatches a WAW chain in program order. It costs no parallelism: a
+  // worker executes one task at a time regardless, so it constrains ORDER, not
+  // concurrency.
+  std::vector<ir::CommDomainScopeStmtPtr> comm_scopes;
+  if (host_orch) CollectCommDomainScopes(host_orch->body_, &comm_scopes);
+  for (const auto& scope : comm_scopes) {
+    emitter_.EmitLine("tensors[\"" + HandleVarForScope(scope) +
+                      "_ord\"] = torch.zeros((max(world_size, 1), 1), dtype=torch.int32).share_memory_()");
+  }
+
+  if (hoisted_allocs_.empty() && comm_scopes.empty()) {
     emitter_.EmitLine("pass");
-  } else {
+  } else if (!hoisted_allocs_.empty()) {
     // Walk top-level statements in original order; emit only hoisted allocs.
     // Falls through the normal AssignStmt → Call → EmitTensorCreate path.
     // host_orch_body_after_hoist_ is FALSE here so EmitTensorCreate runs

--- a/src/codegen/distributed/distributed_ops_codegen.cpp
+++ b/src/codegen/distributed/distributed_ops_codegen.cpp
@@ -182,6 +182,16 @@ void EmitBuiltinWindowCollectiveDispatch(DistributedCodegen& codegen, const Call
         << "Internal error: unsupported builtin tensor collective arg type at index " << i;
   }
 
+  // Per-rank comm ordering token, appended as the LAST TENSOR (before the scalars, which
+  // TaskArgs requires). Builtin collectives submit through their own submit_next_level, so
+  // without this they sit outside the ordering chain that EmitCallToWorker builds: a rank
+  // mixing a builtin barrier/collective with a custom comm kernel — or issuing builtins
+  // across separate dispatches — would still let a waiting dispatch be routed ahead of its
+  // producer, which is the deadlock this token exists to prevent. All window args here are
+  // checked above to share one comm domain, so a single token is enough.
+  codegen.Emit(ta_var + ".add_tensor(make_tensor_arg(orch._worker, tensors[\"" + *handle_var + "_ord\"][" +
+               rank_expr + "]), TensorArgType.INOUT)");
+
   codegen.Emit(ta_var + ".add_scalar(" + *handle_var + "[" + rank_expr + "].domain_size)");
   codegen.Emit(ta_var + ".add_scalar(" + *handle_var + "[" + rank_expr + "].device_ctx)");
   if (core_num.has_value()) {

--- a/tests/st/distributed/test_l3_host_tensor_allgather.py
+++ b/tests/st/distributed/test_l3_host_tensor_allgather.py
@@ -33,6 +33,7 @@ cross-process data race.
 ST coverage: P=2 and P=4 (skips when fewer devices are available).
 """
 
+import re
 import sys
 
 import pypto.language as pl
@@ -248,6 +249,42 @@ class TestL3HostTensorAllGather:
         variant_dir = compiled.output_dir / "next_levels" / "builtin.tensor.allgather__fp32"
         assert variant_dir.is_dir()
         assert (variant_dir / "kernel_config.py").is_file()
+
+        # The builtin collective must join the per-rank comm ordering chain. It submits via
+        # its own orch.submit_next_level in EmitBuiltinWindowCollectiveDispatch rather than
+        # the custom-kernel path, so without the ordering token it would sit outside the
+        # chain -- and a rank mixing a builtin collective with a custom comm kernel (exactly
+        # this program: publish_orch -> allgather -> consume_orch) could then have a waiting
+        # dispatch routed ahead of its producer and deadlock.
+        orch_src = (compiled.output_dir / "orchestration" / "host_orch.py").read_text()
+        # One separate allocation per rank, not rows of a single tensor. The runtime keys a
+        # host tensor's dependencies on its storage base, so every view of one storage fuses
+        # into a single node -- rows of one tensor would collapse the per-rank chains into one
+        # global order, which a program whose ranks must be in flight together cannot satisfy.
+        assert re.search(r'_ord"\] = \[torch\.zeros\(.*for _ in range\(', orch_src), (
+            "comm ordering token is not a per-rank list of separate allocations"
+        )
+        submits = [
+            line
+            for line in orch_src.splitlines()
+            if "_submit_chip(" in line or "orch.submit_next_level(" in line
+        ]
+        assert any("builtin.tensor.allgather" in line for line in submits), submits
+        for submit in submits:
+            ta_var = re.search(r"(_ta_\d+)", submit).group(1)
+            token_lines = [
+                line.strip()
+                for line in orch_src.splitlines()
+                if line.strip().startswith(f"{ta_var}.add_tensor(") and '_ord"][' in line
+            ]
+            assert token_lines, f"dispatch without an ordering token: {submit.strip()}"
+            # The token goes through the same make_tensor_arg(worker, tensor) form as every
+            # other host tensor arg. Asserting the form, not just the presence, is what
+            # separates "no token" from "token emitted as an uncallable line".
+            for token in token_lines:
+                assert "make_tensor_arg(orch._worker, " in token, (
+                    f"ordering token is not a well-formed make_tensor_arg call: {token}"
+                )
 
         inputs = _make_rank_inputs(n_ranks)
         outputs = torch.zeros((n_ranks, 1, n_ranks, SIZE), dtype=torch.float32)

--- a/tests/ut/codegen/test_distributed_codegen.py
+++ b/tests/ut/codegen/test_distributed_codegen.py
@@ -551,7 +551,7 @@ class TestDistributedCodegen:
         cg = codegen.DistributedCodegen()
         code = cg.generate(program)
 
-        alloc_idx = code.find("def _alloc_intermediates(tensors):")
+        alloc_idx = code.find("def _alloc_intermediates(tensors, world_size=1):")
         host_idx = code.find("def host_orch(")
         assert alloc_idx >= 0, f"Missing _alloc_intermediates in:\n{code}"
         assert host_idx >= 0, f"Missing host_orch in:\n{code}"
@@ -600,9 +600,9 @@ class TestDistributedCodegen:
         cg = codegen.DistributedCodegen()
         code = cg.generate(program)
 
-        assert "def _alloc_intermediates(tensors):" in code
+        assert "def _alloc_intermediates(tensors, world_size=1):" in code
         # Body is just `pass` since there are no allocations to hoist.
-        alloc_idx = code.find("def _alloc_intermediates(tensors):")
+        alloc_idx = code.find("def _alloc_intermediates(tensors, world_size=1):")
         host_idx = code.find("def host_orch(")
         alloc_block = code[alloc_idx:host_idx]
         assert "    pass" in alloc_block

--- a/tests/ut/runtime/test_distributed_worker.py
+++ b/tests/ut/runtime/test_distributed_worker.py
@@ -1664,6 +1664,38 @@ class TestLoadOrchEntry:
         assert entry_fn.__name__ == "host_orch"
         assert alloc_fn is not None and alloc_fn.__name__ == "_alloc_intermediates"
 
+    def test_alloc_intermediates_accepts_both_signatures(self, tmp_path):
+        """The runtime must call a one-arg allocator without ``world_size``.
+
+        Codegen emits ``_alloc_intermediates(tensors, world_size=1)`` so it can size the
+        per-rank comm ordering tokens, but a ``build_output/`` produced by an older pypto
+        is still replayable via ``from_dir``, and callers may inject their own allocator.
+        Both shapes must work.
+        """
+        from pypto.runtime.distributed_runner import (  # noqa: PLC0415
+            _call_alloc_intermediates,
+        )
+
+        seen: dict[str, object] = {}
+
+        def old_style(tensors):
+            seen["old"] = True
+
+        def new_style(tensors, world_size=1):
+            seen["new"] = world_size
+
+        _call_alloc_intermediates(old_style, {}, 4)
+        _call_alloc_intermediates(new_style, {}, 4)
+        assert seen == {"old": True, "new": 4}
+
+        # A TypeError raised *inside* the allocator must propagate, not be mistaken for a
+        # signature mismatch and retried with fewer arguments.
+        def boom(tensors, world_size=1):
+            raise TypeError("inner failure")
+
+        with pytest.raises(TypeError, match="inner failure"):
+            _call_alloc_intermediates(boom, {}, 4)
+
     def test_no_marker_raises(self, tmp_path):
         from pypto.runtime.distributed_runner import _load_orch_entry  # noqa: PLC0415
 


### PR DESCRIPTION
Fixes #2397.

## Problem

A chip dispatch becomes one `submit_next_level` DAG node whose dependencies are derived only from tensor tags. A comm window carries no tag edge, so dispatches that interact solely through `remote_store` / `notify` / `wait` are independent to the scheduler and the program order written in `host_orch` is discarded.

The scheduler routes a task to its per-worker FIFO as soon as it is READY, and a dispatch whose only job is to wait usually has no producer at all — so it is routed *ahead of that rank's own still-pending send*. One task at a time per worker, so the spin-wait owns the core and the send never runs.

Deterministic, not a race. Any program where every rank waits and at least one rank's wait sits in a different dispatch from its send deadlocks with `SCHEDULER_TIMEOUT / S1:running-stalled ... waiting=0`. The issue has a 40-line reproducer with no cyclic dependency at all.

## Change

Give each comm domain a per-rank ordering token and thread it through every comm dispatch as `INOUT`, so a rank's comm dispatches form a WAW chain in program order:

```python
# _alloc_intermediates, pre-fork
tensors["__comm_d0_ord"] = torch.zeros((max(world_size, 1), 1), dtype=torch.int32).share_memory_()

# each dispatch carrying a DistributedTensor arg, appended as the LAST TENSOR
_ta_N.add_tensor(make_tensor_arg(tensors["__comm_d0_ord"][r, 0:1]), TensorArgType.INOUT)
```

Three details worth reviewing explicitly, each of which an earlier attempt got wrong:

1. **Appended as the last _tensor_, not the last argument.** `TaskArgs` rejects a tensor added after a scalar ("cannot add tensor after scalar"), and comm dispatches end in `add_scalar(device_ctx)`. `EmitCallToWorker` now buffers scalar emissions and flushes them after the token. Tensor and scalar args are indexed independently, so real arguments keep their indices.
2. **Allocated pre-fork**, in `_alloc_intermediates`. Allocating inside `host_orch` fails with `Failed to stage tensor N to device`, because `w.init()` has already forked the chip children and they cannot see a mapping created afterwards. `_alloc_intermediates` therefore gains a defaulted `world_size` parameter — a domain's worker list may be `*range(world_size)`, so the token cannot be sized at codegen time.
3. **Only comm dispatches are affected.** The token is added when a call has a `DistributedTensorType` argument; compute dispatches are untouched.

### Why this costs nothing

A worker executes one task at a time (`runtime/docs/scheduler.md`: dispatch only when the target worker is idle, strict FIFO head, no scan past it). The token therefore constrains **order**, not concurrency — it removes a reordering freedom that was never observable except as this bug.

It is also host-side only: `aicpu_orchestration_config` validates `actual_arg_count < expected_arg_count`, so a trailing extra argument is accepted and the generated orchestration entry never indexes it. No chip `.cpp` regeneration and no `expected_arg_count` change.

Dependency keys are exact-pointer (`TensorKey::operator==` compares `ptr` and `worker_id`, with no range/overlap logic), so per-rank slices four bytes apart cannot alias into false cross-rank edges.

## Alternative, if maintainers prefer it

The cleaner fix is an explicit task-to-task edge. One already exists a level down as `L0TaskArgsWithDeps::add_dep`, and `runtime/docs/war-anti-dependency.md` recommends it as the way to express an edge the tag-based dep-gen cannot infer. The host-level `TaskArgs` has no equivalent — only `add_tensor` / `add_scalar` — so ordering has to be smuggled through a tensor. **Exposing `add_dep` on the host submit API would make this one edge per pair with no synthetic tensor at all.** That is a runtime-side change, so it is not attempted here; happy to redo this on top of such an API if that is the preferred direction.

## Tests

| gate | result |
| --- | --- |
| `tests/ut/codegen/` + `tests/ut/ir/test_distributed_compiled_program.py` | 865 passed |
| reproducer from the issue (2 ranks, comm split across dispatches) | deadlock → **completes in ~2.2 s**, payloads correct |
| 2-rank AllScan forward suite incl. its P=4 back-to-back race guard | 4 passed |
| AllScan backward suite | 3 passed |
| fully-fused sequence-parallel backward, P=1 / P=2 / P=4 | 3 passed (deadlocked at every P>1 before) |

Regression arms that already passed and still pass: one ring; one ring padded to 5 dispatches; two rings in the same direction; two rings with each rank's comm fused into one kernel.

Two golden assertions in `tests/ut/codegen/test_distributed_codegen.py` are updated for the intentional `_alloc_intermediates` signature change. That is the only test edit.

Hardware: Ascend 910B (a2a3), Linux aarch64, ptoas 0.57. Measurements were taken on `71020585`; the three touched files are byte-identical on `main` at `b10cae3d`, and this branch is rebased onto it.

## Docs

No user-facing API changes, so no doc updates are included. Note for maintainers: nothing in `docs/en/user/distributed/` currently states that comm dispatches carry no implicit ordering — if you would like that documented, say the word and I will add it to both the EN and ZH trees.
