### PR TITLE
feat(ir): split an odd shape across the two AIV lanes

### DIFF
--- a/docs/en/dev/codegen/00-pto_codegen.md
+++ b/docs/en/dev/codegen/00-pto_codegen.md
@@ -203,20 +203,36 @@ or call `set_validshape` on the source tile before taking the view.
   `tile.set_validshape`, `tpush` emits the same tile handle after its runtime valid shape has been
   updated. For split `tpush`, codegen temporarily uses the full physical transport box, then restores
   the producer tile's logical valid shape.
-- The Cube-to-Vector FIFO is physically box-strided at **every** split: the ISA builds the GM slot
-  view from the popped tile's compile-time rows/cols and the producer's box row pitch, then strides
-  that view with the tile's *runtime* `valid_col`. A partial valid shape on TPOP therefore collapses
-  the GM row gap and makes the consumer read one contiguous run instead of one box row per burst —
-  silent corruption of the *valid* region, since the ISA's matching assertion is compiled out in
-  release builds. So a partial Acc-to-Vec transfer uses the full physical box for both TPUSH and
-  TPOP, whether the transfer is no-split or `split = 1` / `split = 2`, and restores the logical valid
-  shape immediately on each side of the transport — on the consumer side through a metadata-only
-  `pto.treshape` (a frontend tpop result is not a locally bound PTOAS tile, so `pto.set_validshape`
-  cannot restore it in place).
+- `split` is pto-isa's `TileSplitAxis`, printed verbatim. `0` = no split, `1` / `2` = up-down /
+  left-right, and `3` / `4` = the same two axes over an **odd** extent:
+
+  | Code | pto-isa | Lane 0 | Lane 1 | Lane 1's band starts at |
+  | ---- | ------- | ------ | ------ | ----------------------- |
+  | 0 | `TILE_NO_SPLIT` | whole tile | (single reader) | — |
+  | 1 / 2 | `TILE_UP_DOWN` / `TILE_LEFT_RIGHT` | `e0` | `e1` | `e1 * pitch` |
+  | 3 / 4 | `TILE_UP_DOWN_ODD` / `TILE_LEFT_RIGHT_ODD` | `e0` | `e1` | `(e1 + 1) * pitch` |
+
+  `eL` is lane `L`'s **runtime** valid extent on the split axis — the ISA reads it off the popped
+  tile (`popVecTileFromGMFiFo`), so the even codes require `e0 == e1` and the odd ones
+  `e0 == e1 + 1`. [LowerAutoVectorSplit](../passes/20-lower_auto_vector_split.md) materializes those
+  extents and [ExpandMixedKernel](../passes/21-expand_mixed_kernel.md) picks the matching code.
+- The Cube-to-Vector FIFO carries a compacted rectangle: the producer stores its `valid_row` x
+  `valid_col` block at a `valid_col` row pitch, and each consumer lane reads its band back with the
+  same pitch (`gmStrideR = valid_col`, doubled for the left-right codes). A partial valid shape on
+  one side of the transport and not the other therefore mis-strides the pop — silent corruption of
+  the *valid* region, since the ISA's matching assertion is compiled out in release builds. So a
+  partial Acc-to-Vec transfer uses the full physical box for both TPUSH and TPOP, whether the
+  transfer is no-split or split, and restores the logical valid shape immediately on each side of the
+  transport — on the consumer side through a metadata-only `pto.treshape` (a frontend tpop result is
+  not a locally bound PTOAS tile, so `pto.set_validshape` cannot restore it in place). The split-axis
+  extent is the exception: it stays per-lane on the TPOP operands, because that is what tells the ISA
+  where lane 1's band begins.
 - When a tpop result `TileView.valid_shape` differs from the physical tile shape, PTO codegen emits PTOAS frontend operands as `%buf = pto.tpop_from_*(%valid_row, %valid_col) {[id = I, ]split = N} -> !pto.tile_buf<..., v_row=?, v_col=?, ...>`. This covers dynamic expressions and static non-full shapes such as `[0, 0]`; the operands carry the logical extents used by compute and store. The full-box Cube-to-Vector transport above overrides this for a statically-shaped, non-empty partial pop, because `pto.treshape` carries no valid-row/valid-col operands and so can only restore *static* logical extents.
-- For split consumers, `SplitVectorKernel` localizes those dynamic tpop
+- For split consumers, `LowerAutoVectorSplit` localizes those dynamic tpop
   valid-shape operands per subblock (for example global `[8, 16]` becomes
-  `[8, 16]` then `[0, 16]` under up/down split of a `[16, 16]` tile).
+  `[8, 16]` then `[0, 16]` under up/down split of a `[16, 16]` tile). An odd
+  split axis reaches the operands the same way — a `[17, 128]` tile pops
+  `[9, 128]` on lane 0 and `[8, 128]` on lane 1 under `split = 3`.
 - `system.tfree_*` derives `split` from its tile argument, so the frontend must free the exact SSA value produced by `tile.tpop_*`, even though the PTO instruction itself does not take the tile as an explicit operand
 - `ExpandMixedKernel` now auto-generates consumer-side `system.tfree_*` after split-generated `tile.tpop_*`, preserving `tpop -> direct users -> tfree -> next tpop`
 - `reserve_buffer` and `import_reserved_buffer` return `i32` SSA values; `initialize_pipe` references them as operands

--- a/docs/en/dev/debug/00-torch_codegen.md
+++ b/docs/en/dev/debug/00-torch_codegen.md
@@ -87,18 +87,27 @@ Mappings are registered by category:
 
 ### Cross-core operation mappings
 
-- `tile.tpush_to_aiv` -> `_cross_core_rt.push_to_aiv(tile, split)`
+- `tile.tpush_to_aiv` -> `_cross_core_rt.push_to_aiv(tile, split[, lane_stride])`
 - `tile.tpush_to_aic` -> `_cross_core_rt.push_to_aic(tile, split)`
 - `tile.tpop_from_aic` -> `_cross_core_rt.pop_from_aic(split)`
 - `tile.tpop_from_aiv` -> `_cross_core_rt.pop_from_aiv(split)`
 - `tile.get_subblock_idx` -> `_get_subblock_idx()`
 
-`split` is normalized by `_split_mode_to_int()`:
+`split` is normalized by `_split_mode_to_int()` and carries pto-isa's
+`TileSplitAxis`:
 
 - `0`: NONE
-- `1`: UP_DOWN
-- `2`: LEFT_RIGHT
+- `1` / `2`: UP_DOWN / LEFT_RIGHT — the two lanes hold equal extents
+- `3` / `4`: the same axes over an ODD extent — lane 0 holds one cell more
 - invalid/unparsable values: raise `ValueError` (fail fast)
+
+The odd codes are validated against the tile's RUNTIME valid extent, not its
+physical box: an even box with an odd valid extent (16 with `valid_shape` 15)
+is exactly the case they exist for. `lane_stride` rides along only when
+[LowerAutoVectorSplit](../passes/20-lower_auto_vector_split.md) rebalanced a
+ragged boundary; the runtime then cuts the lanes there instead of at the box
+half. Odd codes are rejected on `push_to_aic` / `pop_from_aiv`, mirroring PTO
+codegen — pto-isa has no odd Vector-to-Cube transport.
 
 ## Tile/Tensor Boundary and Valid-Region Semantics
 
@@ -155,10 +164,11 @@ It also provides:
   - `pop_from_aiv` waits for both lane queues, then consumes a pair and returns lane0 payload
 - `split=1/2`: push enqueues by current lane; pop waits until both lanes are ready, then merges
 
