### PR TITLE
fix(codegen): raise post-verification invariants as InternalError

### DIFF
--- a/.claude/rules/error-checking.md
+++ b/.claude/rules/error-checking.md
@@ -4,7 +4,7 @@
 
 PyPTO uses two distinct macros: `CHECK` for user errors, `INTERNAL_CHECK` for internal bugs. When operating on IR and a `Span` is in scope, prefer the `_SPAN` variants (`CHECK_SPAN`, `INTERNAL_CHECK_SPAN`, `UNREACHABLE_SPAN`, `INTERNAL_UNREACHABLE_SPAN`) — they auto-emit IR source location on failure and dramatically improve debuggability for both users and developers.
 
-**Inside passes, codegen, and backend emitters**: these operate on IR that earlier passes have already verified. A failed invariant there therefore almost always indicates a **compiler bug** — use `INTERNAL_CHECK_SPAN`, not `CHECK`. Reserve `CHECK` / `CHECK_SPAN` for documented user-facing limitations (e.g. "feature X not yet supported — use Y"). In `src/codegen` / `src/backend` specifically, argument-count and post-`As<T>()` checks are always internal — `tests/lint/check_emitter_check_classification.py` enforces this.
+**Inside passes, codegen, and backend emitters**: these operate on IR that earlier passes have already verified. A failed invariant there therefore almost always indicates a **compiler bug** — use `INTERNAL_CHECK_SPAN`, not `CHECK`. Reserve `CHECK` / `CHECK_SPAN` for documented user-facing limitations (e.g. "feature X not yet supported — use Y"). In `src/codegen` / `src/backend` specifically, argument-count checks are always internal — `tests/lint/check_emitter_check_classification.py` enforces that, and rejects any `CHECK` whose message claims an internal error. Post-`As<T>()` checks belong to the same class, but that sweep is unfinished and the lint does not detect them.
 
 ## CHECK / CHECK_SPAN - User Input Validation
 

--- a/.claude/rules/error-checking.md
+++ b/.claude/rules/error-checking.md
@@ -4,7 +4,7 @@
 
 PyPTO uses two distinct macros: `CHECK` for user errors, `INTERNAL_CHECK` for internal bugs. When operating on IR and a `Span` is in scope, prefer the `_SPAN` variants (`CHECK_SPAN`, `INTERNAL_CHECK_SPAN`, `UNREACHABLE_SPAN`, `INTERNAL_UNREACHABLE_SPAN`) — they auto-emit IR source location on failure and dramatically improve debuggability for both users and developers.
 
-**Inside passes**: passes operate on IR that earlier passes have already verified. A failed invariant inside a pass therefore almost always indicates a **compiler bug** — use `INTERNAL_CHECK_SPAN`, not `CHECK`. Reserve `CHECK` / `CHECK_SPAN` for documented user-facing limitations (e.g. "feature X not yet supported — use Y").
+**Inside passes, codegen, and backend emitters**: these operate on IR that earlier passes have already verified. A failed invariant there therefore almost always indicates a **compiler bug** — use `INTERNAL_CHECK_SPAN`, not `CHECK`. Reserve `CHECK` / `CHECK_SPAN` for documented user-facing limitations (e.g. "feature X not yet supported — use Y"). In `src/codegen` / `src/backend` specifically, argument-count and post-`As<T>()` checks are always internal — `tests/lint/check_emitter_check_classification.py` enforces this.
 
 ## CHECK / CHECK_SPAN - User Input Validation
 
@@ -194,6 +194,6 @@ void InternalHelper(IRNode* node) {
 | **For** | User errors / documented user-facing limitations | Internal bugs (pass invariants, postconditions) |
 | **Raises** | `pypto::ValueError` | `pypto::InternalError` |
 | **Message** | User-friendly | Technical, mark as "Internal error" |
-| **Inside passes** | Rare — only for surfaced limitations | Default |
+| **In passes / codegen / backend** | Rare — only for surfaced limitations | Default |
 
 **Remember:** `CHECK` = user error, `INTERNAL_CHECK` = PyPTO bug. Prefer the `_SPAN` variants whenever an IR `Span` is reachable. Always use PyPTO exceptions!

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,6 +56,13 @@ repos:
           language_version: python3
           pass_filenames: false
 
+        - id: check-emitter-check-classification
+          name: check-emitter-check-classification
+          entry: python tests/lint/check_emitter_check_classification.py
+          language: python
+          language_version: python3
+          pass_filenames: false
+
         - id: check-op-name-literals
           name: check-op-name-literals
           entry: python tests/lint/check_op_name_literals.py

--- a/docs/en/dev/02-error-handling.md
+++ b/docs/en/dev/02-error-handling.md
@@ -251,6 +251,11 @@ the whole pass pipeline, so an invariant that fails there cannot have come from 
 | Unsupported dtype x backend, unsupported feature combination | `CHECK_SPAN` | The user chose the dtype and the backend; the message should name the remedy |
 | A user-supplied kwarg's value (e.g. `tensor.create`'s `init_value`) | `CHECK_SPAN` | No upstream pass constrains it |
 
+The table is the policy, not a description of the current tree: the argument-count sweep is done,
+but roughly 34 post-`As<T>()` checks in these two directories are still `CHECK`. That sweep needs
+per-site judgment — several sit beside tests that assert `ValueError` — so it was left for a
+follow-up rather than done mechanically, and the lint below deliberately does not flag them.
+
 `op` is a `const ir::CallPtr&` in every emitter registration macro, so `op->span_` is in scope and
 the `_SPAN` form is almost always available — it attaches the IR source location these sites would
 otherwise lack.

--- a/docs/en/dev/02-error-handling.md
+++ b/docs/en/dev/02-error-handling.md
@@ -238,6 +238,34 @@ CHECK_SPAN(args.size() == 2, span) << "tensor.matmul requires 2 args";
 
 Passes operate on IR that has already been verified by earlier passes. A failed invariant inside a pass therefore almost always indicates a **compiler bug**, not a user error — use `INTERNAL_CHECK_SPAN` / `INTERNAL_UNREACHABLE_SPAN`. Reserve `CHECK_SPAN` for genuine user-facing limitations that the user can work around (e.g. "4D scatter_update is not yet lowered — use 2D"). If you're unsure, ask: *would the message read "this is a PyPTO bug, please report" or "please change your code"?*
 
+### Inside codegen and backend emitters
+
+The same reasoning applies with less room for doubt. `src/codegen` and `src/backend` run *after*
+the whole pass pipeline, so an invariant that fails there cannot have come from user input:
+
+| Class | Verdict | Why |
+| ----- | ------- | --- |
+| Argument count (`op->args_.size() == N`) | `INTERNAL_CHECK_SPAN` | Arity is fixed by the op definition and enforced by the registry's deduce-type function at IR-construction time |
+| Result of an `As<T>()` downcast | `INTERNAL_CHECK_SPAN` | The operand type was settled during type deduction and re-checked by the verifier |
+| Codegen-internal bookkeeping (SSA names, offset maps) | `INTERNAL_CHECK` | Populated by codegen itself; no user-reachable input |
+| Unsupported dtype x backend, unsupported feature combination | `CHECK_SPAN` | The user chose the dtype and the backend; the message should name the remedy |
+| A user-supplied kwarg's value (e.g. `tensor.create`'s `init_value`) | `CHECK_SPAN` | No upstream pass constrains it |
+
+`op` is a `const ir::CallPtr&` in every emitter registration macro, so `op->span_` is in scope and
+the `_SPAN` form is almost always available — it attaches the IR source location these sites would
+otherwise lack.
+
+**One deliberate exception.** `ChooseL0Tile` (`src/ir/transforms/utils/l0_tile_chooser.cpp`) raises
+its rejections as `CHECK`s on purpose: `AutoTileMatmulL0` catches `pypto::ValueError` specifically
+in order to emit perf hint PH-AT-005 and leave the matmul untouched. Because `InternalError` is a
+*sibling* of `ValueError` rather than a subclass, converting those checks would turn a graceful
+skip into an uncaught abort.
+
+These sites are unreachable from Python by construction, so no runtime test can hold the
+classification in place. `tests/lint/check_emitter_check_classification.py` (wired into
+`.pre-commit-config.yaml`) is the guard: it rejects a `CHECK` in either tree whose message says
+"Internal error", and a `CHECK` on a call's argument count.
+
 ## Related
 
 - [IR Overview — Source Location Tracking](ir/00-overview.md)

--- a/docs/zh/dev/02-error-handling.md
+++ b/docs/zh/dev/02-error-handling.md
@@ -232,6 +232,31 @@ CHECK_SPAN(args.size() == 2, span) << "tensor.matmul requires 2 args";
 
 Pass 处理的 IR 已被早期 pass 验证过。Pass 中的失败不变式因此几乎总是表明**编译器 bug**,而非用户错误 —— 应使用 `INTERNAL_CHECK_SPAN` / `INTERNAL_UNREACHABLE_SPAN`。仅当确实需要将文档化的用户限制(例如 "4D scatter_update 尚未下沉,请使用 2D")作为用户错误暴露时,才使用 `CHECK_SPAN`。如果不确定,自问:消息读起来是 "这是 PyPTO bug,请上报" 还是 "请修改你的代码"?
 
+### Codegen 与后端发射器内部
+
+同样的推理在这里更无疑义。`src/codegen` 和 `src/backend` 运行在整条 pass 流水线**之后**,
+因此其中失败的不变式不可能来自用户输入:
+
+| 类别 | 结论 | 原因 |
+| ---- | ---- | ---- |
+| 参数个数(`op->args_.size() == N`) | `INTERNAL_CHECK_SPAN` | 参数个数由算子定义固定,并在 IR 构造期由注册表的类型推导函数强制校验 |
+| `As<T>()` 向下转型的结果 | `INTERNAL_CHECK_SPAN` | 操作数类型在类型推导阶段已确定,并由验证器复查 |
+| Codegen 内部簿记(SSA 名字、偏移映射) | `INTERNAL_CHECK` | 由 codegen 自身填充,用户无法触及 |
+| 不支持的 dtype x 后端组合、不支持的特性组合 | `CHECK_SPAN` | dtype 和后端由用户选择,消息应给出解决办法 |
+| 用户传入的 kwarg 取值(如 `tensor.create` 的 `init_value`) | `CHECK_SPAN` | 没有上游 pass 对其加以约束 |
+
+在所有发射器注册宏中 `op` 都是 `const ir::CallPtr&`,因此 `op->span_` 始终在作用域内,
+`_SPAN` 形式几乎总是可用 —— 它能补上这些位置原本缺失的 IR 源码位置。
+
+**一处刻意的例外。** `ChooseL0Tile`(`src/ir/transforms/utils/l0_tile_chooser.cpp`)故意用
+`CHECK` 抛出它的拒绝:`AutoTileMatmulL0` 专门捕获 `pypto::ValueError`,以便发出性能提示
+PH-AT-005 并原样保留该 matmul。由于 `InternalError` 是 `ValueError` 的**兄弟类**而非子类,
+转换这些检查会把优雅跳过变成未捕获的中止。
+
+这些位置在设计上无法从 Python 触达,因此没有任何运行期测试能守住该分类。
+`tests/lint/check_emitter_check_classification.py`(已接入 `.pre-commit-config.yaml`)是守卫:
+它会拒绝两棵树中消息含 "Internal error" 的 `CHECK`,以及针对调用参数个数的 `CHECK`。
+
 ## 相关文档
 
 - [IR 概述 — 源码位置跟踪](ir/00-overview.md)

