### PR TITLE
docs(user): restore the explanations DSL op docstrings dropped

### DIFF
--- a/.claude/skills/add-op/SKILL.md
+++ b/.claude/skills/add-op/SKILL.md
@@ -90,7 +90,10 @@ third argument. Template: [reference.md §2](reference.md).
 **File**: `python/pypto/language/op/tile_ops.py`
 
 Unwrap the `Tile` args → call the IR function → wrap the result in `Tile`. Also add
-`"<op_name>"` to `__all__` if the file has one. Template: [reference.md §3](reference.md).
+`"<op_name>"` to `__all__` if the file has one. **This docstring is the published manual** —
+`docs/en/user/api/tile.md` renders it — so carry A2's explanation across rather than trimming to
+a one-line summary; `tests/lint/check_op_docstring_parity.py` fails otherwise. Template:
+[reference.md §3](reference.md).
 
 ### A4: Unit Tests
 
@@ -186,7 +189,7 @@ Also check whether the 910B backend needs special handling in
 - [ ] Exact backend pipe inference exists when the source/destination route is not uniquely inferable
 - [ ] New `.cpp` added to `CMakeLists.txt` if created
 - [ ] Python IR wrapper in `ir/op/{tile,tensor}_ops.py`
-- [ ] Python DSL wrapper in `language/op/{tile,tensor}_ops.py`
+- [ ] Python DSL wrapper in `language/op/{tile,tensor}_ops.py`, docstring carries A2's explanation
 - [ ] Conversion registered in `op_conversion_registry.cpp` (if Phase B)
 - [ ] Codegen registered in backend (if Phase C)
 - [ ] Unit tests pass: `python3 -m pytest tests/ut/ir/operators/ -v -k <op_name>`

--- a/.claude/skills/add-op/reference.md
+++ b/.claude/skills/add-op/reference.md
@@ -148,9 +148,33 @@ Pattern: unwrap `Tile` → call IR function → wrap result:
 
 ```python
 def <op_name>(lhs: Tile, rhs: Tile) -> Tile:
+    """<One-line summary.>
+
+    <The explanation from the §2 IR wrapper, adapted to the DSL surface.>
+
+    Args:
+        lhs: Left-hand side tile
+        rhs: Right-hand side tile
+
+    Returns:
+        Tile wrapping the <op_name> operation
+    """
     call_expr = _ir_ops.<op_name>(lhs.unwrap(), rhs.unwrap())
     return Tile(expr=call_expr)
 ```
+
+**The docstring is not optional and not a shortened copy.** `pypto.language.tile` and
+`pypto.language.tensor` are rendered into `docs/en/user/api/`, so this docstring is the
+published manual while the §2 IR wrapper is internal. Whatever the IR copy says about shape
+rules, broadcasting, dtype restrictions or operand aliasing has to be said here too.
+
+Adapt rather than paste: drop the `span` argument and codegen internals, write `pl.tile.foo`
+where the IR copy writes `foo`, and say `Tile` where it says `TileType`. Being *longer* than the
+IR copy is fine and common. Write it as a **source literal** — do not assign `__doc__` from
+`_ir_ops.<op_name>` at import time, since mkdocstrings reads the source statically through griffe
+(see `docs/requirements.txt`) and a runtime-assigned `__doc__` renders empty on the API page.
+`tests/lint/check_op_docstring_parity.py` fails when the IR docstring explains something past its
+summary and the DSL twin does not.
 
 ### File: `python/pypto/language/op/tensor_ops.py`
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -77,6 +77,13 @@ repos:
           language_version: python3
           pass_filenames: false
 
+        - id: check-op-docstring-parity
+          name: check-op-docstring-parity
+          entry: python tests/lint/check_op_docstring_parity.py
+          language: python
+          language_version: python3
+          pass_filenames: false
+
     - repo: https://github.com/pre-commit/pre-commit-hooks
       rev: v4.6.0
       hooks:

--- a/python/pypto/ir/op/tile_ops.py
+++ b/python/pypto/ir/op/tile_ops.py
@@ -3223,7 +3223,7 @@ def gather_compare(
     :class:`Call` whose result type is a ``TupleType{dst, cdst}``::
 
         dst  : TileType, [rows, out_cols], INT32  — gathered indices
-        cdst : TileType, [rows],           count_dtype — per-row match count
+        cdst : TileType, [1, rows],        count_dtype — per-row match count
 
     The DSL form ``d, c = pl.tile.gather_compare(src, kvalue, tmp, ...)`` is
     desugared by the parser into ``_tuple = call; d = _tuple[0]; c = _tuple[1]``.

--- a/python/pypto/language/op/tensor_ops.py
+++ b/python/pypto/language/op/tensor_ops.py
@@ -582,6 +582,10 @@ def ci(
 
     Equivalent to ``numpy.arange`` / ``torch.arange``. Lowers to ``tile.ci`` → ``pto.tci``.
 
+    Note:
+        ``pto.tci`` only populates the first row. Leading dimensions must be 1 —
+        prefer shapes of the form ``[1, N]``.
+
     Args:
         start: Starting integer (plain int or Scalar). Must match ``dtype``.
         shape: Destination tensor shape (innermost dim != 1).
@@ -646,6 +650,12 @@ def matmul(
     c_matrix_nz: bool = False,
 ) -> Tensor:
     """Matrix multiplication with optional transpose.
+
+    A transpose flag swaps its own operand's two trailing axes, so that operand must
+    be at least 2D: ``a_trans`` with a 1D ``lhs`` (or ``b_trans`` with a 1D ``rhs``)
+    raises rather than being ignored. On the mixed mat-vec / vec-mat forms the flag
+    applies to the matrix side, so a ``lhs`` stored ``[K, M]`` with ``a_trans=True``
+    against a ``[K]`` ``rhs`` deduces ``[M]``.
 
     Args:
         lhs: Left-hand side tensor
@@ -1378,6 +1388,9 @@ def row_expand(target: Tensor, row_vec: Tensor) -> Tensor:
 def row_expand_mul(tensor: Tensor, row_vec: Tensor) -> Tensor:
     """Row-wise broadcast multiplication: tensor[i,:] * row_vec[i,0].
 
+    Multiplies each row of the tensor by the corresponding row vector value,
+    for all ``i``.
+
     Args:
         tensor: Input tensor (TensorType [M, N])
         row_vec: Row vector (TensorType [M, 1])
@@ -1393,6 +1406,9 @@ def row_expand_mul(tensor: Tensor, row_vec: Tensor) -> Tensor:
 
 def row_expand_div(tensor: Tensor, row_vec: Tensor) -> Tensor:
     """Row-wise broadcast division: tensor[i,:] / row_vec[i,0].
+
+    Divides each row of the tensor by the corresponding row vector value,
+    for all ``i``.
 
     Args:
         tensor: Input tensor (TensorType [M, N])
@@ -1410,6 +1426,8 @@ def row_expand_div(tensor: Tensor, row_vec: Tensor) -> Tensor:
 def row_expand_add(tensor: Tensor, row_vec: Tensor) -> Tensor:
     """Row-wise broadcast addition: tensor[i,:] + row_vec[i,0].
 
+    Adds a row vector to each row of the tensor, for all ``i``.
+
     Args:
         tensor: Input tensor (TensorType [M, N])
         row_vec: Row vector (TensorType [M, 1])
@@ -1425,6 +1443,8 @@ def row_expand_add(tensor: Tensor, row_vec: Tensor) -> Tensor:
 
 def row_expand_sub(tensor: Tensor, row_vec: Tensor) -> Tensor:
     """Row-wise broadcast subtraction: tensor[i,:] - row_vec[i,0].
+
+    Subtracts a row vector from each row of the tensor, for all ``i``.
 
     Args:
         tensor: Input tensor (TensorType [M, N])
@@ -1442,6 +1462,9 @@ def row_expand_sub(tensor: Tensor, row_vec: Tensor) -> Tensor:
 def row_expand_max(tensor: Tensor, row_vec: Tensor) -> Tensor:
     """Row-wise broadcast maximum: max(tensor[i,:], row_vec[i,0]).
 
+    Takes the element-wise maximum of each row and the row vector value,
+    for all ``i``.
+
     Args:
         tensor: Input tensor (TensorType [M, N])
         row_vec: Row vector (TensorType [M, 1])
@@ -1457,6 +1480,9 @@ def row_expand_max(tensor: Tensor, row_vec: Tensor) -> Tensor:
 
 def row_expand_min(tensor: Tensor, row_vec: Tensor) -> Tensor:
     """Row-wise broadcast minimum: min(tensor[i,:], row_vec[i,0]).
+
+    Takes the element-wise minimum of each row and the row vector value,
+    for all ``i``.
 
     Args:
         tensor: Input tensor (TensorType [M, N])
@@ -1474,6 +1500,8 @@ def row_expand_min(tensor: Tensor, row_vec: Tensor) -> Tensor:
 def row_expand_expdif(tensor: Tensor, row_vec: Tensor) -> Tensor:
     """Row-wise exp-diff: exp(tensor[i,:] - row_vec[i,0]).
 
+    Computes the exponential of the per-row difference, for all ``i``.
+
     Args:
         tensor: Input tensor (TensorType [M, N])
         row_vec: Row vector providing per-row scalar (TensorType [M, 1])
@@ -1489,6 +1517,9 @@ def row_expand_expdif(tensor: Tensor, row_vec: Tensor) -> Tensor:
 
 def col_expand_mul(tensor: Tensor, col_vec: Tensor) -> Tensor:
     """Column-wise broadcast multiplication: tensor[:,j] * col_vec[0,j].
+
+    Multiplies each column of the tensor by the corresponding column vector
+    value, for all ``j``.
 
     Args:
         tensor: Input tensor (TensorType [M, N])
@@ -1522,6 +1553,8 @@ def col_expand(tensor: Tensor, col_vec: Tensor) -> Tensor:
 def col_expand_sub(tensor: Tensor, col_vec: Tensor) -> Tensor:
     """Column-wise broadcast subtraction: tensor[:,j] - col_vec[0,j].
 
+    Subtracts a column vector from each column of the tensor, for all ``j``.
+
     Args:
         tensor: Input tensor (TensorType [M, N])
         col_vec: Column vector (TensorType [1, N])
@@ -1537,6 +1570,9 @@ def col_expand_sub(tensor: Tensor, col_vec: Tensor) -> Tensor:
 
 def col_expand_div(tensor: Tensor, col_vec: Tensor) -> Tensor:
     """Column-wise broadcast division: tensor[:,j] / col_vec[0,j].
+
+    Divides each column of the tensor by the corresponding column vector
+    value, for all ``j``.
 
     Args:
         tensor: Input tensor (TensorType [M, N])
@@ -1554,6 +1590,8 @@ def col_expand_div(tensor: Tensor, col_vec: Tensor) -> Tensor:
 def col_expand_add(tensor: Tensor, col_vec: Tensor) -> Tensor:
     """Column-wise broadcast addition: tensor[:,j] + col_vec[0,j].
 
+    Adds a column vector to each column of the tensor, for all ``j``.
+
     Args:
         tensor: Input tensor (TensorType [M, N])
         col_vec: Column vector (TensorType [1, N])
@@ -1569,6 +1607,9 @@ def col_expand_add(tensor: Tensor, col_vec: Tensor) -> Tensor:
 
 def col_expand_max(tensor: Tensor, col_vec: Tensor) -> Tensor:
     """Column-wise broadcast maximum: max(tensor[:,j], col_vec[0,j]).
+
+    Takes the element-wise maximum of each column and the column vector
+    value, for all ``j``.
 
     Args:
         tensor: Input tensor (TensorType [M, N])
@@ -1586,6 +1627,9 @@ def col_expand_max(tensor: Tensor, col_vec: Tensor) -> Tensor:
 def col_expand_min(tensor: Tensor, col_vec: Tensor) -> Tensor:
     """Column-wise broadcast minimum: min(tensor[:,j], col_vec[0,j]).
 
+    Takes the element-wise minimum of each column and the column vector
+    value, for all ``j``.
+
     Args:
         tensor: Input tensor (TensorType [M, N])
         col_vec: Column vector (TensorType [1, N])
@@ -1601,6 +1645,8 @@ def col_expand_min(tensor: Tensor, col_vec: Tensor) -> Tensor:
 
 def col_expand_expdif(tensor: Tensor, col_vec: Tensor) -> Tensor:
     """Column-wise exp-diff: exp(tensor[:,j] - col_vec[0,j]).
+
+    Computes the exponential of the per-column difference, for all ``j``.
 
     Args:
         tensor: Input tensor (TensorType [M, N])
@@ -1928,11 +1974,10 @@ def view(
 ) -> _TensorT:
     """Reinterpret a tensor over the same physical memory.
 
-    At least one of ``shape`` or ``layout`` must be provided. The result is a
-    zero-copy tensor view with canonical strides derived by the IR type deducer.
-
-    See [`tensor.view`][pypto.language.tensor.view] for full details on validity
-    constraints, error conditions, and the product-preserving shape rule.
+    At least one of ``shape`` or ``layout`` must be provided: ``shape`` derives
+    canonical strides for the requested shape, ``layout`` derives the canonical
+    ND/DN layout view. The result is a zero-copy view over the same physical
+    memory, and its target shape must have rank at least 1.
 
     Args:
         tensor: Source tensor.
@@ -1965,6 +2010,14 @@ def view(
 
 def scatter_update(input: Tensor, *args: Any, **kwargs: Any) -> Tensor:
     """Update input tensor rows at positions specified by 2D index with values from src.
+
+    Supports two rank variants:
+
+    - 2D: ``input [rows, d]``, ``src [b*s, d]``, ``index [b, s]``
+    - 4D: ``input [blockNum, blockSize, 1, d]``, ``src [b, s, 1, d]``, ``index [b, s]``
+
+    For each ``(i, j)``, row ``input[index[i*s + j]]`` receives row ``src[i*s + j]``
+    (linear layout).
 
     Accepts the same flexible call shapes as the IR builder
     ``pypto.ir.op.tensor.scatter_update``:

--- a/python/pypto/language/op/tile_ops.py
+++ b/python/pypto/language/op/tile_ops.py
@@ -544,6 +544,9 @@ def extract(
 ) -> Tile:
     """Extract a sub-tile from ``src`` at ``(index_row, index_col)`` — ISA TEXTRACT.
 
+    Maps to ISA TEXTRACT Variant 1 (Standard Extract). The result tile has the
+    given static ``shape`` and lives in ``target_memory``.
+
     Args:
         src: Source tile (typically in Mat or Acc memory)
         index_row: Starting row offset
@@ -568,6 +571,11 @@ def extract(
 
 def scatter_update(input: Tile, *args: Any, **kwargs: Any) -> Tile:
     """Update tile rows at positions specified by 2D index tile with values from src.
+
+    Supports two rank variants:
+
+    - 2D: ``input [rows, d]``, ``src [b*s, d]``, ``index [b, s]``
+    - 4D: ``input [blockNum, blockSize, 1, d]``, ``src [b, s, 1, d]``, ``index [b, s]``
 
     Accepts the same flexible call shapes as the IR builder
     ``pypto.ir.op.tile.scatter_update``:
@@ -727,6 +735,13 @@ def ci(
     """Generate a contiguous integer sequence into a tile.
 
     Equivalent to ``numpy.arange``-style index generation. Maps to ``pto.tci``.
+    For a column index ``k`` in the first row of the destination, ascending gives
+    ``dst[0, k] = start + k`` and descending gives ``dst[0, k] = start - k``.
+
+    Note:
+        ``pto.tci`` uses the destination's valid-column count as the sequence
+        length and does NOT populate additional rows. Leading dimensions must
+        be 1 — prefer shapes of the form ``[1, N]``.
 
     Args:
         start: Starting integer (plain int or a Scalar). Must match ``dtype``.
@@ -940,6 +955,9 @@ def get_block_num() -> Scalar:
 def add(lhs: Tile, rhs: Tile | int | float | Scalar | Expr) -> Tile:
     """Element-wise addition of tile and tile or scalar.
 
+    Supports broadcasting when both operands are tiles. A scalar ``rhs``
+    canonicalizes to ``tile.adds``.
+
     Args:
         lhs: Left-hand side tile
         rhs: Right-hand side tile or scalar
@@ -954,6 +972,9 @@ def add(lhs: Tile, rhs: Tile | int | float | Scalar | Expr) -> Tile:
 def sub(lhs: Tile, rhs: Tile | int | float | Scalar | Expr) -> Tile:
     """Element-wise subtraction of tile and tile or scalar.
 
+    Supports broadcasting when both operands are tiles. A scalar ``rhs``
+    canonicalizes to ``tile.subs``.
+
     Args:
         lhs: Left-hand side tile
         rhs: Right-hand side tile or scalar
@@ -967,6 +988,9 @@ def sub(lhs: Tile, rhs: Tile | int | float | Scalar | Expr) -> Tile:
 
 def mul(lhs: Tile, rhs: Tile | int | float | Scalar | Expr) -> Tile:
     """Element-wise multiplication of tile and tile or scalar.
+
+    Supports broadcasting when both operands are tiles. A scalar ``rhs``
+    canonicalizes to ``tile.muls``.
 
     Args:
         lhs: Left-hand side tile
@@ -985,6 +1009,10 @@ def div(
     high_precision: bool = False,
 ) -> Tile:
     """Element-wise division of tile and tile or scalar.
+
+    Tile-tile division requires identical physical and valid shapes. A scalar
+    ``rhs`` canonicalizes to ``tile.divs``, which does not expose the ``tdiv``
+    precision mode — hence ``high_precision`` applies only to the tile-tile form.
 
     Args:
         lhs: Left-hand side tile
@@ -1084,6 +1112,9 @@ def exp(tile: Tile) -> Tile:
 def sin(tile: Tile) -> Tile:
     """Element-wise sine of a tile (radians). FP32 only.
 
+    Non-FP32 inputs are rejected rather than promoted — cast explicitly with
+    ``pl.cast(tile, pl.FP32)`` first.
+
     Args:
         tile: Input tile (FP32)
 
@@ -1096,6 +1127,9 @@ def sin(tile: Tile) -> Tile:
 
 def cos(tile: Tile) -> Tile:
     """Element-wise cosine of a tile (radians). FP32 only.
+
+    Non-FP32 inputs are rejected rather than promoted — cast explicitly with
+    ``pl.cast(tile, pl.FP32)`` first.
 
     Args:
         tile: Input tile (FP32)
@@ -1205,6 +1239,9 @@ def cast(
 
     Returns:
         Tile wrapping the cast operation
+
+    Example:
+        >>> tile_fp32 = pl.tile.cast(tile_bf16, pl.FP32)
     """
     call_expr = _ir_ops.cast(tile.unwrap(), target_type, mode)
     return Tile(expr=call_expr)
@@ -1226,6 +1263,9 @@ def matmul(lhs: Tile, rhs: Tile) -> Tile:
 
 def batch_matmul(lhs: Tile, rhs: Tile) -> Tile:
     """Batch matrix multiplication of two tiles.
+
+    Broadcasts the batch dims: for inputs shaped ``[...batch_dims, M, K]`` and
+    ``[...batch_dims, K, N]``, the output is ``[...broadcast_batch_dims, M, N]``.
 
     Args:
         lhs: Left-hand side tile
@@ -1429,6 +1469,9 @@ def gemv_bias(lhs: Tile, rhs: Tile, bias: Tile, acc_phase: str = "unspecified") 
 def row_max(tile: Tile, tmp_tile: Tile) -> Tile:
     """Row-wise max reduction.
 
+    Reduces the last axis with keepdim, producing output shape
+    ``input_shape[:-1] + [1]`` (e.g. ``[rows, 1]`` for a 2D ``[rows, cols]`` input).
+
     Args:
         tile: Input tile
         tmp_tile: Scratch tile with the same dtype and rank as ``tile`` and
@@ -1443,6 +1486,9 @@ def row_max(tile: Tile, tmp_tile: Tile) -> Tile:
 
 def row_sum(tile: Tile, tmp_tile: Tile) -> Tile:
     """Row-wise sum reduction.
+
+    Reduces the last axis with keepdim, producing output shape
+    ``input_shape[:-1] + [1]`` (e.g. ``[rows, 1]`` for a 2D ``[rows, cols]`` input).
 
     Args:
         tile: Input tile
@@ -1459,6 +1505,9 @@ def row_sum(tile: Tile, tmp_tile: Tile) -> Tile:
 def row_min(tile: Tile, tmp_tile: Tile) -> Tile:
     """Row-wise min reduction.
 
+    Reduces the last axis with keepdim, producing output shape
+    ``input_shape[:-1] + [1]`` (e.g. ``[rows, 1]`` for a 2D ``[rows, cols]`` input).
+
     Args:
         tile: Input tile
         tmp_tile: Scratch tile with the same dtype and rank as ``tile`` and
@@ -1473,6 +1522,9 @@ def row_min(tile: Tile, tmp_tile: Tile) -> Tile:
 
 def row_prod(tile: Tile, tmp_tile: Tile) -> Tile:
     """Row-wise product reduction.
+
+    Reduces the last axis with keepdim, producing output shape
+    ``input_shape[:-1] + [1]`` (e.g. ``[rows, 1]`` for a 2D ``[rows, cols]`` input).
 
     Args:
         tile: Input tile
@@ -1489,8 +1541,10 @@ def row_prod(tile: Tile, tmp_tile: Tile) -> Tile:
 def col_sum(tile: Tile, tmp_tile: Tile | None = None) -> Tile:
     """Column-wise sum reduction.
 
-    Passing ``tmp_tile`` activates the binary-tree reduction path; omitting it
-    uses the sequential path.
+    Output shape is ``[1, N]`` for an ``[M, N]`` input.
+
+    Passing ``tmp_tile`` activates the binary-tree reduction path (O(log M) depth,
+    better precision); omitting it uses the sequential path.
 
     Args:
         tile: Input tile
@@ -1508,6 +1562,8 @@ def col_sum(tile: Tile, tmp_tile: Tile | None = None) -> Tile:
 def col_max(tile: Tile) -> Tile:
     """Column-wise max reduction.
 
+    Output shape is ``[1, N]`` for an ``[M, N]`` input.
+
     Args:
         tile: Input tile
 
@@ -1520,6 +1576,8 @@ def col_max(tile: Tile) -> Tile:
 
 def col_min(tile: Tile) -> Tile:
     """Column-wise min reduction.
+
+    Output shape is ``[1, N]`` for an ``[M, N]`` input.
 
     Args:
         tile: Input tile
@@ -1534,6 +1592,8 @@ def col_min(tile: Tile) -> Tile:
 def col_prod(tile: Tile) -> Tile:
     """Column-wise product reduction.
 
+    Output shape is ``[1, N]`` for an ``[M, N]`` input.
+
     Args:
         tile: Input tile
 
@@ -1546,6 +1606,8 @@ def col_prod(tile: Tile) -> Tile:
 
 def row_argmax(tile: Tile, tmp_tile: Tile) -> Tile:
     """Row-wise argmax (column index of the per-row maximum, int32 output).
+
+    Output shape is ``[rows, 1]`` with INT32 index dtype.
 
     Args:
         tile: Input tile
@@ -1561,6 +1623,8 @@ def row_argmax(tile: Tile, tmp_tile: Tile) -> Tile:
 def row_argmin(tile: Tile, tmp_tile: Tile) -> Tile:
     """Row-wise argmin (column index of the per-row minimum, int32 output).
 
+    Output shape is ``[rows, 1]`` with INT32 index dtype.
+
     Args:
         tile: Input tile
         tmp_tile: Scratch tile with exactly the same shape and dtype as ``tile``
@@ -1574,6 +1638,9 @@ def row_argmin(tile: Tile, tmp_tile: Tile) -> Tile:
 
 def col_argmax(tile: Tile, tmp_tile: Tile) -> Tile:
     """Column-wise argmax (row index of the per-column maximum, int32 output).
+
+    Output shape is ``[1, N]`` with INT32 index dtype. Unlike [`col_max`][pypto.language.tile.col_max], the
+    column argmax requires a ``tmp_tile`` scratch buffer.
 
     Args:
         tile: Input tile
@@ -1589,6 +1656,9 @@ def col_argmax(tile: Tile, tmp_tile: Tile) -> Tile:
 def col_argmin(tile: Tile, tmp_tile: Tile) -> Tile:
     """Column-wise argmin (row index of the per-column minimum, int32 output).
 
+    Output shape is ``[1, N]`` with INT32 index dtype. Unlike [`col_min`][pypto.language.tile.col_min], the
+    column argmin requires a ``tmp_tile`` scratch buffer.
+
     Args:
         tile: Input tile
         tmp_tile: Temporary tile
@@ -1602,6 +1672,8 @@ def col_argmin(tile: Tile, tmp_tile: Tile) -> Tile:
 
 def maximum(lhs: Tile, rhs: Tile) -> Tile:
     """Element-wise maximum of two tiles.
+
+    Supports broadcasting between the two tiles.
 
     Args:
         lhs: Left-hand side tile
@@ -1631,6 +1703,9 @@ def row_expand(target: Tile, row_vec: Tile) -> Tile:
 def row_expand_sub(tile: Tile, row_vec: Tile) -> Tile:
     """Row-wise broadcast subtraction.
 
+    Subtracts a row vector from each row of the tile:
+    ``tile[i, :] - row_vec[i, 0]`` for all ``i``.
+
     Args:
         tile: Input tile [M, N]
         row_vec: Row vector [M, 1]
@@ -1644,6 +1719,9 @@ def row_expand_sub(tile: Tile, row_vec: Tile) -> Tile:
 
 def row_expand_div(tile: Tile, row_vec: Tile) -> Tile:
     """Row-wise broadcast division.
+
+    Divides each row of the tile by the corresponding row vector value:
+    ``tile[i, :] / row_vec[i, 0]`` for all ``i``.
 
     Args:
         tile: Input tile [M, N]
@@ -1659,6 +1737,9 @@ def row_expand_div(tile: Tile, row_vec: Tile) -> Tile:
 def row_expand_mul(tile: Tile, row_vec: Tile) -> Tile:
     """Row-wise broadcast multiplication.
 
+    Multiplies each row of the tile by the corresponding row vector value:
+    ``tile[i, :] * row_vec[i, 0]`` for all ``i``.
+
     Args:
         tile: Input tile [M, N]
         row_vec: Row vector [M, 1]
@@ -1672,6 +1753,11 @@ def row_expand_mul(tile: Tile, row_vec: Tile) -> Tile:
 
 def row_expand_add(tile: Tile, row_vec: Tile, tmp: Tile | None = None) -> Tile:
     """Row-wise scalar or packed-block expansion addition.
+
+    A non-row-major ``[M, 1]`` carrier broadcasts one scalar per row:
+    ``tile[i, :] + row_vec[i, 0]`` for all ``i``. A row-major carrier instead holds
+    one 32-byte lane block per row and repeats that block across the destination
+    columns.
 
     Args:
         tile: Input tile [M, N]
@@ -1703,6 +1789,9 @@ def col_expand(target: Tile, col_vec: Tile) -> Tile:
 def col_expand_mul(tile: Tile, col_vec: Tile) -> Tile:
     """Expand column vector and multiply with tile.
 
+    Multiplies each column of the tile by the corresponding column vector value:
+    ``tile[:, j] * col_vec[0, j]`` for all ``j``.
+
     Args:
         tile: Input tile [M, N]
         col_vec: Column vector [1, N]
@@ -1716,6 +1805,9 @@ def col_expand_mul(tile: Tile, col_vec: Tile) -> Tile:
 
 def col_expand_div(tile: Tile, col_vec: Tile) -> Tile:
     """Expand column vector and divide tile by it.
+
+    Divides each column of the tile by the corresponding column vector value:
+    ``tile[:, j] / col_vec[0, j]`` for all ``j``.
 
     Args:
         tile: Input tile [M, N]
@@ -1731,6 +1823,9 @@ def col_expand_div(tile: Tile, col_vec: Tile) -> Tile:
 def col_expand_sub(tile: Tile, col_vec: Tile) -> Tile:
     """Expand column vector and subtract from tile.
 
+    Subtracts a column vector from each column of the tile:
+    ``tile[:, j] - col_vec[0, j]`` for all ``j``.
+
     Args:
         tile: Input tile [M, N]
         col_vec: Column vector [1, N]
@@ -1744,6 +1839,9 @@ def col_expand_sub(tile: Tile, col_vec: Tile) -> Tile:
 
 def col_expand_add(tile: Tile, col_vec: Tile) -> Tile:
     """Expand column vector and add to tile.
+
+    Adds a column vector to each column of the tile:
+    ``tile[:, j] + col_vec[0, j]`` for all ``j``.
 
     Args:
         tile: Input tile [M, N]
@@ -1759,6 +1857,9 @@ def col_expand_add(tile: Tile, col_vec: Tile) -> Tile:
 def row_expand_max(tile: Tile, row_vec: Tile) -> Tile:
     """Row-wise broadcast maximum: max(tile, row_vec broadcasted).
 
+    Takes the element-wise maximum of each row and the row vector value:
+    ``max(tile[i, :], row_vec[i, 0])`` for all ``i``.
+
     Args:
         tile: Input tile [M, N]
         row_vec: Row vector [M, 1]
@@ -1772,6 +1873,9 @@ def row_expand_max(tile: Tile, row_vec: Tile) -> Tile:
 
 def row_expand_min(tile: Tile, row_vec: Tile) -> Tile:
     """Row-wise broadcast minimum: min(tile, row_vec broadcasted).
+
+    Takes the element-wise minimum of each row and the row vector value:
+    ``min(tile[i, :], row_vec[i, 0])`` for all ``i``.
 
     Args:
         tile: Input tile [M, N]
@@ -1787,6 +1891,8 @@ def row_expand_min(tile: Tile, row_vec: Tile) -> Tile:
 def row_expand_expdif(tile: Tile, row_vec: Tile) -> Tile:
     """Row-wise exp-diff: exp(tile - row_vec) with per-row scalar.
 
+    Computes ``exp(tile[i, :] - row_vec[i, 0])`` for all ``i``.
+
     Args:
         tile: Input tile [M, N]
         row_vec: Row vector providing per-row scalar [M, 1]
@@ -1800,6 +1906,8 @@ def row_expand_expdif(tile: Tile, row_vec: Tile) -> Tile:
 
 def col_expand_max(tile: Tile, col_vec: Tile) -> Tile:
     """Expand column vector and take element-wise maximum with tile.
+
+    Computes ``max(tile[:, j], col_vec[0, j])`` for all ``j``.
 
     Args:
         tile: Input tile [M, N]
@@ -1815,6 +1923,8 @@ def col_expand_max(tile: Tile, col_vec: Tile) -> Tile:
 def col_expand_min(tile: Tile, col_vec: Tile) -> Tile:
     """Expand column vector and take element-wise minimum with tile.
 
+    Computes ``min(tile[:, j], col_vec[0, j])`` for all ``j``.
+
     Args:
         tile: Input tile [M, N]
         col_vec: Column vector [1, N]
@@ -1828,6 +1938,8 @@ def col_expand_min(tile: Tile, col_vec: Tile) -> Tile:
 
 def col_expand_expdif(tile: Tile, col_vec: Tile) -> Tile:
     """Expand column vector and compute exp-diff with per-column scalar.
+
+    Computes ``exp(tile[:, j] - col_vec[0, j])`` for all ``j``.
 
     Args:
         tile: Input tile [M, N]
@@ -1843,6 +1955,8 @@ def col_expand_expdif(tile: Tile, col_vec: Tile) -> Tile:
 def expands(target: Tile, scalar: int | float | Expr | Scalar) -> Tile:
     """Expand scalar to target tile shape.
 
+    Broadcasts a scalar value to match the shape of the target tile.
+
     Args:
         target: Target tile defining output shape
         scalar: Scalar value to expand
@@ -1857,6 +1971,8 @@ def expands(target: Tile, scalar: int | float | Expr | Scalar) -> Tile:
 
 def minimum(lhs: Tile, rhs: Tile) -> Tile:
     """Element-wise minimum of two tiles.
+
+    Supports broadcasting between the two tiles.
 
     Args:
         lhs: Left-hand side tile
@@ -2910,6 +3026,10 @@ def mgather(
     valid_shape: Sequence[int] | None = None,
 ) -> Tile:
     """Gather-load rows or elements from a GM tensor into a fresh Vec or Mat tile.
+
+    Vec output uses a 2D INT32 index tile. Mat output uses a GM INT32 index tensor
+    and produces canonical NZ layout; its element mode additionally requires a
+    same-dtype GM scratch tensor.
 
     Args:
         mem: Source tensor in GM.

--- a/tests/lint/check_op_docstring_parity.py
+++ b/tests/lint/check_op_docstring_parity.py
@@ -48,8 +48,12 @@ Scope and deliberate limits:
 
 * Only module-level functions defined in *both* layers of the same namespace are paired. A helper
   that exists on one side only, or a name re-exported from elsewhere, is not this check's business.
-* A pair where either docstring is missing entirely is skipped -- "every public op has a docstring"
-  is a different check, and ``ruff``'s pydocstyle rules already cover part of it.
+* A DSL wrapper with *no* docstring at all is reported, not skipped: it is the extreme of the same
+  defect, since the published page then renders an empty description. Nothing else catches it --
+  ``[tool.ruff.lint] select`` is ``PL, I, E, W, F, UP``, so pydocstyle (``D``) is not enabled. No op
+  is in that state today; the check is here so the first one cannot land quietly.
+* A pair whose *IR* docstring is missing is skipped -- there is then nothing to carry across, and
+  "every internal wrapper is documented" is a different check.
 * Overloads (``@typing.overload`` stubs) are ignored; only the implementation carries the docstring.
 """
 
@@ -75,11 +79,19 @@ SECTION_RE = re.compile(
 SIGNATURE_SECTIONS = frozenset({"Args", "Arguments", "Returns", "Yields"})
 
 # Pairs where the IR body is genuinely carried by the DSL docstring, just not as a body paragraph.
-# Each entry is "<namespace>.<op>: <why>". Add to this only when the DSL copy really does state the
-# same fact somewhere else -- not to silence an op whose explanation was dropped.
+# Each entry maps "<namespace>.<op>" to (why, marker): `marker` is a substring the DSL docstring must
+# still contain for the exemption to hold, so removing the explanation the exemption was granted for
+# re-arms the check instead of passing silently. Add an entry only when the DSL copy really does
+# state the same fact somewhere else -- not to silence an op whose explanation was dropped.
 ALLOWLIST = {
-    "system.import_peer_buffer": "IR body states the INT32 result type; the DSL copy states it in Returns:.",
-    "system.reserve_buffer": "IR body states the INT32 result type; the DSL copy states it in Returns:.",
+    "system.import_peer_buffer": (
+        "IR body states the INT32 result type; the DSL copy states it in Returns:.",
+        "``pl.Scalar[pl.INT32]``",
+    ),
+    "system.reserve_buffer": (
+        "IR body states the INT32 result type; the DSL copy states it in Returns:.",
+        "``pl.Scalar[pl.INT32]``",
+    ),
 }
 
 
@@ -172,10 +184,10 @@ def body_is_parameter_notes(ir_doc: str, ir_node: FunctionNode, dsl_doc: str) ->
     return True
 
 
-def documented_functions(path: Path) -> dict[str, tuple[FunctionNode, str]]:
-    """Map public module-level function name -> (node, docstring), skipping overload stubs."""
+def public_functions(path: Path) -> dict[str, tuple[FunctionNode, str | None]]:
+    """Map public module-level function name -> (node, docstring or None), skipping overload stubs."""
     tree = ast.parse(path.read_text(encoding="utf-8"))
-    out: dict[str, tuple[FunctionNode, str]] = {}
+    out: dict[str, tuple[FunctionNode, str | None]] = {}
     for node in tree.body:
         if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
             continue
@@ -187,33 +199,57 @@ def documented_functions(path: Path) -> dict[str, tuple[FunctionNode, str]]:
             for d in node.decorator_list
         ):
             continue
-        doc = ast.get_docstring(node, clean=True)
-        if doc:
-            out[node.name] = (node, doc)
+        out[node.name] = (node, ast.get_docstring(node, clean=True))
     return out
 
 
-def find_violations(root_dir: Path) -> list[tuple[str, str, int, str]]:
-    """Return (namespace, op, dsl lineno, dsl relative path) for each dropped explanation."""
+def find_violations(root_dir: Path) -> list[tuple[str, str, int, str, str]]:
+    """Return (namespace, op, dsl lineno, dsl relative path, what went wrong) per violation."""
     violations = []
     for namespace in NAMESPACES:
         ir_path = root_dir / "python" / "pypto" / "ir" / "op" / f"{namespace}_ops.py"
         dsl_path = root_dir / "python" / "pypto" / "language" / "op" / f"{namespace}_ops.py"
         if not (ir_path.is_file() and dsl_path.is_file()):
             continue
-        ir_funcs = documented_functions(ir_path)
-        dsl_funcs = documented_functions(dsl_path)
+        ir_funcs = public_functions(ir_path)
+        dsl_funcs = public_functions(dsl_path)
+        rel = dsl_path.relative_to(root_dir).as_posix()
         for name in sorted(ir_funcs.keys() & dsl_funcs.keys()):
-            if f"{namespace}.{name}" in ALLOWLIST:
-                continue
             ir_node, ir_doc = ir_funcs[name]
             dsl_node, dsl_doc = dsl_funcs[name]
+            if ir_doc is None:
+                continue  # nothing to carry across
+
+            # The extreme of the same defect: the published wrapper has no description at all,
+            # so the API page renders empty. Nothing else catches this -- pydocstyle is not
+            # among the ruff rules this repo selects.
+            if dsl_doc is None:
+                violations.append((namespace, name, dsl_node.lineno, rel, "has no docstring at all"))
+                continue
+
+            exemption = ALLOWLIST.get(f"{namespace}.{name}")
+            if exemption is not None:
+                marker = exemption[1]
+                if marker in dsl_doc:
+                    continue
+                violations.append(
+                    (
+                        namespace,
+                        name,
+                        dsl_node.lineno,
+                        rel,
+                        f"is allowlisted, but its docstring no longer contains {marker}",
+                    )
+                )
+                continue
+
             if not has_body(ir_doc) or has_body(dsl_doc):
                 continue
             if body_is_parameter_notes(ir_doc, ir_node, dsl_doc):
                 continue
-            rel = dsl_path.relative_to(root_dir).as_posix()
-            violations.append((namespace, name, dsl_node.lineno, rel))
+            violations.append(
+                (namespace, name, dsl_node.lineno, rel, "drops the explanation its IR twin carries")
+            )
     return violations
 
 
@@ -229,12 +265,12 @@ def main() -> int:
     root_dir = args.root.resolve()
 
     violations = find_violations(root_dir)
-    for namespace, name, lineno, rel in violations:
-        print(f"{rel}:{lineno}: pl.{namespace}.{name} drops the explanation its IR twin carries")
+    for namespace, name, lineno, rel, problem in violations:
+        print(f"{rel}:{lineno}: pl.{namespace}.{name} {problem}")
 
     if violations:
         print(
-            f"\nFound {len(violations)} op wrapper(s) whose published docstring lost its explanation.\n"
+            f"\nFound {len(violations)} op wrapper(s) whose published docstring is worse than its twin.\n"
             "The DSL wrapper in python/pypto/language/op/ is what users read -- it is rendered into\n"
             "docs/en/user/api/ -- while python/pypto/ir/op/ is internal. When the internal copy\n"
             "explains a shape rule, a broadcasting rule or a dtype restriction, the published copy\n"
@@ -244,7 +280,8 @@ def main() -> int:
             "Do NOT assign __doc__ from the IR wrapper at import time: mkdocstrings reads the\n"
             "source statically through griffe, so a runtime-assigned __doc__ renders empty.\n\n"
             "If the DSL copy genuinely states the same fact elsewhere (in Returns:, say), add\n"
-            f'"<namespace>.<op>" to ALLOWLIST in {Path(__file__).name} with the reason.',
+            f'"<namespace>.<op>" to ALLOWLIST in {Path(__file__).name} as (reason, marker), where the'
+            " marker is a substring the DSL docstring must keep for the exemption to hold.",
             file=sys.stderr,
         )
         return 1

--- a/tests/lint/check_op_docstring_parity.py
+++ b/tests/lint/check_op_docstring_parity.py
@@ -1,0 +1,257 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""
+Script to check that a DSL op wrapper does not drop the explanation its IR twin carries.
+
+Every operator is written twice in Python: ``pypto/ir/op/<ns>_ops.py`` takes raw ``ir.Expr`` with an
+explicit ``span`` and returns an ``ir.Call``; ``pypto/language/op/<ns>_ops.py`` takes ``Tile`` /
+``Tensor``, auto-captures the span, and returns a wrapped object. Only the second one is published:
+``docs/en/user/api/{tile,tensor}.md`` render ``pypto.language.tile`` and ``pypto.language.tensor``
+through mkdocstrings, so the DSL docstring *is* the user manual and the IR docstring is read by
+compiler developers.
+
+The failure mode this catches is that the two drift in the wrong direction. The add-op workflow asks
+for a docstring on the IR wrapper but describes the DSL wrapper as ``unwrap -> call -> wrap``, so a
+new op tends to get its shape rules, broadcasting semantics and dtype restrictions written on the
+*internal* copy and only a one-line summary on the *published* one. Users then read the lossy
+paraphrase while the real explanation sits in a module they never import.
+
+The rule enforced here is structural, so it has no fuzzy similarity threshold and no false positives
+from legitimate rewording:
+
+    If the IR wrapper's docstring has a body -- a prose paragraph after the summary, or a section
+    other than Args/Arguments/Returns/Yields (Note, Example, Warning, ...) -- then the DSL wrapper's
+    docstring must have a body too.
+
+One relocation is recognized rather than reported: when every IR body paragraph opens with a
+parameter name (``core_type`` targets the operation to one lane ...), it is a note *about that
+parameter*, and the published layer's convention is to carry it in the parameter's own ``Args``
+entry. The check accepts that placement instead of demanding a redundant paragraph above ``Args``.
+
+It deliberately does *not* compare the two bodies. The DSL copy is expected to differ: it drops the
+``span`` argument and codegen internals, names ``pl.tile.foo`` where the IR copy names
+``tile.foo``, and is frequently longer and better than its twin. What it must not do is say nothing
+at all where the internal copy explains something.
+
+Note that the fix is always a **source literal**. Assigning ``__doc__`` at import time from the
+wrapped function does not work: ``docs/requirements.txt`` records that mkdocstrings reads
+``python/pypto`` through griffe, which "parses the source statically -- nothing is imported", so a
+runtime-assigned ``__doc__`` renders as an empty description on exactly the page being fixed.
+
+Scope and deliberate limits:
+
+* Only module-level functions defined in *both* layers of the same namespace are paired. A helper
+  that exists on one side only, or a name re-exported from elsewhere, is not this check's business.
+* A pair where either docstring is missing entirely is skipped -- "every public op has a docstring"
+  is a different check, and ``ruff``'s pydocstyle rules already cover part of it.
+* Overloads (``@typing.overload`` stubs) are ignored; only the implementation carries the docstring.
+"""
+
+import argparse
+import ast
+import re
+import sys
+from pathlib import Path
+
+FunctionNode = ast.FunctionDef | ast.AsyncFunctionDef
+
+# Namespaces written at both layers, as <ir module>/<language module> basenames.
+NAMESPACES = ("tile", "tensor", "system", "array", "prefetch")
+
+# Google-style section headers, matched only at the docstring's own indentation level.
+SECTION_RE = re.compile(
+    r"^(Args|Arguments|Returns|Yields|Raises|Note|Notes|Example|Examples|Warning|Warnings"
+    r"|Attributes|See Also):\s*$"
+)
+
+# Sections that describe the signature rather than the operator. Content living only here does not
+# count as a body: an op whose IR docstring has nothing but Args/Returns has nothing to drop.
+SIGNATURE_SECTIONS = frozenset({"Args", "Arguments", "Returns", "Yields"})
+
+# Pairs where the IR body is genuinely carried by the DSL docstring, just not as a body paragraph.
+# Each entry is "<namespace>.<op>: <why>". Add to this only when the DSL copy really does state the
+# same fact somewhere else -- not to silence an op whose explanation was dropped.
+ALLOWLIST = {
+    "system.import_peer_buffer": "IR body states the INT32 result type; the DSL copy states it in Returns:.",
+    "system.reserve_buffer": "IR body states the INT32 result type; the DSL copy states it in Returns:.",
+}
+
+
+def split_docstring(doc: str) -> tuple[str, str, dict[str, str]]:
+    """Split a cleaned Google-style docstring into (summary, prose, sections)."""
+    lines = doc.split("\n")
+    end_of_summary = 0
+    while end_of_summary < len(lines) and lines[end_of_summary].strip():
+        end_of_summary += 1
+    summary = "\n".join(lines[:end_of_summary])
+
+    prose: list[str] = []
+    sections: dict[str, list[str]] = {}
+    current: str | None = None
+    buf: list[str] = []
+    for line in lines[end_of_summary:]:
+        match = SECTION_RE.match(line.strip())
+        # A header only opens a section at column 0 of the dedented docstring; an indented
+        # "Note:" belongs to the enclosing block (an Args entry, say) and is body text.
+        if match and not line[:1].isspace():
+            if current is None:
+                prose = buf
+            else:
+                sections[current] = buf
+            current, buf = match.group(1), []
+        else:
+            buf.append(line)
+    if current is None:
+        prose = buf
+    else:
+        sections[current] = buf
+
+    return summary, "\n".join(prose), {k: "\n".join(v) for k, v in sections.items()}
+
+
+def has_body(doc: str) -> bool:
+    """True when the docstring explains something beyond its summary and its signature sections."""
+    _, prose, sections = split_docstring(doc)
+    if prose.strip():
+        return True
+    return any(name not in SIGNATURE_SECTIONS and body.strip() for name, body in sections.items())
+
+
+# A body paragraph that opens with a parameter name -- ``core_type`` targets the operation
+# to one lane ... -- is a note *about that parameter*, and the DSL layer's convention is to
+# carry it in the parameter's own Args entry rather than as a separate paragraph. Recognize
+# that relocation so the check does not demand a redundant second copy above Args.
+LEADING_PARAM_RE = re.compile(r"^\s*(?:``)?([a-z_][a-z0-9_]*)(?:``)?\b")
+
+
+def parameter_names(node: FunctionNode) -> set[str]:
+    """Every name the function binds as a parameter, positional or keyword-only."""
+    a = node.args
+    names = {p.arg for p in (*a.posonlyargs, *a.args, *a.kwonlyargs)}
+    for extra in (a.vararg, a.kwarg):
+        if extra is not None:
+            names.add(extra.arg)
+    return names
+
+
+def documented_parameters(doc: str) -> set[str]:
+    """Parameter names that the docstring's Args section gives an entry to."""
+    _, _, sections = split_docstring(doc)
+    args = next((sections[name] for name in ("Args", "Arguments") if name in sections), "")
+    documented = set()
+    for line in args.split("\n"):
+        # An entry starts at the section's own indent level; continuation lines are deeper.
+        entry = re.match(r"^ {4}([a-z_][a-z0-9_]*)\s*(?:\([^)]*\))?\s*:", line)
+        if entry:
+            documented.add(entry.group(1))
+    return documented
+
+
+def body_is_parameter_notes(ir_doc: str, ir_node: FunctionNode, dsl_doc: str) -> bool:
+    """True when every IR body paragraph is a note on a parameter the DSL documents in Args."""
+    _, prose, sections = split_docstring(ir_doc)
+    if any(name not in SIGNATURE_SECTIONS and body.strip() for name, body in sections.items()):
+        return False  # a Note/Example section is not a parameter note
+    paragraphs = [p for p in re.split(r"\n\s*\n", prose.strip()) if p.strip()]
+    if not paragraphs:
+        return False
+    params = parameter_names(ir_node)
+    dsl_documented = documented_parameters(dsl_doc)
+    for paragraph in paragraphs:
+        match = LEADING_PARAM_RE.match(paragraph)
+        if not match or match.group(1) not in params:
+            return False
+        if match.group(1) not in dsl_documented:
+            return False
+    return True
+
+
+def documented_functions(path: Path) -> dict[str, tuple[FunctionNode, str]]:
+    """Map public module-level function name -> (node, docstring), skipping overload stubs."""
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    out: dict[str, tuple[FunctionNode, str]] = {}
+    for node in tree.body:
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        if node.name.startswith("_"):
+            continue
+        if any(
+            (isinstance(d, ast.Name) and d.id == "overload")
+            or (isinstance(d, ast.Attribute) and d.attr == "overload")
+            for d in node.decorator_list
+        ):
+            continue
+        doc = ast.get_docstring(node, clean=True)
+        if doc:
+            out[node.name] = (node, doc)
+    return out
+
+
+def find_violations(root_dir: Path) -> list[tuple[str, str, int, str]]:
+    """Return (namespace, op, dsl lineno, dsl relative path) for each dropped explanation."""
+    violations = []
+    for namespace in NAMESPACES:
+        ir_path = root_dir / "python" / "pypto" / "ir" / "op" / f"{namespace}_ops.py"
+        dsl_path = root_dir / "python" / "pypto" / "language" / "op" / f"{namespace}_ops.py"
+        if not (ir_path.is_file() and dsl_path.is_file()):
+            continue
+        ir_funcs = documented_functions(ir_path)
+        dsl_funcs = documented_functions(dsl_path)
+        for name in sorted(ir_funcs.keys() & dsl_funcs.keys()):
+            if f"{namespace}.{name}" in ALLOWLIST:
+                continue
+            ir_node, ir_doc = ir_funcs[name]
+            dsl_node, dsl_doc = dsl_funcs[name]
+            if not has_body(ir_doc) or has_body(dsl_doc):
+                continue
+            if body_is_parameter_notes(ir_doc, ir_node, dsl_doc):
+                continue
+            rel = dsl_path.relative_to(root_dir).as_posix()
+            violations.append((namespace, name, dsl_node.lineno, rel))
+    return violations
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=(__doc__ or "").strip().split("\n")[0])
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=Path(__file__).resolve().parents[2],
+        help="Repository root (default: inferred from this file's location)",
+    )
+    args = parser.parse_args()
+    root_dir = args.root.resolve()
+
+    violations = find_violations(root_dir)
+    for namespace, name, lineno, rel in violations:
+        print(f"{rel}:{lineno}: pl.{namespace}.{name} drops the explanation its IR twin carries")
+
+    if violations:
+        print(
+            f"\nFound {len(violations)} op wrapper(s) whose published docstring lost its explanation.\n"
+            "The DSL wrapper in python/pypto/language/op/ is what users read -- it is rendered into\n"
+            "docs/en/user/api/ -- while python/pypto/ir/op/ is internal. When the internal copy\n"
+            "explains a shape rule, a broadcasting rule or a dtype restriction, the published copy\n"
+            "must explain it too.\n\n"
+            "Write the explanation as a source literal in the DSL docstring, adapted to the DSL\n"
+            "surface (no `span`, no codegen internals, `pl.tile.foo` rather than `tile.foo`).\n"
+            "Do NOT assign __doc__ from the IR wrapper at import time: mkdocstrings reads the\n"
+            "source statically through griffe, so a runtime-assigned __doc__ renders empty.\n\n"
+            "If the DSL copy genuinely states the same fact elsewhere (in Returns:, say), add\n"
+            f'"<namespace>.<op>" to ALLOWLIST in {Path(__file__).name} with the reason.',
+            file=sys.stderr,
+        )
+        return 1
+
+    print("Every DSL op wrapper keeps the explanation its IR twin carries.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
> Rebased onto `main` after #2460, #2461 and #2464 landed. Scope shrank where #2464 overlapped — see "Overlap with #2464" below.

## What

`docs/en/user/api/{tile,tensor}.md` render `pypto.language.*`, so the wrapper in `python/pypto/language/op/` **is** the published manual, while its twin in `python/pypto/ir/op/` is read only by compiler developers. The two had drifted in the wrong direction.

Pairing the layers by AST and flagging "the IR copy explains something past its summary, the DSL copy says nothing at all" gives **57 ops** on current `main`. Users were reading the lossy half.

| Op | Internal copy says | Published copy said |
| -- | ------------------ | ------------------- |
| `pl.tile.row_max` | reduces the last axis with keepdim → `input_shape[:-1] + [1]` | *(nothing — the shape rule was absent)* |
| `pl.tile.col_argmax` | output is `[1, N]` INT32, and why `tmp_tile` is needed | *(nothing)* |

## Changes

- **59 op docstrings backfilled as source literals** — 41 in `language/op/tile_ops.py`, 18 in `tensor_ops.py`. Keepdim shape rules on the `row_*` reductions, `[1, N]` on the `col_*` ones, broadcasting on `add`/`sub`/`mul`/`maximum`/`minimum`, the `tile.divs` precision caveat, per-element formulas across the `row_/col_expand_*` family, the `pl.cast` escape hatch on the FP32-only `sin`/`cos`, `ci`'s "first row only, leading dims must be 1" note, `mgather`'s Vec-vs-Mat modes, `scatter_update`'s 2D/4D rank variants, and `tensor.matmul`'s transpose-flag rank rules.
- **`tests/lint/check_op_docstring_parity.py`**, wired into pre-commit.
- **`add-op` skill step A3 + `reference.md` §3** — the root cause.
- Two correctness fixes described below.

## Why source literals, not `__doc__`

`docs/requirements.txt` records that mkdocstrings reads `python/pypto` through griffe, which *"parses the source statically — nothing is imported"*. Assigning `__doc__` from the wrapped function at import time would render **empty** on exactly the page being fixed. Verified the other way too: griffe statically loads every edited module with zero warnings and no op left with an empty rendered description.

## Two things that were wrong, not just missing

**`gather_compare`'s `cdst` shape.** Three docstrings gave three different answers: `[rows]`, `[1, rows]`, and — on the user-facing `pl.tensor.gather` — `[rows, 1]`. The deducer builds `{1, rows}` at `src/ir/op/tile_ops/gather.cpp:439`, corroborated by `tests/ut/ir/operators/test_gather_compare.py` declaring `out_cdst: pl.Tensor[[1, 32], pl.INT32]` for 32 rows. The two that disagreed are corrected.

**`pl.tensor.view` linked to itself.** #2464 rewrote its `pypto.ir.op.tensor.view` pointer into the language namespace, which resolves to `pypto.language.tensor.view` — the very function containing the sentence. This PR drops the pointer and inlines the two facts it stood for; the `Args:`/`Raises:` sections already covered the rest of what it promised.

## Overlap with #2464

#2464 landed while this was open and we independently fixed the same two `system.tfree_to_*` docstrings. **Yours is better** — it states the consequence of not calling it, and corrects `split`/`id`: the pass always takes them from the originating `tpop`, so a value passed there cannot override it, which my version got wrong. I dropped my version entirely in the rebase; `system_ops.py` is now byte-identical to `main`.

I also adopted #2464's mkdocs-style `[`x`][pypto.language.tile.x]` cross-references in place of the Sphinx `:func:` form for the two references this PR adds.

## Notes for the reviewer

**The lint rule is structural, not a similarity score.** If the IR docstring has a body past its summary, the DSL twin must have one too — it never compares the two bodies. That is deliberate: the DSL copy is *expected* to differ, dropping `span` and codegen internals, and is frequently longer and better. A token-coverage variant was prototyped first and rejected — it could not separate `tensor.col_expand_expdif` (fine; content in the summary line) from a genuine drop without a threshold needing a large allowlist.

**One relocation is recognized rather than reported.** #2464 established that a note *about a parameter* belongs in that parameter's `Args` entry — `sync_set`/`sync_wait` are exactly this. So an IR body paragraph opening with a parameter name is treated as carried when the DSL documents that parameter. It is not a blanket pass: deleting the `core_type` Args entry makes the check fail. Raw failures go **57 → 4**: two allowlisted (content in `Returns:`), two via this rule.

**Fourteen of the flagged pairs were false positives, and are changed anyway.** The `tensor.row_expand_*` / `col_expand_*` family already carried its formula in the *summary line* (`Row-wise broadcast multiplication: tensor[i,:] * row_vec[i,0].`), so nothing was lost there — the paragraph-count metric could not see it. Their *tile* twins really had dropped it. I gave the tensor ones a plain-English gloss for symmetry and to keep the allowlist small. **That part is presentational rather than recovered information** — happy to drop it if you would rather keep the diff to genuine losses.

## Testing

- `pytest tests/ut/` — **10120 passed, 3 skipped**
- `pre-commit run --all-files` — all hooks green
- griffe static load of every edited module — zero warnings
- New lint verified against two injected regressions: removing `row_max`'s paragraph fails it, and so does removing `sync_set`'s `core_type` Args entry
