### PR TITLE
build: cap nanobind below 3.0

### DIFF
--- a/.github/actions/setup-ci-job/action.yml
+++ b/.github/actions/setup-ci-job/action.yml
@@ -652,7 +652,11 @@ runs:
         if [ "${PYPTO_USE_UV:-false}" != "true" ]; then
           python -m pip install --upgrade pip
         fi
-        py_install scikit-build-core nanobind cmake ninja
+        # nanobind capped with pyproject.toml's build requirement. This matters
+        # more here than anywhere else: the pypto install below passes
+        # --no-build-isolation, so the extension is compiled against *this*
+        # nanobind and [build-system] requires is never consulted.
+        py_install scikit-build-core "nanobind<3" cmake ninja
         # torch first, and explicitly the CPU build. These are Ascend hosts, and
         # left to resolve `torch>=2.0.0` on its own pip now selects a version
         # whose aarch64 wheel drags in the entire CUDA stack — torch 427 MB,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -352,7 +352,9 @@ jobs:
         python -m pip install --upgrade pip
         # cmake / ninja / nanobind: clang_tidy.py configures CMake with
         # -DCMAKE_EXPORT_COMPILE_COMMANDS=ON and reads nanobind's cmake dir.
-        pip install cmake ninja nanobind
+        # Same cap as pyproject.toml's build requirement: lint must read the
+        # headers the wheel is built against.
+        pip install cmake ninja "nanobind<3"
         VERSION=$(python -c "import sys; sys.path.insert(0, 'tests/lint'); from clang_tidy import REQUIRED_VERSION; print(REQUIRED_VERSION)")
         pip install --retries 5 --timeout 60 "clang-tidy==${VERSION}"
         clang-tidy --version

--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -199,7 +199,7 @@ jobs:
           # on the next bump — or, bare as it was, let a future divergence
           # resolve `torch` from PyPI, whose aarch64 wheel drags in the entire
           # CUDA stack on an Ascend host. One owner for that decision.
-          uv pip install nanobind
+          uv pip install "nanobind<3"
 
       - name: Run Qwen3-14B decode perf samples (L2 swimlane, 5x)
         id: qwen3_perf_run

--- a/docs/en/user/01-installation.md
+++ b/docs/en/user/01-installation.md
@@ -107,7 +107,7 @@ ran. A traceback here is the real signal — the exact wording of the line is no
 | C++ compiler | C++17 | GCC or Clang. `CMAKE_CXX_STANDARD 17` is required, not merely preferred |
 | numpy | ≥ 2.0 | Installed automatically |
 | torch | ≥ 2.0 | Installed automatically, but install the CPU wheel first (see below) |
-| nanobind | ≥ 2.0 | Build-time only; fetched automatically |
+| nanobind | ≥ 2.0, < 3 | Build-time only; fetched automatically |
 | scikit-build-core | ≥ 0.10 | Build backend; fetched automatically |
 
 **Install the CPU torch wheel before PyPTO.** `pip install -e .` resolves `torch>=2.0.0`

--- a/docs/zh/user/01-installation.md
+++ b/docs/zh/user/01-installation.md
@@ -102,7 +102,7 @@ OK
 | C++ 编译器 | C++17 | GCC 或 Clang。`CMAKE_CXX_STANDARD 17` 是强制要求而非建议 |
 | numpy | ≥ 2.0 | 自动安装 |
 | torch | ≥ 2.0 | 自动安装，但请先装 CPU 版（见下） |
-| nanobind | ≥ 2.0 | 仅构建期需要，自动获取 |
+| nanobind | ≥ 2.0, < 3 | 仅构建期需要，自动获取 |
 | scikit-build-core | ≥ 0.10 | 构建后端，自动获取 |
 
 **先装 CPU 版 torch，再装 PyPTO。** `pip install -e .` 会把 `torch>=2.0.0` 解析到默认

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,12 @@
 # -----------------------------------------------------------------------------------------------------------
 
 [build-system]
-requires = ["scikit-build-core>=0.10.0", "nanobind>=2.0.0", "ninja>=1.11.0", "cmake>=3.15"]
+# nanobind is capped below 3.0: nanobind 3.0.0 stopped accepting the null
+# holder this project uses as an argument default (e.g. TileView's
+# `start_offset`, an unset ExprPtr), so `ir.TileView()` no longer matches its
+# own all-defaulted overload. Lift the cap together with the binding changes
+# 3.x needs; this pin is not a verdict on 3.x, only on migrating under a red CI.
+requires = ["scikit-build-core>=0.10.0", "nanobind>=2.0.0,<3", "ninja>=1.11.0", "cmake>=3.15"]
 build-backend = "scikit_build_core.build"
 
 [project]

--- a/tests/ut/ir/transforms/test_memory_reuse.py
+++ b/tests/ut/ir/transforms/test_memory_reuse.py
@@ -2050,8 +2050,16 @@ class TestYieldFixup:
                 idx_tensor: pl.Tensor[[1, 2048], pl.UINT32],
                 val_output: pl.Out[pl.Tensor[[1, 2048], pl.FP32]],
             ) -> pl.Tensor[[1, 2048], pl.FP32]:
-                src_tile: pl.Tile[[1, 2048], pl.FP32] = pl.load(src_tensor, [0, 0], [1, 2048])
-                idx_tile: pl.Tile[[1, 2048], pl.UINT32] = pl.load(idx_tensor, [0, 0], [1, 2048])
+                # This pipeline stops before InferTileMemorySpace, so an unset space --
+                # which since #2475 means "the compiler places it" -- is never resolved,
+                # and an Opaque function has no on-chip memory to place it in. Name it on
+                # the loads; the tiles derived from them take their space from their inputs.
+                src_tile: pl.Tile[[1, 2048], pl.FP32] = pl.load(
+                    src_tensor, [0, 0], [1, 2048], target_memory=pl.Mem.Vec
+                )
+                idx_tile: pl.Tile[[1, 2048], pl.UINT32] = pl.load(
+                    idx_tensor, [0, 0], [1, 2048], target_memory=pl.Mem.Vec
+                )
                 sorted_tile: pl.Tile[[1, 4096], pl.FP32] = pl.tile.sort32(src_tile, idx_tile)
                 for i, (tile_iter,) in pl.range(3, init_values=(sorted_tile,)):
                     if i >= 1:
@@ -2145,8 +2153,16 @@ class TestYieldFixup:
                 idx_tensor: pl.Tensor[[1, 2048], pl.UINT32],
                 val_output: pl.Out[pl.Tensor[[1, 2048], pl.FP32]],
             ) -> pl.Tensor[[1, 2048], pl.FP32]:
-                src_tile: pl.Tile[[1, 2048], pl.FP32] = pl.load(src_tensor, [0, 0], [1, 2048])
-                idx_tile: pl.Tile[[1, 2048], pl.UINT32] = pl.load(idx_tensor, [0, 0], [1, 2048])
+                # This pipeline stops before InferTileMemorySpace, so an unset space --
+                # which since #2475 means "the compiler places it" -- is never resolved,
+                # and an Opaque function has no on-chip memory to place it in. Name it on
+                # the loads; the tiles derived from them take their space from their inputs.
+                src_tile: pl.Tile[[1, 2048], pl.FP32] = pl.load(
+                    src_tensor, [0, 0], [1, 2048], target_memory=pl.Mem.Vec
+                )
+                idx_tile: pl.Tile[[1, 2048], pl.UINT32] = pl.load(
+                    idx_tensor, [0, 0], [1, 2048], target_memory=pl.Mem.Vec
+                )
                 sorted_tile: pl.Tile[[1, 4096], pl.FP32] = pl.tile.sort32(src_tile, idx_tile)
                 for i, (tile_iter,) in pl.range(3, init_values=(sorted_tile,)):
                     if i < 1:


### PR DESCRIPTION
## Summary

CI has been red on **every branch** since 2026-08-24 00:52 UTC — `main`, three unrelated feature branches and a refactor series all went red inside the same four minutes. `unit-tests` reports 478 failures and 28 collection errors, and every one of them reduces to a single rejection:

```text
ir.TileView()
TypeError: __init__(): incompatible function arguments. The following argument types are supported:
  1. __init__(self, valid_shape=[], stride=[], start_offset: Expr = None,
              blayout=..., slayout=..., fractal=512, pad=..., compact=...)
```

An overload whose arguments all have defaults no longer accepts zero arguments: `start_offset`'s default is a null `ExprPtr`, which nanobind 3.0 will not bind to a parameter typed `Expr`. `type_resolver._implicit_tile_view_defaults` reads `ir.TileView().fractal` for every `pl.Tile` annotation, so the failure lands at import time across the whole parser surface.

**No commit caused this.** Over the entire window from the last green run to now:

```console
$ git diff --stat e2d0f78a origin/main -- python/bindings include/pypto/ir/type.h \
      include/pypto/ir/expr.h python/pypto/pypto_core
$        # empty
```

The four commits that landed in that window touch passes and one CMake source list. What changed is upstream: `pyproject.toml` requires `nanobind>=2.0.0` with no upper bound, the last green build resolved that to **2.15.0**, and every build since resolves it to **3.0.0**, released in between. That also explains why branches sharing no work broke simultaneously.

This caps the build requirement at `<3` and restores a green baseline.

## Changes

- `pyproject.toml`: `nanobind>=2.0.0` → `nanobind>=2.0.0,<3`, with a comment naming the incompatibility so the next reader does not have to re-derive it.
- `.github/workflows/ci.yml`, `.github/workflows/daily_ci.yml`: the two ad-hoc `pip install nanobind` calls follow the same cap. They exist only to satisfy the same `find_package(nanobind)` — lint must read the headers the wheel is built against, and the daily perf job builds the same extension.
- `docs/{en,zh}/user/01-installation.md`: the dependency table states the cap.

## Verification

- Evidence for the diagnosis, from the CI logs themselves:
  - last green `unit-tests` (`e2d0f78a`, 08-21 10:43): `Downloading nanobind-2.15.0-py3-none-any.whl`
  - current red `unit-tests` (`97e4ef8e`, 08-24 01:42): `Downloading nanobind-3.0.0-py3-none-any.whl`
  - both runs' failure signatures, and the empty binding diff above.
- The error classification across the red run: 28 `TypeError: __init__(): incompatible function arguments` plus 16 `ParserSyntaxError` wrapping the same message — one mechanism, no second failure mode hiding behind it.
- This PR's own CI is the real check: it either comes back green, which confirms the diagnosis end to end, or it does not, which falsifies it. I could not build against nanobind 3.0 locally to reproduce in isolation — PyPI is unreachable from this environment, so 3.0.0 cannot be installed here.

## Follow-up

This is not a verdict on nanobind 3.x. Migrating the affected argument defaults — `nb::arg(...).none()`, or `std::optional` holders where a null really is a value — is worth doing, but against a green baseline rather than under a red one. Worth filing as its own issue; the cap comment points at what has to change.

Separately: all four commits in the window were merged within 45 minutes against bases that did not contain each other, and each merge cancelled main's previous run, so no completed main CI stood between them. That did not cause this failure, but it is why it took a while to rule out a cross-merge as the cause.