### PR TITLE
test(st): run every system test on the platform it was asked for

### DIFF
--- a/tests/st/README.md
+++ b/tests/st/README.md
@@ -85,10 +85,6 @@ not expanded — that fixture is built once and shared by every item in its
 scope, so it cannot hold one artefact per platform. Such a test runs on the
 first `--platform` id its `@pytest.mark.platforms` marker allows.
 
-A test taking `backend_type` (there is no fixture of that name — the matrix
-supplies it) gets it paired with the platform in a single parametrize, so the
-backend a case compiles for and the toolchain it runs on can never disagree.
-
 A single active platform is *not* parametrized, so `--platform=a2a3` keeps the
 plain node ids; naming two or more grows the familiar `[a2a3]` / `[a5]`
 suffixes.
@@ -151,18 +147,18 @@ expression nobody can trace back.
 run the case (the feature does not exist on that arch) and `platform_xfail`
 when it *ought to* and does not yet.
 
-#### Cases that pin an architecture
+#### The platform is the only architecture knob
 
-A `PTOTestCase` subclass that redefines `get_backend_type()` pins its backend,
-while the toolchain that assembles and executes the artefact follows the
-platform — so such a case cannot honour a platform of the other architecture.
-The harness detects this before compiling and **skips** the case with a reason
-naming the conflict, instead of compiling for one architecture and executing on
-the other. Make the case arch-agnostic by dropping the override (the platform
-then decides the backend), or state the limitation with
-`@pytest.mark.platforms(...)` so the variant is never generated. The legacy
-`PTOTestCase(backend_type=...)` constructor argument pins the backend the same
-way and is treated the same.
+A test case has no backend of its own. Codegen's backend is derived from the
+resolved platform (`platform_to_backend`) at every compile site, so an artefact
+can never be built for one architecture and executed on another. There is no
+`get_backend_type()` on `PTOTestCase` and no `backend_type=` constructor
+argument; a case that still defines the former fails loudly rather than being
+quietly ignored.
+
+To say that a case genuinely cannot run on an architecture, restrict its tests
+with `@pytest.mark.platforms(..., reason=...)` — the limitation belongs to the
+test, not to a backend field on the case.
 
 ### Verbose Output
 

--- a/tests/st/README.md
+++ b/tests/st/README.md
@@ -74,11 +74,20 @@ pytest tests/st/runtime/ops/test_matmul.py::TestMatmulOperations::test_matmul_sh
 
 ### Platform Selection
 
-Every test that uses the `test_runner` fixture runs on the platforms named
+Every test that takes the `test_runner` fixture runs on the platforms named
 by `--platform`, without declaring anything: the platform matrix expands the
 test over the active allowlist and binds each variant's platform to the case
 it builds. `--platform` accepts a comma-separated subset of `a2a3`, `a5`,
 `a2a3sim`, `a5sim` and defaults to `a2a3` (matching legacy on-NPU CI).
+
+A test that reaches the runner through a module- or session-scoped fixture is
+not expanded — that fixture is built once and shared by every item in its
+scope, so it cannot hold one artefact per platform. Such a test runs on the
+first `--platform` id its `@pytest.mark.platforms` marker allows.
+
+A test taking `backend_type` (there is no fixture of that name — the matrix
+supplies it) gets it paired with the platform in a single parametrize, so the
+backend a case compiles for and the toolchain it runs on can never disagree.
 
 A single active platform is *not* parametrized, so `--platform=a2a3` keeps the
 plain node ids; naming two or more grows the familiar `[a2a3]` / `[a5]`
@@ -151,7 +160,9 @@ The harness detects this before compiling and **skips** the case with a reason
 naming the conflict, instead of compiling for one architecture and executing on
 the other. Make the case arch-agnostic by dropping the override (the platform
 then decides the backend), or state the limitation with
-`@pytest.mark.platforms(...)` so the variant is never generated.
+`@pytest.mark.platforms(...)` so the variant is never generated. The legacy
+`PTOTestCase(backend_type=...)` constructor argument pins the backend the same
+way and is treated the same.
 
 ### Verbose Output
 
@@ -459,7 +470,7 @@ Use pytest markers to categorize or restrict tests:
 # Restrict a test (or a whole class) to a subset of platforms.  The
 # intersection with the --platform CLI filter decides which variants run.
 @pytest.mark.platforms("a5", "a5sim", reason="uses an Ascend 950 only operand")
-def test_ascend950_specific(test_runner, platform):
+def test_ascend950_specific(test_runner):
     ...
 
 # Expect a failure on one platform without dropping the case from the run.

--- a/tests/st/README.md
+++ b/tests/st/README.md
@@ -74,11 +74,20 @@ pytest tests/st/runtime/ops/test_matmul.py::TestMatmulOperations::test_matmul_sh
 
 ### Platform Selection
 
-Each runtime test case is automatically parametrized over four target
-platforms: `a2a3`, `a5`, `a2a3sim`, `a5sim`. The `--platform` CLI option acts
-as a **filter** that selects which subset is actually executed (it accepts a
-comma-separated list and defaults to `a2a3` when omitted, matching the
-legacy on-NPU CI behaviour).
+Every test that uses the `test_runner` fixture runs on the platforms named
+by `--platform`, without declaring anything: the platform matrix expands the
+test over the active allowlist and binds each variant's platform to the case
+it builds. `--platform` accepts a comma-separated subset of `a2a3`, `a5`,
+`a2a3sim`, `a5sim` and defaults to `a2a3` (matching legacy on-NPU CI).
+
+A single active platform is *not* parametrized, so `--platform=a2a3` keeps the
+plain node ids; naming two or more grows the familiar `[a2a3]` / `[a5]`
+suffixes.
+
+Keep `--forked` when a run spans both architectures: a single process that
+executes on `a2a3*` and `a5*` simulators through the pre-compile pipeline
+segfaults while cleaning up at session end (pre-existing; every test still
+passes first).
 
 ```bash
 # Default: run a2a3 only (matches legacy CI; requires Ascend 910B hardware)
@@ -102,8 +111,47 @@ pytest tests/st/ -v --forked --platform=a2a3sim,a5sim,a2a3
 
 A test case can additionally restrict itself to a subset of platforms via the
 ``@pytest.mark.platforms(...)`` marker, e.g. ``@pytest.mark.platforms("a5",
-"a5sim")`` to mark a test as Ascend 950 only. The intersection of the CLI
-filter and the per-test whitelist determines which variants actually run.
+"a5sim", reason="...")`` to mark a test as Ascend 950 only. The intersection of
+the CLI filter and the per-test whitelist determines which variants actually
+run. Always pass `reason=` — it is the only record of *why* the case is
+restricted. An unknown platform id in either marker fails collection instead of
+quietly deselecting the test everywhere.
+
+#### Expected failures on one platform
+
+A case that runs everywhere but is known to fail on one platform belongs in
+`@pytest.mark.platform_xfail(...)`, not in a CI `-k` exclusion:
+
+```python
+@pytest.mark.platform_xfail(
+    "a5",
+    reason="950 board: manual pl.tpush_to_aic gets no V->C fractal adapter",
+)
+def test_multiple_pipes(self, test_runner):
+    ...
+```
+
+The case still runs on every platform, so the day the underlying fix lands the
+run reports an XPASS (the marker is strict by default) instead of the verdict
+staying frozen. Pass `strict=False` only for a genuinely flaky failure. This is
+what keeps a guard job's command a plain directory: a newly-evaluated failure
+gets a marker with a reason next to the test, rather than a name in a `-k`
+expression nobody can trace back.
+
+`platforms` vs `platform_xfail`: use `platforms` when the platform *cannot*
+run the case (the feature does not exist on that arch) and `platform_xfail`
+when it *ought to* and does not yet.
+
+#### Cases that pin an architecture
+
+A `PTOTestCase` subclass that redefines `get_backend_type()` pins its backend,
+while the toolchain that assembles and executes the artefact follows the
+platform — so such a case cannot honour a platform of the other architecture.
+The harness detects this before compiling and **skips** the case with a reason
+naming the conflict, instead of compiling for one architecture and executing on
+the other. Make the case arch-agnostic by dropping the override (the platform
+then decides the backend), or state the limitation with
+`@pytest.mark.platforms(...)` so the variant is never generated.
 
 ### Verbose Output
 
@@ -399,7 +447,7 @@ Refer to existing tests for more examples:
 The [`conftest.py`](conftest.py) provides useful fixtures:
 
 - `test_config`: Session-scoped `RunConfig` built from CLI options
-- `test_runner`: Session-scoped `TestRunner` (reused across tests, caches compiled binaries)
+- `test_runner`: `TestRunner` bound to this item's platform (the compile cache it consults is process-wide, so per-item instances still share compiled binaries)
 - `optimization_strategy`: Current optimization strategy string from `--strategy`
 - `tensor_shape`: Parameterized fixture yielding standard shapes `(64,64)`, `(128,128)`, `(256,256)`
 
@@ -410,8 +458,13 @@ Use pytest markers to categorize or restrict tests:
 ```python
 # Restrict a test (or a whole class) to a subset of platforms.  The
 # intersection with the --platform CLI filter decides which variants run.
-@pytest.mark.platforms("a5", "a5sim")
+@pytest.mark.platforms("a5", "a5sim", reason="uses an Ascend 950 only operand")
 def test_ascend950_specific(test_runner, platform):
+    ...
+
+# Expect a failure on one platform without dropping the case from the run.
+@pytest.mark.platform_xfail("a5", reason="950 layout mismatch, see #1234")
+def test_runs_everywhere_fails_on_950(test_runner):
     ...
 
 @pytest.mark.slow  # Long-running test
@@ -419,9 +472,11 @@ def test_large_model(test_runner):
     ...
 ```
 
-To make a single test run on every supported platform, parametrize it with
-the canonical ``PLATFORMS`` list and accept a ``platform`` argument that you
-forward to your ``PTOTestCase`` subclass:
+Declaring ``platform`` yourself is only needed when the **test body** uses the
+value — to vary a dtype, a tolerance, or which case class to build. Parametrize
+it with the canonical ``PLATFORMS`` list (or a narrower one) and forward it to
+your ``PTOTestCase`` subclass; an explicit ``platform`` parametrize always wins
+over the automatic expansion:
 
 ```python
 from harness.core.harness import PLATFORMS

--- a/tests/st/conftest.py
+++ b/tests/st/conftest.py
@@ -43,11 +43,7 @@ from harness.core.environment import (  # noqa: E402
     get_simpler_python_path,
     get_simpler_scripts_path,
 )
