### PR TITLE
fix(runtime): make the chip swimlane collection level reachable and rename it to enable_chip_swimlane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -849,7 +849,7 @@ jobs:
         run: |
           source activate.sh
           task-submit --device "$DEVICE_ID" --timeout 3600 --max-time 600 \
-            --run "cd $GITHUB_WORKSPACE/st-direct-checkout && source activate.sh && python -m pytest tests/st/runtime/framework_and_models/test_perf_swimlane.py -v --device=\$TASK_DEVICE --platform=a2a3 --enable-l2-swimlane --forked"
+            --run "cd $GITHUB_WORKSPACE/st-direct-checkout && source activate.sh && python -m pytest tests/st/runtime/framework_and_models/test_perf_swimlane.py -v --device=\$TASK_DEVICE --platform=a2a3 --enable-chip-swimlane --forked"
 
       - name: Test dump-args output
         run: |

--- a/docs/en/dev/01-compile-profiling.md
+++ b/docs/en/dev/01-compile-profiling.md
@@ -139,7 +139,7 @@ calls (sub-microsecond on modern hardware).
 
 ## Related
 
-- **Runtime DFX** (`RunConfig.enable_l2_swimlane`, `enable_dump_args`,
+- **Runtime DFX** (`RunConfig.enable_chip_swimlane`, `enable_dump_args`,
   `enable_pmu`, `enable_dep_gen`) drives Simpler's per-task diagnostic
   artefacts — swimlane records, tensor I/O dumps, AICore PMU CSVs, and
   PTO2 dep_gen edges. The four flags are independent, share

--- a/docs/en/dev/03-runtime-dfx.md
+++ b/docs/en/dev/03-runtime-dfx.md
@@ -11,7 +11,7 @@ renamed `enable_chip_swimlane` member.
 
 | `RunConfig` field | pytest flag | `CallConfig` member | Artefact under `dfx_outputs/` | Post-run converter |
 | ----------------- | ----------- | ------------------- | ----------------------------- | ------------------ |
-| `enable_l2_swimlane: bool` | `--enable-l2-swimlane` | `enable_chip_swimlane` | `chip_swimlane_records.json` | `swimlane_converter` → `merged_swimlane_*.json` |
+| `enable_l2_swimlane: int` | `--enable-l2-swimlane [PERF_LEVEL]` (bare = `4`) | `enable_chip_swimlane` (`0` off .. `4` full) | `chip_swimlane_records.json` | `swimlane_converter` → `merged_swimlane_*.json` |
 | `enable_dump_args: int` | `--dump-args [LEVEL]` (bare = `1`) | `enable_dump_args` (`0` off, `1` partial, `2` full) | `args_dump/{args_dump.json,bin}` | `dump_viewer` (manual) |
 | `enable_pmu: int` | `--enable-pmu [N]` (bare = `2`) | `enable_pmu` (`0` off, `>0` event type) | `pmu.csv` | — |
 | `enable_dep_gen: bool` | `--enable-dep-gen` | `enable_dep_gen` | `deps.json` | `deps_viewer` (manual) |
@@ -20,6 +20,24 @@ renamed `enable_chip_swimlane` member.
 The five flags are **fully independent** and may be combined in any
 subset. Enabling *any* of them auto-forces `RunConfig.save_kernels=True`
 so the `<work_dir>/dfx_outputs/` directory survives the run.
+
+### Swimlane collection levels
+
+`enable_l2_swimlane` is a **level**, not a toggle. Each level is a real guard
+in the runtime collectors, so a lower level never stamps the data a higher one
+does and no post-processing recovers it:
+
+| Level | Adds | Unlocks |
+| ----- | ---- | ------- |
+| `0` / `False` | — | collection off |
+| `1` | AICore per-task start / end + task record buffer | per-task lanes |
+| `2` | + AICPU-stamped dispatch / finish | the `[dispatch, start]` pickup gap |
+| `3` | + scheduler main-loop phase records | `simpler_setup.tools.sched_overhead_analysis`, the Toolkit plugin's Scheduler View |
+| `4` / `True` | + orchestrator phase records | the Toolkit plugin's AICPU Orchestrator view |
+
+`True` requests level `4`, matching the bare `--enable-l2-swimlane` and the
+runtime harness's bare `--enable-chip-swimlane`. An out-of-range level raises
+`ValueError` from `RunConfig`.
 
 ## Output contract
 
@@ -129,7 +147,8 @@ run(
     MyProgram, a, b, c,
     config=RunConfig(
         platform="a2a3sim",
-        enable_l2_swimlane=True,     # produces chip_swimlane_records.json
+        enable_l2_swimlane=4,        # full swimlane -> chip_swimlane_records.json
+                                     # (True is the same level 4; use 1-3 for less)
         enable_dep_gen=True,         # produces deps.json (render with deps_viewer on demand)
         enable_pmu=4,                # PMU event = MEMORY
     ),
@@ -139,11 +158,13 @@ run(
 ### From pytest
 
 ```bash
+# Bare flag = level 4 (full)
 pytest tests/st/runtime/framework_and_models/test_perf_swimlane.py \
     --platform a2a3sim --enable-l2-swimlane
 
+# AICore timing only — the cheapest capture
 pytest tests/st/runtime/ \
-    --platform a2a3sim --enable-l2-swimlane --enable-dep-gen
+    --platform a2a3sim --enable-l2-swimlane 1 --enable-dep-gen
 ```
 
 ## Selective tensor dump

--- a/docs/en/dev/03-runtime-dfx.md
+++ b/docs/en/dev/03-runtime-dfx.md
@@ -3,15 +3,15 @@
 PyPTO exposes Simpler's five runtime diagnostic sub-features as independent
 toggles on [`RunConfig`](../../../python/pypto/runtime/runner.py). Each
 toggle maps to a field on Simpler's `CallConfig` and to the matching pytest
-flag in `tests/st/conftest.py`. PyPTO retains the public
-`enable_l2_swimlane` spelling for compatibility while mapping it to Simpler's
-renamed `enable_chip_swimlane` member.
+flag in `tests/st/conftest.py`. Field names match Simpler's; the former
+`enable_l2_swimlane` / `--enable-l2-swimlane` spellings still work and are
+covered under [Deprecated aliases](#deprecated-aliases).
 
 ## Flag matrix
 
 | `RunConfig` field | pytest flag | `CallConfig` member | Artefact under `dfx_outputs/` | Post-run converter |
 | ----------------- | ----------- | ------------------- | ----------------------------- | ------------------ |
-| `enable_l2_swimlane: int` | `--enable-l2-swimlane [PERF_LEVEL]` (bare = `4`) | `enable_chip_swimlane` (`0` off .. `4` full) | `chip_swimlane_records.json` | `swimlane_converter` → `merged_swimlane_*.json` |
+| `enable_chip_swimlane: int` | `--enable-chip-swimlane` (= `4`) / `--chip-swimlane-level N` | `enable_chip_swimlane` (`0` off .. `4` full) | `chip_swimlane_records.json` | `swimlane_converter` → `merged_swimlane_*.json` |
 | `enable_dump_args: int` | `--dump-args [LEVEL]` (bare = `1`) | `enable_dump_args` (`0` off, `1` partial, `2` full) | `args_dump/{args_dump.json,bin}` | `dump_viewer` (manual) |
 | `enable_pmu: int` | `--enable-pmu [N]` (bare = `2`) | `enable_pmu` (`0` off, `>0` event type) | `pmu.csv` | — |
 | `enable_dep_gen: bool` | `--enable-dep-gen` | `enable_dep_gen` | `deps.json` | `deps_viewer` (manual) |
@@ -23,7 +23,7 @@ so the `<work_dir>/dfx_outputs/` directory survives the run.
 
 ### Swimlane collection levels
 
-`enable_l2_swimlane` is a **level**, not a toggle. Each level is a real guard
+`enable_chip_swimlane` is a **level**, not a toggle. Each level is a real guard
 in the runtime collectors, so a lower level never stamps the data a higher one
 does and no post-processing recovers it:
 
@@ -35,9 +35,16 @@ does and no post-processing recovers it:
 | `3` | + scheduler main-loop phase records | `simpler_setup.tools.sched_overhead_analysis`, the Toolkit plugin's Scheduler View |
 | `4` / `True` | + orchestrator phase records | the Toolkit plugin's AICPU Orchestrator view |
 
-`True` requests level `4`, matching the bare `--enable-l2-swimlane` and the
-runtime harness's bare `--enable-chip-swimlane`. An out-of-range level raises
-`ValueError` from `RunConfig`.
+`True` requests level `4` — the same thing the bare `--enable-chip-swimlane`
+flag requests, in PyPTO and in the runtime harness alike. An out-of-range level
+raises `ValueError` from `RunConfig`.
+
+On the pytest surface the bare flag and the level are **two** options
+(`--enable-chip-swimlane` and `--chip-swimlane-level N`) rather than one
+optional-valued option. An optional-valued flag swallows the following token, so
+`pytest --enable-chip-swimlane tests/st/runtime/` would fail with
+`invalid int value: 'tests/st/runtime/'`. Splitting them keeps the bare flag
+order-independent.
 
 ## Output contract
 
@@ -94,7 +101,7 @@ dependency arrows. But dep_gen collection has high overhead that perturbs the
 very timing the swimlane measures. The two captures therefore come from separate
 runs (Simpler's documented "capture the graph once, time many times" workflow).
 
-For **onboard L2**, enabling `enable_l2_swimlane` runs the kernel twice,
+For **onboard L2**, enabling `enable_chip_swimlane` runs the kernel twice,
 transparently:
 
 1. **Graph pass** — dep_gen only, producing `deps.json`. Runs in a **separate
@@ -147,7 +154,7 @@ run(
     MyProgram, a, b, c,
     config=RunConfig(
         platform="a2a3sim",
-        enable_l2_swimlane=4,        # full swimlane -> chip_swimlane_records.json
+        enable_chip_swimlane=4,        # full swimlane -> chip_swimlane_records.json
                                      # (True is the same level 4; use 1-3 for less)
         enable_dep_gen=True,         # produces deps.json (render with deps_viewer on demand)
         enable_pmu=4,                # PMU event = MEMORY
@@ -160,11 +167,11 @@ run(
 ```bash
 # Bare flag = level 4 (full)
 pytest tests/st/runtime/framework_and_models/test_perf_swimlane.py \
-    --platform a2a3sim --enable-l2-swimlane
+    --platform a2a3sim --enable-chip-swimlane
 
 # AICore timing only — the cheapest capture
 pytest tests/st/runtime/ \
-    --platform a2a3sim --enable-l2-swimlane 1 --enable-dep-gen
+    --platform a2a3sim --chip-swimlane-level 1 --enable-dep-gen
 ```
 
 ## Selective tensor dump
@@ -296,7 +303,7 @@ By default the swimlane / dependency-graph tools label tasks by numeric
 id (`task(rXtY)` / `func_<id>(...)`). To recover real kernel names
 (`matmul(rXtY)`), a name map must sit next to the records. Simpler's own
 SceneTest harness writes this file; pypto does not use SceneTest, so when
-`enable_l2_swimlane` or `enable_dep_gen` is set the runner synthesises
+`enable_chip_swimlane` or `enable_dep_gen` is set the runner synthesises
 `<work_dir>/dfx_outputs/name_map_<case>.json` from the `func_id` / `name`
 fields already in `kernel_config.py`. It is consumed automatically:
 `swimlane_converter` is invoked with `--func-names <name_map>`, and
@@ -335,12 +342,33 @@ this hint at the end of every scope-stats-enabled run.
 
 ## Deprecated aliases
 
-`RunConfig.runtime_profiling` and the pytest flag `--runtime-profiling`
-were the original way to opt into L2 swimlane capture before the four
-DFX features became independently controllable. They are kept as
-aliases for `enable_l2_swimlane` / `--enable-l2-swimlane` so existing
-scripts keep working; both paths emit a `DeprecationWarning` and will
-be removed in a future release. Migrate to the new names.
+`RunConfig.enable_l2_swimlane` and the pytest flag `--enable-l2-swimlane`
+are the former spellings of `enable_chip_swimlane` /
+`--enable-chip-swimlane`. Simpler's Worker/Chip/Core naming migration
+renamed the L2 layer to "chip" (`L2Swimlane*` -> `ChipSwimlane*`,
+`l2_swimlane_records.json` -> `chip_swimlane_records.json`), and PyPTO now
+follows that contract.
+
+Both old spellings keep working and emit a `DeprecationWarning`; they will
+be removed in a future release. Values and semantics are unchanged, so
+migration is a rename:
+
+```python
+RunConfig(enable_l2_swimlane=True)    # deprecated
+RunConfig(enable_chip_swimlane=4)     # same capture
+```
+
+Details worth knowing:
+
+- `enable_l2_swimlane` is **not** a dataclass field — it is a constructor
+  keyword plus a property. That keeps `dataclasses.replace(cfg,
+  enable_chip_swimlane=N)` unambiguous; an alias field would be re-supplied
+  by `replace()` from the old instance and could silently override the value
+  you just passed.
+- Reading `cfg.enable_l2_swimlane` is silent (it returns the canonical
+  level). Passing the old constructor keyword, or assigning to the
+  attribute, warns.
+- Passing both spellings at once raises `ValueError`.
 
 ## Replaying an existing build_output
 

--- a/docs/en/dev/03-runtime-replay.md
+++ b/docs/en/dev/03-runtime-replay.md
@@ -21,7 +21,7 @@ replay(
     config=RunConfig(
         platform="a2a3sim",
         enable_pmu=2,
-        enable_l2_swimlane=True,
+        enable_chip_swimlane=True,
     ),
 )
 ```

--- a/docs/en/user/00-getting_started.md
+++ b/docs/en/user/00-getting_started.md
@@ -150,7 +150,7 @@ a per-launch timing object. The runtime emits per-run host/device timing as
 `[STRACE]` log markers (simpler PR #1177, on by default under
 `SIMPLER_DFX`); parse them with simpler's `strace_timing` /
 `device_log_timing` tools rather than reading a return value. For per-task
-device timing, enable the L2 swimlane DFX (`RunConfig(enable_l2_swimlane=True)`)
+device timing, enable the L2 swimlane DFX (`RunConfig(enable_chip_swimlane=True)`)
 and read `chip_swimlane_records.json`.
 
 ### Benchmarking (`benchmark`)

--- a/docs/en/user/distributed/04-debugging.md
+++ b/docs/en/user/distributed/04-debugging.md
@@ -57,7 +57,7 @@ SIMPLER_DEVICE_STRACE_ENABLE=0 python script.py
 
 ### Distributed DFX Entry Points
 
-- **L2 swimlane:** `RunConfig(enable_l2_swimlane=True)` — enables per-task timing
+- **L2 swimlane:** `RunConfig(enable_chip_swimlane=True)` — enables per-task timing
   inside the worker, propagates through L3 orchestration. Writes
   `dfx_outputs/chip_swimlane_records.json` (onboard: merged into
   `merged_swimlane_*.json` alongside the dependency graph below).

--- a/docs/en/user/performance/00-swimlane.md
+++ b/docs/en/user/performance/00-swimlane.md
@@ -28,7 +28,7 @@ from pypto.runtime import ChipWorker, RunConfig
 
 cfg = RunConfig(
     platform="a2a3",
-    enable_l2_swimlane=True,   # per-task timing
+    enable_l2_swimlane=4,      # per-task timing, full collection
     enable_dep_gen=True,       # the task DAG the timing is joined against
     save_kernels=True,         # keep the output directory
 )
@@ -47,7 +47,7 @@ Both land under the run's output directory:
 recorded in the swimlane record itself, to keep the device hot path clean. The join happens
 afterwards, on the host.
 
-### Collection is levelled, and `RunConfig` requests full collection
+### Collection is levelled
 
 The runtime collects at one of four levels, each adding to the one below:
 
@@ -62,10 +62,17 @@ Each level is a real guard in the collectors, not a verbosity setting: at level 
 dispatch and finish timestamps are **never stamped**, so no post-processing can recover
 them.
 
-> **`RunConfig.enable_l2_swimlane` remains a `bool` compatibility spelling. `True` maps to
-> Simpler's `enable_chip_swimlane` level 4 (full collection); `False` maps to 0.** The typed
-> `RunConfig` API does not expose levels 1–3; use the runtime harness's
-> `--enable-chip-swimlane <1|2|3>` when a lower collection level is required.
+`RunConfig.enable_l2_swimlane` **is** that level — pass any of `0`-`4` to request it:
+
+```python
+cfg = RunConfig(platform="a2a3", enable_l2_swimlane=3,  # sched phases and below
+                enable_dep_gen=True, save_kernels=True)
+```
+
+`True` is accepted for source compatibility and means level `4` (full), matching the bare
+`--enable-l2-swimlane` and the runtime harness's bare `--enable-chip-swimlane`; `False`
+means `0`. Higher levels collect more and therefore perturb timing more, so drop to the
+lowest level that answers your question.
 
 ### Two things that will mislead you if you do not know them
 
@@ -159,9 +166,8 @@ python -m simpler_setup.tools.sched_overhead_analysis \
     --chip-swimlane-records-json <records>.json --deps-json <deps>.json
 ```
 
-This one needs a **level ≥ 3** capture for its scheduler-loop parts. `RunConfig`'s full
-level-4 capture satisfies that requirement; use the runtime harness's
-`--enable-chip-swimlane <level>` only when selecting a different collection level.
+This one needs a **level ≥ 3** capture for its scheduler-loop parts —
+`RunConfig(enable_l2_swimlane=3)` or the default full level `4`.
 
 It reports per-engine and system-wide overhead as a share of the makespan, the pickup-cost
 distribution, the AICPU scheduler-loop budget, and a critical-path attribution splitting

--- a/docs/en/user/performance/00-swimlane.md
+++ b/docs/en/user/performance/00-swimlane.md
@@ -28,7 +28,7 @@ from pypto.runtime import ChipWorker, RunConfig
 
 cfg = RunConfig(
     platform="a2a3",
-    enable_l2_swimlane=4,      # per-task timing, full collection
+    enable_chip_swimlane=4,      # per-task timing, full collection
     enable_dep_gen=True,       # the task DAG the timing is joined against
     save_kernels=True,         # keep the output directory
 )
@@ -62,17 +62,16 @@ Each level is a real guard in the collectors, not a verbosity setting: at level 
 dispatch and finish timestamps are **never stamped**, so no post-processing can recover
 them.
 
-`RunConfig.enable_l2_swimlane` **is** that level — pass any of `0`-`4` to request it:
+`RunConfig.enable_chip_swimlane` **is** that level — pass any of `0`-`4` to request it:
 
 ```python
-cfg = RunConfig(platform="a2a3", enable_l2_swimlane=3,  # sched phases and below
+cfg = RunConfig(platform="a2a3", enable_chip_swimlane=3,  # sched phases and below
                 enable_dep_gen=True, save_kernels=True)
 ```
 
-`True` is accepted for source compatibility and means level `4` (full), matching the bare
-`--enable-l2-swimlane` and the runtime harness's bare `--enable-chip-swimlane`; `False`
-means `0`. Higher levels collect more and therefore perturb timing more, so drop to the
-lowest level that answers your question.
+`True` is accepted for source compatibility and means level `4` (full) — the same thing the
+bare `--enable-chip-swimlane` flag requests; `False` means `0`. Higher levels collect more
+and therefore perturb timing more, so drop to the lowest level that answers your question.
 
 ### Two things that will mislead you if you do not know them
 
@@ -167,7 +166,7 @@ python -m simpler_setup.tools.sched_overhead_analysis \
 ```
 
 This one needs a **level ≥ 3** capture for its scheduler-loop parts —
-`RunConfig(enable_l2_swimlane=3)` or the default full level `4`.
+`RunConfig(enable_chip_swimlane=3)` or the default full level `4`.
 
 It reports per-engine and system-wide overhead as a share of the makespan, the pickup-cost
 distribution, the AICPU scheduler-loop budget, and a critical-path attribution splitting

--- a/docs/en/user/tutorials/05-scheduling-tuning.md
+++ b/docs/en/user/tutorials/05-scheduling-tuning.md
@@ -18,7 +18,7 @@ observations.
 | Question | Flag | Output |
 | -------- | ---- | ------ |
 | What shape is the graph? | `enable_dep_gen=True` | `<work_dir>/dfx_outputs/deps.json` |
-| Did tasks actually overlap? | `enable_l2_swimlane=True` | `<work_dir>/dfx_outputs/chip_swimlane_records.json` |
+| Did tasks actually overlap? | `enable_chip_swimlane=True` | `<work_dir>/dfx_outputs/chip_swimlane_records.json` |
 | Are runtime rings near full? | `enable_scope_stats=True` | `<work_dir>/dfx_outputs/scope_stats/scope_stats.jsonl` |
 | Which pipe is the bottleneck? | `enable_pmu=2` | `<work_dir>/dfx_outputs/pmu.csv` |
 
@@ -54,7 +54,7 @@ readings worth having:
 A parallel graph does not guarantee parallel execution. The swimlane shows per-task timing:
 
 ```python
-kernel(a, b, out, config=RunConfig(platform="a2a3sim", enable_l2_swimlane=True))
+kernel(a, b, out, config=RunConfig(platform="a2a3sim", enable_chip_swimlane=True))
 ```
 
 > **Simulator caveat:** on `*sim` platforms this is single-pass and emits only

--- a/docs/zh/dev/01-compile-profiling.md
+++ b/docs/zh/dev/01-compile-profiling.md
@@ -137,7 +137,7 @@ with CompileProfiler() as prof:
 
 ## 相关功能
 
-- **运行时 DFX**（`RunConfig.enable_l2_swimlane` / `enable_dump_args` /
+- **运行时 DFX**（`RunConfig.enable_chip_swimlane` / `enable_dump_args` /
   `enable_pmu` / `enable_dep_gen`）驱动 Simpler 的每任务诊断产物 —— swimlane
   记录、tensor I/O dump、AICore PMU CSV、PTO2 dep_gen 边。四个 flag 互相
   独立，共用 `<work_dir>/dfx_outputs/` 作为输出根目录，与编译 profiling

--- a/docs/zh/dev/03-runtime-dfx.md
+++ b/docs/zh/dev/03-runtime-dfx.md
@@ -10,7 +10,7 @@ flag。为保持调用方兼容，PyPTO 保留公开名称 `enable_l2_swimlane`�
 
 | `RunConfig` 字段 | pytest flag | `CallConfig` 成员 | `dfx_outputs/` 下产物 | 后处理工具 |
 | ---------------- | ----------- | ----------------- | --------------------- | ---------- |
-| `enable_l2_swimlane: bool` | `--enable-l2-swimlane` | `enable_chip_swimlane` | `chip_swimlane_records.json` | `swimlane_converter` → `merged_swimlane_*.json` |
+| `enable_l2_swimlane: int` | `--enable-l2-swimlane [PERF_LEVEL]`（裸 flag = `4`） | `enable_chip_swimlane`（`0` 关 .. `4` 全量） | `chip_swimlane_records.json` | `swimlane_converter` → `merged_swimlane_*.json` |
 | `enable_dump_args: int` | `--dump-args [LEVEL]`（裸 flag = `1`） | `enable_dump_args`（`0` 关，`1` 部分，`2` 全量） | `args_dump/{args_dump.json,bin}` | `dump_viewer`（手动） |
 | `enable_pmu: int` | `--enable-pmu [N]`（裸 flag = `2`） | `enable_pmu`（`0` 关，`>0` 事件类型） | `pmu.csv` | — |
 | `enable_dep_gen: bool` | `--enable-dep-gen` | `enable_dep_gen` | `deps.json` | `deps_viewer`（手动） |
@@ -19,6 +19,22 @@ flag。为保持调用方兼容，PyPTO 保留公开名称 `enable_l2_swimlane`�
 五个开关**完全正交**，可任意组合。任一开启时自动将
 `RunConfig.save_kernels` 强制设为 `True`，确保 `<work_dir>/dfx_outputs/`
 目录在 run 结束后保留。
+
+### Swimlane 采集等级
+
+`enable_l2_swimlane` 是**等级**而非开关。每个等级在 runtime 采集器里都是真实的
+判断分支，低等级不会打点高等级才有的数据，事后也无法通过后处理补回：
+
+| 等级 | 新增内容 | 解锁能力 |
+| ---- | -------- | -------- |
+| `0` / `False` | — | 关闭采集 |
+| `1` | AICore 逐任务 start / end + task record buffer | 逐任务泳道 |
+| `2` | + AICPU 打点的 dispatch / finish | `[dispatch, start]` 取任务间隙 |
+| `3` | + scheduler 主循环 phase 记录 | `simpler_setup.tools.sched_overhead_analysis`、Toolkit 插件的 Scheduler View |
+| `4` / `True` | + orchestrator phase 记录 | Toolkit 插件的 AICPU Orchestrator 视图 |
+
+`True` 请求等级 `4`，与裸 `--enable-l2-swimlane` 以及 runtime harness 的裸
+`--enable-chip-swimlane` 一致。超出范围的等级由 `RunConfig` 抛 `ValueError`。
 
 ## 产物契约
 
@@ -110,7 +126,8 @@ run(
     MyProgram, a, b, c,
     config=RunConfig(
         platform="a2a3sim",
-        enable_l2_swimlane=True,     # 生成 chip_swimlane_records.json
+        enable_l2_swimlane=4,        # 全量 swimlane -> chip_swimlane_records.json
+                                     # （True 等价于等级 4；需要更轻量时用 1-3）
         enable_dep_gen=True,         # 生成 deps.json（按需用 deps_viewer 渲染 HTML）
         enable_pmu=4,                # PMU 事件 = MEMORY
     ),
@@ -120,11 +137,13 @@ run(
 ### 从 pytest
 
 ```bash
+# 裸 flag = 等级 4（全量）
 pytest tests/st/runtime/framework_and_models/test_perf_swimlane.py \
     --platform a2a3sim --enable-l2-swimlane
 
+# 仅 AICore 计时——最轻量的采集
 pytest tests/st/runtime/ \
-    --platform a2a3sim --enable-l2-swimlane --enable-dep-gen
+    --platform a2a3sim --enable-l2-swimlane 1 --enable-dep-gen
 ```
 
 ## 选择性张量 Dump

--- a/docs/zh/dev/03-runtime-dfx.md
+++ b/docs/zh/dev/03-runtime-dfx.md
@@ -3,14 +3,14 @@
 PyPTO 将 Simpler 的五项运行时诊断子功能以独立开关的形式暴露在
 [`RunConfig`](../../../python/pypto/runtime/runner.py) 上。每个开关都映射到
 Simpler 的 `CallConfig` 字段，以及 `tests/st/conftest.py` 中对应的 pytest
-flag。为保持调用方兼容，PyPTO 保留公开名称 `enable_l2_swimlane`，但内部
-映射到 Simpler 已更名的 `enable_chip_swimlane` 成员。
+flag。字段名与 Simpler 保持一致；旧拼写 `enable_l2_swimlane` /
+`--enable-l2-swimlane` 仍可用，见[已弃用别名](#已弃用别名)。
 
 ## 开关映射表
 
 | `RunConfig` 字段 | pytest flag | `CallConfig` 成员 | `dfx_outputs/` 下产物 | 后处理工具 |
 | ---------------- | ----------- | ----------------- | --------------------- | ---------- |
-| `enable_l2_swimlane: int` | `--enable-l2-swimlane [PERF_LEVEL]`（裸 flag = `4`） | `enable_chip_swimlane`（`0` 关 .. `4` 全量） | `chip_swimlane_records.json` | `swimlane_converter` → `merged_swimlane_*.json` |
+| `enable_chip_swimlane: int` | `--enable-chip-swimlane`（= `4`）/ `--chip-swimlane-level N` | `enable_chip_swimlane`（`0` 关 .. `4` 全量） | `chip_swimlane_records.json` | `swimlane_converter` → `merged_swimlane_*.json` |
 | `enable_dump_args: int` | `--dump-args [LEVEL]`（裸 flag = `1`） | `enable_dump_args`（`0` 关，`1` 部分，`2` 全量） | `args_dump/{args_dump.json,bin}` | `dump_viewer`（手动） |
 | `enable_pmu: int` | `--enable-pmu [N]`（裸 flag = `2`） | `enable_pmu`（`0` 关，`>0` 事件类型） | `pmu.csv` | — |
 | `enable_dep_gen: bool` | `--enable-dep-gen` | `enable_dep_gen` | `deps.json` | `deps_viewer`（手动） |
@@ -22,7 +22,7 @@ flag。为保持调用方兼容，PyPTO 保留公开名称 `enable_l2_swimlane`�
 
 ### Swimlane 采集等级
 
-`enable_l2_swimlane` 是**等级**而非开关。每个等级在 runtime 采集器里都是真实的
+`enable_chip_swimlane` 是**等级**而非开关。每个等级在 runtime 采集器里都是真实的
 判断分支，低等级不会打点高等级才有的数据，事后也无法通过后处理补回：
 
 | 等级 | 新增内容 | 解锁能力 |
@@ -33,8 +33,13 @@ flag。为保持调用方兼容，PyPTO 保留公开名称 `enable_l2_swimlane`�
 | `3` | + scheduler 主循环 phase 记录 | `simpler_setup.tools.sched_overhead_analysis`、Toolkit 插件的 Scheduler View |
 | `4` / `True` | + orchestrator phase 记录 | Toolkit 插件的 AICPU Orchestrator 视图 |
 
-`True` 请求等级 `4`，与裸 `--enable-l2-swimlane` 以及 runtime harness 的裸
-`--enable-chip-swimlane` 一致。超出范围的等级由 `RunConfig` 抛 `ValueError`。
+`True` 请求等级 `4` —— 与裸 `--enable-chip-swimlane` 请求的是同一件事，PyPTO
+与 runtime harness 皆然。超出范围的等级由 `RunConfig` 抛 `ValueError`。
+
+在 pytest 侧，裸 flag 与等级是**两个**选项（`--enable-chip-swimlane` 与
+`--chip-swimlane-level N`），而不是一个可选带值的选项。可选带值的 flag 会吞掉
+后面那个 token，`pytest --enable-chip-swimlane tests/st/runtime/` 会报
+`invalid int value: 'tests/st/runtime/'`。拆成两个选项后，裸 flag 与参数顺序无关。
 
 ## 产物契约
 
@@ -83,7 +88,7 @@ join——device 热路径不再记录 per-task fanout，因此没有 dep_gen �
 耗时。所以这两份抓取来自两次独立运行（这正是 Simpler 文档描述的“抓一次图、计多次
 时”工作流）。
 
-于是在 **onboard L2** 平台上开启 `enable_l2_swimlane` 会透明地把 kernel 跑两遍：
+于是在 **onboard L2** 平台上开启 `enable_chip_swimlane` 会透明地把 kernel 跑两遍：
 
 1. **抓图趟** —— 仅开 dep_gen，产出 `deps.json`，在**独立子进程**里运行
    （`python -m pypto.runtime._dep_gen_capture`）。这是必须的、不只是为了整洁：
@@ -126,7 +131,7 @@ run(
     MyProgram, a, b, c,
     config=RunConfig(
         platform="a2a3sim",
-        enable_l2_swimlane=4,        # 全量 swimlane -> chip_swimlane_records.json
+        enable_chip_swimlane=4,        # 全量 swimlane -> chip_swimlane_records.json
                                      # （True 等价于等级 4；需要更轻量时用 1-3）
         enable_dep_gen=True,         # 生成 deps.json（按需用 deps_viewer 渲染 HTML）
         enable_pmu=4,                # PMU 事件 = MEMORY
@@ -139,11 +144,11 @@ run(
 ```bash
 # 裸 flag = 等级 4（全量）
 pytest tests/st/runtime/framework_and_models/test_perf_swimlane.py \
-    --platform a2a3sim --enable-l2-swimlane
+    --platform a2a3sim --enable-chip-swimlane
 
 # 仅 AICore 计时——最轻量的采集
 pytest tests/st/runtime/ \
-    --platform a2a3sim --enable-l2-swimlane 1 --enable-dep-gen
+    --platform a2a3sim --chip-swimlane-level 1 --enable-dep-gen
 ```
 
 ## 选择性张量 Dump
@@ -262,7 +267,7 @@ twopi`。`dot` 是默认值，在 ~500 节点以内 DAG 风格最清晰；更大
 默认情况下，swimlane / 依赖图工具用数字 id 标注任务（`task(rXtY)` /
 `func_<id>(...)`）。要恢复真实 kernel 名称（`matmul(rXtY)`），records
 旁边必须有一份 name map。Simpler 自带的 SceneTest harness 会写这个文件；
-pypto 不使用 SceneTest，因此当开启 `enable_l2_swimlane` 或
+pypto 不使用 SceneTest，因此当开启 `enable_chip_swimlane` 或
 `enable_dep_gen` 时，runner 会从 `kernel_config.py` 已有的 `func_id` /
 `name` 字段合成 `<work_dir>/dfx_outputs/name_map_<case>.json`。它会被自动
 消费：`swimlane_converter` 通过 `--func-names <name_map>` 调用，
@@ -300,11 +305,29 @@ python runtime/tools/scope_stats_plot.py \
 
 ## 已弃用别名
 
-`RunConfig.runtime_profiling` 与 pytest flag `--runtime-profiling` 是
-四项 DFX 独立化之前唯一启用 L2 swimlane 采集的入口，现作为
-`enable_l2_swimlane` / `--enable-l2-swimlane` 的别名暂时保留，以兼容
-仍在使用它们的外部脚本。两条路径都会发出 `DeprecationWarning`，并将
-在未来版本中移除，请尽快迁移到新名称。
+`RunConfig.enable_l2_swimlane` 与 pytest flag `--enable-l2-swimlane` 是
+`enable_chip_swimlane` / `--enable-chip-swimlane` 的旧拼写。Simpler 的
+Worker/Chip/Core 命名迁移把 L2 这一层改名为 "chip"（`L2Swimlane*` ->
+`ChipSwimlane*`，`l2_swimlane_records.json` ->
+`chip_swimlane_records.json`），PyPTO 现在遵循该契约。
+
+两个旧拼写仍可用，并会发出 `DeprecationWarning`，将在未来版本中移除。
+取值与语义完全不变，迁移就是改个名字：
+
+```python
+RunConfig(enable_l2_swimlane=True)    # 已弃用
+RunConfig(enable_chip_swimlane=4)     # 等价采集
+```
+
+几个值得知道的细节：
+
+- `enable_l2_swimlane` **不是** dataclass 字段，而是构造参数 + property。
+  这样 `dataclasses.replace(cfg, enable_chip_swimlane=N)` 才不会有歧义；
+  若把别名做成字段，`replace()` 会从旧实例把它一并传回，可能静默覆盖你刚
+  传入的值。
+- 读取 `cfg.enable_l2_swimlane` 不告警（返回规范字段的等级）。使用旧构造
+  参数、或对该属性赋值，才会告警。
+- 同时传入两种拼写会抛 `ValueError`。
 
 ## 重放已有的 build_output
 

--- a/docs/zh/dev/03-runtime-replay.md
+++ b/docs/zh/dev/03-runtime-replay.md
@@ -20,7 +20,7 @@ replay(
     config=RunConfig(
         platform="a2a3sim",
         enable_pmu=2,
-        enable_l2_swimlane=True,
+        enable_chip_swimlane=True,
     ),
 )
 ```

--- a/docs/zh/user/00-getting_started.md
+++ b/docs/zh/user/00-getting_started.md
@@ -132,7 +132,7 @@ compiled = prefill_fwd.compile()
 runtime 以 `[STRACE]` 日志标记的形式输出每次运行的 host/device 计时（simpler
 PR #1177，在 `SIMPLER_DFX` 下默认开启）；用 simpler 的 `strace_timing` /
 `device_log_timing` 工具解析这些标记，而不是读取返回值。需要 per-task 的 device
-计时时，开启 L2 swimlane DFX（`RunConfig(enable_l2_swimlane=True)`）并读取
+计时时，开启 L2 swimlane DFX（`RunConfig(enable_chip_swimlane=True)`）并读取
 `chip_swimlane_records.json`。
 
 ### 性能基准（`benchmark`）

--- a/docs/zh/user/distributed/04-debugging.md
+++ b/docs/zh/user/distributed/04-debugging.md
@@ -49,7 +49,7 @@ SIMPLER_DEVICE_STRACE_ENABLE=0 python script.py
 
 ### 分布式 DFX 入口点
 
-- **L2 swimlane：** `RunConfig(enable_l2_swimlane=True)`——在 worker 内部启用
+- **L2 swimlane：** `RunConfig(enable_chip_swimlane=True)`——在 worker 内部启用
   逐任务计时，并透传到 L3 编排。写入 `dfx_outputs/chip_swimlane_records.json`
   （onboard 场景会与下面的依赖图合并为 `merged_swimlane_*.json`）。
 - **Scope 统计：** `RunConfig(enable_scope_stats=True)`——写入

--- a/docs/zh/user/performance/00-swimlane.md
+++ b/docs/zh/user/performance/00-swimlane.md
@@ -26,7 +26,7 @@ from pypto.runtime import ChipWorker, RunConfig
 
 cfg = RunConfig(
     platform="a2a3",
-    enable_l2_swimlane=True,   # 逐任务计时
+    enable_l2_swimlane=4,      # 逐任务计时，完整采集
     enable_dep_gen=True,       # 计时所要 join 的任务 DAG
     save_kernels=True,         # 保留输出目录
 )
@@ -43,7 +43,7 @@ cfg = RunConfig(
 
 第二个开关的意义在于：后继边被**刻意不**记录进泳道图记录本身，以保持设备侧热路径干净。join 是事后在 host 上做的。
 
-### 采集是分级的，而 `RunConfig` 请求完整采集
+### 采集是分级的
 
 运行时按四个等级采集，每一级在下一级之上追加：
 
@@ -56,7 +56,16 @@ cfg = RunConfig(
 
 每一级在采集器里都是实打实的门禁，不是啰嗦程度设置：等级 1 下 dispatch 与 finish 时间戳**根本不会被打**，任何后处理都恢复不出来。
 
-> **`RunConfig.enable_l2_swimlane` 保留了旧的 `bool` 兼容命名。`True` 会映射到 Simpler 的 `enable_chip_swimlane` 等级 4（完整采集），`False` 映射为 0。** 类型约定下的 `RunConfig` 不暴露等级 1–3；需要较低采集等级时，请使用运行时 harness 的 `--enable-chip-swimlane <1|2|3>`。
+`RunConfig.enable_l2_swimlane` **就是**这个等级，直接传 `0`-`4` 即可：
+
+```python
+cfg = RunConfig(platform="a2a3", enable_l2_swimlane=3,  # 调度器阶段及以下
+                enable_dep_gen=True, save_kernels=True)
+```
+
+为保持调用方兼容，仍接受 `True`，它表示等级 `4`（完整采集），与裸 `--enable-l2-swimlane`
+以及 runtime harness 的裸 `--enable-chip-swimlane` 一致；`False` 表示 `0`。等级越高采集越多、
+对计时的扰动也越大，所以请用能回答你问题的最低等级。
 
 ### 不知道就会被误导的两件事
 
@@ -126,7 +135,7 @@ python -m simpler_setup.tools.sched_overhead_analysis \
 
 它给出逐引擎与全系统的开销占 makespan 的比例、取件代价分布、AICPU 调度循环预算，以及把关键路径拆成「计算」与「调度器注入」两部分的归因。同样这些数字可以用 `swimlane_converter --overhead` 叠加成时间线上的 counter 轨。
 
-它的调度循环部分需要**等级 ≥ 3** 的采集。`RunConfig` 的完整等级 4 采集满足这个要求；只有在通过 `--enable-chip-swimlane <level>` 选择其他采集等级时才需要运行时 harness。
+它的调度循环部分需要**等级 ≥ 3** 的采集 —— `RunConfig(enable_l2_swimlane=3)`，或默认的完整等级 `4`。
 
 那份报告里有两个定义值得记住，因为它们把真问题和假问题分开了：
 

--- a/docs/zh/user/performance/00-swimlane.md
+++ b/docs/zh/user/performance/00-swimlane.md
@@ -26,7 +26,7 @@ from pypto.runtime import ChipWorker, RunConfig
 
 cfg = RunConfig(
     platform="a2a3",
-    enable_l2_swimlane=4,      # 逐任务计时，完整采集
+    enable_chip_swimlane=4,      # 逐任务计时，完整采集
     enable_dep_gen=True,       # 计时所要 join 的任务 DAG
     save_kernels=True,         # 保留输出目录
 )
@@ -56,16 +56,16 @@ cfg = RunConfig(
 
 每一级在采集器里都是实打实的门禁，不是啰嗦程度设置：等级 1 下 dispatch 与 finish 时间戳**根本不会被打**，任何后处理都恢复不出来。
 
-`RunConfig.enable_l2_swimlane` **就是**这个等级，直接传 `0`-`4` 即可：
+`RunConfig.enable_chip_swimlane` **就是**这个等级，直接传 `0`-`4` 即可：
 
 ```python
-cfg = RunConfig(platform="a2a3", enable_l2_swimlane=3,  # 调度器阶段及以下
+cfg = RunConfig(platform="a2a3", enable_chip_swimlane=3,  # 调度器阶段及以下
                 enable_dep_gen=True, save_kernels=True)
 ```
 
-为保持调用方兼容，仍接受 `True`，它表示等级 `4`（完整采集），与裸 `--enable-l2-swimlane`
-以及 runtime harness 的裸 `--enable-chip-swimlane` 一致；`False` 表示 `0`。等级越高采集越多、
-对计时的扰动也越大，所以请用能回答你问题的最低等级。
+为保持调用方兼容，仍接受 `True`，它表示等级 `4`（完整采集）—— 与裸 `--enable-chip-swimlane`
+请求的是同一件事；`False` 表示 `0`。等级越高采集越多、对计时的扰动也越大，所以请用能回答你
+问题的最低等级。
 
 ### 不知道就会被误导的两件事
 
@@ -135,7 +135,7 @@ python -m simpler_setup.tools.sched_overhead_analysis \
 
 它给出逐引擎与全系统的开销占 makespan 的比例、取件代价分布、AICPU 调度循环预算，以及把关键路径拆成「计算」与「调度器注入」两部分的归因。同样这些数字可以用 `swimlane_converter --overhead` 叠加成时间线上的 counter 轨。
 
-它的调度循环部分需要**等级 ≥ 3** 的采集 —— `RunConfig(enable_l2_swimlane=3)`，或默认的完整等级 `4`。
+它的调度循环部分需要**等级 ≥ 3** 的采集 —— `RunConfig(enable_chip_swimlane=3)`，或默认的完整等级 `4`。
 
 那份报告里有两个定义值得记住，因为它们把真问题和假问题分开了：
 

--- a/docs/zh/user/tutorials/05-scheduling-tuning.md
+++ b/docs/zh/user/tutorials/05-scheduling-tuning.md
@@ -15,7 +15,7 @@
 | 问题 | 开关 | 产物 |
 | ---- | ---- | ---- |
 | 图长成什么样？ | `enable_dep_gen=True` | `<work_dir>/dfx_outputs/deps.json` |
-| 任务真的重叠了吗？ | `enable_l2_swimlane=True` | `<work_dir>/dfx_outputs/chip_swimlane_records.json` |
+| 任务真的重叠了吗？ | `enable_chip_swimlane=True` | `<work_dir>/dfx_outputs/chip_swimlane_records.json` |
 | 运行时的环是否接近满？ | `enable_scope_stats=True` | `<work_dir>/dfx_outputs/scope_stats/scope_stats.jsonl` |
 | 哪条 pipe 是瓶颈？ | `enable_pmu=2` | `<work_dir>/dfx_outputs/pmu.csv` |
 
@@ -47,7 +47,7 @@ viewer 默认输出文本，要图视图得传 `--format html`。
 一张并行的图并不保证并行的执行。swimlane 给出逐任务时序：
 
 ```python
-kernel(a, b, out, config=RunConfig(platform="a2a3sim", enable_l2_swimlane=True))
+kernel(a, b, out, config=RunConfig(platform="a2a3sim", enable_chip_swimlane=True))
 ```
 
 > **模拟器注意事项：** 在 `*sim` 平台上这是单趟的，只产出 `chip_swimlane_records.json`。合并后的 `merged_swimlane_*.json` 视图会被**有意跳过**，因为模拟器尚未提供转换器所需的任务元数据。在真机平台上同一个开关会把负载**跑两遍** —— 先一趟 dep_gen 采集图，再一趟干净的计时 —— 因为采集会扰动时序。

--- a/examples/models/02_vector_dag.py
+++ b/examples/models/02_vector_dag.py
@@ -159,7 +159,7 @@ def golden(tensors: dict, params: dict | None = None) -> None:
 def main():
     parser = argparse.ArgumentParser(description="Vector DAG example")
     parser.add_argument(
-        "--enable-l2-swimlane",
+        "--enable-chip-swimlane",
         action="store_true",
         default=False,
         help="Enable on-device runtime profiling and generate swimlane JSON",
@@ -174,7 +174,7 @@ def main():
         a,
         b,
         f,
-        config=RunConfig(enable_l2_swimlane=args.enable_l2_swimlane),
+        config=RunConfig(enable_chip_swimlane=args.enable_chip_swimlane),
     )
 
     # Golden validation

--- a/examples/models/04_paged_attention.py
+++ b/examples/models/04_paged_attention.py
@@ -580,7 +580,7 @@ def build_tensors(
 def main():
     parser = argparse.ArgumentParser(description="Paged attention example")
     parser.add_argument(
-        "--enable-l2-swimlane",
+        "--enable-chip-swimlane",
         action="store_true",
         default=False,
         help="Enable on-device runtime profiling and generate swimlane JSON",
@@ -628,7 +628,7 @@ def main():
             strategy=OptimizationStrategy.Default,
             dump_passes=True,
             backend_type=BackendType.Ascend910B,
-            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_chip_swimlane=args.enable_chip_swimlane,
         ),
     )
 

--- a/examples/models/06_paged_attention_dynamic.py
+++ b/examples/models/06_paged_attention_dynamic.py
@@ -512,7 +512,7 @@ def main():
     """
     parser = argparse.ArgumentParser(description="Dynamic paged attention example")
     parser.add_argument(
-        "--enable-l2-swimlane",
+        "--enable-chip-swimlane",
         action="store_true",
         default=False,
         help="Enable on-device runtime profiling and generate swimlane JSON",
@@ -556,7 +556,7 @@ def main():
             strategy=OptimizationStrategy.Default,
             dump_passes=True,
             backend_type=BackendType.Ascend910B,
-            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_chip_swimlane=args.enable_chip_swimlane,
         ),
     )
 

--- a/examples/models/07_paged_attention_multi_config.py
+++ b/examples/models/07_paged_attention_multi_config.py
@@ -766,7 +766,7 @@ def build_tensors_multi_config(
 def main():
     parser = argparse.ArgumentParser(description="Multi-config paged attention example")
     parser.add_argument(
-        "--enable-l2-swimlane",
+        "--enable-chip-swimlane",
         action="store_true",
         default=False,
         help="Enable on-device runtime profiling and generate swimlane JSON",
@@ -816,7 +816,7 @@ def main():
             dump_passes=True,
             backend_type=BackendType.Ascend910B,
             compile_profiling=True,
-            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_chip_swimlane=args.enable_chip_swimlane,
         ),
     )
 

--- a/examples/models/09_paged_attention_spmd.py
+++ b/examples/models/09_paged_attention_spmd.py
@@ -747,7 +747,7 @@ def main():
     )
     parser.add_argument("-d", "--device", type=int, default=default_device)
     parser.add_argument(
-        "--enable-l2-swimlane",
+        "--enable-chip-swimlane",
         action="store_true",
         default=False,
         help="Enable on-device runtime profiling and generate swimlane JSON",
@@ -797,7 +797,7 @@ def main():
         strategy=OptimizationStrategy.Default,
         dump_passes=True,
         backend_type=BackendType.Ascend950 if args.platform.startswith("a5") else BackendType.Ascend910B,
-        enable_l2_swimlane=args.enable_l2_swimlane,
+        enable_chip_swimlane=args.enable_chip_swimlane,
     )
     compiled = run(program, config=run_config)
     output = compiled(*input_tensors, config=run_config)

--- a/python/pypto/ir/distributed_compiled_program.py
+++ b/python/pypto/ir/distributed_compiled_program.py
@@ -411,7 +411,7 @@ class DistributedCompiledProgram:
         ring-sizing overrides (``ring_task_window`` / ``ring_heap`` /
         ``ring_dep_pool``) size this dispatch's runtime ring buffers, and its
         runtime-diagnostic DFX flags (``enable_dump_args`` / ``enable_pmu`` /
-        ``enable_dep_gen`` / ``enable_scope_stats`` / ``enable_l2_swimlane``) are
+        ``enable_dep_gen`` / ``enable_scope_stats`` / ``enable_chip_swimlane``) are
         written per dispatch under ``<output_dir>/dfx_outputs/rank{r}/d{k}/``
         (``d{k}`` is the card's k-th dispatch, so multiple dispatches to one card
         keep separate artifacts). Onboard swimlane runs a dep-gen-only graph

--- a/python/pypto/runtime/_dep_gen_capture.py
+++ b/python/pypto/runtime/_dep_gen_capture.py
@@ -9,7 +9,7 @@
 
 """Subprocess entry point that captures a dep_gen ``deps.json`` for swimlane.
 
-When ``enable_l2_swimlane`` is requested on an onboard platform, the swimlane
+When ``enable_chip_swimlane`` is requested on an onboard platform, the swimlane
 converter needs a task graph that only a dep_gen run produces. dep_gen and
 swimlane cannot share one in-process run: the runtime's per-run finalize does
 not reliably reclaim the SVM host-register mappings the DFX collectors allocate,

--- a/python/pypto/runtime/debug/replay.py
+++ b/python/pypto/runtime/debug/replay.py
@@ -36,7 +36,7 @@ Python::
     replay(
         "build_output/_jit_xxx/",
         a, b, c,
-        config=RunConfig(platform="a2a3sim", enable_pmu=2, enable_l2_swimlane=True),
+        config=RunConfig(platform="a2a3sim", enable_pmu=2, enable_chip_swimlane=4),
     )
 """
 
@@ -320,15 +320,24 @@ def _main(
     parser.add_argument("--platform", default=default_platform, help="Target execution platform")
     parser.add_argument("--device-id", type=int, default=0, help="Hardware device index")
     parser.add_argument("--pmu", type=int, default=0, metavar="LEVEL", help="PMU level")
+    # Two options, not one optional-valued option: this parser has a positional
+    # ``work_dir``, and an ``nargs="?"`` flag would eat it in
+    # ``replay --swimlane build_output/x``.
     parser.add_argument(
         "--swimlane",
-        nargs="?",
+        action="store_const",
         const=_SWIMLANE_FULL_LEVEL,
         default=0,
+        help=f"Enable chip swimlane capture at the full level ({_SWIMLANE_FULL_LEVEL}). "
+        "Use --swimlane-level N for a lower level.",
+    )
+    parser.add_argument(
+        "--swimlane-level",
+        default=None,
         type=int,
         choices=range(_SWIMLANE_MAX_LEVEL + 1),
         metavar="LEVEL",
-        help=_SWIMLANE_CLI_HELP,
+        help=_SWIMLANE_CLI_HELP + " Takes precedence over --swimlane.",
     )
     parser.add_argument(
         "--dump-args",
@@ -400,7 +409,7 @@ def _main(
         platform=args.platform,
         device_id=args.device_id,
         enable_pmu=args.pmu,
-        enable_l2_swimlane=args.swimlane,
+        enable_chip_swimlane=(args.swimlane_level if args.swimlane_level is not None else args.swimlane),
         enable_dump_args=args.dump_args,
         enable_dep_gen=args.dep_gen,
         enable_scope_stats=args.scope_stats,

--- a/python/pypto/runtime/debug/replay.py
+++ b/python/pypto/runtime/debug/replay.py
@@ -54,7 +54,14 @@ import torch
 from pypto.runtime._binary_cache import binary_context_lock, invalidate_binary_context
 from pypto.runtime.debug.pto_rebuild import rebuild_kernel_cpp_from_pto
 from pypto.runtime.device_tensor import DeviceTensor
-from pypto.runtime.runner import RunConfig, _DfxOpts, execute_compiled
+from pypto.runtime.runner import (
+    _SWIMLANE_CLI_HELP,
+    _SWIMLANE_FULL_LEVEL,
+    _SWIMLANE_MAX_LEVEL,
+    RunConfig,
+    _DfxOpts,
+    execute_compiled,
+)
 
 __all__ = ["replay", "invalidate_binary_cache"]
 
@@ -313,7 +320,16 @@ def _main(
     parser.add_argument("--platform", default=default_platform, help="Target execution platform")
     parser.add_argument("--device-id", type=int, default=0, help="Hardware device index")
     parser.add_argument("--pmu", type=int, default=0, metavar="LEVEL", help="PMU level")
-    parser.add_argument("--swimlane", action="store_true", help="Enable L2 swimlane capture")
+    parser.add_argument(
+        "--swimlane",
+        nargs="?",
+        const=_SWIMLANE_FULL_LEVEL,
+        default=0,
+        type=int,
+        choices=range(_SWIMLANE_MAX_LEVEL + 1),
+        metavar="LEVEL",
+        help=_SWIMLANE_CLI_HELP,
+    )
     parser.add_argument(
         "--dump-args",
         nargs="?",

--- a/python/pypto/runtime/debug/run_script_writer.py
+++ b/python/pypto/runtime/debug/run_script_writer.py
@@ -100,7 +100,8 @@ CLI flags (forwarded to ``pypto.runtime.debug.replay._main``)
   --platform PLAT          target platform (default: {default_platform})
   --device-id N            hardware device index (default: 0)
   --pmu LEVEL              enable PMU profiling at LEVEL
-  --swimlane               enable L2 swimlane capture
+  --swimlane [LEVEL]       chip swimlane capture (bare=4 full, 1=AICore timing,
+                           2=+dispatch/finish, 3=+sched phases, 4=+orch phases)
   --dump-args [LEVEL]      dump per-task arguments to disk (bare=1 partial, 2 full)
   --dep-gen                enable dep_gen profiling
   --no-recompile           skip forced cpp-edit invalidation; compatibility checks may rebuild

--- a/python/pypto/runtime/debug/run_script_writer.py
+++ b/python/pypto/runtime/debug/run_script_writer.py
@@ -100,8 +100,9 @@ CLI flags (forwarded to ``pypto.runtime.debug.replay._main``)
   --platform PLAT          target platform (default: {default_platform})
   --device-id N            hardware device index (default: 0)
   --pmu LEVEL              enable PMU profiling at LEVEL
-  --swimlane [LEVEL]       chip swimlane capture (bare=4 full, 1=AICore timing,
-                           2=+dispatch/finish, 3=+sched phases, 4=+orch phases)
+  --swimlane               chip swimlane capture at the full level (4)
+  --swimlane-level N       chip swimlane level: 1=AICore timing, 2=+dispatch/finish,
+                           3=+sched phases, 4=+orch phases
   --dump-args [LEVEL]      dump per-task arguments to disk (bare=1 partial, 2 full)
   --dep-gen                enable dep_gen profiling
   --no-recompile           skip forced cpp-edit invalidation; compatibility checks may rebuild

--- a/python/pypto/runtime/device_runner.py
+++ b/python/pypto/runtime/device_runner.py
@@ -896,7 +896,7 @@ def execute_on_device(  # noqa: PLR0913
     aicpu_thread_num: int | None = None,
     enable_sdma: bool = False,
     output_prefix: str | None = None,
-    enable_l2_swimlane: bool = False,
+    enable_l2_swimlane: int | bool = 0,
     enable_dump_args: int = 0,
     enable_pmu: int = 0,
     enable_dep_gen: bool = False,
@@ -935,8 +935,12 @@ def execute_on_device(  # noqa: PLR0913
             whenever any ``enable_*`` DFX flag is set — Simpler's
             ``CallConfig::validate()`` would otherwise reject the call.
             Passing it with all flags off creates no artefacts.
-        enable_l2_swimlane: Capture per-task chip perf records
-            (``chip_swimlane_records.json``). This public PyPTO compatibility
+        enable_l2_swimlane: Chip swimlane collection **level** for the
+            per-task perf records (``chip_swimlane_records.json``). ``0`` off;
+            ``1`` AICore timing; ``2`` plus AICPU dispatch / finish; ``3`` plus
+            scheduler phases; ``4`` plus orchestrator phases. ``True`` requests
+            the full level (``4``), matching the runtime harness's bare
+            ``--enable-chip-swimlane``. This public PyPTO compatibility
             spelling maps to Simpler's ``enable_chip_swimlane`` field.
         enable_dump_args: Per-task argument dump level into
             ``<output_prefix>/args_dump/``. ``0`` off; ``1`` partial
@@ -973,8 +977,18 @@ def execute_on_device(  # noqa: PLR0913
             f"L3 execution is not yet exposed at the pypto user-API layer."
         )
 
+    from .runner import _normalize_swimlane_level  # noqa: PLC0415
+
+    # Validate the level here too, so both entry points reject an out-of-range
+    # request identically instead of letting the CallConfig setter clamp it.
+    enable_l2_swimlane = _normalize_swimlane_level(enable_l2_swimlane, "enable_l2_swimlane")
+
     any_dfx = (
-        enable_l2_swimlane or enable_dump_args > 0 or enable_pmu > 0 or enable_dep_gen or enable_scope_stats
+        enable_l2_swimlane > 0
+        or enable_dump_args > 0
+        or enable_pmu > 0
+        or enable_dep_gen
+        or enable_scope_stats
     )
     if any_dfx and not output_prefix:
         raise ValueError(

--- a/python/pypto/runtime/device_runner.py
+++ b/python/pypto/runtime/device_runner.py
@@ -896,7 +896,7 @@ def execute_on_device(  # noqa: PLR0913
     aicpu_thread_num: int | None = None,
     enable_sdma: bool = False,
     output_prefix: str | None = None,
-    enable_l2_swimlane: int | bool = 0,
+    enable_chip_swimlane: int | bool = 0,
     enable_dump_args: int = 0,
     enable_pmu: int = 0,
     enable_dep_gen: bool = False,
@@ -935,13 +935,12 @@ def execute_on_device(  # noqa: PLR0913
             whenever any ``enable_*`` DFX flag is set — Simpler's
             ``CallConfig::validate()`` would otherwise reject the call.
             Passing it with all flags off creates no artefacts.
-        enable_l2_swimlane: Chip swimlane collection **level** for the
+        enable_chip_swimlane: Chip swimlane collection **level** for the
             per-task perf records (``chip_swimlane_records.json``). ``0`` off;
             ``1`` AICore timing; ``2`` plus AICPU dispatch / finish; ``3`` plus
             scheduler phases; ``4`` plus orchestrator phases. ``True`` requests
             the full level (``4``), matching the runtime harness's bare
-            ``--enable-chip-swimlane``. This public PyPTO compatibility
-            spelling maps to Simpler's ``enable_chip_swimlane`` field.
+            ``--enable-chip-swimlane``.
         enable_dump_args: Per-task argument dump level into
             ``<output_prefix>/args_dump/``. ``0`` off; ``1`` partial
             (only ``pl.dump_tag`` / ``dumps=`` marked tensors); ``2`` full
@@ -981,10 +980,10 @@ def execute_on_device(  # noqa: PLR0913
 
     # Validate the level here too, so both entry points reject an out-of-range
     # request identically instead of letting the CallConfig setter clamp it.
-    enable_l2_swimlane = _normalize_swimlane_level(enable_l2_swimlane, "enable_l2_swimlane")
+    enable_chip_swimlane = _normalize_swimlane_level(enable_chip_swimlane, "enable_chip_swimlane")
 
     any_dfx = (
-        enable_l2_swimlane > 0
+        enable_chip_swimlane > 0
         or enable_dump_args > 0
         or enable_pmu > 0
         or enable_dep_gen
@@ -993,7 +992,7 @@ def execute_on_device(  # noqa: PLR0913
     if any_dfx and not output_prefix:
         raise ValueError(
             "execute_on_device: output_prefix is required when any DFX flag "
-            "(enable_l2_swimlane / enable_dump_args / enable_pmu / enable_dep_gen / "
+            "(enable_chip_swimlane / enable_dump_args / enable_pmu / enable_dep_gen / "
             "enable_scope_stats) is enabled — runtime CallConfig::validate() would "
             "otherwise reject the call."
         )
@@ -1007,9 +1006,8 @@ def execute_on_device(  # noqa: PLR0913
     # level, while ``enable_dep_gen`` takes `bool`; ``enable_pmu`` is a raw
     # ``int32_t`` (0 disabled, >0 event type); ``enable_dump_args`` is a dump
     # level (0 off, 1 partial, 2 full) whose setter also accepts a bool
-    # (True→1 partial, False→0). Keep the public PyPTO argument's legacy name,
-    # but map it to Simpler's current member.
-    cfg.enable_chip_swimlane = enable_l2_swimlane
+    # (True→1 partial, False→0).
+    cfg.enable_chip_swimlane = enable_chip_swimlane
     cfg.enable_dump_args = enable_dump_args
     cfg.enable_pmu = enable_pmu
     cfg.enable_dep_gen = enable_dep_gen

--- a/python/pypto/runtime/distributed_runner.py
+++ b/python/pypto/runtime/distributed_runner.py
@@ -698,9 +698,10 @@ def _make_call_config(
             # records) and set ``co_enable_swimlane_dep_gen=False`` on the timing
             # pass so dep_gen does not perturb it. Simulator and direct
             # single-pass builders keep the default co-enable behavior.
-            # ``enable_l2_swimlane`` is an int (0/1/2), so the ``or``/``and`` chain
-            # can yield an int; the ``CallConfig.enable_dep_gen`` pybind setter
-            # only accepts ``bool``. Wrap in ``bool(...)`` to avoid a TypeError.
+            # ``enable_l2_swimlane`` is a collection level (0-4), so the
+            # ``or``/``and`` chain can yield an int; the
+            # ``CallConfig.enable_dep_gen`` pybind setter only accepts ``bool``.
+            # Wrap in ``bool(...)`` to avoid a TypeError.
             call_config.enable_dep_gen = bool(
                 dfx.enable_dep_gen or (co_enable_swimlane_dep_gen and dfx.enable_l2_swimlane)
             )
@@ -749,7 +750,7 @@ def _run_l3_swimlane_two_pass(
     print("[swimlane] run 1/2: capturing the per-dispatch task graph (deps.json); its timing is discarded.")
     deps_cfg = dataclasses.replace(
         config,
-        enable_l2_swimlane=False,
+        enable_l2_swimlane=0,
         enable_dep_gen=True,
         enable_pmu=0,
         enable_scope_stats=False,
@@ -1335,7 +1336,7 @@ def execute_distributed(
                 _close_local_worker(w)
 
     dfx_base = output_dir / "dfx_outputs"
-    swimlane = config is not None and config.enable_l2_swimlane
+    swimlane = config is not None and config.enable_l2_swimlane > 0
 
     # Scope DFX artifacts to this run: drop any stale ``rank*/d{k}`` dirs from an
     # earlier (possibly larger) run before the first dispatch writes new ones.
@@ -1345,7 +1346,7 @@ def execute_distributed(
         if _DfxOpts.from_run_config(config).any():
             _clear_dfx_dispatch_dirs(dfx_base)
 
-    if config is not None and config.enable_l2_swimlane and not compiled.platform.endswith("sim"):
+    if config is not None and config.enable_l2_swimlane > 0 and not compiled.platform.endswith("sim"):
         # Two-pass for clean timing, mirroring the L2 swimlane workflow: dep_gen
         # collection perturbs timing, so the per-dispatch task graph and the kept
         # timing come from separate dispatches.
@@ -2497,7 +2498,7 @@ class DistributedWorker(Worker):
                 return DistributedRunHandle._completed(self)
 
             postprocess: Callable[[], None] | None = None
-            if config is not None and config.enable_l2_swimlane:
+            if config is not None and config.enable_l2_swimlane > 0:
 
                 def collect_swimlane() -> None:
                     _collect_l3_swimlane(compiled.output_dir, compiled.platform)
@@ -2529,7 +2530,7 @@ class DistributedWorker(Worker):
             return _make_call_config(compiled._distributed_config), None, False
 
         dfx_base = compiled.output_dir / "dfx_outputs"
-        two_pass_swimlane = bool(config.enable_l2_swimlane) and not compiled.platform.endswith("sim")
+        two_pass_swimlane = config.enable_l2_swimlane > 0 and not compiled.platform.endswith("sim")
         call_config = None
         if not two_pass_swimlane:
             call_config = _make_call_config(compiled._distributed_config, config, dfx_base=dfx_base)

--- a/python/pypto/runtime/distributed_runner.py
+++ b/python/pypto/runtime/distributed_runner.py
@@ -648,11 +648,11 @@ def _make_call_config(
     applies its own ``PTO2_RING_*`` env var / compile-time fallback.
 
     DFX diagnostics (``enable_dump_args`` / ``enable_pmu`` / ``enable_dep_gen``
-    / ``enable_scope_stats`` / ``enable_l2_swimlane``) are likewise read from
+    / ``enable_scope_stats`` / ``enable_chip_swimlane``) are likewise read from
     *run_config* and written to the shared ``config`` the host_orch chip dispatch
     forwards to every ``orch.submit_next_level``; their artifacts land under
     *dfx_base* (``<output_dir>/dfx_outputs``). By default,
-    ``enable_l2_swimlane`` co-enables dep_gen so a single dispatch still has the
+    ``enable_chip_swimlane`` co-enables dep_gen so a single dispatch still has the
     task graph needed by the converter. Onboard L3 callers use a two-pass
     graph/timing protocol and set *co_enable_swimlane_dep_gen* false while
     building the clean timing pass.
@@ -698,17 +698,15 @@ def _make_call_config(
             # records) and set ``co_enable_swimlane_dep_gen=False`` on the timing
             # pass so dep_gen does not perturb it. Simulator and direct
             # single-pass builders keep the default co-enable behavior.
-            # ``enable_l2_swimlane`` is a collection level (0-4), so the
+            # ``enable_chip_swimlane`` is a collection level (0-4), so the
             # ``or``/``and`` chain can yield an int; the
             # ``CallConfig.enable_dep_gen`` pybind setter only accepts ``bool``.
             # Wrap in ``bool(...)`` to avoid a TypeError.
             call_config.enable_dep_gen = bool(
-                dfx.enable_dep_gen or (co_enable_swimlane_dep_gen and dfx.enable_l2_swimlane)
+                dfx.enable_dep_gen or (co_enable_swimlane_dep_gen and dfx.enable_chip_swimlane)
             )
             call_config.enable_scope_stats = dfx.enable_scope_stats
-            # PyPTO keeps ``enable_l2_swimlane`` as a public compatibility
-            # spelling; Simpler's current CallConfig member is chip-scoped.
-            call_config.enable_chip_swimlane = dfx.enable_l2_swimlane
+            call_config.enable_chip_swimlane = dfx.enable_chip_swimlane
             # Base dir shared by every chip; ``_submit_chip`` namespaces it per
             # dispatch (``<dfx_base>/rank{worker}/d{k}``) so per-dispatch
             # artifacts (pmu.csv, deps.json, chip_swimlane_records.json, ...) don't
@@ -750,7 +748,7 @@ def _run_l3_swimlane_two_pass(
     print("[swimlane] run 1/2: capturing the per-dispatch task graph (deps.json); its timing is discarded.")
     deps_cfg = dataclasses.replace(
         config,
-        enable_l2_swimlane=0,
+        enable_chip_swimlane=0,
         enable_dep_gen=True,
         enable_pmu=0,
         enable_scope_stats=False,
@@ -1245,11 +1243,11 @@ def execute_distributed(
             ``ring_dep_pool``, each a scalar or a per-ring list of 4 ints) size
             this dispatch's runtime ring buffers, and its
             runtime-diagnostic DFX flags (``enable_dump_args`` / ``enable_pmu``
-            / ``enable_dep_gen`` / ``enable_scope_stats`` / ``enable_l2_swimlane``)
+            / ``enable_dep_gen`` / ``enable_scope_stats`` / ``enable_chip_swimlane``)
             are written per dispatch under
             ``<output_dir>/dfx_outputs/rank{r}/d{k}/`` (``d{k}`` is the card's
             k-th dispatch, so multiple — even different — chip programs on one
-            card keep separate artifacts). Onboard, ``enable_l2_swimlane`` runs a
+            card keep separate artifacts). Onboard, ``enable_chip_swimlane`` runs a
             clean two-pass dispatch (pass 1 dep_gen → ``deps.json``, pass 2
             swimlane → records with unperturbed timing) and additionally produces
             ``merged_swimlane_*.json`` per dispatch. The remaining compile-side
@@ -1336,7 +1334,7 @@ def execute_distributed(
                 _close_local_worker(w)
 
     dfx_base = output_dir / "dfx_outputs"
-    swimlane = config is not None and config.enable_l2_swimlane > 0
+    swimlane = config is not None and config.enable_chip_swimlane > 0
 
     # Scope DFX artifacts to this run: drop any stale ``rank*/d{k}`` dirs from an
     # earlier (possibly larger) run before the first dispatch writes new ones.
@@ -1346,7 +1344,7 @@ def execute_distributed(
         if _DfxOpts.from_run_config(config).any():
             _clear_dfx_dispatch_dirs(dfx_base)
 
-    if config is not None and config.enable_l2_swimlane > 0 and not compiled.platform.endswith("sim"):
+    if config is not None and config.enable_chip_swimlane > 0 and not compiled.platform.endswith("sim"):
         # Two-pass for clean timing, mirroring the L2 swimlane workflow: dep_gen
         # collection perturbs timing, so the per-dispatch task graph and the kept
         # timing come from separate dispatches.
@@ -1394,7 +1392,7 @@ def execute_distributed_compiled(
             ``__call__``. Its per-task ring-sizing overrides size this dispatch's
             runtime ring buffers, and its runtime-diagnostic DFX flags
             (``enable_dump_args`` / ``enable_pmu`` / ``enable_dep_gen`` /
-            ``enable_scope_stats`` / ``enable_l2_swimlane``) are written per
+            ``enable_scope_stats`` / ``enable_chip_swimlane``) are written per
             dispatch under ``<output_dir>/dfx_outputs/rank{r}/d{k}/``. Other
             compile-side fields are not consumed on the dispatch path.
         platform: Override the persisted platform (e.g. ``a2a3sim`` → ``a2a3``).
@@ -2382,7 +2380,7 @@ class DistributedWorker(Worker):
         dispatch's runtime ring buffers without
         touching the prepared program's shared config, so consecutive dispatches
         can use different ring sizes. Its runtime DFX fields are also applied per
-        dispatch. On onboard L3, ``enable_l2_swimlane`` executes the workload
+        dispatch. On onboard L3, ``enable_chip_swimlane`` executes the workload
         twice on the same prepared worker: first with dep-gen only, then with
         swimlane enabled and dep-gen disabled. Mutable host/resident arguments
         are not restored between those profiling passes and can therefore be
@@ -2498,7 +2496,7 @@ class DistributedWorker(Worker):
                 return DistributedRunHandle._completed(self)
 
             postprocess: Callable[[], None] | None = None
-            if config is not None and config.enable_l2_swimlane > 0:
+            if config is not None and config.enable_chip_swimlane > 0:
 
                 def collect_swimlane() -> None:
                     _collect_l3_swimlane(compiled.output_dir, compiled.platform)
@@ -2530,7 +2528,7 @@ class DistributedWorker(Worker):
             return _make_call_config(compiled._distributed_config), None, False
 
         dfx_base = compiled.output_dir / "dfx_outputs"
-        two_pass_swimlane = config.enable_l2_swimlane > 0 and not compiled.platform.endswith("sim")
+        two_pass_swimlane = config.enable_chip_swimlane > 0 and not compiled.platform.endswith("sim")
         call_config = None
         if not two_pass_swimlane:
             call_config = _make_call_config(compiled._distributed_config, config, dfx_base=dfx_base)
@@ -2692,7 +2690,7 @@ class DistributedWorker(Worker):
         ring sizing and runtime DFX fields apply without touching the prepared
         program's shared config. In a multi-program worker each program can
         therefore use its own ring sizes and diagnostics. On onboard L3,
-        ``enable_l2_swimlane`` executes a dep-gen graph pass followed by a
+        ``enable_chip_swimlane`` executes a dep-gen graph pass followed by a
         dep-gen-disabled timing pass; mutable arguments are not restored between
         them. ``None`` snapshots the program's baseline for this dispatch.
         """

--- a/python/pypto/runtime/execute_artifact.py
+++ b/python/pypto/runtime/execute_artifact.py
@@ -46,7 +46,13 @@ import traceback
 from pathlib import Path
 from typing import Any
 
-from pypto.runtime.runner import _DfxOpts, _execute_on_device
+from pypto.runtime.runner import (
+    _SWIMLANE_CLI_HELP,
+    _SWIMLANE_FULL_LEVEL,
+    _SWIMLANE_MAX_LEVEL,
+    _DfxOpts,
+    _execute_on_device,
+)
 
 __all__ = ["ArtifactSetupError", "execute_artifact_dir", "execute_batch_manifest", "main"]
 
@@ -358,7 +364,16 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--device-id", type=int, required=True, help="Hardware device index")
     # DFX toggles — names mirror tests/st/conftest.py so the harness round-trip
     # (_dfx_to_cli) is symmetric.
-    parser.add_argument("--enable-l2-swimlane", action="store_true", help="Capture L2 swimlane records")
+    parser.add_argument(
+        "--enable-l2-swimlane",
+        nargs="?",
+        const=_SWIMLANE_FULL_LEVEL,
+        default=0,
+        type=int,
+        choices=range(_SWIMLANE_MAX_LEVEL + 1),
+        metavar="LEVEL",
+        help=_SWIMLANE_CLI_HELP,
+    )
     parser.add_argument(
         "--dump-args",
         type=int,

--- a/python/pypto/runtime/execute_artifact.py
+++ b/python/pypto/runtime/execute_artifact.py
@@ -43,6 +43,7 @@ Exit contract (the harness relies on it; ``task-submit`` propagates it verbatim)
 import argparse
 import json
 import traceback
+import warnings
 from pathlib import Path
 from typing import Any
 
@@ -263,7 +264,7 @@ def execute_batch_manifest(
     # execution (each _execute_on_device opens + closes its own worker) so the
     # dep-gen child owns the device first, preserving the two-pass design.
     first_platform = str(entries[0]["platform"])
-    if dfx.enable_l2_swimlane and not first_platform.endswith("sim"):
+    if dfx.enable_chip_swimlane and not first_platform.endswith("sim"):
         for entry in entries:
             _run_and_mark(entry)
         return all_ok
@@ -365,7 +366,7 @@ def _build_parser() -> argparse.ArgumentParser:
     # DFX toggles — names mirror tests/st/conftest.py so the harness round-trip
     # (_dfx_to_cli) is symmetric.
     parser.add_argument(
-        "--enable-l2-swimlane",
+        "--enable-chip-swimlane",
         nargs="?",
         const=_SWIMLANE_FULL_LEVEL,
         default=0,
@@ -373,6 +374,19 @@ def _build_parser() -> argparse.ArgumentParser:
         choices=range(_SWIMLANE_MAX_LEVEL + 1),
         metavar="LEVEL",
         help=_SWIMLANE_CLI_HELP,
+    )
+    # Deprecated spelling. Separate dest so ``main`` can tell it was used and
+    # warn; ``default=None`` distinguishes "absent" from an explicit ``0``.
+    parser.add_argument(
+        "--enable-l2-swimlane",
+        dest="enable_l2_swimlane_deprecated",
+        nargs="?",
+        const=_SWIMLANE_FULL_LEVEL,
+        default=None,
+        type=int,
+        choices=range(_SWIMLANE_MAX_LEVEL + 1),
+        metavar="LEVEL",
+        help="Deprecated alias for --enable-chip-swimlane.",
     )
     parser.add_argument(
         "--dump-args",
@@ -396,6 +410,28 @@ def _build_parser() -> argparse.ArgumentParser:
     return parser
 
 
+def _resolve_swimlane_args(parser: argparse.ArgumentParser, args: argparse.Namespace) -> int:
+    """Fold the deprecated ``--enable-l2-swimlane`` into the canonical level.
+
+    Returns the requested collection level, warning when the old flag supplied
+    it and erroring when both flags disagree.
+    """
+    deprecated = args.enable_l2_swimlane_deprecated
+    if deprecated is None:
+        return args.enable_chip_swimlane
+    warnings.warn(
+        "--enable-l2-swimlane is deprecated; use --enable-chip-swimlane.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    if args.enable_chip_swimlane and args.enable_chip_swimlane != deprecated:
+        parser.error(
+            f"--enable-chip-swimlane {args.enable_chip_swimlane} conflicts with the "
+            f"deprecated --enable-l2-swimlane {deprecated}; pass only the former."
+        )
+    return deprecated
+
+
 def main(argv: list[str] | None = None) -> int:
     """CLI entry: run one artifact, print the result marker, return exit code.
 
@@ -406,7 +442,7 @@ def main(argv: list[str] | None = None) -> int:
     parser = _build_parser()
     args = parser.parse_args(argv)
     dfx = _DfxOpts(
-        enable_l2_swimlane=args.enable_l2_swimlane,
+        enable_chip_swimlane=_resolve_swimlane_args(parser, args),
         enable_dump_args=args.dump_args,
         enable_pmu=args.enable_pmu,
         enable_dep_gen=args.enable_dep_gen,

--- a/python/pypto/runtime/runner.py
+++ b/python/pypto/runtime/runner.py
@@ -81,6 +81,66 @@ _RING_DEPTH = 4
 # boundary, but use the current Simpler artifact contract internally.
 _CHIP_SWIMLANE_RECORDS_NAME = "chip_swimlane_records.json"
 
+# Chip-swimlane collection is *levelled*, not a toggle: each level is a real
+# guard in the runtime collectors, so a lower level never records the data a
+# higher one does (no post-processing recovers it).  Mirrors
+# ``ChipSwimlaneLevel`` and the runtime harness's ``--enable-chip-swimlane``.
+#
+#   0 DISABLED      off
+#   1 AICORE_TIMING AICore per-task start/end + task record buffer
+#   2 AICPU_TIMING  + AICPU-stamped dispatch/finish (the [dispatch, start] gap)
+#   3 SCHED_PHASES  + scheduler main-loop phases (``sched_overhead_analysis``)
+#   4 ORCH_PHASES   + orchestrator phases
+_SWIMLANE_MAX_LEVEL = 4
+# What a bare ``True`` (or a bare CLI flag) requests.  Level 4 matches both the
+# runtime harness's bare ``--enable-chip-swimlane`` and the ``CallConfig``
+# nanobind setter, which already maps a Python ``True`` to 4.
+_SWIMLANE_FULL_LEVEL = 4
+# Shared by every ``--enable-l2-swimlane`` / ``--swimlane`` CLI so the ladder is
+# described once. Callers that need extra prose concatenate onto this.
+_SWIMLANE_CLI_HELP = (
+    f"Chip swimlane collection level. Bare flag = {_SWIMLANE_FULL_LEVEL} (full); "
+    "1=AICore timing, 2=+AICPU dispatch/finish, 3=+scheduler phases, "
+    "4=+orchestrator phases; absent = 0 (off)."
+)
+
+
+def _normalize_swimlane_level(value: int | bool, source: str) -> int:
+    """Normalize a chip-swimlane request to an explicit collection level.
+
+    ``bool`` is accepted for source compatibility: ``True`` requests full
+    collection (level :data:`_SWIMLANE_FULL_LEVEL`), matching the runtime's
+    bare ``--enable-chip-swimlane`` and its ``CallConfig`` setter; ``False`` is
+    off.  Normalizing here (rather than deferring to the ``CallConfig`` setter)
+    keeps the level readable from Python and lets the harness round-trip it
+    through the ``--enable-l2-swimlane`` CLI without flattening it.
+
+    Args:
+        value: Requested level (``0``-``4``) or ``bool``.
+        source: Name of the option being normalized, used in error messages.
+
+    Returns:
+        The collection level as an ``int`` in ``[0, _SWIMLANE_MAX_LEVEL]``.
+
+    Raises:
+        TypeError: If *value* is neither ``bool`` nor ``int``.
+        ValueError: If *value* is an out-of-range level.
+    """
+    if isinstance(value, bool):
+        return _SWIMLANE_FULL_LEVEL if value else 0
+    if not isinstance(value, int):
+        raise TypeError(
+            f"{source} must be an int collection level (0-{_SWIMLANE_MAX_LEVEL}) or a bool, "
+            f"got {type(value).__name__}"
+        )
+    if not 0 <= value <= _SWIMLANE_MAX_LEVEL:
+        raise ValueError(
+            f"{source} must be a collection level in [0, {_SWIMLANE_MAX_LEVEL}] "
+            f"(0=off, 1=AICore timing, 2=+dispatch/finish, 3=+sched phases, "
+            f"4=+orch phases), got {value}"
+        )
+    return value
+
 
 @dataclass
 class RunConfig:
@@ -112,10 +172,28 @@ class RunConfig:
             ``build_output/<program_name>_<timestamp>``.
         codegen_only: If ``True``, stop after code generation without executing
             on device.  Useful for validating compilation output.
-        enable_l2_swimlane: Capture per-task chip perf records into
-            ``<work_dir>/dfx_outputs/chip_swimlane_records.json``. On onboard
-            platforms, ``swimlane_converter`` then produces
-            ``merged_swimlane_*.json`` alongside it. Because the converter joins
+        enable_l2_swimlane: Chip swimlane collection **level** — per-task
+            timing records written into
+            ``<work_dir>/dfx_outputs/chip_swimlane_records.json``. Mirrors the
+            runtime harness's ``--enable-chip-swimlane PERF_LEVEL``; each level
+            is a real guard in the runtime collectors, so a lower level never
+            stamps the data a higher one does and no post-processing recovers
+            it:
+
+            * ``0`` / ``False`` — off.
+            * ``1`` — AICore per-task start / end plus the task record buffer.
+            * ``2`` — ``1`` plus AICPU-stamped dispatch / finish, which is what
+              makes the ``[dispatch, start]`` pickup gap readable.
+            * ``3`` — ``2`` plus scheduler main-loop phase records, required by
+              ``python -m simpler_setup.tools.sched_overhead_analysis`` and by
+              the PyPTO Toolkit plugin's Scheduler View.
+            * ``4`` / ``True`` — ``3`` plus orchestrator phase records (the
+              Toolkit plugin's AICPU Orchestrator view). ``True`` requests this
+              full level, matching the runtime harness's bare
+              ``--enable-chip-swimlane``.
+
+            On onboard platforms, ``swimlane_converter`` then produces
+            ``merged_swimlane_*.json`` alongside the records. Because the converter joins
             the timing against a task graph that only ``deps.json`` carries,
             enabling this on an onboard platform runs the workload **twice**: a
             first dep_gen pass captures ``deps.json``, then a clean swimlane pass
@@ -244,7 +322,9 @@ class RunConfig:
     save_kernels: bool = False
     save_kernels_dir: str | None = None
     codegen_only: bool = False
-    enable_l2_swimlane: bool = False
+    # 0=off, 1=AICore timing, 2=+dispatch/finish, 3=+sched phases, 4=+orch
+    # phases. ``True`` normalizes to 4 (full), ``False`` to 0.
+    enable_l2_swimlane: int | bool = 0
     enable_dump_args: int = 0  # 0=off, 1=partial (dump_tag-marked), 2=full
     enable_pmu: int = 0
     enable_dep_gen: bool = False
@@ -284,6 +364,10 @@ class RunConfig:
         if not self.platform.startswith(expected_arch):
             sim_suffix = "sim" if self.platform.endswith("sim") else ""
             self.platform = f"{expected_arch}{sim_suffix}"
+
+        # Chip swimlane is levelled; normalize ``bool``/int to an explicit
+        # level before ``any_dfx_enabled()`` and the CLI round-trip read it.
+        self.enable_l2_swimlane = _normalize_swimlane_level(self.enable_l2_swimlane, "enable_l2_swimlane")
 
         # Any DFX flag requires kernel artefacts to be retained so the
         # ``<work_dir>/dfx_outputs/`` directory survives the run.
@@ -359,7 +443,7 @@ class RunConfig:
         independent toggles that share an output directory.
         """
         return (
-            self.enable_l2_swimlane
+            self.enable_l2_swimlane > 0
             or self.enable_dump_args > 0
             or self.enable_pmu > 0
             or self.enable_dep_gen
@@ -528,20 +612,32 @@ class _DfxOpts:
     """Bundle of runtime DFX toggles passed through the execute pipeline.
 
     Each field maps to a ``CallConfig`` member on the runtime side. The public
-    ``enable_l2_swimlane`` field maps to ``enable_chip_swimlane``; the other
-    names are unchanged. ``any()`` answers whether the runtime needs an
+    ``enable_l2_swimlane`` field maps to ``enable_chip_swimlane`` and carries a
+    collection level (see :func:`_normalize_swimlane_level`); the other names
+    are unchanged. ``any()`` answers whether the runtime needs an
     ``output_prefix``.
     """
 
-    enable_l2_swimlane: bool = False
+    # Collection level (0=off .. 4=full); ``__post_init__`` normalizes a bool.
+    enable_l2_swimlane: int | bool = 0
     enable_dump_args: int = 0  # 0=off, 1=partial, 2=full
     enable_pmu: int = 0
     enable_dep_gen: bool = False
     enable_scope_stats: bool = False
 
+    def __post_init__(self) -> None:
+        # Frozen dataclass: normalize in place so a ``bool`` handed to the
+        # constructor (or to ``dataclasses.replace``) becomes the same explicit
+        # level ``RunConfig`` produces. ``_dfx_to_cli`` stringifies this field.
+        object.__setattr__(
+            self,
+            "enable_l2_swimlane",
+            _normalize_swimlane_level(self.enable_l2_swimlane, "enable_l2_swimlane"),
+        )
+
     def any(self) -> bool:
         return (
-            self.enable_l2_swimlane
+            self.enable_l2_swimlane > 0
             or self.enable_dump_args > 0
             or self.enable_pmu > 0
             or self.enable_dep_gen
@@ -835,6 +931,9 @@ def _build_call_config(
 
     # ``enable_l2_swimlane`` is PyPTO's compatibility spelling. Simpler renamed
     # the CallConfig member as part of its Worker/Chip/Core naming migration.
+    # The value is already a normalized collection level (0-4), so it lands on
+    # the runtime's ``int32_t`` field verbatim rather than through the setter's
+    # bool shortcut.
     cfg.enable_chip_swimlane = run_config.enable_l2_swimlane
     cfg.enable_dump_args = run_config.enable_dump_args
     cfg.enable_pmu = run_config.enable_pmu

--- a/python/pypto/runtime/runner.py
+++ b/python/pypto/runtime/runner.py
@@ -24,12 +24,14 @@ Typical usage::
     compiled = run(MyProgram, a, b, c, config=RunConfig(platform="a2a3sim"))
 """
 
+import functools
 import importlib.util
 import json
 import shlex
 import subprocess
 import sys
 import uuid
+import warnings
 from collections.abc import Callable
 from ctypes import _SimpleCData
 from dataclasses import dataclass, field, replace
@@ -76,9 +78,8 @@ def _load_golden_from_data_dir(out_dir: Path, output_names: set[str]) -> dict[st
 # per-ring RunConfig override (list/tuple) must supply exactly this many entries.
 _RING_DEPTH = 4
 
-# Simpler's Worker/Chip/Core naming migration renamed the runtime swimlane
-# artifact.  Keep the legacy ``enable_l2_swimlane`` spelling at PyPTO's public
-# boundary, but use the current Simpler artifact contract internally.
+# Artifact name from Simpler's Worker/Chip/Core naming migration (formerly
+# ``l2_swimlane_records.json``).
 _CHIP_SWIMLANE_RECORDS_NAME = "chip_swimlane_records.json"
 
 # Chip-swimlane collection is *levelled*, not a toggle: each level is a real
@@ -102,6 +103,14 @@ _SWIMLANE_CLI_HELP = (
     f"Chip swimlane collection level. Bare flag = {_SWIMLANE_FULL_LEVEL} (full); "
     "1=AICore timing, 2=+AICPU dispatch/finish, 3=+scheduler phases, "
     "4=+orchestrator phases; absent = 0 (off)."
+)
+
+
+_SWIMLANE_ALIAS_DEPRECATION = (
+    "RunConfig.enable_l2_swimlane is deprecated; use enable_chip_swimlane instead. "
+    "Same values and semantics — Simpler renamed the L2 layer to 'chip', and the "
+    "runtime artifact is chip_swimlane_records.json. The alias will be removed in "
+    "a future release."
 )
 
 
@@ -172,7 +181,7 @@ class RunConfig:
             ``build_output/<program_name>_<timestamp>``.
         codegen_only: If ``True``, stop after code generation without executing
             on device.  Useful for validating compilation output.
-        enable_l2_swimlane: Chip swimlane collection **level** — per-task
+        enable_chip_swimlane: Chip swimlane collection **level** — per-task
             timing records written into
             ``<work_dir>/dfx_outputs/chip_swimlane_records.json``. Mirrors the
             runtime harness's ``--enable-chip-swimlane PERF_LEVEL``; each level
@@ -192,6 +201,9 @@ class RunConfig:
               full level, matching the runtime harness's bare
               ``--enable-chip-swimlane``.
 
+            The former spelling ``enable_l2_swimlane`` still works (constructor
+            keyword and attribute) but emits a ``DeprecationWarning``.
+
             On onboard platforms, ``swimlane_converter`` then produces
             ``merged_swimlane_*.json`` alongside the records. Because the converter joins
             the timing against a task graph that only ``deps.json`` carries,
@@ -207,8 +219,7 @@ class RunConfig:
             and only emit ``chip_swimlane_records.json`` — the merged swimlane file
             is intentionally skipped because the simulator does not yet ship the
             task metadata the converter needs. Mirrors runtime's
-            ``enable_chip_swimlane`` field. The PyPTO option retains its legacy
-            spelling for source compatibility.
+            ``CallConfig.enable_chip_swimlane`` field.
         enable_dump_args: Per-task argument dump **level** written into
             ``<work_dir>/dfx_outputs/args_dump/``. Inspect with
             ``python -m simpler_setup.tools.dump_viewer``. Mirrors
@@ -323,8 +334,10 @@ class RunConfig:
     save_kernels_dir: str | None = None
     codegen_only: bool = False
     # 0=off, 1=AICore timing, 2=+dispatch/finish, 3=+sched phases, 4=+orch
-    # phases. ``True`` normalizes to 4 (full), ``False`` to 0.
-    enable_l2_swimlane: int | bool = 0
+    # phases. ``True`` normalizes to 4 (full), ``False`` to 0. The former
+    # spelling ``enable_l2_swimlane`` is still accepted; see the deprecation
+    # shim installed just below the class.
+    enable_chip_swimlane: int | bool = 0
     enable_dump_args: int = 0  # 0=off, 1=partial (dump_tag-marked), 2=full
     enable_pmu: int = 0
     enable_dep_gen: bool = False
@@ -367,7 +380,9 @@ class RunConfig:
 
         # Chip swimlane is levelled; normalize ``bool``/int to an explicit
         # level before ``any_dfx_enabled()`` and the CLI round-trip read it.
-        self.enable_l2_swimlane = _normalize_swimlane_level(self.enable_l2_swimlane, "enable_l2_swimlane")
+        self.enable_chip_swimlane = _normalize_swimlane_level(
+            self.enable_chip_swimlane, "enable_chip_swimlane"
+        )
 
         # Any DFX flag requires kernel artefacts to be retained so the
         # ``<work_dir>/dfx_outputs/`` directory survives the run.
@@ -443,12 +458,67 @@ class RunConfig:
         independent toggles that share an output directory.
         """
         return (
-            self.enable_l2_swimlane > 0
+            self.enable_chip_swimlane > 0
             or self.enable_dump_args > 0
             or self.enable_pmu > 0
             or self.enable_dep_gen
             or self.enable_scope_stats
         )
+
+    @property
+    def enable_l2_swimlane(self) -> int:
+        """Deprecated alias for :attr:`enable_chip_swimlane`.
+
+        Reading is intentionally silent: ``dataclasses.replace()`` and existing
+        callers go through here, and warning on every read would make
+        ``replace(cfg, ...)`` noisy without pointing at a name the caller chose.
+        Assigning, and the constructor keyword, do warn.
+        """
+        return self.enable_chip_swimlane
+
+    @enable_l2_swimlane.setter
+    def enable_l2_swimlane(self, value: int | bool) -> None:
+        warnings.warn(_SWIMLANE_ALIAS_DEPRECATION, DeprecationWarning, stacklevel=2)
+        self.enable_chip_swimlane = _normalize_swimlane_level(value, "enable_l2_swimlane")
+
+
+# ---------------------------------------------------------------------------
+# Deprecated ``enable_l2_swimlane`` spelling
+# ---------------------------------------------------------------------------
+# Simpler's Worker/Chip/Core naming migration renamed the L2 layer to "chip"
+# (``L2Swimlane*`` -> ``ChipSwimlane*``, ``l2_swimlane_records.json`` ->
+# ``chip_swimlane_records.json``). ``RunConfig`` follows that contract, but the
+# old spelling stays usable for one release.
+#
+# The alias is deliberately **not** a dataclass field. ``dataclasses.replace()``
+# re-supplies every field from the existing instance, so an alias field (or an
+# ``InitVar``) would arrive alongside the canonical one on every ``replace``
+# call and there is no way to tell "the caller typed the old name" from "replace
+# echoed the old value back". That ambiguity resolves either into spurious
+# warnings or — worse — into ``replace(cfg, enable_chip_swimlane=N)`` being
+# silently overridden by the stale alias. Keeping the alias off the field list
+# leaves ``replace``, ``fields()``, ``asdict()`` and ``repr()`` clean, and routes
+# the old name through an ``__init__`` wrapper plus a property instead.
+
+_RUN_CONFIG_INIT = RunConfig.__init__
+
+
+@functools.wraps(_RUN_CONFIG_INIT)
+def _run_config_init(self: RunConfig, *args: Any, **kwargs: Any) -> None:
+    """``RunConfig.__init__`` that also accepts the deprecated alias."""
+    alias = kwargs.pop("enable_l2_swimlane", None)
+    if alias is not None:
+        warnings.warn(_SWIMLANE_ALIAS_DEPRECATION, DeprecationWarning, stacklevel=2)
+        if "enable_chip_swimlane" in kwargs:
+            raise ValueError(
+                "RunConfig received both enable_chip_swimlane and the deprecated "
+                "enable_l2_swimlane; pass only enable_chip_swimlane."
+            )
+        kwargs["enable_chip_swimlane"] = alias
+    _RUN_CONFIG_INIT(self, *args, **kwargs)
+
+
+RunConfig.__init__ = _run_config_init  # type: ignore[method-assign]
 
 
 @dataclass
@@ -612,14 +682,13 @@ class _DfxOpts:
     """Bundle of runtime DFX toggles passed through the execute pipeline.
 
     Each field maps to a ``CallConfig`` member on the runtime side. The public
-    ``enable_l2_swimlane`` field maps to ``enable_chip_swimlane`` and carries a
-    collection level (see :func:`_normalize_swimlane_level`); the other names
-    are unchanged. ``any()`` answers whether the runtime needs an
-    ``output_prefix``.
+    ``enable_chip_swimlane`` field carries a collection level (see
+    :func:`_normalize_swimlane_level`). ``any()`` answers whether the runtime
+    needs an ``output_prefix``.
     """
 
     # Collection level (0=off .. 4=full); ``__post_init__`` normalizes a bool.
-    enable_l2_swimlane: int | bool = 0
+    enable_chip_swimlane: int | bool = 0
     enable_dump_args: int = 0  # 0=off, 1=partial, 2=full
     enable_pmu: int = 0
     enable_dep_gen: bool = False
@@ -631,13 +700,13 @@ class _DfxOpts:
         # level ``RunConfig`` produces. ``_dfx_to_cli`` stringifies this field.
         object.__setattr__(
             self,
-            "enable_l2_swimlane",
-            _normalize_swimlane_level(self.enable_l2_swimlane, "enable_l2_swimlane"),
+            "enable_chip_swimlane",
+            _normalize_swimlane_level(self.enable_chip_swimlane, "enable_chip_swimlane"),
         )
 
     def any(self) -> bool:
         return (
-            self.enable_l2_swimlane > 0
+            self.enable_chip_swimlane > 0
             or self.enable_dump_args > 0
             or self.enable_pmu > 0
             or self.enable_dep_gen
@@ -647,7 +716,7 @@ class _DfxOpts:
     @classmethod
     def from_run_config(cls, cfg: "RunConfig") -> "_DfxOpts":
         return cls(
-            enable_l2_swimlane=cfg.enable_l2_swimlane,
+            enable_chip_swimlane=cfg.enable_chip_swimlane,
             enable_dump_args=cfg.enable_dump_args,
             enable_pmu=cfg.enable_pmu,
             enable_dep_gen=cfg.enable_dep_gen,
@@ -695,7 +764,7 @@ def _execute_dfx_passes(
         dfx: The DFX toggles the caller requested.
         platform: Target execution platform (used only to detect ``*sim``).
     """
-    if not dfx.enable_l2_swimlane or platform.endswith("sim"):
+    if not dfx.enable_chip_swimlane or platform.endswith("sim"):
         run_pass(dfx)
         return
 
@@ -929,12 +998,9 @@ def _build_call_config(
     if at is not None:
         cfg.aicpu_thread_num = at
 
-    # ``enable_l2_swimlane`` is PyPTO's compatibility spelling. Simpler renamed
-    # the CallConfig member as part of its Worker/Chip/Core naming migration.
-    # The value is already a normalized collection level (0-4), so it lands on
-    # the runtime's ``int32_t`` field verbatim rather than through the setter's
-    # bool shortcut.
-    cfg.enable_chip_swimlane = run_config.enable_l2_swimlane
+    # Already a normalized collection level (0-4), so it lands on the runtime's
+    # ``int32_t`` field verbatim rather than through the setter's bool shortcut.
+    cfg.enable_chip_swimlane = run_config.enable_chip_swimlane
     cfg.enable_dump_args = run_config.enable_dump_args
     cfg.enable_pmu = run_config.enable_pmu
     cfg.enable_dep_gen = run_config.enable_dep_gen
@@ -1021,7 +1087,7 @@ def _execute_on_device(
             device_id,
             enable_sdma=enable_sdma,
             output_prefix=str(dfx_dir) if dfx_dir is not None else None,
-            enable_l2_swimlane=pass_dfx.enable_l2_swimlane,
+            enable_chip_swimlane=pass_dfx.enable_chip_swimlane,
             enable_dump_args=pass_dfx.enable_dump_args,
             enable_pmu=pass_dfx.enable_pmu,
             enable_dep_gen=pass_dfx.enable_dep_gen,
@@ -1125,11 +1191,11 @@ def _collect_dfx_artifacts(
     # ``--func-names``. Written whenever swimlane or dep_gen is enabled (the two
     # consumers); harmless no-op when no kernel names are available.
     name_map_path: Path | None = None
-    if dfx.enable_l2_swimlane or dfx.enable_dep_gen:
+    if dfx.enable_chip_swimlane or dfx.enable_dep_gen:
         name_map_path = _write_name_map(dfx_dir.parent, dfx_dir)
 
     chip_swimlane_records = dfx_dir / _CHIP_SWIMLANE_RECORDS_NAME
-    if dfx.enable_l2_swimlane and chip_swimlane_records.exists():
+    if dfx.enable_chip_swimlane and chip_swimlane_records.exists():
         # Swimlane conversion is onboard-only — the simulator produces
         # ``chip_swimlane_records.json`` but does not yet ship the matching
         # task metadata the converter expects.
@@ -1452,7 +1518,7 @@ def execute_compiled(  # noqa: PLR0913
             aicpu_thread_num=effective_aicpu_thread_num,
             enable_sdma=enable_sdma,
             output_prefix=str(dfx_dir) if dfx_dir is not None else None,
-            enable_l2_swimlane=pass_dfx.enable_l2_swimlane,
+            enable_chip_swimlane=pass_dfx.enable_chip_swimlane,
             enable_dump_args=pass_dfx.enable_dump_args,
             enable_pmu=pass_dfx.enable_pmu,
             enable_dep_gen=pass_dfx.enable_dep_gen,

--- a/tests/st/conftest.py
+++ b/tests/st/conftest.py
@@ -54,7 +54,12 @@ from harness.core.test_runner import (  # noqa: E402
 from pypto import LogLevel  # noqa: E402
 from pypto.pypto_core import _clear_thread_log_level, _set_thread_log_level  # noqa: E402
 from pypto.pypto_core.passes import MemoryPlanner  # noqa: E402
-from pypto.runtime.runner import RunConfig  # noqa: E402
+from pypto.runtime.runner import (  # noqa: E402
+    _SWIMLANE_CLI_HELP,
+    _SWIMLANE_FULL_LEVEL,
+    _SWIMLANE_MAX_LEVEL,
+    RunConfig,
+)
 
 # Temp directories created for pre-compilation (when --save-kernels is not set).
 # Cleaned up in pytest_sessionfinish.
@@ -226,9 +231,15 @@ def pytest_addoption(parser):
     # ``enable_chip_swimlane`` member.
     parser.addoption(
         "--enable-l2-swimlane",
-        action="store_true",
-        default=False,
-        help="Capture per-task chip perf records into <work_dir>/dfx_outputs/chip_swimlane_records.json. "
+        nargs="?",
+        const=_SWIMLANE_FULL_LEVEL,
+        default=0,
+        type=int,
+        choices=range(_SWIMLANE_MAX_LEVEL + 1),
+        metavar="PERF_LEVEL",
+        help=_SWIMLANE_CLI_HELP + " Records are written into "
+        "<work_dir>/dfx_outputs/chip_swimlane_records.json. The bare flag matches the runtime "
+        "harness's bare --enable-chip-swimlane. "
         "On onboard platforms, also render merged_swimlane_*.json and run the kernel twice: a dep_gen "
         "pass to capture deps.json (the converter's task graph) then a clean swimlane pass, since "
         "dep_gen collection perturbs the timing. Simulator platforms emit only the records (the merged "
@@ -833,7 +844,7 @@ def pytest_collection_finish(session: pytest.Session) -> None:
 
     dump_passes: bool = session.config.getoption("--dump-passes")
     codegen_only: bool = session.config.getoption("--codegen-only")
-    enable_l2_swimlane: bool = session.config.getoption("--enable-l2-swimlane")
+    enable_l2_swimlane: int = session.config.getoption("--enable-l2-swimlane")
     enable_dump_args: int = session.config.getoption("--dump-args")
     enable_pmu: int = session.config.getoption("--enable-pmu")
     enable_dep_gen: bool = session.config.getoption("--enable-dep-gen")

--- a/tests/st/conftest.py
+++ b/tests/st/conftest.py
@@ -21,6 +21,7 @@ import shutil
 import sys
 import tempfile
 import textwrap
+import warnings
 from collections import Counter
 from contextlib import nullcontext
 from datetime import datetime
@@ -82,6 +83,28 @@ def setup_simpler_dependency(request):
     for path in [get_simpler_python_path(), get_simpler_scripts_path()]:
         if path.exists() and str(path) not in sys.path:
             sys.path.insert(0, str(path))
+
+
+def _resolve_swimlane_option(config: pytest.Config) -> int:
+    """Return the requested chip-swimlane collection level.
+
+    Precedence: an explicit ``--chip-swimlane-level N`` wins, then the bare
+    ``--enable-chip-swimlane`` (full level), then the deprecated bare
+    ``--enable-l2-swimlane`` (same level, with a warning). Absent means off.
+    """
+    level: int | None = config.getoption("--chip-swimlane-level")
+    if level is not None:
+        return level
+    if config.getoption("--enable-chip-swimlane"):
+        return _SWIMLANE_FULL_LEVEL
+    if config.getoption("enable_l2_swimlane_deprecated"):
+        warnings.warn(
+            "--enable-l2-swimlane is deprecated; use --enable-chip-swimlane (or --chip-swimlane-level N).",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return _SWIMLANE_FULL_LEVEL
+    return 0
 
 
 def pytest_addoption(parser):
@@ -226,24 +249,44 @@ def pytest_addoption(parser):
     )
     # ── DFX (Design For X) toggles ────────────────────────────────────────
     # Each maps to the same-named field on ``RunConfig`` and to the corresponding
-    # runtime ``CallConfig`` member. The public PyPTO swimlane spelling remains
-    # ``enable_l2_swimlane`` for compatibility and maps to Simpler's renamed
-    # ``enable_chip_swimlane`` member.
+    # runtime ``CallConfig`` member.
+    #
+    # The bare enable flag and the level-valued form are deliberately two
+    # options. An ``nargs="?"`` option greedily eats the next non-dash token, so
+    # a single option would turn the conventional
+    # ``pytest --enable-chip-swimlane tests/st/runtime/`` into
+    # "invalid int value: 'tests/st/runtime/'" — the flag used to be
+    # ``store_true`` and that ordering has always worked. Keeping the bare flag
+    # valueless makes it order-independent again.
     parser.addoption(
-        "--enable-l2-swimlane",
-        nargs="?",
+        "--enable-chip-swimlane",
+        action="store_const",
         const=_SWIMLANE_FULL_LEVEL,
         default=0,
-        type=int,
-        choices=range(_SWIMLANE_MAX_LEVEL + 1),
-        metavar="PERF_LEVEL",
-        help=_SWIMLANE_CLI_HELP + " Records are written into "
-        "<work_dir>/dfx_outputs/chip_swimlane_records.json. The bare flag matches the runtime "
-        "harness's bare --enable-chip-swimlane. "
+        help=f"Enable chip swimlane capture at the full level ({_SWIMLANE_FULL_LEVEL}), matching the "
+        "runtime harness's bare --enable-chip-swimlane. Use --chip-swimlane-level N for a lower "
+        "level. Records are written into <work_dir>/dfx_outputs/chip_swimlane_records.json. "
         "On onboard platforms, also render merged_swimlane_*.json and run the kernel twice: a dep_gen "
         "pass to capture deps.json (the converter's task graph) then a clean swimlane pass, since "
         "dep_gen collection perturbs the timing. Simulator platforms emit only the records (the merged "
         "swimlane is skipped).",
+    )
+    parser.addoption(
+        "--chip-swimlane-level",
+        default=None,
+        type=int,
+        choices=range(_SWIMLANE_MAX_LEVEL + 1),
+        metavar="PERF_LEVEL",
+        help=_SWIMLANE_CLI_HELP + " Takes precedence over --enable-chip-swimlane.",
+    )
+    # Deprecated spelling, kept because CI and existing scripts still pass it.
+    # Valueless like the original ``store_true`` form it replaces.
+    parser.addoption(
+        "--enable-l2-swimlane",
+        dest="enable_l2_swimlane_deprecated",
+        action="store_true",
+        default=False,
+        help="Deprecated alias for --enable-chip-swimlane.",
     )
     parser.addoption(
         "--dump-args",
@@ -464,7 +507,7 @@ def test_config(request) -> RunConfig:
         save_kernels_dir=save_kernels_dir,
         dump_passes=request.config.getoption("--dump-passes"),
         codegen_only=request.config.getoption("--codegen-only"),
-        enable_l2_swimlane=request.config.getoption("--enable-l2-swimlane"),
+        enable_chip_swimlane=_resolve_swimlane_option(request.config),
         enable_dump_args=request.config.getoption("--dump-args"),
         enable_pmu=request.config.getoption("--enable-pmu"),
         enable_dep_gen=request.config.getoption("--enable-dep-gen"),
@@ -844,7 +887,7 @@ def pytest_collection_finish(session: pytest.Session) -> None:
 
     dump_passes: bool = session.config.getoption("--dump-passes")
     codegen_only: bool = session.config.getoption("--codegen-only")
-    enable_l2_swimlane: int = session.config.getoption("--enable-l2-swimlane")
+    enable_chip_swimlane: int = _resolve_swimlane_option(session.config)
     enable_dump_args: int = session.config.getoption("--dump-args")
     enable_pmu: int = session.config.getoption("--enable-pmu")
     enable_dep_gen: bool = session.config.getoption("--enable-dep-gen")
@@ -912,7 +955,7 @@ def pytest_collection_finish(session: pytest.Session) -> None:
             pypto_log_level=pypto_log_level,
             compile_workers=max_workers,
             device_pool=device_pool,
-            enable_l2_swimlane=enable_l2_swimlane,
+            enable_chip_swimlane=enable_chip_swimlane,
             enable_dump_args=enable_dump_args,
             enable_pmu=enable_pmu,
             enable_dep_gen=enable_dep_gen,

--- a/tests/st/distributed/test_l3_dfx_per_rank.py
+++ b/tests/st/distributed/test_l3_dfx_per_rank.py
@@ -27,7 +27,7 @@ This exercises the driver wiring (``_make_call_config`` setting the DFX flags +
 base ``output_prefix``) and the codegen wiring (``_submit_chip`` appending the
 ``/rank{worker}/d{k}`` suffix per dispatch).
 
-``enable_l2_swimlane`` is also covered: on L3 it co-enables dep_gen and emits
+``enable_chip_swimlane`` is also covered: on L3 it co-enables dep_gen and emits
 ``rank{r}/d{k}/chip_swimlane_records.json`` + ``rank{r}/d{k}/deps.json`` per
 dispatch; onboard it is additionally converted to
 ``rank{r}/d{k}/merged_swimlane_*.json`` (conversion is skipped on the simulator,
@@ -162,7 +162,7 @@ class TestL3DfxPerRank:
         outputs = torch.zeros((n_ranks, ROWS, COLS), dtype=torch.float32)
 
         # User asks for swimlane only; dep_gen is co-enabled by the driver.
-        run_config = RunConfig(platform=test_config.platform, enable_l2_swimlane=True)
+        run_config = RunConfig(platform=test_config.platform, enable_chip_swimlane=True)
         compiled(inputs, outputs, config=run_config)
 
         assert torch.allclose(outputs, inputs + 1.0)

--- a/tests/st/harness/core/test_runner.py
+++ b/tests/st/harness/core/test_runner.py
@@ -457,10 +457,10 @@ def _dfx_to_cli(dfx: "_DfxOpts") -> list[str]:
     ``pypto.runtime.execute_artifact._build_parser``.
     """
     argv: list[str] = []
-    if dfx.enable_l2_swimlane:
+    if dfx.enable_chip_swimlane:
         # Levelled, not a toggle — pass the level explicitly so a level 1-3
         # capture is not silently promoted to the bare flag's level 4.
-        argv += ["--enable-l2-swimlane", str(dfx.enable_l2_swimlane)]
+        argv += ["--enable-chip-swimlane", str(dfx.enable_chip_swimlane)]
     if dfx.enable_dump_args:
         argv += ["--dump-args", str(dfx.enable_dump_args)]
     if dfx.enable_pmu:
@@ -992,7 +992,7 @@ def start_pipeline(  # noqa: PLR0913
     compile_workers: int,
     device_pool: "queue.Queue[int]",
     analyze_auto_scopes_for_deps: bool = False,
-    enable_l2_swimlane: int = 0,
+    enable_chip_swimlane: int = 0,
     enable_dump_args: int = 0,
     enable_pmu: int = 0,
     enable_dep_gen: bool = False,
@@ -1042,7 +1042,7 @@ def start_pipeline(  # noqa: PLR0913
         "analyze_auto_scopes_for_deps": analyze_auto_scopes_for_deps,
         "memory_planner": memory_planner,
         "dfx": _DfxOpts(
-            enable_l2_swimlane=enable_l2_swimlane,
+            enable_chip_swimlane=enable_chip_swimlane,
             enable_dump_args=enable_dump_args,
             enable_pmu=enable_pmu,
             enable_dep_gen=enable_dep_gen,

--- a/tests/st/harness/core/test_runner.py
+++ b/tests/st/harness/core/test_runner.py
@@ -458,7 +458,9 @@ def _dfx_to_cli(dfx: "_DfxOpts") -> list[str]:
     """
     argv: list[str] = []
     if dfx.enable_l2_swimlane:
-        argv.append("--enable-l2-swimlane")
+        # Levelled, not a toggle — pass the level explicitly so a level 1-3
+        # capture is not silently promoted to the bare flag's level 4.
+        argv += ["--enable-l2-swimlane", str(dfx.enable_l2_swimlane)]
     if dfx.enable_dump_args:
         argv += ["--dump-args", str(dfx.enable_dump_args)]
     if dfx.enable_pmu:
@@ -990,7 +992,7 @@ def start_pipeline(  # noqa: PLR0913
     compile_workers: int,
     device_pool: "queue.Queue[int]",
     analyze_auto_scopes_for_deps: bool = False,
-    enable_l2_swimlane: bool = False,
+    enable_l2_swimlane: int = 0,
     enable_dump_args: int = 0,
     enable_pmu: int = 0,
     enable_dep_gen: bool = False,

--- a/tests/st/runtime/cross_core/test_cross_core_grouped_tpop_tfree.py
+++ b/tests/st/runtime/cross_core/test_cross_core_grouped_tpop_tfree.py
@@ -264,7 +264,7 @@ class TestCrossCoreGroupedTpopTfree:
                     device_id,
                     aicpu_thread_num=runtime_cfg.get("aicpu_thread_num", 0),
                     output_prefix=output_prefix,
-                    enable_l2_swimlane=test_config.enable_l2_swimlane,
+                    enable_chip_swimlane=test_config.enable_chip_swimlane,
                     enable_dump_args=test_config.enable_dump_args,
                     enable_pmu=test_config.enable_pmu,
                     enable_dep_gen=test_config.enable_dep_gen,

--- a/tests/st/runtime/framework_and_models/test_perf_swimlane.py
+++ b/tests/st/runtime/framework_and_models/test_perf_swimlane.py
@@ -12,9 +12,9 @@
 Runs matmul 64x64x64 (PTO backend) with profiling and validates the
 generated chip_swimlane_records.json in build_output/<run_dir>/dfx_outputs/.
 
-Requires ``--enable-l2-swimlane`` to be set; pass ``--platform=a2a3`` (or
+Requires ``--enable-chip-swimlane`` to be set; pass ``--platform=a2a3`` (or
 ``a5``) to switch the target.  All tests in this file are skipped
-automatically when ``--enable-l2-swimlane`` is not passed.
+automatically when ``--enable-chip-swimlane`` is not passed.
 """
 
 from pathlib import Path
@@ -88,10 +88,10 @@ def swimlane_file(test_runner) -> Path:
     """Run matmul once with profiling and return the generated swimlane file.
 
     Skips the entire test session (all dependent tests) when
-    --enable-l2-swimlane is not passed.
+    --enable-chip-swimlane is not passed.
     """
-    if not test_runner.config.enable_l2_swimlane:
-        pytest.skip("pass --enable-l2-swimlane to run swimlane tests")
+    if not test_runner.config.enable_chip_swimlane:
+        pytest.skip("pass --enable-chip-swimlane to run swimlane tests")
 
     before: set[Path] = set(_BUILD_OUTPUT_DIR.glob("*/dfx_outputs/chip_swimlane_records.json"))
 

--- a/tests/st/runtime/scheduling/test_manual_scope_pipeline.py
+++ b/tests/st/runtime/scheduling/test_manual_scope_pipeline.py
@@ -47,9 +47,9 @@ How to run
 
     # On real hardware, with profiling enabled:
     pytest tests/st/runtime/scheduling/test_manual_scope_pipeline.py \\
-        --enable-l2-swimlane --platform=a2a3
+        --enable-chip-swimlane --platform=a2a3
 
-    # Without --enable-l2-swimlane, the swimlane assertions skip and only
+    # Without --enable-chip-swimlane, the swimlane assertions skip and only
     # numerical correctness is checked.
 """
 
@@ -197,15 +197,15 @@ class TestManualScopePipeline:
 
 
 # ---------------------------------------------------------------------------
-# Swimlane validation — only when --enable-l2-swimlane is enabled.
+# Swimlane validation — only when --enable-chip-swimlane is enabled.
 # ---------------------------------------------------------------------------
 
 
 @pytest.fixture(scope="module")
 def manual_scope_swimlane_file(test_runner) -> Path:
     """Run the pipeline once with profiling and return the swimlane JSON."""
-    if not test_runner.config.enable_l2_swimlane:
-        pytest.skip("pass --enable-l2-swimlane to validate the manual_scope swimlane")
+    if not test_runner.config.enable_chip_swimlane:
+        pytest.skip("pass --enable-chip-swimlane to validate the manual_scope swimlane")
 
     before: set[Path] = set(_BUILD_OUTPUT_DIR.glob("*/dfx_outputs/chip_swimlane_records.json"))
     result = test_runner.run(_ManualScopePipelinePTO())
@@ -498,8 +498,8 @@ class TestPhaseFenceAuto:
 
 @pytest.fixture(scope="module")
 def phase_fence_swimlane_file(test_runner) -> Path:
-    if not test_runner.config.enable_l2_swimlane:
-        pytest.skip("pass --enable-l2-swimlane to validate the phase-fence swimlane")
+    if not test_runner.config.enable_chip_swimlane:
+        pytest.skip("pass --enable-chip-swimlane to validate the phase-fence swimlane")
     before: set[Path] = set(_BUILD_OUTPUT_DIR.glob("*/dfx_outputs/chip_swimlane_records.json"))
     result = test_runner.run(_PhaseFenceManualScopePTO())
     assert result.passed, f"phase-fence manual_scope failed: {result.error}"
@@ -516,8 +516,8 @@ def phase_fence_swimlane_data(phase_fence_swimlane_file: Path) -> dict:
 
 @pytest.fixture(scope="module")
 def phase_fence_auto_swimlane_file(test_runner) -> Path:
-    if not test_runner.config.enable_l2_swimlane:
-        pytest.skip("pass --enable-l2-swimlane to validate the auto phase-fence swimlane")
+    if not test_runner.config.enable_chip_swimlane:
+        pytest.skip("pass --enable-chip-swimlane to validate the auto phase-fence swimlane")
     before: set[Path] = set(_BUILD_OUTPUT_DIR.glob("*/dfx_outputs/chip_swimlane_records.json"))
     result = test_runner.run(_PhaseFenceAutoPTO())
     assert result.passed, f"phase-fence auto failed: {result.error}"
@@ -718,8 +718,8 @@ class TestBranchChainManualScope:
 
 @pytest.fixture(scope="module")
 def branch_chain_swimlane_file(test_runner) -> Path:
-    if not test_runner.config.enable_l2_swimlane:
-        pytest.skip("pass --enable-l2-swimlane to validate the branch-chain swimlane")
+    if not test_runner.config.enable_chip_swimlane:
+        pytest.skip("pass --enable-chip-swimlane to validate the branch-chain swimlane")
     before: set[Path] = set(_BUILD_OUTPUT_DIR.glob("*/dfx_outputs/chip_swimlane_records.json"))
     result = test_runner.run(_BranchChainManualScopePTO())
     assert result.passed, f"branch-chain manual_scope failed: {result.error}"
@@ -940,8 +940,8 @@ class _OriginalKVProjOuterParallelPTO(PTOTestCase):
 @pytest.fixture(scope="module")
 def original_kv_proj_swimlane_file(test_runner) -> Path:
     """Run the original kv_proj case once and return the generated swimlane JSON."""
-    if not test_runner.config.enable_l2_swimlane:
-        pytest.skip("pass --enable-l2-swimlane to validate the original kv_proj swimlane")
+    if not test_runner.config.enable_chip_swimlane:
+        pytest.skip("pass --enable-chip-swimlane to validate the original kv_proj swimlane")
 
     before: set[Path] = set(_BUILD_OUTPUT_DIR.glob("*/dfx_outputs/chip_swimlane_records.json"))
     result = test_runner.run(_OriginalKVProjOuterParallelPTO())

--- a/tests/st/runtime/scheduling/test_phase_fence_dep_compression.py
+++ b/tests/st/runtime/scheduling/test_phase_fence_dep_compression.py
@@ -124,8 +124,8 @@ def _snapshot_swimlane_branches_from_env() -> int:
 
 
 def _new_swimlane_file(test_runner, case: PTOTestCase, *, label: str) -> Path:
-    if not test_runner.config.enable_l2_swimlane:
-        pytest.skip(f"pass --enable-l2-swimlane to validate {label}")
+    if not test_runner.config.enable_chip_swimlane:
+        pytest.skip(f"pass --enable-chip-swimlane to validate {label}")
     before: set[Path] = set(_BUILD_OUTPUT_DIR.glob("*/dfx_outputs/chip_swimlane_records.json"))
     result = test_runner.run(case)
     assert result.passed, f"{label} failed: {result.error}"
@@ -894,9 +894,9 @@ def _chained_snapshot_manual_dummy_case(*, branches: int = _BRANCHES, platform: 
 class TestPhaseFenceDepCompressionCorrectness:
     @pytest.fixture(autouse=True)
     def _skip_when_collecting_l2_swimlane(self, test_runner):
-        if test_runner.config.enable_l2_swimlane:
+        if test_runner.config.enable_chip_swimlane:
             pytest.skip(
-                "correctness cases run without --enable-l2-swimlane; swimlane mode runs profiling witnesses"
+                "correctness cases run without --enable-chip-swimlane; swimlane mode runs profiling witnesses"
             )
 
     @pytest.mark.parametrize("platform", PLATFORMS)

--- a/tests/st/runtime/scheduling/test_pl_at_deps_pipeline.py
+++ b/tests/st/runtime/scheduling/test_pl_at_deps_pipeline.py
@@ -44,9 +44,9 @@ How to run
 
     # On real hardware, with profiling enabled:
     pytest tests/st/runtime/scheduling/test_pl_at_deps_pipeline.py \\
-        --enable-l2-swimlane --platform=a2a3
+        --enable-chip-swimlane --platform=a2a3
 
-    # Without --enable-l2-swimlane, the swimlane assertions skip and only
+    # Without --enable-chip-swimlane, the swimlane assertions skip and only
     # numerical correctness is checked.
 """
 
@@ -184,15 +184,15 @@ class TestPlAtDepsPipeline:
 
 
 # ---------------------------------------------------------------------------
-# Swimlane validation — only when --enable-l2-swimlane is enabled.
+# Swimlane validation — only when --enable-chip-swimlane is enabled.
 # ---------------------------------------------------------------------------
 
 
 @pytest.fixture(scope="module")
 def pl_at_deps_swimlane_file(test_runner) -> Path:
     """Run the pipeline once with profiling and return the swimlane JSON."""
-    if not test_runner.config.enable_l2_swimlane:
-        pytest.skip("pass --enable-l2-swimlane to validate the pl.at-deps swimlane")
+    if not test_runner.config.enable_chip_swimlane:
+        pytest.skip("pass --enable-chip-swimlane to validate the pl.at-deps swimlane")
 
     before: set[Path] = set(_BUILD_OUTPUT_DIR.glob("*/dfx_outputs/chip_swimlane_records.json"))
     result = test_runner.run(_PlAtDepsPipelinePTO())
@@ -412,8 +412,8 @@ class TestPhaseFencePlAtDeps:
 
 @pytest.fixture(scope="module")
 def phase_fence_pl_at_swimlane_file(test_runner) -> Path:
-    if not test_runner.config.enable_l2_swimlane:
-        pytest.skip("pass --enable-l2-swimlane to validate the phase-fence pl.at swimlane")
+    if not test_runner.config.enable_chip_swimlane:
+        pytest.skip("pass --enable-chip-swimlane to validate the phase-fence pl.at swimlane")
     before: set[Path] = set(_BUILD_OUTPUT_DIR.glob("*/dfx_outputs/chip_swimlane_records.json"))
     result = test_runner.run(_PhaseFencePlAtDepsPTO())
     assert result.passed, f"phase-fence pl.at-deps failed: {result.error}"
@@ -601,8 +601,8 @@ class TestBranchChainPlAtDeps:
 
 @pytest.fixture(scope="module")
 def branch_chain_pl_at_swimlane_file(test_runner) -> Path:
-    if not test_runner.config.enable_l2_swimlane:
-        pytest.skip("pass --enable-l2-swimlane to validate the branch-chain pl.at swimlane")
+    if not test_runner.config.enable_chip_swimlane:
+        pytest.skip("pass --enable-chip-swimlane to validate the branch-chain pl.at swimlane")
     before: set[Path] = set(_BUILD_OUTPUT_DIR.glob("*/dfx_outputs/chip_swimlane_records.json"))
     result = test_runner.run(_BranchChainPlAtDepsPTO())
     assert result.passed, f"branch-chain pl.at-deps failed: {result.error}"

--- a/tests/ut/ir/test_compiled_program.py
+++ b/tests/ut/ir/test_compiled_program.py
@@ -842,7 +842,7 @@ class TestCompiledProgramExtraction:
 
             cp.build_call_config(
                 RunConfig(
-                    enable_l2_swimlane=True,
+                    enable_chip_swimlane=True,
                     enable_dump_args=True,
                     enable_pmu=2,
                     enable_dep_gen=True,

--- a/tests/ut/ir/test_compiled_program.py
+++ b/tests/ut/ir/test_compiled_program.py
@@ -850,7 +850,7 @@ class TestCompiledProgramExtraction:
                 dfx_dir=tmp_path / "dfx",
             )
 
-        assert fake_call_config.enable_chip_swimlane is True
+        assert fake_call_config.enable_chip_swimlane == 4  # True normalizes to the full level
         assert fake_call_config.enable_dump_args is True
         assert fake_call_config.enable_pmu == 2
         assert fake_call_config.enable_dep_gen is True

--- a/tests/ut/runtime/test_distributed_worker.py
+++ b/tests/ut/runtime/test_distributed_worker.py
@@ -569,7 +569,7 @@ class TestPreparedSwimlaneTwoPass:
 
         run_config = RunConfig(
             platform="a2a3",
-            enable_l2_swimlane=1,  # pyright: ignore[reportArgumentType]
+            enable_l2_swimlane=1,  # AICore-timing level, not just "on"
             enable_pmu=3,
             enable_scope_stats=True,
             enable_dump_args=2,
@@ -597,7 +597,7 @@ class TestPreparedSwimlaneTwoPass:
         assert m["make_call_config"].call_count == 2
         deps_build, timing_build = m["make_call_config"].call_args_list
         deps_config = deps_build.args[1]
-        assert deps_config.enable_l2_swimlane is False
+        assert deps_config.enable_l2_swimlane == 0
         assert deps_config.enable_dep_gen is True
         assert deps_config.enable_pmu == 0
         assert deps_config.enable_scope_stats is False
@@ -630,7 +630,7 @@ class TestPreparedSwimlaneTwoPass:
         m["make_call_config"].return_value = call_config
         run_config = RunConfig(
             platform="a2a3sim",
-            enable_l2_swimlane=1,  # pyright: ignore[reportArgumentType]
+            enable_l2_swimlane=1,  # AICore-timing level, not just "on"
         )
         with patch("pypto.runtime.distributed_runner._collect_l3_swimlane") as collect:
             rt(_resident(rt, (16, 16)), config=run_config)
@@ -2421,7 +2421,7 @@ class _BoolStrictCallConfig:
 
     The real ``CallConfig.enable_dep_gen`` pybind overload accepts only ``bool``
     and raises ``TypeError`` on an ``int`` — exactly the crash issue #1952
-    reproduces when the int ``enable_l2_swimlane`` CLI flag (0/1/2) leaks through
+    reproduces when the int ``enable_l2_swimlane`` collection level (0-4) leaks through
     the ``and``/``or`` chain unwrapped. ``bool`` is a subclass of ``int``, so
     ``isinstance(value, bool)`` matches the pybind behavior (rejects ``1``/``0``).
     """
@@ -2469,20 +2469,16 @@ def fake_simpler_task_interface(monkeypatch):
 class TestMakeCallConfigDepGenType:
     """``_make_call_config`` must assign a ``bool`` to ``enable_dep_gen``.
 
-    Regression for issue #1952: ``enable_l2_swimlane`` is an int (0/1/2), so the
+    Regression for issue #1952: ``enable_l2_swimlane`` is a collection level
+    (0-4), so the
     ``dfx.enable_dep_gen or (co_enable_swimlane_dep_gen and dfx.enable_l2_swimlane)``
     chain can yield an int, which the ``bool``-only pybind setter rejects.
     """
 
-    # The pypto-lib CLI wires ``--enable-l2-swimlane`` as ``type=int,
-    # choices=(0, 1, 2)``, so ``RunConfig`` receives an ``int`` here even though
-    # the field is annotated ``bool`` — that int is precisely the crash trigger
-    # under test, hence the deliberate ``pyright: ignore[reportArgumentType]``.
-
     def test_int_swimlane_flag_yields_bool_dep_gen(self, tmp_path, fake_simpler_task_interface):
         # ``--enable-l2-swimlane 1`` reaches RunConfig as the int ``1``; the
         # co-enable path must still hand ``enable_dep_gen`` a genuine ``bool``.
-        run_config = RunConfig(enable_l2_swimlane=1)  # pyright: ignore[reportArgumentType]
+        run_config = RunConfig(enable_l2_swimlane=1)
         cfg = _make_call_config(DistributedConfig(), run_config, dfx_base=tmp_path / "dfx")
         assert cfg.enable_dep_gen is True
         assert cfg.enable_chip_swimlane == 1
@@ -2490,12 +2486,12 @@ class TestMakeCallConfigDepGenType:
     def test_int_zero_swimlane_yields_bool_false_dep_gen(self, tmp_path, fake_simpler_task_interface):
         # Another DFX flag opens the block while swimlane is the int ``0``; the
         # ``and``/``or`` chain would otherwise assign int ``0`` and still crash.
-        run_config = RunConfig(enable_dump_args=1, enable_l2_swimlane=0)  # pyright: ignore[reportArgumentType]
+        run_config = RunConfig(enable_dump_args=1, enable_l2_swimlane=0)
         cfg = _make_call_config(DistributedConfig(), run_config, dfx_base=tmp_path / "dfx")
         assert cfg.enable_dep_gen is False
 
     def test_clean_timing_suppresses_implicit_dep_gen(self, tmp_path, fake_simpler_task_interface):
-        run_config = RunConfig(enable_l2_swimlane=1)  # pyright: ignore[reportArgumentType]
+        run_config = RunConfig(enable_l2_swimlane=1)
         cfg = _make_call_config(
             DistributedConfig(),
             run_config,
@@ -2506,7 +2502,7 @@ class TestMakeCallConfigDepGenType:
 
     def test_explicit_dep_gen_still_wins_when_co_enable_is_off(self, tmp_path, fake_simpler_task_interface):
         run_config = RunConfig(
-            enable_l2_swimlane=1,  # pyright: ignore[reportArgumentType]
+            enable_l2_swimlane=1,  # AICore-timing level, not just "on"
             enable_dep_gen=True,
         )
         cfg = _make_call_config(

--- a/tests/ut/runtime/test_distributed_worker.py
+++ b/tests/ut/runtime/test_distributed_worker.py
@@ -569,7 +569,7 @@ class TestPreparedSwimlaneTwoPass:
 
         run_config = RunConfig(
             platform="a2a3",
-            enable_l2_swimlane=1,  # AICore-timing level, not just "on"
+            enable_chip_swimlane=1,  # AICore-timing level, not just "on"
             enable_pmu=3,
             enable_scope_stats=True,
             enable_dump_args=2,
@@ -597,14 +597,14 @@ class TestPreparedSwimlaneTwoPass:
         assert m["make_call_config"].call_count == 2
         deps_build, timing_build = m["make_call_config"].call_args_list
         deps_config = deps_build.args[1]
-        assert deps_config.enable_l2_swimlane == 0
+        assert deps_config.enable_chip_swimlane == 0
         assert deps_config.enable_dep_gen is True
         assert deps_config.enable_pmu == 0
         assert deps_config.enable_scope_stats is False
         assert deps_config.enable_dump_args == 0
 
         timing_config = timing_build.args[1]
-        assert timing_config.enable_l2_swimlane == 1
+        assert timing_config.enable_chip_swimlane == 1
         assert timing_config.enable_dep_gen is False
         assert timing_config.enable_pmu == 3
         assert timing_config.enable_scope_stats is True
@@ -630,7 +630,7 @@ class TestPreparedSwimlaneTwoPass:
         m["make_call_config"].return_value = call_config
         run_config = RunConfig(
             platform="a2a3sim",
-            enable_l2_swimlane=1,  # AICore-timing level, not just "on"
+            enable_chip_swimlane=1,  # AICore-timing level, not just "on"
         )
         with patch("pypto.runtime.distributed_runner._collect_l3_swimlane") as collect:
             rt(_resident(rt, (16, 16)), config=run_config)
@@ -690,7 +690,7 @@ class TestPreparedSwimlaneTwoPass:
         ):
             rt(
                 _resident(rt, (16, 16)),
-                config=RunConfig(platform="a2a3", enable_l2_swimlane=True),
+                config=RunConfig(platform="a2a3", enable_chip_swimlane=True),
             )
 
         assert [call.args[2] for call in submit_persistent.call_args_list] == [
@@ -2421,7 +2421,7 @@ class _BoolStrictCallConfig:
 
     The real ``CallConfig.enable_dep_gen`` pybind overload accepts only ``bool``
     and raises ``TypeError`` on an ``int`` — exactly the crash issue #1952
-    reproduces when the int ``enable_l2_swimlane`` collection level (0-4) leaks through
+    reproduces when the int ``enable_chip_swimlane`` collection level (0-4) leaks through
     the ``and``/``or`` chain unwrapped. ``bool`` is a subclass of ``int``, so
     ``isinstance(value, bool)`` matches the pybind behavior (rejects ``1``/``0``).
     """
@@ -2469,16 +2469,16 @@ def fake_simpler_task_interface(monkeypatch):
 class TestMakeCallConfigDepGenType:
     """``_make_call_config`` must assign a ``bool`` to ``enable_dep_gen``.
 
-    Regression for issue #1952: ``enable_l2_swimlane`` is a collection level
+    Regression for issue #1952: ``enable_chip_swimlane`` is a collection level
     (0-4), so the
-    ``dfx.enable_dep_gen or (co_enable_swimlane_dep_gen and dfx.enable_l2_swimlane)``
+    ``dfx.enable_dep_gen or (co_enable_swimlane_dep_gen and dfx.enable_chip_swimlane)``
     chain can yield an int, which the ``bool``-only pybind setter rejects.
     """
 
     def test_int_swimlane_flag_yields_bool_dep_gen(self, tmp_path, fake_simpler_task_interface):
-        # ``--enable-l2-swimlane 1`` reaches RunConfig as the int ``1``; the
+        # ``--enable-chip-swimlane 1`` reaches RunConfig as the int ``1``; the
         # co-enable path must still hand ``enable_dep_gen`` a genuine ``bool``.
-        run_config = RunConfig(enable_l2_swimlane=1)
+        run_config = RunConfig(enable_chip_swimlane=1)
         cfg = _make_call_config(DistributedConfig(), run_config, dfx_base=tmp_path / "dfx")
         assert cfg.enable_dep_gen is True
         assert cfg.enable_chip_swimlane == 1
@@ -2486,12 +2486,12 @@ class TestMakeCallConfigDepGenType:
     def test_int_zero_swimlane_yields_bool_false_dep_gen(self, tmp_path, fake_simpler_task_interface):
         # Another DFX flag opens the block while swimlane is the int ``0``; the
         # ``and``/``or`` chain would otherwise assign int ``0`` and still crash.
-        run_config = RunConfig(enable_dump_args=1, enable_l2_swimlane=0)
+        run_config = RunConfig(enable_dump_args=1, enable_chip_swimlane=0)
         cfg = _make_call_config(DistributedConfig(), run_config, dfx_base=tmp_path / "dfx")
         assert cfg.enable_dep_gen is False
 
     def test_clean_timing_suppresses_implicit_dep_gen(self, tmp_path, fake_simpler_task_interface):
-        run_config = RunConfig(enable_l2_swimlane=1)
+        run_config = RunConfig(enable_chip_swimlane=1)
         cfg = _make_call_config(
             DistributedConfig(),
             run_config,
@@ -2502,7 +2502,7 @@ class TestMakeCallConfigDepGenType:
 
     def test_explicit_dep_gen_still_wins_when_co_enable_is_off(self, tmp_path, fake_simpler_task_interface):
         run_config = RunConfig(
-            enable_l2_swimlane=1,  # AICore-timing level, not just "on"
+            enable_chip_swimlane=1,  # AICore-timing level, not just "on"
             enable_dep_gen=True,
         )
         cfg = _make_call_config(

--- a/tests/ut/runtime/test_execute_artifact.py
+++ b/tests/ut/runtime/test_execute_artifact.py
@@ -99,7 +99,7 @@ def test_dfx_flags_parsed_into_dfx_opts(tmp_path):
         rc = main(
             _argv(
                 tmp_path,
-                "--enable-l2-swimlane",
+                "--enable-chip-swimlane",
                 "--dump-args",
                 "2",
                 "--enable-pmu",
@@ -111,7 +111,7 @@ def test_dfx_flags_parsed_into_dfx_opts(tmp_path):
     assert rc == 0
     _, kwargs = run.call_args
     assert kwargs["dfx"] == _DfxOpts(
-        enable_l2_swimlane=True,
+        enable_chip_swimlane=True,
         enable_dump_args=2,
         enable_pmu=5,
         enable_dep_gen=True,

--- a/tests/ut/runtime/test_replay.py
+++ b/tests/ut/runtime/test_replay.py
@@ -140,7 +140,7 @@ def test_replay_forwards_dfx_flags(tmp_path: Path) -> None:
     work_dir = _make_build_output(tmp_path)
     config = RunConfig(
         platform="a2a3sim",
-        enable_l2_swimlane=True,
+        enable_chip_swimlane=True,
         enable_pmu=2,
         enable_dump_args=True,
         enable_dep_gen=True,
@@ -149,7 +149,7 @@ def test_replay_forwards_dfx_flags(tmp_path: Path) -> None:
     with patch.object(replay_module, "execute_compiled") as ec:
         replay(work_dir, config=config)
     dfx = ec.call_args.kwargs["dfx"]
-    assert dfx.enable_l2_swimlane == 4  # True normalizes to the full level
+    assert dfx.enable_chip_swimlane == 4  # True normalizes to the full level
     assert dfx.enable_pmu == 2
     assert dfx.enable_dump_args is True
     assert dfx.enable_dep_gen is True
@@ -396,13 +396,14 @@ def test_cli_invokes_replay_with_dfx_flags(tmp_path: Path) -> None:
     assert captured["validate"] is False
     cfg = captured["config"]
     assert cfg.enable_pmu == 2
-    assert cfg.enable_l2_swimlane == 4  # bare --swimlane = full level
+    assert cfg.enable_chip_swimlane == 4  # bare --swimlane = full level
     assert cfg.enable_scope_stats is True
     assert cfg.device_id == 5
 
 
 def test_cli_swimlane_accepts_explicit_level(tmp_path: Path) -> None:
-    # Regression (issue #2385): --swimlane takes an optional collection level.
+    # Regression (issue #2385): --swimlane-level requests a specific level;
+    # --swimlane stays valueless so it cannot eat the work_dir positional.
     work_dir = _make_build_output(tmp_path)
     captured: dict = {}
 
@@ -413,9 +414,9 @@ def test_cli_swimlane_accepts_explicit_level(tmp_path: Path) -> None:
         patch.object(replay_module, "replay", side_effect=fake_replay),
         patch.object(replay_module, "_load_named_inputs_from_golden", return_value=[("a", torch.zeros(1))]),
     ):
-        rc = _main([str(work_dir), "--swimlane", "2", "--device-id", "5"])
+        rc = _main([str(work_dir), "--swimlane-level", "2", "--device-id", "5"])
     assert rc == 0
-    assert captured["config"].enable_l2_swimlane == 2
+    assert captured["config"].enable_chip_swimlane == 2
 
 
 def test_cli_no_recompile_flag(tmp_path: Path) -> None:

--- a/tests/ut/runtime/test_replay.py
+++ b/tests/ut/runtime/test_replay.py
@@ -149,7 +149,7 @@ def test_replay_forwards_dfx_flags(tmp_path: Path) -> None:
     with patch.object(replay_module, "execute_compiled") as ec:
         replay(work_dir, config=config)
     dfx = ec.call_args.kwargs["dfx"]
-    assert dfx.enable_l2_swimlane is True
+    assert dfx.enable_l2_swimlane == 4  # True normalizes to the full level
     assert dfx.enable_pmu == 2
     assert dfx.enable_dump_args is True
     assert dfx.enable_dep_gen is True
@@ -396,9 +396,26 @@ def test_cli_invokes_replay_with_dfx_flags(tmp_path: Path) -> None:
     assert captured["validate"] is False
     cfg = captured["config"]
     assert cfg.enable_pmu == 2
-    assert cfg.enable_l2_swimlane is True
+    assert cfg.enable_l2_swimlane == 4  # bare --swimlane = full level
     assert cfg.enable_scope_stats is True
     assert cfg.device_id == 5
+
+
+def test_cli_swimlane_accepts_explicit_level(tmp_path: Path) -> None:
+    # Regression (issue #2385): --swimlane takes an optional collection level.
+    work_dir = _make_build_output(tmp_path)
+    captured: dict = {}
+
+    def fake_replay(wd, *tensors, config=None, **kwargs):
+        captured["config"] = config
+
+    with (
+        patch.object(replay_module, "replay", side_effect=fake_replay),
+        patch.object(replay_module, "_load_named_inputs_from_golden", return_value=[("a", torch.zeros(1))]),
+    ):
+        rc = _main([str(work_dir), "--swimlane", "2", "--device-id", "5"])
+    assert rc == 0
+    assert captured["config"].enable_l2_swimlane == 2
 
 
 def test_cli_no_recompile_flag(tmp_path: Path) -> None:

--- a/tests/ut/runtime/test_run_config.py
+++ b/tests/ut/runtime/test_run_config.py
@@ -9,6 +9,7 @@
 
 """Unit tests for ``pypto.runtime.runner.RunConfig`` and DFX plumbing."""
 
+import dataclasses
 import sys
 import types
 from unittest.mock import MagicMock, patch
@@ -37,8 +38,8 @@ class TestRunConfigPlatformResolution:
         assert cfg.platform == platform
         assert cfg.backend_type == expected_backend
 
-    def test_enable_l2_swimlane_forces_save_kernels(self):
-        cfg = RunConfig(platform="a5", enable_l2_swimlane=True)
+    def test_enable_chip_swimlane_forces_save_kernels(self):
+        cfg = RunConfig(platform="a5", enable_chip_swimlane=True)
 
         assert cfg.platform == "a5"
         assert cfg.backend_type == BackendType.Ascend950
@@ -56,7 +57,7 @@ class TestRunConfigDfxFlags:
     @pytest.mark.parametrize(
         "kwargs",
         [
-            {"enable_l2_swimlane": True},
+            {"enable_chip_swimlane": True},
             {"enable_dump_args": True},
             {"enable_pmu": 2},
             {"enable_dep_gen": True},
@@ -103,44 +104,44 @@ class TestRunConfigDfxFlags:
         assert RunConfig(platform="a5", enable_dump_args=False).enable_dump_args == 0
         assert RunConfig(platform="a5", enable_dump_args=True).any_dfx_enabled() is True
 
-    def test_l2_swimlane_level_is_reachable(self):
+    def test_chip_swimlane_level_is_reachable(self):
         # Regression (issue #2385): every collection level the runtime supports
         # must be requestable from RunConfig, not just "on" == full.
-        assert RunConfig(platform="a5", enable_l2_swimlane=0).enable_l2_swimlane == 0
+        assert RunConfig(platform="a5", enable_chip_swimlane=0).enable_chip_swimlane == 0
         for level in (1, 2, 3, 4):
-            cfg = RunConfig(platform="a5", enable_l2_swimlane=level)
-            assert cfg.enable_l2_swimlane == level
+            cfg = RunConfig(platform="a5", enable_chip_swimlane=level)
+            assert cfg.enable_chip_swimlane == level
             assert cfg.any_dfx_enabled() is True
             assert cfg.save_kernels is True
 
-    def test_l2_swimlane_bool_maps_to_full_level(self):
+    def test_chip_swimlane_bool_maps_to_full_level(self):
         # ``True`` means the runtime's bare-flag level 4, matching the
         # CallConfig setter and the runtime harness's --enable-chip-swimlane.
-        assert RunConfig(platform="a5", enable_l2_swimlane=True).enable_l2_swimlane == 4
-        assert RunConfig(platform="a5", enable_l2_swimlane=False).enable_l2_swimlane == 0
-        assert RunConfig(platform="a5", enable_l2_swimlane=False).any_dfx_enabled() is False
+        assert RunConfig(platform="a5", enable_chip_swimlane=True).enable_chip_swimlane == 4
+        assert RunConfig(platform="a5", enable_chip_swimlane=False).enable_chip_swimlane == 0
+        assert RunConfig(platform="a5", enable_chip_swimlane=False).any_dfx_enabled() is False
 
     @pytest.mark.parametrize("bad", [-1, 5, 99])
-    def test_l2_swimlane_rejects_out_of_range_level(self, bad):
+    def test_chip_swimlane_rejects_out_of_range_level(self, bad):
         with pytest.raises(ValueError, match="collection level in"):
-            RunConfig(platform="a5", enable_l2_swimlane=bad)
+            RunConfig(platform="a5", enable_chip_swimlane=bad)
 
-    def test_l2_swimlane_rejects_non_int(self):
-        with pytest.raises(TypeError, match="enable_l2_swimlane"):
-            RunConfig(platform="a5", enable_l2_swimlane="full")  # pyright: ignore[reportArgumentType]
+    def test_chip_swimlane_rejects_non_int(self):
+        with pytest.raises(TypeError, match="enable_chip_swimlane"):
+            RunConfig(platform="a5", enable_chip_swimlane="full")  # pyright: ignore[reportArgumentType]
 
     def test_dfx_opts_normalizes_swimlane_bool(self):
         # _DfxOpts is constructed directly by the harness and by the CLI, so it
         # normalizes too — _dfx_to_cli stringifies this field.
-        assert _DfxOpts(enable_l2_swimlane=True).enable_l2_swimlane == 4
-        assert _DfxOpts(enable_l2_swimlane=2).enable_l2_swimlane == 2
-        assert _DfxOpts(enable_l2_swimlane=0).any() is False
+        assert _DfxOpts(enable_chip_swimlane=True).enable_chip_swimlane == 4
+        assert _DfxOpts(enable_chip_swimlane=2).enable_chip_swimlane == 2
+        assert _DfxOpts(enable_chip_swimlane=0).any() is False
 
     def test_dfx_flags_are_independent(self):
         # Enabling one flag must not implicitly enable another.
         cfg = RunConfig(platform="a5", enable_dep_gen=True)
         assert cfg.enable_dep_gen is True
-        assert cfg.enable_l2_swimlane == 0
+        assert cfg.enable_chip_swimlane == 0
         assert cfg.enable_dump_args == 0
         assert cfg.enable_pmu == 0
         assert cfg.enable_scope_stats is False
@@ -152,7 +153,7 @@ class TestRunConfigDfxFlags:
         assert cfg.enable_scope_stats is True
         assert cfg.any_dfx_enabled() is True
         assert cfg.save_kernels is True
-        assert cfg.enable_l2_swimlane == 0
+        assert cfg.enable_chip_swimlane == 0
         assert cfg.enable_dump_args == 0
         assert cfg.enable_pmu == 0
         assert cfg.enable_dep_gen is False
@@ -160,14 +161,14 @@ class TestRunConfigDfxFlags:
     def test_dfx_opts_from_run_config_carries_all_five(self):
         cfg = RunConfig(
             platform="a5",
-            enable_l2_swimlane=True,
+            enable_chip_swimlane=True,
             enable_dump_args=2,
             enable_pmu=2,
             enable_dep_gen=True,
             enable_scope_stats=True,
         )
         opts = _DfxOpts.from_run_config(cfg)
-        assert opts.enable_l2_swimlane == 4  # True normalizes to the full level
+        assert opts.enable_chip_swimlane == 4  # True normalizes to the full level
         assert opts.enable_dump_args == 2
         assert opts.enable_pmu == 2
         assert opts.enable_dep_gen is True
@@ -180,6 +181,74 @@ class TestRunConfigDfxFlags:
 
     def test_dfx_opts_any_false_when_all_off(self):
         assert _DfxOpts().any() is False
+
+
+class TestSwimlaneAliasDeprecation:
+    """``enable_l2_swimlane`` is the deprecated spelling of ``enable_chip_swimlane``.
+
+    The alias is deliberately not a dataclass field, so ``dataclasses.replace``
+    keeps working on the canonical name — that is the property most of these
+    tests pin down.
+    """
+
+    def test_deprecated_kwarg_maps_and_warns(self):
+        with pytest.warns(DeprecationWarning, match="enable_l2_swimlane is deprecated"):
+            cfg = RunConfig(platform="a5", enable_l2_swimlane=2)
+        assert cfg.enable_chip_swimlane == 2
+
+    def test_deprecated_kwarg_still_normalizes_bool(self):
+        with pytest.warns(DeprecationWarning):
+            assert RunConfig(platform="a5", enable_l2_swimlane=True).enable_chip_swimlane == 4
+        with pytest.warns(DeprecationWarning):
+            assert RunConfig(platform="a5", enable_l2_swimlane=False).enable_chip_swimlane == 0
+
+    def test_alias_read_returns_canonical_without_warning(self, recwarn):
+        # Reads stay silent on purpose: dataclasses.replace() goes through this
+        # property, so warning here would fire on unrelated replace() calls.
+        cfg = RunConfig(platform="a5", enable_chip_swimlane=3)
+        assert cfg.enable_l2_swimlane == 3
+        assert not [w for w in recwarn if issubclass(w.category, DeprecationWarning)]
+
+    def test_alias_assignment_warns_and_writes_through(self):
+        cfg = RunConfig(platform="a5")
+        with pytest.warns(DeprecationWarning, match="enable_l2_swimlane is deprecated"):
+            cfg.enable_l2_swimlane = 2
+        assert cfg.enable_chip_swimlane == 2
+
+    def test_alias_assignment_normalizes_and_validates(self):
+        cfg = RunConfig(platform="a5")
+        with pytest.warns(DeprecationWarning):
+            cfg.enable_l2_swimlane = True
+        assert cfg.enable_chip_swimlane == 4
+        with pytest.raises(ValueError, match="collection level in"), pytest.warns(DeprecationWarning):
+            cfg.enable_l2_swimlane = 9
+
+    def test_both_spellings_is_an_error(self):
+        with (
+            pytest.raises(ValueError, match="pass only enable_chip_swimlane"),
+            pytest.warns(DeprecationWarning),
+        ):
+            RunConfig(platform="a5", enable_chip_swimlane=1, enable_l2_swimlane=3)
+
+    def test_canonical_name_does_not_warn(self, recwarn):
+        cfg = RunConfig(platform="a5", enable_chip_swimlane=2)
+        assert cfg.enable_chip_swimlane == 2
+        assert not [w for w in recwarn if issubclass(w.category, DeprecationWarning)]
+
+    def test_replace_on_canonical_name_is_silent_and_wins(self, recwarn):
+        # Regression guard for the alias design: an alias *field* (or InitVar)
+        # would be re-supplied by replace() from the old instance and could
+        # silently override the value the caller just passed.
+        cfg = RunConfig(platform="a5", enable_chip_swimlane=4)
+        assert dataclasses.replace(cfg, enable_chip_swimlane=1).enable_chip_swimlane == 1
+        assert dataclasses.replace(cfg, enable_chip_swimlane=0).enable_chip_swimlane == 0
+        assert dataclasses.replace(cfg, enable_dep_gen=True).enable_chip_swimlane == 4
+        assert not [w for w in recwarn if issubclass(w.category, DeprecationWarning)]
+
+    def test_alias_is_not_a_dataclass_field(self):
+        names = {f.name for f in dataclasses.fields(RunConfig)}
+        assert "enable_chip_swimlane" in names
+        assert "enable_l2_swimlane" not in names
 
 
 class TestRunConfigRingSizing:
@@ -481,7 +550,7 @@ class TestMakeCallConfigDfx:
 
     The runtime-diagnostic flags (``enable_dump_args`` / ``enable_pmu`` /
     ``enable_dep_gen`` / ``enable_scope_stats`` / public
-    ``enable_l2_swimlane``) are transcribed onto the shared ``CallConfig`` and
+    ``enable_chip_swimlane``) are transcribed onto the shared ``CallConfig`` and
     their artifacts rooted at ``dfx_base``. The public swimlane option maps to
     Simpler's ``enable_chip_swimlane`` and additionally co-enables ``dep_gen``
     so the converter has a task graph.
@@ -515,7 +584,7 @@ class TestMakeCallConfigDfx:
         dfx_base = tmp_path / "dfx_outputs"
         # User asks for swimlane only; dep_gen is auto-enabled because the
         # converter needs deps.json to resolve task arrows / kernel names.
-        run_config = RunConfig(platform="a2a3sim", enable_l2_swimlane=True)
+        run_config = RunConfig(platform="a2a3sim", enable_chip_swimlane=True)
         cfg = _make_dist_call_config_with_fake(
             DistributedConfig(), run_config, monkeypatch, dfx_base=dfx_base
         )
@@ -704,14 +773,14 @@ class TestExecuteOnDeviceDfxValidation:
                 runtime_name="tensormap_and_ringbuffer",
                 device_id=0,
                 output_prefix=None,
-                enable_l2_swimlane=True,
+                enable_chip_swimlane=True,
             )
 
     def test_dfx_without_output_prefix_raises_for_each_flag(self):
         from pypto.runtime.device_runner import execute_on_device  # noqa: PLC0415
 
         for flag in [
-            {"enable_l2_swimlane": True},
+            {"enable_chip_swimlane": True},
             {"enable_dump_args": True},
             {"enable_pmu": 2},
             {"enable_dep_gen": True},
@@ -751,7 +820,7 @@ class TestExecuteOnDeviceDfxValidation:
             assert worker.run.called
             assert worker.close.called
 
-    def test_public_l2_option_maps_to_simpler_chip_field(self, tmp_path):
+    def test_public_option_maps_to_simpler_chip_field(self, tmp_path):
         """The compatibility option must populate Simpler's renamed member."""
         from pypto.runtime import device_runner  # noqa: PLC0415
 
@@ -765,7 +834,7 @@ class TestExecuteOnDeviceDfxValidation:
                     runtime_name="tensormap_and_ringbuffer",
                     device_id=0,
                     output_prefix=str(tmp_path),
-                    enable_l2_swimlane=True,
+                    enable_chip_swimlane=True,
                 )
 
         call_config = worker.init.call_args.kwargs["prewarm_config"]

--- a/tests/ut/runtime/test_run_config.py
+++ b/tests/ut/runtime/test_run_config.py
@@ -103,11 +103,44 @@ class TestRunConfigDfxFlags:
         assert RunConfig(platform="a5", enable_dump_args=False).enable_dump_args == 0
         assert RunConfig(platform="a5", enable_dump_args=True).any_dfx_enabled() is True
 
+    def test_l2_swimlane_level_is_reachable(self):
+        # Regression (issue #2385): every collection level the runtime supports
+        # must be requestable from RunConfig, not just "on" == full.
+        assert RunConfig(platform="a5", enable_l2_swimlane=0).enable_l2_swimlane == 0
+        for level in (1, 2, 3, 4):
+            cfg = RunConfig(platform="a5", enable_l2_swimlane=level)
+            assert cfg.enable_l2_swimlane == level
+            assert cfg.any_dfx_enabled() is True
+            assert cfg.save_kernels is True
+
+    def test_l2_swimlane_bool_maps_to_full_level(self):
+        # ``True`` means the runtime's bare-flag level 4, matching the
+        # CallConfig setter and the runtime harness's --enable-chip-swimlane.
+        assert RunConfig(platform="a5", enable_l2_swimlane=True).enable_l2_swimlane == 4
+        assert RunConfig(platform="a5", enable_l2_swimlane=False).enable_l2_swimlane == 0
+        assert RunConfig(platform="a5", enable_l2_swimlane=False).any_dfx_enabled() is False
+
+    @pytest.mark.parametrize("bad", [-1, 5, 99])
+    def test_l2_swimlane_rejects_out_of_range_level(self, bad):
+        with pytest.raises(ValueError, match="collection level in"):
+            RunConfig(platform="a5", enable_l2_swimlane=bad)
+
+    def test_l2_swimlane_rejects_non_int(self):
+        with pytest.raises(TypeError, match="enable_l2_swimlane"):
+            RunConfig(platform="a5", enable_l2_swimlane="full")  # pyright: ignore[reportArgumentType]
+
+    def test_dfx_opts_normalizes_swimlane_bool(self):
+        # _DfxOpts is constructed directly by the harness and by the CLI, so it
+        # normalizes too — _dfx_to_cli stringifies this field.
+        assert _DfxOpts(enable_l2_swimlane=True).enable_l2_swimlane == 4
+        assert _DfxOpts(enable_l2_swimlane=2).enable_l2_swimlane == 2
+        assert _DfxOpts(enable_l2_swimlane=0).any() is False
+
     def test_dfx_flags_are_independent(self):
         # Enabling one flag must not implicitly enable another.
         cfg = RunConfig(platform="a5", enable_dep_gen=True)
         assert cfg.enable_dep_gen is True
-        assert cfg.enable_l2_swimlane is False
+        assert cfg.enable_l2_swimlane == 0
         assert cfg.enable_dump_args == 0
         assert cfg.enable_pmu == 0
         assert cfg.enable_scope_stats is False
@@ -119,7 +152,7 @@ class TestRunConfigDfxFlags:
         assert cfg.enable_scope_stats is True
         assert cfg.any_dfx_enabled() is True
         assert cfg.save_kernels is True
-        assert cfg.enable_l2_swimlane is False
+        assert cfg.enable_l2_swimlane == 0
         assert cfg.enable_dump_args == 0
         assert cfg.enable_pmu == 0
         assert cfg.enable_dep_gen is False
@@ -134,7 +167,7 @@ class TestRunConfigDfxFlags:
             enable_scope_stats=True,
         )
         opts = _DfxOpts.from_run_config(cfg)
-        assert opts.enable_l2_swimlane is True
+        assert opts.enable_l2_swimlane == 4  # True normalizes to the full level
         assert opts.enable_dump_args == 2
         assert opts.enable_pmu == 2
         assert opts.enable_dep_gen is True
@@ -486,7 +519,7 @@ class TestMakeCallConfigDfx:
         cfg = _make_dist_call_config_with_fake(
             DistributedConfig(), run_config, monkeypatch, dfx_base=dfx_base
         )
-        assert cfg.enable_chip_swimlane is True
+        assert cfg.enable_chip_swimlane == 4  # True normalizes to the full level
         assert cfg.enable_dep_gen is True  # co-enabled
         assert cfg.output_prefix == str(dfx_base)
 

--- a/tests/ut/runtime/test_swimlane_two_pass.py
+++ b/tests/ut/runtime/test_swimlane_two_pass.py
@@ -53,8 +53,18 @@ def test_onboard_swimlane_captures_deps_then_times_in_process():
     assert captures == 1
     assert len(seen) == 1
     timing = seen[0]
-    assert timing.enable_l2_swimlane is True
+    assert timing.enable_l2_swimlane == 4  # True normalizes to the full level
     assert timing.enable_dep_gen is False  # dep_gen forced off on the timing pass
+
+
+def test_onboard_swimlane_preserves_requested_level():
+    # Regression (issue #2385): the two-pass split must carry the requested
+    # collection level through to the timing pass, not re-derive an on/off flag.
+    seen, captures = _drive(_DfxOpts(enable_l2_swimlane=2), "a2a3")
+    assert captures == 1
+    assert len(seen) == 1
+    assert seen[0].enable_l2_swimlane == 2
+    assert seen[0].enable_dep_gen is False
 
 
 def test_onboard_swimlane_with_explicit_dep_gen_still_one_capture():
@@ -63,7 +73,7 @@ def test_onboard_swimlane_with_explicit_dep_gen_still_one_capture():
     seen, captures = _drive(_DfxOpts(enable_l2_swimlane=True, enable_dep_gen=True), "a2a3")
     assert captures == 1
     assert len(seen) == 1
-    assert seen[0].enable_l2_swimlane is True and seen[0].enable_dep_gen is False
+    assert seen[0].enable_l2_swimlane == 4 and seen[0].enable_dep_gen is False
 
 
 def test_onboard_swimlane_timing_dfx_ride_the_in_process_pass():
@@ -89,7 +99,7 @@ def test_only_dep_gen_is_single_pass_no_capture():
     assert captures == 0
     assert len(seen) == 1
     assert seen[0].enable_dep_gen is True
-    assert seen[0].enable_l2_swimlane is False
+    assert seen[0].enable_l2_swimlane == 0
 
 
 def test_no_dfx_is_single_pass_no_capture():
@@ -104,7 +114,7 @@ def test_sim_swimlane_stays_single_pass_no_capture():
     seen, captures = _drive(_DfxOpts(enable_l2_swimlane=True), "a2a3sim")
     assert captures == 0
     assert len(seen) == 1
-    assert seen[0].enable_l2_swimlane is True
+    assert seen[0].enable_l2_swimlane == 4
 
 
 def test_build_args_spec_host_tensor_saves_real_data(tmp_path):

--- a/tests/ut/runtime/test_swimlane_two_pass.py
+++ b/tests/ut/runtime/test_swimlane_two_pass.py
@@ -9,7 +9,7 @@
 
 """Unit tests for the two-pass L2 swimlane execution protocol.
 
-Enabling ``enable_l2_swimlane`` on an onboard platform captures the dep_gen task
+Enabling ``enable_chip_swimlane`` on an onboard platform captures the dep_gen task
 graph (``deps.json``) in a subprocess, then runs a clean-timing swimlane pass
 in-process — the two cannot share one process because the runtime leaks SVM
 host-register mappings between DFX runs. These tests drive
@@ -48,39 +48,39 @@ def _drive(dfx: _DfxOpts, platform: str) -> tuple[list[_DfxOpts], int]:
 
 
 def test_onboard_swimlane_captures_deps_then_times_in_process():
-    seen, captures = _drive(_DfxOpts(enable_l2_swimlane=True), "a2a3")
+    seen, captures = _drive(_DfxOpts(enable_chip_swimlane=True), "a2a3")
     # deps captured once (subprocess), one in-process timing pass.
     assert captures == 1
     assert len(seen) == 1
     timing = seen[0]
-    assert timing.enable_l2_swimlane == 4  # True normalizes to the full level
+    assert timing.enable_chip_swimlane == 4  # True normalizes to the full level
     assert timing.enable_dep_gen is False  # dep_gen forced off on the timing pass
 
 
 def test_onboard_swimlane_preserves_requested_level():
     # Regression (issue #2385): the two-pass split must carry the requested
     # collection level through to the timing pass, not re-derive an on/off flag.
-    seen, captures = _drive(_DfxOpts(enable_l2_swimlane=2), "a2a3")
+    seen, captures = _drive(_DfxOpts(enable_chip_swimlane=2), "a2a3")
     assert captures == 1
     assert len(seen) == 1
-    assert seen[0].enable_l2_swimlane == 2
+    assert seen[0].enable_chip_swimlane == 2
     assert seen[0].enable_dep_gen is False
 
 
 def test_onboard_swimlane_with_explicit_dep_gen_still_one_capture():
     # An explicit --enable-dep-gen alongside swimlane must NOT add an in-process
     # dep_gen run: the subprocess capture already produced deps.json.
-    seen, captures = _drive(_DfxOpts(enable_l2_swimlane=True, enable_dep_gen=True), "a2a3")
+    seen, captures = _drive(_DfxOpts(enable_chip_swimlane=True, enable_dep_gen=True), "a2a3")
     assert captures == 1
     assert len(seen) == 1
-    assert seen[0].enable_l2_swimlane == 4 and seen[0].enable_dep_gen is False
+    assert seen[0].enable_chip_swimlane == 4 and seen[0].enable_dep_gen is False
 
 
 def test_onboard_swimlane_timing_dfx_ride_the_in_process_pass():
     # PMU / args-dump / scope-stats are timing-sensitive: they ride the clean
     # in-process timing pass (the subprocess capture is dep_gen-only).
     dfx = _DfxOpts(
-        enable_l2_swimlane=True,
+        enable_chip_swimlane=True,
         enable_pmu=2,
         enable_dump_args=1,
         enable_scope_stats=True,
@@ -99,7 +99,7 @@ def test_only_dep_gen_is_single_pass_no_capture():
     assert captures == 0
     assert len(seen) == 1
     assert seen[0].enable_dep_gen is True
-    assert seen[0].enable_l2_swimlane == 0
+    assert seen[0].enable_chip_swimlane == 0
 
 
 def test_no_dfx_is_single_pass_no_capture():
@@ -111,10 +111,10 @@ def test_no_dfx_is_single_pass_no_capture():
 
 def test_sim_swimlane_stays_single_pass_no_capture():
     # Simulator skips swimlane conversion anyway, so no capture / second run.
-    seen, captures = _drive(_DfxOpts(enable_l2_swimlane=True), "a2a3sim")
+    seen, captures = _drive(_DfxOpts(enable_chip_swimlane=True), "a2a3sim")
     assert captures == 0
     assert len(seen) == 1
-    assert seen[0].enable_l2_swimlane == 4
+    assert seen[0].enable_chip_swimlane == 4
 
 
 def test_build_args_spec_host_tensor_saves_real_data(tmp_path):

--- a/tests/ut/runtime/test_task_submit_dispatch.py
+++ b/tests/ut/runtime/test_task_submit_dispatch.py
@@ -167,10 +167,10 @@ def test_dfx_to_cli_empty_for_default():
 
 
 def test_dfx_to_cli_emits_only_enabled_flags():
-    dfx = _DfxOpts(enable_l2_swimlane=True, enable_dump_args=2, enable_pmu=5, enable_dep_gen=True)
+    dfx = _DfxOpts(enable_chip_swimlane=True, enable_dump_args=2, enable_pmu=5, enable_dep_gen=True)
     argv = test_runner._dfx_to_cli(dfx)
     assert argv == [
-        "--enable-l2-swimlane",
+        "--enable-chip-swimlane",
         "4",
         "--dump-args",
         "2",
@@ -180,15 +180,85 @@ def test_dfx_to_cli_emits_only_enabled_flags():
     ]
 
 
+def _load_st_conftest():
+    """Import tests/st/conftest.py under a private name.
+
+    Loaded by path rather than ``import conftest`` so pytest's own conftest
+    collection is not disturbed.
+    """
+    import importlib.util  # noqa: PLC0415
+
+    path = _ST_DIR / "conftest.py"
+    spec = importlib.util.spec_from_file_location("_st_conftest_under_test", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class _FakeConfig:
+    """Minimal stand-in for ``pytest.Config.getoption``."""
+
+    def __init__(self, bare=0, level=None, deprecated=False):
+        self._values = {
+            "--enable-chip-swimlane": bare,
+            "--chip-swimlane-level": level,
+            "enable_l2_swimlane_deprecated": deprecated,
+        }
+
+    def getoption(self, name):
+        return self._values[name]
+
+
+def test_st_conftest_resolves_the_swimlane_options():
+    resolve = _load_st_conftest()._resolve_swimlane_option
+    assert resolve(_FakeConfig()) == 0
+    assert resolve(_FakeConfig(bare=4)) == 4
+    assert resolve(_FakeConfig(level=2)) == 2
+    assert resolve(_FakeConfig(level=0)) == 0  # explicit off
+    # An explicit level wins over the bare enable flag.
+    assert resolve(_FakeConfig(bare=4, level=1)) == 1
+
+
+def test_st_conftest_still_accepts_the_deprecated_flag():
+    # CI passes --enable-l2-swimlane, so it must keep resolving (with a warning).
+    resolve = _load_st_conftest()._resolve_swimlane_option
+    with pytest.warns(DeprecationWarning, match="--enable-l2-swimlane is deprecated"):
+        assert resolve(_FakeConfig(deprecated=True)) == 4
+
+
+def test_execute_artifact_accepts_the_deprecated_swimlane_flag():
+    # CI and existing scripts still pass --enable-l2-swimlane; it must keep
+    # working (with a DeprecationWarning) and land on the canonical level.
+    parser = execute_artifact._build_parser()
+    args = parser.parse_args(["--enable-l2-swimlane", "2", "--device-id", "0"])
+    with pytest.warns(DeprecationWarning, match="--enable-l2-swimlane is deprecated"):
+        assert execute_artifact._resolve_swimlane_args(parser, args) == 2
+
+    bare = parser.parse_args(["--enable-l2-swimlane", "--device-id", "0"])
+    with pytest.warns(DeprecationWarning):
+        assert execute_artifact._resolve_swimlane_args(parser, bare) == 4
+
+    absent = parser.parse_args(["--enable-chip-swimlane", "3", "--device-id", "0"])
+    assert execute_artifact._resolve_swimlane_args(parser, absent) == 3
+
+
+def test_execute_artifact_rejects_conflicting_swimlane_flags():
+    parser = execute_artifact._build_parser()
+    args = parser.parse_args(["--enable-chip-swimlane", "1", "--enable-l2-swimlane", "3", "--device-id", "0"])
+    with pytest.raises(SystemExit), pytest.warns(DeprecationWarning):
+        execute_artifact._resolve_swimlane_args(parser, args)
+
+
 def test_dfx_to_cli_round_trips_the_swimlane_level():
     # Regression (issue #2385): a level 1-3 capture must survive the harness ->
     # execute_artifact CLI hop instead of being flattened to the bare flag.
     for level in (1, 2, 3, 4):
-        argv = test_runner._dfx_to_cli(_DfxOpts(enable_l2_swimlane=level))
-        assert argv == ["--enable-l2-swimlane", str(level)]
+        argv = test_runner._dfx_to_cli(_DfxOpts(enable_chip_swimlane=level))
+        assert argv == ["--enable-chip-swimlane", str(level)]
         # ``--device-id`` is the parser's only required argument.
         parsed = execute_artifact._build_parser().parse_args([*argv, "--device-id", "0"])
-        assert parsed.enable_l2_swimlane == level
+        assert parsed.enable_chip_swimlane == level
 
 
 # ---------------------------------------------------------------------------
@@ -207,7 +277,7 @@ def test_parse_executed_device():
 
 
 def test_task_submit_argv_and_pass(tmp_path):
-    dfx = _DfxOpts(enable_l2_swimlane=True)
+    dfx = _DfxOpts(enable_chip_swimlane=True)
     with patch.object(
         test_runner.subprocess,
         "run",
@@ -229,7 +299,7 @@ def test_task_submit_argv_and_pass(tmp_path):
     run_cmd = argv[-1]
     assert "pypto.runtime.execute_artifact" in run_cmd
     assert "--device-id $TASK_DEVICE" in run_cmd
-    assert "--enable-l2-swimlane" in run_cmd
+    assert "--enable-chip-swimlane" in run_cmd
     # Device run only; the harness validates with the real tolerance afterwards.
     assert "--no-validate" in run_cmd
     # full child output persisted next to the artifact

--- a/tests/ut/runtime/test_task_submit_dispatch.py
+++ b/tests/ut/runtime/test_task_submit_dispatch.py
@@ -28,6 +28,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 from pypto.pypto_core.passes import MemoryPlanner
+from pypto.runtime import execute_artifact
 from pypto.runtime.runner import RunConfig, _DfxOpts
 
 _ST_DIR = Path(__file__).resolve().parents[2] / "st"
@@ -170,12 +171,24 @@ def test_dfx_to_cli_emits_only_enabled_flags():
     argv = test_runner._dfx_to_cli(dfx)
     assert argv == [
         "--enable-l2-swimlane",
+        "4",
         "--dump-args",
         "2",
         "--enable-pmu",
         "5",
         "--enable-dep-gen",
     ]
+
+
+def test_dfx_to_cli_round_trips_the_swimlane_level():
+    # Regression (issue #2385): a level 1-3 capture must survive the harness ->
+    # execute_artifact CLI hop instead of being flattened to the bare flag.
+    for level in (1, 2, 3, 4):
+        argv = test_runner._dfx_to_cli(_DfxOpts(enable_l2_swimlane=level))
+        assert argv == ["--enable-l2-swimlane", str(level)]
+        # ``--device-id`` is the parser's only required argument.
+        parsed = execute_artifact._build_parser().parse_args([*argv, "--device-id", "0"])
+        assert parsed.enable_l2_swimlane == level
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Two related commits: the first makes the swimlane **collection level** reachable, the second aligns the **name** with the runtime.

## Summary

**1. `fix(runtime)`: the collection level was unreachable.** Chip swimlane collection is *levelled* (`ChipSwimlaneLevel` 0-4), and each level is a real guard in the collectors — a lower level never stamps the data a higher one does, and no post-processing recovers it. The `RunConfig` field was typed `bool`, so levels 1-3 could not be expressed, and all the CLIs were `action="store_true"`. The harness's `_dfx_to_cli` emitted only the bare flag, so even a caller who smuggled an int through the untyped dataclass lost it at the `execute_artifact` subprocess hop.

**2. `refactor(runtime)`: `enable_l2_swimlane` -> `enable_chip_swimlane`.** Simpler's Worker/Chip/Core migration renamed the L2 layer to "chip" (`L2Swimlane*` -> `ChipSwimlane*`, `--enable-l2-swimlane` -> `--enable-chip-swimlane`, `l2_swimlane_records.json` -> `chip_swimlane_records.json`). PyPTO kept the old public spelling and translated at three call sites — so the same switch had two names depending on which side of the boundary you were on, and PyPTO already wrote the *new* artifact name while advertising the *old* option name.

Afterwards `sched_overhead_analysis` (needs level >= 3), the `[dispatch, start]` pickup gap (>= 2), and the Toolkit plugin's Scheduler / AICPU Orchestrator views are reachable from a `RunConfig`-driven capture; a cheap level-1 capture is available when collection overhead would perturb the measurement; and one name means one thing on both sides.

**Backward compatible.** `True` still means the full level 4 — exactly what the runtime's `CallConfig` setter has produced for a Python `True` since simpler #782. The old spellings still work with a `DeprecationWarning`.

> Worth flagging for reviewers: issue #2385 states that `True` currently lands as level **1**. Against the pinned runtime that is no longer true — `runtime/python/bindings/task_interface.cpp:1949` maps `True -> 4` and clamps `[0, 4]`. So the issue's open question ("should `True` mean 1 or 4?") is settled by the code: 4 is the status quo, and preserving it is the no-op choice.

| Level | Adds | Unlocks |
|---|---|---|
| 0 / `False` | — | off |
| 1 | AICore per-task start / end | per-task lanes |
| 2 | + AICPU dispatch / finish | the `[dispatch, start]` pickup gap |
| 3 | + scheduler main-loop phases | `sched_overhead_analysis`, Scheduler View |
| 4 / `True` | + orchestrator phases | AICPU Orchestrator view |

## The one design decision worth reviewing

`enable_l2_swimlane` is deliberately **not** a dataclass field — it is an `__init__` keyword plus a property.

`dataclasses.replace()` re-supplies every field from the existing instance, so an alias *field* (or an `InitVar`) arrives alongside the canonical one on every `replace` call, with no way to distinguish "the caller typed the old name" from "replace echoed the old value back". Both resolutions of that ambiguity are bad, and I verified them while prototyping:

- *alias wins on difference* -> `replace(cfg, enable_chip_swimlane=1)` on a level-4 config silently returned **4**.
- *canonical wins* / *sentinel defaults* -> the same call raised a spurious conflict `ValueError`.

Keeping the alias off the field list removes the ambiguity entirely and leaves `replace`, `fields()`, `asdict()` and `repr()` clean. Reads are silent (that is the path `replace` takes); the constructor keyword and attribute assignment warn; passing both spellings raises `ValueError`. `test_replace_on_canonical_name_is_silent_and_wins` pins this down.

## Changes

- `python/pypto/runtime/runner.py`: `enable_chip_swimlane: int | bool`, normalized once by `_normalize_swimlane_level()` in `RunConfig.__post_init__` and `_DfxOpts.__post_init__`. Out-of-range now raises `ValueError` instead of being silently clamped by the runtime setter. Shared `_SWIMLANE_CLI_HELP` / `_SWIMLANE_FULL_LEVEL` / `_SWIMLANE_MAX_LEVEL` so the ladder is described once. Deprecation shim below the class.
- `execute_artifact.py`, `tests/st/conftest.py`, `debug/replay.py`: CLIs take an optional level (bare flag = 4, `choices=range(5)`). `--enable-l2-swimlane` survives on both `--enable-chip-swimlane` CLIs with a separate dest, so **the CI job and external scripts that pass it keep working**; conflicting spellings are a usage error.
- `tests/st/harness/core/test_runner.py`: `_dfx_to_cli` emits the level, so a level 1-3 capture survives the harness -> `execute_artifact` hop.
- `device_runner.py`: routes through the same validator, so both entry points reject an out-of-range level identically.
- `distributed_runner.py`: truthiness gates become explicit `> 0`; the issue #1952 `bool(...)` wrap on `enable_dep_gen` is preserved.
- `examples/models/{02,04,06,07,09}`: flag renamed together with its argparse `dest` (they must move as a pair).
- `.github/workflows/ci.yml`: our own pytest invocation moves to the new flag. `daily_ci.yml` keeps the old one — it drives a `pypto-lib` script whose flag is not ours to rename.
- Docs (en/zh): level tables; the "`RunConfig` cannot reach levels 1-3" caveat removed now that it is false; the "Deprecated aliases" section rewritten — it previously documented a `runtime_profiling` alias that no longer exists anywhere in the codebase.
- Tests: ~10 `is True/False` assertions became `== 4` / `== 0`. These assert the field's *representation*, not behaviour, and had to move with the type. Six now-stale `# pyright: ignore[reportArgumentType]` suppressions removed — one existed only because the `bool` annotation rejected the level this PR makes legal.

## Verification

- `pytest tests/ut/ tests/lint/ -n 2` -> **9792 passed**, 11 skipped, 19 failed.
  - The 19 are pre-existing and ambient: `ImportError: cannot import name 'MAILBOX_PREPARATION_DISPOSITION_VALUES' from '_task_interface'`, a stale installed `.so`. They reproduce identically on unmodified `main` (baselined), and none is in a file this PR touches behaviourally.
- New coverage: levels 0-4 reachable; `True -> 4` / `False -> 0`; out-of-range `ValueError`, non-int `TypeError`; level preserved across the swimlane two-pass split; end-to-end `_dfx_to_cli` -> `execute_artifact._build_parser()` round-trip per level; nine tests for the deprecation shim; resolver tests for both CLIs including the deprecated flag CI passes.
- `ruff check` / `ruff format --check` clean across `python/`, `tests/`, `examples/`.
- `check_docs_en_zh_parity.py` and `check_english_only.py` pass.
- Claims in the new docs cross-checked against the pinned runtime submodule (unmodified): `int32_t enable_chip_swimlane` (`call_config.h:115`), the `True -> 4` setter and `[0,4]` clamp (`task_interface.cpp:1949-1952`), `ChipSwimlaneLevel` 0-4 semantics.

Closes #2385
