### PR TITLE
feat(ir): hoist boundary-tensor slices out of a Graph region

### DIFF
--- a/docs/en/dev/passes/00-pass_manager.md
+++ b/docs/en/dev/passes/00-pass_manager.md
@@ -513,7 +513,8 @@ The PTO-oriented tile stage of `Default` is:
 34. [`LegalizeGraphBoundary`](45-legalize_graph_boundary.md) (hoists values a Graph body derives from its boundary scalars to the call sites, and rejects the boundaries the host_build_graph runtime cannot record; no-op for programs with no Graph function)
 35. [`MaterializeRuntimeScopes`](46-materialize_runtime_scopes.md) (inserts AUTO RuntimeScopeStmt so orchestration codegen emits SIMPLER_SCOPE 1:1)
 36. [`ClassifyIterArgCarry`](47-classify_iter_arg_carry.md) (stamps each ForStmt iter_arg as trivial alias / rebind carry, and sizes manual-scope TaskId fence arrays)
-37. [`InsertCommFence`](48-insert_comm_fence.md) (inserts a whole-tensor system.cacheinvalid + GM system.fence between each publishing write and the pld.system.notify that releases it; runs dead last so the inserted ops stay adjacent to their notify through codegen)
+37. [`InsertCommFence`](48-insert_comm_fence.md) (inserts a whole-tensor system.cacheinvalid + GM system.fence between each publishing write and the pld.system.notify that releases it; runs after every statement-reordering pass so the inserted ops stay adjacent to their notify through codegen)
+38. [`MaterializeValidShapeSymbols`](49-materialize_valid_shape_symbols.md) (runs dead last; turns each device-kernel valid_shape symbol the kernel cannot bind into a leading Scalar[INDEX] param fed from the call site's actual valid extent)
 
 [`ResolveBackendOpLayouts`](20-resolve_backend_op_layouts.md) repairs
 backend-constrained elementwise tile ops using registered layout metadata.

--- a/docs/en/dev/passes/45-legalize_graph_boundary.md
+++ b/docs/en/dev/passes/45-legalize_graph_boundary.md
@@ -61,10 +61,82 @@ naming the variable and explaining why the value cannot be reconstructed.
 New parameters are **appended**, not prepended: `CoreTaskArgs` requires every
 tensor argument to precede every scalar one.
 
+## Step B — derived slices of a boundary tensor
+
+Replay patches a boundary tensor's **address**. A view taken *inside* the region
+is re-derived from whatever the recording froze, so it must be taken at the call
+site instead:
+
+```python
+wl = pl.tensor.slice(w, [128, 128], [layer_idx * 128, 0])   # inside the region
+```
+
+Step B moves that slice out and passes the result in as an additional boundary
+tensor. Each slice site becomes its own parameter with its own fixed shape,
+which is what the runtime's `BOUNDARY_VIEW` classification requires — it matches
+on same-buffer plus offset, with the shape playing no part, so a view whose shape
+varied between calls could not be classified at all.
+
+The hoisted statements are emitted **scalars first, then tensors**, because a
+slice's offset is typically a Step A scalar and the binding has to precede its
+use. The *parameter* order is the reverse — tensors before scalars — which is
+what `CoreTaskArgs` requires. A view of a region-local tensor stays put.
+
+**A view of a hoisted view is hoisted too.** Once `wl` moves out it is a boundary
+parameter, so `wr = slice(wl, ...)` is in exactly the position `wl` was. The body
+is SSA in definition order, so one forward pass reaches the whole chain — a view
+can only name a source defined before it. Leaving `wr` behind is silent:
+`graph_rebind_tensor` patches the buffer address from `wl` but keeps the offset
+recorded on the first call.
+
+**A hoisted view must have a compile-time-constant shape.** Replay copies a
+view's `shapes` and `strides` straight from the recorded template and patches
+only `buffer_addr` and `start_offset`, so an extent read from a boundary scalar
+would apply the first call's shape to a later call's buffer. A view of a
+boundary tensor whose operands the call site cannot recompute is rejected for the
+same reason, rather than left in place.
+
+**A varying offset is fine, and that is not obvious.** Codegen clamps a runtime
+view to `min(declared, source.shapes[i] - offset[i])`, so the *actual* shape is
+offset-dependent even when the IR extent is constant. It does not reach replay
+because a hoisted view is passed as its **own** boundary tensor rather than
+re-derived in the region: `graph_tensor_from_boundary` tries `BOUNDARY_EXACT`
+across all boundary tensors before any `BOUNDARY_VIEW`, and a node consuming the
+view matches the view itself, so `graph_rebind_tensor` replaces the whole
+`GraphTensor` — `shapes`, `strides` and `extent_elem` included. The frozen-shape
+behaviour belongs to `BOUNDARY_VIEW`, which is the in-region case this step
+hoists out. Requiring the offset to be provably in bounds would reject the
+motivating case, a per-layer `layer_idx * 5120`.
+
+## Step C — allocations inside the region
+
+`pl.create_tensor` **is allowed** in the region, subject to one rule: its shape
+must be a compile-time constant.
+
+Codegen lowers it into a batched `alloc_tensors`, and the runtime records that as
+a kernel-less node — the same shape `submit_dummy_task` records — so it does not
+poison the recording. It does count toward the node limit, and one under a
+runtime loop or branch is a topology that varies between calls; both are Step D's
+concern.
+
+What recording cannot reproduce is a *shape* read from a boundary scalar. The
+extent is copied into the node and the buffer's address derived from it, and
+replay never re-runs the body, so a later call with a larger extent is handed the
+first call's buffer — a wrong address layout rather than a fallback. Step D
+rejects that, and `tensor.full` outright, which orchestration codegen has no
+lowering for.
+
+Hoisting a region-local allocation to a boundary parameter is *not* done: it
+would add a second `InOut` parameter, and the return-alias mapping requires the
+callee's `ReturnStmt` to name a parameter directly in order to disambiguate which
+one a tensor return aliases — an invariant a synthesised parameter does not
+satisfy. Automating it needs that mapping reworked first.
+
 ## Step D — boundary legality
 
 | Check | Why |
 | ----- | --- |
+| The compilation targets `host_build_graph` | `GraphTaskArgs` and `rt_submit_graph` exist only in that runtime's orchestration API, and codegen emits them unconditionally, so a Graph built against the default `tensormap_and_ringbuffer` yields orchestration C++ that names undeclared symbols. Reported here, against the function the user wrote, rather than as a C++ error in generated code |
 | At least one tensor parameter | A graph with an empty boundary has nothing to patch on replay; the runtime refuses to cache it |
 | At most 128 tensor parameters | `GRAPH_MAX_TENSOR_ARGS` — the boundary is a fixed-size `GraphTaskArgs` |
 | At most 64 scalar parameters | `GRAPH_MAX_SCALAR_ARGS`. Checked after Step A, which *adds* scalar parameters, so a signature that fit before hoisting can stop fitting after |
@@ -103,9 +175,9 @@ that property.
 
 ## Not yet handled
 
-Derived *tensor slices* of a boundary tensor are handled separately. An
-allocation inside the region is allowed here, subject to the constant-shape rule
-above; hoisting one to the call site is a later change.
+Automatically hoisting a region-local allocation to a boundary parameter — one
+is allowed in place, subject to the constant-shape rule above — and packing a
+boundary of more than 128 tensors into a scratch arena.
 
 ## See also
 

--- a/docs/en/dev/passes/46-materialize_runtime_scopes.md
+++ b/docs/en/dev/passes/46-materialize_runtime_scopes.md
@@ -47,7 +47,10 @@ final `Simplify` — and before
 [`InsertCommFence`](48-insert_comm_fence.md). Running after every rewriting
 transform means none of them has to reason about the inserted scope wrappers.
 
-**Scope**: only `Orchestration` functions are modified. InCore / AIC / AIV /
+**Scope**: orchestration bodies — `Orchestration` and `Graph` — are modified.
+A Graph body is orchestration too, and codegen emits `SIMPLER_SCOPE` solely from
+`RuntimeScopeStmt`, so skipping it would yield a scope-less Graph function.
+InCore / AIC / AIV /
 Group / Spmd bodies are never scope-wrapped by codegen, so they are returned
 unchanged.
 

--- a/docs/en/dev/passes/47-classify_iter_arg_carry.md
+++ b/docs/en/dev/passes/47-classify_iter_arg_carry.md
@@ -1,6 +1,7 @@
 # ClassifyIterArgCarry Pass
 
-Classifies every `ForStmt` iter_arg in an Orchestration function as a **trivial
+Classifies every `ForStmt` iter_arg in an orchestration body — `Orchestration`
+or `Graph`, both of which codegen lowers into carry variables — as a **trivial
 alias** or a **rebind carry**, and sizes `Scalar[TASK_ID]` fence arrays inside a
 `pl.manual_scope`. The plan is stamped onto `ForStmt.attrs_` so the orchestration
 codegen reads it instead of re-deriving it.

--- a/docs/en/dev/passes/48-insert_comm_fence.md
+++ b/docs/en/dev/passes/48-insert_comm_fence.md
@@ -141,7 +141,8 @@ It runs after every statement-reordering pass in the Default pipeline
 inserted ops have no operands and no dependency edges, so an earlier insertion
 could be moved away from its notify/wait; running here keeps them adjacent through
 codegen. Only [`MaterializeValidShapeSymbols`](49-materialize_valid_shape_symbols.md)
-follows, and it rewrites device-kernel signatures rather than reordering statements. The passes before it only touch Orchestration functions, so the InCore IR
+follows, and it rewrites device-kernel signatures rather than reordering statements. The passes before it only touch orchestration bodies (`Orchestration` and
+`Graph`), so the InCore IR
 this pass sees is exactly what codegen lowers.
 
 ## Which writes the pass marks

--- a/docs/en/dev/passes/index.md
+++ b/docs/en/dev/passes/index.md
@@ -4,7 +4,7 @@ Every transformation PyPTO runs over the IR, numbered to match its position in t
 default pipeline.
 
 Pass documentation is numbered so that reading it front to back walks the
-compilation pipeline in execution order. `01`–`46` are pipeline passes; `91`+ is
+compilation pipeline in execution order. `01`–`49` are pipeline passes; `91`+ is
 reserved for passes that run at several positions and for infrastructure that is not
 a pipeline pass at all.
 
@@ -65,7 +65,7 @@ a pipeline pass at all.
 | 45 | [LegalizeGraphBoundary](45-legalize_graph_boundary.md) | Hoists the boundary scalars a `Graph` body derives out to its call sites, and rejects boundaries the `host_build_graph` runtime could not record |
 | 46 | [MaterializeRuntimeScopes](46-materialize_runtime_scopes.md) | Inserts AUTO `RuntimeScopeStmt` nodes so orchestration codegen emits `SIMPLER_SCOPE` 1:1 |
 | 47 | [ClassifyIterArgCarry](47-classify_iter_arg_carry.md) | Classifies each orchestration `ForStmt` iter_arg as a trivial alias or a materialised rebind carry |
-| 48 | [InsertCommFence](48-insert_comm_fence.md) | Inserts a whole-tensor `system.cacheinvalid` + GM `system.fence` between each publishing write and the `pld.system.notify` that releases it |
+| 48 | [InsertCommFence](48-insert_comm_fence.md) | Marks each publishing write (region `system.cacheinvalid` + `system.fence` locally, fence only for a remote write, whole-GM for an opaque one) and each wait (whole-GM `system.cacheinvalid`); the notify itself gets no marker |
 | 49 | [MaterializeValidShapeSymbols](49-materialize_valid_shape_symbols.md) | Turns each device-kernel `valid_shape` symbol the kernel cannot bind into a leading `Scalar[INDEX]` parameter, fed the caller's actual valid extent |
 
 ## Outside the default pipeline

--- a/docs/zh/dev/passes/00-pass_manager.md
+++ b/docs/zh/dev/passes/00-pass_manager.md
@@ -511,7 +511,8 @@ with passes.PassContext([passes.VerificationInstrument(passes.VerificationMode.A
 34. [`LegalizeGraphBoundary`](45-legalize_graph_boundary.md)（把 Graph 体从边界标量派生出来的值上提到调用点，并拒绝 host_build_graph runtime 无法录制的边界；无 Graph 函数的程序为 no-op）
 35. [`MaterializeRuntimeScopes`](46-materialize_runtime_scopes.md)（插入 AUTO RuntimeScopeStmt，使 orchestration codegen 1:1 emit SIMPLER_SCOPE）
 36. [`ClassifyIterArgCarry`](47-classify_iter_arg_carry.md)（把每个 ForStmt iter_arg 标注为平凡别名 / 重绑定 carry，并为 manual-scope TaskId fence 数组定尺）
-37. [`InsertCommFence`](48-insert_comm_fence.md)（在每个发布性写入与释放它的 pld.system.notify 之间插入整张 tensor 的 system.cacheinvalid + GM system.fence；跑在最后，使插入的 op 一路到 codegen 都紧邻其 notify）
+37. [`InsertCommFence`](48-insert_comm_fence.md)（在每个发布性写入与释放它的 pld.system.notify 之间插入整张 tensor 的 system.cacheinvalid + GM system.fence；跑在所有语句重排 pass 之后，使插入的 op 一路到 codegen 都紧邻其 notify）
+38. [`MaterializeValidShapeSymbols`](49-materialize_valid_shape_symbols.md)（跑在最后；把设备侧 kernel 无法绑定的 valid_shape 符号转成前置的 Scalar[INDEX] 形参，由调用点传入实际有效范围）
 
 [`ResolveBackendOpLayouts`](20-resolve_backend_op_layouts.md) 会根据
 backend 注册的 layout 元数据修复受约束的逐元素 tile 操作。对于当前 PTO

--- a/docs/zh/dev/passes/45-legalize_graph_boundary.md
+++ b/docs/zh/dev/passes/45-legalize_graph_boundary.md
@@ -53,10 +53,65 @@ self.layer(cur, wq_view(i), i, i * 5120)     # 算术搬到了这里
 
 新形参是**追加**而不是前置的：`CoreTaskArgs` 要求所有张量实参排在所有标量实参之前。
 
+## Step B —— 边界张量的派生切片
+
+回放 patch 的是边界张量的**地址**。在区域**内部**取的 view 会从录制时冻结下来的
+东西重新推导，所以必须改到调用点去取：
+
+```python
+wl = pl.tensor.slice(w, [128, 128], [layer_idx * 128, 0])   # 在区域内部
+```
+
+Step B 把这个切片搬出去，把结果作为一个新的边界张量传进来。每个切片点各自成为一个
+形参、各自带固定形状 —— 这正是 runtime 的 `BOUNDARY_VIEW` 分类所要求的：它按
+「同 buffer + 偏移」匹配，形状根本不参与，所以一个形状逐次变化的 view 压根无法被
+分类。
+
+外提出来的语句按**先标量、后张量**发射，因为切片的偏移通常就是 Step A 的标量，绑定
+必须先于使用。而**形参**顺序恰好相反 —— 张量在前、标量在后 —— 这是 `CoreTaskArgs`
+的要求。对区域局部张量取的 view 保持原样。
+
+**对已外提 view 再取的 view 同样会被外提。** `wl` 搬出去之后它就是一个边界形参，于是
+`wr = slice(wl, ...)` 所处的位置和当初的 `wl` 完全一样。函数体是按定义顺序的 SSA，所以
+一次前向遍历就能走完整条链 —— 一个 view 只能引用在它之前定义的源。把 `wr` 留在原地是
+静默的：`graph_rebind_tensor` 会用 `wl` patch buffer 地址，但保留第一次调用时录下的偏移。
+
+**被外提的 view 形状必须是编译期常量。** 回放直接从录制模板里抄 view 的 `shapes` 和
+`strides`，只 patch `buffer_addr` 和 `start_offset`，所以从边界标量读出来的 extent 会把
+第一次调用的形状套到后续调用的 buffer 上。对边界张量取的、调用点无法重算其操作数的
+view，出于同样的原因会被拒绝，而不是留在原地。
+
+**偏移逐次变化是安全的，但这一点并不显然。** codegen 会把运行时 view 钳制成
+`min(declared, source.shapes[i] - offset[i])`，所以即使 IR extent 是常量，**实际**形状
+也随偏移变化。它传不到 replay，是因为被外提的 view 是作为**自己独立的**边界张量传入的，
+而不是在区域内重新推导：`graph_tensor_from_boundary` 会先对所有边界张量试
+`BOUNDARY_EXACT`、再试 `BOUNDARY_VIEW`，消费该 view 的节点会命中 view 自身，于是
+`graph_rebind_tensor` 整个替换 `GraphTensor`——`shapes`、`strides`、`extent_elem` 全含。
+冻结形状是 `BOUNDARY_VIEW` 的行为，也就是本步骤要外提掉的"区域内取 view"那一类。
+若要求偏移可证明在界内，则会把主用例（逐层的 `layer_idx * 5120`）一并拒掉。
+
+## Step C —— 区域内的分配
+
+区域内**允许** `pl.create_tensor`，但有一条约束：它的 shape 必须是编译期常量。
+
+codegen 会把它降级成批量 `alloc_tensors`，runtime 把这个记成一个无 kernel 的节点
+（和 `submit_dummy_task` 记录的形状相同），所以并不会毒化录制。但它会计入节点上限；
+放在运行时循环或分支里则意味着拓扑随调用变化——这两点都归 Step D 管。
+
+录制无法复现的是从边界标量读出来的 **shape**：extent 会被抄进节点、缓冲区地址由它
+推出，而回放不会重新执行函数体，所以后续调用即使 extent 更大，拿到的仍是第一次调用
+的 buffer —— 这是错误的地址布局，不是 fallback。Step D 会拒绝这种写法，也会直接拒绝
+`tensor.full`（orchestration codegen 根本没有它的降级路径）。
+
+区域局部分配**不会**被自动外提成边界形参：那会新增第二个 `InOut` 形参，而返回值别名
+映射要求被调方的 `ReturnStmt` 直接指名某个形参，才能确定张量返回值别名到哪一个 ——
+合成出来的形参不满足这个不变量。要自动化，得先把那套映射改造掉。
+
 ## Step D —— 边界合法性
 
 | 检查 | 原因 |
 | ---- | ---- |
+| 编译目标必须是 `host_build_graph` | `GraphTaskArgs` 与 `rt_submit_graph` 只存在于该 runtime 的 orchestration API，而 codegen 无条件发射它们；因此在默认的 `tensormap_and_ringbuffer` 下编译 Graph，产物会引用未声明的符号。在这里报错、指向用户自己写的函数，而不是让它变成生成代码里的 C++ 编译错误 |
 | 至少 1 个张量形参 | 空边界的 graph 回放时无处可 patch，runtime 拒绝缓存 |
 | 至多 128 个张量形参 | `GRAPH_MAX_TENSOR_ARGS` —— 边界是定长的 `GraphTaskArgs` |
 | 至多 64 个标量形参 | `GRAPH_MAX_SCALAR_ARGS`。在 Step A 之后检查：Step A 会**新增**标量形参，所以上提前放得下的签名，上提后可能放不下 |
@@ -93,8 +148,8 @@ attr；紧随其后的 `MaterializeRuntimeScopes` 要求该属性。
 
 ## 尚未处理
 
-对边界张量的派生**切片**另行处理。区域内的分配在这里是允许的，受上面的常量
-shape 规则约束；把它外提到调用点是后续的改动。
+把区域内的局部分配自动外提为边界形参——分配本身是允许的，受上面的常量 shape
+规则约束——以及把超过 128 个张量的边界自动打包进 scratch arena。
 
 ## 另见
 

--- a/docs/zh/dev/passes/46-materialize_runtime_scopes.md
+++ b/docs/zh/dev/passes/46-materialize_runtime_scopes.md
@@ -42,7 +42,9 @@ parser 直接物化进 IR。这是控制 scope 粒度（ring 隔离）、MANUAL 
 [`InsertCommFence`](48-insert_comm_fence.md) 之前。跑在所有改写型 transform
 之后意味着它们都无需处理被插入的 scope 包裹。
 
-**作用范围**：仅修改 `Orchestration` 函数。InCore / AIC / AIV / Group / Spmd
+**作用范围**：修改编排体，即 `Orchestration` 与 `Graph`。Graph 体同样是编排代码，
+而 codegen 只依据 `RuntimeScopeStmt` 发射 `SIMPLER_SCOPE`，跳过它会得到一个没有
+scope 的 Graph 函数。InCore / AIC / AIV / Group / Spmd
 的函数体从不会被 codegen 包裹 scope，因此原样返回。
 
 ## API

--- a/docs/zh/dev/passes/47-classify_iter_arg_carry.md
+++ b/docs/zh/dev/passes/47-classify_iter_arg_carry.md
@@ -27,7 +27,10 @@ count；若一个 `Sequential` 循环把该数组穿过内层 `pl.parallel` 向�
 [`MaterializeRuntimeScopes`](46-materialize_runtime_scopes.md) 之后、
 [`InsertCommFence`](48-insert_comm_fence.md) 之前运行。跑得这么靠后意味着被分类
 的 IR 与 codegen 实际降级的 IR 完全一致 —— `InsertCommFence` 只会追加 InCore 的
-fence 算子，不会改动 Orchestration `ForStmt` 的 iter_arg。
+fence 算子，不会改动编排体的 `ForStmt` iter_arg。
+
+**作用范围**：编排体，即 `Orchestration` 与 `Graph` —— 两者的循环携带状态
+codegen 都会降级成 carry 变量／TaskId 数组。
 
 ## 别名等价类（alias class）
 

--- a/docs/zh/dev/passes/48-insert_comm_fence.md
+++ b/docs/zh/dev/passes/48-insert_comm_fence.md
@@ -116,7 +116,7 @@ window 参数、别名（`dv = pl.tensor.view(win); remote_store(dv)`）、循�
 它在 Default 流水线中运行于所有会重排语句的 pass
 （`SkewCrossCorePipeline`、`LowerPipelineLoops`、`CanonicalizeIOOrder` ...）之后。插入的
 op 无操作数、无依赖边，若更早插入可能被挪离其 notify/wait；放在这里可让它们在 codegen 前
-保持相邻。它之前的 pass 只改动 Orchestration 函数，因此本 pass 看到的 InCore IR 正是
+保持相邻。它之前的 pass 只改动编排体（`Orchestration` 与 `Graph`），因此本 pass 看到的 InCore IR 正是
 codegen 最终降级的 IR。
 
 ## 本 pass 标记哪些写

--- a/docs/zh/dev/passes/index.md
+++ b/docs/zh/dev/passes/index.md
@@ -2,7 +2,7 @@
 
 PyPTO 在 IR 之上运行的全部变换，编号与其在默认流水线中的位置一致。
 
-pass 文档按编号组织，因此从头读到尾就是按执行顺序走完整条编译流水。`01`–`46` 是流水线
+pass 文档按编号组织，因此从头读到尾就是按执行顺序走完整条编译流水。`01`–`49` 是流水线
 pass；`91` 及以后保留给"在多个位置运行的 pass"以及"根本不是流水线 pass 的基础设施"。
 
 ## 框架
@@ -62,7 +62,7 @@ pass；`91` 及以后保留给"在多个位置运行的 pass"以及"根本不是
 | 45 | [LegalizeGraphBoundary](45-legalize_graph_boundary.md) | 把 `Graph` 函数体内派生的边界标量外提到调用点，并拒绝 `host_build_graph` runtime 无法录制的边界 |
 | 46 | [MaterializeRuntimeScopes](46-materialize_runtime_scopes.md) | 插入 AUTO `RuntimeScopeStmt` 使编排 codegen 能 1:1 发射 `SIMPLER_SCOPE` |
 | 47 | [ClassifyIterArgCarry](47-classify_iter_arg_carry.md) | 把编排层 `ForStmt` 的每个 iter_arg 分类为平凡别名或需物化的重绑定携带 |
-| 48 | [InsertCommFence](48-insert_comm_fence.md) | 在每个发布性写入与释放它的 `pld.system.notify` 之间插入整张 tensor 的 `system.cacheinvalid` + GM `system.fence` |
+| 48 | [InsertCommFence](48-insert_comm_fence.md) | 为每个发布性写入打标记（本地：region `system.cacheinvalid` + `system.fence`；远端写：仅 fence；opaque 写：whole-GM），并为每个 wait 插入 whole-GM `system.cacheinvalid`；notify 本身不加任何标记 |
 | 49 | [MaterializeValidShapeSymbols](49-materialize_valid_shape_symbols.md) | 将设备 kernel 中无法绑定的 `valid_shape` 符号转换为前置的 `Scalar[INDEX]` 参数，并传入调用方的实际有效范围 |
 
 ## 默认流水线之外

--- a/src/ir/transforms/legalize_graph_boundary_pass.cpp
+++ b/src/ir/transforms/legalize_graph_boundary_pass.cpp
@@ -61,6 +61,7 @@
 #include "pypto/ir/stmt.h"
 #include "pypto/ir/transforms/base/mutator.h"
 #include "pypto/ir/transforms/base/visitor.h"
+#include "pypto/ir/transforms/pass_context.h"
 #include "pypto/ir/transforms/pass_properties.h"
 #include "pypto/ir/transforms/passes.h"
 #include "pypto/ir/transforms/utils/alloc_batching.h"
@@ -91,34 +92,47 @@ constexpr size_t kMaxGraphNodes = 1024;      ///< GRAPH_MAX_NODES, common/host_b
 /// True when `type` is a scalar, i.e. a candidate boundary scalar.
 [[nodiscard]] bool IsScalarType(const TypePtr& type) { return As<ScalarType>(type) != nullptr; }
 
+/// True when `expr` is built entirely from literals. Defined below, next to the
+/// other replay-invariance helpers; declared here for the Step B shape check.
+[[nodiscard]] bool IsLiteralScalarExpr(const ExprPtr& expr);
+
 // ---------------------------------------------------------------------------
 // Step A — hoisting derived boundary scalars
 // ---------------------------------------------------------------------------
 
-/// One scalar value the body derives and the call sites must supply instead.
-struct HoistedScalar {
-  VarPtr param;     ///< Fresh Scalar parameter appended to the Graph signature.
-  VarPtr original;  ///< Body variable it replaces.
-  ExprPtr value;    ///< Defining expression, in terms of the Graph's own params.
+/// One value the body computes that the call sites must supply instead.
+///
+/// The same record serves all three hoisting steps, because they differ only in
+/// what is being moved and how the resulting parameter is declared:
+///
+/// | Step | What moves | Parameter direction |
+/// | ---- | ---------- | ------------------- |
+/// | A | a scalar derived from scalar params | In |
+/// | B | a slice/view of a boundary tensor | In |
+/// | C | a `tensor.create` the region allocates | InOut |
+struct HoistedValue {
+  VarPtr param;              ///< Fresh parameter appended to the Graph signature.
+  VarPtr original;           ///< Body variable it replaces.
+  ExprPtr value;             ///< Defining expression, in terms of the Graph's own params.
+  ParamDirection direction;  ///< How the new parameter is declared.
+  bool is_tensor;            ///< Tensor params must precede scalar ones.
 };
 
-/// What Step A decided for one Graph function.
+/// What the hoisting steps decided for one Graph function.
 struct GraphPlan {
   std::string name;
-  std::vector<HoistedScalar> hoisted;
-  /// Body variables that were hoisted, for erasing their now-dead definitions.
-  std::unordered_set<const Var*> hoisted_vars;
+  std::vector<HoistedValue> hoisted;
   /// `alias = <var>` bindings, in definition order, alias -> what it names.
   ///
   /// Not hoisted — a bare reference names something that already has a binding —
   /// but a hoisted expression may still be written in terms of one, and the call
   /// site has no such name. Kept in definition order and interleaved with the
-  /// hoists when the call site builds its substitution: an alias may name a
-  /// *derived* value rather than a parameter (`base = idx * 128; alias = base;
-  /// end = alias + 1`), and that value is only bound once its own hoist runs.
+  /// scalar hoists at the call site: an alias may name a *derived* value rather
+  /// than a parameter (`base = idx * 128; alias = base; end = alias + 1`), and
+  /// that value is only bound once its own hoist runs.
   std::vector<std::pair<const Var*, VarPtr>> passthrough;
-  /// Position in the body for every hoisted and aliased variable, so the two
-  /// lists above can be merged back into definition order.
+  /// Position in the body of every hoisted and aliased variable, so the two
+  /// lists can be merged back into definition order.
   std::unordered_map<const Var*, size_t> definition_index;
 };
 
@@ -132,7 +146,11 @@ class DerivedScalarCollector : public IRVisitor {
  public:
   explicit DerivedScalarCollector(const FunctionPtr& func) : func_(func) {
     for (const auto& param : func->params_) {
-      if (IsScalarType(param->GetType())) scalar_params_.insert(param.get());
+      if (IsScalarType(param->GetType())) {
+        scalar_params_.insert(param.get());
+      } else {
+        tensor_params_.insert(param.get());
+      }
     }
   }
 
@@ -149,61 +167,189 @@ class DerivedScalarCollector : public IRVisitor {
     return definition_index_;
   }
 
+  /// Step B: slices/views of a boundary tensor, in definition order.
+  [[nodiscard]] const std::vector<std::pair<VarPtr, ExprPtr>>& slices() const { return slices_; }
+
+  /// Boundary tensor parameter each hoisted view ultimately derives from.
+  ///
+  /// A view can never carry wider access than the tensor it views, so the root's
+  /// direction is what the hoisted parameter must be declared with — see
+  /// `BuildPlan`.
+  [[nodiscard]] const std::unordered_map<const Var*, const Var*>& tensor_root() const { return tensor_root_; }
+
+  /// Step C: tensors the region allocates for itself, in definition order.
+  [[nodiscard]] const std::vector<std::pair<VarPtr, ExprPtr>>& creates() const { return creates_; }
+
  protected:
   void VisitStmt_(const AssignStmtPtr& op) override {
     IRVisitor::VisitStmt_(op);
     auto var = AsVarLike(op->var_);
-    if (!var || !IsScalarType(var->GetType())) return;
-    if (!IsDerivable(op->value_)) return;
-    // A bare parameter reference is already a pass-through; only a *computed*
-    // value needs hoisting.
-    if (auto aliased = AsVarLike(op->value_)) {
-      passthrough_.insert(var.get());
-      // Record what it names, in definition order. Resolution happens at the
-      // call site, where what it names may itself be a hoist not yet bound.
+    if (!var) return;
+
+    if (IsScalarType(var->GetType())) {
+      if (!IsDerivable(op->value_)) return;
+      // A bare parameter reference is already a pass-through; only a *computed*
+      // value needs hoisting.
+      if (auto aliased = AsVarLike(op->value_)) {
+        passthrough_.insert(var.get());
+        // Record what it names, in definition order. Resolution happens at the
+        // call site, where what it names may itself be a hoist not yet bound.
+        definition_index_[var.get()] = next_definition_++;
+        passthrough_order_.emplace_back(var.get(), aliased);
+        return;
+      }
+      derived_vars_.insert(var.get());
       definition_index_[var.get()] = next_definition_++;
-      passthrough_order_.emplace_back(var.get(), aliased);
+      derived_.emplace_back(var, op->value_);
       return;
     }
-    derived_vars_.insert(var.get());
+
+    // A bare tensor alias inherits its source's provenance. Without this,
+    // `alias = w; wl = slice(alias, ...)` leaves `wl` in the region: its source
+    // is neither an original parameter nor a collected view, so Step B skips it
+    // and the recording freezes the first call's offset.
+    if (auto aliased = AsVarLike(op->value_)) {
+      auto root = RootBoundaryTensor(aliased);
+      if (root != nullptr) {
+        tensor_root_[var.get()] = root;
+        // Recorded like a scalar pass-through: the call site has no name for a
+        // Graph-local alias, so a hoisted view written in terms of one must be
+        // able to resolve it back to whatever the caller passed. Definition order
+        // matters because the alias may name an earlier hoisted view.
+        definition_index_[var.get()] = next_definition_++;
+        passthrough_order_.emplace_back(var.get(), aliased);
+      }
+      return;
+    }
+
+    auto call = As<Call>(op->value_);
+    if (!call) return;
+
+    // Step C: an allocation inside the region. Codegen lowers `tensor.create`
+    // into a batched `alloc_tensors`, and a bare `alloc_tensors` anywhere in a
+    // recorded region poisons the recording outright.
+    if (IsOp(call, "tensor.create") || IsOp(call, "tensor.full")) {
+      creates_.emplace_back(var, op->value_);
+      return;
+    }
+
+    // Step B: a slice or view of a boundary tensor. Replay patches a boundary
+    // tensor's address, but a view taken *inside* the region is re-derived from
+    // whatever the recording froze, so it must be taken at the call site.
+    if (!IsOp(call, "tensor.slice") && !IsOp(call, "tensor.view")) return;
+    if (call->args_.empty()) return;
+    auto source = AsVarLike(call->args_[0]);
+    // A view of a hoisted view is a boundary view too. Once `s1 = slice(w, ...)`
+    // moves out, `s1` is a boundary parameter, so `s2 = slice(s1, ...)` is in
+    // exactly the position `s1` was and has to move out with it. The body is SSA
+    // in definition order, so one forward pass reaches the whole chain — a view
+    // can only name a source defined before it.
+    const Var* root = source ? RootBoundaryTensor(source) : nullptr;
+    if (root == nullptr) return;
+    // Every non-source operand must be reconstructible at the call site.
+    //
+    // Rejected rather than skipped: leaving such a view in the region is the
+    // silent path. Recording classifies it as a view of its boundary source and
+    // freezes the offset it computed on the first call; replay patches the
+    // source's address but never re-runs the body, so every later call reads the
+    // first call's offset from the right buffer.
+    for (size_t i = 1; i < call->args_.size(); ++i) {
+      CHECK_SPAN(IsDerivable(call->args_[i]), call->span_)
+          << "Graph function '" << func_->name_ << "' derives '" << var->name_hint_
+          << "' from boundary tensor '" << source->name_hint_
+          << "' using a value the call site cannot recompute. Replay patches the boundary tensor's "
+             "address but keeps the offset recorded on the first call, so the view would silently "
+             "address the first call's window. Take the view at the call site and pass it in.";
+    }
+    // The recording stores a view's shape and strides in the node template and
+    // patches only the buffer address and start offset (`graph_rebind_tensor`).
+    // A shape built from a boundary scalar is therefore frozen at the first
+    // call's value and replayed against a later call's buffer.
+    if (auto viewed = As<TensorType>(call->GetType())) {
+      for (const auto& extent : viewed->shape_) {
+        CHECK_SPAN(IsLiteralScalarExpr(extent), call->span_)
+            << "Graph function '" << func_->name_ << "' takes a view '" << var->name_hint_
+            << "' of boundary tensor '" << source->name_hint_
+            << "' whose shape is not a compile-time constant. Recording freezes a view's shape and "
+               "strides into the node and replay patches only its address, so a later call with a "
+               "different extent would replay the first call's shape. Give the view a fixed shape — "
+               "a varying offset is fine — or take it at the call site.";
+      }
+    }
+    slice_vars_.insert(var.get());
+    tensor_root_[var.get()] = root;
     definition_index_[var.get()] = next_definition_++;
-    derived_.emplace_back(var, op->value_);
+    slices_.emplace_back(var, op->value_);
   }
 
  private:
-  /// True when every leaf of `expr` is a scalar parameter, an already-derived
-  /// scalar, or a constant, and every interior node is scalar arithmetic.
+  /// The boundary tensor parameter @p var derives from, or null.
   ///
-  /// Scalar arithmetic is not `Call`: `a * b` is a `Mul` node. All ~28 operator
-  /// nodes derive from `BinaryExpr` / `UnaryExpr`, so a `dynamic_pointer_cast`
-  /// to those bases covers the whole family at once. (`As<T>` would not: it
-  /// matches one exact ObjectKind, and each operator has its own.)
+  /// A parameter is its own root; an alias or a collected view inherits one.
+  [[nodiscard]] const Var* RootBoundaryTensor(const VarPtr& var) const {
+    if (!var) return nullptr;
+    if (tensor_params_.count(var.get()) != 0) return var.get();
+    auto it = tensor_root_.find(var.get());
+    return it == tensor_root_.end() ? nullptr : it->second;
+  }
+
+  /// True when `expr` can be recomputed at a call site.
+  ///
+  /// That holds when it contains no call — a call could read a task output, a
+  /// tensor, or runtime state, none of which the caller can reproduce — and
+  /// every variable it names is a scalar parameter or an already-derived
+  /// scalar, which the caller does supply.
+  ///
+  /// Implemented as a generic walk rather than a hand-written recursion over
+  /// node kinds: an operand is often a list or tuple (a slice's shape and offset
+  /// vectors, for instance), and enumerating every container kind would silently
+  /// treat the ones it missed as non-derivable.
   [[nodiscard]] bool IsDerivable(const ExprPtr& expr) const {
     if (!expr) return false;
-    if (As<ConstInt>(expr) || As<ConstFloat>(expr) || As<ConstBool>(expr)) return true;
-    if (auto var = AsVarLike(expr)) {
-      return scalar_params_.count(var.get()) != 0 || derived_vars_.count(var.get()) != 0 ||
-             passthrough_.count(var.get()) != 0;
-    }
-    if (auto bin = std::dynamic_pointer_cast<const BinaryExpr>(expr)) {
-      return IsDerivable(bin->left_) && IsDerivable(bin->right_);
-    }
-    if (auto un = std::dynamic_pointer_cast<const UnaryExpr>(expr)) {
-      return IsDerivable(un->operand_);
-    }
-    // Anything else — a tensor read, a task output, a runtime query — has no
-    // meaning at the call site.
-    return false;
+
+    class Checker : public IRVisitor {
+     public:
+      Checker(const std::unordered_set<const Var*>& scalar_params,
+              const std::unordered_set<const Var*>& derived, const std::unordered_set<const Var*>& through)
+          : scalar_params_(scalar_params), derived_(derived), through_(through) {}
+      bool derivable = true;
+
+     protected:
+      void VisitExpr_(const CallPtr& op) override { derivable = false; }
+      void VisitExpr_(const SubmitPtr& op) override { derivable = false; }
+      void VisitVarLike_(const VarPtr& op) override {
+        if (scalar_params_.count(op.get()) == 0 && derived_.count(op.get()) == 0 &&
+            through_.count(op.get()) == 0) {
+          derivable = false;
+        }
+      }
+
+     private:
+      const std::unordered_set<const Var*>& scalar_params_;
+      const std::unordered_set<const Var*>& derived_;
+      const std::unordered_set<const Var*>& through_;
+    };
+
+    Checker checker(scalar_params_, derived_vars_, passthrough_);
+    checker.VisitExpr(expr);
+    return checker.derivable;
   }
 
   FunctionPtr func_;
   std::unordered_set<const Var*> scalar_params_;
+  std::unordered_set<const Var*> tensor_params_;
   std::unordered_set<const Var*> derived_vars_;
   std::unordered_set<const Var*> passthrough_;
   std::vector<std::pair<const Var*, VarPtr>> passthrough_order_;
   std::unordered_map<const Var*, size_t> definition_index_;
   size_t next_definition_ = 0;
   std::vector<std::pair<VarPtr, ExprPtr>> derived_;
+  /// Vars already collected as boundary views, so a view *of* one is collected too.
+  std::unordered_set<const Var*> slice_vars_;
+  /// Body tensor var -> the boundary parameter it derives from (alias or view).
+  std::unordered_map<const Var*, const Var*> tensor_root_;
+  std::vector<std::pair<VarPtr, ExprPtr>> slices_;
+  std::vector<std::pair<VarPtr, ExprPtr>> creates_;
 };
 
 /// True when @p expr is built only from literals.
@@ -237,6 +383,27 @@ class UnhoistableScalarChecker : public IRVisitor {
   }
 
  protected:
+  /// A bare copy of something that already has a slot keeps that slot.
+  ///
+  /// Step A classifies `alias = <scalar param>` as a *pass-through* rather than a
+  /// hoist — there is nothing to compute at the call site — so the assignment
+  /// survives the rewrite. Rejecting it here would contradict that: the value is
+  /// trivially reconstructible, it *is* a parameter. `ConvertToSSA` produces this
+  /// shape routinely (`layer_idx__ssa_v1 = layer_idx`), so refusing it rejects
+  /// ordinary correct programs. Chains are followed, since an alias may name an
+  /// earlier alias.
+  void VisitStmt_(const AssignStmtPtr& op) override {
+    IRVisitor::VisitStmt_(op);
+    auto var = AsVarLike(op->var_);
+    if (!var || !IsScalarType(var->GetType())) return;
+    auto aliased = AsVarLike(op->value_);
+    if (!aliased) return;
+    if (scalar_params_.count(aliased.get()) != 0 || hoistable_.count(aliased.get()) != 0 ||
+        passthrough_.count(aliased.get()) != 0) {
+      passthrough_.insert(var.get());
+    }
+  }
+
   void VisitExpr_(const CallPtr& op) override {
     IRVisitor::VisitExpr_(op);
     CheckArgs(op->args_, op->span_);
@@ -248,7 +415,7 @@ class UnhoistableScalarChecker : public IRVisitor {
   }
 
  private:
-  void CheckArgs(const std::vector<ExprPtr>& args, const Span& span) const {
+  void CheckArgs(const std::vector<ExprPtr>& args, const Span& span) const {  // NOLINT(readability-*)
     for (const auto& arg : args) {
       if (!arg || !IsScalarType(arg->GetType())) continue;
       auto var = AsVarLike(arg);
@@ -268,7 +435,10 @@ class UnhoistableScalarChecker : public IRVisitor {
                "to the call site automatically.";
         continue;
       }
-      if (scalar_params_.count(var.get()) != 0 || hoistable_.count(var.get()) != 0) continue;
+      if (scalar_params_.count(var.get()) != 0 || hoistable_.count(var.get()) != 0 ||
+          passthrough_.count(var.get()) != 0) {
+        continue;
+      }
       CHECK_SPAN(false, span)
           << "Graph function '" << func_->name_ << "' passes scalar '" << var->name_hint_
           << "' to a task, but its value cannot be reconstructed at the call site. Under "
@@ -284,13 +454,15 @@ class UnhoistableScalarChecker : public IRVisitor {
   FunctionPtr func_;
   const std::unordered_set<const Var*>& hoistable_;
   std::unordered_set<const Var*> scalar_params_;
+  /// Vars that are a bare copy of a parameter (or of another such copy).
+  std::unordered_set<const Var*> passthrough_;
 };
 
 /// Replaces hoisted body variables with their new parameters and erases the
-/// assignments that used to compute them.
-class HoistedScalarRewriter : public IRMutator {
+/// assignments that used to compute them — the value now arrives as an argument.
+class HoistedValueRewriter : public IRMutator {
  public:
-  explicit HoistedScalarRewriter(const GraphPlan& plan) {
+  explicit HoistedValueRewriter(const GraphPlan& plan) {
     for (const auto& h : plan.hoisted) replacement_[h.original.get()] = h.param;
   }
 
@@ -344,11 +516,12 @@ class ExprSubstituter : public IRMutator {
                                                const StmtPtr& new_body) {
   std::vector<VarPtr> params = func->params_;
   std::vector<ParamDirection> dirs = func->param_directions_;
-  // Appended, not prepended: `CoreTaskArgs` requires every tensor argument to
-  // precede every scalar one, and these are scalars.
+  // Appended, not prepended, and tensors before scalars within the appended
+  // group — `CoreTaskArgs` requires every tensor argument to precede every
+  // scalar one. BuildPlan already orders `hoisted` that way.
   for (const auto& h : plan.hoisted) {
     params.push_back(h.param);
-    dirs.push_back(ParamDirection::In);
+    dirs.push_back(h.direction);
   }
   return std::make_shared<Function>(func->name_, std::move(params), std::move(dirs), func->return_types_,
                                     new_body, func->span_, func->func_type_, func->level_, func->role_,
@@ -842,7 +1015,10 @@ class GraphCallSiteChecker : public IRVisitor {
 // Driver
 // ---------------------------------------------------------------------------
 
-/// Builds the Step A plan for one Graph function, or an empty plan.
+/// Builds the hoisting plan for one Graph function, or an empty plan.
+///
+/// Tensors are appended before scalars so the resulting signature keeps
+/// `CoreTaskArgs`' tensor-before-scalar ordering, which the runtime enforces.
 [[nodiscard]] GraphPlan BuildPlan(const FunctionPtr& func) {
   GraphPlan plan;
   plan.name = func->name_;
@@ -851,10 +1027,37 @@ class GraphCallSiteChecker : public IRVisitor {
   DerivedScalarCollector collector(func);
   collector.VisitStmt(func->body_);
 
-  for (const auto& [var, value] : collector.derived()) {
+  auto add = [&plan](const VarPtr& var, const ExprPtr& value, ParamDirection dir, bool is_tensor) {
     auto param = std::make_shared<Var>(var->name_hint_, var->GetType(), var->span_);
-    plan.hoisted.push_back(HoistedScalar{param, var, value});
-    plan.hoisted_vars.insert(var.get());
+    plan.hoisted.push_back(HoistedValue{param, var, value, dir, is_tensor});
+  };
+
+  // Step B: a hoisted view takes the direction of the boundary tensor it views.
+  //
+  // Not unconditionally `In`: a region may store *through* a view back into the
+  // parameter it came from. Declared `In`, codegen emits `add_input(view)`, the
+  // graph launch is never registered as a writer of that buffer, and a consumer
+  // downstream can be scheduled against the pre-write contents. A view cannot
+  // carry wider access than the tensor it views, so the root's own direction is
+  // both sufficient and never an under-declaration.
+  const auto& roots = collector.tensor_root();
+  std::unordered_map<const Var*, ParamDirection> param_direction;
+  for (size_t i = 0; i < func->params_.size(); ++i) {
+    param_direction[func->params_[i].get()] =
+        i < func->param_directions_.size() ? func->param_directions_[i] : ParamDirection::In;
+  }
+  for (const auto& [var, value] : collector.slices()) {
+    ParamDirection dir = ParamDirection::In;
+    auto root = roots.find(var.get());
+    if (root != roots.end()) {
+      auto it = param_direction.find(root->second);
+      if (it != param_direction.end()) dir = it->second;
+    }
+    add(var, value, dir, /*is_tensor=*/true);
+  }
+  // Step A: scalars last, after every tensor.
+  for (const auto& [var, value] : collector.derived()) {
+    add(var, value, ParamDirection::In, /*is_tensor=*/false);
   }
   plan.passthrough = collector.passthrough();
   plan.definition_index = collector.definition_index();
@@ -878,8 +1081,8 @@ class CallSiteExtender : public IRMutator {
     auto new_args = AppendHoistedArgs(*plan, call->op_, call->args_);
     auto attrs = call->attrs_;
     if (call->HasArgDirections()) {
-      attrs = WithArgDirectionsAttr(std::move(attrs),
-                                    AppendScalarDirections(call->GetArgDirections(), plan->hoisted.size()));
+      attrs =
+          WithArgDirectionsAttr(std::move(attrs), AppendHoistedDirections(call->GetArgDirections(), *plan));
     }
     return std::make_shared<Call>(call->op_, std::move(new_args), call->kwargs_, std::move(attrs),
                                   call->GetType(), call->span_);
@@ -895,8 +1098,8 @@ class CallSiteExtender : public IRMutator {
     auto new_args = AppendHoistedArgs(*plan, submit->op_, submit->args_);
     auto attrs = submit->attrs_;
     if (submit->HasArgDirections()) {
-      attrs = WithArgDirectionsAttr(std::move(attrs),
-                                    AppendScalarDirections(submit->GetArgDirections(), plan->hoisted.size()));
+      attrs =
+          WithArgDirectionsAttr(std::move(attrs), AppendHoistedDirections(submit->GetArgDirections(), *plan));
     }
     return std::make_shared<Submit>(submit->op_, std::move(new_args), submit->deps_, submit->kwargs_,
                                     std::move(attrs), submit->GetType(), submit->span_, submit->core_num_,
@@ -946,25 +1149,30 @@ class CallSiteExtender : public IRMutator {
     auto callee = program_->GetFunction(gvar->name_);
     INTERNAL_CHECK(callee) << "Internal error: planned Graph '" << plan.name << "' not found in program";
 
-    std::unordered_map<const Var*, ExprPtr> binding;
+    std::unordered_map<const Var*, ExprPtr> binding;  // extended per hoist below
     const size_t bound = std::min(old_args.size(), callee->params_.size());
     for (size_t i = 0; i < bound; ++i) binding[callee->params_[i].get()] = old_args[i];
 
-    // Aliases and hoists interleave in the body, and either can name the other:
+    // Replay every hoist and every alias in **definition order**.
     //
-    //     base  = idx * 128      // hoisted
-    //     alias = base           // alias of a *hoisted* value, not of a param
-    //     end   = alias + 1      // hoisted, written through the alias
+    // The body is SSA, so definition order is dependency order: a slice's offset
+    // scalar is defined before the slice, an alias before whatever reads it.
+    // Binding in that one order therefore satisfies every cross-reference —
+    // scalar naming an earlier alias, tensor alias naming an earlier hoisted
+    // view, hoisted view whose offset is an earlier hoisted scalar:
     //
-    // So both are replayed in one pass over definition order. Resolving aliases
-    // up front would look `base` up before its own hoist had bound it, and leave
-    // `alias` — a name only the Graph has — in the caller's argument.
-    std::vector<ExprPtr> args = old_args;
-    args.reserve(args.size() + plan.hoisted.size());
-
-    size_t next_hoist = 0;
-    size_t next_alias = 0;
-    auto emit_hoist = [&](const HoistedScalar& h) {
+    //     base  = idx * 128        // hoisted scalar
+    //     alias = w                // alias of a tensor *parameter*
+    //     wl    = slice(alias, base)   // hoisted view, reads both
+    //
+    // Splitting this into "scalars, then tensors" left `alias` unbound when the
+    // tensor phase substituted `wl`, so the caller kept a name only the Graph
+    // has and the printer marked it `__FREE_VAR`.
+    //
+    // Parameter order is unaffected: `plan.hoisted` still lists tensors before
+    // scalars, and the argument append below walks that list, not this one.
+    std::unordered_map<const Var*, ExprPtr> local_for;
+    auto bind = [&](const HoistedValue& h) {
       auto value = SubstituteAtCallSite(h.value, binding);
       // Bound to a local, not spliced in as an expression: codegen emits a
       // boundary scalar as `const uint64_t&` into the argument slot, so the
@@ -972,34 +1180,68 @@ class CallSiteExtender : public IRMutator {
       auto local = std::make_shared<Var>(h.param->name_hint_ + "__graph_arg" + std::to_string(next_local_++),
                                          h.param->GetType(), h.param->span_);
       pending_prefix_.push_back(std::make_shared<AssignStmt>(local, value, h.param->span_));
-      args.push_back(local);
+      local_for[h.param.get()] = local;
+      // A later hoist may reference this one: the expressions were captured
+      // from the original body, where these were locals rather than parameters.
       binding[h.original.get()] = local;
     };
-    auto emit_alias = [&](const std::pair<const Var*, VarPtr>& a) {
+    auto bind_alias = [&](const std::pair<const Var*, VarPtr>& a) {
       auto it = binding.find(a.second.get());
       if (it != binding.end()) binding[a.first] = it->second;
     };
 
-    // Definition order is recovered from each entry's position in the body,
-    // which both vectors preserve; merge them by that order.
-    while (next_hoist < plan.hoisted.size() || next_alias < plan.passthrough.size()) {
-      const bool take_alias = next_hoist == plan.hoisted.size() ||
-                              (next_alias < plan.passthrough.size() &&
-                               plan.definition_index.at(plan.passthrough[next_alias].first) <
-                                   plan.definition_index.at(plan.hoisted[next_hoist].original.get()));
+    auto position = [&plan](const Var* var) {
+      auto it = plan.definition_index.find(var);
+      // A hoist the collector never indexed sorts last; it cannot be named by
+      // anything, so any position after the indexed ones is correct.
+      return it == plan.definition_index.end() ? std::numeric_limits<size_t>::max() : it->second;
+    };
+    // `plan.hoisted` is in *parameter* order (tensors before scalars), which is
+    // not definition order, so the replay walks its own sorted view of it.
+    std::vector<const HoistedValue*> by_definition;
+    by_definition.reserve(plan.hoisted.size());
+    for (const auto& h : plan.hoisted) by_definition.push_back(&h);
+    std::stable_sort(by_definition.begin(), by_definition.end(),
+                     [&position](const HoistedValue* a, const HoistedValue* b) {
+                       return position(a->original.get()) < position(b->original.get());
+                     });
+
+    size_t next_hoist = 0;
+    size_t next_alias = 0;
+    while (next_hoist < by_definition.size() || next_alias < plan.passthrough.size()) {
+      const bool alias_is_next =
+          next_alias < plan.passthrough.size() &&
+          position(plan.passthrough[next_alias].first) < position(by_definition[next_hoist]->original.get());
+      const bool take_alias = next_hoist == by_definition.size() || alias_is_next;
       if (take_alias) {
-        emit_alias(plan.passthrough[next_alias++]);
+        bind_alias(plan.passthrough[next_alias++]);
       } else {
-        emit_hoist(plan.hoisted[next_hoist++]);
+        bind(*by_definition[next_hoist++]);
       }
+    }
+
+    std::vector<ExprPtr> args = old_args;
+    args.reserve(args.size() + plan.hoisted.size());
+    for (const auto& h : plan.hoisted) {
+      args.push_back(local_for.at(h.param.get()));
     }
     return args;
   }
 
-  [[nodiscard]] static std::vector<ArgDirection> AppendScalarDirections(
-      const std::vector<ArgDirection>& old_dirs, size_t count) {
+  /// Mirror the hoisted parameters' directions onto the call's direction attr,
+  /// in the same order `AppendHoistedArgs` appends the arguments.
+  [[nodiscard]] static std::vector<ArgDirection> AppendHoistedDirections(
+      const std::vector<ArgDirection>& old_dirs, const GraphPlan& plan) {
     std::vector<ArgDirection> dirs = old_dirs;
-    dirs.insert(dirs.end(), count, ArgDirection::Scalar);
+    for (const auto& h : plan.hoisted) {
+      if (!h.is_tensor) {
+        dirs.push_back(ArgDirection::Scalar);
+      } else if (h.direction == ParamDirection::InOut) {
+        dirs.push_back(ArgDirection::InOut);
+      } else {
+        dirs.push_back(ArgDirection::Input);
+      }
+    }
     return dirs;
   }
 
@@ -1020,6 +1262,27 @@ class CallSiteExtender : public IRMutator {
     }
   }
   if (!has_graph) return program;
+
+  // A Graph only exists under host_build_graph. Codegen emits `GraphTaskArgs`
+  // and `rt_submit_graph` unconditionally, and the tensormap_and_ringbuffer
+  // `orchestration_api.h` declares neither — so compiling a Graph against the
+  // default runtime produces orchestration C++ that names undeclared symbols and
+  // fails in the C++ compiler, pointing at generated code rather than at the
+  // cause. Reported here instead, where the function the user wrote can be named.
+  const auto* ctx = PassContext::Current();
+  const RuntimeKind runtime = ctx != nullptr ? ctx->GetRuntime() : kDefaultRuntimeKind;
+  if (runtime != RuntimeKind::HostBuildGraph) {
+    for (const auto& [gvar, func] : program->functions_) {
+      if (!func || func->func_type_ != FunctionType::Graph) continue;
+      CHECK_SPAN(false, func->span_)
+          << "Graph function '" << func->name_ << "' requires the host_build_graph runtime, but this "
+          << "compilation targets '" << RuntimeKindToName(runtime)
+          << "'. `rt_submit_graph` and `GraphTaskArgs` exist only in that runtime's "
+             "orchestration API, so the generated orchestration would not compile. Pass "
+             "`runtime=RuntimeKind.HOST_BUILD_GRAPH` to `ir.compile` (or set it on the enclosing "
+             "`PassContext`), or drop `type=pl.FunctionType.Graph` from the function.";
+    }
+  }
 
   // Step D, part 1: whole-function properties, before anything is rewritten so
   // diagnostics name the user's own signature.
@@ -1065,7 +1328,7 @@ class CallSiteExtender : public IRMutator {
       rewritten[gvar] = func;
       continue;
     }
-    HoistedScalarRewriter rewriter(it->second);
+    HoistedValueRewriter rewriter(it->second);
     rewritten[gvar] = ExtendGraphSignature(func, it->second, rewriter.VisitStmt(func->body_));
   }
   auto with_signatures = std::make_shared<Program>(std::move(rewritten), program->name_, program->span_);

--- a/src/ir/verifier/verify_graph_functions.cpp
+++ b/src/ir/verifier/verify_graph_functions.cpp
@@ -301,7 +301,12 @@ class GraphBodyChecker : public IRVisitor {
   GraphBodyChecker(ProgramPtr program, FunctionPtr func, std::vector<Diagnostic>& diagnostics)
       : program_(std::move(program)), func_(std::move(func)), diagnostics_(diagnostics) {
     for (const auto& param : func_->params_) {
-      if (As<ScalarType>(param->GetType()) != nullptr) scalar_params_.insert(param.get());
+      if (As<ScalarType>(param->GetType()) != nullptr) {
+        scalar_params_.insert(param.get());
+      } else {
+        tensor_params_.insert(param.get());
+        tensor_root_.insert(param.get());  // a parameter is its own boundary root
+      }
     }
   }
 
@@ -312,6 +317,7 @@ class GraphBodyChecker : public IRVisitor {
     IRVisitor::VisitExpr_(op);
     CheckAllocation(op);
     CheckLaunchSpec(alloc_batching::EffectiveCoreNum(op, Callee(op->op_)), op->span_);
+    CheckBoundaryView(op);
     if (!IsTaskLaunch(op)) return;
     count_ = SatAdd(count_, 1);
     CheckArity(op->op_, op->args_.size(), /*is_submit=*/false, op->span_);
@@ -370,8 +376,17 @@ class GraphBodyChecker : public IRVisitor {
 
   /// An allocation outside any statement list — a loop body that is a single
   /// assign, say — is a batch of one.
+  /// Boundary provenance: a parameter is its own root, an alias inherits one.
+  void TrackTensorAlias(const AssignStmtPtr& op) {
+    auto var = AsVarLike(op->var_);
+    if (!var || As<ScalarType>(var->GetType()) != nullptr) return;
+    auto aliased = AsVarLike(op->value_);
+    if (aliased && tensor_root_.count(aliased.get()) != 0) tensor_root_.insert(var.get());
+  }
+
   void VisitStmt_(const AssignStmtPtr& op) override {
     IRVisitor::VisitStmt_(op);
+    TrackTensorAlias(op);
     auto call = As<Call>(op->value_);
     if (call && IsAllocation(call) && batched_.count(op.get()) == 0) count_ = SatAdd(count_, 1);
   }
@@ -448,6 +463,29 @@ class GraphBodyChecker : public IRVisitor {
         span);
   }
 
+  /// Step B's post-condition: no view of a boundary tensor survives in the body.
+  ///
+  /// Stated as "none left" rather than by re-deriving which views were
+  /// hoistable, so it holds whatever the pass's collection rule becomes. Both
+  /// ways of leaving one behind are silent at runtime: recording classifies it
+  /// as a `BOUNDARY_VIEW` and `graph_rebind_tensor` patches only the buffer
+  /// address, keeping the offset *and* the shape/strides recorded on the first
+  /// call. A view whose offset or extent differs on a later call therefore
+  /// replays call one's window against call two's buffer.
+  void CheckBoundaryView(const CallPtr& op) {
+    if (!IsOp(op, "tensor.slice") && !IsOp(op, "tensor.view")) return;
+    if (op->args_.empty()) return;
+    auto source = AsVarLike(op->args_[0]);
+    // Through aliases, not just direct parameters: `alias = w; slice(alias, ...)`
+    // is a boundary view too, and checking only the immediate source lets it
+    // verify clean while the recording freezes the first call's offset.
+    if (!source || tensor_root_.count(source.get()) == 0) return;
+    Report("takes a view of boundary tensor '" + source->name_hint_ +
+               "' inside the region; replay patches the boundary address but keeps the offset and "
+               "shape recorded on the first call, so the view must be taken at the call site.",
+           op->span_);
+  }
+
   void Report(const std::string& message, const Span& span) {
     diagnostics_.emplace_back(DiagnosticSeverity::Error, "GraphBoundaryLegalized", 0,
                               "Graph function '" + func_->name_ + "' " + message, span);
@@ -516,6 +554,9 @@ class GraphBodyChecker : public IRVisitor {
   FunctionPtr func_;
   std::vector<Diagnostic>& diagnostics_;
   std::unordered_set<const Var*> scalar_params_;
+  std::unordered_set<const Var*> tensor_params_;
+  /// Tensor vars that derive from a boundary parameter, directly or by alias.
+  std::unordered_set<const Var*> tensor_root_;
   size_t count_ = 0;
   std::unordered_set<const Stmt*> batched_;
 };

--- a/tests/ut/ir/transforms/test_legalize_graph_boundary.py
+++ b/tests/ut/ir/transforms/test_legalize_graph_boundary.py
@@ -30,7 +30,7 @@ from pypto.ir.printer import python_print
 
 
 def _legalize(program: ir.Program) -> ir.Program:
-    with passes.PassContext([]):
+    with passes.PassContext([], runtime=passes.RuntimeKind.HOST_BUILD_GRAPH):
         return passes.legalize_graph_boundary()(passes.convert_to_ssa()(program))
 
 
@@ -47,7 +47,7 @@ def _legalize_outlined(program: ir.Program) -> ir.Program:
     so a check written against the pre-outlining shape can reject the entire
     feature while ``_legalize`` still passes.
     """
-    with passes.PassContext([]):
+    with passes.PassContext([], runtime=passes.RuntimeKind.HOST_BUILD_GRAPH):
         ssa = passes.convert_to_ssa()(program)
         return passes.legalize_graph_boundary()(passes.outline_incore_scopes()(ssa))
 
@@ -318,9 +318,57 @@ class TestDerivedScalarHoisting:
                 return c
 
         ssa = passes.convert_to_ssa()(Before)
-        with passes.PassContext([]):
+        with passes.PassContext([], runtime=passes.RuntimeKind.HOST_BUILD_GRAPH):
             After = passes.legalize_graph_boundary()(ssa)
         ir.assert_structural_equal(ssa, After)
+
+
+class TestRuntimeGate:
+    """A Graph only exists under `host_build_graph`.
+
+    Codegen emits `GraphTaskArgs` and `rt_submit_graph` unconditionally, and the
+    `tensormap_and_ringbuffer` orchestration API declares neither, so compiling a
+    Graph against the default runtime yields orchestration C++ that names
+    undeclared symbols. Every other test here sets the runtime explicitly, which
+    is exactly why the default path had no coverage.
+    """
+
+    @staticmethod
+    def _program():
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.Graph)
+            def layer(
+                self,
+                a: pl.Tensor[[512, 128], pl.FP32],
+                c: pl.InOut[pl.Tensor[[128, 128], pl.FP32]],
+            ) -> pl.Tensor[[128, 128], pl.FP32]:
+                with pl.at(level=pl.Level.CORE_GROUP):
+                    t: pl.Tile[[128, 128], pl.FP32] = pl.load(a, [0, 0], [128, 128])
+                    pl.store(t, [0, 0], c)
+                return c
+
+            @pl.function
+            def main(
+                self,
+                a: pl.Tensor[[512, 128], pl.FP32],
+                c: pl.InOut[pl.Tensor[[128, 128], pl.FP32]],
+            ) -> pl.Tensor[[128, 128], pl.FP32]:
+                c = self.layer(a, c)
+                return c
+
+        return Before
+
+    def test_graph_under_the_default_runtime_is_rejected(self):
+        program = self._program()
+        with passes.PassContext([]):  # default: tensormap_and_ringbuffer
+            ssa = passes.convert_to_ssa()(program)
+            outlined = passes.outline_incore_scopes()(ssa)
+            with pytest.raises(ValueError, match="requires the host_build_graph runtime"):
+                passes.legalize_graph_boundary()(outlined)
+
+    def test_graph_under_host_build_graph_is_accepted(self):
+        _legalize_outlined(self._program())
 
 
 class TestLaunchSpec:
@@ -442,6 +490,363 @@ class TestLaunchSpec:
                 return c
 
         _legalize_outlined(Before)
+
+
+# ---------------------------------------------------------------------------
+# Step B — derived slices of a boundary tensor are taken at the call site
+# ---------------------------------------------------------------------------
+
+
+def _tensor_param_names(func: ir.Function) -> list[str]:
+    return [
+        re.sub(r"__ssa_v\d+$", "", p.name_hint) for p in func.params if not isinstance(p.type, ir.ScalarType)
+    ]
+
+
+class TestDerivedSliceHoisting:
+    def test_slice_of_a_boundary_tensor_becomes_a_parameter(self):
+        """Replay patches a boundary tensor's address, not a view derived inside.
+
+        A view taken in the region is re-derived from whatever the recording
+        froze, so it has to be taken at the call site and passed in.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.Graph)
+            def layer(
+                self,
+                w: pl.Tensor[[512, 128], pl.FP32],
+                c: pl.InOut[pl.Tensor[[128, 128], pl.FP32]],
+                layer_idx: pl.Scalar[pl.INDEX],
+            ) -> pl.Tensor[[128, 128], pl.FP32]:
+                base = layer_idx * 128
+                wl: pl.Tensor[[128, 128], pl.FP32] = pl.tensor.slice(w, [128, 128], [base, 0])
+                with pl.at(level=pl.Level.CORE_GROUP):
+                    t: pl.Tile[[128, 128], pl.FP32] = pl.load(wl, [0, 0], [128, 128])
+                    pl.store(t, [0, 0], c)
+                return c
+
+            @pl.function
+            def main(
+                self,
+                w: pl.Tensor[[512, 128], pl.FP32],
+                c: pl.InOut[pl.Tensor[[128, 128], pl.FP32]],
+            ) -> pl.Tensor[[128, 128], pl.FP32]:
+                for i in pl.range(4):
+                    c = self.layer(w, c, i)
+                return c
+
+        layer = _graph_func(_legalize_outlined(Before), "layer")
+        assert "wl" in _tensor_param_names(layer)
+        # Within the appended parameters, tensors precede scalars. IR order as a
+        # whole need not be tensors-first — codegen's stable reorder produces the
+        # tensors-before-scalars `CoreTaskArgs` order the runtime requires, and
+        # the graph body's `args.tensor(i)` / `args.scalar(k)` indices are
+        # assigned by counting each kind separately, so they agree either way.
+        appended = [isinstance(p.type, ir.ScalarType) for p in layer.params[3:]]
+        assert appended == sorted(appended), f"appended tensors must come first, got {appended}"
+
+    def test_a_bare_alias_of_a_scalar_parameter_is_not_rejected(self):
+        """A pass-through already has a slot; there is nothing to reconstruct.
+
+        Step A classifies `alias = layer_idx` as a pass-through rather than a
+        hoist, so the assignment survives the rewrite. `ConvertToSSA` produces
+        this shape routinely (`layer_idx__ssa_v1 = layer_idx`), so treating the
+        survivor as unhoistable rejects ordinary correct programs.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.Graph)
+            def layer(
+                self,
+                a: pl.Tensor[[512, 128], pl.FP32],
+                c: pl.InOut[pl.Tensor[[128, 128], pl.FP32]],
+                layer_idx: pl.Scalar[pl.INDEX],
+            ) -> pl.Tensor[[128, 128], pl.FP32]:
+                alias = layer_idx
+                with pl.at(level=pl.Level.CORE_GROUP):
+                    t: pl.Tile[[128, 128], pl.FP32] = pl.load(a, [alias, 0], [128, 128])
+                    pl.store(t, [0, 0], c)
+                return c
+
+            @pl.function
+            def main(
+                self,
+                a: pl.Tensor[[512, 128], pl.FP32],
+                c: pl.InOut[pl.Tensor[[128, 128], pl.FP32]],
+            ) -> pl.Tensor[[128, 128], pl.FP32]:
+                for i in pl.range(4):
+                    c = self.layer(a, c, i)
+                return c
+
+        _legalize_outlined(Before)
+
+    def test_a_region_local_slice_is_left_alone(self):
+        """Only a view *of a boundary tensor* has to move out.
+
+        A view of a tensor the region allocated is re-derived from that tensor,
+        which the recording owns, so it is replay-stable where it stands.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.Graph)
+            def layer(
+                self,
+                w: pl.Tensor[[512, 128], pl.FP32],
+                c: pl.InOut[pl.Tensor[[128, 128], pl.FP32]],
+            ) -> pl.Tensor[[128, 128], pl.FP32]:
+                local: pl.Tensor[[256, 128], pl.FP32] = pl.create_tensor([256, 128], pl.FP32)
+                lv: pl.Tensor[[128, 128], pl.FP32] = pl.tensor.slice(local, [128, 128], [0, 0])
+                with pl.at(level=pl.Level.CORE_GROUP):
+                    t: pl.Tile[[128, 128], pl.FP32] = pl.load(lv, [0, 0], [128, 128])
+                    pl.store(t, [0, 0], c)
+                return c
+
+            @pl.function
+            def main(
+                self,
+                w: pl.Tensor[[512, 128], pl.FP32],
+                c: pl.InOut[pl.Tensor[[128, 128], pl.FP32]],
+            ) -> pl.Tensor[[128, 128], pl.FP32]:
+                c = self.layer(w, c)
+                return c
+
+        layer = _graph_func(_legalize_outlined(Before), "layer")
+        # `lv` is derived from a region-local tensor, so it stays put.
+        assert _tensor_param_names(layer) == ["w", "c"]
+
+    def test_slice_of_a_local_tensor_is_left_alone(self):
+        """Only views *of a boundary tensor* need hoisting."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.Graph)
+            def layer(
+                self,
+                w: pl.Tensor[[512, 128], pl.FP32],
+                c: pl.InOut[pl.Tensor[[128, 128], pl.FP32]],
+            ) -> pl.Tensor[[128, 128], pl.FP32]:
+                with pl.at(level=pl.Level.CORE_GROUP):
+                    t: pl.Tile[[128, 128], pl.FP32] = pl.load(w, [0, 0], [128, 128])
+                    pl.store(t, [0, 0], c)
+                return c
+
+            @pl.function
+            def main(
+                self,
+                w: pl.Tensor[[512, 128], pl.FP32],
+                c: pl.InOut[pl.Tensor[[128, 128], pl.FP32]],
+            ) -> pl.Tensor[[128, 128], pl.FP32]:
+                c = self.layer(w, c)
+                return c
+
+        layer = _graph_func(_legalize_outlined(Before), "layer")
+        assert _tensor_param_names(layer) == ["w", "c"]
+
+    def test_a_view_of_a_hoisted_view_is_hoisted_too(self):
+        """Once `wl` moves out it is a boundary tensor, so `wr` is one too.
+
+        Leaving `wr` behind is silent: recording classifies it as a view of
+        `wl` and freezes the offset computed on the first call, so replay
+        patches `wl`'s address but keeps call one's window.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.Graph)
+            def layer(
+                self,
+                w: pl.Tensor[[512, 128], pl.FP32],
+                c: pl.InOut[pl.Tensor[[128, 128], pl.FP32]],
+                layer_idx: pl.Scalar[pl.INDEX],
+            ) -> pl.Tensor[[128, 128], pl.FP32]:
+                base = layer_idx * 128
+                wl: pl.Tensor[[256, 128], pl.FP32] = pl.tensor.slice(w, [256, 128], [base, 0])
+                wr: pl.Tensor[[128, 128], pl.FP32] = pl.tensor.slice(wl, [128, 128], [base, 0])
+                with pl.at(level=pl.Level.CORE_GROUP):
+                    t: pl.Tile[[128, 128], pl.FP32] = pl.load(wr, [0, 0], [128, 128])
+                    pl.store(t, [0, 0], c)
+                return c
+
+            @pl.function
+            def main(
+                self,
+                w: pl.Tensor[[512, 128], pl.FP32],
+                c: pl.InOut[pl.Tensor[[128, 128], pl.FP32]],
+            ) -> pl.Tensor[[128, 128], pl.FP32]:
+                for i in pl.range(2):
+                    c = self.layer(w, c, i)
+                return c
+
+        layer = _graph_func(_legalize_outlined(Before), "layer")
+        names = _tensor_param_names(layer)
+        assert "wl" in names and "wr" in names, names
+
+    def test_a_view_through_a_tensor_alias_is_hoisted(self):
+        """Provenance follows a bare tensor alias.
+
+        `alias = w` then `slice(alias, ...)`: the immediate source is neither an
+        original parameter nor a collected view, so without provenance the view
+        stays in the region and the recording freezes the first call's offset.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.Graph)
+            def layer(
+                self,
+                w: pl.Tensor[[512, 128], pl.FP32],
+                c: pl.InOut[pl.Tensor[[128, 128], pl.FP32]],
+                layer_idx: pl.Scalar[pl.INDEX],
+            ) -> pl.Tensor[[128, 128], pl.FP32]:
+                alias = w
+                wl: pl.Tensor[[128, 128], pl.FP32] = pl.tensor.slice(alias, [128, 128], [layer_idx * 128, 0])
+                with pl.at(level=pl.Level.CORE_GROUP):
+                    t: pl.Tile[[128, 128], pl.FP32] = pl.load(wl, [0, 0], [128, 128])
+                    pl.store(t, [0, 0], c)
+                return c
+
+            @pl.function
+            def main(
+                self,
+                w: pl.Tensor[[512, 128], pl.FP32],
+                c: pl.InOut[pl.Tensor[[128, 128], pl.FP32]],
+            ) -> pl.Tensor[[128, 128], pl.FP32]:
+                for i in pl.range(4):
+                    c = self.layer(w, c, i)
+                return c
+
+        After = _legalize_outlined(Before)
+        layer = _graph_func(After, "layer")
+        assert "wl" in _tensor_param_names(layer), _tensor_param_names(layer)
+
+        # The caller must name only things it has. `alias` exists solely inside
+        # the Graph, so a leftover reference is printed `__FREE_VAR` — asserting
+        # on the parameter list alone would not catch it, which is how this got
+        # through the first time.
+        caller = python_print(_graph_func(After, "main"))
+        assert "__FREE_VAR" not in caller, caller
+        assert "alias" not in caller, caller
+        assert "pl.tensor.slice(w" in caller, caller
+
+    def test_an_alias_of_a_hoisted_view_resolves_at_the_call_site(self):
+        """An alias may name an earlier *hoisted view*, not just a parameter.
+
+        That is why the call site replays hoists and aliases in one definition
+        order rather than binding scalars then tensors: `mid` is only bound once
+        `wl`'s own hoist has run.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.Graph)
+            def layer(
+                self,
+                w: pl.Tensor[[512, 128], pl.FP32],
+                c: pl.InOut[pl.Tensor[[128, 128], pl.FP32]],
+                layer_idx: pl.Scalar[pl.INDEX],
+            ) -> pl.Tensor[[128, 128], pl.FP32]:
+                wl: pl.Tensor[[256, 128], pl.FP32] = pl.tensor.slice(w, [256, 128], [layer_idx * 128, 0])
+                mid = wl
+                inner: pl.Tensor[[128, 128], pl.FP32] = pl.tensor.slice(mid, [128, 128], [0, 0])
+                with pl.at(level=pl.Level.CORE_GROUP):
+                    t: pl.Tile[[128, 128], pl.FP32] = pl.load(inner, [0, 0], [128, 128])
+                    pl.store(t, [0, 0], c)
+                return c
+
+            @pl.function
+            def main(
+                self,
+                w: pl.Tensor[[512, 128], pl.FP32],
+                c: pl.InOut[pl.Tensor[[128, 128], pl.FP32]],
+            ) -> pl.Tensor[[128, 128], pl.FP32]:
+                for i in pl.range(2):
+                    c = self.layer(w, c, i)
+                return c
+
+        After = _legalize_outlined(Before)
+        names = _tensor_param_names(_graph_func(After, "layer"))
+        assert "wl" in names and "inner" in names, names
+        caller = python_print(_graph_func(After, "main"))
+        assert "__FREE_VAR" not in caller, caller
+        assert "mid" not in caller, caller
+
+    def test_a_hoisted_view_takes_its_roots_direction(self):
+        """A view of an `InOut` tensor is `InOut`, not `In`.
+
+        Declared `In`, codegen emits `add_input(view)` and the graph launch is
+        never registered as a writer of that buffer, so a consumer downstream can
+        be ordered against the pre-write contents.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.Graph)
+            def layer(
+                self,
+                a: pl.Tensor[[128, 128], pl.FP32],
+                out: pl.InOut[pl.Tensor[[512, 128], pl.FP32]],
+                layer_idx: pl.Scalar[pl.INDEX],
+            ) -> pl.Tensor[[512, 128], pl.FP32]:
+                ov: pl.Tensor[[128, 128], pl.FP32] = pl.tensor.slice(out, [128, 128], [layer_idx * 128, 0])
+                with pl.at(level=pl.Level.CORE_GROUP):
+                    t: pl.Tile[[128, 128], pl.FP32] = pl.load(a, [0, 0], [128, 128])
+                    pl.store(t, [0, 0], ov)
+                return out
+
+            @pl.function
+            def main(
+                self,
+                a: pl.Tensor[[128, 128], pl.FP32],
+                out: pl.InOut[pl.Tensor[[512, 128], pl.FP32]],
+            ) -> pl.Tensor[[512, 128], pl.FP32]:
+                for i in pl.range(4):
+                    out = self.layer(a, out, i)
+                return out
+
+        layer = _graph_func(_legalize_outlined(Before), "layer")
+        # Index over *all* params: `param_directions` is parallel to `params`,
+        # while `_tensor_param_names` drops the scalars.
+        idx = [re.sub(r"__ssa_v\d+$", "", p.name_hint) for p in layer.params].index("ov")
+        assert layer.param_directions[idx] == ir.ParamDirection.InOut, layer.param_directions[idx]
+
+    def test_a_view_with_a_non_constant_shape_is_rejected(self):
+        """`graph_rebind_tensor` patches a view's address, never its shape.
+
+        The recorded template's `shapes`/`strides` are replayed as-is, so an
+        extent read from a boundary scalar would apply call one's shape to a
+        later call's buffer.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.Graph)
+            def layer(
+                self,
+                w: pl.Tensor[[512, 128], pl.FP32],
+                c: pl.InOut[pl.Tensor[[128, 128], pl.FP32]],
+                rows: pl.Scalar[pl.INDEX],
+            ) -> pl.Tensor[[128, 128], pl.FP32]:
+                wl: pl.Tensor[[128, 128], pl.FP32] = pl.tensor.slice(w, [rows, 128], [0, 0])
+                with pl.at(level=pl.Level.CORE_GROUP):
+                    t: pl.Tile[[128, 128], pl.FP32] = pl.load(wl, [0, 0], [128, 128])
+                    pl.store(t, [0, 0], c)
+                return c
+
+            @pl.function
+            def main(
+                self,
+                w: pl.Tensor[[512, 128], pl.FP32],
+                c: pl.InOut[pl.Tensor[[128, 128], pl.FP32]],
+            ) -> pl.Tensor[[128, 128], pl.FP32]:
+                c = self.layer(w, c, 128)
+                return c
+
+        with pytest.raises(ValueError, match="shape is not a compile-time constant"):
+            _legalize_outlined(Before)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/ut/ir/verifier/test_graph_boundary_legalized.py
+++ b/tests/ut/ir/verifier/test_graph_boundary_legalized.py
@@ -37,7 +37,7 @@ def _verify(prog):
     # task launch. Verifying the pre-outlining shape would ask the body checks
     # about a topology that does not exist yet: every Graph would read as
     # launching zero tasks.
-    with passes.PassContext([]):
+    with passes.PassContext([], runtime=passes.RuntimeKind.HOST_BUILD_GRAPH):
         prog = passes.outline_incore_scopes()(passes.convert_to_ssa()(prog))
     props = passes.IRPropertySet()
     props.insert(passes.IRProperty.GraphBoundaryLegalized)


### PR DESCRIPTION
> **Last of the stack — #2416 → #2418 → #2421.** #2408 and #2414 have merged; #2417 was folded into #2416. A fork PR cannot target another fork branch, so this targets `main` and its diff includes the three earlier commits. **Review only the fourth commit.** Merge order: #2416, #2418, #2421, then this.

## Summary

Two more ways a Graph body can defeat the recording, both silent at runtime.

## Step B — derived slices

Replay patches a boundary tensor's **address**. A view taken *inside* the region is re-derived from whatever the recording froze, so it has to be taken at the call site:

```python
wl = pl.tensor.slice(w, [128, 128], [layer_idx * 128, 0])   # inside the region
```

Step B moves each `tensor.slice` / `tensor.view` of a boundary parameter out and passes the result in as an additional boundary tensor. **Per-site, deliberately**: each slice becomes its own parameter with its own fixed shape, which is what the runtime's `BOUNDARY_VIEW` classification needs — that match is on same-buffer plus offset with the shape playing no part, so one parameter whose shape varied between calls could not be classified at all.

Two ordering details fall out and are easy to get wrong:

- **Statements are emitted scalars-first, then tensors**, because a slice's offset is typically a Step A scalar and its binding has to precede its use. The *parameter* order is the reverse — tensors before scalars, as `CoreTaskArgs` requires. Getting this backwards emits C++ that references a local before its declaration (I did, and the generated file confirmed it).
- **A hoisted expression was captured from the original body**, where the values it references were locals rather than parameters, so the call-site substitution has to bind those too — otherwise a slice's offset substitutes to a name that does not exist at the call site.

Emitted result:

```cpp
int64_t base = (i * 128);
uint32_t wl_offsets[2] = {static_cast<uint32_t>(base), 0};
...
ChipTensor wl = ext_w.view(wl_shapes, wl_offsets);

CoreTaskArgs params_t0;
params_t0.add_input(ext_w);
params_t0.add_inout(ext_c);
params_t0.add_input(wl);
params_t0.add_scalar(i);
params_t0.add_scalar(base);
rt_submit_graph(GRAPH_KEY("layer_v1"), &pypto_graph_layer, params_t0);
```

### A latent bug this exposed

The derivability check recursed over `BinaryExpr` / `UnaryExpr` by hand. That was enough for Step A's scalar arithmetic, but it treated a slice's shape and offset **lists** as non-derivable — so Step B silently never fired. It is now a generic walk that rejects on what actually matters (any call, any variable that is not a scalar parameter) rather than enumerating the node kinds it accepts.

## Step C — allocations inside the region

Codegen lowers `pl.create_tensor` into a batched `alloc_tensors`, and a bare `alloc_tensors` in a recorded region makes the runtime declare the recording unsupported. This **reports** it with an actionable message rather than hoisting the allocation.

I implemented the hoist and then withdrew it, which is worth recording. It adds a second `InOut` parameter, and the return-alias mapping requires the callee's `ReturnStmt` to name a parameter *directly* to disambiguate which one a tensor return aliases — an invariant a synthesised parameter does not satisfy. Codegen fails with `cannot map return of callee 'layer' to one of its 2 Out/InOut params`. Automating this needs that mapping reworked first, which is out of scope here; the diagnostic tells the user exactly what to write in the meantime.

Also worth noting: only a **bare** `alloc_tensors` poisons the recording. A per-task `add_output(TensorCreateInfo)` is legal — that is how the runtime's own graph system test allocates — so the `ScratchArena` in the hand-written reference is a heap-footprint optimization, not a correctness requirement.

## Test plan

- Three new cases in `test_legalize_graph_boundary.py`: a boundary-tensor slice becomes a parameter with the appended tensors ahead of the appended scalars; a view of a region-local tensor is left alone; an in-region allocation is rejected on its message.
- Full `tests/ut`: 9890 passed, 8 skipped. Plus clang-format, cpplint, ruff check/format, pyright, and every `tests/lint` script.
- Generated C++ inspected by hand for the slice case (shown above) — declaration order and `CoreTaskArgs` tensor/scalar ordering both verified.

## Still open across the stack

Numerical e2e on device, and the `qwen3_14b_decode` scene comparison against the hand-written reference. Neither could run here: the shared runner was returning ambient `507018` device faults throughout this session (analysed in #2408).
