### PR TITLE
perf(runtime): fix wide resident dispatch scaling

### DIFF
--- a/examples/runtime/distributed_dispatch_latency.py
+++ b/examples/runtime/distributed_dispatch_latency.py
@@ -1,0 +1,168 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Measure host submission latency for an eight-rank L3 program.
+
+The benchmark intentionally keeps the device program trivial. It measures the
+time for :meth:`DistributedWorker.submit` to return separately from the time
+spent waiting for the submitted work, making host dispatch regressions visible
+without any model or serving dependency.
+
+Run on eight devices::
+
+    python examples/runtime/distributed_dispatch_latency.py --devices 0,1,2,3,4,5,6,7
+"""
+
+import argparse
+import importlib.util
+import statistics
+import sys
+import tempfile
+import time
+from pathlib import Path
+from typing import Any
+
+import torch
+from pypto import ir
+from pypto.ir.distributed_compiled_program import DistributedConfig
+
+WORLD_SIZE = 8
+DIM = 128
+
+
+def load_rank_add_program(directory: Path, tensor_args: int) -> Any:
+    """Generate a model-free program with a configurable chip ABI width.
+
+    PyPTO parses decorated functions from their Python source, so the generated
+    module is written into the benchmark's temporary build directory before it
+    is imported. Only the first two inputs participate in the add; the remaining
+    inputs exist solely to reproduce wide generated TaskArgs construction.
+    """
+    input_count = tensor_args - 1
+    chip_params = ",\n            ".join(
+        f"x{index}: pl.Tensor[[DIM, DIM], pl.FP32]" for index in range(input_count)
+    )
+    host_params = ",\n            ".join(
+        f"x{index}: pl.Tensor[[WORLD_SIZE, DIM, DIM], pl.FP32]" for index in range(input_count)
+    )
+    rank_args = ", ".join(f"x{index}[rank]" for index in range(input_count))
+    source = f"""import pypto.language as pl
+import pypto.language.distributed as pld
+
+WORLD_SIZE = {WORLD_SIZE}
+DIM = {DIM}
+
+@pl.program
+class RankAdd:
+    @pl.function(type=pl.FunctionType.InCore)
+    def tile_add(
+            self,
+            a: pl.Tensor[[DIM, DIM], pl.FP32],
+            b: pl.Tensor[[DIM, DIM], pl.FP32],
+            out: pl.Out[pl.Tensor[[DIM, DIM], pl.FP32]]):
+        tile_a = pl.load(a, [0, 0], [DIM, DIM])
+        tile_b = pl.load(b, [0, 0], [DIM, DIM])
+        return pl.store(pl.add(tile_a, tile_b), [0, 0], out)
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def chip_orch(
+            self,
+            {chip_params},
+            out: pl.Out[pl.Tensor[[DIM, DIM], pl.FP32]]):
+        return self.tile_add(x0, x1, out)
+
+    @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+    def host_orch(
+            self,
+            {host_params},
+            out: pl.Out[pl.Tensor[[WORLD_SIZE, DIM, DIM], pl.FP32]]):
+        for rank in pl.range(pld.world_size()):
+            self.chip_orch({rank_args}, out[rank], device=rank)
+"""
+    module_path = directory / "generated_dispatch_program.py"
+    module_path.write_text(source, encoding="utf-8")
+    module_name = "_pypto_generated_dispatch_program"
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Failed to create an import spec for {module_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module.RankAdd
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--devices", required=True, help="Exactly eight comma-separated device IDs")
+    parser.add_argument("--platform", default="a2a3")
+    parser.add_argument("--rounds", type=int, default=30)
+    parser.add_argument(
+        "--tensor-args",
+        type=int,
+        default=142,
+        help="Total chip tensor arguments per rank, including the output",
+    )
+    return parser.parse_args()
+
+
+def median_and_range(samples: list[float]) -> str:
+    """Format a latency sample set in milliseconds."""
+    return f"median={statistics.median(samples):.3f} ms range={min(samples):.3f}-{max(samples):.3f} ms"
+
+
+def main() -> None:
+    """Compile the minimal program and report submit and wait latency."""
+    args = parse_args()
+    devices = [int(item) for item in args.devices.split(",")]
+    if len(devices) != WORLD_SIZE or len(set(devices)) != WORLD_SIZE:
+        raise ValueError(f"--devices must contain exactly {WORLD_SIZE} unique IDs, got {devices}")
+    if args.rounds <= 0:
+        raise ValueError(f"--rounds must be positive, got {args.rounds}")
+    if args.tensor_args < 3:
+        raise ValueError(f"--tensor-args must be at least 3, got {args.tensor_args}")
+
+    host_source = torch.ones((WORLD_SIZE, DIM, DIM), dtype=torch.float32).share_memory_()
+    host_out = torch.zeros_like(host_source).share_memory_()
+
+    with tempfile.TemporaryDirectory(prefix="pypto-dispatch-latency-") as output_dir:
+        program = load_rank_add_program(Path(output_dir), args.tensor_args)
+        compiled = ir.compile(
+            program,
+            platform=args.platform,
+            output_dir=output_dir,
+            distributed_config=DistributedConfig(device_ids=devices, num_sub_workers=0),
+        )
+        submit_ms: list[float] = []
+        wait_ms: list[float] = []
+        with compiled.prepare() as worker:
+            worker.register(compiled)
+            resident_inputs = [worker.alloc_stacked_tensor(host_source) for _ in range(args.tensor_args - 1)]
+            try:
+                worker.submit(compiled, *resident_inputs, host_out).wait()
+                for _ in range(args.rounds):
+                    started_ns = time.perf_counter_ns()
+                    pending = worker.submit(compiled, *resident_inputs, host_out)
+                    submitted_ns = time.perf_counter_ns()
+                    pending.wait()
+                    finished_ns = time.perf_counter_ns()
+                    submit_ms.append((submitted_ns - started_ns) / 1e6)
+                    wait_ms.append((finished_ns - submitted_ns) / 1e6)
+            finally:
+                for tensor in reversed(resident_inputs):
+                    worker.free_stacked_tensor(tensor)
+
+    torch.testing.assert_close(host_out, torch.full_like(host_out, 2.0))
+    print(f"tensor args per rank: {args.tensor_args}")
+    print(f"submit: {median_and_range(submit_ms)}")
+    print(f"wait:   {median_and_range(wait_ms)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/runtime/distributed_dispatch_latency.py
+++ b/examples/runtime/distributed_dispatch_latency.py
@@ -26,11 +26,11 @@ import sys
 import tempfile
 import time
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir.distributed_compiled_program import DistributedCompiledProgram, DistributedConfig
 
 WORLD_SIZE = 8
 DIM = 128
@@ -133,11 +133,14 @@ def main() -> None:
 
     with tempfile.TemporaryDirectory(prefix="pypto-dispatch-latency-") as output_dir:
         program = load_rank_add_program(Path(output_dir), args.tensor_args)
-        compiled = ir.compile(
-            program,
-            platform=args.platform,
-            output_dir=output_dir,
-            distributed_config=DistributedConfig(device_ids=devices, num_sub_workers=0),
+        compiled = cast(
+            DistributedCompiledProgram,
+            ir.compile(
+                program,
+                platform=args.platform,
+                output_dir=output_dir,
+                distributed_config=DistributedConfig(device_ids=devices, num_sub_workers=0),
+            ),
         )
         submit_ms: list[float] = []
         wait_ms: list[float] = []

--- a/python/pypto/runtime/device_tensor.py
+++ b/python/pypto/runtime/device_tensor.py
@@ -59,6 +59,7 @@ class DeviceTensor:
     shape: tuple[int, ...]
     dtype: torch.dtype
     buffer: Any | None = field(default=None, repr=False, compare=False, hash=False)
+    _wire_tensor: Any | None = field(default=None, init=False, repr=False, compare=False, hash=False)
 
     def __init__(
         self,
@@ -97,6 +98,17 @@ class DeviceTensor:
         object.__setattr__(self, "shape", shape_t)
         object.__setattr__(self, "dtype", dtype)
         object.__setattr__(self, "buffer", buffer)
+        object.__setattr__(self, "_wire_tensor", None)
+
+    def _get_wire_tensor(self, dtype: Any) -> Any:
+        """Return the cached address-free Simpler descriptor for this allocation."""
+        wire_tensor = self._wire_tensor
+        if wire_tensor is None:
+            if self.buffer is None:
+                raise TypeError("A raw-pointer DeviceTensor has no owner Buffer for wire dispatch.")
+            wire_tensor = self.buffer.tensor(shapes=self.shape, dtype=dtype)
+            object.__setattr__(self, "_wire_tensor", wire_tensor)
+        return wire_tensor
 
     @property
     def nbytes(self) -> int:

--- a/python/pypto/runtime/runtime_base.py
+++ b/python/pypto/runtime/runtime_base.py
@@ -92,6 +92,11 @@ class Worker(ABC):
         # DeviceTensor value is the allocation identity: a stale handle must
         # not free a newer allocation that reused the same device address.
         self._owned_tensors: dict[tuple[int, int], DeviceTensor] = {}
+        # Reverse allocation-identity index used by the generated L3 tensor
+        # packing path. A wide distributed dispatch may validate thousands of
+        # resident shards, so looking up the owning ``(worker_id, data_ptr)``
+        # key must not scan the complete allocation table for every argument.
+        self._owned_tensor_keys: dict[int, tuple[int, int]] = {}
         # Raw simpler Workers are bound back to this owner for DeviceTensor
         # wire conversion.  The concrete runtime sets this whenever it creates
         # (or recreates) its backend; tensor_arg.py rejects stale backends whose
@@ -191,9 +196,12 @@ class Worker(ABC):
         ``DeviceTensor`` keeps its Buffer handle after ``free_tensor()`` so
         that the immutable public handle remains inspectable.  The retained
         handle alone is therefore not proof of liveness.  The authoritative
-        check is object identity in ``_device_buffers``: this rejects foreign
-        Workers, freed handles, and pointer-reuse (ABA) cases before a stale
-        wire descriptor can enter simpler ``Worker.run``.
+        check combines the exact ``DeviceTensor`` allocation identity with
+        object identity in ``_device_buffers``: this rejects foreign Workers,
+        freed handles, and pointer-reuse (ABA) cases before a stale wire
+        descriptor can enter simpler ``Worker.run``. The reverse identity
+        index keeps this check O(1), including when *worker_id* is omitted by
+        generated orchestration code.
         """
         self._require_ready("dispatch DeviceTensor")
         worker_name = type(self).__name__
