### PR TITLE
fix(language): keep warning attribution correct under a symlinked import path

### DIFF
--- a/python/pypto/ir/utils.py
+++ b/python/pypto/ir/utils.py
@@ -209,7 +209,15 @@ def has_partial_valid_region(expr: _ir.Expr) -> bool:
 # code, never the call site a user-facing warning should name. Without the
 # separator a sibling like ``<parent>/pypto_kernels/k.py`` would prefix-match
 # ``<parent>/pypto`` and a real user frame would be skipped.
-_PYPTO_PACKAGE_PREFIX = f"{Path(__file__).resolve().parent.parent}{os.sep}"
+#
+# Normalized with ``abspath``, never ``resolve()``: this is compared against
+# frames' ``co_filename``, which keeps the spelling the import used and does
+# *not* follow symlinks. Resolving only this side makes the two disagree
+# whenever the package is reached through a symlinked path -- every library
+# frame then reads as user code, the walk below stops at 1, and the warning
+# names its own line. ``abspath`` normalizes without following links, so both
+# sides stay in the spelling the import system recorded.
+_PYPTO_PACKAGE_PREFIX = f"{Path(os.path.abspath(__file__)).parent.parent}{os.sep}"
 
 
 def caller_warning_stacklevel() -> int:

--- a/tests/ut/language/test_unified_ops.py
+++ b/tests/ut/language/test_unified_ops.py
@@ -16,6 +16,8 @@ they produce structurally equal IR.
 
 import os
 import pathlib
+import subprocess
+import sys
 import warnings
 
 import pypto.ir.utils as pypto_ir_utils
@@ -1686,6 +1688,35 @@ class TestUnifiedOpsCrossPathKwargs:
         assert not ir.structural_equal(unified.unwrap(), pl.tile.col_sum(t).unwrap())
 
 
