### PR TITLE
fix(ir): compute descending loop trip counts correctly

### DIFF
--- a/docs/en/dev/passes/45-classify_iter_arg_carry.md
+++ b/docs/en/dev/passes/45-classify_iter_arg_carry.md
@@ -104,6 +104,12 @@ must have a statically-known trip count. ...
 
 The diagnostic surfaces during this pass, before codegen runs.
 
+"Statically-known" is about the *bounds*, not the direction: `ForStmt::step_`
+carries no sign restriction, so a descending loop such as `pl.parallel(4, 0, -1)`
+has a constant trip count of 4 and is sized exactly like `pl.parallel(4)`. Only a
+loop with a genuinely non-constant bound (`pl.parallel(n)` for a `Scalar` `n`)
+raises the error above.
+
 ## Pass properties
 
 | - | Properties |

--- a/docs/zh/dev/passes/45-classify_iter_arg_carry.md
+++ b/docs/zh/dev/passes/45-classify_iter_arg_carry.md
@@ -97,6 +97,11 @@ must have a statically-known trip count. ...
 
 该诊断在本 pass 阶段抛出，早于 codegen。
 
+“静态可知”指的是*边界*而非方向：`ForStmt::step_` 没有符号限制，因此像
+`pl.parallel(4, 0, -1)` 这样的递减循环 trip count 同样是常量 4，其定长数组的大小与
+`pl.parallel(4)` 完全一致。只有边界本身非常量（例如 `n` 为 `Scalar` 的
+`pl.parallel(n)`）才会触发上面的报错。
+
 ## Pass 属性
 
 | - | 属性 |

--- a/include/pypto/codegen/orchestration/orchestration_analysis.h
+++ b/include/pypto/codegen/orchestration/orchestration_analysis.h
@@ -67,10 +67,12 @@ inline std::optional<int64_t> EvalConstInt(const ir::ExprPtr& expr) {
   return ir::transform_utils::EvalConstInt(expr);
 }
 /// Return the const trip count of ``for_stmt`` if start/stop/step are all
-/// ``ConstInt`` and step is positive; 0 otherwise. Thin forward to
-/// ``ir::transform_utils::EvalConstTripCount``.
+/// compile-time integers; 0 otherwise. Direction-aware — a descending loop
+/// reports its true trip count. Thin forward to
+/// ``ir::transform_utils::EvalConstTripCount``, collapsing its "not a
+/// compile-time constant" case onto 0 for callers that only threshold-compare.
 inline int64_t EvalConstTripCount(const ir::ForStmtPtr& for_stmt) {
-  return ir::transform_utils::EvalConstTripCount(for_stmt);
+  return ir::transform_utils::EvalConstTripCount(for_stmt).value_or(0);
 }
 
 /// Compute total GM-pipe workspace elements required by a root orchestration

