### PR TITLE
test(st): temporarily skip flaky GEMV acc_phase="final" cases that poison the ST batch

### DIFF
--- a/tests/st/runtime/ops/test_gemv.py
+++ b/tests/st/runtime/ops/test_gemv.py
@@ -421,6 +421,12 @@ class TestGemv:
         result = test_runner.run(GemvTestCase(k=512, n=64, ab_dtype=DataType.INT8, config=_cfg()))
         assert result.passed, f"Test failed: {result.error}"
 
+    @pytest.mark.skip(
+        reason="Issue #2428: GEMV with acc_phase='final' intermittently hangs on device "
+        "(SCHEDULER_TIMEOUT sub_class=S1:running-stalled), which poisons the shared chip-run "
+        "lane and fails every remaining artifact in the ST batch. Temporarily skipped to "
+        "unblock CI; re-enable once the hang is root-caused."
+    )
     @pytest.mark.platforms("a2a3")
     def test_tile_gemv_final_phase(self, test_runner):
         result = test_runner.run(GemvTestCase(k=128, n=64, acc_phase="final", config=_cfg()))
@@ -454,6 +460,12 @@ class TestGemvBias:
         result = test_runner.run(GemvTestCase(k=k, n=64, bias=True, ab_dtype=ab_dtype, config=_cfg()))
         assert result.passed, f"Test failed: {result.error}"
 
+    @pytest.mark.skip(
+        reason="Issue #2428: GEMV with acc_phase='final' intermittently hangs on device "
+        "(SCHEDULER_TIMEOUT sub_class=S1:running-stalled), which poisons the shared chip-run "
+        "lane and fails every remaining artifact in the ST batch. Temporarily skipped to "
+        "unblock CI; re-enable once the hang is root-caused."
+    )
     @pytest.mark.platforms("a2a3")
     def test_tile_gemv_bias_final_phase(self, test_runner):
         result = test_runner.run(GemvTestCase(k=128, n=64, bias=True, acc_phase="final", config=_cfg()))
@@ -618,6 +630,12 @@ class TestGemvAcc:
         result = test_runner.run(GemvAccTestCase(k_chunk=k_chunk, n=64, ab_dtype=ab_dtype, config=_cfg()))
         assert result.passed, f"Test failed: {result.error}"
 
+    @pytest.mark.skip(
+        reason="Issue #2428: GEMV with acc_phase='final' intermittently hangs on device "
+        "(SCHEDULER_TIMEOUT sub_class=S1:running-stalled), which poisons the shared chip-run "
+        "lane and fails every remaining artifact in the ST batch. Temporarily skipped to "
+        "unblock CI; re-enable once the hang is root-caused."
+    )
     @pytest.mark.platforms("a2a3")
     def test_tile_gemv_acc_partial_final_phases(self, test_runner):
         result = test_runner.run(GemvAccTestCase(n=64, phased=True, config=_cfg()))


### PR DESCRIPTION
## What

Temporarily skips the three ST cases that run GEMV with `acc_phase="final"`:

- `tests/st/runtime/ops/test_gemv.py::TestGemv::test_tile_gemv_final_phase`
- `tests/st/runtime/ops/test_gemv.py::TestGemvBias::test_tile_gemv_bias_final_phase`
- `tests/st/runtime/ops/test_gemv.py::TestGemvAcc::test_tile_gemv_acc_partial_final_phases`

No production code changes — three `@pytest.mark.skip` decorators, each linking to #2428.

## Why

Those three cases intermittently **hang on device**. The kernel is dispatched, one task starts and never retires, and the PTO2 scheduler times out after ~53 s:

```
[ERROR] validate_runtime_impl: PTO2 runtime failed:
        orch_error_code=0 sched_error_code=100 runtime_status=-100
[ERROR] error detail: sched_error_code=100 SCHEDULER_TIMEOUT
[ERROR] PTO2 scheduler timeout sub_class=S1:running-stalled (detail=1)
        completed=0/1 running=1 ready=0 waiting=0 orch_done=1
        stuck_task_id=4294967296 stuck_core=0
```

