### PR TITLE
docs(passes): correct the three IRPropertySet getter lists and lint them against C++

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -91,6 +91,13 @@ repos:
           language_version: python3
           pass_filenames: false
 
+        - id: check-property-set-doc-parity
+          name: check-property-set-doc-parity
+          entry: python tests/lint/check_property_set_doc_parity.py
+          language: python
+          language_version: python3
+          pass_filenames: false
+
     - repo: https://github.com/pre-commit/pre-commit-hooks
       rev: v4.6.0
       hooks:

--- a/docs/en/dev/passes/00-pass_manager.md
+++ b/docs/en/dev/passes/00-pass_manager.md
@@ -395,6 +395,8 @@ class PassPipeline {
 
 When `VerificationLevel` is `Basic` (the default), the pipeline automatically verifies the **lightweight properties** listed by `GetVerifiedProperties()` (`src/ir/transforms/ir_property.cpp`), each one exactly once per time it is produced. This catches common IR errors without requiring manual `PassContext` setup.
 
+The members of that set — and of `GetStructuralProperties()` and `GetDefaultVerifyProperties()` — are restated in prose three times: the `Returns {...}` clause on each declaration in `ir_property.h`, and a summary row in each language's [Verifier](99-verifier.md) doc. `tests/lint/check_property_set_doc_parity.py` (a pre-commit hook) holds those copies to the C++ initializers, since a property added to an initializer alone compiles and passes CI while every list a developer reads stays short by one.
+
 **How it works**:
 
 1. At pipeline input, verify `GetStructuralProperties() ∩ GetVerifiedProperties()` — the invariants that hold on the user's own IR before any pass runs

--- a/docs/en/dev/passes/99-verifier.md
+++ b/docs/en/dev/passes/99-verifier.md
@@ -178,7 +178,7 @@ Singleton registry mapping `IRProperty` values to `PropertyVerifier` factories. 
 | -------- | ------- | ----------- |
 | `GetStructuralProperties()` | `{TypeChecked, BreakContinueValid, NoRedundantBlocks, UseAfterDef, OutParamNotShadowed, NoNestedInCore, InOutUseValid, PipelineLoopValid, ArrayNotEscaped, ManualDepsOnSubmitOnly, AtomicAddDtypeValid}` | Invariants verified before/after each pass by `VerificationInstrument` (the subset shared with `GetVerifiedProperties()` is also checked at pipeline start) |
 | `GetDefaultVerifyProperties()` | `{SSAForm, TypeChecked, NoNestedCalls, BreakContinueValid, NoRedundantBlocks, UseAfterDef, OutParamNotShadowed, NoNestedInCore, TileTypeCoherence, ArrayNotEscaped}` | Default set for `run_verifier()` |
-| `GetVerifiedProperties()` | `{SSAForm, TypeChecked, MixedKernelExpanded, AllocatedMemoryAddr, BreakContinueValid, NoRedundantBlocks, InOutUseValid, CallDirectionsResolved, ManualDepsOnSubmitOnly, ReturnParamsExplicit, AivSplitValid, HardSyncallOccupancyValid, IterArgCarryClassified, RuntimeScopesMaterialized, AccToGmStoreValid, AtomicAddDtypeValid, TileMemoryInferred}` | Lightweight set for `PassPipeline` auto-verify |
+| `GetVerifiedProperties()` | `{SSAForm, TypeChecked, MixedKernelExpanded, AllocatedMemoryAddr, BreakContinueValid, NoRedundantBlocks, InOutUseValid, CallDirectionsResolved, ManualDepsOnSubmitOnly, ReturnParamsExplicit, AivSplitValid, TileMemoryInferred, HardSyncallOccupancyValid, IterArgCarryClassified, RuntimeScopesMaterialized, DistTensorCtxMaterialized, AccToGmStoreValid, AtomicAddDtypeValid}` | Lightweight set for `PassPipeline` auto-verify |
 
 ### RunVerifier Pass Factory
 

--- a/docs/zh/dev/passes/00-pass_manager.md
+++ b/docs/zh/dev/passes/00-pass_manager.md
@@ -393,6 +393,8 @@ class PassPipeline {
 
 当 `VerificationLevel` 为 `Basic`（默认值）时，流水线会自动验证 `GetVerifiedProperties()`（`src/ir/transforms/ir_property.cpp`）列出的**轻量级属性**，每次产生时各验证一次。这可以在无需手动设置 `PassContext` 的情况下捕获常见的 IR 错误。
 
+该集合——以及 `GetStructuralProperties()` 和 `GetDefaultVerifyProperties()`——的成员在文字描述中被重复列出了三份：`ir_property.h` 中每个声明上的 `Returns {...}` 子句，以及各语言版本 [Verifier](99-verifier.md) 文档中的一行汇总。`tests/lint/check_property_set_doc_parity.py`（一个 pre-commit 钩子）负责让这些副本与 C++ 初始化列表保持一致：仅把属性加进初始化列表而不更新副本，既能编译也能通过 CI，但开发者实际阅读的每一份列表都会少一项。
+
 **工作原理**：
 
 1. 在流水线入口验证 `GetStructuralProperties() ∩ GetVerifiedProperties()`——这些不变量在任何 Pass 运行前就应在用户自己的 IR 上成立

--- a/docs/zh/dev/passes/99-verifier.md
+++ b/docs/zh/dev/passes/99-verifier.md
@@ -178,7 +178,7 @@
 | ---- | ------ | ---- |
 | `GetStructuralProperties()` | `{TypeChecked, BreakContinueValid, NoRedundantBlocks, UseAfterDef, OutParamNotShadowed, NoNestedInCore, InOutUseValid, PipelineLoopValid, ArrayNotEscaped, ManualDepsOnSubmitOnly, AtomicAddDtypeValid}` | 由 `VerificationInstrument` 在每个 Pass 执行前后验证的不变量（与 `GetVerifiedProperties()` 共有的子集还会在流水线启动时验证） |
 | `GetDefaultVerifyProperties()` | `{SSAForm, TypeChecked, NoNestedCalls, BreakContinueValid, NoRedundantBlocks, UseAfterDef, OutParamNotShadowed, NoNestedInCore, TileTypeCoherence, ArrayNotEscaped}` | `run_verifier()` 的默认属性集 |
-| `GetVerifiedProperties()` | `{SSAForm, TypeChecked, MixedKernelExpanded, AllocatedMemoryAddr, BreakContinueValid, NoRedundantBlocks, InOutUseValid, CallDirectionsResolved, ManualDepsOnSubmitOnly, ReturnParamsExplicit, AivSplitValid, HardSyncallOccupancyValid, IterArgCarryClassified, RuntimeScopesMaterialized, AccToGmStoreValid, AtomicAddDtypeValid, TileMemoryInferred}` | `PassPipeline` 自动验证的轻量级属性集 |
+| `GetVerifiedProperties()` | `{SSAForm, TypeChecked, MixedKernelExpanded, AllocatedMemoryAddr, BreakContinueValid, NoRedundantBlocks, InOutUseValid, CallDirectionsResolved, ManualDepsOnSubmitOnly, ReturnParamsExplicit, AivSplitValid, TileMemoryInferred, HardSyncallOccupancyValid, IterArgCarryClassified, RuntimeScopesMaterialized, DistTensorCtxMaterialized, AccToGmStoreValid, AtomicAddDtypeValid}` | `PassPipeline` 自动验证的轻量级属性集 |
 
 ### RunVerifier Pass 工厂
 

--- a/include/pypto/ir/transforms/ir_property.h
+++ b/include/pypto/ir/transforms/ir_property.h
@@ -237,9 +237,9 @@ enum class VerificationLevel {
  * BreakContinueValid, NoRedundantBlocks, InOutUseValid,
  * CallDirectionsResolved, ManualDepsOnSubmitOnly, ReturnParamsExplicit,
  * AivSplitValid, TileMemoryInferred, HardSyncallOccupancyValid,
- * IterArgCarryClassified, RuntimeScopesMaterialized, AccToGmStoreValid,
- * AtomicAddDtypeValid} — lightweight checks that catch the most common IR
- * errors.
+ * IterArgCarryClassified, RuntimeScopesMaterialized,
+ * DistTensorCtxMaterialized, AccToGmStoreValid, AtomicAddDtypeValid} —
+ * lightweight checks that catch the most common IR errors.
  */
 const IRPropertySet& GetVerifiedProperties();
 
@@ -249,7 +249,8 @@ const IRPropertySet& GetVerifiedProperties();
  * These are verified automatically at pipeline start and never declared
  * in per-pass PassProperties. Returns {TypeChecked, BreakContinueValid,
  * NoRedundantBlocks, UseAfterDef, OutParamNotShadowed, NoNestedInCore,
- * InOutUseValid, PipelineLoopValid, ArrayNotEscaped, ManualDepsOnSubmitOnly}.
+ * InOutUseValid, PipelineLoopValid, ArrayNotEscaped, ManualDepsOnSubmitOnly,
+ * AtomicAddDtypeValid}.
  */
 const IRPropertySet& GetStructuralProperties();
 
