### PR TITLE
feat(backend): expose ptoas pass IR dumps

### DIFF
--- a/docs/en/dev/07-ir-lower-trace.md
+++ b/docs/en/dev/07-ir-lower-trace.md
@@ -34,6 +34,31 @@ Both forms create `build/my_program/passes_dump/`, containing
 See the [pass manager documentation](passes/00-pass_manager.md) for dump levels
 and pass-pipeline behavior.
 
+## Dump ptoas pass IR
+
+PyPTO can also expose ptoas's MLIR pass dumps. This is a separate switch from
+`dump_passes` because it observes the backend pipeline after PTO codegen:
+
+```python
+ir.compile(
+    MyProgram,
+    output_dir="build/my_program",
+    dump_ptoas_passes=True,
+)
+```
+
+The same option is available to JIT and runtime callers through
+`RunConfig(dump_ptoas_passes=True)`. PyPTO invokes ptoas with full-module IR
+printing after every pass and writes each codegen unit to its own directory:
+
+```text
+build/my_program/ptoas_passes/<kernel-or-group>/
+```
+
+Per-unit directories keep parallel ptoas invocations from colliding. The files
+inside are named and organized by ptoas/MLIR. This option has no effect with
+`skip_ptoas=True`, because no ptoas pass pipeline runs in that mode.
+
 ## Generate a report
 
 Run the installed command with the dump directory:

--- a/docs/en/dev/codegen/00-pto_codegen.md
+++ b/docs/en/dev/codegen/00-pto_codegen.md
@@ -690,6 +690,8 @@ When the program contains an Orchestration function, the PTO backend generates t
 ```text
 output_dir/
 ├── passes_dump/                     # IR after each pass
+├── ptoas_passes/                    # Optional ptoas IR after each pass
+│   └── <func_name>/                 # ptoas/MLIR-managed dump tree
 ├── ptoas/                           # Intermediates
 │   ├── <func_name>.pto              # MLIR from PTOCodegen
 │   └── <func_name>.cpp              # C++ from ptoas
@@ -699,6 +701,9 @@ output_dir/
 │   └── <orch_func_name>.cpp         # PTO2 runtime orchestration code
 └── kernel_config.py                 # Runtime/orchestration/kernel config
 ```
+
+`ptoas_passes/` is emitted only when `ir.compile(...,
+dump_ptoas_passes=True)` or `RunConfig(dump_ptoas_passes=True)` is used.
 
 The orchestration codegen generates identical orchestration C++ code using the PTO2 runtime API (`rt_submit_task`, `make_tensor_external`, etc.).
 

--- a/docs/en/dev/codegen/00-pto_codegen.md
+++ b/docs/en/dev/codegen/00-pto_codegen.md
@@ -691,7 +691,7 @@ When the program contains an Orchestration function, the PTO backend generates t
 output_dir/
 ├── passes_dump/                     # IR after each pass
 ├── ptoas_passes/                    # Optional ptoas IR after each pass
-│   └── <func_name>/                 # ptoas/MLIR-managed dump tree
+│   └── <kernel-or-group>/            # ptoas/MLIR-managed dump tree
 ├── ptoas/                           # Intermediates
 │   ├── <func_name>.pto              # MLIR from PTOCodegen
 │   └── <func_name>.cpp              # C++ from ptoas