+# Run in a subprocess with the ``pypto`` package reached through a symlink.
+# ``argv[1]`` is the symlinked sys.path entry the import is expected to use.
+_SYMLINKED_IMPORT_PROBE = """\
+import sys
+import warnings
+
+import pypto
+from pypto import DataType, ir
+from pypto.language.op import unified_ops
+from pypto.language.typing import Tensor
+
+link_root = sys.argv[1]
+# Without this an installed copy or a stray PYTHONPATH would make the whole
+# check vacuous by importing through the real path.
+assert pypto.__file__.startswith(link_root), f"import bypassed the symlink: {pypto.__file__}"
+
+src = Tensor(expr=ir.Var("x", ir.TensorType([16, 32], DataType.FP32), ir.Span.unknown()))
+with warnings.catch_warnings(record=True) as caught:
+    warnings.simplefilter("default")
+    unified_ops.slice(src, [8, 32], [0, 0], pad_value=ir.PadValue.min)
+    unified_ops.slice(src, [8, 32], [0, 0], pad_value=ir.PadValue.min)
+    unified_ops.slice(src, [8, 32], [0, 0], pad_value=ir.PadValue.min)
+
+assert len(caught) == 3, f"expected one warning per call site, got {len(caught)}"
+blamed = {w.filename for w in caught}
+assert blamed == {__file__}, f"warnings blamed {sorted(blamed)}, not {__file__}"
+"""
+
+
 class TestUnifiedSlicePadValue:
     """``pl.slice`` forwards ``pad_value``, which both dispatch paths honour.
 
@@ -1856,6 +1887,36 @@ class TestUnifiedSlicePadValue:
         # The frame that would call warnings.warn is itself user code, so the
         # level naming it is 1 — not 2, which would name this test instead.
         assert namespace["warn_site"]() == 1
+
+    def test_symlinked_import_path_still_names_the_caller(self, tmp_path):
+        """Reaching PyPTO through a symlink must not break caller attribution.
+
+        ``co_filename`` keeps the spelling the import used, so a package prefix
+        built by resolving symlinks never matches it under a symlinked
+        ``sys.path`` entry. Every library frame then reads as user code, the
+        walk stops at level 1, and ``warnings.warn`` names its own line —
+        collapsing the probe's three call sites onto a single warning.
+
+        Only a real import through a symlink makes ``__file__`` and the sibling
+        frames share the aliased spelling, so this needs a subprocess; an
+        in-process fake frame would not reproduce it.
+        """
+        package_root = pathlib.Path(pypto_ir_utils.__file__).resolve().parent.parent.parent
+        link_root = tmp_path / "linked_python"
+        link_root.symlink_to(package_root, target_is_directory=True)
+
+        script = tmp_path / "user_kernel.py"
+        script.write_text(_SYMLINKED_IMPORT_PROBE)
+
+        result = subprocess.run(
+            [sys.executable, str(script), str(link_root)],
+            capture_output=True,
+            text=True,
+            env={**os.environ, "PYTHONPATH": str(link_root)},
+            check=False,
+        )
+
+        assert result.returncode == 0, f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
 
     def test_pad_value_reaches_the_parser_path_for_tiles(self):
         """The Tile forward is reached dynamically through the parser too."""


### PR DESCRIPTION
## What changed

`caller_warning_stacklevel()` walks out to the nearest frame outside the `pypto` package so a user-facing warning names the real call site rather than the wrapper that forwarded to it. The prefix it compares against was built with `Path(__file__).resolve()`, which follows symlinks, but it is tested against a frame's `co_filename`, which keeps the spelling the import used and does not.

Reached through a symlinked `sys.path` entry the two never share a prefix, so *every* library frame was judged "outside pypto", the walk stopped at level 1, and `warnings.warn` named its own line.

`python/pypto/ir/utils.py` now normalizes with `abspath` instead — absolute, but without following links, so both sides stay in the spelling the import system recorded.

## Why it matters

This is both of the failures the helper exists to prevent:

1. The warning reports a PyPTO source file instead of the user's kernel.
2. Python's default filter dedupes on `(text, category, lineno)` at the named frame. With that frame now a *fixed* library line, every call site collapses onto it and only the first of N warnings is ever shown — the rest are silently dropped.

It is not an exotic setup: a checkout reached through a symlink is enough. Concretely, `tests/ut/language/test_unified_ops.py::TestUnifiedSlicePadValue` gives `4 failed, 12 passed` when pytest is invoked via a symlinked path and `16 passed` from the resolved path — same commit, same build. Tests that pass or fail purely on the spelling of the checkout path are a trap for anyone bisecting.

Affected warnings today are the `pad_value`-without-narrowing notices in `tensor_ops.slice` and `tile_ops.slice`, both reached through the `pl.slice` dispatcher.

## Why `abspath` rather than resolving both sides

Comparing resolved-against-resolved also fixes the symptom, but it costs a `realpath` syscall per frame on the warning path, and it misclassifies a user file that is itself a symlink into the package tree as library code. Matching on the bare package directory *name* was also considered and rejected: it would treat any user directory called `pypto` as library code.

The trailing-`os.sep` component match is unchanged, so a sibling like `<parent>/pypto_kernels/k.py` is still correctly treated as user code.

## Testing

Added `test_symlinked_import_path_still_names_the_caller`. It symlinks a fresh alias to the package root and runs a probe in a subprocess with `PYTHONPATH` pointing at the alias; the probe calls `pl.slice` three times on distinct lines and asserts three warnings, all attributed to itself.

A subprocess is necessary: the bug only appears when `__file__` and the sibling library frames share the aliased spelling, which requires a real import through the symlink — an in-process fake frame does not reproduce it. The probe also asserts `pypto.__file__` actually came from the link, since an installed copy or a stray `PYTHONPATH` would otherwise make the check vacuous.

Verified the test genuinely fails without the fix (`expected one warning per call site, got 1`), not just that it passes with it.

- `tests/ut/language/test_unified_ops.py`: 162 passed, from **both** the symlinked and the resolved invocation path
- `tests/ut/language` + `tests/ut/ir`: 7646 passed, 2 skipped
- `ruff check`, `ruff format --check`, and the full pre-commit hook set: clean
