### PR TITLE
refactor(ir): declare reserved Function attr keys once per layer

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -70,6 +70,13 @@ repos:
           language_version: python3
           pass_filenames: false
 
+        - id: check-function-attr-key-parity
+          name: check-function-attr-key-parity
+          entry: python tests/lint/check_function_attr_key_parity.py
+          language: python
+          language_version: python3
+          pass_filenames: false
+
     - repo: https://github.com/pre-commit/pre-commit-hooks
       rev: v4.6.0
       hooks:

--- a/docs/en/dev/ir/01-hierarchy.md
+++ b/docs/en/dev/ir/01-hierarchy.md
@@ -518,6 +518,29 @@ func_orch = ir.Function("orchestrator", params, return_types, body, span, ir.Fun
 | `role_` | optional[Role] | Hierarchy role (auto-derived from `func_type_` for InCore/AIC/AIV/Group/Orchestration; see below) |
 | `attrs_` | list[(str, Any)] | Ordered free-form metadata, exposed as `UsualField` (participates in structural traversal) |
 
+### Reserved `attrs_` keys
+
+A key that one pass writes and another reads is a contract, and spelling it as a
+bare string literal at each site leaves that contract with no single point of
+rename. Reserved `Function` attr keys are therefore declared once per layer:
+
+| Layer | Declaration site |
+| ----- | ---------------- |
+| C++ | `include/pypto/ir/function.h` — `inline constexpr const char* kAttr...`, each with a lifecycle comment naming the writer pass, the readers, and whether the key is ever stripped |
+| Python | `python/pypto/_function_attrs.py` — `..._ATTR = "..."` for the subset the DSL, backend and JIT layers touch |
+
+`tests/lint/check_function_attr_key_parity.py` (a pre-commit hook) enforces
+three things: the two declaration sites agree on every key Python declares, the
+identifiers correspond (`kAttrDualAivDispatch` ↔ `DUAL_AIV_DISPATCH_ATTR`), and
+no other source spells one of the keys as a bare literal at a site that reads or
+writes `attrs`.
+
+Keys on other node kinds have their own owners and are not covered by this
+check: `Call` / `Submit` attrs are declared in `include/pypto/ir/expr.h`
+(`kAttrCoreNum`, `kAttrDevice`, `kAttrPredicate`, `kAttrManualDepEdges`, …), and
+`ForStmt` / pass-internal attrs in
+`include/pypto/ir/transforms/utils/attrs.h`.
+
 ### Auto-derivation of `level_` / `role_`
 
 For `func_type_` in {`InCore`, `AIC`, `AIV`, `Group`, `Orchestration`}, the

--- a/docs/zh/dev/ir/01-hierarchy.md
+++ b/docs/zh/dev/ir/01-hierarchy.md
@@ -472,6 +472,26 @@ func_orch = ir.Function("orchestrator", params, return_types, body, span, ir.Fun
 | `role_` | optional[Role] | 层次角色（对 InCore/AIC/AIV/Group/Orchestration 自动派生，详见下文） |
 | `attrs_` | list[(str, Any)] | 有序的自由形式元数据，以 `UsualField` 暴露（参与结构遍历） |
 
+### 保留的 `attrs_` 键
+
+一个 pass 写入、另一个 pass 读取的键是一份契约；若在每个站点都写成裸字符串字面量，
+这份契约就没有唯一的重命名入口。因此保留的 `Function` attr 键在每一层只声明一次：
+
+| 层 | 声明位置 |
+| -- | -------- |
+| C++ | `include/pypto/ir/function.h` — `inline constexpr const char* kAttr...`，每个键都带生命周期注释，说明写入 pass、读取方，以及该键是否会被剥离 |
+| Python | `python/pypto/_function_attrs.py` — `..._ATTR = "..."`，仅覆盖 DSL、后端与 JIT 层实际使用的子集 |
+
+`tests/lint/check_function_attr_key_parity.py`（pre-commit 钩子）强制三件事：
+两个声明位置对 Python 声明的每个键取值一致；标识符互相对应
+（`kAttrDualAivDispatch` ↔ `DUAL_AIV_DISPATCH_ATTR`）；其他源文件不得在读写
+`attrs` 的站点上把这些键写成裸字面量。
+
+其他节点类型的键各有归属，不在本检查范围内：`Call` / `Submit` 的 attr 声明在
+`include/pypto/ir/expr.h`（`kAttrCoreNum`、`kAttrDevice`、`kAttrPredicate`、
+`kAttrManualDepEdges` 等），`ForStmt` / pass 内部 attr 声明在
+`include/pypto/ir/transforms/utils/attrs.h`。
+
 ### `level_` / `role_` 自动派生
 
 当 `func_type_` 属于 {`InCore`, `AIC`, `AIV`, `Group`, `Orchestration`} 时，

--- a/include/pypto/ir/expr.h
+++ b/include/pypto/ir/expr.h
@@ -1227,7 +1227,7 @@ inline CallPtr SubmitToCallView(const SubmitPtr& submit) {
     // re-emitted below from core_num_ / sync_start_. Drop any stray attr of
     // the same key so the field stays the single source of truth (Call::GetAttr
     // returns the first match, so a stale attr would otherwise shadow it).
-    if (k != kAttrManualDepEdges && k != "core_num" && k != "sync_start" && k != "allow_early_resolve" &&
+    if (k != kAttrManualDepEdges && k != kAttrCoreNum && k != kAttrSyncStart && k != "allow_early_resolve" &&
         k != kAttrPredicate) {
       attrs.emplace_back(k, v);
     }
@@ -1264,8 +1264,8 @@ inline CallPtr SubmitToCallView(const SubmitPtr& submit) {
   // Spmd-wrapper function's attrs). core_num_/sync_start_ are first-class
   // Submit fields and never appear in submit->attrs_, so no duplication.
   if (submit->core_num_.has_value()) {
-    attrs.emplace_back("core_num", std::any(*submit->core_num_));
-    attrs.emplace_back("sync_start", std::any(submit->sync_start_));
+    attrs.emplace_back(kAttrCoreNum, std::any(*submit->core_num_));
+    attrs.emplace_back(kAttrSyncStart, std::any(submit->sync_start_));
   }
   // Speculative early-dispatch opt-in — surface as a Call-view attr so
   // orchestration codegen emits ``Arg::set_allow_early_resolve(true)``. Only

--- a/include/pypto/ir/function.h
+++ b/include/pypto/ir/function.h
@@ -385,6 +385,91 @@ inline ParamDirection StringToParamDirection(const std::string& str) {
 inline constexpr const char* kAttrSpmdUnwrapped = "spmd_unwrapped";
 
 /**
+ * @brief Reserved Function attr key marking an AIV kernel that runs on BOTH
+ * vector sub-lanes of a mixed kernel.
+ *
+ * Value type: ``bool``. Written by ``LowerAutoVectorSplit`` (pass 20) and
+ * ``SplitVectorKernel`` (pass 23) onto the AIV lane, and by
+ * ``ExpandMixedKernel`` (pass 21) for the backend-inferred no-split case
+ * (``BackendHandler::RequiresNoSplitDualAivDispatch``). Read by PTO codegen
+ * (``PTOCodegen::IsDualAivDispatchFunction`` — subblock-aware emission),
+ * orchestration codegen (both-lanes MixedKernel dispatch) and
+ * ``VerifyHardSyncallOccupancy`` (a dual-dispatched AIV kernel is a mixed-kernel
+ * lane, not a standalone AIV launch). Never stripped — it survives to codegen.
+ *
+ * Mode-agnostic on purpose: it states only "both AIV sub-lanes execute this
+ * body". The per-op split geometry rides the ``split`` attr / per-op ints, so a
+ * multi-mode ``pl.split_aiv`` function carries this marker with no
+ * function-level ``split`` mode at all.
+ */
+inline constexpr const char* kAttrDualAivDispatch = "dual_aiv_dispatch";
+
+/**
+ * @brief Reserved Function attr key marking an InCore function outlined from a
+ * scope that held ``pl.split_aiv`` region(s).
+ *
+ * Value type: ``bool``. Written by ``ScopeOutliner`` (pass 8) when it outlines a
+ * CORE_GROUP scope containing ``SplitAivScopeStmt`` regions, and re-stamped by
+ * ``LowerAutoVectorSplit`` (pass 20) on the functions it lowers. Read by
+ * ``SplitVectorKernel`` (pass 23, to stamp ``dual_aiv_dispatch`` without
+ * re-halving an already-lowered body), ``MemoryReuse`` (pass 33 — it gates the
+ * Ascend910B ``tile.load`` + ``tpop_from_aic`` in-place hazard guard) and
+ * ``VerifyAivSplit`` (provenance for the boundary-op checks). Never stripped.
+ *
+ * ``MemoryReuse`` keys on this marker rather than on ``Function::GetSplitMode``
+ * precisely because a multi-mode region function has no single function-level
+ * mode once pass 20 has lowered and erased the per-region ones — dropping the
+ * marker there silently disables a hardware-correctness guard.
+ */
+inline constexpr const char* kAttrSplitAiv = "split_aiv";
+
+/**
+ * @brief Reserved Function attr key recording that ``pl.split_aiv`` regions were
+ * already transpose-hazard-checked per region.
+ *
+ * Value type: ``bool``. Written by ``LowerAutoVectorSplit`` (pass 20), which
+ * validates each region against its own unambiguous mode. Read by
+ * ``ExpandMixedKernel`` (pass 21) to skip its single-function-mode transpose
+ * check, which would otherwise mis-check a multi-mode function against whichever
+ * mode happened to be stamped function-level. Never stripped.
+ */
+inline constexpr const char* kAttrSplitAivRegionValidated = "split_aiv_region_validated";
+
+/**
+ * @brief Reserved Function attr key naming a hand-written external C++ kernel
+ * source.
+ *
+ * Value type: ``std::string`` (an absolute path). Written by the
+ * ``@pl.function(external_source=...)`` decorator; the function's DSL body is
+ * then an empty ``...``. Read by ``ExpandMixedKernel`` (external members cannot
+ * be ABI-normalised or inferred into dual dispatch),
+ * ``VerifyReturnParamsExplicit`` (a declaration-only body legitimately has no
+ * ``ReturnStmt``), the Python printer, and the backend, which compiles the named
+ * ``.cpp`` in place of PyPTO codegen. Never stripped.
+ *
+ * Decorator-only: the printer emits it as an ``@pl.function(external_source=...)``
+ * keyword rather than a ``pl.func_attr({...})`` body prologue, because the parser
+ * must read it before it walks the body. Kept in sync with the parser's
+ * ``_DECORATOR_ONLY_FUNC_ATTRS``.
+ */
+inline constexpr const char* kAttrExternalSource = "external_source";
+
+/**
+ * @brief Reserved Function attr key opting a function out of automatic
+ * ``RuntimeScopeStmt`` materialization.
+ *
+ * Value type: ``bool``; **absent means true**, so only the opt-out (``false``)
+ * is ever stored. Written by the ``@pl.function(auto_scope=False)`` decorator and
+ * by ``MaterializeRuntimeScopes`` (pass 44), which stamps ``false`` on the
+ * functions it has already processed. Read by that same pass (idempotence),
+ * ``AutoDeriveTaskDependencies`` (pass 38), ``VerifyRuntimeScopesMaterialized``
+ * and the Python printer.
+ *
+ * Decorator-only, for the same reason as ``kAttrExternalSource`` — see there.
+ */
+inline constexpr const char* kAttrAutoScope = "auto_scope";
+
+/**
  * @brief Function definition
  *
  * Represents a complete function definition with name, parameters, return types, and body.

--- a/python/pypto/_function_attrs.py
+++ b/python/pypto/_function_attrs.py
@@ -1,0 +1,49 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Reserved ``Function.attrs`` keys shared between the DSL, the backend and the JIT.
+
+Every key here is also declared in C++ as an ``inline constexpr const char*`` in
+``include/pypto/ir/function.h``, which carries the authoritative lifecycle
+documentation for each one (which pass writes it, which reads it, whether it is
+ever stripped). This module is the Python half of the same pair so a rename has
+one place to change per layer instead of one place per call site.
+
+``tests/lint/check_function_attr_key_parity.py`` fails when the two halves
+disagree, so a key added or renamed on one side cannot silently drift from the
+other.
+"""
+
+# AIV kernel running on BOTH vector sub-lanes of a mixed kernel (bool).
+DUAL_AIV_DISPATCH_ATTR = "dual_aiv_dispatch"
+
+# InCore function outlined from a scope holding ``pl.split_aiv`` region(s) (bool).
+SPLIT_AIV_ATTR = "split_aiv"
+
+# ``pl.split_aiv`` regions already transpose-hazard-checked per region (bool).
+SPLIT_AIV_REGION_VALIDATED_ATTR = "split_aiv_region_validated"
+
+# Absolute path to a hand-written external C++ kernel source (str). When present
+# on an AIC/AIV function the DSL body is empty (``...``): the compiler assigns the
+# function a kernel func_id and emits the orchestration submit as usual, but skips
+# PyPTO codegen and instead compiles the referenced ``.cpp`` as the InCore kernel
+# (see pto_backend).
+EXTERNAL_SOURCE_ATTR = "external_source"
+
+# Opt-out of automatic ``RuntimeScopeStmt`` materialization (bool). Absent means
+# True, so only the opt-out (False) is ever stored.
+AUTO_SCOPE_ATTR = "auto_scope"
+
+__all__ = [
+    "AUTO_SCOPE_ATTR",
+    "DUAL_AIV_DISPATCH_ATTR",
+    "EXTERNAL_SOURCE_ATTR",
+    "SPLIT_AIV_ATTR",
+    "SPLIT_AIV_REGION_VALIDATED_ATTR",
+]

--- a/python/pypto/backend/pto_backend.py
+++ b/python/pypto/backend/pto_backend.py
@@ -38,6 +38,7 @@ except ImportError:  # pragma: no cover - fallback for older interpreters
 from typing import Any
 
 from pypto._external_source import EXTERNAL_INCLUDE_DIRS_ATTR, decode_external_include_dirs
+from pypto._function_attrs import DUAL_AIV_DISPATCH_ATTR, EXTERNAL_SOURCE_ATTR
 from pypto.backend._ptoas_locate import PTOAS_RELATIVE_PATHS as _PTOAS_RELATIVE_PATHS
 from pypto.backend._ptoas_locate import find_ptoas_binary as _find_ptoas_binary
 from pypto.backend._ptoas_preprocess import preprocess_ptoas_output as _preprocess_ptoas_output
@@ -723,7 +724,7 @@ def _requires_dual_aiv_dispatch(func: _ir_core.Function) -> bool:
     split_mode = getattr(func, "split", None)
     if split_mode is not None and split_mode != _ir_core.SplitMode.NONE:
         return True
-    return bool(getattr(func, "attrs", {}).get("dual_aiv_dispatch", False))
+    return bool(getattr(func, "attrs", {}).get(DUAL_AIV_DISPATCH_ATTR, False))
 
 
 def _uses_spmd_block_ops(func: _ir_core.Function) -> bool:
@@ -1187,7 +1188,7 @@ def _external_source_of(func: _ir_core.Function) -> str | None:
     this original path in the manifest (so its sibling files stay reachable),
     instead of generating a kernel.
     """
-    return dict(func.attrs).get("external_source")
+    return dict(func.attrs).get(EXTERNAL_SOURCE_ATTR)
 
 
 def _external_include_dirs_of(func: _ir_core.Function) -> tuple[str, ...]:

--- a/python/pypto/debug/torch_codegen.py
+++ b/python/pypto/debug/torch_codegen.py
@@ -20,6 +20,7 @@ import torch
 import pypto.language as pl
 from pypto import DataType
 from pypto import ir as _ir
+from pypto._function_attrs import DUAL_AIV_DISPATCH_ATTR
 
 # ---------------------------------------------------------------------------
 # DataType -> torch dtype string
@@ -854,7 +855,7 @@ def _build_group_meta(program: _ir.Program) -> dict[str, dict[str, Any]]:
             split = _split_mode_to_int(func.split)
             if split == 0:
                 split = _split_mode_to_int(aiv_func.split)
-        dual_aiv_dispatch = bool(getattr(aiv_func, "attrs", {}).get("dual_aiv_dispatch", False))
+        dual_aiv_dispatch = bool(getattr(aiv_func, "attrs", {}).get(DUAL_AIV_DISPATCH_ATTR, False))
         group_meta[func.name] = {
             "aic": aic_name,
             "aiv": aiv_name,

--- a/python/pypto/jit/specializer.py
+++ b/python/pypto/jit/specializer.py
@@ -44,6 +44,7 @@ from dataclasses import dataclass, field
 from typing import Any, cast
 
 from pypto._external_source import EXTERNAL_INCLUDE_DIRS_ATTR, encode_external_include_dirs
+from pypto._function_attrs import DUAL_AIV_DISPATCH_ATTR
 from pypto.language.typing.array import Array as _LangArray
 from pypto.pypto_core import DataType
 from pypto.pypto_core.ir import TensorLayout
@@ -1864,7 +1865,7 @@ class Specializer:
                 encoded_include_dirs = encode_external_include_dirs(ctx.external_include_dirs)
                 function_attrs.append(f'"{EXTERNAL_INCLUDE_DIRS_ATTR}": {encoded_include_dirs!r}')
             if dual_aiv_dispatch:
-                function_attrs.append('"dual_aiv_dispatch": True')
+                function_attrs.append(f'"{DUAL_AIV_DISPATCH_ATTR}": True')
             attrs = f", attrs={{{', '.join(function_attrs)}}}" if function_attrs else ""
             return [
                 f"@pl.function(type=pl.FunctionType.{core_upper}, external_source={source!r}{attrs})",

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -18,6 +18,7 @@ from contextlib import contextmanager
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, TypeGuard, cast
 
+from pypto._function_attrs import AUTO_SCOPE_ATTR, EXTERNAL_SOURCE_ATTR
 from pypto.ir import IRBuilder
 from pypto.ir import op as ir_op
 from pypto.ir.printer import python_print
@@ -90,7 +91,7 @@ _OMIT_ATTR: Any = object()
 #   - ``external_source`` selects the no-DSL-body path entirely (the body must
 #                         be a bare ``...``, so there is nowhere to put a
 #                         prologue in the first place)
-_DECORATOR_ONLY_FUNC_ATTRS: frozenset[str] = frozenset({"auto_scope", "external_source"})
+_DECORATOR_ONLY_FUNC_ATTRS: frozenset[str] = frozenset({AUTO_SCOPE_ATTR, EXTERNAL_SOURCE_ATTR})
 
 # Enum values that op wrappers and printed ``attrs={...}`` dicts take verbatim.
 # ``parse_expression`` cannot represent these: it either rejects the standalone
@@ -981,8 +982,8 @@ class ASTParser:
         func_name = func_def.name
         self._func_name = func_name
         self._func_level = func_level
-        # auto_scope rides in func_attrs (key "auto_scope"); absent ⇒ default True.
-        self._func_auto_scope = bool((func_attrs or {}).get("auto_scope", True))
+        # auto_scope rides in func_attrs; absent ⇒ default True.
+        self._func_auto_scope = bool((func_attrs or {}).get(AUTO_SCOPE_ATTR, True))
         self._func_type = func_type
         self._param_dim_symbols = set()
         func_span = self.span_tracker.get_span(func_def)
@@ -1075,7 +1076,7 @@ class ASTParser:
 
             # Parse function body. HOST SubWorkers carry pure-Python source
             # via ``inline_body`` and are not parsed as DSL.
-            external_source = (func_attrs or {}).get("external_source")
+            external_source = (func_attrs or {}).get(EXTERNAL_SOURCE_ATTR)
             if external_source is not None:
                 # Header-only external C++ kernel: no DSL body to parse. The
                 # signature (params + directions + return types) is the contract

--- a/python/pypto/language/parser/decorator.py
+++ b/python/pypto/language/parser/decorator.py
@@ -20,6 +20,7 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Any, TypeAlias, TypeVar, cast, overload
 
+from pypto._function_attrs import AUTO_SCOPE_ATTR, EXTERNAL_SOURCE_ATTR
 from pypto.compile_profiling import CompileProfiler, get_active_profiler
 from pypto.pypto_core import ir
 
@@ -532,14 +533,6 @@ def _expr_references_ssa(expr: ir.Expr) -> bool:
     return finder.found
 
 
-# Function-attr key carrying the path to a hand-written external C++ kernel
-# source. When present on an AIC/AIV function, the DSL body is empty (``...``):
-# the compiler assigns the function a kernel func_id and emits the orchestration
-# submit as usual, but skips PyPTO codegen and instead compiles the referenced
-# ``.cpp`` as the InCore kernel (see pto_backend). Stored as an absolute path str.
-EXTERNAL_SOURCE_ATTR = "external_source"
-
-
 def _resolve_external_source(external_source: str | Path, caller_frame: Any) -> str:
     """Resolve an ``external_source`` argument to an absolute file path string.
 
@@ -1021,7 +1014,7 @@ def function(
             func_attrs = _normalize_attrs(attrs) if attrs is not None else None
             # Fold auto_scope=False into attrs (absent ⇒ default True).
             if auto_scope is False:
-                func_attrs = {**(func_attrs or {}), "auto_scope": False}
+                func_attrs = {**(func_attrs or {}), AUTO_SCOPE_ATTR: False}
             # Fold external_source into attrs — marks this as a header-only
             # external kernel (empty ``...`` body, backed by hand-written C++).
             if resolved_external_source is not None:
@@ -1266,7 +1259,7 @@ def program(cls: type | None = None, *, strict_ssa: bool = False) -> ir.Program 
                 # MaterializeRuntimeScopes and the parser both read attrs["auto_scope"].
                 func_auto_scope = _extract_function_auto_scope_from_decorator(func_def)
                 if func_auto_scope is False:
-                    func_attrs["auto_scope"] = False
+                    func_attrs[AUTO_SCOPE_ATTR] = False
 
                 # External C++ kernel: @pl.function(external_source=...) stashed the
                 # resolved path on the method object (the value is a runtime Path

--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -109,8 +109,6 @@ CoreType InferFunctionCoreType(const FunctionPtr& func) {
 
 namespace {
 
-constexpr const char* kDualAivDispatchAttr = "dual_aiv_dispatch";
-
 const char* ParamDirectionToRuntimeName(ParamDirection dir) {
   switch (dir) {
     case ParamDirection::In:
@@ -176,7 +174,7 @@ std::string GenerateConfigFunction(int expected_arg_count) {
 // because their hand-written source owns sub-lane partitioning.
 bool RequiresDualAivDispatch(const FunctionPtr& aiv_func) {
   if (aiv_func == nullptr) return false;
-  return aiv_func->HasAttr(kDualAivDispatchAttr) && aiv_func->GetAttr<bool>(kDualAivDispatchAttr, false);
+  return aiv_func->HasAttr(kAttrDualAivDispatch) && aiv_func->GetAttr<bool>(kAttrDualAivDispatch, false);
 }
 
 // Returns the opening of a rt_submit_{aic,aiv}_task call.

--- a/src/codegen/pto/pto_codegen.cpp
+++ b/src/codegen/pto/pto_codegen.cpp
@@ -2021,8 +2021,8 @@ bool PTOCodegen::IsAIVFunction() const {
 }
 
 bool PTOCodegen::IsDualAivDispatchFunction() const {
-  return fs_.current_function && fs_.current_function->HasAttr("dual_aiv_dispatch") &&
-         fs_.current_function->GetAttr<bool>("dual_aiv_dispatch", false);
+  return fs_.current_function && fs_.current_function->HasAttr(ir::kAttrDualAivDispatch) &&
+         fs_.current_function->GetAttr<bool>(ir::kAttrDualAivDispatch, false);
 }
 
 void PTOCodegen::EmitExtraAllocTiles() {

--- a/src/ir/transforms/auto_derive_task_dependencies_pass.cpp
+++ b/src/ir/transforms/auto_derive_task_dependencies_pass.cpp
@@ -2267,7 +2267,7 @@ Pass AutoDeriveTaskDependencies(bool analyze_auto_scopes) {
 
       const bool analyze_whole_body_as_auto_scope = analyze_auto_scopes &&
                                                     func->func_type_ == FunctionType::Orchestration &&
-                                                    func->GetAttr<bool>("auto_scope", true);
+                                                    func->GetAttr<bool>(kAttrAutoScope, true);
       AutoDepMutator mutator(program, &storage, &task_ids.task_id_by_expr(), &task_ids.task_id_by_var_id(),
                              &task_ids.task_ids_by_var_id(), &task_ids.task_id_dynamic_slots_by_var_id(),
                              &task_ids.task_id_array_extent_by_var_id(), &task_ids.task_ids_by_array_var_id(),

--- a/src/ir/transforms/expand_mixed_kernel_pass.cpp
+++ b/src/ir/transforms/expand_mixed_kernel_pass.cpp
@@ -65,8 +65,6 @@ namespace ir {
 
 namespace {
 
-constexpr const char* kDualAivDispatchAttr = "dual_aiv_dispatch";
-
 using core_affinity::ClassifyCallAffinity;
 using core_affinity::ClassifyMoveDirection;
 using core_affinity::CombineAffinity;
@@ -1147,7 +1145,7 @@ ExpandedKernel ExpandMixedFunction(const FunctionPtr& func, bool create_group = 
   // the single-func-mode check for them. A multi-mode function carries no single
   // ``func->GetSplitMode()`` and this whole-function check would mis-check the
   // other region's axis (critique #2).
-  if (!func->HasAttr("split_aiv_region_validated")) {
+  if (!func->HasAttr(kAttrSplitAivRegionValidated)) {
     if (auto mode = func->GetSplitMode(); mode.has_value() && *mode != SplitMode::None) {
       int split_dim = (*mode == SplitMode::UpDown) ? 0 : 1;
       auto hazard = split_axis::FindTransposeSplitHazard(func->body_, split_dim);
@@ -1364,9 +1362,9 @@ ExpandedKernel ExpandMixedFunction(const FunctionPtr& func, bool create_group = 
   auto aiv_attrs = func->attrs_;
   if (needs_dual_aiv_dispatch) {
     aiv_attrs.erase(std::remove_if(aiv_attrs.begin(), aiv_attrs.end(),
-                                   [](const auto& kv) { return kv.first == kDualAivDispatchAttr; }),
+                                   [](const auto& kv) { return kv.first == kAttrDualAivDispatch; }),
                     aiv_attrs.end());
-    aiv_attrs.emplace_back(kDualAivDispatchAttr, true);
+    aiv_attrs.emplace_back(kAttrDualAivDispatch, true);
   }
   auto aiv_func = std::make_shared<Function>(aiv_name, aiv_params, func->param_directions_,
                                              func->return_types_, aiv_cloned_body, func->span_,
@@ -1587,7 +1585,7 @@ bool NeedsInferredNoSplitDualAivDispatch(const FunctionPtr& func) {
   const auto* backend_handler = pass_context ? pass_context->GetBackendHandler()
                                              : pypto::backend::BackendConfig::GetBackend()->GetHandler();
   if (!backend_handler->RequiresNoSplitDualAivDispatch() ||
-      func->GetAttr<bool>(kDualAivDispatchAttr, false) || func->HasAttr("external_source") ||
+      func->GetAttr<bool>(kAttrDualAivDispatch, false) || func->HasAttr(kAttrExternalSource) ||
       func->requires_runtime_binding_) {
     return false;
   }
@@ -1604,9 +1602,9 @@ FunctionPtr WithDualAivDispatch(const FunctionPtr& func) {
   auto result = MutableCopy(func);
   auto attrs = result->attrs_;
   attrs.erase(std::remove_if(attrs.begin(), attrs.end(),
-                             [](const auto& kv) { return kv.first == kDualAivDispatchAttr; }),
+                             [](const auto& kv) { return kv.first == kAttrDualAivDispatch; }),
               attrs.end());
-  attrs.emplace_back(kDualAivDispatchAttr, true);
+  attrs.emplace_back(kAttrDualAivDispatch, true);
   result->attrs_ = std::move(attrs);
   return result;
 }
@@ -1821,10 +1819,11 @@ NormalizedGroups NormalizeHandWrittenGroupAbis(const ProgramPtr& program,
     if (!needs_abi_normalization && !needs_dual_aiv_dispatch) continue;
 
     if (needs_abi_normalization) {
-      CHECK_SPAN(
-          !aic.inner_callee->HasAttr("external_source") && !aiv.inner_callee->HasAttr("external_source") &&
-              !aic.inner_callee->requires_runtime_binding_ && !aiv.inner_callee->requires_runtime_binding_,
-          group->span_)
+      CHECK_SPAN(!aic.inner_callee->HasAttr(kAttrExternalSource) &&
+                     !aiv.inner_callee->HasAttr(kAttrExternalSource) &&
+                     !aic.inner_callee->requires_runtime_binding_ &&
+                     !aiv.inner_callee->requires_runtime_binding_,
+                 group->span_)
           << "Mixed Group '" << group->name_
           << "' has AIC/AIV members with different argument layouts. External or runtime-bound members "
              "cannot be adapted; declare both members with the same signature and forward the Group's full "

--- a/src/ir/transforms/lower_auto_vector_split_pass.cpp
+++ b/src/ir/transforms/lower_auto_vector_split_pass.cpp
@@ -94,12 +94,6 @@ using split_axis::ProcessStmts;
 using split_axis::SplitDimension;
 using split_axis::TileInfo;
 
-constexpr const char* kDualAivDispatchAttr = "dual_aiv_dispatch";
-constexpr const char* kSplitAivAttr = "split_aiv";
-// Stamped by the explicit-region path so ExpandMixedKernel (pass 21) skips its
-// single-func-mode transpose-hazard check (validated per-region here instead).
-constexpr const char* kSplitAivRegionValidatedAttr = "split_aiv_region_validated";
-
 CallPtr AsCall(const ExprPtr& expr) { return std::dynamic_pointer_cast<const Call>(expr); }
 
 // Defined below LowerStmts; forward-declared so the LowerStmts SplitAivScopeStmt
@@ -1074,11 +1068,11 @@ FunctionPtr LowerExplicitRegionFunction(const FunctionPtr& func) {
   auto attrs = func->attrs_;
   attrs.erase(std::remove_if(attrs.begin(), attrs.end(),
                              [](const auto& kv) {
-                               return kv.first == kSplitAivAttr || kv.first == kSplitAivRegionValidatedAttr;
+                               return kv.first == kAttrSplitAiv || kv.first == kAttrSplitAivRegionValidated;
                              }),
               attrs.end());
-  attrs.emplace_back(kSplitAivAttr, true);
-  attrs.emplace_back(kSplitAivRegionValidatedAttr, true);
+  attrs.emplace_back(kAttrSplitAiv, true);
+  attrs.emplace_back(kAttrSplitAivRegionValidated, true);
 
   auto new_func = MutableCopy(func);
   new_func->body_ = cloned_body;
@@ -1090,12 +1084,12 @@ std::vector<std::pair<std::string, std::any>> WithSplitAivAttrs(const FunctionPt
   auto attrs = func->attrs_;
   attrs.erase(std::remove_if(attrs.begin(), attrs.end(),
                              [](const auto& kv) {
-                               return kv.first == "split" || kv.first == kSplitAivAttr ||
-                                      kv.first == kDualAivDispatchAttr;
+                               return kv.first == "split" || kv.first == kAttrSplitAiv ||
+                                      kv.first == kAttrDualAivDispatch;
                              }),
               attrs.end());
   attrs.emplace_back("split", static_cast<int>(mode));
-  attrs.emplace_back(kSplitAivAttr, true);
+  attrs.emplace_back(kAttrSplitAiv, true);
   return attrs;
 }
 
@@ -1141,7 +1135,7 @@ FunctionPtr LowerFunction(const FunctionPtr& func, SplitMode mode) {
 }
 
 bool IsAlreadyExplicitSplitAiv(const FunctionPtr& func) {
-  return func->HasAttr(kSplitAivAttr) && func->GetAttr<bool>(kSplitAivAttr, false);
+  return func->HasAttr(kAttrSplitAiv) && func->GetAttr<bool>(kAttrSplitAiv, false);
 }
 
 // Roll up the cross-core affinity of a statement list, mirroring

--- a/src/ir/transforms/materialize_runtime_scopes_pass.cpp
+++ b/src/ir/transforms/materialize_runtime_scopes_pass.cpp
@@ -245,7 +245,7 @@ Pass MaterializeRuntimeScopes() {
     // ``pl.manual_scope()``), which the parser already materialised into the
     // IR. The simpler runtime's implicit top-level scope covers correctness, so
     // emitting zero compiler scopes is valid. Leave such functions untouched.
-    if (!func->GetAttr<bool>("auto_scope", true)) return func;
+    if (!func->GetAttr<bool>(kAttrAutoScope, true)) return func;
 
     const bool whole_layer_manual = func->GetAttr<bool>(kAttrCompilerAutoManualLayerCandidate, false);
     StmtPtr inner = func->body_;
@@ -268,11 +268,11 @@ Pass MaterializeRuntimeScopes() {
     std::vector<std::pair<std::string, std::any>> new_attrs;
     new_attrs.reserve(func->attrs_.size() + 1);
     for (const auto& kv : func->attrs_) {
-      if (kv.first != "auto_scope" && kv.first != kAttrCompilerAutoManualLayerCandidate) {
+      if (kv.first != kAttrAutoScope && kv.first != kAttrCompilerAutoManualLayerCandidate) {
         new_attrs.push_back(kv);
       }
     }
-    new_attrs.emplace_back("auto_scope", std::any(false));
+    new_attrs.emplace_back(kAttrAutoScope, std::any(false));
 
     return std::make_shared<Function>(func->name_, func->params_, func->param_directions_,
                                       func->return_types_, new_body, func->span_, func->func_type_,

--- a/src/ir/transforms/memory_reuse_pass.cpp
+++ b/src/ir/transforms/memory_reuse_pass.cpp
@@ -1661,7 +1661,7 @@ bool NeedsLoadTpopHazardGuard(const FunctionPtr& func) {
   // pl.split_aiv regions have their per-region modes lowered + erased by
   // LowerAutoVectorSplit, so no single function-level mode survives. Key on the
   // marker too so the guard still fires for them.
-  if (func->HasAttr("split_aiv") && func->GetAttr<bool>("split_aiv", false)) return true;
+  if (func->HasAttr(kAttrSplitAiv) && func->GetAttr<bool>(kAttrSplitAiv, false)) return true;
   const auto split_mode = func->GetSplitMode();
   return split_mode.has_value() && *split_mode != SplitMode::None;
 }

--- a/src/ir/transforms/python_printer.cpp
+++ b/src/ir/transforms/python_printer.cpp
@@ -2518,7 +2518,7 @@ void IRPythonPrinter::VisitFunction(const FunctionPtr& func) {
   // deprecated ``attrs=`` keyword and the compiler never warns on its own
   // output. Kept in sync with the parser's ``_DECORATOR_ONLY_FUNC_ATTRS``.
   auto is_filtered_attr = [](const std::string& k, const std::any& v) {
-    if (k == "auto_scope" || k == "external_source") return true;
+    if (k == kAttrAutoScope || k == kAttrExternalSource) return true;
     if (k != "split") return false;
     const int* split_value = std::any_cast<int>(&v);
     return split_value != nullptr && *split_value == static_cast<int>(SplitMode::None);
@@ -2540,8 +2540,8 @@ void IRPythonPrinter::VisitFunction(const FunctionPtr& func) {
     bool has_level = func->level_.has_value();
     bool has_role = func->role_.has_value();
     // Absent ⇒ default True ⇒ not printed.
-    bool auto_scope_off = !func->GetAttr<bool>("auto_scope", true);
-    std::string external_source = func->GetAttr<std::string>("external_source", "");
+    bool auto_scope_off = !func->GetAttr<bool>(kAttrAutoScope, true);
+    std::string external_source = func->GetAttr<std::string>(kAttrExternalSource, "");
     if (has_type || has_level || has_role || auto_scope_off || !external_source.empty()) {
       stream_ << "(";
       bool first = true;

--- a/src/ir/transforms/split_vector_kernel_pass.cpp
+++ b/src/ir/transforms/split_vector_kernel_pass.cpp
@@ -50,9 +50,6 @@ namespace ir {
 
 namespace {
 
-constexpr const char* kDualAivDispatchAttr = "dual_aiv_dispatch";
-constexpr const char* kExternalSourceAttr = "external_source";
-
 using split_axis::InjectSubblockIdx;
 using split_axis::ProcessStmts;
 using split_axis::SplitDimension;
@@ -62,7 +59,7 @@ bool RequiresNoSplitDualAivSync(const FunctionPtr& func) {
   return func != nullptr && func->func_type_ == FunctionType::AIV &&
          pypto::backend::BackendConfig::IsConfigured() &&
          pypto::ir::PassContext::Current()->GetBackendHandler()->RequiresNoSplitDualAivDispatch() &&
-         func->HasAttr(kDualAivDispatchAttr) && func->GetAttr<bool>(kDualAivDispatchAttr, false);
+         func->HasAttr(kAttrDualAivDispatch) && func->GetAttr<bool>(kAttrDualAivDispatch, false);
 }
 
 // ---------------------------------------------------------------------------
@@ -158,7 +155,7 @@ std::vector<std::pair<std::string, std::any>> WithSplitAttrs(const FunctionPtr& 
   auto attrs = func->attrs_;
   attrs.erase(
       std::remove_if(attrs.begin(), attrs.end(),
-                     [](const auto& kv) { return kv.first == "split" || kv.first == kDualAivDispatchAttr; }),
+                     [](const auto& kv) { return kv.first == "split" || kv.first == kAttrDualAivDispatch; }),
       attrs.end());
   if (mode != SplitMode::None) {
     attrs.emplace_back("split", static_cast<int>(mode));
@@ -166,7 +163,7 @@ std::vector<std::pair<std::string, std::any>> WithSplitAttrs(const FunctionPtr& 
     // codegen. Stamp the attribute here so codegen reads it directly instead
     // of re-deriving from SplitMode.
     if (is_aiv) {
-      attrs.emplace_back(kDualAivDispatchAttr, true);
+      attrs.emplace_back(kAttrDualAivDispatch, true);
     }
   }
   return attrs;
@@ -596,23 +593,23 @@ Pass SplitVectorKernel() {
       // External kernels are signature-only declarations. Their hand-written
       // source owns sub-lane partitioning, so preserve launch attrs but never
       // synthesize a DSL body (which would violate the external-source contract).
-      if (func->HasAttr(kExternalSourceAttr)) {
+      if (func->HasAttr(kAttrExternalSource)) {
         if (func->func_type_ == FunctionType::AIV) {
           auto explicit_mode = func->GetSplitMode();
-          bool split_aiv = func->HasAttr("split_aiv") && func->GetAttr<bool>("split_aiv", false);
+          bool split_aiv = func->HasAttr(kAttrSplitAiv) && func->GetAttr<bool>(kAttrSplitAiv, false);
           if (explicit_mode.has_value() && explicit_mode.value() != SplitMode::None) {
             auto external_func = MutableCopy(func);
             external_func->attrs_ = WithSplitAttrs(func, explicit_mode.value(), /*is_aiv=*/true);
             new_functions.push_back(external_func);
             changed = true;
             continue;
-          } else if (split_aiv && !func->GetAttr<bool>(kDualAivDispatchAttr, false)) {
+          } else if (split_aiv && !func->GetAttr<bool>(kAttrDualAivDispatch, false)) {
             auto external_func = MutableCopy(func);
             auto attrs = external_func->attrs_;
             attrs.erase(std::remove_if(attrs.begin(), attrs.end(),
-                                       [](const auto& kv) { return kv.first == kDualAivDispatchAttr; }),
+                                       [](const auto& kv) { return kv.first == kAttrDualAivDispatch; }),
                         attrs.end());
-            attrs.emplace_back(kDualAivDispatchAttr, true);
+            attrs.emplace_back(kAttrDualAivDispatch, true);
             external_func->attrs_ = std::move(attrs);
             new_functions.push_back(external_func);
             changed = true;
@@ -634,7 +631,7 @@ Pass SplitVectorKernel() {
       // function reaches here split_aiv-marked, so re-halving here would
       // double-halve the (already-half) body.
       if ((func->func_type_ == FunctionType::AIV || func->func_type_ == FunctionType::AIC) &&
-          func->HasAttr("split_aiv") && func->GetAttr<bool>("split_aiv", false)) {
+          func->HasAttr(kAttrSplitAiv) && func->GetAttr<bool>(kAttrSplitAiv, false)) {
         auto explicit_mode = func->GetSplitMode();
         auto new_func = MutableCopy(func);
         if (explicit_mode.has_value() && explicit_mode.value() != SplitMode::None) {
@@ -651,10 +648,10 @@ Pass SplitVectorKernel() {
           // stamping here (all RequiresDualAivDispatch consults).
           auto attrs = func->attrs_;
           attrs.erase(std::remove_if(attrs.begin(), attrs.end(),
-                                     [](const auto& kv) { return kv.first == kDualAivDispatchAttr; }),
+                                     [](const auto& kv) { return kv.first == kAttrDualAivDispatch; }),
                       attrs.end());
           if (func->func_type_ == FunctionType::AIV) {
-            attrs.emplace_back(kDualAivDispatchAttr, true);
+            attrs.emplace_back(kAttrDualAivDispatch, true);
           }
           new_func->attrs_ = std::move(attrs);
         }

--- a/src/ir/transforms/utils/scope_outline_utils.cpp
+++ b/src/ir/transforms/utils/scope_outline_utils.cpp
@@ -1264,7 +1264,7 @@ StmtPtr ScopeOutliner::OutlineScope(const ScopeStmtPtr& op,
            "split would otherwise be silently dropped (the per-region split governs the lanes). "
            "To pin a custom cross-core slot count, use "
            "optimizations=[pl.cross_core_slot(slot_num=N)], which is orthogonal to splitting.";
-    outlined_attrs.emplace_back("split_aiv", true);
+    outlined_attrs.emplace_back(kAttrSplitAiv, true);
     // Stamp a function-level representative ``split`` mode ONLY when all regions
     // share one mode (``uniform_mode``) AND that mode is a real split. Differing
     // sibling modes have no single representative: leave the function-level mode

--- a/src/ir/verifier/verify_aiv_split.cpp
+++ b/src/ir/verifier/verify_aiv_split.cpp
@@ -37,13 +37,6 @@ namespace ir {
 
 namespace {
 
-/// Function attr recording that ``OutlineIncoreScopes`` minted this InCore
-/// function by outlining a CORE_GROUP scope that held ``pl.split_aiv`` regions.
-/// Written in ``scope_outline_utils.cpp`` and re-stamped by ``LowerAutoVectorSplit``;
-/// read here as the provenance signal for check (h). Kept as a literal for the
-/// same reason both producers do — it is a plain attr key, not an operator name.
-constexpr const char* kSplitAivAttr = "split_aiv";
-
 /// Everything that differs between the two split-axis boundary ops: the memory
 /// space each side must carry, plus the direction-specific diagnostic wording.
 /// Keeping it in one table row per op means a reader (and an editor) sees the
@@ -589,9 +582,12 @@ class AivSplitValidPropertyVerifierImpl : public PropertyVerifier {
       // the body can still establish.
       FunctionSplitFactScanner scanner;
       scanner.VisitStmt(func->body_);
+      // ``kAttrSplitAiv`` (function.h) is the provenance signal for check (h):
+      // ScopeOutliner stamps it when it outlines a scope holding pl.split_aiv
+      // regions, and LowerAutoVectorSplit re-stamps it on the lowered result.
       SplitAivStructuralVerifier verifier(
           diagnostics, scanner.facts(), func->func_type_ == FunctionType::InCore,
-          func->HasAttr(kSplitAivAttr) && func->GetAttr<bool>(kSplitAivAttr, false));
+          func->HasAttr(kAttrSplitAiv) && func->GetAttr<bool>(kAttrSplitAiv, false));
       verifier.VisitStmt(func->body_);
     }
   }

--- a/src/ir/verifier/verify_hard_syncall_occupancy.cpp
+++ b/src/ir/verifier/verify_hard_syncall_occupancy.cpp
@@ -411,7 +411,13 @@ class HardSyncallOccupancyVerifierImpl : public PropertyVerifier {
     // satisfiable; a mix / aic_only barrier waits for CUBE cores that no AIV-only
     // launch provides. (A dual-AIV-dispatched AIV kernel is a mixed-kernel lane
     // reached via Group, handled by the Group branch — not a standalone launch.)
-    if (kernel->func_type_ == FunctionType::AIV && !kernel->HasAttr(kAttrDualAivDispatch)) {
+    //
+    // Read the VALUE, not just the key: ``kAttrDualAivDispatch`` is declared bool
+    // and ``HasAttr`` ignores the value, so an explicit ``dual_aiv_dispatch=False``
+    // would suppress this check on a kernel that is NOT dual-dispatched. Every
+    // other reader of the key (both codegens, SplitVectorKernel) already reads the
+    // value; this arm was the one that did not.
+    if (kernel->func_type_ == FunctionType::AIV && !kernel->GetAttr<bool>(kAttrDualAivDispatch, false)) {
       for (const auto& hs : HardSyncallsCached(kernel, syncalls)) {
         if (hs.core_type != "aiv_only") {
           diagnostics.emplace_back(DiagnosticSeverity::Error, "HardSyncallOccupancy", 0,

--- a/src/ir/verifier/verify_hard_syncall_occupancy.cpp
+++ b/src/ir/verifier/verify_hard_syncall_occupancy.cpp
@@ -411,7 +411,7 @@ class HardSyncallOccupancyVerifierImpl : public PropertyVerifier {
     // satisfiable; a mix / aic_only barrier waits for CUBE cores that no AIV-only
     // launch provides. (A dual-AIV-dispatched AIV kernel is a mixed-kernel lane
     // reached via Group, handled by the Group branch — not a standalone launch.)
-    if (kernel->func_type_ == FunctionType::AIV && !kernel->HasAttr("dual_aiv_dispatch")) {
+    if (kernel->func_type_ == FunctionType::AIV && !kernel->HasAttr(kAttrDualAivDispatch)) {
       for (const auto& hs : HardSyncallsCached(kernel, syncalls)) {
         if (hs.core_type != "aiv_only") {
           diagnostics.emplace_back(DiagnosticSeverity::Error, "HardSyncallOccupancy", 0,

--- a/src/ir/verifier/verify_return_params_explicit.cpp
+++ b/src/ir/verifier/verify_return_params_explicit.cpp
@@ -42,7 +42,7 @@ class ReturnParamsExplicitVerifierImpl : public PropertyVerifier {
       // External C++ kernels are header-only declarations (empty '...' body); the
       // implementation lives in the hand-written source named by "external_source".
       // They legitimately have no ReturnStmt, so exempt them from this property.
-      if (func->HasAttr("external_source")) continue;
+      if (func->HasAttr(kAttrExternalSource)) continue;
       const bool applies = IsInCoreType(func->func_type_) || func->func_type_ == FunctionType::Group ||
                            func->func_type_ == FunctionType::Spmd;
       if (!applies) continue;

--- a/src/ir/verifier/verify_runtime_scopes_materialized.cpp
+++ b/src/ir/verifier/verify_runtime_scopes_materialized.cpp
@@ -31,7 +31,7 @@ class RuntimeScopesMaterializedPropertyVerifierImpl : public PropertyVerifier {
     if (!program) return;
     for (const auto& [gv, func] : program->functions_) {
       if (!func || func->func_type_ != FunctionType::Orchestration) continue;
-      if (!func->GetAttr<bool>("auto_scope", true)) continue;
+      if (!func->GetAttr<bool>(kAttrAutoScope, true)) continue;
 
       diagnostics.emplace_back(DiagnosticSeverity::Error, "RuntimeScopesMaterialized", 0,
                                "Orchestration function '" + func->name_ +

--- a/tests/lint/check_function_attr_key_parity.py
+++ b/tests/lint/check_function_attr_key_parity.py
@@ -76,10 +76,18 @@ SCAN_ROOTS = ("include", "src", "python")
 # key once. ``.pyi`` stubs are outside the scan by construction -- only ``.py`` is parsed.
 EXEMPT = frozenset({CPP_DECL, PY_DECL})
 
-# ``inline constexpr const char* kAttrFoo = "foo";`` in function.h.
+# ``inline constexpr const char* kAttrFoo = "foo";`` in function.h. The ``*`` binds loosely so the
+# ``const char *kAttrFoo`` spelling matches too -- clang-format normalises it, but a declaration this
+# pattern missed would be skipped in silence rather than reported, which is the one failure this
+# lint must not have. ``CPP_DECL_SANITY_RE`` below closes the rest of that hole.
 CPP_DECL_RE = re.compile(
-    r'^\s*inline\s+constexpr\s+const\s+char\*\s+(kAttr\w+)\s*=\s*"([^"]+)"\s*;', re.MULTILINE
+    r'^\s*inline\s+constexpr\s+const\s+char\s*\*\s*(kAttr\w+)\s*=\s*"([^"]+)"\s*;', re.MULTILINE
 )
+
+# Anything that declares a ``kAttr...`` constant, however spelled. Every match must also be matched
+# by ``CPP_DECL_RE``; one that is not means the strict pattern has drifted from the header and a key
+# is going unpoliced, so it is reported rather than ignored.
+CPP_DECL_SANITY_RE = re.compile(r"^.*\b(kAttr\w+)\s*=\s*\"", re.MULTILINE)
 
 # ``FOO_ATTR = "foo"`` in _function_attrs.py.
 PY_DECL_RE = re.compile(r'^([A-Z][A-Z0-9_]*_ATTR)\s*=\s*"([^"]+)"\s*$', re.MULTILINE)
@@ -139,12 +147,21 @@ def strip_cpp_comments(text: str) -> str:
 def parse_declarations(root: Path) -> tuple[dict[str, str], dict[str, str], list[str]]:
     """Return (cpp ident->key, python ident->key, errors)."""
     errors: list[str] = []
-    cpp_text = (root / CPP_DECL).read_text(encoding="utf-8")
-    cpp = {m.group(1): m.group(2) for m in CPP_DECL_RE.finditer(strip_cpp_comments(cpp_text))}
+    cpp_text = strip_cpp_comments((root / CPP_DECL).read_text(encoding="utf-8"))
+    cpp = {m.group(1): m.group(2) for m in CPP_DECL_RE.finditer(cpp_text)}
     py_text = (root / PY_DECL).read_text(encoding="utf-8")
     py = {m.group(1): m.group(2) for m in PY_DECL_RE.finditer(py_text)}
     if not cpp:
         errors.append(f'{CPP_DECL}: no `inline constexpr const char* kAttr... = "...";` declarations found')
+    # A key the strict pattern missed would be skipped in silence -- ``if not cpp`` cannot fire while
+    # the other keys still match. Report the mismatch instead of parsing a partial list.
+    for m in CPP_DECL_SANITY_RE.finditer(cpp_text):
+        if m.group(1) not in cpp:
+            errors.append(
+                f"{CPP_DECL}: `{m.group(1)}` is declared in a form CPP_DECL_RE does not match, so it "
+                f'would go unpoliced -- write it as `inline constexpr const char* {m.group(1)} = "...";` '
+                f"or widen the pattern"
+            )
     if not py:
         errors.append(f'{PY_DECL}: no `..._ATTR = "..."` declarations found')
     return cpp, py, errors

--- a/tests/lint/check_function_attr_key_parity.py
+++ b/tests/lint/check_function_attr_key_parity.py
@@ -1,0 +1,325 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""
+Script to check that reserved ``Function.attrs`` keys are declared once per layer and agree.
+
+Each key is a contract between a writer pass and a reader that may sit on the other side of the
+C++/Python boundary -- ``split_aiv`` is stamped by ``ScopeOutliner`` and read by ``MemoryReuse`` to
+gate an Ascend910B in-place hazard guard; ``dual_aiv_dispatch`` is stamped in ``src/ir/transforms``
+and read by both codegens and by the torch debug emitter. A key spelled as a bare literal at each of
+those sites has no single point of rename: a writer renamed without its readers leaves every reader
+silently reading an absent attr, which reads as "feature off" rather than as an error.
+
+The keys are therefore declared once in C++ (``include/pypto/ir/function.h``, which also carries the
+authoritative per-key lifecycle documentation) and once in Python (``python/pypto/_function_attrs``).
+This check enforces three things:
+
+1. *Parity* -- every key the Python module declares pairs with a C++ declaration holding the same
+   string, so a key renamed on one side cannot drift from the other. The C++ header is the
+   authoritative list and may declare keys Python has no use for (``spmd_unwrapped`` today); the
+   reverse is an error, since a Python-only key names an attr no pass writes.
+2. *Name agreement* -- ``kAttrDualAivDispatch`` in C++ pairs with ``DUAL_AIV_DISPATCH_ATTR`` in
+   Python. The identifiers are mechanically derived from one another, so a mismatched pair is
+   reported even when both sides happen to hold the same string.
+3. *No redeclaration* -- no other source may spell one of these key strings as a bare literal at a
+   site that provably reads or writes ``attrs``. That is the shape the declarations exist to replace.
+
+Scope and deliberate limits:
+
+* Only the keys declared in ``function.h`` are policed. ``Call`` / ``Submit`` attrs live in
+  ``expr.h`` and ForStmt / pass-internal attrs in ``transforms/utils/attrs.h``; those are separate
+  key spaces with their own owners, and folding them in here would make one failure message span
+  three unrelated headers.
+* Comments and docstrings are exempt -- prose naming a key is documentation, not a use. C++ comments
+  are stripped before scanning; Python is parsed with ``ast`` so only real string literals are seen.
+* Tests are exempt. A test that hand-builds ``attrs={"dual_aiv_dispatch": True}`` is asserting on the
+  wire format itself, and pinning it to the constant would make the test pass vacuously after a
+  rename -- exactly the failure it exists to catch.
+* The C++ scan flags any bare occurrence; the Python scan flags only *attrs-anchored* shapes. Two
+  keys are overloaded in Python and a blanket scan would be wrong about both: ``split_aiv`` also
+  names the ``pl.split_aiv`` DSL construct (an ``__all__`` entry, a ``_VALID_ITERATORS`` member, a
+  ``_loop_kind_stack`` sentinel), and ``auto_scope`` / ``external_source`` are also user-facing
+  ``@pl.function(...)`` keyword parameters. Those are separate contracts that happen to share a
+  spelling. The anchors below are the shapes that only an attr key takes:
+
+  1. ``<expr naming attrs>.get("key", ...)`` -- ``dict(func.attrs).get(...)``,
+     ``(func_attrs or {}).get(...)``, ``getattr(f, "attrs", {}).get(...)``.
+  2. ``<expr naming attrs>["key"]`` -- subscript load or store.
+  3. A dict-literal key in an assignment whose target names attrs --
+     ``func_attrs = {**(func_attrs or {}), "auto_scope": False}``.
+  4. A module-level collection whose name ends in ``_ATTRS`` -- ``_DECORATOR_ONLY_FUNC_ATTRS``.
+
+  A literal reaching an attrs dict through a helper is not detected; that would need interprocedural
+  analysis. Such sites are still worth converting by hand.
+"""
+
+import argparse
+import ast
+import re
+import sys
+from pathlib import Path
+
+# Declaration sites, relative to the repo root.
+CPP_DECL = "include/pypto/ir/function.h"
+PY_DECL = "python/pypto/_function_attrs.py"
+
+# Directories scanned for bare literals, relative to the repo root.
+SCAN_ROOTS = ("include", "src", "python")
+
+# Paths exempt from the bare-literal scan: the two declaration sites, which necessarily spell each
+# key once. ``.pyi`` stubs are outside the scan by construction -- only ``.py`` is parsed.
+EXEMPT = frozenset({CPP_DECL, PY_DECL})
+
+# ``inline constexpr const char* kAttrFoo = "foo";`` in function.h.
+CPP_DECL_RE = re.compile(
+    r'^\s*inline\s+constexpr\s+const\s+char\*\s+(kAttr\w+)\s*=\s*"([^"]+)"\s*;', re.MULTILINE
+)
+
+# ``FOO_ATTR = "foo"`` in _function_attrs.py.
+PY_DECL_RE = re.compile(r'^([A-Z][A-Z0-9_]*_ATTR)\s*=\s*"([^"]+)"\s*$', re.MULTILINE)
+
+# A name that provably holds a Function attrs mapping. Matched against every identifier reachable
+# from a ``.get`` receiver / subscript value, so ``func.attrs``, ``func_attrs``, ``outlined_attrs``
+# and ``getattr(f, "attrs", {})`` all qualify while ``group_meta`` (the torch emitter's own metadata
+# dict, which mirrors the key names but is not an attrs mapping) does not.
+ATTRS_NAME_RE = re.compile(r"(^|_)attrs$")
+
+# Module-level collections that hold attr keys, matched on the bound name.
+ATTRS_COLLECTION_RE = re.compile(r"_ATTRS$")
+
+
+def cpp_ident_to_py(ident: str) -> str:
+    """``kAttrDualAivDispatch`` -> ``DUAL_AIV_DISPATCH_ATTR``."""
+    body = ident[len("kAttr") :]
+    return re.sub(r"(?<!^)(?=[A-Z])", "_", body).upper() + "_ATTR"
+
+
+def strip_cpp_comments(text: str) -> str:
+    """Blank out ``//`` and ``/* */`` comments, preserving line structure and string literals."""
+    out: list[str] = []
+    i, n = 0, len(text)
+    while i < n:
+        c = text[i]
+        if c in ('"', "'"):
+            out.append(c)
+            i += 1
+            while i < n:
+                out.append(text[i])
+                if text[i] == "\\" and i + 1 < n:
+                    out.append(text[i + 1])
+                    i += 2
+                    continue
+                if text[i] == c:
+                    i += 1
+                    break
+                i += 1
+            continue
+        if c == "/" and i + 1 < n and text[i + 1] == "/":
+            while i < n and text[i] != "\n":
+                i += 1
+            continue
+        if c == "/" and i + 1 < n and text[i + 1] == "*":
+            i += 2
+            while i + 1 < n and not (text[i] == "*" and text[i + 1] == "/"):
+                out.append("\n" if text[i] == "\n" else " ")
+                i += 1
+            i = min(i + 2, n)
+            continue
+        out.append(c)
+        i += 1
+    return "".join(out)
+
+
+def parse_declarations(root: Path) -> tuple[dict[str, str], dict[str, str], list[str]]:
+    """Return (cpp ident->key, python ident->key, errors)."""
+    errors: list[str] = []
+    cpp_text = (root / CPP_DECL).read_text(encoding="utf-8")
+    cpp = {m.group(1): m.group(2) for m in CPP_DECL_RE.finditer(strip_cpp_comments(cpp_text))}
+    py_text = (root / PY_DECL).read_text(encoding="utf-8")
+    py = {m.group(1): m.group(2) for m in PY_DECL_RE.finditer(py_text)}
+    if not cpp:
+        errors.append(f'{CPP_DECL}: no `inline constexpr const char* kAttr... = "...";` declarations found')
+    if not py:
+        errors.append(f'{PY_DECL}: no `..._ATTR = "..."` declarations found')
+    return cpp, py, errors
+
+
+def check_parity(cpp: dict[str, str], py: dict[str, str]) -> list[str]:
+    """Report Python keys with no C++ pair, and identifier pairs that do not correspond.
+
+    One-directional on purpose: ``function.h`` is the authoritative list, and a key no Python layer
+    reads (``spmd_unwrapped``) needs no Python constant. A Python key with no C++ pair is an error --
+    it names an attr no pass writes.
+    """
+    errors: list[str] = []
+    expected_py = {cpp_ident_to_py(ident): (ident, key) for ident, key in cpp.items()}
+    for ident, key in sorted(py.items()):
+        pair = expected_py.get(ident)
+        if pair is None:
+            errors.append(
+                f'{CPP_DECL}: missing a `kAttr...` declaration of "{key}" to pair with `{ident}` in {PY_DECL}'
+            )
+        elif pair[1] != key:
+            errors.append(f'{PY_DECL}: `{ident}` is "{key}" but `{pair[0]}` in {CPP_DECL} is "{pair[1]}"')
+    return errors
+
+
+def scan_cpp(path: Path, rel: str, keys: dict[str, str]) -> list[str]:
+    """Report bare key literals in a C++ source, ignoring comments."""
+    errors: list[str] = []
+    text = strip_cpp_comments(path.read_text(encoding="utf-8", errors="replace"))
+    for lineno, line in enumerate(text.splitlines(), start=1):
+        for key, ident in keys.items():
+            if f'"{key}"' in line:
+                errors.append(f'{rel}:{lineno}: bare attr key "{key}" -- use `{ident}` from {CPP_DECL}')
+    return errors
+
+
+def _mentions_attrs(node: ast.AST) -> bool:
+    """True when any identifier or string reachable from ``node`` names an attrs mapping."""
+    for sub in ast.walk(node):
+        if isinstance(sub, ast.Name) and ATTRS_NAME_RE.search(sub.id):
+            return True
+        if isinstance(sub, ast.Attribute) and ATTRS_NAME_RE.search(sub.attr):
+            return True
+        # getattr(func, "attrs", {}) -- the mapping is named by a literal.
+        if isinstance(sub, ast.Constant) and isinstance(sub.value, str) and ATTRS_NAME_RE.search(sub.value):
+            return True
+    return False
+
+
+class _PyAttrKeyScanner(ast.NodeVisitor):
+    """Collect bare attr-key literals at sites that provably read or write an attrs mapping."""
+
+    def __init__(self, keys: dict[str, str | None], rel: str) -> None:
+        self.keys = keys
+        self.rel = rel
+        self.errors: list[str] = []
+
+    def _report(self, key: str, lineno: int) -> None:
+        ident = self.keys[key]
+        hint = f"use `{ident}`" if ident else f"declare it in {PY_DECL} and use that constant"
+        self.errors.append(f'{self.rel}:{lineno}: bare attr key "{key}" -- {hint}')
+
+    def _check(self, node: ast.AST | None) -> None:
+        if isinstance(node, ast.Constant):
+            key = node.value
+            if isinstance(key, str) and key in self.keys:
+                self._report(key, node.lineno)
+
+    def _check_dict_keys(self, node: ast.AST) -> None:
+        for sub in ast.walk(node):
+            if isinstance(sub, ast.Dict):
+                for key in sub.keys:
+                    self._check(key)
+
+    def visit_Call(self, node: ast.Call) -> None:  # noqa: N802 - ast visitor protocol
+        # Anchor 1: <expr naming attrs>.get("key", ...)
+        func = node.func
+        if isinstance(func, ast.Attribute) and func.attr == "get" and node.args:
+            if _mentions_attrs(func.value):
+                self._check(node.args[0])
+        self.generic_visit(node)
+
+    def visit_Subscript(self, node: ast.Subscript) -> None:  # noqa: N802 - ast visitor protocol
+        # Anchor 2: <expr naming attrs>["key"]
+        if _mentions_attrs(node.value):
+            self._check(node.slice)
+        self.generic_visit(node)
+
+    def _visit_assign(self, targets: list[ast.expr], value: ast.AST | None) -> None:
+        if value is None:
+            return
+        # Anchor 3: a dict-literal key in an assignment whose target names attrs.
+        if any(_mentions_attrs(t) for t in targets):
+            self._check_dict_keys(value)
+        # Anchor 4: a module-level collection of attr keys, matched on the bound name.
+        if any(isinstance(t, ast.Name) and ATTRS_COLLECTION_RE.search(t.id) for t in targets):
+            for sub in ast.walk(value):
+                if isinstance(sub, (ast.Set, ast.List, ast.Tuple)):
+                    for elt in sub.elts:
+                        self._check(elt)
+
+    def visit_Assign(self, node: ast.Assign) -> None:  # noqa: N802 - ast visitor protocol
+        self._visit_assign(list(node.targets), node.value)
+        self.generic_visit(node)
+
+    def visit_AnnAssign(self, node: ast.AnnAssign) -> None:  # noqa: N802 - ast visitor protocol
+        self._visit_assign([node.target], node.value)
+        self.generic_visit(node)
+
+
+def scan_py(path: Path, rel: str, keys: dict[str, str | None]) -> list[str]:
+    """Report bare key literals at attrs-anchored sites, ignoring comments and docstrings."""
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8", errors="replace"), filename=str(path))
+    except SyntaxError as e:
+        return [f"{rel}: could not parse ({e})"]
+    scanner = _PyAttrKeyScanner(keys, rel)
+    scanner.visit(tree)
+    return scanner.errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", default=None, help="Repository root (default: inferred)")
+    args = parser.parse_args()
+
+    root = Path(args.root).resolve() if args.root else Path(__file__).resolve().parents[2]
+
+    cpp, py, errors = parse_declarations(root)
+    if errors:
+        for e in errors:
+            print(f"ERROR: {e}", file=sys.stderr)
+        return 1
+
+    errors = check_parity(cpp, py)
+
+    # key -> the identifier a use site should reach it through.
+    cpp_keys = {key: ident for ident, key in cpp.items()}
+    # Driven by the C++ list so a key with no Python constant yet is still reported at an
+    # attrs-anchored Python site; the message then asks for the declaration rather than an import.
+    py_by_key = {key: ident for ident, key in py.items()}
+    py_keys: dict[str, str | None] = {key: py_by_key.get(key) for key in cpp_keys}
+
+    for scan_root in SCAN_ROOTS:
+        base = root / scan_root
+        if not base.is_dir():
+            continue
+        for path in sorted(base.rglob("*")):
+            if not path.is_file():
+                continue
+            rel = path.relative_to(root).as_posix()
+            if rel in EXEMPT:
+                continue
+            if path.suffix in (".h", ".hpp", ".cpp", ".cc"):
+                errors.extend(scan_cpp(path, rel, cpp_keys))
+            elif path.suffix == ".py":
+                errors.extend(scan_py(path, rel, py_keys))
+
+    if errors:
+        print(
+            "Reserved Function attr keys must reach every use site through a declared constant.\n",
+            file=sys.stderr,
+        )
+        for e in errors:
+            print(f"ERROR: {e}", file=sys.stderr)
+        print(
+            f"\n{len(errors)} problem(s). Declare the key in {CPP_DECL} and {PY_DECL}"
+            " (with its lifecycle comment) and import it at the use site.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"OK: {len(cpp)} reserved Function attr key(s) declared once per layer and in agreement.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/ut/ir/transforms/test_verify_hard_syncall_occupancy.py
+++ b/tests/ut/ir/transforms/test_verify_hard_syncall_occupancy.py
@@ -247,6 +247,47 @@ def _bare_kernel_program():
     return Prog
 
 
+def _aiv_default_mix_program_dual_dispatch_false(n: int):
+    """As ``_aiv_default_mix_program``, but the kernel states ``dual_aiv_dispatch=False``.
+
+    ``False`` means "NOT dual-dispatched", so this is a standalone AIV launch and the
+    mix barrier is just as unsatisfiable as in the plain case. The verifier used to key
+    on ``HasAttr``, which is true for a present-but-false attr, and so skipped the check
+    on exactly the kernels the attr says are *not* dual-dispatched.
+    """
+
+    @pl.program
+    class Prog:
+        @pl.function(type=pl.FunctionType.InCore)
+        def add(
+            self,
+            a: pl.Tensor[[n * TR, TC], pl.FP32],
+            b: pl.Tensor[[n * TR, TC], pl.FP32],
+            out: pl.Out[pl.Tensor[[n * TR, TC], pl.FP32]],
+        ) -> pl.Tensor[[n * TR, TC], pl.FP32]:
+            pl.func_attr({"dual_aiv_dispatch": False})
+            i = pl.tile.get_block_idx()
+            o = i * TR
+            ta = pl.load(a, [o, 0], [TR, TC])
+            tb = pl.load(b, [o, 0], [TR, TC])
+            pl.system.syncall()  # default core_type="mix" — no AIC participants in an AIV launch
+            out = pl.store(pl.add(ta, tb), [o, 0], out)
+            return out
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def orchestrator(
+            self,
+            a: pl.Tensor[[n * TR, TC], pl.FP32],
+            b: pl.Tensor[[n * TR, TC], pl.FP32],
+            out: pl.Out[pl.Tensor[[n * TR, TC], pl.FP32]],
+        ) -> pl.Tensor[[n * TR, TC], pl.FP32]:
+            with pl.spmd(n):
+                out = self.add(a, b, out)
+            return out
+
+    return Prog
+
+
 def _aiv_default_mix_program(n: int):
     """Pure-AIV kernel with the DEFAULT (mix) hard barrier — unsatisfiable in an AIV launch."""
 
@@ -701,6 +742,15 @@ class TestHardSyncallOccupancy:
         """A pure-AIV kernel with the default (mix) hard barrier can never complete (no AIC)."""
         with pytest.raises(pypto.Error, match="can never complete"):
             _run(_aiv_default_mix_program(48))
+
+    def test_standalone_default_mix_barrier_rejected_with_dual_dispatch_false(self):
+        """``dual_aiv_dispatch=False`` states the kernel is NOT dual-dispatched — still checked.
+
+        Regression: the guard read ``HasAttr``, which is true for a present-but-false
+        attr, so an explicit ``False`` suppressed the very check it should have left on.
+        """
+        with pytest.raises(pypto.Error, match="can never complete"):
+            _run(_aiv_default_mix_program_dual_dispatch_false(48))
 
     def test_spmd_submit_partial_occupancy_rejected(self):
         """pl.spmd_submit(core_num=24) carries the block count on the Submit — still checked."""


### PR DESCRIPTION
## Problem

`dual_aiv_dispatch` is declared as `constexpr const char*` in **four separate anonymous namespaces** — `split_vector_kernel_pass.cpp`, `lower_auto_vector_split_pass.cpp`, `expand_mixed_kernel_pass.cpp` and `orchestration_codegen.cpp` — plus raw-literal readers in `pto_codegen.cpp` and `verify_hard_syncall_occupancy.cpp`, and five Python sites across `backend`, `debug` and `jit`.

`split_aiv` has two constexprs and four raw sites, among them its own producer in `ScopeOutliner` and the Ascend910B `tile.load` + `tpop_from_aic` hazard gate in `MemoryReuse`:

```cpp
// src/ir/transforms/memory_reuse_pass.cpp — before
if (func->HasAttr("split_aiv") && func->GetAttr<bool>("split_aiv", false)) return true;
```

That one is the reason this is worth doing rather than filing as tidiness. A key one pass writes and another reads is a contract; spelled as a bare literal at each site it has no single point of rename — and a rename that misses this reader silently disables a hardware-correctness guard rather than failing.

## Approach

Declare each key **once per layer, by node ownership**. These are all `Function` attrs, so the C++ half goes in `include/pypto/ir/function.h` beside the existing `kAttrSpmdUnwrapped`, each with a lifecycle comment naming the writer pass, the readers, and whether the key is ever stripped.

Deliberately **not** `transforms/utils/attrs.h`: that header is never included by `src/codegen`, and both codegens read `dual_aiv_dispatch`. `Call` / `Submit` attrs stay in `expr.h`, `ForStmt` / pass-internal attrs stay in `attrs.h` — the existing three-way split by owner is preserved.

The Python half is a new `pypto._function_attrs`, mirroring the existing `pypto._external_source` precedent; `decorator.py`'s local `EXTERNAL_SOURCE_ATTR` folds into it.

### Keys

| Key | Was | Now |
| --- | --- | --- |
| `dual_aiv_dispatch` | 4 constexpr + 2 raw C++ + 5 Python | `kAttrDualAivDispatch` / `DUAL_AIV_DISPATCH_ATTR` |
| `split_aiv` | 2 constexpr + 4 raw C++ | `kAttrSplitAiv` / `SPLIT_AIV_ATTR` |
| `split_aiv_region_validated` | 1 constexpr + 1 raw C++ | `kAttrSplitAivRegionValidated` / `SPLIT_AIV_REGION_VALIDATED_ATTR` |
| `external_source` | 1 constexpr + 5 raw C++ + 3 Python | `kAttrExternalSource` / `EXTERNAL_SOURCE_ATTR` |
| `auto_scope` | 6 raw C++ + 4 Python | `kAttrAutoScope` / `AUTO_SCOPE_ATTR` |

`auto_scope` is in scope beyond the four keys originally identified: same key class, six raw C++ sites, and one line I had to convert already mixed it with `external_source` (`python_printer.cpp`'s `is_filtered_attr`).

Also routes `SubmitToCallView` through `kAttrCoreNum` / `kAttrSyncStart`, which `expr.h` defines 390 lines above the literals that were shadowing them.

## The lint

`tests/lint/check_function_attr_key_parity.py` (registered as a pre-commit hook) holds the two layers together. Three checks:

1. **Parity** — the declaration sites agree on every key Python declares.
2. **Name agreement** — `kAttrDualAivDispatch` ↔ `DUAL_AIV_DISPATCH_ATTR`, derived mechanically, so a mismatched pair is reported even when both sides hold the same string.
3. **No redeclaration** — no other source respells a key as a bare literal.

Two design points a reviewer should weigh:

**The Python scan is anchored, the C++ scan is not.** A blanket Python scan is wrong here — my first version produced six false positives, because `split_aiv` also names the `pl.split_aiv` DSL construct (an `__all__` entry, a `_VALID_ITERATORS` member, a `_loop_kind_stack` sentinel), and `auto_scope` / `external_source` are also user-facing `@pl.function(...)` keyword parameters. Those are separate contracts that happen to share a spelling. The scan now anchors on four shapes only an attr key takes (`<expr naming attrs>.get(...)`, subscript, dict-literal key in an assignment naming attrs, and a module-level `*_ATTRS` collection). A literal reaching an attrs dict through a helper is not detected; that would need interprocedural analysis.

**Parity is one-directional.** `function.h` is authoritative and may declare keys Python has no use for (`spmd_unwrapped` today); a Python-only key is an error, since it names an attr no pass writes. The alternative — forcing an unused `SPMD_UNWRAPPED_ATTR` into the Python module — buys nothing.

Tests are exempt from the scan on purpose: a test that hand-builds `attrs={"dual_aiv_dispatch": True}` is asserting on the wire format, and pinning it to the constant would make it pass vacuously after a rename — exactly the failure it exists to catch.

I negative-tested all three checks by reverting one site at a time; each is caught, including the `MemoryReuse` hazard gate.

## Verification

- Build clean; `tests/ut/` **10046 passed, 3 skipped, 0 failed**; `ctest` 1/1
- All 19 pre-commit hooks pass, including `cpplint`, `markdownlint-cli2` and `pyright`
- Convention documented in `docs/en/dev/ir/01-hierarchy.md` and its Chinese mirror

**No behaviour change** — every conversion preserves the key string, and the constants are `constexpr`, so this is compile-time-identical to what was there.
