### PR TITLE
feat(compile): select the target Simpler runtime ABI at compile time

### DIFF
--- a/docs/en/dev/codegen/00-pto_codegen.md
+++ b/docs/en/dev/codegen/00-pto_codegen.md
@@ -713,8 +713,25 @@ The orchestration codegen generates identical orchestration C++ code using the P
 
 | Key | When emitted | Notes |
 | --- | ------------ | ----- |
-| `runtime` | Always | Currently `"tensormap_and_ringbuffer"`. |
+| `runtime` | Always | `"tensormap_and_ringbuffer"` (default) or `"host_build_graph"` — the wire name of the `RuntimeKind` selected by `ir.compile(runtime=...)`, or by wrapping the call in `PassContext([], runtime=...)`. |
 | `aicpu_thread_num` | Always (`0`) | `0` selects the runtime's architecture default (a2a3: 4; a5: 5); callers may explicitly override it. |
+
+The runtime is carried by `PassContext` as an `ir::RuntimeKind`, not by a
+codegen-only argument, so passes that must legalize IR for a specific runtime
+switch on `PassContext::GetRuntime()` rather than comparing strings. It is an
+enum rather than a name because the set is closed — one enumerator per
+implementation under `runtime/src/<arch>/runtime/` — so a typo is a compile
+error instead of a value that surfaces much later as an opaque CCEC error about
+a nonexistent include directory.
+
+The wire name crosses the ABI boundary in exactly one place each way:
+`ir::RuntimeKindToName` when writing `kernel_config.py`, and
+`ir::RuntimeKindFromName` when reading one back. Both are re-exported to Python
+as `passes.runtime_kind_to_name` / `passes.runtime_kind_from_name`.
+
+The runtime is also part of the `@pl.jit` cache key, so a `host_build_graph`
+call cannot reuse an artifact compiled for `tensormap_and_ringbuffer`, whose
+`kernel_config.py` names a runtime no matching worker would bind.
 
 ### Argument Unpacking
 

--- a/docs/zh/dev/codegen/00-pto_codegen.md
+++ b/docs/zh/dev/codegen/00-pto_codegen.md
@@ -685,8 +685,22 @@ output_dir/
 
 | 键 | 何时写入 | 备注 |
 | -- | -------- | ---- |
-| `runtime` | 总是 | 目前为 `"tensormap_and_ringbuffer"`。 |
+| `runtime` | 总是 | `"tensormap_and_ringbuffer"`（默认）或 `"host_build_graph"` —— 由 `ir.compile(runtime=...)`（或把调用包在 `PassContext([], runtime=...)` 中）选定的 `RuntimeKind` 所对应的线上名字。 |
 | `aicpu_thread_num` | 总是 (`0`) | `0` 选择 runtime 的架构默认值（a2a3：4；a5：5），调用方也可显式覆盖。 |
+
+runtime 由 `PassContext` 以 `ir::RuntimeKind` 携带，而不是仅作为 codegen 参数，
+这样需要针对特定 runtime 做合法化的 pass 可以 switch `PassContext::GetRuntime()`
+而不是比较字符串。之所以用枚举而非名字：这是一个封闭集合 —— `runtime/src/<arch>/
+runtime/` 下每个实现对应一个枚举值 —— 于是拼错是编译错误，而不是一个要到很晚才以
+晦涩 CCEC 报错（找不到 include 目录）浮现的取值。
+
+线上名字只在两处跨越 ABI 边界：写 `kernel_config.py` 时用 `ir::RuntimeKindToName`，
+读回时用 `ir::RuntimeKindFromName`。两者都以
+`passes.runtime_kind_to_name` / `passes.runtime_kind_from_name` 暴露给 Python。
+
+runtime 同时是 `@pl.jit` 缓存键的一个维度：`host_build_graph` 的调用不能复用为
+`tensormap_and_ringbuffer` 编译出的产物 —— 后者 `kernel_config.py` 里写的
+runtime 没有任何匹配的 worker 会绑定。
 
 ### 参数解包
 

--- a/include/pypto/ir/transforms/pass_context.h
+++ b/include/pypto/ir/transforms/pass_context.h
@@ -12,6 +12,7 @@
 #ifndef PYPTO_IR_TRANSFORMS_PASS_CONTEXT_H_
 #define PYPTO_IR_TRANSFORMS_PASS_CONTEXT_H_
 
+#include <cstdint>
 #include <functional>
 #include <memory>
 #include <string>
@@ -234,6 +235,48 @@ enum class MemoryPlanner {
   DsaRP = 2,  ///< In-tree DSA with automatically recognized reuse penalties.
 };
 
+/**
+ * @brief Which Simpler runtime ABI a compilation targets.
+ *
+ * The two runtimes differ in where the task graph is built, which is what
+ * decides whether an orchestration fragment can be recorded and replayed at
+ * all. Closed set: each enumerator corresponds to one implementation under
+ * `runtime/src/<arch>/runtime/`, and a pass that must legalize IR for a
+ * particular runtime switches on this rather than comparing strings.
+ */
+enum class RuntimeKind : uint8_t {
+  /// Task graph built on the AICPU, dependencies auto-derived through the
+  /// TensorMap. The production runtime, and the default.
+  TensorMapAndRingBuffer = 0,
+  /// Host CPU builds the whole task graph up front, which is what makes Graph
+  /// Execution (record once, replay) possible.
+  HostBuildGraph = 1,
+};
+
+inline constexpr RuntimeKind kDefaultRuntimeKind = RuntimeKind::TensorMapAndRingBuffer;
+
+/**
+ * @brief Wire name for a runtime kind.
+ *
+ * This is the value written to `RUNTIME_CONFIG["runtime"]` in the generated
+ * `kernel_config.py`, the value `CompiledProgram.runtime_name` reports, and the
+ * name used verbatim as a filesystem path component when compiling kernels — so
+ * it is spelled out here rather than derived from the enumerator name.
+ *
+ * @param kind The runtime kind
+ * @return Wire name, e.g. "host_build_graph"
+ */
+[[nodiscard]] std::string RuntimeKindToName(RuntimeKind kind);
+
+/**
+ * @brief Parse a wire name back into a runtime kind.
+ *
+ * @param name Wire name as it appears in `RUNTIME_CONFIG["runtime"]`
+ * @return The matching kind
+ * @throws pypto::ValueError if the name is not one PyPTO can compile for
+ */
+[[nodiscard]] RuntimeKind RuntimeKindFromName(const std::string& name);
+
 class PassContext {
  public:
   /**
@@ -256,13 +299,17 @@ class PassContext {
    *        dbC=2 automatically. When true, AutoTileMatmulL0 may emit two co-live
    *        L0C accumulators and the legacy PyPTO allocator preserves the
    *        ping-pong where capacity permits.
+   * @param runtime Which Simpler runtime ABI to target (default:
+   *        TensorMapAndRingBuffer). Passes that must legalize IR for a specific
+   *        runtime switch on this rather than inspecting codegen options.
    */
   explicit PassContext(std::vector<PassInstrumentPtr> instruments,
                        VerificationLevel verification_level = VerificationLevel::Basic,
                        DiagnosticPhase diagnostic_phase = DiagnosticPhase::PrePipeline,
                        DiagnosticCheckSet disabled_diagnostics = {DiagnosticCheck::UnusedControlFlowResult},
                        MemoryPlanner memory_planner = MemoryPlanner::PyPTO,
-                       bool enable_pypto_l0c_double_buffer = false);
+                       bool enable_pypto_l0c_double_buffer = false,
+                       RuntimeKind runtime = kDefaultRuntimeKind);
 
   /**
    * @brief Push this context onto the thread-local stack
@@ -328,6 +375,13 @@ class PassContext {
   [[nodiscard]] bool GetEnablePyptoL0cDoubleBuffer() const;
 
   /**
+   * @brief Get the target Simpler runtime ABI for this context.
+   *
+   * Passes gate runtime-specific legalization on this value.
+   */
+  [[nodiscard]] RuntimeKind GetRuntime() const;
+
+  /**
    * @brief Get the currently active context (top of thread-local stack)
    * @return Pointer to current context, or nullptr if none
    */
