### PR TITLE
[experiment, do not merge] A5 mixed-kernel stall: bisect midpoint 471b0102 (A5 job only)

### DIFF
--- a/.github/actions/setup-ci-job/action.yml
+++ b/.github/actions/setup-ci-job/action.yml
@@ -269,7 +269,12 @@ runs:
     - name: Check NPU
       if: ${{ inputs.needs-device == 'true' }}
       shell: bash
-      run: npu-smi info
+      # EXPERIMENT BRANCH: the npu-a5 pool cannot init dcmi outside a card
+      # session, so a bare `npu-smi info` fails with -8005. Borrow the card the
+      # job was assigned and run the probe inside it.
+      run: |
+        task-submit --device "$DEVICE_ID" --timeout 3600 --max-time 120 \
+          --run "cd $GITHUB_WORKSPACE/${{ inputs.checkout-path }} && npu-smi info"
 
     - name: Scope ccache to pto-isa version
       # Namespace ccache by the pinned pto-isa commit so an ISA bump forces a real
@@ -431,6 +436,18 @@ runs:
         # env snapshot may not carry the workspace path.
         _PYPTO_ENV_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
         source "$_PYPTO_ENV_DIR/venv/bin/activate"
+        # Put the venv's own site-packages at the FRONT of PYTHONPATH. CANN's
+        # set_env.sh (sourced above on device jobs) prepends its site-packages,
+        # and every PYTHONPATH entry is searched before the venv's -- so CANN
+        # >= 9.2.0, which ships an unrelated package of its own named `pypto`
+        # (0.2.1, pybind11-based), otherwise shadows the one this job just
+        # built. Only the npu-a5 pool hits it; the a2a3 pool is on CANN 9.0.0.
+        # Prepend unconditionally: activate.sh is sourced more than once per
+        # job and each source re-runs set_env.sh, which re-prepends CANN's dir.
+        _PYPTO_SITE="$(python -c 'import sysconfig; print(sysconfig.get_paths()["purelib"])' 2>/dev/null)"
+        if [ -n "$_PYPTO_SITE" ]; then
+          export PYTHONPATH="$_PYPTO_SITE${PYTHONPATH:+:$PYTHONPATH}"
+        fi
         EOF
         if [ "$UNSET_RING" = "true" ]; then
           printf '%s\n' 'unset PTO2_RING_HEAP PTO2_RING_TASK_WINDOW PTO2_RING_DEP_POOL' >> activate.sh

--- a/.github/workflows/a5-exp.yml
+++ b/.github/workflows/a5-exp.yml
@@ -1,0 +1,77 @@
+# Throwaway experiment workflow (do not merge).
+#
+# ONE job, nothing in front of it: the qwen3 scope-3 mixed-kernel ST case on
+# real A5 silicon. No lint / unit-test / docs gate, no toolchain lead job, and
+# ci.yml + docs.yml have their pull_request triggers removed on this branch so
+# nothing else is scheduled and nothing else competes for the shared NPU pool.
+#
+# The three toolchain values below are normally supplied by ci.yml's `toolchain`
+# job, which exists to keep them out of workflow files. They are inlined here on
+# purpose: this branch is a single-shot bisect probe that is never merged, and
+# the lead job would otherwise be a second job. The values are exactly the ones
+# pinned AT THIS BASE COMMIT (471b0102):
+#   toolchain/versions.env  -> PTOAS_VERSION=v0.57
+#                              PTOAS_SHA256_AARCH64=4858c837...
+#   runtime submodule 3165cc89 -> pto_isa.pin = 83d01313...
+name: a5-experiment
+
+on:
+  pull_request:
+    branches: [ "main" ]
+  workflow_dispatch:
+
+concurrency:
+  group: a5-exp-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  a5-qwen3-mixed:
+    permissions:
+      contents: read
+    runs-on: [self-hosted, linux, arm64, npu-a5]
+    defaults:
+      run:
+        working-directory: a5-checkout
+    env:
+      PTOAS_ROOT: ${{ github.workspace }}/a5-checkout/ptoas-bin
+      PTO_ISA_ROOT: ${{ github.workspace }}/a5-checkout/pto-isa
+      PTOAS_VERSION: v0.57
+      PTOAS_SHA256: 4858c837e12b1b588f281207c95916dc20968a7cdc656aadd549a87658a06692
+      CMAKE_BUILD_PARALLEL_LEVEL: 16
+      CMAKE_C_COMPILER_LAUNCHER: ccache
+      CMAKE_CXX_COMPILER_LAUNCHER: ccache
+      CCACHE_MAXSIZE: 30G
+      CCACHE_UMASK: '000'
+    steps:
+      - name: Fetch composite action definitions
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github/actions
+          clean: false
+          persist-credentials: false
+
+      - name: Setup CI job
+        uses: ./.github/actions/setup-ci-job
+        with:
+          checkout-path: a5-checkout
+          needs-device: 'true'
+          pip-cache-name: pip-a5
+          pto-isa-commit: 83d01313d9bfc247c4b7c8bcf969d1019f0d106f
+          toolchain: bundle
+
+      - name: Test qwen3 scope-3 mixed kernel (A5, on board)
+        timeout-minutes: 60
+        run: |
+          source activate.sh
+          echo "[device] DEVICE_ID=$DEVICE_ID"
+          test -n "$DEVICE_ID" || { echo "DEVICE_ID is empty in the runner env"; exit 1; }
+          task-submit --device "$DEVICE_ID" --timeout 3600 --max-time 3600 \
+            --run "cd $GITHUB_WORKSPACE/a5-checkout && source activate.sh && python -m pytest \
+              tests/st/runtime/framework_and_models/test_qwen3_decode_scope3_mixed.py \
+              -v --forked --platform=a5 --device=\$TASK_DEVICE"
+
+      - name: Kill orphaned task-submit tasks
+        if: always()
+        uses: ./.github/actions/kill-orphaned-tasks
+        with:
+          checkout-path: a5-checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,9 @@
 name: CI
 
