### PR TITLE
fix(ir): carry the operands' valid_shape into a tensor matmul product

### DIFF
--- a/docs/en/dev/ir/05-operators.md
+++ b/docs/en/dev/ir/05-operators.md
@@ -428,6 +428,19 @@ XOR, `part_*`, broadcasting, different valid regions, and direct distributed
 window operands are not covered by this rule because their current lowering or
 combination contracts require separate handling.
 
+`tensor.matmul` follows the same rule its `tile.matmul` lowering does: the
+result's storage is the physical `[M, N]`, while its effective `valid_shape` is
+`[lhs valid M, rhs valid N]` (each picked from the axis `a_trans` / `b_trans`
+selects for the physical shape). This is what lets a caller pad an operand up to
+the cube fractal — `pl.slice(q, [16, K], off, valid_shape=[5, K])`, the
+tensor-level spelling of `pl.load(..., valid_shape=...)` — and still have the
+logical extent reach the store. The mat-vec and vec-mat forms carry their single
+surviving extent; the 0-D dot product and the ND batched form deduce fully-valid
+results, the latter matching its `tile.batch_matmul` lowering. `tensor.matmul_acc`
+writes into the accumulator, so its result carries the accumulator's valid
+region, as `tile.matmul_acc` does — except in the ND form, which stays fully
+valid to match the `tile.batch_matmul_acc` it lowers to.
+
 `pl.reinterpret_view(data, dtype, *, shape=None)` dispatches to the equivalent `pl.tensor` or `pl.tile` operator and returns the same kind. It is a zero-copy view over exactly the same bytes, so `dtype` must differ and be one of signed/unsigned 8/16/32/64-bit integers, FP16, BF16, or FP32. With no `shape`, ND/row-major scales the last axis and DN/col-major scales the penultimate axis by the source/target byte-width ratio. An explicit shape must be byte-equivalent and fully static unless it is provably identical to the auto-inferred shape; a partial `valid_shape` only permits that auto-equivalent shape. Zero/null padding metadata is preserved, while dtype-dependent max/min padding is cleared. The initial executable path supports packed ND in-core tensors and packed flat (`none_box`) row/col-major tiles; DN tensor inference is available but Tensor-to-Tile lowering rejects it, and orchestration tensors are unsupported.
 
 **Example:**

--- a/docs/zh/dev/ir/05-operators.md
+++ b/docs/zh/dev/ir/05-operators.md
@@ -392,6 +392,16 @@ Scalar 比较与 XOR（`cmp` 和 `xors`）仍不在此规则的支持范围内�
 元数据。比较、XOR、`part_*`、广播、不同有效区域，以及直接使用 distributed
 window 的操作数不在这条规则范围内，因为它们当前的下降或合并契约需要单独处理。
 
+`tensor.matmul` 遵循与其下降目标 `tile.matmul` 相同的规则：结果的存储是物理
+`[M, N]`，而其 effective `valid_shape` 是 `[lhs 有效 M, rhs 有效 N]`（各自取自
+`a_trans` / `b_trans` 为物理 shape 选中的同一根轴）。正是这条规则让调用方可以把
+操作数补齐到 cube fractal —— `pl.slice(q, [16, K], off, valid_shape=[5, K])`，即
+`pl.load(..., valid_shape=...)` 的 tensor 级写法 —— 并让逻辑范围一路传到 store。
+mat-vec 与 vec-mat 形式携带其唯一保留的范围；0 维点积和 ND batched 形式推导为完全
+有效的结果，后者与其 `tile.batch_matmul` 下降保持一致。`tensor.matmul_acc` 写入
+累加器，因此结果携带累加器的有效区域，与 `tile.matmul_acc` 一致；但 ND 形式除外
+—— 它保持完全有效，以匹配其下降目标 `tile.batch_matmul_acc`。
+
 `pl.reinterpret_view(data, dtype, *, shape=None)` 会根据输入分派到等价的 `pl.tensor` 或 `pl.tile` 算子，并保持返回类型种类不变。它是覆盖完全相同字节的零拷贝视图，因此 `dtype` 必须不同，且仅支持有/无符号 8/16/32/64 位整数、FP16、BF16 与 FP32。省略 `shape` 时，ND/row-major 缩放最后一轴，DN/col-major 按源/目标字节宽度比例缩放倒数第二轴。显式 shape 必须字节数相等；除非能证明它与自动推导 shape 等价，否则必须完全静态。部分有效的 `valid_shape` 只能使用与自动推导结果等价的 shape。零值/null padding 元数据会保留，依赖 dtype 的 max/min padding 则会清除。初始可执行路径支持 packed ND in-core tensor 及 packed、flat（`none_box`）row/col-major tile；DN tensor 可做类型推导但 Tensor-to-Tile 下降会拒绝，编排层 tensor 暂不支持。
 
 **示例：**

