### PR TITLE
fix(language): keep the CHECK_SPAN location out of DSL error headers

### DIFF
--- a/docs/en/dev/02-error-handling.md
+++ b/docs/en/dev/02-error-handling.md
@@ -160,6 +160,19 @@ Two consequences for op authors:
 - **Always give `CHECK` a `<<` message.** Once the tail is stripped, a bare `CHECK(cond);` has nothing left to say, and the user gets a generic "backend check reported no message" placeholder instead of an actionable error.
 - **Do not hand-roll `throw pypto::ValueError(...)` to dodge the tail.** That workaround predates the parser-side strip and is no longer needed for DSL-reachable checks.
 
+#### A `CHECK_SPAN` location is stripped too, but only where the arrow replaces it
+
+`FatalLogger` writes the `*_SPAN` macros' `[<file>:<line>:<column>]` location *before* that newline, so it is part of the payload and survives the tail strip — an absolute path in the middle of the bold header. Worse, it need not agree with the `-->` arrow underneath: the check's span is whatever IR node it was handed, often an *operand's definition*, while the arrow is the call site.
+
+`concise_error_message(exc, strip_trailing_span=True)` drops it. The parameter is opt-in because removing the location is only safe when the caller has a better place to show one:
+
+| Call site | `strip_trailing_span` | Why |
+| --------- | --------------------- | --- |
+| `_dispatch_op` / `_dispatch_ir_builder_op` (`ast_parser.py`) | `True` | Raises with `span=` — the renderer's arrow and code snippet locate the failing call |
+| Parse-function wrappers (`decorator.py`) | `False` (default) | Raises with no `span=`, so the inline location is the only one the user would get |
+
+The strip is gated on the `Check failed:` tail actually having been removed. Only `FatalLogger` emits the inline location, and it always emits the tail alongside — so a pure-Python message that happens to end in bracketed colon-separated integers (an extended slice, say) is never touched.
+
 ### Internal invariant checks — `INTERNAL_CHECK_SPAN`
 
 Throw `InternalError` when an internal invariant is violated. Always attach the IR node's `Span` so the error message includes the user's source location:

--- a/docs/zh/dev/02-error-handling.md
+++ b/docs/zh/dev/02-error-handling.md
@@ -152,6 +152,19 @@ CHECK_SPAN(shape.size() == 2, span) << "tensor.matmul: only 2D inputs are suppor
 - **务必为 `CHECK` 提供 `<<` 消息。** 尾部被剥离后,裸写的 `CHECK(cond);` 将无话可说,用户只会看到"后端检查未提供消息"这样的通用占位文本,而非可据以修正的错误。
 - **不要为了绕开尾部而手写 `throw pypto::ValueError(...)`。** 该变通做法早于解析器侧的剥离机制,对 DSL 可达的检查已无必要。
 
+#### `CHECK_SPAN` 的位置信息同样会被剥离,但仅限箭头可以取而代之的场合
+
+`FatalLogger` 把 `*_SPAN` 系列宏的 `[<文件>:<行号>:<列号>]` 位置写在那个换行符**之前**,因此它属于 payload 的一部分,能在尾部剥离后存活下来 —— 于是加粗标题中间出现一条绝对路径。更糟的是,它未必与下方的 `-->` 箭头一致:检查的 span 是传给它的那个 IR 节点(往往是某个**操作数的定义处**),而箭头指向的是调用点。
+
+`concise_error_message(exc, strip_trailing_span=True)` 会把它去掉。该参数是可选开关,因为只有当调用方有更合适的位置展示来源时,移除它才是安全的:
+
+| 调用点 | `strip_trailing_span` | 原因 |
+| ------ | --------------------- | ---- |
+| `_dispatch_op` / `_dispatch_ir_builder_op`(`ast_parser.py`) | `True` | 抛出时带 `span=` —— 渲染器的箭头与代码片段已能定位失败的调用 |
+| 解析函数的包装层(`decorator.py`) | `False`(默认) | 抛出时不带 `span=`,内联位置是用户唯一能拿到的来源 |
+
+剥离动作以"`Check failed:` 尾部确实被移除"为前提。只有 `FatalLogger` 会写出内联位置,且它总是同时写出尾部 —— 因此一条恰好以方括号包裹的冒号分隔整数结尾的纯 Python 消息(例如扩展切片)绝不会被误伤。
+
 ### 内部不变式检查 — `INTERNAL_CHECK_SPAN`
 
 当违反内部不变式时抛出 `InternalError`。始终附加 IR 节点的 `Span`，使错误消息包含用户源代码位置：

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -8263,14 +8263,23 @@ class ASTParser:
             # which the renderer would splice into the bold ``Error:`` header ahead of the
             # ``-->`` source arrow. It stays reachable through ``__cause__`` under
             # PTO_BACKTRACE=1. A pure-Python ValueError has no tail, so this is a no-op.
