### PR TITLE
feat(ir): add matmul_acc init_cond and fix Acc sub-slice accumulation

### DIFF
--- a/docs/en/dev/ir/05-operators.md
+++ b/docs/en/dev/ir/05-operators.md
@@ -151,6 +151,51 @@ exact physical M/N/K box compatibility while allowing the accumulator's valid
 M/N rectangle and the rhs valid K extent to contain the smaller rectangle PTO
 computes from lhs M/K and rhs N.
 
+#### Conditional accumulator initialization (`init_cond`)
+
+`tile.matmul_acc` and `tensor.matmul_acc` take an optional fourth operand,
+`init_cond`: a BOOL scalar that selects, per execution, whether the accumulator
+is *overwritten* with `lhs @ rhs` or accumulated into. It is the split-K
+`k == 0` idiom, and it removes the need either to zero the accumulator or to
+peel the first K step:
+
+```python
+acc = pl.tile.create([16, N], pl.INT32, target_memory=pl.Mem.Acc)
+for k0 in pl.pipeline(0, K, K_TILE, stage=2):
+    ...
+    acc = pl.tile.matmul_acc(acc, a_left, b_right, init_cond=(k0 == 0))
+```
+
+The predicate is a positional operand rather than a registry kwarg because it
+may be loop-dependent; kwargs carry only compile-time constants. Registering it
+as an operand also means it participates in the use-def chain like any other
+SSA value.
+
+Lowering depends on whether the predicate is known at compile time:
+
+| `init_cond` | Emitted |
+| ----------- | ------- |
+| absent, or literal `False` | `pto.tmatmul.acc ins(dst, lhs, rhs) outs(dst)` |
+| literal `True` | `pto.tmatmul ins(lhs, rhs) outs(dst)` |
+| runtime predicate | `scf.if cond { pto.tmatmul } else { pto.tmatmul.acc }` |
+
+The ISA carries this as bit 63 (`cmatrixInit`) of the MAD's Xt register, so the
+hardware needs no branch; `pto.tmatmul` and `pto.tmatmul.acc` are distinct ops
+with no init operand, hence the branch. Because `matmul_acc` is in place
+(`set_output_reuses_input(0)`), both arms write the same buffer and the `scf.if`
+yields no value — no phi is materialized on the Acc tile.
+
+Two limitations, both diagnosed rather than silently dropped:
+
+- **Rank > 2 is rejected.** The batched form expands into several
+  `tile.matmul_acc` calls inside `FlattenTileNdTo2D`, which has no place to
+  thread a per-call predicate. Loop over the batch dimension instead.
+- **`AutoTileMatmulL0` does not tile a predicated call.** That pass matches on a
+  3-operand `tile.matmul_acc`, so a 4-operand one opts out and is left as
+  written — which is what a hand-managed split-K wants. An oversized predicated
+  accumulate is therefore the author's responsibility, exactly as an oversized
+  unpredicated `tile.matmul_acc` already is.
+
 At the tile layer, `tile.batch_matmul` provides batched semantics for
 `TileType` operands. It accepts rank >= 2 tiles, broadcasts the leading batch
 dimensions, and keeps the same operand-only interface style as `tile.matmul`.

--- a/docs/en/dev/passes/16-canonicalize_tile_slice.md
+++ b/docs/en/dev/passes/16-canonicalize_tile_slice.md
@@ -55,7 +55,7 @@ For each InCore-typed function, in three phases:
 
 2. **Rewrite consumers** — for each slice:
    - **`tile.extract(slice, ir, ic, shape)`** → `tile.extract(base, ir + off_row, ic + off_col, shape)`. The extract reads the slice's source directly; the index add is constant-folded when both terms are `ConstInt`.
