### PR TITLE
fix(bindings): accept a default TileView offset

### DIFF
--- a/python/bindings/modules/ir.cpp
+++ b/python/bindings/modules/ir.cpp
@@ -681,14 +681,25 @@ void BindIR(nb::module_& m) {
       "Tile view representation with valid shape, stride, start offset, layouts, fractal, pad, and "
       "compact mode. "
       "Immutable from Python — set all fields at construction time.")
-      .def(nb::init<const std::vector<ExprPtr>&, const std::vector<ExprPtr>&, ExprPtr, TileLayout, TileLayout,
-                    uint64_t, PadValue, CompactMode>(),
-           nb::arg("valid_shape") = std::vector<ExprPtr>{}, nb::arg("stride") = std::vector<ExprPtr>{},
-           nb::arg("start_offset") = ExprPtr{}, nb::arg("blayout") = TileLayout::row_major,
-           nb::arg("slayout") = TileLayout::none_box, nb::arg("fractal") = static_cast<uint64_t>(512),
-           nb::arg("pad") = PadValue::null, nb::arg("compact") = CompactMode::null,
-           "Create a tile view; fields default to empty/null/row_major/none_box/512/null/null. "
-           "fractal is a size in bytes, not elements.")
+      .def(nb::init<>(), "Create a tile view with the C++ default field values.")
+      .def(
+          "__init__",
+          [](nb::pointer_and_handle<TileView> instance, const std::vector<ExprPtr>& valid_shape,
+             const std::vector<ExprPtr>& stride, const nb::object& start_offset, TileLayout blayout,
+             TileLayout slayout, uint64_t fractal, PadValue pad, CompactMode compact) {
+            ExprPtr offset;
+            if (!start_offset.is_none()) {
+              offset = nb::cast<ExprPtr>(start_offset);
+            }
+            new (instance.p)
+                TileView(valid_shape, stride, std::move(offset), blayout, slayout, fractal, pad, compact);
+          },
+          nb::arg("valid_shape") = std::vector<ExprPtr>{}, nb::arg("stride") = std::vector<ExprPtr>{},
+          nb::arg("start_offset") = nb::none(), nb::arg("blayout") = TileLayout::row_major,
+          nb::arg("slayout") = TileLayout::none_box, nb::arg("fractal") = static_cast<uint64_t>(512),
+          nb::arg("pad") = PadValue::null, nb::arg("compact") = CompactMode::null,
+          "Create a tile view; fields default to empty/null/row_major/none_box/512/null/null. "
+          "fractal is a size in bytes, not elements.")
       .def(nb::init<const std::vector<int64_t>&, const std::vector<int64_t>&, ExprPtr, TileLayout, TileLayout,
                     uint64_t, PadValue, CompactMode>(),
            nb::arg("valid_shape"), nb::arg("stride"), nb::arg("start_offset"),


### PR DESCRIPTION
## Summary

Make the nanobind `TileView` constructor handle its default/optional start offset without an ambiguous conversion.

Current PyPTO `main` exposes an `ExprPtr` constructor with `None` as the default argument. With the wheel build used by pypto-serving NPU CI, evaluating `ir.TileView()` fails in `_implicit_tile_view_defaults` with an incompatible-constructor `TypeError`. Model compilation then aborts and the Serving worker reports zero KV cache blocks.

- Bind the true C++ default constructor explicitly.
- Accept a Python object for `start_offset`, map `None` to a null `ExprPtr`, and otherwise cast it to `ExprPtr` before placement construction.
- Preserve the existing integer-shape constructor and all public defaults.

Observed downstream failure: hw-native-sys/pypto-serving#180 unit-tests. This PR is independent of the full-rank dispatch work in #2490.

## Verification

- Rebuilt the PyPTO extension with this patch.
- `tests/ut/language/parser/test_type_resolver.py`
- `tests/ut/ir/core/test_tile_view_equality.py`
- `tests/ut/ir/test_tensor_view_semantics.py`

Result: `243 passed`.