-            msg = concise_error_message(e)
+            # ``strip_trailing_span`` additionally drops the ``[<file>:<line>:<col>]`` a
+            # ``CHECK_SPAN`` leaves in the payload: we raise with ``span=`` below, so the
+            # arrow and snippet locate the call anyway, and the inline copy is an absolute
+            # path in the middle of the header (often naming an operand's *definition*,
+            # not the call, which reads as a contradiction against the arrow).
+            msg = concise_error_message(e, strip_trailing_span=True)
             if not msg.startswith(f"pl.{op_name}") and not msg.startswith(f"{module_name}.{op_name}"):
                 msg = f"{module_name} operation '{op_name}': {msg}"
             hint = self._scalar_operand_hint(args, kwargs)
             raise InvalidOperationError(msg, span=span, hint=hint) from e
         except Exception as e:
+            # ``span=`` below gives the renderer its ``-->`` arrow, so strip the inline
+            # ``[<file>:<line>:<col>]`` a ``CHECK_SPAN`` leaves in the payload rather than
+            # printing an absolute path inside the bold ``Error:`` header.
             raise InvalidOperationError(
-                f"Error in {module_name} operation '{op_name}': {concise_error_message(e)}",
+                f"Error in {module_name} operation '{op_name}': "
+                f"{concise_error_message(e, strip_trailing_span=True)}",
                 span=span,
             ) from e
 
@@ -8420,8 +8429,12 @@ class ASTParser:
             # Compiler bug, not a bad kernel - surface it with its type and trace intact.
             raise
         except Exception as e:
+            # ``span=`` below gives the renderer its ``-->`` arrow, so strip the inline
+            # ``[<file>:<line>:<col>]`` a ``CHECK_SPAN`` leaves in the payload rather than
+            # printing an absolute path inside the bold ``Error:`` header.
             raise InvalidOperationError(
-                f"Error in {module_name} operation '{op_name}': {concise_error_message(e)}",
+                f"Error in {module_name} operation '{op_name}': "
+                f"{concise_error_message(e, strip_trailing_span=True)}",
                 span=span,
             ) from e
 

--- a/python/pypto/language/parser/diagnostics/exceptions.py
+++ b/python/pypto/language/parser/diagnostics/exceptions.py
@@ -9,6 +9,7 @@
 
 """Parser error exceptions with rich diagnostic information."""
 
+import re
 from typing import Final
 
 from pypto.pypto_core import InternalError, ir
@@ -152,8 +153,16 @@ _UNSPECIFIED_CHECK_MESSAGE = (
     "(re-run with PTO_BACKTRACE=1 to see which check failed)"
 )
 
+# The ``[<file>:<line>:<column>]`` suffix ``FatalLogger::~FatalLogger``
+# (``include/pypto/core/logging.h``) appends for the ``*_SPAN`` check macros, written
+# *before* the newline that starts the ``Check failed:`` tail and therefore surviving the
+# tail strip below. ``Span::is_valid()`` guarantees a positive line; the column is either
+# positive or the ``-1`` sentinel. ``[^\[\]]*`` keeps the filename from eating an earlier
+# bracket, and the anchor keeps the match to the very end of the payload.
+_TRAILING_SPAN_RE: Final = re.compile(r"\s*\[[^\[\]]*:\d+:-?\d+\]\Z")
 