-Split dimension semantics:
+Split dimension semantics (mirroring pto-isa's `TileSplitAxis`):
 
-- `split=1` (UP_DOWN): split/merge on `dim=0`
-- `split=2` (LEFT_RIGHT): split/merge on `dim=1`
+- `split=1` (UP_DOWN) / `split=3` (UP_DOWN_ODD): split/merge on `dim=0`
+- `split=2` (LEFT_RIGHT) / `split=4` (LEFT_RIGHT_ODD): split/merge on `dim=1`
+- the `_ODD` codes take the **ceil** half for lane 0 and the floor half for lane 1
 
 ### Synchronization and timeouts
 
@@ -230,7 +240,7 @@ Dynamic-dimension strategy:
 Main error classes:
 
 - `TypeError`: invalid entry node type
-- `ValueError`: unsupported op, invalid split/lane, non-even split dimension
+- `ValueError`: unsupported op, invalid split/lane, split dimension whose parity contradicts the split code (`1` / `2` need an even extent, `3` / `4` an odd one)
 - `RuntimeError`: pipe wait timeout, mixed-kernel thread failure/timeout
 
 For concurrency failures, codegen reports the first captured thread traceback to improve localization by function and lane.
@@ -239,7 +249,7 @@ For concurrency failures, codegen reports the first captured thread traceback to
 
 - `system.*` ops are emitted as no-ops in debug mode
 - Group pairing relies on `<group>_aic/_aiv` naming convention
-- `split=1/2` requires the split dimension to be divisible by 2
+- `split=1/2` requires an even split dimension; `split=3/4` requires an odd one
 - Group return is fixed to AIV lane0 output
 - Runtime is a Python semantic simulator, not equivalent to hardware pipeline timing
 

--- a/docs/en/dev/passes/20-lower_auto_vector_split.md
+++ b/docs/en/dev/passes/20-lower_auto_vector_split.md
@@ -340,6 +340,38 @@ as an internal assertion in PTO codegen (`SplitAivScopeStmt reached PTO codegen`
 (`split_axis_utils`); it is **not** called for `None` (the region path branches on
 `None` first — there is no axis to derive).
 
+### Split mode vs pto-isa split code
+
+`SplitMode` names the axis the author picked. The `split` attr that reaches the
+device names something narrower — pto-isa's `TileSplitAxis`, which also says how
+the two lanes' **runtime** extents relate, because that is how the consumer finds
+lane 1's band inside the FIFO slot (`popVecTileFromGMFiFo`):
+
+| Code | pto-isa | Lane 1's band starts at | Requires |
+| ---- | ------- | ----------------------- | -------- |
+| 0 | `TILE_NO_SPLIT` | — | single reader |
+| 1 / 2 | `TILE_UP_DOWN` / `TILE_LEFT_RIGHT` | `e1 * pitch` | `e0 == e1` |
+| 3 / 4 | `TILE_UP_DOWN_ODD` / `TILE_LEFT_RIGHT_ODD` | `(e1 + 1) * pitch` | `e0 == e1 + 1` |
+
+The two vocabularies live on different ops:
+
+- **`tile.aiv_shard` / `tile.aic_gather` carry the MODE** (`0` / `1` / `2`). This
+  pass stamps `int(mode)` — the author's axis, nothing more.
+- **`tile.tpush_*` / `tile.tpop_*` / `system.tfree_*` carry the CODE** (`0`..`4`),
+  chosen by [ExpandMixedKernel](21-expand_mixed_kernel.md) from that mode plus the
+  full-width tile's extents (`split_axis::ShardSplitCode`) when it folds the
+  boundary into a transport pair. PTO codegen prints it verbatim as `{split = N}`.
+
+An odd split axis reaches the odd codes in two ways, and the halving treats both
+identically: `ComputeHalfDimSize` gives BOTH lanes the **ceil** half as their
+physical box, and the per-lane valid extent carries the raggedness.
+
+| Boundary tile | Lane boxes | Lane extents | Code |
+| ------------- | ---------- | ------------ | ---- |
+| `[17, 128]`, fully valid | `[9, 128]` | 9 / 8 | 3 |
+| `[16, 128]`, valid `[15, 128]` | `[8, 128]` | 8 / 7 | 3 |
+| `[16, 128]`, fully valid | `[8, 128]` | 8 / 8 | 1 |
+
 ## Partially-valid operands across the boundary
 
 A crossing value whose `valid_shape` is short of its physical box is a kernel's
@@ -354,11 +386,12 @@ geometric rule at the end of this section instead.
 
 | Ragged axis | Mode | Extent is | Carrier | Status |
 | ----------- | ---- | --------- | ------- | ------ |
-| rows (split axis) | `UpDown` | per-lane | TPOP `valid_row` operand (free field) | **supported** |
+| rows (split axis) | `UpDown` | per-lane | TPOP `valid_row` operand | **supported** when the lanes are placeable (below) |
 | cols (non-split) | `UpDown` | shared, static | full-box transport + static `pto.treshape` | supported |
 | rows (non-split) | `LeftRight` | shared, static | TPOP `valid_row` operand | supported |
 | cols (split axis) | `LeftRight` | per-lane | none | **rejected** |
 | cols, runtime-valued | either | shared, dynamic | none (`treshape` takes no operands) | **rejected** |
+| rows, runtime-valued | `UpDown` | per-lane, dynamic | TPOP `valid_row` operand, even code | supported (see the note below) |
 | rows per-lane **and** cols narrowed | `UpDown` | both | none (`treshape` rewrites both axes) | **rejected** |
 
 `ReshapeSplitAxis` can only ceil-halve the split-axis extent (the lane index is
@@ -369,6 +402,26 @@ logical rectangle is rejected with its span. The AUTO arm applies the same *exte
 `LocalizeShardValidForLane`, but not the store guard below — its consumers are
 rebuilt by the halving walk rather than by this one.
 
+- **The two lanes' extents must be placeable.** The split-axis extent is not a
+  free field: pto-isa derives lane 1's band from the popped tile's own valid
+  extent — `e1` cells in (`TILE_UP_DOWN`) or `e1 + 1` (the `_ODD` modes). So the
+  placeable shapes are exactly `e0 == e1` (even code), `e0 == e1 + 1` (odd code)
+  and `e1 == 0` (lane 1 pops nothing, so its band is never dereferenced — the
+  even code stays exact). The box partition does not guarantee that for a ragged
+  boundary — 13 of a 16-row box gives 8 and 5 — which is what the balanced
+  partition below is for. When it does not apply, `ShardSplitCode` reports the
+  extents instead, naming what would work.
+- **A runtime split-axis valid extent keeps the even code.** The split code is a
+  compile-time attr, but which one the lanes need appears to depend on their
+  *runtime* extents: 15 of a 16-wide axis leaves the lanes at 8 and 7. The even
+  code is what this path emits, and what the device is measured to accept —
+  `tests/st/runtime/cross_core/test_cross_core_split_parity.py` compares
+  `output[:VR, :VC]` elementwise for `VC = 1, 7, 8, 9, 15` on a2a3 and passes,
+  and perturbing that golden on lane 1's columns alone does fail it, so the
+  check covers the band in question. Reading pto-isa's pop suggests a mis-placed
+  lane 1 instead; which reading is the contract is asked upstream in
+  [pto-isa#263](https://github.com/hw-native-sys/pto-isa/issues/263). Until that
+  answers, the encoding follows the measured behaviour.
 - **An empty lane's store is guarded.** A lane the ragged extent does not reach
   has extent `0`, and a zero-row `TSTORE` is outside pto-isa's contract
   (`TSTORE_IMPL` asserts `GetValidRow() > 0`). The store gets a runtime
@@ -382,22 +435,79 @@ rebuilt by the halving walk rather than by this one.
   per-lane extents exist and could only judge the join on its own ceil-div guess.
   A gather fed by a localized shard is typed exactly — the bands always abut, so
   the joined extent is the pre-shard `V` — and only a partial that both lanes
-  share is rejected.
+  share is rejected. The same geometry is why the gather has **no odd form**:
+  `GatherSplitCode` always returns an even code and rejects a boundary whose
+  lanes would differ (pad the axis and narrow the cube-side result instead).
+
+## Balancing a ragged boundary across the lanes
+
+The split partitions the split axis between the lanes: lane `L` owns
+`[L*S, L*S + S)` of it. Two partitions are possible, and they differ only when
+the boundary tile is ragged:
+
+| Partition | `S` | Lane extents for a `[16, …]` box valid to 13 | Placeable? |
+| --------- | --- | -------------------------------------------- | ---------- |
+| box (default) | `ceil(box / 2)` = 8 | 8 and 5 | no |
+| **valid** (rebalanced) | `ceil(V / 2)` = 7 | 7 and 6 | yes — `TILE_UP_DOWN_ODD` |
+
+The box partition is universal: it works for every tile in the region whatever
+its valid extent, which is why it is the default. What it cannot do is keep the
+lanes within one cell of each other, and that is exactly what the transport
+needs (see the placeability rule above). Balancing the VALID region instead
+makes `e0 - e1 ∈ {0, 1}` by construction — and splits the real work evenly
+rather than leaving lane 1 the remainder.
+
+`split_axis::ResolveLaneStride` runs over the body before it is rewritten and
+returns the balanced stride only when it is both needed and sound:
+
+- at least one Cube→Vector boundary, all agreeing on the same static
+  `(box, valid)` on the split axis, with `ceil(V / 2) < ceil(box / 2)`
+  (otherwise the box partition already balances);
+- no Vector→Cube boundary (the gather re-joins the lanes positionally at their
+  own extents, which only abut when they are equal);
+- every other split-axis tile in the body derives from that boundary — a tile
+  with an independent origin (a `tile.load`, a generator) spans the FULL box,
+  which the balanced partition would not cover.
+
+Anything else keeps the box partition. The stride then threads through the whole
+halving — offsets (`AdjustOffsets`), per-lane valid extents
+(`LocalizeValidDimForSplit`), the shard's own type
+(`LocalizeShardValidForLane`) — while the physical box stays `ceil(box / 2)`, so
+buffers and slot sizes are unchanged. It is stamped on the boundary op as
+`lane_stride=S` so [ExpandMixedKernel](21-expand_mixed_kernel.md) derives the
+transport code from the same partition. A `tile.reshape` that migrates the split
+axis inside a rebalanced body is rejected: a migrated axis carries its own half,
+which cannot express a partition balanced on another axis.
+
+```python
+# 13 of 16 valid rows, UP_DOWN. Lane 0 takes rows 0-6, lane 1 rows 7-12.
+popped: pl.Tile[[8, 128], pl.FP32, pl.Mem.Vec,
+                pl.TileView(valid_shape=[pl.min(pl.max(13, aiv_id * 7) - aiv_id * 7, 7), 128])
+               ] = pl.tile.aiv_shard(qk, split=1, lane_stride=7)
+out_store = pl.tile.store(popped, [0 + aiv_id * 7, 0], out_0)
+```
+
+Explicit `pl.split_aiv` regions are never rebalanced: their per-lane offsets are
+the author's own (`out[aiv_id * HALF : ...]`), and the compiler must not
+partition the data differently from the way the region indexes it.
 
 ## Algorithm
 
 `LowerFunction` rewrites one mixed `InCore` function:
 
 ```text
-1. split_dim = SplitDimension(mode); split_int = int(mode).
+1. split_dim = SplitDimension(mode); the boundary op carries int(mode).
 2. InjectSubblockIdx(func, is_aiv=true) prepends
        subblock_idx = tile.get_subblock_idx()
    to the body (fresh name if 'subblock_idx' is taken).
+2a. ResolveLaneStride(body, split_dim) picks the partition: the balanced
+    ceil(V / 2) for a body that is one ragged crossing, else null (the box
+    partition). It threads through every offset / per-lane extent below.
 3. LowerStmts walks the flat body:
 
    Boundary tile.move (ClassifyMoveDirection):
      CUBE_TO_VECTOR — replace the move with
-         tile.aiv_shard(full_cube_tile, split=int(mode))   -> HALF
+         tile.aiv_shard(full_cube_tile, split=int(mode)[, lane_stride=S])  -> HALF
        The deduced HALF type already carries the consuming-lane memory
        (Vec): the split deducer leaves memory_space null and
        OpRegistry::Create fills it from tile.aiv_shard's set_output_memory

--- a/docs/en/dev/passes/21-expand_mixed_kernel.md
+++ b/docs/en/dev/passes/21-expand_mixed_kernel.md
@@ -266,6 +266,10 @@ Phase 2 — Expand each InCore function F:
   4. Build AIC body: keep CUBE + SHARED stmts, prune VECTOR, recurse into MIXED loops
      - For boundary move (Cube→Vector): emit tpush_to_aiv(source_tile)
      - For boundary move (Vector→Cube): emit dest_var = tpop_from_aiv() with fractal TileView
+  4a. For an op-driven boundary (tile.aiv_shard / tile.aic_gather), derive the
+      pto-isa split CODE for the tpush/tpop pair from the op's authored MODE plus
+      the full-width tile's extents (BoundaryTransportSplitCode ->
+      split_axis::ShardSplitCode / GatherSplitCode) — see "The split code" below
   5. Build AIV body: symmetric (keep VECTOR + SHARED, prune CUBE)
      - For boundary move (Cube→Vector): emit dest_var = tpop_from_aic() with fractal TileView
      - For boundary move (Vector→Cube): emit tile.move to adapt fractal layout, then tpush_to_aic(adapted_tile)
@@ -343,6 +347,32 @@ emitted as a bare `EvalStmt` and the wrapper returns the matching Group
 params directly (e.g. `return out_0`), keeping the `ReturnParamsExplicit`
 invariant. Only when some position is not a param writeback does it fall back
 to the legacy `result = aiv_call(); return result` form.
+
+## The split code
+
+`tile.aiv_shard` / `tile.aic_gather` carry the authored **mode** (`0` / `1` / `2`);
+the transport pair this pass mints carries pto-isa's `TileSplitAxis` **code**
+(`0`..`4`), which additionally says how the two AIV lanes' *runtime* extents
+relate — that is how the consumer finds lane 1's band inside the FIFO slot:
+
+| Code | pto-isa | Lane 1's band starts at | Requires |
+| ---- | ------- | ----------------------- | -------- |
+| 1 / 2 | `TILE_UP_DOWN` / `TILE_LEFT_RIGHT` | `e1 * pitch` | `e0 == e1` |
+| 3 / 4 | `TILE_UP_DOWN_ODD` / `TILE_LEFT_RIGHT_ODD` | `(e1 + 1) * pitch` | `e0 == e1 + 1` |
+
+`BoundaryTransportSplitCode` reads the lane extents `eL = clamp(V - L*S, 0, S)`
+off the FULL-width tile — the shard's operand (Cube→Vector) or the gather's result
+(Vector→Cube). `S` is the partition stride: the tile's physical half, or the
+balanced `lane_stride=S` attr when
+[LowerAutoVectorSplit](20-lower_auto_vector_split.md) rebalanced a ragged
+boundary. So an odd split axis (an odd physical box, an odd valid extent inside
+an even one, or a rebalanced odd valid region) takes the odd code, an empty
+lane 1 keeps the even one, and a ragged extent pto-isa cannot place — only
+reachable on the box partition — is rejected with the extents that would work.
+Both lane bodies run the same derivation on the same inputs, so the AIC and AIV
+sides always agree. The Vector→Cube gather has no odd form (pto-isa's vector-side
+producer offsets lane 1 by lane 1's own extent), so it is even-only. Full
+derivation: [LowerAutoVectorSplit](20-lower_auto_vector_split.md).
 
 ## Example 1: InCore without existing Group caller
 

--- a/docs/zh/dev/codegen/00-pto_codegen.md
+++ b/docs/zh/dev/codegen/00-pto_codegen.md
@@ -196,19 +196,34 @@ tile 调用 `set_validshape`。
   `tile.set_validshape` 更新，`tpush` 会发射已经更新运行时 valid shape 的同一个
   tile handle。对于 split `tpush`，codegen 会临时使用完整物理传输 box，随后恢复
   producer tile 的逻辑 valid shape。
-- Cube-to-Vector FIFO 在**任意** split 下都按物理 box stride 搬运：ISA 用被弹出
-  tile 的编译期 rows/cols 以及 producer 的 box 行间距构造 GM 槽位视图，再用该 tile
-  的*运行时* `valid_col` 去 stride 这个视图。因此 TPOP 上的部分 valid shape 会让 GM
-  行间隙塌缩为 0，消费侧读到的是一段连续数据而不是每次一行 box——这会静默破坏
-  *有效*区域的数据，因为 ISA 中对应的断言在 release 构建里被编译掉了。所以部分有效的
-  Acc-to-Vec 传输在无切分以及 `split = 1` / `split = 2` 下，TPUSH 和 TPOP 都使用完整
-  物理 box，并在传输两侧立即恢复逻辑 valid shape——消费侧通过纯元数据的
-  `pto.treshape` 恢复（前端 tpop 结果不是 PTOAS 的本地绑定 tile，`pto.set_validshape`
-  无法就地修改它）。
+- `split` 就是 pto-isa 的 `TileSplitAxis`，原样打印。`0` = 不切分，`1` / `2` = 上下 /
+  左右，`3` / `4` = 同样两个轴、但 extent 为**奇数**：
+
+  | Code | pto-isa | Lane 0 | Lane 1 | Lane 1 的数据段起点 |
+  | ---- | ------- | ------ | ------ | ------------------- |
+  | 0 | `TILE_NO_SPLIT` | 整块 tile | （单一读者） | — |
+  | 1 / 2 | `TILE_UP_DOWN` / `TILE_LEFT_RIGHT` | `e0` | `e1` | `e1 * pitch` |
+  | 3 / 4 | `TILE_UP_DOWN_ODD` / `TILE_LEFT_RIGHT_ODD` | `e0` | `e1` | `(e1 + 1) * pitch` |
+
+  `eL` 是 lane `L` 在切分轴上的**运行时** valid extent——ISA 直接从被弹出的 tile 上读取
+  （`popVecTileFromGMFiFo`），因此偶数 code 要求 `e0 == e1`，奇数 code 要求
+  `e0 == e1 + 1`。这些 extent 由
+  [LowerAutoVectorSplit](../passes/20-lower_auto_vector_split.md) 物化，
+  [ExpandMixedKernel](../passes/21-expand_mixed_kernel.md) 选择匹配的 code。
+- Cube-to-Vector FIFO 搬运的是紧凑矩形：producer 以 `valid_col` 为行间距写入
+  `valid_row` x `valid_col` 数据块，每个消费 lane 再以相同间距读回自己的数据段
+  （`gmStrideR = valid_col`，左右切分的 code 下加倍）。因此若传输两侧的 valid shape
+  不一致，pop 的 stride 就会错位——这会静默破坏*有效*区域的数据，因为 ISA 中对应的
+  断言在 release 构建里被编译掉了。所以部分有效的 Acc-to-Vec 传输无论是否切分，
+  TPUSH 和 TPOP 都使用完整物理 box，并在传输两侧立即恢复逻辑 valid shape——消费侧
+  通过纯元数据的 `pto.treshape` 恢复（前端 tpop 结果不是 PTOAS 的本地绑定 tile，
+  `pto.set_validshape` 无法就地修改它）。唯一的例外是切分轴上的 extent：它必须保持
+  逐 lane 的值并留在 TPOP 操作数上，因为 ISA 正是靠它定位 lane 1 的数据段起点。
 - 当 tpop 结果的 `TileView.valid_shape` 与物理 tile shape 不一致时，PTO codegen 会生成 PTOAS 前端操作数：`%buf = pto.tpop_from_*(%valid_row, %valid_col) {[id = I, ]split = N} -> !pto.tile_buf<..., v_row=?, v_col=?, ...>`。这同时覆盖动态表达式和 `[0, 0]` 这类静态非满形状；operand 携带后续计算和 store 使用的逻辑范围。对于静态形状、非空的部分 pop，上述 Cube-to-Vector 完整 box 传输优先，因为 `pto.treshape` 不带 valid-row/valid-col operand，只能恢复*静态*逻辑范围。
-- 对于 split consumer，`SplitVectorKernel` 会按 subblock 本地化这些动态
+- 对于 split consumer，`LowerAutoVectorSplit` 会按 subblock 本地化这些动态
   tpop valid-shape operand（例如 `[16, 16]` tile 做上下切分时，全局
-  `[8, 16]` 会变成 `[8, 16]` 和 `[0, 16]`）。
+  `[8, 16]` 会变成 `[8, 16]` 和 `[0, 16]`）。奇数切分轴走同一条路径——`[17, 128]`
+  的 tile 在 `split = 3` 下，lane 0 弹出 `[9, 128]`，lane 1 弹出 `[8, 128]`。
 - `system.tfree_*` 的 `split` 来自其 tile 参数，因此前端必须释放由 `tile.tpop_*` 产生的那个确切 SSA 值，即使 PTO 指令本身并不显式接收该 tile 作为操作数
 - `ExpandMixedKernel` 现在会在 split 生成的消费侧 `tile.tpop_*` 之后自动补 `system.tfree_*`，保持 `tpop -> direct users -> tfree -> next tpop`
 - `reserve_buffer` 和 `import_reserved_buffer` 返回 `i32` SSA 值；`initialize_pipe` 以操作数引用这些值

--- a/docs/zh/dev/debug/00-torch_codegen.md
+++ b/docs/zh/dev/debug/00-torch_codegen.md
@@ -87,18 +87,25 @@ torch_codegen(node: _ir.Program | _ir.Function, check_shapes: bool = False) -> s
 
 ### cross-core 相关映射
 
-- `tile.tpush_to_aiv` -> `_cross_core_rt.push_to_aiv(tile, split)`
+- `tile.tpush_to_aiv` -> `_cross_core_rt.push_to_aiv(tile, split[, lane_stride])`
 - `tile.tpush_to_aic` -> `_cross_core_rt.push_to_aic(tile, split)`
 - `tile.tpop_from_aic` -> `_cross_core_rt.pop_from_aic(split)`
 - `tile.tpop_from_aiv` -> `_cross_core_rt.pop_from_aiv(split)`
 - `tile.get_subblock_idx` -> `_get_subblock_idx()`
 
-`split` 参数统一通过 `_split_mode_to_int()` 归一化为整数：
+`split` 参数统一通过 `_split_mode_to_int()` 归一化为整数，取值即 pto-isa 的
+`TileSplitAxis`：
 
 - `0`: NONE
-- `1`: UP_DOWN
-- `2`: LEFT_RIGHT
+- `1` / `2`: UP_DOWN / LEFT_RIGHT——两个 lane extent 相等
+- `3` / `4`: 同样两个轴、但 extent 为奇数——lane 0 多一格
 - 非法或不可解析取值：抛出 `ValueError`（fail fast）
+
+奇数 code 按 tile 的**运行时** valid extent 校验，而非物理 box：偶数 box 配奇数 valid
+extent（box 16、`valid_shape` 15）正是它们存在的场景。只有
+[LowerAutoVectorSplit](../passes/20-lower_auto_vector_split.md) 对 ragged 边界做了均分时
+才会带上 `lane_stride`，此时运行时按该步长切分而不是按 box 折半。`push_to_aic` /
+`pop_from_aiv` 拒绝奇数 code，与 PTO codegen 一致——pto-isa 没有奇数的 Vector→Cube 传输。
 
 ## Tile/Tensor 边界与有效区语义
 
@@ -156,8 +163,9 @@ Cross-core 的入队/切分/合并路径同样会保留这两个属性，确保�
 
 split 维度定义：
 
-- `split=1`（UP_DOWN）：按 `dim=0` 切分/拼接
-- `split=2`（LEFT_RIGHT）：按 `dim=1` 切分/拼接
+- `split=1`（UP_DOWN）/ `split=3`（UP_DOWN_ODD）：按 `dim=0` 切分/拼接
+- `split=2`（LEFT_RIGHT）/ `split=4`（LEFT_RIGHT_ODD）：按 `dim=1` 切分/拼接
+- `_ODD` code 下 lane 0 取 **ceil** 折半，lane 1 取 floor 折半
 
 ### 同步与超时
 
@@ -229,7 +237,7 @@ split 维度定义：
 主要错误类型：
 
 - `TypeError`：入口 node 类型错误
-- `ValueError`：不支持的 op、非法 split、lane 不合法、split 维度不可二分
+- `ValueError`：不支持的 op、非法 split、lane 不合法、split 维度奇偶性与 split code 不符（`1` / `2` 需要偶数 extent，`3` / `4` 需要奇数）
 - `RuntimeError`：pipe 等待超时、混合核线程失败/超时
 
 并发失败时保留首个线程 traceback，便于快速定位具体函数和 lane。
@@ -238,7 +246,7 @@ split 维度定义：
 
 - `system.*` 操作按 no-op 处理，仅保留语义占位
 - Group 配对依赖命名约定 `<group>_aic/_aiv`
-- `split=1/2` 依赖对应切分维度可被 2 整除
+- `split=1/2` 要求切分维度为偶数；`split=3/4` 要求为奇数
 - Group 返回值固定取 AIV lane0
 - 该运行时为单机 Python 语义模拟，不等价于硬件流水线时序
 

--- a/docs/zh/dev/passes/20-lower_auto_vector_split.md
+++ b/docs/zh/dev/passes/20-lower_auto_vector_split.md
@@ -299,6 +299,36 @@ attrs，因此 [`ExpandMixedKernel`](21-expand_mixed_kernel.md) 凭该标记跳�
 `SplitDimension(mode)` 对 `UpDown` 返回 `0`，对 `LeftRight` 返回 `1`
 （`split_axis_utils`）；对 `None` **不调用**（区域路径先对 `None` 分支——无轴可推导）。
 
+### split 模式与 pto-isa split code
+
+`SplitMode` 描述的是作者选的轴。真正下发到设备的 `split` 属性含义更窄——它是 pto-isa
+的 `TileSplitAxis`，还要说明两个 lane 的**运行时** extent 之间的关系，因为消费侧正是
+靠它在 FIFO 槽位中定位 lane 1 的数据段（`popVecTileFromGMFiFo`）：
+
+| Code | pto-isa | Lane 1 的数据段起点 | 要求 |
+| ---- | ------- | ------------------- | ---- |
+| 0 | `TILE_NO_SPLIT` | — | 单一读者 |
+| 1 / 2 | `TILE_UP_DOWN` / `TILE_LEFT_RIGHT` | `e1 * pitch` | `e0 == e1` |
+| 3 / 4 | `TILE_UP_DOWN_ODD` / `TILE_LEFT_RIGHT_ODD` | `(e1 + 1) * pitch` | `e0 == e1 + 1` |
+
+这两套词汇分别落在不同的算子上：
+
+- **`tile.aiv_shard` / `tile.aic_gather` 携带 MODE**（`0` / `1` / `2`）。本 pass 只
+  盖 `int(mode)`——作者选的轴，仅此而已。
+- **`tile.tpush_*` / `tile.tpop_*` / `system.tfree_*` 携带 CODE**（`0`..`4`），由
+  [ExpandMixedKernel](21-expand_mixed_kernel.md) 在把边界折叠成传输对时，根据该 mode
+  与全宽 tile 的 extent 推导（`split_axis::ShardSplitCode`）。PTO codegen 原样打印为
+  `{split = N}`。
+
+奇数切分轴有两种来源，折半逻辑对二者完全一致：`ComputeHalfDimSize` 让**两个** lane 都
+拿到 **ceil** 折半作为物理 box，参差不齐的部分由逐 lane 的 valid extent 承载。
+
+| 边界 tile | Lane box | Lane extent | Code |
+| --------- | -------- | ----------- | ---- |
+| `[17, 128]`，全有效 | `[9, 128]` | 9 / 8 | 3 |
+| `[16, 128]`，valid `[15, 128]` | `[8, 128]` | 8 / 7 | 3 |
+| `[16, 128]`，全有效 | `[8, 128]` | 8 / 8 | 1 |
+
 ## 跨边界的部分有效（partially-valid）操作数
 
 `valid_shape` 不足物理 box 的跨界值，正是 kernel 的 ragged 尾部。Cube→Vector FIFO
@@ -311,11 +341,12 @@ lane 的——lane `L` 持有 `clamp(V - L*half, 0, half)`——因此哪种模�
 
 | 收窄的轴 | 模式 | extent 性质 | 载体 | 状态 |
 | -------- | ---- | ----------- | ---- | ---- |
-| 行（切分轴） | `UpDown` | 逐 lane | TPOP `valid_row` 操作数（自由字段） | **支持** |
+| 行（切分轴） | `UpDown` | 逐 lane | TPOP `valid_row` 操作数 | 两个 lane 可摆放时**支持**（见下） |
 | 列（非切分轴） | `UpDown` | 两 lane 相同、静态 | 整 box 传输 + 静态 `pto.treshape` | 支持 |
 | 行（非切分轴） | `LeftRight` | 两 lane 相同、静态 | TPOP `valid_row` 操作数 | 支持 |
 | 列（切分轴） | `LeftRight` | 逐 lane | 无 | **拒绝** |
 | 列为运行期值 | 任意 | 两 lane 相同、动态 | 无（`treshape` 不带操作数） | **拒绝** |
+| 行为运行期值 | `UpDown` | 逐 lane、动态 | TPOP `valid_row` 操作数、偶数 code | 支持（见下方说明） |
 | 行逐 lane **且**列收窄 | `UpDown` | 两者 | 无（`treshape` 会同时重写两个轴） | **拒绝** |
 
 `ReshapeSplitAxis` 只能对切分轴做 ceil 折半，因为 lane 索引不属于 op 的类型函数。
@@ -325,6 +356,22 @@ lane 的——lane `L` 持有 `clamp(V - L*half, 0, half)`——因此哪种模�
 报错。AUTO 分支通过 `LocalizeShardValidForLane` 施加同样的 *extent* 修正，但不含下面的
 store 保护——它的消费者由折半遍历重建，而非本遍历。
 
+- **两个 lane 的 extent 必须可摆放。** 切分轴上的 extent 并不是自由字段：pto-isa 根据
+  被弹出 tile 自身的 valid extent 推导 lane 1 的数据段起点——`TILE_UP_DOWN` 下是 `e1`，
+  `_ODD` 模式下是 `e1 + 1`。因此可摆放的形态只有三种：`e0 == e1`（偶数 code）、
+  `e0 == e1 + 1`（奇数 code），以及 `e1 == 0`（lane 1 不弹出任何数据，其数据段永远不会
+  被解引用，偶数 code 依然精确）。box 分区对 ragged 边界并不保证这一点——16 行 box 上
+  `V = 13` 会得到 8 与 5——这正是下文均分分区要解决的问题；均分不适用时，
+  `ShardSplitCode` 会报错并给出可行的取值。
+- **运行期的切分轴 valid extent 沿用偶数 code。** split code 是编译期属性，而两个 lane
+  需要哪一个看起来取决于它们的**运行期** extent：16 宽的轴上 valid 15 会让两 lane 变成 8 与 7。
+  该路径发偶数 code，这也是设备实测接受的行为——
+  `tests/st/runtime/cross_core/test_cross_core_split_parity.py` 在 a2a3 上对
+  `VC = 1, 7, 8, 9, 15` 逐元素比对 `output[:VR, :VC]` 并通过，且仅把 golden 在 lane 1 的列上
+  扰动即会失败，说明该校验确实覆盖了这段数据。而按 pto-isa 的 pop 源码推理会得出 lane 1 落位
+  错误；究竟哪一种才是契约，已在
+  [pto-isa#263](https://github.com/hw-native-sys/pto-isa/issues/263) 上向属主提问。在有答复之前，
+  编码遵循实测行为。
 - **空 lane 的 store 被保护。** ragged extent 覆盖不到的 lane，其 extent 为 `0`，而
   零行 `TSTORE` 超出 pto-isa 契约（`TSTORE_IMPL` 断言 `GetValidRow() > 0`）。store
   被加上运行时 `extent > 0` 判断；`tpop` 与 `tfree` 保持**无条件**——两个 lane 都占用
@@ -335,22 +382,70 @@ store 保护——它的消费者由折半遍历重建，而非本遍历。
   相邻时才是矩形。该规则在**本 pass** 而非类型推导中执行：推导发生在逐 lane extent 存在
   之前，只能依据自己的 ceil 猜测来判断。由 localized shard 供给的 gather 会被精确定型
   ——两段必然相邻，拼合 extent 即 shard 前的 `V`——只有两个 lane 共享的部分 extent 才会
-  被拒绝。
+  被拒绝。同样的几何原因决定了 gather **没有奇数形态**：`GatherSplitCode` 始终返回偶数
+  code，并拒绝两个 lane extent 不等的边界（请改为补齐该轴，再在 cube 侧收窄结果）。
+
+## 把 ragged 边界在两个 lane 之间均分
+
+切分会把切分轴分给两个 lane：lane `L` 拥有 `[L*S, L*S + S)`。可选的分区有两种，只有
+边界 tile 是 ragged 时二者才不同：
+
+| 分区 | `S` | `[16, …]` box、valid 为 13 时的 lane extent | 可摆放？ |
+| ---- | --- | ------------------------------------------- | -------- |
+| box（默认） | `ceil(box / 2)` = 8 | 8 与 5 | 否 |
+| **valid**（均分） | `ceil(V / 2)` = 7 | 7 与 6 | 是——`TILE_UP_DOWN_ODD` |
+
+box 分区是通用的：无论 tile 的 valid extent 如何都成立，所以它是默认选择。它做不到的
+是让两个 lane 相差不超过 1，而这恰恰是传输的硬要求（见上文可摆放规则）。改为均分
+**valid** 区域后，`e0 - e1 ∈ {0, 1}` 由构造保证——并且真实工作量也被平均分配，而不是把
+余数全丢给 lane 1。
+
+`split_axis::ResolveLaneStride` 在改写函数体之前扫描一遍，只有在既必要又安全时才返回
+均分步长：
+
+- 至少有一个 Cube→Vector 边界，且所有边界在切分轴上的静态 `(box, valid)` 一致，并且
+  `ceil(V / 2) < ceil(box / 2)`（否则 box 分区本身已经是均分的）；
+- 没有 Vector→Cube 边界（gather 按各自的 extent 位置拼接两个 lane，只有 extent 相等时
+  两段才相邻）；
+- 函数体内其他切分轴上的 tile 全都派生自该边界——独立来源的 tile（`tile.load`、
+  生成类算子）跨越**整个** box，而均分分区覆盖不到。
+
+其余情况一律保持 box 分区。选定的步长会贯穿整个折半流程——偏移（`AdjustOffsets`）、
+逐 lane 的 valid extent（`LocalizeValidDimForSplit`）、shard 自身的类型
+（`LocalizeShardValidForLane`）——而物理 box 仍是 `ceil(box / 2)`，因此缓冲区和槽位大小
+不变。步长以 `lane_stride=S` 盖在边界算子上，供
+[ExpandMixedKernel](21-expand_mixed_kernel.md) 用同一分区推导传输 code。在均分的函数体里
+若出现迁移切分轴的 `tile.reshape`，会被拒绝：迁移后的轴带着自己的 half，无法表达按另一
+条轴的 valid 做的均分。
+
+```python
+# 16 行 box 里有 13 行有效，UP_DOWN。lane 0 取第 0-6 行，lane 1 取第 7-12 行。
+popped: pl.Tile[[8, 128], pl.FP32, pl.Mem.Vec,
+                pl.TileView(valid_shape=[pl.min(pl.max(13, aiv_id * 7) - aiv_id * 7, 7), 128])
+               ] = pl.tile.aiv_shard(qk, split=1, lane_stride=7)
+out_store = pl.tile.store(popped, [0 + aiv_id * 7, 0], out_0)
+```
+
+显式 `pl.split_aiv` 区域永远不做均分：那里的逐 lane 偏移是作者自己写的
+（`out[aiv_id * HALF : ...]`），编译器不能用与区域索引方式不同的分区去切数据。
 
 ## 算法
 
 `LowerFunction` 改写一个混合 `InCore` 函数：
 
 ```text
-1. split_dim = SplitDimension(mode); split_int = int(mode)。
+1. split_dim = SplitDimension(mode)；边界算子携带 int(mode)。
 2. InjectSubblockIdx(func, is_aiv=true) 在函数体顶部插入
        subblock_idx = tile.get_subblock_idx()
    （若 'subblock_idx' 已占用则取新名）。
+2a. ResolveLaneStride(body, split_dim) 选择分区：对于只有一个 ragged 跨界的
+    函数体取均分的 ceil(V / 2)，否则为 null（box 分区）。它会贯穿下面每一处
+    偏移与逐 lane extent。
 3. LowerStmts 遍历扁平函数体：
 
    边界 tile.move（ClassifyMoveDirection）：
      CUBE_TO_VECTOR —— 将 move 替换为
-         tile.aiv_shard(full_cube_tile, split=int(mode))   -> 半
+         tile.aiv_shard(full_cube_tile, split=int(mode)[, lane_stride=S])  -> 半
        推导出的半类型已经带有消费侧 lane 内存（Vec）：切分推导器让 memory_space
        保持为空，由 OpRegistry::Create 用 tile.aiv_shard 的 set_output_memory
        声明填充，与显式形式同源。将结果 var 连同其半尺寸种入 tile_vars，并记录

--- a/docs/zh/dev/passes/21-expand_mixed_kernel.md
+++ b/docs/zh/dev/passes/21-expand_mixed_kernel.md
@@ -227,6 +227,10 @@ program_expanded = expand_pass(program)
   4. 构建 AIC 函数体：保留 CUBE + SHARED 语句，删除 VECTOR，递归处理 MIXED 循环
      - 对于边界移动（Cube→Vector）：生成 tpush_to_aiv(source_tile)
      - 对于边界移动（Vector→Cube）：生成 dest_var = tpop_from_aiv()，携带 fractal TileView
+  4a. 对由算子驱动的边界（tile.aiv_shard / tile.aic_gather），根据该算子携带的
+      MODE 与全宽 tile 的 extent，推导 tpush/tpop 对使用的 pto-isa split CODE
+      （BoundaryTransportSplitCode -> split_axis::ShardSplitCode / GatherSplitCode）
+      ——见下文“split code”
   5. 构建 AIV 函数体：对称（保留 VECTOR + SHARED，删除 CUBE）
      - 对于边界移动（Cube→Vector）：生成 dest_var = tpop_from_aic()，携带 fractal TileView
      - 对于边界移动（Vector→Cube）：生成 tile.move 适配 fractal 布局，然后 tpush_to_aic(adapted_tile)
@@ -318,6 +322,28 @@ pass 或打印输出。
 直接返回自身参数——AIV 调用作为纯 `EvalStmt` 发出，包装函数直接
 `return out_0`，从而维持 `ReturnParamsExplicit` 不变量。只有当某个返回位置
 不是参数回写时，才回退到旧的 `result = aiv_call(); return result` 形式。
+
+## split code
+
+`tile.aiv_shard` / `tile.aic_gather` 携带作者选择的 **mode**（`0` / `1` / `2`）；本 pass
+生成的传输对携带的是 pto-isa 的 `TileSplitAxis` **code**（`0`..`4`），后者还表达了两个
+AIV lane 的*运行时* extent 之间的关系——消费侧正是靠它在 FIFO 槽位中定位 lane 1 的数据段：
+
+| Code | pto-isa | Lane 1 的数据段起点 | 要求 |
+| ---- | ------- | ------------------- | ---- |
+| 1 / 2 | `TILE_UP_DOWN` / `TILE_LEFT_RIGHT` | `e1 * pitch` | `e0 == e1` |
+| 3 / 4 | `TILE_UP_DOWN_ODD` / `TILE_LEFT_RIGHT_ODD` | `(e1 + 1) * pitch` | `e0 == e1 + 1` |
+
+`BoundaryTransportSplitCode` 从**全宽** tile 上读取 lane extent
+`eL = clamp(V - L*S, 0, S)`——shard 取其操作数（Cube→Vector），gather 取其结果
+（Vector→Cube）。`S` 是分区步长：默认为该 tile 的物理 half；当
+[LowerAutoVectorSplit](20-lower_auto_vector_split.md) 对 ragged 边界做了均分时，则取算子上
+`lane_stride=S` 属性。因此奇数切分轴（奇数物理 box、偶数 box 内的奇数 valid extent，或均分
+后的奇数 valid 区域）会取奇数 code；lane 1 为空时保持偶数 code；pto-isa 无法摆放的 ragged
+extent（只可能出现在 box 分区上）则被拒绝，并给出可行的取值。两侧 lane 的函数体用相同输入执行同一推导，因此 AIC 与 AIV 侧永远一致。
+Vector→Cube 的 gather 没有奇数形态（pto-isa 的向量侧 producer 按 lane 1 自身的 extent
+偏移），因此只使用偶数 code。完整推导见
+[LowerAutoVectorSplit](20-lower_auto_vector_split.md)。
 
 ## 示例 1：InCore 没有已有 Group 调用者
 

--- a/include/pypto/ir/stmt.h
+++ b/include/pypto/ir/stmt.h
@@ -122,6 +122,86 @@ inline SplitMode StringToSplitMode(const std::string& str) {
 }
 
 /**
+ * @brief ISA split codes carried by the ``split`` attr of the cross-core ops.
+ *
+ * The attr on the TRANSPORT ops — ``tile.tpush_*`` / ``tile.tpop_*`` /
+ * ``system.tfree_*`` — mirrors pto-isa's ``TileSplitAxis`` 1:1, because PTO
+ * codegen prints it verbatim as ``{split = N}``. (The boundary ops
+ * ``tile.aiv_shard`` / ``tile.aic_gather`` carry the authored ``SplitMode``
+ * instead — 0/1/2 only; ExpandMixedKernel derives the code from it.)
+ *
+ * | Code | pto-isa                 | Lane 0            | Lane 1            |
+ * | ---- | ----------------------- | ----------------- | ----------------- |
+ * | 0    | ``TILE_NO_SPLIT``       | whole tile        | (single reader)   |
+ * | 1    | ``TILE_UP_DOWN``        | rows ``[0, N/2)`` | rows ``[N/2, N)`` |
+ * | 2    | ``TILE_LEFT_RIGHT``     | cols ``[0, N/2)`` | cols ``[N/2, N)`` |
+ * | 3    | ``TILE_UP_DOWN_ODD``    | ``N/2 + 1`` rows  | ``N/2`` rows      |
+ * | 4    | ``TILE_LEFT_RIGHT_ODD`` | ``N/2 + 1`` cols  | ``N/2`` cols      |
+ *
+ * ``SplitMode`` names the axis the author picked; the ODD codes additionally
+ * encode that the two lanes' extents differ by one, so they have no
+ * ``SplitMode`` spelling. Codes 3/4 are legal only on the C2V (Cube -> Vector)
+ * shard direction: pto-isa's V2C producer (``pushVec2GMFiFo``) offsets lane 1
+ * by lane 1's own extent and so has no odd form. See
+ * ``split_axis::ShardSplitCode`` for how a boundary's code is chosen.
+ */
+constexpr int kSplitNone = 0;
+constexpr int kSplitUpDown = 1;
+constexpr int kSplitLeftRight = 2;
+constexpr int kSplitUpDownOdd = 3;
+constexpr int kSplitLeftRightOdd = 4;
+constexpr int kSplitCodeMax = kSplitLeftRightOdd;
+
+/// @brief Whether @p code is one of the two odd (ragged-lane) split codes.
+[[nodiscard]] inline bool IsOddSplitCode(int code) {
+  return code == kSplitUpDownOdd || code == kSplitLeftRightOdd;
+}
+
+/// @brief Whether @p code is a split code the IR (and pto-isa) understands.
+[[nodiscard]] inline bool IsValidSplitCode(int code) { return code >= kSplitNone && code <= kSplitCodeMax; }
+
+/**
+ * @brief The split code for @p mode over a split axis of the given parity.
+ * @param mode The authored split mode (``None`` always yields ``kSplitNone``).
+ * @param odd_extent Whether the PRE-split split-axis extent is statically odd.
+ */
+[[nodiscard]] inline int SplitCodeFor(SplitMode mode, bool odd_extent) {
+  switch (mode) {
+    case SplitMode::None:
+      return kSplitNone;
+    case SplitMode::UpDown:
+      return odd_extent ? kSplitUpDownOdd : kSplitUpDown;
+    case SplitMode::LeftRight:
+      return odd_extent ? kSplitLeftRightOdd : kSplitLeftRight;
+  }
+  throw pypto::TypeError("Unknown SplitMode");
+}
+
+/**
+ * @brief The authored mode behind a split code (both odd codes normalize to
+ *        their even sibling — parity is not part of the authored mode).
+ */
+[[nodiscard]] inline SplitMode SplitModeFromSplitCode(int code) {
+  switch (code) {
+    case kSplitNone:
+      return SplitMode::None;
+    case kSplitUpDown:
+    case kSplitUpDownOdd:
+      return SplitMode::UpDown;
+    case kSplitLeftRight:
+    case kSplitLeftRightOdd:
+      return SplitMode::LeftRight;
+    default:
+      throw pypto::ValueError("Unknown cross-core split code: " + std::to_string(code));
+  }
+}
+
+/// @brief The tile dimension a split code partitions (0 = rows, 1 = columns).
+[[nodiscard]] inline int SplitAxisFromSplitCode(int code) {
+  return (code == kSplitUpDown || code == kSplitUpDownOdd) ? 0 : 1;
+}
+
+/**
  * @brief Convert ForKind to string
  * @param kind The for loop kind
  * @return String representation ("Sequential", "Parallel", "Unroll", or "Pipeline")

--- a/include/pypto/ir/transforms/utils/core_affinity.h
+++ b/include/pypto/ir/transforms/utils/core_affinity.h
@@ -82,10 +82,16 @@ struct CVBoundaryMove {
   // op already encodes the half/full shape in result_type and the cross-core
   // fractal/post-move behaviour differs (see ExpandMixedKernel's boundary arm).
   bool op_driven = false;
-  // Split axis carried by the originating op (1 = UP_DOWN/axis0,
-  // 2 = LEFT_RIGHT/axis1). Stamped onto the generated tpush/tpop. 0 for
-  // tile.move boundaries (split assigned later by SplitVectorKernel).
+  // Split MODE carried by the originating op (1 = UP_DOWN/axis0,
+  // 2 = LEFT_RIGHT/axis1); 0 for tile.move boundaries (split assigned later by
+  // SplitVectorKernel). The pto-isa split CODE stamped onto the generated
+  // tpush/tpop is derived from this mode plus the boundary tile's extents —
+  // see split_axis::ShardSplitCode / GatherSplitCode.
   int split = 0;
+  // Partition stride the halving used, from the originating op's optional
+  // `lane_stride` attr (see split_axis::ResolveLaneStride). 0 = the default box
+  // partition, where the stride is the tile's own physical half.
+  int lane_stride = 0;
 };
 
 }  // namespace core_affinity

--- a/include/pypto/ir/transforms/utils/split_axis_utils.h
+++ b/include/pypto/ir/transforms/utils/split_axis_utils.h
@@ -12,9 +12,12 @@
 #ifndef PYPTO_IR_TRANSFORMS_UTILS_SPLIT_AXIS_UTILS_H_
 #define PYPTO_IR_TRANSFORMS_UTILS_SPLIT_AXIS_UTILS_H_
 
+#include <cstdint>
+#include <optional>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 
 #include "pypto/ir/expr.h"
@@ -41,6 +44,129 @@ namespace split_axis {
 int SplitDimension(SplitMode mode);
 
 /**
+ * @brief Half of a split-axis extent: the CEIL half.
+ *
+ * Both lanes get the same physical box, so an odd extent ``2k + 1`` gives each
+ * of them ``k + 1`` cells and the per-lane valid extent carries the raggedness
+ * (pto-isa's ``TILE_UP_DOWN_ODD``: "AIV0 = rows/2 + 1, AIV1 = rows/2"). An even
+ * extent is unaffected. A dynamic extent has no compile-time parity and keeps
+ * ``floordiv(dim, 2)``.
+ *
+ * @param dim_size The pre-split extent on the split axis.
+ * @return The per-lane physical extent.
+ */
+ExprPtr ComputeHalfDimSize(const ExprPtr& dim_size);
+
+/**
+ * @brief The per-lane partition stride for an AUTO-split body, or null.
+ *
+ * The split partitions the split axis between the two AIV lanes: lane L owns
+ * ``[L * S, L * S + S)`` of it, where ``S`` is this stride. Two partitions are
+ * possible, and they differ only when the boundary tile is ragged:
+ *
+ * | Partition | ``S`` | Lane extents for a `[16, ...]` box valid to 13 |
+ * | --------- | ----- | ---------------------------------------------- |
+ * | box (default) | ``ceil(box / 2)`` = 8 | 8 and 5 |
+ * | valid (this)  | ``ceil(V / 2)`` = 7   | 7 and 6 |
+ *
+ * The box partition is universal — it works for every tile in the region
+ * whatever its valid extent — but pto-isa can only place lane 1's FIFO band at
+ * its own extent (even codes) or one past it (odd codes), so lanes 8 and 5 have
+ * no expressible transport. Balancing the VALID region instead makes the two
+ * lanes differ by at most one by construction, which is exactly what the codes
+ * express — and it splits the real work evenly rather than leaving lane 1 the
+ * remainder.
+ *
+ * It is only sound when the whole body agrees on one logical row space, so this
+ * returns null (keep the box partition) unless:
+ *
+ * - the body has at least one Cube -> Vector boundary and they all agree on the
+ *   same static ``(box, valid)`` on the split axis;
+ * - no Vector -> Cube boundary is present (the gather re-joins the lanes
+ *   positionally at their own extents, which only abut when they are equal);
+ * - every other split-axis tile in the body is derived from that boundary — a
+ *   tile with an independent origin (a `tile.load`, a generator) spans the FULL
+ *   box, which the balanced partition would not cover.
+ *
+ * @param stmts The pre-lowering body statements.
+ * @param split_dim The partitioned tile dimension (see SplitDimension).
+ * @return The balanced stride as a ConstInt, or null to keep the box partition.
+ */
+ExprPtr ResolveLaneStride(const std::vector<StmtPtr>& stmts, int split_dim);
+
+/**
+ * @brief The pto-isa split code a Cube -> Vector boundary op must carry.
+ *
+ * pto-isa derives lane 1's band inside the FIFO slot from the popped tile's own
+ * RUNTIME valid extents, so the code has to state how the two lanes' extents
+ * relate (a2a3/a5 ``TPush.hpp popVecTileFromGMFiFo``):
+ *
+ * | Code                    | lane 1's band starts at | requires   |
+ * | ----------------------- | ----------------------- | ---------- |
+ * | ``kSplitUpDown`` / LR    | ``e1 * pitch``          | ``e0 == e1`` |
+ * | ``kSplitUpDownOdd`` / LR | ``(e1 + 1) * pitch``    | ``e0 == e1 + 1`` |
+ *
+ * where ``eL = clamp(V - L * half, 0, half)`` is lane L's extent, ``V`` the
+ * boundary tile's valid split-axis extent and ``half = ceil(box / 2)`` — the
+ * same clamp the halving materializes into the popped tile's valid_shape.
+ *
+ * That covers both odd shapes: an odd physical box (``V == box == 2k + 1`` gives
+ * ``k + 1`` / ``k``) and an odd valid extent inside an even box (``V == box - 1``
+ * gives ``half`` / ``half - 1``). An empty lane 1 (``e1 == 0``, i.e.
+ * ``V <= half``) reads nothing wherever it is pointed, so it keeps the even
+ * code. Any other ragged extent has no expressible band pair and is rejected
+ * with an actionable message rather than silently popping the wrong rows.
+ *
+ * A dynamic (non-ConstInt) box or valid extent has no compile-time lane extents;
+ * it keeps the even code, the only one whose lowering does not depend on the
+ * parity.
+ *
+ * @param mode The split mode (``None`` yields ``kSplitNone``).
+ * @param full_type The PRE-split (full-width) boundary tile type.
+ * @param split_dim The partitioned tile dimension (see SplitDimension).
+ * @param lane_stride The body's partition stride (see ResolveLaneStride); null
+ *        for the default box partition, where ``S = ceil(box / 2)``.
+ * @param op_name Op name for diagnostics.
+ * @param span Span for diagnostics.
+ * @return The split code to stamp on the boundary / tpush / tpop op.
+ */
+int ShardSplitCode(SplitMode mode, const TypePtr& full_type, int split_dim, const ExprPtr& lane_stride,
+                   const std::string& op_name, const Span& span);
+
+/**
+ * @brief The pto-isa split code a Vector -> Cube boundary op must carry.
+ *
+ * The gather has no odd form — pto-isa's vector-side producer
+ * (``pushVec2GMFiFo``) offsets lane 1 by lane 1's OWN extent, so the two bands
+ * abut only when the lanes are equal. This returns the even code and rejects a
+ * boundary whose lanes would differ.
+ *
+ * @param mode The split mode (``None`` yields ``kSplitNone``).
+ * @param full_type The FULL (gathered) boundary tile type.
+ * @param split_dim The partitioned tile dimension (see SplitDimension).
+ * @param op_name Op name for diagnostics.
+ * @param span Span for diagnostics.
+ * @return The even split code for @p mode.
+ */
+int GatherSplitCode(SplitMode mode, const TypePtr& full_type, int split_dim, const std::string& op_name,
+                    const Span& span);
+
+/**
+ * @brief The lane extents ``eL = clamp(V - L * S, 0, S)`` of a boundary tile.
+ *
+ * Exposed for the passes that need the pair itself (diagnostics, the transport
+ * code choice); returns nullopt when either the box or the valid extent on the
+ * split axis is not a compile-time constant.
+ *
+ * @param full_type The PRE-split (full-width) boundary tile type.
+ * @param split_dim The partitioned tile dimension (see SplitDimension).
+ * @param lane_stride The body's partition stride; null for the box partition.
+ * @return ``{lane0, lane1}`` extents, or nullopt when not static.
+ */
+std::optional<std::pair<int64_t, int64_t>> StaticLaneExtents(const TypePtr& full_type, int split_dim,
+                                                             const ExprPtr& lane_stride);
+
+/**
  * @brief Detect a vector reduction that collapses the split axis.
  *
  * When an AIV lane holds only half of a tile (after the split), a reduction
@@ -64,7 +190,10 @@ bool IsReduceOnSplitAxis(const CallPtr& call, int split_dim);
  * Once a tile var has been partitioned along the split axis, downstream ops
  * (e.g. ``tile.store``, loop ``iter_args``/``return_vars``) need its halved
  * extent to re-localize their split-dim offsets. ``half_dim_size`` is that
- * extent (a ``ConstInt`` for static dims, a ``floordiv`` expression otherwise).
+ * extent (a ``ConstInt`` for static dims, a ``floordiv`` expression otherwise)
+ * — the tile's PHYSICAL half. How far apart the two lanes' data sits is the
+ * partition stride instead (see ResolveLaneStride), which equals this half
+ * unless the body was rebalanced onto a ragged boundary's valid region.
  */
 struct TileInfo {
   ExprPtr half_dim_size;
@@ -154,19 +283,23 @@ TransposeSplitHazard FindTransposeSplitHazard(const StmtPtr& body, int split_dim
  * apply the final ``Substitute`` over the rebuilt body.
  *
  * @param stmts The statements to process.
- * @param mode The split mode (UpDown / LeftRight).
- * @param split_int The integer split attribute stamped on cross-core ops.
+ * @param mode The split mode (UpDown / LeftRight). The split attribute stamped
+ *        on each cross-core op is derived from it and the parity of that op's
+ *        own split-axis extent (see the ``kSplitUpDownOdd`` codes in stmt.h).
  * @param split_dim The partitioned tile dimension (see SplitDimension).
  * @param tile_vars In/out map of split-tracked tile vars to their halved extent.
  * @param is_aiv Whether this is an AIV lane (gates per-op halving).
  * @param subblock_idx The per-subblock index expr (null for non-AIV).
  * @param var_replacements In/out map of original vars to their rebuilt versions.
+ * @param lane_stride The body's partition stride (see ResolveLaneStride); null
+ *        keeps the default box partition.
  * @return The rewritten statement list.
  */
-std::vector<StmtPtr> ProcessStmts(const std::vector<StmtPtr>& stmts, SplitMode mode, int split_int,
-                                  int split_dim, std::unordered_map<const Var*, TileInfo>& tile_vars,
-                                  bool is_aiv, const ExprPtr& subblock_idx,
-                                  std::unordered_map<const Var*, VarPtr>& var_replacements);
+std::vector<StmtPtr> ProcessStmts(const std::vector<StmtPtr>& stmts, SplitMode mode, int split_dim,
+                                  std::unordered_map<const Var*, TileInfo>& tile_vars, bool is_aiv,
+                                  const ExprPtr& subblock_idx,
+                                  std::unordered_map<const Var*, VarPtr>& var_replacements,
+                                  const ExprPtr& lane_stride = nullptr);
 
 /**
  * @brief Give each explicit-boundary ``tile.aiv_shard`` its TRUE per-lane valid
@@ -217,10 +350,11 @@ std::vector<StmtPtr> LocalizeExplicitBoundaryValid(const std::vector<StmtPtr>& s
  * @param operand_type The pre-split tile type the shard reads.
  * @param split_dim The partitioned tile dimension (see SplitDimension).
  * @param subblock_idx The per-lane index expr; null leaves the type unchanged.
+ * @param lane_stride The body's partition stride; null for the box partition.
  * @return The retyped shard type, or @p shard_type when no repair applies.
  */
 TypePtr LocalizeShardValidForLane(const TypePtr& shard_type, const TypePtr& operand_type, int split_dim,
-                                  const ExprPtr& subblock_idx);
+                                  const ExprPtr& subblock_idx, const ExprPtr& lane_stride = nullptr);
 
 }  // namespace split_axis
 }  // namespace ir

--- a/python/pypto/debug/torch_codegen.py
+++ b/python/pypto/debug/torch_codegen.py
@@ -106,6 +106,16 @@ def _copy_region_attrs(src, dst):
     return dst
 
 
+# pto-isa TileSplitAxis codes carried by the cross-core ``split`` attr:
+# 0 = no split, 1 = up/down, 2 = left/right, 3 / 4 = the same two axes over an
+# ODD extent (lane 0 takes the ceil half, lane 1 the floor one).
+_SPLIT_CODES = (1, 2, 3, 4)
+
+
+def _is_odd_split(split):
+    return split in (3, 4)
+
+
 class _CrossCoreRuntime:
     def __init__(self):
         self._lock = threading.Lock()
@@ -116,10 +126,10 @@ class _CrossCoreRuntime:
         with self._cv:
             self._no_split_dual_aiv_dispatch = bool(no_split_dual_aiv_dispatch)
             self._to_aiv = deque()
-            self._to_aiv_split = {1: {0: deque(), 1: deque()}, 2: {0: deque(), 1: deque()}}
+            self._to_aiv_split = {c: {0: deque(), 1: deque()} for c in _SPLIT_CODES}
             self._to_aiv_dual_nosplit = {0: deque(), 1: deque()}
             self._to_aic = deque()
-            self._to_aic_split = {1: {0: deque(), 1: deque()}, 2: {0: deque(), 1: deque()}}
+            self._to_aic_split = {c: {0: deque(), 1: deque()} for c in _SPLIT_CODES}
             self._to_aic_dual_nosplit = {0: deque(), 1: deque()}
             self._cv.notify_all()
 
@@ -140,8 +150,8 @@ class _CrossCoreRuntime:
                 1: len(self._to_aiv_dual_nosplit[1]),
             },
             "to_aiv_split": {
-                1: {0: len(self._to_aiv_split[1][0]), 1: len(self._to_aiv_split[1][1])},
-                2: {0: len(self._to_aiv_split[2][0]), 1: len(self._to_aiv_split[2][1])},
+                c: {0: len(self._to_aiv_split[c][0]), 1: len(self._to_aiv_split[c][1])}
+                for c in _SPLIT_CODES
             },
             "to_aic": len(self._to_aic),
             "to_aic_dual_nosplit": {
@@ -149,8 +159,8 @@ class _CrossCoreRuntime:
                 1: len(self._to_aic_dual_nosplit[1]),
             },
             "to_aic_split": {
-                1: {0: len(self._to_aic_split[1][0]), 1: len(self._to_aic_split[1][1])},
-                2: {0: len(self._to_aic_split[2][0]), 1: len(self._to_aic_split[2][1])},
+                c: {0: len(self._to_aic_split[c][0]), 1: len(self._to_aic_split[c][1])}
+                for c in _SPLIT_CODES
             },
         }
 
@@ -172,25 +182,57 @@ class _CrossCoreRuntime:
             self._cv.wait(timeout=min(0.05, remaining))
 
     @staticmethod
-    def _split_tile(tile, split):
-        dim = 0 if split == 1 else 1
+    def _split_tile(tile, split, lane_stride=None):
+        # Partition a pushed tile between the two AIV lanes exactly the way the
+        # compiler did: lane L owns [L * S, L * S + S) of the split axis, where S
+        # is the partition stride (`lane_stride` when a ragged boundary was
+        # rebalanced, else the ceil half of the physical box). The split CODE
+        # states how the two lanes' VALID extents relate — equal for 1/2, one
+        # apart for the _ODD codes 3/4 — so it is validated against those
+        # extents, not against the physical box, which stays even in the common
+        # "even box, odd valid extent" case.
+        dim = 0 if split in (1, 3) else 1
         size = int(tile.shape[dim])
-        if size % 2 != 0:
-            raise ValueError(f"Split mode {split} requires even dimension size, got {size}")
-        half = size // 2
+        # Two distinct quantities: every lane's PHYSICAL box is the ceil half of
+        # the pushed tile (that is the buffer the compiler typed), while the
+        # partition STRIDE only says where lane 1's data begins — they differ
+        # exactly when a ragged boundary was rebalanced (box 16, stride 7).
+        box_half = (size + 1) // 2
+        stride = int(lane_stride) if lane_stride else box_half
+        if stride <= 0 or stride > box_half:
+            raise ValueError(
+                f"Split mode {split} got an out-of-range lane stride {stride} for a {size}-wide "
+                f"axis (per-lane box {box_half})"
+            )
+        valid_shape = getattr(tile, "_pypto_valid_shape", None)
+        valid = int(valid_shape[dim]) if valid_shape is not None else size
+        lane0 = min(valid, stride)
+        lane1 = min(max(valid - stride, 0), stride)
+        # Only the _ODD codes carry a contract worth checking here: they exist to
+        # say "lane 1 is exactly one cell shorter". The even codes stay permissive
+        # — this runtime is a semantic simulator, and it is the compiler
+        # (split_axis::ShardSplitCode) that refuses lane extents pto-isa cannot
+        # place.
+        if _is_odd_split(split) and lane0 != lane1 + 1:
+            raise ValueError(
+                f"Split mode {split} requires lanes one cell apart, but a valid extent of {valid} "
+                f"over stride {stride} gives {lane0} and {lane1}"
+            )
+        # Lane L takes a box_half-wide slice starting at L * stride, so both
+        # payloads keep the physical shape the compiler gave the popped tile.
         if dim == 0:
-            part0 = tile[:half, ...].clone()
-            part1 = tile[half:, ...].clone()
+            part0 = tile[:box_half, ...].clone()
+            part1 = tile[stride : stride + box_half, ...].clone()
         else:
-            part0 = tile[:, :half, ...].clone()
-            part1 = tile[:, half:, ...].clone()
+            part0 = tile[:, :box_half, ...].clone()
+            part1 = tile[:, stride : stride + box_half, ...].clone()
 
         full_shape = getattr(tile, "_pypto_full_shape", None)
         if full_shape is not None:
             full0 = list(int(s) for s in full_shape)
             full1 = list(int(s) for s in full_shape)
-            full0[dim] = min(full0[dim], half)
-            full1[dim] = max(full1[dim] - half, 0)
+            full0[dim] = min(full0[dim], box_half)
+            full1[dim] = min(max(full1[dim] - stride, 0), box_half)
             part0._pypto_full_shape = tuple(full0)
             part1._pypto_full_shape = tuple(full1)
 
@@ -198,8 +240,8 @@ class _CrossCoreRuntime:
         if valid_shape is not None:
             valid0 = list(int(s) for s in valid_shape)
             valid1 = list(int(s) for s in valid_shape)
-            valid0[dim] = min(valid0[dim], half)
-            valid1[dim] = max(valid1[dim] - half, 0)
+            valid0[dim] = lane0
+            valid1[dim] = lane1
             part0._pypto_valid_shape = tuple(valid0)
             part1._pypto_valid_shape = tuple(valid1)
 
@@ -207,7 +249,7 @@ class _CrossCoreRuntime:
 
     @staticmethod
     def _merge_tile(part0, part1, split):
-        dim = 0 if split == 1 else 1
+        dim = 0 if split in (1, 3) else 1
         merged = torch.cat([part0, part1], dim=dim)
 
         full0 = getattr(part0, "_pypto_full_shape", tuple(part0.shape))
@@ -229,8 +271,9 @@ class _CrossCoreRuntime:
 
         return merged
 
-    def push_to_aiv(self, tile, split):
+    def push_to_aiv(self, tile, split, lane_stride=0):
         split = int(split)
+        lane_stride = int(lane_stride)
         with self._cv:
             if split == 0:
                 if self._no_split_dual_aiv_dispatch:
@@ -238,8 +281,8 @@ class _CrossCoreRuntime:
                     self._to_aiv_dual_nosplit[1].append(_copy_region_attrs(tile, tile.clone()))
                 else:
                     self._to_aiv.append(_copy_region_attrs(tile, tile.clone()))
-            elif split in (1, 2):
-                lane0, lane1 = self._split_tile(tile, split)
+            elif split in _SPLIT_CODES:
+                lane0, lane1 = self._split_tile(tile, split, lane_stride)
                 self._to_aiv_split[split][0].append(lane0)
                 self._to_aiv_split[split][1].append(lane1)
             else:
@@ -261,7 +304,7 @@ class _CrossCoreRuntime:
                     return queue.popleft()
                 self._wait_for_locked(lambda: len(self._to_aiv) > 0, "tpop_from_aic", split, lane)
                 return self._to_aiv.popleft()
-            if split in (1, 2):
+            if split in _SPLIT_CODES:
                 if lane not in (0, 1):
                     raise ValueError(f"Split tpop_from_aic requires lane in {{0,1}}, got {lane}")
                 queue = self._to_aiv_split[split][lane]
@@ -271,6 +314,11 @@ class _CrossCoreRuntime:
 
     def push_to_aic(self, tile, split):
         split = int(split)
+        if _is_odd_split(split):
+            # pto-isa places lane 1's Vector -> Cube band at lane 1's own extent,
+            # so the two only abut when the lanes are equal: there is no odd V2C
+            # transport, and PTO codegen rejects these codes too.
+            raise ValueError(f"Unsupported odd split mode for push_to_aic: {split}")
         lane = _get_subblock_idx()
         with self._cv:
             if split == 0:
@@ -282,7 +330,7 @@ class _CrossCoreRuntime:
                     self._to_aic_dual_nosplit[lane].append(_copy_region_attrs(tile, tile.clone()))
                 else:
                     self._to_aic.append(_copy_region_attrs(tile, tile.clone()))
-            elif split in (1, 2):
+            elif split in _SPLIT_CODES:
                 if lane not in (0, 1):
                     raise ValueError(f"Split tpush_to_aic requires lane in {{0,1}}, got {lane}")
                 self._to_aic_split[split][lane].append(_copy_region_attrs(tile, tile.clone()))
@@ -292,6 +340,8 @@ class _CrossCoreRuntime:
 
     def pop_from_aiv(self, split):
         split = int(split)
+        if _is_odd_split(split):
+            raise ValueError(f"Unsupported odd split mode for pop_from_aiv: {split}")
         lane = _get_subblock_idx()
         with self._cv:
             if split == 0:
@@ -309,7 +359,7 @@ class _CrossCoreRuntime:
                     return lane0_tile
                 self._wait_for_locked(lambda: len(self._to_aic) > 0, "tpop_from_aiv", split, lane)
                 return self._to_aic.popleft()
-            if split in (1, 2):
+            if split in _SPLIT_CODES:
                 lane0_q = self._to_aic_split[split][0]
                 lane1_q = self._to_aic_split[split][1]
                 self._wait_for_locked(
@@ -332,7 +382,7 @@ def _run_mixed_kernels(group_name, meta, *args):
     aiv_name = meta["aiv"]
     split = int(meta.get("split", 0))
     dual_aiv_dispatch = bool(meta.get("dual_aiv_dispatch", False))
-    num_aiv_lanes = 2 if split in (1, 2) or dual_aiv_dispatch else 1
+    num_aiv_lanes = 2 if split in _SPLIT_CODES or dual_aiv_dispatch else 1
 
     _cross_core_rt.reset(no_split_dual_aiv_dispatch=(split == 0 and dual_aiv_dispatch))
     aic_fn = globals().get(aic_name)
@@ -711,8 +761,17 @@ def _split_kwarg(kw: dict[str, Any]) -> int:
     return _split_mode_to_int(kw.get("split", 0))
 
 
+def _lane_stride_kwarg(kw: dict[str, Any]) -> int:
+    """The partition stride a rebalanced ragged boundary carries (0 = box partition)."""
+    return int(kw.get("lane_stride", 0) or 0)
+
+
 def _handle_tpush_to_aiv(a: list[str], kw: dict[str, Any]) -> str:
-    return f"_cross_core_rt.push_to_aiv({a[0]}, {_split_kwarg(kw)})"
+    # The stride is emitted only when a ragged boundary was rebalanced, so every
+    # other kernel keeps the two-argument form.
+    stride = _lane_stride_kwarg(kw)
+    stride_arg = f", {stride}" if stride else ""
+    return f"_cross_core_rt.push_to_aiv({a[0]}, {_split_kwarg(kw)}{stride_arg})"
 
 
 def _handle_tpush_to_aic(a: list[str], kw: dict[str, Any]) -> str:

--- a/python/pypto/ir/op/tile_ops.py
+++ b/python/pypto/ir/op/tile_ops.py
@@ -2955,17 +2955,29 @@ def _resolve_tpop_type(
     return None
 
 
-def tpush_to_aiv(tile: Expr, *, split: int, id: int | None = None, span: Span | None = None) -> Call:
+def tpush_to_aiv(
+    tile: Expr,
+    *,
+    split: int,
+    lane_stride: int | None = None,
+    id: int | None = None,
+    span: Span | None = None,
+) -> Call:
     """Push tile data from AIC to AIV via cross-core pipe.
 
     Args:
         tile: Tile data to push
-        split: Split mode (0=none, 1=up-down, 2=left-right)
+        split: pto-isa split code (0=none, 1/2=up-down/left-right, 3/4=the same
+            axes over an odd extent)
+        lane_stride: Partition stride carried when a ragged boundary was
+            balanced across the two AIV lanes; omit for the box partition
         id: Optional frontend pipe id. Omit to use PTOAS default id 0.
         span: Optional source span
     """
     actual_span = _get_span_or_capture(span, frame_offset=1)
-    kwargs = {"split": split}
+    kwargs: dict[str, Any] = {"split": split}
+    if lane_stride is not None:
+        kwargs["lane_stride"] = lane_stride
     if id is not None:
         kwargs["id"] = id
     return _ir_core.create_op_call("tile.tpush_to_aiv", [tile], kwargs, actual_span)
@@ -2987,7 +2999,7 @@ def tpush_to_aic(tile: Expr, *, split: int, id: int | None = None, span: Span | 
     return _ir_core.create_op_call("tile.tpush_to_aic", [tile], kwargs, actual_span)
 
 
-def aiv_shard(tile: Expr, *, split: int, span: Span | None = None) -> Call:
+def aiv_shard(tile: Expr, *, split: int, lane_stride: int | None = None, span: Span | None = None) -> Call:
     """Cross the AIC -> AIV boundary, halving on the split axis (full -> half).
 
     ``split=1`` / ``2`` halve the named axis. ``split=0`` (a task-parallel
@@ -2997,10 +3009,16 @@ def aiv_shard(tile: Expr, *, split: int, span: Span | None = None) -> Call:
     Args:
         tile: Input tile (TileType; 2D unless split=0)
         split: Split mode (0=no split axis, 1=up-down/axis0, 2=left-right/axis1)
+        lane_stride: Partition stride stamped by LowerAutoVectorSplit when it
+            balances a ragged boundary across the two AIV lanes; omit for the
+            default box partition
         span: Optional source span
     """
     actual_span = _get_span_or_capture(span, frame_offset=1)
-    return _ir_core.create_op_call("tile.aiv_shard", [tile], {"split": split}, actual_span)
+    kwargs: dict[str, Any] = {"split": split}
+    if lane_stride is not None:
+        kwargs["lane_stride"] = lane_stride
+    return _ir_core.create_op_call("tile.aiv_shard", [tile], kwargs, actual_span)
 
 
 def aic_gather(tile: Expr, *, split: int, span: Span | None = None) -> Call:
@@ -3025,6 +3043,7 @@ def tpop_from_aic(
     shape: list[int] | None = None,
     dtype: DataType | None = None,
     split: int = 0,
+    lane_stride: int | None = None,
     id: int | None = None,
     span: Span | None = None,
 ) -> Call:
@@ -3034,13 +3053,18 @@ def tpop_from_aic(
         result_type: Explicit result type (e.g. TileType). Mutually exclusive with shape/dtype.
         shape: Shape of the tile to receive (alternative to result_type).
         dtype: Data type of the tile to receive (alternative to result_type).
-        split: Split mode (0=none, 1=up-down, 2=left-right)
+        split: pto-isa split code (0=none, 1/2=up-down/left-right, 3/4=the same
+            axes over an odd extent)
+        lane_stride: Partition stride carried when a ragged boundary was
+            balanced across the two AIV lanes; omit for the box partition
         id: Optional frontend pipe id. Omit to use PTOAS default id 0.
         span: Optional source span
     """
     actual_span = _get_span_or_capture(span, frame_offset=1)
     resolved_type = _resolve_tpop_type(result_type, shape, dtype, MemorySpace.Vec)
-    kwargs = {"split": split}
+    kwargs: dict[str, Any] = {"split": split}
+    if lane_stride is not None:
+        kwargs["lane_stride"] = lane_stride
     if id is not None:
         kwargs["id"] = id
     if resolved_type is not None:

--- a/python/pypto/language/op/system_ops.py
+++ b/python/pypto/language/op/system_ops.py
@@ -272,7 +272,14 @@ def cacheinvalid(
     return _ir_ops.cacheinvalid(tensor.unwrap(), shp, off, span=span)
 
 
-def tpush_to_aiv(tile: Tile, *, split: int, id: int | None = None, span: Span | None = None) -> Call:
+def tpush_to_aiv(
+    tile: Tile,
+    *,
+    split: int,
+    lane_stride: int | None = None,
+    id: int | None = None,
+    span: Span | None = None,
+) -> Call:
     """Push tile data from AIC to AIV via cross-core pipe.
 
     The Vector side receives it with [`tpop_from_aic`][pypto.language.system.tpop_from_aic] and releases the
@@ -281,12 +288,15 @@ def tpush_to_aiv(tile: Tile, *, split: int, id: int | None = None, span: Span | 
 
     Args:
         tile: Tile to send. Its Cube-side buffer stays live until the consumer frees the slot.
-        split: Split mode (0=none, 1=up-down, 2=left-right). Selects the axis along
-            which the two AIV lanes divide the tile; 0 sends it whole.
+        split: pto-isa split code (0=none, 1/2=up-down/left-right, 3/4=the same
+            axes over an odd extent). Selects the axis along which the two AIV
+            lanes divide the tile, and how their extents relate; 0 sends it whole.
+        lane_stride: Partition stride carried when a ragged boundary was balanced
+            across the two AIV lanes; omit for the default box partition.
         id: Optional frontend pipe id. Omit to use PTOAS default id 0.
         span: Optional source span
     """
-    return _ir_ops.tpush_to_aiv(tile.unwrap(), split=split, id=id, span=span)
+    return _ir_ops.tpush_to_aiv(tile.unwrap(), split=split, lane_stride=lane_stride, id=id, span=span)
 
 
 def tpush_to_aic(tile: Tile, *, split: int, id: int | None = None, span: Span | None = None) -> Call:
@@ -349,6 +359,7 @@ def tpop_from_aic(
     shape: list[int] | None = None,
     dtype: DataType | None = None,
     split: int = 0,
+    lane_stride: int | None = None,
     id: int | None = None,
     span: Span | None = None,
 ) -> Tile:
@@ -357,11 +368,16 @@ def tpop_from_aic(
     Args:
         shape: Shape of the tile to receive
         dtype: Data type of the tile to receive
-        split: Split mode (0=none, 1=up-down, 2=left-right)
+        split: pto-isa split code (0=none, 1/2=up-down/left-right, 3/4=the same
+            axes over an odd extent)
+        lane_stride: Partition stride carried when a ragged boundary was
+            balanced across the two AIV lanes; omit for the box partition
         id: Optional frontend pipe id. Omit to use PTOAS default id 0.
         span: Optional source span
     """
-    call = _ir_ops.tpop_from_aic(shape=shape, dtype=dtype, split=split, id=id, span=span)
+    call = _ir_ops.tpop_from_aic(
+        shape=shape, dtype=dtype, split=split, lane_stride=lane_stride, id=id, span=span
+    )
     return Tile(expr=call)
 
 

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -6272,9 +6272,17 @@ class ASTParser:
         # attr on the lowered op, never a SplitMode literal); any other kwarg is
         # rejected as well.
         explicit_split: ast.expr | None = None
+        explicit_lane_stride: ast.expr | None = None
         for kw in call.keywords:
             if kw.arg == "split":
                 explicit_split = cast("ast.expr", kw.value)
+                continue
+            if kw.arg == "lane_stride":
+                # Compiler bookkeeping stamped by LowerAutoVectorSplit when it
+                # balances a ragged boundary across the two AIV lanes; it only
+                # ever appears alongside an explicit ``split=`` in the printed
+                # outlined form, and is accepted here so that round-trips.
+                explicit_lane_stride = cast("ast.expr", kw.value)
                 continue
             if kw.arg == "mode":
                 raise ParserSyntaxError(
@@ -6350,9 +6358,28 @@ class ASTParser:
                     span=span,
                     hint=hint,
                 )
-            return ir.create_op_call(
-                f"{op_ns}.{op_name}", [operand_expr], {"split": int(explicit_split.value)}, span
-            )
+            kwargs: dict[str, Any] = {"split": int(explicit_split.value)}
+            if explicit_lane_stride is not None:
+                if op_name == "aic_gather":
+                    raise ParserSyntaxError(
+                        "pl.aic_gather() does not take a lane_stride= argument: only the Cube -> "
+                        "Vector shard is ever rebalanced onto a ragged boundary's valid region, so "
+                        "the gather always re-joins the lanes on the box partition",
+                        span=span,
+                        hint=hint,
+                    )
+                if not (
+                    isinstance(explicit_lane_stride, ast.Constant)
+                    and isinstance(explicit_lane_stride.value, int)
+                ):
+                    raise ParserSyntaxError(
+                        f"pl.{op_name}(..., lane_stride=N) requires an integer partition stride, got "
+                        f"'{ast.unparse(explicit_lane_stride)}'",
+                        span=span,
+                        hint=hint,
+                    )
+                kwargs["lane_stride"] = int(explicit_lane_stride.value)
+            return ir.create_op_call(f"{op_ns}.{op_name}", [operand_expr], kwargs, span)
 
         # High-level scoped form — inherit the mode from the enclosing scope.
         # This is the only path that emits the tensor form (region-only).
@@ -6361,6 +6388,14 @@ class ASTParser:
                 f"pl.{op_name}() must be used inside a 'for ... in pl.split_aiv(...)' loop "
                 "(or pass an explicit integer 'split=' in the outlined form); it otherwise "
                 "inherits the split mode from that scope",
+                span=span,
+                hint=hint,
+            )
+        if explicit_lane_stride is not None:
+            raise ParserSyntaxError(
+                f"pl.{op_name}() does not take a lane_stride= argument inside a "
+                "'for ... in pl.split_aiv(...)' loop — the partition follows the region's own "
+                "per-lane offsets",
                 span=span,
                 hint=hint,
             )

--- a/src/backend/common/pto_ops_crosscore.cpp
+++ b/src/backend/common/pto_ops_crosscore.cpp
@@ -35,6 +35,7 @@
 #include "pypto/ir/kind_traits.h"
 #include "pypto/ir/pipe.h"
 #include "pypto/ir/scalar_expr.h"
+#include "pypto/ir/stmt.h"
 #include "pypto/ir/tile_view_semantics.h"
 #include "pypto/ir/transforms/utils/memref_utils.h"
 #include "pypto/ir/type.h"
@@ -223,9 +224,14 @@ static std::string MakeTpushCodegenPTO(const char* target, const CallPtr& op,
   INTERNAL_CHECK_SPAN(tile, op->span_) << op_name << " first argument must be a Var or IterArg";
 
   const int split = op->GetKwarg<int>("split", -1);
-  CHECK(split >= 0 && split <= 2) << op_name
-                                  << " requires 'split' attribute (0=none, 1=up-down, 2=left-right), got "
-                                  << split;
+  CHECK(ir::IsValidSplitCode(split))
+      << op_name
+      << " requires 'split' attribute (0=none, 1=up-down, 2=left-right, 3=up-down/odd, "
+         "4=left-right/odd), got "
+      << split;
+  CHECK(!(ir::IsOddSplitCode(split) && std::string_view(target) == "aic"))
+      << op_name << ": pto-isa has no odd split for the Vector -> Cube direction (split = " << split
+      << "). Only the Cube -> Vector shard splits an odd axis.";
 
   std::string tile_buf = codegen.GetExprAsCode(op->args_[0]);
   std::string tile_type = codegen.GetExprTypeAnnotation(op->args_[0]);
@@ -257,9 +263,14 @@ static std::string MakeTpopCodegenPTO(const char* target, const CallPtr& op,
       << op_name << " takes no arguments, got " << op->args_.size();
 
   const int split = op->GetKwarg<int>("split", 0);
-  CHECK(split >= 0 && split <= 2) << op_name
-                                  << " requires 'split' attribute (0=none, 1=up-down, 2=left-right), got "
-                                  << split;
+  CHECK(ir::IsValidSplitCode(split))
+      << op_name
+      << " requires 'split' attribute (0=none, 1=up-down, 2=left-right, 3=up-down/odd, "
+         "4=left-right/odd), got "
+      << split;
+  CHECK(!(ir::IsOddSplitCode(split) && std::string_view(target) == "aiv"))
+      << op_name << ": pto-isa has no odd split for the Vector -> Cube direction (split = " << split
+      << "). Only the Cube -> Vector shard splits an odd axis.";
 
   std::string result_buf = codegen.GetCurrentResultTarget();
   INTERNAL_CHECK_SPAN(!result_buf.empty(), op->span_) << op_name << " requires assignment target (tile_buf)";
@@ -300,11 +311,25 @@ static std::string MakeTpopCodegenPTO(const char* target, const CallPtr& op,
   // tile CAN carry a dynamic physical extent (ReshapeSplitAxis lowers a dynamic
   // split axis to floordiv(dim, 2)). Without this the pop would reach that
   // INTERNAL_CHECK instead of falling back to the direct-TPOP path.
+  // An ODD split is the one case that must NOT take the full-box path: the two
+  // lanes pop different extents (ceil / floor), and pto-isa derives lane 1's
+  // slot offset from the popped tile's own RUNTIME valid extents
+  // (TILE_UP_DOWN_ODD: subAIVOffset = subBlockId * (validRow + subBlockId) *
+  // validCol). Widening either lane to the box would place lane 1 one cell past
+  // the producer's band. Such a tile carries a per-lane (non-static) valid
+  // extent anyway, so this only makes the requirement explicit.
   const bool use_full_box =
-      std::string_view(target) == "aic" && !logical_row.empty() && !logical_col.empty() &&
-      has_static_logical_shape && !statically_empty && result_tile_type &&
+      std::string_view(target) == "aic" && !ir::IsOddSplitCode(split) && !logical_row.empty() &&
+      !logical_col.empty() && has_static_logical_shape && !statically_empty && result_tile_type &&
       result_tile_type->GetMemorySpace() == ir::MemorySpace::Vec && result_tile_type->shape_.size() >= 2 &&
       As<ir::ConstInt>(result_tile_type->shape_[0]) && As<ir::ConstInt>(result_tile_type->shape_[1]);
+  // PTOAS enforces the same contract from the other side ("expects odd C2V
+  // split tpop to provide per-sub-core valid_row and valid_col operands"), so
+  // fail here with the op's own span rather than in the assembler.
+  INTERNAL_CHECK_SPAN(!ir::IsOddSplitCode(split) || (!logical_row.empty() && !logical_col.empty()), op->span_)
+      << "Internal error: " << op_name
+      << " with an odd split must carry per-lane valid_row / valid_col operands; the split-axis "
+         "localization in LowerAutoVectorSplit produces them";
   std::string transport_row = logical_row;
   std::string transport_col = logical_col;
   if (use_full_box) {

--- a/src/ir/op/tile_ops/cross_core.cpp
+++ b/src/ir/op/tile_ops/cross_core.cpp
@@ -11,6 +11,7 @@
 
 #include <any>
 #include <cstddef>
+#include <cstdint>
 #include <memory>
 #include <optional>
 #include <string>
@@ -25,6 +26,7 @@
 #include "pypto/ir/op_registry.h"
 #include "pypto/ir/scalar_expr.h"
 #include "pypto/ir/span.h"
+#include "pypto/ir/stmt.h"
 #include "pypto/ir/tile_view_semantics.h"
 #include "pypto/ir/transforms/printer.h"
 #include "pypto/ir/type.h"
@@ -41,8 +43,14 @@ TypePtr DeduceUnknownType(const std::vector<ExprPtr>& args,
 }
 
 // Read the required "split" int attr shared by the split-axis reshape ops
-// (reuses the tpush/tpop encoding: 0 = NONE/no split axis, 1 = UP_DOWN/axis0,
-// 2 = LEFT_RIGHT/axis1).
+// (0 = NONE/no split axis, 1 = UP_DOWN/axis0, 2 = LEFT_RIGHT/axis1).
+//
+// These two ops carry the AUTHORED MODE, not the pto-isa split code: the odd
+// codes (kSplitUpDownOdd / kSplitLeftRightOdd, see include/pypto/ir/stmt.h)
+// describe how the two lanes' RUNTIME extents relate, which is a property of
+// the transport rather than of the author's choice of axis. ExpandMixedKernel
+// derives the code from this mode plus the boundary tile's extents when it
+// mints the tpush / tpop pair (split_axis::ShardSplitCode).
 //
 // 0 is the task-parallel (``mode=pl.SplitMode.NONE``) region: both AIV lanes run
 // the full body, so there is no axis to halve — the op still marks the AIC/AIV
@@ -60,10 +68,33 @@ int ReadSplitAttr(const std::vector<std::pair<std::string, std::any>>& kwargs, c
       << op_name << " requires a 'split' attr (0 = NONE/no split axis, 1 = UP_DOWN/axis0, "
       << "2 = LEFT_RIGHT/axis1)";
   const int split = *split_opt;
-  CHECK_SPAN(split == 0 || split == 1 || split == 2, span)
+  CHECK_SPAN(split == kSplitNone || split == kSplitUpDown || split == kSplitLeftRight, span)
       << op_name << " split must be 0 (NONE/no split axis), 1 (UP_DOWN/axis0) or 2 (LEFT_RIGHT/axis1), "
       << "but got " << split;
   return split;
+}
+
+// The optional "lane_stride" attr: how far apart the two AIV lanes' data sits on
+// the split axis. Absent (the common case) means the default box partition,
+// where the stride is the tile's own physical half. LowerAutoVectorSplit stamps
+// it when it rebalances a ragged boundary across the lanes, and ExpandMixedKernel
+// reads it back to pick the transport's pto-isa split code — so it is the
+// compiler's own bookkeeping, never something an author writes.
+void CheckLaneStrideAttr(const std::vector<std::pair<std::string, std::any>>& kwargs,
+                         const ExprPtr& split_axis_extent, const std::string& op_name, const Span& span) {
+  for (const auto& [key, value] : kwargs) {
+    if (key != "lane_stride") continue;
+    const int stride = AnyCast<int>(value, "kwarg key: lane_stride");
+    CHECK_SPAN(stride > 0, span) << op_name << ": 'lane_stride' must be a positive partition stride, but got "
+                                 << stride;
+    if (auto extent = As<ConstInt>(split_axis_extent)) {
+      const int64_t box_half = (extent->value_ + 1) / 2;
+      CHECK_SPAN(stride <= box_half, span)
+          << op_name << ": 'lane_stride' " << stride << " exceeds the per-lane physical half " << box_half
+          << " of a " << extent->value_ << "-wide split axis";
+    }
+    return;
+  }
 }
 
 // Shared split-axis reshape core for both the tile ops (tile.aiv_shard /
@@ -71,18 +102,21 @@ int ReadSplitAttr(const std::vector<std::pair<std::string, std::any>>& kwargs, c
 // Halves (shard, `halve` = true) or doubles (gather, `halve` = false) the
 // split-axis extent of `shape` and `valid`.
 //
-// Static (ConstInt) extents are halved/doubled directly; for the halving
-// direction a static split-axis extent must be even. Dynamic (non-ConstInt)
-// extents are reshaped symbolically (floordiv(dim, 2) on shard, dim * 2 on
-// gather) so the result type reflects the shard/gather along the split axis
-// rather than an identity reshape.
+// The physical half is the CEIL half, which is what makes an ODD split axis
+// representable: 2k+1 gives BOTH lanes a (k+1)-cell box, and the raggedness is
+// carried by the per-lane valid extent that LowerAutoVectorSplit materializes
+// once the lane index is in scope (lane 0 fills k+1, lane 1 fills k). That is
+// pto-isa's TILE_UP_DOWN_ODD / TILE_LEFT_RIGHT_ODD contract, which
+// ExpandMixedKernel selects when it mints the transport ops
+// (split_axis::ShardSplitCode). An even extent is unaffected: ceil(2k/2) == k.
 //
-// The even-extent requirement applies to the PHYSICAL split-axis extent only;
-// the per-lane valid_shape is reshaped with ceil-div on halve (floordiv(dim + 1,
-// 2), keeping valid <= physical) since the true per-lane valid region is
-// localized later at lowering time, which knows the subblock (lane) index. This
-// avoids rejecting an input whose physical extent is even but whose partial
-// valid_shape happens to be odd.
+// Dynamic (non-ConstInt) extents are reshaped symbolically (floordiv(dim, 2) on
+// shard, dim * 2 on gather) so the result type reflects the shard/gather along
+// the split axis rather than an identity reshape.
+//
+// The per-lane valid_shape is reshaped with ceil-div on halve (floordiv(dim + 1,
+// 2), keeping valid <= physical), since the true per-lane valid region is
+// localized later at lowering time.
 struct SplitReshaped {
   std::vector<ExprPtr> shape;
   std::vector<ExprPtr> valid;
@@ -91,16 +125,12 @@ struct SplitReshaped {
 SplitReshaped ReshapeSplitAxis(std::vector<ExprPtr> shape, std::vector<ExprPtr> valid, size_t axis,
                                bool halve, const std::string& op_name, const Span& span) {
   if (auto c = As<ConstInt>(shape[axis])) {
-    if (halve) {
-      CHECK_SPAN(c->value_ % 2 == 0, span)
-          << op_name << ": split-axis static extent " << c->value_ << " must be even to shard in half";
-      shape[axis] = std::make_shared<ConstInt>(c->value_ / 2, c->dtype(), shape[axis]->span_);
-    } else {
-      shape[axis] = std::make_shared<ConstInt>(c->value_ * 2, c->dtype(), shape[axis]->span_);
-    }
+    // Ceil half: exact for an even extent, lane 1's spare cell for an odd one.
+    const int64_t reshaped = halve ? (c->value_ + 1) / 2 : c->value_ * 2;
+    shape[axis] = std::make_shared<ConstInt>(reshaped, c->dtype(), shape[axis]->span_);
   } else {
-    // Dynamic split-axis extent: symbolic half / double. Per-lane evenness is
-    // resolved at lowering time, which knows the subblock index.
+    // Dynamic split-axis extent: symbolic half / double. The per-lane extents
+    // are resolved at lowering time, which knows the subblock index.
     auto two = std::make_shared<ConstInt>(2, GetScalarDtype(shape[axis]), shape[axis]->span_);
     shape[axis] = halve ? MakeFloorDiv(shape[axis], two, shape[axis]->span_)
                         : MakeMul(shape[axis], two, shape[axis]->span_);
@@ -314,7 +344,8 @@ TypePtr DeduceSplitReshape(const std::vector<ExprPtr>& args,
   CHECK_SPAN(tile_type->shape_.size() == 2, args[0]->span_)
       << op_name << " requires a 2D tile, but got rank " << tile_type->shape_.size();
 
-  const size_t axis = (split == 1) ? 0 : 1;
+  const size_t axis = static_cast<size_t>(SplitAxisFromSplitCode(split));
+  CheckLaneStrideAttr(kwargs, tile_type->shape_[axis], op_name, args[0]->span_);
   CheckSplitBoundaryCarriesValid(op_name, tile_type->shape_, GetValidShape(tile_type), static_cast<int>(axis),
                                  halve, args[0]->span_);
   auto reshaped =
@@ -369,7 +400,7 @@ TypePtr DeduceSplitReshapeTensor(const std::vector<ExprPtr>& args,
       << ". Reshape the operand to 2D (pl.reshape) before the shard / gather so the "
          "UP_DOWN / LEFT_RIGHT split axis is unambiguous.";
 
-  const size_t axis = (split == 1) ? 0 : 1;
+  const size_t axis = static_cast<size_t>(SplitAxisFromSplitCode(split));
 
   // Valid shape: TensorView::valid_shape if set, otherwise the static shape
   // (mirrors GetValidShape for tiles).
@@ -418,6 +449,9 @@ REGISTER_OP("tile.tpush_to_aiv")
     .set_cross_core_role(core_affinity::CrossCoreRole::TPush)
     .add_argument("tile", "Tile data to transfer")
     .set_attr<int>("split")
+    // Optional partition stride (see tile.aiv_shard); consumed by the torch
+    // reference runtime, ignored by PTO codegen.
+    .set_attr<int>("lane_stride")
     .set_attr<int>("id")
     .no_memory_spec()
     .f_deduce_type(DeduceUnknownType);
@@ -442,6 +476,9 @@ REGISTER_OP("tile.tpop_from_aic")
     .set_cross_core_role(core_affinity::CrossCoreRole::TPop)
     .no_argument()
     .set_attr<int>("split")
+    // Optional partition stride (see tile.aiv_shard); consumed by the torch
+    // reference runtime, ignored by PTO codegen.
+    .set_attr<int>("lane_stride")
     .set_attr<int>("id")
     .no_memory_spec()
     .f_deduce_type(DeduceUnknownType);
@@ -498,6 +535,9 @@ REGISTER_OP("tile.aiv_shard")
         "shape (split=0)")
     .add_argument("tile", "Tile data to shard (TileType, 2D)")
     .set_attr<int>("split")
+    // Optional; stamped by LowerAutoVectorSplit when it balances a ragged
+    // boundary across the two lanes (see CheckLaneStrideAttr).
+    .set_attr<int>("lane_stride")
     .set_output_memory(MemorySpace::Vec)
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {

--- a/src/ir/transforms/expand_mixed_kernel_pass.cpp
+++ b/src/ir/transforms/expand_mixed_kernel_pass.cpp
@@ -26,6 +26,7 @@
 #include "pypto/backend/common/backend_config.h"
 #include "pypto/backend/common/backend_handler.h"
 #include "pypto/core/any_cast.h"
+#include "pypto/core/dtype.h"
 #include "pypto/core/logging.h"
 #include "pypto/ir/core_affinity_kind.h"
 #include "pypto/ir/expr.h"
@@ -366,7 +367,8 @@ void CollectCVBoundaryMoves(const std::vector<StmtPtr>& stmts,
                                                     call->args_[0],
                                                     call->GetType(),
                                                     /*op_driven=*/true,
-                                                    call->GetKwarg<int>("split", 0)};
+                                                    call->GetKwarg<int>("split", 0),
+                                                    call->GetKwarg<int>("lane_stride", 0)};
       } else if (call) {
         auto dir = ClassifyMoveDirection(call);
         if (dir != CVDirection::NONE) {
@@ -403,12 +405,44 @@ void CollectCVBoundaryMoves(const std::vector<StmtPtr>& stmts,
 // TPUSH / TPOP creation helpers
 // ============================================================================
 
-std::vector<std::pair<std::string, std::any>> MakeSplitKwargs(int split = 0) {
-  return {{"split", std::any(split)}};
+std::vector<std::pair<std::string, std::any>> MakeSplitKwargs(int split = 0, int lane_stride = 0) {
+  std::vector<std::pair<std::string, std::any>> kwargs{{"split", std::any(split)}};
+  // The partition stride only rides along when a ragged boundary was rebalanced
+  // (see split_axis::ResolveLaneStride). PTO codegen ignores it — it prints only
+  // id and split — but the torch reference runtime needs it to cut the two lanes
+  // where the compiler did.
+  if (lane_stride > 0) {
+    kwargs.emplace_back("lane_stride", std::any(lane_stride));
+  }
+  return kwargs;
 }
 
-CallPtr CreateTpush(const std::string& op_name, const ExprPtr& tile, const Span& span, int split = 0) {
-  return OpRegistry::GetInstance().Create(op_name, {tile}, MakeSplitKwargs(split), span);
+/// The pto-isa split code for an op-driven boundary's tpush / tpop pair.
+///
+/// ``CVBoundaryMove::split`` is the authored MODE (see cross_core.cpp); the code
+/// additionally encodes how the two lanes' runtime extents relate, which only
+/// the FULL-width tile can tell us: the shard's operand (Cube -> Vector) or the
+/// gather's result (Vector -> Cube). Both sides of the pipe run this on the same
+/// inputs, so the AIC and AIV bodies always agree on the code.
+int BoundaryTransportSplitCode(const CVBoundaryMove& bm, const Span& span) {
+  const SplitMode mode = SplitModeFromSplitCode(bm.split);
+  if (mode == SplitMode::None) return kSplitNone;
+  const int split_dim = split_axis::SplitDimension(mode);
+  if (bm.direction == CVDirection::CUBE_TO_VECTOR) {
+    // `lane_stride` is what LowerAutoVectorSplit actually partitioned by: absent
+    // (0) for the default box partition, the balanced stride when it rebalanced
+    // a ragged boundary across the lanes.
+    ExprPtr lane_stride =
+        bm.lane_stride > 0 ? std::make_shared<ConstInt>(bm.lane_stride, DataType::INDEX, span) : nullptr;
+    return split_axis::ShardSplitCode(mode, bm.source_tile->GetType(), split_dim, lane_stride,
+                                      "tile.aiv_shard", span);
+  }
+  return split_axis::GatherSplitCode(mode, bm.result_type, split_dim, "tile.aic_gather", span);
+}
+
+CallPtr CreateTpush(const std::string& op_name, const ExprPtr& tile, const Span& span, int split = 0,
+                    int lane_stride = 0) {
+  return OpRegistry::GetInstance().Create(op_name, {tile}, MakeSplitKwargs(split, lane_stride), span);
 }
 
 CallPtr CreateTpop(const std::string& op_name, const TypePtr& result_type, const Span& span,
@@ -762,7 +796,17 @@ std::vector<StmtPtr> BuildCoreBody(CoreSide side, const std::vector<StmtPtr>& st
         // off this transfer memory rather than the op's result memory — which
         // names the other lane whenever this side is the producer.
         const MemorySpace xfer_ms = GetBoundaryTpopMemory(side);
-        const int op_split = bm.op_driven ? bm.split : 0;
+        // The transport carries the pto-isa split CODE, not the authored mode:
+        // when the two AIV lanes' extents differ by one — an odd physical box,
+        // or an odd valid extent inside an even one — the pair takes the ODD
+        // code, whose lane 1 band sits one cell past its own extent. Derived
+        // from the FULL (cube-side) tile: the shard's operand, the gather's
+        // result.
+        const int op_split = bm.op_driven ? BoundaryTransportSplitCode(bm, stmt->span_) : kSplitNone;
+        // Only the Cube -> Vector direction is ever rebalanced, so only its
+        // transport carries the stride.
+        const int op_lane_stride =
+            (bm.op_driven && bm.direction == CVDirection::CUBE_TO_VECTOR) ? bm.lane_stride : 0;
         if (bm.direction == push_direction) {
           ExprPtr push_source = bm.source_tile;
           // AIV V->C push: insert tile.move (tmov) to adapt the source into
@@ -805,7 +849,7 @@ std::vector<StmtPtr> BuildCoreBody(CoreSide side, const std::vector<StmtPtr>& st
             push_source = tmov_var;
           }
           result.push_back(std::make_shared<EvalStmt>(
-              CreateTpush(push_op, push_source, stmt->span_, op_split), stmt->span_));
+              CreateTpush(push_op, push_source, stmt->span_, op_split, op_lane_stride), stmt->span_));
         } else {
           // Op-driven pop: the half/full shape comes from the op result type and
           // the memory from this side's transfer memory; the explicit follow-on
@@ -863,8 +907,8 @@ std::vector<StmtPtr> BuildCoreBody(CoreSide side, const std::vector<StmtPtr>& st
           tpop_var_remap[tpop_var.get()] = tpop_var;
           // tile.move boundary tpops carry no split kwarg here (assigned later by
           // SplitVectorKernel); op-driven tpops stamp the op's split now.
-          auto pop_kwargs =
-              bm.op_driven ? MakeSplitKwargs(op_split) : std::vector<std::pair<std::string, std::any>>{};
+          auto pop_kwargs = bm.op_driven ? MakeSplitKwargs(op_split, op_lane_stride)
+                                         : std::vector<std::pair<std::string, std::any>>{};
           result.push_back(std::make_shared<AssignStmt>(
               tpop_var, CreateTpop(pop_op, tpop_result_type, stmt->span_, pop_kwargs), stmt->span_));
           if (needs_post_move) {

--- a/src/ir/transforms/lower_auto_vector_split_pass.cpp
+++ b/src/ir/transforms/lower_auto_vector_split_pass.cpp
@@ -103,21 +103,17 @@ void CheckNoCubeTileHalved(const std::vector<StmtPtr>& stmts,
 void ValidateTransposeSplitHazard(const std::vector<StmtPtr>& stmts, int split_dim, const Span& region_span);
 void ValidateMixedExplicitRegion(const std::vector<StmtPtr>& stmts, const Span& region_span);
 
-// Half of a split-axis physical extent: ConstInt even -> value/2, dynamic ->
-// floordiv(dim, 2). Mirrors split_axis::ComputeHalfDimSize (anonymous in
-// split_axis_utils.cpp) for the tracked TileInfo extent.
-ExprPtr HalfDimExtent(const ExprPtr& dim_size) {
-  if (auto ci = std::dynamic_pointer_cast<const ConstInt>(dim_size)) {
-    return std::make_shared<ConstInt>(ci->value_ / 2, ci->dtype(), ci->span_);
+// Make a split-kwarg call. On tile.aiv_shard / tile.aic_gather the split int
+// attr is the authored SplitMode, NOT the pto-isa split code; ExpandMixedKernel
+// derives the code from it (see split_axis::ShardSplitCode / GatherSplitCode).
+CallPtr MakeReshapeOpCall(const std::string& op_name, const ExprPtr& source, int split_mode, const Span& span,
+                          const ExprPtr& lane_stride = nullptr) {
+  std::vector<std::pair<std::string, std::any>> kwargs{{"split", std::any(split_mode)}};
+  // Only a rebalanced body stamps the stride; the default box partition leaves
+  // the attr absent so every non-ragged kernel's IR is unchanged.
+  if (auto stride = std::dynamic_pointer_cast<const ConstInt>(lane_stride)) {
+    kwargs.emplace_back("lane_stride", std::any(static_cast<int>(stride->value_)));
   }
-  auto two = std::make_shared<ConstInt>(2, GetScalarDtype(dim_size), dim_size->span_);
-  return MakeFloorDiv(dim_size, two, dim_size->span_);
-}
-
-// Make a split-kwarg call (split int attr is the SplitMode int encoding).
-CallPtr MakeReshapeOpCall(const std::string& op_name, const ExprPtr& source, int split_int,
-                          const Span& span) {
-  std::vector<std::pair<std::string, std::any>> kwargs{{"split", std::any(split_int)}};
   return OpRegistry::GetInstance().Create(op_name, {source}, kwargs, span);
 }
 
@@ -267,11 +263,12 @@ std::unordered_set<std::string> CollectBodyVarNames(const StmtPtr& body) {
 // cube-operand integrity check is a separate post-lowering walk
 // (CheckNoCubeTileHalved) so it observes the FINAL stmts regardless of how a
 // tile was routed.
-std::vector<StmtPtr> LowerStmts(const std::vector<StmtPtr>& stmts, SplitMode mode, int split_int,
-                                int split_dim, std::unordered_map<const Var*, TileInfo>& tile_vars,
+std::vector<StmtPtr> LowerStmts(const std::vector<StmtPtr>& stmts, SplitMode mode, int split_dim,
+                                std::unordered_map<const Var*, TileInfo>& tile_vars,
                                 const ExprPtr& subblock_idx,
                                 std::unordered_map<const Var*, VarPtr>& var_replacements,
-                                std::unordered_set<std::string>& used_names) {
+                                std::unordered_set<std::string>& used_names,
+                                const ExprPtr& lane_stride = nullptr) {
   std::vector<StmtPtr> result;
   result.reserve(stmts.size());
 
@@ -354,8 +351,8 @@ std::vector<StmtPtr> LowerStmts(const std::vector<StmtPtr>& stmts, SplitMode mod
       // with the freshly minted name afterwards so the next sibling skips it.
       auto inj = InjectSubblockIdxIntoStmts(region_stmts, used_names);
       used_names = inj.used_names;
-      auto lowered = LowerStmts(inj.body_stmts, rmode, static_cast<int>(rmode), rdim, r_tile_vars,
-                                inj.subblock_idx_expr, r_var_repl, used_names);
+      auto lowered =
+          LowerStmts(inj.body_stmts, rmode, rdim, r_tile_vars, inj.subblock_idx_expr, r_var_repl, used_names);
 
       // Per-region cube-operand backstop and transpose-hazard check, using THIS
       // region's split_dim and span so diagnostics point at the region.
@@ -391,7 +388,13 @@ std::vector<StmtPtr> LowerStmts(const std::vector<StmtPtr>& stmts, SplitMode mod
           // (matmul/Acc result) stays FULL; only the result is halved and tracked.
           INTERNAL_CHECK_SPAN(!call->args_.empty(), call->span_)
               << "Internal error: C->V boundary tile.move must carry a source tile";
-          auto shard = MakeReshapeOpCall("tile.aiv_shard", call->args_[0], split_int, call->span_);
+          // The boundary op carries the authored MODE; ExpandMixedKernel derives
+          // the pto-isa split code (including the odd ones) from it and the
+          // cube tile's extents when it mints the tpush / tpop pair. When the
+          // body was rebalanced onto this boundary's valid region, the stride
+          // rides along so that derivation sees the same partition.
+          auto shard = MakeReshapeOpCall("tile.aiv_shard", call->args_[0], static_cast<int>(mode),
+                                         call->span_, lane_stride);
           // Result: the op's deduced HALF type. The split deducer leaves the memory
           // space null, and OpRegistry::Create fills it from tile.aiv_shard's
           // set_output_memory declaration — Vec, the CONSUMING (vector) lane, which
@@ -405,7 +408,7 @@ std::vector<StmtPtr> LowerStmts(const std::vector<StmtPtr>& stmts, SplitMode mod
           // LocalizeExplicitBoundaryValid. A fully-valid split axis is returned
           // unchanged, so the common case keeps the deducer's exact type.
           auto half_type = split_axis::LocalizeShardValidForLane(shard->GetType(), call->args_[0]->GetType(),
-                                                                 split_dim, subblock_idx);
+                                                                 split_dim, subblock_idx, lane_stride);
           auto new_var = std::make_shared<Var>(assign->var_->name_hint_, half_type, assign->var_->span_);
           auto shard_typed =
               std::make_shared<Call>(shard->op_, shard->args_, shard->kwargs_, half_type, shard->span_);
@@ -414,7 +417,7 @@ std::vector<StmtPtr> LowerStmts(const std::vector<StmtPtr>& stmts, SplitMode mod
             // Record split_dim too: the V->C arm now gathers along the tracked
             // dim, so a C->V shard result fed straight into a V->C boundary must
             // carry the real dim (LEFT_RIGHT => 1), not the default 0.
-            TileInfo info{HalfDimExtent(tt->shape_[split_dim]), split_dim};
+            TileInfo info{split_axis::ComputeHalfDimSize(tt->shape_[split_dim]), split_dim};
             tile_vars[assign->var_.get()] = info;
             tile_vars[new_var.get()] = info;
           }
@@ -465,9 +468,12 @@ std::vector<StmtPtr> LowerStmts(const std::vector<StmtPtr>& stmts, SplitMode mod
               << tracked_split_dim
               << ", but tile.aic_gather reassembles a 2D tile along dim 0 or dim 1 only. Cross to "
               << "the cube side before the op that moved the split axis there.";
-          // SplitMode encoding: dim 0 -> UP_DOWN(1), dim 1 -> LEFT_RIGHT(2), matching
-          // DeduceSplitReshape's `axis = (split == 1) ? 0 : 1`.
-          const int gather_split = tracked_split_dim == 0 ? 1 : 2;
+          // The gather carries the authored MODE for the axis it re-joins (dim 0
+          // -> UP_DOWN, dim 1 -> LEFT_RIGHT); its transport code (always an even
+          // one — the V->C direction has no odd form) is derived downstream by
+          // ExpandMixedKernel.
+          const int gather_split =
+              static_cast<int>(tracked_split_dim == 0 ? SplitMode::UpDown : SplitMode::LeftRight);
           auto gather = MakeReshapeOpCall("tile.aic_gather", src, gather_split, call->span_);
           // Gather result: full shape, with the memory space OpRegistry::Create
           // fills in from tile.aic_gather's set_output_memory declaration — Mat, the
@@ -525,8 +531,8 @@ std::vector<StmtPtr> LowerStmts(const std::vector<StmtPtr>& stmts, SplitMode mod
       CoreAffinity aff = ClassifyCallAffinity(leaf_call);
       if (aff == CoreAffinity::VECTOR) {
         // Route this single vector stmt through the shared halving machinery.
-        auto lowered = ProcessStmts({stmt}, mode, split_int, split_dim, tile_vars, /*is_aiv=*/true,
-                                    subblock_idx, var_replacements);
+        auto lowered = ProcessStmts({stmt}, mode, split_dim, tile_vars, /*is_aiv=*/true, subblock_idx,
+                                    var_replacements, lane_stride);
         for (auto& s : lowered) result.push_back(s);
         continue;
       }
@@ -542,8 +548,8 @@ std::vector<StmtPtr> LowerStmts(const std::vector<StmtPtr>& stmts, SplitMode mod
     // --- Compound stmts: recurse into the body for vector content. ---
     if (auto for_stmt = std::dynamic_pointer_cast<const ForStmt>(stmt)) {
       auto body = transform_utils::FlattenToStmts(for_stmt->body_);
-      auto new_body =
-          LowerStmts(body, mode, split_int, split_dim, tile_vars, subblock_idx, var_replacements, used_names);
+      auto new_body = LowerStmts(body, mode, split_dim, tile_vars, subblock_idx, var_replacements, used_names,
+                                 lane_stride);
       auto new_for = MutableCopy(for_stmt);
       new_for->body_ = loop_repair::MakeBody(new_body, for_stmt->span_);
       result.push_back(new_for);
@@ -551,13 +557,13 @@ std::vector<StmtPtr> LowerStmts(const std::vector<StmtPtr>& stmts, SplitMode mod
     }
     if (auto if_stmt = std::dynamic_pointer_cast<const IfStmt>(stmt)) {
       auto then_body = transform_utils::FlattenToStmts(if_stmt->then_body_);
-      auto new_then = LowerStmts(then_body, mode, split_int, split_dim, tile_vars, subblock_idx,
-                                 var_replacements, used_names);
+      auto new_then = LowerStmts(then_body, mode, split_dim, tile_vars, subblock_idx, var_replacements,
+                                 used_names, lane_stride);
       std::optional<StmtPtr> new_else;
       if (if_stmt->else_body_.has_value()) {
         auto else_body = transform_utils::FlattenToStmts(*if_stmt->else_body_);
-        auto new_else_stmts = LowerStmts(else_body, mode, split_int, split_dim, tile_vars, subblock_idx,
-                                         var_replacements, used_names);
+        auto new_else_stmts = LowerStmts(else_body, mode, split_dim, tile_vars, subblock_idx,
+                                         var_replacements, used_names, lane_stride);
         new_else = loop_repair::MakeBody(new_else_stmts, if_stmt->span_);
       }
       auto new_if = MutableCopy(if_stmt);
@@ -568,8 +574,8 @@ std::vector<StmtPtr> LowerStmts(const std::vector<StmtPtr>& stmts, SplitMode mod
     }
     if (auto while_stmt = std::dynamic_pointer_cast<const WhileStmt>(stmt)) {
       auto body = transform_utils::FlattenToStmts(while_stmt->body_);
-      auto new_body =
-          LowerStmts(body, mode, split_int, split_dim, tile_vars, subblock_idx, var_replacements, used_names);
+      auto new_body = LowerStmts(body, mode, split_dim, tile_vars, subblock_idx, var_replacements, used_names,
+                                 lane_stride);
       auto new_while = MutableCopy(while_stmt);
       new_while->body_ = loop_repair::MakeBody(new_body, while_stmt->span_);
       result.push_back(new_while);
@@ -890,7 +896,7 @@ std::vector<StmtPtr> LowerExplicitRegions(const std::vector<StmtPtr>& stmts,
       // sibling regions get unique subblock indices.
       std::unordered_map<const Var*, TileInfo> ignored_tile_vars;
       std::unordered_map<const Var*, VarPtr> ignored_var_repl;
-      auto lowered = LowerStmts({stmt}, SplitMode::None, /*split_int=*/0, /*split_dim=*/0, ignored_tile_vars,
+      auto lowered = LowerStmts({stmt}, SplitMode::None, /*split_dim=*/0, ignored_tile_vars,
                                 /*subblock_idx=*/nullptr, ignored_var_repl, used_names);
       for (auto& s : lowered) result.push_back(s);
       continue;
@@ -1094,7 +1100,6 @@ std::vector<std::pair<std::string, std::any>> WithSplitAivAttrs(const FunctionPt
 }
 
 FunctionPtr LowerFunction(const FunctionPtr& func, SplitMode mode) {
-  int split_int = static_cast<int>(mode);
   int split_dim = SplitDimension(mode);
 
   // Inject get_subblock_idx at the top (is_aiv=true => a binding is prepended).
@@ -1108,8 +1113,13 @@ FunctionPtr LowerFunction(const FunctionPtr& func, SplitMode mode) {
   // reserved.
   std::unordered_set<std::string> used_names = injected.used_names;
 
-  auto new_stmts = LowerStmts(injected.body_stmts, mode, split_int, split_dim, tile_vars,
-                              injected.subblock_idx_expr, var_replacements, used_names);
+  // Partition the split axis by the boundary's VALID region when the body is a
+  // single ragged crossing (see split_axis::ResolveLaneStride); null keeps the
+  // universal box partition.
+  auto lane_stride = split_axis::ResolveLaneStride(injected.body_stmts, split_dim);
+
+  auto new_stmts = LowerStmts(injected.body_stmts, mode, split_dim, tile_vars, injected.subblock_idx_expr,
+                              var_replacements, used_names, lane_stride);
 
   // Effective cube-operand backstop: re-walk the rebuilt body and assert no
   // CUBE-affine op operates on a halved tile (see CheckNoCubeTileHalved).

--- a/src/ir/transforms/split_vector_kernel_pass.cpp
+++ b/src/ir/transforms/split_vector_kernel_pass.cpp
@@ -84,12 +84,17 @@ bool IsCrossCoreSplitOp(const OpPtr& op) {
          IsOp(op, "tile.tpop_from_aic");
 }
 
+// The AUTHORED mode behind a cross-core op's split attribute. The odd codes
+// (3 / 4) normalize to their even sibling: parity is a property of one tile's
+// split-axis extent, not of the function's split mode, so two pipes of
+// different parity in one function still agree on the mode.
 std::optional<SplitMode> SplitModeFromInt(int split) {
-  if (split == 0) return std::nullopt;
-  if (split == 1) return SplitMode::UpDown;
-  if (split == 2) return SplitMode::LeftRight;
-  throw pypto::ValueError("SplitVectorKernel found invalid cross-core split attribute: " +
-                          std::to_string(split));
+  if (split == kSplitNone) return std::nullopt;
+  if (!IsValidSplitCode(split)) {
+    throw pypto::ValueError("SplitVectorKernel found invalid cross-core split attribute: " +
+                            std::to_string(split));
+  }
+  return SplitModeFromSplitCode(split);
 }
 
 // Infer the split mode from the function body's cross-core pipe ops. All
@@ -496,7 +501,6 @@ std::vector<StmtPtr> BuildNoSplitLane1ReplayStmts(const std::vector<StmtPtr>& st
 // explicit tpush/tpop boundaries (no tile.move -> aiv_shard rewrite needed).
 FunctionPtr ProcessStandaloneSplitFunction(const FunctionPtr& func, SplitMode mode) {
   if (mode == SplitMode::None) return func;
-  int split_int = static_cast<int>(mode);
   int split_dim = SplitDimension(mode);
   bool is_aiv = (func->func_type_ == FunctionType::AIV);
 
@@ -512,7 +516,7 @@ FunctionPtr ProcessStandaloneSplitFunction(const FunctionPtr& func, SplitMode mo
 
   auto injected = InjectSubblockIdx(func, is_aiv);
 
-  auto new_stmts = ProcessStmts(injected.body_stmts, mode, split_int, split_dim, tile_vars, is_aiv,
+  auto new_stmts = ProcessStmts(injected.body_stmts, mode, split_dim, tile_vars, is_aiv,
                                 injected.subblock_idx_expr, var_replacements);
   StmtPtr new_body =
       (new_stmts.size() == 1) ? new_stmts[0] : std::make_shared<SeqStmts>(new_stmts, func->span_);

--- a/src/ir/transforms/utils/split_axis_utils.cpp
+++ b/src/ir/transforms/utils/split_axis_utils.cpp
@@ -11,6 +11,7 @@
 
 #include "pypto/ir/transforms/utils/split_axis_utils.h"
 
+#include <algorithm>
 #include <any>
 #include <cstddef>
 #include <cstdint>
@@ -25,6 +26,7 @@
 #include "pypto/core/dtype.h"
 #include "pypto/core/error.h"
 #include "pypto/core/logging.h"
+#include "pypto/ir/core_affinity_kind.h"
 #include "pypto/ir/expr.h"
 #include "pypto/ir/function.h"
 #include "pypto/ir/kind_traits.h"
@@ -36,6 +38,7 @@
 #include "pypto/ir/transforms/base/visitor.h"
 #include "pypto/ir/transforms/printer.h"
 #include "pypto/ir/transforms/utils/auto_name_utils.h"
+#include "pypto/ir/transforms/utils/core_affinity.h"
 #include "pypto/ir/transforms/utils/loop_state_repair.h"
 #include "pypto/ir/transforms/utils/mutable_copy.h"
 #include "pypto/ir/transforms/utils/transform_utils.h"
@@ -93,26 +96,20 @@ bool IsUnsupportedAutoSplitGenerator(const CallPtr& call) {
   return IsOp(call, "tile.ci") || IsOp(call, "tile.random");
 }
 
-// Half-dim computation. Throws on odd ConstInt because silently floor-dividing
-// odd dims would drop data, and reliably padding the box requires
-// producer/consumer/slot-size co-ordination that lives outside this pass.
-// Users who need odd extents should pad the tile box to a multiple of the
-// producer's innerDim and narrow back with pl.tile.set_validshape; see
-// docs/en/dev/passes/22-split_vector_kernel.md.
-ExprPtr ComputeHalfDimSize(const ExprPtr& dim_size) {
-  if (auto ci = std::dynamic_pointer_cast<const ConstInt>(dim_size)) {
-    if ((ci->value_ % 2) != 0) {
-      throw pypto::ValueError(
-          "SplitVectorKernel requires an even split dimension, got " + std::to_string(ci->value_) +
-          ". Pad the tile box such that the halved dimension stays a multiple of the producer's "
-          "innerDim — i.e. pad the full box to a multiple of (2 * innerDim) (e.g. 32 for Acc "
-          "fractal=1024, or 64/elem_bytes for fractal=512) — and use pl.tile.set_validshape(...) "
-          "with the original odd extent.");
-    }
-    return std::make_shared<ConstInt>(ci->value_ / 2, ci->dtype(), ci->span_);
-  }
-  auto two = std::make_shared<ConstInt>(2, GetScalarDtype(dim_size), dim_size->span_);
-  return MakeFloorDiv(dim_size, two, dim_size->span_);
+// Whether a split-axis extent is statically ODD, i.e. the two AIV lanes hold
+// DIFFERENT extents (lane 0 = ceil, lane 1 = floor). A dynamic extent has no
+// compile-time parity and is treated as even (the pre-existing floordiv
+// behaviour); ShardSplitCode keeps such a boundary on the even split code.
+bool IsOddSplitExtent(const ExprPtr& dim_size) {
+  auto ci = std::dynamic_pointer_cast<const ConstInt>(dim_size);
+  return ci != nullptr && (ci->value_ % 2) != 0;
+}
+
+// How far apart the two lanes' data sits for a tile whose physical half is
+// @p box_half: the body's partition stride when ResolveLaneStride found one,
+// else the box half itself (the default box partition).
+ExprPtr LaneStep(const ExprPtr& lane_stride, const ExprPtr& box_half) {
+  return lane_stride ? lane_stride : box_half;
 }
 
 ExprPtr MakeConstLike(const ExprPtr& ref, int64_t value, const Span& span) {
@@ -123,18 +120,31 @@ ExprPtr MakeIndexConst(int64_t value, const Span& span) {
   return std::make_shared<ConstInt>(value, DataType::INDEX, span);
 }
 
+// Lane L's valid extent on the split axis: ``clamp(V - L * S, 0, S)``, where
+// @p lane_extent is the partition stride S (the tile's physical half under the
+// default box partition, the balanced ``ceil(V / 2)`` under a rebalanced body).
 ExprPtr LocalizeValidDimForSplit(const ExprPtr& valid_dim, const ExprPtr& original_dim,
-                                 const ExprPtr& half_dim_size, const ExprPtr& subblock_idx) {
+                                 const ExprPtr& lane_extent, const ExprPtr& subblock_idx) {
   if (!valid_dim) return valid_dim;
   if (!subblock_idx) {
-    return half_dim_size;
+    return lane_extent;
   }
+  // Shortcut: a fully-valid axis whose stride is EXACTLY half of it splits into
+  // two identical lanes, so the stride is already the per-lane extent. Anything
+  // else falls through to the clamp — an odd axis (the ceil stride over-states
+  // lane 1 by one cell, which is what pto-isa reads the runtime extents for),
+  // and a rebalanced stride (which is narrower than the full axis by design).
+  // A dynamic axis keeps the shortcut, as it had before parity mattered.
   if (AreExprsEqual(valid_dim, original_dim)) {
-    return half_dim_size;
+    auto original_const = std::dynamic_pointer_cast<const ConstInt>(original_dim);
+    auto extent_const = std::dynamic_pointer_cast<const ConstInt>(lane_extent);
+    const bool exact_half = original_const == nullptr || extent_const == nullptr ||
+                            extent_const->value_ * 2 == original_const->value_;
+    if (exact_half) return lane_extent;
   }
 
   auto span = valid_dim->span_;
-  auto subblock_offset = MakeMul(subblock_idx, half_dim_size, span);
+  auto subblock_offset = MakeMul(subblock_idx, lane_extent, span);
   // Saturating subtract, NOT `max(valid - offset, 0)`: a valid extent can carry
   // an UNSIGNED dtype (tile.set_validshape accepts UINT64), where `valid -
   // offset` wraps to a huge value for the lane the extent does not reach and the
@@ -142,7 +152,7 @@ ExprPtr LocalizeValidDimForSplit(const ExprPtr& valid_dim, const ExprPtr& origin
   // minuend first is correct for both signednesses.
   auto reached = MakeMax(valid_dim, subblock_offset, span);
   auto remaining = MakeSub(reached, subblock_offset, span);
-  return MakeMin(remaining, half_dim_size, span);
+  return MakeMin(remaining, lane_extent, span);
 }
 
 // Whether a tile.set_validshape split-axis operand must be localized to the
@@ -162,42 +172,63 @@ bool ValidOperandNeedsLocalize(const ExprPtr& valid_dim, const ExprPtr& original
   return valid_const != nullptr && half_const != nullptr && valid_const->value_ > half_const->value_;
 }
 
-CallPtr RebuildCallWithSplit(const CallPtr& call, int split_int) {
+CallPtr RebuildCallWithSplit(const CallPtr& call, int split_code) {
   std::vector<std::pair<std::string, std::any>> new_kwargs;
   bool has_split = false;
   for (const auto& [key, val] : call->kwargs_) {
     if (key == "split") {
-      new_kwargs.emplace_back("split", std::any(split_int));
+      new_kwargs.emplace_back("split", std::any(split_code));
       has_split = true;
     } else {
       new_kwargs.emplace_back(key, val);
     }
   }
   if (!has_split) {
-    new_kwargs.emplace_back("split", std::any(split_int));
+    new_kwargs.emplace_back("split", std::any(split_code));
   }
   return std::make_shared<Call>(call->op_, call->args_, std::move(new_kwargs), call->GetType(), call->span_);
 }
 
-TypePtr HalveTileShape(const TypePtr& type, int dim, const ExprPtr& subblock_idx) {
+// The halved tile's TileView.
+//
+// An explicit pre-split view is carried through with its split-axis extent
+// localized to the current lane. A tile with NO view is fully valid, which
+// needs no view of its own after an EVEN halving — both lanes fill their box.
+// An ODD halving is the exception: the ceil box over-states lane 1 by one cell,
+// so the lane's true extent has to be materialized as a view even though the
+// pre-split tile carried none. Downstream that extent is what reaches the
+// store's row count and pto-isa's per-lane TPOP valid operands.
+std::optional<TileView> HalvedTileView(const std::shared_ptr<const TileType>& tt, int dim,
+                                       const std::vector<ExprPtr>& new_shape, const ExprPtr& subblock_idx,
+                                       const ExprPtr& lane_stride) {
+  const ExprPtr step = LaneStep(lane_stride, new_shape[dim]);
+  if (const auto& tile_view = tt->tile_view_; tile_view.has_value()) {
+    TileView tv = tile_view.value();
+    if (dim < static_cast<int>(tv.valid_shape.size())) {
+      tv.valid_shape[dim] =
+          LocalizeValidDimForSplit(tv.valid_shape[dim], tt->shape_[dim], step, subblock_idx);
+    }
+    return tv;
+  }
+  // A tile with no view is fully valid; on the box partition that stays true
+  // per lane unless the axis is odd. A rebalanced body always needs the view:
+  // its stride is narrower than the box, so neither lane fills its box.
+  if (!subblock_idx || (!lane_stride && !IsOddSplitExtent(tt->shape_[dim]))) return std::nullopt;
+  TileView tv = tile_view_semantics::GetEffectiveTileView(*tt);
+  tv.valid_shape = new_shape;
+  tv.valid_shape[dim] = LocalizeValidDimForSplit(tt->shape_[dim], tt->shape_[dim], step, subblock_idx);
+  return tv;
+}
+
+TypePtr HalveTileShape(const TypePtr& type, int dim, const ExprPtr& subblock_idx,
+                       const ExprPtr& lane_stride) {
   auto tt = std::dynamic_pointer_cast<const TileType>(type);
   if (!tt || dim < 0 || dim >= static_cast<int>(tt->shape_.size())) return type;
 
   std::vector<ExprPtr> new_shape = tt->shape_;
   new_shape[dim] = ComputeHalfDimSize(tt->shape_[dim]);
 
-  // Keep TileView.valid_shape consistent with halved physical shape, and for
-  // partial valid regions localize the split dimension to the current subblock.
-  std::optional<TileView> new_tile_view = tt->tile_view_;
-  if (const auto& tile_view = tt->tile_view_; tile_view.has_value()) {
-    TileView tv = tile_view.value();
-    if (dim < static_cast<int>(tv.valid_shape.size())) {
-      tv.valid_shape[dim] =
-          LocalizeValidDimForSplit(tv.valid_shape[dim], tt->shape_[dim], new_shape[dim], subblock_idx);
-    }
-    new_tile_view = std::move(tv);
-  }
-
+  auto new_tile_view = HalvedTileView(tt, dim, new_shape, subblock_idx, lane_stride);
   return std::make_shared<TileType>(new_shape, tt->dtype_, tt->memref_, new_tile_view, tt->memory_space_);
 }
 
@@ -219,25 +250,63 @@ ExprPtr LocalizeTupleElementForSplit(const ExprPtr& tuple_expr, int dim, const E
   return std::make_shared<MakeTuple>(std::move(new_elements), tuple_expr->span_);
 }
 
-CallPtr RebuildTpopWithHalvedShape(const CallPtr& call, int split_int, int split_dim,
-                                   const ExprPtr& subblock_idx) {
-  auto new_result_type = HalveTileShape(call->GetType(), split_dim, subblock_idx);
+CallPtr RebuildTpopWithHalvedShape(const CallPtr& call, int split_code, int split_dim,
+                                   const ExprPtr& subblock_idx, const ExprPtr& lane_stride) {
+  auto new_result_type = HalveTileShape(call->GetType(), split_dim, subblock_idx, lane_stride);
 
   std::vector<std::pair<std::string, std::any>> new_kwargs;
   bool has_split = false;
   for (const auto& [key, val] : call->kwargs_) {
     if (key == "split") {
-      new_kwargs.emplace_back("split", std::any(split_int));
+      new_kwargs.emplace_back("split", std::any(split_code));
       has_split = true;
     } else {
       new_kwargs.emplace_back(key, val);
     }
   }
   if (!has_split) {
-    new_kwargs.emplace_back("split", std::any(split_int));
+    new_kwargs.emplace_back("split", std::any(split_code));
   }
 
   return std::make_shared<Call>(call->op_, call->args_, std::move(new_kwargs), new_result_type, call->span_);
+}
+
+// The two AIV lanes' split-axis extents for a boundary tile, when the box, the
+// valid extent and the partition stride are all compile-time constants.
+//
+// ``eL = clamp(V - L * S, 0, S)`` — the same clamp LocalizeValidDimForSplit
+// materializes into the popped tile's valid_shape, and therefore exactly what
+// PTOAS hands pto-isa as the tile's runtime valid extent.
+struct LaneExtents {
+  int64_t lane0 = 0;
+  int64_t lane1 = 0;
+  int64_t stride = 0;    ///< the partition stride S
+  int64_t box_half = 0;  ///< ceil(box / 2), the per-lane physical box
+  int64_t valid = 0;     ///< V, the pre-split valid extent on the split axis
+};
+
+std::optional<LaneExtents> ComputeLaneExtents(const std::shared_ptr<const TileType>& tt, int split_dim,
+                                              const ExprPtr& lane_stride) {
+  if (!tt || split_dim < 0 || split_dim >= static_cast<int>(tt->shape_.size())) return std::nullopt;
+  auto box = std::dynamic_pointer_cast<const ConstInt>(tt->shape_[split_dim]);
+  if (!box) return std::nullopt;
+  const auto valid_shape = tile_view_semantics::GetEffectiveTileView(*tt).valid_shape;
+  if (split_dim >= static_cast<int>(valid_shape.size())) return std::nullopt;
+  auto valid = std::dynamic_pointer_cast<const ConstInt>(valid_shape[split_dim]);
+  if (!valid) return std::nullopt;
+
+  LaneExtents extents;
+  extents.box_half = (box->value_ + 1) / 2;
+  extents.valid = valid->value_;
+  extents.stride = extents.box_half;
+  if (lane_stride) {
+    auto stride_const = std::dynamic_pointer_cast<const ConstInt>(lane_stride);
+    if (!stride_const) return std::nullopt;
+    extents.stride = stride_const->value_;
+  }
+  extents.lane0 = std::min(valid->value_, extents.stride);
+  extents.lane1 = std::min(std::max(valid->value_ - extents.stride, static_cast<int64_t>(0)), extents.stride);
+  return extents;
 }
 
 ExprPtr AdjustOffsets(const ExprPtr& offsets_expr, int split_dim, const ExprPtr& half_size,
@@ -275,23 +344,14 @@ ExprPtr AdjustOffsets(const ExprPtr& offsets_expr, int split_dim, const ExprPtr&
 }
 
 TypePtr ApplyTrackedTileShape(const TypePtr& type, int dim, const ExprPtr& half_dim_size,
-                              const ExprPtr& subblock_idx) {
+                              const ExprPtr& subblock_idx, const ExprPtr& lane_stride) {
   auto tt = std::dynamic_pointer_cast<const TileType>(type);
   if (!tt || dim < 0 || dim >= static_cast<int>(tt->shape_.size())) return type;
 
   std::vector<ExprPtr> new_shape = tt->shape_;
   new_shape[dim] = half_dim_size;
 
-  std::optional<TileView> new_tile_view = tt->tile_view_;
-  if (const auto& tile_view = tt->tile_view_; tile_view.has_value()) {
-    TileView tv = tile_view.value();
-    if (dim < static_cast<int>(tv.valid_shape.size())) {
-      tv.valid_shape[dim] =
-          LocalizeValidDimForSplit(tv.valid_shape[dim], tt->shape_[dim], half_dim_size, subblock_idx);
-    }
-    new_tile_view = std::move(tv);
-  }
-
+  auto new_tile_view = HalvedTileView(tt, dim, new_shape, subblock_idx, lane_stride);
   return std::make_shared<TileType>(new_shape, tt->dtype_, tt->memref_, new_tile_view, tt->memory_space_);
 }
 
@@ -345,7 +405,8 @@ StmtPtr TryMigrateReshapeSplit(const CallPtr& call, const std::shared_ptr<const 
                                const std::shared_ptr<const TileType>& in_tt, int in_split_dim,
                                const ExprPtr& subblock_idx,
                                std::unordered_map<const Var*, TileInfo>& tile_vars,
-                               std::unordered_map<const Var*, VarPtr>& var_replacements) {
+                               std::unordered_map<const Var*, VarPtr>& var_replacements,
+                               const ExprPtr& lane_stride) {
   auto res_tt = std::dynamic_pointer_cast<const TileType>(call->GetType());
   if (!res_tt || call->args_.size() < 2) return nullptr;
   INTERNAL_CHECK_SPAN(in_split_dim >= 0 && in_split_dim < static_cast<int>(in_tt->shape_.size()), call->span_)
@@ -354,13 +415,33 @@ StmtPtr TryMigrateReshapeSplit(const CallPtr& call, const std::shared_ptr<const 
 
   // Flat-offset tracking only applies when the split partition is a contiguous
   // prefix (every input dim before the split dim is 1 -- always true for the
-  // dim-0 UP_DOWN split, not for a LEFT_RIGHT col split of a multi-row tile) and
-  // all extents are static. Otherwise defer to generic halving (same-axis path).
+  // dim-0 UP_DOWN split, not for a LEFT_RIGHT col split of a multi-row tile),
+  // all extents are static, and the input split axis is EVEN -- an odd axis has
+  // no exact element count to match a result dim's first half against. Anything
+  // else defers to generic halving (same-axis path), which ceil-halves.
   const int64_t prefix_in = StaticDimProduct(in_tt->shape_, 0, in_split_dim);
   auto orig_c = std::dynamic_pointer_cast<const ConstInt>(in_tt->shape_[in_split_dim]);
   const int64_t inner_in =
       StaticDimProduct(in_tt->shape_, in_split_dim + 1, static_cast<int>(in_tt->shape_.size()));
-  if (prefix_in != 1 || !orig_c || (orig_c->value_ % 2) != 0 || inner_in < 0) return nullptr;
+
+  // An ODD input split axis has no exact element count to match a result dim's
+  // first half against, so migration cannot be expressed. Falling through is
+  // only safe when the generic (same-axis) path can still carry the split: if
+  // the result's own split dim is gone or singleton -- `[15, 1] -> [1, 15]` --
+  // that path leaves the reshape FULL width while each lane holds a half, so
+  // both lanes would read the same rows. Reject instead of miscompiling.
+  if (orig_c && (orig_c->value_ % 2) != 0) {
+    const bool same_axis_carries_split = in_split_dim < static_cast<int>(res_tt->shape_.size()) &&
+                                         !IsSingletonDim(res_tt->shape_[in_split_dim]);
+    CHECK_SPAN(same_axis_carries_split, call->span_)
+        << "SplitVectorKernel: tile.reshape moves an ODD split axis (dim " << in_split_dim << ", extent "
+        << orig_c->value_ << ") onto a result whose dim " << in_split_dim
+        << " cannot carry it, and an odd axis cannot be tracked through the reshape (its two lanes hold "
+           "different extents). Pad that axis to an even extent and narrow it back with "
+           "pl.tile.set_validshape(...), or keep the reshape out of the split scope.";
+    return nullptr;
+  }
+  if (prefix_in != 1 || !orig_c || inner_in < 0) return nullptr;
 
   // Number of elements in the first half (row-major) of the split partition.
   const int64_t split_flat = (orig_c->value_ / 2) * inner_in;
@@ -392,9 +473,18 @@ StmtPtr TryMigrateReshapeSplit(const CallPtr& call, const std::shared_ptr<const 
   // migrate when it actually moves.
   if (d_out == in_split_dim) return nullptr;
 
+  // A migrated axis carries its own half, which is derived from the RESULT dim's
+  // box — it cannot express a partition balanced on another axis's valid extent.
+  CHECK_SPAN(!lane_stride, call->span_)
+      << "SplitVectorKernel: tile.reshape moves the split axis from dim " << in_split_dim << " to dim "
+      << d_out
+      << " inside a split region whose ragged boundary was balanced across the two AIV lanes. The two "
+         "partitions cannot be reconciled: pad the boundary tile's valid extent to its physical box "
+         "with pl.tile.set_validshape(...), or move the reshape out of the split scope.";
+
   // Halve the migrated dim on both the reshape target arg and the result type.
   ExprPtr half_dim_size = ComputeHalfDimSize(res_tt->shape_[d_out]);
-  auto new_result_type = HalveTileShape(call->GetType(), d_out, subblock_idx);
+  auto new_result_type = HalveTileShape(call->GetType(), d_out, subblock_idx, /*lane_stride=*/nullptr);
   std::vector<ExprPtr> new_args = call->args_;
   new_args[1] = HalveTupleElement(call->args_[1], d_out);
 
@@ -408,9 +498,10 @@ StmtPtr TryMigrateReshapeSplit(const CallPtr& call, const std::shared_ptr<const 
   return std::make_shared<AssignStmt>(new_var, new_call, assign->span_);
 }
 
-StmtPtr ProcessStmt(const StmtPtr& stmt, SplitMode mode, int split_int, int split_dim,
+StmtPtr ProcessStmt(const StmtPtr& stmt, SplitMode mode, int split_dim,
                     std::unordered_map<const Var*, TileInfo>& tile_vars, bool is_aiv,
-                    const ExprPtr& subblock_idx, std::unordered_map<const Var*, VarPtr>& var_replacements) {
+                    const ExprPtr& subblock_idx, std::unordered_map<const Var*, VarPtr>& var_replacements,
+                    const ExprPtr& lane_stride) {
   if (auto assign = std::dynamic_pointer_cast<const AssignStmt>(stmt)) {
     auto call = std::dynamic_pointer_cast<const Call>(assign->value_);
     if (!call || !call->op_) return stmt;
@@ -418,7 +509,13 @@ StmtPtr ProcessStmt(const StmtPtr& stmt, SplitMode mode, int split_int, int spli
     const auto& op_name = call->op_->name_;
 
     if (IsOp(call, "tile.tpush_to_aiv") || IsOp(call, "tile.tpush_to_aic")) {
-      auto new_call = RebuildCallWithSplit(call, split_int);
+      INTERNAL_CHECK_SPAN(!call->args_.empty(), call->span_)
+          << "Internal error: " << op_name << " must carry the pushed tile";
+      const int push_code =
+          IsOp(call, "tile.tpush_to_aic")
+              ? GatherSplitCode(mode, call->args_[0]->GetType(), split_dim, op_name, call->span_)
+              : ShardSplitCode(mode, call->args_[0]->GetType(), split_dim, lane_stride, op_name, call->span_);
+      auto new_call = RebuildCallWithSplit(call, push_code);
       return std::make_shared<AssignStmt>(assign->var_, new_call, assign->span_);
     }
 
@@ -426,12 +523,15 @@ StmtPtr ProcessStmt(const StmtPtr& stmt, SplitMode mode, int split_int, int spli
     // tpop_from_aiv: AIC consumes from vector — keep full tile shape; only sync split attribute
     // (vector-side split affects AIV compute, not the matmul operand tile delivered to cube).
     if (IsOp(call, "tile.tpop_from_aiv")) {
-      auto new_call = RebuildCallWithSplit(call, split_int);
+      auto new_call =
+          RebuildCallWithSplit(call, GatherSplitCode(mode, call->GetType(), split_dim, op_name, call->span_));
       return std::make_shared<AssignStmt>(assign->var_, new_call, assign->span_);
     }
     if (IsOp(call, "tile.tpop_from_aic")) {
       auto tt = std::dynamic_pointer_cast<const TileType>(call->GetType());
-      auto new_call = RebuildTpopWithHalvedShape(call, split_int, split_dim, subblock_idx);
+      auto new_call = RebuildTpopWithHalvedShape(
+          call, ShardSplitCode(mode, call->GetType(), split_dim, lane_stride, op_name, call->span_),
+          split_dim, subblock_idx, lane_stride);
       auto new_var =
           std::make_shared<Var>(assign->var_->name_hint_, new_call->GetType(), assign->var_->span_);
       if (tt && split_dim < static_cast<int>(tt->shape_.size())) {
@@ -468,12 +568,13 @@ StmtPtr ProcessStmt(const StmtPtr& stmt, SplitMode mode, int split_int, int spli
       }
       ExprPtr half_dim_size = ComputeHalfDimSize(tt->shape_[split_dim]);
 
-      auto new_result_type = HalveTileShape(call->GetType(), split_dim, subblock_idx);
+      auto new_result_type = HalveTileShape(call->GetType(), split_dim, subblock_idx, lane_stride);
+      const ExprPtr load_step = LaneStep(lane_stride, half_dim_size);
       std::vector<ExprPtr> new_args = call->args_;
-      new_args[1] = AdjustOffsets(call->args_[1], split_dim, half_dim_size, subblock_idx);
+      new_args[1] = AdjustOffsets(call->args_[1], split_dim, load_step, subblock_idx);
       new_args[2] = HalveTupleElement(call->args_[2], split_dim);
-      new_args[3] = LocalizeTupleElementForSplit(call->args_[3], split_dim, tt->shape_[split_dim],
-                                                 half_dim_size, subblock_idx);
+      new_args[3] = LocalizeTupleElementForSplit(call->args_[3], split_dim, tt->shape_[split_dim], load_step,
+                                                 subblock_idx);
 
       auto new_call =
           std::make_shared<Call>(call->op_, std::move(new_args), call->kwargs_, new_result_type, call->span_);
@@ -491,8 +592,8 @@ StmtPtr ProcessStmt(const StmtPtr& stmt, SplitMode mode, int split_int, int spli
       if (tile_var) {
         auto it = tile_vars.find(tile_var.get());
         if (it != tile_vars.end()) {
-          auto new_offsets =
-              AdjustOffsets(call->args_[1], it->second.split_dim, it->second.half_dim_size, subblock_idx);
+          auto new_offsets = AdjustOffsets(call->args_[1], it->second.split_dim,
+                                           LaneStep(lane_stride, it->second.half_dim_size), subblock_idx);
           std::vector<ExprPtr> new_args = call->args_;
           new_args[1] = new_offsets;
           auto new_call = std::make_shared<Call>(call->op_, std::move(new_args), call->kwargs_,
@@ -551,7 +652,7 @@ StmtPtr ProcessStmt(const StmtPtr& stmt, SplitMode mode, int split_int, int spli
       // accepted auto shape keeps the physical split axis at the same index.
       if (tt && IsOp(call, "tile.reshape") && in_split_dim >= 0 && in_tt) {
         if (auto migrated = TryMigrateReshapeSplit(call, assign, in_tt, in_split_dim, subblock_idx, tile_vars,
-                                                   var_replacements)) {
+                                                   var_replacements, lane_stride)) {
           return migrated;
         }
         // nullptr -> split extent stays in place; fall through to generic halving.
@@ -641,7 +742,8 @@ StmtPtr ProcessStmt(const StmtPtr& stmt, SplitMode mode, int split_int, int spli
           }
         }
 
-        auto new_result_type = HalveTileShape(call->GetType(), result_split_dim, subblock_idx);
+        auto new_result_type = HalveTileShape(call->GetType(), result_split_dim, subblock_idx, lane_stride);
+        const ExprPtr lane_step = LaneStep(lane_stride, half_dim_size);
         std::vector<ExprPtr> new_args = call->args_;
         if ((IsOp(call, "tile.full") || IsOp(call, "tile.create")) && call->args_.size() >= 1) {
           new_args[0] = HalveTupleElement(call->args_[0], result_split_dim);
@@ -668,7 +770,7 @@ StmtPtr ProcessStmt(const StmtPtr& stmt, SplitMode mode, int split_int, int spli
           auto slice_src = AsVarLike(call->args_[0]);
           bool slice_src_is_split = slice_src && tile_vars.count(slice_src.get()) != 0;
           if (!slice_src_is_split) {
-            new_args[2] = AdjustOffsets(call->args_[2], result_split_dim, half_dim_size, subblock_idx);
+            new_args[2] = AdjustOffsets(call->args_[2], result_split_dim, lane_step, subblock_idx);
           }
 
           // Optional explicit valid_shape (arg[3]) must stay consistent with the
@@ -679,8 +781,8 @@ StmtPtr ProcessStmt(const StmtPtr& stmt, SplitMode mode, int split_int, int spli
           // LocalizeTupleElementForSplit is a no-op on a tuple whose split_dim
           // is out of range.
           if (call->args_.size() >= 4) {
-            new_args[3] = LocalizeTupleElementForSplit(
-                call->args_[3], result_split_dim, tt->shape_[result_split_dim], half_dim_size, subblock_idx);
+            new_args[3] = LocalizeTupleElementForSplit(call->args_[3], result_split_dim,
+                                                       tt->shape_[result_split_dim], lane_step, subblock_idx);
           }
         } else if (IsOp(call, "tile.set_validshape") && call->args_.size() == 3) {
           // args = (tile, valid_row, valid_col). Halving the result type alone
@@ -696,10 +798,9 @@ StmtPtr ProcessStmt(const StmtPtr& stmt, SplitMode mode, int split_int, int spli
           // migrated/higher result_split_dim that would index past the args.
           const int operand_idx = 1 + result_split_dim;  // dim 0 -> row, 1 -> col
           if (operand_idx < static_cast<int>(call->args_.size()) &&
-              ValidOperandNeedsLocalize(call->args_[operand_idx], tt->shape_[result_split_dim],
-                                        half_dim_size)) {
+              ValidOperandNeedsLocalize(call->args_[operand_idx], tt->shape_[result_split_dim], lane_step)) {
             new_args[operand_idx] = LocalizeValidDimForSplit(
-                call->args_[operand_idx], tt->shape_[result_split_dim], half_dim_size, subblock_idx);
+                call->args_[operand_idx], tt->shape_[result_split_dim], lane_step, subblock_idx);
           }
         }
         auto new_call = std::make_shared<Call>(call->op_, std::move(new_args), call->kwargs_, new_result_type,
@@ -721,7 +822,14 @@ StmtPtr ProcessStmt(const StmtPtr& stmt, SplitMode mode, int split_int, int spli
     if (!call || !call->op_) return stmt;
 
     if (IsOp(call, "tile.tpush_to_aiv") || IsOp(call, "tile.tpush_to_aic")) {
-      auto new_call = RebuildCallWithSplit(call, split_int);
+      INTERNAL_CHECK_SPAN(!call->args_.empty(), call->span_)
+          << "Internal error: " << call->op_->name_ << " must carry the pushed tile";
+      const int push_code =
+          IsOp(call, "tile.tpush_to_aic")
+              ? GatherSplitCode(mode, call->args_[0]->GetType(), split_dim, call->op_->name_, call->span_)
+              : ShardSplitCode(mode, call->args_[0]->GetType(), split_dim, lane_stride, call->op_->name_,
+                               call->span_);
+      auto new_call = RebuildCallWithSplit(call, push_code);
       return std::make_shared<EvalStmt>(new_call, eval->span_);
     }
 
@@ -730,8 +838,8 @@ StmtPtr ProcessStmt(const StmtPtr& stmt, SplitMode mode, int split_int, int spli
       if (tile_var) {
         auto it = tile_vars.find(tile_var.get());
         if (it != tile_vars.end()) {
-          auto new_offsets =
-              AdjustOffsets(call->args_[1], it->second.split_dim, it->second.half_dim_size, subblock_idx);
+          auto new_offsets = AdjustOffsets(call->args_[1], it->second.split_dim,
+                                           LaneStep(lane_stride, it->second.half_dim_size), subblock_idx);
           std::vector<ExprPtr> new_args = call->args_;
           new_args[1] = new_offsets;
           auto new_call = std::make_shared<Call>(call->op_, std::move(new_args), call->kwargs_,
@@ -773,7 +881,7 @@ StmtPtr ProcessStmt(const StmtPtr& stmt, SplitMode mode, int split_int, int spli
             tracked_info = it->second;
             tile_vars[ia.get()] = it->second;
             new_type = ApplyTrackedTileShape(ia->GetType(), it->second.split_dim, it->second.half_dim_size,
-                                             subblock_idx);
+                                             subblock_idx, lane_stride);
           }
         }
       }
@@ -797,7 +905,7 @@ StmtPtr ProcessStmt(const StmtPtr& stmt, SplitMode mode, int split_int, int spli
       flat.push_back(for_stmt->body_);
     }
     auto new_body_stmts =
-        ProcessStmts(flat, mode, split_int, split_dim, tile_vars, is_aiv, subblock_idx, var_replacements);
+        ProcessStmts(flat, mode, split_dim, tile_vars, is_aiv, subblock_idx, var_replacements, lane_stride);
     StmtPtr new_body = (new_body_stmts.size() == 1)
                            ? new_body_stmts[0]
                            : std::make_shared<SeqStmts>(new_body_stmts, for_stmt->span_);
@@ -815,7 +923,7 @@ StmtPtr ProcessStmt(const StmtPtr& stmt, SplitMode mode, int split_int, int spli
       if (it != tile_vars.end()) {
         tile_vars[new_return_vars[i].get()] = it->second;
         auto new_type = ApplyTrackedTileShape(new_return_vars[i]->GetType(), it->second.split_dim,
-                                              it->second.half_dim_size, subblock_idx);
+                                              it->second.half_dim_size, subblock_idx, lane_stride);
         if (new_type != new_return_vars[i]->GetType()) {
           auto new_return_var =
               std::make_shared<Var>(new_return_vars[i]->name_hint_, new_type, new_return_vars[i]->span_);
@@ -836,8 +944,8 @@ StmtPtr ProcessStmt(const StmtPtr& stmt, SplitMode mode, int split_int, int spli
     } else {
       then_flat.push_back(if_stmt->then_body_);
     }
-    auto new_then = ProcessStmts(then_flat, mode, split_int, split_dim, tile_vars, is_aiv, subblock_idx,
-                                 var_replacements);
+    auto new_then = ProcessStmts(then_flat, mode, split_dim, tile_vars, is_aiv, subblock_idx,
+                                 var_replacements, lane_stride);
     StmtPtr new_then_body =
         (new_then.size() == 1) ? new_then[0] : std::make_shared<SeqStmts>(new_then, if_stmt->span_);
 
@@ -850,8 +958,8 @@ StmtPtr ProcessStmt(const StmtPtr& stmt, SplitMode mode, int split_int, int spli
       } else {
         else_flat.push_back(else_body);
       }
-      auto new_else_stmts = ProcessStmts(else_flat, mode, split_int, split_dim, tile_vars, is_aiv,
-                                         subblock_idx, var_replacements);
+      auto new_else_stmts = ProcessStmts(else_flat, mode, split_dim, tile_vars, is_aiv, subblock_idx,
+                                         var_replacements, lane_stride);
       new_else = (new_else_stmts.size() == 1) ? new_else_stmts[0]
                                               : std::make_shared<SeqStmts>(new_else_stmts, if_stmt->span_);
     }
@@ -862,8 +970,8 @@ StmtPtr ProcessStmt(const StmtPtr& stmt, SplitMode mode, int split_int, int spli
   }
 
   if (auto seq = std::dynamic_pointer_cast<const SeqStmts>(stmt)) {
-    auto new_stmts = ProcessStmts(seq->stmts_, mode, split_int, split_dim, tile_vars, is_aiv, subblock_idx,
-                                  var_replacements);
+    auto new_stmts = ProcessStmts(seq->stmts_, mode, split_dim, tile_vars, is_aiv, subblock_idx,
+                                  var_replacements, lane_stride);
     return std::make_shared<SeqStmts>(new_stmts, seq->span_);
   }
 
@@ -881,15 +989,16 @@ std::string ReserveFreshName(std::unordered_set<std::string>& used_names, const 
 
 }  // namespace
 
-std::vector<StmtPtr> ProcessStmts(const std::vector<StmtPtr>& stmts, SplitMode mode, int split_int,
-                                  int split_dim, std::unordered_map<const Var*, TileInfo>& tile_vars,
-                                  bool is_aiv, const ExprPtr& subblock_idx,
-                                  std::unordered_map<const Var*, VarPtr>& var_replacements) {
+std::vector<StmtPtr> ProcessStmts(const std::vector<StmtPtr>& stmts, SplitMode mode, int split_dim,
+                                  std::unordered_map<const Var*, TileInfo>& tile_vars, bool is_aiv,
+                                  const ExprPtr& subblock_idx,
+                                  std::unordered_map<const Var*, VarPtr>& var_replacements,
+                                  const ExprPtr& lane_stride) {
   std::vector<StmtPtr> result;
   result.reserve(stmts.size());
   for (const auto& stmt : stmts) {
     result.push_back(
-        ProcessStmt(stmt, mode, split_int, split_dim, tile_vars, is_aiv, subblock_idx, var_replacements));
+        ProcessStmt(stmt, mode, split_dim, tile_vars, is_aiv, subblock_idx, var_replacements, lane_stride));
   }
   return result;
 }
@@ -1014,8 +1123,232 @@ struct LocalizedTile {
 
 }  // namespace
 
+namespace {
+
+// Scan for the balanced partition stride (see ResolveLaneStride in the header).
+//
+// Walks the PRE-lowering body in order, tracking which vars carry
+// boundary-derived data. It answers one question — "does every split-axis tile
+// in this body come from one ragged Cube -> Vector boundary?" — and any doubt
+// (a second boundary shape, a gather, an independently split tile, a dynamic
+// extent) makes it decline, leaving the universal box partition in place.
+class LaneStrideScanner : public IRVisitor {
+ public:
+  explicit LaneStrideScanner(int split_dim) : split_dim_(split_dim) {}
+
+  /// The boundary's ``(box, valid)`` on the split axis, or nullopt to decline.
+  [[nodiscard]] std::optional<std::pair<int64_t, int64_t>> GetBoundary() const {
+    if (blocked_ || !boundary_.has_value()) return std::nullopt;
+    return boundary_;
+  }
+
+ protected:
+  void VisitStmt_(const AssignStmtPtr& op) override {
+    Consider(As<Call>(op->value_), op->var_);
+    IRVisitor::VisitStmt_(op);
+  }
+
+  void VisitStmt_(const EvalStmtPtr& op) override {
+    Consider(As<Call>(op->expr_), nullptr);
+    IRVisitor::VisitStmt_(op);
+  }
+
+ private:
+  void Consider(const CallPtr& call, const VarPtr& result) {
+    if (blocked_ || !call || !call->op_) return;
+
+    // The Vector -> Cube direction re-joins the lanes positionally at their own
+    // extents, which only abut when the two are equal.
+    if (IsOp(call, "tile.aic_gather") || IsOp(call, "tile.tpush_to_aic") ||
+        IsOp(call, "tile.tpop_from_aiv") ||
+        core_affinity::ClassifyMoveDirection(call) == core_affinity::CVDirection::VECTOR_TO_CUBE) {
+      blocked_ = true;
+      return;
+    }
+
+    // Cube -> Vector boundary: the tile it partitions is the cube-side operand
+    // (a move / shard) or the popped result (an already-lowered tpop).
+    const bool is_move_boundary =
+        core_affinity::ClassifyMoveDirection(call) == core_affinity::CVDirection::CUBE_TO_VECTOR;
+    if (is_move_boundary || IsOp(call, "tile.aiv_shard") || IsOp(call, "tile.tpop_from_aic")) {
+      auto full_type = IsOp(call, "tile.tpop_from_aic")
+                           ? call->GetType()
+                           : (call->args_.empty() ? nullptr : call->args_[0]->GetType());
+      RecordBoundary(full_type, result);
+      return;
+    }
+
+    // Everything else that produces a tile split on this axis must derive from
+    // the boundary; a fresh one (a load, a generator) spans the full box.
+    auto tt = std::dynamic_pointer_cast<const TileType>(call->GetType());
+    if (!tt || split_dim_ >= static_cast<int>(tt->shape_.size())) return;
+    if (IsSingletonDim(tt->shape_[split_dim_])) return;
+    // Cube-affine ops keep their full width (the affinity gate never halves
+    // them), so they neither derive from nor conflict with the partition.
+    if (core_affinity::ClassifyCallAffinity(call) == core_affinity::CoreAffinity::CUBE) return;
+
+    // EVERY operand the split axis partitions must come from the boundary, not
+    // just one of them: `tile.add(shard, vec_param)` mixes a boundary-derived
+    // half with a full-width parameter, and a balanced stride would give the
+    // two operands different rows. A singleton operand is replicated across the
+    // lanes rather than partitioned, so it neither derives nor conflicts.
+    bool partitioned_operand = false;
+    for (const auto& arg : call->args_) {
+      auto arg_tt = std::dynamic_pointer_cast<const TileType>(arg->GetType());
+      if (!arg_tt || split_dim_ >= static_cast<int>(arg_tt->shape_.size())) continue;
+      if (IsSingletonDim(arg_tt->shape_[split_dim_])) continue;
+      partitioned_operand = true;
+      auto var = AsVarLike(arg);
+      if (!var || derived_.count(var.get()) == 0) {
+        blocked_ = true;
+        return;
+      }
+    }
+    // No partitioned operand at all: this op mints its own split-axis tile.
+    if (!partitioned_operand) {
+      blocked_ = true;
+      return;
+    }
+    if (result) derived_.insert(result.get());
+  }
+
+  void RecordBoundary(const TypePtr& full_type, const VarPtr& result) {
+    auto tt = std::dynamic_pointer_cast<const TileType>(full_type);
+    auto extents = ComputeLaneExtents(tt, split_dim_, /*lane_stride=*/nullptr);
+    if (!extents.has_value()) {
+      blocked_ = true;
+      return;
+    }
+    auto box = std::dynamic_pointer_cast<const ConstInt>(tt->shape_[split_dim_]);
+    const std::pair<int64_t, int64_t> shape{box->value_, extents->valid};
+    if (boundary_.has_value() && *boundary_ != shape) {
+      blocked_ = true;  // two boundaries of different shape: no single partition
+      return;
+    }
+    boundary_ = shape;
+    if (result) derived_.insert(result.get());
+  }
+
+  int split_dim_;
+  bool blocked_ = false;
+  std::optional<std::pair<int64_t, int64_t>> boundary_;
+  std::unordered_set<const Var*> derived_;
+};
+
+}  // namespace
+
+ExprPtr ResolveLaneStride(const std::vector<StmtPtr>& stmts, int split_dim) {
+  if (split_dim < 0) return nullptr;
+  LaneStrideScanner scanner(split_dim);
+  for (const auto& stmt : stmts) {
+    scanner.VisitStmt(stmt);
+  }
+  auto boundary = scanner.GetBoundary();
+  if (!boundary.has_value()) return nullptr;
+  const auto [box, valid] = *boundary;
+  const int64_t balanced = (valid + 1) / 2;
+  // Nothing to rebalance when the balanced stride IS the box half — a fully
+  // valid boundary, or one short by a single cell. Leaving the stride null
+  // there keeps the IR of every such kernel byte-identical to before. An EMPTY
+  // boundary (valid == 0) has no partition to balance either, and a zero stride
+  // is not a legal one: keep the box partition, where both lanes are empty.
+  if (balanced <= 0 || valid >= box || balanced == (box + 1) / 2) return nullptr;
+  return std::make_shared<ConstInt>(balanced, DataType::INDEX, Span::unknown());
+}
+
+// The CEIL half, so an odd extent 2k+1 gives both lanes the same (k+1)-cell BOX
+// and lets the per-lane valid extent carry the raggedness (lane 0 fills k+1,
+// lane 1 fills k). That mirrors pto-isa's TILE_UP_DOWN_ODD /
+// TILE_LEFT_RIGHT_ODD ("AIV0 = rows/2 + 1, AIV1 = rows/2"), which derives lane
+// 1's slot offset from the lanes' RUNTIME valid extents. An even extent is
+// unaffected: ceil(2k / 2) == k.
+//
+// A dynamic extent keeps floordiv(dim, 2) — its parity is unknown at compile
+// time, so no odd split code can be stamped for it either (see ShardSplitCode).
+ExprPtr ComputeHalfDimSize(const ExprPtr& dim_size) {
+  if (auto ci = std::dynamic_pointer_cast<const ConstInt>(dim_size)) {
+    return std::make_shared<ConstInt>((ci->value_ + 1) / 2, ci->dtype(), ci->span_);
+  }
+  auto two = std::make_shared<ConstInt>(2, GetScalarDtype(dim_size), dim_size->span_);
+  return MakeFloorDiv(dim_size, two, dim_size->span_);
+}
+
+std::optional<std::pair<int64_t, int64_t>> StaticLaneExtents(const TypePtr& full_type, int split_dim,
+                                                             const ExprPtr& lane_stride) {
+  auto extents =
+      ComputeLaneExtents(std::dynamic_pointer_cast<const TileType>(full_type), split_dim, lane_stride);
+  if (!extents.has_value()) return std::nullopt;
+  return std::make_pair(extents->lane0, extents->lane1);
+}
+
+int ShardSplitCode(SplitMode mode, const TypePtr& full_type, int split_dim, const ExprPtr& lane_stride,
+                   const std::string& op_name, const Span& span) {
+  if (mode == SplitMode::None) return kSplitNone;
+  auto tt = std::dynamic_pointer_cast<const TileType>(full_type);
+  auto extents = ComputeLaneExtents(tt, split_dim, lane_stride);
+  // No compile-time lane extents (a runtime box, valid extent or stride): emit
+  // the even code, which is what this path emitted before the odd codes existed
+  // and what the device is measured to accept.
+  //
+  // Reading pto-isa's pop suggests otherwise — it derives lane 1's band from the
+  // popped tile's runtime valid extent, so a runtime extent that leaves the
+  // lanes unequal (15 of a 16-wide axis gives 8 and 7) looks like it would need
+  // the odd code. The device says the even code is right: rejecting these
+  // boundaries was tried and it took down
+  // tests/st/runtime/cross_core/test_cross_core_split_parity.py, whose
+  // LEFT_RIGHT cases (lanes 8 / 7 and 8 / 1) pass an elementwise on-device
+  // comparison — re-verified by perturbing the golden on lane 1's columns
+  // alone, which does fail. Which reading is the contract is asked upstream in
+  // hw-native-sys/pto-isa#263; until that answers, the encoding follows the
+  // measured behaviour rather than the source reading.
+  if (!extents.has_value()) return SplitCodeFor(mode, /*odd_extent=*/false);
+
+  if (extents->lane0 == extents->lane1) return SplitCodeFor(mode, /*odd_extent=*/false);
+  if (extents->lane0 == extents->lane1 + 1) return SplitCodeFor(mode, /*odd_extent=*/true);
+  // Lane 1 pops nothing, so pto-isa never dereferences its band — the even code
+  // is exact whatever lane 0 holds. This is the empty-tail shard (a valid extent
+  // that does not reach the second lane at all).
+  if (extents->lane1 == 0) return SplitCodeFor(mode, /*odd_extent=*/false);
+
+  // Only the BOX partition can land here: the balanced stride is ceil(V / 2) by
+  // construction, so its lanes never differ by more than one. ResolveLaneStride
+  // declined to rebalance this body, and the reason is what the fix must target.
+  CHECK_SPAN(false, span)
+      << op_name << ": the Cube -> Vector boundary tile's valid split-axis extent (" << extents->valid
+      << " of a " << PythonPrint(tt->shape_[split_dim]) << "-wide dim " << split_dim
+      << ") leaves the two AIV lanes " << extents->lane0 << " and " << extents->lane1
+      << " cells. pto-isa places lane 1's band at its own extent (TILE_UP_DOWN / TILE_LEFT_RIGHT) or one "
+         "past it (the _ODD modes), so the lanes must be equal, differ by exactly one, or leave lane 1 "
+         "empty. The compiler balances a ragged boundary across the lanes automatically, but only when "
+         "the whole split body derives from it — this one also holds an independently split value (a "
+         "tile.load, a generator, a full-width operand) or a Vector -> Cube gather, which spans the full "
+         "box. Either move that value out of the split scope, or widen the valid extent to "
+      << (2 * extents->box_half) << " / " << (2 * extents->box_half - 1)
+      << " with pl.tile.set_validshape(...), or narrow it to at most " << extents->box_half
+      << " so the whole value stays on lane 0.";
+  return kSplitNone;  // unreachable: CHECK_SPAN(false, ...) always throws
+}
+
+int GatherSplitCode(SplitMode mode, const TypePtr& full_type, int split_dim, const std::string& op_name,
+                    const Span& span) {
+  if (mode == SplitMode::None) return kSplitNone;
+  auto tt = std::dynamic_pointer_cast<const TileType>(full_type);
+  // A gather is never rebalanced (ResolveLaneStride declines a body that holds
+  // one), so its lanes always sit on the box partition.
+  auto extents = ComputeLaneExtents(tt, split_dim, /*lane_stride=*/nullptr);
+  if (extents.has_value() && extents->lane0 != extents->lane1 && extents->lane1 != 0) {
+    CHECK_SPAN(false, span)
+        << op_name << ": the Vector -> Cube boundary tile's split axis (dim " << split_dim
+        << ") leaves the two AIV lanes " << extents->lane0 << " and " << extents->lane1
+        << " cells. Each lane hands the cube a band placed at its OWN extent, so the two only abut when "
+           "the lanes are equal — the gather has no odd form. Pad that axis to "
+        << (2 * extents->box_half) << " and narrow the cube-side result with pl.tile.set_validshape(...).";
+  }
+  return SplitCodeFor(mode, /*odd_extent=*/false);
+}
+
 TypePtr LocalizeShardValidForLane(const TypePtr& shard_type, const TypePtr& operand_type, int split_dim,
-                                  const ExprPtr& subblock_idx) {
+                                  const ExprPtr& subblock_idx, const ExprPtr& lane_stride) {
   auto shard = std::dynamic_pointer_cast<const TileType>(shard_type);
   auto operand = std::dynamic_pointer_cast<const TileType>(operand_type);
   if (!shard || !operand || !subblock_idx || split_dim < 0 ||
@@ -1024,14 +1357,18 @@ TypePtr LocalizeShardValidForLane(const TypePtr& shard_type, const TypePtr& oper
     return shard_type;
   }
   const auto operand_valid = tile_view_semantics::GetEffectiveTileView(*operand).valid_shape;
-  // A fully-valid split axis needs no repair: both lanes hold `half`, which is
-  // exactly what ReshapeSplitAxis already produced.
+  // A fully-valid EVEN split axis on the box partition needs no repair: both
+  // lanes hold `half`, which is exactly what ReshapeSplitAxis already produced.
+  // A fully-valid ODD axis still does (its lanes hold ceil and floor), and so
+  // does any rebalanced body (its stride is narrower than the box half) — only
+  // the lane index, in scope here, can tell the lanes apart.
   if (static_cast<int>(operand_valid.size()) <= split_dim ||
-      AreExprsEqual(operand_valid[split_dim], operand->shape_[split_dim])) {
+      (!lane_stride && AreExprsEqual(operand_valid[split_dim], operand->shape_[split_dim]) &&
+       !IsOddSplitExtent(operand->shape_[split_dim]))) {
     return shard_type;
   }
   auto lane_extent = LocalizeValidDimForSplit(operand_valid[split_dim], operand->shape_[split_dim],
-                                              shard->shape_[split_dim], subblock_idx);
+                                              LaneStep(lane_stride, shard->shape_[split_dim]), subblock_idx);
   return WithValidDim(shard, split_dim, lane_extent);
 }
 
@@ -1201,10 +1538,15 @@ std::vector<StmtPtr> LocalizeStmts(const std::vector<StmtPtr>& stmts, int split_
         continue;
       }
       const auto operand_valid = tile_view_semantics::GetEffectiveTileView(*operand).valid_shape;
-      // A fully-valid split axis needs no repair: both lanes hold `half`, which
-      // is exactly what ReshapeSplitAxis already produced.
+      // A fully-valid EVEN split axis needs no repair: both lanes hold `half`,
+      // which is exactly what ReshapeSplitAxis already produced. A fully-valid
+      // ODD one does: its lanes hold ceil and floor, the transport picks the odd
+      // code for exactly that reason, and pto-isa then reads the per-lane extents
+      // off the popped tile. Leaving both lanes at the ceil guess would place
+      // lane 1's band one cell too far.
       if (static_cast<int>(operand_valid.size()) <= split_dim ||
-          AreExprsEqual(operand_valid[split_dim], operand->shape_[split_dim])) {
+          (AreExprsEqual(operand_valid[split_dim], operand->shape_[split_dim]) &&
+           !IsOddSplitExtent(operand->shape_[split_dim]))) {
         result.push_back(stmt);
         continue;
       }

--- a/tests/st/codegen/dsl/test_split_odd_axis_codegen.py
+++ b/tests/st/codegen/dsl/test_split_odd_axis_codegen.py
@@ -1,0 +1,268 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""An ODD split axis across the AIC/AIV boundary: which code the transport carries.
+
+pto-isa's Cube->Vector FIFO finds lane 1's band inside the slot from the popped
+tile's own RUNTIME valid extent -- at ``e1`` cells for ``TILE_UP_DOWN``, at
+``e1 + 1`` for ``TILE_UP_DOWN_ODD`` (``popVecTileFromGMFiFo``). So a split whose
+two lanes differ by exactly one -- an odd extent -- is expressible only under the
+_ODD codes (``split = 3`` / ``4``), and the compiler, not the author, picks them:
+``pl.split`` names the axis, and ExpandMixedKernel derives the code from the
+boundary tile's extents.
+
+The two ways an odd axis reaches the boundary:
+
+* an odd VALID extent inside an even physical box (``15`` of ``16`` rows: lanes
+  hold 8 and 7) -- the shape a real kernel's ragged tail has, since an Acc box is
+  fractal-aligned and therefore even;
+* an odd physical BOX (``17`` rows: lanes hold 9 and 8), for tiles whose box is
+  not fractal-bound.
+
+A deeper tail (``13`` of ``16``) would leave the box partition's lanes 8 and 5 --
+further than one cell apart, so pto-isa could place neither. The compiler
+partitions the boundary's VALID region instead (7 and 6, ``lane_stride=7``),
+which is both placeable and evenly balanced. That rebalance needs the whole
+split body to derive from the one boundary, so a body that also splits an
+independent value keeps the universal box partition and reports the unplaceable
+extents.
+"""
+
+import re
+
+import pypto.language as pl
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from pypto.runtime import RunConfig  # noqa: E402
+
+ROWS, COLS, K = 16, 128, 128
+HALF = ROWS // 2
+ODD_VALID_M = 15  # lanes hold 8 and 7 -> TILE_UP_DOWN_ODD
+DEEP_TAIL_VALID_M = 13  # box lanes 8 and 5 -> rebalanced to 7 and 6
+ODD_BOX_ROWS = 17  # a fully-valid ODD box: lanes hold 9 and 8
+ODD_BOX_HALF = (ODD_BOX_ROWS + 1) // 2
+
+
+@pl.jit
+def odd_rows(
+    a: pl.Tensor[[ODD_VALID_M, K], pl.BF16],
+    w: pl.Tensor[[COLS, K], pl.BF16],
+    out: pl.Out[pl.Tensor[[ROWS, COLS], pl.FP32]],
+) -> pl.Tensor[[ROWS, COLS], pl.FP32]:
+    """``a @ w.T`` split by rows, with 15 of the box's 16 rows real."""
+    with pl.at(
+        level=pl.Level.CORE_GROUP,
+        optimizations=[pl.split(pl.SplitMode.UP_DOWN)],
+        name_hint="odd_rows",
+    ):
+        a_tile = pl.slice(a, [ROWS, K], [0, 0], valid_shape=[ODD_VALID_M, K])
+        acc = pl.matmul(a_tile, w[0:COLS, 0:K], b_trans=True, out_dtype=pl.FP32)
+        out[:] = pl.exp(acc)
+    return out
+
+
+@pl.jit
+def deep_tail_rows(
+    a: pl.Tensor[[DEEP_TAIL_VALID_M, K], pl.BF16],
+    w: pl.Tensor[[COLS, K], pl.BF16],
+    out: pl.Out[pl.Tensor[[ROWS, COLS], pl.FP32]],
+) -> pl.Tensor[[ROWS, COLS], pl.FP32]:
+    """13 real rows: the box partition's 8 / 5 is rebalanced to 7 / 6."""
+    with pl.at(
+        level=pl.Level.CORE_GROUP,
+        optimizations=[pl.split(pl.SplitMode.UP_DOWN)],
+        name_hint="deep_tail_rows",
+    ):
+        a_tile = pl.slice(a, [ROWS, K], [0, 0], valid_shape=[DEEP_TAIL_VALID_M, K])
+        acc = pl.matmul(a_tile, w[0:COLS, 0:K], b_trans=True, out_dtype=pl.FP32)
+        out[:] = pl.exp(acc)
+    return out
+
+
+@pl.jit
+def deep_tail_with_independent_value(
+    a: pl.Tensor[[DEEP_TAIL_VALID_M, K], pl.BF16],
+    w: pl.Tensor[[COLS, K], pl.BF16],
+    extra: pl.Tensor[[ROWS, COLS], pl.FP32],
+    out: pl.Out[pl.Tensor[[ROWS, COLS], pl.FP32]],
+    out2: pl.Out[pl.Tensor[[ROWS, COLS], pl.FP32]],
+):
+    """The same tail, plus a value split independently of the boundary.
+
+    ``extra`` spans all 16 rows, which the boundary's 13-row balanced partition
+    would not cover — so the body stays on the box partition, whose 8 / 5 lanes
+    have no placeable transport.
+    """
+    with pl.at(
+        level=pl.Level.CORE_GROUP,
+        optimizations=[pl.split(pl.SplitMode.UP_DOWN)],
+        name_hint="deep_tail_mixed",
+    ):
+        a_tile = pl.slice(a, [ROWS, K], [0, 0], valid_shape=[DEEP_TAIL_VALID_M, K])
+        acc = pl.matmul(a_tile, w[0:COLS, 0:K], b_trans=True, out_dtype=pl.FP32)
+        out[:] = pl.exp(acc)
+        out2[:] = pl.abs(extra)
+    return out, out2
+
+
+@pl.jit
+def explicit_region_odd_box(
+    a: pl.Tensor[[ODD_BOX_ROWS, K], pl.BF16],
+    w: pl.Tensor[[COLS, K], pl.BF16],
+    out: pl.Out[pl.Tensor[[ODD_BOX_ROWS, COLS], pl.FP32]],
+) -> pl.Tensor[[ODD_BOX_ROWS, COLS], pl.FP32]:
+    """An explicit ``pl.split_aiv`` region over a fully-valid ODD box (17 rows)."""
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="region_odd"):
+        acc = pl.matmul(a[0:ODD_BOX_ROWS, 0:K], w[0:COLS, 0:K], b_trans=True, out_dtype=pl.FP32)
+        for aiv_id in pl.split_aiv(2, mode=pl.SplitMode.UP_DOWN):
+            shard = pl.aiv_shard(acc)
+            out[aiv_id * ODD_BOX_HALF : aiv_id * ODD_BOX_HALF + ODD_BOX_HALF, 0:COLS] = shard
+    return out
+
+
+def _args(valid_m: int):
+    return [
+        torch.randn(valid_m, K, dtype=torch.bfloat16),
+        torch.randn(COLS, K, dtype=torch.bfloat16),
+        torch.empty(ROWS, COLS, dtype=torch.float32),
+    ]
+
+
+@pytest.fixture(scope="session")
+def odd_rows_pto(tmp_path_factory) -> str:
+    """Codegen-only .pto for the odd-extent kernel, emitted once and shared.
+
+    The dump directory comes from ``tmp_path_factory`` so that concurrent pytest
+    workers never share (and delete) one another's output.
+
+    PTO codegen writes the .pto before the downstream kernel-compilation step
+    (simpler_setup), which is absent in a codegen-only CI env, so a post-codegen
+    failure is captured rather than raised.
+    """
+    dump_dir = tmp_path_factory.mktemp("split_odd_axis")
+    cfg = RunConfig(platform="a2a3", codegen_only=True, save_kernels=True, save_kernels_dir=str(dump_dir))
+    error: Exception | None = None
+    try:
+        odd_rows(*_args(ODD_VALID_M), config=cfg)
+    except Exception as e:  # noqa: BLE001 - see docstring
+        error = e
+    ptos = sorted(dump_dir.rglob("*.pto"))
+    assert ptos, f"codegen emitted no .pto under {dump_dir}; compile raised: {error!r}"
+    return ptos[0].read_text()
+
+
+def _lowered_half(program_text: str, suffix: str) -> str:
+    """One lowered function body from the printed program."""
+    match = re.search(rf"def (\w+_{suffix})\(", program_text)
+    assert match, program_text[:400]
+    return program_text.split(f"def {match.group(1)}")[1].split("\n    def ")[0]
+
+
+def _pto_half(pto_text: str, suffix: str) -> str:
+    """One lowered kernel body. Split on the DEFINITION, not the bare symbol —
+    the cube half references the vector kernel by name too."""
+    match = re.search(rf"func\.func @(\w+_{suffix})\(", pto_text)
+    assert match, pto_text[:400]
+    return pto_text.split(f"func.func @{match.group(1)}(")[1].split("func.func")[0]
+
+
+def test_odd_valid_extent_takes_the_odd_split_code(odd_rows_pto):
+    """Both ends of the transport agree on ``TILE_UP_DOWN_ODD``.
+
+    The push, the pop and the slot release all name the same pipe, so a code
+    that differed between them would place the lanes on different bands.
+    """
+    pto = odd_rows_pto
+
+    assert re.search(r"pto\.tpush_to_aiv\(.*?\) \{split = 3\}", _pto_half(pto, "aic")), pto
+    aiv = _pto_half(pto, "aiv")
+    assert re.search(r"pto\.tpop_from_aic\(%\w+, %\w+\) \{split = 3\}", aiv), aiv
+    assert "pto.tfree_from_aic {split = 3}" in aiv, aiv
+
+
+def test_odd_pop_carries_a_per_lane_row_extent_and_the_full_column_box(odd_rows_pto):
+    """The ODD code is only half the contract: PTOAS also wants per-lane operands.
+
+    The row extent is the lane's own (``clamp(15 - lane * 8, 0, 8)`` -> 8 / 7);
+    the column extent stays the physical box, because the pop strides the GM slot
+    with it and the producer wrote the box.
+    """
+    aiv = _pto_half(odd_rows_pto, "aiv")
+
+    pop = next(line for line in aiv.splitlines() if "pto.tpop_from_aic" in line)
+    row_ssa, col = re.search(r"pto\.tpop_from_aic\((%\w+), (%\w+)\)", pop).groups()
+    assert col == f"%c{COLS}_index", pop
+    # The row operand is a min/max clamp over the lane index, not a constant.
+    assert re.search(rf"{re.escape(row_ssa)} = arith\.minsi", aiv), aiv
+    assert f"arith.subi %c{ODD_VALID_M}_index" in aiv, aiv
+    # The full-box transport + treshape path is for a STATIC narrowing; a
+    # per-lane extent must reach pto-isa as an operand instead.
+    assert "pto.treshape" not in aiv, f"a per-lane extent cannot survive a static restore:\n{aiv}"
+
+
+def test_deep_tail_is_rebalanced_onto_the_valid_region():
+    """13 valid rows split 7 / 6, not the box partition's 8 / 5.
+
+    Every consumer follows the same partition: the pop's per-lane extents, the
+    lane-localized compute, and the store offsets (``idx * 7``) — otherwise the
+    two lanes would disagree about which rows they own.
+    """
+    printed = str(deep_tail_rows.lower(config=RunConfig(platform="a2a3")))
+    aiv = _lowered_half(printed, "aiv")
+
+    # The stride rides onto the transport so every consumer of the boundary —
+    # including the torch reference runtime — cuts the lanes at the same row.
+    assert "pl.tile.tpop_from_aic(split=3, lane_stride=7)" in aiv, aiv
+    # clamp(13 - lane * 7, 0, 7) -> 7 and 6.
+    assert re.search(r"pl\.const\(13, pl\.INDEX\)[^]]*?pl\.const\(7, pl\.INDEX\)", aiv), aiv
+    assert re.search(r"pl\.tile\.store\([^)]*subblock_idx \* 7", aiv), aiv
+    assert "subblock_idx * 8" not in aiv, f"the box partition must not survive:\n{aiv}"
+
+
+def test_rebalance_is_declined_when_a_value_is_split_independently():
+    """A body that also splits its own value keeps the box partition — and reports.
+
+    ``extra`` spans the full 16-row box, which the boundary's balanced partition
+    does not cover, so rebalancing is unsound here. The box partition's 8 / 5
+    lanes then have no expressible transport, and the diagnostic must name both
+    the blocking value and the extents that would work.
+    """
+    with pytest.raises(ValueError) as exc:
+        deep_tail_with_independent_value.lower(config=RunConfig(platform="a2a3"))
+
+    message = str(exc.value)
+    assert "leaves the two AIV lanes 8 and 5 cells" in message
+    # The diagnostic must hand the author a way out, not just a refusal.
+    assert "independently split value" in message
+    assert "pl.tile.set_validshape" in message
+    assert "16 / 15" in message
+
+
+def test_explicit_region_odd_box_localizes_the_per_lane_extent():
+    """A fully-valid ODD box is per-lane in an explicit region too.
+
+    ``ReshapeSplitAxis`` gives both lanes the ceil half (9), which is right for
+    the physical box and wrong for the extents pto-isa reads off the popped tile:
+    17 rows split 9 / 8. The region path used to take the "fully valid needs no
+    repair" shortcut here, leaving both lanes at 9 while the transport picked the
+    odd code — lane 1 would then have been placed one row too far.
+    """
+    printed = str(explicit_region_odd_box.lower(config=RunConfig(platform="a2a3")))
+    aiv = _lowered_half(printed, "aiv")
+
+    assert "pl.tile.tpop_from_aic(split=3)" in aiv, aiv
+    # clamp(17 - aiv_id * 9, 0, 9) -> 9 and 8, on a 9-row box.
+    assert re.search(r"pl\.const\(17, pl\.INDEX\)[^]]*?pl\.const\(9, pl\.INDEX\)", aiv), aiv
+    assert re.search(r"pl\.tile\.store\([^)]*\* 9", aiv), aiv
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/ut/debug/test_torch_codegen.py
+++ b/tests/ut/debug/test_torch_codegen.py
@@ -839,6 +839,69 @@ def test_cross_core_split_merge_preserves_region_attrs():
     assert getattr(merged, "_pypto_full_shape", None) == (2, 4)
 
 
+def test_cross_core_rebalanced_split_slices_at_the_box_but_starts_at_the_stride():
+    """`lane_stride` moves lane 1's START; the slice WIDTH stays the physical box.
+
+    A ragged boundary rebalanced onto its valid region (16-row box, 13 valid,
+    stride 7) gives both lanes the compiler's 8-row box — lane 0 rows 0-7 and
+    lane 1 rows 7-14 — with per-lane valid extents 7 and 6. Cutting at the
+    stride instead would hand the lanes 7- and 9-row payloads that no longer
+    match the tile types the IR carries.
+    """
+    ns: dict[str, Any] = {}
+    exec(torch_codegen_module._PREAMBLE, ns)  # noqa: S102
+
+    rt = ns["_cross_core_rt"]
+    set_lane = ns["_set_subblock_idx"]
+
+    tile = torch.arange(16 * 2, dtype=torch.float32).reshape(16, 2)
+    setattr(tile, "_pypto_valid_shape", (13, 2))
+    setattr(tile, "_pypto_full_shape", (16, 2))
+
+    rt.push_to_aiv(tile, 3, 7)
+    set_lane(0)
+    lane0 = rt.pop_from_aic(3)
+    set_lane(1)
+    lane1 = rt.pop_from_aic(3)
+
+    assert tuple(lane0.shape) == (8, 2)
+    assert tuple(lane1.shape) == (8, 2)
+    # Lane 1 begins at the stride, not at the box half.
+    assert torch.equal(lane0, tile[0:8])
+    assert torch.equal(lane1, tile[7:15])
+    # clamp(13 - lane * 7, 0, 7) -> 7 and 6.
+    assert getattr(lane0, "_pypto_valid_shape", None) == (7, 2)
+    assert getattr(lane1, "_pypto_valid_shape", None) == (6, 2)
+
+
+def test_cross_core_odd_split_rejects_lanes_that_are_not_one_apart():
+    """The _ODD codes exist to say "lane 1 is one cell shorter" — enforce it."""
+    ns: dict[str, Any] = {}
+    exec(torch_codegen_module._PREAMBLE, ns)  # noqa: S102
+
+    rt = ns["_cross_core_rt"]
+    tile = torch.zeros(16, 2, dtype=torch.float32)
+    setattr(tile, "_pypto_valid_shape", (13, 2))
+
+    # Box partition (stride 8) over 13 valid rows gives 8 and 5.
+    with pytest.raises(ValueError, match="lanes one cell apart"):
+        rt.push_to_aiv(tile, 3)
+
+
+def test_cross_core_vector_to_cube_rejects_the_odd_codes():
+    """pto-isa has no odd Vector -> Cube transport, so the runtime refuses it."""
+    ns: dict[str, Any] = {}
+    exec(torch_codegen_module._PREAMBLE, ns)  # noqa: S102
+
+    rt = ns["_cross_core_rt"]
+    tile = torch.zeros(8, 2, dtype=torch.float32)
+
+    with pytest.raises(ValueError, match="Unsupported odd split mode for push_to_aic"):
+        rt.push_to_aic(tile, 3)
+    with pytest.raises(ValueError, match="Unsupported odd split mode for pop_from_aiv"):
+        rt.pop_from_aiv(4)
+
+
 def test_cross_core_no_split_dual_dispatch_runtime_pipe_pairing():
     """No-split dual-dispatch runtime should broadcast AIC->AIV and pair AIV->AIC traffic."""
     ns: dict[str, Any] = {}

--- a/tests/ut/ir/test_cross_core_ops.py
+++ b/tests/ut/ir/test_cross_core_ops.py
@@ -330,7 +330,7 @@ def test_split_reshape_rejects_non_2d_tile():
 
 
 def test_split_reshape_rejects_bad_split_attr():
-    """split must be 0, 1 or 2 — anything else is rejected."""
+    """split names the authored MODE — 0, 1 or 2; the pto-isa codes live on tpush/tpop."""
     span = ir.Span.unknown()
     tile_var = ir.Var("t", ir.TileType([16, 128], DataType.FP32), span)
 
@@ -389,13 +389,20 @@ def test_split_reshape_at_split_zero_skips_even_extent_guard():
     assert result.shape == [15, 128]
 
 
-def test_aiv_shard_rejects_odd_split_axis():
-    """aiv_shard requires the static split-axis extent to be even."""
+def test_aiv_shard_shards_an_odd_split_axis_to_the_ceil_half():
+    """An odd split axis shards to the CEIL half — both lanes get the same box.
+
+    pto-isa's TILE_UP_DOWN_ODD gives lane 0 ``rows / 2 + 1`` and lane 1
+    ``rows / 2``. A type function does not know the lane, so the deduced box is
+    the ceil half for both and the raggedness is carried by the per-lane valid
+    extent that LowerAutoVectorSplit materializes.
+    """
     span = ir.Span.unknown()
     tile_var = ir.Var("t", ir.TileType([15, 128], DataType.FP32), span)
 
-    with pytest.raises(ValueError, match="must be even"):
-        ir.create_op_call("tile.aiv_shard", [tile_var], {"split": 1}, span)
+    sharded = ir.create_op_call("tile.aiv_shard", [tile_var], {"split": 1}, span)
+    assert isinstance(sharded.type, ir.TileType)
+    assert sharded.type.shape == [8, 128]  # ceil(15 / 2)
 
 
 def test_aiv_shard_allows_even_physical_with_odd_valid_shape():
@@ -544,7 +551,7 @@ def test_tensor_split_reshape_rejects_distributed_tensor():
 
 
 def test_tensor_split_reshape_rejects_bad_split_attr():
-    """split must be 0, 1 or 2 — anything else is rejected."""
+    """split names the authored MODE — 0, 1 or 2; the pto-isa codes live on tpush/tpop."""
     span = ir.Span.unknown()
     tensor_var = ir.Var("t", ir.TensorType([16, 128], DataType.FP32), span)
 
@@ -585,13 +592,14 @@ def test_tensor_split_reshape_at_split_zero_allows_non_2d():
     assert result.shape == [2, 16, 128]
 
 
-def test_tensor_aiv_shard_rejects_odd_split_axis():
-    """tensor.aiv_shard requires the static split-axis extent to be even."""
+def test_tensor_aiv_shard_shards_an_odd_split_axis_to_the_ceil_half():
+    """Tensor mirror of the tile deducer: an odd axis shards to the ceil half."""
     span = ir.Span.unknown()
     tensor_var = ir.Var("t", ir.TensorType([15, 128], DataType.FP32), span)
 
-    with pytest.raises(ValueError, match="must be even"):
-        ir.create_op_call("tensor.aiv_shard", [tensor_var], {"split": 1}, span)
+    sharded = ir.create_op_call("tensor.aiv_shard", [tensor_var], {"split": 1}, span)
+    assert isinstance(sharded.type, ir.TensorType)
+    assert sharded.type.shape == [8, 128]  # ceil(15 / 2)
 
 
 def test_tensor_aiv_shard_allows_even_physical_with_odd_valid_shape():

--- a/tests/ut/ir/transforms/test_expand_mixed_kernel_split_aiv.py
+++ b/tests/ut/ir/transforms/test_expand_mixed_kernel_split_aiv.py
@@ -228,6 +228,148 @@ def _build_aic_gather_program():
     return ir.Program([func], "test_aic_gather", span), half2
 
 
+# ---------------------------------------------------------------------------
+# The pto-isa split CODE the folded transport carries
+# ---------------------------------------------------------------------------
+
+
+def _build_shard_program(box_rows, valid_rows, lane_stride=None):
+    """The same C->V shard over a [box_rows, 128] cube tile valid to `valid_rows`.
+
+    Only the split code is under test here, so the body stops at the shard: its
+    result is stored straight out, at the per-lane box the deducer produced.
+    `lane_stride` is the partition stride LowerAutoVectorSplit stamps when it
+    rebalances a ragged boundary; None leaves the default box partition.
+    """
+    span = ir.Span.unknown()
+    view = ir.TileView(
+        valid_shape=[
+            ir.ConstInt(valid_rows, DataType.INDEX, span),
+            ir.ConstInt(128, DataType.INDEX, span),
+        ]
+    )
+    qk = ir.Var("qk", _tile([box_rows, 128], view, MS.Vec), span)
+    half_rows = (box_rows + 1) // 2
+    out_0 = ir.Var("out_0", ir.TensorType([half_rows, 128], FP32), span)
+
+    shard_kwargs = {} if lane_stride is None else {"lane_stride": lane_stride}
+    shard = T.aiv_shard(qk, split=1, span=span, **shard_kwargs)
+    assert isinstance(shard.type, ir.TileType)
+    half = ir.Var("half", _tile(shard.type.shape, shard.type.tile_view, MS.Vec), span)
+    store = T.store(half, [0, 0], out_0, span=span)
+    out_store = ir.Var("out_store", store.type, span)
+
+    body = ir.SeqStmts(
+        [
+            ir.AssignStmt(half, shard, span),
+            ir.AssignStmt(out_store, store, span),
+            ir.ReturnStmt([out_store], span),
+        ],
+        span,
+    )
+    func = ir.Function(
+        "split_aiv",
+        [(qk, _IN), (out_0, _OUT)],
+        [out_0.type],
+        body,
+        span,
+        ir.FunctionType.InCore,
+        attrs={"split": ir.SplitMode.UP_DOWN, "split_aiv": True},
+    )
+    return ir.Program([func], "test_shard_split_code", span)
+
+
+@pytest.mark.parametrize(
+    ("box_rows", "valid_rows", "lane_stride", "expected_code", "why"),
+    [
+        (128, 128, None, 1, "both lanes hold 64 rows -> the even code"),
+        (128, 127, None, 3, "lanes hold 64 and 63 -> TILE_UP_DOWN_ODD"),
+        (127, 127, None, 3, "an odd BOX: lanes hold 64 and 63 -> TILE_UP_DOWN_ODD"),
+        (128, 40, None, 1, "lane 1 is empty, so its band is never read -> the even code"),
+        (16, 13, 7, 3, "a rebalanced ragged boundary: lanes hold 7 and 6 -> TILE_UP_DOWN_ODD"),
+        (16, 12, 6, 1, "a rebalanced EVEN valid region: lanes hold 6 and 6 -> the even code"),
+    ],
+)
+def test_folded_transport_carries_the_pto_isa_split_code(
+    box_rows, valid_rows, lane_stride, expected_code, why
+):
+    """The transport code states how the two AIV lanes' RUNTIME extents relate.
+
+    pto-isa builds lane 1's band inside the FIFO slot from the popped tile's own
+    valid extent — at ``e1`` cells for TILE_UP_DOWN / TILE_LEFT_RIGHT, one past
+    it for the _ODD modes. The boundary op only carries the authored mode, so
+    ExpandMixedKernel is where the code is chosen (split_axis::ShardSplitCode).
+    """
+    printed = ir.python_print(_expand(_build_shard_program(box_rows, valid_rows, lane_stride)))
+
+    # The stride rides onto the transport too, so the torch reference runtime
+    # cuts the lanes where the compiler did.
+    stride_attr = "" if lane_stride is None else f", lane_stride={lane_stride}"
+    assert f"pl.tile.tpush_to_aiv(qk, split={expected_code}{stride_attr})" in printed, why
+    assert f"pl.tile.tpop_from_aic(split={expected_code}{stride_attr})" in printed, why
+
+
+def test_folded_transport_carries_the_left_right_odd_code():
+    """The dim-1 mirror: an odd COLUMN axis takes TILE_LEFT_RIGHT_ODD (code 4)."""
+    span = ir.Span.unknown()
+    qk = ir.Var("qk", _tile([128, 15], None, MS.Vec), span)
+    out_0 = ir.Var("out_0", ir.TensorType([128, 8], FP32), span)
+
+    shard = T.aiv_shard(qk, split=2, span=span)
+    assert isinstance(shard.type, ir.TileType)
+    half = ir.Var("half", _tile(shard.type.shape, shard.type.tile_view, MS.Vec), span)
+    store = T.store(half, [0, 0], out_0, span=span)
+    out_store = ir.Var("out_store", store.type, span)
+    body = ir.SeqStmts(
+        [
+            ir.AssignStmt(half, shard, span),
+            ir.AssignStmt(out_store, store, span),
+            ir.ReturnStmt([out_store], span),
+        ],
+        span,
+    )
+    func = ir.Function(
+        "split_aiv",
+        [(qk, _IN), (out_0, _OUT)],
+        [out_0.type],
+        body,
+        span,
+        ir.FunctionType.InCore,
+        attrs={"split": ir.SplitMode.LEFT_RIGHT, "split_aiv": True},
+    )
+    printed = ir.python_print(_expand(ir.Program([func], "test_lr_split_code", span)))
+
+    assert "pl.tile.tpush_to_aiv(qk, split=4)" in printed, printed
+    assert "pl.tile.tpop_from_aic(split=4)" in printed, printed
+
+
+def test_folded_transport_rejects_lane_extents_pto_isa_cannot_place():
+    """Lanes more than one cell apart have no expressible band pair.
+
+    (A RUNTIME split-axis valid extent keeps the even code instead of being
+    rejected — see the comment on `ShardSplitCode` and pto-isa#263. That path is
+    covered on device by tests/st/runtime/cross_core/test_cross_core_split_parity.py,
+    not here: a hand-built program with a dynamic extent does not satisfy this
+    file's ambient roundtrip instrument.)
+
+    A 100-of-128 extent leaves lane 0 with 64 rows and lane 1 with 36: neither
+    ``e1`` (36) nor ``e1 + 1`` (37) is row 64, so every code would pop the wrong
+    rows. Report it, naming the extents that would work.
+    """
+    with pytest.raises(ValueError, match="leaves the two AIV lanes 64 and 36 cells"):
+        _expand(_build_shard_program(128, 100))
+
+
+def test_folded_transport_stays_on_the_box_partition_without_a_stride():
+    """Without the attr the same tile keeps the box partition — and is rejected.
+
+    13 of a 16-row box gives 8 and 5 on the box partition; only the rebalanced
+    form above is placeable, so the attr is what distinguishes the two.
+    """
+    with pytest.raises(ValueError, match="leaves the two AIV lanes 8 and 5 cells"):
+        _expand(_build_shard_program(16, 13))
+
+
 def test_aic_gather_folds_into_vector_to_cube_boundary():
     program, _ = _build_aic_gather_program()
     after = _expand(program)

--- a/tests/ut/ir/transforms/test_lower_auto_vector_split.py
+++ b/tests/ut/ir/transforms/test_lower_auto_vector_split.py
@@ -165,15 +165,21 @@ def test_auto_c2v_boundary_localizes_a_ragged_split_axis():
     ``ReshapeSplitAxis`` can only ceil-halve the split-axis valid extent, because
     an op's type function does not know the lane. Here ``subblock_idx`` is in
     scope, so ``LocalizeShardValidForLane`` replaces that guess with the truth —
-    lane 0 holds 100 of its 64-row half (clamped to 64), lane 1 holds 36 —
-    instead of giving BOTH lanes ``ceil(100 / 2) = 50``.
+    lane 0 holds 64 of the 127 valid rows, lane 1 the remaining 63 — instead of
+    giving BOTH lanes ``ceil(127 / 2) = 64``.
+
+    The valid extent is 127 of a 128-row box, so the two lanes differ by exactly
+    one. The boundary op still carries the authored MODE (``split=1``); the
+    pto-isa code that expresses "lane 1 is one shorter" (3 =
+    ``TILE_UP_DOWN_ODD``) is picked downstream, when ExpandMixedKernel mints the
+    tpush / tpop pair — see ``split_axis::ShardSplitCode``.
     """
 
     @pl.program
     class Before:
         @pl.function(type=pl.FunctionType.InCore, attrs={"split": pl.SplitMode.UP_DOWN})
         def split_auto(
-            qk: pl.Tile[[128, 128], pl.FP32, pl.Mem.Mat, pl.TileView(valid_shape=[100, 128])],
+            qk: pl.Tile[[128, 128], pl.FP32, pl.Mem.Mat, pl.TileView(valid_shape=[127, 128])],
             out_0: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
         ) -> pl.Tensor[[128, 128], pl.FP32]:
             popped = pl.tile.move(qk, target_memory=pl.Mem.Vec)
@@ -187,7 +193,7 @@ def test_auto_c2v_boundary_localizes_a_ragged_split_axis():
             attrs={"split": pl.SplitMode.UP_DOWN, "split_aiv": True},
         )
         def split_auto(
-            qk: pl.Tile[[128, 128], pl.FP32, pl.Mem.Mat, pl.TileView(valid_shape=[100, 128])],
+            qk: pl.Tile[[128, 128], pl.FP32, pl.Mem.Mat, pl.TileView(valid_shape=[127, 128])],
             out_0: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
         ) -> pl.Tensor[[128, 128], pl.FP32]:
             subblock_idx = pl.tile.get_subblock_idx()
@@ -196,7 +202,7 @@ def test_auto_c2v_boundary_localizes_a_ragged_split_axis():
                 pl.FP32,
                 pl.Mem.Vec,
                 pl.TileView(
-                    valid_shape=[pl.min(pl.max(100, subblock_idx * 64) - subblock_idx * 64, 64), 128]
+                    valid_shape=[pl.min(pl.max(127, subblock_idx * 64) - subblock_idx * 64, 64), 128]
                 ),
             ] = pl.tile.aiv_shard(qk, split=1)
             out_store = pl.tile.store(popped, [0 + subblock_idx * 64, 0], out_0)
@@ -292,6 +298,249 @@ def test_vector_load_halved_and_offset_localized():
             seed_vec = pl.tile.aiv_shard(cube_seed, split=1)  # noqa: F841
             prev = pl.tile.load(data, [0 + subblock_idx * 64, 0], [64, 128], target_memory=pl.Mem.Vec)
             out_store = pl.tile.store(prev, [0 + subblock_idx * 64, 0], out_0)
+            return out_store
+
+    ir.assert_structural_equal(_lower(Before), Expected)
+
+
+def test_ragged_boundary_is_rebalanced_across_the_two_lanes():
+    """A ragged C->V boundary partitions its VALID region, not the box.
+
+    The box partition gives lane 0 all 8 rows of its half and lane 1 the
+    remaining 5 — extents pto-isa cannot place, since it puts lane 1's FIFO band
+    at its own extent (or one past it). Balancing the 13 valid rows instead
+    gives 7 and 6: placeable under ``TILE_UP_DOWN_ODD``, and the work is split
+    evenly. The physical box stays the box half (8); only the partition stride
+    changes, and it rides to ExpandMixedKernel on the ``lane_stride`` attr.
+    """
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore, attrs={"split": pl.SplitMode.UP_DOWN})
+        def split_auto(
+            qk: pl.Tile[[16, 128], pl.FP32, pl.Mem.Mat, pl.TileView(valid_shape=[13, 128])],
+            out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
+        ) -> pl.Tensor[[16, 128], pl.FP32]:
+            popped = pl.tile.move(qk, target_memory=pl.Mem.Vec)
+            out_store = pl.tile.store(popped, [0, 0], out_0)
+            return out_store
+
+    @pl.program
+    class Expected:
+        @pl.function(
+            type=pl.FunctionType.InCore,
+            attrs={"split": pl.SplitMode.UP_DOWN, "split_aiv": True},
+        )
+        def split_auto(
+            qk: pl.Tile[[16, 128], pl.FP32, pl.Mem.Mat, pl.TileView(valid_shape=[13, 128])],
+            out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
+        ) -> pl.Tensor[[16, 128], pl.FP32]:
+            subblock_idx = pl.tile.get_subblock_idx()
+            popped: pl.Tile[
+                [8, 128],
+                pl.FP32,
+                pl.Mem.Vec,
+                pl.TileView(valid_shape=[pl.min(pl.max(13, subblock_idx * 7) - subblock_idx * 7, 7), 128]),
+            ] = pl.tile.aiv_shard(qk, split=1, lane_stride=7)
+            out_store = pl.tile.store(popped, [0 + subblock_idx * 7, 0], out_0)
+            return out_store
+
+    ir.assert_structural_equal(_lower(Before), Expected)
+
+
+def test_empty_boundary_keeps_the_box_partition():
+    """A boundary with nothing valid has no partition to balance.
+
+    ``ceil(0 / 2)`` is 0, and a zero stride is not a legal partition — the
+    boundary op's own attr check rejects it. An empty crossing therefore keeps
+    the box partition, where both lanes are empty and the even code is exact.
+    """
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore, attrs={"split": pl.SplitMode.UP_DOWN})
+        def split_auto(
+            qk: pl.Tile[[16, 128], pl.FP32, pl.Mem.Mat, pl.TileView(valid_shape=[0, 128])],
+            out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
+        ) -> pl.Tensor[[16, 128], pl.FP32]:
+            popped = pl.tile.move(qk, target_memory=pl.Mem.Vec)
+            out_store = pl.tile.store(popped, [0, 0], out_0)
+            return out_store
+
+    @pl.program
+    class Expected:
+        @pl.function(
+            type=pl.FunctionType.InCore,
+            attrs={"split": pl.SplitMode.UP_DOWN, "split_aiv": True},
+        )
+        def split_auto(
+            qk: pl.Tile[[16, 128], pl.FP32, pl.Mem.Mat, pl.TileView(valid_shape=[0, 128])],
+            out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
+        ) -> pl.Tensor[[16, 128], pl.FP32]:
+            subblock_idx = pl.tile.get_subblock_idx()
+            popped: pl.Tile[
+                [8, 128],
+                pl.FP32,
+                pl.Mem.Vec,
+                pl.TileView(valid_shape=[pl.min(pl.max(0, subblock_idx * 8) - subblock_idx * 8, 8), 128]),
+            ] = pl.tile.aiv_shard(qk, split=1)
+            out_store = pl.tile.store(popped, [0 + subblock_idx * 8, 0], out_0)
+            return out_store
+
+    ir.assert_structural_equal(_lower(Before), Expected)
+
+
+def test_rebalance_is_declined_when_a_value_is_split_independently():
+    """A body that also splits its own value keeps the universal box partition.
+
+    The balanced partition covers only the boundary's 13 valid rows, so a
+    ``tile.load`` spanning all 16 would lose row 15 and double-cover row 7. Both
+    tiles therefore stay on the box partition (offsets ``idx * 8``), and it is
+    ExpandMixedKernel that reports the unplaceable lane extents.
+    """
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore, attrs={"split": pl.SplitMode.UP_DOWN})
+        def split_auto(
+            qk: pl.Tile[[16, 128], pl.FP32, pl.Mem.Mat, pl.TileView(valid_shape=[13, 128])],
+            data: pl.Tensor[[16, 128], pl.FP32],
+            out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
+        ) -> pl.Tensor[[16, 128], pl.FP32]:
+            popped = pl.tile.move(qk, target_memory=pl.Mem.Vec)  # noqa: F841
+            prev = pl.tile.load(data, [0, 0], [16, 128], target_memory=pl.Mem.Vec)
+            out_store = pl.tile.store(prev, [0, 0], out_0)
+            return out_store
+
+    @pl.program
+    class Expected:
+        @pl.function(
+            type=pl.FunctionType.InCore,
+            attrs={"split": pl.SplitMode.UP_DOWN, "split_aiv": True},
+        )
+        def split_auto(
+            qk: pl.Tile[[16, 128], pl.FP32, pl.Mem.Mat, pl.TileView(valid_shape=[13, 128])],
+            data: pl.Tensor[[16, 128], pl.FP32],
+            out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
+        ) -> pl.Tensor[[16, 128], pl.FP32]:
+            subblock_idx = pl.tile.get_subblock_idx()
+            popped: pl.Tile[  # noqa: F841
+                [8, 128],
+                pl.FP32,
+                pl.Mem.Vec,
+                pl.TileView(valid_shape=[pl.min(pl.max(13, subblock_idx * 8) - subblock_idx * 8, 8), 128]),
+            ] = pl.tile.aiv_shard(qk, split=1)
+            prev = pl.tile.load(data, [0 + subblock_idx * 8, 0], [8, 128], target_memory=pl.Mem.Vec)
+            out_store = pl.tile.store(prev, [0 + subblock_idx * 8, 0], out_0)
+            return out_store
+
+    ir.assert_structural_equal(_lower(Before), Expected)
+
+
+def test_vector_load_on_an_odd_split_axis_takes_the_ceil_half():
+    """An ODD split axis halves to the CEIL box, with the lane's own valid extent.
+
+    A `[15, 32]` tile cannot be cut into two equal boxes, so both lanes get the
+    ceil half (`8`) and the per-lane valid extent carries the difference: lane 0
+    fills all 8 rows, lane 1 only 7. The store offsets follow the box
+    (`idx * 8`), so the two lanes' rows stay contiguous in the output.
+
+    This tile never crosses the AIC/AIV boundary, so no pto-isa split code is
+    involved — the ceil halving alone makes an odd extent representable.
+    """
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore, attrs={"split": pl.SplitMode.UP_DOWN})
+        def split_auto(
+            cube_seed: pl.Tile[[128, 128], pl.FP32, pl.Mem.Mat],
+            data: pl.Tensor[[15, 32], pl.FP32],
+            out_0: pl.Out[pl.Tensor[[15, 32], pl.FP32]],
+        ) -> pl.Tensor[[15, 32], pl.FP32]:
+            seed_vec = pl.tile.move(cube_seed, target_memory=pl.Mem.Vec)  # noqa: F841
+            prev = pl.tile.load(data, [0, 0], [15, 32], target_memory=pl.Mem.Vec)
+            out_store = pl.tile.store(prev, [0, 0], out_0)
+            return out_store
+
+    @pl.program
+    class Expected:
+        @pl.function(
+            type=pl.FunctionType.InCore,
+            attrs={"split": pl.SplitMode.UP_DOWN, "split_aiv": True},
+        )
+        def split_auto(
+            cube_seed: pl.Tile[[128, 128], pl.FP32, pl.Mem.Mat],
+            data: pl.Tensor[[15, 32], pl.FP32],
+            out_0: pl.Out[pl.Tensor[[15, 32], pl.FP32]],
+        ) -> pl.Tensor[[15, 32], pl.FP32]:
+            subblock_idx = pl.tile.get_subblock_idx()
+            seed_vec = pl.tile.aiv_shard(cube_seed, split=1)  # noqa: F841
+            prev: pl.Tile[
+                [8, 32],
+                pl.FP32,
+                pl.Mem.Vec,
+                pl.TileView(valid_shape=[pl.min(pl.max(15, subblock_idx * 8) - subblock_idx * 8, 8), 32]),
+            ] = pl.tile.load(
+                data,
+                [0 + subblock_idx * 8, 0],
+                [8, 32],
+                [pl.min(pl.max(15, subblock_idx * 8) - subblock_idx * 8, 8), 32],
+                target_memory=pl.Mem.Vec,
+            )
+            out_store = pl.tile.store(prev, [0 + subblock_idx * 8, 0], out_0)
+            return out_store
+
+    ir.assert_structural_equal(_lower(Before), Expected)
+
+
+def test_vector_load_on_an_odd_split_axis_left_right():
+    """The dim-1 mirror: an odd COLUMN axis also halves to the ceil box.
+
+    A `[32, 15]` tile gives both lanes an 8-column box; lane 0 fills all 8 and
+    lane 1 only 7, and the column offsets follow the box (`idx * 8`). Pinning
+    the LEFT_RIGHT side separately keeps a dim-1 regression from hiding behind
+    the UP_DOWN cases.
+    """
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore, attrs={"split": pl.SplitMode.LEFT_RIGHT})
+        def split_auto(
+            cube_seed: pl.Tile[[128, 128], pl.FP32, pl.Mem.Mat],
+            data: pl.Tensor[[32, 15], pl.FP32],
+            out_0: pl.Out[pl.Tensor[[32, 15], pl.FP32]],
+        ) -> pl.Tensor[[32, 15], pl.FP32]:
+            seed_vec = pl.tile.move(cube_seed, target_memory=pl.Mem.Vec)  # noqa: F841
+            prev = pl.tile.load(data, [0, 0], [32, 15], target_memory=pl.Mem.Vec)
+            out_store = pl.tile.store(prev, [0, 0], out_0)
+            return out_store
+
+    @pl.program
+    class Expected:
+        @pl.function(
+            type=pl.FunctionType.InCore,
+            attrs={"split": pl.SplitMode.LEFT_RIGHT, "split_aiv": True},
+        )
+        def split_auto(
+            cube_seed: pl.Tile[[128, 128], pl.FP32, pl.Mem.Mat],
+            data: pl.Tensor[[32, 15], pl.FP32],
+            out_0: pl.Out[pl.Tensor[[32, 15], pl.FP32]],
+        ) -> pl.Tensor[[32, 15], pl.FP32]:
+            subblock_idx = pl.tile.get_subblock_idx()
+            seed_vec = pl.tile.aiv_shard(cube_seed, split=2)  # noqa: F841
+            prev: pl.Tile[
+                [32, 8],
+                pl.FP32,
+                pl.Mem.Vec,
+                pl.TileView(valid_shape=[32, pl.min(pl.max(15, subblock_idx * 8) - subblock_idx * 8, 8)]),
+            ] = pl.tile.load(
+                data,
+                [0, 0 + subblock_idx * 8],
+                [32, 8],
+                [32, pl.min(pl.max(15, subblock_idx * 8) - subblock_idx * 8, 8)],
+                target_memory=pl.Mem.Vec,
+            )
+            out_store = pl.tile.store(prev, [0, 0 + subblock_idx * 8], out_0)
             return out_store
 
     ir.assert_structural_equal(_lower(Before), Expected)


### PR DESCRIPTION
## Summary

pto-isa and PTOAS gained `TILE_UP_DOWN_ODD` / `TILE_LEFT_RIGHT_ODD`, which place lane 1's FIFO band one cell past its own **runtime** valid extent — and the even modes now derive that band from the runtime extent too, where they previously used the compile-time box. Neither fact was representable in the split lowering: `ComputeHalfDimSize` rejected an odd split axis outright ("SplitVectorKernel requires an even split dimension"), and a ragged boundary could hand the transport lane extents that no split code can place. A mixed kernel can now split an odd shape — an odd tile box, or an odd valid extent inside an even box — and a ragged boundary is balanced across the two lanes instead of leaving lane 1 the remainder. The DSL is unchanged: authors still write `pl.split(pl.SplitMode.UP_DOWN)`, and the compiler picks the ISA encoding.

## Changes

- `src/ir/transforms/utils/split_axis_utils.{h,cpp}`: halve the split axis with the **ceil** half, so an odd extent gives both lanes the same physical box and the per-lane valid extent carries the raggedness. Adds `ShardSplitCode` / `GatherSplitCode` (the lane-extent rule that picks the pto-isa code) and `ResolveLaneStride` (the balanced partition), and generalizes the lane clamp `clamp(V - L*S, 0, S)` over a partition stride `S`.
- `src/ir/transforms/lower_auto_vector_split_pass.cpp`: resolve the partition once per body and thread it through offsets, per-lane valid extents and the shard's type; stamp it as `lane_stride` when the body is rebalanced. Explicit `pl.split_aiv` regions are never rebalanced — their per-lane offsets are the author's own.
- `src/ir/transforms/expand_mixed_kernel_pass.cpp`: derive the transport's split code from the boundary tile's two lane extents when folding a boundary into `tpush`/`tpop`, so both lane bodies agree by construction.
- `src/ir/op/tile_ops/cross_core.cpp`, `include/pypto/ir/stmt.h`: the boundary ops keep the authored `SplitMode` (0/1/2); the split **codes** 0..4 that mirror pto-isa's `TileSplitAxis` live on the transport ops. Adds the optional `lane_stride` attr with its validation.
- `src/backend/common/pto_ops_crosscore.cpp`: accept codes 3/4, keep an odd pop off the static full-box + `treshape` path, and require the per-lane `valid_row`/`valid_col` operands PTOAS asks for.
- `python/pypto/debug/torch_codegen.py`, `python/pypto/language/parser/ast_parser.py`: the torch reference runtime splits the odd modes (lane 0 ceil, lane 1 floor); the parser round-trips the printed `lane_stride=` attr.
- Docs (`docs/en` + `docs/zh`) and tests: new unit coverage for the ceil halving, the code choice, the rebalance and its decline, plus `tests/st/codegen/dsl/test_split_odd_axis_codegen.py` end to end.

Behavior change: a ragged Cube→Vector boundary whose lanes would sit more than one cell apart is now either rebalanced (7 / 6 for 13 valid rows of a 16-row box, instead of the unplaceable 8 / 5) or, when the body also splits a value with an independent origin, reported with the extents that would work. Kernels whose boundary is fully valid are unaffected — their IR is unchanged. No migration step.

## Verification

- `cmake --build build --parallel 32`: success.
- `pytest tests/ut/ tests/lint/ -n 16`: 10050 passed, 8 skipped.
- `pytest tests/st/codegen/`: 55 passed, 30 deselected.
- `ptoas-0.59 <generated>.pto --enable-insert-sync --pto-level=level3`: assembles to `TileSplitAxis::TILE_UP_DOWN_ODD` on TPUSH/TPOP/TFREE.
- On a2a3 hardware (`task-submit`), `exp(a @ w.T)` split UP_DOWN: 15 valid rows of a 16-row box (lanes 8/7, box partition) and 13 valid rows (lanes 7/6, rebalanced) both match torch on every valid row (max relative error < 5e-6) and leave the padding rows untouched.
- On a2a3 hardware, `pytest tests/st/runtime/ops/test_abs.py` (even split regression): 4 passed.