### PR TITLE
fix(ir): fold WindowBuffer identity in structural_equal

### DIFF
--- a/src/ir/transforms/structural_equal.cpp
+++ b/src/ir/transforms/structural_equal.cpp
@@ -785,6 +785,7 @@ class StructuralEqualImpl {
   bool EqualVar(const VarPtr& lhs, const VarPtr& rhs);
   bool EqualMemRef(const MemRefPtr& lhs, const MemRefPtr& rhs);
   bool EqualIterArg(const IterArgPtr& lhs, const IterArgPtr& rhs);
+  bool EqualWindowBuffer(const WindowBufferPtr& lhs, const WindowBufferPtr& rhs);
   bool EqualType(const TypePtr& lhs, const TypePtr& rhs);
   bool IsLoopVarFieldContext() const {
     return !field_name_stack_.empty() && field_name_stack_.back() == "loop_var";
@@ -941,6 +942,12 @@ bool StructuralEqualImpl<AssertMode>::Equal(const IRNodePtr& lhs, const IRNodePt
     return result;
   }
 
+  // Check WindowBuffer before Var (WindowBuffer inherits from Var)
+  if (auto lhs_wb = As<WindowBuffer>(lhs)) {
+    bool result = EqualWindowBuffer(lhs_wb, std::static_pointer_cast<const WindowBuffer>(rhs));
+    return result;
+  }
+
   if (auto lhs_var = As<Var>(lhs)) {
     bool result = EqualVar(lhs_var, std::static_pointer_cast<const Var>(rhs));
     return result;
@@ -979,7 +986,6 @@ bool StructuralEqualImpl<AssertMode>::Equal(const IRNodePtr& lhs, const IRNodePt
   EQUAL_DISPATCH(InlineStmt)
   EQUAL_DISPATCH(Function)
   EQUAL_DISPATCH_TRANSPARENT(Program)
-  EQUAL_DISPATCH(WindowBuffer)
 
   throw pypto::TypeError("Unknown IR node type in StructuralEqualImpl::Equal: " + lhs->TypeName());
 }
@@ -1380,7 +1386,6 @@ bool StructuralEqualImpl<AssertMode>::EqualMemRef(const MemRefPtr& lhs, const Me
   if (!EqualVar(lhs, rhs)) {
     return false;
   }
-
   // 2. Then, compare MemRef-specific fields: base_, byte_offset_, size_
   if (!EqualVar(lhs->base_, rhs->base_)) {
     if constexpr (AssertMode) {
@@ -1470,6 +1475,45 @@ bool StructuralEqualImpl<AssertMode>::EqualIterArg(const IterArgPtr& lhs, const 
     return false;
   }
 
+  return true;
+}
+
+template <bool AssertMode>
+bool StructuralEqualImpl<AssertMode>::EqualWindowBuffer(const WindowBufferPtr& lhs,
+                                                        const WindowBufferPtr& rhs) {
+  // 1. Compare as Var (variable mapping / identity), mirroring EqualMemRef and
+  //    EqualIterArg. Without this the hash side's WindowBuffer identity fold
+  //    (structural_hash.cpp) has no equality counterpart, so two field-identical
+  //    buffers compare equal yet hash apart.
+  if (!EqualVar(lhs, rhs)) {
+    return false;
+  }
+
+  // 2. WindowBuffer-specific fields.
+  if (!EqualVar(lhs->base_, rhs->base_)) {
+    if constexpr (AssertMode) {
+      ThrowMismatch("WindowBuffer base mismatch", std::static_pointer_cast<const IRNode>(lhs),
+                    std::static_pointer_cast<const IRNode>(rhs));
+    }
+    return false;
+  }
+  if (!Equal(lhs->size_, rhs->size_)) {
+    return false;
+  }
+  if (lhs->load_from_host_ != rhs->load_from_host_) {
+    if constexpr (AssertMode) {
+      ThrowMismatch("WindowBuffer load_from_host mismatch", std::static_pointer_cast<const IRNode>(lhs),
+                    std::static_pointer_cast<const IRNode>(rhs));
+    }
+    return false;
+  }
+  if (lhs->store_to_host_ != rhs->store_to_host_) {
+    if constexpr (AssertMode) {
+      ThrowMismatch("WindowBuffer store_to_host mismatch", std::static_pointer_cast<const IRNode>(lhs),
+                    std::static_pointer_cast<const IRNode>(rhs));
+    }
+    return false;
+  }
   return true;
 }
 

--- a/src/ir/transforms/structural_equal.cpp
+++ b/src/ir/transforms/structural_equal.cpp
@@ -1489,32 +1489,21 @@ bool StructuralEqualImpl<AssertMode>::EqualWindowBuffer(const WindowBufferPtr& l
     return false;
   }
 
-  // 2. WindowBuffer-specific fields.
-  if (!EqualVar(lhs->base_, rhs->base_)) {
-    if constexpr (AssertMode) {
-      ThrowMismatch("WindowBuffer base mismatch", std::static_pointer_cast<const IRNode>(lhs),
-                    std::static_pointer_cast<const IRNode>(rhs));
-    }
-    return false;
-  }
-  if (!Equal(lhs->size_, rhs->size_)) {
-    return false;
-  }
-  if (lhs->load_from_host_ != rhs->load_from_host_) {
-    if constexpr (AssertMode) {
-      ThrowMismatch("WindowBuffer load_from_host mismatch", std::static_pointer_cast<const IRNode>(lhs),
-                    std::static_pointer_cast<const IRNode>(rhs));
-    }
-    return false;
-  }
-  if (lhs->store_to_host_ != rhs->store_to_host_) {
-    if constexpr (AssertMode) {
-      ThrowMismatch("WindowBuffer store_to_host mismatch", std::static_pointer_cast<const IRNode>(lhs),
-                    std::static_pointer_cast<const IRNode>(rhs));
-    }
-    return false;
-  }
-  return true;
+  // 2. Remaining fields (base_, size_, the staging flags) through the reflection
+  //    visitor, exactly as the generic EQUAL_DISPATCH(WindowBuffer) path did
+  //    before this arm existed. Comparing them by hand here would drop the field
+  //    name from the mismatch path -- assert_structural_equal would report a bare
+  //    `value` instead of `size.value` -- and would silently skip any field added
+  //    to WindowBuffer later. The transparent_depth_ save/reset and the
+  //    node_type_stack_ push mirror EQUAL_DISPATCH so field names are recorded
+  //    even when this node is reached from inside a SeqStmts / Program.
+  node_type_stack_.emplace_back("WindowBuffer");
+  int saved_depth = transparent_depth_;
+  transparent_depth_ = 0;
+  bool result = EqualWithFields(lhs, rhs);
+  transparent_depth_ = saved_depth;
+  node_type_stack_.pop_back();
+  return result;
 }
 
 // Explicit template instantiations

--- a/src/ir/transforms/structural_hash.cpp
+++ b/src/ir/transforms/structural_hash.cpp
@@ -495,6 +495,10 @@ StructuralHasher::result_type StructuralHasher::HashType(const TypePtr& type) {
       }
       // Hash layout
       h = hash_combine(h, static_cast<result_type>(tv.layout));
+      // Hash pad — EqualType compares TensorView::pad, and the sibling TileView
+      // branch below hashes its own pad; omitting it here only made TensorType
+      // hashing needlessly coarse.
+      h = hash_combine(h, static_cast<result_type>(tv.pad));
     } else {
       h = hash_combine(h, static_cast<result_type>(0));  // indicate absence
     }

--- a/tests/ut/ir/transforms/test_equality.py
+++ b/tests/ut/ir/transforms/test_equality.py
@@ -1719,6 +1719,21 @@ class TestWindowBufferIdentity:
         assert not ir.structural_equal(lhs, rhs)
         assert ir.structural_hash(lhs) != ir.structural_hash(rhs)
 
+    def test_size_mismatch_still_reports_the_field_path(self):
+        """Field names must survive the hand-written identity arm.
+
+        The arm bypasses the ``EQUAL_DISPATCH`` reflection visitor, which is
+        what pushes ``size`` onto the mismatch path. Comparing the fields by
+        hand instead would degrade ``assert_structural_equal``'s diagnostic to
+        a bare ``value``, dropping the very location the API promises.
+        """
+        base = ir.Var("win", ir.PtrType(), self._span())
+        first, second = self._buffer(base, 4096), self._buffer(base, 8192)
+
+        with pytest.raises(ValueError) as exc_info:
+            ir.assert_structural_equal(first, second, enable_auto_mapping=True)
+        assert "size.value" in str(exc_info.value).split("\n")[0]
+
     def test_a_slot_and_its_type_back_reference_are_cross_checked(self):
         """A buffer's identity must tie its definition to its uses.
 

--- a/tests/ut/ir/transforms/test_equality.py
+++ b/tests/ut/ir/transforms/test_equality.py
@@ -1664,5 +1664,92 @@ class TestSubNodeComparison:
         assert "body" not in path  # SeqStmts field name suppressed
 
 
+class TestWindowBufferIdentity:
+    """``WindowBuffer`` must fold Var identity on the equality side too.
+
+    ``WindowBuffer`` is a ``Var`` subclass with its own ``ObjectKind``, so the
+    precise-match ``As<Var>`` arm in ``Equal`` never saw it and it fell through
+    to plain field comparison, while ``HashNode`` listed it alongside
+    ``MemRef`` / ``IterArg`` / ``Var`` in the identity fold. The two sides
+    disagreed about whether the node carries identity, which broke the
+    equal-implies-equal-hash guarantee and left the buffer's identity
+    unchecked between its definition and its uses.
+    """
+
+    @staticmethod
+    def _span() -> ir.Span:
+        return ir.Span.unknown()
+
+    def _buffer(self, base: ir.Var, size: int) -> ir.WindowBuffer:
+        return ir.WindowBuffer(
+            base, ir.ConstInt(size, DataType.INDEX, self._span()), False, False, self._span()
+        )
+
+    def test_field_identical_buffers_fold_identity_on_both_sides(self):
+        """Two distinct buffers sharing every field are not interchangeable.
+
+        They differ in ``UniqueId``, which the hash folds in, so equality must
+        fold it in too -- otherwise they compare equal yet hash apart.
+        """
+        base = ir.Var("win", ir.PtrType(), self._span())
+        first, second = self._buffer(base, 4096), self._buffer(base, 4096)
+
+        assert not ir.structural_equal(first, second)
+        assert ir.structural_hash(first) != ir.structural_hash(second)
+
+    def test_buffer_is_equal_to_itself_and_hashes_stably(self):
+        buffer = self._buffer(ir.Var("win", ir.PtrType(), self._span()), 4096)
+        assert ir.structural_equal(buffer, buffer)
+        assert ir.structural_hash(buffer) == ir.structural_hash(buffer)
+
+    def test_enclosing_scopes_fold_buffer_identity(self):
+        """The same gap at container level, which is what a hash-keyed cache hits."""
+        base = ir.Var("win", ir.PtrType(), self._span())
+
+        def scope() -> ir.CommDomainScopeStmt:
+            return ir.CommDomainScopeStmt(
+                [0, 1],
+                [self._buffer(base, 4096)],
+                "d0",
+                body=ir.BreakStmt(self._span()),
+                span=self._span(),
+            )
+
+        lhs, rhs = scope(), scope()
+        assert not ir.structural_equal(lhs, rhs)
+        assert ir.structural_hash(lhs) != ir.structural_hash(rhs)
+
+    def test_a_slot_and_its_type_back_reference_are_cross_checked(self):
+        """A buffer's identity must tie its definition to its uses.
+
+        ``CommDomainScopeStmt::slots_`` defines the buffers;
+        ``DistributedTensorType::window_buffer_`` refers back to one of them.
+        While ``WindowBuffer`` never reached ``EqualVar`` it was never entered
+        into the variable bijection, so nothing checked that the two sides pick
+        the *same* slot -- and ``EqualVar`` alone cannot tell two buffers apart,
+        since ``WindowBufferType`` is a field-less singleton.
+        """
+
+        def scope(pick_second_slot: bool) -> ir.CommDomainScopeStmt:
+            base = ir.Var("win", ir.PtrType(), self._span())
+            slots = [self._buffer(base, 4096), self._buffer(base, 8192)]
+            bound = slots[1] if pick_second_slot else slots[0]
+            tensor = ir.DistributedTensorType(
+                [ir.ConstInt(64, DataType.INDEX, self._span())], DataType.FP32, bound
+            )
+            return ir.CommDomainScopeStmt(
+                [0, 1],
+                slots,
+                "d0",
+                body=ir.EvalStmt(ir.Var("dt", tensor, self._span()), self._span()),
+                span=self._span(),
+            )
+
+        # Same slot list; the tensor is bound to a different allocation in each.
+        assert not ir.structural_equal(scope(False), scope(True), enable_auto_mapping=True)
+        # ... and binding the same slot still matches.
+        assert ir.structural_equal(scope(False), scope(False), enable_auto_mapping=True)
+
+
 if __name__ == "__main__":
     pytest.main(["-v", __file__])

--- a/tests/ut/ir/transforms/test_hash.py
+++ b/tests/ut/ir/transforms/test_hash.py
@@ -515,6 +515,26 @@ class TestHashTypeLadderParity:
         assert not ir.structural_equal(without, with_wb)
         assert hash(without) != hash(with_wb)
 
+    def test_tensor_view_pad_participates_in_the_hash(self):
+        """``EqualType`` compares ``TensorView::pad``, so ``HashType`` must fold it in.
+
+        The sibling ``TileView`` branch always hashed its own ``pad``; the
+        ``TensorView`` branch stopped at ``layout``. That left the contract
+        intact (a field in equality but not the hash only widens the collision
+        class) but made padded tensor views needlessly collision-prone.
+        """
+
+        def make(pad: ir.PadValue) -> ir.TensorType:
+            return ir.TensorType(
+                [64, 1],
+                DataType.FP32,
+                tensor_view=ir.TensorView([1, 1], ir.TensorLayout.ND, [32, 1], pad),
+            )
+
+        null_pad, zero_pad = make(ir.PadValue.null), make(ir.PadValue.zero)
+        assert not ir.structural_equal(null_pad, zero_pad)
+        assert hash(null_pad) != hash(zero_pad)
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## What

`WindowBuffer` is a `Var` subclass with its own `ObjectKind`. `Equal` gates its identity arms on `As<MemRef>` / `As<IterArg>` / `As<Var>` — all precise-kind matches — so a `WindowBuffer` never reached `EqualVar` and fell through to plain field comparison at `structural_equal.cpp:982`. `HashNode` meanwhile listed `WindowBuffer` alongside `MemRef` / `IterArg` / `Var` in its identity fold (`structural_hash.cpp:670`).

The two sides disagreed about whether the node carries identity. This adds an `EqualWindowBuffer` arm mirroring `EqualMemRef` / `EqualIterArg`: `EqualVar` first, then `base_`, `size_`, and the two host-staging flags.

Also folds `TensorView::pad` into `HashType` (one line).

## Why

Two distinct defects fell out of the same gap.

**1. The equal-implies-equal-hash guarantee was broken.** Two buffers sharing a `base_` and an equal `size_`:

```
structural_equal(wb1, wb2) : True
structural_hash(wb1)       : 15180747352527745462
structural_hash(wb2)       : ...463
```

That guarantee is stated in `docs/en/dev/ir/03-structural_comparison.md` ("Hash Consistency Guarantee") and advertised by the `__eq__` / `__hash__` bindings. It reproduces at container level in default mode too, which is the shape that makes a hash-keyed cache over IR nodes silently miss.

**2. Buffer identity was checked nowhere.** Because the node never reached `EqualVar`, it was never entered into the variable bijection — so a slot *definition* (`CommDomainScopeStmt::slots_`) and a *back-reference* (`DistributedTensorType::window_buffer_`) were never cross-checked:

```
A: slots=[4096, 8192], tensor bound to slots[0]
B: slots=[4096, 8192], tensor bound to slots[1]
  structural_equal(A, B, auto_mapping=True) : True   # before this change
```

Two scopes binding a tensor to *different* allocations compared equal. `EqualVar` alone cannot separate two buffers, since `WindowBufferType` is a field-less singleton — identity is the only discriminator.

## Notes for reviewers

- **Why not the other direction.** Dropping `WindowBuffer` from the hash-side identity fold would have aligned the two ladders just as well, but it leaves defect 2 in place: identity would then be folded nowhere. The equal-side arm closes both.
- **The type back-reference is deliberately untouched.** `EqualType` compares `DistributedTensorType::window_buffer_` with a direct `EqualVar` call, bypassing the `Equal()` dispatch, so the new arm does not apply there and the identity-only semantics documented on `HashVarIdentity` are preserved. `test_auto_mapped_window_buffers_of_different_size_hash_together` still passes unchanged.
- **`TensorView::pad`** was compared by `EqualType` but never hashed, while the sibling `TileView` branch always hashed its own. That direction is contract-safe — a field in equality but not the hash only widens the collision class — so this is a hash-quality fix, not a correctness one.
- **Adjacent gap left alone.** `ShapedType::memref_` is a `UsualField` carried by the printer, the serializer and the deserializer, but dropped by both `EqualType` and `HashType`. Adding it builds clean and fixes the comparison, but takes the suite to 616 failures: `RoundtripInstrument` (print → parse → `assert_structural_equal`) fails after `InitMemRef` with `ShapedType memref presence mismatch (false != true)`. The field is not round-trippable today and the omission is what hides it. Fixing it needs a semantics call — whether `tile.store`'s deduced result type should carry the destination's MemRef, or the printer should stop emitting it — so it is out of scope here.

## Testing

`TestWindowBufferIdentity` in `test_equality.py` covers the hash contract, the container-level case, and the definition/use cross-check. `test_tensor_view_pad_participates_in_the_hash` covers the `pad` fold. Each fails without the corresponding change.

Full suite: **10047 passed, 3 skipped**.
