### PR TITLE
[experiment, do not merge] A5 stall: reproduce the 2026-08-13 green run shape

### DIFF
--- a/.github/actions/setup-ci-job/action.yml
+++ b/.github/actions/setup-ci-job/action.yml
@@ -269,7 +269,9 @@ runs:
     - name: Check NPU
       if: ${{ inputs.needs-device == 'true' }}
       shell: bash
-      run: npu-smi info
+      run: |
+        task-submit --device "$DEVICE_ID" --timeout 3600 --max-time 120 \
+          --run "cd $GITHUB_WORKSPACE/${{ inputs.checkout-path }} && npu-smi info"
 
     - name: Scope ccache to pto-isa version
       # Namespace ccache by the pinned pto-isa commit so an ISA bump forces a real
@@ -431,6 +433,10 @@ runs:
         # env snapshot may not carry the workspace path.
         _PYPTO_ENV_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
         source "$_PYPTO_ENV_DIR/venv/bin/activate"
+        _PYPTO_SITE="$(python -c 'import sysconfig; print(sysconfig.get_paths()["purelib"])' 2>/dev/null)"
+        if [ -n "$_PYPTO_SITE" ]; then
+          export PYTHONPATH="$_PYPTO_SITE${PYTHONPATH:+:$PYTHONPATH}"
+        fi
         EOF
         if [ "$UNSET_RING" = "true" ]; then
           printf '%s\n' 'unset PTO2_RING_HEAP PTO2_RING_TASK_WINDOW PTO2_RING_DEP_POOL' >> activate.sh

--- a/.github/workflows/a5-exp.yml
+++ b/.github/workflows/a5-exp.yml
@@ -1,0 +1,78 @@
+# Throwaway experiment workflow (do not merge).
+#
+# ONE job, nothing in front of it: the qwen3 scope-3 mixed-kernel ST case on
+# real A5 silicon. No lint / unit-test / docs gate, no toolchain lead job, and
+# ci.yml + docs.yml have their pull_request triggers removed on this branch so
+# nothing else is scheduled and nothing else competes for the shared NPU pool.
+#
+# The three toolchain values below are normally supplied by ci.yml's `toolchain`
+# job, which exists to keep them out of workflow files. They are inlined here on
+# purpose: this branch is a single-shot bisect probe that is never merged, and
+# the lead job would otherwise be a second job. The values are exactly the ones
+# pinned AT THIS BASE COMMIT (71020585):
+#   toolchain/versions.env  -> PTOAS_VERSION=v0.57
+#                              PTOAS_SHA256_AARCH64=4858c837e12b1b588f281207c95916dc20968a7cdc656aadd549a87658a06692
+#   runtime pin -> pto_isa.pin = 83d01313d9bfc247c4b7c8bcf969d1019f0d106f
+name: a5-experiment
+
+on:
+  pull_request:
+    branches: [ "main" ]
+  workflow_dispatch:
+
+concurrency:
+  group: a5-exp-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  a5-qwen3-mixed:
+    permissions:
+      contents: read
+    runs-on: [self-hosted, linux, arm64, npu-a5]
+    defaults:
+      run:
+        working-directory: a5-checkout
+    env:
+      PTOAS_ROOT: ${{ github.workspace }}/a5-checkout/ptoas-bin
+      PTO_ISA_ROOT: ${{ github.workspace }}/a5-checkout/pto-isa
+      PTOAS_VERSION: v0.57
+      PTOAS_SHA256: 4858c837e12b1b588f281207c95916dc20968a7cdc656aadd549a87658a06692
+      CMAKE_BUILD_PARALLEL_LEVEL: 16
+      CMAKE_C_COMPILER_LAUNCHER: ccache
+      CMAKE_CXX_COMPILER_LAUNCHER: ccache
+      CCACHE_MAXSIZE: 30G
+      CCACHE_UMASK: '000'
+    steps:
+      - name: Fetch composite action definitions
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github/actions
+          clean: false
+          persist-credentials: false
+
+      - name: Setup CI job
+        uses: ./.github/actions/setup-ci-job
+        with:
+          checkout-path: a5-checkout
+          needs-device: 'true'
+          pip-cache-name: pip-a5
+          pto-isa-commit: 83d01313d9bfc247c4b7c8bcf969d1019f0d106f
+          toolchain: bundle
+
+      - name: Test qwen3 scope-3 mixed kernel (A5, on board)
+        timeout-minutes: 60
+        run: |
+          source activate.sh
+          echo "[device] DEVICE_ID=$DEVICE_ID"
+          test -n "$DEVICE_ID" || { echo "DEVICE_ID is empty in the runner env"; exit 1; }
+          task-submit --device "$DEVICE_ID" --timeout 3600 --max-time 3600 \
+            --run "cd $GITHUB_WORKSPACE/a5-checkout && source activate.sh && python -m pytest \
+              tests/st/runtime/cross_core/test_cross_core.py \
+              tests/st/runtime/framework_and_models/test_qwen3_decode_scope3_mixed.py \
+              -v --forked --platform=a5 --device=\$TASK_DEVICE"
+
+      - name: Kill orphaned task-submit tasks
+        if: always()
+        uses: ./.github/actions/kill-orphaned-tasks
+        with:
+          checkout-path: a5-checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,6 @@ name: CI
 on:
   push:
     branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,7 +20,6 @@ name: Docs
 on:
   push:
     branches: [ "main" ]
-  pull_request:
   # Republish without a code change, and exercise the deploy path on demand.
   workflow_dispatch:
 


### PR DESCRIPTION
Throwaway single-shot probe. **Do not merge, do not review.**

## The bisect was chasing a boundary that does not exist

`test_qwen3_decode_scope3_mixed[a5]` passed on board at `main@71020585` on 2026-08-13. Re-tested today, **that same commit stalls** — same runner instance and card (`npu-a5-3`, device 0), identical signature:

```
sub_class=S1:running-stalled (detail=1) completed=41/563 running=1 ready=0
waiting=521 orch_done=1 stuck_task_id=8589934631 stuck_core=1
```

So the six earlier probes (#2425, #2426, #2430, #2434, #2435, #2436) were all red simply because everything is red. **Their commit-level verdicts are void**, including the ones that appeared to rule out #2378, #2273, #2382 and #2351. This control should have run first.

## What this probe changes

One thing: the pytest invocation. The 2026-08-13 run executed the full `cross_core` file (10 cases) before qwen3 in a single session; every probe since has run qwen3 alone. Board state left by preceding work is a plausible reason the same binary behaves differently.

- **qwen3 green here** → the stall depends on what runs before it, not on any source change; the a5 job as written is order-sensitive.
- **qwen3 red here** → the 2026-08-13 green is not reproducible in any form, and the difference is environmental drift on the npu-a5 host.

Two `cross_core` cases are expected to fail: they are xfail-ed on a later commit this branch deliberately does not carry. Only the qwen3 result matters.