### PR TITLE
fix(ir): hash a null TileView start_offset instead of aborting

### DIFF
--- a/docs/en/dev/ir/03-structural_comparison.md
+++ b/docs/en/dev/ir/03-structural_comparison.md
@@ -294,7 +294,7 @@ compiles, passes serialization round-trips, and compares correctly — then hits
 guarantee above, since `structural_equal` accepts what `structural_hash`
 rejects.
 
-Two dispatch hazards to mirror across the ladders:
+Three dispatch hazards to mirror across the ladders:
 
 - **Subclass kinds.** `As<T>()` is a precise `ObjectKind` match, so
   `As<TensorType>(dt)` returns `nullptr` for a `DistributedTensorType` by
@@ -303,6 +303,16 @@ Two dispatch hazards to mirror across the ladders:
 - **Subclass-only fields.** `DistributedTensorType::window_buffer_` has no
   `TensorType` counterpart; a shared branch has to hash and compare it under a
   kind guard.
+- **Nullable fields.** A bare `ExprPtr` field with no non-null invariant —
+  `TileView::start_offset`, which the default ctor and `pl.TileView(...)` both
+  leave unset — is a *legal, distinct* state, not a construction bug.
+  `EqualType` gets that for free by routing it through the null-tolerant
+  `Equal(...)`, so `HashType` must hash a presence tag rather than
+  `INTERNAL_CHECK` on it. Guarding one ladder and not the other breaks the
+  guarantee in the same direction as a missing Type: `structural_equal` reports
+  a value equal to itself that `structural_hash` aborts on. Reserve
+  `INTERNAL_CHECK` in `HashType` for fields that genuinely cannot be null, such
+  as `shape_` elements.
 
 `tests/ut/ir/transforms/test_hash.py::TestHashTypeLadderParity` walks every
 Python-constructible Type and fails when one is missing from `HashType`. Add a

