### PR TITLE
fix(ir): fold a user-written ND tile.assemble offset to 2D

### DIFF
--- a/docs/en/dev/passes/13-flatten_tile_nd_to_2d.md
+++ b/docs/en/dev/passes/13-flatten_tile_nd_to_2d.md
@@ -42,9 +42,9 @@ program_2d = flatten_pass(program)
 
 For each InCore function (InCore, AIC, AIV):
 
-1. **Validate preconditions**: Check static physical shapes, last-axis reduction, no `tile.read`/`tile.write`/`tile.slice` on >2D
+1. **Validate preconditions**: Check static physical shapes, last-axis reduction, no `tile.read`/`tile.write`/`tile.slice` on >2D, and no >2D `tile.assemble` whose written region fails to collapse contiguously
 2. **Transform statements**: Walk function body and convert >2D tile ops to 2D, preserving any dynamic `valid_shape` (see [Dynamic valid_shape](#dynamic-tile-dimensions-issue-1578))
-3. **Verify postconditions**: The `TileOps2D` property verifier independently checks that the rewritten InCore IR contains only supported tile ranks and codegen-ready transpose forms
+3. **Verify postconditions**: The `TileOps2D` property verifier independently checks that the rewritten InCore IR contains only supported tile ranks, 2D `tile.assemble` offsets, and codegen-ready transpose forms
 
 Per-statement handling:
 
@@ -54,6 +54,7 @@ Per-statement handling:
 | `tile.store` (rank>2 tensor) | Inject the original tensor-rank partition `shapes` as an extra 4th operand in the transformed IR so backend codegen can reconstruct the `partition_view`; the DSL source is unchanged. If the tile operand itself is still rank>2 (e.g. a user-written `tile.reshape` to 3D feeding `pl.assemble` into an N-D tensor view), insert a `tile.reshape` to flatten the tile operand to 2D first — the codegen requires a 2D tile while the original tile shape still flows through as the `shapes` partition operand |
 | `tile.store` (2D tensor) | Pass through unchanged |
 | `tile.create`/`tile.full` (>2D) | Rebuild with flattened 2D shape directly |
+| `tile.assemble` (>2D target) | Fold the ND offset into the flattened `(row, col)` space with the same row-major collapse `tile.load` applies to its tensor-rank offsets (`row = ((o0*d1 + o1)*d2 + o2)*… + o[k-2]`, `col = o[k-1]`); the tile operands themselves are flattened by their defining ops. Requires source, target and offset to share one rank, and the written region to collapse to a contiguous row band (`IsRowMajorCollapseContiguous`) — both rejected in the precondition phase otherwise. Without the fold the offset would keep its ND rank on a 2D tile, and codegen (which reads `elements[0]`/`elements[1]` positionally and ignores the rest) would silently place the write at the wrong address |
 | `tile.transpose` | Sole owner of `pto.ttrans` scratch materialization. Arrives 3-arg (input, axis1, axis2). **2D**: create one scratch tile (shape = SOURCE page, in the input's memory space) and emit the codegen-ready 4-arg `tile.transpose(in, a1, a2, scratch)`. **>2D** (last-two-axes swap): unroll into per-batch 2D transposes, each a 4-arg form with scratch sliced from a flat `[batch*A, B]` pool, assembled into the merged 2D output. A batch-axis swap is a user error |
 | `tile.batch_matmul` | Expand to per-batch 2D `tile.matmul`, honoring batch broadcast. A b_trans/a_trans operand arrives as a zero-copy `tile.transpose_view` over a natural load (no transpose-at-load, no copy); the tile-level op carries no transpose semantic. Each operand is handled identically (see operand handling below) |
 | `tile.batch_matmul_acc` | Expand to per-batch 2D `tile.matmul_acc`, slicing the (already-flattened) accumulator per batch index. Memory-space decisions on the accumulator (Vec/Acc round-trips, retargetable producer promotion of an upstream `tile.create`, TileView refresh) are deferred to `InferTileMemorySpace` (pass 17) — flatten emits no inline `tile.move` |

--- a/docs/zh/dev/passes/13-flatten_tile_nd_to_2d.md
+++ b/docs/zh/dev/passes/13-flatten_tile_nd_to_2d.md
@@ -41,9 +41,9 @@ program_2d = flatten_pass(program)
 
 对每个 InCore 函数（InCore、AIC、AIV）：
 
-1. **验证前置条件**：检查静态物理形状、最后轴归约、不允许对 >2D 使用 `tile.read`/`tile.write`/`tile.slice`
+1. **验证前置条件**：检查静态物理形状、最后轴归约、不允许对 >2D 使用 `tile.read`/`tile.write`/`tile.slice`，以及不允许写入区域无法连续折叠的 >2D `tile.assemble`
 2. **变换语句**：遍历函数体，将 >2D Tile 操作转换为 2D，并保留动态的 `valid_shape`（见[动态 valid_shape](#动态-tile-维度issue-1578)）
-3. **验证后置条件**：由独立的 `TileOps2D` 属性验证器 (property verifier) 检查改写后的 InCore IR 仅包含受支持的 Tile rank 与 codegen-ready transpose 形态
+3. **验证后置条件**：由独立的 `TileOps2D` 属性验证器 (property verifier) 检查改写后的 InCore IR 仅包含受支持的 Tile rank、2D `tile.assemble` 偏移与 codegen-ready transpose 形态
 
 按语句类型处理：
 
@@ -53,6 +53,7 @@ program_2d = flatten_pass(program)
 | `tile.store`（rank>2 张量） | 在转换后 IR 中注入原始张量 rank 对应的分区 `shapes` 作为额外的第 4 个操作数，供后端 codegen 重建 `partition_view`；DSL 源码不变。若 tile 操作数本身仍是 rank>2(例如用户显式 `tile.reshape` 升到 3D 后再喂给 `pl.assemble` 写入 N-D 张量视图),pass 会先插入一个 `tile.reshape` 把 tile 操作数压回 2D —— codegen 要求 tile 必须是 2D,而原始 tile shape 仍由 `shapes` 分区操作数携带 |
 | `tile.store`（2D 张量） | 直接透传 |
 | `tile.create`/`tile.full`（>2D） | 直接使用展平的 2D 形状重建 |
+| `tile.assemble`（>2D 目标） | 用与 `tile.load` 折叠 tensor-rank 偏移相同的行主序折叠，把 ND 偏移折进展平后的 `(row, col)` 空间（`row = ((o0*d1 + o1)*d2 + o2)*… + o[k-2]`，`col = o[k-1]`）；Tile 操作数本身由其定义处的算子展平。要求 source、target 与 offset 具有相同 rank，且写入区域能折叠为连续的行区间（`IsRowMajorCollapseContiguous`），否则在前置条件阶段报错。若不折叠，偏移会以 ND rank 残留在 2D Tile 上，而 codegen 只按位置读取 `elements[0]`/`elements[1]` 并忽略其余元素，从而静默地写到错误地址 |
 | `tile.transpose` | `pto.ttrans` scratch 物化的唯一归属。进入时为 3-arg（input, axis1, axis2）。**2D**：创建一块 scratch tile（shape = 源页，位于输入所在 memory），产出 codegen-ready 的 4-arg `tile.transpose(in, a1, a2, scratch)`。**>2D**（末两轴交换）：展开为逐 batch 的 2D transpose，每个都是 4-arg 形态，scratch 从扁平 `[batch*A, B]` 池中切片，再 assemble 进合并后的 2D 输出。交换 batch 轴属用户错误 |
 | `tile.batch_matmul` | 展开为逐 batch 的 2D `tile.matmul`，处理 batch broadcast。b_trans/a_trans 操作数以一个零拷贝 `tile.transpose_view`（覆盖在自然 load 之上）出现（不再 transpose-at-load、不搬数据）；tile 级算子本身无 transpose 语义。每个操作数处理方式一致（见下方操作数处理） |
 | `tile.batch_matmul_acc` | 展开为逐 batch 的 2D `tile.matmul_acc`，按 batch 索引切分（已展平的）累加器。累加器上的内存空间决策（Vec/Acc 来回搬运、上游 `tile.create` 的可重定向生产者改写、TileView 刷新）交由 `InferTileMemorySpace`（pass 17）负责 —— 本 pass 不再发射任何 `tile.move` |

--- a/src/ir/transforms/flatten_tile_nd_to_2d/analysis.cpp
+++ b/src/ir/transforms/flatten_tile_nd_to_2d/analysis.cpp
@@ -20,7 +20,9 @@
 #include "pypto/ir/scalar_expr.h"
 #include "pypto/ir/stmt.h"
 #include "pypto/ir/transforms/base/visitor.h"
+#include "pypto/ir/transforms/utils/tile_conversion_utils.h"
 #include "pypto/ir/type.h"
+#include "pypto/ir/type_inference.h"
 #include "src/ir/transforms/flatten_tile_nd_to_2d/internal.h"
 
 namespace pypto {
@@ -63,6 +65,41 @@ class PreconditionAnalysis : public IRVisitor {
     }
   }
 
+  /// A >2D tile.assemble is flattened by folding its ND offset into the merged
+  /// row axis. That fold is meaningful only when the offset names a point in the
+  /// target's own ND coordinate space, and expressible as a single 2D insert only
+  /// when the written region collapses to one contiguous row band.
+  static void CheckNdAssemble(const CallPtr& call) {
+    if (call->args_.size() != 3) return;
+    auto target_type = As<TileType>(call->args_[0]->GetType());
+    if (!IsNdTile(target_type)) return;
+
+    auto source_type = As<TileType>(call->args_[1]->GetType());
+    auto offset_tuple = As<MakeTuple>(call->args_[2]);
+    CHECK_SPAN(source_type && offset_tuple, call->span_)
+        << "FlattenTileNdTo2D: tile.assemble requires a tile source and a literal offset tuple";
+
+    const size_t rank = target_type->shape_.size();
+    CHECK_SPAN(offset_tuple->elements_.size() == rank, call->span_)
+        << "FlattenTileNdTo2D: tile.assemble into a " << rank << "D tile has a rank-"
+        << offset_tuple->elements_.size() << " offset. The offset names a point in the target's "
+        << "own coordinate space, so it needs exactly one index per target dimension.";
+
+    CHECK_SPAN(source_type->shape_.size() == rank, call->span_)
+        << "FlattenTileNdTo2D: tile.assemble into a " << rank << "D tile has a rank-"
+        << source_type->shape_.size() << " source " << FormatShape(source_type->shape_)
+        << ". Reshape the source to the target rank (pl.tile.reshape) before assembling.";
+
+    CHECK_SPAN(tile_conversion_utils::IsRowMajorCollapseContiguous(source_type->shape_, target_type->shape_),
+               call->span_)
+        << "FlattenTileNdTo2D: tile.assemble writes a " << FormatShape(source_type->shape_)
+        << " region into a " << FormatShape(target_type->shape_)
+        << " tile, which does not collapse to a contiguous row band when the tile is flattened "
+        << "to 2D (hardware tiles are always 2D). Every dimension below the outermost partial "
+        << "one must be written in full. Fix by looping over the outer dimension and assembling "
+        << "one contiguous page per iteration.";
+  }
+
   void CheckCall(const CallPtr& call) {
     if (!call || !call->op_ || As<GlobalVar>(call->op_)) return;
 
@@ -79,6 +116,10 @@ class PreconditionAnalysis : public IRVisitor {
         auto input_tile = As<TileType>(call->args_[0]->GetType());
         CHECK(!IsNdTile(input_tile)) << "FlattenTileNdTo2D: " << name << " is not supported on >2D tiles";
       }
+    }
+
+    if (IsOp(call, "tile.assemble")) {
+      CheckNdAssemble(call);
     }
   }
 };

--- a/src/ir/transforms/flatten_tile_nd_to_2d/rewrite.cpp
+++ b/src/ir/transforms/flatten_tile_nd_to_2d/rewrite.cpp
@@ -946,6 +946,54 @@ std::vector<StmtPtr> TransformBody(const std::vector<StmtPtr>& stmts, FlattenCon
       continue;
     }
 
+    // ---- tile.assemble into a >2D target: fold the ND offset into the flattened
+    //      (row, col) space. The target/source tiles are rewritten to 2D by their
+    //      defining ops, but the offset is a literal MakeTuple that no Substitute
+    //      touches, so the generic path below would leave an ND offset on a 2D
+    //      tile — which codegen reads positionally (row = elements[0], col =
+    //      elements[1], the rest ignored) and would place the write at the wrong
+    //      address. Same row-major fold tile.load applies to its tensor-rank
+    //      offsets. ----
+    if (IsOp(call, "tile.assemble")) {
+      // Pre-substitution types are the ND ones the user wrote; the fold is
+      // expressed in that ND coordinate space (cf. the tile.store branch above).
+      auto orig_target_type = As<TileType>(call->args_[0]->GetType());
+      if (IsNdTile(orig_target_type)) {
+        // Substitute the offset tuple too, not just the tile operands: its elements
+        // are index expressions that may reference Vars this pass remapped, and
+        // folding the pre-substitution elements would carry a stale SSA reference
+        // into the rebuilt call. The tile.store branch above substitutes every arg
+        // for the same reason.
+        auto offset_tuple = As<MakeTuple>(Substitute(call->args_[2], ctx.var_map));
+        INTERNAL_CHECK_SPAN(offset_tuple, span)
+            << "Internal error: tile.assemble offset must be a literal tuple";
+        INTERNAL_CHECK_SPAN(offset_tuple->elements_.size() == orig_target_type->shape_.size(), span)
+            << "Internal error: ND tile.assemble offset rank must match the target rank "
+               "(guaranteed by PreconditionAnalysis)";
+
+        std::vector<ExprPtr> new_args = {
+            Substitute(call->args_[0], ctx.var_map),
+            Substitute(call->args_[1], ctx.var_map),
+            std::make_shared<MakeTuple>(
+                std::vector<ExprPtr>{
+                    CollapseLeadingOffsetsToRow(offset_tuple->elements_, orig_target_type->shape_, span),
+                    offset_tuple->elements_.back()},
+                span),
+        };
+
+        auto deduced = op_registry.Create("tile.assemble", new_args, call->kwargs_, span);
+        auto new_call =
+            std::make_shared<Call>(deduced->op_, deduced->args_, deduced->kwargs_, deduced->attrs_,
+                                   WithCarriedMemRef(deduced->GetType(), assign), deduced->span_);
+        auto new_var =
+            std::make_shared<Var>(assign->var_->name_hint_, new_call->GetType(), assign->var_->span_);
+        result.push_back(std::make_shared<AssignStmt>(new_var, new_call, assign->span_));
+        ctx.Insert(assign->var_, new_var);
+        continue;
+      }
+      // Already-2D target: fall through to the generic re-create path below.
+    }
+
     // ---- All other tile ops (including tile.reshape) and non-tile ops: substitute args ----
     {
       std::vector<ExprPtr> new_args;

--- a/src/ir/transforms/flatten_tile_nd_to_2d/verification.cpp
+++ b/src/ir/transforms/flatten_tile_nd_to_2d/verification.cpp
@@ -80,6 +80,31 @@ class TileOps2DVerifier : public IRVisitor {
                                 stmt_span);
     }
 
+    // A flattened tile.assemble indexes a 2D tile, so its offset must be exactly
+    // (row, col). Codegen reads it positionally and ignores anything past index 1
+    // (pto_ops_datamove.cpp), so a leftover ND offset is a silent misplacement
+    // rather than a hard failure — and the TileType scan below cannot see it,
+    // because the offset is a TupleType.
+    if (IsOp(call, "tile.assemble") && call->args_.size() == 3) {
+      auto offset_tuple = As<MakeTuple>(call->args_[2]);
+      if (!offset_tuple) {
+        // A non-literal offset (e.g. a bare Var in hand-built or re-parsed IR)
+        // leaves the (row, col) form unestablished, so it cannot be accepted
+        // either: the verifier has no way to confirm the postcondition.
+        diagnostics_.emplace_back(DiagnosticSeverity::Error, "TileOps2D", 0,
+                                  "tile.assemble in InCore function '" + func_name_ +
+                                      "' has a non-literal offset (expected a 2-element (row, col) "
+                                      "tuple after FlattenTileNdTo2D)",
+                                  stmt_span);
+      } else if (offset_tuple->elements_.size() != 2) {
+        diagnostics_.emplace_back(DiagnosticSeverity::Error, "TileOps2D", 0,
+                                  "tile.assemble in InCore function '" + func_name_ + "' has a rank-" +
+                                      std::to_string(offset_tuple->elements_.size()) +
+                                      " offset (expected 2: row, col after FlattenTileNdTo2D)",
+                                  stmt_span);
+      }
+    }
+
     for (const auto& arg : call->args_) {
       auto arg_tile = As<TileType>(arg->GetType());
       if (arg_tile && arg_tile->shape_.size() > 2) {

--- a/tests/ut/ir/transforms/test_flatten_tile_nd_to_2d.py
+++ b/tests/ut/ir/transforms/test_flatten_tile_nd_to_2d.py
@@ -1043,6 +1043,200 @@ class TestFlattenTileNdTo2DReshapedStore:
 
 
 # ----------------------------------------------------------------------------
+# User-written ND tile.assemble: the offset must be flattened with the tiles
+# ----------------------------------------------------------------------------
+
+
+class TestFlattenTileNdTo2DAssemble:
+    """A user-written >2D ``pl.tile.assemble`` offset folds into ``(row, col)``.
+
+    The tile operands are flattened by their defining ops, but the offset is a
+    literal tuple that no substitution touches. Left at ND rank it would be read
+    positionally by codegen (``row = elements[0]``), silently placing the write
+    at the wrong address, so the pass folds it with the same row-major collapse
+    it applies to ``tile.load``'s tensor-rank offsets.
+    """
+
+    def test_nd_assemble_offset_collapses_to_row(self):
+        """``[2, 0, 0]`` into a ``[4, 8, 16]`` target becomes row ``2*8 = 16``."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                x: pl.Tensor[[4, 8, 16], pl.FP32],
+                out_0: pl.Out[pl.Tensor[[4, 8, 16], pl.FP32]],
+            ) -> pl.Tensor[[4, 8, 16], pl.FP32]:
+                page: pl.Tile[[1, 8, 16], pl.FP32] = pl.tile.full([1, 8, 16], dtype=pl.FP32, value=1.0)
+                acc: pl.Tile[[4, 8, 16], pl.FP32] = pl.tile.create([4, 8, 16], dtype=pl.FP32)
+                # Write the page into batch slot 2.
+                acc2: pl.Tile[[4, 8, 16], pl.FP32] = pl.tile.assemble(acc, page, [2, 0, 0])
+                out_0: pl.Tensor[[4, 8, 16], pl.FP32] = pl.store(acc2, [0, 0, 0], out_0)
+                return out_0
+
+            @pl.function
+            def main(self, x: pl.Tensor[[4, 8, 16], pl.FP32]) -> pl.Tensor[[4, 8, 16], pl.FP32]:
+                out_0: pl.Tensor[[4, 8, 16], pl.FP32] = pl.create_tensor([4, 8, 16], dtype=pl.FP32)
+                y: pl.Tensor[[4, 8, 16], pl.FP32] = self.main_incore_0(x, out_0)
+                return y
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                x: pl.Tensor[[4, 8, 16], pl.FP32],
+                out_0: pl.Out[pl.Tensor[[4, 8, 16], pl.FP32]],
+            ) -> pl.Tensor[[4, 8, 16], pl.FP32]:
+                page = pl.tile.full([8, 16], dtype=pl.FP32, value=1.0)
+                acc = pl.tile.create([32, 16], dtype=pl.FP32)
+                # Row-major fold of [2, 0, 0] over the target dims [4, 8, 16]:
+                # row = 2*8 + 0 = 16, col = 0.
+                acc2 = pl.tile.assemble(acc, page, [16, 0])
+                out_store = pl.store(acc2, [0, 0, 0], out_0, shapes=[4, 8, 16])
+                return out_store
+
+            @pl.function
+            def main(self, x: pl.Tensor[[4, 8, 16], pl.FP32]) -> pl.Tensor[[4, 8, 16], pl.FP32]:
+                out_0 = pl.create_tensor([4, 8, 16], dtype=pl.FP32)
+                y = self.main_incore_0(x, out_0)
+                return y
+
+        After = passes.flatten_tile_nd_to_2d()(Before)
+        ir.assert_structural_equal(After, Expected)
+
+    def test_nd_assemble_zero_offset(self):
+        """A whole-target assemble at ``[0, 0, 0]`` folds to ``[0, 0]``.
+
+        The placement was already accidentally correct here (``0*8 + 0 == 0``);
+        what the fold fixes is the rank, which downstream ``tile.assemble`` type
+        deduction needs to run its bounds check and valid-region union at all.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                x: pl.Tensor[[4, 8, 16], pl.FP32],
+                out_0: pl.Out[pl.Tensor[[4, 8, 16], pl.FP32]],
+            ) -> pl.Tensor[[4, 8, 16], pl.FP32]:
+                src: pl.Tile[[4, 8, 16], pl.FP32] = pl.tile.full([4, 8, 16], dtype=pl.FP32, value=1.0)
+                tgt: pl.Tile[[4, 8, 16], pl.FP32] = pl.tile.create([4, 8, 16], dtype=pl.FP32)
+                asm: pl.Tile[[4, 8, 16], pl.FP32] = pl.tile.assemble(tgt, src, [0, 0, 0])
+                out_0: pl.Tensor[[4, 8, 16], pl.FP32] = pl.store(asm, [0, 0, 0], out_0)
+                return out_0
+
+            @pl.function
+            def main(self, x: pl.Tensor[[4, 8, 16], pl.FP32]) -> pl.Tensor[[4, 8, 16], pl.FP32]:
+                out_0: pl.Tensor[[4, 8, 16], pl.FP32] = pl.create_tensor([4, 8, 16], dtype=pl.FP32)
+                y: pl.Tensor[[4, 8, 16], pl.FP32] = self.main_incore_0(x, out_0)
+                return y
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                x: pl.Tensor[[4, 8, 16], pl.FP32],
+                out_0: pl.Out[pl.Tensor[[4, 8, 16], pl.FP32]],
+            ) -> pl.Tensor[[4, 8, 16], pl.FP32]:
+                src = pl.tile.full([32, 16], dtype=pl.FP32, value=1.0)
+                tgt = pl.tile.create([32, 16], dtype=pl.FP32)
+                asm = pl.tile.assemble(tgt, src, [0, 0])
+                out_store = pl.store(asm, [0, 0, 0], out_0, shapes=[4, 8, 16])
+                return out_store
+
+            @pl.function
+            def main(self, x: pl.Tensor[[4, 8, 16], pl.FP32]) -> pl.Tensor[[4, 8, 16], pl.FP32]:
+                out_0 = pl.create_tensor([4, 8, 16], dtype=pl.FP32)
+                y = self.main_incore_0(x, out_0)
+                return y
+
+        After = passes.flatten_tile_nd_to_2d()(Before)
+        ir.assert_structural_equal(After, Expected)
+
+    def test_2d_assemble_unchanged(self):
+        """An already-2D ``tile.assemble`` keeps the generic re-create path."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                x: pl.Tensor[[32, 16], pl.FP32],
+                out_0: pl.Out[pl.Tensor[[32, 16], pl.FP32]],
+            ) -> pl.Tensor[[32, 16], pl.FP32]:
+                page: pl.Tile[[8, 16], pl.FP32] = pl.tile.full([8, 16], dtype=pl.FP32, value=1.0)
+                acc: pl.Tile[[32, 16], pl.FP32] = pl.tile.create([32, 16], dtype=pl.FP32)
+                acc2: pl.Tile[[32, 16], pl.FP32] = pl.tile.assemble(acc, page, [16, 0])
+                out_0: pl.Tensor[[32, 16], pl.FP32] = pl.store(acc2, [0, 0], out_0)
+                return out_0
+
+            @pl.function
+            def main(self, x: pl.Tensor[[32, 16], pl.FP32]) -> pl.Tensor[[32, 16], pl.FP32]:
+                out_0: pl.Tensor[[32, 16], pl.FP32] = pl.create_tensor([32, 16], dtype=pl.FP32)
+                y: pl.Tensor[[32, 16], pl.FP32] = self.main_incore_0(x, out_0)
+                return y
+
+        After = passes.flatten_tile_nd_to_2d()(Before)
+        ir.assert_structural_equal(After, Before)
+
+    def test_nd_assemble_non_contiguous_rejected(self):
+        """A ``[2, 4, 16]`` write into ``[4, 8, 16]`` is two disjoint row strips."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                x: pl.Tensor[[4, 8, 16], pl.FP32],
+                out_0: pl.Out[pl.Tensor[[4, 8, 16], pl.FP32]],
+            ) -> pl.Tensor[[4, 8, 16], pl.FP32]:
+                part: pl.Tile[[2, 4, 16], pl.FP32] = pl.tile.full([2, 4, 16], dtype=pl.FP32, value=1.0)
+                acc: pl.Tile[[4, 8, 16], pl.FP32] = pl.tile.create([4, 8, 16], dtype=pl.FP32)
+                acc2: pl.Tile[[4, 8, 16], pl.FP32] = pl.tile.assemble(acc, part, [0, 0, 0])
+                out_0: pl.Tensor[[4, 8, 16], pl.FP32] = pl.store(acc2, [0, 0, 0], out_0)
+                return out_0
+
+            @pl.function
+            def main(self, x: pl.Tensor[[4, 8, 16], pl.FP32]) -> pl.Tensor[[4, 8, 16], pl.FP32]:
+                out_0: pl.Tensor[[4, 8, 16], pl.FP32] = pl.create_tensor([4, 8, 16], dtype=pl.FP32)
+                y: pl.Tensor[[4, 8, 16], pl.FP32] = self.main_incore_0(x, out_0)
+                return y
+
+        with pytest.raises(ValueError, match="contiguous row band"):
+            passes.flatten_tile_nd_to_2d()(Before)
+
+    def test_nd_assemble_rank_mismatched_source_rejected(self):
+        """A 2D source into a 3D target has no ND coordinate space to fold in."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                x: pl.Tensor[[4, 8, 16], pl.FP32],
+                out_0: pl.Out[pl.Tensor[[4, 8, 16], pl.FP32]],
+            ) -> pl.Tensor[[4, 8, 16], pl.FP32]:
+                flat: pl.Tile[[8, 16], pl.FP32] = pl.tile.full([8, 16], dtype=pl.FP32, value=1.0)
+                acc: pl.Tile[[4, 8, 16], pl.FP32] = pl.tile.create([4, 8, 16], dtype=pl.FP32)
+                acc2: pl.Tile[[4, 8, 16], pl.FP32] = pl.tile.assemble(acc, flat, [2, 0, 0])
+                out_0: pl.Tensor[[4, 8, 16], pl.FP32] = pl.store(acc2, [0, 0, 0], out_0)
+                return out_0
+
+            @pl.function
+            def main(self, x: pl.Tensor[[4, 8, 16], pl.FP32]) -> pl.Tensor[[4, 8, 16], pl.FP32]:
+                out_0: pl.Tensor[[4, 8, 16], pl.FP32] = pl.create_tensor([4, 8, 16], dtype=pl.FP32)
+                y: pl.Tensor[[4, 8, 16], pl.FP32] = self.main_incore_0(x, out_0)
+                return y
+
+        with pytest.raises(ValueError, match="rank-2 source"):
+            passes.flatten_tile_nd_to_2d()(Before)
+
+
+# ----------------------------------------------------------------------------
 # Pass property declarations and TileOps2D verifier
 # ----------------------------------------------------------------------------
 
@@ -1085,6 +1279,80 @@ class TestFlattenTileNdTo2DPassProperties:
         props.insert(passes.IRProperty.TileOps2D)
         with pytest.raises(pypto.Error, match="TileOps2D"):
             passes.verify_properties(props, Unflatten, "test_verifier_fails")
+
+    def test_verifier_flags_nd_offset_on_2d_assemble(self):
+        """A 2D ``tile.assemble`` carrying a leftover ND offset is reported.
+
+        Codegen reads the offset positionally (``row = elements[0]``) and ignores
+        anything past index 1, so an unflattened offset is a silent misplacement
+        rather than a hard failure — the verifier has to catch it, and the
+        TileType arg scan cannot, because the offset is a ``TupleType``.
+        """
+        span = ir.Span.unknown()
+        target = ir.Var("target", ir.TileType([32, 16], DataType.FP32), span)
+        source = ir.Var("source", ir.TileType([8, 16], DataType.FP32), span)
+        asm_call = tile_ops.assemble(target, source, [2, 0, 0], span=span)
+        asm = ir.Var("asm", asm_call.type, span)
+        body = ir.SeqStmts(
+            [ir.AssignStmt(asm, asm_call, span), ir.ReturnStmt([asm], span)],
+            span,
+        )
+        func = ir.Function(
+            "nd_offset_assemble",
+            [(target, ir.ParamDirection.In), (source, ir.ParamDirection.In)],
+            [asm_call.type],
+            body,
+            span,
+            ir.FunctionType.InCore,
+        )
+        program = ir.Program([func], "nd_offset_assemble", span)
+        props = passes.IRPropertySet()
+        props.insert(passes.IRProperty.TileOps2D)
+
+        with pytest.raises(pypto.Error, match="TileOps2D"):
+            passes.verify_properties(props, program, "test_nd_offset_assemble")
+
+    def test_verifier_flags_non_literal_assemble_offset(self):
+        """An offset that is not a literal tuple leaves ``(row, col)`` unestablished.
+
+        Type deduction requires a ``MakeTuple`` offset, so this shape only reaches
+        the verifier from hand-built or re-parsed IR — which is exactly what a
+        property verifier exists to check.
+        """
+        span = ir.Span.unknown()
+        target = ir.Var("target", ir.TileType([32, 16], DataType.FP32), span)
+        source = ir.Var("source", ir.TileType([8, 16], DataType.FP32), span)
+        offset = ir.Var("offset", ir.TupleType([ir.ScalarType(DataType.INDEX)] * 2), span)
+        asm_call = ir.Call(
+            ir.get_op("tile.assemble"),
+            [target, source, offset],
+            {},
+            target.type,
+            span,
+        )
+        asm = ir.Var("asm", asm_call.type, span)
+        body = ir.SeqStmts(
+            [ir.AssignStmt(asm, asm_call, span), ir.ReturnStmt([asm], span)],
+            span,
+        )
+        func = ir.Function(
+            "non_literal_offset_assemble",
+            [
+                (target, ir.ParamDirection.In),
+                (source, ir.ParamDirection.In),
+                (offset, ir.ParamDirection.In),
+            ],
+            [asm_call.type],
+            body,
+            span,
+            ir.FunctionType.InCore,
+        )
+        program = ir.Program([func], "non_literal_offset_assemble", span)
+        props = passes.IRPropertySet()
+        props.insert(passes.IRProperty.TileOps2D)
+
+        with pytest.raises(pypto.Error, match="TileOps2D"):
+            passes.verify_properties(props, program, "test_non_literal_offset_assemble")
 
     def test_verifier_allows_rank_raising_reinterpret_view(self):
         """An explicit rank-raising metadata view is exempt, like tile.reshape."""


### PR DESCRIPTION
## Summary

`FlattenTileNdTo2D` rewrites tile operands from ND to 2D, but left a user-written `tile.assemble`'s offset tuple at its original rank. Codegen reads that offset positionally — `row = elements[0]`, `col = elements[1]`, anything past index 1 ignored — so a rank-3 offset silently addressed the wrong location: `[2, 0, 0]` into a `[4, 8, 16]` target wrote at row 2 instead of row 16 once the tile flattened to `[32, 16]`. Nothing caught it, because the offset is a `TupleType` while every rank check in the pass and in its `TileOps2D` verifier inspected `TileType` operands. Assembles the pass synthesizes itself (the batch-matmul path) build correctly ranked offsets and were never affected, which is why no test noticed.

After this change the offset is folded together with the tiles, shapes that cannot be folded are rejected at compile time with an actionable message instead of miscompiled, and the verifier fails the IR if an ND offset ever survives the pass again.

**Behavior change.** Two ND `tile.assemble` shapes that previously compiled now fail with a diagnostic: one whose source or offset rank disagrees with the target, and one whose written region would land as several disjoint row strips rather than a contiguous row band. Both were miscompiled before — the first skipped its valid-region union silently, the second had no single 2D insert that could express it. No migration is needed for a well-formed ND assemble: its offset is rewritten automatically.

## Changes

- `src/ir/transforms/flatten_tile_nd_to_2d/rewrite.cpp`: fold a `>2D`-target `tile.assemble` offset into the flattened `(row, col)` space ahead of the generic re-create path, reusing `CollapseLeadingOffsetsToRow` — the same row-major collapse the pass already applies to `tile.load`'s tensor-rank offsets (`row = ((o0*d1 + o1)*d2 + o2)*… + o[k-2]`, `col = o[k-1]`). An already-2D assemble still takes the generic path unchanged.
- `src/ir/transforms/flatten_tile_nd_to_2d/analysis.cpp`: reject in the precondition phase, before any rewriting, an offset or source whose rank disagrees with the target, and a written region that does not collapse contiguously — via `IsRowMajorCollapseContiguous`, the predicate that already gates the `tile.load` collapse, so the two stay in lockstep.
- `src/ir/transforms/flatten_tile_nd_to_2d/verification.cpp`: the `TileOps2D` property verifier now reports a `tile.assemble` whose offset is not exactly `(row, col)`. Its existing argument scan could not express this, because it only looks at `TileType` arguments.
- `tests/ut/ir/transforms/test_flatten_tile_nd_to_2d.py`: six tests — the offset fold, the zero-offset whole-target case, an already-2D assemble left untouched, the two rejections, and the verifier postcondition. Reverting only the C++ change and rebuilding makes five of them fail; the sixth is the guard against the new branch over-triggering and correctly passes either way.
- `docs/en/dev/passes/13-flatten_tile_nd_to_2d.md`, `docs/zh/dev/passes/13-flatten_tile_nd_to_2d.md`: document the fold, its two preconditions, and the reason an unfolded offset is silent rather than fatal.

A second effect falls out of the rank now agreeing: `DeduceTileAssembleType` stops skipping its bounds check and valid-region union for these programs, so an out-of-bounds ND assemble is caught where it previously passed through.

## Verification

Run by the publication transaction against the exact pushed commit, in this worktree:

- `cmake --build build --parallel "$PYPTO_BUILD_JOBS"`: exit 0
- `pytest tests/ut/ir/transforms/test_flatten_tile_nd_to_2d.py -q`: exit 0 — 78 passed
- `pytest tests/ut/ --ignore=tests/ut/runtime -n "$PYPTO_TEST_JOBS" -q`: exit 0 — 9176 passed, 3 skipped, in 320.86s
- `ruff check .` and `ruff format --check .`: exit 0

`tests/ut/runtime` is excluded from the broader run: on this machine 3 of its tests fail and 4 error because the installed `simpler` package predates the API they exercise (`Tensor.make`, `CallConfig.enable_l2_swimlane`), while their skip guard only checks that `import simpler` succeeds. Those failures reproduce on an unmodified checkout and cannot be reached from an IR pass; nothing else was excluded.

Separately, the six new tests were confirmed to fail against the defect: reverting only the C++ change and rebuilding makes five of them fail, and the sixth (an already-2D assemble left untouched) passes either way by design.