### PR TITLE
feat(runtime): expose device-wide HBM information on DistributedWorker

### DIFF
--- a/docs/en/user/distributed/03-execution.md
+++ b/docs/en/user/distributed/03-execution.md
@@ -35,6 +35,8 @@ directly via `DistributedWorker(compiled)`, importable from
 | `rt.alloc_stacked_tensor(host_w)` | Shard host_w along dim 0 — shard `i` uploaded to card `i`. Returns `StackedDeviceTensor`. |
 | `rt.free_stacked_tensor(stacked)` | Release all shards of a `StackedDeviceTensor`. |
 | `rt.copy_stacked_from(stacked, host_out)` | Staged D2H read-back of every shard into a CPU-contiguous `host_out`; it may be allocated after `prepare()`. |
+| `rt.committed_device_memory(worker_id=0)` | Device HBM (bytes) this worker's own allocator has committed on card `worker_id` — tensors, pooled arenas, runtime buffers. Sum across ids for a multi-chip total. |
+| `rt.device_memory_info(worker_id=0)` | `(free_bytes, total_bytes)` for the whole card `worker_id` runs on, as the driver sees it. Use this to size an allocation; anything else on the card moves `free_bytes` without moving the committed total. Raises on simulator backends rather than reporting zeros. |
 | `rt.release_inherited_host_tensor_refs()` | Drop compatibility lifetime references retained in the parent process. |
 | `rt.close()` | Release buffers, shut down chip workers. Called automatically as context manager. |
 

--- a/docs/zh/user/distributed/03-execution.md
+++ b/docs/zh/user/distributed/03-execution.md
@@ -35,6 +35,8 @@ with compiled.prepare() as rt:
 | `rt.alloc_stacked_tensor(host_w)` | 沿 dim 0 分片 `host_w`——分片 `i` 上传到卡 `i`。返回 `StackedDeviceTensor`。 |
 | `rt.free_stacked_tensor(stacked)` | 释放 `StackedDeviceTensor` 的所有分片。 |
 | `rt.copy_stacked_from(stacked, host_out)` | staged D2H 读回 CPU 连续的 `host_out`；可在 `prepare()` 后分配。 |
+| `rt.committed_device_memory(worker_id=0)` | 本 worker 自己的分配器在卡 `worker_id` 上已提交的设备 HBM 字节数——张量、池化 arena、运行时 buffer。多卡总量需按 id 求和。 |
+| `rt.device_memory_info(worker_id=0)` | `worker_id` 所在整张卡的 `(free_bytes, total_bytes)`，即驱动看到的视图。用它来决定分配多大；卡上其他任何东西都会改变 `free_bytes` 而不改变已提交总量。模拟器后端会抛异常，而不是报告 0。 |
 | `rt.release_inherited_host_tensor_refs()` | 释放父进程中为兼容保留的生命周期引用。 |
 | `rt.close()` | 释放 buffer，关闭芯片 worker。作为上下文管理器时自动调用。 |
 

--- a/python/pypto/runtime/distributed_runner.py
+++ b/python/pypto/runtime/distributed_runner.py
@@ -2253,6 +2253,30 @@ class DistributedWorker(Worker):
             return 0
         return int(self._w.committed_device_memory(worker_id))
 