@@ -353,6 +407,7 @@ class PassContext {
   DiagnosticCheckSet disabled_diagnostics_;
   MemoryPlanner memory_planner_;
   bool enable_pypto_l0c_double_buffer_;
+  RuntimeKind runtime_;
   PassContext* previous_;
 
   static thread_local PassContext* current_;

--- a/python/bindings/modules/passes.cpp
+++ b/python/bindings/modules/passes.cpp
@@ -173,6 +173,18 @@ void BindPass(nb::module_& m) {
       .value("PTOAS", MemoryPlanner::PtoAS,
              "Skip pypto allocation passes; ptoas PlanMemory allocates (--pto-level=level2)");
 
+  nb::enum_<RuntimeKind>(passes, "RuntimeKind", "Which Simpler runtime ABI a compilation targets")
+      .value("TENSORMAP_AND_RINGBUFFER", RuntimeKind::TensorMapAndRingBuffer,
+             "Task graph built on the AICPU, dependencies auto-derived through the TensorMap "
+             "(default)")
+      .value("HOST_BUILD_GRAPH", RuntimeKind::HostBuildGraph,
+             "Host CPU builds the whole task graph up front; required for Graph Execution");
+
+  passes.def("runtime_kind_to_name", &RuntimeKindToName, nb::arg("kind"),
+             "Wire name written to RUNTIME_CONFIG[\"runtime\"], e.g. \"host_build_graph\"");
+  passes.def("runtime_kind_from_name", &RuntimeKindFromName, nb::arg("name"),
+             "Parse a RUNTIME_CONFIG[\"runtime\"] wire name back into a RuntimeKind");
+
   // Bind DiagnosticPhase enum
   nb::enum_<DiagnosticPhase>(passes, "DiagnosticPhase",
                              "Controls when DiagnosticInstrument runs registered checks "
@@ -290,15 +302,16 @@ void BindPass(nb::module_& m) {
                           "verification and the diagnostic channel (warnings + performance\n"
                           "hints) for PassPipeline.")
       .def(nb::init<std::vector<PassInstrumentPtr>, VerificationLevel, DiagnosticPhase, DiagnosticCheckSet,
-                    MemoryPlanner, bool>(),
+                    MemoryPlanner, bool, RuntimeKind>(),
            nb::arg("instruments"), nb::arg("verification_level") = VerificationLevel::Basic,
            nb::arg("diagnostic_phase") = DiagnosticPhase::PrePipeline,
            nb::arg("disabled_diagnostics") = DiagnosticCheckSet{DiagnosticCheck::UnusedControlFlowResult},
            nb::arg("memory_planner") = MemoryPlanner::PyPTO,
-           nb::arg("enable_pypto_l0c_double_buffer") = false,
+           nb::arg("enable_pypto_l0c_double_buffer") = false, nb::arg("runtime") = kDefaultRuntimeKind,
            "Create a PassContext with instruments, verification level, diagnostic phase gate, "
-           "optional disabled diagnostic checks, memory planner selection, and the experimental "
-           "legacy-PyPTO chooser-emitted L0C double-buffer (dbC=2) opt-in")
+           "optional disabled diagnostic checks, memory planner selection, the experimental "
+           "legacy-PyPTO chooser-emitted L0C double-buffer (dbC=2) opt-in, and the target Simpler "
+           "runtime ABI")
       .def("__enter__",
            [](PassContext& self) -> PassContext& {
              self.EnterContext();
@@ -317,6 +330,7 @@ void BindPass(nb::module_& m) {
       .def("get_enable_pypto_l0c_double_buffer", &PassContext::GetEnablePyptoL0cDoubleBuffer,
            "Whether chooser-emitted L0C double-buffering (dbC=2) is enabled under the legacy PyPTO "
            "memory planner")
+      .def("get_runtime", &PassContext::GetRuntime, "Get the target Simpler runtime ABI for this context")
       .def_static("current", &PassContext::Current, nb::rv_policy::reference,
                   "Get the currently active context, or None if no context is active");
 

--- a/python/pypto/backend/pto_backend.py
+++ b/python/pypto/backend/pto_backend.py
@@ -938,6 +938,7 @@ def _generate_config_file(
     func_name_to_external_source: dict[str, str] | None = None,
     func_name_to_external_include_dirs: dict[str, tuple[str, ...]] | None = None,
     enable_sdma: bool = False,
+    runtime: _passes.RuntimeKind = _passes.RuntimeKind.TENSORMAP_AND_RINGBUFFER,
 ) -> str:
     """Generate kernel_config.py content.
 
@@ -966,7 +967,13 @@ def _generate_config_file(
 
     ``enable_sdma`` records that at least one emitted kernel consumes the
     runtime-owned SDMA workspace.
+
+    ``runtime`` selects the Simpler runtime ABI. Its wire name is written to
+    ``RUNTIME_CONFIG["runtime"]`` — the value ``CompiledProgram.runtime_name``
+    reports and the one the ``ChipWorker`` reuse lookup matches against, so a
+    program compiled for one runtime never binds to a worker running another.
     """
+    runtime_name = _passes.runtime_kind_to_name(runtime)
     func_name_to_signature = func_name_to_signature or {}
     func_name_to_external_source = func_name_to_external_source or {}
     func_name_to_external_include_dirs = func_name_to_external_include_dirs or {}
@@ -975,7 +982,7 @@ def _generate_config_file(
 
     runtime_lines = [
         "RUNTIME_CONFIG = {",
-        '\t"runtime": "tensormap_and_ringbuffer",',
+        f'\t"runtime": "{runtime_name}",',
         '\t"aicpu_thread_num": 0,',
     ]
     if enable_sdma:
@@ -994,7 +1001,7 @@ def _generate_config_file(
 
     lines = [
         *header,
-        "# Runtime configuration for tensormap_and_ringbuffer.",
+        f"# Runtime configuration for {runtime_name}.",
         "# AICPU thread count 0 selects the runtime's architecture default (a2a3: 4; a5: 5).",
         *runtime_lines,
         "ORCHESTRATION = {",
@@ -1479,6 +1486,7 @@ def generate(
     memory_planner: _passes.MemoryPlanner | None = None,
     emit_source_loc: bool | None = None,
     dump_ptoas_passes: bool = False,
+    runtime: _passes.RuntimeKind | None = None,
 ) -> dict[str, str]:
     """Generate all PTO backend output files (kernels + orchestration + config).
 
@@ -1504,6 +1512,9 @@ def generate(
         dump_ptoas_passes: When True, dump full-module IR after every ptoas pass
             under ``<output_dir>/ptoas_passes/<codegen-unit>/``. Has no effect
             when ``skip_ptoas=True``.
+        runtime: Simpler runtime ABI to target; its wire name is written to
+            ``RUNTIME_CONFIG["runtime"]`` in the generated ``kernel_config.py``.
+            None uses ``RuntimeKind.TENSORMAP_AND_RINGBUFFER``.
 
     Returns:
         Dict mapping relative file paths to their content.
@@ -1512,6 +1523,8 @@ def generate(
         memory_planner = _passes.MemoryPlanner.PYPTO
     if emit_source_loc is None:
         emit_source_loc = emit_source_loc_default()
+    if runtime is None:
+        runtime = _passes.RuntimeKind.TENSORMAP_AND_RINGBUFFER
 
     # Check for distributed functions (level >= HOST = Linqu level 3)
     has_distributed = any(
@@ -1527,6 +1540,7 @@ def generate(
             memory_planner=memory_planner,
             emit_source_loc=emit_source_loc,
             dump_ptoas_passes=dump_ptoas_passes,
+            runtime=runtime,
         )
 
     # L2-only program with multiple Orchestrations: emit each as a
@@ -1541,6 +1555,7 @@ def generate(
             memory_planner=memory_planner,
             emit_source_loc=emit_source_loc,
             dump_ptoas_passes=dump_ptoas_passes,
+            runtime=runtime,
         )
 
     return _generate_single_chip(
@@ -1550,6 +1565,7 @@ def generate(
         memory_planner=memory_planner,
         emit_source_loc=emit_source_loc,
         dump_ptoas_passes=dump_ptoas_passes,
+        runtime=runtime,
     )
 
 
@@ -1561,6 +1577,7 @@ def _generate_with_distributed(
     memory_planner: _passes.MemoryPlanner = _passes.MemoryPlanner.PYPTO,
     emit_source_loc: bool = True,
     dump_ptoas_passes: bool = False,
+    runtime: _passes.RuntimeKind = _passes.RuntimeKind.TENSORMAP_AND_RINGBUFFER,
 ) -> dict[str, str]:
     """Generate artifacts for a distributed (L3+) program.
 
@@ -1579,7 +1596,7 @@ def _generate_with_distributed(
     cg = _codegen_core.DistributedCodegen()
     orch_code = cg.generate(transformed_program)
     result_files["orchestration/host_orch.py"] = orch_code
-    result_files.update(_materialize_builtin_next_levels(cg.get_builtin_next_level_specs()))
+    result_files.update(_materialize_builtin_next_levels(cg.get_builtin_next_level_specs(), runtime))
 
     # 2. Each chip-level Orchestration → next_levels/{name}/...
     for func in transformed_program.functions.values():
@@ -1594,6 +1611,7 @@ def _generate_with_distributed(
                 memory_planner=memory_planner,
                 emit_source_loc=emit_source_loc,
                 dump_ptoas_passes=dump_ptoas_passes,
+                runtime=runtime,
             )
             for path, content in chip_files.items():
                 result_files[f"next_levels/{func.name}/{path}"] = content
@@ -1652,8 +1670,16 @@ def _builtin_template_output_path(template_name: str, variables: dict[str, str])
     return template_name
 
 
-def _materialize_builtin_next_levels(specs: list[Any]) -> dict[str, str]:
-    """Render builtin chip-callable templates into the distributed ``next_levels`` layout."""
+def _materialize_builtin_next_levels(
+    specs: list[Any], runtime: _passes.RuntimeKind = _passes.RuntimeKind.TENSORMAP_AND_RINGBUFFER
+) -> dict[str, str]:
+    """Render builtin chip-callable templates into the distributed ``next_levels`` layout.
+
+    ``runtime`` must match the one every other chip sub-build was compiled for:
+    ``_assemble_chip_callables`` rejects a ``next_levels/`` tree whose members
+    disagree, since all chip-level tasks in one distributed build share a
+    single runtime.
+    """
     result_files: dict[str, str] = {}
     for spec in specs:
         template_root = _resolve_builtin_template_dir(spec.template_dir)
@@ -1666,6 +1692,7 @@ def _materialize_builtin_next_levels(specs: list[Any]) -> dict[str, str]:
             "entry": spec.entry_symbol,
             "kernel_name": spec.entry_symbol + "_kernel",
             "template_package": spec.template_dir[1:],
+            "runtime": _passes.runtime_kind_to_name(runtime),
         }
         variables.update(spec.template_vars)
         for template in sorted(templates_dir.iterdir(), key=lambda item: item.name):
@@ -1785,6 +1812,7 @@ def _generate_multi_chip(
     memory_planner: _passes.MemoryPlanner = _passes.MemoryPlanner.PYPTO,
     emit_source_loc: bool = True,
     dump_ptoas_passes: bool = False,
+    runtime: _passes.RuntimeKind = _passes.RuntimeKind.TENSORMAP_AND_RINGBUFFER,
 ) -> dict[str, str]:
     """Generate artifacts for an L2-only program with multiple Orchestrations.
 
@@ -1809,6 +1837,7 @@ def _generate_multi_chip(
             memory_planner=memory_planner,
             emit_source_loc=emit_source_loc,
             dump_ptoas_passes=dump_ptoas_passes,
+            runtime=runtime,
         )
         for path, content in chip_files.items():
             result_files[f"next_levels/{func.name}/{path}"] = content
@@ -1823,6 +1852,7 @@ def _generate_single_chip(
     memory_planner: _passes.MemoryPlanner = _passes.MemoryPlanner.PYPTO,
     emit_source_loc: bool = True,
     dump_ptoas_passes: bool = False,
+    runtime: _passes.RuntimeKind = _passes.RuntimeKind.TENSORMAP_AND_RINGBUFFER,
 ) -> dict[str, str]:
     """Generate artifacts for a single-chip (L0-L2) program.
 
@@ -1971,6 +2001,7 @@ def _generate_single_chip(
                     func_name_to_external_source,
                     func_name_to_external_include_dirs,
                     enable_sdma=any(_uses_sdma_workspace(func) for func in emitted_incore_funcs),
+                    runtime=runtime,
                 )
         except Exception as e:
             logger.error("Failed to generate orchestration '%s': %s", orch_func.name, e)

--- a/python/pypto/ir/compile.py
+++ b/python/pypto/ir/compile.py
@@ -57,6 +57,7 @@ class _PassPipelineResult(NamedTuple):
     transformed_program: _ir_core.Program
     memory_planner: _passes.MemoryPlanner
     backend_type: BackendType
+    runtime: _passes.RuntimeKind
 
 
 def _select_backend(*, backend_type: BackendType, platform: str | None) -> BackendType:
@@ -72,6 +73,7 @@ def _validate_pass_context_conflicts(
     verification_level: _passes.VerificationLevel | None,
     diagnostic_phase: _passes.DiagnosticPhase | None,
     memory_planner: _passes.MemoryPlanner | None,
+    runtime: _passes.RuntimeKind | None = None,
 ) -> _passes.PassContext | None:
     """Reject explicit pass settings that conflict with an active context."""
     outer = _passes.PassContext.current()
@@ -90,6 +92,11 @@ def _validate_pass_context_conflicts(
             f"{operation}() was called with memory_planner while a PassContext is already active. "
             "Set the memory planner on the existing PassContext instead."
         )
+    if runtime is not None and outer is not None:
+        raise RuntimeError(
+            f"{operation}() was called with runtime while a PassContext is already active. "
+            "Set the runtime on the existing PassContext instead."
+        )
     return outer
 
 
@@ -105,6 +112,7 @@ def _run_pass_pipeline(  # noqa: PLR0913
     disabled_diagnostics: _passes.DiagnosticCheckSet | None = None,
     memory_planner: _passes.MemoryPlanner | None = None,
     enable_pypto_l0c_double_buffer: bool | None = None,
+    runtime: _passes.RuntimeKind | None = None,
     analyze_auto_scopes_for_deps: bool = False,
     extra_instruments: tuple[_passes.PassInstrument, ...] = (),
     inherit_outer_report_instruments: bool = True,
@@ -118,6 +126,7 @@ def _run_pass_pipeline(  # noqa: PLR0913
         verification_level=verification_level,
         diagnostic_phase=diagnostic_phase,
         memory_planner=memory_planner,
+        runtime=runtime,
     )
 
     default_disabled = _passes.DiagnosticCheckSet()
@@ -142,6 +151,7 @@ def _run_pass_pipeline(  # noqa: PLR0913
             if enable_pypto_l0c_double_buffer is not None
             else outer.get_enable_pypto_l0c_double_buffer()
         )
+        rt = runtime if runtime is not None else outer.get_runtime()
     else:
         instruments = list(extra_instruments)
         vlevel = (
@@ -151,7 +161,8 @@ def _run_pass_pipeline(  # noqa: PLR0913
         disabled = disabled_diagnostics if disabled_diagnostics is not None else default_disabled
         mplan = memory_planner if memory_planner is not None else _passes.MemoryPlanner.PYPTO
         dbc_flag = enable_pypto_l0c_double_buffer if enable_pypto_l0c_double_buffer is not None else False
-    ctx = _passes.PassContext(instruments, vlevel, dphase, disabled, mplan, dbc_flag)
+        rt = runtime if runtime is not None else _passes.RuntimeKind.TENSORMAP_AND_RINGBUFFER
+    ctx = _passes.PassContext(instruments, vlevel, dphase, disabled, mplan, dbc_flag, rt)
 
     if mplan == _passes.MemoryPlanner.PTOAS:
         logger.warning(
@@ -177,7 +188,7 @@ def _run_pass_pipeline(  # noqa: PLR0913
                 output_dir=passes_dump_dir,
             )
 
-    return _PassPipelineResult(transformed_program, mplan, effective_backend_type)
+    return _PassPipelineResult(transformed_program, mplan, effective_backend_type, rt)
 
 
 def compile(  # noqa: PLR0913
@@ -198,6 +209,9 @@ def compile(  # noqa: PLR0913
     analyze_auto_scopes_for_deps: bool = False,
     emit_source_loc: bool | None = None,
     dump_ptoas_passes: bool = False,
+    # Appended, not inserted: every parameter above is positional, so slotting a
+    # new one in the middle would silently rebind existing positional callers.
+    runtime: _passes.RuntimeKind | None = None,
 ) -> "CompiledProgram | DistributedCompiledProgram":
     """Compile a Program through passes and codegen.
 
@@ -274,6 +288,15 @@ def compile(  # noqa: PLR0913
             behavior unless explicitly enabled. User-written manual scopes are
             skipped: they do not get compiler deps or automatic
             NoDep/OutputExisting direction rewrites.
+        runtime: Simpler runtime ABI to target.
+            ``RuntimeKind.TENSORMAP_AND_RINGBUFFER`` (default) builds the task
+            graph on the AICPU and derives dependencies through the TensorMap;
+            ``RuntimeKind.HOST_BUILD_GRAPH`` builds the whole graph on the host
+            up front, which is what Graph Execution (record once, replay)
+            requires. ``None`` inherits the setting from an active outer
+            ``PassContext``. Its wire name is written to
+            ``RUNTIME_CONFIG["runtime"]`` in the generated ``kernel_config.py``
+            and is what a ``ChipWorker`` must match to bind the program.
 
     Returns:
         A :class:`CompiledProgram` that wraps the output directory and can
@@ -305,6 +328,7 @@ def compile(  # noqa: PLR0913
         verification_level=verification_level,
         diagnostic_phase=diagnostic_phase,
         memory_planner=memory_planner,
+        runtime=runtime,
     )
 
     # --- Compile profiling ---------------------------------------------------
@@ -336,6 +360,7 @@ def compile(  # noqa: PLR0913
             disabled_diagnostics=disabled_diagnostics,
             memory_planner=memory_planner,
             enable_pypto_l0c_double_buffer=enable_pypto_l0c_double_buffer,
+            runtime=runtime,
             analyze_auto_scopes_for_deps=analyze_auto_scopes_for_deps,
             extra_instruments=(report_instrument,),
             dump_passes=dump_passes,
@@ -344,6 +369,7 @@ def compile(  # noqa: PLR0913
         transformed_program = pipeline.transformed_program
         mplan = pipeline.memory_planner
         effective_backend_type = pipeline.backend_type
+        effective_runtime = pipeline.runtime
 
         # Codegen target selection is owned by the per-backend BackendHandler;
         # any value of the ``BackendType`` enum is a valid PTO codegen target.
@@ -356,6 +382,7 @@ def compile(  # noqa: PLR0913
                     memory_planner=mplan,
                     emit_source_loc=emit_source_loc,
                     dump_ptoas_passes=dump_ptoas_passes,
+                    runtime=effective_runtime,
                 )
         except PartialCodegenError as exc:
             _write_files(exc.files, output_dir)

--- a/python/pypto/jit/cache.py
+++ b/python/pypto/jit/cache.py
@@ -29,7 +29,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from pypto.pypto_core import DataType
-from pypto.pypto_core.passes import MemoryPlanner
+from pypto.pypto_core.passes import MemoryPlanner, RuntimeKind, runtime_kind_to_name
 
 if TYPE_CHECKING:
     from pypto.ir.pass_manager import OptimizationStrategy
@@ -147,6 +147,7 @@ def make_cache_key(  # noqa: PLR0913 — args are the key's components, one per 
     enable_pypto_l0c_double_buffer: bool = False,
     tensor_layouts: dict[str, "TensorLayout | None"] | None = None,
     dep_layouts: tuple[tuple[str, str, str], ...] = (),
+    runtime: RuntimeKind = RuntimeKind.TENSORMAP_AND_RINGBUFFER,
 ) -> CacheKey:
     """Build a cache key for a JIT call site.
 
@@ -203,6 +204,11 @@ def make_cache_key(  # noqa: PLR0913 — args are the key's components, one per 
             Included for ``PYPTO`` because it changes AutoTileMatmulL0 output
             and allocation. Canonicalized to false for ``DSA_RP`` and ``PTOAS``,
             which enable dbC=2 automatically regardless of this flag.
+        runtime: Effective Simpler runtime ABI resolved from the active
+            ``PassContext``. Included in the key because it is baked into the
+            artifact's ``kernel_config.py`` and decides which worker can bind
+            the program; without it a ``host_build_graph`` call would silently
+            reuse a ``tensormap_and_ringbuffer`` artifact.
 
     Returns:
         Hashable CacheKey tuple.
@@ -241,6 +247,7 @@ def make_cache_key(  # noqa: PLR0913 — args are the key's components, one per 
         ("memory_planner", None if memory_planner is None else str(memory_planner)),
         ("enable_pypto_l0c_double_buffer", effective_pypto_dbc),
         ("dep_layouts", dep_layouts),
+        ("runtime", runtime_kind_to_name(runtime)),
     )
     return (
         source_hash,

--- a/python/pypto/jit/decorator.py
+++ b/python/pypto/jit/decorator.py
@@ -1511,6 +1511,20 @@ def _resolve_enable_pypto_l0c_double_buffer() -> bool:
     return ctx.get_enable_pypto_l0c_double_buffer() if ctx is not None else False
 
 
+def _resolve_runtime() -> _passes.RuntimeKind:
+    """Resolve the target Simpler runtime ABI for the cache key.
+
+    Like ``_resolve_enable_pypto_l0c_double_buffer``, the runtime is selected by
+    wrapping a call in ``with PassContext([], runtime=...)``, which
+    ``ir.compile()`` inherits. ``RunConfig`` does not carry it, so the active
+    context is the only source. Keying on it stops a ``host_build_graph`` call
+    from reusing an artifact compiled for ``tensormap_and_ringbuffer``, whose
+    ``kernel_config.py`` names a runtime no matching worker would bind.
+    """
+    ctx = _passes.PassContext.current()
+    return ctx.get_runtime() if ctx is not None else _passes.RuntimeKind.TENSORMAP_AND_RINGBUFFER
+
+
 # ---------------------------------------------------------------------------
 
 
@@ -2092,6 +2106,7 @@ class JITFunction:
             dump_ptoas_passes=dump_ptoas_passes,
             memory_planner=memory_planner,
             enable_pypto_l0c_double_buffer=_resolve_enable_pypto_l0c_double_buffer(),
+            runtime=_resolve_runtime(),
         )
 
         # L1 cache lookup

--- a/python/pypto/pypto_core/passes.pyi
+++ b/python/pypto/pypto_core/passes.pyi
@@ -102,6 +102,21 @@ class MemoryPlanner(Enum):
     DSA_RP = ...
     PTOAS = ...
 
+class RuntimeKind(Enum):
+    """Which Simpler runtime ABI a compilation targets."""
+
+    TENSORMAP_AND_RINGBUFFER = ...
+    """Task graph built on the AICPU, dependencies auto-derived through the TensorMap."""
+
+    HOST_BUILD_GRAPH = ...
+    """Host CPU builds the whole task graph up front; required for Graph Execution."""
+
+def runtime_kind_to_name(kind: RuntimeKind) -> str:
+    """Wire name written to ``RUNTIME_CONFIG["runtime"]``, e.g. ``"host_build_graph"``."""
+
+def runtime_kind_from_name(name: str) -> RuntimeKind:
+    """Parse a ``RUNTIME_CONFIG["runtime"]`` wire name back into a :class:`RuntimeKind`."""
+
 class DiagnosticPhase(Enum):
     """Controls when DiagnosticInstrument runs registered checks (warnings + perf hints)."""
 
@@ -267,6 +282,7 @@ class PassContext:
         disabled_diagnostics: DiagnosticCheckSet = ...,  # default: {UnusedControlFlowResult}
         memory_planner: MemoryPlanner = MemoryPlanner.PYPTO,
         enable_pypto_l0c_double_buffer: bool = False,
+        runtime: RuntimeKind = RuntimeKind.TENSORMAP_AND_RINGBUFFER,
     ) -> None:
         """Create a PassContext with instruments and pass configuration (incl. memory planner).
 
@@ -274,6 +290,11 @@ class PassContext:
         to chooser-emitted L0C double-buffering (dbC=2; experimental, default
         off). It has no effect under ``DSA_RP`` or ``PTOAS``, which enable
         chooser dbC=2 automatically.
+
+        ``runtime`` selects the target Simpler runtime ABI; its wire name is
+        what lands in ``RUNTIME_CONFIG["runtime"]`` in the generated
+        ``kernel_config.py``. Passes that legalize runtime-specific IR read it
+        from the context.
         """
         ...
 
@@ -298,6 +319,10 @@ class PassContext:
 
     def get_memory_planner(self) -> MemoryPlanner:
         """Get the memory planner selection for this context."""
+        ...
+
+    def get_runtime(self) -> RuntimeKind:
+        """Get the target Simpler runtime ABI for this context."""
         ...
 
     def get_enable_pypto_l0c_double_buffer(self) -> bool:

--- a/python/pypto/runtime/builtins/collectives/all_to_all/templates/kernel_config.py.in
+++ b/python/pypto/runtime/builtins/collectives/all_to_all/templates/kernel_config.py.in
@@ -6,7 +6,7 @@ from simpler.task_interface import ArgDirection as _D
 _ROOT_DIR = Path(__file__).parent
 
 RUNTIME_CONFIG = {
-    "runtime": "tensormap_and_ringbuffer",
+    "runtime": "{{runtime}}",
     "aicpu_thread_num": 0,
 }
 

--- a/python/pypto/runtime/builtins/collectives/all_to_all_v/templates/kernel_config.py.in
+++ b/python/pypto/runtime/builtins/collectives/all_to_all_v/templates/kernel_config.py.in
@@ -6,7 +6,7 @@ from simpler.task_interface import ArgDirection as _D
 _ROOT_DIR = Path(__file__).parent
 
 RUNTIME_CONFIG = {
-    "runtime": "tensormap_and_ringbuffer",
+    "runtime": "{{runtime}}",
     "aicpu_thread_num": 0,
 }
 

--- a/python/pypto/runtime/builtins/collectives/allgather/templates/kernel_config.py.in
+++ b/python/pypto/runtime/builtins/collectives/allgather/templates/kernel_config.py.in
@@ -6,7 +6,7 @@ from simpler.task_interface import ArgDirection as _D
 _ROOT_DIR = Path(__file__).parent
 
 RUNTIME_CONFIG = {
-    "runtime": "tensormap_and_ringbuffer",
+    "runtime": "{{runtime}}",
     "aicpu_thread_num": 0,
 }
 

--- a/python/pypto/runtime/builtins/collectives/allreduce/templates/kernel_config.py.in
+++ b/python/pypto/runtime/builtins/collectives/allreduce/templates/kernel_config.py.in
@@ -6,7 +6,7 @@ from simpler.task_interface import ArgDirection as _D
 _ROOT_DIR = Path(__file__).parent
 
 RUNTIME_CONFIG = {
-    "runtime": "tensormap_and_ringbuffer",
+    "runtime": "{{runtime}}",
     "aicpu_thread_num": 0,
 }
 

--- a/python/pypto/runtime/builtins/collectives/allreduce_ring/templates/kernel_config.py.in
+++ b/python/pypto/runtime/builtins/collectives/allreduce_ring/templates/kernel_config.py.in
@@ -6,7 +6,7 @@ from simpler.task_interface import ArgDirection as _D
 _ROOT_DIR = Path(__file__).parent
 
 RUNTIME_CONFIG = {
-    "runtime": "tensormap_and_ringbuffer",
+    "runtime": "{{runtime}}",
     "aicpu_thread_num": 0,
     "block_dim": 1,
 }

--- a/python/pypto/runtime/builtins/collectives/barrier/templates/kernel_config.py.in
+++ b/python/pypto/runtime/builtins/collectives/barrier/templates/kernel_config.py.in
@@ -6,7 +6,7 @@ from simpler.task_interface import ArgDirection as _D
 _ROOT_DIR = Path(__file__).parent
 
 RUNTIME_CONFIG = {
-    "runtime": "tensormap_and_ringbuffer",
+    "runtime": "{{runtime}}",
     "aicpu_thread_num": 0,
 }
 

--- a/python/pypto/runtime/builtins/collectives/broadcast/templates/kernel_config.py.in
+++ b/python/pypto/runtime/builtins/collectives/broadcast/templates/kernel_config.py.in
@@ -6,7 +6,7 @@ from simpler.task_interface import ArgDirection as _D
 _ROOT_DIR = Path(__file__).parent
 
 RUNTIME_CONFIG = {
-    "runtime": "tensormap_and_ringbuffer",
+    "runtime": "{{runtime}}",
     "aicpu_thread_num": 0,
 }
 

--- a/python/pypto/runtime/builtins/collectives/reduce_scatter/templates/kernel_config.py.in
+++ b/python/pypto/runtime/builtins/collectives/reduce_scatter/templates/kernel_config.py.in
@@ -6,7 +6,7 @@ from simpler.task_interface import ArgDirection as _D
 _ROOT_DIR = Path(__file__).parent
 
 RUNTIME_CONFIG = {
-    "runtime": "tensormap_and_ringbuffer",
+    "runtime": "{{runtime}}",
     "aicpu_thread_num": 0,
 }
 

--- a/python/pypto/runtime/device_runner.py
+++ b/python/pypto/runtime/device_runner.py
@@ -47,6 +47,7 @@ from typing import Any
 import torch
 
 from pypto._external_source import kernel_binary_cache_path
+from pypto.pypto_core.passes import RuntimeKind, runtime_kind_to_name
 
 from ._binary_cache import (
     BinaryCacheContext,
@@ -548,7 +549,7 @@ def _compile_and_assemble_locked(
     runtime_config = getattr(kernel_config, "RUNTIME_CONFIG", {})
     # Default to the runtime that ``pto_backend`` bakes into every generated
     # ``kernel_config.py``; only legacy / hand-written configs omit the key.
-    runtime_name = runtime_config.get("runtime", "tensormap_and_ringbuffer")
+    runtime_name = runtime_config.get("runtime", runtime_kind_to_name(RuntimeKind.TENSORMAP_AND_RINGBUFFER))
 
     # Resolve the pinned PTO-ISA checkout (raises with an actionable message
     # when the pin cannot be honoured).

--- a/python/pypto/runtime/worker.py
+++ b/python/pypto/runtime/worker.py
@@ -47,6 +47,8 @@ import weakref
 from contextlib import suppress
 from typing import TYPE_CHECKING, Any
 
+from pypto.pypto_core.passes import RuntimeKind, runtime_kind_to_name
+
 from .runner import RunConfig
 from .runtime_base import Worker
 
@@ -97,8 +99,9 @@ _ACTIVE_WORKERS: contextvars.ContextVar[tuple[ChipWorker, ...]] = contextvars.Co
 # the value ``CompiledProgram.runtime_name`` reports and the one the reuse
 # lookup in ``device_runner.execute_on_device`` searches for, so a
 # default-constructed ``with ChipWorker():`` bind-matches a freshly compiled
-# program instead of silently falling through to a one-shot worker.
-_DEFAULT_RUNTIME = "tensormap_and_ringbuffer"
+# program instead of silently falling through to a one-shot worker. Derived from
+# the RuntimeKind enum that compilation selects, so the two cannot drift apart.
+_DEFAULT_RUNTIME = runtime_kind_to_name(RuntimeKind.TENSORMAP_AND_RINGBUFFER)
 
 
 def _close_simpler_worker_best_effort(impl: Any) -> None:

--- a/src/ir/transforms/pass_context.cpp
+++ b/src/ir/transforms/pass_context.cpp
@@ -277,20 +277,51 @@ std::string DiagnosticInstrument::GetName() const { return "DiagnosticInstrument
 
 // PassContext
 
+/// The wire name of each runtime kind, in enumerator order. Single table so a
+/// new runtime cannot be added to one direction and forgotten in the other.
+constexpr std::pair<RuntimeKind, const char*> kRuntimeNames[] = {
+    {RuntimeKind::TensorMapAndRingBuffer, "tensormap_and_ringbuffer"},
+    {RuntimeKind::HostBuildGraph, "host_build_graph"},
+};
+
+std::string RuntimeKindToName(RuntimeKind kind) {
+  for (const auto& [candidate, name] : kRuntimeNames) {
+    if (candidate == kind) return name;
+  }
+  INTERNAL_UNREACHABLE << "Internal error: unhandled RuntimeKind value " << static_cast<int>(kind);
+}
+
+RuntimeKind RuntimeKindFromName(const std::string& name) {
+  for (const auto& [kind, candidate] : kRuntimeNames) {
+    if (name == candidate) return kind;
+  }
+  std::ostringstream supported;
+  for (size_t i = 0; i < std::size(kRuntimeNames); ++i) {
+    if (i != 0) supported << ", ";
+    supported << kRuntimeNames[i].second;
+  }
+  CHECK(false) << "Unknown runtime '" << name << "': expected one of " << supported.str();
+  return kDefaultRuntimeKind;  // unreachable; CHECK throws
+}
+
 PassContext::PassContext(std::vector<PassInstrumentPtr> instruments, VerificationLevel verification_level,
                          DiagnosticPhase diagnostic_phase, DiagnosticCheckSet disabled_diagnostics,
-                         MemoryPlanner memory_planner, bool enable_pypto_l0c_double_buffer)
+                         MemoryPlanner memory_planner, bool enable_pypto_l0c_double_buffer,
+                         RuntimeKind runtime)
     : instruments_(std::move(instruments)),
       verification_level_(verification_level),
       diagnostic_phase_(diagnostic_phase),
       disabled_diagnostics_(disabled_diagnostics),
       memory_planner_(memory_planner),
       enable_pypto_l0c_double_buffer_(enable_pypto_l0c_double_buffer),
+      runtime_(runtime),
       previous_(nullptr) {}
 
 VerificationLevel PassContext::GetVerificationLevel() const { return verification_level_; }
 
 MemoryPlanner PassContext::GetMemoryPlanner() const { return memory_planner_; }
+
+RuntimeKind PassContext::GetRuntime() const { return runtime_; }
 
 bool PassContext::GetEnablePyptoL0cDoubleBuffer() const { return enable_pypto_l0c_double_buffer_; }
 

--- a/tests/ut/backend/test_kernel_config_signature.py
+++ b/tests/ut/backend/test_kernel_config_signature.py
@@ -24,6 +24,7 @@ is checked for syntactic validity with ``compile`` (which does not execute the
 import pytest
 from pypto.backend.pto_backend import _generate_config_file
 from pypto.pypto_core import ir as _ir_core
+from pypto.pypto_core import passes
 
 
 def _base_inputs() -> dict:
@@ -150,6 +151,57 @@ class TestOrchestrationConfigSignature:
         assert '"signature": [_D.INOUT, _D.IN, _D.OUT]' in text
         assert "_D.SCALAR" not in text
         assert _is_valid_python(text)
+
+
+class TestKernelConfigRuntime:
+    """``RUNTIME_CONFIG["runtime"]`` follows the selected runtime ABI."""
+
+    def test_default_runtime_is_tensormap_and_ringbuffer(self) -> None:
+        text = _generate_config_file(**_base_inputs())
+        assert '"runtime": "tensormap_and_ringbuffer"' in text
+        assert "# Runtime configuration for tensormap_and_ringbuffer." in text
+        assert _is_valid_python(text)
+
+    def test_host_build_graph_runtime_is_emitted(self) -> None:
+        text = _generate_config_file(**_base_inputs(), runtime=passes.RuntimeKind.HOST_BUILD_GRAPH)
+        # Both the value the runtime reads and the human-facing header comment
+        # must follow, or the file documents a runtime it does not select.
+        assert '"runtime": "host_build_graph"' in text
+        assert "# Runtime configuration for host_build_graph." in text
+        assert "tensormap_and_ringbuffer" not in text
+        assert _is_valid_python(text)
+
+    def test_runtime_does_not_disturb_other_keys(self) -> None:
+        text = _generate_config_file(
+            **_base_inputs(),
+            orchestration_signature=["IN", "OUT"],
+            runtime=passes.RuntimeKind.HOST_BUILD_GRAPH,
+        )
+        assert '"aicpu_thread_num": 0' in text
+        assert '"signature": [_D.IN, _D.OUT]' in text
+        assert _is_valid_python(text)
+
+
+class TestRuntimeWireNames:
+    """The enum is the compile-time contract; the wire name is the ABI boundary."""
+
+    @pytest.mark.parametrize(
+        ("kind", "name"),
+        [
+            (passes.RuntimeKind.TENSORMAP_AND_RINGBUFFER, "tensormap_and_ringbuffer"),
+            (passes.RuntimeKind.HOST_BUILD_GRAPH, "host_build_graph"),
+        ],
+    )
+    def test_wire_name_round_trips(self, kind, name) -> None:
+        # The name is used verbatim as a filesystem path component when
+        # compiling kernels, so it is spelled out rather than derived from the
+        # enumerator; both directions must agree on that spelling.
+        assert passes.runtime_kind_to_name(kind) == name
+        assert passes.runtime_kind_from_name(name) == kind
+
+    def test_unknown_wire_name_is_rejected(self) -> None:
+        with pytest.raises(ValueError, match="Unknown runtime 'ringbuffer'"):
+            passes.runtime_kind_from_name("ringbuffer")
 
 
 if __name__ == "__main__":

--- a/tests/ut/codegen/distributed/test_host_orch_distributed.py
+++ b/tests/ut/codegen/distributed/test_host_orch_distributed.py
@@ -981,6 +981,59 @@ def test_backend_materializes_builtin_next_level_files(tmp_path):
     assert "base += static_cast<int64_t>(active_blocks) * kTileCount" in kernel_cpp
 
 
+@pytest.mark.parametrize(
+    "runtime",
+    [passes.RuntimeKind.TENSORMAP_AND_RINGBUFFER, passes.RuntimeKind.HOST_BUILD_GRAPH],
+)
+def test_every_next_level_reports_the_selected_runtime(tmp_path, runtime):
+    """All chip sub-builds in one distributed program must name the same runtime.
+
+    The builtin collectives are materialized from templates rather than by the
+    orchestration codegen, so they are a second, easily-missed place where the
+    runtime name is written. ``_assemble_chip_callables`` rejects a
+    ``next_levels/`` tree whose members disagree, which would make every
+    distributed program using a collective unrunnable under a non-default
+    runtime.
+    """
+
+    @pl.program
+    class Prog:
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def chip_orch(self, data: pld.DistributedTensor[[SIZE], pl.FP32]):
+            return data
+
+        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+        def host_orch(self):
+            data_buf = pld.alloc_window_buffer(SIZE * pl.FP32.get_byte())
+            signal_buf = pld.alloc_window_buffer(pld.world_size() * pl.INT32.get_byte())
+            data = pld.window(data_buf, [SIZE], dtype=pl.FP32)
+            signal = pld.window(signal_buf, [pld.world_size()], dtype=pl.INT32)
+            for r in pl.range(pld.world_size()):
+                self.chip_orch(data, device=r)
+            pld.tensor.allreduce(data, signal, op=pld.ReduceOp.Sum)
+            return 0
+
+    program = passes.materialize_comm_domain_scopes()(Prog)
+    program = passes.lower_host_tensor_collectives()(program)
+    program = passes.materialize_dist_tensor_ctx()(program)
+    program = _finalize_chip_program_for_generate(program)
+    files = pto_backend.generate(program, str(tmp_path), skip_ptoas=True, runtime=runtime)
+
+    configs = {
+        path: text
+        for path, text in files.items()
+        if path.startswith("next_levels/") and path.endswith("/kernel_config.py")
+    }
+    # Both a user chip Orchestration and a template-materialized builtin, so the
+    # test would still pass vacuously if either side were missing.
+    # Both a user chip Orchestration and a template-materialized builtin, so the
+    # test would still pass vacuously if either side were missing.
+    assert len(configs) >= 2, f"expected a user chip and a builtin config, got {sorted(configs)}"
+    name = passes.runtime_kind_to_name(runtime)
+    for path, text in configs.items():
+        assert f'"runtime": "{name}"' in text, f"{path} does not report runtime {name!r}"
+
+
 @pytest.mark.parametrize("ascend_backend", [BackendType.Ascend950], indirect=True)
 def test_backend_950_materializes_allreduce_with_core_num_launch(tmp_path, ascend_backend):
     @pl.program

--- a/tests/ut/ir/test_compile_runtime.py
+++ b/tests/ut/ir/test_compile_runtime.py
@@ -1,0 +1,143 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Selecting the target Simpler runtime ABI for a compilation.
+
+The runtime name travels through ``PassContext`` rather than being a
+codegen-only argument, so passes that must legalize IR for a specific runtime
+can read it. These tests pin the whole path: the context round-trip, the
+precedence ``ir.compile()`` applies, and the value that lands in the generated
+``kernel_config.py``.
+
+Note that ``tests/ut/conftest.py`` wraps every unit test in a ``PassContext``,
+so ``ir.compile(runtime=...)`` is always a conflict here — selecting the runtime
+by wrapping the call in a context is the path these tests exercise, and the one
+users take in practice.
+"""
+
+import pypto.language as pl
+import pytest
+from pypto.ir.compile import compile as ir_compile
+from pypto.pypto_core import passes
+
+DEFAULT_RUNTIME = passes.RuntimeKind.TENSORMAP_AND_RINGBUFFER
+GRAPH_EXECUTION_RUNTIME = passes.RuntimeKind.HOST_BUILD_GRAPH
+
+
+@pl.program
+class VectorAdd:
+    """Minimal orchestration entry, so compilation emits a ``kernel_config.py``."""
+
+    @pl.function
+    def main(
+        self,
+        a: pl.Tensor[[128, 128], pl.FP32],
+        b: pl.Tensor[[128, 128], pl.FP32],
+        c: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
+    ) -> pl.Tensor[[128, 128], pl.FP32]:
+        with pl.at(level=pl.Level.CORE_GROUP):
+            tile_a: pl.Tile[[128, 128], pl.FP32] = pl.load(a, [0, 0], [128, 128])
+            tile_b: pl.Tile[[128, 128], pl.FP32] = pl.load(b, [0, 0], [128, 128])
+            tile_c: pl.Tile[[128, 128], pl.FP32] = pl.add(tile_a, tile_b)
+            pl.store(tile_c, [0, 0], c)
+        return c
+
+
+# ---------------------------------------------------------------------------
+# PassContext round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_pass_context_default_runtime_is_tensormap_and_ringbuffer():
+    ctx = passes.PassContext([])
+    assert ctx.get_runtime() == DEFAULT_RUNTIME
+
+
+@pytest.mark.parametrize("runtime", [DEFAULT_RUNTIME, GRAPH_EXECUTION_RUNTIME])
+def test_pass_context_runtime_round_trip(runtime):
+    ctx = passes.PassContext([], runtime=runtime)
+    assert ctx.get_runtime() == runtime
+
+
+def test_pass_context_runtime_is_independent_of_memory_planner():
+    ctx = passes.PassContext([], memory_planner=passes.MemoryPlanner.PTOAS, runtime=GRAPH_EXECUTION_RUNTIME)
+    assert ctx.get_memory_planner() == passes.MemoryPlanner.PTOAS
+    assert ctx.get_runtime() == GRAPH_EXECUTION_RUNTIME
+
+
+# ---------------------------------------------------------------------------
+# Validation and precedence
+# ---------------------------------------------------------------------------
+
+
+def test_compile_rejects_runtime_when_a_context_is_active(tmp_path):
+    # Same rule as memory_planner: an explicit argument alongside an active
+    # context is ambiguous, so it is refused rather than silently ranked.
+    with passes.PassContext([], runtime=GRAPH_EXECUTION_RUNTIME):
+        with pytest.raises(RuntimeError, match="runtime while a PassContext is already active"):
+            ir_compile(
+                VectorAdd,
+                runtime=DEFAULT_RUNTIME,
+                skip_ptoas=True,
+                platform="a2a3",
+                output_dir=str(tmp_path / "conflict"),
+            )
+
+
+# ---------------------------------------------------------------------------
+# The value that lands in the artifact
+# ---------------------------------------------------------------------------
+
+# ``kernel_config.py`` is only written when ptoas is not skipped, so these tests
+# need ``skip_ptoas=False`` — but they are about the runtime name, not about
+# kernel compilation. Stub the ptoas invocation, as the neighbouring codegen
+# tests do, so the assertions do not depend on a working ptoas toolchain.
+_STUB_PTOAS_OUTPUT = """\
+#include "pto/pto-inst.hpp"
+using namespace pto;
+
+__global__ AICORE void stub_kernel(__gm__ float* v1) {}
+"""
+
+
+@pytest.fixture
+def stub_ptoas(monkeypatch):
+    monkeypatch.setattr(
+        "pypto.backend.pto_backend._compile_pto_module",
+        lambda _pto_code, _module_name, _output_dir, _memory_planner=None: _STUB_PTOAS_OUTPUT,
+    )
+
+
+def _compile_and_read_config(out_dir) -> str:
+    ir_compile(
+        VectorAdd,
+        skip_ptoas=False,
+        platform="a2a3",
+        output_dir=str(out_dir),
+        dump_passes=False,
+    )
+    return (out_dir / "kernel_config.py").read_text()
+
+
+@pytest.mark.parametrize("runtime", [DEFAULT_RUNTIME, GRAPH_EXECUTION_RUNTIME])
+def test_context_runtime_reaches_kernel_config(tmp_path, runtime, stub_ptoas):
+    with passes.PassContext([], runtime=runtime):
+        config = _compile_and_read_config(tmp_path / passes.runtime_kind_to_name(runtime))
+    name = passes.runtime_kind_to_name(runtime)
+    assert f'"runtime": "{name}"' in config
+    assert f"# Runtime configuration for {name}." in config
+
+
+def test_compile_without_explicit_runtime_defaults_to_tensormap(tmp_path, stub_ptoas):
+    config = _compile_and_read_config(tmp_path / "default")
+    assert f'"runtime": "{passes.runtime_kind_to_name(DEFAULT_RUNTIME)}"' in config
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/ut/jit/test_cache.py
+++ b/tests/ut/jit/test_cache.py
@@ -16,7 +16,11 @@ from pypto.jit.cache import (
     compute_source_hash,
     make_cache_key,
 )
-from pypto.jit.decorator import _resolve_enable_pypto_l0c_double_buffer, _resolve_memory_planner
+from pypto.jit.decorator import (
+    _resolve_enable_pypto_l0c_double_buffer,
+    _resolve_memory_planner,
+    _resolve_runtime,
+)
 from pypto.pypto_core import DataType, ir, passes
 from pypto.pypto_core.passes import MemoryPlanner
 from pypto.runtime import RunConfig
@@ -66,6 +70,7 @@ class TestMakeCacheKey:
         enable_pypto_l0c_double_buffer=False,
         tensor_layouts=None,
         dep_layouts=(),
+        runtime=passes.RuntimeKind.TENSORMAP_AND_RINGBUFFER,
     ):
         return make_cache_key(
             source_hash=source_hash,
@@ -82,6 +87,7 @@ class TestMakeCacheKey:
             enable_pypto_l0c_double_buffer=enable_pypto_l0c_double_buffer,
             tensor_layouts=tensor_layouts,
             dep_layouts=dep_layouts,
+            runtime=runtime,
         )
 
     def test_basic_key_structure(self):
@@ -105,6 +111,7 @@ class TestMakeCacheKey:
             ("memory_planner", None),
             ("enable_pypto_l0c_double_buffer", False),
             ("dep_layouts", ()),
+            ("runtime", "tensormap_and_ringbuffer"),
         )
 
     def test_tensor_shape_in_key(self):
@@ -419,6 +426,32 @@ class TestMakeCacheKey:
         key_off = self._make_key(**kwargs, enable_pypto_l0c_double_buffer=False)
         key_on = self._make_key(**kwargs, enable_pypto_l0c_double_buffer=True)
         assert key_off == key_on
+
+    def test_runtime_splits_key(self):
+        """The runtime is baked into the artifact's ``kernel_config.py`` and decides
+        which worker can bind it, so a ``host_build_graph`` call must not reuse a
+        ``tensormap_and_ringbuffer`` artifact."""
+        kwargs = {
+            "param_names": ["a"],
+            "tensor_shapes": {"a": (8, 8)},
+            "tensor_dtypes": {"a": DataType.FP32},
+        }
+        key_tmrb = self._make_key(**kwargs, runtime=passes.RuntimeKind.TENSORMAP_AND_RINGBUFFER)
+        key_hbg = self._make_key(**kwargs, runtime=passes.RuntimeKind.HOST_BUILD_GRAPH)
+        assert key_tmrb != key_hbg, "runtime must split the cache key"
+
+
+class TestResolveRuntime:
+    """The runtime the JIT keys on must match the one ``ir.compile()`` will use."""
+
+    def test_defaults_to_tensormap_and_ringbuffer(self):
+        assert _resolve_runtime() == passes.RuntimeKind.TENSORMAP_AND_RINGBUFFER
+
+    def test_reads_the_active_pass_context(self):
+        # The runtime is PassContext-only — RunConfig does not carry it — so the
+        # context is the sole source the cache key can consult.
+        with passes.PassContext([], runtime=passes.RuntimeKind.HOST_BUILD_GRAPH):
+            assert _resolve_runtime() == passes.RuntimeKind.HOST_BUILD_GRAPH
 
 
 class TestResolveMemoryPlanner:


### PR DESCRIPTION
## Summary

The runtime name was hardcoded in `_generate_config_file`, so every artifact claimed `"runtime": "tensormap_and_ringbuffer"` regardless of what it was built for. That makes `host_build_graph` — the runtime that builds the whole task graph on the host, and the only one that can record and replay an orchestration fragment — unreachable from the compiler.

`ir.compile(runtime=...)` now selects it. The value travels through `PassContext` rather than as a codegen-only argument, so a pass that must legalize IR for a specific runtime can read it via `PassContext::GetRuntime()`. Precedence, the conflict guard against an active context, and the inheritance rule all follow `memory_planner` exactly:

```python
# explicit
compiled = ir.compile(program, runtime="host_build_graph")

# or inherited from the surrounding context — the form users reach for
with passes.PassContext([], runtime="host_build_graph"):
    compiled = ir.compile(program)
```

## Bug found while threading it

A distributed build writes `kernel_config.py` from **two** places. Besides the per-chip codegen path, the builtin collectives are materialized from templates that each pinned the runtime literally. Left alone, a distributed program calling any collective would emit a `next_levels/` tree whose members disagreed, and `_assemble_chip_callables` rejects that outright:

```
RuntimeError: Inconsistent runtime across next_levels/ sub-builds in <dir>:
'tensormap_and_ringbuffer' (earlier chip) vs 'host_build_graph' (chip 'chip_orch').
```

Every such program would have been unrunnable under a non-default runtime. The eight templates now take the name as a variable, and `test_every_next_level_reports_the_selected_runtime` asserts that every `next_levels/*/kernel_config.py` in one build agrees.

## Three further gaps closed

- **Validation.** The name is used verbatim as a filesystem path component when compiling kernels, so an unknown value previously surfaced much later as an opaque CCEC error about a nonexistent include directory. It is now checked at the API boundary.
- **Duplicated default.** The default string lived in three modules with a comment saying they had to stay in sync. `pypto/backend/runtime_names.py` now owns it — a leaf module importing nothing, so both `pypto.backend` and `pypto.runtime` can depend on it without a cycle.
- **JIT cache key.** Added a runtime dimension. Without it a call under `with PassContext([], runtime="host_build_graph")` would reuse a tensormap artifact whose `kernel_config.py` names a runtime no matching worker binds.

## Test plan

- New `tests/ut/ir/test_compile_runtime.py`: context round-trip, the conflict guard, unknown-name rejection, and the value landing in `kernel_config.py` (ptoas stubbed, as the neighbouring codegen tests do).
- New `TestKernelConfigRuntime` / `TestRuntimeNameValidation` in `tests/ut/backend/test_kernel_config_signature.py`.
- New `test_runtime_splits_key` and `TestResolveRuntime` in `tests/ut/jit/test_cache.py`.
- New `test_every_next_level_reports_the_selected_runtime` in the distributed codegen suite; verified it fails when the template fix is reverted.
- `test_basic_key_structure` pins the cache key's exact shape and was updated for the added dimension — the assertion did its job.
- Full `tests/ut` + `tests/lint`: 9849 passed, 8 skipped.

## Context

First of a stacked series adding Graph Execution support for the `host_build_graph` runtime (RFC #2399). No behaviour changes for existing callers: the default is unchanged and every path that previously emitted `tensormap_and_ringbuffer` still does.