### PR TITLE
ci,docs: run the teaching examples, and verify the manual's first two pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -498,6 +498,21 @@ jobs:
           echo "=== examples/distributed/07_dynamic_rank_count.py -d 0,1,2,3 ==="
           python examples/distributed/07_dynamic_rank_count.py -p a2a3sim -d 0,1,2,3
 
+      # The teaching ladders. These carry the manual's beginner/intermediate/
+      # advanced/utils citations, so leaving them unrun let the pages point at
+      # code nothing checked — the gap that let a silent no-write kernel sit in
+      # the docs. They default to a2a3sim and need no arguments.
+      - name: Run the teaching examples on the simulator
+        run: |
+          source activate.sh
+          set -e
+          for ex in examples/beginner/*.py examples/intermediate/*.py \
+                    examples/advanced/*.py examples/utils/*.py; do
+            case "$ex" in */__init__.py) continue ;; esac
+            echo "=== $ex ==="
+            python "$ex"
+          done
+
       # The user manual's runnable blocks. Teaching code that is never executed
       # rots silently — a kernel can compile, run, write nothing, and still read
       # correctly on the page — so the manual itself is executed here.

--- a/docs/en/user/00-getting_started.md
+++ b/docs/en/user/00-getting_started.md
@@ -28,19 +28,47 @@ memory and returns a `DeviceTensor` handle that `CompiledProgram` accepts in
 place of a `torch.Tensor`. The runtime treats the buffer as already resident
 and skips both H2D and D2H copies for that argument.
 
+<!-- doctest: setup -->
 ```python
+import pypto.language as pl
 import torch
 from pypto import ir
 from pypto.runtime import ChipWorker, RunConfig
 
-compiled = ir.compile(MyKernel)
+ROWS, COLS = 128, 128
+PLATFORM = "__PLATFORM__"
 
-with ChipWorker(config=RunConfig(platform="a2a3sim")) as w:
-    weight = w.alloc_tensor((1024, 4096), torch.float16, init=host_weight)
-    for batch in batches:
-        out = torch.empty(batch.shape[0], 4096, dtype=torch.float16)
-        compiled(batch, weight, out)
-    w.free_tensor(weight)
+
+@pl.jit
+def add_kernel(a: pl.Tensor, b: pl.Tensor, out: pl.Out[pl.Tensor]):
+    with pl.at(level=pl.Level.CORE_GROUP):
+        ta = pl.load(a, [0, 0], [ROWS, COLS])
+        tb = pl.load(b, [0, 0], [ROWS, COLS])
+        pl.store(pl.add(ta, tb), [0, 0], out)
+    return out
+
+
+torch.manual_seed(0)
+A = torch.randn(ROWS, COLS, dtype=torch.float32)
+B = torch.randn(ROWS, COLS, dtype=torch.float32)
+
+# A DeviceTensor carries no shape/dtype for the @pl.jit specializer to read, so
+# the resident-weight pattern below runs a *compiled* program rather than the
+# jit entry directly.
+compiled = ir.compile(add_kernel.lower(A, B, torch.zeros(ROWS, COLS)), platform=PLATFORM)
+```
+
+<!-- doctest: run -->
+```python
+cfg = RunConfig(platform=PLATFORM)
+
+with ChipWorker(config=cfg) as w:
+    resident = w.alloc_tensor((ROWS, COLS), torch.float32, init=B)  # stays on device
+    for _ in range(3):                                              # three "batches"
+        out = torch.zeros(ROWS, COLS, dtype=torch.float32)
+        w.run(compiled, A, resident, out)
+        torch.testing.assert_close(out, A + B, rtol=1e-4, atol=1e-4)
+    w.free_tensor(resident)
 ```
 
 ### Caveats
@@ -61,13 +89,15 @@ worker hidden — library code that needs to pass the worker around, or a
 serving runtime that wants to pre-register many kernels, should drive
 dispatch explicitly:
 
+<!-- doctest: run -->
 ```python
-worker = ChipWorker(config=RunConfig(platform="a2a3sim"))
+worker = ChipWorker(config=RunConfig(platform=PLATFORM))
 try:
-    out = worker.run(compiled, a, b)                 # one-shot
     handle = worker.register(compiled)               # eager registration
-    for _ in range(1000):                            # hot loop, no cid lookup
-        handle(a, b, out)
+    out = torch.zeros(ROWS, COLS, dtype=torch.float32)
+    for _ in range(3):                               # hot loop, no cid lookup
+        handle(A, B, out)
+    torch.testing.assert_close(out, A + B, rtol=1e-4, atol=1e-4)
 finally:
     worker.close()                                   # cids + DeviceTensors released
 ```

--- a/docs/en/user/02-quickstart.md
+++ b/docs/en/user/02-quickstart.md
@@ -34,9 +34,20 @@ import torch
 
 ## Quickstart: element-wise add
 
