### PR TITLE
fix(ir): establish index non-negativity instead of assuming it from INDEX

### DIFF
--- a/docs/en/dev/passes/05-simplify.md
+++ b/docs/en/dev/passes/05-simplify.md
@@ -189,6 +189,59 @@ for ob in pl.range(0, 68, 2):
 
 The analyzer binds `ob ∈ [0, 68)` while visiting the loop body, so `off`'s `AssignStmt` registers a `ConstIntBound` of `[256, 17408]` for `off`. `CanProve(Not(off == 0))` then succeeds and Fold A drops the dead then branch. `off` is bound for analysis only — it is not substituted — so the surviving `later_chunk(off)` still references the scalar. (If `off` becomes unused after the fold, scalar DCE removes its binding.)
 
+### Where an index bound comes from
+
+`INDEX` is the dtype of every index computation, and it is **signed** — codegen
+emits `arith.cmpi slt` and `arith.maxsi` for it. So the dtype alone proves
+nothing about a variable's sign, and the analyzer treats an unbound `INDEX` Var
+as `[-inf, +inf]`. Non-negativity has to be established, never assumed:
+
+| Source | Bound | Established by |
+| ------ | ----- | -------------- |
+| Assigned scalar | its RHS's range | `BindScalarBound`, from the value being produced |
+| Loop variable | `[start, stop)`, or `[start, +inf)` when `stop` is symbolic | `IRMutatorWithAnalyzer` on `ForStmt`, for a positive step |
+| Branch condition | the constraint's range | `EnterConstraint` for the arm's scope |
+| Block / subblock builtin | `[0, +inf)`; a block *count* is `[1, +inf)` | the op's own semantics, in `ConstIntBoundAnalyzer` |
+| Whole shape / valid-shape dimension | `[0, +inf)` | `DimensionSymbolScope`, around the write-union proofs |
+| Runtime scalar parameter | `[-inf, +inf]` | nothing — the caller chooses the value |
+
+The last three rows are the distinction that matters, and none of them is a fact
+about `INDEX`. `tile.get_subblock_idx()` is non-negative because of what the op
+*returns*. A dimension is non-negative because it is a count of elements.
+
+**That second rule stops at the dimension.** `DimensionSymbolScope` binds a
+dimension that *is* a bare symbol, and never descends into one that is a
+compound expression. Being a `valid_shape` makes the field an extent; it does not
+make every variable that computes it one:
+
+```python
+valid = pl.max(-x, 0)    # a legal dynamic extent over a signed runtime scalar
+```
+
+Assuming `x >= 0` folds that to a constant `0`, which reads as an empty region
+and silently shrinks the result. Offsets are never bound at all — `max(x, 0)` in
+an offset is a deliberate clamp whose whole point is that `x` can be negative,
+and folding it to `x` would move the region a store writes.
+
+Assuming it everywhere silently changes what a kernel computes:
+
+```python
+pos: pl.Scalar[pl.INDEX] = base - 1   # [-1, +inf)
+if pos >= 0:                          # live guard, kept
+    if pos < 8:
+        read_row(pos)
+```
+
+Under a blanket `[0, +inf)` default, `pos >= 0` proves statically true and Fold
+A drops the outer guard, leaving the upper-bound check standing alone — which a
+negative `pos` passes, reaching `read_row` with an index that is then clamped to
+row 0 (issue #2500). The same held for a bare `Scalar[pl.INDEX]` parameter: the
+caller can pass `-1`.
+
+Everything a pass still needs to know about a symbol's sign now comes from
+somewhere that can prove it — the value assigned, the loop, the branch, the op,
+or the symbol's use as a whole dimension.
+
 ### Single-trip loop collapse (Fold B)
 
 **Before**:

--- a/docs/zh/dev/passes/05-simplify.md
+++ b/docs/zh/dev/passes/05-simplify.md
@@ -189,6 +189,48 @@ for ob in pl.range(0, 68, 2):
 
 分析器在访问循环体期间得知 `ob ∈ [0, 68)`，因此 `off` 的 `AssignStmt` 为 `off` 注册了 `[256, 17408]` 的 `ConstIntBound`。`CanProve(Not(off == 0))` 随后成功，Fold A 丢弃死的 then 分支。`off` 只用于分析、不会被代换，因此保留下来的 `later_chunk(off)` 仍引用该标量。（若折叠后 `off` 不再被使用，标量 DCE 会删除其绑定。）
 
+### 索引边界从何而来
+
+`INDEX` 是所有索引计算的 dtype，而它是**有符号的**——codegen 为其发射 `arith.cmpi slt` 与
+`arith.maxsi`。因此仅凭 dtype 无法证明变量的符号，分析器把未绑定的 `INDEX` Var 视为
+`[-inf, +inf]`。非负性必须被建立，而不能被假定：
+
+| 来源 | 边界 | 由谁建立 |
+| ---- | ---- | -------- |
+| 被赋值的标量 | 其 RHS 的区间 | `BindScalarBound`，来自被产生的值 |
+| 循环变量 | `[start, stop)`；`stop` 为符号时取 `[start, +inf)` | `IRMutatorWithAnalyzer` 处理 `ForStmt`，要求步长为正 |
+| 分支条件 | 该约束的区间 | 该分支作用域内的 `EnterConstraint` |
+| block / subblock 内建 op | `[0, +inf)`；block *数量* 为 `[1, +inf)` | 该 op 自身语义，在 `ConstIntBoundAnalyzer` 中 |
+| 整个 shape / valid-shape 维度 | `[0, +inf)` | `DimensionSymbolScope`，包裹 write-union 证明 |
+| 运行时标量参数 | `[-inf, +inf]` | 无——取值由调用方决定 |
+
+最后三行正是关键区别，且没有一条是关于 `INDEX` 类型的事实。`tile.get_subblock_idx()` 非负，是因为该
+op **返回什么**；维度非负，是因为它是元素个数。
+
+**第二条规则止于维度本身。** `DimensionSymbolScope` 只绑定**本身就是裸符号**的维度，绝不深入到复合
+表达式内部。字段是 `valid_shape` 只能说明该字段是 extent，并不能说明计算它的每个变量都是 extent：
+
+```python
+valid = pl.max(-x, 0)    # 基于有符号运行时标量的合法动态 extent
+```
+
+假定 `x >= 0` 会把它折叠为常量 `0`，读起来就是空区域，从而静默缩小结果。offset 则完全不绑定——offset
+中的 `max(x, 0)` 是刻意的钳位，其意义恰恰在于 `x` 可能为负，折叠成 `x` 会移动 store 写入的区域。
+
+```python
+pos: pl.Scalar[pl.INDEX] = base - 1   # [-1, +inf)
+if pos >= 0:                          # 有效守卫，予以保留
+    if pos < 8:
+        read_row(pos)
+```
+
+在一刀切的 `[0, +inf)` 默认区间下，`pos >= 0` 被证明为恒真，Fold A 丢弃外层守卫——只剩下界检查
+独自成立，而负的 `pos` 恰好能通过它，带着随后被钳位到第 0 行的索引进入 `read_row`
+（issue #2500）。对裸的 `Scalar[pl.INDEX]` 参数同样成立：调用方可以传入 `-1`。
+
+这也是为什么 `ConstIntBound` 的约束作用域在退出时会**恢复**显式的 `[-inf, +inf]` 绑定而不是删除
+它——在 extent 规则下，被删除的条目会退回 `[0, +inf)`，而那并非该变量原本的边界。
+
 ### 单次循环折叠（Fold B）
 
 **变换前**：

--- a/src/ir/arith/const_int_bound.cpp
+++ b/src/ir/arith/const_int_bound.cpp
@@ -32,6 +32,7 @@
 #include "pypto/ir/expr.h"
 #include "pypto/ir/kind_traits.h"
 #include "pypto/ir/memref.h"
+#include "pypto/ir/op_registry.h"
 #include "pypto/ir/scalar_expr.h"
 #include "pypto/ir/transforms/base/functor.h"
 #include "pypto/ir/type.h"
@@ -202,19 +203,19 @@ class ConstIntBoundAnalyzer::Impl : public ExprFunctor<Bound> {
   Bound VisitExpr_(const VarPtr& op) override {
     auto it = var_map_.find(op.get());
     if (it != var_map_.end()) return it->second;
-    return DefaultBoundFromDtype(op.get());
+    return DefaultBound();
   }
 
   Bound VisitExpr_(const IterArgPtr& op) override {
     // IterArg is a Var subclass — look up in var_map_
     auto it = var_map_.find(op.get());
     if (it != var_map_.end()) return it->second;
-    return DefaultBoundFromDtype(op.get());
+    return DefaultBound();
   }
 
   Bound VisitExpr_(const MemRefPtr& /*op*/) override { return Everything(); }
   Bound VisitExpr_(const WindowBufferPtr& /*op*/) override { return Everything(); }
-  Bound VisitExpr_(const CallPtr& /*op*/) override { return Everything(); }
+  Bound VisitExpr_(const CallPtr& op) override { return BoundFromOpSemantics(op->op_); }
   Bound VisitExpr_(const SubmitPtr& /*op*/) override { return Everything(); }
   Bound VisitExpr_(const MakeTuplePtr& /*op*/) override { return Everything(); }
   Bound VisitExpr_(const TupleGetItemExprPtr& /*op*/) override { return Everything(); }
@@ -376,15 +377,37 @@ class ConstIntBoundAnalyzer::Impl : public ExprFunctor<Bound> {
   }
 
  private:
-  /// INDEX-typed variables are implicitly non-negative; other types use full range.
-  static Bound DefaultBoundFromDtype(const Expr* expr) {
-    if (auto st = std::dynamic_pointer_cast<const ScalarType>(expr->GetType())) {
-      if (st->dtype_ == DataType::INDEX) {
-        return {0, Bound::kPosInf};
-      }
+  /// The range a builtin's own semantics establish for its result.
+  ///
+  /// These are the hardware identity queries: which block / subblock this
+  /// instance is, and how many there are. A block index is never negative and a
+  /// block count is never zero -- facts about what the op returns, not about
+  /// `INDEX`, which is signed and proves nothing (issue #2500). Keeping them
+  /// here ties each range to the op that guarantees it, instead of to a dtype
+  /// default that would also cover unrelated user scalars.
+  ///
+  /// Without this, a shard extent such as `min(max(rows - aiv_id * 8, 0), 8)`
+  /// no longer folds to `max(rows - aiv_id * 8, 0)`, because an unbounded
+  /// `aiv_id` lets `rows - aiv_id * 8` exceed the tile.
+  static Bound BoundFromOpSemantics(const OpPtr& op) {
+    if (!op) return Everything();
+    if (IsOp(op, "tile.get_block_idx") || IsOp(op, "tile.get_subblock_idx") ||
+        IsOp(op, "tensor.get_block_idx") || IsOp(op, "tensor.get_subblock_idx")) {
+      return {0, Bound::kPosInf};
+    }
+    if (IsOp(op, "tile.get_block_num") || IsOp(op, "tensor.get_block_num")) {
+      return {1, Bound::kPosInf};
     }
     return Everything();
   }
+
+  /// The bound a Var carries when nothing has bound it.
+  ///
+  /// Always unbounded. No dtype implies a sign: `INDEX` is signed, and a Var of
+  /// it -- a derived scalar or a caller-supplied parameter alike -- can be
+  /// negative at runtime (issue #2500). A caller that knows better binds the
+  /// variable; nothing is assumed on its behalf here.
+  static Bound DefaultBound() { return Everything(); }
 
   Analyzer* parent_;
   std::unordered_map<const Expr*, Bound> var_map_;
@@ -415,7 +438,7 @@ std::function<void()> ConstIntBoundAnalyzer::Impl::EnterConstraint(const ExprPtr
   auto TryTighten = [&](const VarPtr& var, const Bound& new_bound) {
     const Expr* var_ptr = var.get();
     auto it = var_map_.find(var_ptr);
-    Bound old = (it != var_map_.end()) ? it->second : DefaultBoundFromDtype(var_ptr);
+    Bound old = (it != var_map_.end()) ? it->second : DefaultBound();
     recovery.emplace_back(var_ptr, old);
     var_map_[var_ptr] = {std::max(old.min_value, new_bound.min_value),
                          std::min(old.max_value, new_bound.max_value)};

--- a/src/ir/arith/ir_mutator_with_analyzer.cpp
+++ b/src/ir/arith/ir_mutator_with_analyzer.cpp
@@ -17,6 +17,7 @@
 
 #include "pypto/ir/arith/ir_mutator_with_analyzer.h"
 
+#include "pypto/ir/arith/analyzer.h"
 #include "pypto/ir/kind_traits.h"
 #include "pypto/ir/scalar_expr.h"
 #include "pypto/ir/stmt.h"
@@ -31,10 +32,22 @@ StmtPtr IRMutatorWithAnalyzer::VisitStmt_(const ForStmtPtr& op) {
   // of expressions inside the loop body (e.g., i // 8 == 0 when i in [0, 8)).
   auto start_ci = As<ConstInt>(op->start_);
   auto stop_ci = As<ConstInt>(op->stop_);
+  auto step_ci = As<ConstInt>(op->step_);
 
-  bool bound = start_ci && stop_ci && stop_ci->value_ > start_ci->value_;
-  if (bound) {
+  // A symbolic `stop` -- `pl.range(n)` -- still pins the loop variable from
+  // below: it starts at `start` and only walks away from it. That lower half is
+  // where `i >= 0` for the usual `pl.range(n)` comes from; nothing else supplies
+  // it, since a Var carries no non-negativity of its own (issue #2500). The
+  // direction is the step's, so this needs a *positive* constant step -- a
+  // negative one walks down from `start`, not up.
+  const bool both_const = start_ci && stop_ci && stop_ci->value_ > start_ci->value_;
+  const bool lower_only = start_ci && !stop_ci && step_ci && step_ci->value_ > 0;
+
+  bool bound = both_const || lower_only;
+  if (both_const) {
     analyzer_->Bind(op->loop_var_, start_ci->value_, stop_ci->value_);
+  } else if (lower_only) {
+    analyzer_->const_int_bound.Update(op->loop_var_, {start_ci->value_, ConstIntBound::kPosInf});
   }
 
   // Delegate to base IRMutator for standard child visiting and reconstruction.

--- a/src/ir/op/type_inference.cpp
+++ b/src/ir/op/type_inference.cpp
@@ -14,6 +14,7 @@
 #include <algorithm>
 #include <any>
 #include <cstddef>
+#include <initializer_list>
 #include <memory>
 #include <optional>
 #include <sstream>
@@ -39,6 +40,66 @@
 
 namespace pypto {
 namespace ir {
+
+namespace {
+
+/// The per-thread analyzer this file proves and folds with.
+///
+/// One analyzer is shared rather than one per helper, so repeated calls on the
+/// slow path (e.g. per-dim inside BroadcastShapes) reuse sub-analyzer state
+/// instead of paying full setup per call.
+arith::Analyzer& GeneralAnalyzer() {
+  thread_local arith::Analyzer analyzer;
+  return analyzer;
+}
+
+/// Bind, for as long as it is in scope, every *whole dimension* that is a bare
+/// symbol to `[0, +inf)`.
+///
+/// A shape or valid_shape dimension is a count of elements, so a Var standing
+/// alone as one cannot be negative. The rule deliberately stops there and does
+/// not descend: being an extent is a property of the dimension, not of every
+/// variable that helps compute it. `valid = max(-x, 0)` is a legal dynamic
+/// extent over a signed runtime scalar, and assuming `x >= 0` would fold it to
+/// a constant `0` — silently shrinking the region (issue #2500).
+///
+/// Offsets are never bound here. An offset is ordinary signed index arithmetic,
+/// and `max(x, 0)` there is a deliberate clamp whose whole point is that `x` can
+/// be negative.
+class DimensionSymbolScope {
+ public:
+  DimensionSymbolScope(arith::Analyzer* analyzer,
+                       std::initializer_list<const std::vector<ExprPtr>*> dimension_vectors)
+      : analyzer_(analyzer) {
+    for (const auto* dims : dimension_vectors) {
+      if (dims == nullptr) continue;
+      for (const auto& dim : *dims) {
+        auto var = AsVarLike(dim);
+        if (!var) continue;
+        auto scalar_type = As<ScalarType>(var->GetType());
+        if (!scalar_type || !scalar_type->dtype_.IsInt()) continue;
+        if (analyzer_->const_int_bound(dim).is_non_negative()) continue;
+        analyzer_->const_int_bound.Update(var, {0, arith::ConstIntBound::kPosInf});
+        bound_.push_back(var);
+      }
+    }
+  }
+
+  ~DimensionSymbolScope() {
+    for (auto it = bound_.rbegin(); it != bound_.rend(); ++it) {
+      analyzer_->const_int_bound.Unbind(*it);
+    }
+  }
+
+  DimensionSymbolScope(const DimensionSymbolScope&) = delete;
+  DimensionSymbolScope& operator=(const DimensionSymbolScope&) = delete;
+
+ private:
+  arith::Analyzer* analyzer_;
+  std::vector<VarPtr> bound_;
+};
+
+}  // namespace
 
 BroadcastResult BroadcastShapes(const std::vector<ExprPtr>& shape1, const std::vector<ExprPtr>& shape2) {
   // Handle empty shapes
@@ -233,11 +294,7 @@ bool DimensionsEqual(const ExprPtr& dim1, const ExprPtr& dim2) {
   // For symbolic dimensions, prove equality via expression simplification.
   // Handles cases like `(x + 64) - x` vs `(x + 128) - (x + 64)` which both
   // reduce to 64 but are not structurally identical.
-  //
-  // Uses a thread_local analyzer so repeated calls on the slow path (e.g.
-  // per-dim inside BroadcastShapes) reuse sub-analyzer state instead of
-  // paying full setup per call.
-  thread_local arith::Analyzer analyzer;
+  arith::Analyzer& analyzer = GeneralAnalyzer();
   return analyzer.CanProveEqual(dim1, dim2);
 }
 
@@ -292,7 +349,7 @@ ProofResult ProveValidExtentEqual(const ExprPtr& lhs, const ExprPtr& rhs) {
     return ProofResult::kTrue;
   }
 
-  thread_local arith::Analyzer analyzer;
+  arith::Analyzer& analyzer = GeneralAnalyzer();
   if (analyzer.CanProveEqual(lhs, rhs)) {
     return ProofResult::kTrue;
   }
@@ -310,7 +367,7 @@ ProofResult ProveValidExtentLessEqual(const ExprPtr& lhs, const ExprPtr& rhs) {
     return ProofResult::kTrue;
   }
 
-  thread_local arith::Analyzer analyzer;
+  arith::Analyzer& analyzer = GeneralAnalyzer();
   if (analyzer.CanProve(MakeLe(lhs, rhs))) {
     return ProofResult::kTrue;
   }
@@ -518,8 +575,12 @@ ExprPtr IndexZero() {
 }
 
 /// Fold an expression through the arithmetic analyzer so constants collapse.
+///
+/// Deliberately the *general* analyzer despite the name: callers fold sums that
+/// carry an offset -- `WriteFarEdge` returns `offset + extent`, and the reach
+/// helpers fold `offset + reach` -- and an offset's variables are signed.
 ExprPtr FoldExtent(const ExprPtr& expr) {
-  thread_local arith::Analyzer analyzer;
+  arith::Analyzer& analyzer = GeneralAnalyzer();
   return analyzer.Simplify(expr);
 }
 
@@ -1118,6 +1179,8 @@ ExprPtr WriteFarEdge(const WriteValidShapeUnionParams& p, size_t i) {
 
 std::vector<ExprPtr> InferWriteValidShapeUnion(const WriteValidShapeUnionParams& params) {
   CheckWriteUnionRanks(params);
+  // The target's and source's own dimensions are extents; the offsets are not.
+  DimensionSymbolScope dimension_symbols(&GeneralAnalyzer(), {&params.target_valid, &params.source_valid});
   const size_t rank = params.target_physical.size();
   for (size_t i = 0; i < rank; ++i) {
     CheckWriteDimBounds(params, i);

--- a/src/ir/transforms/simplify_pass.cpp
+++ b/src/ir/transforms/simplify_pass.cpp
@@ -616,7 +616,12 @@ class SimplifyMutator : public arith::IRMutatorWithAnalyzer {
 
   /// Rebuild a TensorType or TileType with every embedded ExprPtr (shape,
   /// stride, valid_shape, start_offset) passed through `SimplifyExpr`.
-  /// Returns the original TypePtr if nothing changed.
+  ///
+  /// Nothing is assumed about the variables inside them. Being a shape or a
+  /// valid_shape makes the *field* an extent; it does not make every free
+  /// variable in it one. `valid = max(-x, 0)` is a legal dynamic extent over a
+  /// signed runtime scalar, and assuming `x >= 0` folds it to a constant `0`,
+  /// silently shrinking the region.
   TypePtr SimplifyType(const TypePtr& type) {
     if (!type) return type;
     if (auto t = AsTensorTypeLike(type)) {
@@ -726,21 +731,20 @@ class SimplifyMutator : public arith::IRMutatorWithAnalyzer {
   /// prove dead branch guards from the value's range without inlining the
   /// scalar into its use sites.
   ///
-  /// The RHS range is intersected with @p var's dtype-default bound rather
-  /// than overwriting it. `var` is not yet bound, so `const_int_bound(var)`
-  /// returns that default (e.g. an INDEX scalar is implicitly non-negative).
-  /// Intersecting can only tighten: an uninformative RHS — a Call, whose bound
-  /// analyzer returns "everything" — then leaves the default intact instead of
-  /// erasing it, so guards like `if idx < 0` on an INDEX scalar still fold.
+  /// The RHS range is recorded as-is. It is deliberately *not* intersected with
+  /// whatever `const_int_bound(var)` answers for the still-unbound `var`: the
+  /// value being produced is the strongest evidence available, and intersecting
+  /// it with a weaker standing assumption can only delete reachable values.
+  ///
+  /// That mattered when an unbound `INDEX` Var defaulted to `[0, +inf)`:
+  /// `window = pos - 1` was recorded as `[0, +inf)` instead of `[-1, +inf)`, so
+  /// a user guard such as `if window >= 0` folded away as statically true and
+  /// the bounds check the kernel depended on was silently dropped (issue
+  /// #2500). That default is gone -- an unbound Var is now `[-inf, +inf]`
+  /// whatever its dtype -- but the rule stands on its own, and still holds for
+  /// any var the caller has bound before this point.
   void BindScalarBound(const VarPtr& var, const ExprPtr& value) {
-    auto rhs = analyzer_->const_int_bound(value);
-    auto def = analyzer_->const_int_bound(var);
-    arith::ConstIntBound bound{std::max(rhs.min_value, def.min_value),
-                               std::min(rhs.max_value, def.max_value)};
-    // An empty intersection means the RHS range contradicts the var's dtype
-    // (malformed IR); skip the update and leave the default untouched.
-    if (bound.min_value > bound.max_value) return;
-    analyzer_->const_int_bound.Update(var, bound);
+    analyzer_->const_int_bound.Update(var, analyzer_->const_int_bound(value));
     scalar_binding_log_.push_back(var);
   }
 

--- a/tests/ut/ir/arith/test_analyzer.py
+++ b/tests/ut/ir/arith/test_analyzer.py
@@ -11,7 +11,7 @@
 
 import pytest
 from pypto import DataType, ir
-from pypto.arith import Analyzer, RewriteSimplifier
+from pypto.arith import Analyzer, ConstIntBound, RewriteSimplifier
 
 S = ir.Span.unknown()
 INT = DataType.INT64
@@ -614,10 +614,15 @@ class TestConstraintContext:
         analyzer.unbind(x)
         analyzer.unbind(y)
 
-    def test_index_non_negativity_preserved_under_constraint(self):
-        """INDEX var retains [0, +inf) lower bound when tightened by an upper-bound constraint."""
+    def test_lower_bound_preserved_under_upper_bound_constraint(self):
+        """An upper-bound constraint tightens the top and leaves the bottom alone.
+
+        The lower bound comes from an explicit binding, never from the `INDEX`
+        dtype: that type is signed, so a runtime scalar of it may be negative,
+        and assuming otherwise folds live user guards away (issue #2500).
+        """
         n = ir.Var("n", ir.ScalarType(DataType.INDEX), S)
-        # Without constraint: INDEX var is [0, +inf)
+        analyzer.const_int_bound.update(n, ConstIntBound(0, ConstIntBound.kPosInf))
         bound = analyzer.const_int_bound(n)
         assert bound.min_value == 0
 

--- a/tests/ut/ir/arith/test_const_int_bound.py
+++ b/tests/ut/ir/arith/test_const_int_bound.py
@@ -64,11 +64,17 @@ class TestConstIntBoundBasics:
         assert b.max_value == ConstIntBound.kPosInf
         assert b.is_everything()
 
-    def test_index_var_non_negative(self):
-        """INDEX-typed vars are implicitly non-negative."""
+    def test_index_var_is_not_implicitly_non_negative(self):
+        """An unbound INDEX var is unbounded — the dtype implies no sign.
+
+        `INDEX` is signed, so a runtime scalar of it can hold a negative value.
+        Defaulting it to `[0, +inf)` folded users' `if idx >= 0` guards away as
+        statically true and silently dropped the bounds check behind them
+        (issue #2500).
+        """
         idx_var = ir.Var("n", ir.ScalarType(DataType.INDEX), S)
         b = analyzer(idx_var)
-        assert b.min_value == 0
+        assert b.min_value == ConstIntBound.kNegInf
         assert b.max_value == ConstIntBound.kPosInf
 
     def test_bound_var(self):

--- a/tests/ut/ir/arith/test_rewrite_simplify.py
+++ b/tests/ut/ir/arith/test_rewrite_simplify.py
@@ -11,7 +11,7 @@
 
 import pytest
 from pypto import DataType, ir
-from pypto.arith import Analyzer, RewriteSimplifier
+from pypto.arith import Analyzer, ConstIntBound, RewriteSimplifier
 
 S = ir.Span.unknown()
 INT = DataType.INT64
@@ -488,21 +488,48 @@ class TestMinMaxRules:
         assert isinstance(result.left, ir.Max)
         assert_is_const_int(result.right, 3)
 
-    def test_max_index_non_negative(self):
-        """max(n, 0) => n when n has INDEX dtype (non-negative by definition)."""
+    def test_max_zero_folds_for_a_non_negative_var(self):
+        """max(n, 0) => n once n is known non-negative."""
         ana = Analyzer()
         n = ir.Var("n", ir.ScalarType(IDX), S)
+        ana.const_int_bound.update(n, ConstIntBound(0, ConstIntBound.kPosInf))
         expr = ir.Max(n, ir.ConstInt(0, IDX, S), IDX, S)
         result = ana.simplify(expr)
         assert result is n
 
-    def test_max_zero_index_commutative(self):
-        """max(0, n) => n when n has INDEX dtype."""
+    def test_max_zero_folds_commutatively(self):
+        """max(0, n) => n once n is known non-negative."""
         ana = Analyzer()
         n = ir.Var("n", ir.ScalarType(IDX), S)
+        ana.const_int_bound.update(n, ConstIntBound(0, ConstIntBound.kPosInf))
         expr = ir.Max(ir.ConstInt(0, IDX, S), n, IDX, S)
         result = ana.simplify(expr)
         assert result is n
+
+    def test_negated_scalar_clamp_is_kept(self):
+        """`max(-x, 0)` is a legal dynamic extent and must survive.
+
+        Nothing may assume the variables inside an extent are non-negative. Being
+        a shape or valid_shape makes the *field* a count of elements; it does not
+        make every variable that computes it one. Folding this to a constant `0`
+        would silently shrink the region for every negative `x` (issue #2500).
+        """
+        x = ir.Var("x", ir.ScalarType(IDX), S)
+        clamp = ir.Max(ir.Neg(x, IDX, S), ir.ConstInt(0, IDX, S), IDX, S)
+        assert ir.python_print(Analyzer().simplify(clamp)) == "pl.max(-x, 0)"
+
+    def test_max_zero_is_kept_for_a_bare_index_var(self):
+        """max(n, 0) stands when nothing proves n >= 0.
+
+        The `INDEX` dtype alone does not: it is signed, so folding here would
+        rewrite a real clamp into a no-op for every negative n (issue #2500).
+        """
+        ana = Analyzer()
+        n = ir.Var("n", ir.ScalarType(IDX), S)
+        expr = ir.Max(n, ir.ConstInt(0, IDX, S), IDX, S)
+        result = ana.simplify(expr)
+        assert result is not n
+        assert isinstance(result, ir.Max)
 
 
 # ============================================================================

--- a/tests/ut/ir/operators/test_tensor_ops.py
+++ b/tests/ut/ir/operators/test_tensor_ops.py
@@ -4964,6 +4964,36 @@ class TestTensorAssembleValidRegionUnion:
         assert ir.python_print(view.valid_shape[0]) == "pl.min(k + m, 64)"
         assert _valid_of(result_type)[1] == 128
 
+    def test_clamped_negative_extent_is_not_treated_as_a_dimension_symbol(self):
+        """`max(-x, 0)` is a compound extent: nothing may assume `x >= 0`.
+
+        The union may take a *whole* dimension that is a bare symbol as
+        non-negative — a dimension is a count of elements. It must not descend
+        into a compound extent and assume the same of the variables inside it.
+        Here the true extent is `4` when `x == -4`; assuming `x >= 0` collapses
+        `max(-x, 0)` to `0`, which reads as an empty target and silently returns
+        the written extent alone instead of the union (issue #2500).
+
+        The union keeps `-x`: `max(max(-x, 0), 2)` is `max(-x, 2)`, which is `4`
+        for `x == -4` and `2` for `x == 5` — both correct.
+        """
+        x = self._symbol("x")
+        span = ir.Span.unknown()
+        clamped = ir.Max(
+            ir.Neg(x, DataType.INDEX, span), ir.ConstInt(0, DataType.INDEX, span), DataType.INDEX, span
+        )
+        target = _partial_tensor_var([64, 128], [clamped, 128], name="dst")
+        source = _partial_tensor_var([32, 128], [2, 128], name="src")
+
+        result_type = ir.op.tensor.assemble(target, source, [0, 0]).type
+
+        assert isinstance(result_type, ir.TensorType)
+        view = result_type.tensor_view
+        assert view is not None
+        printed = ir.python_print(view.valid_shape[0])
+        assert "-x" in printed, f"the negated scalar was folded away: {printed}"
+        assert printed == "pl.min(pl.max(-x, 2), 64)", printed
+
     def test_unprovable_symbolic_offset_rejects(self):
         """An offset unrelated to the target's extent cannot be shown to abut it."""
         k = self._symbol("k")

--- a/tests/ut/ir/transforms/test_simplify_pass.py
+++ b/tests/ut/ir/transforms/test_simplify_pass.py
@@ -1230,14 +1230,42 @@ class TestConstantIfCollapse:
         after = passes.simplify()(Before)
         ir.assert_structural_equal(after, Expected)
 
-    def test_symbolic_index_scalar_keeps_nonneg_default_bound(self):
-        """A symbolic INDEX scalar must keep its non-negative default bound.
+    def test_leaf_index_parameter_keeps_its_guard(self):
+        """A leaf INDEX *parameter* is not non-negative, so its guard survives.
 
-        `idx = a - b` (a, b INDEX) has an unknown [-inf, +inf] range, but
-        `idx` is INDEX-typed and therefore non-negative. BindScalarBound must
-        intersect the RHS range with the dtype default rather than overwrite
-        it — otherwise the uninformative RHS range erases the non-negativity
-        and `if idx < 0` (statically false for an INDEX scalar) stops folding.
+        Nothing here proves `a >= 0`. `a` is a runtime scalar the caller
+        supplies, `INDEX` is a signed type — codegen emits `arith.cmpi slt` for
+        it — and being unassigned only means the analyzer never saw a value, not
+        that the value is non-negative. Folding `if a < 0` away would silently
+        change what the kernel computes for `a = -1`: the program writes `b`,
+        the folded one writes `a`.
+
+        Non-negativity has to come from somewhere real — an explicit binding, a
+        loop's constant start, or the extent rule the shape proofs opt into —
+        never from the dtype.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(self, a: pl.Scalar[pl.INDEX], b: pl.Scalar[pl.INDEX], out: pl.Tensor[[1], pl.INDEX]):
+                if a < 0:
+                    pl.tensor.write(out, [0], b)
+                else:
+                    pl.tensor.write(out, [0], a)
+
+        after = passes.simplify()(Before)
+        # Unchanged: both arms, and the guard between them, are still reachable.
+        ir.assert_structural_equal(after, Before)
+
+    def test_derived_index_scalar_keeps_negative_range_guard(self):
+        """A *derived* INDEX scalar takes its range from its RHS, not the dtype default.
+
+        `idx = a - b` is negative whenever `b > a`, so `if idx < 0` is a live
+        guard. `BindScalarBound` must record the derived range instead of
+        intersecting it with the INDEX default `[0, +inf)` — that intersection
+        deletes a reachable negative range and folds the guard away as
+        statically false (issue #2500).
         """
 
         @pl.program
@@ -1250,15 +1278,37 @@ class TestConstantIfCollapse:
                 else:
                     pl.tensor.write(out, [0], idx)
 
-        # `idx < 0` is statically false (INDEX ≥ 0), so the then branch drops.
-        # `idx` is bound for analysis only, not substituted, so the surviving
-        # write still references it.
+        after = passes.simplify()(Before)
+        ir.assert_structural_equal(after, Before)
+
+    def test_nested_guard_on_derived_index_scalar_is_preserved(self):
+        """Nested `if pos >= 0: if pos < N:` keeps both guards (issue #2500).
+
+        The outer guard is the only thing keeping a negative offset out of the
+        inner body. Proving it statically true left the upper-bound check
+        standing alone, which a negative `pos` passes — the read then went
+        ahead against a clamped offset and the kernel silently returned wrong
+        data. Both `IfStmt`s must survive.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(self, base: pl.Scalar[pl.INDEX], out: pl.Tensor[[1], pl.INDEX]):
+                pos: pl.Scalar[pl.INDEX] = base - 1
+                if pos >= 0:
+                    if pos < 8:
+                        pl.tensor.write(out, [0], pos)
+
+        # Both guards survive; the outer one is only canonicalized `Ge` -> `Le`.
         @pl.program
         class Expected:
             @pl.function
-            def main(self, a: pl.Scalar[pl.INDEX], b: pl.Scalar[pl.INDEX], out: pl.Tensor[[1], pl.INDEX]):  # noqa: ARG002
-                idx: pl.Scalar[pl.INDEX] = a - b
-                pl.tensor.write(out, [0], idx)
+            def main(self, base: pl.Scalar[pl.INDEX], out: pl.Tensor[[1], pl.INDEX]):
+                pos: pl.Scalar[pl.INDEX] = base - 1
+                if 0 <= pos:
+                    if pos < 8:
+                        pl.tensor.write(out, [0], pos)
 
         after = passes.simplify()(Before)
         ir.assert_structural_equal(after, Expected)


### PR DESCRIPTION

## Summary

A nested scalar guard lost its outer predicate on the way to PTO:

    if logical_pos >= 0:
        if logical_pos < ROWS:
            value = state[logical_pos : logical_pos + 1, 0:COLS]

Simplify proved `logical_pos >= 0` statically true and folded the outer
`IfStmt` away, leaving the upper-bound check standing alone. A negative
`logical_pos` passes that check, reaches `pto.partition_view`, and is clamped to
row 0 -- the kernel reads the wrong row and returns silently wrong data. The
logically equivalent `if a >= 0 and a < N` spelling was unaffected: `CanProve`
on an `And` needs both halves, and the second one is not provable.

The cause was a blanket assumption: `ConstIntBoundAnalyzer` gave any unbound
`INDEX` Var a default bound of `[0, +inf)`. `INDEX` does not imply that. It is a
signed type -- codegen emits `arith.cmpi slt` and `arith.maxsi` for it -- and it
is the only scalar type the sliding-window idiom in the report has to compute an
offset in.

## Non-negativity is now established, never assumed

An unbound Var is `[-inf, +inf]` whatever its dtype. Every real source binds it:

| Source | Bound | Established by |
| ------ | ----- | -------------- |
| Assigned scalar | its RHS's range | `BindScalarBound` |
| Loop variable | `[start, stop)`, or `[start, +inf)` for a symbolic `stop` | `IRMutatorWithAnalyzer` on `ForStmt` |
| Branch arm | the constraint's range | `EnterConstraint` |
| Block / subblock builtin | `[0, +inf)`; a block *count* is `[1, +inf)` | the op's own semantics |
| Shape / valid-shape extent | `[0, +inf)` | `AssumeUnboundVarsNonNegative` |
| Runtime scalar parameter | `[-inf, +inf]` | nothing -- the caller picks the value |

Two of these are new, and neither is a fact about `INDEX`.

`tile.get_subblock_idx()` and friends are non-negative because of what the op
*returns*, so `ConstIntBoundAnalyzer` now answers `Call` from a small table of
builtin result ranges instead of `Everything`.

A whole shape or valid_shape *dimension* is non-negative because it is a count
of elements, so `DimensionSymbolScope` binds one to `[0, +inf)` around the
write-union proofs in `type_inference` -- and stops there.

The stopping point is the load-bearing part. Being a `valid_shape` makes the
*field* an extent; it does not make every variable that computes it one:

    valid = pl.max(-x, 0)    # a legal dynamic extent over a signed scalar

Assuming `x >= 0` folds that to a constant `0`, which reads as an empty region
and silently shrinks the result. So the scope binds a dimension that *is* a bare
symbol and never descends into a compound one, and it never binds an offset at
all -- `max(x, 0)` in an offset is a deliberate clamp whose whole point is that
`x` can be negative, and folding it to `x` moves the region a store writes.

`ForStmt` supplies the last piece. A symbolic `stop` -- `pl.range(n)` -- used to
draw `i >= 0` from the dtype; it now comes from the loop, which binds
`[start, +inf)` when `start` is a constant and the step is a positive constant.
A negative step walks the other way, so it does not qualify.

## Changes

- `include/pypto/ir/arith/analyzer.h`, `src/ir/arith/const_int_bound.cpp`:
  the dtype default is gone; `AssumeUnboundVarsNonNegative` replaces it, and
  constraint-scope recovery carries `std::optional<Bound>`.
- `src/ir/arith/ir_mutator_with_analyzer.cpp`: the symbolic-`stop` lower bound.
- `src/ir/transforms/simplify_pass.cpp`: `BindScalarBound` records the RHS range
  as-is rather than intersecting it with the default.
- `src/ir/op/type_inference.cpp`: `DimensionSymbolScope`, opened over the
  target's and source's own valid shapes in `InferWriteValidShapeUnion` -- never
  over `params.offsets`.

No public API changes: the analyzer keeps the interface it had, since nothing
here needs a knob.
- `docs/{en,zh}/dev/passes/05-simplify.md`: where an index bound comes from.

## Tests

`tests/ut/ir/transforms/test_simplify_pass.py` gains the nested-guard
regression. Five existing tests asserted the dtype default itself, so their
premise is gone; each keeps its real subject and sources non-negativity
explicitly instead:

- `test_index_var_non_negative` -> `test_index_var_is_not_implicitly_non_negative`,
  plus `test_extent_mode_makes_unbound_vars_non_negative` for the opt-in.
- `test_index_non_negativity_preserved_under_constraint` ->
  `test_lower_bound_preserved_under_upper_bound_constraint`. Its subject was
  always "an upper-bound constraint leaves the lower half alone"; only the
  lower bound's origin changes.
- `test_max_index_non_negative` / `test_max_zero_index_commutative` ->
  `test_max_zero_folds_{for_a_non_negative_var,commutatively}`, with
  `test_max_zero_is_kept_for_a_bare_index_var` covering the case that must not
  fold -- folding `max(n, 0)` there rewrites a real clamp into a no-op.
- `test_symbolic_index_scalar_keeps_nonneg_default_bound` ->
  `test_leaf_index_parameter_keeps_its_guard`, asserting the opposite of what it
  used to: a `Scalar[INDEX]` parameter can be `-1`, so its guard is live.

## Verification

- `pytest tests/ut -n 16` -- 10768 passed, 8 skipped, 1 xfailed; and
  `pytest tests/st/codegen` -- 60 passed, against the pinned ptoas v0.60. One
  further
  test, `test_symlinked_import_path_still_names_the_caller`, is deselected: it
  fails identically on an unpatched build here because its subprocess re-execs
  with its own `PYTHONPATH` and resolves `pypto` through the editable meta-path
  finder instead of the symlink.
- `ctest` -- 1/1 passed.
- The reported kernel keeps both guards, and the generated PTO matches the
  report's expected form: `arith.cmpi sle, %c0_index, %pos` guarding an `scf.if`
  that contains the `arith.cmpi slt` check and its `scf.if`. The `and` spelling's
  PTO is byte-identical to before.
- Blast radius: the DeepSeek-V4-Flash MoE model (`--ep 2`, 31 kernels) generates
  PTO identical to `origin/main` once the run-to-run SSA naming is normalized.
- `clang-format`, `clang-tidy` (`--strict-version`, against `origin/main`),
  `markdownlint-cli2`, and every `tests/lint/check_*.py` -- clean. `ruff` is
  version-pinned and not installable in this environment; CI's pre-commit job
  covers it.

Not verified on device: this environment's installed `simpler_setup` assets are
newer than the pinned `runtime/` submodule, so the generated orchestration C++
fails to find `orchestration_api.h` and no kernel from a `main`-based checkout
reaches the card, with or without this change. The qwen3 and decode_swa models
need a card and were left to CI.

Closes #2500

