### PR TITLE
feat(distributed): share synthesized allreduce signals per data-buffer lineage

### DIFF
--- a/docs/en/dev/passes/41-synthesize_allreduce_signals.md
+++ b/docs/en/dev/passes/41-synthesize_allreduce_signals.md
@@ -33,27 +33,44 @@ data buffer.
 For every host-orchestration function:
 
 1. Collect existing variable names in the program.
-2. Visit direct `AssignStmt`, `EvalStmt`, and `ReturnStmt` forms of
-   `pld.tensor.allreduce`.
-3. Preserve calls that already pass an explicit signal argument.
-4. For calls that pass only the target tensor, allocate fresh generated names
-   for a private signal buffer and signal view.
-5. Insert statement-level bindings immediately before the allreduce call:
+2. Pre-scan the body: does it carry any `pld.tensor.allreduce` call, and does
+   any of those calls omit the signal argument?
+3. If the function has implicit-signal (single-argument) calls, group them by
+   the lineage of their data buffer (traced back through `pld.tensor.window` to
+   the `pld.tensor.alloc_window_buffer` LHS), and hoist one shared signal
+   binding per group to the top of the function body:
 
-```python
-__allreduce_signal_world_size_0 = pld.system.world_size()
-__allreduce_signal_buf_0: pl.Ptr = pld.tensor.alloc_window_buffer(__allreduce_signal_world_size_0 * core_num * pl.INT32.get_byte())
-__allreduce_signal_0 = pld.tensor.window(
-    __allreduce_signal_buf_0,
-    [__allreduce_signal_world_size_0, core_num],
-    dtype=pl.INT32,
-)
-data = pld.tensor.allreduce(data, __allreduce_signal_0, op=pld.ReduceOp.Sum)
-```
+    ```python
+    __allreduce_signal_world_size_0 = pld.system.world_size()
+    __allreduce_signal_buf_0: pl.Ptr = pld.tensor.alloc_window_buffer(__allreduce_signal_world_size_0 * core_num * pl.INT32.get_byte())
+    __allreduce_signal_0 = pld.tensor.window(
+        __allreduce_signal_buf_0,
+        [__allreduce_signal_world_size_0, core_num],
+        dtype=pl.INT32,
+    )
+    ```
 
-The generated signal shape is rank-2 `[world_size, core_num]`, and its byte
-allocation uses the same lane count. The default `core_num=1` preserves the
-previous representation and behavior.
+4. Rewrite every implicit-signal `pld.tensor.allreduce` call — including calls
+   inside `for` / `while` loops — to pass the shared signal:
+
+    ```python
+    data = pld.tensor.allreduce(data, __allreduce_signal_0, op=pld.ReduceOp.Sum)
+    ```
+
+5. Preserve calls that already pass an explicit signal argument unchanged;
+   return-position calls are still lifted to an assignment so host lowering can
+   dispatch them.
+
+The generated signal shape is rank-2 `[world_size, core_num]`, where `core_num`
+is the widest lane count requested by that lineage group's implicit-signal calls
+(the default `core_num=1` preserves the previous single-lane representation);
+the byte allocation uses the same lane count. One binding is shared per
+data-buffer lineage (device-coverage) group and reused by every implicit-signal
+call over that buffer — correct because the host builtin kernels self-clear
+their barrier cells after every call, so a reused signal is safe back-to-back
+and across loop iterations. Distinct data buffers get distinct signals, so
+implicit allreduces over different device subsets in one function do not merge
+into a single comm-domain scope.
 
 ## Print / Parse Round Trip
 
@@ -74,18 +91,16 @@ The pass raises `pypto::ValueError` when:
 - an allreduce call has a positional argument count other than `target` or
   `target, signal`,
 - an allreduce appears as a nested expression instead of a direct assignment,
-  expression statement, or return value,
-- an allreduce **that omits its signal** appears inside a `for` / `while` loop.
+  expression statement, or return value.
 
