### PR TITLE
ci: support mixed-architecture self-hosted runners and bound the shared uv cache

### DIFF
--- a/.github/actions/setup-ci-job/action.yml
+++ b/.github/actions/setup-ci-job/action.yml
@@ -230,6 +230,11 @@ runs:
         # concurrent access, and sharing it is the point — a wheel any job has
         # already downloaded is hardlinked into the next venv instead of being
         # fetched and unpacked again.
+        #
+        # Sharing it also means nothing bounds it: uv has no size cap and evicts
+        # nothing on its own. The last step of this action is what keeps it from
+        # growing without limit; see the comment there for what it removes and
+        # why that specific set.
         {
           echo "CCACHE_DIR=$CI_CACHE_ROOT/ccache"
           echo "PIP_CACHE_DIR=$CI_CACHE_ROOT/$PIP_CACHE_NAME"
@@ -753,3 +758,79 @@ runs:
     - name: Show ccache stats (after)
       shell: bash
       run: ccache -s || true
+
+    - name: Drop the always-rebuilt local wheels from the shared uv cache
+      # Runs even when the build failed: a crashed run leaves its entries behind
+      # too, and this removes them by package name rather than by run.
+      if: ${{ always() && inputs.toolchain == 'bundle' }}
+      shell: bash
+      working-directory: ${{ inputs.checkout-path }}
+      run: |
+        # UV_CACHE_DIR is shared by every job on this host (see "Check runner
+        # config"), and uv bounds it in no way at all: there is no size cap, no
+        # TTL, and no eviction — only the explicit `uv cache clean` / `uv cache
+        # prune` commands. Nothing in this repo ran either, so the directory only
+        # ever grew, and on a busy host it reached the terabyte range.
+        #
+        # What grew is pypto and simpler specifically. Both are installed from a
+        # local directory named on the command line:
+        #
+        #     uv pip install --no-build-isolation '.[dev]'
+        #     uv pip install --no-build-isolation ./runtime
+        #
+        # and uv documents that form as a special case — it "will always rebuild
+        # and reinstall any local directory dependencies passed explicitly on the
+        # command-line". Always rebuilt means the cached wheel can never be hit,
+        # so these entries carry no value whatsoever; they are pure residue, and
+        # each one is an extension-module wheel (~112 MiB at -g2, ~19 MiB at -g1).
+        # Nine self-hosted jobs per run, seven of them also building simpler, all
+        # writing into one directory that never shrinks.
+        #
+        # Clean by package name, which leaves the part of the cache that does pay
+        # for itself — torch, nanobind, cmake, ninja and the rest of the resolved
+        # dependency set — intact for the next job.
+        #
+        # NOT `uv cache prune --ci`, the usual CI recommendation: it removes
+        # pre-built wheels and *retains* wheels built from source, which is
+        # precisely backwards here. It would evict the entries worth keeping and
+        # keep the ones that grow.
+        if [ ! -f activate.sh ]; then
+          echo "no activate.sh (bootstrap did not get that far) — skipping"
+          exit 0
+        fi
+        source activate.sh
+        if ! command -v uv >/dev/null 2>&1; then
+          echo "uv not on PATH — skipping"
+          exit 0
+        fi
+        cache_dir="$(uv cache dir 2>/dev/null || echo "${UV_CACHE_DIR:-}")"
+        # One job per host does this, not all of them. `uv cache clean` takes a
+        # lock over the *whole* cache, and every job here reaches this step at
+        # roughly the same time while its neighbours are still installing. Left
+        # to queue, each one pays the wait and only the first accomplishes
+        # anything: a measured run had a job block 4m22s and then report "No
+        # cache entries found", because the holder had already removed the same
+        # entries. `flock -n` turns that wait into an immediate exit.
+        #
+        # The lock lives under CI_CACHE_ROOT, which the runner-config step
+        # creates, rather than in the cache dir, which may not exist yet.
+        exec 9>"$CI_CACHE_ROOT/.uv-cleanup.lock" || exit 0
+        if ! flock -n 9; then
+          echo "another job on this host is already cleaning the uv cache — skipping"
+          exit 0
+        fi
+        # df, not du: this runs on the critical path and `du` walks the tree,
+        # which on the terabyte-scale cache this step exists to prevent is the
+        # slowest thing here. The filesystem's own accounting is O(1) and is
+        # what the disk-space alarm actually watches. uv reports what it removed.
+        df -h "$cache_dir" 2>/dev/null | tail -1 | sed "s|^|cache_df before |" || true
+        # No --force. That flag skips uv's in-use lock, and the cache is shared
+        # with whatever else the host is running; a concurrent install must not
+        # have entries deleted from under it.
+        #
+        # UV_LOCK_TIMEOUT caps how long we wait for that lock (default 300s).
+        # Keep it short: this job's tests are queued behind this step, and the
+        # work is not urgent — whichever job next finds the lock free does it.
+        UV_LOCK_TIMEOUT=30 uv cache clean pypto simpler \
+          || echo "::warning::uv cache clean did not complete (cache left as-is)"
+        df -h "$cache_dir" 2>/dev/null | tail -1 | sed "s|^|cache_df after  |" || true

--- a/.github/actions/setup-ci-job/action.yml
+++ b/.github/actions/setup-ci-job/action.yml
@@ -43,12 +43,15 @@ description: >-
   is tempted to find an interpreter on its own; conda is the wrong answer, and
   the right one is to move the step after the bootstrap instead.
 
-  The calling job must define PTOAS_ROOT, PTOAS_VERSION,
-  PTOAS_SHA256, the CMAKE_* and the non-path CCACHE_* (MAXSIZE / UMASK) environment
-  variables; they are read from the job environment here. CCACHE_NAMESPACE and
-  every cache path (CCACHE_DIR, PIP_CACHE_DIR, PTOAS_CACHE_DIR, UV_CACHE_DIR) are
-  resolved and exported by this action — they derive from CI_CACHE_ROOT and so
-  cannot live in the caller's static job-level `env:` block.
+  When install-toolchain is true, the calling job must define PTOAS_ROOT,
+  PTOAS_VERSION, PTOAS_SHA256_AARCH64, and PTOAS_SHA256_X86_64. Every caller
+  must also define the CMAKE_* and non-path CCACHE_* (MAXSIZE / UMASK)
+  environment variables; they are read from the job environment here. The
+  action selects the checksum that matches the actual host architecture.
+  CCACHE_NAMESPACE and every cache path (CCACHE_DIR, PIP_CACHE_DIR,
+  PTOAS_CACHE_DIR, UV_CACHE_DIR) are resolved and exported by this action —
+  they derive from CI_CACHE_ROOT and so cannot live in the caller's static
+  job-level `env:` block.
 
   Which installer a job gets follows from its toolchain, and the bootstrap step
   states it in PYPTO_USE_UV. The bundle carries uv, so bundle jobs build the venv
@@ -561,6 +564,25 @@ runs:
         # intentionally tests Python 3.10. Install the matching cp310 wheel into
         # an isolated venv so PTOAS_ROOT/bin/ptoas keeps the existing contract.
         PTOAS_ARCH="$(uname -m)"
+        case "$PTOAS_ARCH" in
+          aarch64)
+            PTOAS_SHA256_NAME=PTOAS_SHA256_AARCH64
+            PTOAS_SHA256="${PTOAS_SHA256_AARCH64:-}"
+            ;;
+          x86_64)
+            PTOAS_SHA256_NAME=PTOAS_SHA256_X86_64
+            PTOAS_SHA256="${PTOAS_SHA256_X86_64:-}"
+            ;;
+          *)
+            echo "::error::Unsupported ptoas host architecture '$PTOAS_ARCH'"
+            echo "Supported architectures are aarch64 and x86_64."
+            exit 1
+            ;;
+        esac
+        if ! printf '%s' "$PTOAS_SHA256" | grep -qE '^[0-9a-f]{64}$'; then
+          echo "::error::$PTOAS_SHA256_NAME must be a 64-character lowercase SHA256"
+          exit 1
+        fi
         PTOAS_PACKAGE_VERSION="${PTOAS_VERSION#v}"
         PTOAS_WHEEL_NAME="ptoas-${PTOAS_PACKAGE_VERSION}-cp310-cp310-manylinux_2_34_${PTOAS_ARCH}.whl"
         CACHE_WHEEL="$PTOAS_CACHE_DIR/$PTOAS_WHEEL_NAME"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
   # one of them is documentation, elides the whole build/test pipeline below:
   # `clang-tidy`, `unit-tests`, `codegen-tests`, the four device jobs and
   # `system-tests-a5sim`. A prose-only change cannot break a build or a test, so
