### PR TITLE
fix(ir): adapt hand-written V->C pushes to the cross-core fractal layout

### DIFF
--- a/docs/en/dev/passes/21-expand_mixed_kernel.md
+++ b/docs/en/dev/passes/21-expand_mixed_kernel.md
@@ -97,9 +97,15 @@ Ascend950 (a5) — hardware cross-core pipe carries data in fractal layout:
 | Direction | Push/Pop TileView (blayout, slayout) | Name |
 | --------- | ------------------------------------ | ---- |
 | Vec→Left | col_major, row_major | NZ |
-| Vec→Right | row_major, col_major | ZN |
+| Vec→Right | col_major, row_major | NZ |
 | Vec→Mat | must be explicitly set in move | — |
 | Mat/Acc→Vec | must be explicitly set in move | — |
+
+`Vec→Right` crosses as NZ, not as the ZN a Right operand ends up in: a5 inserts
+the Vec tile into the Mat FIFO through `TINSERT_IMPL<TInsertMode::NZ>`, so the
+bridge tile has to stay NZ. The ZN view belongs to the `Mat → Right` `tile.move`
+the cube side makes after the pop, which is one step later than this table
+describes — the same split the a2a3 table below spells out.
 
 Ascend910B (a2a3) — cross-core transfer goes through GM → Mat, and Mat only supports the NZ layout. Both Left and Right destinations use NZ at the transfer boundary; the final Left/Right layout is resolved by the subsequent `Mat → Left/Right` `tile.move` (MTE1):
 
@@ -111,6 +117,41 @@ Ascend910B (a2a3) — cross-core transfer goes through GM → Mat, and Mat only 
 | Mat/Acc→Vec | preserve original | — |
 
 On both backends, the AIV push side (V→C) inserts a `tile.move` before `tpush_to_aic` to convert the source tile into the required fractal layout. The `tile.move` helper (`CreateMove`) propagates `blayout`/`slayout` kwargs when the result type carries a TileView.
+
+### Hand-written pipes get the same adapter
+
+The rule above describes the boundary-move path, which only sees the pipes this pass
+builds while expanding an InCore function. A pipe authored directly (`pl.reserve_buffer`,
+`pl.{aic,aiv}_initialize_pipe` and `pl.tpush_to_aic`, written out by hand) never reaches
+it. On a backend where `RequiresVtoCFractalAdapt()` holds, such a push would ship a bare
+ND tile into a FIFO the cube reads as fractal, scattering every element of the popped
+tile.
+
+`AdaptManualVtoCPush` closes that gap. It runs as the pass's final phase, over **every**
+AIV function the pass emits — not over the functions it was handed. That distinction
+matters: `tile.tpush_to_aic` declares `CoreAffinity::VECTOR`, so a hand-written push is
+legal inside an InCore body, and such a body only becomes an AIV function during this
+pass. A pure-vector body reaches AIV through the non-mixed conversion, and a mixed body
+carries the statement into its expanded AIV half; both happen after the per-function loop,
+so an earlier hook would still leave the bare ND push behind.
+
+Three properties keep the sweep cheap and safe:
+
+- **One fixed boundary, no cross-function analysis.** The adapter asks for the cube-side
+  transfer memory, `GetBoundaryTpopMemory(CoreSide::AIC)`, instead of locating the
+  matching `tpop` in the peer function. That is exact rather than approximate because
+  `BuildCrossCoreTransferView` maps `Mat`, `Left` and `Right` onto the same fractal view:
+  wherever the consumer pops to, the layout it expects is the one this produces.
+- **Idempotent, and it defers to the author.** A push whose source already carries the
+  boundary view is left alone. Re-running the pass adds nothing, a program that stages
+  the move by hand keeps its own, and the pushes the boundary-move path already adapted
+  are not touched twice.
+- **The backend is consulted lazily.** `RequiresVtoCFractalAdapt()` is read inside the
+  mutator, on the first V→C push it meets, so a program with no hand-written push does
+  not need a configured backend to walk past this phase.
+
+The rewritten push preserves the original call's kwargs — dropping `id` would collapse a
+multi-pipe program onto a single FIFO.
 
 ### GM-mediated cross-lane dependencies
 

--- a/docs/zh/dev/passes/21-expand_mixed_kernel.md
+++ b/docs/zh/dev/passes/21-expand_mixed_kernel.md
@@ -69,9 +69,14 @@ Ascend950（a5）——硬件跨核 pipe 直接按 fractal 布局传输数据：
 | 方向 | Push/Pop TileView (blayout, slayout) | 名称 |
 | ---- | ------------------------------------ | ---- |
 | Vec->Left | col_major, row_major | NZ |
-| Vec->Right | row_major, col_major | ZN |
+| Vec->Right | col_major, row_major | NZ |
 | Vec->Mat | 需要显式在move中设置，否则同src | — |
 | Mat/Acc->Vec | 需要显式在move中设置，否则同src | — |
