### PR TITLE
feat(codegen): emit Graph functions and launch them with rt_submit_graph

### DIFF
--- a/docs/en/dev/passes/46-materialize_runtime_scopes.md
+++ b/docs/en/dev/passes/46-materialize_runtime_scopes.md
@@ -40,8 +40,9 @@ lets the output round-trip: the inserted `with pl.scope()` blocks parse back onl
 under `auto_scope=False` (the parser rejects hand-placed AUTO scopes in the
 default mode, where the compiler owns placement).
 
-**When to use**: in the `Default` strategy, immediately after the final
-`Simplify` and before
+**When to use**: in the `Default` strategy, immediately after
+[`LegalizeGraphBoundary`](45-legalize_graph_boundary.md) — which follows the
+final `Simplify` — and before
 [`ClassifyIterArgCarry`](47-classify_iter_arg_carry.md) and
 [`InsertCommFence`](48-insert_comm_fence.md). Running after every rewriting
 transform means none of them has to reason about the inserted scope wrappers.

--- a/docs/en/dev/passes/48-insert_comm_fence.md
+++ b/docs/en/dev/passes/48-insert_comm_fence.md
@@ -133,14 +133,15 @@ pass stays idempotent.
 ## Position in the pipeline
 
 ```text
-... -> MaterializeRuntimeScopes -> ClassifyIterArgCarry -> InsertCommFence   (last)
+... -> ClassifyIterArgCarry -> InsertCommFence -> MaterializeValidShapeSymbols   (last)
 ```
 
-It runs **last** in the Default pipeline, after every statement-reordering pass
+It runs after every statement-reordering pass in the Default pipeline
 (`SkewCrossCorePipeline`, `LowerPipelineLoops`, `CanonicalizeIOOrder`, ...). The
 inserted ops have no operands and no dependency edges, so an earlier insertion
-could be moved away from its notify/wait; running last keeps them adjacent through
-codegen. The passes before it only touch Orchestration functions, so the InCore IR
+could be moved away from its notify/wait; running here keeps them adjacent through
+codegen. Only [`MaterializeValidShapeSymbols`](49-materialize_valid_shape_symbols.md)
+follows, and it rewrites device-kernel signatures rather than reordering statements. The passes before it only touch Orchestration functions, so the InCore IR
 this pass sees is exactly what codegen lowers.
 
 ## Which writes the pass marks

--- a/docs/zh/dev/passes/46-materialize_runtime_scopes.md
+++ b/docs/zh/dev/passes/46-materialize_runtime_scopes.md
@@ -35,7 +35,9 @@ parser 直接物化进 IR。这是控制 scope 粒度（ring 隔离）、MANUAL 
 `auto_scope=False` 下才能解析回来（parser 在默认模式下拒绝手写 AUTO scope，
 默认模式由编译器决定放置）。
 
-**何时使用**：在 `Default` 策略中紧跟最终的 `Simplify` 之后运行，位于
+**何时使用**：在 `Default` 策略中紧跟
+[`LegalizeGraphBoundary`](45-legalize_graph_boundary.md)（它本身跟在最终的
+`Simplify` 之后）运行，位于
 [`ClassifyIterArgCarry`](47-classify_iter_arg_carry.md) 与
 [`InsertCommFence`](48-insert_comm_fence.md) 之前。跑在所有改写型 transform
 之后意味着它们都无需处理被插入的 scope 包裹。

--- a/docs/zh/dev/passes/48-insert_comm_fence.md
+++ b/docs/zh/dev/passes/48-insert_comm_fence.md
@@ -110,12 +110,12 @@ window 参数、别名（`dv = pl.tensor.view(win); remote_store(dv)`）、循�
 ## 在流水线中的位置
 
 ```text
-... -> MaterializeRuntimeScopes -> ClassifyIterArgCarry -> InsertCommFence   (最后)
+... -> ClassifyIterArgCarry -> InsertCommFence -> MaterializeValidShapeSymbols   (最后)
 ```
 
-它在 Default 流水线中**最后**运行，位于所有会重排语句的 pass
+它在 Default 流水线中运行于所有会重排语句的 pass
 （`SkewCrossCorePipeline`、`LowerPipelineLoops`、`CanonicalizeIOOrder` ...）之后。插入的
-op 无操作数、无依赖边，若更早插入可能被挪离其 notify/wait；放最后可让它们在 codegen 前
+op 无操作数、无依赖边，若更早插入可能被挪离其 notify/wait；放在这里可让它们在 codegen 前
 保持相邻。它之前的 pass 只改动 Orchestration 函数，因此本 pass 看到的 InCore IR 正是
 codegen 最终降级的 IR。
 

--- a/include/pypto/ir/transforms/passes.h
+++ b/include/pypto/ir/transforms/passes.h
@@ -279,9 +279,13 @@ Pass MaterializeValidShapeSymbols();
  *
  * Also rejects, at compile time, the boundary shapes the runtime would decline
  * to cache — an oversized or empty tensor boundary, runtime-allocated outputs,
- * return values, nested graphs, and call sites carrying explicit dependencies or
- * a dispatch predicate. Almost all of those degrade to a silent non-graph
- * fallback at runtime, which no numerical test can detect.
+ * a *computed* return value, nested graphs, and call sites carrying explicit
+ * dependencies or a dispatch predicate. Returning a parameter is allowed:
+ * `return c` for an `InOut` parameter is the DSL's spelling for writing in place
+ * and lowers to an alias, so only a genuinely new value is refused —
+ * `rt_submit_graph` yields a valid task id solely on a cache hit, so nothing may
+ * depend on a graph call's result. Almost all of those degrade to a silent
+ * non-graph fallback at runtime, which no numerical test can detect.
  *
  * @return Program-level pass
  */

--- a/python/pypto/ir/pass_manager.py
+++ b/python/pypto/ir/pass_manager.py
@@ -537,6 +537,7 @@ class PassManager:
         # *during* pass execution) whenever the pipeline dumps IR.
         mplan = ctx.get_memory_planner() if ctx else passes.MemoryPlanner.PYPTO
         dbc_flag = ctx.get_enable_pypto_l0c_double_buffer() if ctx else False
+        runtime = ctx.get_runtime() if ctx else passes.RuntimeKind.TENSORMAP_AND_RINGBUFFER
         outer_phase = ctx.get_diagnostic_phase() if ctx else passes.get_default_diagnostic_phase()
         if outer_phase == passes.DiagnosticPhase.POST_PASS:
             inner_phase = passes.DiagnosticPhase.PRE_PIPELINE
@@ -544,7 +545,7 @@ class PassManager:
             inner_phase = outer_phase
 
         with passes.PassContext(
-            [*outer_instruments, *extra_instruments], level, inner_phase, disabled, mplan, dbc_flag
+            [*outer_instruments, *extra_instruments], level, inner_phase, disabled, mplan, dbc_flag, runtime
         ):
             try:
                 return self._pipeline.run(input_ir)
@@ -576,10 +577,12 @@ class PassManager:
         ctx = passes.PassContext.current()
         outer_instruments = list(ctx.get_instruments()) if ctx else []
         level = ctx.get_verification_level() if ctx else passes.get_default_verification_level()
-        # Propagate the outer memory planner + legacy-PYPTO dbC=2 opt-in (see run_passes)
-        # so profiling doesn't silently reset them and disable planner-gated behaviour.
+        # Propagate the outer memory planner, the legacy-PYPTO dbC=2 opt-in and the
+        # runtime ABI (see run_passes) so profiling doesn't silently reset them and
+        # disable planner- or runtime-gated behaviour.
         mplan = ctx.get_memory_planner() if ctx else passes.MemoryPlanner.PYPTO
         dbc_flag = ctx.get_enable_pypto_l0c_double_buffer() if ctx else False
+        runtime = ctx.get_runtime() if ctx else passes.RuntimeKind.TENSORMAP_AND_RINGBUFFER
         dphase = ctx.get_diagnostic_phase() if ctx else passes.get_default_diagnostic_phase()
         if ctx:
             disabled = ctx.get_disabled_diagnostics()
@@ -588,7 +591,7 @@ class PassManager:
             disabled.insert(passes.DiagnosticCheck.UnusedControlFlowResult)
 
         with passes.PassContext(
-            [*outer_instruments, timing_instrument], level, dphase, disabled, mplan, dbc_flag
+            [*outer_instruments, timing_instrument], level, dphase, disabled, mplan, dbc_flag, runtime
         ):
             try:
                 return self._pipeline.run(input_ir)

--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -163,6 +163,17 @@ std::string GenerateScalarUnpack(const std::string& var_name, int scalar_index,
   return oss.str();
 }
 
