### PR TITLE
perf(runtime): name fork-inherited host memory instead of staging it

### DIFF
--- a/python/pypto/runtime/distributed_runner.py
+++ b/python/pypto/runtime/distributed_runner.py
@@ -1525,6 +1525,18 @@ class DistributedWorker(Worker):
         )
         self._buffer_owner_id: bytes | None = None
         self._buffer_id_seq = 0
+        # One identity per host *range*, not per copy. Both properties this buys are load
+        # bearing: a consumer's ImportRegistry only drops an entry when the owner releases the
+        # Buffer, which a named copy never does, so minting per copy would leave one permanent
+        # ImportedBuffer per copy in every chip child — unbounded for a per-step D2H read-back.
+        # And re-copying the same range must reuse its identity, because one identity may name
+        # only one backing: `materialize` refuses a second descriptor for an identity it has
+        # already handed out.
+        self._named_identities: dict[tuple[int, int], tuple[bytes, int]] = {}
+        # Minting is not atomic (`+=` is load/add/store, and the lazy owner mint is
+        # check-then-act) while `alloc_stacked_tensor` runs one thread per chip through this
+        # path, so the cache and the counter are guarded together.
+        self._named_identity_mu = threading.Lock()
         self._persistent = bool(persistent)
         self._reset_persistent_windows = reset_persistent_windows
         self._persistent_error: BaseException | None = None
@@ -2179,18 +2191,36 @@ class DistributedWorker(Worker):
             return 0
         return int(self._w.committed_device_memory(worker_id))
 
-    def _next_buffer_identity(self) -> tuple[bytes, int]:
-        """Mint the ``(owner_instance_id, buffer_id)`` pair a named host range needs."""
+    def _buffer_identity_for(self, host_ptr: int, nbytes: int) -> tuple[bytes, int]:
+        """Return the stable ``(owner_instance_id, buffer_id)`` naming this host range.
+
+        Keyed on the range rather than counted per call, so a range copied N times keeps one
+        identity: the consumer's ``ImportRegistry`` refuses a second descriptor for an identity
+        it has already materialized, and it only drops an entry when the owner releases the
+        Buffer — which the named path never does, since it hands out the caller's own mapping.
+        Per-copy identities would therefore both collide on a re-copy and grow a child's
+        registry without bound. Distinct sub-ranges of one registered tensor still get distinct
+        identities, which is what a sharded upload needs.
+
+        Held under a lock because ``alloc_stacked_tensor`` drives this from one thread per chip.
+        """
         from simpler.buffer import (  # noqa: PLC0415  # pyright: ignore[reportMissingImports]
             mint_owner_instance_id,
         )
 
-        owner = self._buffer_owner_id
-        if owner is None:
-            owner = mint_owner_instance_id()
-            self._buffer_owner_id = owner
-        self._buffer_id_seq += 1
-        return owner, self._buffer_id_seq
+        key = (int(host_ptr), int(nbytes))
+        with self._named_identity_mu:
+            cached = self._named_identities.get(key)
+            if cached is not None:
+                return cached
+            owner = self._buffer_owner_id
+            if owner is None:
+                owner = mint_owner_instance_id()
+                self._buffer_owner_id = owner
+            self._buffer_id_seq += 1
+            identity = (owner, self._buffer_id_seq)
+            self._named_identities[key] = identity
+            return identity
 
     def _named_host_buffer(self, host_ptr: int, nbytes: int) -> Any:
         """Name a fork-inherited MAP_SHARED host range in place, or ``None`` to stage it.
@@ -2222,7 +2252,7 @@ class DistributedWorker(Worker):
         for start, stop, is_shared in self._inherited_host_spans:
             if host_ptr < start or end > stop or not is_shared:
                 continue
-            owner, buffer_id = self._next_buffer_identity()
+            owner, buffer_id = self._buffer_identity_for(host_ptr, nbytes)
             return wrap_fork_inherited(
                 host_ptr,
                 nbytes,
@@ -2394,6 +2424,8 @@ class DistributedWorker(Worker):
         # No later copy may name these ranges: the parent has dropped its references, so a
         # copy after this point stages rather than wrapping memory nobody vouches for.
         self._inherited_host_spans = ()
+        with self._named_identity_mu:
+            self._named_identities.clear()
 
     def copy_stacked_from(self, stacked: StackedDeviceTensor, host: torch.Tensor) -> None:
         """Read every shard of *stacked* back to *host* (D2H) — the read-back
