### PR TITLE
chore(runtime): bump simpler to 93adc386; adapt STRACE span ladder rename

### DIFF
--- a/docs/en/user/00-getting_started.md
+++ b/docs/en/user/00-getting_started.md
@@ -232,7 +232,7 @@ stats.print_mean_tree(spread="both")  # mean per node, with ±stdev and [min..ma
 
 ```text
 mean of 20 launches (warmup 5 excluded); each node: mean ±stdev [min..max]:
-simpler_run                71784.1us  ±6797.5  [66482.4..89832.6]
+chip.run                   71784.1us  ±6797.5  [66482.4..89832.6]
 |- bind                    27943.6us  ±4163.7  [24836.7..37713.3]
 |- runner_run               3030.8us   ±184.4    [2822.3..3694.7]
 |  `- device_wall [dev]     2005.2us    ±74.6    [1875.1..2173.2]

--- a/docs/zh/user/00-getting_started.md
+++ b/docs/zh/user/00-getting_started.md
@@ -208,7 +208,7 @@ stats.print_mean_tree(spread="both")  # 每节点均值 + ±stdev + [min..max]
 
 ```text
 mean of 20 launches (warmup 5 excluded); each node: mean ±stdev [min..max]:
-simpler_run                71784.1us  ±6797.5  [66482.4..89832.6]
+chip.run                   71784.1us  ±6797.5  [66482.4..89832.6]
 |- bind                    27943.6us  ±4163.7  [24836.7..37713.3]
 |- runner_run               3030.8us   ±184.4    [2822.3..3694.7]
 |  `- device_wall [dev]     2005.2us    ±74.6    [1875.1..2173.2]

--- a/python/pypto/runtime/bench.py
+++ b/python/pypto/runtime/bench.py
@@ -33,7 +33,7 @@ module therefore:
    file around the measured region (for L3, also around ``prepare()`` so the
    forked chip-worker processes inherit the redirected fd);
 3. parses the captured markers, reading each launch's on-NPU ``device_wall``
-   and host ``simpler_run`` span.
+   and host ``chip.run`` span.
 
 Because the capture is fd-level, **all** stderr produced during the measured
 loop is diverted into the temp file (not shown live). Warmup/teardown logging
@@ -86,7 +86,7 @@ class TraceSpan:
     Attributes:
         depth: Nesting level; a span at depth ``d`` is a child of the nearest
             enclosing span at depth ``d-1``.
-        name: Dotted span path (e.g. ``simpler_run.runner_run.device_wall``).
+        name: Dotted span path (e.g. ``chip.run.runner_run.device_wall``).
         ts: Start timestamp in nanoseconds (host clock, or device clock when
             :attr:`is_device`).
         dur: Span duration in nanoseconds.
@@ -129,7 +129,7 @@ class TraceInvocation:
     spans: list[TraceSpan] = field(default_factory=list)
 
     def root(self) -> "TraceSpan | None":
-        """The depth-0 span (``simpler_run``), or ``None`` if absent."""
+        """The depth-0 span (``chip.run``), or ``None`` if absent."""
         for s in self.spans:
             if s.depth == 0:
                 return s
@@ -205,7 +205,7 @@ class TraceInvocation:
         indentation alone. Nesting is reconstructed from the dotted span names (a
         span's parent is the span whose name is its longest proper dotted
         prefix), which is robust to the host/device clock-domain split —
-        device-domain spans (``simpler_run.runner_run.device_wall.*``) correctly
+        device-domain spans (``chip.run.runner_run.device_wall.*``) correctly
         nest under their host parent even though they are emitted as a separate
         batch. Siblings are ordered by start timestamp; device-domain spans are
         tagged ``[dev]``.
@@ -283,11 +283,13 @@ class TraceInvocation:
 
 # Per-launch ``[STRACE]`` span names. ``host`` is the whole run wall; ``device``
 # is the on-NPU orchestrator wall; ``orch`` / ``sched`` subdivide it (their union