--- a/src/ir/op/tensor_ops/matmul.cpp
+++ b/src/ir/op/tensor_ops/matmul.cpp
@@ -120,6 +120,19 @@ TypePtr DeduceTensorMatMulType(const std::vector<ExprPtr>& args,
 
   std::vector<ExprPtr> output_shape;
 
+  // Storage follows the physical M / N above; the logical rectangle follows the
+  // operands' valid M / N, exactly as tile.matmul deduces it (see
+  // DeduceMatmulProductInfo in tile_ops/matmul.cpp). Without this an operand
+  // whose rows are padded for the cube fractal — the tensor-level spelling of
+  // `pl.load(..., valid_shape=...)` — would deduce a fully-valid product and the
+  // logical extent would be lost at the tensor level while the lowered tile
+  // still carries it. Left empty on the paths that have no valid M / N to carry:
+  // the 0D dot product, and the ND path whose tile.batch_matmul counterpart
+  // likewise deduces a fully-valid result.
+  std::vector<ExprPtr> output_valid;
+  const auto lhs_valid = GetValidShape(lhs_type);
+  const auto rhs_valid = GetValidShape(rhs_type);
+
   if (lhs_shape.size() == 1 && rhs_shape.size() == 1) {
     // Vector x vector (dot product): [K] x [K] -> scalar (0D tensor)
     CheckContractionExtents(lhs_shape[0], rhs_shape[0],
@@ -132,6 +145,7 @@ TypePtr DeduceTensorMatMulType(const std::vector<ExprPtr>& args,
     ExprPtr k_lhs = a_trans ? lhs_shape[0] : lhs_shape[1];
     CheckContractionExtents(k_lhs, rhs_shape[0], "tensor.matmul requires matching inner dimensions");
     output_shape = {m_dim};
+    output_valid = {a_trans ? lhs_valid[1] : lhs_valid[0]};
   } else if (lhs_shape.size() == 1 && rhs_shape.size() == 2) {
     // Vector x matrix: [K] x [K, N] -> [N]
     // With b_trans the rhs is stored [N, K], so the contraction axis is dim 1.
@@ -139,6 +153,7 @@ TypePtr DeduceTensorMatMulType(const std::vector<ExprPtr>& args,
     ExprPtr n_dim = b_trans ? rhs_shape[0] : rhs_shape[1];
     CheckContractionExtents(lhs_shape[0], k_rhs, "tensor.matmul requires matching inner dimensions");
     output_shape = {n_dim};
+    output_valid = {b_trans ? rhs_valid[0] : rhs_valid[1]};
   } else if (lhs_shape.size() == 2 && rhs_shape.size() == 2) {
     // 2D x 2D matrix multiplication
     ExprPtr m_dim = a_trans ? lhs_shape[1] : lhs_shape[0];
@@ -150,6 +165,7 @@ TypePtr DeduceTensorMatMulType(const std::vector<ExprPtr>& args,
     CheckContractionExtents(k_lhs, k_rhs, "tensor.matmul requires matching inner dimensions");
 
     output_shape = {m_dim, n_dim};
+    output_valid = {a_trans ? lhs_valid[1] : lhs_valid[0], b_trans ? rhs_valid[0] : rhs_valid[1]};
   } else {
     // For higher-dimensional tensors (both must have at least 2 dimensions),
     // use batched matmul semantics
@@ -185,7 +201,12 @@ TypePtr DeduceTensorMatMulType(const std::vector<ExprPtr>& args,
     output_shape.push_back(n_dim);
   }
 
-  return std::make_shared<TensorType>(output_shape, out_dtype);
+  if (output_valid.empty()) {
+    return std::make_shared<TensorType>(output_shape, out_dtype);
+  }
+  // A valid_shape equal to the physical shape canonicalizes away in the
+  // TensorType constructor, so a fully-valid product still deduces no view.
+  return MakeFreshTensorType(std::move(output_shape), out_dtype, std::move(output_valid));
 }
 
 // ============================================================================
@@ -304,7 +325,17 @@ TypePtr DeduceTensorMatMulAccType(const std::vector<ExprPtr>& args,
     }
   }
 
-  return std::make_shared<TensorType>(acc_shape, result_dtype);
+  // The product is written into the accumulator, so the result carries the
+  // accumulator's valid region — the same rule tile.matmul_acc applies. The ND
+  // form stays fully valid, for the same reason tensor.matmul's does: it lowers
+  // to tile.batch_matmul_acc, whose deducer makes the whole result valid, so a
+  // narrower rectangle advertised here would contradict the tile the conversion
+  // produces and the store would either fail its tile-level check or write the
+  // padded region.
+  if (acc_ndim > 2 || lhs_ndim > 2 || rhs_ndim > 2) {
+    return std::make_shared<TensorType>(acc_shape, result_dtype);
+  }
+  return MakeFreshTensorType(acc_shape, result_dtype, GetValidShape(acc_type));
 }
 
 REGISTER_OP("tensor.matmul_acc")

--- a/tests/ut/ir/operators/test_tensor_ops.py
+++ b/tests/ut/ir/operators/test_tensor_ops.py
@@ -51,15 +51,15 @@ def _tensor_var(name: str, shape: list[int], dtype: DataType = DataType.FP16) ->
     return ir.Var(name, ir.TensorType(dims, dtype), span)
 
 
+def _const_shape_of(result_type) -> list[int]:
+    """Return a deduced TensorType's shape, requiring every dim static."""
+    assert isinstance(result_type, ir.TensorType)
+    return _const_int_values(result_type.shape)
+
+
 def _const_shape(call: ir.Call) -> list[int]:
     """Return the deduced output shape of a tensor op call, requiring every dim static."""
-    result_type = call.type
-    assert isinstance(result_type, ir.TensorType)
-    dims = []
-    for dim in result_type.shape:
-        assert isinstance(dim, ir.ConstInt)
-        dims.append(dim.value)
-    return dims
+    return _const_shape_of(call.type)
 
 
 def test_tensor_create():
@@ -301,6 +301,139 @@ def test_tensor_matmul_acc_nd_acc_batch_mismatch_fails():
 
     with pytest.raises(ValueError, match="acc batch dim"):
         ir.op.tensor.matmul_acc(acc, lhs, rhs)
+
+
+# ---- valid_shape propagation through matmul (issue #2442) ---------------------------------
+#
+# Storage follows the physical M / N; the logical rectangle follows the operands' valid M / N,
+# the same rule tile.matmul applies. This is what lets a caller pad an operand up to the cube
+# fractal — `pl.slice(q, [16, K], off, valid_shape=[5, K])`, the tensor-level spelling of
+# `pl.load(..., valid_shape=...)` — without the logical extent being lost at the tensor level
+# while the lowered tile still carries it.
+
+
+def test_tensor_matmul_carries_lhs_valid_m():
+    """A row-padded lhs yields a product whose valid M is the lhs's, not the padded M."""
+    lhs = _partial_tensor_var([16, 128], [5, 128], name="lhs", dtype=DataType.BF16)
+    rhs = _tensor_var("rhs", [128, 256], DataType.BF16)
+
+    result_type = ir.op.tensor.matmul(lhs, rhs, out_dtype=DataType.FP32).type
+
+    assert isinstance(result_type, ir.TensorType)
+    assert _const_shape_of(result_type) == [16, 256]
+    assert result_type.tensor_view is not None
+    assert _const_int_values(result_type.tensor_view.valid_shape) == [5, 256]
+
+
+def test_tensor_matmul_carries_rhs_valid_n():
+    """A column-narrowed rhs narrows the product's valid N."""
+    lhs = _tensor_var("lhs", [16, 128], DataType.BF16)
+    rhs = _partial_tensor_var([128, 256], [128, 200], name="rhs", dtype=DataType.BF16)
+
+    result_type = ir.op.tensor.matmul(lhs, rhs, out_dtype=DataType.FP32).type
+
+    assert isinstance(result_type, ir.TensorType)
+    assert result_type.tensor_view is not None
+    assert _const_int_values(result_type.tensor_view.valid_shape) == [16, 200]
+
+
+def test_tensor_matmul_valid_dims_follow_transpose_flags():
+    """a_trans / b_trans pick the valid M / N from the same axes as the physical shape."""
+    # lhs is stored [K, M] = [128, 16] with valid [128, 5]; rhs is stored [N, K] = [256, 128].
+    lhs = _partial_tensor_var([128, 16], [128, 5], name="lhs", dtype=DataType.BF16)
+    rhs = _partial_tensor_var([256, 128], [200, 128], name="rhs", dtype=DataType.BF16)
+
+    result_type = ir.op.tensor.matmul(lhs, rhs, out_dtype=DataType.FP32, a_trans=True, b_trans=True).type
+
+    assert isinstance(result_type, ir.TensorType)
+    assert _const_shape_of(result_type) == [16, 256]
+    assert result_type.tensor_view is not None
+    assert _const_int_values(result_type.tensor_view.valid_shape) == [5, 200]
+
+
+def test_tensor_matmul_fully_valid_operands_yield_no_explicit_view():
+    """Fully valid operands still deduce a bare product type — no view churn."""
+    lhs = _tensor_var("lhs", [16, 128], DataType.BF16)
+    rhs = _tensor_var("rhs", [128, 256], DataType.BF16)
+
+    result_type = ir.op.tensor.matmul(lhs, rhs, out_dtype=DataType.FP32).type
+
+    assert isinstance(result_type, ir.TensorType)
+    # Redundant full validity is canonicalized away by the TensorType constructor.
+    assert result_type.tensor_view is None or len(result_type.tensor_view.valid_shape) == 0
+
+
+def test_tensor_matmul_carries_symbolic_valid_m():
+    """A runtime valid extent survives into the product unchanged."""
+    span = ir.Span.unknown()
+    vm = ir.Var("vm", ir.ScalarType(DataType.INDEX), span)
+    view = ir.TensorView([], ir.TensorLayout.ND, valid_shape=[vm, ir.ConstInt(128, DataType.INDEX, span)])
+    lhs_type = ir.TensorType([16, 128], DataType.BF16, None, view)
+    lhs = ir.Var("lhs", lhs_type, span)
+    rhs = _tensor_var("rhs", [128, 256], DataType.BF16)
+
+    result_type = ir.op.tensor.matmul(lhs, rhs, out_dtype=DataType.FP32).type
+
+    assert isinstance(result_type, ir.TensorType)
+    assert result_type.tensor_view is not None
+    assert result_type.tensor_view.valid_shape[0] == vm
+
+
+def test_tensor_matmul_mat_vec_carries_valid_m():
+    """The mat-vec form carries the single surviving valid extent."""
+    lhs = _partial_tensor_var([16, 128], [5, 128], name="lhs", dtype=DataType.BF16)
+    rhs = _tensor_var("rhs", [128], DataType.BF16)
+
+    result_type = ir.op.tensor.matmul(lhs, rhs, out_dtype=DataType.FP32).type
+
+    assert isinstance(result_type, ir.TensorType)
+    assert _const_shape_of(result_type) == [16]
+    assert result_type.tensor_view is not None
+    assert _const_int_values(result_type.tensor_view.valid_shape) == [5]
+
+
+def test_tensor_matmul_nd_batch_stays_fully_valid():
+    """The ND path deduces a fully-valid product, matching its tile.batch_matmul lowering."""
+    lhs = _partial_tensor_var([2, 16, 128], [2, 5, 128], name="lhs", dtype=DataType.BF16)
+    rhs = _tensor_var("rhs", [2, 128, 256], DataType.BF16)
+
+    result_type = ir.op.tensor.matmul(lhs, rhs, out_dtype=DataType.FP32).type
+
+    assert isinstance(result_type, ir.TensorType)
+    assert _const_shape_of(result_type) == [2, 16, 256]
+    assert result_type.tensor_view is None or len(result_type.tensor_view.valid_shape) == 0
+
+
+def test_tensor_matmul_acc_carries_acc_valid_shape():
+    """matmul_acc writes into the accumulator, so the result carries the acc's valid region."""
+    acc = _partial_tensor_var([16, 256], [5, 256], name="acc", dtype=DataType.FP32)
+    lhs = _partial_tensor_var([16, 128], [5, 128], name="lhs", dtype=DataType.BF16)
+    rhs = _tensor_var("rhs", [128, 256], DataType.BF16)
+
+    result_type = ir.op.tensor.matmul_acc(acc, lhs, rhs).type
+
+    assert isinstance(result_type, ir.TensorType)
+    assert _const_shape_of(result_type) == [16, 256]
+    assert result_type.tensor_view is not None
+    assert _const_int_values(result_type.tensor_view.valid_shape) == [5, 256]
+
+
+def test_tensor_matmul_acc_nd_batch_stays_fully_valid():
+    """The ND acc path deduces a fully-valid result, matching tile.batch_matmul_acc.
+
+    tile.batch_matmul_acc makes its whole result valid, so advertising the
+    accumulator's narrower rectangle here would contradict the tile the
+    conversion produces.
+    """
+    acc = _partial_tensor_var([2, 16, 256], [2, 5, 256], name="acc", dtype=DataType.FP32)
+    lhs = _partial_tensor_var([2, 16, 128], [2, 5, 128], name="lhs", dtype=DataType.BF16)
+    rhs = _tensor_var("rhs", [2, 128, 256], DataType.BF16)
+
+    result_type = ir.op.tensor.matmul_acc(acc, lhs, rhs).type
+
+    assert isinstance(result_type, ir.TensorType)
+    assert _const_shape_of(result_type) == [2, 16, 256]
+    assert result_type.tensor_view is None or len(result_type.tensor_view.valid_shape) == 0
 
 
 def test_tensor_row_max():

--- a/tests/ut/language/parser/test_subscript_syntax.py
+++ b/tests/ut/language/parser/test_subscript_syntax.py
@@ -714,6 +714,28 @@ class TestTensorSubscriptWrite:
         printed = narrow_write.as_python()
         assert "tensor.assemble" in printed
 
+    def test_tensor_subscript_write_accepts_matmul_narrowed_by_padded_lhs(self):
+        """A row-padded matmul lhs narrows the product, so a 5-row window is accepted.
+
+        Issue #2442: `pl.slice(q, [16, K], off, valid_shape=[5, K])` is the tensor-level
+        spelling of `pl.load(..., valid_shape=...)` — it pads the operand up to the cube
+        fractal while keeping the logical M. The product must carry that logical M, or
+        this write reads as a 16-vs-5 mismatch and the padded form is unusable.
+        """
+
+        @pl.function
+        def padded_matmul_write(
+            out: pl.Tensor[[5, 256], pl.FP32],
+            q: pl.Tensor[[5, 128], pl.BF16],
+            k: pl.Tensor[[128, 256], pl.BF16],
+        ) -> pl.Tensor[[5, 256], pl.FP32]:
+            q_pad = pl.slice(q, [16, 128], [0, 0], valid_shape=[5, 128], clamp=True)
+            out[0:5, :] = pl.matmul(q_pad, k, out_dtype=pl.FP32)
+            return out
+
+        assert isinstance(padded_matmul_write, ir.Function)
+        assert "tensor.assemble" in padded_matmul_write.as_python()
+
     def test_tensor_subscript_write_rejects_static_and_valid_mismatch(self):
         """src.static=[16, 8], valid=[16, 4]; window 6 cols matches neither — still reject."""
 


### PR DESCRIPTION
## Summary

A tensor-level `pl.matmul` whose operand extents are not multiples of 16 fails in ptoas with `'pto.alloc_tile' op expects result boxed tile rows to be a multiple of innerRows (16), but got 5`. The tile level already expresses this case as `pl.load(..., valid_shape=[5, K])` — a 16-row tile whose logical extent is 5 — and the tensor level can spell the same thing with `pl.slice(q, [16, K], off, valid_shape=[5, K], clamp=True)`. That lowered correctly, but the extent died at the matmul: `DeduceTensorMatMulType` returned a bare `TensorType` with no `tensor_view_`, so the product came out `[16, N]` *fully valid* and the store was rejected as a 16-vs-5 mismatch. `tensor.matmul` / `tensor.matmul_acc` now deduce the valid rectangle the way their tile counterparts always have, so a caller can pad an operand up to the cube fractal and still have the logical extent reach the store — no `pl.set_validshape` after every matmul, no widened store. Fully-valid operands deduce exactly the type they did before.

This is the first half of #2442. It does not auto-pad: a bare `a[0:5, :]` still reaches ptoas unaligned.

## Changes

- `src/ir/op/tensor_ops/matmul.cpp`: `tensor.matmul` deduces `[lhs valid M, rhs valid N]`, each read from the axis `a_trans` / `b_trans` already selects for the physical shape. Mat-vec and vec-mat carry their single surviving extent; the 0-D dot product and the ND batched form stay fully valid, the latter matching the `tile.batch_matmul` it lowers to. `tensor.matmul_acc` carries the accumulator's valid region, since the product is written into it — except in its ND form, which stays fully valid for the same reason, matching the `tile.batch_matmul_acc` it lowers to. Storage still follows the physical `[M, N]`, and a valid shape equal to the physical shape canonicalizes away in the `TensorType` constructor, so no view appears where none did before.
- `tests/ut/ir/operators/test_tensor_ops.py`: nine type-deduction cases — padded lhs M, narrowed rhs N, transpose-flag axis selection, fully-valid operands producing no explicit view, a symbolic extent surviving unchanged, the mat-vec form, the ND form staying fully valid, `matmul_acc` carrying the accumulator's region, and ND `matmul_acc` staying fully valid. `_const_shape` is split into a `_const_shape_of(type)` helper reusing the existing `_const_int_values`, with the call-taking form delegating to it.
- `tests/ut/language/parser/test_subscript_syntax.py`: an end-to-end case in the shape #2442 reports — padded slice, matmul, then a 5-row subscript write into a 5-row tensor. It sits beside the existing `pl.set_validshape` case that already covered the same parser rule.
- `docs/en/dev/ir/05-operators.md`, `docs/zh/dev/ir/05-operators.md`: state the matmul rule in the section that already documents `valid_shape` propagation for the tensor-level unary, scalar, and elementwise ops.

## Behavior change

The deduced type of a tensor-level matmul over a partially-valid operand narrows from fully valid to the operands' valid rectangle. Callers that worked around the old behavior with an explicit `pl.set_validshape` after the matmul still work — the explicit call sets the same extent — and can drop it.

## Verification

Run in the worktree checkout at the pushed commit:

- `clang-format --dry-run --Werror src/ir/op/tensor_ops/matmul.cpp`: exit 0.
- `python tests/lint/check_english_only.py`: exit 0, 1263 files pass.
- `python tests/lint/check_op_name_literals.py`: exit 0.
- `python tests/lint/check_docs_en_zh_parity.py`: exit 0, 159 paired paths.
- `python -m pytest tests/ut/ir/operators/test_tensor_ops.py tests/ut/language/parser/test_subscript_syntax.py -q`: 514 passed.
- `python -m pytest tests/ut -q -n 16`: 10128 passed, 8 skipped. `TestUnifiedSlicePadValue::test_symlinked_import_path_still_names_the_caller` is deselected — it spawns a subprocess whose `PYTHONPATH` drops this checkout, so a stale editable install answers `pypto.pypto_core` and the import fails before reaching any of this change. Pre-existing environment breakage on this machine, unrelated to the change.

Manual check against ptoas 0.57 / `platform="a2a3sim"`, using the repro kernel from #2442 with `M = 5`: it compiles with a plain `out[0:M, :] = pl.matmul(...)`, and the emitted `.pto` matches the `pl.set_validshape` workaround line for line, minus the one `pto.set_validshape` the workaround had to emit. The L1, L0A, and L0C allocations are 16 rows with `valid_row = 5`; the load transfers 5 rows and the store writes 5.
