### PR TITLE
perf(runtime): let the caller declare a host range immutable, not just shared

### DIFF
--- a/docs/en/user/distributed/03-execution.md
+++ b/docs/en/user/distributed/03-execution.md
@@ -159,11 +159,15 @@ with compiled.prepare(
     resident = rt.alloc_stacked_tensor(weights)
 ```
 
-`immutable_host_tensors` is a promise about **uploads**. A declared range used as a
-`copy_from` destination is still staged: writing a copy-on-write page in the child leaves
-the parent reading the old contents, and writing a read-only mapping faults. Both are
-worse than the copy the declaration was meant to avoid. Anything not declared, or
-allocated after `prepare()`, keeps staging exactly as before.
+`immutable_host_tensors` is a promise about **uploads**, and reading back into a declared
+range is refused rather than quietly staged — staging would write the same bytes into the
+same range, breaking the promise while looking like it worked. Read back into a tensor you
+did not declare. Anything not declared, or allocated after `prepare()`, keeps staging
+exactly as before.
+
+A named upload source is granted `READ`; only a destination is granted `READWRITE`. That
+matters for a read-only mapping: describing it as writable would tell the runtime a
+consumer may write memory that faults on a write.
 
 ## One-Shot vs Persistent Worker
 

--- a/docs/en/user/distributed/03-execution.md
+++ b/docs/en/user/distributed/03-execution.md
@@ -135,35 +135,45 @@ it may be an ordinary tensor allocated after `prepare()`. It does not need
 ### Skipping the staging copy
 
 Staging costs one full host-side copy of the payload, which for a large resident weight
-is worth avoiding. A range can be named in place instead — no staging buffer, no
-memcpy — when the child can already see it and nothing will change it:
+is worth avoiding. A range registered through `inherited_host_tensors` is named in place
+instead — no staging buffer, no memcpy — because it predates the fork and every child
+holds it at the same address.
 
-- it was registered through `inherited_host_tensors`, so it predates the fork and every
-  child holds it at the same address; **and**
-- it is either shared memory (`.share_memory_()`, which `torch.is_shared()` reports), or
-  the caller lists it in `immutable_host_tensors`.
+**Listing a tensor is a guarantee you make.** By passing it in
+`inherited_host_tensors` you assert two things:
 
-The second option exists because `is_shared()` answers a different question than the one
-that matters. It reports whether the storage is a shared-memory allocation; what decides
-safety is whether anything writes those bytes after the fork. A read-only `MAP_SHARED`
-file mapping wrapped with `mmap` + `numpy.frombuffer` + `torch.from_numpy` is genuinely
-shared and still reports `False`, so it would be copied needlessly. Declaring it says what
-inference cannot see.
+- its backing is **visible across processes** — a `MAP_SHARED` mapping, whether torch's
+  own shared memory or an external file mapping; and
+- that mapping stays **valid for the worker's lifetime**.
+
+Passing a `MAP_PRIVATE` backing is **unsupported**. Copy-on-write leaves the child reading
+its pre-fork snapshot, so an upload may carry stale or incorrect data. Nothing detects
+this for you.
+
+PyPTO cannot verify the guarantee, and does not try. `torch.is_shared()` answers a
+different question — whether the storage is a torch shared-memory allocation — and a
+read-only `MAP_SHARED` file mapping wrapped with `mmap` + `numpy.frombuffer` +
+`torch.from_numpy` is genuinely shared while reporting `False`. Reading
+`/proc/self/maps` would answer correctly but only on Linux, and the simulator also runs
+on macOS. So `is_shared()` is kept as a one-way signal: `True` confirms a torch-managed
+shared backing, `False` is inconclusive, and for the tensors it cannot confirm PyPTO
+emits one `RuntimeWarning` at `prepare()` time and proceeds. It never rejects the tensor
+and never falls back to staging — falling back would silently reinstate the copy you
+asked it to skip.
 
 ```python
-weights = map_readonly_shared(path)          # mmap-backed, is_shared() == False
+weights = map_readonly_shared(path)          # mmap-backed MAP_SHARED, is_shared() == False
 with compiled.prepare(
-    inherited_host_tensors=[weights],        # visible in every child
-    immutable_host_tensors=[weights],        # and never written after this point
+    inherited_host_tensors=[weights],        # "visible in every child, for my lifetime"
 ) as rt:
     resident = rt.alloc_stacked_tensor(weights)
 ```
 
-`immutable_host_tensors` is a promise about **uploads**, and reading back into a declared
-range is refused rather than quietly staged — staging would write the same bytes into the
-same range, breaking the promise while looking like it worked. Read back into a tensor you
-did not declare. Anything not declared, or allocated after `prepare()`, keeps staging
-exactly as before.
+The guarantee is about visibility, so it holds in both directions: a listed range may be
+an upload source or a read-back destination. Writability is left to the hardware — a range
+mapped `MAP_SHARED` from a read-only file descriptor faults on write rather than corrupting
+anything. Anything not listed, or allocated after `prepare()`, keeps staging exactly as
+before.
 
 A named upload source is granted `READ`; only a destination is granted `READWRITE`. That
 matters for a read-only mapping: describing it as writable would tell the runtime a

--- a/docs/en/user/distributed/03-execution.md
+++ b/docs/en/user/distributed/03-execution.md
@@ -132,6 +132,39 @@ When a host endpoint is a `torch.Tensor`, it only needs to be CPU-contiguous;
 it may be an ordinary tensor allocated after `prepare()`. It does not need
 `.share_memory_()`, pre-fork allocation, or `inherited_host_tensors`.
 
+### Skipping the staging copy
+
+Staging costs one full host-side copy of the payload, which for a large resident weight
+is worth avoiding. A range can be named in place instead — no staging buffer, no
+memcpy — when the child can already see it and nothing will change it:
+
+- it was registered through `inherited_host_tensors`, so it predates the fork and every
+  child holds it at the same address; **and**
+- it is either shared memory (`.share_memory_()`, which `torch.is_shared()` reports), or
+  the caller lists it in `immutable_host_tensors`.
+
+The second option exists because `is_shared()` answers a different question than the one
+that matters. It reports whether the storage is a shared-memory allocation; what decides
+safety is whether anything writes those bytes after the fork. A read-only `MAP_SHARED`
+file mapping wrapped with `mmap` + `numpy.frombuffer` + `torch.from_numpy` is genuinely
+shared and still reports `False`, so it would be copied needlessly. Declaring it says what
+inference cannot see.
+
+```python
+weights = map_readonly_shared(path)          # mmap-backed, is_shared() == False
+with compiled.prepare(
+    inherited_host_tensors=[weights],        # visible in every child
+    immutable_host_tensors=[weights],        # and never written after this point
+) as rt:
+    resident = rt.alloc_stacked_tensor(weights)
+```
+
+`immutable_host_tensors` is a promise about **uploads**. A declared range used as a
+`copy_from` destination is still staged: writing a copy-on-write page in the child leaves
+the parent reading the old contents, and writing a read-only mapping faults. Both are
+worse than the copy the declaration was meant to avoid. Anything not declared, or
+allocated after `prepare()`, keeps staging exactly as before.
+
 ## One-Shot vs Persistent Worker
 
 ### One-Shot

--- a/docs/zh/user/distributed/03-execution.md
+++ b/docs/zh/user/distributed/03-execution.md
@@ -121,33 +121,38 @@ with compiled.prepare() as rt:
 ### 跳过 staging 拷贝
 
 staging 需要在 host 侧完整拷贝一份数据；对体积很大的常驻权重，这份拷贝值得省掉。
-当子进程本来就能看到这段内存、且它不会再被写入时，可以直接按地址命名该区间，
-既不需要 staging buffer 也不需要 memcpy：
+通过 `inherited_host_tensors` 注册的区间会被直接按地址命名，既不需要 staging buffer
+也不需要 memcpy：它在 fork 之前就已存在，每个子进程都在同一地址看到它。
 
-- 该张量通过 `inherited_host_tensors` 注册，因此在 fork 之前就已存在，每个子进程
-  都在同一地址看到它；**并且**
-- 它要么是共享内存（`.share_memory_()`，即 `torch.is_shared()` 为真），要么由调用方
-  在 `immutable_host_tensors` 中声明。
+**列入该列表即是你作出的保证。** 把一个张量传入 `inherited_host_tensors`，等于断言两点：
 
-之所以需要第二种方式，是因为 `is_shared()` 回答的并不是真正相关的问题。它表示
-storage 是否为共享内存分配，而决定安全性的是 fork 之后是否有人写这些字节。用
-`mmap` + `numpy.frombuffer` + `torch.from_numpy` 包装的只读 `MAP_SHARED` 文件映射
-确实是共享的，但 `is_shared()` 仍返回 `False`，于是会被无谓地拷贝一遍。显式声明
-补上了推断看不到的信息。
+- 它的后备内存**跨进程可见**——即 `MAP_SHARED` 映射，无论是 torch 自己的共享内存
+  还是外部文件映射；并且
+- 该映射在 worker 的整个生命周期内**始终有效**。
+
+传入 `MAP_PRIVATE` 后备内存属于**不受支持**的用法。写时复制会让子进程一直读到 fork
+之前的快照，因此上传的数据可能是陈旧或错误的。这一点不会被自动检测出来。
+
+PyPTO 无法验证这项保证，也不去尝试。`is_shared()` 回答的是另一个问题——storage 是否
+为 torch 的共享内存分配；而用 `mmap` + `numpy.frombuffer` + `torch.from_numpy` 包装的
+只读 `MAP_SHARED` 文件映射确实是共享的，`is_shared()` 却返回 `False`。读取
+`/proc/self/maps` 能给出正确答案，但仅限 Linux，而模拟器同样运行在 macOS 上。因此
+`is_shared()` 被保留为单向信号：`True` 可确认是 torch 管理的共享内存，`False` 则无从
+判断；对于无法确认的张量，PyPTO 会在 `prepare()` 时发出一次 `RuntimeWarning` 后继续
+执行。它既不拒绝该张量，也不退回 staging——退回 staging 会悄悄把你要求省掉的那份拷贝
+重新加回来。
 
 ```python
-weights = map_readonly_shared(path)          # mmap 支撑，is_shared() == False
+weights = map_readonly_shared(path)          # mmap 支撑的 MAP_SHARED，is_shared() == False
 with compiled.prepare(
-    inherited_host_tensors=[weights],        # 每个子进程都可见
-    immutable_host_tensors=[weights],        # 且此后不再写入
+    inherited_host_tensors=[weights],        # “每个子进程都可见，且在我的生命周期内有效”
 ) as rt:
     resident = rt.alloc_stacked_tensor(weights)
 ```
 
-`immutable_host_tensors` 只是关于**上传**的承诺；把被声明的区间用作 `copy_from`
-的目标会直接报错，而不是悄悄退回 staging——staging 会往同一段内存写同样的字节，
-一样违背这项承诺，却看起来一切正常。请读回到未被声明的张量中。未声明的张量，或在
-`prepare()` 之后分配的张量，其行为与此前完全一致。
+这项保证针对的是可见性，因此两个方向都成立：被列入的区间既可作上传源，也可作读回目标。
+可写性交由硬件负责——以只读文件描述符建立的 `MAP_SHARED` 映射在写入时会直接触发错误，
+而不会破坏任何数据。未列入的张量，或在 `prepare()` 之后分配的张量，其行为与此前完全一致。
 
 被命名的上传源只授予 `READ`，只有目标才授予 `READWRITE`。这对只读映射很关键：把它
 描述为可写，等于告诉 runtime 消费者可以写一段写入即出错的内存。

--- a/docs/zh/user/distributed/03-execution.md
+++ b/docs/zh/user/distributed/03-execution.md
@@ -118,6 +118,37 @@ with compiled.prepare() as rt:
 `torch.Tensor` 时只需是 CPU 连续张量，可以是在 `prepare()` 后创建的普通张量；
 无需 `.share_memory_()`、fork 前分配或 `inherited_host_tensors`。
 
+### 跳过 staging 拷贝
+
+staging 需要在 host 侧完整拷贝一份数据；对体积很大的常驻权重，这份拷贝值得省掉。
+当子进程本来就能看到这段内存、且它不会再被写入时，可以直接按地址命名该区间，
+既不需要 staging buffer 也不需要 memcpy：
+
+- 该张量通过 `inherited_host_tensors` 注册，因此在 fork 之前就已存在，每个子进程
+  都在同一地址看到它；**并且**
+- 它要么是共享内存（`.share_memory_()`，即 `torch.is_shared()` 为真），要么由调用方
+  在 `immutable_host_tensors` 中声明。
+
+之所以需要第二种方式，是因为 `is_shared()` 回答的并不是真正相关的问题。它表示
+storage 是否为共享内存分配，而决定安全性的是 fork 之后是否有人写这些字节。用
+`mmap` + `numpy.frombuffer` + `torch.from_numpy` 包装的只读 `MAP_SHARED` 文件映射
+确实是共享的，但 `is_shared()` 仍返回 `False`，于是会被无谓地拷贝一遍。显式声明
+补上了推断看不到的信息。
+
+```python
+weights = map_readonly_shared(path)          # mmap 支撑，is_shared() == False
+with compiled.prepare(
+    inherited_host_tensors=[weights],        # 每个子进程都可见
+    immutable_host_tensors=[weights],        # 且此后不再写入
+) as rt:
+    resident = rt.alloc_stacked_tensor(weights)
+```
+
+`immutable_host_tensors` 只是关于**上传**的承诺。被声明的区间若用作 `copy_from`
+的目标，仍然走 staging：子进程写入 copy-on-write 页会让父进程继续读到旧数据，而
+写只读映射会直接出错——两者都比这项声明想省下的那次拷贝更糟。未声明的张量，或在
+`prepare()` 之后分配的张量，其行为与此前完全一致。
+
 ## One-Shot vs 持久 Worker
 
 ### One-Shot

--- a/docs/zh/user/distributed/03-execution.md
+++ b/docs/zh/user/distributed/03-execution.md
@@ -144,10 +144,13 @@ with compiled.prepare(
     resident = rt.alloc_stacked_tensor(weights)
 ```
 
-`immutable_host_tensors` 只是关于**上传**的承诺。被声明的区间若用作 `copy_from`
-的目标，仍然走 staging：子进程写入 copy-on-write 页会让父进程继续读到旧数据，而
-写只读映射会直接出错——两者都比这项声明想省下的那次拷贝更糟。未声明的张量，或在
+`immutable_host_tensors` 只是关于**上传**的承诺；把被声明的区间用作 `copy_from`
+的目标会直接报错，而不是悄悄退回 staging——staging 会往同一段内存写同样的字节，
+一样违背这项承诺，却看起来一切正常。请读回到未被声明的张量中。未声明的张量，或在
 `prepare()` 之后分配的张量，其行为与此前完全一致。
+
+被命名的上传源只授予 `READ`，只有目标才授予 `READWRITE`。这对只读映射很关键：把它
+描述为可写，等于告诉 runtime 消费者可以写一段写入即出错的内存。
 
 ## One-Shot vs 持久 Worker
 

--- a/python/pypto/ir/distributed_compiled_program.py
+++ b/python/pypto/ir/distributed_compiled_program.py
@@ -481,6 +481,7 @@ class DistributedCompiledProgram:
         reset_persistent_windows: bool | None = None,
         callbacks: dict[str, Callable[..., Any]] | None = None,
         sub_worker_overrides: dict[str, Callable[..., Any]] | None = None,
+        inherited_host_tensors: Sequence[torch.Tensor] | None = None,
         startup_timeout_s: float | None = None,
     ) -> "DistributedWorker":
         """Prepare a reusable L3 execution handle (setup once, dispatch many).
@@ -537,6 +538,17 @@ class DistributedCompiledProgram:
                 raises ``ValueError``. In multi-program mode the callbacks apply
                 to every prepared program.
             sub_worker_overrides: Deprecated alias for ``callbacks``.
+            inherited_host_tensors: Host ranges that predate the fork and that
+                the caller **guarantees** are visible across processes — a
+                ``MAP_SHARED`` mapping, whether torch's own shared memory or an
+                external file mapping — and stay valid for the worker's lifetime.
+                Listed ranges are named in place by ``copy_to`` / ``copy_from``
+                instead of being staged through an owned shm ``Buffer``, which
+                removes one full host-side copy of the payload. Passing a
+                ``MAP_PRIVATE`` backing is unsupported and may upload stale or
+                incorrect data; see :class:`DistributedWorker` for the full
+                contract and for the warning emitted when the guarantee cannot
+                be confirmed.
             startup_timeout_s: Optional positive finite bound, in seconds, for
                 the forked worker hierarchy to report startup readiness. ``None``
                 keeps Simpler's default timeout.
@@ -554,6 +566,7 @@ class DistributedCompiledProgram:
             reset_persistent_windows=reset_persistent_windows,
             callbacks=callbacks,
             sub_worker_overrides=sub_worker_overrides,
+            inherited_host_tensors=inherited_host_tensors,
             startup_timeout_s=startup_timeout_s,
         )
 

--- a/python/pypto/runtime/distributed_runner.py
+++ b/python/pypto/runtime/distributed_runner.py
@@ -2297,9 +2297,15 @@ class DistributedWorker(Worker):
         listed it in ``immutable_host_tensors``, promising nothing writes it after
         ``prepare()``.
 
-        The declaration applies to upload sources only: a declared range used as a D2H
-        destination still has to be genuinely shared, since writing a private page in the child
-        leaves the parent reading the old contents and writing a read-only mapping faults.
+        The declaration applies to upload sources only, and a read-back into a declared range
+        is refused rather than quietly staged: staging writes the same bytes, so it would break
+        the promise just as thoroughly while looking like it worked. An undeclared range still
+        has to be genuinely shared to be named as a destination, since writing a private page in
+        the child leaves the parent reading the old contents.
+
+        A named source is granted ``READ`` and only a destination ``READWRITE``. Naming a
+        read-only mapping ``READWRITE`` would tell the ABI a consumer may write memory that
+        faults on a write — the same kind of misdeclaration this option exists to remove.
 
         Both conditions exist because inference alone is wrong in both directions. A
         ``MAP_PRIVATE`` range is inherited too, but copy-on-write means the child keeps
@@ -2322,14 +2328,19 @@ class DistributedWorker(Worker):
         )
 
         end = host_ptr + nbytes
-        # The declaration covers *reads* only. Naming a declared non-shared range as a D2H
-        # destination would contradict the declaration and break either way: a MAP_PRIVATE page
-        # written by the child splits copy-on-write, so the parent keeps seeing the old bytes,
-        # and a read-only file mapping faults outright. Writes therefore still require a range
-        # that is genuinely shared.
-        declared_immutable = not writing and any(
+        declared_immutable = any(
             start <= host_ptr and end <= stop for start, stop in self._immutable_host_spans
         )
+        if writing and declared_immutable:
+            # The caller promised nothing writes this range after prepare(), and a read-back
+            # would do exactly that. Refusing is the only way to honour the promise: staging
+            # writes the same bytes, so silently taking that path would break it just as
+            # thoroughly while looking like it worked.
+            raise ValueError(
+                f"copy_from destination 0x{host_ptr:x}+{nbytes} lies in a range declared through "
+                "immutable_host_tensors, which promises nothing writes it after prepare(); read "
+                "back into a tensor that was not declared immutable."
+            )
         for start, stop, is_shared in self._inherited_host_spans:
             if host_ptr < start or end > stop:
                 continue
@@ -2341,7 +2352,11 @@ class DistributedWorker(Worker):
                 nbytes,
                 owner,
                 buffer_id,
-                access=AccessMode.READWRITE,
+                # A source is read by the child and nothing more, so say so: naming a read-only
+                # mapping READWRITE would tell the ABI the consumer may write memory that faults
+                # on a write, which is the same class of misdeclaration this whole option exists
+                # to remove. FORK_SHM accepts any access, so READ is expressible here.
+                access=AccessMode.READWRITE if writing else AccessMode.READ,
                 backend_kind=BackendKind.FORK_SHM,
             )
         return None

--- a/python/pypto/runtime/distributed_runner.py
+++ b/python/pypto/runtime/distributed_runner.py
@@ -1439,6 +1439,22 @@ def execute_distributed_compiled(
     return compiled(*args, config=config)
 
 
+def _immutable_host_spans(
+    tensors: Sequence[torch.Tensor] | None,
+) -> tuple[tuple[int, int], ...]:
+    """Return ``(start, end)`` for each range the caller declares is never written post-fork."""
+    spans: list[tuple[int, int]] = []
+    for tensor in tensors or ():
+        if tensor.device.type != "cpu" or not tensor.is_contiguous():
+            raise ValueError(
+                "DistributedWorker immutable_host_tensors must be contiguous CPU tensors; "
+                f"got device={tensor.device} shape={tuple(tensor.shape)}."
+            )
+        start = tensor.data_ptr()
+        spans.append((start, start + tensor.numel() * tensor.element_size()))
+    return tuple(spans)
+
+
 class DistributedWorker(Worker):
     """L3 distributed execution handle: prepare once, dispatch many.
 
