### PR TITLE
fix(core): stop flattening every op-deduction exception to ValueError

### DIFF
--- a/docs/en/dev/02-error-handling.md
+++ b/docs/en/dev/02-error-handling.md
@@ -116,6 +116,11 @@ except Exception as e:
     raise InvalidOperationError(...) from e
 ```
 
+This covers speculative evaluations too, where the broad handler *swallows* rather than
+wraps (`try: ... except Exception: pass`, then fall through to another strategy). Those
+are the worse case: a swallowed `InternalError` is replaced by whatever unrelated error
+the fall-through path raises next.
+
 ### Platform support for stack traces
 
 `3rdparty/libbacktrace` tracks upstream [ianlancetaylor/libbacktrace](https://github.com/ianlancetaylor/libbacktrace).

--- a/docs/en/dev/02-error-handling.md
+++ b/docs/en/dev/02-error-handling.md
@@ -67,6 +67,55 @@ stricter — it rejects anything other than `0` or `1` — so stick to those two
 path — `libbacktrace`, `nanobind`, libc, the C++ standard library, and the `error.h` / `logging.h`
 throw sites (`kFileNameFilter` in `src/core/backtrace.cpp`).
 
+### Augmenting an error without flattening it
+
+An intermediate frame often wants to add context to an error already in flight — the op registry
+appends the IR span to every type-deduction failure, so a message thrown deep inside a deduction
+function still names the offending DSL line. Catching `const Error&` and constructing a fresh
+exception does that, but at two costs: the concrete type collapses to whatever the catcher throws,
+and the stack trace captured at the original throw is replaced by the catcher's own.
+
+Use `Error::RethrowWithMessage` instead. It is virtual and every subclass overrides it, so the
+exception rethrows as its own type carrying the frames of the original throw:
+
+```cpp
+try {
+  result_type = deduce_type_fn(args, kwargs);
+} catch (const Error& e) {
+  // Concrete type and original trace survive; only the message changes.
+  e.RethrowWithMessage(std::string(e.what()) + LocationSuffix(span));
+} catch (const std::exception& e) {
+  // Non-PyPTO exceptions carry no PyPTO trace to keep.
+  throw ValueError(std::string(e.what()) + LocationSuffix(span));
+}
+```
+
+Catching `const std::exception&` alone is the trap: `InternalError`, `TypeError` and `IndexError`
+all derive from `Error : std::runtime_error`, so a single handler that rethrows `ValueError`
+silently flattens every one of them — erasing the `CHECK` / `INTERNAL_CHECK` distinction for
+everything below the catch, and defeating the ordered translator chain in
+`python/bindings/modules/error.cpp` before it can run.
+
+**Adding a new `Error` subclass?** End the class body with `PYPTO_ERROR_RETHROW_SUPPORT(YourError)`,
+which defines the trace-adopting constructor and the override. A subclass that omits it still
+compiles, but rethrows as a plain `Error`. A subclass carrying extra state needs a hand-written
+override so that state survives too — `VerificationError` is the worked example.
+
+The Python parser has the mirror-image trap. Its handlers wrap stray exceptions as source-located
+`ParserError`s, which would re-hide an `InternalError` the moment it escaped C++. Every broad
+`except Exception` on the parse path therefore re-raises `BUG_CLASS_EXCEPTIONS`
+(`python/pypto/language/parser/diagnostics/exceptions.py`) first:
+
+```python
+except ParserError:
+    raise
+except BUG_CLASS_EXCEPTIONS:
+    # Compiler bug, not a bad kernel - surface it with its type and trace intact.
+    raise
+except Exception as e:
+    raise InvalidOperationError(...) from e
+```
+
 ### Platform support for stack traces
 
 `3rdparty/libbacktrace` tracks upstream [ianlancetaylor/libbacktrace](https://github.com/ianlancetaylor/libbacktrace).

--- a/docs/zh/dev/02-error-handling.md
+++ b/docs/zh/dev/02-error-handling.md
@@ -110,6 +110,10 @@ except Exception as e:
     raise InvalidOperationError(...) from e
 ```
 
