### PR TITLE
fix(ir): keep a runtime split-axis extent off the pl.split_aiv boundary tile

### DIFF
--- a/docs/en/dev/codegen/00-pto_codegen.md
+++ b/docs/en/dev/codegen/00-pto_codegen.md
@@ -226,9 +226,12 @@ or call `set_validshape` on the source tile before taking the view.
   transport — on the consumer side through a metadata-only `pto.treshape` (a frontend tpop result is
   not a locally bound PTOAS tile, so `pto.set_validshape` cannot restore it in place). The split-axis
   extent is the exception: it stays per-lane on the TPOP operands, because that is what tells the ISA
-  where lane 1's band begins.
+  where lane 1's band begins — which is also why a per-lane extent the compiler could not verify must
+  never get there. A `pl.split_aiv` boundary whose split-axis extent is a runtime value keeps the FULL
+  box on the popped tile (`split_axis::WithFullSplitAxisValid`) so the even code's band lands on the
+  box half, and carries the lane's own extent on the consumers instead.
 - When a tpop result `TileView.valid_shape` differs from the physical tile shape, PTO codegen emits PTOAS frontend operands as `%buf = pto.tpop_from_*(%valid_row, %valid_col) {[id = I, ]split = N} -> !pto.tile_buf<..., v_row=?, v_col=?, ...>`. This covers dynamic expressions and static non-full shapes such as `[0, 0]`; the operands carry the logical extents used by compute and store. The full-box Cube-to-Vector transport above overrides this for a statically-shaped, non-empty partial pop, because `pto.treshape` carries no valid-row/valid-col operands and so can only restore *static* logical extents.
-- For split consumers, `LowerAutoVectorSplit` localizes those dynamic tpop
+- For split consumers of a hand-written pop, `SplitVectorKernel` localizes those dynamic tpop
   valid-shape operands per subblock (for example global `[8, 16]` becomes
   `[8, 16]` then `[0, 16]` under up/down split of a `[16, 16]` tile). An odd
   split axis reaches the operands the same way — a `[17, 128]` tile pops

--- a/docs/en/dev/passes/20-lower_auto_vector_split.md
+++ b/docs/en/dev/passes/20-lower_auto_vector_split.md
@@ -413,17 +413,30 @@ rebuilt by the halving walk rather than by this one.
   boundary — 13 of a 16-row box gives 8 and 5 — which is what the balanced
   partition below is for. When it does not apply, `ShardSplitCode` reports the
   extents instead, naming what would work.