@@ -1513,6 +1529,7 @@ class DistributedWorker(Worker):
         callbacks: dict[str, Callable[..., Any]] | None = None,
         sub_worker_overrides: dict[str, Callable[..., Any]] | None = None,
         inherited_host_tensors: Sequence[torch.Tensor] | None = None,
+        immutable_host_tensors: Sequence[torch.Tensor] | None = None,
         startup_timeout_s: float | None = None,
     ) -> None:
         super().__init__()  # initialize Worker ABC state (_owned_tensors)
@@ -1543,6 +1560,15 @@ class DistributedWorker(Worker):
         # the caller's to know and cannot be inferred from an address, so record it here,
         # where the tensors are still in hand, as (start, end, is_shared) spans. A
         # MAP_PRIVATE range is deliberately left to staging — see `_named_host_buffer`.
+        # Ranges the caller *declares* are never written after ``prepare()``. This cannot be
+        # inferred: ``torch.is_shared()`` answers "is this storage a shared-memory allocation",
+        # while what the copy path needs to know is "will anyone write these bytes after the
+        # fork". A read-only ``MAP_SHARED`` file mapping built with ``mmap`` + ``from_numpy`` is
+        # genuinely shared at the OS level and still reports ``False``, so inference rejects
+        # exactly the case that benefits most. Only the caller knows, so it says so here.
+        self._immutable_host_spans: tuple[tuple[int, int], ...] = _immutable_host_spans(
+            immutable_host_tensors
+        )
         self._inherited_host_spans: tuple[tuple[int, int, bool], ...] = tuple(
             (
                 tensor.data_ptr(),
@@ -2260,12 +2286,19 @@ class DistributedWorker(Worker):
         needs no staging buffer and no host-side memcpy. A tensor allocated after
         ``prepare`` has no mapping in the child, so the caller stages it.
 
-        **Shared mappings only, deliberately.** A ``MAP_PRIVATE`` range is inherited too,
-        but copy-on-write means the child keeps reading its pre-fork snapshot: a parent that
-        registers a tensor and then writes to it would upload the old bytes. Staging is not
-        merely a fallback there — it is the correct behaviour, because its ``memmove`` runs
-        in the parent and therefore reads the current contents. Naming a private range would
-        trade one memcpy for a silent staleness bug, so ``FORK_COW`` is not used here.
+        **Shared, or declared immutable.** A range that ``torch.is_shared()`` reports as
+        shared is always safe to name. A range that does not is named only if the caller
+        listed it in ``immutable_host_tensors``, promising nothing writes it after
+        ``prepare()``.
+
+        Both conditions exist because inference alone is wrong in both directions. A
+        ``MAP_PRIVATE`` range is inherited too, but copy-on-write means the child keeps
+        reading its pre-fork snapshot, so a parent that writes after registering would
+        upload stale bytes — there, staging is not a fallback but the correct behaviour,
+        since its ``memmove`` runs in the parent. Conversely a read-only ``MAP_SHARED`` file
+        mapping wrapped through ``mmap`` + ``from_numpy`` reports ``is_shared() == False``
+        while being perfectly safe to name, which is why the declaration exists rather than
+        a wider guess.
 
         Each range is wrapped on its own rather than offset into a whole-tensor Buffer,
         because a Buffer carries no offset: a shard's address is interior to its stacked
@@ -2279,8 +2312,13 @@ class DistributedWorker(Worker):
         )
 
         end = host_ptr + nbytes
+        declared_immutable = any(
+            start <= host_ptr and end <= stop for start, stop in self._immutable_host_spans
+        )
         for start, stop, is_shared in self._inherited_host_spans:
-            if host_ptr < start or end > stop or not is_shared:
+            if host_ptr < start or end > stop:
+                continue
+            if not is_shared and not declared_immutable:
                 continue
             owner, buffer_id = self._buffer_identity_for(host_ptr, nbytes)
             return wrap_fork_inherited(
@@ -2488,6 +2526,7 @@ class DistributedWorker(Worker):
         # No later copy may name these ranges: the parent has dropped its references, so a
         # copy after this point stages rather than wrapping memory nobody vouches for.
         self._inherited_host_spans = ()
+        self._immutable_host_spans = ()
         with self._named_identity_mu:
             self._named_identities.clear()
 
@@ -2804,6 +2843,7 @@ class DistributedWorker(Worker):
             finally:
                 self._inherited_host_tensors = ()
                 self._inherited_host_spans = ()
+                self._immutable_host_spans = ()
                 self._named_identities.clear()
                 self._persistent_domains_by_program.clear()
                 if self._close_complete:

--- a/python/pypto/runtime/distributed_runner.py
+++ b/python/pypto/runtime/distributed_runner.py
@@ -1439,27 +1439,6 @@ def execute_distributed_compiled(
     return compiled(*args, config=config)
 
 
-def _immutable_host_spans(
-    tensors: Sequence[torch.Tensor] | None,
-) -> tuple[tuple[int, int], ...]:
-    """Return ``(start, end)`` for each range the caller declares is never written post-fork."""
-    spans: list[tuple[int, int]] = []
-    for tensor in tensors or ():
-        if not isinstance(tensor, torch.Tensor):
-            raise TypeError(
-                "DistributedWorker immutable_host_tensors entries must be torch.Tensor objects, "
-                f"got {type(tensor).__name__}."
-            )
-        if tensor.device.type != "cpu" or not tensor.is_contiguous():
-            raise ValueError(
-                "DistributedWorker immutable_host_tensors must be contiguous CPU tensors; "
-                f"got device={tensor.device} shape={tuple(tensor.shape)}."
-            )
-        start = tensor.data_ptr()
-        spans.append((start, start + tensor.numel() * tensor.element_size()))
-    return tuple(spans)
-
-
 class DistributedWorker(Worker):
     """L3 distributed execution handle: prepare once, dispatch many.
 
@@ -1482,9 +1461,20 @@ class DistributedWorker(Worker):
     tensor (no ``copy_from``). Explicit :meth:`alloc_tensor` /
     :meth:`alloc_stacked_tensor` uploads and copy-backs stage through
     runtime-owned POSIX-shm Buffers, so their CPU-contiguous host endpoints may
-    be ordinary tensors created after ``prepare``. ``inherited_host_tensors``
-    remains a compatibility lifetime facility; it does not make an ordinary
-    tensor a valid direct dispatch argument.
+    be ordinary tensors created after ``prepare``.
+
+    ``inherited_host_tensors`` keeps such a host range alive for the worker's
+    lifetime *and* is a caller guarantee about it: listing a tensor asserts that
+    its backing is visible across processes — a ``MAP_SHARED`` mapping, whether
+    torch's own shared memory or an external file mapping — and that the mapping
+    stays valid for as long as the worker lives. Listed ranges are then named in
+    place instead of staged, which is what removes the per-copy ``memmove``.
+    Passing a ``MAP_PRIVATE`` backing is **unsupported**: copy-on-write leaves the
+    child reading its pre-fork snapshot, so uploads may carry stale or incorrect
+    data. PyPTO cannot verify the guarantee — ``torch.is_shared()`` returns
+    ``False`` for valid external ``MAP_SHARED`` mappings — so it warns once at
+    prepare time for the tensors it cannot confirm and proceeds. Listing a tensor
+    does not make it a valid direct dispatch argument.
 
     ``callbacks`` binds a caller-supplied callable to a SubWorker by name — e.g.
     a real sampling closure. Abstract SubWorkers (declared with a ``...`` body)
@@ -1534,7 +1524,6 @@ class DistributedWorker(Worker):
         callbacks: dict[str, Callable[..., Any]] | None = None,
         sub_worker_overrides: dict[str, Callable[..., Any]] | None = None,
         inherited_host_tensors: Sequence[torch.Tensor] | None = None,
-        immutable_host_tensors: Sequence[torch.Tensor] | None = None,
         startup_timeout_s: float | None = None,
     ) -> None:
         super().__init__()  # initialize Worker ABC state (_owned_tensors)
@@ -1560,29 +1549,40 @@ class DistributedWorker(Worker):
         self._inherited_host_tensors = inherited
         # `copy_to` / `copy_from` stage through a simpler-owned shm Buffer so an ordinary
         # post-fork tensor is a legal endpoint. That relaxation costs one full copy of the
-        # payload, which a fork-inherited MAP_SHARED range does not need: parent and child
-        # see the same pages, so it can be named in place. Whether a range is MAP_SHARED is
-        # the caller's to know and cannot be inferred from an address, so record it here,
-        # where the tensors are still in hand, as (start, end, is_shared) spans. A
-        # MAP_PRIVATE range is staged unless the caller declares it immutable below, and even
-        # then only as an upload source — see `_named_host_buffer`.
-        # Ranges the caller *declares* are never written after ``prepare()``. This cannot be
-        # inferred: ``torch.is_shared()`` answers "is this storage a shared-memory allocation",
-        # while what the copy path needs to know is "will anyone write these bytes after the
-        # fork". A read-only ``MAP_SHARED`` file mapping built with ``mmap`` + ``from_numpy`` is
-        # genuinely shared at the OS level and still reports ``False``, so inference rejects
-        # exactly the case that benefits most. Only the caller knows, so it says so here.
-        self._immutable_host_spans: tuple[tuple[int, int], ...] = _immutable_host_spans(
-            immutable_host_tensors
-        )
-        self._inherited_host_spans: tuple[tuple[int, int, bool], ...] = tuple(
+        # payload, which a fork-inherited range visible across processes does not need:
+        # parent and child see the same pages, so it can be named in place. Record the
+        # extents here, where the tensors are still in hand, since an address alone says
+        # nothing about its backing.
+        #
+        # Listing a tensor is the caller's guarantee that the backing is cross-process
+        # visible (see the class docstring). It is not inferred, because no portable check
+        # exists: `torch.is_shared()` answers "is this storage a torch shared-memory
+        # allocation", which is a different question. A read-only MAP_SHARED file mapping
+        # built with `mmap` + `from_numpy` is genuinely shared at the OS level and still
+        # reports False, so inference would reject exactly the case that benefits most,
+        # while reading /proc/self/maps would tie this file to Linux and the simulator also
+        # runs on macOS.
+        self._inherited_host_spans: tuple[tuple[int, int], ...] = tuple(
             (
                 tensor.data_ptr(),
                 tensor.data_ptr() + tensor.numel() * tensor.element_size(),
-                bool(tensor.is_shared()),
             )
             for tensor in inherited
         )
+        # `is_shared()` is kept as a one-way signal: True confirms a torch-managed shared
+        # backing, False is inconclusive. Warn once rather than per tensor, and never
+        # reject or silently fall back to staging — falling back would hide the cost this
+        # facility exists to remove, and rejecting would refuse the valid external mapping.
+        unverifiable = sum(1 for tensor in inherited if not tensor.is_shared())
+        if unverifiable:
+            warnings.warn(
+                f"DistributedWorker: {unverifiable} of {len(inherited)} inherited_host_tensors "
+                "cannot be verified as cross-process visible (torch.is_shared() is False, which "
+                "is inconclusive for external MAP_SHARED mappings). Naming them relies on the "
+                "caller's guarantee; a MAP_PRIVATE backing yields stale or incorrect data.",
+                RuntimeWarning,
+                stacklevel=3,
+            )
         self._buffer_owner_id: bytes | None = None
         self._buffer_id_seq = 0
         # One identity per host *range*, not per copy. Both properties this buys are load
@@ -2292,29 +2292,22 @@ class DistributedWorker(Worker):
         needs no staging buffer and no host-side memcpy. A tensor allocated after
         ``prepare`` has no mapping in the child, so the caller stages it.
 
-        **Shared, or declared immutable.** A range that ``torch.is_shared()`` reports as
-        shared is always safe to name. A range that does not is named only if the caller
-        listed it in ``immutable_host_tensors``, promising nothing writes it after
-        ``prepare()``.
+        **The list is the guarantee.** Listing a tensor in ``inherited_host_tensors``
+        asserts that its backing is visible across processes and stays valid for the
+        worker's lifetime, so any range inside a listed span is named in place. Nothing is
+        inferred and nothing is rejected: ``torch.is_shared()`` is a one-way signal, so
+        deciding from it would refuse a read-only ``MAP_SHARED`` file mapping — which
+        reports ``False`` while being perfectly safe to name — and reading
+        ``/proc/self/maps`` would tie this to Linux while the simulator also runs on macOS.
+        A ``MAP_PRIVATE`` backing is unsupported here rather than handled: the child keeps
+        reading its pre-fork snapshot, so the caller would upload stale bytes.
 
-        The declaration applies to upload sources only, and a read-back into a declared range
-        is refused rather than quietly staged: staging writes the same bytes, so it would break
-        the promise just as thoroughly while looking like it worked. An undeclared range still
-        has to be genuinely shared to be named as a destination, since writing a private page in
-        the child leaves the parent reading the old contents.
-
-        A named source is granted ``READ`` and only a destination ``READWRITE``. Naming a
-        read-only mapping ``READWRITE`` would tell the ABI a consumer may write memory that
-        faults on a write — the same kind of misdeclaration this option exists to remove.
-
-        Both conditions exist because inference alone is wrong in both directions. A
-        ``MAP_PRIVATE`` range is inherited too, but copy-on-write means the child keeps
-        reading its pre-fork snapshot, so a parent that writes after registering would
-        upload stale bytes — there, staging is not a fallback but the correct behaviour,
-        since its ``memmove`` runs in the parent. Conversely a read-only ``MAP_SHARED`` file
-        mapping wrapped through ``mmap`` + ``from_numpy`` reports ``is_shared() == False``
-        while being perfectly safe to name, which is why the declaration exists rather than
-        a wider guess.
+        Writability is left to the MMU rather than tracked here, because visibility and
+        writability are separate properties and one caller guarantee only covers the first.
+        A range mapped ``MAP_SHARED`` from a read-only fd is genuinely shared and still
+        faults on write, so a read-back into it fails immediately instead of corrupting
+        anything. A named source is granted ``READ`` and only a destination ``READWRITE``,
+        so the ABI is never told a consumer may write memory it may not.
 
         Each range is wrapped on its own rather than offset into a whole-tensor Buffer,
         because a Buffer carries no offset: a shard's address is interior to its stacked
@@ -2328,23 +2321,8 @@ class DistributedWorker(Worker):
         )
 
         end = host_ptr + nbytes
-        declared_immutable = any(
-            start <= host_ptr and end <= stop for start, stop in self._immutable_host_spans
-        )
-        if writing and declared_immutable:
-            # The caller promised nothing writes this range after prepare(), and a read-back
-            # would do exactly that. Refusing is the only way to honour the promise: staging
-            # writes the same bytes, so silently taking that path would break it just as
-            # thoroughly while looking like it worked.
-            raise ValueError(
-                f"copy_from destination 0x{host_ptr:x}+{nbytes} lies in a range declared through "
-                "immutable_host_tensors, which promises nothing writes it after prepare(); read "
-                "back into a tensor that was not declared immutable."
-            )
-        for start, stop, is_shared in self._inherited_host_spans:
+        for start, stop in self._inherited_host_spans:
             if host_ptr < start or end > stop:
-                continue
-            if not is_shared and not declared_immutable:
                 continue
             owner, buffer_id = self._buffer_identity_for(host_ptr, nbytes)
             return wrap_fork_inherited(
@@ -2556,7 +2534,6 @@ class DistributedWorker(Worker):
         # No later copy may name these ranges: the parent has dropped its references, so a
         # copy after this point stages rather than wrapping memory nobody vouches for.
         self._inherited_host_spans = ()
-        self._immutable_host_spans = ()
         with self._named_identity_mu:
             self._named_identities.clear()
 
@@ -2873,7 +2850,6 @@ class DistributedWorker(Worker):
             finally:
                 self._inherited_host_tensors = ()
                 self._inherited_host_spans = ()
-                self._immutable_host_spans = ()
                 self._named_identities.clear()
                 self._persistent_domains_by_program.clear()
                 if self._close_complete:

--- a/python/pypto/runtime/distributed_runner.py
+++ b/python/pypto/runtime/distributed_runner.py
@@ -1445,6 +1445,11 @@ def _immutable_host_spans(
     """Return ``(start, end)`` for each range the caller declares is never written post-fork."""
     spans: list[tuple[int, int]] = []
     for tensor in tensors or ():
+        if not isinstance(tensor, torch.Tensor):
+            raise TypeError(
+                "DistributedWorker immutable_host_tensors entries must be torch.Tensor objects, "
+                f"got {type(tensor).__name__}."
+            )
         if tensor.device.type != "cpu" or not tensor.is_contiguous():
             raise ValueError(
                 "DistributedWorker immutable_host_tensors must be contiguous CPU tensors; "
@@ -1559,7 +1564,8 @@ class DistributedWorker(Worker):
         # see the same pages, so it can be named in place. Whether a range is MAP_SHARED is
         # the caller's to know and cannot be inferred from an address, so record it here,
         # where the tensors are still in hand, as (start, end, is_shared) spans. A
-        # MAP_PRIVATE range is deliberately left to staging — see `_named_host_buffer`.
+        # MAP_PRIVATE range is staged unless the caller declares it immutable below, and even
+        # then only as an upload source — see `_named_host_buffer`.
         # Ranges the caller *declares* are never written after ``prepare()``. This cannot be
         # inferred: ``torch.is_shared()`` answers "is this storage a shared-memory allocation",
         # while what the copy path needs to know is "will anyone write these bytes after the
@@ -2278,7 +2284,7 @@ class DistributedWorker(Worker):
             self._named_identities[key] = identity
             return identity
 
-    def _named_host_buffer(self, host_ptr: int, nbytes: int) -> Any:
+    def _named_host_buffer(self, host_ptr: int, nbytes: int, *, writing: bool = False) -> Any:
         """Name a fork-inherited MAP_SHARED host range in place, or ``None`` to stage it.
 
         Only memory registered through ``inherited_host_tensors`` can be named at all: it
@@ -2290,6 +2296,10 @@ class DistributedWorker(Worker):
         shared is always safe to name. A range that does not is named only if the caller
         listed it in ``immutable_host_tensors``, promising nothing writes it after
         ``prepare()``.
+
+        The declaration applies to upload sources only: a declared range used as a D2H
+        destination still has to be genuinely shared, since writing a private page in the child
+        leaves the parent reading the old contents and writing a read-only mapping faults.
 
         Both conditions exist because inference alone is wrong in both directions. A
         ``MAP_PRIVATE`` range is inherited too, but copy-on-write means the child keeps
@@ -2312,7 +2322,12 @@ class DistributedWorker(Worker):
         )
 
         end = host_ptr + nbytes
-        declared_immutable = any(
+        # The declaration covers *reads* only. Naming a declared non-shared range as a D2H
+        # destination would contradict the declaration and break either way: a MAP_PRIVATE page
+        # written by the child splits copy-on-write, so the parent keeps seeing the old bytes,
+        # and a read-only file mapping faults outright. Writes therefore still require a range
+        # that is genuinely shared.
+        declared_immutable = not writing and any(
             start <= host_ptr and end <= stop for start, stop in self._immutable_host_spans
         )
         for start, stop, is_shared in self._inherited_host_spans:
@@ -2354,7 +2369,7 @@ class DistributedWorker(Worker):
         src = self._device_buffer(src_dev_ptr, worker_id, "copy_from")
         if not isinstance(nbytes, int) or nbytes <= 0:
             raise ValueError(f"nbytes must be a positive int, got {nbytes!r}")
-        dst = self._named_host_buffer(int(dst_host_ptr), int(nbytes))
+        dst = self._named_host_buffer(int(dst_host_ptr), int(nbytes), writing=True)
         if dst is not None:
             self._w.copy_from(dst, src)
             return

--- a/python/pypto/runtime/distributed_runner.py
+++ b/python/pypto/runtime/distributed_runner.py
@@ -1592,7 +1592,7 @@ class DistributedWorker(Worker):
         # And re-copying the same range must reuse its identity, because one identity may name
         # only one backing: `materialize` refuses a second descriptor for an identity it has
         # already handed out.
-        self._named_identities: dict[tuple[int, int], tuple[bytes, int]] = {}
+        self._named_identities: dict[tuple[int, int, bool], tuple[bytes, int]] = {}
         # Minting is not atomic (`+=` is load/add/store, and the lazy owner mint is
         # check-then-act) while `alloc_stacked_tensor` runs one thread per chip through this
         # path, so the cache and the counter are guarded together.
@@ -2253,7 +2253,7 @@ class DistributedWorker(Worker):
             return 0
         return int(self._w.committed_device_memory(worker_id))
 
-    def _buffer_identity_for(self, host_ptr: int, nbytes: int) -> tuple[bytes, int]:
+    def _buffer_identity_for(self, host_ptr: int, nbytes: int, *, writing: bool) -> tuple[bytes, int]:
         """Return the stable ``(owner_instance_id, buffer_id)`` naming this host range.
 
         Keyed on the range rather than counted per call, so a range copied N times keeps one
@@ -2264,13 +2264,19 @@ class DistributedWorker(Worker):
         registry without bound. Distinct sub-ranges of one registered tensor still get distinct
         identities, which is what a sharded upload needs.
 
+        The direction is part of the key because it decides the descriptor's ``access``: a
+        source is named ``READ`` and a destination ``READWRITE``. One identity may name only
+        one backing, so a range copied in both directions under a single identity would have
+        ``materialize`` reject the second descriptor for the changed access. Two identities per
+        range is still bounded — the property that matters is that it does not grow per copy.
+
         Held under a lock because ``alloc_stacked_tensor`` drives this from one thread per chip.
         """
         from simpler.buffer import (  # noqa: PLC0415  # pyright: ignore[reportMissingImports]
             mint_owner_instance_id,
         )
 
-        key = (int(host_ptr), int(nbytes))
+        key = (int(host_ptr), int(nbytes), bool(writing))
         with self._named_identity_mu:
             cached = self._named_identities.get(key)
             if cached is not None:
@@ -2324,7 +2330,7 @@ class DistributedWorker(Worker):
         for start, stop in self._inherited_host_spans:
             if host_ptr < start or end > stop:
                 continue
-            owner, buffer_id = self._buffer_identity_for(host_ptr, nbytes)
+            owner, buffer_id = self._buffer_identity_for(host_ptr, nbytes, writing=writing)
             return wrap_fork_inherited(
                 host_ptr,
                 nbytes,

--- a/tests/ut/runtime/test_distributed_worker.py
+++ b/tests/ut/runtime/test_distributed_worker.py
@@ -3330,7 +3330,9 @@ class TestNamedInheritedHostRanges:
         named = patched_setup["worker"].copy_to.call_args.args[1]
         assert isinstance(named, _NamedHostRange)
         assert (named.base, named.nbytes) == (host.data_ptr(), nbytes)
-        assert (named.backend_kind, named.access) == ("FORK_SHM", "READWRITE")
+        # READ, not READWRITE as this asserted before: an upload source is only ever read by the
+        # child, and granting write access to a mapping that may be read-only misdescribes it.
+        assert (named.backend_kind, named.access) == ("FORK_SHM", "READ")
         # The point of naming it: no staging buffer is created at all.
         patched_setup["worker"].create_buffer.assert_not_called()
         rt.close()
@@ -3377,13 +3379,12 @@ class TestNamedInheritedHostRanges:
         patched_setup["worker"].create_buffer.assert_not_called()
         rt.close()
 
-    def test_a_declared_range_is_not_named_as_a_d2h_destination(self, patched_setup):
-        """The declaration is a promise about reads, so it must not license writes.
+    def test_a_read_back_into_a_declared_range_is_refused(self, patched_setup):
+        """Writing a range declared immutable is a caller bug, and staging would hide it.
 
-        Naming a declared non-shared range as a read-back destination would break either way: a
-        MAP_PRIVATE page written by the child splits copy-on-write, so the parent keeps reading
-        the old bytes, and a read-only file mapping — which is the case this option exists for —
-        faults on the write. Both are silent-or-worse, so D2H still requires a shared range.
+        Falling back to staging would write the same bytes into the same range, breaking the
+        promise just as thoroughly while looking like it worked — and for the read-only mapping
+        this option exists for, that write faults. Refusing names the mistake instead.
         """
         host = torch.zeros(4, 4, dtype=torch.float32)  # NOT shared
         rt = DistributedWorker(
@@ -3394,14 +3395,55 @@ class TestNamedInheritedHostRanges:
         dev = self._dev(rt)
         nbytes = host.numel() * host.element_size()
 
-        rt.copy_from(host.data_ptr(), dev.data_ptr, nbytes)
-
-        staged = patched_setup["worker"].copy_from.call_args.args[0]
-        assert not isinstance(staged, _NamedHostRange), "a declared range must not receive a D2H"
+        with pytest.raises(ValueError, match="declared through immutable_host_tensors"):
+            rt.copy_from(host.data_ptr(), dev.data_ptr, nbytes)
         rt.close()
 
-    def test_a_shared_range_is_still_named_as_a_d2h_destination(self, patched_setup):
-        """The direction rule must not regress the case that was already safe."""
+    def test_a_shared_range_declared_immutable_is_also_refused_for_read_back(self, patched_setup):
+        """Shared memory makes the write *work*; it does not make it consistent with the promise.
+
+        This is the case a mechanical check would wave through: the bytes land where the parent
+        can see them, so nothing breaks — except the declaration the caller made, which other
+        decisions now rest on.
+        """
+        host = torch.zeros(4, 4, dtype=torch.float32).share_memory_()
+        rt = DistributedWorker(
+            _fake_compiled([_param("a", [4, 4])], []),
+            inherited_host_tensors=[host],
+            immutable_host_tensors=[host],
+        )
+        dev = self._dev(rt)
+        nbytes = host.numel() * host.element_size()
+
+        with pytest.raises(ValueError, match="declared through immutable_host_tensors"):
+            rt.copy_from(host.data_ptr(), dev.data_ptr, nbytes)
+        rt.close()
+
+    def test_a_named_upload_source_is_granted_read_only(self, patched_setup):
+        """An upload source is read by the child and nothing more, so the descriptor says READ.
+
+        Granting READWRITE would tell the ABI a consumer may write memory that, for the
+        read-only file mapping this option targets, faults on a write — the same class of
+        misdeclaration the declaration exists to remove.
+        """
+        host = torch.zeros(4, 4, dtype=torch.float32)
+        rt = DistributedWorker(
+            _fake_compiled([_param("a", [4, 4])], []),
+            inherited_host_tensors=[host],
+            immutable_host_tensors=[host],
+        )
+        dev = self._dev(rt)
+        nbytes = host.numel() * host.element_size()
+
+        rt.copy_to(dev.data_ptr, host.data_ptr(), nbytes)
+
+        named = patched_setup["worker"].copy_to.call_args.args[1]
+        assert isinstance(named, _NamedHostRange)
+        assert (named.backend_kind, named.access) == ("FORK_SHM", "READ")
+        rt.close()
+
+    def test_an_undeclared_shared_range_is_still_named_as_a_d2h_destination(self, patched_setup):
+        """The rules above must not regress the case that was already safe: shared, undeclared."""
         host = torch.zeros(4, 4, dtype=torch.float32).share_memory_()
         rt = DistributedWorker(_fake_compiled([_param("a", [4, 4])], []), inherited_host_tensors=[host])
         dev = self._dev(rt)

--- a/tests/ut/runtime/test_distributed_worker.py
+++ b/tests/ut/runtime/test_distributed_worker.py
@@ -3377,6 +3377,49 @@ class TestNamedInheritedHostRanges:
         patched_setup["worker"].create_buffer.assert_not_called()
         rt.close()
 
+    def test_a_declared_range_is_not_named_as_a_d2h_destination(self, patched_setup):
+        """The declaration is a promise about reads, so it must not license writes.
+
+        Naming a declared non-shared range as a read-back destination would break either way: a
+        MAP_PRIVATE page written by the child splits copy-on-write, so the parent keeps reading
+        the old bytes, and a read-only file mapping — which is the case this option exists for —
+        faults on the write. Both are silent-or-worse, so D2H still requires a shared range.
+        """
+        host = torch.zeros(4, 4, dtype=torch.float32)  # NOT shared
+        rt = DistributedWorker(
+            _fake_compiled([_param("a", [4, 4])], []),
+            inherited_host_tensors=[host],
+            immutable_host_tensors=[host],
+        )
+        dev = self._dev(rt)
+        nbytes = host.numel() * host.element_size()
+
+        rt.copy_from(host.data_ptr(), dev.data_ptr, nbytes)
+
+        staged = patched_setup["worker"].copy_from.call_args.args[0]
+        assert not isinstance(staged, _NamedHostRange), "a declared range must not receive a D2H"
+        rt.close()
+
+    def test_a_shared_range_is_still_named_as_a_d2h_destination(self, patched_setup):
+        """The direction rule must not regress the case that was already safe."""
+        host = torch.zeros(4, 4, dtype=torch.float32).share_memory_()
+        rt = DistributedWorker(_fake_compiled([_param("a", [4, 4])], []), inherited_host_tensors=[host])
+        dev = self._dev(rt)
+        nbytes = host.numel() * host.element_size()
+
+        rt.copy_from(host.data_ptr(), dev.data_ptr, nbytes)
+
+        assert isinstance(patched_setup["worker"].copy_from.call_args.args[0], _NamedHostRange)
+        rt.close()
+
+    def test_a_non_tensor_declared_entry_is_rejected(self, patched_setup):
+        """Matches how `inherited_host_tensors` rejects them: TypeError, not AttributeError."""
+        with pytest.raises(TypeError, match="immutable_host_tensors entries must be torch.Tensor"):
+            DistributedWorker(
+                _fake_compiled([_param("a", [4, 4])], []),
+                immutable_host_tensors=[None],  # pyright: ignore[reportArgumentType]
+            )
+
     def test_declaring_a_range_does_not_name_its_neighbours(self, patched_setup):
         """The declaration is per range, so an undeclared private tensor still stages."""
         declared = torch.zeros(4, 4, dtype=torch.float32)

--- a/tests/ut/runtime/test_distributed_worker.py
+++ b/tests/ut/runtime/test_distributed_worker.py
@@ -1947,6 +1947,21 @@ class TestMultiProgram:
         assert fake_worker.call_args.kwargs["persistent"] is True
         assert fake_worker.call_args.kwargs["reset_persistent_windows"] is None
 
+    def test_prepare_forwards_inherited_host_tensors(self):
+        """The documented entry point is ``compiled.prepare(inherited_host_tensors=...)``.
+
+        Regression: the keyword existed only on the DistributedWorker constructor, so the
+        call the user manual shows raised TypeError and the zero-copy path was reachable
+        only through the lower-level API.
+        """
+        from pypto.ir.distributed_compiled_program import DistributedCompiledProgram  # noqa: PLC0415
+
+        primary = _fake_compiled([_param("a", [4])], [])
+        host = torch.zeros(4, dtype=torch.float32).share_memory_()
+        with patch("pypto.runtime.distributed_runner.DistributedWorker") as fake_worker:
+            DistributedCompiledProgram.prepare(primary, inherited_host_tensors=[host])
+        assert fake_worker.call_args.kwargs["inherited_host_tensors"] == [host]
+
     def test_prepare_forwards_startup_timeout(self):
         from pypto.ir.distributed_compiled_program import DistributedCompiledProgram  # noqa: PLC0415
 
@@ -3502,6 +3517,52 @@ class TestNamedInheritedHostRanges:
         rt.copy_to(dev.data_ptr, other.data_ptr(), nbytes)
 
         assert not isinstance(patched_setup["worker"].copy_to.call_args.args[1], _NamedHostRange)
+        rt.close()
+
+    def test_a_range_listed_through_prepare_is_named(self, patched_setup):
+        """End to end through the documented entry point, not just the constructor."""
+        from pypto.ir.distributed_compiled_program import DistributedCompiledProgram  # noqa: PLC0415
+
+        host = torch.zeros(4, 4, dtype=torch.float32).share_memory_()
+        rt = DistributedCompiledProgram.prepare(
+            _fake_compiled([_param("a", [4, 4])], []),
+            inherited_host_tensors=[host],
+        )
+        dev = self._dev(rt)
+        nbytes = host.numel() * host.element_size()
+        patched_setup["worker"].create_buffer.reset_mock()
+
+        rt.copy_to(dev.data_ptr, host.data_ptr(), nbytes)
+
+        assert isinstance(patched_setup["worker"].copy_to.call_args.args[1], _NamedHostRange)
+        patched_setup["worker"].create_buffer.assert_not_called()
+        rt.close()
+
+    def test_the_same_range_in_both_directions_gets_distinct_identities(self, patched_setup):
+        """One identity may name only one backing, and the two directions differ in access.
+
+        Regression: the identity was keyed on ``(host_ptr, nbytes)`` alone while a source is
+        granted READ and a destination READWRITE, so a copy_to followed by a copy_from on one
+        range reused a single identity under two descriptors — which `ImportRegistry.materialize`
+        rejects for the changed access. Keyed by direction, both are named and reuse stays
+        per-range rather than per-copy.
+        """
+        host = torch.zeros(4, 4, dtype=torch.float32).share_memory_()
+        rt = DistributedWorker(_fake_compiled([_param("a", [4, 4])], []), inherited_host_tensors=[host])
+        dev = self._dev(rt)
+        nbytes = host.numel() * host.element_size()
+
+        rt.copy_to(dev.data_ptr, host.data_ptr(), nbytes)
+        rt.copy_from(host.data_ptr(), dev.data_ptr, nbytes)
+
+        src = patched_setup["worker"].copy_to.call_args.args[1]
+        dst = patched_setup["worker"].copy_from.call_args.args[0]
+        assert (src.access, dst.access) == ("READ", "READWRITE")
+        assert src.buffer_id != dst.buffer_id
+
+        # Re-copying either direction must still reuse that direction's identity.
+        rt.copy_to(dev.data_ptr, host.data_ptr(), nbytes)
+        assert patched_setup["worker"].copy_to.call_args.args[1].buffer_id == src.buffer_id
         rt.close()
 
     def test_copy_to_stages_a_partially_overlapping_range(self, patched_setup):

--- a/tests/ut/runtime/test_distributed_worker.py
+++ b/tests/ut/runtime/test_distributed_worker.py
@@ -3352,6 +3352,71 @@ class TestNamedInheritedHostRanges:
         assert ctypes.string_at(staged.base, nbytes) == ctypes.string_at(host.data_ptr(), nbytes)
         rt.close()
 
+    def test_a_declared_immutable_range_is_named_even_when_not_shared(self, patched_setup):
+        """The case inference cannot reach: safe to name, but `is_shared()` says otherwise.
+
+        A read-only `MAP_SHARED` file mapping wrapped through `mmap` + `from_numpy` is shared at
+        the OS level and reports `is_shared() == False`, so it is staged despite being the single
+        biggest beneficiary of naming. The caller declaring it closes that gap.
+        """
+        host = torch.zeros(4, 4, dtype=torch.float32)  # NOT shared
+        rt = DistributedWorker(
+            _fake_compiled([_param("a", [4, 4])], []),
+            inherited_host_tensors=[host],
+            immutable_host_tensors=[host],
+        )
+        dev = self._dev(rt)
+        nbytes = host.numel() * host.element_size()
+        patched_setup["worker"].create_buffer.reset_mock()
+
+        rt.copy_to(dev.data_ptr, host.data_ptr(), nbytes)
+
+        named = patched_setup["worker"].copy_to.call_args.args[1]
+        assert isinstance(named, _NamedHostRange)
+        assert (named.base, named.nbytes) == (host.data_ptr(), nbytes)
+        patched_setup["worker"].create_buffer.assert_not_called()
+        rt.close()
+
+    def test_declaring_a_range_does_not_name_its_neighbours(self, patched_setup):
+        """The declaration is per range, so an undeclared private tensor still stages."""
+        declared = torch.zeros(4, 4, dtype=torch.float32)
+        other = torch.zeros(4, 4, dtype=torch.float32)
+        rt = DistributedWorker(
+            _fake_compiled([_param("a", [4, 4])], []),
+            inherited_host_tensors=[declared, other],
+            immutable_host_tensors=[declared],
+        )
+        dev = self._dev(rt)
+        nbytes = other.numel() * other.element_size()
+
+        rt.copy_to(dev.data_ptr, other.data_ptr(), nbytes)
+
+        assert not isinstance(patched_setup["worker"].copy_to.call_args.args[1], _NamedHostRange)
+        rt.close()
+
+    def test_a_declared_range_must_still_be_inherited(self, patched_setup):
+        """Declaring immutability says nothing about reachability: a post-fork tensor has no
+        mapping in the child, so it stages regardless of what the caller promises."""
+        host = torch.zeros(4, 4, dtype=torch.float32)
+        rt = DistributedWorker(
+            _fake_compiled([_param("a", [4, 4])], []),
+            immutable_host_tensors=[host],
+        )
+        dev = self._dev(rt)
+        nbytes = host.numel() * host.element_size()
+
+        rt.copy_to(dev.data_ptr, host.data_ptr(), nbytes)
+
+        assert not isinstance(patched_setup["worker"].copy_to.call_args.args[1], _NamedHostRange)
+        rt.close()
+
+    def test_a_non_cpu_declared_tensor_is_rejected(self, patched_setup):
+        with pytest.raises(ValueError, match="immutable_host_tensors must be contiguous CPU"):
+            DistributedWorker(
+                _fake_compiled([_param("a", [4, 4])], []),
+                immutable_host_tensors=[torch.zeros(4, 4).t()],
+            )
+
     def test_copy_to_stages_a_partially_overlapping_range(self, patched_setup):
         host = torch.zeros(8, dtype=torch.float32).share_memory_()
         rt = DistributedWorker(_fake_compiled([_param("a", [4, 4])], []), inherited_host_tensors=[host])

--- a/tests/ut/runtime/test_distributed_worker.py
+++ b/tests/ut/runtime/test_distributed_worker.py
@@ -22,6 +22,7 @@ import importlib.util
 import json
 import sys
 import threading
+import warnings
 import weakref
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
@@ -3337,12 +3338,19 @@ class TestNamedInheritedHostRanges:
         patched_setup["worker"].create_buffer.assert_not_called()
         rt.close()
 
-    def test_copy_to_stages_a_private_inherited_range(self, patched_setup):
-        # MAP_PRIVATE: the child's pages are frozen at fork, so a named range would upload
-        # whatever was there before a later parent write. Staging reads the parent's current
-        # contents instead, which is why it stays the correct path here.
+    def test_copy_to_stages_an_unlisted_range(self, patched_setup):
+        # Reachability, not backing: a tensor the caller never listed has no guarantee attached,
+        # so it stages and the memmove reads the parent's current contents.
+        #
+        # This replaces test_copy_to_stages_a_private_inherited_range, which asserted the
+        # opposite for a *listed* private tensor: that listing a MAP_PRIVATE range was safe
+        # because the runtime would infer it from `is_shared()` and stage it anyway. Under the
+        # caller-guarantee contract that inference is gone, so a listed private range is now
+        # named and uploads stale bytes. That is a deliberate narrowing of the contract, agreed
+        # in review; if it is ever rejected, restore the `is_shared()` gate in
+        # `_named_host_buffer` rather than weakening this test.
         host = torch.zeros(4, 4, dtype=torch.float32)
-        rt = DistributedWorker(_fake_compiled([_param("a", [4, 4])], []), inherited_host_tensors=[host])
+        rt = DistributedWorker(_fake_compiled([_param("a", [4, 4])], []))
         dev = self._dev(rt)
         nbytes = host.numel() * host.element_size()
         host.fill_(1.0)
@@ -3354,18 +3362,17 @@ class TestNamedInheritedHostRanges:
         assert ctypes.string_at(staged.base, nbytes) == ctypes.string_at(host.data_ptr(), nbytes)
         rt.close()
 
-    def test_a_declared_immutable_range_is_named_even_when_not_shared(self, patched_setup):
-        """The case inference cannot reach: safe to name, but `is_shared()` says otherwise.
+    def test_a_listed_range_is_named_even_when_not_shared(self, patched_setup):
+        """The case no portable check can reach: safe to name, but `is_shared()` says otherwise.
 
         A read-only `MAP_SHARED` file mapping wrapped through `mmap` + `from_numpy` is shared at
-        the OS level and reports `is_shared() == False`, so it is staged despite being the single
-        biggest beneficiary of naming. The caller declaring it closes that gap.
+        the OS level and reports `is_shared() == False`. Listing it is the caller's guarantee,
+        so it is named rather than staged — which is the whole point of the facility.
         """
-        host = torch.zeros(4, 4, dtype=torch.float32)  # NOT shared
+        host = torch.zeros(4, 4, dtype=torch.float32)  # NOT torch-shared
         rt = DistributedWorker(
             _fake_compiled([_param("a", [4, 4])], []),
             inherited_host_tensors=[host],
-            immutable_host_tensors=[host],
         )
         dev = self._dev(rt)
         nbytes = host.numel() * host.element_size()
@@ -3379,73 +3386,18 @@ class TestNamedInheritedHostRanges:
         patched_setup["worker"].create_buffer.assert_not_called()
         rt.close()
 
-    def test_a_read_back_into_a_declared_range_is_refused(self, patched_setup):
-        """Writing a range declared immutable is a caller bug, and staging would hide it.
+    def test_a_read_back_into_a_listed_range_is_named(self, patched_setup):
+        """Both directions, deliberately: one guarantee, no direction rule.
 
-        Falling back to staging would write the same bytes into the same range, breaking the
-        promise just as thoroughly while looking like it worked — and for the read-only mapping
-        this option exists for, that write faults. Refusing names the mistake instead.
-        """
-        host = torch.zeros(4, 4, dtype=torch.float32)  # NOT shared
-        rt = DistributedWorker(
-            _fake_compiled([_param("a", [4, 4])], []),
-            inherited_host_tensors=[host],
-            immutable_host_tensors=[host],
-        )
-        dev = self._dev(rt)
-        nbytes = host.numel() * host.element_size()
-
-        with pytest.raises(ValueError, match="declared through immutable_host_tensors"):
-            rt.copy_from(host.data_ptr(), dev.data_ptr, nbytes)
-        rt.close()
-
-    def test_a_shared_range_declared_immutable_is_also_refused_for_read_back(self, patched_setup):
-        """Shared memory makes the write *work*; it does not make it consistent with the promise.
-
-        This is the case a mechanical check would wave through: the bytes land where the parent
-        can see them, so nothing breaks — except the declaration the caller made, which other
-        decisions now rest on.
-        """
-        host = torch.zeros(4, 4, dtype=torch.float32).share_memory_()
-        rt = DistributedWorker(
-            _fake_compiled([_param("a", [4, 4])], []),
-            inherited_host_tensors=[host],
-            immutable_host_tensors=[host],
-        )
-        dev = self._dev(rt)
-        nbytes = host.numel() * host.element_size()
-
-        with pytest.raises(ValueError, match="declared through immutable_host_tensors"):
-            rt.copy_from(host.data_ptr(), dev.data_ptr, nbytes)
-        rt.close()
-
-    def test_a_named_upload_source_is_granted_read_only(self, patched_setup):
-        """An upload source is read by the child and nothing more, so the descriptor says READ.
-
-        Granting READWRITE would tell the ABI a consumer may write memory that, for the
-        read-only file mapping this option targets, faults on a write — the same class of
-        misdeclaration the declaration exists to remove.
+        The guarantee is about visibility, so it holds whichever way the bytes move. Writability
+        is the MMU's business — a range mapped MAP_SHARED from a read-only fd faults on write
+        instead of corrupting anything, so the runtime does not need to police it.
         """
         host = torch.zeros(4, 4, dtype=torch.float32)
         rt = DistributedWorker(
             _fake_compiled([_param("a", [4, 4])], []),
             inherited_host_tensors=[host],
-            immutable_host_tensors=[host],
         )
-        dev = self._dev(rt)
-        nbytes = host.numel() * host.element_size()
-
-        rt.copy_to(dev.data_ptr, host.data_ptr(), nbytes)
-
-        named = patched_setup["worker"].copy_to.call_args.args[1]
-        assert isinstance(named, _NamedHostRange)
-        assert (named.backend_kind, named.access) == ("FORK_SHM", "READ")
-        rt.close()
-
-    def test_an_undeclared_shared_range_is_still_named_as_a_d2h_destination(self, patched_setup):
-        """The rules above must not regress the case that was already safe: shared, undeclared."""
-        host = torch.zeros(4, 4, dtype=torch.float32).share_memory_()
-        rt = DistributedWorker(_fake_compiled([_param("a", [4, 4])], []), inherited_host_tensors=[host])
         dev = self._dev(rt)
         nbytes = host.numel() * host.element_size()
 
@@ -3454,39 +3406,80 @@ class TestNamedInheritedHostRanges:
         assert isinstance(patched_setup["worker"].copy_from.call_args.args[0], _NamedHostRange)
         rt.close()
 
-    def test_a_non_tensor_declared_entry_is_rejected(self, patched_setup):
-        """Matches how `inherited_host_tensors` rejects them: TypeError, not AttributeError."""
-        with pytest.raises(TypeError, match="immutable_host_tensors entries must be torch.Tensor"):
-            DistributedWorker(
-                _fake_compiled([_param("a", [4, 4])], []),
-                immutable_host_tensors=[None],  # pyright: ignore[reportArgumentType]
-            )
+    def test_a_named_upload_source_is_granted_read_only(self, patched_setup):
+        """An upload source is read by the child and nothing more, so the descriptor says READ.
 
-    def test_declaring_a_range_does_not_name_its_neighbours(self, patched_setup):
-        """The declaration is per range, so an undeclared private tensor still stages."""
-        declared = torch.zeros(4, 4, dtype=torch.float32)
-        other = torch.zeros(4, 4, dtype=torch.float32)
-        rt = DistributedWorker(
-            _fake_compiled([_param("a", [4, 4])], []),
-            inherited_host_tensors=[declared, other],
-            immutable_host_tensors=[declared],
-        )
-        dev = self._dev(rt)
-        nbytes = other.numel() * other.element_size()
-
-        rt.copy_to(dev.data_ptr, other.data_ptr(), nbytes)
-
-        assert not isinstance(patched_setup["worker"].copy_to.call_args.args[1], _NamedHostRange)
-        rt.close()
-
-    def test_a_declared_range_must_still_be_inherited(self, patched_setup):
-        """Declaring immutability says nothing about reachability: a post-fork tensor has no
-        mapping in the child, so it stages regardless of what the caller promises."""
+        Granting READWRITE would tell the ABI a consumer may write memory that, for the
+        read-only file mapping this targets, faults on a write.
+        """
         host = torch.zeros(4, 4, dtype=torch.float32)
         rt = DistributedWorker(
             _fake_compiled([_param("a", [4, 4])], []),
-            immutable_host_tensors=[host],
+            inherited_host_tensors=[host],
         )
+        dev = self._dev(rt)
+        nbytes = host.numel() * host.element_size()
+
+        rt.copy_to(dev.data_ptr, host.data_ptr(), nbytes)
+
+        named = patched_setup["worker"].copy_to.call_args.args[1]
+        assert (named.backend_kind, named.access) == ("FORK_SHM", "READ")
+        rt.close()
+
+    def test_a_named_read_back_destination_is_granted_readwrite(self, patched_setup):
+        """A destination is written, so the descriptor must say so."""
+        host = torch.zeros(4, 4, dtype=torch.float32).share_memory_()
+        rt = DistributedWorker(_fake_compiled([_param("a", [4, 4])], []), inherited_host_tensors=[host])
+        dev = self._dev(rt)
+        nbytes = host.numel() * host.element_size()
+
+        rt.copy_from(host.data_ptr(), dev.data_ptr, nbytes)
+
+        named = patched_setup["worker"].copy_from.call_args.args[0]
+        assert (named.backend_kind, named.access) == ("FORK_SHM", "READWRITE")
+        rt.close()
+
+    def test_an_unverifiable_listed_tensor_warns_once(self, patched_setup):
+        """`is_shared()` survives as a best-effort signal: False is inconclusive, so warn.
+
+        One warning per worker, not per tensor and not per copy, and it neither rejects the
+        tensor nor falls back to staging — falling back would silently reinstate the copy this
+        facility removes.
+        """
+        unverifiable = torch.zeros(4, 4, dtype=torch.float32)
+        confirmed = torch.zeros(4, 4, dtype=torch.float32).share_memory_()
+
+        with pytest.warns(RuntimeWarning, match="cannot be verified as cross-process visible") as rec:
+            rt = DistributedWorker(
+                _fake_compiled([_param("a", [4, 4])], []),
+                inherited_host_tensors=[unverifiable, confirmed],
+            )
+
+        assert len(rec) == 1
+        assert "1 of 2" in str(rec[0].message)
+        dev = self._dev(rt)
+        nbytes = unverifiable.numel() * unverifiable.element_size()
+        rt.copy_to(dev.data_ptr, unverifiable.data_ptr(), nbytes)
+        assert isinstance(patched_setup["worker"].copy_to.call_args.args[1], _NamedHostRange)
+        rt.close()
+
+    def test_all_confirmed_tensors_warn_not_at_all(self, patched_setup):
+        """`is_shared() == True` is conclusive, so there is nothing to caveat."""
+        host = torch.zeros(4, 4, dtype=torch.float32).share_memory_()
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            rt = DistributedWorker(
+                _fake_compiled([_param("a", [4, 4])], []),
+                inherited_host_tensors=[host],
+            )
+        rt.close()
+
+    def test_a_listed_range_must_still_be_inherited(self, patched_setup):
+        """The guarantee says nothing about reachability: a post-fork tensor has no mapping in
+        the child, so it stages regardless of what the caller promises."""
+        host = torch.zeros(4, 4, dtype=torch.float32)
+        rt = DistributedWorker(_fake_compiled([_param("a", [4, 4])], []))
         dev = self._dev(rt)
         nbytes = host.numel() * host.element_size()
 
@@ -3495,12 +3488,21 @@ class TestNamedInheritedHostRanges:
         assert not isinstance(patched_setup["worker"].copy_to.call_args.args[1], _NamedHostRange)
         rt.close()
 
-    def test_a_non_cpu_declared_tensor_is_rejected(self, patched_setup):
-        with pytest.raises(ValueError, match="immutable_host_tensors must be contiguous CPU"):
-            DistributedWorker(
-                _fake_compiled([_param("a", [4, 4])], []),
-                immutable_host_tensors=[torch.zeros(4, 4).t()],
-            )
+    def test_listing_a_range_does_not_name_its_neighbours(self, patched_setup):
+        """The guarantee is per listed range, so an unlisted tensor still stages."""
+        listed = torch.zeros(4, 4, dtype=torch.float32)
+        other = torch.zeros(4, 4, dtype=torch.float32)
+        rt = DistributedWorker(
+            _fake_compiled([_param("a", [4, 4])], []),
+            inherited_host_tensors=[listed],
+        )
+        dev = self._dev(rt)
+        nbytes = other.numel() * other.element_size()
+
+        rt.copy_to(dev.data_ptr, other.data_ptr(), nbytes)
+
+        assert not isinstance(patched_setup["worker"].copy_to.call_args.args[1], _NamedHostRange)
+        rt.close()
 
     def test_copy_to_stages_a_partially_overlapping_range(self, patched_setup):
         host = torch.zeros(8, dtype=torch.float32).share_memory_()


### PR DESCRIPTION
Follow-up to #2422, and the answer to the question I left open on it.

## What #2422 ended up doing

It names a fork-inherited host range in place instead of staging a full copy of it, restricted to ranges `torch.is_shared()` reports as shared. That restriction is right for what it prevents — a `MAP_PRIVATE` range is inherited too, and copy-on-write means the child keeps reading its pre-fork snapshot, so naming one would upload stale bytes. Staging is the correct behaviour there, not a fallback.

Measured, it also switches the optimisation off in the case it was written for. I flagged that on the PR before it merged and proposed three shapes for a fix; this is the one I argued for, now with numbers.

## The predicate answers a different question

`torch.is_shared()` answers *"is this storage a shared-memory allocation"*. The copy path needs to know *"will anyone write these bytes after the fork"*.

Those come apart in the case that matters. `pypto-serving` maps its prepacked DeepSeek V4 sidecar read-only and shared, through `mmap` + `numpy.frombuffer` + `torch.from_numpy`. That mapping is genuinely `MAP_SHARED` at the OS level — from `/proc/self/smaps`, `rw-s`, `VmFlags: rd wr sh mr mw me ms` — and reports `is_shared() == False`, because the storage was not allocated by torch's map allocator. So the 346.6 GB of resident weights, the single biggest beneficiary, take the staging path.

`immutable_host_tensors` therefore declares rather than guesses: the caller lists the ranges nothing writes after `prepare()`, and those are named even when `is_shared()` is `False`. Inference stays for everyone else, so no existing caller changes behaviour. The caller does know — `pypto-serving`'s own helper is called `_inherited_host_weights` and documents its return as *"immutable main and MTP weights that must be visible at worker fork"*.

## Measured

pypto main at this branch's parent, DeepSeek V4 Flash W8A8, 8 × 910B2, 346.6 GB resident, warm kernel cache, `pypto-serving` carrying its matching change (hw-native-sys/pypto-serving#184):

| | resident upload | `model loaded` |
|---|---:|---:|
| main as-is | 91.0s | — |
| with the declaration | **32.1s** | **39.5s** |

**2.8× on the upload.** Consistent with the 31.7s measured on #2422's first revision, which named these ranges for the wrong reason before review correctly stopped it — so the mechanism was never in doubt, only the way of asking for it.

As always with these numbers: the absolute seconds are node-dependent (`pypto-serving`#134 measured the same class of host-copy cost at ~492s on one machine and ~62s on another). The transferable claim is that one full copy of the payload is removed rather than parallelised.

## The alternative I rejected, and why

Rather than change pypto, the mapping could be made to satisfy the existing predicate: `torch.from_file(shared=True)` does report `is_shared() == True`, a slice/view of it keeps that, and it accepts `/proc/self/fd/N` so `pypto-serving`#134's single-descriptor flow survives.

Measured, it maps `rw-s` and **a write through the tensor reaches the file** — at mode 0444, opened `O_RDONLY`, because the process is root and permission checks do not apply. #134 maps the sidecar `PROT_READ` on purpose so a 346 GB artifact cannot be corrupted through the serving path. Trading that for startup time is the wrong direction, so the declaration lives here instead.

## Tests

Four cases in `TestNamedInheritedHostRanges`:

- a declared non-shared range is named, and no staging buffer is created;
- the declaration is per range — an undeclared private neighbour still stages;
- a declared range that was never inherited still stages, because immutability says nothing about whether the child can reach it;
- a non-contiguous declared tensor is rejected.

`pre-commit` clean including `pyright`; the file's 174 unit tests pass, three runs.

## Not addressed here

DeepSeek V4 decode still stalls after the first token on pypto HEAD — #2354, unrelated to this path and unchanged by it. Startup is fast; generation is a separate problem.
