### PR TITLE
[experiment, do not merge] restore the pre-#2378 cross-core ring depth on A5

### DIFF
--- a/.github/actions/setup-ci-job/action.yml
+++ b/.github/actions/setup-ci-job/action.yml
@@ -80,6 +80,13 @@ inputs:
       CANN_ROOT is not required in the runner config.
     required: false
     default: 'false'
+  npu-check-timeout:
+    description: >-
+      Maximum seconds the initial npu-smi task-submit probe may wait for the
+      requested device. A5 callers override the 5-minute default because that
+      pool can stay occupied by longer on-board suites.
+    required: false
+    default: '300'
   install-toolchain:
     description: >-
       When 'true' (the default) download ptoas, clone the pinned pto-isa, and
@@ -269,7 +276,9 @@ runs:
     - name: Check NPU
       if: ${{ inputs.needs-device == 'true' }}
       shell: bash
-      run: npu-smi info
+      run: |
+        task-submit --device "$DEVICE_ID" --timeout "${{ inputs.npu-check-timeout }}" --max-time 120 \
+          --run "cd $GITHUB_WORKSPACE/${{ inputs.checkout-path }} && npu-smi info"
 
     - name: Scope ccache to pto-isa version
       # Namespace ccache by the pinned pto-isa commit so an ISA bump forces a real

--- a/.github/actions/setup-ci-job/action.yml
+++ b/.github/actions/setup-ci-job/action.yml
@@ -359,6 +359,17 @@ runs:
         # colon, which the loader would read as the current directory (the codegen
         # job never sources set_env.sh, so LD_LIBRARY_PATH is often unset here).
         printf '%s\n' 'export LD_LIBRARY_PATH="$CONDA_PREFIX/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"' >> activate.sh
+        # Keep the venv's site-packages ahead of CANN's on PYTHONPATH; the
+        # bundle step below carries the full rationale. Appended here rather
+        # than inside the heredoc above because this path sources set_env.sh
+        # AFTER the venv activate (the bundle path sources it before), and it
+        # is set_env.sh that puts CANN's site-packages on PYTHONPATH.
+        cat >> activate.sh <<'EOF'
+        _PYPTO_SITE="$(python -c 'import sysconfig; print(sysconfig.get_paths()["purelib"])' 2>/dev/null)"
+        if [ -n "$_PYPTO_SITE" ]; then
+          export PYTHONPATH="$_PYPTO_SITE${PYTHONPATH:+:$PYTHONPATH}"
+        fi
+        EOF
         # dist HCCL tests break with the runner's systemd PTO2_RING_* env; the
         # other jobs rely on it. Append the unset only when the caller asks.
         if [ "$UNSET_RING" = "true" ]; then
@@ -440,6 +451,36 @@ runs:
         # env snapshot may not carry the workspace path.
         _PYPTO_ENV_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
         source "$_PYPTO_ENV_DIR/venv/bin/activate"
+        # Put the venv's own site-packages at the FRONT of PYTHONPATH.
+        #
+        # CANN's set_env.sh (sourced above on device jobs) prepends its
+        # site-packages to PYTHONPATH, and every PYTHONPATH entry is searched
+        # before the venv's site-packages — no activation order can change
+        # that, since the venv dir is only reached via the interpreter's own
+        # site step. CANN >= 9.2.0 ships a package of its own named `pypto`
+        # there (0.2.1, pybind11-based; unrelated to this project), which
+        # otherwise shadows the one this job just built and silently turns
+        # every `import pypto` into that one. CANN 9.0.0, still on the a2a3
+        # pool, carries no such package — which is why only the npu-a5 jobs
+        # hit it.
+        #
+        # Dropping CANN's entry instead is not an option: te, tbe, te_fusion,
+        # auto_tune, schedule_search, hccl and ge all live in that same dir.
+        # In a venv purelib and platlib are one dir, so this covers the
+        # compiled extension too.
+        #
+        # Prepend unconditionally, with no "skip if already present" guard.
+        # activate.sh is sourced more than once per job — the step sources it,
+        # then the task-submit child sources it again — and each source runs
+        # set_env.sh, which prepends CANN's dir afresh. A guard that skipped on
+        # finding the venv dir anywhere would leave that new CANN copy IN FRONT
+        # of it, silently restoring the shadow it exists to prevent. Re-adding
+        # keeps the venv first every time; the duplicate entries left behind are
+        # harmless and bounded by the number of sources.
+        _PYPTO_SITE="$(python -c 'import sysconfig; print(sysconfig.get_paths()["purelib"])' 2>/dev/null)"
+        if [ -n "$_PYPTO_SITE" ]; then
+          export PYTHONPATH="$_PYPTO_SITE${PYTHONPATH:+:$PYTHONPATH}"
+        fi
         EOF
         if [ "$UNSET_RING" = "true" ]; then
           printf '%s\n' 'unset PTO2_RING_HEAP PTO2_RING_TASK_WINDOW PTO2_RING_DEP_POOL' >> activate.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1124,6 +1124,119 @@ jobs:
         with:
           checkout-path: lib-checkout
 
