### PR TITLE
feat(ir): let matmul_acc's init_cond accept the operands it already accumulates

### DIFF
--- a/docs/en/dev/ir/05-operators.md
+++ b/docs/en/dev/ir/05-operators.md
@@ -260,11 +260,11 @@ computes from lhs M/K and rhs N.
 
 #### Conditional accumulator initialization (`init_cond`)
 
-`tile.matmul_acc` and `tensor.matmul_acc` take an optional fourth operand,
-`init_cond`: a BOOL scalar that selects, per execution, whether the accumulator
-is *overwritten* with `lhs @ rhs` or accumulated into. It is the split-K
-`k == 0` idiom, and it removes the need either to zero the accumulator or to
-peel the first K step:
+`tile.matmul_acc`, `tile.batch_matmul_acc` and `tensor.matmul_acc` take an
+optional fourth operand, `init_cond`: a BOOL scalar that selects, per execution,
+whether the accumulator is *overwritten* with `lhs @ rhs` or accumulated into.
+It is the split-K `k == 0` idiom, and it removes the need either to zero the
+accumulator or to peel the first K step:
 
 ```python
 acc = pl.tile.create([16, N], pl.INT32, target_memory=pl.Mem.Acc)
@@ -272,6 +272,16 @@ for k0 in pl.pipeline(0, K, K_TILE, stage=2):
     ...
     acc = pl.tile.matmul_acc(acc, a_left, b_right, init_cond=(k0 == 0))
 ```
+
+The predicate's domain is exactly `matmul_acc`'s own: any operand shape that
+accumulates without a predicate accumulates with one. A `tensor.matmul_acc` with
+an operand of rank > 2 converts to `tile.batch_matmul_acc`, which forwards
+`init_cond` verbatim to every 2D `tile.matmul_acc` that `FlattenTileNdTo2D`
+unrolls it into — each of those is the sole writer of its own row band of the
+accumulator, so the predicate applies band by band. (Only `batch_count == 1`
+reaches codegen today; a larger batch is rejected in `FlattenTileNdTo2D` for a
+reason unrelated to the predicate — the per-batch accumulator would be a strided
+L0C row window, which the MAD cannot address.)
 
 The predicate is a positional operand rather than a registry kwarg because it
 may be loop-dependent; kwargs carry only compile-time constants. Registering it

--- a/docs/en/dev/ir/05-operators.md
+++ b/docs/en/dev/ir/05-operators.md
@@ -334,9 +334,13 @@ a predicate, so the pass no longer generates an accumulator phi at all.
 
 One limitation, diagnosed rather than silently dropped:
 
