### PR TITLE
build: pin the build inputs instead of resolving them per build

### DIFF
--- a/.github/actions/setup-ci-job/action.yml
+++ b/.github/actions/setup-ci-job/action.yml
@@ -664,9 +664,13 @@ runs:
           echo "build-constraints.txt missing at $BUILD_CONSTRAINTS" >&2
           exit 1
         }
-        echo "PIP_CONSTRAINT=$BUILD_CONSTRAINTS" >> "$GITHUB_ENV"
-        echo "UV_CONSTRAINT=$BUILD_CONSTRAINTS" >> "$GITHUB_ENV"
-        export PIP_CONSTRAINT="$BUILD_CONSTRAINTS" UV_CONSTRAINT="$BUILD_CONSTRAINTS"
+        # PIP_BUILD_CONSTRAINT is the variable pip applies to build
+        # dependencies; PIP_CONSTRAINT is what older pip honours for them. Both,
+        # because the runners do not all carry the same pip.
+        for v in PIP_CONSTRAINT PIP_BUILD_CONSTRAINT UV_CONSTRAINT UV_BUILD_CONSTRAINT; do
+          echo "$v=$BUILD_CONSTRAINTS" >> "$GITHUB_ENV"
+          export "$v=$BUILD_CONSTRAINTS"
+        done
         py_install scikit-build-core nanobind cmake ninja
         # torch first, and explicitly the CPU build. These are Ascend hosts, and
         # left to resolve `torch>=2.0.0` on its own pip now selects a version
@@ -698,8 +702,19 @@ runs:
         # One line naming the build inputs this artifact was produced from. The
         # 2026-08-24 outage was hard to place precisely because nothing reported
         # them: an upstream release and a code change looked identical.
-        echo "[build inputs] $(python -m pip list --format=freeze 2>/dev/null |
-          grep -iE '^(cmake|nanobind|ninja|scikit[-_]build[-_]core)==' | tr '\n' ' ')"
+        # importlib.metadata rather than `pip list`: the bundle toolchain's venv
+        # is built by `uv venv` and has no pip in it at all, which is exactly the
+        # set of jobs that outage hit.
+        python - <<'PY'
+        from importlib.metadata import PackageNotFoundError, version
+        names = ("cmake", "nanobind", "ninja", "scikit-build-core")
+        def resolve(n):
+            try:
+                return f"{n}=={version(n)}"
+            except PackageNotFoundError:
+                return f"{n}=<absent>"
+        print("[build inputs]", " ".join(resolve(n) for n in names))
+        PY
         # simpler (./runtime) is only needed on the codegen -> device path; the
         # --codegen-only job skips it (install-toolchain=false).
         if [ "$INSTALL_TOOLCHAIN" = "true" ]; then

--- a/.github/actions/setup-ci-job/action.yml
+++ b/.github/actions/setup-ci-job/action.yml
@@ -652,11 +652,22 @@ runs:
         if [ "${PYPTO_USE_UV:-false}" != "true" ]; then
           python -m pip install --upgrade pip
         fi
-        # nanobind capped with pyproject.toml's build requirement. This matters
-        # more here than anywhere else: the pypto install below passes
+        # Build inputs come from this checkout's build-constraints.txt. The
+        # workflow-level default assumes a checkout at $GITHUB_WORKSPACE; jobs
+        # using this action may check out into a subdirectory, so resolve the
+        # real path here and publish it for every later step in the job.
+        # It matters more here than anywhere else: the pypto install below passes
         # --no-build-isolation, so the extension is compiled against *this*