+这同样适用于推测性求值 —— 那里的宽泛处理块是把异常**吞掉**而非包装(`try: ... except
+Exception: pass`,然后回退到其他解析策略)。这种情况反而更糟:被吞掉的 `InternalError`
+会被回退路径接下来抛出的、毫不相干的错误取代。
+
 ### 栈回溯的平台支持
 
 `3rdparty/libbacktrace` 跟随上游 [ianlancetaylor/libbacktrace](https://github.com/ianlancetaylor/libbacktrace)。

--- a/docs/zh/dev/02-error-handling.md
+++ b/docs/zh/dev/02-error-handling.md
@@ -65,6 +65,51 @@ PTO_BACKTRACE=1 python my_kernel.py   # 所有错误都显示 C++ 栈帧，而�
 libc、C++ 标准库，以及 `error.h` / `logging.h` 中的抛出点（见 `src/core/backtrace.cpp` 的
 `kFileNameFilter`）。
 
+### 在不丢失类型的前提下补充错误信息
+
+中间栈帧常常需要为正在传播的异常补充上下文 —— 算子注册表会为每一次类型推导失败附加 IR span,
+使得深埋在推导函数内部抛出的消息仍然能指向出错的 DSL 行。用 `catch (const Error&)` 再构造一个新
+异常也能做到,但代价有两个:具体异常类型会塌缩成捕获方抛出的那一种,并且原始抛出点捕获的栈回溯
+会被捕获方自己的栈回溯替换掉。
+
+请改用 `Error::RethrowWithMessage`。它是虚函数,每个子类都做了覆写,因此异常会以自身的类型、
+携带原始抛出点的栈帧重新抛出:
+
+```cpp
+try {
+  result_type = deduce_type_fn(args, kwargs);
+} catch (const Error& e) {
+  // 具体类型与原始栈回溯都得以保留,只有消息发生变化。
+  e.RethrowWithMessage(std::string(e.what()) + LocationSuffix(span));
+} catch (const std::exception& e) {
+  // 非 PyPTO 异常本就没有可保留的 PyPTO 栈回溯。
+  throw ValueError(std::string(e.what()) + LocationSuffix(span));
+}
+```
+
+只写 `catch (const std::exception&)` 是典型陷阱:`InternalError`、`TypeError` 和 `IndexError` 都
+派生自 `Error : std::runtime_error`,因此单个重新抛出 `ValueError` 的处理块会把它们统统压平 ——
+这既抹掉了捕获点之下所有代码的 `CHECK` / `INTERNAL_CHECK` 区分,也让
+`python/bindings/modules/error.cpp` 中按派生程度排序的转换链根本没有机会生效。
+
+**新增 `Error` 子类时?** 在类体末尾加上 `PYPTO_ERROR_RETHROW_SUPPORT(YourError)`,它会定义沿用
+既有栈回溯的构造函数和覆写。缺少它仍可编译,但重新抛出时会退化为普通 `Error`。带额外状态的子类
+需要手写覆写以保住这些状态 —— `VerificationError` 就是现成的示例。
+
+Python 解析器有一个镜像陷阱。它的处理块会把漏出的异常包装成带源码位置的 `ParserError`,一旦
+`InternalError` 从 C++ 逃逸出来就会被重新隐藏。因此解析路径上每一个宽泛的 `except Exception` 都
+会先重新抛出 `BUG_CLASS_EXCEPTIONS`(`python/pypto/language/parser/diagnostics/exceptions.py`):
+
+```python
+except ParserError:
+    raise
+except BUG_CLASS_EXCEPTIONS:
+    # Compiler bug, not a bad kernel - surface it with its type and trace intact.
+    raise
+except Exception as e:
+    raise InvalidOperationError(...) from e
+```
+
 ### 栈回溯的平台支持
 
 `3rdparty/libbacktrace` 跟随上游 [ianlancetaylor/libbacktrace](https://github.com/ianlancetaylor/libbacktrace)。

--- a/include/pypto/core/error.h
+++ b/include/pypto/core/error.h
@@ -199,9 +199,62 @@ class Error : public std::runtime_error {
    */
   [[nodiscard]] std::string GetFullMessage() const;
 
+  /**
+   * @brief Rethrow this error as its own concrete type with a replacement message
+   *
+   * Lets an intermediate frame augment the message (e.g. append an IR span) without
+   * flattening the exception type or discarding the stack trace captured at the
+   * original throw site. Catching `const Error&` and constructing a fresh exception
+   * would do both, erasing the CHECK / INTERNAL_CHECK distinction for everything
+   * below the catch.
+   *
+   * Every direct subclass must override this - see PYPTO_ERROR_RETHROW_SUPPORT. This
+   * base implementation covers a plain `Error`.
+   *
+   * @param message Replacement message for the rethrown exception
+   */
+  [[noreturn]] virtual void RethrowWithMessage(const std::string& message) const {
+    throw Error(message, stack_trace_);
+  }
+
+ protected:
+  /**
+   * @brief Constructs an Error adopting an existing stack trace
+   *
+   * Used by RethrowWithMessage so the reported frames stay those of the original
+   * throw. Deliberately not PYPTO_ALWAYS_INLINE: nothing is captured here.
+   *
+   * @param message Error message describing what went wrong
+   * @param stack_trace Stack frames captured at the original throw site
+   */
+  Error(const std::string& message, std::vector<StackFrame> stack_trace)
+      : std::runtime_error(message), stack_trace_(std::move(stack_trace)) {}
+
  private:
   std::vector<StackFrame> stack_trace_;  ///< Captured stack frames at error creation
 };
+
+/**
+ * @brief Give an Error subclass typed, trace-preserving rethrow
+ *
+ * Defines the trace-adopting constructor and the RethrowWithMessage override that
+ * together let an intermediate frame restate the message without changing the
+ * exception type or losing the original stack trace. A subclass that omits this
+ * silently downgrades to a plain `Error` on rethrow.
+ *
+ * Expands to a `public:` section, so place it last in the class body.
+ *
+ * @param ClassName Name of the Error subclass being defined
+ */
+#define PYPTO_ERROR_RETHROW_SUPPORT(ClassName)                                      \
+ protected:                                                                         \
+  ClassName(const std::string& message, std::vector<StackFrame> stack_trace)        \
+      : Error(message, std::move(stack_trace)) {}                                   \
+                                                                                    \
+ public:                                                                            \
+  [[noreturn]] void RethrowWithMessage(const std::string& message) const override { \
+    throw ClassName(message, GetStackTrace());                                      \
+  }
 
 /**
  * @brief Exception raised when a function receives an argument of correct type but inappropriate value
@@ -216,6 +269,8 @@ class Error : public std::runtime_error {
 class ValueError : public Error {
  public:
   PYPTO_ALWAYS_INLINE explicit ValueError(const std::string& message) : Error(message) {}
+
+  PYPTO_ERROR_RETHROW_SUPPORT(ValueError)
 };
 
 /**
@@ -231,6 +286,8 @@ class ValueError : public Error {
 class TypeError : public Error {
  public:
   PYPTO_ALWAYS_INLINE explicit TypeError(const std::string& message) : Error(message) {}
+
+  PYPTO_ERROR_RETHROW_SUPPORT(TypeError)
 };
 
 /**
@@ -247,6 +304,8 @@ class TypeError : public Error {
 class RuntimeError : public Error {
  public:
   PYPTO_ALWAYS_INLINE explicit RuntimeError(const std::string& message) : Error(message) {}
+
+  PYPTO_ERROR_RETHROW_SUPPORT(RuntimeError)
 };
 
 /**
@@ -262,6 +321,8 @@ class RuntimeError : public Error {
 class NotImplementedError : public Error {
  public:
   PYPTO_ALWAYS_INLINE explicit NotImplementedError(const std::string& message) : Error(message) {}
+
+  PYPTO_ERROR_RETHROW_SUPPORT(NotImplementedError)
 };
 
 /**
@@ -277,6 +338,8 @@ class NotImplementedError : public Error {
 class IndexError : public Error {
  public:
   PYPTO_ALWAYS_INLINE explicit IndexError(const std::string& message) : Error(message) {}
+
+  PYPTO_ERROR_RETHROW_SUPPORT(IndexError)
 };
 
 /**
@@ -292,6 +355,8 @@ class IndexError : public Error {
 class AssertionError : public Error {
  public:
   PYPTO_ALWAYS_INLINE explicit AssertionError(const std::string& message) : Error(message) {}
+
+  PYPTO_ERROR_RETHROW_SUPPORT(AssertionError)
 };
 
 /**
@@ -311,6 +376,8 @@ class AssertionError : public Error {
 class InternalError : public Error {
  public:
   PYPTO_ALWAYS_INLINE explicit InternalError(const std::string& message) : Error(message) {}
+
+  PYPTO_ERROR_RETHROW_SUPPORT(InternalError)
 };
 
 /**
@@ -402,6 +469,30 @@ class VerificationError : public Error {
    * @return Const reference to vector of diagnostics
    */
   [[nodiscard]] const std::vector<Diagnostic>& GetDiagnostics() const { return diagnostics_; }
+
+  /**
+   * @brief Rethrow as a VerificationError with a replacement message
+   *
+   * Hand-written rather than PYPTO_ERROR_RETHROW_SUPPORT: the diagnostics carry the
+   * per-issue detail that makes this exception useful, so they must survive the
+   * rethrow alongside the stack trace.
+   *
+   * @param message Replacement report for the rethrown exception
+   */
+  [[noreturn]] void RethrowWithMessage(const std::string& message) const override {
+    throw VerificationError(message, diagnostics_, GetStackTrace());
+  }
+
+ protected:
+  /**
+   * @brief Constructs a VerificationError adopting an existing stack trace
+   * @param report Formatted verification report
+   * @param diagnostics Vector of all diagnostics (errors and warnings)
+   * @param stack_trace Stack frames captured at the original throw site
+   */
+  VerificationError(const std::string& report, std::vector<Diagnostic> diagnostics,
+                    std::vector<StackFrame> stack_trace)
+      : Error(report, std::move(stack_trace)), diagnostics_(std::move(diagnostics)) {}
 
  private:
   std::vector<Diagnostic> diagnostics_;  ///< All diagnostics (errors and warnings)

--- a/python/bindings/modules/testing.cpp
+++ b/python/bindings/modules/testing.cpp
@@ -104,6 +104,47 @@ namespace python {
 }
 
 /**
+ * @brief Throw the PyPTO exception named by `kind`
+ *
+ * Sole throw site for `rethrow_with_message` below, so tests can assert that the
+ * reported stack trace still names this function after the rethrow.
+ *
+ * @param kind Exception class name, e.g. "InternalError"
+ * @param message Error message to include in the exception
+ */
+[[noreturn]] void RaiseByKind(const std::string& kind, const std::string& message) {
+  if (kind == "ValueError") throw pypto::ValueError(message);
+  if (kind == "TypeError") throw pypto::TypeError(message);
+  if (kind == "RuntimeError") throw pypto::RuntimeError(message);
+  if (kind == "NotImplementedError") throw pypto::NotImplementedError(message);
+  if (kind == "IndexError") throw pypto::IndexError(message);
+  if (kind == "AssertionError") throw pypto::AssertionError(message);
+  if (kind == "InternalError") throw pypto::InternalError(message);
+  if (kind == "Error") throw pypto::Error(message);
+  throw pypto::ValueError("Unknown exception kind for testing: " + kind);
+}
+
+/**
+ * @brief Raise `kind`, then route it through Error::RethrowWithMessage
+ *
+ * Exercises the trace-preserving typed rethrow that OpRegistry::CreateImpl depends on:
+ * the exception reaching Python must keep the concrete type and the frames captured at
+ * the original throw inside RaiseByKind, while carrying the replacement message.
+ *
+ * @param kind Exception class name to raise
+ * @param original Message given to the original exception
+ * @param replacement Message the rethrown exception should carry instead
+ */
+[[noreturn]] void rethrow_with_message(const std::string& kind, const std::string& original,
+                                       const std::string& replacement) {
+  try {
+    RaiseByKind(kind, original);
+  } catch (const pypto::Error& e) {
+    e.RethrowWithMessage(replacement);
+  }
+}
+
+/**
  * @brief Return DSA-RP recognizer output without running placement.
  *
  * This intentionally lives in the internal testing module: production callers
@@ -249,6 +290,10 @@ void BindTesting(nb::module_& m) {
   testing.def("raise_internal_error_with_span", &raise_internal_error_with_span, nb::arg("message"),
               nb::arg("filename"), nb::arg("line"), nb::arg("col"),
               "Raise an InternalError with IR source span for testing");
+
+  testing.def("rethrow_with_message", &rethrow_with_message, nb::arg("kind"), nb::arg("original"),
+              nb::arg("replacement"),
+              "Raise `kind` and rethrow it via Error::RethrowWithMessage for testing");
 
   testing.def("recognize_dsa_reuse_penalties", &RecognizeDsaReusePenaltiesForTesting, nb::arg("function"),
               "Return recognized DSA-RP edges without running placement");

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -8723,6 +8723,11 @@ class ASTParser:
             value = self.expr_evaluator.eval_expr(attr)
             if isinstance(value, ir.MemorySpace):
                 return ir.ConstInt(value.value, DataType.INDEX, self.span_tracker.get_span(attr))
+        except BUG_CLASS_EXCEPTIONS:
+            # This eval is speculative, so its failure is normally not worth reporting - but a
+            # failed internal invariant is, and swallowing it here would replace the diagnostic
+            # with the unrelated "standalone attribute access" error raised below.
+            raise
         except Exception:
             pass
         # This might be accessing a DataType enum or similar

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -35,6 +35,7 @@ from pypto.pypto_core import arith as _arith
 
 from ._dsl_invoker import invoke_dsl
 from .diagnostics import (
+    BUG_CLASS_EXCEPTIONS,
     InvalidOperationError,
     ParserError,
     ParserSyntaxError,
@@ -8242,6 +8243,9 @@ class ASTParser:
             return self._attach_op_attrs(invoke_dsl(op_func, args, kwargs, span), attrs)
         except ParserError:
             raise
+        except BUG_CLASS_EXCEPTIONS:
+            # Compiler bug, not a bad kernel - surface it with its type and trace intact.
+            raise
         except (TypeError, ValueError) as e:
             # Wrapper may have prefixed its message (``pl.<op>:`` from
             # ``_raise_type_dispatch_error`` or ``pl.<module>.<op>:``) or raised
@@ -8401,6 +8405,9 @@ class ASTParser:
         try:
             return self._attach_op_attrs(op_func(*args, **kwargs, span=span), attrs)
         except ParserError:
+            raise
+        except BUG_CLASS_EXCEPTIONS:
+            # Compiler bug, not a bad kernel - surface it with its type and trace intact.
             raise
         except Exception as e:
             raise InvalidOperationError(

--- a/python/pypto/language/parser/decorator.py
+++ b/python/pypto/language/parser/decorator.py
@@ -25,7 +25,7 @@ from pypto.pypto_core import ir
 
 from .ast_parser import ASTParser
 from .comment_extractor import extract_line_comments
-from .diagnostics import ParserError, ParserSyntaxError, concise_error_message
+from .diagnostics import BUG_CLASS_EXCEPTIONS, ParserError, ParserSyntaxError, concise_error_message
 from .enum_utils import FUNCTION_TYPE_MAP, LEVEL_MAP, ROLE_MAP, SPLIT_MODE_MAP, extract_enum_value
 from .source_lookup import get_class_source_lines
 
@@ -1038,6 +1038,9 @@ def function(
             except ParserError:
                 # Re-raise ParserError as-is, it already has source lines
                 raise
+            except BUG_CLASS_EXCEPTIONS:
+                # Compiler bug, not a bad kernel - surface it with its type and trace intact.
+                raise
             except Exception as e:
                 # Wrap unexpected exceptions as ParserError
                 raise ParserSyntaxError(
@@ -1335,6 +1338,9 @@ def program(cls: type | None = None, *, strict_ssa: bool = False) -> ir.Program 
                         hint="Check for Python syntax errors in your function definition",
                     ) from e
                 except ParserError:
+                    raise
+                except BUG_CLASS_EXCEPTIONS:
+                    # Compiler bug, not a bad kernel - surface it with its type and trace intact.
                     raise
                 except Exception as e:
                     raise ParserSyntaxError(

--- a/python/pypto/language/parser/diagnostics/__init__.py
+++ b/python/pypto/language/parser/diagnostics/__init__.py
@@ -11,6 +11,7 @@
 
 from .error_codes import ErrorCategory, ErrorCode, get_error_code
 from .exceptions import (
+    BUG_CLASS_EXCEPTIONS,
     InvalidOperationError,
     ParserError,
     ParserSyntaxError,
@@ -25,6 +26,7 @@ from .renderer import ErrorRenderer
 
 __all__ = [
     # Exceptions
+    "BUG_CLASS_EXCEPTIONS",
     "ParserError",
     "ParserSyntaxError",
     "ParserTypeError",

--- a/python/pypto/language/parser/diagnostics/exceptions.py
+++ b/python/pypto/language/parser/diagnostics/exceptions.py
@@ -9,7 +9,16 @@
 
 """Parser error exceptions with rich diagnostic information."""
 
-from pypto.pypto_core import ir
+from typing import Final
+
+from pypto.pypto_core import InternalError, ir
+
+# Bug-class exceptions: a failed internal invariant is a PyPTO bug, not a bad kernel.
+# Re-wrapping one as a user-facing ParserError hides both its type and the C++ traceback
+# that diagnoses it, so every parser handler that broadly catches `Exception` lets these
+# through untouched. See `.claude/rules/error-checking.md` for the CHECK /
+# INTERNAL_CHECK split this preserves.
+BUG_CLASS_EXCEPTIONS: Final = (InternalError, AssertionError)
 
 
 class ParserError(Exception):

--- a/python/pypto/language/parser/expr_evaluator.py
+++ b/python/pypto/language/parser/expr_evaluator.py
@@ -16,7 +16,7 @@ from pypto.pypto_core import DataType, ir
 
 from ..typing.dynamic import DynVar
 from ..typing.scalar import Scalar
-from .diagnostics import ParserTypeError
+from .diagnostics import BUG_CLASS_EXCEPTIONS, ParserTypeError
 
 if TYPE_CHECKING:
     from .span_tracker import SpanTracker
@@ -88,6 +88,11 @@ class ExprEvaluator:
             # builtins (open, __import__, exec) but does not prevent calling methods on
             # objects the user placed in scope, which is by design.
             return eval(code, {"__builtins__": _SAFE_BUILTINS}, dict(self.closure_vars))  # noqa: S307
+        except BUG_CLASS_EXCEPTIONS:
+            # Compiler bug, not an unevaluatable expression - surface it with its type and
+            # trace intact. try_eval_expr only swallows ParserTypeError, so this propagates
+            # there too rather than silently falling through to another resolution strategy.
+            raise
         except NameError as e:
             raise ParserTypeError(
                 f"Cannot resolve expression '{expr_str}': {e}",

--- a/python/pypto/language/parser/text_parser.py
+++ b/python/pypto/language/parser/text_parser.py
@@ -16,7 +16,7 @@ import types
 
 from pypto.pypto_core import ir
 
-from .diagnostics.exceptions import ParserError, ParserSyntaxError
+from .diagnostics.exceptions import BUG_CLASS_EXCEPTIONS, ParserError, ParserSyntaxError
 from .enum_utils import FUNCTION_TYPE_MAP, LEVEL_MAP, ROLE_MAP
 from .span_tracker import active_source_map, ast_column_to_span_column
 
@@ -261,6 +261,9 @@ def parse(
         exec(compiled_code, exec_ns)
     except ParserError:
         # Re-raise ParserError as-is, it already has source lines
+        raise
+    except BUG_CLASS_EXCEPTIONS:
+        # Compiler bug, not a bad kernel - surface it with its type and trace intact.
         raise
     except Exception as e:
         # Convert exec-time errors to ParserSyntaxError with source location when possible.

--- a/python/pypto/pypto_core/testing.pyi
+++ b/python/pypto/pypto_core/testing.pyi
@@ -53,6 +53,9 @@ def raise_internal_error(message: str) -> NoReturn:
 def raise_internal_error_with_span(message: str, filename: str, line: int, col: int) -> NoReturn:
     """Raise an InternalError with IR source span for testing"""
 
+def rethrow_with_message(kind: str, original: str, replacement: str) -> NoReturn:
+    """Raise `kind` and rethrow it via Error::RethrowWithMessage for testing"""
+
 def recognize_dsa_reuse_penalties(function: Function) -> list[DsaReusePenaltyEdge]:
     """Return recognized DSA-RP edges without running placement."""
 

--- a/src/ir/op/testing.cpp
+++ b/src/ir/op/testing.cpp
@@ -23,8 +23,11 @@
 #include <utility>
 #include <vector>
 
+#include "pypto/core/error.h"
+#include "pypto/core/logging.h"
 #include "pypto/ir/expr.h"
 #include "pypto/ir/op_registry.h"
+#include "pypto/ir/type.h"
 
 namespace pypto {
 namespace ir {
@@ -44,6 +47,31 @@ REGISTER_OP("test.op")
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
       return args[0]->GetType();
+    });
+
+// Type deduction that fails an internal invariant. Used exclusively to verify that
+// OpRegistry::CreateImpl surfaces the concrete exception type (InternalError) and the
+// stack trace of the real throw site, rather than flattening both into a ValueError
+// raised from the registry itself.
+REGISTER_OP("test.deduce_raises_internal")
+    .set_op_category("TestOp")
+    .set_description("Test-only op whose type deduction fails an internal invariant")
+    .add_argument("x", "Input")
+    .f_deduce_type([](const std::vector<ExprPtr>& args,
+                      const std::vector<std::pair<std::string, std::any>>& kwargs) -> TypePtr {
+      INTERNAL_CHECK(false) << "Internal error: test.deduce_raises_internal always fails";
+      return nullptr;
+    });
+
+// Sibling of the above for the user-error half of the same contract: a TypeError raised
+// during deduction must reach the caller as a TypeError, not a ValueError.
+REGISTER_OP("test.deduce_raises_type")
+    .set_op_category("TestOp")
+    .set_description("Test-only op whose type deduction raises TypeError")
+    .add_argument("x", "Input")
+    .f_deduce_type([](const std::vector<ExprPtr>& args,
+                      const std::vector<std::pair<std::string, std::any>>& kwargs) -> TypePtr {
+      throw TypeError("test.deduce_raises_type always fails");
     });
 
 // Used exclusively to test the "missing conversion" error path in ConvertTensorToTileOps.

--- a/src/ir/op_registry.cpp
+++ b/src/ir/op_registry.cpp
@@ -33,6 +33,15 @@
 namespace pypto {
 namespace ir {
 
+namespace {
+
+/// Format an IR span as a " at <file>:<line>:<col>" suffix, empty when unknown.
+///
+/// Kept out of line so `Span::to_string()` is only paid on the error path.
+std::string LocationSuffix(const Span& span) { return span.is_valid() ? " at " + span.to_string() : ""; }
+
+}  // namespace
+
 void ValidateKwargs(const std::vector<std::pair<std::string, std::any>>& kwargs,
                     const std::unordered_map<std::string, std::type_index>& allowed_kwargs,
                     const std::string& op_name) {
@@ -159,9 +168,15 @@ CallPtr OpRegistry::CreateImpl(const std::string& op_name, const std::vector<Exp
   TypePtr result_type;
   try {
     result_type = deduce_type_fn(args, kwargs);
+  } catch (const Error& e) {
+    // Append the IR location but keep the concrete exception type and the stack trace
+    // captured at the original throw. Flattening every PyPTO exception to ValueError
+    // here erased the CHECK / INTERNAL_CHECK distinction for all op type deduction.
+    e.RethrowWithMessage(std::string(e.what()) + LocationSuffix(span));
   } catch (const std::exception& e) {
-    std::string location = span.is_valid() ? " at " + span.to_string() : "";
-    throw ValueError(std::string(e.what()) + location);
+    // Non-PyPTO exceptions (e.g. std::bad_any_cast from a wrong-typed kwarg) stay
+    // ValueError: they are reachable from user input and carry no PyPTO trace to keep.
+    throw ValueError(std::string(e.what()) + LocationSuffix(span));
   }
   INTERNAL_CHECK_SPAN(result_type, span) << "Type deduction failed for '" + op_name + "'";
 

--- a/tests/ut/core/test_error.py
+++ b/tests/ut/core/test_error.py
@@ -498,6 +498,7 @@ class TestRethrowWithMessage:
         assert "replacement" in message
         assert "original" not in message
 
+    @pytest.mark.skipif(_MACOS, reason="macOS cannot symbolize a CPython MH_BUNDLE extension module")
     @pytest.mark.parametrize("kind", ["InternalError", "AssertionError"])
     def test_bug_class_keeps_the_original_throw_site(self, kind: str, no_backtrace_env: None):
         """The trace keeps the frame that threw, below the frame that caught and rethrew.
@@ -516,6 +517,7 @@ class TestRethrowWithMessage:
             f"expected both the throw and rethrow frames, got {len(binding_frames)} in: {files}"
         )
 
+    @pytest.mark.skipif(_MACOS, reason="macOS cannot symbolize a CPython MH_BUNDLE extension module")
     def test_direct_raise_has_one_frame_at_the_throw_site(self, no_backtrace_env: None):
         """Baseline for the test above: a plain raise contributes exactly one binding frame."""
         with pytest.raises(pypto.InternalError) as exc_info:

--- a/tests/ut/core/test_error.py
+++ b/tests/ut/core/test_error.py
@@ -460,5 +460,78 @@ class TestSpanInErrors:
         assert "Check failed:" in error_str
 
 
+class TestRethrowWithMessage:
+    """Test `Error::RethrowWithMessage` — typed, trace-preserving message replacement.
+
+    An intermediate frame often wants to add context to an in-flight error (the op registry
+    appends the IR span to every type-deduction failure). Catching `const Error&` and
+    constructing a fresh exception does that at the cost of collapsing the concrete type and
+    replacing the original stack trace with the catcher's own. `RethrowWithMessage` exists so
+    that context can be added without paying either.
+    """
+
+    _EXPECTED_PY_TYPE = {
+        "ValueError": ValueError,
+        "TypeError": TypeError,
+        "RuntimeError": RuntimeError,
+        "NotImplementedError": NotImplementedError,
+        "IndexError": IndexError,
+        "AssertionError": AssertionError,
+        "InternalError": pypto.InternalError,
+        "Error": pypto.Error,
+    }
+
+    @pytest.mark.parametrize("kind", list(_EXPECTED_PY_TYPE))
+    def test_concrete_type_is_preserved(self, kind: str):
+        """Each subclass rethrows as itself, not as its base or as ValueError."""
+        with pytest.raises(self._EXPECTED_PY_TYPE[kind]):
+            testing.rethrow_with_message(kind, "original", "replacement")
+
+    @pytest.mark.parametrize("kind", list(_EXPECTED_PY_TYPE))
+    def test_message_is_replaced(self, kind: str):
+        with pytest.raises(self._EXPECTED_PY_TYPE[kind]) as exc_info:
+            testing.rethrow_with_message(kind, "original", "replacement")
+
+        # Bug-class errors append the traceback, which echoes the source line of each
+        # frame - including `RaiseByKind(kind, original);`. Compare only the message.
+        message = str(exc_info.value).split(_TRACE_HEADER, 1)[0]
+        assert "replacement" in message
+        assert "original" not in message
+
+    @pytest.mark.parametrize("kind", ["InternalError", "AssertionError"])
+    def test_bug_class_keeps_the_original_throw_site(self, kind: str, no_backtrace_env: None):
+        """The trace keeps the frame that threw, below the frame that caught and rethrew.
+
+        Both frames live in the binding module, so their *count* is what discriminates:
+        RaiseByKind and rethrow_with_message contribute one each when the trace is carried
+        over, while constructing a fresh exception in the catch block would leave only the
+        latter - every frame below the catch having already been unwound.
+        """
+        with pytest.raises((pypto.InternalError, AssertionError)) as exc_info:
+            testing.rethrow_with_message(kind, "original", "replacement")
+
+        files = _assert_has_trace(str(exc_info.value))
+        binding_frames = [f for f in files if f.endswith("python/bindings/modules/testing.cpp")]
+        assert len(binding_frames) >= 2, (
+            f"expected both the throw and rethrow frames, got {len(binding_frames)} in: {files}"
+        )
+
+    def test_direct_raise_has_one_frame_at_the_throw_site(self, no_backtrace_env: None):
+        """Baseline for the test above: a plain raise contributes exactly one binding frame."""
+        with pytest.raises(pypto.InternalError) as exc_info:
+            testing.raise_internal_error("invariant broken")
+
+        files = _assert_has_trace(str(exc_info.value))
+        binding_frames = [f for f in files if f.endswith("python/bindings/modules/testing.cpp")]
+        assert len(binding_frames) == 1, f"expected a single binding frame, got: {files}"
+
+    def test_internal_error_is_not_a_value_error(self):
+        """The regression this mechanism exists to prevent."""
+        with pytest.raises(pypto.InternalError) as exc_info:
+            testing.rethrow_with_message("InternalError", "original", "replacement")
+
+        assert not isinstance(exc_info.value, ValueError)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/ir/operators/test_op_registry.py
+++ b/tests/ut/ir/operators/test_op_registry.py
@@ -958,9 +958,22 @@ class TestDeduceTypeExceptionPassthrough:
         assert "kernel.py:12:15" in str(exc_info.value)
 
     def test_unknown_span_appends_no_location(self):
-        with pytest.raises(pypto.InternalError) as exc_info:
-            ir.create_op_call("test.deduce_raises_internal", [self._arg()], ir.Span.unknown())
-        assert "always fails" in str(exc_info.value)
+        """An unknown span adds nothing - not a rendered placeholder.
+
+        `Span.unknown()` stringifies to ":-1:-1", so a merely-substring assertion would
+        stay green if the guard in LocationSuffix were dropped. Comparing the two messages
+        for exact equality pins the behaviour in both directions instead: the located one
+        must differ by the suffix and nothing else. Uses the TypeError op because it is
+        user-class, so neither message carries a traceback that would need filtering.
+        """
+        with pytest.raises(TypeError) as unknown_info:
+            ir.create_op_call("test.deduce_raises_type", [self._arg()], ir.Span.unknown())
+        with pytest.raises(TypeError) as located_info:
+            ir.create_op_call("test.deduce_raises_type", [self._arg()], ir.Span("kernel.py", 12, 15))
+
+        unknown_message = str(unknown_info.value)
+        assert unknown_message == "test.deduce_raises_type always fails"
+        assert str(located_info.value) == f"{unknown_message} at kernel.py:12:15"
 
     def test_type_error_is_not_flattened(self):
         """The user-error half of the contract: TypeError stays a TypeError."""

--- a/tests/ut/ir/operators/test_op_registry.py
+++ b/tests/ut/ir/operators/test_op_registry.py
@@ -17,6 +17,9 @@ Tests cover:
 - Error cases
 """
 
+import sys
+
+import pypto
 import pytest
 from pypto import DataType, ir
 from pypto.pypto_core import testing
@@ -906,6 +909,69 @@ class TestNoDuplicateOps:
     def test_no_duplicate_rejects_unknown_op(self):
         with pytest.raises(ValueError):
             testing.is_no_duplicate_op("pld.system.not_an_op")
+
+
+class TestDeduceTypeExceptionPassthrough:
+    """`OpRegistry::CreateImpl` must not flatten deduction failures to ValueError.
+
+    Every op Call is built through that one funnel. It appends the IR span to the
+    message, and used to do so by catching `const std::exception&` and rethrowing a
+    fresh `ValueError` - which collapsed InternalError / TypeError / IndexError into
+    one class and replaced the stack trace of the real throw site with its own.
+    """
+
+    @staticmethod
+    def _arg():
+        return ir.ConstInt(1, DataType.INT32, ir.Span.unknown())
+
+    def test_internal_error_is_not_flattened(self):
+        """An INTERNAL_CHECK inside type deduction stays an InternalError."""
+        with pytest.raises(pypto.InternalError):
+            ir.create_op_call("test.deduce_raises_internal", [self._arg()], ir.Span.unknown())
+
+    def test_internal_error_is_not_a_value_error(self):
+        """Guards the specific regression: InternalError must not be catchable as ValueError."""
+        with pytest.raises(pypto.InternalError) as exc_info:
+            ir.create_op_call("test.deduce_raises_internal", [self._arg()], ir.Span.unknown())
+        assert not isinstance(exc_info.value, ValueError)
+
+    @pytest.mark.skipif(
+        sys.platform == "darwin", reason="libbacktrace cannot symbolize an MH_BUNDLE on macOS"
+    )
+    def test_internal_error_keeps_original_throw_site(self):
+        """The trace still reaches the deduction function that actually threw.
+
+        Constructing a fresh exception in the registry's catch block would root the trace
+        at the catch instead, losing every frame below it - so the presence of the
+        deduction site is what distinguishes a preserved trace from a rebuilt one.
+        (`op_registry.cpp` appears either way: it is a genuine caller frame.)
+        """
+        with pytest.raises(pypto.InternalError) as exc_info:
+            ir.create_op_call("test.deduce_raises_internal", [self._arg()], ir.Span.unknown())
+        assert "src/ir/op/testing.cpp" in str(exc_info.value)
+
+    def test_span_is_still_appended(self):
+        """Preserving the type must not cost the IR location the funnel adds."""
+        span = ir.Span("kernel.py", 12, 15)
+        with pytest.raises(pypto.InternalError) as exc_info:
+            ir.create_op_call("test.deduce_raises_internal", [self._arg()], span)
+        assert "kernel.py:12:15" in str(exc_info.value)
+
+    def test_unknown_span_appends_no_location(self):
+        with pytest.raises(pypto.InternalError) as exc_info:
+            ir.create_op_call("test.deduce_raises_internal", [self._arg()], ir.Span.unknown())
+        assert "always fails" in str(exc_info.value)
+
+    def test_type_error_is_not_flattened(self):
+        """The user-error half of the contract: TypeError stays a TypeError."""
+        with pytest.raises(TypeError) as exc_info:
+            ir.create_op_call("test.deduce_raises_type", [self._arg()], ir.Span.unknown())
+        assert not isinstance(exc_info.value, ValueError)
+
+    def test_value_error_still_surfaces_as_value_error(self):
+        """The common case is unchanged: a CHECK in deduction stays a ValueError."""
+        with pytest.raises(ValueError):
+            ir.create_op_call("tile.cast", [self._arg()], ir.Span.unknown())
 
 
 if __name__ == "__main__":

--- a/tests/ut/ir/test_distributed_ops.py
+++ b/tests/ut/ir/test_distributed_ops.py
@@ -25,6 +25,7 @@ After the MemRef-mirror redesign:
 from importlib import resources
 from typing import Any, cast
 
+import pypto
 import pytest
 from pypto import DataType, ir
 from pypto.ir.op.distributed import system_ops as dist_system_ops
@@ -1814,7 +1815,9 @@ def test_tile_put_rejects_stage_larger_than_transfer():
     # 128 cols > 64 transfer cols.
     stage = _make_tile_var("stage", [16, 128], DataType.FP16, span)
 
-    with pytest.raises(ValueError, match="must fit within"):
+    # InternalError, not ValueError: pld.tile.put is materialised by ConvertTensorToTileOps
+    # and its staging tile is compiler-created, so an oversized stage is a pass bug.
+    with pytest.raises(pypto.InternalError, match="must fit within"):
         dist_tile_ops.put(dst, peer, src, stage, atomic=ir.AtomicType.None_, span=span)
 
 
@@ -2169,7 +2172,8 @@ def test_tile_get_rejects_stage_larger_than_transfer():
     # 32 rows > 16 transfer rows.
     stage = _make_tile_var("stage", [32, 64], DataType.FP16, span)
 
-    with pytest.raises(ValueError, match="must fit within"):
+    # InternalError, not ValueError: see the put sibling above.
+    with pytest.raises(pypto.InternalError, match="must fit within"):
         dist_tile_ops.get(dst, peer, src, stage, span=span)
 
 

--- a/tests/ut/language/parser/test_error_wrapping.py
+++ b/tests/ut/language/parser/test_error_wrapping.py
@@ -208,6 +208,28 @@ class TestBugClassErrorsAreNotWrapped:
                 result: pl.Tensor[[64], pl.BF16] = pl.tensor.cast(x, target_type=pl.BF16)
                 return result
 
+    def test_assertion_error_from_op_is_not_wrapped(self, monkeypatch):
+        """The other arm of BUG_CLASS_EXCEPTIONS.
+
+        A bare `AssertionError` is bug-class for the same reason `InternalError` is, and
+        pytest's own machinery depends on it propagating - wrapping one would turn a
+        failed assertion anywhere under the parser into a confusing kernel diagnostic.
+        """
+
+        def _raise_assertion(*args, **kwargs):
+            raise AssertionError("synthetic failed assertion")
+
+        monkeypatch.setattr(_dsl_tensor, "cast", _raise_assertion)
+
+        with pytest.raises(AssertionError, match="synthetic failed assertion") as exc_info:
+
+            @pl.function
+            def bad_kernel(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.BF16]:
+                result: pl.Tensor[[64], pl.BF16] = pl.tensor.cast(x, target_type=pl.BF16)
+                return result
+
+        assert not isinstance(exc_info.value, ParserError)
+
     def test_internal_error_is_not_a_parser_error(self, monkeypatch):
         """Guards the specific regression: it must not be catchable as ParserError."""
         monkeypatch.setattr(_dsl_tensor, "cast", self._raise_internal)

--- a/tests/ut/language/parser/test_error_wrapping.py
+++ b/tests/ut/language/parser/test_error_wrapping.py
@@ -15,9 +15,11 @@ subclasses with source location information, rather than escaping as raw
 tracebacks.
 """
 
+import pypto
 import pypto.language as pl
 import pytest
 from pypto import ir
+from pypto.language.op import tensor_ops as _dsl_tensor
 from pypto.language.parser.diagnostics import (
     InvalidOperationError,
     ParserError,
@@ -179,6 +181,73 @@ class TestTypeMismatchReassignment:
                 t = pl.create_tensor([16, 16], dtype=pl.FP32)  # noqa: F841
                 t = pl.create_tensor([4, 4], dtype=pl.FP32)  # different shape  # noqa: F841
                 return x
+
+
+class TestBugClassErrorsAreNotWrapped:
+    """Bug-class exceptions must escape the parser with type and traceback intact.
+
+    The parser wraps stray exceptions as user-facing ParserErrors so a bad kernel gets
+    a source-located diagnostic. A failed internal invariant is not a bad kernel - it is
+    a PyPTO bug, and wrapping it hides both the `InternalError` type and the C++ stack
+    trace that diagnoses it. Every broad `except Exception` on the parse path therefore
+    lets `BUG_CLASS_EXCEPTIONS` through first.
+    """
+
+    @staticmethod
+    def _raise_internal(*args, **kwargs):
+        raise pypto.InternalError("Internal error: synthetic pass bug")
+
+    def test_internal_error_from_op_is_not_wrapped(self, monkeypatch):
+        """`_dispatch_op` re-raises rather than producing an InvalidOperationError."""
+        monkeypatch.setattr(_dsl_tensor, "cast", self._raise_internal)
+
+        with pytest.raises(pypto.InternalError, match="synthetic pass bug"):
+
+            @pl.function
+            def bad_kernel(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.BF16]:
+                result: pl.Tensor[[64], pl.BF16] = pl.tensor.cast(x, target_type=pl.BF16)
+                return result
+
+    def test_internal_error_is_not_a_parser_error(self, monkeypatch):
+        """Guards the specific regression: it must not be catchable as ParserError."""
+        monkeypatch.setattr(_dsl_tensor, "cast", self._raise_internal)
+
+        with pytest.raises(pypto.InternalError) as exc_info:
+
+            @pl.function
+            def bad_kernel(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.BF16]:
+                result: pl.Tensor[[64], pl.BF16] = pl.tensor.cast(x, target_type=pl.BF16)
+                return result
+
+        assert not isinstance(exc_info.value, ParserError)
+
+    def test_internal_error_survives_program_parsing(self, monkeypatch):
+        """The @pl.program wrapper passes it through too, not just @pl.function."""
+        monkeypatch.setattr(_dsl_tensor, "cast", self._raise_internal)
+
+        with pytest.raises(pypto.InternalError, match="synthetic pass bug"):
+
+            @pl.program
+            class BadProgram:
+                @pl.function
+                def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.BF16]:
+                    result: pl.Tensor[[64], pl.BF16] = pl.tensor.cast(x, target_type=pl.BF16)
+                    return result
+
+    def test_user_errors_are_still_wrapped(self, monkeypatch):
+        """The passthrough must not leak ordinary user errors past the diagnostic layer."""
+
+        def _raise_value(*args, **kwargs):
+            raise ValueError("Invalid rounding mode 99")
+
+        monkeypatch.setattr(_dsl_tensor, "cast", _raise_value)
+
+        with pytest.raises(InvalidOperationError, match="Invalid rounding mode"):
+
+            @pl.function
+            def bad_kernel(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.BF16]:
+                result: pl.Tensor[[64], pl.BF16] = pl.tensor.cast(x, target_type=pl.BF16)
+                return result
 
 
 if __name__ == "__main__":

--- a/tests/ut/language/parser/test_error_wrapping.py
+++ b/tests/ut/language/parser/test_error_wrapping.py
@@ -234,6 +234,45 @@ class TestBugClassErrorsAreNotWrapped:
                     result: pl.Tensor[[64], pl.BF16] = pl.tensor.cast(x, target_type=pl.BF16)
                     return result
 
+    def test_internal_error_from_closure_eval_is_not_wrapped(self, monkeypatch):
+        """`ExprEvaluator.eval_expr` re-raises instead of producing a ParserTypeError.
+
+        A compile-time closure expression can call into PyPTO and trip an internal
+        invariant; wrapping that as "Failed to evaluate expression" erases both the type
+        and the trace.
+        """
+
+        class _Boom:
+            @property
+            def value(self):
+                raise pypto.InternalError("Internal error: synthetic pass bug")
+
+        boom = _Boom()
+
+        with pytest.raises(pypto.InternalError, match="synthetic pass bug"):
+
+            @pl.function
+            def bad_kernel(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                result: pl.Tensor[[64], pl.FP32] = pl.tensor.adds(x, boom.value)
+                return result
+
+    def test_ordinary_eval_failure_is_still_wrapped(self):
+        """The passthrough must not leak ordinary eval failures past the diagnostics."""
+
+        class _BadValue:
+            @property
+            def value(self):
+                raise ValueError("not a compile-time constant")
+
+        bad = _BadValue()
+
+        with pytest.raises(ParserError):
+
+            @pl.function
+            def bad_kernel(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                result: pl.Tensor[[64], pl.FP32] = pl.tensor.adds(x, bad.value)
+                return result
+
     def test_user_errors_are_still_wrapped(self, monkeypatch):
         """The passthrough must not leak ordinary user errors past the diagnostic layer."""
 


### PR DESCRIPTION
## What

`OpRegistry::CreateImpl` is the single funnel through which every op `Call` is built. It appends the IR span to type-deduction failures, and did so by catching `const std::exception&` and rethrowing a fresh `ValueError`:

```cpp
try {
  result_type = deduce_type_fn(args, kwargs);
} catch (const std::exception& e) {
  std::string location = span.is_valid() ? " at " + span.to_string() : "";
  throw ValueError(std::string(e.what()) + location);   // flattens everything
}
```

`InternalError`, `TypeError` and `IndexError` all derive from `Error : std::runtime_error`, so that one handler flattened all of them.

## Why it matters

**The CHECK / INTERNAL_CHECK distinction was erased** for every `INTERNAL_CHECK*` site reachable from op type deduction. A compiler bug reached users as a value error, and the carefully ordered translator chain in `python/bindings/modules/error.cpp` never got the chance to run.

**The traceback vanished too** — the less obvious half. `InternalError` always reports `GetFullMessage()`; `ValueError` goes through `UserErrorMessage()`, which suppresses the trace unless `PTO_BACKTRACE=1`. So flattening the type silently also switched the trace off for exactly the errors where it is the primary artefact. Setting `PTO_BACKTRACE=1` would not have recovered it either: you'd get the *replacement* exception's frames, rooted at the catch block with everything below already unwound.

Before, an `INTERNAL_CHECK` inside a deduction function surfaced as:

```
ValueError: Internal error: <msg>
Check failed: false at /…/src/ir/op/testing.cpp:62 at kernel.py:12:15
```

After:

```
pypto.InternalError: Internal error: <msg>
Check failed: false at /…/src/ir/op/testing.cpp:62 at kernel.py:12:15

C++ Traceback (most recent call last):
 File "./python/bindings/modules/ir.cpp", line 745
   return OpRegistry::GetInstance().CreateUserFacing(op_name, args, span);
 File "./src/ir/op_registry.cpp", line 170
   result_type = deduce_type_fn(args, kwargs);
 File "./src/ir/op/testing.cpp", line 62
   INTERNAL_CHECK(false) << "Internal error: …";
```

The final frame is the deduction function itself — it exists only because the trace was carried over.

## How

**`Error::RethrowWithMessage`** (`include/pypto/core/error.h`) — a virtual that rethrows as the concrete type while adopting the stack trace captured at the original throw, so an intermediate frame can restate a message without paying either cost. Subclasses opt in with a one-line `PYPTO_ERROR_RETHROW_SUPPORT(X)`; `VerificationError` overrides by hand so its `diagnostics_` survive.

**`CreateImpl` splits its catch** — PyPTO exceptions keep type and trace and still get the span appended; non-PyPTO ones (a `std::bad_any_cast` from a wrong-typed kwarg) stay `ValueError` as before.

**Python passthrough** — the parser had the mirror-image trap: its broad `except Exception` handlers wrap strays as source-located `ParserError`s, which would re-hide an `InternalError` the moment it escaped C++. There are **seven** such handlers on the parse path — any one would have undone the fix. All now re-raise a shared `BUG_CLASS_EXCEPTIONS` first, while ordinary user errors are still wrapped exactly as before:

| Site | Shape |
| ---- | ----- |
| `ast_parser.py` — both op dispatchers | wraps as `InvalidOperationError` |
| `decorator.py` — both `parse_function` wrappers | wraps as `ParserSyntaxError` |
| `text_parser.py` — the exec path | wraps as `ParserSyntaxError` |
| `expr_evaluator.py` — `eval_expr` | wraps as `ParserTypeError` |
| `ast_parser.py` — `parse_attribute` | **swallows** (`except Exception: pass`) |

The last one is the worst of the set and the least obvious: because it swallows rather than wraps, an `InternalError` there was not merely re-typed but replaced outright by the unrelated `UnsupportedFeatureError: Standalone attribute access not supported` raised on the fall-through path. The last two were caught in review (thanks @chatgpt-codex-connector) and landed in 3ba3f8a5.

## For reviewers

**Two tests changed, and the reason is worth a look.** `test_tile_{put,get}_rejects_stage_larger_than_transfer` asserted `pytest.raises(ValueError)` against an `INTERNAL_CHECK_SPAN` whose own message begins `"Internal error:"`. `pld.tile.put` / `get` are materialized by `ConvertTensorToTileOps` and, per `docs/en/dev/distributed_ops.md`, never appear on the DSL surface — their staging tile is compiler-created, so an oversized stage is a pass bug and the check is classified correctly. The tests were encoding the flattening bug. Corrected to `pypto.InternalError`, keeping `match="must fit within"`.

**Blast radius is smaller than it looks.** Under `src/ir/op` the ratio is 1,389 `CHECK` to 21 `INTERNAL_CHECK`, so the common user-error path is byte-identical. The two tests above were the only fallout across the whole suite.

**Adding an `Error` subclass later?** End the class body with `PYPTO_ERROR_RETHROW_SUPPORT(YourError)`. Omitting it still compiles but degrades to a plain `Error` on rethrow — documented in `docs/en/dev/02-error-handling.md`.

**Not addressed here:** the `Check failed: <expr> at <abs cpp path>` tail visible in the samples above is a separate finding (`ast_parser.py` `_dispatch_op` not sanitizing) and is left alone deliberately.

## Testing

- Full suite green: **9,940 passed, 3 skipped, 0 failed**.
- 34 new tests: the rethrow mechanism per subclass (`tests/ut/core/test_error.py`), the registry contract (`tests/ut/ir/operators/test_op_registry.py`), and the parser passthrough (`tests/ut/language/parser/test_error_wrapping.py`), backed by two test-only ops and a `rethrow_with_message` binding.
- Verified the new tests actually discriminate rather than passing vacuously: reverting the `ast_parser.py` passthrough reproduces the exact `InvalidOperationError: … Internal error: synthetic pass bug` re-wrapping and fails three of them; reverting either half of the `expr_evaluator` / `parse_attribute` pair reproduces the compound `UnsupportedFeatureError` swallow.
- Trace-preservation assertions are chosen to be real discriminators — a file boundary in the registry test, a frame *count* in the mechanism test (both frames there share a file, so presence alone would be a tautology).
- Docs updated in `docs/en/` and `docs/zh/`.
- Review hardening in 0f5a2c89: two frame-count assertions could never hold on macOS (`_assert_has_trace` returns an empty list there after checking the no-symbolization fallback) and are now skipped; `test_unknown_span_appends_no_location` compares the unknown-span and located messages for exact equality, since `Span::unknown()` renders as `:-1:-1` and the old substring check would have accepted a dropped guard; and the `AssertionError` arm of `BUG_CLASS_EXCEPTIONS` is now covered at the parser layer.