+<!-- doctest: setup -->
 ```python
 import pypto.language as pl
+import torch
+from pypto.runtime import RunConfig
 
+CFG = RunConfig(platform="__PLATFORM__")
+torch.manual_seed(0)
+A = torch.randn(128, 128, dtype=torch.float32)
+B = torch.randn(128, 128, dtype=torch.float32)
+```
+
+<!-- doctest: run -->
+```python
 @pl.jit
 def add(
     a: pl.Tensor[[128, 128], pl.FP32],
@@ -47,8 +58,13 @@ def add(
         out[:] = pl.add(a, b)
     return out
 
+
 compiled = add.compile()
 print(f"Generated code in: {compiled.output_dir}")
+
+out = torch.zeros(128, 128, dtype=torch.float32)
+add(A, B, out, config=CFG)
+torch.testing.assert_close(out, A + B, rtol=1e-4, atol=1e-4)
 ```
 
 | Line | What it does |
@@ -82,6 +98,7 @@ after. Every tensor parameter has a direction — `In` by default, or an explici
 Intermediate values are ordinary Python names. They need no annotation, and no buffer is
 declared for them — the compiler allocates whatever the chain requires:
 
+<!-- doctest: run -->
 ```python
 @pl.jit
 def add_then_square(
@@ -93,6 +110,11 @@ def add_then_square(
         s = pl.add(a, b)
         out[:] = pl.mul(s, s)
     return out
+
+
+out = torch.zeros(128, 128, dtype=torch.float32)
+add_then_square(A, B, out, config=CFG)
+torch.testing.assert_close(out, (A + B) * (A + B), rtol=1e-4, atol=1e-4)
 ```
 
 Write shapes and dtypes inline in the annotations. A module-level alias

--- a/docs/zh/user/00-getting_started.md
+++ b/docs/zh/user/00-getting_started.md
@@ -23,19 +23,47 @@
 一个 `DeviceTensor` 句柄；`CompiledProgram` 接受它替代 `torch.Tensor` 入参。runtime
 把这块 buffer 视为已经驻留在 device 上，对该入参跳过 H2D 与 D2H 拷贝。
 
+<!-- doctest: setup -->
 ```python
+import pypto.language as pl
 import torch
 from pypto import ir
 from pypto.runtime import ChipWorker, RunConfig
 
-compiled = ir.compile(MyKernel)
+ROWS, COLS = 128, 128
+PLATFORM = "__PLATFORM__"
 
-with ChipWorker(config=RunConfig(platform="a2a3sim")) as w:
-    weight = w.alloc_tensor((1024, 4096), torch.float16, init=host_weight)
-    for batch in batches:
-        out = torch.empty(batch.shape[0], 4096, dtype=torch.float16)
-        compiled(batch, weight, out)
-    w.free_tensor(weight)
+
+@pl.jit
+def add_kernel(a: pl.Tensor, b: pl.Tensor, out: pl.Out[pl.Tensor]):
+    with pl.at(level=pl.Level.CORE_GROUP):
+        ta = pl.load(a, [0, 0], [ROWS, COLS])
+        tb = pl.load(b, [0, 0], [ROWS, COLS])
+        pl.store(pl.add(ta, tb), [0, 0], out)
+    return out
+
+
+torch.manual_seed(0)
+A = torch.randn(ROWS, COLS, dtype=torch.float32)
+B = torch.randn(ROWS, COLS, dtype=torch.float32)
+
+# A DeviceTensor carries no shape/dtype for the @pl.jit specializer to read, so
+# the resident-weight pattern below runs a *compiled* program rather than the
+# jit entry directly.
+compiled = ir.compile(add_kernel.lower(A, B, torch.zeros(ROWS, COLS)), platform=PLATFORM)
+```
+
+<!-- doctest: run -->
+```python
+cfg = RunConfig(platform=PLATFORM)
+
+with ChipWorker(config=cfg) as w:
+    resident = w.alloc_tensor((ROWS, COLS), torch.float32, init=B)  # stays on device
+    for _ in range(3):                                              # three "batches"
+        out = torch.zeros(ROWS, COLS, dtype=torch.float32)
+        w.run(compiled, A, resident, out)
+        torch.testing.assert_close(out, A + B, rtol=1e-4, atol=1e-4)
+    w.free_tensor(resident)
 ```
 
 ### 注意事项
@@ -53,15 +81,17 @@ with ChipWorker(config=RunConfig(platform="a2a3sim")) as w:
 对象本身被藏起来了 —— 库代码需要把 worker 传来传去，或者常驻服务想预注册多个 kernel
 时，应该显式地驱动 dispatch：
 
+<!-- doctest: run -->
 ```python
-worker = ChipWorker(config=RunConfig(platform="a2a3sim"))
+worker = ChipWorker(config=RunConfig(platform=PLATFORM))
 try:
-    out = worker.run(compiled, a, b)                 # 单次
-    handle = worker.register(compiled)               # 预注册
-    for _ in range(1000):                            # 热循环，无 cid lookup
-        handle(a, b, out)
+    handle = worker.register(compiled)               # eager registration
+    out = torch.zeros(ROWS, COLS, dtype=torch.float32)
+    for _ in range(3):                               # hot loop, no cid lookup
+        handle(A, B, out)
+    torch.testing.assert_close(out, A + B, rtol=1e-4, atol=1e-4)
 finally:
-    worker.close()                                   # cid + DeviceTensor 统一释放
+    worker.close()                                   # cids + DeviceTensors released
 ```
 
 `worker.register(compiled)` 立即触发 `compile_and_assemble` + simpler `register`，