-  # spending four in-house arm64 CPU / NPU slots (a scarce shared pool) on it
+  # spending four in-house CPU / NPU slots (a scarce shared pool) on it
   # only delays every other PR in the queue.
   #
   # Two mechanisms, because one of them does not work for a matrix job:
@@ -236,7 +236,7 @@ jobs:
   # test job lists both of them in its `needs` (the five jobs that also consume
   # `needs.toolchain.outputs.*` list `toolchain` alongside), so a formatting or
   # static-analysis failure short-circuits the run before any downstream job
-  # claims a GitHub-hosted ubuntu slot or one of the in-house arm64 CPU / NPU
+  # claims a GitHub-hosted ubuntu slot or one of the in-house CPU / NPU
   # slots (a scarce shared pool).
   #
   # This cannot weaken the merge rule: `pre-commit` and `clang-tidy` are
@@ -247,16 +247,16 @@ jobs:
   # both in that required list; the whole gate rests on it.
   #
   # Accepted trade-offs:
-  #  - `clang-tidy` runs on the in-house arm64 *cpu* pool, so that pool is now a
+  #  - `clang-tidy` runs on the in-house *cpu* pool, so that pool is now a
   #    serialization point for the whole workflow: if it is saturated or offline,
   #    no test job starts. Its setup is not cheap either (per-job venv, pip
   #    install of cmake/ninja/nanobind + pinned clang-tidy, a full CMake
   #    configure), and that wall time is prepended to every test job on the green
   #    path. Accepted to keep a non-linting tree off the scarce device runners.
   #  - `codegen-tests` used to run concurrently with `clang-tidy` on that same
-  #    arm64 cpu pool (hence their separate checkout trees, so neither one's
+  #    self-hosted cpu pool (hence their separate checkout trees, so neither one's
   #    `git clean` wipes the other). They are serialized within a run now, which