-def concise_error_message(exc: Exception) -> str:
+
+def concise_error_message(exc: Exception, strip_trailing_span: bool = False) -> str:
     """Extract a concise user-facing message from an exception.
 
     Strips C++ internal details (stack traces and CHECK macro output) that are
@@ -166,6 +175,20 @@ def concise_error_message(exc: Exception) -> str:
     empty string, because an empty bold ``Error:`` header is strictly worse than the
     C++ noise it replaced. An exception that was simply raised with an empty message
     keeps its empty message -- only a stripped check tail earns the fallback.
+
+    Args:
+        exc: Exception to extract the user-facing message from.
+        strip_trailing_span: Also drop the ``[<file>:<line>:<column>]`` location that a
+            ``CHECK_SPAN`` / ``INTERNAL_CHECK_SPAN`` leaves at the end of the payload.
+            Opt-in, because the caller must have a better place to show the location:
+            pass it only when the resulting :class:`ParserError` carries a ``span=`` of
+            its own, so the renderer's ``-->`` arrow and code snippet still point the
+            user at a source line. Callers that raise without a span (the parse-function
+            wrappers in ``decorator.py``) must leave it off -- the inline location is the
+            only one the user would get.
+
+    Returns:
+        The user-facing message, free of C++ traceback and ``Check failed:`` noise.
     """
     msg = str(exc)
     # Strip "C++ Traceback ..." block appended by GetFullMessage()
@@ -190,6 +213,11 @@ def concise_error_message(exc: Exception) -> str:
         if pos != -1:
             msg = msg[:pos]
             stripped_check_tail = True
+    # Gated on the tail: only FatalLogger writes the inline span, and it always writes the
+    # tail alongside it. A pure-Python message that happens to end in bracketed
+    # colon-separated integers (a slice, say) is therefore never touched.
+    if strip_trailing_span and stripped_check_tail:
+        msg = _TRAILING_SPAN_RE.sub("", msg)
     msg = msg.strip()
     # Gate on the tail actually having been removed, not on "something was there before":
     # `GetFullMessage()` always appends a traceback (or the "no stack trace" note), so a

--- a/tests/ut/language/parser/test_error_wrapping.py
+++ b/tests/ut/language/parser/test_error_wrapping.py
@@ -166,6 +166,67 @@ class TestBackendCheckMessageSanitized:
         assert lines[1].lstrip().startswith("-->")
 
 
+class TestCheckSpanLocationStrippedFromHeader:
+    """A ``CHECK_SPAN`` must not print its location inline in the bold ``Error:`` header.
+
+    ``FatalLogger::~FatalLogger`` (``include/pypto/core/logging.h``) appends
+    ``[<file>:<line>:<column>]`` *before* the newline that starts the ``Check failed:``
+    tail, so the span's **absolute** path survives that tail's strip and lands in the
+    header. The ``-->`` arrow below it already names a location -- and a different one,
+    since the check's span is whatever IR node it was handed (here the ``tmp`` operand's
+    definition) while the arrow is the call site.
+    """
+
+    @staticmethod
+    def _mismatched_row_max():
+        """Build a kernel whose only fault is an FP16 scratch tile for an FP32 reduction.
+
+        Drives the CHECK_SPAN in src/ir/op/tile_ops/reduction.cpp, which passes
+        ``args[1]->span_`` -- the ``tmp`` definition, one line above the failing call.
+        """
+
+        @pl.function
+        def bad(t: pl.Tensor[[64, 64], pl.FP32]) -> pl.Tile[[64, 1], pl.FP32]:
+            a: pl.Tile[[64, 64], pl.FP32] = pl.tile.load(t, offsets=[0, 0], shapes=[64, 64])
+            tmp: pl.Tile[[64, 64], pl.FP16] = pl.tile.create([64, 64], pl.FP16)
+            m: pl.Tile[[64, 1], pl.FP32] = pl.tile.row_max(a, tmp)
+            return m
+
+        return bad
+
+    def test_header_carries_no_inline_source_location(self):
+        """The op's message survives; the bracketed path it ended with does not."""
+        with pytest.raises(InvalidOperationError) as exc_info:
+            self._mismatched_row_max()
+
+        message = exc_info.value.message
+        assert "test_error_wrapping.py" not in message
+        assert not message.rstrip().endswith("]")
+        # Positive half: an over-eager strip that eats the payload fails here.
+        assert "tmp_tile dtype fp16 and input dtype fp32" in message
+
+    def test_rendered_diagnostic_still_locates_the_failing_call(self):
+        """Dropping the inline span costs no location -- the arrow and snippet remain."""
+        with pytest.raises(InvalidOperationError) as exc_info:
+            self._mismatched_row_max()
+
+        lines = ErrorRenderer(use_color=False).render(exc_info.value).split("\n")
+        assert lines[0].startswith("Error:")
+        assert "test_error_wrapping.py" not in lines[0]
+        assert lines[1].lstrip().startswith("--> ")
+        assert "test_error_wrapping.py" in lines[1]
+        assert any("pl.tile.row_max(a, tmp)" in line for line in lines)
+
+    def test_span_detail_survives_on_the_cause(self):
+        """The location is hidden from the header, not destroyed."""
+        with pytest.raises(InvalidOperationError) as exc_info:
+            self._mismatched_row_max()
+
+        cause = exc_info.value.__cause__
+        assert isinstance(cause, ValueError)
+        assert "test_error_wrapping.py" in str(cause)
+
+
 class TestProgramCatchAll:
     """Tests that @pl.program wraps unexpected exceptions like @pl.function does."""
 

