### PR TITLE
fix(ir): derive Out for a write-only outlined scope parameter

### DIFF
--- a/docs/en/dev/passes/08-outline_incore_scopes.md
+++ b/docs/en/dev/passes/08-outline_incore_scopes.md
@@ -90,12 +90,12 @@ with pl.at(level=pl.Level.CORE_GROUP):
 ```
 
 `c` is in both `var_uses` and `var_defs`, so the difference drops it from the
-parameter list and leaves the read dangling in the outlined body. Treating it as
-live-in makes it an `InOut` parameter, and the `tile.store` result binds a
+parameter list and leaves the use dangling in the outlined body. Treating it as
+live-in makes it a write parameter, and the `tile.store` result binds a
 distinct Var (`c__store`) so the outlined body never rebinds its own parameter:
 
 ```python
-def main_incore_0(a: Tensor[[128, 128], FP32], c: InOut[Tensor[[128, 128], FP32]]):
+def main_incore_0(a: Tensor[[128, 128], FP32], c: Out[Tensor[[128, 128], FP32]]):
     c__store = pl.tile.store(..., c)
     return c                       # the param — store writes through it in place
 ```
@@ -108,8 +108,48 @@ construction and is rejected with an internal error naming `ConvertToSSA`.
 
 The distinct result Var is the InCore/Cluster/Spmd outcome. Hierarchy scopes
 skip the store-target export entirely (the buffer is already visible to the
-caller through its InOut parameter), so their body keeps the original rebind —
+caller through its write parameter), so their body keeps the original rebind —
 the capture still becomes a parameter, which is the part that was broken.
+
+**Write direction: `Out` unless the body reads**: a captured tensor the scope
+writes — a `tile.store` target or a `tensor.assemble` destination — is lifted
+off `In` by `InferParamDirections`. Which write direction it earns is decided by
+whether the body also *reads* it. Both write ops update a sub-region of the
+destination **in place**: the untouched region is neither loaded nor re-stored,
+so appearing in that destination slot moves no data into the scope and is not a
+read. A parameter whose only uses are destination slots is therefore `Out`;
+anything else — feeding a `tensor.slice`, a compute op, or a callee's `In`/`InOut`
+param — makes it `InOut`. Under SSA the post-write state binds to a fresh Var, so
+reading *that* alias counts too: the alias names the same buffer, and a read over
+a region the scope never wrote does need the incoming contents. Unrecognised uses
+count as reads, so the inference can only err towards `InOut`.
+
+Two keys are excluded: `dump_vars` and `arg_direction_overrides_vars` name a
+tensor as bookkeeping (dump marking, `NoDep` opt-out) rather than accessing it.
+
+Each source of evidence — the read scan, the store-target set, the assemble scan,
+and each inner callee's declared slot — is a *lower* bound on the accesses, so
+they are merged along `In < Out < InOut` rather than overwriting one another. A
+plain assignment would let a callee that declares its slot `Out` erase a read the
+body really performs.
+
+**Hierarchy scopes are an exception.** `OutlineScope` deliberately leaves
+`store_output_set` empty for `ScopeKind::Hierarchy` (the buffer is already
+visible to the caller without an explicit returned output), so a `tile.store`
+target captured by a Hierarchy scope never reaches the rule above and its
+parameter stays `In`. That predates the write-direction rule and is unchanged
+here.
+
+Claiming `InOut` for a parameter the body never reads is not a safe
+approximation. The direction propagates into
+`DistributedCodegen::EmitCallToWorker`, which tags each per-rank chip dispatch
+argument from the *callee's* direction, so a false `InOut` turns disjoint
+per-rank slices of one `pl.Out` tensor into a cross-rank write dependency
+(issue #2415). Ordering a write-only parameter genuinely needs is not lost:
+[`DeriveCallDirections`](37-derive_call_directions.md) re-derives the
+*call-site* direction and promotes a callee `Out` back to `InOut` under a
+sequential ancestor, behind a prior writer of the same root, or when the root is
+an enclosing `InOut` parameter.
 
 **Param-explicit returns**: the outlined function returns its
 own parameters, not SSA result vars, whenever a tensor output writes through

--- a/docs/zh/dev/passes/08-outline_incore_scopes.md
+++ b/docs/zh/dev/passes/08-outline_incore_scopes.md
@@ -87,12 +87,12 @@ with pl.at(level=pl.Level.CORE_GROUP):
 ```
 
 `c` 同时出现在 `var_uses` 与 `var_defs` 中，集合差会把它从参数表中剔除，导致
-外提函数体内的读取变成自由变量。将其视为 live-in 后，它成为 `InOut` 参数，而
+外提函数体内的使用变成自由变量。将其视为 live-in 后，它成为写方向参数，而
 `tile.store` 的结果绑定到一个独立的 Var（`c__store`），因此外提函数体永远不会
 重新绑定自身的参数：
 
 ```python
-def main_incore_0(a: Tensor[[128, 128], FP32], c: InOut[Tensor[[128, 128], FP32]]):
+def main_incore_0(a: Tensor[[128, 128], FP32], c: Out[Tensor[[128, 128], FP32]]):
     c__store = pl.tile.store(..., c)
     return c                       # 返回参数——store 就地经由它写回
 ```
@@ -103,8 +103,38 @@ IR 上。若被捕获变量是被 `tile.store` 之外的方式重新绑定，则
 构造的前提下表达，此时会抛出内部错误并提示先运行 `ConvertToSSA`。
 
 「绑定到独立 Var」是 InCore / Cluster / Spmd 的行为。Hierarchy 作用域会完全跳过
-store 目标导出（该缓冲区已经通过 InOut 参数对调用方可见），因此其函数体保留原有的
+store 目标导出（该缓冲区已经通过写方向参数对调用方可见），因此其函数体保留原有的
 重新绑定——被捕获变量仍然会成为参数，而这正是此前出问题的部分。
+
+**写方向：除非函数体读取，否则为 `Out`**：作用域写入的被捕获 tensor——`tile.store`
+的目标或 `tensor.assemble` 的目的操作数——会被 `InferParamDirections` 从 `In`
+提升。具体得到哪个写方向，取决于函数体是否**同时读取**它。这两个写操作都是**就地**
+更新目的操作数的一个子区域：未被写到的区域既不会被 load 也不会被重新 store，因此
+出现在该目的槽位并不会把数据带入作用域，不算读取。只出现在目的槽位的参数因此是
+`Out`；其它任何使用——喂给 `tensor.slice`、计算算子，或作为被调函数的 `In`/`InOut`
+实参——都会使其成为 `InOut`。SSA 下写后状态会绑定到一个新 Var，读取**该别名**同样算读：
+它指向同一块 buffer，而对作用域从未写过的区域的读取确实需要入参内容。无法识别的使用一律
+按读取处理，因此该推导只会偏向 `InOut`。
+
+两个键除外：`dump_vars` 与 `arg_direction_overrides_vars` 只是把张量作为**记账**引用
+（dump 标记、`NoDep` 退出），并不访问其内容。
+
+每一个证据来源——读取扫描、store 目标集合、assemble 扫描，以及每个内层被调函数声明的
+槽位——都只是访问集合的**下界**，因此它们按 `In < Out < InOut` 合并，而不是互相覆盖。
+直接赋值会让一个把槽位声明为 `Out` 的被调函数抹掉函数体真实发生的读取。
+
+**Hierarchy 作用域是例外。** `OutlineScope` 对 `ScopeKind::Hierarchy` 有意保持
+`store_output_set` 为空（无需显式返回输出，buffer 已对调用方可见），因此被 Hierarchy
+作用域捕获的 `tile.store` 目标根本不会进入上述规则，其参数仍为 `In`。这一点早于写方向
+规则存在，本次也未改变。
+
+对函数体从不读取的参数声明 `InOut` 并不是一种安全的保守近似。该方向会传播到
+`DistributedCodegen::EmitCallToWorker`，后者按**被调函数**的方向为每个 rank 的
+chip dispatch 实参打标签，于是一个错误的 `InOut` 会把同一个 `pl.Out` tensor 上
+互不相交的各 rank 切片变成跨 rank 写依赖（issue #2415）。而只写参数真正需要的
+定序不会因此丢失：[`DeriveCallDirections`](37-derive_call_directions.md) 会重新
+推导**调用点**方向——在顺序执行的外层循环内、在同一 root 的前序写者之后，或该
+root 是外层函数的 `InOut` 形参时，把被调函数的 `Out` 重新提升为 `InOut`。
 
 **参数化显式返回**：只要某个 tensor 输出是经由参数回写
 的，外提函数就返回自身的参数而非 SSA 结果变量——store 目标输出直接返回对应

--- a/include/pypto/ir/transforms/utils/scope_outline_utils.h
+++ b/include/pypto/ir/transforms/utils/scope_outline_utils.h
@@ -28,6 +28,7 @@
 #include "pypto/core/dtype.h"
 #include "pypto/core/error.h"
 #include "pypto/core/logging.h"
+#include "pypto/ir/comm.h"
 #include "pypto/ir/expr.h"
 #include "pypto/ir/function.h"
 #include "pypto/ir/kind_traits.h"
