### PR TITLE
fix(ir): stop the inliner fusing a trailing '_' into the reserved '__'

### DIFF
--- a/docs/en/dev/passes/01-inline_functions.md
+++ b/docs/en/dev/passes/01-inline_functions.md
@@ -36,12 +36,14 @@ program_inlined = inline_pass(program)
 3. **Iterate to fixpoint** — each iteration walks every function (including the Inline ones, so that nested Inline-calls-Inline expands transitively):
    - For every top-level `LHS = inline_call(args)` or `EvalStmt(inline_call(args))` in a function body:
      - Build the param-substitution map (formal `Var` → actual `Expr`).
-     - Alpha-rename every locally-bound `Var` in the inlined body to a fresh name (`<orig>_inline<counter>`) to avoid collisions across multiple call sites.
+     - Alpha-rename every locally-bound `Var` in the inlined body to a fresh name (`<orig>_inline<counter>`, with any trailing `_` trimmed off `<orig>`) to avoid collisions across multiple call sites.
      - Splice the renamed-and-substituted body's statements before the call site.
      - Replace the call with: `LHS = renamed_return` (single-return) or `LHS = MakeTuple([renamed_returns...])` (multi-return). When `LHS` resolves to the same `Var` as the substituted return value, the assignment is omitted to avoid a redundant SSA copy.
 4. **Drop** all Inline functions from the program.
 
 The pass uses a single underscore (`_inline`) in the rename suffix because `__` is reserved by the IR's auto-naming convention (see `auto_name_utils.h`).
+
+A single-underscore suffix is not sufficient on its own: `<orig>` may itself end in `_` — `_` is Python's throwaway name and the documented loop variable of `for _ in pl.split_aiv(...)` — and plain concatenation would then fuse two individually-legal underscores into the reserved delimiter. `FreshName` therefore joins through `auto_name::JoinNameSuffix`, which trims that tail: `_` renames to `_inline7`, not `__inline7`. A `<orig>` that *already* contains `__` is passed through unchanged, so an author-written `a__b` stays the user-facing error `ValidateBaseName` reports rather than being silently normalized.
 
 ## Example
 

--- a/docs/zh/dev/passes/01-inline_functions.md
+++ b/docs/zh/dev/passes/01-inline_functions.md
@@ -36,12 +36,14 @@ program_inlined = inline_pass(program)
 3. **迭代到不动点** — 每次迭代遍历所有函数(包括 Inline 函数本身,以便嵌套的 Inline-calls-Inline 也能传递展开):
    - 对函数体中每个顶层 `LHS = inline_call(args)` 或 `EvalStmt(inline_call(args))`:
      - 构建参数替换映射(形参 `Var` → 实参 `Expr`)。
-     - 对内联体中每个本地绑定的 `Var` 做 alpha 重命名(`<orig>_inline<counter>`),避免多个调用点之间冲突。
+     - 对内联体中每个本地绑定的 `Var` 做 alpha 重命名(`<orig>_inline<counter>`,并去掉 `<orig>` 末尾的 `_`),避免多个调用点之间冲突。
      - 在调用点之前插入重命名+替换后的函数体语句。
      - 用 `LHS = renamed_return`(单返回值)或 `LHS = MakeTuple([renamed_returns...])`(多返回值)替换调用。当 `LHS` 与替换后的返回 `Var` 是同一个 `Var` 时,赋值被省略以避免冗余 SSA 拷贝。
 4. **删除**所有 Inline 函数。
 
 重命名后缀使用单下划线(`_inline`),因为 `__` 被 IR 自动命名约定保留(参见 `auto_name_utils.h`)。
