### PR TITLE
docs: order the API pages by __all__, and stop hiding undocumented names

### DIFF
--- a/docs/en/api/array.md
+++ b/docs/en/api/array.md
@@ -6,5 +6,4 @@ later `deps=`. See [Declaring an edge](../user/tasks/02-submit.md).
 ::: pypto.language.array
     options:
       show_root_heading: false
-      members_order: source
       filters: ["!^_"]

--- a/docs/en/api/language.md
+++ b/docs/en/api/language.md
@@ -9,7 +9,6 @@ of two tiles is `pl.tile.add`, of two tensors `pl.tensor.add`. See
     options:
       show_root_heading: false
       show_submodules: false
-      members_order: alphabetical
       filters:
         - "!^_"
         - "!^(parser|optimizations|adir|array|prefetch|tile|system|tensor)$"

--- a/docs/en/api/optimizations.md
+++ b/docs/en/api/optimizations.md
@@ -6,5 +6,4 @@ The optimization entries a `pl.at(..., optimizations=[...])` list accepts — `p
 ::: pypto.language.optimizations
     options:
       show_root_heading: false
-      members_order: source
       filters: ["!^_"]

--- a/docs/en/api/prefetch.md
+++ b/docs/en/api/prefetch.md
@@ -6,5 +6,4 @@ Asynchronous GM to L2 prefetch. The handle types these produce are described in 
 ::: pypto.language.prefetch
     options:
       show_root_heading: false
-      members_order: source
       filters: ["!^_"]

--- a/docs/en/api/system.md
+++ b/docs/en/api/system.md
@@ -6,5 +6,4 @@ rather than value-producing operators — most return nothing.
 ::: pypto.language.system
     options:
       show_root_heading: false
-      members_order: source
       filters: ["!^_"]

--- a/docs/en/api/tensor.md
+++ b/docs/en/api/tensor.md
@@ -7,5 +7,4 @@ orchestration or wherever a whole tensor is the unit of work. See
 ::: pypto.language.tensor
     options:
       show_root_heading: false
-      members_order: source
       filters: ["!^_"]

--- a/docs/en/api/tile.md
+++ b/docs/en/api/tile.md
@@ -7,5 +7,4 @@ rather than their `pl.*` or `pl.tensor.*` counterparts.
 ::: pypto.language.tile
     options:
       show_root_heading: false
-      members_order: source
       filters: ["!^_"]

--- a/docs/zh/api/array.md
+++ b/docs/zh/api/array.md
@@ -5,5 +5,4 @@
 ::: pypto.language.array
     options:
       show_root_heading: false
-      members_order: source
       filters: ["!^_"]

--- a/docs/zh/api/language.md
+++ b/docs/zh/api/language.md
@@ -6,7 +6,6 @@
     options:
       show_root_heading: false
       show_submodules: false
-      members_order: alphabetical
       filters:
         - "!^_"
         - "!^(parser|optimizations|adir|array|prefetch|tile|system|tensor)$"

--- a/docs/zh/api/optimizations.md
+++ b/docs/zh/api/optimizations.md
@@ -5,5 +5,4 @@
 ::: pypto.language.optimizations
     options:
       show_root_heading: false
-      members_order: source
       filters: ["!^_"]

--- a/docs/zh/api/prefetch.md
+++ b/docs/zh/api/prefetch.md
@@ -5,5 +5,4 @@ GM 到 L2 的异步预取。它们产出的句柄类型见[特性矩阵](../user
 ::: pypto.language.prefetch
     options:
       show_root_heading: false
-      members_order: source
       filters: ["!^_"]

--- a/docs/zh/api/system.md
+++ b/docs/zh/api/system.md
@@ -5,5 +5,4 @@
 ::: pypto.language.system
     options:
       show_root_heading: false
-      members_order: source
       filters: ["!^_"]

--- a/docs/zh/api/tensor.md
+++ b/docs/zh/api/tensor.md
@@ -5,5 +5,4 @@
 ::: pypto.language.tensor
     options:
       show_root_heading: false
-      members_order: source
       filters: ["!^_"]

--- a/docs/zh/api/tile.md
+++ b/docs/zh/api/tile.md
@@ -5,5 +5,4 @@ Tile 级算子 —— 在 InCore 函数内接受并返回 `pl.Tile` 值的那一
 ::: pypto.language.tile
     options:
       show_root_heading: false
-      members_order: source
       filters: ["!^_"]

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -131,7 +131,25 @@ plugins:
             docstring_style: google
             show_source: false
             show_root_heading: true
-            members_order: source
+            # `__all__` in each of these modules is hand-grouped by concept -- create
+            # before read before write, `mul` next to `muls`, the whole fillpad family
+            # together -- so it is the reading order the author already chose. Without
+            # this the page falls back to alphabetical *within kind*, which splits
+            # constants from classes from functions and scatters every family across
+            # 270 entries. `source` is the fallback for class members, where `__all__`
+            # does not apply.
+            members_order: ["__all__", "source"]
+            # Without this, members are bucketed attributes/classes/functions before
+            # `__all__` is applied within each bucket -- which splits exactly the pairs
+            # `__all__` puts side by side (`jit` from `JITFunction`, `function` /
+            # `inline` / `program` from `InlineFunction`). One sequence, author order.
+            group_by_category: false
+            # Default `false` silently drops any member without a docstring -- which was
+            # hiding 34 public `pl.*` names, `jit` and every dtype (`FP16`, `INT32`, ...)
+            # among them. A reader looking one up found nothing at all. Showing the name
+            # and its value beats omitting it; a missing description is a docstring to
+            # write, not a reason to leave the symbol undiscoverable.
+            show_if_no_docstring: true
 
 # Rewrites repo-relative links that escape `docs/` (source files, `.claude/rules`,
 # `examples/`) into GitHub blob URLs at build time. The markdown keeps working


### PR DESCRIPTION
Follow-up to #2466. The `pl` page read as an arbitrary list.

## The ordering

It was sorted **by kind, then case-sensitively alphabetically** — so every
constant came before every class, every class before every function, and each
family was scattered across 270 entries: `mul` nowhere near `muls`, `tpush`
nowhere near `tpop`. The `pl` page pinned `members_order: alphabetical`
outright, which is what produced the wall.

**The right order already exists.** `__all__` in each of these modules is
hand-grouped by concept — decorators, then parsing, then types, then control
flow; `create` before `read` before `write`; the whole fillpad family together.
mkdocstrings can sort by it, so it now does.

| before | after |
| --- | --- |
| `IntLike RUNTIME Array AsyncEvent AsyncSession AtomicType CompactMode DynVar ForKind FunctionType InOut InlineFunction JITFunction Level MemRef …` | `jit JITFunction function inline program InlineFunction parse loads parse_program loads_program Tensor Tile Scalar Array Tuple DynVar InOut …` |

Two settings were fighting `__all__` and both are gone: the per-page
`members_order` overrides, and the kind bucketing (`group_by_category`), which
applied `__all__` only *within* each bucket and so still split the pairs
`__all__` puts side by side — `jit` from `JITFunction`, `function`/`inline`/
`program` from `InlineFunction`. Ordering is one policy, so it now lives once in
`mkdocs.yml`.

## The bigger thing measuring it turned up

`show_if_no_docstring` defaults to `false`, and a bare `NAME = value` carries no
docstring — so **34 public `pl.*` names were absent from the reference
entirely**:

- **`pl.jit`** — the entry point of the whole DSL
- **all 22 dtypes** — `FP16`, `FP32`, `BF16`, `INT32`, …
- `create_tile`, `create_tensor`, `AUTO`, `Mem`, `Ptr`, and the 5 layout constants

`pl.FP16` appears in nearly every example in the manual and could not be looked
up in the API reference at all. Every one of these is in `__all__`; none is
private. Showing the name and its value beats omitting it — the missing prose is
a docstring to write, not a reason to keep the symbol undiscoverable.

Each entry the flag adds was checked to be public API: **34 on `pl`, 2 on
`tile`, 1 on `optimizations` — no noise.**

## Verification

| Check | Result |
| ----- | ------ |
| `mkdocs build --strict` | passes, **0 warnings** |
| Member counts | 544 → same names, reordered; +37 previously-hidden public names |
| `check_docs_nav` / `check_docs_en_zh_parity` / `check_docs_symbol_coverage` / `check_english_only` | PASS |
| markdownlint (`tests/lint/.markdownlint.yaml`) | 16 files, 0 issues |

## Known follow-up

The 37 newly-surfaced names currently render as name + value with **no
description**. That is strictly better than being absent, but it is not the end
state — the dtypes and `pl.jit` deserve real docstrings. Happy to do that as a
separate pass.
