### PR TITLE
docs(performance): document the critical-path and dependency-redundancy analyses

### DIFF
--- a/docs/en/user/performance/00-swimlane.md
+++ b/docs/en/user/performance/00-swimlane.md
@@ -182,6 +182,56 @@ problem from a fake one:
 - An idle core **with ready, undispatched work** is overhead. That is the scheduler not
   keeping up, and belongs to [Runtime overhead](02-runtime-overhead.md).
 
+### Where the makespan actually went
+
+`sched_overhead_analysis` answers one question. The critical-path analysis answers the
+broader one — *what is the dependency-limited floor, and which tasks spent the rest?*
+
+```bash
+python -m simpler_setup.tools.critical_path <run-dir>
+```
+
+It discovers every directory holding `chip_swimlane_records.json`, `deps.json` and
+`name_map*.json` as siblings, and writes one report per rank beside its records file. Point
+it at a whole run tree rather than a single rank.
+
+Two paths come out of it, and the difference between them is the finding:
+
+| Path | What it is |
+| ---- | ---------- |
+| **Static CPM** | the longest duration-weighted chain — the latency floor with unlimited cores |
+| **Observed** | the as-executed backward walk from the last task to finish |
+
+Each task's compute plus the stall in front of it tiles the observed makespan exactly, and
+the stall is attributed as `data-wait` (an upstream producer is late), `core-wait` (the
+assigned core was busy — resource serialization) or `front-gap` (launch delay before any
+task ran).
+
+That gives the verdict the rest of this chapter branches on:
+
+| Reading | Verdict | Where it goes |
+| ------- | ------- | ------------- |
+| Static CPM near the makespan | dependency-bound — more cores cannot help | [03](03-dependencies.md), and granularity in [01](01-task-granularity.md) |
+| Static CPM well below, `core-wait` dominant | resource serialization | [01](01-task-granularity.md) |
+| Static CPM well below, `front-gap` large | launch and dispatch cost | [02](02-runtime-overhead.md), [06](06-host.md) |
+| Compute high, stall low | genuinely compute-bound | [04](04-incore.md) |
+
+> **Check the tiling line before quoting anything.** Each rank prints
+> `tiling check: compute+stall = ... vs makespan ...`, and it must read `exact`. A non-zero
+> difference means the walk did not tile the makespan and the per-task attribution is
+> unsound. Two more that quietly invalidate a report: families named `unknown` or `cid<N>`
+> mean the name map did not resolve, so family-level conclusions mean nothing; and with
+> multiple rounds the capture covers the **first** round, so the makespan includes warm-up.
+>
+> **One capture is one sample.** Two captures of the same unchanged workload can differ by
+> several points of stall share. Never compare two configurations from one capture each.
+
+The `critical-path-analysis` skill in the `pypto-user` plugin
+(`claude plugin install pypto-user@pypto-skills`) drives this end to end — artifact
+resolution, the validation list above, and the interpretation. The tool itself is in the
+runtime and needs no device, no build and no checkout: it is pure post-processing over a
+capture someone else took.
+
 ## Next
 
 With the picture in front of you, work down the chapter in order — granularity, then