@@ -257,7 +258,8 @@ const IRPropertySet& GetStructuralProperties();
  * @brief Default property set for explicit verification
  *
  * Returns {SSAForm, TypeChecked, NoNestedCalls, BreakContinueValid,
- * NoRedundantBlocks, UseAfterDef, OutParamNotShadowed, NoNestedInCore} — the properties checked by
+ * NoRedundantBlocks, UseAfterDef, OutParamNotShadowed, NoNestedInCore,
+ * TileTypeCoherence, ArrayNotEscaped} — the properties checked by
  * run_verifier() when no explicit set is given.
  */
 const IRPropertySet& GetDefaultVerifyProperties();

--- a/tests/lint/check_property_set_doc_parity.py
+++ b/tests/lint/check_property_set_doc_parity.py
@@ -1,0 +1,226 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""
+Script to check that the three ``IRPropertySet`` getters are spelled the same everywhere.
+
+``GetVerifiedProperties()``, ``GetStructuralProperties()`` and ``GetDefaultVerifyProperties()`` each
+have a C++ initializer and three prose copies of it: the ``Returns {...}`` clause on the declaration,
+and a summary row in the English and Chinese verifier docs. Nothing in the build links them, and no
+test reads either copy, so a property added to the initializer alone compiles and passes CI while
+every list a developer actually reads stays one entry short.
+
+That is not hypothetical: ``DistTensorCtxMaterialized`` was absent from all three copies of
+``GetVerifiedProperties()``, which named 17 properties for a set that returns 18. The omitted entry
+was the distributed-only property -- the least likely of the 18 to appear in a reader's own test, and
+so the least likely to be noticed. The lists are consulted precisely when someone needs to know what
+``PassPipeline`` auto-verifies (e.g. whether a new pass must preserve a property), which is when
+being wrong by one costs the most.
+
+This check enforces, against the initializers in ``ir_property.cpp`` as the authoritative lists:
+
+1. *Coverage* -- each copy names each initializer's properties exactly once, and nothing else.
+2. *Order* -- each copy lists them in the initializer's order, so a copy can be diffed against the
+   C++ by position rather than by set membership.
+3. *Completeness* -- every getter with an initializer has a ``Returns {...}`` clause and a row in
+   both docs, so a newly added set cannot start out undocumented.
+
+Each site is also sanity-checked for pattern drift: a copy written in a form the regexes here do not
+match would be skipped in silence, which is the one failure this lint must not have, so an unparsed
+site is reported rather than ignored.
+
+Usage:
+
+    python tests/lint/check_property_set_doc_parity.py
+"""
+
+import argparse
+import re
+import sys
+from collections import Counter
+from pathlib import Path
+
+# The initializers (authoritative) and the three sites that restate them, relative to the repo root.
+IMPL_DECL = "src/ir/transforms/ir_property.cpp"
+HEADER_DECL = "include/pypto/ir/transforms/ir_property.h"
+DOC_DECLS = ("docs/en/dev/passes/99-verifier.md", "docs/zh/dev/passes/99-verifier.md")
+
+# `const IRPropertySet& GetFooProperties() { static const IRPropertySet props{...}; return props; }`
+IMPL_RE = re.compile(
+    r"const IRPropertySet& (\w+)\(\)\s*\{\s*"
+    r"(?:/[/*].*?\n\s*)*"  # optional leading comment lines inside the body
+    r"static const IRPropertySet \w+\{(.*?)\};",
+    re.DOTALL,
+)
+# Any definition of a getter returning the set, used to catch one the strict pattern would skip.
+IMPL_ANY_RE = re.compile(r"const IRPropertySet& (\w+)\(\)\s*\{")
+
+# A doxygen block immediately followed by `const IRPropertySet& GetFooProperties();` in the header.
+HEADER_RE = re.compile(r"/\*\*(.*?)\*/\s*const IRPropertySet& (\w+)\(\);", re.DOTALL)
+# Any declaration of such a getter, used to catch one with no doxygen block at all.
+HEADER_ANY_RE = re.compile(r"^const IRPropertySet& (\w+)\(\);", re.MULTILINE)
+
+# `| `GetFooProperties()` | `{A, B, C}` | description |` in the docs' summary table.
+DOC_ROW_RE = re.compile(r"^\|\s*`(\w+)\(\)`\s*\|\s*`\{([^}]*)\}`\s*\|", re.MULTILINE)
+# Any row keyed on such a getter, used to catch one whose set cell is written some other way. Both
+# doc files are full of tables keyed on a `method()` cell, so this is matched only against the
+# getters the C++ actually defines -- everything else is an unrelated API table.
+DOC_ROW_ANY_RE = re.compile(r"^\|\s*`(\w+)\(\)`\s*\|", re.MULTILINE)
+
+# The `{...}` payload of a `Returns {...}` clause, which wraps across ` * `-prefixed comment lines.
+RETURNS_RE = re.compile(r"Returns\s*\{([^}]*)\}")
+
+
+def read(root: Path, rel: str) -> str:
+    return (root / rel).read_text(encoding="utf-8")
+
+
+def split_names(payload: str) -> list[str]:
+    """Split a `{A, B, C}` payload into property names, folding any line wrapping."""
+    flat = re.sub(r"\s*\n\s*\*?\s*", " ", payload)
+    return [name.strip() for name in flat.split(",") if name.strip()]
+
+
+def parse_impl(root: Path) -> tuple[dict[str, list[str]], list[str]]:
+    """Return (getter -> properties in initializer order, errors) from the C++ implementation."""
+    text = read(root, IMPL_DECL)
+    sets = {m.group(1): re.findall(r"IRProperty::(\w+)", m.group(2)) for m in IMPL_RE.finditer(text)}
+    errors = [
+        f"{IMPL_DECL}: `{m.group(1)}()` does not parse as `static const IRPropertySet <name>{{...}};`, "
+        f"so the lists that restate it go unpoliced"
+        for m in IMPL_ANY_RE.finditer(text)
+        if m.group(1) not in sets
+    ]
+    if not sets:
+        errors.append(f"{IMPL_DECL}: found no `const IRPropertySet& <name>()` definitions at all")
+    return sets, errors
+
+
+def parse_header(root: Path, known: set[str]) -> tuple[dict[str, list[str]], list[str]]:
+    """Return (getter -> properties named by its `Returns {...}` clause, errors) from the header."""
+    text = read(root, HEADER_DECL)
+    parsed: dict[str, list[str]] = {}
+    errors: list[str] = []
+    for m in HEADER_RE.finditer(text):
+        returns = RETURNS_RE.search(m.group(1))
+        if returns is None:
+            errors.append(
+                f"{HEADER_DECL}: the doc comment on `{m.group(2)}()` has no `Returns {{...}}` clause "
+                f"naming the set's members"
+            )
+            continue
+        parsed[m.group(2)] = split_names(returns.group(1))
+    errors += [
+        f"{HEADER_DECL}: `{m.group(1)}()` is declared with no preceding doxygen block, so its members "
+        f"are documented nowhere"
+        for m in HEADER_ANY_RE.finditer(text)
+        if m.group(1) in known and m.group(1) not in parsed and not any(m.group(1) in e for e in errors)
+    ]
+    return parsed, errors
+
+
+def parse_doc(root: Path, rel: str, known: set[str]) -> tuple[dict[str, list[str]], list[str]]:
+    """Return (getter -> properties named by its summary row, errors) from one verifier doc."""
+    text = read(root, rel)
+    parsed = {m.group(1): split_names(m.group(2)) for m in DOC_ROW_RE.finditer(text) if m.group(1) in known}
+    errors = [
+        f"{rel}: the row for `{m.group(1)}()` does not spell its members as a `` `{{A, B, C}}` `` cell, "
+        f"so it goes unpoliced"
+        for m in DOC_ROW_ANY_RE.finditer(text)
+        if m.group(1) in known and m.group(1) not in parsed
+    ]
+    return parsed, errors
+
+
+def compare(site: str, getter: str, expected: list[str], actual: list[str]) -> list[str]:
+    """Report members the copy is missing, ones it invents or repeats, and any order drift."""
+    errors = [
+        f"{site}: `{getter}()` returns `{name}` but the list here omits it "
+        f"({len(actual)} named, {len(expected)} returned)"
+        for name in expected
+        if name not in actual
+    ]
+    errors += [
+        f"{site}: `{getter}()` is listed here as containing `{name}`, which is not in the "
+        f"{IMPL_DECL} initializer"
+        for name in actual
+        if name not in expected
+    ]
+    errors += [
+        f"{site}: `{getter}()` lists `{name}` {count} times -- name each member exactly once"
+        for name, count in sorted(Counter(actual).items())
+        if count > 1
+    ]
+    # Past the checks above, `actual` holds each expected name exactly once and nothing else, so it
+    # is a permutation of `expected` -- equal in length, and unequal only at some shared index.
+    if not errors and actual != expected:
+        first = next(i for i, (a, e) in enumerate(zip(actual, expected)) if a != e)
+        errors.append(
+            f"{site}: `{getter}()` diverges from the {IMPL_DECL} initializer at position {first} "
+            f"(`{actual[first]}` here, `{expected[first]}` in C++) -- keep the order so the lists stay "
+            f"diffable by position"
+        )
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=(__doc__ or "").strip().split("\n")[0])
+    parser.add_argument(
+        "--root", type=Path, default=Path(__file__).resolve().parents[2], help="Repository root"
+    )
+    args = parser.parse_args()
+    root: Path = args.root
+
+    impl, errors = parse_impl(root)
+    if errors:
+        for e in errors:
+            print(f"ERROR: {e}", file=sys.stderr)
+        return 1
+
+    known = set(impl)
+    sites = [(HEADER_DECL, parse_header(root, known))]
+    sites += [(rel, parse_doc(root, rel, known)) for rel in DOC_DECLS]
+    for site, (parsed, site_errors) in sites:
+        errors.extend(site_errors)
+        for getter, expected in impl.items():
+            if getter not in parsed:
+                errors.append(
+                    f"{site}: `{getter}()` is defined in {IMPL_DECL} but its members are not listed "
+                    f"here -- add them, in the initializer's order"
+                )
+                continue
+            errors.extend(compare(site, getter, expected, parsed[getter]))
+        errors.extend(
+            f"{site}: `{getter}()` is documented here but has no initializer in {IMPL_DECL}"
+            for getter in parsed
+            if getter not in impl
+        )
+
+    if errors:
+        print(
+            f"Every IRPropertySet getter must name the same members in {IMPL_DECL}, in its doc comment, "
+            f"and in both verifier docs.\n"
+            f"A property added to the initializer alone compiles and passes CI, so the drift shows up "
+            f"only as a list a developer reads and trusts while it is short by one.\n",
+            file=sys.stderr,
+        )
+        for e in errors:
+            print(f"ERROR: {e}", file=sys.stderr)
+        print(f"\n{len(errors)} problem(s).", file=sys.stderr)
+        return 1
+
+    total = sum(len(v) for v in impl.values())
+    print(
+        f"OK: {len(impl)} IRPropertySet getter(s), {total} membership(s), listed consistently across "
+        f"the initializer, the header comment, and both verifier docs."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/lint/check_property_set_doc_parity.py
+++ b/tests/lint/check_property_set_doc_parity.py
@@ -28,7 +28,10 @@ This check enforces, against the initializers in ``ir_property.cpp`` as the auth
 2. *Order* -- each copy lists them in the initializer's order, so a copy can be diffed against the
    C++ by position rather than by set membership.
 3. *Completeness* -- every getter with an initializer has a ``Returns {...}`` clause and a row in
-   both docs, so a newly added set cannot start out undocumented.
+   both docs, and no site states members for a getter the C++ no longer defines, so neither adding a
+   set nor removing one can leave a copy behind in one language and not the other.
+4. *Uniqueness* -- no site states a getter's members twice. Two copies can disagree, and only one of
+   them would be compared against the C++.
 
 Each site is also sanity-checked for pattern drift: a copy written in a form the regexes here do not
 match would be skipped in silence, which is the one failure this lint must not have, so an unparsed
@@ -65,11 +68,14 @@ HEADER_RE = re.compile(r"/\*\*(.*?)\*/\s*const IRPropertySet& (\w+)\(\);", re.DO
 # Any declaration of such a getter, used to catch one with no doxygen block at all.
 HEADER_ANY_RE = re.compile(r"^const IRPropertySet& (\w+)\(\);", re.MULTILINE)
 
-# `| `GetFooProperties()` | `{A, B, C}` | description |` in the docs' summary table.
+# `| `GetFooProperties()` | `{A, B, C}` | description |` in the docs' summary table. Requiring the
+# `{...}` cell is specific enough on its own -- it matches the three property-set rows and nothing
+# else in either doc -- so this is deliberately NOT narrowed to the getters the C++ defines: a row
+# left behind for a deleted getter has to keep matching in order to be reported as stale.
 DOC_ROW_RE = re.compile(r"^\|\s*`(\w+)\(\)`\s*\|\s*`\{([^}]*)\}`\s*\|", re.MULTILINE)
 # Any row keyed on such a getter, used to catch one whose set cell is written some other way. Both
-# doc files are full of tables keyed on a `method()` cell, so this is matched only against the
-# getters the C++ actually defines -- everything else is an unrelated API table.
+# doc files are full of tables keyed on a `method()` cell, so this one IS matched only against the
+# getters the C++ defines -- everything else is an unrelated API table, however it is written.
 DOC_ROW_ANY_RE = re.compile(r"^\|\s*`(\w+)\(\)`\s*\|", re.MULTILINE)
 
 # The `{...}` payload of a `Returns {...}` clause, which wraps across ` * `-prefixed comment lines.
@@ -107,6 +113,12 @@ def parse_header(root: Path, known: set[str]) -> tuple[dict[str, list[str]], lis
     parsed: dict[str, list[str]] = {}
     errors: list[str] = []
     for m in HEADER_RE.finditer(text):
+        if m.group(2) in parsed:
+            errors.append(
+                f"{HEADER_DECL}: `{m.group(2)}()` is declared more than once with a `Returns {{...}}` "
+                f"clause -- the copies can disagree and only one is compared, so keep exactly one"
+            )
+            continue
         returns = RETURNS_RE.search(m.group(1))
         if returns is None:
             errors.append(
@@ -125,10 +137,25 @@ def parse_header(root: Path, known: set[str]) -> tuple[dict[str, list[str]], lis
 
 
 def parse_doc(root: Path, rel: str, known: set[str]) -> tuple[dict[str, list[str]], list[str]]:
-    """Return (getter -> properties named by its summary row, errors) from one verifier doc."""
+    """Return (getter -> properties named by its summary row, errors) from one verifier doc.
+
+    Rows are collected without reference to `known` so that a row surviving a getter's deletion is
+    still returned, and so reaches the caller's "documented but has no initializer" check. Only the
+    malformed-row sweep is scoped to `known`, because its pattern alone cannot tell a property-set
+    row from the several unrelated API tables these docs key on a `method()` cell.
+    """
     text = read(root, rel)
-    parsed = {m.group(1): split_names(m.group(2)) for m in DOC_ROW_RE.finditer(text) if m.group(1) in known}
-    errors = [
+    parsed: dict[str, list[str]] = {}
+    errors: list[str] = []
+    for m in DOC_ROW_RE.finditer(text):
+        if m.group(1) in parsed:
+            errors.append(
+                f"{rel}: `{m.group(1)}()` has more than one summary row -- the rows can disagree and "
+                f"only one is compared, so keep exactly one"
+            )
+            continue
+        parsed[m.group(1)] = split_names(m.group(2))
+    errors += [
         f"{rel}: the row for `{m.group(1)}()` does not spell its members as a `` `{{A, B, C}}` `` cell, "
         f"so it goes unpoliced"
         for m in DOC_ROW_ANY_RE.finditer(text)


### PR DESCRIPTION
## What

`GetVerifiedProperties()` returns **18** properties, but its `Returns {...}` doc comment and the summary rows in both verifier docs each named **17** — all three omitted `DistTensorCtxMaterialized`.

Auditing the neighbours turned up the same drift in both sibling getters, so all three are corrected against their initializers, in initializer order:

| Getter | Returns | Doc comment named | Missing |
| ------ | ------- | ----------------- | ------- |
| `GetVerifiedProperties` | 18 | 17 | `DistTensorCtxMaterialized` |
| `GetStructuralProperties` | 11 | 10 | `AtomicAddDtypeValid` |
| `GetDefaultVerifyProperties` | 10 | 8 | `TileTypeCoherence`, `ArrayNotEscaped` |

The `99-verifier.md` rows for the latter two were already correct; only the `GetVerifiedProperties()` row needed fixing (it also had `TileMemoryInferred` out of order).

## Why

These lists are consulted precisely when someone needs to know what `PassPipeline` auto-verifies — e.g. deciding whether a new pass must preserve a property — which is when being wrong by one costs the most. The omitted entry was the distributed-only property: the least likely of the 18 to appear in a reader's own test, and so the least likely to be noticed.

The root cause is structural. Each set is spelled out four times — the C++ initializer plus three prose copies (the doc comment, and a row in each language's verifier doc) — with nothing linking them. A property added to an initializer alone compiles and passes CI while every list a developer actually reads stays short by one.

## The lint

`tests/lint/check_property_set_doc_parity.py` closes that gap, treating the initializers in `ir_property.cpp` as authoritative and holding the three copies to them on **membership**, **order** (so a copy stays diffable against the C++ by position), and **completeness** (a newly added set cannot start out undocumented).

It mirrors the existing `check_ir_property_parity.py`, including its rule that a site written in a form the regexes do not match is *reported* rather than silently skipped — the one failure mode a lint like this must not have. Its catch-all checks are scoped to the getters the C++ actually defines, so the docs' many other `` `method()` ``-keyed API tables do not trip it.

Registered as a pre-commit hook and documented in both `00-pass_manager.md` files.

## Verification

- Runtime set equals the documented list exactly: 18 members, empty symmetric difference.
- Four mutation tests against a scratch tree, all caught:
  - reintroducing the original omission → flags all three sites (`17 named, 18 returned`)
  - adding a property to the C++ initializer alone → flags all three sites
  - a reordered doc row → reports position-level drift
  - a misspelled name (`SSAFrom`) → rejected as not an enumerator
- Worktree build clean; `tests/ut/ir/verifier` + `tests/ut/pass` 81 passed.
- All 22 pre-commit hooks pass, including `clang-format`, `cpplint`, `markdownlint-cli2`, `ruff`, and `pyright`.

## Reviewer notes

- **No functional change.** C++ edits are comment-only; the only recompile is `passes.cpp` picking up the header.
- `DistTensorCtxMaterialized` still has no row in the **Built-in Rules** table in `99-verifier.md`, deliberately: that table is selective (25 of ~40 registered verifiers), so adding just this one would be arbitrary. The property is documented in `43-materialize_dist_tensor_ctx.md` and `00-pass_manager.md`.