--- a/docs/zh/dev/07-ir-lower-trace.md
+++ b/docs/zh/dev/07-ir-lower-trace.md
@@ -33,6 +33,31 @@ ir.compile(
 以及连续编号的 `NN_after_PassName.py` 快照。转储级别和 Pass 流水线行为详见
 [Pass 管理器文档](passes/00-pass_manager.md)。
 
+## 转储 ptoas Pass IR
+
+PyPTO 也可以暴露 ptoas 的 MLIR Pass 转储。它与 `dump_passes` 是两个独立开关，
+因为它观察的是 PTO codegen 之后的后端流水线：
+
+```python
+ir.compile(
+    MyProgram,
+    output_dir="build/my_program",
+    dump_ptoas_passes=True,
+)
+```
+
+JIT 和 runtime 调用方也可以通过 `RunConfig(dump_ptoas_passes=True)` 使用该
+选项。PyPTO 会让 ptoas 在每个 Pass 后转储完整 module IR，并把每个 codegen
+单元写入独立目录：
+
+```text
+build/my_program/ptoas_passes/<kernel-or-group>/
+```
+
+独立目录可以避免并行 ptoas 调用互相覆盖。目录内的文件名和组织方式由
+ptoas/MLIR 决定。`skip_ptoas=True` 时不会运行 ptoas Pass 流水线，因此该选项
+不产生任何转储。
+
 ## 生成报告
 
 使用转储目录运行已安装的命令：

--- a/docs/zh/dev/codegen/00-pto_codegen.md
+++ b/docs/zh/dev/codegen/00-pto_codegen.md
@@ -662,6 +662,8 @@ InCore Function -> PTOCodegen -> .pto -> ptoas -> .cpp -> kernel_wrapper -> kern
 ```text
 output_dir/
 ├── passes_dump/                     # IR after each pass
+├── ptoas_passes/                    # 可选：每个 ptoas Pass 后的 IR
+│   └── <func_name>/                 # 由 ptoas/MLIR 管理的转储树
 ├── ptoas/                           # Intermediates
 │   ├── <func_name>.pto              # MLIR from PTOCodegen
 │   └── <func_name>.cpp              # C++ from ptoas
@@ -671,6 +673,9 @@ output_dir/
 │   └── <orch_func_name>.cpp         # PTO2 runtime orchestration code
 └── kernel_config.py                 # Runtime/orchestration/kernel config
 ```
+
+仅当使用 `ir.compile(..., dump_ptoas_passes=True)` 或
+`RunConfig(dump_ptoas_passes=True)` 时才会生成 `ptoas_passes/`。
 
 编排代码生成使用 PTO2 运行时 API (`rt_submit_task`, `make_tensor_external` 等) 生成编排 C++ 代码。
 

--- a/docs/zh/dev/codegen/00-pto_codegen.md
+++ b/docs/zh/dev/codegen/00-pto_codegen.md
@@ -663,7 +663,7 @@ InCore Function -> PTOCodegen -> .pto -> ptoas -> .cpp -> kernel_wrapper -> kern
 output_dir/
 ├── passes_dump/                     # IR after each pass
 ├── ptoas_passes/                    # 可选：每个 ptoas Pass 后的 IR
-│   └── <func_name>/                 # 由 ptoas/MLIR 管理的转储树
+│   └── <kernel-or-group>/            # 由 ptoas/MLIR 管理的转储树
 ├── ptoas/                           # Intermediates
 │   ├── <func_name>.pto              # MLIR from PTOCodegen
 │   └── <func_name>.cpp              # C++ from ptoas

--- a/python/pypto/backend/pto_backend.py
+++ b/python/pypto/backend/pto_backend.py
@@ -992,19 +992,31 @@ def _build_group_mapping(
     return groups, ungrouped
 
 
-def _get_ptoas_flags(memory_planner: _passes.MemoryPlanner = _passes.MemoryPlanner.PYPTO) -> list[str]:
+def _get_ptoas_flags(
+    memory_planner: _passes.MemoryPlanner = _passes.MemoryPlanner.PYPTO,
+    passes_dump_dir: str | None = None,
+) -> list[str]:
     """Build the common ptoas flag list for kernel compilation.
 
     ``MemoryPlanner.PYPTO`` and ``MemoryPlanner.DSA_RP`` bake physical
     addresses in PyPTO and trust them (``--pto-level=level3``);
     ``MemoryPlanner.PTOAS`` emits no addresses and lets the ptoas PlanMemory
-    pass allocate (``--pto-level=level2``).
+    pass allocate (``--pto-level=level2``). When ``passes_dump_dir`` is set,
+    request full-module IR snapshots after every ptoas pass.
     """
     level = "level2" if memory_planner == _passes.MemoryPlanner.PTOAS else "level3"
     flags = [
         "--enable-insert-sync",
         f"--pto-level={level}",
     ]
+    if passes_dump_dir is not None:
+        flags.extend(
+            [
+                "--mlir-print-ir-after-all",
+                "--mlir-print-ir-module-scope",
+                f"--mlir-print-ir-tree-dir={passes_dump_dir}",
+            ]
+        )
     flags.extend(_backend_core.get_handler().get_extra_ptoas_flags())
     return flags
 
@@ -1045,6 +1057,7 @@ def _compile_pto_module(
     unit_name: str,
     output_dir: str,
     memory_planner: _passes.MemoryPlanner = _passes.MemoryPlanner.PYPTO,
+    dump_ptoas_passes: bool = False,
 ) -> str:
     """Run ptoas for one MLIR module and return the generated C++."""
     ptoas_dir = os.path.join(output_dir, "ptoas")
@@ -1054,11 +1067,16 @@ def _compile_pto_module(
     with open(pto_path, "w") as f:
         f.write(pto_code)
 
+    passes_dump_dir = None
+    if dump_ptoas_passes:
+        passes_dump_dir = os.path.join(output_dir, "ptoas_passes", unit_name)
+        os.makedirs(passes_dump_dir, exist_ok=True)
+
     cpp_path = os.path.join(ptoas_dir, f"{unit_name}.cpp")
     _run_ptoas(
         pto_path,
         cpp_path,
-        ptoas_flags=_get_ptoas_flags(memory_planner),
+        ptoas_flags=_get_ptoas_flags(memory_planner, passes_dump_dir),
     )
 
     with open(cpp_path) as f:
@@ -1072,6 +1090,7 @@ def _emit_single_function_output(
     output_dir: str,
     skip_ptoas: bool,
     memory_planner: _passes.MemoryPlanner = _passes.MemoryPlanner.PYPTO,
+    dump_ptoas_passes: bool = False,
 ) -> None:
     """Emit output files for one InCore function."""
     suffix = "pto" if skip_ptoas else "cpp"
@@ -1080,7 +1099,13 @@ def _emit_single_function_output(
         result_files[kernel_rel] = pto_code
         return
 
-    ptoas_cpp = _compile_pto_module(pto_code, func.name, output_dir, memory_planner)
+    ptoas_cpp = _compile_pto_module(
+        pto_code,
+        func.name,
+        output_dir,
+        memory_planner=memory_planner,
+        dump_ptoas_passes=dump_ptoas_passes,
+    )
     result_files[kernel_rel] = _generate_kernel_wrapper(func, ptoas_cpp)
 
 
@@ -1092,13 +1117,20 @@ def _emit_group_output(
     output_dir: str,
     skip_ptoas: bool,
     memory_planner: _passes.MemoryPlanner = _passes.MemoryPlanner.PYPTO,
+    dump_ptoas_passes: bool = False,
 ) -> None:
     """Emit output files for one grouped MLIR module."""
     if skip_ptoas:
         result_files[os.path.join("kernels", f"{group_name}.pto")] = pto_code
         return
 
-    ptoas_cpp = _compile_pto_module(pto_code, group_name, output_dir, memory_planner)
+    ptoas_cpp = _compile_pto_module(
+        pto_code,
+        group_name,
+        output_dir,
+        memory_planner=memory_planner,
+        dump_ptoas_passes=dump_ptoas_passes,
+    )
     group_uses_spmd = any(_uses_spmd_block_ops(f) for f in members)
     for func in members:
         result_files[_get_kernel_output_path(func, "cpp")] = _generate_kernel_wrapper(
@@ -1164,6 +1196,7 @@ def _emit_unit(
     output_dir: str,
     skip_ptoas: bool,
     memory_planner: _passes.MemoryPlanner = _passes.MemoryPlanner.PYPTO,
+    dump_ptoas_passes: bool = False,
 ) -> _EmitResult:
     """Run ptoas + wrapper generation for one codegen unit.
 
@@ -1175,11 +1208,24 @@ def _emit_unit(
     try:
         if unit.is_group:
             _emit_group_output(
-                local_files, unit.name, unit.funcs, unit.pto_code, output_dir, skip_ptoas, memory_planner
+                local_files,
+                unit.name,
+                unit.funcs,
+                unit.pto_code,
+                output_dir,
+                skip_ptoas,
+                memory_planner,
+                dump_ptoas_passes,
             )
         else:
             _emit_single_function_output(
-                local_files, unit.funcs[0], unit.pto_code, output_dir, skip_ptoas, memory_planner
+                local_files,
+                unit.funcs[0],
+                unit.pto_code,
+                output_dir,
+                skip_ptoas,
+                memory_planner,
+                dump_ptoas_passes,
             )
         ptoas_record.end = time.perf_counter()
         return _EmitResult(name=unit.name, files=local_files, ptoas_record=ptoas_record)
@@ -1223,18 +1269,33 @@ def _run_ptoas_phase(
     result_files: dict[str, str],
     errors: list[tuple[str, Exception]],
     memory_planner: _passes.MemoryPlanner = _passes.MemoryPlanner.PYPTO,
+    dump_ptoas_passes: bool = False,
 ) -> None:
     """Phase 2: run ptoas for all codegen units, sequentially or in parallel."""
     max_workers = _get_max_workers()
 
     if max_workers == 1 or len(units) <= 1:
         for unit in units:
-            result = _emit_unit(unit, output_dir, skip_ptoas, memory_planner)
+            result = _emit_unit(
+                unit,
+                output_dir,
+                skip_ptoas,
+                memory_planner=memory_planner,
+                dump_ptoas_passes=dump_ptoas_passes,
+            )
             _collect_emit_result(result, unit, prof, result_files, errors)
     else:
         with ThreadPoolExecutor(max_workers=max_workers) as executor:
             futures = [
-                executor.submit(_emit_unit, unit, output_dir, skip_ptoas, memory_planner) for unit in units
+                executor.submit(
+                    _emit_unit,
+                    unit,
+                    output_dir,
+                    skip_ptoas,
+                    memory_planner,
+                    dump_ptoas_passes,
+                )
+                for unit in units
             ]
             for unit, future in zip(units, futures):
                 result = future.result()  # exceptions caught inside _emit_unit
@@ -1272,6 +1333,7 @@ def generate(
     *,
     memory_planner: _passes.MemoryPlanner | None = None,
     emit_source_loc: bool | None = None,
+    dump_ptoas_passes: bool = False,
 ) -> dict[str, str]:
     """Generate all PTO backend output files (kernels + orchestration + config).
 
@@ -1294,6 +1356,9 @@ def generate(
             MLIR ``loc("file":line:col)`` from the IR Span so ptoas diagnostics
             name the user's source. None reads the ``PYPTO_EMIT_PTO_LOC``
             environment default (on).
+        dump_ptoas_passes: When True, dump full-module IR after every ptoas pass
+            under ``<output_dir>/ptoas_passes/<codegen-unit>/``. Has no effect
+            when ``skip_ptoas=True``.
 
     Returns:
         Dict mapping relative file paths to their content.
@@ -1316,6 +1381,7 @@ def generate(
             skip_ptoas,
             memory_planner=memory_planner,
             emit_source_loc=emit_source_loc,
+            dump_ptoas_passes=dump_ptoas_passes,
         )
 
     # L2-only program with multiple Orchestrations: emit each as a
@@ -1329,6 +1395,7 @@ def generate(
             skip_ptoas,
             memory_planner=memory_planner,
             emit_source_loc=emit_source_loc,
+            dump_ptoas_passes=dump_ptoas_passes,
         )
 
     return _generate_single_chip(
@@ -1337,6 +1404,7 @@ def generate(
         skip_ptoas,
         memory_planner=memory_planner,
         emit_source_loc=emit_source_loc,
+        dump_ptoas_passes=dump_ptoas_passes,
     )
 
 
@@ -1347,6 +1415,7 @@ def _generate_with_distributed(
     *,
     memory_planner: _passes.MemoryPlanner = _passes.MemoryPlanner.PYPTO,
     emit_source_loc: bool = True,
+    dump_ptoas_passes: bool = False,
 ) -> dict[str, str]:
     """Generate artifacts for a distributed (L3+) program.
 
@@ -1379,6 +1448,7 @@ def _generate_with_distributed(
                 skip_ptoas,
                 memory_planner=memory_planner,
                 emit_source_loc=emit_source_loc,
+                dump_ptoas_passes=dump_ptoas_passes,
             )
             for path, content in chip_files.items():
                 result_files[f"next_levels/{func.name}/{path}"] = content
@@ -1569,6 +1639,7 @@ def _generate_multi_chip(
     *,
     memory_planner: _passes.MemoryPlanner = _passes.MemoryPlanner.PYPTO,
     emit_source_loc: bool = True,
+    dump_ptoas_passes: bool = False,
 ) -> dict[str, str]:
     """Generate artifacts for an L2-only program with multiple Orchestrations.
 
@@ -1592,6 +1663,7 @@ def _generate_multi_chip(
             skip_ptoas,
             memory_planner=memory_planner,
             emit_source_loc=emit_source_loc,
+            dump_ptoas_passes=dump_ptoas_passes,
         )
         for path, content in chip_files.items():
             result_files[f"next_levels/{func.name}/{path}"] = content
@@ -1605,6 +1677,7 @@ def _generate_single_chip(
     *,
     memory_planner: _passes.MemoryPlanner = _passes.MemoryPlanner.PYPTO,
     emit_source_loc: bool = True,
+    dump_ptoas_passes: bool = False,
 ) -> dict[str, str]:
     """Generate artifacts for a single-chip (L0-L2) program.
 
@@ -1716,7 +1789,16 @@ def _generate_single_chip(
     # Each _emit_unit call runs the ptoas subprocess and generates the
     # kernel wrapper.  These are data-independent and subprocess-heavy, so
     # a thread pool gives real parallelism (subprocess.run releases the GIL).
-    _run_ptoas_phase(units, output_dir, skip_ptoas, prof, result_files, errors, memory_planner)
+    _run_ptoas_phase(
+        units,
+        output_dir,
+        skip_ptoas,
+        prof,
+        result_files,
+        errors,
+        memory_planner=memory_planner,
+        dump_ptoas_passes=dump_ptoas_passes,
+    )
 
     # Orchestration + config
     if orch_func is not None:

--- a/python/pypto/backend/pto_backend.py
+++ b/python/pypto/backend/pto_backend.py
@@ -1099,13 +1099,16 @@ def _emit_single_function_output(
         result_files[kernel_rel] = pto_code
         return
 
-    ptoas_cpp = _compile_pto_module(
-        pto_code,
-        func.name,
-        output_dir,
-        memory_planner=memory_planner,
-        dump_ptoas_passes=dump_ptoas_passes,
-    )
+    if dump_ptoas_passes:
+        ptoas_cpp = _compile_pto_module(
+            pto_code,
+            func.name,
+            output_dir,
+            memory_planner,
+            dump_ptoas_passes=True,
+        )
+    else:
+        ptoas_cpp = _compile_pto_module(pto_code, func.name, output_dir, memory_planner)
     result_files[kernel_rel] = _generate_kernel_wrapper(func, ptoas_cpp)
 
 
@@ -1124,13 +1127,16 @@ def _emit_group_output(
         result_files[os.path.join("kernels", f"{group_name}.pto")] = pto_code
         return
 
-    ptoas_cpp = _compile_pto_module(
-        pto_code,
-        group_name,
-        output_dir,
-        memory_planner=memory_planner,
-        dump_ptoas_passes=dump_ptoas_passes,
-    )
+    if dump_ptoas_passes:
+        ptoas_cpp = _compile_pto_module(
+            pto_code,
+            group_name,
+            output_dir,
+            memory_planner,
+            dump_ptoas_passes=True,
+        )
+    else:
+        ptoas_cpp = _compile_pto_module(pto_code, group_name, output_dir, memory_planner)
     group_uses_spmd = any(_uses_spmd_block_ops(f) for f in members)
     for func in members:
         result_files[_get_kernel_output_path(func, "cpp")] = _generate_kernel_wrapper(

--- a/python/pypto/ir/compile.py
+++ b/python/pypto/ir/compile.py
@@ -197,6 +197,7 @@ def compile(  # noqa: PLR0913
     distributed_config: Any = None,
     analyze_auto_scopes_for_deps: bool = False,
     emit_source_loc: bool | None = None,
+    dump_ptoas_passes: bool = False,
 ) -> "CompiledProgram | DistributedCompiledProgram":
     """Compile a Program through passes and codegen.
 
@@ -218,6 +219,10 @@ def compile(  # noqa: PLR0913
             (``True`` -> ``CONCISE``, ``False`` -> ``NONE``). ``EXPLICIT`` makes
             each dump self-describing for tile layouts and distributed window
             buffers (issue #2088). Default: ``True`` (``CONCISE``).
+        dump_ptoas_passes: When True, dump full-module intermediate IR after
+            every ptoas pass under
+            ``<output_dir>/ptoas_passes/<codegen-unit>/``. Default: False.
+            Has no effect when ``skip_ptoas=True``.
         backend_type: Backend type for passes and codegen (default: Ascend910B)
         skip_ptoas: Skip the ptoas compilation step and emit raw MLIR (.pto) files
             instead of compiled C++ kernel wrappers.
@@ -350,6 +355,7 @@ def compile(  # noqa: PLR0913
                     skip_ptoas=skip_ptoas,
                     memory_planner=mplan,
                     emit_source_loc=emit_source_loc,
+                    dump_ptoas_passes=dump_ptoas_passes,
                 )
         except PartialCodegenError as exc:
             _write_files(exc.files, output_dir)

--- a/python/pypto/jit/cache.py
+++ b/python/pypto/jit/cache.py
@@ -142,6 +142,7 @@ def make_cache_key(  # noqa: PLR0913 — args are the key's components, one per 
     strategy: "OptimizationStrategy | None" = None,
     distributed_config: Any = None,
     analyze_auto_scopes_for_deps: bool = False,
+    dump_ptoas_passes: bool = False,
     memory_planner: "MemoryPlanner | None" = None,
     enable_pypto_l0c_double_buffer: bool = False,
     tensor_layouts: dict[str, "TensorLayout | None"] | None = None,
@@ -188,6 +189,9 @@ def make_cache_key(  # noqa: PLR0913 — args are the key's components, one per 
         analyze_auto_scopes_for_deps: Compile-side switch for deriving explicit
             task dependencies from AUTO runtime scopes. Included in the key
             because it changes generated orchestration dependencies.
+        dump_ptoas_passes: Whether ptoas writes intermediate IR after every
+            pass. Included in the key so enabling dumps cannot reuse an
+            artifact compiled without the requested dump output.
         memory_planner: Effective on-chip memory planner (``PYPTO``,
             ``DSA_RP``, or ``PTOAS``) as resolved from the ``RunConfig`` field
             and any active ``PassContext``. Included in the key because it
@@ -233,6 +237,7 @@ def make_cache_key(  # noqa: PLR0913 — args are the key's components, one per 
     )
     compile_opts = (
         ("analyze_auto_scopes_for_deps", analyze_auto_scopes_for_deps),
+        ("dump_ptoas_passes", dump_ptoas_passes),
         ("memory_planner", None if memory_planner is None else str(memory_planner)),
         ("enable_pypto_l0c_double_buffer", effective_pypto_dbc),
         ("dep_layouts", dep_layouts),

--- a/python/pypto/jit/decorator.py
+++ b/python/pypto/jit/decorator.py
@@ -2069,6 +2069,7 @@ class JITFunction:
         analyze_auto_scopes_for_deps = (
             run_config.analyze_auto_scopes_for_deps if run_config is not None else False
         )
+        dump_ptoas_passes = run_config.dump_ptoas_passes if run_config is not None else False
         # The planner decides whether physical addresses are baked into the
         # artifact, so it must split the cache: compiling one kernel under both
         # planners must not hand the second call the first one's artifact.
@@ -2088,6 +2089,7 @@ class JITFunction:
             strategy=strategy,
             distributed_config=distributed_config,
             analyze_auto_scopes_for_deps=analyze_auto_scopes_for_deps,
+            dump_ptoas_passes=dump_ptoas_passes,
             memory_planner=memory_planner,
             enable_pypto_l0c_double_buffer=_resolve_enable_pypto_l0c_double_buffer(),
         )

--- a/python/pypto/jit/decorator.py
+++ b/python/pypto/jit/decorator.py
@@ -1452,6 +1452,7 @@ def _run_config_compile_kwargs(run_config: Any) -> dict[str, Any]:
     kwargs: dict[str, Any] = {
         "strategy": run_config.strategy,
         "dump_passes": run_config.dump_passes,
+        "dump_ptoas_passes": run_config.dump_ptoas_passes,
         "profiling": run_config.compile_profiling,
         "diagnostic_phase": run_config.diagnostic_phase,
         "disabled_diagnostics": run_config.disabled_diagnostics,

--- a/python/pypto/runtime/runner.py
+++ b/python/pypto/runtime/runner.py
@@ -89,9 +89,9 @@ class RunConfig:
     When passed to :meth:`pypto.jit.decorator.JITFunction.lower`, only
     ``platform``, ``strategy``, diagnostics, dependency analysis, and
     ``memory_planner`` affect pass execution. Runtime and artifact fields such
-    as ``device_id``, ``dump_passes``, ``save_kernels_dir``, and
-    ``compile_profiling`` are ignored; ``lower()`` does not execute or write
-    compilation artifacts.
+    as ``device_id``, ``dump_passes``, ``dump_ptoas_passes``,
+    ``save_kernels_dir``, and ``compile_profiling`` are ignored; ``lower()``
+    does not execute or write compilation artifacts.
 
     Attributes:
         platform: Target execution platform — ``"a2a3sim"`` / ``"a2a3"``
@@ -105,6 +105,10 @@ class RunConfig:
             (``NONE`` / ``CONCISE`` / ``EXPLICIT``) or a ``bool``
             (``True`` -> ``CONCISE``, ``False`` -> ``NONE``). ``EXPLICIT`` resolves
             implicit tile layouts and distributed window buffers in the dump.
+        dump_ptoas_passes: If ``True``, dump full-module intermediate IR after
+            every ptoas pass under
+            ``<output_dir>/ptoas_passes/<codegen-unit>/``. Has no effect when
+            ptoas is unavailable and compilation stops at raw ``.pto`` output.
         save_kernels: If ``True``, retain generated artefacts after execution.
             When ``False`` (default), a temporary directory is used and cleaned up.
         save_kernels_dir: Directory to save generated artefacts when *save_kernels*
@@ -264,6 +268,7 @@ class RunConfig:
     distributed_config: "DistributedConfig | None" = None
     analyze_auto_scopes_for_deps: bool = False
     memory_planner: MemoryPlanner | None = None
+    dump_ptoas_passes: bool = False
 
     def __post_init__(self) -> None:
         if self.platform not in ("a2a3sim", "a2a3", "a5sim", "a5"):
@@ -415,6 +420,7 @@ def compile_program(  # noqa: PLR0913
     strategy: OptimizationStrategy,
     backend_type: BackendType,
     dump_passes: bool | PassDumpLevel = False,
+    dump_ptoas_passes: bool = False,
     diagnostic_phase: DiagnosticPhase | None = None,
     disabled_diagnostics: DiagnosticCheckSet | None = None,
     profiling: bool = False,
@@ -434,6 +440,8 @@ def compile_program(  # noqa: PLR0913
         backend_type: Code-generation backend.
         dump_passes: Per-pass IR dump control — a :class:`~pypto.ir.PassDumpLevel`
             or a ``bool`` (``True`` -> ``CONCISE``, ``False`` -> ``NONE``).
+        dump_ptoas_passes: If ``True``, dump intermediate IR after every ptoas
+            pass under ``<work_dir>/ptoas_passes/<codegen-unit>/``.
         diagnostic_phase: Override the diagnostic phase gate for compilation.
         disabled_diagnostics: Set of diagnostic checks to disable.
         profiling: If ``True``, enable compile profiling.
@@ -451,6 +459,7 @@ def compile_program(  # noqa: PLR0913
         output_dir=str(work_dir),
         strategy=strategy,
         dump_passes=dump_passes,
+        dump_ptoas_passes=dump_ptoas_passes,
         backend_type=backend_type,
         diagnostic_phase=diagnostic_phase,
         disabled_diagnostics=disabled_diagnostics,
@@ -504,6 +513,7 @@ def run(
         strategy=config.strategy,
         backend_type=config.backend_type,
         dump_passes=config.dump_passes,
+        dump_ptoas_passes=config.dump_ptoas_passes,
         diagnostic_phase=config.diagnostic_phase,
         disabled_diagnostics=config.disabled_diagnostics,
         platform=config.platform,

--- a/tests/ut/backend/test_ptoas_sentinels_match.py
+++ b/tests/ut/backend/test_ptoas_sentinels_match.py
@@ -18,6 +18,7 @@ These tests catch silent drift if either side evolves.
 from __future__ import annotations
 
 import inspect
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -104,6 +105,40 @@ def test_memory_planner_selects_ptoas_level(monkeypatch, planner, expected_level
     handler = SimpleNamespace(get_extra_ptoas_flags=lambda: [])
     monkeypatch.setattr(pto_backend._backend_core, "get_handler", lambda: handler)
     assert expected_level in pto_backend._get_ptoas_flags(planner)
+
+
+def test_compile_pto_module_enables_per_unit_pass_dump(tmp_path, monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_run_ptoas(pto_path, output_path, ptoas_flags=None):
+        captured["pto_path"] = pto_path
+        captured["output_path"] = output_path
+        captured["flags"] = ptoas_flags
+        Path(output_path).write_text("generated cpp")
+
+    monkeypatch.setattr(pto_backend, "_run_ptoas", fake_run_ptoas)
+    handler = SimpleNamespace(get_extra_ptoas_flags=lambda: ["--pto-arch", "a3"])
+    monkeypatch.setattr(pto_backend._backend_core, "get_handler", lambda: handler)
+
+    result = pto_backend._compile_pto_module(
+        "module {}",
+        "vector_kernel",
+        str(tmp_path),
+        dump_ptoas_passes=True,
+    )
+
+    dump_dir = tmp_path / "ptoas_passes" / "vector_kernel"
+    assert result == "generated cpp"
+    assert dump_dir.is_dir()
+    assert captured["flags"] == [
+        "--enable-insert-sync",
+        "--pto-level=level3",
+        "--mlir-print-ir-after-all",
+        "--mlir-print-ir-module-scope",
+        f"--mlir-print-ir-tree-dir={dump_dir}",
+        "--pto-arch",
+        "a3",
+    ]
 
 
 if __name__ == "__main__":

--- a/tests/ut/ir/test_compile_pipeline.py
+++ b/tests/ut/ir/test_compile_pipeline.py
@@ -97,12 +97,14 @@ def test_compile_preserves_dump_and_report_artifacts(tmp_path):
         output_dir=str(output_dir),
         dump_passes=True,
         skip_ptoas=True,
+        dump_ptoas_passes=True,
     )
 
     passes_dump = output_dir / "passes_dump"
     assert (passes_dump / "00_frontend.py").is_file()
     assert list(passes_dump.glob("*_after_*.py"))
     assert (output_dir / "report").is_dir()
+    assert not (output_dir / "ptoas_passes").exists()
 
 
 def test_compile_owned_profiler_writes_nested_pass_and_codegen_stages(tmp_path):

--- a/tests/ut/jit/test_cache.py
+++ b/tests/ut/jit/test_cache.py
@@ -101,6 +101,7 @@ class TestMakeCacheKey:
         assert dist_part is None  # single-chip default
         assert compile_opts == (
             ("analyze_auto_scopes_for_deps", False),
+            ("dump_ptoas_passes", False),
             ("memory_planner", None),
             ("enable_pypto_l0c_double_buffer", False),
             ("dep_layouts", ()),

--- a/tests/ut/jit/test_decorator.py
+++ b/tests/ut/jit/test_decorator.py
@@ -2266,6 +2266,7 @@ class TestCompileKwargForwarding:
         cfg = RunConfig(
             strategy=OptimizationStrategy.Default,
             dump_passes=True,
+            dump_ptoas_passes=True,
             compile_profiling=True,
             save_kernels_dir=str(artifacts_dir),
             analyze_auto_scopes_for_deps=True,
@@ -2273,6 +2274,7 @@ class TestCompileKwargForwarding:
         kwargs = _run_config_compile_kwargs(cfg)
         assert kwargs["strategy"] == OptimizationStrategy.Default
         assert kwargs["dump_passes"] is True
+        assert kwargs["dump_ptoas_passes"] is True
         assert kwargs["profiling"] is True  # mapped from RunConfig.compile_profiling
         assert kwargs["output_dir"] == str(artifacts_dir)  # from RunConfig.save_kernels_dir
         assert kwargs["analyze_auto_scopes_for_deps"] is True

--- a/tests/ut/jit/test_decorator.py
+++ b/tests/ut/jit/test_decorator.py
@@ -2431,6 +2431,39 @@ class TestCompileKwargForwarding:
         assert first != second
         assert third == first
 
+    def test_resolve_compiled_splits_cache_on_ptoas_pass_dump(self, monkeypatch):
+        """Enabling ptoas pass dumps cannot reuse an artifact compiled without them."""
+        torch = pytest.importorskip("torch")
+
+        @jit
+        def cfg_kernel(a: pl.Tensor[[128, 128], pl.FP32], c: pl.Out[pl.Tensor[[128, 128], pl.FP32]]):
+            c = a
+            return c
+
+        compile_calls = {"n": 0}
+
+        def fake_compile(*_args, **_kwargs):
+            compile_calls["n"] += 1
+            return f"compiled-{compile_calls['n']}"
+
+        monkeypatch.setattr(cfg_kernel, "_compile", fake_compile)
+
+        a = torch.randn(128, 128)
+        c = torch.empty(128, 128)
+
+        def resolve(dump_ptoas_passes):
+            cfg = RunConfig(dump_ptoas_passes=dump_ptoas_passes)
+            return cfg_kernel._resolve_compiled((a, c), {"config": cfg})[0]
+
+        first = resolve(False)
+        second = resolve(True)
+        third = resolve(False)
+
+        assert compile_calls["n"] == 2
+        assert len(cfg_kernel._cache) == 2
+        assert first != second
+        assert third == first
+
     def test_compile_forwards_run_config_kwargs(self, monkeypatch):
         """_compile forwards ir_compile_kwargs verbatim to ir.compile()."""
         # `pypto.ir.compile` the attribute is the re-exported function, so

--- a/tests/ut/runtime/test_run_config.py
+++ b/tests/ut/runtime/test_run_config.py
@@ -49,6 +49,11 @@ class TestRunConfigPlatformResolution:
 
         assert cfg.analyze_auto_scopes_for_deps is False
 
+    def test_ptoas_pass_dump_defaults_off(self):
+        cfg = RunConfig(platform="a5")
+
+        assert cfg.dump_ptoas_passes is False
+
 
 class TestRunConfigDfxFlags:
     """Verify the five DFX flags are independent and propagate correctly."""
@@ -560,6 +565,25 @@ class TestRunConfigCompileForwarding:
 
         assert captured["memory_planner"] == MemoryPlanner.DSA_RP
 
+    def test_run_forwards_ptoas_pass_dump(self, monkeypatch):
+        captured: dict = {}
+
+        class FakeCompiled:
+            def __call__(self, *_args, **_kwargs):
+                return None
+
+        def fake_compile(_program, **kwargs):
+            captured.update(kwargs)
+            return FakeCompiled()
+
+        import pypto.ir as ir_mod  # noqa: PLC0415
+
+        monkeypatch.setattr(ir_mod, "compile", fake_compile)
+
+        run(object(), config=RunConfig(platform="a2a3sim", dump_ptoas_passes=True))
+
+        assert captured["dump_ptoas_passes"] is True
+
     def test_execute_compiled_accepts_auto_scope_deps_switch(self, tmp_path, monkeypatch):
         captured: dict = {}
 
@@ -639,9 +663,11 @@ class TestRunConfigCompileForwarding:
             strategy=RunConfig().strategy,
             backend_type=BackendType.Ascend910B,
             analyze_auto_scopes_for_deps=True,
+            dump_ptoas_passes=True,
         )
 
         assert captured["analyze_auto_scopes_for_deps"] is True
+        assert captured["dump_ptoas_passes"] is True
 
 
 # ``execute_on_device`` lives in ``device_runner`` which eagerly imports the


### PR DESCRIPTION
## Summary

Add an opt-in PyPTO entry point for dumping the intermediate IR produced by every ptoas pass. Direct compilation and RunConfig/JIT callers can enable `dump_ptoas_passes=True`; dumps are separated by codegen unit so parallel ptoas workers do not collide. `skip_ptoas=True` remains a no-op for this option.

## Changes

- Pass MLIR print flags to ptoas and store snapshots under `ptoas_passes/<kernel-or-group>/`.
- Forward `dump_ptoas_passes` through `ir.compile`, `RunConfig`, JIT, runtime, and distributed/multi-chip codegen.
- Cover flag construction and API forwarding, and document the artifact layout in English and Chinese.

## Verification

- Clean CMake configure/build: passed
- `ruff check` and `ruff format --check`: passed
- `pyright python/pypto/backend/pto_backend.py python/pypto/ir/compile.py`: 0 errors
- Focused PTOAS dump tests: 4 passed
- Affected IR/runtime/JIT suite excluding the environment-incompatible `TestExecuteOnDeviceDfxValidation`: 213 passed