@@ -2708,6 +2740,7 @@ class DistributedWorker(Worker):
             finally:
                 self._inherited_host_tensors = ()
                 self._inherited_host_spans = ()
+                self._named_identities.clear()
                 self._persistent_domains_by_program.clear()
                 if self._close_complete:
                     self._device_buffers.clear()

--- a/python/pypto/runtime/distributed_runner.py
+++ b/python/pypto/runtime/distributed_runner.py
@@ -1510,12 +1510,11 @@ class DistributedWorker(Worker):
         self._inherited_host_tensors = inherited
         # `copy_to` / `copy_from` stage through a simpler-owned shm Buffer so an ordinary
         # post-fork tensor is a legal endpoint. That relaxation costs one full copy of the
-        # payload, which a fork-inherited range does not need: it is present in every child
-        # at the same virtual address and can be named in place. Record the classification
-        # here, where the tensors are still in hand — MAP_SHARED (`FORK_SHM`) may serve as
-        # an output, MAP_PRIVATE (`FORK_COW`) is read-only because a child's write would
-        # split the page into a copy the parent never sees — as (start, end, is_shared)
-        # spans that a bare address can be resolved against later.
+        # payload, which a fork-inherited MAP_SHARED range does not need: parent and child
+        # see the same pages, so it can be named in place. Whether a range is MAP_SHARED is
+        # the caller's to know and cannot be inferred from an address, so record it here,
+        # where the tensors are still in hand, as (start, end, is_shared) spans. A
+        # MAP_PRIVATE range is deliberately left to staging — see `_named_host_buffer`.
         self._inherited_host_spans: tuple[tuple[int, int, bool], ...] = tuple(
             (
                 tensor.data_ptr(),
@@ -2193,14 +2192,20 @@ class DistributedWorker(Worker):
         self._buffer_id_seq += 1
         return owner, self._buffer_id_seq
 
-    def _named_host_buffer(self, host_ptr: int, nbytes: int, *, api: str, writing: bool) -> Any:
-        """Name a fork-inherited host range in place, or return ``None`` to stage it.
+    def _named_host_buffer(self, host_ptr: int, nbytes: int) -> Any:
+        """Name a fork-inherited MAP_SHARED host range in place, or ``None`` to stage it.
 
-        Only memory registered through ``inherited_host_tensors`` can be named: it predates
-        the fork, so every child holds it at the same virtual address and the copy needs no
-        staging buffer and no host-side memcpy. Anything else — in particular a tensor
-        allocated after ``prepare`` — has no mapping in the child and must go through shm,
-        which is what the caller falls back to.
+        Only memory registered through ``inherited_host_tensors`` can be named at all: it
+        predates the fork, so every child holds it at the same virtual address and the copy
+        needs no staging buffer and no host-side memcpy. A tensor allocated after
+        ``prepare`` has no mapping in the child, so the caller stages it.
+
+        **Shared mappings only, deliberately.** A ``MAP_PRIVATE`` range is inherited too,
+        but copy-on-write means the child keeps reading its pre-fork snapshot: a parent that
+        registers a tensor and then writes to it would upload the old bytes. Staging is not
+        merely a fallback there — it is the correct behaviour, because its ``memmove`` runs
+        in the parent and therefore reads the current contents. Naming a private range would
+        trade one memcpy for a silent staleness bug, so ``FORK_COW`` is not used here.
 
         Each range is wrapped on its own rather than offset into a whole-tensor Buffer,
         because a Buffer carries no offset: a shard's address is interior to its stacked
@@ -2215,21 +2220,16 @@ class DistributedWorker(Worker):
 
         end = host_ptr + nbytes
         for start, stop, is_shared in self._inherited_host_spans:
-            if host_ptr < start or end > stop:
+            if host_ptr < start or end > stop or not is_shared:
                 continue
-            if writing and not is_shared:
-                # A COW range cannot receive data: the child's write splits the page into a
-                # private copy the parent never reads back. Staging is still correct here,
-                # so fall through rather than refusing the copy.
-                return None
             owner, buffer_id = self._next_buffer_identity()
             return wrap_fork_inherited(
                 host_ptr,
                 nbytes,
                 owner,
                 buffer_id,
-                access=AccessMode.READWRITE if is_shared else AccessMode.READ,
-                backend_kind=BackendKind.FORK_SHM if is_shared else BackendKind.FORK_COW,
+                access=AccessMode.READWRITE,
+                backend_kind=BackendKind.FORK_SHM,
             )
         return None
 
@@ -2239,7 +2239,7 @@ class DistributedWorker(Worker):
         dst = self._device_buffer(dst_dev_ptr, worker_id, "copy_to")
         if not isinstance(nbytes, int) or nbytes <= 0:
             raise ValueError(f"nbytes must be a positive int, got {nbytes!r}")
-        src = self._named_host_buffer(int(src_host_ptr), int(nbytes), api="copy_to", writing=False)
+        src = self._named_host_buffer(int(src_host_ptr), int(nbytes))
         if src is not None:
             self._w.copy_to(dst, src)
             return
@@ -2256,7 +2256,7 @@ class DistributedWorker(Worker):
         src = self._device_buffer(src_dev_ptr, worker_id, "copy_from")
         if not isinstance(nbytes, int) or nbytes <= 0:
             raise ValueError(f"nbytes must be a positive int, got {nbytes!r}")
-        dst = self._named_host_buffer(int(dst_host_ptr), int(nbytes), api="copy_from", writing=True)
+        dst = self._named_host_buffer(int(dst_host_ptr), int(nbytes))
         if dst is not None:
             self._w.copy_from(dst, src)
             return

--- a/python/pypto/runtime/distributed_runner.py
+++ b/python/pypto/runtime/distributed_runner.py
@@ -1508,6 +1508,24 @@ class DistributedWorker(Worker):
                     f"got device={tensor.device} shape={tuple(tensor.shape)}."
                 )
         self._inherited_host_tensors = inherited
+        # `copy_to` / `copy_from` stage through a simpler-owned shm Buffer so an ordinary
+        # post-fork tensor is a legal endpoint. That relaxation costs one full copy of the
+        # payload, which a fork-inherited range does not need: it is present in every child
+        # at the same virtual address and can be named in place. Record the classification
+        # here, where the tensors are still in hand — MAP_SHARED (`FORK_SHM`) may serve as
+        # an output, MAP_PRIVATE (`FORK_COW`) is read-only because a child's write would
+        # split the page into a copy the parent never sees — as (start, end, is_shared)
+        # spans that a bare address can be resolved against later.
+        self._inherited_host_spans: tuple[tuple[int, int, bool], ...] = tuple(
+            (
+                tensor.data_ptr(),
+                tensor.data_ptr() + tensor.numel() * tensor.element_size(),
+                bool(tensor.is_shared()),
+            )
+            for tensor in inherited
+        )
+        self._buffer_owner_id: bytes | None = None
+        self._buffer_id_seq = 0
         self._persistent = bool(persistent)
         self._reset_persistent_windows = reset_persistent_windows
         self._persistent_error: BaseException | None = None
@@ -2162,12 +2180,69 @@ class DistributedWorker(Worker):
             return 0
         return int(self._w.committed_device_memory(worker_id))
 
+    def _next_buffer_identity(self) -> tuple[bytes, int]:
+        """Mint the ``(owner_instance_id, buffer_id)`` pair a named host range needs."""
+        from simpler.buffer import (  # noqa: PLC0415  # pyright: ignore[reportMissingImports]
+            mint_owner_instance_id,
+        )
+
+        owner = self._buffer_owner_id
+        if owner is None:
+            owner = mint_owner_instance_id()
+            self._buffer_owner_id = owner
+        self._buffer_id_seq += 1
+        return owner, self._buffer_id_seq
+
+    def _named_host_buffer(self, host_ptr: int, nbytes: int, *, api: str, writing: bool) -> Any:
+        """Name a fork-inherited host range in place, or return ``None`` to stage it.
+
+        Only memory registered through ``inherited_host_tensors`` can be named: it predates
+        the fork, so every child holds it at the same virtual address and the copy needs no
+        staging buffer and no host-side memcpy. Anything else — in particular a tensor
+        allocated after ``prepare`` — has no mapping in the child and must go through shm,
+        which is what the caller falls back to.
+
+        Each range is wrapped on its own rather than offset into a whole-tensor Buffer,
+        because a Buffer carries no offset: a shard's address is interior to its stacked
+        tensor, so per-range wrapping is what keeps one shard's copy from moving the whole
+        stack.
+        """
+        from simpler.buffer import (  # noqa: PLC0415  # pyright: ignore[reportMissingImports]
+            AccessMode,
+            BackendKind,
+            wrap_fork_inherited,
+        )
+
+        end = host_ptr + nbytes
+        for start, stop, is_shared in self._inherited_host_spans:
+            if host_ptr < start or end > stop:
+                continue
+            if writing and not is_shared:
+                # A COW range cannot receive data: the child's write splits the page into a
+                # private copy the parent never reads back. Staging is still correct here,
+                # so fall through rather than refusing the copy.
+                return None
+            owner, buffer_id = self._next_buffer_identity()
+            return wrap_fork_inherited(
+                host_ptr,
+                nbytes,
+                owner,
+                buffer_id,
+                access=AccessMode.READWRITE if is_shared else AccessMode.READ,
+                backend_kind=BackendKind.FORK_SHM if is_shared else BackendKind.FORK_COW,
+            )
+        return None
+
     def copy_to(self, dst_dev_ptr: int, src_host_ptr: int, nbytes: int, *, worker_id: int = 0) -> None:
         """H2D copy: ``nbytes`` from host *src_host_ptr* to device *dst_dev_ptr*."""
         self._require_open("copy_to")
         dst = self._device_buffer(dst_dev_ptr, worker_id, "copy_to")
         if not isinstance(nbytes, int) or nbytes <= 0:
             raise ValueError(f"nbytes must be a positive int, got {nbytes!r}")
+        src = self._named_host_buffer(int(src_host_ptr), int(nbytes), api="copy_to", writing=False)
+        if src is not None:
+            self._w.copy_to(dst, src)
+            return
         host = self._w.create_buffer(nbytes)
         try:
             ctypes.memmove(int(host.base), src_host_ptr, nbytes)
@@ -2181,6 +2256,10 @@ class DistributedWorker(Worker):
         src = self._device_buffer(src_dev_ptr, worker_id, "copy_from")
         if not isinstance(nbytes, int) or nbytes <= 0:
             raise ValueError(f"nbytes must be a positive int, got {nbytes!r}")
+        dst = self._named_host_buffer(int(dst_host_ptr), int(nbytes), api="copy_from", writing=True)
+        if dst is not None:
+            self._w.copy_from(dst, src)
+            return
         host = self._w.create_buffer(nbytes)
         try:
             self._w.copy_from(host, src)
@@ -2312,6 +2391,9 @@ class DistributedWorker(Worker):
         """
         self._require_open("release_inherited_host_tensor_refs")
         self._inherited_host_tensors = ()
+        # No later copy may name these ranges: the parent has dropped its references, so a
+        # copy after this point stages rather than wrapping memory nobody vouches for.
+        self._inherited_host_spans = ()
 
     def copy_stacked_from(self, stacked: StackedDeviceTensor, host: torch.Tensor) -> None:
         """Read every shard of *stacked* back to *host* (D2H) — the read-back
@@ -2625,6 +2707,7 @@ class DistributedWorker(Worker):
                 self._close_complete = True
             finally:
                 self._inherited_host_tensors = ()
+                self._inherited_host_spans = ()
                 self._persistent_domains_by_program.clear()
                 if self._close_complete:
                     self._device_buffers.clear()

--- a/tests/ut/runtime/test_distributed_worker.py
+++ b/tests/ut/runtime/test_distributed_worker.py
@@ -24,6 +24,7 @@ import sys
 import threading
 import weakref
 from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
 from typing import Any
@@ -3346,7 +3347,16 @@ class TestNamedInheritedHostRanges:
         assert not isinstance(patched_setup["worker"].copy_to.call_args.args[1], _NamedHostRange)
         rt.close()
 
-    def test_named_ranges_get_distinct_buffer_ids(self, patched_setup):
+    def test_one_range_keeps_one_identity_across_copies(self, patched_setup):
+        """Re-copying a range must reuse its identity, not mint a new one.
+
+        Two reasons, both in the consumer: ``ImportRegistry.materialize`` refuses a second
+        descriptor for an identity it already handed out, so a fresh id per copy would make the
+        second copy of a range fail outright; and a consumer only drops an entry when the owner
+        releases the Buffer, which the named path never does — so per-copy identities would
+        leave one permanent ``ImportedBuffer`` per copy in every chip child. A per-step D2H
+        read-back would grow that registry for the life of the process.
+        """
         host = torch.zeros(4, 4, dtype=torch.float32).share_memory_()
         rt = DistributedWorker(_fake_compiled([_param("a", [4, 4])], []), inherited_host_tensors=[host])
         dev = self._dev(rt)
@@ -3357,9 +3367,69 @@ class TestNamedInheritedHostRanges:
         rt.copy_to(dev.data_ptr, host.data_ptr(), nbytes)
         second = patched_setup["worker"].copy_to.call_args.args[1]
 
-        # A Buffer identity is what a consumer keys on; two live names must not collide.
+        assert (first.owner, first.buffer_id) == (second.owner, second.buffer_id)
+        rt.close()
+
+    def test_distinct_sub_ranges_get_distinct_identities(self, patched_setup):
+        """Identity is per range, so a sharded upload's halves must not collide on one name."""
+        host = torch.zeros(4, 4, dtype=torch.float32).share_memory_()
+        rt = DistributedWorker(_fake_compiled([_param("a", [4, 4])], []), inherited_host_tensors=[host])
+        dev = self._dev(rt)
+        half = host.numel() * host.element_size() // 2
+
+        rt.copy_to(dev.data_ptr, host.data_ptr(), half)
+        first = patched_setup["worker"].copy_to.call_args.args[1]
+        rt.copy_to(dev.data_ptr, host.data_ptr() + half, half)
+        second = patched_setup["worker"].copy_to.call_args.args[1]
+
         assert first.owner == second.owner
         assert first.buffer_id != second.buffer_id
+        rt.close()
+
+    def test_concurrent_copies_of_distinct_ranges_never_share_an_identity(self, patched_setup):
+        """The configuration `alloc_stacked_tensor` actually creates: one thread per chip.
+
+        Identity minting is not atomic on its own — `+=` is load/add/store and the first-time
+        owner mint is check-then-act — and two ranges landing on one identity is a hard failure
+        in the consumer, not a silent one. A single-threaded test cannot observe that, so this
+        drives the path concurrently and asserts the mapping is still one-to-one.
+        """
+        host = torch.zeros(64, 4, dtype=torch.float32).share_memory_()
+        rt = DistributedWorker(_fake_compiled([_param("a", [4, 4])], []), inherited_host_tensors=[host])
+        row = 4 * host.element_size()
+        rows = 64
+        seen: list[tuple[int, tuple[Any, int]]] = []
+        lock = threading.Lock()
+
+        def _copy(index: int) -> None:
+            offset = host.data_ptr() + index * row
+            named = rt._named_host_buffer(offset, row)
+            with lock:
+                seen.append((offset, (named.owner, named.buffer_id)))
+
+        with ThreadPoolExecutor(max_workers=8) as pool:
+            list(pool.map(_copy, range(rows)))
+
+        identities = [identity for _, identity in seen]
+        assert len(seen) == rows
+        # One identity per range, and no range sharing another's: both directions matter, since
+        # a duplicate id makes the child refuse the import and a missing one breaks reuse.
+        assert len(set(identities)) == rows
+        assert len({offset for offset, _ in seen}) == rows
+        rt.close()
+
+    def test_identity_cache_is_dropped_with_the_ranges_it_names(self, patched_setup):
+        """After the parent releases its references, nothing may keep naming those ranges."""
+        host = torch.zeros(4, 4, dtype=torch.float32).share_memory_()
+        rt = DistributedWorker(_fake_compiled([_param("a", [4, 4])], []), inherited_host_tensors=[host])
+        dev = self._dev(rt)
+        nbytes = host.numel() * host.element_size()
+        rt.copy_to(dev.data_ptr, host.data_ptr(), nbytes)
+        assert rt._named_identities
+
+        rt.release_inherited_host_tensor_refs()
+
+        assert not rt._named_identities
         rt.close()
 
 

--- a/tests/ut/runtime/test_distributed_worker.py
+++ b/tests/ut/runtime/test_distributed_worker.py
@@ -109,6 +109,18 @@ class _ControlledNativeHandle:
             raise self.error
 
 
+class _NamedHostRange:
+    """What ``wrap_fork_inherited`` returns: a host range named in place, never copied."""
+
+    def __init__(self, data_ptr, nbytes, owner, buffer_id, *, access=None, backend_kind=None) -> None:
+        self.base = data_ptr
+        self.nbytes = nbytes
+        self.owner = owner
+        self.buffer_id = buffer_id
+        self.access = access
+        self.backend_kind = backend_kind
+
+
 class _FakeBuffer:
     def __init__(self, base: int, nbytes: int, *, host: bool = False, owner_worker_id: int = 0) -> None:
         self.nbytes = nbytes
@@ -132,6 +144,20 @@ def patched_setup():
     task_interface = ModuleType("simpler.task_interface")
     setattr(task_interface, "DataType", SimpleNamespace(UINT8=object()))
     setattr(simpler, "task_interface", task_interface)
+    # `simpler.buffer` is the zero-copy naming path: a test can tell a named range from a
+    # staged copy by which of these two the worker was handed.
+    buffer_mod = ModuleType("simpler.buffer")
+    setattr(buffer_mod, "AccessMode", SimpleNamespace(READ="READ", READWRITE="READWRITE"))
+    setattr(buffer_mod, "BackendKind", SimpleNamespace(FORK_SHM="FORK_SHM", FORK_COW="FORK_COW"))
+    setattr(buffer_mod, "mint_owner_instance_id", lambda: b"owner-id")
+    setattr(
+        buffer_mod,
+        "wrap_fork_inherited",
+        lambda data_ptr, nbytes, owner, buffer_id, **kwargs: _NamedHostRange(
+            data_ptr, nbytes, owner, buffer_id, **kwargs
+        ),
+    )
+    setattr(simpler, "buffer", buffer_mod)
 
     worker = MagicMock(name="Worker(level=3)")
     worker.chip_contexts = []
@@ -149,6 +175,7 @@ def patched_setup():
             {
                 "simpler": simpler,
                 "simpler.task_interface": task_interface,
+                "simpler.buffer": buffer_mod,
             },
         ),
         patch(f"{mod}._assemble_chip_callables", return_value=chip_callables) as assemble,