-The loop restriction applies only to a *synthesized* signal on the HOST rail:
-`SynthesizeAllReduceSignals` inserts the allocation immediately before the
-allreduce statement, which cannot be placed inside a dynamic loop (a fresh
-allocation per iteration under the same name, and every rank must land on the
-same symmetric window). Passing an explicit signal needs no synthesis, and the
-lowered kernel restores its cells to zero before returning, so an explicit
-signal may be carried across iterations. InCore composites lowered by
+Implicit-signal calls inside `for` / `while` loops are accepted: the shared
+signal for the call's data-buffer lineage is reused on every iteration, which
+is correct because the host builtin kernels
+(`builtin.tensor.allreduce` / `builtin.tensor.allreduce_ring`, lowered by
+`LowerHostTensorCollectives`) self-clear their barrier cells after
+every call via a credit-barrier epilogue. InCore composites lowered by
 [`LowerCompositeOps`](12-lower_composite_ops.md#barrier-signal-protocol) are
-loop-safe because that pass emits the self-clearing credit-barrier epilogue.
+loop-safe for the same reason — that pass emits the self-clearing epilogue.
 
 ## Pass Properties
 

--- a/docs/en/dev/passes/43-lower_host_tensor_collectives.md
+++ b/docs/en/dev/passes/43-lower_host_tensor_collectives.md
@@ -164,6 +164,11 @@ subset it must satisfy `root < participating device count`. The fully-dynamic
 "all device" domain cannot be checked at compile time (no device count is
 known there) — the same documented limitation as the signal-capacity check.
 
+Signals are reusable for the self-clearing host builtins: those kernels clear
+their barrier cells after every call (credit-barrier epilogue), so one
+synthesized or user-allocated signal can back any number of consecutive or
+loop-carried collective calls without re-allocation.
+
 `all_to_all_v`'s single-use Set(1)/wait≥1 signal cannot be reused across a
 `for`/`while` loop in `host_orch` — [`MaterializeCommDomainScopes`](42-materialize_comm_domain_scopes.md),
 which runs immediately before this pass, rejects that case up front (the same

--- a/docs/en/user/distributed/04-debugging.md
+++ b/docs/en/user/distributed/04-debugging.md
@@ -12,7 +12,6 @@ one rank while the cause is on another.
 | **Signal cell never reaches expected value** | Wrong `NotifyOp`: used `Set` instead of `AtomicAdd` for a multi-participant barrier | Use `AtomicAdd` when N ranks contribute to the same slot; use `Set` for 1:1 exchanges. |
 | **Shape mismatch at compile time** | `NR` (world size) used in type annotations without `pl.dynamic` | Wrap runtime-resolved dims in `pl.dynamic("NR")`. The compiler needs the name to bind the runtime value. |
 | **`TypeError` raised at dispatch** | IO buffer not `.share_memory_()` before `prepare()` — the child processes cannot see a buffer allocated after the fork | Call `.share_memory_()` on every host tensor passed to the worker, before `prepare()`. |
-| **Allreduce rejected inside loop** | HOST-rail allreduce that *omits* its signal is rejected inside a dynamic `for`/`while`: signal synthesis cannot allocate a fresh signal per iteration | Pass an explicit signal buffer — it is self-clearing and reusable across iterations — or hoist the call out of the loop. |
 
 ## Fatal Pitfalls
 

--- a/docs/zh/dev/passes/41-synthesize_allreduce_signals.md
+++ b/docs/zh/dev/passes/41-synthesize_allreduce_signals.md
@@ -29,26 +29,41 @@ allocation 处理，并放入 allreduce data buffer 所属的通信域。
 对每个 host-orchestration 函数：
 
 1. 收集当前 program 中已有变量名。
-2. 访问直接出现在 `AssignStmt`、`EvalStmt`、`ReturnStmt` 中的
-   `pld.tensor.allreduce`。
-3. 已经传入显式 signal 的调用保持不变。
-4. 对只传入 target tensor 的调用，生成 fresh 的私有 signal buffer 和
-   signal view 名字。
-5. 在 allreduce 之前插入普通 statement-level binding：
+2. 预扫描函数体：是否携带 `pld.tensor.allreduce` 调用，其中是否有省略
+   signal 参数的调用。
+3. 若函数存在隐式 signal（单参数）调用，则按数据 buffer 的血缘（lineage，
+   沿 `pld.tensor.window` 回溯到 `pld.tensor.alloc_window_buffer` 的 LHS）将
+   调用分组，并为每个分组把一个共享 signal binding（world_size /
+   alloc_window_buffer / window）提升到函数体顶部：
 
-```python
-__allreduce_signal_world_size_0 = pld.system.world_size()
-__allreduce_signal_buf_0: pl.Ptr = pld.tensor.alloc_window_buffer(__allreduce_signal_world_size_0 * core_num * pl.INT32.get_byte())
-__allreduce_signal_0 = pld.tensor.window(
-    __allreduce_signal_buf_0,
-    [__allreduce_signal_world_size_0, core_num],
-    dtype=pl.INT32,
-)
-data = pld.tensor.allreduce(data, __allreduce_signal_0, op=pld.ReduceOp.Sum)
-```
+    ```python
+    __allreduce_signal_world_size_0 = pld.system.world_size()
+    __allreduce_signal_buf_0: pl.Ptr = pld.tensor.alloc_window_buffer(__allreduce_signal_world_size_0 * core_num * pl.INT32.get_byte())
+    __allreduce_signal_0 = pld.tensor.window(
+        __allreduce_signal_buf_0,
+        [__allreduce_signal_world_size_0, core_num],
+        dtype=pl.INT32,
+    )
+    ```
 
-合成 signal 使用 rank-2 `[world_size, core_num]`，buffer 字节数也使用相同的
-lane 数。默认 `core_num=1`，因此保留原有表示和行为。
+4. 把每个隐式 signal 的 `pld.tensor.allreduce` 调用 —— 包括 `for` / `while`
+   循环内的调用 —— 改写为使用该共享 signal：
+
+    ```python
+    data = pld.tensor.allreduce(data, __allreduce_signal_0, op=pld.ReduceOp.Sum)
+    ```
+
+5. 已经传入显式 signal 的调用保持不变；return 位置的调用仍然提升为
+   赋值语句，以便 host lowering 派发。
+
+合成 signal 使用 rank-2 `[world_size, core_num]`，其中 `core_num` 是该血缘
+分组内所有隐式 signal 调用请求的最大 lane 数（默认 `core_num=1` 保留原有的
+单 lane 表示），buffer 字节数也使用相同的 lane 数。每个数据 buffer 血缘
+（设备覆盖范围）分组共享一个 binding，并被该 buffer 上所有隐式 signal 调用
+复用 —— 这是正确的，因为 host builtin kernel 会在每次调用后自清理屏障 cell，
+因此共享 signal 在连续调用与循环迭代之间都可以安全复用。不同的数据 buffer
+会得到不同的 signal，因此一个函数内针对不同设备子集的隐式 allreduce 不会被
+合并进同一个 comm-domain scope。
 
 ## Print / Parse Round Trip
 
@@ -65,10 +80,14 @@ alloc / window / allreduce 链路。
 以下情况会抛出 `pypto::ValueError`：
 
 - allreduce 位置参数数量不是 `target` 或 `target, signal`；
-- allreduce 作为嵌套表达式出现，而不是直接赋值、表达式语句或 return value；
-- **省略 signal 的** allreduce 出现在 `for` / `while` 循环内。
+- allreduce 作为嵌套表达式出现，而不是直接赋值、表达式语句或 return value。
 
-该循环限制只针对 HOST 通道上*被合成*的 signal：`SynthesizeAllReduceSignals` 把分配插入到 allreduce 语句之前，无法放入动态循环内部（每次迭代在同一名字下重新分配，且每个 rank 必须落在同一个对称 window 上）。显式传入 signal 时无需合成，且 lower 后的 kernel 会在返回前把信号槽恢复为零，因此显式 signal 可以跨迭代复用。由 [`LowerCompositeOps`](12-lower_composite_ops.md#屏障-信号协议) lower 的 InCore 组合算子则因该 pass 会发出自清理信用屏障尾声而具备循环安全性。
+`for` / `while` 循环内的隐式 signal 调用会被接受：该调用所属数据 buffer 血缘
+的共享 signal 会在每次迭代中被复用，这是正确的，因为 host builtin kernel
+（`builtin.tensor.allreduce` / `builtin.tensor.allreduce_ring`，由
+`LowerHostTensorCollectives` lower）通过信用屏障尾声在每次调用后自清理屏障
+cell。由 [`LowerCompositeOps`](12-lower_composite_ops.md#屏障-信号协议) lower
+的 InCore 组合算子同样具备循环安全性 —— 该 pass 会发出自清理尾声。
 
 ## Pass 属性
 

--- a/docs/zh/dev/passes/43-lower_host_tensor_collectives.md
+++ b/docs/zh/dev/passes/43-lower_host_tensor_collectives.md
@@ -142,6 +142,10 @@ notify 与 count 发布竞争。`LowerHostTensorCollectives` 在生成 builtin d
 它必须满足 `root < participating device count`。完全动态的 "all device" 域在编译期无法
 校验（那里没有可用的设备数）——与 signal 容量检查存在相同的已记录限制。
 
+signal 可复用（对自清理的 host builtin 而言）：这些 kernel 会在每次调用后
+自清理屏障 cell（信用屏障尾声），因此一个合成或用户分配的 signal 可以支撑
+任意数量的连续调用或循环迭代，无需重新分配。
+
 `all_to_all_v` 的单次使用 Set(1)/wait≥1 信号无法在 `host_orch` 的
 `for`/`while` 循环中复用——本 pass 之前紧邻运行的
 [`MaterializeCommDomainScopes`](42-materialize_comm_domain_scopes.md) 会提前

--- a/docs/zh/user/distributed/04-debugging.md
+++ b/docs/zh/user/distributed/04-debugging.md
@@ -12,7 +12,6 @@ rank 上。
 | **Signal cell 永不达到期望值** | 错误 `NotifyOp` | 多参与者屏障用 `AtomicAdd`；1:1 交换用 `Set`。 |
 | **编译时形状不匹配** | `NR` 未使用 `pl.dynamic` | 将运行时维度包裹在 `pl.dynamic("NR")` 中。 |
 | **派发时抛出 `TypeError`** | IO buffer 在 `prepare()` 前未调用 `.share_memory_()`——fork 出的子进程看不到 fork 之后分配的 buffer | 在 `prepare()` 之前对每个传给 worker 的 host tensor 调用 `.share_memory_()`。 |
-| **循环内 allreduce 被拒绝** | HOST 轨*省略 signal* 的 allreduce 在动态 `for`/`while` 内被拒绝：signal 合成无法为每次迭代分配新 signal | 显式传入 signal buffer（自清理、可跨迭代复用），或将调用提到循环外。 |
 
 ## 致命陷阱
 

--- a/include/pypto/ir/transforms/pass_properties.h
+++ b/include/pypto/ir/transforms/pass_properties.h
@@ -40,6 +40,12 @@ inline const PassProperties kInlineFunctionsProperties{.produced = {IRProperty::
 //    and wraps the host_orch body in nested CommDomainScopeStmts (one per
 //    inferred comm domain).
 
+// SynthesizeAllReduceSignals assumes SSA-form input: ResolveLineageKey walks
+// each data Var's single defining AssignStmt RHS (var_defs is single-assignment,
+// def-dominates-use). IRProperty::SSAForm is deliberately NOT declared required
+// — kInitMemRefProperties invalidates it and nothing re-produces it before this
+// pass runs — so multi-assignment robustness is a tracked follow-up together
+// with MaterializeCommDomainScopes (same gap).
 inline const PassProperties kSynthesizeAllReduceSignalsProperties{};
 
 inline const PassProperties kMaterializeCommDomainScopesProperties{

--- a/src/ir/transforms/materialize_comm_domain_scopes_pass.cpp
+++ b/src/ir/transforms/materialize_comm_domain_scopes_pass.cpp
@@ -24,6 +24,7 @@
 
 #include "pypto/core/error.h"
 #include "pypto/core/logging.h"
+#include "pypto/ir/core.h"
 #include "pypto/ir/expr.h"
 #include "pypto/ir/function.h"
 #include "pypto/ir/kind_traits.h"
@@ -137,7 +138,7 @@ struct CollectiveConsumer {
 class AllocAndWindowCollector : public IRVisitor {
  public:
   void VisitStmt_(const AssignStmtPtr& op) override {
-    auto var = As<Var>(op->var_);
+    auto var = AsVarLike(op->var_);
     auto call = As<Call>(op->value_);
     if (var && call && call->op_) {
       if (IsOp(call, "pld.tensor.alloc_window_buffer")) {
@@ -152,7 +153,9 @@ class AllocAndWindowCollector : public IRVisitor {
         ptr_to_alloc[var.get()] = rec.get();
         allocs.push_back(std::move(rec));
       } else if (IsOp(call, "pld.tensor.window") && !call->args_.empty()) {
-        auto ptr_arg_var = As<Var>(call->args_[0]);
+        // AsVarLike (not As<Var>): the windowed buffer may be an SSA loop carry
+        // (IterArg) — record it so ResolveWindowRecord can follow it.
+        auto ptr_arg_var = AsVarLike(call->args_[0]);
         if (ptr_arg_var) {
           auto it = ptr_to_alloc.find(ptr_arg_var.get());
           if (it != ptr_to_alloc.end()) {
@@ -161,14 +164,30 @@ class AllocAndWindowCollector : public IRVisitor {
             windows.push_back(wr);
           }
         }
+      } else if (IsTensorAllReduce(call) && !call->args_.empty()) {
+        // An allreduce result aliases its data window: record (result, data)
+        // so the substitution below can re-type the result with the same
+        // WindowBuffer (loop-carried results must keep window identity).
+        collective_results.emplace_back(var, AsVarLike(call->args_[0]));
       }
     }
     // Record the AssignStmt def for every Var so ResolveDeviceDescriptor can
     // follow ``for r in pl.range(<var>)`` back to ``<var> = pld.system.world_size()``
     // (CSE / NormalizeStmtStructure hoists such calls out into a temp).
-    if (auto var = As<Var>(op->var_)) {
+    // AsVarLike (not As<Var>): an SSA loop-carry LHS is an IterArg.
+    if (auto var = AsVarLike(op->var_)) {
       var_defs[var.get()] = op->value_;
     }
+    IRVisitor::VisitStmt_(op);
+  }
+
+  void VisitStmt_(const ForStmtPtr& op) override {
+    if (!op->iter_args_.empty()) loops.push_back(op);
+    IRVisitor::VisitStmt_(op);
+  }
+
+  void VisitStmt_(const WhileStmtPtr& op) override {
+    if (!op->iter_args_.empty()) whiles.push_back(op);
     IRVisitor::VisitStmt_(op);
   }
 
@@ -176,6 +195,9 @@ class AllocAndWindowCollector : public IRVisitor {
   std::unordered_map<const Var*, AllocRecord*> ptr_to_alloc;
   std::unordered_map<const Var*, WindowRecord> view_to_window;
   std::vector<WindowRecord> windows;
+  std::vector<std::pair<VarPtr, VarPtr>> collective_results;  ///< {allreduce result, data arg}
+  std::vector<ForStmtPtr> loops;                              ///< loops carrying values (iter_args non-empty)
+  std::vector<WhileStmtPtr> whiles;
   std::unordered_map<const Var*, ExprPtr> var_defs;
 };
 
@@ -309,7 +331,7 @@ class DispatchAnalyzer : public IRVisitor {
     if (!device) return;
     DeviceDescriptor desc = ResolveDeviceDescriptor(device, for_stack_, var_defs_, op->span_);
     for (const auto& arg : op->args_) {
-      auto arg_var = As<Var>(arg);
+      auto arg_var = AsVarLike(arg);
       if (!arg_var) continue;
       auto window = ResolveWindowRecord(arg_var);
       if (window) {
@@ -320,7 +342,9 @@ class DispatchAnalyzer : public IRVisitor {
 
   [[nodiscard]] AllocRecord* ResolveWindowAlloc(const ExprPtr& expr, const std::string& op_name,
                                                 const char* role) {
-    auto view_var = As<Var>(expr);
+    // AsVarLike (not As<Var>): a loop-carried data/signal arg is an IterArg
+    // (ConvertToSSA runs first); ResolveWindowRecord follows its init value.
+    auto view_var = AsVarLike(expr);
     INTERNAL_CHECK_SPAN(view_var, expr->span_)
         << "MaterializeCommDomainScopes: " << op_name << " " << role << " must be a window view Var";
     auto window = ResolveWindowRecord(view_var);
@@ -443,23 +467,31 @@ class DispatchAnalyzer : public IRVisitor {
     auto direct = view_to_window_.find(var.get());
     if (direct != view_to_window_.end()) return &direct->second;
 
+    // An SSA loop carry is an IterArg with no AssignStmt RHS: resolve through
+    // its init value (AsVarLike + initValue_, mirroring InferTileMemorySpace
+    // #2547 — see .claude/rules/ir-kind-traits.md).
+    if (var->GetKind() == ObjectKind::IterArg) {
+      auto init = static_cast<const IterArg*>(var.get())->initValue_;
+      return init ? ResolveWindowRecord(AsVarLike(init), visited) : nullptr;
+    }
+
     auto def_it = var_defs_.find(var.get());
     if (def_it == var_defs_.end() || !def_it->second) return nullptr;
-    if (auto alias = As<Var>(def_it->second)) {
+    if (auto alias = AsVarLike(def_it->second)) {
       return ResolveWindowRecord(alias, visited);
     }
     auto call = As<Call>(def_it->second);
     if (call && IsTensorAllReduce(call) && !call->args_.empty()) {
-      return ResolveWindowRecord(As<Var>(call->args_[0]), visited);
+      return ResolveWindowRecord(AsVarLike(call->args_[0]), visited);
     }
     if (call && IsTensorAllToAll(call) && call->args_.size() > 1) {
-      return ResolveWindowRecord(As<Var>(call->args_[1]), visited);
+      return ResolveWindowRecord(AsVarLike(call->args_[1]), visited);
     }
     if (call && IsTensorAllGather(call) && call->args_.size() > 1) {
-      return ResolveWindowRecord(As<Var>(call->args_[1]), visited);
+      return ResolveWindowRecord(AsVarLike(call->args_[1]), visited);
     }
     if (call && IsTensorAllToAllV(call) && call->args_.size() > 1) {
-      return ResolveWindowRecord(As<Var>(call->args_[1]), visited);
+      return ResolveWindowRecord(AsVarLike(call->args_[1]), visited);
     }
     return nullptr;
   }
@@ -507,6 +539,67 @@ class DispatchAnalyzer : public IRVisitor {
   auto new_type = std::make_shared<const DistributedTensorType>(dt->shape_, dt->dtype_, dt->memref_,
                                                                 dt->tensor_view_, std::make_optional(wb));
   return std::make_shared<Var>(old_var->name_hint_, new_type, old_var->span_);
+}
+
+/// Build a fresh IterArg with an updated DistributedTensorType whose
+/// ``window_buffer_`` points to ``wb`` — a loop carry that views a window must
+/// share the window-buffer object with its init value / yield / return var
+/// (the typecheck verifier compares those by pointer identity).
+[[nodiscard]] IterArgPtr MintIterArgWithWb(const IterArgPtr& iter_arg, const WindowBufferPtr& wb) {
+  auto dt = As<DistributedTensorType>(iter_arg->GetType());
+  INTERNAL_CHECK_SPAN(dt, iter_arg->span_)
+      << "MaterializeCommDomainScopes: loop iter_arg should have DistributedTensorType";
+  auto new_type = std::make_shared<const DistributedTensorType>(dt->shape_, dt->dtype_, dt->memref_,
+                                                                dt->tensor_view_, std::make_optional(wb));
+  return std::make_shared<IterArg>(iter_arg->name_hint_, new_type, iter_arg->initValue_, iter_arg->span_);
+}
+
+/// Follow a Var's def chain (through window / allreduce / all_to_all / allgather /
+/// all_to_all_v aliases and loop-carry init values) to the alloc-window-buffer it
+/// views, returning that alloc's ``WindowBuffer`` (the SAME object the scope slot
+/// holds). Mirrors DispatchAnalyzer::ResolveWindowRecord; used to extend the view
+/// substitution to collective results and loop carries so every DistributedTensorType
+/// denoting the same window shares one WindowBuffer object.
+[[nodiscard]] const WindowBufferPtr* ResolveWindowBufferPtr(const VarPtr& var,
+                                                            const AllocAndWindowCollector& c) {
+  std::unordered_set<const Var*> visited;
+  VarPtr cur = var;
+  while (cur && visited.insert(cur.get()).second) {
+    auto it = c.view_to_window.find(cur.get());
+    if (it != c.view_to_window.end()) return &it->second.alloc->wb;
+    if (cur->GetKind() == ObjectKind::IterArg) {
+      auto init = static_cast<const IterArg*>(cur.get())->initValue_;
+      cur = init ? AsVarLike(init) : nullptr;
+      continue;
+    }
+    auto def_it = c.var_defs.find(cur.get());
+    if (def_it == c.var_defs.end() || !def_it->second) return nullptr;
+    const ExprPtr& def = def_it->second;
+    if (auto alias = AsVarLike(def)) {
+      cur = alias;
+      continue;
+    }
+    auto call = As<Call>(def);
+    if (call && IsOp(call, "pld.tensor.window") && !call->args_.empty()) {
+      cur = AsVarLike(call->args_[0]);
+      continue;
+    }
+    if (call && IsTensorAllReduce(call) && !call->args_.empty()) {
+      cur = AsVarLike(call->args_[0]);
+      continue;
+    }
+    if (call && (IsOp(call, "pld.tensor.all_to_all") || IsOp(call, "pld.tensor.allgather")) &&
+        call->args_.size() > 1) {
+      cur = AsVarLike(call->args_[1]);
+      continue;
+    }
+    if (call && IsOp(call, "pld.tensor.all_to_all_v") && call->args_.size() > 1) {
+      cur = AsVarLike(call->args_[1]);
+      continue;
+    }
+    return nullptr;
+  }
+  return nullptr;
 }
 
 /// Process one host_orch function: identify allocs/windows/dispatches,
@@ -586,11 +679,42 @@ FunctionPtr ProcessHostOrch(const FunctionPtr& func, const std::map<std::string,
                                                    /*store_to_host=*/false, rec->span);
   }
 
-  // Phase 5: build var substitution map for every pld.tensor.window result Var.
+  // Phase 5: build var substitution map for every pld.tensor.window result Var,
+  // every allreduce result Var (aliases its data window), and every loop carry
+  // (iter_arg / return_var) whose lineage is a window. The typecheck verifier
+  // compares loop-carry types (initValue / iter_arg / yield / return_var) by
+  // WindowBuffer pointer identity, so all DistributedTensorTypes denoting the
+  // same window must share one WindowBuffer object after substitution.
   std::unordered_map<const Var*, VarPtr> view_subst;
   for (const auto& w : collector.windows) {
     view_subst[w.old_view_var.get()] = MintViewVar(w.old_view_var, w.alloc->wb);
   }
+  for (const auto& [result_var, data_var] : collector.collective_results) {
+    if (!result_var || !data_var) continue;
+    if (const auto* wb = ResolveWindowBufferPtr(data_var, collector)) {
+      if (view_subst.find(result_var.get()) == view_subst.end()) {
+        view_subst[result_var.get()] = MintViewVar(result_var, *wb);
+      }
+    }
+  }
+  auto sync_loop_carries = [&collector, &view_subst](const std::vector<IterArgPtr>& iter_args,
+                                                     const std::vector<VarPtr>& return_vars) {
+    for (size_t i = 0; i < iter_args.size(); ++i) {
+      const auto& ia = iter_args[i];
+      if (!ia || !ia->initValue_) continue;
+      const auto* wb = ResolveWindowBufferPtr(AsVarLike(ia->initValue_), collector);
+      if (!wb) continue;
+      if (view_subst.find(ia.get()) == view_subst.end()) {
+        view_subst[ia.get()] = MintIterArgWithWb(ia, *wb);
+      }
+      if (i < return_vars.size() && return_vars[i] &&
+          view_subst.find(return_vars[i].get()) == view_subst.end()) {
+        view_subst[return_vars[i].get()] = MintViewVar(return_vars[i], *wb);
+      }
+    }
+  };
+  for (const auto& fs : collector.loops) sync_loop_carries(fs->iter_args_, fs->return_vars_);
+  for (const auto& ws : collector.whiles) sync_loop_carries(ws->iter_args_, ws->return_vars_);
 
   // Phase 6: cluster allocs into pending domain entries by merged descriptor
   // (alloc-order within a domain). Use a vector for deterministic order: scan

--- a/src/ir/transforms/simplify_pass.cpp
+++ b/src/ir/transforms/simplify_pass.cpp
@@ -601,10 +601,30 @@ class SimplifyMutator : public arith::IRMutatorWithAnalyzer {
           new_tv = TensorView(std::move(new_stride), tv.layout, std::move(new_vs), tv.pad);
         }
       }
+      // Remap the window_buffer_ back-reference in lockstep with the
+      // CommDomainScopeStmt slots. Folding a WindowBuffer's size_ (e.g.
+      // `world_size * 1 * 4` -> `world_size * 4` on a synthesized signal)
+      // mints a FRESH WindowBuffer via VisitExpr_(WindowBufferPtr) and records
+      // it in var_remap_; the scope slots pick that up. If this rebuild left
+      // window_buffer_ pointing at the pre-fold object, the view var and its
+      // scope slot would diverge and DistributedCodegen's ScopeForWindowBuffer
+      // (pointer-identity scan) would fail with "not a slot of any open
+      // CommDomainScopeStmt".
+      std::optional<WindowBufferPtr> new_wb;
+      if (auto distributed = As<DistributedTensorType>(type)) {
+        new_wb = distributed->window_buffer_;
+        if (distributed->window_buffer_.has_value()) {
+          auto remapped = As<WindowBuffer>(VisitExpr(*distributed->window_buffer_));
+          INTERNAL_CHECK(remapped) << "Simplify: DistributedTensorType window_buffer_ mutated to "
+                                      "non-WindowBuffer";
+          if (remapped.get() != distributed->window_buffer_->get()) changed = true;
+          new_wb = std::move(remapped);
+        }
+      }
       if (!changed) return type;
       if (auto distributed = As<DistributedTensorType>(type)) {
         return std::make_shared<DistributedTensorType>(std::move(new_shape), t->dtype_, t->memref_,
-                                                       std::move(new_tv), distributed->window_buffer_);
+                                                       std::move(new_tv), std::move(new_wb));
       }
       return std::make_shared<TensorType>(std::move(new_shape), t->dtype_, t->memref_, std::move(new_tv));
     }

--- a/src/ir/transforms/synthesize_allreduce_signals_pass.cpp
+++ b/src/ir/transforms/synthesize_allreduce_signals_pass.cpp
@@ -9,18 +9,23 @@
  * -----------------------------------------------------------------------------------------------------------
  */
 
+#include <algorithm>
 #include <any>
 #include <cstddef>
 #include <cstdint>
+#include <functional>
 #include <map>
 #include <memory>
 #include <set>
 #include <string>
+#include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
 #include "pypto/core/dtype.h"
 #include "pypto/core/logging.h"
+#include "pypto/ir/core.h"
 #include "pypto/ir/expr.h"
 #include "pypto/ir/function.h"
 #include "pypto/ir/kind_traits.h"
@@ -51,6 +56,83 @@ namespace {
          (func->role_.has_value() && *func->role_ == Role::Orchestrator);
 }
 
+// Follow a data Var's SSA def chain back to its alloc-window-buffer LHS Var
+// (its "lineage"), so implicit allreduce calls over the same buffer share one
+// synthesized signal while distinct buffers (and therefore distinct device
+// coverage / comm domains) get distinct signals. Mirrors
+// MaterializeCommDomainScopes::ResolveWindowRecord: ``pld.tensor.window``
+// resolves through args_[0], push-based collectives (all_to_all / allgather /
+// all_to_all_v) resolve through their target arg (args_[1]), and an allreduce
+// result aliases its own data arg (args_[0]).
+//
+// Loop-carried data is an IterArg, not a Var (ConvertToSSA runs first): it has
+// no AssignStmt RHS, so follow its init value instead. IterArg has its own
+// ObjectKind, so As<Var> misses it — use AsVarLike throughout (see
+// .claude/rules/ir-kind-traits.md, same pattern as InferTileMemorySpace #2547).
+// Resolution through the init value keys every loop iteration to the carry's
+// first-iteration lineage; a loop ping-ponging between two *different-coverage*
+// windows is therefore not distinguished (documented limitation).
+[[nodiscard]] const Var* ResolveLineageKey(const VarPtr& var,
+                                           const std::unordered_map<const Var*, ExprPtr>& var_defs) {
+  std::unordered_set<const Var*> visited;
+  const Var* cur = var.get();
+  while (cur != nullptr && visited.insert(cur).second) {
+    if (cur->GetKind() == ObjectKind::IterArg) {
+      auto init = static_cast<const IterArg*>(cur)->initValue_;
+      if (auto next = AsVarLike(init)) {
+        cur = next.get();
+        continue;
+      }
+      return cur;
+    }
+    auto it = var_defs.find(cur);
+    if (it == var_defs.end() || !it->second) return cur;
+    const ExprPtr& def = it->second;
+    if (auto alias = AsVarLike(def)) {
+      // An alias to a loop carry resolves through the carry's init value.
+      if (alias->GetKind() == ObjectKind::IterArg) {
+        auto init = static_cast<const IterArg*>(alias.get())->initValue_;
+        if (auto next = AsVarLike(init)) {
+          cur = next.get();
+          continue;
+        }
+        return cur;
+      }
+      cur = alias.get();
+      continue;
+    }
+    if (auto call = As<Call>(def)) {
+      if (call->op_ && IsOp(call, "pld.tensor.window") && !call->args_.empty()) {
+        if (auto buf = AsVarLike(call->args_[0])) {
+          cur = buf.get();
+          continue;
+        }
+      }
+      if (IsTensorAllReduce(call) && !call->args_.empty()) {
+        if (auto tgt = AsVarLike(call->args_[0])) {
+          cur = tgt.get();
+          continue;
+        }
+      }
+      if (call->op_ && (IsOp(call, "pld.tensor.all_to_all") || IsOp(call, "pld.tensor.allgather")) &&
+          call->args_.size() > 1) {
+        if (auto tgt = AsVarLike(call->args_[1])) {
+          cur = tgt.get();
+          continue;
+        }
+      }
+      if (call->op_ && IsOp(call, "pld.tensor.all_to_all_v") && call->args_.size() > 1) {
+        if (auto tgt = AsVarLike(call->args_[1])) {
+          cur = tgt.get();
+          continue;
+        }
+      }
+    }
+    return cur;
+  }
+  return cur != nullptr ? cur : var.get();
+}
+
 class NameCollector : public IRVisitor {
  public:
   std::set<std::string> names;
@@ -70,10 +152,110 @@ class NameCollector : public IRVisitor {
   }
 };
 
+// One shared mesh signal per data-buffer lineage group. Each group's binding is
+// hoisted to the top of the function body and reused by every implicit-signal
+// allreduce call over that buffer (including calls inside for/while loops): the
+// host builtin kernels self-clear their barrier cells after each call, so a
+// reused signal is correct across back-to-back and loop-carried calls. Distinct
+// data buffers get distinct signals, so implicit allreduces over different
+// device subsets do not merge into one comm-domain scope.
+struct SharedSignalBinding {
+  std::vector<StmtPtr> prefix;  ///< world_size / alloc_window_buffer / window assigns
+  VarPtr signal_var;
+};
+
+struct SignalNames {
+  std::string world_size_name;
+  std::string buf_name;
+  std::string signal_name;
+};
+
+[[nodiscard]] SignalNames FreshSignalNames(std::set<std::string>* used_names, int64_t* next_id) {
+  while (true) {
+    auto suffix = std::to_string((*next_id)++);
+    SignalNames names{"__allreduce_signal_world_size_" + suffix, "__allreduce_signal_buf_" + suffix,
+                      "__allreduce_signal_" + suffix};
+    if (used_names->count(names.world_size_name) != 0 || used_names->count(names.buf_name) != 0 ||
+        used_names->count(names.signal_name) != 0) {
+      continue;
+    }
+    used_names->insert(names.world_size_name);
+    used_names->insert(names.buf_name);
+    used_names->insert(names.signal_name);
+    return names;
+  }
+}
+
+[[nodiscard]] SharedSignalBinding MakeSharedSignalBinding(std::set<std::string>* used_names, int64_t* next_id,
+                                                          const Span& span, int core_num) {
+  auto names = FreshSignalNames(used_names, next_id);
+  INTERNAL_CHECK_SPAN(core_num > 0, span)
+      << "SynthesizeAllReduceSignals requires a positive allreduce core_num";
+
+  auto world_size_call = OpRegistry::GetInstance().Create("pld.system.world_size", {}, span);
+  auto world_size_var = std::make_shared<Var>(names.world_size_name, world_size_call->GetType(), span);
+  auto world_size_assign = std::make_shared<AssignStmt>(world_size_var, world_size_call, span);
+
+  auto core_num_expr = std::make_shared<ConstInt>(core_num, DataType::INT64, span);
+  auto four = std::make_shared<ConstInt>(4, DataType::INT64, span);
+  auto signal_elements = MakeMul(world_size_var, core_num_expr, span);
+  auto size_bytes = MakeMul(signal_elements, four, span);
+
+  std::vector<std::pair<std::string, std::any>> alloc_kwargs = {{"name", names.buf_name}};
+  auto alloc_call =
+      OpRegistry::GetInstance().Create("pld.tensor.alloc_window_buffer", {size_bytes}, alloc_kwargs, span);
+  auto buf_var = std::make_shared<Var>(names.buf_name, alloc_call->GetType(), span);
+  auto buf_assign = std::make_shared<AssignStmt>(buf_var, alloc_call, span);
+
+  auto signal_shape = std::make_shared<MakeTuple>(std::vector<ExprPtr>{world_size_var, core_num_expr}, span);
+  std::vector<std::pair<std::string, std::any>> window_kwargs = {{"dtype", DataType::INT32}};
+  auto window_call =
+      OpRegistry::GetInstance().Create("pld.tensor.window", {buf_var, signal_shape}, window_kwargs, span);
+  auto signal_var = std::make_shared<Var>(names.signal_name, window_call->GetType(), span);
+  auto signal_assign = std::make_shared<AssignStmt>(signal_var, window_call, span);
+
+  return {{world_size_assign, buf_assign, signal_assign}, signal_var};
+}
+
+/// Pre-scan: does this host_orch function need the synthesizer at all?
+///
+/// The synthesizer runs on any function carrying a ``pld.tensor.allreduce``
+/// (it also lifts return-position calls and rejects nested calls for
+/// explicit-signal functions); only a 1-arg call additionally needs a shared
+/// signal binding.
+class AllReduceSignalNeedFinder : public IRVisitor {
+ public:
+  bool has_allreduce = false;                           ///< any pld.tensor.allreduce call
+  std::vector<std::pair<ExprPtr, int>> implicit_calls;  ///< 1-arg calls in visit order: {data, core_num}
+  std::unordered_map<const Var*, ExprPtr> var_defs;     ///< Var* -> defining RHS (lineage resolution)
+
+ protected:
+  void VisitExpr_(const CallPtr& op) override {
+    if (IsTensorAllReduce(op)) {
+      has_allreduce = true;
+      if (op->args_.size() == 1) {
+        implicit_calls.emplace_back(op->args_[0], op->GetKwarg<int>("core_num"));
+      }
+    }
+    IRVisitor::VisitExpr_(op);
+  }
+
+  void VisitStmt_(const AssignStmtPtr& op) override {
+    // AsVarLike (not As<Var>): an SSA loop-carry LHS is an IterArg and must be
+    // resolvable back through ResolveLineageKey (ir-kind-traits.md).
+    if (auto var = AsVarLike(op->var_)) {
+      var_defs[var.get()] = op->value_;
+    }
+    IRVisitor::VisitStmt_(op);
+  }
+};
+
 class AllReduceSignalSynthesizer : public IRMutator {
  public:
-  AllReduceSignalSynthesizer(std::set<std::string>* used_names, int64_t* next_id)
-      : used_names_(used_names), next_id_(next_id) {}
+  using SignalLookup = std::function<VarPtr(const ExprPtr&)>;
+
+  AllReduceSignalSynthesizer(std::set<std::string>* used_names, int64_t* next_id, SignalLookup signal_lookup)
+      : used_names_(used_names), next_id_(next_id), signal_lookup_(std::move(signal_lookup)) {}
 
   [[nodiscard]] bool modified() const { return modified_; }
 
@@ -96,15 +278,12 @@ class AllReduceSignalSynthesizer : public IRMutator {
       return op;
     }
 
-    auto [prefix, signal] = MakeSignalBinding(call->span_, call->GetKwarg<int>("core_num"));
     auto target = VisitExpr(call->args_[0]);
-    auto rewritten_call = MakeAllReduceCall(call, target, signal);
+    auto rewritten_call = MakeAllReduceCall(call, target, signal_lookup_(call->args_[0]));
     auto result = MutableCopy(op);
     result->value_ = rewritten_call;
-
-    prefix.push_back(result);
     modified_ = true;
-    return SeqStmts::Flatten(std::move(prefix), op->span_);
+    return result;
   }
 
   StmtPtr VisitStmt_(const EvalStmtPtr& op) override {
@@ -116,13 +295,10 @@ class AllReduceSignalSynthesizer : public IRMutator {
       return op;
     }
 
-    auto [prefix, signal] = MakeSignalBinding(call->span_, call->GetKwarg<int>("core_num"));
     auto target = VisitExpr(call->args_[0]);
-    auto rewritten_call = MakeAllReduceCall(call, target, signal);
-    std::vector<StmtPtr> stmts = std::move(prefix);
-    stmts.push_back(std::make_shared<EvalStmt>(rewritten_call, op->span_, op->leading_comments_));
+    auto rewritten_call = MakeAllReduceCall(call, target, signal_lookup_(call->args_[0]));
     modified_ = true;
-    return SeqStmts::Flatten(std::move(stmts), op->span_);
+    return std::make_shared<EvalStmt>(rewritten_call, op->span_, op->leading_comments_);
   }
 
   StmtPtr VisitStmt_(const ReturnStmtPtr& op) override {
@@ -143,15 +319,7 @@ class AllReduceSignalSynthesizer : public IRMutator {
 
       CheckAllReduceCall(call);
       auto target = VisitExpr(call->args_[0]);
-      ExprPtr signal;
-      if (call->args_.size() == 1) {
-        auto [prefix, synthesized_signal] = MakeSignalBinding(call->span_, call->GetKwarg<int>("core_num"));
-        for (auto& stmt : prefix) prelude.push_back(std::move(stmt));
-        signal = synthesized_signal;
-      } else {
-        signal = VisitExpr(call->args_[1]);
-      }
-
+      auto signal = call->args_.size() == 1 ? signal_lookup_(call->args_[0]) : VisitExpr(call->args_[1]);
       auto rewritten_call = MakeAllReduceCall(call, target, signal);
       auto result_var = std::make_shared<Var>(FreshGeneratedName("__allreduce_result_"),
                                               rewritten_call->GetType(), call->span_);
@@ -168,58 +336,11 @@ class AllReduceSignalSynthesizer : public IRMutator {
     return SeqStmts::Flatten(std::move(prelude), op->span_);
   }
 
-  StmtPtr VisitStmt_(const ForStmtPtr& op) override {
-    ++repeating_scope_depth_;
-    auto result = IRMutator::VisitStmt_(op);
-    --repeating_scope_depth_;
-    return result;
-  }
-
-  StmtPtr VisitStmt_(const WhileStmtPtr& op) override {
-    ++repeating_scope_depth_;
-    auto result = IRMutator::VisitStmt_(op);
-    --repeating_scope_depth_;
-    return result;
-  }
-
  private:
   void CheckAllReduceCall(const CallPtr& call) const {
     CHECK_SPAN(call->args_.size() == 1 || call->args_.size() == 2, call->span_)
         << "pld.tensor.allreduce expects target[, signal], got " << call->args_.size()
         << " positional arguments";
-    // Only a *synthesized* signal is loop-bound: the binding this pass inserts
-    // cannot be allocated once per dynamic iteration, and every rank has to land
-    // on the same symmetric window. An explicit signal needs no synthesis, and
-    // the lowered kernel restores its cells to zero before returning, so
-    // carrying one across iterations is safe.
-    CHECK_SPAN(repeating_scope_depth_ == 0 || call->args_.size() == 2, call->span_)
-        << "pld.tensor.allreduce without an explicit signal is not supported inside a for/while "
-           "loop on the HOST rail: the synthesized signal binding cannot be allocated per dynamic "
-           "iteration. Pass an explicit signal buffer — it is self-clearing and reusable across "
-           "iterations — or hoist the call out of the loop.";
-  }
-
-  struct SignalNames {
-    std::string world_size_name;
-    std::string buf_name;
-    std::string signal_name;
-  };
-
-  [[nodiscard]] SignalNames FreshSignalNames() {
-    while (true) {
-      auto suffix = std::to_string((*next_id_)++);
-      auto world_size_name = "__allreduce_signal_world_size_" + suffix;
-      auto buf_name = "__allreduce_signal_buf_" + suffix;
-      auto signal_name = "__allreduce_signal_" + suffix;
-      if (used_names_->count(world_size_name) != 0 || used_names_->count(buf_name) != 0 ||
-          used_names_->count(signal_name) != 0) {
-        continue;
-      }
-      used_names_->insert(world_size_name);
-      used_names_->insert(buf_name);
-      used_names_->insert(signal_name);
-      return {world_size_name, buf_name, signal_name};
-    }
   }
 
   [[nodiscard]] std::string FreshGeneratedName(const std::string& prefix) {
@@ -231,37 +352,6 @@ class AllReduceSignalSynthesizer : public IRMutator {
     }
   }
 
-  [[nodiscard]] std::pair<std::vector<StmtPtr>, VarPtr> MakeSignalBinding(const Span& span, int core_num) {
-    auto names = FreshSignalNames();
-    INTERNAL_CHECK_SPAN(core_num > 0, span)
-        << "SynthesizeAllReduceSignals requires a positive allreduce core_num";
-
-    auto world_size_call = OpRegistry::GetInstance().Create("pld.system.world_size", {}, span);
-    auto world_size_var = std::make_shared<Var>(names.world_size_name, world_size_call->GetType(), span);
-    auto world_size_assign = std::make_shared<AssignStmt>(world_size_var, world_size_call, span);
-
-    auto core_num_expr = std::make_shared<ConstInt>(core_num, DataType::INT64, span);
-    auto four = std::make_shared<ConstInt>(4, DataType::INT64, span);
-    auto signal_elements = MakeMul(world_size_var, core_num_expr, span);
-    auto size_bytes = MakeMul(signal_elements, four, span);
-
-    std::vector<std::pair<std::string, std::any>> alloc_kwargs = {{"name", names.buf_name}};
-    auto alloc_call =
-        OpRegistry::GetInstance().Create("pld.tensor.alloc_window_buffer", {size_bytes}, alloc_kwargs, span);
-    auto buf_var = std::make_shared<Var>(names.buf_name, alloc_call->GetType(), span);
-    auto buf_assign = std::make_shared<AssignStmt>(buf_var, alloc_call, span);
-
-    auto signal_shape =
-        std::make_shared<MakeTuple>(std::vector<ExprPtr>{world_size_var, core_num_expr}, span);
-    std::vector<std::pair<std::string, std::any>> window_kwargs = {{"dtype", DataType::INT32}};
-    auto window_call =
-        OpRegistry::GetInstance().Create("pld.tensor.window", {buf_var, signal_shape}, window_kwargs, span);
-    auto signal_var = std::make_shared<Var>(names.signal_name, window_call->GetType(), span);
-    auto signal_assign = std::make_shared<AssignStmt>(signal_var, window_call, span);
-
-    return {{world_size_assign, buf_assign, signal_assign}, signal_var};
-  }
-
   [[nodiscard]] CallPtr MakeAllReduceCall(const CallPtr& call, const ExprPtr& target, const ExprPtr& signal) {
     return OpRegistry::GetInstance().Create("pld.tensor.allreduce", {target, signal}, call->kwargs_,
                                             call->span_);
@@ -269,7 +359,7 @@ class AllReduceSignalSynthesizer : public IRMutator {
 
   std::set<std::string>* used_names_;
   int64_t* next_id_;
-  int repeating_scope_depth_ = 0;
+  SignalLookup signal_lookup_;
   bool modified_ = false;
 };
 
@@ -291,8 +381,74 @@ Pass SynthesizeAllReduceSignals() {
         continue;
       }
 
-      AllReduceSignalSynthesizer synthesizer(&name_collector.names, &next_signal_id);
-      auto new_body = synthesizer.VisitStmt(func->body_);
+      // One shared mesh signal per data-buffer lineage group, hoisted before the
+      // body and reused by every implicit-signal call over that buffer (incl.
+      // inside loops — self-clearing kernels make reuse safe). Distinct data
+      // buffers get distinct signals, so implicit allreduces over different
+      // device subsets do not merge into a single comm-domain scope. The
+      // synthesizer still runs for explicit-signal functions to lift
+      // return-position calls and reject nested calls.
+      AllReduceSignalNeedFinder finder;
+      finder.VisitStmt(func->body_);
+      if (!finder.has_allreduce) {
+        new_functions[gvar] = func;
+        continue;
+      }
+
+      std::vector<const void*> lineage_order;
+      std::unordered_map<const void*, int> lineage_core_num;
+      std::unordered_map<const void*, VarPtr> lineage_to_signal;
+      std::vector<StmtPtr> body_stmts;
+      for (const auto& [data_expr, core_num] : finder.implicit_calls) {
+        const void* key;
+        // AsVarLike (not As<Var>): loop-carried data is an IterArg and must
+        // resolve through its lineage group, not fall back to a per-call
+        // signal (ir-kind-traits.md).
+        if (auto data_var = AsVarLike(data_expr)) {
+          key = static_cast<const void*>(ResolveLineageKey(data_var, finder.var_defs));
+        } else {
+          key = static_cast<const void*>(data_expr.get());  // non-Var data → per-call signal
+        }
+        auto [it, inserted] = lineage_core_num.emplace(key, core_num);
+        if (!inserted) {
+          it->second = std::max(it->second, core_num);
+        } else {
+          lineage_order.push_back(key);
+        }
+      }
+      for (const void* key : lineage_order) {
+        auto binding = MakeSharedSignalBinding(&name_collector.names, &next_signal_id, func->span_,
+                                               lineage_core_num[key]);
+        lineage_to_signal[key] = binding.signal_var;
+        body_stmts.insert(body_stmts.end(), binding.prefix.begin(), binding.prefix.end());
+      }
+      StmtPtr body_to_visit;
+      if (body_stmts.empty()) {
+        body_to_visit = func->body_;
+      } else {
+        body_stmts.push_back(func->body_);
+        body_to_visit = SeqStmts::Flatten(std::move(body_stmts), func->span_);
+      }
+
+      AllReduceSignalSynthesizer::SignalLookup signal_lookup = [&lineage_to_signal,
+                                                                &finder](const ExprPtr& data) -> VarPtr {
+        const void* key;
+        // AsVarLike (not As<Var>): loop-carried data is an IterArg and must
+        // resolve through its lineage group, not fall back to a per-call
+        // signal (ir-kind-traits.md).
+        if (auto data_var = AsVarLike(data)) {
+          key = static_cast<const void*>(ResolveLineageKey(data_var, finder.var_defs));
+        } else {
+          key = static_cast<const void*>(data.get());
+        }
+        auto it = lineage_to_signal.find(key);
+        INTERNAL_CHECK(it != lineage_to_signal.end())
+            << "SynthesizeAllReduceSignals: no synthesized signal for allreduce data lineage";
+        return it->second;
+      };
+
+      AllReduceSignalSynthesizer synthesizer(&name_collector.names, &next_signal_id, signal_lookup);
+      auto new_body = synthesizer.VisitStmt(body_to_visit);
       if (!synthesizer.modified()) {
         new_functions[gvar] = func;
         continue;

--- a/tests/st/distributed/test_l3_host_tensor_allreduce.py
+++ b/tests/st/distributed/test_l3_host_tensor_allreduce.py
@@ -364,6 +364,79 @@ def _build_host_allreduce_signal_reuse():
     return HostTensorAllReduceSignalReuse
 
 
+def _build_host_allreduce_loop(rounds: int = 3):
+    """Host allreduce whose implicit-signal call sits INSIDE a ``for`` loop.
+
+    SynthesizeAllReduceSignals hoists ONE shared signal (keyed to the data
+    buffer's lineage) and rewrites the in-loop call to use it (previously
+    rejected as a single-use signal inside a repeating scope). Loop-carried
+    reuse is safe because the builtin kernels self-clear their barrier cells
+    after each call (self-clearing epilogue).
+    """
+
+    ROUNDS = rounds
+
+    @pl.program
+    class HostTensorAllReduceLoop:
+        @pl.function(type=pl.FunctionType.InCore)
+        def publish_step(
+            self,
+            inp: pl.Tensor[[1, SIZE], pl.FP32],
+            data: pl.InOut[pld.DistributedTensor[[1, SIZE], pl.FP32]],
+        ) -> pld.DistributedTensor[[1, SIZE], pl.FP32]:
+            local = pl.load(inp, [0, 0], [1, SIZE])
+            return pl.store(local, [0, 0], data)
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def publish_orch(
+            self,
+            inp: pl.Tensor[[1, SIZE], pl.FP32],
+            data: pl.InOut[pld.DistributedTensor[[1, SIZE], pl.FP32]],
+        ) -> pld.DistributedTensor[[1, SIZE], pl.FP32]:
+            return self.publish_step(inp, data)
+
+        @pl.function(type=pl.FunctionType.InCore)
+        def consume_step(
+            self,
+            data: pld.DistributedTensor[[1, SIZE], pl.FP32],
+            out: pl.Out[pl.Tensor[[1, SIZE], pl.FP32]],
+        ) -> pl.Tensor[[1, SIZE], pl.FP32]:
+            reduced = pl.load(data, [0, 0], [1, SIZE])
+            return pl.store(reduced, [0, 0], out)
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def consume_orch(
+            self,
+            data: pld.DistributedTensor[[1, SIZE], pl.FP32],
+            out: pl.Out[pl.Tensor[[1, SIZE], pl.FP32]],
+        ) -> pl.Tensor[[1, SIZE], pl.FP32]:
+            return self.consume_step(data, out)
+
+        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+        def host_orch(
+            self,
+            inputs: pl.Tensor[[ROUNDS, NR, 1, SIZE], pl.FP32],
+            outputs: pl.Out[pl.Tensor[[ROUNDS, NR, 1, SIZE], pl.FP32]],
+        ) -> pl.Tensor[[ROUNDS, NR, 1, SIZE], pl.FP32]:
+            data_buf = pld.alloc_window_buffer(SIZE * pl.FP32.get_byte())
+
+            # Every iteration's allreduce is implicit-signal; one shared signal
+            # is synthesized for this buffer's lineage and reused across
+            # iterations.
+            for it in pl.range(ROUNDS):
+                for r in pl.range(pld.world_size()):
+                    data = pld.window(data_buf, [1, SIZE], dtype=pl.FP32)
+                    self.publish_orch(inputs[it, r], data, device=r)
+                data = pld.window(data_buf, [1, SIZE], dtype=pl.FP32)
+                data = pld.tensor.allreduce(data, op=pld.ReduceOp.Sum)
+                for r in pl.range(pld.world_size()):
+                    self.consume_orch(data, outputs[it, r], device=r)
+
+            return outputs
+
+    return HostTensorAllReduceLoop
+
+
 class TestL3HostTensorAllReduce:
     @pytest.mark.parametrize("n_ranks", [2, 4])
     def test_host_tensor_allreduce(self, test_config, device_ids, n_ranks):
@@ -426,6 +499,43 @@ class TestL3HostTensorAllReduce:
             expected = _expected_allreduce(inputs[rd])
             assert torch.allclose(outputs[rd], expected), (
                 f"host allreduce signal-reuse round {rd} P={n_ranks} mismatch: "
+                f"max diff = {(outputs[rd] - expected).abs().max().item()}"
+            )
+
+    @pytest.mark.parametrize("n_ranks", [2, 4])
+    def test_host_tensor_allreduce_loop(self, test_config, device_ids, n_ranks):
+        """Implicit-signal allreduce inside a ``for`` loop in host_orch.
+
+        SynthesizeAllReduceSignals must accept the call (previously rejected
+        inside a repeating scope), hoist ONE shared signal, and the loop must
+        reuse it round after round (safe via the self-clearing epilogue).
+        """
+        if len(device_ids) < n_ranks:
+            pytest.skip(f"host allreduce P={n_ranks} needs {n_ranks} devices, got {device_ids}")
+
+        rounds = 3
+        compiled = ir.compile(
+            _build_host_allreduce_loop(rounds),
+            platform=test_config.platform,
+            distributed_config=DistributedConfig(
+                device_ids=device_ids[:n_ranks],
+                num_sub_workers=0,
+            ),
+        )
+        variant_dir = compiled.output_dir / "next_levels" / "builtin.tensor.allreduce__sum__fp32"
+        assert variant_dir.is_dir()
+
+        # Each round carries a distinct offset so a stale round-1 result in a
+        # later round (a missed epilogue reset on a reused signal) cannot match
+        # the round's golden.
+        inputs = torch.stack([_make_rank_inputs(n_ranks, round_offset=rd * 10000.0) for rd in range(rounds)])
+        outputs = torch.zeros_like(inputs)
+        compiled(inputs, outputs)
+
+        for rd in range(rounds):
+            expected = _expected_allreduce(inputs[rd])
+            assert torch.allclose(outputs[rd], expected), (
+                f"host allreduce loop round {rd} P={n_ranks} mismatch: "
                 f"max diff = {(outputs[rd] - expected).abs().max().item()}"
             )
 

--- a/tests/ut/ir/transforms/test_materialize_comm_domain_scopes.py
+++ b/tests/ut/ir/transforms/test_materialize_comm_domain_scopes.py
@@ -151,10 +151,17 @@ def _flatten_stmts(stmt: ir.Stmt) -> list[ir.Stmt]:
         result.extend(_flatten_stmts(stmt.body))
     if isinstance(stmt, ir.ForStmt):
         result.extend(_flatten_stmts(stmt.body))
+    if isinstance(stmt, ir.WhileStmt):
+        result.extend(_flatten_stmts(stmt.body))
     return result
 
 
 def _apply(program: ir.Program) -> ir.Program:
+    # Run ConvertToSSA first, matching the real pipeline (pass_manager.py runs
+    # it before these passes): loop-carried data becomes an IterArg, the exact
+    # shape the passes must handle — without this the loop tests assert against
+    # IR the compiler never produces (review #2504).
+    program = cast(ir.Program, passes.convert_to_ssa()(program))
     return cast(ir.Program, passes.materialize_comm_domain_scopes()(_synthesize(program)))
 
 
@@ -328,11 +335,11 @@ def test_explicit_allreduce_assignment_keeps_user_signal():
     assert synthetic_assigns == []
     assert len(allreduces) == 1
     assert len(allreduces[0].args) == 2
-    assert _as_var(allreduces[0].args[1]).name_hint == "signal"
+    assert _as_var(allreduces[0].args[1]).name_hint == "signal__ssa_v0"
 
     scopes = _get_comm_domain_scopes(host)
     assert len(scopes) == 1
-    assert [slot.base.name_hint for slot in scopes[0].slots] == ["data_buf", "signal_buf"]
+    assert [slot.base.name_hint for slot in scopes[0].slots] == ["data_buf__ssa_v0", "signal_buf__ssa_v0"]
 
 
 def test_implicit_allreduce_signal_is_materialized_in_data_comm_domain():
@@ -381,10 +388,80 @@ def test_implicit_allreduce_signal_is_materialized_in_data_comm_domain():
 
     scopes = _get_comm_domain_scopes(host)
     assert len(scopes) == 1
+    # Shared signal binding is hoisted to the top of the body, so its slot precedes data_buf.
     assert [slot.base.name_hint for slot in scopes[0].slots] == [
-        "data_buf",
         "__allreduce_signal_buf_0",
+        "data_buf__ssa_v0",
     ]
+
+
+def test_implicit_allreduce_over_distinct_subsets_gets_distinct_signals():
+    """One shared signal per data-buffer lineage, not per function.
+
+    Two data buffers dispatched to disjoint device subsets ({0,1} and {2,3}),
+    each reduced implicitly, must each get its own synthesized signal. A single
+    per-function shared signal would merge both subsets into the signal's
+    coverage while each data buffer keeps its own domain, so
+    LowerHostTensorCollectives would reject every call (data and signal in
+    different comm-domain scopes).
+    """
+
+    @pl.program
+    class P:
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def chip_orch(self, data: pld.DistributedTensor[[256], pl.FP32]):
+            return data
+
+        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+        def host_orch(self):
+            buf_a = pld.alloc_window_buffer(256 * pl.FP32.get_byte())
+            buf_b = pld.alloc_window_buffer(256 * pl.FP32.get_byte())
+            data_a = pld.window(buf_a, [256], dtype=pl.FP32)
+            data_b = pld.window(buf_b, [256], dtype=pl.FP32)
+            self.chip_orch(data_a, device=0)
+            self.chip_orch(data_a, device=1)
+            self.chip_orch(data_b, device=2)
+            self.chip_orch(data_b, device=3)
+            data_a = pld.tensor.allreduce(data_a, op=pld.ReduceOp.Sum)
+            data_b = pld.tensor.allreduce(data_b, op=pld.ReduceOp.Sum)
+            return data_a
+
+    result = _apply(P)
+    host = _get_func(result, "host_orch")
+    stmts = _flatten_stmts(host.body)
+    signal_windows = [
+        stmt
+        for stmt in stmts
+        if isinstance(stmt, ir.AssignStmt)
+        and isinstance(stmt.value, ir.Call)
+        and stmt.value.op.name == _OP_PLD_TENSOR_WINDOW
+        and stmt.var.name_hint.startswith("__allreduce_signal_")
+    ]
+    allreduces = [
+        stmt.value
+        for stmt in stmts
+        if isinstance(stmt, ir.AssignStmt)
+        and isinstance(stmt.value, ir.Call)
+        and stmt.value.op.name == _OP_PLD_TENSOR_ALLREDUCE
+    ]
+
+    # Two distinct data lineages -> two distinct synthesized signals.
+    assert len(signal_windows) == 2
+    assert len(allreduces) == 2
+    signal_names = {stmt.var.name_hint for stmt in signal_windows}
+    assert len(signal_names) == 2
+    for ar in allreduces:
+        assert len(ar.args) == 2
+        assert _as_var(ar.args[1]).name_hint in signal_names
+
+    # After materialization, each (data, signal) pair lands in its own
+    # comm-domain scope: {0,1} for buf_a and {2,3} for buf_b.
+    scopes = _get_comm_domain_scopes(host)
+    assert len(scopes) == 2
+    assert list(scopes[0].devices) == [0, 1]
+    assert [slot.base.name_hint for slot in scopes[0].slots] == ["__allreduce_signal_buf_0", "buf_a__ssa_v0"]
+    assert list(scopes[1].devices) == [2, 3]
+    assert [slot.base.name_hint for slot in scopes[1].slots] == ["__allreduce_signal_buf_1", "buf_b__ssa_v0"]
 
 
 def test_optional_signal_allreduce_round_trips_before_materialization():
@@ -525,6 +602,56 @@ def test_synthesize_multicore_allreduce_signal_uses_core_lanes_and_bytes():
     assert alloc_size.left.right.value == 4
 
 
+def test_implicit_allreduce_core_num_widening_sizes_signal_to_max():
+    """Two implicit allreduces over the same data buffer with different
+    core_num share ONE synthesized signal, sized to the widest core_num (the
+    allow_wider_lanes contract in LowerHostTensorCollectives)."""
+
+    @pl.program
+    class P:
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def chip_orch(self, data: pld.DistributedTensor[[256], pl.FP32]):
+            return data
+
+        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+        def host_orch(self):
+            data_buf = pld.alloc_window_buffer(256 * pl.FP32.get_byte())
+            data = pld.window(data_buf, [256], dtype=pl.FP32)
+            for r in pl.range(pld.world_size()):
+                self.chip_orch(data, device=r)
+            a = pld.tensor.allreduce(data, core_num=1)
+            b = pld.tensor.allreduce(data, core_num=4)
+            return a, b
+
+    result = _apply(P)
+    host = _get_func(result, "host_orch")
+    stmts = _flatten_stmts(host.body)
+    signal_windows = [
+        stmt
+        for stmt in stmts
+        if isinstance(stmt, ir.AssignStmt)
+        and isinstance(stmt.value, ir.Call)
+        and stmt.value.op.name == _OP_PLD_TENSOR_WINDOW
+        and stmt.var.name_hint.startswith("__allreduce_signal_")
+    ]
+    allreduces = [
+        stmt
+        for stmt in stmts
+        if isinstance(stmt, ir.AssignStmt)
+        and isinstance(stmt.value, ir.Call)
+        and stmt.value.op.name == _OP_PLD_TENSOR_ALLREDUCE
+    ]
+    assert len(signal_windows) == 1
+    assert len(allreduces) == 2
+    signal_type = signal_windows[0].var.type
+    assert isinstance(signal_type, ir.DistributedTensorType)
+    assert isinstance(signal_type.shape[1], ir.ConstInt)
+    assert signal_type.shape[1].value == 4  # widened to the max core_num
+    # Both calls reuse the one shared signal.
+    signals = {_as_var(_as_call(stmt.value).args[1]).name_hint for stmt in allreduces}
+    assert signals == {signal_windows[0].var.name_hint}
+
+
 def test_synthesized_allreduce_signal_round_trips_after_materialization():
     @pl.program
     class P:
@@ -642,7 +769,11 @@ def test_implicit_allreduce_signal_names_are_program_unique():
         ),
     )
 
-    result = _apply(program)
+    # NOTE: deliberately NOT `_apply` (which runs ConvertToSSA first) — this
+    # test pre-defines user vars named `__allreduce_*`, which SSA cannot rename
+    # (reserved `__` delimiter in auto-name bases) and which are exactly what
+    # the synthesized-name-uniqueness contract must dodge.
+    result = cast(ir.Program, passes.materialize_comm_domain_scopes()(_synthesize(program)))
     hosts = [_get_func(result, "host_orch_a"), _get_func(result, "host_orch_b")]
     allreduce_signal_args = [
         _as_var(_as_call(stmt.value).args[1]).name_hint
@@ -671,20 +802,28 @@ def test_implicit_allreduce_signal_names_are_program_unique():
         "__allreduce_signal_1",
         "__allreduce_signal_2",
     ]
+    # One shared signal per data-buffer lineage (one per function here, since
+    # each reduces a single buffer), hoisted to the top of the body:
+    # host_orch_a's shared binding is __allreduce_signal_1 (skipping the
+    # user-pre-used _0 names) and precedes the user's hand-written signal.
     assert world_size_vars == [
-        "__allreduce_signal_world_size_0",
         "__allreduce_signal_world_size_1",
+        "__allreduce_signal_world_size_0",
         "__allreduce_signal_world_size_2",
     ]
     assert signal_slots == [
-        "__allreduce_signal_buf_0",
         "__allreduce_signal_buf_1",
+        "__allreduce_signal_buf_0",
         "__allreduce_signal_buf_2",
     ]
     assert len(signal_slots) == len(set(signal_slots))
 
 
-def test_consecutive_implicit_allreduces_get_fresh_signal_slots():
+def test_consecutive_implicit_allreduces_share_one_signal_slot():
+    """Consecutive implicit allreduces over the same buffer share ONE
+    synthesized signal slot (safe since the host builtin kernels self-clear
+    their barrier cells after each call)."""
+
     @pl.program
     class P:
         @pl.function(type=pl.FunctionType.Orchestration)
@@ -705,11 +844,65 @@ def test_consecutive_implicit_allreduces_get_fresh_signal_slots():
     host = _get_func(result, "host_orch")
     scopes = _get_comm_domain_scopes(host)
     assert len(scopes) == 1
+    # Shared binding is hoisted to the top, so the signal buffer slot precedes data_buf.
     assert [slot.base.name_hint for slot in scopes[0].slots] == [
-        "data_buf",
         "__allreduce_signal_buf_0",
-        "__allreduce_signal_buf_1",
+        "data_buf__ssa_v0",
     ]
+    allreduces = [
+        _as_call(stmt.value)
+        for stmt in _flatten_stmts(host.body)
+        if isinstance(stmt, ir.AssignStmt)
+        and isinstance(stmt.value, ir.Call)
+        and stmt.value.op.name == _OP_PLD_TENSOR_ALLREDUCE
+    ]
+    assert len(allreduces) == 2
+    assert _as_var(allreduces[0].args[1]).name_hint == "__allreduce_signal_0"
+    assert _as_var(allreduces[1].args[1]).name_hint == "__allreduce_signal_0"
+
+
+def test_implicit_allreduce_inside_loop_uses_shared_signal():
+    """An implicit-signal allreduce inside a for loop is accepted (previously
+    rejected as a single-use signal) and reuses the buffer's one shared
+    signal, hoisted outside the loop."""
+
+    @pl.program
+    class P:
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def chip_orch(self, data: pld.DistributedTensor[[256], pl.FP32]):
+            return data
+
+        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+        def host_orch(self):
+            data_buf = pld.alloc_window_buffer(256 * pl.FP32.get_byte())
+            data = pld.window(data_buf, [256], dtype=pl.FP32)
+            for r in pl.range(pld.world_size()):
+                self.chip_orch(data, device=r)
+            for it in pl.range(2):
+                data = pld.tensor.allreduce(data, op=pld.ReduceOp.Sum)
+            return data
+
+    result = _apply(P)
+    host = _get_func(result, "host_orch")
+    signal_windows = [
+        stmt
+        for stmt in _flatten_stmts(host.body)
+        if isinstance(stmt, ir.AssignStmt)
+        and isinstance(stmt.value, ir.Call)
+        and stmt.value.op.name == _OP_PLD_TENSOR_WINDOW
+        and stmt.var.name_hint.startswith("__allreduce_signal_")
+    ]
+    allreduces = [
+        stmt
+        for stmt in _flatten_stmts(host.body)
+        if isinstance(stmt, ir.AssignStmt)
+        and isinstance(stmt.value, ir.Call)
+        and stmt.value.op.name == _OP_PLD_TENSOR_ALLREDUCE
+    ]
+    # One shared signal hoisted to the top; the (single) in-loop allreduce reuses it.
+    assert len(signal_windows) == 1
+    assert len(allreduces) == 1
+    assert _as_var(_as_call(allreduces[0].value).args[1]).name_hint == signal_windows[0].var.name_hint
 
 
 def test_synthesize_allreduce_signals_reserves_existing_alloc_names():
@@ -746,7 +939,9 @@ def test_synthesize_allreduce_signals_reserves_existing_alloc_names():
         and stmt.value.op.name == _OP_PLD_TENSOR_ALLOC_WINDOW_BUFFER
     ]
 
-    assert alloc_names == ["__allreduce_signal_buf_0", "__allreduce_signal_buf_1"]
+    # Shared binding is hoisted to the top, so the synthesized alloc precedes the
+    # user's pre-existing __allreduce_signal_buf_0 alloc.
+    assert alloc_names == ["__allreduce_signal_buf_1", "__allreduce_signal_buf_0"]
 
 
 def test_ssa_allreduce_result_keeps_source_window_lineage():
@@ -784,10 +979,11 @@ def test_ssa_allreduce_result_keeps_source_window_lineage():
     scopes = _get_comm_domain_scopes(host)
 
     assert len(scopes) == 1
+    # Shared signal binding is hoisted to the top of the body, so its slot precedes data_buf.
     assert [slot.base.name_hint for slot in scopes[0].slots] == [
-        "data_buf",
-        "signal_buf",
         "__allreduce_signal_buf_0",
+        "data_buf__ssa_v0",
+        "signal_buf__ssa_v0",
     ]
 
 
@@ -830,9 +1026,10 @@ def test_return_implicit_allreduce_is_lifted_for_host_lowering():
 
     scopes = _get_comm_domain_scopes(host)
     assert len(scopes) == 1
+    # Shared signal binding is hoisted to the top of the body, so its slot precedes data_buf.
     assert [slot.base.name_hint for slot in scopes[0].slots] == [
-        "data_buf",
         "__allreduce_signal_buf_0",
+        "data_buf__ssa_v0",
     ]
 
 
@@ -873,7 +1070,7 @@ def test_return_explicit_allreduce_is_lifted_for_host_lowering():
     assert synthetic_assigns == []
     assert len(allreduce_assigns) == 1
     assert allreduce_assigns[0].var.name_hint.startswith("__allreduce_result_")
-    assert _as_var(_as_call(allreduce_assigns[0].value).args[1]).name_hint == "signal"
+    assert _as_var(_as_call(allreduce_assigns[0].value).args[1]).name_hint == "signal__ssa_v0"
     assert len(returns) == 1
     assert isinstance(returns[0].value[0], ir.Var)
     assert returns[0].value[0] is allreduce_assigns[0].var
@@ -913,9 +1110,10 @@ def test_implicit_allreduce_eval_stmt_gets_signal():
 
     scopes = _get_comm_domain_scopes(host)
     assert len(scopes) == 1
+    # Shared signal binding is hoisted to the top of the body, so its slot precedes data_buf.
     assert [slot.base.name_hint for slot in scopes[0].slots] == [
-        "data_buf",
         "__allreduce_signal_buf_0",
+        "data_buf__ssa_v0",
     ]
 
 
@@ -955,14 +1153,14 @@ def test_explicit_allreduce_eval_stmt_keeps_user_signal():
 
     assert synthetic_assigns == []
     assert len(allreduces) == 1
-    assert _as_var(allreduces[0].args[1]).name_hint == "signal"
+    assert _as_var(allreduces[0].args[1]).name_hint == "signal__ssa_v0"
 
 
-def test_implicit_allreduce_in_loop_is_rejected():
-    """The HOST-rail signal synthesis cannot allocate a fresh signal per dynamic
-    iteration, so an allreduce that omits its signal is rejected inside a loop.
-    Passing one explicitly is accepted - see the ``_is_accepted`` cases below.
-    """
+def test_implicit_allreduce_in_while_loop_uses_shared_signal():
+    """An implicit-signal allreduce inside a while loop is accepted: ONE shared
+    signal is synthesized (hoisted before the loop) and the in-loop call reuses
+    it — safe because the host builtin kernels self-clear their barrier cells
+    after each call."""
 
     @pl.program
     class P:
@@ -976,33 +1174,32 @@ def test_implicit_allreduce_in_loop_is_rejected():
             data = pld.window(data_buf, [256], dtype=pl.FP32)
             for r in pl.range(pld.world_size()):
                 self.chip_orch(data, device=r)
-            for _ in pl.range(2):
-                data = pld.tensor.allreduce(data, op=pld.ReduceOp.Sum)
-            return data
-
-    with pytest.raises(ValueError, match="without an explicit signal is not supported inside a for/while"):
-        _apply(P)
-
-
-def test_implicit_allreduce_in_while_loop_is_rejected():
-    @pl.program
-    class P:
-        @pl.function(type=pl.FunctionType.Orchestration)
-        def chip_orch(self, data: pld.DistributedTensor[[256], pl.FP32]):
-            return data
-
-        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
-        def host_orch(self):
-            data_buf = pld.alloc_window_buffer(256 * pl.FP32.get_byte())
-            data = pld.window(data_buf, [256], dtype=pl.FP32)
             for r in pl.range(pld.world_size()):
                 self.chip_orch(data, device=r)
             while True:
                 data = pld.tensor.allreduce(data, op=pld.ReduceOp.Sum)
             return data
 
-    with pytest.raises(ValueError, match="without an explicit signal is not supported inside a for/while"):
-        _apply(P)
+    synthesized = _synthesize(P)
+    host = _get_func(synthesized, "host_orch")
+    signal_windows = [
+        stmt
+        for stmt in _flatten_stmts(host.body)
+        if isinstance(stmt, ir.AssignStmt)
+        and isinstance(stmt.value, ir.Call)
+        and stmt.value.op.name == _OP_PLD_TENSOR_WINDOW
+        and stmt.var.name_hint.startswith("__allreduce_signal_")
+    ]
+    allreduces = [
+        stmt
+        for stmt in _flatten_stmts(host.body)
+        if isinstance(stmt, ir.AssignStmt)
+        and isinstance(stmt.value, ir.Call)
+        and stmt.value.op.name == _OP_PLD_TENSOR_ALLREDUCE
+    ]
+    assert len(signal_windows) == 1
+    assert len(allreduces) == 1
+    assert _as_var(_as_call(allreduces[0].value).args[1]).name_hint == signal_windows[0].var.name_hint
 
 
 def test_explicit_allreduce_in_loop_is_accepted():

--- a/tests/ut/ir/transforms/test_simplify_pass.py
+++ b/tests/ut/ir/transforms/test_simplify_pass.py
@@ -26,6 +26,8 @@ import pypto.language.distributed as pld
 import pytest
 from pypto import ir, passes
 
+_OP_PLD_TENSOR_ALLREDUCE = ir.get_op("pld.tensor.allreduce").name
+
 # ============================================================================
 # Pass metadata
 # ============================================================================
@@ -1673,6 +1675,92 @@ class TestDeadIfReturnVarsDCE:
 
         assert has_tensor_write(then_stmts), "tensor.write side-effect in then branch must survive phi-prune"
         assert has_tensor_write(else_stmts), "tensor.write side-effect in else branch must survive phi-prune"
+
+
+class TestDistributedWindowBufferRemap:
+    def test_window_buffer_remapped_in_lockstep_with_scope_slot(self):
+        """Simplify folding a synthesized signal's window-buffer size
+        (``world_size * 1 * 4`` → ``world_size * 4``) must remap the
+        ``DistributedTensorType.window_buffer_`` back-reference in lockstep
+        with the ``CommDomainScopeStmt`` slot — both must point at the SAME
+        post-fold ``WindowBuffer``. Regression: the type rebuild left
+        ``window_buffer_`` on the pre-fold object, so
+        ``DistributedCodegen::ScopeForWindowBuffer``'s pointer-identity scan
+        failed with "not a slot of any open CommDomainScopeStmt".
+        """
+
+        @pl.program
+        class P:
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def chip_orch(self, data: pld.DistributedTensor[[256], pl.FP32]):
+                return data
+
+            @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+            def host_orch(self):
+                data_buf = pld.alloc_window_buffer(256 * pl.FP32.get_byte())
+                data = pld.window(data_buf, [256], dtype=pl.FP32)
+                for r in pl.range(pld.world_size()):
+                    self.chip_orch(data, device=r)
+                data = pld.tensor.allreduce(data, op=pld.ReduceOp.Sum)
+                return data
+
+        # NOTE: run under a BEFORE_AND_AFTER-only context (no print/parse
+        # roundtrip) — the materialize pass's output wraps the body in
+        # CommDomainScopeStmt and stamps window_buffer_ back-references on
+        # view Vars, neither of which the printer/parser pair roundtrips
+        # (same override the materialize test file applies to all its passes).
+        # The in-memory structural check below is the point of this test.
+        instruments: list[passes.PassInstrument] = [
+            passes.VerificationInstrument(passes.VerificationMode.BEFORE_AND_AFTER)
+        ]
+        with passes.PassContext(instruments):
+            materialized = passes.materialize_comm_domain_scopes()(passes.synthesize_allreduce_signals()(P))
+            simplified = passes.simplify()(materialized)
+        host = next(f for f in simplified.functions.values() if f.name == "host_orch")
+
+        # `ir.flatten_to_stmts` does not descend into CommDomainScopeStmt
+        # bodies, so walk recursively (the materialize test file uses the same
+        # shape for the same reason).
+        def walk(stmt):
+            out = [stmt]
+            if isinstance(stmt, ir.SeqStmts):
+                for child in stmt.stmts:
+                    out.extend(walk(child))
+            if isinstance(stmt, ir.ScopeStmt):
+                out.extend(walk(stmt.body))
+            if isinstance(stmt, ir.ForStmt):
+                out.extend(walk(stmt.body))
+            if isinstance(stmt, ir.WhileStmt):
+                out.extend(walk(stmt.body))
+            return out
+
+        stmts = walk(host.body)
+
+        scopes = [s for s in stmts if isinstance(s, ir.CommDomainScopeStmt)]
+        assert len(scopes) == 1
+        signal_slots = [
+            slot for slot in scopes[0].slots if slot.base.name_hint.startswith("__allreduce_signal_buf_")
+        ]
+        assert len(signal_slots) == 1
+
+        allreduce_assigns = [
+            s
+            for s in stmts
+            if isinstance(s, ir.AssignStmt)
+            and isinstance(s.value, ir.Call)
+            and s.value.op.name == _OP_PLD_TENSOR_ALLREDUCE
+        ]
+        assert len(allreduce_assigns) == 1
+        allreduce_call = allreduce_assigns[0].value
+        assert isinstance(allreduce_call, ir.Call)
+        signal_var = allreduce_call.args[1]
+        assert isinstance(signal_var, ir.Var)
+        signal_type = signal_var.type
+        assert isinstance(signal_type, ir.DistributedTensorType)
+
+        # The view Var's window_buffer back-reference must be the SAME object
+        # as the scope slot (both post-fold).
+        assert signal_type.window_buffer is signal_slots[0]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Synthesize one shared allreduce signal per **data-buffer lineage (device-coverage) group** in a host-orchestration function — hoisted to the top of the body — instead of a fresh signal per implicit-signal call. Every implicit-signal `pld.tensor.allreduce` call is rewritten to pass the signal shared by calls over the same data buffer, including calls inside `for` / `while` loops.

This lifts the host-rail in-loop restriction that previously forced an error (`Allreduce rejected inside loop`) for the *implicit*-signal (single-argument) form. It is safe because the host builtin kernels now self-clear their barrier cells after every call (landed in #2279), so a reused signal is correct across back-to-back and loop-carried calls.

Signals are keyed by **data-buffer lineage** rather than one-per-function: tracing each data argument back through `pld.tensor.window` to its `pld.tensor.alloc_window_buffer` LHS means a single function that implicitly reduces buffers over *different* device subsets gets *distinct* signals. Each `(data, signal)` pair therefore stays in its own comm-domain scope — a single per-function signal would merge both subsets into one scope and make `LowerHostTensorCollectives` reject every call.

Closes #2310.

## Why this is now unblocked

#2279 folded the *explicit*-signal in-loop lift into itself (`CheckAllReduceCall` now rejects only the omitted-signal case). This PR covers the remaining *implicit*-signal (synthesized) case — the one #2310 tracks.

## What changed

- **`SynthesizeAllReduceSignals`** (`synthesize_allreduce_signals_pass.cpp`): synthesize one shared signal per data-buffer lineage group instead of per call or per function. An `AllReduceSignalNeedFinder` pre-scan records the 1-arg calls (`{data, core_num}`) and each `Var`'s defining RHS; `ResolveLineageKey` follows a data `Var`'s def chain (through `Var` aliases, `pld.tensor.window`, `pld.tensor.allreduce`, and the target args of `all_to_all`/`allgather`/`all_to_all_v`) back to its `alloc_window_buffer` LHS. Calls are partitioned by that lineage key in first-appearance order, each group gets one hoisted `world_size` / `alloc_window_buffer` / `window` binding sized to the group's widest `core_num`, and `AllReduceSignalSynthesizer` resolves each 1-arg call's signal through a `SignalLookup` keyed by lineage. The 2-arg (explicit-signal) path is unchanged, and the loop-depth rejection path is removed.
- **`MaterializeCommDomainScopes`** (`materialize_comm_domain_scopes_pass.cpp`): handle SSA loop-carried data. `ConvertToSSA` runs before this pass, and a loop-carried value is an `IterArg` (its own `ObjectKind`, so `As<Var>` misses it): `ResolveWindowAlloc` / `ResolveWindowRecord` / the dispatch-arg site use `AsVarLike` and resolve an `IterArg` through its `initValue_` (same pattern as `InferTileMemorySpace` #2547). The view substitution additionally re-types collective results and loop carries (iter_args/return_vars) with the shared `WindowBuffer` so the typecheck verifier's pointer-identity check holds across the loop-carry edges.
- **Simplify** (`simplify_pass.cpp`): remap `DistributedTensorType::window_buffer_` in lockstep with the `CommDomainScopeStmt` slots. `Simplify` folds the synthesized signal size `world_size * 1 * 4` → `world_size * 4`, minting a fresh `WindowBuffer` for the scope slot; previously the type rebuild left `window_buffer_` pointing at the pre-fold object, so `DistributedCodegen::ScopeForWindowBuffer`'s pointer-identity scan failed with "not a slot of any open CommDomainScopeStmt". This surfaced only in distributed sim (the shared signal allocates inside a foldable expression).
- **Pass properties** (`pass_properties.h`): record the SSA single-assignment assumption on `kSynthesizeAllReduceSignalsProperties` (SSAForm is deliberately not declared `required` — `kInitMemRefProperties` invalidates it and nothing re-produces it); multi-assignment robustness is a tracked follow-up shared with `MaterializeCommDomainScopes`.
- **Unit tests** (`test_materialize_comm_domain_scopes.py`): the harness now runs `ConvertToSSA` first (matching the real pipeline; `name_hint` assertions updated for the SSA renames); loop-rejection tests became positive shared-signal/in-loop acceptance tests; added `test_implicit_allreduce_over_distinct_subsets_gets_distinct_signals` (two buffers dispatched to `{0,1}` and `{2,3}`, each implicitly reduced → two distinct signals and two comm-domain scopes) and `test_implicit_allreduce_core_num_widening_sizes_signal_to_max` (two implicit calls, `core_num` 1 and 4, share one signal sized to 4 — the `allow_wider_lanes` contract). `test_simplify_pass.py` adds `TestDistributedWindowBufferRemap::test_window_buffer_remapped_in_lockstep_with_scope_slot`, asserting the view Var's `window_buffer` and the scope slot are the same object post-fold (reverting the `simplify_pass.cpp` hunk fails it).
- **System test** (`test_l3_host_tensor_allreduce.py`): add `test_host_tensor_allreduce_loop` covering implicit-signal allreduce in a loop, with per-round distinct inputs so a missed epilogue reset on a reused signal cannot pass spuriously.
- **Docs** (en + zh): rewrite the pass algorithm for the shared-signal-per-lineage model; drop the "Allreduce rejected inside loop" debugging row; note signal reusability for the self-clearing host builtins and that distinct data buffers get distinct signals.

## Test plan

- Sim UT: full `tests/ut` green on head `0ebfb2f0` — 10632 passed / 14 skipped / 3 xfailed (2 unrelated Docker-environment failures: `test_repository_is_clean` runs `git ls-files` from inside the container against a worktree `.git` outside the mount; `test_symlinked_import_path_still_names_the_caller` is bypassed by the editable install). Includes the new distinct-subset, core_num-widening, and Simplify window-buffer-remap regression UTs.
- Distributed sim ST (`a2a3sim`, `--shm-size=4g`): `test_l3_host_tensor_allreduce{,_multicore}.py` = **15 passed / 6 failed**; the 6 failures are pre-existing baselines reproduced identically on pristine `origin/main` (Max/Min are an NPU-only gate; the two multicore `p2-c4-wide-stride` cases are documented flaky under load). The new `test_host_tensor_allreduce_loop` passes P=2/P=4.
- Pre-commit: green (ruff, pyright, clang-format, cpplint, markdownlint, repo lints) — including the review-round fixes for pyright typing, `misc-include-cleaner` (`pypto/ir/core.h` for `ObjectKind`), and `check-op-name-literals`.
- NPU ST (pending, developer): `tests/st/distributed/test_l3_host_tensor_allreduce.py` P=2 / P=4.

## Notes

- Rebased on latest `origin/main` (`28cf265e`) with all four review-round items addressed (IterArg handling in both passes, SSA-first test harness, Simplify/core_num regression UTs, SSA-dependency comment).
- Per-lineage keying (rather than one-per-function) addresses a correctness gap surfaced in review: implicit allreduces over disjoint device subsets must not share a signal.
- Loop-carried lineage resolution keys every iteration to the carry's first-iteration lineage; a loop ping-ponging between *different-coverage* windows is a documented limitation.