+  mixed-kernel-tests-a5:
+    # A5 (Ascend950) on-board coverage for MIXED KERNELS — InCore scopes holding
+    # both Cube (AIC) and Vector (AIV) work, which ExpandMixedKernel splits into
+    # an AIC + AIV pair wrapped in a Group (docs/en/dev/passes/21-expand_mixed_kernel.md).
+    # Everything else in this workflow exercises that path on a2a3 (910B) only:
+    # `system-tests*` run --platform=a2a3, and `system-tests-a5sim` runs the a5
+    # profile in the SIMULATOR. This job is the first per-PR run of the mixed /
+    # cross-core path on real A5 silicon.
+    #
+    # Scope — the two suites already validated on the a5 profile elsewhere, so a
+    # red result here means a regression and not an unvalidated combination:
+    #   - cross_core/test_cross_core.py            V<->C tpush/tpop over all three
+    #                                              split modes (UP_DOWN /
+    #                                              LEFT_RIGHT / none), multi-pipe,
+    #                                              explicit slot_num (arch-aware
+    #                                              sizing), bidirectional-in-spmd.
+    #                                              Runs on a5sim in the job below.
+    #   - test_qwen3_decode_scope3_mixed.py        the real mixed-kernel model
+    #                                              scope (out-proj + residual +
+    #                                              RMSNorm + MLP). Runs on a5 in
+    #                                              daily_ci.yml `a5-system-tests`.
+    # Deliberately NOT here: the mixed suites carrying `@pytest.mark.platforms("a2a3")`
+    # (syncall, sync_set_wait, split parity incl. split_aiv, tpush/grouped-tfree
+    # valid-shape, split-reduce parity) — pytest deselects them under --platform=a5,
+    # so listing them would only add collection noise; and test_fused_matmul_scatter.py,
+    # whose test cases hardcode `get_backend_type() -> Ascend910B`, so under
+    # --platform=a5 it would compile for 910B and run on A5 silicon. Widen this
+    # list once those are made arch-agnostic.
+    #
+    # Setup is the standard device-job shape (same composite action / env as
+    # `system-tests`), on the npu-a5 runner pool. That runner must satisfy the
+    # setup-ci-job contract for a bundle job: CI_CACHE_ROOT / CANN_ROOT +
+    # DEVICE_ID in its .env, the pypto-toolchain bundle installed, and
+    # task-submit / npu-smi / ccache / git / curl on PATH. No conda: CONDA_ROOT
+    # is read only on the conda path.
+    # Checkout / install land under ./a5-checkout so they never collide with the
+    # other jobs' trees on a shared self-hosted host.
+    #
+    # Lint gate (see the pre-commit job) — never claim an NPU slot for a tree that
+    # doesn't lint. Docs-only gate (see the `changes` job) — prose cannot break a build.
+    needs: [changes, toolchain, pre-commit, clang-tidy]
+    if: needs.changes.outputs.docs_only != 'true'
+    # Checkout + test only — no write scopes needed on GITHUB_TOKEN.
+    permissions:
+      contents: read
+    runs-on: [self-hosted, linux, arm64, npu-a5]
+    defaults:
+      run:
+        working-directory: a5-checkout
+    env:
+      PTOAS_ROOT: ${{ github.workspace }}/a5-checkout/ptoas-bin
+      PTO_ISA_ROOT: ${{ github.workspace }}/a5-checkout/pto-isa
+      PTOAS_VERSION: ${{ needs.toolchain.outputs.ptoas_version }}
+      PTOAS_SHA256: ${{ needs.toolchain.outputs.ptoas_sha256_aarch64 }}
+      CMAKE_BUILD_PARALLEL_LEVEL: 16
+      CMAKE_C_COMPILER_LAUNCHER: ccache
+      CMAKE_CXX_COMPILER_LAUNCHER: ccache
+      CCACHE_MAXSIZE: 30G
+      # Shared ci-cache/ccache dir still holds root-owned entries from the
+      # container era; keep the umask that leaves new entries mutually writable.
+      # The cache *paths* and CCACHE_NAMESPACE are derived by setup-ci-job from
+      # the runner config's CI_CACHE_ROOT.
+      CCACHE_UMASK: '000'
+    steps:
+      - name: Fetch composite action definitions
+        # Local `uses: ./.github/actions/...` resolves against $GITHUB_WORKSPACE,
+        # but this job checks the repo out into ./a5-checkout — sparse-fetch just
+        # the action defs at the workspace root first (clean: false leaves sibling
+        # subdir checkouts on this persistent runner untouched).
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github/actions
+          clean: false
+          # Bootstrap only fetches the public .github/actions tree; it doesn't
+          # need the token persisted into .git/config afterward (zizmor artipacked).
+          persist-credentials: false
+
+      - name: Setup CI job
+        uses: ./.github/actions/setup-ci-job
+        with:
+          checkout-path: a5-checkout
+          needs-device: 'true'
+          npu-check-timeout: '3600'
+          pip-cache-name: pip-a5
+          pto-isa-commit: ${{ needs.toolchain.outputs.pto_isa_commit }}
+          # Python and GCC come from the pypto-toolchain bundle, like every
+          # other self-hosted job. The npu-a5 pool is provisioned with the
+          # bundle and carries no conda env, so this is not optional here.
+          toolchain: bundle
+
+      - name: Test mixed-kernel system tests (A5, on board)
+        timeout-minutes: 60
+        # Mechanism B: one task-submit card session wrapping a single pytest run
+        # (no precompile pipeline), executed in-process on the borrowed card. Both
+        # suites are parametrized over the platform ids, so --platform=a5 selects
+        # exactly the a5 variants and deselects the a2a3-marked ones.
+        # --forked isolates each case's device init, as the daily a5 job does.
+        run: |
+          source activate.sh
+          echo "[device] DEVICE_ID=$DEVICE_ID"
+          test -n "$DEVICE_ID" || { echo "DEVICE_ID is empty in the runner env"; exit 1; }
+          task-submit --device "$DEVICE_ID" --timeout 3600 --max-time 3600 \
+            --run "cd $GITHUB_WORKSPACE/a5-checkout && source activate.sh && python -m pytest \
+              tests/st/runtime/cross_core/test_cross_core.py \
+              tests/st/runtime/framework_and_models/test_qwen3_decode_scope3_mixed.py \
+              -v --forked --platform=a5 --device=\$TASK_DEVICE"
+
+      - name: Kill orphaned task-submit tasks
+        if: always()
+        uses: ./.github/actions/kill-orphaned-tasks
+        with:
+          checkout-path: a5-checkout
+
   system-tests-a5sim:
     # Lint gate (see the pre-commit job); `toolchain` is ungated and runs
     # alongside it.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1145,6 +1145,16 @@ jobs:
     #                                              scope (out-proj + residual +
     #                                              RMSNorm + MLP). Runs on a5 in
     #                                              daily_ci.yml `a5-system-tests`.