--- a/docs/zh/dev/ir/03-structural_comparison.md
+++ b/docs/zh/dev/ir/03-structural_comparison.md
@@ -292,7 +292,7 @@ bool EqualWithFields(const NodePtr& lhs_op, const NodePtr& rhs_op) {
 "相等的节点哈希值也相等"的保证：`structural_equal` 接受的输入，
 `structural_hash` 却拒绝。
 
-有两类分发陷阱需要在各条分支链之间保持一致：
+有三类分发陷阱需要在各条分支链之间保持一致：
 
 - **子类 kind。** `As<T>()` 是精确的 `ObjectKind` 匹配，因此
   `As<TensorType>(dt)` 对 `DistributedTensorType` 按设计返回 `nullptr`
@@ -300,6 +300,14 @@ bool EqualWithFields(const NodePtr& lhs_op, const NodePtr& rhs_op) {
   并使用 `static_pointer_cast` —— 参见 `.claude/rules/ir-kind-traits.md`。
 - **仅子类持有的字段。** `DistributedTensorType::window_buffer_` 在
   `TensorType` 上没有对应字段；共用分支必须在 kind 判断的保护下对它做哈希与比较。
+- **可为空的字段。** 没有非空不变式的裸 `ExprPtr` 字段 —— 例如
+  `TileView::start_offset`，默认构造函数与 `pl.TileView(...)` 都会将其留空 ——
+  是一种*合法且可区分*的状态，而不是构造错误。`EqualType` 通过容忍空值的
+  `Equal(...)` 天然支持这一点，因此 `HashType` 必须对它哈希一个存在性标记，
+  而不是用 `INTERNAL_CHECK` 断言。只在一条分支链上加断言，会以与"漏掉某个
+  Type"相同的方式破坏上述保证：`structural_equal` 判定与自身相等的值，
+  `structural_hash` 却会中止。`HashType` 中的 `INTERNAL_CHECK` 应当只用于
+  确实不可能为空的字段，例如 `shape_` 的元素。
 
 `tests/ut/ir/transforms/test_hash.py::TestHashTypeLadderParity` 会遍历每一个
 可由 Python 构造的 Type，当某个 Type 在 `HashType` 中缺失时测试失败。每新增一个

--- a/src/ir/transforms/structural_hash.cpp
+++ b/src/ir/transforms/structural_hash.cpp
@@ -546,9 +546,21 @@ StructuralHasher::result_type StructuralHasher::HashType(const TypePtr& type) {
         INTERNAL_CHECK(dim) << "structural_hash encountered null stride dimension in TileView";
         h = hash_combine(h, HashNode(dim));
       }
-      // Hash start_offset
-      INTERNAL_CHECK(tv.start_offset) << "structural_hash encountered null start_offset in TileView";
-      h = hash_combine(h, HashNode(tv.start_offset));
+      // Hash start_offset. Unlike valid_shape / stride elements, a null
+      // start_offset is a legal TileView state, not a construction bug: the
+      // default ctor leaves it unset (type.h), pl.TileView(...) defaults it to
+      // None, and IsImplicitPrintedTileView reads non-null as "explicit
+      // offset". EqualType compares it through the null-tolerant Equal(...)
+      // (structural_equal.cpp), so asserting here broke equal => equal-hash by
+      // aborting on a type structural_equal happily accepts. Hash the
+      // presence tag the way the optional fields around this branch do, and
+      // mirror ir::Hash(const TileView&)'s null tolerance (type.cpp).
+      if (tv.start_offset) {
+        h = hash_combine(h, static_cast<result_type>(1));  // indicate presence
+        h = hash_combine(h, HashNode(tv.start_offset));
+      } else {
+        h = hash_combine(h, static_cast<result_type>(0));  // indicate absence
+      }
       // Hash blayout
       h = hash_combine(h, static_cast<result_type>(tv.blayout));
       // Hash slayout

--- a/tests/ut/ir/transforms/test_hash.py
+++ b/tests/ut/ir/transforms/test_hash.py
@@ -11,6 +11,7 @@
 
 from collections.abc import Callable
 
+import pypto.language as pl
 import pytest
 from pypto import DataType, ir
 from pypto.pypto_core import ir as _core_ir
@@ -328,6 +329,18 @@ def _dims(*extents: int) -> list[ir.ConstInt]:
     return [ir.ConstInt(e, DataType.INT64, _span()) for e in extents]
 
 
+def _start_offset_of(tile_type: ir.Type) -> ir.Expr | None:
+    """Read ``tile_view.start_offset`` off a ``TileType``, asserting the view survived.
+
+    ``TileType``'s ctor canonicalizes an implicit view away to ``None``, so a
+    bare attribute chain would silently read through a dropped view.
+    """
+    assert isinstance(tile_type, ir.TileType)
+    tile_view = tile_type.tile_view
+    assert tile_view is not None, "TileType canonicalized the view away"
+    return tile_view.start_offset
+
+
 # One shared WindowBuffer so the two instances a factory builds stay
 # structurally equal: window_buffer_ is compared by Var identity, not by value.
 _SHARED_WINDOW_BUFFER = ir.WindowBuffer(
@@ -352,6 +365,22 @@ _TYPE_FACTORIES: dict[str, Callable[[], ir.Type]] = {
         _dims(64, 128), DataType.FP32, _SHARED_WINDOW_BUFFER
     ),
     "TileType": lambda: ir.TileType([64, 128], DataType.FP16),
+    # A partial view: start_offset stays None, which is the state
+    # pl.TileView(...) and TileView's default ctor both produce.
+    "TileType_view_null_start_offset": lambda: ir.TileType(
+        [64, 128],
+        DataType.FP16,
+        tile_view=ir.TileView(valid_shape=[32, 128], pad=ir.PadValue.zero),
+    ),
+    "TileType_view_explicit_start_offset": lambda: ir.TileType(
+        [64, 128],
+        DataType.FP16,
+        tile_view=ir.TileView(
+            valid_shape=[32, 128],
+            pad=ir.PadValue.zero,
+            start_offset=ir.ConstInt(0, DataType.INDEX, _span()),
+        ),
+    ),
     "ArrayType": lambda: ir.ArrayType(DataType.INT32, 16),
     "TupleType": lambda: ir.TupleType([ir.ScalarType(DataType.INT64), ir.ArrayType(DataType.INT32, 8)]),
     "PtrType": lambda: ir.PtrType(),
@@ -534,6 +563,64 @@ class TestHashTypeLadderParity:
         null_pad, zero_pad = make(ir.PadValue.null), make(ir.PadValue.zero)
         assert not ir.structural_equal(null_pad, zero_pad)
         assert hash(null_pad) != hash(zero_pad)
+
+    def test_null_tile_view_start_offset_hashes_apart_from_an_explicit_zero(self):
+        """A null ``TileView::start_offset`` must hash, not abort.
+
+        ``start_offset`` carries no non-null invariant: the C++ default ctor
+        leaves it unset, ``pl.TileView(...)`` defaults it to ``None``, and
+        ``IsImplicitPrintedTileView`` reads non-null as "explicit offset".
+        ``EqualType`` compares it through the null-tolerant ``Equal(...)``, so
+        ``HashType``'s ``INTERNAL_CHECK`` used to abort on a ``TileType`` that
+        ``structural_equal`` reported equal to itself.
+        """
+
+        def make(start_offset: ir.Expr | None) -> ir.TileType:
+            return ir.TileType(
+                [64, 128],
+                DataType.FP16,
+                tile_view=ir.TileView(valid_shape=[32, 128], pad=ir.PadValue.zero, start_offset=start_offset),
+            )
+
+        null_off = make(None)
+        assert _start_offset_of(null_off) is None
+        # Null is a distinct state, not a stand-in for offset 0.
+        zero_off = make(ir.ConstInt(0, DataType.INDEX, _span()))
+        assert not ir.structural_equal(null_off, zero_off)
+        assert hash(null_off) != hash(zero_off)
+
+    def test_a_kernel_signature_with_a_partial_tile_view_is_hashable(self):
+        """The null ``start_offset`` above is reachable from plain DSL syntax.
+
+        A ``pl.Tile[...]`` annotation carrying a partial ``pl.TileView(...)``
+        leaves ``start_offset`` unset, so the abort propagated all the way out
+        of ``structural_hash(program)``.
+        """
+
+        @pl.program
+        class Mod:
+            @pl.function
+            def main(
+                self,
+                x: pl.Tile[
+                    [64, 32],
+                    pl.FP32,
+                    pl.Mem.Vec,
+                    pl.TileView(valid_shape=[32, 32], pad=pl.PadValue.zero),
+                ],
+            ) -> pl.Tile[
+                [64, 32], pl.FP32, pl.Mem.Vec, pl.TileView(valid_shape=[32, 32], pad=pl.PadValue.zero)
+            ]:
+                return x
+
+        main = Mod["main"]
+        assert main is not None
+        param_type = main.params[0].type
+        assert _start_offset_of(param_type) is None
+        assert ir.structural_equal(param_type, param_type)
+        assert isinstance(ir.structural_hash(param_type), int)
+        assert isinstance(hash(param_type), int)
+        assert isinstance(ir.structural_hash(Mod), int)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What

`HashType` no longer aborts on a `TileType` whose `TileView::start_offset` is null. It hashes a presence tag instead, the same way the optional fields around it already do.

## Why

`TileView::start_offset` carries no non-null invariant — null is a legal, meaningful state, not a construction bug:

- the C++ default ctor leaves it unset (`include/pypto/ir/type.h`)
- `pl.TileView(...)` defaults it to `None` (`python/pypto/ir/type.py`)
- `IsImplicitPrintedTileView` *reads* non-null as "explicit offset", and `NormalizeImplicitTileView` has an opt-in `fill_start_offset` to materialize a `0`
- serialization documents the field as "Expr node or nil"

Two of the three comparators honored that. `EqualType` compares the field through the null-tolerant `Equal(...)`, and `ir::Hash(const TileView&)` maps null to a distinct value via `HashExprForAreExprsEqual`. `HashType` asserted on it.

The result was a `TileType` that `structural_equal` reported equal to itself but that raised `InternalError` from `structural_hash` / Python `hash()`, so any hash-keyed container over such a type aborted. It is reachable straight from a kernel signature — a `pl.Tile[...]` annotation carrying a partial `pl.TileView(...)` is enough — and the abort then propagated out of `structural_hash(program)`:

```python
@pl.program
class M:
    @pl.function
    def main(
        self,
        x: pl.Tile[[64, 32], pl.FP32, pl.Mem.Vec, pl.TileView(valid_shape=[32, 32], pad=pl.PadValue.zero)],
    ) -> pl.Tile[[64, 32], pl.FP32, pl.Mem.Vec, pl.TileView(valid_shape=[32, 32], pad=pl.PadValue.zero)]:
        return x

t = M["main"].params[0].type
t.tile_view.start_offset      # None
ir.structural_equal(t, t)     # True
ir.structural_hash(t)         # InternalError: ... null start_offset in TileView
```

Passing an explicit `start_offset=0` made every line succeed. Compilation itself was unaffected.

## Why this fix and not a non-null invariant

The alternative — making non-null `start_offset` a real `TileView` invariant enforced at construction — would contradict the IR design rather than implement it. `IsImplicitPrintedTileView` distinguishes implicit from explicit views precisely by whether `start_offset` is set, and `NormalizeImplicitTileView`'s `fill_start_offset` parameter exists because callers that want a materialized `0` must ask for it. Filling the field at construction would collapse that distinction.

## Notes for reviewers

- **Null stays distinct from an explicit `start_offset=0`.** That is deliberate and correct: `structural_equal` reports those two types unequal, so they must not share a hash.
- **Hash values for `TileType`s with a non-null `start_offset` change**, because the presence tag is now mixed in. `structural_hash` values are in-memory only — nothing persists or asserts a literal hash — and the full suite is green.
- The trailing `INTERNAL_CHECK`s on `valid_shape` / `stride` elements are left as-is; a null element there really would be a construction bug.

## Tests

Five new regression cases in `tests/ut/ir/transforms/test_hash.py`, all confirmed to fail without the fix (verified by reverting the C++ change and rebuilding):

- two new `_TYPE_FACTORIES` entries (null and explicit `start_offset`) that feed the existing `TestHashTypeLadderParity` harness, generating 3 parametrized checks covering "does not raise", "equal implies equal hash", and the auto-mapping variant
- `test_null_tile_view_start_offset_hashes_apart_from_an_explicit_zero`
- `test_a_kernel_signature_with_a_partial_tile_view_is_hashable`, pinning the user-reachable DSL path above

Full unit suite: 10128 passed, 3 skipped. `ctest` 1/1. `pre-commit run` clean on the changed files.

## Docs

`docs/en/dev/ir/03-structural_comparison.md` (and its `zh` mirror) gain a third "dispatch hazard" bullet for nullable fields. That section already warned about the two other ways the four hand-written `Type` ladders drift apart; this bug is the same failure class, and the section is where the next author would look.
