### PR TITLE
docs(language): document the parameters a signature cannot explain

### DIFF
--- a/python/pypto/jit/decorator.py
+++ b/python/pypto/jit/decorator.py
@@ -191,13 +191,13 @@ def _build_tensor_meta(
     dyn_dims: dict[int, DynDim] | None = None,
     layout: _ir.TensorLayout | None = None,
 ) -> TensorMeta:
-    """Build a :class:`TensorMeta` from per-dim extents and a resolved dtype.
+    """Build a ``TensorMeta`` from per-dim extents and a resolved dtype.
 
     ``dyn_dims`` maps ``dim_idx → DynDim`` for dims declared dynamic at this
     parameter (via ``bind_dynamic`` or an annotation-embedded ``pl.dynamic()``).
     The DynDim's ``static_bound`` is filled from the corresponding extent.
-    Shared by the torch-tensor path (:func:`_extract_tensor_meta`, extent = the
-    real tensor dim) and the signature path (:meth:`JITFunction._bind_args_from_signature`,
+    Shared by the torch-tensor path (``_extract_tensor_meta``, extent = the
+    real tensor dim) and the signature path (``JITFunction._bind_args_from_signature``,
     extent = the static annotation dim or a placeholder for dynamic dims).
 
     ``layout`` is the annotation's third slot. It never comes from a runtime
@@ -247,7 +247,7 @@ def _resolve_annotation(annotation: Any, ann_ns: dict[str, Any] | None) -> Any:
     """Resolve one parameter annotation, evaluating the string form if needed.
 
     ``from __future__ import annotations`` in the *user's* module leaves every
-    annotation as a string; ``ann_ns`` (from :func:`_func_name_lookup`) is the
+    annotation as a string; ``ann_ns`` (from ``_func_name_lookup``) is the
     namespace to evaluate it in.
 
     Args:
@@ -517,7 +517,7 @@ def _build_dyndim_map_for_func(
        match but can differ, e.g. ``rows = pl.dynamic("M")``).
 
     ``DynDim.static_bound`` is filled with ``0`` here as a placeholder; the
-    real per-call extent is injected by :func:`_extract_tensor_meta` from the
+    real per-call extent is injected by ``_extract_tensor_meta`` from the
     actual ``torch.Tensor`` argument.
     """
     func_def = _get_func_def(func)
@@ -561,7 +561,7 @@ def _compute_per_func_dyndim_maps(
     """Per JIT function in the dep graph, return ``param → dim_idx → DynDim``.
 
     Each function's map starts from its own declarations
-    (:func:`_build_dyndim_map_for_func`) and is augmented leaf-first with
+    (``_build_dyndim_map_for_func``) and is augmented leaf-first with
     DynDim entries cascaded from every dep it calls: if a dep param
     ``a.dim=0`` is dynamic and the caller passes its arg ``x`` to that
     param, then ``x.dim=0`` is marked dynamic at the caller too. This
@@ -630,8 +630,8 @@ def _build_dynvar_anchor_index(
     """Inverse map ``DynVar name → list of (param, dim_idx) anchor sites``.
 
     Lets ``[M, HIDDEN]`` (where ``M`` is a DynVar bound to a seeded param's
-    dim) resolve via :func:`_extract_local_tensor_metas` to the parent dim's
-    :class:`DynDim`.
+    dim) resolve via ``_extract_local_tensor_metas`` to the parent dim's
+    ``DynDim``.
     """
     anchors: dict[str, list[tuple[str, int]]] = {}
     for pname, meta in seed_meta.items():
@@ -668,16 +668,16 @@ def _scan_dep_io(
     """Return ``dep_name → (param_names, output_param_names)`` for every @pl.jit
     dep called from ``func``'s body.
 
-    Used by :func:`_extract_local_tensor_metas` to propagate metas through
+    Used by ``_extract_local_tensor_metas`` to propagate metas through
     ``v1, ..., vk = dep(args)`` assignments (each ``vi`` inherits the meta of
     the caller arg bound to the i-th output-like parameter).
 
     ``output_param_names`` covers both ``pl.Out[...]`` and ``pl.InOut[...]``
     params — a caller can capture either from ``v = dep(...)`` — and is kept in
     declaration order so it stays aligned with the callee's return order (the
-    positional target<->param zip in :func:`_dep_out_metas`).
+    positional target<->param zip in ``_dep_out_metas``).
 
-    ``caller_func_type`` mirrors :func:`_discover_deps`'s gating: a host
+    ``caller_func_type`` mirrors ``_discover_deps``'s gating: a host
     orchestrator also admits ``orchestration`` deps (its chip orchestrators).
     """
     out: dict[str, tuple[list[str], list[str]]] = {}
@@ -736,7 +736,7 @@ def _fold_int_arith(op: ast.operator, lhs: int, rhs: int) -> int | None:
 
     Used by ``_extract_local_tensor_metas._resolve_shape_elt`` to keep the
     shape-element resolver under the per-function branch limit. Anything
-    involving a :class:`DynDim` operand is rejected upstream — this helper
+    involving a ``DynDim`` operand is rejected upstream — this helper
     only sees ``int·int``.
     """
     if isinstance(op, ast.Add):
@@ -964,7 +964,7 @@ def _extract_local_tensor_metas(
        scalars, and simple int arithmetic over those), dtype from ``dtype=``.
        A shape element that resolves through a dynamic alias — either
        ``tokens = pl.tensor.dim(P, k)`` for a seeded param ``P`` whose dim
-       ``k`` is :class:`DynDim`-bound, or a direct reference to a DynVar
+       ``k`` is ``DynDim``-bound, or a direct reference to a DynVar
        declared in the seed metas — stamps the matching ``DynDim`` onto the
        local's shape so the dynamic chain keeps flowing through subsequent
        deps.
@@ -983,10 +983,10 @@ def _extract_local_tensor_metas(
        ``pl.Out[...]`` parameters — each ``vi`` inherits the meta of the caller
        argument bound to the i-th ``Out`` parameter (the in-place-output
        convention every such kernel follows, and the same heuristic
-       :func:`_infer_return_type` uses on the callee side).
+       ``_infer_return_type`` uses on the callee side).
 
     ``seed_meta`` pre-populates the table with the caller's parameter metas
-    (including any :class:`DynDim` entries those carry) so a ``pl.slice`` of a
+    (including any ``DynDim`` entries those carry) so a ``pl.slice`` of a
     parameter, a dep call passing a parameter through, or a local
     ``pl.create_tensor`` sized off a dynamic dim of a parameter all resolve;
     ``seed_scalars`` lets compile-time-specialized scalar parameters appear