-  #    frees a slot for other PRs at the cost of arm64-cpu wall time.
+  #    frees a slot for other PRs at the cost of self-hosted cpu wall time.
   #
   # `toolchain` is deliberately NOT gated: it is a seconds-long metadata read on
   # a free GitHub-hosted runner, so gating it would protect no scarce capacity
@@ -284,7 +284,7 @@ jobs:
     env:
       PIP_CONSTRAINT: ${{ github.workspace }}/clang-tidy-checkout/build-constraints.txt
       PIP_BUILD_CONSTRAINT: ${{ github.workspace }}/clang-tidy-checkout/build-constraints.txt
-    # De-containered: runs host-native on the in-house arm64 CPU runner (same
+    # De-containered: runs host-native on the in-house CPU runner (same
     # infra as before, minus the localhost:5000/ci-py310 image). clang_tidy.py
     # generates compile_commands.json via a CMake configure (needs cmake / ninja /
     # nanobind and a C++ compiler) and pip-installs the pinned clang-tidy, so it
@@ -293,13 +293,13 @@ jobs:
     # pto-isa / simpler / device) — just the conda env + a per-job venv.
     #
     # Checks out under ./clang-tidy-checkout so its `git clean` never wipes the
-    # sibling codegen-checkout tree (both jobs share the arm64 cpu runner pool).
+    # sibling codegen-checkout tree (both jobs share the cpu runner pool).
     #
     # Docs-only gate (see the `changes` job) — a prose-only PR touches no C++, and
-    # skipping the gate here keeps the scarce arm64 cpu pool free.
+    # skipping the gate here keeps the scarce cpu pool free.
     needs: changes
     if: needs.changes.outputs.docs_only != 'true'
-    runs-on: [self-hosted, linux, arm64, cpu]
+    runs-on: [self-hosted, linux, cpu]
     defaults:
       run:
         working-directory: clang-tidy-checkout
@@ -471,7 +471,7 @@ jobs:
     if: needs.changes.outputs.docs_changed == 'true'
     permissions:
       contents: read
-    runs-on: [self-hosted, linux, arm64, cpu]
+    runs-on: [self-hosted, linux, cpu]
     defaults:
       run:
         working-directory: docs-checkout
@@ -479,7 +479,8 @@ jobs:
       PTOAS_ROOT: ${{ github.workspace }}/docs-checkout/ptoas-bin
       PTO_ISA_ROOT: ${{ github.workspace }}/docs-checkout/pto-isa
       PTOAS_VERSION: ${{ needs.toolchain.outputs.ptoas_version }}
-      PTOAS_SHA256: ${{ needs.toolchain.outputs.ptoas_sha256_aarch64 }}
+      PTOAS_SHA256_AARCH64: ${{ needs.toolchain.outputs.ptoas_sha256_aarch64 }}
+      PTOAS_SHA256_X86_64: ${{ needs.toolchain.outputs.ptoas_sha256_x86_64 }}
       CMAKE_BUILD_PARALLEL_LEVEL: 16
       CMAKE_C_COMPILER_LAUNCHER: ccache
       CMAKE_CXX_COMPILER_LAUNCHER: ccache
@@ -521,14 +522,15 @@ jobs:
     # Checkout + test only — no write scopes needed on GITHUB_TOKEN.
     permissions:
       contents: read
-    runs-on: [self-hosted, linux, arm64, cpu]
+    runs-on: [self-hosted, linux, cpu]
     defaults:
       run:
         working-directory: examples-checkout
     env:
       PTOAS_ROOT: ${{ github.workspace }}/examples-checkout/ptoas-bin
       PTOAS_VERSION: ${{ needs.toolchain.outputs.ptoas_version }}
-      PTOAS_SHA256: ${{ needs.toolchain.outputs.ptoas_sha256_aarch64 }}
+      PTOAS_SHA256_AARCH64: ${{ needs.toolchain.outputs.ptoas_sha256_aarch64 }}
+      PTOAS_SHA256_X86_64: ${{ needs.toolchain.outputs.ptoas_sha256_x86_64 }}
       CMAKE_BUILD_PARALLEL_LEVEL: 16
       CMAKE_C_COMPILER_LAUNCHER: ccache
       CMAKE_CXX_COMPILER_LAUNCHER: ccache
@@ -621,12 +623,12 @@ jobs:
     # land under ./codegen-checkout so they don't collide with other jobs' trees
     # on the shared self-hosted host.
     #
-    # Lint gate (see the pre-commit job) — shares the arm64 cpu pool with
+    # Lint gate (see the pre-commit job) — shares the self-hosted cpu pool with
     # clang-tidy, so it must not start until that pool's lint job is green.
     # Docs-only gate (see the `changes` job) — prose cannot break a build.
     needs: [changes, pre-commit, clang-tidy]
     if: needs.changes.outputs.docs_only != 'true'
-    runs-on: [self-hosted, linux, arm64, cpu]
+    runs-on: [self-hosted, linux, cpu]
     defaults:
       run:
         working-directory: codegen-checkout
@@ -718,16 +720,17 @@ jobs:
     # TEST MODE: keep the device runner so DEVICE_ID/DEVICE_ID exist and pin
     # task-submit to that card (validates the new compile-card-free + task-submit
     # execute flow deterministically). FLIP TO PROD: change this to
-    # `[self-hosted, linux, arm64, cpu]` and drop --task-submit-device below so
+    # `[self-hosted, linux, cpu]` and drop --task-submit-device below so
     # cases borrow any free card via `--device auto`.
