### PR TITLE
fix(ir): restrict strict IntSet bounds to integer scalars

### DIFF
--- a/src/ir/arith/const_int_bound.cpp
+++ b/src/ir/arith/const_int_bound.cpp
@@ -397,8 +397,23 @@ class ConstIntBoundAnalyzer::Impl : public ExprFunctor<Bound> {
 std::function<void()> ConstIntBoundAnalyzer::Impl::EnterConstraint(const ExprPtr& constraint) {
   std::vector<std::pair<const Expr*, Bound>> recovery;
 
+  // A strict comparison is recorded as the equivalent closed bound. Only integers
+  // have a predecessor, so `x > c` is `x >= c + 1` for them and merely `x >= c` for
+  // everything else: applying the unit step to a float variable records `f >= 2`
+  // for `f > 1.0`, which excludes the legal value 1.5 and lets CanProve() fold a
+  // nested `f >= 2.0` to always-true. The relaxed bound stays sound — a float
+  // variable keeps contributing bounds, just without the strictness.
+  auto IsIntegerScalar = [](const VarPtr& var) {
+    auto scalar_type = As<ScalarType>(var->GetType());
+    return scalar_type && scalar_type->dtype_.IsInt();
+  };
+  auto StrictBound = [&](const VarPtr& var, int64_t bound, int64_t unit) {
+    return IsIntegerScalar(var) ? InfAwareAdd(bound, unit) : bound;
+  };
+
   // Helper: try to tighten bound for a variable.
-  auto TryTighten = [&](const Expr* var_ptr, const Bound& new_bound) {
+  auto TryTighten = [&](const VarPtr& var, const Bound& new_bound) {
+    const Expr* var_ptr = var.get();
     auto it = var_map_.find(var_ptr);
     Bound old = (it != var_map_.end()) ? it->second : DefaultBoundFromDtype(var_ptr);
     recovery.emplace_back(var_ptr, old);
@@ -413,10 +428,10 @@ std::function<void()> ConstIntBoundAnalyzer::Impl::EnterConstraint(const ExprPtr
     if (auto ge = As<Ge>(expr)) {
       if (auto var = As<Var>(ge->left_)) {
         auto rb = VisitExpr(ge->right_);
-        if (rb.is_const()) TryTighten(var.get(), {rb.min_value, Bound::kPosInf});
+        if (rb.is_const()) TryTighten(var, {rb.min_value, Bound::kPosInf});
       } else if (auto var = As<Var>(ge->right_)) {
         auto lb = VisitExpr(ge->left_);
-        if (lb.is_const()) TryTighten(var.get(), {Bound::kNegInf, lb.max_value});
+        if (lb.is_const()) TryTighten(var, {Bound::kNegInf, lb.max_value});
       }
       return;
     }
@@ -424,10 +439,10 @@ std::function<void()> ConstIntBoundAnalyzer::Impl::EnterConstraint(const ExprPtr
     if (auto gt = As<Gt>(expr)) {
       if (auto var = As<Var>(gt->left_)) {
         auto rb = VisitExpr(gt->right_);
-        if (rb.is_const()) TryTighten(var.get(), {InfAwareAdd(rb.min_value, 1), Bound::kPosInf});
+        if (rb.is_const()) TryTighten(var, {StrictBound(var, rb.min_value, 1), Bound::kPosInf});
       } else if (auto var = As<Var>(gt->right_)) {
         auto lb = VisitExpr(gt->left_);
-        if (lb.is_const()) TryTighten(var.get(), {Bound::kNegInf, InfAwareAdd(lb.max_value, -1)});
+        if (lb.is_const()) TryTighten(var, {Bound::kNegInf, StrictBound(var, lb.max_value, -1)});
       }
       return;
     }
@@ -435,10 +450,10 @@ std::function<void()> ConstIntBoundAnalyzer::Impl::EnterConstraint(const ExprPtr
     if (auto le = As<Le>(expr)) {
       if (auto var_l = As<Var>(le->left_)) {
         auto rb = VisitExpr(le->right_);
-        if (rb.is_const()) TryTighten(var_l.get(), {Bound::kNegInf, rb.max_value});
+        if (rb.is_const()) TryTighten(var_l, {Bound::kNegInf, rb.max_value});
       } else if (auto var_r = As<Var>(le->right_)) {
         auto lb = VisitExpr(le->left_);
-        if (lb.is_const()) TryTighten(var_r.get(), {lb.min_value, Bound::kPosInf});
+        if (lb.is_const()) TryTighten(var_r, {lb.min_value, Bound::kPosInf});
       }
       return;
     }
@@ -446,10 +461,10 @@ std::function<void()> ConstIntBoundAnalyzer::Impl::EnterConstraint(const ExprPtr
     if (auto lt = As<Lt>(expr)) {
       if (auto var = As<Var>(lt->left_)) {
         auto rb = VisitExpr(lt->right_);
-        if (rb.is_const()) TryTighten(var.get(), {Bound::kNegInf, InfAwareAdd(rb.max_value, -1)});
+        if (rb.is_const()) TryTighten(var, {Bound::kNegInf, StrictBound(var, rb.max_value, -1)});
       } else if (auto var = As<Var>(lt->right_)) {
         auto lb = VisitExpr(lt->left_);
-        if (lb.is_const()) TryTighten(var.get(), {InfAwareAdd(lb.min_value, 1), Bound::kPosInf});
+        if (lb.is_const()) TryTighten(var, {StrictBound(var, lb.min_value, 1), Bound::kPosInf});
       }
       return;
     }
@@ -457,10 +472,10 @@ std::function<void()> ConstIntBoundAnalyzer::Impl::EnterConstraint(const ExprPtr
     if (auto eq = As<Eq>(expr)) {
       if (auto var = As<Var>(eq->left_)) {
         auto rb = VisitExpr(eq->right_);
-        if (rb.is_const()) TryTighten(var.get(), rb);
+        if (rb.is_const()) TryTighten(var, rb);
       } else if (auto var = As<Var>(eq->right_)) {
         auto lb = VisitExpr(eq->left_);
-        if (lb.is_const()) TryTighten(var.get(), lb);
+        if (lb.is_const()) TryTighten(var, lb);
       }
       return;
     }

--- a/src/ir/arith/int_set.cpp
+++ b/src/ir/arith/int_set.cpp
@@ -389,74 +389,103 @@ class IntSetAnalyzer::Impl : public ExprFunctor<IntSet> {
 std::function<void()> IntSetAnalyzer::Impl::EnterConstraint(const ExprPtr& constraint) {
   std::vector<std::pair<const Expr*, IntSet>> recovery;
 
-  auto TryTighten = [&](const Expr* var_ptr, const IntSet& new_set) {
+  // SymMaxLower / SymMinUpper merge a new bound with the existing one by building
+  // Ge / Min / Max over the two, and those builders reject operands that are not
+  // scalars of the same numeric category. So a bound is recorded only when it is a
+  // numeric scalar matching the category of the variable it bounds; anything else
+  // (non-scalar, bool, mismatched category) is dropped instead.
+  auto NumericScalarType = [](const ExprPtr& expr) -> ScalarTypePtr {
+    auto scalar_type = As<ScalarType>(expr->GetType());
+    if (scalar_type && (scalar_type->dtype_.IsInt() || scalar_type->dtype_.IsFloat())) return scalar_type;
+    return nullptr;
+  };
+
+  auto TryTighten = [&](const VarPtr& var, const IntSet& new_set) {
+    if (new_set.is_everything()) return;  // No bound survived — nothing to record.
+    auto var_type = NumericScalarType(var);
+    if (!var_type) return;
+    auto MatchesVarCategory = [&](const ExprPtr& bound) {
+      auto bound_type = NumericScalarType(bound);
+      return bound_type && bound_type->dtype_.IsInt() == var_type->dtype_.IsInt();
+    };
+    if (new_set.min_value && !MatchesVarCategory(new_set.min_value)) return;
+    if (new_set.max_value && !MatchesVarCategory(new_set.max_value)) return;
+
+    const Expr* var_ptr = var.get();
     auto it = var_map_.find(var_ptr);
     IntSet old = (it != var_map_.end()) ? it->second : IntSet::Everything();
+    // Update() / Bind() are not routed through this guard, so an existing bound may
+    // be of the other category — merging it here is what would build the mixed Min/Max.
+    if (old.min_value && !MatchesVarCategory(old.min_value)) return;
+    if (old.max_value && !MatchesVarCategory(old.max_value)) return;
+
     recovery.emplace_back(var_ptr, old);
     // Tighten: new_min = max(old.min, new.min), new_max = min(old.max, new.max)
     var_map_[var_ptr] = {SymMaxLower(old.min_value, new_set.min_value, parent_),
                          SymMinUpper(old.max_value, new_set.max_value, parent_)};
   };
 
-  auto AreIntegerScalarOperands = [](const ExprPtr& left, const ExprPtr& right) {
-    // type.h is included directly, but LLVM 21 include-cleaner can miss it after a transitive inclusion.
-    auto left_type = As<ScalarType>(left->GetType());    // NOLINT(misc-include-cleaner)
-    auto right_type = As<ScalarType>(right->GetType());  // NOLINT(misc-include-cleaner)
-    return left_type && right_type && left_type->dtype_.IsInt() && right_type->dtype_.IsInt();
-  };
-
   ExprPtr one = MakeConstInt(1, DataType::INT64);
+
+  // A strict comparison is stored as the equivalent closed bound. Integers have a
+  // predecessor, so `left > right` is *exactly* `left >= right + 1`. No other dtype
+  // does — `f > 1.0` does not imply `f >= 2.0` — so there the strictness is simply
+  // forgotten and the non-strict bound `left >= right` is recorded instead: weaker,
+  // but sound, and it keeps float comparisons contributing bounds at all.
+  auto StrictBound = [&](const ExprPtr& bound, bool increment) -> ExprPtr {
+    auto bound_type = NumericScalarType(bound);
+    if (!bound_type || !bound_type->dtype_.IsInt()) return bound;
+    return MaybeSimplify(parent_, increment ? MakeAdd(bound, one) : MakeSub(bound, one));
+  };
 
   std::function<void(const ExprPtr&)> TryParse = [&](const ExprPtr& expr) {
     // Ge: left >= right  =>  left.min = right
     if (auto ge = As<Ge>(expr)) {
       if (auto var = As<Var>(ge->left_)) {
-        TryTighten(var.get(), {ge->right_, nullptr});
+        TryTighten(var, {ge->right_, nullptr});
       }
       if (auto var = As<Var>(ge->right_)) {
-        TryTighten(var.get(), {nullptr, ge->left_});
+        TryTighten(var, {nullptr, ge->left_});
       }
       return;
     }
-    // Gt: for integer operands, left > right  =>  left.min = right + 1
+    // Gt: left > right  =>  left.min = right + 1
     if (auto gt = As<Gt>(expr)) {
-      if (!AreIntegerScalarOperands(gt->left_, gt->right_)) return;
       if (auto var = As<Var>(gt->left_)) {
-        TryTighten(var.get(), {MaybeSimplify(parent_, MakeAdd(gt->right_, one)), nullptr});
+        TryTighten(var, {StrictBound(gt->right_, /*increment=*/true), nullptr});
       }
       if (auto var = As<Var>(gt->right_)) {
-        TryTighten(var.get(), {nullptr, MaybeSimplify(parent_, MakeSub(gt->left_, one))});
+        TryTighten(var, {nullptr, StrictBound(gt->left_, /*increment=*/false)});
       }
       return;
     }
     // Le: left <= right  =>  left.max = right
     if (auto le = As<Le>(expr)) {
       if (auto var = As<Var>(le->left_)) {
-        TryTighten(var.get(), {nullptr, le->right_});
+        TryTighten(var, {nullptr, le->right_});
       }
       if (auto var = As<Var>(le->right_)) {
-        TryTighten(var.get(), {le->left_, nullptr});
+        TryTighten(var, {le->left_, nullptr});
       }
       return;
     }
-    // Lt: for integer operands, left < right  =>  left.max = right - 1
+    // Lt: left < right  =>  left.max = right - 1
     if (auto lt = As<Lt>(expr)) {
-      if (!AreIntegerScalarOperands(lt->left_, lt->right_)) return;
       if (auto var = As<Var>(lt->left_)) {
-        TryTighten(var.get(), {nullptr, MaybeSimplify(parent_, MakeSub(lt->right_, one))});
+        TryTighten(var, {nullptr, StrictBound(lt->right_, /*increment=*/false)});
       }
       if (auto var = As<Var>(lt->right_)) {
-        TryTighten(var.get(), {MaybeSimplify(parent_, MakeAdd(lt->left_, one)), nullptr});
+        TryTighten(var, {StrictBound(lt->left_, /*increment=*/true), nullptr});
       }
       return;
     }
     // Eq: left == right  =>  left = [right, right]
     if (auto eq = As<Eq>(expr)) {
       if (auto var = As<Var>(eq->left_)) {
-        TryTighten(var.get(), IntSet::SinglePoint(eq->right_));
+        TryTighten(var, IntSet::SinglePoint(eq->right_));
       }
       if (auto var = As<Var>(eq->right_)) {
-        TryTighten(var.get(), IntSet::SinglePoint(eq->left_));
+        TryTighten(var, IntSet::SinglePoint(eq->left_));
       }
       return;
     }

--- a/src/ir/arith/int_set.cpp
+++ b/src/ir/arith/int_set.cpp
@@ -29,6 +29,7 @@
 #include "pypto/ir/program.h"
 #include "pypto/ir/scalar_expr.h"
 #include "pypto/ir/transforms/base/functor.h"
+#include "pypto/ir/type.h"
 
 namespace pypto {
 namespace ir {
@@ -397,6 +398,13 @@ std::function<void()> IntSetAnalyzer::Impl::EnterConstraint(const ExprPtr& const
                          SymMinUpper(old.max_value, new_set.max_value, parent_)};
   };
 
+  auto AreIntegerScalarOperands = [](const ExprPtr& left, const ExprPtr& right) {
+    // type.h is included directly, but LLVM 21 include-cleaner can miss it after a transitive inclusion.
+    auto left_type = As<ScalarType>(left->GetType());    // NOLINT(misc-include-cleaner)
+    auto right_type = As<ScalarType>(right->GetType());  // NOLINT(misc-include-cleaner)
+    return left_type && right_type && left_type->dtype_.IsInt() && right_type->dtype_.IsInt();
+  };
+
   ExprPtr one = MakeConstInt(1, DataType::INT64);
 
   std::function<void(const ExprPtr&)> TryParse = [&](const ExprPtr& expr) {
@@ -410,8 +418,9 @@ std::function<void()> IntSetAnalyzer::Impl::EnterConstraint(const ExprPtr& const
       }
       return;
     }
-    // Gt: left > right  =>  left.min = right + 1
+    // Gt: for integer operands, left > right  =>  left.min = right + 1
     if (auto gt = As<Gt>(expr)) {
+      if (!AreIntegerScalarOperands(gt->left_, gt->right_)) return;
       if (auto var = As<Var>(gt->left_)) {
         TryTighten(var.get(), {MaybeSimplify(parent_, MakeAdd(gt->right_, one)), nullptr});
       }
@@ -430,8 +439,9 @@ std::function<void()> IntSetAnalyzer::Impl::EnterConstraint(const ExprPtr& const
       }
       return;
     }
-    // Lt: left < right  =>  left.max = right - 1
+    // Lt: for integer operands, left < right  =>  left.max = right - 1
     if (auto lt = As<Lt>(expr)) {
+      if (!AreIntegerScalarOperands(lt->left_, lt->right_)) return;
       if (auto var = As<Var>(lt->left_)) {
         TryTighten(var.get(), {nullptr, MaybeSimplify(parent_, MakeSub(lt->right_, one))});
       }

--- a/tests/ut/ir/arith/test_analyzer.py
+++ b/tests/ut/ir/arith/test_analyzer.py
@@ -325,6 +325,21 @@ class TestConstraintContext:
         assert bound.max_value == 99
         analyzer.unbind(x)
 
+    def test_strict_float_constraint_skips_the_integer_unit_step(self):
+        # `f > 1.0` permits f = 1.5, so it must be recorded as `f >= 1`, not as the
+        # unit-stepped `f >= 2` — the latter lets a nested `f >= 2.0` fold to
+        # always-true and silently drops the else branch of the inner IfStmt.
+        f = ir.Var("f", ir.ScalarType(DataType.FP32), S)
+        cf_one = ir.ConstFloat(1.0, DataType.FP32, S)
+        cf_two = ir.ConstFloat(2.0, DataType.FP32, S)
+        cf_half = ir.ConstFloat(0.5, DataType.FP32, S)
+
+        with analyzer.constraint_context(ir.Gt(f, cf_one, BOOL, S)):
+            assert analyzer.const_int_bound(f).min_value == 1
+            assert analyzer.can_prove(ir.Ge(f, cf_two, BOOL, S)) is False
+            # The relaxed bound is still a bound: weaker facts stay provable.
+            assert analyzer.can_prove(ir.Ge(f, cf_half, BOOL, S)) is True
+
     def test_nested_constraints(self):
         analyzer.bind(x, 0, 100)
 

--- a/tests/ut/ir/arith/test_int_set.py
+++ b/tests/ut/ir/arith/test_int_set.py
@@ -302,24 +302,58 @@ class TestIntSetConstraint:
             s = ana.int_set(x)
             assert_is_const_int(s.max_value, 9)
 
-    @pytest.mark.parametrize("constraint", [ir.Lt, ir.Gt])
-    def test_strict_float_constraint_does_not_use_integer_unit(self, constraint):
+    def test_constraint_lt_tightens_index_dtype(self):
+        # INDEX is the dtype of loop vars and valid-shape scalars, and it is the
+        # dtype the integer guard is most load-bearing for: DataType.INDEX must
+        # classify as an integer, or every loop-bound constraint would be dropped.
+        ana = Analyzer()
+        idx = ir.Var("idx", ir.ScalarType(DataType.INDEX), S)
+        ana.int_set.update(idx, IntSet.everything())
+        with ana.constraint_context(ir.Lt(idx, ir.ConstInt(10, DataType.INDEX, S), BOOL, S)):
+            assert_is_const_int(ana.int_set(idx).max_value, 9)
+
+    def test_non_strict_float_constraint_still_bounds(self):
+        # A float variable keeps contributing bounds — only the unit step is
+        # integer-only, and Ge does not use it.
+        ana = Analyzer()
+        value = ir.Var("value", ir.ScalarType(FLOAT), S)
+        ana.int_set.update(value, IntSet.everything())
+        with ana.constraint_context(ir.Ge(value, cf(1.0), BOOL, S)):
+            constrained = ana.int_set(value)
+            assert isinstance(constrained.min_value, ir.ConstFloat)
+            assert constrained.min_value.value == 1.0
+            assert constrained.max_value is None
+
+    @pytest.mark.parametrize(
+        ("constraint", "bound_attr", "other_attr"),
+        [(ir.Gt, "min_value", "max_value"), (ir.Lt, "max_value", "min_value")],
+    )
+    def test_strict_float_constraint_drops_the_unit_step(self, constraint, bound_attr, other_attr):
+        # Floats have no predecessor: `f > 1.0` must record `f >= 1.0`, never
+        # `f >= 2.0` — the latter excludes the legal value 1.5.
         ana = Analyzer()
         value = ir.Var("value", ir.ScalarType(FLOAT), S)
         ana.int_set.update(value, IntSet.everything())
         with ana.constraint_context(constraint(value, cf(1.0), BOOL, S)):
             constrained = ana.int_set(value)
-            assert constrained.min_value is None
-            assert constrained.max_value is None
+            bound = getattr(constrained, bound_attr)
+            assert isinstance(bound, ir.ConstFloat)
+            assert bound.value == 1.0
+            assert getattr(constrained, other_attr) is None
 
-    @pytest.mark.parametrize("constraint", [ir.Lt, ir.Gt])
-    def test_strict_non_scalar_constraint_is_ignored(self, constraint):
+    @pytest.mark.parametrize("constraint", [ir.Lt, ir.Gt, ir.Le, ir.Ge, ir.Eq])
+    def test_non_scalar_constraint_is_ignored(self, constraint):
+        # A non-scalar bound would be handed to MakeAdd/MakeSub (strict) or to the
+        # Ge/Min/Max builders inside SymMaxLower/SymMinUpper (non-strict), both of
+        # which reject it. Drop the constraint instead, keeping the existing bound.
         analyzer = IntSetAnalyzer()
         scalar = ir.Var("scalar", ir.ScalarType(INT), S)
         tensor = ir.Var("tensor", ir.TensorType([1], FLOAT), S)
+        analyzer.update(scalar, IntSet.interval(ci(0), ci(100)))
 
         assert analyzer.enter_constraint(constraint(tensor, scalar, BOOL, S)) is None
         assert analyzer.enter_constraint(constraint(scalar, tensor, BOOL, S)) is None
+        assert_is_const_int(analyzer(scalar).max_value, 100)
 
     def test_constraint_scope_restores(self):
         ana = Analyzer()

--- a/tests/ut/ir/arith/test_int_set.py
+++ b/tests/ut/ir/arith/test_int_set.py
@@ -15,6 +15,7 @@ from pypto.arith import Analyzer, IntSet, IntSetAnalyzer
 
 S = ir.Span.unknown()
 INT = DataType.INT64
+FLOAT = DataType.FP32
 BOOL = DataType.BOOL
 
 x = ir.Var("x", ir.ScalarType(INT), S)
@@ -28,6 +29,10 @@ d = ir.Var("d", ir.ScalarType(INT), S)
 
 def ci(value: int) -> ir.ConstInt:
     return ir.ConstInt(value, INT, S)
+
+
+def cf(value: float) -> ir.ConstFloat:
+    return ir.ConstFloat(value, FLOAT, S)
 
 
 def assert_is_const_int(expr: ir.Expr | None, expected: int) -> None:
@@ -296,6 +301,25 @@ class TestIntSetConstraint:
         with ana.constraint_context(ir.Lt(x, ci(10), BOOL, S)):
             s = ana.int_set(x)
             assert_is_const_int(s.max_value, 9)
+
+    @pytest.mark.parametrize("constraint", [ir.Lt, ir.Gt])
+    def test_strict_float_constraint_does_not_use_integer_unit(self, constraint):
+        ana = Analyzer()
+        value = ir.Var("value", ir.ScalarType(FLOAT), S)
+        ana.int_set.update(value, IntSet.everything())
+        with ana.constraint_context(constraint(value, cf(1.0), BOOL, S)):
+            constrained = ana.int_set(value)
+            assert constrained.min_value is None
+            assert constrained.max_value is None
+
+    @pytest.mark.parametrize("constraint", [ir.Lt, ir.Gt])
+    def test_strict_non_scalar_constraint_is_ignored(self, constraint):
+        analyzer = IntSetAnalyzer()
+        scalar = ir.Var("scalar", ir.ScalarType(INT), S)
+        tensor = ir.Var("tensor", ir.TensorType([1], FLOAT), S)
+
+        assert analyzer.enter_constraint(constraint(tensor, scalar, BOOL, S)) is None
+        assert analyzer.enter_constraint(constraint(scalar, tensor, BOOL, S)) is None
 
     def test_constraint_scope_restores(self):
         ana = Analyzer()


### PR DESCRIPTION
## Summary

- apply unit-step tightening for strict comparisons only when both operands are integer scalars
- leave floating-point strict constraints unbounded instead of constructing mixed-type arithmetic
- ignore non-scalar strict constraints instead of raising during scalar dtype lookup

## Testing

- `python -m pytest tests/ut/ir/arith/test_int_set.py -n "$PYPTO_TEST_JOBS" -v`
- `python -m pytest tests/ut/ -n "$PYPTO_TEST_JOBS" -v`
- `pre-commit run --files src/ir/arith/int_set.cpp tests/ut/ir/arith/test_int_set.py`