@@ -1006,13 +1006,13 @@ def _extract_local_tensor_metas(
     dynvar_anchors = _build_dynvar_anchor_index(seed_meta or {})
 
     def _resolve_shape_elt(elt: ast.expr) -> ShapeDim | None:
-        """Resolve a shape element to an ``int`` or a :class:`DynDim`.
+        """Resolve a shape element to an ``int`` or a ``DynDim``.
 
         Dynamic resolution paths (added on top of the original static integer
         resolver):
 
         - ``Name`` that's a dim-alias for ``(P, k)`` where ``P`` is a seeded
-          param with a :class:`DynDim` at dim ``k`` → returns that DynDim.
+          param with a ``DynDim`` at dim ``k`` → returns that DynDim.
         - ``Name`` that's a DynVar declared on a seeded param → returns the
           DynDim of the (first) anchor site.
 
@@ -1210,7 +1210,7 @@ def _arg_ref(arg: ast.expr) -> str | _SlicedArg | None:
 
     - ``ast.Name`` → the variable name (``str``).
     - ``ast.Subscript`` of a Name with integer indices (``x[r]``, ``x[r, 0]``)
-      → a :class:`_SlicedArg` recording the base name and how many leading
+      → a ``_SlicedArg`` recording the base name and how many leading
       dims the indexing drops. Slice indices (``x[r:r+1]``) keep their dim and
       are not counted.
     - anything else (literal, attribute, computed expr) → ``None``.
@@ -1237,7 +1237,7 @@ def _extract_call_args_for_dep(
       pairs it with the dep's parameter list by index) and the keyword
       name for a keyword argument.
     - ``arg_ref`` is the caller-side reference: a variable name (``str``), a
-      :class:`_SlicedArg` for a per-rank subscript (``x[r]``), or ``None`` for
+      ``_SlicedArg`` for a per-rank subscript (``x[r]``), or ``None`` for
       other non-``Name`` expressions (literals, attribute access, …).
 
     Mixed calls like ``dep(a, out=out)`` are preserved correctly. Returns
@@ -1272,7 +1272,7 @@ def _build_param_mapping(
     ``_extract_call_args_for_dep``: a list of ``(param_name, arg_ref)``
     pairs where ``param_name is None`` marks a positional argument (paired
     with ``dep_param_names`` by index) and a string is a keyword name. The
-    ``arg_ref`` may be a name (``str``), a :class:`_SlicedArg`, or ``None``.
+    ``arg_ref`` may be a name (``str``), a ``_SlicedArg``, or ``None``.
     Mixed positional + keyword call sites collapse to the same dict.
     """
     mapping: dict[str, str | _SlicedArg | None] = {}
@@ -1308,10 +1308,10 @@ def _resolve_dep_call_metadata(
     ``caller_func``'s body and apply the positional-or-keyword mapping.
     Intermediate tensors produced in the caller — ``pl.create_tensor``,
     ``pl.slice`` views, and the return values of other ``@pl.jit`` deps — are
-    folded into the metadata pool (see :func:`_extract_local_tensor_metas`).
+    folded into the metadata pool (see ``_extract_local_tensor_metas``).
     Falls back to name-based matching when call-site extraction fails.
 
-    ``caller_func_type`` is forwarded to :func:`_extract_local_tensor_metas`
+    ``caller_func_type`` is forwarded to ``_extract_local_tensor_metas``
     so a host orchestrator's body can also recognise chip-orchestrator deps
     when walking ``v = chip_orch(...)`` return-capture assignments.
     """
@@ -1541,9 +1541,9 @@ class JITFunction:
             ``pld.window`` / ``pld.world_size()`` and the per-rank
             ``device=`` dispatch loop. End-to-end runtime dispatch works when
             the caller supplies ``config=RunConfig(distributed_config=...)``:
-            the config is forwarded through :meth:`_compile` → ``ir.compile()``
-            (see :func:`_run_config_compile_kwargs`), which yields a
-            ``DistributedCompiledProgram`` that :meth:`__call__` dispatches
+            the config is forwarded through ``_compile`` → ``ir.compile()``
+            (see ``_run_config_compile_kwargs``), which yields a
+            ``DistributedCompiledProgram`` that ``__call__`` dispatches
             per-rank.
         _level: pl.Level or None.
         _auto_scope: Whether the compiler auto-inserts AUTO runtime scopes
@@ -1609,7 +1609,7 @@ class JITFunction:
         """Synthetic filename for the generated, specialized source.
 
         Statements that survive specialization are remapped to the user's real
-        ``.py`` via the source map (see :meth:`Specializer.source_map`); this
+        ``.py`` via the source map (see ``Specializer.source_map``); this
         ``<jit:name>`` marker is only the fallback identity for synthesized
         statements that have no original location. Naming the kernel here is far
         more navigable than an anonymous ``<string>``. See issue #1612.
@@ -1796,7 +1796,7 @@ class JITFunction:
     ]:
         """Bind *args/**kwargs to param names and classify into tensor/scalar metadata.
 
-        Tensor metas carry :class:`DynDim` entries for every param dim that is
+        Tensor metas carry ``DynDim`` entries for every param dim that is
         either declared dynamic at this function (``bind_dynamic`` / annotation
         ``pl.dynamic()``) **or** cascaded up from a dep's declarations.
         Cascading happens during ``_compute_per_func_dyndim_maps`` so the cache
@@ -1867,16 +1867,15 @@ class JITFunction:
         dict[str, DataType],
         dict[int, dict[str, dict[int, DynDim]]],
     ]:
-        """Derive the same metadata as :meth:`_bind_args`, but from the kernel's
+        """Derive the same metadata as ``_bind_args``, but from the kernel's
         own parameter annotations — no tensor arguments required.
 
-        Used by :meth:`lower` and :meth:`compile` in annotation-driven signature
-        mode. Each tensor parameter's ``pl.Tensor[[...], dtype]`` annotation
-        supplies the shape/dtype contract directly: static dims are annotation
-        integers, while dynamic dims (``pl.dynamic`` / ``bind_dynamic``) are
-        marked dynamic and given a placeholder extent. Dynamic dimensions lower
-        to runtime ``pl.tensor.dim`` reads and, on the compiled path, collapse to
-        ``None`` in the cache key.
+        Used by [`lower`][pypto.language.JITFunction.lower] and
+        [`compile`][pypto.language.JITFunction.compile] in annotation-driven signature mode. Each tensor
+        parameter's ``pl.Tensor[[...], dtype]`` annotation supplies the shape/dtype contract directly: static
+        dims are annotation integers, while dynamic dims (``pl.dynamic`` / ``bind_dynamic``) are marked
+        dynamic and given a placeholder extent. Dynamic dimensions lower to runtime ``pl.tensor.dim`` reads
+        and, on the compiled path, collapse to ``None`` in the cache key.
 
         Scalar parameters carry no value in the signature, so their values must
         come from ``kwargs`` (or a signature default). A literal is specialized
@@ -1993,11 +1992,12 @@ class JITFunction:
     ) -> tuple[_Specialization, Any | None]:
         """Bind signature or sample arguments and consume the ``RunConfig``.
 
-        Shared by :meth:`lower`, :meth:`__call__`, and :meth:`compile`.
+        Shared by [`lower`][pypto.language.JITFunction.lower], ``__call__``, and
+        [`compile`][pypto.language.JITFunction.compile].
 
         When ``allow_signature_mode`` is set and no positional args are given,
         the shape/dtype contract is read from the kernel's own annotations via
-        :meth:`_bind_args_from_signature`. :meth:`__call__` never enables this
+        ``_bind_args_from_signature``. ``__call__`` never enables this
         because on-device dispatch needs real tensors.
 
         Returns:
@@ -2046,7 +2046,7 @@ class JITFunction:
     ) -> tuple[Any, list[Any], Any | None]:
         """Look up or build a specialized CompiledProgram.
 
-        Shared by :meth:`__call__` (which then dispatches) and :meth:`compile`
+        Shared by ``__call__`` (which then dispatches) and [`compile`][pypto.language.JITFunction.compile]
         (which then returns the CompiledProgram). Cache keys include all inputs
         that affect the generated artifact.
 
@@ -2145,7 +2145,7 @@ class JITFunction:
         A ``config=RunConfig(...)`` keyword argument is consumed here rather
         than passed to the decorated function: its compile-side fields
         (``strategy``, ``dump_passes``, diagnostics, ...) are forwarded to
-        ``ir.compile()`` via :func:`_run_config_compile_kwargs`, and its
+        ``ir.compile()`` via ``_run_config_compile_kwargs``, and its
         runtime fields drive on-device execution.  ``strategy`` also takes
         part in the cache key so artifacts compiled under different strategy
         values never share a cache entry.
@@ -2153,7 +2153,7 @@ class JITFunction:
         Args:
             *args: Positional arguments matching the decorated function's params.
             **kwargs: Keyword arguments.  A ``config`` keyword, if present, is
-                a :class:`~pypto.runtime.runner.RunConfig` and is consumed by
+                a ``RunConfig`` and is consumed by
                 the JIT machinery (not forwarded to the decorated function).
 
         Returns:
@@ -2170,17 +2170,17 @@ class JITFunction:
 
     def compile(self, *args: Any, **kwargs: Any) -> Any:
         """Specialize + compile for the shape/dtype combination implied by *args*,
-        and return the underlying :class:`~pypto.ir.compiled_program.CompiledProgram`.
+        and return the underlying ``CompiledProgram``.
 
-        Same specialization / cache pipeline as :meth:`__call__`, minus the
+        Same specialization / cache pipeline as ``__call__``, minus the
         on-device dispatch. Use this when you want to drive execution through
         the runtime worker API directly:
 
-        - :meth:`pypto.runtime.ChipWorker.run` / :meth:`~pypto.runtime.ChipWorker.register`
+        - ``pypto.runtime.ChipWorker.run`` / ``register``
           for explicit L2 dispatch.
-        - :attr:`CompiledProgram.chip_callable` / ``runtime_name`` / ``runtime_config``
+        - ``CompiledProgram.chip_callable`` / ``runtime_name`` / ``runtime_config``
           to drive a hand-constructed ``simpler.worker.Worker``.
-        - :attr:`CompiledProgram.build_orch_args` / ``build_call_config`` to
+        - ``CompiledProgram.build_orch_args`` / ``build_call_config`` to
           assemble the simpler dispatch tuple yourself.
 
         ``config=RunConfig(...)`` is still consumed (and its compile-side
@@ -2190,7 +2190,7 @@ class JITFunction:
         ``RunConfig`` (``device_id``, DFX flags, ...) do not apply here —
         they affect dispatch, not the compiled artefact.
 
-        Subsequent calls (either :meth:`__call__` or :meth:`compile`) with the
+        Subsequent calls (either ``__call__`` or [`compile`][pypto.language.JITFunction.compile]) with the
         same specialization key hit the L1 cache and return the same
         ``CompiledProgram`` instance.
 
@@ -2249,13 +2249,13 @@ class JITFunction:
                 contents are not read. Omit **all** positional args to compile
                 straight from the signature annotations instead.
             **kwargs: Keyword arguments. A ``config`` keyword, if present, is
-                a :class:`~pypto.runtime.runner.RunConfig`. In signature mode,
+                a ``RunConfig``. In signature mode,
                 scalar parameter values are also passed here (by name) — a
                 literal to specialize it, or ``pl.RUNTIME`` to leave it
                 unspecialized.
 
         Returns:
-            The cached :class:`CompiledProgram` for this specialization.
+            The cached ``CompiledProgram`` for this specialization.
         """
         compiled, _ordered_args, _run_config = self._resolve_compiled(args, kwargs, allow_signature_mode=True)
         return compiled
@@ -2277,7 +2277,7 @@ class JITFunction:
                 into the IR) or ``pl.RUNTIME`` (left unspecialized).
 
         Returns:
-            The specialized :class:`ir.Program` after configured passes.
+            The specialized ``ir.Program`` after configured passes.
         """
         import pypto.language as pl  # noqa: PLC0415
         from pypto.ir.compile import _run_pass_pipeline  # noqa: PLC0415
@@ -2332,13 +2332,13 @@ class JITFunction:
         artifacts (orchestration C++, kernel MLIR).
 
         ``per_func_dyn`` is the per-function effective DynDim map computed in
-        :meth:`_bind_args`; reused here so :func:`_resolve_dep_call_metadata`
+        ``_bind_args``; reused here so ``_resolve_dep_call_metadata``
         doesn't re-walk the dep graph on every cache miss.
 
         ``ir_compile_kwargs`` are forwarded verbatim to ``ir.compile()`` —
         compile-side knobs (``strategy``, ``dump_passes``, ``output_dir``,
         ``profiling``, diagnostics, ...) that the JIT caller derives from a
-        ``RunConfig`` via :func:`_run_config_compile_kwargs`.
+        ``RunConfig`` via ``_run_config_compile_kwargs``.
         """
         from pypto.ir.compile import compile as ir_compile  # noqa: PLC0415
 

--- a/python/pypto/language/arg_direction.py
+++ b/python/pypto/language/arg_direction.py
@@ -9,7 +9,7 @@
 
 """Per-call-site direction markers for PyPTO Language DSL.
 
-These markers attach an explicit :class:`pypto.ir.ArgDirection` to a call
+These markers attach an explicit ``pypto.ir.ArgDirection`` to a call
 argument and are stored on ``ir.Call.attrs['arg_directions']`` (also
 accessible via the ``ir.Call.arg_directions`` shortcut property).
 
@@ -25,12 +25,12 @@ preserve the metadata::
     )
 
 Each ``pl.adir.<name>`` symbol is a direct alias of the matching
-:class:`ir.ArgDirection` enum value — they are not callable. Per-argument
+``ir.ArgDirection`` enum value — they are not callable. Per-argument
 wrapper forms such as ``pl.adir.input(x)`` are intentionally not supported.
 
 The markers correspond 1:1 with the runtime task-submission methods on
 ``PTOParam`` (``add_input`` / ``add_output`` / ``add_inout`` /
-``add_no_dep`` / ``add_scalar``) and with :class:`ir.ArgDirection` enum
+``add_no_dep`` / ``add_scalar``) and with ``ir.ArgDirection`` enum
 values:
 
 ==================== ================================

--- a/python/pypto/language/dsl_api.py
+++ b/python/pypto/language/dsl_api.py
@@ -720,7 +720,7 @@ class SpmdContext:
         # decorator parses the function source rather than executing it — but
         # returning ``self`` keeps ``as`` syntactically legal (and ``tid``
         # non-``None`` under static checking) when a script is executed directly
-        # (e.g. for linting), matching :meth:`AtContext.__enter__`.
+        # (e.g. for linting), matching ``AtContext.__enter__``.
         return self
 
     def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
@@ -920,7 +920,7 @@ class SplitAivContext:
     """Loop iterator for the explicit AIV-split region.
 
     The parser recognizes ``for aiv_id in pl.split_aiv(2, mode=...):`` and builds
-    a first-class :class:`~pypto.pypto_core.ir.SplitAivScopeStmt` region node
+    a first-class ``SplitAivScopeStmt`` region node
     carrying the requested ``SplitMode``. Unlike the legacy whole-InCore-scope
     split, this region is a structural node that may be nested anywhere in an
     InCore body — inside a ``pl.range`` / ``pl.pipeline`` loop or an ``if``. The
@@ -955,7 +955,7 @@ def split_aiv(n: int, *, mode: ir.SplitMode) -> SplitAivContext:
         for aiv_id in pl.split_aiv(2, mode=pl.SplitMode.UP_DOWN):
             ...  # body runs per AIV lane; aiv_id = pl.tile.get_subblock_idx()
 
-    The loop builds a first-class :class:`~pypto.pypto_core.ir.SplitAivScopeStmt`
+    The loop builds a first-class ``SplitAivScopeStmt``
     region carrying the requested ``SplitMode``. Because it is a structural node
     (not a whole-InCore-scope flag), it is **nestable**: the region may appear
     inside a ``pl.range`` / ``pl.pipeline`` loop or an ``if``, and sibling regions

--- a/python/pypto/language/op/prefetch_ops.py
+++ b/python/pypto/language/op/prefetch_ops.py
@@ -9,9 +9,9 @@
 
 """``pl.prefetch.*`` — asynchronous GM->L2 prefetch operations.
 
-A latency-hiding cache hint: :func:`async_prefetch` starts an SDMA-backed pull of
-a global-memory region into L2 while unrelated compute proceeds, and
-:func:`wait` blocks until it lands. The prefetch changes no tensor values, so a
+A latency-hiding cache hint: [`async_prefetch`][pypto.language.prefetch.async_prefetch] starts an SDMA-backed
+pull of a global-memory region into L2 while unrelated compute proceeds, and
+[`wait`][pypto.language.prefetch.wait] blocks until it lands. The prefetch changes no tensor values, so a
 kernel is numerically identical with or without it — only performance differs.
 
 Typical usage::
@@ -56,8 +56,9 @@ def make_context() -> PrefetchAsyncContext:
     context to a hidden runtime-owned SDMA allocation.
 
     Returns:
-        A :class:`PrefetchAsyncContext` handle to pass to :func:`async_prefetch`
-        and :func:`session`.
+        A [`PrefetchAsyncContext`][pypto.language.PrefetchAsyncContext] handle to pass to
+        [`async_prefetch`][pypto.language.prefetch.async_prefetch]
+        and [`session`][pypto.language.prefetch.session].
     """
     return PrefetchAsyncContext(expr=_ir_prefetch.make_context())
 
@@ -68,13 +69,15 @@ def async_prefetch(src: Tensor, ctx: PrefetchAsyncContext) -> AsyncEvent:
     Does not block and does not modify ``src``.
 
     Args:
-        src: A flat contiguous logical-1D GM :class:`pl.Tensor` to pull into L2.
+        src: A flat contiguous logical-1D GM [`pl.Tensor`][pypto.language.Tensor] to pull into L2.
             The op verifier (C++) requires a fully static shape whose dimensions
             are all 1 except the last — e.g. ``[N]`` or ``[1, N]``.
-        ctx: A :class:`PrefetchAsyncContext` from :func:`make_context`.
+        ctx: A [`PrefetchAsyncContext`][pypto.language.PrefetchAsyncContext] from
+            [`make_context`][pypto.language.prefetch.make_context].
 
     Returns:
-        An :class:`AsyncEvent` to pass to :func:`wait` along with the session.
+        An [`AsyncEvent`][pypto.language.AsyncEvent] to pass to [`wait`][pypto.language.prefetch.wait] along
+        with the session.
     """
     return AsyncEvent(expr=_ir_prefetch.async_prefetch(_unwrap(src), _unwrap(ctx)))
 
@@ -83,10 +86,11 @@ def session(ctx: PrefetchAsyncContext) -> AsyncSession:
     """Project the asynchronous session bound to a prefetch context.
 
     Args:
-        ctx: A :class:`PrefetchAsyncContext` from :func:`make_context`.
+        ctx: A [`PrefetchAsyncContext`][pypto.language.PrefetchAsyncContext] from
+            [`make_context`][pypto.language.prefetch.make_context].
 
     Returns:
-        An :class:`AsyncSession` to pass to :func:`wait`.
+        An [`AsyncSession`][pypto.language.AsyncSession] to pass to [`wait`][pypto.language.prefetch.wait].
     """
     return AsyncSession(expr=_ir_prefetch.session(_unwrap(ctx)))
 
@@ -98,11 +102,13 @@ def wait(event: AsyncEvent, session_handle: AsyncSession) -> Scalar:
     data is resident in L2.
 
     Args:
-        event: An :class:`AsyncEvent` from :func:`async_prefetch`.
-        session_handle: The matching :class:`AsyncSession` from :func:`session`.
+        event: An [`AsyncEvent`][pypto.language.AsyncEvent] from
+            [`async_prefetch`][pypto.language.prefetch.async_prefetch].
+        session_handle: The matching [`AsyncSession`][pypto.language.AsyncSession] from
+            [`session`][pypto.language.prefetch.session].
 
     Returns:
-        A ``BOOL`` :class:`Scalar` done flag.
+        A ``BOOL`` [`Scalar`][pypto.language.Scalar] done flag.
     """
     return Scalar(expr=_ir_prefetch.wait(_unwrap(event), _unwrap(session_handle)))
 

--- a/python/pypto/language/op/system_ops.py
+++ b/python/pypto/language/op/system_ops.py
@@ -317,10 +317,10 @@ def tfree_to_aic(
     Args:
         tile: The tile returned by the matching [`tpop_from_aic`][pypto.language.system.tpop_from_aic].
         span: Optional source span
-        split: Split mode (0=none, 1=up-down, 2=left-right). Leave ``None``: the
-            ``StampTfreeSplit`` pass copies it from the originating ``tpop``. Pass a
-            value only to override that.
-        id: Optional frontend pipe id. Omit to use PTOAS default id 0.
+        split: Leave ``None``. The ``StampTfreeSplit`` pass always takes this from
+            the originating ``tpop``, so a value passed here cannot override it.
+        id: Optional frontend pipe id, inherited from the originating ``tpop`` when
+            omitted. Supplying one that disagrees with the ``tpop`` is rejected.
     """
     return _ir_ops.tfree_to_aic(tile.unwrap(), split=split, id=id, span=span)
 
@@ -336,10 +336,10 @@ def tfree_to_aiv(
     Args:
         tile: The tile returned by the matching [`tpop_from_aiv`][pypto.language.system.tpop_from_aiv].
         span: Optional source span
-        split: Split mode (0=none, 1=up-down, 2=left-right). Leave ``None``: the
-            ``StampTfreeSplit`` pass copies it from the originating ``tpop``. Pass a
-            value only to override that.
-        id: Optional frontend pipe id. Omit to use PTOAS default id 0.
+        split: Leave ``None``. The ``StampTfreeSplit`` pass always takes this from
+            the originating ``tpop``, so a value passed here cannot override it.
+        id: Optional frontend pipe id, inherited from the originating ``tpop`` when
+            omitted. Supplying one that disagrees with the ``tpop`` is rejected.
     """
     return _ir_ops.tfree_to_aiv(tile.unwrap(), split=split, id=id, span=span)
 

--- a/python/pypto/language/op/system_ops.py
+++ b/python/pypto/language/op/system_ops.py
@@ -75,7 +75,15 @@ def sync_set(
 ) -> Call:
     """Set a Cube/Vector cross-core event using a static or dynamic event id.
 
-    Set ``core_type`` to ``"aic"`` or ``"aiv"`` inside a mixed InCore kernel.
+    Args:
+        event_id: Event to signal. An int in the user-available range 0-13, or a
+            dynamic ``pl.Scalar[pl.INDEX]``. IDs 14 and 15 are reserved.
+        pipe: Pipe the event is raised on. The matching [`sync_wait`][pypto.language.system.sync_wait] must
+            name the same pipe -- pairing event ids and pipes is the author's responsibility.
+        ffts_mode: Optional FFTS mode, 0, 1 or 2. Accepted by ``sync_set`` only.
+        core_type: ``"aic"`` or ``"aiv"``, to keep the event on the intended lane
+            when a mixed InCore kernel is expanded. Omit in an explicitly typed kernel.
+        span: Optional source span
     """
     event_expr = event_id.unwrap() if isinstance(event_id, Scalar) else event_id
     return _ir_ops.sync_set(event_expr, pipe=pipe, ffts_mode=ffts_mode, core_type=core_type, span=span)
@@ -90,7 +98,12 @@ def sync_wait(
 ) -> Call:
     """Wait for a Cube/Vector cross-core event using a static or dynamic event id.
 
-    Set ``core_type`` to ``"aic"`` or ``"aiv"`` inside a mixed InCore kernel.
+    Args:
+        event_id: Event to wait on -- the one a matching [`sync_set`][pypto.language.system.sync_set] raises.
+        pipe: Pipe the event is awaited on; must match the ``sync_set``.
+        core_type: ``"aic"`` or ``"aiv"``, to keep the wait on the intended lane
+            when a mixed InCore kernel is expanded. Omit in an explicitly typed kernel.
+        span: Optional source span
     """
     event_expr = event_id.unwrap() if isinstance(event_id, Scalar) else event_id
     return _ir_ops.sync_wait(event_expr, pipe=pipe, core_type=core_type, span=span)
@@ -124,7 +137,7 @@ def syncall(
       ``core_type`` (a partial launch deadlocks on device — error 507018). The
       compiler rejects a partial-occupancy hard launch at compile time
       (``HardSyncallOccupancy`` verifier, issue #1935). See
-      :func:`pypto.ir.op.system_ops.syncall`.
+      ``pypto.ir.op.system_ops.syncall``.
     - ``mode="soft"``: GM-polling barrier that works at partial occupancy.
       Each participant updates a shared counter in an exclusive 64-byte GM
       cache line and polls until all participants arrive. Supported for every
@@ -260,26 +273,74 @@ def cacheinvalid(
 
 
 def tpush_to_aiv(tile: Tile, *, split: int, id: int | None = None, span: Span | None = None) -> Call:
-    """Push tile data from AIC to AIV via cross-core pipe."""
+    """Push tile data from AIC to AIV via cross-core pipe.
+
+    The Vector side receives it with [`tpop_from_aic`][pypto.language.system.tpop_from_aic] and releases the
+    slot with [`tfree_to_aic`][pypto.language.system.tfree_to_aic]; ``split`` and ``id`` must match across all
+    three.
+
+    Args:
+        tile: Tile to send. Its Cube-side buffer stays live until the consumer frees the slot.
+        split: Split mode (0=none, 1=up-down, 2=left-right). Selects the axis along
+            which the two AIV lanes divide the tile; 0 sends it whole.
+        id: Optional frontend pipe id. Omit to use PTOAS default id 0.
+        span: Optional source span
+    """
     return _ir_ops.tpush_to_aiv(tile.unwrap(), split=split, id=id, span=span)
 
 
 def tpush_to_aic(tile: Tile, *, split: int, id: int | None = None, span: Span | None = None) -> Call:
-    """Push tile data from AIV to AIC via cross-core pipe."""
+    """Push tile data from AIV to AIC via cross-core pipe.
+
+    The Cube side receives it with [`tpop_from_aiv`][pypto.language.system.tpop_from_aiv] and releases the
+    slot with [`tfree_to_aiv`][pypto.language.system.tfree_to_aiv]; ``split`` and ``id`` must match across all
+    three.
+
+    Args:
+        tile: Tile to send. Its Vector-side buffer stays live until the consumer frees the slot.
+        split: Split mode (0=none, 1=up-down, 2=left-right). Selects the axis along
+            which the two AIV lanes divide the tile; 0 sends it whole.
+        id: Optional frontend pipe id. Omit to use PTOAS default id 0.
+        span: Optional source span
+    """
     return _ir_ops.tpush_to_aic(tile.unwrap(), split=split, id=id, span=span)
 
 
 def tfree_to_aic(
     tile: Tile, span: Span | None = None, *, split: int | None = None, id: int | None = None
 ) -> Call:
-    """Release ring buffer slot back to AIC producer."""
+    """Release ring buffer slot back to AIC producer.
+
+    Call this once the tile from [`tpop_from_aic`][pypto.language.system.tpop_from_aic] has been consumed.
+    Until it runs, the slot stays occupied and the producer blocks once the ring fills.
+
+    Args:
+        tile: The tile returned by the matching [`tpop_from_aic`][pypto.language.system.tpop_from_aic].
+        span: Optional source span
+        split: Split mode (0=none, 1=up-down, 2=left-right). Leave ``None``: the
+            ``StampTfreeSplit`` pass copies it from the originating ``tpop``. Pass a
+            value only to override that.
+        id: Optional frontend pipe id. Omit to use PTOAS default id 0.
+    """
     return _ir_ops.tfree_to_aic(tile.unwrap(), split=split, id=id, span=span)
 
 
 def tfree_to_aiv(
     tile: Tile, span: Span | None = None, *, split: int | None = None, id: int | None = None
 ) -> Call:
-    """Release ring buffer slot back to AIV producer."""
+    """Release ring buffer slot back to AIV producer.
+
+    Call this once the tile from [`tpop_from_aiv`][pypto.language.system.tpop_from_aiv] has been consumed.
+    Until it runs, the slot stays occupied and the producer blocks once the ring fills.
+
+    Args:
+        tile: The tile returned by the matching [`tpop_from_aiv`][pypto.language.system.tpop_from_aiv].
+        span: Optional source span
+        split: Split mode (0=none, 1=up-down, 2=left-right). Leave ``None``: the
+            ``StampTfreeSplit`` pass copies it from the originating ``tpop``. Pass a
+            value only to override that.
+        id: Optional frontend pipe id. Omit to use PTOAS default id 0.
+    """
     return _ir_ops.tfree_to_aiv(tile.unwrap(), split=split, id=id, span=span)
 
 
@@ -383,6 +444,16 @@ def task_dummy(*, deps: Sequence[Scalar | Array | None]) -> Scalar:
     intercepted syntactically and lowered to ``system.task_dummy`` with manual
     dep edges. The body exists so the public DSL name resolves for static
     checkers and imports.
+
+    Args:
+        deps: TaskIds the barrier waits on -- each a ``pl.Scalar[pl.TASK_ID]``
+            returned by ``pl.submit``, or a ``pl.array`` of them for fan-in.
+            ``None`` entries are skipped, so a conditionally-produced TaskId needs
+            no branch at the call site.
+
+    Returns:
+        A ``pl.Scalar[pl.TASK_ID]`` that becomes ready once every dep has. Depend on
+        it instead of listing all of `deps` again at each consumer.
     """
     raise RuntimeError(
         "pl.system.task_dummy is a DSL parser construct and cannot be called directly; "
@@ -424,9 +495,10 @@ def available_cluster_count(*, span: Span | None = None) -> Scalar:
 def available_aiv_count(*, span: Span | None = None) -> Scalar:
     """This run's standalone AIV core count, as reported by the runtime.
 
-    The AIV counterpart of :func:`available_cluster_count` — the ``core_num``
-    of a vector-only ``pl.spmd`` launch. A mixed launch sizes itself on
-    :func:`available_cluster_count` (one block per cluster), not on this.
+    The AIV counterpart of [`available_cluster_count`][pypto.language.system.available_cluster_count] — the
+    ``core_num`` of a vector-only ``pl.spmd`` launch. A mixed launch sizes itself on
+    [`available_cluster_count`][pypto.language.system.available_cluster_count] (one block per cluster), not on
+    this.
 
     Codegen lowers it to the orchestration helper ``rt_available_aiv_count()``.
 

--- a/python/pypto/language/op/tensor_ops.py
+++ b/python/pypto/language/op/tensor_ops.py
@@ -2136,7 +2136,7 @@ def gather(
     [`pl.tile.gather_compare`][pypto.language.tile.gather_compare]:
         Scalar threshold compare (applied to every row). Returns ``(dst, cdst)`` —
         gathered indices ``[rows, out_cols] INT32`` and per-row match counts
-        ``[rows, 1] count_dtype``.
+        ``[1, rows] count_dtype``.
 
     Args:
         input: Source tensor (FP16/FP32/INT16/INT32).
@@ -2315,7 +2315,7 @@ def gather_row(  # noqa: PLR0913
     ``src_offset`` (block-table lookup, multi-source selection, invalid clamping)
     and the ``dst_offset`` slot itself, so arbitrary gather logic stays in the
     kernel. DMAs ``src`` straight into ``acc`` (``GM -> L1``, no ``tmov``); the
-    returned tile feeds ``pl.matmul`` directly.
+    returned tensor feeds ``pl.matmul`` directly.
 
     Args:
         acc: On-chip accumulator from [`create_l1`][pypto.language.tensor.create_l1] (loop-carried).

--- a/python/pypto/language/op/tensor_ops.py
+++ b/python/pypto/language/op/tensor_ops.py
@@ -441,7 +441,7 @@ def slice(
             ``None`` means the source's padding mode carries through.
             Accepts ``PadValue.zero`` / ``PadValue.max`` / ``PadValue.min``, or
             the literal sugars ``0``, ``math.inf``, ``-math.inf`` (same
-            spelling as :func:`tensor.fillpad`). Only meaningful when the
+            spelling as [`tensor.fillpad`][pypto.language.tensor.fillpad]). Only meaningful when the
             *effective* valid region is smaller than ``shape`` — which an explicit
             ``valid_shape``, a partially-valid source, or ``clamp=True`` can each
             bring about.
@@ -514,7 +514,7 @@ def fillpad_expand(
 ) -> Tensor:
     """Copy a smaller source tensor into a larger destination tensor, padding the rest.
 
-    Unlike :func:`fillpad` (which keeps the same shape and only fills the invalid
+    Unlike [`fillpad`][pypto.language.tensor.fillpad] (which keeps the same shape and only fills the invalid
     view region), the destination ``shape`` may be larger than the source in
     either dimension. The source's valid region is copied into the top-left of
     the destination and every other element is filled with ``pad_value``.
@@ -1931,7 +1931,7 @@ def view(
     At least one of ``shape`` or ``layout`` must be provided. The result is a
     zero-copy tensor view with canonical strides derived by the IR type deducer.
 
-    See :func:`pypto.ir.op.tensor.view` for full details on validity
+    See [`tensor.view`][pypto.language.tensor.view] for full details on validity
     constraints, error conditions, and the product-preserving shape rule.
 
     Args:
@@ -2120,7 +2120,7 @@ def gather(
     The tensor layer exposes a single unified ``gather``. Based on the arguments
     you pass, it lowers to one of three tile-level ops:
 
-    Index form (``dim`` + ``index``) → :func:`pl.tile.gather`::
+    Index form (``dim`` + ``index``) → [`pl.tile.gather`][pypto.language.tile.gather]::
 
         output[b, k] = input[b, index[b, k]]
 
@@ -2128,11 +2128,12 @@ def gather(
         ``index`` must be an INT32 tensor, or INT16 when ``input`` is a 16-bit
         dtype (FP16/INT16); its shape matches ``input`` on every axis except ``dim``.
 
-    Mask form (``mask_pattern=<int>``) → :func:`pl.tile.gather_mask`:
+    Mask form (``mask_pattern=<int>``) → [`pl.tile.gather_mask`][pypto.language.tile.gather_mask]:
         Selects columns of each row by a fixed hardware mask pattern. Last-dim
         shrinks by 2 (P0101/P1010) or 4 (P0001..P1000), or stays the same for P1111.
 
-    Compare form (``kvalue`` + ``cmp_mode`` + ``out_cols``) → :func:`pl.tile.gather_compare`:
+    Compare form (``kvalue`` + ``cmp_mode`` + ``out_cols``) →
+    [`pl.tile.gather_compare`][pypto.language.tile.gather_compare]:
         Scalar threshold compare (applied to every row). Returns ``(dst, cdst)`` —
         gathered indices ``[rows, out_cols] INT32`` and per-row match counts
         ``[rows, 1] count_dtype``.
@@ -2271,7 +2272,7 @@ def paged_gather(  # noqa: PLR0913
 def create_l1(shape: Sequence[IntLike], dtype: DataType, transpose: bool = False) -> Tensor:
     """Create an on-chip (L1/Mat) accumulator for a kernel-driven paged gather.
 
-    Companion of :func:`gather_row`. Returns a tensor-typed value that composes
+    Companion of [`gather_row`][pypto.language.tensor.gather_row]. Returns a tensor-typed value that composes
     with ``pl.matmul`` / softmax but lowers to an L1 (``MemorySpace.Mat``) tile,
     so a kernel can build a matmul operand directly on-chip — no GM round-trip.
 
@@ -2310,14 +2311,14 @@ def gather_row(  # noqa: PLR0913
     """Gather one GM row into a sub-region of an on-chip accumulator (DPS).
 
     Per-row primitive for a kernel-driven paged gather into L1 — the flexible
-    counterpart to :func:`paged_gather`: the caller computes the physical
+    counterpart to [`paged_gather`][pypto.language.tensor.paged_gather]: the caller computes the physical
     ``src_offset`` (block-table lookup, multi-source selection, invalid clamping)
     and the ``dst_offset`` slot itself, so arbitrary gather logic stays in the
     kernel. DMAs ``src`` straight into ``acc`` (``GM -> L1``, no ``tmov``); the
     returned tile feeds ``pl.matmul`` directly.
 
     Args:
-        acc: On-chip accumulator from :func:`create_l1` (loop-carried).
+        acc: On-chip accumulator from [`create_l1`][pypto.language.tensor.create_l1] (loop-carried).
         src: Source pool in GM.
         dst_offset: ``[row, col]`` slot within ``acc`` to write.
         src_offset: ``[row, col]`` physical offset within the GM ``src``.
@@ -2368,8 +2369,8 @@ def scatter(
     The tensor layer exposes a single unified ``scatter``. Based on the arguments
     you pass, it lowers to one of two tile-level ops:
 
-    Index form (``dim`` + ``index`` + ``src``) → :func:`pl.tile.scatter` — the
-    column-wise inverse of :func:`gather`, so ``index`` has the same shape as
+    Index form (``dim`` + ``index`` + ``src``) → [`pl.tile.scatter`][pypto.language.tile.scatter] — the
+    column-wise inverse of [`gather`][pypto.language.tensor.gather], so ``index`` has the same shape as
     ``src`` (just like gather's index matches its output)::
 
         output = input
@@ -2380,7 +2381,7 @@ def scatter(
         width must match ``input``: 4-byte input → INT32, 2-byte → INT16,
         1-byte → INT16.
 
-    Mask form (``mask_pattern=<int>`` + ``dst``) → :func:`pl.tile.scatter_mask`:
+    Mask form (``mask_pattern=<int>`` + ``dst``) → [`pl.tile.scatter_mask`][pypto.language.tile.scatter_mask]:
         Writes each row of ``input`` into the columns of ``dst`` selected by the
         hardware mask pattern. ``dst.cols`` equals ``input.cols * stride``
         (stride = 2 for P0101/P1010, 4 for P0001..P1000, 1 for P1111).
@@ -2443,6 +2444,13 @@ def alloc(
     The result is a base ``Ptr`` (allocation identity token): the printer
     annotates the assignment target as ``pl.Ptr``, matching the IR design
     where ``tensor.alloc`` Calls carry ``PtrType``.
+
+    Args:
+        memory_space: Space the allocation lives in, as resolved by InferTileMemorySpace.
+        size: Allocation size in bytes.
+
+    Returns:
+        A ``Ptr`` standing for the allocation, carrying no address of its own.
     """
     return PtrType()
 

--- a/python/pypto/language/op/tile_ops.py
+++ b/python/pypto/language/op/tile_ops.py
@@ -216,7 +216,7 @@ class MemRefType:
     the text-parser can ``exec()``.
 
     Note: this is *not* the type of a ``tile.alloc`` / ``tensor.alloc`` result —
-    those produce a base ``Ptr`` (``PtrType``); see :func:`alloc`.
+    those produce a base ``Ptr`` (``PtrType``); see [`alloc`][pypto.language.tile.alloc].
     """
 
 
@@ -502,7 +502,7 @@ def gather_row(  # noqa: PLR0913
     slot itself, so arbitrary gather logic stays in the kernel. Writes ``dst``
     in place, so a loop-carried accumulator is filled row by row and feeds
     ``pl.matmul`` directly — the tile-level counterpart of
-    :func:`pypto.language.op.tensor_ops.gather_row`.
+    ``pypto.language.op.tensor_ops.gather_row``.
 
     Args:
         dst: Destination on-chip accumulator tile (Mat/L1 or Vec/UB).
@@ -667,7 +667,7 @@ def aiv_shard(x: _SplitOperandT, span: Span | None = None) -> _SplitOperandT:
 def aic_gather(x: _SplitOperandT, span: Span | None = None) -> _SplitOperandT:
     """Hand a vector-produced operand to the cube (AIV -> AIC crossing).
 
-    Inverse of :func:`aiv_shard`: in a data-parallel region it **rejoins** the two
+    Inverse of [`aiv_shard`][pypto.language.tile.aiv_shard]: in a data-parallel region it **rejoins** the two
     lanes' halves along the split axis, and in a task-parallel ``mode=NONE`` region
     it crosses and **preserves the shape**. It is how a V->C crossing out of a
     region is named; an unnamed one is rejected by the ``AivSplitValid`` verifier.
@@ -679,7 +679,7 @@ def aic_gather(x: _SplitOperandT, span: Span | None = None) -> _SplitOperandT:
     the push and still sends its own tile. Gather only a value both lanes agree
     on; if they must contribute different data, use a data-parallel region.
 
-    Like :func:`aiv_shard`, the split mode is
+    Like [`aiv_shard`][pypto.language.tile.aiv_shard], the split mode is
     **inherited** from the enclosing ``for aiv_id in pl.split_aiv(mode=...)``
     scope and must not be passed here. Calling it eagerly (outside a parsed
     program) raises, since there is no scope to read the mode from.
@@ -757,6 +757,19 @@ def tri(
     ``upper=False`` writes one where ``j <= i + diagonal``; ``upper=True``
     writes one where ``j >= i + diagonal``. Only the optional valid region is
     written.
+
+    Args:
+        diagonal: Offset of the boundary from the main diagonal, in columns.
+            0 includes the diagonal; positive shifts it right, negative left.
+            May be a runtime ``Scalar``.
+        shape: Shape of the destination tile (static).
+        valid_shape: Optional written region (each dim ``<= shape``). Elements
+            outside it are left untouched. Defaults to the full shape.
+        dtype: Destination dtype. Defaults to ``INT32``.
+        upper: Select the upper triangle instead of the lower.
+
+    Returns:
+        A tile holding 1 inside the selected triangle and 0 outside it.
     """
     diagonal_expr = diagonal.unwrap() if isinstance(diagonal, Scalar) else diagonal
     call_expr = _ir_ops.tri(
@@ -854,7 +867,7 @@ def fillpad_expand(
 ) -> Tile:
     """Copy a smaller source tile into a larger destination tile, padding the rest.
 
-    Unlike :func:`fillpad` (which keeps the same physical shape and only fills the
+    Unlike [`fillpad`][pypto.language.tile.fillpad] (which keeps the same physical shape and only fills the
     valid-region expansion), this op produces a *larger* output tile: the source's
     valid region is copied to the top-left and every other element is filled with
     ``pad_value``. Equivalent to TFILLPAD_EXPAND on the hardware.
@@ -1312,7 +1325,7 @@ def matmul_mx(lhs: Tile, lhs_scale: Tile, rhs: Tile, rhs_scale: Tile) -> Tile:
 def matmul_mx_acc(acc: Tile, lhs: Tile, lhs_scale: Tile, rhs: Tile, rhs_scale: Tile) -> Tile:
     """MX block-scale matmul with accumulation.
 
-    Data operands follow :func:`matmul_mx`: an FP4 lhs must first be cast to
+    Data operands follow [`matmul_mx`][pypto.language.tile.matmul_mx]: an FP4 lhs must first be cast to
     FP8E4M3FN, and the operation itself receives two FP8E4M3FN tiles.
 
     Args:
@@ -1334,7 +1347,7 @@ def matmul_mx_acc(acc: Tile, lhs: Tile, lhs_scale: Tile, rhs: Tile, rhs_scale: T
 def matmul_mx_bias(lhs: Tile, lhs_scale: Tile, rhs: Tile, rhs_scale: Tile, bias: Tile) -> Tile:
     """MX block-scale matmul with bias.
 
-    Data operands follow :func:`matmul_mx`: an FP4 lhs must first be cast to
+    Data operands follow [`matmul_mx`][pypto.language.tile.matmul_mx]: an FP4 lhs must first be cast to
     FP8E4M3FN, and the operation itself receives two FP8E4M3FN tiles.
 
     Args:
@@ -1376,7 +1389,7 @@ def gemv_acc(acc: Tile, lhs: Tile, rhs: Tile, acc_phase: str = "unspecified") ->
     """GEMV with accumulation: C[1,N] += A[1,K] @ B[K,N].
 
     ``acc`` must use the GEMV output dtype. The logical K extents and lhs/rhs
-    dtype requirements are identical to :func:`gemv`.
+    dtype requirements are identical to [`gemv`][pypto.language.tile.gemv].
 
     Args:
         acc: Accumulator tile [1, N]
@@ -1396,7 +1409,7 @@ def gemv_bias(lhs: Tile, rhs: Tile, bias: Tile, acc_phase: str = "unspecified") 
 
     ``bias`` must use the GEMV output dtype and its valid shape must cover the
     logical output shape ``[1, N]``. The logical K extents and lhs/rhs dtype
-    requirements are identical to :func:`gemv`.
+    requirements are identical to [`gemv`][pypto.language.tile.gemv].
 
     Args:
         lhs: Row vector tile [1, K]
@@ -1889,8 +1902,8 @@ def cmps(lhs: Tile, rhs: int | float | Expr | Scalar, cmp_type: int = 0) -> Tile
 def max(lhs: Scalar | int | Expr, rhs: Scalar | int | Expr) -> Scalar:
     """Scalar max of two values.
 
-    Tile reductions are direction-specific — use :func:`row_max` (collapses the
-    last axis) or :func:`col_max` (collapses axis 0).
+    Tile reductions are direction-specific — use [`row_max`][pypto.language.tile.row_max] (collapses the
+    last axis) or [`col_max`][pypto.language.tile.col_max] (collapses axis 0).
 
     Args:
         lhs: First scalar operand
@@ -1905,8 +1918,8 @@ def max(lhs: Scalar | int | Expr, rhs: Scalar | int | Expr) -> Scalar:
 def min(lhs: Scalar | int | Expr, rhs: Scalar | int | Expr) -> Scalar:
     """Scalar min of two values.
 
-    Tile reductions are direction-specific — use :func:`row_min` (collapses the
-    last axis) or :func:`col_min` (collapses axis 0).
+    Tile reductions are direction-specific — use [`row_min`][pypto.language.tile.row_min] (collapses the
+    last axis) or [`col_min`][pypto.language.tile.col_min] (collapses axis 0).
 
     Args:
         lhs: First scalar operand
@@ -1947,7 +1960,7 @@ def slice(
             ``None`` means the source's padding mode carries through.
             Accepts ``PadValue.zero`` / ``PadValue.max`` / ``PadValue.min``, or
             the literal sugars ``0``, ``math.inf``, ``-math.inf`` (same
-            spelling as :func:`tile.fillpad`). Only meaningful when the
+            spelling as [`tile.fillpad`][pypto.language.tile.fillpad]). Only meaningful when the
             *effective* valid region is smaller than ``shape`` — which an explicit
             ``valid_shape`` or a partially-valid source tile can each bring about.
 
@@ -1955,7 +1968,7 @@ def slice(
         Tile wrapping the slice operation
 
     Note:
-        Unlike :func:`pypto.language.op.tensor.slice`, there is no ``clamp``
+        Unlike [`tensor.slice`][pypto.language.tensor.slice], there is no ``clamp``
         option: an on-chip window has nothing that could clamp it, so
         ``offset + shape`` must stay inside the source tile.
     """
@@ -2635,7 +2648,7 @@ def gather(src: Tile, indices: Tile, tmp: Tile) -> Tile:
     """Gather elements from src tile by per-element indices (index form).
 
     Computes ``dst[i, j] = src[indices[i, j]]``. Maps to PTOAS ``pto.tgather``
-    index form. For the hardware mask-pattern variant, use :func:`gather_mask`.
+    index form. For the hardware mask-pattern variant, use [`gather_mask`][pypto.language.tile.gather_mask].
 
     Args:
         src: Source tile (FP16, FP32, INT16, or INT32)
@@ -2664,6 +2677,14 @@ def gatherb(
     ``src.dtype`` and may select another supported byte interpretation.
     A sliced source must have a byte address that PyPTO can prove is 32-byte
     aligned; dynamic column offsets are rejected conservatively.
+
+    Args:
+        src: Source tile to gather blocks from.
+        offset: UINT32 tile of **byte** offsets into ``src`` -- not element indices.
+        output_dtype: Byte interpretation of the result. Defaults to ``src.dtype``.
+
+    Returns:
+        Tile wrapping the gatherb operation.
     """
     return Tile(expr=_ir_ops.gatherb(src.unwrap(), offset.unwrap(), output_dtype=output_dtype))
 
@@ -2677,11 +2698,11 @@ def gather_mask(
     """Gather elements from src tile by a fixed hardware mask pattern (mask form).
 
     Selects elements according to a stride/mask pattern baked into the hardware.
-    For the per-element indices variant, use :func:`gather`.
+    For the per-element indices variant, use [`gather`][pypto.language.tile.gather].
 
     Args:
         src: Source tile (FP16, FP32, INT16, or INT32)
-        mask_pattern: Mask pattern selector (1-7), see :class:`MaskPattern`.
+        mask_pattern: Mask pattern selector (1-7), see [`MaskPattern`][pypto.language.tile.MaskPattern].
             1=P0101, 2=P1010, 3=P0001, 4=P0010, 5=P0100, 6=P1000, 7=P1111
         output_dtype: Optional output dtype. When provided, the result tile has
             this dtype instead of ``src``'s dtype (bit reinterpretation, no
@@ -2728,8 +2749,8 @@ def gather_compare(
 
     The ``a, b = call(...)`` Python tuple unpack is desugared by the parser
     into ``_tuple = call; a = _tuple[0]; b = _tuple[1]``. The parser
-    consumes the underlying tuple-typed :class:`ir.Call` returned by
-    :func:`pypto.ir.op.tile_ops.gather_compare`; the ``(Tile, Tile)`` split
+    consumes the underlying tuple-typed ``ir.Call`` returned by
+    ``pypto.ir.op.tile_ops.gather_compare``; the ``(Tile, Tile)`` split
     below only runs in interactive Python contexts.
 
     Args:
@@ -2772,7 +2793,7 @@ def scatter(dst: Tile, src: Tile, indexes: Tile) -> Tile:
     **same [rows, cols] shape as** ``src``. Maps to PTOAS ``pto.tscatter`` index
     form. The op is DPS — ``dst`` is the first (in/out) argument, rewritten in
     place, and the returned Tile aliases the same buffer. For the hardware
-    mask-pattern variant, use :func:`scatter_mask`.
+    mask-pattern variant, use [`scatter_mask`][pypto.language.tile.scatter_mask].
 
     Args:
         dst: Destination tile (same dtype as ``src``; rewritten in-place).
@@ -2793,9 +2814,9 @@ def scatter_mask(dst: Tile, src: Tile, mask_pattern: int) -> Tile:
     """Scatter ``src`` rows into mask-marked columns of ``dst`` (mask form).
 
     For each row, the elements of ``src`` are written into the columns of
-    ``dst`` selected by ``mask_pattern`` (the inverse of :func:`gather_mask`).
+    ``dst`` selected by ``mask_pattern`` (the inverse of [`gather_mask`][pypto.language.tile.gather_mask]).
 
-    Unlike :func:`gather_mask` (a real ``pto.tgather`` ISA op on A2/A3 and A5),
+    Unlike [`gather_mask`][pypto.language.tile.gather_mask] (a real ``pto.tgather`` ISA op on A2/A3 and A5),
     mask-pattern scatter is not a distinct pto-isa instruction — PyPTO emits it
     as a ``pto.tscatter`` mask-form construct for A2/A3 / CPU-sim style lowering
     paths.
@@ -2803,7 +2824,7 @@ def scatter_mask(dst: Tile, src: Tile, mask_pattern: int) -> Tile:
     Args:
         dst: Destination tile (rewritten on positions selected by ``mask_pattern``)
         src: Source tile (compact rows; same dtype as ``dst``)
-        mask_pattern: Mask pattern selector (1-7), see :class:`MaskPattern`.
+        mask_pattern: Mask pattern selector (1-7), see [`MaskPattern`][pypto.language.tile.MaskPattern].
             1=P0101, 2=P1010, 3=P0001, 4=P0010, 5=P0100, 6=P1000, 7=P1111
 
     Returns:

--- a/python/pypto/language/op/tile_ops.py
+++ b/python/pypto/language/op/tile_ops.py
@@ -764,7 +764,8 @@ def tri(
             May be a runtime ``Scalar``.
         shape: Shape of the destination tile (static).
         valid_shape: Optional written region (each dim ``<= shape``). Elements
-            outside it are left untouched. Defaults to the full shape.
+            outside it are not written, so their value is whatever the freshly
+            allocated tile holds. Defaults to the full shape.
         dtype: Destination dtype. Defaults to ``INT32``.
         upper: Select the upper triangle instead of the lower.
 

--- a/python/pypto/language/op/unified_ops.py
+++ b/python/pypto/language/op/unified_ops.py
@@ -839,8 +839,11 @@ def transpose(input: T, axis1: int, axis2: int) -> T:
 
     Args:
         input: Value to transpose.
-        axis1: First axis to exchange.
-        axis2: Second axis to exchange. Swapping an axis with itself is a no-op.
+        axis1: First axis to exchange. Must be a compile-time constant; negative
+            indexing is supported.
+        axis2: Second axis to exchange. Must differ from ``axis1`` after negative
+            indexing is resolved -- naming the same axis twice is rejected, not
+            treated as a no-op.
     """
     if isinstance(input, Tensor):
         return _tensor.transpose(input, axis1, axis2)

--- a/python/pypto/language/op/unified_ops.py
+++ b/python/pypto/language/op/unified_ops.py
@@ -191,7 +191,7 @@ def _reject_tmp_for_tensor(op_name: str, tmp: Any, param: str = "tmp") -> None:
 def _require_tmp_for_tile(op_name: str, tmp: Tile | None, requirement: str) -> Tile:
     """Guard the Tile path of an op whose Tile form *requires* a scratch operand.
 
-    The mirror image of :func:`_reject_tmp_for_tensor`: tile buffer lifetimes are
+    The mirror image of ``_reject_tmp_for_tensor``: tile buffer lifetimes are
     user-managed, so the operand the Tensor path must omit is the same one the
     Tile path cannot synthesize. Both directions raise ``TypeError`` — this is a
     wrong-arguments-for-this-overload error, the same class CPython raises for a
@@ -278,7 +278,7 @@ def _is_scalar_like(v: object) -> bool:
 def _to_scalar_expr(v: Any) -> _ir_core.Expr:
     """Coerce a scalar-like value to an ``Expr``.
 
-    Caller must have already passed :func:`_is_scalar_like`. ``Scalar`` is
+    Caller must have already passed ``_is_scalar_like``. ``Scalar`` is
     unwrapped, raw ``Expr`` is returned as-is, and Python ``int`` / ``float``
     are materialized as ``ConstInt`` / ``ConstFloat`` with the parser-pinned
     span (or frame-captured fallback).
@@ -386,7 +386,16 @@ def div(
     high_precision: bool = False,
 ) -> Scalar: ...
 def div(lhs, rhs, high_precision: bool = False):
-    """Element-wise division, dispatched by input type."""
+    """Element-wise division, dispatched by input type.
+
+    A scalar ``rhs`` against a Tile dispatches to ``tile.divs``.
+
+    Args:
+        high_precision: Select PTOAS's high-precision divide. Available for
+            Tensor/Tensor and Tile/Tile only -- a scalar divisor has no
+            high-precision form, so passing it there raises rather than silently
+            falling back.
+    """
     if isinstance(lhs, Tensor) and isinstance(rhs, (Tensor, int, float, Scalar, _ir_core.Expr)):
         return _tensor.div(lhs, rhs, high_precision=high_precision)
     if isinstance(lhs, Tile) and isinstance(rhs, Tile):
@@ -540,7 +549,12 @@ def exp(input: T) -> T:
 
 
 def log(input: T, high_precision: bool = False) -> T:
-    """Element-wise natural logarithm, dispatched by input type."""
+    """Element-wise natural logarithm, dispatched by input type.
+
+    Args:
+        input: Input tensor or tile.
+        high_precision: Select PTOAS's high-precision logarithm mode.
+    """
     if isinstance(input, Tensor):
         return _tensor.log(input, high_precision=high_precision)
     if isinstance(input, Tile):
@@ -761,7 +775,15 @@ def col_expand_expdif(lhs: T, rhs: T) -> T:
 
 
 def expands(target: Tensor | Tile, scalar: int | float | Scalar) -> Tensor | Tile:
-    """Expand scalar to target shape, dispatched by target type."""
+    """Expand scalar to target shape, dispatched by target type.
+
+    Note the argument order: the value being broadcast is the *second* argument.
+    ``target`` supplies the shape and dtype; it is not read.
+
+    Args:
+        target: Value whose shape the scalar is broadcast to.
+        scalar: Value to broadcast into every element.
+    """
     if isinstance(target, Tensor):
         return _tensor.expands(target, scalar)
     if isinstance(target, Tile):
@@ -813,7 +835,13 @@ def reinterpret_view(
 
 
 def transpose(input: T, axis1: int, axis2: int) -> T:
-    """Transpose operation, dispatched by input type."""
+    """Transpose operation, dispatched by input type.
+
+    Args:
+        input: Value to transpose.
+        axis1: First axis to exchange.
+        axis2: Second axis to exchange. Swapping an axis with itself is a no-op.
+    """
     if isinstance(input, Tensor):
         return _tensor.transpose(input, axis1, axis2)
     if isinstance(input, Tile):
@@ -851,7 +879,7 @@ def slice(
     ``pad_value`` sets the padding mode for elements outside the effective valid
     region, on either path. ``None`` carries the source's mode through. Accepts
     ``PadValue.zero`` / ``PadValue.max`` / ``PadValue.min``, or the literal
-    sugars ``0``, ``math.inf``, ``-math.inf`` (same spelling as :func:`fillpad`).
+    sugars ``0``, ``math.inf``, ``-math.inf`` (same spelling as [`fillpad`][pypto.language.fillpad]).
     It only bites when the valid region is smaller than ``shape`` — which an
     explicit ``valid_shape``, a partially-valid source, or (Tensor-only)
     ``clamp=True`` can each bring about; passing it otherwise warns.
@@ -1029,7 +1057,7 @@ def matmul_acc(
     """Matrix multiplication with accumulation, dispatched by input type.
 
     ``a_trans`` / ``b_trans`` are Tensor-only for the same reason as in
-    :func:`matmul` — at tile level transposition is a type property, not an op
+    [`matmul`][pypto.language.matmul] — at tile level transposition is a type property, not an op
     flag — so passing either with Tile operands raises rather than being
     dropped.
 
@@ -1303,7 +1331,16 @@ def cast(
     target_type: int | DataType,
     mode: str | int = "round",
 ) -> Tensor | Tile | Scalar:
-    """Type casting, dispatched by input type."""
+    """Type casting, dispatched by input type.
+
+    Args:
+        input: Value to convert.
+        target_type: Destination dtype.
+        mode: Rounding mode, as a name or its int code -- ``"none"`` (0),
+            ``"rint"`` (1), ``"round"`` (2, the default), ``"floor"`` (3),
+            ``"ceil"`` (4), ``"trunc"`` (5), ``"odd"`` (6). A ``Scalar`` input
+            supports the default only and raises for any other mode.
+    """
     if isinstance(input, Tensor):
         return _tensor.cast(input, target_type, mode)
     if isinstance(input, Tile):
@@ -1435,7 +1472,7 @@ def xors(lhs: Tile, rhs: int | Scalar, tmp: Tile) -> Tile: ...
 def xors(lhs, rhs, tmp=None):
     """Element-wise bitwise XOR with a scalar, dispatched by input type.
 
-    See :func:`xor` for why only the tile path takes ``tmp``.
+    See [`xor`][pypto.language.xor] for why only the tile path takes ``tmp``.
     """
     if isinstance(lhs, Tensor):
         _reject_tmp_for_tensor("xors", tmp)

--- a/python/pypto/language/optimizations.py
+++ b/python/pypto/language/optimizations.py
@@ -82,8 +82,8 @@ class Split(Optimization):
         mode: Split mode (``SplitMode.NONE``, ``SplitMode.UP_DOWN``, or
             ``SplitMode.LEFT_RIGHT``).
         slot_num: **Deprecated** — use ``pl.cross_core_slot(slot_num=N)``, which
-            carries the same value without naming a split mode. Kept as an alias
-            so existing kernels keep working; see :class:`CrossCoreSlot`.
+            carries the same value without naming a split mode. Kept as an alias so existing kernels keep
+            working; see [`CrossCoreSlot`][pypto.language.optimizations.CrossCoreSlot].
     """
 
     mode: SplitMode

--- a/python/pypto/language/parser/text_parser.py
+++ b/python/pypto/language/parser/text_parser.py
@@ -367,10 +367,12 @@ def loads(filepath: str) -> ir.Function | ir.Program:
 def parse_program(code: str, filename: str = "<string>") -> ir.Program:
     """Parse a DSL program from a string.
 
-    .. deprecated::
-        Use :func:`parse` instead, which auto-detects functions and programs.
+    !!! warning "Deprecated"
+        Use [`parse`][pypto.language.parse] instead, which auto-detects functions
+        and programs.
 
-    This is now an alias for :func:`parse` that validates the result is a Program.
+    This is now an alias for [`parse`][pypto.language.parse] that validates the
+    result is a Program.
 
     Args:
         code: Python source code containing a @pl.program decorated class
@@ -395,10 +397,12 @@ def parse_program(code: str, filename: str = "<string>") -> ir.Program:
 def loads_program(filepath: str) -> ir.Program:
     """Load a DSL program from a file.
 
-    .. deprecated::
-        Use :func:`loads` instead, which auto-detects functions and programs.
+    !!! warning "Deprecated"
+        Use [`loads`][pypto.language.loads] instead, which auto-detects functions
+        and programs.
 
-    This is now an alias for :func:`loads` that validates the result is a Program.
+    This is now an alias for [`loads`][pypto.language.loads] that validates the
+    result is a Program.
 
     Args:
         filepath: Path to Python file containing @pl.program decorated class

--- a/python/pypto/language/scope.py
+++ b/python/pypto/language/scope.py
@@ -37,7 +37,7 @@ class scope:
     By default the compiler inserts AUTO scopes for you (function body + each
     ``for`` / ``if`` body). To place scopes yourself, set
     ``@pl.function(auto_scope=False)`` and use this context manager (and the
-    ``pl.range(..., scope=...)`` sugar). See :class:`ScopeMode` for AUTO vs
+    ``pl.range(..., scope=...)`` sugar). See [`ScopeMode`][pypto.language.ScopeMode] for AUTO vs
     MANUAL.
 
     Usage::
@@ -207,9 +207,9 @@ def spmd_submit(*args: Any, **kwargs: Any) -> Any:
     core_num=N, sync_start=..., deps=[...])`` syntactically and never actually
     calls this body. It is defined only so the name resolves (imports / linters).
 
-    It is the SPMD sibling of :func:`submit`: a single orchestration task that
+    It is the SPMD sibling of [`submit`][pypto.language.submit]: a single orchestration task that
     the runtime fans out across ``core_num`` logical blocks (each kernel reads
-    its block index via ``pl.tile.get_block_idx()``). Like :func:`submit` it
+    its block index via ``pl.tile.get_block_idx()``). Like [`submit`][pypto.language.submit] it
     returns one producer TaskId, so the whole dispatch can be named as a
     dependency of later tasks.
 
@@ -223,12 +223,12 @@ def spmd_submit(*args: Any, **kwargs: Any) -> Any:
     expression) — the positional slots are the kernel's own arguments.
     ``sync_start`` (default ``False``) requires all blocks to launch atomically.
     ``deps=[...]``, ``allow_early_resolve=True`` and ``predicate=(...)`` work
-    exactly as on :func:`submit` (note: a ``sync_start`` task cannot itself be
+    exactly as on [`submit`][pypto.language.submit] (note: a ``sync_start`` task cannot itself be
     block-by-block pre-staged, but it can still be flagged to let its consumers
     pre-stage). The callee may be an InCore / AIC / AIV kernel or a co-scheduled
     Group.
 
-    Like :func:`submit`, it works in both auto and manual scope; its primary use
+    Like [`submit`][pypto.language.submit], it works in both auto and manual scope; its primary use
     is explicit dependency wiring inside ``pl.manual_scope()``.
     """
     raise RuntimeError(

--- a/python/pypto/language/typing/prefetch_handle.py
+++ b/python/pypto/language/typing/prefetch_handle.py
@@ -10,13 +10,13 @@
 """DSL wrappers for the opaque async-prefetch handles.
 
 Three handle classes back the ``pl.prefetch.*`` surface, each serving the two
-roles :class:`pld.CommCtx` does:
+roles ``pld.CommCtx`` does:
 
 * **Type annotation** — ``ctx: pl.PrefetchAsyncContext = pl.prefetch.make_context()``
-  declares an :class:`ir.PrefetchAsyncContextType`-valued ``Var`` in printed IR.
+  declares an ``ir.PrefetchAsyncContextType``-valued ``Var`` in printed IR.
 * **Value wrapper** — the ``pl.prefetch.*`` wrappers return these classes so
   handles flow through the DSL as typed values instead of raw ``ir.Call``
-  objects. The parser's ``invoke_dsl`` unwraps via :meth:`unwrap` at the
+  objects. The parser's ``invoke_dsl`` unwraps via ``unwrap`` at the
   parser boundary.
 """
 
@@ -35,7 +35,7 @@ class _OpaqueHandle:
         self._expr: Expr | None = expr
 
     def unwrap(self) -> Expr:
-        """Return the wrapped :class:`ir.Expr`.
+        """Return the wrapped ``ir.Expr``.
 
         Raises:
             RuntimeError: If the instance was constructed without an ``expr``
@@ -55,24 +55,26 @@ class _OpaqueHandle:
 class PrefetchAsyncContext(_OpaqueHandle):
     """Handle to an asynchronous GM->L2 prefetch context.
 
-    Produced by :func:`pl.prefetch.make_context`; consumed by
-    :func:`pl.prefetch.async_prefetch` and :func:`pl.prefetch.session`.
+    Produced by [`pl.prefetch.make_context`][pypto.language.prefetch.make_context]; consumed by
+    [`pl.prefetch.async_prefetch`][pypto.language.prefetch.async_prefetch] and
+    [`pl.prefetch.session`][pypto.language.prefetch.session].
     """
 
 
 class AsyncEvent(_OpaqueHandle):
     """Handle to an in-flight asynchronous prefetch completion event.
 
-    Produced by :func:`pl.prefetch.async_prefetch`; consumed by
-    :func:`pl.prefetch.wait` together with the matching :class:`AsyncSession`.
+    Produced by [`pl.prefetch.async_prefetch`][pypto.language.prefetch.async_prefetch]; consumed by
+    [`pl.prefetch.wait`][pypto.language.prefetch.wait] together with the matching
+    [`AsyncSession`][pypto.language.AsyncSession].
     """
 
 
 class AsyncSession(_OpaqueHandle):
-    """Handle to the asynchronous session an :class:`AsyncEvent` belongs to.
+    """Handle to the asynchronous session an [`AsyncEvent`][pypto.language.AsyncEvent] belongs to.
 
-    Produced by :func:`pl.prefetch.session`; consumed by
-    :func:`pl.prefetch.wait`.
+    Produced by [`pl.prefetch.session`][pypto.language.prefetch.session]; consumed by
+    [`pl.prefetch.wait`][pypto.language.prefetch.wait].
     """
 
 

--- a/python/pypto/language/typing/ptr.py
+++ b/python/pypto/language/typing/ptr.py
@@ -9,16 +9,16 @@
 
 """``pl.Ptr`` — DSL wrapper for an opaque pointer handle.
 
-Single class serving two roles, mirroring :class:`pl.Tensor` /
-:class:`pl.Tile`:
+Single class serving two roles, mirroring [`pl.Tensor`][pypto.language.Tensor] /
+[`pl.Tile`][pypto.language.Tile]:
 
 * **Type annotation** — printed-IR round-trip uses ``buf: pl.Ptr =
   pl.tile.alloc(...)`` / ``buf: pl.Ptr = pld.alloc_window_buffer(...)``
-  to signal that the LHS is an :class:`ir.PtrType`-valued ``Var``.
+  to signal that the LHS is an ``ir.PtrType``-valued ``Var``.
 * **Value wrapper** — DSL ops that return a Ptr-typed result wrap the
-  underlying :class:`ir.Expr` in this class so the DSL surface stays
+  underlying ``ir.Expr`` in this class so the DSL surface stays
   language-level (no raw ``ir.Call`` leaking out of wrappers). The
-  parser's ``invoke_dsl`` unwraps via :meth:`unwrap` at the parser
+  parser's ``invoke_dsl`` unwraps via ``unwrap`` at the parser
   boundary, the same way it handles ``Tensor`` / ``Tile`` / ``Scalar`` /
   ``Array``.
 """
@@ -38,7 +38,7 @@ class Ptr:
         self._expr: Expr | None = expr
 
     def unwrap(self) -> Expr:
-        """Return the wrapped :class:`ir.Expr`.
+        """Return the wrapped ``ir.Expr``.
 
         Raises:
             RuntimeError: If the instance was constructed without an

--- a/python/pypto/language/typing/scalar.py
+++ b/python/pypto/language/typing/scalar.py
@@ -269,19 +269,19 @@ class RuntimeScalarMarker(Scalar):
     annotation-driven signature mode (``compile()`` / ``lower()`` with no
     tensor arguments) needs one value per scalar parameter. Passing a literal
     **specializes** that value into the compiled artifact; passing
-    :data:`RUNTIME` leaves the parameter **unspecialized** — it stays a real
+    [`RUNTIME`][pypto.language.RUNTIME] leaves the parameter **unspecialized** — it stays a real
     ``pl.Scalar`` parameter in the generated program and its value is supplied
     at dispatch, exactly like a ``pl.dynamic`` dimension extent. Unspecialized
     scalars also drop out of the specialization cache key, so one artifact
     serves every runtime value.
 
-    Subclasses :class:`Scalar` so that a type checker accepts it as the default
+    Subclasses [`Scalar`][pypto.language.Scalar] so that a type checker accepts it as the default
     of a scalar parameter — ``n: pl.Scalar[dtype] = pl.RUNTIME`` — for the same
-    reason :class:`~pypto.language.typing.dynamic.DynVar` does: the marker
+    reason ``DynVar`` does: the marker
     stands in wherever a ``Scalar`` is expected. It carries no dtype of its own;
     the parameter's annotation supplies that.
 
-    Use the :data:`RUNTIME` singleton rather than instantiating this class.
+    Use the [`RUNTIME`][pypto.language.RUNTIME] singleton rather than instantiating this class.
 
     Examples:
         >>> import pypto.language as pl
@@ -293,7 +293,7 @@ class RuntimeScalarMarker(Scalar):
     def __init__(self) -> None:
         """Initialize the marker with no dtype and no wrapped expression.
 
-        Bypasses :meth:`Scalar.__init__`, which requires one of the two — this
+        Bypasses ``Scalar.__init__``, which requires one of the two — this
         marker deliberately has neither, and its dtype comes from the annotated
         parameter it defaults.
         """
@@ -319,7 +319,7 @@ class RuntimeScalarMarker(Scalar):
 
 
 RUNTIME = RuntimeScalarMarker()
-"""Singleton :class:`RuntimeScalarMarker` — see the class docstring."""
+"""Singleton ``RuntimeScalarMarker`` — see the class docstring."""
 
 
 BoolLike: TypeAlias = bool | Scalar | Expr
@@ -330,7 +330,7 @@ def predicate_to_expr(value: BoolLike | None, span: Span | None = None) -> Expr 
     """Coerce an optional boolean predicate operand to an ``Expr``.
 
     A Python ``bool`` becomes ``ConstInt(.., BOOL)`` — a compile-time constant an
-    operator's lowering can fold away. A :class:`Scalar` (typically a comparison
+    operator's lowering can fold away. A [`Scalar`][pypto.language.Scalar] (typically a comparison
     such as ``k == 0``) is unwrapped to the symbolic expression it carries, which
     stays a runtime value.
 


### PR DESCRIPTION
Follow-up to #2459. Now that the API reference renders from the docstrings, this
fixes what it exposed.

## 1. Parameters a signature cannot explain

A count of missing `Args:` sections overstates the problem: the type-dispatched
wrappers render their `@overload` signatures, so `pl.add` already shows all three
typed forms and an `Args:` block would add nothing. What a reader genuinely
cannot recover is a parameter whose meaning is a *convention* — `split: int`,
`ffts_mode: int | None`, `mode: str | int`.

Worst offenders were the cross-core primitives — one line of prose over four
opaque parameters each:

| | before | after |
| --- | --- | --- |
| `tpush_to_aiv` / `tpush_to_aic` | 1 line; `split`, `id` undocumented | the three-op protocol + both attrs |
| `tfree_to_aic` / `tfree_to_aiv` | 1 line | + that `StampTfreeSplit` normally fills `split` in |
| `sync_set` / `sync_wait` | `ffts_mode` undocumented | event-id range 0–13, 14/15 reserved |
| `cast` | 1 line | all seven rounding modes + the `Scalar` restriction |

Also `tri`, `gatherb`, `task_dummy`, `div`, `log`, `transpose`, `expands`, `alloc`.

Wording for the shared cross-core attrs is taken from the already-documented
siblings `tpop_from_aic` / `tpop_from_aiv`, so all four ops of one protocol
describe them identically. `split` is documented as the **0..2** this branch's
codegen accepts (`0=none, 1=up-down, 2=left-right`) — the 0..4 extension is on
the unmerged odd-split branch, not here.

**Deliberately left alone:** `slice`, `matmul`, `matmul_acc`, `reshape`,
`fillpad`, `fillpad_expand`, `cmp`, `rsqrt`. Each already explains its parameters
in prose; a table would restate the paragraph directly above it.

## 2. Sphinx roles were rendering as literal text

mkdocstrings has no Sphinx-role support, so **133 markers reached the published
pages verbatim** — `:func: tpop_from_aic` where a link belonged.

| | count |
| --- | --- |
| → mkdocstrings cross-references | 88 (language) + 6 (jit) |
| → plain code spans | 23 + 47 |
| `.. deprecated::` → admonition | 2 |

Code spans are for targets the site does not render — private helpers, dunder
methods, `ir.*` core types. A code span is what the marker meant; a guessed link
would be worse.

**Rendered API pages now contain 0 literal Sphinx markup (was 133).**

## Verification

| Check | Result |
| ----- | ------ |
| `mkdocs build --strict` | passes, **0 warnings** |
| griffe parse (`Args:` pairs, annotations) | clean |
| `ruff check` / `ruff format --check` | clean |
| all 9 `tests/lint/check_*.py` | PASS |
| `tests/ut/language` + `tests/ut/ir` | **7696 passed**, 3 skipped |

One local failure, `test_symlinked_import_path_still_names_the_caller`, is
environmental: its subprocess inherits an interpreter whose editable meta-finder
overrides `PYTHONPATH` and imports a stale checkout. Re-running the same
subprocess with that finder stripped returns 0.