-        # nanobind and [build-system] requires is never consulted.
-        py_install scikit-build-core "nanobind<3" cmake ninja
+        # install and [build-system] requires is never consulted.
+        BUILD_CONSTRAINTS="$(pwd)/build-constraints.txt"
+        test -f "$BUILD_CONSTRAINTS" || {
+          echo "build-constraints.txt missing at $BUILD_CONSTRAINTS" >&2
+          exit 1
+        }
+        echo "PIP_CONSTRAINT=$BUILD_CONSTRAINTS" >> "$GITHUB_ENV"
+        echo "UV_CONSTRAINT=$BUILD_CONSTRAINTS" >> "$GITHUB_ENV"
+        export PIP_CONSTRAINT="$BUILD_CONSTRAINTS" UV_CONSTRAINT="$BUILD_CONSTRAINTS"
+        py_install scikit-build-core nanobind cmake ninja
         # torch first, and explicitly the CPU build. These are Ascend hosts, and
         # left to resolve `torch>=2.0.0` on its own pip now selects a version
         # whose aarch64 wheel drags in the entire CUDA stack — torch 427 MB,
@@ -684,6 +695,11 @@ runs:
           py_install "$TORCH_PIN"
         fi
         py_install --no-build-isolation '.[dev]'
+        # One line naming the build inputs this artifact was produced from. The
+        # 2026-08-24 outage was hard to place precisely because nothing reported
+        # them: an upstream release and a code change looked identical.
+        echo "[build inputs] $(python -m pip list --format=freeze 2>/dev/null |
+          grep -iE '^(cmake|nanobind|ninja|scikit[-_]build[-_]core)==' | tr '\n' ' ')"
         # simpler (./runtime) is only needed on the codegen -> device path; the
         # --codegen-only job skips it (install-toolchain=false).
         if [ "$INSTALL_TOOLCHAIN" = "true" ]; then

--- a/.github/docker/github_ci.Dockerfile
+++ b/.github/docker/github_ci.Dockerfile
@@ -24,10 +24,15 @@ RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.10 1 &
     update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.10 1 && \
     curl -sS https://bootstrap.pypa.io/get-pip.py | python
 
-# Build tools (needed by pip install -e .)
-RUN pip install --no-cache-dir \
+# Build tools (needed by pip install -e .). Versions come from the same
+# build-constraints.txt the workflows use: without it, rebuilding this image
+# would change what every containerised job builds against, with no workflow
+# change to point at.
+COPY build-constraints.txt /tmp/build-constraints.txt
+RUN pip install --no-cache-dir -c /tmp/build-constraints.txt \
       "scikit-build-core>=0.10.0" "nanobind>=2.0.0" \
-      "ninja>=1.11.0" "cmake>=3.15"
+      "ninja>=1.11.0" "cmake>=3.15" && \
+    rm /tmp/build-constraints.txt
 
 # Project runtime + dev dependencies
 RUN pip install --no-cache-dir \

--- a/.github/workflows/build_github_image.yml
+++ b/.github/workflows/build_github_image.yml
@@ -3,7 +3,7 @@ name: Build CI Image
 on:
   push:
     branches: [main]
-    paths: [".github/docker/github_ci.Dockerfile"]
+    paths: [".github/docker/github_ci.Dockerfile", "build-constraints.txt"]
   workflow_dispatch:
 
 env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -275,6 +275,14 @@ jobs:
         extra_args: --all-files
 
   clang-tidy:
+    # Build inputs come from build-constraints.txt rather than from whatever
+    # PyPI offers today; pip applies a constraints file to build-dependency
+    # installs too, so this reaches the CMake configure below. The path carries
+    # this job's checkout directory: unlike unit-tests it checks out into
+    # clang-tidy-checkout, and pip fails hard on a constraints file that is not
+    # there.
+    env:
+      PIP_CONSTRAINT: ${{ github.workspace }}/clang-tidy-checkout/build-constraints.txt
     # De-containered: runs host-native on the in-house arm64 CPU runner (same
     # infra as before, minus the localhost:5000/ci-py310 image). clang_tidy.py
     # generates compile_commands.json via a CMake configure (needs cmake / ninja /
@@ -352,9 +360,9 @@ jobs:
         python -m pip install --upgrade pip
         # cmake / ninja / nanobind: clang_tidy.py configures CMake with
         # -DCMAKE_EXPORT_COMPILE_COMMANDS=ON and reads nanobind's cmake dir.
