### PR TITLE
fix(language): resolve a @pl.program class by its own definition, not by name

### DIFF
--- a/docs/en/dev/language/03-functions.md
+++ b/docs/en/dev/language/03-functions.md
@@ -155,6 +155,49 @@ disabled.insert(passes.DiagnosticCheck.OutParamWriteDropped)
 ir.compile(program, disabled_diagnostics=disabled)
 ```
 
+## How a `@pl.program` Class Is Located
+
+`@pl.program` parses the class *body from source*, so it first has to find the
+`class` statement that produced the decorated object. The class name alone does
+not identify it: one function may define the same name in several branches, and
+every one of them carries the same `__qualname__`.
+
+The decorator resolves this from the line numbers of the methods in the class
+body, so each branch is parsed from its own source:
+
+```python
+def make(case):
+    if case == "add":
+        @pl.program
+        class Prog:                                # parsed from *this* body
+            @pl.function
+            def main(self, x: pl.Tensor[[8], pl.FP32]) -> pl.Tensor[[8], pl.FP32]:
+                return pl.add(x, 1.0)
+        return Prog
+
+    @pl.program
+    class Prog:                                    # and this one from *this* body
+        @pl.function
+        def main(self, x: pl.Tensor[[8], pl.FP32]) -> pl.Tensor[[8], pl.FP32]:
+            return pl.mul(x, 3.0)
+    return Prog
+```
+
+When the definitions genuinely cannot be told apart, the decorator raises a
+`ParserSyntaxError` naming every candidate line rather than picking one — a
+wrong pick would compile a body you never wrote. Give the classes distinct
+names, or define the class once and vary it through a closure variable:
+
+```python
+def make(scale):
+    @pl.program
+    class Prog:                                    # one definition, parameterised
+        @pl.function
+        def main(self, x: pl.Tensor[[8], pl.FP32]) -> pl.Tensor[[8], pl.FP32]:
+            return pl.mul(x, scale)
+    return Prog
+```
+
 ## Cross-Module Function Reuse
 
 Functions defined outside a `@pl.program` class can be reused via two mechanisms.

--- a/docs/zh/dev/language/03-functions.md
+++ b/docs/zh/dev/language/03-functions.md
@@ -144,6 +144,46 @@ disabled.insert(passes.DiagnosticCheck.OutParamWriteDropped)
 ir.compile(program, disabled_diagnostics=disabled)
 ```
 
+## `@pl.program` 如何定位类定义
+
+`@pl.program` 是*从源码解析*类体的，因此它必须先找到生成被装饰对象的那条 `class`
+语句。仅凭类名无法确定这一点: 同一个函数可以在多个分支里定义同名类，它们的
+`__qualname__` 完全相同。
+
+装饰器通过类体中各方法的行号来消歧，因此每个分支都按自己的源码解析:
+
+```python
+def make(case):
+    if case == "add":
+        @pl.program
+        class Prog:                                # 解析*这个*类体
+            @pl.function
+            def main(self, x: pl.Tensor[[8], pl.FP32]) -> pl.Tensor[[8], pl.FP32]:
+                return pl.add(x, 1.0)
+        return Prog
+
+    @pl.program
+    class Prog:                                    # 这个则解析*这个*类体
+        @pl.function
+        def main(self, x: pl.Tensor[[8], pl.FP32]) -> pl.Tensor[[8], pl.FP32]:
+            return pl.mul(x, 3.0)
+    return Prog
+```
+
+当多个定义确实无法区分时，装饰器会抛出 `ParserSyntaxError` 并列出全部候选行号，
+而不是任选其一——选错就会编译出你从未写过的类体。此时请给各个类取不同的名字，
+或者只定义一次、用闭包变量参数化:
+
+```python
+def make(scale):
+    @pl.program
+    class Prog:                                    # 单一定义，参数化
+        @pl.function
+        def main(self, x: pl.Tensor[[8], pl.FP32]) -> pl.Tensor[[8], pl.FP32]:
+            return pl.mul(x, scale)
+    return Prog
+```
+
 ## 跨模块函数复用
 
 在 `@pl.program` 类之外定义的函数可通过两种机制复用。

--- a/python/pypto/language/parser/decorator.py
+++ b/python/pypto/language/parser/decorator.py
@@ -28,7 +28,7 @@ from .ast_parser import ASTParser
 from .comment_extractor import extract_line_comments
 from .diagnostics import BUG_CLASS_EXCEPTIONS, ParserError, ParserSyntaxError, concise_error_message
 from .enum_utils import FUNCTION_TYPE_MAP, LEVEL_MAP, ROLE_MAP, SPLIT_MODE_MAP, extract_enum_value
-from .source_lookup import get_class_source_lines
+from .source_lookup import DuplicateClassDefinitionError, get_class_source_lines
 
 
 def _is_pl_func_attr_stmt(stmt: ast.stmt) -> bool:
@@ -815,6 +815,17 @@ def _get_source_info(entity: Callable | type, entity_type: str) -> tuple[str, li
         else:
             source_lines_raw, starting_line = inspect.getsourcelines(entity)
         return source_file, source_lines_raw, starting_line
+    except DuplicateClassDefinitionError as exc:
+        # Falling through to the line-number-blind fallbacks would resolve the
+        # ambiguity by picking the first definition — which is the silent
+        # mis-parse this error exists to report. Surface it instead.
+        raise ParserSyntaxError(
+            f"Cannot tell which definition of {entity_type} '{name}' to parse: {exc}",
+            hint=(
+                "Give each definition a distinct name, or define the "
+                f"{entity_type} once and read the differing values from closure variables."
+            ),
+        ) from exc
     except (OSError, TypeError):
         pass
 

--- a/python/pypto/language/parser/source_lookup.py
+++ b/python/pypto/language/parser/source_lookup.py
@@ -22,32 +22,86 @@ the result stays identical to ``inspect.getsourcelines``. Anything the index
 cannot resolve returns ``None`` so callers fall back to ``inspect``, which
 remains the source of truth.
 
+**Duplicate qualnames.** A qualname is not unique: two branches of one function
+may each define ``class Prog``, and both carry the qualname
+``make.<locals>.Prog``. ``inspect.findsource`` resolves that by source order —
+it returns the *first* definition for every one of them, so a decorator built on
+it silently parses the wrong body. This module instead locates the definition
+that actually produced ``cls`` from the line numbers of the code objects in the
+class body (``vars(cls)``), and raises `DuplicateClassDefinitionError` when
+nothing in the class object can distinguish the candidates. Guessing is never a
+valid answer here: the caller would compile a body the user never wrote.
+
 On CPython 3.13+ the index is bypassed entirely. There every class carries its
 own ``__firstlineno__``, so ``inspect`` already resolves the line without
-parsing — and, unlike a qualname-keyed index, it tells apart two classes that
-share a ``__qualname__``. Deferring keeps that disambiguation exact instead of
-approximating it.
+parsing — and it tells duplicate qualnames apart, which a qualname-keyed
+index cannot.
 """
 
 import ast
+import dataclasses
 import inspect
 import linecache
+import types
+from collections.abc import Iterator
+from typing import Any
 
-__all__ = ["get_class_source_lines"]
+__all__ = ["DuplicateClassDefinitionError", "get_class_source_lines"]
+
+
+class DuplicateClassDefinitionError(RuntimeError):
+    """Raised when a class's source definition cannot be identified unambiguously.
+
+    Carries the candidate definition lines so callers can render an actionable
+    diagnostic instead of compiling an arbitrary one of them.
+    """
+
+    def __init__(self, cls: type, source_file: str, first_lines: list[int]) -> None:
+        self.qualname: str = getattr(cls, "__qualname__", None) or getattr(cls, "__name__", "<unknown>")
+        self.source_file = source_file
+        self.first_lines = first_lines
+        locations = ", ".join(str(line) for line in first_lines)
+        super().__init__(
+            f"'{self.qualname}' is defined {len(first_lines)} times in {source_file} "
+            f"(lines {locations}), and nothing on the class object identifies which "
+            "definition built it"
+        )
+
+
+@dataclasses.dataclass(frozen=True)
+class _ClassSite:
+    """One ``class X: ...`` definition, as located in a file's AST.
+
+    Attributes:
+        first_line: 1-based line ``inspect.getsourcelines`` would start the block
+            at — the first decorator's line when decorated, else the ``class`` line
+        header_line: 1-based line of the ``class`` keyword itself
+        end_line: 1-based last line of the class body
+    """
+
+    first_line: int
+    header_line: int
+    end_line: int
+
+    def contains(self, line: int) -> bool:
+        """True when ``line`` falls inside this class's body."""
+        return self.header_line <= line <= self.end_line
 
 
 class _ClassLineIndexer(ast.NodeVisitor):
-    """Index ``qualname -> 1-based first source line`` for every class in a module AST.
+    """Index ``qualname -> [class site]`` for every class in a module AST.
 
     Mirrors CPython's ``inspect._ClassFinder`` bookkeeping so lookups agree with
     ``inspect.findsource``: the ``<locals>`` marker for classes nested in
-    functions, the decorator line taking precedence over the ``class`` line, and
-    "first match in source order wins" when a qualname is defined more than once.
+    functions, and the decorator line taking precedence over the ``class`` line.
+    Unlike ``_ClassFinder`` it keeps *every* definition of a repeated qualname,
+    in source order, so the caller can pick the right one rather than assume the
+    first.
     """
 
     def __init__(self) -> None:
         self._stack: list[str] = []
-        self.index: dict[str, int] = {}
+        self.index: dict[str, list[_ClassSite]] = {}
 
     def visit_FunctionDef(self, node: ast.FunctionDef | ast.AsyncFunctionDef) -> None:
         self._stack.append(node.name)
@@ -61,20 +115,20 @@ class _ClassLineIndexer(ast.NodeVisitor):
     def visit_ClassDef(self, node: ast.ClassDef) -> None:
         self._stack.append(node.name)
         first_line = node.decorator_list[0].lineno if node.decorator_list else node.lineno
-        # setdefault: generic_visit walks in source order, and CPython stops at
-        # the first qualname match, so an earlier definition must win.
-        self.index.setdefault(".".join(self._stack), first_line)
+        site = _ClassSite(first_line, node.lineno, node.end_lineno or node.lineno)
+        # generic_visit walks in source order, so appending keeps the sites sorted.
+        self.index.setdefault(".".join(self._stack), []).append(site)
         self.generic_visit(node)
         self._stack.pop()
 
 
 # Per-file class-line index, keyed by source filename. Each value keeps the exact
 # ``lines`` list the index was built from, so staleness is an identity check.
-_CLASS_LINE_INDEX_CACHE: dict[str, tuple[list[str], dict[str, int]]] = {}
+_CLASS_LINE_INDEX_CACHE: dict[str, tuple[list[str], dict[str, list[_ClassSite]]]] = {}
 
 
-def _class_line_index(source_file: str, lines: list[str]) -> dict[str, int]:
-    """Return the ``qualname -> first line`` index for ``source_file``, parsing once.
+def _class_line_index(source_file: str, lines: list[str]) -> dict[str, list[_ClassSite]]:
+    """Return the ``qualname -> class sites`` index for ``source_file``, parsing once.
 
     ``linecache`` hands back the *same* list object for a given cache entry and
     builds a fresh one whenever the file is re-read (or a synthetic entry is
@@ -86,7 +140,7 @@ def _class_line_index(source_file: str, lines: list[str]) -> dict[str, int]:
         lines: Full source lines of the file, as returned by linecache
 
     Returns:
-        Mapping from class qualname to its 1-based first source line
+        Mapping from class qualname to every definition of it, in source order
 
     Raises:
         SyntaxError: If the file does not parse
@@ -114,6 +168,69 @@ def _records_own_first_line(cls: type) -> bool:
         return False
 
 
+def _code_objects(value: Any) -> Iterator[types.CodeType]:
+    """Yield the code objects a class-body entry directly holds.
+
+    Covers plain functions plus the descriptors a class body commonly wraps them
+    in — ``staticmethod`` / ``classmethod`` and ``property``. Anything else
+    (constants, nested classes, arbitrary objects) yields nothing and simply
+    contributes no evidence.
+    """
+    if isinstance(value, (staticmethod, classmethod)):
+        holders: tuple[Any, ...] = (value.__func__,)
+    elif isinstance(value, property):
+        holders = (value.fget, value.fset, value.fdel)
+    else:
+        holders = (value,)
+
+    for holder in holders:
+        code = getattr(holder, "__code__", None)
+        if isinstance(code, types.CodeType):
+            yield code
+
+
+def _member_definition_lines(cls: type) -> set[int]:
+    """Return the source lines of every code object defined in ``cls``'s body.
+
+    Each line is where CPython recorded the member's definition — the first
+    decorator line for a decorated ``def``, the ``def`` line otherwise. Both fall
+    strictly inside the owning ``class`` block, which is what makes them usable
+    as evidence of *which* same-named class body ran. Members assigned from
+    elsewhere (``m = some_module_level_func``) land outside every candidate and
+    are simply not evidence.
+    """
+    try:
+        namespace = vars(cls)
+    except TypeError:
+        return set()
+    return {code.co_firstlineno for value in namespace.values() for code in _code_objects(value)}
+
+
+def _resolve_class_site(cls: type, source_file: str, sites: list[_ClassSite]) -> _ClassSite:
+    """Pick the definition among ``sites`` that produced ``cls``.
+
+    Args:
+        cls: Class being located
+        source_file: File the sites were indexed from, for the error message
+        sites: Every definition of ``cls``'s qualname, in source order
+
+    Returns:
+        The single matching site
+
+    Raises:
+        DuplicateClassDefinitionError: If the qualname is defined more than once
+            and the class body's code objects do not single out one definition
+    """
+    if len(sites) == 1:
+        return sites[0]
+
+    member_lines = _member_definition_lines(cls)
+    matched = [site for site in sites if any(site.contains(line) for line in member_lines)]
+    if len(matched) == 1:
+        return matched[0]
+    raise DuplicateClassDefinitionError(cls, source_file, [site.first_line for site in sites])
+
+
 def _indexed_class_source_lines(cls: type) -> tuple[list[str], int] | None:
     """Resolve ``cls``'s source from the per-file index, or None to defer.
 
@@ -125,12 +242,15 @@ def _indexed_class_source_lines(cls: type) -> tuple[list[str], int] | None:
         ``inspect.getsourcelines``, or None when the caller must fall back to
         ``inspect`` — either because the class is not in the index, or because
         the runtime already resolves it correctly and without parsing
+
+    Raises:
+        DuplicateClassDefinitionError: If the file defines ``cls``'s qualname
+            more than once and the right definition cannot be identified
     """
-    # A class carrying its own line number needs no index, and a qualname-keyed
-    # index would be *wrong* for it: two classes sharing a __qualname__ resolve
-    # to distinct lines that only __firstlineno__ can tell apart. Let inspect do
-    # it; the index exists solely for runtimes that would otherwise parse the
-    # whole file once per class.
+    # A class carrying its own line number needs no index, and it already
+    # resolves duplicate qualnames exactly. Let inspect do it; the index exists
+    # solely for runtimes that would otherwise parse the whole file once per
+    # class and then mis-resolve those duplicates.
     if _records_own_first_line(cls):
         return None
 
@@ -150,13 +270,21 @@ def _indexed_class_source_lines(cls: type) -> tuple[list[str], int] | None:
         if not lines:
             return None
 
-        starting_line = _class_line_index(source_file, lines).get(qualname)
-        if starting_line is None:
+        sites = _class_line_index(source_file, lines).get(qualname)
+        if not sites:
             return None
-        return inspect.getblock(lines[starting_line - 1 :]), starting_line
     except (OSError, TypeError, ValueError, SyntaxError, AttributeError):
         # Any surprise (unparseable file, no getblock, exotic loader) falls back
         # to inspect, which stays the source of truth for this lookup.
+        return None
+
+    # Outside the try: an unresolvable duplicate is a real diagnostic, not a
+    # reason to fall back to inspect — which would answer with the first
+    # definition and hide the ambiguity again.
+    starting_line = _resolve_class_site(cls, source_file, sites).first_line
+    try:
+        return inspect.getblock(lines[starting_line - 1 :]), starting_line
+    except (OSError, TypeError, ValueError, SyntaxError, AttributeError):
         return None
 
 
@@ -168,9 +296,13 @@ def get_class_source_lines(cls: type) -> tuple[list[str], int]:
 
     Returns:
         Tuple of (source_lines, starting_line_1based), identical to what
-        ``inspect.getsourcelines(cls)`` returns
+        ``inspect.getsourcelines(cls)`` returns — except that a repeated
+        qualname resolves to the definition that actually built ``cls`` rather
+        than to the first one in the file
 
     Raises:
+        DuplicateClassDefinitionError: If the file defines ``cls``'s qualname
+            more than once and the right definition cannot be identified
         OSError: If the source is unavailable, as ``inspect`` raises
         TypeError: If ``cls`` is a built-in or otherwise has no source
     """

--- a/python/pypto/language/parser/source_lookup.py
+++ b/python/pypto/language/parser/source_lookup.py
@@ -27,8 +27,8 @@ may each define ``class Prog``, and both carry the qualname
 ``make.<locals>.Prog``. ``inspect.findsource`` resolves that by source order —
 it returns the *first* definition for every one of them, so a decorator built on
 it silently parses the wrong body. This module instead locates the definition
-that actually produced ``cls`` from the line numbers of the code objects in the
-class body (``vars(cls)``), and raises `DuplicateClassDefinitionError` when
+that actually produced ``cls`` from the line numbers of the code objects its
+body defines in this same file, and raises `DuplicateClassDefinitionError` when
 nothing in the class object can distinguish the candidates. Guessing is never a
 valid answer here: the caller would compile a body the user never wrote.
 
@@ -42,6 +42,7 @@ import ast
 import dataclasses
 import inspect
 import linecache
+import os
 import types
 from collections.abc import Iterator
 from typing import Any
@@ -189,21 +190,57 @@ def _code_objects(value: Any) -> Iterator[types.CodeType]:
             yield code
 
 
-def _member_definition_lines(cls: type) -> set[int]:
-    """Return the source lines of every code object defined in ``cls``'s body.
+def _identifies_source_file(candidate: str, source_file: str) -> bool:
+    """True when ``candidate`` names the same file as ``source_file``.
+
+    Compares the strings first, which is the normal case — a module's methods
+    record the very filename ``inspect.getsourcefile`` reports for its classes —
+    and falls back to an inode comparison so a symlinked or differently-spelled
+    path still counts. A name no file backs, such as an ``exec`` pseudo-filename,
+    identifies nothing.
+    """
+    if candidate == source_file:
+        return True
+    try:
+        return os.path.samefile(candidate, source_file)
+    except (OSError, ValueError):
+        return False
+
+
+def _member_definition_lines(cls: type, source_file: str) -> set[int]:
+    """Return the ``source_file`` lines of the code objects defined in ``cls``'s body.
 
     Each line is where CPython recorded the member's definition — the first
     decorator line for a decorated ``def``, the ``def`` line otherwise. Both fall
     strictly inside the owning ``class`` block, which is what makes them usable
-    as evidence of *which* same-named class body ran. Members assigned from
-    elsewhere (``m = some_module_level_func``) land outside every candidate and
-    are simply not evidence.
+    as evidence of *which* same-named class body ran.
+
+    A line number only means something in the file it was recorded against, so a
+    member whose code object comes from *another* file is dropped rather than
+    measured against this one. A class body may hold such a member as an ordinary
+    attribute (``helper = some_imported_function``), and its unrelated line can
+    otherwise land inside a sibling candidate's block and manufacture an
+    ambiguity that does not exist. Members assigned from elsewhere in this same
+    file need no special case: they land outside every candidate and are simply
+    not evidence.
     """
     try:
         namespace = vars(cls)
     except TypeError:
         return set()
-    return {code.co_firstlineno for value in namespace.values() for code in _code_objects(value)}
+
+    lines: set[int] = set()
+    # Filenames repeat across a class body; resolving each one once keeps the
+    # inode fallback off the per-member path.
+    is_this_file: dict[str, bool] = {}
+    for value in namespace.values():
+        for code in _code_objects(value):
+            filename = code.co_filename
+            if filename not in is_this_file:
+                is_this_file[filename] = _identifies_source_file(filename, source_file)
+            if is_this_file[filename]:
+                lines.add(code.co_firstlineno)
+    return lines
 
 
 def _resolve_class_site(cls: type, source_file: str, sites: list[_ClassSite]) -> _ClassSite:
@@ -211,7 +248,8 @@ def _resolve_class_site(cls: type, source_file: str, sites: list[_ClassSite]) ->
 
     Args:
         cls: Class being located
-        source_file: File the sites were indexed from, for the error message
+        source_file: File the sites were indexed from; also scopes which member
+            code objects count as line evidence
         sites: Every definition of ``cls``'s qualname, in source order
 
     Returns:
@@ -224,7 +262,7 @@ def _resolve_class_site(cls: type, source_file: str, sites: list[_ClassSite]) ->
     if len(sites) == 1:
         return sites[0]
 
-    member_lines = _member_definition_lines(cls)
+    member_lines = _member_definition_lines(cls, source_file)
     matched = [site for site in sites if any(site.contains(line) for line in member_lines)]
     if len(matched) == 1:
         return matched[0]

--- a/tests/ut/codegen/test_phase_fence_dep_compression.py
+++ b/tests/ut/codegen/test_phase_fence_dep_compression.py
@@ -835,7 +835,7 @@ class TestPhaseFenceDepCompressionCodegen:
             if case_name == "scalar":
 
                 @pl.program
-                class Prog:
+                class ProgScalar:
                     @pl.function(type=pl.FunctionType.InCore)
                     def kern(
                         self,
@@ -860,12 +860,12 @@ class TestPhaseFenceDepCompressionCodegen:
                             out, _ = pl.submit(self.kern, x, out, tile_r, 0, deps=[tid])
                         return out
 
-                return Prog
+                return ProgScalar
 
             if case_name == "mixed_array_scalar":
 
                 @pl.program
-                class Prog:
+                class ProgMixedArrayScalar:
                     @pl.function(type=pl.FunctionType.InCore)
                     def kern(
                         self,
@@ -894,12 +894,12 @@ class TestPhaseFenceDepCompressionCodegen:
                                 tids[branch] = tid
                         return out
 
-                return Prog
+                return ProgMixedArrayScalar
 
             if case_name == "two_arrays_same_call":
 
                 @pl.program
-                class Prog:
+                class ProgTwoArraysSameCall:
                     @pl.function(type=pl.FunctionType.InCore)
                     def kern(
                         self,
@@ -929,10 +929,10 @@ class TestPhaseFenceDepCompressionCodegen:
                                 tids_b[branch] = tid
                         return out
 
-                return Prog
+                return ProgTwoArraysSameCall
 
             @pl.program
-            class Prog:
+            class ProgAutoScope:
                 @pl.function(type=pl.FunctionType.InCore)
                 def kern(
                     self,
@@ -959,7 +959,7 @@ class TestPhaseFenceDepCompressionCodegen:
                         tids[branch] = tid
                     return out
 
-            return Prog
+            return ProgAutoScope
 
         code = _compile_program(make_program(case_name))
         assert "rt_submit_dummy_task" not in code, code

--- a/tests/ut/ir/parser/test_alloc_window_buffer.py
+++ b/tests/ut/ir/parser/test_alloc_window_buffer.py
@@ -323,7 +323,7 @@ def test_alloc_window_buffer_rejects_non_positive_static_dim():
     with pytest.raises(ParserSyntaxError, match="all dimensions must be positive"):
 
         @pl.program
-        class P:  # noqa: F841
+        class PZeroDim:  # noqa: F841
             @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
             def host_orch(self):
                 buf = pld.alloc_window_buffer([0, 128], dtype=pl.FP32)  # noqa: F841
@@ -332,7 +332,7 @@ def test_alloc_window_buffer_rejects_non_positive_static_dim():
     with pytest.raises(ParserSyntaxError, match="all dimensions must be positive"):
 
         @pl.program
-        class P:  # noqa: F841
+        class PNegativeDim:  # noqa: F841
             @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
             def host_orch(self):
                 buf = pld.alloc_window_buffer([64, -1], dtype=pl.FP32)  # noqa: F841

--- a/tests/ut/ir/transforms/test_canonicalize_tile_slice.py
+++ b/tests/ut/ir/transforms/test_canonicalize_tile_slice.py
@@ -1529,7 +1529,7 @@ class TestAccAccumulatorSliceContiguity:
         if valid_shape is None:
 
             @pl.program
-            class Prog:
+            class ProgPlainSlice:
                 @pl.function(type=pl.FunctionType.InCore)
                 def kernel(
                     self,
@@ -1555,10 +1555,12 @@ class TestAccAccumulatorSliceContiguity:
                     out = pl.tile.store(acc_new, [0, 0], out)
                     return out
 
+            return ProgPlainSlice
+
         else:
 
             @pl.program
-            class Prog:
+            class ProgValidShapeSlice:
                 @pl.function(type=pl.FunctionType.InCore)
                 def kernel(
                     self,
@@ -1584,7 +1586,7 @@ class TestAccAccumulatorSliceContiguity:
                     out = pl.tile.store(acc_new, [0, 0], out)
                     return out
 
-        return Prog
+            return ProgValidShapeSlice
 
     def test_row_window_of_multi_block_column_acc_rejected(self):
         """A [16, 32] row window of a [32, 32] Acc tile spans neither the full

--- a/tests/ut/ir/transforms/test_flatten_tile_nd_to_2d.py
+++ b/tests/ut/ir/transforms/test_flatten_tile_nd_to_2d.py
@@ -1385,7 +1385,7 @@ class TestFlattenTileNdTo2DControlFlow:
         if loop_kind == "for":
 
             @pl.program
-            class Before:
+            class BeforeForLoop:
                 @pl.function(type=pl.FunctionType.InCore)
                 def main_incore_0(
                     self,
@@ -1404,10 +1404,12 @@ class TestFlattenTileNdTo2DControlFlow:
                     y = self.main_incore_0(x, out_0)
                     return y
 
+            Before = BeforeForLoop
+
         else:
 
             @pl.program
-            class Before:
+            class BeforeWhileLoop:
                 @pl.function(type=pl.FunctionType.InCore)
                 def main_incore_0(
                     self,
@@ -1427,6 +1429,8 @@ class TestFlattenTileNdTo2DControlFlow:
                     out_0 = pl.create_tensor([2, 3, 4], dtype=pl.FP32)
                     y = self.main_incore_0(x, out_0)
                     return y
+
+            Before = BeforeWhileLoop
 
         Before = passes.convert_to_ssa()(Before)
         After = passes.flatten_tile_nd_to_2d()(Before)

--- a/tests/ut/language/parser/test_decorator.py
+++ b/tests/ut/language/parser/test_decorator.py
@@ -2500,6 +2500,30 @@ class TestClassSourceLookup:
             assert f'WHICH = "{cls.WHICH}"' in block, f"resolved the wrong body for WHICH={cls.WHICH}"
             assert cls.which.__code__.co_firstlineno > start, "method must sit inside the resolved block"
 
+    def test_a_member_from_another_file_is_not_line_evidence(self):
+        """A class attribute defined in a *different* file contributes no line.
+
+        Its `co_firstlineno` is numbered against its own file, so measuring it
+        against this one can land inside a sibling candidate's block and
+        manufacture an ambiguity that does not exist. A class body holding
+        `helper = some_imported_function` is exactly that shape.
+        """
+        first, second = _make_shadowed_classes()
+        _, first_start = source_lookup.get_class_source_lines(first)
+
+        # A callable from another file whose line falls inside the FIRST block.
+        decoy_line = first_start + 1
+        decoy_source = "\n" * (decoy_line - 1) + "def decoy(): pass\n"
+        namespace = {}
+        exec(compile(decoy_source, "<not-this-file>", "exec"), namespace)  # noqa: S102
+        setattr(second, "decoy", namespace["decoy"])
+        assert getattr(second, "decoy").__code__.co_firstlineno == decoy_line
+
+        lines, start = source_lookup.get_class_source_lines(second)
+
+        assert 'WHICH = "second"' in "".join(lines), "an unrelated file's line steered the lookup"
+        assert start != first_start
+
     def test_indistinguishable_shadowed_qualname_is_reported_not_guessed(self):
         """With no evidence to pick a definition, the lookup refuses to guess.
 

--- a/tests/ut/language/parser/test_decorator.py
+++ b/tests/ut/language/parser/test_decorator.py
@@ -2387,31 +2387,62 @@ def _make_local_class() -> type:
 
 
 def _make_shadowed_classes() -> tuple[type, type]:
-    """Return two classes sharing one qualname, in definition order."""
+    """Return two classes sharing one qualname, in definition order.
+
+    Each body defines a method, so the code objects in `vars(cls)` point back at
+    the definition that built it -- the evidence the lookup resolves a repeated
+    qualname with.
+    """
 
     class Shadowed:
         WHICH = "first"
+
+        def which(self) -> str:
+            return self.WHICH
 
     first = Shadowed
 
     class Shadowed:  # noqa: F811 - deliberate duplicate qualname
         WHICH = "second"
 
+        def which(self) -> str:
+            return self.WHICH
+
     return first, Shadowed
 
 
-def _lookup_classes() -> list[type]:
-    """Every class shape the lookup must handle, including a shadowed qualname."""
-    first_shadowed, second_shadowed = _make_shadowed_classes()
+def _make_opaque_shadowed_classes() -> tuple[type, type]:
+    """Return two classes sharing one qualname whose bodies hold no code objects.
+
+    Neither class object carries anything that points back at its own
+    definition, so a runtime without `__firstlineno__` cannot tell them apart.
+    """
+
+    class Opaque:
+        WHICH = "first"
+
+    first = Opaque
+
+    class Opaque:  # noqa: F811 - deliberate duplicate qualname
+        WHICH = "second"
+
+    return first, Opaque
+
+
+def _unique_qualname_classes() -> list[type]:
+    """Class shapes whose qualname is defined exactly once in this file."""
     return [
         _LookupPlain,
         _LookupPlain.Nested,
         _LookupDecorated,
         _make_local_class(),
-        first_shadowed,
-        second_shadowed,
         TestClassSourceLookup,
     ]
+
+
+def _lookup_classes() -> list[type]:
+    """Every class shape the lookup must handle, including a shadowed qualname."""
+    return [*_unique_qualname_classes(), *_make_shadowed_classes()]
 
 
 # Whether this runtime actually consults the qualname index. CPython 3.13+ stamps
@@ -2441,8 +2472,12 @@ class TestClassSourceLookup:
 
         Asserted end to end through `_get_source_info` so it holds on runtimes
         that use the index and on those that defer to `inspect`.
+
+        Shadowed qualnames are the one place the two may legitimately disagree
+        (`inspect` answers with the first definition on runtimes without
+        `__firstlineno__`), so they get their own test below.
         """
-        for cls in _lookup_classes():
+        for cls in _unique_qualname_classes():
             expected_lines, expected_start = inspect.getsourcelines(cls)
             actual_lines, actual_start = source_lookup.get_class_source_lines(cls)
 
@@ -2450,6 +2485,65 @@ class TestClassSourceLookup:
                 f"{cls.__qualname__}: start line {actual_start} != inspect's {expected_start}"
             )
             assert actual_lines == expected_lines, f"{cls.__qualname__}: source block differs from inspect's"
+
+    def test_shadowed_qualname_resolves_to_the_class_that_was_built(self):
+        """Two same-qualname classes each resolve to their *own* body.
+
+        `inspect.findsource` matches on qualname alone and so answers with the
+        first definition for both -- the collapse that made every later
+        `@pl.program` of a repeated name compile the first one's kernel.
+        """
+        for cls in _make_shadowed_classes():
+            lines, start = source_lookup.get_class_source_lines(cls)
+            block = "".join(lines)
+
+            assert f'WHICH = "{cls.WHICH}"' in block, f"resolved the wrong body for WHICH={cls.WHICH}"
+            assert cls.which.__code__.co_firstlineno > start, "method must sit inside the resolved block"
+
+    def test_indistinguishable_shadowed_qualname_is_reported_not_guessed(self):
+        """With no evidence to pick a definition, the lookup refuses to guess.
+
+        Guessing here is what the old behaviour did, and it is unrecoverable
+        downstream: the caller compiles a body the user never wrote, with no
+        warning. Runtimes that stamp `__firstlineno__` resolve it exactly and so
+        never reach this path.
+        """
+        for cls in _make_opaque_shadowed_classes():
+            if source_lookup._records_own_first_line(cls):
+                lines, _ = source_lookup.get_class_source_lines(cls)
+                assert f'WHICH = "{cls.WHICH}"' in "".join(lines)
+                continue
+
+            with pytest.raises(source_lookup.DuplicateClassDefinitionError) as excinfo:
+                source_lookup.get_class_source_lines(cls)
+
+            assert len(excinfo.value.first_lines) == 2
+            assert "Opaque" in excinfo.value.qualname
+
+    def test_duplicate_program_class_names_parse_their_own_bodies(self):
+        """End to end: two `@pl.program class Prog` in one function stay distinct."""
+
+        def make(case: str) -> ir.Program:
+            if case == "add":
+
+                @pl.program
+                class Prog:
+                    @pl.function
+                    def main(self, x: pl.Tensor[[8], pl.FP32]) -> pl.Tensor[[8], pl.FP32]:
+                        return pl.add(x, 1.0)
+
+                return Prog
+
+            @pl.program
+            class Prog:
+                @pl.function
+                def main(self, x: pl.Tensor[[8], pl.FP32]) -> pl.Tensor[[8], pl.FP32]:
+                    return pl.mul(x, 3.0)
+
+            return Prog
+
+        assert "tensor.adds" in ir.python_print(make("add"))
+        assert "tensor.muls" in ir.python_print(make("mul"))
 
     def test_defers_to_inspect_when_the_class_records_its_own_line(self):
         """The index is bypassed exactly when the runtime stamps `__firstlineno__`.
@@ -2493,18 +2587,20 @@ class TestClassSourceLookup:
         assert actual_lines == expected_lines
         assert actual_lines[0].lstrip().startswith("@_identity_decorator")
 
-    def test_index_keeps_the_first_of_two_same_qualname_classes(self):
-        """The index's tie-break matches `_ClassFinder`: first definition wins.
+    def test_index_keeps_every_definition_of_a_repeated_qualname(self):
+        """The index records all same-qualname classes, in source order.
 
-        Exercises the index directly, so it documents that behaviour on every
-        runtime -- including those where `get_class_source_lines` defers and the
-        ambiguity is instead resolved by `__firstlineno__`.
+        `_ClassFinder` keeps only the first, which is precisely what makes it
+        unable to resolve the later ones. Exercises the index directly, so it
+        documents the shape on every runtime -- including those where
+        `get_class_source_lines` defers and `__firstlineno__` does the picking.
         """
         source = "class Dup:\n    pass\n\n\nclass Dup:\n    pass\n"
         indexer = source_lookup._ClassLineIndexer()
         indexer.visit(ast.parse(source))
 
-        assert indexer.index["Dup"] == 1
+        assert [site.first_line for site in indexer.index["Dup"]] == [1, 5]
+        assert [site.end_line for site in indexer.index["Dup"]] == [2, 6]
 
     @pytest.mark.skipif(not _INDEX_IN_USE, reason="runtime resolves classes via __firstlineno__")
     def test_file_is_parsed_once_regardless_of_class_count(self, monkeypatch):
@@ -2541,11 +2637,11 @@ class TestClassSourceLookup:
         try:
             before_lines: list[str] = before.splitlines(keepends=True)
             linecache.cache[filename] = (len(before), None, before_lines, filename)
-            assert source_lookup._class_line_index(filename, before_lines)["Alpha"] == 1
+            assert source_lookup._class_line_index(filename, before_lines)["Alpha"][0].first_line == 1
 
             after_lines: list[str] = after.splitlines(keepends=True)
             linecache.cache[filename] = (len(after), None, after_lines, filename)
-            assert source_lookup._class_line_index(filename, after_lines)["Alpha"] == 2
+            assert source_lookup._class_line_index(filename, after_lines)["Alpha"][0].first_line == 2
         finally:
             linecache.cache.pop(filename, None)
             source_lookup._CLASS_LINE_INDEX_CACHE.pop(filename, None)


### PR DESCRIPTION
## Summary

`@pl.program` parses the decorated class from source, so it has to map the class
object back to its `class` statement. Before CPython 3.13 a class carries no line
number, so that lookup searched the file for a `ClassDef` matching `__qualname__`
and stopped at the first hit. A qualname is a lexical name, not an identity: two
branches of one function that each define `class Prog` both compile to
`make.<locals>.Prog`, so every one of them resolved to the **first** definition
and the later bodies were never parsed. Nothing warned, because the decorator
still returned a valid `ir.Program` — built from source the caller never wrote.

Each definition now parses from its own body, and a case that genuinely cannot be
told apart raises instead of guessing. CPython 3.13+ was never affected (it stamps
`__firstlineno__` and already resolved these exactly), and this change leaves that
path untouched.

## Changes

- `python/pypto/language/parser/source_lookup.py`: the per-file index keeps every
  definition of a repeated qualname instead of only the first, and picks the one
  that built the class from the `co_firstlineno` of the code objects in its body —
  a method's definition line falls inside its own `class` block, so the class
  object identifies itself through its members. When no member singles out a
  candidate, it raises the new `DuplicateClassDefinitionError` instead of
  compiling an arbitrary body. Only code objects recorded against that same file
  count as evidence: a class body may hold a callable defined elsewhere as an
  ordinary attribute (`helper = imported_fn`), and its line number means nothing
  here — left unfiltered it can land inside a sibling candidate's block and
  manufacture an ambiguity that does not exist.
- `python/pypto/language/parser/decorator.py`: surfaces that error as a
  `ParserSyntaxError` naming every candidate line, ahead of the line-number-blind
  linecache fallbacks that would otherwise re-select the first definition.
- `tests/ut/codegen/test_phase_fence_dep_compression.py`,
  `tests/ut/ir/transforms/test_canonicalize_tile_slice.py`,
  `tests/ut/ir/transforms/test_flatten_tile_nd_to_2d.py`,
  `tests/ut/ir/parser/test_alloc_window_buffer.py`: four parametrized tests were
  silently degenerate and ran the first variant for every case. Their classes now
  carry distinct names so each variant stands on its own. Every previously
  vacuous case passes with the program it was written for, so the collapse was
  hiding no further defect.
- `tests/ut/language/parser/test_decorator.py`: adds coverage for shadowed
  qualnames resolving to their own bodies, a member from another file not
  steering the lookup, the indistinguishable case raising with both candidate
  lines, the index keeping all sites, and an end-to-end `@pl.program` case.
- `docs/en/dev/language/03-functions.md` and its `docs/zh` mirror: document how a
  `@pl.program` class is located and what to do when two definitions cannot be
  told apart.

## Behaviour change for reviewers

Only one path can newly raise: a duplicate-named class whose body holds **no**
code objects, where the class object retains nothing tying it to a definition.
`@pl.program` cannot reach it — the decorator requires at least one `@pl.function`
method, and that method is the evidence. Three existing tests in
`TestClassSourceLookup` pinned "matches `inspect` exactly", which for a shadowed
qualname is the defect itself; they now assert correct resolution instead, and the
`_ClassFinder` first-wins behaviour is still documented by the index-level test.

An AST sweep over `tests/`, `examples/`, and `python/` found no duplicate-qualname
classes left beyond the deliberate fixtures in `test_decorator.py`.

## Verification

All run at the rebased HEAD `b9d7431`, inside the push transaction:

- `cmake --build build --parallel 20`: exit 0
- `ruff check .`: exit 0 (All checks passed)
- `ruff format --check .`: exit 0 (1099 files already formatted)
- `python tests/lint/check_headers.py`, `check_english_only.py`,
  `check_docs_en_zh_parity.py` (167 paired paths), `check_docs_nav.py`
  (167 nav entries): exit 0
- `python -m pytest` over the five touched test files: exit 0
  (260 passed, 2 xfailed)
- `python -m pytest tests/ut -n 8`: exit 0
  (10356 passed, 3 skipped, 2 xfailed)

Also run outside the transaction:

- `pyright` on the two changed parser modules and the changed test file: exit 0
  (0 errors, 0 warnings)
- Manual repro from the report: the two same-named programs now print
  `pl.tensor.adds(x, 1.0)` and `pl.tensor.muls(x, 3.0)` instead of the first
  body twice.
- The new `test_a_member_from_another_file_is_not_line_evidence` was confirmed
  to fail (with the false `DuplicateClassDefinitionError`) against the parser
  module stashed back to the first commit, and to pass with the fix.

`tests/st/` was not run; the change is Python-only and needs no hardware.