### PR TITLE
fix(codegen): Forward runtime lanes to split AIV FIFOs

### DIFF
--- a/docs/en/dev/codegen/00-pto_codegen.md
+++ b/docs/en/dev/codegen/00-pto_codegen.md
@@ -914,11 +914,13 @@ function has no synthetic subblock parameter already, the backend adds a
 private trailing parameter to the generated function. The explicit overload
 derives the byte offset from each call's actual tile type, so one automatic
 pipe can safely carry differently sized sequential transfers. Like block
-identity, the runtime lane is emitted unconditionally (no `__CPU_SIM` fork)
-because `GlobalContext.sub_block_id` is populated by the scheduler on every
-platform. CPU simulation and in-core cost-model builds retain PTO-ISA's normal
-two-argument endpoint because those implementations already model their lane
-context and do not expose the device-only explicit-lane overload.
+identity, the wrapper resolves the runtime lane unconditionally because
+`GlobalContext.sub_block_id` is populated by the scheduler on every platform.
+The endpoint argument is build-guarded: device builds pass the lane to the
+explicit overload, while CPU simulation and in-core cost-model builds retain
+PTO-ISA's normal two-argument endpoint because those implementations already
+model their lane context and do not expose the device-only explicit-lane
+overload.
 
 **Detection scope.** Both layers detect SPMD usage on a per-function basis:
 

--- a/docs/en/dev/codegen/00-pto_codegen.md
+++ b/docs/en/dev/codegen/00-pto_codegen.md
@@ -905,11 +905,20 @@ scheduler stores in `GlobalContext.sub_block_id`) and appends
 `__pypto_spmd_subblock_idx` after any block-identity args. It deliberately
 reads the runtime lane id rather than the ccec `get_subblockid()` register,
 which returns a stale value under the `tensormap_and_ringbuffer` dispatch.
-This is independent of — and coexists with — the `get_subblockid()` macro
-bridge (`pypto_runtime_subblock_id`) that A2A3 dual-AIV wrappers install for
-ptoas-*internal* pipe-slot offsets. Like block identity, it is emitted
-unconditionally (no `__CPU_SIM` fork) because `GlobalContext.sub_block_id` is
-populated by the scheduler on every platform.
+
+Split AIV FIFO endpoints use that runtime value even when the tensor program
+does not call `tile.get_subblock_idx()`: after PTOAS lowers a split endpoint,
+the wrapper backend forwards the lane as the third argument of PTO-ISA's
+explicit `TPUSH(pipe, tile, subblock_id)` / `TPOP(...)` overload. If the
+function has no synthetic subblock parameter already, the backend adds a
+private trailing parameter to the generated function. The explicit overload
+derives the byte offset from each call's actual tile type, so one automatic
+pipe can safely carry differently sized sequential transfers. Like block
+identity, the runtime lane is emitted unconditionally (no `__CPU_SIM` fork)
+because `GlobalContext.sub_block_id` is populated by the scheduler on every
+platform. CPU simulation and in-core cost-model builds retain PTO-ISA's normal
+two-argument endpoint because those implementations already model their lane
+context and do not expose the device-only explicit-lane overload.
 
 **Detection scope.** Both layers detect SPMD usage on a per-function basis:
 
@@ -918,7 +927,9 @@ populated by the scheduler on every platform.
   block / subblock params to a given function's signature.
 - `_uses_spmd_block_ops` / `_uses_dynamic_subblock_id` (Python,
   `python/pypto/backend/pto_backend.py`) drive whether the wrapper appends the
-  matching locals to the inner call site.
+  matching locals to the inner call site. Split `TPUSH` / `TPOP` endpoints are
+  additionally detected by `_runtime_split_fifo_endpoint_counts`; they reuse
+  that subblock argument or request the private one described above.
 
 For non-SPMD sibling functions in an SPMD group (`group_uses_spmd=True` but
 the function itself does not call `tile.get_block_*`), the wrapper still
@@ -928,7 +939,7 @@ the inner call, matching the function's MLIR signature.
 
 This replaces the earlier macro-shadow + `[[block_local]] static` /
 `static thread_local` bridge plus `#pragma push_macro` / `#undef` /
-`pop_macro` dance. Block identity now flows through the call graph like
+`pop_macro` dance. Block and lane identity now flow through the call graph like
 every other per-launch value (tensor pointers, scalar args, dynamic dims).
 
 ### Implementation

--- a/docs/zh/dev/codegen/00-pto_codegen.md
+++ b/docs/zh/dev/codegen/00-pto_codegen.md
@@ -858,11 +858,17 @@ wrapper 从 `intrinsic.h::get_sub_block_id(args)`(调度器写入
 `GlobalContext.sub_block_id` 的运行时 per-core lane id)解析出值,并把
 `__pypto_spmd_subblock_idx` 追加在 block 身份实参之后。它刻意读取运行时
 lane id,而非 ccec `get_subblockid()` 寄存器 -- 后者在
-`tensormap_and_ringbuffer` 调度下返回过期值。这与 A2A3 dual-AIV wrapper 为
-ptoas **内部** pipe-slot 偏移安装的 `get_subblockid()` 宏桥接
-(`pypto_runtime_subblock_id`)相互独立、并存。与 block 身份一样,它无条件发射
-(无 `__CPU_SIM` 分叉),因为 `GlobalContext.sub_block_id` 在每个平台都由调度器
-填充。
+`tensormap_and_ringbuffer` 调度下返回过期值。
+
+即使张量程序没有调用 `tile.get_subblock_idx()`，split AIV FIFO 端点也会使用这个
+运行时值：PTOAS 下沉 split 端点后，wrapper 后端把 lane 作为 PTO-ISA 显式重载
+`TPUSH(pipe, tile, subblock_id)` / `TPOP(...)` 的第三个实参传入。如果函数还没有
+合成的 subblock 形参，后端会给生成函数增加一个私有尾随形参。显式重载根据每次调用
+的实际 tile 类型推导字节偏移，因此同一个自动 pipe 可以安全承载大小不同的连续传输。
+与 block 身份一样，运行时 lane 无条件发射（无 `__CPU_SIM` 分叉），因为
+`GlobalContext.sub_block_id` 在每个平台都由调度器填充。CPU simulation 和 in-core
+cost-model 构建保留 PTO-ISA 的普通双实参端点，因为这些实现已经对 lane context
+建模，且不提供仅用于 device 的显式 lane 重载。
 
 **检测范围。** 两层各自基于函数体独立检测 SPMD usage:
 
