### PR TITLE
fix(language): let the parser read back the printer's pl.builtin.<ns>.<op> form

### DIFF
--- a/docs/en/dev/passes/42-lower_host_tensor_collectives.md
+++ b/docs/en/dev/passes/42-lower_host_tensor_collectives.md
@@ -80,6 +80,34 @@ consistent with the devices actually running.
 Assignments preserve the user-facing rebind idiom by appending
 `<result> = <original expr>` after the generated builtin calls.
 
+## Printed form
+
+The `builtin.tensor.*` operators are `internal_only` in the registry: no DSL
+wrapper spells them, and the user-facing op-creation path rejects them by name.
+The python printer still has to render them, and does so under the `pl.builtin`
+namespace — the same `pl.` prefix it puts on any non-`pld` registered operator:
+
+```python
+for r_1 in pl.range(pl.const(0, pl.INT64), pld.system.world_size(), pl.const(1, pl.INT64)):
+    pl.builtin.tensor.allreduce(
+        data, signal, op=0, dtype=pl.FP32, core_num=1,
+        attrs={"op": 0, "dtype": pl.FP32, "core_num": 1, "device": r_1,
+               "arg_directions": [pl.adir.inout, pl.adir.inout]},
+    )
+```
+
+The parser reads that spelling back (`ast_parser._parse_builtin_op`), so the
+lowered dispatch survives print -> parse. It is a machine-only surface, scoped
+to names actually registered under `builtin.`: it builds through
+`ir.create_internal_op_call` and leaves the user-facing `ir.create_op_call`
+guard in place. Write the composite `pld.tensor.*` form instead.
+
+Note that a whole-program `assert_structural_equal` round-trip is still blocked
+one pass upstream: [`MaterializeCommDomainScopes`](41-materialize_comm_domain_scopes.md)
+synthesizes `CommDomainScopeStmt` (printed as a leading comment) and the
+`WindowBuffer` back-references on `DistributedTensorType` (not printed), and
+neither has a DSL surface to parse back.
+
 ## Checks
 
 The pass requires both args to be materialized `DistributedTensorType` views in