@@ -3225,6 +3252,114 @@ class TestPersistentDistributedWorker:
         assert len(errors) == 1
         assert isinstance(errors[0], RuntimeError)
         assert str(errors[0]) == "persistent dispatch failed before cleanup"
+        rt.close()
+
+
+class TestNamedInheritedHostRanges:
+    """The zero-copy H2D/D2H path and, more importantly, where it must NOT engage.
+
+    Staging a copy through shm costs a full host-side memcpy of the payload, which a
+    fork-inherited MAP_SHARED range does not need. The boundary matters more than the
+    optimisation: a MAP_PRIVATE range is inherited too, but copy-on-write freezes the
+    child's view at fork, so naming one would upload stale bytes the moment the parent
+    writes. These tests pin that boundary.
+    """
+
+    @staticmethod
+    def _dev(rt):
+        return _resident(rt, (4, 4))
+
+    def test_copy_to_names_a_contained_shared_range(self, patched_setup):
+        host = torch.zeros(4, 4, dtype=torch.float32).share_memory_()
+        rt = DistributedWorker(_fake_compiled([_param("a", [4, 4])], []), inherited_host_tensors=[host])
+        dev = self._dev(rt)
+        nbytes = host.numel() * host.element_size()
+        patched_setup["worker"].create_buffer.reset_mock()
+
+        rt.copy_to(dev.data_ptr, host.data_ptr(), nbytes)
+
+        named = patched_setup["worker"].copy_to.call_args.args[1]
+        assert isinstance(named, _NamedHostRange)
+        assert (named.base, named.nbytes) == (host.data_ptr(), nbytes)
+        assert (named.backend_kind, named.access) == ("FORK_SHM", "READWRITE")
+        # The point of naming it: no staging buffer is created at all.
+        patched_setup["worker"].create_buffer.assert_not_called()
+        rt.close()
+
+    def test_copy_to_stages_a_private_inherited_range(self, patched_setup):
+        # MAP_PRIVATE: the child's pages are frozen at fork, so a named range would upload
+        # whatever was there before a later parent write. Staging reads the parent's current
+        # contents instead, which is why it stays the correct path here.
+        host = torch.zeros(4, 4, dtype=torch.float32)
+        rt = DistributedWorker(_fake_compiled([_param("a", [4, 4])], []), inherited_host_tensors=[host])
+        dev = self._dev(rt)
+        nbytes = host.numel() * host.element_size()
+        host.fill_(1.0)
+
+        rt.copy_to(dev.data_ptr, host.data_ptr(), nbytes)
+
+        staged = patched_setup["worker"].copy_to.call_args.args[1]
+        assert not isinstance(staged, _NamedHostRange)
+        assert ctypes.string_at(staged.base, nbytes) == ctypes.string_at(host.data_ptr(), nbytes)
+        rt.close()
+
+    def test_copy_to_stages_a_partially_overlapping_range(self, patched_setup):
+        host = torch.zeros(8, dtype=torch.float32).share_memory_()
+        rt = DistributedWorker(_fake_compiled([_param("a", [4, 4])], []), inherited_host_tensors=[host])
+        dev = self._dev(rt)
+        nbytes = host.numel() * host.element_size()
+        patched_setup["worker"].create_buffer.reset_mock()
+
+        # Starts inside the span but runs past its end: naming it would hand the child a
+        # Buffer longer than the mapping it vouches for.
+        rt.copy_to(dev.data_ptr, host.data_ptr() + 4, nbytes)
+
+        assert not isinstance(patched_setup["worker"].copy_to.call_args.args[1], _NamedHostRange)
+        patched_setup["worker"].create_buffer.assert_called_once()
+        rt.close()
+
+    def test_copy_from_names_a_shared_range(self, patched_setup):
+        host = torch.zeros(4, 4, dtype=torch.float32).share_memory_()
+        rt = DistributedWorker(_fake_compiled([_param("a", [4, 4])], []), inherited_host_tensors=[host])
+        dev = self._dev(rt)
+        nbytes = host.numel() * host.element_size()
+        patched_setup["worker"].create_buffer.reset_mock()
+
+        rt.copy_from(host.data_ptr(), dev.data_ptr, nbytes)
+
+        named = patched_setup["worker"].copy_from.call_args.args[0]
+        assert isinstance(named, _NamedHostRange)
+        assert named.backend_kind == "FORK_SHM"
+        patched_setup["worker"].create_buffer.assert_not_called()
+        rt.close()
+
+    def test_releasing_inherited_refs_sends_later_copies_back_to_staging(self, patched_setup):
+        host = torch.zeros(4, 4, dtype=torch.float32).share_memory_()
+        rt = DistributedWorker(_fake_compiled([_param("a", [4, 4])], []), inherited_host_tensors=[host])
+        dev = self._dev(rt)
+        nbytes = host.numel() * host.element_size()
+
+        rt.release_inherited_host_tensor_refs()
+        rt.copy_to(dev.data_ptr, host.data_ptr(), nbytes)
+
+        # The parent has dropped its references, so nobody vouches for the mapping anymore.
+        assert not isinstance(patched_setup["worker"].copy_to.call_args.args[1], _NamedHostRange)
+        rt.close()
+
+    def test_named_ranges_get_distinct_buffer_ids(self, patched_setup):
+        host = torch.zeros(4, 4, dtype=torch.float32).share_memory_()
+        rt = DistributedWorker(_fake_compiled([_param("a", [4, 4])], []), inherited_host_tensors=[host])
+        dev = self._dev(rt)
+        nbytes = host.numel() * host.element_size()
+
+        rt.copy_to(dev.data_ptr, host.data_ptr(), nbytes)
+        first = patched_setup["worker"].copy_to.call_args.args[1]
+        rt.copy_to(dev.data_ptr, host.data_ptr(), nbytes)
+        second = patched_setup["worker"].copy_to.call_args.args[1]
+
+        # A Buffer identity is what a consumer keys on; two live names must not collide.
+        assert first.owner == second.owner
+        assert first.buffer_id != second.buffer_id
         rt.close()
 
 