@@ -871,7 +877,9 @@ ptoas **内部** pipe-slot 偏移安装的 `get_subblockid()` 宏桥接
   block / subblock 形参。
 - `_uses_spmd_block_ops` / `_uses_dynamic_subblock_id`(Python，位于
   `python/pypto/backend/pto_backend.py`)决定 wrapper 是否把相应局部变量追加到
-  对内函数调用末尾。
+  对内函数调用末尾。split `TPUSH` / `TPOP` 端点还由
+  `_runtime_split_fifo_endpoint_counts` 检测；它们复用该 subblock 实参，或请求上述
+  私有形参。
 
 对于 SPMD 组内自身不调用 `tile.get_block_*` 的 sibling 函数
 (`group_uses_spmd=True` 但函数本身不用 SPMD ops)，wrapper 仍会声明这两个
@@ -880,7 +888,7 @@ ptoas **内部** pipe-slot 偏移安装的 `get_subblockid()` 宏桥接
 
 此设计替换了旧的宏 shadow + `[[block_local]] static` /
 `static thread_local` 桥接以及 `#pragma push_macro` / `#undef` /
-`pop_macro` 舞步。block 身份现在与张量指针、标量参数、动态维一样
+`pop_macro` 舞步。block 和 lane 身份现在与张量指针、标量参数、动态维一样
 通过调用图正常传递。
 
 ### 实现

--- a/docs/zh/dev/codegen/00-pto_codegen.md
+++ b/docs/zh/dev/codegen/00-pto_codegen.md
@@ -865,10 +865,11 @@ lane id,而非 ccec `get_subblockid()` 寄存器 -- 后者在
 `TPUSH(pipe, tile, subblock_id)` / `TPOP(...)` 的第三个实参传入。如果函数还没有
 合成的 subblock 形参，后端会给生成函数增加一个私有尾随形参。显式重载根据每次调用
 的实际 tile 类型推导字节偏移，因此同一个自动 pipe 可以安全承载大小不同的连续传输。
-与 block 身份一样，运行时 lane 无条件发射（无 `__CPU_SIM` 分叉），因为
-`GlobalContext.sub_block_id` 在每个平台都由调度器填充。CPU simulation 和 in-core
-cost-model 构建保留 PTO-ISA 的普通双实参端点，因为这些实现已经对 lane context
-建模，且不提供仅用于 device 的显式 lane 重载。
+与 block 身份一样，wrapper 会无条件解析运行时 lane，因为
+`GlobalContext.sub_block_id` 在每个平台都由调度器填充。端点实参则受构建条件保护：
+device 构建会把 lane 传给显式重载，而 CPU simulation 和 in-core cost-model 构建保留
+PTO-ISA 的普通双实参端点，因为这些实现已经对 lane context 建模，且不提供仅用于
+device 的显式 lane 重载。
 
 **检测范围。** 两层各自基于函数体独立检测 SPMD usage:
 

--- a/python/pypto/backend/pto_backend.py
+++ b/python/pypto/backend/pto_backend.py
@@ -665,6 +665,12 @@ _SPMD_BLOCK_OPS = frozenset(
     {_ir_core.get_op("tile.get_block_idx").name, _ir_core.get_op("tile.get_block_num").name}
 )
 _SUBBLOCK_OPS = frozenset({_ir_core.get_op("tile.get_subblock_idx").name})
+_AIV_FIFO_ENDPOINT_OPS = frozenset(
+    {
+        _ir_core.get_op("tile.tpop_from_aic").name,
+        _ir_core.get_op("tile.tpush_to_aic").name,
+    }
+)
 _SDMA_WORKSPACE_OPS = frozenset({_ir_core.get_op("prefetch.make_context").name})
 _DEFERRED_COMPLETION_OPS = frozenset({_ir_core.get_op("pld.system.defer_wait").name})
 
@@ -699,10 +705,10 @@ def _function_uses_ops(func: _ir_core.Function, op_names: frozenset[str]) -> boo
 def _uses_dynamic_subblock_id(func: _ir_core.Function) -> bool:
     """Return whether the function reads subblock id from the runtime lane context.
 
-    Drives both the runtime-subblock macro bridge and the synthetic
-    ``%__pypto_spmd_subblock_idx`` param forwarded by the kernel wrapper, so it
-    must detect ``tile.get_subblock_idx`` wherever it appears (including nested
-    in larger expressions) to stay consistent with the C++ signature emission.
+    Drives the synthetic ``%__pypto_spmd_subblock_idx`` param forwarded by the
+    kernel wrapper, so it must detect ``tile.get_subblock_idx`` wherever it
+    appears (including nested in larger expressions) to stay consistent with
+    the C++ signature emission.
     """
     return _function_uses_ops(func, _SUBBLOCK_OPS)
 
@@ -736,15 +742,195 @@ def _uses_spmd_block_ops(func: _ir_core.Function) -> bool:
     return _function_uses_ops(func, _SPMD_BLOCK_OPS)
 
 
-def _needs_runtime_subblock_bridge(func: _ir_core.Function) -> bool:
-    """Return whether A2A3 split AIV wrappers must source subblock id from runtime context."""
+def _runtime_split_fifo_endpoint_counts(func: _ir_core.Function) -> tuple[int, int]:
+    """Return split AIV ``(TPUSH, TPOP)`` endpoint counts needing runtime lane identity."""
+
     if not _requires_dual_aiv_dispatch(func):
-        return False
+        return 0, 0
+    if _get_fixed_subblock_id(func) is not None:
+        return 0, 0
     if _codegen_core.infer_function_core_type(func) != _ir_core.CoreType.VECTOR:
-        return False
+        return 0, 0
     if not _backend_core.get_handler().requires_runtime_subblock_bridge():