+    # Two cross_core cases are xfail under --platform=a5 — the first on-board run
+    # of this job is what found them, and neither is a mixed-kernel regression
+    # this job should gate on until it is fixed:
+    #   - test_explicit_slot_num       ptoas rejects `local_slot_num` on
+    #                                  pto.{aic,aiv}_initialize_pipe for the 950
+    #                                  frontend pipe lowering (was already xfail
+    #                                  on a5sim; the gap is the backend, not the sim).
+    #   - test_multiple_pipes_nosplit  compiles and runs, but every output element
+    #                                  is wrong on 950 silicon; passes on a5sim.
+    # Both are xfail rather than deselected, so a backend fix surfaces as XPASS here.
     # Deliberately NOT here: the mixed suites carrying `@pytest.mark.platforms("a2a3")`
     # (syncall, sync_set_wait, split parity incl. split_aiv, tpush/grouped-tfree
     # valid-shape, split-reduce parity) — pytest deselects them under --platform=a5,

--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -34,86 +34,96 @@ jobs:
           echo "PTO_ISA_COMMIT=$commit" >> "$GITHUB_OUTPUT"
 
   a5-system-tests:
+    # Nightly A5 (Ascend950) on-board coverage. Setup is the standard device-job
+    # shape — the same composite action / env / task-submit mechanism as ci.yml
+    # `mixed-kernel-tests-a5` and the `qwen3-perf` job below — on the npu-a5
+    # runner pool. That runner must satisfy the setup-ci-job contract for a
+    # bundle job: CI_CACHE_ROOT / CANN_ROOT + DEVICE_ID in its .env, the
+    # pypto-toolchain bundle installed, and task-submit / npu-smi / ccache /
+    # git / curl on PATH. No conda: CONDA_ROOT is read only on the conda path.
+    #
+    # The card comes from the runner's DEVICE_ID rather than the old hardcoded
+    # `--device 6`, so the job schedules on any card in the pool.
+    #
+    # Checkout / install land under ./daily-a5-checkout — a dir distinct from
+    # ci.yml's ./a5-checkout, because kill-orphaned-tasks matches tasks by
+    # "$GITHUB_WORKSPACE/<checkout-path>". Sharing a dir would let one workflow's
+    # cleanup kill the other's tasks on a shared workspace root.
     needs: toolchain
