### PR TITLE
fix(ir): stamp compact mode on a runtime-narrowed matmul accumulator

### DIFF
--- a/docs/en/dev/codegen/00-pto_codegen.md
+++ b/docs/en/dev/codegen/00-pto_codegen.md
@@ -680,9 +680,28 @@ layout/fractal/pad/compact mode from the associated TileView (when available):
 | `compact` | `TileView::compact` | `null(0)`, `normal(1)` | `null(0)` |
 
 When no TileView is associated with the MemRef, the codegen falls back to the default values listed above.
-The `compact` attribute is omitted for its null default. A partial `tile.extract` into L0A/L0B sets
-`normal(1)` automatically so TEXTRACT transfers only the logical `valid_shape` instead of treating
-box-alignment padding as data.
+The `compact` attribute is omitted for its null default. Two paths set `normal(1)` automatically:
+
+- A partial `tile.extract` into L0A/L0B, so TEXTRACT transfers only the logical `valid_shape` instead
+  of treating box-alignment padding as data.
+- An **Acc (L0C) tile whose valid rows are not provably equal to its physical rows**, as produced by the
+  `tile.matmul`, `tile.matmul_bias`, and `tile.matmul_mx` deducers. `mad` always lays the product out
+  with an N-fractal stride of `ceil(validRow/16)*16` taken from the *lhs* valid rows, while every Acc
+  reader derives its stride from the compile-time physical `Rows` unless the tile is compact. Without
+  the flag a runtime-narrowed accumulator is read back at a different pitch than it was written at.
+  Only the **row** extent decides this — every Acc stride the ISA derives is a function of `validRow`
+  alone, so a narrowed column extent keeps the non-compact form.
+
+  Compact is stamped **only where the accumulator's layout is established**, never re-derived on an
+  alias of it. `tile.matmul_acc` (and `matmul_mx_acc`) *inherit* the accumulator operand's mode,
+  because the op reuses that operand's buffer in place and codegen aliases the two only when their
+  full tile config matches. `tile.set_validshape` likewise inherits: it is metadata-only and may run
+  *after* the buffer was written, so the pitch its readers must use is the one `mad` already wrote at
+  — deriving a new one from the narrowed rows would re-interpret bytes that were never repacked.
+
+Note that the Acc → L1 readers (`TExtractAccToMat`, `TMovCcToCb`) have no `CompactMode` branch in
+PTO-ISA on either a2a3 or a5, so a runtime-narrowed accumulator consumed by `tile.extract` /
+`tile.move` into L1 still reads at the physical `Rows` pitch. That gap needs a matching PTO-ISA change.
 
 ## Kernel Wrapper Generation (PTO Backend)
 

--- a/docs/zh/dev/codegen/00-pto_codegen.md
+++ b/docs/zh/dev/codegen/00-pto_codegen.md
@@ -652,8 +652,29 @@ tile_c = pl.mul(tile_a, tile_b)
 | `compact` | `TileView::compact` | `null(0)`, `normal(1)` | `null(0)` |
 
 当 MemRef 没有关联 TileView 时，代码生成器使用上表中的默认值。默认的 null
-`compact` 属性不会输出。进入 L0A/L0B 的部分 `tile.extract` 会自动设置
-`normal(1)`，使 TEXTRACT 仅传输逻辑 `valid_shape`，而不会把 box 对齐填充当作数据。
+`compact` 属性不会输出。有两条路径会自动设置 `normal(1)`：
+
+- 进入 L0A/L0B 的部分 `tile.extract`，使 TEXTRACT 仅传输逻辑 `valid_shape`，
+  而不会把 box 对齐填充当作数据。
+- **有效行数无法证明等于物理行数的 Acc (L0C) tile**，由 `tile.matmul`、
+  `tile.matmul_bias`、`tile.matmul_mx` 的类型推导产生。`mad` 始终以
+  `ceil(validRow/16)*16` 的 N-fractal stride 写出乘积，其中 `validRow` 取自 **lhs**
+  的有效行数；而所有 Acc 读取方在 tile 非 compact 时都按编译期物理 `Rows` 推导
+  stride。缺少该标记时，运行期窄化的累加器读回时使用的 pitch 与写入时不同。只有
+  **行** 维度决定这一点 —— ISA 推导的每个 Acc stride 都只是 `validRow` 的函数，
+  因此仅窄化列维度时保持非 compact 形式。
+
+  compact 只在**确立累加器布局的那一处**盖章，绝不在它的别名上重新推导。
+  `tile.matmul_acc`（以及 `matmul_mx_acc`）**继承**累加器操作数的模式，因为该 op
+  原地复用那块 buffer，而 codegen 只有在两者完整 tile 配置一致时才会做别名。
+  `tile.set_validshape` 同样是继承：它只改元数据，且可能在 buffer **写入之后**才
+  执行，因此读取方必须使用的仍是 `mad` 当初写入时的 pitch —— 若按窄化后的行数重新
+  推导，就会以从未重排过的方式重新解释这些字节。
+
+注意：在 a2a3 与 a5 上，PTO-ISA 的 Acc → L1 读取方（`TExtractAccToMat`、
+`TMovCcToCb`）都没有 `CompactMode` 分支，因此运行期窄化的累加器若经
+`tile.extract` / `tile.move` 进入 L1，仍会按物理 `Rows` pitch 读取。该缺口需要
+PTO-ISA 侧配套修改。
 
 ## 内核包装器生成 (PTO 后端)
 

