### PR TITLE
fix(jit): accept closure constants and runtime-sized locals in a jitted program

### DIFF
--- a/docs/en/user/distributed/01-collectives.md
+++ b/docs/en/user/distributed/01-collectives.md
@@ -40,21 +40,16 @@ data = pld.tensor.allreduce(data, op=pld.ReduceOp.Sum, core_num=4)
 - 2(P-1) steps: reduce-scatter + allgather
 - O(N/P) remote traffic per step — each rank reads one neighbour
 - Signal shape: `[2 × (NR − 1), NR]`
-- Requires compile-time-known NR — use a factory function pattern **with the
-  `@pl.program` class form**: an outer Python function takes `nr`/`size`,
-  derives `total_rounds = 2 * (nr - 1)`, and defines the `@pl.program` class
-  inside its own body, so `[total_rounds, nr]` becomes a compile-time
-  constant. `@pl.program` / `@pl.function` snapshot the defining frame's
-  locals at decoration time, which is what makes those closure constants
-  resolve.
-- The `@pl.jit` family does **not** work for this: its constant folding reads
-  only the function's module globals (`__globals__`), never `__closure__`
-  (`python/pypto/jit/specializer.py`), so a factory closure constant
-  referenced in a HOST orchestrator body fails to resolve with
-  `Undefined variable`. See
+- Requires compile-time-known NR — use a factory function pattern: an outer
+  Python function takes `nr`/`size`, derives `total_rounds = 2 * (nr - 1)`,
+  and defines the program inside its own body, so `[total_rounds, nr]`
+  becomes a compile-time constant.
+- Both decorator families support this. `@pl.program` / `@pl.function`
+  snapshot the defining frame's locals at decoration time. The `@pl.jit`
+  family folds closure constants into the source it regenerates, so a factory
+  constant referenced in a HOST orchestrator body resolves the same way. See
   `collectives/test_l3_tensor_allreduce_ring_intrinsic.py` in [Runnable
-  Examples](#runnable-examples), which uses the `@pl.program` class form for
-  exactly this reason.
+  Examples](#runnable-examples) for the class form.
 - Best for large messages (>16 KiB) and high bandwidth
 
 | Aspect | Mesh | Ring |

--- a/docs/en/user/distributed/13-allreduce_mesh.md
+++ b/docs/en/user/distributed/13-allreduce_mesh.md
@@ -47,18 +47,20 @@ body, so one module-level `@pl.program` serves any world size picked with `-d`
 `tests/st/distributed/collectives/test_l3_allreduce.py`, the system test for
 this same collective.
 
-Steps 01-07 use the `@pl.jit` family, and the switch to the class form here is
-**required, not stylistic** — but the reason is the *dynamic* signal shape, not
-a compile-time one. `signal` is a window shaped `[pld.world_size(), 1]`, and
-`@pl.jit` must statically infer shape and dtype for every parameter it forwards
-to a dependency; it rejects this one with `missing inferred tensor metadata for
-parameter 'signal'`. `@pl.program` carries no such requirement. (`@pl.jit` is
-fine with distributed tensors as such — steps 03, 05, 06 and 07 all pass them
-— it is specifically a runtime-sized window dim it cannot type.)
+Steps 01-07 use the `@pl.jit` family, and the class form here is a
+presentational choice rather than a requirement. `signal` is a window shaped
+`[pld.world_size(), 1]`, whose row count no static rule can fold. `@pl.jit`
+gives such a dim a synthesized dynamic dimension, declares it via `pl.dynamic`
+in the program it generates, and the kernel binds it from the actual argument's
+descriptor — structurally what the class form below writes by hand as `NR`,
+differing only in the symbol's name. The class form is used here because it
+makes that shape explicit next to the system test it mirrors.
 
-Steps 09 and 10 switch for a stronger reason: their chunk size `SIZE // nr` is
-a **tile shape**, and tile shapes must be known when the kernel is compiled, so
-those genuinely need a compile-time rank count and a factory. A signal row
+Steps 09 and 10 switch for a reason that *is* binding: their chunk size
+`SIZE // nr` is a **tile shape**, and tile shapes must be known when the kernel
+is compiled, so those genuinely need a compile-time rank count and a factory.
+That limit applies to either decorator family — a dynamic dim reaching a tile
+shape is rejected downstream by `InitMemRef`, not by the frontend. A signal row
 count is not a tile shape, which is why it can stay dynamic here.
 
 The kernel is the four phases every hand-rolled collective shares:
@@ -113,7 +115,7 @@ is exactly why the two-phase and ring variants exist.
 | Sum includes zeros at some ranks | Barrier missing/incorrect; read raced the store | Barrier (notify all / wait all) before Phase 3 |
 | Wrong result only at P=4 | P=2 hides the race (single peer) | Run P≥4; check the barrier covers every peer |
 | Same result on every rank but ≠ torch sum | Reduction order differs (not a bug) | Compare with a tolerance (the example already does) |
-| `missing inferred tensor metadata for parameter 'signal'` | The kernel was written with `@pl.jit`, which cannot type a window whose dim is `pld.world_size()` | Use the `@pl.program` class form (as here); `@pl.jit` needs every dep parameter statically shaped |
+| `InitMemRef requires static shape ... is dynamic` | A runtime-sized dim reached a **tile** shape (e.g. a chunk size derived from the rank count) | Give that kernel a compile-time rank count via a factory, as steps 09-10 do; tile shapes cannot be runtime-sized in either decorator family |
 | Golden fails with a huge diff | Slices summed in the wrong place (e.g. own slice counted twice) | Stage once; accumulate from your own slice, then peers |
 
 ## See also

--- a/docs/zh/user/distributed/01-collectives.md
+++ b/docs/zh/user/distributed/01-collectives.md
@@ -37,17 +37,14 @@ data = pld.tensor.allreduce(data, op=pld.ReduceOp.Sum, core_num=4)
 - 2(P-1) 步：reduce-scatter + allgather
 - 每步 O(N/P) 远程流量——每个 rank 读取一个邻居
 - Signal 形状：`[2 × (NR − 1), NR]`
-- 要求编译时已知 NR——使用工厂函数模式，且必须搭配 **`@pl.program` 类形式**：
-  外层 Python 函数接收 `nr`/`size`，推导出 `total_rounds = 2 * (nr - 1)`，
-  并在自己的函数体内定义 `@pl.program` 类，使 `[total_rounds, nr]` 成为
-  编译期常量。`@pl.program` / `@pl.function` 会在装饰时捕获*定义处*帧的
-  局部变量，这正是那些闭包常量能够解析的原因。
-- `@pl.jit` 系列在这里**不可用**：它的常量折叠只读取函数的模块全局
-  （`__globals__`），从不读取 `__closure__`
-  （`python/pypto/jit/specializer.py`），因此在 HOST 编排体内引用的工厂
-  闭包常量会以 `Undefined variable` 失败。参见下方"可运行示例"一节中的
-  `collectives/test_l3_tensor_allreduce_ring_intrinsic.py`——该测试正是
-  出于这个原因使用 `@pl.program` 类形式。
+- 要求编译时已知 NR——使用工厂函数模式：外层 Python 函数接收 `nr`/`size`，
+  推导出 `total_rounds = 2 * (nr - 1)`，并在自己的函数体内定义程序，使
+  `[total_rounds, nr]` 成为编译期常量。
+- 两种装饰器系列都支持这一模式。`@pl.program` / `@pl.function` 会在装饰时
+  捕获*定义处*帧的局部变量；`@pl.jit` 系列则会把闭包常量折叠进它重新生成
+  的源码，因此在 HOST 编排体内引用的工厂常量同样能够解析。类形式的写法参见
+  下方"可运行示例"一节中的
+  `collectives/test_l3_tensor_allreduce_ring_intrinsic.py`。
 - 最适合大消息（>16 KiB）和高带宽
 
 | 方面 | Mesh | Ring |

--- a/docs/zh/user/distributed/13-allreduce_mesh.md
+++ b/docs/zh/user/distributed/13-allreduce_mesh.md
@@ -42,17 +42,18 @@ OK
 数量工厂。这与本集合通信的系统测试
 `tests/st/distributed/collectives/test_l3_allreduce.py` 完全一致。
 
-步骤 01-07 使用 `@pl.jit` 系列；这里改用 class form 是**必需的，而非风格
-选择**——但原因是信号形状是*动态的*，而非编译期的。`signal` 是形状为
-`[pld.world_size(), 1]` 的窗口，而 `@pl.jit` 必须为它传给依赖函数的每个
-参数静态推断形状与 dtype，因此会报
-`missing inferred tensor metadata for parameter 'signal'`；`@pl.program`
-没有这一要求。（`@pl.jit` 本身并不排斥分布式张量——步骤 03、05、06、07
-都传递它们——它无法处理的是运行期决定的窗口维度。）
+步骤 01-07 使用 `@pl.jit` 系列；这里改用 class form 是一种呈现上的选择，
+而非必需。`signal` 是形状为 `[pld.world_size(), 1]` 的窗口，其行数无法由
+任何静态规则折叠。`@pl.jit` 会为这样的维度合成一个动态维，在它生成的程序
+里用 `pl.dynamic` 声明，kernel 再从实参的 descriptor 绑定它——这在结构上
+就是下面 class form 手写的 `NR`，只是符号名不同。这里采用 class form，是为
+了让该形状与它对应的系统测试并排展示得更清楚。
 
-步骤 09 与 10 改用 class form 的理由更强：它们的块大小 `SIZE // nr` 是
-**tile 形状**，而 tile 形状必须在 kernel 编译时已知，所以那里确实需要
-编译期 rank 数量与工厂。信号的行数不是 tile 形状，因此这里可以保持动态。
+步骤 09 与 10 改用 class form 的理由则**确实是硬性的**：它们的块大小
+`SIZE // nr` 是 **tile 形状**，而 tile 形状必须在 kernel 编译时已知，所以
+那里确实需要编译期 rank 数量与工厂。这一限制对两种装饰器系列同样成立——
+动态维一旦流入 tile 形状，会在下游由 `InitMemRef` 拒绝，而不是在前端。
+信号的行数不是 tile 形状，因此这里可以保持动态。
 
 kernel 是每个手工集合通信共有的四阶段：
 
@@ -105,7 +106,7 @@ rank 读取。round 密集：`P-1` 次远程读取加一个 barrier。正是这�
 | 某些 rank 的和里含零 | barrier 缺失/错误；读取竞争了 store | Phase 3 前做 barrier（通知全部/等待全部） |
 | 只在 P=4 出错 | P=2 掩盖竞争（单一对端） | 用 P≥4 运行；检查 barrier 覆盖每个对端 |
 | 每个 rank 结果相同但与 torch 和不同 | 归约顺序不同（非 bug） | 用容差比较（示例已如此） |
-| `missing inferred tensor metadata for parameter 'signal'` | kernel 写成了 `@pl.jit`，而它无法为维度是 `pld.world_size()` 的窗口定型 | 改用 `@pl.program` class form（如本例）；`@pl.jit` 要求每个依赖参数都是静态形状 |
+| `InitMemRef requires static shape ... is dynamic` | 运行期决定的维度流入了 **tile** 形状（例如由 rank 数量推导出的块大小） | 像步骤 09-10 那样用工厂给该 kernel 一个编译期 rank 数量；两种装饰器系列都不允许 tile 形状是运行期尺寸 |
 | golden 出现巨大差异 | slice 被求和在错误位置（如自己的 slice 被重复计算） | 只 staging 一次；从自己的 slice 开始再累加对端 |
 
 ## 参见（See also）

--- a/python/pypto/jit/cache.py
+++ b/python/pypto/jit/cache.py
@@ -147,6 +147,7 @@ def make_cache_key(  # noqa: PLR0913 — args are the key's components, one per 
     enable_pypto_l0c_double_buffer: bool = False,
     tensor_layouts: dict[str, "TensorLayout | None"] | None = None,
     dep_layouts: tuple[tuple[str, str, str], ...] = (),
+    closure_constants: tuple[tuple[str, str, str], ...] = (),
     runtime: RuntimeKind = RuntimeKind.TENSORMAP_AND_RINGBUFFER,
 ) -> CacheKey:
     """Build a cache key for a JIT call site.
@@ -164,6 +165,14 @@ def make_cache_key(  # noqa: PLR0913 — args are the key's components, one per 
             ``tensor_layouts``, one call deeper: they shape the generated dep
             signatures but appear in no entry-parameter meta, and a postponed
             annotation hides a rebind from ``source_hash``.
+        closure_constants: ``(function name, free variable, repr of value)``
+            triples for the closure constants folded into the generated source.
+            Same reasoning again: the folder inlines them as literals, so they
+            change the artifact, but they live in ``__closure__`` rather than in
+            the function text — rebinding a cell (``nonlocal rows = 96``) leaves
+            ``source_hash`` identical and would otherwise hand the next call the
+            previous value's artifact. ``repr`` keeps the component hashable and
+            keeps ``1``, ``1.0``, and ``True`` distinct.
         dynamic_dims: Set of (param_name, dim_index) pairs that are dynamic.
             Dynamic dims are stored as None in the cache key so different
             concrete values for that dimension produce the same cache entry.
@@ -247,6 +256,7 @@ def make_cache_key(  # noqa: PLR0913 — args are the key's components, one per 
         ("memory_planner", None if memory_planner is None else str(memory_planner)),
         ("enable_pypto_l0c_double_buffer", effective_pypto_dbc),
         ("dep_layouts", dep_layouts),
+        ("closure_constants", closure_constants),
         ("runtime", runtime_kind_to_name(runtime)),
     )
     return (

--- a/python/pypto/jit/decorator.py
+++ b/python/pypto/jit/decorator.py
@@ -78,6 +78,7 @@ from .specializer import (
     _collect_annotation_dynamic_dims,
     _collect_dynvar_names,
     build_specialize_context,
+    func_name_lookup,
 )
 
 # ---------------------------------------------------------------------------
@@ -247,7 +248,7 @@ def _resolve_annotation(annotation: Any, ann_ns: dict[str, Any] | None) -> Any:
     """Resolve one parameter annotation, evaluating the string form if needed.
 
     ``from __future__ import annotations`` in the *user's* module leaves every
-    annotation as a string; ``ann_ns`` (from ``_func_name_lookup``) is the
+    annotation as a string; ``ann_ns`` (from :func:`func_name_lookup`) is the
     namespace to evaluate it in.
 
     Args:
@@ -271,7 +272,7 @@ def _resolve_annotation(annotation: Any, ann_ns: dict[str, Any] | None) -> Any:
 def _annotation_namespace(func: Any, sig: inspect.Signature) -> dict[str, Any] | None:
     """Namespace for resolving ``func``'s string annotations, or None if unneeded."""
     if any(isinstance(p.annotation, str) for n, p in sig.parameters.items() if n != "self"):
-        return _func_name_lookup(func)
+        return func_name_lookup(func)
     return None
 
 
@@ -641,27 +642,6 @@ def _build_dynvar_anchor_index(
     return anchors
 
 
-def _func_name_lookup(func: Any) -> dict[str, Any]:
-    """Return ``func.__globals__`` merged with closure free-var bindings.
-
-    A function defined inside a test method (or any other enclosing scope)
-    captures module-level helpers (``HIDDEN``, ``ROWS``, ...) as closure free
-    vars, not as globals — both namespaces have to be inspected for static
-    shape-element resolution to find them. Closure bindings override globals,
-    matching Python's own name-resolution order at the function's call site.
-    """
-    out: dict[str, Any] = dict(getattr(func, "__globals__", {}))
-    co_freevars = getattr(getattr(func, "__code__", None), "co_freevars", ())
-    closure = getattr(func, "__closure__", None) or ()
-    for fv_name, cell in zip(co_freevars, closure, strict=True):
-        try:
-            out[fv_name] = cell.cell_contents
-        except ValueError:
-            # Unbound closure cell — skip silently (matches _discover_deps).
-            pass
-    return out
-
-
 def _scan_dep_io(
     func: Any, caller_func_type: str = "orchestration"
 ) -> dict[str, tuple[list[str], list[str]]]:
@@ -1000,7 +980,7 @@ def _extract_local_tensor_metas(
     func_def = _get_func_def(func)
     local: dict[str, TensorMeta] = dict(seed_meta or {})
     dtype_map = _get_pl_dtype_map()
-    func_globals = _func_name_lookup(func)
+    func_globals = func_name_lookup(func)
     scalars: dict[str, int | float | bool] = seed_scalars or {}
     dim_aliases: dict[str, tuple[str, int]] = {}
     dynvar_anchors = _build_dynvar_anchor_index(seed_meta or {})
@@ -1652,6 +1632,45 @@ class JITFunction:
             )
         return self._dep_layouts
 
+    def _folded_closure_constants(self) -> tuple[tuple[str, str, str], ...]:
+        """Closure constants that fold into the generated source, for the cache key.
+
+        The body transformer inlines a free ``int`` / ``float`` / ``bool`` as a
+        literal, so its value is baked into the artifact — but it lives in
+        ``__closure__``, not in the function text. Rebinding the cell
+        (``nonlocal rows``) therefore leaves ``source_hash`` identical, and
+        without this component the next call would be handed the previous
+        value's artifact. Same shape of problem as ``_dep_declared_layouts``.
+
+        Deliberately **not** memoized, unlike ``_dep_declared_layouts`` and
+        ``_get_source_hash``: a closure cell can be rebound over this
+        ``JITFunction``'s lifetime, which is exactly the case this guards.
+
+        Every foldable free variable is reported, not only those the body
+        actually references. That is a superset, so it can split the cache more
+        finely than strictly required — the safe direction — and it avoids
+        re-deriving which names survive folding.
+
+        Returns:
+            Sorted ``(function name, free variable, repr of value)`` triples
+        """
+        collected: list[tuple[str, str, str]] = []
+        for func_obj in (self._func, *(dep._func for dep in self._get_deps())):
+            func_name = getattr(func_obj, "__name__", "<unknown>")
+            co_freevars = getattr(getattr(func_obj, "__code__", None), "co_freevars", ())
+            closure = getattr(func_obj, "__closure__", None) or ()
+            for fv_name, cell in zip(co_freevars, closure, strict=True):
+                try:
+                    value = cell.cell_contents
+                except ValueError:
+                    # Unbound cell — nothing folds, so nothing to key on.
+                    continue
+                # Mirror the folder's own test so the key covers exactly what
+                # gets inlined (see _BodyTransformer.visit_Name).
+                if isinstance(value, (int, float, bool)) and not isinstance(value, type):
+                    collected.append((func_name, fv_name, repr(value)))
+        return tuple(sorted(collected))
+
     def _get_dep_graph(
         self,
     ) -> tuple[
@@ -1904,7 +1923,7 @@ class JITFunction:
         # ``Tensor`` / ``Scalar`` instance annotations on Python 3.10.
         ann_ns: dict[str, Any] | None = None
         if any(isinstance(p.annotation, str) for n, p in sig.parameters.items() if n != "self"):
-            ann_ns = _func_name_lookup(self._func)
+            ann_ns = func_name_lookup(self._func)
 
         deps, callers_by_id, _, call_args_cache = self._get_dep_graph()
         per_func_dyn_maps = _compute_per_func_dyndim_maps(
@@ -2095,6 +2114,7 @@ class JITFunction:
             tensor_dtypes={n: m.dtype for n, m in specialization.tensor_meta.items()},
             tensor_layouts={n: m.layout for n, m in specialization.tensor_meta.items()},
             dep_layouts=self._dep_declared_layouts(),
+            closure_constants=self._folded_closure_constants(),
             dynamic_dims={
                 (n, i) for n, m in specialization.tensor_meta.items() for i in m.dynamic_dim_indices()
             },

--- a/python/pypto/jit/decorator.py
+++ b/python/pypto/jit/decorator.py
@@ -186,6 +186,46 @@ def _is_tensor(obj: Any) -> bool:
     return isinstance(obj, torch.Tensor)
 
 
+# Prefix for the dynamic symbols ``@pl.jit`` invents when a local tensor's
+# extent is only known at runtime. Reserved: user DSL code must not declare
+# ``pl.dynamic()`` symbols starting with it.
+_SYNTHESIZED_DYN_PREFIX = "_jitdyn_"
+
+
+def _synthesized_dyn_dim(owner: str, base: str, dim_idx: int) -> DynDim:
+    """Build the placeholder ``DynDim`` for an extent only known at runtime.
+
+    A local tensor sized by a runtime expression — ``pld.world_size()``,
+    ``pl.tensor.read(cfg, [0])``, arithmetic over a ``DynDim`` — has no static
+    extent to record. Rather than dropping the whole meta (which surfaces as
+    ``_build_params``' "missing inferred tensor metadata" the moment the local
+    crosses a dep call boundary), stamp a fresh symbol on that dim. The
+    generated program then declares it via ``pl.dynamic`` and the kernel binds
+    it from the actual argument's descriptor, exactly as a hand-written
+    ``@pl.program`` would.
+
+    The symbol is qualified by the function that owns the local. Two functions
+    each holding a runtime-sized local named ``tmp`` would otherwise land on one
+    name for unrelated extents. That is not *wrong* — a dynamic symbol carries no
+    cross-function equality constraint, and each function emits its own
+    "read dim k of the declaring argument" binding — but one name on two
+    unrelated tensors makes a dumped program much harder to read.
+
+    Args:
+        owner: Name of the function whose body declares the local
+        base: Name of the local the meta describes, for a readable symbol
+        dim_idx: Index of the unresolved dim within that local's shape
+
+    Returns:
+        A ``synthesized=True`` DynDim named ``_jitdyn_<owner>_<base>_d<dim_idx>``
+    """
+    name = f"{_SYNTHESIZED_DYN_PREFIX}{owner}_{base}_d{dim_idx}"
+    # ``static_bound=1`` matches the placeholder extent ``_signature_tensor_meta``
+    # uses for annotation-declared dynamic dims: the specialized program is
+    # extent-independent, so no concrete value is available or needed here.
+    return DynDim(name=name, literal=name, static_bound=1, synthesized=True)
+
+
 def _build_tensor_meta(
     extents: Sequence[int],
     dtype: DataType,
@@ -248,7 +288,7 @@ def _resolve_annotation(annotation: Any, ann_ns: dict[str, Any] | None) -> Any:
     """Resolve one parameter annotation, evaluating the string form if needed.
 
     ``from __future__ import annotations`` in the *user's* module leaves every
-    annotation as a string; ``ann_ns`` (from :func:`func_name_lookup`) is the
+    annotation as a string; ``ann_ns`` (from ``func_name_lookup``) is the
     namespace to evaluate it in.
 
     Args:
@@ -838,14 +878,15 @@ def _update_local_tensor_meta(
     dim_aliases: dict[str, tuple[str, int]],
     dep_io: dict[str, tuple[list[str], list[str]]],
     resolve_int: Callable[[ast.expr], int | None],
-    pl_attr_handlers: dict[str, Callable[[ast.Call], TensorMeta | None]],
+    pl_attr_handlers: dict[str, Callable[[ast.Call, str | None], TensorMeta | None]],
 ) -> None:
     """Apply one assignment's metadata effects to the source-ordered state."""
     parts = _assignment_parts(stmt)
     if parts is None:
         return
     targets, value = parts
-    has_named_target = any(isinstance(target, ast.Name) for target in targets)
+    named_target = next((t.id for t in targets if isinstance(t, ast.Name)), None)
+    has_named_target = named_target is not None
     meta: TensorMeta | None = None
     preserve_existing = False
     dep_target_metas: list[dict[str, TensorMeta]] = [{} for _ in targets]
@@ -862,7 +903,9 @@ def _update_local_tensor_meta(
         if isinstance(fn, ast.Attribute) and isinstance(fn.value, ast.Name) and has_named_target:
             handler = pl_attr_handlers.get(fn.attr)
             if handler is not None:
-                meta = handler(value)
+                # The target name seeds any dynamic symbol the handler has to
+                # synthesize for a runtime-sized extent.
+                meta = handler(value, named_target)
             else:
                 # Keep the pre-existing behavior for pl operations whose
                 # result metadata this extractor does not model (for example,
@@ -905,7 +948,7 @@ def _walk_local_tensor_meta_stmts(
     dim_aliases: dict[str, tuple[str, int]],
     dep_io: dict[str, tuple[list[str], list[str]]],
     resolve_int: Callable[[ast.expr], int | None],
-    pl_attr_handlers: dict[str, Callable[[ast.Call], TensorMeta | None]],
+    pl_attr_handlers: dict[str, Callable[[ast.Call, str | None], TensorMeta | None]],
 ) -> bool:
     """Walk supported DSL scopes in source order until the selected call."""
     for stmt in stmts:
@@ -970,9 +1013,15 @@ def _extract_local_tensor_metas(
     parameter, a dep call passing a parameter through, or a local
     ``pl.create_tensor`` sized off a dynamic dim of a parameter all resolve;
     ``seed_scalars`` lets compile-time-specialized scalar parameters appear
-    as shape dimensions. Anything not statically resolvable is skipped
-    silently — the clear ``ValueError`` in ``Specializer._build_params`` then
-    fires for that variable. When ``stop_at_dep`` is provided, extraction stops
+    as shape dimensions.
+
+    A ``pl.create_tensor`` / ``pld.window`` dim that no static rule resolves —
+    a runtime extent such as ``pld.world_size()``, ``pl.tensor.read(cfg, [0])``,
+    or arithmetic over a ``DynDim`` — becomes a synthesized ``DynDim`` (see
+    :func:`_synthesized_dyn_dim`) rather than voiding the whole meta. Everything
+    else not statically resolvable is still skipped silently, and the clear
+    ``ValueError`` in ``Specializer._build_params`` fires for that variable.
+    When ``stop_at_dep`` is provided, extraction stops
     immediately before the first source-ordered call to that dependency. This
     produces the point-in-time metadata visible to that call and ignores later
     rebindings.
@@ -1050,14 +1099,23 @@ def _extract_local_tensor_metas(
         v = _resolve_shape_elt(elt)
         return v if isinstance(v, int) else None
 
-    def _resolve_shape(node: ast.expr | None) -> tuple[ShapeDim, ...] | None:
+    def _resolve_shape(node: ast.expr | None, dyn_base: str | None = None) -> tuple[ShapeDim, ...] | None:
+        """Resolve a shape literal, optionally synthesizing runtime-only dims.
+
+        ``dyn_base`` is the name of the local being assigned. When given, a dim
+        that no static rule resolves becomes a synthesized ``DynDim`` instead of
+        failing the whole shape (see :func:`_synthesized_dyn_dim`). Callers that
+        pass ``None`` keep the strict all-or-nothing behaviour.
+        """
         if not isinstance(node, ast.List):
             return None
         dims: list[ShapeDim] = []
-        for elt in node.elts:
+        for i, elt in enumerate(node.elts):
             v = _resolve_shape_elt(elt)
             if v is None:
-                return None
+                if dyn_base is None:
+                    return None
+                v = _synthesized_dyn_dim(func_def.name, dyn_base, i)
             dims.append(v)
         return tuple(dims)
 
@@ -1071,26 +1129,31 @@ def _extract_local_tensor_metas(
                 return dtype_map.get(kw.value.attr)
         return None
 
-    def _create_tensor_meta(call: ast.Call) -> TensorMeta | None:
-        shape = _resolve_shape(call.args[0]) if call.args else None
+    def _create_tensor_meta(call: ast.Call, target: str | None = None) -> TensorMeta | None:
+        # A runtime-sized extent (``pl.create_tensor([n, 128], ...)`` where ``n``
+        # is read from a tensor) synthesizes a dynamic dim rather than dropping
+        # the meta -- the allocation itself is runtime-sized either way.
+        shape = _resolve_shape(call.args[0], target) if call.args else None
         dtype_val = _dtype_from_kw(call)
         if shape is None or dtype_val is None:
             return None
         return TensorMeta(shape=shape, dtype=dtype_val)
 
-    def _window_meta(call: ast.Call) -> TensorMeta | None:
+    def _window_meta(call: ast.Call, target: str | None = None) -> TensorMeta | None:
         # pld.window(buffer, [shape], dtype=pl.XXX) — a distributed window view
         # over a window buffer. Shape is the 2nd positional arg; dtype is the
         # ``dtype=`` keyword (same spelling as create_tensor). Lets a host
         # orchestrator's per-rank window locals propagate their meta into the
         # ``pld.DistributedTensor`` parameters of the chip orchestrator it calls.
-        shape = _resolve_shape(call.args[1]) if len(call.args) >= 2 else None
+        # A runtime-sized dim (``[pld.world_size(), 1]``) synthesizes a dynamic
+        # dim, the same way create_tensor does.
+        shape = _resolve_shape(call.args[1], target) if len(call.args) >= 2 else None
         dtype_val = _dtype_from_kw(call)
         if shape is None or dtype_val is None:
             return None
         return TensorMeta(shape=shape, dtype=dtype_val)
 
-    def _reshape_meta(call: ast.Call) -> TensorMeta | None:
+    def _reshape_meta(call: ast.Call, target: str | None = None) -> TensorMeta | None:
         # pl.reshape(input, shape) — dtype inherited from source tensor.
         src = (
             call.args[0] if call.args else next((kw.value for kw in call.keywords if kw.arg == "input"), None)
@@ -1105,6 +1168,10 @@ def _extract_local_tensor_metas(
         )
         if shape_node is None:
             return None
+        # Strict on purpose (no ``target``): a reshape's dims are constrained by
+        # the source's element count, which a freshly invented symbol cannot
+        # express. ``pl.slice`` below is strict for the mirror reason — it
+        # already has a better answer, the parent dim's static bound.
         shape = _resolve_shape(shape_node)
         if shape is None:
             return None
@@ -1116,7 +1183,7 @@ def _extract_local_tensor_metas(
             return None
         return TensorMeta(shape=shape, dtype=src_meta.dtype)
 
-    def _slice_meta(call: ast.Call) -> TensorMeta | None:
+    def _slice_meta(call: ast.Call, target: str | None = None) -> TensorMeta | None:
         # pl.slice(tensor, shape, offset, ...) — shape is positional index 1 or kw `shape=`.
         src = call.args[0] if call.args else None
         if not isinstance(src, ast.Name) or src.id not in local:
@@ -1346,10 +1413,33 @@ def _resolve_dep_call_metadata(
         dep_scalar_values = {n: caller_scalar_values[n] for n in dep_param_names if n in caller_scalar_values}
         dep_scalar_dtypes = {n: caller_scalar_dtypes[n] for n in dep_param_names if n in caller_scalar_dtypes}
 
-    # Overlay DynDim from the dep's own declarations (pre-computed in
-    # _compute_per_func_dyndim_maps). Dims already carrying a DynDim from
-    # the caller take precedence; we only fill plain int dims and pin
-    # ``static_bound`` to the meta's current extent so cache keys stay coherent.
+    _overlay_dep_declared_dyn_dims(dep_dyn_map, dep_tensor_meta)
+    _overlay_dep_declared_layouts(dep, dep_tensor_meta)
+
+    return dep_tensor_meta, dep_scalar_values, dep_scalar_dtypes
+
+
+def _overlay_dep_declared_dyn_dims(
+    dep_dyn_map: dict[str, dict[int, DynDim]], dep_tensor_meta: dict[str, TensorMeta]
+) -> None:
+    """Stamp the DynDims a dep declares itself onto its parameter metas, in place.
+
+    ``dep_dyn_map`` is pre-computed by ``_compute_per_func_dyndim_maps``. A
+    DynDim the caller actually derived takes precedence — its symbol is the one
+    bound at the call site — so only plain int dims and synthesized placeholders
+    are overwritten. The replacement keeps whatever ``static_bound`` the dim
+    already carried (the int extent, or a placeholder's ``1``) so cache keys stay
+    coherent.
+
+    Replacing a placeholder matters beyond naming: the dep's body may reference
+    its declared symbol (``for i in pl.range(NR)``). Keeping the invented name
+    on the parameter would leave that reference unbound in the generated
+    program, so the declaration wins whenever we only had a placeholder.
+
+    Args:
+        dep_dyn_map: Per-parameter ``dim_idx -> DynDim`` the dep declares
+        dep_tensor_meta: Per-parameter meta to update in place
+    """
     for dep_param, dim_to_dyn in dep_dyn_map.items():
         meta = dep_tensor_meta.get(dep_param)
         if meta is None:
@@ -1357,20 +1447,18 @@ def _resolve_dep_call_metadata(
         new_shape: list[ShapeDim] = list(meta.shape)
         changed = False
         for i, dyn in dim_to_dyn.items():
-            if i >= len(new_shape) or isinstance(new_shape[i], DynDim):
+            if i >= len(new_shape):
                 continue
             existing = new_shape[i]
-            assert isinstance(existing, int)
-            new_shape[i] = DynDim(name=dyn.name, literal=dyn.literal, static_bound=existing)
+            if isinstance(existing, DynDim) and not existing.synthesized:
+                continue
+            static_bound = existing.static_bound if isinstance(existing, DynDim) else existing
+            new_shape[i] = DynDim(name=dyn.name, literal=dyn.literal, static_bound=static_bound)
             changed = True
         if changed:
             dep_tensor_meta[dep_param] = TensorMeta(
                 shape=tuple(new_shape), dtype=meta.dtype, layout=meta.layout
             )
-
-    _overlay_dep_declared_layouts(dep, dep_tensor_meta)
-
-    return dep_tensor_meta, dep_scalar_values, dep_scalar_dtypes
 
 
 def _overlay_dep_declared_layouts(dep: JITFunction, dep_tensor_meta: dict[str, TensorMeta]) -> None:

--- a/python/pypto/jit/specializer.py
+++ b/python/pypto/jit/specializer.py
@@ -67,11 +67,19 @@ class DynDim:
                      same compilation, but still available as the static-shape
                      fallback wherever a numeric dim is required (e.g.
                      ``pl.slice`` parent-dim inheritance, ``ir.compile``).
+        synthesized: True when ``@pl.jit`` invented this symbol for an extent it
+                     could not resolve statically — a runtime-valued dim such as
+                     ``pld.world_size()`` or ``pl.tensor.read(...)``. Such a dim
+                     is a placeholder: a dep that declares the same dim with
+                     ``pl.dynamic`` replaces it with the user's symbol, so a
+                     kernel body referencing that name stays bound. A DynDim the
+                     caller actually derived is never replaced.
     """
 
     name: str
     literal: str
     static_bound: int
+    synthesized: bool = False
 
 
 ShapeDim = int | DynDim

--- a/python/pypto/jit/specializer.py
+++ b/python/pypto/jit/specializer.py
@@ -123,10 +123,14 @@ class SpecializeContext:
         scalar_values: Concrete value per scalar param name.
         scalar_dtypes: DataType annotation per scalar param name.
         dep_names: Names of dep functions called from this function.
-        py_globals: The originating function's ``__globals__``. The specializer
-            uses this to resolve module-level int/float/bool constants (e.g.
-            ``BATCH``, ``HIDDEN`` imported from a config module) by inlining
-            them at the use site.
+        py_globals: Every name visible to the originating function — its
+            ``__globals__`` merged with its closure free vars, as built by
+            :func:`func_name_lookup`. The specializer uses this to resolve
+            int/float/bool constants (``BATCH`` imported from a config module,
+            a factory's captured rank count) by inlining them at the use site.
+            Closure free vars must be included: the generated program is
+            ``exec``'d in a fresh module, so a captured name that survives
+            unfolded is undefined there (#2449).
         orig_file: Path to the user's real source file (``inspect.getsourcefile``),
             or ``None`` when the function has no on-disk source (REPL / exec).
             Used to map generated diagnostics back to the user's ``.py`` (#1612).
@@ -199,6 +203,38 @@ class SpecializeContext:
                 if isinstance(d, DynDim):
                     out[d.name] = d.literal
         return out
+
+
+# ---------------------------------------------------------------------------
+# Name resolution
+# ---------------------------------------------------------------------------
+
+
+def func_name_lookup(func: Any) -> dict[str, Any]:
+    """Return ``func.__globals__`` merged with closure free-var bindings.
+
+    A function defined inside a factory, a test method, or any other enclosing
+    scope captures the names it uses (``HIDDEN``, ``ROWS``, a factory's ``nr``,
+    ...) as closure free vars, not as globals — both namespaces have to be
+    inspected to find them. Closure bindings override globals, matching Python's
+    own name-resolution order at the function's call site.
+
+    This is the namespace every ``@pl.jit`` name lookup must use. The generated
+    ``@pl.program`` source is ``exec``'d in a fresh module holding only ``pl``
+    and ``pld``, so a free name that survives into it is undefined there; both
+    static shape resolution and body constant-folding therefore resolve against
+    this mapping rather than ``__globals__`` alone.
+    """
+    out: dict[str, Any] = dict(getattr(func, "__globals__", {}))
+    co_freevars = getattr(getattr(func, "__code__", None), "co_freevars", ())
+    closure = getattr(func, "__closure__", None) or ()
+    for fv_name, cell in zip(co_freevars, closure, strict=True):
+        try:
+            out[fv_name] = cell.cell_contents
+        except ValueError:
+            # Unbound closure cell — skip silently (matches _discover_deps).
+            pass
+    return out
 
 
 # ---------------------------------------------------------------------------
@@ -2099,7 +2135,10 @@ def build_specialize_context(  # noqa: PLR0913 — pass-through assembler; each 
         scalar_dtypes=scalar_dtypes,
         dep_names=dep_names,
         auto_scope=auto_scope,
-        py_globals=getattr(func, "__globals__", {}),
+        # Closure-aware: a factory-defined kernel captures its constants as free
+        # vars, which never appear in __globals__. Folding must see them or they
+        # survive verbatim into the generated source and are undefined there.
+        py_globals=func_name_lookup(func),
         orig_file=orig_file,
         orig_start_line=orig_start_line,
         orig_col_offset=orig_col_offset,

--- a/tests/ut/jit/test_cache.py
+++ b/tests/ut/jit/test_cache.py
@@ -111,6 +111,7 @@ class TestMakeCacheKey:
             ("memory_planner", None),
             ("enable_pypto_l0c_double_buffer", False),
             ("dep_layouts", ()),
+            ("closure_constants", ()),
             ("runtime", "tensormap_and_ringbuffer"),
         )
 

--- a/tests/ut/jit/test_decorator.py
+++ b/tests/ut/jit/test_decorator.py
@@ -21,6 +21,7 @@ import pytest
 from pypto.ir import OptimizationStrategy, PassManager
 from pypto.ir.compiled_program import CompiledProgram
 from pypto.jit.decorator import (
+    _SYNTHESIZED_DYN_PREFIX,
     JITFunction,
     _arg_ref,
     _build_param_mapping,
@@ -35,11 +36,12 @@ from pypto.jit.decorator import (
     _scan_dep_io,
     _scan_dynamic_dims,
     _SlicedArg,
+    _synthesized_dyn_dim,
     jit,
 )
-from pypto.jit.specializer import Specializer, TensorMeta
+from pypto.jit.specializer import DynDim, Specializer, TensorMeta
 from pypto.language.parser.diagnostics.exceptions import ParserTypeError
-from pypto.pypto_core import DataType, ir
+from pypto.pypto_core import DataType, InternalError, ir
 from pypto.runtime.runner import RunConfig
 
 # ---------------------------------------------------------------------------
@@ -827,8 +829,64 @@ def _callsite_metadata_kernel(x: pl.Tensor, out: pl.Out[pl.Tensor]) -> pl.Tensor
     return out
 
 
+# --- Runtime-sized local extents (synthesized DynDim) ------------------------
+# Fixtures for the tests covering a local tensor whose extent is only known at
+# runtime: one decorated dep, then plain (undecorated) caller bodies fed straight
+# to ``_extract_local_tensor_metas`` / ``_resolve_dep_call_metadata``.
+
+
+@jit.incore
+def _synth_dim_kernel(t: pl.Tensor, out: pl.Out[pl.Tensor]) -> pl.Tensor:
+    """Dependency for the synthesized-dim overlay tests."""
+    return out
+
+
 # Module global (not a closure var) for the folding-precedence test.
 _CLOSURE_FOLD_ROWS = 64
+
+
+def _runtime_create_body(cfg: pl.Tensor, out: pl.Out[pl.Tensor]) -> pl.Tensor:
+    """create_tensor whose leading extent is read out of a tensor at runtime."""
+    n = pl.tensor.read(cfg, [0])
+    tmp = pl.create_tensor([n, 8], dtype=pl.FP32)  # noqa: F841 — tracked by metadata extraction
+    return out
+
+
+def _dyn_arith_create_body(src: pl.Tensor, out: pl.Out[pl.Tensor]) -> pl.Tensor:
+    """create_tensor sized by arithmetic over a DynDim — not statically foldable."""
+    rows = pl.tensor.dim(src, 0)
+    tmp = pl.create_tensor([rows * 2, 8], dtype=pl.FP32)  # noqa: F841 — tracked by extraction
+    return out
+
+
+def _runtime_window_body(out: pl.Out[pl.Tensor]) -> pl.Tensor:
+    """pld.window whose leading extent is the runtime world size."""
+    buf = pld.alloc_window_buffer([2, 8], dtype=pl.INT32)
+    win = pld.window(buf, [pld.world_size(), 8], dtype=pl.INT32)  # noqa: F841 — tracked
+    return out
+
+
+def _runtime_reshape_body(src: pl.Tensor, cfg: pl.Tensor, out: pl.Out[pl.Tensor]) -> pl.Tensor:
+    """pl.reshape with a runtime extent — stays strict, no meta."""
+    n = pl.tensor.read(cfg, [0])
+    flat = pl.reshape(src, [n, 8])  # noqa: F841 — deliberately untracked
+    return out
+
+
+def _runtime_create_then_dep(cfg: pl.Tensor, out: pl.Out[pl.Tensor]) -> pl.Tensor:
+    """A runtime-sized local crossing a dep call boundary (issue #2450's shape)."""
+    n = pl.tensor.read(cfg, [0])
+    tmp = pl.create_tensor([n, 8], dtype=pl.FP32)
+    out = _synth_dim_kernel(tmp, out)
+    return out
+
+
+def _dyn_alias_create_then_dep(src: pl.Tensor, out: pl.Out[pl.Tensor]) -> pl.Tensor:
+    """A local carrying a caller-derived (not synthesized) DynDim into a dep."""
+    rows = pl.tensor.dim(src, 0)
+    tmp = pl.create_tensor([rows, 8], dtype=pl.FP32)
+    out = _synth_dim_kernel(tmp, out)
+    return out
 
 
 def _plain_rebind_callsite(src: pl.Tensor, out: pl.Out[pl.Tensor]) -> pl.Tensor:
@@ -1079,10 +1137,17 @@ class TestSliceAndDepReturnMetadata:
         program = attn_entry.lower(big, cfg, out)
         assert isinstance(program, ir.Program)
 
-    def test_unresolvable_create_tensor_dim_still_raises_clear_error(self):
-        """A pl.create_tensor with a non-static dim has no parent to fall back
-        to, so the view is untracked and the existing clear ValueError fires
-        for the downstream dep parameter."""
+    def test_runtime_create_tensor_dim_defers_to_the_shared_pipeline(self):
+        """A runtime-sized ``pl.create_tensor`` dim no longer fails in the JIT
+        frontend — it becomes a synthesized DynDim and the shared pass pipeline
+        diagnoses whatever the program actually does with it.
+
+        Here the kernel loads the WHOLE tensor as a tile, so the dynamic dim
+        reaches the tile shape, which InitMemRef rejects. That is the same
+        error a hand-written ``@pl.program`` gets for the same code — the point
+        of this test is that ``@pl.jit`` no longer front-runs it with a
+        frontend-only "missing inferred tensor metadata".
+        """
         torch = pytest.importorskip("torch")
 
         @jit.incore
@@ -1101,8 +1166,9 @@ class TestSliceAndDepReturnMetadata:
 
         cfg = torch.zeros(1, dtype=torch.int64)
         out = torch.empty(16, 32)
-        with pytest.raises(ValueError, match="missing inferred tensor metadata"):
+        with pytest.raises(InternalError, match="InitMemRef requires static shape") as excinfo:
             bad_entry.lower(cfg, out)
+        assert "missing inferred tensor metadata" not in str(excinfo.value)
 
     def test_extract_local_tensor_metas_reshape(self):
         """``_extract_local_tensor_metas`` infers metas for pl.reshape results."""
@@ -1322,8 +1388,6 @@ class TestDynamicLocalTensorMetadata:
         """An alias rebound to a non-``pl.tensor.dim`` value must not stamp
         the parent's DynDim onto downstream shape resolution — regression for
         the flow-insensitive alias bug raised by CodeRabbit."""
-        from pypto.jit.specializer import DynDim  # noqa: PLC0415
-
         m_dim = DynDim(name="M", literal="M", static_bound=5)
         seed = {"x": TensorMeta(shape=(m_dim, 128), dtype=DataType.FP32)}
 
@@ -1334,9 +1398,14 @@ class TestDynamicLocalTensorMetadata:
             return buf
 
         metas = _extract_local_tensor_metas(body, seed_meta=seed)
-        # ``buf`` must NOT be recorded — ``tokens`` is no longer a clean dim
-        # alias, so pl.create_tensor's shape can't be statically resolved.
-        assert "buf" not in metas
+        # ``tokens`` is no longer a clean dim alias, so the dim cannot be
+        # statically resolved: it gets a synthesized placeholder. What must NOT
+        # happen is inheriting the parent's ``M`` — that is the flow-insensitive
+        # bug this guards.
+        dim = metas["buf"].shape[0]
+        assert isinstance(dim, DynDim)
+        assert dim.synthesized
+        assert dim.name != m_dim.name
 
     def test_issue_1524_repro_compiles(self):
         """The exact failing pattern from issue #1524."""
@@ -2862,6 +2931,173 @@ class TestClosureConstantFolding:
         source = self._specialize(entry, a, out)
         assert "pl.create_tensor([64, 64]" in source
         assert not re.search(r"\b_CLOSURE_FOLD_ROWS\b", source)
+
+
+class TestRuntimeSizedLocalExtents:
+    """A local tensor whose extent is only known at runtime (issue #2450).
+
+    ``pld.window(buf, [pld.world_size(), 1], ...)`` and
+    ``pl.create_tensor([pl.tensor.read(cfg, [0]), 128], ...)`` have no static
+    extent. Before this behaviour the whole meta was dropped, and the moment the
+    local was passed to a dep ``_build_params`` raised "missing inferred tensor
+    metadata". Now the unresolved dim becomes a synthesized ``DynDim``, which the
+    generated program declares via ``pl.dynamic`` and the kernel binds from the
+    actual argument's descriptor — the same IR a hand-written ``@pl.program``
+    produces for this pattern.
+    """
+
+    @staticmethod
+    def _leading_dim(metas: dict[str, TensorMeta], name: str):
+        assert name in metas, f"{name!r} has no meta: {sorted(metas)}"
+        return metas[name].shape[0]
+
+    def test_runtime_create_extent_synthesizes_dyn_dim(self):
+        """A create_tensor dim read out of a tensor becomes a synthesized DynDim."""
+        seed = {
+            "cfg": TensorMeta(shape=(1,), dtype=DataType.INT64),
+            "out": TensorMeta(shape=(16, 8), dtype=DataType.FP32),
+        }
+        metas = _extract_local_tensor_metas(_runtime_create_body, seed_meta=seed)
+        dim = self._leading_dim(metas, "tmp")
+        assert isinstance(dim, DynDim)
+        assert dim.synthesized
+        assert dim.name.startswith(_SYNTHESIZED_DYN_PREFIX)
+        # Only the unresolved dim is synthesized; the literal one stays an int.
+        assert metas["tmp"].shape[1] == 8
+        assert metas["tmp"].dtype == DataType.FP32
+
+    def test_runtime_window_extent_synthesizes_dyn_dim(self):
+        """pld.window sized by pld.world_size() gets a synthesized DynDim."""
+        seed = {"out": TensorMeta(shape=(16, 8), dtype=DataType.FP32)}
+        metas = _extract_local_tensor_metas(_runtime_window_body, seed_meta=seed)
+        dim = self._leading_dim(metas, "win")
+        assert isinstance(dim, DynDim)
+        assert dim.synthesized
+        assert metas["win"].shape[1] == 8
+        assert metas["win"].dtype == DataType.INT32
+
+    def test_arithmetic_over_dyn_dim_synthesizes(self):
+        """``M * 2`` is not statically foldable, so that dim is synthesized too."""
+        seed = {
+            "src": TensorMeta(shape=(DynDim(name="M", literal="M", static_bound=32), 8), dtype=DataType.FP32),
+            "out": TensorMeta(shape=(16, 8), dtype=DataType.FP32),
+        }
+        metas = _extract_local_tensor_metas(_dyn_arith_create_body, seed_meta=seed)
+        dim = self._leading_dim(metas, "tmp")
+        assert isinstance(dim, DynDim)
+        assert dim.synthesized
+
+    def test_statically_resolvable_dims_are_not_synthesized(self):
+        """Existing static resolution is untouched — no placeholder is invented."""
+        seed = {
+            "src": TensorMeta(shape=(32, 32), dtype=DataType.FP32),
+            "out": TensorMeta(shape=(16, 8), dtype=DataType.FP32),
+        }
+        metas = _extract_local_tensor_metas(_slice_then_dep_body, seed_meta=seed)
+        assert metas["buf"] == TensorMeta(shape=(16, 8), dtype=DataType.FP32)
+        assert all(not isinstance(d, DynDim) for d in metas["buf"].shape)
+
+    def test_reshape_stays_strict(self):
+        """A reshape dim is constrained by the source's element count, which an
+        invented symbol cannot express — it still declines the meta."""
+        seed = {
+            "src": TensorMeta(shape=(16, 8), dtype=DataType.FP32),
+            "cfg": TensorMeta(shape=(1,), dtype=DataType.INT64),
+            "out": TensorMeta(shape=(16, 8), dtype=DataType.FP32),
+        }
+        metas = _extract_local_tensor_metas(_runtime_reshape_body, seed_meta=seed)
+        assert "flat" not in metas
+
+    def test_synthesized_dim_reaches_dep_parameter(self):
+        """The dep parameter is typed instead of raising "missing inferred
+        tensor metadata" — issue #2450's failure."""
+        seed = {
+            "cfg": TensorMeta(shape=(1,), dtype=DataType.INT64),
+            "out": TensorMeta(shape=(16, 8), dtype=DataType.FP32),
+        }
+        metas, _, _ = _resolve_dep_call_metadata(
+            _synth_dim_kernel, _runtime_create_then_dep, seed, {}, {}, {}
+        )
+        dim = self._leading_dim(metas, "t")
+        assert isinstance(dim, DynDim)
+        assert dim.synthesized
+
+    def test_dep_declared_symbol_replaces_synthesized_placeholder(self):
+        """A dep that declares the dim ``pl.dynamic`` gets its own symbol back.
+
+        The dep's body may reference that name (``for i in pl.range(NR)``);
+        keeping the invented one would leave the reference unbound.
+        """
+        seed = {
+            "cfg": TensorMeta(shape=(1,), dtype=DataType.INT64),
+            "out": TensorMeta(shape=(16, 8), dtype=DataType.FP32),
+        }
+        dep_dyn_map = {"t": {0: DynDim(name="NR", literal="NR", static_bound=0)}}
+        metas, _, _ = _resolve_dep_call_metadata(
+            _synth_dim_kernel, _runtime_create_then_dep, seed, {}, {}, dep_dyn_map
+        )
+        dim = self._leading_dim(metas, "t")
+        assert isinstance(dim, DynDim)
+        assert dim.name == "NR"
+        assert not dim.synthesized
+
+    def test_runtime_sized_local_lowers_end_to_end(self):
+        """The headline claim: a runtime-sized local crossing a dep boundary
+        reaches a real ``ir.Program``, with the synthesized symbol declared via
+        ``pl.dynamic`` and left dynamic in the kernel's parameter type."""
+        torch = pytest.importorskip("torch")
+
+        @jit.incore
+        def scale_incore(t: pl.Tensor, out: pl.Out[pl.Tensor]) -> pl.Tensor:
+            tile = pl.load(t, [0, 0], [64, 64])
+            pl.store(pl.add(tile, tile), [0, 0], out)
+            return out
+
+        @jit
+        def runtime_sized_entry(cfg: pl.Tensor, out: pl.Out[pl.Tensor]) -> pl.Tensor:
+            n = pl.tensor.read(cfg, [0])
+            tmp = pl.create_tensor([n, 64], dtype=pl.FP32)
+            return scale_incore(tmp, out)
+
+        cfg = torch.zeros(1, dtype=torch.int64)
+        out = torch.zeros(64, 64, dtype=torch.float32)
+        program = runtime_sized_entry.lower(cfg, out)
+        assert isinstance(program, ir.Program)
+
+        # The kernel parameter kept a dynamic leading dim rather than being
+        # frozen to the placeholder extent.
+        kernel = program.get_function("scale_incore")
+        assert kernel is not None
+        param_type = kernel.params[0].type
+        assert isinstance(param_type, ir.TensorType)
+        leading = param_type.shape[0]
+        assert not isinstance(leading, ir.ConstInt), f"leading dim froze to {leading}"
+
+    def test_synthesized_symbol_is_qualified_by_owning_function(self):
+        """Two functions each holding a runtime-sized local of the same name get
+        distinct symbols, so a dumped program never shows one name on two
+        unrelated tensors."""
+        a = _synthesized_dyn_dim("host_entry", "tmp", 0)
+        b = _synthesized_dyn_dim("mid", "tmp", 0)
+        assert a.name != b.name
+        assert a.name.startswith(_SYNTHESIZED_DYN_PREFIX)
+        assert b.name.startswith(_SYNTHESIZED_DYN_PREFIX)
+
+    def test_caller_derived_dyn_dim_outranks_dep_declaration(self):
+        """A DynDim the caller actually derived is NOT replaced — its symbol is
+        the one bound at the call site (pre-existing precedence)."""
+        seed = {
+            "src": TensorMeta(shape=(DynDim(name="M", literal="M", static_bound=32), 8), dtype=DataType.FP32),
+            "out": TensorMeta(shape=(16, 8), dtype=DataType.FP32),
+        }
+        dep_dyn_map = {"t": {0: DynDim(name="NR", literal="NR", static_bound=0)}}
+        metas, _, _ = _resolve_dep_call_metadata(
+            _synth_dim_kernel, _dyn_alias_create_then_dep, seed, {}, {}, dep_dyn_map
+        )
+        dim = self._leading_dim(metas, "t")
+        assert isinstance(dim, DynDim)
+        assert dim.name == "M"
+        assert not dim.synthesized
 
 
 if __name__ == "__main__":

--- a/tests/ut/jit/test_decorator.py
+++ b/tests/ut/jit/test_decorator.py
@@ -12,6 +12,7 @@
 import ast
 import importlib
 import inspect
+import re
 import warnings
 
 import pypto.language as pl
@@ -36,7 +37,7 @@ from pypto.jit.decorator import (
     _SlicedArg,
     jit,
 )
-from pypto.jit.specializer import TensorMeta
+from pypto.jit.specializer import Specializer, TensorMeta
 from pypto.language.parser.diagnostics.exceptions import ParserTypeError
 from pypto.pypto_core import DataType, ir
 from pypto.runtime.runner import RunConfig
@@ -824,6 +825,10 @@ def _reshape_body(src: pl.Tensor, out: pl.Out[pl.Tensor]) -> pl.Tensor:
 def _callsite_metadata_kernel(x: pl.Tensor, out: pl.Out[pl.Tensor]) -> pl.Tensor:
     """Dependency used by point-in-time call-site metadata tests."""
     return out
+
+
+# Module global (not a closure var) for the folding-precedence test.
+_CLOSURE_FOLD_ROWS = 64
 
 
 def _plain_rebind_callsite(src: pl.Tensor, out: pl.Out[pl.Tensor]) -> pl.Tensor:
@@ -2663,6 +2668,200 @@ class TestJitSourceProvenance:
         incore = list(prog.get_function("_provenance_kernel").body)[0]
         assert incore.span.filename == __file__
         assert incore.span.begin_line == expected_with_line
+
+
+class TestClosureConstantFolding:
+    """A ``@pl.jit`` function defined inside a factory (issue #2449).
+
+    The generated ``@pl.program`` source is ``exec``'d in a fresh module holding
+    only ``pl`` and ``pld``, so every free name in a body must be folded to a
+    literal first. Folding used to read ``__globals__`` alone, where a closure
+    free var never appears — so a factory constant survived verbatim and the
+    parser raised ``Undefined variable``. Annotations always worked (they are
+    rendered from ``tensor_meta``, not from the name), which made the gap
+    invisible from outside.
+    """
+
+    @staticmethod
+    def _specialize(entry, *args) -> str:
+        _pn, _, tmeta, sv, sd, pfd = entry._bind_args(args, {})
+        contexts = entry._build_contexts(tmeta, sv, sd, pfd)
+        return Specializer(f"_jit_{entry.__name__}", contexts).specialize()
+
+    @staticmethod
+    def _build_factory_entry(rows: int):
+        """Return a @pl.jit entry whose body references the factory's ``rows``."""
+
+        @jit.incore
+        def copy_incore(t: pl.Tensor, out: pl.Out[pl.Tensor]) -> pl.Tensor:
+            tile = pl.load(t, [0, 0], [64, 64])
+            pl.store(tile, [0, 0], out)
+            return out
+
+        @jit
+        def entry(a: pl.Tensor, out: pl.Out[pl.Tensor]) -> pl.Tensor:
+            # ``rows`` is a closure free var, not a module global.
+            tmp = pl.create_tensor([rows, 64], dtype=pl.FP32)
+            return copy_incore(tmp, out)
+
+        return entry
+
+    def test_closure_constant_folds_into_generated_body(self):
+        """A factory constant referenced in a body is inlined as a literal."""
+        torch = pytest.importorskip("torch")
+
+        entry = self._build_factory_entry(64)
+        a = torch.zeros(64, 64, dtype=torch.float32)
+        out = torch.zeros(64, 64, dtype=torch.float32)
+        source = self._specialize(entry, a, out)
+
+        assert "pl.create_tensor([64, 64]" in source
+        # The free name must not survive — it is undefined in the generated module.
+        assert not re.search(r"\brows\b", source)
+
+    def test_closure_constant_specializes_per_value(self):
+        """Two factory instantiations fold their own constant, not a shared one."""
+        torch = pytest.importorskip("torch")
+
+        a = torch.zeros(64, 64, dtype=torch.float32)
+        out = torch.zeros(64, 64, dtype=torch.float32)
+        assert "pl.create_tensor([32, 64]" in self._specialize(self._build_factory_entry(32), a, out)
+        assert "pl.create_tensor([96, 64]" in self._specialize(self._build_factory_entry(96), a, out)
+
+    @staticmethod
+    def _build_mutable_factory_entry():
+        """Return (entry, setter) sharing one closure cell, so the setter
+        rebinds the *same* ``JITFunction``'s captured constant."""
+
+        rows = 64
+
+        @jit.incore
+        def copy_incore(t: pl.Tensor, out: pl.Out[pl.Tensor]) -> pl.Tensor:
+            tile = pl.load(t, [0, 0], [64, 64])
+            pl.store(tile, [0, 0], out)
+            return out
+
+        @jit
+        def entry(a: pl.Tensor, out: pl.Out[pl.Tensor]) -> pl.Tensor:
+            tmp = pl.create_tensor([rows, 64], dtype=pl.FP32)
+            return copy_incore(tmp, out)
+
+        def set_rows(value: int) -> None:
+            nonlocal rows
+            rows = value
+
+        return entry, set_rows
+
+    def test_rebound_closure_cell_changes_the_generated_source(self):
+        """Rebinding the cell on one JITFunction changes what gets emitted.
+
+        This is the premise of the cache-key test below: if the artifact did not
+        depend on the cell, keying on it would be pointless.
+        """
+        torch = pytest.importorskip("torch")
+
+        entry, set_rows = self._build_mutable_factory_entry()
+        a = torch.zeros(64, 64, dtype=torch.float32)
+        out = torch.zeros(64, 64, dtype=torch.float32)
+
+        before = self._specialize(entry, a, out)
+        set_rows(96)
+        after = self._specialize(entry, a, out)
+
+        assert "pl.create_tensor([64, 64]" in before
+        assert "pl.create_tensor([96, 64]" in after
+
+    def test_rebound_closure_cell_splits_the_cache(self):
+        """A rebound cell must not silently reuse the previous artifact.
+
+        ``_get_source_hash`` hashes the function *text*, which a ``nonlocal``
+        rebind leaves byte-identical, so the closure values have to enter the
+        key separately. Two distinct factory instances would not catch this —
+        they are different ``JITFunction`` objects with their own caches.
+        """
+        torch = pytest.importorskip("torch")
+
+        entry, set_rows = self._build_mutable_factory_entry()
+        a = torch.zeros(64, 64, dtype=torch.float32)
+        out = torch.zeros(64, 64, dtype=torch.float32)
+
+        del a, out
+        before = entry._folded_closure_constants()
+        source_hash_before = entry._get_source_hash()
+        set_rows(96)
+        after = entry._folded_closure_constants()
+
+        # The text-based hash cannot see the rebind — that is the whole problem.
+        assert entry._get_source_hash() == source_hash_before
+        # The closure component does, so the composed key differs.
+        assert before != after
+        assert ("entry", "rows", "64") in before
+        assert ("entry", "rows", "96") in after
+
+    def test_rebound_closure_cell_recompiles_instead_of_reusing(self):
+        """The observable consequence: ``compile()`` must not hand back the
+        artifact built from the previous cell value.
+
+        Kept separate from the key-component test so this assertion is reached
+        on its own — a regression in the key wiring has to fail *here*, not be
+        masked by an earlier assertion.
+        """
+        torch = pytest.importorskip("torch")
+
+        entry, set_rows = self._build_mutable_factory_entry()
+        a = torch.zeros(64, 64, dtype=torch.float32)
+        out = torch.zeros(64, 64, dtype=torch.float32)
+
+        compiled_before = entry.compile(a, out, config=RunConfig(platform="a2a3sim"))
+        set_rows(128)
+        compiled_after = entry.compile(a, out, config=RunConfig(platform="a2a3sim"))
+        assert compiled_before is not compiled_after, "stale artifact reused after rebind"
+        assert len(entry._cache) == 2
+        # An unchanged cell must still hit the cache, or the key would be useless.
+        assert entry.compile(a, out, config=RunConfig(platform="a2a3sim")) is compiled_after
+        assert len(entry._cache) == 2
+
+    def test_closure_constants_key_component_is_stable_and_typed(self):
+        """Equal state yields an equal component (so a genuine re-call still
+        hits the cache), and ``repr`` keeps look-alike values apart."""
+        from pypto.jit.cache import make_cache_key  # noqa: PLC0415
+
+        def key_for(closure_constants):
+            return make_cache_key(
+                source_hash="h",
+                param_names=["x"],
+                tensor_shapes={"x": (64, 64)},
+                tensor_dtypes={"x": DataType.FP32},
+                dynamic_dims=set(),
+                scalar_values={},
+                closure_constants=closure_constants,
+            )
+
+        base = key_for((("entry", "rows", "1"),))
+        assert base == key_for((("entry", "rows", "1"),))
+        # 1 / 1.0 / True all fold, and all produce different literals.
+        assert len({base, key_for((("entry", "rows", "1.0"),)), key_for((("entry", "rows", "True"),))}) == 3
+
+    def test_module_globals_still_fold(self):
+        """Closure bindings are merged on top of globals, not instead of them."""
+        torch = pytest.importorskip("torch")
+
+        @jit.incore
+        def copy_incore(t: pl.Tensor, out: pl.Out[pl.Tensor]) -> pl.Tensor:
+            tile = pl.load(t, [0, 0], [64, 64])
+            pl.store(tile, [0, 0], out)
+            return out
+
+        @jit
+        def entry(a: pl.Tensor, out: pl.Out[pl.Tensor]) -> pl.Tensor:
+            tmp = pl.create_tensor([_CLOSURE_FOLD_ROWS, 64], dtype=pl.FP32)
+            return copy_incore(tmp, out)
+
+        a = torch.zeros(64, 64, dtype=torch.float32)
+        out = torch.zeros(64, 64, dtype=torch.float32)
+        source = self._specialize(entry, a, out)
+        assert "pl.create_tensor([64, 64]" in source
+        assert not re.search(r"\b_CLOSURE_FOLD_ROWS\b", source)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Two independent `@pl.jit` frontend gaps stopped code that a hand-written
`@pl.program` accepts, both reported as `Undefined variable` / `missing
inferred tensor metadata` well before anything reached the shared pipeline.
A factory-defined kernel could not reference the factory's constants from its
body, and a local tensor whose extent is only known at runtime could not be
passed to a dep. Afterwards both forms compile, and the generated program is
the same IR the equivalent `@pl.program` produces. Fixes #2449 and #2450.

The two are unrelated defects that happen to meet in the same reported
scenario -- a rank-count factory allocating a `pld.world_size()`-sized signal
window -- so they are separate commits.

## Changes

- `python/pypto/jit/specializer.py`: `_func_name_lookup` moves here from
  `decorator.py` as the public `func_name_lookup`, and
  `build_specialize_context` hands it to the body constant folder instead of
  `func.__globals__`. The generated program is `exec`'d in a fresh module
  holding only `pl` and `pld`, so a free name that is not folded to a literal
  is undefined there; closure free vars never appear in `__globals__`. Dep
  discovery and static shape resolution were already closure-aware, which is
  why only a closure constant in a *body* failed.
- `python/pypto/jit/decorator.py`: a `pl.create_tensor` / `pld.window` dim that
  no static rule resolves now becomes a synthesized `DynDim` instead of voiding
  the whole meta. The generated program declares it via `pl.dynamic` and the
  kernel binds it from the actual argument's descriptor. A dep that declares
  the dim itself gets its own symbol back, since its body may reference that
  name (`for i in pl.range(NR)`); a `DynDim` the caller derived still outranks
  the declaration. Symbols are qualified by the owning function so a dumped
  program never shows one name on two unrelated tensors.
- `python/pypto/jit/specializer.py`: `DynDim` gains a `synthesized` flag so the
  overlay can tell a placeholder from a caller-derived symbol.
- `tests/ut/jit/test_decorator.py`: 13 tests across `TestClosureConstantFolding`
  and `TestRuntimeSizedLocalExtents`, covering both fixes, the precedence rules,
  an end-to-end lowering to `ir.Program`, and the cases deliberately left strict.

## Behavior notes

`pl.reshape` and `pl.slice` stay strict: a reshape dim is constrained by the
source's element count, which an invented symbol cannot express, and a slice
already has the better answer in its parent dim's static bound.

One diagnostic changes. A runtime dim that goes on to reach a *tile* shape is
still rejected, but now by `InitMemRef` ("requires static shape ... put runtime
extent in TileView.valid_shape instead") rather than by the JIT frontend. That
is the same error a hand-written `@pl.program` gets for the same code;
`@pl.jit` no longer front-runs it. `test_runtime_create_tensor_dim_defers_to_the_shared_pipeline`
pins that behavior. No migration is required, and no other interface changes.

## Verification

- `python -m pytest tests/ut/ -n 2 -q` on this branch: 20 failed, 10414 passed,
  6 skipped, 2 xfailed.
- `python -m pytest tests/ut/ -n 2 -q` on the same base without these commits:
  20 failed, 10401 passed, 6 skipped, 2 xfailed. Identical failure set; the
  +13 are the tests added here. The 20 are pre-existing on `main`
  (`tests/ut/runtime/test_worker_reuse.py`, `test_tensor_arg.py`, and others).
- `python -m pytest tests/ut/jit -n 2 -q` as the push-time validation: 396 passed.
- `ruff check` / `ruff format --check` on the changed files: clean. Commit hooks
  (including `pyright`) passed on both commits.
- Both issues' reported programs compile: the #2449 rank-count factory over
  `@pl.jit.host`, and the #2450 `pld.world_size()`-sized signal window. Also
  checked `pl.tensor.read`-sized and `DynDim`-arithmetic extents, a kernel body
  referencing its declared symbol, and two functions holding same-named
  runtime-sized locals.
- Not run: on-device execution. Verification here is compile/lower only.