-        # Same cap as pyproject.toml's build requirement: lint must read the
-        # headers the wheel is built against.
-        pip install cmake ninja "nanobind<3"
+        # Versions come from build-constraints.txt via PIP_CONSTRAINT, so lint
+        # reads the same headers the wheel is built against.
+        pip install cmake ninja nanobind
         VERSION=$(python -c "import sys; sys.path.insert(0, 'tests/lint'); from clang_tidy import REQUIRED_VERSION; print(REQUIRED_VERSION)")
         pip install --retries 5 --timeout 60 "clang-tidy==${VERSION}"
         clang-tidy --version
@@ -372,6 +380,13 @@ jobs:
         fi
 
   unit-tests:
+    # Build inputs come from build-constraints.txt rather than from whatever
+    # PyPI offers today; pip applies a constraints file to build-dependency
+    # installs too, so this reaches the isolated wheel build below. Declared
+    # per job because this one checks out at the workspace root -- the jobs that
+    # check out into a subdirectory get the path from setup-ci-job instead.
+    env:
+      PIP_CONSTRAINT: ${{ github.workspace }}/build-constraints.txt
     # Lint gate (see the pre-commit job) — don't spend a runner on a tree that
     # doesn't lint.
     #
@@ -1337,6 +1352,8 @@ jobs:
       PTOAS_ROOT: ${{ github.workspace }}/ptoas-bin
       PTOAS_VERSION: ${{ needs.toolchain.outputs.ptoas_version }}
       PTOAS_SHA256: ${{ needs.toolchain.outputs.ptoas_sha256_x86_64 }}
+      # Build inputs from build-constraints.txt; see the clang-tidy job.
+      PIP_CONSTRAINT: ${{ github.workspace }}/build-constraints.txt
     container:
       image: ghcr.io/hw-native-sys/pypto/github-ci:latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -283,6 +283,7 @@ jobs:
     # there.
     env:
       PIP_CONSTRAINT: ${{ github.workspace }}/clang-tidy-checkout/build-constraints.txt
+      PIP_BUILD_CONSTRAINT: ${{ github.workspace }}/clang-tidy-checkout/build-constraints.txt
     # De-containered: runs host-native on the in-house arm64 CPU runner (same
     # infra as before, minus the localhost:5000/ci-py310 image). clang_tidy.py
     # generates compile_commands.json via a CMake configure (needs cmake / ninja /
@@ -381,12 +382,15 @@ jobs:
 
   unit-tests:
     # Build inputs come from build-constraints.txt rather than from whatever
-    # PyPI offers today; pip applies a constraints file to build-dependency
-    # installs too, so this reaches the isolated wheel build below. Declared
-    # per job because this one checks out at the workspace root -- the jobs that
-    # check out into a subdirectory get the path from setup-ci-job instead.
+    # PyPI offers today. Both variables on purpose: PIP_BUILD_CONSTRAINT is the
+    # one pip applies to build dependencies, and PIP_CONSTRAINT is what older
+    # pip honours for them -- this job upgrades pip to the latest release, so it
+    # has to satisfy whichever is in force. Declared per job because this one
+    # checks out at the workspace root; the jobs that check out into a
+    # subdirectory get the path from setup-ci-job instead.
     env:
       PIP_CONSTRAINT: ${{ github.workspace }}/build-constraints.txt
+      PIP_BUILD_CONSTRAINT: ${{ github.workspace }}/build-constraints.txt
     # Lint gate (see the pre-commit job) — don't spend a runner on a tree that
     # doesn't lint.
     #
@@ -1352,8 +1356,9 @@ jobs:
       PTOAS_ROOT: ${{ github.workspace }}/ptoas-bin
       PTOAS_VERSION: ${{ needs.toolchain.outputs.ptoas_version }}
       PTOAS_SHA256: ${{ needs.toolchain.outputs.ptoas_sha256_x86_64 }}
-      # Build inputs from build-constraints.txt; see the clang-tidy job.
+      # Build inputs from build-constraints.txt; see the unit-tests job.
       PIP_CONSTRAINT: ${{ github.workspace }}/build-constraints.txt
