### PR TITLE
feat(ir): add FunctionType::Graph

### DIFF
--- a/docs/en/dev/ir/01-hierarchy.md
+++ b/docs/en/dev/ir/01-hierarchy.md
@@ -509,7 +509,7 @@ func_orch = ir.Function("orchestrator", params, return_types, body, span, ir.Fun
 | Field | Type | Description |
 | ----- | ---- | ----------- |
 | `name_` | string | Function name |
-| `func_type_` | FunctionType | Function type (Opaque, Orchestration, InCore, AIC, AIV, Group, or Spmd) |
+| `func_type_` | FunctionType | Function type (see the FunctionType table below) |
 | `params_` | list[VarPtr] | Parameter variables (DefField) |
 | `param_directions_` | list[ParamDirection] | Parameter directions, same length as params_ |
 | `return_types_` | list[TypePtr] | Return types |
@@ -587,8 +587,20 @@ Consequences:
 | `AIV` | Vector core kernel (specialized InCore) |
 | `Group` | Co-scheduled group of AIC + AIV kernels |
 | `Spmd` | SPMD data-parallel dispatch wrapper |
+| `Inline` | Whole-body substitution at every call site; eliminated by `InlineFunctions` before any other pass |
+| `Graph` | Callable orchestration fragment, recorded once and replayed by the `host_build_graph` runtime |
 
 `IsInCoreType(type)` / `ir.is_incore_type(type)` returns `True` for `InCore`, `AIC`, and `AIV`.
+
+`IsOrchestrationLike(type)` returns `True` for `Orchestration` and `Graph`. Both
+have orchestration bodies, so a pass that processes a function *because it
+orchestrates tasks* must use this rather than `== FunctionType::Orchestration`,
+which silently skips Graph bodies. The exception is code that means "the single
+compilation entry point" — that stays a strict comparison, since a Graph is
+called by the entry and is never the entry itself.
+
+A Graph function derives `{Level::CHIP, Role::Orchestrator}` like any other
+orchestration body, so level and role alone no longer identify the entry either.
 
 ## Program Node
 

--- a/docs/en/dev/language/03-functions.md
+++ b/docs/en/dev/language/03-functions.md
@@ -44,6 +44,30 @@ def aicore_kernel(x: pl.INT64) -> pl.INT64:
 
 When no type is specified, functions default to `Opaque`.
 
+### Graph Fragments
+
+`pl.FunctionType.Graph` marks a function as a recordable orchestration fragment.
+Under the `host_build_graph` runtime each call site becomes one task launch that
+the runtime records on the first call and replays afterwards, so N calls cost one
+graph build instead of N:
+
+```python
+@pl.program
+class Decoder:
+    @pl.function(type=pl.FunctionType.Graph)
+    def layer(self, cur, normed, next_hidden, wq, layer_base: pl.Scalar[pl.INDEX]):
+        ...
+
+    @pl.function
+    def decode(self, cur, normed, next_hidden, wq):
+        for i in pl.range(40):
+            self.layer(cur, normed, next_hidden, wq, i * 5120)
+```
+
+One Graph function is one recorded topology: the runtime identifies the recording
+by the address of the emitted C++ function, so there is no cache key to name or
+keep unique.
+
 ### Parameter Directions
 
 Parameters can have `In` (default), `Out`, or `InOut` directions using wrapper types:

--- a/docs/zh/dev/ir/01-hierarchy.md
+++ b/docs/zh/dev/ir/01-hierarchy.md
@@ -463,7 +463,7 @@ func_orch = ir.Function("orchestrator", params, return_types, body, span, ir.Fun
 | 字段 | 类型 | 说明 |
 | ---- | ---- | ---- |
 | `name_` | string | 函数名称 |
-| `func_type_` | FunctionType | 函数类型（Opaque、Orchestration、InCore、AIC、AIV、Group 或 Spmd） |
+| `func_type_` | FunctionType | 函数类型（见下方 FunctionType 表格） |
 | `params_` | list[VarPtr] | 参数变量 (DefField) |
 | `param_directions_` | list[ParamDirection] | 参数方向，与 params_ 长度相同 |
 | `return_types_` | list[TypePtr] | 返回类型 |
@@ -536,8 +536,19 @@ def sample(logits: pl.Tensor[[B, V], pl.FP32]) -> pl.Tensor[[B], pl.INT32]:
 | `AIV` | Vector 核心内核（特化的 InCore） |
 | `Group` | AIC + AIV 内核的协调调度组 |
 | `Spmd` | SPMD 数据并行调度封装 |
+| `Inline` | 在每个调用点整体替换函数体；由 `InlineFunctions` 在其它 pass 之前消除 |
+| `Graph` | 可调用的编排片段，由 `host_build_graph` runtime 录制一次、之后回放 |
 
 `IsInCoreType(type)` / `ir.is_incore_type(type)` 对 `InCore`、`AIC` 和 `AIV` 返回 `True`。
+
+`IsOrchestrationLike(type)` 对 `Orchestration` 和 `Graph` 返回 `True`。两者的函数体
+都是编排代码，所以「因为它编排任务而处理该函数」的 pass 必须用这个谓词，而不是
+`== FunctionType::Orchestration` —— 后者会静默跳过 Graph 函数体。例外是那些含义为
+「唯一的编译入口」的代码，它们保持严格比较：Graph 是被入口调用的，它本身永远不是
+入口。
+
+Graph 函数和其它编排体一样派生出 `{Level::CHIP, Role::Orchestrator}`，因此仅凭
+level 和 role 也无法再区分出入口。
 
 ## Program 节点
 

--- a/docs/zh/dev/language/03-functions.md
+++ b/docs/zh/dev/language/03-functions.md
@@ -43,6 +43,28 @@ def aicore_kernel(x: pl.INT64) -> pl.INT64:
 
 未指定类型时, 函数默认为 `Opaque`。
 
+### Graph 片段
+
+`pl.FunctionType.Graph` 把函数标记为可录制的编排片段。在 `host_build_graph`
+runtime 下，每个调用点变成一次 task launch：runtime 在第一次调用时录制、之后回放，
+于是 N 次调用只付一次建图代价，而不是 N 次：
+
+```python
+@pl.program
+class Decoder:
+    @pl.function(type=pl.FunctionType.Graph)
+    def layer(self, cur, normed, next_hidden, wq, layer_base: pl.Scalar[pl.INDEX]):
+        ...
+
+    @pl.function
+    def decode(self, cur, normed, next_hidden, wq):
+        for i in pl.range(40):
+            self.layer(cur, normed, next_hidden, wq, i * 5120)
+```
+
+一个 Graph 函数就是一份被录制的拓扑：runtime 用生成的 C++ 函数地址来标识这份录制，
+因此不存在需要命名、也不需要保证唯一的 cache key。
+
 ### 参数方向
 
 参数可以使用包装类型指定 `In` (默认)、`Out` 或 `InOut` 方向:

--- a/include/pypto/ir/function.h
+++ b/include/pypto/ir/function.h
@@ -48,6 +48,11 @@ namespace ir {
  * - Spmd: SPMD data-parallel dispatch wrapper
  * - Inline: Whole-body substitution at every call site by the InlineFunctions
  *   pass. Eliminated from the program before any other pass runs.
+ * - Graph: A callable orchestration fragment. Its body is orchestration code,
+ *   but each call site is a single task launch that the host_build_graph
+ *   runtime records once and replays thereafter. The runtime identifies the
+ *   recording by the address of the emitted C++ function, so one Graph
+ *   function is one recorded topology with no key to keep in sync.
  */
 enum class FunctionType : uint8_t {
   Opaque = 0,         ///< Default: unspecified function type
@@ -57,7 +62,8 @@ enum class FunctionType : uint8_t {
   AIV = 4,            ///< Vector core kernel (specialized InCore)
   Group = 5,          ///< Co-scheduled group of AIC + AIV kernels
   Spmd = 6,           ///< SPMD data-parallel dispatch
-  Inline = 7          ///< Whole-body substitution at every call site
+  Inline = 7,         ///< Whole-body substitution at every call site
+  Graph = 8           ///< Recordable/replayable orchestration fragment
 };
 
 /**
@@ -258,6 +264,8 @@ inline std::string FunctionTypeToString(FunctionType type) {
       return "Spmd";
     case FunctionType::Inline:
       return "Inline";
+    case FunctionType::Graph:
+      return "Graph";
   }
   throw pypto::TypeError("Unknown FunctionType");
 }
@@ -270,6 +278,8 @@ inline std::string FunctionTypeToString(FunctionType type) {
 inline Level FunctionTypeToLevel(FunctionType type) {
   switch (type) {
     case FunctionType::Orchestration:
+    case FunctionType::Graph:
+      // A Graph body is chip-level orchestration; only its call site differs.
       return Level::CHIP;
     case FunctionType::InCore:
       return Level::CHIP_DIE;
@@ -303,6 +313,23 @@ inline bool IsWrapperType(FunctionType type) {
 }
 
 /**
+ * @brief Check if a FunctionType has an orchestration body (Orchestration or Graph)
+ *
+ * Orchestration and Graph bodies are both host/AICPU task-orchestration code, so
+ * every pass that processes a function *because it orchestrates tasks* must
+ * accept both. Prefer this over `== FunctionType::Orchestration`, which silently
+ * skips Graph bodies and produces a program missing whatever that pass
+ * contributes.
+ *
+ * The exception is code that means "the single compilation entry point" rather
+ * than "an orchestration body" — that must stay a strict comparison, since a
+ * Graph is called by the entry, never the entry itself.
+ */
+inline bool IsOrchestrationLike(FunctionType type) {
+  return type == FunctionType::Orchestration || type == FunctionType::Graph;
+}
+
+/**
  * @brief Convert string to FunctionType
  * @param str String representation
  * @return FunctionType enum value
@@ -325,6 +352,8 @@ inline FunctionType StringToFunctionType(const std::string& str) {
     return FunctionType::Spmd;
   } else if (str == "Inline") {
     return FunctionType::Inline;
+  } else if (str == "Graph") {
+    return FunctionType::Graph;
   } else {
     throw pypto::TypeError("Unknown FunctionType: " + str);
   }
@@ -430,10 +459,13 @@ class Function : public IRNode {
     CHECK(params_.size() == param_directions_.size())
         << "params and param_directions must have same size, got " << params_.size() << " vs "
         << param_directions_.size();
-    if (IsInCoreType(func_type_) || func_type_ == FunctionType::Group ||
-        func_type_ == FunctionType::Orchestration) {
+    if (IsInCoreType(func_type_) || func_type_ == FunctionType::Group || IsOrchestrationLike(func_type_)) {
       Level derived_level = FunctionTypeToLevel(func_type_);
-      Role derived_role = (func_type_ == FunctionType::Orchestration) ? Role::Orchestrator : Role::SubWorker;
+      // A Graph body orchestrates tasks, so it is an Orchestrator like any other
+      // orchestration body. Code that must single out the compilation *entry*
+      // therefore cannot key on the role alone — see IsChipOrch in
+      // materialize_comm_domain_scopes_pass.cpp, which excludes Graph explicitly.
+      Role derived_role = IsOrchestrationLike(func_type_) ? Role::Orchestrator : Role::SubWorker;
       if (level_.has_value()) {
         CHECK(*level_ == derived_level)
             << "Function '" << name_ << "' has func_type=" << FunctionTypeToString(func_type_)
@@ -479,10 +511,10 @@ class Function : public IRNode {
   }
 
  public:
-  std::string name_;            // Function name
-  FunctionType func_type_;      // Function type (Opaque, Orchestration, InCore, AIC, AIV, or Group)
-  std::optional<Level> level_;  // Hierarchy level (nullopt = infer from func_type)
-  std::optional<Role> role_;    // Function role (nullopt = default per level)
+  std::string name_;                                     // Function name
+  FunctionType func_type_;                               // Function type (see the FunctionType enum)
+  std::optional<Level> level_;                           // Hierarchy level (nullopt = infer from func_type)
+  std::optional<Role> role_;                             // Function role (nullopt = default per level)
   std::vector<std::pair<std::string, std::any>> attrs_;  // Function-level attributes (key-value metadata)
   bool requires_runtime_binding_ = false;  // SubWorker with abstract (`...`) body: impl bound at runtime
   std::vector<VarPtr> params_;             // Parameter variables
@@ -535,6 +567,16 @@ class Function : public IRNode {
 };
 
 using FunctionPtr = std::shared_ptr<const Function>;
+
+/**
+ * @brief Null-safe overload of IsOrchestrationLike for a function handle
+ *
+ * A null handle is not orchestration-like, so callers that already hold a
+ * possibly-null FunctionPtr need no separate guard.
+ */
+inline bool IsOrchestrationLike(const FunctionPtr& func) {
+  return func != nullptr && IsOrchestrationLike(func->func_type_);
+}
 
 }  // namespace ir
 }  // namespace pypto

--- a/python/bindings/modules/ir.cpp
+++ b/python/bindings/modules/ir.cpp
@@ -1671,6 +1671,7 @@ void BindIR(nb::module_& m) {
       .value("Group", FunctionType::Group, "Co-scheduled group of AIC + AIV kernels")
       .value("Spmd", FunctionType::Spmd, "SPMD data-parallel dispatch")
       .value("Inline", FunctionType::Inline, "Whole-body substitution at every call site")
+      .value("Graph", FunctionType::Graph, "Recordable/replayable orchestration fragment")
       .export_values();
 
   // Level enum — hierarchy level in the Linqu machine model

--- a/python/pypto/language/parser/enum_utils.py
+++ b/python/pypto/language/parser/enum_utils.py
@@ -64,6 +64,7 @@ FUNCTION_TYPE_MAP: dict[str, ir.FunctionType] = {
     "Group": ir.FunctionType.Group,
     "Spmd": ir.FunctionType.Spmd,
     "Inline": ir.FunctionType.Inline,
+    "Graph": ir.FunctionType.Graph,
 }
 
 

--- a/python/pypto/pypto_core/ir.pyi
+++ b/python/pypto/pypto_core/ir.pyi
@@ -836,6 +836,9 @@ class FunctionType(enum.Enum):
     - Spmd: SPMD data-parallel dispatch
     - Inline: Whole-body substitution at every call site by the
       InlineFunctions pass (eliminated before any other pass runs)
+    - Graph: A callable orchestration fragment. Its body is orchestration
+      code, but each call site is a single task launch that the
+      host_build_graph runtime records once and replays thereafter.
     """
 
     Opaque = ...
@@ -861,6 +864,9 @@ class FunctionType(enum.Enum):
 
     Inline = ...
     """Whole-body substitution at every call site."""
+
+    Graph = ...
+    """Recordable/replayable orchestration fragment."""
 
 class Level(enum.Enum):
     """Hierarchy level in the Linqu machine model.

--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -3261,6 +3261,15 @@ class OrchestrationStmtCodegen : public CodegenBase {
       return;
     }
 
+    // A Graph is a task launch, not a kernel, so it has no core type. Its
+    // emission path lands with the rest of Graph Execution; until then, say so
+    // here rather than letting InferFunctionCoreType below abort with an
+    // internal "expects AIC or AIV" error that names nothing actionable.
+    CHECK_SPAN(callee_func->func_type_ != FunctionType::Graph, call->span_)
+        << "Graph function '" << callee_name
+        << "' cannot be compiled yet: type=pl.FunctionType.Graph is authorable, but the orchestration "
+           "codegen that emits a graph launch is not in place yet.";
+
     CoreType core_type = InferFunctionCoreType(callee_func);
     (*func_name_to_core_type_)[callee_name] = core_type;
 

--- a/src/ir/transforms/materialize_comm_domain_scopes_pass.cpp
+++ b/src/ir/transforms/materialize_comm_domain_scopes_pass.cpp
@@ -485,6 +485,11 @@ class DispatchAnalyzer : public IRVisitor {
 
 [[nodiscard]] bool IsChipOrch(const FunctionPtr& func) {
   if (!func || !func->level_.has_value() || *func->level_ != Level::CHIP) return false;
+  // A Graph function carries {CHIP, Orchestrator} exactly like a chip entry, so
+  // the role disjunct below matches it even though its func_type_ does not. It
+  // is a task launched *by* a chip entry, never a host dispatch target, so
+  // exclude it explicitly — narrowing the func_type_ term alone would not help.
+  if (func->func_type_ == FunctionType::Graph) return false;
   return func->func_type_ == FunctionType::Orchestration ||
          (func->role_.has_value() && *func->role_ == Role::Orchestrator);
 }

--- a/src/ir/transforms/outline_cluster_scopes_pass.cpp
+++ b/src/ir/transforms/outline_cluster_scopes_pass.cpp
@@ -253,8 +253,10 @@ Pass OutlineClusterScopes() {
     }
 
     for (const auto& [gvar, func] : program->functions_) {
-      // Only process Opaque and Orchestration functions (Group functions are already outlined)
-      if (func->func_type_ != FunctionType::Opaque && func->func_type_ != FunctionType::Orchestration) {
+      // Only process Opaque and orchestration-like (Orchestration / Graph)
+      // bodies; Group functions are already outlined. A Cluster or Spmd scope
+      // left un-outlined inside a Graph body makes the verifier below fail.
+      if (func->func_type_ != FunctionType::Opaque && !IsOrchestrationLike(func->func_type_)) {
         new_functions.push_back(func);
         continue;
       }

--- a/src/ir/transforms/outline_incore_scopes_pass.cpp
+++ b/src/ir/transforms/outline_incore_scopes_pass.cpp
@@ -198,10 +198,10 @@ Pass OutlineIncoreScopes() {
     }
 
     for (const auto& [gvar, func] : program->functions_) {
-      // Process Opaque and Orchestration functions; other function types
-      // (InCore/Group/Spmd) are already outlined or not expected to carry
-      // InCore scopes.
-      if (func->func_type_ != FunctionType::Opaque && func->func_type_ != FunctionType::Orchestration) {
+      // Process Opaque and orchestration-like (Orchestration / Graph) bodies;
+      // other function types (InCore/Group/Spmd) are already outlined or not
+      // expected to carry InCore scopes.
+      if (func->func_type_ != FunctionType::Opaque && !IsOrchestrationLike(func->func_type_)) {
         new_functions.push_back(func);
         continue;
       }
@@ -242,12 +242,21 @@ Pass OutlineIncoreScopes() {
 
       // Create new function with transformed body.
       // If any InCore scopes were outlined, promote Opaque -> Orchestration.
+      //
+      // The promotion must be conditional on the source type being Opaque. This
+      // expression is an unconditional overwrite, and was only correct while the
+      // gate above admitted exactly {Opaque, Orchestration}; now that Graph is
+      // admitted too, an unguarded write would silently erase the Graph marker
+      // of any Graph function whose body carries an InCore scope, leaving it
+      // indistinguishable from a plain Orchestration entry downstream.
       const auto& outlined = outliner.GetOutlinedFunctions();
-      FunctionType new_func_type = outlined.empty() ? func->func_type_ : FunctionType::Orchestration;
+      FunctionType new_func_type = (outlined.empty() || func->func_type_ != FunctionType::Opaque)
+                                       ? func->func_type_
+                                       : FunctionType::Orchestration;
       auto new_func = MutableCopy(func);
       new_func->body_ = new_body;
       new_func->func_type_ = new_func_type;
-      if (new_func_type == FunctionType::Orchestration) {
+      if (IsOrchestrationLike(new_func_type)) {
         new_func->level_ = FunctionTypeToLevel(new_func_type);
         new_func->role_ = Role::Orchestrator;
       }
@@ -317,8 +326,9 @@ class SplitIncoreOrchPropertyVerifierImpl : public PropertyVerifier {
           diagnostics, "SplitIncoreOrch",
           "InCore ScopeStmt found in non-InCore function (should have been outlined)");
       verifier.VisitStmt(func->body_);
-      // Also check Orchestration functions for leaked compute tensor ops
-      if (func->func_type_ == FunctionType::Orchestration) {
+      // Also check orchestration bodies for leaked compute tensor ops — the
+      // same leak invariant applies to a Graph body.
+      if (IsOrchestrationLike(func->func_type_)) {
         OrchComputeTensorOpVerifier compute_verifier(diagnostics);
         compute_verifier.VisitStmt(func->body_);
       }

--- a/tests/ut/ir/test_function_type.py
+++ b/tests/ut/ir/test_function_type.py
@@ -25,8 +25,13 @@ def test_function_type_enum():
         ir.FunctionType.AIV,
         ir.FunctionType.Group,
         ir.FunctionType.Spmd,
+        ir.FunctionType.Inline,
+        ir.FunctionType.Graph,
     ]
     assert len(all_types) == len(set(all_types))
+    # Distinctness alone cannot notice a member missing from the list above, so
+    # pin the count against the enum itself.
+    assert len(all_types) == len(ir.FunctionType.__members__)
 
 
 def test_function_constructor_with_type():
@@ -240,6 +245,7 @@ def test_function_type_serialization():
 
     non_opaque_types = [
         ir.FunctionType.Orchestration,
+        ir.FunctionType.Graph,
         ir.FunctionType.InCore,
         ir.FunctionType.AIC,
         ir.FunctionType.AIV,

--- a/tests/ut/ir/test_graph_function.py
+++ b/tests/ut/ir/test_graph_function.py
@@ -1,0 +1,197 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""``FunctionType.Graph``.
+
+A Graph function is a callable orchestration fragment: its body is orchestration
+code, but each call site is one task launch that the ``host_build_graph`` runtime
+records once and replays thereafter. The runtime identifies the recording by the
+address of the emitted C++ function, so the type carries no cache key.
+
+Graph is authored like every other function type — ``type=pl.FunctionType.Graph``
+— which is also how it prints, so print->parse works through the same path as the
+rest of the enum.
+"""
+
+import tempfile
+
+import pypto.language as pl
+import pytest
+from pypto import ir
+from pypto.ir.printer import python_print
+from pypto.language.parser.text_parser import parse_program
+
+
+def _layer(program: ir.Program) -> ir.Function:
+    """Fetch the Graph function, narrowing away the Optional for type checking."""
+    func = program.get_function("layer")
+    assert func is not None
+    return func
+
+
+@pl.program
+class GraphInProgram:
+    """The primary authoring path: a Graph method inside ``@pl.program``."""
+
+    @pl.function(type=pl.FunctionType.Graph)
+    def layer(
+        self,
+        a: pl.Tensor[[128, 128], pl.FP32],
+        c: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
+    ) -> pl.Tensor[[128, 128], pl.FP32]:
+        with pl.at(level=pl.Level.CORE_GROUP):
+            t: pl.Tile[[128, 128], pl.FP32] = pl.load(a, [0, 0], [128, 128])
+            pl.store(t, [0, 0], c)
+        return c
+
+
+# ---------------------------------------------------------------------------
+# The enum itself
+# ---------------------------------------------------------------------------
+
+
+def test_graph_is_a_distinct_function_type():
+    assert ir.FunctionType.Graph not in {
+        ir.FunctionType.Opaque,
+        ir.FunctionType.Orchestration,
+        ir.FunctionType.InCore,
+        ir.FunctionType.AIC,
+        ir.FunctionType.AIV,
+        ir.FunctionType.Group,
+        ir.FunctionType.Spmd,
+        ir.FunctionType.Inline,
+    }
+
+
+def test_graph_derives_chip_level_and_orchestrator_role():
+    """A Graph body orchestrates tasks, so it is a chip-level Orchestrator.
+
+    This is what makes ``{CHIP, Orchestrator}`` ambiguous: code that must single
+    out the compilation *entry* can no longer key on level+role, because a Graph
+    now matches too. ``IsChipOrch`` in materialize_comm_domain_scopes_pass.cpp
+    excludes Graph explicitly for exactly this reason.
+    """
+    func = _layer(GraphInProgram)
+    assert func.func_type == ir.FunctionType.Graph
+    assert func.level == ir.Level.CHIP
+    assert func.role == ir.Role.Orchestrator
+
+
+# Serialization round-trip is covered for every non-Opaque type, Graph included,
+# by ``test_function_type_serialization`` in test_function_type.py.
+
+
+# ---------------------------------------------------------------------------
+# Both decorator paths
+# ---------------------------------------------------------------------------
+
+
+def test_graph_type_on_the_standalone_path():
+    # The standalone path builds the IR inside the decorator, rather than
+    # deferring to the @pl.program walker, so it is a genuinely separate route
+    # to the same type.
+    @pl.function(type=pl.FunctionType.Graph)
+    def standalone(
+        a: pl.Tensor[[128, 128], pl.FP32],
+        c: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
+    ) -> pl.Tensor[[128, 128], pl.FP32]:
+        with pl.at(level=pl.Level.CORE_GROUP):
+            t: pl.Tile[[128, 128], pl.FP32] = pl.load(a, [0, 0], [128, 128])
+            pl.store(t, [0, 0], c)
+        return c
+
+    assert standalone.func_type == ir.FunctionType.Graph
+
+
+def test_plain_function_is_unaffected():
+    @pl.function
+    def plain(x: pl.Scalar[pl.INT32]) -> pl.Scalar[pl.INT32]:
+        return x
+
+    assert plain.func_type == ir.FunctionType.Opaque
+
+
+# ---------------------------------------------------------------------------
+# The gap this change opens, reported rather than crashed on
+# ---------------------------------------------------------------------------
+
+
+def test_compiling_a_graph_call_reports_that_codegen_is_missing():
+    """Until the graph-launch emission path lands, say so instead of crashing.
+
+    A Graph callee reaches `InferFunctionCoreType`, which recognises only
+    AIC/AIV and aborts with an internal error naming nothing actionable. This
+    change makes the type authorable, so it also has to make the gap legible.
+
+    The Graph body opens its own device scope, which is how one is actually
+    written — and is only reachable because the scope outliners now admit Graph
+    bodies. Without that the compile would stop earlier on a leftover scope, and
+    this diagnostic would be unreachable for every realistic program.
+
+    The message is matched in full: it names the authoring form, so a spelling
+    that no longer exists would otherwise survive here unnoticed.
+    """
+    from pypto.backend.pto_backend import PartialCodegenError  # noqa: PLC0415
+    from pypto.ir.compile import compile as ir_compile  # noqa: PLC0415
+
+    @pl.program
+    class UsesGraph:
+        @pl.function(type=pl.FunctionType.Graph)
+        def layer(
+            self,
+            a: pl.Tensor[[128, 128], pl.FP32],
+            c: pl.InOut[pl.Tensor[[128, 128], pl.FP32]],
+        ) -> pl.Tensor[[128, 128], pl.FP32]:
+            with pl.at(level=pl.Level.CORE_GROUP):
+                t: pl.Tile[[128, 128], pl.FP32] = pl.load(a, [0, 0], [128, 128])
+                pl.store(t, [0, 0], c)
+            return c
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def main(
+            self,
+            a: pl.Tensor[[128, 128], pl.FP32],
+            c: pl.InOut[pl.Tensor[[128, 128], pl.FP32]],
+        ) -> pl.Tensor[[128, 128], pl.FP32]:
+            c = self.layer(a, c)
+            return c
+
+    expected = (
+        "Graph function 'layer' cannot be compiled yet: type=pl.FunctionType.Graph is authorable, "
+        "but the orchestration codegen that emits a graph launch is not in place yet."
+    )
+    with tempfile.TemporaryDirectory() as out_dir:
+        with pytest.raises(PartialCodegenError) as excinfo:
+            ir_compile(UsesGraph, skip_ptoas=True, platform="a2a3", output_dir=out_dir, dump_passes=False)
+
+    # PartialCodegenError word-wraps each message into a table cell, so compare
+    # against the text with the gutter and the wrapping collapsed away — a
+    # substring match on one line would not notice a stale spelling in another.
+    reported = " ".join(str(excinfo.value).replace("|", " ").split())
+    assert expected in reported
+
+
+# ---------------------------------------------------------------------------
+# print -> parse
+# ---------------------------------------------------------------------------
+
+
+def test_printed_form_is_the_authored_form():
+    text = python_print(GraphInProgram)
+    assert "type=pl.FunctionType.Graph" in text
+
+
+def test_graph_function_roundtrips():
+    reparsed = parse_program(python_print(GraphInProgram))
+    ir.assert_structural_equal(GraphInProgram, reparsed)
+    assert _layer(reparsed).func_type == ir.FunctionType.Graph
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/ut/ir/transforms/test_outline_incore_scopes.py
+++ b/tests/ut/ir/transforms/test_outline_incore_scopes.py
@@ -3068,5 +3068,64 @@ class TestPromotionFoldsParamDimReads:
         assert len(self._dim_reads(self._main_stmts(After))) == 1
 
 
+class TestGraphFunctionTypeIsPreserved:
+    """A Graph body is scanned for InCore scopes without losing its identity.
+
+    The promotion that turns an Opaque body into Orchestration once it has been
+    outlined is an unconditional overwrite of ``func_type_``. That was safe only
+    while the pass admitted exactly Opaque and Orchestration; admitting Graph
+    without guarding the promotion would erase the marker silently, leaving a
+    function indistinguishable from a plain Orchestration entry downstream.
+    """
+
+    @staticmethod
+    def _outline(program):
+        with passes.PassContext([]):
+            return passes.outline_incore_scopes()(passes.convert_to_ssa()(program))
+
+    def test_graph_with_incore_scope_is_outlined_and_stays_graph(self):
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.Graph)
+            def layer(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                with pl.at(level=pl.Level.CORE_GROUP):
+                    y: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
+                return y
+
+        After = self._outline(Before)
+
+        layer = After.get_function("layer")
+        assert layer is not None
+        assert layer.func_type == ir.FunctionType.Graph, "outlining must not overwrite the Graph marker"
+        # The scope really was outlined, so this does not pass by being skipped.
+        assert After.get_function("layer_incore_0") is not None
+
+    def test_graph_without_incore_scope_stays_graph(self):
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.Graph)
+            def layer(self, x: pl.Scalar[pl.INT32]) -> pl.Scalar[pl.INT32]:
+                return x
+
+        layer = self._outline(Before).get_function("layer")
+        assert layer is not None
+        assert layer.func_type == ir.FunctionType.Graph
+
+    def test_opaque_promotion_still_works(self):
+        """Guarding the promotion must not disable it for the Opaque case."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.Opaque)
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                with pl.at(level=pl.Level.CORE_GROUP):
+                    y: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
+                return y
+
+        main = self._outline(Before).get_function("main")
+        assert main is not None
+        assert main.func_type == ir.FunctionType.Orchestration
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
> Rebased onto `main` now that #2408 has merged, so this is a clean single-commit diff. The rest of the series (#2416 → #2417 → #2418 → #2421 → #2423) is held in draft and will be opened one at a time as each lands, to keep device CI off six simultaneous branches.

> **Updated after review discussion:** the `@pl.function(graph="<key>")` marker is gone. Graph is now authored and printed as `type=pl.FunctionType.Graph`, like every other `FunctionType`, and no cache key travels with the function. See [No cache key](#no-cache-key) below. This removed the entire decorator/printer/parser half of the change: `decorator.py`, `decorator.pyi`, `ast_parser.py` and `python_printer.cpp` are back to their `main` contents, and the decorator/printer/parser half of the change went away entirely.

## Summary

A Graph function is a callable orchestration fragment: its body is orchestration code, but each call site is a single task launch that the `host_build_graph` runtime records once and replays thereafter. A 40-layer decoder then costs one graph build instead of forty, and `N × per-layer` ring slots collapse to N outer tasks.

This lands the type. **Nothing consumes it yet** — the passes, the verifier and codegen follow in later PRs in this stack.

```python
@pl.program
class Decoder:
    @pl.function(type=pl.FunctionType.Graph)
    def layer(self, cur, normed, next_hidden, wq, layer_base: pl.Scalar[pl.INDEX]):
        ...

    @pl.function
    def decode(self, ...):
        for i in pl.range(40):
            self.layer(cur, normed, next_hidden, wq_view(i), i * 5120)
```

## `IsOrchestrationLike()`

This helper is the point of the exercise. Orchestration and Graph bodies are both host/AICPU task-orchestration code, so a pass that processes a function *because it orchestrates tasks* must accept both. `== FunctionType::Orchestration` silently skips a Graph body and emits a program missing whatever that pass contributes — no error, just absent output.

Code that means "the single compilation entry point" keeps the strict comparison, since a Graph is called by the entry and is never the entry itself. Rewriting the existing predicates is the next PR in the stack; this one only introduces the helper and documents the rule.

## Level and role no longer identify the entry

A Graph derives `{Level::CHIP, Role::Orchestrator}` like any other orchestration body. `IsChipOrch` in `materialize_comm_domain_scopes_pass.cpp` matched on the role alone, so it would have indexed every Graph function as a host dispatch target — the `func_type_` term there is a disjunct, so narrowing it would not have helped. It now excludes Graph explicitly.

I checked the neighbouring role-based predicates: the other four are additionally gated on `Level::HOST`, which a CHIP-level Graph never satisfies, and `DistributedCodegen` emits only the single highest-level orchestrator, which a CHIP-level Graph can never be in an L3 program.

## No cache key

An earlier revision of this PR carried a user-supplied cache key (`@pl.function(graph="qwen_decoder_layer_v1")`), on the assumption the runtime needed one. It does not. From `runtime/src/common/host_build_graph/docs/GRAPH_EXECUTION.md`:

> The function pointer is the default Graph identity.

```cpp
rt_submit_graph(&graph_function, args, /*variant=*/0);                       // default
rt_submit_graph(GRAPH_KEY("stable_name"), &graph_function, args, /*variant=*/0);  // opt-in
```

PyPTO emits exactly one C++ function per Graph function, so the function pointer is already one-per-topology and unique by construction. The explicit-key overload exists for callers that need a name stable across builds, and the same doc warns:

> The explicit-key overload deliberately excludes the Graph function pointer from the cache identity so the key remains stable; using the same key for different functions can select the wrong recorded topology.

So choosing the key form would trade an identity the compiler guarantees unique for a hand-typed one that two functions can collide on, with a silent wrong replay as the failure mode. The previous revision defended that with a validator, a per-program uniqueness check, and a printer special case — and the uniqueness check was scoped to one `@pl.program` while the runtime requires uniqueness across an orchestration callable, so it would not even have caught the collision it existed for.

Taking the default identity removes all of it. If a stable cross-build name is ever needed, it can be added later as an opt-in without changing anything here.

## The two scope outliners come along

`OutlineIncoreScopes` and `OutlineClusterScopes` admit only `Opaque` and `Orchestration`. A Graph body carrying a `pl.at` scope — which is how one is actually written — therefore stops on a leftover scope long before reaching the "graph codegen is not in place yet" diagnostic this PR adds, making that diagnostic unreachable for every realistic program. Both move to `IsOrchestrationLike` here rather than with the rest of the predicate audit in #2416.

`OutlineIncoreScopes`'s `Opaque -> Orchestration` promotion is an unconditional overwrite of `func_type_`, safe only while the gate admitted exactly those two. It is now guarded on the source type being `Opaque`; an unguarded write would silently erase the Graph marker of every Graph body that has a scope, leaving it indistinguishable from a plain Orchestration entry downstream.

## Round-trip

Graph prints as `type=pl.FunctionType.Graph`, the same form it is authored in, so print→parse goes through the path every other `FunctionType` already uses. `FUNCTION_TYPE_MAP` in `enum_utils.py` gains its one entry — without it, every print→parse roundtrip check (which the UT suite runs after *every* pass) would fail on a Graph program. The `@pl.program` walker needs no change: it already reads `type=` and validates it against that map.

## Test plan

- New `tests/ut/ir/test_graph_function.py`: the enum, level/role derivation, the type on **both** decorator paths, and print→parse round-trip. The not-yet-supported codegen path is exercised by compiling a Graph that opens its own `pl.at` scope — the realistic shape, reachable only because of the outliner change above — and the diagnostic is matched in full (with the `PartialCodegenError` table's wrapping normalised away) so a stale spelling in it cannot survive.
- `tests/ut/ir/transforms/test_outline_incore_scopes.py`: a Graph with an InCore scope is outlined and stays a Graph; one without a scope stays a Graph; the `Opaque -> Orchestration` promotion still fires. The first fails if the promotion guard is reverted.
- `test_function_type.py`: Graph added to the serialization sweep; the enum list now also pins its length against `FunctionType.__members__`, since distinctness alone could not notice a missing member (`Inline` was already absent).
- Full `tests/ut`: 10101 passed, 8 skipped, 1 pre-existing environment failure unrelated to this branch (`test_symlinked_import_path_still_names_the_caller`, which also fails on unmodified `main` in this worktree). Plus clang-format, cpplint, ruff check/format, pyright, and every `tests/lint` script.