-        return False
-    return _uses_dynamic_subblock_id(func)
+        return 0, 0
+
+    counts = {"tile.tpush_to_aic": 0, "tile.tpop_from_aic": 0}
+
+    class _EndpointFinder(_ir_core.IRVisitor):
+        def visit_call(self, op: _ir_core.Call) -> None:
+            ir_op = getattr(op, "op", None)
+            name = ir_op.name if isinstance(ir_op, _ir_core.Op) else ""
+            if name in _AIV_FIFO_ENDPOINT_OPS:
+                split = op.kwargs.get("split", 0)
+                if isinstance(split, bool) or not isinstance(split, int):
+                    raise RuntimeError(
+                        f"{func.name}: cross-core split attribute must be an integer, got {split!r}"
+                    )
+                if split != 0:
+                    counts[name] += 1
+            super().visit_call(op)
+
+    finder = _EndpointFinder()
+    finder.visit_stmt(func.body)
+    return counts["tile.tpush_to_aic"], counts["tile.tpop_from_aic"]
+
+
+def _find_matching_delimiter(
+    code: str,
+    start: int,
+    opening: str,
+    closing: str,
+) -> int:
+    """Return the matching delimiter index in generated PTOAS C++."""
+
+    if start < 0 or start >= len(code) or code[start] != opening:
+        return -1
+    depth = 0
+    for index in range(start, len(code)):
+        char = code[index]
+        if char == opening:
+            depth += 1
+        elif char == closing:
+            depth -= 1
+            if depth == 0:
+                return index
+    return -1
+
+
+def _find_ptoas_function(
+    func_name: str,
+    ptoas_code: str,
+) -> tuple[int, int, int, int]:
+    """Locate one named function in preprocessed PTOAS C++."""
+
+    pattern = re.compile(rf"\bstatic\s+__aicore__\s+void\s+{re.escape(func_name)}\s*(\()")
+    matches = list(pattern.finditer(ptoas_code))
+    if len(matches) != 1:
+        raise RuntimeError(f"{func_name}: expected exactly one PTOAS function definition, got {len(matches)}")
+
+    match = matches[0]
+    params_start = match.start(1)
+    params_end = _find_matching_delimiter(ptoas_code, params_start, "(", ")")
+    if params_end < 0:
+        raise RuntimeError(f"{func_name}: malformed PTOAS function parameter list")
+    body_start = ptoas_code.find("{", params_end)
+    if body_start < 0:
+        raise RuntimeError(f"{func_name}: malformed PTOAS function body")
+    body_end = _find_matching_delimiter(ptoas_code, body_start, "{", "}")
+    if body_end < 0:
+        raise RuntimeError(f"{func_name}: unterminated PTOAS function body")
+    return params_start, params_end, body_start, body_end
+
+
+_SPLIT_FIFO_TEMPLATE_MARKERS = (
+    "TileSplitAxis::TILE_UP_DOWN",
+    "TileSplitAxis::TILE_LEFT_RIGHT",
+    "TileSplitAxis::TILE_UP_DOWN_ODD",
+    "TileSplitAxis::TILE_LEFT_RIGHT_ODD",
+)
+
+_RUNTIME_SPLIT_FIFO_LANE_ARG = "PYPTO_SPLIT_RUNTIME_LANE_ARG"
+
+
+def _second_call_argument_end(code: str, args_start: int, args_end: int, func_name: str) -> int:
+    """Return where a runtime lane argument belongs after a FIFO call's tile argument."""
+
+    depths = {"(": 0, "[": 0, "{": 0, "<": 0}
+    closing_to_opening = {")": "(", "]": "[", "}": "{", ">": "<"}
+    top_level_commas = 0
+    for index in range(args_start + 1, args_end):
+        char = code[index]
+        if char in depths:
+            depths[char] += 1
+        elif char in closing_to_opening:
+            opening = closing_to_opening[char]
+            if depths[opening] > 0:
+                depths[opening] -= 1
+        elif char == "," and all(depth == 0 for depth in depths.values()):
+            top_level_commas += 1
+            if top_level_commas == 2:
+                return index
+    if top_level_commas != 1:
+        raise RuntimeError(f"{func_name}: expected split TPUSH/TPOP to have at least pipe and tile arguments")
+    return args_end
+
+
+def _forward_runtime_lane_to_split_fifo_calls(
+    func: _ir_core.Function,
+    ptoas_code: str,
+) -> tuple[str, bool]:
+    """Pass the runtime AIV lane directly to split PTO-ISA TPUSH/TPOP calls.
+
+    The A2A3 runtime dispatch payload has the authoritative lane identity, while
+    PTO-ISA's zero-argument ``get_subblockid()`` can remain zero on both lanes.
+    Its explicit TPUSH/TPOP overloads calculate the per-call byte offset from
+    the actual tile type, so this remains correct when one automatic FIFO carries
+    differently sized transfers at different points in a mixed kernel.
+    """
+
+    expected_pushes, expected_pops = _runtime_split_fifo_endpoint_counts(func)
+    if expected_pushes == 0 and expected_pops == 0:
+        return ptoas_code, False
+
+    params_start, params_end, body_start, body_end = _find_ptoas_function(func.name, ptoas_code)
+    add_runtime_param = not _uses_dynamic_subblock_id(func)
+    if add_runtime_param:
+        subblock_param = "__pypto_runtime_subblock_idx"
+    else:
+        trailing_param = re.search(
+            r"(?:^|,)\s*int32_t\s+([A-Za-z_]\w*)\s*$",
+            ptoas_code[params_start + 1 : params_end],
+        )
+        if trailing_param is None:
+            raise RuntimeError(
+                f"{func.name}: PTOAS function is missing its trailing runtime subblock parameter"
+            )
+        subblock_param = trailing_param.group(1)
+
+    call_pattern = re.compile(r"\b(TPUSH|TPOP)\s*(<)")
+    insertions: list[tuple[int, str]] = []
+    rewritten_counts = {"TPUSH": 0, "TPOP": 0}
+    position = body_start + 1
+    while (match := call_pattern.search(ptoas_code, position, body_end)) is not None:
+        template_start = match.start(2)
+        template_end = _find_matching_delimiter(ptoas_code, template_start, "<", ">")
+        if template_end < 0 or template_end >= body_end:
+            raise RuntimeError(f"{func.name}: malformed {match.group(1)} template argument list")
+        template_args = ptoas_code[template_start + 1 : template_end]
+        position = template_end + 1
+        if not any(marker in template_args for marker in _SPLIT_FIFO_TEMPLATE_MARKERS):
+            continue
+
+        args_start = template_end + 1
+        while args_start < body_end and ptoas_code[args_start].isspace():
+            args_start += 1
+        if args_start >= body_end or ptoas_code[args_start] != "(":
+            raise RuntimeError(f"{func.name}: malformed split {match.group(1)} call")
+        args_end = _find_matching_delimiter(ptoas_code, args_start, "(", ")")
+        if args_end < 0 or args_end >= body_end:
+            raise RuntimeError(f"{func.name}: unterminated split {match.group(1)} call")
+        insertion_at = _second_call_argument_end(ptoas_code, args_start, args_end, func.name)
+        insertions.append((insertion_at, f" {_RUNTIME_SPLIT_FIFO_LANE_ARG}({subblock_param})"))
+        rewritten_counts[match.group(1)] += 1
+        position = args_end + 1
+
+    if (expected_pushes > 0) != (rewritten_counts["TPUSH"] > 0) or (expected_pops > 0) != (
+        rewritten_counts["TPOP"] > 0
+    ):
+        raise RuntimeError(
+            f"{func.name}: split FIFO endpoints do not match PTOAS calls: "
+            f"IR push/pop={expected_pushes}/{expected_pops}, "
+            f"PTOAS push/pop={rewritten_counts['TPUSH']}/{rewritten_counts['TPOP']}"
+        )
+
+    if add_runtime_param:
+        separator = "" if not ptoas_code[params_start + 1 : params_end].strip() else ", "
+        insertions.append((params_end, f"{separator}int32_t {subblock_param}"))
+
+    rewritten = ptoas_code
+    for insertion_at, text in sorted(insertions, reverse=True):
+        rewritten = rewritten[:insertion_at] + text + rewritten[insertion_at:]
+    return rewritten, True
 
 
 def _generate_kernel_header(
@@ -769,25 +955,11 @@ def _generate_kernel_header(
 
             """
         )
-    elif _needs_runtime_subblock_bridge(func):
-        subblock_override = textwrap.dedent(
-            """\
-            #if !defined(__CPU_SIM)
-            #include "intrinsic.h"
 
-            // A2A3 mixed tasks run the same AIV kernel on two vector cores.
-            // Bridge the runtime-provided lane id into PTO-ISA get_subblockid().
-            [[block_local]] static int32_t pypto_runtime_subblock_id;
-            #define get_subblockid() pypto_runtime_subblock_id
-            #endif
-
-            """
-        )
-
-    # Include intrinsic.h when the wrapper needs runtime SPMD identity or the
-    # SDMA workspace. The SPMD values flow into the kernel as trailing
-    # wrapper-passed parameters, so there is no macro shadow, no
-    # [[block_local]] static / thread_local storage, and no __CPU_SIM fork.
+    # Include intrinsic.h when the wrapper needs runtime SPMD or AIV lane
+    # identity, or the SDMA workspace. Identity values flow into the kernel as
+    # trailing wrapper-passed parameters, so there is no macro shadow or
+    # block-local storage.
     if uses_spmd is None:
         uses_spmd = _uses_spmd_block_ops(func)
     if uses_subblock is None:
@@ -826,23 +998,32 @@ def _generate_kernel_wrapper(
     func_uses_subblock = _uses_dynamic_subblock_id(func)
     func_uses_sdma = _uses_sdma_workspace(func)
     func_uses_deferred_completion = _uses_deferred_completion(func)
+    ptoas_body = _preprocess_ptoas_output(ptoas_code)
+    ptoas_body, fifo_uses_subblock = _forward_runtime_lane_to_split_fifo_calls(func, ptoas_body)
+    wrapper_uses_subblock = func_uses_subblock or fifo_uses_subblock
     header = _generate_kernel_header(
         func,
         uses_spmd=uses_spmd,
-        uses_subblock=func_uses_subblock,
+        uses_subblock=wrapper_uses_subblock,
         uses_sdma=func_uses_sdma,
         uses_deferred_completion=func_uses_deferred_completion,
     )
-    ptoas_body = _preprocess_ptoas_output(ptoas_code)
     unpacking_code, var_names = _generate_arg_unpacking(func, uses_spmd=uses_spmd)
-    runtime_subblock_setup = ""
-    if _needs_runtime_subblock_bridge(func):
-        runtime_subblock_setup = (
-            "#if !defined(__CPU_SIM)\n"
-            "    // Read A2A3 mixed-task subblock id from runtime dispatch context\n"
-            "    pypto_runtime_subblock_id = get_sub_block_id(args);\n"
+
+    fifo_lane_arg_bridge = ""
+    fifo_lane_arg_cleanup = ""
+    if fifo_uses_subblock:
+        # PTO-ISA exposes the explicit runtime-lane TPUSH/TPOP overload only on
+        # A2A3 device code. CPU simulation and the in-core cost model already
+        # model their lane context through the ordinary two-argument endpoint.
+        fifo_lane_arg_bridge = (
+            "#if defined(__CPU_SIM) || defined(__COSTMODEL)\n"
+            f"#define {_RUNTIME_SPLIT_FIFO_LANE_ARG}(subblock_id)\n"
+            "#else\n"
+            f"#define {_RUNTIME_SPLIT_FIFO_LANE_ARG}(subblock_id) , subblock_id\n"
             "#endif\n\n"
         )
+        fifo_lane_arg_cleanup = f"#undef {_RUNTIME_SPLIT_FIFO_LANE_ARG}\n\n"
 
     # Resolve SPMD block identity once from intrinsic.h::get_block_idx(args) /
     # get_block_num(args). Locals are declared whenever any function in the
@@ -862,9 +1043,8 @@ def _generate_kernel_wrapper(
     # stale under the tensormap_and_ringbuffer dispatch (see intrinsic.h). The
     # value is valid under both onboard and __CPU_SIM (the scheduler populates
     # GlobalContext.sub_block_id on every platform), so no __CPU_SIM fork.
-    # (func_uses_subblock is computed once above, before the header call.)
     subblock_arg_setup = ""
-    if func_uses_subblock:
+    if wrapper_uses_subblock:
         subblock_arg_setup = (
             "    // Read SPMD subblock (AIV lane) id from runtime dispatch payload\n"
             "    int32_t __pypto_spmd_subblock_idx = get_sub_block_id(args);\n\n"
@@ -889,7 +1069,7 @@ def _generate_kernel_wrapper(
         call_args_list.append("__pypto_sdma_workspace")
     if func_uses_spmd:
         call_args_list = call_args_list + ["__pypto_spmd_block_idx", "__pypto_spmd_block_num"]
-    if func_uses_subblock:
+    if wrapper_uses_subblock:
         call_args_list = call_args_list + ["__pypto_spmd_subblock_idx"]
     call_args = ", ".join(call_args_list)
 
@@ -902,7 +1082,6 @@ def _generate_kernel_wrapper(
         "    // Reset AI Core atomic mode inherited from a prior kernel.\n"
         "    set_atomic_none();\n"
         "#endif\n\n"
-        f"{runtime_subblock_setup}"
         f"{spmd_args_setup}"
         f"{subblock_arg_setup}"
         f"{unpacking_code}\n"
@@ -914,8 +1093,8 @@ def _generate_kernel_wrapper(
 
     deferred_completion_adapter = _DEFERRED_COMPLETION_ADAPTER if func_uses_deferred_completion else ""
     return (
-        f"{header}\n{deferred_completion_adapter}"
-        f"// --- ptoas-generated code ---\n{ptoas_body}\n{wrapper_func}"
+        f"{header}\n{deferred_completion_adapter}{fifo_lane_arg_bridge}"
+        f"// --- ptoas-generated code ---\n{ptoas_body}\n{fifo_lane_arg_cleanup}{wrapper_func}"
     )
 
 

--- a/tests/st/runtime/cross_core/test_cross_core_grouped_tpop_tfree.py
+++ b/tests/st/runtime/cross_core/test_cross_core_grouped_tpop_tfree.py
@@ -165,11 +165,18 @@ def _replace_ptoas_function_body(wrapper_text: str, new_ptoas_text: str, func_na
     """Replace one rewritten PTOAS function body without disturbing its group peers."""
     _, _, old_body_start, old_body_end = _find_ptoas_function(func_name, wrapper_text)
     _, _, new_body_start, new_body_end = _find_ptoas_function(func_name, new_ptoas_text)
-    return (
+    rewritten = (
         wrapper_text[: old_body_start + 1]
         + new_ptoas_text[new_body_start + 1 : new_body_end]
         + wrapper_text[old_body_end:]
     )
+    _, _, rewritten_body_start, rewritten_body_end = _find_ptoas_function(func_name, rewritten)
+    old_non_target = wrapper_text[: old_body_start + 1] + wrapper_text[old_body_end:]
+    rewritten_non_target = rewritten[: rewritten_body_start + 1] + rewritten[rewritten_body_end:]
+    assert rewritten_non_target == old_non_target, (
+        f"Rewriting {func_name} must preserve every other grouped function and wrapper section"
+    )
+    return rewritten
 
 
 def _rebuild_consecutive_tpop_tfree_artifact(work_dir: Path) -> None:
@@ -188,12 +195,7 @@ def _rebuild_consecutive_tpop_tfree_artifact(work_dir: Path) -> None:
     for kernel in kernel_config.KERNELS:
         wrapper_path = Path(kernel["source"])
         wrapper_text = wrapper_path.read_text(encoding="utf-8")
-        lane_forwarding_count = wrapper_text.count("PYPTO_SPLIT_RUNTIME_LANE_ARG(")
-        assert lane_forwarding_count > 2, "Expected split AIV calls to forward the runtime lane"
         rewritten_wrapper = _replace_ptoas_function_body(wrapper_text, new_body, "main_incore_0_aic")
-        assert rewritten_wrapper.count("PYPTO_SPLIT_RUNTIME_LANE_ARG(") == lane_forwarding_count, (
-            "Reordering the AIC body must preserve split AIV lane forwarding"
-        )
         wrapper_path.write_text(
             rewritten_wrapper,
             encoding="utf-8",

--- a/tests/st/runtime/cross_core/test_cross_core_grouped_tpop_tfree.py
+++ b/tests/st/runtime/cross_core/test_cross_core_grouped_tpop_tfree.py
@@ -38,7 +38,7 @@ import pytest
 import torch
 from harness.core.harness import platform_to_backend
 from pypto import ir
-from pypto.backend.pto_backend import _preprocess_ptoas_output, _run_ptoas
+from pypto.backend.pto_backend import _find_ptoas_function, _preprocess_ptoas_output, _run_ptoas
 from pypto.runtime.device_runner import (
     build_orch_args_from_inputs,
     compile_and_assemble,
@@ -161,10 +161,15 @@ def _rewrite_consecutive_tpop_tfree_pto(pto_path: Path) -> None:
     pto_path.write_text(rewritten, encoding="utf-8")
 
 
-def _replace_ptoas_body(wrapper_text: str, new_body: str) -> str:
-    start = wrapper_text.index("// --- ptoas-generated code ---")
-    end = wrapper_text.index("// --- Kernel entry point ---")
-    return f"{wrapper_text[:start]}// --- ptoas-generated code ---\n\n{new_body}\n{wrapper_text[end:]}"
+def _replace_ptoas_function_body(wrapper_text: str, new_ptoas_text: str, func_name: str) -> str:
+    """Replace one rewritten PTOAS function body without disturbing its group peers."""
+    _, _, old_body_start, old_body_end = _find_ptoas_function(func_name, wrapper_text)
+    _, _, new_body_start, new_body_end = _find_ptoas_function(func_name, new_ptoas_text)
+    return (
+        wrapper_text[: old_body_start + 1]
+        + new_ptoas_text[new_body_start + 1 : new_body_end]
+        + wrapper_text[old_body_end:]
+    )
 
 
 def _rebuild_consecutive_tpop_tfree_artifact(work_dir: Path) -> None:
@@ -183,7 +188,16 @@ def _rebuild_consecutive_tpop_tfree_artifact(work_dir: Path) -> None:
     for kernel in kernel_config.KERNELS:
         wrapper_path = Path(kernel["source"])
         wrapper_text = wrapper_path.read_text(encoding="utf-8")
-        wrapper_path.write_text(_replace_ptoas_body(wrapper_text, new_body), encoding="utf-8")
+        lane_forwarding_count = wrapper_text.count("PYPTO_SPLIT_RUNTIME_LANE_ARG(")
+        assert lane_forwarding_count > 2, "Expected split AIV calls to forward the runtime lane"
+        rewritten_wrapper = _replace_ptoas_function_body(wrapper_text, new_body, "main_incore_0_aic")
+        assert rewritten_wrapper.count("PYPTO_SPLIT_RUNTIME_LANE_ARG(") == lane_forwarding_count, (
+            "Reordering the AIC body must preserve split AIV lane forwarding"
+        )
+        wrapper_path.write_text(
+            rewritten_wrapper,
+            encoding="utf-8",
+        )
 
 
 class TestCrossCoreGroupedTpopTfree:

--- a/tests/ut/codegen/test_pto_codegen.py
+++ b/tests/ut/codegen/test_pto_codegen.py
@@ -171,6 +171,63 @@ __global__ AICORE void test_func(__gm__ float* v1, float v2, __gm__ float* v3) {
 }
 """
 
+SAMPLE_GROUPED_SPLIT_PTOAS_OUTPUT = """\
+#include "pto/pto-inst.hpp"
+using namespace pto;
+
+AICORE void split_cube(__gm__ float* v1) {
+  return;
+}
+
+AICORE void split_vec(__gm__ float* v1, int32_t v4) {
+  auto v2 = TPipe<0, Direction::DIR_C2V, 512, 8, 2, false>(v1, 0, 0);
+  Tile<TileType::Vec, float, 8, 16, BLayout::RowMajor> v3;
+  TPOP<TPipe<0, Direction::DIR_C2V, 512, 8, 2, false>,
+       Tile<TileType::Vec, float, 8, 16, BLayout::RowMajor>,
+       TileSplitAxis::TILE_UP_DOWN>(v2, v3);
+  return;
+}
+"""
+
+
+def _split_ptoas_output_for(
+    func_name: str,
+    *,
+    runtime_lane_param: bool = False,
+    direction: str = "DIR_C2V",
+    include_push: bool = False,
+) -> str:
+    """Return one split PTOAS function, optionally with a V2C push."""
+
+    params = "__gm__ float* v1"
+    if runtime_lane_param:
+        params += ", int32_t v2"
+    pipe = "v3" if runtime_lane_param else "v2"
+    popped = "v4" if runtime_lane_param else "v3"
+    produced = "v5" if runtime_lane_param else "v4"
+    push = ""
+    if include_push:
+        push = f"""\
+  TPUSH<TPipe<0, Direction::{direction}, 1024, 4, 2, false>,
+        Tile<TileType::Vec, bfloat16_t, 8, 16, BLayout::RowMajor>,
+        TileSplitAxis::TILE_UP_DOWN>({pipe}, {produced});
+"""
+    return f"""\
+#include "pto/pto-inst.hpp"
+using namespace pto;
+
+AICORE void {func_name}({params}) {{
+  auto {pipe} = TPipe<0, Direction::{direction}, 1024, 4, 2, false>(v1, 0, 0);
+  Tile<TileType::Vec, float, 8, 16, BLayout::RowMajor> {popped};
+  Tile<TileType::Vec, bfloat16_t, 8, 16, BLayout::RowMajor> {produced};
+  TPOP<TPipe<0, Direction::{direction}, 1024, 4, 2, false>,
+       Tile<TileType::Vec, float, 8, 16, BLayout::RowMajor>,
+       TileSplitAxis::TILE_UP_DOWN>({pipe}, {popped});
+{push}
+  return;
+}}
+"""
+
 
 def _make_func(name, params_spec):
     """Build a Function from parameter specs.
@@ -1760,19 +1817,20 @@ class TestGenerateKernelWrapper:
         assert func is not None
         assert transformed.get_function("split_vec__aiv1") is None
 
-        wrapper = _generate_kernel_wrapper(func, SAMPLE_PTOAS_OUTPUT)
+        wrapper = _generate_kernel_wrapper(
+            func,
+            _split_ptoas_output_for(func.name, runtime_lane_param=True),
+        )
         assert "PYPTO_FIXED_SUBBLOCK_ID" not in wrapper
-        assert wrapper.count("#if !defined(__CPU_SIM)\n") == 2
-        assert '#if !defined(__CPU_SIM)\n#include "intrinsic.h"' in wrapper
-        assert "[[block_local]] static int32_t pypto_runtime_subblock_id;" in wrapper
         assert '#include "intrinsic.h"' in wrapper
-        assert "#define get_subblockid() pypto_runtime_subblock_id" in wrapper
-        assert (
-            "#if !defined(__CPU_SIM)\n"
-            "    // Read A2A3 mixed-task subblock id from runtime dispatch context\n"
-            "    pypto_runtime_subblock_id = get_sub_block_id(args);\n"
-            "#endif"
-        ) in wrapper
+        assert "[[block_local]]" not in wrapper
+        assert "#define get_subblockid()" not in wrapper
+        assert "int32_t __pypto_runtime_subblock_idx" not in wrapper
+        assert "TileSplitAxis::TILE_UP_DOWN>(v3, v4 PYPTO_SPLIT_RUNTIME_LANE_ARG(v2));" in wrapper
+        assert "#define PYPTO_SPLIT_RUNTIME_LANE_ARG(subblock_id) , subblock_id" in wrapper
+        assert "#undef PYPTO_SPLIT_RUNTIME_LANE_ARG" in wrapper
+        assert "int32_t __pypto_spmd_subblock_idx = get_sub_block_id(args);" in wrapper
+        assert "split_vec(out__ssa_v0, __gm_pipe_buffer, __pypto_spmd_subblock_idx);" in wrapper
 
     def test_no_split_dual_dispatch_wrapper_uses_runtime_subblock_bridge_on_a2a3(self):
         @pl.program
@@ -1793,9 +1851,147 @@ class TestGenerateKernelWrapper:
 
         wrapper = _generate_kernel_wrapper(func, SAMPLE_PTOAS_OUTPUT)
         assert "PYPTO_FIXED_SUBBLOCK_ID" not in wrapper
-        assert "[[block_local]] static int32_t pypto_runtime_subblock_id;" in wrapper
-        assert "#define get_subblockid() pypto_runtime_subblock_id" in wrapper
-        assert "pypto_runtime_subblock_id = get_sub_block_id(args);" in wrapper
+        assert "[[block_local]]" not in wrapper
+        assert "#define get_subblockid()" not in wrapper
+        assert "int32_t __pypto_spmd_subblock_idx = get_sub_block_id(args);" in wrapper
+        assert "__pypto_spmd_subblock_idx);" in wrapper
+
+    def test_split_fifo_calls_reuse_existing_dynamic_subblock_parameter(self):
+        """A function using the lane op forwards its existing PTOAS parameter to FIFO calls."""
+
+        @pl.program
+        class ExplicitLaneSplitProgram:
+            @pl.function(type=pl.FunctionType.AIV)
+            def split_vec(self):
+                pl.func_attr({"split": pl.SplitMode.UP_DOWN})
+                pl.tile.get_subblock_idx()
+                pipe_buf = pl.reserve_buffer(name="c2v_slot_buffer", size=4096, base=0x1000)
+                pl.aiv_initialize_pipe(dir_mask=1, slot_size=512, c2v_consumer_buf=pipe_buf)
+                popped: pl.Tile[[8, 16], pl.FP32, pl.MemorySpace.Vec, pl.TileView()] = pl.tpop_from_aic(
+                    split=1
+                )
+                pl.tfree_to_aic(popped)
+
+        func = ExplicitLaneSplitProgram.get_function("split_vec")
+        assert func is not None
+
+        wrapper = _generate_kernel_wrapper(
+            func,
+            _split_ptoas_output_for(func.name, runtime_lane_param=True),
+        )
+
+        assert "int32_t __pypto_runtime_subblock_idx" not in wrapper
+        assert "TileSplitAxis::TILE_UP_DOWN>(v3, v4 PYPTO_SPLIT_RUNTIME_LANE_ARG(v2));" in wrapper
+        assert "int32_t __pypto_spmd_subblock_idx = get_sub_block_id(args);" in wrapper
+        assert "split_vec(__pypto_spmd_subblock_idx);" in wrapper
+
+    def test_legacy_fixed_lane_wrapper_keeps_compile_time_subblock_id(self):
+        """Legacy lane-specialized AIV wrappers retain their fixed lane override."""
+
+        @pl.program
+        class FixedLaneSplitProgram:
+            @pl.function(type=pl.FunctionType.AIV)
+            def split_vec__aiv1(self):
+                pl.func_attr({"split": pl.SplitMode.UP_DOWN})
+                pipe_buf = pl.reserve_buffer(name="c2v_slot_buffer", size=4096, base=0x1000)
+                pl.aiv_initialize_pipe(dir_mask=1, slot_size=512, c2v_consumer_buf=pipe_buf)
+                popped: pl.Tile[[8, 16], pl.FP32, pl.MemorySpace.Vec, pl.TileView()] = pl.tpop_from_aic(
+                    split=1
+                )
+                pl.tfree_to_aic(popped)
+
+        func = FixedLaneSplitProgram.get_function("split_vec__aiv1")
+        assert func is not None
+
+        wrapper = _generate_kernel_wrapper(func, _split_ptoas_output_for(func.name))
+
+        assert "#define PYPTO_FIXED_SUBBLOCK_ID 1" in wrapper
+        assert "#define get_subblockid() PYPTO_FIXED_SUBBLOCK_ID" in wrapper
+        assert "TileSplitAxis::TILE_UP_DOWN>(v2, v3);" in wrapper
+        assert "__pypto_runtime_subblock_idx" not in wrapper
+
+    def test_one_automatic_pipe_supports_different_sequential_split_tile_sizes(self):
+        """Per-call lane forwarding must not assume one byte offset per automatic FIFO."""
+
+        @pl.program
+        class SequentialTransfersProgram:
+            @pl.function(type=pl.FunctionType.AIV)
+            def split_vec(self):
+                pl.func_attr({"split": pl.SplitMode.UP_DOWN})
+                pipe_buf = pl.reserve_buffer(name="c2v_slot_buffer", size=65536, base=0x1000)
+                pl.aiv_initialize_pipe(
+                    pipe_buf,
+                    pipe_buf,
+                    dir_mask=3,
+                    slot_size=16384,
+                    slot_num=4,
+                )
+                first: pl.Tile[[16, 64], pl.FP32, pl.MemorySpace.Vec, pl.TileView()] = pl.tpop_from_aic(
+                    split=1
+                )
+                reply: pl.Tile[[16, 64], pl.FP32] = pl.tile.muls(first, 2.0)
+                pl.tpush_to_aic(reply, split=1)
+                pl.tfree_to_aic(first)
+                second: pl.Tile[[16, 128], pl.FP32, pl.MemorySpace.Vec, pl.TileView()] = pl.tpop_from_aic(
+                    split=1
+                )
+                pl.tfree_to_aic(second)
+
+        func = SequentialTransfersProgram.get_function("split_vec")
+        assert func is not None
+        fixture = """\
+#include "pto/pto-inst.hpp"
+using namespace pto;
+
+AICORE void split_vec() {
+  auto pipe = TPipe<0, Direction::DIR_BOTH, 16384, 4, 4, false>(0, 0, 0);
+  Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor> first;
+  Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor> reply;
+  Tile<TileType::Vec, float, 16, 128, BLayout::RowMajor> second;
+  TPOP<TPipe<0, Direction::DIR_BOTH, 16384, 4, 4, false>,
+       Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor>,
+       TileSplitAxis::TILE_UP_DOWN>(pipe, first);
+  TPUSH<TPipe<0, Direction::DIR_BOTH, 16384, 4, 4, false>,
+        Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor>,
+        TileSplitAxis::TILE_UP_DOWN>(pipe, reply);
+  TFREE<TPipe<0, Direction::DIR_BOTH, 16384, 4, 4, false>,
+        TileSplitAxis::TILE_UP_DOWN>(pipe);
+  TPOP<TPipe<0, Direction::DIR_BOTH, 16384, 4, 4, false>,
+       Tile<TileType::Vec, float, 16, 128, BLayout::RowMajor>,
+       TileSplitAxis::TILE_UP_DOWN>(pipe, second);
+  return;
+}
+"""
+
+        wrapper = _generate_kernel_wrapper(func, fixture)
+
+        assert wrapper.count("PYPTO_SPLIT_RUNTIME_LANE_ARG(__pypto_runtime_subblock_idx)") == 3
+        assert "TileSplitAxis::TILE_UP_DOWN>(pipe);" in wrapper
+        assert ".setEntryOffset(" not in wrapper
+
+    def test_split_fifo_bridge_fails_closed_when_ptoas_omits_an_endpoint_kind(self):
+        """Missing split PTOAS endpoint directions are rejected during wrapper generation."""
+
+        @pl.program
+        class BidirectionalProgram:
+            @pl.function(type=pl.FunctionType.AIV)
+            def split_vec(self):
+                pl.func_attr({"split": pl.SplitMode.UP_DOWN})
+                pipe_buf = pl.reserve_buffer(name="pipe", size=4096, base=0x1000)
+                pl.aiv_initialize_pipe(pipe_buf, pipe_buf, dir_mask=3, slot_size=1024)
+                popped: pl.Tile[[8, 16], pl.FP32, pl.MemorySpace.Vec, pl.TileView()] = pl.tpop_from_aic(
+                    split=1
+                )
+                produced: pl.Tile[[8, 16], pl.BF16] = pl.tile.cast(popped, target_type=pl.BF16)
+                pl.tpush_to_aic(produced, split=1)
+                pl.tfree_to_aic(popped)
+
+        func = BidirectionalProgram.get_function("split_vec")
+        assert func is not None
+        pop_only = _split_ptoas_output_for(func.name, direction="DIR_BOTH")
+
+        with pytest.raises(RuntimeError, match=r"IR push/pop=1/1, PTOAS push/pop=0/1"):
+            _generate_kernel_wrapper(func, pop_only)
 
     def test_split_aiv_wrapper_uses_runtime_subblock_bridge_in_group_output_on_a2a3(
         self, tmp_path, monkeypatch
@@ -1836,7 +2032,9 @@ class TestGenerateKernelWrapper:
 
         monkeypatch.setattr(
             "pypto.backend.pto_backend._compile_pto_module",
-            lambda _pto_code, _module_name, _output_dir, _memory_planner=None: SAMPLE_PTOAS_OUTPUT,
+            lambda _pto_code, _module_name, _output_dir, _memory_planner=None: (
+                SAMPLE_GROUPED_SPLIT_PTOAS_OUTPUT
+            ),
         )
 
         result_files = {}
@@ -1855,12 +2053,11 @@ class TestGenerateKernelWrapper:
         split_vec_wrapper = next(
             content for path, content in result_files.items() if path.endswith("split_vec.cpp")
         )
-        assert "static __aicore__ void test_func" in split_cube_wrapper
-        assert "static __aicore__ void test_func" in split_vec_wrapper
-        assert '#if !defined(__CPU_SIM)\n#include "intrinsic.h"' in split_vec_wrapper
-        assert "[[block_local]] static int32_t pypto_runtime_subblock_id;" in split_vec_wrapper
-        assert "#define get_subblockid() pypto_runtime_subblock_id" in split_vec_wrapper
-        assert "pypto_runtime_subblock_id = get_sub_block_id(args);" in split_vec_wrapper
+        assert "static __aicore__ void split_cube" in split_cube_wrapper
+        assert "static __aicore__ void split_vec" in split_vec_wrapper
+        assert "__pypto_runtime_subblock_idx" not in split_cube_wrapper
+        assert "TileSplitAxis::TILE_UP_DOWN>(v2, v3);" in split_cube_wrapper
+        assert "TileSplitAxis::TILE_UP_DOWN>(v2, v3 PYPTO_SPLIT_RUNTIME_LANE_ARG(v4));" in split_vec_wrapper
 
     def test_spmd_wrapper_drops_macro_bridge_and_appends_block_args(self):
         @pl.program

--- a/tests/ut/codegen/test_pto_codegen.py
+++ b/tests/ut/codegen/test_pto_codegen.py
@@ -1815,6 +1815,7 @@ class TestGenerateKernelWrapper:
         transformed = _run_default_passes(SplitWrapperProgram)
         func = transformed.get_function("split_vec")
         assert func is not None
+        assert _uses_dynamic_subblock_id(func) is True
         assert transformed.get_function("split_vec__aiv1") is None
 
         wrapper = _generate_kernel_wrapper(
@@ -2029,6 +2030,7 @@ AICORE void split_vec() {
         split_vec = transformed.get_function("split_vec")
         assert split_cube is not None
         assert split_vec is not None
+        assert _uses_dynamic_subblock_id(split_vec) is True
 
         monkeypatch.setattr(
             "pypto.backend.pto_backend._compile_pto_module",


### PR DESCRIPTION
## Summary

A2A3 mixed tasks dispatch one split AIV function across two vector lanes, but the zero-argument lane intrinsic can report lane 0 for both. This change forwards the authoritative runtime subblock ID to the explicit per-call PTO-ISA TPUSH/TPOP overloads, keeping FIFO entries lane-disjoint even when sequential transfers use different tile sizes.

The change is private to code generation: it adds no public API, leaves AIC and legacy fixed-lane functions unchanged, and preserves the existing CPU-simulation and cost-model endpoint ABI.

## Changes

- Detect eligible split AIV FIFO endpoints from the IR and adapt only the exact PTOAS-selected AIV function.
- Reuse an existing runtime subblock parameter or add one private parameter, then forward it at every split TPUSH/TPOP call.
- Preserve two-argument CPU-simulation and cost-model calls through a conditional adapter; TFREE remains unchanged.
- Fail closed on malformed or structurally inconsistent PTOAS output.
- Add grouped-output, existing-parameter, sequential different-size, legacy fixed-lane, CPU/cost-model, and failure-path regressions.
- Document the runtime-lane and per-call offset contract in English and Chinese.

## Verification

- python -m pytest tests/ut/codegen/test_pto_codegen.py: 913 passed.
- python -m pytest tests/ut/: 10,250 passed, 69 skipped, 2 xfailed.
- Ruff, format, and Pyright on the changed surface: passed with 0 type errors.
- Two-device A2A3 silicon campaign on devices 2 and 3: P1-P3 passed 30/30 seeded and 300/300 stability launches.
- The formerly broken P2 lane-1 rows 48-95 now have 0/6144 mismatches; P3 verifies one automatic pipe with 4096-byte and 8192-byte per-call lane geometry.
- Generated PTO, wrappers, orchestration, and device binaries were byte-identical across fresh dump-on/off builds.

An additional dense C,CVC case remains blocked before transport by the independent pre-existing MemoryReuse nested-accumulator join defect; it does not exercise this repair. No performance claim is made.