### PR TITLE
fix(language): keep the C++ `Check failed:` tail out of DSL error headers

### DIFF
--- a/docs/en/dev/02-error-handling.md
+++ b/docs/en/dev/02-error-handling.md
@@ -95,6 +95,17 @@ CHECK_SPAN(shape.size() == 2, span) << "tensor.matmul: only 2D inputs are suppor
 
 The `span` argument follows the same safety rule as `INTERNAL_CHECK_SPAN`: it is evaluated only on failure, but unconditionally evaluated there. The span source must therefore be safe to dereference at the failure point (typically a local `Span` variable or a sibling IR node known non-null).
 
+#### The `Check failed:` tail is stripped before it reaches DSL users
+
+`FatalLogger::~FatalLogger` appends `\nCheck failed: <expr> at <file>:<line>` to **every** check message, `CHECK` included. That tail names a C++ expression and an absolute build-machine path — useful when debugging PyPTO, noise for someone whose kernel is simply invalid. Since the renderer splices the whole message into its bold `Error:` header, an unstripped tail lands between the header and the `-->` arrow pointing at the user's own source.
+
+The DSL parser therefore routes a user-facing backend exception through `concise_error_message()` (`python/pypto/language/parser/diagnostics/exceptions.py`) before wrapping it in a `ParserError`. The raw text stays reachable via `PTO_BACKTRACE=1`, which prints the Python traceback carrying the original exception as `__cause__`.
+
+Two consequences for op authors:
+
+- **Always give `CHECK` a `<<` message.** Once the tail is stripped, a bare `CHECK(cond);` has nothing left to say, and the user gets a generic "backend check reported no message" placeholder instead of an actionable error.
+- **Do not hand-roll `throw pypto::ValueError(...)` to dodge the tail.** That workaround predates the parser-side strip and is no longer needed for DSL-reachable checks.
+
 ### Internal invariant checks — `INTERNAL_CHECK_SPAN`
 
 Throw `InternalError` when an internal invariant is violated. Always attach the IR node's `Span` so the error message includes the user's source location:

--- a/docs/zh/dev/02-error-handling.md
+++ b/docs/zh/dev/02-error-handling.md
@@ -92,6 +92,17 @@ CHECK_SPAN(shape.size() == 2, span) << "tensor.matmul: only 2D inputs are suppor
 
 `span` 参数遵循与 `INTERNAL_CHECK_SPAN` 相同的安全规则:它仅在失败时求值,但在失败路径中是无条件求值的。因此 span 来源必须在失败点可以安全求值(典型如局部 `Span` 变量或已确认非空的兄弟 IR 节点)。
 
+#### `Check failed:` 尾部在抵达 DSL 用户前会被剥离
+
+`FatalLogger::~FatalLogger` 会给**每一条**检查消息(包括 `CHECK`)追加 `\nCheck failed: <表达式> at <文件>:<行号>`。该尾部包含 C++ 表达式和构建机器上的绝对路径 —— 调试 PyPTO 时有用,但对于只是写错了 kernel 的用户而言纯属噪声。由于渲染器会把整条消息拼进加粗的 `Error:` 标题,未剥离的尾部会夹在标题与指向用户源码的 `-->` 箭头之间。
+
+因此,DSL 解析器在把面向用户的后端异常包装成 `ParserError` 之前,会先经过 `concise_error_message()`(`python/pypto/language/parser/diagnostics/exceptions.py`)。原始文本仍可通过 `PTO_BACKTRACE=1` 获取 —— 它会打印 Python 回溯,其中以 `__cause__` 携带原始异常。
+
+对算子作者的两点影响:
+
+- **务必为 `CHECK` 提供 `<<` 消息。** 尾部被剥离后,裸写的 `CHECK(cond);` 将无话可说,用户只会看到"后端检查未提供消息"这样的通用占位文本,而非可据以修正的错误。
+- **不要为了绕开尾部而手写 `throw pypto::ValueError(...)`。** 该变通做法早于解析器侧的剥离机制,对 DSL 可达的检查已无必要。
+
 ### 内部不变式检查 — `INTERNAL_CHECK_SPAN`
 
 当违反内部不变式时抛出 `InternalError`。始终附加 IR 节点的 `Span`，使错误消息包含用户源代码位置：

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -1213,7 +1213,9 @@ class ASTParser:
         try:
             self.builder.add_function_attrs(attrs)
         except ValueError as exc:
