### PR TITLE
fix(ir): Canonicalize nested accumulator joins

### DIFF
--- a/docs/en/dev/passes/33-materialize_semantic_aliases.md
+++ b/docs/en/dev/passes/33-materialize_semantic_aliases.md
@@ -50,24 +50,33 @@ its own fresh MemRef. This pass closes that gap:
 1. **Top-down retarget** (`TopDownRetargeter`): for each `ForStmt`, take each
    `iter_arg`'s canonical MemRef as the target and push it onto the yielded value
    and its producer chain (following in-place `output-reuses-input` ops and
-   view inputs). `IfStmt` return values are retargeted into both branch yields.
+   view inputs). `IfStmt` return values are retargeted into both branch yields,
+   then the collected type rewrites are applied.
 2. **Normalize peeled accumulator phis**: visit nested `IfStmt` nodes in
    post-order and recognize both direct in-place accumulator producers and
    branch-local loops carried by an accumulator seeded outside that branch.
    When exactly one branch is the accumulator continuation, retarget the other
    branch's local seed, the phi result, aliases, and nested loop carry onto the
-   same `Acc` allocation. This is allowed only when the seed is local to the
-   branch and the target is dead in the remainder of that branch.
-3. **Apply retype** (`RetypeApplier`): rewrite the collected variable types in
-   place so the producer writes directly into the carried buffer.
+   reused input's canonical `Acc` allocation. Both the accumulator loop and the
+   sibling seed must be local to their respective branches, and the target must
+   be dead in the remainder of the seed branch. When a branch-local loop is
+   seeded outside the `IfStmt`, that external seed must also have no independent
+   post-`if` read; otherwise the sibling branch would clobber an observable
+   value on the path where the loop does not execute.
+3. **Normalize semantic identity chains**
+   (`NormalizeIdentityCopyBuffersMutator`): make bare SSA copies share their
+   source allocation and make every registered in-place result share its reused
+   input allocation. This closes lowering-created type drift before any memory
+   planner observes lifetimes or PTOAS emits tile handles.
 
 The pass is a no-op when there is nothing to retarget (`Compute` returns no
 rewrites), and skips `Orchestration` functions (no TileType variables).
 
 ## Relationship to codegen
 
-PTO codegen renders variables that resolve to the *same* MemRef identity
-(`base` + `byte_offset` + `size`) as a single `tile_buf` handle, so after this
+PTO codegen renders variables that resolve to the *same* physical MemRef window
+(`base` + `byte_offset` + `size` + pipeline-slot metadata) as a single
+`tile_buf` handle, so after this
 pass a loop-carried accumulator emits an in-place `pto.tadd ins(%acc, %t)
 outs(%acc)` rather than writing to a distinct `%acc_next` buffer. Under
 `memory_planner=DSA_RP`, each resulting allocation identity becomes one DSA
@@ -80,7 +89,10 @@ physical address for ptoas `PlanMemory`. See
 - Views/partial-views keep their distinct `byte_offset`/`size` metadata. Under
   `DSA_RP`, all members that share one `base` belong to one physical allocation;
   placement moves that allocation as a unit and writeback preserves each
-  member's relative offset.
+  member's relative offset. Sharing only the `base` is not enough to establish a
+  must-alias relation: disjoint byte windows and different pipeline slots remain
+  distinct until the producer is safely retargeted to the exact canonical
+  window.
 - In the default (`PYPTO`) pipeline this pass plus `MemoryReuse` compose to the
   behavior of the former single `MemoryReuse` pass.
 - `DSA_RP` and `PTOAS` both skip opportunistic MemRef coalescing here; neither
@@ -88,3 +100,7 @@ physical address for ptoas `PlanMemory`. See
 - Accumulator-phi normalization runs for every memory planner before lifetime
   planning. The legacy `PYPTO` path repeats it after opportunistic reuse because
   reuse can introduce a fresh carry/phi mismatch.
+- The preferred spelling for new matmul accumulators is a single
+  `tile.matmul_acc(..., init_cond=...)`. Peeled `matmul`/`matmul_acc` branches
+  remain supported for existing hand-written kernels and are normalized by this
+  pass.

--- a/docs/en/dev/passes/33-materialize_semantic_aliases.md
+++ b/docs/en/dev/passes/33-materialize_semantic_aliases.md
@@ -51,7 +51,14 @@ its own fresh MemRef. This pass closes that gap:
    `iter_arg`'s canonical MemRef as the target and push it onto the yielded value
    and its producer chain (following in-place `output-reuses-input` ops and
    view inputs). `IfStmt` return values are retargeted into both branch yields.
