### PR TITLE
fix(debug): honour matmul_acc's init_cond in the torch reference

### DIFF
--- a/docs/en/dev/debug/00-torch_codegen.md
+++ b/docs/en/dev/debug/00-torch_codegen.md
@@ -85,6 +85,30 @@ Mappings are registered by category:
 - cross-core pipe operations
 - `system.*` operations (no-op in debug codegen)
 
+### Accumulating matmuls and `init_cond`
+
+`tile.matmul_acc` / `tensor.matmul_acc` take an optional trailing `init_cond`
+operand — a BOOL scalar carrying the MAD's `cmatrixInit` bit. Where the
+predicate holds, the op **overwrites** the accumulator with `lhs @ rhs` instead
+of accumulating into it, so a reference that ignored it would model an
+overwrite as an accumulate.
+
+The predicate is a *scalar*, not an elementwise mask, so it emits a whole-op
+branch rather than a `torch.where`:
+
+| Call | Emitted expression |
+| ---- | ------------------ |
+| `matmul_acc(acc, a, b)` | `(acc + torch.matmul(a, b).float())` |
+| `matmul_acc(acc, a, b, k == 0)` | `_acc_init(acc, torch.matmul(a, b).float(), (k == 0))` |
+| `matmul_acc(acc, a, b, True)` | `torch.matmul(a, b).float()` |
+| `matmul_acc(acc, a, b, False)` | `(acc + torch.matmul(a, b).float())` |
+
+A literal predicate is folded to the arm it selects, mirroring how PTO codegen
+picks `pto.tmatmul` over `pto.tmatmul.acc` instead of emitting an `scf.if` on a
+compile-time constant. `_acc_init` is a preamble helper; `tile.batch_matmul_acc`
+and `tile.gemv_acc` share the same emitter, so they pick the predicate up for
+free if it is ever added to those ops.
+
 ### Cross-core operation mappings
 
 - `tile.tpush_to_aiv` -> `_cross_core_rt.push_to_aiv(tile, split[, lane_stride])`

--- a/docs/zh/dev/debug/00-torch_codegen.md
+++ b/docs/zh/dev/debug/00-torch_codegen.md
@@ -85,6 +85,27 @@ torch_codegen(node: _ir.Program | _ir.Function, check_shapes: bool = False) -> s
 - cross-core 管道操作
 - `system.*` 操作（调试场景下按 no-op 处理）
 
+### 累加型 matmul 与 `init_cond`
+
+`tile.matmul_acc` / `tensor.matmul_acc` 可以带一个可选的尾部 `init_cond`
+操作数——一个承载 MAD `cmatrixInit` 位的 BOOL 标量（scalar）。在谓词成立的迭代上，
+该算子会用 `lhs @ rhs` **覆盖**（overwrite）累加器，而不是累加进去；因此忽略它的参考
+实现会把覆盖建模成累加。
+
+该谓词是*标量*而非逐元素掩码，所以生成的是整个算子级别的分支，而不是 `torch.where`：
+
+| 调用 | 生成的表达式 |
+| ---- | ------------ |
+| `matmul_acc(acc, a, b)` | `(acc + torch.matmul(a, b).float())` |
+| `matmul_acc(acc, a, b, k == 0)` | `_acc_init(acc, torch.matmul(a, b).float(), (k == 0))` |
+| `matmul_acc(acc, a, b, True)` | `torch.matmul(a, b).float()` |
+| `matmul_acc(acc, a, b, False)` | `(acc + torch.matmul(a, b).float())` |
+
+字面量谓词会直接折叠成它所选中的那一支，这与 PTO codegen 选择 `pto.tmatmul` 而非
+`pto.tmatmul.acc`（而不是对编译期常量发射 `scf.if`）的做法一致。`_acc_init` 是
+preamble 中的辅助函数；`tile.batch_matmul_acc` 和 `tile.gemv_acc` 共用同一个
+emitter，因此一旦这些算子将来支持该谓词，它们可以直接受益。
+
 ### cross-core 相关映射
 
 - `tile.tpush_to_aiv` -> `_cross_core_rt.push_to_aiv(tile, split[, lane_stride])`