-    runs-on: [self-hosted, a5-device6]
+    # Checkout + test only — no write scopes needed on GITHUB_TOKEN.
+    permissions:
+      contents: read
+    runs-on: [self-hosted, linux, arm64, npu-a5]
     defaults:
       run:
-        shell: bash -leo pipefail {0}
+        working-directory: daily-a5-checkout
     env:
-      PTOAS_ROOT: ${{ github.workspace }}/ptoas-bin
-      PTO_ISA_ROOT: ${{ github.workspace }}/pto-isa
+      PTOAS_ROOT: ${{ github.workspace }}/daily-a5-checkout/ptoas-bin
+      PTO_ISA_ROOT: ${{ github.workspace }}/daily-a5-checkout/pto-isa
       PTOAS_VERSION: ${{ needs.toolchain.outputs.ptoas_version }}
       PTOAS_SHA256: ${{ needs.toolchain.outputs.ptoas_sha256_aarch64 }}
+      CMAKE_BUILD_PARALLEL_LEVEL: 16
+      CMAKE_C_COMPILER_LAUNCHER: ccache
+      CMAKE_CXX_COMPILER_LAUNCHER: ccache
+      CCACHE_MAXSIZE: 30G
+      # Shared ci-cache/ccache dir still holds root-owned entries from the
+      # container era; keep the umask that leaves new entries mutually writable.
+      # The cache *paths* and CCACHE_NAMESPACE are derived by setup-ci-job from
+      # the runner config's CI_CACHE_ROOT.
+      CCACHE_UMASK: '000'
     steps:
-      - uses: actions/checkout@v4
+      - name: Fetch composite action definitions
+        # Local `uses: ./.github/actions/...` resolves against $GITHUB_WORKSPACE,
+        # but this job checks the repo out into ./daily-a5-checkout — sparse-fetch
+        # just the action defs at the workspace root first (clean: false leaves
+        # sibling subdir checkouts on this persistent runner untouched).
+        uses: actions/checkout@v4
         with:
-          submodules: true
+          sparse-checkout: .github/actions
+          clean: false
+          # Bootstrap only fetches the public .github/actions tree; it doesn't
+          # need the token persisted into .git/config afterward (zizmor artipacked).
+          persist-credentials: false
 
-      - name: Install project and dependencies
-        run: |
-          pip install -v .[dev]
-
-      - name: Cache ptoas environment
-        id: cache-ptoas
-        uses: actions/cache@v4
+      - name: Setup CI job
+        uses: ./.github/actions/setup-ci-job
         with:
-          path: ${{ github.workspace }}/ptoas-bin
-          key: ptoas-aarch64-${{ env.PTOAS_VERSION }}-${{ env.PTOAS_SHA256 }}
-
-      - name: Install ptoas
-        if: steps.cache-ptoas.outputs.cache-hit != 'true'
-        run: |
-          PTOAS_PACKAGE_VERSION="${PTOAS_VERSION#v}"
-          PTOAS_WHEEL_NAME="ptoas-${PTOAS_PACKAGE_VERSION}-cp310-cp310-manylinux_2_34_aarch64.whl"
-          PTOAS_WHEEL="/tmp/$PTOAS_WHEEL_NAME"
-          curl --fail --location --retry 3 --retry-all-errors \
-            "https://github.com/hw-native-sys/PTOAS/releases/download/${PTOAS_VERSION}/${PTOAS_WHEEL_NAME}" \
-            -o "$PTOAS_WHEEL"
-          echo "${PTOAS_SHA256}  $PTOAS_WHEEL" | sha256sum -c -
-          rm -rf "$PTOAS_ROOT"
-          python -m venv "$PTOAS_ROOT" --system-site-packages
-          "$PTOAS_ROOT/bin/python" -m pip install "$PTOAS_WHEEL"
-          "$PTOAS_ROOT/bin/ptoas" --version
-
-      - name: Clone pto-isa repository
-        run: |
-          timeout 60 git clone https://github.com/hw-native-sys/pto-isa.git $GITHUB_WORKSPACE/pto-isa \
-            || { rm -rf $GITHUB_WORKSPACE/pto-isa; timeout 300 git clone https://gitcode.com/luohuan40/pto-isa.git $GITHUB_WORKSPACE/pto-isa; }
-          cd $GITHUB_WORKSPACE/pto-isa
-          git checkout ${{ needs.toolchain.outputs.pto_isa_commit }}
-
-      - name: Install simpler
-        run: |
-          rm -rf ./runtime/build
-          pip install -v ./runtime
+          checkout-path: daily-a5-checkout
+          needs-device: 'true'
+          npu-check-timeout: '3600'
+          pip-cache-name: pip-daily-a5
+          pto-isa-commit: ${{ needs.toolchain.outputs.pto_isa_commit }}
+          # Python and GCC come from the pypto-toolchain bundle, like every
+          # other self-hosted job. The npu-a5 pool is provisioned with the
+          # bundle and carries no conda env, so this is not optional here.
+          toolchain: bundle
 
       - name: Run A5 system tests
-        # `cd $GITHUB_WORKSPACE` is a no-op (the child already runs from the
-        # checkout root — the relative tests/st/... paths resolve today) but it
-        # puts the workspace path into the task command so the cleanup step below
-        # can grep -F "$GITHUB_WORKSPACE" to find THIS job's task.
+        timeout-minutes: 60
+        # Mechanism B: one task-submit card session wrapping a single pytest run,
+        # executed in-process on the borrowed card. The `cd $GITHUB_WORKSPACE/
+        # daily-a5-checkout` also puts this job's checkout dir into the task
+        # command, which is how the cleanup step below finds THIS job's tasks.
         run: |
-          task-submit --timeout 3600 --max-time 1800 --device 6 \
-            --run "cd $GITHUB_WORKSPACE && pytest tests/st/runtime/ops/test_assemble.py tests/st/runtime/ops/test_gather.py tests/st/runtime/ops/test_mscatter.py tests/st/runtime/ops/test_random.py tests/st/runtime/framework_and_models/test_qwen3_decode_scope3_mixed.py tests/st/runtime/control_flow/test_dyn_orch_shape.py::TestDynOrchShapeOperations::test_dyn_orch_paged_attention -v --forked --platform=a5 --device=6 \
+          source activate.sh
+          echo "[device] DEVICE_ID=$DEVICE_ID"
+          test -n "$DEVICE_ID" || { echo "DEVICE_ID is empty in the runner env"; exit 1; }
+          task-submit --device "$DEVICE_ID" --timeout 3600 --max-time 3600 \
+            --run "cd $GITHUB_WORKSPACE/daily-a5-checkout && source activate.sh && python -m pytest \
+              tests/st/runtime/ops/test_assemble.py \
+              tests/st/runtime/ops/test_gather.py \
+              tests/st/runtime/ops/test_mscatter.py \
+              tests/st/runtime/ops/test_random.py \
+              tests/st/runtime/framework_and_models/test_qwen3_decode_scope3_mixed.py \
+              tests/st/runtime/control_flow/test_dyn_orch_shape.py::TestDynOrchShapeOperations::test_dyn_orch_paged_attention \
+              -v --forked --platform=a5 --device=\$TASK_DEVICE \
               -k 'not (test_tile_row_expand or test_fillpad_zero or test_fillpad_max or test_fillpad_min or TestMscatter)'"
 
       - name: Kill orphaned task-submit tasks
-        # If this job is cancelled or killed mid-flight, the task-submit task it
-        # submitted keeps running server-side (detached) and holds device 6 until
-        # --max-time. always() runs even on cancellation; match by this job's
-        # workspace path (embedded in the --run above) so we never touch another
-        # job's tasks.
         if: always()
-        run: |
-          echo "cleaning up task-submit tasks for $GITHUB_WORKSPACE"
-          task-submit --list 2>/dev/null \
-            | grep -F "$GITHUB_WORKSPACE" \
-            | grep -oE 'task_[0-9_]+' \
-            | sort -u \
-            | while read -r tid; do
-                echo "  killing $tid"
-                task-submit --kill "$tid" || true
-              done || true
+        uses: ./.github/actions/kill-orphaned-tasks
+        with:
+          checkout-path: daily-a5-checkout
 
   qwen3-perf:
     # Qwen3-14B decode performance monitoring (moved out of per-PR ci.yml).

--- a/docs/en/dev/passes/21-expand_mixed_kernel.md
+++ b/docs/en/dev/passes/21-expand_mixed_kernel.md
@@ -192,6 +192,11 @@ normalises to that form.
 > (`local_slot_num < slot_num`, an a2/a3-only optimisation) is not yet exposed
 > on the automatic split path — use the manual `pl.aic_initialize_pipe` /
 > `pl.aiv_initialize_pipe` system ops for that.
+>
+> That manual route is a2/a3-only too, and not just for `local_slot_num <
+> slot_num`: ptoas rejects the `local_slot_num` operand on
+> `pto.{aic,aiv}_initialize_pipe` for the 950 frontend pipe lowering whatever
+> its value, so on a5 the operand must be omitted entirely.
 
 For consumer-side cross-core tiles, the pass also ensures each `tile.tpop_*` has a matching
 `system.tfree_*`. When an existing free is obviously too early, the pass delays it to a later statement in the same

--- a/docs/zh/dev/passes/21-expand_mixed_kernel.md
+++ b/docs/zh/dev/passes/21-expand_mixed_kernel.md
@@ -157,6 +157,10 @@ scope：完全没有 split 的内核同样会驱动一条（a2a3 上通过双 AI
 > 将逻辑环深与更小的本地驻留窗口解耦（`local_slot_num < slot_num`，仅 a2/a3 的
 > 优化）目前尚未在自动拆分路径暴露——如需该能力请使用手动的
 > `pl.aic_initialize_pipe` / `pl.aiv_initialize_pipe` 系统算子。
+>
+> 该手动路径同样仅限 a2/a3，且不只限于 `local_slot_num < slot_num` 的情形：
+> 950 前端 pipe lowering 下，ptoas 会拒绝 `pto.{aic,aiv}_initialize_pipe` 上的
+> `local_slot_num` 操作数（无论取值为何），因此在 a5 上必须完全省略该操作数。
 
 对于消费侧跨核 tile，该 Pass 还会保证每个 `tile.tpop_*` 都有匹配的
 `system.tfree_*`。若现有 `tfree` 明显过早，Pass 会在不重排彼此独立 `tpop`

--- a/src/ir/transforms/utils/cross_core_pipe.cpp
+++ b/src/ir/transforms/utils/cross_core_pipe.cpp
@@ -294,7 +294,10 @@ AutomaticPipeSetup BuildAutomaticPipeSetup(const std::string& func_name, const s
     INTERNAL_CHECK_SPAN(slot_num_override.value() > 0, span)
         << "Cross-core slot_num override must be positive: " << slot_num_override.value();
   }
-  const int effective_slot_num = slot_num_override.value_or(kDefaultAutoPipeSlotNum);
+  // EXPERIMENT (do not merge): restore the pre-#2378 ring depth (PTOAS's own
+  // dir_mask derivation, 8 unidirectional / 4 bidirectional) to test whether the
+  // shallow 2-slot default is what stalls the A5 mixed kernel on board.
+  const int effective_slot_num = slot_num_override.value_or(GetPtoasImplicitSlotNum(dir_mask));
   // Bound-check the slot size before multiplying so an oversized inferred size
   // can't overflow the int64 buffer_size computation.
   const int64_t slot_size_i64 = common_slot_size.value();

--- a/tests/st/runtime/cross_core/test_cross_core.py
+++ b/tests/st/runtime/cross_core/test_cross_core.py
@@ -50,6 +50,9 @@ MULTI_PIPE_BUFFER_SIZE = MULTI_PIPE_SLOT_SIZE * 8
 # pins the local slot count. Reserve-buffer size is arch-dependent:
 #   a3 -> slot_size * local_slot_num ; a5 -> slot_size * slot_num.
 # Keeping local_slot_num == slot_num makes a single buffer size correct on both.
+# NOTE: a5 does not accept the operand at all -- ptoas rejects `local_slot_num`
+# on pto.{aic,aiv}_initialize_pipe regardless of its value, so this case is
+# a2/a3-only in practice; see the xfail on test_explicit_slot_num.
 SLOTNUM_DIM = 16
 SLOTNUM_SLOT_SIZE = SLOTNUM_DIM * SLOTNUM_DIM * 4
 SLOTNUM_SLOT_NUM = 4
@@ -925,15 +928,24 @@ class TestCrossCore:
         result = test_runner.run(BidirectSpmdNoSplitTest(backend_type=backend_type))
         assert result.passed, f"Cross-core bidirect spmd no-split failed: {result.error}"
 
-    def test_multiple_pipes_nosplit(self, test_runner, backend_type):
+    def test_multiple_pipes_nosplit(self, test_runner, backend_type, platform):
         """Explicit multiple pipe ids: compile through full pipeline and verify correctness."""
+        if platform == "a5":
+            # Compiles and runs, but every output element is wrong on 950
+            # silicon -- and only there: the same case passes under a5sim, so
+            # the simulator does not model whatever the two concurrent pipes
+            # hit on board. Kept xfail (not skip) so a fix shows up as XPASS.
+            pytest.xfail("950 board: explicit multi-pipe produces wrong results (passes on a5sim)")
         result = test_runner.run(MultiPipeNoSplitTest(backend_type=backend_type))
         assert result.passed, f"Cross-core explicit multi-pipe no-split failed: {result.error}"
 
     def test_explicit_slot_num(self, test_runner, backend_type, platform):
         """Explicit slot_num / local_slot_num: compile through full pipeline and verify correctness."""
-        if platform == "a5sim":
-            pytest.xfail("950 backend explicit slot_num pipe not yet validated on sim")
+        if platform in ("a5sim", "a5"):
+            # Not a sim-only gap: ptoas rejects the `local_slot_num` operand on
+            # pto.{aic,aiv}_initialize_pipe for the 950 frontend pipe lowering,
+            # so this never reaches the device on either a5 target.
+            pytest.xfail("950 backend: ptoas rejects local_slot_num on {aic,aiv}_initialize_pipe")
         result = test_runner.run(ExplicitSlotNumTest(backend_type=backend_type))
         assert result.passed, f"Cross-core explicit slot_num failed: {result.error}"
 


### PR DESCRIPTION
Throwaway branch. **Do not merge, do not review** — its only purpose is to run `mixed-kernel-tests-a5` once on real 950 silicon. It will be closed and the branch deleted as soon as that job reports.

## What this probes

`test_qwen3_decode_scope3_mixed[a5]` passes on board at `main@71020585` and stalls 3/3 at `main >= 49ed7797` — scheduler timeout, `S1:running-stalled`, always inside the `oproj_block` mixed kernel, at a different task index and core each run (37/core 2, 32/core 1, 28/core 2).

Comparing the A5 device kernels compiled from those two bases, the only semantic difference is #2378: `oproj_block`'s C2V ring went 8 → 2 slots, `mlp_block`'s bidirectional rings 4 → 2. Every kernel without a cross-core pipe is byte-identical, and the orchestration differs only by the runtime type renames from #2273.

This commit puts the ring depth back on PTOAS's own `dir_mask` derivation (8 unidirectional / 4 bidirectional), reproducing the last-known-good device configuration exactly — the generated `TPipe<>` template arguments and every `.pto` match `main@71020585`, apart from `slot_num` now being stated explicitly instead of left implicit.

- **`mixed-kernel-tests-a5` green** → #2378 is the trigger; the real fix is tracked separately.
- **`mixed-kernel-tests-a5` red** → the search moves to the Simpler / PTO-ISA bump in #2273.

## Expected reds

The unit tests that pin the 2-slot default are deliberately untouched, so `unit-tests` and `codegen-tests` will fail here. Neither gates `mixed-kernel-tests-a5` (`needs: [changes, toolchain, pre-commit, clang-tidy]`).