--- a/include/pypto/ir/transforms/utils/scope_outline_utils.h
+++ b/include/pypto/ir/transforms/utils/scope_outline_utils.h
@@ -235,7 +235,7 @@ class DeferredWaitContractValidator {
       // needs no statically known trip count. Returning before the arithmetic
       // below also keeps `trip_count` out of the divisor when it is unknown.
       if (!body_result.has_deferred_wait) return body_result;
-      auto trip_count = transform_utils::EvalConstTripCount(loop);
+      auto trip_count = transform_utils::EvalConstTripCount(loop).value_or(0);
       CHECK_SPAN(trip_count > 0, stmt->span_)
           << "deferred waiter registration loop must have a statically known positive trip count "
              "so the per-waiter condition budget can be proved";

--- a/include/pypto/ir/transforms/utils/transform_utils.h
+++ b/include/pypto/ir/transforms/utils/transform_utils.h
@@ -148,21 +148,48 @@ inline CallPtr AsCallOrSubmitView(const ExprPtr& expr) {
   return nullptr;
 }
 
-/// Constant-evaluate @p expr if it is a ``ConstInt``; ``nullopt`` otherwise.
+/// Constant-evaluate @p expr if it is a ``ConstInt``, or a ``Neg`` of one;
+/// ``nullopt`` otherwise.
+///
+/// The ``Neg`` case matters for negative literals: the DSL parser folds
+/// ``-1`` to ``ConstInt(-1)`` and ``Simplify`` const-folds ``Neg`` as well, but
+/// IR built through the builder API or parsed from ``.pto`` before the first
+/// ``Simplify`` can still carry ``Neg(ConstInt(1))``. Peeking through it keeps
+/// constant detection independent of how far the pipeline has run.
 inline std::optional<int64_t> EvalConstInt(const ExprPtr& expr) {
   if (auto ci = As<ConstInt>(expr)) return ci->value_;
+  if (auto neg = As<Neg>(expr)) {
+    if (auto inner = As<ConstInt>(neg->operand_)) return -inner->value_;
+  }
   return std::nullopt;
 }
 
+/// Trip count of a loop with compile-time bounds @p start / @p stop / @p step.
+///
+/// Direction-aware: handles ascending (``step > 0``) and descending
+/// (``step < 0``) loops alike, and returns 0 for an empty or zero-step loop.
+/// ``ForStmt::step_`` carries no sign restriction, and ``pl.range(64, 0, -1)``
+/// is valid DSL, so a positive-step-only formula silently mis-answers a loop
+/// whose trip count is perfectly well-defined.
+inline int64_t ComputeStaticTripCount(int64_t start, int64_t stop, int64_t step) {
+  if (step > 0 && start < stop) return (stop - start + step - 1) / step;
+  if (step < 0 && start > stop) return (start - stop + (-step) - 1) / (-step);
+  return 0;
+}
+
 /// Return the const trip count of @p for_stmt when start/stop/step are all
-/// ``ConstInt`` and step is positive; 0 otherwise.
-inline int64_t EvalConstTripCount(const ForStmtPtr& for_stmt) {
+/// compile-time integers; ``nullopt`` when any bound is not.
+///
+/// The optional is load-bearing: "the bounds are not compile-time constants"
+/// and "the loop provably runs zero times" are different propositions, and
+/// callers that fall back to a dynamic path must not conflate them. Callers
+/// that only threshold-compare can use ``.value_or(0)``.
+inline std::optional<int64_t> EvalConstTripCount(const ForStmtPtr& for_stmt) {
   auto start = EvalConstInt(for_stmt->start_);
   auto stop = EvalConstInt(for_stmt->stop_);
   auto step = EvalConstInt(for_stmt->step_);
-  if (!start || !stop || !step || *step <= 0) return 0;
-  int64_t trip = (*stop - *start + *step - 1) / *step;
-  return trip > 0 ? trip : 0;
+  if (!start || !stop || !step) return std::nullopt;
+  return ComputeStaticTripCount(*start, *stop, *step);
 }
 
 /// Peek through a leading compiler-inserted ``RuntimeScopeStmt`` so structural

--- a/include/pypto/ir/transforms/utils/transform_utils.h
+++ b/include/pypto/ir/transforms/utils/transform_utils.h
@@ -14,6 +14,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <limits>
 #include <optional>
 #include <string>
 #include <unordered_map>
@@ -159,7 +160,13 @@ inline CallPtr AsCallOrSubmitView(const ExprPtr& expr) {
 inline std::optional<int64_t> EvalConstInt(const ExprPtr& expr) {
   if (auto ci = As<ConstInt>(expr)) return ci->value_;
   if (auto neg = As<Neg>(expr)) {
-    if (auto inner = As<ConstInt>(neg->operand_)) return -inner->value_;
+    if (auto inner = As<ConstInt>(neg->operand_)) {
+      // -INT64_MIN is not representable; negating it is UB. No such literal can
+      // be a meaningful loop bound, so report "not a constant" rather than
+      // inventing a value.
+      if (inner->value_ == std::numeric_limits<int64_t>::min()) return std::nullopt;
+      return -inner->value_;
+    }
   }
   return std::nullopt;
 }
@@ -171,10 +178,29 @@ inline std::optional<int64_t> EvalConstInt(const ExprPtr& expr) {
 /// ``ForStmt::step_`` carries no sign restriction, and ``pl.range(64, 0, -1)``
 /// is valid DSL, so a positive-step-only formula silently mis-answers a loop
 /// whose trip count is perfectly well-defined.
+///
+/// The span and the step magnitude are computed in ``uint64_t``. Signed
+/// arithmetic would be UB at the edges of the range — ``stop - start``
+/// overflows for a full-width span, and ``-step`` overflows at ``INT64_MIN`` —
+/// and UB here would silently corrupt a carry-array size. Unsigned wraparound
+/// is defined and yields the exact magnitude in both directions. A trip count
+/// that does not fit in ``int64_t`` saturates: every caller uses this as a size
+/// or a threshold, so saturating is safe where wrapping negative is not.
 inline int64_t ComputeStaticTripCount(int64_t start, int64_t stop, int64_t step) {
-  if (step > 0 && start < stop) return (stop - start + step - 1) / step;
-  if (step < 0 && start > stop) return (start - stop + (-step) - 1) / (-step);
-  return 0;
+  const bool ascending = step > 0 && start < stop;
+  const bool descending = step < 0 && start > stop;
+  if (!ascending && !descending) return 0;
+
+  const auto ustart = static_cast<uint64_t>(start);
+  const auto ustop = static_cast<uint64_t>(stop);
+  const auto ustep = static_cast<uint64_t>(step);
+  // Magnitudes: defined under unsigned wraparound even at the range edges.
+  const uint64_t span = ascending ? ustop - ustart : ustart - ustop;
+  const uint64_t magnitude = ascending ? ustep : (0U - ustep);
+
+  const uint64_t trips = (span + magnitude - 1) / magnitude;
+  constexpr auto kMax = static_cast<uint64_t>(std::numeric_limits<int64_t>::max());
+  return static_cast<int64_t>(trips > kMax ? kMax : trips);
 }
 
 /// Return the const trip count of @p for_stmt when start/stop/step are all

--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -1605,16 +1605,28 @@ class OrchestrationStmtCodegen : public CodegenBase {
   /// hard-coded ``i < stop`` silently compiles a descending loop into zero
   /// iterations. When the step is a compile-time constant its sign picks the
   /// operator directly, which keeps the overwhelmingly common ascending case
-  /// emitting exactly the same text as before; a runtime step falls back to a
-  /// sign test evaluated per iteration.
+  /// emitting exactly the same text as before.
+  ///
+  /// A zero step must yield zero iterations, matching
+  /// ``transform_utils::ComputeStaticTripCount``. Letting it pick either
+  /// comparison emits ``i += 0`` under a condition that can hold, i.e. a loop
+  /// that never terminates. So the constant case tests the sign three ways, and
+  /// the runtime case requires a non-zero step in *both* direction branches
+  /// rather than treating "not positive" as "negative".
   void EmitForLoopHeader(const std::string& loop_var, const std::string& start_expr,
                          const std::string& stop_expr, const std::string& step_expr, const ExprPtr& step) {
     std::string cond;
     if (auto const_step = transform_utils::EvalConstInt(step)) {
-      cond = loop_var + (*const_step < 0 ? " > " : " < ") + stop_expr;
+      if (*const_step > 0) {
+        cond = loop_var + " < " + stop_expr;
+      } else if (*const_step < 0) {
+        cond = loop_var + " > " + stop_expr;
+      } else {
+        cond = "false";
+      }
     } else {
-      cond = "((" + step_expr + ") > 0 ? " + loop_var + " < " + stop_expr + " : " + loop_var + " > " +
-             stop_expr + ")";
+      cond = "(((" + step_expr + ") > 0 && " + loop_var + " < " + stop_expr + ") || ((" + step_expr +
+             ") < 0 && " + loop_var + " > " + stop_expr + "))";
     }
     EmitIndentedLine("for (int64_t " + loop_var + " = " + start_expr + "; " + cond + "; " + loop_var +
                      " += " + step_expr + ") {");

--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -884,10 +884,22 @@ class OrchestrationStmtCodegen : public CodegenBase {
           collection.data_name = ReserveSyntheticEmitName("dynamic_compiler_dep_tids");
           collection.count_name = ReserveSyntheticEmitName(collection.data_name + "_count");
           const std::string capacity_name = ReserveSyntheticEmitName(collection.data_name + "_capacity");
-          EmitIndentedLine("const int64_t " + capacity_name + " = ((((" + step_expr + ") > 0 && (" +
-                           stop_expr + ") > (" + start_expr + ")) ? (((" + stop_expr + ") - (" + start_expr +
-                           ") + (" + step_expr + ") - 1) / (" + step_expr + ")) : 0) * " +
-                           std::to_string(dynamic_compiler_dep_slots_per_iter) + ");");
+          // Bind the bounds to locals first: each appears several times in the
+          // trip-count expression, and the loop may descend, so the emitted
+          // formula needs both branches. Mirrors
+          // ``transform_utils::ComputeStaticTripCount`` — keep the two in sync.
+          const std::string cap_start = ReserveSyntheticEmitName(capacity_name + "_start");
+          const std::string cap_stop = ReserveSyntheticEmitName(capacity_name + "_stop");
+          const std::string cap_step = ReserveSyntheticEmitName(capacity_name + "_step");
+          EmitIndentedLine("const int64_t " + cap_start + " = " + start_expr + ";");
+          EmitIndentedLine("const int64_t " + cap_stop + " = " + stop_expr + ";");
+          EmitIndentedLine("const int64_t " + cap_step + " = " + step_expr + ";");
+          EmitIndentedLine("const int64_t " + capacity_name + " = ((" + cap_step + " > 0 && " + cap_start +
+                           " < " + cap_stop + ") ? ((" + cap_stop + " - " + cap_start + " + " + cap_step +
+                           " - 1) / " + cap_step + ") : (" + cap_step + " < 0 && " + cap_start + " > " +
+                           cap_stop + ") ? ((" + cap_start + " - " + cap_stop + " + (-" + cap_step +
+                           ") - 1) / (-" + cap_step + ")) : 0) * " +
+                           std::to_string(dynamic_compiler_dep_slots_per_iter) + ";");
           const std::string profile_start_name =
               ReserveSyntheticEmitName(collection.data_name + "_profile_start");
           EmitIndentedLine("#if SIMPLER_ORCH_PROFILING");
@@ -917,7 +929,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
       manual_task_id_map_by_key_[TaskIdHoistKey(edge)] = barrier_tid;
     }
 
-    EmitForLoopHeader(loop_var, start_expr, stop_expr, step_expr);
+    EmitForLoopHeader(loop_var, start_expr, stop_expr, step_expr, for_stmt->step_);
     {
       IndentGuard indent_guard(Active());
       PushCppScope();
@@ -1586,10 +1598,26 @@ class OrchestrationStmtCodegen : public CodegenBase {
 
   void EmitBlankLine() { Active().EmitLine(""); }
 
+  /// Emit the C++ ``for`` header for a ForStmt.
+  ///
+  /// The continuation test depends on the sign of the step: ``ForStmt::step_``
+  /// carries no sign restriction and ``pl.range(64, 0, -1)`` is valid DSL, so a
+  /// hard-coded ``i < stop`` silently compiles a descending loop into zero
+  /// iterations. When the step is a compile-time constant its sign picks the
+  /// operator directly, which keeps the overwhelmingly common ascending case
+  /// emitting exactly the same text as before; a runtime step falls back to a
+  /// sign test evaluated per iteration.
   void EmitForLoopHeader(const std::string& loop_var, const std::string& start_expr,
-                         const std::string& stop_expr, const std::string& step_expr) {
-    EmitIndentedLine("for (int64_t " + loop_var + " = " + start_expr + "; " + loop_var + " < " + stop_expr +
-                     "; " + loop_var + " += " + step_expr + ") {");
+                         const std::string& stop_expr, const std::string& step_expr, const ExprPtr& step) {
+    std::string cond;
+    if (auto const_step = transform_utils::EvalConstInt(step)) {
+      cond = loop_var + (*const_step < 0 ? " > " : " < ") + stop_expr;
+    } else {
+      cond = "((" + step_expr + ") > 0 ? " + loop_var + " < " + stop_expr + " : " + loop_var + " > " +
+             stop_expr + ")";
+    }
+    EmitIndentedLine("for (int64_t " + loop_var + " = " + start_expr + "; " + cond + "; " + loop_var +
+                     " += " + step_expr + ") {");
   }
 
   void EmitArrayCopyLoop(int64_t extent, const std::string& dst_array, const std::string& src_array,

--- a/src/codegen/pto/pto_control_flow_codegen.cpp
+++ b/src/codegen/pto/pto_control_flow_codegen.cpp
@@ -24,6 +24,7 @@
 #include "pypto/ir/scalar_expr.h"
 #include "pypto/ir/stmt.h"
 #include "pypto/ir/transforms/utils/memref_utils.h"
+#include "pypto/ir/transforms/utils/transform_utils.h"
 #include "pypto/ir/type.h"
 
 namespace pypto {
@@ -531,6 +532,39 @@ void PTOCodegen::VisitStmt_(const ForStmtPtr& op) {
       << "Internal error: ForKind::Pipeline reached codegen — LowerPipelineLoops "
       << "and CanonicalizeIOOrder should have demoted it to Sequential. "
       << "The pipeline is incomplete.";
+
+  // Device loops lower to MLIR ``scf.for``, which iterates lower -> upper bound
+  // and is defined for a positive step only. A descending ``ForStmt`` has no
+  // faithful lowering: emitting it verbatim yields a zero-trip ``scf.for`` that
+  // the assembler folds away, silently discarding the loop body. Surface it as
+  // a user-facing limitation instead of miscompiling.
+  //
+  // Tracking: ptoas issue hw-native-sys/PTOAS#1288 — ptoas does not enforce
+  // ``scf.for``'s "constant step operand must be positive" verifier invariant
+  // (a negative step drops the body, a zero step emits ``i += 0``). How that
+  // issue is resolved decides this check's fate:
+  //
+  //   * ptoas gains descending-loop support (normalizing lb -> ub with a
+  //     derived induction variable) — delete this check, the lowering above
+  //     becomes correct as-is.
+  //   * ptoas only adds the verifier rejection — KEEP this check. It still
+  //     earns its place by failing earlier, naming the user's loop via the
+  //     ``Span``, and telling them how to rewrite it, rather than surfacing an
+  //     assembler error against generated ``.pto`` the user never wrote.
+  //
+  // Only a compile-time step is checked. A runtime step that turns out negative
+  // still lowers to the same ill-defined ``scf.for``; proving its sign needs the
+  // arith analyzer and is left for the normalizing rewrite that would lift this
+  // restriction altogether. Orchestration functions emit C++ directly and are
+  // unaffected — they support descending loops natively.
+  if (auto const_step = ir::transform_utils::EvalConstInt(op->step_)) {
+    CHECK_SPAN(*const_step > 0, op->span_)
+        << "loops in device functions must have a positive step, but this loop steps by " << *const_step
+        << ". Device code lowers to MLIR 'scf.for', which only counts upward. "
+           "Rewrite the loop in ascending form and invert the index in the body — "
+           "replace 'for i in pl.range(64, 0, -1)' with 'for t in pl.range(0, 64)' plus "
+           "'i = 64 - t'. Orchestration functions support descending loops directly.";
+  }
 
   // Evaluate loop bounds and ensure they are index-typed for scf.for.
   // EmitCastToIndex is a no-op when the bound is already DataType::INDEX

--- a/src/codegen/pto/pto_control_flow_codegen.cpp
+++ b/src/codegen/pto/pto_control_flow_codegen.cpp
@@ -539,23 +539,24 @@ void PTOCodegen::VisitStmt_(const ForStmtPtr& op) {
   // the assembler folds away, silently discarding the loop body. Surface it as
   // a user-facing limitation instead of miscompiling.
   //
-  // Tracking: ptoas issue hw-native-sys/PTOAS#1288 — ptoas does not enforce
-  // ``scf.for``'s "constant step operand must be positive" verifier invariant
-  // (a negative step drops the body, a zero step emits ``i += 0``). How that
-  // issue is resolved decides this check's fate:
+  // This check is permanent, not a workaround pending an assembler fix. The
+  // PTOAS team has confirmed they will not support a non-positive ``scf.for``
+  // step in the foreseeable future; hw-native-sys/PTOAS#1288 will be closed by
+  // adding the missing assertion only (today ptoas silently accepts such a
+  // step — a negative one drops the body, a zero one emits ``i += 0``). So a
+  // descending device loop stays unrepresentable, and this check is the only
+  // thing standing between the user and a silently empty kernel.
   //
-  //   * ptoas gains descending-loop support (normalizing lb -> ub with a
-  //     derived induction variable) — delete this check, the lowering above
-  //     becomes correct as-is.
-  //   * ptoas only adds the verifier rejection — KEEP this check. It still
-  //     earns its place by failing earlier, naming the user's loop via the
-  //     ``Span``, and telling them how to rewrite it, rather than surfacing an
-  //     assembler error against generated ``.pto`` the user never wrote.
+  // Keep it even once that assertion ships: it fires earlier, names the user's
+  // loop through the ``Span``, and says how to rewrite it, whereas the
+  // assembler can only report against generated ``.pto`` the user never wrote.
   //
   // Only a compile-time step is checked. A runtime step that turns out negative
   // still lowers to the same ill-defined ``scf.for``; proving its sign needs the
-  // arith analyzer and is left for the normalizing rewrite that would lift this
-  // restriction altogether. Orchestration functions emit C++ directly and are
+  // arith analyzer. Closing that gap would mean normalizing descending loops to
+  // ascending form here (deriving the induction variable from an ascending
+  // counter), which is the only route to supporting them at all now that the
+  // assembler will not. Orchestration functions emit C++ directly and are
   // unaffected — they support descending loops natively.
   if (auto const_step = ir::transform_utils::EvalConstInt(op->step_)) {
     CHECK_SPAN(*const_step > 0, op->span_)

--- a/src/ir/transforms/auto_tile_matmul_l0_pass.cpp
+++ b/src/ir/transforms/auto_tile_matmul_l0_pass.cpp
@@ -2515,7 +2515,7 @@ bool IsPipelineAccumulatorProfitable(const PipelineAccumulatorCandidate& candida
 std::optional<PipelineAccumulatorCandidate> AnalyzePipelineAccumulator(
     const ForStmtPtr& loop, const MemoryAllocatorPolicy& policy, const backend::BackendHandler* handler) {
   const int stages = loop ? loop->GetAttr<int>(kPipelineStagesAttr, 0) : 0;
-  const int64_t trip_count = loop ? transform_utils::EvalConstTripCount(loop) : -1;
+  const int64_t trip_count = loop ? transform_utils::EvalConstTripCount(loop).value_or(0) : -1;
   if (!loop || loop->kind_ != ForKind::Pipeline || loop->HasAttr(kPipelineOverlapStoresAttr) ||
       loop->HasAttr(kPipelineDoubleBufferCAttr) || stages < 2 || trip_count < stages ||
       trip_count % stages != 0) {

--- a/src/ir/transforms/classify_iter_arg_carry_pass.cpp
+++ b/src/ir/transforms/classify_iter_arg_carry_pass.cpp
@@ -282,7 +282,7 @@ int64_t ResolveArrayCarrySize(const ForStmtPtr& for_stmt, size_t idx) {
   if (idx >= for_stmt->iter_args_.size()) return 0;
   if (!IsTaskIdScalar(for_stmt->iter_args_[idx])) return 0;
   if (for_stmt->kind_ == ForKind::Parallel) {
-    return transform_utils::EvalConstTripCount(for_stmt);
+    return transform_utils::EvalConstTripCount(for_stmt).value_or(0);
   }
   if (for_stmt->kind_ != ForKind::Sequential) return 0;
   auto yield = transform_utils::GetLastYieldStmt(transform_utils::UnwrapAutoScope(for_stmt->body_));

--- a/src/ir/transforms/expand_manual_phase_fence_pass.cpp
+++ b/src/ir/transforms/expand_manual_phase_fence_pass.cpp
@@ -34,6 +34,7 @@
 #include "pypto/ir/transforms/base/visitor.h"
 #include "pypto/ir/transforms/pass_properties.h"
 #include "pypto/ir/transforms/passes.h"
+#include "pypto/ir/transforms/utils/transform_utils.h"
 #include "pypto/ir/type.h"
 
 namespace pypto {
@@ -66,28 +67,9 @@ struct LoopBodyDepIndex {
   std::unordered_set<const Var*> updated_arrays;
 };
 
-struct TripCountInfo {
-  bool known = false;
-  int64_t count = 0;
-};
-
 using ArrayAliasSet = std::unordered_set<const Var*>;
 using ArrayAliasMap = std::unordered_map<const Var*, std::shared_ptr<ArrayAliasSet>>;
 using NestedLoopSummaryCollector = std::function<void(const ForStmtPtr&, LoopBodyDepIndex*, bool)>;
-
-static std::optional<int64_t> EvalConstInt(const ExprPtr& expr) {
-  if (auto ci = As<ConstInt>(expr)) return ci->value_;
-  return std::nullopt;
-}
-
-static TripCountInfo EvalConstTripCount(const ForStmtPtr& for_stmt) {
-  auto start = EvalConstInt(for_stmt->start_);
-  auto stop = EvalConstInt(for_stmt->stop_);
-  auto step = EvalConstInt(for_stmt->step_);
-  if (!start || !stop || !step || *step <= 0) return TripCountInfo{};
-  int64_t trip = (*stop - *start + *step - 1) / *step;
-  return TripCountInfo{true, trip > 0 ? trip : 0};
-}
 
 static bool IsTaskIdArrayVar(const VarPtr& var) {
   if (!var) return false;
@@ -367,12 +349,12 @@ class ManualPhaseFenceMutator : public IRMutator {
     const auto& summary = GetLoopSummary(for_stmt);
     MergeLoopSafetyInfo(index, summary);
     if (!include_consumers) return;
-    const auto trip_count = EvalConstTripCount(for_stmt);
-    if (!trip_count.known || trip_count.count <= 0) return;
+    const auto trip_count = transform_utils::EvalConstTripCount(for_stmt);
+    if (trip_count.value_or(0) <= 0) return;
     for (const Var* key : summary.dep_array_order) {
       auto it = summary.dep_arrays.find(key);
       if (it == summary.dep_arrays.end()) continue;
-      MergeDepArrayInfo(index, key, it->second, trip_count.count);
+      MergeDepArrayInfo(index, key, it->second, *trip_count);
     }
   }
 
@@ -418,9 +400,10 @@ class ManualPhaseFenceMutator : public IRMutator {
     };
 
     const bool is_parallel = for_stmt->kind_ == ForKind::Parallel;
-    const auto trip_count = EvalConstTripCount(for_stmt);
-    if (is_parallel && (!trip_count.known || trip_count.count <= 0)) return decisions;
-    if (for_stmt->kind_ == ForKind::Sequential && trip_count.known && trip_count.count <= 0) return decisions;
+    const auto trip_count = transform_utils::EvalConstTripCount(for_stmt);
+    if (is_parallel && trip_count.value_or(0) <= 0) return decisions;
+    if (for_stmt->kind_ == ForKind::Sequential && trip_count.has_value() && *trip_count <= 0)
+      return decisions;
 
     for (const auto& iter_arg : for_stmt->iter_args_) {
       if (iter_arg) current_iter_args.insert(iter_arg.get());
@@ -437,7 +420,7 @@ class ManualPhaseFenceMutator : public IRMutator {
         continue;
       }
       int64_t consumers = info.consumer_count;
-      if (trip_count.known && trip_count.count > 0) consumers *= trip_count.count;
+      if (trip_count.value_or(0) > 0) consumers *= *trip_count;
       try_add(dep_array, dep_array, consumers, info.consumers);
     }
 

--- a/src/ir/transforms/expand_manual_phase_fence_pass.cpp
+++ b/src/ir/transforms/expand_manual_phase_fence_pass.cpp
@@ -350,7 +350,7 @@ class ManualPhaseFenceMutator : public IRMutator {
     MergeLoopSafetyInfo(index, summary);
     if (!include_consumers) return;
     const auto trip_count = transform_utils::EvalConstTripCount(for_stmt);
-    if (trip_count.value_or(0) <= 0) return;
+    if (!trip_count.has_value() || *trip_count <= 0) return;
     for (const Var* key : summary.dep_array_order) {
       auto it = summary.dep_arrays.find(key);
       if (it == summary.dep_arrays.end()) continue;
@@ -401,9 +401,10 @@ class ManualPhaseFenceMutator : public IRMutator {
 
     const bool is_parallel = for_stmt->kind_ == ForKind::Parallel;
     const auto trip_count = transform_utils::EvalConstTripCount(for_stmt);
-    if (is_parallel && trip_count.value_or(0) <= 0) return decisions;
-    if (for_stmt->kind_ == ForKind::Sequential && trip_count.has_value() && *trip_count <= 0)
+    if (is_parallel && (!trip_count.has_value() || *trip_count <= 0)) return decisions;
+    if (for_stmt->kind_ == ForKind::Sequential && trip_count.has_value() && *trip_count <= 0) {
       return decisions;
+    }
 
     for (const auto& iter_arg : for_stmt->iter_args_) {
       if (iter_arg) current_iter_args.insert(iter_arg.get());
@@ -420,7 +421,7 @@ class ManualPhaseFenceMutator : public IRMutator {
         continue;
       }
       int64_t consumers = info.consumer_count;
-      if (trip_count.value_or(0) > 0) consumers *= *trip_count;
+      if (trip_count.has_value() && *trip_count > 0) consumers *= *trip_count;
       try_add(dep_array, dep_array, consumers, info.consumers);
     }
 

--- a/src/ir/transforms/lower_pipeline_loops_pass.cpp
+++ b/src/ir/transforms/lower_pipeline_loops_pass.cpp
@@ -33,6 +33,7 @@
 #include "pypto/ir/transforms/utils/attrs.h"
 #include "pypto/ir/transforms/utils/deep_clone_utils.h"
 #include "pypto/ir/transforms/utils/mutable_copy.h"
+#include "pypto/ir/transforms/utils/transform_utils.h"
 #include "pypto/ir/type.h"
 
 namespace pypto {
@@ -69,12 +70,7 @@ std::optional<int64_t> TryGetConstInt(const ExprPtr& expr) {
   return std::nullopt;
 }
 
-/// Trip count for a static for-loop range.
-int64_t ComputeStaticTripCount(int64_t start, int64_t stop, int64_t step) {
-  if (step > 0 && start < stop) return (stop - start + step - 1) / step;
-  if (step < 0 && start > stop) return (start - stop + (-step) - 1) / (-step);
-  return 0;
-}
+using transform_utils::ComputeStaticTripCount;
 
 ExprPtr MakeConstIndex(int64_t value, const Span& span) {
   return std::make_shared<ConstInt>(value, DataType::INDEX, span);

--- a/src/ir/transforms/skew_cross_core_pipeline_pass.cpp
+++ b/src/ir/transforms/skew_cross_core_pipeline_pass.cpp
@@ -78,12 +78,7 @@ std::optional<int64_t> TryGetConstInt(const ExprPtr& expr) {
   return std::nullopt;
 }
 
-/// Trip count for a static for-loop range.
-int64_t ComputeStaticTripCount(int64_t start, int64_t stop, int64_t step) {
-  if (step > 0 && start < stop) return (stop - start + step - 1) / step;
-  if (step < 0 && start > stop) return (start - stop + (-step) - 1) / (-step);
-  return 0;
-}
+using transform_utils::ComputeStaticTripCount;
 
 ExprPtr MakeConstIndex(int64_t value, const Span& span) {
   return std::make_shared<ConstInt>(value, DataType::INDEX, span);

--- a/src/ir/transforms/utils/buffer_root_collector.cpp
+++ b/src/ir/transforms/utils/buffer_root_collector.cpp
@@ -73,7 +73,7 @@ void BufferRootCollector::VisitStmt_(const ForStmtPtr& for_stmt) {
   auto init_roots = InitializeLoopCarryRoots(for_stmt->iter_args_);
   IRVisitor::VisitStmt_(for_stmt);
   RecordLoopReturnRoots(for_stmt->body_, for_stmt->return_vars_, init_roots,
-                        transform_utils::EvalConstTripCount(for_stmt) > 0);
+                        transform_utils::EvalConstTripCount(for_stmt).value_or(0) > 0);
 }
 
 void BufferRootCollector::VisitStmt_(const WhileStmtPtr& while_stmt) {

--- a/tests/ut/codegen/test_codegen_preconditions.py
+++ b/tests/ut/codegen/test_codegen_preconditions.py
@@ -59,10 +59,11 @@ def test_device_kernel_rejects_descending_loop():
     dropping the entire loop body with no diagnostic from any stage. The kernel
     loaded its input, computed nothing, and stored.
 
-    Tracked upstream as ptoas issue hw-native-sys/PTOAS#1288. If ptoas gains
-    descending-loop support this test (and the check it covers) should be
-    replaced by one asserting the loop lowers correctly; if ptoas merely starts
-    rejecting the step, this stays as the earlier, better-located diagnostic.
+    The PTOAS team has confirmed they will not support a non-positive
+    ``scf.for`` step in the foreseeable future — hw-native-sys/PTOAS#1288 will
+    be closed by adding the missing assertion only. So this rejection is
+    permanent, and the test stays: even once that assertion ships, the PyPTO
+    check fires earlier and names the user's loop instead of generated ``.pto``.
     """
     n = 64
 

--- a/tests/ut/codegen/test_codegen_preconditions.py
+++ b/tests/ut/codegen/test_codegen_preconditions.py
@@ -13,6 +13,7 @@ import pypto.language.distributed as pld
 import pytest
 from pypto import backend, codegen, passes
 from pypto.backend import BackendType
+from pypto.ir.pass_manager import OptimizationStrategy, PassManager
 
 
 @pytest.fixture(autouse=True)
@@ -47,6 +48,74 @@ def test_distributed_codegen_requires_comm_domain_materialization_when_distribut
     cg = codegen.DistributedCodegen()
     with pytest.raises(pypto.InternalError, match="DistributedCodegen preconditions"):
         cg.generate(program)
+
+
+def test_device_kernel_rejects_descending_loop():
+    """A descending loop in a device function must fail loudly, not silently.
+
+    Regression: device code lowers to MLIR ``scf.for``, which counts upward
+    only. A ``pl.range(8, 0, -1)`` was transcribed verbatim into
+    ``scf.for %i = 8 to 0 step -1`` — a zero-trip loop that ptoas folded away,
+    dropping the entire loop body with no diagnostic from any stage. The kernel
+    loaded its input, computed nothing, and stored.
+
+    Tracked upstream as ptoas issue hw-native-sys/PTOAS#1288. If ptoas gains
+    descending-loop support this test (and the check it covers) should be
+    replaced by one asserting the loop lowers correctly; if ptoas merely starts
+    rejecting the step, this stays as the earlier, better-located diagnostic.
+    """
+    n = 64
+
+    @pl.program
+    class Descending:
+        @pl.function(type=pl.FunctionType.AIV)
+        def kern(
+            self,
+            x: pl.Tensor[[n, n], pl.FP32],
+            out: pl.Out[pl.Tensor[[n, n], pl.FP32]],
+        ) -> pl.Tensor[[n, n], pl.FP32]:
+            acc: pl.Tile[[n, n], pl.FP32] = pl.load(x, [0, 0], [n, n])
+            for _i, (acc,) in pl.range(8, 0, -1, init_values=(acc,)):
+                acc = pl.add(acc, acc)
+                acc = pl.yield_(acc)
+            return pl.store(acc, [0, 0], out)
+
+    backend.reset_for_testing()
+    backend.set_backend_type(BackendType.Ascend910B)
+    optimized = PassManager.get_strategy(OptimizationStrategy.Default).run_passes(Descending)
+
+    with pytest.raises(ValueError, match="must have a positive step"):
+        codegen.PTOCodegen().generate(optimized)
+
+
+def test_device_kernel_accepts_ascending_loop():
+    """The ascending counterpart of the descending-loop rejection still lowers.
+
+    Guards the rejection above against over-reach: only a non-positive constant
+    step is refused.
+    """
+    n = 64
+
+    @pl.program
+    class Ascending:
+        @pl.function(type=pl.FunctionType.AIV)
+        def kern(
+            self,
+            x: pl.Tensor[[n, n], pl.FP32],
+            out: pl.Out[pl.Tensor[[n, n], pl.FP32]],
+        ) -> pl.Tensor[[n, n], pl.FP32]:
+            acc: pl.Tile[[n, n], pl.FP32] = pl.load(x, [0, 0], [n, n])
+            for _i, (acc,) in pl.range(0, 8, 1, init_values=(acc,)):
+                acc = pl.add(acc, acc)
+                acc = pl.yield_(acc)
+            return pl.store(acc, [0, 0], out)
+
+    backend.reset_for_testing()
+    backend.set_backend_type(BackendType.Ascend910B)
+    optimized = PassManager.get_strategy(OptimizationStrategy.Default).run_passes(Ascending)
+
+    mlir = codegen.PTOCodegen().generate(optimized)
+    assert "scf.for" in mlir, mlir
 
 
 def test_orchestration_codegen_precondition_entry_point():

--- a/tests/ut/codegen/test_orchestration_task_deps.py
+++ b/tests/ut/codegen/test_orchestration_task_deps.py
@@ -510,6 +510,61 @@ def test_compiler_derived_deps_for_dynamic_trip_tensor_carrier_falls_back():
     assert ".set_dependencies(" not in code
 
 
+def test_descending_parallel_loop_emits_descending_cpp_loop():
+    """Regression: a descending ``pl.parallel`` must not compile to a dead loop.
+
+    ``EvalConstTripCount`` returned 0 for any ``step <= 0``, and the emitted C++
+    repeated the same positive-step assumption twice more: the fan-in capacity
+    expression evaluated to 0, and ``EmitForLoopHeader`` hard-coded ``i < stop``
+    so ``for (i = 4; i < 0; i += -1)`` ran zero times. The kernel silently
+    submitted nothing.
+
+    Both directions run 4 times, so both must take the static ``PTO2TaskId[4]``
+    path and emit a loop whose condition actually admits iterations.
+    """
+
+    backend.reset_for_testing()
+    backend.set_backend_type(BackendType.Ascend910B)
+
+    def build(start, stop, step):
+        @pl.program
+        class P:
+            @pl.function(type=pl.FunctionType.AIV)
+            def fill(self, out: pl.Out[pl.Tensor[[64], pl.FP32]]) -> pl.Tensor[[64], pl.FP32]:
+                return out
+
+            @pl.function(type=pl.FunctionType.AIV)
+            def consume(self, q: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                return q
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(self, q: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                q_c = q
+                for _i, (q_c,) in pl.parallel(start, stop, step, init_values=(q_c,)):
+                    q_c = self.fill(q_c)
+                    q_c = pl.yield_(q_c)
+                return self.consume(q_c)
+
+        return P
+
+    up = _generate_orch_full_pipeline(build(0, 4, 1), analyze_auto_scopes_for_deps=True)
+    down = _generate_orch_full_pipeline(build(4, 0, -1), analyze_auto_scopes_for_deps=True)
+
+    # The ascending case must be byte-for-byte unchanged in its loop header:
+    # a constant positive step still emits the plain ``<`` form.
+    assert re.search(r"for \(int64_t \w+ = 0; \w+ < 4; \w+ \+= 1\)", up), up
+
+    # The descending case must test ``>``, not ``<`` — otherwise it never runs.
+    down_header = re.search(r"for \(int64_t (\w+) = 4; \1 ([<>]) 0; \1 \+= -1\)", down)
+    assert down_header, down
+    assert down_header.group(2) == ">", down
+
+    # Both directions have a static trip count of 4, so neither may fall back to
+    # the dynamic vector path (whose capacity expression also evaluated to 0).
+    for code in (up, down):
+        assert "std::vector<PTO2TaskId>" not in code, code
+
+
 def test_compiler_derived_deps_for_dynamic_parallel_tensor_carriers_share_phase_barrier():
     """Dynamic parallel tensor producers in one phase should share one dummy barrier."""
 

--- a/tests/ut/codegen/test_orchestration_task_deps.py
+++ b/tests/ut/codegen/test_orchestration_task_deps.py
@@ -559,10 +559,50 @@ def test_descending_parallel_loop_emits_descending_cpp_loop():
     assert down_header, down
     assert down_header.group(2) == ">", down
 
-    # Both directions have a static trip count of 4, so neither may fall back to
+    # Both directions have a static trip count of 4, so both must size their
+    # compiler-dep fan-in as a fixed PTO2TaskId[4] and neither may fall back to
     # the dynamic vector path (whose capacity expression also evaluated to 0).
-    for code in (up, down):
-        assert "std::vector<PTO2TaskId>" not in code, code
+    for label, code in (("ascending", up), ("descending", down)):
+        assert re.search(r"PTO2TaskId \w+\[4\]", code), (label, code)
+        assert "std::vector<PTO2TaskId>" not in code, (label, code)
+
+
+def test_zero_step_loop_emits_a_terminating_condition():
+    """A zero step must produce zero iterations, never a non-terminating loop.
+
+    Review catch on #2427: picking the comparison from `step < 0` alone sent a
+    constant zero step down the `<` branch, emitting `for (i = 0; i < N; i += 0)`
+    — an infinite loop in the generated orchestration function. A zero step is
+    zero-trip per `ComputeStaticTripCount`, so the emitted condition must agree.
+    """
+
+    backend.reset_for_testing()
+    backend.set_backend_type(BackendType.Ascend910B)
+
+    @pl.program
+    class P:
+        @pl.function(type=pl.FunctionType.AIV)
+        def fill(self, out: pl.Out[pl.Tensor[[64], pl.FP32]]) -> pl.Tensor[[64], pl.FP32]:
+            return out
+
+        @pl.function(type=pl.FunctionType.AIV)
+        def consume(self, q: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            return q
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def main(self, q: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            q_c = q
+            for _i, (q_c,) in pl.parallel(0, 4, 0, init_values=(q_c,)):
+                q_c = self.fill(q_c)
+                q_c = pl.yield_(q_c)
+            return self.consume(q_c)
+
+    code = _generate_orch_full_pipeline(P, analyze_auto_scopes_for_deps=True)
+
+    # Whatever else it does, it must not emit a loop that both steps by zero and
+    # has a condition that can hold.
+    for header in re.findall(r"for \(int64_t \w+ = [^;]+; ([^;]+); \w+ \+= 0\)", code):
+        assert header.strip() == "false", code
 
 
 def test_compiler_derived_deps_for_dynamic_parallel_tensor_carriers_share_phase_barrier():

--- a/tests/ut/ir/transforms/test_classify_iter_arg_carry.py
+++ b/tests/ut/ir/transforms/test_classify_iter_arg_carry.py
@@ -209,6 +209,58 @@ def test_manual_scope_parallel_task_id_carry_is_sized():
             assert attrs[f"iter_arg_rebind_{idx}"] is True
 
 
+def test_manual_scope_parallel_descending_task_id_carry_is_sized():
+    """A descending ``pl.parallel`` has a statically-known trip count too.
+
+    Regression: ``EvalConstTripCount`` guarded with ``step <= 0``, so
+    ``pl.parallel(4, 0, -1)`` reported 0 and the pass rejected it with the
+    dynamic-trip-count diagnostic — telling the user to supply a Python int
+    for a bound that already was one. The extent must match the ascending
+    ``pl.parallel(4)`` case, since both loops run 4 times.
+    """
+    rows, cols, tile = 128, 128, 32
+
+    @pl.program
+    class Prog:
+        @pl.function(type=pl.FunctionType.AIV)
+        def kern(
+            self,
+            x: pl.Tensor[[rows, cols], pl.FP32],
+            out: pl.InOut[pl.Tensor[[rows, cols], pl.FP32]],
+            row: pl.Scalar[pl.INDEX],
+            col: pl.Scalar[pl.INDEX],
+        ) -> pl.Tensor[[rows, cols], pl.FP32]:
+            t: pl.Tile[[tile, tile], pl.FP32] = pl.load(x, [row, col], [tile, tile])
+            r: pl.Tile[[tile, tile], pl.FP32] = pl.add(t, t)
+            return pl.store(r, [row, col], out)
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def main(
+            self,
+            x: pl.Tensor[[rows, cols], pl.FP32],
+            out: pl.Out[pl.Tensor[[rows, cols], pl.FP32]],
+        ) -> pl.Tensor[[rows, cols], pl.FP32]:
+            with pl.manual_scope():
+                prev_tid = None
+                for i in pl.range(4):
+                    row: pl.Scalar[pl.INDEX] = i * tile
+                    for j in pl.parallel(4, 0, -1):
+                        col: pl.Scalar[pl.INDEX] = j * tile
+                        out, prev_tid = pl.submit(self.kern, x, out, row, col, deps=[prev_tid])
+            return out
+
+    transformed = PassManager.get_strategy(OptimizationStrategy.Default).run_passes(Prog)
+    loops = _for_stmts(_orch_func(transformed).body)
+    assert len(loops) == 2, [loop.kind for loop in loops]
+    outer, inner = loops
+
+    assert inner.kind == ir.ForKind.Parallel
+    inner_attrs = _carry_attrs(inner)
+    outer_attrs = _carry_attrs(outer)
+    assert any(v == 4 for k, v in inner_attrs.items() if k.startswith("iter_arg_array_size_")), inner_attrs
+    assert any(v == 4 for k, v in outer_attrs.items() if k.startswith("iter_arg_array_size_")), outer_attrs
+
+
 def test_manual_scope_parallel_dynamic_trip_count_rejected():
     """A dynamic ``pl.parallel`` trip count cannot size the fence array, so the
     pass rejects it with a user-facing error instead of silently mis-lowering."""


### PR DESCRIPTION
## What

`EvalConstTripCount` guarded with `if (*step <= 0) return 0;`, so a descending loop reported a trip count of 0 even though all three bounds were compile-time constants. `ForStmt::step_` carries no sign restriction, `pl.range(64, 0, -1)` is valid DSL, and `CtrlFlowTransform` already has a passing test (`test_break_negative_step`) proving the front end honours descending loops — so the helper contradicted both the IR contract and the language.

The single `int64_t` return conflated three different propositions, and every caller read `0` as the first:

1. the bounds are not compile-time constants
2. the loop provably runs zero times
3. **the loop counts down** — which is neither

## Why fixing the helper alone was not enough

The positive-step assumption had been copied into four more places. Three of them were the "fallbacks" that exist to cover case 1, so they repeated the same mistake:

| Site | Was | Now |
| --- | --- | --- |
| `transform_utils.h` | `step <= 0` → `0` | `ComputeStaticTripCount`, direction-aware; returns `std::optional` so case 1 is distinguishable |
| `orchestration_codegen.cpp` — loop header | hard-coded `i < stop` | comparison follows the step's sign |
| `orchestration_codegen.cpp` — fan-in capacity | positive-step-only formula, emitted as C++ text | descending branch added; bounds bound to locals so each is evaluated once, not three times |
| `expand_manual_phase_fence_pass.cpp` | byte-identical broken copy + a `TripCountInfo` struct grown to recover the distinction the sentinel erased | deleted, uses the shared helper |
| `pto_control_flow_codegen.cpp` | emitted `scf.for %i = 8 to 0 step -1` | rejected with a user-facing error |

`EvalConstInt` also now peeks through `Neg(ConstInt)`. This matters: the parser folds `-1` to `ConstInt(-1)`, but IR from the builder API or a `.pto` file before the first `Simplify` can still carry `Neg(ConstInt(1))` — which is exactly why the two passes that got trip counts right have their own `TryGetConstInt`.

`LowerPipelineLoops` and `SkewCrossCorePipeline` had correct but byte-identical private copies; both now share the helper. **One implementation of this arithmetic instead of four.**

## Effect

Orchestration, same program, only the loop direction differs:

```cpp
// ascending  pl.parallel(0, 4, 1)   — byte-identical to pre-fix output
for (int64_t _i = 0; _i < 4; _i += 1) {

// descending pl.parallel(4, 0, -1)  — was `_i < 0`, i.e. zero iterations
for (int64_t _i = 4; _i > 0; _i += -1) {
```

Both now take the static `PTO2TaskId[4]` path rather than the zero-capacity dynamic fallback. The manual-scope path previously rejected `pl.parallel(4, 0, -1)` with *"must have a statically-known trip count … e.g. `pl.parallel(4)`"* — for a bound that already was a Python int.

## Device path

Device code lowers to MLIR `scf.for`, which counts upward only, so a descending loop has no faithful lowering there. Emitting it verbatim produced a zero-trip loop that ptoas folded away — the kernel loaded its input, computed nothing, and stored, with **no diagnostic from any stage**. It is now rejected:

> loops in device functions must have a positive step, but this loop steps by -1. Device code lowers to MLIR 'scf.for', which only counts upward. Rewrite the loop in ascending form and invert the index in the body — replace `for i in pl.range(64, 0, -1)` with `for t in pl.range(0, 64)` plus `i = 64 - t`. Orchestration functions support descending loops directly.

Filed upstream as **hw-native-sys/PTOAS#1288**: ptoas does not enforce `scf.for`'s "constant step operand must be positive" verifier invariant. A negative step drops the body; a zero step emits `for (i = lb; i < ub; i += 0)` — an infinite loop in the generated kernel. Both exit 0 with empty stderr.

**Confirmed with the PTOAS team: they will not support a non-positive step in the foreseeable future** — #1288 will be closed by adding the missing assertion only. So the PyPTO rejection is permanent rather than a workaround pending an assembler fix, and it should stay even once that assertion ships: it fires earlier, names the user's loop through the `Span`, and says how to rewrite it, whereas the assembler can only report against generated `.pto` the user never wrote. Supporting descending device loops at all would now mean normalizing them to ascending form in PyPTO's own lowering — a separate piece of work, not something to wait upstream for.

## Reviewer notes

- **Ascending output is unchanged.** A constant positive step emits exactly the text it did before, which matters because `EmitForLoopHeader` is on the path of every orchestration loop.
- **Dynamic-step loops do change.** A non-constant step now emits `((step) > 0 ? i < stop : i > stop)` instead of a bare `i < stop`. It is loop-invariant so any compiler hoists it, but it is a real change to emitted output beyond the descending case.
- **The device check only covers a compile-time step.** A runtime step that turns out negative still lowers to the same ill-defined `scf.for`; proving its sign needs the arith analyzer. Documented in the code rather than left silent. Now that the assembler will not reject it either, closing this gap means normalizing descending loops in PyPTO — tracked as follow-up, not blocking this PR.
- The `std::optional` change touches all 11 call sites; the four that only threshold-compare use `.value_or(0)` and are unaffected in behaviour.

## Testing

- Full unit suite: **9910 passed, 3 skipped, 0 failed**
- C++ ctest: 1/1 passed
- pre-commit: all 17 hooks pass

Three regression tests, each a direction-flip of an existing passing test so the contrast is exact:

- `test_manual_scope_parallel_descending_task_id_carry_is_sized` — `pl.parallel(4, 0, -1)` sizes its fence array to 4, like `pl.parallel(4)`
- `test_descending_parallel_loop_emits_descending_cpp_loop` — ascending header unchanged, descending tests `>`, neither falls back to the dynamic vector
- `test_device_kernel_rejects_descending_loop` / `test_device_kernel_accepts_ascending_loop` — rejection fires, and does not over-reach

No test in the tree used a descending `pl.parallel`, and no descending loop reached codegen. That is why this survived.

