### PR TITLE
refactor(ir): de-duplicate the pipeline loop-cloning helpers and the const-int readers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -236,6 +236,7 @@ set(PYPTO_SOURCES
     src/ir/transforms/utils/normalize_stmt_structure.cpp
     src/ir/transforms/utils/op_predicates.cpp
     src/ir/transforms/utils/parent_stmt_analysis.cpp
+    src/ir/transforms/utils/pipeline_loop_utils.cpp
     src/ir/transforms/utils/return_lineage_utils.cpp
     src/ir/transforms/utils/scope_outline_utils.cpp
     src/ir/transforms/utils/split_axis_utils.cpp

--- a/include/pypto/ir/transforms/utils/cross_core_pipe.h
+++ b/include/pypto/ir/transforms/utils/cross_core_pipe.h
@@ -65,7 +65,12 @@ constexpr int kAutoBufferBase = -1;
 /// deliberately independent of PTOAS's own fallback below.
 constexpr int kDefaultAutoPipeSlotNum = 2;
 
-std::optional<int64_t> TryGetConstIntValue(const ExprPtr& expr);
+/// Compile-time integer value of @p expr, or ``nullopt`` when it is not one
+/// **or is negative**. The non-negative half of the contract is what the name
+/// carries: callers here read tile shape dimensions and slot sizes, where a
+/// negative is nonsense rather than a value to propagate. For the plain
+/// signed reading, use ``transform_utils::EvalConstInt``, which this wraps.
+std::optional<int64_t> TryGetNonNegativeConstInt(const ExprPtr& expr);
 std::optional<int64_t> TryGetTileSlotSizeBytes(const TypePtr& type);
 void RecordObservedSlotSize(PipeDirectionMetadata& metadata, int64_t slot_size);
 void RecordTileSlotSize(PipeDirectionMetadata& metadata, const TypePtr& type);

--- a/include/pypto/ir/transforms/utils/pipeline_loop_utils.h
+++ b/include/pypto/ir/transforms/utils/pipeline_loop_utils.h
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#ifndef PYPTO_IR_TRANSFORMS_UTILS_PIPELINE_LOOP_UTILS_H_
+#define PYPTO_IR_TRANSFORMS_UTILS_PIPELINE_LOOP_UTILS_H_
+
+#include <cstdint>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "pypto/ir/expr.h"
+#include "pypto/ir/span.h"
+#include "pypto/ir/stmt.h"
+
+namespace pypto {
+namespace ir {
+namespace pipeline_loop {
+
+/// Body-cloning primitives shared by the loop passes that replicate a loop body
+/// into per-stage clones: ``LowerPipelineLoops`` (same-core `pl.pipeline`
+/// replication), ``SkewCrossCorePipeline`` (cross-core prologue/steady/epilogue
+/// skew), and ``UnrollLoops`` (the throwing const-int accessor only).
+///
+/// These are pure IR-construction helpers with no pass state. They were
+/// maintained as byte-identical private copies in each pass, which is how the
+/// #2002 cube-accumulator fix came to exist in one copy and not the other. The
+/// membership *taggers* are deliberately NOT here — see the note at the bottom
+/// of this header.
+///
+/// For constant evaluation, prefer ``transform_utils::EvalConstInt`` directly:
+/// it is the non-throwing form, and it guards the ``INT64_MIN`` negation that
+/// the former per-pass ``TryGetConstInt`` copies did not. ``GetConstIntValue``
+/// below is only the throwing wrapper over it.
+
+/// Extract a compile-time integer from a ``ConstInt`` or ``Neg(ConstInt)``
+/// expression, throwing a user-facing ``ValueError`` when @p expr is not one.
+///
+/// @param expr  The expression to evaluate.
+/// @param pass  Pass name used as the diagnostic prefix (e.g. "LowerPipelineLoops").
+/// @param what  What the value is, for the message (e.g. "step").
+/// @throws pypto::ValueError if @p expr is not a compile-time integer constant.
+int64_t GetConstIntValue(const ExprPtr& expr, const char* pass, const std::string& what);
+
+/// An ``INDEX``-typed ``ConstInt``.
+ExprPtr MakeConstIndex(int64_t value, const Span& span);
+
+/// `base + offset_val`, with constant-folding when `base` is a ConstInt.
+/// Emitting the unfolded form trips the round-trip verifier because the
+/// reparser folds `8 + 1` back to `9`.
+ExprPtr OffsetIndex(const ExprPtr& base, int64_t offset_val, const Span& span);
+
+/// Build a fresh outer loop variable mirroring `original` (same name, same type, same span).
+VarPtr CloneLoopVar(const VarPtr& original);
+
+/// Fresh IterArg mirroring `original`, with `init_value` as the initial value.
+IterArgPtr MakeFreshIterArg(const IterArgPtr& original, const ExprPtr& init_value);
+
+/// Fresh Var mirroring `original` with a suffixed name (for intermediate return_vars).
+VarPtr MakeFreshVar(const VarPtr& original, const std::string& suffix);
+
+/// Split a body into (stmts_before_yield, yield_values). If the body ends with a
+/// terminal `YieldStmt` (either standalone or as the final stmt of a top-level
+/// `SeqStmts`), strip it and return its values. Otherwise return the body unchanged
+/// and an empty value list. Always pass through — callers that have no iter_args
+/// simply see an empty yield vector and treat `stmts` as the whole body.
+std::pair<StmtPtr, std::vector<ExprPtr>> SplitBodyYield(const StmtPtr& body);
+
+/// Widen a vector of return_vars to expressions.
+std::vector<ExprPtr> ReturnVarsAsExprs(const std::vector<VarPtr>& vars);
+
+/// Collect `initValue_` expressions from a vector of IterArgs — used when the
+/// tail runs without a preceding main loop, so its iter_args seed directly
+/// from the source loop's init values rather than a main-loop return_var.
+std::vector<ExprPtr> InitValueExprs(const std::vector<IterArgPtr>& iter_args);
+
+/// Fresh return_vars matching the originals' types, with a suffix applied to names.
+std::vector<VarPtr> MakeFreshReturnVars(const std::vector<VarPtr>& originals, const std::string& suffix);
+
+// ---------------------------------------------------------------------------
+// Deliberately NOT shared: the pipeline-membership taggers.
+//
+// `LowerPipelineLoops::PipelineMembershipTagger` and
+// `SkewCrossCorePipeline::MembershipTagger` stamp the same
+// `kPipelineMembershipAttr`, but their skip sets are genuinely different and
+// each is load-bearing for its own pass. Unifying them would change buffer
+// allocation on one side or the other. See the class comment on each tagger for
+// the reasoning; the divergence is documented there, not resolved here.
+// ---------------------------------------------------------------------------
+
+}  // namespace pipeline_loop
+}  // namespace ir
+}  // namespace pypto
+
+#endif  // PYPTO_IR_TRANSFORMS_UTILS_PIPELINE_LOOP_UTILS_H_

--- a/src/ir/transforms/lower_pipeline_loops_pass.cpp
+++ b/src/ir/transforms/lower_pipeline_loops_pass.cpp
@@ -33,6 +33,7 @@
 #include "pypto/ir/transforms/utils/attrs.h"
 #include "pypto/ir/transforms/utils/deep_clone_utils.h"
 #include "pypto/ir/transforms/utils/mutable_copy.h"
+#include "pypto/ir/transforms/utils/pipeline_loop_utils.h"
 #include "pypto/ir/transforms/utils/transform_utils.h"
 #include "pypto/ir/type.h"
 
@@ -43,70 +44,26 @@ using Attrs = std::vector<std::pair<std::string, std::any>>;
 
 namespace {
 
-/// Extract a compile-time integer from a ConstInt or Neg(ConstInt) expression.
-int64_t GetConstIntValue(const ExprPtr& expr, const std::string& what) {
-  if (auto ci = std::dynamic_pointer_cast<const ConstInt>(expr)) {
-    return ci->value_;
-  }
-  if (auto neg = std::dynamic_pointer_cast<const Neg>(expr)) {
-    if (auto inner = std::dynamic_pointer_cast<const ConstInt>(neg->operand_)) {
-      return -inner->value_;
-    }
-  }
-  throw pypto::ValueError("LowerPipelineLoops: " + what + " must be a compile-time integer constant, got " +
-                          expr->TypeName());
-}
-
-/// Non-throwing variant — returns nullopt if `expr` is not a compile-time integer.
-std::optional<int64_t> TryGetConstInt(const ExprPtr& expr) {
-  if (auto ci = std::dynamic_pointer_cast<const ConstInt>(expr)) {
-    return ci->value_;
-  }
-  if (auto neg = std::dynamic_pointer_cast<const Neg>(expr)) {
-    if (auto inner = std::dynamic_pointer_cast<const ConstInt>(neg->operand_)) {
-      return -inner->value_;
-    }
-  }
-  return std::nullopt;
-}
-
 using transform_utils::ComputeStaticTripCount;
+using transform_utils::EvalConstInt;
 
-ExprPtr MakeConstIndex(int64_t value, const Span& span) {
-  return std::make_shared<ConstInt>(value, DataType::INDEX, span);
+// Body-cloning primitives shared with SkewCrossCorePipeline; see
+// `utils/pipeline_loop_utils.h` for why they are not per-pass copies.
+using pipeline_loop::CloneLoopVar;
+using pipeline_loop::InitValueExprs;
+using pipeline_loop::MakeConstIndex;
+using pipeline_loop::MakeFreshIterArg;
+using pipeline_loop::MakeFreshReturnVars;
+using pipeline_loop::MakeFreshVar;
+using pipeline_loop::OffsetIndex;
+using pipeline_loop::ReturnVarsAsExprs;
+using pipeline_loop::SplitBodyYield;
+
+/// Throwing const-int accessor, prefixed with this pass's name.
+int64_t GetConstIntValue(const ExprPtr& expr, const std::string& what) {
+  return pipeline_loop::GetConstIntValue(expr, "LowerPipelineLoops", what);
 }
 
-/// `base + offset_val`, with constant-folding when `base` is a ConstInt.
-/// Emitting the unfolded form trips the round-trip verifier because the
-/// reparser folds `8 + 1` back to `9`.
-ExprPtr OffsetIndex(const ExprPtr& base, int64_t offset_val, const Span& span) {
-  if (offset_val == 0) return base;
-  if (auto ci = std::dynamic_pointer_cast<const ConstInt>(base)) {
-    return MakeConstIndex(ci->value_ + offset_val, span);
-  }
-  return MakeAdd(base, MakeConstIndex(offset_val, span), span);
-}
-
-/// Build a fresh outer loop variable mirroring `original` (same name, same type, same span).
-VarPtr CloneLoopVar(const VarPtr& original) {
-  return std::make_shared<Var>(original->name_hint_, original->GetType(), original->span_);
-}
-
-/// Fresh IterArg mirroring `original`, with `init_value` as the initial value.
-IterArgPtr MakeFreshIterArg(const IterArgPtr& original, const ExprPtr& init_value) {
-  return std::make_shared<IterArg>(original->name_hint_, original->GetType(), init_value, original->span_);
-}
-
-/// Fresh Var mirroring `original` with a suffixed name (for intermediate return_vars).
-VarPtr MakeFreshVar(const VarPtr& original, const std::string& suffix) {
-  return std::make_shared<Var>(original->name_hint_ + suffix, original->GetType(), original->span_);
-}
-
-/// Split a body into (stmts_before_yield, yield_values). If the body ends with a
-/// terminal `YieldStmt` (either standalone or as the final stmt of a top-level
-/// `SeqStmts`), strip it and return its values. Otherwise return the body unchanged
-/// and an empty value list. Always pass through — callers that have no iter_args
-/// simply see an empty yield vector and treat `stmts` as the whole body.
 /// Tag every tile-producing ``Call`` in a cloned pipeline-stage body with one
 /// ``(group, stage)`` pipeline-membership pair. The pair is *appended* to any
 /// membership already present, so a tile inside an already-lowered inner
@@ -144,6 +101,11 @@ VarPtr MakeFreshVar(const VarPtr& original, const std::string& suffix) {
 /// compute/drain chunks; that pass then rotates each replicated group's Acc
 /// membership modulo two before MemoryReuse consumes it. See
 /// `loop_double_buffers_c_` in the tagger.
+///
+/// `SkewCrossCorePipeline::MembershipTagger` stamps the same attr but is NOT a
+/// copy of this one: it keeps cube accumulators tagged and skips the cross-core
+/// `tpop` instead. Both skip sets are load-bearing — see that tagger's comment
+/// before changing either.
 class PipelineMembershipTagger : public IRMutator {
  public:
   PipelineMembershipTagger(int32_t group, int32_t stage, bool loop_double_buffers_c)
@@ -198,22 +160,6 @@ class PipelineMembershipTagger : public IRMutator {
   int32_t stage_;
   bool loop_double_buffers_c_;
 };
-
-std::pair<StmtPtr, std::vector<ExprPtr>> SplitBodyYield(const StmtPtr& body) {
-  if (auto yield = std::dynamic_pointer_cast<const YieldStmt>(body)) {
-    return {std::make_shared<SeqStmts>(std::vector<StmtPtr>{}, body->span_), yield->value_};
-  }
-  auto seq = std::dynamic_pointer_cast<const SeqStmts>(body);
-  if (!seq || seq->stmts_.empty()) {
-    return {body, {}};
-  }
-  auto yield = std::dynamic_pointer_cast<const YieldStmt>(seq->stmts_.back());
-  if (!yield) {
-    return {body, {}};
-  }
-  std::vector<StmtPtr> without(seq->stmts_.begin(), seq->stmts_.end() - 1);
-  return {std::make_shared<SeqStmts>(std::move(without), seq->span_), yield->value_};
-}
 
 /**
  * @brief Mutator that lowers user-written `pl.pipeline(N, stage=F)` loops
@@ -275,8 +221,8 @@ class LowerPipelineMutator : public IRMutator {
     int64_t step = GetConstIntValue(op->step_, "step");
     INTERNAL_CHECK_SPAN(step != 0, op->span_) << "LowerPipelineLoops: step cannot be zero";
 
-    auto start_const = TryGetConstInt(op->start_);
-    auto stop_const = TryGetConstInt(op->stop_);
+    auto start_const = EvalConstInt(op->start_);
+    auto stop_const = EvalConstInt(op->stop_);
     // Cross-core loops are skewed/demoted to Sequential by the earlier
     // SkewCrossCorePipeline pass, so by here only same-core pipeline loops
     // (GM->L1, L1->L0, nested matmul stage loops) remain Pipeline-marked. They
@@ -364,31 +310,6 @@ class LowerPipelineMutator : public IRMutator {
       prev_yields = std::move(cloned_yields);
     }
     return {SeqStmts::Flatten(std::move(clones), sp), std::move(prev_yields)};
-  }
-
-  std::vector<ExprPtr> ReturnVarsAsExprs(const std::vector<VarPtr>& vars) {
-    std::vector<ExprPtr> result;
-    result.reserve(vars.size());
-    for (const auto& v : vars) result.push_back(v);
-    return result;
-  }
-
-  /// Collect `initValue_` expressions from a vector of IterArgs — used when the
-  /// tail runs without a preceding main loop, so its iter_args seed directly
-  /// from the source loop's init values rather than a main-loop return_var.
-  std::vector<ExprPtr> InitValueExprs(const std::vector<IterArgPtr>& iter_args) {
-    std::vector<ExprPtr> result;
-    result.reserve(iter_args.size());
-    for (const auto& ia : iter_args) result.push_back(ia->initValue_);
-    return result;
-  }
-
-  /// Fresh return_vars matching the originals' types, with a suffix applied to names.
-  std::vector<VarPtr> MakeFreshReturnVars(const std::vector<VarPtr>& originals, const std::string& suffix) {
-    std::vector<VarPtr> result;
-    result.reserve(originals.size());
-    for (const auto& v : originals) result.push_back(MakeFreshVar(v, suffix));
-    return result;
   }
 
   /**

--- a/src/ir/transforms/lower_pipeline_loops_pass.cpp
+++ b/src/ir/transforms/lower_pipeline_loops_pass.cpp
@@ -20,7 +20,6 @@
 #include <vector>
 
 #include "pypto/core/dtype.h"
-#include "pypto/core/error.h"
 #include "pypto/core/logging.h"
 #include "pypto/ir/expr.h"
 #include "pypto/ir/function.h"

--- a/src/ir/transforms/skew_cross_core_pipeline_pass.cpp
+++ b/src/ir/transforms/skew_cross_core_pipeline_pass.cpp
@@ -38,6 +38,7 @@
 #include "pypto/ir/transforms/utils/attrs.h"
 #include "pypto/ir/transforms/utils/deep_clone_utils.h"
 #include "pypto/ir/transforms/utils/mutable_copy.h"
+#include "pypto/ir/transforms/utils/pipeline_loop_utils.h"
 #include "pypto/ir/transforms/utils/transform_utils.h"
 #include "pypto/ir/type.h"
 
@@ -51,84 +52,24 @@ namespace {
 using transform_utils::FlattenToStmts;
 using transform_utils::GetCallFromStmt;
 
-/// Extract a compile-time integer from a ConstInt or Neg(ConstInt) expression.
-int64_t GetConstIntValue(const ExprPtr& expr, const std::string& what) {
-  if (auto ci = std::dynamic_pointer_cast<const ConstInt>(expr)) {
-    return ci->value_;
-  }
-  if (auto neg = std::dynamic_pointer_cast<const Neg>(expr)) {
-    if (auto inner = std::dynamic_pointer_cast<const ConstInt>(neg->operand_)) {
-      return -inner->value_;
-    }
-  }
-  throw pypto::ValueError("SkewCrossCorePipeline: " + what +
-                          " must be a compile-time integer constant, got " + expr->TypeName());
-}
-
-/// Non-throwing variant — returns nullopt if `expr` is not a compile-time integer.
-std::optional<int64_t> TryGetConstInt(const ExprPtr& expr) {
-  if (auto ci = std::dynamic_pointer_cast<const ConstInt>(expr)) {
-    return ci->value_;
-  }
-  if (auto neg = std::dynamic_pointer_cast<const Neg>(expr)) {
-    if (auto inner = std::dynamic_pointer_cast<const ConstInt>(neg->operand_)) {
-      return -inner->value_;
-    }
-  }
-  return std::nullopt;
-}
-
 using transform_utils::ComputeStaticTripCount;
+using transform_utils::EvalConstInt;
 
-ExprPtr MakeConstIndex(int64_t value, const Span& span) {
-  return std::make_shared<ConstInt>(value, DataType::INDEX, span);
-}
+// Body-cloning primitives shared with LowerPipelineLoops; see
+// `utils/pipeline_loop_utils.h` for why they are not per-pass copies.
+using pipeline_loop::CloneLoopVar;
+using pipeline_loop::InitValueExprs;
+using pipeline_loop::MakeConstIndex;
+using pipeline_loop::MakeFreshIterArg;
+using pipeline_loop::MakeFreshReturnVars;
+using pipeline_loop::MakeFreshVar;
+using pipeline_loop::OffsetIndex;
+using pipeline_loop::ReturnVarsAsExprs;
+using pipeline_loop::SplitBodyYield;
 
-/// `base + offset_val`, with constant-folding when `base` is a ConstInt.
-/// Emitting the unfolded form trips the round-trip verifier because the
-/// reparser folds `8 + 1` back to `9`.
-ExprPtr OffsetIndex(const ExprPtr& base, int64_t offset_val, const Span& span) {
-  if (offset_val == 0) return base;
-  if (auto ci = std::dynamic_pointer_cast<const ConstInt>(base)) {
-    return MakeConstIndex(ci->value_ + offset_val, span);
-  }
-  return MakeAdd(base, MakeConstIndex(offset_val, span), span);
-}
-
-/// Build a fresh outer loop variable mirroring `original` (same name, same type, same span).
-VarPtr CloneLoopVar(const VarPtr& original) {
-  return std::make_shared<Var>(original->name_hint_, original->GetType(), original->span_);
-}
-
-/// Fresh IterArg mirroring `original`, with `init_value` as the initial value.
-IterArgPtr MakeFreshIterArg(const IterArgPtr& original, const ExprPtr& init_value) {
-  return std::make_shared<IterArg>(original->name_hint_, original->GetType(), init_value, original->span_);
-}
-
-/// Fresh Var mirroring `original` with a suffixed name (for intermediate return_vars).
-VarPtr MakeFreshVar(const VarPtr& original, const std::string& suffix) {
-  return std::make_shared<Var>(original->name_hint_ + suffix, original->GetType(), original->span_);
-}
-
-/// Split a body into (stmts_before_yield, yield_values). If the body ends with a
-/// terminal `YieldStmt` (either standalone or as the final stmt of a top-level
-/// `SeqStmts`), strip it and return its values. Otherwise return the body unchanged
-/// and an empty value list. Always pass through — callers that have no iter_args
-/// simply see an empty yield vector and treat `stmts` as the whole body.
-std::pair<StmtPtr, std::vector<ExprPtr>> SplitBodyYield(const StmtPtr& body) {
-  if (auto yield = std::dynamic_pointer_cast<const YieldStmt>(body)) {
-    return {std::make_shared<SeqStmts>(std::vector<StmtPtr>{}, body->span_), yield->value_};
-  }
-  auto seq = std::dynamic_pointer_cast<const SeqStmts>(body);
-  if (!seq || seq->stmts_.empty()) {
-    return {body, {}};
-  }
-  auto yield = std::dynamic_pointer_cast<const YieldStmt>(seq->stmts_.back());
-  if (!yield) {
-    return {body, {}};
-  }
-  std::vector<StmtPtr> without(seq->stmts_.begin(), seq->stmts_.end() - 1);
-  return {std::make_shared<SeqStmts>(std::move(without), seq->span_), yield->value_};
+/// Throwing const-int accessor, prefixed with this pass's name.
+int64_t GetConstIntValue(const ExprPtr& expr, const std::string& what) {
+  return pipeline_loop::GetConstIntValue(expr, "SkewCrossCorePipeline", what);
 }
 
 // ---------------------------------------------------------------------------
@@ -198,7 +139,27 @@ bool BodyHasCrossCorePair(const StmtPtr& body) {
 }
 
 /// Tag every tile-producing `Call` in @p body with one `(group, stage)`
-/// pipeline-membership pair (mirrors LowerPipelineLoops' PipelineMembershipTagger).
+/// pipeline-membership pair.
+///
+/// **Not a mirror of LowerPipelineLoops' `PipelineMembershipTagger`.** The two
+/// stamp the same `kPipelineMembershipAttr`, but their skip sets differ, and each
+/// difference is load-bearing for its own pass — do not unify them:
+///
+///  - This tagger skips the cross-core receive (`IsTpopStmt`, below); LPL has no
+///    tpop to skip.
+///  - LPL skips cube accumulators (a `tile.matmul*` producing a `Mem.Acc` tile)
+///    unless the loop carries `kPipelineDoubleBufferCAttr`, added by #2002. This
+///    tagger does not, deliberately. LPL's argument for skipping is that the
+///    serialized cube retires one tile's MAD before starting the next, so two
+///    stages' accumulators are never co-live; under a cross-core skew that does
+///    not hold the same way, since a produce clone's accumulator is drained to
+///    the peer core while the next clone's MAD runs — the same overlap LPL
+///    carves out for dbC=2. Separating the stages' buffers is this pass's whole
+///    purpose (see `docs/en/dev/passes/26-skew_cross_core_pipeline.md`), and
+///    since #1949 `MemoryReuse`'s capacity-gated path honours membership in
+///    every space including `Acc`, so adopting LPL's skip here would drop these
+///    accumulators out of the gate entirely. No skew test covers a matmul body
+///    today, so that change would also be unverified.
 ///
 /// Why the skew pass must do this itself: MemoryReuse keeps the per-stage *load*
 /// buffers of a software pipeline private (its ping-pong guard, keyed on
@@ -311,8 +272,8 @@ class SkewCrossCoreMutator : public IRMutator {
     // pass and CanonicalizeIOOrder no longer handle cross-core ops.
     int64_t step = GetConstIntValue(inner_step, "step");
     INTERNAL_CHECK_SPAN(step != 0, op->span_) << "SkewCrossCorePipeline: step cannot be zero";
-    auto start_const = TryGetConstInt(inner_start);
-    auto stop_const = TryGetConstInt(inner_stop);
+    auto start_const = EvalConstInt(inner_start);
+    auto stop_const = EvalConstInt(inner_stop);
     if (start_const.has_value() && stop_const.has_value()) {
       // Skew depth = the producer's lead in iterations (= produces/consumes per steady
       // iteration). Cross-core producer skew defaults to DEPTH-2 so the two pipeline
@@ -746,31 +707,6 @@ class SkewCrossCoreMutator : public IRMutator {
     cleaned->kind_ = ForKind::Sequential;
     cleaned->attrs_ = StripAttr(op->attrs_, kPipelineStagesAttr);
     return cleaned;
-  }
-
-  std::vector<ExprPtr> ReturnVarsAsExprs(const std::vector<VarPtr>& vars) {
-    std::vector<ExprPtr> result;
-    result.reserve(vars.size());
-    for (const auto& v : vars) result.push_back(v);
-    return result;
-  }
-
-  /// Collect `initValue_` expressions from a vector of IterArgs — used when the
-  /// tail runs without a preceding main loop, so its iter_args seed directly
-  /// from the source loop's init values rather than a main-loop return_var.
-  std::vector<ExprPtr> InitValueExprs(const std::vector<IterArgPtr>& iter_args) {
-    std::vector<ExprPtr> result;
-    result.reserve(iter_args.size());
-    for (const auto& ia : iter_args) result.push_back(ia->initValue_);
-    return result;
-  }
-
-  /// Fresh return_vars matching the originals' types, with a suffix applied to names.
-  std::vector<VarPtr> MakeFreshReturnVars(const std::vector<VarPtr>& originals, const std::string& suffix) {
-    std::vector<VarPtr> result;
-    result.reserve(originals.size());
-    for (const auto& v : originals) result.push_back(MakeFreshVar(v, suffix));
-    return result;
   }
 
   /// If `v` is a SCALAR recomputable purely from the loop var + loop-invariant

--- a/src/ir/transforms/skew_cross_core_pipeline_pass.cpp
+++ b/src/ir/transforms/skew_cross_core_pipeline_pass.cpp
@@ -21,8 +21,6 @@
 #include <utility>
 #include <vector>
 
-#include "pypto/core/dtype.h"
-#include "pypto/core/error.h"
 #include "pypto/core/logging.h"
 #include "pypto/ir/expr.h"
 #include "pypto/ir/function.h"

--- a/src/ir/transforms/unroll_loops_pass.cpp
+++ b/src/ir/transforms/unroll_loops_pass.cpp
@@ -28,6 +28,7 @@
 #include "pypto/ir/transforms/passes.h"
 #include "pypto/ir/transforms/utils/deep_clone_utils.h"
 #include "pypto/ir/transforms/utils/mutable_copy.h"
+#include "pypto/ir/transforms/utils/pipeline_loop_utils.h"
 
 namespace pypto {
 namespace ir {
@@ -38,32 +39,10 @@ namespace {
 /// Prevents excessive memory/CPU usage from large trip counts.
 constexpr int64_t kMaxUnrollIterations = 1024;
 
-/**
- * @brief Extract a compile-time integer value from a ConstInt or Neg(ConstInt) expression.
- *
- * Handles both positive constants (ConstInt) and negative literals (Neg wrapping ConstInt),
- * since the Python parser represents `-1` as `ir.neg(ir.ConstInt(1))`.
- *
- * @param expr Expression to extract from
- * @param what Description for error messages (e.g., "start", "stop", "step")
- * @return int64_t The constant value
- * @throws pypto::ValueError if expression is not a compile-time constant integer
- */
-static int64_t GetConstIntValue(const ExprPtr& expr, const std::string& what) {
-  auto ci = std::dynamic_pointer_cast<const ConstInt>(expr);
-  if (ci) {
-    return ci->value_;
-  }
-  // Handle Neg(ConstInt) for negative literals
-  auto neg = std::dynamic_pointer_cast<const Neg>(expr);
-  if (neg) {
-    auto inner = std::dynamic_pointer_cast<const ConstInt>(neg->operand_);
-    if (inner) {
-      return -inner->value_;
-    }
-  }
-  throw pypto::ValueError("Unroll loop " + what + " must be a compile-time integer constant, got " +
-                          expr->TypeName());
+/// Throwing const-int accessor, prefixed with this pass's name. Shared with the
+/// pipeline loop passes: see `utils/pipeline_loop_utils.h`.
+int64_t GetConstIntValue(const ExprPtr& expr, const std::string& what) {
+  return pipeline_loop::GetConstIntValue(expr, "UnrollLoops", what);
 }
 
 /**

--- a/src/ir/transforms/utils/cross_core_pipe.cpp
+++ b/src/ir/transforms/utils/cross_core_pipe.cpp
@@ -43,10 +43,10 @@ const auto& FlattenBody = transform_utils::FlattenToStmts;
 
 }  // namespace
 
-std::optional<int64_t> TryGetConstIntValue(const ExprPtr& expr) {
-  auto const_int = std::dynamic_pointer_cast<const ConstInt>(expr);
-  if (!const_int || const_int->value_ < 0) return std::nullopt;
-  return const_int->value_;
+std::optional<int64_t> TryGetNonNegativeConstInt(const ExprPtr& expr) {
+  auto value = transform_utils::EvalConstInt(expr);
+  if (!value.has_value() || *value < 0) return std::nullopt;
+  return value;
 }
 
 std::optional<int64_t> TryGetTileSlotSizeBytes(const TypePtr& type) {
@@ -55,7 +55,7 @@ std::optional<int64_t> TryGetTileSlotSizeBytes(const TypePtr& type) {
 
   int64_t element_count = 1;
   for (const auto& dim : tile_type->shape_) {
-    auto dim_value = TryGetConstIntValue(dim);
+    auto dim_value = TryGetNonNegativeConstInt(dim);
     if (!dim_value.has_value()) return std::nullopt;
     INTERNAL_CHECK(*dim_value == 0 || element_count <= std::numeric_limits<int64_t>::max() / *dim_value)
         << "Tile element count overflow while inferring cross-core slot size";

--- a/src/ir/transforms/utils/pipeline_loop_utils.cpp
+++ b/src/ir/transforms/utils/pipeline_loop_utils.cpp
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include "pypto/ir/transforms/utils/pipeline_loop_utils.h"
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "pypto/core/dtype.h"
+#include "pypto/core/error.h"
+#include "pypto/ir/expr.h"
+#include "pypto/ir/kind_traits.h"
+#include "pypto/ir/scalar_expr.h"
+#include "pypto/ir/span.h"
+#include "pypto/ir/stmt.h"
+#include "pypto/ir/transforms/utils/transform_utils.h"
+
+namespace pypto {
+namespace ir {
+namespace pipeline_loop {
+
+int64_t GetConstIntValue(const ExprPtr& expr, const char* pass, const std::string& what) {
+  if (auto value = transform_utils::EvalConstInt(expr)) {
+    return *value;
+  }
+  throw pypto::ValueError(std::string(pass) + ": " + what + " must be a compile-time integer constant, got " +
+                          expr->TypeName());
+}
+
+ExprPtr MakeConstIndex(int64_t value, const Span& span) {
+  return std::make_shared<ConstInt>(value, DataType::INDEX, span);
+}
+
+ExprPtr OffsetIndex(const ExprPtr& base, int64_t offset_val, const Span& span) {
+  if (offset_val == 0) return base;
+  if (auto ci = As<ConstInt>(base)) {
+    return MakeConstIndex(ci->value_ + offset_val, span);
+  }
+  return MakeAdd(base, MakeConstIndex(offset_val, span), span);
+}
+
+VarPtr CloneLoopVar(const VarPtr& original) {
+  return std::make_shared<Var>(original->name_hint_, original->GetType(), original->span_);
+}
+
+IterArgPtr MakeFreshIterArg(const IterArgPtr& original, const ExprPtr& init_value) {
+  return std::make_shared<IterArg>(original->name_hint_, original->GetType(), init_value, original->span_);
+}
+
+VarPtr MakeFreshVar(const VarPtr& original, const std::string& suffix) {
+  return std::make_shared<Var>(original->name_hint_ + suffix, original->GetType(), original->span_);
+}
+
+std::pair<StmtPtr, std::vector<ExprPtr>> SplitBodyYield(const StmtPtr& body) {
+  if (auto yield = As<YieldStmt>(body)) {
+    return {std::make_shared<SeqStmts>(std::vector<StmtPtr>{}, body->span_), yield->value_};
+  }
+  auto seq = As<SeqStmts>(body);
+  if (!seq || seq->stmts_.empty()) {
+    return {body, {}};
+  }
+  auto yield = As<YieldStmt>(seq->stmts_.back());
+  if (!yield) {
+    return {body, {}};
+  }
+  std::vector<StmtPtr> without(seq->stmts_.begin(), seq->stmts_.end() - 1);
+  return {std::make_shared<SeqStmts>(std::move(without), seq->span_), yield->value_};
+}
+
+std::vector<ExprPtr> ReturnVarsAsExprs(const std::vector<VarPtr>& vars) {
+  std::vector<ExprPtr> result;
+  result.reserve(vars.size());
+  for (const auto& v : vars) result.push_back(v);
+  return result;
+}
+
+std::vector<ExprPtr> InitValueExprs(const std::vector<IterArgPtr>& iter_args) {
+  std::vector<ExprPtr> result;
+  result.reserve(iter_args.size());
+  for (const auto& ia : iter_args) result.push_back(ia->initValue_);
+  return result;
+}
+
+std::vector<VarPtr> MakeFreshReturnVars(const std::vector<VarPtr>& originals, const std::string& suffix) {
+  std::vector<VarPtr> result;
+  result.reserve(originals.size());
+  for (const auto& v : originals) result.push_back(MakeFreshVar(v, suffix));
+  return result;
+}
+
+}  // namespace pipeline_loop
+}  // namespace ir
+}  // namespace pypto

--- a/src/ir/transforms/window_externalization/analysis.cpp
+++ b/src/ir/transforms/window_externalization/analysis.cpp
@@ -438,7 +438,7 @@ std::optional<OrderedLoopOffsets> GetOrderedLoopOffsets(const ExprPtr& expr, con
   if (!first_offset.has_value() || !last_offset.has_value()) return std::nullopt;
 
   auto affine = ParseAffineInLoop(expr, loop->loop_var_.get());
-  auto loop_step = GetConstIntValue(loop->step_);
+  auto loop_step = transform_utils::EvalConstInt(loop->step_);
   if (!affine.has_value() || !loop_step.has_value()) return std::nullopt;
   // Only the *sign* of `coeff * step` decides the order, and the operand signs
   // decide the sign on their own -- so read it off them instead of evaluating a
@@ -1260,8 +1260,8 @@ std::optional<CalleeRewriteAnalysis> AnalyzeAggregateWindowLoop(
   }
   if (!loop) return std::nullopt;
 
-  auto stop = GetConstIntValue(loop->stop_);
-  auto step = GetConstIntValue(loop->step_);
+  auto stop = transform_utils::EvalConstInt(loop->stop_);
+  auto step = transform_utils::EvalConstInt(loop->step_);
   if (!stop.has_value() || !step.has_value()) {
     auto known_trip_count = GetKnownPositiveTripCount(loop);
     if (!known_trip_count.has_value() || *known_trip_count <= 0) return std::nullopt;

--- a/src/ir/transforms/window_externalization/common.cpp
+++ b/src/ir/transforms/window_externalization/common.cpp
@@ -527,17 +527,11 @@ std::optional<AffineForm> ParseAffineInLoop(const ExprPtr& expr, const Var* loop
   return std::nullopt;
 }
 
-std::optional<int64_t> GetConstIntValue(const ExprPtr& expr) {
-  auto ci = As<ConstInt>(expr);
-  if (!ci) return std::nullopt;
-  return ci->value_;
-}
-
 std::optional<int64_t> GetStaticTripCount(const ForStmtPtr& loop) {
   if (!loop) return std::nullopt;
-  auto start = GetConstIntValue(loop->start_);
-  auto stop = GetConstIntValue(loop->stop_);
-  auto step = GetConstIntValue(loop->step_);
+  auto start = transform_utils::EvalConstInt(loop->start_);
+  auto stop = transform_utils::EvalConstInt(loop->stop_);
+  auto step = transform_utils::EvalConstInt(loop->step_);
   if (!start.has_value() || !stop.has_value() || !step.has_value() || *step == 0) return std::nullopt;
   if ((*step > 0 && *stop <= *start) || (*step < 0 && *stop >= *start)) return int64_t{0};
   auto distance = CheckedSub(*stop, *start);
@@ -552,7 +546,7 @@ std::optional<int64_t> GetKnownPositiveTripCount(const ForStmtPtr& loop) {
   auto static_trip_count = GetStaticTripCount(loop);
   if (static_trip_count.has_value()) return static_trip_count;
   if (!loop) return std::nullopt;
-  auto step = GetConstIntValue(loop->step_);
+  auto step = transform_utils::EvalConstInt(loop->step_);
   if (!step.has_value() || *step == 0) return std::nullopt;
 
   auto distance_expr = *step > 0 ? MakeSub(loop->stop_, loop->start_, loop->span_)
@@ -591,7 +585,7 @@ std::optional<ExprPtr> SimplifyWithLoopValue(const ExprPtr& expr, const VarPtr& 
 
 std::optional<ExprPtr> GetLoopValueAtTrip(const ForStmtPtr& loop, int64_t trip_index) {
   if (!loop || trip_index < 0) return std::nullopt;
-  auto step = GetConstIntValue(loop->step_);
+  auto step = transform_utils::EvalConstInt(loop->step_);
   if (!step.has_value()) return std::nullopt;
   auto delta = CheckedMul(trip_index, *step);
   if (!delta.has_value()) return std::nullopt;

--- a/src/ir/transforms/window_externalization/internal.h
+++ b/src/ir/transforms/window_externalization/internal.h
@@ -154,7 +154,21 @@ std::optional<LinearIndexExpr> ParseLinearIndexExpr(const ExprPtr& expr);
 std::optional<int64_t> ConstantDiffIfSameLinearBase(const ExprPtr& lhs, const ExprPtr& rhs);
 std::optional<AffineForm> ParseAffineInLoop(const ExprPtr& expr, const Var* loop_var);
 
-std::optional<int64_t> GetConstIntValue(const ExprPtr& expr);
+/// Trip count of @p loop when all three bounds are compile-time integers.
+///
+/// Deliberately NOT ``transform_utils::EvalConstTripCount``: this pass needs a
+/// stricter contract than that helper offers. Here ``nullopt`` means "cannot
+/// prove anything about this loop, do not window it", so the two cases where
+/// the shared helper answers with a *value* must answer ``nullopt`` instead:
+///
+///  - A zero step. ``ComputeStaticTripCount`` reports 0 trips; that is a claim
+///    the loop is provably empty, and callers here would rewrite on it.
+///  - Bounds whose span or step magnitude overflows ``int64_t``.
+///    ``ComputeStaticTripCount`` saturates to ``INT64_MAX`` — safe for the
+///    size/threshold callers it was written for, but this pass feeds trip counts
+///    into buffer sizing (see #2477).
+///
+/// The const-int reading itself is shared: both use ``EvalConstInt``.
 std::optional<int64_t> GetStaticTripCount(const ForStmtPtr& loop);
 std::optional<int64_t> GetKnownPositiveTripCount(const ForStmtPtr& loop);
 std::optional<ExprPtr> SimplifyWithLoopBound(const ExprPtr& expr, const VarPtr& loop_var, int64_t value);

--- a/src/ir/transforms/window_externalization/orch_rewriter.cpp
+++ b/src/ir/transforms/window_externalization/orch_rewriter.cpp
@@ -1234,7 +1234,7 @@ class OrchRewriter : public IRMutator {
       }
 
       auto extent_ci = As<ConstInt>(output.window_shape[i]);
-      auto loop_step = GetConstIntValue(loop->step_);
+      auto loop_step = transform_utils::EvalConstInt(loop->step_);
       if (!extent_ci || !loop_step.has_value()) return LoopRegionRole::Unknown;
       if (varying_dim.has_value()) return LoopRegionRole::Unknown;
       if (varying_dims_used && varying_dims_used->count(i)) return LoopRegionRole::Unknown;

--- a/tests/lint/clang_tidy.py
+++ b/tests/lint/clang_tidy.py
@@ -387,6 +387,51 @@ def _detect_nanobind_cmake_dir() -> str | None:
         return None
 
 
+def _would_clobber_cache(build_dir: Path) -> bool:
+    """True when configuring into *build_dir* would destroy an existing CMake cache.
+
+    ``ensure_compile_commands`` configures with its own settings — notably an
+    explicit ``CMAKE_CXX_COMPILER`` — which CMake treats as a cache-invalidating
+    change. Running that against a developer's working tree deletes its cache and,
+    if this configure then fails, leaves the tree unbuildable. A tree that already
+    exports a compile database needs no configure, and an unconfigured directory
+    has no cache to lose; only the in-between case is destructive.
+    """
+    if (build_dir / "compile_commands.json").exists():
+        return False  # ensure_compile_commands returns early — nothing is run
+    return (build_dir / "CMakeCache.txt").exists()
+
+
+def _resolve_build_dir(requested: str | None) -> tuple[Path, str | None]:
+    """Pick the build directory to read compile commands from.
+
+    Returns ``(build_dir, tmp_dir)``, where *tmp_dir* is non-``None`` only when a
+    scratch directory was created and the caller must remove it. A requested
+    directory is honoured unless configuring into it would clobber its cache, in
+    which case a scratch directory is used and the reason is reported.
+    """
+    if not requested:
+        tmp_dir = tempfile.mkdtemp(prefix="pypto-clang-tidy-")
+        _vprint(f"[clang-tidy] Using temp build dir: {tmp_dir}")
+        return Path(tmp_dir), tmp_dir
+
+    build_dir = Path(requested).resolve()
+    if not _would_clobber_cache(build_dir):
+        _vprint(f"[clang-tidy] Using explicit build dir: {build_dir}")
+        return build_dir, None
+
+    print(
+        f"[clang-tidy] {build_dir} is a configured build tree with no "
+        "compile_commands.json. Configuring into it would overwrite its CMake cache "
+        "with this lint's own settings, so a scratch directory is used instead. To "
+        "lint against that tree directly, re-configure it with "
+        "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON.",
+        file=sys.stderr,
+    )
+    tmp_dir = tempfile.mkdtemp(prefix="pypto-clang-tidy-")
+    return Path(tmp_dir), tmp_dir
+
+
 def ensure_compile_commands(build_dir: Path) -> Path:
     """Generate ``compile_commands.json`` via CMake if it doesn't already exist.
 
@@ -756,15 +801,8 @@ def main(argv: list[str] | None = None) -> int:
         print("[clang-tidy] No files to lint.")
         return 0
 
-    # 4. Resolve build directory (temp dir if not provided)
-    tmp_dir = None
-    if args.build_dir:
-        build_dir = Path(args.build_dir).resolve()
-        _vprint(f"[clang-tidy] Using explicit build dir: {build_dir}")
-    else:
-        tmp_dir = tempfile.mkdtemp(prefix="pypto-clang-tidy-")
-        build_dir = Path(tmp_dir)
-        _vprint(f"[clang-tidy] Using temp build dir: {build_dir}")
+    # 4. Resolve build directory
+    build_dir, tmp_dir = _resolve_build_dir(args.build_dir)
 
     have_errors = 0
     try:

--- a/tests/lint/clang_tidy.py
+++ b/tests/lint/clang_tidy.py
@@ -743,7 +743,8 @@ def main(argv: list[str] | None = None) -> int:
     Steps:
         1. Verify clang-tidy is installed and check its version.
         2. Collect C/C++ source and header files.
-        3. Resolve build directory (explicit ``-B`` > existing ``./build`` > temp dir).
+        3. Resolve build directory: the explicit ``-B``, or a temp dir when it is
+           omitted -- or when configuring into it would clobber its CMake cache.
         4. Lint header files first (fixes may affect source files).
         5. Lint source files (all enabled checks via compile database).
         6. Re-print version warning at the end (if any).


### PR DESCRIPTION
## What

Three related cleanups in the loop-transform passes, plus one lint-infrastructure fix. Each is a separate commit.

**1. Extract the duplicated pipeline loop-cloning helpers** (`541481a`)

`LowerPipelineLoops` and `SkewCrossCorePipeline` each carried a private, byte-identical copy of eleven body-cloning helpers — 76 lines of code differing only in one error-string literal. The nine pure ones move to a new `utils/pipeline_loop_utils.{h,cpp}`; the three that were private members are pure and lift unchanged.

Both `TryGetConstInt` copies are **deleted** rather than moved: `transform_utils::EvalConstInt` (added by #2427) already does the job and additionally guards the `INT64_MIN` negation the local copies reached as UB. `GetConstIntValue` becomes a throwing wrapper over it taking a pass-name prefix, which folds in the third copy in `UnrollLoops`.

**2. Route the last two const-int readers through `EvalConstInt`** (`7059af1`)

Three functions named `GetConstIntValue` / `TryGetConstIntValue` survived with three different contracts, so picking the wrong one was a silent behaviour change rather than a compile error. `window_externalization`'s copy matched `ConstInt` only, missing `Neg(ConstInt)`; `cross_core_pipe`'s additionally rejected negatives without saying so in its name.

**3. Stop `clang_tidy.py` clobbering a supplied build dir** (`6f1e4ae`)

When given a `-B` tree that is configured but exports no compile database, the lint configured into it with its own `CMAKE_CXX_COMPILER`, which CMake treats as cache-invalidating — deleting the cache and, when the re-run failed, leaving the tree unbuildable.

## Why

Two copies kept in sync by hand is what let #2002's cube-accumulator fix land in `LowerPipelineLoops` alone; the comment in `SkewCrossCorePipeline` claiming its tagger "mirrors" that one has been false since 13 July.

## What a reviewer should know

**The two pipeline-membership taggers are deliberately NOT merged.** Their skip sets differ and each is load-bearing: the skew pass skips the cross-core `tpop`, `LowerPipelineLoops` skips cube accumulators outside a dbC=2 loop. Adopting the latter in the skew pass would drop those accumulators out of `MemoryReuse`'s capacity gate, which since #1949 honours membership in *every* space including `Acc` — and per-stage buffer separation is that pass's whole purpose (`26-skew_cross_core_pipeline.md`). No skew test covers a matmul body, so the change would also be unverified. Both taggers now document the divergence and point at each other.

**`GetStaticTripCount` stays local by design**, and now says why. It needs a stricter contract than `ComputeStaticTripCount` offers: here `nullopt` means "cannot prove anything, do not window", so a zero step must not report 0 trips (a claim the loop is provably empty, which callers would rewrite on) and an overflowing span must not saturate to `INT64_MAX`, since this pass feeds trip counts into buffer sizing — the overflow handling #2477 added deliberately. Only the const-int reading is shared.

**Two intentional behaviour changes, both latent:**

- `UnrollLoops`' diagnostic prefix changes from `"Unroll loop step must be…"` to `"UnrollLoops: step must be…"`, matching its two siblings. Nothing asserts on that text.
- The `Neg` peek makes previously-invisible negative-step orchestration loops visible to window externalization, reaching negative-step branches that already existed there but could not trigger. Inert in the default pipeline — `simplify` runs before `optimize_orch_tensors` — but reachable from the builder API or a `.pto` file.

## Testing

- `tests/ut/` — **10229 passed, 3 skipped**, unchanged from `main`. `ctest` passes.
- All pre-commit hooks pass on every commit: `clang-format`, `cpplint`, `ruff`, `pyright`, and the ten repo lint scripts.
- The build-dir fix was verified against a real tree configured the documented way — before, its `CMakeCache.txt` hash changed and `cmake --build` failed afterwards; after, the hash is byte-identical and the tree still builds.

No new tests. The `INT64_MIN` hardening arrives via `EvalConstInt` rather than being written here, and nothing in the suite exercises it — happy to add a regression test if wanted.
