### PR TITLE
[Withdrawn] restore A5 full-Acc and Vec layout correctness

### DIFF
--- a/docs/en/dev/passes/33-memory_reuse.md
+++ b/docs/en/dev/passes/33-memory_reuse.md
@@ -31,7 +31,8 @@ Semantics-required loop-carry and in-place aliases are already materialized by
 addresses under capacity and reuse penalties in `AllocateMemoryAddr`. Running
 both would erase alternatives before DSA-RP can evaluate them. Correctness
 facts collected for this pass—lifetime interference, semantic no-alias rules,
-and target hazards—remain hard constraints in the DSA-RP problem.
+target hazards, and Vec ND/NZ storage-layout separation—remain hard constraints
+in the DSA-RP problem.
 
 ## API
 
@@ -101,14 +102,18 @@ program_optimized = reuse_pass(program)
 - `DSA_RP` skips `MemoryReuse`; it represents requested pipeline depth as hard
   separations and performs its pipeline-only fallback in `AllocateMemoryAddr`.
 
-**No shape / dtype / TileView compatibility gate**: tiles that share a physical MemRef may carry **different** shapes, dtypes, or `TileView` attributes. PTO codegen binds a per-variable `alloc_tile` to each tile, so each alias declares the shared base with its own static shape / dtype / layout / `valid_shape`. This permits, for example:
+**Shape / dtype reuse, with a Vec storage-layout exception**: tiles that share a physical MemRef may generally carry **different** shapes, dtypes, or `TileView` attributes. PTO codegen binds a per-variable `alloc_tile` to each tile, so each alias declares the shared base with its own static shape / dtype / layout / `valid_shape`.
+
+A5 Vec storage is representation-sensitive: even when their lifetimes are disjoint, a Vec tile with an effective ND-like layout and one with an effective NZ-like layout must not share a physical address. `MemoryReuse` enforces this with the narrow `AreVecNdNzCompatible` gate. Reuse remains permitted within the same Vec representation family (including different fractals), and the gate does not apply to non-Vec memory spaces. `DSA_RP` exports each cross-family pair as an unrelaxable `StorageLayout` hard separation in `AllocateMemoryAddr`.
+
+The remaining flexibility permits, for example:
 
 - cross-dtype reuse — a BF16 tile reusing a dead FP32 tile's buffer (e.g. across `tile.cast`);
 - `tile.fillpad` output reusing its input, and two fillpad outputs with different `pad` sharing one buffer;