+      PIP_BUILD_CONSTRAINT: ${{ github.workspace }}/build-constraints.txt
     container:
       image: ghcr.io/hw-native-sys/pypto/github-ci:latest
     steps:

--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -199,7 +199,7 @@ jobs:
           # on the next bump — or, bare as it was, let a future divergence
           # resolve `torch` from PyPI, whose aarch64 wheel drags in the entire
           # CUDA stack on an Ascend host. One owner for that decision.
-          uv pip install "nanobind<3"
+          uv pip install nanobind  # version from build-constraints.txt (UV_CONSTRAINT)
 
       - name: Run Qwen3-14B decode perf samples (L2 swimlane, 5x)
         id: qwen3_perf_run

--- a/build-constraints.txt
+++ b/build-constraints.txt
@@ -1,0 +1,24 @@
+# Build inputs, pinned.
+#
+# `[build-system] requires` in pyproject.toml states what pypto is *compatible*
+# with. This file states what it is actually *built* against, so the same commit
+# builds the same way tomorrow as it did today.
+#
+# Why both: on 2026-08-24 nanobind 3.0.0 was published, the unbounded
+# `nanobind>=2.0.0` resolved to it, and CI went red on every branch at once with
+# no commit to bisect (#2492, #2493). A compatibility range cannot prevent that
+# -- only a pinned input can.
+#
+# CI reads this through PIP_CONSTRAINT / UV_CONSTRAINT, which pip and uv apply to
+# build-dependency installs too, so it reaches both the isolated wheel builds and
+# the `--no-build-isolation` ones in .github/actions/setup-ci-job.
+#
+# To bump one: change the version here, in its own commit, and let CI say whether
+# it holds. A green run is then a statement about a known set of inputs.
+#
+# Versions below are what CI validated on main at a5113628.
+
+cmake==4.4.2
+nanobind==2.15.0
+ninja==1.13.0
+scikit-build-core==1.0.3

--- a/docs/en/user/01-installation.md
+++ b/docs/en/user/01-installation.md
@@ -110,6 +110,11 @@ ran. A traceback here is the real signal — the exact wording of the line is no
 | nanobind | ≥ 2.0, < 3 | Build-time only; fetched automatically |
 | scikit-build-core | ≥ 0.10 | Build backend; fetched automatically |
 
+The ranges above are what pypto is compatible with. The exact versions CI
+builds against are pinned in `build-constraints.txt` at the repository root;
+pass it as `PIP_CONSTRAINT=$PWD/build-constraints.txt` to reproduce a CI
+build locally.
+
 **Install the CPU torch wheel before PyPTO.** `pip install -e .` resolves `torch>=2.0.0`
 to the default wheel, which carries the full CUDA stack — around 2 GB that a PyPTO
 workflow never uses. Installing `torch` from the CPU index first makes the later resolve

--- a/docs/en/user/01-installation.md
+++ b/docs/en/user/01-installation.md
@@ -111,9 +111,20 @@ ran. A traceback here is the real signal — the exact wording of the line is no
 | scikit-build-core | ≥ 0.10 | Build backend; fetched automatically |
 
 The ranges above are what pypto is compatible with. The exact versions CI
-builds against are pinned in `build-constraints.txt` at the repository root;
-pass it as `PIP_CONSTRAINT=$PWD/build-constraints.txt` to reproduce a CI
-build locally.
+builds against are pinned in `build-constraints.txt` at the repository root. To
+reproduce a CI build locally, point pip at it:
+
+```bash
+PIP_BUILD_CONSTRAINT=$PWD/build-constraints.txt \
+PIP_CONSTRAINT=$PWD/build-constraints.txt \
+    pip install -e .
+```
+
+Both variables, because they cover different pip versions:
+`PIP_BUILD_CONSTRAINT` is the one pip applies to build dependencies from 26.2
+on, and `PIP_CONSTRAINT` is what earlier pip honours there. With only the
+latter, a recent pip resolves `[build-system] requires` freely again and the
+build is no longer the one CI validated.
 
 **Install the CPU torch wheel before PyPTO.** `pip install -e .` resolves `torch>=2.0.0`
 to the default wheel, which carries the full CUDA stack — around 2 GB that a PyPTO

