### PR TITLE
fix(ir): propagate a callee's write onto a caller parameter reached by a carry

### DIFF
--- a/docs/en/dev/ir/05-operators.md
+++ b/docs/en/dev/ir/05-operators.md
@@ -48,6 +48,9 @@ auto dynamic_dim = make_int(kDynamicDim);
 
 ### Argument effects
 
+> The whole chain that consumes these declarations is laid out in
+> [Parameter Direction Inference](08-param-directions.md).
+
 An operator that updates one of its arguments in place must say so. Direction
 inference, dependency analysis and the parameter-direction verifier all ask the
 registry the same question — *does this call write the buffer this argument

--- a/docs/en/dev/ir/08-param-directions.md
+++ b/docs/en/dev/ir/08-param-directions.md
@@ -1,0 +1,210 @@
+# Parameter Direction Inference
+
+`Function::param_directions_` says, for each parameter, whether the function
+reads it, writes it, or both — `In`, `Out`, `InOut`. Almost nothing downstream
+works without it: dependency analysis emits RAW edges from it, the distributed
+codegen tags each per-rank chip dispatch from it, and the host ABI decides from
+it which buffers the caller must allocate.
+
+Getting it wrong is quiet. A parameter that reads `In` while the body writes it
+produces no error and no wrong number at compile time — the dependency edge it
+needed is simply never emitted, and the program races or deadlocks on device.
+
+This page is the whole chain in one place. Each stage has its own page; this one
+says what the stages are, which question each answers, and where the answers
+come from.
+
+## The single source of truth
+
+Every stage below asks the same question — *does this call write the buffer this
+argument names?* — and every stage reads the answer from the same place: the
+operator's own registry declaration.
+
+```cpp
+REGISTER_OP("tile.mscatter")
+    .set_arg_effect(2, ArgEffect::Write)        // fixed
+    .set_write_channel(WriteChannel::Dma);
+
+REGISTER_OP("tile.mgather")
+    .set_arg_effect(2, [](const auto& kwargs) { // kwarg-dependent: `scratch` is
+      ...                                       // written only in Mat elem mode
+      return mat_output && elem_mode ? ArgEffect::Write : ArgEffect::Read;
+    });
+
+REGISTER_OP("system.set_ffts")
+    .no_arg_writes();                           // "writes nothing" must be said
+```
+
+See [Operator System — Argument effects](05-operators.md#argument-effects) for
+the full declaration surface. The query side is
+`GetArgEffect(i, kwargs)`, `HasDeclaredArgEffect(i)`, `WritesAnyArg()` and
+`GetOutputReusesInputArg()`.
+
+This was not always so. The write set used to be a hand-kept list of operator
+names inside each analysis, and the lists disagreed — `pld.system.notify`
+reached production writing a signal no analysis knew about (#2391), and
+`tile.mscatter` was in the same state until its effects were declared.
+
+### What the registry gate does and does not cover
+
+`OpRegistry::ValidateArgEffects()` runs at registration and rejects two shapes:
+
+- an operator declaring `set_output_reuses_input(N)` without classifying
+  argument `N` — a reuse contract implies a verdict about that argument; and
+- an operator declaring a write channel while writing through no argument — a
+  channel describes *how* an operator writes, so one without a write is either a
+  stray declaration or a missing one.
+
+An operator with **neither** — no reuse contract, no write channel — trips
+neither gate. Omitting `set_arg_effect` there is still silent. That is the
+original failure class, and it is not closed; see
+[Known limits](#known-limits).
+
+## The chain
+
+| Stage | Pass | Question it answers |
+| ----- | ---- | ------------------- |
+| [Outlining](#1-outlining-passes-79) | 7 / 8 / 9 | What directions does the function I am *creating* have? |
+| [Caller propagation](#2-caller-propagation-pass-10) | 10 | A callee writes this argument — does my own parameter behind it become `Out`? |
+| [Wrapper recovery + call sites](#3-wrapper-recovery-and-call-sites-pass-37) | 37 | What is each wrapper's *effective* signature, and what direction does each call-site argument have? |
+| [Consistency warning](#4-consistency-warning-postpipeline) | PostPipeline | Does any parameter still read `In` while its body writes it? |
+
+### 1. Outlining (passes 7–9)
+
+`ScopeOutliner::InferParamDirections` gives a freshly outlined scope function its
+signature. Four steps, each a *lower* bound on the accesses — no step may
+overwrite what another saw:
+
+| Step | Evidence |
+| ---- | -------- |
+| 0 | `ParamReadCollector` walks the body for reads |
+| 1a | exported store targets are writes |
+| 1b | `CallWriteTargets` — writes the registry declares |
+| 2 | inner callees' declared slots |
+
+Two subtleties carry most of the correctness.
+
+**Step 0 skips slots the callee purely overwrites.** Passing a capture to a
+write-only slot moves no data into the scope, so it is not a read. Two
+declarations say which slots those are, one per kind of callee: a builtin's
+`ArgEffect::Write` and a user function's `ParamDirection::Out`.
+
+**Step 2 does not merge along `In < Out < InOut`.** `In` is the seeded *no
+evidence yet* floor, so it cannot also mean "somebody read this" — reading it
+that way would promote every write-only capture to `InOut`, the false read that
+turns disjoint per-rank slices of one `pl.Out` tensor into a cross-rank
+dependency (issue #2415). The callee slots are accumulated as two independent
+flags — `In`/`InOut` marks a read, `Out`/`InOut` marks a write — and the
+direction is derived once at the end.
+
+See [Outline InCore Scopes](../passes/08-outline_incore_scopes.md).
+
+### 2. Caller propagation (pass 10)
+
+`ConvertTensorToTileOps` phase 3 lifts a caller's parameter to `Out`/`InOut`
+when the caller forwards it into a callee slot the callee writes.
+
+The argument is rarely the parameter itself. A loop-carried tensor arrives as an
+`IterArg` whose value is the parameter's buffer:
+
+```python
+acc = dst
+for _ in pl.range(4):
+    acc = self.kernel(x, acc)     # kernel(x, out: pl.Out[...])
+```
+
+So the argument is resolved to the buffer it owns — via `BufferRootCollector` —
+before the parameter lookup. An argument that *is* the parameter resolves to
+itself, so this generalises the identity lookup rather than replacing it.
+
+### 3. Wrapper recovery and call sites (pass 37)
+
+`DeriveCallDirections` runs in two parts.
+
+**Phase 0 — write each Group/Spmd wrapper's effective directions back into its
+own signature.** A wrapper forwards its parameters 1:1 to an inner kernel, but
+its own `param_directions_` can still read `In` for a parameter that kernel
+writes: the outliners infer from the body they extracted, and
+`ExpandMixedKernel` / `SplitVectorKernel` later rebuild wrapper bodies around
+freshly split callees without revisiting the signature.
+
+Recovering this used to be recomputed on the fly in four places — this pass,
+`AutoDeriveTaskDependencies`, the `CallDirectionsResolved` verifier, and
+orchestration codegen. Doing it once and storing it in the IR gives every
+consumer one source of truth: `callee->param_directions_`.
+
+**Then the call sites.** Each argument gets an `ArgDirection` — `Input`,
+`Output`, `OutputExisting`, `InOut`, `NoDep`, `Scalar` — which is what
+dependency analysis and codegen actually consume.
+
+See [Derive Call Directions](../passes/37-derive_call_directions.md).
+
+### 4. Consistency warning (PostPipeline)
+
+`DiagnosticCheck::InParamWritten` reports a parameter that still reads `In` while
+its own body writes it. It reads the same two declarations the inference reads —
+registry effects and a callee's `param_directions_` — and reports where they
+contradict the parameter.
+
+It is a **warning, not an `IRProperty`**, and that is forced rather than chosen:
+the check must run after `DeriveCallDirections` (pass 37), and `InitMemRef`
+(pass 31) invalidates `SSAForm` with nothing re-establishing it, so no pipeline
+position is both after pass 37 and in SSA form. Its buffer lineage is therefore
+best-effort across control flow.
+
+See [Verifier — InParamWritten](../passes/99-verifier.md#inparamwritten).
+
+## Shared analyses
+
+Three helpers are read by more than one stage, which is what keeps the stages
+from drifting apart:
+
+| Helper | Answers |
+| ------ | ------- |
+| `BufferRootCollector` | which buffer does this variable own? |
+| `ResultAliasedArgIndex` | which argument's buffer does this call's result name? |
+| `op_predicates::IsBufferAliasingViewOp` | is this a zero-copy view of its input? (`OutputMemoryInheritsInput() && IsInplaceSafe()`) |
+
+The third excludes `tile.transpose`: it inherits the memory *space* but permutes
+into a fresh buffer (`pto.ttrans` is registered `not_inplace_safe()`), so its
+output does not alias its input.
+
+## Known limits
+
+Two gaps are documented rather than closed. The first only under-reports; the
+second errs in **both** directions, which is worth stating plainly because an
+earlier version of this page claimed otherwise.
+
+**A missing declaration is invisible.** Every stage reads the registry, so an
+operator that never declared its effects contributes no write anywhere, and the
+consistency warning cannot see it either — it is reading the very declaration
+that is absent. `ValidateArgEffects` narrows this but does not close it, as
+above.
+
+**The consistency warning's lineage is not per-access.** It runs on non-SSA IR
+(see above), where one environment per name is not exact. `BufferRootCollector`
+scans the whole body up front, so a rebound name carries a single *final*
+mapping that is applied to earlier writes too:
+
+```python
+t = buf1
+t = pl.tile.assemble(t, patch, [0, 0])   # writes buf1
+t = buf2                                  # ... but the map says t -> buf2
+```
+
+`buf2` is reported although nothing writes it, and `buf1` is missed although it
+is written — a false positive and a false negative from the same cause. Pinned
+as a strict `xfail` in `tests/ut/ir/verifier/test_in_param_written.py`.
+
+A view built inside a branch is *not* an instance of this. Its lineage does
+survive the join, but the write after the join really does reach that buffer on
+the taken path, so naming it is the correct may-write answer; that case is
+pinned as a passing test.
+
+## See Also
+
+- [Operator System](05-operators.md) — the declaration surface, in full.
+- [Outline InCore Scopes](../passes/08-outline_incore_scopes.md) — stage 1.
+- [Convert Tensor to Tile Ops](../passes/10-convert_tensor_to_tile_ops.md) — stage 2.
+- [Derive Call Directions](../passes/37-derive_call_directions.md) — stage 3.
+- [IR Verifier](../passes/99-verifier.md) — stage 4.

--- a/docs/en/dev/ir/index.md
+++ b/docs/en/dev/ir/index.md
@@ -16,6 +16,7 @@ the page covering what you are changing.
 | [Operator System](05-operators.md) | Type-safe operator definitions with automatic type deduction |
 | [IR Builder](06-builder.md) | Constructing IR incrementally — context managers in Python, Begin/End in C++ |
 | [IR Parser](07-parser.md) | Converting Python DSL to IR via `@pl.function` / `@pl.program`, and the SSA properties it enforces |
+| [Parameter Directions](08-param-directions.md) | How `In`/`Out`/`InOut` is inferred — the registry declaration every stage reads, and the four passes that build on it |
 
 ## See Also
 

--- a/docs/en/dev/passes/99-verifier.md
+++ b/docs/en/dev/passes/99-verifier.md
@@ -90,6 +90,9 @@ The `run_verifier()` utility creates a standalone `Pass` for ad-hoc use in custo
 
 ### InParamWritten
 
+> This is the last stage of the chain described in
+> [Parameter Direction Inference](../ir/08-param-directions.md).
+
 **Warning**: `DiagnosticCheck::InParamWritten` — a parameter declared `In` is
 written by its own function body.
 

--- a/docs/zh/dev/ir/05-operators.md
+++ b/docs/zh/dev/ir/05-operators.md
@@ -48,6 +48,9 @@ auto dynamic_dim = make_int(kDynamicDim);
 
 ### 参数效应（Argument effects）
 
+> 消费这些声明的整条链见
+> [参数方向推导](08-param-directions.md)。
+
 原地更新某个参数的算子必须显式声明。方向推导（direction inference）、依赖分析
 （dependency analysis）和参数方向验证器都向注册表询问同一个问题——*这次调用是否
 写入该参数所指的缓冲区？*——而从未回答过的算子会被读成纯消费者：

--- a/docs/zh/dev/ir/08-param-directions.md
+++ b/docs/zh/dev/ir/08-param-directions.md
@@ -1,0 +1,185 @@
+# 参数方向推导（Parameter Direction Inference）
+
+`Function::param_directions_` 记录每个参数是被读、被写，还是二者皆有——`In`、
+`Out`、`InOut`。下游几乎一切都依赖它：依赖分析据此发出 RAW 边，分布式 codegen
+据此标记每个 per-rank 的芯片派发，host ABI 据此决定哪些 buffer 必须由调用方分配。
+
+**它出错时是静默的。** 一个声明为 `In` 却被函数体写入的参数，在编译期既不报错、
+也不产生错误数值——它需要的那条依赖边只是从未被发出，程序在设备上表现为竞争或
+死锁。
+
+本页把整条链放在一处。每个阶段各有专页；这里说明**有哪些阶段、各自回答什么问题、
+答案从哪里来**。
+
+## 唯一真相源
+
+下面每个阶段问的都是同一个问题——*这次调用是否写了该实参所指的 buffer？*——
+而且都从同一处取答案：算子自身在注册表上的声明。
+
+```cpp
+REGISTER_OP("tile.mscatter")
+    .set_arg_effect(2, ArgEffect::Write)        // 固定效应
+    .set_write_channel(WriteChannel::Dma);
+
+REGISTER_OP("tile.mgather")
+    .set_arg_effect(2, [](const auto& kwargs) { // 依 kwarg 而定：`scratch`
+      ...                                       // 仅在 Mat elem 模式下被写
+      return mat_output && elem_mode ? ArgEffect::Write : ArgEffect::Read;
+    });
+
+REGISTER_OP("system.set_ffts")
+    .no_arg_writes();                           // "不写任何参数"必须显式声明
+```
+
+完整的声明面见[算子系统 — 参数效应](05-operators.md#参数效应argument-effects)。
+查询面是 `GetArgEffect(i, kwargs)`、`HasDeclaredArgEffect(i)`、`WritesAnyArg()`
+与 `GetOutputReusesInputArg()`。
+
+过去并非如此。写入集合曾是各分析内部手工维护的算子名清单，而这些清单彼此不一致
+——`pld.system.notify` 就这样带着一个没有任何分析知道的信号写入上了生产（#2391），
+`tile.mscatter` 在其效应被声明之前也处于同样状态。
+
+### 注册门禁覆盖什么、不覆盖什么
+
+`OpRegistry::ValidateArgEffects()` 在注册期运行，拒绝两种形态：
+
+- 声明了 `set_output_reuses_input(N)` 却没有对实参 `N` 分类——复用契约意味着对
+  该实参必须有一个判断；
+- 声明了 write channel 却不通过任何实参写入——channel 描述的是算子**如何**写，
+  没有写入的 channel 要么是多余声明，要么是漏了声明。
+
+**两者皆无**的算子——既无复用契约、也无 write channel——两道门都不碰。在那里漏掉
+`set_arg_effect` 依旧是静默的。这正是最初那类故障，且尚未封闭，见[已知限制](#已知限制)。
+
+## 整条链
+
+| 阶段 | Pass | 回答的问题 |
+| ---- | ---- | ---------- |
+| [Outline](#1-outlinepass-79) | 7 / 8 / 9 | 我**正在创建**的这个函数，参数方向是什么？ |
+| [调用方传播](#2-调用方传播pass-10) | 10 | 被调方写了这个实参——它背后我自己的参数是否要变成 `Out`？ |
+| [Wrapper 恢复与调用点](#3-wrapper-恢复与调用点pass-37) | 37 | 每个 wrapper 的**有效**签名是什么？每个调用点实参的方向是什么？ |
+| [一致性警告](#4-一致性警告postpipeline) | PostPipeline | 是否还有参数声明为 `In` 却被自身函数体写入？ |
+
+### 1. Outline（pass 7–9）
+
+`ScopeOutliner::InferParamDirections` 为刚被 outline 出来的 scope 函数确定签名。
+四个步骤，每一步都只是访问集合的**下界**——任何一步都不得覆盖另一步的观测：
+
+| 步骤 | 证据 |
+| ---- | ---- |
+| 0 | `ParamReadCollector` 扫描函数体中的读取 |
+| 1a | 导出的 store 目标即写入 |
+| 1b | `CallWriteTargets`——注册表声明的写入 |
+| 2 | 内层被调函数声明的槽位 |
+
+其中两处细节承载了大部分正确性。
+
+**步骤 0 会跳过被调方纯覆写的槽位。** 把 capture 交给只写槽位并不会把数据搬进本
+作用域，因此不算读取。指明这些槽位的是两份声明，每种被调方各一：内建算子的
+`ArgEffect::Write`，以及用户函数的 `ParamDirection::Out`。
+
+**步骤 2 不按 `In < Out < InOut` 合并。** `In` 是初始化时"尚无证据"的地板，因此它
+不能同时表示"有人读过"——那样理解会把每个只写 capture 提升为 `InOut`，即把同一个
+`pl.Out` 张量的互不相交的 per-rank 切片变成跨 rank 依赖的虚假读取（issue #2415）。
+被调函数的槽位被累积为两个独立标志——`In`/`InOut` 记为读、`Out`/`InOut` 记为写
+——最后一次性推导出方向。
+
+参见 [Outline InCore Scopes](../passes/08-outline_incore_scopes.md)。
+
+### 2. 调用方传播（pass 10）
+
+当调用方把自己的参数转发给被调函数会写入的槽位时，`ConvertTensorToTileOps` 的
+第 3 阶段把该参数提升为 `Out`/`InOut`。
+
+实参**很少**就是参数本身。循环携带的张量以 `IterArg` 的身份到达，其值是参数的
+buffer：
+
+```python
+acc = dst
+for _ in pl.range(4):
+    acc = self.kernel(x, acc)     # kernel(x, out: pl.Out[...])
+```
+
+因此在查参数表之前，实参会先经 `BufferRootCollector` 解析到它所属的 buffer。实参
+本身就是参数时，它解析到自己——所以这是对指针恒等查找的**推广**，而非替换。
+
+### 3. Wrapper 恢复与调用点（pass 37）
+
+`DeriveCallDirections` 分两部分。
+
+**Phase 0——把每个 Group/Spmd wrapper 的有效方向写回它自己的签名。** wrapper 把
+参数 1:1 转发给内层 kernel，但它自己的 `param_directions_` 可能仍对一个内层 kernel
+会写的参数读作 `In`：outliner 是按它提取出的函数体推导的，而 `ExpandMixedKernel` /
+`SplitVectorKernel` 之后围绕新拆分出的被调函数重建 wrapper 函数体时，并不回头修改
+签名。
+
+这个恢复动作过去在四处被各自即时重算——本 pass、`AutoDeriveTaskDependencies`、
+`CallDirectionsResolved` 验证器，以及 orchestration codegen。做一次并存入 IR，使
+每个消费者只有一个依据：`callee->param_directions_`。
+
+**然后是调用点。** 每个实参获得一个 `ArgDirection`——`Input`、`Output`、
+`OutputExisting`、`InOut`、`NoDep`、`Scalar`——这才是依赖分析与 codegen 实际消费的
+东西。
+
+参见 [Derive Call Directions](../passes/37-derive_call_directions.md)。
+
+### 4. 一致性警告（PostPipeline）
+
+`DiagnosticCheck::InParamWritten` 报告仍声明为 `In` 却被自身函数体写入的参数。它读
+的是推导所读的同样两份声明——注册表效应与被调函数的 `param_directions_`——并报告它们
+与该参数相矛盾之处。
+
+它是**警告而非 `IRProperty`**，且这是被迫而非选择：该检查必须在
+`DeriveCallDirections`（pass 37）之后运行，而 `InitMemRef`（pass 31）作废了
+`SSAForm` 且此后无人重建，因此流水线中不存在既在 pass 37 之后、又处于 SSA 形式的
+位置。它的 buffer lineage 在控制流上因而是尽力而为的。
+
+参见 [验证器 — InParamWritten](../passes/99-verifier.md#inparamwritten)。
+
+## 共享分析
+
+有三个 helper 被多个阶段共同读取——这正是各阶段不会彼此漂移的原因：
+
+| Helper | 回答 |
+| ------ | ---- |
+| `BufferRootCollector` | 这个变量属于哪块 buffer？ |
+| `ResultAliasedArgIndex` | 这次调用的结果指向哪个实参的 buffer？ |
+| `op_predicates::IsBufferAliasingViewOp` | 这是否是对输入的零拷贝 view？（`OutputMemoryInheritsInput() && IsInplaceSafe()`） |
+
+第三个排除了 `tile.transpose`：它继承内存**空间**，但会把数据置换进一块全新
+buffer（`pto.ttrans` 注册为 `not_inplace_safe()`），因此其输出并不别名输入。
+
+## 已知限制
+
+有两处缺口是被记录下来而非被封闭的。第一处只会漏报；第二处**两个方向都会出错**
+——这一点需要写明，因为本页早先的版本声称并非如此。
+
+**缺失的声明不可见。** 每个阶段都读注册表，因此从未声明效应的算子在任何地方都不
+贡献写入，一致性警告同样看不见它——它读的正是那份缺失的声明。`ValidateArgEffects`
+缩小了这个缺口但没有封闭，见上文。
+
+**一致性警告的 lineage 不是按访问点维护的。** 它运行在非 SSA 的 IR 上（见上文），
+那里"每个名字一个环境"并不精确。`BufferRootCollector` 预先扫描整个函数体，因此被
+重新绑定的名字只有一份**最终**映射，却也被套用到更早的写入上：
+
+```python
+t = buf1
+t = pl.tile.assemble(t, patch, [0, 0])   # 写的是 buf1
+t = buf2                                  # ……但映射说 t -> buf2
+```
+
+`buf2` 被报告（尽管没有任何东西写它），`buf1` 被漏掉（尽管它确实被写）——同一个成因
+同时造成误报与漏报。已作为 strict `xfail` 钉在
+`tests/ut/ir/verifier/test_in_param_written.py` 中。
+
+分支内建立的 view **不属于**这一类。它的 lineage 确实越过了汇合点，但汇合之后的写入
+在被走到的那条路径上确实到达了那块 buffer，因此点它的名是正确的 may-write 答案；该
+情形以一个通过的测试钉住。
+
+## 参见
+
+- [算子系统](05-operators.md) —— 完整的声明面。
+- [Outline InCore Scopes](../passes/08-outline_incore_scopes.md) —— 阶段 1。
+- [Convert Tensor to Tile Ops](../passes/10-convert_tensor_to_tile_ops.md) —— 阶段 2。
+- [Derive Call Directions](../passes/37-derive_call_directions.md) —— 阶段 3。
+- [IR 验证器](../passes/99-verifier.md) —— 阶段 4。

--- a/docs/zh/dev/ir/index.md
+++ b/docs/zh/dev/ir/index.md
@@ -15,6 +15,7 @@ IR 定义是整个编译器的真源：pass 可以重写，IR 节点定义不可
 | [算子系统](05-operators.md) | 带自动类型推导的类型安全算子定义 |
 | [IR Builder](06-builder.md) | 增量构造 IR —— Python 用上下文管理器，C++ 用 Begin/End |
 | [IR Parser](07-parser.md) | 通过 `@pl.function` / `@pl.program` 把 Python DSL 转成 IR，以及它强制的 SSA 性质 |
+| [参数方向](08-param-directions.md) | `In`/`Out`/`InOut` 如何被推导——各阶段共同读取的注册表声明，以及基于它的四个 pass |
 
 ## 另请参阅
 

--- a/docs/zh/dev/passes/99-verifier.md
+++ b/docs/zh/dev/passes/99-verifier.md
@@ -90,6 +90,8 @@
 
 ### InParamWritten
 
+> 这是[参数方向推导](../ir/08-param-directions.md)所述整条链的最后一环。
+
 **警告**：`DiagnosticCheck::InParamWritten` —— 声明为 `In` 的参数被其所在函数体写入。
 
 这是一个**警告，而非 `IRProperty`**，这个区分是实质性的而非措辞问题。见下文"为何不是属性"。

--- a/include/pypto/ir/transforms/utils/buffer_root_collector.h
+++ b/include/pypto/ir/transforms/utils/buffer_root_collector.h
@@ -70,6 +70,20 @@ class BufferRootCollector : public IRVisitor {
   /// these vars conservatively; aliasing optimizations leave them unmapped.
   std::unordered_set<const Var*> ambiguous_buffer_vars;
 
+  /// Every owning-buffer-root candidate recorded for @p var, empty when the var
+  /// has no lineage. This is what "conservatively" above means in practice: a
+  /// write through an ambiguous var may land on *any* candidate, so a consumer
+  /// deriving dependencies has to account for all of them rather than skip the
+  /// var — skipping drops the dependency for every candidate at once.
+  ///
+  /// `buffer_roots` cannot express this: it holds one root, which is either the
+  /// single unambiguous answer or (under `kFirstOutput`) an arbitrary pick.
+  [[nodiscard]] const std::vector<const Var*>& RootCandidatesOf(const Var* var) const {
+    static const std::vector<const Var*> kNone;
+    auto it = root_candidates_.find(var);
+    return it == root_candidates_.end() ? kNone : it->second;
+  }
+
  protected:
   void VisitStmt_(const IfStmtPtr& if_stmt) override;
   void VisitStmt_(const ForStmtPtr& for_stmt) override;

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -308,6 +308,7 @@ nav:
           - en/dev/ir/05-operators.md
           - en/dev/ir/06-builder.md
           - en/dev/ir/07-parser.md
+          - en/dev/ir/08-param-directions.md
       - Passes:
           - en/dev/passes/index.md
           - en/dev/passes/00-pass_manager.md

--- a/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
+++ b/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
@@ -41,6 +41,7 @@
 #include "pypto/ir/transforms/passes.h"
 #include "pypto/ir/transforms/utils/attrs.h"
 #include "pypto/ir/transforms/utils/auto_name_utils.h"
+#include "pypto/ir/transforms/utils/buffer_root_collector.h"
 #include "pypto/ir/transforms/utils/mutable_copy.h"
 #include "pypto/ir/transforms/utils/result_alias_utils.h"
 #include "pypto/ir/transforms/utils/tile_conversion_utils.h"
@@ -2546,48 +2547,139 @@ Pass ConvertTensorToTileOps() {
         func_map[func->name_] = func;
       }
 
+      // Everything derived from a *body* is computed once, before the fixed
+      // point. The loop below only rewrites `param_directions_` — it replaces a
+      // function with a `MutableCopy` whose body is the same node — so the
+      // parameter index, the buffer lineage and the call list are all invariant
+      // across rounds. Rebuilding them per round made the added analysis cost
+      // O(rounds x program), over the O(N log N) bound
+      // `.claude/rules/pass-complexity.md` sets; hoisting leaves the loop
+      // proportional to the call arguments it actually re-reads.
+      struct CallerFacts {
+        std::unordered_map<const Var*, size_t> param_idx;
+        std::vector<CallPtr> calls;
+        std::unordered_map<const Var*, const Var*> buffer_roots;
+        std::unordered_map<const Var*, std::vector<const Var*>> candidates;
+      };
+      std::unordered_map<std::string, CallerFacts> facts_by_name;
+      for (const auto& func : functions_phase2b) {
+        if (func->func_type_ == FunctionType::InCore) continue;
+
+        CallerFacts f;
+        for (size_t i = 0; i < func->params_.size(); ++i) {
+          f.param_idx[func->params_[i].get()] = i;
+        }
+
+        // An argument rarely *is* the parameter. `for acc in ...: acc =
+        // kernel(x, acc)` forwards a loop-carried `IterArg` whose value is the
+        // parameter's buffer, and looking the IterArg up in `param_idx` finds
+        // nothing — so the enclosing signature kept declaring `In` for a buffer
+        // the call chain writes. Resolving the argument to its owning buffer
+        // first is what makes the propagation reach through a carry, and it is
+        // the same resolution the InParamWritten warning uses to decide which
+        // parameter a write lands on.
+        buffer_root::BufferRootCollector roots(program, buffer_root::AmbiguousRootPolicy::kSkip);
+        roots.Initialize(func->params_);
+        roots.VisitStmt(func->body_);
+        f.buffer_roots = roots.buffer_roots;
+        // An ambiguous var is exactly the case the single-root map cannot
+        // answer, so keep the candidates it does have.
+        for (const Var* var : roots.ambiguous_buffer_vars) {
+          f.candidates[var] = roots.RootCandidatesOf(var);
+        }
+
+        class CallScanner : public IRVisitor {
+         public:
+          std::vector<CallPtr> calls;
+          void VisitExpr_(const CallPtr& call) override {
+            Record(call);
+            IRVisitor::VisitExpr_(call);
+          }
+
+          /// A task launch forwards its arguments exactly as a plain call does,
+          /// and the base visitor does not route `Submit` through the `Call`
+          /// handler (`.claude/rules/pass-submit-awareness.md`). Without this a
+          /// parameter handed to an `Out` callee through `pl.submit` never
+          /// reached the propagation below, so an orchestration function that
+          /// only ever submits kept declaring `In` for a buffer its tasks write.
+          /// The view is transient — the loop reads only `op_` and `args_` — and
+          /// `args_` is a positional prefix of the callee's params, which the
+          /// loop's dual bound already respects.
+          void VisitExpr_(const SubmitPtr& submit) override {
+            Record(SubmitToCallView(submit));
+            IRVisitor::VisitExpr_(submit);
+          }
+
+         private:
+          void Record(const CallPtr& call) {
+            if (std::dynamic_pointer_cast<const GlobalVar>(call->op_)) {
+              calls.push_back(call);
+            }
+          }
+        };
+        CallScanner scanner;
+        scanner.VisitStmt(func->body_);
+        f.calls = std::move(scanner.calls);
+
+        facts_by_name[func->name_] = std::move(f);
+      }
+
       bool changed = true;
       while (changed) {
         changed = false;
         for (auto& func : functions_phase2b) {
           if (func->func_type_ == FunctionType::InCore) continue;
-
-          std::unordered_map<const Var*, size_t> param_idx;
-          for (size_t i = 0; i < func->params_.size(); ++i) {
-            param_idx[func->params_[i].get()] = i;
-          }
-
-          class CallScanner : public IRVisitor {
-           public:
-            std::vector<CallPtr> calls;
-            void VisitExpr_(const CallPtr& call) override {
-              if (std::dynamic_pointer_cast<const GlobalVar>(call->op_)) {
-                calls.push_back(call);
-              }
-              IRVisitor::VisitExpr_(call);
-            }
-          };
-          CallScanner scanner;
-          scanner.VisitStmt(func->body_);
+          auto facts_it = facts_by_name.find(func->name_);
+          if (facts_it == facts_by_name.end()) continue;
+          const CallerFacts& facts = facts_it->second;
 
           auto new_dirs = func->param_directions_;
-          for (const auto& call : scanner.calls) {
+          for (const auto& call : facts.calls) {
             auto gv = std::dynamic_pointer_cast<const GlobalVar>(call->op_);
             if (!gv) continue;
             auto callee_it = func_map.find(gv->name_);
             if (callee_it == func_map.end()) continue;
             const auto& callee = callee_it->second;
             for (size_t ai = 0; ai < call->args_.size() && ai < callee->param_directions_.size(); ++ai) {
-              auto arg_var = As<Var>(call->args_[ai]);
+              // AsVarLike, not As<Var>: an IterArg has its own ObjectKind and
+              // does not match As<Var> (.claude/rules/ir-kind-traits.md).
+              auto arg_var = AsVarLike(call->args_[ai]);
               if (!arg_var) continue;
-              auto pi = param_idx.find(arg_var.get());
-              if (pi == param_idx.end()) continue;
-              ParamDirection callee_dir = callee->param_directions_[ai];
-              ParamDirection& caller_dir = new_dirs[pi->second];
-              if (callee_dir == ParamDirection::Out && caller_dir == ParamDirection::In) {
-                caller_dir = ParamDirection::Out;
-              } else if (callee_dir == ParamDirection::InOut && caller_dir != ParamDirection::InOut) {
-                caller_dir = ParamDirection::InOut;
+              const ParamDirection callee_dir = callee->param_directions_[ai];
+              if (callee_dir != ParamDirection::Out && callee_dir != ParamDirection::InOut) continue;
+
+              // Control flow can leave a value naming more than one buffer:
+              //
+              //     t = a if cond else b
+              //     self.writer(src, t)      # writer declares its slot Out
+              //
+              // The callee writes whichever `t` turned out to be, so *both* `a`
+              // and `b` may be written and both must be upgraded. Skipping the
+              // ambiguous var — which is what this did — drops the dependency
+              // for every candidate at once, and that is the direction that
+              // fails silently: an under-declared `In` loses the RAW edge and
+              // races on device, where an over-declared `Out` only over-orders.
+              // Under `kSkip` such a var has no `buffer_roots` entry by
+              // construction, so the candidate list is the only place the answer
+              // exists.
+              auto cand_it = facts.candidates.find(arg_var.get());
+              std::vector<const Var*> arg_roots;
+              if (cand_it != facts.candidates.end()) {
+                arg_roots = cand_it->second;
+              } else {
+                auto root_it = facts.buffer_roots.find(arg_var.get());
+                arg_roots.push_back(root_it == facts.buffer_roots.end() ? arg_var.get() : root_it->second);
+              }
+
+              for (const Var* arg_root : arg_roots) {
+                auto pi = facts.param_idx.find(arg_root);
+                if (pi == facts.param_idx.end()) continue;
+                ParamDirection& caller_dir = new_dirs[pi->second];
+                if (callee_dir == ParamDirection::Out && caller_dir == ParamDirection::In) {
+                  caller_dir = ParamDirection::Out;
+                } else if (callee_dir == ParamDirection::InOut && caller_dir != ParamDirection::InOut) {
+                  caller_dir = ParamDirection::InOut;
+                }
               }
             }
           }

--- a/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
+++ b/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
@@ -6386,5 +6386,171 @@ class TestRegistryDrivenParamDirections:
         assert self._directions(Prog)["out"] == ir.ParamDirection.InOut
 
 
+class TestCalleeDirectionPropagationThroughCarries:
+    """Propagating a callee's write onto the caller's own signature.
+
+    The caller's argument is rarely the parameter itself. A loop-carried tensor
+    reaches the call as an ``IterArg`` whose value is the parameter's buffer, so
+    the propagation has to resolve the argument to the buffer it owns before it
+    can decide which parameter the callee's write lands on.
+    """
+
+    def test_loop_carried_arg_upgrades_the_caller_parameter(self):
+        """``for _ in ...: acc = kernel(x, acc)`` writes ``dst`` through a carry.
+
+        The argument is an ``IterArg``, which is neither matched by ``As<Var>``
+        nor present in the caller's parameter map, so the enclosing signature
+        kept declaring ``In`` for a buffer the call chain writes — and every
+        consumer of that signature (dependency analysis, distributed codegen arg
+        tags, the host ABI) was told the buffer is a pure input.
+        """
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self, x: pl.Tensor[[64], pl.FP32], out: pl.Out[pl.Tensor[[64], pl.FP32]]
+            ) -> pl.Tensor[[64], pl.FP32]:
+                t: pl.Tile[[64], pl.FP32] = pl.load(x, [0], [64])
+                ret: pl.Tensor[[64], pl.FP32] = pl.store(t, [0], out)
+                return ret
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self, x: pl.Tensor[[64], pl.FP32], dst: pl.Tensor[[64], pl.FP32]
+            ) -> pl.Tensor[[64], pl.FP32]:
+                acc = dst
+                for _ in pl.range(4):
+                    acc = self.kernel(x, acc)
+                return acc
+
+        before = passes.convert_to_ssa()(Prog)
+        after = passes.convert_tensor_to_tile_ops()(before)["main"]
+        assert after is not None
+
+        # The whole map, not just the parameter under test: an upgrade that also
+        # flipped `x` would otherwise pass.
+        directions = {
+            p.name_hint.split("__ssa_v")[0]: d for p, d in zip(after.params, after.param_directions)
+        }
+        assert directions == {"x": ir.ParamDirection.In, "dst": ir.ParamDirection.Out}, directions
+
+        # The direction is only meaningful if the body that produced it survived.
+        # An upgrade that dropped the carry, the call or an argument would still
+        # satisfy the map above, so pin the shape the direction was derived from.
+        text = ir.python_print(passes.convert_tensor_to_tile_ops()(before))
+        assert "pl.range(" in text, text
+        assert text.count("self.kernel(") == 1, text
+        assert "def kernel(" in text and "def main(" in text, text
+
+    def test_submitted_arg_upgrades_the_caller_parameter(self):
+        """A task launch forwards its arguments exactly as a plain call does.
+
+        The base visitor does not route ``Submit`` through the ``Call`` handler
+        (`.claude/rules/pass-submit-awareness.md`), so without a dedicated hook
+        an orchestration function that only ever submits kept declaring ``In``
+        for a buffer its tasks write — the dependency edge that buffer needs is
+        then never emitted.
+        """
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self, x: pl.Tensor[[64], pl.FP32], out: pl.Out[pl.Tensor[[64], pl.FP32]]
+            ) -> pl.Tensor[[64], pl.FP32]:
+                t: pl.Tile[[64], pl.FP32] = pl.load(x, [0], [64])
+                ret: pl.Tensor[[64], pl.FP32] = pl.store(t, [0], out)
+                return ret
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self, x: pl.Tensor[[64], pl.FP32], dst: pl.Tensor[[64], pl.FP32]
+            ) -> pl.Tensor[[64], pl.FP32]:
+                with pl.manual_scope():
+                    res, tid = pl.submit(self.kernel, x, dst)
+                return res
+
+        after = passes.convert_tensor_to_tile_ops()(passes.convert_to_ssa()(Prog))["main"]
+        assert after is not None
+        directions = {
+            p.name_hint.split("__ssa_v")[0]: d for p, d in zip(after.params, after.param_directions)
+        }
+        assert directions == {"x": ir.ParamDirection.In, "dst": ir.ParamDirection.Out}, directions
+
+    def test_ambiguous_arg_upgrades_every_candidate_parameter(self):
+        """Control flow can leave a value naming more than one buffer.
+
+        The callee writes whichever ``t`` turned out to be, so both ``a`` and
+        ``b`` may be written and both must be upgraded. Skipping the ambiguous
+        var dropped the dependency for every candidate at once — the direction
+        that fails silently, since an under-declared ``In`` loses the RAW edge
+        and races on device where an over-declared ``Out`` only over-orders.
+        """
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def writer(
+                self, src: pl.Tensor[[64], pl.FP32], out: pl.Out[pl.Tensor[[64], pl.FP32]]
+            ) -> pl.Tensor[[64], pl.FP32]:
+                t: pl.Tile[[64], pl.FP32] = pl.load(src, [0], [64])
+                ret: pl.Tensor[[64], pl.FP32] = pl.store(t, [0], out)
+                return ret
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                src: pl.Tensor[[64], pl.FP32],
+                a: pl.Tensor[[64], pl.FP32],
+                b: pl.Tensor[[64], pl.FP32],
+                cond: pl.Scalar[pl.INT32],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                if cond > 0:
+                    t: pl.Tensor[[64], pl.FP32] = a
+                else:
+                    t: pl.Tensor[[64], pl.FP32] = b
+                r: pl.Tensor[[64], pl.FP32] = self.writer(src, t)
+                return r
+
+        after = passes.convert_tensor_to_tile_ops()(passes.convert_to_ssa()(Prog))["main"]
+        assert after is not None
+        directions = {
+            p.name_hint.split("__ssa_v")[0]: d for p, d in zip(after.params, after.param_directions)
+        }
+        assert directions["a"] == ir.ParamDirection.Out, directions
+        assert directions["b"] == ir.ParamDirection.Out, directions
+        # The read-only operand must not be swept up by the widening.
+        assert directions["src"] == ir.ParamDirection.In, directions
+
+    def test_direct_arg_still_upgrades_the_caller_parameter(self):
+        """The un-carried shape keeps working: resolving to a buffer root is a
+        generalisation of the identity lookup, not a replacement for it."""
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self, x: pl.Tensor[[64], pl.FP32], out: pl.Out[pl.Tensor[[64], pl.FP32]]
+            ) -> pl.Tensor[[64], pl.FP32]:
+                t: pl.Tile[[64], pl.FP32] = pl.load(x, [0], [64])
+                ret: pl.Tensor[[64], pl.FP32] = pl.store(t, [0], out)
+                return ret
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self, x: pl.Tensor[[64], pl.FP32], dst: pl.Tensor[[64], pl.FP32]
+            ) -> pl.Tensor[[64], pl.FP32]:
+                r: pl.Tensor[[64], pl.FP32] = self.kernel(x, dst)
+                return r
+
+        after = passes.convert_tensor_to_tile_ops()(passes.convert_to_ssa()(Prog))["main"]
+        assert after is not None
+        directions = {
+            p.name_hint.split("__ssa_v")[0]: d for p, d in zip(after.params, after.param_directions)
+        }
+        assert directions["dst"] == ir.ParamDirection.Out
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/ir/verifier/test_in_param_written.py
+++ b/tests/ut/ir/verifier/test_in_param_written.py
@@ -385,19 +385,14 @@ def test_rebinding_a_view_name_drops_the_stale_lineage():
     assert all("'src1'" not in m for m in messages), messages
 
 
-@pytest.mark.xfail(
-    reason="known limitation: the lineage has no join merging, and the IR here is "
-    "not in SSA form (InitMemRef invalidates SSAForm at pass 31, this runs after "
-    "pass 37). A view built inside a branch leaks past the join.",
-    strict=True,
-)
-def test_branch_local_view_does_not_leak_past_the_join():
-    """Pins the false positive rather than asserting it away.
+def test_may_write_through_a_branch_is_reported():
+    """A write on *some* path is a write.
 
-    When ``cond`` is false the write lands on ``v``'s own buffer, never on
-    ``bufA`` — but the branch's lineage survives the join, so ``bufA`` is
-    blamed. ``strict=True`` so that fixing it fails the test and forces this
-    marker off.
+    On the ``cond > 0`` path ``v`` is a view of ``bufA`` and the assemble writes
+    it, so naming ``bufA`` is the correct may-write answer — not, as an earlier
+    version of this test claimed, a join false positive. The lineage surviving
+    the branch is what makes the union over paths conservative in the right
+    direction here.
     """
 
     @pl.program
@@ -417,7 +412,41 @@ def test_branch_local_view_does_not_leak_past_the_join():
             return v
 
     messages = _messages(Prog)
-    assert all("'bufA'" not in m for m in messages), messages
+    assert any("'bufA'" in m for m in messages), messages
+
+
+@pytest.mark.xfail(
+    reason="known limitation: BufferRootCollector scans the whole body up front, so a "
+    "rebound name carries one final mapping that is applied to earlier writes too. "
+    "Reports the buffer bound last and misses the one actually written.",
+    strict=True,
+)
+def test_a_rebound_name_attributes_the_write_to_the_right_buffer():
+    """The real misattribution, in both directions at once.
+
+    ``t`` names ``buf1`` when the assemble writes it and ``buf2`` only
+    afterwards, but the collector's single final mapping says ``t -> buf2``. So
+    ``buf2`` is reported although nothing writes it, and ``buf1`` is missed
+    although it is written. This is the shape that needs SSA or a per-access
+    environment; ``strict=True`` so fixing it forces the marker off.
+    """
+
+    @pl.program
+    class Prog:
+        @pl.function(type=pl.FunctionType.InCore)
+        def kernel(
+            self,
+            buf1: pl.Tile[[16, 128], pl.FP32],
+            buf2: pl.Tile[[16, 128], pl.FP32],
+            patch: pl.Tile[[16, 128], pl.FP32],
+        ) -> pl.Tile[[16, 128], pl.FP32]:
+            t: pl.Tile[[16, 128], pl.FP32] = buf1
+            t = pl.tile.assemble(t, patch, [0, 0])
+            t = buf2
+            return t
+
+    reported = {m.split("'")[1] for m in _messages(Prog)}
+    assert reported == {"buf1"}, reported
 
 
 def test_write_inside_a_branch_is_reported():


### PR DESCRIPTION
fix(ir): propagate a callee's write onto a caller parameter reached by a carry

## Summary

`ConvertTensorToTileOps` phase 3 lifts a caller's parameter to `Out`/`InOut`
when the caller forwards it into a callee slot the callee writes. It matched the
argument against the caller's parameter map by pointer identity, which only
works when the argument *is* the parameter.

It rarely is. A loop-carried tensor reaches the call as an `IterArg` whose value
is the parameter's buffer:

    acc = dst
    for _ in pl.range(4):
        acc = self.kernel(x, acc)     # kernel(x, out: pl.Out[...])

`As<Var>` does not even match an `IterArg` — it has its own `ObjectKind`
(`.claude/rules/ir-kind-traits.md`) — and switching to `AsVarLike` is necessary
but not sufficient: the `IterArg` is still not the parameter, so the lookup
finds nothing. `dst` kept declaring `In` for a buffer the call chain writes, and
every consumer of that signature — dependency analysis, the distributed codegen
argument tags, the host ABI — was told the buffer is a pure input.

The argument is now resolved to the buffer it owns before the lookup, using the
same `BufferRootCollector` the `ParamDirectionsSound` verifier uses to decide
which parameter a write lands on. Resolving to a root generalises the identity
lookup rather than replacing it: an argument that is the parameter resolves to
itself. A variable whose owning buffer control flow leaves ambiguous is skipped,
so the propagation still never invents a write.

## Changes

- `src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp`: phase 3 builds a
  `BufferRootCollector` per function, seeded with its parameters, and resolves
  each argument through it. `As<Var>` becomes `AsVarLike` so an `IterArg`
  reaches the resolution at all. Everything derived from a body — the parameter
  index, the lineage and the call list — is computed once *before* the fixed
  point rather than per round: the loop only rewrites `param_directions_`, so
  those are round-invariant, and rebuilding them made the added analysis
  O(rounds x program) against the O(N log N) bound in
  `.claude/rules/pass-complexity.md`. An argument whose owning buffer control
  flow leaves ambiguous no longer skips the propagation: it upgrades *every*
  candidate root that is a parameter, since the callee writes whichever the value
  turned out to be. Skipping dropped the dependency for all candidates at once,
  the direction that fails silently — an under-declared `In` loses the RAW edge
  and races on device, where an over-declared `Out` only over-orders.
  `BufferRootCollector` gains a read-only `RootCandidatesOf` accessor for the
  list it already maintained privately; nothing else about it changes.
  `CallScanner` gains a `Submit` overload: the
  base visitor does not route a task launch through the `Call` handler
  (`.claude/rules/pass-submit-awareness.md`), so an orchestration function that
  only ever submits kept declaring `In` for a buffer its tasks write.

- `tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py`: the carried shape
  above, the ambiguous shape (`t = a if cond else b` handed to an `Out` slot
  upgrades both `a` and `b` and leaves the read-only operand `In`),
  the un-carried shape (the direct case must keep working — resolving to
  a root generalises the identity lookup rather than replacing it), and the
  `pl.submit` shape. Each asserts the *whole* direction map rather than the one
  parameter under test, so an upgrade that also flipped `x` would fail; the
  carried case additionally pins the loop, the call and its arity, since a
  direction is only meaningful if the body that produced it survived.

- `tests/ut/ir/verifier/test_in_param_written.py`, `docs/{en,zh}/dev/ir/08-param-directions.md`:
  correct a mischaracterisation this stack introduced. The branch case was pinned
  as a strict `xfail` claiming a join false positive, but on the taken path the
  view really is the parameter's buffer and the write really does reach it —
  naming it is the correct may-write answer, so that is a passing test now. The
  genuine false positive is the *final-map* one: `t = buf1; assemble(t, ...);
  t = buf2` reports `buf2`, which nothing writes, and misses `buf1`, which is.
  That is the strict `xfail` now, and the docs no longer claim both known gaps
  only under-report.

- `docs/{en,zh}/dev/ir/08-param-directions.md` (new): the whole direction chain
  in one page. It existed only as four per-pass sections that never referenced
  each other, so the shared part — that every stage asks the registry the same
  question — was invisible unless you had read all four. Covers the declaration
  surface and what `ValidateArgEffects` does *not* gate, the four stages (scope
  outlining, this pass's caller propagation, `DeriveCallDirections` phase 0 plus
  the call sites, and the `InParamWritten` warning), the three shared analyses,
  and the two documented under-reporting limits.

  Placed under `ir/` rather than `passes/`, whose `01-89` numbering is reserved
  for pipeline passes in execution order (`.claude/rules/pass-doc-ordering.md`) —
  a cross-cutting page has no position in that sequence. Back-links added from
  `05-operators.md`'s argument-effects section and `99-verifier.md`'s
  `InParamWritten` section, in both languages, plus `mkdocs.yml` nav and both
  `ir/index.md` tables.

## Verification

- `cmake --build build --parallel 32`: exit 0
- `python -m pytest tests/ut/ -n 16 -q`: 10477 passed, 8 skipped, 3 xfailed
  (10472 before; the 3 new tests are the difference)
- The carried test fails on the previous commit (`dst` derives `In` there); the
  un-carried test passes either way, pinning that the generalisation preserves
  the case that already worked.
- `tests/lint/check_headers.py`, `check_english_only.py`,
  `check_docs_en_zh_parity.py`, `check_op_name_literals.py`,
  `check_no_broad_raises.py`: exit 0 each
- `clang-format --dry-run --Werror`, `ruff check` / `ruff format`: exit 0
- Docs: `check_docs_nav.py` (173 nav entries cover all 173 pages),
  `check_docs_en_zh_parity.py` (173 paired paths), `check_english_only.py`, and
  markdownlint over every touched page: exit 0 each. Every relative link and
  `#anchor` in the new page was resolved against its target file's headings —
  including the Chinese anchors — with zero dead links.