-- N-D tiles with divergent `valid_shape` sharing a buffer (each keeps its own `valid_shape` on its own `alloc_tile`);
+- N-D tiles with divergent `valid_shape` sharing a buffer (each keeps its own `valid_shape` on its own `alloc_tile`), and same-family Vec layouts with different fractals sharing a buffer;
 - L0 cube-input `Left` / `Right` sub-tiles of differing shape sharing one slot (e.g. fused-attention QK `Right` `[k, SEQ]` reused by PV `Right` `[k', HEAD]`, halving peak L0B — issue #1595).
 
-  Earlier revisions gated reuse on an `AreTileTypesCompatible` shape / dtype / view match (with a narrow L0 byte-reuse exception); that gate has been removed. Correctness for read-while-write ops is now handled precisely by the no-alias guard above rather than by a coarse whole-tile match.
+  The former coarse `AreTileTypesCompatible` shape / dtype / view match (with a narrow L0 byte-reuse exception) remains removed. Correctness for read-while-write ops is handled precisely by the no-alias guard above; the Vec ND/NZ rule is an independent physical-storage constraint and therefore also covers unrelated, lifetime-disjoint values.
 
 **Alloc cleanup**:
 
@@ -268,7 +273,8 @@ passes.def("memory_reuse", &pass::MemoryReuse, "Memory reuse optimization");
 - Tests overlapping lifetime no-reuse
 - Tests memory space separation
 - Tests byte-size compatibility
-- Tests cross-dtype / cross-`TileView` reuse (now permitted: BF16↔FP32, fillpad output↔input, divergent `valid_shape`)
+- Tests cross-dtype / cross-`TileView` reuse where storage-compatible (BF16↔FP32, fillpad output↔input, divergent `valid_shape`, same-family Vec fractals)
+- Tests that lifetime-disjoint Vec ND/NZ tiles stay separate with both `MemoryReuse` and `DSA_RP`
 - Tests the no-alias guard (`TestForbidOutputAlias` + `TestInplaceOps`), one case per constraint above:
   - `tile.recip` / `tile.rsqrt` / `tile.row_sum` — output must not alias input (`not_inplace_safe`)
   - `tile.sel` — output must not alias the mask / tmp (`forbid_output_alias`)

--- a/docs/en/dev/passes/33-memory_reuse.md
+++ b/docs/en/dev/passes/33-memory_reuse.md
@@ -31,8 +31,8 @@ Semantics-required loop-carry and in-place aliases are already materialized by
 addresses under capacity and reuse penalties in `AllocateMemoryAddr`. Running
 both would erase alternatives before DSA-RP can evaluate them. Correctness
 facts collected for this pass—lifetime interference, semantic no-alias rules,
-target hazards, and Vec ND/NZ storage-layout separation—remain hard constraints
-in the DSA-RP problem.
+target hazards, and A5 Vec ND/NZ storage-layout separation—remain hard constraints
+in the DSA-RP problem. A2/A3 retain cross-layout reuse.
 
 ## API
 
@@ -104,7 +104,7 @@ program_optimized = reuse_pass(program)
 
 **Shape / dtype reuse, with a Vec storage-layout exception**: tiles that share a physical MemRef may generally carry **different** shapes, dtypes, or `TileView` attributes. PTO codegen binds a per-variable `alloc_tile` to each tile, so each alias declares the shared base with its own static shape / dtype / layout / `valid_shape`.
 
-A5 Vec storage is representation-sensitive: even when their lifetimes are disjoint, a Vec tile with an effective ND-like layout and one with an effective NZ-like layout must not share a physical address. `MemoryReuse` enforces this with the narrow `AreVecNdNzCompatible` gate. Reuse remains permitted within the same Vec representation family (including different fractals), and the gate does not apply to non-Vec memory spaces. `DSA_RP` exports each cross-family pair as an unrelaxable `StorageLayout` hard separation in `AllocateMemoryAddr`.
+A5 Vec storage is representation-sensitive: even when their lifetimes are disjoint, a Vec tile with an effective ND-like layout and one with an effective NZ-like layout must not share a physical address. `MemoryReuse` enforces this with the narrow `AreVecNdNzCompatible` gate. Reuse remains permitted within the same Vec representation family (including different fractals), and the gate does not apply to non-Vec memory spaces or to A2/A3. On A5, `DSA_RP` exports each cross-family pair as an unrelaxable `StorageLayout` hard separation in `AllocateMemoryAddr`.
 
 The remaining flexibility permits, for example:
 
@@ -274,7 +274,7 @@ passes.def("memory_reuse", &pass::MemoryReuse, "Memory reuse optimization");
 - Tests memory space separation
 - Tests byte-size compatibility
 - Tests cross-dtype / cross-`TileView` reuse where storage-compatible (BF16↔FP32, fillpad output↔input, divergent `valid_shape`, same-family Vec fractals)
-- Tests that lifetime-disjoint Vec ND/NZ tiles stay separate with both `MemoryReuse` and `DSA_RP`
+- Tests that lifetime-disjoint Vec ND/NZ tiles stay separate on A5 and remain reusable on A2/A3 with both `MemoryReuse` and `DSA_RP`
 - Tests the no-alias guard (`TestForbidOutputAlias` + `TestInplaceOps`), one case per constraint above:
   - `tile.recip` / `tile.rsqrt` / `tile.row_sum` — output must not alias input (`not_inplace_safe`)
   - `tile.sel` — output must not alias the mask / tmp (`forbid_output_alias`)

--- a/docs/en/dev/passes/34-allocate_memory_addr.md
+++ b/docs/en/dev/passes/34-allocate_memory_addr.md
@@ -82,7 +82,8 @@ post-alias allocation identity becomes one buffer with byte size, alignment,
 and a conservative half-open lifetime. The problem has:
 
 - **hard constraints** for lifetime interference, reserved ranges, semantic
-  no-alias rules, target hazards, and requested pipeline-stage separation.
+  no-alias rules, target hazards, Vec ND/NZ storage-layout separation
+  (`StorageLayout`), and requested pipeline-stage separation.
   Author-declared `pl.MemRef` allocations
   are also hard-separated from every other allocation in their memory space.
   A multi-slot declaration is placed as one buffer covering its full declared
@@ -124,8 +125,9 @@ Pipeline intent uses a strict-then-soft policy:
    reason is pipeline intent, add unit reuse penalties for them, and search
    again.
 3. If the selected placement overlaps a relaxed pair, emit the
-   `PH-DSA-001` performance diagnostic. All semantic and target-hazard
-   separations remain hard. If the relaxed bounded search also finds no fit,
+   `PH-DSA-001` performance diagnostic. All semantic, target-hazard, and
+   `StorageLayout` separations remain hard. If the relaxed bounded search also
+   finds no fit,
    report a compile-time OOM/no-fit error; this remains a search failure, not
    an infeasibility certificate.
 
@@ -233,8 +235,9 @@ passes.def("allocate_memory_addr", &pass::AllocateMemoryAddr,
 - Tests raw pointer uniqueness for MemRef deduplication
 - Tests default policy behavior without a backend configured
 - Tests the capacity diagnostic attributes reserved cross-core pipe bytes (see below)
-- Tests DSA-RP geometry, capacity, hard constraints, penalty activation,
-  deterministic canonical-greedy placement, and independent validation
+- Tests DSA-RP geometry, capacity, hard constraints (including Vec ND/NZ
+  `StorageLayout` separation), penalty activation, deterministic canonical-greedy
+  placement, and independent validation
 - Tests exact pre-solver recognized-edge sets as well as their final placement geometry
 - Characterizes that canonical-greedy `kNoFit` is a bounded-search result, not an infeasibility proof
 

--- a/docs/en/dev/passes/34-allocate_memory_addr.md
+++ b/docs/en/dev/passes/34-allocate_memory_addr.md
@@ -82,8 +82,8 @@ post-alias allocation identity becomes one buffer with byte size, alignment,
 and a conservative half-open lifetime. The problem has:
 
 - **hard constraints** for lifetime interference, reserved ranges, semantic
-  no-alias rules, target hazards, Vec ND/NZ storage-layout separation
-  (`StorageLayout`), and requested pipeline-stage separation.
+  no-alias rules, target hazards, A5 Vec ND/NZ storage-layout separation
+  (`StorageLayout`; not emitted for A2/A3), and requested pipeline-stage separation.
   Author-declared `pl.MemRef` allocations
   are also hard-separated from every other allocation in their memory space.
   A multi-slot declaration is placed as one buffer covering its full declared
@@ -235,8 +235,8 @@ passes.def("allocate_memory_addr", &pass::AllocateMemoryAddr,
 - Tests raw pointer uniqueness for MemRef deduplication
 - Tests default policy behavior without a backend configured
 - Tests the capacity diagnostic attributes reserved cross-core pipe bytes (see below)
-- Tests DSA-RP geometry, capacity, hard constraints (including Vec ND/NZ
-  `StorageLayout` separation), penalty activation, deterministic canonical-greedy
+- Tests DSA-RP geometry, capacity, hard constraints (including A5 Vec ND/NZ
+  `StorageLayout` separation and A2/A3 cross-layout reuse), penalty activation, deterministic canonical-greedy
   placement, and independent validation
 - Tests exact pre-solver recognized-edge sets as well as their final placement geometry
 - Characterizes that canonical-greedy `kNoFit` is a bounded-search result, not an infeasibility proof

--- a/docs/zh/dev/passes/33-memory_reuse.md
+++ b/docs/zh/dev/passes/33-memory_reuse.md
@@ -26,8 +26,8 @@
 
 `MemoryReuse` 在地址分配前先选择共享的 MemRef 身份。`DSA_RP` 则保留这些独立
 身份，并在 `AllocateMemoryAddr` 中结合容量与复用惩罚联合选择地址。二者同时运行
-会在 DSA-RP 评估之前删除候选方案。生命周期干涉、语义 no-alias 规则与目标
-hazard 等正确性事实，在 DSA-RP 问题中仍然是硬约束。
+会在 DSA-RP 评估之前删除候选方案。生命周期干涉、语义 no-alias 规则、目标
+hazard 与 Vec ND/NZ storage-layout 分离等正确性事实，在 DSA-RP 问题中仍然是硬约束。
 
 ## API
 
@@ -97,14 +97,18 @@ program_optimized = reuse_pass(program)
 - `DSA_RP` 跳过 `MemoryReuse`；它把请求的流水线深度表示为硬分离，并在
   `AllocateMemoryAddr` 中执行仅放宽流水线意图的回退。
 
-**不再有 shape / dtype / TileView 兼容性门槛**：共享同一物理 MemRef 的 tile 可以携带**不同**的 shape、dtype 或 `TileView` 属性。PTO codegen 为每个 tile 绑定一条 per-variable 的 `alloc_tile`，因此每个别名都以各自的静态 shape / dtype / layout / `valid_shape` 声明共享基址。这允许例如：
+**允许跨 shape / dtype 复用，但 Vec storage layout 除外**：共享同一物理 MemRef 的 tile 通常可以携带**不同**的 shape、dtype 或 `TileView` 属性。PTO codegen 为每个 tile 绑定一条 per-variable 的 `alloc_tile`，因此每个别名都以各自的静态 shape / dtype / layout / `valid_shape` 声明共享基址。
+
+A5 Vec 存储对表示形式敏感：即使生命周期不相交，有效 layout 分属 ND-like 与 NZ-like 的两个 Vec tile 也不得共享物理地址。`MemoryReuse` 通过狭窄的 `AreVecNdNzCompatible` 门槛执行该限制。同一 Vec 表示族内仍允许复用（包括 fractal 不同的情形），非 Vec 内存空间也不受此门槛限制。`DSA_RP` 会把每个跨表示族 pair 以不可放宽的 `StorageLayout` 硬分离传给 `AllocateMemoryAddr`。
+
+除此之外仍允许例如：
 
 - 跨 dtype 复用 —— BF16 tile 复用已死亡的 FP32 tile 的缓冲区（例如跨 `tile.cast`）；
 - `tile.fillpad` 输出复用其输入，以及两个 `pad` 不同的 fillpad 输出共享一个缓冲区；
-- N-D tile 在 `valid_shape` 不同的情况下共享缓冲区（各自在自己的 `alloc_tile` 上保留各自的 `valid_shape`）；
+- N-D tile 在 `valid_shape` 不同的情况下共享缓冲区（各自在自己的 `alloc_tile` 上保留各自的 `valid_shape`），以及同一 Vec 表示族内 fractal 不同的 tile 共享缓冲区；
 - L0 cube 输入 `Left` / `Right` 中 shape 不同的子 tile 共享同一槽位（例如 fused-attention QK 的 `Right` `[k, SEQ]` 被 PV 的 `Right` `[k', HEAD]` 复用，将 L0B 峰值减半 —— issue #1595）。
 
-  早期版本以 `AreTileTypesCompatible`（shape / dtype / view 匹配，外加一个狭窄的 L0 字节复用例外）作为门槛；该门槛已移除。对读-写同体（read-while-write）算子的正确性现由上面的 no-alias 守护精确处理，而不再依赖粗粒度的整块匹配。
+  旧的粗粒度 `AreTileTypesCompatible`（shape / dtype / view 匹配，外加一个狭窄的 L0 字节复用例外）仍已移除。对读-写同体（read-while-write）算子的正确性由上面的 no-alias 守护精确处理；Vec ND/NZ 规则是独立的物理存储约束，因此也覆盖彼此无关但生命周期不相交的值。
 
 **Alloc 清理**：
 
@@ -255,7 +259,8 @@ passes.def("memory_reuse", &pass::MemoryReuse, "Memory reuse optimization");
 - 测试重叠生命周期不复用
 - 测试内存空间隔离
 - 测试字节大小兼容性
-- 测试跨 dtype / 跨 `TileView` 复用（现已允许：BF16↔FP32、fillpad 输出↔输入、`valid_shape` 不同）
+- 测试 storage-compatible 的跨 dtype / 跨 `TileView` 复用（BF16↔FP32、fillpad 输出↔输入、`valid_shape` 不同、同一 Vec 表示族内 fractal 不同）
+- 测试生命周期不相交的 Vec ND/NZ tile 在 `MemoryReuse` 和 `DSA_RP` 下均保持分离
 - 测试 no-alias 守护（`TestForbidOutputAlias` + `TestInplaceOps`），上表每条约束一个用例：
   - `tile.recip` / `tile.rsqrt` / `tile.row_sum` —— 输出不得 alias 输入（`not_inplace_safe`）
   - `tile.sel` —— 输出不得 alias mask / tmp（`forbid_output_alias`）

--- a/docs/zh/dev/passes/33-memory_reuse.md
+++ b/docs/zh/dev/passes/33-memory_reuse.md
@@ -27,7 +27,7 @@
 `MemoryReuse` 在地址分配前先选择共享的 MemRef 身份。`DSA_RP` 则保留这些独立
 身份，并在 `AllocateMemoryAddr` 中结合容量与复用惩罚联合选择地址。二者同时运行
 会在 DSA-RP 评估之前删除候选方案。生命周期干涉、语义 no-alias 规则、目标
-hazard 与 Vec ND/NZ storage-layout 分离等正确性事实，在 DSA-RP 问题中仍然是硬约束。
+hazard 与 A5 Vec ND/NZ storage-layout 分离等正确性事实，在 DSA-RP 问题中仍然是硬约束；A2/A3 继续允许跨 layout 复用。
 
 ## API
 
@@ -99,7 +99,7 @@ program_optimized = reuse_pass(program)
 
 **允许跨 shape / dtype 复用，但 Vec storage layout 除外**：共享同一物理 MemRef 的 tile 通常可以携带**不同**的 shape、dtype 或 `TileView` 属性。PTO codegen 为每个 tile 绑定一条 per-variable 的 `alloc_tile`，因此每个别名都以各自的静态 shape / dtype / layout / `valid_shape` 声明共享基址。
 
-A5 Vec 存储对表示形式敏感：即使生命周期不相交，有效 layout 分属 ND-like 与 NZ-like 的两个 Vec tile 也不得共享物理地址。`MemoryReuse` 通过狭窄的 `AreVecNdNzCompatible` 门槛执行该限制。同一 Vec 表示族内仍允许复用（包括 fractal 不同的情形），非 Vec 内存空间也不受此门槛限制。`DSA_RP` 会把每个跨表示族 pair 以不可放宽的 `StorageLayout` 硬分离传给 `AllocateMemoryAddr`。
+A5 Vec 存储对表示形式敏感：即使生命周期不相交，有效 layout 分属 ND-like 与 NZ-like 的两个 Vec tile 也不得共享物理地址。`MemoryReuse` 通过狭窄的 `AreVecNdNzCompatible` 门槛执行该限制。同一 Vec 表示族内仍允许复用（包括 fractal 不同的情形），非 Vec 内存空间和 A2/A3 也不受此门槛限制。在 A5 上，`DSA_RP` 会把每个跨表示族 pair 以不可放宽的 `StorageLayout` 硬分离传给 `AllocateMemoryAddr`。
 
 除此之外仍允许例如：
 
@@ -260,7 +260,7 @@ passes.def("memory_reuse", &pass::MemoryReuse, "Memory reuse optimization");
 - 测试内存空间隔离
 - 测试字节大小兼容性
 - 测试 storage-compatible 的跨 dtype / 跨 `TileView` 复用（BF16↔FP32、fillpad 输出↔输入、`valid_shape` 不同、同一 Vec 表示族内 fractal 不同）
-- 测试生命周期不相交的 Vec ND/NZ tile 在 `MemoryReuse` 和 `DSA_RP` 下均保持分离
+- 测试生命周期不相交的 Vec ND/NZ tile 在 A5 上保持分离，并在 A2/A3 上继续复用（覆盖 `MemoryReuse` 和 `DSA_RP`）
 - 测试 no-alias 守护（`TestForbidOutputAlias` + `TestInplaceOps`），上表每条约束一个用例：
   - `tile.recip` / `tile.rsqrt` / `tile.row_sum` —— 输出不得 alias 输入（`not_inplace_safe`）
   - `tile.sel` —— 输出不得 alias mask / tmp（`forbid_output_alias`）

--- a/docs/zh/dev/passes/34-allocate_memory_addr.md
+++ b/docs/zh/dev/passes/34-allocate_memory_addr.md
@@ -73,8 +73,8 @@ compile(program, memory_planner=passes.MemoryPlanner.DSA_RP)
 每个片上内存空间都是独立的固定容量 arena。强制别名物化后的每个分配身份成为一个
 buffer，带有字节大小、对齐和保守的半开生命周期。问题包含：
 
-- 生命周期干涉、预留范围、语义 no-alias、目标 hazard、Vec ND/NZ storage layout
-  分离（`StorageLayout`）和请求的流水线 stage 分离等**硬约束**；作者声明的 `pl.MemRef`
+- 生命周期干涉、预留范围、语义 no-alias、目标 hazard、A5 Vec ND/NZ storage layout
+  分离（`StorageLayout`，A2/A3 不生成）和请求的流水线 stage 分离等**硬约束**；作者声明的 `pl.MemRef`
   分配还会与同一内存空间中的其他所有分配建立硬分离。多 slot 声明会作为覆盖完整
   声明范围的单个 buffer 放置，同时每个成员保留其常量或运行时选择的 slot 偏移；
 - 对生命周期兼容的物理复用，如果内置 recognizer 将其识别为跨 pipe WAR 或 WAW
@@ -207,7 +207,7 @@ passes.def("allocate_memory_addr", &pass::AllocateMemoryAddr,
 - 测试 MemRef 去重的原始指针唯一性
 - 测试无后端配置时的默认策略行为
 - 测试容量诊断会归因跨核流水 ring 预留的字节数（见下文）
-- 测试 DSA-RP 几何、容量、硬约束（包括 Vec ND/NZ 的 `StorageLayout` 分离）、
+- 测试 DSA-RP 几何、容量、硬约束（包括 A5 Vec ND/NZ 的 `StorageLayout` 分离和 A2/A3 跨 layout 复用）、
   惩罚激活、确定性 canonical-greedy 放置以及独立验证
 - 直接测试 solver 之前的精确 recognizer edge 集合，并测试最终放置几何
 - 刻画 canonical-greedy `kNoFit` 只是有界搜索结果，而不是不可行性证明

--- a/docs/zh/dev/passes/34-allocate_memory_addr.md
+++ b/docs/zh/dev/passes/34-allocate_memory_addr.md
@@ -73,8 +73,8 @@ compile(program, memory_planner=passes.MemoryPlanner.DSA_RP)
 每个片上内存空间都是独立的固定容量 arena。强制别名物化后的每个分配身份成为一个
 buffer，带有字节大小、对齐和保守的半开生命周期。问题包含：
 
-- 生命周期干涉、预留范围、语义 no-alias、目标 hazard 和请求的流水线 stage
-  分离等**硬约束**；作者声明的 `pl.MemRef`
+- 生命周期干涉、预留范围、语义 no-alias、目标 hazard、Vec ND/NZ storage layout
+  分离（`StorageLayout`）和请求的流水线 stage 分离等**硬约束**；作者声明的 `pl.MemRef`
   分配还会与同一内存空间中的其他所有分配建立硬分离。多 slot 声明会作为覆盖完整
   声明范围的单个 buffer 放置，同时每个成员保留其常量或运行时选择的 slot 偏移；
 - 对生命周期兼容的物理复用，如果内置 recognizer 将其识别为跨 pipe WAR 或 WAW
@@ -102,8 +102,9 @@ Canonical greedy 尝试偏移 `0`、预留范围末尾，以及已放置硬/软�
 1. 先在所有请求的跨 stage 分离均为硬约束时运行有界 canonical-greedy 搜索。
 2. 若该搜索未找到可放置方案——这并不证明严格数学问题不可行——则仅放宽唯一硬
    理由为流水线意图的 pair，把它们改为单位复用惩罚后再次搜索。
-3. 若最终放置重叠了放宽的 pair，发出 `PH-DSA-001` 性能诊断。所有语义与目标
-   hazard 分离始终保持为硬约束。若放宽后的有界搜索仍未找到可放置方案，则报告
+3. 若最终放置重叠了放宽的 pair，发出 `PH-DSA-001` 性能诊断。所有语义、目标
+   hazard 与 `StorageLayout` 分离始终保持为硬约束。若放宽后的有界搜索仍未找到
+   可放置方案，则报告
    OOM/no-fit 编译错误；这仍表示搜索失败，并非不可行性证明。
 
 > **工具链要求：** `DSA_RP` 依赖 ptoas InsertSync 识别不同分配根之间的物理范围
@@ -206,8 +207,8 @@ passes.def("allocate_memory_addr", &pass::AllocateMemoryAddr,
 - 测试 MemRef 去重的原始指针唯一性
 - 测试无后端配置时的默认策略行为
 - 测试容量诊断会归因跨核流水 ring 预留的字节数（见下文）
-- 测试 DSA-RP 几何、容量、硬约束、惩罚激活、确定性 canonical-greedy 放置、
-  以及独立验证
+- 测试 DSA-RP 几何、容量、硬约束（包括 Vec ND/NZ 的 `StorageLayout` 分离）、
+  惩罚激活、确定性 canonical-greedy 放置以及独立验证
 - 直接测试 solver 之前的精确 recognizer edge 集合，并测试最终放置几何
 - 刻画 canonical-greedy `kNoFit` 只是有界搜索结果，而不是不可行性证明
 

--- a/include/pypto/ir/transforms/dsa/allocation_plan.h
+++ b/include/pypto/ir/transforms/dsa/allocation_plan.h
@@ -29,6 +29,7 @@ enum class AllocationSeparationReason : uint8_t {
   PipelineStage,
   TargetHazard,
   SemanticNoAlias,
+  StorageLayout,
   DeclaredAllocation,
 };
 

--- a/include/pypto/ir/transforms/utils/allocation_constraint_analysis.h
+++ b/include/pypto/ir/transforms/utils/allocation_constraint_analysis.h
@@ -38,6 +38,7 @@ using AllocationForbidAliasMap = std::map<const Var*, std::vector<VarPtr>>;
 struct AllocationConstraintAnalysis {
   std::map<const Var*, uint64_t> declared_allocation_sizes;
   std::set<const Var*> declared_allocation_bases;
+  std::map<const Var*, bool> vec_nz_layout_class;
   AllocationHazardInputs target_hazard_inputs;
   AllocationForbidAliasMap forbid_alias;
   bool needs_load_tpop_hazard_guard = false;

--- a/src/codegen/pto/pto_codegen.cpp
+++ b/src/codegen/pto/pto_codegen.cpp
@@ -452,7 +452,7 @@ bool ShareOneMemRefWindow(const std::shared_ptr<const TileType>& lhs,
 //
 // A declared index naming a non-tile argument (`tile.store` / `tile.write`
 // declare index 2, a TensorType) drops out: GetTileTypeWithMemRef returns null.
-bool ShouldAliasResultToInPlaceInput(const AssignStmtPtr& stmt) {
+bool ShouldAliasResultToInPlaceInput(PTOCodegen& codegen, const AssignStmtPtr& stmt) {
   auto call = As<ir::Call>(stmt->value_);
   if (!call || !call->op_) return false;
 
@@ -479,9 +479,28 @@ bool ShouldAliasResultToInPlaceInput(const AssignStmtPtr& stmt) {
   if (!declared.has_value()) return false;
   auto input_tile_type = input_tile_type_at(*declared);
   if (!input_tile_type) return false;
-  return ShareOneMemRefWindow(result_tile_type, input_tile_type) &&
-         ir::TileBufSignature::FromTileType(*result_tile_type) ==
-             ir::TileBufSignature::FromTileType(*input_tile_type);
+  if (!ShareOneMemRefWindow(result_tile_type, input_tile_type) ||
+      !(ir::TileBufSignature::FromTileType(*result_tile_type) ==
+        ir::TileBufSignature::FromTileType(*input_tile_type))) {
+    return false;
+  }
+
+  // A full-Acc matmul_acc historically used a distinct result handle, even
+  // when memory reuse assigned that handle the accumulator's physical L0C
+  // address. Keep that lowering: making the result and loop-carried input the
+  // very same MLIR SSA changes PTOAS' full-accumulator loop lowering and can
+  // stall long-running kernels. The in-place alias added for #2403 is required
+  // only when operand 0 is a real pto.subview: without it the MAD writes a
+  // private handle instead of the parent Acc window. A lazily materialized
+  // subview no longer denotes that parent window, so it follows the ordinary
+  // distinct-result path too.
+  if (ir::IsOp(call, "tile.matmul_acc")) {
+    const std::string accumulator_ssa = codegen.GetExprAsCode(call->args_[*declared]);
+    const auto* subview = codegen.GetSubviewMaterialization(accumulator_ssa);
+    return subview != nullptr && !subview->emitted;
+  }
+
+  return true;
 }
 
 // `array.update_element` is SSA-functional in the IR (returns a fresh
@@ -2072,7 +2091,7 @@ void PTOCodegen::VisitStmt(const ir::StmtPtr& stmt) {
 void PTOCodegen::VisitStmt_(const AssignStmtPtr& op) {
   auto call = As<ir::Call>(op->value_);
   const bool is_set_validshape = ir::IsOp(call, "tile.set_validshape");
-  const bool alias_result_to_in_place_input = ShouldAliasResultToInPlaceInput(op);
+  const bool alias_result_to_in_place_input = ShouldAliasResultToInPlaceInput(*this, op);
   const bool alias_array_update_to_input = ShouldAliasArrayUpdateResultToInput(op);
 
   if (ir::IsOp(call, "pld.tile.remote_load")) {

--- a/src/ir/transforms/dsa/allocation_plan.cpp
+++ b/src/ir/transforms/dsa/allocation_plan.cpp
@@ -114,12 +114,10 @@ AllocationPlan BuildDsaAllocationPlan(const FunctionPtr& func) {
   auto add_disjoint_layout_pairs = [&intervals, &add_separation](std::vector<size_t> earlier,
                                                                  std::vector<size_t> later) {
     std::sort(earlier.begin(), earlier.end(), [&intervals](size_t lhs, size_t rhs) {
-      return std::pair{intervals[lhs].last_use_point, lhs} <
-             std::pair{intervals[rhs].last_use_point, rhs};
+      return std::pair{intervals[lhs].last_use_point, lhs} < std::pair{intervals[rhs].last_use_point, rhs};
     });
     std::sort(later.begin(), later.end(), [&intervals](size_t lhs, size_t rhs) {
-      return std::pair{intervals[lhs].def_point, lhs} <
-             std::pair{intervals[rhs].def_point, rhs};
+      return std::pair{intervals[lhs].def_point, lhs} < std::pair{intervals[rhs].def_point, rhs};
     });
 
     size_t eligible = 0;

--- a/src/ir/transforms/dsa/allocation_plan.cpp
+++ b/src/ir/transforms/dsa/allocation_plan.cpp
@@ -101,6 +101,41 @@ AllocationPlan BuildDsaAllocationPlan(const FunctionPtr& func) {
     }
   }
 
+  // A5 Vec storage is representation-sensitive: lifetime-disjoint ND and NZ
+  // tiles still need different physical addresses.  Materialize only the
+  // cross-class pairs, preserving reuse within each representation family.
+  std::vector<size_t> vec_nd_intervals;
+  std::vector<size_t> vec_nz_intervals;
+  for (size_t index = 0; index < intervals.size(); ++index) {
+    const auto layout = constraints.vec_nz_layout_class.find(intervals[index].variable.get());
+    if (layout == constraints.vec_nz_layout_class.end()) continue;
+    (layout->second ? vec_nz_intervals : vec_nd_intervals).push_back(index);
+  }
+  auto add_disjoint_layout_pairs = [&intervals, &add_separation](std::vector<size_t> earlier,
+                                                                 std::vector<size_t> later) {
+    std::sort(earlier.begin(), earlier.end(), [&intervals](size_t lhs, size_t rhs) {
+      return std::pair{intervals[lhs].last_use_point, lhs} <
+             std::pair{intervals[rhs].last_use_point, rhs};
+    });
+    std::sort(later.begin(), later.end(), [&intervals](size_t lhs, size_t rhs) {
+      return std::pair{intervals[lhs].def_point, lhs} <
+             std::pair{intervals[rhs].def_point, rhs};
+    });
+
+    size_t eligible = 0;
+    for (size_t later_index : later) {
+      while (eligible < earlier.size() &&
+             intervals[earlier[eligible]].last_use_point <= intervals[later_index].def_point) {
+        ++eligible;
+      }
+      for (size_t prior = 0; prior < eligible; ++prior) {
+        add_separation(earlier[prior], later_index, AllocationSeparationReason::StorageLayout);
+      }
+    }
+  };
+  add_disjoint_layout_pairs(vec_nd_intervals, vec_nz_intervals);
+  add_disjoint_layout_pairs(vec_nz_intervals, vec_nd_intervals);
+
   // Preserve requested software-pipeline depth as hard separations first. The
   // DSA-RP driver alone may later relax this typed policy under capacity pressure.
   using GroupKey = std::pair<MemorySpace, int32_t>;

--- a/src/ir/transforms/memory_reuse_pass.cpp
+++ b/src/ir/transforms/memory_reuse_pass.cpp
@@ -2181,13 +2181,15 @@ std::map<VarPtr, VarPtr> IdentifyReuseOpportunities(
            pipeline_load_tiles.count(b.variable.get()) != 0;
   };
 
+  const bool enforce_vec_nd_nz_layout = IsA5Target();
+
   // Can `cand` join a single physical buffer that already holds `member`?
   // Lifetimes must not overlap (touching is allowed: a buffer's reader is
   // consumed before the writer at the same statement produces its output), and
   // neither directional gate may block. Shape/dtype need not match: PTO binds a
   // per-var alloc_tile so differing shapes/dtypes legally alias one base, and
   // largest-first ordering guarantees the buffer is sized to its representative.
-  // On Vec only, ND and NZ must not share — see AreVecNdNzCompatible.
+  // On A5 Vec only, ND and NZ must not share — see AreVecNdNzCompatible.
   auto can_share = [&](const LifetimeInterval& cand, const LifetimeInterval& member) {
     // Group-interval overlap is a fast reject; when it fires, fall back to the
     // precise per-var check so mutually-exclusive / same-value phi-family tiles
@@ -2197,7 +2199,7 @@ std::map<VarPtr, VarPtr> IdentifyReuseOpportunities(
     if (hazard_blocks(cand, member) || hazard_blocks(member, cand)) return false;
     if (forbid_blocks(cand, member) || forbid_blocks(member, cand)) return false;
     if (pipeline_blocks(cand, member)) return false;  // symmetric — one call suffices
-    if (!AreVecNdNzCompatible(cand.variable, member.variable)) return false;
+    if (enforce_vec_nd_nz_layout && !AreVecNdNzCompatible(cand.variable, member.variable)) return false;
     return true;
   };
 
@@ -3310,9 +3312,13 @@ AllocationConstraintAnalysis AnalyzeAllocationConstraints(const FunctionPtr& fun
   }
   ValidateDeclaredAllocs(func->body_, result.declared_allocation_bases, lifetimes.var_liveness);
 
-  for (const LifetimeInterval& interval : lifetimes.lifetimes) {
-    if (const auto layout_class = GetVecNzLayoutClass(interval.variable)) {
-      result.vec_nz_layout_class.emplace(interval.variable.get(), *layout_class);
+  // A5 Vec addresses are representation-sensitive. A2/A3 retain the legacy
+  // cross-layout reuse policy, so do not export StorageLayout hard edges there.
+  if (IsA5Target()) {
+    for (const LifetimeInterval& interval : lifetimes.lifetimes) {
+      if (const auto layout_class = GetVecNzLayoutClass(interval.variable)) {
+        result.vec_nz_layout_class.emplace(interval.variable.get(), *layout_class);
+      }
     }
   }
 

--- a/src/ir/transforms/memory_reuse_pass.cpp
+++ b/src/ir/transforms/memory_reuse_pass.cpp
@@ -279,7 +279,9 @@ inline bool SubtreeWritesBase(const StmtPtr& stmt, const Var* target_base) {
 bool IsA5Target() {
   if (!backend::BackendConfig::IsConfigured()) return false;
   const auto* ctx = PassContext::Current();
-  return ctx != nullptr && ctx->GetBackendHandler()->GetPtoTargetArch() == "a5";
+  const auto* handler =
+      ctx != nullptr ? ctx->GetBackendHandler() : backend::BackendConfig::GetBackend()->GetHandler();
+  return handler->GetPtoTargetArch() == "a5";
 }
 
 bool IsA5Prelu(const CallPtr& call) { return IsOp(call, "tile.prelu") && IsA5Target(); }

--- a/src/ir/transforms/memory_reuse_pass.cpp
+++ b/src/ir/transforms/memory_reuse_pass.cpp
@@ -41,6 +41,7 @@
 #include "pypto/ir/op_registry.h"
 #include "pypto/ir/scalar_expr.h"
 #include "pypto/ir/stmt.h"
+#include "pypto/ir/tile_view_semantics.h"
 #include "pypto/ir/transforms/base/mutator.h"
 #include "pypto/ir/transforms/base/visitor.h"
 #include "pypto/ir/transforms/pass_context.h"
@@ -1454,12 +1455,27 @@ LifetimeAnalysisResult AnalyzeAllocationLifetimesImpl(const StmtPtr& func_body,
           std::move(pipeline_load_tiles)};
 }
 
-// NOTE: The former tile-type reuse-compatibility gate (AreTileTypesCompatible)
-// has been removed. PTO codegen binds a per-var alloc_tile to each tile, so two
-// tiles that share a physical MemRef can legally carry different shapes, dtypes,
-// or TileView attributes. In-place read/write hazards are handled precisely by
-// not_inplace_safe() and per-operand forbid_output_alias() markers (see
-// ForbidAliasCollector below).
+// PTO codegen binds a per-var alloc_tile to each tile, so lifetime-disjoint
+// values may generally share one physical MemRef despite different shapes or
+// dtypes.  Vec ND and NZ are the narrow exception on A5: reusing one address
+// across those representation families silently corrupts mixed-kernel values,
+// even when no single tile.move aliases its own input.  Keep the gate Vec-only
+// so Left/Right/Mat cross-shape reuse remains available.
+static bool IsNzLikeBlayout(TileLayout blayout) { return blayout == TileLayout::col_major; }
+
+static std::optional<bool> GetVecNzLayoutClass(const VarPtr& var) {
+  auto tile = As<TileType>(var->GetType());
+  if (!tile) return std::nullopt;
+  const auto space = tile->GetMemorySpace();
+  if (!space || *space != MemorySpace::Vec) return std::nullopt;
+  return IsNzLikeBlayout(tile_view_semantics::GetEffectiveTileView(*tile).blayout);
+}
+
+static bool AreVecNdNzCompatible(const VarPtr& first, const VarPtr& second) {
+  const auto first_class = GetVecNzLayoutClass(first);
+  const auto second_class = GetVecNzLayoutClass(second);
+  return !first_class.has_value() || !second_class.has_value() || first_class == second_class;
+}
 
 /**
  * @brief Check if two lifetimes overlap.
@@ -2168,10 +2184,10 @@ std::map<VarPtr, VarPtr> IdentifyReuseOpportunities(
   // Can `cand` join a single physical buffer that already holds `member`?
   // Lifetimes must not overlap (touching is allowed: a buffer's reader is
   // consumed before the writer at the same statement produces its output), and
-  // neither directional gate may block. No tile-type / size check is needed:
-  // PTO binds a per-var alloc_tile so differing shapes/dtypes legally alias one
-  // base, and largest-first ordering guarantees the buffer is sized to its
-  // representative (no member is ever larger than the buffer it joins).
+  // neither directional gate may block. Shape/dtype need not match: PTO binds a
+  // per-var alloc_tile so differing shapes/dtypes legally alias one base, and
+  // largest-first ordering guarantees the buffer is sized to its representative.
+  // On Vec only, ND and NZ must not share — see AreVecNdNzCompatible.
   auto can_share = [&](const LifetimeInterval& cand, const LifetimeInterval& member) {
     // Group-interval overlap is a fast reject; when it fires, fall back to the
     // precise per-var check so mutually-exclusive / same-value phi-family tiles
@@ -2181,6 +2197,7 @@ std::map<VarPtr, VarPtr> IdentifyReuseOpportunities(
     if (hazard_blocks(cand, member) || hazard_blocks(member, cand)) return false;
     if (forbid_blocks(cand, member) || forbid_blocks(member, cand)) return false;
     if (pipeline_blocks(cand, member)) return false;  // symmetric — one call suffices
+    if (!AreVecNdNzCompatible(cand.variable, member.variable)) return false;
     return true;
   };
 
@@ -3292,6 +3309,12 @@ AllocationConstraintAnalysis AnalyzeAllocationConstraints(const FunctionPtr& fun
     result.declared_allocation_bases.insert(base);
   }
   ValidateDeclaredAllocs(func->body_, result.declared_allocation_bases, lifetimes.var_liveness);
+
+  for (const LifetimeInterval& interval : lifetimes.lifetimes) {
+    if (const auto layout_class = GetVecNzLayoutClass(interval.variable)) {
+      result.vec_nz_layout_class.emplace(interval.variable.get(), *layout_class);
+    }
+  }
 
   result.needs_load_tpop_hazard_guard = NeedsLoadTpopHazardGuard(func);
   if (result.needs_load_tpop_hazard_guard) {

--- a/tests/ut/codegen/test_matmul_init_cond.py
+++ b/tests/ut/codegen/test_matmul_init_cond.py
@@ -70,6 +70,27 @@ class MatmulAccPlain:
 
 
 @pl.program
+class MatmulAccSubview:
+    """A legal column window of a larger Acc tile used as the destination."""
+
+    @pl.function(type=pl.FunctionType.InCore)
+    def kernel(
+        self,
+        lhs: pl.Tensor[[16, 16], pl.FP32],
+        rhs: pl.Tensor[[16, 16], pl.FP32],
+        output: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+    ) -> pl.Tensor[[16, 16], pl.FP32]:
+        lhs_mat = pl.load(lhs, [0, 0], [16, 16], target_memory=pl.MemorySpace.Mat)
+        rhs_mat = pl.load(rhs, [0, 0], [16, 16], target_memory=pl.MemorySpace.Mat)
+        lhs_tile = pl.move(lhs_mat, target_memory=pl.MemorySpace.Left)
+        rhs_tile = pl.move(rhs_mat, target_memory=pl.MemorySpace.Right)
+        parent = pl.tile.create([16, 32], pl.FP32, target_memory=pl.MemorySpace.Acc)
+        accumulator = pl.tile.slice(parent, [16, 16], [0, 16])
+        result = pl.tile.matmul_acc(accumulator, lhs_tile, rhs_tile)
+        return pl.store(result, [0, 0], output)
+
+
+@pl.program
 class MatmulAccInitTrue:
     """Literal ``True`` — folds to the non-accumulating form."""
 
@@ -144,6 +165,49 @@ class MatmulAccSplitK:
             b: pl.Tile[[16, 16], pl.FP32] = pl.load(rhs, [k0, 0], [16, 16], target_memory=pl.MemorySpace.Mat)
             acc_tile = pl.matmul_acc(acc_tile, a, b, init_cond=(k0 == 0))
         return pl.store(acc_tile, [0, 0], output)
+
+
+def _matmul_acc_io_ssas(mlir: str) -> tuple[str, str]:
+    lines = [line.strip() for line in mlir.splitlines() if "pto.tmatmul.acc" in line]
+    assert len(lines) == 1, f"expected exactly one pto.tmatmul.acc, got:\n{mlir}"
+    line = lines[0]
+    ins = line.split("ins(", 1)[1].split(")", 1)[0].split(":", 1)[0]
+    outs = line.split("outs(", 1)[1].split(")", 1)[0].split(":", 1)[0]
+    return ins.split(",", 1)[0].strip(), outs.strip()
+
+
+def test_full_accumulator_keeps_distinct_result_handle():
+    """Full-Acc accumulation keeps the pre-#2403 result-handle lowering."""
+    mlir = _generate_default_mlir(MatmulAccPlain)
+    _, result = _matmul_acc_io_ssas(mlir)
+    acc_allocs = {
+        line.split("=", 1)[0].strip(): line.split("addr = ", 1)[1].split()[0]
+        for line in mlir.splitlines()
+        if "= pto.alloc_tile addr = " in line and "loc=acc" in line
+    }
+    assert result in acc_allocs and any(
+        handle != result and address == acc_allocs[result] for handle, address in acc_allocs.items()
+    ), (
+        "a full Acc result must get its own MLIR handle even when memory reuse gives "
+        f"it the accumulator's L0C address:\n{mlir}"
+    )
+
+
+def test_acc_subview_accumulates_in_place():
+    """A real Acc pto.subview must remain the MAD's in-place destination."""
+    mlir = _generate_default_mlir(MatmulAccSubview)
+    subviews = {line.split("=", 1)[0].strip() for line in mlir.splitlines() if "= pto.subview " in line}
+    assert subviews, f"expected an Acc pto.subview destination:\n{mlir}"
+    accumulator, result = _matmul_acc_io_ssas(mlir)
+    assert accumulator == result and result in subviews, (
+        "matmul_acc must write the parent Acc window through its pto.subview SSA:\n" + mlir
+    )
+    assert not any(
+        "pto.tmov" in line
+        and "loc=acc" in line.split("ins(", 1)[-1].split("outs(", 1)[0]
+        and "loc=acc" in line.split("outs(", 1)[-1]
+        for line in mlir.splitlines()
+    ), f"subview accumulation must not emit an Acc-to-Acc move:\n{mlir}"
 
 
 def test_no_init_cond_emits_only_the_accumulating_form():

--- a/tests/ut/ir/transforms/test_auto_tile_matmul_acc_mn.py
+++ b/tests/ut/ir/transforms/test_auto_tile_matmul_acc_mn.py
@@ -832,10 +832,10 @@ def test_canonical_split_k_boundary_codegen_uses_box_aligned_physical_width():
         r"valid_col = %c16_index : !pto\.tile_buf<loc=mat, dtype=i8, rows=384, cols=32,",
         pto,
     ), pto
-    # The boundary sub-tile's Acc is the one buffer the whole predicated K-loop
-    # writes: allocated at the box-aligned physical width (cols=32) and narrowed
-    # to the logical N=16 by the explicit set_validshape the accumulator seed
-    # carries.  Pin the pair on the buffer the boundary tstore actually drains.
+    # The boundary sub-tile's Acc is allocated at the box-aligned physical width
+    # (cols=32) and narrowed to logical N=16. Full-Acc codegen may give the seed
+    # and result distinct SSA handles, so pin the logical shape on the result
+    # handle drained by the boundary tstore instead of requiring one SSA name.
     tail_store = re.search(
         r"pto\.tstore ins\((?P<acc>%[\w.]+) : !pto\.tile_buf<loc=acc, dtype=i32, "
         r"rows=(?P<rows>128|144), cols=32,[^)]*\) outs\([^)]*<(?P=rows)x16xi32>\)",
@@ -845,12 +845,16 @@ def test_canonical_split_k_boundary_codegen_uses_box_aligned_physical_width():
     tail_acc = re.escape(tail_store.group("acc"))
     tail_rows = tail_store.group("rows")
     assert re.search(
-        rf"{tail_acc} = pto\.alloc_tile [^\n]*: !pto\.tile_buf<loc=acc, dtype=i32, "
+        rf"{tail_acc} = pto\.alloc_tile [^\n]*valid_row = %c{tail_rows}_index "
+        rf"valid_col = %c16_index : !pto\.tile_buf<loc=acc, dtype=i32, "
         rf"rows={tail_rows}, cols=32,",
         pto,
     ), pto
     assert re.search(
-        rf"pto\.set_validshape {tail_acc}, %c{tail_rows}_index, %c16_index : "
+        rf"(?P<seed>%[\w.]+) = pto\.alloc_tile [^\n]*valid_row = %c{tail_rows}_index "
+        rf"valid_col = %c32_index : !pto\.tile_buf<loc=acc, dtype=i32, "
+        rf"rows={tail_rows}, cols=32,[^\n]*\n\s*"
+        rf"pto\.set_validshape (?P=seed), %c{tail_rows}_index, %c16_index : "
         rf"!pto\.tile_buf<loc=acc, dtype=i32, rows={tail_rows}, cols=32,",
         pto,
     ), pto

--- a/tests/ut/ir/transforms/test_memory_reuse.py
+++ b/tests/ut/ir/transforms/test_memory_reuse.py
@@ -16,6 +16,8 @@ This aligns MemRef objects consistently: if two tiles share a MemRef in
 ``After``, the corresponding tiles in ``Expected`` must also share.
 """
 
+from concurrent.futures import ThreadPoolExecutor
+
 import pypto.language as pl
 import pytest
 from pypto import DataType, InternalError, backend, ir, passes
@@ -37,6 +39,19 @@ def _run_pipeline(program: ir.Program) -> ir.Program:
     tests exercise the same combined transformation.
     """
     return passes.memory_reuse()(passes.materialize_semantic_aliases()(passes.init_mem_ref()(program)))
+
+
+def _run_pipeline_without_pass_context(program: ir.Program) -> ir.Program:
+    """Run the public standalone pass path without pytest's thread-local context."""
+
+    def run() -> ir.Program:
+        assert passes.PassContext.current() is None
+        return _run_pipeline(program)
+
+    # The autouse verification fixture owns a PassContext on the test thread.
+    # A fresh worker thread has no active context but shares BackendConfig.
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        return executor.submit(run).result()
 
 
 def _collect_allocated_tile_ranges(program: ir.Program) -> dict[str, tuple[int, int]]:
@@ -4189,7 +4204,7 @@ class TestStorageLayoutReuseGate:
         """Only A5 separates disjoint-lifetime ND and NZ Vec tiles."""
 
         Before = self._build_nd_nz_program()
-        After = _run_pipeline(Before)
+        After = _run_pipeline_without_pass_context(Before)
         bases = _collect_tile_memref_bases(After)
         assert "tile_nd" in bases and "tile_nz" in bases, f"missing tiles in {bases}"
         is_separate = bases["tile_nd"] != bases["tile_nz"]

--- a/tests/ut/ir/transforms/test_memory_reuse.py
+++ b/tests/ut/ir/transforms/test_memory_reuse.py
@@ -4159,14 +4159,12 @@ class TestStorageLayoutReuseGate:
             @pl.function(type=pl.FunctionType.InCore)
             def kernel(
                 self,
-                inp: pl.Tensor[[64, 64], pl.BF16],
-                out_nd: pl.Out[pl.Tensor[[64, 64], pl.BF16]],
                 out_nz: pl.Out[pl.Tensor[[64, 64], pl.BF16]],
             ) -> pl.Tensor[[64, 64], pl.BF16]:
-                tile_nd: pl.Tile[[64, 64], pl.BF16, pl.Mem.Vec] = pl.tile.load(
-                    inp, [0, 0], [64, 64], target_memory=pl.Mem.Vec
+                tile_nd: pl.Tile[[64, 64], pl.BF16, pl.Mem.Vec] = pl.tile.full(
+                    [64, 64], dtype=pl.BF16, value=0.0
                 )
-                _a: pl.Tensor[[64, 64], pl.BF16] = pl.tile.store(tile_nd, [0, 0], out_nd)
+                _consumed: pl.Tile[[64, 64], pl.BF16, pl.Mem.Vec] = pl.tile.add(tile_nd, tile_nd)
                 tile_nz: pl.Tile[
                     [64, 64],
                     pl.BF16,
@@ -4176,25 +4174,37 @@ class TestStorageLayoutReuseGate:
                         slayout=pl.TileLayout.row_major,
                         fractal=1024,
                     ),
-                ] = pl.tile.load(inp, [0, 0], [64, 64], target_memory=pl.Mem.Vec)
+                ] = pl.tile.full([64, 64], dtype=pl.BF16, value=1.0)
                 result: pl.Tensor[[64, 64], pl.BF16] = pl.tile.store(tile_nz, [0, 0], out_nz)
                 return result
 
         return Before
 
-    def test_nd_and_nz_vec_tiles_do_not_reuse(self):
-        """Disjoint-lifetime ND and NZ Vec tiles of equal size keep separate buffers."""
+    @pytest.mark.parametrize(
+        ("ascend_backend", "should_separate"),
+        [(BackendType.Ascend950, True), (BackendType.Ascend910B, False)],
+        indirect=["ascend_backend"],
+    )
+    def test_nd_and_nz_vec_tiles_follow_target_policy(self, ascend_backend, should_separate):
+        """Only A5 separates disjoint-lifetime ND and NZ Vec tiles."""
 
         Before = self._build_nd_nz_program()
         After = _run_pipeline(Before)
         bases = _collect_tile_memref_bases(After)
         assert "tile_nd" in bases and "tile_nz" in bases, f"missing tiles in {bases}"
-        assert bases["tile_nd"] != bases["tile_nz"], (
-            f"ND and NZ Vec tiles must not share a MemRef; both bound to {bases['tile_nd']}"
+        is_separate = bases["tile_nd"] != bases["tile_nz"]
+        assert is_separate is should_separate, (
+            f"{ascend_backend.name} expected separate={should_separate}, "
+            f"got ND {bases['tile_nd']} and NZ {bases['tile_nz']}"
         )
 
-    def test_dsa_rp_nd_and_nz_vec_tiles_do_not_overlap(self, ascend_backend):
-        """DSA-RP exports the ND/NZ restriction as an unrelaxable hard edge."""
+    @pytest.mark.parametrize(
+        ("ascend_backend", "should_separate"),
+        [(BackendType.Ascend950, True), (BackendType.Ascend910B, False)],
+        indirect=["ascend_backend"],
+    )
+    def test_dsa_rp_nd_and_nz_vec_tiles_follow_target_policy(self, ascend_backend, should_separate):
+        """DSA-RP exports the ND/NZ hard edge on A5 and keeps A2/A3 reuse."""
 
         Before = self._build_nd_nz_program()
         with passes.PassContext([], memory_planner=passes.MemoryPlanner.DSA_RP):
@@ -4205,8 +4215,10 @@ class TestStorageLayoutReuseGate:
         ranges = _collect_allocated_tile_ranges(After)
         nd_offset, nd_size = ranges["tile_nd"]
         nz_offset, nz_size = ranges["tile_nz"]
-        assert nd_offset + nd_size <= nz_offset or nz_offset + nz_size <= nd_offset, (
-            f"DSA-RP must physically separate ND {ranges['tile_nd']} and NZ {ranges['tile_nz']} Vec tiles"
+        is_separate = nd_offset + nd_size <= nz_offset or nz_offset + nz_size <= nd_offset
+        assert is_separate is should_separate, (
+            f"{ascend_backend.name} expected separate={should_separate}, "
+            f"got ND {ranges['tile_nd']} and NZ {ranges['tile_nz']}"
         )
 
     def test_same_nz_family_different_fractal_vec_tiles_can_reuse(self):

--- a/tests/ut/ir/transforms/test_memory_reuse.py
+++ b/tests/ut/ir/transforms/test_memory_reuse.py
@@ -18,7 +18,7 @@ This aligns MemRef objects consistently: if two tiles share a MemRef in
 
 import pypto.language as pl
 import pytest
-from pypto import DataType, InternalError, backend, ir, passes, testing
+from pypto import DataType, InternalError, backend, ir, passes
 from pypto.backend import BackendType
 from pypto.ir.op import tile
 from pypto.ir.pass_manager import OptimizationStrategy, PassManager
@@ -4143,12 +4143,13 @@ class TestL0CrossShapeReuse:
         )
 
 
-class TestStorageLayoutReuse:
-    """Disjoint tiles may reuse storage across TileView representations.
+class TestStorageLayoutReuseGate:
+    """Vec ND↔NZ tiles must not share a MemRef; other layout diffs may.
 
-    The tile.move ``not_inplace_safe`` constraint precisely separates a move
-    from its source. Unrelated ND and NZ values therefore need no global layout
-    gate and remain eligible for ordinary lifetime-based reuse.
+    A5 mixed kernels silently corrupt values when lifetime-disjoint ND and NZ
+    tiles reuse one Vec address. The ``tile.move`` producer/consumer no-alias
+    rule is not sufficient because the conflicting values may be unrelated.
+    Gate only Vec ND↔NZ so same-family and non-Vec reuse remain available.
     """
 
     @staticmethod
@@ -4181,29 +4182,32 @@ class TestStorageLayoutReuse:
 
         return Before
 
-    def test_nd_and_nz_vec_tiles_can_reuse(self):
-        """Disjoint-lifetime ND and NZ Vec tiles of equal size share a buffer."""
+    def test_nd_and_nz_vec_tiles_do_not_reuse(self):
+        """Disjoint-lifetime ND and NZ Vec tiles of equal size keep separate buffers."""
 
         Before = self._build_nd_nz_program()
         After = _run_pipeline(Before)
         bases = _collect_tile_memref_bases(After)
         assert "tile_nd" in bases and "tile_nz" in bases, f"missing tiles in {bases}"
-        assert bases["tile_nd"] == bases["tile_nz"], (
-            "unrelated ND and NZ Vec tiles should share a lifetime-compatible MemRef; "
-            f"got {bases['tile_nd']} vs {bases['tile_nz']}"
+        assert bases["tile_nd"] != bases["tile_nz"], (
+            f"ND and NZ Vec tiles must not share a MemRef; both bound to {bases['tile_nd']}"
         )
 
-    def test_dsa_rp_nd_and_nz_vec_tiles_have_no_layout_separation(self, ascend_backend):
-        """DSA-RP does not add a hard edge solely for ND/NZ representations."""
+    def test_dsa_rp_nd_and_nz_vec_tiles_do_not_overlap(self, ascend_backend):
+        """DSA-RP exports the ND/NZ restriction as an unrelaxable hard edge."""
 
         Before = self._build_nd_nz_program()
-        initialized = passes.init_mem_ref()(Before)
-        function = next(iter(initialized.functions.values()))
-        edges = {
-            (edge["first_name"], edge["second_name"], edge["cost"])
-            for edge in testing.recognize_dsa_reuse_penalties(function)
-        }
-        assert ("tile_nd", "tile_nz", 1) in edges
+        with passes.PassContext([], memory_planner=passes.MemoryPlanner.DSA_RP):
+            After = passes.allocate_memory_addr()(
+                passes.materialize_semantic_aliases()(passes.init_mem_ref()(Before))
+            )
+
+        ranges = _collect_allocated_tile_ranges(After)
+        nd_offset, nd_size = ranges["tile_nd"]
+        nz_offset, nz_size = ranges["tile_nz"]
+        assert nd_offset + nd_size <= nz_offset or nz_offset + nz_size <= nd_offset, (
+            f"DSA-RP must physically separate ND {ranges['tile_nd']} and NZ {ranges['tile_nz']} Vec tiles"
+        )
 
     def test_same_nz_family_different_fractal_vec_tiles_can_reuse(self):
         """Same NZ family (col_major) with fractal-only difference may coalesce."""


### PR DESCRIPTION
## Summary

- preserve a distinct result handle for full-Acc `tile.matmul_acc` values that reuse the accumulator's physical L0C address
- keep true, unmaterialized Acc subviews in place so MAD still updates their parent window
- prevent A5 Vec ND and NZ representation families from sharing one physical address in both the legacy and DSA-RP memory planners
- retain the existing A2/A3 cross-layout reuse policy and document the target-specific constraint
- make the A5 policy work for standalone pass invocation even when no `PassContext` is active

## Root cause

Two independent compiler regressions prevented the DeepSeek V4 Flash path from producing stable end-to-end tokens:

1. A full accumulator was lowered with the same MLIR handle as its loop-carried `matmul_acc` input. This changed PTOAS full-accumulator loop lowering and could stall long-running kernels. Only a real `pto.subview` needs the in-place handle introduced for subview correctness.
2. On A5, lifetime-disjoint Vec values using ND and NZ representations could reuse one address. Mixed kernels can then read representation-incompatible contents and silently corrupt decode values.

The layout restriction is queried through the configured backend handler and applies only when the PTO target architecture is `a5`. When a pass runs without an active `PassContext`, it falls back to the globally configured backend instead of silently disabling the A5 gate.

## Validation

- [x] Current worktree build at `be24b058` is clean and up to date on `origin/main` `bd3a477d`
- [x] Standalone no-`PassContext` regression verifies A5 separates ND/NZ while A2/A3 retains reuse
- [x] Affected test set: 169 passed
- [x] Full isolated unit suite: 10331 passed, 3 skipped, 2 xfailed
- [x] GitHub CI: 14/14 jobs passed, including unit, codegen, A5 mixed-kernel, model, direct/distributed system, and A5 simulator tests
- [x] `git diff --check`, Ruff check/format, pre-commit, clang-tidy, and documentation checks

The final-head local tests loaded both the Python package and native extension from the current worktree staging while retaining the shared dependency environment. The primary PyPTO editable finder was explicitly absent. The current native extension SHA-256 is `50d0b73b65249bc567dea52b83e65c0975b070d31e2d54678b1ed70f219c966d`.

The patch-equivalent pre-rebase stack (`6a3a8b25`) was also validated with the companion repository fixes on 8 devices using real DeepSeek V4 Flash EP8/TP2 weights: prefill 16 plus 32 decode steps completed, all 33 token markers were finite, rank-consistent, and greedy, with steady-state TPOT 213.861 ms/token. That end-to-end result depends on all companion PRs below; it is not a PyPTO-only validation.

## Companion PRs

- pypto-lib: https://github.com/hw-native-sys/pypto-lib/pull/1019
- PTO-ISA: https://gitcode.com/CANN/pto-isa/merge_requests/1525

## Risk

- A5 Vec peak memory may increase where ND and NZ lifetimes previously shared storage; same-representation reuse remains enabled.
- DSA-RP materializes cross-layout hard relations only for disjoint A5 Vec intervals.
- The `matmul_acc` codegen change is limited to full Acc values; actual unmaterialized subviews keep the in-place path.