--- a/python/pypto/debug/torch_codegen.py
+++ b/python/pypto/debug/torch_codegen.py
@@ -608,6 +608,13 @@ def _assemble(target, source, offsets, atomic=0):
     else:
         target[slices] = source[valid_slices]
     return target
+
+def _acc_init(acc, prod, init_cond):
+    # `init_cond` is the MAD's cmatrixInit bit: where the predicate holds the op
+    # *overwrites* the accumulator with the fresh product instead of adding into
+    # it.  The predicate is a BOOL *scalar*, so this is a whole-op branch rather
+    # than an elementwise torch.where.
+    return prod if init_cond else acc + prod
 """
 
 # ---------------------------------------------------------------------------
@@ -663,17 +670,55 @@ def _handle_tensor_matmul(a: list[str], kw: dict[str, Any]) -> str:
     return expr
 
 
+def _acc_expr(acc: str, prod: str, init_cond: str | None) -> str:
+    """Combine an accumulator with a fresh matmul product.
+
+    The accumulating matmuls take an optional trailing `init_cond` operand -- a
+    BOOL scalar carrying the MAD's ``cmatrixInit`` bit.  Where it holds, the op
+    *overwrites* `acc` with `prod` instead of accumulating into it, so dropping
+    it would model an overwrite as an accumulate.
+
+    Args:
+        acc: Emitted expression for the accumulator operand
+        prod: Emitted expression for the `lhs @ rhs` product
+        init_cond: Emitted expression for the predicate, or None when the call
+            carries no `init_cond` operand (always accumulate)
+
+    Returns:
+        A Python expression string for the op's result
+    """
+    if init_cond is None:
+        return f"({acc} + {prod})"
+    # Fold a literal predicate the way the pto backend does, so the generated
+    # script keeps the shape of the branch the machine actually takes.
+    if init_cond in ("True", "1"):
+        return prod
+    if init_cond in ("False", "0"):
+        return f"({acc} + {prod})"
+    return f"_acc_init({acc}, {prod}, {init_cond})"
+
+
+def _init_cond_arg(a: list[str], index: int) -> str | None:
+    """Return the emitted `init_cond` operand at `index`, or None if absent."""
+    return a[index] if len(a) > index else None
+
+
 def _handle_tensor_matmul_acc(a: list[str], kw: dict[str, Any]) -> str:
     acc, lhs, rhs = a[0], a[1], a[2]
     if kw.get("a_trans"):
         lhs = f"{lhs}.mT"
     if kw.get("b_trans"):
         rhs = f"{rhs}.mT"
-    expr = f"({acc} + torch.matmul({lhs}, {rhs}))"
+    expr = _acc_expr(acc, f"torch.matmul({lhs}, {rhs})", _init_cond_arg(a, 3))
     out_dtype = kw.get("out_dtype")
     if isinstance(out_dtype, DataType):
         expr = f"{expr}.to({_torch_dtype(out_dtype)})"
     return expr
+
+
+def _tile_matmul_acc(a: list[str], _kw: dict[str, Any]) -> str:
+    """Accumulating tile matmul; `.float()` matches hardware FP32 accumulation."""
+    return _acc_expr(a[0], f"torch.matmul({a[1]}, {a[2]}).float()", _init_cond_arg(a, 3))
 
 
 def _handle_cast(a: list[str], kw: dict[str, Any]) -> str:
@@ -1078,11 +1123,11 @@ def _register_ops() -> None:  # noqa: PLR0915
     # tile matmul variants — .float() to match hardware FP32 accumulation output
     m["tile.matmul"] = lambda a, _kw: f"torch.matmul({a[0]}, {a[1]}).float()"
     m["tile.batch_matmul"] = lambda a, _kw: f"torch.matmul({a[0]}, {a[1]}).float()"
-    m["tile.matmul_acc"] = lambda a, _kw: f"({a[0]} + torch.matmul({a[1]}, {a[2]}).float())"
-    m["tile.batch_matmul_acc"] = lambda a, _kw: f"({a[0]} + torch.matmul({a[1]}, {a[2]}).float())"
+    m["tile.matmul_acc"] = _tile_matmul_acc
+    m["tile.batch_matmul_acc"] = _tile_matmul_acc
     m["tile.matmul_bias"] = lambda a, _kw: f"(torch.matmul({a[0]}, {a[1]}).float() + {a[2]})"
     m["tile.gemv"] = lambda a, _kw: f"torch.matmul({a[0]}, {a[1]}).float()"
-    m["tile.gemv_acc"] = lambda a, _kw: f"({a[0]} + torch.matmul({a[1]}, {a[2]}).float())"
+    m["tile.gemv_acc"] = _tile_matmul_acc
     m["tile.gemv_bias"] = lambda a, _kw: f"(torch.matmul({a[0]}, {a[1]}).float() + {a[2]})"
 
     # tile ternary ops (third arg is workspace/tmp, ignore it)

--- a/tests/ut/debug/test_torch_codegen.py
+++ b/tests/ut/debug/test_torch_codegen.py
@@ -449,6 +449,120 @@ def test_tile_matmul_acc():
     assert "acc + torch.matmul(a, b).float()" in code
 
 
+def test_tile_matmul_acc_runtime_init_cond_overwrites():
+    """A runtime init_cond must overwrite the accumulator, not accumulate into it."""
+
+    @pl.program
+    class SplitKFromNonZeroAcc:
+        @pl.function(type=pl.FunctionType.InCore)
+        def kernel(
+            self,
+            seed: pl.Tensor[[16, 16], pl.FP32],
+            lhs: pl.Tensor[[16, 32], pl.FP32],
+            rhs: pl.Tensor[[32, 16], pl.FP32],
+            output: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+        ) -> pl.Tensor[[16, 16], pl.FP32]:
+            # A *non-zero* accumulator is what separates overwrite from
+            # accumulate; the tile.create zero seed the compiler emits today
+            # makes the two coincide. Seeding it with a matmul both keeps the
+            # accumulator in Acc and gives it a value the k0 == 0 step must drop.
+            seed_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(
+                seed, [0, 0], [16, 16], target_memory=pl.MemorySpace.Mat
+            )
+            head: pl.Tile[[16, 16], pl.FP32] = pl.load(
+                lhs, [0, 0], [16, 16], target_memory=pl.MemorySpace.Mat
+            )
+            acc_tile: pl.Tile[[16, 16], pl.FP32, pl.MemorySpace.Acc] = pl.matmul(seed_tile, head)
+            for k0 in pl.range(0, 32, 16):
+                a: pl.Tile[[16, 16], pl.FP32] = pl.load(
+                    lhs, [0, k0], [16, 16], target_memory=pl.MemorySpace.Mat
+                )
+                b: pl.Tile[[16, 16], pl.FP32] = pl.load(
+                    rhs, [k0, 0], [16, 16], target_memory=pl.MemorySpace.Mat
+                )
+                acc_tile = pl.matmul_acc(acc_tile, a, b, init_cond=(k0 == 0))
+            return pl.store(acc_tile, [0, 0], output)
+
+    code = torch_codegen(SplitKFromNonZeroAcc)
+    assert "_acc_init(acc_tile, torch.matmul(a, b).float(), (k0 == 0))" in code
+
+    ns: dict = {}
+    exec(code, ns)  # noqa: S102
+    seed = torch.full((16, 16), 3.0)
+    lhs = torch.ones(16, 32)
+    rhs = torch.ones(32, 16)
+    out = torch.zeros(16, 16)
+    ns["kernel"](seed, lhs, rhs, out)
+
+    # k0 == 0 overwrites the seeded accumulator; k0 == 16 accumulates into it.
+    overwrite = lhs[:, :16] @ rhs[:16, :] + lhs[:, 16:] @ rhs[16:, :]
+    assert torch.allclose(out, overwrite)
+    # Dropping the predicate would fold the seed product in instead.
+    assert not torch.allclose(out, seed @ lhs[:, :16] + overwrite)
+
+
+def test_tile_matmul_acc_literal_init_cond_folds():
+    """A literal init_cond picks one arm outright, mirroring the pto backend."""
+
+    @pl.program
+    class MatmulAccInitTrue:
+        @pl.function(type=pl.FunctionType.InCore)
+        def kernel(
+            self,
+            lhs: pl.Tensor[[16, 16], pl.FP32],
+            rhs: pl.Tensor[[16, 16], pl.FP32],
+            output: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+        ) -> pl.Tensor[[16, 16], pl.FP32]:
+            a: pl.Tile[[16, 16], pl.FP32] = pl.load(lhs, [0, 0], [16, 16], target_memory=pl.MemorySpace.Mat)
+            b: pl.Tile[[16, 16], pl.FP32] = pl.load(rhs, [0, 0], [16, 16], target_memory=pl.MemorySpace.Mat)
+            acc: pl.Tile[[16, 16], pl.FP32, pl.MemorySpace.Acc] = pl.matmul(a, b)
+            out_tile: pl.Tile[[16, 16], pl.FP32] = pl.tile.matmul_acc(acc, a, b, init_cond=True)
+            return pl.store(out_tile, [0, 0], output)
+
+    @pl.program
+    class MatmulAccInitFalse:
+        @pl.function(type=pl.FunctionType.InCore)
+        def kernel(
+            self,
+            lhs: pl.Tensor[[16, 16], pl.FP32],
+            rhs: pl.Tensor[[16, 16], pl.FP32],
+            output: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+        ) -> pl.Tensor[[16, 16], pl.FP32]:
+            a: pl.Tile[[16, 16], pl.FP32] = pl.load(lhs, [0, 0], [16, 16], target_memory=pl.MemorySpace.Mat)
+            b: pl.Tile[[16, 16], pl.FP32] = pl.load(rhs, [0, 0], [16, 16], target_memory=pl.MemorySpace.Mat)
+            acc: pl.Tile[[16, 16], pl.FP32, pl.MemorySpace.Acc] = pl.matmul(a, b)
+            out_tile: pl.Tile[[16, 16], pl.FP32] = pl.tile.matmul_acc(acc, a, b, init_cond=False)
+            return pl.store(out_tile, [0, 0], output)
+
+    # True selects the overwrite arm outright -- the accumulator drops out.
+    assert "out_tile = torch.matmul(a, b).float()" in torch_codegen(MatmulAccInitTrue)
+    # False selects the accumulating arm, identical to carrying no predicate.
+    assert "out_tile = (acc + torch.matmul(a, b).float())" in torch_codegen(MatmulAccInitFalse)
+
+
+def test_tensor_matmul_acc_init_cond_with_transpose():
+    """tensor.matmul_acc must honour init_cond alongside a_trans/b_trans."""
+
+    @pl.program
+    class TensorSplitK:
+        @pl.function(type=pl.FunctionType.InCore)
+        def kernel(
+            self,
+            acc: pl.Tensor[[16, 16], pl.FP32],
+            # a_trans=True, so lhs is [K=32, M=16] and the product is [16, 16].
+            lhs: pl.Tensor[[32, 16], pl.FP32],
+            rhs: pl.Tensor[[32, 16], pl.FP32],
+            output: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+        ) -> pl.Tensor[[16, 16], pl.FP32]:
+            result: pl.Tensor[[16, 16], pl.FP32] = acc
+            for k0 in pl.range(0, 2):
+                result = pl.matmul_acc(result, lhs, rhs, a_trans=True, init_cond=(k0 == 0))
+            return pl.assemble(output, result, [0, 0])
+
+    code = torch_codegen(TensorSplitK)
+    assert "_acc_init(result, torch.matmul(lhs.mT, rhs), (k0 == 0))" in code
+
+
 def test_tile_cmp():
     """tile.cmp should emit correct comparison operator."""
     a = _tile_var("a", [64])


### PR DESCRIPTION
## Summary

`torch_codegen`'s PyTorch reference emitters for the accumulating matmuls read only three operands and unconditionally emitted `acc + lhs @ rhs`. The optional trailing `init_cond` operand — a BOOL scalar carrying the MAD's `cmatrixInit` bit, which makes the op *overwrite* the accumulator where the predicate holds — was silently dropped, so the reference accumulated on exactly the iterations the machine overwrites.

Every in-tree caller is masked today: the predicated calls `AutoTileMatmulL0` generates seed their accumulator with `tile.create`, which maps to `torch.zeros`, so overwrite and accumulate coincide. A hand-written kernel that predicates a *non-zero* accumulator got a wrong reference rather than a failing one — worse, because it can declare a genuinely miscompiled kernel correct. After this change such a kernel gets a reference that matches the machine.

No behavior changes for a call carrying no `init_cond`: the emitted expression is byte-identical to before. This is the debug/reference path only; no product codegen is touched.

## Changes

- `python/pypto/debug/torch_codegen.py`: `tile.matmul_acc` and `tensor.matmul_acc` now emit the predicate. Because `init_cond` is a *scalar* rather than an elementwise mask, it lowers to a whole-op branch through a new `_acc_init` preamble helper, not a `torch.where` (which rejects a Python bool condition anyway). A literal predicate folds to the arm it selects, mirroring how PTO codegen picks `pto.tmatmul` over `pto.tmatmul.acc` instead of branching on a compile-time constant — both spellings fold, the BOOL `ConstInt` a DSL `init_cond=True` produces and the `ConstBool` the arithmetic simplifier yields. `tile.batch_matmul_acc` and `tile.gemv_acc` share the emitter; they take 3 operands today, so nothing changes for them, but they pick the predicate up if it is ever added to those ops.
- `tests/ut/debug/test_torch_codegen.py`: three DSL-written tests. A split-K kernel whose accumulator is seeded by a `pl.matmul` (non-zero and legally Acc-resident) executes the generated script and asserts the result equals the product alone, and explicitly asserts it does *not* equal the seed-folded-in value the old emitter produced. Two more cover literal-predicate folding and `tensor.matmul_acc` composing `init_cond` with `a_trans`. All three fail against the previous emitter.
- `docs/en/dev/debug/00-torch_codegen.md`, `docs/zh/dev/debug/00-torch_codegen.md`: new "Accumulating matmuls and `init_cond`" section with the call → emitted-expression table and the reason the predicate is a branch rather than a `torch.where`.

## Verification

- `python -m pytest tests/ut -n 8 -q`: 0 — 10330 passed, 3 skipped, 2 xfailed (run by the push transaction against the pushed commit)
- `python -m pytest tests/ut/debug/test_torch_codegen.py -q`: 0 — 83 passed
- `python -m pytest tests/st/codegen/torch -n 8 -q`: 0 — 31 passed
- `ruff check .`: 0 — all checks passed
- `ruff format --check .`: 0 — 1097 files already formatted
- `pyright python/pypto/debug/torch_codegen.py tests/ut/debug/test_torch_codegen.py`: 0 — 0 errors, 0 warnings
- `pre-commit run --files <4 changed files>`: 0 — all hooks passed or skipped
- Negative check: with `python/pypto/debug/torch_codegen.py` reverted, the three new tests fail; with the fix they pass.