--- a/include/pypto/ir/type_inference.h
+++ b/include/pypto/ir/type_inference.h
@@ -641,6 +641,39 @@ inline void InheritTileViewLayout(TileView& dst, const std::shared_ptr<const Til
   dst.compact = eff.compact;
 }
 
+/**
+ * @brief Stamp PTO's compact mode on an L0C view whose valid rows may be narrower than its
+ *        physical rows
+ *
+ * `mad` lays a matrix product out in L0C with an N-fractal stride of ceil(M/16)*16, where M is
+ * the *valid* row count of the L0A operand (pto-isa `TMatmul.hpp`:
+ * `uint16_t m = aMatrix.GetValidRow()`). Every Acc reader instead derives its stride from the
+ * tile's compile-time physical `Rows` unless the tile is compact, in which case it recomputes
+ * ceil(validRow/16)*16 — exactly the stride `mad` wrote at (`tstore_common.hpp`,
+ * `TStoreAccNz2nd` and siblings). A narrowed accumulator that is not compact is therefore read
+ * back at a different pitch than it was written at, silently scrambling every N-fractal above
+ * the first (issue #2470). This mirrors the L0A/L0B stamping `tile.extract` gained for #2232.
+ *
+ * Only the row extent decides this: every Acc stride the ISA derives is a function of `validRow`
+ * alone, so a narrowed *column* extent leaves writer and reader in agreement and keeps the
+ * historical non-compact form.
+ *
+ * Stamps whenever equality is not *proven*, so an undecidable symbolic extent is treated as
+ * narrowed. That is the safe direction: a compact tile whose valid rows happen to fill the box
+ * recomputes the same stride it would have read from `Rows`.
+ *
+ * @param dst Accumulator TileView to stamp (valid_shape must already be set)
+ * @param physical_shape The accumulator's physical shape
+ */
+inline void StampCompactForNarrowedAccRows(TileView& dst, const std::vector<ExprPtr>& physical_shape) {
+  if (dst.valid_shape.empty() || physical_shape.empty()) {
+    return;
+  }
+  if (ProveValidExtentEqual(dst.valid_shape[0], physical_shape[0]) != ProofResult::kTrue) {
+    dst.compact = CompactMode::normal;
+  }
+}
+
 namespace detail {
 
 /**

--- a/src/backend/common/pto_ops_shared.cpp
+++ b/src/backend/common/pto_ops_shared.cpp
@@ -491,9 +491,21 @@ void CheckSubviewTileCompat(const ir::TileType& source, const ir::TileType& resu
                                         << res_v.fractal << "); pto.subview requires identical fractal";
   CHECK(src_v.pad == res_v.pad)
       << op_name << ": pad mismatch between source and result; pto.subview requires identical pad mode";
+  // An Acc compact mismatch is reachable from ordinary DSL: a matmul whose lhs carries a
+  // narrowed valid row count produces a compact L0C tile (stride ceil(validRow/16)*16), while a
+  // plain `tile.create(target_memory=Acc)` window stays non-compact (stride = physical rows).
+  // The two really do address L0C at different pitches, so the copy is not expressible as a
+  // subview — say so in the user's terms rather than in `pto.subview`'s (#2470).
+  const bool acc_windows =
+      source.GetMemorySpace() == ir::MemorySpace::Acc && result.GetMemorySpace() == ir::MemorySpace::Acc;
   CHECK(src_v.compact == res_v.compact)
-      << op_name
-      << ": compact mismatch between source and result; pto.subview requires identical compact mode";
+      << op_name << ": compact mismatch between source and result; pto.subview requires identical "
+      << "compact mode"
+      << (acc_windows ? "; the two accumulator windows disagree on their L0C fractal stride. A matmul "
+                        "whose lhs carries narrowed valid rows writes L0C at ceil(validRow/16)*16, "
+                        "and no wider full-height accumulator window can view that layout. Drop the "
+                        "narrowing from the matmul operand and compute the full tile."
+                      : "");
   CHECK(src_v.pad == ir::PadValue::null)
       << op_name << ": pto.subview does not support pad_value (" << static_cast<int>(src_v.pad)
       << "); apply tile.fillpad on the result tile instead of carrying a pad on the slice/assemble window";

--- a/src/ir/op/tile_ops/matmul.cpp
+++ b/src/ir/op/tile_ops/matmul.cpp
@@ -115,6 +115,7 @@ TypePtr DeduceTileMatMulType(const std::vector<ExprPtr>& args,
   tile_view_semantics::SetTileLayout(
       tile_view, tile_view_semantics::GetImplicitTileLayout(geometry.physical_shape, MemorySpace::Acc));
   tile_view.valid_shape = geometry.valid_shape;
+  StampCompactForNarrowedAccRows(tile_view, geometry.physical_shape);
 
   return std::make_shared<TileType>(std::move(geometry.physical_shape), geometry.accumulator_dtype,
                                     std::nullopt, tile_view, MemorySpace::Acc);
@@ -198,6 +199,13 @@ TypePtr DeduceTileMatMulAccType(const std::vector<ExprPtr>& args,
   tile_view_semantics::SetTileLayout(
       tile_view, tile_view_semantics::GetImplicitTileLayout(output_shape, MemorySpace::Acc));
   tile_view.valid_shape = acc_valid;
+  // Inherit the accumulator's compact mode rather than re-deriving it. This op
+  // is `set_output_reuses_input(0)`: the result *is* the accumulator's buffer,
+  // and codegen only aliases the two when their `TileBufSignature` — compact
+  // included — matches, so inheriting keeps that alias legal by construction.
+  // `tile.matmul` is where the accumulator's stride is established, so it is
+  // the only place that derives compact from the valid rows (#2470).
+  tile_view.compact = tile_view_semantics::GetEffectiveTileView(*acc_type).compact;
 
   return std::make_shared<TileType>(output_shape, geometry.accumulator_dtype, std::nullopt, tile_view,
                                     MemorySpace::Acc);
@@ -266,6 +274,7 @@ TypePtr DeduceTileMatMulBiasType(const std::vector<ExprPtr>& args,
   tile_view_semantics::SetTileLayout(
       tile_view, tile_view_semantics::GetImplicitTileLayout(geometry.physical_shape, MemorySpace::Acc));
   tile_view.valid_shape = geometry.valid_shape;
+  StampCompactForNarrowedAccRows(tile_view, geometry.physical_shape);
   return std::make_shared<TileType>(std::move(geometry.physical_shape), geometry.accumulator_dtype,
                                     std::nullopt, tile_view, MemorySpace::Acc);
 }

--- a/src/ir/op/tile_ops/matmul_mx.cpp
+++ b/src/ir/op/tile_ops/matmul_mx.cpp
@@ -237,6 +237,7 @@ TypePtr DeduceTileMatMulMxType(const std::vector<ExprPtr>& args,
   tile_view.slayout = TileLayout::row_major;
   tile_view.fractal = 1024;
   tile_view.valid_shape = {m_valid, n_valid};
+  StampCompactForNarrowedAccRows(tile_view, output_shape);
   return std::make_shared<TileType>(output_shape, DataType::FP32, std::nullopt, tile_view);
 }
 

--- a/src/ir/op/tile_ops/transform.cpp
+++ b/src/ir/op/tile_ops/transform.cpp
@@ -981,6 +981,12 @@ TypePtr DeduceTileSetValidShapeType(const std::vector<ExprPtr>& args,
   // row_major / fractal=1024, a [M, 1] Vec tile is col_major, ...). Default-
   // constructing a TileView here would pin the raw row_major / none_box /
   // fractal=512 defaults onto an alias of, e.g., an Acc accumulator.
+  // The inherited `compact` is deliberately kept as-is, including for an Acc
+  // alias. This op is metadata-only and may run *after* the buffer was written,
+  // so the stride its readers must use is the one the producing `mad` already
+  // laid the bytes out at — not one derived from the new valid rows. Narrowing
+  // a fully-written accumulator here must therefore leave its non-compact
+  // reading pitch alone.
   TileView tile_view = tile_view_semantics::GetEffectiveTileView(*tile_type);
   tile_view.valid_shape = {args[1], args[2]};
 

--- a/tests/ut/codegen/test_pto_codegen_ops.py
+++ b/tests/ut/codegen/test_pto_codegen_ops.py
@@ -2640,6 +2640,190 @@ class TestSetValidShapeCodegen:
             self._generate_mlir(Prog)
 
 
+_ACC_M = 64
+_ACC_K = 128
+_ACC_N = 256
+
+# tile.assemble cases keep the accumulator small enough for the 128 KiB L0C arena.
+_ASM_M = 32
+_ASM_K = 128
+_ASM_N = 64
+
+
+@pl.program
+class AssembleNarrowedAccIntoFullWindow:
+    """A compact matmul result assembled into a *non*-narrowed Acc buffer.
+
+    The two windows address L0C at different fractal strides, so the copy is not
+    expressible as a `pto.subview`. Before #2470 both sides read as non-compact
+    and the mismatch was a silent miscompile.
+    """
+
+    @pl.function(type=pl.FunctionType.InCore)
+    def kernel(
+        self,
+        lhs: pl.Tensor[[_ASM_M, _ASM_K], pl.INT8],
+        rhs: pl.Tensor[[_ASM_K, _ASM_N], pl.INT8],
+        valid_rows: pl.Scalar[pl.INDEX],
+        output: pl.Out[pl.Tensor[[_ASM_M, 2 * _ASM_N], pl.INT32]],
+    ) -> pl.Tensor[[_ASM_M, 2 * _ASM_N], pl.INT32]:
+        lhs_tile: pl.Tile[[_ASM_M, _ASM_K], pl.INT8] = pl.load(
+            lhs,
+            [0, 0],
+            [_ASM_M, _ASM_K],
+            valid_shape=[valid_rows, _ASM_K],
+            target_memory=pl.MemorySpace.Mat,
+        )
+        rhs_tile: pl.Tile[[_ASM_K, _ASM_N], pl.INT8] = pl.load(
+            rhs, [0, 0], [_ASM_K, _ASM_N], target_memory=pl.MemorySpace.Mat
+        )
+        part: pl.Tile[[_ASM_M, _ASM_N], pl.INT32] = pl.tile.matmul(lhs_tile, rhs_tile)
+        big: pl.Tile[[_ASM_M, 2 * _ASM_N], pl.INT32] = pl.tile.create(
+            [_ASM_M, 2 * _ASM_N], pl.INT32, target_memory=pl.MemorySpace.Acc
+        )
+        joined: pl.Tile[[_ASM_M, 2 * _ASM_N], pl.INT32] = pl.tile.assemble(big, part, [0, 0])
+        return pl.store(joined, [0, 0], output)
+
+
+@pl.program
+class AssembleFullAccIntoFullWindow:
+    """The remedy the diagnostic names: compute the full tile, no narrowing."""
+
+    @pl.function(type=pl.FunctionType.InCore)
+    def kernel(
+        self,
+        lhs: pl.Tensor[[_ASM_M, _ASM_K], pl.INT8],
+        rhs: pl.Tensor[[_ASM_K, _ASM_N], pl.INT8],
+        output: pl.Out[pl.Tensor[[_ASM_M, 2 * _ASM_N], pl.INT32]],
+    ) -> pl.Tensor[[_ASM_M, 2 * _ASM_N], pl.INT32]:
+        lhs_tile: pl.Tile[[_ASM_M, _ASM_K], pl.INT8] = pl.load(
+            lhs, [0, 0], [_ASM_M, _ASM_K], target_memory=pl.MemorySpace.Mat
+        )
+        rhs_tile: pl.Tile[[_ASM_K, _ASM_N], pl.INT8] = pl.load(
+            rhs, [0, 0], [_ASM_K, _ASM_N], target_memory=pl.MemorySpace.Mat
+        )
+        part: pl.Tile[[_ASM_M, _ASM_N], pl.INT32] = pl.tile.matmul(lhs_tile, rhs_tile)
+        big: pl.Tile[[_ASM_M, 2 * _ASM_N], pl.INT32] = pl.tile.create(
+            [_ASM_M, 2 * _ASM_N], pl.INT32, target_memory=pl.MemorySpace.Acc
+        )
+        joined: pl.Tile[[_ASM_M, 2 * _ASM_N], pl.INT32] = pl.tile.assemble(big, part, [0, 0])
+        return pl.store(joined, [0, 0], output)
+
+
+@pl.program
+class MatmulAccRuntimeNarrowedRows:
+    """Issue #2470: the matmul's lhs carries a runtime valid row count."""
+
+    @pl.function(type=pl.FunctionType.InCore)
+    def kernel(
+        self,
+        lhs: pl.Tensor[[_ACC_M, _ACC_K], pl.INT8],
+        rhs: pl.Tensor[[_ACC_K, _ACC_N], pl.INT8],
+        valid_rows: pl.Scalar[pl.INDEX],
+        output: pl.Out[pl.Tensor[[_ACC_M, _ACC_N], pl.INT32]],
+    ) -> pl.Tensor[[_ACC_M, _ACC_N], pl.INT32]:
+        lhs_tile: pl.Tile[[_ACC_M, _ACC_K], pl.INT8] = pl.load(
+            lhs,
+            [0, 0],
+            [_ACC_M, _ACC_K],
+            valid_shape=[valid_rows, _ACC_K],
+            target_memory=pl.MemorySpace.Mat,
+        )
+        rhs_tile: pl.Tile[[_ACC_K, _ACC_N], pl.INT8] = pl.load(
+            rhs, [0, 0], [_ACC_K, _ACC_N], target_memory=pl.MemorySpace.Mat
+        )
+        acc_tile: pl.Tile[[_ACC_M, _ACC_N], pl.INT32] = pl.tile.matmul(lhs_tile, rhs_tile)
+        return pl.store(acc_tile, [0, 0], output)
+
+
+@pl.program
+class MatmulAccFullRows:
+    """The same reduction with no narrowing anywhere -- the control case."""
+
+    @pl.function(type=pl.FunctionType.InCore)
+    def kernel(
+        self,
+        lhs: pl.Tensor[[_ACC_M, _ACC_K], pl.INT8],
+        rhs: pl.Tensor[[_ACC_K, _ACC_N], pl.INT8],
+        output: pl.Out[pl.Tensor[[_ACC_M, _ACC_N], pl.INT32]],
+    ) -> pl.Tensor[[_ACC_M, _ACC_N], pl.INT32]:
+        lhs_tile: pl.Tile[[_ACC_M, _ACC_K], pl.INT8] = pl.load(
+            lhs, [0, 0], [_ACC_M, _ACC_K], target_memory=pl.MemorySpace.Mat
+        )
+        rhs_tile: pl.Tile[[_ACC_K, _ACC_N], pl.INT8] = pl.load(
+            rhs, [0, 0], [_ACC_K, _ACC_N], target_memory=pl.MemorySpace.Mat
+        )
+        acc_tile: pl.Tile[[_ACC_M, _ACC_N], pl.INT32] = pl.tile.matmul(lhs_tile, rhs_tile)
+        return pl.store(acc_tile, [0, 0], output)
+
+
+class TestMatmulAccCompactCodegen:
+    """Issue #2470: a runtime-narrowed accumulator must reach PTOAS as compact."""
+
+    def _generate_mlir(self, program_cls) -> str:
+        """Run PassManager and PTOCodegen on the given program, return MLIR string."""
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        optimized = PassManager.get_strategy(OptimizationStrategy.Default).run_passes(program_cls)
+        funcs = list(optimized.functions.values())
+        assert funcs, "Program has no functions"
+        single = ir.Program([funcs[0]], funcs[0].name, optimized.span)
+        return codegen.PTOCodegen().generate(single)
+
+    def test_runtime_narrowed_matmul_stores_from_a_compact_accumulator(self):
+        """The store that reads L0C must use the stride ``mad`` wrote it at.
+
+        ``mad`` takes M from the L0A operand's *valid* rows and lays the result
+        out with an N-fractal stride of ceil(M/16)*16.  ``TSTORE`` recovers that
+        stride only for a compact tile; otherwise it walks L0C at the physical
+        ``Rows``, so every N-fractal above the first came back scrambled.
+        """
+        mlir = self._generate_mlir(MatmulAccRuntimeNarrowedRows)
+
+        store_lines = [line for line in mlir.splitlines() if "pto.tstore" in line]
+        assert store_lines, f"expected a pto.tstore for the accumulator, got:\n{mlir}"
+        for line in store_lines:
+            assert re.search(r"!pto\.tile_buf<loc=acc,[^>]*compact=1>", line), (
+                "a runtime-narrowed accumulator must be stored as compact, or TSTORE reads "
+                f"L0C at the physical Rows pitch instead of ceil(validRow/16)*16;\ngot:\n{line}"
+            )
+
+        # The accumulator's own allocation must agree with the store's view, or
+        # one L0C buffer would be declared at two different strides.
+        alloc_lines = [line for line in mlir.splitlines() if "pto.alloc_tile" in line and "loc=acc" in line]
+        assert alloc_lines, f"expected an Acc pto.alloc_tile, got:\n{mlir}"
+        for line in alloc_lines:
+            assert re.search(r"!pto\.tile_buf<loc=acc,[^>]*compact=1>", line), line
+
+    def test_full_width_matmul_accumulator_stays_noncompact(self):
+        """Without narrowing, the emitted accumulator keeps its historical form."""
+        mlir = self._generate_mlir(MatmulAccFullRows)
+
+        assert not re.search(r"!pto\.tile_buf<loc=acc,[^>]*compact=1>", mlir), (
+            f"a fully valid accumulator must not be stamped compact:\n{mlir}"
+        )
+
+    def test_assembling_a_narrowed_accumulator_into_a_full_window_is_rejected(self):
+        """Two Acc windows at different L0C strides cannot share a ``pto.subview``.
+
+        Before the accumulator carried compact this compiled and silently copied
+        at the wrong pitch. Rejecting it is the fix; the message has to name the
+        user's construct and a remedy rather than ``pto.subview``'s invariant.
+        """
+        with pytest.raises(ValueError, match="L0C fractal stride") as excinfo:
+            self._generate_mlir(AssembleNarrowedAccIntoFullWindow)
+
+        assert "Drop the narrowing from the matmul operand" in str(excinfo.value), str(excinfo.value)
+
+    def test_assembling_a_full_accumulator_still_compiles(self):
+        """The remedy the diagnostic names works, and the ordinary case is untouched."""
+        mlir = self._generate_mlir(AssembleFullAccIntoFullWindow)
+
+        assert "pto.subview" in mlir, mlir
+        assert not re.search(r"!pto\.tile_buf<loc=acc,[^>]*compact=1>", mlir), mlir
+
+
 class TestMrgSortCodegen:
     """Tests for mrgsort format1 code generation with constant and variable block_len."""
 

--- a/tests/ut/ir/operators/test_mx_ops.py
+++ b/tests/ut/ir/operators/test_mx_ops.py
@@ -314,6 +314,24 @@ class TestMatmulMxTypes:
         with pytest.raises(ValueError, match="acc valid rows"):
             ir.op.tile.matmul_mx_acc(acc, *self._mx_operands(span, valid=(8, 64, 16)), span)
 
+    def test_narrowed_rows_stamp_compact_and_full_rows_do_not(self):
+        """Issue #2470: MX shares the L0C stride contract of the plain matmuls.
+
+        ``mad`` takes M from the lhs *valid* rows and lays L0C out at
+        ceil(M/16)*16, while the Acc readers key off the physical ``Rows``
+        unless the tile is compact.  All three MX ops route their output type
+        through the same deducer, so ``matmul_mx`` covers the family.
+        """
+        span = ir.Span.unknown()
+
+        narrowed = ir.op.tile.matmul_mx(*self._mx_operands(span, valid=(8, 64, 16)), span).type
+        assert isinstance(narrowed, ir.TileType)
+        assert narrowed.get_effective_tile_view().compact == ir.CompactMode.normal
+
+        full = ir.op.tile.matmul_mx(*self._mx_operands(span, valid=(16, 64, 32)), span).type
+        assert isinstance(full, ir.TileType)
+        assert full.get_effective_tile_view().compact == ir.CompactMode.null
+
     @pytest.mark.parametrize(
         ("index", "name", "shape", "dtype", "valid_shape"),
         [

--- a/tests/ut/ir/operators/test_tile_ops.py
+++ b/tests/ut/ir/operators/test_tile_ops.py
@@ -2103,6 +2103,189 @@ class TestTileMatMulOps:
         assert _const_values(matmul_acc_type.shape) == [16, 32]
         assert _valid_of(matmul_acc_type) == [16, 16]
 
+    @staticmethod
+    def _narrowable_matmul_operands(span, lhs_valid_rows):
+        """lhs [64, 128] narrowed to `lhs_valid_rows`, plus a fully valid rhs / bias."""
+
+        def dims(*values):
+            return [ir.ConstInt(value, DataType.INDEX, span) for value in values]
+
+        lhs = ir.Var(
+            "lhs",
+            ir.TileType(
+                dims(64, 128),
+                DataType.INT8,
+                tile_view=ir.TileView(valid_shape=[lhs_valid_rows, ir.ConstInt(128, DataType.INDEX, span)]),
+                memory_space=ir.MemorySpace.Left,
+            ),
+            span,
+        )
+        rhs = ir.Var(
+            "rhs",
+            ir.TileType(
+                dims(128, 256),
+                DataType.INT8,
+                tile_view=ir.TileView(valid_shape=dims(128, 256)),
+                memory_space=ir.MemorySpace.Right,
+            ),
+            span,
+        )
+        bias = ir.Var(
+            "bias",
+            ir.TileType(dims(1, 256), DataType.INT32, tile_view=ir.TileView(valid_shape=dims(1, 256))),
+            span,
+        )
+        return lhs, rhs, bias
+
+    @staticmethod
+    def _compact_of(result_type):
+        """Compact mode of a deduced tile type, narrowing ``Type`` for the checker."""
+        assert isinstance(result_type, ir.TileType)
+        return result_type.get_effective_tile_view().compact
+
+    def test_matmul_family_stamps_compact_for_runtime_narrowed_rows(self):
+        """Issue #2470: a runtime-narrowed L0C must advertise the stride ``mad`` wrote at.
+
+        ``mad`` lays the product out with an N-fractal stride of ceil(M/16)*16,
+        where M is the lhs *valid* rows, while every Acc reader keys off the
+        tile's compile-time physical ``Rows`` unless the tile is compact.  A
+        runtime row count therefore has to stamp compact — the same reasoning
+        that makes a partial ``tile.extract`` into L0A/L0B compact (#2232).
+        """
+        span = ir.Span.unknown()
+        rows = ir.Var("rows", ir.ScalarType(DataType.INDEX), span)
+        lhs, rhs, bias = self._narrowable_matmul_operands(span, rows)
+
+        matmul_type = tile.matmul(lhs, rhs).type
+        assert isinstance(matmul_type, ir.TileType)
+        assert _valid_of(matmul_type) == [rows, 256]
+        assert self._compact_of(matmul_type) == ir.CompactMode.normal
+
+        # The accumulate step reuses the accumulator's storage, so it must reach
+        # the same compact mode or the two views of one L0C buffer disagree.
+        acc = ir.Var("acc", matmul_type, span)
+        assert self._compact_of(tile.matmul_acc(acc, lhs, rhs).type) == ir.CompactMode.normal
+        assert self._compact_of(tile.matmul_bias(lhs, rhs, bias).type) == ir.CompactMode.normal
+
+    def test_matmul_full_rows_stay_noncompact(self):
+        """A fully valid accumulator keeps its historical non-compact form."""
+        span = ir.Span.unknown()
+        lhs, rhs, bias = self._narrowable_matmul_operands(span, ir.ConstInt(64, DataType.INDEX, span))
+
+        matmul_type = tile.matmul(lhs, rhs).type
+        assert self._compact_of(matmul_type) == ir.CompactMode.null
+
+        acc = ir.Var("acc", matmul_type, span)
+        assert self._compact_of(tile.matmul_acc(acc, lhs, rhs).type) == ir.CompactMode.null
+        assert self._compact_of(tile.matmul_bias(lhs, rhs, bias).type) == ir.CompactMode.null
+
+    def test_matmul_narrowed_columns_alone_stay_noncompact(self):
+        """Only the row extent moves the Acc stride, so a narrow N changes nothing.
+
+        Every Acc stride the ISA derives is a function of ``validRow`` alone; a
+        narrowed column extent leaves writer and reader in agreement.
+        """
+        span = ir.Span.unknown()
+
+        def dims(*values):
+            return [ir.ConstInt(value, DataType.INDEX, span) for value in values]
+
+        lhs = ir.Var(
+            "lhs",
+            ir.TileType(
+                dims(64, 128),
+                DataType.INT8,
+                tile_view=ir.TileView(valid_shape=dims(64, 128)),
+                memory_space=ir.MemorySpace.Left,
+            ),
+            span,
+        )
+        rhs = ir.Var(
+            "rhs",
+            ir.TileType(
+                dims(128, 256),
+                DataType.INT8,
+                tile_view=ir.TileView(valid_shape=dims(128, 240)),
+                memory_space=ir.MemorySpace.Right,
+            ),
+            span,
+        )
+
+        matmul_type = tile.matmul(lhs, rhs).type
+        assert _valid_of(matmul_type) == [64, 240]
+        assert self._compact_of(matmul_type) == ir.CompactMode.null
+
+    def test_set_validshape_keeps_the_stride_an_accumulator_was_written_at(self):
+        """Narrowing an already-written accumulator must not re-interpret its bytes.
+
+        ``tile.set_validshape`` is a metadata-only alias that may run *after*
+        the buffer was filled. A full-width ``tile.matmul`` lays L0C out at the
+        physical row pitch, so deriving compact from the *new* valid rows here
+        would make every later reader walk those same bytes at
+        ``ceil(16/16)*16`` instead — silently corrupting them. The op inherits
+        the source's compact mode and nothing else.
+        """
+        span = ir.Span.unknown()
+        lhs, rhs, _ = self._narrowable_matmul_operands(span, ir.ConstInt(64, DataType.INDEX, span))
+        written = tile.matmul(lhs, rhs).type
+        assert self._compact_of(written) == ir.CompactMode.null
+
+        narrowed = tile.set_validshape(ir.Var("acc", written, span), 16, 256).type
+        assert _valid_of(narrowed) == [16, 256]
+        assert self._compact_of(narrowed) == ir.CompactMode.null
+
+    def test_set_validshape_carries_a_compact_accumulator_through(self):
+        """A compact accumulator stays compact when its valid window moves."""
+        span = ir.Span.unknown()
+        rows = ir.Var("rows", ir.ScalarType(DataType.INDEX), span)
+        lhs, rhs, _ = self._narrowable_matmul_operands(span, rows)
+        written = tile.matmul(lhs, rhs).type
+        assert self._compact_of(written) == ir.CompactMode.normal
+
+        narrowed = tile.set_validshape(ir.Var("acc", written, span), rows, 256).type
+        assert self._compact_of(narrowed) == ir.CompactMode.normal
+
+    def test_matmul_acc_inherits_the_accumulator_compact_mode(self):
+        """The in-place result must describe its buffer exactly as the input does.
+
+        ``tile.matmul_acc`` is ``set_output_reuses_input(0)``; codegen only
+        aliases result and accumulator when their ``TileBufSignature`` — compact
+        included — matches, so the result inherits rather than re-derives.
+        """
+        span = ir.Span.unknown()
+        rows = ir.Var("rows", ir.ScalarType(DataType.INDEX), span)
+        lhs, rhs, _ = self._narrowable_matmul_operands(span, rows)
+
+        # A non-compact accumulator stays non-compact even beside a narrowed lhs.
+        plain_acc = ir.TileType(
+            [ir.ConstInt(64, DataType.INDEX, span), ir.ConstInt(256, DataType.INDEX, span)],
+            DataType.INT32,
+            tile_view=ir.TileView(
+                valid_shape=[rows, ir.ConstInt(256, DataType.INDEX, span)],
+            ),
+            memory_space=ir.MemorySpace.Acc,
+        )
+        result = tile.matmul_acc(ir.Var("acc", plain_acc, span), lhs, rhs).type
+        assert self._compact_of(result) == ir.CompactMode.null
+
+    def test_set_validshape_leaves_non_accumulator_tiles_noncompact(self):
+        """A narrowed Vec tile has no L0C stride contract to preserve."""
+        span = ir.Span.unknown()
+        rows = ir.Var("rows", ir.ScalarType(DataType.INDEX), span)
+        vec = ir.Var(
+            "vec",
+            ir.TileType(
+                [ir.ConstInt(64, DataType.INDEX, span), ir.ConstInt(256, DataType.INDEX, span)],
+                DataType.FP32,
+                memory_space=ir.MemorySpace.Vec,
+            ),
+            span,
+        )
+
+        narrowed = tile.set_validshape(vec, rows, 256).type
+        assert _valid_of(narrowed) == [rows, 256]
+        assert self._compact_of(narrowed) == ir.CompactMode.null
+
     def test_matmul_rejects_mismatched_physical_k_with_matching_valid_k(self):
         """Logical K agreement does not make incompatible physical boxes legal."""
         span = ir.Span.unknown()


### PR DESCRIPTION
## Summary

A `pl.matmul` / `pl.matmul_acc` chain whose left operand carries a **runtime**
`valid_shape` row count silently returned wrong data for the rows that *were*
valid (issue #2470). `mad` and every L0C reader disagreed about the
accumulator's fractal stride, with no compile diagnostic and no runtime error.

**Writer.** `TMATMUL_IMPL` takes M from the L0A operand's *valid* rows and
passes it straight to `mad`, which lays the result out in L0C with an N-fractal
stride of `ceil(M/16)*16`. Nothing on that path consults the destination's
`Rows` (pto-isa `TMatmul.hpp`, a2a3 and a5 alike: `uint16_t m = aMatrix.GetValidRow()`).

**Reader.** `TStoreAccNz2nd` and its siblings use the tile's *compile-time
physical* `Rows`, switching to `ceil(validRow/16)*16` only for a compact tile
(`tstore_common.hpp`).

With a 64-row box and 16 valid rows that is a factor-4 skew: the store's
N-fractal `j` picks up the matmul's N-fractal `4j`, so only `j = 0` survived —
matching the reported 2048-correct / 30720-wrong split. The Acc `TileType`
deducers built their `TileView` with a narrowed `valid_shape` but left `compact`
at its `null` default. `tile.extract` gained the same stamping for L0A/L0B in
#2232; L0C never did.

After this change the emitted `pto.tstore` and the Acc `pto.alloc_tile` both
carry `compact=1` for a runtime-narrowed matmul, so the reader walks L0C at the
pitch `mad` wrote it at. A fully valid accumulator is byte-identical to before.

## Changes

- `include/pypto/ir/type_inference.h`: new `StampCompactForNarrowedAccRows`,
  which sets `CompactMode::normal` when the Acc valid rows are not *provably*
  equal to the physical rows. Only the row extent decides this — every Acc
  stride the ISA derives is a function of `validRow` alone, so a narrowed
  column extent leaves writer and reader in agreement and keeps the historical
  non-compact form.
- `src/ir/op/tile_ops/matmul.cpp`: `tile.matmul` and `tile.matmul_bias` derive
  it; `tile.matmul_acc` **inherits** its accumulator operand's mode.
- `src/ir/op/tile_ops/matmul_mx.cpp`: derive in `DeduceTileMatMulMxType`, which
  all three of `tile.matmul_mx{,_acc,_bias}` route their output type through.
  A5 shares the contract exactly — its `TMatmul.hpp` also takes
  `aMatrix.GetValidRow()`, and its `TStoreAcc*` honour `CompactMode::Normal`.
- `src/backend/common/pto_ops_shared.cpp`: a `tile.assemble` between two Acc
  windows that disagree on compact is now reported in the user's terms with a
  remedy, instead of as `pto.subview`'s internal invariant. That shape
  previously compiled and copied at the wrong pitch — the same defect on the
  Acc→Acc path.

Compact is stamped **only where an accumulator's layout is established**, and
inherited everywhere that merely aliases it. `tile.matmul_acc` is
`set_output_reuses_input(0)` — codegen aliases result and operand only when
their `TileBufSignature` (compact included) matches, so inheriting keeps the
in-place accumulation legal by construction. `tile.set_validshape` likewise
inherits, unchanged from `main`: it is metadata-only and may run *after* the
buffer was written, so the pitch its readers must use is the one `mad` already
wrote at.
- `docs/{en,zh}/dev/codegen/00-pto_codegen.md`: document both automatic
  `normal(1)` paths and the remaining Acc→L1 gap.
- Tests, see below.

Deliberately untouched: `batch_matmul` sets `valid_shape = output_shape` so the
predicate can never fire, and the `gemv` family rebuilds its own view in
`BuildGemvResultType` (valid rows 1, physical 16), where the stamp is
numerically a no-op.

## Behavior change

Programs that were silently miscompiled now either produce correct data or, for
the Acc→Acc `tile.assemble` shape above, fail at compile time with a message
naming the remedy. No API or signature changes.

## Not fixed here

The Acc → L1 readers (`TExtractAccToMat`, `TMovCcToCb`) have no `CompactMode`
branch in pto-isa on either a2a3 or a5, so a runtime-narrowed accumulator
consumed by `tile.extract` / `tile.move` into L1 still reads at the physical
`Rows` pitch. That needs a matching pto-isa change; this PR does not make it
worse, and both docs say so.

`tile.matmul_acc` also still accepts an accumulator whose valid rows are
*wider* than its lhs (`lhs_valid_M <= acc_valid_M`), which produces the same
class of stride disagreement on a different axis and is not fixable by stamping
— a compact tile recomputes its stride from its own `validRow`. The MX family
is immune because `DeduceTileMatMulMxAccType` enforces equality. Left for a
separate change.

## Tests

- `tests/ut/ir/operators/test_tile_ops.py`, `test_mx_ops.py`: narrowed rows
  stamp compact for `tile.matmul`, `matmul_bias`, and MX; full rows and
  column-only narrowing stay non-compact; `matmul_acc` inherits its
  accumulator's mode; and `set_validshape` neither invents nor drops compact —
  narrowing an already-written full-width accumulator keeps its physical pitch.
- `tests/ut/codegen/test_pto_codegen_ops.py`: the emitted `pto.tstore` and the
  Acc `pto.alloc_tile` both carry `compact=1` for a runtime-narrowed matmul and
  neither does without narrowing; the rejected `tile.assemble` names its
  remedy, and that remedy compiles.

## Verification

Run on a linked worktree with the branch rebased onto the current `origin/main`, Ascend910B backend, `PYPTO_VERIFY_LEVEL=roundtrip` per-pass
verification from the UT conftest.

- `cmake --build build --parallel 32`: exit 0, no warnings.
- `pytest tests/ut/ tests/lint/ -n 16 -q`: **10223 passed, 8 skipped, 1 failed.**
  The one failure is
  `tests/ut/language/test_unified_ops.py::TestUnifiedSlicePadValue::test_symlinked_import_path_still_names_the_caller`,
  which is an artifact of this machine's editable install hijacking
  `import pypto` (`AssertionError: import bypassed the symlink`). It reproduces
  on an unmodified checkout and is unrelated to this change.
- `pytest tests/st/codegen/dsl --codegen-only -n 16 -q`: 25 passed.
- `clang-format --dry-run --Werror` on all five changed C++ files: clean.
- `ruff format --check` and `ruff check` with the project's settings on the
  three changed test files: clean (the only `ruff check` findings are on
  pre-existing lines, none on lines this PR adds).
- `pyright` on the three changed test files: 0 errors, 0 warnings.

Not run: on-device execution. The issue's reproducer needs pypto-lib's `golden`
harness and an a2a3 device; the reporter already verified on hardware that
rewriting `CompactMode::Null` to `CompactMode::Normal` on the generated Acc
tiles turns the FAIL into a PASS, and this change makes the compiler emit
exactly that.