--- a/tests/ut/language/parser/test_static_operations.py
+++ b/tests/ut/language/parser/test_static_operations.py
@@ -426,6 +426,50 @@ class TestConciseErrorMessage:
         assert "Check failed" not in result
         assert "f.cpp" not in result
 
+    def test_trailing_span_is_kept_by_default(self):
+        """``strip_trailing_span`` is opt-in: callers that raise without a ``span=`` keep it.
+
+        ``decorator.py``'s parse-function wrappers are those callers -- the inline location
+        is the only one their ``ParserError`` can offer the user.
+        """
+        msg = "The operator tile.row_max requires a 2D operand [kernel.py:9:3]\nCheck failed: x at f.cpp:1"
+        assert concise_error_message(ValueError(msg)).endswith("[kernel.py:9:3]")
+
+    def test_strip_trailing_span_removes_the_inline_location(self):
+        """Opted in, the ``CHECK_SPAN`` location leaves the header; the payload stays whole."""
+        msg = (
+            "The operator tile.row_max requires a 2D operand [/abs/path/kernel.py:9:3]"
+            "\nCheck failed: x at /abs/path/src/ir/op/tile_ops/reduction.cpp:88"
+        )
+        result = concise_error_message(ValueError(msg), strip_trailing_span=True)
+        assert result == "The operator tile.row_max requires a 2D operand"
+
+    def test_strip_trailing_span_accepts_the_negative_column_sentinel(self):
+        """``Span`` renders an unknown column as ``-1``; that form must strip too."""
+        msg = "Bad operand [/abs/path/kernel.py:9:-1]\nCheck failed: x at f.cpp:1"
+        result = concise_error_message(ValueError(msg), strip_trailing_span=True)
+        assert result == "Bad operand"
+
+    def test_strip_trailing_span_leaves_a_plain_python_message_alone(self):
+        """No ``Check failed:`` tail means no ``FatalLogger`` span -- so nothing to strip.
+
+        Guards the one way this could corrupt a message: a pure-Python error whose text
+        happens to end in bracketed colon-separated integers (an extended slice, say).
+        """
+        exc = ValueError("step must divide the extent, got a[0:64:3]")
+        assert (
+            concise_error_message(exc, strip_trailing_span=True)
+            == "step must divide the extent, got a[0:64:3]"
+        )
+
+    def test_strip_trailing_span_on_message_less_check_reports_the_fallback(self):
+        """A payload that is *only* a span strips to empty -- which must not render bare."""
+        msg = " [/abs/path/kernel.py:9:3]\nCheck failed: tmp_type at f.cpp:88"
+        result = concise_error_message(ValueError(msg), strip_trailing_span=True)
+        assert result
+        assert "kernel.py" not in result
+        assert "PTO_BACKTRACE=1" in result
+
     def test_empty_message(self):
         """Test with empty exception message."""
         exc = ValueError("")


### PR DESCRIPTION
## What