-# is the "Effective" on-device execution window). The span root was renamed
-# ``run_prepared`` -> ``simpler_run`` in simpler #1210, so the names are sourced
-# at call time from the installed runtime's ``strace_timing._ROUNDS_TABLE_NAMES``
-# via :func:`_span_names` rather than hardcoded — this keeps ``benchmark`` working
-# against both runtime generations. These legacy names are the pre-#1210 fallback.
+# is the "Effective" on-device execution window). The span root has been renamed
+# twice — ``run_prepared`` -> ``simpler_run`` (simpler #1210), then
+# ``simpler_run`` -> ``chip.run`` when #1877/#1893 made every span lead with the
+# word for the level that emitted it — so the names are sourced at call time from
+# the installed runtime's ``strace_timing._ROUNDS_TABLE_NAMES`` via
+# :func:`_span_names` rather than hardcoded. These legacy names are the pre-#1210
+# fallback, used only when that table is absent entirely.
 _LEGACY_SPAN_NAMES = {
     "host": "run_prepared",
     "device": "run_prepared.runner_run.device_wall",
@@ -295,24 +297,64 @@ _LEGACY_SPAN_NAMES = {
     "sched": "run_prepared.runner_run.device_wall.sched",
 }
 
+# PyPTO's span key -> the ``_ROUNDS_TABLE_NAMES`` keys that may carry it, newest
+# generation first. The whole-run entry was keyed ``host`` until simpler #1893
+# renamed it ``run``: the word ``host`` names a *processor*, and the span it
+# labels is the chip's run, so the table stopped spelling it that way. PyPTO
+# keeps ``host`` as its own key (it is the host-side wall, and it is the name
+# :class:`BenchmarkStats` exposes); only the lookup has to know both spellings.
+# ``device`` / ``orch`` / ``sched`` are stable across both generations.
+_RUNTIME_SPAN_KEYS = {
+    "host": ("run", "host"),
+    "device": ("device",),
+    "orch": ("orch",),
+    "sched": ("sched",),
+}
+
+
+# Span families the invocation-keyed views must not consume. They share the
+# ``[STRACE]`` grammar but carry no invocation id, so admitting one groups all of
+# its spans into a single forged invocation. ``l3.`` is the pre-#1877 spelling of
+# the per-task scheduler family; #1893 re-spelled it after the level's topology
+# position (``node``, plus ``network1..3`` for each hop above it), and #1886
+# reserved ``ext.`` for producers outside simpler. Applied on top of simpler's own
+# filter, which keeps spellings it does not recognize — see
+# :func:`_parse_stats_from_strace`.
+_NON_INVOCATION_PREFIXES = ("l3.", "node.", "network1.", "network2.", "network3.", "ext.")
+
 
 @functools.lru_cache(maxsize=1)
 def _span_names() -> dict[str, str]:
     """Resolve the four ``[STRACE]`` span names from the installed runtime.
 
-    Reads ``strace_timing._ROUNDS_TABLE_NAMES`` (added in simpler #1210 alongside
-    the ``run_prepared`` -> ``simpler_run`` root rename). ``_ROUNDS_TABLE_NAMES``
-    is a private symbol absent from pre-#1210 simpler, so fall back to the legacy
-    hardcoded names when it (or one of its keys) is missing.
+    Reads ``strace_timing._ROUNDS_TABLE_NAMES`` (added in simpler #1210), trying
+    each spelling in :data:`_RUNTIME_SPAN_KEYS` so one lookup covers both the
+    ``host``-keyed and the ``run``-keyed generation of the table.
+
+    Resolution is all-or-nothing: a table that answers only some of the four
+    keys is a generation this function does not know, and mixing its names with
+    the legacy ones would silently yield spans that match nothing. Falling back
+    wholesale keeps the failure to "every sample is zero" in one place rather
+    than spreading it across metrics.
     """
     try:
         from simpler_setup.tools.strace_timing import (  # noqa: PLC0415  # pyright: ignore[reportMissingImports]
             _ROUNDS_TABLE_NAMES,
         )
-
-        return {key: _ROUNDS_TABLE_NAMES[key] for key in _LEGACY_SPAN_NAMES}
-    except (ImportError, AttributeError, TypeError, KeyError):
+    except (ImportError, AttributeError):
         return dict(_LEGACY_SPAN_NAMES)
+
+    resolved: dict[str, str] = {}
+    for key, candidates in _RUNTIME_SPAN_KEYS.items():
+        for candidate in candidates:
+            try:
+                resolved[key] = _ROUNDS_TABLE_NAMES[candidate]
+            except (TypeError, KeyError):
+                continue
+            break
+        else:
+            return dict(_LEGACY_SPAN_NAMES)
+    return resolved
 
 
 # Runtime log level that makes the ``LOG_TIMING`` ``[STRACE]`` markers visible.
@@ -1024,7 +1066,7 @@ def _parse_l3_stats(invocations: Any, stats: BenchmarkStats, *, rounds: int, war
 
     # The capture must begin before ``prepare()`` so forked chip workers inherit
     # its fd, but prepare-time setup can emit unrelated invocation groups such as
-    # ``simpler_prewarm.build``. Only a depth-0 canonical run root identifies an
+    # ``chip.prewarm.build``. Only a depth-0 canonical run root identifies an
     # actual dispatch. Do not filter on ``device_wall`` per invocation: retaining
     # a real run with a missing device marker preserves its round alignment and
     # exposes a zero metric.
@@ -1143,7 +1185,7 @@ def _parse_stats_from_strace(
     invocation per launch), orders by ``inv``, drops the first *warmup*
     invocations, and reads each remaining launch's host (``<root>``) and device
     (``<root>.runner_run.device_wall``) span durations (µs). The ``<root>`` span
-    name is resolved per :func:`_span_names` (``run_prepared`` / ``simpler_run``).
+    name is resolved per :func:`_span_names` (``chip.run`` on current simpler).
 
     L3 (``distributed=True``): prepared swimlane pass sentinels first restrict
     the input to complete dep-gen-disabled timing regions, when present; then
@@ -1173,13 +1215,21 @@ def _parse_stats_from_strace(
     # preserves compatibility with older parsers that consumed one per line.
     lines = log_text.replace("[STRACE]", "\n[STRACE]").splitlines()
     spans = _strace_timing.parse_spans(lines)
-    if hasattr(_strace_timing, "legacy_spans"):
-        spans = _strace_timing.legacy_spans(spans)
-    else:
-        # Simpler versions before L3/L4 tracing do not expose the canonical
-        # filter. They do not normally emit l3.* markers either, but filtering
-        # the namespace locally makes mixed-version log ingestion safe.
-        spans = [span for span in spans if not span.name.startswith("l3.")]
+    # Drop the families that carry no invocation id, so none of them forges a
+    # lane in ``group_invocations`` below. The local prefix filter runs
+    # unconditionally rather than only as a fallback: simpler's own filter
+    # deliberately *keeps* any family it does not recognize (dropping unfamiliar
+    # names silently is how ``chip.prewarm.build`` once vanished from its
+    # tables), so a current simpler passes the pre-#1893 ``l3.`` spelling
+    # through. Then apply simpler's filter too, since it is the authority on the
+    # families its own generation emits — #1877 renamed it ``legacy_spans`` ->
+    # ``invocation_spans``, so try both names before giving up on it.
+    spans = [span for span in spans if not span.name.startswith(_NON_INVOCATION_PREFIXES)]
+    span_filter = getattr(_strace_timing, "invocation_spans", None) or getattr(
+        _strace_timing, "legacy_spans", None
+    )
+    if span_filter is not None:
+        spans = span_filter(spans)
     invocations = _strace_timing.group_invocations(spans)
     if not invocations:
         return stats

--- a/tests/ut/runtime/test_benchmark.py
+++ b/tests/ut/runtime/test_benchmark.py
@@ -34,8 +34,10 @@ from pypto.runtime.bench import (
     _L3_SWIMLANE_GRAPH_END,
     _L3_SWIMLANE_TIMING_BEGIN,
     _L3_SWIMLANE_TIMING_END,
+    _LEGACY_SPAN_NAMES,
     BenchmarkStats,
     _parse_stats_from_strace,
+    _span_names,
     benchmark,
 )
 from pypto.runtime.elf_parser import elf_build_id_64, fnv1a_64
@@ -43,25 +45,61 @@ from pypto.runtime.elf_parser import elf_build_id_64, fnv1a_64
 
 @pytest.fixture
 def span_root() -> str:
-    """Skip unless the optional ``simpler`` runtime is importable; return its
-    ``[STRACE]`` span root name.
+    """Skip unless the optional ``simpler`` runtime is importable; return the
+    ``[STRACE]`` span root :func:`_parse_stats_from_strace` will look for.
 
-    :func:`_parse_stats_from_strace` lazily imports ``simpler_setup.tools.
-    strace_timing`` (the single source of truth for the ``[STRACE]`` grammar
-    *and* span names) and reads the per-launch span names from its
-    ``_ROUNDS_TABLE_NAMES``. The root was renamed ``run_prepared`` ->
-    ``simpler_run`` in simpler #1210, so the synthetic markers below build their
-    names off this fixture rather than hardcoding a root — keeping the tests
-    working against both runtime generations. Absent on the unit-test CI host,
-    where these parse tests skip.
+    That function lazily imports ``simpler_setup.tools.strace_timing`` (the
+    single source of truth for the ``[STRACE]`` grammar *and* span names), so
+    the synthetic markers below build their names off the same
+    :func:`_span_names` resolution the parser uses rather than hardcoding a
+    root. The root has been renamed twice (``run_prepared`` -> ``simpler_run``
+    in simpler #1210, then ``simpler_run`` -> ``chip.run`` in #1877/#1893), and
+    these tests exercise the parse *logic*, not the spelling — the spelling is
+    what :func:`test_span_names_resolve_from_installed_runtime` guards.
+
+    ``strace_timing`` is absent on the unit-test CI host, where these parse
+    tests skip.
     """
-    mod = pytest.importorskip("simpler_setup.tools.strace_timing")
-    # ``_ROUNDS_TABLE_NAMES`` is a private symbol absent from pre-#1210 simpler;
-    # fall back to the legacy root so the tests stay compatible with both.
-    try:
-        return mod._ROUNDS_TABLE_NAMES["host"]
-    except (AttributeError, TypeError, KeyError):
-        return "run_prepared"
+    pytest.importorskip("simpler_setup.tools.strace_timing")
+    return _span_names()["host"]
+
+
+def test_span_names_resolve_from_installed_runtime():
+    """``_span_names`` must read the installed runtime, not its legacy fallback.
+
+    The span names live in ``strace_timing._ROUNDS_TABLE_NAMES``, whose keys and
+    values both moved when simpler renamed the span ladder (#1877/#1893: the
+    whole-run entry re-keyed ``host`` -> ``run``, every value re-rooted
+    ``simpler_run`` -> ``chip.run``). :func:`_span_names` swallows a lookup miss
+    and returns :data:`_LEGACY_SPAN_NAMES`, which no *table-bearing* runtime
+    emits — so a future rename would leave every ``host_wall_us`` /
+    ``device_wall_us`` sample silently 0.0 rather than raising. The ``span_root``
+    fixture cannot catch that (it would drift to the same fallback and stay
+    green), so assert here that the resolution actually came from the runtime.
+
+    Gated on the table existing. A pre-#1210 simpler has no
+    ``_ROUNDS_TABLE_NAMES`` at all, and there the legacy names are the documented
+    answer rather than drift — asserting against them would fail a configuration
+    :func:`_span_names` still supports. Once the table exists, a fallback can
+    only mean pypto does not know how that table spells its keys, which is
+    exactly what this guards.
+    """
+    strace_timing = pytest.importorskip("simpler_setup.tools.strace_timing")
+    if not hasattr(strace_timing, "_ROUNDS_TABLE_NAMES"):
+        pytest.skip("pre-#1210 simpler has no _ROUNDS_TABLE_NAMES; the legacy fallback is correct there")
+    names = _span_names()
+
+    assert names != _LEGACY_SPAN_NAMES, (
+        "_span_names() fell back to the legacy pre-#1210 names, so the installed "
+        "simpler spells _ROUNDS_TABLE_NAMES differently than pypto expects; "
+        "every benchmark timing sample would parse as 0.0. Teach "
+        "_RUNTIME_SPAN_KEYS the new spelling."
+    )
+    # The three subdivisions all nest under the run root, so the resolved set
+    # must describe one tree — a half-migrated table would not.
+    root = names["host"]
+    for key in ("device", "orch", "sched"):
+        assert names[key].startswith(f"{root}."), f"{key}={names[key]!r} is not nested under {root!r}"
 
 
 def _strace_line(
@@ -161,9 +199,16 @@ def test_parse_no_markers_returns_empty(span_root):
     assert stats.invocations == []
 
 
-def test_parse_ignores_l3_host_scheduling_spans(span_root, monkeypatch):
-    """L3/L4 host-scheduler markers must not form a bogus benchmark lane."""
-    lines = [_strace_line(0, "l3.dispatch", 900_000, pid=99, hid="0")]
+@pytest.mark.parametrize("scheduler_span", ["l3.dispatch", "node.dispatch", "network1.dispatch"])
+def test_parse_ignores_host_scheduling_spans(span_root, monkeypatch, scheduler_span):
+    """Per-task host-scheduler markers must not form a bogus benchmark lane.
+
+    These carry no invocation id, so admitting one groups every such span into a
+    single forged invocation. simpler #1893 re-spelled the family after the
+    emitting level's topology position (``l3.`` -> ``node.``, plus ``network1..3``
+    for the hops above it), so all three spellings are covered.
+    """
+    lines = [_strace_line(0, scheduler_span, 900_000, pid=99, hid="0")]
     lines += _launch_lines(0, span_root, host_us=50, device_us=5, pid=100)
 
     stats = _parse_stats_from_strace("\n".join(lines), rounds=1, warmup=0)
@@ -172,9 +217,12 @@ def test_parse_ignores_l3_host_scheduling_spans(span_root, monkeypatch):
     assert stats.device_wall_us == [5.0]
     assert len(stats.invocations) == 1
 
-    # Older compatible runtimes predate the helper. PyPTO still filters the
-    # namespace locally instead of failing import or selecting the bogus lane.
+    # Older compatible runtimes predate simpler's own filter, and #1877 renamed
+    # it ``legacy_spans`` -> ``invocation_spans``. With neither present PyPTO
+    # still filters the namespaces locally instead of failing import or
+    # selecting the bogus lane.
     strace_timing = sys.modules["simpler_setup.tools.strace_timing"]
+    monkeypatch.delattr(strace_timing, "invocation_spans", raising=False)
     monkeypatch.delattr(strace_timing, "legacy_spans", raising=False)
     fallback_stats = _parse_stats_from_strace("\n".join(lines), rounds=1, warmup=0)
     assert fallback_stats.host_wall_us == [50.0]
@@ -366,7 +414,7 @@ def test_parse_l3_ignores_prepare_time_prewarm_groups(span_root):
         # ``prepare()`` runs before benchmark dispatches while stderr is already
         # captured. Simpler's arena prewarm emits this non-dispatch STRACE group
         # with no canonical run root or device-wall span.
-        lines.append(_strace_line(0, "simpler_prewarm.build", 800_000, pid=pid, hid="0"))
+        lines.append(_strace_line(0, "chip.prewarm.build", 800_000, pid=pid, hid="0"))
         lines += _launch_lines(1, span_root, host_us=99, device_us=99, pid=pid)  # warmup
         lines += _launch_lines(2, span_root, host_us=100, device_us=measured_us[0], pid=pid)
         lines += _launch_lines(3, span_root, host_us=300, device_us=measured_us[1], pid=pid)
@@ -1172,7 +1220,7 @@ def test_benchmark_l3_ignores_prepare_setup_groups(span_root):
         def prepare(self, config: Any = None, **kwargs: Any) -> _FakeDistributedWorker:
             del config, kwargs
             for pid in (100, 101):
-                line = _strace_line(0, "simpler_prewarm.build", 800_000, pid=pid, hid="0")
+                line = _strace_line(0, "chip.prewarm.build", 800_000, pid=pid, hid="0")
                 os.write(2, (line + "\n").encode())
             return self._rt
 


### PR DESCRIPTION
## What

Bumps the `runtime` submodule `1f27a157` → `93adc386` (47 commits) and adapts pypto to the one pypto-facing change in that range.

simpler #1877/#1880/#1886/#1893/#1909 make every `[STRACE]` span lead with the word for the **level** that emitted it:

| before | after |
| --- | --- |
| `simpler_run` | `chip.run` |
| `simpler_prewarm.build` | `chip.prewarm.build` |
| `l3.*` (per-task scheduler) | `node.*` / `network1..3.*` |
| — | `ext.<producer>.*` reserved for non-simpler producers |
| `strace_timing.legacy_spans` | `strace_timing.invocation_spans` |
| `_ROUNDS_TABLE_NAMES["host"]` | `_ROUNDS_TABLE_NAMES["run"]` |

## Why it mattered

Both consequences in `bench.py` were **silent**, not loud.

**1. Every timing sample would have parsed as `0.0`.** `_span_names()` looked up `"host"` and swallowed the `KeyError`, falling back to the pre-#1210 `run_prepared.*` names — which match nothing on a current runtime:

```
old code: KeyError 'host' -> swallowed -> run_prepared.* -> every sample 0.0
```

Each key is now resolved through a candidate table accepting both spellings, all-or-nothing so a half-known table cannot mix generations.

**2. The old scheduler spelling leaked back in.** The `legacy_spans` `hasattr` guard fell through to a local filter covering only the `l3.` prefix. pypto's own prefix filter now runs unconditionally and simpler's filter after it — `invocation_spans` deliberately *keeps* families it does not recognise (its docstring: dropping unfamiliar names silently is how `chip.prewarm.build` once vanished from its tables), so a current simpler passes the pre-#1893 spelling straight through.

**3. The unit tests could not have caught either.** The `span_root` fixture repeated the same swallow-and-fall-back, so fixture and parser drifted together and stayed green. It now derives from `_span_names()`, and a separate `test_span_names_resolve_from_installed_runtime` asserts the resolution did not fall back. That guard is gated on `_ROUNDS_TABLE_NAMES` existing, so a genuinely pre-#1210 simpler — where the legacy names are the documented answer — skips instead of failing.

## What did *not* change

Checked surface by surface: `tensormap_and_ringbuffer`'s `pto_types.h` and `pto_orchestration_api.h` are **byte-identical** across the range, so orchestration codegen, `Tensor` field emission, and the task-interface exports are untouched — the +299-line orchestration-API churn in this range is confined to `host_build_graph`, which pypto does not use. `simpler.task_interface.__all__`, the public `Worker` API, `KernelCompiler.compile_incore` / `compile_orchestration`, `torch_interop`, `pto_isa`, `deps_viewer`, and `dump_viewer` are all unchanged.

`runtime/pto_isa.pin` advances `f51c92f6` → `cd4a3d3f`, which CI derives from the submodule on its own.

## Validation

- `pytest tests/ut/` — **10109 passed, 8 skipped**
- `ruff check` + `ruff format --check` + `pyright` on the changed files — clean
- `tests/lint/{check_headers,check_english_only,check_docs_en_zh_parity,check_docs_nav,check_no_broad_raises,check_op_name_literals}.py` — clean
- **On-device a2a3** (`PTOAS_ROOT` pinned to the repo's `v0.57`), 147 passed total:
  - `framework_and_models` — 86 passed
  - DFX with flags: `--enable-chip-swimlane` 4, `--dump-args` 8 — the `swimlane_converter` / `dump_viewer` regression guard
  - scatter/gather ops — 35 passed (historically the pto-isa-sensitive set)
  - L3 comm-less — 14 passed

The load-bearing guard is `test_benchmark_st.py`, which asserts `not stats.all_zero_device` and `device_us_min > 0` — exactly the failure mode above. Both the L2 cases and the L3 `test_benchmark_l3_surfaces_per_rank_timing` case pass. The L3 case must run alone; after the two L2 cases in the same process it hits a pre-existing L2→L3 fork issue unrelated to this change.

## Review notes

One review thread is intentionally left open rather than resolved: the suggestion to make the `unit-tests` job install `./runtime` so `tests/ut/runtime/test_benchmark.py` runs in CI. The observation behind it is correct — `tests/ut` runs in exactly one job, which installs only `.[dev]`, so those tests always skip. The remediation is declined because the real coverage is `test_benchmark_st.py` under `system-tests-direct` (real card, real `[STRACE]` output, passing on this PR), whereas the UT feeds synthetic markers and so could not validate the actual span names even with the runtime installed. Rationale is on the thread.