-from harness.core.harness import (  # noqa: E402
-    ALL_PLATFORM_IDS,
-    PTOTestCase,
-    platform_to_backend,
-)
+from harness.core.harness import ALL_PLATFORM_IDS, PTOTestCase  # noqa: E402
 from harness.core.test_runner import (  # noqa: E402
     TestRunner,
     _cache_key,
@@ -542,9 +538,8 @@ def _resolve_item_platform(node: pytest.Item | pytest.FixtureRequest, config: py
         1. An explicit ``platform`` parametrize on the test itself.
         2. The value injected by :func:`pytest_generate_tests` (the platform
            matrix), for tests that never mention ``platform``.
-        3. The first ``--platform`` id, matching the legacy single-platform
-           behaviour — this is also what a module-level generator such as
-           ``tests/st/runtime/cross_core/`` resolves its ``backend_type`` from.
+        3. The first ``--platform`` id its ``@pytest.mark.platforms`` marker
+           allows, matching the legacy single-platform behaviour.
 
     Args:
         node: The item (or a request pointing at one) whose platform is wanted.
@@ -751,11 +746,6 @@ def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
     with its ``@pytest.mark.platforms``, so a case joins a new platform's guard
     job without touching its test body.
 
-    A test taking ``backend_type`` gets it paired with the platform in one
-    parametrize, so the backend it compiles for and the toolchain it runs on
-    can never disagree. That name has no fixture of its own — this is where it
-    comes from — so it is emitted even for a single active platform.
-
     The test must take ``test_runner`` itself. A test that reaches the runner
     through a module- or session-scoped fixture cannot vary per item — that
     fixture is built once and shared — so expanding it would hand every variant
@@ -782,14 +772,6 @@ def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
     # pytest_collection_modifyitems, which deselects them; parametrizing an
     # empty list would instead leave one item behind marked "empty parameter set".
     allowed = [p for p in cli if item_filter is None or p in item_filter] or cli
-    if "backend_type" in direct:
-        metafunc.parametrize(
-            "_st_platform,backend_type",
-            [(p, platform_to_backend(p)) for p in allowed],
-            ids=list(allowed),
-            indirect=["_st_platform"],
-        )
-        return
     if len(cli) > 1:
         metafunc.parametrize("_st_platform", allowed, ids=list(allowed), indirect=True)
 
@@ -938,6 +920,7 @@ def _collect_test_case_from_item(
     item: pytest.Item,
     seen: dict[str, PTOTestCase],
     session_memory_planner: MemoryPlanner | None,
+    session_platform: str,
 ) -> None:
     """Inspect *item* and add any discovered PTOTestCase instances to *seen*.
 
@@ -1012,10 +995,10 @@ def _collect_test_case_from_item(
             continue
         # Bind the item's platform so each matrix variant compiles its own
         # artefact; without this the variants share one cache key and only the
-        # first platform is ever built.
-        platform = params.get("platform") or params.get("_st_platform")
-        if platform:
-            instance.bind_platform(platform)
+        # first platform is ever built. An item the matrix did not expand runs
+        # on the session platform, which is what the pipeline resolves for it.
+        platform = params.get("platform") or params.get("_st_platform") or session_platform
+        instance.bind_platform(platform)
         seen.setdefault(_cache_key(instance, platform, session_memory_planner), instance)
 
 
@@ -1039,10 +1022,12 @@ def pytest_collection_finish(session: pytest.Session) -> None:
 
     # ── discover PTOTestCase instances ───────────────────────────────────────
     session_memory_planner = _parse_memory_planner(session.config.getoption("--memory-planner"))
+    platform_filter = _parse_platform_filter(session.config.getoption("--platform"))
+    session_platform: str = platform_filter[0] if platform_filter else "a2a3"
     seen: dict[str, PTOTestCase] = {}  # effective cache_key → instance (deduped)
 
     for item in session.items:
-        _collect_test_case_from_item(item, seen, session_memory_planner)
+        _collect_test_case_from_item(item, seen, session_memory_planner, session_platform)
 
     # Read the task-submit / pipeline options *before* the empty-discovery guard:
     # a suite that only creates PTOTestCases dynamically leaves ``seen`` empty yet
@@ -1132,11 +1117,6 @@ def pytest_collection_finish(session: pytest.Session) -> None:
     else:
         cache_dir = Path(tempfile.mkdtemp(prefix="pypto_precompile_"))
         _temp_precompile_dirs.append(cache_dir)
-
-    # ``--platform`` is a CSV allowlist; the per-test value resolved by
-    # ``tc.get_platform()`` overrides this fallback inside the pipeline.
-    platform_filter = _parse_platform_filter(session.config.getoption("--platform"))
-    session_platform: str = platform_filter[0] if platform_filter else "a2a3"
 
     # Build the device pool from --device.  N parallel executes max.
     devices = _parse_device_option(session.config.getoption("--device"))

--- a/tests/st/conftest.py
+++ b/tests/st/conftest.py
@@ -24,6 +24,7 @@ import textwrap
 import warnings
 from collections import Counter
 from contextlib import nullcontext
+from dataclasses import replace
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -114,11 +115,13 @@ def pytest_addoption(parser):
         action="store",
         default="a2a3",
         help=(
-            "Comma-separated allowlist of target platforms; each test under "
-            "tests/st/runtime/ is parametrized over a2a3, a5, a2a3sim, a5sim "
-            "and only variants whose id appears here are run "
-            "(default: a2a3, matching legacy CI behaviour). Legacy "
-            "non-parametrized tests inherit this value as their platform."
+            "Comma-separated allowlist of target platforms out of a2a3, a5, "
+            "a2a3sim, a5sim (default: a2a3, matching legacy CI behaviour). "
+            "Every test using the test_runner fixture is expanded over this "
+            "list, intersected with its @pytest.mark.platforms marker; tests "
+            "that parametrize `platform` themselves keep their own list and "
+            "only the variants named here run. A single active platform is not "
+            "parametrized, so node ids stay unsuffixed."
         ),
     )
     parser.addoption(
@@ -528,13 +531,81 @@ def device_ids(request) -> list[int]:
     return _parse_device_option(request.config.getoption("--device"))
 
 
-@pytest.fixture(scope="session")
-def test_runner(test_config) -> TestRunner:
-    """Session-scoped fixture providing a test runner instance.
+def _resolve_item_platform(node: pytest.Item | pytest.FixtureRequest, config: pytest.Config) -> str:
+    """Return the platform *node* runs on.
 
-    Session scope is used because the same runner can be reused across all tests.
+    Resolution order:
+        1. An explicit ``platform`` parametrize on the test itself.
+        2. The value injected by :func:`pytest_generate_tests` (the platform
+           matrix), for tests that never mention ``platform``.
+        3. The first ``--platform`` id, matching the legacy single-platform
+           behaviour — this is also what a module-level generator such as
+           ``tests/st/runtime/cross_core/`` resolves its ``backend_type`` from.
+
+    Args:
+        node: The item (or a request pointing at one) whose platform is wanted.
+        config: The session config, read for the ``--platform`` fallback.
+
+    Returns:
+        One of :data:`ALL_PLATFORM_IDS`.
     """
-    return TestRunner(test_config)
+    callspec = getattr(node, "callspec", None)
+    params = callspec.params if callspec else {}
+    resolved = params.get("platform") or params.get("_st_platform")
+    if resolved:
+        return resolved
+    cli = _parse_platform_filter(config.getoption("--platform"))
+    return cli[0] if cli else "a2a3"
+
+
+def _marker_platforms(marker: pytest.Mark, marker_name: str, test_name: str) -> set[str]:
+    """Return the platform ids a ``platforms`` / ``platform_xfail`` marker names.
+
+    A typo used to narrow the marker's id set silently: the unknown id matched
+    no platform, so the test was deselected everywhere and looked like it had
+    simply never been written. Fail collection instead.
+
+    Args:
+        marker: The marker to read.
+        marker_name: Its name, for the error message.
+        test_name: The test carrying it, for the error message.
+
+    Returns:
+        The validated platform ids.
+
+    Raises:
+        pytest.UsageError: The marker names no platform, or an unknown one.
+    """
+    unknown = [arg for arg in marker.args if arg not in ALL_PLATFORM_IDS]
+    if not marker.args or unknown:
+        detail = f"unknown platform id(s) {unknown}" if unknown else "no platform ids"
+        raise pytest.UsageError(
+            f"@pytest.mark.{marker_name} on {test_name} has {detail}; "
+            f"expected one or more of: {', '.join(ALL_PLATFORM_IDS)}"
+        )
+    return set(marker.args)
+
+
+@pytest.fixture
+def _st_platform(request) -> str:
+    """Return the platform this item runs on (see :func:`_resolve_item_platform`)."""
+    return _resolve_item_platform(request.node, request.config)
+
+
+@pytest.fixture
+def test_runner(test_config, _st_platform) -> TestRunner:
+    """Return a runner bound to this item's platform.
+
+    Function-scoped rather than session-scoped: one item may run on ``a2a3``
+    and the next on ``a5`` within the same session, and ``RunConfig.platform``
+    is what the runner falls back to for cases that do not pin a platform
+    themselves. The pipeline state a runner consults (compile futures, batches)
+    lives at module level in ``harness.core.test_runner``, so per-item runner
+    instances share it.
+    """
+    if _st_platform == test_config.platform:
+        return TestRunner(test_config)
+    return TestRunner(replace(test_config, platform=_st_platform))
 
 
 @pytest.fixture
@@ -562,8 +633,17 @@ def pytest_configure(config):
     """Register custom markers and apply early runtime settings."""
     config.addinivalue_line(
         "markers",
-        "platforms(*ids): restrict the test to the given platform ids "
-        "(intersected with the --platform CLI filter)",
+        "platforms(*ids, reason=...): restrict the test to the given platform ids "
+        "(intersected with the --platform CLI filter). State why in reason= — it "
+        "is the only record of whether the case is limited by the platform or "
+        "waiting on a fix.",
+    )
+    config.addinivalue_line(
+        "markers",
+        "platform_xfail(*ids, reason=..., strict=True): expect failure on the "
+        "given platforms. The case still runs, so an XPASS reports the fix "
+        "instead of freezing the verdict; prefer this over excluding the case "
+        "from a guard job with -k.",
     )
     config.addinivalue_line("markers", "slow: mark test as slow")
     config.addinivalue_line(
@@ -631,6 +711,63 @@ def pytest_itemcollected(item):
         item.add_marker("device_batch")
 
 
+def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
+    """Expand ``test_runner``-based tests over the active platform allowlist.
+
+    A test that declares ``platform`` itself keeps its own parametrize, and one
+    that requests ``backend_type`` is left to the module-level
+    ``pytest_generate_tests`` that owns its arch selection (see
+    ``tests/st/runtime/cross_core/``). Everything else is expanded over the
+    ``--platform`` allowlist intersected with its ``@pytest.mark.platforms``,
+    so a case joins a new platform's guard job without touching its test body.
+
+    Expansion only happens when more than one platform is active: a plain
+    ``--platform=a2a3`` run keeps today's node ids, and only a multi-platform
+    invocation grows the ``[a2a3]`` / ``[a5]`` suffixes.
+    """
+    if "test_runner" not in metafunc.fixturenames:
+        return
+    if "platform" in metafunc.fixturenames or "backend_type" in metafunc.fixturenames:
+        return
+    cli = _parse_platform_filter(metafunc.config.getoption("--platform")) or ALL_PLATFORM_IDS
+    marker = metafunc.definition.get_closest_marker("platforms")
+    item_filter = (
+        _marker_platforms(marker, "platforms", metafunc.definition.name) if marker is not None else None
+    )
+    allowed = [p for p in cli if item_filter is None or p in item_filter]
+    if len(allowed) > 1:
+        metafunc.parametrize("_st_platform", allowed, ids=list(allowed), indirect=True)
+
+
+def pytest_runtest_setup(item: pytest.Item) -> None:
+    """Apply ``@pytest.mark.platform_xfail`` to the platform this item runs on.
+
+    A platform-conditional expectation cannot be spelled with a plain
+    ``xfail``, and raising ``pytest.xfail()`` inside the body aborts before the
+    test runs, so a later fix can never surface as an XPASS. Attaching the
+    marker here keeps the case running on every platform and reports the fix
+    the moment it lands.
+
+    Args:
+        item: The item about to run.
+
+    Raises:
+        pytest.UsageError: The marker names no/unknown platforms, or no reason.
+    """
+    marker = item.get_closest_marker("platform_xfail")
+    if marker is None:
+        return
+    platforms = _marker_platforms(marker, "platform_xfail", item.name)
+    reason = marker.kwargs.get("reason")
+    if not reason:
+        raise pytest.UsageError(
+            f"@pytest.mark.platform_xfail on {item.name} needs reason=... — an "
+            "unexplained expected failure cannot be told apart from a stale one."
+        )
+    if _resolve_item_platform(item, item.config) in platforms:
+        item.add_marker(pytest.mark.xfail(reason=reason, strict=marker.kwargs.get("strict", True)))
+
+
 def pytest_collection_modifyitems(config, items):
     """Deselect items that fall outside the active platform allowlist.
 
@@ -656,14 +793,14 @@ def pytest_collection_modifyitems(config, items):
     for item in items:
         item_marker = next(item.iter_markers(name="platforms"), None)
         if item_marker is not None:
-            item_filter = {p for p in item_marker.args if p in canonical}
+            item_filter = _marker_platforms(item_marker, "platforms", item.name)
         else:
             item_filter = canonical
         allowed = cli_filter & item_filter
 
         callspec = getattr(item, "callspec", None)
         params = callspec.params if callspec else {}
-        platform_param = params.get("platform")
+        platform_param = params.get("platform") or params.get("_st_platform")
 
         if platform_param is not None:
             if platform_param in allowed:
@@ -802,7 +939,13 @@ def _collect_test_case_from_item(
         except Exception:
             # _Unresolvable arg, or a constructor mismatch — leave for inline.
             continue
-        seen.setdefault(_cache_key(instance, session_memory_planner=session_memory_planner), instance)
+        # Bind the item's platform so each matrix variant compiles its own
+        # artefact; without this the variants share one cache key and only the
+        # first platform is ever built.
+        platform = params.get("platform") or params.get("_st_platform")
+        if platform:
+            instance.bind_platform(platform)
+        seen.setdefault(_cache_key(instance, platform, session_memory_planner), instance)
 
 
 def pytest_collection_finish(session: pytest.Session) -> None:

--- a/tests/st/conftest.py
+++ b/tests/st/conftest.py
@@ -24,7 +24,6 @@ import textwrap
 import warnings
 from collections import Counter
 from contextlib import nullcontext
-from dataclasses import replace
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -44,12 +43,17 @@ from harness.core.environment import (  # noqa: E402
     get_simpler_python_path,
     get_simpler_scripts_path,
 )
-from harness.core.harness import ALL_PLATFORM_IDS, PTOTestCase  # noqa: E402
+from harness.core.harness import (  # noqa: E402
+    ALL_PLATFORM_IDS,
+    PTOTestCase,
+    platform_to_backend,
+)
 from harness.core.test_runner import (  # noqa: E402
     TestRunner,
     _cache_key,
     configure_inline_task_submit,
     execution_summary_lines,
+    set_current_item_platform,
     shutdown_pipeline,
     start_pipeline,
 )
@@ -554,8 +558,15 @@ def _resolve_item_platform(node: pytest.Item | pytest.FixtureRequest, config: py
     resolved = params.get("platform") or params.get("_st_platform")
     if resolved:
         return resolved
-    cli = _parse_platform_filter(config.getoption("--platform"))
-    return cli[0] if cli else "a2a3"
+    cli = list(_parse_platform_filter(config.getoption("--platform")) or ALL_PLATFORM_IDS)
+    marker = node.get_closest_marker("platforms") if hasattr(node, "get_closest_marker") else None
+    if marker is not None:
+        item_filter = _marker_platforms(marker, "platforms", getattr(node, "name", "<item>"))
+        # An item the marker excludes from every active platform is deselected by
+        # pytest_collection_modifyitems; keep the raw first id so this resolver
+        # never has to invent one.
+        cli = [p for p in cli if p in item_filter] or cli
+    return cli[0]
 
 
 def _marker_platforms(marker: pytest.Mark, marker_name: str, test_name: str) -> set[str]:
@@ -586,26 +597,47 @@ def _marker_platforms(marker: pytest.Mark, marker_name: str, test_name: str) -> 
     return set(marker.args)
 
 
-@pytest.fixture
+def _direct_argnames(func: Any) -> set[str]:
+    """Return the fixture names *func* requests in its own signature.
+
+    ``Metafunc.fixturenames`` is the whole closure, so it cannot tell a test
+    that takes ``test_runner`` from one that merely depends on a fixture which
+    does. Only the former can be expanded per platform.
+
+    Args:
+        func: The test function.
+
+    Returns:
+        The parameter names of the function signature.
+    """
+    try:
+        return set(inspect.signature(func).parameters)
+    except (TypeError, ValueError):  # builtins / unsupported callables
+        return set()
+
+
+@pytest.fixture(autouse=True)
 def _st_platform(request) -> str:
-    """Return the platform this item runs on (see :func:`_resolve_item_platform`)."""
+    """Return the platform this item runs on (see :func:`_resolve_item_platform`).
+
+    Autouse so that :func:`pytest_generate_tests` always has this fixture in the
+    closure to parametrize; the platform matrix expands *this* name rather than
+    the test signature, which is what keeps test bodies unchanged.
+    """
     return _resolve_item_platform(request.node, request.config)
 
 
-@pytest.fixture
-def test_runner(test_config, _st_platform) -> TestRunner:
-    """Return a runner bound to this item's platform.
+@pytest.fixture(scope="session")
+def test_runner(test_config) -> TestRunner:
+    """Session-scoped fixture providing a test runner instance.
 
-    Function-scoped rather than session-scoped: one item may run on ``a2a3``
-    and the next on ``a5`` within the same session, and ``RunConfig.platform``
-    is what the runner falls back to for cases that do not pin a platform
-    themselves. The pipeline state a runner consults (compile futures, batches)
-    lives at module level in ``harness.core.test_runner``, so per-item runner
-    instances share it.
+    Deliberately still session-scoped: module- and session-scoped fixtures in
+    the suite request it, and a function-scoped runner makes those a
+    ``ScopeMismatch``. The per-item platform reaches the runner through
+    ``set_current_item_platform`` (published by :func:`pytest_runtest_setup`)
+    rather than through a differently-scoped fixture.
     """
-    if _st_platform == test_config.platform:
-        return TestRunner(test_config)
-    return TestRunner(replace(test_config, platform=_st_platform))
+    return TestRunner(test_config)
 
 
 @pytest.fixture
@@ -714,33 +746,65 @@ def pytest_itemcollected(item):
 def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
     """Expand ``test_runner``-based tests over the active platform allowlist.
 
-    A test that declares ``platform`` itself keeps its own parametrize, and one
-    that requests ``backend_type`` is left to the module-level
-    ``pytest_generate_tests`` that owns its arch selection (see
-    ``tests/st/runtime/cross_core/``). Everything else is expanded over the
-    ``--platform`` allowlist intersected with its ``@pytest.mark.platforms``,
-    so a case joins a new platform's guard job without touching its test body.
+    A test that declares ``platform`` itself keeps its own parametrize.
+    Everything else is expanded over the ``--platform`` allowlist intersected
+    with its ``@pytest.mark.platforms``, so a case joins a new platform's guard
+    job without touching its test body.
 
-    Expansion only happens when more than one platform is active: a plain
+    A test taking ``backend_type`` gets it paired with the platform in one
+    parametrize, so the backend it compiles for and the toolchain it runs on
+    can never disagree. That name has no fixture of its own — this is where it
+    comes from — so it is emitted even for a single active platform.
+
+    The test must take ``test_runner`` itself. A test that reaches the runner
+    through a module- or session-scoped fixture cannot vary per item — that
+    fixture is built once and shared — so expanding it would hand every variant
+    the first platform's artefact. Those items run on the single platform
+    :func:`_resolve_item_platform` picks for them.
+
+    Expansion only happens when the CLI names more than one platform: a plain
     ``--platform=a2a3`` run keeps today's node ids, and only a multi-platform
-    invocation grows the ``[a2a3]`` / ``[a5]`` suffixes.
+    invocation grows the ``[a2a3]`` / ``[a5]`` suffixes. Within such a run a
+    marker that narrows the test to one platform is still parametrized, so the
+    item carries that platform instead of falling back to the first CLI id.
     """
-    if "test_runner" not in metafunc.fixturenames:
+    direct = _direct_argnames(metafunc.function)
+    if "test_runner" not in direct:
         return
-    if "platform" in metafunc.fixturenames or "backend_type" in metafunc.fixturenames:
+    if "platform" in metafunc.fixturenames:
         return
-    cli = _parse_platform_filter(metafunc.config.getoption("--platform")) or ALL_PLATFORM_IDS
+    cli = list(_parse_platform_filter(metafunc.config.getoption("--platform")) or ALL_PLATFORM_IDS)
     marker = metafunc.definition.get_closest_marker("platforms")
     item_filter = (
         _marker_platforms(marker, "platforms", metafunc.definition.name) if marker is not None else None
     )
-    allowed = [p for p in cli if item_filter is None or p in item_filter]
-    if len(allowed) > 1:
+    # A marker that excludes every active platform leaves the variants to
+    # pytest_collection_modifyitems, which deselects them; parametrizing an
+    # empty list would instead leave one item behind marked "empty parameter set".
+    allowed = [p for p in cli if item_filter is None or p in item_filter] or cli
+    if "backend_type" in direct:
+        metafunc.parametrize(
+            "_st_platform,backend_type",
+            [(p, platform_to_backend(p)) for p in allowed],
+            ids=list(allowed),
+            indirect=["_st_platform"],
+        )
+        return
+    if len(cli) > 1:
         metafunc.parametrize("_st_platform", allowed, ids=list(allowed), indirect=True)
 
 
+@pytest.hookimpl(tryfirst=True)
 def pytest_runtest_setup(item: pytest.Item) -> None:
-    """Apply ``@pytest.mark.platform_xfail`` to the platform this item runs on.
+    """Publish this item's platform, then apply ``@pytest.mark.platform_xfail``.
+
+    ``tryfirst`` so the platform is published before pytest's own
+    ``pytest_runtest_setup`` builds this item's fixtures: a module-scoped
+    fixture that calls ``test_runner.run()`` during that setup must compile for
+    the platform of the item that triggered it, not for the session default.
+
+    The xfail half is a platform-conditional expectation, which a plain
+    ``xfail`` cannot spell.
 
     A platform-conditional expectation cannot be spelled with a plain
     ``xfail``, and raising ``pytest.xfail()`` inside the body aborts before the
@@ -754,6 +818,8 @@ def pytest_runtest_setup(item: pytest.Item) -> None:
     Raises:
         pytest.UsageError: The marker names no/unknown platforms, or no reason.
     """
+    set_current_item_platform(_resolve_item_platform(item, item.config))
+
     marker = item.get_closest_marker("platform_xfail")
     if marker is None:
         return
@@ -766,6 +832,11 @@ def pytest_runtest_setup(item: pytest.Item) -> None:
         )
     if _resolve_item_platform(item, item.config) in platforms:
         item.add_marker(pytest.mark.xfail(reason=reason, strict=marker.kwargs.get("strict", True)))
+
+
+def pytest_runtest_teardown(item: pytest.Item) -> None:  # noqa: ARG001
+    """Drop the published platform so it cannot leak into the next item."""
+    set_current_item_platform(None)
 
 
 def pytest_collection_modifyitems(config, items):

--- a/tests/st/harness/core/harness.py
+++ b/tests/st/harness/core/harness.py
@@ -350,14 +350,18 @@ class PTOTestCase(ABC):
         ``platform=`` — the platform matrix is driven by the item's parametrize
         variant instead (see ``pytest_generate_tests`` in ``tests/st/conftest.py``).
         A case that pinned its own platform (constructor arg or a
-        :py:meth:`get_platform` override) is left untouched.
+        :py:meth:`get_platform` override) is left untouched, and so is one that
+        pinned a backend through the legacy ``backend_type`` constructor arg:
+        binding a platform over that pin would silently win (see
+        :py:meth:`get_backend_type`) and hide an architecture conflict that
+        :func:`arch_mismatch_reason` must report.
 
         Args:
             platform: One of :data:`ALL_PLATFORM_IDS`.
         """
         if platform not in ALL_PLATFORM_IDS:
             raise ValueError(f"Unknown platform '{platform}'. Expected one of {ALL_PLATFORM_IDS}.")
-        if self.get_platform() is None:
+        if self.get_platform() is None and self._override_backend is None:
             self._override_platform = platform
 
     def get_backend_type(self) -> BackendType:

--- a/tests/st/harness/core/harness.py
+++ b/tests/st/harness/core/harness.py
@@ -82,36 +82,6 @@ def platform_to_backend(platform: str) -> BackendType:
         raise ValueError(f"Unknown platform '{platform}'. Expected one of {ALL_PLATFORM_IDS}.") from exc
 
 
-def arch_mismatch_reason(test_case: "PTOTestCase", resolved_platform: str) -> str | None:
-    """Return why *test_case* cannot run on *resolved_platform*, or None when it can.
-
-    A subclass that redefines :py:meth:`PTOTestCase.get_backend_type` wins over
-    the ``platform`` constructor arg, while the toolchain that assembles and
-    executes the artefact follows the platform.  A case pinned to
-    ``Ascend910B`` would therefore compile 910B code and run it on 950 silicon
-    under ``--platform=a5``.  The runner calls this before compiling and skips
-    the case instead, so a whole file can be added to an a5 guard job without
-    silently testing the wrong architecture.
-
-    Args:
-        test_case: The case about to be compiled.
-        resolved_platform: The platform resolved for it (see ``_resolve_platform``).
-
-    Returns:
-        A user-facing skip reason, or ``None`` when the case matches the platform.
-    """
-    want = platform_to_backend(resolved_platform)
-    got = test_case.get_backend_type()
-    if got is want:
-        return None
-    return (
-        f"{test_case.get_name()} pins get_backend_type()={got.name}, but "
-        f"--platform={resolved_platform} needs {want.name}. Drop the "
-        f"get_backend_type() override to make the case arch-agnostic, or declare "
-        f'the limitation with @pytest.mark.platforms("a2a3", "a2a3sim", reason=...).'
-    )
-
-
 class DataType(Enum):
     """Supported data types for tensors."""
 
@@ -237,7 +207,6 @@ class PTOTestCase(ABC):
         config: RunConfig | None = None,
         *,
         platform: str | None = None,
-        backend_type: BackendType | None = None,
         strategy: OptimizationStrategy | None = None,
         memory_planner: MemoryPlanner | None = None,
         enable_pypto_l0c_double_buffer: bool | None = None,
@@ -251,10 +220,9 @@ class PTOTestCase(ABC):
                 ``get_platform()`` (which defaults to ``None``, deferring to
                 the session-wide ``--platform`` CLI value, currently
                 ``a2a3``).  Pass explicitly to run the same test case on a
-                different platform without subclassing.
-            backend_type: (Legacy) Override the backend type for code
-                generation.  Prefer ``platform``.  If both are given, the
-                value derived from ``platform`` wins.
+                different platform without subclassing.  The platform is the
+                only architecture knob a case has: codegen's backend is derived
+                from it by :func:`platform_to_backend`.
             strategy: Override the optimization strategy.  If None, falls
                 back to the class-level ``get_strategy()`` default (Default).
             memory_planner: Override the on-chip memory planner
@@ -264,7 +232,6 @@ class PTOTestCase(ABC):
         """
         self.config = config or RunConfig()
         self._override_platform = platform
-        self._override_backend = backend_type
         self._override_strategy = strategy
         self._override_memory_planner = memory_planner
         self._override_enable_pypto_l0c_double_buffer = enable_pypto_l0c_double_buffer
@@ -350,37 +317,15 @@ class PTOTestCase(ABC):
         ``platform=`` — the platform matrix is driven by the item's parametrize
         variant instead (see ``pytest_generate_tests`` in ``tests/st/conftest.py``).
         A case that pinned its own platform (constructor arg or a
-        :py:meth:`get_platform` override) is left untouched, and so is one that
-        pinned a backend through the legacy ``backend_type`` constructor arg:
-        binding a platform over that pin would silently win (see
-        :py:meth:`get_backend_type`) and hide an architecture conflict that
-        :func:`arch_mismatch_reason` must report.
+        :py:meth:`get_platform` override) is left untouched.
 
         Args:
             platform: One of :data:`ALL_PLATFORM_IDS`.
         """
         if platform not in ALL_PLATFORM_IDS:
             raise ValueError(f"Unknown platform '{platform}'. Expected one of {ALL_PLATFORM_IDS}.")
-        if self.get_platform() is None and self._override_backend is None:
+        if self.get_platform() is None:
             self._override_platform = platform
-
-    def get_backend_type(self) -> BackendType:
-        """Return the backend type for code generation.
-
-        Resolution order:
-            1. The ``platform`` constructor arg, if set, decides the backend
-               via :data:`_PLATFORM_TO_BACKEND` (preferred path).
-            2. The legacy ``backend_type`` constructor arg, if set.
-            3. ``BackendType.Ascend910B`` as the global default.
-
-        Subclasses may still override this method; the constructor override
-        only applies when the subclass does **not** redefine the method.
-        """
-        if self._override_platform is not None:
-            return platform_to_backend(self._override_platform)
-        if self._override_backend is not None:
-            return self._override_backend
-        return BackendType.Ascend910B
 
     def define_scalars(self) -> list[ScalarSpec]:
         """Define scalar TaskArg parameters for this test.

--- a/tests/st/harness/core/harness.py
+++ b/tests/st/harness/core/harness.py
@@ -82,6 +82,36 @@ def platform_to_backend(platform: str) -> BackendType:
         raise ValueError(f"Unknown platform '{platform}'. Expected one of {ALL_PLATFORM_IDS}.") from exc
 
 
+def arch_mismatch_reason(test_case: "PTOTestCase", resolved_platform: str) -> str | None:
+    """Return why *test_case* cannot run on *resolved_platform*, or None when it can.
+
+    A subclass that redefines :py:meth:`PTOTestCase.get_backend_type` wins over
+    the ``platform`` constructor arg, while the toolchain that assembles and
+    executes the artefact follows the platform.  A case pinned to
+    ``Ascend910B`` would therefore compile 910B code and run it on 950 silicon
+    under ``--platform=a5``.  The runner calls this before compiling and skips
+    the case instead, so a whole file can be added to an a5 guard job without
+    silently testing the wrong architecture.
+
+    Args:
+        test_case: The case about to be compiled.
+        resolved_platform: The platform resolved for it (see ``_resolve_platform``).
+
+    Returns:
+        A user-facing skip reason, or ``None`` when the case matches the platform.
+    """
+    want = platform_to_backend(resolved_platform)
+    got = test_case.get_backend_type()
+    if got is want:
+        return None
+    return (
+        f"{test_case.get_name()} pins get_backend_type()={got.name}, but "
+        f"--platform={resolved_platform} needs {want.name}. Drop the "
+        f"get_backend_type() override to make the case arch-agnostic, or declare "
+        f'the limitation with @pytest.mark.platforms("a2a3", "a2a3sim", reason=...).'
+    )
+
+
 class DataType(Enum):
     """Supported data types for tensors."""
 
@@ -312,6 +342,23 @@ class PTOTestCase(ABC):
         redefine the method.
         """
         return self._override_platform
+
+    def bind_platform(self, platform: str) -> None:
+        """Bind *platform* to this case when it did not pin one itself.
+
+        Called by the harness for cases whose test body does not pass
+        ``platform=`` — the platform matrix is driven by the item's parametrize
+        variant instead (see ``pytest_generate_tests`` in ``tests/st/conftest.py``).
+        A case that pinned its own platform (constructor arg or a
+        :py:meth:`get_platform` override) is left untouched.
+
+        Args:
+            platform: One of :data:`ALL_PLATFORM_IDS`.
+        """
+        if platform not in ALL_PLATFORM_IDS:
+            raise ValueError(f"Unknown platform '{platform}'. Expected one of {ALL_PLATFORM_IDS}.")
+        if self.get_platform() is None:
+            self._override_platform = platform
 
     def get_backend_type(self) -> BackendType:
         """Return the backend type for code generation.

--- a/tests/st/harness/core/test_runner.py
+++ b/tests/st/harness/core/test_runner.py
@@ -181,6 +181,23 @@ def _cache_key(
     return f"{tc.get_name()}@{resolved_platform}@{planner_tag}"
 
 
+# The platform of the item pytest is currently setting up or running, published
+# by the system-test ``pytest_runtest_setup`` hook. This is how a per-item
+# platform reaches the session-scoped ``test_runner`` fixture: module- and
+# session-scoped fixtures in the suite request that fixture, so it cannot itself
+# be function-scoped without turning every one of them into a ScopeMismatch.
+_current_item_platform: dict[str, str | None] = {"value": None}
+
+
+def set_current_item_platform(platform: str | None) -> None:
+    """Publish (or, with ``None``, retract) the platform of the running item.
+
+    Args:
+        platform: The item's platform, or ``None`` between items.
+    """
+    _current_item_platform["value"] = platform
+
+
 def _install_backend(backend_type: BackendType) -> None:
     """Install *backend_type* globally for the inline compile that follows.
 
@@ -238,7 +255,8 @@ def _resolve_platform(config_platform: str, test_case: PTOTestCase | None = None
 
     The test-case-level platform (set via the ``platform`` constructor arg or
     overridden in :py:meth:`PTOTestCase.get_platform`) takes precedence over
-    the session-wide ``--platform`` value.  When *test_case* is ``None`` the
+    the platform of the running item, which in turn takes precedence over the
+    session-wide ``--platform`` value.  When *test_case* is ``None`` the
     function preserves the historical behaviour of returning ``config_platform``
     so legacy code paths still work.
     """
@@ -249,6 +267,9 @@ def _resolve_platform(config_platform: str, test_case: PTOTestCase | None = None
             tc_platform = None
         if tc_platform:
             return tc_platform
+    item_platform = _current_item_platform["value"]
+    if item_platform:
+        return item_platform
     return config_platform
 
 

--- a/tests/st/harness/core/test_runner.py
+++ b/tests/st/harness/core/test_runner.py
@@ -387,18 +387,19 @@ def _write_golden_for_test_case(test_case: PTOTestCase, output_path: Path) -> No
 def _compile_for_cache(
     test_case: "PTOTestCase",
     work_dir: Path,
+    resolved_platform: str,
     dump_passes: bool,
     analyze_auto_scopes_for_deps: bool,
     session_memory_planner: MemoryPlanner | None = None,
 ) -> None:
-    """Compile one test case into *work_dir* (called from thread pool).
+    """Compile one test case into *work_dir* for *resolved_platform*.
 
     The backend type MUST already be set by the caller before entering the pool.
     Only ``get_program`` is serialised (via ``_get_program_lock``) because the
     ``@pl.program`` decorator is not thread-safe; ``compile_program`` writes to
     an isolated directory and runs concurrently.
     """
-    backend_type = platform_to_backend(_resolve_platform("", test_case))
+    backend_type = platform_to_backend(resolved_platform)
     with _get_program_lock:
         program = test_case.get_program()
     if program is None:
@@ -471,6 +472,7 @@ def _fused_compile_task(
         _compile_for_cache(
             tc,
             work_dir,
+            resolved,
             dump_passes,
             analyze_auto_scopes_for_deps,
             session_memory_planner,

--- a/tests/st/harness/core/test_runner.py
+++ b/tests/st/harness/core/test_runner.py
@@ -63,7 +63,7 @@ from pypto.runtime.runner import (
 )
 from pypto.runtime.tensor_spec import TensorSpec as RuntimeTensorSpec
 
-from harness.core.harness import PTOTestCase, arch_mismatch_reason
+from harness.core.harness import PTOTestCase, platform_to_backend
 
 # tests/st/harness/core/test_runner.py -> tests/st/ -> project root
 _ST_DIR = Path(__file__).parent.parent.parent
@@ -141,13 +141,6 @@ _MAX_TASK_SUBMIT_INFLIGHT = 512
 # runs concurrently.
 _get_program_lock = threading.Lock()
 
-# Map BackendType to the architecture prefix used by the platform string.
-# "a2a3" covers Ascend 910B; "a5" covers Ascend 950.
-_BACKEND_TO_ARCH: dict[BackendType, str] = {
-    BackendType.Ascend910B: "a2a3",
-    BackendType.Ascend950: "a5",
-}
-
 
 def _cache_key(
     tc: PTOTestCase,
@@ -161,13 +154,13 @@ def _cache_key(
     which toolchain a given artifact was produced for. Resolution order:
 
     1. ``resolved_platform`` (the value returned by :func:`_resolve_platform`
-       for the current session). Callers should pass it whenever they have it
-       so a legacy test case run with ``--platform=a2a3sim`` is keyed to
-       ``a2a3sim`` rather than the backend-derived ``a2a3``.
-    2. ``tc.get_platform()`` for parametrized cases that pinned a platform on
-       the test case itself.
-    3. The backend architecture (``a2a3``/``a5``) as a final fallback for
-       cases that neither set a platform nor receive a resolved one.
+       for the current session). Callers should pass it whenever they have it.
+    2. ``tc.get_platform()``, for a case that pinned a platform itself or was
+       bound to its item's platform by :func:`_bind_item_platform`.
+
+    Raises:
+        ValueError: Neither is available. Keying an artifact without a platform
+            would let two architectures share one compile.
     """
     if not resolved_platform:
         try:
@@ -175,7 +168,7 @@ def _cache_key(
         except AttributeError:
             resolved_platform = None
     if not resolved_platform:
-        resolved_platform = _BACKEND_TO_ARCH.get(tc.get_backend_type(), "unknown")
+        raise ValueError(f"cannot key an artifact for {tc.get_name()}: no platform resolved or bound")
     planner = _resolve_case_memory_planner(tc, session_memory_planner)
     planner_tag = planner.name.lower() if planner is not None else "default"
     return f"{tc.get_name()}@{resolved_platform}@{planner_tag}"
@@ -224,30 +217,31 @@ def _install_backend(backend_type: BackendType) -> None:
     set_backend_type(backend_type)
 
 
-def _bind_and_check_arch(test_case: PTOTestCase, resolved_platform: str) -> str | None:
-    """Bind *resolved_platform* onto *test_case*, then report an arch conflict.
+def _bind_item_platform(test_case: PTOTestCase, resolved_platform: str) -> None:
+    """Bind *resolved_platform* onto *test_case* before it is compiled.
 
-    Binding first is what separates a *pinned* backend from the default one:
-    an unbound case answers ``get_backend_type()`` with the base-class
-    ``Ascend910B`` default, which is not a pin and must not read as a conflict.
-    Once the platform is bound, only a subclass that redefines
-    ``get_backend_type()`` can still disagree with it — and that case genuinely
-    cannot run on this platform.
-
-    Binding also makes the legacy path follow the platform: ``_run_inline`` and
-    ``_compile_for_cache`` take the backend from ``tc.get_backend_type()``, so
-    before this a case that never mentioned a platform compiled for 910B even
-    under ``--platform=a5``.
+    The platform is a case's only architecture knob: every compile site derives
+    codegen's backend from it through :func:`platform_to_backend`, so an
+    artifact can no longer be built for one architecture and executed on
+    another. Binding is also what lets the cache key and the compile-pool
+    grouping tell one matrix variant from the next.
 
     Args:
         test_case: The case about to be compiled (mutated: platform bound).
         resolved_platform: The platform resolved for it.
 
-    Returns:
-        A skip reason when the case pins a conflicting backend, else ``None``.
+    Raises:
+        pytest.UsageError: The case redefines ``get_backend_type``, a knob the
+            harness no longer reads.
     """
+    if getattr(type(test_case), "get_backend_type", None) is not None:
+        raise pytest.UsageError(
+            f"{type(test_case).__name__} defines get_backend_type(), which the harness no "
+            "longer reads: the backend follows the platform. Delete the override, and if the "
+            "case really cannot run on the other architecture say so with "
+            '@pytest.mark.platforms("a2a3", "a2a3sim", reason=...) on its tests.'
+        )
     test_case.bind_platform(resolved_platform)
-    return arch_mismatch_reason(test_case, resolved_platform)
 
 
 def _resolve_platform(config_platform: str, test_case: PTOTestCase | None = None) -> str:
@@ -404,7 +398,7 @@ def _compile_for_cache(
     ``@pl.program`` decorator is not thread-safe; ``compile_program`` writes to
     an isolated directory and runs concurrently.
     """
-    backend_type = test_case.get_backend_type()
+    backend_type = platform_to_backend(_resolve_platform("", test_case))
     with _get_program_lock:
         program = test_case.get_program()
     if program is None:
@@ -449,10 +443,6 @@ class CompileArtifact:
     work_dir: Path
     resolved_platform: str
     error: str | None = None
-    #: Set when the case pins a backend the resolved platform cannot serve; the
-    #: artefact holds nothing and neither the batch submitter nor the execute
-    #: pool may touch it (``TestRunner.run`` turns it into a pytest skip).
-    skip_reason: str | None = None
     runtime_name: str | None = None
     chip_callable: Any | None = None
     enable_sdma: bool = False
@@ -474,12 +464,8 @@ def _fused_compile_task(
     already be set on the main thread before this task is submitted.
     """
     resolved = _resolve_platform(session_platform, tc)
+    _bind_item_platform(tc, resolved)
     work_dir = cache_dir / _cache_key(tc, resolved, session_memory_planner)
-    # A backend-pinned case cannot be compiled for this platform. Report it
-    # instead of burning a compile slot on an artefact ``run()`` will skip.
-    skip_reason = _bind_and_check_arch(tc, resolved)
-    if skip_reason is not None:
-        return CompileArtifact(work_dir=work_dir, resolved_platform=resolved, skip_reason=skip_reason)
     work_dir.mkdir(parents=True, exist_ok=True)
     try:
         _compile_for_cache(
@@ -1045,11 +1031,7 @@ def _batch_submitter(batch_size: int, cache_dir: Path) -> None:
                 artifact = cfut.result()
             except Exception:  # noqa: BLE001 — run() re-raises the compile crash with context
                 continue
-            if (
-                artifact.error is not None
-                or artifact.skip_reason is not None
-                or _pipeline_ctx.get("codegen_only")
-            ):
+            if artifact.error is not None or _pipeline_ctx.get("codegen_only"):
                 continue
             if artifact.resolved_platform.endswith("sim"):
                 continue
@@ -1170,11 +1152,11 @@ def start_pipeline(  # noqa: PLR0913
 
     groups: dict[BackendType, list[PTOTestCase]] = {}
     for tc in test_cases:
-        # Bind before grouping: the group key IS the backend the compile pool
-        # installs globally, and an unbound case answers with the base-class
-        # Ascend910B default rather than the platform it will be built for.
-        tc.bind_platform(_resolve_platform(session_platform, tc))
-        groups.setdefault(tc.get_backend_type(), []).append(tc)
+        # Bind before grouping so each case carries the platform whose backend
+        # the compile pool will install globally for its group.
+        resolved = _resolve_platform(session_platform, tc)
+        _bind_item_platform(tc, resolved)
+        groups.setdefault(platform_to_backend(resolved), []).append(tc)
 
     group_items = list(groups.items())
     for i, (backend_type, group) in enumerate(group_items):
@@ -1336,9 +1318,7 @@ class TestRunner:
             RunResult with pass/fail status and details.
         """
         resolved_platform = _resolve_platform(self.config.platform, test_case)
-        skip_reason = _bind_and_check_arch(test_case, resolved_platform)
-        if skip_reason is not None:
-            pytest.skip(skip_reason)
+        _bind_item_platform(test_case, resolved_platform)
         cache_k = _cache_key(test_case, resolved_platform, self.config.memory_planner)
         cfut = _compile_futures.get(cache_k)
         if cfut is not None:
@@ -1447,7 +1427,7 @@ class TestRunner:
         work_dir, use_temp = _inline_work_dir(self.config, test_name, resolved_platform)
 
         try:
-            backend_type = test_case.get_backend_type()
+            backend_type = platform_to_backend(resolved_platform)
             _install_backend(backend_type)
 
             program = test_case.get_program()

--- a/tests/st/harness/core/test_runner.py
+++ b/tests/st/harness/core/test_runner.py
@@ -37,7 +37,13 @@ from pathlib import Path
 from typing import Any
 
 import pytest
-from pypto.backend import BackendType, reset_for_testing, set_backend_type
+from pypto.backend import (
+    BackendType,
+    get_backend_type,
+    is_backend_configured,
+    reset_for_testing,
+    set_backend_type,
+)
 from pypto.pypto_core import LogLevel, _set_thread_log_level
 from pypto.pypto_core.passes import MemoryPlanner
 from pypto.runtime import compile_program
@@ -57,7 +63,7 @@ from pypto.runtime.runner import (
 )
 from pypto.runtime.tensor_spec import TensorSpec as RuntimeTensorSpec
 
-from harness.core.harness import PTOTestCase
+from harness.core.harness import PTOTestCase, arch_mismatch_reason
 
 # tests/st/harness/core/test_runner.py -> tests/st/ -> project root
 _ST_DIR = Path(__file__).parent.parent.parent
@@ -173,6 +179,58 @@ def _cache_key(
     planner = _resolve_case_memory_planner(tc, session_memory_planner)
     planner_tag = planner.name.lower() if planner is not None else "default"
     return f"{tc.get_name()}@{resolved_platform}@{planner_tag}"
+
+
+def _install_backend(backend_type: BackendType) -> None:
+    """Install *backend_type* globally for the inline compile that follows.
+
+    ``set_backend_type`` is a process-global one-time setter — idempotent for
+    the same value, an error for a different one — so a session that walks the
+    platform matrix inside one process (no ``--forked``) has to clear the
+    previous backend before installing the next. The inline path is serial on
+    the calling thread, so nothing is compiling across the switch.
+
+    The exception is an inline case running *while the pre-compile pipeline is
+    alive*: its worker threads compile against the installed backend, so
+    clearing it underneath them would race. There the original single-shot
+    error is kept, which is what the pipeline's own per-group draining
+    (see :func:`start_pipeline`) is designed around.
+
+    Args:
+        backend_type: The backend the caller is about to compile for.
+    """
+    if _compile_pools:
+        set_backend_type(backend_type)
+        return
+    if is_backend_configured() and get_backend_type() != backend_type:
+        reset_for_testing()
+    set_backend_type(backend_type)
+
+
+def _bind_and_check_arch(test_case: PTOTestCase, resolved_platform: str) -> str | None:
+    """Bind *resolved_platform* onto *test_case*, then report an arch conflict.
+
+    Binding first is what separates a *pinned* backend from the default one:
+    an unbound case answers ``get_backend_type()`` with the base-class
+    ``Ascend910B`` default, which is not a pin and must not read as a conflict.
+    Once the platform is bound, only a subclass that redefines
+    ``get_backend_type()`` can still disagree with it — and that case genuinely
+    cannot run on this platform.
+
+    Binding also makes the legacy path follow the platform: ``_run_inline`` and
+    ``_compile_for_cache`` take the backend from ``tc.get_backend_type()``, so
+    before this a case that never mentioned a platform compiled for 910B even
+    under ``--platform=a5``.
+
+    Args:
+        test_case: The case about to be compiled (mutated: platform bound).
+        resolved_platform: The platform resolved for it.
+
+    Returns:
+        A skip reason when the case pins a conflicting backend, else ``None``.
+    """
+    test_case.bind_platform(resolved_platform)
+    return arch_mismatch_reason(test_case, resolved_platform)
 
 
 def _resolve_platform(config_platform: str, test_case: PTOTestCase | None = None) -> str:
@@ -370,6 +428,10 @@ class CompileArtifact:
     work_dir: Path
     resolved_platform: str
     error: str | None = None
+    #: Set when the case pins a backend the resolved platform cannot serve; the
+    #: artefact holds nothing and neither the batch submitter nor the execute
+    #: pool may touch it (``TestRunner.run`` turns it into a pytest skip).
+    skip_reason: str | None = None
     runtime_name: str | None = None
     chip_callable: Any | None = None
     enable_sdma: bool = False
@@ -392,6 +454,11 @@ def _fused_compile_task(
     """
     resolved = _resolve_platform(session_platform, tc)
     work_dir = cache_dir / _cache_key(tc, resolved, session_memory_planner)
+    # A backend-pinned case cannot be compiled for this platform. Report it
+    # instead of burning a compile slot on an artefact ``run()`` will skip.
+    skip_reason = _bind_and_check_arch(tc, resolved)
+    if skip_reason is not None:
+        return CompileArtifact(work_dir=work_dir, resolved_platform=resolved, skip_reason=skip_reason)
     work_dir.mkdir(parents=True, exist_ok=True)
     try:
         _compile_for_cache(
@@ -957,7 +1024,11 @@ def _batch_submitter(batch_size: int, cache_dir: Path) -> None:
                 artifact = cfut.result()
             except Exception:  # noqa: BLE001 — run() re-raises the compile crash with context
                 continue
-            if artifact.error is not None or _pipeline_ctx.get("codegen_only"):
+            if (
+                artifact.error is not None
+                or artifact.skip_reason is not None
+                or _pipeline_ctx.get("codegen_only")
+            ):
                 continue
             if artifact.resolved_platform.endswith("sim"):
                 continue
@@ -1078,6 +1149,10 @@ def start_pipeline(  # noqa: PLR0913
 
     groups: dict[BackendType, list[PTOTestCase]] = {}
     for tc in test_cases:
+        # Bind before grouping: the group key IS the backend the compile pool
+        # installs globally, and an unbound case answers with the base-class
+        # Ascend910B default rather than the platform it will be built for.
+        tc.bind_platform(_resolve_platform(session_platform, tc))
         groups.setdefault(tc.get_backend_type(), []).append(tc)
 
     group_items = list(groups.items())
@@ -1240,6 +1315,9 @@ class TestRunner:
             RunResult with pass/fail status and details.
         """
         resolved_platform = _resolve_platform(self.config.platform, test_case)
+        skip_reason = _bind_and_check_arch(test_case, resolved_platform)
+        if skip_reason is not None:
+            pytest.skip(skip_reason)
         cache_k = _cache_key(test_case, resolved_platform, self.config.memory_planner)
         cfut = _compile_futures.get(cache_k)
         if cfut is not None:
@@ -1349,7 +1427,7 @@ class TestRunner:
 
         try:
             backend_type = test_case.get_backend_type()
-            set_backend_type(backend_type)
+            _install_backend(backend_type)
 
             program = test_case.get_program()
             if program is None:

--- a/tests/st/runtime/cross_core/test_cross_core.py
+++ b/tests/st/runtime/cross_core/test_cross_core.py
@@ -30,7 +30,6 @@ import pypto.language as pl
 import pytest
 import torch
 from harness.core.harness import DataType, PTOTestCase, TensorSpec
-from pypto.backend import BackendType
 
 M = 32
 K = 64
@@ -59,50 +58,10 @@ SLOTNUM_SLOT_NUM = 4
 SLOTNUM_LOCAL_SLOT_NUM = 4
 SLOTNUM_BUFFER_SIZE = SLOTNUM_SLOT_SIZE * SLOTNUM_LOCAL_SLOT_NUM
 
-_PLATFORM_TO_BACKEND: dict[str, BackendType] = {
-    "a2a3": BackendType.Ascend910B,
-    "a2a3sim": BackendType.Ascend910B,
-    "a5": BackendType.Ascend950,
-    "a5sim": BackendType.Ascend950,
-}
-_DEFAULT_PLATFORM = "a2a3"
-
-
-def _resolve_platform(config: pytest.Config) -> str:
-    """Resolve the effective platform from the session-wide allowlist."""
-    raw_platform = str(config.getoption("--platform") or "")
-    tokens = [tok.strip() for tok in raw_platform.split(",") if tok.strip()]
-    valid_platforms = tuple(dict.fromkeys(tok for tok in tokens if tok in _PLATFORM_TO_BACKEND))
-    if tokens and not valid_platforms:
-        raise pytest.UsageError(
-            "tests/st/runtime/cross_core/test_cross_core.py "
-            "supports --platform values (a2a3, a2a3sim, a5, or a5sim)"
-        )
-    return valid_platforms[0] if valid_platforms else _DEFAULT_PLATFORM
-
-
-def _resolve_backend_type(config: pytest.Config) -> BackendType:
-    """Resolve backend from the selected platform, defaulting to a2a3."""
-    platform = _resolve_platform(config)
-    try:
-        return _PLATFORM_TO_BACKEND[platform]
-    except KeyError as exc:
-        raise pytest.UsageError(
-            f"Unsupported --platform {platform!r} for tests/st/runtime/cross_core/test_cross_core.py"
-        ) from exc
-
-
-def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
-    """Drive backend selection from the session-wide --platform filter."""
-    if "backend_type" not in metafunc.fixturenames and "platform" not in metafunc.fixturenames:
-        return
-
-    platform = _resolve_platform(metafunc.config)
-    backend_type = _resolve_backend_type(metafunc.config)
-    if "backend_type" in metafunc.fixturenames:
-        metafunc.parametrize("backend_type", [backend_type], ids=[platform])
-    if "platform" in metafunc.fixturenames:
-        metafunc.parametrize("platform", [platform])
+# ``backend_type`` comes from the system-test platform matrix in
+# tests/st/conftest.py: one variant per active ``--platform`` id, each paired
+# with the platform its cases are built and executed for, so the backend and
+# the toolchain cannot disagree.
 
 
 @pl.program

--- a/tests/st/runtime/cross_core/test_cross_core.py
+++ b/tests/st/runtime/cross_core/test_cross_core.py
@@ -58,11 +58,6 @@ SLOTNUM_SLOT_NUM = 4
 SLOTNUM_LOCAL_SLOT_NUM = 4
 SLOTNUM_BUFFER_SIZE = SLOTNUM_SLOT_SIZE * SLOTNUM_LOCAL_SLOT_NUM
 
-# ``backend_type`` comes from the system-test platform matrix in
-# tests/st/conftest.py: one variant per active ``--platform`` id, each paired
-# with the platform its cases are built and executed for, so the backend and
-# the toolchain cannot disagree.
-
 
 @pl.program
 class V2CUDProgram:
@@ -833,63 +828,63 @@ class ExplicitSlotNumTest(PTOTestCase):
 class TestCrossCore:
     """Cross-core communication system tests."""
 
-    def test_tpush_tpop_v2c_updown(self, test_runner, backend_type):
+    def test_tpush_tpop_v2c_updown(self, test_runner):
         """V2C updown pipe: compile through full pipeline and verify kernel artifacts."""
-        result = test_runner.run(V2CUDTest(backend_type=backend_type))
+        result = test_runner.run(V2CUDTest())
         assert result.passed, f"Cross-core V2C updown compilation failed: {result.error}"
 
-    def test_tpush_tpop_v2c_leftright(self, test_runner, backend_type):
+    def test_tpush_tpop_v2c_leftright(self, test_runner):
         """V2C left-right pipe: compile through full pipeline and verify kernel artifacts."""
-        result = test_runner.run(V2CLRTest(backend_type=backend_type))
+        result = test_runner.run(V2CLRTest())
         assert result.passed, f"Cross-core V2C left-right compilation failed: {result.error}"
 
-    def test_tpush_tpop_v2c_nosplit(self, test_runner, backend_type):
+    def test_tpush_tpop_v2c_nosplit(self, test_runner):
         """V2C no-split pipe: compile through full pipeline and verify correctness."""
-        result = test_runner.run(V2CNoSplitTest(backend_type=backend_type))
+        result = test_runner.run(V2CNoSplitTest())
         assert result.passed, f"Cross-core V2C no-split compilation failed: {result.error}"
 
-    def test_tpop_c2v_leftright(self, test_runner, backend_type):
+    def test_tpop_c2v_leftright(self, test_runner):
         """C2V left-right pipe: compile through full pipeline and verify correctness."""
-        result = test_runner.run(C2VLRTest(backend_type=backend_type))
+        result = test_runner.run(C2VLRTest())
         assert result.passed, f"Cross-core C2V left-right compilation failed: {result.error}"
 
-    def test_tpop_c2v_updown(self, test_runner, backend_type):
+    def test_tpop_c2v_updown(self, test_runner):
         """C2V updown pipe: compile through full pipeline and verify correctness."""
-        result = test_runner.run(C2VUDTest(backend_type=backend_type))
+        result = test_runner.run(C2VUDTest())
         assert result.passed, f"Cross-core C2V updown compilation failed: {result.error}"
 
-    def test_tpop_c2v_nosplit(self, test_runner, backend_type):
+    def test_tpop_c2v_nosplit(self, test_runner):
         """C2V no-split pipe: compile through full pipeline and verify correctness."""
-        result = test_runner.run(C2VNoSplitTest(backend_type=backend_type))
+        result = test_runner.run(C2VNoSplitTest())
         assert result.passed, f"Cross-core C2V no-split compilation failed: {result.error}"
 
-    def test_tpop_bidirect_updown(self, test_runner, backend_type):
+    def test_tpop_bidirect_updown(self, test_runner):
         """Bidirect updown pipe: compile through full pipeline and verify correctness."""
-        result = test_runner.run(BiDirectUDTest(backend_type=backend_type))
+        result = test_runner.run(BiDirectUDTest())
         assert result.passed, f"Cross-core bidirect updown compilation failed: {result.error}"
 
-    def test_tpop_bidirect_leftright(self, test_runner, backend_type):
+    def test_tpop_bidirect_leftright(self, test_runner):
         """Bidirect left-right pipe: compile through full pipeline and verify correctness."""
-        result = test_runner.run(BiDirectLRTest(backend_type=backend_type))
+        result = test_runner.run(BiDirectLRTest())
         assert result.passed, f"Cross-core bidirect left-right compilation failed: {result.error}"
 
-    def test_tpop_bidirect_nosplit(self, test_runner, backend_type):
+    def test_tpop_bidirect_nosplit(self, test_runner):
         """Bidirect no-split pipe: compile through full pipeline and verify correctness."""
-        result = test_runner.run(BiDirectNoSplitTest(backend_type=backend_type))
+        result = test_runner.run(BiDirectNoSplitTest())
         assert result.passed, f"Cross-core bidirect no-split compilation failed: {result.error}"
 
-    def test_tpop_bidirect_spmd_nosplit(self, test_runner, backend_type):
+    def test_tpop_bidirect_spmd_nosplit(self, test_runner):
         """Bidirect cube<->vec + transpose fused in one no-split pl.spmd scope.
 
         On-board guard for #1761: the secondary-subblock replay of the scope's
         ``tile.transpose`` must not 507018-hang the AICore.
         """
-        result = test_runner.run(BidirectSpmdNoSplitTest(backend_type=backend_type))
+        result = test_runner.run(BidirectSpmdNoSplitTest())
         assert result.passed, f"Cross-core bidirect spmd no-split failed: {result.error}"
 
-    def test_multiple_pipes_nosplit(self, test_runner, backend_type):
+    def test_multiple_pipes_nosplit(self, test_runner):
         """Explicit multiple pipe ids: compile through full pipeline and verify correctness."""
-        result = test_runner.run(MultiPipeNoSplitTest(backend_type=backend_type))
+        result = test_runner.run(MultiPipeNoSplitTest())
         assert result.passed, f"Cross-core explicit multi-pipe no-split failed: {result.error}"
 
     # ptoas rejects the operand outright for the 950 frontend pipe lowering,
@@ -907,9 +902,9 @@ class TestCrossCore:
             "manual pl.{aic,aiv}_initialize_pipe route this case exercises does not exist on 950"
         ),
     )
-    def test_explicit_slot_num(self, test_runner, backend_type):
+    def test_explicit_slot_num(self, test_runner):
         """Explicit slot_num / local_slot_num: compile through full pipeline and verify correctness."""
-        result = test_runner.run(ExplicitSlotNumTest(backend_type=backend_type))
+        result = test_runner.run(ExplicitSlotNumTest())
         assert result.passed, f"Cross-core explicit slot_num failed: {result.error}"
 
 

--- a/tests/st/runtime/cross_core/test_cross_core.py
+++ b/tests/st/runtime/cross_core/test_cross_core.py
@@ -933,16 +933,21 @@ class TestCrossCore:
         result = test_runner.run(MultiPipeNoSplitTest(backend_type=backend_type))
         assert result.passed, f"Cross-core explicit multi-pipe no-split failed: {result.error}"
 
-    # `local_slot_num` on pto.{aic,aiv}_initialize_pipe is an a2/a3-only operand,
-    # not an unimplemented 950 feature: ptoas rejects it outright for the 950
-    # frontend pipe lowering, whatever its value --
+    # ptoas rejects the operand outright for the 950 frontend pipe lowering,
+    # whatever its value --
     #   error: 'pto.aic_initialize_pipe' op 'local_slot_num' is only supported
     #          for a2/a3 frontend pipe lowering
-    # so the whole manual pl.{aic,aiv}_initialize_pipe route this case exercises
-    # is a2/a3-only by design. Deselected rather than xfail-ed: xfail says "this
-    # ought to work and does not", which would keep a permanent platform
-    # limitation on the report as if it were a defect awaiting a fix.
-    @pytest.mark.platforms("a2a3", "a2a3sim")
+    # Deselected rather than platform_xfail-ed: xfail says "this ought to work
+    # and does not", which would keep a permanent platform limitation on the
+    # report as if it were a defect awaiting a fix.
+    @pytest.mark.platforms(
+        "a2a3",
+        "a2a3sim",
+        reason=(
+            "local_slot_num on pto.{aic,aiv}_initialize_pipe is an a2/a3-only operand, so the "
+            "manual pl.{aic,aiv}_initialize_pipe route this case exercises does not exist on 950"
+        ),
+    )
     def test_explicit_slot_num(self, test_runner, backend_type):
         """Explicit slot_num / local_slot_num: compile through full pipeline and verify correctness."""
         result = test_runner.run(ExplicitSlotNumTest(backend_type=backend_type))

--- a/tests/st/runtime/cross_core/test_cross_core_grouped_tpop_tfree.py
+++ b/tests/st/runtime/cross_core/test_cross_core_grouped_tpop_tfree.py
@@ -36,7 +36,7 @@ from typing import Any
 
 import pytest
 import torch
-from pypto.backend import BackendType
+from harness.core.harness import platform_to_backend
 from pypto.backend.pto_backend import _preprocess_ptoas_output, _run_ptoas
 from pypto.runtime import compile_program
 from pypto.runtime.device_runner import (
@@ -48,30 +48,23 @@ from pypto.runtime.device_runner import (
 
 from tests.st.runtime.cross_core.test_cross_core import V2CUDProgram
 
-_PLATFORM_TO_BACKEND: dict[str, BackendType] = {
-    "a2a3": BackendType.Ascend910B,
-}
 _DEFAULT_PLATFORM = "a2a3"
 _PROJECT_ROOT = Path(__file__).resolve().parents[4]
 
 
-def _resolve_platform(config: pytest.Config) -> str:
-    """Resolve the effective platform from the session-wide allowlist."""
-    raw_platform = str(config.getoption("--platform") or "")
-    tokens = [tok.strip() for tok in raw_platform.split(",") if tok.strip()]
-    if tokens and _DEFAULT_PLATFORM not in tokens:
-        raise pytest.UsageError(
-            "tests/st/runtime/cross_core/test_cross_core_grouped_tpop_tfree.py only supports --platform=a2a3"
-        )
-    return _DEFAULT_PLATFORM
-
-
 def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
-    """Provide the single effective platform to the standalone runtime regression."""
+    """Parametrize the standalone runtime regression over the requested platforms.
+
+    This case is a2a3-only, which its ``@pytest.mark.platforms("a2a3")`` marker
+    states; the system-test conftest deselects every other id. Emitting the
+    requested ids and letting that filter run keeps a mixed ``--platform`` list
+    working, where rejecting one here aborted the whole collection.
+    """
     if "platform" not in metafunc.fixturenames:
         return
-    platform = _resolve_platform(metafunc.config)
-    metafunc.parametrize("platform", [platform], ids=[platform])
+    raw_platform = str(metafunc.config.getoption("--platform") or "")
+    tokens = [tok.strip() for tok in raw_platform.split(",") if tok.strip()] or [_DEFAULT_PLATFORM]
+    metafunc.parametrize("platform", tokens, ids=tokens)
 
 
 def _load_kernel_config(work_dir: Path) -> Any:
@@ -93,15 +86,6 @@ def _require_ptoas() -> None:
     if os.environ.get("PTOAS_ROOT") or shutil.which("ptoas"):
         return
     pytest.skip("ptoas is unavailable for the consecutive-tpop/consecutive-tfree runtime regression")
-
-
-def _resolve_backend_type(platform: str) -> BackendType:
-    try:
-        return _PLATFORM_TO_BACKEND[platform]
-    except KeyError as exc:
-        raise pytest.UsageError(
-            "tests/st/runtime/cross_core/test_cross_core_grouped_tpop_tfree.py only supports --platform=a2a3"
-        ) from exc
 
 
 _TRAILING_LOC_RE = re.compile(r'\s+loc\("(?:[^"\\]|\\.)*":\d+:\d+\)\s*$')
@@ -211,7 +195,7 @@ class TestCrossCoreGroupedTpopTfree:
         from harness.core.test_runner import _last_device  # noqa: PLC0415
 
         _require_ptoas()
-        backend_type = _resolve_backend_type(platform)
+        backend_type = platform_to_backend(platform)
         device_id = int(os.environ.get("TASK_DEVICE", str(test_config.device_id)))
 
         test_name = "cross_core_v2c_updown_consecutive_tpop_then_tfree"

--- a/tests/st/runtime/framework_and_models/test_batch_paged_attention.py
+++ b/tests/st/runtime/framework_and_models/test_batch_paged_attention.py
@@ -36,7 +36,6 @@ import pytest
 import torch
 from examples.models.paged_attention_batch import BuildBatchPagedAttentionProgram
 from harness.core.harness import DataType, PTOTestCase, TensorSpec
-from pypto.backend import BackendType
 from pypto.ir.pass_manager import OptimizationStrategy
 
 DEFAULT_SCALE = 1.0
@@ -79,9 +78,6 @@ class BatchQKMatmulTestCase(PTOTestCase):
 
     def get_strategy(self) -> OptimizationStrategy:
         return OptimizationStrategy.Default
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend910B
 
     def define_tensors(self) -> list[TensorSpec]:
         query_rows = self.batch * self.num_heads
@@ -264,9 +260,6 @@ class BatchSoftmaxPrepareTestCase(PTOTestCase):
     def get_strategy(self) -> OptimizationStrategy:
         return OptimizationStrategy.Default
 
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend910B
-
     def define_tensors(self) -> list[TensorSpec]:
         batch_q_tile = self.batch * self.q_tile
 
@@ -439,9 +432,6 @@ class BatchPVMatmulTestCase(PTOTestCase):
 
     def get_strategy(self) -> OptimizationStrategy:
         return OptimizationStrategy.Default
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend910B
 
     def define_tensors(self) -> list[TensorSpec]:
         key_cache_rows = self.batch * self.block_num * self.block_size

--- a/tests/st/runtime/framework_and_models/test_ci.py
+++ b/tests/st/runtime/framework_and_models/test_ci.py
@@ -26,7 +26,6 @@ import pypto.language as pl
 import pytest
 import torch
 from harness.core.harness import DataType, PTOTestCase, TensorSpec
-from pypto.backend import BackendType
 from pypto.ir.pass_manager import OptimizationStrategy
 
 ROWS = 1
@@ -293,9 +292,6 @@ class _CiBaseTestCase(PTOTestCase):
 
     def get_strategy(self) -> OptimizationStrategy:
         return OptimizationStrategy.Default
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend910B
 
 
 class CiAscendStart0TestCase(_CiBaseTestCase):

--- a/tests/st/runtime/framework_and_models/test_dynamic_paged_attention.py
+++ b/tests/st/runtime/framework_and_models/test_dynamic_paged_attention.py
@@ -28,7 +28,6 @@ from examples.models.paged_attention_dynamic import (
     build_dynamic_paged_attention_program,
 )
 from harness.core.harness import DataType, PTOTestCase, TensorSpec
-from pypto.backend import BackendType
 from pypto.ir.pass_manager import OptimizationStrategy
 
 # ---------------------------------------------------------------------------
@@ -80,9 +79,6 @@ class DynamicPagedAttentionTestCase(PTOTestCase):
 
     def get_strategy(self) -> OptimizationStrategy:
         return OptimizationStrategy.Default
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend910B
 
     def get_program(self) -> Any:
         return build_dynamic_paged_attention_program(

--- a/tests/st/runtime/framework_and_models/test_incore_array.py
+++ b/tests/st/runtime/framework_and_models/test_incore_array.py
@@ -30,7 +30,6 @@ import pypto.language as pl
 import pytest
 import torch
 from harness.core.harness import DataType, PTOTestCase, TensorSpec
-from pypto.backend import BackendType
 from pypto.ir.pass_manager import OptimizationStrategy
 
 
@@ -99,9 +98,6 @@ class IncoreArrayRoundTripTestCase(PTOTestCase):
 
     def get_strategy(self) -> OptimizationStrategy:
         return OptimizationStrategy.Default
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend910B
 
     def compute_expected(self, tensors, params=None):
         expected = torch.zeros_like(tensors["dst_t"])
@@ -177,9 +173,6 @@ class IncoreArrayConditionalTestCase(PTOTestCase):
 
     def get_strategy(self) -> OptimizationStrategy:
         return OptimizationStrategy.Default
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend910B
 
     def compute_expected(self, tensors, params=None):
         expected = torch.zeros_like(tensors["dst_t"])

--- a/tests/st/runtime/framework_and_models/test_paged_attention.py
+++ b/tests/st/runtime/framework_and_models/test_paged_attention.py
@@ -45,7 +45,6 @@ from examples.models.paged_attention import (
     kernel_softmax_prepare_unaligned,
 )
 from harness.core.harness import DataType, PTOTestCase, TensorSpec
-from pypto.backend import BackendType
 from pypto.ir.pass_manager import OptimizationStrategy
 
 DEFAULT_SCALE = 0.0884
@@ -735,9 +734,6 @@ class PTOASTestCaseMixin:
 
     def get_strategy(self) -> OptimizationStrategy:
         return OptimizationStrategy.Default
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend910B
 
 
 class QKMatmulPTOASTestCase(PTOASTestCaseMixin, QKMatmulTestCase):

--- a/tests/st/runtime/framework_and_models/test_paged_attention_multi_config.py
+++ b/tests/st/runtime/framework_and_models/test_paged_attention_multi_config.py
@@ -41,7 +41,6 @@ from examples.models.paged_attention_multi_config import (
     make_kernel_qk_matmul,
 )
 from harness.core.harness import DataType, PTOTestCase, TensorSpec
-from pypto.backend import BackendType
 from pypto.ir.pass_manager import OptimizationStrategy
 
 
@@ -595,9 +594,6 @@ class PTOASTestCaseMixin:
 
     def get_strategy(self) -> OptimizationStrategy:
         return OptimizationStrategy.Default
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend910B
 
 
 class SoftmaxPreparePTOASTestCase(PTOASTestCaseMixin, SoftmaxPrepareTestCase):

--- a/tests/st/runtime/framework_and_models/test_paged_attention_spmd.py
+++ b/tests/st/runtime/framework_and_models/test_paged_attention_spmd.py
@@ -21,7 +21,6 @@ from typing import Any
 import pytest
 import torch
 from harness.core.harness import DataType, PTOTestCase, TensorSpec
-from pypto.backend import BackendType
 from pypto.ir.pass_manager import OptimizationStrategy
 
 _spmd_module = importlib.import_module("examples.models.09_paged_attention_spmd")
@@ -102,9 +101,6 @@ class PagedAttentionSpmdTestCase(PTOTestCase):
     def get_strategy(self) -> OptimizationStrategy:
         return OptimizationStrategy.Default
 
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend910B
-
     def get_program(self) -> Any:
         return build_paged_attention_spmd_program(
             batch=self.batch,
@@ -154,9 +150,6 @@ class PTOASTestCaseMixin:
 
     def get_strategy(self) -> OptimizationStrategy:
         return OptimizationStrategy.Default
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend910B
 
 
 class PagedAttentionSpmdPTOASTestCase(PTOASTestCaseMixin, PagedAttentionSpmdTestCase):

--- a/tests/st/runtime/ops/test_argmax_reduction.py
+++ b/tests/st/runtime/ops/test_argmax_reduction.py
@@ -44,7 +44,6 @@ import pypto.language as pl
 import pytest
 import torch
 from harness.core.harness import DataType, PTOTestCase, TensorSpec
-from pypto.backend import BackendType
 
 _PL_DT = {DataType.FP32: pl.FP32, DataType.FP16: pl.FP16}
 _DTYPES = [DataType.FP32, DataType.FP16]
@@ -79,9 +78,6 @@ class _ArgBase(PTOTestCase):
     def get_name(self) -> str:
         v = f"_v{self._valid[0]}x{self._valid[1]}" if self._valid else "_aligned"
         return f"{self.op_name}_{self._m}x{self._n}_{self._dtype.value}{v}"
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend910B
 
     def _out_shape(self) -> list[int]:
         return [self._m, 1] if self.reduce_dim == 1 else [1, self._n]

--- a/tests/st/runtime/ops/test_cast.py
+++ b/tests/st/runtime/ops/test_cast.py
@@ -28,7 +28,6 @@ import pypto.language as pl
 import pytest
 import torch
 from harness.core.harness import DataType, PTOTestCase, TensorSpec
-from pypto.backend import BackendType
 from pypto.ir.pass_manager import OptimizationStrategy
 
 N = 16
@@ -129,9 +128,6 @@ class TileCastColMajorNarrowTestCase(PTOTestCase):
     def get_strategy(self) -> OptimizationStrategy:
         return OptimizationStrategy.Default
 
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend910B
-
     def compute_expected(self, tensors, params=None) -> None:
         # Reshape round-trip is a no-op on values; the cast only narrows the dtype,
         # so each element keeps its value and position: out[0, k] == a[0, k].
@@ -155,9 +151,6 @@ class TileCastRowMajorNarrowTestCase(PTOTestCase):
 
     def get_strategy(self) -> OptimizationStrategy:
         return OptimizationStrategy.Default
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend910B
 
     def compute_expected(self, tensors, params=None) -> None:
         tensors["out"][:] = tensors["a"].to(torch.int16)

--- a/tests/st/runtime/ops/test_col_reduction.py
+++ b/tests/st/runtime/ops/test_col_reduction.py
@@ -25,7 +25,6 @@ import pypto.language as pl
 import pytest
 import torch
 from harness.core.harness import DataType, PTOTestCase, TensorSpec
-from pypto.backend import BackendType
 from pypto.ir.pass_manager import OptimizationStrategy
 
 # =============================================================================
@@ -419,9 +418,6 @@ class ColSum32x64FP32(PTOTestCase):
     def get_strategy(self) -> OptimizationStrategy:
         return OptimizationStrategy.Default
 
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend910B
-
     def define_tensors(self) -> list[TensorSpec]:
         return [
             TensorSpec("input_tensor", [32, 64], DataType.FP32, init_value=torch.randn),
@@ -441,9 +437,6 @@ class ColSum32x64FP32Sequential(PTOTestCase):
 
     def get_strategy(self) -> OptimizationStrategy:
         return OptimizationStrategy.Default
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend910B
 
     def define_tensors(self) -> list[TensorSpec]:
         return [
@@ -465,9 +458,6 @@ class ColSum16x16FP32(PTOTestCase):
     def get_strategy(self) -> OptimizationStrategy:
         return OptimizationStrategy.Default
 
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend910B
-
     def define_tensors(self) -> list[TensorSpec]:
         return [
             TensorSpec("input_tensor", [16, 16], DataType.FP32, init_value=torch.randn),
@@ -488,9 +478,6 @@ class ColSum8x128FP32(PTOTestCase):
     def get_strategy(self) -> OptimizationStrategy:
         return OptimizationStrategy.Default
 
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend910B
-
     def define_tensors(self) -> list[TensorSpec]:
         return [
             TensorSpec("input_tensor", [8, 128], DataType.FP32, init_value=torch.randn),
@@ -510,9 +497,6 @@ class ColSum32x64FP16(PTOTestCase):
 
     def get_strategy(self) -> OptimizationStrategy:
         return OptimizationStrategy.Default
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend910B
 
     def define_tensors(self) -> list[TensorSpec]:
         return [
@@ -545,9 +529,6 @@ class ColSum16x16FP32Sequential(PTOTestCase):
     def get_strategy(self) -> OptimizationStrategy:
         return OptimizationStrategy.Default
 
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend910B
-
     def define_tensors(self) -> list[TensorSpec]:
         return [
             TensorSpec("input_tensor", [16, 16], DataType.FP32, init_value=torch.randn),
@@ -568,9 +549,6 @@ class ColSum8x128FP32Sequential(PTOTestCase):
     def get_strategy(self) -> OptimizationStrategy:
         return OptimizationStrategy.Default
 
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend910B
-
     def define_tensors(self) -> list[TensorSpec]:
         return [
             TensorSpec("input_tensor", [8, 128], DataType.FP32, init_value=torch.randn),
@@ -590,9 +568,6 @@ class ColSum32x64FP16Sequential(PTOTestCase):
 
     def get_strategy(self) -> OptimizationStrategy:
         return OptimizationStrategy.Default
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend910B
 
     def define_tensors(self) -> list[TensorSpec]:
         return [
@@ -624,9 +599,6 @@ class ColMax32x64FP32(PTOTestCase):
     def get_strategy(self) -> OptimizationStrategy:
         return OptimizationStrategy.Default
 
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend910B
-
     def define_tensors(self) -> list[TensorSpec]:
         return [
             TensorSpec("input_tensor", [32, 64], DataType.FP32, init_value=torch.randn),
@@ -646,9 +618,6 @@ class ColMax16x16FP32(PTOTestCase):
 
     def get_strategy(self) -> OptimizationStrategy:
         return OptimizationStrategy.Default
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend910B
 
     def define_tensors(self) -> list[TensorSpec]:
         return [
@@ -670,9 +639,6 @@ class ColMax8x128FP32(PTOTestCase):
     def get_strategy(self) -> OptimizationStrategy:
         return OptimizationStrategy.Default
 
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend910B
-
     def define_tensors(self) -> list[TensorSpec]:
         return [
             TensorSpec("input_tensor", [8, 128], DataType.FP32, init_value=torch.randn),
@@ -692,9 +658,6 @@ class ColMax32x64FP16(PTOTestCase):
 
     def get_strategy(self) -> OptimizationStrategy:
         return OptimizationStrategy.Default
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend910B
 
     def define_tensors(self) -> list[TensorSpec]:
         return [
@@ -721,9 +684,6 @@ class ColMin32x64FP32(PTOTestCase):
     def get_strategy(self) -> OptimizationStrategy:
         return OptimizationStrategy.Default
 
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend910B
-
     def define_tensors(self) -> list[TensorSpec]:
         return [
             TensorSpec("input_tensor", [32, 64], DataType.FP32, init_value=torch.randn),
@@ -743,9 +703,6 @@ class ColMin16x16FP32(PTOTestCase):
 
     def get_strategy(self) -> OptimizationStrategy:
         return OptimizationStrategy.Default
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend910B
 
     def define_tensors(self) -> list[TensorSpec]:
         return [
@@ -767,9 +724,6 @@ class ColMin8x128FP32(PTOTestCase):
     def get_strategy(self) -> OptimizationStrategy:
         return OptimizationStrategy.Default
 
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend910B
-
     def define_tensors(self) -> list[TensorSpec]:
         return [
             TensorSpec("input_tensor", [8, 128], DataType.FP32, init_value=torch.randn),
@@ -789,9 +743,6 @@ class ColMin32x64FP16(PTOTestCase):
 
     def get_strategy(self) -> OptimizationStrategy:
         return OptimizationStrategy.Default
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend910B
 
     def define_tensors(self) -> list[TensorSpec]:
         return [

--- a/tests/st/runtime/ops/test_expand_ops.py
+++ b/tests/st/runtime/ops/test_expand_ops.py
@@ -27,7 +27,6 @@ import pypto.language as pl
 import pytest
 import torch
 from harness.core.harness import DataType, PTOTestCase, TensorSpec
-from pypto.backend import BackendType
 from pypto.ir.pass_manager import OptimizationStrategy
 
 M, N = 32, 64
@@ -216,9 +215,6 @@ class _ExpandCase(PTOTestCase):
 
     def get_strategy(self) -> OptimizationStrategy:
         return OptimizationStrategy.Default
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend910B
 
     def define_tensors(self) -> list[TensorSpec]:
         return [

--- a/tests/st/runtime/ops/test_fillpad_expand.py
+++ b/tests/st/runtime/ops/test_fillpad_expand.py
@@ -34,7 +34,6 @@ import pypto.language as pl
 import pytest
 import torch
 from harness.core.harness import DataType, PTOTestCase, TensorSpec
-from pypto.backend import BackendType
 from pypto.ir.pass_manager import OptimizationStrategy
 
 # =============================================================================
@@ -316,9 +315,6 @@ class _FillpadExpandCase(PTOTestCase):
 
     def get_strategy(self) -> OptimizationStrategy:
         return OptimizationStrategy.Default
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend910B
 
     def define_tensors(self) -> list[TensorSpec]:
         return [

--- a/tests/st/runtime/ops/test_gather.py
+++ b/tests/st/runtime/ops/test_gather.py
@@ -43,7 +43,6 @@ import pypto.language as pl
 import pytest
 import torch
 from harness.core.harness import PLATFORMS, DataType, PTOTestCase, TensorSpec
-from pypto.backend import BackendType
 from pypto.ir.pass_manager import OptimizationStrategy
 
 # --- Shared init helpers ---
@@ -560,12 +559,6 @@ class GatherA5INT16IndexTestCase(_GatherBaseTestCase):
 
     def get_name(self) -> str:
         return "gather_a5_int16_index"
-
-    def get_backend_type(self) -> BackendType:
-        # INT16 indices are an A5 feature. Pin the backend so the global
-        # ``set_backend_type`` matches the parametrized ``a5`` platform — the
-        # base class otherwise defaults to Ascend910B.
-        return BackendType.Ascend950
 
     def define_tensors(self) -> list[TensorSpec]:
         return [

--- a/tests/st/runtime/ops/test_gather_row_dynamic_valid_shape.py
+++ b/tests/st/runtime/ops/test_gather_row_dynamic_valid_shape.py
@@ -48,7 +48,6 @@ import pypto.language as pl
 import pytest
 import torch
 from harness.core.harness import PLATFORMS, DataType, PTOTestCase, TensorSpec
-from pypto.backend import BackendType
 from pypto.ir.pass_manager import OptimizationStrategy
 
 HEAD_DIM = 128
@@ -119,9 +118,6 @@ class GatherRowDynamicValidShapeTestCase(PTOTestCase):
 
     def get_strategy(self) -> OptimizationStrategy:
         return OptimizationStrategy.Default
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend910B
 
     def get_program(self) -> Any:
         return GatherRowDynamicValidShapeProgram

--- a/tests/st/runtime/ops/test_paged_gather.py
+++ b/tests/st/runtime/ops/test_paged_gather.py
@@ -35,7 +35,6 @@ import pypto.language as pl
 import pytest
 import torch
 from harness.core.harness import PLATFORMS, DataType, PTOTestCase, TensorSpec
-from pypto.backend import BackendType
 from pypto.ir.pass_manager import OptimizationStrategy
 
 # Paged KV pool geometry.
@@ -147,9 +146,6 @@ class _PagedGatherBaseTestCase(PTOTestCase):
 
     def get_strategy(self) -> OptimizationStrategy:
         return OptimizationStrategy.Default
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend910B
 
     def define_tensors(self) -> list[TensorSpec]:
         return [

--- a/tests/st/runtime/ops/test_prod_reduction.py
+++ b/tests/st/runtime/ops/test_prod_reduction.py
@@ -28,7 +28,6 @@ import pypto.language as pl
 import pytest
 import torch
 from harness.core.harness import DataType, PTOTestCase, TensorSpec
-from pypto.backend import BackendType
 from pypto.ir.pass_manager import OptimizationStrategy
 
 
@@ -251,9 +250,6 @@ class RowProd32x64FP32(PTOTestCase):
     def get_strategy(self) -> OptimizationStrategy:
         return OptimizationStrategy.Default
 
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend910B
-
     def define_tensors(self) -> list[TensorSpec]:
         return [
             TensorSpec("input_tensor", [32, 64], DataType.FP32, init_value=_prod_init([32, 64])),
@@ -274,9 +270,6 @@ class RowProd16x16FP32(PTOTestCase):
     def get_strategy(self) -> OptimizationStrategy:
         return OptimizationStrategy.Default
 
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend910B
-
     def define_tensors(self) -> list[TensorSpec]:
         return [
             TensorSpec("input_tensor", [16, 16], DataType.FP32, init_value=_prod_init([16, 16])),
@@ -296,9 +289,6 @@ class RowProd8x128FP32(PTOTestCase):
 
     def get_strategy(self) -> OptimizationStrategy:
         return OptimizationStrategy.Default
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend910B
 
     def define_tensors(self) -> list[TensorSpec]:
         return [
@@ -327,9 +317,6 @@ class RowProd32x64FP16(PTOTestCase):
     def get_strategy(self) -> OptimizationStrategy:
         return OptimizationStrategy.Default
 
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend910B
-
     def define_tensors(self) -> list[TensorSpec]:
         return [
             TensorSpec("input_tensor", [32, 64], DataType.FP16, init_value=_prod_init([32, 64])),
@@ -355,9 +342,6 @@ class ColProd32x64FP32(PTOTestCase):
     def get_strategy(self) -> OptimizationStrategy:
         return OptimizationStrategy.Default
 
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend910B
-
     def define_tensors(self) -> list[TensorSpec]:
         return [
             TensorSpec("input_tensor", [32, 64], DataType.FP32, init_value=_prod_init([32, 64])),
@@ -378,9 +362,6 @@ class ColProd16x16FP32(PTOTestCase):
     def get_strategy(self) -> OptimizationStrategy:
         return OptimizationStrategy.Default
 
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend910B
-
     def define_tensors(self) -> list[TensorSpec]:
         return [
             TensorSpec("input_tensor", [16, 16], DataType.FP32, init_value=_prod_init([16, 16])),
@@ -400,9 +381,6 @@ class ColProd8x128FP32(PTOTestCase):
 
     def get_strategy(self) -> OptimizationStrategy:
         return OptimizationStrategy.Default
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend910B
 
     def define_tensors(self) -> list[TensorSpec]:
         return [
@@ -429,9 +407,6 @@ class ColProd32x64FP16(PTOTestCase):
 
     def get_strategy(self) -> OptimizationStrategy:
         return OptimizationStrategy.Default
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend910B
 
     def define_tensors(self) -> list[TensorSpec]:
         return [
@@ -582,9 +557,6 @@ class RowProdValidCol48FP32(PTOTestCase):
     def get_strategy(self) -> OptimizationStrategy:
         return OptimizationStrategy.Default
 
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend910B
-
     def define_tensors(self) -> list[TensorSpec]:
         return [
             TensorSpec("input_tensor", [32, 64], DataType.FP32, init_value=_prod_init([32, 64])),
@@ -606,9 +578,6 @@ class RowProdValidCol50FP32(PTOTestCase):
     def get_strategy(self) -> OptimizationStrategy:
         return OptimizationStrategy.Default
 
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend910B
-
     def define_tensors(self) -> list[TensorSpec]:
         return [
             TensorSpec("input_tensor", [32, 64], DataType.FP32, init_value=_prod_init([32, 64])),
@@ -629,9 +598,6 @@ class ColProdValidRow20FP32(PTOTestCase):
 
     def get_strategy(self) -> OptimizationStrategy:
         return OptimizationStrategy.Default
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend910B
 
     def define_tensors(self) -> list[TensorSpec]:
         return [
@@ -719,9 +685,6 @@ class TensorRowProd32x64FP32(PTOTestCase):
     def get_strategy(self) -> OptimizationStrategy:
         return OptimizationStrategy.Default
 
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend910B
-
     def define_tensors(self) -> list[TensorSpec]:
         return [
             TensorSpec("a", [32, 64], DataType.FP32, init_value=_prod_init([32, 64])),
@@ -741,9 +704,6 @@ class TensorColProd32x64FP32(PTOTestCase):
 
     def get_strategy(self) -> OptimizationStrategy:
         return OptimizationStrategy.Default
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend910B
 
     def define_tensors(self) -> list[TensorSpec]:
         return [

--- a/tests/st/runtime/ops/test_random.py
+++ b/tests/st/runtime/ops/test_random.py
@@ -44,7 +44,6 @@ import pypto.language as pl
 import pytest
 import torch
 from harness.core.harness import PLATFORMS, DataType, PTOTestCase, TensorSpec
-from pypto.backend import BackendType
 from pypto.ir.pass_manager import OptimizationStrategy
 
 # =============================================================================
@@ -180,9 +179,6 @@ class _RandomDetermCase(PTOTestCase):
 
     def get_strategy(self) -> OptimizationStrategy:
         return OptimizationStrategy.Default
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend950
 
     def define_tensors(self) -> list[TensorSpec]:
         return [TensorSpec("output", self.out_shape, self.dtype, is_output=True)]

--- a/tests/st/runtime/ops/test_scalar_write_transpose.py
+++ b/tests/st/runtime/ops/test_scalar_write_transpose.py
@@ -15,7 +15,6 @@ import pypto.language as pl
 import pytest
 import torch
 from harness.core.harness import DataType, PTOTestCase, TensorSpec
-from pypto.backend import BackendType
 from pypto.ir.pass_manager import OptimizationStrategy
 
 ROWS = 16
@@ -180,9 +179,6 @@ class _FP32WriteBase(PTOTestCase):
     def get_strategy(self) -> OptimizationStrategy:
         return OptimizationStrategy.Default
 
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend910B
-
     def compute_expected(self, tensors, params=None):
         expected = torch.full((ROWS, COLS), -1.0, dtype=torch.float32)
         vals = tensors["vals"].reshape(TOPK, ROWS)
@@ -200,9 +196,6 @@ class _INT32WriteBase(PTOTestCase):
 
     def get_strategy(self) -> OptimizationStrategy:
         return OptimizationStrategy.Default
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend910B
 
     def compute_expected(self, tensors, params=None):
         expected = torch.full((ROWS, COLS), -7, dtype=torch.int32)

--- a/tests/st/runtime/ops/test_scatter.py
+++ b/tests/st/runtime/ops/test_scatter.py
@@ -76,7 +76,6 @@ import pypto.language as pl
 import pytest
 import torch
 from harness.core.harness import PLATFORMS, DataType, PTOTestCase, TensorSpec
-from pypto.backend import BackendType
 from pypto.ir.pass_manager import OptimizationStrategy
 
 # --- Data builders (negative sentinel base, positive distinct values) ---
@@ -432,9 +431,6 @@ class _ScatterBaseTestCase(PTOTestCase):
     def get_strategy(self) -> OptimizationStrategy:
         return OptimizationStrategy.Default
 
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend910B
-
     def compute_expected(self, tensors, params=None):
         # Ground truth derived from the actual index + values (not a copy of any
         # input): a no-op leaves `base` (all negative) and fails immediately, and
@@ -553,10 +549,6 @@ class _ScatterMaskBaseTestCase(PTOTestCase):
 
     def get_strategy(self) -> OptimizationStrategy:
         return OptimizationStrategy.Default
-
-    def get_backend_type(self) -> BackendType:
-        # Mask-form pto.tscatter is an A2/A3 feature; A5 (Ascend950) rejects it.
-        return BackendType.Ascend910B
 
     def compute_expected(self, tensors, params=None):
         # Preserve dst's unselected (sentinel) columns; write inp into the

--- a/tests/st/runtime/ops/test_scatter.py
+++ b/tests/st/runtime/ops/test_scatter.py
@@ -59,7 +59,8 @@ values to repeated targets).
 gather: each compact ``input`` row is written into the mask-selected columns of
 the wider ``dst`` (``dst.cols == input.cols * stride``). The form runs on the
 A2/A3 backend (``BackendType.Ascend910B``); A5 (``Ascend950``) rejects it, so
-those cases are pinned to A2/A3 only. Column selection mirrors gather: P0101
+``TestScatterMaskForm`` carries a ``platforms`` marker restricting it to the
+A2/A3 ids. Column selection mirrors gather: P0101
 hits even columns (``0::2``), P1010 hits odd columns (``1::2``).
 
 The raw ``pto.tscatter`` mask instruction zero-fills the entire ``dst`` before
@@ -535,7 +536,10 @@ class Scatter1RowTestCase(_ScatterBaseTestCase):
 
 
 class _ScatterMaskBaseTestCase(PTOTestCase):
-    """Base for mask-form scatter cases. Pinned to A2/A3 (Ascend910B).
+    """Base for mask-form scatter cases.
+
+    A2/A3 only — the restriction lives on ``TestScatterMaskForm``'s
+    ``platforms`` marker, since a case follows whatever platform it is run on.
 
     Subclasses set ``_start`` (0 for P0101, 1 for P1010) and ``_stride`` (2);
     ``compute_expected`` writes ``inp`` into the ``[start::stride]`` columns of
@@ -672,6 +676,13 @@ class TestScatterIndexForm:
         assert result.passed, f"Test failed: {result.error}"
 
 
+# The mask form is A2/A3 only. That restriction used to ride on a
+# ``get_backend_type`` pin on the case classes; it belongs on the tests, which
+# is what the platform matrix reads. Worth re-checking on silicon: under ptoas
+# 0.57 all four compile *and* pass on a5sim, so the rejection may no longer
+# hold — but a5sim has been wrong about 950 before (it does not model the
+# on-chip layout), so this stays restricted until a board run says otherwise.
+@pytest.mark.platforms("a2a3", "a2a3sim", reason="A5/Ascend950 rejects the pto.tscatter mask form")
 class TestScatterMaskForm:
     """Mask-form row scatter — A2/A3 only (A5/Ascend950 rejects the mask form).
 

--- a/tests/st/runtime/ops/test_scatter_update.py
+++ b/tests/st/runtime/ops/test_scatter_update.py
@@ -25,7 +25,6 @@ import pypto.language as pl
 import pytest
 import torch
 from harness.core.harness import DataType, PTOTestCase, TensorSpec
-from pypto.backend import BackendType
 from pypto.ir.pass_manager import OptimizationStrategy
 
 
@@ -255,9 +254,6 @@ class TileScatterUpdateTestCase(PTOTestCase):
     def get_strategy(self) -> OptimizationStrategy:
         return OptimizationStrategy.Default
 
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend910B
-
     def compute_expected(self, tensors, params=None):
         input_t = tensors["input_t"].clone()
         index_t = tensors["index_t"]
@@ -296,9 +292,6 @@ class TileScatterUpdateFP16TestCase(PTOTestCase):
     def get_strategy(self) -> OptimizationStrategy:
         return OptimizationStrategy.Default
 
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend910B
-
     def compute_expected(self, tensors, params=None):
         input_t = tensors["input_t"].clone()
         index_t = tensors["index_t"]
@@ -336,9 +329,6 @@ class TileScatterUpdateDuplicateIndicesTestCase(PTOTestCase):
     def get_strategy(self) -> OptimizationStrategy:
         return OptimizationStrategy.Default
 
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend910B
-
     def compute_expected(self, tensors, params=None):
         input_t = tensors["input_t"].clone()
         index_t = tensors["index_t"]
@@ -374,9 +364,6 @@ class TileScatterUpdateSingleBatchTestCase(PTOTestCase):
 
     def get_strategy(self) -> OptimizationStrategy:
         return OptimizationStrategy.Default
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend910B
 
     def compute_expected(self, tensors, params=None):
         input_t = tensors["input_t"].clone()
@@ -415,9 +402,6 @@ class TileScatterUpdateShuffledIndicesTestCase(PTOTestCase):
 
     def get_strategy(self) -> OptimizationStrategy:
         return OptimizationStrategy.Default
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend910B
 
     def compute_expected(self, tensors, params=None):
         input_t = tensors["input_t"].clone()
@@ -469,9 +453,6 @@ class IndexCastFromTileReadTestCase(PTOTestCase):
     def get_strategy(self) -> OptimizationStrategy:
         return OptimizationStrategy.Default
 
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend910B
-
     def compute_expected(self, tensors, params=None):
         expected = torch.zeros_like(tensors["dst_t"])
         row = int(tensors["index_t"][0, 0].item())
@@ -508,9 +489,6 @@ class IndexCastToTileInsertTestCase(PTOTestCase):
 
     def get_strategy(self) -> OptimizationStrategy:
         return OptimizationStrategy.Default
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend910B
 
     def compute_expected(self, tensors, params=None):
         expected = tensors["input_t"].clone()

--- a/tests/st/runtime/test_fused_matmul_scatter.py
+++ b/tests/st/runtime/test_fused_matmul_scatter.py
@@ -44,7 +44,6 @@ import pypto.language as pl
 import pytest
 import torch
 from harness.core.harness import PLATFORMS, DataType, PTOTestCase, TensorSpec
-from pypto.backend import BackendType
 from pypto.ir.pass_manager import OptimizationStrategy
 
 # Shapes match the issue repro exactly.
@@ -146,9 +145,6 @@ class FusedMatmulScatterTestCase(PTOTestCase):
     def get_strategy(self) -> OptimizationStrategy:
         return OptimizationStrategy.Default
 
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend910B
-
     def define_tensors(self) -> list[TensorSpec]:
         return [
             TensorSpec("x", [B, H], DataType.BF16, init_value=_make_x),
@@ -188,9 +184,6 @@ class ScatterOnlyTestCase(PTOTestCase):
 
     def get_strategy(self) -> OptimizationStrategy:
         return OptimizationStrategy.Default
-
-    def get_backend_type(self) -> BackendType:
-        return BackendType.Ascend910B
 
     def define_tensors(self) -> list[TensorSpec]:
         return [

--- a/tests/ut/runtime/test_st_platform_matrix.py
+++ b/tests/ut/runtime/test_st_platform_matrix.py
@@ -55,6 +55,19 @@ def _load_st_conftest():
     return module
 
 
+@pytest.fixture(autouse=True)
+def _restore_published_platform():
+    """Keep the module-global item platform from leaking between tests.
+
+    The ``platform_xfail`` tests call the conftest hook that publishes it, and
+    ``_resolve_platform`` reads it as a fallback — so without this a later test
+    in the same worker sees a platform no one set for it.
+    """
+    saved = test_runner._current_item_platform["value"]
+    yield
+    test_runner.set_current_item_platform(saved)
+
+
 class _Case(harness.PTOTestCase):
     """Minimal concrete case: no platform, no backend pin."""
 

--- a/tests/ut/runtime/test_st_platform_matrix.py
+++ b/tests/ut/runtime/test_st_platform_matrix.py
@@ -1,0 +1,288 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Unit tests for the system-test platform matrix.
+
+These pin the two halves of "any case, any platform":
+
+- the *guard*: a case pinning ``get_backend_type()`` is skipped instead of
+  being compiled for one architecture and executed on another;
+- the *matrix*: ``pytest_generate_tests`` expands ``test_runner``-based tests
+  over the ``--platform`` allowlist, and each variant keys its own artefact.
+
+The harness package (``harness.core.*``) and the system-test ``conftest.py``
+live under ``tests/st``; both are loaded by path so this stays a device-free
+unit test.
+"""
+
+import importlib
+import importlib.util
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from pypto.backend import BackendType
+from pypto.pypto_core.passes import MemoryPlanner
+
+_ST_DIR = Path(__file__).resolve().parents[2] / "st"
+if str(_ST_DIR) not in sys.path:
+    sys.path.insert(0, str(_ST_DIR))
+
+harness = importlib.import_module("harness.core.harness")
+test_runner = importlib.import_module("harness.core.test_runner")
+
+
+def _load_st_conftest():
+    """Import tests/st/conftest.py under a private name.
+
+    Loaded by path rather than ``import conftest`` so pytest's own conftest
+    collection is not disturbed.
+    """
+    path = _ST_DIR / "conftest.py"
+    spec = importlib.util.spec_from_file_location("_st_conftest_matrix_under_test", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class _Case(harness.PTOTestCase):
+    """Minimal concrete case: no platform, no backend pin."""
+
+    def get_name(self) -> str:
+        return "matrix_case"
+
+    def define_tensors(self) -> list[Any]:
+        return []
+
+    def get_program(self) -> Any:
+        return object()
+
+    def compute_expected(self, tensors, params=None) -> None:
+        pass
+
+
+class _PinnedCase(_Case):
+    """Legacy shape: the subclass hard-pins the backend."""
+
+    def get_name(self) -> str:
+        return "pinned_case"
+
+    def get_backend_type(self) -> BackendType:
+        return BackendType.Ascend910B
+
+
+# ---------------------------------------------------------------------------
+# The guard: pinned backend vs resolved platform
+# ---------------------------------------------------------------------------
+
+
+def test_unpinned_case_follows_the_platform():
+    case = _Case()
+    assert test_runner._bind_and_check_arch(case, "a5") is None
+    # Binding is what makes the compile follow the platform: before it, the
+    # base class answers with the Ascend910B default whatever the platform is.
+    assert case.get_backend_type() is BackendType.Ascend950
+    assert case.get_platform() == "a5"
+
+
+def test_pinned_case_is_skipped_on_the_other_arch():
+    reason = test_runner._bind_and_check_arch(_PinnedCase(), "a5")
+    assert reason is not None
+    assert "get_backend_type()=Ascend910B" in reason
+    assert "--platform=a5" in reason
+    # The message must say how to fix it, not just that it broke.
+    assert "platforms(" in reason
+
+
+def test_pinned_case_still_runs_on_its_own_arch():
+    assert test_runner._bind_and_check_arch(_PinnedCase(), "a2a3sim") is None
+
+
+def test_bind_platform_never_overrides_an_explicit_pin():
+    case = _Case(platform="a2a3sim")
+    case.bind_platform("a5")
+    assert case.get_platform() == "a2a3sim"
+    assert case.get_backend_type() is BackendType.Ascend910B
+
+
+def test_bind_platform_rejects_an_unknown_id():
+    with pytest.raises(ValueError, match="Unknown platform"):
+        _Case().bind_platform("a9")
+
+
+def test_cache_key_separates_the_platform_variants():
+    a2a3, a5 = _Case(), _Case()
+    a2a3.bind_platform("a2a3")
+    a5.bind_platform("a5sim")
+    key_a2a3 = test_runner._cache_key(a2a3, session_memory_planner=MemoryPlanner.PYPTO)
+    key_a5 = test_runner._cache_key(a5, session_memory_planner=MemoryPlanner.PYPTO)
+    assert key_a2a3 != key_a5
+    assert key_a2a3.endswith("@a2a3@pypto") and key_a5.endswith("@a5sim@pypto")
+
+
+# ---------------------------------------------------------------------------
+# The matrix: pytest_generate_tests
+# ---------------------------------------------------------------------------
+
+
+class _FakeMetafunc:
+    """Stand-in for ``pytest.Metafunc`` recording a single parametrize call."""
+
+    def __init__(self, platform_option: str, fixturenames: list[str], marker_args=None):
+        self.fixturenames = fixturenames
+        self.config = SimpleNamespace(getoption=lambda name: {"--platform": platform_option}[name])
+        marker = SimpleNamespace(args=tuple(marker_args), kwargs={}) if marker_args is not None else None
+        self.definition = SimpleNamespace(
+            name="test_fake",
+            get_closest_marker=lambda name: marker if name == "platforms" else None,
+        )
+        self.calls: list[tuple] = []
+
+    def parametrize(self, argname, argvalues, ids=None, indirect=False):
+        self.calls.append((argname, list(argvalues), list(ids or []), indirect))
+
+
+_RUNNER_FIXTURES = ["test_runner", "_st_platform", "test_config"]
+
+
+def _generate(metafunc):
+    _load_st_conftest().pytest_generate_tests(metafunc)
+    return metafunc.calls
+
+
+def test_single_platform_keeps_todays_node_ids():
+    # One active platform: no parametrize, so `test_foo` does not become
+    # `test_foo[a2a3]` for every existing CI selector.
+    assert _generate(_FakeMetafunc("a2a3", _RUNNER_FIXTURES)) == []
+
+
+def test_multi_platform_expands_over_the_allowlist():
+    calls = _generate(_FakeMetafunc("a2a3,a5sim", _RUNNER_FIXTURES))
+    assert calls == [("_st_platform", ["a2a3", "a5sim"], ["a2a3", "a5sim"], True)]
+
+
+def test_expansion_intersects_the_platforms_marker():
+    calls = _generate(_FakeMetafunc("a2a3,a2a3sim,a5", _RUNNER_FIXTURES, marker_args=["a2a3", "a2a3sim"]))
+    assert calls == [("_st_platform", ["a2a3", "a2a3sim"], ["a2a3", "a2a3sim"], True)]
+
+
+def test_marker_narrowing_to_one_platform_does_not_parametrize():
+    assert _generate(_FakeMetafunc("a2a3,a5", _RUNNER_FIXTURES, marker_args=["a5"])) == []
+
+
+def test_marker_outside_the_allowlist_leaves_the_item_for_deselection():
+    # Empty intersection: nothing to parametrize, and pytest_collection_modifyitems
+    # drops the item because its effective allowed set is empty.
+    assert _generate(_FakeMetafunc("a2a3", _RUNNER_FIXTURES, marker_args=["a5", "a5sim"])) == []
+
+
+def test_explicitly_parametrized_tests_are_left_alone():
+    fixtures = [*_RUNNER_FIXTURES, "platform"]
+    assert _generate(_FakeMetafunc("a2a3,a5", fixtures)) == []
+
+
+def test_backend_type_tests_keep_their_own_generator():
+    # tests/st/runtime/cross_core/ drives arch selection from its own
+    # pytest_generate_tests; expanding it here would double-parametrize it.
+    fixtures = [*_RUNNER_FIXTURES, "backend_type"]
+    assert _generate(_FakeMetafunc("a2a3,a5", fixtures)) == []
+
+
+def test_tests_without_the_runner_are_untouched():
+    assert _generate(_FakeMetafunc("a2a3,a5", ["tmp_path"])) == []
+
+
+def test_empty_platform_option_expands_over_every_platform():
+    calls = _generate(_FakeMetafunc("", _RUNNER_FIXTURES))
+    assert calls == [("_st_platform", list(harness.ALL_PLATFORM_IDS), list(harness.ALL_PLATFORM_IDS), True)]
+
+
+def test_a_typo_in_the_platforms_marker_fails_collection():
+    # Before, an unknown id narrowed the marker to nothing and the test was
+    # silently deselected on every platform.
+    with pytest.raises(pytest.UsageError, match="unknown platform id"):
+        _generate(_FakeMetafunc("a2a3,a5", _RUNNER_FIXTURES, marker_args=["a2a3", "a5typo"]))
+
+
+def test_an_empty_platforms_marker_fails_collection():
+    with pytest.raises(pytest.UsageError, match="no platform ids"):
+        _generate(_FakeMetafunc("a2a3,a5", _RUNNER_FIXTURES, marker_args=[]))
+
+
+# ---------------------------------------------------------------------------
+# platform_xfail
+# ---------------------------------------------------------------------------
+
+
+class _FakeItem:
+    """Stand-in for a collected item carrying a ``platform_xfail`` marker."""
+
+    def __init__(self, platform_option: str, args, kwargs, params=None):
+        self.name = "test_fake"
+        self.config = SimpleNamespace(getoption=lambda name: {"--platform": platform_option}[name])
+        self.callspec = SimpleNamespace(params=dict(params or {}))
+        self._marker = SimpleNamespace(args=tuple(args), kwargs=dict(kwargs))
+        self.added: list[Any] = []
+
+    def get_closest_marker(self, name):
+        return self._marker if name == "platform_xfail" else None
+
+    def add_marker(self, marker):
+        self.added.append(marker)
+
+
+def _setup(item):
+    _load_st_conftest().pytest_runtest_setup(item)
+    return item.added
+
+
+def test_platform_xfail_applies_on_the_listed_platform():
+    item = _FakeItem("a5", ["a5"], {"reason": "950 board only"}, params={"_st_platform": "a5"})
+    (marker,) = _setup(item)
+    assert marker.kwargs["reason"] == "950 board only"
+    # Strict by default: a deterministic failure that starts passing must be
+    # reported, not silently absorbed.
+    assert marker.kwargs["strict"] is True
+
+
+def test_platform_xfail_is_inert_on_other_platforms():
+    item = _FakeItem("a2a3", ["a5"], {"reason": "950 board only"}, params={"_st_platform": "a2a3"})
+    assert _setup(item) == []
+
+
+def test_platform_xfail_falls_back_to_the_cli_platform():
+    # cross_core-style items carry no platform param; the session's first
+    # --platform id is what their module-level generator resolves too.
+    item = _FakeItem("a5", ["a5"], {"reason": "950 board only"})
+    assert len(_setup(item)) == 1
+
+
+def test_platform_xfail_honours_an_explicit_non_strict():
+    item = _FakeItem("a5", ["a5"], {"reason": "flaky on 950", "strict": False})
+    (marker,) = _setup(item)
+    assert marker.kwargs["strict"] is False
+
+
+def test_platform_xfail_requires_a_reason():
+    item = _FakeItem("a5", ["a5"], {})
+    with pytest.raises(pytest.UsageError, match="needs reason"):
+        _setup(item)
+
+
+def test_platform_xfail_rejects_a_typo():
+    item = _FakeItem("a5", ["a5typo"], {"reason": "950 board only"})
+    with pytest.raises(pytest.UsageError, match="unknown platform id"):
+        _setup(item)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/ut/runtime/test_st_platform_matrix.py
+++ b/tests/ut/runtime/test_st_platform_matrix.py
@@ -23,6 +23,7 @@ unit test.
 
 import importlib
 import importlib.util
+import inspect
 import sys
 from pathlib import Path
 from types import SimpleNamespace
@@ -114,6 +115,20 @@ def test_bind_platform_never_overrides_an_explicit_pin():
     assert case.get_backend_type() is BackendType.Ascend910B
 
 
+def test_a_constructor_backend_pin_is_not_overridden():
+    # `PTOTestCase(backend_type=...)` is a pin like a get_backend_type override:
+    # binding a platform over it would win silently and hide the conflict.
+    case = _Case(backend_type=BackendType.Ascend910B)
+    reason = test_runner._bind_and_check_arch(case, "a5")
+    assert reason is not None and "Ascend910B" in reason
+    assert case.get_backend_type() is BackendType.Ascend910B
+
+
+def test_a_matching_constructor_backend_pin_runs():
+    case = _Case(backend_type=BackendType.Ascend910B)
+    assert test_runner._bind_and_check_arch(case, "a2a3sim") is None
+
+
 def test_bind_platform_rejects_an_unknown_id():
     with pytest.raises(ValueError, match="Unknown platform"):
         _Case().bind_platform("a9")
@@ -134,11 +149,24 @@ def test_cache_key_separates_the_platform_variants():
 # ---------------------------------------------------------------------------
 
 
+def _fn_taking(*argnames: str):
+    """Return a function whose signature requests exactly *argnames*."""
+
+    def _test(*_args, **_kwargs):
+        pass
+
+    _test.__signature__ = inspect.Signature(
+        [inspect.Parameter(name, inspect.Parameter.POSITIONAL_OR_KEYWORD) for name in argnames]
+    )
+    return _test
+
+
 class _FakeMetafunc:
     """Stand-in for ``pytest.Metafunc`` recording a single parametrize call."""
 
-    def __init__(self, platform_option: str, fixturenames: list[str], marker_args=None):
+    def __init__(self, platform_option: str, fixturenames: list[str], marker_args=None, signature=None):
         self.fixturenames = fixturenames
+        self.function = _fn_taking(*(signature if signature is not None else fixturenames))
         self.config = SimpleNamespace(getoption=lambda name: {"--platform": platform_option}[name])
         marker = SimpleNamespace(args=tuple(marker_args), kwargs={}) if marker_args is not None else None
         self.definition = SimpleNamespace(
@@ -148,7 +176,8 @@ class _FakeMetafunc:
         self.calls: list[tuple] = []
 
     def parametrize(self, argname, argvalues, ids=None, indirect=False):
-        self.calls.append((argname, list(argvalues), list(ids or []), indirect))
+        recorded_indirect = list(indirect) if isinstance(indirect, (list, tuple)) else indirect
+        self.calls.append((argname, list(argvalues), list(ids or []), recorded_indirect))
 
 
 _RUNNER_FIXTURES = ["test_runner", "_st_platform", "test_config"]
@@ -175,8 +204,11 @@ def test_expansion_intersects_the_platforms_marker():
     assert calls == [("_st_platform", ["a2a3", "a2a3sim"], ["a2a3", "a2a3sim"], True)]
 
 
-def test_marker_narrowing_to_one_platform_does_not_parametrize():
-    assert _generate(_FakeMetafunc("a2a3,a5", _RUNNER_FIXTURES, marker_args=["a5"])) == []
+def test_marker_narrowing_to_one_platform_still_binds_it():
+    # Without the parametrize the item would carry no platform and fall back to
+    # the first CLI id — a2a3 — which its own marker excludes.
+    calls = _generate(_FakeMetafunc("a2a3,a5", _RUNNER_FIXTURES, marker_args=["a5"]))
+    assert calls == [("_st_platform", ["a5"], ["a5"], True)]
 
 
 def test_marker_outside_the_allowlist_leaves_the_item_for_deselection():
@@ -190,15 +222,57 @@ def test_explicitly_parametrized_tests_are_left_alone():
     assert _generate(_FakeMetafunc("a2a3,a5", fixtures)) == []
 
 
-def test_backend_type_tests_keep_their_own_generator():
-    # tests/st/runtime/cross_core/ drives arch selection from its own
-    # pytest_generate_tests; expanding it here would double-parametrize it.
+def test_backend_type_is_paired_with_the_platform():
+    # One parametrize, not two: a separate backend_type axis would let the
+    # backend a case compiles for disagree with the platform it runs on.
     fixtures = [*_RUNNER_FIXTURES, "backend_type"]
-    assert _generate(_FakeMetafunc("a2a3,a5", fixtures)) == []
+    calls = _generate(_FakeMetafunc("a2a3,a5sim", fixtures))
+    assert calls == [
+        (
+            "_st_platform,backend_type",
+            [("a2a3", BackendType.Ascend910B), ("a5sim", BackendType.Ascend950)],
+            ["a2a3", "a5sim"],
+            ["_st_platform"],
+        )
+    ]
+
+
+def test_backend_type_is_emitted_even_for_a_single_platform():
+    # Unlike _st_platform, backend_type has no fixture of its own, so skipping
+    # the parametrize would leave the test with no such argument at all.
+    fixtures = [*_RUNNER_FIXTURES, "backend_type"]
+    calls = _generate(_FakeMetafunc("a2a3", fixtures))
+    assert calls == [
+        (
+            "_st_platform,backend_type",
+            [("a2a3", BackendType.Ascend910B)],
+            ["a2a3"],
+            ["_st_platform"],
+        )
+    ]
+
+
+def test_backend_type_respects_the_platforms_marker():
+    fixtures = [*_RUNNER_FIXTURES, "backend_type"]
+    calls = _generate(_FakeMetafunc("a2a3,a5", fixtures, marker_args=["a2a3", "a2a3sim"]))
+    assert calls == [
+        ("_st_platform,backend_type", [("a2a3", BackendType.Ascend910B)], ["a2a3"], ["_st_platform"])
+    ]
 
 
 def test_tests_without_the_runner_are_untouched():
     assert _generate(_FakeMetafunc("a2a3,a5", ["tmp_path"])) == []
+
+
+def test_a_runner_reached_through_another_fixture_is_not_expanded():
+    # The runner arrives via a module-scoped fixture, which is built once for
+    # the whole module and so cannot hold one artefact per platform.
+    metafunc = _FakeMetafunc(
+        "a2a3,a5",
+        ["swimlane", "test_runner", "_st_platform", "test_config"],
+        signature=["swimlane"],
+    )
+    assert _generate(metafunc) == []
 
 
 def test_empty_platform_option_expands_over_every_platform():
@@ -216,6 +290,43 @@ def test_a_typo_in_the_platforms_marker_fails_collection():
 def test_an_empty_platforms_marker_fails_collection():
     with pytest.raises(pytest.UsageError, match="no platform ids"):
         _generate(_FakeMetafunc("a2a3,a5", _RUNNER_FIXTURES, marker_args=[]))
+
+
+# ---------------------------------------------------------------------------
+# Per-item platform resolution
+# ---------------------------------------------------------------------------
+
+
+class _FakeNode:
+    """Stand-in for a collected item, for the platform resolver."""
+
+    def __init__(self, params=None, marker_args=None, name="test_fake"):
+        self.name = name
+        self.callspec = SimpleNamespace(params=dict(params or {})) if params is not None else None
+        self._marker = SimpleNamespace(args=tuple(marker_args)) if marker_args is not None else None
+
+    def get_closest_marker(self, name):
+        return self._marker if name == "platforms" else None
+
+
+def _resolve(node, platform_option):
+    config = SimpleNamespace(getoption=lambda name: {"--platform": platform_option}[name])
+    return _load_st_conftest()._resolve_item_platform(node, config)
+
+
+def test_the_parametrized_platform_wins():
+    assert _resolve(_FakeNode(params={"_st_platform": "a5sim"}), "a2a3,a5sim") == "a5sim"
+    assert _resolve(_FakeNode(params={"platform": "a5"}), "a2a3,a5") == "a5"
+
+
+def test_an_unexpanded_item_falls_back_to_the_first_cli_platform():
+    assert _resolve(_FakeNode(), "a5,a2a3") == "a5"
+
+
+def test_the_fallback_honours_the_platforms_marker():
+    # The item is not parametrized (its runner comes from a shared fixture), so
+    # the fallback must not hand it a platform its own marker excludes.
+    assert _resolve(_FakeNode(marker_args=["a5"]), "a2a3,a5") == "a5"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/ut/runtime/test_st_platform_matrix.py
+++ b/tests/ut/runtime/test_st_platform_matrix.py
@@ -71,62 +71,47 @@ class _Case(harness.PTOTestCase):
         pass
 
 
-class _PinnedCase(_Case):
-    """Legacy shape: the subclass hard-pins the backend."""
+class _LeftoverPinCase(_Case):
+    """A case that still carries the removed backend knob."""
 
     def get_name(self) -> str:
-        return "pinned_case"
+        return "leftover_pin_case"
 
     def get_backend_type(self) -> BackendType:
         return BackendType.Ascend910B
 
 
 # ---------------------------------------------------------------------------
-# The guard: pinned backend vs resolved platform
+# The platform is a case's only architecture knob
 # ---------------------------------------------------------------------------
 
 
-def test_unpinned_case_follows_the_platform():
+def test_a_case_carries_no_backend_of_its_own():
+    # Not "the default is 910B" — there is no such accessor to default.
+    assert not hasattr(harness.PTOTestCase, "get_backend_type")
+    with pytest.raises(TypeError):
+        _Case(backend_type=BackendType.Ascend910B)  # pyright: ignore[reportCallIssue]
+
+
+def test_the_backend_is_derived_from_the_bound_platform():
     case = _Case()
-    assert test_runner._bind_and_check_arch(case, "a5") is None
-    # Binding is what makes the compile follow the platform: before it, the
-    # base class answers with the Ascend910B default whatever the platform is.
-    assert case.get_backend_type() is BackendType.Ascend950
+    test_runner._bind_item_platform(case, "a5")
     assert case.get_platform() == "a5"
+    assert harness.platform_to_backend(case.get_platform()) is BackendType.Ascend950
 
 
-def test_pinned_case_is_skipped_on_the_other_arch():
-    reason = test_runner._bind_and_check_arch(_PinnedCase(), "a5")
-    assert reason is not None
-    assert "get_backend_type()=Ascend910B" in reason
-    assert "--platform=a5" in reason
-    # The message must say how to fix it, not just that it broke.
-    assert "platforms(" in reason
-
-
-def test_pinned_case_still_runs_on_its_own_arch():
-    assert test_runner._bind_and_check_arch(_PinnedCase(), "a2a3sim") is None
+def test_a_leftover_backend_override_is_rejected():
+    # Silent dead code otherwise: the harness stopped reading this method, so a
+    # case still defining it would compile for whatever the platform says while
+    # its author believes the override decides.
+    with pytest.raises(pytest.UsageError, match="get_backend_type"):
+        test_runner._bind_item_platform(_LeftoverPinCase(), "a5")
 
 
 def test_bind_platform_never_overrides_an_explicit_pin():
     case = _Case(platform="a2a3sim")
     case.bind_platform("a5")
     assert case.get_platform() == "a2a3sim"
-    assert case.get_backend_type() is BackendType.Ascend910B
-
-
-def test_a_constructor_backend_pin_is_not_overridden():
-    # `PTOTestCase(backend_type=...)` is a pin like a get_backend_type override:
-    # binding a platform over it would win silently and hide the conflict.
-    case = _Case(backend_type=BackendType.Ascend910B)
-    reason = test_runner._bind_and_check_arch(case, "a5")
-    assert reason is not None and "Ascend910B" in reason
-    assert case.get_backend_type() is BackendType.Ascend910B
-
-
-def test_a_matching_constructor_backend_pin_runs():
-    case = _Case(backend_type=BackendType.Ascend910B)
-    assert test_runner._bind_and_check_arch(case, "a2a3sim") is None
 
 
 def test_bind_platform_rejects_an_unknown_id():
@@ -142,6 +127,12 @@ def test_cache_key_separates_the_platform_variants():
     key_a5 = test_runner._cache_key(a5, session_memory_planner=MemoryPlanner.PYPTO)
     assert key_a2a3 != key_a5
     assert key_a2a3.endswith("@a2a3@pypto") and key_a5.endswith("@a5sim@pypto")
+
+
+def test_cache_key_refuses_an_artifact_with_no_platform():
+    # Two architectures sharing one key would share one compile.
+    with pytest.raises(ValueError, match="no platform resolved or bound"):
+        test_runner._cache_key(_Case(), session_memory_planner=MemoryPlanner.PYPTO)
 
 
 # ---------------------------------------------------------------------------
@@ -220,44 +211,6 @@ def test_marker_outside_the_allowlist_leaves_the_item_for_deselection():
 def test_explicitly_parametrized_tests_are_left_alone():
     fixtures = [*_RUNNER_FIXTURES, "platform"]
     assert _generate(_FakeMetafunc("a2a3,a5", fixtures)) == []
-
-
-def test_backend_type_is_paired_with_the_platform():
-    # One parametrize, not two: a separate backend_type axis would let the
-    # backend a case compiles for disagree with the platform it runs on.
-    fixtures = [*_RUNNER_FIXTURES, "backend_type"]
-    calls = _generate(_FakeMetafunc("a2a3,a5sim", fixtures))
-    assert calls == [
-        (
-            "_st_platform,backend_type",
-            [("a2a3", BackendType.Ascend910B), ("a5sim", BackendType.Ascend950)],
-            ["a2a3", "a5sim"],
-            ["_st_platform"],
-        )
-    ]
-
-
-def test_backend_type_is_emitted_even_for_a_single_platform():
-    # Unlike _st_platform, backend_type has no fixture of its own, so skipping
-    # the parametrize would leave the test with no such argument at all.
-    fixtures = [*_RUNNER_FIXTURES, "backend_type"]
-    calls = _generate(_FakeMetafunc("a2a3", fixtures))
-    assert calls == [
-        (
-            "_st_platform,backend_type",
-            [("a2a3", BackendType.Ascend910B)],
-            ["a2a3"],
-            ["_st_platform"],
-        )
-    ]
-
-
-def test_backend_type_respects_the_platforms_marker():
-    fixtures = [*_RUNNER_FIXTURES, "backend_type"]
-    calls = _generate(_FakeMetafunc("a2a3,a5", fixtures, marker_args=["a2a3", "a2a3sim"]))
-    assert calls == [
-        ("_st_platform,backend_type", [("a2a3", BackendType.Ascend910B)], ["a2a3"], ["_st_platform"])
-    ]
 
 
 def test_tests_without_the_runner_are_untouched():

--- a/tests/ut/runtime/test_task_submit_dispatch.py
+++ b/tests/ut/runtime/test_task_submit_dispatch.py
@@ -130,6 +130,7 @@ def test_precompile_forwards_session_memory_planner(tmp_path):
         test_runner._compile_for_cache(
             case,
             tmp_path,
+            "a2a3",
             dump_passes=False,
             analyze_auto_scopes_for_deps=False,
             session_memory_planner=MemoryPlanner.DSA_RP,

--- a/tests/ut/runtime/test_task_submit_dispatch.py
+++ b/tests/ut/runtime/test_task_submit_dispatch.py
@@ -404,9 +404,6 @@ def test_fused_compile_records_sdma_capability(tmp_path):
     )
     fake_device_runner = SimpleNamespace(compile_and_assemble=fake_compile_and_assemble)
     tc = Mock()
-    # The compile task refuses to build a case whose pinned backend contradicts
-    # the resolved platform, so the stub must answer with a real BackendType.
-    tc.get_backend_type.return_value = test_runner.BackendType.Ascend910B
 
     with (
         patch.object(test_runner, "_resolve_platform", return_value="a2a3"),

--- a/tests/ut/runtime/test_task_submit_dispatch.py
+++ b/tests/ut/runtime/test_task_submit_dispatch.py
@@ -404,6 +404,9 @@ def test_fused_compile_records_sdma_capability(tmp_path):
     )
     fake_device_runner = SimpleNamespace(compile_and_assemble=fake_compile_and_assemble)
     tc = Mock()
+    # The compile task refuses to build a case whose pinned backend contradicts
+    # the resolved platform, so the stub must answer with a real BackendType.
+    tc.get_backend_type.return_value = test_runner.BackendType.Ascend910B
 
     with (
         patch.object(test_runner, "_resolve_platform", return_value="a2a3"),


### PR DESCRIPTION
## Summary

The system-test platform matrix only reached cases that parametrized `platform` themselves — about half of `tests/st/runtime`. The rest resolved to the session's first `--platform` id but still compiled for `Ascend910B`, because the backend came from `PTOTestCase.get_backend_type()`, whose default (and 60 subclass overrides) is 910B whatever the platform is. Under `--platform=a5sim` an unparametrized case emitted `pto.target_arch = "a2a3"`, so adding a file to an A5 guard job tested the wrong architecture rather than the one asked for.

Two changes follow from that. Every test that takes `test_runner` is now expanded over the `--platform` allowlist, so a case joins a new platform's guard job without touching its test body. And a case no longer answers two questions about architecture: `get_backend_type()` is deleted, the backend is derived from the resolved platform at every compile site, and a case that genuinely cannot run somewhere says so next to the test with `@pytest.mark.platforms(..., reason=...)` instead of in a CI `-k` expression.

Existing invocations are unaffected: with one active platform nothing new is parametrized, and `--platform=a2a3` collects the same 1273 node ids as before, with one exception noted below.

## Changes

- `tests/st/harness/core/harness.py`: `PTOTestCase` loses `get_backend_type()` and the `backend_type=` constructor argument — the platform carries the architecture *and* the sim/onboard bit, and `platform_to_backend()` is total over the four ids. `bind_platform()` attaches the resolved platform to a case that did not pin one.
- `tests/st/harness/core/test_runner.py`: every compile site (`TestRunner._run_inline`, `_compile_for_cache`, the compile-pool grouping) derives its backend from the resolved platform, so an artefact can no longer be built for one architecture and executed on another. `_bind_item_platform()` rejects a case that still defines `get_backend_type`, with a message pointing at `@pytest.mark.platforms`, so the removal cannot rot into silently ignored dead code. `_cache_key` refuses an artefact with no platform rather than falling back to a backend-derived arch. `set_current_item_platform()` carries the running item's platform to the session-scoped runner. `set_backend_type` is process-global and single-shot, so the inline path resets it before installing a different backend — multi-platform sessions no longer require `--forked` to switch architecture.
- 21 test files: the 62 `get_backend_type` overrides are deleted. 60 pinned `Ascend910B` — exactly the mismatch that made an A5 guard job test the wrong architecture — and two pinned `Ascend950` only to line up with an a5-parametrized test.
- `tests/st/conftest.py`: `pytest_generate_tests` parametrizes the `_st_platform` fixture over the allowlist intersected with `@pytest.mark.platforms`. Only a test that takes `test_runner` in its own signature is expanded — one that reaches the runner through a module- or session-scoped fixture cannot hold an artefact per platform, and runs on the single platform the resolver picks. Discovery keys each variant's artefact by platform so the variants do not share one compile. `@pytest.mark.platforms` now takes `reason=` and rejects unknown platform ids instead of silently deselecting the test everywhere; the new `@pytest.mark.platform_xfail(*ids, reason=..., strict=True)` states a platform-specific expected failure that still runs, so a fix surfaces as an XPASS.
- `tests/st/runtime/cross_core/`: `test_cross_core.py` drops its module-level `pytest_generate_tests` and the `backend_type` parameter; its tests join the matrix like everything else and collect an A5 variant under a multi-platform run instead of always taking the first `--platform` id. `test_explicit_slot_num` carries its a2/a3-only limitation in `reason=`. The grouped tpop/tfree regression emits the requested platform ids instead of aborting collection when the CLI names one it does not support.
- `tests/ut/runtime/test_st_platform_matrix.py`: device-free unit tests for platform resolution, the expansion rules, both markers, and the "no backend knob" invariant.
- `tests/st/README.md`: platform selection, what is and is not expanded, the two markers and when to choose each, and the single architecture knob.

No migration is required for existing tests. Declaring `platform` yourself is still supported and still wins over the automatic expansion; it is now only needed when the test body uses the value.

**One node-id change**: the 12 `test_cross_core.py` tests lose the `[a2a3]` suffix their deleted module-level generator used to add under a single-platform run. No CI job selects them by id.

## Verification

Against the current base (6d9e2ecb):

- `pytest tests/st --collect-only -q --platform=a2a3`: 1273 node ids, identical to the base except the 12 cross_core ids above. The run also proves no existing `@pytest.mark.platforms` carries a typo, since one would now fail collection.
- `pytest tests/st --collect-only -q --platform=a2a3,a5`: 2029 items, against 1783 on the base. `test_cross_core.py` alone goes from 12 to 23 — both platforms for every test except the a2/a3-only `test_explicit_slot_num`.
- `pytest tests/ut/runtime -q`: 691 passed, including the new matrix tests. (One further failure, `test_alloc_intermediates_accepts_both_signatures`, reproduces unchanged on the base in this environment and is absent from CI.)
- `pytest tests/st/runtime/framework_and_models/test_perf_swimlane.py tests/st/runtime/scheduling/test_manual_scope_pipeline.py tests/st/runtime/scheduling/test_pl_at_deps_pipeline.py --platform=a2a3sim --codegen-only -q`: 7 passed, 28 skipped. These are the modules whose session- and module-scoped fixtures request `test_runner`; they are the ones CI reported as `ScopeMismatch` on the first commit of this branch.
- `pytest tests/st/runtime/ops/test_abs.py tests/st/runtime/cross_core/test_cross_core.py --platform=a2a3sim,a5sim --codegen-only -q`: 31 passed — cross_core now compiles for both architectures in one run.
- `pytest tests/st/runtime/ops/test_abs.py --platform=a2a3sim,a5sim -q`: 8 passed on the simulators, in one process.
- `pytest tests/st/runtime/ops/test_abs.py::TestAbs::test_tile_abs --platform=a5sim --codegen-only --save-kernels`: the generated `kernel.pto` carries `pto.target_arch = "a5"` and `compiled_meta.json` `"backend_type": "Ascend950"`, where the base emitted `"a2a3"` / `"Ascend910B"` for the same command.
- `ruff check` and `ruff format --check` on every changed file: clean.

Not covered: nothing here ran on A5 silicon, and the de-pinned cases have only been checked to *collect*, not to lower or execute on 950. Whether a given case actually passes on `a5` is what the guard job now gets to find out; a case that cannot should get `@pytest.mark.platforms(..., reason=...)` at that point.

One caveat worth knowing: a single process that executes on both architectures' simulators through the pre-compile pipeline segfaults in teardown after every test passes. That reproduces unchanged on the base, so it is not introduced here; `README` records it and keeps `--forked` recommended for cross-architecture runs.
