### PR TITLE
fix(codegen): lower host tensor assemble in distributed codegen

### DIFF
--- a/src/codegen/distributed/distributed_codegen.cpp
+++ b/src/codegen/distributed/distributed_codegen.cpp
@@ -973,8 +973,15 @@ void DistributedCodegen::VisitExpr_(const ir::CallPtr& op) {
     return;
   }
 
+  const std::string& op_name = op->op_->name_;
+  const bool is_unhandled_tensor_or_tile_op =
+      op_name.rfind("tensor.", 0) == 0 || op_name.rfind("tile.", 0) == 0;
+  CHECK_SPAN(!is_unhandled_tensor_or_tile_op, op->span_)
+      << "DistributedCodegen does not support op '" << op_name << "' in function '" << current_func_->name_
+      << "'. Move this operation into a lower-level function or add a registered HOST-orchestrator lowering.";
+
   // Regular op call
-  current_expr_value_ = op->op_->name_ + "(" + FormatArgs(op->args_) + ")";
+  current_expr_value_ = op_name + "(" + FormatArgs(op->args_) + ")";
 }
 
 void DistributedCodegen::VisitExpr_(const ir::VarPtr& op) {

--- a/src/codegen/distributed/distributed_ops_codegen.cpp
+++ b/src/codegen/distributed/distributed_ops_codegen.cpp
@@ -502,32 +502,43 @@ REGISTER_DISTRIBUTED_OP(tensor_assemble, "tensor.assemble") {
 
   auto offset_tuple = As<MakeTuple>(op->args_[2]);
   INTERNAL_CHECK_SPAN(offset_tuple, op->span_) << "Internal error: tensor.assemble offset must be MakeTuple";
-  CHECK_SPAN(offset_tuple->elements_.size() == target_type->shape_.size() &&
-                 source_type->shape_.size() == target_type->shape_.size(),
-             op->span_)
-      << "tensor.assemble in a HOST orchestrator requires target, source, and offset to have the same rank";
+  const size_t target_rank = target_type->shape_.size();
+  const size_t source_rank = source_type->shape_.size();
+  CHECK_SPAN(offset_tuple->elements_.size() == target_rank, op->span_)
+      << "tensor.assemble in a HOST orchestrator requires offset rank to match target rank";
+  CHECK_SPAN(source_rank <= target_rank, op->span_)
+      << "tensor.assemble in a HOST orchestrator requires source rank not to exceed target rank";
 
   const std::vector<ExprPtr> source_valid_shape = ir::GetValidShape(source_type);
+  const size_t leading_target_rank = target_rank - source_rank;
   std::ostringstream target_indices;
   std::ostringstream source_indices;
-  for (size_t i = 0; i < source_valid_shape.size(); ++i) {
+  for (size_t i = 0; i < target_rank; ++i) {
     if (i > 0) {
       target_indices << ", ";
-      source_indices << ", ";
     }
     const std::string offset_i = codegen.GetExprAsCode(offset_tuple->elements_[i]);
-    const std::string extent_i = codegen.GetExprAsCode(source_valid_shape[i]);
+    const std::string extent_i =
+        i < leading_target_rank ? "1" : codegen.GetExprAsCode(source_valid_shape[i - leading_target_rank]);
     auto offset_const = As<ConstInt>(offset_tuple->elements_[i]);
     if (offset_const && offset_const->value_ == 0) {
       target_indices << "0:" << extent_i;
     } else {
       target_indices << offset_i << ":" << offset_i << " + " << extent_i;
     }
-    source_indices << "0:" << extent_i;
+  }
+  for (size_t i = 0; i < source_rank; ++i) {
+    if (i > 0) {
+      source_indices << ", ";
+    }
+    source_indices << "0:" << codegen.GetExprAsCode(source_valid_shape[i]);
   }
 
-  codegen.Emit("tensors[\"" + target_name + "\"][" + target_indices.str() + "] = tensors[\"" + source_name +
-               "\"][" + source_indices.str() + "]");
+  std::string source_expr = "tensors[\"" + source_name + "\"]";
+  if (source_rank > 0) {
+    source_expr += "[" + source_indices.str() + "]";
+  }
+  codegen.Emit("tensors[\"" + target_name + "\"][" + target_indices.str() + "] = " + source_expr);
   if (lhs != target_name) {
     codegen.Emit("tensors[\"" + lhs + "\"] = tensors[\"" + target_name + "\"]");
   }

--- a/src/codegen/distributed/distributed_ops_codegen.cpp
+++ b/src/codegen/distributed/distributed_ops_codegen.cpp
@@ -33,6 +33,7 @@
 #include "pypto/ir/kind_traits.h"
 #include "pypto/ir/scalar_expr.h"
 #include "pypto/ir/type.h"
+#include "pypto/ir/type_inference.h"
 
 namespace pypto {
 namespace codegen {
@@ -460,6 +461,76 @@ REGISTER_DISTRIBUTED_OP(tensor_slice, "tensor.slice") {
   std::ostringstream line;
   line << "tensors[\"" << lhs << "\"] = tensors[\"" << input_name << "\"][" << indices.str() << "]";
   codegen.Emit(line.str());
+  dist_codegen.MarkDeclared(lhs);
+  return "";
+}
+
+// ============================================================================
+// tensor.assemble — write a source tensor into a target tensor slice.
+//
+// IR form:
+//   result = tensor.assemble(target, source, offset, *, atomic)
+//
+// The operation is SSA-functional but writes in place: ``result`` aliases
+// ``target`` after the source's valid region has been copied into the target
+// window. HOST orchestrators have no atomic-combine instruction, so atomic add
+// is rejected instead of being silently reduced to a plain Python assignment.
+// ============================================================================
+REGISTER_DISTRIBUTED_OP(tensor_assemble, "tensor.assemble") {
+  auto& dist_codegen = dynamic_cast<DistributedCodegen&>(codegen);
+
+  INTERNAL_CHECK_SPAN(op->args_.size() == 3, op->span_)
+      << "Internal error: tensor.assemble expects 3 arguments";
+
+  const int atomic = op->GetKwarg<int>("atomic", static_cast<int>(ir::AtomicType::kNone));
+  CHECK_SPAN(atomic == static_cast<int>(ir::AtomicType::kNone), op->span_)
+      << "pl.assemble(..., atomic=pl.AtomicType.Add) is only supported inside an InCore function. "
+         "This assemble is in a HOST orchestrator, where no atomic-combine instruction exists. Move it "
+         "inside the scope that produces the partial result.";
+
+  const std::string target_name = codegen.GetExprAsCode(op->args_[0]);
+  const std::string source_name = codegen.GetExprAsCode(op->args_[1]);
+  const std::string lhs = codegen.GetCurrentResultTarget();
+  CHECK(!target_name.empty()) << "tensor.assemble target must resolve to a non-empty Python name";
+  CHECK(!source_name.empty()) << "tensor.assemble source must resolve to a non-empty Python name";
+  CHECK(!lhs.empty()) << "tensor.assemble in a HOST orchestrator must have an assignment target";
+
+  auto target_type = ir::As<ir::TensorType>(op->args_[0]->GetType());
+  auto source_type = ir::As<ir::TensorType>(op->args_[1]->GetType());
+  CHECK_SPAN(target_type && source_type, op->span_)
+      << "tensor.assemble in a HOST orchestrator currently supports plain Tensor operands only";
+
+  auto offset_tuple = As<MakeTuple>(op->args_[2]);
+  INTERNAL_CHECK_SPAN(offset_tuple, op->span_) << "Internal error: tensor.assemble offset must be MakeTuple";
+  CHECK_SPAN(offset_tuple->elements_.size() == target_type->shape_.size() &&
+                 source_type->shape_.size() == target_type->shape_.size(),
+             op->span_)
+      << "tensor.assemble in a HOST orchestrator requires target, source, and offset to have the same rank";
+
+  const std::vector<ExprPtr> source_valid_shape = ir::GetValidShape(source_type);
+  std::ostringstream target_indices;
+  std::ostringstream source_indices;
+  for (size_t i = 0; i < source_valid_shape.size(); ++i) {
+    if (i > 0) {
+      target_indices << ", ";
+      source_indices << ", ";
+    }
+    const std::string offset_i = codegen.GetExprAsCode(offset_tuple->elements_[i]);
+    const std::string extent_i = codegen.GetExprAsCode(source_valid_shape[i]);
+    auto offset_const = As<ConstInt>(offset_tuple->elements_[i]);
+    if (offset_const && offset_const->value_ == 0) {
+      target_indices << "0:" << extent_i;
+    } else {
+      target_indices << offset_i << ":" << offset_i << " + " << extent_i;
+    }
+    source_indices << "0:" << extent_i;
+  }
+
+  codegen.Emit("tensors[\"" + target_name + "\"][" + target_indices.str() + "] = tensors[\"" + source_name +
+               "\"][" + source_indices.str() + "]");
+  if (lhs != target_name) {
+    codegen.Emit("tensors[\"" + lhs + "\"] = tensors[\"" + target_name + "\"]");
+  }
   dist_codegen.MarkDeclared(lhs);
   return "";
 }

--- a/tests/ut/codegen/distributed/test_host_orch_distributed.py
+++ b/tests/ut/codegen/distributed/test_host_orch_distributed.py
@@ -114,6 +114,45 @@ def test_host_orch_tensor_assemble_emits_tensor_dict_slice_write():
     compile(code, "<host_orch>", "exec")
 
 
+def test_host_orch_tensor_assemble_right_aligns_lower_rank_source():
+    @pl.program
+    class Prog:
+        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+        def host_orch(self, out: pl.Tensor[[2, 8, 32], pl.FP32]) -> pl.Tensor[[2, 8, 32], pl.FP32]:
+            tmp = pl.create_tensor([4, 16], dtype=pl.FP32)
+            out = pl.assemble(out, tmp, [1, 3, 7])
+            return out
+
+    code = _lower(Prog, convert_to_ssa=True)
+
+    assert re.search(
+        r'tensors\["out__ssa_v0"\]\[1:1 \+ 1, 3:3 \+ 4, 7:7 \+ 16\] = '
+        r'tensors\["tmp__ssa_v0"\]\[0:4, 0:16\]',
+        code,
+    ), code
+    compile(code, "<host_orch>", "exec")
+
+
+def test_host_orch_tensor_assemble_uses_source_valid_shape():
+    @pl.program
+    class Prog:
+        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+        def host_orch(self, out: pl.Tensor[[8, 32], pl.FP32]) -> pl.Tensor[[8, 32], pl.FP32]:
+            tmp = pl.create_tensor([4, 16], dtype=pl.FP32)
+            narrowed = pl.slice(tmp, [4, 16], [0, 0], valid_shape=[3, 9])
+            out = pl.assemble(out, narrowed, [2, 5])
+            return out
+
+    code = _lower(Prog, convert_to_ssa=True)
+
+    assert re.search(
+        r'tensors\["out__ssa_v0"\]\[2:2 \+ 3, 5:5 \+ 9\] = '
+        r'tensors\["narrowed__ssa_v0"\]\[0:3, 0:9\]',
+        code,
+    ), code
+    compile(code, "<host_orch>", "exec")
+
+
 def test_host_orch_atomic_tensor_assemble_is_rejected():
     @pl.program
     class Prog:

--- a/tests/ut/codegen/distributed/test_host_orch_distributed.py
+++ b/tests/ut/codegen/distributed/test_host_orch_distributed.py
@@ -89,6 +89,58 @@ def _lower_host_collectives(program):
 
 
 # ---------------------------------------------------------------------------
+# HOST tensor op lowering and rejection
+# ---------------------------------------------------------------------------
+
+
+def test_host_orch_tensor_assemble_emits_tensor_dict_slice_write():
+    @pl.program
+    class Prog:
+        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+        def host_orch(self, out: pl.Tensor[[8, 32], pl.FP32]) -> pl.Tensor[[8, 32], pl.FP32]:
+            tmp = pl.create_tensor([4, 16], dtype=pl.FP32)
+            out = pl.assemble(out, tmp, [3, 7])
+            return out
+
+    code = _lower(Prog, convert_to_ssa=True)
+
+    assert re.search(
+        r'tensors\["out__ssa_v0"\]\[3:3 \+ 4, 7:7 \+ 16\] = '
+        r'tensors\["tmp__ssa_v0"\]\[0:4, 0:16\]',
+        code,
+    ), code
+    assert re.search(r'tensors\["out__ssa_v1"\] = tensors\["out__ssa_v0"\]', code), code
+    assert "tensor.assemble(" not in code
+    compile(code, "<host_orch>", "exec")
+
+
+def test_host_orch_atomic_tensor_assemble_is_rejected():
+    @pl.program
+    class Prog:
+        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+        def host_orch(self, out: pl.Tensor[[8], pl.FP32]) -> pl.Tensor[[8], pl.FP32]:
+            tmp = pl.create_tensor([8], dtype=pl.FP32)
+            out = pl.assemble(out, tmp, [0], atomic=pl.AtomicType.Add)
+            return out
+
+    with pytest.raises(ValueError, match="only supported inside an InCore function"):
+        _lower(Prog, convert_to_ssa=True)
+
+
+def test_host_orch_unhandled_tensor_op_is_rejected():
+    @pl.program
+    class Prog:
+        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+        def host_orch(self) -> pl.Tensor[[8, 32], pl.FP32]:
+            tmp = pl.create_tensor([256], dtype=pl.FP32)
+            reshaped = pl.reshape(tmp, [8, 32])
+            return reshaped
+
+    with pytest.raises(ValueError, match=r"does not support op 'tensor\.reshape'.*host_orch"):
+        _lower(Prog, convert_to_ssa=True)
+
+
+# ---------------------------------------------------------------------------
 # Positive: DistributedTensor formals + device= → with orch.allocate_domain
 # + Buffer.tensor + add_scalar(ctx) + worker= + world_size lowering
 # ---------------------------------------------------------------------------

--- a/tests/ut/codegen/test_distributed_codegen.py
+++ b/tests/ut/codegen/test_distributed_codegen.py
@@ -175,6 +175,8 @@ class TestDistributedCodegen:
 
         assert "for " in code
         assert "in range(" in code
+        assert "submit_sub" in code
+        assert 'sub_ids["worker"]' in code
 
     def test_python_imports(self):
         """Generated code contains required Python imports."""

--- a/tests/ut/codegen/test_distributed_codegen.py
+++ b/tests/ut/codegen/test_distributed_codegen.py
@@ -159,12 +159,15 @@ class TestDistributedCodegen:
 
         @pl.program
         class Input:
+            @pl.function(level=pl.Level.POD, role=pl.Role.SubWorker)
+            def worker(x: pl.Tensor[[64], pl.FP32]):
+                pass
+
             @pl.function(level=pl.Level.POD, role=pl.Role.Orchestrator)
             def orch_with_loop(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                y: pl.Tensor[[64], pl.FP32] = x
                 for i in pl.range(0, 4):
-                    y = pl.add(y, x)
-                return y
+                    self.worker(x)
+                return x
 
         program = passes.convert_to_ssa()(Input)
         cg = codegen.DistributedCodegen()


### PR DESCRIPTION
## Summary

Addresses #2304 by lowering plain `tensor.assemble` calls in distributed HOST orchestration to tensor-dictionary slice writes. The generated code now preserves every offset dimension and copies only the source valid region. Atomic HOST assemble and other unregistered tensor or tile operations fail with actionable diagnostics instead of producing invalid Python.

## Changes

- `src/codegen/distributed`: register the HOST `tensor.assemble` lowering, preserve SSA aliases, reject unsupported atomic combine, and fail fast on unsupported tensor/tile operations.
- `tests/ut/codegen`: cover multidimensional assemble lowering and rejection paths, and update the loop fixture to use a supported same-level SubWorker dispatch.

## Verification

- `cmake -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo -Dnanobind_DIR=...` and `cmake --build build --parallel "$PYPTO_BUILD_JOBS"`: passed.
- Isolated distributed-codegen tests (`python -S`, no xdist): 69 passed.
- Isolated full codegen suite (`python -S`, no xdist): 888 passed, 2 skipped.
- `ruff check` and `ruff format --check` on the changed Python tests: passed.
- `clang-format --dry-run --Werror` on the changed C++ sources: passed.