-- **Rank > 2 is rejected.** The batched form expands into several
-  `tile.matmul_acc` calls inside `FlattenTileNdTo2D`, which has no place to
-  thread a per-call predicate. Loop over the batch dimension instead.
+- **`batch_count > 1` is rejected.** Not because of the predicate — this shape
+  fails identically without one. `FlattenTileNdTo2D` gives each batch a
+  `tile.slice` of the accumulator, and a row window of a multi-block-column
+  L0C tile is strided, which the MAD cannot address (pto-isa#253). Rank > 2 is
+  fine as long as the batch dims multiply to 1, which is the grouped-GEMM case
+  (`[1, N, K]` weights). For a genuine batch, loop over the batch dimension
+  instead.
 
 An oversized *predicated* `tile.matmul_acc` is K-tiled like the unpredicated
 one: the caller's predicate is ANDed with the emitted loop's own `ko == 0`, and

--- a/docs/zh/dev/ir/05-operators.md
+++ b/docs/zh/dev/ir/05-operators.md
@@ -294,8 +294,11 @@ block 都会发出双倍 MAD。
 
 一项限制，以显式诊断而非静默丢弃的方式处理：
 
-- **拒绝 rank > 2**。批量形式在 `FlattenTileNdTo2D` 中会展开为多次
-  `tile.matmul_acc` 调用，无处安放逐调用的谓词。请改为在 batch 维上循环。
+- **拒绝 `batch_count > 1`**。这与谓词无关 —— 该形状在不带谓词时同样失败。
+  `FlattenTileNdTo2D` 会为每个 batch 取一份累加器的 `tile.slice`，而多 block
+  列 L0C tile 的行窗口是跨步的，MAD 无法寻址（pto-isa#253）。只要 batch 维之积
+  为 1，rank > 2 就是允许的 —— 这正是 grouped GEMM 的情形（`[1, N, K]` 权重）。
+  若确实需要多个 batch，请改为在 batch 维上循环。
 
 超尺寸的*带谓词* `tile.matmul_acc` 与无谓词形式一样会被做 K 切分：调用方的谓词与
 所生成循环自身的 `ko == 0` 做与运算，而剥离出的尾块保持无谓词的 3 操作数形式

--- a/docs/zh/dev/ir/05-operators.md
+++ b/docs/zh/dev/ir/05-operators.md
@@ -231,9 +231,10 @@ lhs M/K 与 rhs N 实际计算的较小矩形。
 
 #### 条件式累加器初始化（`init_cond`）
 
-`tile.matmul_acc` 与 `tensor.matmul_acc` 接受一个可选的第四操作数 `init_cond`：
-一个 BOOL 标量，用于逐次执行地选择累加器是被 `lhs @ rhs` **覆写**还是被累加。
-这就是 split-K 的 `k == 0` 惯用法，它同时省去了清零累加器与剥离首个 K 步的需要：
+`tile.matmul_acc`、`tile.batch_matmul_acc` 与 `tensor.matmul_acc` 接受一个可选的
+第四操作数 `init_cond`：一个 BOOL 标量，用于逐次执行地选择累加器是被 `lhs @ rhs`
+**覆写**还是被累加。这就是 split-K 的 `k == 0` 惯用法，它同时省去了清零累加器与
+剥离首个 K 步的需要：
 
 ```python
 acc = pl.tile.create([16, N], pl.INT32, target_memory=pl.Mem.Acc)
@@ -241,6 +242,14 @@ for k0 in pl.pipeline(0, K, K_TILE, stage=2):
     ...
     acc = pl.tile.matmul_acc(acc, a_left, b_right, init_cond=(k0 == 0))
 ```
+
+该谓词的适用范围与 `matmul_acc` 本身完全一致：凡是不带谓词能够累加的操作数形状，
+带谓词同样能够累加。操作数 rank > 2 的 `tensor.matmul_acc` 会转换为
+`tile.batch_matmul_acc`，后者将 `init_cond` 原样转发给 `FlattenTileNdTo2D` 展开出的
+每一个 2D `tile.matmul_acc` —— 其中每一个都是自己那条累加器行带的唯一写者，因此谓词
+按行带逐一生效。（目前只有 `batch_count == 1` 能走到 codegen；更大的 batch 会在
+`FlattenTileNdTo2D` 中被拒绝，原因与谓词无关 —— 逐 batch 的累加器会是一个跨步的 L0C
+行窗口，而 MAD 无法寻址它。）
 
 该谓词是位置操作数而非 registry kwarg，因为它可能依赖循环变量，而 kwarg 只承载
 编译期常量。作为操作数注册也意味着它像其他 SSA 值一样参与 use-def 链。

--- a/python/pypto/ir/op/tile_ops.py
+++ b/python/pypto/ir/op/tile_ops.py
@@ -1938,6 +1938,8 @@ def batch_matmul_acc(
     lhs: Expr,
     rhs: Expr,
     span: Span | None = None,
+    *,
+    init_cond: Expr | None = None,
 ) -> Call:
     """Batch matrix multiplication with accumulation.
 
@@ -1945,17 +1947,26 @@ def batch_matmul_acc(
     rhs. The broadcast batch shape must equal acc's batch shape (acc is the in-place
     accumulation target and is not broadcast).
 
+    ``init_cond`` behaves exactly as it does on
+    [`matmul_acc`][pypto.ir.op.tile_ops.matmul_acc]: where the predicate holds,
+    ``acc`` is overwritten with ``lhs @ rhs`` instead of accumulated into.
+    ``FlattenTileNdTo2D`` forwards it to every 2D ``tile.matmul_acc`` it unrolls
+    this op into — each of those is the sole writer of its own row band of the
+    accumulator, so the predicate applies band by band.
+
     Args:
         acc: Accumulator tile (TileType, at least 2D)
         lhs: Left-hand side tile (TileType, at least 2D)
         rhs: Right-hand side tile (TileType, at least 2D)
         span: Optional source span for debugging (auto-captured if not provided)
+        init_cond: Optional BOOL scalar predicate selecting overwrite over accumulate
 
     Returns:
         Call expression for batch matrix multiplication with accumulation
     """
     actual_span = _get_span_or_capture(span)
-    return _ir_core.create_op_call("tile.batch_matmul_acc", [acc, lhs, rhs], {}, actual_span)
+    args = [acc, lhs, rhs] if init_cond is None else [acc, lhs, rhs, init_cond]
+    return _ir_core.create_op_call("tile.batch_matmul_acc", args, {}, actual_span)
 
 
 def gemv(lhs: Expr, rhs: Expr, span: Span | None = None, *, acc_phase: str = "unspecified") -> Call:

--- a/python/pypto/language/op/tile_ops.py
+++ b/python/pypto/language/op/tile_ops.py
@@ -1310,22 +1310,31 @@ def matmul_acc(acc: Tile, lhs: Tile, rhs: Tile, init_cond: BoolLike | None = Non
     return Tile(expr=call_expr)
 
 
-def batch_matmul_acc(acc: Tile, lhs: Tile, rhs: Tile) -> Tile:
+def batch_matmul_acc(acc: Tile, lhs: Tile, rhs: Tile, init_cond: BoolLike | None = None) -> Tile:
     """Batch matrix multiplication with accumulation: acc += lhs @ rhs.
 
     Performs the in-place ``acc += lhs @ rhs`` with batch-dim broadcasting between
     ``lhs`` and ``rhs``. The broadcast batch shape must equal the batch shape of
     ``acc`` (acc is the in-place accumulation target and is not broadcast).
 
+    ``init_cond`` behaves exactly as on
+    [`matmul_acc`][pypto.language.op.tile_ops.matmul_acc]: where it holds, ``acc``
+    is overwritten with ``lhs @ rhs`` rather than accumulated into.
+    ``FlattenTileNdTo2D`` forwards the predicate to every 2D ``tile.matmul_acc``
+    it unrolls this op into.
+
     Args:
         acc: Accumulator tile (at least 2D)
         lhs: Left-hand side tile (at least 2D)
         rhs: Right-hand side tile (at least 2D)
+        init_cond: Optional predicate selecting overwrite over accumulate
 
     Returns:
         Tile wrapping the batch_matmul_acc operation
     """
-    call_expr = _ir_ops.batch_matmul_acc(acc.unwrap(), lhs.unwrap(), rhs.unwrap())
+    call_expr = _ir_ops.batch_matmul_acc(
+        acc.unwrap(), lhs.unwrap(), rhs.unwrap(), init_cond=predicate_to_expr(init_cond)
+    )
     return Tile(expr=call_expr)
 
 

--- a/src/ir/op/tile_ops/batch_matmul.cpp
+++ b/src/ir/op/tile_ops/batch_matmul.cpp
@@ -157,8 +157,10 @@ TypePtr DeduceTileBatchMatMulAccType(const std::vector<ExprPtr>& args,
                                      const std::vector<std::pair<std::string, std::any>>& kwargs,
                                      const std::string& op_name) {
   (void)kwargs;
-  CHECK(args.size() == 3) << "The operator " << op_name << " requires exactly 3 arguments, but got "
-                          << args.size();
+  CHECK(args.size() == 3 || args.size() == 4)
+      << "The operator " << op_name << " requires 3 arguments (acc, lhs, rhs) or 4 with the optional "
+      << "init_cond predicate, but got " << args.size();
+  CheckMatmulInitCond(args, 3, op_name);
 
   auto acc_type = As<TileType>(args[0]->GetType());
   auto lhs_type = As<TileType>(args[1]->GetType());
@@ -298,6 +300,10 @@ REGISTER_OP("tile.batch_matmul_acc")
     .add_argument("acc", "Accumulator tile (TileType, at least 2D)")
     .add_argument("lhs", "Left-hand side tile (TileType, at least 2D)")
     .add_argument("rhs", "Right-hand side tile (TileType, at least 2D)")
+    .add_argument("init_cond",
+                  "Optional BOOL scalar; where it holds the accumulator is overwritten with "
+                  "lhs @ rhs instead of accumulated into (the split-K `k == 0` step). Forwarded "
+                  "verbatim to every tile.matmul_acc FlattenTileNdTo2D unrolls this op into")
     .set_input_memory(0, MemorySpace::Acc)
     .set_input_memory(1, MemorySpace::Left)
     .set_input_memory(2, MemorySpace::Right)

--- a/src/ir/transforms/flatten_tile_nd_to_2d/batch_matmul.cpp
+++ b/src/ir/transforms/flatten_tile_nd_to_2d/batch_matmul.cpp
@@ -778,6 +778,18 @@ BatchMatmulAccResult LowerBatchMatmulAcc(const AssignStmtPtr& assign, const Call
       << "FlattenTileNdTo2D: tile.batch_matmul_acc expects acc to be 2D after flatten, got rank "
       << acc_type->shape_.size();
 
+  // The optional init_cond predicate is loop-invariant across the batch unroll:
+  // each emitted tile.matmul_acc is the sole writer of its own row band of acc,
+  // so "overwrite instead of accumulate" applies band by band. Forward it
+  // verbatim rather than dropping it — a silently dropped predicate would
+  // accumulate into an uninitialized accumulator on the k == 0 step.
+  const ExprPtr init_cond = call->args_.size() == 4 ? Substitute(call->args_[3], ctx.var_map) : nullptr;
+  auto make_matmul_acc = [&](const ExprPtr& acc, const ExprPtr& lhs, const ExprPtr& rhs) {
+    std::vector<ExprPtr> mm_args = {acc, lhs, rhs};
+    if (init_cond) mm_args.push_back(init_cond);
+    return op_registry.Create("tile.matmul_acc", mm_args, span);
+  };
+
   // Normalize lhs/rhs operands (peel safe reshape, flag tile.transpose_view).
   auto lhs_info = NormalizeBatchMatmulOperand(call->args_[1], "lhs", def_map, ctx);
   auto rhs_info = NormalizeBatchMatmulOperand(call->args_[2], "rhs", def_map, ctx);
@@ -874,7 +886,7 @@ BatchMatmulAccResult LowerBatchMatmulAcc(const AssignStmtPtr& assign, const Call
     out.stmts.insert(out.stmts.end(), lhs_page.stmts.begin(), lhs_page.stmts.end());
     out.stmts.insert(out.stmts.end(), rhs_page.stmts.begin(), rhs_page.stmts.end());
 
-    auto matmul_acc = op_registry.Create("tile.matmul_acc", {current_acc, lhs_page.var, rhs_page.var}, span);
+    auto matmul_acc = make_matmul_acc(current_acc, lhs_page.var, rhs_page.var);
     auto new_acc = std::make_shared<Var>(current_acc->name_hint_, matmul_acc->GetType(), span);
     out.stmts.push_back(std::make_shared<AssignStmt>(new_acc, matmul_acc, assign->span_));
     out.output_var = new_acc;
@@ -903,7 +915,7 @@ BatchMatmulAccResult LowerBatchMatmulAcc(const AssignStmtPtr& assign, const Call
     auto acc_page_var = std::make_shared<Var>("acc_page_" + suffix, acc_slice->GetType(), span);
     out.stmts.push_back(std::make_shared<AssignStmt>(acc_page_var, acc_slice, assign->span_));
 
-    auto matmul_acc = op_registry.Create("tile.matmul_acc", {acc_page_var, lhs_page.var, rhs_page.var}, span);
+    auto matmul_acc = make_matmul_acc(acc_page_var, lhs_page.var, rhs_page.var);
     auto matmul_var = std::make_shared<Var>("matmul_acc_" + suffix, matmul_acc->GetType(), span);
     out.stmts.push_back(std::make_shared<AssignStmt>(matmul_var, matmul_acc, assign->span_));
 

--- a/src/ir/transforms/op_conversion_registry.cpp
+++ b/src/ir/transforms/op_conversion_registry.cpp
@@ -1137,16 +1137,13 @@ void OpConversionRegistry::RegisterMatmulOps() {
         const bool nd = rank_of(args[0]) > 2 || rank_of(args[1]) > 2 || rank_of(args[2]) > 2;
         const std::string out_op = nd ? "tile.batch_matmul_acc" : "tile.matmul_acc";
         std::vector<ExprPtr> out_args = {args[0], args[1], args[2]};
-        if (args.size() == 4) {
-          // The batched form expands into several tile.matmul_acc calls inside
-          // FlattenTileNdTo2D, which has no place to thread a per-call
-          // predicate; only the 2D path carries init_cond.
-          CHECK_SPAN(!nd, span)
-              << "tensor.matmul_acc does not support init_cond on operands of rank > 2 (got acc rank "
-              << rank_of(args[0]) << ", lhs rank " << rank_of(args[1]) << ", rhs rank " << rank_of(args[2])
-              << "). Loop over the batch dimension and accumulate with 2D operands instead.";
-          out_args.push_back(args[3]);
-        }
+        // init_cond rides along on both forms. The batched op forwards it to every
+        // tile.matmul_acc FlattenTileNdTo2D unrolls it into, so the predicate's
+        // domain is exactly tensor.matmul_acc's own: whatever shape accumulates
+        // without a predicate accumulates with one. (batch_count > 1 is rejected
+        // later, in FlattenTileNdTo2D, for a reason unrelated to init_cond — the
+        // per-batch accumulator is a strided L0C row window the MAD cannot address.)
+        if (args.size() == 4) out_args.push_back(args[3]);
         return ConversionResult{OpRegistry::GetInstance().Create(out_op, out_args, span)};
       },
       {{1, {MemorySpace::Mat, "a_trans"}}, {2, {MemorySpace::Mat, "b_trans"}}});

--- a/tests/ut/codegen/test_matmul_init_cond.py
+++ b/tests/ut/codegen/test_matmul_init_cond.py
@@ -256,5 +256,47 @@ class TestAutoTiledPredicateFolds:
         assert mlir.count("pto.tmatmul ") == 1, mlir
 
 
+class TestGroupedOperandsCarryPredicate:
+    """A grouped GEMM keeps its group axis and still gets the predicate.
+
+    A MoE expert slices its weights as ``w[e:e+1, :, :]`` — rank 3, batch 1 —
+    which converts to ``tile.batch_matmul_acc``. That op forwards ``init_cond``
+    to the single 2D ``tile.matmul_acc`` the batch=1 fast path emits, so the
+    predicate's domain is exactly ``matmul_acc``'s own rather than a rank-2
+    subset of it. Without the forwarding, the grouped site is the one shape in a
+    split-K tree that cannot use the idiom the rest of the tree uses.
+    """
+
+    def test_rank3_batch_one_folds_to_one_overwrite_and_one_accumulate(self):
+        @pl.program
+        class GroupedSplitK:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                x: pl.Tensor[[16, 512], pl.BF16],
+                w: pl.Tensor[[2, 64, 512], pl.BF16],
+                output: pl.Out[pl.Tensor[[1, 16, 64], pl.FP32]],
+            ) -> pl.Tensor[[1, 16, 64], pl.FP32]:
+                acc = pl.tensor.create([1, 16, 64], pl.FP32)
+                for kb in pl.pipeline(0, 2, stage=2):
+                    k0 = kb * 256
+                    x_k = pl.tensor.slice(x, [16, 256], [0, k0])
+                    # Keeps the expert axis: rank 3, batch_count == 1.
+                    w_k = pl.tensor.slice(w, [1, 64, 256], [0, 0, k0])
+                    acc = pl.matmul_acc(acc, x_k, w_k, b_trans=True, init_cond=(kb == 0))
+                return pl.tensor.assemble(output, acc, [0, 0, 0])
+
+        mlir = _generate_default_mlir(GroupedSplitK)
+        # The predicate is a seed test on the unrolled K induction variable, so
+        # it folds: the kb == 0 step overwrites, the rest accumulate. A dropped
+        # predicate would accumulate into an uninitialized accumulator (no
+        # pto.tmatmul at all); an unfolded one would emit a branch.
+        assert "scf.if" not in mlir, "a compile-time-constant init_cond must select one arm outright\n" + mlir
+        assert mlir.count("pto.tmatmul ") == 1, (
+            "the kb == 0 step must overwrite the accumulator exactly once\n" + mlir
+        )
+        assert mlir.count("pto.tmatmul.acc") >= 1, "the remaining K steps must accumulate\n" + mlir
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/ir/transforms/test_flatten_tile_nd_to_2d.py
+++ b/tests/ut/ir/transforms/test_flatten_tile_nd_to_2d.py
@@ -3032,6 +3032,85 @@ class TestNdTensorMatmulConversion:
         assert names_flatten.count(_OP_TILE_MATMUL) == 1
         assert names_flatten.count(_OP_TILE_MATMUL_ACC) == 1
 
+    @pytest.mark.parametrize("runtime_predicate", [False, True])
+    def test_nd_tensor_matmul_acc_forwards_init_cond(self, runtime_predicate):
+        """A grouped (rank-3, batch=1) ``tensor.matmul_acc`` carries ``init_cond``.
+
+        The predicate's domain is exactly ``matmul_acc``'s own: an operand shape
+        that accumulates without a predicate accumulates with one. Conversion
+        routes the rank-3 call to ``tile.batch_matmul_acc``, which forwards the
+        predicate to the single 2D ``tile.matmul_acc`` the batch=1 fast path
+        emits — the accumulator is a whole tile there, so there is no slice and
+        no per-band bookkeeping.
+
+        Both spellings are covered: a literal ``ConstBool`` (which codegen folds
+        to one of ``pto.tmatmul`` / ``pto.tmatmul.acc``) and a runtime scalar
+        (which lowers to a branch over the two).
+        """
+        span = ir.Span("test_init_cond", 1, 1, 1, 1)
+        ib = IRBuilder()
+        with ib.program("main") as prog:
+            prog.declare_function("main_incore_0")
+
+            with ib.function("main_incore_0", type=ir.FunctionType.InCore) as f:
+                h0 = f.param("h0", ir.TensorType([16, 256], DataType.BF16))
+                w0 = f.param("w0", ir.TensorType([1, 64, 256], DataType.BF16))
+                h1 = f.param("h1", ir.TensorType([16, 256], DataType.BF16))
+                w1 = f.param("w1", ir.TensorType([1, 64, 256], DataType.BF16))
+                k = f.param("k", ir.ScalarType(DataType.INDEX))
+                out_p = f.param(
+                    "out_0",
+                    ir.TensorType([1, 16, 64], DataType.FP32),
+                    direction=ir.ParamDirection.Out,
+                )
+                f.return_type(ir.TensorType([1, 16, 64], DataType.FP32))
+
+                predicate = (
+                    ir.Eq(k, ir.ConstInt(0, DataType.INDEX, span), DataType.BOOL, span)
+                    if runtime_predicate
+                    else ir.ConstBool(True, span)
+                )
+                y_acc = ib.let(
+                    "y_acc",
+                    tensor_ops.matmul(h0, w0, b_trans=True, out_dtype=DataType.FP32),
+                )
+                y_acc_2 = ib.let(
+                    "y_acc_2",
+                    tensor_ops.matmul_acc(y_acc, h1, w1, b_trans=True, init_cond=predicate),
+                )
+                out_r = ib.let("out_0", tensor_ops.assemble(out_p, y_acc_2, [0, 0, 0]))
+                ib.return_stmt(out_r)
+            prog.add_function(f.get_result())
+        Before = prog.get_result()
+
+        after_convert = passes.convert_tensor_to_tile_ops()(Before)
+        batch_accs = [c for c in self._collect_calls(after_convert) if c.op.name == _OP_TILE_BATCH_MATMUL_ACC]
+        assert len(batch_accs) == 1
+        assert len(batch_accs[0].args) == 4, (
+            "conversion must forward init_cond to tile.batch_matmul_acc rather than "
+            f"rejecting or dropping it, got {len(batch_accs[0].args)} args"
+        )
+
+        after_flatten = passes.flatten_tile_nd_to_2d()(after_convert)
+        accs = [c for c in self._collect_calls(after_flatten) if c.op.name == _OP_TILE_MATMUL_ACC]
+        assert len(accs) == 1, "batch=1 fast path emits exactly one 2D tile.matmul_acc"
+        assert len(accs[0].args) == 4, (
+            "FlattenTileNdTo2D must forward init_cond onto the emitted tile.matmul_acc; "
+            "a dropped predicate would accumulate into an uninitialized accumulator"
+        )
+        assert ir.structural_equal(accs[0].args[3], predicate)
+
+    @staticmethod
+    def _collect_calls(prog: ir.Program) -> list[ir.Call]:
+        fn = prog.get_function("main_incore_0")
+        assert fn is not None
+        body = cast(ir.SeqStmts, fn.body)
+        return [
+            stmt.value
+            for stmt in body.stmts
+            if isinstance(stmt, ir.AssignStmt) and isinstance(stmt.value, ir.Call)
+        ]
+
 
 # ----------------------------------------------------------------------------
 # Regression coverage for #1278 — TileType memory_space presence mismatch on

--- a/tests/ut/ir/transforms/test_flatten_tile_nd_to_2d.py
+++ b/tests/ut/ir/transforms/test_flatten_tile_nd_to_2d.py
@@ -3032,8 +3032,7 @@ class TestNdTensorMatmulConversion:
         assert names_flatten.count(_OP_TILE_MATMUL) == 1
         assert names_flatten.count(_OP_TILE_MATMUL_ACC) == 1
 
-    @pytest.mark.parametrize("runtime_predicate", [False, True])
-    def test_nd_tensor_matmul_acc_forwards_init_cond(self, runtime_predicate):
+    def test_nd_tensor_matmul_acc_forwards_init_cond(self):
         """A grouped (rank-3, batch=1) ``tensor.matmul_acc`` carries ``init_cond``.
 
         The predicate's domain is exactly ``matmul_acc``'s own: an operand shape
@@ -3043,73 +3042,135 @@ class TestNdTensorMatmulConversion:
         emits — the accumulator is a whole tile there, so there is no slice and
         no per-band bookkeeping.
 
-        Both spellings are covered: a literal ``ConstBool`` (which codegen folds
-        to one of ``pto.tmatmul`` / ``pto.tmatmul.acc``) and a runtime scalar
-        (which lowers to a branch over the two).
+        ``Expected`` pins the whole lowered function, not just the predicated
+        call: the accumulator must thread from the seeding ``tile.matmul`` into
+        ``tile.matmul_acc``'s operand 0, the grouped ``[1, 64, 256]`` weight must
+        collapse through ``tensor.view`` + ``transpose_view`` to a ``[256, 64]``
+        Mat operand, and the result must stay a ``[16, 64]`` Acc tile. Only the
+        trailing operand differs between the two parametrizations.
+
+        A *runtime* predicate is used deliberately: it pins that the predicate
+        arrives as a live SSA expression over ``k``, which a literal could not
+        distinguish from a constant the pass invented. The literal spelling is
+        covered end to end in ``tests/ut/codegen/test_matmul_init_cond.py``,
+        where it must fold to a single MAD.
         """
-        span = ir.Span("test_init_cond", 1, 1, 1, 1)
-        ib = IRBuilder()
-        with ib.program("main") as prog:
-            prog.declare_function("main_incore_0")
 
-            with ib.function("main_incore_0", type=ir.FunctionType.InCore) as f:
-                h0 = f.param("h0", ir.TensorType([16, 256], DataType.BF16))
-                w0 = f.param("w0", ir.TensorType([1, 64, 256], DataType.BF16))
-                h1 = f.param("h1", ir.TensorType([16, 256], DataType.BF16))
-                w1 = f.param("w1", ir.TensorType([1, 64, 256], DataType.BF16))
-                k = f.param("k", ir.ScalarType(DataType.INDEX))
-                out_p = f.param(
-                    "out_0",
-                    ir.TensorType([1, 16, 64], DataType.FP32),
-                    direction=ir.ParamDirection.Out,
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore, level=pl.Level.CHIP_DIE, role=pl.Role.SubWorker)
+            def main_incore_0(
+                self,
+                h0: pl.Tensor[[16, 256], pl.BF16],
+                w0: pl.Tensor[[1, 64, 256], pl.BF16],
+                h1: pl.Tensor[[16, 256], pl.BF16],
+                w1: pl.Tensor[[1, 64, 256], pl.BF16],
+                k: pl.Scalar[pl.INDEX],
+                out_0: pl.Out[pl.Tensor[[1, 16, 64], pl.FP32]],
+            ) -> pl.Tensor[[1, 16, 64], pl.FP32]:
+                acc_: pl.Tensor[[1, 16, 64], pl.FP32] = pl.tensor.matmul(
+                    h0, w0, b_trans=True, out_dtype=pl.FP32
                 )
-                f.return_type(ir.TensorType([1, 16, 64], DataType.FP32))
-
-                predicate = (
-                    ir.Eq(k, ir.ConstInt(0, DataType.INDEX, span), DataType.BOOL, span)
-                    if runtime_predicate
-                    else ir.ConstBool(True, span)
+                acc_2: pl.Tensor[[1, 16, 64], pl.FP32] = pl.tensor.matmul_acc(
+                    acc_, h1, w1, b_trans=True, init_cond=(k == 0)
                 )
-                y_acc = ib.let(
-                    "y_acc",
-                    tensor_ops.matmul(h0, w0, b_trans=True, out_dtype=DataType.FP32),
+                out_r: pl.Tensor[[1, 16, 64], pl.FP32] = pl.tensor.assemble(out_0, acc_2, [0, 0, 0])
+                return out_r
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore, level=pl.Level.CHIP_DIE, role=pl.Role.SubWorker)
+            def main_incore_0(
+                self,
+                h0: pl.Tensor[[16, 256], pl.BF16],
+                w0: pl.Tensor[[1, 64, 256], pl.BF16],
+                h1: pl.Tensor[[16, 256], pl.BF16],
+                w1: pl.Tensor[[1, 64, 256], pl.BF16],
+                k: pl.Scalar[pl.INDEX],
+                out_0: pl.Out[pl.Tensor[[1, 16, 64], pl.FP32]],
+            ) -> pl.Tensor[[1, 16, 64], pl.FP32]:
+                h0_mat: pl.Tile[[16, 256], pl.BF16, pl.Mem.Mat] = pl.tile.load(
+                    h0,
+                    [0, 0],
+                    [16, 256],
+                    [16, 256],
+                    target_memory=pl.Mem.Mat,
+                    attrs={"__compiler_tensor_to_tile_mat_bridge": True},
                 )
-                y_acc_2 = ib.let(
-                    "y_acc_2",
-                    tensor_ops.matmul_acc(y_acc, h1, w1, b_trans=True, init_cond=predicate),
+                w0_mat_view2d: pl.Tensor[
+                    [64, 256], pl.BF16, pl.TensorView(stride=[256, 1], layout=pl.TensorLayout.ND)
+                ] = pl.tensor.view(w0, [64, 256])
+                w0_mat: pl.Tile[[64, 256], pl.BF16, pl.Mem.Mat] = pl.tile.load(
+                    w0_mat_view2d,
+                    [0, 0],
+                    [64, 256],
+                    [64, 256],
+                    target_memory=pl.Mem.Mat,
+                    attrs={"__compiler_tensor_to_tile_mat_bridge": True},
                 )
-                out_r = ib.let("out_0", tensor_ops.assemble(out_p, y_acc_2, [0, 0, 0]))
-                ib.return_stmt(out_r)
-            prog.add_function(f.get_result())
-        Before = prog.get_result()
+                w0_mat_t: pl.Tile[
+                    [256, 64],
+                    pl.BF16,
+                    pl.Mem.Mat,
+                    pl.TileView(blayout=pl.TileLayout.row_major, slayout=pl.TileLayout.col_major),
+                ] = pl.tile.transpose_view(w0_mat)
+                lhs_slice_0: pl.Tile[[16, 256], pl.BF16, pl.Mem.Mat] = pl.tile.slice(
+                    h0_mat, [16, 256], [0, 0]
+                )
+                rhs_slice_0: pl.Tile[
+                    [256, 64],
+                    pl.BF16,
+                    pl.Mem.Mat,
+                    pl.TileView(blayout=pl.TileLayout.row_major, slayout=pl.TileLayout.col_major),
+                ] = pl.tile.slice(w0_mat_t, [256, 64], [0, 0])
+                acc__tile: pl.Tile[[16, 64], pl.FP32, pl.Mem.Acc] = pl.tile.matmul(lhs_slice_0, rhs_slice_0)
+                h1_mat: pl.Tile[[16, 256], pl.BF16, pl.Mem.Mat] = pl.tile.load(
+                    h1,
+                    [0, 0],
+                    [16, 256],
+                    [16, 256],
+                    target_memory=pl.Mem.Mat,
+                    attrs={"__compiler_tensor_to_tile_mat_bridge": True},
+                )
+                w1_mat_view2d: pl.Tensor[
+                    [64, 256], pl.BF16, pl.TensorView(stride=[256, 1], layout=pl.TensorLayout.ND)
+                ] = pl.tensor.view(w1, [64, 256])
+                w1_mat: pl.Tile[[64, 256], pl.BF16, pl.Mem.Mat] = pl.tile.load(
+                    w1_mat_view2d,
+                    [0, 0],
+                    [64, 256],
+                    [64, 256],
+                    target_memory=pl.Mem.Mat,
+                    attrs={"__compiler_tensor_to_tile_mat_bridge": True},
+                )
+                w1_mat_t: pl.Tile[
+                    [256, 64],
+                    pl.BF16,
+                    pl.Mem.Mat,
+                    pl.TileView(blayout=pl.TileLayout.row_major, slayout=pl.TileLayout.col_major),
+                ] = pl.tile.transpose_view(w1_mat)
+                lhs_slice_0_1: pl.Tile[[16, 256], pl.BF16, pl.Mem.Mat] = pl.tile.slice(
+                    h1_mat, [16, 256], [0, 0]
+                )
+                rhs_slice_0_1: pl.Tile[
+                    [256, 64],
+                    pl.BF16,
+                    pl.Mem.Mat,
+                    pl.TileView(blayout=pl.TileLayout.row_major, slayout=pl.TileLayout.col_major),
+                ] = pl.tile.slice(w1_mat_t, [256, 64], [0, 0])
+                # The forwarded predicate — the whole point of the test. Without
+                # the forwarding this is a 3-operand call, and the k == 0 step
+                # would accumulate into an uninitialized accumulator.
+                acc__tile_1: pl.Tile[[16, 64], pl.FP32, pl.Mem.Acc] = pl.tile.matmul_acc(
+                    acc__tile, lhs_slice_0_1, rhs_slice_0_1, k == 0
+                )
+                out_0__tile: pl.Tensor[[1, 16, 64], pl.FP32] = pl.tile.store(
+                    acc__tile_1, [0, 0, 0], out_0, [1, 16, 64]
+                )
+                return out_0__tile
 
-        after_convert = passes.convert_tensor_to_tile_ops()(Before)
-        batch_accs = [c for c in self._collect_calls(after_convert) if c.op.name == _OP_TILE_BATCH_MATMUL_ACC]
-        assert len(batch_accs) == 1
-        assert len(batch_accs[0].args) == 4, (
-            "conversion must forward init_cond to tile.batch_matmul_acc rather than "
-            f"rejecting or dropping it, got {len(batch_accs[0].args)} args"
-        )
-
-        after_flatten = passes.flatten_tile_nd_to_2d()(after_convert)
-        accs = [c for c in self._collect_calls(after_flatten) if c.op.name == _OP_TILE_MATMUL_ACC]
-        assert len(accs) == 1, "batch=1 fast path emits exactly one 2D tile.matmul_acc"
-        assert len(accs[0].args) == 4, (
-            "FlattenTileNdTo2D must forward init_cond onto the emitted tile.matmul_acc; "
-            "a dropped predicate would accumulate into an uninitialized accumulator"
-        )
-        assert ir.structural_equal(accs[0].args[3], predicate)
-
-    @staticmethod
-    def _collect_calls(prog: ir.Program) -> list[ir.Call]:
-        fn = prog.get_function("main_incore_0")
-        assert fn is not None
-        body = cast(ir.SeqStmts, fn.body)
-        return [
-            stmt.value
-            for stmt in body.stmts
-            if isinstance(stmt, ir.AssignStmt) and isinstance(stmt.value, ir.Call)
-        ]
+        After = passes.flatten_tile_nd_to_2d()(passes.convert_tensor_to_tile_ops()(Before))
+        ir.assert_structural_equal(After, Expected)
 
 
 # ----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`pl.matmul_acc` accumulates a grouped GEMM whose weight slice keeps its group axis — a rank-3 `[1, N, K]` right operand into a rank-3 `[1, M, N]` accumulator — and `ConvertTensorToTileOps` lowers it through `tile.batch_matmul_acc` without complaint. Adding the `init_cond` predicate to that *same* operand shape made it illegal:

```text
ValueError: tensor.matmul_acc does not support init_cond on operands of rank > 2
(got acc rank 3, lhs rank 2, rhs rank 3). Loop over the batch dimension and
accumulate with 2D operands instead.
```

So the split-K predicate was available on exactly the shapes that do not need a grouped weight view, and unavailable on the one MoE case that does. A routed expert could not share the accumulation form the rest of its model tree uses, and had to keep the `if k == 0: matmul / else: matmul_acc` peel.

This makes `init_cond`'s domain exactly `tensor.matmul_acc`'s own: whatever operand shape accumulates without a predicate accumulates with one.

## Why the old check was wrong

The rejection landed with the feature (#2403) as its scope boundary, not as a discovered hazard — `init_cond` was wired through the 2D op only, and the check made the unwired path fail loudly instead of silently dropping the predicate. That is the right thing to do while landing a feature, but its stated rationale does not describe the failing case:

> The batched form expands into several tile.matmul_acc calls inside FlattenTileNdTo2D, which has no place to thread a per-call predicate.

A `[1, N, K]` operand has `batch_count == 1`, where `LowerBatchMatmulAcc`'s fast path emits a **single** whole-tile `tile.matmul_acc` — no fan-out, no slice, and that call already carries a 4th operand slot. The check tested `rank > 2`, but the property that matters is `batch_count > 1`.

## Changes

- **`src/ir/op/tile_ops/batch_matmul.cpp`** — `tile.batch_matmul_acc` gains the same optional 4th `init_cond` operand as `tile.matmul_acc`: `args.size() == 3 || == 4`, validated by the shared `CheckMatmulInitCond`, plus the matching `add_argument`.
- **`src/ir/transforms/flatten_tile_nd_to_2d/batch_matmul.cpp`** — `LowerBatchMatmulAcc` forwards the predicate to every 2D `tile.matmul_acc` it emits, via a `make_matmul_acc` helper used by both the `batch_count == 1` fast path and the general path. Forwarding rather than dropping is the point: a silently dropped predicate would accumulate into an uninitialized accumulator on the `k == 0` step.
- **`src/ir/transforms/op_conversion_registry.cpp`** — the `CHECK_SPAN(!nd, ...)` rejection is removed; `init_cond` now rides along on both `out_op` choices.
- **Python wrappers** — `init_cond` exposed on `pypto.ir.op.tile_ops.batch_matmul_acc` and `pypto.language.op.tile_ops.batch_matmul_acc`, mirroring their `matmul_acc` siblings. No `.pyi` change: these go through `create_op_call`.
- **Docs** — `docs/en/dev/ir/05-operators.md` and its `zh` mirror record the domain rule and why `batch_count > 1` is out of scope.
- **Tests** — two forwarding tests in `test_flatten_tile_nd_to_2d.py` (literal and runtime predicate, asserting arity 4 survives both conversion and flattening) and one end-to-end codegen test in `test_matmul_init_cond.py`.

Codegen needed no change — it already folds a constant predicate and branches on a runtime one.

## Behaviour

| | `batch_count == 1` | `batch_count >= 2` |
| --- | --- | --- |
| no predicate | works (unchanged) | already broken — 2 strict xfails in `test_flatten_tile_nd_to_2d.py` |
| `init_cond` | **now works** (was: rank rejection) | **same failure, same pass, same message as no-predicate** |

`batch_count > 1` is deliberately left alone. It is rejected by the wall that actually blocks it — the per-batch accumulator is a strided L0C row window the MAD cannot address, tracked as hw-native-sys/pto-isa#253 — instead of by a rank test that fired first and reported the wrong cause. Nothing that compiled before stops compiling.

## Verification

- Full unit suite: **10379 passed, 3 skipped, 2 xfailed**. The 2 xfails are the pre-existing `batch_count == 2` cases, unchanged.
- The grouped split-K repro that motivated this now compiles, and its three controls (`--peel`, `--rank2`, `--rank2-runtime`) still pass.
- Emitted code for the grouped case is optimal: one `pto.tmatmul` for the seeding step, `pto.tmatmul.acc` for the rest, and **zero `scf.if`** — the same instruction count as the peel it replaces, with a single-def accumulator.
- The shape a real MoE kernel needs — a rank-3 weight slice at a *runtime* group index, `w[eid : eid + 1, ...]`, with `init_cond` — compiles to 1 overwrite / 3 accumulates / 0 branches.