+
+`Vec->Right` 在边界上按 NZ 传输，而不是 Right 操作数最终的 ZN：a5 通过
+`TINSERT_IMPL<TInsertMode::NZ>` 把 Vec tile 插入 Mat FIFO，因此桥接 tile 必须保持
+NZ。ZN 属于 cube 侧在 pop 之后所做的 `Mat → Right` `tile.move`，比本表描述的边界晚
+一步——与下面 a2a3 表格中写明的拆分相同。
 
 Ascend910B（a2a3）——跨核传输经过 GM → Mat，Mat 仅支持 NZ 布局。因此 Left 和 Right 目标在传输边界统一使用 NZ，最终的 Left/Right 布局由后续 `Mat → Left/Right` `tile.move`（MTE1）处理：
 
@@ -83,6 +88,32 @@ Ascend910B（a2a3）——跨核传输经过 GM → Mat，Mat 仅支持 NZ 布�
 | Mat/Acc->Vec | 保持原始布局 | — |
 
 在两种后端上，AIV 推送侧（V→C）都会在 `tpush_to_aic` 前插入一个 `tile.move` 将源 tile 转换为所需的 fractal 布局。`tile.move` 辅助函数（`CreateMove`）在结果类型携带 TileView 时会传播 `blayout`/`slayout` kwargs。
+
+### 手写 pipe 同样获得该适配
+
+上述规则描述的是边界移动路径，它只能看到本 pass 在展开 InCore 函数时构建的 pipe。完全手写的
+pipe（`pl.reserve_buffer`、`pl.{aic,aiv}_initialize_pipe` 与 `pl.tpush_to_aic`）不会经过该
+路径。在 `RequiresVtoCFractalAdapt()` 成立的后端上，这样的推送会把裸 ND tile 送进一个被 cube
+按 fractal 解释的 FIFO，导致弹出 tile 的每个元素都错位。
+
+`AdaptManualVtoCPush` 负责补上这个缺口。它作为本 pass 的最后一个阶段运行，遍历本 pass **产出**
+的每一个 AIV 函数，而不是它收到的那些。这个区别很关键：`tile.tpush_to_aic` 声明的 affinity 是
+`CoreAffinity::VECTOR`，因此手写推送合法地出现在 InCore 体内，而这样的函数体正是在本 pass 中才
+变成 AIV 函数 —— 纯向量体经由非混合转换成为 AIV，混合体则把该语句带进展开后的 AIV 半边；两者都
+发生在逐函数循环之后，所以更早的钩子仍会漏掉那条裸 ND 推送。
+
+三条性质保证这次扫描既省又安全：
+
+- **固定边界，无需跨函数分析。** 适配器取 cube 侧传输内存
+  `GetBoundaryTpopMemory(CoreSide::AIC)`，而不是到对端函数里定位匹配的 `tpop`。这是精确而非
+  近似的，因为 `BuildCrossCoreTransferView` 把 `Mat`、`Left`、`Right` 映射到同一个 fractal
+  视图：无论消费者弹到哪里，它期望的布局都正是这里产出的那个。
+- **幂等，且尊重作者的手写。** 源 tile 已经携带边界视图的推送会被跳过。重复运行本 pass 不会叠加，
+  手工完成该 move 的程序保留自己的写法，边界移动路径已适配过的推送也不会被再插一次。
+- **后端按需查询。** `RequiresVtoCFractalAdapt()` 在 mutator 内部、遇到第一条 V→C 推送时才读取，
+  因此没有手写推送的程序无需配置后端即可走过该阶段。
+
+重写后的推送保留原调用的 kwargs —— 丢掉 `id` 会让多 pipe 程序坍缩到同一个 FIFO 上。
 
 ### 经 GM 中转的跨核依赖
 

--- a/src/ir/transforms/expand_mixed_kernel_pass.cpp
+++ b/src/ir/transforms/expand_mixed_kernel_pass.cpp
@@ -433,13 +433,88 @@ CallPtr CreateMove(const ExprPtr& tile, MemorySpace target_memory, const TypePtr
   return std::make_shared<Call>(op, std::vector<ExprPtr>{tile}, std::move(kwargs), result_type, span);
 }
 
-// ============================================================================
-// Parameterized Core Body Builder (shared by AIC and AIV)
-// ============================================================================
-
 MemorySpace GetBoundaryTpopMemory(CoreSide side) {
   return (side == CoreSide::AIC) ? MemorySpace::Mat : MemorySpace::Vec;
 }