--- a/docs/zh/user/02-quickstart.md
+++ b/docs/zh/user/02-quickstart.md
@@ -29,9 +29,20 @@ import torch
 
 ## Quickstart：逐元素加法
 
+<!-- doctest: setup -->
 ```python
 import pypto.language as pl
+import torch
+from pypto.runtime import RunConfig
 
+CFG = RunConfig(platform="__PLATFORM__")
+torch.manual_seed(0)
+A = torch.randn(128, 128, dtype=torch.float32)
+B = torch.randn(128, 128, dtype=torch.float32)
+```
+
+<!-- doctest: run -->
+```python
 @pl.jit
 def add(
     a: pl.Tensor[[128, 128], pl.FP32],
@@ -42,8 +53,13 @@ def add(
         out[:] = pl.add(a, b)
     return out
 
+
 compiled = add.compile()
 print(f"Generated code in: {compiled.output_dir}")
+
+out = torch.zeros(128, 128, dtype=torch.float32)
+add(A, B, out, config=CFG)
+torch.testing.assert_close(out, A + B, rtol=1e-4, atol=1e-4)
 ```
 
 | 行 | 作用 |
@@ -75,6 +91,7 @@ print(f"Generated code in: {compiled.output_dir}")
 中间值就是普通的 Python 名字。它们不需要标注，也不需要为它们声明缓冲区 —— 这条链需要什么，
 编译器就分配什么：
 
+<!-- doctest: run -->
 ```python
 @pl.jit
 def add_then_square(
@@ -86,6 +103,11 @@ def add_then_square(
         s = pl.add(a, b)
         out[:] = pl.mul(s, s)
     return out
+
+
+out = torch.zeros(128, 128, dtype=torch.float32)
+add_then_square(A, B, out, config=CFG)
+torch.testing.assert_close(out, (A + B) * (A + B), rtol=1e-4, atol=1e-4)
 ```
 
 形状与 dtype 要**内联写在标注里**。模块级别名（`T = pl.Tensor[[128, 128], pl.FP32]`）**不行**：


### PR DESCRIPTION
Follow-up to #2394, which introduced the runnable-doc-block gate for the Performance chapter. A survey of the rest of the manual turned up two gaps, both the same shape — **teaching code that nothing executes**.

## 1. Only `examples/distributed` was run by CI

| Directory | Files | Was CI-run |
| --------- | ----- | ---------- |
| `distributed` | 7 | yes |
| `beginner` / `intermediate` / `advanced` / `utils` | 20 | **no** |
| `models` | 9 | **no** |

Everything the Tutorials chapter cites sits in that unrun set, so those pages could point at code that had stopped working and nothing would say so. This is the same gap that let a silent no-write kernel sit in the docs.

**All 20 were run on the simulator before wiring them up, and all 20 pass** — so the new step locks in a state that is good today rather than importing a backlog of failures.

## 2. The two highest-traffic pages had zero verified code

`00-getting_started.md` and `02-quickstart.md` carry 24 python blocks between them and not one was checked. Three blocks on each are now runnable and asserted.

Converting the residency example surfaced a constraint worth stating outright: **a `DeviceTensor` carries no shape/dtype for the `@pl.jit` specializer**, so that pattern has to dispatch a *compiled* program rather than the jit entry —

```
ValueError: @pl.jit: missing inferred tensor metadata for parameter 'b'
```

The page said `ir.compile(MyKernel)` and then dispatched through the kernel. It now compiles once in setup and explains why.

## `examples/models` is deliberately not wired up

Re-checked against the pinned pto-isa (`f51c92f6`), which is now fetchable here:

| Example | Old result | With the pinned pto-isa |
| ------- | ---------- | ----------------------- |
| `06_paged_attention_dynamic` | FAIL (`TFillPadMode`) | **PASS** |
| `07_paged_attention_multi_config` | FAIL (`template argument 1 is invalid`) | **PASS** |
| `09_paged_attention_spmd` | FAIL | PASS on 2 of 3 runs |

So two of the three were the environment, as suspected. The third is not: it fails
intermittently with `507018` (`ACL_ERROR_RT_AICPU_EXCEPTION`) and passed on both retries.
Wiring a flaky example into a required job would make the job flaky, so `models` stays out
until that one is understood — the rest of the directory is healthy.

## Verification

- **17 runnable doc blocks across the manual, all passing** on `a2a3sim` (13 from #2394 plus 6 here).
- `--check-parity` clean: every zh block byte-identical to its en counterpart.
- All 20 teaching examples pass on the simulator.
- `check_docs_en_zh_parity`, `check_docs_nav`, `check_english_only`, `check_docs_symbol_coverage`, markdownlint (296 files).

## Still uncovered

`language/00-types`, `language/04-scopes` and `tasks/03-tuning` have several blocks each, no runnable ones, and cite no examples at all — the remaining pure gaps, left for a follow-up.