@@ -208,12 +216,14 @@ class Worker(ABC):
             raise TypeError(
                 f"{label}: {worker_name} does not retain owner Buffers required for DeviceTensor dispatch."
             )
-        if worker_id is None:
-            owned = any(
-                ptr == tensor.data_ptr and buffer is tensor.buffer for (_wid, ptr), buffer in buffers.items()
-            )
-        else:
-            owned = buffers.get((worker_id, tensor.data_ptr)) is tensor.buffer
+        key = self._owned_tensor_keys.get(id(tensor))
+        owned = (
+            key is not None
+            and key[1] == tensor.data_ptr
+            and (worker_id is None or key[0] == worker_id)
+            and self._owned_tensors.get(key) is tensor
+            and buffers.get(key) is tensor.buffer
+        )
         if not owned:
             placement = "" if worker_id is None else f" on worker_id={worker_id}"
             raise ValueError(
@@ -265,7 +275,9 @@ class Worker(ABC):
             init=init,
             init_prep=self._prepare_init,
         )
-        self._owned_tensors[(worker_id, t.data_ptr)] = t
+        key = (worker_id, t.data_ptr)
+        self._owned_tensors[key] = t
+        self._owned_tensor_keys[id(t)] = key
         return t
 
     def free_tensor(self, t: DeviceTensor, *, worker_id: int = 0) -> None:
@@ -310,6 +322,7 @@ class Worker(ABC):
         # can retry. A successful first free removes the key and keeps the
         # genuine second-free path idempotent.
         del self._owned_tensors[key]
+        del self._owned_tensor_keys[id(t)]
 
     def _close_owned_tensors(self) -> None:
         """Release any DeviceTensors the caller forgot to :meth:`free_tensor`.
@@ -323,6 +336,7 @@ class Worker(ABC):
         # close()) don't double-iterate.
         leaked = self._owned_tensors
         self._owned_tensors = {}
+        self._owned_tensor_keys.clear()
         for worker_id, ptr in leaked:
             try:
                 self.free(ptr, worker_id=worker_id)

--- a/python/pypto/runtime/tensor_arg.py
+++ b/python/pypto/runtime/tensor_arg.py
@@ -103,8 +103,8 @@ def make_tensor_arg(worker: Any, arg: Any) -> Any:
               simpler's worker-aware wire helper).
             - :class:`~pypto.runtime.DeviceTensor`: a worker-resident buffer;
               after owner/liveness validation, its retained ``Buffer``
-              constructs an address-free wire ``Tensor`` (memory is
-              caller-managed).
+              lazily constructs and reuses an address-free wire ``Tensor``
+              descriptor (memory is caller-managed).
             - simpler ``Tensor``: returned as-is (already device-side).
 
     Returns:
@@ -125,5 +125,5 @@ def make_tensor_arg(worker: Any, arg: Any) -> Any:
             dtype = task_interface.torch_dtype_to_datatype(arg.dtype)
         except KeyError as e:
             raise ValueError(f"Unsupported DeviceTensor dtype: {arg.dtype}") from e
-        return arg.buffer.tensor(shapes=arg.shape, dtype=dtype)
+        return arg._get_wire_tensor(dtype)
     return torch_interop.make_tensor_arg(worker, arg)

--- a/tests/ut/runtime/test_runtime_base.py
+++ b/tests/ut/runtime/test_runtime_base.py
@@ -116,6 +116,7 @@ def test_alloc_tensor_tracks_in_owned_set():
     t = h.alloc_tensor((4,), torch.float32)
     # Tracking is keyed by (worker_id, data_ptr); default worker_id is 0.
     assert (0, t.data_ptr) in h._owned_tensors
+    assert h._owned_tensor_keys[id(t)] == (0, t.data_ptr)
 
 
 def test_free_tensor_untracks_and_frees():
@@ -123,6 +124,7 @@ def test_free_tensor_untracks_and_frees():
     t = h.alloc_tensor((4,), torch.float32)
     h.free_tensor(t)
     assert (0, t.data_ptr) not in h._owned_tensors
+    assert id(t) not in h._owned_tensor_keys
     assert h.freed == [t.data_ptr]
 
 
@@ -135,6 +137,7 @@ def test_close_owned_tensors_frees_leaked():
     h._close_owned_tensors()
     assert b.data_ptr in h.freed
     assert h._owned_tensors == {}
+    assert h._owned_tensor_keys == {}
 
 
 def test_close_owned_tensors_swallows_free_errors():

--- a/tests/ut/runtime/test_tensor_arg.py
+++ b/tests/ut/runtime/test_tensor_arg.py
@@ -59,9 +59,12 @@ def test_device_tensor_derives_wire_tensor_from_retained_buffer():
         "pypto.runtime.task_interface.torch_dtype_to_datatype",
         side_effect=lambda d: f"<dtype:{d}>",
     ):
-        make_tensor_arg(worker, dt)
+        first = make_tensor_arg(worker, dt)
+        second = make_tensor_arg(worker, dt)
 
-    owner._require_owned_resident_tensor.assert_called_once_with(dt, "Tensor argument")
+    assert first is second
+    assert owner._require_owned_resident_tensor.call_count == 2
+    owner._require_owned_resident_tensor.assert_called_with(dt, "Tensor argument")
     assert len(captured["tensor_calls"]) == 1
     call = captured["tensor_calls"][0]
     assert call["shapes"] == (8, 16)
@@ -101,6 +104,62 @@ def test_owner_liveness_failure_prevents_wire_tensor_creation():
 
     with pytest.raises(ValueError, match="not a live allocation"):
         make_tensor_arg(worker, dt)
+
+
+def test_cached_wire_tensor_still_requires_live_owner():
+    """Descriptor reuse must not bypass freed or foreign allocation checks."""
+
+    from pypto.runtime.tensor_arg import bind_tensor_arg_owner, make_tensor_arg  # noqa: PLC0415
+
+    worker = MagicMock(name="worker")
+    owner = MagicMock(name="pypto_owner")
+    bind_tensor_arg_owner(worker, owner)
+    buffer = MagicMock(name="buffer")
+    buffer.base = 0xABCD
+    dt = DeviceTensor(buffer.base, (4,), torch.float32, buffer=buffer)
+
+    make_tensor_arg(worker, dt)
+    owner._require_owned_resident_tensor.side_effect = ValueError("allocation was freed")
+
+    with pytest.raises(ValueError, match="allocation was freed"):
+        make_tensor_arg(worker, dt)
+
+    buffer.tensor.assert_called_once()
+
+
+def test_owner_liveness_lookup_does_not_scan_device_buffers():
+    """Wide resident dispatch uses an O(1) allocation identity lookup."""
+
+    class NoIterationDict(dict):
+        def items(self):
+            raise AssertionError("resident tensor validation must not scan all device buffers")
+
+    from pypto.runtime.tensor_arg import bind_tensor_arg_owner, make_tensor_arg  # noqa: PLC0415
+
+    owner = MagicMock(name="pypto_owner")
+    owner._tensor_arg_worker = None
+    worker = MagicMock(name="worker")
+    bind_tensor_arg_owner(worker, owner)
+
+    buffer = MagicMock(name="buffer")
+    buffer.base = 0xABCD
+    buffer.tensor.return_value = MagicMock(name="wire_tensor")
+    dt = DeviceTensor(buffer.base, (4,), torch.float32, buffer=buffer)
+    key = (7, dt.data_ptr)
+    owner._require_owned_resident_tensor = None
+
+    from pypto.runtime.runtime_base import Worker  # noqa: PLC0415
+
+    owner._require_owned_resident_tensor = Worker._require_owned_resident_tensor.__get__(owner)
+    owner._require_ready = MagicMock(name="require_ready")
+    owner._owned_tensor_keys = {id(dt): key}
+    owner._owned_tensors = {key: dt}
+    owner._device_buffers = NoIterationDict({key: buffer})
+
+    make_tensor_arg(worker, dt)
+
+    owner._require_ready.assert_called_once_with("dispatch DeviceTensor")
+    buffer.tensor.assert_called_once()
 
 
 def test_stale_raw_backend_is_rejected_before_owner_validation():


### PR DESCRIPTION
## Summary

- make resident `DeviceTensor` ownership validation O(1) instead of scanning every live buffer
- cache each immutable address-free Simpler tensor descriptor while still validating liveness on every dispatch
- add a model-free DP8 benchmark with a configurable wide tensor ABI
- add regression tests for descriptor reuse, stale-handle rejection, and non-scanning ownership lookup

Fixes #2532.

## Root cause

Generated L3 orchestration calls `make_tensor_arg()` once per tensor per rank. For a DeepSeek-like workload with 141 resident inputs across DP8, that is 1,128 resident shards. The current no-`worker_id` ownership check linearly scanned the approximately 1,128-entry `_device_buffers` map for every shard, making dispatch descriptor packing O(N²). It also rebuilt the same immutable wire descriptor on every dispatch.

The reverse identity index preserves checks for foreign workers, freed handles, and pointer reuse (ABA), while making the ownership lookup O(1). Descriptor caching happens only after that check, and every reuse still performs the liveness check.

## Standalone NPU benchmark

```bash
PTO2_RING_DEP_POOL=131072 \
PTO2_RING_TASK_WINDOW=131072 \
PTO2_RING_HEAP=536870912 \
python examples/runtime/distributed_dispatch_latency.py \
  --devices 0,1,2,3,4,5,6,7 --rounds 20 --tensor-args 142
```

| revision | submit median | wait median |
|---|---:|---:|
| `b10cae3d` | 5.209 ms | 1.297 ms |
| `bd3a477d` before | 64.173 ms | 0.939 ms |
| this change | 10.380 ms | 0.953 ms |

The DP8 first-to-last `runner_run` entry spread drops from about 64 ms to about 7.1 ms. The remaining difference from `b10cae3d` is fixed current task-graph packing/build overhead rather than allocation-count scaling.

## Validation

- `python -m pytest tests/ut/runtime -q`: 694 passed
- `ruff check` on all changed Python files: passed
- `ruff format --check` on all changed Python files: passed
- header check: 1,096 passed
- English-only check: 1,288 passed
- standalone DP8 benchmark correctness assertion: passed