--- a/docs/zh/dev/02-error-handling.md
+++ b/docs/zh/dev/02-error-handling.md
@@ -245,6 +245,10 @@ Pass 处理的 IR 已被早期 pass 验证过。Pass 中的失败不变式因此
 | 不支持的 dtype x 后端组合、不支持的特性组合 | `CHECK_SPAN` | dtype 和后端由用户选择,消息应给出解决办法 |
 | 用户传入的 kwarg 取值(如 `tensor.create` 的 `init_value`) | `CHECK_SPAN` | 没有上游 pass 对其加以约束 |
 
+上表是策略,而非对当前代码树的描述:参数个数的清理已经完成,但这两个目录中仍有约 34 处
+post-`As<T>()` 检查是 `CHECK`。该清理需要逐点判断 —— 其中若干紧邻断言 `ValueError` 的测试 ——
+因此留作后续工作,而非机械替换;下文的 lint 也刻意不标记它们。
+
 在所有发射器注册宏中 `op` 都是 `const ir::CallPtr&`,因此 `op->span_` 始终在作用域内,
 `_SPAN` 形式几乎总是可用 —— 它能补上这些位置原本缺失的 IR 源码位置。
 

--- a/src/backend/common/pto_ops_crosscore.cpp
+++ b/src/backend/common/pto_ops_crosscore.cpp
@@ -217,7 +217,8 @@ static std::string MakeTpushCodegenPTO(const char* target, const CallPtr& op,
   auto& codegen = AsPto(codegen_base);
   const std::string op_name = std::string("tpush_to_") + target;
 
-  CHECK(op->args_.size() == 1) << op_name << " requires 1 argument (tile), got " << op->args_.size();
+  INTERNAL_CHECK_SPAN(op->args_.size() == 1, op->span_)
+      << op_name << " requires 1 argument (tile), got " << op->args_.size();
   auto tile = AsVarLike(op->args_[0]);
   INTERNAL_CHECK_SPAN(tile, op->span_) << op_name << " first argument must be a Var or IterArg";
 
@@ -252,7 +253,8 @@ static std::string MakeTpopCodegenPTO(const char* target, const CallPtr& op,
   auto& codegen = AsPto(codegen_base);
   const std::string op_name = std::string("tpop_from_") + target;
 
-  CHECK(op->args_.size() == 0) << op_name << " takes no arguments, got " << op->args_.size();
+  INTERNAL_CHECK_SPAN(op->args_.size() == 0, op->span_)
+      << op_name << " takes no arguments, got " << op->args_.size();
 
   const int split = op->GetKwarg<int>("split", 0);
   CHECK(split >= 0 && split <= 2) << op_name
@@ -357,8 +359,8 @@ static std::string MakeTfreeCodegenPTO(const char* target, const CallPtr& op,
   auto& codegen = AsPto(codegen_base);
   const std::string op_name = std::string("tfree_to_") + target;
 
-  CHECK(op->args_.size() == 1) << op_name << " requires 1 argument (tile from tpop), got "
-                               << op->args_.size();
+  INTERNAL_CHECK_SPAN(op->args_.size() == 1, op->span_)
+      << op_name << " requires 1 argument (tile from tpop), got " << op->args_.size();
   INTERNAL_CHECK_SPAN(op->HasKwarg("split"), op->span_)
       << "Internal error: system." << op_name
       << " is missing its 'split' kwarg; StampTfreeSplit must "
@@ -410,9 +412,8 @@ static std::string MakeInitializePipeCodegenPTO(const char* target, const CallPt
   auto& codegen = AsPto(codegen_base);
   const std::string op_name = std::string(target) + "_initialize_pipe";
 
-  CHECK(op->args_.size() == 2) << op_name
-                               << " requires 2 arguments (c2v_consumer_buf, v2c_consumer_buf), got "
-                               << op->args_.size();
+  INTERNAL_CHECK_SPAN(op->args_.size() == 2, op->span_)
+      << op_name << " requires 2 arguments (c2v_consumer_buf, v2c_consumer_buf), got " << op->args_.size();
   const int dir_mask = op->GetKwarg<int>("dir_mask", -1);
   const int slot_size = op->GetKwarg<int>("slot_size", -1);
   CHECK(dir_mask >= 0) << op_name << " requires 'dir_mask' attribute";
@@ -537,7 +538,8 @@ void RegisterCrossCoreOps(Backend& backend, const std::unordered_set<std::string
 
   reg("system.reserve_buffer", [](const ir::CallPtr& op, codegen::CodegenBase& codegen_base) {
     auto& codegen = AsPto(codegen_base);
-    CHECK(op->args_.size() == 0) << "reserve_buffer takes no arguments, got " << op->args_.size();
+    INTERNAL_CHECK_SPAN(op->args_.size() == 0, op->span_)
+        << "reserve_buffer takes no arguments, got " << op->args_.size();
 
     const auto name = op->GetKwarg<std::string>("name");
     const int size = op->GetKwarg<int>("size", -1);
@@ -580,7 +582,8 @@ void RegisterCrossCoreOps(Backend& backend, const std::unordered_set<std::string
 
   reg("system.import_peer_buffer", [](const ir::CallPtr& op, codegen::CodegenBase& codegen_base) {
     auto& codegen = AsPto(codegen_base);
-    CHECK(op->args_.size() == 0) << "import_peer_buffer takes no arguments, got " << op->args_.size();
+    INTERNAL_CHECK_SPAN(op->args_.size() == 0, op->span_)
+        << "import_peer_buffer takes no arguments, got " << op->args_.size();
 
     const auto name = op->GetKwarg<std::string>("name");
     const auto peer_func = op->GetKwarg<std::string>("peer_func");
@@ -612,7 +615,8 @@ void RegisterCrossCoreOps(Backend& backend, const std::unordered_set<std::string
         << "system.syncall: core_type must be aiv_only|aic_only|mix, got " << core_type;
 
     if (mode == "hard") {
-      CHECK(op->args_.empty()) << "system.syncall (hard form) takes no arguments, got " << op->args_.size();
+      INTERNAL_CHECK_SPAN(op->args_.empty(), op->span_)
+          << "system.syncall (hard form) takes no arguments, got " << op->args_.size();
       codegen.Emit("pto.syncall() mode = #pto.sync_all_mode<hard>, core_type = #pto.sync_core_type<" +
                    core_type + ">");
       return std::string("");
@@ -622,7 +626,7 @@ void RegisterCrossCoreOps(Backend& backend, const std::unordered_set<std::string
     // The current PTO-ISA uses one soft operand ABI for every participant set:
     // [gm_workspace] or [gm_workspace, used_cores]. Omitting used_cores asks
     // PTO-ISA to derive the participant count from the launch configuration.
-    CHECK(op->args_.size() == 1 || op->args_.size() == 2)
+    INTERNAL_CHECK_SPAN(op->args_.size() == 1 || op->args_.size() == 2, op->span_)
         << "system.syncall (soft " << core_type << ") requires gm_workspace and optional used_cores, got "
         << op->args_.size() << " operands";
 

--- a/src/backend/common/pto_ops_datamove.cpp
+++ b/src/backend/common/pto_ops_datamove.cpp
@@ -73,8 +73,8 @@ using pto_ops_detail::MaterializeSubviewOperandIfNeeded;
 // Arguments: args[0] = target (destination base), args[1] = source, args[2] = offset MakeTuple
 static std::string MakeTileAssembleCodegenPTO(const CallPtr& op, codegen::CodegenBase& codegen_base) {
   auto& codegen = AsPto(codegen_base);
-  CHECK(op->args_.size() == 3) << "tile.assemble requires 3 arguments (target, source, offset), got "
-                               << op->args_.size();
+  INTERNAL_CHECK_SPAN(op->args_.size() == 3, op->span_)
+      << "tile.assemble requires 3 arguments (target, source, offset), got " << op->args_.size();
 
   auto target_tile_type = ir::As<ir::TileType>(op->args_[0]->GetType());
   auto source_tile_type = ir::As<ir::TileType>(op->args_[1]->GetType());
@@ -345,7 +345,7 @@ static std::string MakeTileAssembleCodegenPTO(const CallPtr& op, codegen::Codege
 // so only the valid side, and the GM partition_view sizes, can be dynamic.
 static std::string MakeGatherRowCodegenPTO(const CallPtr& op, codegen::CodegenBase& codegen_base) {
   auto& codegen = AsPto(codegen_base);
-  CHECK(op->args_.size() == 5 || op->args_.size() == 6)
+  INTERNAL_CHECK_SPAN(op->args_.size() == 5 || op->args_.size() == 6, op->span_)
       << "tile.gather_row requires 5-6 arguments "
          "(dst, src, dst_offset, src_offset, shapes[, valid_shape]), got "
       << op->args_.size();
@@ -528,8 +528,8 @@ static std::string MakeGatherRowCodegenPTO(const CallPtr& op, codegen::CodegenBa
 static std::string MakeSort32CodegenPTO(const std::string& pto_op_name, const CallPtr& op,
                                         codegen::CodegenBase& codegen_base) {
   auto& codegen = AsPto(codegen_base);
-  CHECK(op->args_.size() == 2) << "Operation:[" << pto_op_name
-                               << "] requires 2 arguments (src, idx), but got " << op->args_.size();
+  INTERNAL_CHECK_SPAN(op->args_.size() == 2, op->span_)
+      << "Operation:[" << pto_op_name << "] requires 2 arguments (src, idx), but got " << op->args_.size();
 
   std::string src = codegen.GetExprAsCode(op->args_[0]);
   std::string idx = codegen.GetExprAsCode(op->args_[1]);
@@ -562,7 +562,8 @@ static std::string MakeSort32CodegenPTO(const std::string& pto_op_name, const Ca
 //   ins(src, {maskPattern = #pto.mask_pattern<Pxxxx>} : src_type, "row") outs(dst : dst_type)
 static std::string MakeGatherMaskCodegenPTO(const CallPtr& op, codegen::CodegenBase& codegen_base) {
   auto& codegen = AsPto(codegen_base);
-  CHECK(op->args_.size() == 1) << "tile.gather_mask requires 1 argument (src), but got " << op->args_.size();
+  INTERNAL_CHECK_SPAN(op->args_.size() == 1, op->span_)
+      << "tile.gather_mask requires 1 argument (src), but got " << op->args_.size();
 
   int pattern = op->GetKwarg<int>("mask_pattern");
   CHECK(pattern >= 1 && pattern < static_cast<int>(mask_patterns.size()))
@@ -601,8 +602,8 @@ static std::string MakeGatherMaskCodegenPTO(const CallPtr& op, codegen::CodegenB
 // must resolve their own DPS targets — done via ResolveTupleResultElements.
 static std::string MakeGatherCompareCodegenPTO(const CallPtr& op, codegen::CodegenBase& codegen_base) {
   auto& codegen = AsPto(codegen_base);
-  CHECK(op->args_.size() == 3) << "tile.gather_compare requires 3 arguments (src, kvalue, tmp), but got "
-                               << op->args_.size();
+  INTERNAL_CHECK_SPAN(op->args_.size() == 3, op->span_)
+      << "tile.gather_compare requires 3 arguments (src, kvalue, tmp), but got " << op->args_.size();
 
   ir::VarPtr tuple_var = codegen.GetCurrentResultVar();
   INTERNAL_CHECK_SPAN(tuple_var, op->span_)
@@ -662,8 +663,8 @@ static std::string MakeGatherCompareCodegenPTO(const CallPtr& op, codegen::Codeg
 // only src in ins(); dst is the outs() scale tile (address = src_addr >> SHIFT).
 static std::string MakeTGetScaleAddrCodegenPTO(const CallPtr& op, codegen::CodegenBase& codegen_base) {
   auto& codegen = AsPto(codegen_base);
-  CHECK(op->args_.size() == 2) << op->op_->name_ << " requires 2 arguments (dst_scale, src), but got "
-                               << op->args_.size();
+  INTERNAL_CHECK_SPAN(op->args_.size() == 2, op->span_)
+      << op->op_->name_ << " requires 2 arguments (dst_scale, src), but got " << op->args_.size();
 
   std::string src = codegen.GetExprAsCode(op->args_[1]);
   std::string src_ty = codegen.GetExprTypeAnnotation(op->args_[1]);
@@ -701,8 +702,8 @@ static std::string MakeTGetScaleAddrCodegenPTO(const CallPtr& op, codegen::Codeg
 // GetCurrentResultTarget() returns the same SSA as args_[0].
 static std::string MakeScatterCodegenPTO(const CallPtr& op, codegen::CodegenBase& codegen_base) {
   auto& codegen = AsPto(codegen_base);
-  CHECK(op->args_.size() == 3) << "tile.scatter requires 3 arguments (dst, src, indexes), but got "
-                               << op->args_.size();
+  INTERNAL_CHECK_SPAN(op->args_.size() == 3, op->span_)
+      << "tile.scatter requires 3 arguments (dst, src, indexes), but got " << op->args_.size();
 
   std::string src = codegen.GetExprAsCode(op->args_[1]);
   std::string idx = codegen.GetExprAsCode(op->args_[2]);
@@ -760,8 +761,8 @@ static std::string MakeScatterCodegenPTO(const CallPtr& op, codegen::CodegenBase
 // within each row, which PTOAS v0.55 names the "row" axis.
 static std::string MakeScatterMaskCodegenPTO(const CallPtr& op, codegen::CodegenBase& codegen_base) {
   auto& codegen = AsPto(codegen_base);
-  CHECK(op->args_.size() == 2) << "tile.scatter_mask requires 2 arguments (dst, src), but got "
-                               << op->args_.size();
+  INTERNAL_CHECK_SPAN(op->args_.size() == 2, op->span_)
+      << "tile.scatter_mask requires 2 arguments (dst, src), but got " << op->args_.size();
 
   int pattern = op->GetKwarg<int>("mask_pattern");
   CHECK(pattern >= 1 && pattern < static_cast<int>(mask_patterns.size()))
@@ -813,7 +814,7 @@ static std::string MakeScatterMaskCodegenPTO(const CallPtr& op, codegen::Codegen
 static std::string MakeMrgSortCodegenPTO(const std::string& pto_op_name, const CallPtr& op,
                                          codegen::CodegenBase& codegen_base) {
   auto& codegen = AsPto(codegen_base);
-  CHECK(op->args_.size() >= 3 && op->args_.size() <= 5)
+  INTERNAL_CHECK_SPAN(op->args_.size() >= 3 && op->args_.size() <= 5, op->span_)
       << "Operation:[" << pto_op_name << "] requires 3-5 arguments (2-4 srcs + tmp), but got "
       << op->args_.size();
 
@@ -872,8 +873,9 @@ static std::string MakeMrgSortCodegenPTO(const std::string& pto_op_name, const C
 static std::string MakeMrgSort1CodegenPTO(const std::string& pto_op_name, const CallPtr& op,
                                           codegen::CodegenBase& codegen_base) {
   auto& codegen = AsPto(codegen_base);
-  CHECK(op->args_.size() == 2) << "Operation:[" << pto_op_name
-                               << "] requires 2 arguments (src, block_len), but got " << op->args_.size();
+  INTERNAL_CHECK_SPAN(op->args_.size() == 2, op->span_)
+      << "Operation:[" << pto_op_name << "] requires 2 arguments (src, block_len), but got "
+      << op->args_.size();
 
   std::string src = codegen.GetExprAsCode(op->args_[0]);
   std::string src_type = codegen.GetExprTypeAnnotation(op->args_[0]);
@@ -1025,7 +1027,7 @@ void RegisterDataMoveOps(Backend& backend, const std::unordered_set<std::string>
     // reflected in the result tile-buf type) — the pto.subview sizes/offset come
     // from the full-rank shape/offset tuples, so codegen ignores it. An empty
     // 4th MakeTuple is the "no valid_shape" sentinel that pairs with drop_dims.
-    CHECK(op->args_.size() >= 3 && op->args_.size() <= 5)
+    INTERNAL_CHECK_SPAN(op->args_.size() >= 3 && op->args_.size() <= 5, op->span_)
         << "Operation:[tile.slice] requires 3-5 arguments (tile, shape, offset[, valid_shape[, "
            "drop_dims]]), but got "
         << op->args_.size();
@@ -1212,7 +1214,7 @@ void RegisterDataMoveOps(Backend& backend, const std::unordered_set<std::string>
 
   reg("tile.extract", [](const ir::CallPtr& op, codegen::CodegenBase& codegen_base) {
     auto& codegen = AsPto(codegen_base);
-    CHECK(op->args_.size() == 4)
+    INTERNAL_CHECK_SPAN(op->args_.size() == 4, op->span_)
         << "tile.extract requires 4 arguments (src, index_row, index_col, shape), but got "
         << op->args_.size();
 
@@ -1255,8 +1257,8 @@ void RegisterDataMoveOps(Backend& backend, const std::unordered_set<std::string>
 
   reg("tile.reshape", [](const ir::CallPtr& op, codegen::CodegenBase& codegen_base) {
     auto& codegen = AsPto(codegen_base);
-    CHECK(op->args_.size() == 2) << "Operation:[tile.reshape] requires 2 arguments (tile, shape), but got "
-                                 << op->args_.size();
+    INTERNAL_CHECK_SPAN(op->args_.size() == 2, op->span_)
+        << "Operation:[tile.reshape] requires 2 arguments (tile, shape), but got " << op->args_.size();
     std::string result_target = codegen.GetCurrentResultTarget();
 
     // Derive the result type from the result var's TileType so a MemRef-less
@@ -1336,8 +1338,8 @@ void RegisterDataMoveOps(Backend& backend, const std::unordered_set<std::string>
     //    which owns no buffer) and the PTOAS planner, where addr-less aliased
     //    vars collapse onto ONE tile_buf handle: the second alloc_tile that
     //    would have carried the transposed layout is never emitted.
-    CHECK(op->args_.size() == 1) << "Operation:[tile.transpose_view] requires 1 argument (tile), but got "
-                                 << op->args_.size();
+    INTERNAL_CHECK_SPAN(op->args_.size() == 1, op->span_)
+        << "Operation:[tile.transpose_view] requires 1 argument (tile), but got " << op->args_.size();
     auto& codegen = AsPto(codegen_base);
     std::string result_target = codegen.GetCurrentResultTarget();
 
@@ -1366,7 +1368,7 @@ void RegisterDataMoveOps(Backend& backend, const std::unordered_set<std::string>
 
   reg("tile.set_validshape", [](const ir::CallPtr& op, codegen::CodegenBase& codegen_base) {
     auto& codegen = AsPto(codegen_base);
-    CHECK(op->args_.size() == 3)
+    INTERNAL_CHECK_SPAN(op->args_.size() == 3, op->span_)
         << "tile.set_validshape requires 3 arguments (tile, valid_rows, valid_cols), but got "
         << op->args_.size();
 

--- a/src/backend/common/pto_ops_distributed.cpp
+++ b/src/backend/common/pto_ops_distributed.cpp
@@ -359,7 +359,7 @@ static std::string MakeRemoteLoadCodegenPTO(const CallPtr& op, codegen::CodegenB
 // reshape.
 static std::string MakeRemoteStoreCodegenPTO(const CallPtr& op, codegen::CodegenBase& codegen_base) {
   auto& codegen = AsPto(codegen_base);
-  CHECK(op->args_.size() == 4)
+  INTERNAL_CHECK_SPAN(op->args_.size() == 4, op->span_)
       << "pld.tile.remote_store requires 4 arguments (src_tile, target, peer, offsets), got "
       << op->args_.size();
 
@@ -460,9 +460,10 @@ static std::string MakeRemoteStoreCodegenPTO(const CallPtr& op, codegen::Codegen
 //   pto.comm.tnotify(<pview>, <value>) {notifyOp = #pto<notify_op (set|atomic_add)>}
 static std::string MakeNotifyCodegenPTO(const CallPtr& op, codegen::CodegenBase& codegen_base) {
   auto& codegen = AsPto(codegen_base);
-  CHECK(op->args_.size() == 4) << "pld.system.notify requires 4 arguments (target, peer, offsets, "
-                                  "value), got "
-                               << op->args_.size();
+  INTERNAL_CHECK_SPAN(op->args_.size() == 4, op->span_)
+      << "pld.system.notify requires 4 arguments (target, peer, offsets, "
+         "value), got "
+      << op->args_.size();
 
   auto binding = ResolveDistTensorBinding(op->args_[0], codegen, "pld.system.notify");
   auto offsets_tuple = As<ir::MakeTuple>(op->args_[2]);
@@ -520,8 +521,8 @@ static std::string MakeNotifyCodegenPTO(const CallPtr& op, codegen::CodegenBase&
 //   pto.comm.twait(<pview>, <expected>) {cmp = #pto<wait_cmp (eq|ge)>}
 static std::string MakeWaitCodegenPTO(const CallPtr& op, codegen::CodegenBase& codegen_base) {
   auto& codegen = AsPto(codegen_base);
-  CHECK(op->args_.size() == 3) << "pld.system.wait requires 3 arguments (signal, offsets, expected), got "
-                               << op->args_.size();
+  INTERNAL_CHECK_SPAN(op->args_.size() == 3, op->span_)
+      << "pld.system.wait requires 3 arguments (signal, offsets, expected), got " << op->args_.size();
 
   auto signal_var = AsVarLike(op->args_[0]);
   CHECK(signal_var) << "pld.system.wait signal must be a Var-like expression";
@@ -798,7 +799,7 @@ static std::string MakeDeferWaitCodegenPTO(const CallPtr& op, codegen::CodegenBa
 static std::string MakePutCodegenPTO(const CallPtr& op, codegen::CodegenBase& codegen_base) {
   auto& codegen = AsPto(codegen_base);
   const size_t n = op->args_.size();
-  CHECK(n == 4 || n == 5 || n == 7 || n == 8)
+  INTERNAL_CHECK_SPAN(n == 4 || n == 5 || n == 7 || n == 8, op->span_)
       << "pld.tile.put requires 4/5 (single/double stage, full-slice) or 7/8 (single/double stage, "
          "subregion) arguments (dst, peer, src, stage[, stage2][, dst_offsets, src_offsets, shape]), got "
       << n;
@@ -942,7 +943,7 @@ static std::string MakePutCodegenPTO(const CallPtr& op, codegen::CodegenBase& co
 static std::string MakeGetCodegenPTO(const CallPtr& op, codegen::CodegenBase& codegen_base) {
   auto& codegen = AsPto(codegen_base);
   const size_t n = op->args_.size();
-  CHECK(n == 4 || n == 5 || n == 7 || n == 8)
+  INTERNAL_CHECK_SPAN(n == 4 || n == 5 || n == 7 || n == 8, op->span_)
       << "pld.tile.get requires 4/5 (single/double stage, full-slice) or 7/8 (single/double stage, "
          "subregion) arguments (dst, peer, src, stage[, stage2][, dst_offsets, src_offsets, shape]), got "
       << n;
@@ -1110,8 +1111,8 @@ void RegisterDistributedOps(Backend& backend, const std::unordered_set<std::stri
   reg("pld.system.get_comm_ctx",
       [](const ir::CallPtr& op, codegen::CodegenBase& codegen_base) -> std::string {
         auto& cg = AsPto(codegen_base);
-        CHECK(op->args_.size() == 1) << "pld.system.get_comm_ctx expects exactly 1 argument, got "
-                                     << op->args_.size();
+        INTERNAL_CHECK_SPAN(op->args_.size() == 1, op->span_)
+            << "pld.system.get_comm_ctx expects exactly 1 argument, got " << op->args_.size();
         auto var = ir::AsVarLike(op->args_[0]);
         CHECK(var) << "pld.system.get_comm_ctx expects a Var (DistributedTensor param), got "
                    << op->args_[0]->TypeName();
@@ -1131,7 +1132,8 @@ void RegisterDistributedOps(Backend& backend, const std::unordered_set<std::stri
   // (rankId, rankNum) u64 slot via ``pto.load_scalar`` + ``arith.trunci``.
   reg("pld.system.rank", [](const ir::CallPtr& op, codegen::CodegenBase& codegen_base) -> std::string {
     auto& cg = AsPto(codegen_base);
-    CHECK(op->args_.size() == 1) << "pld.system.rank expects exactly 1 argument, got " << op->args_.size();
+    INTERNAL_CHECK_SPAN(op->args_.size() == 1, op->span_)
+        << "pld.system.rank expects exactly 1 argument, got " << op->args_.size();
     std::string ctx_ssa = cg.GetExprAsCode(op->args_[0]);
     std::string rk_pair = EmitLoadRankPair(cg, ctx_ssa);
     std::string rk = cg.GetCurrentResultTarget();
@@ -1146,7 +1148,8 @@ void RegisterDistributedOps(Backend& backend, const std::unordered_set<std::stri
   // i64 right by 32 instead of issuing a second pto.load_scalar.
   reg("pld.system.nranks", [](const ir::CallPtr& op, codegen::CodegenBase& codegen_base) -> std::string {
     auto& cg = AsPto(codegen_base);
-    CHECK(op->args_.size() == 1) << "pld.system.nranks expects exactly 1 argument, got " << op->args_.size();
+    INTERNAL_CHECK_SPAN(op->args_.size() == 1, op->span_)
+        << "pld.system.nranks expects exactly 1 argument, got " << op->args_.size();
     namespace cl = codegen::distributed::comm_layout;
     static_assert(cl::kRankNumOffset == cl::kRankIdOffset + 4,
                   "pld.system.nranks codegen assumes rankNum sits in the high 32 bits of rankId's i64 slot");

--- a/src/backend/common/pto_ops_elementwise.cpp
+++ b/src/backend/common/pto_ops_elementwise.cpp
@@ -202,8 +202,8 @@ static std::string MakeTileSelCodegenPTO(const CallPtr& op, codegen::CodegenBase
 // address before codegen (required at --pto-level=level3).
 static std::string MakeTileTransposeCodegenPTO(const CallPtr& op, codegen::CodegenBase& codegen_base) {
   auto& codegen = AsPto(codegen_base);
-  CHECK(op->args_.size() == 4) << "tile.transpose requires 4 arguments (src, axis0, axis1, tmp), got "
-                               << op->args_.size();
+  INTERNAL_CHECK_SPAN(op->args_.size() == 4, op->span_)
+      << "tile.transpose requires 4 arguments (src, axis0, axis1, tmp), got " << op->args_.size();
 
   std::string src_ssa = codegen.GetExprAsCode(op->args_[0]);
   std::string src_type = codegen.GetExprTypeAnnotation(op->args_[0]);
@@ -237,8 +237,8 @@ struct SingleOperandOp {
 static std::string MakeSingleOperandCodegenPTO(const SingleOperandOp& spec, const CallPtr& op,
                                                codegen::CodegenBase& codegen_base) {
   auto& codegen = AsPto(codegen_base);
-  CHECK(op->args_.size() == 2) << spec.ir_name << " requires 2 arguments" << spec.arg_desc << ", got "
-                               << op->args_.size();
+  INTERNAL_CHECK_SPAN(op->args_.size() == 2, op->span_)
+      << spec.ir_name << " requires 2 arguments" << spec.arg_desc << ", got " << op->args_.size();
   const ir::ExprPtr& operand = op->args_[spec.operand_idx];
   EmitInsOuts(codegen, spec.pto_op,
               {{codegen.GetExprAsCode(operand), codegen.GetExprTypeAnnotation(operand)}});
@@ -308,8 +308,9 @@ static std::string MakeAssignCodegenPTO(const std::string& pto_op_name, const Ca
 static std::string MakeCiCodegenPTO(const std::string& pto_op_name, const CallPtr& op,
                                     codegen::CodegenBase& codegen_base) {
   auto& codegen = AsPto(codegen_base);
-  CHECK(op->args_.size() == 2) << "Operation:[" << pto_op_name
-                               << "] requires 2 arguments (start, shape), but got " << op->args_.size();
+  INTERNAL_CHECK_SPAN(op->args_.size() == 2, op->span_)
+      << "Operation:[" << pto_op_name << "] requires 2 arguments (start, shape), but got "
+      << op->args_.size();
   bool descending = op->GetKwarg<bool>("descending");
   std::string src = codegen.GetExprAsCode(op->args_[0]);
   std::string src_type = codegen.GetExprTypeAnnotation(op->args_[0]);
@@ -334,7 +335,7 @@ static std::string MakeCiCodegenPTO(const std::string& pto_op_name, const CallPt
 // Shape and optional valid_shape operands are type-only and are not emitted.
 static std::string MakeTriCodegenPTO(const CallPtr& op, codegen::CodegenBase& codegen_base) {
   auto& codegen = AsPto(codegen_base);
-  CHECK(op->args_.size() == 2 || op->args_.size() == 3)
+  INTERNAL_CHECK_SPAN(op->args_.size() == 2 || op->args_.size() == 3, op->span_)
       << "Operation:[pto.ttri] requires 2 or 3 arguments (diagonal, shape, [valid_shape]), but got "
       << op->args_.size();
   auto result_type = As<ir::TileType>(op->GetType());
@@ -404,7 +405,7 @@ static std::string MakeGatherbCodegenPTO(const CallPtr& op, codegen::CodegenBase
 static std::string MakeRandomCodegenPTO(const std::string& pto_op_name, const CallPtr& op,
                                         codegen::CodegenBase& codegen_base) {
   auto& codegen = AsPto(codegen_base);
-  CHECK(op->args_.size() == 7 || op->args_.size() == 8)
+  INTERNAL_CHECK_SPAN(op->args_.size() == 7 || op->args_.size() == 8, op->span_)
       << "Operation:[" << pto_op_name
       << "] requires 7 or 8 arguments (key0, key1, counter0, counter1, counter2, "
          "counter3, shape, [valid_shape]), but got "
@@ -445,8 +446,8 @@ static std::string MakeRandomCodegenPTO(const std::string& pto_op_name, const Ca
 static std::string MakePrintCodegenPTO(const std::string& pto_op_name, const CallPtr& op,
                                        codegen::CodegenBase& codegen_base) {
   auto& codegen = AsPto(codegen_base);
-  CHECK(op->args_.size() == 1) << "Operation:" << pto_op_name << "] requires 1 argument, but got "
-                               << op->args_.size();
+  INTERNAL_CHECK_SPAN(op->args_.size() == 1, op->span_)
+      << "Operation:" << pto_op_name << "] requires 1 argument, but got " << op->args_.size();
   std::string src = codegen.GetExprAsCode(op->args_[0]);
   codegen.Emit(pto_op_name + " ins(" + src + " | !pto.partition_tensor_view<MxNxdtype>)");
   return "";
@@ -764,7 +765,8 @@ void RegisterElementwiseOps(Backend& backend, const std::unordered_set<std::stri
     auto reg_entry = backend.RegisterOp("tile.row_expand_add");
     reg_entry.f_codegen([](const ir::CallPtr& op, codegen::CodegenBase& codegen) {
       const size_t arity = op->args_.size();
-      CHECK(arity == 2 || arity == 3) << "tile.row_expand_add requires 2 or 3 arguments, but got " << arity;
+      INTERNAL_CHECK_SPAN(arity == 2 || arity == 3, op->span_)
+          << "tile.row_expand_add requires 2 or 3 arguments, but got " << arity;
       return MakeNaryCodegenPTO("pto.trowexpandadd", arity, op, codegen);
     });
   }
@@ -782,7 +784,8 @@ void RegisterElementwiseOps(Backend& backend, const std::unordered_set<std::stri
   // format.
   reg("tile.move", [](const ir::CallPtr& op, codegen::CodegenBase& codegen_base) {
     auto& codegen = AsPto(codegen_base);
-    CHECK(op->args_.size() == 1) << "tile.move requires 1 argument, got " << op->args_.size();
+    INTERNAL_CHECK_SPAN(op->args_.size() == 1, op->span_)
+        << "tile.move requires 1 argument, got " << op->args_.size();
 
     // Under memory_planner=PtoAS there is no baked address: AllocateMemoryAddr is
     // skipped and every `byte_offset_` is still the -1 sentinel, so the offset
@@ -884,7 +887,8 @@ void RegisterElementwiseOps(Backend& backend, const std::unordered_set<std::stri
     backend.RegisterOp("tile.rsqrt")
         .f_codegen([](const ir::CallPtr& op, codegen::CodegenBase& codegen) {
           size_t arity = op->args_.size();
-          CHECK(arity == 1 || arity == 2) << "tile.rsqrt requires 1 or 2 arguments, but got " << arity;
+          INTERNAL_CHECK_SPAN(arity == 1 || arity == 2, op->span_)
+              << "tile.rsqrt requires 1 or 2 arguments, but got " << arity;
           return MakeNaryCodegenPTO("pto.trsqrt", arity, op, codegen);
         })
         .set_input_layout(0, ir::TileLayout::row_major)
@@ -898,7 +902,7 @@ void RegisterElementwiseOps(Backend& backend, const std::unordered_set<std::stri
     backend.RegisterOp("tile.col_sum")
         .f_codegen([](const ir::CallPtr& op, codegen::CodegenBase& codegen_base) {
           auto& codegen = AsPto(codegen_base);
-          CHECK(op->args_.size() == 1 || op->args_.size() == 2)
+          INTERNAL_CHECK_SPAN(op->args_.size() == 1 || op->args_.size() == 2, op->span_)
               << "tile.col_sum requires 1 or 2 arguments, but got " << op->args_.size();
           std::string config_attr = op->args_.size() == 2 ? " {isBinary = true}" : "";
           codegen.Emit("pto.tcolsum " + GenerateInsOutsClause(op, codegen, config_attr));
@@ -984,12 +988,9 @@ void RegisterElementwiseOps(Backend& backend, const std::unordered_set<std::stri
     return [pto_op, init_pto_op, supports_init_cond](const ir::CallPtr& op,
                                                      codegen::CodegenBase& codegen_base) -> std::string {
       auto& codegen = AsPto(codegen_base);
-      const size_t max_args = supports_init_cond ? 4 : 3;
-      CHECK(op->args_.size() == 3 || (supports_init_cond && op->args_.size() == 4))
+      INTERNAL_CHECK_SPAN(op->args_.size() == 3 || (supports_init_cond && op->args_.size() == 4), op->span_)
           << pto_op << " requires 3 arguments (acc, lhs, rhs)"
           << (supports_init_cond ? " or 4 with init_cond" : "") << ", but got " << op->args_.size();
-      INTERNAL_CHECK(op->args_.size() <= max_args)
-          << "Internal error: " << pto_op << " arity exceeds what this codegen accepts";
 
       std::string dst = codegen.GetCurrentResultTarget();
       std::string lhs = codegen.GetExprAsCode(op->args_[1]);
@@ -1069,9 +1070,9 @@ void RegisterElementwiseOps(Backend& backend, const std::unordered_set<std::stri
   auto make_mx_acc_codegen = [](const std::string& pto_op) {
     return [pto_op](const ir::CallPtr& op, codegen::CodegenBase& codegen_base) -> std::string {
       auto& codegen = AsPto(codegen_base);
-      CHECK(op->args_.size() == 5) << pto_op
-                                   << " requires 5 arguments: acc, lhs, lhs_scale, rhs, rhs_scale, but got "
-                                   << op->args_.size();
+      INTERNAL_CHECK_SPAN(op->args_.size() == 5, op->span_)
+          << pto_op << " requires 5 arguments: acc, lhs, lhs_scale, rhs, rhs_scale, but got "
+          << op->args_.size();
 
       std::string dst = codegen.GetCurrentResultTarget();
       INTERNAL_CHECK(!dst.empty()) << "Internal error: " << pto_op

--- a/src/backend/common/pto_ops_memory.cpp
+++ b/src/backend/common/pto_ops_memory.cpp
@@ -536,7 +536,8 @@ static std::string GetFlatOffsetSSA(const ir::MakeTuplePtr& indices_tuple,
 // Helper function for tile.read (indices -> flat offset -> pto.tgetval)
 static std::string MakeTileReadCodegenPTO(const CallPtr& op, codegen::CodegenBase& codegen_base) {
   auto& codegen = AsPto(codegen_base);
-  CHECK(op->args_.size() == 2) << "tile.read requires 2 arguments, but got " << op->args_.size();
+  INTERNAL_CHECK_SPAN(op->args_.size() == 2, op->span_)
+      << "tile.read requires 2 arguments, but got " << op->args_.size();
 
   auto tile_type = As<ir::TileType>(op->args_[0]->GetType());
   INTERNAL_CHECK_SPAN(tile_type, op->span_) << "tile.read first argument must be TileType";
@@ -566,7 +567,8 @@ static std::string MakeTileReadCodegenPTO(const CallPtr& op, codegen::CodegenBas
 // Helper function for tile.write (indices -> flat offset -> pto.tsetval)
 static std::string MakeTileWriteCodegenPTO(const CallPtr& op, codegen::CodegenBase& codegen_base) {
   auto& codegen = AsPto(codegen_base);
-  CHECK(op->args_.size() == 3) << "tile.write requires 3 arguments, but got " << op->args_.size();
+  INTERNAL_CHECK_SPAN(op->args_.size() == 3, op->span_)
+      << "tile.write requires 3 arguments, but got " << op->args_.size();
 
   auto tile_type = As<ir::TileType>(op->args_[0]->GetType());
   INTERNAL_CHECK_SPAN(tile_type, op->span_) << "tile.write first argument must be TileType";
@@ -599,7 +601,8 @@ static std::string MakeTileWriteCodegenPTO(const CallPtr& op, codegen::CodegenBa
 
 static std::string MakeTensorReadCodegenPTO(const CallPtr& op, codegen::CodegenBase& codegen_base) {
   auto& codegen = AsPto(codegen_base);
-  CHECK(op->args_.size() == 2) << "tensor.read requires 2 arguments, but got " << op->args_.size();
+  INTERNAL_CHECK_SPAN(op->args_.size() == 2, op->span_)
+      << "tensor.read requires 2 arguments, but got " << op->args_.size();
 
   auto tensor_type_ptr = AsTensorTypeLike(op->args_[0]->GetType());
   INTERNAL_CHECK_SPAN(tensor_type_ptr, op->span_) << "tensor.read first argument must be TensorType";
@@ -635,7 +638,8 @@ static std::string MakeTensorReadCodegenPTO(const CallPtr& op, codegen::CodegenB
 
 static std::string MakeTensorWriteCodegenPTO(const CallPtr& op, codegen::CodegenBase& codegen_base) {
   auto& codegen = AsPto(codegen_base);
-  CHECK(op->args_.size() == 3) << "tensor.write requires 3 arguments, but got " << op->args_.size();
+  INTERNAL_CHECK_SPAN(op->args_.size() == 3, op->span_)
+      << "tensor.write requires 3 arguments, but got " << op->args_.size();
 
   auto tensor_type_ptr = AsTensorTypeLike(op->args_[0]->GetType());
   INTERNAL_CHECK_SPAN(tensor_type_ptr, op->span_) << "tensor.write first argument must be TensorType";
@@ -678,7 +682,8 @@ static std::string MakeTensorWriteCodegenPTO(const CallPtr& op, codegen::Codegen
 
 static std::string MakeTensorDimCodegenPTO(const CallPtr& op, codegen::CodegenBase& codegen_base) {
   auto& codegen = AsPto(codegen_base);
-  CHECK(op->args_.size() == 2) << "tensor.dim requires 2 arguments, but got " << op->args_.size();
+  INTERNAL_CHECK_SPAN(op->args_.size() == 2, op->span_)
+      << "tensor.dim requires 2 arguments, but got " << op->args_.size();
   auto input_tensor = ir::As<ir::TensorType>(op->args_[0]->GetType());
   CHECK(input_tensor) << "tensor.dim need TensorType for first arg, but got "
                       << op->args_[0]->GetType()->TypeName();
@@ -752,7 +757,7 @@ void RegisterMemoryOps(Backend& backend, const std::unordered_set<std::string>& 
   // pto.local_array_set mutates the same `pto.declare_local_array` storage.
   reg("array.create", [](const ir::CallPtr& op, codegen::CodegenBase& codegen_base) {
     auto& codegen = AsPto(codegen_base);
-    CHECK(op->args_.size() == 1) << "array.create requires 1 argument (extent)";
+    INTERNAL_CHECK_SPAN(op->args_.size() == 1, op->span_) << "array.create requires 1 argument (extent)";
     auto array_type = ir::As<ir::ArrayType>(op->GetType());
     CHECK(array_type) << "array.create must return ArrayType";
     std::string result = codegen.GetCurrentResultTarget();
@@ -764,7 +769,8 @@ void RegisterMemoryOps(Backend& backend, const std::unordered_set<std::string>& 
 
   reg("array.get_element", [](const ir::CallPtr& op, codegen::CodegenBase& codegen_base) {
     auto& codegen = AsPto(codegen_base);
-    CHECK(op->args_.size() == 2) << "array.get_element requires 2 arguments (array, index)";
+    INTERNAL_CHECK_SPAN(op->args_.size() == 2, op->span_)
+        << "array.get_element requires 2 arguments (array, index)";
     auto array_type = ir::As<ir::ArrayType>(op->args_[0]->GetType());
     CHECK(array_type) << "array.get_element first argument must be an ArrayType";
     std::string result = codegen.GetCurrentResultTarget();
@@ -779,7 +785,8 @@ void RegisterMemoryOps(Backend& backend, const std::unordered_set<std::string>& 
 
   reg("array.update_element", [](const ir::CallPtr& op, codegen::CodegenBase& codegen_base) {
     auto& codegen = AsPto(codegen_base);
-    CHECK(op->args_.size() == 3) << "array.update_element requires 3 arguments (array, index, value)";
+    INTERNAL_CHECK_SPAN(op->args_.size() == 3, op->span_)
+        << "array.update_element requires 3 arguments (array, index, value)";
     auto array_type = ir::As<ir::ArrayType>(op->args_[0]->GetType());
     CHECK(array_type) << "array.update_element first argument must be an ArrayType";
     // arr resolves to the input array's SSA; the AssignStmt dispatch has already
@@ -805,7 +812,8 @@ void RegisterMemoryOps(Backend& backend, const std::unordered_set<std::string>& 
   auto reg_spmd_identity_op = [&](const char* tile_op, std::string (codegen::PTOCodegen::*getter)() const) {
     reg(tile_op, [tile_op, getter](const ir::CallPtr& op, codegen::CodegenBase& codegen_base) {
       auto& codegen = AsPto(codegen_base);
-      CHECK(op->args_.empty()) << tile_op << " takes no arguments, got " << op->args_.size();
+      INTERNAL_CHECK_SPAN(op->args_.empty(), op->span_)
+          << tile_op << " takes no arguments, got " << op->args_.size();
       std::string result = codegen.GetCurrentResultTarget();
       INTERNAL_CHECK_SPAN(!result.empty(), op->span_) << tile_op << " requires assignment target";
       std::string arg_ssa = (codegen.*getter)();

--- a/src/backend/common/pto_ops_shared.cpp
+++ b/src/backend/common/pto_ops_shared.cpp
@@ -75,8 +75,9 @@ codegen::PTOCodegen& AsPto(codegen::CodegenBase& codegen_base) {
 // Validate a call's arity with the canonical "Operation:[<pto_op>] requires N
 // argument(s), but got M" message shared by the simple-op handlers.
 void CheckArity(const CallPtr& op, std::string_view pto_op_name, size_t arity) {
-  CHECK(op->args_.size() == arity) << "Operation:[" << pto_op_name << "] requires " << arity << " argument"
-                                   << (arity != 1 ? "s" : "") << ", but got " << op->args_.size();
+  INTERNAL_CHECK_SPAN(op->args_.size() == arity, op->span_)
+      << "Operation:[" << pto_op_name << "] requires " << arity << " argument" << (arity != 1 ? "s" : "")
+      << ", but got " << op->args_.size();
 }
 
 const std::vector<std::string> cmp_modes = {"eq", "ne", "lt", "le", "gt", "ge"};

--- a/src/codegen/array_op_codegen.cpp
+++ b/src/codegen/array_op_codegen.cpp
@@ -48,7 +48,7 @@ using namespace pypto::ir;  // NOLINT(build/namespaces)
 REGISTER_ORCHESTRATION_OP(array_create, ("array.create")) {
   // array.create(extent) -> ArrayType. Emit a stack-local C-style array
   // declaration: ``dtype name[N] = {0};``.
-  CHECK(op->args_.size() == 1) << "array.create requires 1 argument (extent)";
+  INTERNAL_CHECK_SPAN(op->args_.size() == 1, op->span_) << "array.create requires 1 argument (extent)";
   auto array_type = As<ArrayType>(op->GetType());
   CHECK(array_type) << "array.create must return ArrayType";
 
@@ -85,7 +85,7 @@ REGISTER_ORCHESTRATION_OP(array_create, ("array.create")) {
 
 REGISTER_ORCHESTRATION_OP(array_get_element, ("array.get_element")) {
   // array.get_element(array, index) -> ScalarType. Emit ``dtype tmp = arr[i];``.
-  CHECK(op->args_.size() == 2) << "array.get_element requires 2 arguments";
+  INTERNAL_CHECK_SPAN(op->args_.size() == 2, op->span_) << "array.get_element requires 2 arguments";
 
   std::string array_name = codegen.GenerateExprString(op->args_[0]);
   std::string index_expr = codegen.GenerateExprString(op->args_[1]);
@@ -108,7 +108,7 @@ REGISTER_ORCHESTRATION_OP(array_update_element, ("array.update_element")) {
   // Lowered to an in-place write. The orchestration codegen's AssignStmt
   // dispatch aliases the LHS to the input array's emit name BEFORE invoking
   // this handler, so writes to the result variable land on the same storage.
-  CHECK(op->args_.size() == 3) << "array.update_element requires 3 arguments";
+  INTERNAL_CHECK_SPAN(op->args_.size() == 3, op->span_) << "array.update_element requires 3 arguments";
 
   std::string array_name = codegen.GenerateExprString(op->args_[0]);
   std::string index_expr = codegen.GenerateExprString(op->args_[1]);

--- a/src/codegen/distributed/distributed_ops_codegen.cpp
+++ b/src/codegen/distributed/distributed_ops_codegen.cpp
@@ -409,7 +409,7 @@ REGISTER_DISTRIBUTED_OP(builtin_tensor_all_to_all_v, "builtin.tensor.all_to_all_
 REGISTER_DISTRIBUTED_OP(tensor_slice, "tensor.slice") {
   auto& dist_codegen = dynamic_cast<DistributedCodegen&>(codegen);
 
-  CHECK(op->args_.size() == 3 || op->args_.size() == 4 || op->args_.size() == 5)
+  INTERNAL_CHECK_SPAN(op->args_.size() == 3 || op->args_.size() == 4 || op->args_.size() == 5, op->span_)
       << "tensor.slice host_orch codegen expects 3-5 args (input, shape, offset[, valid_shape[, "
          "drop_dims]]), "
          "got "

--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -2397,7 +2397,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
     CHECK_SPAN(read && IsOp(read, "tensor.read") && konst, pred->span_)
         << "Submit dispatch predicate must compare a tensor element (a tensor.read, e.g. t[i]) against "
            "an integer literal; got neither side in that form";
-    CHECK_SPAN(read->args_.size() >= 2, read->span_)
+    INTERNAL_CHECK_SPAN(read->args_.size() >= 2, read->span_)
         << "tensor.read in a dispatch predicate must have a tensor and an index list";
 
     // tensor.read(tensor, MakeTuple(i0, i1, ...)) — arg 0 is the tensor, arg 1

--- a/src/codegen/pto/pto_codegen.cpp
+++ b/src/codegen/pto/pto_codegen.cpp
@@ -1988,7 +1988,7 @@ std::string PTOCodegen::GetGMSlotBufferSSAForPipe(int pipe_id, int dir_mask) {
   }
 
   auto offset_it = gm_slot_buffer_offsets_.find(key);
-  CHECK(offset_it != gm_slot_buffer_offsets_.end())
+  INTERNAL_CHECK(offset_it != gm_slot_buffer_offsets_.end())
       << "Internal error: missing GM slot buffer offset for frontend pipe id " << pipe_id << " and dir_mask "
       << dir_mask;
   const int64_t byte_offset = offset_it->second;

--- a/src/codegen/pto/pto_control_flow_codegen.cpp
+++ b/src/codegen/pto/pto_control_flow_codegen.cpp
@@ -67,13 +67,13 @@ static std::string JoinPairs(const std::vector<std::string>& lhs, const std::str
 // ========================================================================
 
 void PTOCodegen::VisitStmt_(const EvalStmtPtr& op) {
-  INTERNAL_CHECK_SPAN(op != nullptr, op->span_) << "Internal error: null EvalStmt";
+  INTERNAL_CHECK(op != nullptr) << "Internal error: null EvalStmt";
   INTERNAL_CHECK_SPAN(op->expr_ != nullptr, op->span_) << "Internal error: EvalStmt has null expression";
   VisitExpr(op->expr_);
 }
 
 void PTOCodegen::VisitStmt_(const YieldStmtPtr& op) {
-  INTERNAL_CHECK_SPAN(op != nullptr, op->span_) << "Internal error: null YieldStmt";
+  INTERNAL_CHECK(op != nullptr) << "Internal error: null YieldStmt";
 
   if (op->value_.empty()) {
     return;
@@ -211,7 +211,7 @@ bool IsDefinedInBranch(const ir::Var* var, const StmtPtr& body) {
 }  // namespace
 
 void PTOCodegen::VisitStmt_(const IfStmtPtr& op) {
-  INTERNAL_CHECK_SPAN(op != nullptr, op->span_) << "Internal error: null IfStmt";
+  INTERNAL_CHECK(op != nullptr) << "Internal error: null IfStmt";
   INTERNAL_CHECK_SPAN(op->condition_ != nullptr, op->span_) << "Internal error: IfStmt has null condition";
   INTERNAL_CHECK_SPAN(op->then_body_ != nullptr, op->span_) << "Internal error: IfStmt has null then_body";
 
@@ -516,11 +516,11 @@ void PTOCodegen::VisitStmt_(const IfStmtPtr& op) {
 }
 
 void PTOCodegen::VisitStmt_(const ForStmtPtr& op) {
-  INTERNAL_CHECK_SPAN(op != nullptr, op->span_) << "Internal error: null ForStmt";
+  INTERNAL_CHECK(op != nullptr) << "Internal error: null ForStmt";
   INTERNAL_CHECK_SPAN(op->loop_var_ != nullptr, op->span_) << "Internal error: ForStmt has null loop_var";
   INTERNAL_CHECK_SPAN(op->body_ != nullptr, op->span_) << "Internal error: ForStmt has null body";
 
-  CHECK(op->iter_args_.size() == op->return_vars_.size())
+  INTERNAL_CHECK_SPAN(op->iter_args_.size() == op->return_vars_.size(), op->span_)
       << "ForStmt iter_args size (" << op->iter_args_.size() << ") must equal return_vars size ("
       << op->return_vars_.size() << ")";
 
@@ -696,11 +696,11 @@ void PTOCodegen::VisitStmt_(const ForStmtPtr& op) {
 }
 
 void PTOCodegen::VisitStmt_(const WhileStmtPtr& op) {
-  INTERNAL_CHECK_SPAN(op != nullptr, op->span_) << "Internal error: null WhileStmt";
+  INTERNAL_CHECK(op != nullptr) << "Internal error: null WhileStmt";
   INTERNAL_CHECK_SPAN(op->condition_ != nullptr, op->span_) << "Internal error: WhileStmt has null condition";
   INTERNAL_CHECK_SPAN(op->body_ != nullptr, op->span_) << "Internal error: WhileStmt has null body";
 
-  CHECK(op->iter_args_.size() == op->return_vars_.size())
+  INTERNAL_CHECK_SPAN(op->iter_args_.size() == op->return_vars_.size(), op->span_)
       << "WhileStmt iter_args size (" << op->iter_args_.size() << ") must equal return_vars size ("
       << op->return_vars_.size() << ")";
 

--- a/src/codegen/tensor_op_codegen.cpp
+++ b/src/codegen/tensor_op_codegen.cpp
@@ -184,7 +184,7 @@ REGISTER_ORCHESTRATION_OP(tensor_read, ("tensor.read")) {
   // while other runtimes may synchronize with a producer. Using the API
   // uniformly preserves that policy and avoids the type-unsafe raw deref via
   // buffer.addr that a direct static_cast<T*>(ptr)[idx] would imply.
-  CHECK(op->args_.size() == 2) << "tensor.read requires 2 arguments";
+  INTERNAL_CHECK_SPAN(op->args_.size() == 2, op->span_) << "tensor.read requires 2 arguments";
 
   std::string input_name = codegen.TryGetVarName(op->args_[0]);
   CHECK(!input_name.empty()) << "tensor.read input must be a variable";
@@ -233,7 +233,7 @@ REGISTER_ORCHESTRATION_OP(tensor_write, ("tensor.write")) {
   // host view of an external tensor and does not support task-produced tensors,
   // while other runtimes may synchronize with producers and consumers. This is
   // the same reason tensor.read uses get_tensor_data<T>() instead of a raw store.
-  CHECK(op->args_.size() == 3) << "tensor.write requires 3 arguments";
+  INTERNAL_CHECK_SPAN(op->args_.size() == 3, op->span_) << "tensor.write requires 3 arguments";
 
   std::string input_name = codegen.TryGetVarName(op->args_[0]);
   CHECK(!input_name.empty()) << "tensor.write input must be a variable";
@@ -281,7 +281,7 @@ REGISTER_ORCHESTRATION_OP(tensor_slice, ("tensor.slice")) {
   // tensor.slice(input, shape_tuple, offset_tuple[, valid_shape_tuple[, drop_dims_tuple]])
   // -> Generate a runtime view and, for rank-reducing scalar indices, reshape away
   // the statically-unit axes recorded in drop_dims.
-  CHECK(op->args_.size() >= 3 && op->args_.size() <= 5)
+  INTERNAL_CHECK_SPAN(op->args_.size() >= 3 && op->args_.size() <= 5, op->span_)
       << "tensor.slice requires 3 to 5 arguments (input, shape, offset[, valid_shape[, drop_dims]])";
 
   std::string input_name = codegen.TryGetVarName(op->args_[0]);
@@ -427,7 +427,7 @@ REGISTER_ORCHESTRATION_OP(tensor_slice, ("tensor.slice")) {
 REGISTER_ORCHESTRATION_OP(tensor_reshape, ("tensor.reshape")) {
   // tensor.reshape(input, shape_tuple[, valid_shape_tuple]) -> Generate shape array variable and call
   // .reshape() on the runtime ChipTensor (see runtime/.../tensor.h: ChipTensor::reshape).
-  CHECK(op->args_.size() == 2 || op->args_.size() == 3)
+  INTERNAL_CHECK_SPAN(op->args_.size() == 2 || op->args_.size() == 3, op->span_)
       << "tensor.reshape requires 2 or 3 arguments (input, shape[, valid_shape])";
 
   std::string input_name = codegen.TryGetVarName(op->args_[0]);
@@ -483,7 +483,7 @@ REGISTER_ORCHESTRATION_OP(tensor_transpose, ("tensor.transpose")) {
   // The optional 4th `valid_shape` argument from the IR op is intentionally
   // ignored at the orchestration layer (it only affects IR metadata, mirroring
   // how tensor.reshape handles valid_shape here).
-  CHECK(op->args_.size() == 3 || op->args_.size() == 4)
+  INTERNAL_CHECK_SPAN(op->args_.size() == 3 || op->args_.size() == 4, op->span_)
       << "tensor.transpose requires 3 or 4 arguments (input, axis1, axis2[, valid_shape])";
 
   std::string input_name = codegen.TryGetVarName(op->args_[0]);

--- a/tests/lint/check_emitter_check_classification.py
+++ b/tests/lint/check_emitter_check_classification.py
@@ -33,6 +33,11 @@ macro statement at a time (balanced predicate parens, then to the terminating ``
 fixed-line-window scan instead reports adjacent ``INTERNAL_CHECK_SPAN`` lines that legitimately
 say "Internal error" -- ``pto_ops_crosscore.cpp`` and ``scope_outline_utils.h`` both have that
 shape.
+
+C++ raw string literals get their own masking pass. Emitter code builds target syntax out of
+literals such as ``R"(", dtype="opaque", count=)"`` (``distributed_codegen.cpp``), whose body
+carries unpaired quotes. Scanning those as ordinary literals desynchronizes the masker, which
+both hides real checks after the literal and can report text inside one as code.
 """
 
 import argparse
@@ -113,6 +118,50 @@ def _blank_block_comment(text: str, out: list[str], i: int, n: int) -> int:
     return i
 
 
+# C++ raw-string prefixes, longest first so `u8R` wins over `R`.
+_RAW_PREFIXES = ("u8R", "LR", "uR", "UR", "R")
+
+# A raw-string delimiter is at most 16 characters and excludes whitespace,
+# parentheses and backslash.
+_RAW_DELIM_MAX = 16
+
+
+def _raw_prefix_start(text: str, quote: int) -> int:
+    """Offset where a raw-string prefix ending at *quote* begins, or -1 for none."""
+    for prefix in _RAW_PREFIXES:
+        start = quote - len(prefix)
+        if start < 0 or text[start:quote] != prefix:
+            continue
+        before = text[start - 1] if start > 0 else ""
+        if not (before.isalnum() or before == "_"):
+            return start
+    return -1
+
+
+def _blank_raw_string(text: str, out: list[str], i: int, n: int) -> tuple[int, int, int] | None:
+    """Blank a raw string literal ``R"delim( ... )delim"`` opening at *i*.
+
+    Returns ``(offset past the literal, content start, content end)``, or None when the
+    literal is malformed, so the caller can fall back to ordinary quote handling.
+    """
+    j = i + 1
+    while j < n and text[j] != "(" and (j - i - 1) < _RAW_DELIM_MAX:
+        if text[j].isspace() or text[j] in ")\\":
+            return None
+        j += 1
+    if j >= n or text[j] != "(":
+        return None
+    terminator = ")" + text[i + 1 : j] + '"'
+    body = j + 1
+    end = text.find(terminator, body)
+    stop = n if end == -1 else end + len(terminator)
+    end = n if end == -1 else end
+    for k in range(i + 1, min(stop, n)):
+        if text[k] != "\n":
+            out[k] = " "
+    return stop, body, min(end, n)
+
+
 def _blank_quoted(text: str, out: list[str], i: int, n: int, quote: str) -> tuple[int, int]:
     """Blank the contents of a ``quote``-delimited literal starting at its opening quote.
 
@@ -148,8 +197,15 @@ def _blank_comments_and_strings(text: str) -> tuple[str, list[tuple[int, int]]]:
         elif ch == "/" and nxt == "*":
             i = _blank_block_comment(text, out, i, n)
         elif ch == '"':
-            i, start = _blank_quoted(text, out, i, n, '"')
-            strings.append((start, min(i - 1, n)))
+            raw = None
+            if _raw_prefix_start(text, i) >= 0:
+                raw = _blank_raw_string(text, out, i, n)
+            if raw is not None:
+                i, body_start, body_end = raw
+                strings.append((body_start, body_end))
+            else:
+                i, start = _blank_quoted(text, out, i, n, '"')
+                strings.append((start, min(i - 1, n)))
         elif ch == "'":
             i, _ = _blank_quoted(text, out, i, n, "'")
         else:

--- a/tests/lint/check_emitter_check_classification.py
+++ b/tests/lint/check_emitter_check_classification.py
@@ -1,0 +1,266 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""
+Script to check that codegen and backend emitters classify their checks correctly.
+
+``src/codegen`` and ``src/backend`` run strictly *after* verification. An invariant that fails
+there is a compiler bug, not user input, so it belongs to ``INTERNAL_CHECK`` /
+``INTERNAL_CHECK_SPAN`` (``pypto::InternalError``) rather than ``CHECK`` / ``CHECK_SPAN``
+(``pypto::ValueError``). See ``.claude/rules/error-checking.md`` and
+``docs/en/dev/02-error-handling.md``.
+
+These sites cannot be reached from Python by construction -- arity and operand types are settled
+by the op registry's deduce-type functions at IR-construction time, and ``Call`` / ``ForStmt`` have
+no Python bindings -- so no runtime test can hold the classification in place. This lint is the
+guard.
+
+Two rules, both scoped to ``src/codegen`` and ``src/backend``:
+
+Rule A -- a ``CHECK`` whose message says "Internal error". The macro throws ``ValueError`` while
+the message tells the user it is a compiler bug; one of the two is wrong.
+
+Rule B -- a ``CHECK`` on a call's argument count. Arity is fixed by the op definition and enforced
+before codegen runs, so a mismatch is a broken pass or a broken op definition.
+
+The scanner walks each file once, tracking comments and string literals, and extracts one whole
+macro statement at a time (balanced predicate parens, then to the terminating ``;``). A naive
+fixed-line-window scan instead reports adjacent ``INTERNAL_CHECK_SPAN`` lines that legitimately
+say "Internal error" -- ``pto_ops_crosscore.cpp`` and ``scope_outline_utils.h`` both have that
+shape.
+"""
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# Trees that run after verification. Everything here is post-verification by construction.
+SCANNED_DIRS = ("src/codegen", "src/backend")
+
+SOURCE_SUFFIXES = frozenset({".cpp", ".cc", ".h", ".hpp"})
+
+# Sites that are genuinely user-facing despite matching a rule. Each entry is
+# "<repo-relative path>:<line>" and needs a comment saying why the user can actually reach it.
+ALLOWLIST: frozenset[str] = frozenset()
+
+# ``CHECK(`` / ``CHECK_SPAN(`` but never ``INTERNAL_CHECK(`` / ``INTERNAL_CHECK_SPAN(``.
+_MACRO_RE = re.compile(r"(?<![A-Za-z0-9_])(CHECK|CHECK_SPAN)\s*\(")
+
+# ``op->args_.size()`` / ``call->args_.empty()`` and friends.
+_ARITY_RE = re.compile(r"\bargs_\s*\.\s*(?:size|empty)\s*\(")
+
+# ``const size_t arity = op->args_.size();`` -- a local alias for the argument count.
+_ARITY_ALIAS_RE = re.compile(
+    r"\b(?:const\s+)?(?:size_t|auto|int|int64_t|std::size_t)\s+(\w+)\s*=\s*[^;]*"
+    r"\bargs_\s*\.\s*(?:size|empty)\s*\(\s*\)"
+)
+
+_IDENT_RE = re.compile(r"\b[A-Za-z_]\w*\b")
+
+_INTERNAL_MARKER = "internal error"
+
+
+def get_git_tracked_sources(root_dir: Path) -> list[Path]:
+    """Get the git-tracked C++ sources under the scanned emitter trees."""
+    try:
+        result = subprocess.run(
+            ["git", "ls-files", "--", *SCANNED_DIRS],
+            cwd=root_dir,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except subprocess.CalledProcessError as e:
+        print(f"Error: Failed to get git tracked files: {e}", file=sys.stderr)
+        sys.exit(1)
+    except FileNotFoundError:
+        print("Error: git command not found", file=sys.stderr)
+        sys.exit(1)
+
+    files = []
+    for line in result.stdout.splitlines():
+        path = root_dir / line
+        if Path(line).suffix in SOURCE_SUFFIXES and path.is_file():
+            files.append(path)
+    return sorted(files)
+
+
+def _blank_line_comment(text: str, out: list[str], i: int, n: int) -> int:
+    """Blank a ``//`` comment through end of line; return the offset just past it."""
+    while i < n and text[i] != "\n":
+        out[i] = " "
+        i += 1
+    return i
+
+
+def _blank_block_comment(text: str, out: list[str], i: int, n: int) -> int:
+    """Blank a ``/* ... */`` comment, keeping newlines; return the offset just past it."""
+    while i < n and not (text[i] == "*" and i + 1 < n and text[i + 1] == "/"):
+        if text[i] != "\n":
+            out[i] = " "
+        i += 1
+    for _ in range(2):
+        if i < n:
+            out[i] = " "
+            i += 1
+    return i
+
+
+def _blank_quoted(text: str, out: list[str], i: int, n: int, quote: str) -> tuple[int, int]:
+    """Blank the contents of a ``quote``-delimited literal starting at its opening quote.
+
+    Returns ``(offset just past the literal, offset of its first content char)``.
+    """
+    i += 1
+    start = i
+    while i < n and text[i] != quote:
+        if text[i] == "\\":
+            out[i] = " "
+            i += 1
+        if i < n:
+            if text[i] != "\n":
+                out[i] = " "
+            i += 1
+    return i + 1, start
+
+
+def _blank_comments_and_strings(text: str) -> tuple[str, list[tuple[int, int]]]:
+    """Blank out comments and string-literal *contents*, keeping every offset stable.
+
+    Returns the masked text plus the ``(start, end)`` span of each string literal's contents, so
+    the caller can still read message text without tripping over ``(``, ``)`` or ``;`` inside it.
+    """
+    out = list(text)
+    strings: list[tuple[int, int]] = []
+    i, n = 0, len(text)
+    while i < n:
+        ch = text[i]
+        nxt = text[i + 1] if i + 1 < n else ""
+        if ch == "/" and nxt == "/":
+            i = _blank_line_comment(text, out, i, n)
+        elif ch == "/" and nxt == "*":
+            i = _blank_block_comment(text, out, i, n)
+        elif ch == '"':
+            i, start = _blank_quoted(text, out, i, n, '"')
+            strings.append((start, min(i - 1, n)))
+        elif ch == "'":
+            i, _ = _blank_quoted(text, out, i, n, "'")
+        else:
+            i += 1
+    return "".join(out), strings
+
+
+def _statement_end(masked: str, close_paren: int) -> int:
+    """Offset of the ``;`` terminating the macro statement, scanning from the predicate's ``)``."""
+    depth = 0
+    for i in range(close_paren + 1, len(masked)):
+        ch = masked[i]
+        if ch in "([{":
+            depth += 1
+        elif ch in ")]}":
+            depth -= 1
+        elif ch == ";" and depth <= 0:
+            return i
+    return len(masked)
+
+
+def _matching_paren(masked: str, open_paren: int) -> int:
+    """Offset of the ``)`` closing the ``(`` at *open_paren*, or -1 when unbalanced."""
+    depth = 0
+    for i in range(open_paren, len(masked)):
+        if masked[i] == "(":
+            depth += 1
+        elif masked[i] == ")":
+            depth -= 1
+            if depth == 0:
+                return i
+    return -1
+
+
+def find_violations(path: Path) -> list[tuple[int, str, str]]:
+    """Return ``(line, rule, detail)`` for every mis-classified check in *path*."""
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as e:
+        print(f"Error: Failed to read {path}: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    masked, strings = _blank_comments_and_strings(text)
+    aliases = {m.group(1) for m in _ARITY_ALIAS_RE.finditer(masked)}
+
+    violations: list[tuple[int, str, str]] = []
+    for match in _MACRO_RE.finditer(masked):
+        open_paren = match.end() - 1
+        close_paren = _matching_paren(masked, open_paren)
+        if close_paren < 0:
+            continue
+        end = _statement_end(masked, close_paren)
+        line = text.count("\n", 0, match.start()) + 1
+        macro = match.group(1)
+
+        predicate = masked[open_paren + 1 : close_paren]
+        message = " ".join(text[s:e] for s, e in strings if s >= close_paren and e <= end).lower()
+
+        if _INTERNAL_MARKER in message:
+            violations.append((line, "A", f'{macro} message says "Internal error"'))
+            continue
+
+        idents = set(_IDENT_RE.findall(predicate))
+        if _ARITY_RE.search(predicate) or (idents & aliases):
+            violations.append((line, "B", f"{macro} on a call's argument count"))
+
+    return violations
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Check that codegen/backend emitters use INTERNAL_CHECK for post-verification invariants."
+    )
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=Path(__file__).resolve().parents[2],
+        help="Repository root (defaults to the repo containing this script)",
+    )
+    args = parser.parse_args()
+    root_dir = args.root.resolve()
+
+    total = 0
+    for path in get_git_tracked_sources(root_dir):
+        rel = path.relative_to(root_dir).as_posix()
+        for line, rule, detail in find_violations(path):
+            if f"{rel}:{line}" in ALLOWLIST:
+                continue
+            print(f"{rel}:{line}: [rule {rule}] {detail}")
+            total += 1
+
+    if total:
+        print(
+            f"\nFound {total} mis-classified check(s) in {' and '.join(SCANNED_DIRS)}.\n"
+            "These trees run after verification, so a failed invariant there is a compiler bug:\n"
+            "    CHECK(cond)                       -> INTERNAL_CHECK(cond)\n"
+            "    CHECK(cond)      // op in scope   -> INTERNAL_CHECK_SPAN(cond, op->span_)\n"
+            "    CHECK_SPAN(cond, span)            -> INTERNAL_CHECK_SPAN(cond, span)\n"
+            "Prefer the _SPAN form whenever an IR node is in scope -- it attaches the IR source\n"
+            "location. Keep the plain form when the predicate is itself the null guard for the\n"
+            "pointer whose ->span_ you would read (see .claude/rules/error-checking.md).\n"
+            "If a site is genuinely reachable by user input -- an unsupported dtype, a bad kwarg,\n"
+            f"a documented limitation -- add its `<path>:<line>` to ALLOWLIST in {Path(__file__).name}\n"
+            "with a comment saying how the user reaches it.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"All checks in {' and '.join(SCANNED_DIRS)} are classified correctly.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/ut/tools/test_check_emitter_check_classification.py
+++ b/tests/ut/tools/test_check_emitter_check_classification.py
@@ -101,6 +101,40 @@ def test_quoting_edge_cases_do_not_desync_the_scanner(tmp_path: Path, source: st
     assert _rules(tmp_path, source) == ["B"]
 
 
+@pytest.mark.parametrize(
+    "source, expected",
+    [
+        # The reported case: emitter code builds target syntax from raw literals whose body
+        # carries unpaired quotes. Scanning one as an ordinary literal desynchronizes the
+        # masker and silently hides every check after it.
+        ('os << R"(", dtype="opaque", count=)" << n;\nCHECK(op->args_.size() == 1) << "x";', ["B"]),
+        # The mirror failure: arity text inside a raw literal is data, not code.
+        ('const char* s = R"(CHECK(op->args_.size() == 1))";', []),
+        # A custom delimiter must terminate on its own )delim" and nothing shorter.
+        (
+            'auto s = R"d(" CHECK(op->args_.size()==2) )d";\nCHECK(op->args_.size() == 3) << "y";',
+            ["B"],
+        ),
+        # Encoding-prefixed raw literals are raw too.
+        (
+            'auto a = u8R"(")"; auto b = uR"(")";\n'
+            'auto c = UR"(")"; auto d = LR"(")";\n'
+            'CHECK(op->args_.size() == 1) << "z";',
+            ["B"],
+        ),
+        # An identifier merely ending in R does not open a raw literal.
+        ('MYR"abc";\nCHECK(op->args_.size() == 1) << "w";', ["B"]),
+        # A raw-string message still carries its text to rule A.
+        ('CHECK(foo) << R"(Internal error: bad)";', ["A"]),
+        # A malformed literal must not hang or crash the scan.
+        ('auto s = R"(never closed\nCHECK(op->args_.size() == 1);', []),
+    ],
+)
+def test_raw_string_literals_are_masked(tmp_path: Path, source: str, expected: list[str]) -> None:
+    """C++ raw literals may contain unpaired quotes; the masker must skip their bodies whole."""
+    assert _rules(tmp_path, source) == expected
+
+
 def test_repository_is_clean() -> None:
     """The emitter trees must stay classified correctly; this is the gate itself."""
     root = Path(__file__).resolve().parents[3]

--- a/tests/ut/tools/test_check_emitter_check_classification.py
+++ b/tests/ut/tools/test_check_emitter_check_classification.py
@@ -1,0 +1,117 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Tests for the emitter check-classification lint.
+
+The lint guards an invariant no runtime test can reach: ``src/codegen`` and ``src/backend`` run
+after verification, so their argument-count and "Internal error" checks must be ``INTERNAL_CHECK*``
+rather than ``CHECK``. These tests pin the scanner's behaviour on the C++ shapes that a naive
+line-window or regex implementation gets wrong.
+"""
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+
+def _load_lint() -> ModuleType:
+    path = Path(__file__).resolve().parents[2] / "lint" / "check_emitter_check_classification.py"
+    spec = importlib.util.spec_from_file_location("pypto_check_emitter_check_classification", path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+lint = _load_lint()
+
+
+def _rules(tmp_path: Path, source: str) -> list[str]:
+    """Run the scanner over *source* and return the rule letter of each violation."""
+    path = tmp_path / "emitter.cpp"
+    path.write_text(source + "\n")
+    return [rule for _, rule, _ in lint.find_violations(path)]
+
+
+@pytest.mark.parametrize(
+    "source, expected",
+    [
+        # Rule B -- a CHECK on a call's argument count.
+        ('CHECK(op->args_.size() == 2) << "x";', ["B"]),
+        ('CHECK(op->args_.empty()) << "x";', ["B"]),
+        ('CHECK_SPAN(op->args_.size() == 2, op->span_) << "x";', ["B"]),
+        # An arity value bound to a local alias is still an arity check.
+        ('const size_t arity = op->args_.size();\nCHECK(arity == 2) << "x";', ["B"]),
+        # Rule A -- the macro throws ValueError while the message claims a compiler bug.
+        ('CHECK(foo) << "Internal error: bad";', ["A"]),
+        # The INTERNAL_ forms are the fix, never the violation.
+        ('INTERNAL_CHECK(op->args_.size() == 2) << "x";', []),
+        ('INTERNAL_CHECK_SPAN(op->args_.size() == 2, op->span_) << "x";', []),
+        ('INTERNAL_CHECK(foo) << "Internal error: bad";', []),
+        # A genuine user-facing check is left alone.
+        ('CHECK(dtype.IsFloat()) << "not supported on this backend; use FP32";', []),
+    ],
+)
+def test_rule_classification(tmp_path: Path, source: str, expected: list[str]) -> None:
+    assert _rules(tmp_path, source) == expected
+
+
+def test_adjacent_internal_check_does_not_bleed_into_a_clean_check(tmp_path: Path) -> None:
+    """The scanner must read one whole statement, not a fixed window of lines.
+
+    ``pto_ops_crosscore.cpp`` and ``scope_outline_utils.h`` both put an ``INTERNAL_CHECK_SPAN``
+    whose message legitimately says "Internal error" directly below a ``CHECK``. A line-window
+    implementation reports the clean ``CHECK`` for its neighbour's message.
+    """
+    source = 'CHECK(foo) << "fine";\nINTERNAL_CHECK_SPAN(bar, op->span_)\n    << "Internal error: nope";'
+    assert _rules(tmp_path, source) == []
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        '// Internal error: prose about a CHECK(op->args_.size() == 1)\nCHECK(foo) << "fine";',
+        '/* CHECK(op->args_.size() == 1) << "Internal error"; */\nCHECK(foo) << "fine";',
+        'const char* s = "CHECK(op->args_.size() == 1)";\nCHECK(foo) << "fine";',
+    ],
+)
+def test_comments_and_string_literals_are_not_scanned(tmp_path: Path, source: str) -> None:
+    assert _rules(tmp_path, source) == []
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        # A quote inside a char literal must not open a string and swallow the rest of the file.
+        'char c = \'"\';\nCHECK(op->args_.size() == 1) << "x";',
+        # An escaped quote must not close the message early.
+        'CHECK(foo) << "a \\" b";\nCHECK(op->args_.size() == 3) << "y";',
+    ],
+)
+def test_quoting_edge_cases_do_not_desync_the_scanner(tmp_path: Path, source: str) -> None:
+    assert _rules(tmp_path, source) == ["B"]
+
+
+def test_repository_is_clean() -> None:
+    """The emitter trees must stay classified correctly; this is the gate itself."""
+    root = Path(__file__).resolve().parents[3]
+    offenders = [
+        f"{path.relative_to(root).as_posix()}:{line}: [rule {rule}] {detail}"
+        for path in lint.get_git_tracked_sources(root)
+        for line, rule, detail in lint.find_violations(path)
+        if f"{path.relative_to(root).as_posix()}:{line}" not in lint.ALLOWLIST
+    ]
+    assert offenders == [], "Mis-classified checks in codegen/backend:\n" + "\n".join(offenders)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## What

`src/codegen` and `src/backend` run after the whole pass pipeline, so an invariant that fails there is a compiler bug. **66 of them were raised with `CHECK`**, which throws `pypto::ValueError` and reaches the user as an ordinary Python `ValueError` — indistinguishable from a mistake in their own kernel, with no IR location and no C++ frames to attach to a bug report.

The clearest case said so outright: `pto_codegen.cpp` emitted `"Internal error: missing GM slot buffer offset"` through a macro that throws `ValueError`.

By layer, `src/ir/transforms` sits at roughly 4:1 internal-to-user checks (rule followed); these two trees were near 1:1.

## Changes

**Reclassified 66 checks** to `INTERNAL_CHECK` / `INTERNAL_CHECK_SPAN`:

- The GM slot-offset lookup (`pto_codegen.cpp`) — no `Span` in scope, so the plain form.
- The two `ForStmt`/`WhileStmt` `iter_args_`-vs-`return_vars_` size checks. Six sites in the tree test this predicate; these were the only two not already `INTERNAL_CHECK_SPAN`, and each sits sandwiched between `INTERNAL_CHECK_SPAN` calls on the same node.
- Both duplicated `array.get_element` arity checks, which restate what `DeduceArrayGetElementType` already enforced at construction.
- The arity sweep across `pto_ops_*.cpp` and `src/codegen`, including the shared `CheckArity` helper that fans out to 19 call sites.

Messages are preserved verbatim. **65 of the 66 now also carry `op->span_`**, so they gain the IR source location they previously lacked. A redundant `CHECK`/`INTERNAL_CHECK` pair on the same value in `make_acc_codegen` is collapsed.

**Five span-safety fixes.** `pto_control_flow_codegen.cpp` wrote `INTERNAL_CHECK_SPAN(op != nullptr, op->span_)` in five places — the span argument dereferences the very pointer the check guards, so on failure it segfaults instead of raising. `logging.h:639-646` documents this contract explicitly. These are the only five instances in the repo.

**A regression lint.** These sites cannot be reached from Python by construction — arity and operand types are settled by the op registry at IR-construction time, and `Call`/`ForStmt` have no Python bindings — so no runtime test can hold the classification in place. `tests/lint/check_emitter_check_classification.py` rejects a `CHECK` in either tree whose message says "Internal error" (rule A) or whose predicate tests a call's argument count (rule B), wired into `.pre-commit-config.yaml` beside the sibling `check_*` hooks.

**Docs**: a classification table in `docs/{en,zh}/dev/02-error-handling.md`, and one clause extended in `.claude/rules/error-checking.md` (rules budget unchanged at 2321/2500).

## Deliberately left alone

| | Why |
| --- | --- |
| `l0_tile_chooser.cpp` — 17 `CHECK`s | Load-bearing exception-as-control-flow. `auto_tile_matmul_l0_pass.cpp:1094` catches `pypto::ValueError` *specifically* to emit perf hint PH-AT-005 and skip the matmul. `InternalError` is a **sibling** of `ValueError`, not a subclass, so converting these turns a graceful skip into an uncaught abort. Seven tests pin the messages; one pins the contract end-to-end. |
| `tensor_op_codegen.cpp` `init_value` checks | Genuine user kwarg with no upstream verifier; every message names a remedy. |
| `pto_codegen.cpp` 4-bit dtype checks | Genuine unsupported dtype × backend combination. |
| Post-`As<T>()` type re-checks (~45) and enum-tag decodes (~10) | Same defect class, but each needs individual judgment and several sit next to live `ValueError` tests. The new lint does not flag them. |

## Verification

| Check | Result |
| --- | --- |
| Build (12 touched files force-recompiled) | clean |
| `tests/ut/` | **9978 passed, 3 skipped, 0 failed** |
| `pre-commit run --all-files` | all 18 hooks pass |
| Lint negative check | **64** violations against the parent commit (1 rule A + 63 rule B), **0** after |

**Zero test delta**, as expected: no test in the repo asserted on any converted message, and neither tree contains a `try`/`catch`.

## Notes for reviewers

- **The lint found a site the audit missed.** `orchestration_codegen.cpp:2400` — a `CHECK_SPAN` on `tensor.read`'s arity, which the registry pins at exactly 2. That is why the pre-fix count is 64 rather than 63.
- **The scanner reads one whole macro statement**, not a line window. That matters: `pto_ops_crosscore.cpp` and `scope_outline_utils.h` both put an `INTERNAL_CHECK_SPAN` whose message legitimately says "Internal error" directly below a clean `CHECK`, and a window-based implementation reports the `CHECK` for its neighbour's message. `tests/ut/tools/test_check_emitter_check_classification.py` pins that plus the quoting edge cases (char literals, escaped quotes) — 16 tests.
- **Behavioural caveat**: `pypto.InternalError` subclasses `RuntimeError`, not `ValueError`, so `except ValueError` around `.lower()` no longer swallows these. That is the intended effect, and unreachable in normal use.

