### PR TITLE
[experiment, do not merge] A5 stall probe at e2079529 (#2351)

### DIFF
--- a/.github/actions/setup-ci-job/action.yml
+++ b/.github/actions/setup-ci-job/action.yml
@@ -269,7 +269,9 @@ runs:
     - name: Check NPU
       if: ${{ inputs.needs-device == 'true' }}
       shell: bash
-      run: npu-smi info
+      run: |
+        task-submit --device "$DEVICE_ID" --timeout 3600 --max-time 120 \
+          --run "cd $GITHUB_WORKSPACE/${{ inputs.checkout-path }} && npu-smi info"
 
     - name: Scope ccache to pto-isa version
       # Namespace ccache by the pinned pto-isa commit so an ISA bump forces a real
@@ -431,6 +433,10 @@ runs:
         # env snapshot may not carry the workspace path.
         _PYPTO_ENV_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
         source "$_PYPTO_ENV_DIR/venv/bin/activate"
+        _PYPTO_SITE="$(python -c 'import sysconfig; print(sysconfig.get_paths()["purelib"])' 2>/dev/null)"
+        if [ -n "$_PYPTO_SITE" ]; then
+          export PYTHONPATH="$_PYPTO_SITE${PYTHONPATH:+:$PYTHONPATH}"
+        fi
         EOF
         if [ "$UNSET_RING" = "true" ]; then
           printf '%s\n' 'unset PTO2_RING_HEAP PTO2_RING_TASK_WINDOW PTO2_RING_DEP_POOL' >> activate.sh

--- a/.github/workflows/a5-exp.yml
+++ b/.github/workflows/a5-exp.yml
@@ -1,0 +1,77 @@
+# Throwaway experiment workflow (do not merge).
+#
+# ONE job, nothing in front of it: the qwen3 scope-3 mixed-kernel ST case on
+# real A5 silicon. No lint / unit-test / docs gate, no toolchain lead job, and
+# ci.yml + docs.yml have their pull_request triggers removed on this branch so
+# nothing else is scheduled and nothing else competes for the shared NPU pool.
+#
+# The three toolchain values below are normally supplied by ci.yml's `toolchain`
+# job, which exists to keep them out of workflow files. They are inlined here on
+# purpose: this branch is a single-shot bisect probe that is never merged, and
+# the lead job would otherwise be a second job. The values are exactly the ones
+# pinned AT THIS BASE COMMIT (e2079529):
+#   toolchain/versions.env  -> PTOAS_VERSION=v0.57
+#                              PTOAS_SHA256_AARCH64=4858c837e12b1b588f281207c95916dc20968a7cdc656aadd549a87658a06692
+#   runtime pin -> pto_isa.pin = 83d01313d9bfc247c4b7c8bcf969d1019f0d106f
+name: a5-experiment
+
+on:
+  pull_request:
+    branches: [ "main" ]
+  workflow_dispatch:
+
+concurrency:
+  group: a5-exp-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  a5-qwen3-mixed:
+    permissions:
+      contents: read
+    runs-on: [self-hosted, linux, arm64, npu-a5]
+    defaults:
+      run:
+        working-directory: a5-checkout
+    env:
+      PTOAS_ROOT: ${{ github.workspace }}/a5-checkout/ptoas-bin
+      PTO_ISA_ROOT: ${{ github.workspace }}/a5-checkout/pto-isa
+      PTOAS_VERSION: v0.57
+      PTOAS_SHA256: 4858c837e12b1b588f281207c95916dc20968a7cdc656aadd549a87658a06692
+      CMAKE_BUILD_PARALLEL_LEVEL: 16
+      CMAKE_C_COMPILER_LAUNCHER: ccache
+      CMAKE_CXX_COMPILER_LAUNCHER: ccache
+      CCACHE_MAXSIZE: 30G
+      CCACHE_UMASK: '000'
+    steps:
+      - name: Fetch composite action definitions
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github/actions
+          clean: false
+          persist-credentials: false
+
+      - name: Setup CI job
+        uses: ./.github/actions/setup-ci-job
+        with:
+          checkout-path: a5-checkout
+          needs-device: 'true'
+          pip-cache-name: pip-a5
+          pto-isa-commit: 83d01313d9bfc247c4b7c8bcf969d1019f0d106f
+          toolchain: bundle
+
+      - name: Test qwen3 scope-3 mixed kernel (A5, on board)
+        timeout-minutes: 60
+        run: |
+          source activate.sh
+          echo "[device] DEVICE_ID=$DEVICE_ID"
+          test -n "$DEVICE_ID" || { echo "DEVICE_ID is empty in the runner env"; exit 1; }
+          task-submit --device "$DEVICE_ID" --timeout 3600 --max-time 3600 \
+            --run "cd $GITHUB_WORKSPACE/a5-checkout && source activate.sh && python -m pytest \
+              tests/st/runtime/framework_and_models/test_qwen3_decode_scope3_mixed.py \
+              -v --forked --platform=a5 --device=\$TASK_DEVICE"
+
+      - name: Kill orphaned task-submit tasks
+        if: always()
+        uses: ./.github/actions/kill-orphaned-tasks
+        with:
+          checkout-path: a5-checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,6 @@ name: CI
 on:
   push:
     branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,7 +20,6 @@ name: Docs
 on:
   push:
     branches: [ "main" ]
-  pull_request:
   # Republish without a code change, and exercise the deploy path on demand.
   workflow_dispatch:
 


### PR DESCRIPTION
Throwaway single-shot probe. **Do not merge, do not review.** Schedules exactly one job (`a5-qwen3-mixed`); `ci.yml` and `docs.yml` have their `pull_request` triggers removed on this branch so nothing else is scheduled and nothing competes for the shared NPU pool.

## Bisect state

`test_qwen3_decode_scope3_mixed[a5]` stalls on board — `sched_error_code=100`, `S1:running-stalled`, always inside the `oproj_block` mixed kernel, at a different task index every run (37 / 32 / 28 / 18 / 30 / 24 / 37) and on a varying core. Good at `main@71020585`.

| probe | result |
|---|---|
| #2378 ring depth restored to 8/4 | still stalls → ruled out |
| `33ff8b49` (before #2273 Simpler/PTO-ISA bump) | still stalls → ruled out |
| `set_atomic_none()` injection removed (#2382) | still stalls → ruled out |
| `471b0102` | still stalls |

Remaining window: `71020585..471b0102`, 12 commits.

## What this tests

`e2079529` — #2351 `feat(ir): make pl.split_aiv authoritative for AIV placement` — the 4th of those 12. Picked ahead of the blind midpoint because #2411 already reports #2351 stalling DeepSeek V4 MTP-1 packed prefill, which is the same shape of regression.

- **red** → the culprit is in `8e27c013..e2079529` (4 commits; #2351 the prime suspect)
- **green** → #2351 is cleared and the culprit is in `cde1046c..471b0102` (8 commits)

## Note on the two setup patches

This branch carries two `setup-ci-job` fixes that are not on main yet and that the npu-a5 pool needs: the NPU probe must run inside a `task-submit` card session (a bare `npu-smi info` fails with `dcmi ... -8005`), and the venv site-packages must be ahead of CANN's on `PYTHONPATH` (CANN >= 9.2.0 ships an unrelated package of its own named `pypto` that otherwise shadows the freshly built one). Neither touches compiler or runtime behaviour.