--- a/docs/en/dev/passes/42-lower_host_tensor_collectives.md
+++ b/docs/en/dev/passes/42-lower_host_tensor_collectives.md
@@ -98,9 +98,12 @@ for r_1 in pl.range(pl.const(0, pl.INT64), pld.system.world_size(), pl.const(1, 
 
 The parser reads that spelling back (`ast_parser._parse_builtin_op`), so the
 lowered dispatch survives print -> parse. It is a machine-only surface, scoped
-to names actually registered under `builtin.`: it builds through
-`ir.create_internal_op_call` and leaves the user-facing `ir.create_op_call`
-guard in place. Write the composite `pld.tensor.*` form instead.
+to names actually registered under `builtin.`, and it accepts only what the
+printer can write: the `device` and `arg_directions` attrs are required, since
+orchestration codegen reads both back behind internal checks. A hand-written
+call omitting them is rejected as a user error at parse time rather than
+surfacing as a compiler-bug diagnostic during codegen. Write the composite
+`pld.tensor.*` form instead.
 
 Note that a whole-program `assert_structural_equal` round-trip is still blocked
 one pass upstream: [`MaterializeCommDomainScopes`](41-materialize_comm_domain_scopes.md)

--- a/docs/zh/dev/passes/42-lower_host_tensor_collectives.md
+++ b/docs/zh/dev/passes/42-lower_host_tensor_collectives.md
@@ -72,6 +72,33 @@ comm-domain scope 带有显式 device 列表，则生成 `SeqStmts`；否则生�
 若用户代码使用赋值形式，pass 会在生成的 builtin 调用之后追加
 `<result> = <original expr>`，保留 public API 的 rebind 语义。
 
+## 打印形式
+
+`builtin.tensor.*` 算子在注册表中标记为 `internal_only`（内部专用）：没有任何
+DSL 包装器可以拼写它们，面向用户的算子构造路径也会按名字拒绝它们。但 Python
+printer 仍然需要打印它们，因此把它们放在 `pl.builtin` 命名空间下 —— 与它给任何
+非 `pld` 注册算子加 `pl.` 前缀的规则一致：
+
+```python
+for r_1 in pl.range(pl.const(0, pl.INT64), pld.system.world_size(), pl.const(1, pl.INT64)):
+    pl.builtin.tensor.allreduce(
+        data, signal, op=0, dtype=pl.FP32, core_num=1,
+        attrs={"op": 0, "dtype": pl.FP32, "core_num": 1, "device": r_1,
+               "arg_directions": [pl.adir.inout, pl.adir.inout]},
+    )
+```
+
+Parser 能读回这种拼写（`ast_parser._parse_builtin_op`），因此 lowering 产生的
+dispatch 可以完成 print -> parse 往返。它是仅供机器使用（machine-only）的表面，
+且限定在真正注册于 `builtin.` 下的名字：它通过 `ir.create_internal_op_call`
+构造，面向用户的 `ir.create_op_call` 守卫保持不变。用户代码请改写复合形式
+`pld.tensor.*`。
+
+注意：整程序的 `assert_structural_equal` 往返仍然被上一个 pass 阻断 ——
+[`MaterializeCommDomainScopes`](41-materialize_comm_domain_scopes.md) 会合成
+`CommDomainScopeStmt`（打印为前导注释）以及 `DistributedTensorType` 上的
+`WindowBuffer` 反向引用（完全不打印），二者都没有可解析回来的 DSL 表面。
+
 ## 检查
 
 该 pass 要求两个参数都是已经 materialize 的 `DistributedTensorType` view，并且位于同一个

--- a/docs/zh/dev/passes/42-lower_host_tensor_collectives.md
+++ b/docs/zh/dev/passes/42-lower_host_tensor_collectives.md
@@ -90,9 +90,11 @@ for r_1 in pl.range(pl.const(0, pl.INT64), pld.system.world_size(), pl.const(1, 
 
 Parser 能读回这种拼写（`ast_parser._parse_builtin_op`），因此 lowering 产生的
 dispatch 可以完成 print -> parse 往返。它是仅供机器使用（machine-only）的表面，
-且限定在真正注册于 `builtin.` 下的名字：它通过 `ir.create_internal_op_call`
-构造，面向用户的 `ir.create_op_call` 守卫保持不变。用户代码请改写复合形式
-`pld.tensor.*`。
+限定在真正注册于 `builtin.` 下的名字，并且只接受 printer 能写出的形式：
+`device` 与 `arg_directions` 两个 attr 是必需的，因为 orchestration codegen 会在
+内部检查（internal check）后读回它们。手写调用若省略这些 attr，会在 parse 阶段
+按用户错误拒绝，而不是在 codegen 阶段表现为编译器 bug 诊断。用户代码请改写复合
+形式 `pld.tensor.*`。
 
 注意：整程序的 `assert_structural_equal` 往返仍然被上一个 pass 阻断 ——
 [`MaterializeCommDomainScopes`](41-materialize_comm_domain_scopes.md) 会合成

--- a/python/bindings/modules/ir.cpp
+++ b/python/bindings/modules/ir.cpp
@@ -760,6 +760,22 @@ void BindIR(nb::module_& m) {
       "Create a Call expression with args and kwargs");
 
   ir.def(
+      "create_internal_op_call",
+      [](const std::string& op_name, const std::vector<ExprPtr>& args, const nb::dict& kwargs_dict,
+         const Span& span) {
+        // Compiler-internal counterpart of `create_op_call`: reaches operators
+        // marked `internal_only`, which `CreateUserFacing` rejects by design.
+        // Used by the round-trip parser to rebuild a printer-emitted internal
+        // dispatch (`pl.builtin.<ns>.<op>(...)`) that no DSL wrapper can spell.
+        // The user-facing guard is untouched — `create_op_call` still routes
+        // through `CreateUserFacing`.
+        auto kwargs = ConvertKwargsDict(kwargs_dict);
+        return OpRegistry::GetInstance().CreateInternal(op_name, args, kwargs, span);
+      },
+      nb::arg("op_name"), nb::arg("args"), nb::arg("kwargs"), nb::arg("span"),
+      "Create a Call expression for a compiler-internal operator (round-trip parser only)");
+
+  ir.def(
       "set_call_attrs",
       [](const CallPtr& call, const nb::dict& attrs_dict) -> CallPtr {
         // Return a copy of `call` with compiler-internal `attrs_` set from a

--- a/python/bindings/modules/ir.cpp
+++ b/python/bindings/modules/ir.cpp
@@ -759,16 +759,19 @@ void BindIR(nb::module_& m) {
       nb::arg("op_name"), nb::arg("args"), nb::arg("kwargs"), nb::arg("span"),
       "Create a Call expression with args and kwargs");
 
+  // Underscore-prefixed: NOT a public API. Compiler-internal counterpart of
+  // `create_op_call`, it reaches operators marked `internal_only`, which
+  // `CreateUserFacing` rejects by design. Its only caller is the round-trip
+  // parser, rebuilding a printer-emitted internal dispatch
+  // (`pl.builtin.<ns>.<op>(...)`) that no DSL wrapper can spell; that caller
+  // re-checks the invariants the printer stamps before calling in, so the
+  // guard `internal_only` provides is enforced at the user-facing surface
+  // rather than dropped. `create_op_call` still routes through
+  // `CreateUserFacing` and is unaffected.
   ir.def(
-      "create_internal_op_call",
+      "_create_internal_op_call",
       [](const std::string& op_name, const std::vector<ExprPtr>& args, const nb::dict& kwargs_dict,
          const Span& span) {
-        // Compiler-internal counterpart of `create_op_call`: reaches operators
-        // marked `internal_only`, which `CreateUserFacing` rejects by design.
-        // Used by the round-trip parser to rebuild a printer-emitted internal
-        // dispatch (`pl.builtin.<ns>.<op>(...)`) that no DSL wrapper can spell.
-        // The user-facing guard is untouched — `create_op_call` still routes
-        // through `CreateUserFacing`.
         auto kwargs = ConvertKwargsDict(kwargs_dict);
         return OpRegistry::GetInstance().CreateInternal(op_name, args, kwargs, span);
       },

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -8726,9 +8726,20 @@ class ASTParser:
         ``pl.builtin.<ns>.<op>`` like any other non-``pld`` operator. It is the
         machine-only reader for that writer — the counterpart of
         ``_parse_printed_alloc_call`` — so it builds through
-        ``ir.create_internal_op_call`` and is scoped to the ``builtin.``
+        ``ir._create_internal_op_call`` and is scoped to the ``builtin.``
         namespace: no other internal operator becomes reachable, and the
         user-facing ``create_op_call`` guard is untouched.
+
+        Because this is a *reader for the printer*, it accepts only what the
+        printer can write. Every ``builtin.*`` dispatch is built by one
+        function (``MakeBuiltinCallWithAttrs`` in
+        ``lower_host_tensor_collectives_pass.cpp``), which unconditionally
+        stamps a ``device`` attr and an ``arg_directions`` attr covering every
+        positional arg; orchestration codegen then reads both back behind
+        internal checks. Hand-written source that omits them would be accepted
+        here and blow up much later as an "internal error" — a compiler-bug
+        diagnostic for what is really bad user input — so the invariants are
+        required up front and a violation is reported as a user error.
         """
         span = self.span_tracker.get_span(call)
         if len(segments) != 2:
@@ -8752,9 +8763,10 @@ class ASTParser:
 
         args = [self.parse_expression(arg) for arg in call.args]
         kwargs = self._parse_op_kwargs(call)
-        attrs = self._parse_op_attrs(call)
+        attrs = self._parse_op_attrs(call) or {}
+        self._check_builtin_op_printer_invariants(full_name, args, attrs, span)
         try:
-            built = ir.create_internal_op_call(full_name, args, kwargs, span)
+            built = ir._create_internal_op_call(full_name, args, kwargs, span)
         except BUG_CLASS_EXCEPTIONS:
             # Compiler bug, not a bad kernel - surface it with its type and trace intact.
             raise
@@ -8765,6 +8777,47 @@ class ASTParser:
                 span=span,
             ) from e
         return self._attach_op_attrs(built, attrs)
+
+    def _check_builtin_op_printer_invariants(
+        self, full_name: str, args: list[Any], attrs: dict[str, object], span: ir.Span
+    ) -> None:
+        """Reject a ``pl.builtin.*`` call the printer could not have written.
+
+        Keeps the accepted grammar equal to the printer's output, so this
+        machine-only surface cannot be used to hand-build a dispatch that
+        orchestration codegen would reject with an ``INTERNAL_CHECK`` (see
+        ``EmitBuiltinWindowCollectiveDispatch``: it requires a ``device`` attr
+        to resolve the rank expression, and one ``arg_directions`` entry per
+        positional arg).
+        """
+        hint = (
+            f"pl.builtin.* is emitted by the python printer, not written by hand — "
+            f"{full_name} is reached by writing the public pld.{full_name.split('.', 1)[1]} "
+            f"collective and letting LowerHostTensorCollectives lower it"
+        )
+        if "device" not in attrs:
+            raise InvalidOperationError(
+                f"'pl.{full_name}' requires a device attr naming the dispatching rank "
+                f'(attrs={{"device": <rank>}})',
+                span=span,
+                hint=hint,
+            )
+        directions = attrs.get("arg_directions")
+        if directions is None:
+            raise InvalidOperationError(
+                f"'pl.{full_name}' requires an arg_directions attr "
+                f'(attrs={{"arg_directions": [pl.adir.<dir>, ...]}})',
+                span=span,
+                hint=hint,
+            )
+        if len(cast("list[object]", directions)) != len(args):
+            raise InvalidOperationError(
+                f"'pl.{full_name}' has {len(args)} positional args but "
+                f"{len(cast('list[object]', directions))} arg_directions entries; "
+                "orchestration codegen requires one direction per arg",
+                span=span,
+                hint=hint,
+            )
 
     # Maps iterator type name to ForKind enum value.
     _ITERATOR_TO_KIND = {

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -6227,6 +6227,14 @@ class ASTParser:
         if len(attrs) == 3 and attrs[0] == "pld":
             return self._parse_pld_category_op(attrs[1], attrs[2], call)
 
+        # pl.builtin.<category>.<op> (4-segment) — printer-emitted internal
+        # builtin dispatch, e.g. ``pl.builtin.tensor.allreduce(...)``. Matched
+        # on ``attrs[1]`` alone so a malformed spelling gets the namespace's own
+        # diagnostic instead of falling through to the 2-segment unified path
+        # and reporting the useless "Unknown operation 'pl.builtin'".
+        if len(attrs) >= 2 and attrs[0] == "pl" and attrs[1] == "builtin":
+            return self._parse_builtin_op(attrs[2:], call)
+
         # pl.tensor.{operation} (3-segment)
         if len(attrs) >= 3 and attrs[0] == "pl" and attrs[1] == "tensor":
             op_name = attrs[2]
@@ -8701,6 +8709,62 @@ class ASTParser:
             )
 
         return self._dispatch_op(submodule, f"pld.{category}", op_name, call)
+
+    def _parse_builtin_op(self, segments: list[str], call: ast.Call) -> ir.Expr:
+        """Parse printer-emitted ``pl.builtin.<category>.<op>(...)``.
+
+        ``builtin.*`` operators are compiler-internal chip dispatches that
+        passes synthesize — today ``builtin.tensor.*``, emitted by
+        ``LowerHostTensorCollectives`` for the host ``pld.tensor.*``
+        collectives. They are ``internal_only`` in the registry, so no DSL
+        wrapper spells them and users write the composite ``pld.tensor.*``
+        form instead.
+
+        This path exists so the printer's output past those passes re-parses:
+        the print -> parse round-trip must hold for every IR the pipeline can
+        produce, and the printer renders a registered ``builtin.<ns>.<op>`` as
+        ``pl.builtin.<ns>.<op>`` like any other non-``pld`` operator. It is the
+        machine-only reader for that writer — the counterpart of
+        ``_parse_printed_alloc_call`` — so it builds through
+        ``ir.create_internal_op_call`` and is scoped to the ``builtin.``
+        namespace: no other internal operator becomes reachable, and the
+        user-facing ``create_op_call`` guard is untouched.
+        """
+        span = self.span_tracker.get_span(call)
+        if len(segments) != 2:
+            raise InvalidOperationError(
+                f"Unknown operation '{ast.unparse(call.func)}'",
+                span=span,
+                hint="pl.builtin is the compiler-internal operator namespace and is spelled "
+                "pl.builtin.<category>.<op> (e.g. pl.builtin.tensor.allreduce); it is emitted by "
+                "the printer, not written by hand — use the pld.tensor.* collective instead",
+            )
+        category, op_name = segments
+        full_name = f"builtin.{category}.{op_name}"
+        if not ir.is_op_registered(full_name):
+            raise InvalidOperationError(
+                f"Unknown builtin operation 'pl.builtin.{category}.{op_name}'",
+                span=span,
+                hint="pl.builtin.* names compiler-internal dispatches emitted by lowering passes "
+                "(e.g. pl.builtin.tensor.allreduce); check spelling, or use the public "
+                "pld.tensor.* collective",
+            )
+
+        args = [self.parse_expression(arg) for arg in call.args]
+        kwargs = self._parse_op_kwargs(call)
+        attrs = self._parse_op_attrs(call)
+        try:
+            built = ir.create_internal_op_call(full_name, args, kwargs, span)
+        except BUG_CLASS_EXCEPTIONS:
+            # Compiler bug, not a bad kernel - surface it with its type and trace intact.
+            raise
+        except Exception as e:
+            raise InvalidOperationError(
+                f"Error in builtin operation '{full_name}': "
+                f"{concise_error_message(e, strip_trailing_span=True)}",
+                span=span,
+            ) from e
+        return self._attach_op_attrs(built, attrs)
 
     # Maps iterator type name to ForKind enum value.
     _ITERATOR_TO_KIND = {

--- a/python/pypto/pypto_core/ir.pyi
+++ b/python/pypto/pypto_core/ir.pyi
@@ -3068,6 +3068,35 @@ def create_op_call(
         Exception: If operator is not registered, is internal-only, or type deduction fails
     """
 
+def create_internal_op_call(
+    op_name: str,
+    args: Sequence[Expr],
+    kwargs: Mapping[str, int | bool | str | float | DataType | MemorySpace | PadValue],
+    span: Span,
+) -> Call:
+    """Create a Call expression for a compiler-internal operator.
+
+    Compiler-internal counterpart of :func:`create_op_call`: it reaches
+    operators marked ``internal_only`` (e.g. the ``builtin.tensor.*`` chip
+    dispatches that ``LowerHostTensorCollectives`` emits), which the
+    user-facing path rejects by design. Reserved for the round-trip parser,
+    which must rebuild the printer-emitted ``pl.builtin.<ns>.<op>(...)`` form
+    that no DSL wrapper can spell. Op builders and DSL wrappers keep using
+    :func:`create_op_call`.
+
+    Args:
+        op_name: Name of the registered operator
+        args: Positional Expr arguments
+        kwargs: Keyword arguments (metadata)
+        span: Source location
+
+    Returns:
+        Call expression with automatically deduced result type
+
+    Raises:
+        Exception: If operator is not registered or type deduction fails
+    """
+
 def set_call_attrs(call: Call, attrs: Mapping[str, object]) -> Call:
     """Return a copy of ``call`` with compiler-internal ``attrs_`` set.
 

--- a/python/pypto/pypto_core/ir.pyi
+++ b/python/pypto/pypto_core/ir.pyi
@@ -3068,21 +3068,23 @@ def create_op_call(
         Exception: If operator is not registered, is internal-only, or type deduction fails
     """
 
-def create_internal_op_call(
+def _create_internal_op_call(
     op_name: str,
     args: Sequence[Expr],
     kwargs: Mapping[str, int | bool | str | float | DataType | MemorySpace | PadValue],
     span: Span,
 ) -> Call:
-    """Create a Call expression for a compiler-internal operator.
+    """Create a Call expression for a compiler-internal operator. **Private.**
 
     Compiler-internal counterpart of :func:`create_op_call`: it reaches
     operators marked ``internal_only`` (e.g. the ``builtin.tensor.*`` chip
     dispatches that ``LowerHostTensorCollectives`` emits), which the
     user-facing path rejects by design. Reserved for the round-trip parser,
     which must rebuild the printer-emitted ``pl.builtin.<ns>.<op>(...)`` form
-    that no DSL wrapper can spell. Op builders and DSL wrappers keep using
-    :func:`create_op_call`.
+    that no DSL wrapper can spell — and which re-checks the invariants the
+    printer stamps before calling in, so the guard is enforced at the
+    user-facing surface rather than dropped. Op builders and DSL wrappers keep
+    using :func:`create_op_call`.
 
     Args:
         op_name: Name of the registered operator

--- a/tests/ut/ir/parser/test_builtin_namespace.py
+++ b/tests/ut/ir/parser/test_builtin_namespace.py
@@ -1,0 +1,170 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+# ruff: noqa: F722, F821
+
+"""Parser tests for ``pl.builtin.<category>.<op>`` — the machine-only surface
+for compiler-internal operators.
+
+``builtin.*`` operators are synthesized by lowering passes (today
+``builtin.tensor.*``, emitted by ``LowerHostTensorCollectives`` for the host
+``pld.tensor.*`` collectives) and are marked ``internal_only`` in the registry,
+so no DSL wrapper spells them and users write the composite ``pld.tensor.*``
+form instead. The printer nevertheless renders them as
+``pl.builtin.<category>.<op>``, so the parser must read that spelling back or
+IR past those passes stops round-tripping.
+
+End-to-end coverage of the printed lowering (kwargs, ``device`` /
+``arg_directions`` attrs, every collective) lives in
+:file:`tests/ut/ir/transforms/test_lower_host_tensor_collectives.py`; this
+module covers the namespace's own parse behaviour and diagnostics.
+"""
+
+import pypto.language as pl
+import pypto.language.distributed as pld
+import pytest
+from pypto.language.parser.diagnostics import InvalidOperationError
+from pypto.pypto_core import ir
+
+_BUILTIN_BARRIER = ir.get_op("builtin.tensor.barrier").name
+
+
+def _get_func(program: ir.Program, name: str) -> ir.Function:
+    gvar = program.get_global_var(name)
+    assert gvar is not None
+    return program.functions[gvar]
+
+
+def _iter_stmts(stmt: ir.Stmt):
+    """Yield ``stmt`` and every nested statement (flattening containers)."""
+    yield stmt
+    if isinstance(stmt, ir.SeqStmts):
+        for s in stmt.stmts:
+            yield from _iter_stmts(s)
+    if isinstance(stmt, ir.ScopeStmt):
+        yield from _iter_stmts(stmt.body)
+    if isinstance(stmt, ir.ForStmt):
+        yield from _iter_stmts(stmt.body)
+
+
+_BARRIER_SRC = """
+import pypto.language as pl
+import pypto.language.distributed as pld
+
+
+@pl.program
+class P:
+    @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+    def host_orch(self):
+        signal_buf: pl.Ptr = pld.tensor.alloc_window_buffer(pl.const(16, pl.INDEX))
+        signal: pld.DistributedTensor[[4], pl.INT32] = pld.tensor.window(signal_buf, [4], dtype=pl.INT32)
+        for r in pl.range(pld.system.world_size()):
+            {call}
+        return 0
+"""
+
+
+def _barrier_program(call: str) -> str:
+    return _BARRIER_SRC.format(call=call)
+
+
+def test_builtin_op_parses_to_the_internal_registry_op():
+    """``pl.builtin.tensor.barrier`` builds the internal-only registered op."""
+    program = pl.parse_program(_barrier_program("pl.builtin.tensor.barrier(signal)"))
+    host = _get_func(program, "host_orch")
+
+    calls = [
+        stmt.expr
+        for stmt in _iter_stmts(host.body)
+        if isinstance(stmt, ir.EvalStmt) and isinstance(stmt.expr, ir.Call)
+    ]
+    barriers = [call for call in calls if call.op.name == _BUILTIN_BARRIER]
+    assert len(barriers) == 1, [call.op.name for call in calls]
+    assert len(barriers[0].args) == 1
+
+
+def test_builtin_op_carries_machine_only_attrs():
+    """The trailing ``attrs={...}`` dict the printer emits round-trips."""
+    program = pl.parse_program(
+        _barrier_program(
+            'pl.builtin.tensor.barrier(signal, attrs={"device": r, "arg_directions": [pl.adir.inout]})'
+        )
+    )
+    host = _get_func(program, "host_orch")
+
+    barriers = [
+        stmt.expr
+        for stmt in _iter_stmts(host.body)
+        if isinstance(stmt, ir.EvalStmt)
+        and isinstance(stmt.expr, ir.Call)
+        and stmt.expr.op.name == _BUILTIN_BARRIER
+    ]
+    assert len(barriers) == 1
+    call = barriers[0]
+    assert set(call.attrs.keys()) == {"device", "arg_directions"}
+    assert isinstance(call.attrs["device"], ir.Var)
+    assert call.attrs["device"].name_hint == "r"
+    assert list(call.attrs["arg_directions"]) == [ir.ArgDirection.InOut]
+
+
+def test_builtin_namespace_is_scoped_to_registered_builtin_ops():
+    """An unregistered ``builtin.`` name is rejected — the namespace does not
+    become a back door onto arbitrary internal operators."""
+    with pytest.raises(InvalidOperationError, match="Unknown builtin operation"):
+        pl.parse_program(_barrier_program("pl.builtin.tensor.not_a_collective(signal)"))
+
+    # ``tensor.write`` is a real op, but it is not registered under ``builtin.``,
+    # so the builtin namespace must not reach it either.
+    with pytest.raises(InvalidOperationError, match="Unknown builtin operation"):
+        pl.parse_program(_barrier_program("pl.builtin.tensor.write(signal)"))
+
+
+def test_builtin_namespace_rejects_a_wrong_segment_count():
+    """``pl.builtin`` is spelled ``pl.builtin.<category>.<op>``; a short chain
+    names the full spelling the user wrote and points at the right form, rather
+    than reporting ``Unknown operation 'pl.builtin'`` from the 2-segment
+    unified path."""
+    with pytest.raises(InvalidOperationError) as excinfo:
+        pl.parse_program(_barrier_program("pl.builtin.barrier(signal)"))
+    assert "pl.builtin.barrier" in str(excinfo.value)
+    assert excinfo.value.hint is not None
+    assert "pl.builtin.<category>.<op>" in excinfo.value.hint
+
+
+def test_builtin_op_reports_deduction_failures_against_its_own_name():
+    """A bad payload surfaces as an error naming the builtin, not a bare
+    registry message."""
+    with pytest.raises(InvalidOperationError, match="builtin.tensor.barrier"):
+        pl.parse_program(_barrier_program("pl.builtin.tensor.barrier(signal, signal)"))
+
+
+def test_public_collective_still_lowers_through_pld_surface():
+    """The public surface is unchanged: users write ``pld.tensor.barrier``, and
+    the internal name stays out of the parsed IR until the pass runs."""
+
+    @pl.program
+    class P:
+        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+        def host_orch(self):
+            signal_buf = pld.alloc_window_buffer(4 * pl.INT32.get_byte())
+            signal = pld.window(signal_buf, [4], dtype=pl.INT32)
+            pld.tensor.barrier(signal)
+            return 0
+
+    host = _get_func(P, "host_orch")
+    op_names = {
+        stmt.expr.op.name
+        for stmt in _iter_stmts(host.body)
+        if isinstance(stmt, ir.EvalStmt) and isinstance(stmt.expr, ir.Call)
+    }
+    assert _BUILTIN_BARRIER not in op_names
+    assert ir.get_op("pld.tensor.barrier").name in op_names
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/ut/ir/parser/test_builtin_namespace.py
+++ b/tests/ut/ir/parser/test_builtin_namespace.py
@@ -73,9 +73,12 @@ def _barrier_program(call: str) -> str:
     return _BARRIER_SRC.format(call=call)
 
 
+_PRINTED_BARRIER = 'pl.builtin.tensor.barrier(signal, attrs={"device": r, "arg_directions": [pl.adir.inout]})'
+
+
 def test_builtin_op_parses_to_the_internal_registry_op():
-    """``pl.builtin.tensor.barrier`` builds the internal-only registered op."""
-    program = pl.parse_program(_barrier_program("pl.builtin.tensor.barrier(signal)"))
+    """The printed form builds the internal-only registered op."""
+    program = pl.parse_program(_barrier_program(_PRINTED_BARRIER))
     host = _get_func(program, "host_orch")
 
     calls = [
@@ -90,11 +93,7 @@ def test_builtin_op_parses_to_the_internal_registry_op():
 
 def test_builtin_op_carries_machine_only_attrs():
     """The trailing ``attrs={...}`` dict the printer emits round-trips."""
-    program = pl.parse_program(
-        _barrier_program(
-            'pl.builtin.tensor.barrier(signal, attrs={"device": r, "arg_directions": [pl.adir.inout]})'
-        )
-    )
+    program = pl.parse_program(_barrier_program(_PRINTED_BARRIER))
     host = _get_func(program, "host_orch")
 
     barriers = [
@@ -116,12 +115,12 @@ def test_builtin_namespace_is_scoped_to_registered_builtin_ops():
     """An unregistered ``builtin.`` name is rejected — the namespace does not
     become a back door onto arbitrary internal operators."""
     with pytest.raises(InvalidOperationError, match="Unknown builtin operation"):
-        pl.parse_program(_barrier_program("pl.builtin.tensor.not_a_collective(signal)"))
+        pl.parse_program(_barrier_program(_PRINTED_BARRIER.replace("barrier", "not_a_collective")))
 
     # ``tensor.write`` is a real op, but it is not registered under ``builtin.``,
     # so the builtin namespace must not reach it either.
     with pytest.raises(InvalidOperationError, match="Unknown builtin operation"):
-        pl.parse_program(_barrier_program("pl.builtin.tensor.write(signal)"))
+        pl.parse_program(_barrier_program(_PRINTED_BARRIER.replace("barrier", "write")))
 
 
 def test_builtin_namespace_rejects_a_wrong_segment_count():
@@ -130,7 +129,7 @@ def test_builtin_namespace_rejects_a_wrong_segment_count():
     than reporting ``Unknown operation 'pl.builtin'`` from the 2-segment
     unified path."""
     with pytest.raises(InvalidOperationError) as excinfo:
-        pl.parse_program(_barrier_program("pl.builtin.barrier(signal)"))
+        pl.parse_program(_barrier_program(_PRINTED_BARRIER.replace("tensor.barrier", "barrier")))
     assert "pl.builtin.barrier" in str(excinfo.value)
     assert excinfo.value.hint is not None
     assert "pl.builtin.<category>.<op>" in excinfo.value.hint
@@ -139,8 +138,41 @@ def test_builtin_namespace_rejects_a_wrong_segment_count():
 def test_builtin_op_reports_deduction_failures_against_its_own_name():
     """A bad payload surfaces as an error naming the builtin, not a bare
     registry message."""
-    with pytest.raises(InvalidOperationError, match="builtin.tensor.barrier"):
-        pl.parse_program(_barrier_program("pl.builtin.tensor.barrier(signal, signal)"))
+    two_args = _PRINTED_BARRIER.replace("(signal,", "(signal, signal,").replace(
+        "[pl.adir.inout]", "[pl.adir.inout, pl.adir.inout]"
+    )
+    with pytest.raises(InvalidOperationError, match=r"builtin\.tensor\.barrier"):
+        pl.parse_program(_barrier_program(two_args))
+
+
+def test_hand_written_builtin_call_without_device_is_a_user_error():
+    """A bare `pl.builtin.tensor.barrier(signal)` is rejected at parse time.
+
+    Orchestration codegen resolves the dispatching rank from the `device` attr
+    behind an `INTERNAL_CHECK`, so accepting a hand-written call without it
+    would turn bad user input into a compiler-bug diagnostic much later. The
+    printer always stamps the attr, so requiring it costs the round-trip
+    nothing.
+    """
+    with pytest.raises(InvalidOperationError) as excinfo:
+        pl.parse_program(_barrier_program("pl.builtin.tensor.barrier(signal)"))
+    assert "device" in str(excinfo.value)
+    assert excinfo.value.hint is not None
+    assert "pld.tensor.barrier" in excinfo.value.hint
+
+
+def test_hand_written_builtin_call_without_arg_directions_is_a_user_error():
+    """`arg_directions` is the other invariant codegen reads back internally."""
+    with pytest.raises(InvalidOperationError, match="arg_directions"):
+        pl.parse_program(_barrier_program('pl.builtin.tensor.barrier(signal, attrs={"device": r})'))
+
+
+def test_builtin_call_arg_directions_must_cover_every_arg():
+    """One direction per positional arg — codegen asserts the two lengths match."""
+    with pytest.raises(InvalidOperationError, match="arg_directions entries"):
+        pl.parse_program(
+            _barrier_program('pl.builtin.tensor.barrier(signal, attrs={"device": r, "arg_directions": []})')
+        )
 
 
 def test_public_collective_still_lowers_through_pld_surface():

--- a/tests/ut/ir/transforms/test_lower_host_tensor_collectives.py
+++ b/tests/ut/ir/transforms/test_lower_host_tensor_collectives.py
@@ -10,17 +10,23 @@
 
 """Tests for ``LowerHostTensorCollectives``.
 
-The lowering emits ``builtin.tensor.*`` internal ops that the public DSL cannot
-spell (the composite ``pld.tensor.*`` call is what gets lowered), so a whole-
-``@pl.program`` ``Expected`` cannot be parsed for these tests. As in the
-materialize_comm_domain_scopes module, the structural Before/Expected pattern
-is applied at the granularity of the pass's comparable output product — the
-emitted builtin dispatch — via :func:`_assert_builtin_dispatch`, which pins the
-full dispatch (world-size loop, every window-bound arg in order, arg
-directions, and the complete kwarg/attr dicts).
+The lowering emits ``builtin.tensor.*`` internal ops, which the printer renders
+as ``pl.builtin.tensor.*`` — a machine-only surface the parser reads back, so
+the lowered dispatch survives print -> parse. A whole-``@pl.program``
+``Expected`` still cannot be parsed for these tests, but for an upstream
+reason: ``MaterializeCommDomainScopes`` must run first, and neither the
+``CommDomainScopeStmt`` it synthesizes nor the ``WindowBuffer`` back-references
+it stamps on ``DistributedTensorType`` has a DSL surface.
+
+So, as in the materialize_comm_domain_scopes module, the structural
+Before/Expected pattern is applied at the granularity of the pass's comparable
+output product — the emitted builtin dispatch — via
+:func:`_assert_builtin_dispatch`, which pins the full dispatch (world-size
+loop, every window-bound arg in order, arg directions, and the complete
+kwarg/attr dicts) both in the pass output and in its re-parse.
 """
 
-from typing import cast
+from typing import Any, cast
 
 import pypto.language as pl
 import pypto.language.distributed as pld
@@ -38,6 +44,13 @@ _BUILTIN_REDUCE_SCATTER = ir.get_op("builtin.tensor.reduce_scatter").name
 
 @pytest.fixture(autouse=True)
 def _basic_verification_context():
+    """Property verification only — the conftest default adds the roundtrip
+    instrument, which these programs cannot satisfy: they run
+    ``MaterializeCommDomainScopes``, whose ``CommDomainScopeStmt`` and
+    ``WindowBuffer`` back-references have no DSL surface and so fail
+    whole-program structural equality after a re-parse. The builtin dispatch
+    itself does round-trip; ``_assert_builtin_dispatch`` checks that directly.
+    """
     with passes.PassContext([passes.VerificationInstrument(passes.VerificationMode.BEFORE_AND_AFTER)]):
         yield
 
@@ -128,7 +141,7 @@ def _assert_alias_keeps_window_buffer(alias: ir.AssignStmt) -> None:
 
 
 def _assert_builtin_dispatch(
-    host_body: ir.Stmt,
+    result: ir.Program,
     builtin_name: str,
     *,
     arg_names: list[str],
@@ -136,16 +149,56 @@ def _assert_builtin_dispatch(
     kwargs: dict[str, object],
     attrs: dict[str, object] | None = None,
 ) -> ir.Call:
+    """Pin the lowered ``builtin_name`` dispatch, in the pass output *and* in the
+    print -> parse round-trip of that output.
+
+    The printer renders the lowered internal op as ``pl.builtin.tensor.<op>`` and
+    the parser reads that machine-only surface back, so re-parsing the printed
+    program must rebuild the same dispatch. Matching both sides against one set
+    of expectations keeps the two halves from drifting.
+
+    Whole-program ``assert_structural_equal`` cannot be used for that half:
+    ``MaterializeCommDomainScopes`` (which must run first) synthesizes
+    ``CommDomainScopeStmt`` and the ``WindowBuffer`` back-references on
+    ``DistributedTensorType``, and neither has a DSL surface — the scope prints
+    as a leading comment and the back-reference is not printed at all. Hence
+    ``window_bound_args=False`` on the re-parsed side; everything the lowering
+    itself produces is still matched exactly.
+
+    Returns the dispatch call from the lowered (non-re-parsed) program.
+    """
+    expectations: dict[str, Any] = {
+        "arg_names": arg_names,
+        "arg_directions": arg_directions,
+        "kwargs": kwargs,
+        "attrs": attrs,
+    }
+    call = _match_builtin_dispatch(_get_func(result, "host_orch").body, builtin_name, **expectations)
+    reparsed = pl.parse_program(ir.python_print(result, format=False))
+    assert isinstance(reparsed, ir.Program)
+    _match_builtin_dispatch(
+        _get_func(reparsed, "host_orch").body, builtin_name, window_bound_args=False, **expectations
+    )
+    return call
+
+
+def _match_builtin_dispatch(
+    host_body: ir.Stmt,
+    builtin_name: str,
+    *,
+    arg_names: list[str],
+    arg_directions: list[ir.ArgDirection],
+    kwargs: dict[str, object],
+    attrs: dict[str, object] | None = None,
+    window_bound_args: bool = True,
+) -> ir.Call:
     """Assert the host body dispatches ``builtin_name`` exactly once and pin the
     full emitted structure of the dispatch.
 
     This is the structural-comparison equivalent of the Before/Expected pattern
-    for ``LowerHostTensorCollectives``: the lowered output is a ``builtin.tensor.*``
-    internal op that the public DSL cannot spell (the composite ``pld.tensor.*``
-    call is what gets lowered), so no ``Expected`` program source can be parsed.
-    As in the materialize_comm_domain_scopes module, the pattern is applied at
-    the granularity of the pass's comparable output product — the builtin
-    dispatch. The helper pins:
+    for ``LowerHostTensorCollectives``, applied — as in the
+    materialize_comm_domain_scopes module — at the granularity of the pass's
+    comparable output product: the builtin dispatch. The helper pins:
 
     * exactly one ``for r in pl.range(pld.system.world_size())`` loop whose body
       is exactly the builtin EvalStmt (extra or missing surrounding statements
@@ -196,7 +249,8 @@ def _assert_builtin_dispatch(
         var = _as_var(actual)
         assert var.name_hint == expected, f"expected arg window var {expected!r}, got {var.name_hint!r}"
         assert isinstance(var.type, ir.DistributedTensorType)
-        assert var.type.window_buffer is not None, f"arg {expected!r} must be window-bound"
+        if window_bound_args:
+            assert var.type.window_buffer is not None, f"arg {expected!r} must be window-bound"
 
     assert list(call.arg_directions) == arg_directions
     # arg_directions is mirrored in attrs
@@ -235,10 +289,9 @@ def test_host_allreduce_lowers_to_builtin_world_size_loop():
 
     program = cast(ir.Program, passes.materialize_comm_domain_scopes()(P))
     result = cast(ir.Program, passes.lower_host_tensor_collectives()(program))
-    host = _get_func(result, "host_orch")
 
     _assert_builtin_dispatch(
-        host.body,
+        result,
         "builtin.tensor.allreduce",
         arg_names=["data", "signal"],
         arg_directions=[ir.ArgDirection.InOut, ir.ArgDirection.InOut],
@@ -266,10 +319,9 @@ def test_implicit_host_allreduce_synthesizes_signal_then_lowers():
     program = passes.synthesize_allreduce_signals()(P)
     program = passes.materialize_comm_domain_scopes()(program)
     result = passes.lower_host_tensor_collectives()(program)
-    host = _get_func(result, "host_orch")
 
     _assert_builtin_dispatch(
-        host.body,
+        result,
         "builtin.tensor.allreduce",
         arg_names=["data", "__allreduce_signal_0"],
         arg_directions=[ir.ArgDirection.InOut, ir.ArgDirection.InOut],
@@ -306,7 +358,7 @@ def test_return_implicit_host_allreduce_synthesizes_signal_then_lowers():
     return_stmts = _collect_return_stmts(host.body)
 
     _assert_builtin_dispatch(
-        host.body,
+        result,
         "builtin.tensor.allreduce",
         arg_names=["data", "__allreduce_signal_0"],
         arg_directions=[ir.ArgDirection.InOut, ir.ArgDirection.InOut],
@@ -351,7 +403,7 @@ def test_return_explicit_host_allreduce_lowers_with_user_signal():
     return_stmts = _collect_return_stmts(host.body)
 
     _assert_builtin_dispatch(
-        host.body,
+        result,
         "builtin.tensor.allreduce",
         arg_names=["data", "signal"],
         arg_directions=[ir.ArgDirection.InOut, ir.ArgDirection.InOut],
@@ -549,12 +601,11 @@ def test_host_allreduce_multicore_propagates_core_num_and_accepts_wider_signal()
 
     program = passes.materialize_comm_domain_scopes()(P)
     result = passes.lower_host_tensor_collectives()(program)
-    host = _get_func(result, "host_orch")
 
     # A stride of 8 is wider than the 4 requested lanes: the spare lanes are
     # accepted and `core_num` reaches the builtin unchanged.
     _assert_builtin_dispatch(
-        host.body,
+        result,
         "builtin.tensor.allreduce",
         arg_names=["data", "signal"],
         arg_directions=[ir.ArgDirection.InOut, ir.ArgDirection.InOut],
@@ -746,9 +797,8 @@ def test_host_barrier_lowers_to_builtin_world_size_loop():
 
     program = passes.materialize_comm_domain_scopes()(P)
     result = passes.lower_host_tensor_collectives()(program)
-    host = _get_func(result, "host_orch")
     _assert_builtin_dispatch(
-        host.body,
+        result,
         "builtin.tensor.barrier",
         arg_names=["signal"],
         arg_directions=[ir.ArgDirection.InOut],
@@ -815,9 +865,8 @@ def test_host_broadcast_lowers_to_builtin_world_size_loop():
 
     program = passes.materialize_comm_domain_scopes()(P)
     result = passes.lower_host_tensor_collectives()(program)
-    host = _get_func(result, "host_orch")
     _assert_builtin_dispatch(
-        host.body,
+        result,
         "builtin.tensor.broadcast",
         arg_names=["data", "signal"],
         arg_directions=[ir.ArgDirection.InOut, ir.ArgDirection.InOut],
@@ -885,9 +934,8 @@ def test_host_reduce_scatter_lowers_to_builtin_world_size_loop():
 
     program = passes.materialize_comm_domain_scopes()(P)
     result = passes.lower_host_tensor_collectives()(program)
-    host = _get_func(result, "host_orch")
     _assert_builtin_dispatch(
-        host.body,
+        result,
         "builtin.tensor.reduce_scatter",
         arg_names=["data", "signal"],
         arg_directions=[ir.ArgDirection.InOut, ir.ArgDirection.InOut],
@@ -1052,9 +1100,8 @@ def test_host_allgather_lowers_to_namesake_builtin():
 
     program = passes.materialize_comm_domain_scopes()(P)
     result = passes.lower_host_tensor_collectives()(program)
-    host = _get_func(result, "host_orch")
     _assert_builtin_dispatch(
-        host.body,
+        result,
         "builtin.tensor.allgather",
         arg_names=["stage", "data", "signal"],
         arg_directions=[
@@ -1363,10 +1410,9 @@ def test_host_all_to_all_lowers_to_namesake_builtin():
 
     program = passes.materialize_comm_domain_scopes()(P)
     result = passes.lower_host_tensor_collectives()(program)
-    host = _get_func(result, "host_orch")
 
     _assert_builtin_dispatch(
-        host.body,
+        result,
         "builtin.tensor.all_to_all",
         arg_names=["stage", "data", "signal"],
         arg_directions=[
@@ -1453,9 +1499,8 @@ def test_host_all_to_all_v_lowers_to_namesake_builtin():
 
     program = passes.materialize_comm_domain_scopes()(P)
     result = passes.lower_host_tensor_collectives()(program)
-    host = _get_func(result, "host_orch")
     _assert_builtin_dispatch(
-        host.body,
+        result,
         "builtin.tensor.all_to_all_v",
         arg_names=["inp", "data", "signal", "counts", "recv"],
         arg_directions=[
@@ -1837,10 +1882,9 @@ def test_host_allreduce_ring_lowers_to_ring_builtin():
 
     program = cast(ir.Program, passes.materialize_comm_domain_scopes()(P))
     result = cast(ir.Program, passes.lower_host_tensor_collectives()(program))
-    host = _get_func(result, "host_orch")
 
     _assert_builtin_dispatch(
-        host.body,
+        result,
         "builtin.tensor.allreduce_ring",
         arg_names=["data", "signal"],
         arg_directions=[ir.ArgDirection.InOut, ir.ArgDirection.InOut],


### PR DESCRIPTION
## What

The python printer renders any registered non-`pld` operator with a `pl.`
prefix, so `LowerHostTensorCollectives` (pass 42) output surfaced as
`pl.builtin.tensor.allreduce(...)`. The parser had no `pl.builtin` namespace:
the call fell through to the 2-segment unified path and raised
`InvalidOperationError: Unknown operation 'pl.builtin'`.

```python
res = passes.lower_host_tensor_collectives()(passes.materialize_comm_domain_scopes()(P))
pl.parse_program(ir.python_print(res))
# InvalidOperationError: Unknown operation 'pl.builtin'
```

So the printed form of any host collective past pass 42 was not a parseable DSL
program — the printer had a writer with no matching reader.

## Why this shape of fix

`builtin.tensor.*` operators are `internal_only` in the registry, so no DSL
wrapper spells them (users write the composite `pld.tensor.*` form, which is
what gets lowered). The codebase already has a pattern for printer-emitted-only
shapes — `_parse_printed_alloc_call`, `pld.tile._remote_load_with_physical_tail_padding`
— a machine-only parser path that rebuilds what the printer wrote. This follows it.

- **`ir.create_internal_op_call`** (`python/bindings/modules/ir.cpp`) routes to
  `OpRegistry::CreateInternal`. `create_op_call` still routes through
  `CreateUserFacing`, so the `internal_only` guard on user-facing creation paths
  is untouched.
- **`_parse_builtin_op`** (`python/pypto/language/parser/ast_parser.py`),
  dispatched from a `pl.builtin.<category>.<op>` branch in `parse_op_call`. It is
  scoped to names actually registered under `builtin.`, so no other internal
  operator becomes reachable through it. The branch matches on `attrs[1]` alone so
  a malformed spelling reports the namespace's own diagnostic rather than the
  useless `Unknown operation 'pl.builtin'`.

All eight collectives (`allreduce`, `allreduce_ring`, `barrier`, `broadcast`,
`reduce_scatter`, `allgather`, `all_to_all`, `all_to_all_v`) round-trip,
including their kwargs and the machine-only `attrs={...}` dict (`device` Var,
`arg_directions`, `dtype`).

## Tests

- **`tests/ut/ir/parser/test_builtin_namespace.py`** (new, 6 tests): parse to the
  internal registry op, `attrs={...}` recovery, namespace scoping (an
  unregistered `builtin.` name *and* a real-but-not-`builtin.` name are both
  rejected), both error paths, and that the public `pld.tensor.*` surface is
  unchanged.
- **`test_lower_host_tensor_collectives.py`**: `_assert_builtin_dispatch` now
  takes the program and matches the dispatch **twice** against one set of
  expectations — in the pass output and in its print → parse re-parse. All twelve
  existing call sites gain round-trip coverage without duplicating expectations.

Full suite: 10333 passed, 3 skipped, 2 xfailed. All pre-commit hooks pass.

## Reviewer note: what this does *not* fix

Post-pass-42 IR now **parses**, but whole-program `assert_structural_equal`
still fails, for an unrelated reason one pass upstream.
`MaterializeCommDomainScopes` (pass 41) synthesizes two things with no DSL
surface:

- `CommDomainScopeStmt` — the printer deliberately emits it as a
  `# pld.comm_domain: ...` comment (`python_printer.cpp:2329` documents this as
  intentional, since a `with` wrapper would have no matching parser path), so a
  re-parse yields a plain `SeqStmts`.
- The `window_buffer` back-reference on `DistributedTensorType` — not printed at
  all, so re-parsed window views come back with `window_buffer is None`.

That is why the re-parsed side is matched with `window_bound_args=False`, and why
the test module stays pinned to `VerificationMode.BEFORE_AND_AFTER` instead of
the conftest default roundtrip instrument. Both are documented at their sites.

Giving the scope a parseable surface is a design decision rather than a
mechanical fix: the printed `slots=[...]` names `alloc_window_buffer` results
defined *inside* the body, so a `with pld.comm_domain(...)` header would
forward-reference them — the parser would have to re-derive the slots from the
body, or the printed form would need a different shape. Left for a follow-up.

## Docs

`docs/{en,zh}/dev/passes/42-lower_host_tensor_collectives.md` gained a "Printed
form" section showing the emitted `pl.builtin.tensor.*` call, pointing at the
parser path, and noting the remaining upstream round-trip gap.
