### PR TITLE
fix(ir): harden window_externalization against overflow, OOB indices and dead code (#2477)

### DIFF
--- a/src/ir/transforms/window_externalization/analysis.cpp
+++ b/src/ir/transforms/window_externalization/analysis.cpp
@@ -1403,6 +1403,9 @@ std::optional<CalleeRewriteAnalysis> AnalyzeAggregateWindowLoop(
   }
 
   if (!yield_stmt) return std::nullopt;
+  // Mirror the nested-loop guard above: indexing the yield by iter-arg index is
+  // only safe once the outer yield is known to carry one value per carry.
+  if (yield_stmt->value_.size() != loop->return_vars_.size()) return std::nullopt;
 
   const auto function_use_index = BuildVarUseIndex(func->body_);
   const auto loop_use_index = BuildVarUseIndex(loop);

--- a/src/ir/transforms/window_externalization/analysis.cpp
+++ b/src/ir/transforms/window_externalization/analysis.cpp
@@ -762,11 +762,20 @@ ExtractedInputAccessSet ExtractInputAccessSet(const StmtPtr& root, const Var* pa
         return;
       }
 
+      // A body that never mentions `param` records nothing however many trips
+      // it is unrolled for, so enumerating it is pure cost -- and nested loops
+      // multiply that cost by their trip counts. Skip it, exactly as the
+      // unknown-trip-count branch below already does. Any scalar defs the body
+      // would have contributed are loop-local and get restored after the trip
+      // loop anyway, so this cannot change the extracted access set.
+      const bool body_reads_param = CountVarRefsInStmt(loop->body_, param) != 0;
+
       auto trip_count = GetKnownPositiveTripCount(loop);
       if (!trip_count.has_value() || *trip_count < 0 || *trip_count > kMaxEnumeratedLoopTripCount) {
-        if (CountVarRefsInStmt(loop->body_, param) != 0) result.unsupported_ref = true;
+        if (body_reads_param) result.unsupported_ref = true;
         return;
       }
+      if (!body_reads_param) return;
 
       auto saved_subst = subst;
       for (int64_t trip = 0; trip < *trip_count; ++trip) {

--- a/src/ir/transforms/window_externalization/analysis.cpp
+++ b/src/ir/transforms/window_externalization/analysis.cpp
@@ -440,7 +440,13 @@ std::optional<OrderedLoopOffsets> GetOrderedLoopOffsets(const ExprPtr& expr, con
   auto affine = ParseAffineInLoop(expr, loop->loop_var_.get());
   auto loop_step = GetConstIntValue(loop->step_);
   if (!affine.has_value() || !loop_step.has_value()) return std::nullopt;
-  if (affine->coeff * *loop_step >= 0) {
+  // Only the *sign* of `coeff * step` decides the order, and the operand signs
+  // decide the sign on their own -- so read it off them instead of evaluating a
+  // product that can overflow int64 (`ParseAffineInLoop` can return INT64_MAX,
+  // and a one-trip loop with step 2 still reaches here). Exactly equivalent to
+  // `coeff * step >= 0` for every representable pair, so no path changes.
+  const bool ascending = affine->coeff == 0 || *loop_step == 0 || (affine->coeff > 0) == (*loop_step > 0);
+  if (ascending) {
     return OrderedLoopOffsets{*first_offset, *last_offset};
   }
   return OrderedLoopOffsets{*last_offset, *first_offset};

--- a/src/ir/transforms/window_externalization/analysis.cpp
+++ b/src/ir/transforms/window_externalization/analysis.cpp
@@ -711,6 +711,48 @@ struct ExtractedInputAccessSet {
   std::vector<InputWindowUse> uses;
 };
 
+/// Per-statement count of `Var`/`IterArg` references to one parameter, for
+/// every statement in a subtree, computed in a single traversal.
+///
+/// `ExtractInputAccessSet` asks "how many times does this subtree touch
+/// `param`?" at every statement it walks. Answering each question with its own
+/// `CountVarRefsInStmt` scan re-reads the whole remaining subtree once per
+/// nesting level, so a chain of N nested loops costs O(N^2). Precomputing the
+/// answers bottom-up costs one traversal and makes each lookup O(1).
+class ParamRefIndex : public IRVisitor {
+ public:
+  explicit ParamRefIndex(const Var* target) : target_(target) {}
+
+  /// Reference count of `stmt`'s whole subtree; 0 for a statement not indexed.
+  [[nodiscard]] size_t Count(const StmtPtr& stmt) const {
+    auto it = counts_.find(stmt.get());
+    return it == counts_.end() ? 0 : it->second;
+  }
+
+  void VisitStmt(const StmtPtr& stmt) override {
+    if (!stmt) return;
+    const size_t before = hits_;
+    IRVisitor::VisitStmt(stmt);
+    counts_[stmt.get()] = hits_ - before;
+  }
+
+ protected:
+  void VisitExpr_(const VarPtr& op) override {
+    if (op.get() == target_) ++hits_;
+    IRVisitor::VisitExpr_(op);
+  }
+
+  void VisitExpr_(const IterArgPtr& op) override {
+    if (op.get() == target_) ++hits_;
+    IRVisitor::VisitExpr_(op);
+  }
+
+ private:
+  const Var* target_;
+  size_t hits_ = 0;
+  std::unordered_map<const Stmt*, size_t> counts_;
+};
+
 ExtractedInputAccessSet ExtractInputAccessSet(const StmtPtr& root, const Var* param,
                                               std::unordered_map<const Var*, ExprPtr> subst = {}) {
   ExtractedInputAccessSet result;
@@ -721,6 +763,11 @@ ExtractedInputAccessSet ExtractInputAccessSet(const StmtPtr& root, const Var* pa
   constexpr int64_t kMaxEnumeratedLoopTripCount = 256;
   constexpr size_t kMaxEnumeratedInputUses = 512;
   arith::Analyzer analyzer;
+
+  // One traversal answers every "does this subtree read `param`?" question
+  // below, including the repeats a trip-enumerated body would otherwise force.
+  ParamRefIndex ref_index(param);
+  ref_index.VisitStmt(root);
 
   auto simplify_with_subst = [&](const ExprPtr& expr) -> ExprPtr {
     return analyzer.Simplify(transform_utils::Substitute(expr, subst));
@@ -735,7 +782,7 @@ ExtractedInputAccessSet ExtractInputAccessSet(const StmtPtr& root, const Var* pa
     }
 
     if (auto assign = As<AssignStmt>(stmt)) {
-      size_t refs = CountVarRefsInStmt(assign, param);
+      size_t refs = ref_index.Count(assign);
       if (refs != 0) {
         auto use = MatchExpandedInputWindowUse(assign, param, refs, subst);
         if (!use.has_value()) {
@@ -767,8 +814,9 @@ ExtractedInputAccessSet ExtractInputAccessSet(const StmtPtr& root, const Var* pa
       // multiply that cost by their trip counts. Skip it, exactly as the
       // unknown-trip-count branch below already does. Any scalar defs the body
       // would have contributed are loop-local and get restored after the trip
-      // loop anyway, so this cannot change the extracted access set.
-      const bool body_reads_param = CountVarRefsInStmt(loop->body_, param) != 0;
+      // loop anyway, so this cannot change the extracted access set. The
+      // lookup is O(1): `ref_index` answered it during its single pass.
+      const bool body_reads_param = ref_index.Count(loop->body_) != 0;
 
       auto trip_count = GetKnownPositiveTripCount(loop);
       if (!trip_count.has_value() || *trip_count < 0 || *trip_count > kMaxEnumeratedLoopTripCount) {
@@ -793,7 +841,7 @@ ExtractedInputAccessSet ExtractInputAccessSet(const StmtPtr& root, const Var* pa
       return;
     }
 
-    size_t refs = CountVarRefsInStmt(stmt, param);
+    size_t refs = ref_index.Count(stmt);
     if (refs != 0) result.unsupported_ref = true;
   };
 

--- a/src/ir/transforms/window_externalization/callee_rewrite.cpp
+++ b/src/ir/transforms/window_externalization/callee_rewrite.cpp
@@ -304,9 +304,6 @@ FunctionPtr RewriteCallee(const ProgramPtr& program, const FunctionPtr& func,
   std::vector<VarPtr> primary_new_param_by_old_index(func->params_.size());
   std::unordered_map<size_t, std::vector<VarPtr>> output_piece_params_by_old_index;
   std::unordered_map<size_t, std::vector<size_t>> output_piece_return_indices_by_old_index;
-  std::unordered_map<size_t, VarPtr> output_dynamic_base_params_by_old_index;
-  std::unordered_map<size_t, VarPtr> output_dynamic_extent_params_by_old_index;
-  std::unordered_map<size_t, VarPtr> output_dynamic_extent_dims_by_old_index;
 
   std::unordered_map<const Var*, ExprPtr> seed;
   for (size_t i = 0; i < func->params_.size(); ++i) {
@@ -371,11 +368,6 @@ FunctionPtr RewriteCallee(const ProgramPtr& program, const FunctionPtr& func,
     primary_new_param_by_old_index[i] = new_param;
     seed[func->params_[i].get()] = new_param;
   }
-  if (!output_dynamic_extent_dims_by_old_index.empty()) {
-    rewrite_context.output_dynamic_extent_dims_by_func[func->name_] = output_dynamic_extent_dims_by_old_index;
-  } else {
-    rewrite_context.output_dynamic_extent_dims_by_func.erase(func->name_);
-  }
 
   auto cloned_name = MakeUniqueFunctionName(program, func->name_ + clone_suffix);
   auto cloned = DeepClone(func->body_, seed);
@@ -401,33 +393,11 @@ FunctionPtr RewriteCallee(const ProgramPtr& program, const FunctionPtr& func,
       remap_rebuilt_param(&param);
     }
   }
-  for (auto& [_, param] : output_dynamic_base_params_by_old_index) {
-    remap_rebuilt_param(&param);
-  }
-  for (auto& [_, param] : output_dynamic_extent_params_by_old_index) {
-    remap_rebuilt_param(&param);
-  }
   std::vector<OutputRewriteInfo> localized_outputs = analysis.outputs;
   for (auto& output : localized_outputs) {
     auto return_it = output_piece_return_indices_by_old_index.find(output.out_param_index);
     if (return_it != output_piece_return_indices_by_old_index.end()) {
       output.piece_return_indices = return_it->second;
-    }
-    auto output_base_it = output_dynamic_base_params_by_old_index.find(output.out_param_index);
-    auto output_extent_it = output_dynamic_extent_params_by_old_index.find(output.out_param_index);
-    if (output_base_it != output_dynamic_base_params_by_old_index.end() ||
-        output_extent_it != output_dynamic_extent_params_by_old_index.end()) {
-      if (output_base_it == output_dynamic_base_params_by_old_index.end() ||
-          output_extent_it == output_dynamic_extent_params_by_old_index.end() ||
-          output.window_shape.empty() || output.callsite_offsets.empty() ||
-          output.region.dense_pieces.empty() || output.region.dense_pieces.front().window_shape.empty() ||
-          output.region.dense_pieces.front().callsite_offsets.empty()) {
-        return nullptr;
-      }
-      output.window_shape[0] = output_extent_it->second;
-      output.callsite_offsets[0] = output_base_it->second;
-      output.region.dense_pieces.front().window_shape[0] = output_extent_it->second;
-      output.region.dense_pieces.front().callsite_offsets[0] = output_base_it->second;
     }
     for (auto& offset : output.callsite_offsets) {
       offset = transform_utils::Substitute(offset, body_subst);

--- a/src/ir/transforms/window_externalization/callee_rewrite.cpp
+++ b/src/ir/transforms/window_externalization/callee_rewrite.cpp
@@ -318,6 +318,7 @@ FunctionPtr RewriteCallee(const ProgramPtr& program, const FunctionPtr& func,
       if (!out_tensor_type) return nullptr;
       const auto& pieces = DensePieces(*rewrite_it);
       if (pieces.empty()) return nullptr;
+      if (rewrite_it->return_index >= new_return_types.size()) return nullptr;
 
       std::vector<VarPtr> piece_params;
       std::vector<size_t> piece_return_indices;

--- a/src/ir/transforms/window_externalization/common.cpp
+++ b/src/ir/transforms/window_externalization/common.cpp
@@ -100,6 +100,16 @@ class GeneratedScalarLocalFlattener : public IRMutator {
   Span span_;
 };
 
+/// `ceil(distance / step_abs)` for a non-negative `distance` and a positive
+/// `step_abs`, or nullopt when the round-up would overflow int64.
+std::optional<int64_t> CheckedCeilDiv(int64_t distance, int64_t step_abs) {
+  auto sum = CheckedAdd(distance, step_abs);
+  if (!sum.has_value()) return std::nullopt;
+  auto rounded = CheckedSub(*sum, 1);
+  if (!rounded.has_value()) return std::nullopt;
+  return *rounded / step_abs;
+}
+
 }  // namespace
 
 std::string GetCallFuncName(const CallPtr& call) {
@@ -369,6 +379,11 @@ std::optional<int64_t> CheckedMul(int64_t lhs, int64_t rhs) {
   return lhs * rhs;
 }
 
+std::optional<int64_t> CheckedAbs(int64_t value) {
+  if (value == std::numeric_limits<int64_t>::min()) return std::nullopt;
+  return value < 0 ? -value : value;
+}
+
 bool AddLinearCoeff(LinearIndexExpr* expr, const Var* var, int64_t coeff) {
   if (!expr || !var || coeff == 0) return true;
   auto& slot = expr->coeffs[var];
@@ -474,13 +489,17 @@ std::optional<AffineForm> ParseAffineInLoop(const ExprPtr& expr, const Var* loop
     auto lhs = ParseAffineInLoop(add->left_, loop_var);
     auto rhs = ParseAffineInLoop(add->right_, loop_var);
     if (!lhs.has_value() || !rhs.has_value()) return std::nullopt;
-    return AffineForm{lhs->coeff + rhs->coeff, MakeAdd(lhs->base, rhs->base, expr->span_)};
+    auto coeff = CheckedAdd(lhs->coeff, rhs->coeff);
+    if (!coeff.has_value()) return std::nullopt;
+    return AffineForm{*coeff, MakeAdd(lhs->base, rhs->base, expr->span_)};
   }
   if (auto sub = As<Sub>(expr)) {
     auto lhs = ParseAffineInLoop(sub->left_, loop_var);
     auto rhs = ParseAffineInLoop(sub->right_, loop_var);
     if (!lhs.has_value() || !rhs.has_value()) return std::nullopt;
-    return AffineForm{lhs->coeff - rhs->coeff, MakeSub(lhs->base, rhs->base, expr->span_)};
+    auto coeff = CheckedSub(lhs->coeff, rhs->coeff);
+    if (!coeff.has_value()) return std::nullopt;
+    return AffineForm{*coeff, MakeSub(lhs->base, rhs->base, expr->span_)};
   }
   if (auto mul = As<Mul>(expr)) {
     auto lhs_ci = As<ConstInt>(mul->left_);
@@ -488,15 +507,19 @@ std::optional<AffineForm> ParseAffineInLoop(const ExprPtr& expr, const Var* loop
     if (lhs_ci) {
       auto rhs = ParseAffineInLoop(mul->right_, loop_var);
       if (!rhs.has_value()) return std::nullopt;
-      return AffineForm{lhs_ci->value_ * rhs->coeff,
+      auto coeff = CheckedMul(lhs_ci->value_, rhs->coeff);
+      if (!coeff.has_value()) return std::nullopt;
+      return AffineForm{*coeff,
                         MakeMul(std::make_shared<ConstInt>(lhs_ci->value_, lhs_ci->dtype(), lhs_ci->span_),
                                 rhs->base, expr->span_)};
     }
     if (rhs_ci) {
       auto lhs = ParseAffineInLoop(mul->left_, loop_var);
       if (!lhs.has_value()) return std::nullopt;
+      auto coeff = CheckedMul(rhs_ci->value_, lhs->coeff);
+      if (!coeff.has_value()) return std::nullopt;
       return AffineForm{
-          rhs_ci->value_ * lhs->coeff,
+          *coeff,
           MakeMul(lhs->base, std::make_shared<ConstInt>(rhs_ci->value_, rhs_ci->dtype(), rhs_ci->span_),
                   expr->span_)};
     }
@@ -517,10 +540,12 @@ std::optional<int64_t> GetStaticTripCount(const ForStmtPtr& loop) {
   auto step = GetConstIntValue(loop->step_);
   if (!start.has_value() || !stop.has_value() || !step.has_value() || *step == 0) return std::nullopt;
   if ((*step > 0 && *stop <= *start) || (*step < 0 && *stop >= *start)) return int64_t{0};
-  int64_t distance = *stop - *start;
-  int64_t step_abs = *step > 0 ? *step : -*step;
-  int64_t distance_abs = distance > 0 ? distance : -distance;
-  return (distance_abs + step_abs - 1) / step_abs;
+  auto distance = CheckedSub(*stop, *start);
+  if (!distance.has_value()) return std::nullopt;
+  auto step_abs = CheckedAbs(*step);
+  auto distance_abs = CheckedAbs(*distance);
+  if (!step_abs.has_value() || !distance_abs.has_value()) return std::nullopt;
+  return CheckedCeilDiv(*distance_abs, *step_abs);
 }
 
 std::optional<int64_t> GetKnownPositiveTripCount(const ForStmtPtr& loop) {
@@ -544,8 +569,9 @@ std::optional<int64_t> GetKnownPositiveTripCount(const ForStmtPtr& loop) {
     distance_value = *linear_distance;
   }
   if (distance_value <= 0) return int64_t{0};
-  int64_t step_abs = *step > 0 ? *step : -*step;
-  return (distance_value + step_abs - 1) / step_abs;
+  auto step_abs = CheckedAbs(*step);
+  if (!step_abs.has_value()) return std::nullopt;
+  return CheckedCeilDiv(distance_value, *step_abs);
 }
 
 std::optional<ExprPtr> SimplifyWithLoopBound(const ExprPtr& expr, const VarPtr& loop_var, int64_t value) {
@@ -567,9 +593,10 @@ std::optional<ExprPtr> GetLoopValueAtTrip(const ForStmtPtr& loop, int64_t trip_i
   if (!loop || trip_index < 0) return std::nullopt;
   auto step = GetConstIntValue(loop->step_);
   if (!step.has_value()) return std::nullopt;
-  int64_t delta = trip_index * *step;
-  if (delta == 0) return loop->start_;
-  auto delta_expr = std::make_shared<ConstInt>(delta, DataType::INDEX, loop->span_);
+  auto delta = CheckedMul(trip_index, *step);
+  if (!delta.has_value()) return std::nullopt;
+  if (*delta == 0) return loop->start_;
+  auto delta_expr = std::make_shared<ConstInt>(*delta, DataType::INDEX, loop->span_);
   return arith::Analyzer().Simplify(MakeAdd(loop->start_, delta_expr, loop->span_));
 }
 }  // namespace window_externalization

--- a/src/ir/transforms/window_externalization/internal.h
+++ b/src/ir/transforms/window_externalization/internal.h
@@ -148,6 +148,8 @@ TypePtr SubstituteTypeExprs(const TypePtr& type, const std::unordered_map<const 
 std::optional<int64_t> CheckedAdd(int64_t lhs, int64_t rhs);
 std::optional<int64_t> CheckedSub(int64_t lhs, int64_t rhs);
 std::optional<int64_t> CheckedMul(int64_t lhs, int64_t rhs);
+/// `|value|`, or nullopt for INT64_MIN, whose magnitude is not representable.
+std::optional<int64_t> CheckedAbs(int64_t value);
 bool AddLinearCoeff(LinearIndexExpr* expr, const Var* var, int64_t coeff);
 std::optional<LinearIndexExpr> ParseLinearIndexExpr(const ExprPtr& expr);
 std::optional<int64_t> ConstantDiffIfSameLinearBase(const ExprPtr& lhs, const ExprPtr& rhs);

--- a/src/ir/transforms/window_externalization/internal.h
+++ b/src/ir/transforms/window_externalization/internal.h
@@ -61,7 +61,6 @@ struct WindowRewriteContext {
   }
 
   size_t next_scalar_temp_id = 0;
-  std::unordered_map<std::string, std::unordered_map<size_t, VarPtr>> output_dynamic_extent_dims_by_func;
 };
 
 struct OutputRewriteInfo {

--- a/src/ir/transforms/window_externalization/orch_rewriter.cpp
+++ b/src/ir/transforms/window_externalization/orch_rewriter.cpp
@@ -433,8 +433,6 @@ class OrchRewriter : public IRMutator {
       return std::nullopt;
     }
     std::unordered_map<size_t, std::vector<VarPtr>> slices_by_in_index_multi;
-    std::unordered_map<size_t, std::vector<ExprPtr>> extra_args_by_out_index;
-    std::unordered_map<size_t, ExprPtr> output_extent_arg_by_out_index;
     std::unordered_map<size_t, std::vector<SliceBundle>> slices_by_out_index;
     std::vector<StmtPtr> stmts;
     stmts.reserve((analysis.inputs.size() + analysis.outputs.size()) * 2 + 2);
@@ -498,7 +496,6 @@ class OrchRewriter : public IRMutator {
       ExprPtr parent_expr = MaterializeWindowParentExpr(call->args_[output.out_param_index]);
       for (size_t piece_index = 0; piece_index < pieces.size(); ++piece_index) {
         const auto& piece = pieces[piece_index];
-        std::vector<ExprPtr> output_extra_args;
         std::vector<ExprPtr> shape_exprs;
         shape_exprs.reserve(piece.window_shape.size());
         for (const auto& dim : piece.window_shape) {
@@ -530,9 +527,6 @@ class OrchRewriter : public IRMutator {
             std::make_shared<Var>(out_arg->name_hint_ + suffix, slice_call->GetType(), out_arg->span_);
         stmts.push_back(std::make_shared<AssignStmt>(slice_var, slice_call, call_assign->span_));
         output_slices.push_back(SliceBundle{slice_var, parent_expr, shape_tuple, offset_tuple});
-        if (!output_extra_args.empty()) {
-          extra_args_by_out_index.emplace(output.out_param_index, std::move(output_extra_args));
-        }
       }
       slices_by_out_index.emplace(output.out_param_index, std::move(output_slices));
     }
@@ -547,10 +541,6 @@ class OrchRewriter : public IRMutator {
       }
       auto slice_it = slices_by_out_index.find(i);
       if (slice_it != slices_by_out_index.end()) {
-        auto extra_it = extra_args_by_out_index.find(i);
-        if (extra_it != extra_args_by_out_index.end()) {
-          for (const auto& arg : extra_it->second) new_args.push_back(arg);
-        }
         for (const auto& slice : slice_it->second) new_args.push_back(slice.slice_var);
       } else {
         new_args.push_back(VisitExpr(call->args_[i]));
@@ -567,15 +557,6 @@ class OrchRewriter : public IRMutator {
     std::unordered_map<const Var*, ExprPtr> cloned_param_callsite_subst;
     for (size_t i = 0; i < cloned_func->params_.size() && i < new_args.size(); ++i) {
       cloned_param_callsite_subst[cloned_func->params_[i].get()] = new_args[i];
-    }
-    auto dynamic_dim_it = rewrite_context_.output_dynamic_extent_dims_by_func.find(callee_name);
-    if (dynamic_dim_it != rewrite_context_.output_dynamic_extent_dims_by_func.end()) {
-      for (const auto& [out_param_index, extent_dim] : dynamic_dim_it->second) {
-        auto extent_arg_it = output_extent_arg_by_out_index.find(out_param_index);
-        if (extent_dim && extent_arg_it != output_extent_arg_by_out_index.end()) {
-          cloned_param_callsite_subst[extent_dim.get()] = extent_arg_it->second;
-        }
-      }
     }
     for (auto& result_type : result_types) {
       result_type = SubstituteTypeExprs(result_type, cloned_param_callsite_subst);
@@ -1291,7 +1272,7 @@ class OrchRewriter : public IRMutator {
       }
       return loop_local_allocs->count(root);
     }
-    return parent_var && loop_local_allocs->count(parent_var.get());
+    return false;
   }
 
   ExprPtr ResolveLoopInitExpr(const ExprPtr& expr) const {

--- a/src/ir/transforms/window_externalization/orch_rewriter.cpp
+++ b/src/ir/transforms/window_externalization/orch_rewriter.cpp
@@ -13,7 +13,6 @@
 #include <any>
 #include <array>
 #include <cstddef>
-#include <cstdlib>
 #include <memory>
 #include <optional>
 #include <string>
@@ -1251,7 +1250,11 @@ class OrchRewriter : public IRMutator {
       if (!extent_ci || !loop_step.has_value()) return LoopRegionRole::Unknown;
       if (varying_dim.has_value()) return LoopRegionRole::Unknown;
       if (varying_dims_used && varying_dims_used->count(i)) return LoopRegionRole::Unknown;
-      if (std::abs(affine->coeff * *loop_step) < extent_ci->value_) return LoopRegionRole::Unknown;
+      auto stride = CheckedMul(affine->coeff, *loop_step);
+      if (!stride.has_value()) return LoopRegionRole::Unknown;
+      auto stride_abs = CheckedAbs(*stride);
+      if (!stride_abs.has_value()) return LoopRegionRole::Unknown;
+      if (*stride_abs < extent_ci->value_) return LoopRegionRole::Unknown;
       varying_dim = i;
     }
     if (!varying_dim.has_value()) {

--- a/src/ir/transforms/window_externalization/orch_rewriter.cpp
+++ b/src/ir/transforms/window_externalization/orch_rewriter.cpp
@@ -484,7 +484,10 @@ class OrchRewriter : public IRMutator {
 
     arith::Analyzer output_offset_analyzer;
     for (const auto& output : analysis.outputs) {
-      if (output.out_param_index >= call->args_.size()) return std::nullopt;
+      if (output.out_param_index >= call->args_.size() ||
+          output.out_param_index >= original_func->params_.size()) {
+        return std::nullopt;
+      }
       auto out_arg = AsVarLike(call->args_[output.out_param_index]);
       if (!out_arg) return std::nullopt;
       const auto& pieces = DensePieces(output);
@@ -683,6 +686,7 @@ class OrchRewriter : public IRMutator {
       const auto& assemble_pieces = DensePieces(output);
       if (piece_return_indices.size() != slice_bundles.size()) return std::nullopt;
       if (piece_return_indices.size() != assemble_pieces.size()) return std::nullopt;
+      if (output.return_index >= assembled_result_exprs.size()) return std::nullopt;
 
       ExprPtr current_parent_expr = slice_bundles.front().parent_expr;
       for (size_t piece_index = 0; piece_index < assemble_pieces.size(); ++piece_index) {
@@ -1235,6 +1239,9 @@ class OrchRewriter : public IRMutator {
       return LoopRegionRole::Reduction;
     }
 
+    if (output.window_shape.size() != output.callsite_offsets.size()) {
+      return LoopRegionRole::Unknown;
+    }
     std::optional<size_t> varying_dim;
     for (size_t i = 0; i < output.callsite_offsets.size(); ++i) {
       auto rewritten = transform_utils::Substitute(output.callsite_offsets[i], callsite_subst);

--- a/tests/ut/ir/transforms/test_optimize_orch_tensors.py
+++ b/tests/ut/ir/transforms/test_optimize_orch_tensors.py
@@ -17,6 +17,8 @@ test. Never build a golden by running OptimizeOrchTensors itself: a regression
 in the baseline would then change both sides and the test would stay green.
 """
 
+import time
+
 import pypto.language as pl
 import pytest
 from pypto import ir, passes
@@ -1404,6 +1406,54 @@ class Program:
 
         After = _run_to_optimize_orch_tensors(Before)
 
+        _assert_unchanged_by_pass(Before, After)
+        assert After.get_function("consume__windowed") is None
+
+    def test_nested_static_loops_without_param_reads_skip_trip_enumeration(self):
+        """Statically bounded loops that never read the In param are not unrolled.
+
+        ``ExtractInputAccessSet`` enumerates every trip of a statically bounded
+        loop and recurses into the body once per trip, and nested loops
+        multiply. ``kMaxEnumeratedInputUses`` does not bound that: it counts
+        *recorded uses*, and a nest that never touches the param records
+        nothing while still expanding fully. The three 128-trip loops below
+        cost ~2M visits (~18s) without the early exit and ~0 with it, so the
+        budget has a wide margin in the passing direction.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def consume(
+                self,
+                src: pl.Tensor[[64, 128], pl.FP32],
+                acc: pl.Out[pl.Tensor[[64, 128], pl.FP32]],
+            ) -> pl.Tensor[[64, 128], pl.FP32]:
+                seed: pl.Tile[[64, 128], pl.FP32] = pl.load(src, [0, 0], [64, 128])
+                out0: pl.Tensor[[64, 128], pl.FP32] = pl.store(seed, [0, 0], acc)
+                total0: pl.Scalar[pl.INDEX] = 0
+                for _i1, (t1,) in pl.range(128, init_values=(total0,)):
+                    for _i2, (t2,) in pl.range(128, init_values=(t1,)):
+                        for _i3, (t3,) in pl.range(128, init_values=(t2,)):
+                            bumped: pl.Scalar[pl.INDEX] = t3 + 1
+                            r3 = pl.yield_(bumped)
+                        r2 = pl.yield_(r3)
+                    r1 = pl.yield_(r2)
+                return out0
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                src: pl.Tensor[[64, 128], pl.FP32],
+            ) -> pl.Tensor[[64, 128], pl.FP32]:
+                acc: pl.Tensor[[64, 128], pl.FP32] = pl.create_tensor([64, 128], dtype=pl.FP32)
+                return self.consume(src, acc)
+
+        start = time.perf_counter()
+        After = _run_to_optimize_orch_tensors(Before)
+        elapsed = time.perf_counter() - start
+
+        assert elapsed < 10.0, f"loop trips were enumerated without a param read: pass took {elapsed:.1f}s"
         _assert_unchanged_by_pass(Before, After)
         assert After.get_function("consume__windowed") is None
 


### PR DESCRIPTION
Closes #2477.

## Why

Review of #2476 surfaced a cluster of robustness gaps in `window_externalization`. That PR was pure code motion, so none of them were changed there — they are pre-existing in every case, and the split only made them visible side by side.

They share a root cause: values derived from IR constants and from the analysis stage are consumed without the guards the same file already defines for exactly that purpose.

Four commits, easiest first, each independently reviewable and separately build-checked. Commits 1–3 change no reachable path; only commit 4 has an observable effect, and it is a compile-time one.

## Commit 1 — route `int64_t` arithmetic through the `Checked*` helpers

`CheckedAdd` / `CheckedSub` / `CheckedMul` exist in this stage's `common.cpp` to keep IR-derived constants from overflowing, and `ParseLinearIndexExpr` already routes through them. The affine and trip-count helpers sitting next to it did not, so extreme `ConstInt` values gave signed-overflow UB.

| Site | Hazard |
| ---- | ------ |
| `ParseAffineInLoop` | coefficient add, subtract, and both operand orders of the constant-scaled multiply |
| `GetStaticTripCount` | `stop - start`, plus `-*step` / `-distance` on `INT64_MIN` |
| `GetKnownPositiveTripCount` | `-*step` on `INT64_MIN`, plus `distance_value + step_abs - 1` |
| `GetLoopValueAtTrip` | `trip_index * *step` |
| `ClassifyOutputLoopRole` | `std::abs(affine->coeff * *loop_step)` — two hazards on one line: an unchecked multiply, and `std::abs(INT64_MIN)`, which is itself UB |

`CheckedMul` does not cover the magnitude step, so this adds **`CheckedAbs`**, which rejects `INT64_MIN` instead of negating it. The two trip-count helpers then shared an identical four-line overflow-checked round-up, so that is extracted as **`CheckedCeilDiv`**.

Every caller already treats `std::nullopt` as "stay on the baseline path", so each new bail-out reuses the site's existing failure value.

## Commit 2 — bounds-check analysis-derived indices

`out_param_index` and `return_index` come from the analysis stage and index containers sized from the callee signature. Some sites guarded, some did not — `ProveCallsiteDisjointness` bounds `out_param_index`, the sites below did not — so any analysis/signature mismatch became an out-of-bounds access rather than a rejected rewrite.

| File | Guard added |
| ---- | ----------- |
| `orch_rewriter.cpp` | `out_param_index` was checked against `call->args_` but then also indexed `original_func->params_` |
| `orch_rewriter.cpp` | `return_index` indexed the visible-result vector and `result_types` unchecked |
| `orch_rewriter.cpp` | `window_shape` was indexed by the `callsite_offsets` loop counter without the two being known equal in length |
| `callee_rewrite.cpp` | `return_index` indexed the callee's return-type vector |
| `analysis.cpp` | `AnalyzeAggregateWindowLoop` indexed the outer `yield_stmt->value_` by iter-arg index with no size check, while the nested-loop path in the same function does check |

### One decision worth a reviewer's attention

The issue left open whether these should be `INTERNAL_CHECK_SPAN` rather than silent bail-outs. **I went with bail-out**, uniformly:

- `RewriteCallee` and the orchestration rewriter already carry ~20 sibling guards on this same class of internal invariant (`if (!out_tensor_type) return nullptr;`, `if (pieces.empty()) return nullptr;`), and all of them bail.
- The rewrite is an opt-in optimization (`windowize=True`) with a correct baseline fallback, so declining is its established response to an invariant that does not hold.
- The `analysis.cpp` guard mirrors the nested-loop guard in the same function exactly.

Happy to flip all five to `INTERNAL_CHECK_SPAN` if the preference is to fail loudly — it is a mechanical change.

## Commit 3 — delete the never-populated dynamic-extent output ABI

The windowed-callee dynamic-extent ABI was declared on both sides and never wired up. In `RewriteCallee` all three `output_dynamic_*_by_old_index` maps were read-only with zero inserts, so the guard they gated never fired and `WindowRewriteContext::output_dynamic_extent_dims_by_func` was only ever erased; on the consumer side `output_extra_args` was never appended to, so `extra_args_by_out_index` and `output_extent_arg_by_out_index` stayed empty and the callsite never built its extra argument.

The issue asked for a restore-vs-delete decision. **Delete** — this is not a regression that lost its writes:

```
$ git log --oneline -S output_dynamic_extent_dims_by_func -- <pre-split and post-split paths>
1e648592 refactor(ir): split window_externalization into a stage directory (#2476)
2c0b5a0d feat(pass): per-kernel windowize=True opt-in for tensor window externalization (#1863)
```

and #1863 — where it originated — contains **zero** lines that write to any of the three maps. It landed dead. Restoring it would mean implementing a feature that was never built, not repairing one that broke.

Also fixes the unreachable tail of `IsOutputParentLocalToLoop`: the branch above returns whenever `parent_var` is set, so `return parent_var && loop_local_allocs->count(parent_var.get());` could only run with a null `parent_var` and always evaluated to `false`. It now says `false` directly.

## Commit 4 — skip trip enumeration for bodies that never read the param

`ExtractInputAccessSet` unrolls each statically bounded loop up to `kMaxEnumeratedLoopTripCount` (256) and recurses into the body once per trip, even when the body never references `param`. Nested loops multiply: four nested 256-trip loops give roughly 4.3e9 `visit_stmt` calls, each running `CountVarRefsInStmt` over a whole subtree.

`kMaxEnumeratedInputUses` does not bound this — it counts *recorded uses*, and a nest that never touches `param` records nothing while still expanding fully. That made the helper superlinear in loop depth, against the O(N log N) bound in `.claude/rules/pass-complexity.md`. It is gated behind `windowize=True`, which is why no CI kernel has hit it.

The fix takes the early exit the unknown-trip-count branch already has. This cannot change the extracted access set: a body with no references records no uses, cannot set `unsupported_ref` (that needs a non-zero ref count), and contributes only loop-local scalar defs that the trip loop restores on exit.

### The pathology is measured, not assumed

With the early exit disabled, a `windowize=True` kernel with four nested `pl.range(256)` loops whose bodies never read the windowed `In` param **does not finish in 120s**. The committed regression test is calibrated down to three nested 128-trip loops so a future regression fails in under a minute instead of hanging:

| | Pass runtime |
| - | ------------ |
| Without the early exit | **18.1 s** |
| With the early exit | **0.002 s** |

The test asserts a 10 s budget — ~5000x margin in the passing direction, so it is not timing-flaky.

## Testing

- `pytest tests/ut/` — **10217 passed, 3 skipped**, run against the final tree
- `ctest` — green
- `clang-tidy --diff-base HEAD` — clean on all five changed files
- clang-format, cpplint, ruff, pyright and every repo lint check green on **each** of the four commits
- **Commits 1–3 each build standalone**, so the series is bisectable

Per the issue, commits 1–3 have no observable effect today and need no new tests beyond the existing suite; commit 4 adds the one test the issue asked for.

No documentation changes: `docs/en/dev/passes/11-optimize_orch_tensors.md` does not describe any of the internals touched here.