`CHECK_SPAN` diagnostics printed a full absolute path inline in the bold `Error:`
header. `FatalLogger::~FatalLogger` (`include/pypto/core/logging.h:600-603`) writes the
`*_SPAN` macros' ` [<file>:<line>:<column>]` location **before** the newline that starts
the `Check failed:` tail, so it is part of the user payload and survived
`concise_error_message`'s tail strip.

Two wrinkles made it worse than plain noise: the inline location need not agree with the
`-->` arrow below it — the check's span is whatever IR node it was handed, often an
*operand's definition*, while the arrow is the call site — and the renderer prints the
arrow's path anyway, so the header was the only place a raw absolute path appeared.

Before / after, on `pl.tile.row_max(a, tmp)` with `a: FP32`, `tmp: FP16`:

```diff
- Error: pl.tile operation 'row_max': ... but got tmp_tile dtype fp16 and input dtype fp32 [/abs/path/repro.py:10:9]
+ Error: pl.tile operation 'row_max': ... but got tmp_tile dtype fp16 and input dtype fp32
    --> /abs/path/repro.py:11:40
     |
  10 |         tmp: pl.Tile[[64, 64], pl.FP16] = pl.tile.create([64, 64], pl.FP16)
  11 |         m: pl.Tile[[64, 1], pl.FP32] = pl.tile.row_max(a, tmp)
     |                                        ^^^^^^^^^^^^^^^
```

Follow-up to #2424, which stripped the `Check failed:` tail itself but left this
location behind.

## How

Call-site side, as the C++ emission has to stay for callers that have nowhere else to
show a location.

- **`diagnostics/exceptions.py`** — `concise_error_message` gains an opt-in
  `strip_trailing_span=False` that removes a trailing `[<text>:<int>:<int>]`
  (`Span::is_valid()` guarantees a positive line; the column is positive or the `-1`
  sentinel, so both forms match).
- **`ast_parser.py`** — passed at the three op-dispatch raise sites in `_dispatch_op` /
  `_dispatch_ir_builder_op`.

The parameter is opt-in because dropping the location is only safe where the caller has
a better place to show one:

| Call site | `strip_trailing_span` | Why |
| --------- | --------------------- | --- |
| `_dispatch_op` / `_dispatch_ir_builder_op` | `True` | Raises with `span=` — the arrow and code snippet locate the failing call |
| Parse-function wrappers (`decorator.py`) | `False` (default) | Raises with no `span=`, so the inline location is the only one the user would get |

## Notes for reviewers

- **The strip is gated on the `Check failed:` tail actually having been removed.** Only
  `FatalLogger` emits the inline location, and it always emits the tail alongside it —
  so a pure-Python message that happens to end in bracketed colon-separated integers (an
  extended slice such as `a[0:64:3]`) is never touched. There is a test for exactly that.
- **Nothing is destroyed** — the full C++ text, location included, stays reachable
  through `__cause__` under `PTO_BACKTRACE=1`.
- **A message that is *only* a span** (a `CHECK_SPAN` with no `<<` payload) strips to
  empty and falls through to the existing `_UNSPECIFIED_CHECK_MESSAGE` placeholder,
  rather than rendering a bare `Error:` header.
- **Trade-off worth naming:** this drops the operand-definition location the inline span
  sometimes carried (line 10 vs. the call on line 11 above). The message names the
  operand anyway, and the arrow now agrees with the header. The 117 `CHECK_SPAN` sites
  under `src/ir/op/` are unchanged — C++ still emits the span, it is just no longer
  rendered in the header.

## Testing

- 5 unit tests in `tests/ut/language/parser/test_static_operations.py`: opt-in default,
  the strip itself, the `-1` column sentinel, the slice-lookalike guard, and the
  message-less-check fallback.
- `TestCheckSpanLocationStrippedFromHeader` in
  `tests/ut/language/parser/test_error_wrapping.py` drives the real `CHECK_SPAN` at
  `src/ir/op/tile_ops/reduction.cpp:88` end to end and asserts the rendered diagnostic
  still locates the failing call.
- Verified non-vacuous: 6 of the new tests fail with the source change reverted.
- Full Python suite: **10054 passed, 3 skipped**. All pre-commit hooks clean.

## Docs

New subsection in `docs/en/dev/02-error-handling.md` and its `docs/zh/` mirror,
documenting when the flag is and is not safe to pass.