-- **A runtime split-axis valid extent keeps the even code.** The split code is a
-  compile-time attr, but which one the lanes need appears to depend on their
-  *runtime* extents: 15 of a 16-wide axis leaves the lanes at 8 and 7. The even
-  code is what this path emits, and what the device is measured to accept —
-  `tests/st/runtime/cross_core/test_cross_core_split_parity.py` compares
-  `output[:VR, :VC]` elementwise for `VC = 1, 7, 8, 9, 15` on a2a3 and passes,
-  and perturbing that golden on lane 1's columns alone does fail it, so the
-  check covers the band in question. Reading pto-isa's pop suggests a mis-placed
-  lane 1 instead; which reading is the contract is asked upstream in
-  [pto-isa#263](https://github.com/hw-native-sys/pto-isa/issues/263). Until that
-  answers, the encoding follows the measured behaviour.
+- **A runtime split-axis valid extent pops the FULL box.** The split code is a
+  compile-time attr, but which one the lanes need depends on their *runtime*
+  extents: 12 of a 16-row axis leaves them at 8 and 4, 16 leaves them at 8 and 8.
+  No code is right for both, so the boundary op does not carry a per-lane extent
+  at all — `LocalizeExplicitBoundaryValid` gives it the full box
+  (`split_axis::WithFullSplitAxisValid`) and moves the lane's extent onto the
+  first consumer. That pairs exactly with the even code: the producer transports
+  the full physical box, so lane 1's band sits at the box half and the even code
+  points there, whatever the extent turns out to be. Confirmed on a2a3 for every
+  extent 1..16 of a 16-row boundary. The [pto-isa
+  pop](https://github.com/hw-native-sys/pto-isa/issues/263) does place lane 1 at
+  the popped tile's own extent, as its source reads — the earlier measurement
+  that suggested otherwise came from a probe whose operands were uniform
+  constants, which makes every row and column of the product identical and any
+  band offset indistinguishable.
+- **The same extent on a hand-written `tile.tpop_from_aic` is still misplaced.**
+  `SplitVectorKernel`'s halving localizes a declared `valid_shape` onto the pop
+  itself, where pto-isa reads it as the band offset. Widening only the pop does
+  not fix that path: its consumers inherit the author's declaration and then
+  write partial destinations out of a full source, which measures worse on
+  device. The xfailing params of
+  `tests/st/runtime/cross_core/test_cross_core_split_parity.py` record the
+  regimes this affects (`half < V < box` on `UP_DOWN`, and any narrowed column
+  extent on `LEFT_RIGHT`, where the pop additionally mis-strides the GM gap).
 - **An empty lane's store is guarded.** A lane the ragged extent does not reach
   has extent `0`, and a zero-row `TSTORE` is outside pto-isa's contract
   (`TSTORE_IMPL` asserts `GetValidRow() > 0`). The store gets a runtime

--- a/docs/en/dev/passes/20-lower_auto_vector_split.md
+++ b/docs/en/dev/passes/20-lower_auto_vector_split.md
@@ -393,7 +393,7 @@ geometric rule at the end of this section instead.
 | rows (non-split) | `LeftRight` | shared, static | TPOP `valid_row` operand | supported |
 | cols (split axis) | `LeftRight` | per-lane | none | **rejected** |
 | cols, runtime-valued | either | shared, dynamic | none (`treshape` takes no operands) | **rejected** |
-| rows, runtime-valued | `UpDown` | per-lane, dynamic | TPOP `valid_row` operand, even code | supported (see the note below) |
+| rows, runtime-valued | `UpDown` | per-lane, dynamic | the boundary op's FULL box + the first consumer's `valid_shape` | supported (see the note below) |
 | rows per-lane **and** cols narrowed | `UpDown` | both | none (`treshape` rewrites both axes) | **rejected** |
 
 `ReshapeSplitAxis` can only ceil-halve the split-axis extent (the lane index is

--- a/docs/en/dev/passes/20-lower_auto_vector_split.md
+++ b/docs/en/dev/passes/20-lower_auto_vector_split.md
@@ -428,15 +428,21 @@ rebuilt by the halving walk rather than by this one.
   that suggested otherwise came from a probe whose operands were uniform
   constants, which makes every row and column of the product identical and any
   band offset indistinguishable.
-- **The same extent on a hand-written `tile.tpop_from_aic` is still misplaced.**
-  `SplitVectorKernel`'s halving localizes a declared `valid_shape` onto the pop
-  itself, where pto-isa reads it as the band offset. Widening only the pop does
-  not fix that path: its consumers inherit the author's declaration and then
-  write partial destinations out of a full source, which measures worse on
-  device. The xfailing params of
-  `tests/st/runtime/cross_core/test_cross_core_split_parity.py` record the
-  regimes this affects (`half < V < box` on `UP_DOWN`, and any narrowed column
-  extent on `LEFT_RIGHT`, where the pop additionally mis-strides the GM gap).
+- **The same ROW extent on a hand-written `tile.tpop_from_aic` is still
+  misplaced.** `SplitVectorKernel`'s halving localizes a declared `valid_shape`
+  onto the pop itself, where pto-isa reads it as the band offset. Widening only
+  the pop does not fix that path: its consumers inherit the author's declaration
+  and then write partial destinations out of a full source, which measures worse
+  on device. The xfailing params of
+  `tests/st/runtime/cross_core/test_cross_core_split_parity.py` record the regime
+  this affects: `half < V < box` on `UP_DOWN`.
+- **A narrowed COLUMN extent is rejected on every path.** It has no carrier at
+  all — the slot is written at the producer's physical column pitch while the pop
+  rebuilds its geometry from the tile's own `validCol` — and on `LeftRight` it is
+  the split axis, so it would have to be per-lane. `CheckSplitBoundaryCarriesValid`
+  (`src/ir/op/tile_ops/cross_core.cpp`) owns that contract; it runs both in the
+  boundary op's deduction and from `ShardSplitCode`, so a hand-written
+  `tile.tpush_to_aiv` / `tile.tpop_from_aic` pair is held to it too.
 - **An empty lane's store is guarded.** A lane the ragged extent does not reach
   has extent `0`, and a zero-row `TSTORE` is outside pto-isa's contract
   (`TSTORE_IMPL` asserts `GetValidRow() > 0`). The store gets a runtime

--- a/docs/zh/dev/codegen/00-pto_codegen.md
+++ b/docs/zh/dev/codegen/00-pto_codegen.md
@@ -218,9 +218,12 @@ tile 调用 `set_validshape`。
   TPUSH 和 TPOP 都使用完整物理 box，并在传输两侧立即恢复逻辑 valid shape——消费侧
   通过纯元数据的 `pto.treshape` 恢复（前端 tpop 结果不是 PTOAS 的本地绑定 tile，
   `pto.set_validshape` 无法就地修改它）。唯一的例外是切分轴上的 extent：它必须保持
-  逐 lane 的值并留在 TPOP 操作数上，因为 ISA 正是靠它定位 lane 1 的数据段起点。
+  逐 lane 的值并留在 TPOP 操作数上，因为 ISA 正是靠它定位 lane 1 的数据段起点——也正因如此，
+  编译期无法核验的逐 lane extent 绝不能到达那里。`pl.split_aiv` 区域中切分轴 extent 为运行期
+  值的边界，会让被弹出的 tile 保留完整 box（`split_axis::WithFullSplitAxisValid`），使偶数
+  code 的数据段落在 box 的一半处，而把 lane 自身的 extent 交给消费者携带。
 - 当 tpop 结果的 `TileView.valid_shape` 与物理 tile shape 不一致时，PTO codegen 会生成 PTOAS 前端操作数：`%buf = pto.tpop_from_*(%valid_row, %valid_col) {[id = I, ]split = N} -> !pto.tile_buf<..., v_row=?, v_col=?, ...>`。这同时覆盖动态表达式和 `[0, 0]` 这类静态非满形状；operand 携带后续计算和 store 使用的逻辑范围。对于静态形状、非空的部分 pop，上述 Cube-to-Vector 完整 box 传输优先，因为 `pto.treshape` 不带 valid-row/valid-col operand，只能恢复*静态*逻辑范围。
-- 对于 split consumer，`LowerAutoVectorSplit` 会按 subblock 本地化这些动态
+- 对于手写 pop 的 split consumer，`SplitVectorKernel` 会按 subblock 本地化这些动态
   tpop valid-shape operand（例如 `[16, 16]` tile 做上下切分时，全局
   `[8, 16]` 会变成 `[8, 16]` 和 `[0, 16]`）。奇数切分轴走同一条路径——`[17, 128]`
   的 tile 在 `split = 3` 下，lane 0 弹出 `[9, 128]`，lane 1 弹出 `[8, 128]`。

--- a/docs/zh/dev/passes/20-lower_auto_vector_split.md
+++ b/docs/zh/dev/passes/20-lower_auto_vector_split.md
@@ -375,12 +375,16 @@ store 保护——它的消费者由折半遍历重建，而非本遍历。
   extent 验证。[pto-isa 的 pop](https://github.com/hw-native-sys/pto-isa/issues/263)
   确实按被弹出 tile 自身的 extent 放置 lane 1，与其源码读法一致——此前得出相反结论的实测，
   其探针两个操作数都是常量，乘积的每一行每一列都相同，落位错误因而无法分辨。
-- **手写 `tile.tpop_from_aic` 上的同类 extent 仍会落位错误。** `SplitVectorKernel` 的折半
-  会把用户声明的 `valid_shape` 局部化到 pop 自身，而 pto-isa 正是从这里读取数据段偏移。
+- **手写 `tile.tpop_from_aic` 上的同类行 extent 仍会落位错误。** `SplitVectorKernel` 的
+  折半会把用户声明的 `valid_shape` 局部化到 pop 自身，而 pto-isa 正是从这里读取数据段偏移。
   仅加宽 pop 并不能修复该路径：其消费者继承作者的声明，随后从完整来源写入部分目标，实测
   结果更差。`tests/st/runtime/cross_core/test_cross_core_split_parity.py` 中标记 xfail
-  的参数记录了受影响的取值范围（`UP_DOWN` 下 `half < V < box`，以及 `LEFT_RIGHT` 下任何
-  被收窄的列 extent——此时 pop 还会算错 GM 的行间隔）。
+  的参数记录了受影响的取值范围：`UP_DOWN` 下 `half < V < box`。
+- **被收窄的列 extent 在所有路径上一律拒绝。** 它根本没有承载者——槽位按生产者的物理列
+  间距写入，而 pop 依据 tile 自身的 `validCol` 重建读取几何——并且在 `LeftRight` 下它就是
+  切分轴，必须逐 lane 取值。该契约由 `CheckSplitBoundaryCarriesValid`
+  （`src/ir/op/tile_ops/cross_core.cpp`）统一持有：它既在边界算子的类型推导中运行，也由
+  `ShardSplitCode` 调用，因此手写的 `tile.tpush_to_aiv` / `tile.tpop_from_aic` 同样受其约束。
 - **空 lane 的 store 被保护。** ragged extent 覆盖不到的 lane，其 extent 为 `0`，而
   零行 `TSTORE` 超出 pto-isa 契约（`TSTORE_IMPL` 断言 `GetValidRow() > 0`）。store
   被加上运行时 `extent > 0` 判断；`tpop` 与 `tfree` 保持**无条件**——两个 lane 都占用

--- a/docs/zh/dev/passes/20-lower_auto_vector_split.md
+++ b/docs/zh/dev/passes/20-lower_auto_vector_split.md
@@ -365,15 +365,22 @@ store 保护——它的消费者由折半遍历重建，而非本遍历。
   被解引用，偶数 code 依然精确）。box 分区对 ragged 边界并不保证这一点——16 行 box 上
   `V = 13` 会得到 8 与 5——这正是下文均分分区要解决的问题；均分不适用时，
   `ShardSplitCode` 会报错并给出可行的取值。
-- **运行期的切分轴 valid extent 沿用偶数 code。** split code 是编译期属性，而两个 lane
-  需要哪一个看起来取决于它们的**运行期** extent：16 宽的轴上 valid 15 会让两 lane 变成 8 与 7。
-  该路径发偶数 code，这也是设备实测接受的行为——
-  `tests/st/runtime/cross_core/test_cross_core_split_parity.py` 在 a2a3 上对
-  `VC = 1, 7, 8, 9, 15` 逐元素比对 `output[:VR, :VC]` 并通过，且仅把 golden 在 lane 1 的列上
-  扰动即会失败，说明该校验确实覆盖了这段数据。而按 pto-isa 的 pop 源码推理会得出 lane 1 落位
-  错误；究竟哪一种才是契约，已在
-  [pto-isa#263](https://github.com/hw-native-sys/pto-isa/issues/263) 上向属主提问。在有答复之前，
-  编码遵循实测行为。
+- **运行期的切分轴 valid extent 弹出完整 box。** split code 是编译期属性，而两个 lane
+  需要哪一个取决于它们的**运行期** extent：16 行的轴上 valid 12 会让两 lane 变成 8 与 4，
+  valid 16 则是 8 与 8，没有哪个 code 对两者都正确。因此边界算子干脆不携带逐 lane
+  extent——`LocalizeExplicitBoundaryValid` 给它完整 box
+  （`split_axis::WithFullSplitAxisValid`），并把 lane 的 extent 放到第一个消费者上。
+  这与偶数 code 恰好配套：生产者搬运的是完整物理 box，lane 1 的数据段就落在 box 的一半处，
+  偶数 code 正好指向那里，与运行期 extent 无关。已在 a2a3 上对 16 行边界的 1..16 全部
+  extent 验证。[pto-isa 的 pop](https://github.com/hw-native-sys/pto-isa/issues/263)
+  确实按被弹出 tile 自身的 extent 放置 lane 1，与其源码读法一致——此前得出相反结论的实测，
+  其探针两个操作数都是常量，乘积的每一行每一列都相同，落位错误因而无法分辨。
+- **手写 `tile.tpop_from_aic` 上的同类 extent 仍会落位错误。** `SplitVectorKernel` 的折半
+  会把用户声明的 `valid_shape` 局部化到 pop 自身，而 pto-isa 正是从这里读取数据段偏移。
+  仅加宽 pop 并不能修复该路径：其消费者继承作者的声明，随后从完整来源写入部分目标，实测
+  结果更差。`tests/st/runtime/cross_core/test_cross_core_split_parity.py` 中标记 xfail
+  的参数记录了受影响的取值范围（`UP_DOWN` 下 `half < V < box`，以及 `LEFT_RIGHT` 下任何
+  被收窄的列 extent——此时 pop 还会算错 GM 的行间隔）。
 - **空 lane 的 store 被保护。** ragged extent 覆盖不到的 lane，其 extent 为 `0`，而
   零行 `TSTORE` 超出 pto-isa 契约（`TSTORE_IMPL` 断言 `GetValidRow() > 0`）。store
   被加上运行时 `extent > 0` 判断；`tpop` 与 `tfree` 保持**无条件**——两个 lane 都占用

--- a/docs/zh/dev/passes/20-lower_auto_vector_split.md
+++ b/docs/zh/dev/passes/20-lower_auto_vector_split.md
@@ -348,7 +348,7 @@ lane 的——lane `L` 持有 `clamp(V - L*half, 0, half)`——因此哪种模�
 | 行（非切分轴） | `LeftRight` | 两 lane 相同、静态 | TPOP `valid_row` 操作数 | 支持 |
 | 列（切分轴） | `LeftRight` | 逐 lane | 无 | **拒绝** |
 | 列为运行期值 | 任意 | 两 lane 相同、动态 | 无（`treshape` 不带操作数） | **拒绝** |
-| 行为运行期值 | `UpDown` | 逐 lane、动态 | TPOP `valid_row` 操作数、偶数 code | 支持（见下方说明） |
+| 行为运行期值 | `UpDown` | 逐 lane、动态 | 边界算子保留整 box + 第一个消费者的 `valid_shape` | 支持（见下方说明） |
 | 行逐 lane **且**列收窄 | `UpDown` | 两者 | 无（`treshape` 会同时重写两个轴） | **拒绝** |
 
 `ReshapeSplitAxis` 只能对切分轴做 ceil 折半，因为 lane 索引不属于 op 的类型函数。

--- a/include/pypto/ir/transforms/utils/split_axis_utils.h
+++ b/include/pypto/ir/transforms/utils/split_axis_utils.h
@@ -117,9 +117,15 @@ ExprPtr ResolveLaneStride(const std::vector<StmtPtr>& stmts, int split_dim);
  * code. Any other ragged extent has no expressible band pair and is rejected
  * with an actionable message rather than silently popping the wrong rows.
  *
- * A dynamic (non-ConstInt) box or valid extent has no compile-time lane extents;
- * it keeps the even code, the only one whose lowering does not depend on the
- * parity.
+ * A dynamic (non-ConstInt) box or valid extent has no compile-time lane extents,
+ * so no code can be verified against them. It keeps the even code, which is exact
+ * only when the boundary tile also declares the full split-axis box: the producer
+ * transports that box, so lane 1's band sits at the box half and the even code
+ * points there whatever the extent turns out to be. LocalizeExplicitBoundaryValid
+ * establishes that pairing for a ``pl.split_aiv`` region (WithFullSplitAxisValid)
+ * and moves the lane's own extent onto the boundary's consumers. A hand-written
+ * ``tile.tpop_from_aic`` keeps its declared per-lane extent and is still
+ * misplaced for such a boundary — see RebuildTpopWithHalvedShape.
  *
  * @param mode The split mode (``None`` yields ``kSplitNone``).
  * @param full_type The PRE-split (full-width) boundary tile type.
@@ -165,6 +171,45 @@ int GatherSplitCode(SplitMode mode, const TypePtr& full_type, int split_dim, con
  */
 std::optional<std::pair<int64_t, int64_t>> StaticLaneExtents(const TypePtr& full_type, int split_dim,
                                                              const ExprPtr& lane_stride);
+
+/**
+ * @brief Whether the boundary's per-lane extents are known at compile time.
+ *
+ * The split code is a compile-time promise about the lanes' RUNTIME extents, and
+ * ShardSplitCode can only keep (or refuse) that promise when both the box and
+ * the valid extent are constants. When they are not, the per-lane extent must
+ * NOT be materialized onto the boundary tile: pto-isa would place lane 1's band
+ * at that extent, while the producer transported the full physical box. The
+ * boundary tile keeps its full split-axis extent instead, and the lane's real
+ * extent is carried by its consumers.
+ *
+ * @param full_type The PRE-split (full-width) boundary tile type.
+ * @param split_dim The partitioned tile dimension (see SplitDimension).
+ * @param lane_stride The body's partition stride; null for the box partition.
+ * @return ``true`` when both lane extents are compile-time constants.
+ */
+bool HasStaticLaneExtents(const TypePtr& full_type, int split_dim, const ExprPtr& lane_stride);
+
+/**
+ * @brief The same tile type with its split-axis extent declared FULL.
+ *
+ * pto-isa finds lane 1's band inside the FIFO slot from the POPPED tile's own
+ * split-axis extent, while the producer always transports the full physical box
+ * (PTO codegen's ``EmitTpushTransportValidShape`` widens every split tpush). The
+ * two agree only when the lanes' extents were verifiable at compile time — the
+ * balanced partition and the odd codes exist exactly to make them agree. When
+ * they were not (see HasStaticLaneExtents), the boundary tile must declare the
+ * box instead, which puts lane 1's band at the box half, where the producer
+ * wrote it. The lane's real extent is then carried by the boundary's consumers:
+ * the halving localizes each of them from its own pre-split type, and the
+ * explicit-region walk stamps it on the first one it reaches.
+ *
+ * @param type The (already halved) boundary tile type.
+ * @param split_dim The partitioned tile dimension (see SplitDimension).
+ * @return The type with ``valid_shape[split_dim] == shape_[split_dim]``;
+ *         @p type unchanged when it is not a TileType or already full there.
+ */
+TypePtr WithFullSplitAxisValid(const TypePtr& type, int split_dim);
 
 /**
  * @brief Detect a vector reduction that collapses the split axis.

--- a/include/pypto/ir/type_inference.h
+++ b/include/pypto/ir/type_inference.h
@@ -184,6 +184,37 @@ enum class ProofResult {
 ProofResult ProveValidExtentEqual(const ExprPtr& lhs, const ExprPtr& rhs);
 
 /**
+ * @brief Enforce what a Cube <-> Vector boundary can carry in its valid_shape.
+ *
+ * The FIFO slot is written by the producer at its PHYSICAL column pitch and read
+ * back by each lane with pto-isa's own geometry, which it derives from the
+ * POPPED tile's runtime valid extents (``popVecTileFromGMFiFo``):
+ * ``gmStrideR = validCol`` (doubled for the left-right codes) and
+ * ``subAIVOffset = subBlockId * validRow * validCol`` (``* validCol`` for
+ * left-right). Both only reconstruct the producer's rectangle when the COLUMN
+ * extent is the full physical box, which is why a narrowed column extent has no
+ * carrier across this boundary at all -- on LEFT_RIGHT it is additionally the
+ * split axis, so it would have to be per-lane, which nothing can express.
+ *
+ * Called from the boundary op's own deduction (``tile.aiv_shard`` /
+ * ``tile.aic_gather``) AND from the transport code choice
+ * (``split_axis::ShardSplitCode``), so a hand-written
+ * ``tile.tpush_to_aiv`` / ``tile.tpop_from_aic`` pair is held to the same
+ * contract as a compiler-generated boundary.
+ *
+ * @param op_name Op name for diagnostics.
+ * @param shape The tile's PHYSICAL shape (rank 2; other ranks return).
+ * @param valid The tile's valid_shape.
+ * @param split_axis 0 (UP_DOWN), 1 (LEFT_RIGHT), or -1 for a split=0 crossing.
+ * @param halve Whether this boundary actually splits (a gather passes false).
+ * @param span Span for diagnostics.
+ * @throws pypto::ValueError naming the shapes that would work.
+ */
+void CheckSplitBoundaryCarriesValid(const std::string& op_name, const std::vector<ExprPtr>& shape,
+                                    const std::vector<ExprPtr>& valid, int split_axis, bool halve,
+                                    const Span& span);
+
+/**
  * @brief Prove whether one valid-extent expression is less than or equal to another
  *
  * @return kTrue when lhs <= rhs is proven, kFalse when lhs > rhs is proven,

--- a/src/ir/op/tile_ops/cross_core.cpp
+++ b/src/ir/op/tile_ops/cross_core.cpp
@@ -218,92 +218,6 @@ std::string DescribeExtent(const ExprPtr& valid_dim, const ExprPtr& dim) {
   return PythonPrint(valid_dim) + " of " + PythonPrint(dim);
 }
 
-// `split_axis` is 0 (UP_DOWN), 1 (LEFT_RIGHT), or -1 for the shape-preserving
-// split=0 crossing, which has no split axis and therefore no per-lane extent.
-void CheckSplitBoundaryCarriesValid(const std::string& op_name, const std::vector<ExprPtr>& shape,
-                                    const std::vector<ExprPtr>& valid, int split_axis, bool halve,
-                                    const Span& span) {
-  if (shape.size() != 2 || valid.size() != 2) {
-    return;
-  }
-  // (1) The gather is exempt from the column contract at EVERY split, including
-  // the shape-preserving split=0 crossing: a V2C pop lands in an NZ Mat tile
-  // through TLoadGm2L1Nd2nz, which reads neither validRow nor validCol, and it
-  // never takes the pto.treshape path (use_full_box is gated on the C2V pop).
-  //
-  // Its own rule — that the two lanes' bands must abut — is NOT checked here.
-  // This deducer runs before the per-lane extents exist, so the only extent it
-  // can see is its own lane-agnostic ceil-div guess; judging the join on that
-  // both misreports the extents and rejects shapes that are representable once
-  // the lanes are localized. LowerAutoVectorSplit owns that rule instead, where
-  // the true extents are known (split_axis_utils.cpp).
-  if (!halve) {
-    return;
-  }
-
-  // (2) The column field is the contested one. A full column extent needs no
-  // restore at all, which also leaves the row field free.
-  if (IsFullExtent(valid[1], shape[1])) {
-    return;
-  }
-
-  // (3) LEFT_RIGHT narrows the split axis, so the column extent is per-lane.
-  const bool column_is_per_lane = (split_axis == 1);
-  CHECK_SPAN(!column_is_per_lane, span)
-      << op_name << ": LEFT_RIGHT splits the column axis, but this tile's valid column extent ("
-      << DescribeExtent(valid[1], shape[1])
-      << ") does not cover the full box, so the two AIV lanes would hold different amounts of real "
-         "data. A per-lane column extent cannot cross this boundary: the Cube<->Vector FIFO pins the "
-         "transported column extent to the physical one, and the only way to restore a narrower "
-         "extent afterwards (pto.treshape) is compile-time static and so cannot express a per-lane "
-         "value.\n"
-      << "Author one of these instead:\n"
-      << "  * split the row axis: mode=pl.SplitMode.UP_DOWN (a per-lane ROW extent IS carried)\n"
-      << "  * make the columns fully valid before the crossing and let the padding be don't-care at "
-         "the store:\n"
-      << "        acc = pl.set_validshape(acc, <valid_rows>, " << PythonPrint(shape[1]) << ")\n"
-      << "        out[..., c0 : c0 + <half>] = shard   # c0 = aiv_id * <half>\n"
-      << "  * keep the ragged column tail in its own matmul outside the pl.split_aiv region";
-
-  // (4) The narrowed column extent must be rebuilt after the full-box transport,
-  // and pto.treshape can only rebuild static extents -- on BOTH axes at once.
-  const bool column_is_static = static_cast<bool>(As<ConstInt>(valid[1]));
-  CHECK_SPAN(column_is_static, span)
-      << op_name << ": this tile's valid column extent (" << DescribeExtent(valid[1], shape[1])
-      << ") is a runtime value narrower than the physical box. A narrowed column extent has to be "
-         "rebuilt after the boundary's full-box transport, and the only rebuild available "
-         "(pto.treshape) is compile-time static.\n"
-      << "Fix: make the columns fully valid before the crossing --\n"
-      << "        acc = pl.set_validshape(acc, <valid_rows>, " << PythonPrint(shape[1]) << ")\n"
-      << "    and store the full column box; the padded columns are don't-care.";
-
-  // A row extent that is per-lane (split-axis narrowing on an UP_DOWN shard) or
-  // runtime-valued cannot survive the static treshape that the narrowed column
-  // extent forces, because treshape rewrites both axes from one target type.
-  const bool row_is_per_lane = (split_axis == 0) && !IsFullExtent(valid[0], shape[0]);
-  const bool row_is_static = static_cast<bool>(As<ConstInt>(valid[0]));
-  CHECK_SPAN(!row_is_per_lane, span)
-      << op_name << ": UP_DOWN split with BOTH a per-lane row extent (" << DescribeExtent(valid[0], shape[0])
-      << ", so the lanes hold different row counts) and a "
-      << "narrowed column extent (" << DescribeExtent(valid[1], shape[1]) << ") is not supported. "
-      << "The per-lane row extent rides on the TPOP valid_row operand, but the narrowed column "
-         "extent can only be restored by pto.treshape, which rebuilds BOTH axes from one static "
-         "type and would overwrite that per-lane row.\n"
-      << "Fix: widen the columns before the crossing and store the full column box --\n"
-      << "        acc = pl.set_validshape(acc, " << PythonPrint(valid[0]) << ", " << PythonPrint(shape[1])
-      << ")\n"
-      << "        out[r0 : r0 + <half>, 0 : " << PythonPrint(shape[1]) << "] = shard";
-  CHECK_SPAN(row_is_static, span)
-      << op_name << ": this tile's valid row extent (" << DescribeExtent(valid[0], shape[0])
-      << ") is a runtime value and its valid column extent (" << DescribeExtent(valid[1], shape[1])
-      << ") is narrower than the physical box. The narrowed column extent forces a full-box "
-         "transport whose logical extents are rebuilt by the static pto.treshape, which cannot "
-         "express a runtime row extent.\n"
-      << "Fix: make the columns fully valid before the crossing --\n"
-      << "        acc = pl.set_validshape(acc, <valid_rows>, " << PythonPrint(shape[1]) << ")\n"
-      << "    and store the full column box; the padded columns are don't-care.";
-}
-
 // Deducer for the tile-level split-axis reshape ops tile.aiv_shard (full ->
 // half) and tile.aic_gather (half -> full). The single positional tile argument
 // is reshaped along the split axis selected by the "split" int attr.
@@ -436,6 +350,92 @@ TypePtr DeduceSplitReshapeTensor(const std::vector<ExprPtr>& args,
 }
 
 }  // namespace
+
+// `split_axis` is 0 (UP_DOWN), 1 (LEFT_RIGHT), or -1 for the shape-preserving
+// split=0 crossing, which has no split axis and therefore no per-lane extent.
+void CheckSplitBoundaryCarriesValid(const std::string& op_name, const std::vector<ExprPtr>& shape,
+                                    const std::vector<ExprPtr>& valid, int split_axis, bool halve,
+                                    const Span& span) {
+  if (shape.size() != 2 || valid.size() != 2) {
+    return;
+  }
+  // (1) The gather is exempt from the column contract at EVERY split, including
+  // the shape-preserving split=0 crossing: a V2C pop lands in an NZ Mat tile
+  // through TLoadGm2L1Nd2nz, which reads neither validRow nor validCol, and it
+  // never takes the pto.treshape path (use_full_box is gated on the C2V pop).
+  //
+  // Its own rule — that the two lanes' bands must abut — is NOT checked here.
+  // This deducer runs before the per-lane extents exist, so the only extent it
+  // can see is its own lane-agnostic ceil-div guess; judging the join on that
+  // both misreports the extents and rejects shapes that are representable once
+  // the lanes are localized. LowerAutoVectorSplit owns that rule instead, where
+  // the true extents are known (split_axis_utils.cpp).
+  if (!halve) {
+    return;
+  }
+
+  // (2) The column field is the contested one. A full column extent needs no
+  // restore at all, which also leaves the row field free.
+  if (IsFullExtent(valid[1], shape[1])) {
+    return;
+  }
+
+  // (3) LEFT_RIGHT narrows the split axis, so the column extent is per-lane.
+  const bool column_is_per_lane = (split_axis == 1);
+  CHECK_SPAN(!column_is_per_lane, span)
+      << op_name << ": LEFT_RIGHT splits the column axis, but this tile's valid column extent ("
+      << DescribeExtent(valid[1], shape[1])
+      << ") does not cover the full box, so the two AIV lanes would hold different amounts of real "
+         "data. A per-lane column extent cannot cross this boundary: the Cube<->Vector FIFO pins the "
+         "transported column extent to the physical one, and the only way to restore a narrower "
+         "extent afterwards (pto.treshape) is compile-time static and so cannot express a per-lane "
+         "value.\n"
+      << "Author one of these instead:\n"
+      << "  * split the row axis: mode=pl.SplitMode.UP_DOWN (a per-lane ROW extent IS carried)\n"
+      << "  * make the columns fully valid before the crossing and let the padding be don't-care at "
+         "the store:\n"
+      << "        acc = pl.set_validshape(acc, <valid_rows>, " << PythonPrint(shape[1]) << ")\n"
+      << "        out[..., c0 : c0 + <half>] = shard   # c0 = aiv_id * <half>\n"
+      << "  * keep the ragged column tail in its own matmul outside the pl.split_aiv region";
+
+  // (4) The narrowed column extent must be rebuilt after the full-box transport,
+  // and pto.treshape can only rebuild static extents -- on BOTH axes at once.
+  const bool column_is_static = static_cast<bool>(As<ConstInt>(valid[1]));
+  CHECK_SPAN(column_is_static, span)
+      << op_name << ": this tile's valid column extent (" << DescribeExtent(valid[1], shape[1])
+      << ") is a runtime value narrower than the physical box. A narrowed column extent has to be "
+         "rebuilt after the boundary's full-box transport, and the only rebuild available "
+         "(pto.treshape) is compile-time static.\n"
+      << "Fix: make the columns fully valid before the crossing --\n"
+      << "        acc = pl.set_validshape(acc, <valid_rows>, " << PythonPrint(shape[1]) << ")\n"
+      << "    and store the full column box; the padded columns are don't-care.";
+
+  // A row extent that is per-lane (split-axis narrowing on an UP_DOWN shard) or
+  // runtime-valued cannot survive the static treshape that the narrowed column
+  // extent forces, because treshape rewrites both axes from one target type.
+  const bool row_is_per_lane = (split_axis == 0) && !IsFullExtent(valid[0], shape[0]);
+  const bool row_is_static = static_cast<bool>(As<ConstInt>(valid[0]));
+  CHECK_SPAN(!row_is_per_lane, span)
+      << op_name << ": UP_DOWN split with BOTH a per-lane row extent (" << DescribeExtent(valid[0], shape[0])
+      << ", so the lanes hold different row counts) and a "
+      << "narrowed column extent (" << DescribeExtent(valid[1], shape[1]) << ") is not supported. "
+      << "The per-lane row extent rides on the TPOP valid_row operand, but the narrowed column "
+         "extent can only be restored by pto.treshape, which rebuilds BOTH axes from one static "
+         "type and would overwrite that per-lane row.\n"
+      << "Fix: widen the columns before the crossing and store the full column box --\n"
+      << "        acc = pl.set_validshape(acc, " << PythonPrint(valid[0]) << ", " << PythonPrint(shape[1])
+      << ")\n"
+      << "        out[r0 : r0 + <half>, 0 : " << PythonPrint(shape[1]) << "] = shard";
+  CHECK_SPAN(row_is_static, span)
+      << op_name << ": this tile's valid row extent (" << DescribeExtent(valid[0], shape[0])
+      << ") is a runtime value and its valid column extent (" << DescribeExtent(valid[1], shape[1])
+      << ") is narrower than the physical box. The narrowed column extent forces a full-box "
+         "transport whose logical extents are rebuilt by the static pto.treshape, which cannot "
+         "express a runtime row extent.\n"
+      << "Fix: make the columns fully valid before the crossing --\n"
+      << "        acc = pl.set_validshape(acc, <valid_rows>, " << PythonPrint(shape[1]) << ")\n"
+      << "    and store the full column box; the padded columns are don't-care.";
+}
 
 // ============================================================================
 // Cross-Core Tile Transfer Operations (tpush / tpop)

--- a/src/ir/transforms/utils/split_axis_utils.cpp
+++ b/src/ir/transforms/utils/split_axis_utils.cpp
@@ -83,6 +83,16 @@ bool IsReduceOnSplitAxis(const CallPtr& call, int split_dim) {
   return false;
 }
 
+TypePtr WithFullSplitAxisValid(const TypePtr& type, int split_dim) {
+  auto tt = std::dynamic_pointer_cast<const TileType>(type);
+  if (!tt || split_dim < 0 || split_dim >= static_cast<int>(tt->shape_.size())) return type;
+  TileView tv = tile_view_semantics::GetEffectiveTileView(*tt);
+  if (split_dim >= static_cast<int>(tv.valid_shape.size())) return type;
+  if (AreExprsEqual(tv.valid_shape[split_dim], tt->shape_[split_dim])) return type;
+  tv.valid_shape[split_dim] = tt->shape_[split_dim];
+  return std::make_shared<TileType>(tt->shape_, tt->dtype_, tt->memref_, std::move(tv), tt->memory_space_);
+}
+
 namespace {
 
 bool IsSingletonDim(const ExprPtr& dim_size) {
@@ -250,8 +260,36 @@ ExprPtr LocalizeTupleElementForSplit(const ExprPtr& tuple_expr, int dim, const E
   return std::make_shared<MakeTuple>(std::move(new_elements), tuple_expr->span_);
 }
 
+// A store must not read a boundary tile whose split-axis extent was left at the
+// transport's (see WithFullSplitAxisValid): that extent is the truth about the
+// FIFO band and a lie about how much of the lane's box is data.
+void RejectDeferredValidStore(bool deferred, const CallPtr& call) {
+  CHECK_SPAN(!deferred, call->span_)
+      << "tile.store: this store consumes a Cube -> Vector boundary tile directly, and that "
+         "boundary's split-axis valid extent is a RUNTIME value, so the two AIV lanes' extents "
+         "are not known at compile time. The popped tile therefore has to declare the transport's "
+         "full box — that is what places lane 1's band where the producer wrote it — rather than "
+         "the lane's own extent, and storing it would write the lane's padding as data.\n"
+         "Author one of these instead:\n"
+         "  * narrow after the crossing: run a vector op whose result carries the extent you want "
+         "stored (e.g. pl.fillpad(...) to define the padding, then pl.set_validshape(...)), and "
+         "store that\n"
+         "  * make the split-axis valid extent a compile-time constant, so the lanes can be "
+         "balanced and the extent can ride on the transport itself\n"
+         "  * keep the extent at or below the box half, so the second lane is empty";
+}
+
 CallPtr RebuildTpopWithHalvedShape(const CallPtr& call, int split_code, int split_dim,
                                    const ExprPtr& subblock_idx, const ExprPtr& lane_stride) {
+  // NOT widened for a runtime extent, unlike the boundary ops in
+  // LocalizeExplicitBoundaryValid. A hand-written tpop declares its own
+  // valid_shape and its consumers inherit that declaration, so widening the pop
+  // alone leaves each consumer writing a partial destination out of a full
+  // source — measured to produce wrong data on a2a3 for every extent except the
+  // two where the widening is a no-op. See
+  // tests/st/runtime/cross_core/test_cross_core_split_parity.py, whose
+  // xfailing params record what a runtime split-axis extent still gets wrong on
+  // this path.
   auto new_result_type = HalveTileShape(call->GetType(), split_dim, subblock_idx, lane_stride);
 
   std::vector<std::pair<std::string, std::any>> new_kwargs;
@@ -1119,6 +1157,12 @@ struct LocalizedTile {
   ExprPtr lane_extent;                     ///< clamp(V - idx*half, 0, half)
   ExprPtr joined_extent;                   ///< V, the pre-shard extent a gather restores
   std::shared_ptr<const TileType> before;  ///< the type before localization
+  /// The extent could NOT ride on the boundary op itself (see
+  /// WithFullSplitAxisValid): the shard keeps the full box so the transport
+  /// places lane 1's band correctly, and the extent lands on this consumer chain
+  /// instead. An op that READS the extent without producing a tile — a store —
+  /// has nowhere to put it and is rejected.
+  bool deferred = false;
 };
 
 }  // namespace
@@ -1281,26 +1325,33 @@ std::optional<std::pair<int64_t, int64_t>> StaticLaneExtents(const TypePtr& full
   return std::make_pair(extents->lane0, extents->lane1);
 }
 
+bool HasStaticLaneExtents(const TypePtr& full_type, int split_dim, const ExprPtr& lane_stride) {
+  return StaticLaneExtents(full_type, split_dim, lane_stride).has_value();
+}
+
 int ShardSplitCode(SplitMode mode, const TypePtr& full_type, int split_dim, const ExprPtr& lane_stride,
                    const std::string& op_name, const Span& span) {
   if (mode == SplitMode::None) return kSplitNone;
   auto tt = std::dynamic_pointer_cast<const TileType>(full_type);
   auto extents = ComputeLaneExtents(tt, split_dim, lane_stride);
-  // No compile-time lane extents (a runtime box, valid extent or stride): emit
-  // the even code, which is what this path emitted before the odd codes existed
-  // and what the device is measured to accept.
+  // No compile-time lane extents (a runtime box, valid extent or stride): the
+  // even code, which is exact only when the boundary tile carries the FULL
+  // split-axis box rather than the lane's extent. The producer transports the
+  // full box (PTO codegen widens every split tpush), so lane 1's band sits at
+  // the box half and the even code points pto-isa there; which lane holds how
+  // much data is carried by the tile's CONSUMERS, where no band offset depends
+  // on it. LocalizeExplicitBoundaryValid establishes that pairing for a
+  // pl.split_aiv region's boundary op (WithFullSplitAxisValid).
   //
-  // Reading pto-isa's pop suggests otherwise — it derives lane 1's band from the
-  // popped tile's runtime valid extent, so a runtime extent that leaves the
-  // lanes unequal (15 of a 16-wide axis gives 8 and 7) looks like it would need
-  // the odd code. The device says the even code is right: rejecting these
-  // boundaries was tried and it took down
-  // tests/st/runtime/cross_core/test_cross_core_split_parity.py, whose
-  // LEFT_RIGHT cases (lanes 8 / 7 and 8 / 1) pass an elementwise on-device
-  // comparison — re-verified by perturbing the golden on lane 1's columns
-  // alone, which does fail. Which reading is the contract is asked upstream in
-  // hw-native-sys/pto-isa#263; until that answers, the encoding follows the
-  // measured behaviour rather than the source reading.
+  // The pairing is what makes this safe. The even code beside a PER-LANE extent
+  // silently mis-places lane 1: a 16-row box valid to 12 leaves the lanes 8 and
+  // 4, and pto-isa reads lane 1's band at row 4 while the producer wrote it at
+  // row 8. A hand-written tile.tpop_from_aic still pairs this way and is still
+  // wrong for such an extent -- widening it alone regresses the device (see
+  // RebuildTpopWithHalvedShape). It went unnoticed for as long as it did
+  // because tests/st/runtime/cross_core/test_cross_core_split_parity.py fed
+  // both operands uniform constants, which makes every row and column of the
+  // product identical and any band offset indistinguishable.
   if (!extents.has_value()) return SplitCodeFor(mode, /*odd_extent=*/false);
 
   if (extents->lane0 == extents->lane1) return SplitCodeFor(mode, /*odd_extent=*/false);
@@ -1553,14 +1604,22 @@ std::vector<StmtPtr> LocalizeStmts(const std::vector<StmtPtr>& stmts, int split_
       INTERNAL_CHECK_SPAN(state.lane_index, call->span_)
           << "Internal error: a pl.split_aiv region with a partially-valid split axis has no "
              "tile.get_subblock_idx binding, so the per-lane extent cannot be materialized";
-      auto new_type = LocalizeShardValidForLane(shard, operand, split_dim, state.lane_index);
+      auto localized = LocalizeShardValidForLane(shard, operand, split_dim, state.lane_index);
       auto lane_extent =
-          tile_view_semantics::GetEffectiveTileView(*std::dynamic_pointer_cast<const TileType>(new_type))
+          tile_view_semantics::GetEffectiveTileView(*std::dynamic_pointer_cast<const TileType>(localized))
               .valid_shape[split_dim];
+      // Where the extent may LAND. It belongs on the shard itself only when the
+      // transport was verified to place both lanes' bands, which needs
+      // compile-time lane extents: pto-isa reads lane 1's band offset off this
+      // very tile, and the producer transported the full box. A runtime extent
+      // leaves the shard full-width and hands the lane's extent to the consumers
+      // below (see WithFullSplitAxisValid).
+      const bool deferred = !HasStaticLaneExtents(operand, split_dim, /*lane_stride=*/nullptr);
+      auto new_type = deferred ? WithFullSplitAxisValid(shard, split_dim) : localized;
       auto new_var = std::make_shared<Var>(assign->var_->name_hint_, new_type, assign->var_->span_);
       auto new_call = std::make_shared<Call>(call->op_, call->args_, call->kwargs_, new_type, call->span_);
       state.replacements[assign->var_.get()] = new_var;
-      state.tracked[new_var.get()] = LocalizedTile{lane_extent, operand_valid[split_dim], shard};
+      state.tracked[new_var.get()] = LocalizedTile{lane_extent, operand_valid[split_dim], shard, deferred};
       result.push_back(std::make_shared<AssignStmt>(new_var, new_call, assign->span_));
       continue;
     }
@@ -1660,6 +1719,11 @@ std::vector<StmtPtr> LocalizeStmts(const std::vector<StmtPtr>& stmts, int split_
       // the store on a non-empty lane. The tpop and the tfree stay
       // UNCONDITIONAL: both lanes must still pop and free the slot or the pipe
       // desynchronizes.
+      // A store of a DEFERRED boundary tile would write the transport's box, not
+      // the lane's data: the extent never got a consumer to land on.
+      if (IsOp(call, "tile.store")) {
+        RejectDeferredValidStore(source->deferred, call);
+      }
       if (IsOp(call, "tile.store") && !IsProvablyPositive(source->lane_extent)) {
         // The guard can be a plain IfStmt because a store's SSA result is a
         // destination-passing alias (see CollectChainedStoreDestinations). Only a

--- a/src/ir/transforms/utils/split_axis_utils.cpp
+++ b/src/ir/transforms/utils/split_axis_utils.cpp
@@ -43,6 +43,7 @@
 #include "pypto/ir/transforms/utils/mutable_copy.h"
 #include "pypto/ir/transforms/utils/transform_utils.h"
 #include "pypto/ir/type.h"
+#include "pypto/ir/type_inference.h"
 
 namespace pypto {
 namespace ir {
@@ -1333,6 +1334,20 @@ int ShardSplitCode(SplitMode mode, const TypePtr& full_type, int split_dim, cons
                    const std::string& op_name, const Span& span) {
   if (mode == SplitMode::None) return kSplitNone;
   auto tt = std::dynamic_pointer_cast<const TileType>(full_type);
+  // What the FIFO can carry at all. The boundary ops are checked when their type
+  // is deduced; a HAND-WRITTEN tile.tpush_to_aiv / tile.tpop_from_aic pair never
+  // goes through that deduction, and reaches the transport here instead. Both
+  // must obey the same contract, because it is pto-isa's geometry rather than a
+  // pass's convention: the pop derives its GM row stride and its lane offset
+  // from the popped tile's own valid extents, so a narrowed COLUMN extent
+  // mis-strides the read against the producer's full-box pitch (measured on
+  // a2a3: a [16, 16] boundary read back with valid_col 12 or 8 misses the
+  // golden, while 16 matches).
+  if (tt) {
+    CheckSplitBoundaryCarriesValid(op_name, tt->shape_,
+                                   tile_view_semantics::GetEffectiveTileView(*tt).valid_shape, split_dim,
+                                   /*halve=*/true, span);
+  }
   auto extents = ComputeLaneExtents(tt, split_dim, lane_stride);
   // No compile-time lane extents (a runtime box, valid extent or stride): the
   // even code, which is exact only when the boundary tile carries the FULL

--- a/src/ir/transforms/utils/split_axis_utils.cpp
+++ b/src/ir/transforms/utils/split_axis_utils.cpp
@@ -261,6 +261,18 @@ ExprPtr LocalizeTupleElementForSplit(const ExprPtr& tuple_expr, int dim, const E
   return std::make_shared<MakeTuple>(std::move(new_elements), tuple_expr->span_);
 }
 
+// Whether @p call fills a tile's PAD region, i.e. reads where the operand's valid
+// data ends in order to define everything past it. Such an op is the one kind of
+// consumer that cannot receive a deferred extent: its result is fully valid by
+// construction, so the extent has nowhere to land, and it would fill nothing.
+// `tile.set_validshape` to the full box looks the same in the type system but is
+// a relabel, not a fill — the author is declaring the padding to be data, which
+// is exactly what a deferred boundary hands them.
+bool FillsPadRegion(const CallPtr& call) {
+  return IsOp(call, "tile.fillpad") || IsOp(call, "tile.fillpad_inplace") ||
+         IsOp(call, "tile.fillpad_expand");
+}
+
 // A store must not read a boundary tile whose split-axis extent was left at the
 // transport's (see WithFullSplitAxisValid): that extent is the truth about the
 // FIFO band and a lie about how much of the lane's box is data.
@@ -1451,6 +1463,19 @@ struct LocalizeState {
 std::vector<StmtPtr> LocalizeStmts(const std::vector<StmtPtr>& stmts, int split_dim, const Span& span,
                                    LocalizeState& state);
 
+/// The tracked (localized or deferred) boundary tile this call reads, or null.
+const LocalizedTile* FindTrackedSource(const CallPtr& call, const LocalizeState& state) {
+  for (const auto& arg : call->args_) {
+    auto arg_var = AsVarLike(arg);
+    if (!arg_var) continue;
+    auto replaced = state.replacements.find(arg_var.get());
+    const Var* key = (replaced != state.replacements.end()) ? replaced->second.get() : arg_var.get();
+    auto it = state.tracked.find(key);
+    if (it != state.tracked.end()) return &it->second;
+  }
+  return nullptr;
+}
+
 /// Recurse into a nested body, preserving its statement kind.
 StmtPtr LocalizeNestedBody(const StmtPtr& body, int split_dim, const Span& span, LocalizeState& state) {
   if (!body) return body;
@@ -1582,6 +1607,20 @@ std::vector<StmtPtr> LocalizeStmts(const std::vector<StmtPtr>& stmts, int split_
       continue;
     }
 
+    // A store whose result is ignored is an EvalStmt, so the AssignStmt walk below
+    // never sees it — but it reads the boundary tile's extent just the same, and
+    // a deferred one would put the transport's padding in the output.
+    if (auto eval = std::dynamic_pointer_cast<const EvalStmt>(stmt)) {
+      if (auto eval_call = AsCall(eval->expr_);
+          eval_call && eval_call->op_ && IsOp(eval_call, "tile.store")) {
+        if (const LocalizedTile* eval_source = FindTrackedSource(eval_call, state)) {
+          RejectDeferredValidStore(eval_source->deferred, eval_call);
+        }
+      }
+      result.push_back(stmt);
+      continue;
+    }
+
     auto assign = std::dynamic_pointer_cast<const AssignStmt>(stmt);
     auto call = assign ? AsCall(assign->value_) : nullptr;
     if (!assign || !call || !call->op_) {
@@ -1640,18 +1679,7 @@ std::vector<StmtPtr> LocalizeStmts(const std::vector<StmtPtr>& stmts, int split_
     }
 
     // --- Consumers: carry the per-lane extent, or say why we cannot. ---------
-    const LocalizedTile* source = nullptr;
-    for (const auto& arg : call->args_) {
-      auto arg_var = AsVarLike(arg);
-      if (!arg_var) continue;
-      auto replaced = state.replacements.find(arg_var.get());
-      const Var* key = (replaced != state.replacements.end()) ? replaced->second.get() : arg_var.get();
-      auto it = state.tracked.find(key);
-      if (it != state.tracked.end()) {
-        source = &it->second;
-        break;
-      }
-    }
+    const LocalizedTile* source = FindTrackedSource(call, state);
     // tile.aic_gather is the region's EXIT: it re-joins the two lanes' bands and
     // hands a FULL tile back to the cube. This is the one place the join can be
     // typed correctly, because it is the only place the lanes' TRUE extents are
@@ -1766,6 +1794,24 @@ std::vector<StmtPtr> LocalizeStmts(const std::vector<StmtPtr>& stmts, int split_
       result.push_back(stmt);
       continue;
     }
+
+    // A pad FILL is the one consumer that reads where the lane's data ends. Its
+    // result is fully valid by construction, so it hits the widen shortcut below
+    // and the deferred extent would be dropped — leaving the fill with nothing to
+    // do and the transport's padding declared as data.
+    CHECK_SPAN(!(source->deferred && FillsPadRegion(call)), call->span_)
+        << call->op_->name_
+        << ": this fills the padding of a Cube -> Vector boundary tile whose split-axis valid extent "
+           "is a RUNTIME value. The boundary has to declare the transport's full box (that is what "
+           "places lane 1's band where the producer wrote it), so by the time the fill runs there is "
+           "no per-lane boundary left to fill up to, and it would define nothing.\n"
+        << "Author one of these instead:\n"
+        << "  * fill the padding on the CUBE side, before the crossing: pl.fillpad(acc) ahead of "
+           "pl.aiv_shard(acc), so the transported box carries defined padding\n"
+        << "  * put the lane's own compute first — any op that passes valid_shape through (a cast, an "
+           "elementwise) materializes the lane extent, and a fill after it works normally\n"
+        << "  * make the split-axis valid extent a compile-time constant, so it rides the boundary "
+           "itself";
 
     // A consumer that WIDENS the logical region back to the whole physical box
     // (a set_validshape to the full extent) deliberately drops the per-lane

--- a/tests/st/codegen/dsl/test_split_odd_axis_codegen.py
+++ b/tests/st/codegen/dsl/test_split_odd_axis_codegen.py
@@ -128,6 +128,31 @@ def explicit_region_odd_box(
     return out
 
 
+@pl.jit
+def runtime_tail_rows(
+    a: pl.Tensor[[ROWS, K], pl.BF16],
+    w: pl.Tensor[[COLS, K], pl.BF16],
+    vt: pl.Tensor[[1], pl.INDEX],
+    out: pl.Out[pl.Tensor[[ROWS, COLS], pl.FP32]],
+) -> pl.Tensor[[ROWS, COLS], pl.FP32]:
+    """A RUNTIME row extent across the boundary: the lanes cannot be compared.
+
+    ``clamp(v - lane * 8, 0, 8)`` is 8 / 4 for ``v = 12`` and 8 / 8 for ``v = 16``
+    — the compiler cannot tell which, so it cannot pick a code that places lane 1
+    at its extent. The boundary op keeps the FULL box instead, which is where the
+    producer wrote lane 1's rows, and the extent rides on the consumers.
+    """
+    v: pl.Scalar[pl.INDEX] = pl.tensor.read(vt, [0])
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="runtime_tail"):
+        a_tile = pl.slice(a, [ROWS, K], [0, 0], valid_shape=[v, K])
+        acc = pl.matmul(a_tile, w[0:COLS, 0:K], b_trans=True, out_dtype=pl.FP32)
+        for aiv_id in pl.split_aiv(2, mode=pl.SplitMode.UP_DOWN):
+            shard = pl.aiv_shard(acc)
+            scaled = pl.mul(shard, 2.0)
+            out[aiv_id * HALF : aiv_id * HALF + HALF, 0:COLS] = scaled
+    return out
+
+
 def _args(valid_m: int):
     return [
         torch.randn(valid_m, K, dtype=torch.bfloat16),
@@ -262,6 +287,54 @@ def test_explicit_region_odd_box_localizes_the_per_lane_extent():
     # clamp(17 - aiv_id * 9, 0, 9) -> 9 and 8, on a 9-row box.
     assert re.search(r"pl\.const\(17, pl\.INDEX\)[^]]*?pl\.const\(9, pl\.INDEX\)", aiv), aiv
     assert re.search(r"pl\.tile\.store\([^)]*\* 9", aiv), aiv
+
+
+@pytest.fixture(scope="session")
+def runtime_tail_pto(tmp_path_factory) -> str:
+    """Codegen-only .pto for the runtime-extent kernel."""
+    dump_dir = tmp_path_factory.mktemp("split_runtime_tail")
+    cfg = RunConfig(platform="a2a3", codegen_only=True, save_kernels=True, save_kernels_dir=str(dump_dir))
+    error: Exception | None = None
+    try:
+        runtime_tail_rows(
+            torch.randn(ROWS, K, dtype=torch.bfloat16),
+            torch.randn(COLS, K, dtype=torch.bfloat16),
+            torch.tensor([12], dtype=torch.int64),
+            torch.empty(ROWS, COLS, dtype=torch.float32),
+            config=cfg,
+        )
+    except Exception as e:  # noqa: BLE001 - see odd_rows_pto
+        error = e
+    ptos = sorted(dump_dir.rglob("*.pto"))
+    assert ptos, f"codegen emitted no .pto under {dump_dir}; compile raised: {error!r}"
+    return ptos[0].read_text()
+
+
+def test_runtime_extent_pops_the_full_box(runtime_tail_pto):
+    """The per-lane extent must NOT reach the pop.
+
+    pto-isa reads lane 1's band offset off the popped tile's own split-axis
+    extent while the producer transports the full physical box, so a pop
+    declaring ``clamp(v - 8, 0, 8)`` sends lane 1 to row ``v - 8`` — four rows
+    early for ``v = 12``, and silently, since nothing else disagrees. A pop of
+    the full box carries no operands at all and lands on the box half.
+    """
+    aiv = _pto_half(runtime_tail_pto, "aiv")
+
+    assert re.search(r"pto\.tpop_from_aic \{split = 1\}", aiv), aiv
+    assert "pto.tpop_from_aic(" not in aiv, f"the pop must carry no per-lane extent:\n{aiv}"
+
+
+def test_runtime_extent_lands_on_the_first_consumer(runtime_tail_pto):
+    """Widening the pop must not LOSE the extent — it moves one op downstream."""
+    aiv = _pto_half(runtime_tail_pto, "aiv")
+
+    # clamp(v - lane * 8, 0, 8), materialized for the consumer rather than the pop.
+    assert re.search(r"arith\.minsi", aiv), aiv
+    assert re.search(r"arith\.maxsi", aiv), aiv
+    consumer = re.search(r"pto\.alloc_tile[^\n]*valid_row = (%\w+)", aiv)
+    assert consumer, f"no consumer tile carries a computed valid_row:\n{aiv}"
+    assert not consumer.group(1).startswith("%c"), f"consumer extent is a constant:\n{aiv}"
 
 
 if __name__ == "__main__":

--- a/tests/st/codegen/dsl/test_split_odd_axis_codegen.py
+++ b/tests/st/codegen/dsl/test_split_odd_axis_codegen.py
@@ -153,6 +153,43 @@ def runtime_tail_rows(
     return out
 
 
+@pl.jit
+def runtime_tail_fillpad_first(
+    a: pl.Tensor[[ROWS, K], pl.BF16],
+    w: pl.Tensor[[COLS, K], pl.BF16],
+    vt: pl.Tensor[[1], pl.INDEX],
+    out: pl.Out[pl.Tensor[[ROWS, COLS], pl.FP32]],
+) -> pl.Tensor[[ROWS, COLS], pl.FP32]:
+    """A pad fill straight off the boundary, with nothing to fill up to."""
+    v: pl.Scalar[pl.INDEX] = pl.tensor.read(vt, [0])
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="fill_first"):
+        a_tile = pl.slice(a, [ROWS, K], [0, 0], valid_shape=[v, K])
+        acc = pl.matmul(a_tile, w[0:COLS, 0:K], b_trans=True, out_dtype=pl.FP32)
+        for aiv_id in pl.split_aiv(2, mode=pl.SplitMode.UP_DOWN):
+            shard = pl.aiv_shard(acc)
+            padded = pl.fillpad(shard, pad_value=pl.PadValue.zero)
+            out[aiv_id * HALF : aiv_id * HALF + HALF, 0:COLS] = padded
+    return out
+
+
+@pl.jit
+def runtime_tail_store_first(
+    a: pl.Tensor[[ROWS, K], pl.BF16],
+    w: pl.Tensor[[COLS, K], pl.BF16],
+    vt: pl.Tensor[[1], pl.INDEX],
+    out: pl.Out[pl.Tensor[[ROWS, COLS], pl.FP32]],
+) -> pl.Tensor[[ROWS, COLS], pl.FP32]:
+    """The boundary tile stored directly, with no consumer to carry the extent."""
+    v: pl.Scalar[pl.INDEX] = pl.tensor.read(vt, [0])
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="store_first"):
+        a_tile = pl.slice(a, [ROWS, K], [0, 0], valid_shape=[v, K])
+        acc = pl.matmul(a_tile, w[0:COLS, 0:K], b_trans=True, out_dtype=pl.FP32)
+        for aiv_id in pl.split_aiv(2, mode=pl.SplitMode.UP_DOWN):
+            shard = pl.aiv_shard(acc)
+            out[aiv_id * HALF : aiv_id * HALF + HALF, 0:COLS] = shard
+    return out
+
+
 def _args(valid_m: int):
     return [
         torch.randn(valid_m, K, dtype=torch.bfloat16),
@@ -335,6 +372,41 @@ def test_runtime_extent_lands_on_the_first_consumer(runtime_tail_pto):
     consumer = re.search(r"pto\.alloc_tile[^\n]*valid_row = (%\w+)", aiv)
     assert consumer, f"no consumer tile carries a computed valid_row:\n{aiv}"
     assert not consumer.group(1).startswith("%c"), f"consumer extent is a constant:\n{aiv}"
+
+
+def _runtime_tail_args(v: int):
+    return [
+        torch.randn(ROWS, K, dtype=torch.bfloat16),
+        torch.randn(COLS, K, dtype=torch.bfloat16),
+        torch.tensor([v], dtype=torch.int64),
+        torch.empty(ROWS, COLS, dtype=torch.float32),
+    ]
+
+
+def test_runtime_extent_rejects_a_pad_fill_at_the_boundary():
+    """The extent has to land on a consumer -- a pad fill is not one.
+
+    ``tile.fillpad`` reads where the lane's data ENDS, and its result is fully
+    valid by construction. Off a boundary that carries the transport's box it
+    would fill nothing and hand the padding on as data, so it is refused with the
+    two authoring routes that do work.
+    """
+    with pytest.raises(ValueError) as exc:
+        runtime_tail_fillpad_first(*_runtime_tail_args(12), config=RunConfig(platform="a2a3"))
+
+    message = str(exc.value)
+    assert "fills the padding of a Cube -> Vector boundary tile" in message, message
+    assert "pl.fillpad(acc) ahead of pl.aiv_shard(acc)" in message, message
+
+
+def test_runtime_extent_rejects_a_direct_store_of_the_boundary():
+    """Storing the boundary tile itself would write the transport's padding."""
+    with pytest.raises(ValueError) as exc:
+        runtime_tail_store_first(*_runtime_tail_args(12), config=RunConfig(platform="a2a3"))
+
+    message = str(exc.value)
+    assert "consumes a Cube -> Vector boundary tile directly" in message, message
+    assert "narrow after the crossing" in message, message
 
 
 if __name__ == "__main__":

--- a/tests/st/runtime/cross_core/test_cross_core_column_extent_carrier.py
+++ b/tests/st/runtime/cross_core/test_cross_core_column_extent_carrier.py
@@ -1,0 +1,170 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""What a Cube -> Vector boundary can carry in its COLUMN extent.
+
+The column is not a free field. The FIFO slot is written at the producer's
+PHYSICAL column pitch, while pto-isa rebuilds the read geometry from the popped
+tile's own extents (``gmStrideR = validCol``, doubled for the left-right codes;
+``subAIVOffset`` likewise scales by ``validCol``). A narrowed column therefore
+mis-strides the read -- unless codegen transports the full box and restores the
+logical extents afterwards, which is what it does for a STATIC narrowing
+(``use_full_box`` + ``pto.treshape`` in ``MakeTpopCodegenPTO``).
+
+So exactly one narrowed-column shape has a carrier, and this probe pins it from
+both sides: the static narrowing is carried, and the two shapes that would need
+``treshape`` to express something it cannot are rejected with their span. The
+operands are ramps (``a[i,k] = i+1``, ``b[k,j] = j+1``) so that every row AND
+column of the product is distinct -- uniform operands make a mis-stride
+indistinguishable from a correct read, which is how this went unnoticed.
+
+The runtime-valued and LEFT_RIGHT narrowings are the other two no-carrier shapes;
+they are covered by ``test_cross_core_split_parity.py``.
+"""
+
+from typing import Any
+
+import pypto.language as pl
+import pytest
+import torch
+from harness.core.harness import DataType, PTOTestCase, TensorSpec
+
+ROWS, COLS = 16, 16
+SLOT = ROWS * COLS * 4
+BUF = SLOT * 4
+
+
+def _row_ramp() -> torch.Tensor:
+    return torch.arange(1, 17, dtype=torch.bfloat16).reshape(16, 1).expand(16, 16).contiguous()
+
+
+def _col_ramp() -> torch.Tensor:
+    return torch.arange(1, 17, dtype=torch.bfloat16).expand(16, 16).contiguous()
+
+
+def _program(vr: int, vc: int) -> Any:
+    @pl.program
+    class P:
+        @pl.function(type=pl.FunctionType.AIC, attrs={"split": pl.SplitMode.UP_DOWN})
+        def cube_producer(
+            self,
+            a: pl.Tensor[[ROWS, COLS], pl.BF16],
+            b: pl.Tensor[[ROWS, COLS], pl.BF16],
+            output: pl.Out[pl.Tensor[[ROWS, COLS], pl.FP32]],
+        ):
+            peer = pl.import_peer_buffer(name="slot_buf", peer_func="vector_consumer")
+            pl.aic_initialize_pipe(dir_mask=1, slot_size=SLOT, c2v_consumer_buf=peer)
+            a_mat: pl.Tile[[ROWS, COLS], pl.BF16, pl.Mem.Mat] = pl.load(
+                a, [0, 0], [ROWS, COLS], target_memory=pl.MemorySpace.Mat
+            )
+            b_mat: pl.Tile[[ROWS, COLS], pl.BF16, pl.Mem.Mat] = pl.load(
+                b, [0, 0], [ROWS, COLS], target_memory=pl.MemorySpace.Mat
+            )
+            a_left: pl.Tile[[ROWS, COLS], pl.BF16, pl.Mem.Left] = pl.move(
+                a_mat, target_memory=pl.MemorySpace.Left
+            )
+            b_right: pl.Tile[[ROWS, COLS], pl.BF16, pl.Mem.Right] = pl.move(
+                b_mat, target_memory=pl.MemorySpace.Right
+            )
+            acc: pl.Tile[[ROWS, COLS], pl.FP32] = pl.matmul(a_left, b_right)
+            narrowed: pl.Tile[[ROWS, COLS], pl.FP32, pl.Mem.Acc, pl.TileView(valid_shape=[vr, vc])] = (
+                pl.tile.set_validshape(acc, vr, vc)
+            )
+            pl.tpush_to_aiv(narrowed, split=1)
+
+        @pl.function(type=pl.FunctionType.AIV, attrs={"split": pl.SplitMode.UP_DOWN})
+        def vector_consumer(
+            self,
+            a: pl.Tensor[[ROWS, COLS], pl.BF16],
+            b: pl.Tensor[[ROWS, COLS], pl.BF16],
+            output: pl.Out[pl.Tensor[[ROWS, COLS], pl.FP32]],
+        ) -> pl.Tensor[[ROWS, COLS], pl.FP32]:
+            buf = pl.reserve_buffer(name="slot_buf", size=BUF, base=0x2000)
+            pl.aiv_initialize_pipe(dir_mask=1, slot_size=SLOT, c2v_consumer_buf=buf)
+            popped: pl.Tile[[ROWS, COLS], pl.FP32, pl.Mem.Vec, pl.TileView(valid_shape=[vr, vc])] = (
+                pl.tpop_from_aic(split=1)
+            )
+            incremented: pl.Tile[[ROWS, COLS], pl.FP32] = pl.add(popped, 1.0)
+            pl.tfree_to_aic(popped)
+            return pl.store(incremented, [0, 0], output)
+
+        @pl.function(type=pl.FunctionType.Group, attrs={"split": pl.SplitMode.UP_DOWN})
+        def group_func(
+            self,
+            a: pl.Tensor[[ROWS, COLS], pl.BF16],
+            b: pl.Tensor[[ROWS, COLS], pl.BF16],
+            output: pl.Out[pl.Tensor[[ROWS, COLS], pl.FP32]],
+        ) -> pl.Tensor[[ROWS, COLS], pl.FP32]:
+            self.cube_producer(a, b, output)
+            return self.vector_consumer(a, b, output)
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def main(
+            self,
+            a: pl.Tensor[[ROWS, COLS], pl.BF16],
+            b: pl.Tensor[[ROWS, COLS], pl.BF16],
+            output: pl.Out[pl.Tensor[[ROWS, COLS], pl.FP32]],
+        ) -> pl.Tensor[[ROWS, COLS], pl.FP32]:
+            return self.group_func(a, b, output)
+
+    return P
+
+
+class _Case(PTOTestCase):
+    __test__ = False
+
+    def __init__(self, vr, vc, *, platform=None, config=None):
+        self._vr, self._vc = vr, vc
+        super().__init__(config, platform=platform)
+
+    def get_name(self):
+        return f"zz_static_col_vr{self._vr}_vc{self._vc}"
+
+    def define_tensors(self):
+        return [
+            TensorSpec("a", [ROWS, COLS], DataType.BF16, init_value=_row_ramp),
+            TensorSpec("b", [ROWS, COLS], DataType.BF16, init_value=_col_ramp),
+            TensorSpec("output", [ROWS, COLS], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self):
+        return _program(self._vr, self._vc)
+
+    def compute_expected(self, tensors, params=None):
+        mm = torch.matmul(tensors["a"].float(), tensors["b"].float())
+        tensors["output"][:] = float("nan")
+        tensors["output"][: self._vr, : self._vc] = mm[: self._vr, : self._vc] + 1.0
+
+
+@pytest.mark.platforms("a2a3")
+@pytest.mark.parametrize("platform", [pytest.param("a2a3", id="a2a3")])
+@pytest.mark.parametrize("vr,vc", [(16, 16), (16, 12), (16, 8)], ids=["full", "vc12", "vc8"])
+def test_static_narrowed_column_is_carried(test_runner, vr, vc, platform):
+    """A STATIC column narrowing rides the full-box transport and is restored."""
+    result = test_runner.run(_Case(vr, vc, platform=platform))
+    assert result.passed, f"static (VR={vr},VC={vc}): {result.error}"
+
+
+@pytest.mark.platforms("a2a3")
+@pytest.mark.parametrize("platform", [pytest.param("a2a3", id="a2a3")])
+def test_per_lane_row_with_narrowed_column_is_rejected(test_runner, platform):
+    """Both axes narrowed has no carrier: treshape rebuilds them from one type.
+
+    The per-lane row extent rides on the TPOP valid_row operand; the narrowed
+    column can only come back through ``pto.treshape``, which carries no operands
+    and rewrites BOTH axes -- overwriting the row the lane needs.
+    """
+    result = test_runner.run(_Case(8, 12, platform=platform))
+
+    assert not result.passed, "a per-lane row beside a narrowed column must not compile"
+    assert "narrowed column extent" in result.error, result.error
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/st/runtime/cross_core/test_cross_core_dynamic_valid_shape.py
+++ b/tests/st/runtime/cross_core/test_cross_core_dynamic_valid_shape.py
@@ -21,7 +21,7 @@ from pypto.runtime.runner import RunConfig
 ROWS = 16
 COLS = 16
 VALID_ROWS = 8
-VALID_COLS = 12
+VALID_COLS = COLS  # the column extent is pinned to the physical box by the FIFO transport
 SLOT_SIZE_BYTES = ROWS * COLS * 4
 BUFFER_SIZE_BYTES = SLOT_SIZE_BYTES * 4
 
@@ -113,7 +113,7 @@ class C2VDynamicTpopValidShapeTestCase(PTOTestCase):
                     [ROWS, COLS],
                     pl.FP32,
                     pl.Mem.Vec,
-                    pl.TileView(valid_shape=[valid_rows, valid_cols]),
+                    pl.TileView(valid_shape=[valid_rows, VALID_COLS]),
                 ] = pl.tpop_from_aic(split=1)
                 incremented: pl.Tile[[ROWS, COLS], pl.FP32] = pl.add(popped, 1.0)
                 pl.tfree_to_aic(popped)
@@ -222,8 +222,8 @@ class C2VDynamicTpushValidShapeTestCase(PTOTestCase):
                     [ROWS, COLS],
                     pl.FP32,
                     pl.Mem.Acc,
-                    pl.TileView(valid_shape=[valid_rows, valid_cols]),
-                ] = pl.tile.set_validshape(acc, valid_rows, valid_cols)
+                    pl.TileView(valid_shape=[valid_rows, VALID_COLS]),
+                ] = pl.tile.set_validshape(acc, valid_rows, VALID_COLS)
                 pl.tpush_to_aiv(narrowed, split=1)
 
             @pl.function(type=pl.FunctionType.AIV, attrs={"split": pl.SplitMode.UP_DOWN})
@@ -250,7 +250,7 @@ class C2VDynamicTpushValidShapeTestCase(PTOTestCase):
                     [ROWS, COLS],
                     pl.FP32,
                     pl.Mem.Vec,
-                    pl.TileView(valid_shape=[valid_rows, valid_cols]),
+                    pl.TileView(valid_shape=[valid_rows, VALID_COLS]),
                 ] = pl.tpop_from_aic(split=1)
                 incremented: pl.Tile[[ROWS, COLS], pl.FP32] = pl.add(popped, 1.0)
                 pl.tfree_to_aic(popped)

--- a/tests/st/runtime/cross_core/test_cross_core_split_parity.py
+++ b/tests/st/runtime/cross_core/test_cross_core_split_parity.py
@@ -9,11 +9,20 @@
 
 """Cross-core 1C2V split runtime parity probes.
 
-These probes exercise ``UP_DOWN`` and ``LEFT_RIGHT`` splits on an even static
-[16, 16] tile with the runtime ``valid_shape`` swept through every parity
-regime (small / below-half / at-half / above-half / near-full):
+These probes exercise an ``UP_DOWN`` split on an even static [16, 16] tile with
+the runtime ``valid_row`` swept through every parity regime (small / below-half
+/ at-half / above-half / near-full):
 
-  VR/VC ∈ {1, 7, 8, 9, 15}
+  VR ∈ {1, 7, 8, 9, 12, 15}
+
+The COLUMN extent is not swept, and is not a free field: the FIFO slot is
+written at the producer's physical column pitch and pto-isa rebuilds the read
+geometry from the popped tile's own ``validCol`` (``gmStrideR = validCol``,
+doubled for the left-right codes). A narrowed column therefore mis-strides the
+read on either mode, and on ``LEFT_RIGHT`` it is the split axis as well, so it
+would have to differ per lane -- which nothing can express. That shape is
+rejected now, and ``test_left_right_narrowed_column_is_rejected`` pins the
+diagnostic.
 
 For each subblock, ``SplitVectorKernel``'s ``LocalizeValidDimForSplit`` computes
 the per-subblock valid extent as
@@ -107,8 +116,8 @@ def _build_c2v_ud_program() -> Any:
                 [ROWS, COLS],
                 pl.FP32,
                 pl.Mem.Acc,
-                pl.TileView(valid_shape=[valid_rows, valid_cols]),
-            ] = pl.tile.set_validshape(acc, valid_rows, valid_cols)
+                pl.TileView(valid_shape=[valid_rows, COLS]),
+            ] = pl.tile.set_validshape(acc, valid_rows, COLS)
             pl.tpush_to_aiv(narrowed, split=1)
 
         @pl.function(type=pl.FunctionType.AIV, attrs={"split": pl.SplitMode.UP_DOWN})
@@ -135,7 +144,7 @@ def _build_c2v_ud_program() -> Any:
                 [ROWS, COLS],
                 pl.FP32,
                 pl.Mem.Vec,
-                pl.TileView(valid_shape=[valid_rows, valid_cols]),
+                pl.TileView(valid_shape=[valid_rows, COLS]),
             ] = pl.tpop_from_aic(split=1)
             incremented: pl.Tile[[ROWS, COLS], pl.FP32] = pl.add(popped, 1.0)
             pl.tfree_to_aic(popped)
@@ -358,15 +367,6 @@ _UP_DOWN_PARITY_CASES = [
     (15, 16, "vr15", True),
 ]
 
-_LEFT_RIGHT_PARITY_CASES = [
-    (16, 1, "vc1", True),
-    (16, 7, "vc7", True),
-    (16, 8, "vc8", False),
-    (16, 9, "vc9", True),
-    (16, 12, "vc12", True),
-    (16, 15, "vc15", True),
-]
-
 
 def _sweep_params(cases):
     """(vr, vc) params, with the known-unplaceable extents marked xfail."""
@@ -394,11 +394,23 @@ class TestSplitParityRuntime:
 
     @pytest.mark.platforms("a2a3")
     @pytest.mark.parametrize("platform", [pytest.param("a2a3", id="a2a3")])
-    @pytest.mark.parametrize("vr,vc", _sweep_params(_LEFT_RIGHT_PARITY_CASES))
-    def test_left_right_valid_shape_parity(self, test_runner, vr, vc, platform):
-        case = _C2VValidShapeParityCase(vr, vc, pl.SplitMode.LEFT_RIGHT, platform=platform)
+    def test_left_right_narrowed_column_is_rejected(self, test_runner, platform):
+        """LEFT_RIGHT narrows the SPLIT axis, which the transport cannot carry.
+
+        pto-isa reconstructs the producer's rectangle from the popped tile's own
+        column extent -- ``gmStrideR = 2 * validCol`` and
+        ``subAIVOffset = subBlockId * validCol`` -- so both the pitch and lane 1's
+        band only line up when ``validCol`` is the lane's full column box. A
+        narrowed column extent has no carrier at all, and used to compile into a
+        silently mis-strided read: on a2a3 this sweep passed for every VC only
+        because its operands were uniform constants.
+        """
+        case = _C2VValidShapeParityCase(ROWS, 9, pl.SplitMode.LEFT_RIGHT, platform=platform)
         result = test_runner.run(case)
-        assert result.passed, f"LEFT_RIGHT (VR={vr},VC={vc}) failed: {result.error}"
+
+        assert not result.passed, "a per-lane column extent must not compile"
+        assert "LEFT_RIGHT splits the column axis" in result.error, result.error
+        assert "mode=pl.SplitMode.UP_DOWN" in result.error, result.error
 
 
 # ---------------------------------------------------------------------------

--- a/tests/st/runtime/cross_core/test_cross_core_split_parity.py
+++ b/tests/st/runtime/cross_core/test_cross_core_split_parity.py
@@ -17,11 +17,18 @@ regime (small / below-half / at-half / above-half / near-full):
 
 For each subblock, ``SplitVectorKernel``'s ``LocalizeValidDimForSplit`` computes
 the per-subblock valid extent as
-``max(min(valid_dim - subblock_idx * half_dim, half_dim), 0)`` (see
-``src/ir/transforms/split_vector_kernel_pass.cpp:233``). The store
+``max(min(valid_dim - subblock_idx * half_dim, half_dim), 0)``. The store
 auto-adjusts its offset to the subblock-relative slot via ``AdjustOffsets``,
 so the user-written store offset stays ``[0, 0]`` and the compiler places
 subblock 0 at the origin and subblock 1 at the split-axis half.
+
+A RUNTIME extent never reaches the transport itself, though: pto-isa finds
+lane 1's band inside the slot from the popped tile's own split-axis extent, so
+a tile declaring ``clamp(VR - 8, 0, 8)`` would send lane 1 to row ``VR - 8``
+while the producer wrote its rows at row 8. The popped tile therefore declares
+the full box on the split axis (``split_axis::WithFullSplitAxisValid``) and the
+localized extent lands on its consumers. That is what the sweep below checks
+element by element -- which is why the operands must not be uniform.
 
 This is the canonical pattern users follow when they need to ship an odd
 extent (e.g. ``valid_rows = 17``) through ``tpush_to_aiv`` / ``tpop_from_aic``:
@@ -46,6 +53,20 @@ COLS = 16
 HALF = ROWS // 2
 SLOT_SIZE_BYTES = ROWS * COLS * 4
 BUFFER_SIZE_BYTES = SLOT_SIZE_BYTES * 4
+
+
+# Operands whose product varies on both axes -- see define_tensors below. Named
+# functions rather than tensor literals: golden_writer inlines a tensor
+# init_value only up to 100 elements, and extracts the SOURCE of a named
+# function, so these two must stay self-contained (no module-level names).
+def _row_ramp() -> torch.Tensor:
+    """``a[i, k] = i + 1`` on a [16, 16] BF16 box."""
+    return torch.arange(1, 17, dtype=torch.bfloat16).reshape(16, 1).expand(16, 16).contiguous()
+
+
+def _col_ramp() -> torch.Tensor:
+    """``b[k, j] = j + 1`` on a [16, 16] BF16 box."""
+    return torch.arange(1, 17, dtype=torch.bfloat16).expand(16, 16).contiguous()
 
 
 def _build_c2v_ud_program() -> Any:
@@ -276,9 +297,15 @@ class _C2VValidShapeParityCase(PTOTestCase):
         return f"cross_core_split_parity_{sm}_vr{self._valid_rows}_vc{self._valid_cols}"
 
     def define_tensors(self) -> list[TensorSpec]:
+        # a[i, k] = i + 1 and b[k, j] = j + 1 give C[i, j] = COLS * (i + 1) * (j + 1):
+        # distinct on every row AND every column. Uniform operands (the constants
+        # this probe used to carry) make every element of the product identical,
+        # which makes a lane whose FIFO band is read at the wrong offset
+        # indistinguishable from a correct one -- the exact defect this sweep
+        # exists to catch.
         return [
-            TensorSpec("a", [ROWS, COLS], DataType.BF16, init_value=1.0),
-            TensorSpec("b", [ROWS, COLS], DataType.BF16, init_value=2.0),
+            TensorSpec("a", [ROWS, COLS], DataType.BF16, init_value=_row_ramp),
+            TensorSpec("b", [ROWS, COLS], DataType.BF16, init_value=_col_ramp),
             TensorSpec(
                 "valid_shape",
                 [2],
@@ -304,23 +331,54 @@ class _C2VValidShapeParityCase(PTOTestCase):
 
 
 # Valid-shape parity sweep on box [16, 16]: covers below-half (1, 7), at-half
-# (8), above-half (9, 15) — the regimes that distinguish "subblock 1 no-op"
-# from "subblock 1 contributes a partial extent".
+# (8), above-half (9, 12, 15) — the regimes that distinguish "subblock 1 no-op"
+# from "subblock 1 contributes a partial extent". 12 is the deep tail: it leaves
+# the lanes 8 and 4, the widest gap the box partition can produce, so a lane 1
+# read at its own extent lands four rows (or columns) off.
+#
+# The xfailing params are the ones a HAND-WRITTEN ``tile.tpop_from_aic`` still
+# gets wrong on a2a3, and they were invisible until this probe stopped feeding
+# uniform operands. Its declared per-lane extent reaches the transport, so
+# pto-isa places lane 1's band at that extent instead of at the box half where
+# the producer wrote it; on LEFT_RIGHT a narrowed split-axis (column) extent
+# additionally collapses the pop's GM row gap, which is why even the
+# empty-lane-1 columns miss. Widening only the pop is not the fix here — the
+# consumers inherit the declared extent and then write partial destinations out
+# of a full source, which measures worse. A ``pl.split_aiv`` region has no such
+# problem: LocalizeExplicitBoundaryValid keeps the boundary op full-width and
+# moves the lane extent onto the consumers.
+_UNPLACEABLE = "runtime split-axis extent on a hand-written tpop: lane 1's band is placed at its own extent"
+
 _UP_DOWN_PARITY_CASES = [
-    (1, 16, "vr1"),
-    (7, 16, "vr7"),
-    (8, 16, "vr8"),
-    (9, 16, "vr9"),
-    (15, 16, "vr15"),
+    (1, 16, "vr1", False),
+    (7, 16, "vr7", False),
+    (8, 16, "vr8", False),
+    (9, 16, "vr9", True),
+    (12, 16, "vr12", True),
+    (15, 16, "vr15", True),
 ]
 
 _LEFT_RIGHT_PARITY_CASES = [
-    (16, 1, "vc1"),
-    (16, 7, "vc7"),
-    (16, 8, "vc8"),
-    (16, 9, "vc9"),
-    (16, 15, "vc15"),
+    (16, 1, "vc1", True),
+    (16, 7, "vc7", True),
+    (16, 8, "vc8", False),
+    (16, 9, "vc9", True),
+    (16, 12, "vc12", True),
+    (16, 15, "vc15", True),
 ]
+
+
+def _sweep_params(cases):
+    """(vr, vc) params, with the known-unplaceable extents marked xfail."""
+    return [
+        pytest.param(
+            vr,
+            vc,
+            id=name,
+            marks=[pytest.mark.xfail(strict=True, reason=_UNPLACEABLE)] if broken else [],
+        )
+        for vr, vc, name, broken in cases
+    ]
 
 
 class TestSplitParityRuntime:
@@ -328,11 +386,7 @@ class TestSplitParityRuntime:
 
     @pytest.mark.platforms("a2a3")
     @pytest.mark.parametrize("platform", [pytest.param("a2a3", id="a2a3")])
-    @pytest.mark.parametrize(
-        "vr,vc",
-        [c[:2] for c in _UP_DOWN_PARITY_CASES],
-        ids=[c[2] for c in _UP_DOWN_PARITY_CASES],
-    )
+    @pytest.mark.parametrize("vr,vc", _sweep_params(_UP_DOWN_PARITY_CASES))
     def test_up_down_valid_shape_parity(self, test_runner, vr, vc, platform):
         case = _C2VValidShapeParityCase(vr, vc, pl.SplitMode.UP_DOWN, platform=platform)
         result = test_runner.run(case)
@@ -340,11 +394,7 @@ class TestSplitParityRuntime:
 
     @pytest.mark.platforms("a2a3")
     @pytest.mark.parametrize("platform", [pytest.param("a2a3", id="a2a3")])
-    @pytest.mark.parametrize(
-        "vr,vc",
-        [c[:2] for c in _LEFT_RIGHT_PARITY_CASES],
-        ids=[c[2] for c in _LEFT_RIGHT_PARITY_CASES],
-    )
+    @pytest.mark.parametrize("vr,vc", _sweep_params(_LEFT_RIGHT_PARITY_CASES))
     def test_left_right_valid_shape_parity(self, test_runner, vr, vc, platform):
         case = _C2VValidShapeParityCase(vr, vc, pl.SplitMode.LEFT_RIGHT, platform=platform)
         result = test_runner.run(case)

--- a/tests/st/runtime/cross_core/test_cross_core_tpush_valid_shape.py
+++ b/tests/st/runtime/cross_core/test_cross_core_tpush_valid_shape.py
@@ -82,8 +82,8 @@ class C2VTpushValidShapeTestCase(PTOTestCase):
                     [ROWS, COLS],
                     pl.FP32,
                     pl.Mem.Acc,
-                    pl.TileView(valid_shape=[valid_rows, valid_cols]),
-                ] = pl.tile.set_validshape(acc, valid_rows, valid_cols)
+                    pl.TileView(valid_shape=[valid_rows, COLS]),
+                ] = pl.tile.set_validshape(acc, valid_rows, COLS)
                 pl.tpush_to_aiv(narrowed, split=1)
 
             @pl.function(type=pl.FunctionType.AIV, attrs={"split": pl.SplitMode.UP_DOWN})
@@ -111,7 +111,7 @@ class C2VTpushValidShapeTestCase(PTOTestCase):
                     [ROWS, COLS],
                     pl.FP32,
                     pl.Mem.Vec,
-                    pl.TileView(valid_shape=[valid_rows, valid_cols]),
+                    pl.TileView(valid_shape=[valid_rows, COLS]),
                 ] = pl.tpop_from_aic(split=1)
                 incremented: pl.Tile[[ROWS, COLS], pl.FP32] = pl.add(popped, 1.0)
                 pl.tfree_to_aic(popped)


### PR DESCRIPTION
## What

A `pl.split_aiv(..., mode=UP_DOWN)` region whose boundary tile carries a **runtime** split-axis valid extent silently handed lane 1 the wrong rows. Over a 16-row box valid to `V`, lane 1 read its band starting at row `V - 8` instead of row 8 — re-emitting a duplicate of lane 0's tail over the genuinely valid rows `[8, V)`, so the kernel's real answer for those rows was lost. No diagnostic at any layer.

## Why

pto-isa finds lane 1's band inside the Cube→Vector FIFO slot from the **popped tile's own** split-axis valid extent (`e1 * pitch` for the even codes), while PTO codegen always transports the producer's **full physical box** (`EmitTpushTransportValidShape` widens every split tpush). The two only agree when the compiler could compare the lanes at compile time — which is exactly what the balanced partition (`ResolveLaneStride`) and the odd split codes exist to arrange.

A runtime extent has no compile-time lanes, so nothing arranged it, yet `LocalizeExplicitBoundaryValid` still materialized `clamp(V - lane * half, 0, half)` onto the boundary op. `ShardSplitCode` returned the even code without a placeability check, and pto-isa read the per-lane extent as the band offset:

```
V = 12, box = 16  ->  lanes 8 and 4
                      lane 1's data is at row 8 (producer wrote the full box)
                      lane 1 reads at row 4   (e1 * pitch)
```

The two shapes that happen to be safe — fully valid (`e1 == half`) and short enough to leave lane 1 empty (`e1 == 0`) — are the common ones, which is why this went unnoticed.

## How

Such a boundary now declares the **full** split-axis box (`split_axis::WithFullSplitAxisValid`) and the lane's own extent rides on the boundary's consumers, where no band offset depends on it. That pairs exactly with the even code the transport already picks: the producer wrote the full box, so lane 1's band sits at the box half and the even code points there whatever the extent turns out to be. The pop then carries no valid-shape operands at all.

```mlir
; before -- the per-lane clamp reaches the pop, and pto-isa reads it as the offset
%5 = arith.minsi %3, %c8_i64
%sh__tile = pto.tpop_from_aic(%5, %c256_index) {split = 1}

; after -- the pop takes the box; the clamp lands on the cast's destination
%sh__tile = pto.tpop_from_aic {split = 1}
%f__tile  = pto.alloc_tile addr = ... valid_row = %5 valid_col = %c256_index
```

A store consuming the boundary tile directly is rejected with an actionable message instead: it reads the extent without producing a tile, so there is nowhere for the extent to land.

Two new helpers on `split_axis`: `HasStaticLaneExtents` (were the lanes comparable at compile time, i.e. did `ShardSplitCode` get to verify or refuse?) and `WithFullSplitAxisValid`.

## Verification

Device (a2a3), 16-row boundary, exact comparison against the torch reference:

| `valid_rows` | before | after |
| ------------ | ------ | ----- |
| 1, 7, 8, 16 | PASS | PASS |
| 9 | FAIL — out row 8 = ref row **1** | PASS |
| 12 | FAIL — out row 8 = ref row **4** | PASS |
| 13 | FAIL — out row 8 = ref row **5** | PASS |
| 15 | FAIL — out row 8 = ref row **7** | PASS |

- `tests/ut/`: 10278 passed, 3 skipped, 2 xfailed.
- `tests/st/runtime/cross_core/` on device: passes (see the xfail note below).
- Two new codegen tests in `test_split_odd_axis_codegen.py` pin the emission; both fail on a pre-fix build.

## Notes for the reviewer

**The parity probe was blind, and that is why the encoding was previously believed correct.** `test_cross_core_split_parity.py` fed both matmul operands uniform constants (`a = 1.0`, `b = 2.0`), which makes every element of the product identical — a band read at the wrong offset returns the same numbers. It now uses row/column ramps (`C[i,j] = K*(i+1)*(j+1)`) and sweeps the deep tail (12) as well. This also answers [pto-isa#263](https://github.com/hw-native-sys/pto-isa/issues/263): the source reading of `popVecTileFromGMFiFo` was right; the measurement that suggested otherwise was vacuous. The comments and docs that cited it are updated.

**A hand-written `tile.tpop_from_aic` is *not* fixed here, deliberately.** I tried the same widening on that path and it made the device worse: those consumers inherit the author's declared `valid_shape`, so widening only the pop leaves them writing partial destinations out of a full source, and on a2a3 that corrupted every extent except the two where the widening is a no-op — including cases that passed before. Rather than ship a regression, that path keeps today's behaviour and the affected regimes are marked **strict xfail** in the parity sweep (`vr9/12/15`; and `vc1/7/9/12/15`, since on LEFT_RIGHT a narrowed split-axis extent additionally collapses the pop's GM row gap). `RebuildTpopWithHalvedShape` carries a comment explaining why widening alone is not the fix there. Current sweep: 7 passed, 8 xfailed.

**Unrelated observation:** the pre-existing non-strict xfail `test_spmd.py::test_spmd_mixed_kernel` ("SPMD+MixedKernel precision issue under investigation") now xpasses. I have no baseline for it and did not attribute it to this change, so I left the marker alone.


---

## Follow-up commit: the LEFT_RIGHT half is now rejected, not miscompiled

Reviewing the residual `LEFT_RIGHT` failures against pto-isa's source
(`a2a3/TPush.hpp popVecTileFromGMFiFo`) showed they are a *different* defect from
the band placement above, and one the compiler already had a rule for:

```cpp
gmStrideR    = validCol;                      // doubled for the left-right codes
subAIVOffset = subBlockId * validRow * validCol;   // * validCol on LEFT_RIGHT
```

The slot is written at the producer's **physical** column pitch, so both of those
only reconstruct the producer's rectangle when `validCol` is the full box. A
narrowed column extent mis-strides the read on *either* mode — and on
`LEFT_RIGHT` it is the split axis as well, so it would have to differ per lane,
which nothing can express.

`CheckSplitBoundaryCarriesValid` has enforced exactly this since the boundary ops
were introduced, but only from `tile.aiv_shard` / `tile.aic_gather` **type
deduction**. A hand-written `tile.tpush_to_aiv` / `tile.tpop_from_aic` pair
carries its `split` as an attr and its type as an annotation, so it never reached
that deduction. The rule now also runs from `split_axis::ShardSplitCode`, which
every transport op passes through.

Measured on a2a3 with non-uniform operands, `[16, 16]` boundary, `UP_DOWN`:
`valid = (16, 16)` matches the golden; `(16, 12)` and `(16, 8)` do not. The
column is the *non-split* axis there, so that is the pitch alone — no lane
placement involved.

### Three probes were asserting that mis-strided kernels pass

Each declared a runtime column extent and only passed because its operands were
uniform constants:

| Probe | Was | Now |
| ----- | --- | --- |
| `cross_core_dynamic_valid_shape` | `VALID_COLS = 12` of a 16-col box — asserted a mis-strided kernel matches | column moves to the full box; its subject (the dynamic **row** extent) is untouched |
| `cross_core_tpush_valid_shape` | passed an already-full column extent as a runtime scalar | declared statically |
| `cross_core_split_parity` | swept `VC` over a `LEFT_RIGHT` split — the unrepresentable shape itself | one test asserting the diagnostic; the `UP_DOWN` sweep declares a full column |

**`cross_core_dynamic_valid_shape` is the one to look at closely**: correcting it
narrows what that probe covers (a static narrowed column is representable via the
full-box + `treshape` path, but not alongside the per-lane row extent this probe
exists for — `treshape` rebuilds both axes from one static type). I chose to keep
its dynamic row extent and give up the column narrowing; say the word if you'd
rather it kept a static narrowed column and dropped the dynamic row.

Remaining after this: `vr9`/`vr12`/`vr15` on the hand-written pop — the row-band
placement, still strict-xfail, unchanged by this commit.


### Column-extent contract: the full picture

Confirmed on device which narrowed-column shapes have a carrier, so the rejection
is not broader than the hardware requires:

| `[16,16]` C2V boundary | carrier | status |
| ---------------------- | ------- | ------ |
| column full | rides the transport unchanged | supported |
| column **static** narrowing, full rows | full-box transport + `pto.treshape` | supported — **verified on a2a3** (`(16,12)`, `(16,8)` match element for element) |
| column **runtime** narrowing | none — `treshape` takes no operands | rejected |
| column narrowed on `LEFT_RIGHT` | none — it is the split axis, so it would have to be per-lane | rejected |
| per-lane row **and** narrowed column | none — `treshape` rebuilds both axes from one static type | rejected |

The supported static narrowing had never been exercised with data that could
reveal a mis-stride, so `test_cross_core_column_extent_carrier.py` now pins it
(ramp operands), together with the per-lane-row + narrowed-column rejection.

`cross_core_dynamic_valid_shape` keeps its dynamic **row** extent, as intended —
that is a real carrier (the TPOP `valid_row` operand) and is what the probe
exists for.