+    def device_memory_info(self, worker_id: int = 0) -> tuple[int, int]:
+        """Free and total device HBM (bytes) as the driver sees it, for the device
+        chip *worker_id* runs on. Routes through the underlying simpler
+        ``Worker(level=3)`` facade, which forwards the query to the forked chip child.
+
+        This is a device-wide snapshot and answers a different question from
+        :meth:`committed_device_memory`, which reports only what this worker's own
+        ``MemoryAllocator`` has committed. Anything else on the card -- another
+        process, another worker, the driver itself -- moves ``free_bytes`` without
+        moving that committed total.
+
+        Unlike :meth:`committed_device_memory`, a failed query is never softened
+        into a zero here: a caller sizing a KV cache from a fabricated ``(0, 0)``
+        would silently under-allocate, so the underlying error propagates instead.
+        Simulator backends synthesize no device-wide memory and raise
+        ``NotImplementedError``.
+
+        Returns:
+            ``(free_bytes, total_bytes)``, both as Python ints.
+        """
+        self._require_open("device_memory_info")
+        info = self._w.device_memory_info(worker_id)
+        return int(info.free_bytes), int(info.total_bytes)
+
     def _buffer_identity_for(self, host_ptr: int, nbytes: int, *, writing: bool) -> tuple[bytes, int]:
         """Return the stable ``(owner_instance_id, buffer_id)`` naming this host range.
 

--- a/tests/ut/runtime/test_distributed_worker.py
+++ b/tests/ut/runtime/test_distributed_worker.py
@@ -3694,5 +3694,119 @@ class TestNamedInheritedHostRanges:
         rt.close()
 
 
+class TestDeviceMemoryInfo:
+    """``DistributedWorker.device_memory_info`` forwards a device-wide HBM query.
+
+    Distinct from ``committed_device_memory``, which reports only what this
+    worker's own allocator committed; this one is what the driver sees for the
+    whole card, so a serving process can size a KV cache against it.
+    """
+
+    @staticmethod
+    def _worker(patched_setup):
+        return DistributedWorker(_fake_compiled([_param("a", [16, 16])], []))
+
+    def test_forwards_the_logical_worker_id_unchanged(self, patched_setup):
+        """The id names a logical chip worker, so it must not be remapped on the way down."""
+        m = patched_setup
+        m["worker"].device_memory_info.return_value = SimpleNamespace(free_bytes=1024, total_bytes=4096)
+        rt = self._worker(patched_setup)
+
+        rt.device_memory_info(3)
+
+        m["worker"].device_memory_info.assert_called_once_with(3)
+        rt.close()
+
+    def test_defaults_to_worker_zero(self, patched_setup):
+        m = patched_setup
+        m["worker"].device_memory_info.return_value = SimpleNamespace(free_bytes=1, total_bytes=2)
+        rt = self._worker(patched_setup)
+
+        rt.device_memory_info()
+
+        m["worker"].device_memory_info.assert_called_once_with(0)
+        rt.close()
+
+    def test_returns_plain_ints_not_the_simpler_struct(self, patched_setup):
+        """simpler answers with a ``DeviceMemoryInfo``; callers are promised ints.
+
+        Returning the struct would leak a simpler type through the facade, which is
+        the coupling this method exists to avoid.
+        """
+        m = patched_setup
+        m["worker"].device_memory_info.return_value = SimpleNamespace(free_bytes=1234, total_bytes=5678)
+        rt = self._worker(patched_setup)
+
+        free, total = rt.device_memory_info(0)
+
+        assert (free, total) == (1234, 5678)
+        assert type(free) is int and type(total) is int
+        rt.close()
+
+    def test_normalizes_non_int_byte_counts(self, patched_setup):
+        """A binding may hand back a numpy-ish scalar; the tuple stays plain ints."""
+
+        class _IntLike:
+            def __init__(self, value):
+                self._value = value
+
+            def __index__(self):
+                return self._value
+
+            __int__ = __index__
+
+        m = patched_setup
+        m["worker"].device_memory_info.return_value = SimpleNamespace(
+            free_bytes=_IntLike(7), total_bytes=_IntLike(9)
+        )
+        rt = self._worker(patched_setup)
+
+        free, total = rt.device_memory_info(0)
+
+        assert (free, total) == (7, 9)
+        assert type(free) is int and type(total) is int
+        rt.close()
+
+    def test_rejects_use_after_close(self, patched_setup):
+        """Consistent with every other DistributedWorker method."""
+        m = patched_setup
+        m["worker"].device_memory_info.return_value = SimpleNamespace(free_bytes=1, total_bytes=2)
+        rt = self._worker(patched_setup)
+        rt.close()
+
+        with pytest.raises(RuntimeError, match="after close"):
+            rt.device_memory_info(0)
+
+    def test_propagates_unsupported_backend(self, patched_setup):
+        """Simulator backends have no device-wide memory to report.
+
+        The error must reach the caller: a swallowed one would look like a card
+        with no free memory.
+        """
+        m = patched_setup
+        m["worker"].device_memory_info.side_effect = NotImplementedError(
+            "device_memory_info is not supported on simulator backends"
+        )
+        rt = self._worker(patched_setup)
+
+        with pytest.raises(NotImplementedError, match="simulator backends"):
+            rt.device_memory_info(0)
+        rt.close()
+
+    def test_does_not_soften_a_failed_query_into_zero(self, patched_setup):
+        """``committed_device_memory`` answers 0 when it cannot ask; this must not.
+
+        A caller sizing an allocation from a fabricated ``(0, 0)`` would silently
+        under-allocate instead of failing, so the runtime error propagates.
+        """
+        m = patched_setup
+        m["worker"].device_memory_info.side_effect = RuntimeError("query failed")
+        rt = self._worker(patched_setup)
+
+        with pytest.raises(RuntimeError, match="query failed"):
+            rt.device_memory_info(0)
+        rt.close()
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Adds `DistributedWorker.device_memory_info(worker_id=0) -> tuple[int, int]`,
returning free and total device HBM for the card that logical chip worker runs
on. It forwards to the `Worker(level=3)` facade `DistributedWorker` already
owns.

Serving integrations need this to size a KV cache. Today they either call
`torch.npu.mem_get_info` — pulling in `torch-npu` for a single query — or reach
past `DistributedWorker` into the simpler `Worker` underneath it.

The underlying query landed in simpler #2011 and reached this repository with
the runtime bump in #2530, which is what unblocked this.

## Why it is a separate method from `committed_device_memory`

They answer different questions. `committed_device_memory` reports what *this
worker's* allocator has committed; `device_memory_info` is the whole card as the
driver sees it. Another process, another worker, or the driver itself moves
`free_bytes` without moving the committed total, so sizing an allocation against
the committed figure ignores every other tenant on the card.

That also decides the error behaviour, where this deliberately diverges from its
neighbour: `committed_device_memory` answers `0` when it has no worker to ask,
and this must not. A caller sizing a cache from a fabricated `(0, 0)`
under-allocates silently instead of failing — a worse outcome than the
exception. The underlying error propagates unchanged, including the
`NotImplementedError` simulator backends raise. The divergence is commented at
the call site so it does not later get "tidied up" into consistency.

The tuple is normalized to Python ints rather than returned as simpler's
`DeviceMemoryInfo`, since handing back that struct would leak a simpler type
through the facade — the coupling this method exists to remove.

## Changes

- `python/pypto/runtime/distributed_runner.py`: the new method, beside
  `committed_device_memory`.
- `tests/ut/runtime/test_distributed_worker.py`: `TestDeviceMemoryInfo`, seven
  cases on the existing mocked `Worker(level=3)` fixture — no card needed.
- `docs/{en,zh}/user/distributed/03-execution.md`: the method table gains this
  method, and `committed_device_memory` alongside it. That one was missing, and
  without it the new row has nothing to be distinct from.

## Verification

- `pytest tests/ut/runtime/test_distributed_worker.py` — 189 passed
- `pytest tests/ut/` — 10426 passed, 8 skipped, 2 xfailed
- `ruff check` + `ruff format --check` + `pyright` on the changed files — clean
- `tests/lint/check_*.py` — clean

Both pytest runs and the lint scripts ran inside the push transaction, bound to
the pushed commit.

Each test was checked against a mutated implementation to confirm it is
load-bearing: dropping the `int()` normalization, hard-coding `worker_id=0`,
dropping the open guard, and softening failures to `(0, 0)` each fail exactly
the test that covers them, and the restored implementation passes all seven.

Not run on device: every path here is a forward to a mocked `Worker`, and the
device-side query is simpler's own, covered by simpler #2011.

Closes #2413