### PR DESCRIPTION
## What

`copy_to` / `copy_from` stage every device copy through a simpler-owned POSIX-shm Buffer plus a full host→host `memmove` of the payload. `alloc_tensor` is `malloc` + `copy_to`, so a resident weight set is copied once on the host before any byte reaches a chip — 346.6 GB of it for DeepSeek V4 Flash W8A8.

The staging is deliberate and worth keeping: it is what lets an ordinary post-fork tensor be a legal endpoint (`_require_copy_host_tensor`). But a range registered through `inherited_host_tensors` does not need it — that memory predates the fork, so every child already holds it at the same virtual address and `simpler.buffer.wrap_fork_inherited` can name it in place. So this is a fast path, not a change of contract:

| range | naming | staged instead |
|---|---|---|
| fork-inherited, `MAP_SHARED` | `FORK_SHM`, `READWRITE`, either direction | — |
| fork-inherited, `MAP_PRIVATE` | never | always — see below |
| anything else | — | always, exactly as today |

**Correction after review (thanks @codex-reviewer).** The first revision of this PR also named `MAP_PRIVATE` ranges as `FORK_COW` for uploads. That was wrong, and not just conservatively so: copy-on-write leaves the child reading its pre-fork snapshot, so a parent that registers a tensor through `inherited_host_tensors` and then writes to it would have uploaded the *old* bytes, silently. Staging is not a fallback for private ranges — it is the correct behaviour, because its `memmove` runs in the parent and therefore reads the current contents. The fast path is now restricted to `MAP_SHARED`, and `FORK_COW` is not used at all.