+/// C++ symbol emitted for a Graph function's recorded body.
+///
+/// The runtime identifies a graph by a bare function pointer
+/// (``rt_graph_function_id`` static_asserts on that), so each Graph function is
+/// emitted once as a named file-scope function rather than inlined as a lambda
+/// at every call site — a lambda would mint one pointer per syntactic
+/// occurrence and burn through the 16-entry Definition cache.
+std::string GraphFunctionSymbol(const std::string& func_name) {
+  return "pypto_graph_" + auto_name::GetCompatibleBaseName(func_name);
+}
+
 std::string GenerateConfigFunction(int expected_arg_count) {
   std::ostringstream oss;
   oss << "__attribute__((visibility(\"default\")))\n";
@@ -280,6 +291,15 @@ class OrchestrationStmtCodegen : public CodegenBase {
         << "Internal error: initial indent must be a non-negative multiple of 4, got " << indent;
     emitter_.SetIndentLevel(indent / 4);
   }
+  /// Prefix every task-arg variable this instance declares.
+  ///
+  /// A Graph function is emitted by a *second* codegen instance whose
+  /// ``task_counter_`` / ``alloc_counter_`` restart at 0. Without a distinct
+  /// prefix, the entry and each graph helper would each declare ``params_t0``
+  /// in the same file — legal C++, since they are separate function scopes, but
+  /// it makes every generated identifier ambiguous to read and to grep.
+  void SetTaskVarPrefix(std::string prefix) { task_var_prefix_ = std::move(prefix); }
+
   void SetEffectiveUses(std::unordered_set<const Var*> uses) { effective_uses_ = std::move(uses); }
   [[nodiscard]] bool NeedsVectorInclude() const { return needs_vector_include_; }
 
@@ -2826,7 +2846,17 @@ class OrchestrationStmtCodegen : public CodegenBase {
 
   /// Emit the per-task ``Arg`` declaration. Dependency edges (if any) are
   /// attached separately by ``EmitManualDeps`` via ``set_dependencies``.
-  void EmitTaskParamsDecl(const std::string& task_var) { EmitIndentedLine("CoreTaskArgs " + task_var + ";"); }
+  ///
+  /// @p args_type selects the ``Arg`` instantiation. A task submitted inside
+  /// orchestration takes `CoreTaskArgs`; a Graph boundary takes `GraphTaskArgs`,
+  /// which `rt_submit_graph` requires. The two are *different* instantiations of
+  /// the same template — `Arg<MAX_TENSOR_ARGS, MAX_SCALAR_ARGS>` versus
+  /// `Arg<GRAPH_MAX_TENSOR_ARGS, GRAPH_MAX_SCALAR_ARGS>` — so they are not
+  /// interchangeable, and passing the wrong one is a compile error in the
+  /// generated file rather than anything a codegen text assertion would catch.
+  void EmitTaskParamsDecl(const std::string& task_var, const std::string& args_type = "CoreTaskArgs") {
+    EmitIndentedLine(args_type + " " + task_var + ";");
+  }
 
   struct TaskDispatchPlan {
     std::string comment;
@@ -2874,7 +2904,9 @@ class OrchestrationStmtCodegen : public CodegenBase {
     }
   };
 
-  std::string CurrentTaskVarName() const { return "params_t" + std::to_string(task_counter_); }
+  std::string CurrentTaskVarName() const {
+    return task_var_prefix_ + "params_t" + std::to_string(task_counter_);
+  }
 
   TaskDispatchPlan BuildTaskDispatchPlan(const std::string& comment, const CallPtr& call,
                                          std::vector<ParamEntry>&& params, const ExprPtr& launch_core_num,
@@ -3358,14 +3390,14 @@ class OrchestrationStmtCodegen : public CodegenBase {
       return;
     }
 
-    // A Graph is a task launch, not a kernel, so it has no core type. Its
-    // emission path lands with the rest of Graph Execution; until then, say so
-    // here rather than letting InferFunctionCoreType below abort with an
-    // internal "expects AIC or AIV" error that names nothing actionable.
-    CHECK_SPAN(callee_func->func_type_ != FunctionType::Graph, call->span_)
-        << "Graph function '" << callee_name
-        << "' cannot be compiled yet: type=pl.FunctionType.Graph is authorable, but the orchestration "
-           "codegen that emits a graph launch is not in place yet.";
+    // A Graph is a recordable orchestration fragment launched as one task, not
+    // a kernel. It must be intercepted before InferFunctionCoreType, which
+    // recognises only AIC/AIV and hard-fails on anything else. This replaces the
+    // placeholder guard that reported the missing emission path.
+    if (callee_func->func_type_ == FunctionType::Graph) {
+      GenerateGraphCallCode(call, callee_func, capture_plain_task_id);
+      return;
+    }
 
     CoreType core_type = InferFunctionCoreType(callee_func);
     (*func_name_to_core_type_)[callee_name] = core_type;
@@ -3382,6 +3414,64 @@ class OrchestrationStmtCodegen : public CodegenBase {
     BuildDirectCallDispatchPlan(call, callee_func, callee_name, core_type, func_id, std::move(params),
                                 capture_plain_task_id)
         .Emit(*this);
+  }
+
+  /// Emit the launch of a Graph function: one task carrying the whole region.
+  ///
+  /// Deliberately unlike every other submit here, in two ways:
+  ///
+  /// * The result is discarded. ``rt_submit_graph`` returns a valid task id only
+  ///   on a cache *hit*; on the recording pass ``graph_begin`` reports an invalid
+  ///   one. Nothing may chain a dependency on it — ordering comes from the
+  ///   boundary tensors' dataflow, which is why LegalizeGraphBoundary rejects a
+  ///   Graph that returns a computed value.
+  /// * The callee gets no kernel id. A Graph has no ``.cpp`` under ``kernels/``,
+  ///   so registering it in ``func_name_to_id_`` would put a phantom entry in
+  ///   ``kernel_config.py``'s KERNELS list pointing at a file that does not
+  ///   exist.
+  ///
+  /// The recording is identified by the emitted function's own address, via the
+  /// ``rt_submit_graph(function, args)`` overload. The ``GRAPH_KEY("...")``
+  /// overload exists for callers needing a name stable across builds, but it
+  /// drops the function pointer from the cache identity, so two functions
+  /// sharing a key silently replay one recording. One Graph function is one
+  /// emitted C++ function here, so the address is already the right identity.
+  void GenerateGraphCallCode(const CallPtr& call, const FunctionPtr& callee_func,
+                             bool capture_plain_task_id) {
+    // A graph launch produces no TaskId a consumer may depend on:
+    // `rt_submit_graph` returns a valid id only on a cache *hit*, so this
+    // function discards the result and declares no `TaskOutputTensors`. The
+    // caller, however, keys its dependency binding on `task_counter_` advancing
+    // and would then emit `task_<n>_outs.task_id()` naming a variable that was
+    // never declared — generated C++ that does not compile.
+    //
+    // `LegalizeGraphBoundary` rejects an *explicit* dependency on a graph
+    // launch; a compiler-derived manual-scope edge is the same situation and is
+    // caught here, where the producing edge is known.
+    INTERNAL_CHECK_SPAN(!capture_plain_task_id && CompilerDepOutputArgs(call).empty(), call->span_)
+        << "Internal error: Graph function '" << callee_func->name_
+        << "' is launched as the producer of a task dependency, but rt_submit_graph yields a valid "
+           "task id only on a cache hit. Order the graph against its consumers through its boundary "
+           "tensors instead of a TaskId edge.";
+
+    auto params = BuildTaskParams(call, callee_func);
+    const std::string task_var = CurrentTaskVarName();
+
+    EmitBlankLine();
+    EmitIndentedLine("// Graph region: " + callee_func->name_ + " (recorded once, then replayed)");
+    // `rt_submit_graph(GraphFunction, const GraphTaskArgs&)` — the boundary
+    // container is its own `Arg` instantiation, sized by GRAPH_MAX_*_ARGS.
+    EmitTaskParamsDecl(task_var, "GraphTaskArgs");
+    for (const auto& p : params) {
+      INTERNAL_CHECK_SPAN(p.direction != ArgDirection::Output, call->span_)
+          << "Internal error: Graph function '" << callee_func->name_
+          << "' has a runtime-allocated output argument; a recorded graph's boundary tensors must "
+             "already exist so replay can patch their addresses.";
+      EmitIndentedLine(task_var + "." + ArgDirectionToMethodName(p.direction) + "(" + p.value + ");");
+    }
+    EmitSelectiveDumpCall(task_var, params);
+    EmitIndentedLine("rt_submit_graph(&" + GraphFunctionSymbol(callee_func->name_) + ", " + task_var + ");");
+    ++task_counter_;
   }
 
   void GenerateSpmdCallCode(const CallPtr& call, const FunctionPtr& spmd_func, bool capture_plain_task_id) {
@@ -4171,6 +4261,9 @@ class OrchestrationStmtCodegen : public CodegenBase {
   std::string current_result_var_;
   std::vector<VarPtr> current_return_vars_;
   int task_counter_ = 0;
+  /// Disambiguates task-arg variables between the entry and each Graph helper,
+  /// whose counters restart at 0. Empty for the entry (preserving its names).
+  std::string task_var_prefix_;
   int phase_fence_barrier_counter_ = 0;
   int alloc_counter_ = 0;
   /// Depth of nested ``RuntimeScopeStmt(manual=true)``. While > 0, the codegen
@@ -4300,6 +4393,177 @@ class OrchestrationStmtCodegen : public CodegenBase {
   std::unordered_map<const Function*, std::vector<std::optional<size_t>>> returned_param_indices_cache_;
 };
 
+/// Collect, in deterministic order, the Graph functions this entry launches.
+std::vector<FunctionPtr> CollectReferencedGraphFunctions(const ProgramPtr& program,
+                                                         const FunctionPtr& entry) {
+  class Collector : public IRVisitor {
+   public:
+    explicit Collector(ProgramPtr program) : program_(std::move(program)) {}
+    std::vector<FunctionPtr> found;
+
+   protected:
+    void VisitExpr_(const CallPtr& op) override {
+      IRVisitor::VisitExpr_(op);
+      Record(op->op_);
+    }
+    void VisitExpr_(const SubmitPtr& op) override {
+      IRVisitor::VisitExpr_(op);
+      Record(op->op_);
+    }
+
+   private:
+    void Record(const OpPtr& callee_op) {
+      auto gvar = As<GlobalVar>(callee_op);
+      if (!gvar || !program_) return;
+      auto callee = program_->GetFunction(gvar->name_);
+      if (!callee || callee->func_type_ != FunctionType::Graph) return;
+      if (!seen_.insert(callee->name_).second) return;  // one definition per graph
+      found.push_back(callee);
+    }
+
+    ProgramPtr program_;
+    std::unordered_set<std::string> seen_;
+  };
+
+  Collector collector(program);
+  if (entry->body_) collector.VisitStmt(entry->body_);
+  return collector.found;
+}
+
+/// Emit `int64_t <symbol> = <param>.shape()[axis];` for every dynamic extent a
+/// body references.
+///
+/// A tensor parameter whose shape carries a `Var` extent declares that symbol;
+/// the body then reads it as a plain identifier. Both the entry and each Graph
+/// helper bind their tensor parameters at the top of their own function, so both
+/// need these definitions — a Graph body referencing one without this block
+/// names an undeclared variable and the generated file does not compile.
+///
+/// @p pre_defined seeds the dedup set with names already spoken for (scalar
+/// parameters, body-local definitions): a symbol sharing one of those names is
+/// not what the body's occurrences refer to, and defining it would shadow the
+/// real one. Dedup is by emitted *name* rather than by `Var`, because a symbol
+/// carries no emit-name mapping and prints as its name hint.
+std::string GenerateDynamicDimDefs(const std::vector<VarPtr>& params, const std::string& body_code,
+                                   OrchestrationStmtCodegen* codegen,
+                                   std::unordered_set<std::string> pre_defined) {
+  std::vector<std::string> defs;
+  for (const auto& var : params) {
+    auto tensor_type = AsTensorTypeLike(var->GetType());
+    if (!tensor_type) continue;
+    const std::string param_name = auto_name::GetCompatibleBaseName(var->name_hint_);
+    for (size_t axis = 0; axis < tensor_type->shape_.size(); ++axis) {
+      auto extent = As<Var>(tensor_type->shape_[axis]);
+      if (!extent) continue;
+      const std::string symbol_name = codegen->GetVarName(extent);
+      if (!pre_defined.insert(symbol_name).second) continue;
+      if (!ReferencesIdentifier(body_code, symbol_name)) continue;
+      defs.push_back("    int64_t " + symbol_name + " = " +
+                     codegen->GetTensorShapeDim(param_name, static_cast<int64_t>(axis)) + ";\n");
+    }
+  }
+  if (defs.empty()) return "";
+  std::string out = "\n    // Dynamic-dim symbols (extent of the declaring argument)\n";
+  for (const auto& def : defs) out += def;
+  return out;
+}
+
+/// Emit one named file-scope function per Graph the entry launches.
+///
+/// The body is generated by a *second* codegen instance. Two settings differ
+/// from the entry's and both matter:
+///
+/// * ``param_name_set`` is empty. `GetExternalTensorName` rewrites any name in
+///   that set to ``ext_<name>``, which is right for the entry (whose parameters
+///   arrive through ``orch_args``) and wrong here, where they are ordinary
+///   function parameters bound at the top of the body.
+/// * A task-var prefix, because this instance's counters restart at 0.
+///
+/// Boundary scalars are bound as ``const uint64_t&``, never by value. The
+/// runtime tracks a boundary scalar by the *address* of its argument slot, so
+/// copying it into a local would sever that link and the value would be frozen
+/// into the recording at its first-call value.
+std::string GenerateGraphFunctions(const ProgramPtr& program, const FunctionPtr& entry,
+                                   std::map<std::string, int>* func_name_to_id,
+                                   std::map<std::string, CoreType>* func_name_to_core_type,
+                                   std::map<std::string, std::vector<std::string>>* func_name_to_signature,
+                                   int* next_func_id) {
+  std::ostringstream oss;
+  int graph_index = 0;
+  for (const auto& graph_func : CollectReferencedGraphFunctions(program, entry)) {
+    CodegenEffectiveUseCollector use_collector;
+    use_collector.VisitStmt(graph_func->body_);
+
+    // Same analyses the entry runs. Without the tuple mappings,
+    // GenerateTupleReturnAliases / GenerateSubmitReturnAliases find an empty map
+    // and return early, so a multi-output call or a `pl.submit` inside a Graph
+    // binds neither its output tensors nor its TaskId.
+    OrchestrationInfoCollector graph_info;
+    graph_info.VisitStmt(graph_func->body_);
+
+    // Seeded with the *same* string the parameter declarations below use.
+    // Unseeded, `GetVarName` falls back to `GetSSABaseName(name_hint_)`, which is
+    // a different normalisation from `auto_name::GetCompatibleBaseName`; wherever
+    // the two disagree the body would reference a symbol the header never
+    // declared. Seeding makes them agree by construction.
+    std::unordered_map<const Var*, std::string> emit_name_map;
+    for (const auto& param : graph_func->params_) {
+      emit_name_map[param.get()] = auto_name::GetCompatibleBaseName(param->name_hint_);
+    }
+    OrchestrationStmtCodegen body_codegen(program, func_name_to_id, func_name_to_core_type,
+                                          func_name_to_signature, next_func_id, std::move(emit_name_map),
+                                          /*param_name_set=*/{}, /*param_name_to_orch_index=*/{},
+                                          /*packed_fp4_axis=*/{}, /*dist_param_to_ctx_param=*/{});
+    body_codegen.SetTaskVarPrefix("g" + std::to_string(graph_index) + "_");
+    body_codegen.SetCallTupleElements(graph_info.call_tuple_elements);
+    body_codegen.SetTupleVarToKey(graph_info.tuple_var_to_key);
+    body_codegen.SetEffectiveUses(std::move(use_collector.var_uses));
+    body_codegen.PrepareCrossScopeTaskIdHoists(graph_func->body_);
+    body_codegen.SetInitialIndent(4);
+    body_codegen.VisitStmt(graph_func->body_);
+
+    // Signature fixed by `using GraphFunction = void (*)(const GraphTaskArgs &)`
+    // in the runtime's orchestration_api.h; `rt_submit_graph` takes that pointer.
+    oss << "static void " << GraphFunctionSymbol(graph_func->name_) << "(const GraphTaskArgs& args) {\n";
+
+    int tensor_index = 0;
+    int scalar_index = 0;
+    for (const auto& param : graph_func->params_) {
+      const std::string name = auto_name::GetCompatibleBaseName(param->name_hint_);
+      if (AsTensorTypeLike(param->GetType())) {
+        oss << "    const TaskTensor& " << name << " = args.tensor(" << tensor_index << ").ref();\n";
+        ++tensor_index;
+        continue;
+      }
+      // Reference, not a copy: the runtime anchors this slot's address during
+      // recording and re-reads it on every replay.
+      oss << "    const uint64_t& " << name << " = args.scalar(" << scalar_index << ");\n";
+      ++scalar_index;
+    }
+
+    const std::string graph_body_code = body_codegen.GetGeneratedCode();
+    // A Graph body may carry a dynamic loop as long as it launches nothing
+    // (LegalizeGraphBoundary only forbids a *launch* under a non-constant bound),
+    // so the symbol it reads has to be defined here just as it is at the entry.
+    std::unordered_set<std::string> graph_defined;
+    CodegenEffectiveUseCollector graph_body_vars;
+    graph_body_vars.VisitStmt(graph_func->body_);
+    for (const auto* def : graph_body_vars.var_defs) graph_defined.insert(GetSSABaseName(def->name_hint_));
+    for (const auto& param : graph_func->params_) {
+      if (!AsTensorTypeLike(param->GetType())) {
+        graph_defined.insert(auto_name::GetCompatibleBaseName(param->name_hint_));
+      }
+    }
+    oss << GenerateDynamicDimDefs(graph_func->params_, graph_body_code, &body_codegen,
+                                  std::move(graph_defined));
+
+    oss << graph_body_code;
+    oss << "}\n\n";
+    ++graph_index;
+  }
+  return oss.str();
+}
+
 OrchestrationResult GenerateOrchestration(const ir::ProgramPtr& program, const ir::FunctionPtr& func) {
   CHECK(program != nullptr) << "Cannot generate orchestration for null program";
   CHECK(func != nullptr) << "Cannot generate orchestration for null function";
@@ -4403,6 +4667,11 @@ OrchestrationResult GenerateOrchestration(const ir::ProgramPtr& program, const i
 
   oss << GenerateConfigFunction(expected_arg_count);
 
+  // Each Graph function referenced by this entry is emitted once, ahead of the
+  // entry that launches it, so the call site can take its address.
+  oss << GenerateGraphFunctions(program, func, &func_name_to_id, &func_name_to_core_type,
+                                &func_name_to_signature, &next_func_id);
+
   oss << "__attribute__((visibility(\"default\")))\n";
   oss << "void aicpu_orchestration_entry(const ChipTaskArgs& orch_args) {\n";
 
@@ -4462,25 +4731,9 @@ OrchestrationResult GenerateOrchestration(const ir::ProgramPtr& program, const i
   CodegenEffectiveUseCollector body_vars;
   body_vars.VisitStmt(func->body_);
   for (const auto* def : body_vars.var_defs) defined_names.insert(GetSSABaseName(def->name_hint_));
-  std::vector<std::string> dyn_dim_defs;
-  for (const auto& var : func->params_) {
-    auto tensor_type = AsTensorTypeLike(var->GetType());
-    if (!tensor_type) continue;
-    const std::string param_name = auto_name::GetCompatibleBaseName(var->name_hint_);
-    for (size_t axis = 0; axis < tensor_type->shape_.size(); ++axis) {
-      auto extent = As<Var>(tensor_type->shape_[axis]);
-      if (!extent) continue;
-      const std::string symbol_name = stmt_codegen.GetVarName(extent);
-      if (!defined_names.insert(symbol_name).second) continue;
-      if (!ReferencesIdentifier(body_code, symbol_name)) continue;
-      dyn_dim_defs.push_back("    int64_t " + symbol_name + " = " +
-                             stmt_codegen.GetTensorShapeDim(param_name, static_cast<int64_t>(axis)) + ";\n");
-    }
-  }
-  if (!dyn_dim_defs.empty()) {
-    oss << "\n    // Dynamic-dim symbols (extent of the declaring argument)\n";
-    for (const auto& def : dyn_dim_defs) oss << def;
-  }
+  // Shared with each Graph helper, which binds its own tensor parameters and
+  // needs the same definitions; see GenerateDynamicDimDefs.
+  oss << GenerateDynamicDimDefs(func->params_, body_code, &stmt_codegen, std::move(defined_names));
 
   // The outermost SIMPLER_SCOPE() is now an explicit RuntimeScopeStmt emitted by
   // stmt_codegen (see MaterializeRuntimeScopes); just splice its output in.

--- a/src/ir/transforms/legalize_graph_boundary_pass.cpp
+++ b/src/ir/transforms/legalize_graph_boundary_pass.cpp
@@ -599,6 +599,64 @@ class RegionAllocationChecker : public IRVisitor {
   FunctionPtr func_;
 };
 
+/// Rejects a launch whose core count replay cannot reproduce.
+///
+/// Recording stores the launch spec into the node — `logical_block_num =
+/// block_num` — and replay copies it straight back (`slot.logical_block_num =
+/// source.logical_block_num`). Only boundary tensors and boundary *scalar slots*
+/// are refreshed; the block count is not. A `core_num` read from a boundary
+/// scalar is therefore frozen at the first call's value, so a later call asking
+/// for more blocks silently schedules the first call's number and leaves the
+/// rest of the work undone.
+///
+/// The effective core count is resolved the way codegen resolves it — the launch
+/// carries it for a direct `pl.spmd_submit`, the callee for a scope-based
+/// `pl.spmd` or Group wrapper — so the two agree on what is being checked.
+class LaunchSpecChecker : public IRVisitor {
+ public:
+  LaunchSpecChecker(FunctionPtr func, ProgramPtr program)
+      : func_(std::move(func)), program_(std::move(program)) {}
+
+ protected:
+  void VisitExpr_(const CallPtr& op) override {
+    IRVisitor::VisitExpr_(op);
+    Check(alloc_batching::EffectiveCoreNum(op, Callee(op->op_)), op->span_);
+  }
+
+  void VisitExpr_(const SubmitPtr& op) override {
+    IRVisitor::VisitExpr_(op);
+    // `core_num_` is the Submit's own field; the wrapper attr is the fallback,
+    // matching SubmitToCallView's surfacing of kAttrCoreNum.
+    ExprPtr core_num = op->core_num_.value_or(nullptr);
+    if (!core_num) {
+      auto callee = Callee(op->op_);
+      if (callee) core_num = callee->GetAttr<ExprPtr>(kAttrCoreNum, nullptr);
+    }
+    Check(core_num, op->span_);
+  }
+
+ private:
+  [[nodiscard]] FunctionPtr Callee(const OpPtr& callee_op) const {
+    auto gvar = As<GlobalVar>(callee_op);
+    if (!gvar || !program_) return nullptr;
+    return program_->GetFunction(gvar->name_);
+  }
+
+  void Check(const ExprPtr& core_num, const Span& span) const {
+    if (!core_num || IsLiteralScalarExpr(core_num)) return;
+    CHECK_SPAN(false, span)
+        << "Graph function '" << func_->name_
+        << "' launches a task whose core_num is not a compile-time constant. Recording copies the "
+           "launch spec into the node and replay restores it unchanged — only boundary tensors and "
+           "scalars are patched — so the first call's block count would be replayed for every later "
+           "call, leaving the rest of the work unexecuted. Use a constant core_num inside the Graph, "
+           "or move the launch to the call site.";
+  }
+
+  FunctionPtr func_;
+  ProgramPtr program_;
+};
+
 void CheckRegionAllocations(const FunctionPtr& func) {
   RegionAllocationChecker checker(func);
   checker.VisitStmt(func->body_);
@@ -643,9 +701,14 @@ class NestedGraphChecker : public IRVisitor {
 void CheckGraphSignature(const FunctionPtr& func) {
   size_t tensor_params = 0;
   size_t scalar_params = 0;
+  // `param_directions_` is not guaranteed to be as long as `params_` at every
+  // point in the pipeline — `window_externalization` guards the same access —
+  // and a Graph reaches this check before the pass that would normalise it. A
+  // missing entry is not a legality violation to report, so treat it as the
+  // default `In` rather than reading out of bounds.
   for (size_t i = 0; i < func->params_.size(); ++i) {
     const auto& param = func->params_[i];
-    const auto dir = func->param_directions_[i];
+    const auto dir = i < func->param_directions_.size() ? func->param_directions_[i] : ParamDirection::In;
     if (IsScalarType(param->GetType())) {
       CHECK_SPAN(dir == ParamDirection::In, param->span_)
           << "Graph function '" << func->name_ << "' declares scalar parameter '" << param->name_hint_
@@ -682,7 +745,7 @@ void CheckGraphSignature(const FunctionPtr& func) {
          "the call site and pass fewer, or split the region.";
 }
 
-/// Rejects a Graph returning anything other than one of its own parameters.
+/// Rejects a Graph that returns a value the caller could consume.
 ///
 /// `return c` where `c` is an InOut parameter is the DSL's spelling for writing
 /// in place, and lowers to an alias rather than a value — that is fine. A
@@ -840,7 +903,29 @@ class CallSiteExtender : public IRMutator {
                                     submit->sync_start_, submit->allow_early_resolve_, submit->predicate_);
   }
 
+  /// Splice any bindings synthesised while rewriting this statement's
+  /// expression in ahead of it.
+  StmtPtr VisitStmt_(const AssignStmtPtr& op) override {
+    pending_prefix_.clear();
+    auto stmt = IRMutator::VisitStmt_(op);
+    return WithPrefix(std::move(stmt), op->span_);
+  }
+
+  StmtPtr VisitStmt_(const EvalStmtPtr& op) override {
+    pending_prefix_.clear();
+    auto stmt = IRMutator::VisitStmt_(op);
+    return WithPrefix(std::move(stmt), op->span_);
+  }
+
  private:
+  [[nodiscard]] StmtPtr WithPrefix(StmtPtr stmt, const Span& span) {
+    if (pending_prefix_.empty()) return stmt;
+    std::vector<StmtPtr> stmts = std::move(pending_prefix_);
+    pending_prefix_.clear();
+    stmts.push_back(std::move(stmt));
+    return SeqStmts::Flatten(std::move(stmts), span);
+  }
+
   [[nodiscard]] const GraphPlan* LookupPlan(const OpPtr& op) const {
     auto gvar = As<GlobalVar>(op);
     if (!gvar || !program_) return nullptr;
@@ -849,8 +934,14 @@ class CallSiteExtender : public IRMutator {
   }
 
   /// Rebuild each hoisted expression against this call site's actual arguments.
+  ///
+  /// Each rebuilt value is bound to a fresh local rather than inlined into the
+  /// argument list: orchestration codegen accepts only a Var or a literal as an
+  /// argument, so an inline `i * 5120` would fail there. The binding statements
+  /// accumulate in `pending_prefix_` and the statement overrides splice them in
+  /// immediately before the call.
   [[nodiscard]] std::vector<ExprPtr> AppendHoistedArgs(const GraphPlan& plan, const OpPtr& callee_op,
-                                                       const std::vector<ExprPtr>& old_args) const {
+                                                       const std::vector<ExprPtr>& old_args) {
     auto gvar = As<GlobalVar>(callee_op);
     auto callee = program_->GetFunction(gvar->name_);
     INTERNAL_CHECK(callee) << "Internal error: planned Graph '" << plan.name << "' not found in program";
@@ -875,8 +966,14 @@ class CallSiteExtender : public IRMutator {
     size_t next_alias = 0;
     auto emit_hoist = [&](const HoistedScalar& h) {
       auto value = SubstituteAtCallSite(h.value, binding);
-      args.push_back(value);
-      binding[h.original.get()] = value;
+      // Bound to a local, not spliced in as an expression: codegen emits a
+      // boundary scalar as `const uint64_t&` into the argument slot, so the
+      // value needs an addressable home at the call site.
+      auto local = std::make_shared<Var>(h.param->name_hint_ + "__graph_arg" + std::to_string(next_local_++),
+                                         h.param->GetType(), h.param->span_);
+      pending_prefix_.push_back(std::make_shared<AssignStmt>(local, value, h.param->span_));
+      args.push_back(local);
+      binding[h.original.get()] = local;
     };
     auto emit_alias = [&](const std::pair<const Var*, VarPtr>& a) {
       auto it = binding.find(a.second.get());
@@ -908,6 +1005,8 @@ class CallSiteExtender : public IRMutator {
 
   ProgramPtr program_;
   const std::unordered_map<std::string, GraphPlan>& plans_;
+  std::vector<StmtPtr> pending_prefix_;
+  int next_local_ = 0;
 };
 
 [[nodiscard]] ProgramPtr TransformProgram(const ProgramPtr& program) {
@@ -930,6 +1029,9 @@ class CallSiteExtender : public IRMutator {
     if (!func->body_) continue;
 
     CheckRegionAllocations(func);
+
+    LaunchSpecChecker launch_spec(func, program);
+    launch_spec.VisitStmt(func->body_);
 
     NestedGraphChecker nested(func, program);
     nested.VisitStmt(func->body_);
@@ -985,6 +1087,11 @@ class CallSiteExtender : public IRMutator {
       std::unordered_set<const Var*> hoistable;  // all hoistable values are now params
       UnhoistableScalarChecker checker(func, hoistable);
       checker.VisitStmt(func->body_);
+      // Also after the rewrite: Step A turns a derived scalar into a parameter,
+      // which does not make it replay-stable as a *launch spec* — only as an
+      // argument.
+      LaunchSpecChecker launch_spec(func, result);
+      launch_spec.VisitStmt(func->body_);
       continue;
     }
     GraphCallSiteChecker call_checker(func, result);

--- a/src/ir/verifier/verify_graph_functions.cpp
+++ b/src/ir/verifier/verify_graph_functions.cpp
@@ -227,9 +227,12 @@ void VerifySignature(const FunctionPtr& func, std::vector<Diagnostic>& diagnosti
 
   size_t tensor_params = 0;
   size_t scalar_params = 0;
+  // `param_directions_` may be shorter than `params_` at some points in the
+  // pipeline, so a missing entry reads as the default `In` rather than out of
+  // bounds — matching the guard in `window_externalization`.
   for (size_t i = 0; i < func->params_.size(); ++i) {
     const auto& param = func->params_[i];
-    const auto dir = func->param_directions_[i];
+    const auto dir = i < func->param_directions_.size() ? func->param_directions_[i] : ParamDirection::In;
     if (As<ScalarType>(param->GetType()) != nullptr) {
       if (dir != ParamDirection::In) {
         report("declares scalar parameter '" + param->name_hint_ +
@@ -238,6 +241,18 @@ void VerifySignature(const FunctionPtr& func, std::vector<Diagnostic>& diagnosti
                param->span_);
       }
       ++scalar_params;
+      continue;
+    }
+    // Only a tensor is a tensor boundary. `GenerateGraphFunctions` binds a
+    // parameter through `args.tensor(i).ref()` when `AsTensorTypeLike` holds and
+    // through `args.scalar(k)` otherwise, so counting every non-scalar as a
+    // tensor would let a Tile, Tuple or pointer-like parameter verify as a
+    // boundary tensor and then take the scalar ABI in codegen.
+    if (!AsTensorTypeLike(param->GetType())) {
+      report("declares parameter '" + param->name_hint_ +
+                 "' as neither a tensor nor a scalar. A Graph boundary carries only tensors and "
+                 "scalars; codegen would bind this one through the scalar argument slot.",
+             param->span_);
       continue;
     }
     ++tensor_params;
@@ -296,6 +311,7 @@ class GraphBodyChecker : public IRVisitor {
   void VisitExpr_(const CallPtr& op) override {
     IRVisitor::VisitExpr_(op);
     CheckAllocation(op);
+    CheckLaunchSpec(alloc_batching::EffectiveCoreNum(op, Callee(op->op_)), op->span_);
     if (!IsTaskLaunch(op)) return;
     count_ = SatAdd(count_, 1);
     CheckArity(op->op_, op->args_.size(), /*is_submit=*/false, op->span_);
@@ -304,6 +320,12 @@ class GraphBodyChecker : public IRVisitor {
 
   void VisitExpr_(const SubmitPtr& op) override {
     IRVisitor::VisitExpr_(op);
+    ExprPtr submit_core_num = op->core_num_.value_or(nullptr);
+    if (!submit_core_num) {
+      auto callee = Callee(op->op_);
+      if (callee) submit_core_num = callee->GetAttr<ExprPtr>(kAttrCoreNum, nullptr);
+    }
+    CheckLaunchSpec(submit_core_num, op->span_);
     count_ = SatAdd(count_, 1);
     CheckArity(op->op_, op->args_.size(), /*is_submit=*/true, op->span_);
     CheckScalarArgs(op->args_, op->span_);
@@ -406,6 +428,26 @@ class GraphBodyChecker : public IRVisitor {
     }
   }
 
+  [[nodiscard]] FunctionPtr Callee(const OpPtr& callee_op) const {
+    auto gvar = As<GlobalVar>(callee_op);
+    if (!gvar || !program_) return nullptr;
+    return program_->GetFunction(gvar->name_);
+  }
+
+  /// A launch spec is frozen into the recorded node, not patched on replay.
+  ///
+  /// Replay restores `slot.logical_block_num = source.logical_block_num` from the
+  /// Definition and refreshes only boundary tensors and scalar slots, so a
+  /// `core_num` reading a boundary scalar replays the first call's block count
+  /// and silently leaves the rest of the work unscheduled.
+  void CheckLaunchSpec(const ExprPtr& core_num, const Span& span) {
+    if (!core_num || IsLiteralScalarExpr(core_num)) return;
+    Report(
+        "launches a task whose core_num is not a compile-time constant; recording freezes the launch "
+        "spec into the node and replay restores it unchanged.",
+        span);
+  }
+
   void Report(const std::string& message, const Span& span) {
     diagnostics_.emplace_back(DiagnosticSeverity::Error, "GraphBoundaryLegalized", 0,
                               "Graph function '" + func_->name_ + "' " + message, span);
@@ -435,7 +477,9 @@ class GraphBodyChecker : public IRVisitor {
     // lets it through here and fails much later, as an INTERNAL_CHECK in
     // codegen's direction handling.
     for (size_t i = argc; i < params; ++i) {
-      if (callee->param_directions_[i] == ParamDirection::Out) continue;
+      if (i < callee->param_directions_.size() && callee->param_directions_[i] == ParamDirection::Out) {
+        continue;
+      }
       Report("launches '" + callee->name_ + "' without supplying '" + callee->params_[i]->name_hint_ +
                  "', which is not an Out parameter. A Submit may omit only a runtime-allocated Out "
                  "tail.",

--- a/tests/ut/codegen/test_orchestration_codegen_graph.py
+++ b/tests/ut/codegen/test_orchestration_codegen_graph.py
@@ -1,0 +1,405 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Orchestration codegen for ``FunctionType.Graph``.
+
+A Graph function is emitted once as a **named file-scope function**, and each
+call site launches it with ``rt_submit_graph``. Named rather than an inlined
+lambda because the runtime identifies a graph by a bare function pointer: a
+lambda would mint one pointer per syntactic occurrence and burn through the
+16-entry Definition cache.
+
+The assertions that matter most are the ones covering silent failures. A
+boundary scalar bound by value instead of by reference severs the pointer
+identity the runtime uses to track it, and the value is frozen at its first-call
+number on every later replay — with no warning anywhere.
+"""
+
+import os
+import re
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+from unittest import mock
+
+import pypto.language as pl
+import pytest
+from pypto.ir.compile import compile as ir_compile
+from pypto.pypto_core import passes
+
+# ``kernel_config.py`` is only written when ptoas is not skipped, but these tests
+# are about the emitted orchestration and manifest, not kernel compilation. Stub
+# the ptoas invocation as the neighbouring codegen tests do.
+_STUB_PTOAS_OUTPUT = """\
+#include "pto/pto-inst.hpp"
+using namespace pto;
+
+__global__ AICORE void stub_kernel(__gm__ float* v1) {}
+"""
+
+
+@pl.program
+class Decoder:
+    """One recordable layer, launched four times from the entry."""
+
+    @pl.function(type=pl.FunctionType.Graph)
+    def layer(
+        self,
+        a: pl.Tensor[[512, 128], pl.FP32],
+        c: pl.InOut[pl.Tensor[[128, 128], pl.FP32]],
+        layer_idx: pl.Scalar[pl.INDEX],
+    ) -> pl.Tensor[[128, 128], pl.FP32]:
+        base = layer_idx * 128
+        with pl.at(level=pl.Level.CORE_GROUP):
+            t: pl.Tile[[128, 128], pl.FP32] = pl.load(a, [base, 0], [128, 128])
+            pl.store(t, [0, 0], c)
+        return c
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def main(
+        self,
+        a: pl.Tensor[[512, 128], pl.FP32],
+        c: pl.InOut[pl.Tensor[[128, 128], pl.FP32]],
+    ) -> pl.Tensor[[128, 128], pl.FP32]:
+        for i in pl.range(4):
+            c = self.layer(a, c, i)
+        return c
+
+
+@pytest.fixture(scope="module")
+def artifact_root() -> Path:
+    """Compile Decoder for host_build_graph and return the output directory."""
+    out_dir = tempfile.mkdtemp()
+    with (
+        mock.patch(
+            "pypto.backend.pto_backend._compile_pto_module",
+            lambda _code, _name, _dir, _planner=None: _STUB_PTOAS_OUTPUT,
+        ),
+        passes.PassContext([], runtime=passes.RuntimeKind.HOST_BUILD_GRAPH),
+    ):
+        ir_compile(
+            Decoder,
+            skip_ptoas=False,
+            platform="a2a3",
+            output_dir=out_dir,
+            dump_passes=False,
+        )
+    return Path(out_dir)
+
+
+@pytest.fixture(scope="module")
+def artifacts(artifact_root) -> dict[str, str]:
+    """The emitted files, keyed by path relative to the output directory."""
+    return {
+        str(path.relative_to(artifact_root)): path.read_text()
+        for path in artifact_root.rglob("*")
+        if path.is_file() and path.suffix in {".cpp", ".py"}
+    }
+
+
+@pytest.fixture(scope="module")
+def orch(artifacts) -> str:
+    return artifacts["orchestration/main.cpp"]
+
+
+def _graph_body(orch: str) -> str:
+    """The emitted graph function, up to the entry that follows it."""
+    start = orch.index("static void pypto_graph_layer")
+    return orch[start : orch.index("aicpu_orchestration_entry")]
+
+
+def _entry_body(orch: str) -> str:
+    return orch[orch.index("aicpu_orchestration_entry") :]
+
+
+# ---------------------------------------------------------------------------
+# The emitted graph function
+# ---------------------------------------------------------------------------
+
+
+def test_graph_is_a_named_file_scope_function(orch):
+    assert "static void pypto_graph_layer(const GraphTaskArgs& args) {" in orch
+
+
+def test_boundary_tensors_are_bound_from_the_task_args(orch):
+    body = _graph_body(orch)
+    assert "const TaskTensor& a = args.tensor(0).ref();" in body
+    assert "const TaskTensor& c = args.tensor(1).ref();" in body
+
+
+def test_boundary_scalars_are_bound_by_reference(orch):
+    """The single most consequential line in the whole feature.
+
+    The runtime tracks a boundary scalar by the *address* of its argument slot.
+    Copying it into a local (``uint64_t base = args.scalar(1);``) severs that
+    link, so the value is frozen at the first call's number and silently reused
+    on every replay.
+    """
+    body = _graph_body(orch)
+    assert "const uint64_t& layer_idx = args.scalar(0);" in body
+    assert "const uint64_t& base = args.scalar(1);" in body
+
+
+def test_graph_body_allocates_nothing(orch):
+    # A bare alloc_tensors inside the region poisons the recording outright.
+    assert "alloc_tensors(" not in _graph_body(orch)
+
+
+def test_graph_body_task_vars_do_not_collide_with_the_entry(orch):
+    # The graph body is emitted by a second codegen instance whose counters
+    # restart at 0; without a prefix both would declare `params_t0`.
+    assert "g0_params_t0" in _graph_body(orch)
+    # Anchored: `"params_t0" in entry` is also true of `g0_params_t0`, so a
+    # substring check passes even if the entry gained a prefix too — which is
+    # the regression this guards against.
+    entry = _entry_body(orch)
+    assert re.search(r"(?<![0-9A-Za-z_])params_t0\b", entry), entry
+
+
+# ---------------------------------------------------------------------------
+# The call site
+# ---------------------------------------------------------------------------
+
+
+def test_call_site_submits_the_graph_by_key_and_pointer(orch):
+    assert "rt_submit_graph(&pypto_graph_layer," in _entry_body(orch)
+
+
+def test_derived_scalar_is_computed_at_the_call_site(orch):
+    """LegalizeGraphBoundary moved ``base = layer_idx * 128`` out here.
+
+    Inside the region it would have had no argument slot; out here it is an
+    ordinary pass-through scalar the runtime can patch on replay.
+    """
+    entry = _entry_body(orch)
+    assert "(i * 128)" in entry
+    assert entry.count("add_scalar") == 2  # layer_idx and the hoisted base
+
+
+def test_graph_result_is_not_chained(orch):
+    # rt_submit_graph yields a valid task id only on a cache hit, so the call
+    # site must not bind or depend on its result.
+    entry = _entry_body(orch)
+    assert "= rt_submit_graph" not in entry
+
+
+# ---------------------------------------------------------------------------
+# The manifest
+# ---------------------------------------------------------------------------
+
+
+def test_graph_is_not_a_kernel(artifacts):
+    """A Graph has no .cpp under kernels/, so it must not reach KERNELS.
+
+    Registering it would put an entry in the manifest pointing at a file that
+    does not exist, which fails at runtime rather than at build time.
+    """
+    config = artifacts["kernel_config.py"]
+    assert "pypto_graph_layer" not in config
+    assert '"name": "layer"' not in config
+    # The real kernel outlined out of the graph body is still listed.
+    assert "layer_incore_0" in config
+
+
+def test_artifact_targets_the_graph_runtime(artifacts):
+    assert '"runtime": "host_build_graph"' in artifacts["kernel_config.py"]
+
+
+# ---------------------------------------------------------------------------
+# The generated file against the real runtime headers
+# ---------------------------------------------------------------------------
+
+
+def _runtime_include_args(repo_root: Path) -> list[str]:
+    """``-I`` flags for the a2a3 host_build_graph orchestration headers.
+
+    Every directory holding a header, minus ``tensormap_and_ringbuffer``: the two
+    runtimes ship same-named headers (``types.h``, ``runtime_status.h``), so
+    leaving the other one on the path lets it shadow the one under test. The
+    tree roots come last, for the includes spelled with a directory prefix
+    (``common/host_phase_kind.h``, ``host_build_graph/graph_cache.h``).
+    """
+    src = repo_root / "runtime" / "src"
+    dirs = sorted(
+        {
+            header.parent
+            for tree in ("common", "a2a3")
+            for header in (src / tree).rglob("*.h")
+            if "tensormap_and_ringbuffer" not in header.parts
+        }
+    )
+    roots = [
+        src / "common" / "platform" / "include",
+        src / "a2a3" / "platform" / "include",
+        src / "common",
+        src,
+    ]
+    return [f"-I{path}" for path in [*dirs, *roots]]
+
+
+def test_generated_orchestration_compiles_against_the_pinned_runtime(artifact_root):
+    """Type-check the emitted file — the only check that covers the graph ABI.
+
+    Every other test here matches generated *text*, so it agrees with whatever
+    codegen currently emits. That cannot catch a mismatch with the runtime's
+    actual types: `rt_submit_graph` takes `void (*)(const GraphTaskArgs&)` and
+    `GraphTaskArgs` is a different `Arg` instantiation from `CoreTaskArgs`, while
+    `args.tensor(i).ref()` yields `const simpler::hbg::Tensor&` (aliased
+    `TaskTensor`). Emitting `CoreTaskArgs` or a boundary tensor type there is a
+    hard compile error in the generated file that a string assertion happily
+    confirms instead of catching.
+    """
+    repo_root = Path(__file__).resolve().parents[3]
+    main_cpp = artifact_root / "orchestration" / "main.cpp"
+    assert main_cpp.is_file(), f"no orchestration emitted at {main_cpp}"
+
+    if not (repo_root / "runtime" / "src" / "a2a3" / "runtime" / "host_build_graph").is_dir():
+        pytest.skip("runtime submodule not checked out")
+    candidates = (os.environ.get("CXX"), "g++-15", "g++", "c++")
+    compiler = next(
+        (found for name in candidates if name and (found := shutil.which(name))),
+        None,
+    )
+    if compiler is None:
+        pytest.skip("no C++ compiler available")
+
+    result = subprocess.run(
+        [compiler, "-std=c++17", "-fsyntax-only", *_runtime_include_args(repo_root), str(main_cpp)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode == 0:
+        return
+
+    # A missing header means this environment's include layout differs from the
+    # one the flags above assume — not a codegen defect, so do not fail on it.
+    # Anything the compiler blames on the generated file is.
+    if "fatal error:" in result.stderr and str(main_cpp) not in result.stderr.split("fatal error:")[0][-200:]:
+        pytest.skip(f"runtime headers not resolvable here: {result.stderr.strip().splitlines()[0]}")
+    blamed = [line for line in result.stderr.splitlines() if "error:" in line]
+    raise AssertionError(
+        "generated orchestration does not compile against the pinned runtime:\n" + "\n".join(blamed[:15])
+    )
+
+
+@pl.program
+class _DynDim:
+    """A Graph whose body reads a dynamic extent of a boundary tensor.
+
+    `LegalizeGraphBoundary` only forbids a *launch* under a non-constant bound,
+    so a dynamic loop that launches nothing is legal here.
+    """
+
+    @pl.function(type=pl.FunctionType.Graph)
+    def layer(
+        self,
+        a: pl.Tensor[[pl.dynamic("N"), 128], pl.FP32],
+        c: pl.InOut[pl.Tensor[[128, 128], pl.FP32]],
+    ) -> pl.Tensor[[128, 128], pl.FP32]:
+        n = pl.tensor.dim(a, 0)
+        for _ in pl.range(n):
+            pass
+        with pl.at(level=pl.Level.CORE_GROUP):
+            t: pl.Tile[[128, 128], pl.FP32] = pl.load(a, [0, 0], [128, 128])
+            pl.store(t, [0, 0], c)
+        return c
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def main(
+        self,
+        a: pl.Tensor[[pl.dynamic("N"), 128], pl.FP32],
+        c: pl.InOut[pl.Tensor[[128, 128], pl.FP32]],
+    ) -> pl.Tensor[[128, 128], pl.FP32]:
+        c = self.layer(a, c)
+        return c
+
+
+@pl.program
+class _SubmitDeps:
+    """A Graph whose body submits two tasks with an explicit TaskId edge."""
+
+    @pl.function(type=pl.FunctionType.AIV)
+    def k1(
+        self, x: pl.Tensor[[128, 128], pl.FP32], o: pl.InOut[pl.Tensor[[128, 128], pl.FP32]]
+    ) -> pl.Tensor[[128, 128], pl.FP32]:
+        t: pl.Tile[[128, 128], pl.FP32] = pl.load(x, [0, 0], [128, 128])
+        o = pl.store(t, [0, 0], o)
+        return o
+
+    @pl.function(type=pl.FunctionType.AIV)
+    def k2(
+        self, x: pl.Tensor[[128, 128], pl.FP32], o: pl.InOut[pl.Tensor[[128, 128], pl.FP32]]
+    ) -> pl.Tensor[[128, 128], pl.FP32]:
+        t: pl.Tile[[128, 128], pl.FP32] = pl.load(x, [0, 0], [128, 128])
+        o = pl.store(t, [0, 0], o)
+        return o
+
+    @pl.function(type=pl.FunctionType.Graph)
+    def layer(
+        self,
+        a: pl.Tensor[[128, 128], pl.FP32],
+        c: pl.InOut[pl.Tensor[[128, 128], pl.FP32]],
+        d: pl.InOut[pl.Tensor[[128, 128], pl.FP32]],
+    ):
+        with pl.manual_scope():
+            c, t1 = pl.spmd_submit(self.k1, a, c, core_num=1)
+            d, _ = pl.spmd_submit(self.k2, c, d, core_num=1, deps=[t1])
+        return c, d
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def main(
+        self,
+        a: pl.Tensor[[128, 128], pl.FP32],
+        c: pl.InOut[pl.Tensor[[128, 128], pl.FP32]],
+        d: pl.InOut[pl.Tensor[[128, 128], pl.FP32]],
+    ):
+        c, d = self.layer(a, c, d)
+        return c, d
+
+
+def _compile_orch(program) -> str:
+    """Compile one program for host_build_graph and return orchestration/main.cpp."""
+    out_dir = tempfile.mkdtemp()
+    with (
+        mock.patch(
+            "pypto.backend.pto_backend._compile_pto_module",
+            lambda _code, _name, _dir, _planner=None: _STUB_PTOAS_OUTPUT,
+        ),
+        passes.PassContext([], runtime=passes.RuntimeKind.HOST_BUILD_GRAPH),
+    ):
+        ir_compile(program, skip_ptoas=False, platform="a2a3", output_dir=out_dir, dump_passes=False)
+    return (Path(out_dir) / "orchestration" / "main.cpp").read_text()
+
+
+def test_graph_helper_defines_the_dynamic_dims_its_body_reads():
+    """The helper binds its own tensor parameters, so it needs its own symbols.
+
+    The entry emits these from its parameter shapes; a Graph body reading one
+    without the matching definition names an undeclared variable.
+    """
+    body = _graph_body(_compile_orch(_DynDim))
+    assert "int64_t N = (int64_t)a.shapes[0];" in body, body
+    # The loop that reads it is what makes the definition load-bearing.
+    assert "i < N;" in body, body
+
+
+def test_graph_helper_binds_submit_task_ids():
+    """`GenerateSubmitReturnAliases` needs the tuple mappings from
+    `OrchestrationInfoCollector`, which the entry sets and the graph instance
+    must set too — otherwise the TaskId is never bound and the dependency edge
+    inside the region is lost."""
+    body = _graph_body(_compile_orch(_SubmitDeps))
+    assert "TaskId t1 = task_0_outs.task_id();" in body, body
+    assert "] = t1;" in body, body
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/ut/ir/test_graph_function.py
+++ b/tests/ut/ir/test_graph_function.py
@@ -19,8 +19,6 @@ Graph is authored like every other function type — ``type=pl.FunctionType.Grap
 rest of the enum.
 """
 
-import tempfile
-
 import pypto.language as pl
 import pytest
 from pypto import ir
@@ -115,66 +113,6 @@ def test_plain_function_is_unaffected():
         return x
 
     assert plain.func_type == ir.FunctionType.Opaque
-
-
-# ---------------------------------------------------------------------------
-# The gap this change opens, reported rather than crashed on
-# ---------------------------------------------------------------------------
-
-
-def test_compiling_a_graph_call_reports_that_codegen_is_missing():
-    """Until the graph-launch emission path lands, say so instead of crashing.
-
-    A Graph callee reaches `InferFunctionCoreType`, which recognises only
-    AIC/AIV and aborts with an internal error naming nothing actionable. This
-    change makes the type authorable, so it also has to make the gap legible.
-
-    The Graph body opens its own device scope, which is how one is actually
-    written — and is only reachable because the scope outliners now admit Graph
-    bodies. Without that the compile would stop earlier on a leftover scope, and
-    this diagnostic would be unreachable for every realistic program.
-
-    The message is matched in full: it names the authoring form, so a spelling
-    that no longer exists would otherwise survive here unnoticed.
-    """
-    from pypto.backend.pto_backend import PartialCodegenError  # noqa: PLC0415
-    from pypto.ir.compile import compile as ir_compile  # noqa: PLC0415
-
-    @pl.program
-    class UsesGraph:
-        @pl.function(type=pl.FunctionType.Graph)
-        def layer(
-            self,
-            a: pl.Tensor[[128, 128], pl.FP32],
-            c: pl.InOut[pl.Tensor[[128, 128], pl.FP32]],
-        ) -> pl.Tensor[[128, 128], pl.FP32]:
-            with pl.at(level=pl.Level.CORE_GROUP):
-                t: pl.Tile[[128, 128], pl.FP32] = pl.load(a, [0, 0], [128, 128])
-                pl.store(t, [0, 0], c)
-            return c
-
-        @pl.function(type=pl.FunctionType.Orchestration)
-        def main(
-            self,
-            a: pl.Tensor[[128, 128], pl.FP32],
-            c: pl.InOut[pl.Tensor[[128, 128], pl.FP32]],
-        ) -> pl.Tensor[[128, 128], pl.FP32]:
-            c = self.layer(a, c)
-            return c
-
-    expected = (
-        "Graph function 'layer' cannot be compiled yet: type=pl.FunctionType.Graph is authorable, "
-        "but the orchestration codegen that emits a graph launch is not in place yet."
-    )
-    with tempfile.TemporaryDirectory() as out_dir:
-        with pytest.raises(PartialCodegenError) as excinfo:
-            ir_compile(UsesGraph, skip_ptoas=True, platform="a2a3", output_dir=out_dir, dump_passes=False)
-
-    # PartialCodegenError word-wraps each message into a table cell, so compare
-    # against the text with the gutter and the wrapping collapsed away — a
-    # substring match on one line would not notice a stale spelling in another.
-    reported = " ".join(str(excinfo.value).replace("|", " ").split())
-    assert expected in reported
 
 
 # ---------------------------------------------------------------------------

--- a/tests/ut/ir/transforms/test_legalize_graph_boundary.py
+++ b/tests/ut/ir/transforms/test_legalize_graph_boundary.py
@@ -323,6 +323,127 @@ class TestDerivedScalarHoisting:
         ir.assert_structural_equal(ssa, After)
 
 
+class TestLaunchSpec:
+    """`core_num` is frozen into the recorded node, not patched on replay.
+
+    Recording stores `logical_block_num = block_num` and replay copies it back
+    from the Definition (`slot.logical_block_num = source.logical_block_num`);
+    only boundary tensors and scalar slots are refreshed. A `core_num` read from
+    a boundary scalar therefore replays call one's block count for every later
+    call — the rest of the blocks are never scheduled, with no diagnostic.
+    """
+
+    def test_core_num_from_a_boundary_scalar_is_rejected(self):
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.AIV)
+            def kernel(
+                self,
+                x: pl.Tensor[[128, 128], pl.FP32],
+                o: pl.InOut[pl.Tensor[[128, 128], pl.FP32]],
+            ) -> pl.Tensor[[128, 128], pl.FP32]:
+                t: pl.Tile[[128, 128], pl.FP32] = pl.load(x, [0, 0], [128, 128])
+                o = pl.store(t, [0, 0], o)
+                return o
+
+            @pl.function(type=pl.FunctionType.Graph)
+            def layer(
+                self,
+                a: pl.Tensor[[128, 128], pl.FP32],
+                c: pl.InOut[pl.Tensor[[128, 128], pl.FP32]],
+                blocks: pl.Scalar[pl.INDEX],
+            ) -> pl.Tensor[[128, 128], pl.FP32]:
+                with pl.manual_scope():
+                    c, _ = pl.spmd_submit(self.kernel, a, c, core_num=blocks)
+                return c
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                a: pl.Tensor[[128, 128], pl.FP32],
+                c: pl.InOut[pl.Tensor[[128, 128], pl.FP32]],
+            ) -> pl.Tensor[[128, 128], pl.FP32]:
+                c = self.layer(a, c, 4)
+                return c
+
+        with pytest.raises(ValueError, match="core_num is not a compile-time constant"):
+            _legalize_outlined(Before)
+
+    def test_core_num_derived_from_a_boundary_scalar_is_rejected(self):
+        """Step A would hoist `blocks * 2` into a parameter, which makes it a
+        replay-patchable *argument* but not a replay-patchable *launch spec*."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.AIV)
+            def kernel(
+                self,
+                x: pl.Tensor[[128, 128], pl.FP32],
+                o: pl.InOut[pl.Tensor[[128, 128], pl.FP32]],
+            ) -> pl.Tensor[[128, 128], pl.FP32]:
+                t: pl.Tile[[128, 128], pl.FP32] = pl.load(x, [0, 0], [128, 128])
+                o = pl.store(t, [0, 0], o)
+                return o
+
+            @pl.function(type=pl.FunctionType.Graph)
+            def layer(
+                self,
+                a: pl.Tensor[[128, 128], pl.FP32],
+                c: pl.InOut[pl.Tensor[[128, 128], pl.FP32]],
+                blocks: pl.Scalar[pl.INDEX],
+            ) -> pl.Tensor[[128, 128], pl.FP32]:
+                with pl.manual_scope():
+                    c, _ = pl.spmd_submit(self.kernel, a, c, core_num=blocks * 2)
+                return c
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                a: pl.Tensor[[128, 128], pl.FP32],
+                c: pl.InOut[pl.Tensor[[128, 128], pl.FP32]],
+            ) -> pl.Tensor[[128, 128], pl.FP32]:
+                c = self.layer(a, c, 4)
+                return c
+
+        with pytest.raises(ValueError, match="core_num is not a compile-time constant"):
+            _legalize_outlined(Before)
+
+    def test_constant_core_num_is_accepted(self):
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.AIV)
+            def kernel(
+                self,
+                x: pl.Tensor[[128, 128], pl.FP32],
+                o: pl.InOut[pl.Tensor[[128, 128], pl.FP32]],
+            ) -> pl.Tensor[[128, 128], pl.FP32]:
+                t: pl.Tile[[128, 128], pl.FP32] = pl.load(x, [0, 0], [128, 128])
+                o = pl.store(t, [0, 0], o)
+                return o
+
+            @pl.function(type=pl.FunctionType.Graph)
+            def layer(
+                self,
+                a: pl.Tensor[[128, 128], pl.FP32],
+                c: pl.InOut[pl.Tensor[[128, 128], pl.FP32]],
+                blocks: pl.Scalar[pl.INDEX],
+            ) -> pl.Tensor[[128, 128], pl.FP32]:
+                with pl.manual_scope():
+                    c, _ = pl.spmd_submit(self.kernel, a, c, core_num=4)
+                return c
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                a: pl.Tensor[[128, 128], pl.FP32],
+                c: pl.InOut[pl.Tensor[[128, 128], pl.FP32]],
+            ) -> pl.Tensor[[128, 128], pl.FP32]:
+                c = self.layer(a, c, 4)
+                return c
+
+        _legalize_outlined(Before)
+
+
 # ---------------------------------------------------------------------------
 # Step D — boundaries the runtime could not cache
 # ---------------------------------------------------------------------------
@@ -343,7 +464,13 @@ class TestBoundaryLegality:
         with pytest.raises(ValueError, match="empty boundary"):
             _legalize(Before)
 
-    def test_graph_returning_a_value_is_rejected(self):
+    def test_graph_returning_a_computed_value_is_rejected(self):
+        """A return that aliases an InOut parameter is fine; a computed one is not.
+
+        ``rt_submit_graph`` yields a valid task id only on a cache hit, so a
+        graph cannot hand a computed value back to its caller.
+        """
+
         @pl.program
         class Before:
             @pl.function(type=pl.FunctionType.Graph)


### PR DESCRIPTION
> **Stacked on #2416 → #2418.** #2408 and #2414 have merged; #2417 was folded into #2416. A fork PR cannot target another fork branch, so this targets `main` and its diff includes the two earlier commits. **Review only the third commit.** Merge order: #2416, #2418, then this.

## Summary

Completes the P1 path — a Graph function now compiles end to end. Each one is emitted once as a named file-scope function, and every call site launches it with `rt_submit_graph`:

```cpp
static void pypto_graph_layer(const CoreTaskArgs& args) {
    const ChipTensor& a = args.tensor(0).ref();
    const ChipTensor& c = args.tensor(1).ref();
    const uint64_t& layer_idx = args.scalar(0);
    const uint64_t& base = args.scalar(1);
    PTO2_SCOPE() {
        CoreTaskArgs g0_params_t0;
        g0_params_t0.add_input(a);
        g0_params_t0.add_inout(c);
        g0_params_t0.add_scalar(base);
        rt_submit_aiv_task(0, g0_params_t0);
    }
}

__attribute__((visibility("default")))
void aicpu_orchestration_entry(const ChipTaskArgs& orch_args) {
    ...
        for (int64_t i = 0; i < 4; i += 1) {
            PTO2_SCOPE() {
                int64_t base = (i * 128);          // hoisted out of the region

                CoreTaskArgs params_t0;
                params_t0.add_input(ext_a);
                params_t0.add_inout(ext_c);
                params_t0.add_scalar(i);
                params_t0.add_scalar(base);
                rt_submit_graph(GRAPH_KEY("layer_v1"), &pypto_graph_layer, params_t0);
            }
        }
}
```

**Named, not an inlined lambda**, because the runtime identifies a graph by a bare function pointer (`rt_graph_function_id` static_asserts on that). A lambda would mint one pointer per syntactic occurrence, so N call sites would record N separate Definitions and burn through the 16-entry cache — exactly the cost this feature exists to avoid.

## Three load-bearing details

**Boundary scalars are bound as `const uint64_t&`, never by value.** The runtime tracks a boundary scalar by the *address* of its argument slot: it anchors that address while recording and re-reads it on replay. Copying into a local severs the link and the value is frozen at its first-call number on every later replay, with no warning. This is the one silent wrong-answer path in the feature, so there is a text assertion on the emitted line.

**The submit's result is discarded.** `rt_submit_graph` returns a valid task id only on a cache *hit*; the recording pass returns an invalid one. Ordering comes from the boundary tensors' dataflow instead, which is why the pass rejects a Graph that returns a computed value.

**A Graph never enters `func_name_to_id_`.** Every name in that map becomes a `KERNELS` entry in `kernel_config.py`, and a Graph has no `.cpp` under `kernels/` — registering it would leave the manifest pointing at a file that does not exist, failing at runtime rather than at build time.

The dispatch branch sits ahead of `InferFunctionCoreType`, which recognises only AIC/AIV and hard-fails on anything else.

## Second codegen instance

The graph body is generated by its own `OrchestrationStmtCodegen`, with two settings that differ from the entry's and both matter:

- An **empty `param_name_set`**. `GetExternalTensorName` rewrites any name in that set to `ext_<name>`, which is right for the entry (parameters arrive through `orch_args`) and wrong here, where they are ordinary function parameters.
- A **task-var prefix**, since that instance's `task_counter_` restarts at 0 and both emitters would otherwise declare `params_t0`.

## One fix to the previous PR's pass

LegalizeGraphBoundary's return check compared the `ReturnStmt` operand against `params_` by pointer identity. By that point in the pipeline the returned Var is a *rebound SSA version* of the parameter, so the idiomatic `return c` for an `InOut` parameter was rejected — which would have made the feature unusable. The check now runs on the declared return **types**: a tensor return is an in-place alias and is allowed; a scalar return is refused.

## Test plan

- New `tests/ut/codegen/test_orchestration_codegen_graph.py` (10 cases): the named function, tensor and **by-reference scalar** binding, no `alloc_tensors` in the region, no task-var collision between the two emitters, the `rt_submit_graph` call shape, the hoisted scalar computed at the call site, the result not being chained, and the Graph's absence from `KERNELS` while its outlined kernel is still listed.
- Full `tests/ut`: 9887 passed, 8 skipped. Plus clang-format, cpplint, ruff check/format, pyright, and every `tests/lint` script.

## Not yet verified

Numerical e2e on device. The generated shape matches the hand-written reference at `runtime/examples/a2a3/host_build_graph/qwen3_14b_decode/`, but I have not run it on hardware — the shared runner in this session was returning ambient `507018` device faults (see #2408). Worth a device run before merging the stack.