-            raise ParserSyntaxError(str(exc), span=span, hint=None) from exc
+            # The duplicate-key rejection is a C++ ``CHECK`` in IRBuilder::AddFunctionAttrs,
+            # so strip FatalLogger's implementation-facing tail before it reaches the header.
+            raise ParserSyntaxError(concise_error_message(exc), span=span, hint=None) from exc
 
     def _parse_func_attr_value(self, key: str, value_node: ast.expr) -> Any:
         """Reconstruct one ``pl.func_attr`` value from its Python AST node.
@@ -8249,7 +8251,15 @@ class ASTParser:
             # rounding mode ...")``). Make sure the surfaced error always names
             # the op so users can locate the bad call. When any operand was a
             # Scalar, append a hint pointing at Python operators.
-            msg = str(e)
+            #
+            # Sanitize first: most ops type-check in C++, and a ``CHECK`` throws
+            # ``pypto::ValueError`` -- so backend op-validation failures land *here*, not
+            # in the ``except Exception`` branch below. Their message still carries
+            # FatalLogger's "Check failed: <C++ expr> at <absolute path>.cpp:<line>" tail,
+            # which the renderer would splice into the bold ``Error:`` header ahead of the
+            # ``-->`` source arrow. It stays reachable through ``__cause__`` under
+            # PTO_BACKTRACE=1. A pure-Python ValueError has no tail, so this is a no-op.
+            msg = concise_error_message(e)
             if not msg.startswith(f"pl.{op_name}") and not msg.startswith(f"{module_name}.{op_name}"):
                 msg = f"{module_name} operation '{op_name}': {msg}"
             hint = self._scalar_operand_hint(args, kwargs)

--- a/python/pypto/language/parser/diagnostics/exceptions.py
+++ b/python/pypto/language/parser/diagnostics/exceptions.py
@@ -132,6 +132,18 @@ class ScopeIsolationError(ParserError):
     pass
 
 
+_CHECK_TAIL_MARKER = "Check failed: "
+
+# What a check with no ``<<`` payload leaves behind once its tail is stripped. ``CHECK`` is
+# the *user*-error macro (see .claude/rules/error-checking.md); ``INTERNAL_CHECK`` is the
+# bug-class one, and this helper runs on messages from both. So the wording must not read
+# as "you found a compiler bug" -- it says the check was silent and names the escape hatch.
+_UNSPECIFIED_CHECK_MESSAGE = (
+    "The operation was rejected by a backend check that reported no message "
+    "(re-run with PTO_BACKTRACE=1 to see which check failed)"
+)
+
+
 def concise_error_message(exc: Exception) -> str:
     """Extract a concise user-facing message from an exception.
 
@@ -139,8 +151,14 @@ def concise_error_message(exc: Exception) -> str:
     useful for debugging but noisy in parser error reports. The full details
     remain accessible via PTO_BACKTRACE=1 which shows the Python traceback
     containing the original exception with all C++ information.