Host-side this surfaces as the generic `507018 ACL_ERROR_RT_AICPU_EXCEPTION`, the bounded device drain then fails (`507014`), and the card is marked unusable.

**The blast radius is what makes this urgent.** `system-tests-direct` executes 64 artifacts in a single shared `ChipWorker` (`--execute-via-task-submit --execute-batch-size=64`). Once the hang poisons the chip-run lane, every remaining artifact in that batch fails at submit:

```
RuntimeError: chip run lane is poisoned: finalize_native_run failed with code -100
```

Those victims are marked `PYPTO_EXEC_RESULT=FAIL`, indistinguishable from genuine failures. In run [32133935090](https://github.com/hw-native-sys/pypto/actions/runs/32133935090/job/95748183312) that meant `33 failed, 722 passed` — **1** real fault and **32** poisoned victims spanning `test_gemv.py` (12), `test_log.py` (12), `test_mat_slice_to_left.py` (1) and `test_matmul.py` (8). Tests in the next batch pass normally.

## Reviewer notes

**This is not a bad card, and not new.** Sampling recent failing `system-tests-direct` jobs gives the same signature every time, with the root cause always a GEMV carrying `acc_phase="final"`:

| Run | Root-cause case | Runner / card |
| --- | --------------- | ------------- |
| 32133935090 | `tile_gemv_bias_1x128x64_fp32_final` | npu-7 / chipId 6 |
| 32145770063 | `tile_gemv_1x128x64_fp32_final` | npu-8 / chipId 6 |
| 32136297209 | `tile_gemv_bias_1x128x64_fp32_final` | npu-9 / chipId 4 |
| 32133882108 | `tile_gemv_1x128x64_fp32_final` | npu-8 / chipId 5 |
| 32133871280 | `tile_gemv_acc_1x256x64_fp32_chunks2_partial_final` | npu-3 / chipId 5 |
| 32131113285 (`main`) | `tile_gemv_1x128x64_fp32_final` | npu-8 / chipId 6 |
| 32024375537 (2026-08-17) | `tile_gemv_1x128x64_fp32_final` | npu-10 / chipId 6 |

Five runners, three cards, reproduces on `main` — the fault is in the kernel, not the hardware. Which of the three cases hangs varies per run.

**Scope of this PR is deliberately narrow.** It unblocks CI and nothing else. Two follow-ups are captured in #2428:

1. **The real bug** — root-cause the `acc_phase="final"` device hang. `S1:running-stalled` with `orch_done=1` and one task never retiring has the shape of an unsatisfied wait rather than a slow kernel. Suggested starting points: raise `PTO2_SCHEDULER_TIMEOUT_MS` on a repro to confirm deadlock vs slow; diff the generated `.pto` for `final` vs `unspecified` at the same shape; bisect around c9f21061 `feat(codegen): support single-row GEMV on A2/A3` (#2185), the only recent change in this area.
2. **The amplifier** — `execute_batch_manifest` in `python/pypto/runtime/execute_artifact.py` keeps feeding a poisoned worker. It should detect the poisoned-lane / device-unusable error, close the worker, reopen a fresh one for the remaining entries, and classify what it cannot run as `INFRA` rather than `FAIL`. That would turn these runs from 33 red into 1 red.

Every skip reason names #2428, so these three do not become ownerless indefinite skips.

## Testing

- `ruff format --check` and `ruff check` clean; full pre-commit suite (including pyright) passed on commit.
- AST check confirms all three functions carry `pytest.mark.skip` and that no other test in the file gained one.
- Local pytest collection was not run: the primary checkout's `pypto_core.so` is stale against this branch, and a from-scratch worktree C++ build is not warranted for a decorator-only change to a test file. CI covers it.

Related: #2428