-    runs-on: [self-hosted, linux, arm64, npu]
+    runs-on: [self-hosted, linux, npu]
     defaults:
       run:
         working-directory: st-checkout
     env:
       PTOAS_ROOT: ${{ github.workspace }}/st-checkout/ptoas-bin
       PTOAS_VERSION: ${{ needs.toolchain.outputs.ptoas_version }}
-      PTOAS_SHA256: ${{ needs.toolchain.outputs.ptoas_sha256_aarch64 }}
+      PTOAS_SHA256_AARCH64: ${{ needs.toolchain.outputs.ptoas_sha256_aarch64 }}
+      PTOAS_SHA256_X86_64: ${{ needs.toolchain.outputs.ptoas_sha256_x86_64 }}
       CMAKE_BUILD_PARALLEL_LEVEL: 16
       CMAKE_C_COMPILER_LAUNCHER: ccache
       CMAKE_CXX_COMPILER_LAUNCHER: ccache
@@ -836,16 +839,17 @@ jobs:
       contents: read
     # TEST MODE: keep the device runner so DEVICE_ID exists and pin task-submit
     # to that card. FLIP TO PROD: change this to
-    # `[self-hosted, linux, arm64, cpu]` and drop --task-submit-device / the
+    # `[self-hosted, linux, cpu]` and drop --task-submit-device / the
     # explicit --device below so cases borrow any free card via `--device auto`.
-    runs-on: [self-hosted, linux, arm64, npu]
+    runs-on: [self-hosted, linux, npu]
     defaults:
       run:
         working-directory: st-direct-checkout
     env:
       PTOAS_ROOT: ${{ github.workspace }}/st-direct-checkout/ptoas-bin
       PTOAS_VERSION: ${{ needs.toolchain.outputs.ptoas_version }}
-      PTOAS_SHA256: ${{ needs.toolchain.outputs.ptoas_sha256_aarch64 }}
+      PTOAS_SHA256_AARCH64: ${{ needs.toolchain.outputs.ptoas_sha256_aarch64 }}
+      PTOAS_SHA256_X86_64: ${{ needs.toolchain.outputs.ptoas_sha256_x86_64 }}
       CMAKE_BUILD_PARALLEL_LEVEL: 16
       CMAKE_C_COMPILER_LAUNCHER: ccache
       CMAKE_CXX_COMPILER_LAUNCHER: ccache
@@ -981,14 +985,15 @@ jobs:
       contents: read
     # TEST MODE: keep the 2-device runner and pin task-submit to DEVICE_ID
     # (see system-tests). FLIP TO PROD: cpu runner + `--device auto --device-num 2`.
-    runs-on: [self-hosted, linux, arm64, npu]
+    runs-on: [self-hosted, linux, npu]
     defaults:
       run:
         working-directory: dist-checkout
     env:
       PTOAS_ROOT: ${{ github.workspace }}/dist-checkout/ptoas-bin
       PTOAS_VERSION: ${{ needs.toolchain.outputs.ptoas_version }}
-      PTOAS_SHA256: ${{ needs.toolchain.outputs.ptoas_sha256_aarch64 }}
+      PTOAS_SHA256_AARCH64: ${{ needs.toolchain.outputs.ptoas_sha256_aarch64 }}
+      PTOAS_SHA256_X86_64: ${{ needs.toolchain.outputs.ptoas_sha256_x86_64 }}
       CMAKE_BUILD_PARALLEL_LEVEL: 16
       CMAKE_C_COMPILER_LAUNCHER: ccache
       CMAKE_CXX_COMPILER_LAUNCHER: ccache
@@ -1065,14 +1070,15 @@ jobs:
       contents: read
     # TEST MODE: keep the device runner and pin task-submit to its card (see
     # system-tests). FLIP TO PROD: cpu runner + `--device auto`.
-    runs-on: [self-hosted, linux, arm64, npu]
+    runs-on: [self-hosted, linux, npu]
     defaults:
       run:
         working-directory: lib-checkout
     env:
       PTOAS_ROOT: ${{ github.workspace }}/lib-checkout/ptoas-bin
       PTOAS_VERSION: ${{ needs.toolchain.outputs.ptoas_version }}
-      PTOAS_SHA256: ${{ needs.toolchain.outputs.ptoas_sha256_aarch64 }}
+      PTOAS_SHA256_AARCH64: ${{ needs.toolchain.outputs.ptoas_sha256_aarch64 }}
+      PTOAS_SHA256_X86_64: ${{ needs.toolchain.outputs.ptoas_sha256_x86_64 }}
       CMAKE_BUILD_PARALLEL_LEVEL: 16
       CMAKE_C_COMPILER_LAUNCHER: ccache
       CMAKE_CXX_COMPILER_LAUNCHER: ccache
@@ -1280,14 +1286,15 @@ jobs:
     # Checkout + test only — no write scopes needed on GITHUB_TOKEN.
     permissions:
       contents: read
-    runs-on: [self-hosted, linux, arm64, npu-a5]
+    runs-on: [self-hosted, linux, npu-a5]
     defaults:
       run:
         working-directory: a5-checkout
     env:
       PTOAS_ROOT: ${{ github.workspace }}/a5-checkout/ptoas-bin
       PTOAS_VERSION: ${{ needs.toolchain.outputs.ptoas_version }}