--- a/docs/zh/user/01-installation.md
+++ b/docs/zh/user/01-installation.md
@@ -105,6 +105,10 @@ OK
 | nanobind | ≥ 2.0, < 3 | 仅构建期需要，自动获取 |
 | scikit-build-core | ≥ 0.10 | 构建后端，自动获取 |
 
+上表给出的是 pypto 兼容的版本范围。CI 实际构建所用的确切版本固定在仓库根目录的
+`build-constraints.txt` 中；本地复现 CI 构建时传入
+`PIP_CONSTRAINT=$PWD/build-constraints.txt` 即可。
+
 **先装 CPU 版 torch，再装 PyPTO。** `pip install -e .` 会把 `torch>=2.0.0` 解析到默认
 wheel，它携带完整 CUDA 栈 —— 约 2GB，而 PyPTO 的工作流一点也用不到。先从 CPU 索引安装
 `torch`，后续解析就变成空操作。

--- a/docs/zh/user/01-installation.md
+++ b/docs/zh/user/01-installation.md
@@ -106,8 +106,18 @@ OK
 | scikit-build-core | ≥ 0.10 | 构建后端，自动获取 |
 
 上表给出的是 pypto 兼容的版本范围。CI 实际构建所用的确切版本固定在仓库根目录的
-`build-constraints.txt` 中；本地复现 CI 构建时传入
-`PIP_CONSTRAINT=$PWD/build-constraints.txt` 即可。
+`build-constraints.txt` 中。本地复现 CI 构建时，把它指给 pip：
+
+```bash
+PIP_BUILD_CONSTRAINT=$PWD/build-constraints.txt \
+PIP_CONSTRAINT=$PWD/build-constraints.txt \
+    pip install -e .
+```
+
+两个变量都要传，因为它们覆盖不同的 pip 版本：`PIP_BUILD_CONSTRAINT` 是 pip 26.2
+起用于约束构建依赖的变量，`PIP_CONSTRAINT` 则是更早版本在该场景下认的那个。只传后者
+的话，较新的 pip 会重新自由解析 `[build-system] requires`，构建出来的就不是 CI 验证
+过的那一份了。
 
 **先装 CPU 版 torch，再装 PyPTO。** `pip install -e .` 会把 `torch>=2.0.0` 解析到默认
 wheel，它携带完整 CUDA 栈 —— 约 2GB，而 PyPTO 的工作流一点也用不到。先从 CPU 索引安装

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,11 +8,14 @@
 # -----------------------------------------------------------------------------------------------------------
 
 [build-system]
-# nanobind is capped below 3.0: nanobind 3.0.0 stopped accepting the null
-# holder this project uses as an argument default (e.g. TileView's
+# These are compatibility ranges, not the versions anything is built against:
+# build-constraints.txt pins those, and CI applies it through PIP_CONSTRAINT.
+#
+# nanobind is additionally capped below 3.0 because 3.0.0 stopped accepting the
+# null holder this project uses as an argument default (e.g. TileView's
 # `start_offset`, an unset ExprPtr), so `ir.TileView()` no longer matches its
 # own all-defaulted overload. Lift the cap together with the binding changes
-# 3.x needs; this pin is not a verdict on 3.x, only on migrating under a red CI.
+# 3.x needs; that cap is not a verdict on 3.x, only on migrating under a red CI.
 requires = ["scikit-build-core>=0.10.0", "nanobind>=2.0.0,<3", "ninja>=1.11.0", "cmake>=3.15"]
 build-backend = "scikit_build_core.build"
 


### PR DESCRIPTION
## Summary

Closes #2493.

`[build-system] requires` is a compatibility range, and pip re-resolves it from PyPI on every build — there is no lock file, so the same commit does not build the same way twice. On 2026-08-24 nanobind 3.0.0 was published, the unbounded `nanobind>=2.0.0` resolved to it, and CI went red on **every branch at once** with no commit to bisect. #2492 stopped the bleeding by capping nanobind; `scikit-build-core`, `ninja` and `cmake` still carry exactly the same open bound.

