### PR TITLE
fix(ir): resolve IfStmt branch yields through their own loop slot

### DIFF
--- a/src/ir/transforms/utils/loop_state_repair.cpp
+++ b/src/ir/transforms/utils/loop_state_repair.cpp
@@ -21,6 +21,7 @@
 
 #include "pypto/core/logging.h"
 #include "pypto/ir/expr.h"
+#include "pypto/ir/kind_traits.h"
 #include "pypto/ir/span.h"
 #include "pypto/ir/stmt.h"
 #include "pypto/ir/transforms/utils/dead_code_elimination.h"
@@ -119,37 +120,95 @@ StmtPtr FilterYieldStmt(const StmtPtr& stmt, const std::vector<size_t>& kept_ind
   });
 }
 
-StmtPtr FixDanglingYieldStmt(const StmtPtr& stmt, const std::vector<IterArgPtr>& iter_args,
-                             const std::unordered_set<const Var*>& defined_vars) {
-  return TransformLastStmt(stmt, [&](const StmtPtr& s) -> StmtPtr {
-    auto yield_stmt = std::dynamic_pointer_cast<const YieldStmt>(s);
-    if (!yield_stmt) return s;
+/// Return the trailing `YieldStmt` of `stmts`, or nullptr if absent.
+std::shared_ptr<const YieldStmt> TrailingYield(const std::vector<StmtPtr>& stmts) {
+  if (stmts.empty()) return nullptr;
+  return std::dynamic_pointer_cast<const YieldStmt>(stmts.back());
+}
 
-    std::vector<ExprPtr> new_values;
-    for (size_t i = 0; i < yield_stmt->value_.size(); ++i) {
-      var_collectors::VarDefUseCollector collector;
-      collector.VisitExpr(yield_stmt->value_[i]);
-      bool has_undefined = std::any_of(collector.var_uses.begin(), collector.var_uses.end(),
-                                       [&](const Var* ref) { return !defined_vars.count(ref); });
-      if (has_undefined && i < iter_args.size()) {
-        new_values.push_back(iter_args[i]);
-      } else {
-        new_values.push_back(yield_stmt->value_[i]);
-      }
+/// Per-slot fallback for one scope's trailing yield: `carriers[i]` is the
+/// enclosing loop's iter_arg that carries yield slot `i`, or null when no carry
+/// backs that slot.
+///
+/// A loop body's own trailing yield is positionally aligned with the loop's
+/// `iter_args_`, so there `carriers == iter_args`. A nested IfStmt's branch
+/// yields are aligned with that IfStmt's `return_vars_` instead — a different
+/// index space — so their slots must be re-mapped before an iter_arg can stand
+/// in for a dangling value.
+using SlotCarriers = std::vector<IterArgPtr>;
+
+/// Re-map `carriers` (slots of `enclosing_yield`) onto the slots of `if_stmt`'s
+/// branch yields. Branch slot `i` binds `return_vars_[i]`, which the enclosing
+/// yield carries at whatever position that var appears in. Slots whose var the
+/// enclosing yield does not carry stay null: no iter_arg is known to hold that
+/// value, so a dangling yield there is left for StripDanglingIfReturnVars to
+/// drop rather than silently bound to an unrelated carry.
+SlotCarriers MapCarriersToIfSlots(const std::shared_ptr<const IfStmt>& if_stmt,
+                                  const std::shared_ptr<const YieldStmt>& enclosing_yield,
+                                  const SlotCarriers& carriers) {
+  SlotCarriers slots(if_stmt->return_vars_.size(), nullptr);
+  if (!enclosing_yield) return slots;
+
+  std::unordered_map<const Var*, size_t> slot_of;
+  for (size_t j = 0; j < enclosing_yield->value_.size(); ++j) {
+    if (auto v = AsVarLike(enclosing_yield->value_[j])) slot_of.emplace(v.get(), j);
+  }
+  for (size_t i = 0; i < slots.size(); ++i) {
+    auto it = slot_of.find(if_stmt->return_vars_[i].get());
+    if (it != slot_of.end() && it->second < carriers.size()) slots[i] = carriers[it->second];
+  }
+  return slots;
+}
+
+/// Replace every value of `yield_stmt` that references an undefined Var with
+/// the iter_arg carrying that slot. Slots with no known carrier are left alone.
+StmtPtr ReplaceDanglingYieldValues(const std::shared_ptr<const YieldStmt>& yield_stmt,
+                                   const SlotCarriers& carriers,
+                                   const std::unordered_set<const Var*>& defined_vars) {
+  std::vector<ExprPtr> new_values;
+  new_values.reserve(yield_stmt->value_.size());
+  for (size_t i = 0; i < yield_stmt->value_.size(); ++i) {
+    var_collectors::VarDefUseCollector collector;
+    collector.VisitExpr(yield_stmt->value_[i]);
+    bool has_undefined = std::any_of(collector.var_uses.begin(), collector.var_uses.end(),
+                                     [&](const Var* ref) { return !defined_vars.count(ref); });
+    if (has_undefined && i < carriers.size() && carriers[i]) {
+      new_values.push_back(carriers[i]);
+    } else {
+      new_values.push_back(yield_stmt->value_[i]);
     }
-    return std::make_shared<YieldStmt>(new_values, yield_stmt->span_);
-  });
+  }
+  return std::make_shared<YieldStmt>(new_values, yield_stmt->span_);
+}
+
+std::vector<StmtPtr> FixDanglingYieldsInScope(const std::vector<StmtPtr>& stmts, const SlotCarriers& carriers,
+                                              const std::unordered_set<const Var*>& defined_vars) {
+  const auto trailing = TrailingYield(stmts);
+
+  std::vector<StmtPtr> result;
+  result.reserve(stmts.size());
+  for (const auto& stmt : stmts) {
+    if (auto if_stmt = std::dynamic_pointer_cast<const IfStmt>(stmt)) {
+      auto branch_carriers = MapCarriersToIfSlots(if_stmt, trailing, carriers);
+      auto new_then =
+          FixDanglingYieldsInScope(FlattenBody(if_stmt->then_body_), branch_carriers, defined_vars);
+      auto new_else = ProcessElseBranch(if_stmt, [&](const std::vector<StmtPtr>& es) {
+        return FixDanglingYieldsInScope(es, branch_carriers, defined_vars);
+      });
+      result.push_back(RebuildIfStmt(if_stmt, new_then, new_else));
+    } else if (auto yield_stmt = std::dynamic_pointer_cast<const YieldStmt>(stmt)) {
+      result.push_back(ReplaceDanglingYieldValues(yield_stmt, carriers, defined_vars));
+    } else {
+      result.push_back(stmt);
+    }
+  }
+  return result;
 }
 
 std::vector<StmtPtr> FixDanglingLoopBodyYields(const std::vector<StmtPtr>& stmts,
                                                const std::vector<IterArgPtr>& iter_args,
                                                const std::unordered_set<const Var*>& defined_vars) {
-  std::vector<StmtPtr> result;
-  result.reserve(stmts.size());
-  for (const auto& stmt : stmts) {
-    result.push_back(FixDanglingYieldStmt(stmt, iter_args, defined_vars));
-  }
-  return result;
+  return FixDanglingYieldsInScope(stmts, iter_args, defined_vars);
 }
 
 void PullDefinitionChain(const Var* var_ptr, const std::unordered_map<const Var*, StmtPtr>& def_map,
@@ -355,6 +414,10 @@ std::vector<StmtPtr> FixupDanglingYieldValues(const std::vector<StmtPtr>& stmts)
       body_def_collector.VisitStmt(body);
       auto all_defined = defined_so_far;
       all_defined.insert(body_def_collector.var_defs.begin(), body_def_collector.var_defs.end());
+      // iter_args are bound by the loop header, not by a body statement, so the
+      // body walk above never sees them. Without this a yield that just passes a
+      // carry through would be misread as dangling and rewritten.
+      for (const auto& iter_arg : iter_args) all_defined.insert(iter_arg.get());
 
       auto body_stmts = FixupDanglingYieldValues(FlattenBody(body));
       body_stmts = FixDanglingLoopBodyYields(body_stmts, iter_args, all_defined);
@@ -383,12 +446,6 @@ std::vector<StmtPtr> FixupDanglingYieldValues(const std::vector<StmtPtr>& stmts)
 }
 
 namespace {
-
-/// Return the trailing `YieldStmt` of `stmts`, or nullptr if absent.
-std::shared_ptr<const YieldStmt> TrailingYield(const std::vector<StmtPtr>& stmts) {
-  if (stmts.empty()) return nullptr;
-  return std::dynamic_pointer_cast<const YieldStmt>(stmts.back());
-}
 
 /// True when every Var referenced by `expr` is in `defined`.
 bool ExprRefsAllDefined(const ExprPtr& expr, const std::unordered_set<const Var*>& defined) {

--- a/src/ir/transforms/utils/loop_state_repair.cpp
+++ b/src/ir/transforms/utils/loop_state_repair.cpp
@@ -127,35 +127,53 @@ std::shared_ptr<const YieldStmt> TrailingYield(const std::vector<StmtPtr>& stmts
 }
 
 /// Per-slot fallback for one scope's trailing yield: `carriers[i]` is the
-/// enclosing loop's iter_arg that carries yield slot `i`, or null when no carry
-/// backs that slot.
+/// iter_arg that carries yield slot `i`, or null when no carry backs it.
 ///
 /// A loop body's own trailing yield is positionally aligned with the loop's
 /// `iter_args_`, so there `carriers == iter_args`. A nested IfStmt's branch
 /// yields are aligned with that IfStmt's `return_vars_` instead — a different
-/// index space — so their slots must be re-mapped before an iter_arg can stand
-/// in for a dangling value.
-using SlotCarriers = std::vector<IterArgPtr>;
+/// index space — so their fallbacks are derived per IfStmt rather than
+/// inherited positionally.
+using SlotCarriers = std::vector<VarPtr>;
 
-/// Re-map `carriers` (slots of `enclosing_yield`) onto the slots of `if_stmt`'s
-/// branch yields. Branch slot `i` binds `return_vars_[i]`, which the enclosing
-/// yield carries at whatever position that var appears in. Slots whose var the
-/// enclosing yield does not carry stay null: no iter_arg is known to hold that
-/// value, so a dangling yield there is left for StripDanglingIfReturnVars to
-/// drop rather than silently bound to an unrelated carry.
-SlotCarriers MapCarriersToIfSlots(const std::shared_ptr<const IfStmt>& if_stmt,
-                                  const std::shared_ptr<const YieldStmt>& enclosing_yield,
-                                  const SlotCarriers& carriers) {
-  SlotCarriers slots(if_stmt->return_vars_.size(), nullptr);
-  if (!enclosing_yield) return slots;
+/// Fallbacks for one IfStmt's branch yields, read off the branches themselves.
+///
+/// Slot `i` of either branch yield binds `return_vars_[i]`, so the value the
+/// *other* branch gives that same phi is the incoming value a branch whose own
+/// producer was pruned should fall back to. Only an iter_arg qualifies: it is
+/// bound by the enclosing loop header and therefore in scope in both branches,
+/// whereas a branch-local var is not. Two branches naming different iter_args
+/// at one slot leave it null — that phi merges two distinct carries and no
+/// single one stands for it.
+///
+/// Reading the branches keeps the fallback independent of what the loop's
+/// trailing yield happens to name, so an intervening alias between the IfStmt
+/// and that yield does not hide the carry.
+SlotCarriers BranchCarriers(const std::shared_ptr<const IfStmt>& if_stmt,
+                            const std::vector<StmtPtr>& then_stmts,
+                            const std::optional<std::vector<StmtPtr>>& else_stmts) {
+  const size_t num_slots = if_stmt->return_vars_.size();
+  SlotCarriers slots(num_slots, nullptr);
+  std::vector<bool> conflicting(num_slots, false);
 
-  std::unordered_map<const Var*, size_t> slot_of;
-  for (size_t j = 0; j < enclosing_yield->value_.size(); ++j) {
-    if (auto v = AsVarLike(enclosing_yield->value_[j])) slot_of.emplace(v.get(), j);
-  }
-  for (size_t i = 0; i < slots.size(); ++i) {
-    auto it = slot_of.find(if_stmt->return_vars_[i].get());
-    if (it != slot_of.end() && it->second < carriers.size()) slots[i] = carriers[it->second];
+  auto absorb = [&](const std::vector<StmtPtr>& branch_stmts) {
+    const auto yield_stmt = TrailingYield(branch_stmts);
+    if (!yield_stmt) return;
+    for (size_t i = 0; i < num_slots && i < yield_stmt->value_.size(); ++i) {
+      auto iter_arg = As<IterArg>(yield_stmt->value_[i]);
+      if (!iter_arg) continue;
+      if (!slots[i]) {
+        slots[i] = iter_arg;
+      } else if (slots[i].get() != iter_arg.get()) {
+        conflicting[i] = true;
+      }
+    }
+  };
+  absorb(then_stmts);
+  if (else_stmts.has_value()) absorb(*else_stmts);
+
+  for (size_t i = 0; i < num_slots; ++i) {
+    if (conflicting[i]) slots[i] = nullptr;
   }
   return slots;
 }
@@ -183,18 +201,20 @@ StmtPtr ReplaceDanglingYieldValues(const std::shared_ptr<const YieldStmt>& yield
 
 std::vector<StmtPtr> FixDanglingYieldsInScope(const std::vector<StmtPtr>& stmts, const SlotCarriers& carriers,
                                               const std::unordered_set<const Var*>& defined_vars) {
-  const auto trailing = TrailingYield(stmts);
-
   std::vector<StmtPtr> result;
   result.reserve(stmts.size());
   for (const auto& stmt : stmts) {
     if (auto if_stmt = std::dynamic_pointer_cast<const IfStmt>(stmt)) {
-      auto branch_carriers = MapCarriersToIfSlots(if_stmt, trailing, carriers);
-      auto new_then =
-          FixDanglingYieldsInScope(FlattenBody(if_stmt->then_body_), branch_carriers, defined_vars);
-      auto new_else = ProcessElseBranch(if_stmt, [&](const std::vector<StmtPtr>& es) {
-        return FixDanglingYieldsInScope(es, branch_carriers, defined_vars);
-      });
+      auto then_stmts = FlattenBody(if_stmt->then_body_);
+      std::optional<std::vector<StmtPtr>> else_stmts;
+      if (if_stmt->else_body_.has_value()) else_stmts = FlattenBody(*if_stmt->else_body_);
+
+      const auto branch_carriers = BranchCarriers(if_stmt, then_stmts, else_stmts);
+      auto new_then = FixDanglingYieldsInScope(then_stmts, branch_carriers, defined_vars);
+      std::optional<std::vector<StmtPtr>> new_else;
+      if (else_stmts.has_value()) {
+        new_else = FixDanglingYieldsInScope(*else_stmts, branch_carriers, defined_vars);
+      }
       result.push_back(RebuildIfStmt(if_stmt, new_then, new_else));
     } else if (auto yield_stmt = std::dynamic_pointer_cast<const YieldStmt>(stmt)) {
       result.push_back(ReplaceDanglingYieldValues(yield_stmt, carriers, defined_vars));
@@ -208,7 +228,7 @@ std::vector<StmtPtr> FixDanglingYieldsInScope(const std::vector<StmtPtr>& stmts,
 std::vector<StmtPtr> FixDanglingLoopBodyYields(const std::vector<StmtPtr>& stmts,
                                                const std::vector<IterArgPtr>& iter_args,
                                                const std::unordered_set<const Var*>& defined_vars) {
-  return FixDanglingYieldsInScope(stmts, iter_args, defined_vars);
+  return FixDanglingYieldsInScope(stmts, SlotCarriers(iter_args.begin(), iter_args.end()), defined_vars);
 }
 
 void PullDefinitionChain(const Var* var_ptr, const std::unordered_map<const Var*, StmtPtr>& def_map,

--- a/tests/ut/ir/transforms/test_expand_mixed_kernel_a5.py
+++ b/tests/ut/ir/transforms/test_expand_mixed_kernel_a5.py
@@ -3649,7 +3649,7 @@ class TestDCERegression:
                         q_phi = pl.yield_(q_then)
                     else:
                         q_phi = pl.yield_(q_iter)
-                    p_rv, q_rv = pl.yield_(p_phi, q_phi)  # noqa: F841
+                    p_rv, q_rv = pl.yield_(p_phi, q_phi)
                 return p_rv
 
         After = _expand(Before)
@@ -3686,7 +3686,7 @@ class TestDCERegression:
                         q_phi = pl.yield_(q_iter)
                     else:
                         q_phi = pl.yield_(q_iter)
-                    p_rv, q_rv = pl.yield_(p_phi, q_phi)  # noqa: F841
+                    p_rv, q_rv = pl.yield_(p_phi, q_phi)
 
             @pl.function(type=pl.FunctionType.AIV)
             def main_incore_0_aiv(
@@ -3715,7 +3715,7 @@ class TestDCERegression:
                         # Pre-fix this arm yielded p_iter, so q_phi merged two
                         # different tensors and PTO codegen aborted.
                         q_phi = pl.yield_(q_iter)
-                    p_rv, q_rv = pl.yield_(p_phi, q_phi)  # noqa: F841
+                    p_rv, q_rv = pl.yield_(p_phi, q_phi)
                 return p_rv
 
             @pl.function(type=pl.FunctionType.Group)

--- a/tests/ut/ir/transforms/test_expand_mixed_kernel_a5.py
+++ b/tests/ut/ir/transforms/test_expand_mixed_kernel_a5.py
@@ -3585,6 +3585,153 @@ class TestDCERegression:
 
         ir.assert_structural_equal(After, Expected)
 
+    def test_two_divergent_branch_yields_keep_their_own_carriers(self):
+        """Regression for issue #2443: one loop, two divergent guards, two carries.
+
+        A software-pipelined kernel runs the producer and the consumer in one
+        body, so its guards are necessarily divergent and write different
+        tensors::
+
+            for i, (p_iter, q_iter) in pl.range(...):
+                if i == 0: p_iter = ...   # produce
+                if i == 1: q_iter = ...   # consume
+
+        Both stores here are Vec-sourced, so AIC prunes them and both branch
+        yields go dangling on that lane. The fallback must resolve each phi
+        through its OWN loop slot -- ``p_phi`` to ``p_iter``, ``q_phi`` to
+        ``q_iter``. Indexing the loop's iter_args by the branch yield's own
+        position instead collapsed every single-value branch yield onto
+        ``iter_args[0]``, unifying two distinct tensors: the ``else`` arms then
+        disagreed with the ``then`` arms on the backing SSA and PTO codegen
+        aborted on the merged in-place return_var.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                x: pl.Tensor[[16, 128], pl.BF16],
+                w: pl.Tensor[[128, 128], pl.BF16],
+                p_out: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
+                q_out: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
+            ) -> pl.Tensor[[16, 128], pl.FP32]:
+                for i, (p_iter, q_iter) in pl.range(4, init_values=(p_out, q_out)):
+                    if i == 0:
+                        x_mat = pl.load(x, [0, 0], [16, 128], target_memory=pl.MemorySpace.Mat)
+                        x_left = pl.move(x_mat, target_memory=pl.MemorySpace.Left)
+                        w_mat = pl.load(w, [0, 0], [128, 128], target_memory=pl.MemorySpace.Mat)
+                        w_right = pl.move(w_mat, target_memory=pl.MemorySpace.Right)
+                        z = pl.matmul(x_left, w_right)
+                        z_vec = pl.move(
+                            z,
+                            target_memory=pl.MemorySpace.Vec,
+                            blayout=pl.TileLayout.row_major,
+                            slayout=pl.TileLayout.none_box,
+                        )
+                        p_then = pl.store(z_vec, [0, 0], p_iter)
+                        p_phi = pl.yield_(p_then)
+                    else:
+                        p_phi = pl.yield_(p_iter)
+                    if i == 1:
+                        x_mat_1 = pl.load(x, [0, 0], [16, 128], target_memory=pl.MemorySpace.Mat)
+                        x_left_1 = pl.move(x_mat_1, target_memory=pl.MemorySpace.Left)
+                        w_mat_1 = pl.load(w, [0, 0], [128, 128], target_memory=pl.MemorySpace.Mat)
+                        w_right_1 = pl.move(w_mat_1, target_memory=pl.MemorySpace.Right)
+                        z_1 = pl.matmul(x_left_1, w_right_1)
+                        z_vec_1 = pl.move(
+                            z_1,
+                            target_memory=pl.MemorySpace.Vec,
+                            blayout=pl.TileLayout.row_major,
+                            slayout=pl.TileLayout.none_box,
+                        )
+                        q_then = pl.store(z_vec_1, [0, 0], q_iter)
+                        q_phi = pl.yield_(q_then)
+                    else:
+                        q_phi = pl.yield_(q_iter)
+                    p_rv, q_rv = pl.yield_(p_phi, q_phi)  # noqa: F841
+                return p_rv
+
+        After = _expand(Before)
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.AIC)
+            def main_incore_0_aic(
+                self,
+                x: pl.Tensor[[16, 128], pl.BF16],
+                w: pl.Tensor[[128, 128], pl.BF16],
+                p_out: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
+                q_out: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
+            ):
+                for i, (p_iter, q_iter) in pl.range(4, init_values=(p_out, q_out)):
+                    if i == 0:
+                        x_mat = pl.load(x, [0, 0], [16, 128], target_memory=pl.MemorySpace.Mat)
+                        x_left = pl.move(x_mat, target_memory=pl.MemorySpace.Left)
+                        w_mat = pl.load(w, [0, 0], [128, 128], target_memory=pl.MemorySpace.Mat)
+                        w_right = pl.move(w_mat, target_memory=pl.MemorySpace.Right)
+                        z = pl.matmul(x_left, w_right)
+                        pl.tpush_to_aiv(z, split=0)
+                        p_phi = pl.yield_(p_iter)
+                    else:
+                        p_phi = pl.yield_(p_iter)
+                    if i == 1:
+                        x_mat_1 = pl.load(x, [0, 0], [16, 128], target_memory=pl.MemorySpace.Mat)
+                        x_left_1 = pl.move(x_mat_1, target_memory=pl.MemorySpace.Left)
+                        w_mat_1 = pl.load(w, [0, 0], [128, 128], target_memory=pl.MemorySpace.Mat)
+                        w_right_1 = pl.move(w_mat_1, target_memory=pl.MemorySpace.Right)
+                        z_1 = pl.matmul(x_left_1, w_right_1)
+                        pl.tpush_to_aiv(z_1, split=0)
+                        # The fix: q_phi falls back to q_iter, not to iter_args[0].
+                        q_phi = pl.yield_(q_iter)
+                    else:
+                        q_phi = pl.yield_(q_iter)
+                    p_rv, q_rv = pl.yield_(p_phi, q_phi)  # noqa: F841
+
+            @pl.function(type=pl.FunctionType.AIV)
+            def main_incore_0_aiv(
+                self,
+                x: pl.Tensor[[16, 128], pl.BF16],
+                w: pl.Tensor[[128, 128], pl.BF16],
+                p_out: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
+                q_out: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
+            ) -> pl.Tensor[[16, 128], pl.FP32]:
+                for i, (p_iter, q_iter) in pl.range(4, init_values=(p_out, q_out)):
+                    if i == 0:
+                        z_vec: pl.Tile[[16, 128], pl.FP32, pl.MemorySpace.Vec, pl.TileView()] = (
+                            pl.tpop_from_aic(split=0)
+                        )
+                        p_then = pl.store(z_vec, [0, 0], p_iter)
+                        p_phi = pl.yield_(p_then)
+                    else:
+                        p_phi = pl.yield_(p_iter)
+                    if i == 1:
+                        z_vec_1: pl.Tile[[16, 128], pl.FP32, pl.MemorySpace.Vec, pl.TileView()] = (
+                            pl.tpop_from_aic(split=0)
+                        )
+                        q_then = pl.store(z_vec_1, [0, 0], q_iter)
+                        q_phi = pl.yield_(q_then)
+                    else:
+                        # Pre-fix this arm yielded p_iter, so q_phi merged two
+                        # different tensors and PTO codegen aborted.
+                        q_phi = pl.yield_(q_iter)
+                    p_rv, q_rv = pl.yield_(p_phi, q_phi)  # noqa: F841
+                return p_rv
+
+            @pl.function(type=pl.FunctionType.Group)
+            def main_incore_0(
+                self,
+                x: pl.Tensor[[16, 128], pl.BF16],
+                w: pl.Tensor[[128, 128], pl.BF16],
+                p_out: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
+                q_out: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
+            ) -> pl.Tensor[[16, 128], pl.FP32]:
+                self.main_incore_0_aic(x, w, p_out, q_out)
+                self.main_incore_0_aiv(x, w, p_out, q_out)
+                return p_out
+
+        ir.assert_structural_equal(After, Expected)
+
     def test_transient_shared_alias_does_not_keep_dead_iter_arg_alive(self):
         """Dead iter_args should be re-stripped after DCE removes shared-only aliases.
 


### PR DESCRIPTION
## Summary

A software-pipelined kernel keeps its producer and its consumer in one loop body, so its two guards are divergent and write different buffers. In a mixed AIC/AIV kernel that shape aborted in PTO codegen with `IfStmt in-place return_var 'q__phi_v4' yields different backing SSAs across branches`. The abort was a correct guard on IR that `ExpandMixedKernel` had already broken: its dangling-yield repair resolved every `if`-branch yield through the *enclosing loop's* `iter_args_[i]`, but a branch yield is indexed against that `IfStmt`'s own `return_vars_`. Every single-value branch yield therefore collapsed onto `iter_args_[0]`, unifying two distinct output tensors into one phi. After this change each phi falls back to the carry that actually backs it, and the loop compiles in a mixed kernel exactly as it already did in a pure-AIC one.

The defect needed a loop carrying more than one tensor to become visible, which is why it survived since #539: with a single iter_arg and a single phi, slot 0 of both index spaces coincide. It is reachable only from `ExpandMixedKernel` (the sole caller of `FinalizeSplitCoreBody`) — that is why deleting an otherwise irrelevant `split_aiv` block made the identical loop compile.

Nothing else changes: no interface, no pass ordering, no migration step. Where the old mapping happened to be correct (one carry, or a phi already sitting in slot 0) the repaired IR is identical.

## Changes

- `src/ir/transforms/utils/loop_state_repair.cpp`: `FixDanglingLoopBodyYields` now walks a scope carrying an explicit per-slot carrier vector instead of the raw `iter_args_`. A loop body's own trailing yield keeps the positional mapping; an `IfStmt`'s branch yields get their fallbacks derived per `IfStmt` instead of inherited positionally.
- `src/ir/transforms/utils/loop_state_repair.cpp`: those per-branch fallbacks are read off the branches themselves. Slot `i` of either branch yield binds `return_vars_[i]`, so the value the *other* branch gives that phi is its incoming value — the fallback a branch whose producer was pruned needs. Only an iter_arg qualifies: it is bound by the loop header and therefore in scope in both branches, whereas a branch-local var is not. Two branches naming different iter_args at one slot leave it unmapped, since that phi merges two distinct carries. Reading the branches rather than the enclosing yield keeps the fallback independent of what that yield happens to name, so an intervening alias between the `if` and the loop's trailing yield cannot hide the carry.
- `src/ir/transforms/utils/loop_state_repair.cpp`: the same repair treated every loop-carry passthrough as dangling, because iter_args are bound by the loop header and the body walk that builds the "defined" set never sees them. They are now seeded explicitly, so a yield that merely passes a carry through is no longer rewritten at all.
- `tests/ut/ir/transforms/test_expand_mixed_kernel_a5.py`: adds `test_two_divergent_branch_yields_keep_their_own_carriers` next to the existing single-carry regression from #534. One loop, two divergent guards, two carried output tensors; both stores are Vec-sourced so AIC prunes them and every branch yield on that lane goes dangling. Reverting either half of the fix fails it — pre-fix, `q_phi` takes `p_iter` on both lanes.

## Verification

- `cmake --build build --parallel 32`: exit 0.
- `pytest tests/ut/ir/transforms/test_expand_mixed_kernel_{a5,a2a3,split_aiv}.py`: 93 passed.
- `pytest tests/ut -n 16`: 10093 passed, 8 skipped. `test_symlinked_import_path_still_names_the_caller` was deselected — it re-execs a subprocess with its own `PYTHONPATH`, which drops the shim pointing at this worktree's freshly built extension and picks up the stale one installed in the local conda env (`AttributeError: module 'pypto.pypto_core.passes' has no attribute 'RuntimeKind'`). Local environment skew, unrelated to this change.
- The reproducer attached to #2443 (`repro_ifstmt_phi.py`, mixed AIC/AIV, `platform="a2a3sim"`): aborted before the change, prints `compiled OK` after.
- Alias probe for the review point above — a loop-carried GM tensor phi whose then-arm store is Vec-sourced (pruned on AIC) and whose surviving alias is a cube-sourced `tile.store` naming the phi, with the loop yielding the alias. AIC output is byte-identical across `origin/main`, the first version of this branch, and the reworked one, and leaves no free var: `RemapDanglingGmRefsToParam` repoints the GM version onto the shared base parameter.
- `clang-format --dry-run -Werror`, `ruff check`, `ruff format --check`, `tests/lint/check_op_name_literals.py`, `check_english_only.py`, `check_headers.py`, `check_no_broad_raises.py`: all clean. `tests/lint/clang_tidy.py --diff-base origin/main` reports nothing on the new code; its three `bugprone-unchecked-optional-access` hits are on pre-existing `has_value()`-guarded lines this change does not touch, from a local clang-tidy 18.1.8 against the pinned 21.1.0.

Fixes #2443
