### PR TITLE
refactor(runtime): delegate PTO-ISA resolution to simpler and stop reading PTO_ISA_ROOT

### DIFF
--- a/.github/actions/setup-ci-job/action.yml
+++ b/.github/actions/setup-ci-job/action.yml
@@ -4,16 +4,15 @@ description: >-
   `codegen-tests`) and the on-device ones (ci.yml `system-tests`,
   `system-tests-direct`, `dist-system-tests`, `pypto-lib-model`; daily_ci.yml
   `qwen3-perf`). All of them run directly on the host, as the same user, through
-  this one action: resilient submodule checkout into a per-job dir, ptoas +
-  pto-isa install, a per-job conda venv + activate.sh, and a from-source
+  this one action: resilient submodule checkout into a per-job dir, a ptoas
+  install, a per-job conda venv + activate.sh, and a from-source
   build/install of pypto (+ simpler). No container: the CPU jobs used to run in
   `localhost:5000/ci-py310` as root, which forced a root/ci-runner umask split on
   the shared ccache — running them on the host as ci-runner retires that.
 
   The device jobs differ from the CPU ones in two inputs: `needs-device` (gate the
-  npu-smi check + CANN set_env.sh) and `install-toolchain` (gate ptoas download +
-  pto-isa clone + the simpler build — the `--codegen-only` job needs none of
-  them).
+  npu-smi check + CANN set_env.sh) and `install-toolchain` (gate the ptoas
+  download + the simpler build — the `--codegen-only` job needs neither).
 
   Each host describes its own layout in the runner's `.env` (the file in the
   runner application's root dir, which the runner service loads into every job it
@@ -44,7 +43,7 @@ description: >-
   is tempted to find an interpreter on its own; conda is the wrong answer, and
   the right one is to move the step after the bootstrap instead.
 
-  The calling job must define PTOAS_ROOT, PTO_ISA_ROOT, PTOAS_VERSION,
+  The calling job must define PTOAS_ROOT, PTOAS_VERSION,
   PTOAS_SHA256, the CMAKE_* and the non-path CCACHE_* (MAXSIZE / UMASK) environment
   variables; they are read from the job environment here. CCACHE_NAMESPACE and
   every cache path (CCACHE_DIR, PIP_CACHE_DIR, PTOAS_CACHE_DIR, UV_CACHE_DIR) are
@@ -82,18 +81,22 @@ inputs:
     default: 'false'
   install-toolchain:
     description: >-
-      When 'true' (the default) download ptoas, clone the pinned pto-isa, and
-      build+install simpler (./runtime) — everything the codegen -> device path
-      needs. The `--codegen-only` job passes 'false': it never assembles, never
-      touches pto-isa and never runs simpler, so it only needs the pypto build.
+      When 'true' (the default) download ptoas and build+install simpler
+      (./runtime) — everything the codegen -> device path needs. Simpler's own
+      installer resolves the pinned pto-isa checkout (runtime/pto_isa.pin is the
+      single source of truth), so this action never clones it. The
+      `--codegen-only` job passes 'false': it never assembles, never touches
+      pto-isa and never runs simpler, so it only needs the pypto build.
     required: false
     default: 'true'
   pto-isa-commit:
     description: >-
-      pto-isa commit to pin (needs.toolchain.outputs.pto_isa_commit). Required
-      when install-toolchain is 'true' (it selects both the pto-isa checkout and
-      the ccache namespace). Leave empty for the codegen-only job, which pins
-      nothing and keeps ccache in the default namespace.
+      Pinned pto-isa commit (needs.toolchain.outputs.pto_isa_commit, read from
+      runtime/pto_isa.pin). Required when install-toolchain is 'true' — it
+      namespaces ccache so an ISA bump forces a real recompile. It does not
+      select the checkout: simpler resolves that from the pin itself. Leave
+      empty for the codegen-only job, which pins nothing and keeps ccache in the
+      default namespace.
     required: false
     default: ''
   toolchain:
@@ -279,16 +282,6 @@ runs:
       if: ${{ inputs.pto-isa-commit != '' }}
       shell: bash
       run: echo "CCACHE_NAMESPACE=pto-isa-${{ inputs.pto-isa-commit }}" >> "$GITHUB_ENV"