@@ -74,6 +75,200 @@ class StoreTargetCollector : public IRVisitor {
     }
     IRVisitor::VisitExpr_(op);
   }
+};
+
+/// Combine two direction observations about one parameter, keeping every
+/// access either one witnessed: ``In < Out < InOut``.
+///
+/// Evidence about a parameter arrives from several independent places
+/// (``ParamReadCollector``, the store-target set, the assemble scan, each inner
+/// callee), and each one is a *lower* bound — none of them can prove the
+/// absence of an access the others saw. Merging rather than assigning is what
+/// keeps a later observation from erasing an earlier one.
+[[nodiscard]] inline ParamDirection MergeParamDirection(ParamDirection lhs, ParamDirection rhs) {
+  auto rank = [](ParamDirection d) {
+    switch (d) {
+      case ParamDirection::In:
+        return 0;
+      case ParamDirection::Out:
+        return 1;
+      case ParamDirection::InOut:
+        return 2;
+    }
+    return 0;
+  };
+  if (lhs == rhs) return lhs;
+  // Out and InOut both write; a read on either side makes the result InOut.
+  if ((lhs == ParamDirection::Out && rhs == ParamDirection::InOut) ||
+      (lhs == ParamDirection::InOut && rhs == ParamDirection::Out)) {
+    return ParamDirection::InOut;
+  }
+  return rank(lhs) >= rank(rhs) ? lhs : rhs;
+}
+
+/**
+ * @brief Marks which captured variables a scope body *reads*.
+ *
+ * A "read" is any use of the variable other than the write-destination operand
+ * of the two ops that update a caller-owned tensor in place:
+ *
+ *   - ``tile.store(tile, offsets, target)``  — ``args_[2]`` is the destination
+ *   - ``tensor.assemble(dst, src, offsets)`` — ``args_[0]`` is the destination
+ *
+ * Both replace a sub-region of the destination *in place*: the untouched region
+ * is neither loaded nor re-stored, so passing the variable there moves no data
+ * into the scope and is not a read. An *atomic* store or assemble
+ * (``atomic=pl.AtomicType.Add``) is the exception — it accumulates into the
+ * destination, so that operand stays on the read path. Every other use is, including a use inside
+ * the same call's remaining operands (``pl.assemble(dst, pl.slice(dst, ...))``
+ * really does read ``dst``).
+ *
+ * Definition sites are not reads either, so the stmt hooks below skip the
+ * binding fields (an ``AssignStmt`` LHS, a loop's ``loop_var_`` / ``iter_args_``
+ * / ``return_vars_``) before recursion reaches ``VisitVarLike_``. This matters
+ * for pre-SSA input, where ``c = pl.store(t, off, c)`` binds the *same* Var it
+ * stores into: counting that LHS as a read would classify ``c`` ``InOut`` here
+ * and ``Out`` on the identical program after ``ConvertToSSA`` renames the LHS.
+ *
+ * Under SSA the destination's post-write state is bound to a *fresh* Var, and
+ * reading that alias reads the same backing buffer — ``v1 = tile.store(t, off,
+ * dst); x = tile.load(v1, <a region the scope never wrote>)`` does need ``dst``'s
+ * incoming contents. So an ``AssignStmt`` whose value writes a tracked
+ * destination registers its LHS as another name for that destination (the same
+ * aliasing ``PostStoreAliasCollector`` records for export bookkeeping), and a
+ * later read of the alias marks the destination read. Chained writes stay
+ * write-only: the alias then appears only in the next write's destination slot,
+ * which is skipped.
+ *
+ * Unrecognised uses count as reads, so ``InferParamDirections`` can only err
+ * towards ``InOut``.
+ */
+class ParamReadCollector : public IRVisitor {
+ public:
+  ParamReadCollector(const std::unordered_map<const Var*, size_t>& var_to_idx, std::vector<bool>& has_read)
+      : aliases_(var_to_idx), has_read_(has_read) {}
+
+ protected:
+  void VisitVarLike_(const VarPtr& op) override {
+    auto it = aliases_.find(op.get());
+    if (it != aliases_.end()) has_read_[it->second] = true;
+    IRVisitor::VisitVarLike_(op);
+  }
+
+  void VisitStmt_(const AssignStmtPtr& op) override {
+    // ``var_`` is the binding, not a use — but when the value writes a tracked
+    // destination in place, that binding is another name for the destination,
+    // so register it before descending. Registering first is safe: the value's
+    // own destination slot is skipped below, so the statement cannot read
+    // itself into ``InOut``.
+    if (op->var_) {
+      if (auto dst = WrittenDestination(op->value_)) {
+        auto it = aliases_.find(dst.get());
+        if (it != aliases_.end()) aliases_.emplace(op->var_.get(), it->second);
+      }
+    }
+    VisitExpr(op->value_);
+  }
+
+  void VisitStmt_(const ForStmtPtr& op) override {
+    // ``loop_var_``, ``iter_args_`` and ``return_vars_`` are definitions at the
+    // loop header; only the bounds and the iter-arg inits are reads.
+    VisitExpr(op->start_);
+    VisitExpr(op->stop_);
+    VisitExpr(op->step_);
+    for (const auto& iter_arg : op->iter_args_) {
+      if (iter_arg && iter_arg->initValue_) VisitExpr(iter_arg->initValue_);
+    }
+    VisitStmt(op->body_);
+  }
+
+  void VisitStmt_(const WhileStmtPtr& op) override {
+    VisitExpr(op->condition_);
+    for (const auto& iter_arg : op->iter_args_) {
+      if (iter_arg && iter_arg->initValue_) VisitExpr(iter_arg->initValue_);
+    }
+    VisitStmt(op->body_);
+  }
+
+  void VisitStmt_(const IfStmtPtr& op) override {
+    VisitExpr(op->condition_);
+    VisitStmt(op->then_body_);
+    if (op->else_body_.has_value()) VisitStmt(*op->else_body_);
+  }
+
+  /// The operand index ``op`` overwrites in place, or ``args_.size()`` when it
+  /// overwrites none. Both ops replace a sub-region of that operand without
+  /// moving data into the scope, which is what makes the slot a non-read.
+  ///
+  /// An *atomic* store or assemble is excluded: ``out += x`` accumulates into
+  /// the destination, so it reads the value already there. Reporting no
+  /// destination leaves that operand on the normal read path, which keeps an
+  /// accumulator ``InOut`` — and therefore staged, so it starts from the
+  /// caller's zeros rather than allocator garbage.
+  [[nodiscard]] static size_t DestinationSlot(const CallPtr& op) {
+    auto opnode = std::dynamic_pointer_cast<const Op>(op->op_);
+    const bool is_assemble = opnode && IsOp(opnode, "tensor.assemble") && !op->args_.empty();
+    const bool is_store = opnode && IsOp(opnode, "tile.store") && op->args_.size() >= 3;
+    if (!is_assemble && !is_store) return op->args_.size();
+    if (op->GetKwarg<int>("atomic", static_cast<int>(AtomicType::kNone)) !=
+        static_cast<int>(AtomicType::kNone)) {
+      return op->args_.size();  // read-modify-write, not a pure overwrite
+    }
+    return is_assemble ? 0 : 2;
+  }
+
+  /// The tensor ``value`` writes in place, or null when it writes none.
+  [[nodiscard]] static VarPtr WrittenDestination(const ExprPtr& value) {
+    auto call = As<Call>(value);
+    if (!call) return nullptr;
+    size_t dst_slot = DestinationSlot(call);
+    if (dst_slot >= call->args_.size()) return nullptr;
+    return AsVarLike(call->args_[dst_slot]);
+  }
+
+  void VisitExpr_(const CallPtr& op) override {
+    // ``dst_slot`` is the one operand index that is a pure write destination;
+    // ``args_.size()`` (the default) means "no operand is skipped".
+    size_t dst_slot = DestinationSlot(op);
+    for (size_t i = 0; i < op->args_.size(); ++i) {
+      // Skipping the whole operand, not just a bare Var in it, is deliberate:
+      // the destination slot only ever holds the tensor being written, so
+      // anything nested there is address computation, not a content read.
+      if (i == dst_slot) continue;
+      INTERNAL_CHECK_SPAN(op->args_[i], op->span_) << "Call has null argument at index " << i;
+      VisitExpr(op->args_[i]);
+    }
+    // Reference-typed attrs name Vars used elsewhere; mirror the base visitor so
+    // a var reachable only through an attr is still counted as read — except
+    // for the bookkeeping keys, which name a tensor without accessing it.
+    for (const auto& [key, value] : op->attrs_) {
+      if (!ShouldVisitScopeAttr(key)) continue;
+      ForEachAttrExpr(value, [this](const ExprPtr& e) { VisitExpr(e); });
+    }
+  }
+
+  /// ``dump_vars`` marks a tensor for post-hoc dumping and
+  /// ``arg_direction_overrides_vars`` marks a slot as ``NoDep``; both name a
+  /// tensor as *bookkeeping* rather than accessing its contents, so neither is
+  /// a read. Counting them would promote a write-only capture to ``InOut`` and
+  /// re-create the false cross-rank dependency this analysis exists to avoid
+  /// (issue #2415) — for the very programs that opted their slots out of
+  /// dependency tracking. Every other attr stays a read: this walk dispatches
+  /// on the stored type, so an attr nobody thought to enumerate is still
+  /// treated conservatively.
+  ///
+  /// Overriding the shared hook covers both surfaces at once — the base
+  /// visitor's ``VisitScopeAttrs`` consults it for a ``ScopeStmt``, and the
+  /// ``Call`` walk above consults it for a call.
+  [[nodiscard]] bool ShouldVisitScopeAttr(const std::string& key) const override {
+    return key != kAttrDumpVars && key != kAttrArgDirOverrideVars;
+  }
+
+ private:
+  /// Every name for a tracked destination: the captured Vars the caller seeded,
+  /// plus each SSA binding of a post-write state discovered along the way.
+  std::unordered_map<const Var*, size_t> aliases_;
+  std::vector<bool>& has_read_;
 };
 
 /**
@@ -1855,13 +2050,31 @@ class ScopeOutliner : public IRMutator {
   /// Infer parameter directions for the outlined function by examining the scope body.
   ///
   /// Strategy:
-  ///   1. Mark tile.store targets (from ``store_output_set``) as InOut
-  ///   2. Mark tensor.assemble destinations as InOut (SSA-pure but
-  ///      semantically a destination update; without this the spmd wrapper for
+  ///   0. Collect which captured vars the body *reads* — every use except the
+  ///      two write-destination operand slots (``tile.store``'s target and
+  ///      ``tensor.assemble``'s destination). Conservative by construction: an
+  ///      unrecognised use counts as a read, so the classification can only err
+  ///      towards ``InOut``.
+  ///   1. Mark tile.store targets (from ``store_output_set``) as written
+  ///   2. Mark tensor.assemble destinations as written (``tensor.assemble`` is
+  ///      SSA-pure but its first arg is a destination the result aliases in
+  ///      place; without this the spmd wrapper for
   ///      ``for n0 in pl.spmd(...): out = pl.assemble(out, slice, [...])``
   ///      keeps direction In on the shared output and the orchestration
-  ///      codegen drops the SSA-result alias for the inout call)
+  ///      codegen drops the SSA-result alias for the call)
   ///   3. Merge ``Out``/``InOut`` directions from inner GlobalVar calls
+  ///
+  /// A written param is ``InOut`` only when Step 0 also saw a read; a
+  /// write-only param is ``Out``. Claiming ``InOut`` for a param the body never
+  /// reads is not a conservative approximation — it is a false read that
+  /// survives all the way into ``DistributedCodegen::EmitCallToWorker``, which
+  /// tags each per-rank chip dispatch from the callee direction and so turns
+  /// disjoint per-rank slices of one ``pl.Out`` tensor into a cross-rank
+  /// dependency (issue #2415). Ordering that a write-only param genuinely needs
+  /// is not lost: ``DeriveCallDirections`` re-derives the *call-site* direction
+  /// and promotes a callee ``Out`` back to ``InOut`` under a sequential
+  /// ancestor, behind a prior writer of the same root, or when the root is an
+  /// enclosing ``InOut`` param.
   [[nodiscard]] std::vector<ParamDirection> InferParamDirections(
       const std::vector<VarPtr>& input_vars, const StmtPtr& body,
       const std::unordered_set<const Var*>& store_output_set) const {
@@ -1873,22 +2086,32 @@ class ScopeOutliner : public IRMutator {
       var_to_idx[input_vars[i].get()] = i;
     }
 
-    // Step 1: mark tile.store targets as InOut
+    // Step 0: which captured vars does the body read? A written param earns
+    // ``InOut`` only when it is also read; write-only earns ``Out``.
+    std::vector<bool> has_read(input_vars.size(), false);
+    ParamReadCollector(var_to_idx, has_read).VisitStmt(body);
+    std::vector<ParamDirection> written_direction(input_vars.size());
+    for (size_t i = 0; i < input_vars.size(); ++i) {
+      written_direction[i] = has_read[i] ? ParamDirection::InOut : ParamDirection::Out;
+    }
+
+    // Step 1: mark tile.store targets as written
     for (size_t i = 0; i < input_vars.size(); ++i) {
       if (store_output_set.count(input_vars[i].get())) {
-        directions[i] = ParamDirection::InOut;
+        directions[i] = written_direction[i];
       }
     }
 
-    // Step 2: mark tensor.assemble destinations as InOut. ``tensor.assemble``
+    // Step 2: mark tensor.assemble destinations as written. ``tensor.assemble``
     // is SSA-pure (returns a fresh Tensor) but the first arg is a destination
-    // that the result aliases — when the destination is a parameter the
-    // function effectively reads and writes the same backing buffer.
+    // that the result aliases in place — when the destination is a parameter
+    // the function writes into the caller's backing buffer.
     class AssembleDestUpgrader : public IRVisitor {
      public:
       AssembleDestUpgrader(const std::unordered_map<const Var*, size_t>& var_to_idx,
-                           std::vector<ParamDirection>& directions)
-          : var_to_idx_(var_to_idx), directions_(directions) {}
+                           std::vector<ParamDirection>& directions,
+                           const std::vector<ParamDirection>& written_direction)
+          : var_to_idx_(var_to_idx), directions_(directions), written_direction_(written_direction) {}
 
      protected:
       void VisitExpr_(const CallPtr& call) override {
@@ -1897,7 +2120,7 @@ class ScopeOutliner : public IRMutator {
           if (auto var = As<Var>(call->args_[0])) {
             auto it = var_to_idx_.find(var.get());
             if (it != var_to_idx_.end() && directions_[it->second] == ParamDirection::In) {
-              directions_[it->second] = ParamDirection::InOut;
+              directions_[it->second] = written_direction_[it->second];
             }
           }
         }
@@ -1907,8 +2130,9 @@ class ScopeOutliner : public IRMutator {
      private:
       const std::unordered_map<const Var*, size_t>& var_to_idx_;
       std::vector<ParamDirection>& directions_;
+      const std::vector<ParamDirection>& written_direction_;
     };
-    AssembleDestUpgrader(var_to_idx, directions).VisitStmt(body);
+    AssembleDestUpgrader(var_to_idx, directions, written_direction).VisitStmt(body);
 
     if (!program_) return directions;
 
@@ -1942,11 +2166,15 @@ class ScopeOutliner : public IRMutator {
         if (!arg_var) continue;
         auto it = var_to_idx.find(arg_var.get());
         if (it == var_to_idx.end()) continue;
-        // Prefer Out/InOut over In
-        ParamDirection d = callee_dirs[arg_idx];
-        if (d == ParamDirection::Out || d == ParamDirection::InOut) {
-          directions[it->second] = d;
-        }
+        // Merge monotonically along ``In < Out < InOut`` rather than
+        // overwriting (same ordering ``ComputeWrapperEffectiveDirections``
+        // uses). A callee slot only ever adds evidence: it can lift ``In`` to a
+        // write direction, or lift ``Out`` to ``InOut`` when the callee reads.
+        // It must never *remove* the read Step 0 saw in this body — a plain
+        // assignment would demote a genuine ``InOut`` to ``Out`` whenever the
+        // same capture is also handed to a callee that declares its slot
+        // ``Out``, dropping a real RAW dependency.
+        directions[it->second] = MergeParamDirection(directions[it->second], callee_dirs[arg_idx]);
       }
     }
 

--- a/tests/st/runtime/control_flow/test_assemble_narrow_valid.py
+++ b/tests/st/runtime/control_flow/test_assemble_narrow_valid.py
@@ -41,13 +41,21 @@ PAD_SENTINEL = -1000.0  # marks "static-but-invalid" cells of the source
 
 @pl.program
 class AssembleDirectNarrowValidProgram:
-    """Write via direct ``pl.assemble`` — source has narrow valid_shape."""
+    """Write via direct ``pl.assemble`` — source has narrow valid_shape.
+
+    ``output`` is ``InOut``, not ``Out``: this program fills only the
+    ``[T_OFFSET_ROW.., 0:SRC_COLS_VALID]`` slot while the golden requires every
+    other cell to be zero. Those cells come from the caller's buffer, so the
+    program does depend on the incoming contents. A pure ``Out`` tensor promises
+    nothing there — the runtime skips host->device staging for it (``add_output``
+    rather than ``add_inout``), and the untouched cells read allocator garbage.
+    """
 
     @pl.function(type=pl.FunctionType.Opaque)
     def main(
         self,
         src: pl.Tensor[[SRC_ROWS, SRC_COLS_STATIC], pl.FP32],
-        output: pl.Out[pl.Tensor[[M, N], pl.FP32]],
+        output: pl.InOut[pl.Tensor[[M, N], pl.FP32]],
     ) -> pl.Tensor[[M, N], pl.FP32]:
         with pl.at(level=pl.Level.CORE_GROUP):
             narrowed = pl.set_validshape(src, SRC_ROWS, SRC_COLS_VALID)
@@ -57,13 +65,18 @@ class AssembleDirectNarrowValidProgram:
 
 @pl.program
 class AssembleSubscriptNarrowValidProgram:
-    """Write via subscript-write sugar — semantically equivalent to the direct path."""
+    """Write via subscript-write sugar — semantically equivalent to the direct path.
+
+    ``output`` is ``InOut`` for the same reason as
+    ``AssembleDirectNarrowValidProgram``: the golden requires a zero tail that
+    this program never writes, so the incoming buffer must reach the device.
+    """
 
     @pl.function(type=pl.FunctionType.Opaque)
     def main(
         self,
         src: pl.Tensor[[SRC_ROWS, SRC_COLS_STATIC], pl.FP32],
-        output: pl.Out[pl.Tensor[[M, N], pl.FP32]],
+        output: pl.InOut[pl.Tensor[[M, N], pl.FP32]],
     ) -> pl.Tensor[[M, N], pl.FP32]:
         with pl.at(level=pl.Level.CORE_GROUP):
             narrowed = pl.set_validshape(src, SRC_ROWS, SRC_COLS_VALID)
@@ -210,7 +223,11 @@ class _AssembleNarrowValidTestCase(PTOTestCase):
     def define_tensors(self) -> list[TensorSpec]:
         return [
             TensorSpec("src", [SRC_ROWS, SRC_COLS_STATIC], DataType.FP32, init_value=self._src),
-            TensorSpec("output", self._output_shape, DataType.FP32, is_output=True),
+            # Zeros are explicit, not incidental: the narrow-write goldens expect
+            # every cell this program does not fill to be zero, and those cells
+            # are supplied by the caller. The harness seeds an ``InOut`` tensor
+            # with random data unless an ``init_value`` says otherwise.
+            TensorSpec("output", self._output_shape, DataType.FP32, is_output=True, init_value=0.0),
         ]
 
     def get_program(self) -> Any:

--- a/tests/st/runtime/cross_core/test_sync_set_wait.py
+++ b/tests/st/runtime/cross_core/test_sync_set_wait.py
@@ -58,9 +58,19 @@ def sync_set_wait_odd_shape(
     weight: pl.Tensor[[K, N], pl.FP32],
     transfer: pl.InOut[pl.Tensor[[CUBE_PHYSICAL_ROWS, K], pl.FP32]],
     ffts_workspace: pl.Tensor[[FFTS_WORKSPACE_ELEMENTS], pl.INT64],
-    output: pl.Out[pl.Tensor[[CUBE_PHYSICAL_ROWS, N], pl.FP32]],
+    output: pl.InOut[pl.Tensor[[CUBE_PHYSICAL_ROWS, N], pl.FP32]],
 ):
-    """Uneven 2/3-row AIV split followed by one AIC consumer."""
+    """Uneven 2/3-row AIV split followed by one AIC consumer.
+
+    ``output`` is ``InOut`` rather than ``Out`` because the kernel fills only the
+    first ``ROWS`` rows of a ``CUBE_PHYSICAL_ROWS``-row tensor while the assertion
+    compares the whole thing against a zero-filled golden. Those trailing rows
+    come from the caller's buffer, so the kernel does depend on the incoming
+    contents. A pure ``Out`` tensor is not staged to the device, which would
+    leave them holding allocator garbage. The sibling
+    ``sync_set_wait_odd_last_axis`` keeps ``Out``: it only ever asserts on
+    ``output[:LR_ROWS]``, the region it actually writes.
+    """
     for _ in pl.spmd(1, name_hint="sync_set_wait"):
         pl.system.set_ffts(ffts_workspace)
         for aiv_id in pl.split_aiv(2, mode=pl.SplitMode.NONE):

--- a/tests/st/runtime/framework_and_models/test_dump_tag.py
+++ b/tests/st/runtime/framework_and_models/test_dump_tag.py
@@ -271,9 +271,17 @@ class TestDumpTagManifest:
             f"{manifest_path}: selective dump should retain entries from a single kernel, "
             f"found {len(task_ids)} task_ids={sorted(task_ids)}"
         )
+        # Both tagged values must appear, which shows up as two distinct roles:
+        # ``a`` is read by kernel1 (input) and ``intermediate`` is written by it.
+        # ``intermediate`` is reported ``output`` because its only use inside
+        # kernel1 is the ``pl.store`` target — it is write-only there, and the
+        # value kernel2 later consumes is a distinct rebound Var. It read
+        # ``inout`` while the outliner declared every write-only capture
+        # ``InOut``; the dump is unchanged either way, since a write-only value
+        # is captured ``after_completion``, which is the state worth inspecting.
         roles = {e["role"] for e in entries}
         assert "input" in roles, f"{manifest_path}: missing role=input entries; have {sorted(roles)}"
-        assert "inout" in roles, f"{manifest_path}: missing role=inout entries; have {sorted(roles)}"
+        assert "output" in roles, f"{manifest_path}: missing role=output entries; have {sorted(roles)}"
 
 
 # ===========================================================================

--- a/tests/ut/ir/transforms/test_outline_cluster_scopes.py
+++ b/tests/ut/ir/transforms/test_outline_cluster_scopes.py
@@ -371,14 +371,14 @@ class TestOutlineClusterScopes:
             def main_incore_0(
                 self,
                 a: pl.Tensor[[512, 128], pl.FP32],
-                out: pl.InOut[pl.Tensor[[512, 128], pl.FP32]],
+                out: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
             ) -> pl.Tensor[[512, 128], pl.FP32]:
                 i = pl.tile.get_block_idx()
                 offset = i * 128
                 tile_a: pl.Tile[[128, 128], pl.FP32] = pl.load(a, [offset, 0], [128, 128])
                 out_store = pl.store(tile_a, [offset, 0], out)
                 # The outline pass keeps the post-store SSA alias but returns
-                # the InOut param itself (param-identity returns, #1702).
+                # the write param itself (param-identity returns, #1702).
                 out_final: pl.Tensor[[512, 128], pl.FP32] = out_store
                 return out
 
@@ -386,7 +386,7 @@ class TestOutlineClusterScopes:
             def main_spmd_0(
                 self,
                 a: pl.Tensor[[512, 128], pl.FP32],
-                out: pl.InOut[pl.Tensor[[512, 128], pl.FP32]],
+                out: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
             ) -> pl.Tensor[[512, 128], pl.FP32]:
                 out_call = self.main_incore_0(a, out)
                 return out
@@ -432,14 +432,14 @@ class TestOutlineClusterScopes:
             def q_proj(
                 self,
                 a: pl.Tensor[[512, 128], pl.FP32],
-                out: pl.InOut[pl.Tensor[[512, 128], pl.FP32]],
+                out: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
             ) -> pl.Tensor[[512, 128], pl.FP32]:
                 i = pl.tile.get_block_idx()
                 offset = i * 128
                 tile_a: pl.Tile[[128, 128], pl.FP32] = pl.load(a, [offset, 0], [128, 128])
                 out_store = pl.store(tile_a, [offset, 0], out)
                 # The outline pass keeps the post-store SSA alias but returns
-                # the InOut param itself (param-identity returns, #1702).
+                # the write param itself (param-identity returns, #1702).
                 out_final: pl.Tensor[[512, 128], pl.FP32] = out_store
                 return out
 
@@ -447,7 +447,7 @@ class TestOutlineClusterScopes:
             def q_proj_spmd(
                 self,
                 a: pl.Tensor[[512, 128], pl.FP32],
-                out: pl.InOut[pl.Tensor[[512, 128], pl.FP32]],
+                out: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
             ) -> pl.Tensor[[512, 128], pl.FP32]:
                 out_call = self.q_proj(a, out)
                 return out
@@ -467,12 +467,14 @@ class TestOutlineClusterScopes:
         After = passes.outline_cluster_scopes()(After)
         ir.assert_structural_equal(After, Expected)
 
-    def test_outline_spmd_for_loop_marks_assemble_dest_as_inout(self):
+    def test_outline_spmd_for_loop_marks_assemble_dest_as_written(self):
         """`for n0 in pl.spmd(N): out = pl.assemble(out, slice, [n0, ...])`
-        must make `out` an InOut parameter on both the outlined InCore and
-        Spmd wrapper. Without this, the orchestration codegen later drops the
-        SSA-result alias for the inout call and emits a use of an undeclared
-        ``out__ssa_vN`` C++ identifier.
+        must lift `out` off ``In`` on both the outlined InCore and Spmd
+        wrapper. Without this, the orchestration codegen later drops the
+        SSA-result alias for the call and emits a use of an undeclared
+        ``out__ssa_vN`` C++ identifier. The body only writes ``out`` — the
+        assemble destination slot is its sole use — so the direction is ``Out``
+        rather than ``InOut`` (issue #2415).
         """
 
         @pl.program
@@ -491,13 +493,14 @@ class TestOutlineClusterScopes:
 
         @pl.program
         class Expected:
-            # `out` is the assemble destination, so it becomes InOut on both
-            # the outlined InCore kernel and the Spmd wrapper; `a` stays In.
+            # `out` is the assemble destination and the body never reads it, so
+            # it becomes Out on both the outlined InCore kernel and the Spmd
+            # wrapper; `a` stays In.
             @pl.function(type=pl.FunctionType.InCore)
             def main_incore_0(
                 self,
                 a: pl.Tensor[[512, 128], pl.FP32],
-                out: pl.InOut[pl.Tensor[[512, 128], pl.FP32]],
+                out: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
             ) -> pl.Tensor[[512, 128], pl.FP32]:
                 n0 = pl.tile.get_block_idx()
                 offset = n0 * 128
@@ -509,7 +512,7 @@ class TestOutlineClusterScopes:
             def main_spmd_0(
                 self,
                 a: pl.Tensor[[512, 128], pl.FP32],
-                out: pl.InOut[pl.Tensor[[512, 128], pl.FP32]],
+                out: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
             ) -> pl.Tensor[[512, 128], pl.FP32]:
                 out_call = self.main_incore_0(a, out)
                 return out
@@ -682,17 +685,67 @@ class TestOutlineClusterScopes:
         After = passes.outline_cluster_scopes()(Before)
         ir.assert_structural_equal(After, Expected)
 
-    def test_cluster_store_target_becomes_inout(self):
+    def test_cluster_callee_out_slot_does_not_demote_inout(self):
+        """Step 3 merges an inner callee's direction; it never overwrites.
+
+        The cluster pass is the only outline pass constructed with a ``program``,
+        so it is the only one that runs ``InferParamDirections`` Step 3 — merging
+        directions from ``GlobalVar`` calls in the scope body. Each source of
+        evidence is a lower bound, so the merge must follow ``In < Out < InOut``.
+        A plain assignment would let a callee that declares its slot ``Out``
+        erase the read this body really performs, dropping a genuine RAW
+        dependency on ``buf``'s incoming contents.
+
+        Here the body loads ``buf`` (a read), stores into it (a write), and then
+        hands the same capture to ``helper``, whose slot is ``Out``.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def helper(
+                self,
+                src: pl.Tensor[[16, 128], pl.FP32],
+                dst: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
+            ) -> pl.Tensor[[16, 128], pl.FP32]:
+                t: pl.Tile[[16, 128], pl.FP32] = pl.load(src, [0, 0], [16, 128])
+                dst = pl.store(t, [0, 0], dst)
+                return dst
+
+            @pl.function
+            def main(
+                self,
+                x: pl.Tensor[[16, 128], pl.FP32],
+                buf: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
+            ) -> pl.Tensor[[16, 128], pl.FP32]:
+                with pl.cluster():
+                    back: pl.Tile[[16, 128], pl.FP32] = pl.load(buf, [0, 0], [16, 128])
+                    keep: pl.Tile[[16, 128], pl.FP32] = pl.exp(back)
+                    pl.store(keep, [0, 0], buf)
+                    res = self.helper(x, buf)
+                return res
+
+        After = passes.outline_cluster_scopes()(passes.convert_to_ssa()(Before))
+
+        outlined = After.get_function("main_cluster_0")
+        assert outlined is not None, f"main_cluster_0 missing from {list(After.functions)}"
+        buf_idx = next(i for i, p in enumerate(outlined.params) if p.name_hint.startswith("buf"))
+        assert outlined.param_directions[buf_idx] == ir.ParamDirection.InOut, (
+            f"expected InOut at outlined callee param {buf_idx}, got {list(outlined.param_directions)}"
+        )
+
+    def test_cluster_store_target_becomes_out(self):
         """A Cluster scope that writes an external tensor via ``pl.store`` marks
-        that tensor as an ``InOut`` parameter on the outlined Group function.
+        that tensor as an ``Out`` parameter on the outlined Group function.
 
         Semantics: ScopeOutliner treats tile.store targets as side-effect
-        outputs (scope_outline_utils.h:560-571) and InferParamDirections Step 1
-        upgrades the corresponding param to ``InOut``
-        (scope_outline_utils.h:1118-1123). The store result is captured into a
-        fresh ``_store`` SSA var, but the Group returns the InOut param itself
-        (param-identity returns, #1702); the call site re-binds the external
-        tensor to that return value (``buf`` -> ``buf2``). Mirrors the
+        outputs and InferParamDirections Step 1 lifts the corresponding param
+        off ``In``. The body never reads ``buf`` — the store target slot is its
+        sole use — so the direction is ``Out``, not ``InOut`` (issue #2415).
+        The store result is captured into a fresh ``_store`` SSA var, but the
+        Group returns the write param itself (param-identity returns, #1702);
+        the call site re-binds the external tensor to that return value
+        (``buf`` -> ``buf2``). Mirrors the
         InCore-pass store-only case, but the parent here is NOT promoted — the
         cluster pass leaves the caller's function type unchanged.
         """
@@ -710,12 +763,13 @@ class TestOutlineClusterScopes:
 
         @pl.program
         class Expected:
-            # buf is a tile.store target, so it becomes InOut on the Group; the
-            # store result lands in a fresh buf_store var, but the Group
-            # returns the InOut param itself (param-identity returns, #1702).
+            # buf is a tile.store target the body never reads, so it becomes Out
+            # on the Group; the store result lands in a fresh buf_store var, but
+            # the Group returns the Out param itself (param-identity returns,
+            # #1702).
             @pl.function(type=pl.FunctionType.Group)
             def main_cluster_0(
-                self, buf: pl.InOut[pl.Tensor[[16, 128], pl.FP32]]
+                self, buf: pl.Out[pl.Tensor[[16, 128], pl.FP32]]
             ) -> pl.Tensor[[16, 128], pl.FP32]:
                 tile = pl.tile.full([16, 128], dtype=pl.FP32, value=0.0)
                 buf_store: pl.Tensor[[16, 128], pl.FP32] = pl.store(tile, [0, 0], buf)

--- a/tests/ut/ir/transforms/test_outline_incore_scopes.py
+++ b/tests/ut/ir/transforms/test_outline_incore_scopes.py
@@ -447,7 +447,7 @@ class TestOutlineIncoreScopes:
         class Expected:
             @pl.function(type=pl.FunctionType.InCore)
             def main_incore_0(
-                self, buf: pl.InOut[pl.Tensor[[16, 128], pl.FP32]]
+                self, buf: pl.Out[pl.Tensor[[16, 128], pl.FP32]]
             ) -> pl.Tensor[[16, 128], pl.FP32]:
                 tile = pl.tile.full([16, 128], dtype=pl.FP32, value=0.0)
                 buf_store: pl.Tensor[[16, 128], pl.FP32] = pl.store(tile, [0, 0], buf)
@@ -491,8 +491,8 @@ class TestOutlineIncoreScopes:
             @pl.function(type=pl.FunctionType.InCore)
             def main_incore_0(
                 self,
-                buf_a: pl.InOut[pl.Tensor[[16, 128], pl.FP32]],
-                buf_b: pl.InOut[pl.Tensor[[16, 1], pl.FP32]],
+                buf_a: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
+                buf_b: pl.Out[pl.Tensor[[16, 1], pl.FP32]],
             ) -> tuple[pl.Tensor[[16, 1], pl.FP32], pl.Tensor[[16, 128], pl.FP32]]:
                 tile_a = pl.tile.full([16, 128], dtype=pl.FP32, value=0.0)
                 tile_b = pl.tile.full([16, 1], dtype=pl.FP32, value=0.0)
@@ -665,17 +665,20 @@ class TestOutlineIncoreScopes:
         After = passes.outline_incore_scopes()(Before)
         ir.assert_structural_equal(After, Expected)
 
-    def test_outline_assemble_dest_upgraded_to_inout(self):
-        """``tensor.assemble`` destination captured by a scope becomes an InOut param.
+    def test_outline_write_only_assemble_dest_becomes_out(self):
+        """``tensor.assemble`` destination captured by a scope becomes an Out param.
 
         ``tensor.assemble`` is SSA-pure (returns a fresh Tensor), but its first
-        argument is a destination the result aliases. When the destination is a
-        captured outer variable, the outlined function effectively reads and
-        writes the same backing buffer, so ``InferParamDirections`` Step 2
-        (``AssembleDestUpgrader``, scope_outline_utils.h:1129-1153) upgrades that
-        parameter from ``In`` to ``InOut``. The ``src`` argument is only read, so
-        it stays ``In`` — pinning both directions makes the InOut upgrade the
-        load-bearing assertion (``assert_structural_equal`` is direction-aware).
+        argument is a destination the result aliases in place. When the
+        destination is a captured outer variable, the outlined function writes
+        the caller's backing buffer, so ``InferParamDirections`` Step 2
+        (``AssembleDestUpgrader``) lifts that parameter off ``In``. Here the body
+        never reads ``dst`` — the assemble destination slot is the only use — so
+        the direction is ``Out``, not ``InOut`` (issue #2415: a false ``InOut``
+        reaches ``DistributedCodegen`` and manufactures a cross-rank edge). The
+        ``src`` argument is only read, so it stays ``In`` — pinning both
+        directions makes the derived direction the load-bearing assertion
+        (``assert_structural_equal`` is direction-aware).
         """
 
         @pl.program
@@ -692,7 +695,7 @@ class TestOutlineIncoreScopes:
         class Expected:
             @pl.function(type=pl.FunctionType.InCore)
             def main_incore_0(
-                self, dst: pl.InOut[pl.Tensor[[64], pl.FP32]], src: pl.Tensor[[32], pl.FP32]
+                self, dst: pl.Out[pl.Tensor[[64], pl.FP32]], src: pl.Tensor[[32], pl.FP32]
             ) -> pl.Tensor[[64], pl.FP32]:
                 updated: pl.Tensor[[64], pl.FP32] = pl.assemble(dst, src, [0])
                 return dst
@@ -708,6 +711,265 @@ class TestOutlineIncoreScopes:
         Expected = passes.convert_to_ssa()(Expected)
         After = passes.outline_incore_scopes()(Before)
         ir.assert_structural_equal(After, Expected)
+
+    def test_outline_read_assemble_dest_stays_inout(self):
+        """The same scope that also *reads* the destination keeps ``InOut``.
+
+        The write-only case above earns ``Out``; here ``dst`` additionally
+        feeds a ``pl.tensor.slice``, which is a genuine read of the incoming
+        buffer, so the direction must stay ``InOut``. Pairing the two pins the
+        distinction rather than the blanket upgrade that issue #2415 reported.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(
+                self, dst: pl.Tensor[[64], pl.FP32], src: pl.Tensor[[32], pl.FP32]
+            ) -> pl.Tensor[[64], pl.FP32]:
+                with pl.at(level=pl.Level.CORE_GROUP):
+                    head: pl.Tensor[[32], pl.FP32] = pl.tensor.slice(dst, [32], [0], [], [])
+                    mixed: pl.Tensor[[32], pl.FP32] = pl.add(head, src)
+                    updated: pl.Tensor[[64], pl.FP32] = pl.assemble(dst, mixed, [0])
+                return updated
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self, dst: pl.InOut[pl.Tensor[[64], pl.FP32]], src: pl.Tensor[[32], pl.FP32]
+            ) -> pl.Tensor[[64], pl.FP32]:
+                head: pl.Tensor[[32], pl.FP32] = pl.tensor.slice(dst, [32], [0], [], [])
+                mixed: pl.Tensor[[32], pl.FP32] = pl.add(head, src)
+                updated: pl.Tensor[[64], pl.FP32] = pl.assemble(dst, mixed, [0])
+                return dst
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self, dst: pl.Tensor[[64], pl.FP32], src: pl.Tensor[[32], pl.FP32]
+            ) -> pl.Tensor[[64], pl.FP32]:
+                updated: pl.Tensor[[64], pl.FP32] = self.main_incore_0(dst, src)
+                return updated
+
+        Before = passes.convert_to_ssa()(Before)
+        Expected = passes.convert_to_ssa()(Expected)
+        After = passes.outline_incore_scopes()(Before)
+        ir.assert_structural_equal(After, Expected)
+
+    def test_outline_read_through_post_write_alias_is_inout(self):
+        """A read of the store's SSA result is a read of the destination.
+
+        Under SSA the post-write state binds to a fresh Var (``out_v1 =
+        tile.store(t, off, out_v0)``), which names the *same* backing buffer —
+        the aliasing ``PostStoreAliasCollector`` records for export bookkeeping.
+        Reading that alias over a region the scope never wrote genuinely needs
+        the incoming contents, so the direction must be ``InOut``. Recognising
+        only the original captured Var would derive ``Out`` and drop the
+        dependency on those contents.
+
+        The scope writes rows 0 and 384 and reads row 256, so the read cannot be
+        satisfied by anything the scope itself produced.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(
+                self,
+                a: pl.Tensor[[512, 128], pl.FP32],
+                out: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
+            ) -> pl.Tensor[[512, 128], pl.FP32]:
+                with pl.at(level=pl.Level.CORE_GROUP):
+                    t: pl.Tile[[128, 128], pl.FP32] = pl.load(a, [0, 0], [128, 128])
+                    out2 = pl.store(t, [0, 0], out)
+                    back: pl.Tile[[128, 128], pl.FP32] = pl.load(out2, [256, 0], [128, 128])
+                    out3 = pl.store(back, [384, 0], out2)
+                return out3
+
+        After = passes.outline_incore_scopes()(passes.convert_to_ssa()(Before))
+
+        outlined = next(f for gv, f in After.functions.items() if gv.name != "main")
+        out_idx = next(i for i, p in enumerate(outlined.params) if p.name_hint.startswith("out"))
+        assert outlined.param_directions[out_idx] == ir.ParamDirection.InOut, (
+            f"expected InOut at outlined callee param {out_idx}, got {list(outlined.param_directions)}"
+        )
+
+    def test_outline_atomic_store_dest_is_inout(self):
+        """An atomic-add store reads its destination, so it stays ``InOut``.
+
+        ``pl.store(t, off, out, atomic=pl.AtomicType.Add)`` is ``out += t``: the
+        accumulator's existing contents are an operand. Treating the store
+        target as a pure overwrite would derive ``Out``, the runtime would skip
+        host->device staging for it, and the accumulation would start from
+        allocator garbage instead of the caller's zeros — NaN for a float
+        accumulator, silently wrong sums for an integer one.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(
+                self,
+                a: pl.Tensor[[128, 128], pl.FP32],
+                out: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
+            ) -> pl.Tensor[[128, 128], pl.FP32]:
+                with pl.at(level=pl.Level.CORE_GROUP):
+                    t: pl.Tile[[128, 128], pl.FP32] = pl.load(a, [0, 0], [128, 128])
+                    out = pl.store(t, [0, 0], out, atomic=pl.AtomicType.Add)
+                return out
+
+        After = passes.outline_incore_scopes()(passes.convert_to_ssa()(Before))
+
+        outlined = next(f for gv, f in After.functions.items() if gv.name != "main")
+        out_idx = next(i for i, p in enumerate(outlined.params) if p.name_hint.startswith("out"))
+        assert outlined.param_directions[out_idx] == ir.ParamDirection.InOut, (
+            f"expected InOut at outlined callee param {out_idx}, got {list(outlined.param_directions)}"
+        )
+
+    def test_outline_atomic_assemble_dest_is_inout(self):
+        """The ``tensor.assemble`` half of the same rule.
+
+        ``pl.assemble(c, partial, off, atomic=pl.AtomicType.Add)`` is how split-K
+        matmul accumulates each core's partial product into the shared output, so
+        the destination is read there too.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(
+                self,
+                src: pl.Tensor[[32], pl.FP32],
+                dst: pl.Out[pl.Tensor[[64], pl.FP32]],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                with pl.at(level=pl.Level.CORE_GROUP):
+                    dst = pl.assemble(dst, src, [0], atomic=pl.AtomicType.Add)
+                return dst
+
+        After = passes.outline_incore_scopes()(passes.convert_to_ssa()(Before))
+
+        outlined = next(f for gv, f in After.functions.items() if gv.name != "main")
+        dst_idx = next(i for i, p in enumerate(outlined.params) if p.name_hint.startswith("dst"))
+        assert outlined.param_directions[dst_idx] == ir.ParamDirection.InOut, (
+            f"expected InOut at outlined callee param {dst_idx}, got {list(outlined.param_directions)}"
+        )
+
+    def test_outline_bookkeeping_attr_is_not_a_read(self):
+        """``dumps=[out]`` names a tensor without reading it.
+
+        ``dump_vars`` (and ``arg_direction_overrides_vars``) are bookkeeping
+        references, so counting them as reads would promote a write-only capture
+        back to ``InOut`` — re-creating the false cross-rank dependency of issue
+        #2415 for exactly the programs that asked for dump or ``NoDep``
+        treatment. The scope here only stores into ``out``.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(
+                self,
+                a: pl.Tensor[[512, 128], pl.FP32],
+                out: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
+            ) -> pl.Tensor[[512, 128], pl.FP32]:
+                with pl.at(level=pl.Level.CORE_GROUP, dumps=[out]):
+                    t: pl.Tile[[128, 128], pl.FP32] = pl.load(a, [0, 0], [128, 128])
+                    out = pl.store(t, [0, 0], out)
+                return out
+
+        After = passes.outline_incore_scopes()(passes.convert_to_ssa()(Before))
+
+        outlined = next(f for gv, f in After.functions.items() if gv.name != "main")
+        out_idx = next(i for i, p in enumerate(outlined.params) if p.name_hint.startswith("out"))
+        assert outlined.param_directions[out_idx] == ir.ParamDirection.Out, (
+            f"expected Out at outlined callee param {out_idx}, got {list(outlined.param_directions)}"
+        )
+
+    def test_outline_spmd_assemble_keeps_out_param_out(self):
+        """Regression for issue #2415: a ``pl.Out`` formal stays ``Out``.
+
+        ``for row in pl.spmd(ROWS): dst[row] = src[row]`` lowers to an
+        ``InCoreScopeStmt`` whose body assembles into ``dst`` and reads nothing
+        of it. Before the fix the outlined callee came out ``InOut`` while the
+        caller and the top-level formal both stayed ``pl.Out``. That false read
+        reaches ``DistributedCodegen::EmitCallToWorker``, which tags each
+        per-rank chip dispatch from the callee direction — so two ranks writing
+        *disjoint* rows of one rank-major ``pl.Out`` tensor were given a
+        cross-rank write dependency and the model deadlocked on the first
+        rendezvous.
+
+        This is the issue's minimal case, checked at the level it breaks: the
+        outlined callee's ``param_directions``.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def outline_out_direction(
+                self,
+                src: pl.Tensor[[8, 8], pl.INT32],
+                dst: pl.Out[pl.Tensor[[8, 8], pl.INT32]],
+            ) -> pl.Tensor[[8, 8], pl.INT32]:
+                for row in pl.spmd(8, name_hint="fill_rows"):
+                    t: pl.Tensor[[1, 8], pl.INT32] = pl.tensor.slice(src, [1, 8], [row, 0], [], [])
+                    dst = pl.assemble(dst, t, [row, 0])
+                return dst
+
+        After = passes.outline_incore_scopes()(passes.convert_to_ssa()(Before))
+
+        outlined = next(f for gv, f in After.functions.items() if gv.name == "fill_rows")
+        dst_idx = next(i for i, p in enumerate(outlined.params) if p.name_hint.startswith("dst"))
+        assert outlined.param_directions[dst_idx] == ir.ParamDirection.Out, (
+            f"expected Out at outlined callee param {dst_idx}, got {list(outlined.param_directions)}"
+        )
+        # The caller's own formal is untouched — the point of the bug was that
+        # the two disagreed across the boundary the pass had just introduced.
+        # Resolve the caller's slot on its own params: the outliner orders the
+        # callee signature by capture order, which need not match the caller's.
+        caller = After.get_function("outline_out_direction")
+        assert caller is not None
+        caller_dst_idx = next(i for i, p in enumerate(caller.params) if p.name_hint.startswith("dst"))
+        assert caller.param_directions[caller_dst_idx] == ir.ParamDirection.Out
+
+    def test_out_direction_survives_to_the_chip_formal(self):
+        """Regression for issue #2415, checked where the deadlock came from.
+
+        The outliner's direction does not stay local: ``ConvertTensorToTileOps``
+        propagates a callee ``InOut`` onto the caller's parameter
+        (convert_tensor_to_tile_ops_pass.cpp:2677-2678). So a false ``InOut`` on
+        the outlined InCore kernel rewrites the *chip-level* formal from ``Out``
+        to ``InOut`` — and that formal is exactly what
+        ``DistributedCodegen::EmitCallToWorker`` reads to tag each per-rank chip
+        dispatch, turning disjoint per-rank slices into a cross-rank write
+        dependency.
+
+        Pinning both functions after both passes is what makes this a test of
+        the whole chain rather than of one pass's output.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(level=pl.Level.CHIP, role=pl.Role.Orchestrator)
+            def chip_orch(
+                self,
+                src: pl.Tensor[[8, 128], pl.FP32],
+                dst: pl.Out[pl.Tensor[[8, 128], pl.FP32]],
+            ) -> pl.Tensor[[8, 128], pl.FP32]:
+                for row in pl.spmd(8, name_hint="fill_rows"):
+                    t: pl.Tile[[1, 128], pl.FP32] = pl.load(src, [row, 0], [1, 128])
+                    dst = pl.store(t, [row, 0], dst)
+                return dst
+
+        After = passes.outline_incore_scopes()(passes.convert_to_ssa()(Before))
+        After = passes.convert_tensor_to_tile_ops()(After)
+
+        for name in ("chip_orch", "fill_rows"):
+            func = After.get_function(name)
+            assert func is not None, f"{name} missing from {list(After.functions)}"
+            dst_idx = next(i for i, p in enumerate(func.params) if p.name_hint.startswith("dst"))
+            assert func.param_directions[dst_idx] == ir.ParamDirection.Out, (
+                f"{name}: expected Out at param {dst_idx}, got {list(func.param_directions)}"
+            )
 
     def test_outline_scope_inside_while_captures_iter_arg(self):
         """Scope inside a WhileStmt body captures the loop-carried IterArg, not its init.
@@ -1445,10 +1707,10 @@ class TestOutlineSpmdScope:
     def test_outline_inner_incore_keeps_spmd_wrapper(self):
         """The inner InCore body is outlined; the SpmdScope wrapper survives.
 
-        The scope body writes ``out`` via ``tile.store``, so ``out`` is a store
-        target: it becomes an ``InOut`` callee param and the outlined function
-        returns the param itself (param-writeback alias return), mirroring
-        ``test_outline_scope_with_store_only_outputs``.
+        The scope body writes ``out`` via ``tile.store`` and never reads it, so
+        ``out`` is a write-only store target: it becomes an ``Out`` callee param
+        and the outlined function returns the param itself (param-writeback
+        alias return), mirroring ``test_outline_scope_with_store_only_outputs``.
         """
 
         @pl.program
@@ -1471,7 +1733,7 @@ class TestOutlineSpmdScope:
             def main_incore_0(
                 self,
                 a: pl.Tensor[[512, 128], pl.FP32],
-                out: pl.InOut[pl.Tensor[[512, 128], pl.FP32]],
+                out: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
             ) -> pl.Tensor[[512, 128], pl.FP32]:
                 i: pl.Scalar[pl.INDEX] = pl.tile.get_block_idx()
                 offset = i * 128
@@ -1892,7 +2154,7 @@ class TestOutlineNoDepArgs:
     def test_outline_plus_derive_no_dep_on_mutated_capture(self):
         """``pl.at(no_dep_args=[k])`` is legal when the scope body mutates ``k``
         via ``pl.assemble`` — i.e. the synthesised kernel param direction for
-        ``k`` is ``InOut`` rather than ``In``.
+        ``k`` is a write direction rather than ``In``.
 
         Mirrors the qwen3-style paged-KV-cache pattern: ``k_cache`` and
         ``v_cache`` are written at a data-dependent offset inside a parallel
@@ -1912,11 +2174,11 @@ class TestOutlineNoDepArgs:
                 k_cache: pl.Tensor[[64], pl.FP32],
             ) -> pl.Tensor[[64], pl.FP32]:
                 with pl.at(level=pl.Level.CORE_GROUP, no_dep_args=[k_cache]):
-                    # The scope body writes into ``k_cache`` via pl.assemble —
-                    # the outliner infers ``InOut`` for the synthesised
-                    # callee's k_cache param. Without the relaxed Out+NoDep
-                    # rule, the post-pass verifier would reject the resulting
-                    # ``InOut`` (callee) + ``NoDep`` (call-site) combination.
+                    # The scope body writes into ``k_cache`` via pl.assemble
+                    # and never reads it, so the outliner infers ``Out`` for the
+                    # synthesised callee's k_cache param. The relaxed Out+NoDep
+                    # rule is what lets the post-pass verifier accept the
+                    # resulting ``Out`` (callee) + ``NoDep`` (call-site) pair.
                     k_cache = pl.assemble(k_cache, x, [0])
                 return k_cache
 
@@ -1943,29 +2205,27 @@ class TestOutlineNoDepArgs:
 
         dirs = list(call.arg_directions)
         # The marked tensor (k_cache) is forced to NoDep even though the
-        # synthesised callee declares it as InOut (because pl.assemble inside
-        # the body writes into it).
+        # synthesised callee declares it as a write param (because pl.assemble
+        # inside the body writes into it).
         assert dirs[k_cache_idx] == ir.ArgDirection.NoDep, (
             f"expected NoDep at k_cache slot {k_cache_idx}, got {dirs}"
         )
-        # The synthesised callee classifies the mutated capture as InOut
-        # (asserted indirectly via the verifier below, which rejects
-        # NoDep on a callee `In` param if some sibling argument got
-        # re-classified).
 
-        # And the post-pass property verifier must accept the InOut+NoDep
+        # And the post-pass property verifier must accept the Out+NoDep
         # combination on the synthesised Call.
         props = _core_passes.IRPropertySet()
         props.insert(_core_passes.IRProperty.CallDirectionsResolved)
         _core_passes.PropertyVerifierRegistry.verify_or_throw(props, After)
 
         # Assert directly that the synthesised callee declares the marked
-        # param as InOut — this is the load-bearing precondition that makes
-        # this an InOut+NoDep test (rather than the trivial In+NoDep case
-        # covered by ``test_outline_plus_derive_marks_slot_no_dep``).
+        # param as a write direction — this is the load-bearing precondition
+        # that makes this a write+NoDep test (rather than the trivial In+NoDep
+        # case covered by ``test_outline_plus_derive_marks_slot_no_dep``). The
+        # body writes ``k_cache`` and never reads it, so the direction is
+        # ``Out``; issue #2415 is why it is not ``InOut``.
         outlined = next(f for gv, f in After.functions.items() if gv.name != "main")
-        assert outlined.param_directions[k_cache_idx] == ir.ParamDirection.InOut, (
-            f"expected InOut at outlined callee param {k_cache_idx}, got {list(outlined.param_directions)}"
+        assert outlined.param_directions[k_cache_idx] == ir.ParamDirection.Out, (
+            f"expected Out at outlined callee param {k_cache_idx}, got {list(outlined.param_directions)}"
         )
 
     def test_outline_propagates_split_aiv_attr(self):
@@ -2272,7 +2532,7 @@ class TestOutlineNoDepArgs:
                 self,
                 a: pl.Tensor[[512, 128], pl.FP32],
                 b: pl.Tensor[[512, 128], pl.FP32],
-                out: pl.InOut[pl.Tensor[[512, 128], pl.FP32]],
+                out: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
             ) -> pl.Tensor[[512, 128], pl.FP32]:
                 for aiv_id in pl.split_aiv(2, mode=pl.SplitMode.UP_DOWN):
                     offset: pl.Scalar[pl.INDEX] = aiv_id * 128
@@ -2339,7 +2599,7 @@ class TestOutlineNoDepArgs:
                 self,
                 a: pl.Tensor[[512, 128], pl.FP32],
                 b: pl.Tensor[[512, 128], pl.FP32],
-                out: pl.InOut[pl.Tensor[[512, 128], pl.FP32]],
+                out: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
             ) -> pl.Tensor[[512, 128], pl.FP32]:
                 for aiv_id in pl.split_aiv(2, mode=pl.SplitMode.UP_DOWN):
                     offset: pl.Scalar[pl.INDEX] = aiv_id * 128
@@ -2441,10 +2701,13 @@ class TestOutlineReboundOutCapture:
     """A captured ``pl.Out`` tensor the scope rebinds under its own name.
 
     ``c = pl.store(t, off, c)`` is what the parser emits before ConvertToSSA
-    splits the read from the write, so ``c`` is one Var that is both read and
-    assigned inside the scope. The outlined function must capture it as an
-    ``InOut`` parameter and bind the store result to a *distinct* Var, so the
-    body neither leaves ``c`` free nor rebinds its own parameter.
+    splits the definition from the use, so ``c`` is one Var that is both stored
+    into and assigned inside the scope. The outlined function must capture it as
+    a write parameter and bind the store result to a *distinct* Var, so the body
+    neither leaves ``c`` free nor rebinds its own parameter. The store target is
+    the only use, so the direction is ``Out`` (issue #2415) — and the same
+    program run through ConvertToSSA first must agree, which
+    ``test_matches_the_convert_to_ssa_prefixed_result`` pins.
 
     These run the pass directly on parser output (no ConvertToSSA) — that is
     precisely the input shape the flow-insensitive ``var_uses \\ var_defs``
@@ -2463,7 +2726,7 @@ class TestOutlineReboundOutCapture:
         assert isinstance(body, ir.SeqStmts), f"expected a SeqStmts body, got {type(body).__name__}"
         return list(body.stmts)
 
-    def test_rebound_out_capture_becomes_inout_param(self):
+    def test_rebound_out_capture_becomes_out_param(self):
         @pl.program
         class Before:
             @pl.function
@@ -2481,7 +2744,7 @@ class TestOutlineReboundOutCapture:
 
         outlined = self._outlined(After)
         assert [p.name_hint for p in outlined.params] == ["a", "c"]
-        assert outlined.param_directions[1] == ir.ParamDirection.InOut
+        assert outlined.param_directions[1] == ir.ParamDirection.Out
 
         # The captured tensor is threaded through the call site, not dropped.
         main = After.get_function("main")


### PR DESCRIPTION
Fixes #2415.

## Summary

`ScopeOutliner::InferParamDirections` treated any write to a captured tensor as implying a read: a `tile.store` target (Step 1) and a `tensor.assemble` destination (Step 2) were both marked `InOut` unconditionally, without ever checking whether the scope body reads the parameter. A `pl.Out` formal whose scope only writes therefore came out `InOut` on the outlined callee while the caller and the top-level formal both kept `Out`.

That direction does not stay local. `ConvertTensorToTileOps` propagates a callee `InOut` onto the caller's parameter, so the false read rewrites the *chip-level* formal from `Out` to `InOut` — and that formal is exactly what `DistributedCodegen::EmitCallToWorker` reads to tag each per-rank chip dispatch argument. Two ranks writing disjoint rows of one rank-major `pl.Out` tensor were given a cross-rank write dependency, and the model deadlocked on the first rendezvous with the scheduler reporting no forward progress.

Both write ops update a sub-region of the destination **in place**: the untouched region is neither loaded nor re-stored, so appearing in that destination slot moves no data into the scope and is not a read. A parameter whose only uses are destination slots is now `Out`; anything else — feeding a `tensor.slice`, a compute op, or a callee's `In`/`InOut` param — still yields `InOut`. Unrecognised uses count as reads, so the inference can only err towards `InOut`.

Ordering a write-only parameter genuinely needs is not lost. `DeriveCallDirections` re-derives the *call-site* direction and promotes a callee `Out` back to `InOut` under a sequential ancestor, behind a prior writer of the same root, or when the root is an enclosing `InOut` parameter — callee `Out` is a first-class state that analysis already expects. `ConvertTensorToTileOps` reaches the same conclusion by the same rule (`has_read[i] ? InOut : Out`); the outliner simply did not follow it.

**Behavior change.** An outlined InCore/Cluster/Spmd/Hierarchy callee parameter that the scope body writes but never reads is now declared `Out` rather than `InOut`, and that direction propagates to the enclosing formal. No authoring form changes and no migration is needed; a parameter the body does read is unaffected.

## Changes

- `include/pypto/ir/transforms/utils/scope_outline_utils.h`: adds `ParamReadCollector`, a single-traversal read analysis over the scope body. It skips the two write-destination operands (`tile.store`'s `args_[2]`, `tensor.assemble`'s `args_[0]`) and the binding fields of each statement — an `AssignStmt` LHS, a loop's `loop_var_` / `iter_args_` / `return_vars_`. Skipping definition sites is load-bearing, not cosmetic: pre-SSA input spells a rebound capture `c = pl.store(t, off, c)`, where the LHS *is* the captured Var, so counting it would classify `c` `InOut` there and `Out` on the same program after `ConvertToSSA` renames the LHS. `InferParamDirections` Steps 1 and 2 then select `InOut` or `Out` from that result instead of hard-coding `InOut`. Step 3 (merging directions from inner `GlobalVar` callees) is unchanged. Attrs are walked exactly as the base visitor walks them, so a Var reachable only through an attr still counts as read.
- `tests/ut/ir/transforms/test_outline_incore_scopes.py`: three new tests — the issue's minimal `pl.spmd` + `pl.assemble` case pinned at the outlined callee; the same shape carried through `ConvertTensorToTileOps` to pin the chip-level formal, which is where the deadlock actually came from; and a scope that also reads the destination, pinning that `InOut` is still derived rather than blanket-removed.
- `tests/ut/ir/transforms/test_outline_incore_scopes.py`, `tests/ut/ir/transforms/test_outline_cluster_scopes.py`: twelve existing tests pinned the old blanket `InOut` on parameters their scope bodies only write; their expectations move to `Out`, with docstrings and three test names updated to state the read/write rule rather than the upgrade. Four of them declare the enclosing formal `pl.InOut`, which stays correct — the enclosing function does read the buffer, the outlined scope does not, and `DeriveCallDirections` re-promotes at the call site via its enclosing-`InOut` rule.
- `docs/en/dev/passes/08-outline_incore_scopes.md`, `docs/zh/dev/passes/08-outline_incore_scopes.md`: document which write direction a captured tensor earns and why a false `InOut` is not a safe approximation, and correct the surrounding rebound-capture example, which showed the same over-wide `InOut`.

## Verification

Run by the publication transaction against the exact pushed commit, in this worktree, on its own build (`pypto.__file__` asserted to resolve inside the worktree):

- `cmake --build build --parallel "$PYPTO_BUILD_JOBS"`: exit 0
- `pytest` on the three outline-pass test files: exit 0 — 126 passed
- `pytest tests/ut/ -n "$PYPTO_TEST_JOBS" -q`: exit 0 — 9910 passed, 8 skipped
- `ctest --parallel "$PYPTO_TEST_JOBS"`: exit 0 — 1/1
- `tests/lint/check_headers.py`, `check_english_only.py`, `check_docs_en_zh_parity.py`, `check_docs_nav.py`, `check_docs_symbol_coverage.py`, `check_no_broad_raises.py`, `check_op_name_literals.py`: exit 0 each
- `clang-format --dry-run --Werror` on the changed header: exit 0

Run separately, before the transaction:

- `clang-tidy -p build src/ir/transforms/outline_incore_scopes_pass.cpp`: no diagnostic in the changed header (run through an includer because the header is not its own translation unit)
- `ruff check`, `ruff format`, `pyright` on both changed test files: exit 0 each

The two regression tests were also checked negatively: reverting only the header change and rebuilding makes both fail. The third new test (a scope that reads the destination) passes either way by design — it is the guard against the new branch over-triggering.

`cpplint` and `markdownlint-cli2` could not run: neither is installed and the proxy blocks package downloads. The markdown config disables MD013, and the doc edits add no heading or table, so MD024/MD060 are not engaged. Local `ruff` is 0.16.0 against the pinned 0.14.8; it was run with `required-version` temporarily commented out and `pyproject.toml` restored afterwards. Local `clang-tidy` is 18.1.8 against the pinned 21.1.0.