-      PTOAS_SHA256: ${{ needs.toolchain.outputs.ptoas_sha256_aarch64 }}
+      PTOAS_SHA256_AARCH64: ${{ needs.toolchain.outputs.ptoas_sha256_aarch64 }}
+      PTOAS_SHA256_X86_64: ${{ needs.toolchain.outputs.ptoas_sha256_x86_64 }}
       CMAKE_BUILD_PARALLEL_LEVEL: 16
       CMAKE_C_COMPILER_LAUNCHER: ccache
       CMAKE_CXX_COMPILER_LAUNCHER: ccache

--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -53,14 +53,15 @@ jobs:
     # Checkout + test only — no write scopes needed on GITHUB_TOKEN.
     permissions:
       contents: read
-    runs-on: [self-hosted, linux, arm64, npu-a5]
+    runs-on: [self-hosted, linux, npu-a5]
     defaults:
       run:
         working-directory: daily-a5-checkout
     env:
       PTOAS_ROOT: ${{ github.workspace }}/daily-a5-checkout/ptoas-bin
       PTOAS_VERSION: ${{ needs.toolchain.outputs.ptoas_version }}
-      PTOAS_SHA256: ${{ needs.toolchain.outputs.ptoas_sha256_aarch64 }}
+      PTOAS_SHA256_AARCH64: ${{ needs.toolchain.outputs.ptoas_sha256_aarch64 }}
+      PTOAS_SHA256_X86_64: ${{ needs.toolchain.outputs.ptoas_sha256_x86_64 }}
       CMAKE_BUILD_PARALLEL_LEVEL: 16
       CMAKE_C_COMPILER_LAUNCHER: ccache
       CMAKE_CXX_COMPILER_LAUNCHER: ccache
@@ -137,14 +138,15 @@ jobs:
       contents: read
     # TEST MODE: keep the device runner and pin task-submit to its card (see
     # ci.yml system-tests). FLIP TO PROD: cpu runner + `--device auto`.
-    runs-on: [self-hosted, linux, arm64, npu]
+    runs-on: [self-hosted, linux, npu]
     defaults:
       run:
         working-directory: perf-checkout
     env:
       PTOAS_ROOT: ${{ github.workspace }}/perf-checkout/ptoas-bin
       PTOAS_VERSION: ${{ needs.toolchain.outputs.ptoas_version }}
-      PTOAS_SHA256: ${{ needs.toolchain.outputs.ptoas_sha256_aarch64 }}
+      PTOAS_SHA256_AARCH64: ${{ needs.toolchain.outputs.ptoas_sha256_aarch64 }}
+      PTOAS_SHA256_X86_64: ${{ needs.toolchain.outputs.ptoas_sha256_x86_64 }}
       CMAKE_BUILD_PARALLEL_LEVEL: 16
       CMAKE_C_COMPILER_LAUNCHER: ccache
       CMAKE_CXX_COMPILER_LAUNCHER: ccache

--- a/docs/en/user/performance/04-incore.md
+++ b/docs/en/user/performance/04-incore.md
@@ -17,8 +17,9 @@ NT, TR, TC = 8, 64, 128          # tiles in the loop, tile rows, tile cols
 ROWS = NT * TR
 CFG = RunConfig(platform="__PLATFORM__")
 
-torch.manual_seed(0)
-A = torch.randn(ROWS, TC, dtype=torch.float32)
+# Cycle through binary-exact values in a stable range on every host architecture.
+indices = torch.arange(ROWS * TC, dtype=torch.int64)
+A = (indices % 3 - 1).to(torch.float32).reshape(ROWS, TC)
 
 
 def check(kernel):

--- a/docs/zh/user/performance/04-incore.md
+++ b/docs/zh/user/performance/04-incore.md
@@ -16,8 +16,9 @@ NT, TR, TC = 8, 64, 128          # tiles in the loop, tile rows, tile cols
 ROWS = NT * TR
 CFG = RunConfig(platform="__PLATFORM__")
 
-torch.manual_seed(0)
-A = torch.randn(ROWS, TC, dtype=torch.float32)
+# Cycle through binary-exact values in a stable range on every host architecture.
+indices = torch.arange(ROWS * TC, dtype=torch.int64)
+A = (indices % 3 - 1).to(torch.float32).reshape(ROWS, TC)
 
 
 def check(kernel):


### PR DESCRIPTION
## Summary

Every self-hosted job pinned `arm64` in `runs-on`, so an x86_64 host could never
pick up work even when it carried the same `cpu` / `npu` / `npu-a5` capability
label. This drops the architecture label from all 11 self-hosted jobs and makes
the one thing that genuinely depended on the architecture — the ptoas wheel
checksum — resolve from the host instead of from a caller-side constant.

The capability labels keep their meaning: `cpu` still means "can build and run
host tests", `npu` still means "has an A2/A3 card", `npu-a5` still means "has an
A5 card". Only the "and is aarch64" part goes away.

It also bounds the shared uv cache, which had grown to roughly a terabyte on one
CI host and was reported as a disk-space alarm. That is a separate defect from
the runner labels, but it lives in the same action and in the same "self-hosted
hosts accumulate state that nothing prunes" family, so it rides along here rather
than in a second infrastructure PR.

## Why one checksum cannot serve a mixed pool