-
-    - name: Clone pto-isa
-      if: ${{ inputs.install-toolchain == 'true' }}
-      shell: bash
-      run: |
-        rm -rf "$PTO_ISA_ROOT"
-        timeout 60 git clone https://github.com/hw-native-sys/pto-isa.git "$PTO_ISA_ROOT" \
-          || { rm -rf "$PTO_ISA_ROOT"; timeout 300 git clone https://gitcode.com/luohuan40/pto-isa.git "$PTO_ISA_ROOT"; }
-        cd "$PTO_ISA_ROOT"
-        git checkout ${{ inputs.pto-isa-commit }}
 
     - name: Bootstrap conda + per-job venv + write activate.sh
       if: ${{ inputs.toolchain == 'conda' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -441,7 +441,6 @@ jobs:
         working-directory: examples-checkout
     env:
       PTOAS_ROOT: ${{ github.workspace }}/examples-checkout/ptoas-bin
-      PTO_ISA_ROOT: ${{ github.workspace }}/examples-checkout/pto-isa
       PTOAS_VERSION: ${{ needs.toolchain.outputs.ptoas_version }}
       PTOAS_SHA256: ${{ needs.toolchain.outputs.ptoas_sha256_aarch64 }}
       CMAKE_BUILD_PARALLEL_LEVEL: 16
@@ -546,8 +545,9 @@ jobs:
       run:
         working-directory: codegen-checkout
     env:
-      # No PTOAS_ROOT / PTO_ISA_ROOT: install-toolchain:false means setup-ci-job
-      # never assembles or clones pto-isa, so codegen-only needs neither.
+      # No PTOAS_ROOT: install-toolchain:false means setup-ci-job never
+      # assembles, so codegen-only needs no ptoas. pto-isa is resolved by
+      # simpler from runtime/pto_isa.pin, which this job never installs.
       CMAKE_BUILD_PARALLEL_LEVEL: 16
       CMAKE_C_COMPILER_LAUNCHER: ccache
       CMAKE_CXX_COMPILER_LAUNCHER: ccache
@@ -640,7 +640,6 @@ jobs:
         working-directory: st-checkout
     env:
       PTOAS_ROOT: ${{ github.workspace }}/st-checkout/ptoas-bin
-      PTO_ISA_ROOT: ${{ github.workspace }}/st-checkout/pto-isa
       PTOAS_VERSION: ${{ needs.toolchain.outputs.ptoas_version }}
       PTOAS_SHA256: ${{ needs.toolchain.outputs.ptoas_sha256_aarch64 }}
       CMAKE_BUILD_PARALLEL_LEVEL: 16
@@ -759,7 +758,6 @@ jobs:
         working-directory: st-direct-checkout
     env:
       PTOAS_ROOT: ${{ github.workspace }}/st-direct-checkout/ptoas-bin
-      PTO_ISA_ROOT: ${{ github.workspace }}/st-direct-checkout/pto-isa
       PTOAS_VERSION: ${{ needs.toolchain.outputs.ptoas_version }}
       PTOAS_SHA256: ${{ needs.toolchain.outputs.ptoas_sha256_aarch64 }}
       CMAKE_BUILD_PARALLEL_LEVEL: 16
@@ -903,7 +901,6 @@ jobs:
         working-directory: dist-checkout
     env:
       PTOAS_ROOT: ${{ github.workspace }}/dist-checkout/ptoas-bin
-      PTO_ISA_ROOT: ${{ github.workspace }}/dist-checkout/pto-isa
       PTOAS_VERSION: ${{ needs.toolchain.outputs.ptoas_version }}
       PTOAS_SHA256: ${{ needs.toolchain.outputs.ptoas_sha256_aarch64 }}
       CMAKE_BUILD_PARALLEL_LEVEL: 16
@@ -988,7 +985,6 @@ jobs:
         working-directory: lib-checkout
     env:
       PTOAS_ROOT: ${{ github.workspace }}/lib-checkout/ptoas-bin
-      PTO_ISA_ROOT: ${{ github.workspace }}/lib-checkout/pto-isa
       PTOAS_VERSION: ${{ needs.toolchain.outputs.ptoas_version }}
       PTOAS_SHA256: ${{ needs.toolchain.outputs.ptoas_sha256_aarch64 }}
       CMAKE_BUILD_PARALLEL_LEVEL: 16

--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -41,7 +41,6 @@ jobs:
         shell: bash -leo pipefail {0}
     env:
       PTOAS_ROOT: ${{ github.workspace }}/ptoas-bin
-      PTO_ISA_ROOT: ${{ github.workspace }}/pto-isa
       PTOAS_VERSION: ${{ needs.toolchain.outputs.ptoas_version }}
       PTOAS_SHA256: ${{ needs.toolchain.outputs.ptoas_sha256_aarch64 }}
     steps:
@@ -135,7 +134,6 @@ jobs:
         working-directory: perf-checkout
     env:
       PTOAS_ROOT: ${{ github.workspace }}/perf-checkout/ptoas-bin
-      PTO_ISA_ROOT: ${{ github.workspace }}/perf-checkout/pto-isa
       PTOAS_VERSION: ${{ needs.toolchain.outputs.ptoas_version }}
       PTOAS_SHA256: ${{ needs.toolchain.outputs.ptoas_sha256_aarch64 }}
       CMAKE_BUILD_PARALLEL_LEVEL: 16

--- a/docs/en/dev/00-ecosystem.md
+++ b/docs/en/dev/00-ecosystem.md
@@ -135,13 +135,19 @@ Defines the tile-level instruction set for the target hardware. Provides C++ hea
 
 **Interface:** C++ header library defining the instruction API. Downstream consumers `#include` pto-isa headers; the hardware vendor provides the target-specific implementations that back these headers.
 
-PyPTO's managed checkout under `build_output/_deps/pto-isa` uses the commit in
-`runtime/pto_isa.pin`, matching the runtime submodule's build. To change the
-revision, update the runtime-side pin. Source checkouts read the submodule pin;
-installed environments read the same pin packaged with `simpler_setup`. If the
-pin file is unavailable, PyPTO falls back to the pto-isa remote's default branch
-tip. A caller-provided `PTO_ISA_ROOT` is used as-is and remains under the
-caller's control.
+`runtime/pto_isa.pin` is the single source of truth for the revision, and
+simpler owns the only resolver (`simpler_setup.pto_isa.ensure_pto_isa_root`):
+it manages one checkout under the runtime's `build/pto-isa`, reuses it only when
+that tree is clean and already at the pin, re-clones it otherwise, and verifies
+`HEAD` before returning. PyPTO delegates to it rather than resolving the pin
+itself — a second resolver could hand the kernel compiler an off-pin tree, and
+the compiler skips its own revision re-check precisely because the resolver
+already guaranteed the pin. To change the revision, update the runtime-side pin.
+
+`PTO_ISA_ROOT` is *exported* with the resolved path so downstream consumers that
+build extern CCE kernels can find the ISA headers, but it is never *read*: an
+ambient value is not the pin. Code that needs the headers should call
+`pypto.runtime.pto_isa_include_dir()` instead of reading the variable.
 
 ### simpler — Task Runtime
 

--- a/docs/zh/dev/00-ecosystem.md
+++ b/docs/zh/dev/00-ecosystem.md
@@ -135,12 +135,16 @@ Python DSL → IR（不可变树）→ Pass Pipeline（20+ passes）→ CodeGen
 
 **接口：** 定义指令 API 的 C++ 头文件库。下游消费者 `#include` pto-isa 头文件；硬件厂商提供支撑这些头文件的目标特定实现。
 
-PyPTO 使用 `runtime/pto_isa.pin` 中的提交来管理
-`build_output/_deps/pto-isa` 下的检出，从而与 runtime 子模块的构建保持一致。如需
-更改版本，应更新 runtime 侧的 pin。源码检出会读取子模块中的 pin，安装环境则读取
-随 `simpler_setup` 一同安装的相同 pin。如果 pin 文件不可用，PyPTO 会回退到
-pto-isa 远程仓库默认分支的最新提交。调用方提供的 `PTO_ISA_ROOT` 会直接使用，其
-版本由调用方自行管理。
+`runtime/pto_isa.pin` 是版本的唯一真相来源，解析器只有 simpler 一份
+（`simpler_setup.pto_isa.ensure_pto_isa_root`）：它在 runtime 的 `build/pto-isa`
+下管理唯一一份检出，仅当该工作树干净且已停在 pin 上时才复用，否则重新克隆，并在
+返回前校验 `HEAD`。PyPTO 委托给它而不自行解析 pin —— 第二份解析器可能把偏离 pin
+的目录交给 kernel 编译器，而编译器正是因为"解析器已保证 pin"才跳过自己的版本复
+查。如需更改版本，应更新 runtime 侧的 pin。
+
+`PTO_ISA_ROOT` 会被*导出*为解析结果，供构建 extern CCE kernel 的下游消费者找到
+ISA 头文件；但它永远不会被*读取* —— 环境里的值不等于 pin。需要头文件路径的代码应
+调用 `pypto.runtime.pto_isa_include_dir()`，而不是读这个环境变量。
 
 ### simpler — 任务运行时
 

--- a/python/pypto/runtime/__init__.py
+++ b/python/pypto/runtime/__init__.py
@@ -30,6 +30,7 @@ from .distributed_runner import DistributedRunHandle, DistributedWorker, execute
 from .log_config import _ensure_configured as _ensure_log_configured
 from .log_config import configure_log
 from .log_config import current_level as log_level
+from .pto_isa import ensure_pto_isa_root, pto_isa_include_dir
 from .runner import RunConfig, RunResult, compile_program, execute_compiled, run
 from .runtime_base import Worker
 from .tensor_spec import ScalarSpec, TensorSpec
@@ -37,7 +38,6 @@ from .worker import ChipWorker, RegistrationHandle
 
 # Honour ``PYPTO_RUNTIME_LOG`` before any runtime entry point runs.
 _ensure_log_configured()
-
 
 __all__ = [
     "run",
@@ -47,6 +47,8 @@ __all__ = [
     "execute_distributed_compiled",
     "configure_log",
     "log_level",
+    "ensure_pto_isa_root",
+    "pto_isa_include_dir",
     "BenchmarkStats",
     "TraceInvocation",
     "TraceSpan",

--- a/python/pypto/runtime/device_runner.py
+++ b/python/pypto/runtime/device_runner.py
@@ -16,15 +16,15 @@ implementations of:
   assemble into ``ChipCallable``, locate runtime binaries.
 - :func:`execute_on_device`: Run a ``ChipCallable`` on device via ``ChipWorker``.
 - :func:`validate_golden`: Compare actual outputs against golden reference.
-- :func:`ensure_pto_isa_root`: Manage PTO-ISA repository (clone/checkout).
 
 These functions keep orchestration in PyPTO while relying on the installed
 runtime packages for two integration surfaces:
 
 - ``simpler`` provides the ``_task_interface`` nanobind C++ module.
 - ``simpler_setup`` provides the kernel compiler plus packaged runtime sources,
-  binaries, and ``pto_isa.pin`` for non-source installs. In a source checkout,
-  those assets come from the ``runtime/`` git submodule instead.
+  binaries, and ``pto_isa.pin`` for non-source installs, and owns the only
+  PTO-ISA resolver. In a source checkout, those assets come from the
+  ``runtime/`` git submodule instead.
 """
 
 from __future__ import annotations
@@ -56,6 +56,7 @@ from ._binary_cache import (
 )
 from .elf_parser import elf_build_id_64, extract_text_section
 from .kernel_compiler import KernelCompiler
+from .pto_isa import ensure_pto_isa_root
 from .task_interface import (
     CallConfig,  # pyright: ignore[reportAttributeAccessIssue]
     ChipCallable,  # pyright: ignore[reportAttributeAccessIssue]
@@ -125,54 +126,6 @@ def _kernel_cache_file(
         runtime_name=runtime_name,
         include_dirs=include_dirs,
     )
-
-
-# ---------------------------------------------------------------------------
-# PTO-ISA management
-# ---------------------------------------------------------------------------
-
-_PTO_ISA_HTTPS = "https://github.com/hw-native-sys/pto-isa.git"
-_PTO_ISA_SSH = "git@github.com:hw-native-sys/pto-isa.git"
-_PTO_ISA_HTTPS_FALLBACK = "https://gitcode.com/luohuan40/pto-isa.git"
-_PTO_ISA_SSH_FALLBACK = "git@gitcode.com:luohuan40/pto-isa.git"
-_PTO_ISA_PRIMARY_CLONE_TIMEOUT = 60
-_PTO_ISA_FALLBACK_CLONE_TIMEOUT = 300
-_PROJECT_ROOT = Path(__file__).parents[3]
-_PTO_ISA_PIN_PATH = _PROJECT_ROOT / "runtime" / "pto_isa.pin"
-
-
-def _get_pto_isa_clone_path() -> Path:
-    """Return the default path where PTO-ISA is cloned."""
-    return _PROJECT_ROOT / "build_output" / "_deps" / "pto-isa"
-
-
-def _get_runtime_pto_isa_pin_path() -> Path:
-    """Locate the runtime pin in a source checkout or installed runtime package."""
-    if _PTO_ISA_PIN_PATH.parent.is_dir():
-        return _PTO_ISA_PIN_PATH
-
-    try:
-        runtime_root = getattr(import_module("simpler_setup.environment"), "PROJECT_ROOT")
-    except (ImportError, AttributeError):
-        return _PTO_ISA_PIN_PATH
-    return Path(runtime_root) / "pto_isa.pin"
-
-
-def _read_runtime_pto_isa_pin() -> str | None:
-    """Return the runtime's pinned PTO-ISA commit, or ``None`` when unavailable."""
-    pin_path = _get_runtime_pto_isa_pin_path()
-    try:
-        commit = pin_path.read_text(encoding="utf-8").strip()
-    except OSError as e:
-        logger.warning(
-            f"Failed to read runtime PTO-ISA pin at {pin_path}: {e}; falling back to the latest remote HEAD"
-        )
-        return None
-
-    if not commit:
-        logger.warning(f"Runtime PTO-ISA pin at {pin_path} is empty; falling back to the latest remote HEAD")
-        return None
-    return commit
 
 
 def _clean_git_revision(repo_root: Path) -> tuple[bool, str | None]:
@@ -254,175 +207,14 @@ def _current_binary_context(
     )
 
 
-def _clone_pto_isa(clone_path: Path, primary_url: str, fallback_url: str) -> bool:
-    """Clone pto-isa, trying *primary_url* first with a short timeout.
+# ---------------------------------------------------------------------------
+# PTO-ISA management
+# ---------------------------------------------------------------------------
 
-    Returns:
-        ``True`` if the clone succeeded (based on return code), ``False`` otherwise.
-    """
-    clone_path.parent.mkdir(parents=True, exist_ok=True)
-    try:
-        result = subprocess.run(
-            ["git", "clone", primary_url, str(clone_path)],
-            check=False,
-            capture_output=True,
-            text=True,
-            timeout=_PTO_ISA_PRIMARY_CLONE_TIMEOUT,
-        )
-        if result.returncode == 0:
-            return True
-    except subprocess.TimeoutExpired:
-        logger.warning(
-            f"Cloning pto-isa from {primary_url} timed out after "
-            f"{_PTO_ISA_PRIMARY_CLONE_TIMEOUT}s; falling back to {fallback_url}"
-        )
-    except Exception as e:
-        logger.warning(f"Cloning pto-isa from {primary_url} failed: {e}; falling back to {fallback_url}")
-
-    # Clean up any partial clone before retrying with the fallback.
-    if clone_path.exists():
-        shutil.rmtree(clone_path, ignore_errors=True)
-    try:
-        result = subprocess.run(
-            ["git", "clone", fallback_url, str(clone_path)],
-            check=False,
-            capture_output=True,
-            text=True,
-            timeout=_PTO_ISA_FALLBACK_CLONE_TIMEOUT,
-        )
-        if result.returncode != 0:
-            logger.warning(f"Failed to clone pto-isa:\n{result.stderr}")
-            return False
-    except Exception as e:
-        logger.warning(f"Failed to clone pto-isa: {e}")
-        return False
-    return True
-
-
-def ensure_pto_isa_root(clone_protocol: str = "https") -> str | None:
-    """Ensure ``PTO_ISA_ROOT`` is available, either from env or by cloning.
-
-    Args:
-        clone_protocol: ``"https"`` or ``"ssh"``.
-
-    Returns:
-        PTO-ISA root path if successful, ``None`` otherwise.
-    """
-    existing_root = os.environ.get("PTO_ISA_ROOT")
-    if existing_root:
-        return existing_root
-
-    resolved_commit = _read_runtime_pto_isa_pin()
-    clone_path = _get_pto_isa_clone_path()
-    include_dir = clone_path / "include"
-
-    if not (clone_path.exists() and include_dir.exists() and include_dir.is_dir()):
-        if clone_protocol == "https":
-            primary_url, fallback_url = _PTO_ISA_HTTPS, _PTO_ISA_HTTPS_FALLBACK
-        else:
-            primary_url, fallback_url = _PTO_ISA_SSH, _PTO_ISA_SSH_FALLBACK
-        if not _clone_pto_isa(clone_path, primary_url, fallback_url):
-            return None
-        if resolved_commit and not _checkout_pto_isa_commit(clone_path, resolved_commit):
-            return None
-    elif resolved_commit:
-        if not _checkout_pto_isa_commit(clone_path, resolved_commit):
-            return None
-    else:
-        _update_pto_isa_to_latest(clone_path)
-
-    if not include_dir.exists():
-        return None
-
-    resolved = str(clone_path.resolve())
-    os.environ["PTO_ISA_ROOT"] = resolved
-    return resolved
-
-
-def _checkout_pto_isa_commit(clone_path: Path, commit: str) -> bool:
-    """Checkout *commit* and verify that the managed clone resolves to it."""
-    try:
-        result = subprocess.run(
-            ["git", "rev-parse", "HEAD"],
-            check=True,
-            capture_output=True,
-            text=True,
-            cwd=str(clone_path),
-            timeout=5,
-        )
-        current = result.stdout.strip()
-        target = subprocess.run(
-            ["git", "rev-parse", f"{commit}^{{commit}}"],
-            check=False,
-            capture_output=True,
-            text=True,
-            cwd=str(clone_path),
-            timeout=5,
-        )
-        target_revision = target.stdout.strip() if target.returncode == 0 else ""
-        if not target_revision or current != target_revision:
-            subprocess.run(
-                ["git", "fetch", "origin"],
-                capture_output=True,
-                text=True,
-                cwd=str(clone_path),
-                timeout=30,
-                check=True,
-            )
-            subprocess.run(
-                ["git", "checkout", commit],
-                capture_output=True,
-                text=True,
-                cwd=str(clone_path),
-                timeout=30,
-                check=True,
-            )
-            target_revision = subprocess.run(
-                ["git", "rev-parse", f"{commit}^{{commit}}"],
-                check=True,
-                capture_output=True,
-                text=True,
-                cwd=str(clone_path),
-                timeout=5,
-            ).stdout.strip()
-        checked_out = subprocess.run(
-            ["git", "rev-parse", "HEAD"],
-            check=True,
-            capture_output=True,
-            text=True,
-            cwd=str(clone_path),
-            timeout=5,
-        ).stdout.strip()
-        if checked_out != target_revision:
-            logger.warning(f"Failed to verify pto-isa commit {commit}: HEAD is {checked_out or 'unknown'}")
-            return False
-        return True
-    except (OSError, subprocess.SubprocessError) as e:
-        logger.warning(f"Failed to checkout pto-isa commit {commit}: {e}")
-        return False
-
-
-def _update_pto_isa_to_latest(clone_path: Path) -> None:
-    """Fetch and reset existing clone to the remote default branch."""
-    try:
-        subprocess.run(
-            ["git", "fetch", "origin"],
-            capture_output=True,
-            text=True,
-            cwd=str(clone_path),
-            timeout=30,
-            check=True,
-        )
-        subprocess.run(
-            ["git", "reset", "--hard", "origin/HEAD"],
-            capture_output=True,
-            text=True,
-            cwd=str(clone_path),
-            timeout=30,
-            check=True,
-        )
-    except Exception as e:
-        logger.warning(f"Failed to update pto-isa to latest: {e}")
+# Re-exported from ``.pto_isa`` so this module keeps its historical entry point
+# and so tests can monkey-patch the name used by ``_compile_and_assemble_locked``
+# below. The implementation lives there because resolving the pin must not
+# require the Simpler-backed ``task_interface`` extension this module imports.
 
 
 # ---------------------------------------------------------------------------
@@ -758,14 +550,9 @@ def _compile_and_assemble_locked(
     # ``kernel_config.py``; only legacy / hand-written configs omit the key.
     runtime_name = runtime_config.get("runtime", "tensormap_and_ringbuffer")
 
-    # Ensure PTO-ISA root
-    pto_isa_root = ensure_pto_isa_root(clone_protocol="https")
-    if pto_isa_root is None:
-        raise OSError(
-            "PTO_ISA_ROOT could not be resolved.\n"
-            "Please set it to the PTO-ISA root directory, e.g.:\n"
-            "  export PTO_ISA_ROOT=/path/to/pto-isa"
-        )
+    # Resolve the pinned PTO-ISA checkout (raises with an actionable message
+    # when the pin cannot be honoured).
+    pto_isa_root = ensure_pto_isa_root()
 
     # Create compiler
     compiler = KernelCompiler(platform=platform)

--- a/python/pypto/runtime/pto_isa.py
+++ b/python/pypto/runtime/pto_isa.py
@@ -1,0 +1,88 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Resolution of the pinned PTO-ISA checkout.
+
+``runtime/pto_isa.pin`` is the single source of truth for the revision, and
+``simpler_setup.pto_isa`` owns the only resolver. PyPTO deliberately keeps no
+resolver of its own: a second implementation inevitably drifts, and
+:class:`~pypto.runtime.kernel_compiler.KernelCompiler` skips its own revision
+re-check *because* the resolver already guaranteed the pin -- handing it an
+off-pin tree silently compiles kernels against the wrong ISA headers.
+
+This module is deliberately separate from ``device_runner``. Resolving the pin
+is a build-input question, not a device-execution one, so it must stay
+importable in a codegen-only installation that has no ``simpler`` and therefore
+no ``task_interface`` extension. Nothing here imports ``simpler_setup`` at
+module scope.
+"""
+
+import os
+from functools import lru_cache
+from pathlib import Path
+
+
+def ensure_pto_isa_root() -> str:
+    """Resolve the pinned PTO-ISA checkout, cloning it when necessary.
+
+    Delegates to :func:`simpler_setup.pto_isa.ensure_pto_isa_root`, for which
+    ``pto_isa.pin`` is the single source of truth: it reuses a managed checkout
+    only when that checkout is clean and already at the pin, re-clones it
+    otherwise, serializes concurrent resolutions with a file lock, and verifies
+    ``HEAD`` before returning.
+
+    The resolved path is *exported* as ``PTO_ISA_ROOT`` for downstream consumers
+    that build extern CCE kernels and need the ISA include directory. It is
+    never *read* back: an ambient value is not the pin.
+
+    Returns:
+        Absolute path to the pinned PTO-ISA checkout.
+
+    Raises:
+        RuntimeError: If ``pto_isa.pin`` is missing or malformed.
+        OSError: If the pinned checkout cannot be obtained.
+    """
+    resolved = _resolve_pinned_pto_isa_root()
+    os.environ["PTO_ISA_ROOT"] = resolved
+    return resolved
+
+
+def pto_isa_include_dir() -> Path:
+    """Return the include directory of the pinned PTO-ISA checkout.
+
+    Use this instead of reading ``PTO_ISA_ROOT`` when a ``pl.jit.extern`` kernel
+    or an out-of-tree build needs the PTO-ISA headers -- it resolves the pin on
+    demand rather than trusting whatever the ambient environment happens to say.
+
+    Example::
+
+        from pypto.runtime import pto_isa_include_dir
+
+        _INCLUDE = pto_isa_include_dir()
+
+    Returns:
+        Absolute path to ``<pto-isa>/include``.
+
+    Raises:
+        RuntimeError: If ``pto_isa.pin`` is missing or malformed.
+        OSError: If the pinned checkout cannot be obtained.
+    """
+    return Path(ensure_pto_isa_root()) / "include"
+
+
+@lru_cache(maxsize=1)
+def _resolve_pinned_pto_isa_root() -> str:
+    """Resolve the pin once per process (the underlying call takes a file lock)."""
+    # noqa: PLC0415 -- importing at module scope would make this module, and
+    # therefore ``pypto.runtime``, require simpler in a codegen-only install.
+    from simpler_setup.pto_isa import (  # noqa: PLC0415  # pyright: ignore[reportMissingImports]
+        ensure_pto_isa_root as _resolve,
+    )
+
+    return str(Path(_resolve(verbose=True)).resolve())

--- a/tests/st/distributed/test_l3_explicit_dispatch_onboard.py
+++ b/tests/st/distributed/test_l3_explicit_dispatch_onboard.py
@@ -32,7 +32,6 @@ Run on hardware via ``task-submit`` (one chip)::
 
     task-submit --device auto --device-num 1 --run 'cd <repo> && \
         export PYTHONPATH=<repo>/python:$PYTHONPATH && \
-        export PTO_ISA_ROOT=/path/to/pto-isa && \
         python -m pytest tests/st/distributed/test_l3_explicit_dispatch_onboard.py \
         -v --platform a2a3 --device $TASK_DEVICE'
 

--- a/tests/st/harness/core/test_runner.py
+++ b/tests/st/harness/core/test_runner.py
@@ -403,8 +403,8 @@ def _fused_compile_task(
         )
         # Codegen-only runs skip assembly: the .so is never loaded by the
         # execute task (see _fused_execute_task) and assembling here would
-        # both waste work and race on PTO_ISA_ROOT (start_pipeline skips
-        # the pre-resolve under codegen_only).
+        # both waste work and force a pto-isa checkout the run never needs
+        # (start_pipeline skips the pre-resolve under codegen_only).
         if _pipeline_ctx.get("codegen_only"):
             return CompileArtifact(
                 work_dir=work_dir,
@@ -1022,16 +1022,16 @@ def start_pipeline(  # noqa: PLR0913
 
     _batch_stats.clear()  # fresh per session; read by pytest_terminal_summary
 
-    # Resolve PTO_ISA_ROOT once on the main thread before any compile workers
-    # start.  Otherwise concurrent workers race on `git clone` into the same
-    # path — the first wins, the rest fail with "destination already exists"
-    # and propagate "PTO_ISA_ROOT could not be resolved" as a pre-compilation
-    # error.  Once the env var is set, workers short-circuit via the env-var
-    # branch in ensure_pto_isa_root().
+    # Resolve the pinned pto-isa checkout once on the main thread, before any
+    # compile worker starts.  Correctness no longer depends on this — the
+    # resolver serializes concurrent callers with a file lock — but doing it
+    # here keeps the one-time clone off the critical path and surfaces a
+    # missing/unobtainable pin as a clean session error rather than as N
+    # identical per-test compile failures.
     if not codegen_only:
-        from pypto.runtime.device_runner import ensure_pto_isa_root  # noqa: PLC0415
+        from pypto.runtime import ensure_pto_isa_root  # noqa: PLC0415
 
-        ensure_pto_isa_root(clone_protocol="https")
+        ensure_pto_isa_root()
 
     _device_pool = device_pool
     _pipeline_ctx = {

--- a/tests/st/runtime/test_explicit_dispatch_onboard.py
+++ b/tests/st/runtime/test_explicit_dispatch_onboard.py
@@ -51,8 +51,7 @@ import pypto.language as pl
 import pytest
 import torch
 from pypto import ir
-from pypto.runtime import ChipWorker, Worker
-from pypto.runtime.device_runner import ensure_pto_isa_root
+from pypto.runtime import ChipWorker, Worker, ensure_pto_isa_root
 from pypto.runtime.runner import RunConfig
 
 # Compiled programs default to the tensormap_and_ringbuffer runtime; the
@@ -110,17 +109,16 @@ class BackwardMulProgram:
 
 @pytest.fixture(autouse=True)
 def _pto_isa_root(test_config):
-    """Resolve PTO_ISA_ROOT before any on-board runtime build.
+    """Resolve the pinned pto-isa checkout before any on-board runtime build.
 
     Compiling the tensormap_and_ringbuffer runtime for real silicon needs the
     PTO ISA sources. The PTOTestCase harness resolves this once up front; tests
-    here drive ChipWorker directly, so mirror that bootstrap. Honors an existing
-    PTO_ISA_ROOT env var and otherwise auto-clones (same as the harness). The
-    simulator build does not need it, so skip the resolution for ``*sim``.
+    here drive ChipWorker directly, so mirror that bootstrap. The simulator
+    build does not need it, so skip the resolution for ``*sim``.
     """
     if str(test_config.platform).endswith("sim"):
         return
-    ensure_pto_isa_root(clone_protocol="https")
+    ensure_pto_isa_root()
 
 
 @pytest.fixture

--- a/tests/ut/runtime/test_binary_cache_context.py
+++ b/tests/ut/runtime/test_binary_cache_context.py
@@ -239,11 +239,14 @@ def test_non_git_pto_isa_root_does_not_use_pin_as_actual_identity(
     monkeypatch,
     tmp_path: Path,
 ) -> None:
+    """A non-git root has no verifiable revision, so binary reuse must be off.
+
+    The identity has to come from the checkout's own HEAD. Substituting the pin
+    (what the tree is *supposed* to be) would let stale binaries survive.
+    """
     pto_isa_root = tmp_path / "pto-isa"
     pto_isa_root.mkdir()
     monkeypatch.setattr(device_runner, "_runtime_revision", Mock(return_value=_RUNTIME_OLD))
-    read_pin = Mock(return_value=_PTO_ISA)
-    monkeypatch.setattr(device_runner, "_read_runtime_pto_isa_pin", read_pin)
 
     context = device_runner._current_binary_context(
         object(),
@@ -253,7 +256,6 @@ def test_non_git_pto_isa_root_does_not_use_pin_as_actual_identity(
     )
 
     assert context is None
-    read_pin.assert_not_called()
 
 
 def test_installed_runtime_uses_embedded_revision_with_clean_pto_isa(

--- a/tests/ut/runtime/test_pto_isa_resolution.py
+++ b/tests/ut/runtime/test_pto_isa_resolution.py
@@ -7,125 +7,94 @@
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
 
-"""Regression tests for device-runner diagnostics and PTO-ISA resolution."""
+"""Regression tests for PTO-ISA resolution and device-runner diagnostics."""
 
-import logging
 import sys
-from types import ModuleType
+from types import ModuleType, SimpleNamespace
 from unittest.mock import Mock
 
 import pytest
+from pypto.runtime import pto_isa
 
-_RUNTIME_PIN = "83d01313d9bfc247c4b7c8bcf969d1019f0d106f"
+
+@pytest.fixture
+def fake_simpler_pto_isa(monkeypatch, tmp_path):
+    """Stand in for ``simpler_setup.pto_isa`` and count resolver calls."""
+    pto_isa._resolve_pinned_pto_isa_root.cache_clear()
+
+    pinned_root = tmp_path / "managed" / "pto-isa"
+    (pinned_root / "include").mkdir(parents=True)
+
+    resolve = Mock(return_value=str(pinned_root))
+    module = ModuleType("simpler_setup.pto_isa")
+    setattr(module, "ensure_pto_isa_root", resolve)
+    package = ModuleType("simpler_setup")
+    setattr(package, "__path__", [])
+    monkeypatch.setitem(sys.modules, "simpler_setup", package)
+    monkeypatch.setitem(sys.modules, "simpler_setup.pto_isa", module)
+
+    yield SimpleNamespace(root=pinned_root, resolve=resolve)
+
+    pto_isa._resolve_pinned_pto_isa_root.cache_clear()
 
 
-def _configure_existing_clone(device_runner, monkeypatch, tmp_path):
-    clone_path = tmp_path / "pto-isa"
-    (clone_path / "include").mkdir(parents=True)
+def test_resolution_delegates_to_simpler_and_exports_env(monkeypatch, fake_simpler_pto_isa):
+    """The pinned checkout comes from Simpler; PyPTO only exports the result."""
     monkeypatch.delenv("PTO_ISA_ROOT", raising=False)
-    monkeypatch.setattr(device_runner, "_get_pto_isa_clone_path", lambda: clone_path)
-    return clone_path
+
+    resolved = pto_isa.ensure_pto_isa_root()
+
+    assert resolved == str(fake_simpler_pto_isa.root.resolve())
+    assert pto_isa.os.environ["PTO_ISA_ROOT"] == resolved
+    fake_simpler_pto_isa.resolve.assert_called_once()
 
 
-def test_installed_layout_reads_pin_from_runtime_package(device_runner, monkeypatch, tmp_path):
-    installed_pin = tmp_path / "simpler_setup" / "_assets" / "pto_isa.pin"
-    installed_pin.parent.mkdir(parents=True)
-    installed_pin.write_text(f"{_RUNTIME_PIN}\n", encoding="utf-8")
-    source_pin = tmp_path / "site-packages" / "runtime" / "pto_isa.pin"
-    monkeypatch.setattr(device_runner, "_PTO_ISA_PIN_PATH", source_pin)
+def test_ambient_environment_root_is_ignored(monkeypatch, fake_simpler_pto_isa, tmp_path):
+    """An exported PTO_ISA_ROOT is not the pin — it must never win."""
+    stale_root = tmp_path / "stale-off-pin-pto-isa"
+    stale_root.mkdir()
+    monkeypatch.setenv("PTO_ISA_ROOT", str(stale_root))
 
-    runtime_package = ModuleType("simpler_setup")
-    setattr(runtime_package, "__path__", [])
-    runtime_environment = ModuleType("simpler_setup.environment")
-    setattr(runtime_environment, "PROJECT_ROOT", installed_pin.parent)
-    monkeypatch.setitem(sys.modules, "simpler_setup", runtime_package)
-    monkeypatch.setitem(sys.modules, "simpler_setup.environment", runtime_environment)
+    resolved = pto_isa.ensure_pto_isa_root()
 
-    assert device_runner._read_runtime_pto_isa_pin() == _RUNTIME_PIN
+    assert resolved == str(fake_simpler_pto_isa.root.resolve())
+    assert pto_isa.os.environ["PTO_ISA_ROOT"] == resolved
+    fake_simpler_pto_isa.resolve.assert_called_once()
 
 
-def test_default_revision_uses_runtime_pin(device_runner, monkeypatch, tmp_path):
-    clone_path = _configure_existing_clone(device_runner, monkeypatch, tmp_path)
-    pin_path = tmp_path / "pto_isa.pin"
-    pin_path.write_text(f"{_RUNTIME_PIN}\n")
-    monkeypatch.setattr(device_runner, "_PTO_ISA_PIN_PATH", pin_path)
-    checkout = Mock()
-    update_latest = Mock()
-    monkeypatch.setattr(device_runner, "_checkout_pto_isa_commit", checkout)
-    monkeypatch.setattr(device_runner, "_update_pto_isa_to_latest", update_latest)
+def test_include_dir_is_derived_from_the_pinned_root(fake_simpler_pto_isa):
+    include_dir = pto_isa.pto_isa_include_dir()
 
-    assert device_runner.ensure_pto_isa_root() == str(clone_path.resolve())
-
-    checkout.assert_called_once_with(clone_path, _RUNTIME_PIN)
-    update_latest.assert_not_called()
+    assert include_dir == fake_simpler_pto_isa.root.resolve() / "include"
+    assert include_dir.is_dir()
 
 
-def test_environment_root_is_used_without_checkout(device_runner, monkeypatch, tmp_path):
-    pto_isa_root = tmp_path / "external-pto-isa"
-    monkeypatch.setenv("PTO_ISA_ROOT", str(pto_isa_root))
-    checkout = Mock()
-    read_pin = Mock()
-    monkeypatch.setattr(device_runner, "_checkout_pto_isa_commit", checkout)
-    monkeypatch.setattr(device_runner, "_read_runtime_pto_isa_pin", read_pin)
+def test_resolution_is_cached_per_process(fake_simpler_pto_isa):
+    """The delegate takes a file lock, so repeated compiles must not re-enter it."""
+    first = pto_isa.ensure_pto_isa_root()
+    second = pto_isa.ensure_pto_isa_root()
 
-    assert device_runner.ensure_pto_isa_root() == str(pto_isa_root)
-
-    checkout.assert_not_called()
-    read_pin.assert_not_called()
+    assert first == second
+    fake_simpler_pto_isa.resolve.assert_called_once()
 
 
-def test_fresh_clone_checks_out_runtime_pin(device_runner, monkeypatch, tmp_path):
-    clone_path = tmp_path / "pto-isa"
-    pin_path = tmp_path / "pto_isa.pin"
-    pin_path.write_text(f"{_RUNTIME_PIN}\n")
+def test_unresolvable_pin_raises_instead_of_returning_a_root(monkeypatch):
+    """A failure must surface Simpler's diagnostic, not a silently unpinned path."""
+    pto_isa._resolve_pinned_pto_isa_root.cache_clear()
     monkeypatch.delenv("PTO_ISA_ROOT", raising=False)
-    monkeypatch.setattr(device_runner, "_PTO_ISA_PIN_PATH", pin_path)
-    monkeypatch.setattr(device_runner, "_get_pto_isa_clone_path", lambda: clone_path)
 
-    def clone(*_args):
-        (clone_path / "include").mkdir(parents=True)
-        return True
+    module = ModuleType("simpler_setup.pto_isa")
+    setattr(module, "ensure_pto_isa_root", Mock(side_effect=OSError("PTO-ISA not available.")))
+    package = ModuleType("simpler_setup")
+    setattr(package, "__path__", [])
+    monkeypatch.setitem(sys.modules, "simpler_setup", package)
+    monkeypatch.setitem(sys.modules, "simpler_setup.pto_isa", module)
 
-    monkeypatch.setattr(device_runner, "_clone_pto_isa", clone)
-    checkout = Mock()
-    monkeypatch.setattr(device_runner, "_checkout_pto_isa_commit", checkout)
+    with pytest.raises(OSError, match="PTO-ISA not available"):
+        pto_isa.ensure_pto_isa_root()
 
-    assert device_runner.ensure_pto_isa_root() == str(clone_path.resolve())
-
-    checkout.assert_called_once_with(clone_path, _RUNTIME_PIN)
-
-
-def test_checkout_failure_does_not_return_unpinned_managed_clone(device_runner, monkeypatch, tmp_path):
-    _configure_existing_clone(device_runner, monkeypatch, tmp_path)
-    pin_path = tmp_path / "pto_isa.pin"
-    pin_path.write_text(f"{_RUNTIME_PIN}\n", encoding="utf-8")
-    monkeypatch.setattr(device_runner, "_PTO_ISA_PIN_PATH", pin_path)
-    monkeypatch.setattr(device_runner, "_checkout_pto_isa_commit", Mock(return_value=False))
-
-    assert device_runner.ensure_pto_isa_root() is None
-    assert "PTO_ISA_ROOT" not in device_runner.os.environ
-
-
-@pytest.mark.parametrize("pin_contents", [None, ""])
-def test_unavailable_runtime_pin_falls_back_to_latest(
-    device_runner, monkeypatch, tmp_path, caplog, pin_contents
-):
-    clone_path = _configure_existing_clone(device_runner, monkeypatch, tmp_path)
-    pin_path = tmp_path / "pto_isa.pin"
-    if pin_contents is not None:
-        pin_path.write_text(pin_contents)
-    monkeypatch.setattr(device_runner, "_PTO_ISA_PIN_PATH", pin_path)
-    checkout = Mock()
-    update_latest = Mock()
-    monkeypatch.setattr(device_runner, "_checkout_pto_isa_commit", checkout)
-    monkeypatch.setattr(device_runner, "_update_pto_isa_to_latest", update_latest)
-
-    with caplog.at_level(logging.WARNING):
-        device_runner.ensure_pto_isa_root()
-
-    checkout.assert_not_called()
-    update_latest.assert_called_once_with(clone_path)
-    assert "falling back to the latest remote HEAD" in caplog.text
+    assert "PTO_ISA_ROOT" not in pto_isa.os.environ
+    pto_isa._resolve_pinned_pto_isa_root.cache_clear()
 
 
 def _write_raw_pto(work_dir):


### PR DESCRIPTION
## Summary

PyPTO carried a second pto-isa resolver alongside simpler's, and the two had drifted. Simpler treats `pto_isa.pin` as the single source of truth — it reuses a managed checkout only when that tree is clean and already at the pin, re-clones it otherwise, serializes concurrent callers with a file lock, and verifies `HEAD` before returning. PyPTO's honoured an ambient `PTO_ISA_ROOT` verbatim with no check at all, fell back to the pto-isa remote's default branch tip when the pin was unreadable, and only logged a warning when the checkout did not land on the pin.

The divergence was not cosmetic. `KernelCompiler` skips its own revision re-check on the stated grounds that "the path always comes from `ensure_pto_isa_root()`, which has already verified HEAD == pto_isa.pin". Routed through PyPTO's resolver that premise did not hold, so a stale exported `PTO_ISA_ROOT` silently compiled kernels against off-pin ISA headers with nothing left to catch it.

This deletes PyPTO's resolver and delegates to `simpler_setup.pto_isa`. `PTO_ISA_ROOT` is still *exported* with the resolved path, because downstream extern-CCE-kernel builds read it to find the ISA include directory, but it is never *read* back.

## Changes

- `python/pypto/runtime/pto_isa.py` (new): holds `ensure_pto_isa_root()` and `pto_isa_include_dir()`, delegating to `simpler_setup.pto_isa.ensure_pto_isa_root()` and memoizing per process because the delegate takes a file lock. Deliberately separate from `device_runner`: resolving the pin is a build-input question, not a device-execution one, and this module imports `simpler_setup` only inside the resolver call, so it stays importable in a codegen-only install with no `simpler`.
- `python/pypto/runtime/device_runner.py`: drops the PyPTO-side resolver — `_clone_pto_isa`, `_checkout_pto_isa_commit`, `_update_pto_isa_to_latest`, `_get_pto_isa_clone_path`, `_read_runtime_pto_isa_pin`, `_get_runtime_pto_isa_pin_path`, and the four remote-URL constants — and re-exports `ensure_pto_isa_root` from `.pto_isa`.
- `python/pypto/runtime/__init__.py`: exports both helpers.
- `.github/`: drops the `Clone pto-isa` step and all seven `PTO_ISA_ROOT:` job environment entries. That clone targeted the commit in `runtime/pto_isa.pin`, which is what simpler's installer resolves anyway. The `pto-isa-commit` input stays; it now only namespaces ccache (issue #1139).
- `docs/{en,zh}/dev/00-ecosystem.md`: rewrites the pto-isa paragraph; drops "a caller-provided `PTO_ISA_ROOT` is used as-is".
- `tests/ut/runtime/test_pto_isa_resolution.py`: replaces the pin-mechanics tests (now simpler's responsibility) with delegation, ambient-env-is-ignored, include-dir, per-process caching, and raise-on-failure cases.
- `tests/st/`: harness and fixtures call the new no-argument form; comments no longer describe the env var as the mechanism that de-races compile workers.

## Behavior changes

- `ensure_pto_isa_root()` returns `str` instead of `str | None` and raises simpler's diagnostic on failure. The old `None` path produced an `OSError` advising `export PTO_ISA_ROOT=/path/to/pto-isa`, which is exactly what caused the problem. Its `clone_protocol` parameter is gone (simpler always uses HTTPS with a GitCode fallback).
- An exported `PTO_ISA_ROOT` no longer selects the checkout. Anyone relying on it to point at a hand-managed or off-pin tree loses that override; there is deliberately no replacement, matching simpler, for which the pin is the only truth.

## Follow-up (not in this PR, cross-repo)

`pypto-lib`'s `models/qwen3_14b/paged_attention_cce.py` and the `pypto-user:incore-profiling` scripts still read `os.environ["PTO_ISA_ROOT"]`. They keep working because the export is retained, but `pypto.runtime.pto_isa_include_dir()` is now the supported way to get that path.

## Verification

Built and ran from this worktree (`cmake --build build --parallel 32`), with the pypto editable meta-path finder stripped so the tests exercise worktree code rather than the main checkout. The list below is the push transaction's own validation run against the pushed commit, rebased on `origin/main`.

- `python -m pytest tests/ut/ -q -n 16`: 9900 passed, 8 skipped
- `python -m pytest tests/ut/runtime/ -q -p no:randomly`: 652 passed
- `ruff check python/ tests/`: All checks passed
- `ruff format --check python/ tests/`: 648 files already formatted
- `pyright python/pypto/runtime/{pto_isa,__init__,device_runner}.py`: 0 errors, 0 warnings
- `python tests/lint/check_docs_en_zh_parity.py`: OK, 148 paired markdown paths
- `python tests/lint/check_english_only.py`: 1245 passed, 0 failed
- Manual end-to-end against a real simpler install: with `PTO_ISA_ROOT=/definitely/not/the/pin` exported, `pypto.runtime.pto_isa_include_dir()` resolved to the pin-managed checkout and overwrote the variable, confirming the ambient value is ignored. This also exercised the wheel layout, where the managed checkout lands under `site-packages/simpler_setup/_assets/build/pto-isa`.
- `from pypto.runtime import *` does not import `device_runner`, so the package's wildcard export stays usable without `simpler`.

No on-device ST run: this change does not alter kernel or orchestration codegen, and the ST paths touched are harness bootstrap and docstrings.