This pins the build inputs and gives them one home. `build-constraints.txt` holds the four exact versions CI validated on main at `a5113628`; CI applies it through `PIP_CONSTRAINT` / `UV_CONSTRAINT`, which pip and uv also apply to *build-dependency* installs — so one file reaches both the isolated wheel builds and the `--no-build-isolation` ones. `pyproject.toml` keeps stating the compatibility range; the constraints file decides what is actually used, so a bump becomes one reviewed line plus a CI run.

## Changes

- `build-constraints.txt` (new): `cmake==4.4.2`, `nanobind==2.15.0`, `ninja==1.13.0`, `scikit-build-core==1.0.3`, with a header saying what the file is for and how to bump one.
- `.github/actions/setup-ci-job/action.yml`: resolves this checkout's copy of the file, fails loudly if it is missing, exports both variables and publishes them through `$GITHUB_ENV` for every later step in the job. Then installs the build tools without a hand-copied cap, and logs what was resolved.
- `.github/workflows/ci.yml`: `clang-tidy`, `unit-tests` and `system-tests-a5sim` declare `PIP_CONSTRAINT` themselves; the clang-tidy install drops its `nanobind<3`.
- `.github/workflows/daily_ci.yml`: same, its `uv pip install` drops the cap.
- `pyproject.toml`: says that the versions live in the constraints file; the nanobind `<3` bound stays, since that one is a real incompatibility rather than a pin.
- `docs/{en,zh}/user/01-installation.md`: the dependency table gains a note that the exact versions are pinned, and how to reproduce a CI build locally.

### Why the variable is per job, not workflow-wide

One workflow-level `env:` would be the obvious spelling, and it is wrong here. It would name `$GITHUB_WORKSPACE/build-constraints.txt` for every job, but eight jobs check out into a subdirectory (`a5-checkout`, `st-direct-checkout`, `lib-checkout`, `dist-checkout`, …) and do not have the file at that path. pip and uv **fail hard** on a missing constraints file, and both run before `setup-ci-job` could correct the path — the ptoas wheel install and `pip install --upgrade pip` are earlier than any place a fix could sit. So the three jobs that check out at the workspace root declare it, and `setup-ci-job` resolves the real path for the other eight.

I checked all fourteen jobs rather than guessing: `unit-tests` and `system-tests-a5sim` build pypto directly, `clang-tidy` installs the tools for a CMake configure, eight go through `setup-ci-job`, and `changes` / `toolchain` / `pre-commit` build nothing. `pre-commit`'s hook environments already pin their dependencies exactly (`pytest==7.0.0`, `torch==2.8.0`, `numpy==2.0.0`), so they need nothing here.

## Verification

- All three workflow/action files parse (`yaml.safe_load`), and the parsed structure carries the new `env` entries on exactly those three jobs and nowhere else.
- No `nanobind<3` string remains anywhere under `.github/`; the cap is expressed once, in the constraints file.
- The constrained versions are not invented: they are what the last green `unit-tests` build on main resolved (`cmake-4.4.2`, `nanobind-2.15.0`, `ninja-1.13.0`, `scikit-build-core-1.0.3`), read out of that job's install log.
- Not verifiable locally: GitHub Actions env resolution and `PIP_CONSTRAINT` behaviour in the runners cannot be exercised from a workstation, and PyPI is unreachable from where this was prepared, so no local install could be constrained as a rehearsal. This PR's own CI is the check — and it exercises every path the change touches, since the three job-level declarations and the composite action cover all fourteen jobs.

## Follow-up

- pypto-lib installs the same four tools for its own from-source pypto build (`.github/actions/setup-ci-job/action.yml`) and needs the same constraints file, or at least the same source of truth. Worth a companion PR there once this shape is agreed.
- Migrating to nanobind 3.x stays a separate code change (`nb::arg(...).none()`, or `std::optional` holders); the `<3` bound in `pyproject.toml` names what has to move.