The wheel *name* was already architecture-derived, but the digest it was checked
against was not. In `setup-ci-job`:

```bash
PTOAS_ARCH="$(uname -m)"
PTOAS_WHEEL_NAME="ptoas-${PTOAS_PACKAGE_VERSION}-cp310-cp310-manylinux_2_34_${PTOAS_ARCH}.whl"
...
echo "${PTOAS_SHA256}  $tmp_wheel" | sha256sum -c -
```

Every caller fed `PTOAS_SHA256` from `needs.toolchain.outputs.ptoas_sha256_aarch64`.
On an x86_64 host that pair downloads the *correct* x86_64 wheel and then verifies
it against the *aarch64* digest, so the job dies in `sha256sum -c` — after the
download, with a bare checksum mismatch that names neither the architecture nor
the cause. Removing the `arm64` label without fixing this would turn a scheduling
improvement into a confusing hard failure on the first x86_64 host that picks up
a job.

## Changes

### Runner labels

| Workflow | Jobs | Before | After |
| --- | --- | --- | --- |
| `ci.yml` | `clang-tidy`, `docs-examples`, `examples-tests`, `codegen-tests` | `[self-hosted, linux, arm64, cpu]` | `[self-hosted, linux, cpu]` |
| `ci.yml` | `system-tests`, `system-tests-direct`, `dist-system-tests`, `pypto-lib-model` | `[self-hosted, linux, arm64, npu]` | `[self-hosted, linux, npu]` |
| `ci.yml` | `mixed-kernel-tests-a5` | `[self-hosted, linux, arm64, npu-a5]` | `[self-hosted, linux, npu-a5]` |
| `daily_ci.yml` | `a5-system-tests` | `[self-hosted, linux, arm64, npu-a5]` | `[self-hosted, linux, npu-a5]` |
| `daily_ci.yml` | `qwen3-perf` | `[self-hosted, linux, arm64, npu]` | `[self-hosted, linux, npu]` |

The surrounding comments described these as "the in-house arm64 cpu pool" and
"arm64-cpu wall time"; those are reworded, since the sentence they were making —
a scarce shared pool that must not be spent on a docs-only PR — is unchanged.

### Per-architecture ptoas checksum

Callers now pass both digests instead of pre-selecting one:

```diff
-      PTOAS_SHA256: ${{ needs.toolchain.outputs.ptoas_sha256_aarch64 }}
+      PTOAS_SHA256_AARCH64: ${{ needs.toolchain.outputs.ptoas_sha256_aarch64 }}
+      PTOAS_SHA256_X86_64: ${{ needs.toolchain.outputs.ptoas_sha256_x86_64 }}
```

and `setup-ci-job` selects from the same `uname -m` that already built the wheel
name, next to that line so the two cannot drift apart:

```bash
case "$PTOAS_ARCH" in
  aarch64) PTOAS_SHA256_NAME=PTOAS_SHA256_AARCH64; PTOAS_SHA256="${PTOAS_SHA256_AARCH64:-}" ;;
  x86_64)  PTOAS_SHA256_NAME=PTOAS_SHA256_X86_64;  PTOAS_SHA256="${PTOAS_SHA256_X86_64:-}" ;;
  *)
    echo "::error::Unsupported ptoas host architecture '$PTOAS_ARCH'"
    echo "Supported architectures are aarch64 and x86_64."
    exit 1
    ;;
esac
if ! printf '%s' "$PTOAS_SHA256" | grep -qE '^[0-9a-f]{64}$'; then
  echo "::error::$PTOAS_SHA256_NAME must be a 64-character lowercase SHA256"
  exit 1
fi
```

Two guards, both failing *before* the download rather than after it:

- **an unsupported architecture** is named explicitly. Without this, a third
  architecture would fall through to an empty `PTOAS_SHA256` and surface as a
  `sha256sum` format error;
- **a missing or malformed digest** names the variable that is wrong. This is the
  case that catches a caller which added `PTOAS_SHA256_AARCH64` and forgot
  `PTOAS_SHA256_X86_64` — otherwise that job would pass on every aarch64 host and
  fail only once it happened to land on an x86_64 one.

No new plumbing was needed: `toolchain/versions.env` already carries both
`PTOAS_SHA256_AARCH64` and `PTOAS_SHA256_X86_64`, and the `toolchain` job already
exposed both as outputs. This change is the first consumer of the second one.

### Architecture-stable incore doctest

`docs/{en,zh}/user/performance/04-incore.md` built its doctest input from a seeded
RNG:

```python
torch.manual_seed(0)
A = torch.randn(ROWS, TC, dtype=torch.float32)
```

A seed fixes the bit stream, not the resulting tensor: ATen fills `normal_`
through its vectorized backend, so the same seed does not guarantee the same
float32 values on a NEON host and an AVX2 one. The page's `check()` compares a
kernel's `pl.exp` against `torch.exp` at `rtol=atol=1e-4`, so the doctest would
have been comparing two different implementations *on two different inputs*.

```python
# Cycle through binary-exact values in a stable range on every host architecture.
indices = torch.arange(ROWS * TC, dtype=torch.int64)
A = (indices % 3 - 1).to(torch.float32).reshape(ROWS, TC)
```