-   - **`tile.matmul` / `tile.matmul_acc` / `tile.matmul_bias` operand** (Mat slices only) → the operand is replaced by a fresh `tile.extract(base, off_row, off_col, slice_shape, target_memory=Left|Right)` — `Left` for the lhs operand, `Right` for the rhs. (The `tile.matmul_acc` accumulator operand is `Acc`-resident and never a Mat slice.)
+   - **`tile.matmul` / `tile.matmul_acc` / `tile.matmul_bias` operand** (Mat slices only) → the operand is replaced by a fresh `tile.extract(base, off_row, off_col, slice_shape, target_memory=Left|Right)` — `Left` for the lhs operand, `Right` for the rhs. (The `tile.matmul_acc` accumulator operand is `Acc`-resident and never a Mat slice, so it is not rewritten here; it is instead checked for L0C contiguity — see [Acc accumulator windows](#acc-accumulator-windows).)
    - **`tile.col_expand_*` operand** (Vec slices only) → when the lazy `pto.textract` would not be an identity copy — a dynamic offset, or a window that is not contiguous in the base tile (more than one row *and* narrower than the base) — the operand is replaced by a fresh `tile.extract(base, off_row, off_col, slice_shape, target_memory=Vec)`. Both operands are checked. Contiguous const-offset windows are left untouched.
    - **Ordinary call operand** (Vec slices only, in either an `AssignStmt` or an `EvalStmt`) → compute `(base_byte_offset * 8 + (off_row * base_cols + off_col) * storage_bits) mod 256`. A known concrete MemRef byte offset is included before the modulo calculation; the allocation-planning sentinel is treated as an aligned root, while a non-constant base offset is not statically provable. Scalar SSA definitions are followed through aliases, addition/subtraction, and multiplication to prove aligned dynamic multiples. If the result is nonzero or cannot be proved, replace the operand by a fresh `tile.extract(base, off_row, off_col, slice_shape, target_memory=Vec)`. `tile.slice` itself is skipped so chained views can be peeled, and `tile.extract` uses the direct folding rule above.
    - **SSA escape** (Vec slices only) → an unaligned slice assigned through a plain alias is materialized at the alias definition. An unaligned loop initializer is materialized before the loop and substituted through its `IterArg`; an unaligned value carried by `yield` is materialized before the yield. This prevents aliases and loop-carried identities from bypassing the ordinary-call lookup.
@@ -180,6 +180,33 @@ By contrast, FP32 column 8 is 32 bytes from the source base and remains a zero-c
 
 **Tests**: `tests/ut/ir/transforms/test_canonicalize_tile_slice.py`
 
+## Acc accumulator windows
+
+The pass also **rejects** one shape it cannot repair. L0C is NZ: block
+`(r_b, c_b)` of an `[M, N]` tile sits at `(c_b * M/16 + r_b) * fractal`. A window
+is therefore contiguous only when it spans the parent's full row extent, or lies
+inside a single 16-column block. A row window of a multi-block-column `Acc` tile
+is strided, and the MAD writes its destination compactly from a bare pointer with
+no destination stride, so every block column past the first lands in the wrong
+row tile — silently, with only the first 16 columns of each row tile correct.
+
+Unlike the Vec cases above there is no repair available: an `Acc` window cannot be
+copied out and back, because nothing in the memory graph points into `Acc`. So a
+matmul accumulator operand that is a non-contiguous `Acc` window raises a
+`ValueError` naming the working spelling, which differs only by the sliced axis —
+pack the accumulator as `[rows, N * tiles]` and slice columns.
+
+The check is scoped by the op registry's `set_output_reuses_input`, so it covers
+`tile.matmul_acc` / `tile.gemv_acc` / `tile.matmul_mx_acc` without naming them. It
+stays silent on anything it cannot prove: a symbolic extent, a non-`Acc` layout,
+or a dynamic column offset it cannot show stays inside one block.
+
+This is a workaround for an upstream defect ([hw-native-sys/pto-isa#253](https://github.com/hw-native-sys/pto-isa/issues/253)),
+not a property of the DSL — `TMATMUL_ACC_IMPL` forwards the destination as a bare
+`.data()` pointer and takes `m` from the left operand, so `TileRes::Rows` is never
+read. If pto-isa gains a destination stride, this rejection should be relaxed or
+deleted rather than kept.
+
 ## Pass Properties
 
 | Property | Value |
@@ -200,8 +227,9 @@ By contrast, FP32 column 8 is 32 bytes from the source base and remains a zero-c
 | Vec `tile.slice` feeding an ordinary call, inherited address not provably 32-byte aligned | Replaced by `tile.extract(target_memory=Vec)`; slice dropped (#1789) |
 | Vec `tile.slice` feeding an ordinary call, inherited address provably 32-byte aligned | Untouched; keeps the zero-copy subview |
 | Chained Mat `tile.slice` (slice of a slice) | Peeled; offsets accumulated |
-| `tile.slice` with `valid_shape` / `drop_dims` | Skipped (not a plain window). If such a slice *also* fails either identity-copy condition above — a dynamic offset (e.g. a rank-reducing `t[i]`) or a non-contiguous window — while feeding a col-expand op, codegen rejects it with an `INTERNAL_CHECK` rather than emitting the source-corrupting materialization |
-| Other Left/Right/Acc-resident `tile.slice` | Untouched (no matching consumer) |
+| `tile.slice` with `valid_shape` / `drop_dims` | Skipped (not a plain window). If such a slice *also* fails either identity-copy condition above — a dynamic offset (e.g. a rank-reducing `t[i]`) or a non-contiguous window — while feeding a col-expand op, codegen rejects it with an `INTERNAL_CHECK` rather than emitting the source-corrupting materialization. The Acc accumulator check above still applies to such a slice: it needs only the physical base and offset, which are recorded for every window regardless of canonicalization eligibility |
+| `Acc`-resident `tile.slice` used as a matmul **accumulator**, window neither spanning the parent's full row extent nor inside one 16-column block | **Rejected** with a `ValueError` naming the column-slice spelling — the MAD has no destination stride, so the write would silently land in the wrong row tile (pto-isa#253) |
+| Other Left/Right/Acc-resident `tile.slice`, including a *contiguous* Acc accumulator window | Untouched (no matching consumer) |
 | Functions with no canonical `tile.slice` | Returned unchanged |
 
 ## See also

--- a/docs/zh/dev/ir/05-operators.md
+++ b/docs/zh/dev/ir/05-operators.md
@@ -141,6 +141,44 @@ REGISTER_OP("tensor.matmul")
 M/N/K 装箱严格兼容，同时允许累加器的有效 M/N 矩形以及 rhs 的有效 K 包含 PTO 根据
 lhs M/K 与 rhs N 实际计算的较小矩形。
 
+#### 条件式累加器初始化（`init_cond`）
+
+`tile.matmul_acc` 与 `tensor.matmul_acc` 接受一个可选的第四操作数 `init_cond`：
+一个 BOOL 标量，用于逐次执行地选择累加器是被 `lhs @ rhs` **覆写**还是被累加。
+这就是 split-K 的 `k == 0` 惯用法，它同时省去了清零累加器与剥离首个 K 步的需要：
+
+```python
+acc = pl.tile.create([16, N], pl.INT32, target_memory=pl.Mem.Acc)
+for k0 in pl.pipeline(0, K, K_TILE, stage=2):
+    ...
+    acc = pl.tile.matmul_acc(acc, a_left, b_right, init_cond=(k0 == 0))
+```
+
+该谓词是位置操作数而非 registry kwarg，因为它可能依赖循环变量，而 kwarg 只承载
+编译期常量。作为操作数注册也意味着它像其他 SSA 值一样参与 use-def 链。
+
+降级方式取决于谓词是否在编译期已知：
+
+| `init_cond` | 生成代码 |
+| ----------- | -------- |
+| 缺省，或字面量 `False` | `pto.tmatmul.acc ins(dst, lhs, rhs) outs(dst)` |
+| 字面量 `True` | `pto.tmatmul ins(lhs, rhs) outs(dst)` |
+| 运行期谓词 | `scf.if cond { pto.tmatmul } else { pto.tmatmul.acc }` |
+
+ISA 将该语义承载为 MAD 指令 Xt 寄存器的第 63 位（`cmatrixInit`），因此硬件本身
+无需分支；分支的来源是 `pto.tmatmul` 与 `pto.tmatmul.acc` 是两个独立算子、且不带
+init 操作数。由于 `matmul_acc` 是原地操作（`set_output_reuses_input(0)`），两个分
+支写入同一缓冲区，`scf.if` 不产生返回值 —— Acc tile 上不会生成 phi。
+
+两项限制，均以显式诊断而非静默丢弃的方式处理：
+
+- **拒绝 rank > 2**。批量形式在 `FlattenTileNdTo2D` 中会展开为多次
+  `tile.matmul_acc` 调用，无处安放逐调用的谓词。请改为在 batch 维上循环。
+- **`AutoTileMatmulL0` 不对带谓词的调用做 L0 切分**。该 pass 匹配 3 操作数的
+  `tile.matmul_acc`，因此 4 操作数形式会自动跳过并保持原样 —— 这正是手工管理
+  split-K 所期望的。超尺寸的带谓词累加因而由编写者负责，这与超尺寸的无谓词
+  `tile.matmul_acc` 现有行为一致。
+
 在 tile 层，`tile.batch_matmul` 为 `TileType` 操作数提供批量语义。它接受 rank >= 2 的
 tile，广播前导批量维度，并保持与 `tile.matmul` 相同的纯操作数接口风格。如果批量操作数
 需要转置语义，可以通过两种等价方式表达：在输入上显式使用 `tile.transpose(...)`，或在

--- a/docs/zh/dev/passes/16-canonicalize_tile_slice.md
+++ b/docs/zh/dev/passes/16-canonicalize_tile_slice.md
@@ -180,6 +180,29 @@ scaled:   pl.Tile[[16, 1], pl.FP32, pl.Mem.Vec] = pl.tile.muls(head_ext, 0.5)
 
 **测试**：`tests/ut/ir/transforms/test_canonicalize_tile_slice.py`
 
+## Acc 累加器窗口
+
+本 pass 还会**拒绝**一种它无法修复的形状。L0C 采用 NZ 布局：`[M, N]` tile 的
+block `(r_b, c_b)` 位于 `(c_b * M/16 + r_b) * fractal`。因此，只有当窗口覆盖父
+tile 的全部行范围，或落在单个 16 列 block 之内时，它才是连续的。跨多个列 block
+的 `Acc` tile 的行窗口是跨步的，而 MAD 从裸指针紧凑地写出目的地、没有目的地
+stride，于是第一个列 block 之后的每个列 block 都会落到错误的行 tile 上——而且是
+静默的，每个行 tile 只有前 16 列是正确的。
+
+与上面的 Vec 情形不同，这里没有可用的修复手段：`Acc` 窗口无法拷出再拷回，因为内存
+图中没有任何路径指向 `Acc`。因此，当 matmul 的累加器操作数是非连续的 `Acc` 窗口
+时，会抛出 `ValueError`，并在错误信息中给出可用的写法——两者只差在切分的轴上：把
+累加器按 `[rows, N * tiles]` 分配，然后切列。
+
+该检查以算子注册表的 `set_output_reuses_input` 为作用域，因此无需逐一列举即可覆盖
+`tile.matmul_acc` / `tile.gemv_acc` / `tile.matmul_mx_acc`。对于无法证明的情况它
+保持静默：符号化的 extent、非 `Acc` 布局，或无法证明落在单个 block 内的动态列偏移。
+
+这是针对上游缺陷（[hw-native-sys/pto-isa#253](https://github.com/hw-native-sys/pto-isa/issues/253)）
+的规避，而不是 DSL 的固有属性——`TMATMUL_ACC_IMPL` 把目的地退化为裸 `.data()`
+指针，并从左操作数取 `m`，因此 `TileRes::Rows` 从未被读取。若 pto-isa 支持了目的地
+stride，应放宽或删除该拒绝，而不是把它保留为长期规则。
+
 ## Pass 属性
 
 | 属性 | 取值 |
@@ -200,8 +223,9 @@ scaled:   pl.Tile[[16, 1], pl.FP32, pl.Mem.Vec] = pl.tile.muls(head_ext, 0.5)
 | 喂给普通 call、继承地址无法证明按 32 字节对齐的 Vec `tile.slice` | 替换为 `tile.extract(target_memory=Vec)`；删除 slice（#1789） |
 | 喂给普通 call、继承地址可证明按 32 字节对齐的 Vec `tile.slice` | 保持原样；继续使用零拷贝 subview |
 | 链式 Mat `tile.slice`（slice 的 slice） | 剥离；累加偏移 |
-| 带 `valid_shape` / `drop_dims` 的 `tile.slice` | 跳过（不是普通窗口）。若这样的 slice 同时不满足上述任一恒等拷贝条件——动态偏移（例如降秩的 `t[i]`）或非连续窗口——并喂给 col-expand op，codegen 会以 `INTERNAL_CHECK` 直接报错，而不是生成会破坏源 tile 的代码 |
-| 其他位于 Left/Right/Acc 的 `tile.slice` | 不处理（无匹配的消费者） |
+| 带 `valid_shape` / `drop_dims` 的 `tile.slice` | 跳过（不是普通窗口）。若这样的 slice 同时不满足上述任一恒等拷贝条件——动态偏移（例如降秩的 `t[i]`）或非连续窗口——并喂给 col-expand op，codegen 会以 `INTERNAL_CHECK` 直接报错，而不是生成会破坏源 tile 的代码。上面的 Acc 累加器检查对这类 slice 仍然生效：它只需要物理基址和偏移，而这些信息对每个窗口都会记录，与是否可规范化无关 |
+| 用作 matmul **累加器**、且窗口既不覆盖父 tile 全部行范围、也不落在单个 16 列 block 内的 `Acc` `tile.slice` | **拒绝**并抛出 `ValueError`，错误信息给出切列的写法——MAD 没有目的地 stride，该写入会静默落到错误的行 tile 上（pto-isa#253） |
+| 其他位于 Left/Right/Acc 的 `tile.slice`，含**连续**的 Acc 累加器窗口 | 不处理（无匹配的消费者） |
 | 不含规范 `tile.slice` 的 function | 原样返回 |
 
 ## 参见

--- a/include/pypto/ir/type_inference.h
+++ b/include/pypto/ir/type_inference.h
@@ -257,6 +257,22 @@ void CheckGatherRowOperands(const std::vector<ExprPtr>& args,
                             const std::string& op_name);
 
 /**
+ * @brief Validate the optional ``init_cond`` operand of an accumulating matmul
+ *
+ * ``matmul_acc(acc, lhs, rhs, init_cond)`` overwrites ``acc`` with ``lhs @ rhs``
+ * on the steps where ``init_cond`` holds and accumulates into it otherwise. The
+ * predicate is an ordinary SSA value rather than a kwarg because it may be
+ * loop-dependent (the split-K ``k == 0`` idiom); registry kwargs only carry
+ * compile-time constants.
+ *
+ * @param args Operand list; the operand at @p index is validated when present
+ * @param index Position of ``init_cond``. Nothing is checked when the operand
+ *              list is shorter, since the predicate is optional.
+ * @param op_name Operator name used in diagnostics
+ */
+void CheckMatmulInitCond(const std::vector<ExprPtr>& args, size_t index, const std::string& op_name);
+
+/**
  * @brief Read the elements of a tuple-typed operand
  *
  * A ``MakeTuple`` operand yields its elements directly, which preserves the

--- a/python/pypto/ir/op/tensor_ops.py
+++ b/python/pypto/ir/op/tensor_ops.py
@@ -466,8 +466,15 @@ def matmul_acc(
     a_trans: bool = False,
     b_trans: bool = False,
     span: Span | None = None,
+    *,
+    init_cond: Expr | None = None,
 ) -> Call:
     """Matrix multiplication with accumulation: acc = acc + lhs @ rhs.
+
+    With ``init_cond``, the accumulator's initial value is conditional: on the
+    steps where the predicate holds, ``acc`` is overwritten with ``lhs @ rhs``
+    instead of accumulated into (the split-K ``k == 0`` idiom). Only 2D operands
+    support the predicate.
 
     Args:
         acc: Accumulator tensor
@@ -476,13 +483,15 @@ def matmul_acc(
         a_trans: Whether to transpose lhs
         b_trans: Whether to transpose rhs
         span: Optional source span for debugging (auto-captured if not provided)
+        init_cond: Optional BOOL scalar predicate selecting overwrite over accumulate
 
     Returns:
         Call expression for matrix multiplication with accumulation
     """
     actual_span = _get_span_or_capture(span)
     kwargs: dict[str, Any] = {"a_trans": a_trans, "b_trans": b_trans}
-    return _ir_core.create_op_call("tensor.matmul_acc", [acc, lhs, rhs], kwargs, actual_span)
+    args = [acc, lhs, rhs] if init_cond is None else [acc, lhs, rhs, init_cond]
+    return _ir_core.create_op_call("tensor.matmul_acc", args, kwargs, actual_span)
 
 
 def mul(lhs: Expr, rhs: int | float | Expr, span: Span | None = None) -> Call:

--- a/python/pypto/ir/op/tile_ops.py
+++ b/python/pypto/ir/op/tile_ops.py
@@ -1799,24 +1799,39 @@ def matmul(lhs: Expr, rhs: Expr, span: Span | None = None) -> Call:
     return _ir_core.create_op_call("tile.matmul", [lhs, rhs], {}, actual_span)
 
 
-def matmul_acc(acc: Expr, lhs: Expr, rhs: Expr, span: Span | None = None) -> Call:
+def matmul_acc(
+    acc: Expr,
+    lhs: Expr,
+    rhs: Expr,
+    span: Span | None = None,
+    *,
+    init_cond: Expr | None = None,
+) -> Call:
     """Matrix multiplication with accumulation.
 
     Performs matrix multiplication and accumulates the result: acc = acc + lhs @ rhs.
     This is commonly used in loop-based matrix multiplication where results are
     accumulated over the K dimension.
 
+    With ``init_cond``, the accumulator's initial value is conditional: on the
+    steps where the predicate holds, ``acc`` is overwritten with ``lhs @ rhs``
+    instead of accumulated into. This is the split-K ``k == 0`` idiom, and it
+    keeps the accumulator single-def where a hand-written if/else would put a
+    phi on an in-place Acc buffer.
+
     Args:
         acc: Accumulator tile (TileType) to accumulate into
         lhs: Left-hand side tile (TileType)
         rhs: Right-hand side tile (TileType)
         span: Optional source span for debugging (auto-captured if not provided)
+        init_cond: Optional BOOL scalar predicate selecting overwrite over accumulate
 
     Returns:
         Call expression for matrix multiplication with accumulation
     """
     actual_span = _get_span_or_capture(span)
-    return _ir_core.create_op_call("tile.matmul_acc", [acc, lhs, rhs], {}, actual_span)
+    args = [acc, lhs, rhs] if init_cond is None else [acc, lhs, rhs, init_cond]
+    return _ir_core.create_op_call("tile.matmul_acc", args, {}, actual_span)
 
 
 def matmul_bias(lhs: Expr, rhs: Expr, bias: Expr, span: Span | None = None) -> Call:

--- a/python/pypto/language/op/tensor_ops.py
+++ b/python/pypto/language/op/tensor_ops.py
@@ -129,7 +129,7 @@ from pypto.pypto_core import DataType
 from pypto.pypto_core import ir as _ir_core
 from pypto.pypto_core.ir import AtomicType, Expr, MemorySpace, PadValue, PtrType, TensorLayout
 
-from ..typing import IntLike, Scalar, Tensor
+from ..typing import BoolLike, IntLike, Scalar, Tensor, predicate_to_expr
 
 # Bound TypeVar lets slice / assemble propagate the caller's concrete tensor
 # class (Tensor or its DistributedTensor subclass) through to the return type.
@@ -666,8 +666,22 @@ def matmul_acc(
     rhs: Tensor,
     a_trans: bool = False,
     b_trans: bool = False,
+    init_cond: BoolLike | None = None,
 ) -> Tensor:
     """Matrix multiplication with accumulation: acc += lhs @ rhs.
+
+    ``init_cond`` makes the accumulator's initial value conditional: on the steps
+    where it holds, ``acc`` is overwritten with ``lhs @ rhs`` rather than
+    accumulated into. This is the split-K idiom, and it removes the need to zero
+    the accumulator or to peel the first K step::
+
+        for k0 in pl.pipeline(0, K, K_TILE):
+            acc[t0 : t0 + R, :] = pl.matmul_acc(
+                acc[t0 : t0 + R, :], x_k, w_k, b_trans=True, init_cond=(k0 == 0)
+            )
+
+    Only 2D operands support the predicate; loop over the batch dimension
+    instead of passing higher-rank operands alongside ``init_cond``.
 
     Args:
         acc: Accumulator tensor
@@ -675,11 +689,19 @@ def matmul_acc(
         rhs: Right-hand side tensor
         a_trans: Whether to transpose lhs
         b_trans: Whether to transpose rhs
+        init_cond: Optional predicate selecting overwrite over accumulate
 
     Returns:
         Tensor wrapping the matmul_acc operation
     """
-    call_expr = _ir_ops.matmul_acc(acc.unwrap(), lhs.unwrap(), rhs.unwrap(), a_trans, b_trans)
+    call_expr = _ir_ops.matmul_acc(
+        acc.unwrap(),
+        lhs.unwrap(),
+        rhs.unwrap(),
+        a_trans,
+        b_trans,
+        init_cond=predicate_to_expr(init_cond),
+    )
     return Tensor(expr=call_expr)
 
 

--- a/python/pypto/language/op/tile_ops.py
+++ b/python/pypto/language/op/tile_ops.py
@@ -183,7 +183,7 @@ from pypto.pypto_core.ir import (
     TileLayout,
 )
 
-from ..typing import IntLike, Scalar, Tensor, Tile
+from ..typing import BoolLike, IntLike, Scalar, Tensor, Tile, predicate_to_expr
 from .system_ops import (  # noqa: F401
     tpop_from_aic,
     tpop_from_aiv,
@@ -1219,18 +1219,33 @@ def batch_matmul(lhs: Tile, rhs: Tile) -> Tile:
     return Tile(expr=call_expr)
 
 
-def matmul_acc(acc: Tile, lhs: Tile, rhs: Tile) -> Tile:
+def matmul_acc(acc: Tile, lhs: Tile, rhs: Tile, init_cond: BoolLike | None = None) -> Tile:
     """Matrix multiplication with accumulation: acc += lhs @ rhs.
+
+    ``init_cond`` makes the accumulator's initial value conditional: on the steps
+    where it holds, ``acc`` is overwritten with ``lhs @ rhs`` rather than
+    accumulated into. This is the split-K idiom, and it removes the need to zero
+    the accumulator or to peel the first K step::
+
+        for k0 in pl.pipeline(0, K, K_TILE):
+            acc_t = pl.tile.slice(acc, [ROW_TILE, N], [t0, 0])
+            pl.tile.matmul_acc(acc_t, a, b, init_cond=(k0 == 0))
+
+    A literal ``True`` / ``False`` selects one form at compile time; a runtime
+    predicate lowers to a branch over the two, with no phi on the accumulator.
 
     Args:
         acc: Accumulator tile
         lhs: Left-hand side tile
         rhs: Right-hand side tile
+        init_cond: Optional predicate selecting overwrite over accumulate
 
     Returns:
         Tile wrapping the matmul_acc operation
     """
-    call_expr = _ir_ops.matmul_acc(acc.unwrap(), lhs.unwrap(), rhs.unwrap())
+    call_expr = _ir_ops.matmul_acc(
+        acc.unwrap(), lhs.unwrap(), rhs.unwrap(), init_cond=predicate_to_expr(init_cond)
+    )
     return Tile(expr=call_expr)
 
 

--- a/python/pypto/language/op/unified_ops.py
+++ b/python/pypto/language/op/unified_ops.py
@@ -100,7 +100,7 @@ from pypto.pypto_core import DataType
 from pypto.pypto_core import ir as _ir_core
 from pypto.pypto_core.ir import PadValue
 
-from ..typing import IntLike, Scalar, Tensor, Tile
+from ..typing import BoolLike, IntLike, Scalar, Tensor, Tile
 from . import tensor_ops as _tensor
 from . import tile_ops as _tile
 
@@ -1000,6 +1000,7 @@ def matmul_acc(
     rhs: Tensor,
     a_trans: bool = ...,
     b_trans: bool = ...,
+    init_cond: BoolLike | None = ...,
 ) -> Tensor: ...
 @overload
 def matmul_acc(
@@ -1008,6 +1009,7 @@ def matmul_acc(
     rhs: Tile,
     a_trans: Literal[False] = ...,
     b_trans: Literal[False] = ...,
+    init_cond: BoolLike | None = ...,
 ) -> Tile: ...
 
 
@@ -1017,6 +1019,7 @@ def matmul_acc(
     rhs: T,
     a_trans: bool = False,
     b_trans: bool = False,
+    init_cond: BoolLike | None = None,
 ) -> T:
     """Matrix multiplication with accumulation, dispatched by input type.
 
@@ -1025,20 +1028,25 @@ def matmul_acc(
     flag — so passing either with Tile operands raises rather than being
     dropped.
 
+    ``init_cond`` makes the accumulator's initial value conditional: on the steps
+    where it holds, ``acc`` is overwritten with ``lhs @ rhs`` rather than
+    accumulated into, which is the split-K ``k == 0`` idiom. It applies to 2D
+    operands only.
+
     For Tensor inputs with rank > 2 on any of acc/lhs/rhs, the call is lowered
     to ``tile.batch_matmul_acc`` (with batch broadcasting on lhs/rhs vs the
     fixed acc batch) by ``ConvertTensorToTileOps`` and then unrolled to
     per-batch ``tile.matmul_acc`` by ``FlattenTileNdTo2D``.
     """
     if isinstance(acc, Tensor) and isinstance(lhs, Tensor) and isinstance(rhs, Tensor):
-        return _tensor.matmul_acc(acc, lhs, rhs, a_trans, b_trans)
+        return _tensor.matmul_acc(acc, lhs, rhs, a_trans, b_trans, init_cond)
     if isinstance(acc, Tile) and isinstance(lhs, Tile) and isinstance(rhs, Tile):
         _reject_tile_unsupported(
             "matmul_acc",
             a_trans=(a_trans, _TILE_TRANSPOSE_REMEDY),
             b_trans=(b_trans, _TILE_TRANSPOSE_REMEDY),
         )
-        return _tile.matmul_acc(acc, lhs, rhs)
+        return _tile.matmul_acc(acc, lhs, rhs, init_cond)
     _raise_type_dispatch_error("matmul_acc", acc, lhs, rhs)
 
 

--- a/python/pypto/language/typing/__init__.py
+++ b/python/pypto/language/typing/__init__.py
@@ -24,7 +24,13 @@ from pypto.language.typing.dynamic import DynVar, dynamic
 from pypto.language.typing.memref import MemRef
 from pypto.language.typing.prefetch_handle import AsyncEvent, AsyncSession, PrefetchAsyncContext
 from pypto.language.typing.ptr import Ptr
-from pypto.language.typing.scalar import RUNTIME, RuntimeScalarMarker, Scalar
+from pypto.language.typing.scalar import (
+    RUNTIME,
+    BoolLike,
+    RuntimeScalarMarker,
+    Scalar,
+    predicate_to_expr,
+)
 from pypto.language.typing.tensor import Tensor
 from pypto.language.typing.tile import Tile
 from pypto.language.typing.tuple import Tuple
@@ -38,6 +44,7 @@ __all__ = [
     "Array",
     "AsyncEvent",
     "AsyncSession",
+    "BoolLike",
     "DynVar",
     "InOut",
     "IntLike",
@@ -51,4 +58,5 @@ __all__ = [
     "Tile",
     "Tuple",
     "dynamic",
+    "predicate_to_expr",
 ]

--- a/python/pypto/language/typing/scalar.py
+++ b/python/pypto/language/typing/scalar.py
@@ -9,10 +9,10 @@
 
 """Scalar wrapper type for PyPTO Language DSL."""
 
-from typing import Any, cast
+from typing import Any, TypeAlias, cast
 
 from pypto.pypto_core import DataType
-from pypto.pypto_core.ir import Expr
+from pypto.pypto_core.ir import ConstInt, Expr, Span
 
 
 def _validate_scalar_meta_call(args: tuple[Any, ...], kwargs: dict[str, Any]) -> None:
@@ -322,4 +322,32 @@ RUNTIME = RuntimeScalarMarker()
 """Singleton :class:`RuntimeScalarMarker` — see the class docstring."""
 
 
-__all__ = ["RUNTIME", "RuntimeScalarMarker", "Scalar"]
+BoolLike: TypeAlias = bool | Scalar | Expr
+"""Type alias for predicate parameters accepting a Python bool, a Scalar, or a raw Expr."""
+
+
+def predicate_to_expr(value: BoolLike | None, span: Span | None = None) -> Expr | None:
+    """Coerce an optional boolean predicate operand to an ``Expr``.
+
+    A Python ``bool`` becomes ``ConstInt(.., BOOL)`` — a compile-time constant an
+    operator's lowering can fold away. A :class:`Scalar` (typically a comparison
+    such as ``k == 0``) is unwrapped to the symbolic expression it carries, which
+    stays a runtime value.
+
+    Args:
+        value: Predicate to coerce, or ``None`` to pass through
+        span: Optional span for a materialized constant
+
+    Returns:
+        The corresponding ``Expr``, or ``None`` when @p value is ``None``
+    """
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return ConstInt(int(value), DataType.BOOL, span if span is not None else Span.unknown())
+    if isinstance(value, Scalar):
+        return value.unwrap()
+    return value
+
+
+__all__ = ["RUNTIME", "BoolLike", "RuntimeScalarMarker", "Scalar", "predicate_to_expr"]

--- a/src/backend/common/pto_ops_datamove.cpp
+++ b/src/backend/common/pto_ops_datamove.cpp
@@ -37,6 +37,7 @@
 #include "pypto/ir/scalar_expr.h"
 #include "pypto/ir/storage_size.h"
 #include "pypto/ir/tile_view_semantics.h"
+#include "pypto/ir/transforms/structural_comparison.h"
 #include "pypto/ir/transforms/utils/memref_utils.h"
 #include "pypto/ir/type.h"
 #include "src/backend/common/pto_ops_internal.h"
@@ -124,6 +125,42 @@ static std::string MakeTileAssembleCodegenPTO(const CallPtr& op, codegen::Codege
       << offset_tuple->elements_.size();
   std::string row_off = codegen.GetExprAsCode(offset_tuple->elements_[0]);
   std::string col_off = codegen.GetExprAsCode(offset_tuple->elements_[1]);
+
+  // Self-copy: the source *is* the destination window. `tile.slice` lowers to a
+  // `pto.subview` and registers its (base, row, col) SSAs, so when the source
+  // resolves to a subview of this very `dst` at this very offset, the data is
+  // already in place and the `pto.tmov` below would copy a buffer onto itself.
+  //
+  // This is what an accumulate-into-a-sub-slice becomes once the accumulator
+  // shares the destination's memory space: `tile.matmul_acc` reuses its
+  // accumulator operand's buffer (`set_output_reuses_input(0)`), so the MAD has
+  // already written the window. For an Acc destination the move is not merely
+  // redundant but *illegal* — the ISA has no L0C->L0C `tmov`.
+  //
+  // Matched on the emitted SSA rather than on MemRefs because AllocateMemoryAddr
+  // has already folded a slice's dynamic byte offset down to the bare base by
+  // this point (a dynamic address is not renderable at `pto.alloc_tile addr`);
+  // the subview op is where that offset still lives. Detecting it here rather
+  // than folding the assemble away in the IR also keeps the source's def-use
+  // edge intact — `tile.matmul_acc` is not on dead_code_elimination's
+  // side-effect list, so dropping the use would let DCE delete the very
+  // computation that filled the window.
+  if (const auto* src_view = codegen.GetSubviewMaterialization(src)) {
+    auto src_rows = ir::As<ir::ConstInt>(source_tile_type->shape_[0]);
+    auto src_cols =
+        source_tile_type->shape_.size() > 1 ? ir::As<ir::ConstInt>(source_tile_type->shape_[1]) : nullptr;
+    const bool same_window =
+        src_view->source_ssa == dst && src_view->row_off_ssa == row_off && src_view->col_off_ssa == col_off;
+    // The subview must cover the whole window the assemble writes, not part of
+    // it — otherwise the bytes outside the source's extent still need the move.
+    const bool covers_window = src_rows && src_cols && src_view->view_rows == src_rows->value_ &&
+                               src_view->view_cols == src_cols->value_;
+    // An already-materialized subview no longer denotes the window: its data was
+    // repacked into a separate buffer, so the move back is real.
+    if (same_window && covers_window && !src_view->emitted) {
+      return "";
+    }
+  }
 
   // pto.subview is a view, so writing into the dst_view only affects the
   // [row, col]+sizes window.  Data outside that window must already be present

--- a/src/backend/common/pto_ops_datamove.cpp
+++ b/src/backend/common/pto_ops_datamove.cpp
@@ -37,7 +37,6 @@
 #include "pypto/ir/scalar_expr.h"
 #include "pypto/ir/storage_size.h"
 #include "pypto/ir/tile_view_semantics.h"
-#include "pypto/ir/transforms/structural_comparison.h"
 #include "pypto/ir/transforms/utils/memref_utils.h"
 #include "pypto/ir/type.h"
 #include "src/backend/common/pto_ops_internal.h"
@@ -146,9 +145,11 @@ static std::string MakeTileAssembleCodegenPTO(const CallPtr& op, codegen::Codege
   // side-effect list, so dropping the use would let DCE delete the very
   // computation that filled the window.
   if (const auto* src_view = codegen.GetSubviewMaterialization(src)) {
-    auto src_rows = ir::As<ir::ConstInt>(source_tile_type->shape_[0]);
-    auto src_cols =
-        source_tile_type->shape_.size() > 1 ? ir::As<ir::ConstInt>(source_tile_type->shape_[1]) : nullptr;
+    // Guard the rank before indexing: this runs ahead of the 2-D check further
+    // down, so a rank-0 source would otherwise index an empty shape vector.
+    const bool src_is_2d = source_tile_type->shape_.size() >= 2;
+    auto src_rows = src_is_2d ? ir::As<ir::ConstInt>(source_tile_type->shape_[0]) : nullptr;
+    auto src_cols = src_is_2d ? ir::As<ir::ConstInt>(source_tile_type->shape_[1]) : nullptr;
     const bool same_window =
         src_view->source_ssa == dst && src_view->row_off_ssa == row_off && src_view->col_off_ssa == col_off;
     // The subview must cover the whole window the assemble writes, not part of

--- a/src/backend/common/pto_ops_elementwise.cpp
+++ b/src/backend/common/pto_ops_elementwise.cpp
@@ -969,10 +969,19 @@ void RegisterElementwiseOps(Backend& backend, const std::unordered_set<std::stri
   // guarantees that the output shares the MemRef of the accumulator input
   // (via set_output_reuses_input), so we use the result buffer (dst) as the
   // accumulator operand instead of the IR-level input arg.
-  auto make_acc_codegen = [](const std::string& pto_op) {
-    return [pto_op](const ir::CallPtr& op, codegen::CodegenBase& codegen_base) -> std::string {
+  //
+  // The optional `init_cond` operand (args_[3]) makes the accumulator's initial
+  // value conditional: where it holds, `dst` is overwritten with `lhs @ rhs`
+  // rather than accumulated into.  The ISA carries this as one bit of the MAD's
+  // Xt register, but the `pto.*` tile ops expose it only as the choice between
+  // the accumulating and the non-accumulating op, so a runtime predicate lowers
+  // to a branch over the two.  No phi is needed: both arms write `dst` in place.
+  auto make_acc_codegen = [](const std::string& pto_op, const std::string& init_pto_op) {
+    return [pto_op, init_pto_op](const ir::CallPtr& op, codegen::CodegenBase& codegen_base) -> std::string {
       auto& codegen = AsPto(codegen_base);
-      CHECK(op->args_.size() == 3) << pto_op << " requires 3 arguments: acc, lhs, rhs";
+      CHECK(op->args_.size() == 3 || op->args_.size() == 4)
+          << pto_op << " requires 3 arguments (acc, lhs, rhs) or 4 with init_cond, but got "
+          << op->args_.size();
 
       std::string dst = codegen.GetCurrentResultTarget();
       std::string lhs = codegen.GetExprAsCode(op->args_[1]);
@@ -980,24 +989,63 @@ void RegisterElementwiseOps(Backend& backend, const std::unordered_set<std::stri
       std::string dst_type = codegen.GetCurrentResultTileBufTypeString();
       std::string lhs_type = codegen.GetExprTypeAnnotation(op->args_[1]);
       std::string rhs_type = codegen.GetExprTypeAnnotation(op->args_[2]);
+      const std::string acc_phase = GemvAccPhaseAttr(op);
 
-      std::ostringstream acc_inst;
-      acc_inst << pto_op << " ins(" << dst << ", " << lhs << ", " << rhs;
-      std::vector<std::string> ins_type_parts;
-      for (const auto& t : {dst_type, lhs_type, rhs_type}) {
-        if (!t.empty()) ins_type_parts.push_back(t);
-      }
-      if (!ins_type_parts.empty()) {
-        acc_inst << " : ";
-        for (size_t i = 0; i < ins_type_parts.size(); ++i) {
-          if (i > 0) acc_inst << ", ";
-          acc_inst << ins_type_parts[i];
+      // ins() carries the accumulator only on the accumulating form; the
+      // initializing form reads lhs/rhs alone and writes dst from scratch.
+      auto build = [&](bool initializing) {
+        std::vector<std::string> operands = {lhs, rhs};
+        std::vector<std::string> types = {lhs_type, rhs_type};
+        if (!initializing) {
+          operands.insert(operands.begin(), dst);
+          types.insert(types.begin(), dst_type);
         }
+        std::ostringstream inst;
+        inst << (initializing ? init_pto_op : pto_op) << " ins(";
+        for (size_t i = 0; i < operands.size(); ++i) {
+          if (i > 0) inst << ", ";
+          inst << operands[i];
+        }
+        std::vector<std::string> present;
+        for (const auto& t : types) {
+          if (!t.empty()) present.push_back(t);
+        }
+        if (!present.empty()) {
+          inst << " : ";
+          for (size_t i = 0; i < present.size(); ++i) {
+            if (i > 0) inst << ", ";
+            inst << present[i];
+          }
+        }
+        inst << ") outs(" << dst;
+        if (!dst_type.empty()) inst << " : " << dst_type;
+        inst << ")" << acc_phase;
+        return inst.str();
+      };
+
+      if (op->args_.size() == 3) {
+        codegen.Emit(build(/*initializing=*/false));
+        return "";
       }
-      acc_inst << ") outs(" << dst;
-      if (!dst_type.empty()) acc_inst << " : " << dst_type;
-      acc_inst << ")" << GemvAccPhaseAttr(op);
-      codegen.Emit(acc_inst.str());
+
+      // A literal predicate picks one arm outright; only a runtime one branches.
+      if (auto init_const = As<ir::ConstInt>(op->args_[3])) {
+        codegen.Emit(build(/*initializing=*/init_const->value_ != 0));
+        return "";
+      }
+
+      // Resolve the condition before opening the region so any instruction its
+      // evaluation emits lands outside (and so dominates) both arms.
+      std::string cond = codegen.GetExprAsCode(op->args_[3]);
+      codegen.EmitStructural("scf.if " + cond + " {");
+      codegen.IncreaseIndent();
+      codegen.Emit(build(/*initializing=*/true));
+      codegen.DecreaseIndent();
+      codegen.EmitStructural("} else {");
+      codegen.IncreaseIndent();
+      codegen.Emit(build(/*initializing=*/false));
+      codegen.DecreaseIndent();
+      codegen.EmitStructural("}");
       return "";
     };
   };
@@ -1047,11 +1095,11 @@ void RegisterElementwiseOps(Backend& backend, const std::unordered_set<std::stri
     };
   };
 