The backend kind is a classification the caller must make rather than something inferred from the access mode, so it is recorded at registration time, where the tensors are still in hand, as `(start, end, is_shared)` spans that a bare address is resolved against per copy. Ranges are wrapped individually rather than offset into a whole-tensor Buffer because a Buffer carries no offset: a shard's address is interior to its stacked tensor, so per-range wrapping is what keeps one shard's copy from moving the whole stack. The spans are dropped in `release_inherited_host_tensor_refs` and in `close`, so a copy after the parent releases its references stages instead of naming memory nobody vouches for.

> [!WARNING]
> **The numbers below do not reproduce on the current revision.** Restricting the fast path to `MAP_SHARED` also switched off the DeepSeek case: the prepacked sidecar is `MAP_SHARED` at the OS level but `torch.is_shared()` reports `False` for an `mmap` + `from_numpy` storage, so those ranges are now staged rather than named. `is_shared()` is the wrong predicate, and the fix needs an API decision — see [this comment](https://github.com/hw-native-sys/pypto/pull/2422#issuecomment-5342087994). Treat the table as what the mechanism is worth once the predicate is right, not as what this diff currently does.

## Measured

Current `main` (`49ed7797` + Simpler `1f27a157`), DeepSeek V4 Flash W8A8, 8 × 910B2, 346.6 GB resident, warm kernel cache, `pypto-serving` `71fd275`, `pypto-lib` `f0d352e`, PTOAS v0.57. #2292 is applied on both sides, so the shard upload is concurrent either way and this change is the only variable; the variant is swapped in site-packages between runs, so the kernel cache is warm and identical.

| | resident upload | `model loaded` |
|---|---|---|
| `main` + #2292 | 102.8s | 123.3s |
| + this change | **31.7s** | **39.1s** |
| | 3.24× | 3.15× |

A cold run of the same configuration puts the upload window (`kernel-cache STORED` → `resident main weights uploaded`) at 19.3s; the 31.7s above was taken while other jobs shared the node, so it is the conservative number of the two.

**Please read the absolutes as setup-dependent, not as a property of this change.** `pypto-serving`#134 measured the same class of host-copy cost at ~492s on one node and ~62s on another, with page-cache state, mount and driver all mattering. What transfers is the mechanism: one full copy of the payload, removed rather than parallelised. On a setup where the copy is cheap the win is smaller, but it should not be negative anywhere.

## Not fixed here

DeepSeek V4 decode stalls after the first token on `main` — see #2354. It reproduces with and without this change, and with and without #2292, so it is independent of both; it is mentioned only because it is visible in every run above (`req 0: TRUNCATED 1/32`). Startup, upload and prefill are healthy.

## Testing

`pre-commit` clean (including `pyright`). Exercised end to end by the runs above: the fast path is what carries all 346.6 GB, and staging still carries every post-fork copy on the same runs.

`TestNamedInheritedHostRanges` in `tests/ut/runtime/test_distributed_worker.py` covers the span-resolution boundary: a contained shared range is named (`FORK_SHM` + `READWRITE`, no staging buffer created), a private range is staged **and the staged bytes are the parent's current contents** — that one is the regression guard for the correction above — plus partial overlap, the D2H direction, staging resuming after `release_inherited_host_tensor_refs()`, and distinct buffer identities per call.

The seconds above were measured on the first revision, which named those ranges. I had reasoned that the current revision would be unaffected because the sidecar is `MAP_SHARED`; that reasoning was wrong, for the `torch.is_shared()` reason in the warning above. It is a good illustration of why the caveat was worth stating: the re-measurement I offered is what would have caught it, and it still needs to happen once the predicate is fixed.