+
+    A check that fired without a ``<<`` message leaves nothing behind once its tail
+    is stripped; that reports as :data:`_UNSPECIFIED_CHECK_MESSAGE` rather than as an
+    empty string, because an empty bold ``Error:`` header is strictly worse than the
+    C++ noise it replaced.
     """
-    msg = str(exc)
+    raw = str(exc)
+    msg = raw
     # Strip "C++ Traceback ..." block appended by GetFullMessage()
     pos = msg.find("\n\nC++ Traceback")
     if pos != -1:
@@ -149,14 +167,21 @@ def concise_error_message(exc: Exception) -> str:
     pos = msg.find("\n\nNo stack trace available")
     if pos != -1:
         msg = msg[:pos]
-    # Strip "Check failed: <expr> at <file>:<line>" appended by CHECK macro
-    if msg.startswith("Check failed: "):
-        msg = "Internal backend check failed"
+    # Strip the "Check failed: <expr> at <file>:<line>" tail that FatalLogger::~FatalLogger
+    # (core/logging.h:600-606) glues onto every CHECK. It is always the last line; whatever
+    # precedes it is the ``<<`` payload the op wrote for the user. FatalLogger emits the
+    # "\n" unconditionally, so a message-less check puts the rfind hit at 0 -- that
+    # truncation is what empties the message, handled by the fallback below.
+    if msg.startswith(_CHECK_TAIL_MARKER):
+        msg = ""
     else:
-        pos = msg.rfind("\nCheck failed: ")
+        pos = msg.rfind("\n" + _CHECK_TAIL_MARKER)
         if pos != -1:
             msg = msg[:pos]
-    return msg.strip()
+    msg = msg.strip()
+    if not msg and raw.strip():
+        return _UNSPECIFIED_CHECK_MESSAGE
+    return msg
 
 
 __all__ = [

--- a/python/pypto/language/parser/diagnostics/exceptions.py
+++ b/python/pypto/language/parser/diagnostics/exceptions.py
@@ -155,10 +155,10 @@ def concise_error_message(exc: Exception) -> str:
     A check that fired without a ``<<`` message leaves nothing behind once its tail
     is stripped; that reports as :data:`_UNSPECIFIED_CHECK_MESSAGE` rather than as an
     empty string, because an empty bold ``Error:`` header is strictly worse than the
-    C++ noise it replaced.
+    C++ noise it replaced. An exception that was simply raised with an empty message
+    keeps its empty message -- only a stripped check tail earns the fallback.
     """
-    raw = str(exc)
-    msg = raw
+    msg = str(exc)
     # Strip "C++ Traceback ..." block appended by GetFullMessage()
     pos = msg.find("\n\nC++ Traceback")
     if pos != -1:
@@ -172,14 +172,22 @@ def concise_error_message(exc: Exception) -> str:
     # precedes it is the ``<<`` payload the op wrote for the user. FatalLogger emits the
     # "\n" unconditionally, so a message-less check puts the rfind hit at 0 -- that
     # truncation is what empties the message, handled by the fallback below.
+    stripped_check_tail = False
     if msg.startswith(_CHECK_TAIL_MARKER):
         msg = ""
+        stripped_check_tail = True
     else:
         pos = msg.rfind("\n" + _CHECK_TAIL_MARKER)
         if pos != -1:
             msg = msg[:pos]
+            stripped_check_tail = True
     msg = msg.strip()
-    if not msg and raw.strip():
+    # Gate on the tail actually having been removed, not on "something was there before":
+    # `GetFullMessage()` always appends a traceback (or the "no stack trace" note), so a
+    # bare `pypto::ValueError("")` under PTO_BACKTRACE=1 also strips to empty -- and calling
+    # that a silent backend check would name a check that never ran, while telling the user
+    # to enable a flag they already have on.
+    if not msg and stripped_check_tail:
         return _UNSPECIFIED_CHECK_MESSAGE
     return msg
 