-  reg("tile.matmul_acc", make_acc_codegen("pto.tmatmul.acc"));
+  reg("tile.matmul_acc", make_acc_codegen("pto.tmatmul.acc", "pto.tmatmul"));
   reg("tile.gemv", [](const ir::CallPtr& op, codegen::CodegenBase& codegen) {
     return MakeGemvCodegenPTO("pto.tgemv", 2, op, codegen);
   });
-  reg("tile.gemv_acc", make_acc_codegen("pto.tgemv.acc"));
+  reg("tile.gemv_acc", make_acc_codegen("pto.tgemv.acc", "pto.tgemv"));
   reg("tile.matmul_mx_acc", make_mx_acc_codegen("pto.tmatmul.mx.acc"));
   reg("tile.gemv_bias", [](const ir::CallPtr& op, codegen::CodegenBase& codegen) {
     return MakeGemvCodegenPTO("pto.tgemv.bias", 3, op, codegen);

--- a/src/backend/common/pto_ops_elementwise.cpp
+++ b/src/backend/common/pto_ops_elementwise.cpp
@@ -976,12 +976,20 @@ void RegisterElementwiseOps(Backend& backend, const std::unordered_set<std::stri
   // Xt register, but the `pto.*` tile ops expose it only as the choice between
   // the accumulating and the non-accumulating op, so a runtime predicate lowers
   // to a branch over the two.  No phi is needed: both arms write `dst` in place.
-  auto make_acc_codegen = [](const std::string& pto_op, const std::string& init_pto_op) {
-    return [pto_op, init_pto_op](const ir::CallPtr& op, codegen::CodegenBase& codegen_base) -> std::string {
+  // `supports_init_cond` must track the op's own type deduction: `tile.gemv_acc`
+  // still accepts exactly 3 arguments, so accepting a 4th here would only create
+  // an unreachable branch behind a `CHECK` that fires earlier in deduction.
+  auto make_acc_codegen = [](const std::string& pto_op, const std::string& init_pto_op,
+                             bool supports_init_cond) {
+    return [pto_op, init_pto_op, supports_init_cond](const ir::CallPtr& op,
+                                                     codegen::CodegenBase& codegen_base) -> std::string {
       auto& codegen = AsPto(codegen_base);
-      CHECK(op->args_.size() == 3 || op->args_.size() == 4)
-          << pto_op << " requires 3 arguments (acc, lhs, rhs) or 4 with init_cond, but got "
-          << op->args_.size();
+      const size_t max_args = supports_init_cond ? 4 : 3;
+      CHECK(op->args_.size() == 3 || (supports_init_cond && op->args_.size() == 4))
+          << pto_op << " requires 3 arguments (acc, lhs, rhs)"
+          << (supports_init_cond ? " or 4 with init_cond" : "") << ", but got " << op->args_.size();
+      INTERNAL_CHECK(op->args_.size() <= max_args)
+          << "Internal error: " << pto_op << " arity exceeds what this codegen accepts";
 
       std::string dst = codegen.GetCurrentResultTarget();
       std::string lhs = codegen.GetExprAsCode(op->args_[1]);
@@ -1006,15 +1014,21 @@ void RegisterElementwiseOps(Backend& backend, const std::unordered_set<std::stri
           if (i > 0) inst << ", ";
           inst << operands[i];
         }
-        std::vector<std::string> present;
-        for (const auto& t : types) {
-          if (!t.empty()) present.push_back(t);
-        }
-        if (!present.empty()) {
+        // Type annotations must be all present or all absent: the `: t0, t1, ...`
+        // clause is positional, so emitting a filtered subset would bind the
+        // remaining types to the wrong operands. Mirrors make_mx_acc_codegen.
+        const bool any_type_present =
+            std::any_of(types.begin(), types.end(), [](const std::string& t) { return !t.empty(); });
+        const bool all_types_present =
+            std::all_of(types.begin(), types.end(), [](const std::string& t) { return !t.empty(); });
+        INTERNAL_CHECK(!any_type_present || all_types_present)
+            << "Internal error: " << (initializing ? init_pto_op : pto_op)
+            << " operand type annotations must all be present or all absent, got a partial set";
+        if (all_types_present) {
           inst << " : ";
-          for (size_t i = 0; i < present.size(); ++i) {
+          for (size_t i = 0; i < types.size(); ++i) {
             if (i > 0) inst << ", ";
-            inst << present[i];
+            inst << types[i];
           }
         }
         inst << ") outs(" << dst;
@@ -1095,11 +1109,11 @@ void RegisterElementwiseOps(Backend& backend, const std::unordered_set<std::stri
     };
   };
 
-  reg("tile.matmul_acc", make_acc_codegen("pto.tmatmul.acc", "pto.tmatmul"));
+  reg("tile.matmul_acc", make_acc_codegen("pto.tmatmul.acc", "pto.tmatmul", /*supports_init_cond=*/true));
   reg("tile.gemv", [](const ir::CallPtr& op, codegen::CodegenBase& codegen) {
     return MakeGemvCodegenPTO("pto.tgemv", 2, op, codegen);
   });
-  reg("tile.gemv_acc", make_acc_codegen("pto.tgemv.acc", "pto.tgemv"));
+  reg("tile.gemv_acc", make_acc_codegen("pto.tgemv.acc", "pto.tgemv", /*supports_init_cond=*/false));
   reg("tile.matmul_mx_acc", make_mx_acc_codegen("pto.tmatmul.mx.acc"));
   reg("tile.gemv_bias", [](const ir::CallPtr& op, codegen::CodegenBase& codegen) {
     return MakeGemvCodegenPTO("pto.tgemv.bias", 3, op, codegen);

--- a/src/codegen/pto/pto_codegen.cpp
+++ b/src/codegen/pto/pto_codegen.cpp
@@ -46,9 +46,11 @@
 #include "pypto/ir/span.h"
 #include "pypto/ir/stmt.h"
 #include "pypto/ir/tile_view_semantics.h"
+#include "pypto/ir/transforms/structural_comparison.h"
 #include "pypto/ir/transforms/utils/auto_name_utils.h"
 #include "pypto/ir/transforms/utils/memref_utils.h"
 #include "pypto/ir/transforms/utils/op_predicates.h"
+#include "pypto/ir/transforms/utils/tile_buf_signature.h"
 #include "pypto/ir/transforms/utils/transform_utils.h"
 #include "pypto/ir/transforms/utils/var_collectors.h"
 #include "pypto/ir/type.h"
@@ -406,21 +408,75 @@ bool IsInPlaceInput0DpsOp(const ir::OpPtr& op) {
          ir::IsOp(op, "tile.tget_scale_addr");
 }
 
-bool ShouldAliasScatterResultToInput(const AssignStmtPtr& stmt) {
+bool ShareOneMemRefWindow(const std::shared_ptr<const TileType>& lhs,
+                          const std::shared_ptr<const TileType>& rhs) {
+  auto lhs_memref = ir::GetDefinedMemRef(lhs);
+  auto rhs_memref = ir::GetDefinedMemRef(rhs);
+  if (!lhs_memref || !rhs_memref) return false;
+  if (lhs_memref->base_.get() != rhs_memref->base_.get()) return false;
+  // Same base is not enough: two *different* windows of one allocation share it,
+  // and aliasing those would silently redirect the write. Require the same byte
+  // offset and extent too. The offset is an expression (a slice of a loop-carried
+  // tile carries a loop-dependent one), so compare it structurally.
+  if (lhs_memref->size_ != rhs_memref->size_) return false;
+  const auto& lhs_offset = lhs_memref->byte_offset_;
+  const auto& rhs_offset = rhs_memref->byte_offset_;
+  if (!lhs_offset || !rhs_offset) return lhs_offset == rhs_offset;
+  return ir::structural_equal(lhs_offset, rhs_offset);
+}
+
+// Whether `stmt`'s result Var should be bound to the SSA of the operand the call
+// writes in place, instead of getting its own `pto.alloc_tile`.
+//
+// Two arms, deliberately kept apart:
+//
+//   * `IsInPlaceInput0DpsOp` — ops whose in-place-ness is a codegen-lowering fact.
+//     Gated on a shared base memref only, which is the long-standing behaviour.
+//
+//   * the registry (`set_output_reuses_input`) — the declared, op-level truth.
+//     This is what lets `tile.matmul_acc` accumulate directly into its
+//     accumulator operand: when that operand is a `tile.slice` of a larger Acc
+//     tile its SSA is a `pto.subview`, so the MAD writes straight into the
+//     destination window instead of into a private L0C buffer that would then
+//     need an acc->acc `tmov` the ISA cannot express.
+//
+//     This arm additionally requires an identical `TileBufSignature`. One MLIR
+//     SSA value has exactly one type, so aliasing two vars whose tile configs
+//     differ would silently drop one of them — `tile.fillpad_inplace` reuses its
+//     input's buffer but its result carries `pad`, which the input does not.
+//
+// A declared index naming a non-tile argument (`tile.store` / `tile.write`
+// declare index 2, a TensorType) drops out: GetTileTypeWithMemRef returns null.
+bool ShouldAliasResultToInPlaceInput(const AssignStmtPtr& stmt) {
   auto call = As<ir::Call>(stmt->value_);
-  if (!call || !IsInPlaceInput0DpsOp(call->op_) || call->args_.empty()) {
-    return false;
-  }
+  if (!call || !call->op_) return false;
 
   auto result_tile_type = ir::GetTileTypeWithMemRef(stmt->var_->GetType());
-  auto input_tile_type = ir::GetTileTypeWithMemRef(call->args_[0]->GetType());
-  if (!result_tile_type || !input_tile_type) {
-    return false;
+  if (!result_tile_type) return false;
+
+  auto input_tile_type_at = [&](size_t index) -> std::shared_ptr<const TileType> {
+    if (index >= call->args_.size()) return nullptr;
+    return ir::GetTileTypeWithMemRef(call->args_[index]->GetType());
+  };
+
+  // Legacy arm: shared base memref only, exactly as before.
+  if (IsInPlaceInput0DpsOp(call->op_)) {
+    auto input_tile_type = input_tile_type_at(0);
+    if (!input_tile_type) return false;
+    auto result_memref = ir::GetDefinedMemRef(result_tile_type);
+    auto input_memref = ir::GetDefinedMemRef(input_tile_type);
+    return result_memref && input_memref && result_memref->base_.get() == input_memref->base_.get();
   }
 
-  auto result_memref = ir::GetDefinedMemRef(result_tile_type);
-  auto input_memref = ir::GetDefinedMemRef(input_tile_type);
-  return result_memref && input_memref && result_memref->base_.get() == input_memref->base_.get();
+  auto& registry = ir::OpRegistry::GetInstance();
+  if (!registry.IsRegistered(call->op_->name_)) return false;
+  auto declared = registry.GetEntry(call->op_->name_).GetOutputReusesInputArg();
+  if (!declared.has_value()) return false;
+  auto input_tile_type = input_tile_type_at(*declared);
+  if (!input_tile_type) return false;
+  return ShareOneMemRefWindow(result_tile_type, input_tile_type) &&
+         ir::TileBufSignature::FromTileType(*result_tile_type) ==
+             ir::TileBufSignature::FromTileType(*input_tile_type);
 }
 
 // `array.update_element` is SSA-functional in the IR (returns a fresh
@@ -1966,7 +2022,7 @@ void PTOCodegen::VisitStmt(const ir::StmtPtr& stmt) {
 void PTOCodegen::VisitStmt_(const AssignStmtPtr& op) {
   auto call = As<ir::Call>(op->value_);
   const bool is_set_validshape = ir::IsOp(call, "tile.set_validshape");
-  const bool alias_scatter_result_to_input = ShouldAliasScatterResultToInput(op);
+  const bool alias_result_to_in_place_input = ShouldAliasResultToInPlaceInput(op);
   const bool alias_array_update_to_input = ShouldAliasArrayUpdateResultToInput(op);
 
   if (ir::IsOp(call, "pld.tile.remote_load")) {
@@ -1979,7 +2035,7 @@ void PTOCodegen::VisitStmt_(const AssignStmtPtr& op) {
   }
 
   if (auto tile_type = ir::GetTileTypeWithMemRef(op->var_->GetType())) {
-    if (!is_set_validshape && !alias_scatter_result_to_input) {
+    if (!is_set_validshape && !alias_result_to_in_place_input) {
       EmitAllocTileForVar(op->var_, tile_type);
     }
   }
@@ -1990,7 +2046,7 @@ void PTOCodegen::VisitStmt_(const AssignStmtPtr& op) {
           op->var_->name_hint_;  // Seed for readable MLIR names when no tile buffer exists.
       std::shared_ptr<const TileType> result_tile_type;
       if (auto tile_type = ir::GetTileTypeWithMemRef(op->var_->GetType())) {
-        if (alias_scatter_result_to_input) {
+        if (alias_result_to_in_place_input) {
           result_buf = GetExprAsCode(call->args_[0]);
           INTERNAL_CHECK(!result_buf.empty())
               << "Internal error: " << call->op_->name_ << " result must alias the input tile SSA";

--- a/src/ir/op/tensor_ops/matmul.cpp
+++ b/src/ir/op/tensor_ops/matmul.cpp
@@ -212,8 +212,10 @@ REGISTER_OP("tensor.matmul")
 
 TypePtr DeduceTensorMatMulAccType(const std::vector<ExprPtr>& args,
                                   const std::vector<std::pair<std::string, std::any>>& kwargs) {
-  CHECK(args.size() == 3) << "tensor.matmul_acc requires exactly 3 arguments (acc, lhs, rhs), but got "
-                          << args.size();
+  CHECK(args.size() == 3 || args.size() == 4)
+      << "tensor.matmul_acc requires 3 arguments (acc, lhs, rhs) or 4 with the optional init_cond "
+      << "predicate, but got " << args.size();
+  CheckMatmulInitCond(args, 3, "tensor.matmul_acc");
 
   auto acc_type = As<TensorType>(args[0]->GetType());
   auto lhs_type = As<TensorType>(args[1]->GetType());
@@ -311,6 +313,9 @@ REGISTER_OP("tensor.matmul_acc")
     .add_argument("acc", "Accumulator tensor (TensorType)")
     .add_argument("lhs", "Left-hand side tensor (TensorType)")
     .add_argument("rhs", "Right-hand side tensor (TensorType)")
+    .add_argument("init_cond",
+                  "Optional BOOL scalar; where it holds the accumulator is overwritten with "
+                  "lhs @ rhs instead of accumulated into (the split-K `k == 0` step)")
     .set_attr<bool>("a_trans")
     .set_attr<bool>("b_trans")
     .f_deduce_type([](const std::vector<ExprPtr>& args,

--- a/src/ir/op/tile_ops/matmul.cpp
+++ b/src/ir/op/tile_ops/matmul.cpp
@@ -123,8 +123,10 @@ TypePtr DeduceTileMatMulType(const std::vector<ExprPtr>& args,
 TypePtr DeduceTileMatMulAccType(const std::vector<ExprPtr>& args,
                                 const std::vector<std::pair<std::string, std::any>>& kwargs,
                                 const std::string& op_name) {
-  CHECK(args.size() == 3) << "The operator " << op_name << " requires exactly 3 arguments, but got "
-                          << args.size();
+  CHECK(args.size() == 3 || args.size() == 4)
+      << "The operator " << op_name << " requires 3 arguments (acc, lhs, rhs) or 4 with the optional "
+      << "init_cond predicate, but got " << args.size();
+  CheckMatmulInitCond(args, 3, op_name);
 
   // All arguments must be TileType
   auto acc_type = As<TileType>(args[0]->GetType());
@@ -420,6 +422,9 @@ REGISTER_OP("tile.matmul_acc")
     .add_argument("acc", "Accumulator tile (TileType, 2D)")
     .add_argument("lhs", "Left-hand side tile (TileType, 2D)")
     .add_argument("rhs", "Right-hand side tile (TileType, 2D)")
+    .add_argument("init_cond",
+                  "Optional BOOL scalar; where it holds the accumulator is overwritten with "
+                  "lhs @ rhs instead of accumulated into (the split-K `k == 0` step)")
     .set_input_memory(0, MemorySpace::Acc)
     .set_input_memory(1, MemorySpace::Left)
     .set_input_memory(2, MemorySpace::Right)

--- a/src/ir/op/type_inference.cpp
+++ b/src/ir/op/type_inference.cpp
@@ -456,6 +456,18 @@ void CheckGatherRowOperands(const std::vector<ExprPtr>& args,
   throw ValueError(msg.str());
 }
 
+void CheckMatmulInitCond(const std::vector<ExprPtr>& args, size_t index, const std::string& op_name) {
+  if (args.size() <= index) return;
+  const auto& cond = args[index];
+  auto scalar_type = As<ScalarType>(cond->GetType());
+  CHECK(scalar_type) << "The operator " << op_name << " requires init_cond to be a boolean scalar, but got "
+                     << cond->GetType()->TypeName();
+  CHECK(scalar_type->dtype_ == DataType::BOOL)
+      << "The operator " << op_name << " requires init_cond to have dtype BOOL, but got "
+      << scalar_type->dtype_.ToString()
+      << ". Write a comparison such as `k == 0` rather than passing the index itself.";
+}
+
 void CheckReductionInputNonEmpty(const std::vector<ExprPtr>& valid, const std::string& op_name,
                                  const Span& span) {
   for (size_t i = 0; i < valid.size(); ++i) {

--- a/src/ir/transforms/canonicalize_tile_slice_pass.cpp
+++ b/src/ir/transforms/canonicalize_tile_slice_pass.cpp
@@ -78,6 +78,29 @@
 /// a dynamic row is safe when its known multiple times the base row stride is
 /// aligned, and a dynamic column is safe when its known multiple times the
 /// element storage width is aligned.
+/// Last, the pass **rejects** the col-major (``Acc`` / L0C) dual of the #2010
+/// contiguity condition when the slice is a matmul *accumulator*.  Here there is
+/// no repair to apply — an ``Acc`` window cannot be copied out and back, because
+/// nothing in the memory graph points into ``Acc`` — so the only correct
+/// response is a diagnostic.  In L0C's NZ layout block ``(r_b, c_b)`` of an
+/// ``[M, N]`` tile sits at ``(c_b * M/16 + r_b) * fractal``, so a window is
+/// contiguous only when it spans the parent's full row extent or occupies a
+/// single 16-column block.  A row slice of a multi-block-column accumulator is
+/// therefore strided, and the MAD cannot express a destination stride: pto-isa's
+/// ``TMATMUL_ACC_IMPL`` forwards the destination as a bare ``.data()`` pointer
+/// and derives ``m`` from the *left operand*, so ``TileRes::Rows`` — the only
+/// carrier of the parent stride — is discarded at the intrinsic boundary.  ptoas
+/// preserves it faithfully up to that point (``getSubviewPhysicalType`` keeps the
+/// parent shape and narrows via ``valid``); the information is lost in the last
+/// call.  Without this guard the kernel silently computes wrong results, with
+/// only the first 16 columns of each row tile correct.
+///
+/// Tracked upstream as hw-native-sys/pto-isa#253.  **This guard is scoped to
+/// that defect, not to a property of the DSL** — a row window of an ``Acc`` tile
+/// is a legitimate thing to write, and the IR expresses it correctly all the way
+/// down.  If pto-isa gains a destination stride (or otherwise passes
+/// ``TileRes::Rows`` into ``mad``), the shape becomes representable and this
+/// rejection must be relaxed or deleted, not kept as a permanent DSL rule.
 ///
 /// After all consumers are rewritten the now-dead ``tile.slice`` is dropped.
 /// Chained slices (a slice of a slice) are peeled, accumulating the offset.
@@ -109,6 +132,7 @@
 #include "pypto/ir/span.h"
 #include "pypto/ir/stmt.h"
 #include "pypto/ir/storage_size.h"
+#include "pypto/ir/tile_view_semantics.h"
 #include "pypto/ir/transforms/base/mutator.h"
 #include "pypto/ir/transforms/base/visitor.h"
 #include "pypto/ir/transforms/pass_properties.h"
@@ -237,6 +261,81 @@ std::optional<SliceInfo> ParseCanonicalSlice(const AssignStmtPtr& assign,
   return SliceInfo{base, off_row, off_col, memory_space, is_mat};
 }
 
+/// Number of columns in one L0C fractal box (1024 B / 4 B per INT32|FP32 = 16x16).
+constexpr int64_t kAccBlockCols = 16;
+
+/// Reject a matmul accumulator that is a *strided* window of a col-major (`Acc`)
+/// tile.  See the file header for the full derivation; the short form is that
+/// the MAD writes its `[m, n]` destination compactly from a bare pointer, so a
+/// window is only representable when it spans the parent's full row extent or
+/// occupies a single 16-column block.
+///
+/// Scoped by the op registry's `set_output_reuses_input` — the declared,
+/// op-level statement of "argument `i` is the in-place destination" — so it
+/// covers `tile.matmul_acc` / `tile.gemv_acc` / `tile.matmul_mx_acc` without
+/// naming them, and any future accumulator op for free.  The `col_major` +
+/// `kAccFractal` gate excludes the Vec-resident in-place ops (`tile.scatter`,
+/// `tile.fillpad_inplace`), whose row-major counterpart of this rule is handled
+/// by the rewrite paths above.
+///
+/// Silent on anything it cannot prove: a symbolic extent, a non-`Acc` layout, or
+/// an accumulator that is not a recorded slice all fall through untouched.  The
+/// guard exists to convert a known-wrong lowering into a diagnostic, not to
+/// second-guess shapes it cannot evaluate.
+///
+/// Provisional: this rejects a shape the IR models correctly, purely because
+/// pto-isa's MAD cannot write it (hw-native-sys/pto-isa#253).  Revisit when that
+/// issue closes — if the intrinsic learns the destination stride, drop the
+/// `view_rows != parent_rows` rejection below and keep only whatever the fixed
+/// hardware still cannot express.
+void CheckAccumulatorSliceContiguous(const AssignStmtPtr& assign,
+                                     const std::unordered_map<const Var*, SliceInfo>& slices) {
+  auto call = As<Call>(assign->value_);
+  if (!call || !call->op_) return;
+  auto& reg = OpRegistry::GetInstance();
+  if (!reg.IsRegistered(call->op_->name_)) return;
+  auto declared = reg.GetEntry(call->op_->name_).GetOutputReusesInputArg();
+  if (!declared.has_value() || *declared >= call->args_.size()) return;
+
+  auto acc = AsVarLike(call->args_[*declared]);
+  if (!acc) return;
+  auto slice = slices.find(acc.get());
+  if (slice == slices.end()) return;
+
+  auto view = As<TileType>(acc->GetType());
+  auto parent = As<TileType>(slice->second.base->GetType());
+  if (!view || !parent || view->shape_.size() != 2 || parent->shape_.size() != 2) return;
+
+  // Only the col-major L0C orientation loses its stride at the MAD boundary.
+  // Accept either statement of it: the memory space (set explicitly in tile
+  // programming) or the block layout (which `tile.slice` inherits from source).
+  const auto parent_view = tile_view_semantics::GetEffectiveTileView(*parent);
+  const bool is_acc = parent->memory_space_.has_value() && *parent->memory_space_ == MemorySpace::Acc;
+  if (!is_acc && parent_view.blayout != TileLayout::col_major) return;
+  if (parent_view.fractal != tile_view_semantics::kAccFractal) return;
+
+  auto view_rows = As<ConstInt>(view->shape_[0]);
+  auto view_cols = As<ConstInt>(view->shape_[1]);
+  auto parent_rows = As<ConstInt>(parent->shape_[0]);
+  if (!view_rows || !view_cols || !parent_rows) return;
+
+  if (view_rows->value_ == parent_rows->value_) return;  // spans the full row extent
+  if (view_cols->value_ <= kAccBlockCols) return;        // a single block column
+
+  CHECK_SPAN(false, call->span_)
+      << call->op_->name_ << ": the accumulator is a " << view_rows->value_ << "x" << view_cols->value_
+      << " row window of a " << parent_rows->value_ << "x" << As<ConstInt>(parent->shape_[1])->value_
+      << " Acc (L0C) tile, which is not contiguous in L0C's block layout and cannot be a matmul "
+         "destination — the hardware MAD writes its result compactly and has no destination stride, "
+         "so only the first "
+      << kAccBlockCols << " columns of each row tile would be correct.\n"
+      << "Slice the accumulator along columns instead, so each window spans every row: allocate "
+      << view_rows->value_ << "x" << (parent_rows->value_ / view_rows->value_) * view_cols->value_
+      << " and use tile.slice(acc, [" << view_rows->value_ << ", " << view_cols->value_ << "], [0, i * "
+      << view_cols->value_
+      << "]). That is the same L0C memory, addressed in the order the hardware writes it.";
+}
+
 /// Phase 1 — collect every canonical `tile.slice` definition in the function,
 /// keyed by its result Var.  AssignStmts are visited in program order, so a
 /// chained slice's source is always already recorded.
@@ -258,7 +357,9 @@ class SliceCollector : public IRVisitor {
     }
     if (auto info = ParseCanonicalSlice(op, slices, known_consts_)) {
       slices.emplace(op->var_.get(), *info);
+      return;
     }
+    CheckAccumulatorSliceContiguous(op, slices);
   }
 
  private:

--- a/src/ir/transforms/canonicalize_tile_slice_pass.cpp
+++ b/src/ir/transforms/canonicalize_tile_slice_pass.cpp
@@ -227,15 +227,20 @@ int64_t KnownMultipleModuloAlignment(const ExprPtr& expr,
 /// peeled base/offset.  `known` holds slices collected so far; a slice whose
 /// source is itself a recorded slice is peeled through it (offsets summed), so
 /// `base` is always a non-slice tile.
-std::optional<SliceInfo> ParseCanonicalSlice(const AssignStmtPtr& assign,
-                                             const std::unordered_map<const Var*, SliceInfo>& known,
-                                             const std::unordered_map<const Var*, ExprPtr>& known_consts) {
+std::optional<SliceInfo> ParseSliceWindow(const AssignStmtPtr& assign,
+                                          const std::unordered_map<const Var*, SliceInfo>& known,
+                                          const std::unordered_map<const Var*, ExprPtr>& known_consts,
+                                          bool require_canonical) {
   if (!assign || !assign->var_) return std::nullopt;
   auto call = As<Call>(assign->value_);
   if (!call || !call->op_ || !IsOp(call, "tile.slice")) return std::nullopt;
-  // Only canonical 3-arg slices (input, shape, offset).  A slice carrying
-  // valid_shape / drop_dims is not a plain window and is left untouched.
-  if (call->args_.size() != 3) return std::nullopt;
+  // Rewriting is restricted to canonical 3-arg slices (input, shape, offset): a
+  // slice carrying valid_shape / drop_dims is not a plain window, so the
+  // canonicalization rules below do not apply to it.  The Acc safety check has
+  // no such restriction — it only needs the physical base and offset, and a
+  // non-canonical slice miscompiles exactly the same way — so it parses with
+  // `require_canonical = false`.
+  if (require_canonical ? call->args_.size() != 3 : call->args_.size() < 3) return std::nullopt;
 
   auto src = AsVarLike(call->args_[0]);
   if (!src) return std::nullopt;
@@ -259,6 +264,13 @@ std::optional<SliceInfo> ParseCanonicalSlice(const AssignStmtPtr& assign,
     off_col = MakeCanonicalIndexAdd(it->second.off_col, off_col, assign->span_);
   }
   return SliceInfo{base, off_row, off_col, memory_space, is_mat};
+}
+
+/// Rewrite-eligible slices only — the input to every canonicalization below.
+std::optional<SliceInfo> ParseCanonicalSlice(const AssignStmtPtr& assign,
+                                             const std::unordered_map<const Var*, SliceInfo>& known,
+                                             const std::unordered_map<const Var*, ExprPtr>& known_consts) {
+  return ParseSliceWindow(assign, known, known_consts, /*require_canonical=*/true);
 }
 
 /// Number of columns in one L0C fractal box (1024 B / 4 B per INT32|FP32 = 16x16).
@@ -320,11 +332,29 @@ void CheckAccumulatorSliceContiguous(const AssignStmtPtr& assign,
   if (!view_rows || !view_cols || !parent_rows) return;
 
   if (view_rows->value_ == parent_rows->value_) return;  // spans the full row extent
-  if (view_cols->value_ <= kAccBlockCols) return;        // a single block column
+
+  // A narrow window is safe only when it lies *inside* one 16-column block:
+  // there is then no second block column for the MAD's compact write to
+  // mis-stride. Width alone is not enough — a [16, 16] window at column offset
+  // 8 of a [32, 32] accumulator straddles two blocks and corrupts the parent
+  // exactly like a wider one. A dynamic offset cannot be proven and is
+  // rejected rather than assumed.
+  if (view_cols->value_ <= kAccBlockCols) {
+    auto off_col = As<ConstInt>(slice->second.off_col);
+    if (off_col && off_col->value_ >= 0 &&
+        off_col->value_ / kAccBlockCols == (off_col->value_ + view_cols->value_ - 1) / kAccBlockCols) {
+      return;
+    }
+  }
+
+  // The parent's column extent is only needed to describe the tile; keep it out
+  // of the decision so a symbolic N is still rejected rather than dereferenced.
+  auto parent_cols = As<ConstInt>(parent->shape_[1]);
+  const std::string parent_cols_text = parent_cols ? std::to_string(parent_cols->value_) : std::string("?");
 
   CHECK_SPAN(false, call->span_)
       << call->op_->name_ << ": the accumulator is a " << view_rows->value_ << "x" << view_cols->value_
-      << " row window of a " << parent_rows->value_ << "x" << As<ConstInt>(parent->shape_[1])->value_
+      << " row window of a " << parent_rows->value_ << "x" << parent_cols_text
       << " Acc (L0C) tile, which is not contiguous in L0C's block layout and cannot be a matmul "
          "destination — the hardware MAD writes its result compactly and has no destination stride, "
          "so only the first "
@@ -343,6 +373,12 @@ class SliceCollector : public IRVisitor {
  public:
   std::unordered_map<const Var*, SliceInfo> slices;
   std::unordered_map<const Var*, ExprPtr> scalar_defs;
+  /// Every `tile.slice` window, canonical or not.  `slices` drives the
+  /// rewrites and is therefore restricted to the canonical 3-arg form; the Acc
+  /// safety check needs the physical base and offset of *any* window, since a
+  /// slice carrying an explicit valid_shape reaches the MAD with exactly the
+  /// same broken stride.
+  std::unordered_map<const Var*, SliceInfo> windows;
 
  protected:
   void VisitStmt_(const AssignStmtPtr& op) override {
@@ -355,11 +391,14 @@ class SliceCollector : public IRVisitor {
         if (it != known_consts_.end()) known_consts_.emplace(op->var_.get(), it->second);
       }
     }
+    if (auto window = ParseSliceWindow(op, windows, known_consts_, /*require_canonical=*/false)) {
+      windows.emplace(op->var_.get(), *window);
+    }
     if (auto info = ParseCanonicalSlice(op, slices, known_consts_)) {
       slices.emplace(op->var_.get(), *info);
       return;
     }
-    CheckAccumulatorSliceContiguous(op, slices);
+    CheckAccumulatorSliceContiguous(op, windows);
   }
 
  private:

--- a/src/ir/transforms/op_conversion_registry.cpp
+++ b/src/ir/transforms/op_conversion_registry.cpp
@@ -1119,11 +1119,22 @@ void OpConversionRegistry::RegisterMatmulOps() {
       [rank_of](const std::vector<ExprPtr>& args, const std::vector<std::pair<std::string, std::any>>& kwargs,
                 const Span& span) -> ConversionResult {
         (void)kwargs;
-        INTERNAL_CHECK_SPAN(args.size() == 3, span)
-            << "tensor.matmul_acc conversion expects 3 args (acc, lhs, rhs)";
+        INTERNAL_CHECK_SPAN(args.size() == 3 || args.size() == 4, span)
+            << "tensor.matmul_acc conversion expects 3 args (acc, lhs, rhs) or 4 with init_cond";
         const bool nd = rank_of(args[0]) > 2 || rank_of(args[1]) > 2 || rank_of(args[2]) > 2;
         const std::string out_op = nd ? "tile.batch_matmul_acc" : "tile.matmul_acc";
-        return ConversionResult{OpRegistry::GetInstance().Create(out_op, {args[0], args[1], args[2]}, span)};
+        std::vector<ExprPtr> out_args = {args[0], args[1], args[2]};
+        if (args.size() == 4) {
+          // The batched form expands into several tile.matmul_acc calls inside
+          // FlattenTileNdTo2D, which has no place to thread a per-call
+          // predicate; only the 2D path carries init_cond.
+          CHECK_SPAN(!nd, span)
+              << "tensor.matmul_acc does not support init_cond on operands of rank > 2 (got acc rank "
+              << rank_of(args[0]) << ", lhs rank " << rank_of(args[1]) << ", rhs rank " << rank_of(args[2])
+              << "). Loop over the batch dimension and accumulate with 2D operands instead.";
+          out_args.push_back(args[3]);
+        }
+        return ConversionResult{OpRegistry::GetInstance().Create(out_op, out_args, span)};
       },
       {{1, {MemorySpace::Mat, "a_trans"}}, {2, {MemorySpace::Mat, "b_trans"}}});
 }

--- a/tests/st/runtime/ops/test_matmul_acc_init_cond.py
+++ b/tests/st/runtime/ops/test_matmul_acc_init_cond.py
@@ -1,0 +1,210 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""On-device tests for ``matmul_acc(init_cond=...)`` and accumulation into a
+window of a shared ``Acc`` tile.
+
+Both behaviours are numeric, not structural: the unit tests assert the emitted
+``pto.tmatmul`` / ``pto.tmatmul.acc`` forms, but only a device run shows that the
+first K step actually *overwrites* the accumulator (rather than accumulating onto
+whatever L0C held) and that a window write lands where the parent expects it.
+
+``TestMatmulAccWindowInitCond`` is the shape that motivated the feature: one
+accumulator shared by several output column tiles, each accumulating its own K
+reduction in place. Note the accumulator is sliced along **columns** — a row
+window of a multi-block-column ``Acc`` tile is rejected by
+``CanonicalizeTileSlice``, because the MAD has no destination stride
+(hw-native-sys/pto-isa#253).
+"""
+
+from typing import Any
+
+import pypto.language as pl
+import pytest
+import torch
+from harness.core.harness import PLATFORMS, DataType, PTOTestCase, TensorSpec
+
+# Same rationale as tests/st/runtime/ops/test_matmul.py: the cube reduces K in a
+# different order than torch's single-pass BLAS, so FP32 goldens drift by a few
+# ULP of the partial sums. Reuse that file's calibrated floor.
+_FP32_MATMUL_RTOL = 1e-4
+_FP32_MATMUL_ATOL = 1e-4
+
+
+class TestMatmulAccInitCond(PTOTestCase):
+    """Split-K driven by ``init_cond`` instead of a peeled first step.
+
+    The accumulator is never zeroed, so if ``init_cond`` failed to select the
+    overwriting form on ``k0 == 0`` the result would carry stale L0C content and
+    the comparison against ``a @ b`` would fail.
+    """
+
+    __test__ = False
+
+    def __init__(
+        self, m: int = 64, k: int = 256, n: int = 64, k_tile: int = 64, *, platform=None, config=None
+    ):
+        super().__init__(config, platform=platform)
+        if config is None:
+            self.config.rtol = _FP32_MATMUL_RTOL
+            self.config.atol = _FP32_MATMUL_ATOL
+        self.M, self.K, self.N, self.K_TILE = m, k, n, k_tile
+
+    def get_name(self) -> str:
+        return f"matmul_acc_init_cond_{self.M}x{self.K}x{self.N}_kt{self.K_TILE}"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("a", [self.M, self.K], DataType.FP32, init_value=torch.randn),
+            TensorSpec("b", [self.K, self.N], DataType.FP32, init_value=torch.randn),
+            TensorSpec("c", [self.M, self.N], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        M, K, N, KT = self.M, self.K, self.N, self.K_TILE
+
+        @pl.program
+        class MatmulAccInitCondProgram:
+            @pl.function(type=pl.FunctionType.InCore)
+            def matmul_acc_split_k(
+                self,
+                a: pl.Tensor[[M, K], pl.FP32],
+                b: pl.Tensor[[K, N], pl.FP32],
+                c: pl.Out[pl.Tensor[[M, N], pl.FP32]],
+            ) -> pl.Tensor[[M, N], pl.FP32]:
+                acc = pl.tile.create([M, N], pl.FP32, target_memory=pl.MemorySpace.Acc)
+                for k0 in pl.range(0, K, KT):
+                    a_l1 = pl.load(a, offsets=[0, k0], shapes=[M, KT], target_memory=pl.MemorySpace.Mat)
+                    b_l1 = pl.load(b, offsets=[k0, 0], shapes=[KT, N], target_memory=pl.MemorySpace.Mat)
+                    a_l0 = pl.move(a_l1, target_memory=pl.MemorySpace.Left)
+                    b_l0 = pl.move(b_l1, target_memory=pl.MemorySpace.Right)
+                    acc = pl.matmul_acc(acc, a_l0, b_l0, init_cond=(k0 == 0))
+                out_c = pl.store(acc, offsets=[0, 0], output_tensor=c)
+                return out_c
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orchestrator(
+                self,
+                a: pl.Tensor[[M, K], pl.FP32],
+                b: pl.Tensor[[K, N], pl.FP32],
+                out_c: pl.Out[pl.Tensor[[M, N], pl.FP32]],
+            ) -> pl.Tensor[[M, N], pl.FP32]:
+                out_c = self.matmul_acc_split_k(a, b, out_c)
+                return out_c
+
+        return MatmulAccInitCondProgram
+
+    def compute_expected(self, tensors, params=None):
+        tensors["c"][:] = torch.matmul(tensors["a"], tensors["b"])
+
+
+class TestMatmulAccWindowInitCond(PTOTestCase):
+    """Several output column tiles accumulating into windows of one ``Acc`` tile.
+
+    Each ``[M, N_TILE]`` window runs its own K reduction in place, so this covers
+    the destination aliasing (the MAD must write the window's ``pto.subview``,
+    not a private L0C buffer) together with ``init_cond``.
+    """
+
+    __test__ = False
+
+    def __init__(
+        self,
+        m: int = 16,
+        k: int = 128,
+        n_tile: int = 64,
+        tiles: int = 2,
+        k_tile: int = 64,
+        *,
+        platform=None,
+        config=None,
+    ):
+        super().__init__(config, platform=platform)
+        if config is None:
+            self.config.rtol = _FP32_MATMUL_RTOL
+            self.config.atol = _FP32_MATMUL_ATOL
+        self.M, self.K, self.N_TILE, self.TILES, self.K_TILE = m, k, n_tile, tiles, k_tile
+        self.N = n_tile * tiles
+
+    def get_name(self) -> str:
+        return f"matmul_acc_window_{self.M}x{self.K}x{self.N}_t{self.TILES}"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("a", [self.M, self.K], DataType.FP32, init_value=torch.randn),
+            TensorSpec("b", [self.K, self.N], DataType.FP32, init_value=torch.randn),
+            TensorSpec("c", [self.M, self.N], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        M, K, N, NT, TILES, KT = self.M, self.K, self.N, self.N_TILE, self.TILES, self.K_TILE
+
+        @pl.program
+        class MatmulAccWindowProgram:
+            @pl.function(type=pl.FunctionType.InCore)
+            def matmul_acc_window(
+                self,
+                a: pl.Tensor[[M, K], pl.FP32],
+                b: pl.Tensor[[K, N], pl.FP32],
+                c: pl.Out[pl.Tensor[[M, N], pl.FP32]],
+            ) -> pl.Tensor[[M, N], pl.FP32]:
+                acc = pl.tile.create([M, N], pl.FP32, target_memory=pl.MemorySpace.Acc)
+                for t in pl.range(TILES):
+                    for k0 in pl.range(0, K, KT):
+                        a_l1 = pl.load(a, offsets=[0, k0], shapes=[M, KT], target_memory=pl.MemorySpace.Mat)
+                        b_l1 = pl.load(
+                            b, offsets=[k0, t * NT], shapes=[KT, NT], target_memory=pl.MemorySpace.Mat
+                        )
+                        a_l0 = pl.move(a_l1, target_memory=pl.MemorySpace.Left)
+                        b_l0 = pl.move(b_l1, target_memory=pl.MemorySpace.Right)
+                        # Column window: spans the parent's full row extent, so it
+                        # is contiguous in L0C and legal as a MAD destination.
+                        win = pl.tile.slice(acc, [M, NT], [0, t * NT])
+                        win = pl.matmul_acc(win, a_l0, b_l0, init_cond=(k0 == 0))
+                out_c = pl.store(acc, offsets=[0, 0], output_tensor=c)
+                return out_c
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orchestrator(
+                self,
+                a: pl.Tensor[[M, K], pl.FP32],
+                b: pl.Tensor[[K, N], pl.FP32],
+                out_c: pl.Out[pl.Tensor[[M, N], pl.FP32]],
+            ) -> pl.Tensor[[M, N], pl.FP32]:
+                out_c = self.matmul_acc_window(a, b, out_c)
+                return out_c
+
+        return MatmulAccWindowProgram
+
+    def compute_expected(self, tensors, params=None):
+        tensors["c"][:] = torch.matmul(tensors["a"], tensors["b"])
+
+
+_INIT_COND_SHAPES = [(64, 256, 64, 64), (32, 128, 64, 32)]
+
+
+class TestMatmulAccInitCondOperations:
+    """Device tests for conditional accumulator initialization."""
+
+    @pytest.mark.parametrize("platform", PLATFORMS)
+    @pytest.mark.parametrize("m,k,n,k_tile", _INIT_COND_SHAPES)
+    def test_matmul_acc_init_cond(self, test_runner, platform, m, k, n, k_tile):
+        """Split-K where ``init_cond=(k0 == 0)`` replaces the peeled first step."""
+        result = test_runner.run(TestMatmulAccInitCond(m=m, k=k, n=n, k_tile=k_tile, platform=platform))
+        assert result.passed, f"Test failed: {result.error}"
+
+    @pytest.mark.parametrize("platform", PLATFORMS)
+    def test_matmul_acc_column_window(self, test_runner, platform):
+        """Column windows of one shared ``Acc`` tile, each accumulating over K."""
+        result = test_runner.run(TestMatmulAccWindowInitCond(platform=platform))
+        assert result.passed, f"Test failed: {result.error}"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/ut/codegen/test_matmul_init_cond.py
+++ b/tests/ut/codegen/test_matmul_init_cond.py
@@ -1,0 +1,225 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""``matmul_acc(init_cond=...)`` — conditional accumulator initialization.
+
+``init_cond`` makes the accumulator's initial value conditional: where the
+predicate holds, the accumulator is overwritten with ``lhs @ rhs`` rather than
+accumulated into. This is the split-K ``k == 0`` idiom, and it keeps the
+accumulator single-def where a hand-written if/else would put a phi on an
+in-place Acc buffer.
+
+The ISA carries this as one bit of the MAD's Xt register, but ``pto.tmatmul`` and
+``pto.tmatmul.acc`` are distinct ops, so a *runtime* predicate lowers to a branch
+over the two while a literal one selects a single op at compile time.
+"""
+
+import pypto.language as pl
+import pytest
+from pypto import backend, codegen
+from pypto.backend import BackendType
+from pypto.ir import OptimizationStrategy, PassManager
+from pypto.language.parser.diagnostics import InvalidOperationError
+
+PTOCodegen = codegen.PTOCodegen
+
+
+@pytest.fixture(autouse=True)
+def _setup_backend():
+    backend.reset_for_testing()
+    backend.set_backend_type(BackendType.Ascend910B)
+    yield
+    backend.reset_for_testing()
+
+
+def _generate_default_mlir(program_cls) -> str:
+    pm = PassManager.get_strategy(OptimizationStrategy.Default)
+    program = pm.run_passes(program_cls)
+    result = PTOCodegen().generate(program)
+    return result if isinstance(result, str) else "".join(result.values())
+
+
+@pl.program
+class MatmulAccPlain:
+    """No predicate — the accumulating form, unchanged."""
+
+    @pl.function(type=pl.FunctionType.InCore)
+    def kernel(
+        self,
+        lhs: pl.Tensor[[16, 16], pl.FP32],
+        rhs: pl.Tensor[[16, 16], pl.FP32],
+        acc: pl.Tensor[[16, 16], pl.FP32],
+        output: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+    ) -> pl.Tensor[[16, 16], pl.FP32]:
+        lhs_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(
+            lhs, [0, 0], [16, 16], target_memory=pl.MemorySpace.Mat
+        )
+        rhs_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(
+            rhs, [0, 0], [16, 16], target_memory=pl.MemorySpace.Mat
+        )
+        acc_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(
+            acc, [0, 0], [16, 16], target_memory=pl.MemorySpace.Mat
+        )
+        out_tile: pl.Tile[[16, 16], pl.FP32] = pl.tile.matmul_acc(acc_tile, lhs_tile, rhs_tile)
+        return pl.store(out_tile, [0, 0], output)
+
+
+@pl.program
+class MatmulAccInitTrue:
+    """Literal ``True`` — folds to the non-accumulating form."""
+
+    @pl.function(type=pl.FunctionType.InCore)
+    def kernel(
+        self,
+        lhs: pl.Tensor[[16, 16], pl.FP32],
+        rhs: pl.Tensor[[16, 16], pl.FP32],
+        acc: pl.Tensor[[16, 16], pl.FP32],
+        output: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+    ) -> pl.Tensor[[16, 16], pl.FP32]:
+        lhs_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(
+            lhs, [0, 0], [16, 16], target_memory=pl.MemorySpace.Mat
+        )
+        rhs_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(
+            rhs, [0, 0], [16, 16], target_memory=pl.MemorySpace.Mat
+        )
+        acc_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(
+            acc, [0, 0], [16, 16], target_memory=pl.MemorySpace.Mat
+        )
+        out_tile: pl.Tile[[16, 16], pl.FP32] = pl.tile.matmul_acc(
+            acc_tile, lhs_tile, rhs_tile, init_cond=True
+        )
+        return pl.store(out_tile, [0, 0], output)
+
+
+@pl.program
+class MatmulAccInitFalse:
+    """Literal ``False`` — folds to the accumulating form."""
+
+    @pl.function(type=pl.FunctionType.InCore)
+    def kernel(
+        self,
+        lhs: pl.Tensor[[16, 16], pl.FP32],
+        rhs: pl.Tensor[[16, 16], pl.FP32],
+        acc: pl.Tensor[[16, 16], pl.FP32],
+        output: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+    ) -> pl.Tensor[[16, 16], pl.FP32]:
+        lhs_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(
+            lhs, [0, 0], [16, 16], target_memory=pl.MemorySpace.Mat
+        )
+        rhs_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(
+            rhs, [0, 0], [16, 16], target_memory=pl.MemorySpace.Mat
+        )
+        acc_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(
+            acc, [0, 0], [16, 16], target_memory=pl.MemorySpace.Mat
+        )
+        out_tile: pl.Tile[[16, 16], pl.FP32] = pl.tile.matmul_acc(
+            acc_tile, lhs_tile, rhs_tile, init_cond=False
+        )
+        return pl.store(out_tile, [0, 0], output)
+
+
+@pl.program
+class MatmulAccSplitK:
+    """Runtime predicate — the split-K ``k == 0`` idiom.
+
+    Spelled through the type-dispatched ``pl.matmul_acc`` rather than
+    ``pl.tile.matmul_acc`` so the unified wrapper's Tile path is covered too.
+    """
+
+    @pl.function(type=pl.FunctionType.InCore)
+    def kernel(
+        self,
+        lhs: pl.Tensor[[16, 64], pl.FP32],
+        rhs: pl.Tensor[[64, 16], pl.FP32],
+        output: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+    ) -> pl.Tensor[[16, 16], pl.FP32]:
+        acc_tile: pl.Tile[[16, 16], pl.FP32, pl.MemorySpace.Acc] = pl.tile.create(
+            [16, 16], pl.FP32, target_memory=pl.MemorySpace.Acc
+        )
+        for k0 in pl.range(0, 64, 16):
+            a: pl.Tile[[16, 16], pl.FP32] = pl.load(lhs, [0, k0], [16, 16], target_memory=pl.MemorySpace.Mat)
+            b: pl.Tile[[16, 16], pl.FP32] = pl.load(rhs, [k0, 0], [16, 16], target_memory=pl.MemorySpace.Mat)
+            acc_tile = pl.matmul_acc(acc_tile, a, b, init_cond=(k0 == 0))
+        return pl.store(acc_tile, [0, 0], output)
+
+
+def test_no_init_cond_emits_only_the_accumulating_form():
+    mlir = _generate_default_mlir(MatmulAccPlain)
+    assert "pto.tmatmul.acc" in mlir, mlir
+    # The accumulating op is the only matmul, and nothing is branched over.
+    assert mlir.count("pto.tmatmul") == 1, mlir
+    assert "scf.if" not in mlir, mlir
+
+
+def test_literal_true_folds_to_the_non_accumulating_form():
+    mlir = _generate_default_mlir(MatmulAccInitTrue)
+    assert "pto.tmatmul.acc" not in mlir, (
+        "init_cond=True must overwrite the accumulator, not accumulate into it:\n" + mlir
+    )
+    assert "pto.tmatmul " in mlir, mlir
+    # A compile-time predicate must not leave a branch behind.
+    assert "scf.if" not in mlir, mlir
+
+
+def test_literal_false_folds_to_the_accumulating_form():
+    mlir = _generate_default_mlir(MatmulAccInitFalse)
+    assert "pto.tmatmul.acc" in mlir, mlir
+    assert mlir.count("pto.tmatmul") == 1, mlir
+    assert "scf.if" not in mlir, mlir
+
+
+def test_runtime_predicate_branches_over_both_forms():
+    mlir = _generate_default_mlir(MatmulAccSplitK)
+    assert "scf.if" in mlir, "a runtime init_cond must lower to a branch:\n" + mlir
+    # Both arms are present: initialize on the guarded path, accumulate otherwise.
+    assert "pto.tmatmul.acc" in mlir, mlir
+    assert mlir.count("pto.tmatmul") == 2, (
+        "expected exactly the initializing and accumulating forms:\n" + mlir
+    )
+    # Both arms write the same in-place accumulator, so no phi is materialized
+    # for the tile — scf.if carries no results.
+    assert "scf.if" in mlir and "= scf.if" not in mlir, (
+        "the accumulator is written in place, so scf.if must not yield a value:\n" + mlir
+    )
+
+
+def test_non_boolean_init_cond_is_rejected():
+    with pytest.raises(InvalidOperationError, match="init_cond to have dtype BOOL"):
+
+        @pl.program
+        class BadInitCond:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                lhs: pl.Tensor[[16, 16], pl.FP32],
+                rhs: pl.Tensor[[16, 16], pl.FP32],
+                acc: pl.Tensor[[16, 16], pl.FP32],
+                output: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                lhs_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(
+                    lhs, [0, 0], [16, 16], target_memory=pl.MemorySpace.Mat
+                )
+                rhs_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(
+                    rhs, [0, 0], [16, 16], target_memory=pl.MemorySpace.Mat
+                )
+                acc_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(
+                    acc, [0, 0], [16, 16], target_memory=pl.MemorySpace.Mat
+                )
+                # An index, not a predicate — must be rejected rather than
+                # silently reinterpreted as a truth value.
+                out_tile: pl.Tile[[16, 16], pl.FP32] = pl.tile.matmul_acc(
+                    acc_tile, lhs_tile, rhs_tile, init_cond=pl.read(acc, [0, 0])
+                )
+                return pl.store(out_tile, [0, 0], output)
+
+        _ = BadInitCond
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/ut/codegen/test_matmul_init_cond.py
+++ b/tests/ut/codegen/test_matmul_init_cond.py
@@ -54,7 +54,6 @@ class MatmulAccPlain:
         self,
         lhs: pl.Tensor[[16, 16], pl.FP32],
         rhs: pl.Tensor[[16, 16], pl.FP32],
-        acc: pl.Tensor[[16, 16], pl.FP32],
         output: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
     ) -> pl.Tensor[[16, 16], pl.FP32]:
         lhs_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(
@@ -63,8 +62,8 @@ class MatmulAccPlain:
         rhs_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(
             rhs, [0, 0], [16, 16], target_memory=pl.MemorySpace.Mat
         )
-        acc_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(
-            acc, [0, 0], [16, 16], target_memory=pl.MemorySpace.Mat
+        acc_tile: pl.Tile[[16, 16], pl.FP32, pl.MemorySpace.Acc] = pl.tile.create(
+            [16, 16], pl.FP32, target_memory=pl.MemorySpace.Acc
         )
         out_tile: pl.Tile[[16, 16], pl.FP32] = pl.tile.matmul_acc(acc_tile, lhs_tile, rhs_tile)
         return pl.store(out_tile, [0, 0], output)
@@ -79,7 +78,6 @@ class MatmulAccInitTrue:
         self,
         lhs: pl.Tensor[[16, 16], pl.FP32],
         rhs: pl.Tensor[[16, 16], pl.FP32],
-        acc: pl.Tensor[[16, 16], pl.FP32],
         output: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
     ) -> pl.Tensor[[16, 16], pl.FP32]:
         lhs_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(
@@ -88,8 +86,8 @@ class MatmulAccInitTrue:
         rhs_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(
             rhs, [0, 0], [16, 16], target_memory=pl.MemorySpace.Mat
         )
-        acc_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(
-            acc, [0, 0], [16, 16], target_memory=pl.MemorySpace.Mat
+        acc_tile: pl.Tile[[16, 16], pl.FP32, pl.MemorySpace.Acc] = pl.tile.create(
+            [16, 16], pl.FP32, target_memory=pl.MemorySpace.Acc
         )
         out_tile: pl.Tile[[16, 16], pl.FP32] = pl.tile.matmul_acc(
             acc_tile, lhs_tile, rhs_tile, init_cond=True
@@ -106,7 +104,6 @@ class MatmulAccInitFalse:
         self,
         lhs: pl.Tensor[[16, 16], pl.FP32],
         rhs: pl.Tensor[[16, 16], pl.FP32],
-        acc: pl.Tensor[[16, 16], pl.FP32],
         output: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
     ) -> pl.Tensor[[16, 16], pl.FP32]:
         lhs_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(
@@ -115,8 +112,8 @@ class MatmulAccInitFalse:
         rhs_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(
             rhs, [0, 0], [16, 16], target_memory=pl.MemorySpace.Mat
         )
-        acc_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(
-            acc, [0, 0], [16, 16], target_memory=pl.MemorySpace.Mat
+        acc_tile: pl.Tile[[16, 16], pl.FP32, pl.MemorySpace.Acc] = pl.tile.create(
+            [16, 16], pl.FP32, target_memory=pl.MemorySpace.Acc
         )
         out_tile: pl.Tile[[16, 16], pl.FP32] = pl.tile.matmul_acc(
             acc_tile, lhs_tile, rhs_tile, init_cond=False
@@ -208,8 +205,8 @@ def test_non_boolean_init_cond_is_rejected():
                 rhs_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(
                     rhs, [0, 0], [16, 16], target_memory=pl.MemorySpace.Mat
                 )
-                acc_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(
-                    acc, [0, 0], [16, 16], target_memory=pl.MemorySpace.Mat
+                acc_tile: pl.Tile[[16, 16], pl.FP32, pl.MemorySpace.Acc] = pl.tile.create(
+                    [16, 16], pl.FP32, target_memory=pl.MemorySpace.Acc
                 )
                 # An index, not a predicate — must be rejected rather than
                 # silently reinterpreted as a truth value.

--- a/tests/ut/ir/transforms/test_canonicalize_tile_slice.py
+++ b/tests/ut/ir/transforms/test_canonicalize_tile_slice.py
@@ -1513,35 +1513,76 @@ class TestAccAccumulatorSliceContiguity:
     first 16 columns of each row tile land correctly.
     """
 
-    def _kernel(self, acc_shape, slice_shape, offset):
+    def _kernel(self, acc_shape, slice_shape, offset, valid_shape=None):
         """`acc[offset]` of shape `slice_shape` accumulates `a[M, K] @ b[K, N]`,
         with M/N taken from `slice_shape` so the matmul's own shape check passes
-        and the contiguity guard is what decides the outcome."""
+        and the contiguity guard is what decides the outcome.
+
+        `valid_shape` selects the 4-arg `tile.slice` form, which is not
+        rewrite-eligible. The branch is resolved here in Python rather than in
+        the kernel body: a `None` closure variable and an `is` comparison are
+        both outside what the DSL parser accepts.
+        """
         rows, cols = slice_shape
         k = 64
 
-        @pl.program
-        class Prog:
-            @pl.function(type=pl.FunctionType.InCore)
-            def kernel(
-                self,
-                x: pl.Tensor[[rows, k], pl.FP16],
-                w: pl.Tensor[[k, cols], pl.FP16],
-                out: pl.Out[pl.Tensor[acc_shape, pl.FP32]],
-            ) -> pl.Tensor[acc_shape, pl.FP32]:
-                x_mat: pl.Tile[[rows, k], pl.FP16, pl.Mem.Mat] = pl.tile.load(
-                    x, [0, 0], [rows, k], target_memory=pl.Mem.Mat
-                )
-                a: pl.Tile[[rows, k], pl.FP16, pl.Mem.Left] = pl.tile.move(x_mat, target_memory=pl.Mem.Left)
-                w_mat: pl.Tile[[k, cols], pl.FP16, pl.Mem.Mat] = pl.tile.load(
-                    w, [0, 0], [k, cols], target_memory=pl.Mem.Mat
-                )
-                b: pl.Tile[[k, cols], pl.FP16, pl.Mem.Right] = pl.tile.move(w_mat, target_memory=pl.Mem.Right)
-                acc = pl.tile.create(acc_shape, pl.FP32, target_memory=pl.Mem.Acc)
-                acc_win = pl.tile.slice(acc, slice_shape, offset)
-                acc_new = pl.tile.matmul_acc(acc_win, a, b)
-                out = pl.tile.store(acc_new, [0, 0], out)
-                return out
+        if valid_shape is None:
+
+            @pl.program
+            class Prog:
+                @pl.function(type=pl.FunctionType.InCore)
+                def kernel(
+                    self,
+                    x: pl.Tensor[[rows, k], pl.FP16],
+                    w: pl.Tensor[[k, cols], pl.FP16],
+                    out: pl.Out[pl.Tensor[acc_shape, pl.FP32]],
+                ) -> pl.Tensor[acc_shape, pl.FP32]:
+                    x_mat: pl.Tile[[rows, k], pl.FP16, pl.Mem.Mat] = pl.tile.load(
+                        x, [0, 0], [rows, k], target_memory=pl.Mem.Mat
+                    )
+                    a: pl.Tile[[rows, k], pl.FP16, pl.Mem.Left] = pl.tile.move(
+                        x_mat, target_memory=pl.Mem.Left
+                    )
+                    w_mat: pl.Tile[[k, cols], pl.FP16, pl.Mem.Mat] = pl.tile.load(
+                        w, [0, 0], [k, cols], target_memory=pl.Mem.Mat
+                    )
+                    b: pl.Tile[[k, cols], pl.FP16, pl.Mem.Right] = pl.tile.move(
+                        w_mat, target_memory=pl.Mem.Right
+                    )
+                    acc = pl.tile.create(acc_shape, pl.FP32, target_memory=pl.Mem.Acc)
+                    acc_win = pl.tile.slice(acc, slice_shape, offset)
+                    acc_new = pl.tile.matmul_acc(acc_win, a, b)
+                    out = pl.tile.store(acc_new, [0, 0], out)
+                    return out
+
+        else:
+
+            @pl.program
+            class Prog:
+                @pl.function(type=pl.FunctionType.InCore)
+                def kernel(
+                    self,
+                    x: pl.Tensor[[rows, k], pl.FP16],
+                    w: pl.Tensor[[k, cols], pl.FP16],
+                    out: pl.Out[pl.Tensor[acc_shape, pl.FP32]],
+                ) -> pl.Tensor[acc_shape, pl.FP32]:
+                    x_mat: pl.Tile[[rows, k], pl.FP16, pl.Mem.Mat] = pl.tile.load(
+                        x, [0, 0], [rows, k], target_memory=pl.Mem.Mat
+                    )
+                    a: pl.Tile[[rows, k], pl.FP16, pl.Mem.Left] = pl.tile.move(
+                        x_mat, target_memory=pl.Mem.Left
+                    )
+                    w_mat: pl.Tile[[k, cols], pl.FP16, pl.Mem.Mat] = pl.tile.load(
+                        w, [0, 0], [k, cols], target_memory=pl.Mem.Mat
+                    )
+                    b: pl.Tile[[k, cols], pl.FP16, pl.Mem.Right] = pl.tile.move(
+                        w_mat, target_memory=pl.Mem.Right
+                    )
+                    acc = pl.tile.create(acc_shape, pl.FP32, target_memory=pl.Mem.Acc)
+                    acc_win = pl.tile.slice(acc, slice_shape, offset, valid_shape)
+                    acc_new = pl.tile.matmul_acc(acc_win, a, b)
+                    out = pl.tile.store(acc_new, [0, 0], out)
+                    return out
 
         return Prog
 
@@ -1563,6 +1604,22 @@ class TestAccAccumulatorSliceContiguity:
         block column to mis-stride."""
         prog = self._kernel([32, 16], [16, 16], [16, 0])
         _run_pass(prog)
+
+    def test_narrow_window_straddling_two_blocks_rejected(self):
+        """Width alone does not make a window safe. A [16, 16] window at column
+        offset 8 covers columns 8-23, straddling two 16-column L0C blocks, so
+        the MAD's compact write still mis-strides the second one."""
+        prog = self._kernel([32, 32], [16, 16], [16, 8])
+        with pytest.raises(ValueError, match="not contiguous in L0C's block layout"):
+            _run_pass(prog)
+
+    def test_row_window_with_explicit_valid_shape_rejected(self):
+        """A slice carrying an explicit valid_shape is not rewrite-eligible, but
+        it reaches the MAD with the same broken stride, so the guard must still
+        see it."""
+        prog = self._kernel([32, 32], [16, 32], [16, 0], valid_shape=[16, 32])
+        with pytest.raises(ValueError, match="not contiguous in L0C's block layout"):
+            _run_pass(prog)
 
 
 if __name__ == "__main__":

--- a/tests/ut/ir/transforms/test_canonicalize_tile_slice.py
+++ b/tests/ut/ir/transforms/test_canonicalize_tile_slice.py
@@ -1501,5 +1501,69 @@ class TestNoOp:
         ir.assert_structural_equal(_run_pass(Before), Before)
 
 
+class TestAccAccumulatorSliceContiguity:
+    """A matmul accumulator that is a strided window of an Acc (L0C) tile is
+    rejected.
+
+    L0C is NZ with block ``(r_b, c_b)`` of an ``[M, N]`` tile at
+    ``(c_b * M/16 + r_b) * fractal``, so a window is contiguous only when it
+    spans the parent's full row extent or occupies a single 16-column block.
+    The MAD writes its destination compactly from a bare pointer and has no
+    destination stride, so a strided window silently miscompiles — only the
+    first 16 columns of each row tile land correctly.
+    """
+
+    def _kernel(self, acc_shape, slice_shape, offset):
+        """`acc[offset]` of shape `slice_shape` accumulates `a[M, K] @ b[K, N]`,
+        with M/N taken from `slice_shape` so the matmul's own shape check passes
+        and the contiguity guard is what decides the outcome."""
+        rows, cols = slice_shape
+        k = 64
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                x: pl.Tensor[[rows, k], pl.FP16],
+                w: pl.Tensor[[k, cols], pl.FP16],
+                out: pl.Out[pl.Tensor[acc_shape, pl.FP32]],
+            ) -> pl.Tensor[acc_shape, pl.FP32]:
+                x_mat: pl.Tile[[rows, k], pl.FP16, pl.Mem.Mat] = pl.tile.load(
+                    x, [0, 0], [rows, k], target_memory=pl.Mem.Mat
+                )
+                a: pl.Tile[[rows, k], pl.FP16, pl.Mem.Left] = pl.tile.move(x_mat, target_memory=pl.Mem.Left)
+                w_mat: pl.Tile[[k, cols], pl.FP16, pl.Mem.Mat] = pl.tile.load(
+                    w, [0, 0], [k, cols], target_memory=pl.Mem.Mat
+                )
+                b: pl.Tile[[k, cols], pl.FP16, pl.Mem.Right] = pl.tile.move(w_mat, target_memory=pl.Mem.Right)
+                acc = pl.tile.create(acc_shape, pl.FP32, target_memory=pl.Mem.Acc)
+                acc_win = pl.tile.slice(acc, slice_shape, offset)
+                acc_new = pl.tile.matmul_acc(acc_win, a, b)
+                out = pl.tile.store(acc_new, [0, 0], out)
+                return out
+
+        return Prog
+
+    def test_row_window_of_multi_block_column_acc_rejected(self):
+        """A [16, 32] row window of a [32, 32] Acc tile spans neither the full
+        row extent (16 != 32) nor a single block column (32 > 16)."""
+        prog = self._kernel([32, 32], [16, 32], [16, 0])
+        with pytest.raises(ValueError, match="not contiguous in L0C's block layout"):
+            _run_pass(prog)
+
+    def test_full_row_extent_window_accepted(self):
+        """A column window spans every row, so compact and parent strides
+        coincide and the discarded geometry does not matter."""
+        prog = self._kernel([16, 64], [16, 32], [0, 32])
+        _run_pass(prog)
+
+    def test_single_block_column_window_accepted(self):
+        """A 16-column window occupies one block column, so there is no second
+        block column to mis-stride."""
+        prog = self._kernel([32, 16], [16, 16], [16, 0])
+        _run_pass(prog)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Accumulating a matmul into a sub-slice of a shared `Acc` (L0C) accumulator did
not work. The matmul wrote a private L0C buffer instead of the destination
window, so the accumulator was never updated and the kernel silently produced
wrong results; the `pto.subview` naming the window was emitted but left dead.

This makes that shape work where the hardware can express it, and rejects it
where the hardware cannot. It also adds an `init_cond` predicate to
`matmul_acc`, so split-K no longer has to peel the first K step into a separate
`matmul` behind an `if`.

Nothing existing changes behaviour: `init_cond` defaults to `None`, which is
exactly today's lowering. One shape that used to compile now raises — a row
window of a multi-block-column `Acc` tile used as a matmul destination — because
it was silently miscompiling.

## Changes

- `src/codegen/pto/pto_codegen.cpp`: honour the op registry's declared
  `set_output_reuses_input` when deciding to alias a result to its in-place
  operand, so `tile.matmul_acc` writes the accumulator window's `pto.subview`
  rather than a private `pto.alloc_tile`. The new arm requires a shared memref
  *window* (not merely a shared base) and an identical `TileBufSignature`, so it
  cannot silently redirect a write or drop a differing tile config such as
  `tile.fillpad_inplace`'s `pad`.
- `src/backend/common/pto_ops_datamove.cpp`: elide a `tile.assemble` that copies
  a window back onto itself. Once the matmul writes in place, that assemble is an
  Acc→Acc `tmov`, which the memory graph cannot express.
- `tile.matmul_acc` / `tensor.matmul_acc`: new optional
  `init_cond` predicate. `matmul_acc(acc, a, b, init_cond=(k == 0))` overwrites
  the accumulator when the predicate holds and accumulates otherwise. A constant
  folds at codegen to the `pto.tmatmul` / `pto.tmatmul.acc` already emitted; only
  a dynamic predicate emits an `scf.if`. This mirrors the MAD's `cmatrixInitVal`
  bit, which is assembled into `Xt` at runtime, so a dynamic predicate costs
  scalar ALU ops rather than a branch. `init_cond=True` degenerates to
  "overwrite the destination", so no separate destination-passing `matmul_into`
  op is needed.
- `src/ir/transforms/canonicalize_tile_slice_pass.cpp`: reject a strided `Acc`
  row window used as a matmul destination. In L0C's NZ layout a window is
  contiguous only when it spans the parent's full row extent or occupies a single
  16-column block; otherwise the MAD writes every block column past the first
  into the wrong row tile. This is the column-major dual of the row-major
  contiguity rule this pass already owns for Vec slices (#2010). The diagnostic
  names the working spelling, which differs only by the sliced axis.

## Behaviour and follow-up

The rejection is a workaround for an upstream defect, not a property of the DSL.
A row window of an `Acc` tile is legitimate, and the IR expresses it correctly
the whole way down: ptoas resolves it to a parent-shaped handle narrowed by
`valid`, at the right byte offset. pto-isa then discards it — `TMATMUL_ACC_IMPL`
takes `m` from the *left* operand and forwards the destination as a bare
`.data()` pointer, so `TileRes::Rows`, the only carrier of the parent's
block-column stride, is never read.

Filed upstream as hw-native-sys/pto-isa#253. If pto-isa gains a destination
stride, this rejection should be relaxed or deleted rather than kept.

## Open questions

- **`init_cond` on `gemv_acc`.** Not implemented. `make_acc_codegen` backs both
  ops, and `DeduceTileGemvAccType` accepts exactly 3 arguments, so the helper now
  takes `supports_init_cond` explicitly rather than carrying a path GEMV cannot
  reach. Whether GEMV should gain the same predicate is a separate decision.
- **`system-tests-direct` (shard B).** Failing here, and failing identically on
  `main` at `488ba5d8` — same job, same step, `ACL_ERROR_RT_AICPU_EXCEPTION` on
  `chipId:5`, with failures spanning `test_log`, which involves no matmul, `Acc`,
  or slice. Believed pre-existing and unrelated to this branch, but flagged
  rather than assumed.

## Verification

All run on this branch rebased onto `upstream/main` (`ba15fd66`):

- `pre-commit run --all-files`: exit 0 — all 17 hooks pass
- `cmake --build build --parallel 2`: exit 0
- `python -m pytest tests/ut/ -n 2`: exit 0 — 9807 passed, 3 skipped

System tests (`tests/st/runtime/ops/test_matmul_acc_init_cond.py`, a2a3 device 0)
— 3 passed. These carry the numeric evidence the unit tests structurally cannot:
the accumulator is never zeroed, so a failure to select the overwriting form on
the first K step surfaces directly as stale L0C content.

- split-K with `init_cond=(k0 == 0)` at two shapes, vs `torch.matmul`
- column windows of one shared `Acc` tile, each running its own K reduction in
  place — covers the destination aliasing and `init_cond` together

Additional on-device checks (a2a3 / 910B1, device 0), against `torch.matmul`:

- column-slice accumulation into a `[16, 512]` `Acc` tile across 4 row tiles,
  K=4096 in 8 steps: correct
- the row-slice form that previously miscompiled (7930/8192 elements wrong) is
  now rejected at compile time with the diagnostic naming the column-slice
  spelling
- a row slice of the same `Acc` tile used as a `tile.store` source: still
  correct, confirming the guard is scoped to matmul destinations rather than to
  `Acc` row slices in general