+
+仅靠单下划线后缀并不足够:`<orig>` 本身可能以 `_` 结尾——`_` 是 Python 的弃值名,也是 `for _ in pl.split_aiv(...)` 文档所载的循环变量——此时直接拼接会把两个各自合法的下划线融合成保留分隔符。因此 `FreshName` 通过 `auto_name::JoinNameSuffix` 拼接,该函数会去掉这段尾巴:`_` 重命名为 `_inline7`,而非 `__inline7`。若 `<orig>` 本身**已经**含有 `__`,则原样透传,使作者手写的 `a__b` 仍然是 `ValidateBaseName` 报告的用户错误,而不会被悄悄规范化。
 
 ## 示例
 

--- a/include/pypto/ir/transforms/utils/auto_name_utils.h
+++ b/include/pypto/ir/transforms/utils/auto_name_utils.h
@@ -84,6 +84,30 @@ inline void ValidateBaseName(const std::string& base_name) {
   }
 }
 
+/// Append a `_`-separated `suffix` to `base` without ever *introducing* the
+/// `__` delimiter ValidateBaseName reserves.
+///
+/// A base may legitimately end in `_`: `_` is Python's throwaway name and the
+/// documented loop variable of `for _ in pl.split_aiv(...)` (see
+/// docs/en/user/language/04-scopes.md). A naive `base + "_" + suffix` fuses the
+/// two underscores into the reserved delimiter, so the first downstream renamer
+/// rejects a name the author never wrote.
+///
+/// A base that *already* contains `__` is passed through untouched — that is a
+/// user-facing error ValidateBaseName must still report, not one to hide here.
+/// The contract is exactly: valid base in => valid name out; invalid base in =>
+/// still-invalid name out.
+inline std::string JoinNameSuffix(const std::string& base, const std::string& suffix) {
+  if (base.find("__") != std::string::npos) {
+    return base + "_" + suffix;
+  }
+  std::string_view trimmed(base);
+  while (!trimmed.empty() && trimmed.back() == '_') {
+    trimmed.remove_suffix(1);
+  }
+  return std::string(trimmed) + "_" + suffix;
+}
+
 inline std::string BuildName(const std::string& base_name, const std::string& qualifier = "",
                              const std::optional<std::string>& role = std::nullopt,
                              const std::optional<int>& version = std::nullopt) {

--- a/src/ir/transforms/inline_functions_pass.cpp
+++ b/src/ir/transforms/inline_functions_pass.cpp
@@ -31,6 +31,7 @@
 #include "pypto/ir/transforms/base/visitor.h"
 #include "pypto/ir/transforms/pass_properties.h"
 #include "pypto/ir/transforms/passes.h"
+#include "pypto/ir/transforms/utils/auto_name_utils.h"
 #include "pypto/ir/transforms/utils/deep_clone_utils.h"
 #include "pypto/ir/transforms/utils/mutable_copy.h"
 #include "pypto/ir/transforms/utils/transform_utils.h"
@@ -158,13 +159,20 @@ class DefVarCollector : public IRVisitor {
 // sites of the same inline function. Pass execution is sequential, so a
 // plain static int suffices.
 //
-// Single underscore is intentional — `__` is reserved by the IR auto-naming
-// utility (see auto_name_utils.h::ValidateBaseName) for its own
-// `name__role__version` scheme; re-using `__` here would trip the validator
-// when downstream passes rename the inlined Vars again.
+// `__` is reserved by the IR auto-naming utility (see
+// auto_name_utils.h::ValidateBaseName) for its own `name__role__version`
+// scheme; re-using `__` here trips the validator when downstream passes rename
+// the inlined Vars again.
+//
+// A single-underscore *suffix* is not enough on its own: `orig` may already end
+// in one — `_` is Python's throwaway name and the documented loop variable of
+// `for _ in pl.split_aiv(...)` — in which case plain concatenation *creates* the
+// reserved delimiter out of two individually-legal halves. JoinNameSuffix trims
+// that tail, so `_` inlines to `_inline7` rather than the rejected `__inline7`,
+// while leaving an already-invalid `a__b` invalid for ValidateBaseName to report.
 std::string FreshName(const std::string& orig) {
   static int counter = 0;
-  return orig + "_inline" + std::to_string(counter++);
+  return auto_name::JoinNameSuffix(orig, "inline" + std::to_string(counter++));
 }
 
 // Counts ReturnStmts anywhere inside a body. Splicing only handles a trailing

--- a/tests/ut/ir/transforms/test_inline_functions.py
+++ b/tests/ut/ir/transforms/test_inline_functions.py
@@ -908,5 +908,80 @@ class TestInlineFunctionsSubmitCallSite:
         )
 
 
+class TestInlineFunctionsReservedDelimiter:
+    """A local whose name ends in `_` must not fuse with the `_inlineN` suffix.
+
+    `assert_structural_equal` compares under alpha-equivalence, so it cannot see
+    a name-shape regression. These assert the produced name text directly, and
+    that the first downstream renamer (ConvertToSSA, the first pass to re-derive
+    an auto-name from a Var) accepts the result.
+    """
+
+    def test_underscore_local_does_not_fuse(self):
+        """`_` is Python's throwaway name — inlining must not yield `__inlineN`."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.Inline)
+            def helper(self, x: pl.Tensor[[1], pl.INT32]) -> pl.Tensor[[1], pl.INT32]:
+                _: pl.Tensor[[1], pl.INT32] = pl.mul(x, x)
+                return _
+
+            @pl.function
+            def main(self, a: pl.Tensor[[1], pl.INT32]) -> pl.Tensor[[1], pl.INT32]:
+                z: pl.Tensor[[1], pl.INT32] = self.helper(a)
+                return z
+
+        After = passes.inline_functions()(Before)
+        printed = ir.python_print(After)
+        assert "__" not in printed, printed
+        passes.convert_to_ssa()(After)  # must not raise
+
+    def test_trailing_underscore_local_does_not_fuse(self):
+        """Any base ending in `_`, not only the bare `_`."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.Inline)
+            def helper(self, x: pl.Tensor[[1], pl.INT32]) -> pl.Tensor[[1], pl.INT32]:
+                t_: pl.Tensor[[1], pl.INT32] = pl.mul(x, x)
+                return t_
+
+            @pl.function
+            def main(self, a: pl.Tensor[[1], pl.INT32]) -> pl.Tensor[[1], pl.INT32]:
+                z: pl.Tensor[[1], pl.INT32] = self.helper(a)
+                return z
+
+        After = passes.inline_functions()(Before)
+        printed = ir.python_print(After)
+        assert "__" not in printed, printed
+        assert "t_inline" in printed, printed
+        passes.convert_to_ssa()(After)  # must not raise
+
+    def test_author_written_double_underscore_still_rejected(self):
+        """Inlining must not launder a base that was already invalid.
+
+        Trimming the tail is about not *creating* the reserved delimiter; a name
+        the author wrote with `__` in it stays a user-facing error (see
+        test_convert_to_ssa_pass.py::test_reserved_auto_name_delimiter_in_base_raises).
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.Inline)
+            def helper(self, x: pl.Tensor[[1], pl.INT32]) -> pl.Tensor[[1], pl.INT32]:
+                a__b: pl.Tensor[[1], pl.INT32] = pl.mul(x, x)
+                return a__b
+
+            @pl.function
+            def main(self, a: pl.Tensor[[1], pl.INT32]) -> pl.Tensor[[1], pl.INT32]:
+                z: pl.Tensor[[1], pl.INT32] = self.helper(a)
+                return z
+
+        After = passes.inline_functions()(Before)
+        with pytest.raises(ValueError, match="reserved delimiter '__'"):
+            passes.convert_to_ssa()(After)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/jit/test_decorator.py
+++ b/tests/ut/jit/test_decorator.py
@@ -2054,6 +2054,33 @@ class TestInlineFuncIntegration:
         assert "copy_inline" not in func_names, f"Inline should be spliced, got {func_names}"
         assert "subscript_caller" in func_names
 
+    def test_jit_inline_split_aiv_underscore_loop_var(self):
+        """`for _ in pl.split_aiv(...)` is the documented lane-agnostic idiom and
+        must compile inside an inline callee.
+
+        The inliner alpha-renames callee locals by appending `_inline<N>`; with a
+        loop variable named `_` that used to concatenate into `__inline<N>`, and
+        the `__` there is the delimiter reserved by the IR auto-naming utility,
+        so ConvertToSSA rejected a name the author never wrote.
+        """
+        torch = pytest.importorskip("torch")
+
+        @jit.inline(auto_scope=False)
+        def region(x: pl.Tensor, y: pl.Tensor):
+            M, N = x.shape
+            with pl.spmd(1, name_hint="usc") as _tid:
+                _blk = pl.tile.get_block_idx()
+                for _ in pl.split_aiv(2, mode=pl.SplitMode.NONE):
+                    y = pl.assemble(y, pl.mul(x[0:M, 0:N], 2.0), [0, 0])
+            return y
+
+        @jit
+        def entry(x: pl.Tensor, y: pl.Out[pl.Tensor]):
+            y = region(x, y)
+            return y
+
+        entry.compile(torch.zeros(16, 64), torch.zeros(16, 64))
+
 
 class TestOpaqueFuncIntegration:
     """End-to-end @pl.jit.opaque: dep is emitted as a separate Opaque IR function."""


### PR DESCRIPTION
## Summary

`for _ in pl.split_aiv(2, mode=pl.SplitMode.NONE):` is the lane-agnostic idiom our own docs prescribe — `docs/en/user/language/04-scopes.md:171` and the `AivSplitValid` fix advice in `99-verifier.md` both spell it exactly that way. Inside a `@pl.jit.inline` callee it did not compile:

```text
ValueError: IR auto-name base cannot contain reserved delimiter '__': __inline1
```

The author never wrote `__inline1`. It is synthesized, reported twelve passes downstream of the pass that created it, with no file or line and a message about "IR auto-name base" that means nothing to a kernel author.

`InlineFunctions` alpha-renames every callee-local by concatenating `_inline<N>`. Its comment named the exact hazard and then walked into it:

```cpp
// Single underscore is intentional — `__` is reserved by the IR auto-naming
// utility (see auto_name_utils.h::ValidateBaseName) ...
std::string FreshName(const std::string& orig) {
  static int counter = 0;
  return orig + "_inline" + std::to_string(counter++);
}
```

It guards the *suffix* but never inspects the tail of `orig`. `_` is Python's throwaway name and is valid on its own — it contains no `__`. Appending `_inline1` **creates** the reserved delimiter out of two individually-legal halves, and `ConvertToSSA` (the first pass to re-derive an auto-name from a `Var`) rejects it at `auto_name_utils.h::ValidateBaseName`.

**Not specific to `pl.split_aiv`.** The parser lowers the region's loop target to an ordinary local (`_ = tile.get_subblock_idx()` as the first body statement — `SplitAivScopeStmt` has no loop-variable field), so it is indistinguishable from any other assignment. Probing the shape directly:

| Case | Before | After |
| --- | --- | --- |
| `for _ in pl.split_aiv(...)` in `@pl.jit.inline` | FAIL `__inline1` | OK |
| `for _ in pl.range(2)` in `@pl.jit.inline` | FAIL `__inline1` | OK |
| `_ = pl.mul(...)` in `@pl.jit.inline` | FAIL `__inline3` | OK |
| `t_ = pl.mul(...)` in `@pl.jit.inline` | FAIL `t__inline5` | OK |
| same names in a non-inline callee (control) | OK | OK |

The real rule was: **any local whose name ends in `_`, in any inline callee**. The construct only stood out because its documented idiom is `_`. A *leading* underscore was always harmless (`_tid` → `_tid_inline3`); only the tail mattered.

Rejecting `__` is itself correct and is not relaxed here. `auto_name::Parse` splits at the first `__`, so `t__inline5` parses to base `t` — allowing it would alias against a genuine `t` in the caller, trading a loud compile error for a silent miscompile.

## Changes

- **`include/pypto/ir/transforms/utils/auto_name_utils.h`** — new `JoinNameSuffix`, placed directly beside the `ValidateBaseName` invariant it protects. It trims the base's trailing underscores so the suffix's own `_` is the only separator, and passes through a base that *already* contains `__` untouched. The contract is exactly: **valid base in ⇒ valid name out; invalid base in ⇒ still-invalid name out.** That second half is deliberate — an author-written `a__b` stays the user-facing error `ValidateBaseName` reports rather than being silently normalized, and stays consistent with how a non-inline callee treats the same name.

- **`src/ir/transforms/inline_functions_pass.cpp`** — `FreshName` joins through the helper. `_` now inlines to `_inline7` instead of the rejected `__inline7`. Every name that compiles today keeps its exact spelling, which is why no golden or structural test moves.

- **`docs/{en,zh}/dev/passes/01-inline_functions.md`** — the doc stated the same half-truth as the code comment ("uses a single underscore because `__` is reserved"). Both are rewritten rather than kept: leaving a sentence that asserts the guarantee the code failed to provide would re-plant the trap for the next reader.

- **`tests/ut/ir/transforms/test_inline_functions.py`**, **`tests/ut/jit/test_decorator.py`** — three pass-level tests plus the reported end-to-end shape.

## A note on the tests

They assert the produced name **text**, not structure. `ir.assert_structural_equal` — the pattern the rest of `test_inline_functions.py` uses — compares under alpha-equivalence, so a Before/Expected test cannot see a name-shape regression and would have accepted this bug unchanged.

The third test (`test_author_written_double_underscore_still_rejected`) pins the *other* half of the contract, and is why the helper short-circuits on `__` rather than trimming unconditionally: an unconditional trim would make `t__` compile in an inline callee while the identical name is rejected in a non-inline one.

## Verification

- **Full `tests/ut` suite: 10282 passed, 3 skipped, 2 xfailed, 0 failures.**
- **The new tests genuinely catch the bug.** Run against the pre-fix binary, the two fusion tests and the end-to-end test fail; `test_author_written_double_underscore_still_rejected` passes on both binaries, which is exactly what a contract-*preservation* test should do.
- The reporting kernel's minimal repro (`@pl.jit.inline` + `pl.spmd` + `for _ in pl.split_aiv(2, mode=NONE)`) compiles.
- `JoinNameSuffix` checked standalone over the boundary set `y`, `_tid`, `_`, `t_`, `t__`, `a__b`, `__` — both halves of the contract hold on every one.
- `pre-commit run` on the commit: all 20 hooks pass (clang-format, cpplint, pyright, ruff, docs en↔zh parity, english-only).

## Known-adjacent, deliberately not in this PR

- **The diagnostic for the case that *should* reach a user.** `a__b` still fails at `ConvertToSSA` with no `Span` and compiler-facing wording. The principled fix is to reject it at the frontend where the span exists, but that moves rejection to `@pl.program` parse time and breaks `test_convert_to_ssa_pass.py::test_reserved_auto_name_delimiter_in_base_raises` — a user-visible behavior change deserving its own review.
- **~20 sibling concatenation sites** (`name_hint_ + "_mat"`, `+ "_t"`, `+ "_ctx"`, …) share the shape. I probed these: they are **latent, not live** — all run after `ConvertToSSA`, by which point names are already `x__ssa_v0` and nothing re-validates. A pass reordering could wake them; `JoinNameSuffix` gives that sweep a landing spot.
- **`UnusedVariableCheck` warns `Unused variable '_'`**, contradicting the convention that produced the name. A ~3-line carve-out, but it changes warning output on unrelated programs and the narrow all-underscores rule vs. ruff's broader `_`-prefixed default is a judgment call worth making separately.