--- a/src/ir/op/tile_ops/matmul_mx.cpp
+++ b/src/ir/op/tile_ops/matmul_mx.cpp
@@ -199,7 +199,14 @@ TypePtr DeduceTileMatMulMxType(const std::vector<ExprPtr>& args,
   ExprPtr lhs_scale_k_phys = MxScaleKCeil(k_phys_lhs);
   ExprPtr lhs_scale_k_valid = MxScaleKCeil(k_valid_lhs);
   if (!lhs_scale_k_phys) {
-    CHECK(lhs_scale_type && lhs_scale_type->shape_.size() == 2);
+    // Symbolic lhs K: ceil(K/32) is not computable, so the scale-group count is read off
+    // the declared lhs_scale tile instead. Split so the rank message can name the actual
+    // rank without dereferencing a null scale type.
+    CHECK(lhs_scale_type) << "The operator " << op_name << " requires lhs_scale to be a TileType, but got "
+                          << args[1]->GetType()->TypeName();
+    CHECK(lhs_scale_type->shape_.size() == 2)
+        << "The operator " << op_name << " requires lhs_scale to be 2D, but got "
+        << lhs_scale_type->shape_.size() << " dimensions";
     lhs_scale_k_phys = lhs_scale_type->shape_[1];
   }
   if (!lhs_scale_k_valid) {
@@ -208,7 +215,12 @@ TypePtr DeduceTileMatMulMxType(const std::vector<ExprPtr>& args,
   ExprPtr rhs_scale_k_phys = MxScaleKCeil(k_phys_rhs);
   ExprPtr rhs_scale_k_valid = MxScaleKCeil(k_valid_rhs);
   if (!rhs_scale_k_phys) {
-    CHECK(rhs_scale_type && rhs_scale_type->shape_.size() == 2);
+    // Symbolic rhs K -- see the lhs_scale note above.
+    CHECK(rhs_scale_type) << "The operator " << op_name << " requires rhs_scale to be a TileType, but got "
+                          << args[3]->GetType()->TypeName();
+    CHECK(rhs_scale_type->shape_.size() == 2)
+        << "The operator " << op_name << " requires rhs_scale to be 2D, but got "
+        << rhs_scale_type->shape_.size() << " dimensions";
     rhs_scale_k_phys = rhs_scale_type->shape_[0];
   }
   if (!rhs_scale_k_valid) {

--- a/tests/ut/language/parser/test_error_wrapping.py
+++ b/tests/ut/language/parser/test_error_wrapping.py
@@ -23,6 +23,7 @@ from pypto.language.parser.diagnostics import (
     ParserError,
     ParserTypeError,
 )
+from pypto.language.parser.diagnostics.renderer import ErrorRenderer
 
 
 class TestOpErrorWrapping:
@@ -97,6 +98,70 @@ class TestOpErrorWrapping:
             def unknown(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
                 result: pl.Tensor[[64], pl.FP32] = pl.nonexistent_op(x)  # type: ignore
                 return result
+
+
+class TestBackendCheckMessageSanitized:
+    """A C++ CHECK must not leak FatalLogger's tail into the user-facing diagnostic.
+
+    Most ops type-check in C++. ``CHECK`` throws ``pypto::ValueError``, which surfaces in
+    Python as a plain ``ValueError`` whose message still carries the tail
+    ``FatalLogger::~FatalLogger`` appends: "Check failed: <C++ expr> at <abs path>.cpp:<line>".
+    Left in, the renderer splices it into the bold ``Error:`` header, ahead of the ``-->``
+    arrow that points at the user's own source.
+    """
+
+    @staticmethod
+    def _mismatched_matmul():
+        """Build a kernel whose only fault is FP16 x FP32 matmul operands.
+
+        Drives the CHECK in src/ir/op/tile_ops/matmul.cpp -- the DSL wrapper does no dtype
+        checking of its own, so validation happens in the backend type-deduction function.
+        """
+
+        @pl.function
+        def bad(
+            t1: pl.Tensor[[64, 64], pl.FP16],
+            t2: pl.Tensor[[64, 64], pl.FP32],
+            out: pl.Tensor[[64, 64], pl.FP32],
+        ) -> pl.Tensor[[64, 64], pl.FP32]:
+            a: pl.Tile[[64, 64], pl.FP16] = pl.tile.load(t1, offsets=[0, 0], shapes=[64, 64])
+            b: pl.Tile[[64, 64], pl.FP32] = pl.tile.load(t2, offsets=[0, 0], shapes=[64, 64])
+            c: pl.Tile[[64, 64], pl.FP32] = pl.tile.matmul(a, b)
+            result: pl.Tensor[[64, 64], pl.FP32] = pl.tile.store(c, offsets=[0, 0], output_tensor=out)
+            return result
+
+        return bad
+
+    def test_cpp_check_error_does_not_leak_check_failed_tail(self):
+        """The header carries the op's own message -- not the C++ expression or path."""
+        with pytest.raises(InvalidOperationError) as exc_info:
+            self._mismatched_matmul()
+
+        message = exc_info.value.message
+        assert "Check failed" not in message
+        assert ".cpp" not in message
+        assert "src/ir/op" not in message
+        # Positive half: a future over-eager strip that eats the whole message fails here.
+        assert "identical lhs and rhs data types" in message
+        assert "pl.tile operation 'matmul'" in message
+
+    def test_cpp_check_detail_survives_on_the_cause(self):
+        """The tail is hidden, not destroyed -- PTO_BACKTRACE=1 still reaches it."""
+        with pytest.raises(InvalidOperationError) as exc_info:
+            self._mismatched_matmul()
+
+        cause = exc_info.value.__cause__
+        assert isinstance(cause, ValueError)
+        assert "Check failed" in str(cause)
+
+    def test_rendered_header_is_followed_immediately_by_the_location_arrow(self):
+        """Nothing may sit between the ``Error:`` header and the ``-->`` source arrow."""
+        with pytest.raises(InvalidOperationError) as exc_info:
+            self._mismatched_matmul()
+
+        lines = ErrorRenderer(use_color=False).render(exc_info.value).split("\n")
+        assert lines[0].startswith("Error:")
+        assert lines[1].lstrip().startswith("-->")
 
 
 class TestProgramCatchAll:

--- a/tests/ut/language/parser/test_func_attr.py
+++ b/tests/ut/language/parser/test_func_attr.py
@@ -201,6 +201,29 @@ class TestParserRejections:
                     pl.func_attr({"split": pl.SplitMode.LEFT_RIGHT})
                     out[0:64] = x[0:64]
 
+    def test_duplicate_key_error_does_not_leak_builder_check_tail(self):
+        """The duplicate-key CHECK lives in C++; its FatalLogger tail must not reach the user.
+
+        ``IRBuilder::AddFunctionAttrs`` rejects the second key with a ``CHECK``, whose message
+        carries "Check failed: <C++ expr> at <absolute path>/builder.cpp:<line>". The parser
+        strips that tail so it does not render inside the bold ``Error:`` header.
+        """
+        with pytest.raises(ParserSyntaxError) as exc_info:
+
+            @pl.program
+            class P:
+                @pl.function(type=pl.FunctionType.InCore)
+                def kernel(self, x: pl.Tensor[[64], pl.FP32], out: pl.Out[pl.Tensor[[64], pl.FP32]]):
+                    pl.func_attr({"split": pl.SplitMode.UP_DOWN})
+                    pl.func_attr({"split": pl.SplitMode.LEFT_RIGHT})
+                    out[0:64] = x[0:64]
+
+        message = exc_info.value.message
+        assert "Check failed" not in message
+        assert "builder.cpp" not in message
+        # The actionable half must survive the strip.
+        assert "Each attribute may be declared only once." in message
+
     def test_rejects_duplicate_key_within_one_call(self):
         with pytest.raises((ParserSyntaxError, ValueError), match="[Dd]uplicate.*windowize"):
             pl.parse_program(_source('pl.func_attr({"windowize": True, "windowize": False})'))

--- a/tests/ut/language/parser/test_static_operations.py
+++ b/tests/ut/language/parser/test_static_operations.py
@@ -390,10 +390,41 @@ class TestConciseErrorMessage:
         assert concise_error_message(exc) == "user message"
 
     def test_strips_check_failed_at_start(self):
-        """Test stripping when Check failed: is the entire message."""
+        """A check that fired with no ``<<`` payload reports the fallback, never an empty string."""
         msg = "Check failed: dim > 0 at src/foo.cpp:42"
         exc = ValueError(msg)
-        assert concise_error_message(exc) == "Internal backend check failed"
+        result = concise_error_message(exc)
+        assert result
+        assert "Check failed" not in result
+        assert "PTO_BACKTRACE=1" in result
+
+    def test_message_less_check_does_not_return_empty(self):
+        """The shape a real message-less CHECK produces: FatalLogger always emits the newline.
+
+        ``CHECK(cond);`` with no ``<<`` puts the tail at offset 1, so truncating at the
+        newline leaves nothing -- which would render as an empty bold ``Error:`` header.
+        """
+        msg = (
+            "\nCheck failed: lhs_scale_type && lhs_scale_type->shape_.size() == 2 at "
+            "/home/u/pypto/src/ir/op/tile_ops/matmul_mx.cpp:202 at kernel.py:9:3"
+        )
+        exc = ValueError(msg)
+        result = concise_error_message(exc)
+        assert result
+        assert "Check failed" not in result
+        assert ".cpp" not in result
+
+    def test_check_span_message_keeps_its_payload(self):
+        """CHECK_SPAN puts its IR span before the newline, so the payload must survive."""
+        msg = (
+            "The operator tile.slice requires a 2D operand [kernel.py:9:3]"
+            "\nCheck failed: x at f.cpp:1 at kernel.py:9:3"
+        )
+        exc = ValueError(msg)
+        result = concise_error_message(exc)
+        assert "The operator tile.slice requires a 2D operand" in result
+        assert "Check failed" not in result
+        assert "f.cpp" not in result
 
     def test_empty_message(self):
         """Test with empty exception message."""

--- a/tests/ut/language/parser/test_static_operations.py
+++ b/tests/ut/language/parser/test_static_operations.py
@@ -431,6 +431,20 @@ class TestConciseErrorMessage:
         exc = ValueError("")
         assert concise_error_message(exc) == ""
 
+    def test_empty_message_with_traceback_is_not_called_a_check(self):
+        """Only a stripped check tail earns the fallback -- an empty message keeps its own.
+
+        ``GetFullMessage()`` always appends a traceback block (or the "no stack trace"
+        note), so a bare ``pypto::ValueError("")`` under ``PTO_BACKTRACE=1`` also strips
+        to empty. Naming that a silent backend check would report a check that never ran
+        and tell the user to enable a flag they already have on.
+        """
+        with_trace = ValueError("\n\nC++ Traceback (most recent call last):\n  frame0")
+        assert concise_error_message(with_trace) == ""
+
+        no_symbols = ValueError("\n\nNo stack trace available. \n(Tip: Build with Debug)")
+        assert concise_error_message(no_symbols) == ""
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

`FatalLogger::~FatalLogger` appends `\nCheck failed: <expr> at <file>:<line>` to every check message, and `CHECK` throws `pypto::ValueError` — so every backend op-validation failure lands in `_dispatch_op`'s `except (TypeError, ValueError)` branch, which stringified the exception raw. The `except Exception` branch four lines below already sanitized; this one was simply missed.

`_dispatch_op` is the dispatcher for every DSL namespace (`pl.tensor`, `pl.tile`, `pl.system`, `pl.array`, `pl.prefetch`, `pld.*`, unified `pl.*`), fed by 1,358 `CHECK`/`CHECK_SPAN` statements under `src/ir/op/` — which is what makes this the dominant DSL error path.

**Before** — `pl.tile.matmul` on FP16 × FP32 operands:

```text
Error: pl.tile operation 'matmul': The operator tile.matmul requires identical lhs and rhs data types, but got fp16 and fp32
Check failed: lhs_type->dtype_ == rhs_type->dtype_ at /abs/path/.../src/ir/op/tile_ops/matmul.cpp:82 at kernel.py:9:37
  --> kernel.py:9:37
   |
 9 |     c: pl.Tile[[64, 64], pl.FP32] = pl.tile.matmul(a, b)
   |                                     ^^^^^^^^^^^^^^
```

A C++ boolean expression and an absolute build-machine path are the second thing the user reads — rendered *inside* the bold red header, since `renderer.py` splices the whole multi-line message into `f"Error: {message}"`, with two run-together `at file:line` clauses (C++ path first).

**After:**

```text
Error: pl.tile operation 'matmul': The operator tile.matmul requires identical lhs and rhs data types, but got fp16 and fp32
  --> kernel.py:9:37
   |
 9 |     c: pl.Tile[[64, 64], pl.FP32] = pl.tile.matmul(a, b)
   |                                     ^^^^^^^^^^^^^^
```

## What changed

- **`ast_parser.py`** — the `(TypeError, ValueError)` branch of `_dispatch_op` routes through the existing `concise_error_message()`. The `pl.func_attr` duplicate-key handler gets the same treatment: it surfaces a `CHECK` in `IRBuilder::AddFunctionAttrs` identically.
- **`exceptions.py`** — `concise_error_message()` no longer returns an empty string. See below.
- **`matmul_mx.cpp`** — the two `CHECK`s with no `<<` message get real user-facing text.
- **docs** — a subsection under *User-facing checks*, `en` + `zh`.

The C++ detail is hidden, not destroyed — `PTO_BACKTRACE=1` still prints it through the chained `__cause__`, and a test pins that.

## Why the helper needed hardening

Stripping alone would have regressed a check carrying no `<<` payload. `FatalLogger` emits its newline unconditionally, so for `CHECK(cond);` the tail starts at offset 1 and truncating at that newline leaves `""` — an empty bold `Error:` header, strictly worse than the noise it replaced. `concise_error_message()` now falls back to a named message, and the only two such checks repo-wide (the `tile.matmul_mx` scale operands, reached when K is symbolic) get real text. Those two are **split in two checks** because the rank message cannot name the actual rank while the null guard shares the predicate.

## One test expectation changed

`test_strips_check_failed_at_start` asserted the fallback string `"Internal backend check failed"`. Two independent reasons that is a test fix rather than a test hack:

1. **The wording was wrong.** `CHECK` is the *user*-error macro (`.claude/rules/error-checking.md`); telling someone with an invalid kernel that they hit an "Internal" failure sends them to file a compiler bug. The helper also runs on genuine `InternalError` messages, so the replacement is class-neutral.
2. **Its fixture pinned a shape production never emits.** The input `"Check failed: dim > 0 at src/foo.cpp:42"` has no leading `\n`, but `FatalLogger` always writes one first — so the branch it exercised is dead in production. Every real message-less check takes the other path, which is exactly the empty-string bug. A new test adds the fixture that does occur.

## Testing

- `tests/ut/` — **9,912 passed, 3 skipped, 0 failed**; `ctest` 1/1.
- 7 new tests. Each pairs a negative assertion (`"Check failed" not in msg`) with a positive one (the op's own text survives; the C++ detail survives on `__cause__`), so an over-eager strip cannot pass them.
- Verified by hand end to end, both with and without `PTO_BACKTRACE=1`.

## Interaction with #2419

No conflict — verified with a trial merge (`git merge-tree`, clean). The two are complementary and neither subsumes the other: #2419 adds a `BUG_CLASS_EXCEPTIONS` passthrough *above* this branch so bug-class exceptions escape untouched, and makes a C++ `TypeError` arrive as a real `TypeError` instead of a flattened `ValueError` — it still carries the `Check failed:` tail, and this PR is what strips it. #2419 also keeps appending the IR span *after* the tail, so the strip behaves identically post-merge. Whichever lands second merges cleanly; no rebase needed.

Note for reviewers: after the fix, a `CHECK_SPAN` diagnostic still ends with an inline ` [<abs path>:<line>:<col>]`, because `FatalLogger` writes the span *before* the newline the strip keys on. Left alone deliberately — `decorator.py` raises with no `span=`, where that inline span is the user's only location, so a blanket strip would regress it. It belongs call-site side as a follow-up.

## Compatibility

No interface change. A valid kernel compiles exactly as before; only the text of an already-failing diagnostic changes.