-2. **Apply retype** (`RetypeApplier`): rewrite the collected variable types in
+2. **Normalize peeled accumulator phis**: visit nested `IfStmt` nodes in
+   post-order and recognize both direct in-place accumulator producers and
+   branch-local loops carried by an accumulator seeded outside that branch.
+   When exactly one branch is the accumulator continuation, retarget the other
+   branch's local seed, the phi result, aliases, and nested loop carry onto the
+   same `Acc` allocation. This is allowed only when the seed is local to the
+   branch and the target is dead in the remainder of that branch.
+3. **Apply retype** (`RetypeApplier`): rewrite the collected variable types in
    place so the producer writes directly into the carried buffer.
 
 The pass is a no-op when there is nothing to retarget (`Compute` returns no
@@ -78,3 +85,6 @@ physical address for ptoas `PlanMemory`. See
   behavior of the former single `MemoryReuse` pass.
 - `DSA_RP` and `PTOAS` both skip opportunistic MemRef coalescing here; neither
   may undo a must-alias relation established by this pass.
+- Accumulator-phi normalization runs for every memory planner before lifetime
+  planning. The legacy `PYPTO` path repeats it after opportunistic reuse because
+  reuse can introduce a fresh carry/phi mismatch.

--- a/docs/en/dev/passes/33-materialize_semantic_aliases.md
+++ b/docs/en/dev/passes/33-materialize_semantic_aliases.md
@@ -59,10 +59,11 @@ its own fresh MemRef. This pass closes that gap:
    branch's local seed, the phi result, aliases, and nested loop carry onto the
    reused input's canonical `Acc` allocation. Both the accumulator loop and the
    sibling seed must be local to their respective branches, and the target must
-   be dead in the remainder of the seed branch. When a branch-local loop is
-   seeded outside the `IfStmt`, that external seed must also have no independent
-   post-`if` read; otherwise the sibling branch would clobber an observable
-   value on the path where the loop does not execute.
+   be dead in the remainder of the seed branch. Whether the continuation is a
+   direct `tile.matmul_acc` or a branch-local loop, its reused input and every
+   bare/metadata alias must have no independent post-`if` read; otherwise the
+   sibling branch would clobber an observable value on the path where the
+   continuation does not execute.
 3. **Normalize semantic identity chains**
    (`NormalizeIdentityCopyBuffersMutator`): make bare SSA copies share their
    source allocation and make every registered in-place result share its reused

--- a/docs/zh/dev/passes/33-materialize_semantic_aliases.md
+++ b/docs/zh/dev/passes/33-materialize_semantic_aliases.md
@@ -46,7 +46,12 @@ program = passes.materialize_semantic_aliases()(program)
    的规范 MemRef 作为目标，推送到 yield 值及其 producer 链上（跟随原地
    `output-reuses-input` 算子与 view 输入）。`IfStmt` 的返回值被推送到两个分支的
    yield。
-2. **应用重定型**（`RetypeApplier`）：就地改写收集到的变量类型，使生产者直接写入
+2. **规范化 peeled accumulator phi**：按后序访问嵌套 `IfStmt`，同时识别直接的
+   in-place accumulator producer，以及由分支外 accumulator seed 驱动的分支内
+   loop。当且仅当一个分支是 accumulator continuation 时，把另一个分支的局部
+   seed、phi result、alias 和嵌套 loop carry 重定向到同一个 `Acc` allocation。
+   只有 seed 位于该分支内且 target 在分支剩余部分已 dead 时才允许这样做。
+3. **应用重定型**（`RetypeApplier`）：就地改写收集到的变量类型，使生产者直接写入
    carried buffer。
 
 当没有可重定向的内容时（`Compute` 返回空）本 pass 是 no-op，并跳过
@@ -71,3 +76,6 @@ PTO codegen 把解析到*同一* MemRef 身份（`base` + `byte_offset` + `size`
   `MemoryReuse` pass 的行为。
 - `DSA_RP` 与 `PTOAS` 都跳过这里的机会性 MemRef 合并；二者都不能撤销本 pass
   建立的强制别名关系。
+- accumulator-phi 规范化会在 lifetime planning 之前对所有 memory planner 运行。
+  legacy `PYPTO` 路径在机会性 reuse 之后会再运行一次，因为 reuse 可能引入新的
+  carry/phi mismatch。

--- a/docs/zh/dev/passes/33-materialize_semantic_aliases.md
+++ b/docs/zh/dev/passes/33-materialize_semantic_aliases.md
@@ -45,22 +45,28 @@ program = passes.materialize_semantic_aliases()(program)
 1. **自顶向下重定向**（`TopDownRetargeter`）：对每个 `ForStmt`，取每个 `iter_arg`
    的规范 MemRef 作为目标，推送到 yield 值及其 producer 链上（跟随原地
    `output-reuses-input` 算子与 view 输入）。`IfStmt` 的返回值被推送到两个分支的
-   yield。
+   yield，然后应用收集到的类型改写。
 2. **规范化 peeled accumulator phi**：按后序访问嵌套 `IfStmt`，同时识别直接的
    in-place accumulator producer，以及由分支外 accumulator seed 驱动的分支内
    loop。当且仅当一个分支是 accumulator continuation 时，把另一个分支的局部
-   seed、phi result、alias 和嵌套 loop carry 重定向到同一个 `Acc` allocation。
-   只有 seed 位于该分支内且 target 在分支剩余部分已 dead 时才允许这样做。
-3. **应用重定型**（`RetypeApplier`）：就地改写收集到的变量类型，使生产者直接写入
-   carried buffer。
+   seed、phi result、alias 和嵌套 loop carry 重定向到 reused input 的规范 `Acc`
+   allocation。accumulator loop 和 sibling seed 都必须位于各自分支内，而且 target
+   在 seed 分支剩余部分必须已 dead。当分支内 loop 由 `IfStmt` 外部的 seed 驱动时，
+   该外部 seed 在 `if` 之后也不能存在绕过 phi 的独立读取；否则在 loop 不执行的
+   sibling 路径上，重定向后的 producer 会覆盖仍可观察的值。
+3. **规范化语义 identity chain**（`NormalizeIdentityCopyBuffersMutator`）：让 bare SSA
+   copy 与 source 共享 allocation，并让每个注册的 in-place result 与其 reused input
+   共享 allocation。这样可在任何 memory planner 观察 lifetime 或 PTOAS 发射 tile
+   handle 之前消除 lowering 引入的类型漂移。
 
 当没有可重定向的内容时（`Compute` 返回空）本 pass 是 no-op，并跳过
 `Orchestration` 函数（无 TileType 变量）。
 
 ## 与 codegen 的关系
 
-PTO codegen 把解析到*同一* MemRef 身份（`base` + `byte_offset` + `size`）的变量
-渲染成同一个 `tile_buf` handle，因此本 pass 之后,循环累加器会发出原地的
+PTO codegen 把解析到*同一*物理 MemRef window（`base` + `byte_offset` + `size` +
+pipeline-slot 元数据）的变量渲染成同一个 `tile_buf` handle，因此本 pass 之后,
+循环累加器会发出原地的
 `pto.tadd ins(%acc, %t) outs(%acc)`，而不是写到独立的 `%acc_next`。
 `memory_planner=DSA_RP` 会把每个所得分配身份变成一个 DSA buffer；
 `memory_planner=PTOAS` 则让 codegen 不带物理地址发射该身份，交给 ptoas
@@ -71,7 +77,9 @@ PTO codegen 把解析到*同一* MemRef 身份（`base` + `byte_offset` + `size`
 
 - view / 部分 view 保留各自的 `byte_offset`/`size` 元数据。在 `DSA_RP` 下，共享
   同一 `base` 的所有成员属于同一个物理分配；规划器整体移动该分配，并在回写时保留
-  每个成员的相对偏移。
+  每个成员的相对偏移。仅共享 `base` 不足以建立 must-alias 关系：互不相交的 byte
+  window 和不同 pipeline slot 会保持独立，直到 producer 被安全地重定向到精确的
+  canonical window。
 - 在默认（`PYPTO`）流水线里,本 pass 加上 `MemoryReuse` 组合起来等于原来单个
   `MemoryReuse` pass 的行为。
 - `DSA_RP` 与 `PTOAS` 都跳过这里的机会性 MemRef 合并；二者都不能撤销本 pass
@@ -79,3 +87,6 @@ PTO codegen 把解析到*同一* MemRef 身份（`base` + `byte_offset` + `size`
 - accumulator-phi 规范化会在 lifetime planning 之前对所有 memory planner 运行。
   legacy `PYPTO` 路径在机会性 reuse 之后会再运行一次，因为 reuse 可能引入新的
   carry/phi mismatch。
+- 新的 matmul accumulator 推荐使用单个
+  `tile.matmul_acc(..., init_cond=...)`。为兼容已有手写 kernel，peeled
+  `matmul`/`matmul_acc` 分支仍受支持，并由本 pass 规范化。

--- a/docs/zh/dev/passes/33-materialize_semantic_aliases.md
+++ b/docs/zh/dev/passes/33-materialize_semantic_aliases.md
@@ -51,9 +51,10 @@ program = passes.materialize_semantic_aliases()(program)
    loop。当且仅当一个分支是 accumulator continuation 时，把另一个分支的局部
    seed、phi result、alias 和嵌套 loop carry 重定向到 reused input 的规范 `Acc`
    allocation。accumulator loop 和 sibling seed 都必须位于各自分支内，而且 target
-   在 seed 分支剩余部分必须已 dead。当分支内 loop 由 `IfStmt` 外部的 seed 驱动时，
-   该外部 seed 在 `if` 之后也不能存在绕过 phi 的独立读取；否则在 loop 不执行的
-   sibling 路径上，重定向后的 producer 会覆盖仍可观察的值。
+   在 seed 分支剩余部分必须已 dead。无论 continuation 是直接的
+   `tile.matmul_acc` 还是分支内 loop，它复用的 input 及所有 bare/metadata alias 在
+   `if` 之后都不能存在绕过 phi 的独立读取；否则在 continuation 不执行的 sibling
+   路径上，重定向后的 producer 会覆盖仍可观察的值。
 3. **规范化语义 identity chain**（`NormalizeIdentityCopyBuffersMutator`）：让 bare SSA
    copy 与 source 共享 allocation，并让每个注册的 in-place result 与其 reused input
    共享 allocation。这样可在任何 memory planner 观察 lifetime 或 PTOAS 发射 tile

--- a/src/ir/transforms/memory_reuse_pass.cpp
+++ b/src/ir/transforms/memory_reuse_pass.cpp
@@ -520,6 +520,39 @@ class TopDownRetargeter {
     return AccumulatorTarget{GetDefinedMemRef(in_tile), in_tile->GetMemorySpace(), nullptr};
   }
 
+  /// True when ``var`` is an alias/in-place producer chain whose reused input
+  /// ultimately reaches ``root``. This proves accumulator semantics without
+  /// relying on the MemRefs already being coalesced: MemoryReuse may have just
+  /// packed one member of the family onto another physical window, which is the
+  /// mismatch this analysis exists to repair.
+  bool IsInplaceChainRootedAt(const VarPtr& var, const VarPtr& root) {
+    std::set<const Var*> seen;
+    return IsInplaceChainRootedAt(var, root, seen);
+  }
+
+  bool IsInplaceChainRootedAt(const VarPtr& var, const VarPtr& root, std::set<const Var*>& seen) {
+    if (var.get() == root.get()) return true;
+    if (!seen.insert(var.get()).second) return false;
+
+    auto it = defs_.find(var);
+    if (it == defs_.end() || it->second.kind != VarDef::kAssign) return false;
+    auto assign = As<AssignStmt>(it->second.assign_stmt);
+    if (!assign) return false;
+
+    if (auto alias = AsVarLike(assign->value_)) {
+      return IsInplaceChainRootedAt(alias, root, seen);
+    }
+
+    auto call = As<Call>(assign->value_);
+    if (!call || !call->op_) return false;
+    const auto& reg = OpRegistry::GetInstance();
+    if (!reg.IsRegistered(call->op_->name_)) return false;
+    auto reuse_idx = reg.GetEntry(call->op_->name_).GetOutputReusesInputArg();
+    if (!reuse_idx.has_value() || *reuse_idx >= call->args_.size()) return false;
+    auto reused = AsVarLike(call->args_[*reuse_idx]);
+    return reused && IsInplaceChainRootedAt(reused, root, seen);
+  }
+
   /// Resolve a branch-local accumulator loop seeded by a value defined outside
   /// ``branch_scope``. Both locality halves are required: the loop itself must
   /// be inside the branch and its seed must be outside it.
@@ -536,12 +569,8 @@ class TopDownRetargeter {
     if (!loop_inside_branch) return std::nullopt;
 
     auto init = AsVarLike(loop->iter_args_[it->second.return_idx]->initValue_);
-    auto result_tile = CurrentTileType(var);
     auto init_tile = init ? CurrentTileType(init) : nullptr;
-    if (!init || !result_tile || !init_tile ||
-        !SamePhysicalWindow(GetDefinedMemRef(result_tile), GetDefinedMemRef(init_tile))) {
-      return std::nullopt;
-    }
+    if (!init || !CurrentTileType(var) || !init_tile) return std::nullopt;
 
     auto init_def = defs_.find(init);
     if (init_def != defs_.end()) {
@@ -554,9 +583,8 @@ class TopDownRetargeter {
     auto body_yield = FindYieldStmt(loop->body_);
     if (!body_yield || it->second.return_idx >= body_yield->value_.size()) return std::nullopt;
     auto yielded = AsVarLike(body_yield->value_[it->second.return_idx]);
-    if (!yielded || !SamePhysicalWindow(CurrentMemRef(yielded), GetDefinedMemRef(init_tile))) {
-      return std::nullopt;
-    }
+    auto iter_arg = std::static_pointer_cast<const Var>(loop->iter_args_[it->second.return_idx]);
+    if (!yielded || !IsInplaceChainRootedAt(yielded, iter_arg)) return std::nullopt;
     return AccumulatorTarget{GetDefinedMemRef(init_tile), init_tile->GetMemorySpace(), init};
   }
 

--- a/src/ir/transforms/memory_reuse_pass.cpp
+++ b/src/ir/transforms/memory_reuse_pass.cpp
@@ -2825,9 +2825,14 @@ StmtPtr ApplyMemRefSharing(const StmtPtr& stmt, const std::map<VarPtr, VarPtr>& 
                                           old->size_, old->span_);
         };
 
-        // Create new TileType with shared MemRef
-        auto new_tile_type = std::dynamic_pointer_cast<const TileType>(CloneTypeWithMemRefAndRemapExprs(
-            curr_tile_type, source_memref, [this](const ExprPtr& expr) { return VisitExpr(expr); }));
+        // Rebase the representative through the same path as every member of
+        // its semantic sharing group.  A smaller tile may reuse a larger
+        // allocation; substituting source_memref wholesale here would give the
+        // representative the larger window while its aliases retain their
+        // original window, splitting one loop-carried accumulator family.
+        auto new_tile_type = std::dynamic_pointer_cast<const TileType>(
+            CloneTypeWithMemRefAndRemapExprs(curr_tile_type, rebase_memref(curr_tile_type),
+                                             [this](const ExprPtr& expr) { return VisitExpr(expr); }));
 
         // Create new Var
         auto new_var = std::make_shared<const Var>(op->var_->name_hint_, new_tile_type, op->var_->span_);

--- a/src/ir/transforms/memory_reuse_pass.cpp
+++ b/src/ir/transforms/memory_reuse_pass.cpp
@@ -24,6 +24,7 @@
 #include <set>
 #include <sstream>
 #include <string>
+#include <tuple>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
@@ -73,9 +74,9 @@ class VarUseCollector : public IRVisitor {
  public:
   std::set<VarPtr> used_vars;
 
-  void VisitExpr_(const VarPtr& var) override {
+  void VisitVarLike_(const VarPtr& var) override {
     used_vars.insert(var);
-    IRVisitor::VisitExpr_(var);
+    IRVisitor::VisitVarLike_(var);
   }
 };
 
@@ -110,61 +111,63 @@ bool SamePhysicalWindow(const MemRefPtr& lhs, const MemRefPtr& rhs) {
 //   - IfStmt return_vars: recurse into both branches' yield values with the
 //     same target, and retype the return_var itself.
 //
-// Liveness check: a retype at AssignStmt S is only safe if target's base Ptr
-// is not read between S and the enclosing ForStmt's yield.  The check walks
-// S's full ancestor chain (innermost out), and at each enclosing SeqStmts
-// scans the siblings that execute after the current walk node.  That covers
-// reads inside the same branch, reads after a nested IfStmt in the parent
-// body, and so on up to the enclosing ForStmt — where the retyped value is
-// consumed.
-//
-// Complexity: the retargeter runs a single IR walk to build the def map
-// (O(N)), then one TryRetargetVar per ForStmt iter_arg plus recursion into
-// IfStmt branches.  The liveness check scans the tail of each enclosing
-// SeqStmts up to the owning ForStmt; in the worst case of a deep linear
-// chain this is O(N^2).  In practice body tails are short (matmul/
-// accumulator loops have a handful of producers each), so the realised
-// cost is well below that bound; we accept the super-linear worst case
-// rather than threading a precomputed "bases read at-or-after" index that
-// would complicate the pass for no measurable win on typical IR.
+// Liveness check: one analysis walk numbers statements twice, once with each
+// IfStmt's then arm first and once with its else arm first. A statement can
+// execute after a definition iff it is later in both orderings; sibling arms
+// are later in exactly one and are therefore excluded. Read/write events are
+// indexed by overlapping physical-window component, so each query is O(log N)
+// and the complete retargeting analysis remains O(N log N).
 // ============================================================================
 
 /// Describes where a TileType Var is defined.
 struct VarDef {
   enum Kind { kAssign, kIfReturn, kForReturn, kIterArg, kUnknown };
   Kind kind = kUnknown;
-  StmtPtr assign_stmt;    // AssignStmt (for kAssign)
-  StmtPtr control_stmt;   // IfStmt/ForStmt (for kIfReturn/kForReturn)
+  StmtPtr assign_stmt;   // AssignStmt (for kAssign)
+  StmtPtr control_stmt;  // IfStmt/ForStmt (for kIfReturn/kForReturn)
+  StmtPtr definition_stmt;
+  ForStmtPtr nearest_for;
   size_t return_idx = 0;  // index into return_vars_ (for kIfReturn/kForReturn)
   IterArgPtr iter_arg;    // for kIterArg
-  // Full chain of enclosing stmts from outermost to innermost (does *not*
-  // include the defining assignment/control statement). Used by the liveness
-  // check to walk up through nested IfStmt branches to the enclosing ForStmt's
-  // body.
-  std::vector<StmtPtr> ancestors;
+  size_t order = 0;       // lexical statement order of the definition
 };
 
-/// Walks the IR once to build the def map, recording every AssignStmt's full
-/// enclosing-stmt chain so the liveness check can walk up past IfStmt /
-/// ScopeStmt branches into the enclosing loop body.
+/// Walks the IR once to build definitions, lexical statement intervals and
+/// per-statement VarLike accesses. Definitions keep only their nearest loop;
+/// no per-definition ancestor-chain copies are required.
 class DefMapVisitor : public IRVisitor {
  public:
   std::map<VarPtr, VarDef> defs;
+  std::map<const Stmt*, size_t> stmt_order;
+  std::map<const Stmt*, size_t> stmt_end_order;
+  std::map<const Stmt*, std::set<VarPtr>> reads;
+  std::map<const Stmt*, std::set<VarPtr>> writes;
+  StmtPtr root;
 
-  void Run(const StmtPtr& body) { VisitStmt(body); }
+  void Run(const StmtPtr& body) {
+    root = body;
+    VisitStmt(body);
+    for (auto& [var, def] : defs) {
+      (void)var;
+      if (def.kind == VarDef::kIfReturn || def.kind == VarDef::kForReturn) {
+        def.order = stmt_end_order.at(def.control_stmt.get());
+      }
+    }
+  }
 
  protected:
-  // Generic: every stmt becomes an ancestor of its children.  We push on
-  // enter and pop on exit so per-def ancestor snapshots are correct.
   void VisitStmt(const StmtPtr& stmt) override {
     if (!stmt) return;
+    auto previous = current_stmt_;
+    current_stmt_ = stmt;
+    stmt_order.emplace(stmt.get(), next_order_++);
     IRVisitor::VisitStmt(stmt);
+    stmt_end_order.emplace(stmt.get(), next_order_ - 1);
+    current_stmt_ = previous;
   }
 
   void VisitStmt_(const SeqStmtsPtr& op) override {
-    ancestor_stack_.push_back(op);
     for (const auto& s : op->stmts_) VisitStmt(s);
-    ancestor_stack_.pop_back();
   }
 
   void VisitStmt_(const AssignStmtPtr& op) override {
@@ -172,39 +175,51 @@ class DefMapVisitor : public IRVisitor {
       VarDef d;
       d.kind = VarDef::kAssign;
       d.assign_stmt = op;
-      d.ancestors = ancestor_stack_;
+      d.definition_stmt = op;
+      d.nearest_for = for_stack_.empty() ? nullptr : for_stack_.back();
+      d.order = stmt_order.at(op.get());
       defs[op->var_] = d;
+      writes[op.get()].insert(op->var_);
     }
     if (op->value_) VisitExpr(op->value_);
   }
 
   void VisitStmt_(const IfStmtPtr& op) override {
+    VisitExpr(op->condition_);
     for (size_t i = 0; i < op->return_vars_.size(); ++i) {
       const auto& rv = op->return_vars_[i];
       if (!As<TileType>(rv->GetType())) continue;
       VarDef d;
       d.kind = VarDef::kIfReturn;
       d.control_stmt = op;
+      d.definition_stmt = op;
+      d.nearest_for = for_stack_.empty() ? nullptr : for_stack_.back();
       d.return_idx = i;
-      d.ancestors = ancestor_stack_;
+      d.order = stmt_order.at(op.get());
       defs[rv] = d;
     }
-    ancestor_stack_.push_back(op);
     VisitStmt(op->then_body_);
     if (op->else_body_.has_value()) VisitStmt(op->else_body_.value());
-    ancestor_stack_.pop_back();
   }
 
   void VisitStmt_(const ForStmtPtr& op) override {
+    VisitExpr(op->loop_var_);
+    VisitExpr(op->start_);
+    VisitExpr(op->stop_);
+    VisitExpr(op->step_);
+    for (const auto& iter_arg : op->iter_args_) VisitExpr(iter_arg);
+
     for (size_t i = 0; i < op->iter_args_.size(); ++i) {
       auto ia = op->iter_args_[i];
       if (!As<TileType>(ia->GetType())) continue;
       VarDef d;
       d.kind = VarDef::kIterArg;
       d.control_stmt = op;
+      d.definition_stmt = op;
+      d.nearest_for = op;
       d.return_idx = i;
       d.iter_arg = ia;
-      d.ancestors = ancestor_stack_;
+      d.order = stmt_order.at(op.get());
       defs[std::static_pointer_cast<const Var>(ia)] = d;
     }
     for (size_t i = 0; i < op->return_vars_.size(); ++i) {
@@ -213,50 +228,75 @@ class DefMapVisitor : public IRVisitor {
       VarDef d;
       d.kind = VarDef::kForReturn;
       d.control_stmt = op;
+      d.definition_stmt = op;
+      d.nearest_for = op;
       d.return_idx = i;
-      d.ancestors = ancestor_stack_;
+      d.order = stmt_order.at(op.get());
       defs[rv] = d;
     }
-    ancestor_stack_.push_back(op);
+    for_stack_.push_back(op);
     VisitStmt(op->body_);
-    ancestor_stack_.pop_back();
+    for_stack_.pop_back();
   }
 
-  // Scope statements (InCore/Cluster/Hierarchy/Spmd) must also
-  // participate in the ancestor chain.  Without them, the liveness walk
-  // would jump straight from a scope body's SeqStmts to the enclosing
-  // loop body SeqStmts without finding its path-child, and reads after
-  // the scope in the enclosing body would be missed.
-  void VisitStmt_(const InCoreScopeStmtPtr& op) override { VisitScope(op, op->body_); }
-  void VisitStmt_(const ClusterScopeStmtPtr& op) override { VisitScope(op, op->body_); }
-  void VisitStmt_(const HierarchyScopeStmtPtr& op) override { VisitScope(op, op->body_); }
-  void VisitStmt_(const SpmdScopeStmtPtr& op) override { VisitScope(op, op->body_); }
+  void VisitStmt_(const InCoreScopeStmtPtr& op) override { VisitStmt(op->body_); }
+  void VisitStmt_(const ClusterScopeStmtPtr& op) override { VisitStmt(op->body_); }
+  void VisitStmt_(const HierarchyScopeStmtPtr& op) override { VisitStmt(op->body_); }
+  void VisitStmt_(const SpmdScopeStmtPtr& op) override { VisitStmt(op->body_); }
+
+  void VisitVarLike_(const VarPtr& op) override {
+    if (current_stmt_) reads[current_stmt_.get()].insert(op);
+    IRVisitor::VisitVarLike_(op);
+  }
 
  private:
-  template <typename ScopeStmtPtrT>
-  void VisitScope(const ScopeStmtPtrT& op, const StmtPtr& body) {
-    ancestor_stack_.push_back(op);
-    VisitStmt(body);
-    ancestor_stack_.pop_back();
+  StmtPtr current_stmt_;
+  std::vector<ForStmtPtr> for_stack_;
+  size_t next_order_ = 0;
+};
+
+/// A second lexical numbering with every IfStmt's arms visited in reverse.
+/// In structured control flow, statement A can execute before statement B iff
+/// A precedes B in both this ordering and DefMapVisitor's then-first ordering.
+class ReverseBranchOrderVisitor : public IRVisitor {
+ public:
+  std::map<const Stmt*, size_t> stmt_order;
+  std::map<const Stmt*, size_t> stmt_end_order;
+
+  void Run(const StmtPtr& body) { VisitStmt(body); }
+
+ protected:
+  void VisitStmt(const StmtPtr& stmt) override {
+    if (!stmt) return;
+    stmt_order.emplace(stmt.get(), next_order_++);
+    IRVisitor::VisitStmt(stmt);
+    stmt_end_order.emplace(stmt.get(), next_order_ - 1);
   }
 
-  // Outermost-first stack of enclosing stmts during the walk.
-  std::vector<StmtPtr> ancestor_stack_;
+  void VisitStmt_(const IfStmtPtr& op) override {
+    VisitExpr(op->condition_);
+    if (op->else_body_.has_value()) VisitStmt(*op->else_body_);
+    VisitStmt(op->then_body_);
+    for (const auto& return_var : op->return_vars_) VisitExpr(return_var);
+  }
+
+ private:
+  size_t next_order_ = 0;
 };
 
 /// Visits a stmt subtree and collects the MemRef base Ptrs of every *read*
 /// of a TileType Var.  Writes (the LHS of an AssignStmt) are intentionally
 /// excluded; every other stmt/expression kind dispatches through the default
 /// IRVisitor traversal, so new stmt types are covered automatically.
-class SubtreeReadBaseCollector : public IRVisitor {
+class ExprReadBaseCollector : public IRVisitor {
  public:
   std::set<const Var*> bases;
 
-  void VisitExpr_(const VarPtr& var) override {
+  void VisitVarLike_(const VarPtr& var) override {
     if (auto tile = GetTileTypeWithMemRef(var->GetType())) {
       bases.insert(GetDefinedMemRef(tile)->base_.get());
     }
-    IRVisitor::VisitExpr_(var);
+    IRVisitor::VisitVarLike_(var);
   }
 
   void VisitStmt_(const AssignStmtPtr& op) override {
@@ -265,75 +305,126 @@ class SubtreeReadBaseCollector : public IRVisitor {
   }
 };
 
-/// Collect exact SSA Vars read by a subtree. Assignment LHS definitions are
-/// excluded, matching SubtreeReadBaseCollector's read semantics.
-class SubtreeReadVarCollector : public IRVisitor {
+/// Range-maximum index over events (primary lexical order, reverse-branch
+/// lexical order). A query succeeds when an event lies in the primary interval
+/// and is also after the lower bound in the reverse ordering.
+class ReachableEventIndex {
  public:
-  std::set<const Var*> vars;
-
-  void VisitExpr_(const VarPtr& var) override {
-    vars.insert(var.get());
-    IRVisitor::VisitExpr_(var);
-  }
-
-  void VisitStmt_(const AssignStmtPtr& op) override {
-    if (op->value_) VisitExpr(op->value_);
-  }
-};
-
-bool SubtreeReadsAnyVar(const StmtPtr& stmt, const std::set<const Var*>& candidates) {
-  if (!stmt || candidates.empty()) return false;
-  SubtreeReadVarCollector collector;
-  collector.VisitStmt(stmt);
-  return std::any_of(candidates.begin(), candidates.end(),
-                     [&](const Var* var) { return collector.vars.count(var) > 0; });
-}
-
-/// Collect codegen-visible MemRef windows read by a subtree.
-class SubtreeReadWindowCollector : public IRVisitor {
- public:
-  std::vector<MemRefPtr> windows;
-
-  void VisitExpr_(const VarPtr& var) override {
-    if (auto tile = GetTileTypeWithMemRef(var->GetType())) {
-      windows.push_back(GetDefinedMemRef(tile));
+  void Build(std::vector<std::pair<size_t, size_t>> events) {
+    if (events.empty()) return;
+    std::sort(events.begin(), events.end());
+    events.erase(std::unique(events.begin(), events.end()), events.end());
+    size_ = 1;
+    while (size_ < events.size()) size_ *= 2;
+    primary_.reserve(events.size());
+    max_reverse_.assign(size_ * 2, 0);
+    for (size_t i = 0; i < events.size(); ++i) {
+      primary_.push_back(events[i].first);
+      max_reverse_[size_ + i] = events[i].second + 1;
     }
-    IRVisitor::VisitExpr_(var);
-  }
-
-  void VisitStmt_(const AssignStmtPtr& op) override {
-    if (op->value_) VisitExpr(op->value_);
-  }
-};
-
-bool SubtreeReadsWindow(const StmtPtr& stmt, const MemRefPtr& target) {
-  if (!stmt || !target) return false;
-  SubtreeReadWindowCollector collector;
-  collector.VisitStmt(stmt);
-  return std::any_of(collector.windows.begin(), collector.windows.end(),
-                     [&](const MemRefPtr& window) { return MemRef::MayAlias(window, target); });
-}
-
-/// Collect codegen-visible MemRef windows written by assignment LHSs.
-class SubtreeWriteWindowCollector : public IRVisitor {
- public:
-  std::vector<MemRefPtr> windows;
-
-  void VisitStmt_(const AssignStmtPtr& op) override {
-    if (auto tile = GetTileTypeWithMemRef(op->var_->GetType())) {
-      windows.push_back(GetDefinedMemRef(tile));
+    for (size_t i = size_; i-- > 1;) {
+      max_reverse_[i] = std::max(max_reverse_[i * 2], max_reverse_[i * 2 + 1]);
     }
-    IRVisitor::VisitStmt_(op);
   }
+
+  [[nodiscard]] bool HasAfter(size_t primary_begin, size_t primary_end, size_t reverse_lower) const {
+    if (primary_.empty() || primary_begin > primary_end) return false;
+    size_t left = static_cast<size_t>(std::lower_bound(primary_.begin(), primary_.end(), primary_begin) -
+                                      primary_.begin());
+    size_t right = static_cast<size_t>(std::upper_bound(primary_.begin(), primary_.end(), primary_end) -
+                                       primary_.begin());
+    left += size_;
+    right += size_;
+    size_t maximum = 0;
+    while (left < right) {
+      if (left & 1U) maximum = std::max(maximum, max_reverse_[left++]);
+      if (right & 1U) maximum = std::max(maximum, max_reverse_[--right]);
+      left /= 2;
+      right /= 2;
+    }
+    return maximum > reverse_lower + 1;
+  }
+
+ private:
+  std::vector<size_t> primary_;
+  std::vector<size_t> max_reverse_;
+  size_t size_ = 0;
 };
 
-bool SubtreeWritesWindow(const StmtPtr& stmt, const MemRefPtr& target) {
-  if (!stmt || !target) return false;
-  SubtreeWriteWindowCollector collector;
-  collector.VisitStmt(stmt);
-  return std::any_of(collector.windows.begin(), collector.windows.end(),
-                     [&](const MemRefPtr& window) { return MemRef::MayAlias(window, target); });
-}
+/// Range-minimum index over read events and their logical definition versions.
+/// Aliases can share a physical allocation while naming different values over
+/// time (notably an IterArg's initializer and the corresponding ForStmt
+/// return). A post-If read is an independent observation of the old value only
+/// when the handle being read was defined before that IfStmt.
+///
+/// These queries begin after the complete IfStmt subtree, where primary lexical
+/// order alone proves reachability (both arms precede the suffix in either
+/// branch ordering). The index therefore stores the minimum handle-definition
+/// order per primary interval. Build is O(N log N), each query is O(log N), and
+/// the complete pass remains O(N log N).
+class VersionedReachableEventIndex {
+ public:
+  struct Event {
+    size_t primary;
+    size_t definition;
+  };
+
+  void Build(std::vector<Event> events) {
+    if (events.empty()) return;
+    std::sort(events.begin(), events.end(), [](const Event& lhs, const Event& rhs) {
+      return std::tie(lhs.primary, lhs.definition) < std::tie(rhs.primary, rhs.definition);
+    });
+
+    primary_.reserve(events.size());
+    std::vector<size_t> leaf_minimum;
+    leaf_minimum.reserve(events.size());
+    for (size_t i = 0; i < events.size();) {
+      primary_.push_back(events[i].primary);
+      size_t minimum = events[i].definition;
+      size_t j = i + 1;
+      while (j < events.size() && events[j].primary == events[i].primary) {
+        minimum = std::min(minimum, events[j].definition);
+        ++j;
+      }
+      leaf_minimum.push_back(minimum);
+      i = j;
+    }
+
+    size_ = 1;
+    while (size_ < primary_.size()) size_ *= 2;
+    minimum_definition_.assign(size_ * 2, std::numeric_limits<size_t>::max());
+    for (size_t i = 0; i < leaf_minimum.size(); ++i) {
+      minimum_definition_[size_ + i] = leaf_minimum[i];
+    }
+    for (size_t i = size_; i-- > 1;) {
+      minimum_definition_[i] = std::min(minimum_definition_[i * 2], minimum_definition_[i * 2 + 1]);
+    }
+  }
+
+  [[nodiscard]] bool HasAfterFromHandleDefinedBefore(size_t primary_begin, size_t primary_end,
+                                                     size_t definition_upper) const {
+    if (primary_.empty() || primary_begin > primary_end) return false;
+    size_t left = static_cast<size_t>(std::lower_bound(primary_.begin(), primary_.end(), primary_begin) -
+                                      primary_.begin());
+    size_t right = static_cast<size_t>(std::upper_bound(primary_.begin(), primary_.end(), primary_end) -
+                                       primary_.begin());
+    left += size_;
+    right += size_;
+    size_t minimum = std::numeric_limits<size_t>::max();
+    while (left < right) {
+      if (left & 1U) minimum = std::min(minimum, minimum_definition_[left++]);
+      if (right & 1U) minimum = std::min(minimum, minimum_definition_[--right]);
+      left /= 2;
+      right /= 2;
+    }
+    return minimum < definition_upper;
+  }
+
+ private:
+  std::vector<size_t> primary_;
+  std::vector<size_t> minimum_definition_;
+  size_t size_ = 0;
+};
 
 bool IsA5Target() {
   if (!backend::BackendConfig::IsConfigured()) return false;
@@ -348,9 +439,7 @@ class TopDownRetargeter {
  public:
   /// Runs the analysis. Returns map: old VarPtr -> new Type (with target MemRef).
   std::map<VarPtr, TypePtr> Compute(const StmtPtr& func_body) {
-    DefMapVisitor def_v;
-    def_v.Run(func_body);
-    defs_ = std::move(def_v.defs);
+    BuildAnalysis(func_body);
     VisitForStmts(func_body);
     return std::move(rewrites_);
   }
@@ -377,8 +466,8 @@ class TopDownRetargeter {
   /// the peel must keep compiling, and pypto-lib alone has 95 such sites.
   ///
   /// Retiring this repair is therefore a *long-horizon* intent, not a near-term
-  /// plan.  It would need the source-level migration to land first, and it is
-  /// Until then, prefer `init_cond` in new code and leave existing peels alone.
+  /// plan. It would need the source-level migration to land first. Until then,
+  /// prefer `init_cond` in new code and leave existing peels alone.
   ///
   /// LowerPipelineLoops peels a stage=2 K-loop into an epilogue IfStmt whose live
   /// branch is an in-place accumulator (matmul_acc, output aliasing input on the
@@ -396,25 +485,318 @@ class TopDownRetargeter {
   /// verifies the two preconditions branch exclusivity actually needs: (a) the
   /// seed producer is lexically inside the branch, and (b) a branch-scoped
   /// liveness scan (`IsTargetDeadAtAssign(..., stop_at=if)`) finds no same-branch
-  /// tail read of the accumulator buffer.  For a branch-local loop seeded outside
-  /// the IfStmt, an additional post-if scan proves that no external handle to the
-  /// accumulator window remains observable independently of the phi.  When any
-  /// condition fails, that phi is left to YieldFixup instead of being coalesced.
+  /// tail read of the accumulator buffer. For both a direct `matmul_acc` and a
+  /// branch-local loop seeded outside the IfStmt, an alias-aware post-if scan
+  /// proves that no external handle to the reused input remains observable
+  /// independently of the phi. When any condition fails, that phi is left to
+  /// YieldFixup instead of being coalesced.
   /// Returns the rewrite map (apply via RetypeApplier).  A needed-but-declined
   /// retarget (after the preconditions hold) is a hard error — no legal Acc->Acc
   /// move exists to fall back to.
   std::map<VarPtr, TypePtr> CoalesceAccumulatorIfPhis(const StmtPtr& func_body) {
-    DefMapVisitor def_v;
-    def_v.Run(func_body);
-    defs_ = std::move(def_v.defs);
+    BuildAnalysis(func_body);
     VisitIfPhisForAccumulator(func_body);
     return std::move(rewrites_);
   }
 
  private:
+  struct RewriteJournalEntry {
+    VarPtr var;
+    std::optional<TypePtr> previous;
+  };
+
+  class RewriteTransaction {
+   public:
+    explicit RewriteTransaction(TopDownRetargeter& owner)
+        : owner_(owner), checkpoint_(owner.rewrite_journal_.size()) {}
+    RewriteTransaction(const RewriteTransaction&) = delete;
+    RewriteTransaction& operator=(const RewriteTransaction&) = delete;
+    ~RewriteTransaction() {
+      if (!committed_) owner_.RollbackRewrites(checkpoint_);
+    }
+
+    void Commit() { committed_ = true; }
+
+   private:
+    TopDownRetargeter& owner_;
+    size_t checkpoint_;
+    bool committed_ = false;
+  };
+
   std::map<VarPtr, VarDef> defs_;
+  std::map<const Stmt*, size_t> stmt_order_;
+  std::map<const Stmt*, size_t> stmt_end_order_;
+  std::map<const Stmt*, size_t> reverse_stmt_order_;
+  std::map<const Stmt*, size_t> reverse_stmt_end_order_;
+  StmtPtr analysis_root_;
+  std::map<VarPtr, VarPtr> alias_source_;
+  std::map<VarPtr, VarPtr> alias_root_cache_;
+  std::map<VarPtr, VarPtr> inplace_source_;
+  std::map<VarPtr, VarPtr> inplace_root_cache_;
+  std::map<VarPtr, VarPtr> accumulator_input_cache_;
+  std::set<VarPtr> non_accumulator_producers_;
+  std::map<const MemRef*, size_t> memref_component_;
+  std::map<size_t, ReachableEventIndex> physical_access_index_;
+  std::map<const Var*, VersionedReachableEventIndex> alias_read_index_;
   std::map<VarPtr, TypePtr> rewrites_;
+  std::vector<RewriteJournalEntry> rewrite_journal_;
   std::set<VarPtr> visiting_;  // cycle guard
+
+  void BuildAnalysis(const StmtPtr& func_body) {
+    DefMapVisitor def_v;
+    def_v.Run(func_body);
+    defs_ = std::move(def_v.defs);
+    stmt_order_ = std::move(def_v.stmt_order);
+    stmt_end_order_ = std::move(def_v.stmt_end_order);
+    analysis_root_ = def_v.root;
+
+    ReverseBranchOrderVisitor reverse_v;
+    reverse_v.Run(func_body);
+    reverse_stmt_order_ = std::move(reverse_v.stmt_order);
+    reverse_stmt_end_order_ = std::move(reverse_v.stmt_end_order);
+    BuildAliasFamilies();
+    BuildAccessIndexes(def_v.reads, def_v.writes);
+  }
+
+  static size_t FindSet(std::vector<size_t>& parent, size_t value) {
+    while (parent[value] != value) {
+      parent[value] = parent[parent[value]];
+      value = parent[value];
+    }
+    return value;
+  }
+
+  static void UnionSets(std::vector<size_t>& parent, size_t lhs, size_t rhs) {
+    lhs = FindSet(parent, lhs);
+    rhs = FindSet(parent, rhs);
+    if (lhs != rhs) parent[rhs] = lhs;
+  }
+
+  void BuildAccessIndexes(const std::map<const Stmt*, std::set<VarPtr>>& reads,
+                          const std::map<const Stmt*, std::set<VarPtr>>& writes) {
+    memref_component_.clear();
+    physical_access_index_.clear();
+    alias_read_index_.clear();
+
+    std::map<const MemRef*, MemRefPtr> unique_memrefs;
+    auto register_var = [&](const VarPtr& var) {
+      if (auto tile = GetTileTypeWithMemRef(var->GetType())) {
+        auto memref = GetDefinedMemRef(tile);
+        unique_memrefs.emplace(memref.get(), memref);
+      }
+    };
+    for (const auto& [var, def] : defs_) {
+      (void)def;
+      register_var(var);
+    }
+    for (const auto& [stmt, vars] : reads) {
+      (void)stmt;
+      for (const auto& var : vars) register_var(var);
+    }
+    for (const auto& [stmt, vars] : writes) {
+      (void)stmt;
+      for (const auto& var : vars) register_var(var);
+    }
+
+    std::vector<MemRefPtr> memrefs;
+    memrefs.reserve(unique_memrefs.size());
+    for (const auto& [ptr, memref] : unique_memrefs) {
+      (void)ptr;
+      memrefs.push_back(memref);
+    }
+    std::vector<size_t> parent(memrefs.size());
+    for (size_t i = 0; i < parent.size(); ++i) parent[i] = i;
+
+    std::map<const Var*, std::vector<size_t>> by_base;
+    for (size_t i = 0; i < memrefs.size(); ++i) by_base[memrefs[i]->base_.get()].push_back(i);
+    for (const auto& [base, members] : by_base) {
+      (void)base;
+      struct StaticInterval {
+        int64_t begin;
+        __int128 end;
+        size_t index;
+      };
+      std::vector<StaticInterval> intervals;
+      std::vector<size_t> dynamic;
+      for (size_t index : members) {
+        if (auto offset = As<ConstInt>(memrefs[index]->byte_offset_)) {
+          intervals.push_back(StaticInterval{
+              offset->value_, static_cast<__int128>(offset->value_) + memrefs[index]->size_, index});
+        } else {
+          dynamic.push_back(index);
+        }
+      }
+      std::sort(intervals.begin(), intervals.end(), [](const auto& lhs, const auto& rhs) {
+        return std::tie(lhs.begin, lhs.end) < std::tie(rhs.begin, rhs.end);
+      });
+      if (!intervals.empty()) {
+        size_t representative = intervals.front().index;
+        __int128 component_end = intervals.front().end;
+        for (size_t i = 1; i < intervals.size(); ++i) {
+          if (static_cast<__int128>(intervals[i].begin) < component_end) {
+            UnionSets(parent, representative, intervals[i].index);
+            component_end = std::max(component_end, intervals[i].end);
+          } else {
+            representative = intervals[i].index;
+            component_end = intervals[i].end;
+          }
+        }
+      }
+      // Symbolic offsets may overlap every window in their allocation.
+      if (!dynamic.empty() && !members.empty()) {
+        for (size_t index : members) UnionSets(parent, dynamic.front(), index);
+      }
+    }
+
+    std::map<size_t, size_t> dense_component;
+    for (size_t i = 0; i < memrefs.size(); ++i) {
+      const size_t root = FindSet(parent, i);
+      auto [it, inserted] = dense_component.emplace(root, dense_component.size());
+      (void)inserted;
+      memref_component_[memrefs[i].get()] = it->second;
+    }
+
+    std::map<size_t, std::vector<std::pair<size_t, size_t>>> physical_events;
+    std::map<const Var*, std::vector<VersionedReachableEventIndex::Event>> alias_events;
+    auto record = [&](const Stmt* stmt, const VarPtr& var, bool is_read) {
+      auto primary = stmt_order_.find(stmt);
+      auto reverse = reverse_stmt_order_.find(stmt);
+      if (primary == stmt_order_.end() || reverse == reverse_stmt_order_.end()) return;
+      if (auto tile = GetTileTypeWithMemRef(var->GetType())) {
+        auto component = memref_component_.find(GetDefinedMemRef(tile).get());
+        if (component != memref_component_.end()) {
+          physical_events[component->second].emplace_back(primary->second, reverse->second);
+        }
+      }
+      if (is_read) {
+        auto def = defs_.find(var);
+        // Function inputs and other externally defined handles predate every
+        // statement in the analysed body.
+        const size_t definition = def == defs_.end() ? 0 : def->second.order;
+        alias_events[ResolveAliasRoot(var).get()].push_back(
+            VersionedReachableEventIndex::Event{primary->second, definition});
+      }
+    };
+    for (const auto& [stmt, vars] : reads) {
+      for (const auto& var : vars) record(stmt, var, true);
+    }
+    for (const auto& [stmt, vars] : writes) {
+      for (const auto& var : vars) record(stmt, var, false);
+    }
+    for (auto& [component, events] : physical_events) {
+      physical_access_index_[component].Build(std::move(events));
+    }
+    for (auto& [root, events] : alias_events) alias_read_index_[root].Build(std::move(events));
+  }
+
+  [[nodiscard]] bool IsInside(const StmtPtr& inner, const StmtPtr& outer) const {
+    if (!inner || !outer) return false;
+    auto inner_order = stmt_order_.find(inner.get());
+    auto outer_begin = stmt_order_.find(outer.get());
+    auto outer_end = stmt_end_order_.find(outer.get());
+    return inner_order != stmt_order_.end() && outer_begin != stmt_order_.end() &&
+           outer_end != stmt_end_order_.end() && outer_begin->second <= inner_order->second &&
+           inner_order->second <= outer_end->second;
+  }
+
+  void BuildAliasFamilies() {
+    alias_source_.clear();
+    alias_root_cache_.clear();
+    inplace_source_.clear();
+    inplace_root_cache_.clear();
+    accumulator_input_cache_.clear();
+    non_accumulator_producers_.clear();
+
+    const auto& registry = OpRegistry::GetInstance();
+    for (const auto& [var, def] : defs_) {
+      if (def.kind == VarDef::kIterArg) {
+        if (def.iter_arg) {
+          if (auto init = AsVarLike(def.iter_arg->initValue_)) alias_source_[var] = init;
+        }
+        continue;
+      }
+      if (def.kind == VarDef::kForReturn) {
+        auto loop = As<ForStmt>(def.control_stmt);
+        if (loop && def.return_idx < loop->iter_args_.size()) {
+          alias_source_[var] = std::static_pointer_cast<const Var>(loop->iter_args_[def.return_idx]);
+        }
+        continue;
+      }
+      if (def.kind != VarDef::kAssign) continue;
+      auto assign = As<AssignStmt>(def.assign_stmt);
+      if (!assign) continue;
+
+      if (auto source = AsVarLike(assign->value_)) {
+        // A bare SSA assignment is semantic identity even when lowering has
+        // temporarily left stale MemRef metadata on one side.
+        alias_source_[var] = source;
+        inplace_source_[var] = source;
+        continue;
+      }
+
+      auto call = As<Call>(assign->value_);
+      if (!call || !call->op_ || !registry.IsRegistered(call->op_->name_)) continue;
+      if (!op_predicates::OutputInheritsSourceBuffer(call->op_->name_)) continue;
+      const auto& entry = registry.GetEntry(call->op_->name_);
+      if (auto reuse_idx = entry.GetOutputReusesInputArg();
+          reuse_idx.has_value() && *reuse_idx < call->args_.size()) {
+        if (auto source = AsVarLike(call->args_[*reuse_idx])) {
+          alias_source_[var] = source;
+          inplace_source_[var] = source;
+        }
+        continue;
+      }
+      if (!call->args_.empty()) {
+        if (auto source = AsVarLike(call->args_[0])) alias_source_[var] = source;
+      }
+    }
+  }
+
+  VarPtr ResolveAliasRoot(const VarPtr& var) {
+    auto cached = alias_root_cache_.find(var);
+    if (cached != alias_root_cache_.end()) return cached->second;
+
+    std::vector<VarPtr> path;
+    std::set<const Var*> seen;
+    VarPtr current = var;
+    while (seen.insert(current.get()).second) {
+      auto source = alias_source_.find(current);
+      if (source == alias_source_.end()) break;
+      path.push_back(current);
+      current = source->second;
+      auto root_cached = alias_root_cache_.find(current);
+      if (root_cached != alias_root_cache_.end()) {
+        current = root_cached->second;
+        break;
+      }
+    }
+    for (const auto& member : path) alias_root_cache_[member] = current;
+    alias_root_cache_[var] = current;
+    return current;
+  }
+
+  VarPtr ResolveInplaceRoot(const VarPtr& var) {
+    auto cached = inplace_root_cache_.find(var);
+    if (cached != inplace_root_cache_.end()) return cached->second;
+
+    std::vector<VarPtr> path;
+    std::set<const Var*> seen;
+    VarPtr current = var;
+    while (seen.insert(current.get()).second) {
+      auto source = inplace_source_.find(current);
+      if (source == inplace_source_.end()) break;
+      path.push_back(current);
+      current = source->second;
+      auto root_cached = inplace_root_cache_.find(current);
+      if (root_cached != inplace_root_cache_.end()) {
+        current = root_cached->second;
+        break;
+      }
+    }
+    for (const auto& member : path) inplace_root_cache_[member] = current;
+    inplace_root_cache_[var] = current;
+    return current;
+  }
 
   // Walk IR, calling Propagate for each ForStmt we encounter.
   void VisitForStmts(const StmtPtr& stmt) {
@@ -479,9 +861,10 @@ class TopDownRetargeter {
   struct AccumulatorTarget {
     MemRefPtr memref;
     std::optional<MemorySpace> memory_space;
-    // Non-null only for a branch-local loop whose accumulator is seeded by a
-    // value defined outside the enclosing IfStmt.
-    VarPtr external_seed;
+    // Canonical reused input whose pre-existing aliases must remain observable.
+    // This is populated for both direct in-place accumulator producers and
+    // branch-local accumulator loops.
+    VarPtr reused_input;
   };
 
   // Resolve the canonical allocation of an in-place accumulator producer. A
@@ -489,35 +872,59 @@ class TopDownRetargeter {
   // so return the underlying producer's target rather than a boolean that would
   // make the caller accidentally select the alias's stale MemRef.
   std::optional<AccumulatorTarget> FindInplaceAccumulatorProducer(const VarPtr& var) {
-    std::set<const Var*> seen;
-    return FindInplaceAccumulatorProducer(var, seen);
-  }
-
-  std::optional<AccumulatorTarget> FindInplaceAccumulatorProducer(const VarPtr& var,
-                                                                  std::set<const Var*>& seen) {
-    if (!seen.insert(var.get()).second) return std::nullopt;
-    auto it = defs_.find(var);
-    if (it == defs_.end() || it->second.kind != VarDef::kAssign) return std::nullopt;
-    auto assign = As<AssignStmt>(it->second.assign_stmt);
-    if (!assign) return std::nullopt;
-    auto call = As<Call>(assign->value_);
-    if (!call) {
-      auto alias = AsVarLike(assign->value_);
-      return alias ? FindInplaceAccumulatorProducer(alias, seen) : std::nullopt;
-    }
-    if (!call->op_) return std::nullopt;
-    const auto& reg = OpRegistry::GetInstance();
-    if (!reg.IsRegistered(call->op_->name_)) return std::nullopt;
-    auto reuse_idx = reg.GetEntry(call->op_->name_).GetOutputReusesInputArg();
-    if (!reuse_idx.has_value() || *reuse_idx >= call->args_.size()) return std::nullopt;
-    auto in_var = AsVarLike(call->args_[*reuse_idx]);
+    auto in_var = FindAccumulatorInput(var);
     if (!in_var) return std::nullopt;
     auto in_tile = CurrentTileType(in_var);
     if (!in_tile) return std::nullopt;
     // The registered reuse input is authoritative. Lowering may have left the
     // Call result typed on an older allocation; TryRetargetVar below repairs the
     // result onto this canonical input allocation before the phi is rewritten.
-    return AccumulatorTarget{GetDefinedMemRef(in_tile), in_tile->GetMemorySpace(), nullptr};
+    return AccumulatorTarget{GetDefinedMemRef(in_tile), in_tile->GetMemorySpace(), in_var};
+  }
+
+  VarPtr FindAccumulatorInput(const VarPtr& var) {
+    auto cached = accumulator_input_cache_.find(var);
+    if (cached != accumulator_input_cache_.end()) return cached->second;
+    if (non_accumulator_producers_.count(var) != 0) return nullptr;
+
+    std::vector<VarPtr> path;
+    std::set<const Var*> seen;
+    VarPtr current = var;
+    VarPtr result;
+    while (seen.insert(current.get()).second) {
+      auto known = accumulator_input_cache_.find(current);
+      if (known != accumulator_input_cache_.end()) {
+        result = known->second;
+        break;
+      }
+      if (non_accumulator_producers_.count(current) != 0) break;
+      path.push_back(current);
+
+      auto def = defs_.find(current);
+      if (def == defs_.end() || def->second.kind != VarDef::kAssign) break;
+      auto assign = As<AssignStmt>(def->second.assign_stmt);
+      if (!assign) break;
+      if (auto alias = AsVarLike(assign->value_)) {
+        current = alias;
+        continue;
+      }
+      auto call = As<Call>(assign->value_);
+      if (!call || !call->op_) break;
+      const auto& registry = OpRegistry::GetInstance();
+      if (!registry.IsRegistered(call->op_->name_)) break;
+      auto reuse_idx = registry.GetEntry(call->op_->name_).GetOutputReusesInputArg();
+      if (!reuse_idx.has_value() || *reuse_idx >= call->args_.size()) break;
+      result = AsVarLike(call->args_[*reuse_idx]);
+      break;
+    }
+    for (const auto& member : path) {
+      if (result) {
+        accumulator_input_cache_[member] = result;
+      } else {
+        non_accumulator_producers_.insert(member);
+      }
+    }
+    return result;
   }
 
   /// True when ``var`` is an alias/in-place producer chain whose reused input
@@ -526,31 +933,7 @@ class TopDownRetargeter {
   /// packed one member of the family onto another physical window, which is the
   /// mismatch this analysis exists to repair.
   bool IsInplaceChainRootedAt(const VarPtr& var, const VarPtr& root) {
-    std::set<const Var*> seen;
-    return IsInplaceChainRootedAt(var, root, seen);
-  }
-
-  bool IsInplaceChainRootedAt(const VarPtr& var, const VarPtr& root, std::set<const Var*>& seen) {
-    if (var.get() == root.get()) return true;
-    if (!seen.insert(var.get()).second) return false;
-
-    auto it = defs_.find(var);
-    if (it == defs_.end() || it->second.kind != VarDef::kAssign) return false;
-    auto assign = As<AssignStmt>(it->second.assign_stmt);
-    if (!assign) return false;
-
-    if (auto alias = AsVarLike(assign->value_)) {
-      return IsInplaceChainRootedAt(alias, root, seen);
-    }
-
-    auto call = As<Call>(assign->value_);
-    if (!call || !call->op_) return false;
-    const auto& reg = OpRegistry::GetInstance();
-    if (!reg.IsRegistered(call->op_->name_)) return false;
-    auto reuse_idx = reg.GetEntry(call->op_->name_).GetOutputReusesInputArg();
-    if (!reuse_idx.has_value() || *reuse_idx >= call->args_.size()) return false;
-    auto reused = AsVarLike(call->args_[*reuse_idx]);
-    return reused && IsInplaceChainRootedAt(reused, root, seen);
+    return ResolveInplaceRoot(var).get() == root.get();
   }
 
   /// Resolve a branch-local accumulator loop seeded by a value defined outside
@@ -563,21 +946,15 @@ class TopDownRetargeter {
     auto loop = As<ForStmt>(it->second.control_stmt);
     if (!loop || it->second.return_idx >= loop->iter_args_.size()) return std::nullopt;
 
-    const bool loop_inside_branch =
-        std::any_of(it->second.ancestors.begin(), it->second.ancestors.end(),
-                    [&](const StmtPtr& ancestor) { return ancestor.get() == branch_scope.get(); });
-    if (!loop_inside_branch) return std::nullopt;
+    if (!IsInside(loop, branch_scope)) return std::nullopt;
 
     auto init = AsVarLike(loop->iter_args_[it->second.return_idx]->initValue_);
     auto init_tile = init ? CurrentTileType(init) : nullptr;
     if (!init || !CurrentTileType(var) || !init_tile) return std::nullopt;
 
     auto init_def = defs_.find(init);
-    if (init_def != defs_.end()) {
-      const bool init_inside_branch =
-          std::any_of(init_def->second.ancestors.begin(), init_def->second.ancestors.end(),
-                      [&](const StmtPtr& ancestor) { return ancestor.get() == branch_scope.get(); });
-      if (init_inside_branch) return std::nullopt;
+    if (init_def != defs_.end() && IsInside(init_def->second.definition_stmt, branch_scope)) {
+      return std::nullopt;
     }
 
     auto body_yield = FindYieldStmt(loop->body_);
@@ -635,10 +1012,7 @@ class TopDownRetargeter {
       // When either fails, leave the phi untouched here. YieldFixup will fail
       // loudly rather than emit an unsupported Acc->Acc move.
       if (!seed_already_shared) {
-        const auto& seed_anc = seed_def->second.ancestors;
-        const bool in_branch = std::any_of(seed_anc.begin(), seed_anc.end(),
-                                           [&](const StmtPtr& a) { return a.get() == if_stmt.get(); });
-        if (!in_branch) continue;
+        if (!IsInside(seed_def->second.definition_stmt, if_stmt)) continue;
         if (!IsTargetDeadAfterDefinition(seed_def->second, target.memref,
                                          /*stop_at=*/if_stmt.get())) {
           continue;
@@ -649,10 +1023,16 @@ class TopDownRetargeter {
       // when that external value is not observed independently after the phi.
       // Otherwise retargeting the sibling seed would clobber the external value
       // on the path where the loop does not execute.
-      if (target.external_seed &&
+      if (target.reused_input &&
           HasIndependentExternalUseAfterIf(if_stmt, if_stmt->return_vars_[i], target)) {
         continue;
       }
+
+      // Coalescing one phi is atomic. Retargeting the accumulator side may
+      // recursively plan several rewrites before the seed side is inspected;
+      // a later decline must not leak that partial family into the pass-wide
+      // rewrite map.
+      RewriteTransaction transaction(*this);
 
       // Align any alias/ForReturn wrapper on the accumulator side with the
       // canonical producer target before using it as the phi's allocation.
@@ -692,6 +1072,7 @@ class TopDownRetargeter {
       // here is required by the PTOAS planner, which skips legacy MemoryReuse
       // and otherwise declares a separate head handle for the merged value.
       PlanRewrite(if_stmt->return_vars_[i], target.memref, target.memory_space);
+      transaction.Commit();
     }
   }
 
@@ -724,23 +1105,24 @@ class TopDownRetargeter {
       ~Guard() { s->erase(v); }
     } g{&visiting_, var};
 
+    RewriteTransaction transaction(*this);
+
     auto it = defs_.find(var);
     if (it == defs_.end()) return false;
     const auto& def = it->second;
 
+    bool retargeted = false;
     if (def.kind == VarDef::kAssign) {
-      return RetargetAssign(var, def, target, target_memory);
+      retargeted = RetargetAssign(var, def, target, target_memory);
+    } else if (def.kind == VarDef::kIfReturn) {
+      retargeted = RetargetIfReturn(var, def, target, target_memory);
+    } else if (def.kind == VarDef::kForReturn) {
+      retargeted = RetargetForReturn(var, def, target, target_memory);
+    } else if (def.kind == VarDef::kIterArg) {
+      retargeted = RetargetIterArg(var, def, target, target_memory);
     }
-    if (def.kind == VarDef::kIfReturn) {
-      return RetargetIfReturn(var, def, target, target_memory);
-    }
-    if (def.kind == VarDef::kForReturn) {
-      return RetargetForReturn(var, def, target, target_memory);
-    }
-    if (def.kind == VarDef::kIterArg) {
-      return RetargetIterArg(var, def, target, target_memory);
-    }
-    return false;
+    if (retargeted) transaction.Commit();
+    return retargeted;
   }
 
   /// Retype a Var defined by an AssignStmt.
@@ -762,7 +1144,7 @@ class TopDownRetargeter {
       auto alias_tile = GetTileTypeWithMemRef(alias->GetType());
       auto var_tile = GetTileTypeWithMemRef(var->GetType());
       if (!alias_tile || !var_tile ||
-          !MemRef::SameAllocation(GetDefinedMemRef(alias_tile), GetDefinedMemRef(var_tile))) {
+          !SamePhysicalWindow(GetDefinedMemRef(alias_tile), GetDefinedMemRef(var_tile))) {
         return false;
       }
       if (!TryRetargetVar(alias, target, target_memory)) return false;
@@ -822,7 +1204,7 @@ class TopDownRetargeter {
       auto input_tile = GetTileTypeWithMemRef(input_var->GetType());
       auto output_tile = GetTileTypeWithMemRef(var->GetType());
       if (!input_tile || !output_tile ||
-          !MemRef::SameAllocation(GetDefinedMemRef(input_tile), GetDefinedMemRef(output_tile))) {
+          !SamePhysicalWindow(GetDefinedMemRef(input_tile), GetDefinedMemRef(output_tile))) {
         return false;
       }
       if (!TryRetargetVar(input_var, target, target_memory)) return false;
@@ -849,7 +1231,7 @@ class TopDownRetargeter {
   /// is `target_base`.  Used to detect would-be in-place execution before
   /// we retype the output onto the same buffer.
   static bool CallReadsBase(const Call& call, const Var* target_base, size_t arg_count) {
-    SubtreeReadBaseCollector c;
+    ExprReadBaseCollector c;
     for (size_t i = 0; i < std::min(arg_count, call.args_.size()); ++i) {
       c.VisitExpr(call.args_[i]);
     }
@@ -975,25 +1357,28 @@ class TopDownRetargeter {
   /// `rewrites_` keying compares shared_ptr control blocks, not static types,
   /// so `RetypeApplier`'s ForStmt handler can find the IterArg's planned
   /// retype using the same VarPtr-keyed lookup as ordinary AssignStmt LHS
-  /// rewrites.  Note: when intermediate recursion partially populates
-  /// `rewrites_` and a later step then declines, those entries remain — same
-  /// tolerance as `RetargetIfReturn`'s branch-failure path.  This is safe
-  /// because `RetypeApplier` only acts on retypes that landed at top-level
-  /// callers (the for-stmt's iter_arg in `PropagateFromForStmt`), and the
-  /// declined upper-level returns false so the partial chain isn't surfaced
-  /// as the canonical retype.
+  /// rewrites. Every recursive retarget attempt is transactional: if any arm
+  /// declines, RollbackRewrites restores all entries written since that
+  /// attempt's checkpoint, including successful nested attempts.
   void PlanRewrite(const VarPtr& var, const MemRefPtr& target, std::optional<MemorySpace> target_memory) {
     auto new_type = CloneTypeWithMemRef(var->GetType(), target, target_memory);
+    auto previous = rewrites_.find(var);
+    rewrite_journal_.push_back(RewriteJournalEntry{
+        var, previous == rewrites_.end() ? std::nullopt : std::optional<TypePtr>(previous->second)});
     rewrites_[var] = new_type;
   }
 
-  /// Statement that defines a VarDef for branch-tail liveness purposes.
-  static StmtPtr DefinitionStmt(const VarDef& def) {
-    if (def.kind == VarDef::kAssign) return def.assign_stmt;
-    if (def.kind == VarDef::kIfReturn || def.kind == VarDef::kForReturn || def.kind == VarDef::kIterArg) {
-      return def.control_stmt;
+  void RollbackRewrites(size_t checkpoint) {
+    INTERNAL_CHECK(checkpoint <= rewrite_journal_.size()) << "Invalid rewrite transaction checkpoint";
+    while (rewrite_journal_.size() > checkpoint) {
+      auto entry = std::move(rewrite_journal_.back());
+      rewrite_journal_.pop_back();
+      if (entry.previous.has_value()) {
+        rewrites_[entry.var] = *entry.previous;
+      } else {
+        rewrites_.erase(entry.var);
+      }
     }
-    return nullptr;
   }
 
   /// True when a branch-local accumulator loop's external seed is read after
@@ -1002,86 +1387,48 @@ class TopDownRetargeter {
   /// that sibling's producer in the seed's window would be a clobber.
   bool HasIndependentExternalUseAfterIf(const IfStmtPtr& if_stmt, const VarPtr& if_return,
                                         const AccumulatorTarget& target) {
-    if (!target.external_seed) return false;
+    if (!target.reused_input) return false;
     auto return_def = defs_.find(if_return);
     if (return_def == defs_.end() || return_def->second.kind != VarDef::kIfReturn) return true;
-
-    const std::set<const Var*> external_seed{target.external_seed.get()};
-    StmtPtr child_on_path = if_stmt;
-    for (auto it = return_def->second.ancestors.rbegin(); it != return_def->second.ancestors.rend(); ++it) {
-      const auto& ancestor = *it;
-      if (auto seq = As<SeqStmts>(ancestor)) {
-        auto pos = std::find(seq->stmts_.begin(), seq->stmts_.end(), child_on_path);
-        if (pos != seq->stmts_.end()) {
-          for (++pos; pos != seq->stmts_.end(); ++pos) {
-            if (SubtreeReadsAnyVar(*pos, external_seed)) return true;
-          }
-        }
-      }
-      child_on_path = ancestor;
+    auto primary_end = stmt_end_order_.find(if_stmt.get());
+    auto root_end = stmt_end_order_.find(analysis_root_.get());
+    if (primary_end == stmt_end_order_.end() || root_end == stmt_end_order_.end()) {
+      return true;
     }
-    return false;
+    auto reads = alias_read_index_.find(ResolveAliasRoot(target.reused_input).get());
+    if (reads == alias_read_index_.end()) return false;
+    auto if_begin = stmt_order_.find(if_stmt.get());
+    if (if_begin == stmt_order_.end()) return true;
+    return reads->second.HasAfterFromHandleDefinedBefore(primary_end->second + 1, root_end->second,
+                                                         if_begin->second);
   }
 
-  /// Is target's physical window untouched between the definition and the end
-  /// of its containing body?
-  /// Also walks into nested control flow to check for reads there.
-  /// Liveness check: walks the AssignStmt's full ancestor chain from innermost
-  /// outward and, at every enclosing SeqStmts, scans the siblings that execute
-  /// after the AssignStmt for reads of `target`.  Walking continues past
-  /// IfStmt branches into the parent body so reads that appear after a nested
-  /// IfStmt (but still within the enclosing ForStmt's body) are detected.  The
-  /// walk stops at the first enclosing ForStmt — reads outside the loop body
-  /// cannot observe the retyped value, which is consumed at the loop yield.
-  ///
-  /// This check does NOT special-case IfStmt siblings: it never scans the other
-  /// branch of an enclosing IfStmt.  That is correct — branches are mutually
-  /// exclusive — but it is a conservative side effect, not modelled exclusivity.
-  ///
-  /// `stop_at`, when non-null, bounds the walk to a single enclosing scope: the
-  /// walk halts (returns "dead") upon reaching that statement instead of
-  /// continuing into its parent body.  `CoalesceAccumulatorIfPhis` passes the
-  /// enclosing `IfStmt` so the scan covers only the seed's *branch tail* (a
-  /// same-branch read between the seed producer and the yield) while ignoring
-  /// the mutually-exclusive sibling branch and the legitimate post-if phi
-  /// consumers — the reads it must *not* treat as conflicts.
+  /// Is target's physical window untouched after the definition and before the
+  /// nearest loop (or caller-supplied branch boundary) completes? The dual
+  /// lexical ordering excludes mutually exclusive sibling arms without walking
+  /// ancestor chains or rescanning subtrees.
   bool IsTargetDeadAfterDefinition(const VarDef& def, const MemRefPtr& target,
                                    const Stmt* stop_at = nullptr) {
-    if (def.ancestors.empty()) return true;
+    if (!target || !def.definition_stmt) return false;
+    auto component = memref_component_.find(target.get());
+    if (component == memref_component_.end()) return false;
+    auto accesses = physical_access_index_.find(component->second);
+    if (accesses == physical_access_index_.end()) return true;
 
-    // `child_on_path` is the direct descendant of the current ancestor that
-    // lies on the walk path toward the AssignStmt.  We update it as we step
-    // outward so that, at each SeqStmts level, we can locate it in stmts_.
-    StmtPtr child_on_path = DefinitionStmt(def);
-    if (!child_on_path) return false;
-
-    for (auto it = def.ancestors.rbegin(); it != def.ancestors.rend(); ++it) {
-      const auto& anc = *it;
-
-      if (auto seq = As<SeqStmts>(anc)) {
-        auto pos = std::find(seq->stmts_.begin(), seq->stmts_.end(), child_on_path);
-        if (pos != seq->stmts_.end()) {
-          for (++pos; pos != seq->stmts_.end(); ++pos) {
-            // A later overlapping READ observes the retyped value's bytes; a
-            // later overlapping WRITE-only def clobbers them before their
-            // consumer. Disjoint windows in one allocation are independent.
-            if (SubtreeReadsWindow(*pos, target) || SubtreeWritesWindow(*pos, target)) return false;
-          }
-        }
-      }
-
-      // Branch-scoped boundary: stop at the caller-supplied enclosing statement
-      // (e.g. the accumulator if-phi) rather than walking into its parent body.
-      if (stop_at && anc.get() == stop_at) return true;
-
-      // Stop once we've scanned the body of the enclosing ForStmt: the
-      // retyped value is consumed by that loop's yield, so anything outside
-      // the loop cannot observe it.
-      if (As<ForStmt>(anc)) return true;
-
-      child_on_path = anc;
+    const Stmt* boundary = stop_at;
+    if (!boundary && def.nearest_for) boundary = def.nearest_for.get();
+    if (!boundary && analysis_root_) boundary = analysis_root_.get();
+    auto boundary_end = stmt_end_order_.find(boundary);
+    auto reverse_definition = reverse_stmt_order_.find(def.definition_stmt.get());
+    if (boundary_end == stmt_end_order_.end() || reverse_definition == reverse_stmt_order_.end()) {
+      return false;
     }
-    return true;
+    if (def.kind == VarDef::kIfReturn || def.kind == VarDef::kForReturn) {
+      auto reverse_end = reverse_stmt_end_order_.find(def.definition_stmt.get());
+      if (reverse_end == reverse_stmt_end_order_.end()) return false;
+      return !accesses->second.HasAfter(def.order + 1, boundary_end->second, reverse_end->second);
+    }
+    return !accesses->second.HasAfter(def.order + 1, boundary_end->second, reverse_definition->second);
   }
 
   bool IsTargetDeadAtAssign(const VarDef& def, const MemRefPtr& target, const Stmt* stop_at = nullptr) {
@@ -2823,34 +3170,43 @@ StmtPtr ApplyMemRefSharing(const StmtPtr& stmt, const std::map<VarPtr, VarPtr>& 
         // Members coinciding with the representative reuse the target MemRef
         // object so plain reuse keeps MemRef identity.
         //
-        // Const-offset only. A dynamic byte offset falls back to the target as-is;
-        // this is safe for the same reason AllocateMemoryAddr falls back to the
-        // bare base for dynamic offsets — such a view reaches codegen via
-        // tile.slice → pto.subview, which re-derives its address from the slice
-        // operands, not this MemRef's byte_offset (only const reshape-of-slice
-        // chains, rebased below, depend on it).
+        // Symbolic offsets retain the exact relative-address expression:
+        // target_offset + (member_offset - representative_offset). Collapsing a
+        // dynamic member onto the target MemRef would silently select the
+        // representative's window.
         const MemRefPtr curr_memref = curr_tile_type->memref_.value_or(nullptr);
         auto rebase_memref = [&](const TileTypePtr& tile) -> std::optional<MemRefPtr> {
           if (!tile->memref_.has_value() || !curr_memref) return source_memref;
           const auto& old = tile->memref_.value();
           auto old_off = As<ConstInt>(old->byte_offset_);
           auto curr_off = As<ConstInt>(curr_memref->byte_offset_);
-          if (!old_off || !curr_off) return source_memref;
-          const int64_t rel = old_off->value_ - curr_off->value_;
-          if (rel == 0 && old->size_ == (*source_memref)->size_) return source_memref;
-          // The representative is the earliest-defined member (the whole-buffer
-          // base in the alloc→subview flow), so members sit at non-negative
-          // offsets within the target; a negative or out-of-range rel would
-          // silently rebase onto a neighbouring allocation.
-          INTERNAL_CHECK_SPAN(rel >= 0 && static_cast<uint64_t>(rel) + old->size_ <= (*source_memref)->size_,
+          if (!old_off || !curr_off) {
+            ExprPtr relative;
+            if (structural_equal(old->byte_offset_, curr_memref->byte_offset_)) {
+              relative = MakeZeroByteOffset();
+            } else if (curr_off && curr_off->value_ == 0) {
+              relative = old->byte_offset_;
+            } else {
+              relative = MakeSub(old->byte_offset_, curr_memref->byte_offset_, old->span_);
+            }
+            auto rebased_offset = AddByteOffsets((*source_memref)->byte_offset_, relative);
+            return std::make_shared<MemRef>((*source_memref)->base_, rebased_offset, old->size_, old->span_,
+                                            (*source_memref)->is_pinned_, (*source_memref)->slot_count_,
+                                            (*source_memref)->slot_index_);
+          }
+          const __int128 wide_rel = static_cast<__int128>(old_off->value_) - curr_off->value_;
+          INTERNAL_CHECK_SPAN(wide_rel >= 0 && wide_rel <= std::numeric_limits<int64_t>::max() &&
+                                  wide_rel + old->size_ <= (*source_memref)->size_,
                               old->span_)
               << "Internal error: sharing-group member offset " << old_off->value_
-              << " rebased to rel=" << rel << " size=" << old->size_ << " falls outside reuse target (size "
-              << (*source_memref)->size_ << ")";
+              << " cannot be represented inside reuse target (size " << (*source_memref)->size_ << ")";
+          const int64_t rel = static_cast<int64_t>(wide_rel);
+          if (rel == 0 && old->size_ == (*source_memref)->size_) return source_memref;
           auto rel_expr = std::make_shared<ConstInt>(rel, DataType::INDEX, Span::unknown());
           return std::make_shared<MemRef>((*source_memref)->base_,
                                           AddByteOffsets((*source_memref)->byte_offset_, rel_expr),
-                                          old->size_, old->span_);
+                                          old->size_, old->span_, (*source_memref)->is_pinned_,
+                                          (*source_memref)->slot_count_, (*source_memref)->slot_index_);
         };
 
         // Rebase the representative through the same path as every member of

--- a/src/ir/transforms/memory_reuse_pass.cpp
+++ b/src/ir/transforms/memory_reuse_pass.cpp
@@ -48,6 +48,7 @@
 #include "pypto/ir/transforms/pass_context.h"
 #include "pypto/ir/transforms/pass_properties.h"
 #include "pypto/ir/transforms/passes.h"
+#include "pypto/ir/transforms/structural_comparison.h"
 #include "pypto/ir/transforms/utils/allocation_constraint_analysis.h"
 #include "pypto/ir/transforms/utils/attrs.h"
 #include "pypto/ir/transforms/utils/lifetime_analysis.h"
@@ -77,6 +78,21 @@ class VarUseCollector : public IRVisitor {
     IRVisitor::VisitExpr_(var);
   }
 };
+
+/// True when two MemRefs denote the same codegen-visible byte window.
+/// Allocation identity alone is insufficient: one allocation can contain
+/// multiple disjoint tile windows and pipeline slots.
+bool SamePhysicalWindow(const MemRefPtr& lhs, const MemRefPtr& rhs) {
+  if (!lhs || !rhs || !MemRef::SameAllocation(lhs, rhs) || lhs->size_ != rhs->size_ ||
+      lhs->slot_count_ != rhs->slot_count_ || !structural_equal(lhs->byte_offset_, rhs->byte_offset_)) {
+    return false;
+  }
+
+  const bool lhs_has_slot = lhs->slot_index_.has_value() && *lhs->slot_index_;
+  const bool rhs_has_slot = rhs->slot_index_.has_value() && *rhs->slot_index_;
+  if (lhs_has_slot != rhs_has_slot) return false;
+  return !lhs_has_slot || structural_equal(*lhs->slot_index_, *rhs->slot_index_);
+}
 
 // ============================================================================
 // Top-down target retargeting
@@ -249,35 +265,74 @@ class SubtreeReadBaseCollector : public IRVisitor {
   }
 };
 
-inline bool SubtreeReadsBase(const StmtPtr& stmt, const Var* target_base) {
-  if (!stmt) return false;
-  SubtreeReadBaseCollector c;
-  c.VisitStmt(stmt);
-  return c.bases.count(target_base) > 0;
-}
-
-// Collects the MemRef bases WRITTEN (assignment LHS) in a subtree — the dual of
-// SubtreeReadBaseCollector, which intentionally skips write targets. Used by the
-// branch-tail liveness scan to also reject a later write-only clobber of the base
-// (a fresh def whose LHS aliases the base but that does not read it), which a
-// reads-only scan would miss.
-class SubtreeWriteBaseCollector : public IRVisitor {
+/// Collect exact SSA Vars read by a subtree. Assignment LHS definitions are
+/// excluded, matching SubtreeReadBaseCollector's read semantics.
+class SubtreeReadVarCollector : public IRVisitor {
  public:
-  std::set<const Var*> bases;
+  std::set<const Var*> vars;
+
+  void VisitExpr_(const VarPtr& var) override {
+    vars.insert(var.get());
+    IRVisitor::VisitExpr_(var);
+  }
 
   void VisitStmt_(const AssignStmtPtr& op) override {
-    if (auto tile = GetTileTypeWithMemRef(op->var_->GetType())) {
-      bases.insert(GetDefinedMemRef(tile)->base_.get());
-    }
-    IRVisitor::VisitStmt_(op);  // continue into nested stmts
+    if (op->value_) VisitExpr(op->value_);
   }
 };
 
-inline bool SubtreeWritesBase(const StmtPtr& stmt, const Var* target_base) {
-  if (!stmt) return false;
-  SubtreeWriteBaseCollector c;
-  c.VisitStmt(stmt);
-  return c.bases.count(target_base) > 0;
+bool SubtreeReadsAnyVar(const StmtPtr& stmt, const std::set<const Var*>& candidates) {
+  if (!stmt || candidates.empty()) return false;
+  SubtreeReadVarCollector collector;
+  collector.VisitStmt(stmt);
+  return std::any_of(candidates.begin(), candidates.end(),
+                     [&](const Var* var) { return collector.vars.count(var) > 0; });
+}
+
+/// Collect codegen-visible MemRef windows read by a subtree.
+class SubtreeReadWindowCollector : public IRVisitor {
+ public:
+  std::vector<MemRefPtr> windows;
+
+  void VisitExpr_(const VarPtr& var) override {
+    if (auto tile = GetTileTypeWithMemRef(var->GetType())) {
+      windows.push_back(GetDefinedMemRef(tile));
+    }
+    IRVisitor::VisitExpr_(var);
+  }
+
+  void VisitStmt_(const AssignStmtPtr& op) override {
+    if (op->value_) VisitExpr(op->value_);
+  }
+};
+
+bool SubtreeReadsWindow(const StmtPtr& stmt, const MemRefPtr& target) {
+  if (!stmt || !target) return false;
+  SubtreeReadWindowCollector collector;
+  collector.VisitStmt(stmt);
+  return std::any_of(collector.windows.begin(), collector.windows.end(),
+                     [&](const MemRefPtr& window) { return MemRef::MayAlias(window, target); });
+}
+
+/// Collect codegen-visible MemRef windows written by assignment LHSs.
+class SubtreeWriteWindowCollector : public IRVisitor {
+ public:
+  std::vector<MemRefPtr> windows;
+
+  void VisitStmt_(const AssignStmtPtr& op) override {
+    if (auto tile = GetTileTypeWithMemRef(op->var_->GetType())) {
+      windows.push_back(GetDefinedMemRef(tile));
+    }
+    IRVisitor::VisitStmt_(op);
+  }
+};
+
+bool SubtreeWritesWindow(const StmtPtr& stmt, const MemRefPtr& target) {
+  if (!stmt || !target) return false;
+  SubtreeWriteWindowCollector collector;
+  collector.VisitStmt(stmt);
+  return std::any_of(collector.windows.begin(), collector.windows.end(),
+                     [&](const MemRefPtr& window) { return MemRef::MayAlias(window, target); });
 }
 
 bool IsA5Target() {
@@ -323,11 +378,7 @@ class TopDownRetargeter {
   ///
   /// Retiring this repair is therefore a *long-horizon* intent, not a near-term
   /// plan.  It would need the source-level migration to land first, and it is
-  /// worth doing eventually because the repair is not sound in general: the
-  /// branch-exclusivity argument below does not cover a post-if read of the
-  /// accumulator that bypasses the phi, where the seed path's data is returned
-  /// with no diagnostic at any layer.  Until then, prefer `init_cond` in new
-  /// code and leave existing peels alone.
+  /// Until then, prefer `init_cond` in new code and leave existing peels alone.
   ///
   /// LowerPipelineLoops peels a stage=2 K-loop into an epilogue IfStmt whose live
   /// branch is an in-place accumulator (matmul_acc, output aliasing input on the
@@ -345,10 +396,13 @@ class TopDownRetargeter {
   /// verifies the two preconditions branch exclusivity actually needs: (a) the
   /// seed producer is lexically inside the branch, and (b) a branch-scoped
   /// liveness scan (`IsTargetDeadAtAssign(..., stop_at=if)`) finds no same-branch
-  /// tail read of the accumulator buffer.  When either fails, that phi is left to
-  /// YieldFixup instead of being coalesced.  Returns the rewrite map (apply via
-  /// RetypeApplier).  A needed-but-declined retarget (after the preconditions
-  /// hold) is a hard error — no legal Acc->Acc move exists to fall back to.
+  /// tail read of the accumulator buffer.  For a branch-local loop seeded outside
+  /// the IfStmt, an additional post-if scan proves that no external handle to the
+  /// accumulator window remains observable independently of the phi.  When any
+  /// condition fails, that phi is left to YieldFixup instead of being coalesced.
+  /// Returns the rewrite map (apply via RetypeApplier).  A needed-but-declined
+  /// retarget (after the preconditions hold) is a hard error — no legal Acc->Acc
+  /// move exists to fall back to.
   std::map<VarPtr, TypePtr> CoalesceAccumulatorIfPhis(const StmtPtr& func_body) {
     DefMapVisitor def_v;
     def_v.Run(func_body);
@@ -422,53 +476,71 @@ class TopDownRetargeter {
     }
   }
 
-  // True when `var` is produced by an in-place accumulator op: a Call whose op
-  // reuses input `k` (matmul_acc) and whose output MemRef aliases input `k`'s —
-  // i.e. mad_acc's shared %dst.  This branch's buffer is the one we keep; the
-  // other branch's producer is the seed we retarget onto it.
-  bool IsInplaceAccumulatorProducer(const VarPtr& var) {
+  struct AccumulatorTarget {
+    MemRefPtr memref;
+    std::optional<MemorySpace> memory_space;
+    // Non-null only for a branch-local loop whose accumulator is seeded by a
+    // value defined outside the enclosing IfStmt.
+    VarPtr external_seed;
+  };
+
+  // Resolve the canonical allocation of an in-place accumulator producer. A
+  // bare SSA alias may still carry a stale type after a nested child rewrite,
+  // so return the underlying producer's target rather than a boolean that would
+  // make the caller accidentally select the alias's stale MemRef.
+  std::optional<AccumulatorTarget> FindInplaceAccumulatorProducer(const VarPtr& var) {
     std::set<const Var*> seen;
-    return IsInplaceAccumulatorProducer(var, seen);
+    return FindInplaceAccumulatorProducer(var, seen);
   }
 
-  bool IsInplaceAccumulatorProducer(const VarPtr& var, std::set<const Var*>& seen) {
-    if (!seen.insert(var.get()).second) return false;
+  std::optional<AccumulatorTarget> FindInplaceAccumulatorProducer(const VarPtr& var,
+                                                                  std::set<const Var*>& seen) {
+    if (!seen.insert(var.get()).second) return std::nullopt;
     auto it = defs_.find(var);
-    if (it == defs_.end() || it->second.kind != VarDef::kAssign) return false;
+    if (it == defs_.end() || it->second.kind != VarDef::kAssign) return std::nullopt;
     auto assign = As<AssignStmt>(it->second.assign_stmt);
-    if (!assign) return false;
+    if (!assign) return std::nullopt;
     auto call = As<Call>(assign->value_);
     if (!call) {
       auto alias = AsVarLike(assign->value_);
-      return alias && IsInplaceAccumulatorProducer(alias, seen);
+      return alias ? FindInplaceAccumulatorProducer(alias, seen) : std::nullopt;
     }
-    if (!call->op_) return false;
+    if (!call->op_) return std::nullopt;
     const auto& reg = OpRegistry::GetInstance();
-    if (!reg.IsRegistered(call->op_->name_)) return false;
+    if (!reg.IsRegistered(call->op_->name_)) return std::nullopt;
     auto reuse_idx = reg.GetEntry(call->op_->name_).GetOutputReusesInputArg();
-    if (!reuse_idx.has_value() || *reuse_idx >= call->args_.size()) return false;
+    if (!reuse_idx.has_value() || *reuse_idx >= call->args_.size()) return std::nullopt;
     auto in_var = AsVarLike(call->args_[*reuse_idx]);
-    if (!in_var) return false;
-    auto out_tile = GetTileTypeWithMemRef(var->GetType());
-    auto in_tile = GetTileTypeWithMemRef(in_var->GetType());
-    if (!out_tile || !in_tile) return false;
-    return MemRef::SameAllocation(GetDefinedMemRef(out_tile), GetDefinedMemRef(in_tile));
+    if (!in_var) return std::nullopt;
+    auto in_tile = CurrentTileType(in_var);
+    if (!in_tile) return std::nullopt;
+    // The registered reuse input is authoritative. Lowering may have left the
+    // Call result typed on an older allocation; TryRetargetVar below repairs the
+    // result onto this canonical input allocation before the phi is rewritten.
+    return AccumulatorTarget{GetDefinedMemRef(in_tile), in_tile->GetMemorySpace(), nullptr};
   }
 
-  /// Return whether ``var`` is a branch-local accumulator loop seeded by a
-  /// value defined outside ``branch_scope``.
-  bool IsExternallySeededAccumulatorLoop(const VarPtr& var, const IfStmtPtr& branch_scope) {
+  /// Resolve a branch-local accumulator loop seeded by a value defined outside
+  /// ``branch_scope``. Both locality halves are required: the loop itself must
+  /// be inside the branch and its seed must be outside it.
+  std::optional<AccumulatorTarget> FindExternallySeededAccumulatorLoop(const VarPtr& var,
+                                                                       const IfStmtPtr& branch_scope) {
     auto it = defs_.find(var);
-    if (it == defs_.end() || it->second.kind != VarDef::kForReturn) return false;
+    if (it == defs_.end() || it->second.kind != VarDef::kForReturn) return std::nullopt;
     auto loop = As<ForStmt>(it->second.control_stmt);
-    if (!loop || it->second.return_idx >= loop->iter_args_.size()) return false;
+    if (!loop || it->second.return_idx >= loop->iter_args_.size()) return std::nullopt;
+
+    const bool loop_inside_branch =
+        std::any_of(it->second.ancestors.begin(), it->second.ancestors.end(),
+                    [&](const StmtPtr& ancestor) { return ancestor.get() == branch_scope.get(); });
+    if (!loop_inside_branch) return std::nullopt;
 
     auto init = AsVarLike(loop->iter_args_[it->second.return_idx]->initValue_);
-    auto result_tile = GetTileTypeWithMemRef(var->GetType());
-    auto init_tile = init ? GetTileTypeWithMemRef(init->GetType()) : nullptr;
+    auto result_tile = CurrentTileType(var);
+    auto init_tile = init ? CurrentTileType(init) : nullptr;
     if (!init || !result_tile || !init_tile ||
-        !MemRef::SameAllocation(GetDefinedMemRef(result_tile), GetDefinedMemRef(init_tile))) {
-      return false;
+        !SamePhysicalWindow(GetDefinedMemRef(result_tile), GetDefinedMemRef(init_tile))) {
+      return std::nullopt;
     }
 
     auto init_def = defs_.find(init);
@@ -476,13 +548,16 @@ class TopDownRetargeter {
       const bool init_inside_branch =
           std::any_of(init_def->second.ancestors.begin(), init_def->second.ancestors.end(),
                       [&](const StmtPtr& ancestor) { return ancestor.get() == branch_scope.get(); });
-      if (init_inside_branch) return false;
+      if (init_inside_branch) return std::nullopt;
     }
 
     auto body_yield = FindYieldStmt(loop->body_);
-    if (!body_yield || it->second.return_idx >= body_yield->value_.size()) return false;
+    if (!body_yield || it->second.return_idx >= body_yield->value_.size()) return std::nullopt;
     auto yielded = AsVarLike(body_yield->value_[it->second.return_idx]);
-    return yielded && CurrentBase(yielded) == GetDefinedMemRef(init_tile)->base_.get();
+    if (!yielded || !SamePhysicalWindow(CurrentMemRef(yielded), GetDefinedMemRef(init_tile))) {
+      return std::nullopt;
+    }
+    return AccumulatorTarget{GetDefinedMemRef(init_tile), init_tile->GetMemorySpace(), init};
   }
 
   // For an IfStmt whose branches yield an in-place accumulator on one side and a
@@ -501,25 +576,25 @@ class TopDownRetargeter {
       auto else_var = AsVarLike(else_yield->value_[i]);
       if (!then_var || !else_var) continue;
 
-      const bool then_acc =
-          IsInplaceAccumulatorProducer(then_var) || IsExternallySeededAccumulatorLoop(then_var, if_stmt);
-      const bool else_acc =
-          IsInplaceAccumulatorProducer(else_var) || IsExternallySeededAccumulatorLoop(else_var, if_stmt);
-      if (then_acc == else_acc) continue;  // need exactly one in-place accumulator
+      auto then_target = FindInplaceAccumulatorProducer(then_var);
+      if (!then_target) then_target = FindExternallySeededAccumulatorLoop(then_var, if_stmt);
+      auto else_target = FindInplaceAccumulatorProducer(else_var);
+      if (!else_target) else_target = FindExternallySeededAccumulatorLoop(else_var, if_stmt);
+      if (then_target.has_value() == else_target.has_value()) continue;  // need exactly one accumulator
 
+      const bool then_acc = then_target.has_value();
       const VarPtr& acc_var = then_acc ? then_var : else_var;
       const VarPtr& seed_var = then_acc ? else_var : then_var;
+      const AccumulatorTarget& target = then_acc ? *then_target : *else_target;
 
-      auto acc_tile = GetTileTypeWithMemRef(acc_var->GetType());
-      auto seed_tile = GetTileTypeWithMemRef(seed_var->GetType());
-      if (!acc_tile || !seed_tile) continue;
-      if (acc_tile->GetMemorySpace() != MemorySpace::Acc) continue;  // Acc-only (no legal move)
+      auto seed_tile = CurrentTileType(seed_var);
+      if (!seed_tile) continue;
+      if (target.memory_space != MemorySpace::Acc) continue;  // Acc-only (no legal move)
 
-      auto acc_memref = GetDefinedMemRef(acc_tile);
-      if (MemRef::SameAllocation(acc_memref, GetDefinedMemRef(seed_tile))) continue;  // already shared
+      const bool seed_already_shared = SamePhysicalWindow(target.memref, GetDefinedMemRef(seed_tile));
 
       auto seed_def = defs_.find(seed_var);
-      if (seed_def == defs_.end()) continue;
+      if (!seed_already_shared && seed_def == defs_.end()) continue;
 
       // The `check_liveness=false` bypass below is only sound when branch
       // exclusivity actually applies, which requires BOTH:
@@ -531,49 +606,81 @@ class TopDownRetargeter {
       //      same-branch tail read between the seed producer and the yield).
       // When either fails, leave the phi untouched here. YieldFixup will fail
       // loudly rather than emit an unsupported Acc->Acc move.
-      const auto& seed_anc = seed_def->second.ancestors;
-      const bool in_branch = std::any_of(seed_anc.begin(), seed_anc.end(),
-                                         [&](const StmtPtr& a) { return a.get() == if_stmt.get(); });
-      if (!in_branch) continue;
-      if (!IsTargetDeadAfterDefinition(seed_def->second, acc_memref->base_.get(),
-                                       /*stop_at=*/if_stmt.get())) {
+      if (!seed_already_shared) {
+        const auto& seed_anc = seed_def->second.ancestors;
+        const bool in_branch = std::any_of(seed_anc.begin(), seed_anc.end(),
+                                           [&](const StmtPtr& a) { return a.get() == if_stmt.get(); });
+        if (!in_branch) continue;
+        if (!IsTargetDeadAfterDefinition(seed_def->second, target.memref,
+                                         /*stop_at=*/if_stmt.get())) {
+          continue;
+        }
+      }
+
+      // A branch-local loop can reuse a seed defined outside the IfStmt only
+      // when that external value is not observed independently after the phi.
+      // Otherwise retargeting the sibling seed would clobber the external value
+      // on the path where the loop does not execute.
+      if (target.external_seed &&
+          HasIndependentExternalUseAfterIf(if_stmt, if_stmt->return_vars_[i], target)) {
         continue;
       }
 
-      // Now safe: (a)+(b) plus exclusivity cover every read of acc_memref, so we
+      // Align any alias/ForReturn wrapper on the accumulator side with the
+      // canonical producer target before using it as the phi's allocation.
+      INTERNAL_CHECK_SPAN(TryRetargetVar(acc_var, target.memref, target.memory_space), acc_var->span_)
+          << "Internal error: cannot align the accumulator branch with its canonical L0C allocation";
+
+      // Now safe: (a)+(b) plus exclusivity cover every read of the target allocation, so we
       // bypass the global liveness (which would false-decline on the legitimate
       // post-if phi consumer). A remaining decline is a genuine "cannot coalesce
       // this Acc phi" — fail loud, since no legal Acc->Acc move exists.
-      bool ok = false;
-      if (seed_def->second.kind == VarDef::kAssign) {
-        auto seed_assign = As<AssignStmt>(seed_def->second.assign_stmt);
-        if (!seed_assign) continue;
-        if (As<Call>(seed_assign->value_)) {
-          ok = RetargetAssign(seed_var, seed_def->second, acc_memref, acc_tile->GetMemorySpace(),
-                              /*check_liveness=*/false);
-        } else if (AsVarLike(seed_assign->value_)) {
-          ok = TryRetargetVar(seed_var, acc_memref, acc_tile->GetMemorySpace());
+      bool ok = seed_already_shared;
+      if (!seed_already_shared) {
+        if (seed_def->second.kind == VarDef::kAssign) {
+          auto seed_assign = As<AssignStmt>(seed_def->second.assign_stmt);
+          if (!seed_assign) continue;
+          if (As<Call>(seed_assign->value_)) {
+            ok = RetargetAssign(seed_var, seed_def->second, target.memref, target.memory_space,
+                                /*check_liveness=*/false);
+          } else if (AsVarLike(seed_assign->value_)) {
+            ok = TryRetargetVar(seed_var, target.memref, target.memory_space);
+          } else {
+            continue;
+          }
+        } else if (seed_def->second.kind == VarDef::kForReturn) {
+          ok = TryRetargetVar(seed_var, target.memref, target.memory_space);
         } else {
           continue;
         }
-      } else if (seed_def->second.kind == VarDef::kForReturn) {
-        ok = TryRetargetVar(seed_var, acc_memref, acc_tile->GetMemorySpace());
-      } else {
-        continue;
       }
       INTERNAL_CHECK_SPAN(ok, seed_var->span_)
           << "Internal error: cannot coalesce L0C accumulator across a peeled if-phi — seed producer '"
           << seed_var->name_hint_
           << "' refused retarget onto the accumulator buffer, which would force an illegal "
              "Acc->Acc tile.move.";
+
+      // The phi itself is part of the semantic accumulator family. Pinning it
+      // here is required by the PTOAS planner, which skips legacy MemoryReuse
+      // and otherwise declares a separate head handle for the merged value.
+      PlanRewrite(if_stmt->return_vars_[i], target.memref, target.memory_space);
     }
+  }
+
+  TileTypePtr CurrentTileType(const VarPtr& var) {
+    auto it = rewrites_.find(var);
+    auto type = (it != rewrites_.end()) ? it->second : var->GetType();
+    return GetTileTypeWithMemRef(type);
+  }
+
+  MemRefPtr CurrentMemRef(const VarPtr& var) {
+    auto tile = CurrentTileType(var);
+    return tile ? GetDefinedMemRef(tile) : nullptr;
   }
 
   /// Current (possibly-rewritten) MemRef base of `var`.
   const Var* CurrentBase(const VarPtr& var) {
-    auto it = rewrites_.find(var);
-    auto type = (it != rewrites_.end()) ? it->second : var->GetType();
-    auto tile = GetTileTypeWithMemRef(type);
+    auto tile = CurrentTileType(var);
     if (!tile) return nullptr;
     return GetDefinedMemRef(tile)->base_.get();
   }
@@ -581,8 +688,8 @@ class TopDownRetargeter {
   /// Attempts to rewrite `var`'s MemRef to `target` by walking its producer chain.
   /// Returns true if var already has target MemRef or a rewrite was planned.
   bool TryRetargetVar(const VarPtr& var, const MemRefPtr& target, std::optional<MemorySpace> target_memory) {
-    if (CurrentBase(var) == target->base_.get()) return true;  // already aligned
-    if (!visiting_.insert(var).second) return false;           // cycle
+    if (SamePhysicalWindow(CurrentMemRef(var), target)) return true;  // already aligned
+    if (!visiting_.insert(var).second) return false;                  // cycle
     struct Guard {
       std::set<VarPtr>* s;
       VarPtr v;
@@ -705,7 +812,7 @@ class TopDownRetargeter {
 
     // Unconstrained: check liveness, then plan retype.  (Skipped for if-phi
     // branch coalescing, where branch exclusivity is a stronger guarantee.)
-    if (check_liveness && !IsTargetDeadAtAssign(def, target->base_.get())) return false;
+    if (check_liveness && !IsTargetDeadAtAssign(def, target)) return false;
     PlanRewrite(var, target, target_memory);
     return true;
   }
@@ -861,11 +968,39 @@ class TopDownRetargeter {
     return nullptr;
   }
 
-  /// Is target's base Ptr unread between the definition and the end of its containing body?
+  /// True when a branch-local accumulator loop's external seed is read after
+  /// the enclosing IfStmt through a path other than the IfStmt return value.
+  /// Such a read observes the pre-loop value on the sibling path, so placing
+  /// that sibling's producer in the seed's window would be a clobber.
+  bool HasIndependentExternalUseAfterIf(const IfStmtPtr& if_stmt, const VarPtr& if_return,
+                                        const AccumulatorTarget& target) {
+    if (!target.external_seed) return false;
+    auto return_def = defs_.find(if_return);
+    if (return_def == defs_.end() || return_def->second.kind != VarDef::kIfReturn) return true;
+
+    const std::set<const Var*> external_seed{target.external_seed.get()};
+    StmtPtr child_on_path = if_stmt;
+    for (auto it = return_def->second.ancestors.rbegin(); it != return_def->second.ancestors.rend(); ++it) {
+      const auto& ancestor = *it;
+      if (auto seq = As<SeqStmts>(ancestor)) {
+        auto pos = std::find(seq->stmts_.begin(), seq->stmts_.end(), child_on_path);
+        if (pos != seq->stmts_.end()) {
+          for (++pos; pos != seq->stmts_.end(); ++pos) {
+            if (SubtreeReadsAnyVar(*pos, external_seed)) return true;
+          }
+        }
+      }
+      child_on_path = ancestor;
+    }
+    return false;
+  }
+
+  /// Is target's physical window untouched between the definition and the end
+  /// of its containing body?
   /// Also walks into nested control flow to check for reads there.
   /// Liveness check: walks the AssignStmt's full ancestor chain from innermost
   /// outward and, at every enclosing SeqStmts, scans the siblings that execute
-  /// after the AssignStmt for reads of `target_base`.  Walking continues past
+  /// after the AssignStmt for reads of `target`.  Walking continues past
   /// IfStmt branches into the parent body so reads that appear after a nested
   /// IfStmt (but still within the enclosing ForStmt's body) are detected.  The
   /// walk stops at the first enclosing ForStmt — reads outside the loop body
@@ -882,7 +1017,8 @@ class TopDownRetargeter {
   /// same-branch read between the seed producer and the yield) while ignoring
   /// the mutually-exclusive sibling branch and the legitimate post-if phi
   /// consumers — the reads it must *not* treat as conflicts.
-  bool IsTargetDeadAfterDefinition(const VarDef& def, const Var* target_base, const Stmt* stop_at = nullptr) {
+  bool IsTargetDeadAfterDefinition(const VarDef& def, const MemRefPtr& target,
+                                   const Stmt* stop_at = nullptr) {
     if (def.ancestors.empty()) return true;
 
     // `child_on_path` is the direct descendant of the current ancestor that
@@ -898,10 +1034,10 @@ class TopDownRetargeter {
         auto pos = std::find(seq->stmts_.begin(), seq->stmts_.end(), child_on_path);
         if (pos != seq->stmts_.end()) {
           for (++pos; pos != seq->stmts_.end(); ++pos) {
-            // A later READ observes the retyped value's buffer; a later WRITE-only
-            // def clobbers it before its consumer. Reject both (SubtreeReadsBase
-            // alone misses the write-only clobber — the seed-branch tail case).
-            if (SubtreeReadsBase(*pos, target_base) || SubtreeWritesBase(*pos, target_base)) return false;
+            // A later overlapping READ observes the retyped value's bytes; a
+            // later overlapping WRITE-only def clobbers them before their
+            // consumer. Disjoint windows in one allocation are independent.
+            if (SubtreeReadsWindow(*pos, target) || SubtreeWritesWindow(*pos, target)) return false;
           }
         }
       }
@@ -920,10 +1056,10 @@ class TopDownRetargeter {
     return true;
   }
 
-  bool IsTargetDeadAtAssign(const VarDef& def, const Var* target_base, const Stmt* stop_at = nullptr) {
+  bool IsTargetDeadAtAssign(const VarDef& def, const MemRefPtr& target, const Stmt* stop_at = nullptr) {
     INTERNAL_CHECK(def.kind == VarDef::kAssign)
         << "Internal error: IsTargetDeadAtAssign requires an assignment definition";
-    return IsTargetDeadAfterDefinition(def, target_base, stop_at);
+    return IsTargetDeadAfterDefinition(def, target, stop_at);
   }
 };
 
@@ -3725,27 +3861,27 @@ class NormalizeIdentityCopyBuffersMutator : public IRMutator {
       auto lhs_tile = new_src ? GetTileTypeWithMemRef(op->var_->GetType()) : nullptr;
       auto rhs_tile = new_src ? GetTileTypeWithMemRef(new_src->GetType()) : nullptr;
       if (lhs_tile && rhs_tile &&
-          !MemRef::SameAllocation(GetDefinedMemRef(lhs_tile), GetDefinedMemRef(rhs_tile))) {
+          !SamePhysicalWindow(GetDefinedMemRef(lhs_tile), GetDefinedMemRef(rhs_tile))) {
         auto new_lhs = std::make_shared<Var>(op->var_->name_hint_, new_src->GetType(), op->var_->span_);
         subst_[op->var_] = new_lhs;
         return std::make_shared<AssignStmt>(new_lhs, new_src, op->span_);
       }
     }
     // An in-place accumulator Call (GetOutputReusesInputArg, e.g. tile.matmul_acc)
-    // is not a bare rename, but its output MemRef aliases its reused input's. When
-    // the coalescing retargeted that input onto another buffer (its bare-copy chain
-    // retyped in subst_ above), the Call's output must follow — else it is left
-    // declared on the now-orphaned original buffer that nothing writes, and
-    // downstream reads of this output address a stale, never-written buffer (the
-    // non-divisor K-peel matmul_acc tail after CoalesceAccumulatorIfPhis).
+    // is not a bare rename, but its output MemRef must alias its reused input's.
+    // Retargeting and pipeline/control-flow lowering can expose a stale output
+    // type; normalize it even when the input itself was not substituted during
+    // this traversal (the non-divisor K-peel matmul_acc tail is one example).
     if (auto reanchored = ReanchorInplaceOutput(op)) return reanchored;
     return IRMutator::VisitStmt_(op);
   }
 
  private:
-  /// Re-anchor an in-place op's output onto its reused input's new buffer when the
-  /// input was retargeted, preserving the output's tile metadata (shape/dtype/space)
-  /// and swapping only the MemRef.  Returns nullptr when not applicable.
+  /// Re-anchor an in-place op's output onto its reused input's buffer, preserving
+  /// the output's tile metadata (shape/dtype/space) and swapping only the MemRef.
+  /// This also repairs a producer/output mismatch introduced by control-flow or
+  /// pipeline lowering even when the input itself was not substituted in this
+  /// traversal. Returns nullptr when the allocation already agrees.
   StmtPtr ReanchorInplaceOutput(const AssignStmtPtr& op) {
     auto call = As<Call>(op->value_);
     if (!call) return nullptr;
@@ -3755,15 +3891,12 @@ class NormalizeIdentityCopyBuffersMutator : public IRMutator {
     if (!reuse_idx.has_value() || *reuse_idx >= call->args_.size()) return nullptr;
     auto in_var = AsVarLike(call->args_[*reuse_idx]);
     if (!in_var) return nullptr;
-    auto new_in = AsVarLike(VisitExpr(in_var));                   // follow prior subst_ renames
-    if (!new_in || new_in.get() == in_var.get()) return nullptr;  // input not moved
+    auto new_in = AsVarLike(VisitExpr(in_var));  // follow prior subst_ renames
+    if (!new_in) return nullptr;
     auto lhs_tile = GetTileTypeWithMemRef(op->var_->GetType());
-    auto in_old_tile = GetTileTypeWithMemRef(in_var->GetType());
     auto in_new_tile = GetTileTypeWithMemRef(new_in->GetType());
-    if (!lhs_tile || !in_old_tile || !in_new_tile) return nullptr;
-    // Fire only when the output aliased the input in-place AND the input moved.
-    if (!MemRef::SameAllocation(GetDefinedMemRef(lhs_tile), GetDefinedMemRef(in_old_tile)) ||
-        MemRef::SameAllocation(GetDefinedMemRef(in_new_tile), GetDefinedMemRef(in_old_tile))) {
+    if (!lhs_tile || !in_new_tile ||
+        SamePhysicalWindow(GetDefinedMemRef(lhs_tile), GetDefinedMemRef(in_new_tile))) {
       return nullptr;
     }
     auto new_type = CloneTypeWithMemRef(op->var_->GetType(), GetDefinedMemRef(in_new_tile),
@@ -3824,6 +3957,12 @@ FunctionPtr TransformMaterializeSemanticAliases(const FunctionPtr& func) {
       new_body = applier.VisitStmt(new_body);
     }
   }
+  // Accumulator-phi retargeting can expose bare SSA aliases or in-place outputs
+  // whose types still name the pre-retarget allocation. Those are semantic
+  // aliases too, so normalize them before any planner observes lifetimes or
+  // emits handles. Planner-specific repetitions remain below because later
+  // YieldFixup/reuse steps can create fresh mismatches.
+  new_body = NormalizeIdentityCopyBuffersMutator().VisitStmt(new_body);
 
   // Under memory_planner=PtoAS or DsaRP the whole MemoryReuse pass is skipped.
   // DsaRP must therefore run the remaining correctness normalizations from
@@ -3840,10 +3979,9 @@ FunctionPtr TransformMaterializeSemanticAliases(const FunctionPtr& func) {
   // decisions, which can themselves create fresh mismatches.
   //
   // PTOAS needs only the ForStmt YieldFixup half: addr-less codegen already
-  // re-points a branch-local producer at the if-phi handle. DSA-RP emits
-  // explicit addresses, so after the common accumulator-phi coalescing above it
-  // materializes both IfStmt and ForStmt fixups and finally repairs bare-Var
-  // identity copies before lifetime analysis and placement.
+  // re-points a branch-local producer at the if-phi handle. DSA-RP instead
+  // materializes both IfStmt and ForStmt fixups and repairs bare-Var identity
+  // copies before lifetime analysis and placement.
   const auto* ctx = PassContext::Current();
   if (ctx != nullptr && ctx->GetMemoryPlanner() == MemoryPlanner::DsaRP) {
     // Identity-copy normalization brackets YieldFixup on both sides; see the

--- a/src/ir/transforms/memory_reuse_pass.cpp
+++ b/src/ir/transforms/memory_reuse_pass.cpp
@@ -122,9 +122,9 @@ struct VarDef {
   size_t return_idx = 0;  // index into return_vars_ (for kIfReturn/kForReturn)
   IterArgPtr iter_arg;    // for kIterArg
   // Full chain of enclosing stmts from outermost to innermost (does *not*
-  // include the assign_stmt itself).  Populated for kAssign defs and used
-  // by the liveness check to walk up through nested IfStmt branches to the
-  // enclosing ForStmt's body.
+  // include the defining assignment/control statement). Used by the liveness
+  // check to walk up through nested IfStmt branches to the enclosing ForStmt's
+  // body.
   std::vector<StmtPtr> ancestors;
 };
 
@@ -170,6 +170,7 @@ class DefMapVisitor : public IRVisitor {
       d.kind = VarDef::kIfReturn;
       d.control_stmt = op;
       d.return_idx = i;
+      d.ancestors = ancestor_stack_;
       defs[rv] = d;
     }
     ancestor_stack_.push_back(op);
@@ -187,6 +188,7 @@ class DefMapVisitor : public IRVisitor {
       d.control_stmt = op;
       d.return_idx = i;
       d.iter_arg = ia;
+      d.ancestors = ancestor_stack_;
       defs[std::static_pointer_cast<const Var>(ia)] = d;
     }
     for (size_t i = 0; i < op->return_vars_.size(); ++i) {
@@ -196,6 +198,7 @@ class DefMapVisitor : public IRVisitor {
       d.kind = VarDef::kForReturn;
       d.control_stmt = op;
       d.return_idx = i;
+      d.ancestors = ancestor_stack_;
       defs[rv] = d;
     }
     ancestor_stack_.push_back(op);
@@ -408,9 +411,12 @@ class TopDownRetargeter {
     } else if (auto for_stmt = As<ForStmt>(stmt)) {
       VisitIfPhisForAccumulator(for_stmt->body_);
     } else if (auto if_stmt = As<IfStmt>(stmt)) {
-      TryCoalesceAccIfPhi(if_stmt);
+      // Coalesce nested accumulator phis before their enclosing K-window phi.
+      // Otherwise a later child rewrite can overwrite the outer target and
+      // reintroduce a divergent L0C allocation.
       VisitIfPhisForAccumulator(if_stmt->then_body_);
       if (if_stmt->else_body_.has_value()) VisitIfPhisForAccumulator(if_stmt->else_body_.value());
+      TryCoalesceAccIfPhi(if_stmt);
     } else if (auto scope = As<ScopeStmt>(stmt)) {
       VisitIfPhisForAccumulator(scope->body_);
     }
@@ -421,12 +427,22 @@ class TopDownRetargeter {
   // i.e. mad_acc's shared %dst.  This branch's buffer is the one we keep; the
   // other branch's producer is the seed we retarget onto it.
   bool IsInplaceAccumulatorProducer(const VarPtr& var) {
+    std::set<const Var*> seen;
+    return IsInplaceAccumulatorProducer(var, seen);
+  }
+
+  bool IsInplaceAccumulatorProducer(const VarPtr& var, std::set<const Var*>& seen) {
+    if (!seen.insert(var.get()).second) return false;
     auto it = defs_.find(var);
     if (it == defs_.end() || it->second.kind != VarDef::kAssign) return false;
     auto assign = As<AssignStmt>(it->second.assign_stmt);
     if (!assign) return false;
     auto call = As<Call>(assign->value_);
-    if (!call || !call->op_) return false;
+    if (!call) {
+      auto alias = AsVarLike(assign->value_);
+      return alias && IsInplaceAccumulatorProducer(alias, seen);
+    }
+    if (!call->op_) return false;
     const auto& reg = OpRegistry::GetInstance();
     if (!reg.IsRegistered(call->op_->name_)) return false;
     auto reuse_idx = reg.GetEntry(call->op_->name_).GetOutputReusesInputArg();
@@ -437,6 +453,36 @@ class TopDownRetargeter {
     auto in_tile = GetTileTypeWithMemRef(in_var->GetType());
     if (!out_tile || !in_tile) return false;
     return MemRef::SameAllocation(GetDefinedMemRef(out_tile), GetDefinedMemRef(in_tile));
+  }
+
+  /// Return whether ``var`` is a branch-local accumulator loop seeded by a
+  /// value defined outside ``branch_scope``.
+  bool IsExternallySeededAccumulatorLoop(const VarPtr& var, const IfStmtPtr& branch_scope) {
+    auto it = defs_.find(var);
+    if (it == defs_.end() || it->second.kind != VarDef::kForReturn) return false;
+    auto loop = As<ForStmt>(it->second.control_stmt);
+    if (!loop || it->second.return_idx >= loop->iter_args_.size()) return false;
+
+    auto init = AsVarLike(loop->iter_args_[it->second.return_idx]->initValue_);
+    auto result_tile = GetTileTypeWithMemRef(var->GetType());
+    auto init_tile = init ? GetTileTypeWithMemRef(init->GetType()) : nullptr;
+    if (!init || !result_tile || !init_tile ||
+        !MemRef::SameAllocation(GetDefinedMemRef(result_tile), GetDefinedMemRef(init_tile))) {
+      return false;
+    }
+
+    auto init_def = defs_.find(init);
+    if (init_def != defs_.end()) {
+      const bool init_inside_branch =
+          std::any_of(init_def->second.ancestors.begin(), init_def->second.ancestors.end(),
+                      [&](const StmtPtr& ancestor) { return ancestor.get() == branch_scope.get(); });
+      if (init_inside_branch) return false;
+    }
+
+    auto body_yield = FindYieldStmt(loop->body_);
+    if (!body_yield || it->second.return_idx >= body_yield->value_.size()) return false;
+    auto yielded = AsVarLike(body_yield->value_[it->second.return_idx]);
+    return yielded && CurrentBase(yielded) == GetDefinedMemRef(init_tile)->base_.get();
   }
 
   // For an IfStmt whose branches yield an in-place accumulator on one side and a
@@ -455,8 +501,10 @@ class TopDownRetargeter {
       auto else_var = AsVarLike(else_yield->value_[i]);
       if (!then_var || !else_var) continue;
 
-      const bool then_acc = IsInplaceAccumulatorProducer(then_var);
-      const bool else_acc = IsInplaceAccumulatorProducer(else_var);
+      const bool then_acc =
+          IsInplaceAccumulatorProducer(then_var) || IsExternallySeededAccumulatorLoop(then_var, if_stmt);
+      const bool else_acc =
+          IsInplaceAccumulatorProducer(else_var) || IsExternallySeededAccumulatorLoop(else_var, if_stmt);
       if (then_acc == else_acc) continue;  // need exactly one in-place accumulator
 
       const VarPtr& acc_var = then_acc ? then_var : else_var;
@@ -471,12 +519,7 @@ class TopDownRetargeter {
       if (MemRef::SameAllocation(acc_memref, GetDefinedMemRef(seed_tile))) continue;  // already shared
 
       auto seed_def = defs_.find(seed_var);
-      if (seed_def == defs_.end() || seed_def->second.kind != VarDef::kAssign) continue;
-      // The seed must be a Call producer we can retype; a bare-Var / tuple rename
-      // cannot be retargeted. Leave the phi untouched; YieldFixup will reject
-      // the residual Acc mismatch because no legal copy exists.
-      auto seed_assign = As<AssignStmt>(seed_def->second.assign_stmt);
-      if (!seed_assign || !As<Call>(seed_assign->value_)) continue;
+      if (seed_def == defs_.end()) continue;
 
       // The `check_liveness=false` bypass below is only sound when branch
       // exclusivity actually applies, which requires BOTH:
@@ -492,7 +535,8 @@ class TopDownRetargeter {
       const bool in_branch = std::any_of(seed_anc.begin(), seed_anc.end(),
                                          [&](const StmtPtr& a) { return a.get() == if_stmt.get(); });
       if (!in_branch) continue;
-      if (!IsTargetDeadAtAssign(seed_def->second, acc_memref->base_.get(), /*stop_at=*/if_stmt.get())) {
+      if (!IsTargetDeadAfterDefinition(seed_def->second, acc_memref->base_.get(),
+                                       /*stop_at=*/if_stmt.get())) {
         continue;
       }
 
@@ -500,8 +544,23 @@ class TopDownRetargeter {
       // bypass the global liveness (which would false-decline on the legitimate
       // post-if phi consumer). A remaining decline is a genuine "cannot coalesce
       // this Acc phi" — fail loud, since no legal Acc->Acc move exists.
-      const bool ok = RetargetAssign(seed_var, seed_def->second, acc_memref, acc_tile->GetMemorySpace(),
-                                     /*check_liveness=*/false);
+      bool ok = false;
+      if (seed_def->second.kind == VarDef::kAssign) {
+        auto seed_assign = As<AssignStmt>(seed_def->second.assign_stmt);
+        if (!seed_assign) continue;
+        if (As<Call>(seed_assign->value_)) {
+          ok = RetargetAssign(seed_var, seed_def->second, acc_memref, acc_tile->GetMemorySpace(),
+                              /*check_liveness=*/false);
+        } else if (AsVarLike(seed_assign->value_)) {
+          ok = TryRetargetVar(seed_var, acc_memref, acc_tile->GetMemorySpace());
+        } else {
+          continue;
+        }
+      } else if (seed_def->second.kind == VarDef::kForReturn) {
+        ok = TryRetargetVar(seed_var, acc_memref, acc_tile->GetMemorySpace());
+      } else {
+        continue;
+      }
       INTERNAL_CHECK_SPAN(ok, seed_var->span_)
           << "Internal error: cannot coalesce L0C accumulator across a peeled if-phi — seed producer '"
           << seed_var->name_hint_
@@ -562,7 +621,19 @@ class TopDownRetargeter {
     auto assign = As<AssignStmt>(def.assign_stmt);
     INTERNAL_CHECK_SPAN(assign, var->span_) << "Internal error: kAssign VarDef must carry an AssignStmt";
     auto call = As<Call>(assign->value_);
-    if (!call) return false;
+    if (!call) {
+      auto alias = AsVarLike(assign->value_);
+      if (!alias) return false;
+      auto alias_tile = GetTileTypeWithMemRef(alias->GetType());
+      auto var_tile = GetTileTypeWithMemRef(var->GetType());
+      if (!alias_tile || !var_tile ||
+          !MemRef::SameAllocation(GetDefinedMemRef(alias_tile), GetDefinedMemRef(var_tile))) {
+        return false;
+      }
+      if (!TryRetargetVar(alias, target, target_memory)) return false;
+      PlanRewrite(var, target, target_memory);
+      return true;
+    }
     const auto& reg = OpRegistry::GetInstance();
     if (!reg.IsRegistered(call->op_->name_)) return false;
     const auto& entry = reg.GetEntry(call->op_->name_);
@@ -781,7 +852,16 @@ class TopDownRetargeter {
     rewrites_[var] = new_type;
   }
 
-  /// Is target's base Ptr unread between the AssignStmt and the end of its containing body?
+  /// Statement that defines a VarDef for branch-tail liveness purposes.
+  static StmtPtr DefinitionStmt(const VarDef& def) {
+    if (def.kind == VarDef::kAssign) return def.assign_stmt;
+    if (def.kind == VarDef::kIfReturn || def.kind == VarDef::kForReturn || def.kind == VarDef::kIterArg) {
+      return def.control_stmt;
+    }
+    return nullptr;
+  }
+
+  /// Is target's base Ptr unread between the definition and the end of its containing body?
   /// Also walks into nested control flow to check for reads there.
   /// Liveness check: walks the AssignStmt's full ancestor chain from innermost
   /// outward and, at every enclosing SeqStmts, scans the siblings that execute
@@ -802,13 +882,14 @@ class TopDownRetargeter {
   /// same-branch read between the seed producer and the yield) while ignoring
   /// the mutually-exclusive sibling branch and the legitimate post-if phi
   /// consumers — the reads it must *not* treat as conflicts.
-  bool IsTargetDeadAtAssign(const VarDef& def, const Var* target_base, const Stmt* stop_at = nullptr) {
+  bool IsTargetDeadAfterDefinition(const VarDef& def, const Var* target_base, const Stmt* stop_at = nullptr) {
     if (def.ancestors.empty()) return true;
 
     // `child_on_path` is the direct descendant of the current ancestor that
     // lies on the walk path toward the AssignStmt.  We update it as we step
     // outward so that, at each SeqStmts level, we can locate it in stmts_.
-    StmtPtr child_on_path = def.assign_stmt;
+    StmtPtr child_on_path = DefinitionStmt(def);
+    if (!child_on_path) return false;
 
     for (auto it = def.ancestors.rbegin(); it != def.ancestors.rend(); ++it) {
       const auto& anc = *it;
@@ -837,6 +918,12 @@ class TopDownRetargeter {
       child_on_path = anc;
     }
     return true;
+  }
+
+  bool IsTargetDeadAtAssign(const VarDef& def, const Var* target_base, const Stmt* stop_at = nullptr) {
+    INTERNAL_CHECK(def.kind == VarDef::kAssign)
+        << "Internal error: IsTargetDeadAtAssign requires an assignment definition";
+    return IsTargetDeadAfterDefinition(def, target_base, stop_at);
   }
 };
 
@@ -3725,9 +3812,22 @@ FunctionPtr TransformMaterializeSemanticAliases(const FunctionPtr& func) {
     new_body = applier.VisitStmt(new_body);
   }
 
+  // Peeled accumulator phis are semantic must-alias boundaries. Coalesce them
+  // before lifetime analysis so nested K-loop branches enter every memory
+  // planner as one allocation family. The legacy planner repeats this repair
+  // after packing because packing may introduce new carry mismatches.
+  {
+    TopDownRetargeter acc_coalescer;
+    auto acc_rewrites = acc_coalescer.CoalesceAccumulatorIfPhis(new_body);
+    if (!acc_rewrites.empty()) {
+      RetypeApplier applier(std::move(acc_rewrites));
+      new_body = applier.VisitStmt(new_body);
+    }
+  }
+
   // Under memory_planner=PtoAS or DsaRP the whole MemoryReuse pass is skipped.
-  // DsaRP must therefore run the correctness normalizations from MemoryReuse
-  // Steps 3.75 through 4.5 in the same order. They are not optimizations: when a
+  // DsaRP must therefore run the remaining correctness normalizations from
+  // MemoryReuse Steps 4 through 4.5 in the same order. They are not optimizations: when a
   // peeled accumulator if-phi or
   // loop yields a value living in a different buffer than its iter_arg/return_var,
   // it inserts the `tile.move` that writes the result back into the carry. Without
@@ -3741,18 +3841,11 @@ FunctionPtr TransformMaterializeSemanticAliases(const FunctionPtr& func) {
   //
   // PTOAS needs only the ForStmt YieldFixup half: addr-less codegen already
   // re-points a branch-local producer at the if-phi handle. DSA-RP emits
-  // explicit addresses, so it must first coalesce peeled accumulator if-phis,
-  // then materialize both IfStmt and ForStmt fixups, and finally repair bare-Var
+  // explicit addresses, so after the common accumulator-phi coalescing above it
+  // materializes both IfStmt and ForStmt fixups and finally repairs bare-Var
   // identity copies before lifetime analysis and placement.
   const auto* ctx = PassContext::Current();
   if (ctx != nullptr && ctx->GetMemoryPlanner() == MemoryPlanner::DsaRP) {
-    TopDownRetargeter acc_coalescer;
-    auto acc_rewrites = acc_coalescer.CoalesceAccumulatorIfPhis(new_body);
-    if (!acc_rewrites.empty()) {
-      RetypeApplier applier(std::move(acc_rewrites));
-      new_body = applier.VisitStmt(new_body);
-    }
-
     // Identity-copy normalization brackets YieldFixup on both sides; see the
     // matching step in TransformMemoryReuse for why each side is needed.
     new_body = NormalizeIdentityCopyBuffersMutator().VisitStmt(new_body);

--- a/tests/ut/ir/transforms/test_auto_tile_matmul_acc_mn.py
+++ b/tests/ut/ir/transforms/test_auto_tile_matmul_acc_mn.py
@@ -747,17 +747,26 @@ def test_canonical_split_k_preserves_store_attrs_on_every_output_tile():
     assert all(attrs.get("test_store_marker") == 2232 for attrs in collector.attrs)
 
 
-def test_issue_2232_full_default_pipeline_allocates():
-    """After loop-level M/N tiling, both the issue reproducer and the general
-    two-axis grid reach concrete allocation in the complete Default pipeline."""
+@pytest.mark.parametrize(
+    "kernel",
+    [issue_2232_repro, canonical_split_k_mn],
+    ids=["issue-2232-wide-n", "general-mn-grid"],
+)
+def test_issue_2232_full_default_pipeline_allocates(kernel):
+    """After loop-level M/N tiling, each peeled split-K pattern reaches
+    concrete allocation in the complete Default pipeline.
+
+    Keep these as separate cases: the wide-N reproducer and general two-axis
+    grid exercise different physical accumulator windows, and a failure in one
+    must not prevent the other from reaching MemoryReuse.
+    """
     from pypto.ir.pass_manager import OptimizationStrategy, PassManager  # noqa: PLC0415
 
     _backend.reset_for_testing()
     _backend.set_backend_type(BackendType.Ascend910B)
     pass_manager = PassManager.get_strategy(OptimizationStrategy.Default)
-    for kernel in (issue_2232_repro, canonical_split_k_mn):
-        result = pass_manager.run_passes(_jit_program(kernel))
-        assert result is not None
+    result = pass_manager.run_passes(_jit_program(kernel))
+    assert result is not None
 
 
 def test_predicated_full_default_pipeline_allocates():

--- a/tests/ut/ir/transforms/test_memory_reuse.py
+++ b/tests/ut/ir/transforms/test_memory_reuse.py
@@ -59,6 +59,25 @@ def _collect_allocated_tile_ranges(program: ir.Program) -> dict[str, tuple[int, 
     return ranges
 
 
+def _collect_named_tile_memrefs(program: ir.Program, names: set[str]) -> dict[str, ir.MemRef]:
+    """Collect MemRefs for named tile definitions anywhere in a function body."""
+    result: dict[str, ir.MemRef] = {}
+    function = next(iter(program.functions.values()))
+
+    class _MemRefCollector(ir.IRVisitor):
+        def visit_assign_stmt(self, stmt):  # type: ignore[override]
+            tile_type = stmt.var.type
+            if stmt.var.name_hint in names and isinstance(tile_type, ir.TileType):
+                assert tile_type.memref is not None
+                result[stmt.var.name_hint] = tile_type.memref
+            super().visit_assign_stmt(stmt)
+
+    _MemRefCollector().visit_stmt(function.body)
+    missing = names - result.keys()
+    assert not missing, f"tile definitions not found: {sorted(missing)}"
+    return result
+
+
 def _assert_if_phi_arms_write_the_phi_buffer(program: ir.Program) -> None:
     """Assert every arm of every tile-typed if-phi yields into the phi's own buffer.
 
@@ -1241,6 +1260,76 @@ class TestViewOps:
         assert members["s1"][1] == 64 and members["r1"][1] == 64
         # Each member keeps its own 64-byte size, not the target's 512.
         assert members["r0"][2] == 64 and members["r1"][2] == 64
+
+    def test_smaller_view_group_rebased_to_larger_buffer_keeps_member_windows(self):
+        """A smaller representative keeps its own extent when packed into a larger buffer."""
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(
+                self,
+                inp: pl.Tensor[[8, 16], pl.FP32],
+                dead_in: pl.Tensor[[16, 16], pl.FP32],
+                out_dead: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+                out: pl.Out[pl.Tensor[[1, 16], pl.FP32]],
+            ) -> pl.Tensor[[1, 16], pl.FP32]:
+                dead: pl.Tile[[16, 16], pl.FP32, pl.Mem.Vec] = pl.tile.load(
+                    dead_in, [0, 0], [16, 16], target_memory=pl.Mem.Vec
+                )
+                _dead_out = pl.tile.store(dead, [0, 0], out_dead)
+                src: pl.Tile[[8, 16], pl.FP32, pl.Mem.Vec] = pl.tile.load(
+                    inp, [0, 0], [8, 16], target_memory=pl.Mem.Vec
+                )
+                row: pl.Tile[[1, 16], pl.FP32, pl.Mem.Vec] = pl.tile.slice(src, [1, 16], [3, 0])
+                result = pl.tile.store(row, [0, 0], out)
+                return result
+
+        After = _run_pipeline(Before)
+        ranges = _collect_named_tile_memrefs(After, {"dead", "src", "row"})
+        dead = ranges["dead"]
+        src = ranges["src"]
+        row = ranges["row"]
+        assert src.base_ is dead.base_, "the smaller group did not reuse the larger dead buffer"
+        assert src.size_ == 8 * 16 * 4
+        assert row.base_ is dead.base_
+        assert row.size_ == 16 * 4
+        assert isinstance(row.byte_offset_, ir.ConstInt)
+        assert row.byte_offset_.value == 3 * 16 * 4
+
+    def test_dynamic_view_offset_is_preserved_when_group_is_rebased(self):
+        """Rebasing changes the allocation base, not a dynamic member's relative offset."""
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(
+                self,
+                inp: pl.Tensor[[8, 16], pl.FP32],
+                dead_in: pl.Tensor[[16, 16], pl.FP32],
+                row_index: pl.Scalar[pl.INDEX],
+                out_dead: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+                out: pl.Out[pl.Tensor[[1, 16], pl.FP32]],
+            ) -> pl.Tensor[[1, 16], pl.FP32]:
+                dead: pl.Tile[[16, 16], pl.FP32, pl.Mem.Vec] = pl.tile.load(
+                    dead_in, [0, 0], [16, 16], target_memory=pl.Mem.Vec
+                )
+                _dead_out = pl.tile.store(dead, [0, 0], out_dead)
+                src: pl.Tile[[8, 16], pl.FP32, pl.Mem.Vec] = pl.tile.load(
+                    inp, [0, 0], [8, 16], target_memory=pl.Mem.Vec
+                )
+                row: pl.Tile[[1, 16], pl.FP32, pl.Mem.Vec] = pl.tile.slice(src, [1, 16], [row_index, 0])
+                result = pl.tile.store(row, [0, 0], out)
+                return result
+
+        Initialized = passes.init_mem_ref()(Before)
+        before = _collect_named_tile_memrefs(Initialized, {"row"})["row"]
+        After = passes.memory_reuse()(passes.materialize_semantic_aliases()(Initialized))
+        ranges = _collect_named_tile_memrefs(After, {"dead", "src", "row"})
+        assert ranges["src"].base_ is ranges["dead"].base_
+        assert ranges["row"].base_ is ranges["dead"].base_
+        assert ranges["row"].size_ == before.size_
+        assert ir.structural_equal(ranges["row"].byte_offset_, before.byte_offset_)
 
     def test_loop_carry_retarget_keeps_slice_view_aliased(self):
         """A sub-region view must follow its input when the input is loop-carry
@@ -3973,6 +4062,118 @@ class TestTopDownRetargeter:
         After = _run_pipeline(Before)
         ir.assert_structural_equal(After, Expected)
 
+    def test_failed_if_retarget_rolls_back_successful_sibling_arm(self):
+        """A declined branch must not leak rewrites planned for its sibling.
+
+        The ``then`` add can write directly into the loop-carry buffer. The
+        ``else`` reshape is an inherit-input view and deliberately refuses
+        direct retargeting. The enclosing if-retarget therefore fails as a
+        unit, and the add must retain its original allocation.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                inp: pl.Tensor[[16, 16], pl.FP32],
+                cond: pl.Scalar[pl.INDEX],
+                out: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                source = pl.tile.load(inp, [0, 0], [16, 16], target_memory=pl.Mem.Vec)
+                initial = pl.tile.add(source, source)
+                for _i, (carried,) in pl.range(1, init_values=(initial,)):
+                    if cond < 1:
+                        retargetable = pl.tile.add(source, source)
+                        merged = pl.yield_(retargetable)
+                    else:
+                        blocked = pl.tile.reshape(source, [16, 16])
+                        merged = pl.yield_(blocked)
+                    loop_result = pl.yield_(merged)
+                return pl.tile.store(loop_result, [0, 0], out)
+
+        after = passes.materialize_semantic_aliases()(passes.init_mem_ref()(Before))
+        bases = _collect_tile_memref_bases(after)
+        assert bases["retargetable"] != bases["initial"], (
+            "the successful then-arm rewrite leaked after the else-arm declined"
+        )
+
+    def test_many_loop_carries_use_the_indexed_liveness_path(self):
+        """A wide carry set exercises many liveness queries without subtree rescans."""
+        carry_count = 128
+        initializers = "\n".join(
+            f"        init_{i} = pl.tile.load(inp, [0, 0], [1, 16], target_memory=pl.Mem.Vec)"
+            for i in range(carry_count)
+        )
+        carry_names = ", ".join(f"carry_{i}" for i in range(carry_count))
+        init_names = ", ".join(f"init_{i}" for i in range(carry_count))
+        updates = "\n".join(
+            f"            next_{i} = pl.tile.add(carry_{i}, carry_{i})" for i in range(carry_count)
+        )
+        next_names = ", ".join(f"next_{i}" for i in range(carry_count))
+        result_names = ", ".join(f"result_{i}" for i in range(carry_count))
+        source = f"""
+@pl.program
+class WideCarry:
+    @pl.function(type=pl.FunctionType.InCore)
+    def kernel(
+        self,
+        inp: pl.Tensor[[1, 16], pl.FP32],
+        out: pl.Out[pl.Tensor[[1, 16], pl.FP32]],
+    ) -> pl.Tensor[[1, 16], pl.FP32]:
+{initializers}
+        for _i, ({carry_names}) in pl.range(1, init_values=({init_names})):
+{updates}
+            {result_names} = pl.yield_({next_names})
+        return pl.tile.store(result_0, [0, 0], out)
+"""
+
+        After = passes.materialize_semantic_aliases()(passes.init_mem_ref()(pl.parse_program(source)))
+        ranges = _collect_named_tile_memrefs(After, {"init_0", "next_0", "init_127", "next_127"})
+        assert ranges["next_0"].base_ is ranges["init_0"].base_
+        assert ranges["next_127"].base_ is ranges["init_127"].base_
+
+    def test_shared_alias_suffix_memoizes_accumulator_provenance(self):
+        """Many phis sharing progressively longer producer suffixes stay linear."""
+        chain_length = 128
+        aliases = "\n".join(
+            f"        alias_{i} = {'accumulated' if i == 0 else f'alias_{i - 1}'}"
+            for i in range(chain_length)
+        )
+        phis = "\n".join(
+            f"""        if cond < {i + 1}:
+            seed_{i} = pl.tile.matmul(sa, sb)
+            merged_{i} = pl.yield_(seed_{i})
+        else:
+            merged_{i} = pl.yield_(alias_{i})"""
+            for i in range(chain_length)
+        )
+        source = f"""
+@pl.program
+class SharedSuffix:
+    @pl.function(type=pl.FunctionType.InCore)
+    def kernel(
+        self,
+        lhs: pl.Tensor[[16, 64], pl.BF16],
+        rhs: pl.Tensor[[64, 64], pl.BF16],
+        cond: pl.Scalar[pl.INDEX],
+        out: pl.Out[pl.Tensor[[16, 64], pl.FP32]],
+    ) -> pl.Tensor[[16, 64], pl.FP32]:
+        sa_mat = pl.tile.load(lhs, [0, 0], [16, 64], target_memory=pl.Mem.Mat)
+        sb_mat = pl.tile.load(rhs, [0, 0], [64, 64], target_memory=pl.Mem.Mat)
+        sa = pl.tile.move(sa_mat, target_memory=pl.Mem.Left)
+        sb = pl.tile.move(sb_mat, target_memory=pl.Mem.Right)
+        previous = pl.tile.matmul(sa, sb)
+        accumulated = pl.tile.matmul_acc(previous, sa, sb)
+{aliases}
+{phis}
+        return pl.tile.store(merged_{chain_length - 1}, [0, 0], out)
+"""
+
+        before = passes.init_mem_ref()(pl.parse_program(source))
+        with pytest.raises(InternalError, match="cannot reconcile divergent L0C accumulator buffers"):
+            passes.memory_reuse()(passes.materialize_semantic_aliases()(before))
+
     def test_gating_vec_inplace_if_phi_is_not_acc_coalesced(self):
         """Gating: the accumulator coalescer is Acc-scoped. A structurally
         identical if-phi in Vec space -- ``else`` is an in-place
@@ -4119,6 +4320,171 @@ class TestTopDownRetargeter:
         # Retargeting ``seed`` onto ``initial`` is unsafe because ``initial``
         # remains independently observable after the if on the else path. The
         # remaining divergent Acc phi has no legal Acc-to-Acc repair move.
+        with pytest.raises(InternalError, match="cannot reconcile divergent L0C accumulator buffers"):
+            _run_pipeline(Before)
+
+    def test_direct_accumulator_phi_preserves_reused_input_after_if(self):
+        """A direct ``matmul_acc`` arm cannot donate a reused input read after the phi."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                lhs: pl.Tensor[[16, 64], pl.BF16],
+                rhs: pl.Tensor[[64, 64], pl.BF16],
+                cond: pl.Scalar[pl.INDEX],
+                bypass_out: pl.Out[pl.Tensor[[16, 64], pl.FP32]],
+                out: pl.Out[pl.Tensor[[16, 64], pl.FP32]],
+            ) -> tuple[pl.Tensor[[16, 64], pl.FP32], pl.Tensor[[16, 64], pl.FP32]]:
+                sa_mat = pl.tile.load(lhs, [0, 0], [16, 64], target_memory=pl.Mem.Mat)
+                sb_mat = pl.tile.load(rhs, [0, 0], [64, 64], target_memory=pl.Mem.Mat)
+                sa = pl.tile.move(sa_mat, target_memory=pl.Mem.Left)
+                sb = pl.tile.move(sb_mat, target_memory=pl.Mem.Right)
+                previous = pl.tile.matmul(sa, sb)
+                if cond < 1:
+                    seed = pl.tile.matmul(sa, sb)
+                    merged = pl.yield_(seed)
+                else:
+                    accumulated = pl.tile.matmul_acc(previous, sa, sb)
+                    merged = pl.yield_(accumulated)
+                bypass_result = pl.tile.store(previous, [0, 0], bypass_out)
+                result = pl.tile.store(merged, [0, 0], out)
+                return bypass_result, result
+
+        with pytest.raises(InternalError, match="cannot reconcile divergent L0C accumulator buffers"):
+            _run_pipeline(Before)
+
+    def test_direct_accumulator_phi_preserves_stale_bare_alias_after_if(self):
+        """Bare identity remains observable even when its MemRef metadata has drifted."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                lhs: pl.Tensor[[16, 64], pl.BF16],
+                rhs: pl.Tensor[[64, 64], pl.BF16],
+                cond: pl.Scalar[pl.INDEX],
+                bypass_out: pl.Out[pl.Tensor[[16, 64], pl.FP32]],
+                out: pl.Out[pl.Tensor[[16, 64], pl.FP32]],
+            ) -> tuple[pl.Tensor[[16, 64], pl.FP32], pl.Tensor[[16, 64], pl.FP32]]:
+                sa_mat = pl.tile.load(lhs, [0, 0], [16, 64], target_memory=pl.Mem.Mat)
+                sb_mat = pl.tile.load(rhs, [0, 0], [64, 64], target_memory=pl.Mem.Mat)
+                sa = pl.tile.move(sa_mat, target_memory=pl.Mem.Left)
+                sb = pl.tile.move(sb_mat, target_memory=pl.Mem.Right)
+                previous = pl.tile.matmul(sa, sb)
+                old_value = previous
+                if cond < 1:
+                    seed = pl.tile.matmul(sa, sb)
+                    merged = pl.yield_(seed)
+                else:
+                    accumulated = pl.tile.matmul_acc(previous, sa, sb)
+                    merged = pl.yield_(accumulated)
+                bypass_result = pl.tile.store(old_value, [0, 0], bypass_out)
+                result = pl.tile.store(merged, [0, 0], out)
+                return bypass_result, result
+
+        initialized = passes.init_mem_ref()(Before)
+        aliases: dict[str, ir.Var] = {}
+
+        class _AliasCollector(ir.IRVisitor):
+            def visit_assign_stmt(self, stmt):  # type: ignore[override]
+                if stmt.var.name_hint == "old_value":
+                    aliases[stmt.var.name_hint] = stmt.var
+                super().visit_assign_stmt(stmt)
+
+        function = initialized.get_function("kernel")
+        assert function is not None
+        _AliasCollector().visit_stmt(function.body)
+        old_alias = aliases["old_value"]
+        old_type = old_alias.type
+        assert isinstance(old_type, ir.TileType) and old_type.memref is not None
+        stale_base = ir.Var("stale_acc", ir.PtrType(), old_alias.span)
+        stale_memref = ir.MemRef(stale_base, 8192, old_type.memref.size_, old_alias.span)
+        stale_type = ir.TileType(
+            old_type.shape,
+            old_type.dtype,
+            stale_memref,
+            old_type.tile_view,
+            old_type.memory_space,
+        )
+        stale_alias = ir.Var(old_alias.name_hint, stale_type, old_alias.span)
+
+        class _DriftBareAlias(ir.IRMutator):
+            def visit_var(self, op):
+                if op is old_alias:
+                    return stale_alias
+                return super().visit_var(op)
+
+        drifted = _DriftBareAlias().visit_program(initialized)
+        with pytest.raises(InternalError, match="cannot reconcile divergent L0C accumulator buffers"):
+            passes.memory_reuse()(passes.materialize_semantic_aliases()(drifted))
+
+    def test_direct_accumulator_phi_tracks_iter_arg_initializer_after_if(self):
+        """A carried accumulator remains in the initializer's semantic alias family."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                lhs: pl.Tensor[[16, 64], pl.BF16],
+                rhs: pl.Tensor[[64, 64], pl.BF16],
+                cond: pl.Scalar[pl.INDEX],
+                bypass_out: pl.Out[pl.Tensor[[16, 64], pl.FP32]],
+                out: pl.Out[pl.Tensor[[16, 64], pl.FP32]],
+            ) -> pl.Tensor[[16, 64], pl.FP32]:
+                sa_mat = pl.tile.load(lhs, [0, 0], [16, 64], target_memory=pl.Mem.Mat)
+                sb_mat = pl.tile.load(rhs, [0, 0], [64, 64], target_memory=pl.Mem.Mat)
+                sa = pl.tile.move(sa_mat, target_memory=pl.Mem.Left)
+                sb = pl.tile.move(sb_mat, target_memory=pl.Mem.Right)
+                previous = pl.tile.matmul(sa, sb)
+                for _i, (carried,) in pl.range(1, init_values=(previous,)):
+                    if cond < 1:
+                        seed = pl.tile.matmul(sa, sb)
+                        merged = pl.yield_(seed)
+                    else:
+                        accumulated = pl.tile.matmul_acc(carried, sa, sb)
+                        merged = pl.yield_(accumulated)
+                    _bypass_result = pl.tile.store(previous, [0, 0], bypass_out)
+                    loop_result = pl.yield_(merged)
+                result = pl.tile.store(loop_result, [0, 0], out)
+                return result
+
+        with pytest.raises(InternalError, match="cannot reconcile divergent L0C accumulator buffers"):
+            _run_pipeline(Before)
+
+    def test_direct_accumulator_phi_preserves_metadata_alias_after_if(self):
+        """A pre-if metadata view remains an independent observer of the reused input."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                lhs: pl.Tensor[[16, 64], pl.BF16],
+                rhs: pl.Tensor[[64, 64], pl.BF16],
+                cond: pl.Scalar[pl.INDEX],
+                bypass_out: pl.Out[pl.Tensor[[16, 64], pl.FP32]],
+                out: pl.Out[pl.Tensor[[16, 64], pl.FP32]],
+            ) -> tuple[pl.Tensor[[16, 64], pl.FP32], pl.Tensor[[16, 64], pl.FP32]]:
+                sa_mat = pl.tile.load(lhs, [0, 0], [16, 64], target_memory=pl.Mem.Mat)
+                sb_mat = pl.tile.load(rhs, [0, 0], [64, 64], target_memory=pl.Mem.Mat)
+                sa = pl.tile.move(sa_mat, target_memory=pl.Mem.Left)
+                sb = pl.tile.move(sb_mat, target_memory=pl.Mem.Right)
+                previous = pl.tile.matmul(sa, sb)
+                old_value = pl.tile.set_validshape(previous, 16, 64)
+                if cond < 1:
+                    seed = pl.tile.matmul(sa, sb)
+                    merged = pl.yield_(seed)
+                else:
+                    accumulated = pl.tile.matmul_acc(previous, sa, sb)
+                    merged = pl.yield_(accumulated)
+                bypass_result = pl.tile.store(old_value, [0, 0], bypass_out)
+                result = pl.tile.store(merged, [0, 0], out)
+                return bypass_result, result
+
         with pytest.raises(InternalError, match="cannot reconcile divergent L0C accumulator buffers"):
             _run_pipeline(Before)
 

--- a/tests/ut/ir/transforms/test_memory_reuse.py
+++ b/tests/ut/ir/transforms/test_memory_reuse.py
@@ -3707,6 +3707,66 @@ class TestTopDownRetargeter:
             valid_shape = tile_type.get_effective_tile_view().valid_shape
             assert [dim.value for dim in valid_shape if isinstance(dim, ir.ConstInt)] == [16, 16]
 
+    def test_nested_tensor_matmul_acc_join_needs_no_acc_repair_move(self):
+        """Nested outer/inner K loops lower without an illegal Acc repair move."""
+
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        @pl.program
+        class NestedAccumulator:
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                value: pl.Tensor[[128, 64], pl.BF16],
+                gate_weight: pl.Tensor[[64, 128], pl.BF16],
+                up_weight: pl.Tensor[[64, 128], pl.BF16],
+                down_weight: pl.Tensor[[128, 64], pl.BF16],
+                output: pl.Out[pl.Tensor[[128, 64], pl.FP32]],
+            ) -> pl.Tensor[[128, 64], pl.FP32]:
+                for region_index in pl.spmd(
+                    8,
+                    optimizations=[
+                        pl.split(pl.SplitMode.UP_DOWN),
+                        pl.cross_core_slot(slot_num=4),
+                    ],
+                ):
+                    acc_init = pl.tensor.create([16, 64], dtype=pl.FP32, layout=pl.TensorLayout.ND)
+                    for feature, (acc,) in pl.pipeline(0, 128, 64, stage=3, init_values=(acc_init,)):
+                        a_tile = pl.tensor.slice(value, [16, 64], [region_index * 16, 0])
+                        g_tile = pl.tensor.slice(gate_weight, [64, 64], [0, feature])
+                        u_tile = pl.tensor.slice(up_weight, [64, 64], [0, feature])
+                        gate = pl.tensor.matmul(a_tile, g_tile, out_dtype=pl.FP32)
+                        up = pl.tensor.matmul(a_tile, u_tile, out_dtype=pl.FP32)
+                        sigmoid = pl.tensor.recip(pl.tensor.adds(pl.tensor.exp(pl.tensor.neg(gate)), 1.0))
+                        activation = pl.tensor.cast(
+                            pl.tensor.mul(pl.tensor.mul(gate, sigmoid), up),
+                            target_type=pl.BF16,
+                            mode="round",
+                        )
+                        d_tile = pl.tensor.slice(down_weight, [64, 64], [feature, 0])
+                        if feature == 0:
+                            first = pl.tensor.matmul(activation, d_tile, out_dtype=pl.FP32)
+                            next_acc = pl.yield_(first)
+                        else:
+                            later = pl.tensor.matmul_acc(acc, activation, d_tile)
+                            next_acc = pl.yield_(later)
+                        tile = pl.yield_(next_acc)
+                    output = pl.tensor.assemble(output, tile, [region_index * 16, 0])
+                return output
+
+        lowered = PassManager.get_strategy(OptimizationStrategy.Default).run_passes(NestedAccumulator)
+        aic_functions = [
+            function for function in lowered.functions.values() if function.func_type == ir.FunctionType.AIC
+        ]
+        assert len(aic_functions) == 1
+
+        body = aic_functions[0].as_python()
+        assert "pl.tile.matmul_acc(" in body
+        assert not any(
+            "pl.tile.move(" in line and "target_memory=pl.Mem.Acc" in line for line in body.splitlines()
+        )
+
     def test_pipelined_kloop_accumulator_coalesces_to_one_acc_buffer(self):
         """A stage-2 pipelined K-loop matmul (as AutoTileMatmulL0 emits) whose
         L0C accumulator is large (176x176x4 = 121KB, fp32). After

--- a/tests/ut/ir/transforms/test_memory_reuse.py
+++ b/tests/ut/ir/transforms/test_memory_reuse.py
@@ -16,9 +16,11 @@ This aligns MemRef objects consistently: if two tiles share a MemRef in
 ``After``, the corresponding tiles in ``Expected`` must also share.
 """
 
+import re
+
 import pypto.language as pl
 import pytest
-from pypto import DataType, InternalError, backend, ir, passes, testing
+from pypto import DataType, InternalError, backend, codegen, ir, passes, testing
 from pypto.backend import BackendType
 from pypto.ir.op import tile
 from pypto.ir.pass_manager import OptimizationStrategy, PassManager
@@ -3707,11 +3709,12 @@ class TestTopDownRetargeter:
             valid_shape = tile_type.get_effective_tile_view().valid_shape
             assert [dim.value for dim in valid_shape if isinstance(dim, ir.ConstInt)] == [16, 16]
 
-    def test_nested_tensor_matmul_acc_join_needs_no_acc_repair_move(self):
-        """Nested outer/inner K loops lower without an illegal Acc repair move."""
-
-        backend.reset_for_testing()
-        backend.set_backend_type(BackendType.Ascend910B)
+    @pytest.mark.parametrize(
+        "planner",
+        [passes.MemoryPlanner.PYPTO, passes.MemoryPlanner.DSA_RP, passes.MemoryPlanner.PTOAS],
+    )
+    def test_nested_tensor_matmul_acc_join_needs_no_acc_repair_move(self, planner, ascend_backend):
+        """Nested outer/inner K loops use one L0C handle under every planner."""
 
         @pl.program
         class NestedAccumulator:
@@ -3755,7 +3758,8 @@ class TestTopDownRetargeter:
                     output = pl.tensor.assemble(output, tile, [region_index * 16, 0])
                 return output
 
-        lowered = PassManager.get_strategy(OptimizationStrategy.Default).run_passes(NestedAccumulator)
+        with passes.PassContext([], memory_planner=planner):
+            lowered = PassManager.get_strategy(OptimizationStrategy.Default).run_passes(NestedAccumulator)
         aic_functions = [
             function for function in lowered.functions.values() if function.func_type == ir.FunctionType.AIC
         ]
@@ -3765,6 +3769,27 @@ class TestTopDownRetargeter:
         assert "pl.tile.matmul_acc(" in body
         assert not any(
             "pl.tile.move(" in line and "target_memory=pl.Mem.Acc" in line for line in body.splitlines()
+        )
+
+        aic = aic_functions[0]
+        pto = codegen.PTOCodegen().generate(
+            ir.Program([aic], aic.name, lowered.span),
+            emit_tile_addr=planner != passes.MemoryPlanner.PTOAS,
+        )
+        acc_lines = [line for line in pto.splitlines() if "pto.tmatmul.acc" in line]
+        assert acc_lines, f"{planner}: expected at least one accumulating matmul:\n{pto}"
+        acc_handles = {
+            match.group(1)
+            for line in acc_lines
+            if (match := re.search(r"pto\.tmatmul\.acc ins\((%[A-Za-z0-9_]+)", line))
+        }
+        assert len(acc_handles) == 1, (
+            f"{planner}: expected one persistent L0C handle, got {acc_handles}:\n{pto}"
+        )
+        acc_handle = next(iter(acc_handles))
+        first_partials = [line for line in pto.splitlines() if "pto.tmatmul " in line]
+        assert any(re.search(rf"outs\({re.escape(acc_handle)}(?:\s|:)", line) for line in first_partials), (
+            f"{planner}: first partial must initialize the handle consumed by tmatmul.acc ({acc_handle}):\n{pto}"
         )
 
     def test_pipelined_kloop_accumulator_coalesces_to_one_acc_buffer(self):
@@ -4016,6 +4041,194 @@ class TestTopDownRetargeter:
         # emitting invalid IR for this unlowerable control-flow shape.
         with pytest.raises(InternalError, match="cannot reconcile divergent L0C accumulator buffers"):
             _run_pipeline(_divergent_acc_phi_program())
+
+    def test_pre_if_accumulator_loop_is_not_treated_as_branch_local(self):
+        """A loop result defined before an if cannot justify branch-exclusive reuse."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                lhs: pl.Tensor[[16, 64], pl.BF16],
+                rhs: pl.Tensor[[64, 64], pl.BF16],
+                cond: pl.Scalar[pl.INDEX],
+                bypass_out: pl.Out[pl.Tensor[[16, 64], pl.FP32]],
+                out: pl.Out[pl.Tensor[[16, 64], pl.FP32]],
+            ) -> tuple[pl.Tensor[[16, 64], pl.FP32], pl.Tensor[[16, 64], pl.FP32]]:
+                sa_mat = pl.tile.load(lhs, [0, 0], [16, 64], target_memory=pl.Mem.Mat)
+                sb_mat = pl.tile.load(rhs, [0, 0], [64, 64], target_memory=pl.Mem.Mat)
+                sa = pl.tile.move(sa_mat, target_memory=pl.Mem.Left)
+                sb = pl.tile.move(sb_mat, target_memory=pl.Mem.Right)
+                initial = pl.tile.matmul(sa, sb)
+                for _k, (carried,) in pl.range(1, init_values=(initial,)):
+                    updated = pl.tile.matmul_acc(carried, sa, sb)
+                    loop_result = pl.yield_(updated)
+                if cond < 1:
+                    merged = pl.yield_(loop_result)
+                else:
+                    seed = pl.tile.matmul(sa, sb)
+                    merged = pl.yield_(seed)
+                bypass_result = pl.tile.store(loop_result, [0, 0], bypass_out)
+                result = pl.tile.store(merged, [0, 0], out)
+                return bypass_result, result
+
+        # The pre-if loop result remains live after the if. Treating it as a
+        # branch-local accumulator would retarget the sibling seed onto its
+        # buffer and clobber bypass_result on that path. Decline and fail closed
+        # because the remaining divergent Acc phi has no legal repair move.
+        with pytest.raises(InternalError, match="cannot reconcile divergent L0C accumulator buffers"):
+            _run_pipeline(Before)
+
+    def test_branch_local_accumulator_loop_preserves_external_seed_after_if(self):
+        """A branch-local accumulator loop cannot donate an externally live buffer.
+
+        The loop mutates ``initial`` only on the then path. Retargeting the else
+        branch's fresh ``seed`` onto that allocation would also overwrite
+        ``bypass_result`` on the else path, where the loop never executes.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                lhs: pl.Tensor[[16, 64], pl.BF16],
+                rhs: pl.Tensor[[64, 64], pl.BF16],
+                cond: pl.Scalar[pl.INDEX],
+                bypass_out: pl.Out[pl.Tensor[[16, 64], pl.FP32]],
+                out: pl.Out[pl.Tensor[[16, 64], pl.FP32]],
+            ) -> tuple[pl.Tensor[[16, 64], pl.FP32], pl.Tensor[[16, 64], pl.FP32]]:
+                sa_mat = pl.tile.load(lhs, [0, 0], [16, 64], target_memory=pl.Mem.Mat)
+                sb_mat = pl.tile.load(rhs, [0, 0], [64, 64], target_memory=pl.Mem.Mat)
+                sa = pl.tile.move(sa_mat, target_memory=pl.Mem.Left)
+                sb = pl.tile.move(sb_mat, target_memory=pl.Mem.Right)
+                initial = pl.tile.matmul(sa, sb)
+                if cond < 1:
+                    for _k, (carried,) in pl.range(1, init_values=(initial,)):
+                        updated = pl.tile.matmul_acc(carried, sa, sb)
+                        loop_result = pl.yield_(updated)
+                    merged = pl.yield_(loop_result)
+                else:
+                    seed = pl.tile.matmul(sa, sb)
+                    merged = pl.yield_(seed)
+                bypass_result = pl.tile.store(initial, [0, 0], bypass_out)
+                result = pl.tile.store(merged, [0, 0], out)
+                return bypass_result, result
+
+        # Retargeting ``seed`` onto ``initial`` is unsafe because ``initial``
+        # remains independently observable after the if on the else path. The
+        # remaining divergent Acc phi has no legal Acc-to-Acc repair move.
+        with pytest.raises(InternalError, match="cannot reconcile divergent L0C accumulator buffers"):
+            _run_pipeline(Before)
+
+    def test_accumulator_if_phi_same_base_disjoint_windows_are_coalesced(self):
+        """Same base with a different byte window is not an aligned accumulator.
+
+        This models post-InitMemRef IR where two Acc tiles occupy disjoint halves
+        of one allocation. The fresh seed must be retargeted to the accumulator's
+        exact window; base-pointer equality alone leaves the phi reading bytes
+        that the seed branch never wrote.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                lhs: pl.Tensor[[16, 64], pl.BF16, pl.MemRef("mem_ddr_0", 0, 2048)],
+                rhs: pl.Tensor[[64, 64], pl.BF16, pl.MemRef("mem_ddr_1", 0, 8192)],
+                cond: pl.Scalar[pl.INDEX],
+                out: pl.Out[pl.Tensor[[16, 64], pl.FP32, pl.MemRef("mem_ddr_2", 0, 4096)]],
+            ) -> pl.Tensor[[16, 64], pl.FP32]:
+                mem_mat_3: pl.Ptr = pl.tile.alloc(pl.Mem.Mat, 2048)
+                mem_mat_4: pl.Ptr = pl.tile.alloc(pl.Mem.Mat, 8192)
+                mem_acc_5: pl.Ptr = pl.tile.alloc(pl.Mem.Acc, 8192)
+                sa: pl.Tile[[16, 64], pl.BF16, pl.MemRef(mem_mat_3, 0, 2048), pl.Mem.Mat] = pl.tile.load(
+                    lhs, [0, 0], [16, 64], [16, 64], target_memory=pl.Mem.Mat
+                )
+                sb: pl.Tile[[64, 64], pl.BF16, pl.MemRef(mem_mat_4, 0, 8192), pl.Mem.Mat] = pl.tile.load(
+                    rhs, [0, 0], [64, 64], [64, 64], target_memory=pl.Mem.Mat
+                )
+                prev: pl.Tile[[16, 64], pl.FP32, pl.MemRef(mem_acc_5, 0, 4096), pl.Mem.Acc] = pl.tile.matmul(
+                    sa, sb
+                )
+                if cond < 1:
+                    seed: pl.Tile[[16, 64], pl.FP32, pl.MemRef(mem_acc_5, 4096, 4096), pl.Mem.Acc] = (
+                        pl.tile.matmul(sa, sb)
+                    )
+                    phi = pl.yield_(seed)
+                else:
+                    acc: pl.Tile[[16, 64], pl.FP32, pl.MemRef(mem_acc_5, 0, 4096), pl.Mem.Acc] = (
+                        pl.tile.matmul_acc(prev, sa, sb)
+                    )
+                    phi = pl.yield_(acc)
+                return pl.tile.store(phi, [0, 0], out)
+
+        after = passes.memory_reuse()(Before)
+        ranges = _collect_allocated_tile_ranges(after)
+        for name in ("prev", "seed", "acc"):
+            assert ranges[name] == (0, 4096), f"{name} did not use the canonical Acc window: {ranges}"
+
+        phi_ranges: list[tuple[int, int]] = []
+
+        class _IfReturnCollector(ir.IRVisitor):
+            def visit_if_stmt(self, stmt):  # type: ignore[override]
+                for var in stmt.return_vars:
+                    tile_type = var.type
+                    if isinstance(tile_type, ir.TileType) and tile_type.memref is not None:
+                        offset = tile_type.memref.byte_offset_
+                        assert isinstance(offset, ir.ConstInt)
+                        phi_ranges.append((offset.value, tile_type.memref.size_))
+                super().visit_if_stmt(stmt)
+
+        main = after.get_function("kernel")
+        assert main is not None
+        _IfReturnCollector().visit_stmt(main.body)
+        assert phi_ranges == [(0, 4096)]
+
+    def test_divergent_bare_acc_alias_fails_closed(self):
+        """An alias with a stale MemRef cannot select the accumulator target."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                lhs: pl.Tensor[[16, 64], pl.BF16, pl.MemRef("mem_ddr_0", 0, 2048)],
+                rhs: pl.Tensor[[64, 64], pl.BF16, pl.MemRef("mem_ddr_1", 0, 8192)],
+                cond: pl.Scalar[pl.INDEX],
+                out: pl.Out[pl.Tensor[[16, 64], pl.FP32, pl.MemRef("mem_ddr_2", 0, 4096)]],
+            ) -> pl.Tensor[[16, 64], pl.FP32]:
+                mem_mat_3: pl.Ptr = pl.tile.alloc(pl.Mem.Mat, 2048)
+                mem_mat_4: pl.Ptr = pl.tile.alloc(pl.Mem.Mat, 8192)
+                mem_acc_5: pl.Ptr = pl.tile.alloc(pl.Mem.Acc, 4096)
+                mem_acc_6: pl.Ptr = pl.tile.alloc(pl.Mem.Acc, 4096)
+                mem_acc_7: pl.Ptr = pl.tile.alloc(pl.Mem.Acc, 4096)
+                sa: pl.Tile[[16, 64], pl.BF16, pl.MemRef(mem_mat_3, 0, 2048), pl.Mem.Mat] = pl.tile.load(
+                    lhs, [0, 0], [16, 64], [16, 64], target_memory=pl.Mem.Mat
+                )
+                sb: pl.Tile[[64, 64], pl.BF16, pl.MemRef(mem_mat_4, 0, 8192), pl.Mem.Mat] = pl.tile.load(
+                    rhs, [0, 0], [64, 64], [64, 64], target_memory=pl.Mem.Mat
+                )
+                prev: pl.Tile[[16, 64], pl.FP32, pl.MemRef(mem_acc_5, 0, 4096), pl.Mem.Acc] = pl.tile.matmul(
+                    sa, sb
+                )
+                if cond < 1:
+                    seed: pl.Tile[[16, 64], pl.FP32, pl.MemRef(mem_acc_7, 0, 4096), pl.Mem.Acc] = (
+                        pl.tile.matmul(sa, sb)
+                    )
+                    phi = pl.yield_(seed)
+                else:
+                    acc: pl.Tile[[16, 64], pl.FP32, pl.MemRef(mem_acc_5, 0, 4096), pl.Mem.Acc] = (
+                        pl.tile.matmul_acc(prev, sa, sb)
+                    )
+                    stale_alias: pl.Tile[[16, 64], pl.FP32, pl.MemRef(mem_acc_6, 0, 4096), pl.Mem.Acc] = acc
+                    phi = pl.yield_(stale_alias)
+                return pl.tile.store(phi, [0, 0], out)
+
+        with pytest.raises(InternalError, match="cannot align the accumulator branch"):
+            passes.materialize_semantic_aliases()(Before)
 
     def test_seed_branch_write_only_clobber_blocks_acc_coalesce(self):
         """Safety gate for the accumulator-if-phi coalescer's branch-tail


### PR DESCRIPTION
## Summary

Fix nested K-loop accumulators lowered into peeled `matmul` / `matmul_acc` branches so the first partial, later accumulations, loop carry, and final drain share one canonical L0C allocation. Previously, lowering-created aliases could retain stale MemRefs, allowing PYPTO, DSA-RP, or PTOAS to place the first partial and the accumulation target in different buffers; that either required an unsupported Acc-to-Acc repair move or silently lost the first K contribution. Safe branch-local joins are now canonicalized before memory-planner ownership diverges, while ambiguous or non-local joins fail closed.

## Changes

- Resolve an in-place accumulator's canonical target from its registered reused input instead of trusting an outer alias's potentially stale type.
- Require both the accumulator loop and sibling seed to be local to their respective branches, preserve the existing liveness guard, and pin the merged phi to the canonical accumulator allocation.
- Normalize bare SSA aliases and registered in-place results before PYPTO, DSA-RP, or PTOAS observes lifetimes or emits handles.
- Add cross-planner PTO assertions proving the first `tmatmul` and every `tmatmul.acc` use one handle, plus fail-closed regressions for stale aliases and non-branch-local loops.
- Document the semantic-alias contract in English and Chinese.

## Verification

- `cmake --build build-nested-main --parallel 2`: passed after rebasing onto current `main`.
- `ctest --test-dir build-nested-main --output-on-failure -j 2`: 1/1 passed.
- `python -m pytest tests/ut/ir/transforms/test_memory_reuse.py -q`: 109 passed.
- `python -m pytest tests/ut/codegen/test_pto_codegen_ops.py -q`: 156 passed.
- `python -m pytest tests/ut/codegen/test_memory_planner_switch.py tests/ut/codegen/test_ptoas_planner_views.py -q`: 35 passed.
- Ruff check/format, clang-format, diff checks, EN/ZH documentation parity, and documentation navigation checks: passed.
- Two-device 910B2 validation of the patch before its patch-identical rebase: PYPTO, DSA-RP, and PTOAS each emitted one persistent L0C family; 16 device cells passed with NaN-prefilled outputs, one fixed-input signature, and bit-identical independent controls.
- Composed validation with the split-AIV FIFO-lane repair: dense C,C→V→C SwiGLU passed on both devices with one L0C accumulator and all 6/6 split FIFO calls forwarding the runtime lane.