### PR TITLE
docs(passes): resync pass-property tables with pass_properties.h

### DIFF
--- a/docs/en/dev/passes/00-pass_manager.md
+++ b/docs/en/dev/passes/00-pass_manager.md
@@ -34,13 +34,41 @@ Framework for organizing and executing IR transformation passes on Programs with
 | `NormalizedStmtStructure` | Statement structure normalized |
 | `NoRedundantBlocks` | No single-child or nested SeqStmts |
 | `SplitIncoreOrch` | InCore scopes outlined into separate functions |
-| `ClusterOutlined` | Cluster scopes outlined into Group functions |
 | `HasMemRefs` | MemRef objects initialized on variables |
-| `IncoreTileOps` | InCore functions use tile ops |
-| `MixedKernelExpanded` | Mixed InCore functions split into AIC + AIV + Group |
+| `IncoreTileOps` | InCore functions use tile ops (tile types, load/store) |
 | `AllocatedMemoryAddr` | All MemRefs have valid addresses within buffer limits |
+| `MixedKernelExpanded` | Mixed InCore functions split into AIC + AIV + Group |
+| `ClusterOutlined` | Cluster scopes outlined into Group functions |
+| `TileOps2D` | All tile ops in InCore functions use ≤2D tiles |
+| `TileMemoryInferred` | `TileType::memory_space_` populated in InCore functions |
+| `BreakContinueValid` | Break/continue only in sequential/while loops |
+| `UseAfterDef` | All variable uses are dominated by a definition |
+| `HierarchyOutlined` | Hierarchy scopes outlined into level/role functions |
+| `StructuredCtrlFlow` | No BreakStmt/ContinueStmt — only structured control flow |
+| `VectorKernelSplit` | AIV functions with a split mode have tpop shapes and store offsets adjusted |
+| `OutParamNotShadowed` | Out/InOut params are not reassigned with tensor-creating ops |
+| `NoNestedInCore` | No nested InCore scopes (ScopeStmt inside ScopeStmt) |
+| `InOutUseValid` | No reads of InOut/Out-passed variables after the call (RFC #1026) |
+| `PipelineLoopValid` | Bidirectional invariant: `ForStmt.kind_ == Pipeline` ⇔ has a `pipeline_stages` attr |
+| `PipelineResolved` | No `ForKind::Pipeline` survives; produced by CanonicalizeIOOrder |
+| `CallDirectionsResolved` | Every non-builtin Call has explicit `attrs['arg_directions']` |
 | `TileTypeCoherence` | Every TileType has canonical tile_view (implicit views stored as nullopt) |
+| `InlineFunctionsEliminated` | No `FunctionType::Inline` functions or Calls to them remain |
 | `OrchestrationReferencesResolved` | Every non-builtin Call inside a `FunctionType::Orchestration` function targets a Function in the surrounding Program |
+| `TensorViewCanonical` | TensorView canonicality verified (weak: empty stride ok; strict: requires materialization, RFC #1300 §2.2) |
+| `ArrayNotEscaped` | ArrayType never appears as a function parameter or return type |
+| `CommDomainScopesMaterialized` | Host_orch bodies wrapped in CommDomainScopeStmts, and `pld.tensor.window` result types carry `DistributedTensorType::window_buffer_` back-references |
+| `DistTensorCtxMaterialized` | No `pld.system.get_comm_ctx` survives outside host orchestration; every chip-orchestration / device communication context is an explicit CommCtxType SSA value traceable to a parameter |
+| `RuntimeScopesMaterialized` | Orchestration functions carry explicit RuntimeScopeStmt nodes, so codegen emits no implicit `PTO2_SCOPE()` wrappers |
+| `AssignTypeSymmetry` | Every AssignStmt has `structural_equal(var->GetType(), value->GetType())` (memref excluded as an allocation detail) |
+| `ManualDepsOnSubmitOnly` | No plain cross-function Call carries `attrs["manual_dep_edges"]` — manual edges live in `Submit::deps_` |
+| `ReturnParamsExplicit` | InCore/Group/Spmd tensor returns reference function params by pointer identity (#1702) |
+| `UnrollResolved` | No `ForKind::Unroll` survives; produced by UnrollLoops |
+| `AivSplitValid` | SplitAivScopeStmt regions are structurally valid: no cube compute or split-axis reduce inside a region, boundary ops only inside one |
+| `HardSyncallOccupancyValid` | Every hard (FFTS) `system.syncall` is launched at full occupancy — a partial or over launch deadlocks on device (507018) |
+| `IterArgCarryClassified` | Every Orchestration ForStmt with iter_args carries its `iter_arg_rebind_<i>` carry plan, so codegen reads it instead of re-deriving it |
+| `AccToGmStoreValid` | Every `tile.store` from an Acc-resident tile targets a GM dtype the backend's fix-pipe can narrow into |
+| `AtomicAddDtypeValid` | Every atomic-add write into GM targets a destination dtype the backend's store pipe can combine |
 
 ### IRPropertySet
 
@@ -61,42 +89,65 @@ struct PassProperties {
 | Pass | Required | Produced | Invalidated |
 | ---- | -------- | -------- | ----------- |
 | InlineFunctions | — | InlineFunctionsEliminated | — |
-| UnrollLoops | TypeChecked | TypeChecked | — |
-| CtrlFlowTransform | TypeChecked | TypeChecked, StructuredCtrlFlow | — |
-| ConvertToSSA | TypeChecked | TypeChecked, SSAForm | NormalizedStmtStructure |
-| FlattenCallExpr | SSAForm | SSAForm, NoNestedCalls | NormalizedStmtStructure |
-| NormalizeStmtStructure | TypeChecked | TypeChecked, NormalizedStmtStructure | — |
-| OutlineIncoreScopes | TypeChecked, SSAForm | SplitIncoreOrch | — |
-| OutlineClusterScopes | TypeChecked, SSAForm | ClusterOutlined | — |
-| ConvertTensorToTileOps | SplitIncoreOrch | IncoreTileOps | — |
+| UnrollLoops | — | UnrollResolved | — |
+| CtrlFlowTransform | — | StructuredCtrlFlow | — |
+| ConvertToSSA | — | SSAForm | NormalizedStmtStructure |
+| Simplify | — | — | — |
+| NormalizeStmtStructure | — | NormalizedStmtStructure | — |
+| FlattenCallExpr | SSAForm, NormalizedStmtStructure | SSAForm, NoNestedCalls, NormalizedStmtStructure | — |
+| OutlineHierarchyScopes | SSAForm | SSAForm, HierarchyOutlined, OrchestrationReferencesResolved | — |
+| OutlineIncoreScopes | SSAForm | SSAForm, SplitIncoreOrch, AivSplitValid | — |
+| OutlineClusterScopes | SSAForm | SSAForm, ClusterOutlined | — |
+| ConvertTensorToTileOps | SSAForm, SplitIncoreOrch, NormalizedStmtStructure | SSAForm, IncoreTileOps, NormalizedStmtStructure, AivSplitValid | AivSplitValid |
+| OptimizeOrchTensors | SplitIncoreOrch, IncoreTileOps | SplitIncoreOrch, IncoreTileOps | — |
 | LowerCompositeOps | — | — | — |
-| FlattenTileNdTo2D | SSAForm, IncoreTileOps | SSAForm, TileOps2D | — |
+| FlattenTileNdTo2D | SSAForm, IncoreTileOps, NormalizedStmtStructure | SSAForm, TileOps2D, NormalizedStmtStructure | — |
 | LegalizeTileCast | — | — | — |
-| AutoTileMatmulL0 | SSAForm, IncoreTileOps, TileOps2D | SSAForm, IncoreTileOps, TileOps2D | — |
+| AutoTileMatmulL0 | SSAForm, SplitIncoreOrch, IncoreTileOps, TileOps2D, NormalizedStmtStructure | SSAForm, SplitIncoreOrch, IncoreTileOps, TileOps2D, NormalizedStmtStructure | — |
 | CanonicalizeTileSlice | SSAForm, SplitIncoreOrch, IncoreTileOps, TileOps2D, NormalizedStmtStructure | SSAForm, SplitIncoreOrch, IncoreTileOps, TileOps2D, NormalizedStmtStructure | — |
-| InsertMxScaleAddr | SSAForm, IncoreTileOps, SplitIncoreOrch, TileMemoryInferred, NormalizedStmtStructure | SSAForm, IncoreTileOps, SplitIncoreOrch, TileMemoryInferred, NormalizedStmtStructure | — |
+| InferTileMemorySpace | SSAForm, IncoreTileOps, SplitIncoreOrch, NormalizedStmtStructure | SSAForm, TileMemoryInferred, NormalizedStmtStructure, AivSplitValid, AccToGmStoreValid | AivSplitValid |
+| InsertMxScaleAddr | SSAForm, IncoreTileOps, SplitIncoreOrch, NormalizedStmtStructure, TileMemoryInferred | SSAForm, IncoreTileOps, SplitIncoreOrch, NormalizedStmtStructure, TileMemoryInferred | — |
 | ResolveBackendOpLayouts | SSAForm, IncoreTileOps, SplitIncoreOrch, TileOps2D | SSAForm, IncoreTileOps, SplitIncoreOrch, TileOps2D, NormalizedStmtStructure | — |
-| LowerAutoVectorSplit | SSAForm, IncoreTileOps, SplitIncoreOrch, TileOps2D, TileMemoryInferred, NormalizedStmtStructure | SSAForm, IncoreTileOps, SplitIncoreOrch, TileOps2D, TileMemoryInferred, NormalizedStmtStructure | — |
-| ExpandMixedKernel | SSAForm, IncoreTileOps, SplitIncoreOrch, TileOps2D | SSAForm, MixedKernelExpanded | — |
-| NormalizeReturnOrder | SplitIncoreOrch, IncoreTileOps | — | — |
-| InitMemRef | TypeChecked, SSAForm, SplitIncoreOrch, IncoreTileOps, TileOps2D | HasMemRefs | SSAForm |
-| MaterializeSemanticAliases | SplitIncoreOrch, IncoreTileOps, HasMemRefs, TileOps2D | — | — |
-| MemoryReuse | TypeChecked, SplitIncoreOrch, IncoreTileOps, HasMemRefs, TileOps2D | — | — |
-| AllocateMemoryAddr | TypeChecked, SplitIncoreOrch, IncoreTileOps, HasMemRefs, TileOps2D | AllocatedMemoryAddr | — |
+| LowerAutoVectorSplit | SSAForm, IncoreTileOps, SplitIncoreOrch, TileOps2D, TileMemoryInferred, NormalizedStmtStructure, AivSplitValid | SSAForm, IncoreTileOps, SplitIncoreOrch, TileOps2D, TileMemoryInferred, NormalizedStmtStructure | AivSplitValid |
+| ExpandMixedKernel | SSAForm, IncoreTileOps, SplitIncoreOrch, TileOps2D, TileMemoryInferred, NormalizedStmtStructure | SSAForm, MixedKernelExpanded, NormalizedStmtStructure, HardSyncallOccupancyValid | — |
+| InjectGMPipeBuffer | SSAForm, MixedKernelExpanded, NormalizedStmtStructure | SSAForm, MixedKernelExpanded, NormalizedStmtStructure | — |
+| SplitVectorKernel | SSAForm, MixedKernelExpanded | SSAForm, VectorKernelSplit, NormalizedStmtStructure | — |
+| StampTfreeSplit | SplitIncoreOrch | — | — |
+| NormalizeReturnOrder | SplitIncoreOrch, IncoreTileOps | ReturnParamsExplicit | — |
+| SkewCrossCorePipeline | SSAForm, SplitIncoreOrch, IncoreTileOps, TileOps2D, TileMemoryInferred, NormalizedStmtStructure | SSAForm, SplitIncoreOrch, IncoreTileOps, TileOps2D, TileMemoryInferred, NormalizedStmtStructure | — |
+| LowerPipelineToSlots | SSAForm, SplitIncoreOrch, IncoreTileOps, TileOps2D, TileMemoryInferred, NormalizedStmtStructure | SSAForm, SplitIncoreOrch, IncoreTileOps, TileOps2D, TileMemoryInferred, NormalizedStmtStructure | — |
+| LowerPipelineLoops | SSAForm, SplitIncoreOrch, IncoreTileOps, TileOps2D, TileMemoryInferred, NormalizedStmtStructure | SSAForm, SplitIncoreOrch, IncoreTileOps, TileOps2D, TileMemoryInferred, NormalizedStmtStructure | — |
+| CanonicalizeIOOrder | SSAForm, SplitIncoreOrch, IncoreTileOps, TileOps2D, TileMemoryInferred, NormalizedStmtStructure | SSAForm, SplitIncoreOrch, IncoreTileOps, TileOps2D, TileMemoryInferred, NormalizedStmtStructure, PipelineResolved | — |
+| MaterializeTensorStrides | SSAForm, SplitIncoreOrch, IncoreTileOps, TileOps2D, TileMemoryInferred, NormalizedStmtStructure | SSAForm, SplitIncoreOrch, IncoreTileOps, TileOps2D, TileMemoryInferred, NormalizedStmtStructure, TensorViewCanonical | — |
+| InitMemRef | SSAForm, SplitIncoreOrch, IncoreTileOps, TileOps2D, TileMemoryInferred | HasMemRefs, NormalizedStmtStructure | SSAForm |
+| MaterializeSemanticAliases | SplitIncoreOrch, IncoreTileOps, HasMemRefs, TileOps2D, NormalizedStmtStructure | NormalizedStmtStructure | — |
+| MemoryReuse | SplitIncoreOrch, IncoreTileOps, HasMemRefs, TileOps2D, NormalizedStmtStructure | NormalizedStmtStructure | — |
+| AllocateMemoryAddr | SplitIncoreOrch, IncoreTileOps, HasMemRefs, TileOps2D | AllocatedMemoryAddr | — |
 | FoldNoOpReshape | SplitIncoreOrch, IncoreTileOps, HasMemRefs, TileOps2D | — | — |
-| FuseCreateAssembleToSlice | — | — | — |
+| FuseCreateAssembleToSlice | SplitIncoreOrch | — | — |
 | DeriveCallDirections | SplitIncoreOrch | CallDirectionsResolved | — |
 | AutoDeriveTaskDependencies | SplitIncoreOrch, CallDirectionsResolved | CallDirectionsResolved | — |
 | ExpandManualPhaseFence | NoNestedCalls, NormalizedStmtStructure, CallDirectionsResolved | NoNestedCalls, NormalizedStmtStructure, CallDirectionsResolved | — |
 | SynthesizeAllReduceSignals | — | — | — |
 | MaterializeCommDomainScopes | — | CommDomainScopesMaterialized | — |
 | LowerHostTensorCollectives | CommDomainScopesMaterialized | CommDomainScopesMaterialized | — |
-| MaterializeDistTensorCtx | CommDomainScopesMaterialized | CommDomainScopesMaterialized | — |
-| Simplify | — | — | — |
+| MaterializeDistTensorCtx | CommDomainScopesMaterialized, ReturnParamsExplicit | CommDomainScopesMaterialized, DistTensorCtxMaterialized | — |
 | MaterializeRuntimeScopes | SplitIncoreOrch, CallDirectionsResolved | RuntimeScopesMaterialized | — |
 | ClassifyIterArgCarry | CallDirectionsResolved, RuntimeScopesMaterialized | IterArgCarryClassified, RuntimeScopesMaterialized | — |
+| InsertCommFence | SplitIncoreOrch | — | — |
+| MaterializeValidShapeSymbols | — | — | — |
 
-> **Note**: VerifySSA and TypeCheck are **PropertyVerifiers** (verification rules), not Passes. They run via `VerificationInstrument` or the `run_verifier()` utility — see [Verifier](99-verifier.md).
+The table lists every registered pass, in `Default`-strategy execution order. Update the row
+here whenever you add a pass or change its declaration.
+
+Most `PassProperties` constants live in `include/pypto/ir/transforms/pass_properties.h`, but that
+header is not the whole list: `kFuseCreateAssembleToSliceProperties` is declared locally in
+`src/ir/transforms/fuse_create_assemble_to_slice_pass.cpp`. What authoritatively binds a pass
+*name* to its properties is the `CreateFunctionPass` / `CreateProgramPass` call site, since that
+is where `Pass::GetName()` and the constant meet. Regenerate a row from the call sites rather
+than from the header alone, or a pass-local declaration is silently missed.
+
+> **Note**: VerifySSA and TypeCheck are **PropertyVerifiers** (verification rules), not Passes. They run via `VerificationInstrument` or the `run_verifier()` utility — see [Verifier](99-verifier.md). That is why no pass declares `TypeChecked`: it is a *structural* property (`GetStructuralProperties()`), verified once on the pipeline's input IR rather than established by any pass.
 
 ## C++ Pass Infrastructure
 
@@ -325,26 +376,33 @@ class PassPipeline {
 
 ### Automatic Verification
 
-When `VerificationLevel` is `Basic` (the default), the pipeline automatically verifies a small set of **lightweight properties** exactly once each. This catches common IR errors without requiring manual `PassContext` setup.
-
-**Verified properties**: `{SSAForm, TypeChecked, AllocatedMemoryAddr}`
+When `VerificationLevel` is `Basic` (the default), the pipeline automatically verifies the **lightweight properties** listed by `GetVerifiedProperties()` (`src/ir/transforms/ir_property.cpp`), each one exactly once per time it is produced. This catches common IR errors without requiring manual `PassContext` setup.
 
 **How it works**:
 
-1. After each pass, check if it produced any verified properties not yet checked
-2. Verify those properties using `PropertyVerifierRegistry`
-3. Throw `VerificationError` on errors
-4. Track verified properties to avoid re-checking
+1. At pipeline input, verify `GetStructuralProperties() ∩ GetVerifiedProperties()` — the invariants that hold on the user's own IR before any pass runs
+2. After each pass, verify the properties it *produces* that are in `GetVerifiedProperties()` and not already verified
+3. When a pass *invalidates* such a property, drop it from the verified set so a later producer re-verifies it
+4. Throw `VerificationError` on errors
 
-**With the `Default` strategy**:
+**With the `Default` strategy** (20 checks; the two sets are declared in `ir_property.cpp`, so this schedule follows from them and from the per-pass table above):
 
-| After Pass | Properties Verified | Cumulative |
-| ---------- | ------------------- | ---------- |
-| ConvertToSSA | SSAForm, TypeChecked | 2 |
-| FlattenCallExpr | *(TypeChecked already verified — skipped)* | 2 |
-| AllocateMemoryAddr | AllocatedMemoryAddr | 3 |
+| Verification point | Properties verified |
+| ------------------ | ------------------- |
+| pipeline input | TypeChecked, BreakContinueValid, NoRedundantBlocks, InOutUseValid, ManualDepsOnSubmitOnly, AtomicAddDtypeValid |
+| ConvertToSSA | SSAForm |
+| OutlineIncoreScopes | AivSplitValid |
+| ConvertTensorToTileOps | AivSplitValid *(re-verified — the pass invalidates it, see [10](10-convert_tensor_to_tile_ops.md))* |
+| InferTileMemorySpace | AivSplitValid *(re-verified)*, TileMemoryInferred, AccToGmStoreValid |
+| ExpandMixedKernel | MixedKernelExpanded, HardSyncallOccupancyValid |
+| NormalizeReturnOrder | ReturnParamsExplicit |
+| AllocateMemoryAddr | AllocatedMemoryAddr |
+| DeriveCallDirections | CallDirectionsResolved |
+| MaterializeDistTensorCtx | DistTensorCtxMaterialized |
+| MaterializeRuntimeScopes | RuntimeScopesMaterialized |
+| ClassifyIterArgCarry | IterArgCarryClassified |
 
-**Total: 3 property checks** (each property verified exactly once).
+A pass that under-declares `produced` therefore does not just mis-document itself — it silently removes a verification from this schedule.
 
 **Control via `PassContext`**:
 

--- a/docs/en/dev/passes/02-unroll_loops.md
+++ b/docs/en/dev/passes/02-unroll_loops.md
@@ -84,6 +84,6 @@ UnrollLoops expands `pl.unroll()` loops into their fully unrolled, straight-line
 
 | Property | Value |
 | -------- | ----- |
-| Required | `TypeChecked` |
-| Produced | `TypeChecked` |
-| Invalidated | (none) |
+| Required | — |
+| Produced | `UnrollResolved` |
+| Invalidated | — |

--- a/docs/en/dev/passes/03-ctrl_flow_transform.md
+++ b/docs/en/dev/passes/03-ctrl_flow_transform.md
@@ -8,9 +8,9 @@ PTO codegen emits MLIR-style SCF (structured control flow), which does not direc
 
 **Applies to**: InCore-type functions only (InCore, AIC, AIV). Orchestration/Host functions are skipped because they can use `break`/`continue` natively.
 
-**Requires**: `TypeChecked`
+**Requires**: nothing.
 
-**Produces**: `TypeChecked`, `StructuredCtrlFlow`
+**Produces**: `StructuredCtrlFlow`
 
 **When to use**: Runs automatically in the default pipeline after `UnrollLoops` and before `ConvertToSSA`.
 
@@ -170,6 +170,6 @@ UnrollLoops -> CtrlFlowTransform -> ConvertToSSA -> FlattenCallExpr -> ...
 
 | Property | Value |
 | -------- | ----- |
-| Required | `TypeChecked` |
-| Produced | `TypeChecked`, `StructuredCtrlFlow` |
-| Invalidated | (none) |
+| Required | — |
+| Produced | `StructuredCtrlFlow` |
+| Invalidated | — |

--- a/docs/en/dev/passes/08-outline_incore_scopes.md
+++ b/docs/en/dev/passes/08-outline_incore_scopes.md
@@ -350,3 +350,17 @@ The authoritative per-region mode always rides `SplitAivScopeStmt::split_`, whic
 applies the same rule as a backstop: it omits a `split` attr of `SplitMode.NONE`
 so IR that bypassed this pass (a pre-existing `.pto` blob, a programmatically
 built `Function`) still prints in the canonical, re-parsable form.
+
+## Pass Properties
+
+| Property | Value |
+| -------- | ----- |
+| Required | SSAForm |
+| Produced | SSAForm, SplitIncoreOrch, AivSplitValid |
+| Invalidated | — |
+
+`AivSplitValid` opens here. The pass preserves the first-class `SplitAivScopeStmt` regions inside
+each outlined InCore function, so the structural region verifier can run from this point until
+[`LowerAutoVectorSplit`](20-lower_auto_vector_split.md) erases the node and invalidates the
+property. `ConvertTensorToTileOps` and `InferTileMemorySpace` re-verify it in between, once the
+boundary's memory side becomes observable.

--- a/docs/en/dev/passes/09-outline_cluster_scopes.md
+++ b/docs/en/dev/passes/09-outline_cluster_scopes.md
@@ -174,7 +174,7 @@ deserialized IR that still spells a constant `core_num` on the function.
 
 | Property | Value |
 | -------- | ----- |
-| Required | TypeChecked, SSAForm |
+| Required | SSAForm |
 | Produced | SSAForm, ClusterOutlined |
 | Invalidated | — |
 

--- a/docs/en/dev/passes/10-convert_tensor_to_tile_ops.md
+++ b/docs/en/dev/passes/10-convert_tensor_to_tile_ops.md
@@ -335,8 +335,10 @@ Key changes:
 | Property | Value |
 | -------- | ----- |
 | Required | SSAForm, SplitIncoreOrch, NormalizedStmtStructure |
-| Produced | SSAForm, IncoreTileOps, NormalizedStmtStructure |
-| Invalidated | — |
+| Produced | SSAForm, IncoreTileOps, NormalizedStmtStructure, AivSplitValid |
+| Invalidated | AivSplitValid |
+
+`AivSplitValid` is both invalidated and re-produced, which forces a second verification of the split regions here. `OutlineIncoreScopes` establishes the property while the AIV-split boundary is still `tensor.aiv_shard` / `tensor.aic_gather`; a TensorType carries no memory space, so the verifier's boundary memory-contract check is necessarily skipped there. This pass rewrites those ops to their tile form and attaches the declared boundary memory, which is exactly what that check inspects.
 
 ## Key Components
 

--- a/docs/en/dev/passes/13-flatten_tile_nd_to_2d.md
+++ b/docs/en/dev/passes/13-flatten_tile_nd_to_2d.md
@@ -202,8 +202,8 @@ The phase entry points and rewrite component interface are private to the transf
 
 | Property | Value |
 | -------- | ----- |
-| Required | SSAForm, IncoreTileOps |
-| Produced | SSAForm, TileOps2D |
+| Required | SSAForm, IncoreTileOps, NormalizedStmtStructure |
+| Produced | SSAForm, TileOps2D, NormalizedStmtStructure |
 | Invalidated | — |
 
 ## Scope

--- a/docs/en/dev/passes/17-infer_tile_memory_space.md
+++ b/docs/en/dev/passes/17-infer_tile_memory_space.md
@@ -225,10 +225,12 @@ The pass also registers a `TileMemoryInferred` `PropertyVerifier` (defined in th
 | Property | Value |
 | -------- | ----- |
 | Required | `SSAForm`, `IncoreTileOps`, `SplitIncoreOrch`, `NormalizedStmtStructure` |
-| Produced | `SSAForm`, `TileMemoryInferred`, `NormalizedStmtStructure` |
-| Invalidated | — |
+| Produced | `SSAForm`, `TileMemoryInferred`, `NormalizedStmtStructure`, `AivSplitValid`, `AccToGmStoreValid` |
+| Invalidated | `AivSplitValid` |
 
 The `TileMemoryInferred` property is the contract this pass establishes. Downstream passes (notably `ExpandMixedKernel` and `InitMemRef`) rely on it, and the matching property verifier guards regressions.
+
+`AccToGmStoreValid` becomes decidable only here: whether a `tile.store` narrows from Acc into GM depends on the memory space this pass resolves. `AivSplitValid` is invalidated and re-produced for the same reason — this is the last verification point at which an AIV-split boundary whose operand space was still unresolved at `ConvertTensorToTileOps` becomes observable, before `LowerAutoVectorSplit` erases the region node.
 
 ## Scope
 

--- a/docs/en/dev/passes/20-lower_auto_vector_split.md
+++ b/docs/en/dev/passes/20-lower_auto_vector_split.md
@@ -48,9 +48,11 @@ result = passes.lower_auto_vector_split()(program)
 
 | Property | Value |
 | -------- | ----- |
-| Required | `SSAForm` |
-| Produced | `SSAForm` |
-| Invalidated | — |
+| Required | `SSAForm`, `IncoreTileOps`, `SplitIncoreOrch`, `TileOps2D`, `TileMemoryInferred`, `NormalizedStmtStructure`, `AivSplitValid` |
+| Produced | `SSAForm`, `IncoreTileOps`, `SplitIncoreOrch`, `TileOps2D`, `TileMemoryInferred`, `NormalizedStmtStructure` |
+| Invalidated | `AivSplitValid` |
+
+This pass closes the `AivSplitValid` verification window that `OutlineIncoreScopes` opened: it consumes and erases the first-class `SplitAivScopeStmt` regions, so the structural region verifier cannot run after it. Hence `AivSplitValid` is required on entry and invalidated on exit. The rest of the set is unchanged across the pass — the still-mixed InCore body is rewritten in place.
 
 Source: `include/pypto/ir/transforms/pass_properties.h`
 (`kLowerAutoVectorSplitProperties`).

--- a/docs/en/dev/passes/21-expand_mixed_kernel.md
+++ b/docs/en/dev/passes/21-expand_mixed_kernel.md
@@ -500,9 +500,11 @@ class After:
 
 | Property | Value |
 | -------- | ----- |
-| Required | SSAForm, IncoreTileOps, SplitIncoreOrch, TileOps2D, TileMemoryInferred |
-| Produced | SSAForm, MixedKernelExpanded |
+| Required | SSAForm, IncoreTileOps, SplitIncoreOrch, TileOps2D, TileMemoryInferred, NormalizedStmtStructure |
+| Produced | SSAForm, MixedKernelExpanded, NormalizedStmtStructure, HardSyncallOccupancyValid |
 | Invalidated | — |
+
+`HardSyncallOccupancyValid` is produced here not by anything this pass rewrites, but because resolving each kernel's `FunctionType` to AIV/AIC/Group is the precondition the hard-syncall occupancy verifier depends on. That verifier fires once, right after this pass.
 
 ## Property Verifier
 

--- a/docs/zh/dev/passes/00-pass_manager.md
+++ b/docs/zh/dev/passes/00-pass_manager.md
@@ -34,13 +34,41 @@
 | `NormalizedStmtStructure` | 语句 (Statement) 结构已规范化 |
 | `NoRedundantBlocks` | 无单子节点或嵌套的 SeqStmts |
 | `SplitIncoreOrch` | InCore 作用域已提取为独立函数 |
-| `ClusterOutlined` | Cluster 作用域已提取为 Group 函数 |
 | `HasMemRefs` | 变量上已初始化内存引用 (MemRef) 对象 |
-| `IncoreTileOps` | InCore 函数使用 tile 操作 |
-| `MixedKernelExpanded` | 混合 InCore 函数已拆分为 AIC + AIV + Group |
+| `IncoreTileOps` | InCore 函数使用 tile 操作（tile 类型、load/store） |
 | `AllocatedMemoryAddr` | 所有 MemRef 在缓冲区限制内具有有效地址 |
+| `MixedKernelExpanded` | 混合 InCore 函数已拆分为 AIC + AIV + Group |
+| `ClusterOutlined` | Cluster 作用域已提取为 Group 函数 |
+| `TileOps2D` | InCore 函数中所有 tile 操作的 tile 维度 ≤2D |
+| `TileMemoryInferred` | InCore 函数中 `TileType::memory_space_` 已填充 |
+| `BreakContinueValid` | break/continue 仅出现在 sequential/while 循环中 |
+| `UseAfterDef` | 所有变量使用都被其定义支配 (dominate) |
+| `HierarchyOutlined` | Hierarchy 作用域已提取为 level/role 函数 |
+| `StructuredCtrlFlow` | 不存在 BreakStmt/ContinueStmt——只有结构化控制流 |
+| `VectorKernelSplit` | 带 split 模式的 AIV 函数已调整 tpop 形状与 store 偏移 |
+| `OutParamNotShadowed` | Out/InOut 参数未被创建 tensor 的算子重新赋值 |
+| `NoNestedInCore` | 无嵌套 InCore 作用域（ScopeStmt 内再嵌 ScopeStmt） |
+| `InOutUseValid` | 调用之后不再读取以 InOut/Out 传入的变量（RFC #1026） |
+| `PipelineLoopValid` | 双向不变量：`ForStmt.kind_ == Pipeline` ⇔ 带有 `pipeline_stages` 属性 |
+| `PipelineResolved` | 不再残留 `ForKind::Pipeline`；由 CanonicalizeIOOrder 产生 |
+| `CallDirectionsResolved` | 每个非 builtin Call 都带有显式的 `attrs['arg_directions']` |
 | `TileTypeCoherence` | 每个 TileType 都具有规范的 tile_view（隐式视图存储为 nullopt） |
+| `InlineFunctionsEliminated` | 不再残留 `FunctionType::Inline` 函数及对其的 Call |
 | `OrchestrationReferencesResolved` | `FunctionType::Orchestration` 函数体内每一个非 builtin Call 必须对应到 Program 中存在的 Function |
+| `TensorViewCanonical` | TensorView 规范性已验证（弱模式：允许空 stride；严格模式：要求已材料化，RFC #1300 §2.2） |
+| `ArrayNotEscaped` | ArrayType 不会出现在函数参数或返回类型中 |
+| `CommDomainScopesMaterialized` | host_orch 函数体已被 CommDomainScopeStmt 包裹，且 `pld.tensor.window` 结果类型带有 `DistributedTensorType::window_buffer_` 反向引用 |
+| `DistTensorCtxMaterialized` | host orchestration 之外不再残留 `pld.system.get_comm_ctx`；每个 chip-orchestration / device 通信上下文都是可追溯到参数的显式 CommCtxType SSA 值 |
+| `RuntimeScopesMaterialized` | Orchestration 函数带有显式的 RuntimeScopeStmt 节点，codegen 不再隐式生成 `PTO2_SCOPE()` 包裹 |
+| `AssignTypeSymmetry` | 每个 AssignStmt 满足 `structural_equal(var->GetType(), value->GetType())`（memref 作为分配细节被排除） |
+| `ManualDepsOnSubmitOnly` | 普通跨函数 Call 不携带 `attrs["manual_dep_edges"]`——手写依赖边只存在于 `Submit::deps_` |
+| `ReturnParamsExplicit` | InCore/Group/Spmd 的 tensor 返回值按指针恒等引用函数参数（#1702） |
+| `UnrollResolved` | 不再残留 `ForKind::Unroll`；由 UnrollLoops 产生 |
+| `AivSplitValid` | SplitAivScopeStmt 区域结构合法：区域内无 cube 计算与 split 轴 reduce，边界算子只出现在区域内 |
+| `HardSyncallOccupancyValid` | 每个硬 (FFTS) `system.syncall` 都在满占用下启动——部分或超额启动会导致设备侧死锁 (507018) |
+| `IterArgCarryClassified` | Orchestration 中每个带 iter_args 的 ForStmt 都带有 `iter_arg_rebind_<i>` 携带方案，codegen 直接读取而不再重新推导 |
+| `AccToGmStoreValid` | 每个源 tile 位于 Acc 的 `tile.store` 所写 GM dtype 都能被后端 fix-pipe 收窄 |
+| `AtomicAddDtypeValid` | 每个写入 GM 的 atomic-add 的目标 dtype 都能被后端 store pipe 合并 |
 
 ### IRPropertySet
 
@@ -61,42 +89,64 @@ struct PassProperties {
 | Pass | 所需 | 产生 | 失效 |
 | ---- | ---- | ---- | ---- |
 | InlineFunctions | — | InlineFunctionsEliminated | — |
-| UnrollLoops | TypeChecked | TypeChecked | — |
-| CtrlFlowTransform | TypeChecked | TypeChecked, StructuredCtrlFlow | — |
-| ConvertToSSA | TypeChecked | TypeChecked, SSAForm | NormalizedStmtStructure |
-| FlattenCallExpr | SSAForm | SSAForm, NoNestedCalls | NormalizedStmtStructure |
-| NormalizeStmtStructure | TypeChecked | TypeChecked, NormalizedStmtStructure | — |
-| OutlineIncoreScopes | TypeChecked, SSAForm | SplitIncoreOrch | — |
-| OutlineClusterScopes | TypeChecked, SSAForm | ClusterOutlined | — |
-| ConvertTensorToTileOps | SplitIncoreOrch | IncoreTileOps | — |
+| UnrollLoops | — | UnrollResolved | — |
+| CtrlFlowTransform | — | StructuredCtrlFlow | — |
+| ConvertToSSA | — | SSAForm | NormalizedStmtStructure |
+| Simplify | — | — | — |
+| NormalizeStmtStructure | — | NormalizedStmtStructure | — |
+| FlattenCallExpr | SSAForm, NormalizedStmtStructure | SSAForm, NoNestedCalls, NormalizedStmtStructure | — |
+| OutlineHierarchyScopes | SSAForm | SSAForm, HierarchyOutlined, OrchestrationReferencesResolved | — |
+| OutlineIncoreScopes | SSAForm | SSAForm, SplitIncoreOrch, AivSplitValid | — |
+| OutlineClusterScopes | SSAForm | SSAForm, ClusterOutlined | — |
+| ConvertTensorToTileOps | SSAForm, SplitIncoreOrch, NormalizedStmtStructure | SSAForm, IncoreTileOps, NormalizedStmtStructure, AivSplitValid | AivSplitValid |
+| OptimizeOrchTensors | SplitIncoreOrch, IncoreTileOps | SplitIncoreOrch, IncoreTileOps | — |
 | LowerCompositeOps | — | — | — |
-| FlattenTileNdTo2D | SSAForm, IncoreTileOps | SSAForm, TileOps2D | — |
+| FlattenTileNdTo2D | SSAForm, IncoreTileOps, NormalizedStmtStructure | SSAForm, TileOps2D, NormalizedStmtStructure | — |
 | LegalizeTileCast | — | — | — |
-| AutoTileMatmulL0 | SSAForm, IncoreTileOps, TileOps2D | SSAForm, IncoreTileOps, TileOps2D | — |
+| AutoTileMatmulL0 | SSAForm, SplitIncoreOrch, IncoreTileOps, TileOps2D, NormalizedStmtStructure | SSAForm, SplitIncoreOrch, IncoreTileOps, TileOps2D, NormalizedStmtStructure | — |
 | CanonicalizeTileSlice | SSAForm, SplitIncoreOrch, IncoreTileOps, TileOps2D, NormalizedStmtStructure | SSAForm, SplitIncoreOrch, IncoreTileOps, TileOps2D, NormalizedStmtStructure | — |
-| InsertMxScaleAddr | SSAForm, IncoreTileOps, SplitIncoreOrch, TileMemoryInferred, NormalizedStmtStructure | SSAForm, IncoreTileOps, SplitIncoreOrch, TileMemoryInferred, NormalizedStmtStructure | — |
+| InferTileMemorySpace | SSAForm, IncoreTileOps, SplitIncoreOrch, NormalizedStmtStructure | SSAForm, TileMemoryInferred, NormalizedStmtStructure, AivSplitValid, AccToGmStoreValid | AivSplitValid |
+| InsertMxScaleAddr | SSAForm, IncoreTileOps, SplitIncoreOrch, NormalizedStmtStructure, TileMemoryInferred | SSAForm, IncoreTileOps, SplitIncoreOrch, NormalizedStmtStructure, TileMemoryInferred | — |
 | ResolveBackendOpLayouts | SSAForm, IncoreTileOps, SplitIncoreOrch, TileOps2D | SSAForm, IncoreTileOps, SplitIncoreOrch, TileOps2D, NormalizedStmtStructure | — |
-| LowerAutoVectorSplit | SSAForm, IncoreTileOps, SplitIncoreOrch, TileOps2D, TileMemoryInferred, NormalizedStmtStructure | SSAForm, IncoreTileOps, SplitIncoreOrch, TileOps2D, TileMemoryInferred, NormalizedStmtStructure | — |
-| ExpandMixedKernel | SSAForm, IncoreTileOps, SplitIncoreOrch, TileOps2D | SSAForm, MixedKernelExpanded | — |
-| NormalizeReturnOrder | SplitIncoreOrch, IncoreTileOps | — | — |
-| InitMemRef | TypeChecked, SSAForm, SplitIncoreOrch, IncoreTileOps, TileOps2D | HasMemRefs | SSAForm |
-| MaterializeSemanticAliases | SplitIncoreOrch, IncoreTileOps, HasMemRefs, TileOps2D | — | — |
-| MemoryReuse | TypeChecked, SplitIncoreOrch, IncoreTileOps, HasMemRefs, TileOps2D | — | — |
-| AllocateMemoryAddr | TypeChecked, SplitIncoreOrch, IncoreTileOps, HasMemRefs, TileOps2D | AllocatedMemoryAddr | — |
+| LowerAutoVectorSplit | SSAForm, IncoreTileOps, SplitIncoreOrch, TileOps2D, TileMemoryInferred, NormalizedStmtStructure, AivSplitValid | SSAForm, IncoreTileOps, SplitIncoreOrch, TileOps2D, TileMemoryInferred, NormalizedStmtStructure | AivSplitValid |
+| ExpandMixedKernel | SSAForm, IncoreTileOps, SplitIncoreOrch, TileOps2D, TileMemoryInferred, NormalizedStmtStructure | SSAForm, MixedKernelExpanded, NormalizedStmtStructure, HardSyncallOccupancyValid | — |
+| InjectGMPipeBuffer | SSAForm, MixedKernelExpanded, NormalizedStmtStructure | SSAForm, MixedKernelExpanded, NormalizedStmtStructure | — |
+| SplitVectorKernel | SSAForm, MixedKernelExpanded | SSAForm, VectorKernelSplit, NormalizedStmtStructure | — |
+| StampTfreeSplit | SplitIncoreOrch | — | — |
+| NormalizeReturnOrder | SplitIncoreOrch, IncoreTileOps | ReturnParamsExplicit | — |
+| SkewCrossCorePipeline | SSAForm, SplitIncoreOrch, IncoreTileOps, TileOps2D, TileMemoryInferred, NormalizedStmtStructure | SSAForm, SplitIncoreOrch, IncoreTileOps, TileOps2D, TileMemoryInferred, NormalizedStmtStructure | — |
+| LowerPipelineToSlots | SSAForm, SplitIncoreOrch, IncoreTileOps, TileOps2D, TileMemoryInferred, NormalizedStmtStructure | SSAForm, SplitIncoreOrch, IncoreTileOps, TileOps2D, TileMemoryInferred, NormalizedStmtStructure | — |
+| LowerPipelineLoops | SSAForm, SplitIncoreOrch, IncoreTileOps, TileOps2D, TileMemoryInferred, NormalizedStmtStructure | SSAForm, SplitIncoreOrch, IncoreTileOps, TileOps2D, TileMemoryInferred, NormalizedStmtStructure | — |
+| CanonicalizeIOOrder | SSAForm, SplitIncoreOrch, IncoreTileOps, TileOps2D, TileMemoryInferred, NormalizedStmtStructure | SSAForm, SplitIncoreOrch, IncoreTileOps, TileOps2D, TileMemoryInferred, NormalizedStmtStructure, PipelineResolved | — |
+| MaterializeTensorStrides | SSAForm, SplitIncoreOrch, IncoreTileOps, TileOps2D, TileMemoryInferred, NormalizedStmtStructure | SSAForm, SplitIncoreOrch, IncoreTileOps, TileOps2D, TileMemoryInferred, NormalizedStmtStructure, TensorViewCanonical | — |
+| InitMemRef | SSAForm, SplitIncoreOrch, IncoreTileOps, TileOps2D, TileMemoryInferred | HasMemRefs, NormalizedStmtStructure | SSAForm |
+| MaterializeSemanticAliases | SplitIncoreOrch, IncoreTileOps, HasMemRefs, TileOps2D, NormalizedStmtStructure | NormalizedStmtStructure | — |
+| MemoryReuse | SplitIncoreOrch, IncoreTileOps, HasMemRefs, TileOps2D, NormalizedStmtStructure | NormalizedStmtStructure | — |
+| AllocateMemoryAddr | SplitIncoreOrch, IncoreTileOps, HasMemRefs, TileOps2D | AllocatedMemoryAddr | — |
 | FoldNoOpReshape | SplitIncoreOrch, IncoreTileOps, HasMemRefs, TileOps2D | — | — |
-| FuseCreateAssembleToSlice | — | — | — |
+| FuseCreateAssembleToSlice | SplitIncoreOrch | — | — |
 | DeriveCallDirections | SplitIncoreOrch | CallDirectionsResolved | — |
 | AutoDeriveTaskDependencies | SplitIncoreOrch, CallDirectionsResolved | CallDirectionsResolved | — |
 | ExpandManualPhaseFence | NoNestedCalls, NormalizedStmtStructure, CallDirectionsResolved | NoNestedCalls, NormalizedStmtStructure, CallDirectionsResolved | — |
 | SynthesizeAllReduceSignals | — | — | — |
 | MaterializeCommDomainScopes | — | CommDomainScopesMaterialized | — |
 | LowerHostTensorCollectives | CommDomainScopesMaterialized | CommDomainScopesMaterialized | — |
-| MaterializeDistTensorCtx | CommDomainScopesMaterialized | CommDomainScopesMaterialized | — |
-| Simplify | — | — | — |
+| MaterializeDistTensorCtx | CommDomainScopesMaterialized, ReturnParamsExplicit | CommDomainScopesMaterialized, DistTensorCtxMaterialized | — |
 | MaterializeRuntimeScopes | SplitIncoreOrch, CallDirectionsResolved | RuntimeScopesMaterialized | — |
 | ClassifyIterArgCarry | CallDirectionsResolved, RuntimeScopesMaterialized | IterArgCarryClassified, RuntimeScopesMaterialized | — |
+| InsertCommFence | SplitIncoreOrch | — | — |
+| MaterializeValidShapeSymbols | — | — | — |
 
-> **注意**：VerifySSA 和 TypeCheck 是**属性验证器 (PropertyVerifier)**（验证规则），不是 Pass。它们通过 `VerificationInstrument` 或 `run_verifier()` 工具函数运行——参见[验证器](99-verifier.md)。
+本表按 `Default` 策略的执行顺序列出全部已注册 Pass。新增 Pass 或修改属性声明时，请同步更新
+此处对应的行。
+
+多数 `PassProperties` 常量位于 `include/pypto/ir/transforms/pass_properties.h`，但该头文件并非
+完整清单：`kFuseCreateAssembleToSliceProperties` 就声明在
+`src/ir/transforms/fuse_create_assemble_to_slice_pass.cpp` 内部。真正把 Pass *名字* 与其属性绑定
+起来的是 `CreateFunctionPass` / `CreateProgramPass` 调用点——`Pass::GetName()` 与该常量正是在那里
+汇合。因此请从调用点而非仅从头文件重新生成表格行，否则会静默漏掉 pass 内部的局部声明。
+
+> **注意**：VerifySSA 和 TypeCheck 是**属性验证器 (PropertyVerifier)**（验证规则），不是 Pass。它们通过 `VerificationInstrument` 或 `run_verifier()` 工具函数运行——参见[验证器](99-verifier.md)。这也是没有任何 Pass 声明 `TypeChecked` 的原因：它是**结构性**属性（`GetStructuralProperties()`），在流水线入口的 IR 上验证一次，而不是由某个 Pass 建立。
 
 ## C++ Pass 基础设施
 
@@ -325,26 +375,33 @@ class PassPipeline {
 
 ### 自动验证
 
-当 `VerificationLevel` 为 `Basic`（默认值）时，流水线会自动对一组**轻量级属性**各验证一次。这可以在无需手动设置 `PassContext` 的情况下捕获常见的 IR 错误。
-
-**验证的属性**：`{SSAForm, TypeChecked, AllocatedMemoryAddr}`
+当 `VerificationLevel` 为 `Basic`（默认值）时，流水线会自动验证 `GetVerifiedProperties()`（`src/ir/transforms/ir_property.cpp`）列出的**轻量级属性**，每次产生时各验证一次。这可以在无需手动设置 `PassContext` 的情况下捕获常见的 IR 错误。
 
 **工作原理**：
 
-1. 每个 Pass 执行后，检查是否产生了尚未检查的已验证属性
-2. 使用 `PropertyVerifierRegistry` 验证这些属性
-3. 出错时抛出 `VerificationError`
-4. 跟踪已验证属性以避免重复检查
+1. 在流水线入口验证 `GetStructuralProperties() ∩ GetVerifiedProperties()`——这些不变量在任何 Pass 运行前就应在用户自己的 IR 上成立
+2. 每个 Pass 执行后，验证它所*产生*且位于 `GetVerifiedProperties()` 中、尚未验证过的属性
+3. 当某个 Pass *失效*了这样一个属性时，将其从已验证集合中移除，以便后续的产生者重新验证
+4. 出错时抛出 `VerificationError`
 
-**使用 `Default` 策略时**：
+**使用 `Default` 策略时**（共 20 次检查；两个集合都声明在 `ir_property.cpp` 中，因此该时序完全由它们与上面的逐 Pass 属性表推导得出）：
 
-| Pass 执行后 | 验证的属性 | 累计 |
-| ----------- | ---------- | ---- |
-| ConvertToSSA | SSAForm, TypeChecked | 2 |
-| FlattenCallExpr | *(TypeChecked 已验证——跳过)* | 2 |
-| AllocateMemoryAddr | AllocatedMemoryAddr | 3 |
+| 验证时机 | 验证的属性 |
+| -------- | ---------- |
+| 流水线入口 | TypeChecked, BreakContinueValid, NoRedundantBlocks, InOutUseValid, ManualDepsOnSubmitOnly, AtomicAddDtypeValid |
+| ConvertToSSA | SSAForm |
+| OutlineIncoreScopes | AivSplitValid |
+| ConvertTensorToTileOps | AivSplitValid *（重新验证——本 Pass 会先失效它，参见 [10](10-convert_tensor_to_tile_ops.md)）* |
+| InferTileMemorySpace | AivSplitValid *（重新验证）*、TileMemoryInferred、AccToGmStoreValid |
+| ExpandMixedKernel | MixedKernelExpanded, HardSyncallOccupancyValid |
+| NormalizeReturnOrder | ReturnParamsExplicit |
+| AllocateMemoryAddr | AllocatedMemoryAddr |
+| DeriveCallDirections | CallDirectionsResolved |
+| MaterializeDistTensorCtx | DistTensorCtxMaterialized |
+| MaterializeRuntimeScopes | RuntimeScopesMaterialized |
+| ClassifyIterArgCarry | IterArgCarryClassified |
 
-**总计：3 次属性检查**（每个属性恰好验证一次）。
+因此，一个 Pass 少声明 `produced` 不只是文档写错——它会悄悄地从该时序中抹掉一次验证。
 
 **通过 `PassContext` 控制**：
 

--- a/docs/zh/dev/passes/02-unroll_loops.md
+++ b/docs/zh/dev/passes/02-unroll_loops.md
@@ -6,8 +6,6 @@
 
 此 Pass 静态展开通过 `pl.unroll()` 创建的 for 循环，将其替换为循环体的多份副本，其中循环变量被替换为每次迭代的常量值。
 
-**前置条件**: TypeChecked 属性。
-
 **使用场景**: 在默认流水线（pipeline）中自动运行，位于 `ConvertToSSA` 之前。当循环次数为编译时常量并且您希望为每次迭代复制循环体时，使用 `pl.unroll()`。
 
 ## API
@@ -86,6 +84,6 @@ UnrollLoops 将 `pl.unroll()` 循环展开为完全平铺的直线代码形式�
 
 | 属性 | 值 |
 | ---- | -- |
-| 前置要求（Required） | `TypeChecked` |
-| 产生（Produced） | `TypeChecked` |
-| 失效（Invalidated） | （无） |
+| 前置要求（Required） | — |
+| 产生（Produced） | `UnrollResolved` |
+| 失效（Invalidated） | — |

--- a/docs/zh/dev/passes/03-ctrl_flow_transform.md
+++ b/docs/zh/dev/passes/03-ctrl_flow_transform.md
@@ -8,9 +8,9 @@ PTO codegen 生成 MLIR 格式的 SCF（结构化控制流），不直接支持 
 
 **适用范围**: 仅对 InCore 类函数生效（InCore、AIC、AIV）。Orchestration/Host 函数会被跳过，因为它们可以原生支持 `break`/`continue`。
 
-**所需属性**: `TypeChecked`
+**所需属性**: 无。
 
-**产生属性**: `TypeChecked`, `StructuredCtrlFlow`
+**产生属性**: `StructuredCtrlFlow`
 
 **使用时机**: 在默认流水线中自动运行，位于 `UnrollLoops` 之后、`ConvertToSSA` 之前。
 
@@ -170,6 +170,6 @@ UnrollLoops -> CtrlFlowTransform -> ConvertToSSA -> FlattenCallExpr -> ...
 
 | 属性 | 值 |
 | ---- | -- |
-| 所需 (Required) | `TypeChecked` |
-| 产生 (Produced) | `TypeChecked`, `StructuredCtrlFlow` |
-| 失效 (Invalidated) | (none) |
+| 所需 (Required) | — |
+| 产生 (Produced) | `StructuredCtrlFlow` |
+| 失效 (Invalidated) | — |

--- a/docs/zh/dev/passes/08-outline_incore_scopes.md
+++ b/docs/zh/dev/passes/08-outline_incore_scopes.md
@@ -322,3 +322,16 @@ print → parse 有损（`Kwargs size mismatch`）。权威的逐区域模式始
 `SplitAivScopeStmt::split_`，由 [`LowerAutoVectorSplit`](20-lower_auto_vector_split.md)
 消费。printer 以同一规则兜底：省略取值为 `SplitMode.NONE` 的 `split` 属性，使绕过本 Pass
 的 IR（此前写出的 `.pto`、以编程方式构造的 `Function`）依然以规范、可重新解析的形式打印。
+
+## Pass 属性
+
+| 属性 | 值 |
+| ---- | -- |
+| 所需 | SSAForm |
+| 产生 | SSAForm, SplitIncoreOrch, AivSplitValid |
+| 失效 | — |
+
+`AivSplitValid` 的验证窗口从这里打开。本 Pass 在每个被外提的 InCore 函数内保留第一类
+`SplitAivScopeStmt` 区域，因此结构化区域 verifier 可以从此处一直运行到
+[`LowerAutoVectorSplit`](20-lower_auto_vector_split.md) 擦除该节点并使属性失效为止。
+其间 `ConvertTensorToTileOps` 与 `InferTileMemorySpace` 会在边界内存变得可观察后各重新验证一次。

--- a/docs/zh/dev/passes/09-outline_cluster_scopes.md
+++ b/docs/zh/dev/passes/09-outline_cluster_scopes.md
@@ -165,7 +165,7 @@ Orchestration 代码生成通过 `EffectiveLaunchSpec` 读取该规格：优先�
 
 | 属性 | 值 |
 | ---- | -- |
-| 所需 | TypeChecked, SSAForm |
+| 所需 | SSAForm |
 | 产生 | SSAForm, ClusterOutlined |
 | 失效 | — |
 

--- a/docs/zh/dev/passes/10-convert_tensor_to_tile_ops.md
+++ b/docs/zh/dev/passes/10-convert_tensor_to_tile_ops.md
@@ -320,8 +320,10 @@ class After:
 | 属性 | 值 |
 | ---- | -- |
 | Required | SSAForm, SplitIncoreOrch, NormalizedStmtStructure |
-| Produced | SSAForm, IncoreTileOps, NormalizedStmtStructure |
-| Invalidated | — |
+| Produced | SSAForm, IncoreTileOps, NormalizedStmtStructure, AivSplitValid |
+| Invalidated | AivSplitValid |
+
+`AivSplitValid` 同时被失效并重新产生，从而在此处强制对 split 区域再验证一次。`OutlineIncoreScopes` 建立该属性时，AIV split 边界还是 `tensor.aiv_shard` / `tensor.aic_gather`；TensorType 不携带 memory space，因此验证器的边界内存契约检查在那里必然被跳过。本 Pass 把这些算子改写为 tile 形式并附上声明的边界内存，而这正是该项检查所要检视的内容。
 
 ## 关键组件
 

--- a/docs/zh/dev/passes/13-flatten_tile_nd_to_2d.md
+++ b/docs/zh/dev/passes/13-flatten_tile_nd_to_2d.md
@@ -180,8 +180,8 @@ for c, (o,) in pl.range(0, s_dim, CHUNK, init_values=(out,)):
 
 | 属性 | 值 |
 | ---- | -- |
-| 所需 | SSAForm, IncoreTileOps |
-| 产生 | SSAForm, TileOps2D |
+| 所需 | SSAForm, IncoreTileOps, NormalizedStmtStructure |
+| 产生 | SSAForm, TileOps2D, NormalizedStmtStructure |
 | 失效 | — |
 
 ## 作用范围

--- a/docs/zh/dev/passes/17-infer_tile_memory_space.md
+++ b/docs/zh/dev/passes/17-infer_tile_memory_space.md
@@ -224,10 +224,12 @@ class After:
 | 属性 | 取值 |
 | ---- | ---- |
 | Required | `SSAForm`、`IncoreTileOps`、`SplitIncoreOrch`、`NormalizedStmtStructure` |
-| Produced | `SSAForm`、`TileMemoryInferred`、`NormalizedStmtStructure` |
-| Invalidated | — |
+| Produced | `SSAForm`、`TileMemoryInferred`、`NormalizedStmtStructure`、`AivSplitValid`、`AccToGmStoreValid` |
+| Invalidated | `AivSplitValid` |
 
 `TileMemoryInferred` 属性是本 pass 建立的契约。下游 pass（尤其 `ExpandMixedKernel` 与 `InitMemRef`）依赖该契约，配套的属性 verifier 守护回归。
+
+`AccToGmStoreValid` 只有在这里才可判定：`tile.store` 是否从 Acc 收窄写入 GM，取决于本 pass 解析出的 memory space。`AivSplitValid` 被失效并重新产生也是同一原因——这是最后一个能观察到 AIV split 边界内存的验证点（此前在 `ConvertTensorToTileOps` 处该操作数的 space 可能仍未解析），再往后 `LowerAutoVectorSplit` 就会擦除区域节点。
 
 ## 作用范围
 

--- a/docs/zh/dev/passes/20-lower_auto_vector_split.md
+++ b/docs/zh/dev/passes/20-lower_auto_vector_split.md
@@ -46,9 +46,11 @@ result = passes.lower_auto_vector_split()(program)
 
 | 属性 | 值 |
 | ---- | -- |
-| Required | `SSAForm` |
-| Produced | `SSAForm` |
-| Invalidated | — |
+| Required | `SSAForm`、`IncoreTileOps`、`SplitIncoreOrch`、`TileOps2D`、`TileMemoryInferred`、`NormalizedStmtStructure`、`AivSplitValid` |
+| Produced | `SSAForm`、`IncoreTileOps`、`SplitIncoreOrch`、`TileOps2D`、`TileMemoryInferred`、`NormalizedStmtStructure` |
+| Invalidated | `AivSplitValid` |
+
+本 pass 关闭了由 `OutlineIncoreScopes` 打开的 `AivSplitValid` 验证窗口：它消费并擦除第一类 `SplitAivScopeStmt` 区域，此后结构化区域 verifier 无法再运行。因此该属性在入口被要求、在出口被失效。其余属性在 pass 前后保持不变——仍是混合形态的 InCore 函数体被就地改写。
 
 来源：`include/pypto/ir/transforms/pass_properties.h`
 （`kLowerAutoVectorSplitProperties`）。

--- a/docs/zh/dev/passes/21-expand_mixed_kernel.md
+++ b/docs/zh/dev/passes/21-expand_mixed_kernel.md
@@ -471,9 +471,11 @@ class After:
 
 | 属性 | 值 |
 | ---- | -- |
-| 所需 | SSAForm, IncoreTileOps, SplitIncoreOrch, TileOps2D, TileMemoryInferred |
-| 产生 | SSAForm, MixedKernelExpanded |
+| 所需 | SSAForm, IncoreTileOps, SplitIncoreOrch, TileOps2D, TileMemoryInferred, NormalizedStmtStructure |
+| 产生 | SSAForm, MixedKernelExpanded, NormalizedStmtStructure, HardSyncallOccupancyValid |
 | 失效 | — |
+
+`HardSyncallOccupancyValid` 在此产生，并非因为本 pass 做了什么改写，而是因为它把每个 kernel 的 `FunctionType` 解析为 AIV/AIC/Group——这正是硬 syncall 占用率 verifier 所依赖的前置条件。该 verifier 只在本 pass 之后触发一次。
 
 ## 属性验证器
 


### PR DESCRIPTION
## What

Resyncs the pass-property tables in `docs/en/dev/passes/` and `docs/zh/dev/passes/`
with the `PassProperties` constants in `include/pypto/ir/transforms/pass_properties.h`.

Docs only. No code, no behaviour change.

## Why

Nothing ties the doc tables to the header, so drift accumulated silently across
several pass changes:

| Surface | Wrong |
| --- | --- |
| Per-pass property tables | 8 of 22 |
| Master table rows (`00-pass_manager.md`) | 19 of 35, plus 13 passes with no row |
| IRProperty reference table | 28 of 41 enumerators missing |
| `Automatic Verification` schedule | claimed 3 checks; actually 20 |

These are the surfaces a maintainer reads to decide where a new pass can be
inserted, so a stale row misdirects that decision. The declarations themselves
are correct — every table here moves to match the header, never the reverse.

## Two systematic errors

**`TypeChecked` was listed as a per-pass requirement on ~8 rows.** No pass
declares it; it is a *structural* property (`GetStructuralProperties()`) verified
once on the pipeline's input IR. The note under the master table now says so —
without that, the diff reads as dropping a real requirement.

**Every `AivSplitValid` row was missing**, including the invalidate/re-produce
pairs on `ConvertTensorToTileOps` and `InferTileMemorySpace`. Those exist to force
re-verification once the split boundary's memory side becomes observable. Each
affected table now carries a sentence explaining why a pass invalidates and
re-produces the same property, which otherwise reads as a typo.

## Also in `00-pass_manager.md`

- Master table lists all **48** registered passes in `Default` execution order.
- IRProperty reference table lists all **41** enumerators (was 13).
- `Automatic Verification` claimed `{SSAForm, TypeChecked, AllocatedMemoryAddr}`
  and "3 property checks", derived from the old declarations. Re-derived from
  `GetVerifiedProperties()` / `GetStructuralProperties()` and the pass order:
  **20 checks across 12 verification points**.
- `08-outline_incore_scopes.md` gains a property table — it is the pass that
  *opens* the `AivSplitValid` window and had none.

## Reviewer notes

- The tables were generated from the C++ rather than hand-transcribed, then
  checked back against it; `docs/zh` mirrors `docs/en` row for row.
- Rebased onto `main` at c5ded72b during preparation, which was worth doing:
  #2432 had just changed `MaterializeDistTensorCtx`'s properties and added
  `DistTensorCtxMaterialized` without touching the master table, and #2432 /
  #2447 also moved `TileMemoryInferred` and `DistTensorCtxMaterialized` into
  `GetVerifiedProperties()`. That drift is included in the fix — and is a fair
  illustration of the underlying problem.
- **This fixes the data, not the cause.** Nothing prevents the next pass change
  from desyncing these tables again. I have a working parity checker
  (`pass_properties.h` + `Create*Pass` call sites vs. every doc table, in both
  languages) that reproduced all the counts above and caught the post-rebase
  drift; it was left out of this PR to keep it docs-only, and can follow
  separately if wanted.