+
+// ============================================================================
+// Hand-written cross-core pipe: V->C push layout adaptation
+// ============================================================================
+
+/// Give a hand-written `pl.tpush_to_aic` the same fractal adapter the compiler
+/// inserts for the pipes it builds itself.
+///
+/// The boundary-move path below adapts every V->C push on a backend whose
+/// cross-core boundary carries fractal layout (BackendHandler::
+/// RequiresVtoCFractalAdapt). A hand-written pipe -- pl.reserve_buffer +
+/// pl.{aic,aiv}_initialize_pipe + pl.tpush_to_aic, authored directly in an AIV
+/// function -- never reaches it, because this pass expands InCore functions and
+/// passes every other function through untouched. On Ascend950 that shipped a
+/// bare ND tile into a FIFO the cube reads as fractal, so every element of the
+/// popped tile landed somewhere else: tests/st/runtime/cross_core
+/// test_multiple_pipes_nosplit returns 256/256 wrong values on board while
+/// passing on a5sim (which does not model the on-chip FIFO layout) and on
+/// Ascend910B (which needs no adapter: push/pop goes ub -> gm -> mat and takes
+/// ND directly).
+///
+/// The target view does not depend on where the consumer pops to -- the handler
+/// maps Mat, Left and Right alike onto one fractal view -- so keying off Mat,
+/// the cube-side transfer memory the op-driven branch below already uses, is
+/// exact rather than a guess, and needs no cross-function analysis to find the
+/// matching tpop.
+class AdaptManualVtoCPush : public IRMutator {
+ protected:
+  StmtPtr VisitStmt_(const EvalStmtPtr& op) override {
+    auto call = As<Call>(op->expr_);
+    if (!call || !IsOp(call, "tile.tpush_to_aic") || call->args_.size() != 1) {
+      return IRMutator::VisitStmt_(op);
+    }
+    const ExprPtr& source = call->args_[0];
+    auto src_type = As<TileType>(source->GetType());
+    INTERNAL_CHECK_SPAN(src_type, op->span_) << "Internal error: tile.tpush_to_aic source must be a TileType";
+
+    // Backend gate lives here, not around the caller's loop: a program with no
+    // hand-written push must not require a configured backend to walk this phase.
+    const auto* handler = PassContext::Current()->GetBackendHandler();
+    if (!handler->RequiresVtoCFractalAdapt()) {
+      return IRMutator::VisitStmt_(op);
+    }
+    const TileView src_view = tile_view_semantics::GetEffectiveTileView(*src_type);
+    const TileView fractal_view =
+        handler->BuildCrossCoreTransferView(GetBoundaryTpopMemory(CoreSide::AIC), src_view);
+    // Already in the boundary layout: either a second run of this pass, or an
+    // author who staged the move by hand. Either way there is nothing to add.
+    if (fractal_view.blayout == src_view.blayout && fractal_view.slayout == src_view.slayout) {
+      return IRMutator::VisitStmt_(op);
+    }
+
+    auto adapted_type = std::make_shared<TileType>(src_type->shape_, src_type->dtype_, std::nullopt,
+                                                   fractal_view, MemorySpace::Vec);
+    std::string src_name = "tile";
+    if (auto sv = AsVarLike(source)) {
+      src_name = sv->name_hint_;
+    }
+    const bool is_nz = (fractal_view.blayout == TileLayout::col_major);
+    auto adapted_var = std::make_shared<Var>(src_name + (is_nz ? "_nz" : "_zn"), adapted_type, op->span_);
+    auto adapt_call = CreateMove(source, MemorySpace::Vec, adapted_type, op->span_);
+
+    // Rebuild rather than CreateTpush: a hand-written push carries its own
+    // kwargs (`split`, and `id` selecting one of several pipes), and dropping
+    // `id` would silently collapse a multi-pipe program onto one FIFO. attrs_
+    // rides along for the same reason -- this rewrite replaces the pushed tile
+    // and nothing else, so it must not quietly drop compiler metadata a caller
+    // or an earlier pass attached to the op.
+    auto adapted_push = std::make_shared<Call>(call->op_, std::vector<ExprPtr>{adapted_var}, call->kwargs_,
+                                               call->attrs_, call->GetType(), call->span_);
+    std::vector<StmtPtr> out{std::make_shared<AssignStmt>(adapted_var, adapt_call, op->span_),
+                             std::make_shared<EvalStmt>(adapted_push, op->span_)};
+    return SeqStmts::Flatten(std::move(out), op->span_);
+  }
+};
+
+// ============================================================================
+// Parameterized Core Body Builder (shared by AIC and AIV)
+// ============================================================================
 
 TypePtr BuildBoundaryTpopType(CoreSide side, const TypePtr& original_type) {
   auto tt = std::dynamic_pointer_cast<const TileType>(original_type);
@@ -769,7 +844,10 @@ std::vector<StmtPtr> BuildCoreBody(CoreSide side, const std::vector<StmtPtr>& st
           ExprPtr push_source = bm.source_tile;
           // AIV V->C push: insert tile.move (tmov) to adapt the source into
           // the required fractal layout before tpush.
-          // On Ascend950: Left -> NZ, Right -> ZN.
+          // On Ascend950 both cross as NZ: Left -> NZ, and Right -> NZ too, because
+          // V2C inserts the Vec tile into the Mat FIFO via TINSERT_IMPL<TInsertMode::NZ>.
+          // A Right operand does end up ZN, but only after the cube side's own
+          // Mat -> Right tile.move, one step past this boundary.
           // On Ascend910B: don't need to adapt layout! push/pop will be ub -> gm -> mat, ub -> gm can
           // directly use nd
           if (side == CoreSide::AIV && handler->RequiresVtoCFractalAdapt()) {
@@ -2073,6 +2151,33 @@ Pass ExpandMixedKernel() {
     // to AIV, or left alone because it was not InCore) carries the same stamp
     // and must not keep it either.
     for (auto& func : new_functions) func = StripCorePlacement(func);
+
+    // Phase 6: give every hand-written V->C push the boundary's fractal layout.
+    //
+    // The sweep covers EVERY emitted AIV function rather than only the ones
+    // that were already typed AIV on entry. `tile.tpush_to_aic` declares
+    // CoreAffinity::VECTOR, so it is legal to author one inside an InCore body:
+    // a pure-vector body reaches AIV through the conversion above, and a mixed
+    // body carries the statement into its expanded AIV half. Both produce their
+    // AIV function after the per-function loop, so a hook there would leave
+    // exactly the bare ND push this adapter exists to prevent.
+    //
+    // Running last also makes the boundary-move path's own adapters harmless:
+    // AdaptManualVtoCPush leaves a push whose source already carries the
+    // boundary view alone, so the pushes that path staged are not touched twice.
+    // The backend is consulted inside the mutator, on the first V->C push it
+    // meets, rather than as a guard around this loop: a program with no
+    // hand-written push must not require a configured backend just to walk past
+    // this phase.
+    for (auto& func : new_functions) {
+      if (func->func_type_ != FunctionType::AIV) continue;
+      AdaptManualVtoCPush adapter;
+      auto adapted_body = adapter.VisitStmt(func->body_);
+      if (adapted_body == func->body_) continue;
+      auto adapted = std::make_shared<Function>(*func);
+      adapted->body_ = adapted_body;
+      func = adapted;
+    }
 
     return std::make_shared<Program>(new_functions, program->name_, program->span_);
   };

--- a/tests/st/runtime/cross_core/test_cross_core.py
+++ b/tests/st/runtime/cross_core/test_cross_core.py
@@ -928,42 +928,8 @@ class TestCrossCore:
         result = test_runner.run(BidirectSpmdNoSplitTest(backend_type=backend_type))
         assert result.passed, f"Cross-core bidirect spmd no-split failed: {result.error}"
 
-    def test_multiple_pipes_nosplit(self, request, test_runner, backend_type, platform):
+    def test_multiple_pipes_nosplit(self, test_runner, backend_type):
         """Explicit multiple pipe ids: compile through full pipeline and verify correctness."""
-        if platform == "a5":
-            # Every output element is wrong on 950 silicon -- and only there;
-            # the case passes on a5sim and on a2a3.
-            #
-            # Cause: 950's on-chip cross-core boundary expects a fractal layout,
-            # so the AIV producer must adapt the tile before tpush (Left -> NZ,
-            # Right -> ZN). That adapter is inserted by ExpandMixedKernel, which
-            # is the only place BackendHandler::RequiresVtoCFractalAdapt() is
-            # consulted -- so it covers automatically built cube<->vector pipes
-            # and not a hand-written pl.tpush_to_aic like this one. Compiled for
-            # a5, this program pushes a bare ND tile
-            # (blayout=row_major, slayout=none_box) where the automatic path
-            # emits a pto.tmov into blayout=col_major, slayout=row_major first.
-            # The cube then reads those bytes as fractal, which scrambles every
-            # element rather than perturbing it -- matching what the board
-            # reports. a5sim does not model the on-chip FIFO layout, so it
-            # cannot see this. On 910B the adapter is not needed at all
-            # (RequiresVtoCFractalAdapt() is false: push/pop goes ub -> gm ->
-            # mat, which takes ND directly), so a2a3 keeps passing.
-            #
-            # Marked, not raised: `pytest.xfail(...)` aborts before the body and
-            # can never report XPASS, so it would freeze this verdict instead of
-            # re-checking it. Strict, because a layout mismatch is deterministic
-            # -- a scrambled matmul cannot pass by luck -- so an XPASS means the
-            # adapter now reaches manual pipes and the marker must come out.
-            request.node.add_marker(
-                pytest.mark.xfail(
-                    reason=(
-                        "950 board: manual pl.tpush_to_aic gets no V->C fractal adapter "
-                        "(ExpandMixedKernel is the only consumer of RequiresVtoCFractalAdapt)"
-                    ),
-                    strict=True,
-                )
-            )
         result = test_runner.run(MultiPipeNoSplitTest(backend_type=backend_type))
         assert result.passed, f"Cross-core explicit multi-pipe no-split failed: {result.error}"
 

--- a/tests/ut/ir/transforms/test_expand_mixed_kernel_a5.py
+++ b/tests/ut/ir/transforms/test_expand_mixed_kernel_a5.py
@@ -4003,5 +4003,339 @@ class TestDCERegression:
         passes.run_verifier()(After)
 
 
+class TestManualPipeVtoCFractalAdapt:
+    """A hand-written pl.tpush_to_aic gets the same V->C fractal adapter.
+
+    The push is staged into an NZ Vec tile exactly as the boundary-move path
+    stages the pipes this pass builds itself, and the original call's kwargs
+    ride along -- an `id` reset to the CreateTpush default would collapse a
+    multi-pipe program onto one FIFO, and the Expected programs below pin it.
+
+    The other half of the contract -- that no adapter appears on a backend
+    where RequiresVtoCFractalAdapt() is false -- is held by
+    test_expand_mixed_kernel_a2a3.py::test_v2c_boundary_uses_nz_layout_on_a2a3,
+    which fails as soon as the gate stops being consulted.
+    """
+
+    def test_push_in_a_hand_written_aiv_function_is_adapted(self):
+        """The author already typed the function AIV, so the pass only adapts."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.AIC)
+            def manual_aic(
+                self,
+                a: pl.Tensor[[16, 16], pl.FP32],
+                out_0: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                v2c = pl.reserve_buffer(name="v2c_slot_buffer", size=8192, base=pl.AUTO)
+                pl.aic_initialize_pipe(pl.const(0, pl.INT32), v2c, dir_mask=2, slot_size=1024, id=1)
+                lhs_mat: pl.Tile[[16, 16], pl.FP32, pl.Mem.Mat] = pl.tpop_from_aiv(split=0, id=1)
+                lhs_left = pl.move(lhs_mat, target_memory=pl.MemorySpace.Left)
+                rhs_mat = pl.load(a, [0, 0], [16, 16], target_memory=pl.MemorySpace.Mat)
+                rhs_right = pl.move(rhs_mat, target_memory=pl.MemorySpace.Right)
+                acc = pl.matmul(lhs_left, rhs_right)
+                pl.tfree_to_aiv(lhs_mat, id=1)
+                out_0_store = pl.store(acc, [0, 0], out_0)
+                return out_0_store
+
+            @pl.function(type=pl.FunctionType.AIV)
+            def manual_aiv(
+                self,
+                a: pl.Tensor[[16, 16], pl.FP32],
+                out_0: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+            ):
+                v2c_peer = pl.import_peer_buffer(name="v2c_slot_buffer", peer_func="manual_aic")
+                pl.aiv_initialize_pipe(pl.const(0, pl.INT32), v2c_peer, dir_mask=2, slot_size=1024, id=1)
+                a_tile = pl.load(a, [0, 0], [16, 16])
+                doubled = pl.add(a_tile, a_tile)
+                pl.tpush_to_aic(doubled, split=0, id=1)
+
+            @pl.function(type=pl.FunctionType.Group)
+            def manual_group(
+                self,
+                a: pl.Tensor[[16, 16], pl.FP32],
+                out_0: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                result = self.manual_aic(a, out_0)
+                self.manual_aiv(a, out_0)
+                return result
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.AIC)
+            def manual_aic(
+                self,
+                a: pl.Tensor[[16, 16], pl.FP32],
+                out_0: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                v2c = pl.reserve_buffer(name="v2c_slot_buffer", size=8192, base=pl.AUTO)
+                pl.aic_initialize_pipe(pl.const(0, pl.INT32), v2c, dir_mask=2, slot_size=1024, id=1)
+                lhs_mat: pl.Tile[[16, 16], pl.FP32, pl.Mem.Mat] = pl.tpop_from_aiv(split=0, id=1)
+                lhs_left = pl.move(lhs_mat, target_memory=pl.MemorySpace.Left)
+                rhs_mat = pl.load(a, [0, 0], [16, 16], target_memory=pl.MemorySpace.Mat)
+                rhs_right = pl.move(rhs_mat, target_memory=pl.MemorySpace.Right)
+                acc = pl.matmul(lhs_left, rhs_right)
+                pl.tfree_to_aiv(lhs_mat, id=1)
+                out_0_store = pl.store(acc, [0, 0], out_0)
+                return out_0_store
+
+            @pl.function(type=pl.FunctionType.AIV)
+            def manual_aiv(
+                self,
+                a: pl.Tensor[[16, 16], pl.FP32],
+                out_0: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+            ):
+                v2c_peer = pl.import_peer_buffer(name="v2c_slot_buffer", peer_func="manual_aic")
+                pl.aiv_initialize_pipe(pl.const(0, pl.INT32), v2c_peer, dir_mask=2, slot_size=1024, id=1)
+                a_tile = pl.load(a, [0, 0], [16, 16])
+                doubled = pl.add(a_tile, a_tile)
+                doubled_nz = pl.move(
+                    doubled,
+                    target_memory=pl.MemorySpace.Vec,
+                    blayout=pl.TileLayout.col_major,
+                    slayout=pl.TileLayout.row_major,
+                )
+                pl.tpush_to_aic(doubled_nz, split=0, id=1)
+
+            @pl.function(type=pl.FunctionType.Group)
+            def manual_group(
+                self,
+                a: pl.Tensor[[16, 16], pl.FP32],
+                out_0: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                result = self.manual_aic(a, out_0)
+                self.manual_aiv(a, out_0)
+                return result
+
+        ir.assert_structural_equal(_expand_raw(Before), Expected)
+
+    def test_push_authored_in_an_incore_body_is_adapted(self):
+        """`tile.tpush_to_aic` is VECTOR-affine, so authoring one in an InCore body is legal.
+
+        Such a body only becomes an AIV function inside this pass, after the
+        per-function loop, so the adapter has to sweep what the pass emits
+        rather than what it was handed.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.AIC)
+            def manual_aic(
+                self,
+                a: pl.Tensor[[16, 16], pl.FP32],
+                out_0: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                v2c = pl.reserve_buffer(name="v2c_slot_buffer", size=8192, base=pl.AUTO)
+                pl.aic_initialize_pipe(pl.const(0, pl.INT32), v2c, dir_mask=2, slot_size=1024, id=1)
+                lhs_mat: pl.Tile[[16, 16], pl.FP32, pl.Mem.Mat] = pl.tpop_from_aiv(split=0, id=1)
+                lhs_left = pl.move(lhs_mat, target_memory=pl.MemorySpace.Left)
+                rhs_mat = pl.load(a, [0, 0], [16, 16], target_memory=pl.MemorySpace.Mat)
+                rhs_right = pl.move(rhs_mat, target_memory=pl.MemorySpace.Right)
+                acc = pl.matmul(lhs_left, rhs_right)
+                pl.tfree_to_aiv(lhs_mat, id=1)
+                out_0_store = pl.store(acc, [0, 0], out_0)
+                return out_0_store
+
+            @pl.function(type=pl.FunctionType.InCore)
+            def manual_incore(
+                self,
+                a: pl.Tensor[[16, 16], pl.FP32],
+                out_0: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+            ):
+                v2c_peer = pl.import_peer_buffer(name="v2c_slot_buffer", peer_func="manual_aic")
+                pl.aiv_initialize_pipe(pl.const(0, pl.INT32), v2c_peer, dir_mask=2, slot_size=1024, id=1)
+                a_tile = pl.load(a, [0, 0], [16, 16])
+                doubled = pl.add(a_tile, a_tile)
+                pl.tpush_to_aic(doubled, split=0, id=1)
+
+            @pl.function(type=pl.FunctionType.Group)
+            def manual_group(
+                self,
+                a: pl.Tensor[[16, 16], pl.FP32],
+                out_0: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                result = self.manual_aic(a, out_0)
+                self.manual_incore(a, out_0)
+                return result
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.AIC)
+            def manual_aic(
+                self,
+                a: pl.Tensor[[16, 16], pl.FP32],
+                out_0: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                v2c = pl.reserve_buffer(name="v2c_slot_buffer", size=8192, base=pl.AUTO)
+                pl.aic_initialize_pipe(pl.const(0, pl.INT32), v2c, dir_mask=2, slot_size=1024, id=1)
+                lhs_mat: pl.Tile[[16, 16], pl.FP32, pl.Mem.Mat] = pl.tpop_from_aiv(split=0, id=1)
+                lhs_left = pl.move(lhs_mat, target_memory=pl.MemorySpace.Left)
+                rhs_mat = pl.load(a, [0, 0], [16, 16], target_memory=pl.MemorySpace.Mat)
+                rhs_right = pl.move(rhs_mat, target_memory=pl.MemorySpace.Right)
+                acc = pl.matmul(lhs_left, rhs_right)
+                pl.tfree_to_aiv(lhs_mat, id=1)
+                out_0_store = pl.store(acc, [0, 0], out_0)
+                return out_0_store
+
+            @pl.function(type=pl.FunctionType.AIV)
+            def manual_incore(
+                self,
+                a: pl.Tensor[[16, 16], pl.FP32],
+                out_0: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+            ):
+                v2c_peer = pl.import_peer_buffer(name="v2c_slot_buffer", peer_func="manual_aic")
+                pl.aiv_initialize_pipe(pl.const(0, pl.INT32), v2c_peer, dir_mask=2, slot_size=1024, id=1)
+                a_tile = pl.load(a, [0, 0], [16, 16])
+                doubled = pl.add(a_tile, a_tile)
+                doubled_nz = pl.move(
+                    doubled,
+                    target_memory=pl.MemorySpace.Vec,
+                    blayout=pl.TileLayout.col_major,
+                    slayout=pl.TileLayout.row_major,
+                )
+                pl.tpush_to_aic(doubled_nz, split=0, id=1)
+
+            @pl.function(type=pl.FunctionType.Group)
+            def manual_group(
+                self,
+                a: pl.Tensor[[16, 16], pl.FP32],
+                out_0: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                result = self.manual_aic(a, out_0)
+                self.manual_incore(a, out_0)
+                return result
+
+        ir.assert_structural_equal(_expand_raw(Before), Expected)
+
+    def test_push_keeps_its_attrs(self):
+        """The rewrite replaces the pushed tile and nothing else.
+
+        `Call.attrs` carries compiler metadata an earlier pass or a caller may
+        have attached to the op. Rebuilding the push must not quietly drop it,
+        the same way rebuilding through CreateTpush would drop the kwargs.
+        Asserted on the attrs rather than structurally, because the Expected
+        programs above are written in the DSL and the DSL has no syntax for
+        stamping an opaque attr on a call.
+        """
+
+        class _StampPushAttrs(ir.IRMutator):
+            def visit_call(self, op: ir.Call) -> ir.Expr:
+                expr = super().visit_call(op)
+                call = expr if isinstance(expr, ir.Call) else op
+                if call.op.name != ir.get_op("tile.tpush_to_aic").name:
+                    return expr
+                attrs = dict(call.attrs)
+                attrs["test_push_marker"] = 4471
+                return ir.Call(call.op, list(call.args), dict(call.kwargs), attrs, call.type, call.span)
+
+        class _CollectPushAttrs(ir.IRVisitor):
+            def __init__(self) -> None:
+                super().__init__()
+                self.attrs: list[dict] = []
+
+            def visit_call(self, op: ir.Call) -> None:
+                if op.op.name == ir.get_op("tile.tpush_to_aic").name:
+                    self.attrs.append(dict(op.attrs))
+                super().visit_call(op)
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.AIC)
+            def manual_aic(
+                self,
+                a: pl.Tensor[[16, 16], pl.FP32],
+                out_0: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                v2c = pl.reserve_buffer(name="v2c_slot_buffer", size=8192, base=pl.AUTO)
+                pl.aic_initialize_pipe(pl.const(0, pl.INT32), v2c, dir_mask=2, slot_size=1024, id=1)
+                lhs_mat: pl.Tile[[16, 16], pl.FP32, pl.Mem.Mat] = pl.tpop_from_aiv(split=0, id=1)
+                lhs_left = pl.move(lhs_mat, target_memory=pl.MemorySpace.Left)
+                rhs_mat = pl.load(a, [0, 0], [16, 16], target_memory=pl.MemorySpace.Mat)
+                rhs_right = pl.move(rhs_mat, target_memory=pl.MemorySpace.Right)
+                acc = pl.matmul(lhs_left, rhs_right)
+                pl.tfree_to_aiv(lhs_mat, id=1)
+                out_0_store = pl.store(acc, [0, 0], out_0)
+                return out_0_store
+
+            @pl.function(type=pl.FunctionType.AIV)
+            def manual_aiv(
+                self,
+                a: pl.Tensor[[16, 16], pl.FP32],
+                out_0: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+            ):
+                v2c_peer = pl.import_peer_buffer(name="v2c_slot_buffer", peer_func="manual_aic")
+                pl.aiv_initialize_pipe(pl.const(0, pl.INT32), v2c_peer, dir_mask=2, slot_size=1024, id=1)
+                a_tile = pl.load(a, [0, 0], [16, 16])
+                doubled = pl.add(a_tile, a_tile)
+                pl.tpush_to_aic(doubled, split=0, id=1)
+
+            @pl.function(type=pl.FunctionType.Group)
+            def manual_group(
+                self,
+                a: pl.Tensor[[16, 16], pl.FP32],
+                out_0: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                result = self.manual_aic(a, out_0)
+                self.manual_aiv(a, out_0)
+                return result
+
+        stamped = _StampPushAttrs().visit_program(
+            passes.infer_tile_memory_space()(passes.convert_to_ssa()(Before))
+        )
+        collector = _CollectPushAttrs()
+        collector.visit_program(passes.expand_mixed_kernel()(stamped))
+
+        assert collector.attrs, "the adapted program must still contain a V->C push"
+        assert all(a.get("test_push_marker") == 4471 for a in collector.attrs)
+
+    def test_adapting_is_idempotent(self):
+        """A push already carrying the boundary view is left alone on a second run."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.AIC)
+            def manual_aic(
+                self,
+                a: pl.Tensor[[16, 16], pl.FP32],
+                out_0: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                v2c = pl.reserve_buffer(name="v2c_slot_buffer", size=8192, base=pl.AUTO)
+                pl.aic_initialize_pipe(pl.const(0, pl.INT32), v2c, dir_mask=2, slot_size=1024, id=1)
+                lhs_mat: pl.Tile[[16, 16], pl.FP32, pl.Mem.Mat] = pl.tpop_from_aiv(split=0, id=1)
+                lhs_left = pl.move(lhs_mat, target_memory=pl.MemorySpace.Left)
+                rhs_mat = pl.load(a, [0, 0], [16, 16], target_memory=pl.MemorySpace.Mat)
+                rhs_right = pl.move(rhs_mat, target_memory=pl.MemorySpace.Right)
+                acc = pl.matmul(lhs_left, rhs_right)
+                pl.tfree_to_aiv(lhs_mat, id=1)
+                out_0_store = pl.store(acc, [0, 0], out_0)
+                return out_0_store
+
+            @pl.function(type=pl.FunctionType.AIV)
+            def manual_aiv(
+                self,
+                a: pl.Tensor[[16, 16], pl.FP32],
+                out_0: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+            ):
+                v2c_peer = pl.import_peer_buffer(name="v2c_slot_buffer", peer_func="manual_aic")
+                pl.aiv_initialize_pipe(pl.const(0, pl.INT32), v2c_peer, dir_mask=2, slot_size=1024, id=1)
+                a_tile = pl.load(a, [0, 0], [16, 16])
+                doubled = pl.add(a_tile, a_tile)
+                pl.tpush_to_aic(doubled, split=0, id=1)
+
+            @pl.function(type=pl.FunctionType.Group)
+            def manual_group(
+                self,
+                a: pl.Tensor[[16, 16], pl.FP32],
+                out_0: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                result = self.manual_aic(a, out_0)
+                self.manual_aiv(a, out_0)
+                return result
+
+        Once = _expand_raw(Before)
+        ir.assert_structural_equal(passes.expand_mixed_kernel()(Once), Once)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
Fixes the `test_multiple_pipes_nosplit` failure that #2290 had to park as an xfail on A5.

## The defect

Ascend950 carries fractal layout across the cube/vector boundary, so the AIV producer must stage its tile through a `tile.move` before `tpush_to_aic`. Both cube-side destinations cross as NZ — Left as NZ, and Right as NZ too, because V2C inserts the Vec tile into the Mat FIFO via `TINSERT_IMPL<TInsertMode::NZ>`; a Right operand does end up ZN, but only after the cube side's own `Mat → Right` `tile.move`, one step past the boundary.

`ExpandMixedKernel` inserts that adapter on its boundary-move path — the only consumer of `BackendHandler::RequiresVtoCFractalAdapt()` — so it reaches the pipes the compiler builds while expanding an InCore function, and nothing else. A pipe written by hand (`pl.reserve_buffer` + `pl.{aic,aiv}_initialize_pipe` + `pl.tpush_to_aic`) never reaches it, and shipped a bare ND tile into a FIFO the cube reads as fractal.

The failure is silent — it compiles, it runs, and every element of the popped tile lands somewhere else. Compiling the ST case for both arches shows it directly:

| path | tile the AIV pushes |
|---|---|
| automatic (qwen3 scope-3 `mlp_block`, a5) | `blayout=col_major, slayout=row_major`, preceded by `pto.tmov` |
| hand-written (`multi_pipe`, a5) | `blayout=row_major, slayout=none_box` — bare ND |

That matches what the board reports: 256/256 wrong values, unrelated to the golden rather than off by a tolerance. a5sim passes because it does not model the on-chip FIFO layout; a2a3 passes because it needs no adapter at all (`RequiresVtoCFractalAdapt()` is false — push/pop goes ub → gm → mat and takes ND directly).

## The fix

`AdaptManualVtoCPush` runs as the pass's final phase, sweeping every AIV function the pass **emits** rather than the ones it was handed. `tile.tpush_to_aic` declares `CoreAffinity::VECTOR`, so a hand-written push is legal inside an InCore body: a pure-vector body reaches AIV through the non-mixed conversion and a mixed body carries the statement into its expanded AIV half, both after the per-function loop. A hook there would leave exactly the push this adapter exists to fix.

Three properties keep the sweep cheap and safe:

- **One fixed boundary, no cross-function analysis.** The adapter asks for the cube-side transfer memory, `GetBoundaryTpopMemory(CoreSide::AIC)`, instead of locating the matching `tpop` in the peer function. That is exact rather than approximate because `BuildCrossCoreTransferView` maps `Mat`, `Left` and `Right` onto the same fractal view.
- **Idempotent, and it defers to the author.** A push whose source already carries the boundary view is left alone, so the pushes the boundary-move path staged are not touched twice, a program that stages the move by hand keeps its own, and re-running the pass adds nothing.
- **The backend is consulted lazily**, inside the mutator on the first V→C push it meets, so a program with no hand-written push does not need a configured backend to walk past this phase.

The rewritten push is rebuilt from the original call rather than through `CreateTpush`, which would drop `id` and collapse a multi-pipe program onto a single FIFO. It carries `attrs_` across for the same reason: the rewrite replaces the pushed tile and nothing else, so it must not drop compiler metadata either.

Also corrects the stale `Right -> ZN` boundary claim in the pass comment and in both pass documents. The handler has returned NZ for Right since the `TINSERT_IMPL<TInsertMode::NZ>` fix, and the a5 doc table was still describing the post-move operand layout in a column that asks for the boundary view.

## Verification

- Compiling the multi-pipe ST case for a5 emits the same shape as the automatic path — `alloc_tile blayout=col_major/slayout=row_major`, `pto.tmov`, then the push — with `{id = 0, split = 0}` / `{id = 1, split = 0}` intact and two distinct `TPipe` flag ids (0 and 2).
- The a2a3 `.pto` output is byte-identical to before this change.
- `tests/ut/ir/transforms/` + `tests/ut/codegen/`: 3938 passed, 2 skipped.
- New coverage in `test_expand_mixed_kernel_a5.py`: adapter inserted for a hand-written AIV function, for a push authored in an InCore body, idempotence on a second run, and `Call.attrs` preservation. The first three are `Before`/`Expected` + `ir.assert_structural_equal`; the attrs one asserts on the attrs map because the DSL has no syntax for stamping an opaque attr on a call. Each was checked to fail without its half of the fix.
- The backend gate itself stays pinned by `test_expand_mixed_kernel_a2a3.py::test_v2c_boundary_uses_nz_layout_on_a2a3`, which fails as soon as the gate stops being consulted.
- On board, `mixed-kernel-tests-a5` reports `11 passed, 1 deselected` with `test_multiple_pipes_nosplit[a5]` running on device 0; `test_explicit_slot_num` stays deselected as the a2/a3-only case it is.

Docs updated in `docs/{en,zh}/dev/passes/21-expand_mixed_kernel.md`.