+# EXPERIMENT BRANCH: the pull_request trigger is removed so the full matrix
+# never runs here -- a5-exp.yml carries the single A5 job this branch exists for.
 on:
   push:
-    branches: [ "main" ]
-  pull_request:
     branches: [ "main" ]
   workflow_dispatch:
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,10 +17,11 @@ name: Docs
 # The site is a build artifact and is never committed; the markdown under `docs/`
 # stays the single source of truth.
 
+# EXPERIMENT BRANCH: pull_request trigger removed so this branch schedules
+# exactly one job (a5-exp.yml).
 on:
   push:
     branches: [ "main" ]
-  pull_request:
   # Republish without a code change, and exercise the deploy path on demand.
   workflow_dispatch:
 


### PR DESCRIPTION
Throwaway branch. **Do not merge, do not review** — one on-board A5 run, then closed and deleted.

This branch runs **exactly one job**: `a5-experiment / a5-qwen3-mixed`. It adds a standalone `a5-exp.yml` with no lint / unit-test / docs gate in front of the A5 job, and removes the `pull_request` trigger from `ci.yml` so the full matrix never runs here and never competes for the shared NPU pool. (`toolchain` is kept only as the source of the ptoas version and pto-isa commit that `setup-ci-job` needs — GitHub-hosted, ~13s, no in-house slot.)

It replaces #2431, which cherry-picked the three CI commits onto this same base; `ci.yml` and the docs have drifted since `471b0102`, so that branch was `CONFLICTING` and GitHub never computed a merge ref — no workflow ran at all.

## Bisect state

`test_qwen3_decode_scope3_mixed[a5]` stalls on board with `sched_error_code=100`, `S1:running-stalled`, always inside the `oproj_block` mixed kernel, at a different task index every run (37 / 32 / 28 / 18 / 30 / 24) and on a varying core (2 / 1 / 2 / 2 / 2 / 3). Good at `main@71020585`; bad at `main@33ff8b49` and everything after.

| candidate | verdict | evidence |
|---|---|---|
| #2378 cross-core ring 8/4 → 2 | **ruled out** (#2425) | restoring the ring depth reproduces the known-good device config byte-for-byte; still stalls |
| #2273 Simpler / PTO-ISA bump | **ruled out** (#2426) | `33ff8b49` stalls with `runtime` pinned back at `3165cc89` |
| #2382 `set_atomic_none()` guard | **ruled out** (#2430) | removing the injection still stalls |

#2382 was the *only* device-code delta across the whole window once the ring depth was neutralised — every `.pto` is identical between the good and bad bases and the orchestration differs only by runtime type renames. With it cleared, the regression is very likely not in the compiled artifacts at all.

## What this tests

`471b0102`, the midpoint of the remaining 24-commit window `71020585..33ff8b49`. The `runtime` pin is `3165cc89`.

- **green** → the regression is in `b22cee1e..33ff8b49`
- **red** → it is in `8e27c013..471b0102` (which contains #2351 `pl.split_aiv` placement, #2371 L0C double buffering, #2350 replay-from-build_output)