--- a/docs/en/user/performance/00-swimlane.md
+++ b/docs/en/user/performance/00-swimlane.md
@@ -127,8 +127,10 @@ The runtime also converts the records into a Chrome Trace Event JSON that loads 
 [ui.perfetto.dev](https://ui.perfetto.dev):
 
 ```bash
-python -m simpler_setup.tools.swimlane_converter <records>.json \
-    --deps-json <deps>.json -o out.json
+RECORDS="outputs/<run>/chip_swimlane_records.json"
+DEPS_JSON="outputs/<run>/deps.json"
+python -m simpler_setup.tools.swimlane_converter "$RECORDS" \
+    --deps-json "$DEPS_JSON" -o out.json
 ```
 
 ## Reading it
@@ -161,8 +163,9 @@ that answers one specific question — *when is time lost because an idle core h
 work the scheduler had not placed yet?*
 
 ```bash
+# $RECORDS and $DEPS_JSON as set above
 python -m simpler_setup.tools.sched_overhead_analysis \
-    --chip-swimlane-records-json <records>.json --deps-json <deps>.json
+    --chip-swimlane-records-json "$RECORDS" --deps-json "$DEPS_JSON"
 ```
 
 This one needs a **level ≥ 3** capture for its scheduler-loop parts —
@@ -188,7 +191,8 @@ problem from a fake one:
 broader one — *what is the dependency-limited floor, and which tasks spent the rest?*
 
 ```bash
-python -m simpler_setup.tools.critical_path <run-dir>
+RUN_DIR="outputs/<run>"        # the tree holding the capture
+python -m simpler_setup.tools.critical_path "$RUN_DIR"
 ```
 
 It discovers every directory holding `chip_swimlane_records.json`, `deps.json` and

--- a/docs/en/user/performance/03-dependencies.md
+++ b/docs/en/user/performance/03-dependencies.md
@@ -229,6 +229,43 @@ correct for free. A missing edge in a manual scope is a race, not an error messa
 **How to confirm:** `enable_dep_gen=True`, and read the graph against what you intended —
 this is the one case where reading the whole graph, not a diff of it, is the check.
 
+## Edges you did not need
+
+Having added edges by hand, the opposite question is worth asking: which of them were
+already implied? An edge `(u, v)` is redundant when `v` is reachable from `u` some other
+way — removing it cannot change execution order, only the bookkeeping the scheduler
+carries.
+
+```bash
+python -m simpler_setup.tools.deps_viewer <deps.json> --edge-mode reduced
+python -m simpler_setup.tools.deps_viewer <deps.json> --edge-mode reduced_dataflow
+```
+
+> **Never report from `reduced` alone.** Edges carry a `source`, and `creator` edges — the
+> ones keeping alive the task that owns a tensor a consumer still references — are
+> protected from structural reduction unconditionally, because ordering is not what they
+> encode. Protection is per pair, so a single creator annotation shields the whole edge. On
+> a measured graph of 5120 `creator` plus 1008 `tensormap` edges, **all** 2032 redundant
+> pairs carried a creator annotation: `reduced` reported `0` while `reduced_dataflow`
+> removed 992. A zero from `reduced` is evidence about the mode, not about your graph.
+
+`reduced_dataflow` makes creator edges eligible, dropping one only when every creator
+annotation on the pair is an exactly-known `INOUT` region and every byte provably flows
+from an earlier `Output` on to a later `INOUT` owned by the same creator. Ambiguous or
+over-complex stride metadata keeps the edge, as does an `OUTPUT_EXISTING` edge, which
+begins a reuse generation.
+
+Two more things that look like answers and are not:
+
+- **A graph of depth 1 cannot contain a redundant edge at all** — with no two-hop path
+  there is nothing to imply an edge. Check the depth first; a `0` there ends the audit
+  rather than telling you the graph is minimal.
+- **A cycle silently disables reduction.** The tool warns on stderr, emits the full graph,
+  and still **exits 0**. Read stderr; the exit status is not proof a reduction ran.
+
+Add `--func-names <name_map*.json>` to get kernel names instead of numeric ids in the
+printed edge list. The audit consumes `deps.json` alone — no timing artifacts, no device.
+
 ## Deciding
 
 ```text

--- a/docs/en/user/performance/03-dependencies.md
+++ b/docs/en/user/performance/03-dependencies.md
@@ -237,8 +237,9 @@ way — removing it cannot change execution order, only the bookkeeping the sche
 carries.
 
 ```bash
-python -m simpler_setup.tools.deps_viewer <deps.json> --edge-mode reduced
-python -m simpler_setup.tools.deps_viewer <deps.json> --edge-mode reduced_dataflow
+DEPS_JSON="outputs/<run>/deps.json"
+python -m simpler_setup.tools.deps_viewer "$DEPS_JSON" --edge-mode reduced
+python -m simpler_setup.tools.deps_viewer "$DEPS_JSON" --edge-mode reduced_dataflow
 ```
 
 > **Never report from `reduced` alone.** Edges carry a `source`, and `creator` edges — the
@@ -260,11 +261,12 @@ Two more things that look like answers and are not:
 - **A graph of depth 1 cannot contain a redundant edge at all** — with no two-hop path
   there is nothing to imply an edge. Check the depth first; a `0` there ends the audit
   rather than telling you the graph is minimal.
-- **A cycle silently disables reduction.** The tool warns on stderr, emits the full graph,
-  and still **exits 0**. Read stderr; the exit status is not proof a reduction ran.
+- **A cycle disables reduction without failing.** The tool warns on stderr, emits the full
+  graph, and still **exits 0**. Read stderr; a zero exit is not proof a reduction ran.
 
-Add `--func-names <name_map*.json>` to get kernel names instead of numeric ids in the
-printed edge list. The audit consumes `deps.json` alone — no timing artifacts, no device.
+The audit itself consumes `deps.json` alone — no timing artifacts, no device. Adding
+`--func-names` reads one more file, the run's `name_map*.json`, and is worth it:
+it puts kernel names in the printed edge list instead of numeric ids.
 
 ## Deciding
 

--- a/docs/en/user/performance/04-incore.md
+++ b/docs/en/user/performance/04-incore.md
@@ -191,8 +191,8 @@ The raw output is cluttered. The repo tool cleans it into a per-pipe, Perfetto-v
 trace:
 
 ```bash
-python -m pypto.tools.clean_sim_trace \
-  <build-dir>/kernel_insight_all_funcs_<ts>/funcs/<kernel>/collect/out/OPPROF_* -o <out>
+TRACE="<build-dir>/kernel_insight_all_funcs_<ts>/funcs/<kernel>/collect/out"
+python -m pypto.tools.clean_sim_trace "$TRACE"/OPPROF_* -o trace-out
 ```
 
 That writes `trace.clean.json` with the pipeline lanes in dataflow order —

--- a/docs/zh/user/performance/00-swimlane.md
+++ b/docs/zh/user/performance/00-swimlane.md
@@ -142,6 +142,40 @@ python -m simpler_setup.tools.sched_overhead_analysis \
 - **没有就绪活**的空闲核**不算**开销。它的空闲是依赖图规定的 —— 那表现为并行度低，属于 [管理任务依赖](03-dependencies.md)。
 - **有就绪但未派发的活**时的空闲核算开销。那是调度器没跟上，属于 [运行时开销](02-runtime-overhead.md)。
 
+### makespan 究竟花在哪了
+
+`sched_overhead_analysis` 回答的是一个具体问题。关键路径分析回答的是更大的那个 —— *依赖决定的下限在哪，剩下的时间被谁花掉了？*
+
+```bash
+python -m simpler_setup.tools.critical_path <run-dir>
+```
+
+它会找出每一个同时含有 `chip_swimlane_records.json`、`deps.json` 与 `name_map*.json` 的目录，并在各自的 records 文件旁边写一份逐 rank 的报告。把它指向整棵 run 树，而不是单个 rank。
+
+它给出两条路径，而结论正在于两者之差：
+
+| 路径 | 是什么 |
+| ---- | ------ |
+| **Static CPM** | 按时长加权的最长链 —— 核数无限时的延迟下限 |
+| **Observed** | 从最后结束的任务往回走的实际执行路径 |
+
+每个任务的计算时间加上它前面的停顿，正好铺满 observed makespan；停顿被归为 `data-wait`（上游生产者迟到）、`core-wait`（分到的核在忙 —— 资源串行）或 `front-gap`（第一个任务开始前的启动延迟）。
+
+由此得到本章其余部分据以分叉的判断：
+
+| 读数 | 判断 | 该去哪 |
+| ---- | ---- | ------ |
+| Static CPM 接近 makespan | 依赖受限 —— 加核没用 | [03](03-dependencies.md)，以及 [01](01-task-granularity.md) 的粒度 |
+| Static CPM 远低于它，`core-wait` 占主导 | 资源串行 | [01](01-task-granularity.md) |
+| Static CPM 远低于它，`front-gap` 很大 | 启动与派发开销 | [02](02-runtime-overhead.md)、[06](06-host.md) |
+| 计算占比高、停顿低 | 确实是计算受限 | [04](04-incore.md) |
+
+> **引用任何数字之前，先看 tiling 那一行。** 每个 rank 都会打印 `tiling check: compute+stall = ... vs makespan ...`，它必须是 `exact`。差值非零意味着这次回溯没有铺满 makespan，逐任务的归因就是不可靠的。另有两种情况会悄悄让报告失效：family 显示为 `unknown` 或 `cid<N>` 说明 name map 没解析出来，此时 family 层面的结论毫无意义；以及跑多轮时采集只覆盖**第一轮**，makespan 里含着预热成本。
+>
+> **一次采集只是一个样本。** 同一份没有改动的负载采两次，停顿占比可以差好几个点。绝不要拿两个配置各采一次来做对比。
+
+`pypto-user` 插件里的 `critical-path-analysis` skill（`claude plugin install pypto-user@pypto-skills`）会把这套流程从头跑到尾 —— 定位产物、执行上面那份校验清单、并给出解读。工具本身在 runtime 里，不需要设备、不需要构建、也不需要仓库检出：它是对别人采好的一份数据做纯后处理。
+
 ## 下一步
 
 有了这张图之后，按本章顺序往下走 —— 粒度，然后派发开销，然后依赖图，最后才是 kernel 本身。

--- a/docs/zh/user/performance/00-swimlane.md
+++ b/docs/zh/user/performance/00-swimlane.md
@@ -101,8 +101,10 @@ cfg = RunConfig(platform="a2a3", enable_chip_swimlane=3,  # 调度器阶段及�
 运行时也能把记录转成可以在 [ui.perfetto.dev](https://ui.perfetto.dev) 里加载的 Chrome Trace Event JSON：
 
 ```bash
-python -m simpler_setup.tools.swimlane_converter <records>.json \
-    --deps-json <deps>.json -o out.json
+RECORDS="outputs/<run>/chip_swimlane_records.json"
+DEPS_JSON="outputs/<run>/deps.json"
+python -m simpler_setup.tools.swimlane_converter "$RECORDS" \
+    --deps-json "$DEPS_JSON" -o out.json
 ```
 
 ## 怎么读
@@ -129,8 +131,9 @@ dispatch ──────► start ──────► end ─────�
 当你想把间隙量化而不是靠眼估时，运行时自带一份分析，它只回答一个问题 —— *什么时候，一个空闲的核明明有就绪的活、而调度器还没把活放上去？*
 
 ```bash
+# $RECORDS 与 $DEPS_JSON 沿用上面的赋值
 python -m simpler_setup.tools.sched_overhead_analysis \
-    --chip-swimlane-records-json <records>.json --deps-json <deps>.json
+    --chip-swimlane-records-json "$RECORDS" --deps-json "$DEPS_JSON"
 ```
 
 它给出逐引擎与全系统的开销占 makespan 的比例、取件代价分布、AICPU 调度循环预算，以及把关键路径拆成「计算」与「调度器注入」两部分的归因。同样这些数字可以用 `swimlane_converter --overhead` 叠加成时间线上的 counter 轨。
@@ -147,7 +150,8 @@ python -m simpler_setup.tools.sched_overhead_analysis \
 `sched_overhead_analysis` 回答的是一个具体问题。关键路径分析回答的是更大的那个 —— *依赖决定的下限在哪，剩下的时间被谁花掉了？*
 
 ```bash
-python -m simpler_setup.tools.critical_path <run-dir>
+RUN_DIR="outputs/<run>"        # 存放本次采集的那棵树
+python -m simpler_setup.tools.critical_path "$RUN_DIR"
 ```
 
 它会找出每一个同时含有 `chip_swimlane_records.json`、`deps.json` 与 `name_map*.json` 的目录，并在各自的 records 文件旁边写一份逐 rank 的报告。把它指向整棵 run 树，而不是单个 rank。

--- a/docs/zh/user/performance/03-dependencies.md
+++ b/docs/zh/user/performance/03-dependencies.md
@@ -188,8 +188,9 @@ with pl.at(level=pl.Level.CORE_GROUP,
 手工加过边之后，反过来的问题也值得一问：其中哪些本来就已经被蕴含了？当 `v` 能从 `u` 经由别的路径到达时，边 `(u, v)` 就是冗余的 —— 去掉它不会改变执行顺序，只会减少调度器要维护的簿记。
 
 ```bash
-python -m simpler_setup.tools.deps_viewer <deps.json> --edge-mode reduced
-python -m simpler_setup.tools.deps_viewer <deps.json> --edge-mode reduced_dataflow
+DEPS_JSON="outputs/<run>/deps.json"
+python -m simpler_setup.tools.deps_viewer "$DEPS_JSON" --edge-mode reduced
+python -m simpler_setup.tools.deps_viewer "$DEPS_JSON" --edge-mode reduced_dataflow
 ```
 
 > **绝不要只看 `reduced` 就下结论。** 边带有 `source`，而 `creator` 边 —— 那些为了让「拥有某个消费者仍在引用的张量」的任务保持存活而存在的边 —— 会无条件地免于结构化归约，因为它们编码的根本不是顺序。这种保护是按 pair 生效的，所以一条 creator 标注就能护住整条边。在一份实测的图上（5120 条 `creator` 加 1008 条 `tensormap`），**全部** 2032 个冗余 pair 都带着 creator 标注：`reduced` 报 `0`，而 `reduced_dataflow` 去掉了 992 条。`reduced` 报零，是关于这个模式的证据，不是关于你这张图的。
@@ -199,9 +200,9 @@ python -m simpler_setup.tools.deps_viewer <deps.json> --edge-mode reduced_datafl
 另外两件看着像答案、其实不是的事：
 
 - **深度为 1 的图根本不可能有冗余边** —— 没有两跳路径，也就没有什么能蕴含一条边。先看深度；那里的 `0` 意味着审计到此为止，而不是说明这张图已经最简。
-- **存在环会悄悄让归约失效。** 工具会在 stderr 上告警、输出完整图，并且**仍然以 0 退出**。要读 stderr；退出码不能证明归约真的跑过。
+- **存在环会让归约失效，但不会让命令失败。** 工具会在 stderr 上告警、输出完整图，并且**仍然以 0 退出**。要读 stderr；退出码为 0 不能证明归约真的跑过。
 
-加上 `--func-names <name_map*.json>` 可以让打印出的边列表显示 kernel 名而不是数字 id。这项审计只消耗 `deps.json` —— 不需要时序产物，也不需要设备。
+审计本身只消耗 `deps.json` —— 不需要时序产物，也不需要设备。加上 `--func-names` 会多读一个文件，即本次运行的 `name_map*.json`，但值得：它会让打印出的边列表显示 kernel 名而不是数字 id。
 
 ## 怎么判断
 

--- a/docs/zh/user/performance/03-dependencies.md
+++ b/docs/zh/user/performance/03-dependencies.md
@@ -183,6 +183,26 @@ with pl.at(level=pl.Level.CORE_GROUP,
 
 **怎么确认：** `enable_dep_gen=True`，然后拿图对着你的意图读 —— 这是唯一一种「该读整张图而不是读它的 diff」的情形。
 
+## 你其实不需要的那些边
+
+手工加过边之后，反过来的问题也值得一问：其中哪些本来就已经被蕴含了？当 `v` 能从 `u` 经由别的路径到达时，边 `(u, v)` 就是冗余的 —— 去掉它不会改变执行顺序，只会减少调度器要维护的簿记。
+
+```bash
+python -m simpler_setup.tools.deps_viewer <deps.json> --edge-mode reduced
+python -m simpler_setup.tools.deps_viewer <deps.json> --edge-mode reduced_dataflow
+```
+
+> **绝不要只看 `reduced` 就下结论。** 边带有 `source`，而 `creator` 边 —— 那些为了让「拥有某个消费者仍在引用的张量」的任务保持存活而存在的边 —— 会无条件地免于结构化归约，因为它们编码的根本不是顺序。这种保护是按 pair 生效的，所以一条 creator 标注就能护住整条边。在一份实测的图上（5120 条 `creator` 加 1008 条 `tensormap`），**全部** 2032 个冗余 pair 都带着 creator 标注：`reduced` 报 `0`，而 `reduced_dataflow` 去掉了 992 条。`reduced` 报零，是关于这个模式的证据，不是关于你这张图的。
+
+`reduced_dataflow` 让 creator 边变得可去除，但只在该 pair 上每一条 creator 标注都是确切已知的 `INOUT` 区域、且每个字节都可证明是从更早的 `Output` 流向同一 creator 拥有的更晚的 `INOUT` 时才去。stride 元数据含糊或过于复杂会保留该边，`OUTPUT_EXISTING` 边也会 —— 它开启的是一个新的复用世代。
+
+另外两件看着像答案、其实不是的事：
+
+- **深度为 1 的图根本不可能有冗余边** —— 没有两跳路径，也就没有什么能蕴含一条边。先看深度；那里的 `0` 意味着审计到此为止，而不是说明这张图已经最简。
+- **存在环会悄悄让归约失效。** 工具会在 stderr 上告警、输出完整图，并且**仍然以 0 退出**。要读 stderr；退出码不能证明归约真的跑过。
+
+加上 `--func-names <name_map*.json>` 可以让打印出的边列表显示 kernel 名而不是数字 id。这项审计只消耗 `deps.json` —— 不需要时序产物，也不需要设备。
+
 ## 怎么判断
 
 ```text

--- a/docs/zh/user/performance/04-incore.md
+++ b/docs/zh/user/performance/04-incore.md
@@ -153,8 +153,8 @@ case 上驱动 `incore_profile.py`：
 原始输出很杂。仓库内的工具把它清理成一份按流水分道、可用 Perfetto 查看的 trace：
 
 ```bash
-python -m pypto.tools.clean_sim_trace \
-  <build-dir>/kernel_insight_all_funcs_<ts>/funcs/<kernel>/collect/out/OPPROF_* -o <out>
+TRACE="<build-dir>/kernel_insight_all_funcs_<ts>/funcs/<kernel>/collect/out"
+python -m pypto.tools.clean_sim_trace "$TRACE"/OPPROF_* -o trace-out
 ```
 
 它写出 `trace.clean.json`，泳道按数据流顺序排列 —— **MTE2 → MTE1 → CUBE → VECTOR → FIXPIPE → MTE3** —— 外加 `instr_metrics.json`，含逐指令的流水、cycle 数与 vector 利用率。


### PR DESCRIPTION
Two analyses ship with the runtime and the performance chapter mentioned neither.

## Where each goes

**Critical path → the swimlane page**, because it is what turns the picture into a
verdict. `sched_overhead_analysis` was already there answering one narrow question
(when did an idle core have ready work nobody placed). The critical path answers
the broader one: *what is the dependency-limited floor, and who spent the rest?*

It reports a **static CPM** path (the latency floor with unlimited cores) and an
**observed** backward-blame path whose compute-plus-stall tiles the makespan, with
stall split into `data-wait` / `core-wait` / `front-gap`. That maps directly onto
which of pages 01–06 to read, so the section ends in a routing table rather than in
numbers:

| Reading | Verdict | Where it goes |
| --- | --- | --- |
| Static CPM near the makespan | dependency-bound | 03, and granularity in 01 |
| Static CPM well below, `core-wait` dominant | resource serialization | 01 |
| Static CPM well below, `front-gap` large | launch / dispatch cost | 02, 06 |
| Compute high, stall low | compute-bound | 04 |

**Redundancy → the dependencies page**, next to the edges it audits. Having just
told the reader to declare edges by hand, the page now offers the inverse question.

## Each section leads with the trap

Both tools have a failure mode that looks like a clean answer:

- **`critical_path`** prints `tiling check: compute+stall = ... vs makespan ...`,
  and only `exact` makes the per-task attribution sound. Unresolved kernel families
  and first-round warm-up invalidate a report just as quietly. And **one capture is
  one sample** — two captures of one unchanged workload differ by points of stall
  share, so configurations must never be compared from one capture each.
- **`deps_viewer --edge-mode reduced`** protects `creator` edges unconditionally,
  per pair. **Its `0` is evidence about the mode, not the graph**: on a measured
  graph of 5120 creator + 1008 tensormap edges, every one of the 2032 redundant
  pairs was creator-annotated — `reduced` said `0` while `reduced_dataflow` removed
  **992**. Also: a depth-1 graph cannot hold a redundant edge at all, and a cycle
  skips reduction with a stderr warning **while still exiting 0**.

## Verified against the tools, not the skill text

Every claim was checked in the pinned runtime: the `exact` tiling-check wording
(`critical_path.py:401`), the three stall kinds (`:271,302,305,307`), the cycle
path's `return` with no exit code (`deps_viewer.py:1841`), and `--func-names`.

The pages document **the tools**, which live in the runtime and need no device,
build or checkout. The `critical-path-analysis` skill is named as the assisted
route, the way `04-incore.md` already names `incore-profiling`.

One status note: `critical-path-analysis` is merged in `pypto-skills`;
the dependency-redundancy skill is still open as pypto-skills#14. Since the docs
describe the runtime tool rather than the skill wrapper, they stand either way —
that is why the redundancy section does not name a skill yet.

## Verification

| Check | Result |
| ----- | ------ |
| `mkdocs build --strict` | passes, **0 warnings** |
| New broken anchors | 0 (site-wide count unchanged at 59) |
| Runnable blocks on `03-dependencies.md` | 3/3 pass, en/zh parity OK |
| 4 docs lints | PASS |
| markdownlint | 0 issues across 334 files |