Integer arithmetic is exact on both hosts, so both now exercise byte-identical
inputs. The values are deliberately held to `-1, 0, 1`: `exp` over that set spans
`0.3679 … 2.7183`, where the device's implementation and Torch's agree comfortably
inside the tolerance the page already used. Nothing about the tolerance, the
kernels, or the prose changes — only the input construction.

### Bounding the shared uv cache

`UV_CACHE_DIR` is one directory per host, shared by every job on it — deliberately,
and the existing comment says why: uv's cache is built for concurrent access, so a
wheel one job downloaded is hardlinked into the next job's venv instead of being
fetched again.

Nothing bounded it. uv has no size cap, no TTL, and no eviction of any kind; its
documentation offers only the explicit `uv cache clean` / `uv cache prune`
commands, and this repository invoked neither. ccache has `CCACHE_MAXSIZE` and the
ptoas cache holds one wheel per version and architecture, so uv was the only cache
here with no ceiling at all. It grew monotonically across every job and every run
until the host ran out of disk.

What accumulates is `pypto` and `simpler` specifically. Both install from a local
directory named on the command line:

```bash
uv pip install --no-build-isolation '.[dev]'
uv pip install --no-build-isolation ./runtime
```

and uv documents exactly that form as a special case — it "will always rebuild and
reinstall any local directory dependencies passed explicitly on the command-line."
Always rebuilt means the cached wheel is never hit, so those entries have no value
whatsoever. They are pure residue, and each is an extension-module wheel that
[#2485](https://github.com/hw-native-sys/pypto/pull/2485) measured at 111.9 MiB
under `-g2` and 18.9 MiB under `-g1`. Nine self-hosted jobs per run write one, and
seven of them write a second for `simpler`.

A final step in the action removes those two by name, so the resolved third-party
set — torch, nanobind, cmake, ninja — stays cached for the next job:

```bash
exec 9>"$CI_CACHE_ROOT/.uv-cleanup.lock" || exit 0
if ! flock -n 9; then
  echo "another job on this host is already cleaning the uv cache — skipping"
  exit 0
fi
df -h "$cache_dir" | tail -1 | sed "s|^|cache_df before |" || true
UV_LOCK_TIMEOUT=30 uv cache clean pypto simpler \
  || echo "::warning::uv cache clean did not complete (cache left as-is)"
df -h "$cache_dir" | tail -1 | sed "s|^|cache_df after  |" || true
```

A first draft of this step was measured on CI and the numbers drove every choice
below. It confirmed both the mechanism and the volume — one job reported:

```
uv cache before: 62G
Removed 59719 files (60.1GiB)
uv cache after:  4.0G
```

and, on a host already at steady state, `5.0G -> 4.0G` in 531 ms — one run's
worth of residue, matching the per-run estimate above.

Five deliberate choices:

- **Not `uv cache prune --ci`**, which is the standard CI recommendation and is
  backwards here. It "removes all pre-built wheels and unzipped source
  distributions from the cache, but retains any wheels that were built from
  source" — it would evict the entries worth keeping and retain the ones that
  grow.
- **Not `--force`.** That flag skips uv's in-use lock, and the cache is shared with
  whatever else the host is running; a concurrent install must not have entries
  deleted from under it.
- **One job per host, elected with `flock -n`.** `uv cache clean` locks the whole
  cache, and these jobs reach this step at roughly the same time while their
  neighbours are still installing. Letting them queue made every job pay the wait
  while only the first accomplished anything — a measured job blocked **4m22s**
  and then reported `No cache entries found`, the holder having already removed
  the same entries. The non-blocking lock turns that into an immediate exit.
- **`UV_LOCK_TIMEOUT=30`.** uv waits 300 s for its cache lock by default, which is
  where that 4m22s came from. This job's tests are queued behind the step and the
  work is not urgent, so the elected job gives up quickly and whichever job next
  finds the lock free does it instead. The cap governs only the wait; once the
  lock is held the removal runs to completion. Trade-off: on a host whose cache is
  continuously busy, a round can pass with no cleanup at all. At ~1 GB of growth
  per run that is affordable, and the step's own log says which happened —
  `Removed N files` versus the `::warning::`.
- **`df`, not `du`.** This runs on the critical path, and `du` walks the tree,
  which is the slowest thing here on exactly the oversized cache the step exists
  to prevent. The filesystem's own accounting is O(1) and is what the disk-space
  alarm watches; uv already reports what it removed.

The step is advisory rather than fatal — a cleanup that could fail the job would
be worse than a cache that is briefly too large — and runs under `always()`, so a
crashed build's entries are swept by the next job rather than stranded. It is
gated on the `bundle` toolchain, since the conda path installs with pip and has no
uv cache to bound.

## What did not change

- **`system-tests-a5sim`** keeps a bare `PTOAS_SHA256` fed from
  `ptoas_sha256_x86_64`. It runs on `ubuntu-latest`, which is always x86_64, and
  installs ptoas with its own inline `curl` rather than through `setup-ci-job`, so
  it has no host to select from.
- **Cache isolation.** `CCACHE_DIR`, `PIP_CACHE_DIR`, `PTOAS_CACHE_DIR` and
  `UV_CACHE_DIR` all derive from each runner's own `CI_CACHE_ROOT`, so an aarch64
  host and an x86_64 host never share a cache directory. The cached ptoas wheel is
  additionally named with `${PTOAS_ARCH}`, and `CCACHE_NAMESPACE=pto-isa-<commit>`
  keeps its existing meaning.
- **The hardcoded-digest lint** at `ci.yml` already matched the suffixed spelling
  (`PTOAS_SHA256(_[A-Z0-9]+)?: *[0-9a-f]{64}`), so it covers the new variables
  without modification.
- **GitHub-hosted jobs, gating, and `needs:` edges** are untouched. The docs-only
  and lint gates still short-circuit the same set of jobs.
- **What uv caches during a build.** The cleanup runs after the install, so no job
  loses a cache hit it would otherwise have had. `pypto` and `simpler` were already
  rebuilt from scratch every run; this only stops keeping the result.

## Verification

- `pre-commit run --files` over all five changed files: clean.
- All four workflows and both composite actions parse as YAML.
- Checked mechanically across every workflow and composite action in the tree:
  no self-hosted job pins an architecture label any more, and all **9** jobs that
  invoke `setup-ci-job` with the toolchain installed define both per-architecture
  digests and none retains the ambiguous `PTOAS_SHA256`.
- `(i % 3 - 1)` confirmed to produce exactly `{-1, 0, 1}`, and the en/zh pages
  confirmed to carry the identical snippet.
- The cleanup step's body extracted from the YAML and checked with `bash -n`;
  `uv cache clean`'s variadic package argument confirmed against uv's own
  `CleanArgs` (`pub package: Vec<PackageName>`), `UV_LOCK_TIMEOUT`'s unit and
  300 s default against `uv-static/src/env_vars.rs`, and the `--ci` / `--force`
  semantics quoted above against uv's cache documentation.
- The `flock -n` election exercised directly with three concurrent workers: one
  acquires and runs, two exit immediately, total 2 s rather than the 6 s they
  would take queued.
- **The growth mechanism is measured, not inferred.** A first draft of the step
  ran on CI and removed 59719 files / 60.1 GiB from one host's cache in a single
  job (62 G -> 4.0 G), and 1021.3 MiB from a host already at steady state — about
  one run's worth, as estimated. That also settles which bucket was large.

One claim this PR does not verify, because it needs a runner registration this
branch cannot change: **that a job schedules onto, and passes on, an x86_64
host.** See the review note.

The `UV_LOCK_TIMEOUT=30` value is a judgement call rather than a measured
optimum — there is one observed wait sample, not a distribution of lock-hold
times. The step's own log answers it on the next run: count `Removed N files`
against `::warning::uv cache clean did not complete`. If cleanups are being
skipped too often, raising it costs only the elected job's wait, since the other
jobs now leave immediately either way.

## Review notes

**Runner registration.** Dropping the architecture label means a job lands on
whichever labelled host is free. That is only safe if `cpu` / `npu` / `npu-a5`
are applied *exclusively* to hosts that can genuinely run those jobs on either
architecture. `setup-ci-job` takes `toolchain: bundle` by default, and the jobs
here that omit the input — `docs-examples` among them — therefore need each
`cpu` host to provide:

| Requirement | Asserted by |
| --- | --- |
| the selected `pypto-toolchain` bundle | `pypto-toolchain verify` |
| Python 3.10 | `--require python=3.10` |
| GCC >= 15 | `--require 'gcc>=15'` |
| ccache >= 4.8 | `--require 'ccache>=4.8'` — below it `CCACHE_NAMESPACE` is silently ignored |
| `CI_CACHE_ROOT` | "Check runner config", which also derives every cache path from it |

`CONDA_ROOT` is *not* among them on that default path; only a job that opts into
`toolchain: conda` needs it. Device jobs additionally need `CANN_ROOT` and a
working driver, which no repository-side change can assert.

Please confirm the x86_64 hosts are registered on that basis before merging. The
checksum fix removes the failure this PR would otherwise have caused, but it
cannot vouch for the rest of a host's setup.

**Scope.** The uv cache fix is unrelated to mixed-architecture support and could be
split out if you would rather review them separately; it is here because both are
one-file changes to the same action against the same class of problem, and the CI
host was actively out of disk.

**`pypto-lib-model` went red mid-review, for a reason outside this branch, and is
green again.** Recorded because the history is confusing to read back.

The job clones pypto-lib unpinned, so each run picks up whatever that
repository's default branch holds when the job starts:

```bash
git clone --depth 1 https://github.com/hw-native-sys/pypto-lib.git
```

pypto-lib `ca14b52d` added a parameter-direction ABI check to `golden/runner.py`
that rejected `deepseek_v4_flash_mtp/prefill_csa`, and every pypto PR running
afterwards failed the same way — including branches with nothing in common with
this one. The artifact directions were exactly what the kernel declared
(`pl.Out`, `pl.InOut`, `pl.InOut`), so the compiler side was right; the spec side
read `TensorSpec.is_output`, which those three deliberately left unset because
they are "written in-place but not validated here". One flag was carrying two
meanings — "compare against golden" and "is an output in the kernel ABI".
Reported as pypto-lib#1050 and fixed there by pypto-lib#1047, which marks
`cmp_kv` `InOut` and drops the `init_value` that made the derivation disagree.
Nothing in this PR touches any of it.

Incidentally, the job that failed ran on aarch64 and verified
`ptoas-0.57-cp310-cp310-manylinux_2_34_aarch64.whl` against the aarch64 digest,
so this PR's per-architecture checksum selection was exercised and working on the
very path that failed.
