### PR TITLE
fix(ir): type a loop carry by what its body yields, not by its seed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -250,6 +250,8 @@ set(PYPTO_SOURCES
     src/ir/transforms/canonicalize_io_order_pass.cpp
     src/ir/transforms/structural_equal.cpp
     src/ir/transforms/structural_hash.cpp
+    src/ir/transforms/utils/acc_init_builder.cpp
+    src/ir/transforms/utils/narrow_loop_carry.cpp
     src/ir/transforms/utils/buffer_root_collector.cpp
     src/ir/transforms/utils/core_affinity.cpp
     src/ir/transforms/utils/core_side_ops.cpp

--- a/docs/en/dev/ir/05-operators.md
+++ b/docs/en/dev/ir/05-operators.md
@@ -715,6 +715,14 @@ prefix at all, yet `[8, 16]` valid `[8, 5]` is exact, because dropping a full
 unit axis keeps rows as rows. `tensor.reshape`'s optional third `valid_shape`
 operand may only *narrow* the derived region, never claim data outside it.
 
+An **identity** `tile.reshape` — one whose target shape equals the source's —
+additionally keeps the source's layout triple (`blayout` / `slayout` / `fractal`) and its
+resolved memory space, instead of re-deriving the layout from the shape. Re-deriving
+yields the space-agnostic flat layout, which `NormalizeImplicitTileView` rescues only for
+a view that collapses; an Acc box that is narrowed, padded, or declared `compact` never
+collapses, so the flat layout would stick and its reader would walk L0C as a plain
+row-major buffer (issue #2470).
+
 **Data Flow:** `TensorType (DDR) → tile.load → TileType (Unified Buffer) → tile.{ops} → TileType → tile.store → TensorType (DDR)`
 
 ### Mask patterns

--- a/docs/en/dev/passes/10-convert_tensor_to_tile_ops.md
+++ b/docs/en/dev/passes/10-convert_tensor_to_tile_ops.md
@@ -343,6 +343,35 @@ Key changes:
 - `Out` parameter `ret0_out` added to InCore function
 - `tensor.create` inserted at orchestration call site
 
+## Loop-Carry Valid-Shape Repair
+
+`tensor.matmul` drops its operands' `valid_shape`, so an accumulator only becomes narrower
+than the seed it is carried from once this pass produces a `tile.matmul` over a
+row-narrowed left operand:
+
+```python
+acc = pl.create_tensor([M, N], dtype=pl.INT32)          # full box
+for k0 in pl.pipeline(0, K, K_TILE, stage=2):
+    xk = pl.slice(x, [M, K_TILE], [m0, k0], valid_shape=[v, K_TILE])   # runtime v
+    acc = pl.matmul_acc(acc, xk, wk, b_trans=True)      # narrowed, compact result
+```
+
+The carry is typed from its **init value alone** — `ConvertToSSA` mints the `IterArg` from
+the seed, this pass re-mints it from the converted seed, and both force the loop's
+`return_var` back to that type — so the narrowing dies at the loop boundary. `mad` writes
+L0C at an N-fractal stride of `ceil(v/16)*16` while a reader that believes the full box
+height walks it at the physical row pitch, corrupting every N-fractal above the first
+(issue #2470).
+
+Before returning, this pass therefore calls `narrow_loop_carry::NarrowAccCarries` on each
+function: an Acc carry seeded by `tile.create` is re-declared at the extent its yields
+prove — `tile.create(compact=True)` plus `tile.set_validshape` — and the body's def-use
+closure is re-typed through the operators' own deducers. Repairing it in the pass that
+creates it keeps the pipeline verifiable; leaving it would publish a carry the `TypeCheck`
+diagnostic and the `AccCompactValid` property verifier reject. `FlattenTileNdTo2D` calls
+the same helper, for an ND seed whose narrowing only appears when `tile.batch_matmul` is
+unrolled into 2D matmuls.
+
 ## Implementation
 
 **Header**: `include/pypto/ir/transforms/passes.h`
@@ -351,7 +380,7 @@ Key changes:
 
 **Python binding**: `python/bindings/modules/passes.cpp`
 
-**Tests**: `tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py`
+**Tests**: `tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py`, `tests/ut/ir/transforms/test_narrow_loop_carry_valid_shape.py` (the carry repair)
 
 ## Pass Properties
 

--- a/docs/en/dev/passes/10-convert_tensor_to_tile_ops.md
+++ b/docs/en/dev/passes/10-convert_tensor_to_tile_ops.md
@@ -372,6 +372,11 @@ diagnostic and the `AccCompactValid` property verifier reject. `FlattenTileNdTo2
 the same helper, for an ND seed whose narrowing only appears when `tile.batch_matmul` is
 unrolled into 2D matmuls.
 
+A carry is left exactly as it is when the two readings of its buffer cannot disagree — a
+single-fractal-block `[16, N]` accumulator packs to its physical rows whatever its valid
+rows — or when the narrowed extent is only computed inside the loop body, where the
+re-declared seed could not name it.
+
 ## Implementation
 
 **Header**: `include/pypto/ir/transforms/passes.h`

--- a/docs/en/dev/passes/13-flatten_tile_nd_to_2d.md
+++ b/docs/en/dev/passes/13-flatten_tile_nd_to_2d.md
@@ -204,6 +204,11 @@ carry this pass creates would otherwise be rejected by the `TypeCheck` diagnosti
 the same reason — a 2D seed is narrowed one pass earlier, when `tensor.matmul` becomes
 `tile.matmul`.
 
+A carry is left exactly as it is when the two readings of its buffer cannot disagree — a
+single-fractal-block `[16, N]` accumulator packs to its physical rows whatever its valid
+rows — or when the narrowed extent is only computed inside the loop body, where the
+re-declared seed could not name it.
+
 ## Implementation
 
 **Header**: `include/pypto/ir/transforms/passes.h`

--- a/docs/en/dev/passes/13-flatten_tile_nd_to_2d.md
+++ b/docs/en/dev/passes/13-flatten_tile_nd_to_2d.md
@@ -176,6 +176,34 @@ If a >2D tile reaches the pass with a **dynamic physical shape** (the user did n
 chunk), it cannot be flattened and the pass raises an actionable error pointing to the two fixes:
 chunk the dynamic dim with `pl.range`/`pl.parallel`, or reshape to 2D before the InCore (`pl.at`) scope.
 
+## Loop-carry valid-shape repair
+
+Unrolling a `tile.batch_matmul` whose left operand carries a narrowed `valid_shape`
+produces 2D matmuls whose results are narrower than the accumulator they flow into. The
+loop carry that accumulator travels through is typed from its **init value alone**, so it
+keeps advertising the seed's full box height that no `mad` ever wrote:
+
+```text
+acc__tile      : Tile[[64, 256], INT32]                         <- pl.create_tensor seed
+  iter_arg     : Tile[[64, 256], INT32]                         <- typed from the seed
+  yield        : Tile[[64, 256], INT32, Acc, valid=[v, 256], compact]   <- what the body produced
+  return_var   : Tile[[64, 256], INT32]                         <- forced back to the iter_arg
+```
+
+`mad` lays its product out in L0C at an N-fractal stride of `ceil(v/16)*16`, so a reader
+that believes the full height walks the buffer at the physical row pitch and scrambles
+every N-fractal above the first (issue #2470). This pass therefore calls
+`narrow_loop_carry::NarrowAccCarries` on each function it rewrites, before returning: the
+seed is re-declared at the extent the yields prove — `tile.create(compact=True)` plus
+`tile.set_validshape`, the same form `AutoTileMatmulL0` builds when it splits K — and the
+body's def-use closure is re-typed through the operators' own deducers.
+
+Repairing it here rather than in a later pass is what keeps the pipeline verifiable: the
+carry this pass creates would otherwise be rejected by the `TypeCheck` diagnostic and the
+`AccCompactValid` property verifier. `ConvertTensorToTileOps` calls the same helper for
+the same reason — a 2D seed is narrowed one pass earlier, when `tensor.matmul` becomes
+`tile.matmul`.
+
 ## Implementation
 
 **Header**: `include/pypto/ir/transforms/passes.h`
@@ -184,7 +212,7 @@ The implementation is split by responsibility:
 
 | Phase | File | Responsibility |
 | ----- | ---- | -------------- |
-| Coordination | `src/ir/transforms/flatten_tile_nd_to_2d/pass.cpp` | Select InCore functions and sequence analysis before rewrite |
+| Coordination | `src/ir/transforms/flatten_tile_nd_to_2d/pass.cpp` | Select InCore functions, sequence analysis before rewrite, and repair the loop carries the rewrite narrowed |
 | Analysis | `src/ir/transforms/flatten_tile_nd_to_2d/analysis.cpp` | Read-only precondition validation |
 | Rewrite orchestration | `src/ir/transforms/flatten_tile_nd_to_2d/rewrite.cpp` | Recursive statement traversal and operation dispatch |
 | Rewrite utilities | `src/ir/transforms/flatten_tile_nd_to_2d/rewrite_utils.cpp` | Shared shape, index, and capacity helpers |
@@ -196,7 +224,7 @@ The phase entry points and rewrite component interface are private to the transf
 
 **Python binding**: `python/bindings/modules/passes.cpp`
 
-**Tests**: `tests/ut/ir/transforms/test_flatten_tile_nd_to_2d.py`, `tests/st/codegen/dsl/test_flatten_dynamic_tile_3d.py` (issue #1578 end-to-end)
+**Tests**: `tests/ut/ir/transforms/test_flatten_tile_nd_to_2d.py`, `tests/ut/ir/transforms/test_narrow_loop_carry_valid_shape.py` (the carry repair), `tests/st/codegen/dsl/test_flatten_dynamic_tile_3d.py` (issue #1578 end-to-end)
 
 ## Pass Properties
 

--- a/docs/en/dev/passes/utils.md
+++ b/docs/en/dev/passes/utils.md
@@ -124,3 +124,5 @@ auto used = memref_collectors::CollectUsedBasePtrs(func->body_);
 | `auto_name_utils.h` | SSA name generation, rename maps, name parsing |
 | `parent_stmt_analysis.h` | Parent-child statement mapping |
 | `dead_code_elimination.h` | Dead code removal within functions |
+| `acc_init_builder.h` | `BuildAccStorage`, `BuildNarrowedAccInit` — declare an L0C accumulator, compact when its valid rows do not fill the box |
+| `narrow_loop_carry.h` | `NarrowAccCarries` — re-declare an Acc loop carry at the valid extent its yields prove |

--- a/docs/zh/dev/ir/05-operators.md
+++ b/docs/zh/dev/ir/05-operators.md
@@ -645,6 +645,12 @@ valid `[8, 5]` 是精确的，因为丢弃完全有效的单位轴不改变行�
 `tensor.reshape` 可选的第三个 `valid_shape` 操作数只能*收窄*推导出的区域，
 不能声称拥有该区域之外的数据。
 
+**恒等** `tile.reshape`（目标形状与源形状相同）还会保留源的 layout 三元组
+（`blayout` / `slayout` / `fractal`）及其已解析的内存空间，而不是按形状重新推导 layout。
+重新推导得到的是与空间无关的扁平 layout；`NormalizeImplicitTileView` 只会为可折叠的
+view 兜底，而被收窄、带 pad 或声明了 `compact` 的 Acc 盒永远不可折叠——扁平 layout 于是
+被固化下来，其读者会把 L0C 当作普通 row-major 缓冲区来遍历（issue #2470）。
+
 **数据流：** `TensorType (DDR) → tile.load → TileType (Unified Buffer) → tile.{ops} → TileType → tile.store → TensorType (DDR)`
 
 ### 掩码模式

--- a/docs/zh/dev/passes/10-convert_tensor_to_tile_ops.md
+++ b/docs/zh/dev/passes/10-convert_tensor_to_tile_ops.md
@@ -360,7 +360,7 @@ for k0 in pl.pipeline(0, K, K_TILE, stage=2):
 
 **Python 绑定**：`python/bindings/modules/passes.cpp`
 
-**测试**：`tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py`
+**测试**：`tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py`、`tests/ut/ir/transforms/test_narrow_loop_carry_valid_shape.py`（携带值修复）
 
 ## Pass 属性
 

--- a/docs/zh/dev/passes/10-convert_tensor_to_tile_ops.md
+++ b/docs/zh/dev/passes/10-convert_tensor_to_tile_ops.md
@@ -324,6 +324,30 @@ class After:
 - InCore 函数新增 `Out` 参数 `ret0_out`
 - 编排函数调用点插入 `tensor.create`
 
+## 循环携带值的 valid_shape 修复
+
+`tensor.matmul` 会丢弃操作数的 `valid_shape`，因此只有当本 pass 把它变成作用于被收窄左
+操作数的 `tile.matmul` 之后，累加器才会比它所携带的种子更窄：
+
+```python
+acc = pl.create_tensor([M, N], dtype=pl.INT32)          # 完整盒
+for k0 in pl.pipeline(0, K, K_TILE, stage=2):
+    xk = pl.slice(x, [M, K_TILE], [m0, k0], valid_shape=[v, K_TILE])   # 运行期 v
+    acc = pl.matmul_acc(acc, xk, wk, b_trans=True)      # 收窄且 compact 的结果
+```
+
+循环携带值**只按其初值定型**——`ConvertToSSA` 用种子铸出 `IterArg`，本 pass 再用转换后的
+种子重铸一次，两者都会把循环的 `return_var` 拉回同一类型——于是收窄在循环边界上消失。
+`mad` 以 `ceil(v/16)*16` 的 N-fractal 步长写 L0C，而相信完整盒高的读者按物理行步长遍历，
+第一个之后的每个 N-fractal 都会被打乱（issue #2470）。
+
+因此本 pass 在返回前会对每个函数调用 `narrow_loop_carry::NarrowAccCarries`：由
+`tile.create` 播种的 Acc 携带值会按 yield 可证明的范围重新声明——`tile.create(compact=True)`
+加 `tile.set_validshape`——并让循环体的 def-use 闭包经由算子自身的 deducer 重新定型。在制造
+问题的 pass 里就地修复，才能保持流水线可验证；否则产出的携带值会被 `TypeCheck` 诊断与
+`AccCompactValid` 属性验证器拒绝。`FlattenTileNdTo2D` 调用同一个 helper，用于 ND 种子——
+它的收窄要等到 `tile.batch_matmul` 展开成 2D matmul 时才出现。
+
 ## 实现
 
 **头文件**：`include/pypto/ir/transforms/passes.h`

--- a/docs/zh/dev/passes/10-convert_tensor_to_tile_ops.md
+++ b/docs/zh/dev/passes/10-convert_tensor_to_tile_ops.md
@@ -348,6 +348,10 @@ for k0 in pl.pipeline(0, K, K_TILE, stage=2):
 `AccCompactValid` 属性验证器拒绝。`FlattenTileNdTo2D` 调用同一个 helper，用于 ND 种子——
 它的收窄要等到 `tile.batch_matmul` 展开成 2D matmul 时才出现。
 
+两种情况下携带值保持原样：一是缓冲区的两种读法本来就不会分歧——单 fractal 块的 `[16, N]`
+累加器无论有效行是多少都按物理行打包；二是收窄用的表达式只在循环体内计算，重新声明的种子
+在那之前根本命名不到它。
+
 ## 实现
 
 **头文件**：`include/pypto/ir/transforms/passes.h`

--- a/docs/zh/dev/passes/13-flatten_tile_nd_to_2d.md
+++ b/docs/zh/dev/passes/13-flatten_tile_nd_to_2d.md
@@ -177,6 +177,10 @@ acc__tile      : Tile[[64, 256], INT32]                              <- pl.creat
 `TypeCheck` 诊断与 `AccCompactValid` 属性验证器拒绝。`ConvertTensorToTileOps` 出于同样的
 原因调用同一个 helper——2D 种子在 `tensor.matmul` 变成 `tile.matmul` 时就已经被收窄了。
 
+两种情况下携带值保持原样：一是缓冲区的两种读法本来就不会分歧——单 fractal 块的 `[16, N]`
+累加器无论有效行是多少都按物理行打包；二是收窄用的表达式只在循环体内计算，重新声明的种子
+在那之前根本命名不到它。
+
 ## 实现
 
 **头文件**：`include/pypto/ir/transforms/passes.h`

--- a/docs/zh/dev/passes/13-flatten_tile_nd_to_2d.md
+++ b/docs/zh/dev/passes/13-flatten_tile_nd_to_2d.md
@@ -154,6 +154,29 @@ for c, (o,) in pl.range(0, s_dim, CHUNK, init_values=(out,)):
 如果一个 >2D tile 到达本 Pass 时**物理形状是动态的**（用户没切静态 chunk），它无法展平,Pass 会抛出可操作的
 报错,指向两种修法:用 `pl.range`/`pl.parallel` 对动态维分块,或在进入 InCore（`pl.at`）作用域前 reshape 为 2D。
 
+## 循环携带值的 valid_shape 修复
+
+当 `tile.batch_matmul` 的左操作数带着被收窄的 `valid_shape` 时，展开后得到的 2D matmul
+结果比它流入的累加器更窄。而累加器所经过的循环携带值**只按其初值定型**，因此它仍然宣称
+种子那个没有任何 `mad` 写满过的完整盒高：
+
+```text
+acc__tile      : Tile[[64, 256], INT32]                              <- pl.create_tensor 种子
+  iter_arg     : Tile[[64, 256], INT32]                              <- 按种子定型
+  yield        : Tile[[64, 256], INT32, Acc, valid=[v, 256], compact] <- 循环体实际产出
+  return_var   : Tile[[64, 256], INT32]                              <- 被强行拉回 iter_arg 的类型
+```
+
+`mad` 以 `ceil(v/16)*16` 的 N-fractal 步长把乘积写进 L0C，而相信完整盒高的读者会按物理行
+步长遍历该缓冲区，从而打乱第一个之后的每一个 N-fractal（issue #2470）。因此本 pass 在返回
+之前会对每个改写过的函数调用 `narrow_loop_carry::NarrowAccCarries`：把种子按 yield 可证明
+的范围重新声明——`tile.create(compact=True)` 加 `tile.set_validshape`，与 `AutoTileMatmulL0`
+切分 K 时构造的形式一致——并让循环体的 def-use 闭包通过算子自身的 deducer 重新定型。
+
+在这里修复而不是留给后续 pass，正是流水线可验证性的前提：否则本 pass 产出的携带值会被
+`TypeCheck` 诊断与 `AccCompactValid` 属性验证器拒绝。`ConvertTensorToTileOps` 出于同样的
+原因调用同一个 helper——2D 种子在 `tensor.matmul` 变成 `tile.matmul` 时就已经被收窄了。
+
 ## 实现
 
 **头文件**：`include/pypto/ir/transforms/passes.h`

--- a/docs/zh/dev/passes/13-flatten_tile_nd_to_2d.md
+++ b/docs/zh/dev/passes/13-flatten_tile_nd_to_2d.md
@@ -189,7 +189,7 @@ acc__tile      : Tile[[64, 256], INT32]                              <- pl.creat
 
 | 阶段 | 文件 | 职责 |
 | ---- | ---- | ---- |
-| 协调 | `src/ir/transforms/flatten_tile_nd_to_2d/pass.cpp` | 选择 InCore 函数，并按 analysis → rewrite 顺序执行 |
+| 协调 | `src/ir/transforms/flatten_tile_nd_to_2d/pass.cpp` | 选择 InCore 函数，按 analysis → rewrite 顺序执行，并修复被改写收窄的循环携带值 |
 | 分析 (analysis) | `src/ir/transforms/flatten_tile_nd_to_2d/analysis.cpp` | 只读的前置条件验证 |
 | 改写协调 | `src/ir/transforms/flatten_tile_nd_to_2d/rewrite.cpp` | 递归遍历语句并分派算子改写 |
 | 改写工具 | `src/ir/transforms/flatten_tile_nd_to_2d/rewrite_utils.cpp` | 共享形状、索引和容量辅助逻辑 |
@@ -201,7 +201,7 @@ acc__tile      : Tile[[64, 256], INT32]                              <- pl.creat
 
 **Python 绑定**：`python/bindings/modules/passes.cpp`
 
-**测试**：`tests/ut/ir/transforms/test_flatten_tile_nd_to_2d.py`、`tests/st/codegen/dsl/test_flatten_dynamic_tile_3d.py`（issue #1578 端到端）
+**测试**：`tests/ut/ir/transforms/test_flatten_tile_nd_to_2d.py`、`tests/ut/ir/transforms/test_narrow_loop_carry_valid_shape.py`（携带值修复）、`tests/st/codegen/dsl/test_flatten_dynamic_tile_3d.py`（issue #1578 端到端）
 
 ## Pass 属性
 

--- a/docs/zh/dev/passes/utils.md
+++ b/docs/zh/dev/passes/utils.md
@@ -123,3 +123,5 @@ auto used = memref_collectors::CollectUsedBasePtrs(func->body_);
 | `auto_name_utils.h` | SSA 名称生成、重命名映射、名称解析 |
 | `parent_stmt_analysis.h` | 父子语句映射 |
 | `dead_code_elimination.h` | 函数内死代码消除 |
+| `acc_init_builder.h` | `BuildAccStorage`、`BuildNarrowedAccInit` —— 声明 L0C 累加器；有效行未填满物理盒时声明为 compact |
+| `narrow_loop_carry.h` | `NarrowAccCarries` —— 把 Acc 循环携带值重新声明为其 yield 可证明的有效范围 |

--- a/include/pypto/ir/transforms/utils/acc_init_builder.h
+++ b/include/pypto/ir/transforms/utils/acc_init_builder.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#ifndef PYPTO_IR_TRANSFORMS_UTILS_ACC_INIT_BUILDER_H_
+#define PYPTO_IR_TRANSFORMS_UTILS_ACC_INIT_BUILDER_H_
+
+#include <string>
+#include <vector>
+
+#include "pypto/core/dtype.h"
+#include "pypto/ir/expr.h"
+#include "pypto/ir/span.h"
+#include "pypto/ir/stmt.h"
+
+namespace pypto {
+namespace ir {
+namespace acc_init {
+
+/// A freshly declared L0C accumulator: the statements that declare it, in
+/// order, and the value later statements should read it through.
+struct AccInit {
+  std::vector<StmtPtr> stmts;
+  VarPtr value;
+};
+
+/**
+ * @brief Declare an Acc (L0C) box, optionally packed at the valid-region pitch
+ *
+ * ``tile.create``'s deducer honors ``target_memory=Acc`` and emits the Nz TileView
+ * ``(col_major, row_major, fractal)`` a matmul result carries, so an accumulator declared here
+ * lines up structurally with the ``tile.matmul[_acc]`` values that flow into the same carry.
+ *
+ * @param shape Physical box shape (compile-time constants, as ``tile.create`` requires)
+ * @param dtype Accumulator element type
+ * @param name_hint Name for the bound Var
+ * @param span Source location to attribute the declaration to
+ * @param compact Declare the box written at ``ceil(validRow/16)*16`` rather than at its physical rows
+ * @return The ``AssignStmt`` binding the fresh box
+ */
+AssignStmtPtr BuildAccStorage(const std::vector<ExprPtr>& shape, const DataType& dtype,
+                              const std::string& name_hint, const Span& span, bool compact = false);
+
+/**
+ * @brief Declare an Acc accumulator whose valid rectangle may be narrower than its box
+ *
+ * The narrowed form is a ``tile.create`` followed by ``tile.set_validshape``. Declaring the box
+ * compact (rather than stamping the mode onto a type afterwards) is what makes the mode survive:
+ * a pass-applied refinement is discarded the moment any pass re-deduces the call, whereas the
+ * ``compact`` kwarg is re-read by the deducer. ``tile.set_validshape`` then inherits the mode onto
+ * the narrowed view without re-interpreting bytes it did not write.
+ *
+ * A box whose valid rectangle provably fills it keeps the historical single-``tile.create`` form.
+ *
+ * @param shape Physical box shape (compile-time constants)
+ * @param valid Valid extents, same rank as @p shape; row extent may be dynamic
+ * @param dtype Accumulator element type
+ * @param name_hint Name for the value the caller reads the accumulator through
+ * @param span Source location to attribute the declaration to
+ * @return The declaring statements and the value to use
+ */
+AccInit BuildNarrowedAccInit(const std::vector<ExprPtr>& shape, const std::vector<ExprPtr>& valid,
+                             const DataType& dtype, const std::string& name_hint, const Span& span);
+
+}  // namespace acc_init
+}  // namespace ir
+}  // namespace pypto
+
+#endif  // PYPTO_IR_TRANSFORMS_UTILS_ACC_INIT_BUILDER_H_

--- a/include/pypto/ir/transforms/utils/narrow_loop_carry.h
+++ b/include/pypto/ir/transforms/utils/narrow_loop_carry.h
@@ -54,6 +54,15 @@ namespace narrow_loop_carry {
  *     every ``valid_shape`` is bounded by that box, so a dynamic yield extent is already
  *     trusted to fit inside it. An init that is *itself* already narrowed is never widened
  *     on an undecidable relation.
+ *   * only where the two readings of the buffer would actually disagree
+ *     (``AccPitchesCoincide``, shared with the ``AccCompactValid`` verifier). A
+ *     single-fractal-block box packs to its physical rows whatever its valid rows, so a
+ *     ``[16, N]`` accumulator keeps the exact form it has today.
+ *   * only where the narrowed extents are visible *before* the loop. The re-declared seed
+ *     sits there, and the common spelling puts the row count next to the slice it bounds,
+ *     inside the body -- hoisting that would leave codegen with a symbol it cannot bind.
+ *     Such a carry is declined; where its pitches genuinely differ, ``AccCompactValid``
+ *     then reports it as a compile error rather than letting it corrupt data.
  *
  * @param func Function to repair (any type; only loop carries inside it are touched)
  * @return The repaired function, or @p func itself when nothing narrows

--- a/include/pypto/ir/transforms/utils/narrow_loop_carry.h
+++ b/include/pypto/ir/transforms/utils/narrow_loop_carry.h
@@ -64,6 +64,16 @@ namespace narrow_loop_carry {
  *     Such a carry is declined; where its pitches genuinely differ, ``AccCompactValid``
  *     then reports it as a compile error rather than letting it corrupt data.
  *
+ * Cost is O(N log N) in the size of the function: three linear sweeps -- a scope index, a
+ * decision pass over types, and one top-down rewrite -- over ordered-map lookups. The
+ * rewrite settles each loop's carries *before* visiting its body, so one visit types the
+ * body against the narrowed carry; deciding afterwards would re-type it a second time,
+ * and a nested carry would compound that per level.
+ *
+ * One round: a carry whose yields only narrow *because* an inner carry was repaired is
+ * decided against the types as they were, and is left alone. Nothing miscompiles -- an
+ * unrepaired pitch disagreement is what ``AccCompactValid`` rejects.
+ *
  * @param func Function to repair (any type; only loop carries inside it are touched)
  * @return The repaired function, or @p func itself when nothing narrows
  */

--- a/include/pypto/ir/transforms/utils/narrow_loop_carry.h
+++ b/include/pypto/ir/transforms/utils/narrow_loop_carry.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#ifndef PYPTO_IR_TRANSFORMS_UTILS_NARROW_LOOP_CARRY_H_
+#define PYPTO_IR_TRANSFORMS_UTILS_NARROW_LOOP_CARRY_H_
+
+#include "pypto/ir/function.h"
+
+namespace pypto {
+namespace ir {
+namespace narrow_loop_carry {
+
+/**
+ * @brief Re-declare each Acc (L0C) loop carry at the valid extent its yields prove
+ *
+ * A loop carry is typed from its init value alone: ``ConvertToSSA`` mints the ``IterArg``
+ * from the reaching definition before the loop, ``ConvertTensorToTileOps`` re-mints it
+ * from the converted seed, and both force the loop's ``return_var`` to that same type.
+ * The yields are never consulted.
+ *
+ * That is a lie whenever the body yields a narrower valid extent than the seed declares:
+ * from the second iteration on the carried value *is* the yield. For an accumulator it is
+ * also a miscompile -- ``mad`` lays its product out in L0C at an N-fractal stride of
+ * ``ceil(validRow/16)*16`` taken from the L0A operand's valid rows, while a reader that
+ * believes the seed's full height walks the buffer at the physical row pitch, scrambling
+ * every N-fractal above the first (issue #2470).
+ *
+ * Whoever narrows a matmul result inside a carry therefore has to repair the carry before
+ * it returns, or it publishes IR its own ``TypeCheck`` and ``AccCompactValid`` verifiers
+ * reject. Two passes do: ``ConvertTensorToTileOps`` (a 2D seed, narrowed the moment
+ * ``tensor.matmul`` becomes ``tile.matmul``) and ``FlattenTileNdTo2D`` (an ND seed, narrowed
+ * when ``tile.batch_matmul`` is unrolled into 2D matmuls). Both call this.
+ *
+ * The repair re-declares the *seed* -- the only place the rest of the pipeline reads a
+ * carry's type from -- through the same ``tile.create(compact=...)`` plus
+ * ``tile.set_validshape`` form ``AutoTileMatmulL0`` builds when it splits K, and re-types
+ * the body's def-use closure through the operators' own deducers.
+ *
+ * Deliberately narrow in scope:
+ *   * only **Acc** carries, where a stale extent changes the stride a reader uses. A Vec
+ *     seed may hold bytes the first iteration is entitled to read at full height.
+ *   * only a seed defined by ``tile.create``; anything else may carry bytes whose layout
+ *     this repair must not re-interpret.
+ *   * only a dimension whose yield extent is adoptable: either provably ``<=`` the extent
+ *     the init declares, or declared against an init that still fills its physical box --
+ *     every ``valid_shape`` is bounded by that box, so a dynamic yield extent is already
+ *     trusted to fit inside it. An init that is *itself* already narrowed is never widened
+ *     on an undecidable relation.
+ *
+ * @param func Function to repair (any type; only loop carries inside it are touched)
+ * @return The repaired function, or @p func itself when nothing narrows
+ */
+FunctionPtr NarrowAccCarries(const FunctionPtr& func);
+
+}  // namespace narrow_loop_carry
+}  // namespace ir
+}  // namespace pypto
+
+#endif  // PYPTO_IR_TRANSFORMS_UTILS_NARROW_LOOP_CARRY_H_

--- a/include/pypto/ir/transforms/utils/transform_utils.h
+++ b/include/pypto/ir/transforms/utils/transform_utils.h
@@ -12,12 +12,15 @@
 #ifndef PYPTO_IR_TRANSFORMS_UTILS_TRANSFORM_UTILS_H_
 #define PYPTO_IR_TRANSFORMS_UTILS_TRANSFORM_UTILS_H_
 
+#include <any>
 #include <cstddef>
 #include <cstdint>
 #include <limits>
+#include <memory>
 #include <optional>
 #include <string>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 #include "pypto/ir/expr.h"
@@ -100,6 +103,26 @@ inline CallPtr GetCallFromStmt(const StmtPtr& stmt) {
   if (auto assign = As<AssignStmt>(stmt)) return As<Call>(assign->value_);
   if (auto eval = As<EvalStmt>(stmt)) return As<Call>(eval->expr_);
   return nullptr;
+}
+
+/// Re-attach a Call's attributes to a freshly deduced Call.
+///
+/// ``OpRegistry::Create`` re-runs the operator's deducer and therefore returns a Call
+/// carrying no attributes. A pass that re-deduces a call to refresh its result type must
+/// put them back, or compiler-set semantics (dependency edges, split assignments, pipe
+/// ids, ...) silently disappear from the rebuilt node. Returns @p deduced untouched when
+/// there is nothing to carry over.
+inline CallPtr PreserveCallAttrs(const std::vector<std::pair<std::string, std::any>>& attrs,
+                                 const CallPtr& deduced) {
+  if (attrs.empty()) return deduced;
+  return std::make_shared<Call>(deduced->op_, deduced->args_, deduced->kwargs_, attrs, deduced->GetType(),
+                                deduced->span_);
+}
+
+/// Overload taking the attributes from @p original -- pass the *rebuilt* call when a
+/// mutator has already remapped what its attributes reference.
+inline CallPtr PreserveCallAttrs(const CallPtr& original, const CallPtr& deduced) {
+  return PreserveCallAttrs(original->attrs_, deduced);
 }
 
 /// Collect all AssignStmt var_ (DEF sites) from a statement tree.

--- a/src/ir/op/tile_ops/transform.cpp
+++ b/src/ir/op/tile_ops/transform.cpp
@@ -329,6 +329,20 @@ TypePtr DeduceTileReshapeType(const std::vector<ExprPtr>& args,
   tile_view.pad = source_view.pad;
   tile_view.compact = source_view.compact;
 
+  if (tile_view_semantics::ShapeExprListsEquivalent(new_shape, tile_type->shape_)) {
+    // An identity reshape does not move bytes, so it keeps the source's layout and
+    // space. Re-deriving the layout from the shape yields the space-agnostic flat
+    // default, which `NormalizeImplicitTileView` rescues only for a view that
+    // collapses -- and an Acc box that is narrowed, padded or declared compact never
+    // does, so the flat layout would stick and its reader would walk L0C as if it
+    // were a plain row-major buffer (issue #2470).
+    tile_view.blayout = source_view.blayout;
+    tile_view.slayout = source_view.slayout;
+    tile_view.fractal = source_view.fractal;
+    return std::make_shared<TileType>(new_shape, tile_type->dtype_, std::nullopt, tile_view,
+                                      tile_type->GetMemorySpace());
+  }
+
   tile_view.blayout = tile_view_semantics::InferImplicitTileLayoutFromShape(new_shape);
 
   return std::make_shared<TileType>(new_shape, tile_type->dtype_, std::nullopt, tile_view);

--- a/src/ir/op/tile_ops/transform.cpp
+++ b/src/ir/op/tile_ops/transform.cpp
@@ -330,16 +330,18 @@ TypePtr DeduceTileReshapeType(const std::vector<ExprPtr>& args,
   tile_view.compact = source_view.compact;
 
   if (tile_view_semantics::ShapeExprListsEquivalent(new_shape, tile_type->shape_)) {
-    // An identity reshape does not move bytes, so it keeps the source's layout and
-    // space. Re-deriving the layout from the shape yields the space-agnostic flat
-    // default, which `NormalizeImplicitTileView` rescues only for a view that
-    // collapses -- and an Acc box that is narrowed, padded or declared compact never
-    // does, so the flat layout would stick and its reader would walk L0C as if it
-    // were a plain row-major buffer (issue #2470).
-    tile_view.blayout = source_view.blayout;
-    tile_view.slayout = source_view.slayout;
-    tile_view.fractal = source_view.fractal;
-    return std::make_shared<TileType>(new_shape, tile_type->dtype_, std::nullopt, tile_view,
+    // An identity reshape does not move bytes, so it is a view onto the same address
+    // arithmetic: it keeps the WHOLE source view -- layout triple, `stride` and
+    // `start_offset` included -- and the source's memory space. Rebuilding the view from
+    // the shape instead yields the space-agnostic flat default, which
+    // `NormalizeImplicitTileView` rescues only for a view that collapses -- and an Acc box
+    // that is narrowed, padded or declared compact never does, so the flat layout would
+    // stick and its reader would walk L0C as if it were a plain row-major buffer
+    // (issue #2470). Dropping an explicit `stride` / `start_offset` would relocate a
+    // strided sub-view outright.
+    TileView identity_view = source_view;
+    identity_view.valid_shape = tile_view.valid_shape;
+    return std::make_shared<TileType>(new_shape, tile_type->dtype_, std::nullopt, identity_view,
                                       tile_type->GetMemorySpace());
   }
 

--- a/src/ir/transforms/auto_tile_matmul_l0_pass.cpp
+++ b/src/ir/transforms/auto_tile_matmul_l0_pass.cpp
@@ -189,6 +189,7 @@
 #include "pypto/ir/transforms/pass_context.h"
 #include "pypto/ir/transforms/pass_properties.h"
 #include "pypto/ir/transforms/passes.h"
+#include "pypto/ir/transforms/utils/acc_init_builder.h"
 #include "pypto/ir/transforms/utils/attrs.h"
 #include "pypto/ir/transforms/utils/auto_name_utils.h"
 #include "pypto/ir/transforms/utils/deep_clone_utils.h"
@@ -374,67 +375,34 @@ using DirectDefMap = std::unordered_map<const Var*, AssignStmtPtr>;
 /// chain structurally consistent with the per-iter ``tile.matmul[_acc]``
 /// outputs, so subsequent matmul_acc consumers (and any nested for-loops
 /// initialised from this return_var) still see an Acc-typed accumulator and
-/// can be tiled in turn.  ``tile.create``'s deduce_type honors ``Acc`` and
-/// emits the Nz TileView ``(col_major, row_major, fractal=1024)`` that
-/// matches matmul output, so iter_arg/yield TileViews line up.
+/// can be tiled in turn.
 AssignStmtPtr BuildAccInit(int64_t m, int64_t n, const DataType& dtype, const std::string& name_hint,
                            const Span& span, bool compact = false) {
-  auto& reg = OpRegistry::GetInstance();
-  std::vector<std::pair<std::string, std::any>> kwargs = {{"dtype", dtype},
-                                                          {"target_memory", MemorySpace::Acc}};
-  if (compact) {
-    kwargs.emplace_back("compact", true);
-  }
-  auto call = reg.Create("tile.create", {MakeIndexTuple({m, n}, span)}, kwargs, span);
-  auto var = std::make_shared<Var>(name_hint, call->GetType(), span);
-  return std::make_shared<AssignStmt>(var, call, span);
+  return acc_init::BuildAccStorage({MakeIndex(m, span), MakeIndex(n, span)}, dtype, name_hint, span,
+                                   compact);
 }
 
-struct AccInitValue {
-  std::vector<StmtPtr> stmts;
-  VarPtr value;
-};
+using AccInitValue = acc_init::AccInit;
+
+/// Build an Acc placeholder whose allocation may be box-padded while its valid
+/// rectangle remains the logical output tile.  Delegates to
+/// ``acc_init::BuildNarrowedAccInit``, which ``narrow_loop_carry`` also uses to
+/// re-declare a user-written accumulator seed once a loop proves its carry is
+/// narrower, so the two cannot drift on the compact rule.
+AccInitValue BuildAccInitWithValidShape(int64_t physical_m, int64_t physical_n, ExprPtr valid_m,
+                                        ExprPtr valid_n, const DataType& dtype, const std::string& name_hint,
+                                        const Span& span) {
+  INTERNAL_CHECK_SPAN(valid_m && valid_n, span)
+      << "Internal error: accumulator initializer requires two valid extents";
+  return acc_init::BuildNarrowedAccInit({MakeIndex(physical_m, span), MakeIndex(physical_n, span)},
+                                        {std::move(valid_m), std::move(valid_n)}, dtype, name_hint, span);
+}
 
 enum class MatmulKind {
   kFresh,
   kAccumulate,
   kBias,
 };
-
-/// Build an Acc placeholder whose allocation may be box-padded while its valid
-/// rectangle remains the logical output tile. The ordinary unpadded case keeps
-/// the historical single ``tile.create`` form byte-for-byte.
-AccInitValue BuildAccInitWithValidShape(int64_t physical_m, int64_t physical_n, ExprPtr valid_m,
-                                        ExprPtr valid_n, const DataType& dtype, const std::string& name_hint,
-                                        const Span& span) {
-  INTERNAL_CHECK_SPAN(valid_m && valid_n, span)
-      << "Internal error: accumulator initializer requires two valid extents";
-  auto valid_m_const = As<ConstInt>(valid_m);
-  auto valid_n_const = As<ConstInt>(valid_n);
-  if (valid_m_const && valid_n_const && physical_m == valid_m_const->value_ &&
-      physical_n == valid_n_const->value_) {
-    auto init = BuildAccInit(physical_m, physical_n, dtype, name_hint, span);
-    return AccInitValue{{init}, init->var_};
-  }
-
-  // Declare the buffer compact when its valid rows are not provably its physical
-  // rows -- the same predicate `StampCompactForNarrowedAccRows` applies to a
-  // matmul result, because the K-loop's own `mad` is what writes this buffer and
-  // it takes M from the L0A operand's valid rows. `tile.set_validshape` below
-  // inherits the mode, so the iter_arg, every `tile.matmul_acc` that accumulates
-  // into it (the op inherits its accumulator's compact mode) and the reader after
-  // the loop all agree with the pitch the hardware used. Leaving the seed
-  // non-compact silently skews every N-fractal above the first (#2470, #2510).
-  const bool rows_narrowed =
-      ProveValidExtentEqual(valid_m, MakeIndex(physical_m, span)) != ProofResult::kTrue;
-  auto storage = BuildAccInit(physical_m, physical_n, dtype, name_hint + "_storage", span, rows_narrowed);
-  auto& reg = OpRegistry::GetInstance();
-  auto narrowed_call =
-      reg.Create("tile.set_validshape", {storage->var_, std::move(valid_m), std::move(valid_n)}, span);
-  auto narrowed_var = std::make_shared<Var>(name_hint, narrowed_call->GetType(), span);
-  auto narrowed = std::make_shared<AssignStmt>(narrowed_var, narrowed_call, span);
-  return AccInitValue{{storage, narrowed}, narrowed_var};
-}
 
 struct KLoopRewrite {
   AssignStmtPtr original;

--- a/src/ir/transforms/auto_tile_matmul_l0_pass.cpp
+++ b/src/ir/transforms/auto_tile_matmul_l0_pass.cpp
@@ -205,6 +205,8 @@ namespace ir {
 
 namespace {
 
+using transform_utils::PreserveCallAttrs;
+
 constexpr const char* kPassName = "AutoTileMatmulL0";
 
 ExprPtr MakeIndex(int64_t v, const Span& span) {
@@ -1399,17 +1401,6 @@ class SubtilePlacer {
   [[nodiscard]] virtual VarPtr PlaceAt(std::vector<StmtPtr>& stmts, const VarPtr& sub, const ExprPtr& row_off,
                                        const ExprPtr& col_off, const VarPtr& chain_in, int step) = 0;
 };
-
-CallPtr PreserveCallAttrs(const std::vector<std::pair<std::string, std::any>>& attrs,
-                          const CallPtr& deduced) {
-  if (attrs.empty()) return deduced;
-  return std::make_shared<Call>(deduced->op_, deduced->args_, deduced->kwargs_, attrs, deduced->GetType(),
-                                deduced->span_);
-}
-
-CallPtr PreserveCallAttrs(const CallPtr& original, const CallPtr& deduced) {
-  return PreserveCallAttrs(original->attrs_, deduced);
-}
 
 /// Direct-store placement: ``out = tile.store(sub, [base_r + mi, base_c + ni],
 /// out_prev)`` per sub-tile, chaining the DDR output tensor in SSA form.

--- a/src/ir/transforms/auto_tile_matmul_l0_pass.cpp
+++ b/src/ir/transforms/auto_tile_matmul_l0_pass.cpp
@@ -378,8 +378,7 @@ using DirectDefMap = std::unordered_map<const Var*, AssignStmtPtr>;
 /// can be tiled in turn.
 AssignStmtPtr BuildAccInit(int64_t m, int64_t n, const DataType& dtype, const std::string& name_hint,
                            const Span& span, bool compact = false) {
-  return acc_init::BuildAccStorage({MakeIndex(m, span), MakeIndex(n, span)}, dtype, name_hint, span,
-                                   compact);
+  return acc_init::BuildAccStorage({MakeIndex(m, span), MakeIndex(n, span)}, dtype, name_hint, span, compact);
 }
 
 using AccInitValue = acc_init::AccInit;

--- a/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
+++ b/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
@@ -42,6 +42,7 @@
 #include "pypto/ir/transforms/utils/attrs.h"
 #include "pypto/ir/transforms/utils/auto_name_utils.h"
 #include "pypto/ir/transforms/utils/mutable_copy.h"
+#include "pypto/ir/transforms/utils/narrow_loop_carry.h"
 #include "pypto/ir/transforms/utils/result_alias_utils.h"
 #include "pypto/ir/transforms/utils/tile_conversion_utils.h"
 #include "pypto/ir/transforms/utils/transform_utils.h"
@@ -2601,6 +2602,15 @@ Pass ConvertTensorToTileOps() {
           }
         }
       }
+    }
+
+    // A `tensor.matmul` drops its operands' valid_shape, so an accumulator only
+    // becomes narrower than the seed it is carried from once this pass turns it into
+    // a `tile.matmul` -- which re-types the yields but not the carry those yields
+    // flow through. Repair it here rather than leave a carry the TypeCheck and
+    // AccCompactValid verifiers reject (issue #2470).
+    for (auto& func : functions_phase2b) {
+      func = narrow_loop_carry::NarrowAccCarries(func);
     }
 
     return std::make_shared<Program>(functions_phase2b, program->name_, program->span_);

--- a/src/ir/transforms/flatten_tile_nd_to_2d/pass.cpp
+++ b/src/ir/transforms/flatten_tile_nd_to_2d/pass.cpp
@@ -12,6 +12,7 @@
 #include "pypto/ir/function.h"
 #include "pypto/ir/transforms/pass_properties.h"
 #include "pypto/ir/transforms/passes.h"
+#include "pypto/ir/transforms/utils/narrow_loop_carry.h"
 #include "src/ir/transforms/flatten_tile_nd_to_2d/internal.h"
 
 namespace pypto {
@@ -25,7 +26,13 @@ FunctionPtr TransformFunction(const FunctionPtr& func) {
   }
 
   flatten_tile_nd_to_2d::Analyze(func);
-  return flatten_tile_nd_to_2d::Rewrite(func);
+  auto flattened = flatten_tile_nd_to_2d::Rewrite(func);
+  // Unrolling a `tile.batch_matmul` into 2D matmuls is what first narrows an
+  // accumulator whose left operand carries a runtime valid row count, so the loop
+  // carry that accumulator flows through has to be re-declared at that extent
+  // before this pass returns -- otherwise it publishes a carry its own TypeCheck
+  // and AccCompactValid verifiers reject (issue #2470).
+  return narrow_loop_carry::NarrowAccCarries(flattened);
 }
 
 }  // namespace

--- a/src/ir/transforms/utils/acc_init_builder.cpp
+++ b/src/ir/transforms/utils/acc_init_builder.cpp
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include "pypto/ir/transforms/utils/acc_init_builder.h"
+
+#include <any>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "pypto/core/logging.h"
+#include "pypto/ir/kind_traits.h"
+#include "pypto/ir/memory_space.h"
+#include "pypto/ir/op_registry.h"
+#include "pypto/ir/type_inference.h"
+
+namespace pypto {
+namespace ir {
+namespace acc_init {
+
+AssignStmtPtr BuildAccStorage(const std::vector<ExprPtr>& shape, const DataType& dtype,
+                              const std::string& name_hint, const Span& span, bool compact) {
+  INTERNAL_CHECK_SPAN(!shape.empty(), span) << "Internal error: an Acc box needs a non-empty shape";
+  auto& reg = OpRegistry::GetInstance();
+  std::vector<std::pair<std::string, std::any>> kwargs = {{"dtype", dtype},
+                                                          {"target_memory", MemorySpace::Acc}};
+  if (compact) {
+    kwargs.emplace_back("compact", true);
+  }
+  auto call = reg.Create("tile.create", {std::make_shared<MakeTuple>(shape, span)}, kwargs, span);
+  auto var = std::make_shared<Var>(name_hint, call->GetType(), span);
+  return std::make_shared<AssignStmt>(var, call, span);
+}
+
+AccInit BuildNarrowedAccInit(const std::vector<ExprPtr>& shape, const std::vector<ExprPtr>& valid,
+                             const DataType& dtype, const std::string& name_hint, const Span& span) {
+  INTERNAL_CHECK_SPAN(shape.size() == 2 && valid.size() == 2, span)
+      << "Internal error: a narrowed Acc accumulator is 2D; got shape rank " << shape.size()
+      << " and valid rank " << valid.size();
+  INTERNAL_CHECK_SPAN(valid[0] && valid[1], span)
+      << "Internal error: accumulator initializer requires two valid extents";
+
+  // A statically full rectangle keeps the historical single-`tile.create` form.
+  auto valid_rows_const = As<ConstInt>(valid[0]);
+  auto valid_cols_const = As<ConstInt>(valid[1]);
+  auto rows_const = As<ConstInt>(shape[0]);
+  auto cols_const = As<ConstInt>(shape[1]);
+  if (valid_rows_const && valid_cols_const && rows_const && cols_const &&
+      valid_rows_const->value_ == rows_const->value_ && valid_cols_const->value_ == cols_const->value_) {
+    auto init = BuildAccStorage(shape, dtype, name_hint, span);
+    return AccInit{{init}, init->var_};
+  }
+  const bool rows_fill_box = ProveValidExtentEqual(valid[0], shape[0]) == ProofResult::kTrue;
+
+  // Declare the buffer compact when its valid rows are not provably its physical rows -- the same
+  // predicate `StampCompactForNarrowedAccRows` applies to a matmul result, because the `mad` that
+  // writes this buffer takes M from the L0A operand's valid rows. `tile.set_validshape` below
+  // inherits the mode, so the iter_arg, every `tile.matmul_acc` that accumulates into it (the op
+  // inherits its accumulator's compact mode) and the reader after the loop all agree with the pitch
+  // the hardware used. Leaving the seed non-compact silently skews every N-fractal above the first
+  // (#2470, #2510).
+  auto storage = BuildAccStorage(shape, dtype, name_hint + "_storage", span, !rows_fill_box);
+  auto& reg = OpRegistry::GetInstance();
+  auto narrowed_call = reg.Create("tile.set_validshape", {storage->var_, valid[0], valid[1]}, span);
+  auto narrowed_var = std::make_shared<Var>(name_hint, narrowed_call->GetType(), span);
+  auto narrowed = std::make_shared<AssignStmt>(narrowed_var, narrowed_call, span);
+  return AccInit{{storage, narrowed}, narrowed_var};
+}
+
+}  // namespace acc_init
+}  // namespace ir
+}  // namespace pypto

--- a/src/ir/transforms/utils/acc_init_builder.cpp
+++ b/src/ir/transforms/utils/acc_init_builder.cpp
@@ -23,6 +23,7 @@
 #include "pypto/ir/kind_traits.h"
 #include "pypto/ir/memory_space.h"
 #include "pypto/ir/op_registry.h"
+#include "pypto/ir/scalar_expr.h"
 #include "pypto/ir/span.h"
 #include "pypto/ir/stmt.h"
 #include "pypto/ir/type_inference.h"

--- a/src/ir/transforms/utils/acc_init_builder.cpp
+++ b/src/ir/transforms/utils/acc_init_builder.cpp
@@ -17,10 +17,14 @@
 #include <utility>
 #include <vector>
 
+#include "pypto/core/dtype.h"
 #include "pypto/core/logging.h"
+#include "pypto/ir/expr.h"
 #include "pypto/ir/kind_traits.h"
 #include "pypto/ir/memory_space.h"
 #include "pypto/ir/op_registry.h"
+#include "pypto/ir/span.h"
+#include "pypto/ir/stmt.h"
 #include "pypto/ir/type_inference.h"
 
 namespace pypto {

--- a/src/ir/transforms/utils/narrow_loop_carry.cpp
+++ b/src/ir/transforms/utils/narrow_loop_carry.cpp
@@ -292,30 +292,54 @@ class CarryRewriter : public IRMutator {
     auto rebuilt = IRMutator::VisitStmt_(op);
     auto assign = As<AssignStmt>(rebuilt);
     if (!assign) return rebuilt;
+    return BindResult(op, assign, RededuceIfOperandsMoved(op, assign));
+  }
 
-    // Re-deduce ONLY when an operand actually moved. A freshly deduced type is not
-    // interchangeable with the stored one -- it carries no MemRef and no resolved
-    // memory space -- so re-deducing calls this pass did not disturb would silently
-    // strip both from every tile in the program.
-    auto call = As<Call>(assign->value_);
-    if (!call || !call->op_) return rebuilt;
-    if (!OperandsMoved(op->value_, assign->value_)) return rebuilt;
+  /// The value to bind, re-deduced when this visit moved one of a call's operands.
+  ///
+  /// Re-deduce ONLY then. A freshly deduced type is not interchangeable with the stored
+  /// one -- it carries no MemRef and no resolved memory space -- so re-deducing calls this
+  /// pass did not disturb would silently strip both from every tile in the program.
+  ExprPtr RededuceIfOperandsMoved(const AssignStmtPtr& original, const AssignStmtPtr& rebuilt) {
+    auto call = As<Call>(rebuilt->value_);
+    if (!call || !call->op_) return rebuilt->value_;
+    if (!OperandsMoved(original->value_, rebuilt->value_)) return rebuilt->value_;
     // A call to a user function carries a GlobalVar, not a registered operator --
     // `OpRegistry::Create` rejects those by name, so screen them out first.
     auto& registry = OpRegistry::GetInstance();
-    if (!registry.IsRegistered(call->op_->name_)) return rebuilt;
+    if (!registry.IsRegistered(call->op_->name_)) return rebuilt->value_;
     auto deduced = registry.Create(call->op_->name_, call->args_, call->kwargs_, call->span_);
-    if (!deduced) return rebuilt;
+    if (!deduced) return rebuilt->value_;
     // Attributes come from the *rebuilt* call, whose contents this visit already remapped.
-    auto fresh = transform_utils::PreserveCallAttrs(call, deduced);
+    return transform_utils::PreserveCallAttrs(call, deduced);
+  }
 
-    const auto& old_type = assign->var_->GetType();
-    const auto& new_type = fresh->GetType();
-    if (old_type && new_type && structural_equal(old_type, new_type)) return rebuilt;
+  /// Bind an assignment's result at the type its value now carries.
+  ///
+  /// Every value shape reaches here, not only an operator call: ``alias = acc`` is a legal
+  /// SSA copy, and a mutator that rewrote only its right-hand side would leave the bound
+  /// Var at the width the carry used to have -- an asymmetry ``AssignTypeSymmetry`` and the
+  /// ``TypeCheck`` diagnostic both reject, and a dead end for the propagation, since every
+  /// later use still reads the old type through the alias.
+  ///
+  /// An assignment this visit did not touch keeps its Var, so a program the repair has no
+  /// business in comes through byte-identical.
+  StmtPtr BindResult(const AssignStmtPtr& original, const AssignStmtPtr& rebuilt, const ExprPtr& value) {
+    if (value.get() == original->value_.get()) return rebuilt;
 
-    auto new_var = std::make_shared<Var>(assign->var_->name_hint_, new_type, assign->var_->span_);
-    replaced_[op->var_.get()] = new_var;
-    return std::make_shared<AssignStmt>(new_var, fresh, assign->span_);
+    const auto& old_type = rebuilt->var_->GetType();
+    const auto& new_type = value->GetType();
+    const bool retype = new_type && (!old_type || !structural_equal(old_type, new_type));
+    if (!retype && value.get() == rebuilt->value_.get()) return rebuilt;
+
+    auto result = MutableCopy(rebuilt);  // MutableCopy so leading comments survive
+    result->value_ = value;
+    if (retype) {
+      auto new_var = std::make_shared<Var>(rebuilt->var_->name_hint_, new_type, rebuilt->var_->span_);
+      replaced_[original->var_.get()] = new_var;
+      result->var_ = new_var;
+    }
+    return result;
   }
 
   StmtPtr VisitStmt_(const IfStmtPtr& op) override {

--- a/src/ir/transforms/utils/narrow_loop_carry.cpp
+++ b/src/ir/transforms/utils/narrow_loop_carry.cpp
@@ -12,6 +12,8 @@
 /// Loop-carry valid-shape repair. See ``narrow_loop_carry.h`` for the contract and the
 /// reasoning behind the scope limits; this file is the mechanism.
 
+#include "pypto/ir/transforms/utils/narrow_loop_carry.h"
+
 #include <algorithm>
 #include <map>
 #include <memory>
@@ -30,9 +32,8 @@
 #include "pypto/ir/transforms/base/mutator.h"
 #include "pypto/ir/transforms/structural_comparison.h"
 #include "pypto/ir/transforms/utils/acc_init_builder.h"
-#include "pypto/ir/transforms/utils/mutable_copy.h"
-#include "pypto/ir/transforms/utils/narrow_loop_carry.h"
 #include "pypto/ir/transforms/utils/loop_state_repair.h"
+#include "pypto/ir/transforms/utils/mutable_copy.h"
 #include "pypto/ir/type.h"
 #include "pypto/ir/type_inference.h"
 
@@ -208,7 +209,8 @@ class RetypeClosureMutator : public IRMutator {
                             const std::vector<VarPtr>& original_return_vars) {
     const auto& iter_args = for_stmt ? for_stmt->iter_args_ : while_stmt->iter_args_;
     const auto& body = for_stmt ? for_stmt->body_ : while_stmt->body_;
-    if (iter_args.size() != original_iter_args.size()) return for_stmt ? StmtPtr(for_stmt) : StmtPtr(while_stmt);
+    if (iter_args.size() != original_iter_args.size())
+      return for_stmt ? StmtPtr(for_stmt) : StmtPtr(while_stmt);
 
     std::map<const Var*, VarPtr> carry_seed;
     std::vector<IterArgPtr> new_iter_args = iter_args;
@@ -226,16 +228,15 @@ class RetypeClosureMutator : public IRMutator {
 
     RetypeClosureMutator retyper(std::move(carry_seed));
     auto new_body = retyper.VisitStmt(body);
-    auto new_return_vars = RetypeReturnVars(new_body, for_stmt ? for_stmt->return_vars_ : while_stmt->return_vars_,
-                                            original_return_vars, this);
+    auto new_return_vars = RetypeReturnVars(
+        new_body, for_stmt ? for_stmt->return_vars_ : while_stmt->return_vars_, original_return_vars, this);
     return loop_repair::RebuildLoop(for_stmt, while_stmt, new_iter_args, new_body, new_return_vars);
   }
 
   /// Re-type a loop's ``return_vars`` from its (re-typed) yields, and publish each
   /// replacement to @p publish_to so later statements re-deduce through the new type
   /// rather than merely substituting the var.
-  static std::vector<VarPtr> RetypeReturnVars(const StmtPtr& new_body,
-                                              const std::vector<VarPtr>& return_vars,
+  static std::vector<VarPtr> RetypeReturnVars(const StmtPtr& new_body, const std::vector<VarPtr>& return_vars,
                                               const std::vector<VarPtr>& original_return_vars,
                                               RetypeClosureMutator* publish_to) {
     const auto new_yields = TrailingYieldValues(new_body);
@@ -294,13 +295,11 @@ class NarrowLoopCarryMutator : public RetypeClosureMutator {
 
   StmtPtr VisitStmt_(const ForStmtPtr& op) override {
     // Inner loops first: a nested carry may itself narrow this loop's yields.
-    return NarrowCarries(As<ForStmt>(IRMutator::VisitStmt_(op)), nullptr, op->iter_args_,
-                         op->return_vars_);
+    return NarrowCarries(As<ForStmt>(IRMutator::VisitStmt_(op)), nullptr, op->iter_args_, op->return_vars_);
   }
 
   StmtPtr VisitStmt_(const WhileStmtPtr& op) override {
-    return NarrowCarries(nullptr, As<WhileStmt>(IRMutator::VisitStmt_(op)), op->iter_args_,
-                         op->return_vars_);
+    return NarrowCarries(nullptr, As<WhileStmt>(IRMutator::VisitStmt_(op)), op->iter_args_, op->return_vars_);
   }
 
  private:

--- a/src/ir/transforms/utils/narrow_loop_carry.cpp
+++ b/src/ir/transforms/utils/narrow_loop_carry.cpp
@@ -14,7 +14,7 @@
 
 #include "pypto/ir/transforms/utils/narrow_loop_carry.h"
 
-#include <algorithm>
+#include <cstddef>
 #include <map>
 #include <memory>
 #include <optional>
@@ -22,7 +22,6 @@
 #include <utility>
 #include <vector>
 
-#include "pypto/core/logging.h"
 #include "pypto/ir/expr.h"
 #include "pypto/ir/function.h"
 #include "pypto/ir/kind_traits.h"
@@ -188,14 +187,21 @@ class RetypeClosureMutator : public IRMutator {
   }
 
   StmtPtr VisitStmt_(const ForStmtPtr& op) override {
-    return PropagateIntoLoop(As<ForStmt>(IRMutator::VisitStmt_(op)), nullptr, op->iter_args_,
+    return PropagateIntoLoop(As<ForStmt>(RebuildWithVisitedChildren(op)), nullptr, op->iter_args_,
                              op->return_vars_);
   }
 
   StmtPtr VisitStmt_(const WhileStmtPtr& op) override {
-    return PropagateIntoLoop(nullptr, As<WhileStmt>(IRMutator::VisitStmt_(op)), op->iter_args_,
+    return PropagateIntoLoop(nullptr, As<WhileStmt>(RebuildWithVisitedChildren(op)), op->iter_args_,
                              op->return_vars_);
   }
+
+  /// Visit a loop's children and rebuild it, without either level's carry handling -- the
+  /// caller applies that itself once the body is in its final shape. A named helper rather
+  /// than a qualified ``IRMutator::VisitStmt_`` call, which would read as skipping this
+  /// class's own override.
+  StmtPtr RebuildWithVisitedChildren(const ForStmtPtr& op) { return IRMutator::VisitStmt_(op); }
+  StmtPtr RebuildWithVisitedChildren(const WhileStmtPtr& op) { return IRMutator::VisitStmt_(op); }
 
   /// Carry a re-typed value across a nested loop boundary.
   ///
@@ -209,8 +215,9 @@ class RetypeClosureMutator : public IRMutator {
                             const std::vector<VarPtr>& original_return_vars) {
     const auto& iter_args = for_stmt ? for_stmt->iter_args_ : while_stmt->iter_args_;
     const auto& body = for_stmt ? for_stmt->body_ : while_stmt->body_;
-    if (iter_args.size() != original_iter_args.size())
+    if (iter_args.size() != original_iter_args.size()) {
       return for_stmt ? StmtPtr(for_stmt) : StmtPtr(while_stmt);
+    }
 
     std::map<const Var*, VarPtr> carry_seed;
     std::vector<IterArgPtr> new_iter_args = iter_args;
@@ -295,11 +302,13 @@ class NarrowLoopCarryMutator : public RetypeClosureMutator {
 
   StmtPtr VisitStmt_(const ForStmtPtr& op) override {
     // Inner loops first: a nested carry may itself narrow this loop's yields.
-    return NarrowCarries(As<ForStmt>(IRMutator::VisitStmt_(op)), nullptr, op->iter_args_, op->return_vars_);
+    return NarrowCarries(As<ForStmt>(RebuildWithVisitedChildren(op)), nullptr, op->iter_args_,
+                         op->return_vars_);
   }
 
   StmtPtr VisitStmt_(const WhileStmtPtr& op) override {
-    return NarrowCarries(nullptr, As<WhileStmt>(IRMutator::VisitStmt_(op)), op->iter_args_, op->return_vars_);
+    return NarrowCarries(nullptr, As<WhileStmt>(RebuildWithVisitedChildren(op)), op->iter_args_,
+                         op->return_vars_);
   }
 
  private:

--- a/src/ir/transforms/utils/narrow_loop_carry.cpp
+++ b/src/ir/transforms/utils/narrow_loop_carry.cpp
@@ -36,7 +36,6 @@
 #include <memory>
 #include <optional>
 #include <string>
-#include <type_traits>
 #include <utility>
 #include <vector>
 
@@ -234,7 +233,7 @@ class CarryAnalyzer : public IRVisitor {
   /// The narrowing is declined instead of moving the computation, which would need the
   /// extent to be loop-invariant and is a larger change than this repair.
   template <typename LoopPtr>
-  bool ExtentsAreVisibleBefore(const std::vector<ExprPtr>& extents, const LoopPtr& loop) const {
+  [[nodiscard]] bool ExtentsAreVisibleBefore(const std::vector<ExprPtr>& extents, const LoopPtr& loop) const {
     for (const auto& extent : extents) {
       if (!extent) continue;
       ExtentVarCollector used;

--- a/src/ir/transforms/utils/narrow_loop_carry.cpp
+++ b/src/ir/transforms/utils/narrow_loop_carry.cpp
@@ -19,6 +19,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <type_traits>
 #include <utility>
 #include <vector>
 
@@ -209,14 +210,27 @@ class RetypeClosureMutator : public IRMutator {
                                     new_return_vars, if_stmt->span_);
   }
 
-  StmtPtr VisitStmt_(const ForStmtPtr& op) override {
-    return PropagateIntoLoop(As<ForStmt>(RebuildWithVisitedChildren(op)), nullptr, op->iter_args_,
-                             op->return_vars_);
+  StmtPtr VisitStmt_(const ForStmtPtr& op) override { return VisitLoop(op); }
+
+  StmtPtr VisitStmt_(const WhileStmtPtr& op) override { return VisitLoop(op); }
+
+  /// Visit a loop's children, then carry any re-typed value across its boundary.
+  template <typename LoopPtr>
+  StmtPtr VisitLoop(const LoopPtr& op) {
+    auto rebuilt = RebuildWithVisitedChildren(op);
+    auto loop = As<std::remove_const_t<typename LoopPtr::element_type>>(rebuilt);
+    if (!loop) return rebuilt;
+    return PropagateIntoLoop(loop, op->iter_args_, op->return_vars_);
   }
 
-  StmtPtr VisitStmt_(const WhileStmtPtr& op) override {
-    return PropagateIntoLoop(nullptr, As<WhileStmt>(RebuildWithVisitedChildren(op)), op->iter_args_,
-                             op->return_vars_);
+  /// Rebuild a loop of either kind with new carry state.
+  static StmtPtr RebuildLoopLike(const ForStmtPtr& loop, const std::vector<IterArgPtr>& iter_args,
+                                 const StmtPtr& body, const std::vector<VarPtr>& return_vars) {
+    return loop_repair::RebuildForStmt(loop, iter_args, body, return_vars);
+  }
+  static StmtPtr RebuildLoopLike(const WhileStmtPtr& loop, const std::vector<IterArgPtr>& iter_args,
+                                 const StmtPtr& body, const std::vector<VarPtr>& return_vars) {
+    return loop_repair::RebuildWhileStmt(loop, iter_args, body, return_vars);
   }
 
   /// Visit a loop's children and rebuild it, without either level's carry handling -- the
@@ -232,14 +246,13 @@ class RetypeClosureMutator : public IRMutator {
   /// everything the nested body deduced from it — at the old type. Re-mint the iter_arg
   /// from its new init and re-run the closure through the nested body, exactly as the
   /// outer narrowing does; the loop's own results then follow its re-typed yields.
-  StmtPtr PropagateIntoLoop(const std::shared_ptr<const ForStmt>& for_stmt,
-                            const std::shared_ptr<const WhileStmt>& while_stmt,
-                            const std::vector<IterArgPtr>& original_iter_args,
+  template <typename LoopPtr>
+  StmtPtr PropagateIntoLoop(const LoopPtr& loop, const std::vector<IterArgPtr>& original_iter_args,
                             const std::vector<VarPtr>& original_return_vars) {
-    const auto& iter_args = for_stmt ? for_stmt->iter_args_ : while_stmt->iter_args_;
-    const auto& body = for_stmt ? for_stmt->body_ : while_stmt->body_;
+    const auto& iter_args = loop->iter_args_;
+    const auto& body = loop->body_;
     if (iter_args.size() != original_iter_args.size()) {
-      return for_stmt ? StmtPtr(for_stmt) : StmtPtr(while_stmt);
+      return loop;
     }
 
     std::map<const Var*, VarPtr> carry_seed;
@@ -254,13 +267,12 @@ class RetypeClosureMutator : public IRMutator {
       new_iter_args[i] = new_iter_arg;
       carry_seed[static_cast<const Var*>(original_iter_args[i].get())] = new_iter_arg;
     }
-    if (carry_seed.empty()) return for_stmt ? StmtPtr(for_stmt) : StmtPtr(while_stmt);
+    if (carry_seed.empty()) return loop;
 
     RetypeClosureMutator retyper(std::move(carry_seed));
     auto new_body = retyper.VisitStmt(body);
-    auto new_return_vars = RetypeReturnVars(
-        new_body, for_stmt ? for_stmt->return_vars_ : while_stmt->return_vars_, original_return_vars, this);
-    return loop_repair::RebuildLoop(for_stmt, while_stmt, new_iter_args, new_body, new_return_vars);
+    auto new_return_vars = RetypeReturnVars(new_body, loop->return_vars_, original_return_vars, this);
+    return RebuildLoopLike(loop, new_iter_args, new_body, new_return_vars);
   }
 
   /// Re-type a loop's ``return_vars`` from its (re-typed) yields, and publish each
@@ -323,34 +335,34 @@ class NarrowLoopCarryMutator : public RetypeClosureMutator {
     return std::make_shared<SeqStmts>(out, op->span_);
   }
 
-  StmtPtr VisitStmt_(const ForStmtPtr& op) override {
-    // Inner loops first: a nested carry may itself narrow this loop's yields.
-    return NarrowCarries(As<ForStmt>(RebuildWithVisitedChildren(op)), nullptr, op->iter_args_,
-                         op->return_vars_);
-  }
+  StmtPtr VisitStmt_(const ForStmtPtr& op) override { return VisitLoopAndNarrow(op); }
 
-  StmtPtr VisitStmt_(const WhileStmtPtr& op) override {
-    return NarrowCarries(nullptr, As<WhileStmt>(RebuildWithVisitedChildren(op)), op->iter_args_,
-                         op->return_vars_);
-  }
+  StmtPtr VisitStmt_(const WhileStmtPtr& op) override { return VisitLoopAndNarrow(op); }
 
  private:
-  StmtPtr NarrowCarries(const std::shared_ptr<const ForStmt>& for_stmt,
-                        const std::shared_ptr<const WhileStmt>& while_stmt,
-                        const std::vector<IterArgPtr>& original_iter_args,
+  /// Visit a loop's children, then re-declare every Acc carry the body proves narrower.
+  template <typename LoopPtr>
+  StmtPtr VisitLoopAndNarrow(const LoopPtr& op) {
+    // Inner loops first: a nested carry may itself narrow this loop's yields.
+    auto rebuilt = RebuildWithVisitedChildren(op);
+    auto loop = As<std::remove_const_t<typename LoopPtr::element_type>>(rebuilt);
+    if (!loop) return rebuilt;
+    return NarrowCarries(loop, op->iter_args_, op->return_vars_);
+  }
+
+  template <typename LoopPtr>
+  StmtPtr NarrowCarries(const LoopPtr& loop, const std::vector<IterArgPtr>& original_iter_args,
                         const std::vector<VarPtr>& original_return_vars) {
-    StmtPtr visited = for_stmt ? StmtPtr(for_stmt) : StmtPtr(while_stmt);
-    if (!for_stmt && !while_stmt) return visited;
-    const auto& iter_args = for_stmt ? for_stmt->iter_args_ : while_stmt->iter_args_;
-    const auto& body = for_stmt ? for_stmt->body_ : while_stmt->body_;
-    const auto& return_vars = for_stmt ? for_stmt->return_vars_ : while_stmt->return_vars_;
+    const auto& iter_args = loop->iter_args_;
+    const auto& body = loop->body_;
+    const auto& return_vars = loop->return_vars_;
     if (iter_args.empty() || iter_args.size() != original_iter_args.size()) {
-      return PropagateIntoLoop(for_stmt, while_stmt, original_iter_args, original_return_vars);
+      return PropagateIntoLoop(loop, original_iter_args, original_return_vars);
     }
 
     const auto yields = TrailingYieldValues(body);
     if (yields.size() != iter_args.size()) {
-      return PropagateIntoLoop(for_stmt, while_stmt, original_iter_args, original_return_vars);
+      return PropagateIntoLoop(loop, original_iter_args, original_return_vars);
     }
 
     std::vector<StmtPtr> prologue;
@@ -382,13 +394,13 @@ class NarrowLoopCarryMutator : public RetypeClosureMutator {
       carry_seed[static_cast<const Var*>(original_iter_args[i].get())] = new_iter_arg;
     }
     if (carry_seed.empty()) {
-      return PropagateIntoLoop(for_stmt, while_stmt, original_iter_args, original_return_vars);
+      return PropagateIntoLoop(loop, original_iter_args, original_return_vars);
     }
 
     RetypeClosureMutator retyper(std::move(carry_seed));
     auto new_body = retyper.VisitStmt(body);
     auto new_return_vars = RetypeReturnVars(new_body, return_vars, original_return_vars, this);
-    auto new_loop = loop_repair::RebuildLoop(for_stmt, while_stmt, new_iter_args, new_body, new_return_vars);
+    auto new_loop = RebuildLoopLike(loop, new_iter_args, new_body, new_return_vars);
     if (prologue.empty()) return new_loop;
     prologue.push_back(new_loop);
     return std::make_shared<SeqStmts>(prologue, new_loop->span_);

--- a/src/ir/transforms/utils/narrow_loop_carry.cpp
+++ b/src/ir/transforms/utils/narrow_loop_carry.cpp
@@ -33,6 +33,7 @@
 #include "pypto/ir/transforms/utils/acc_init_builder.h"
 #include "pypto/ir/transforms/utils/loop_state_repair.h"
 #include "pypto/ir/transforms/utils/mutable_copy.h"
+#include "pypto/ir/transforms/utils/var_collectors.h"
 #include "pypto/ir/type.h"
 #include "pypto/ir/type_inference.h"
 
@@ -85,6 +86,28 @@ std::optional<std::vector<ExprPtr>> NarrowedValidShape(const TileTypePtr& init_t
     any = true;
   }
   return any ? std::optional<std::vector<ExprPtr>>{std::move(narrowed)} : std::nullopt;
+}
+
+/// Whether every var the extents name is defined outside @p body.
+///
+/// The re-declared seed sits *before* the loop, so an extent computed inside the body
+/// cannot be named there. `pl.min(M_TILE, t_dim - t0)` written next to the slice it
+/// bounds is the common spelling of exactly that, and hoisting it would leave codegen
+/// with a symbol it cannot bind to a dimension, a scalar parameter, or a loop variable.
+/// The narrowing is declined instead of moving the computation, which would need the
+/// extent to be loop-invariant and is a larger change than this repair.
+bool ExtentsAreVisibleBeforeLoop(const std::vector<ExprPtr>& extents, const StmtPtr& body) {
+  var_collectors::VarDefUseCollector body_defs;
+  body_defs.VisitStmt(body);
+  for (const auto& extent : extents) {
+    if (!extent) continue;
+    var_collectors::VarDefUseCollector extent_vars;
+    extent_vars.VisitExpr(extent);
+    for (const auto* used : extent_vars.var_uses) {
+      if (body_defs.var_defs.count(used) > 0) return false;
+    }
+  }
+  return true;
 }
 
 /// Re-type the def-use closure of a set of re-typed vars.
@@ -342,6 +365,13 @@ class NarrowLoopCarryMutator : public RetypeClosureMutator {
       // Only an L0C carry is re-declared, and `tile.set_validshape` is 2D.
       if (narrowed->size() != 2) continue;
       if (yield_tile->GetMemorySpace() != MemorySpace::Acc) continue;
+      // Nothing to reconcile when both readings of the buffer land on the same pitch --
+      // notably a single-fractal-block box, where `ceil(validRow/16)*16` is the physical
+      // row count whatever the valid rows are. The same predicate `AccCompactValid` uses,
+      // so a carry this declines is also a carry the verifier does not ask about, and a
+      // `[16, N]` accumulator keeps the exact form it has today.
+      if (AccPitchesCoincide(narrowed->at(0), init_tile->shape_[0])) continue;
+      if (!ExtentsAreVisibleBeforeLoop(*narrowed, body)) continue;
 
       auto narrowed_init = BuildNarrowedInit(iter_arg->initValue_, init_tile, *narrowed, &prologue);
       if (!narrowed_init) continue;

--- a/src/ir/transforms/utils/narrow_loop_carry.cpp
+++ b/src/ir/transforms/utils/narrow_loop_carry.cpp
@@ -1,0 +1,400 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/// Loop-carry valid-shape repair. See ``narrow_loop_carry.h`` for the contract and the
+/// reasoning behind the scope limits; this file is the mechanism.
+
+#include <algorithm>
+#include <map>
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "pypto/core/logging.h"
+#include "pypto/ir/expr.h"
+#include "pypto/ir/function.h"
+#include "pypto/ir/kind_traits.h"
+#include "pypto/ir/memory_space.h"
+#include "pypto/ir/op_registry.h"
+#include "pypto/ir/stmt.h"
+#include "pypto/ir/transforms/base/mutator.h"
+#include "pypto/ir/transforms/structural_comparison.h"
+#include "pypto/ir/transforms/utils/acc_init_builder.h"
+#include "pypto/ir/transforms/utils/mutable_copy.h"
+#include "pypto/ir/transforms/utils/narrow_loop_carry.h"
+#include "pypto/ir/transforms/utils/loop_state_repair.h"
+#include "pypto/ir/type.h"
+#include "pypto/ir/type_inference.h"
+
+namespace pypto {
+namespace ir {
+namespace narrow_loop_carry {
+
+namespace {
+
+/// Values of the statement list's terminating ``YieldStmt``, if it has one.
+std::vector<ExprPtr> TrailingYieldValues(const StmtPtr& body) {
+  if (auto seq = As<SeqStmts>(body)) {
+    if (seq->stmts_.empty()) return {};
+    if (auto yield = As<YieldStmt>(seq->stmts_.back())) return yield->value_;
+    return {};
+  }
+  if (auto direct = As<YieldStmt>(body)) return direct->value_;
+  return {};
+}
+
+/// The valid extents a carry should be declared at: per axis, the yield's extent when it
+/// is adoptable (see the comment on the loop below), else the init's. ``std::nullopt``
+/// when no axis narrows.
+std::optional<std::vector<ExprPtr>> NarrowedValidShape(const TileTypePtr& init_type,
+                                                       const TileTypePtr& yield_type) {
+  if (!init_type || !yield_type) return std::nullopt;
+  if (init_type->shape_.size() != yield_type->shape_.size()) return std::nullopt;
+
+  const auto init_valid = GetValidShape(init_type);
+  const auto yield_valid = GetValidShape(yield_type);
+  if (init_valid.size() != yield_valid.size()) return std::nullopt;
+
+  std::vector<ExprPtr> narrowed = init_valid;
+  bool any = false;
+  for (size_t i = 0; i < init_valid.size(); ++i) {
+    if (ProveValidExtentEqual(yield_valid[i], init_valid[i]) == ProofResult::kTrue) continue;
+    // A yield extent is adoptable when it is provably no wider than the one declared --
+    // or when the declared one is the whole box, because every valid_shape is bounded by
+    // its physical shape (`ValidateValidShapeBounds`), so a dynamic yield extent is
+    // already trusted to fit. Without the second case an unconstrained runtime row count
+    // (`v` rather than `min(v, rows)`) would never be adoptable, which is precisely the
+    // shape that reaches a matmul from `pl.slice(..., valid_shape=[v, ...])`.
+    const bool init_fills_the_box =
+        ProveValidExtentEqual(init_valid[i], init_type->shape_[i]) == ProofResult::kTrue;
+    if (!init_fills_the_box &&
+        ProveValidExtentLessEqual(yield_valid[i], init_valid[i]) != ProofResult::kTrue) {
+      continue;
+    }
+    narrowed[i] = yield_valid[i];
+    any = true;
+  }
+  return any ? std::optional<std::vector<ExprPtr>>{std::move(narrowed)} : std::nullopt;
+}
+
+/// Re-type the def-use closure of a set of re-typed vars.
+///
+/// Every rebuilt ``Call`` goes back through ``OpRegistry::Create``, so the operator's own
+/// deducer supplies the new result type — this repair never invents one. A result whose
+/// re-deduced type is unchanged stops the propagation there.
+///
+/// A ``Submit`` value is substituted like any other expression but never re-deduced: it
+/// launches a user function rather than an operator, and it lives in a ``manual_scope`` at
+/// orchestration level, where no Acc tile carry can reach it.
+class RetypeClosureMutator : public IRMutator {
+ public:
+  RetypeClosureMutator() = default;
+  explicit RetypeClosureMutator(std::map<const Var*, VarPtr> seed) : replaced_(std::move(seed)) {}
+
+  /// Register a var whose type moved, so later statements re-deduce through it.
+  void RecordReplacement(const Var* old_var, const VarPtr& new_var) { replaced_[old_var] = new_var; }
+
+ protected:
+  /// Whether visiting rewrote any operand of this call — i.e. whether the value is
+  /// downstream of a var this pass re-typed.
+  static bool OperandsMoved(const ExprPtr& before, const ExprPtr& after) {
+    auto old_call = As<Call>(before);
+    auto new_call = As<Call>(after);
+    if (!old_call || !new_call) return false;
+    if (old_call->args_.size() != new_call->args_.size()) return true;
+    for (size_t i = 0; i < old_call->args_.size(); ++i) {
+      if (old_call->args_[i].get() != new_call->args_[i].get()) return true;
+    }
+    return false;
+  }
+
+  ExprPtr VisitExpr_(const VarPtr& op) override {
+    auto it = replaced_.find(op.get());
+    return it == replaced_.end() ? IRMutator::VisitExpr_(op) : it->second;
+  }
+
+  ExprPtr VisitExpr_(const IterArgPtr& op) override {
+    auto it = replaced_.find(static_cast<const Var*>(op.get()));
+    return it == replaced_.end() ? IRMutator::VisitExpr_(op) : it->second;
+  }
+
+  StmtPtr VisitStmt_(const AssignStmtPtr& op) override {
+    auto rebuilt = IRMutator::VisitStmt_(op);
+    auto assign = As<AssignStmt>(rebuilt);
+    if (!assign) return rebuilt;
+
+    // Re-deduce ONLY when an operand actually moved. A freshly deduced type is not
+    // interchangeable with the stored one — it carries no MemRef and no resolved
+    // memory space — so re-deducing calls this pass did not disturb would silently
+    // strip both from every tile in the program.
+    auto call = As<Call>(assign->value_);
+    if (!call || !call->op_) return rebuilt;
+    if (!OperandsMoved(op->value_, assign->value_)) return rebuilt;
+    // A call to a user function carries a GlobalVar, not a registered operator —
+    // `OpRegistry::Create` rejects those by name, so screen them out first.
+    auto& registry = OpRegistry::GetInstance();
+    if (!registry.IsRegistered(call->op_->name_)) return rebuilt;
+    auto fresh = registry.Create(call->op_->name_, call->args_, call->kwargs_, call->span_);
+    if (!fresh) return rebuilt;
+
+    const auto& old_type = assign->var_->GetType();
+    const auto& new_type = fresh->GetType();
+    if (old_type && new_type && structural_equal(old_type, new_type)) return rebuilt;
+
+    auto new_var = std::make_shared<Var>(assign->var_->name_hint_, new_type, assign->var_->span_);
+    replaced_[op->var_.get()] = new_var;
+    return std::make_shared<AssignStmt>(new_var, fresh, assign->span_);
+  }
+
+  StmtPtr VisitStmt_(const IfStmtPtr& op) override {
+    auto rebuilt = IRMutator::VisitStmt_(op);
+    auto if_stmt = As<IfStmt>(rebuilt);
+    if (!if_stmt || if_stmt->return_vars_.empty()) return rebuilt;
+
+    // A phi is typed from the then branch (ConvertTensorToTileOps and the DSL parser
+    // agree on that), so follow it there rather than inventing a merge.
+    const auto then_yield = TrailingYieldValues(if_stmt->then_body_);
+    if (then_yield.size() != if_stmt->return_vars_.size()) return rebuilt;
+
+    std::vector<VarPtr> new_return_vars;
+    new_return_vars.reserve(if_stmt->return_vars_.size());
+    bool changed = false;
+    for (size_t i = 0; i < if_stmt->return_vars_.size(); ++i) {
+      const auto& rv = if_stmt->return_vars_[i];
+      const auto& yield_type = then_yield[i]->GetType();
+      if (!yield_type || (rv->GetType() && structural_equal(rv->GetType(), yield_type))) {
+        new_return_vars.push_back(rv);
+        continue;
+      }
+      auto new_rv = std::make_shared<Var>(rv->name_hint_, yield_type, rv->span_);
+      replaced_[op->return_vars_[i].get()] = new_rv;
+      new_return_vars.push_back(new_rv);
+      changed = true;
+    }
+    if (!changed) return rebuilt;
+    return std::make_shared<IfStmt>(if_stmt->condition_, if_stmt->then_body_, if_stmt->else_body_,
+                                    new_return_vars, if_stmt->span_);
+  }
+
+  StmtPtr VisitStmt_(const ForStmtPtr& op) override {
+    return PropagateIntoLoop(As<ForStmt>(IRMutator::VisitStmt_(op)), nullptr, op->iter_args_,
+                             op->return_vars_);
+  }
+
+  StmtPtr VisitStmt_(const WhileStmtPtr& op) override {
+    return PropagateIntoLoop(nullptr, As<WhileStmt>(IRMutator::VisitStmt_(op)), op->iter_args_,
+                             op->return_vars_);
+  }
+
+  /// Carry a re-typed value across a nested loop boundary.
+  ///
+  /// Substituting the init value alone leaves the nested ``IterArg`` — and therefore
+  /// everything the nested body deduced from it — at the old type. Re-mint the iter_arg
+  /// from its new init and re-run the closure through the nested body, exactly as the
+  /// outer narrowing does; the loop's own results then follow its re-typed yields.
+  StmtPtr PropagateIntoLoop(const std::shared_ptr<const ForStmt>& for_stmt,
+                            const std::shared_ptr<const WhileStmt>& while_stmt,
+                            const std::vector<IterArgPtr>& original_iter_args,
+                            const std::vector<VarPtr>& original_return_vars) {
+    const auto& iter_args = for_stmt ? for_stmt->iter_args_ : while_stmt->iter_args_;
+    const auto& body = for_stmt ? for_stmt->body_ : while_stmt->body_;
+    if (iter_args.size() != original_iter_args.size()) return for_stmt ? StmtPtr(for_stmt) : StmtPtr(while_stmt);
+
+    std::map<const Var*, VarPtr> carry_seed;
+    std::vector<IterArgPtr> new_iter_args = iter_args;
+    for (size_t i = 0; i < iter_args.size(); ++i) {
+      const auto& iter_arg = iter_args[i];
+      const auto& init = iter_arg->initValue_;
+      if (!init || !init->GetType()) continue;
+      if (iter_arg->GetType() && structural_equal(iter_arg->GetType(), init->GetType())) continue;
+      auto new_iter_arg =
+          std::make_shared<IterArg>(iter_arg->name_hint_, init->GetType(), init, iter_arg->span_);
+      new_iter_args[i] = new_iter_arg;
+      carry_seed[static_cast<const Var*>(original_iter_args[i].get())] = new_iter_arg;
+    }
+    if (carry_seed.empty()) return for_stmt ? StmtPtr(for_stmt) : StmtPtr(while_stmt);
+
+    RetypeClosureMutator retyper(std::move(carry_seed));
+    auto new_body = retyper.VisitStmt(body);
+    auto new_return_vars = RetypeReturnVars(new_body, for_stmt ? for_stmt->return_vars_ : while_stmt->return_vars_,
+                                            original_return_vars, this);
+    return loop_repair::RebuildLoop(for_stmt, while_stmt, new_iter_args, new_body, new_return_vars);
+  }
+
+  /// Re-type a loop's ``return_vars`` from its (re-typed) yields, and publish each
+  /// replacement to @p publish_to so later statements re-deduce through the new type
+  /// rather than merely substituting the var.
+  static std::vector<VarPtr> RetypeReturnVars(const StmtPtr& new_body,
+                                              const std::vector<VarPtr>& return_vars,
+                                              const std::vector<VarPtr>& original_return_vars,
+                                              RetypeClosureMutator* publish_to) {
+    const auto new_yields = TrailingYieldValues(new_body);
+    std::vector<VarPtr> new_return_vars = return_vars;
+    if (new_yields.size() != return_vars.size() || original_return_vars.size() != return_vars.size()) {
+      return new_return_vars;
+    }
+    for (size_t i = 0; i < return_vars.size(); ++i) {
+      const auto& rv = return_vars[i];
+      const auto& yield_type = new_yields[i]->GetType();
+      if (!yield_type || (rv->GetType() && structural_equal(rv->GetType(), yield_type))) continue;
+      auto new_rv = std::make_shared<Var>(rv->name_hint_, yield_type, rv->span_);
+      new_return_vars[i] = new_rv;
+      publish_to->RecordReplacement(original_return_vars[i].get(), new_rv);
+    }
+    return new_return_vars;
+  }
+
+ private:
+  std::map<const Var*, VarPtr> replaced_;
+};
+
+class NarrowLoopCarryMutator : public RetypeClosureMutator {
+ protected:
+  StmtPtr VisitStmt_(const AssignStmtPtr& op) override {
+    // A Var does not carry its defining expression, so remember it: the seed of a carry
+    // is a Var whose definition is the `tile.create` this pass re-declares.
+    if (auto call = As<Call>(op->value_)) defs_[op->var_.get()] = call;
+    return RetypeClosureMutator::VisitStmt_(op);
+  }
+
+  /// Splice a rewritten loop's prologue into the enclosing statement list, so the
+  /// re-declared seed is a sibling of the loop rather than a nested ``SeqStmts``.
+  StmtPtr VisitStmt_(const SeqStmtsPtr& op) override {
+    std::vector<StmtPtr> out;
+    out.reserve(op->stmts_.size());
+    bool changed = false;
+    for (const auto& stmt : op->stmts_) {
+      auto visited = VisitStmt(stmt);
+      if (!visited) {
+        changed = true;
+        continue;
+      }
+      auto expanded = As<SeqStmts>(visited);
+      if (expanded && !As<SeqStmts>(stmt)) {
+        out.insert(out.end(), expanded->stmts_.begin(), expanded->stmts_.end());
+        changed = true;
+        continue;
+      }
+      if (visited.get() != stmt.get()) changed = true;
+      out.push_back(visited);
+    }
+    if (!changed) return op;
+    return std::make_shared<SeqStmts>(out, op->span_);
+  }
+
+  StmtPtr VisitStmt_(const ForStmtPtr& op) override {
+    // Inner loops first: a nested carry may itself narrow this loop's yields.
+    return NarrowCarries(As<ForStmt>(IRMutator::VisitStmt_(op)), nullptr, op->iter_args_,
+                         op->return_vars_);
+  }
+
+  StmtPtr VisitStmt_(const WhileStmtPtr& op) override {
+    return NarrowCarries(nullptr, As<WhileStmt>(IRMutator::VisitStmt_(op)), op->iter_args_,
+                         op->return_vars_);
+  }
+
+ private:
+  StmtPtr NarrowCarries(const std::shared_ptr<const ForStmt>& for_stmt,
+                        const std::shared_ptr<const WhileStmt>& while_stmt,
+                        const std::vector<IterArgPtr>& original_iter_args,
+                        const std::vector<VarPtr>& original_return_vars) {
+    StmtPtr visited = for_stmt ? StmtPtr(for_stmt) : StmtPtr(while_stmt);
+    if (!for_stmt && !while_stmt) return visited;
+    const auto& iter_args = for_stmt ? for_stmt->iter_args_ : while_stmt->iter_args_;
+    const auto& body = for_stmt ? for_stmt->body_ : while_stmt->body_;
+    const auto& return_vars = for_stmt ? for_stmt->return_vars_ : while_stmt->return_vars_;
+    if (iter_args.empty() || iter_args.size() != original_iter_args.size()) {
+      return PropagateIntoLoop(for_stmt, while_stmt, original_iter_args, original_return_vars);
+    }
+
+    const auto yields = TrailingYieldValues(body);
+    if (yields.size() != iter_args.size()) {
+      return PropagateIntoLoop(for_stmt, while_stmt, original_iter_args, original_return_vars);
+    }
+
+    std::vector<StmtPtr> prologue;
+    std::map<const Var*, VarPtr> carry_seed;
+    std::vector<IterArgPtr> new_iter_args = iter_args;
+    for (size_t i = 0; i < iter_args.size(); ++i) {
+      const auto& iter_arg = iter_args[i];
+      auto init_tile = As<TileType>(iter_arg->GetType());
+      auto yield_tile = As<TileType>(yields[i]->GetType());
+      auto narrowed = NarrowedValidShape(init_tile, yield_tile);
+      if (!narrowed) continue;
+      // Only an L0C carry is re-declared, and `tile.set_validshape` is 2D.
+      if (narrowed->size() != 2) continue;
+      if (yield_tile->GetMemorySpace() != MemorySpace::Acc) continue;
+
+      auto narrowed_init = BuildNarrowedInit(iter_arg->initValue_, init_tile, *narrowed, &prologue);
+      if (!narrowed_init) continue;
+
+      auto new_iter_arg = std::make_shared<IterArg>(iter_arg->name_hint_, narrowed_init->GetType(),
+                                                    narrowed_init, iter_arg->span_);
+      new_iter_args[i] = new_iter_arg;
+      carry_seed[static_cast<const Var*>(original_iter_args[i].get())] = new_iter_arg;
+    }
+    if (carry_seed.empty()) {
+      return PropagateIntoLoop(for_stmt, while_stmt, original_iter_args, original_return_vars);
+    }
+
+    RetypeClosureMutator retyper(std::move(carry_seed));
+    auto new_body = retyper.VisitStmt(body);
+    auto new_return_vars = RetypeReturnVars(new_body, return_vars, original_return_vars, this);
+    auto new_loop = loop_repair::RebuildLoop(for_stmt, while_stmt, new_iter_args, new_body, new_return_vars);
+    if (prologue.empty()) return new_loop;
+    prologue.push_back(new_loop);
+    return std::make_shared<SeqStmts>(prologue, new_loop->span_);
+  }
+
+  /// Re-declare a ``tile.create`` seed with the narrowed valid shape.
+  ///
+  /// The seed is rebuilt at its *declaration* rather than aliased through
+  /// ``tile.set_validshape`` alone: that op inherits its source's compact mode, which is
+  /// right for a tile whose bytes may already be written but would leave a fresh
+  /// accumulator advertising the physical row pitch. Declaring the box lets
+  /// ``tile.create``'s own deducer derive the Acc layout for the box it declares.
+  /// Returns null when the init is not a ``tile.create`` this pass can re-declare.
+  ExprPtr BuildNarrowedInit(const ExprPtr& init, const TileTypePtr& init_tile,
+                            const std::vector<ExprPtr>& valid, std::vector<StmtPtr>* prologue) const {
+    auto init_var = AsVarLike(init);
+    if (!init_var) return nullptr;
+    auto def = defs_.find(init_var.get());
+    if (def == defs_.end()) return nullptr;
+    if (!IsOp(def->second, "tile.create")) return nullptr;
+
+    auto narrowed = acc_init::BuildNarrowedAccInit(init_tile->shape_, valid, init_tile->dtype_,
+                                                   init_var->name_hint_ + "_narrowed", init->span_);
+    for (auto& stmt : narrowed.stmts) prologue->push_back(std::move(stmt));
+    return narrowed.value;
+  }
+
+  /// Defining call of each assigned Var, so a carry's seed can be traced back to the
+  /// ``tile.create`` that declared it.
+  std::map<const Var*, CallPtr> defs_;
+};
+
+}  // namespace
+
+FunctionPtr NarrowAccCarries(const FunctionPtr& func) {
+  if (!func || !func->body_) return func;
+  NarrowLoopCarryMutator mutator;
+  auto new_body = mutator.VisitStmt(func->body_);
+  if (new_body.get() == func->body_.get()) return func;
+  auto new_func = MutableCopy(func);
+  new_func->body_ = new_body;
+  return new_func;
+}
+
+}  // namespace narrow_loop_carry
+}  // namespace ir
+}  // namespace pypto

--- a/src/ir/transforms/utils/narrow_loop_carry.cpp
+++ b/src/ir/transforms/utils/narrow_loop_carry.cpp
@@ -11,6 +11,23 @@
 
 /// Loop-carry valid-shape repair. See ``narrow_loop_carry.h`` for the contract and the
 /// reasoning behind the scope limits; this file is the mechanism.
+///
+/// Three linear sweeps, each visiting every node once:
+///
+///   1. ``ScopeIndex``    -- where every Var is defined and which clock range each loop
+///                           spans, so "is this extent visible before the loop?" is an
+///                           interval test on the extent's own (tiny) expression rather
+///                           than a scan of the loop body.
+///   2. ``CarryAnalyzer`` -- decides, per carry, the valid shape to declare. Reads types
+///                           only; rewrites nothing.
+///   3. ``CarryRewriter`` -- applies the decisions top-down. A loop's seed is re-declared
+///                           and its ``IterArg`` re-minted *before* its body is visited,
+///                           so one visit types the whole body against the narrowed carry.
+///
+/// Total cost is O(N log N) in the size of the function: three O(N) traversals over
+/// ordered-map lookups. The ordering in (3) is what keeps it there -- deciding after the
+/// body was already visited would mean re-typing it a second time, and a nested carry
+/// would compound that per level.
 
 #include "pypto/ir/transforms/utils/narrow_loop_carry.h"
 
@@ -30,11 +47,12 @@
 #include "pypto/ir/op_registry.h"
 #include "pypto/ir/stmt.h"
 #include "pypto/ir/transforms/base/mutator.h"
+#include "pypto/ir/transforms/base/visitor.h"
 #include "pypto/ir/transforms/structural_comparison.h"
 #include "pypto/ir/transforms/utils/acc_init_builder.h"
 #include "pypto/ir/transforms/utils/loop_state_repair.h"
 #include "pypto/ir/transforms/utils/mutable_copy.h"
-#include "pypto/ir/transforms/utils/var_collectors.h"
+#include "pypto/ir/transforms/utils/transform_utils.h"
 #include "pypto/ir/type.h"
 #include "pypto/ir/type_inference.h"
 
@@ -46,13 +64,8 @@ namespace {
 
 /// Values of the statement list's terminating ``YieldStmt``, if it has one.
 std::vector<ExprPtr> TrailingYieldValues(const StmtPtr& body) {
-  if (auto seq = As<SeqStmts>(body)) {
-    if (seq->stmts_.empty()) return {};
-    if (auto yield = As<YieldStmt>(seq->stmts_.back())) return yield->value_;
-    return {};
-  }
-  if (auto direct = As<YieldStmt>(body)) return direct->value_;
-  return {};
+  auto yield = transform_utils::GetLastYieldStmt(body);
+  return yield ? yield->value_ : std::vector<ExprPtr>{};
 }
 
 /// The valid extents a carry should be declared at: per axis, the yield's extent when it
@@ -89,59 +102,183 @@ std::optional<std::vector<ExprPtr>> NarrowedValidShape(const TileTypePtr& init_t
   return any ? std::optional<std::vector<ExprPtr>>{std::move(narrowed)} : std::nullopt;
 }
 
-/// Whether every var the extents name is defined outside @p body.
+/// Where each Var is defined, and which half-open clock range each loop spans.
 ///
-/// The re-declared seed sits *before* the loop, so an extent computed inside the body
-/// cannot be named there. `pl.min(M_TILE, t_dim - t0)` written next to the slice it
-/// bounds is the common spelling of exactly that, and hoisting it would leave codegen
-/// with a symbol it cannot bind to a dimension, a scalar parameter, or a loop variable.
-/// The narrowing is declined instead of moving the computation, which would need the
-/// extent to be loop-invariant and is a larger change than this repair.
-bool ExtentsAreVisibleBeforeLoop(const std::vector<ExprPtr>& extents, const StmtPtr& body) {
-  var_collectors::VarDefUseCollector body_defs;
-  body_defs.VisitStmt(body);
-  for (const auto& extent : extents) {
-    if (!extent) continue;
-    var_collectors::VarDefUseCollector extent_vars;
-    extent_vars.VisitExpr(extent);
-    for (const auto* used : extent_vars.var_uses) {
-      if (body_defs.var_defs.count(used) > 0) return false;
+/// One pre-order sweep. It answers the only structural question this repair asks -- "is
+/// this extent visible at the point the seed is declared?" -- without re-walking the
+/// body per carry, which is what would make the pass quadratic on a function with many
+/// carries or deeply nested loops.
+class ScopeIndex : public IRVisitor {
+ public:
+  void Build(const StmtPtr& body) { VisitStmt(body); }
+
+  /// The call that defines @p var, or null when it is not an operator result.
+  [[nodiscard]] CallPtr DefiningCall(const Var* var) const {
+    auto it = defining_call_.find(var);
+    return it == defining_call_.end() ? nullptr : it->second;
+  }
+
+  /// Whether @p var is defined inside @p loop -- an interval test, O(log N).
+  ///
+  /// A var this index never saw (a function parameter, or one defined in an outer
+  /// function) is by construction not inside the loop.
+  [[nodiscard]] bool IsDefinedInside(const Var* var, const Stmt* loop) const {
+    auto def = def_clock_.find(var);
+    auto span = loop_span_.find(loop);
+    if (def == def_clock_.end() || span == loop_span_.end()) return false;
+    return def->second >= span->second.first && def->second < span->second.second;
+  }
+
+ protected:
+  void VisitStmt_(const AssignStmtPtr& op) override {
+    Define(op->var_.get());
+    if (auto call = As<Call>(op->value_)) defining_call_[op->var_.get()] = call;
+    IRVisitor::VisitStmt_(op);
+  }
+
+  void VisitStmt_(const IfStmtPtr& op) override {
+    for (const auto& rv : op->return_vars_) Define(rv.get());
+    IRVisitor::VisitStmt_(op);
+  }
+
+  void VisitStmt_(const ForStmtPtr& op) override {
+    for (const auto& rv : op->return_vars_) Define(rv.get());
+    EnterLoop(op, [&] {
+      Define(op->loop_var_.get());
+      IRVisitor::VisitStmt_(op);
+    });
+  }
+
+  void VisitStmt_(const WhileStmtPtr& op) override {
+    for (const auto& rv : op->return_vars_) Define(rv.get());
+    EnterLoop(op, [&] { IRVisitor::VisitStmt_(op); });
+  }
+
+ private:
+  void Define(const Var* var) { def_clock_.emplace(var, ++clock_); }
+
+  /// Record the clock range @p loop spans. The loop variable and the carries are
+  /// defined *inside* it, so an extent naming one of them is correctly refused.
+  template <typename LoopPtr, typename Fn>
+  void EnterLoop(const LoopPtr& loop, Fn&& visit_children) {
+    const size_t enter = ++clock_;
+    for (const auto& iter_arg : loop->iter_args_) Define(static_cast<const Var*>(iter_arg.get()));
+    visit_children();
+    loop_span_[loop.get()] = {enter, ++clock_};
+  }
+
+  size_t clock_ = 0;
+  std::map<const Var*, size_t> def_clock_;
+  std::map<const Stmt*, std::pair<size_t, size_t>> loop_span_;
+  std::map<const Var*, CallPtr> defining_call_;
+};
+
+/// The valid shape to declare for a carry, keyed by the ``IterArg`` that carries it.
+using CarryDecisions = std::map<const Var*, std::vector<ExprPtr>>;
+
+/// Decides which carries to re-declare. Reads types; rewrites nothing.
+class CarryAnalyzer : public IRVisitor {
+ public:
+  explicit CarryAnalyzer(const ScopeIndex& index) : index_(index) {}
+
+  [[nodiscard]] CarryDecisions Take() { return std::move(decisions_); }
+
+ protected:
+  void VisitStmt_(const ForStmtPtr& op) override {
+    IRVisitor::VisitStmt_(op);
+    Decide(op);
+  }
+
+  void VisitStmt_(const WhileStmtPtr& op) override {
+    IRVisitor::VisitStmt_(op);
+    Decide(op);
+  }
+
+ private:
+  template <typename LoopPtr>
+  void Decide(const LoopPtr& loop) {
+    const auto& iter_args = loop->iter_args_;
+    if (iter_args.empty()) return;
+    const auto yields = TrailingYieldValues(loop->body_);
+    if (yields.size() != iter_args.size()) return;
+
+    for (size_t i = 0; i < iter_args.size(); ++i) {
+      auto init_tile = As<TileType>(iter_args[i]->GetType());
+      auto yield_tile = As<TileType>(yields[i]->GetType());
+      auto narrowed = NarrowedValidShape(init_tile, yield_tile);
+      if (!narrowed) continue;
+      // Only an L0C carry is re-declared, and `tile.set_validshape` is 2D.
+      if (narrowed->size() != 2) continue;
+      if (yield_tile->GetMemorySpace() != MemorySpace::Acc) continue;
+      // Nothing to reconcile when both readings of the buffer land on the same pitch --
+      // notably a single-fractal-block box, where `ceil(validRow/16)*16` is the physical
+      // row count whatever the valid rows are. The same predicate `AccCompactValid` uses,
+      // so a carry this declines is also a carry the verifier does not ask about, and a
+      // `[16, N]` accumulator keeps the exact form it has today.
+      if (AccPitchesCoincide(narrowed->at(0), init_tile->shape_[0])) continue;
+      if (!ExtentsAreVisibleBefore(*narrowed, loop)) continue;
+      // Only a `tile.create` seed can be re-declared as a narrowed box.
+      auto seed = AsVarLike(iter_args[i]->initValue_);
+      if (!seed || !IsOp(index_.DefiningCall(seed.get()), "tile.create")) continue;
+
+      decisions_[static_cast<const Var*>(iter_args[i].get())] = std::move(*narrowed);
     }
   }
-  return true;
-}
 
-/// Re-type the def-use closure of a set of re-typed vars.
+  /// Whether every var the extents name is defined outside @p loop.
+  ///
+  /// The re-declared seed sits *before* the loop, so an extent computed inside the body
+  /// cannot be named there. `pl.min(M_TILE, t_dim - t0)` written next to the slice it
+  /// bounds is the common spelling of exactly that, and hoisting it would leave codegen
+  /// with a symbol it cannot bind to a dimension, a scalar parameter, or a loop variable.
+  /// The narrowing is declined instead of moving the computation, which would need the
+  /// extent to be loop-invariant and is a larger change than this repair.
+  template <typename LoopPtr>
+  bool ExtentsAreVisibleBefore(const std::vector<ExprPtr>& extents, const LoopPtr& loop) const {
+    for (const auto& extent : extents) {
+      if (!extent) continue;
+      ExtentVarCollector used;
+      used.VisitExpr(extent);
+      for (const auto* var : used.vars) {
+        if (index_.IsDefinedInside(var, loop.get())) return false;
+      }
+    }
+    return true;
+  }
+
+  /// The vars an extent expression names. Extents are small arithmetic on scalars, so
+  /// this walks a handful of nodes -- unlike a sweep of the loop body it replaces.
+  class ExtentVarCollector : public IRVisitor {
+   public:
+    std::vector<const Var*> vars;
+
+   protected:
+    void VisitExpr_(const VarPtr& op) override { vars.push_back(op.get()); }
+    void VisitExpr_(const IterArgPtr& op) override { vars.push_back(static_cast<const Var*>(op.get())); }
+  };
+
+  const ScopeIndex& index_;
+  CarryDecisions decisions_;
+};
+
+/// Applies the decisions, and re-types everything downstream of a carry it moved.
 ///
-/// Every rebuilt ``Call`` goes back through ``OpRegistry::Create``, so the operator's own
-/// deducer supplies the new result type — this repair never invents one. A result whose
-/// re-deduced type is unchanged stops the propagation there.
+/// Top-down: a loop's seed is re-declared and its ``IterArg`` re-minted before the body
+/// is visited, so a single visit types the body against the narrowed carry. Every rebuilt
+/// ``Call`` goes back through ``OpRegistry::Create``, so the operator's own deducer
+/// supplies the new result type -- this repair never invents one -- with the original
+/// call's attributes carried across. A result whose re-deduced type is unchanged stops the
+/// propagation there.
 ///
 /// A ``Submit`` value is substituted like any other expression but never re-deduced: it
 /// launches a user function rather than an operator, and it lives in a ``manual_scope`` at
 /// orchestration level, where no Acc tile carry can reach it.
-class RetypeClosureMutator : public IRMutator {
+class CarryRewriter : public IRMutator {
  public:
-  RetypeClosureMutator() = default;
-  explicit RetypeClosureMutator(std::map<const Var*, VarPtr> seed) : replaced_(std::move(seed)) {}
-
-  /// Register a var whose type moved, so later statements re-deduce through it.
-  void RecordReplacement(const Var* old_var, const VarPtr& new_var) { replaced_[old_var] = new_var; }
+  CarryRewriter(const ScopeIndex& index, CarryDecisions decisions)
+      : index_(index), decisions_(std::move(decisions)) {}
 
  protected:
-  /// Whether visiting rewrote any operand of this call — i.e. whether the value is
-  /// downstream of a var this pass re-typed.
-  static bool OperandsMoved(const ExprPtr& before, const ExprPtr& after) {
-    auto old_call = As<Call>(before);
-    auto new_call = As<Call>(after);
-    if (!old_call || !new_call) return false;
-    if (old_call->args_.size() != new_call->args_.size()) return true;
-    for (size_t i = 0; i < old_call->args_.size(); ++i) {
-      if (old_call->args_[i].get() != new_call->args_[i].get()) return true;
-    }
-    return false;
-  }
-
   ExprPtr VisitExpr_(const VarPtr& op) override {
     auto it = replaced_.find(op.get());
     return it == replaced_.end() ? IRMutator::VisitExpr_(op) : it->second;
@@ -158,18 +295,20 @@ class RetypeClosureMutator : public IRMutator {
     if (!assign) return rebuilt;
 
     // Re-deduce ONLY when an operand actually moved. A freshly deduced type is not
-    // interchangeable with the stored one — it carries no MemRef and no resolved
-    // memory space — so re-deducing calls this pass did not disturb would silently
+    // interchangeable with the stored one -- it carries no MemRef and no resolved
+    // memory space -- so re-deducing calls this pass did not disturb would silently
     // strip both from every tile in the program.
     auto call = As<Call>(assign->value_);
     if (!call || !call->op_) return rebuilt;
     if (!OperandsMoved(op->value_, assign->value_)) return rebuilt;
-    // A call to a user function carries a GlobalVar, not a registered operator —
+    // A call to a user function carries a GlobalVar, not a registered operator --
     // `OpRegistry::Create` rejects those by name, so screen them out first.
     auto& registry = OpRegistry::GetInstance();
     if (!registry.IsRegistered(call->op_->name_)) return rebuilt;
-    auto fresh = registry.Create(call->op_->name_, call->args_, call->kwargs_, call->span_);
-    if (!fresh) return rebuilt;
+    auto deduced = registry.Create(call->op_->name_, call->args_, call->kwargs_, call->span_);
+    if (!deduced) return rebuilt;
+    // Attributes come from the *rebuilt* call, whose contents this visit already remapped.
+    auto fresh = transform_utils::PreserveCallAttrs(call, deduced);
 
     const auto& old_type = assign->var_->GetType();
     const auto& new_type = fresh->GetType();
@@ -210,106 +349,6 @@ class RetypeClosureMutator : public IRMutator {
                                     new_return_vars, if_stmt->span_);
   }
 
-  StmtPtr VisitStmt_(const ForStmtPtr& op) override { return VisitLoop(op); }
-
-  StmtPtr VisitStmt_(const WhileStmtPtr& op) override { return VisitLoop(op); }
-
-  /// Visit a loop's children, then carry any re-typed value across its boundary.
-  template <typename LoopPtr>
-  StmtPtr VisitLoop(const LoopPtr& op) {
-    auto rebuilt = RebuildWithVisitedChildren(op);
-    auto loop = As<std::remove_const_t<typename LoopPtr::element_type>>(rebuilt);
-    if (!loop) return rebuilt;
-    return PropagateIntoLoop(loop, op->iter_args_, op->return_vars_);
-  }
-
-  /// Rebuild a loop of either kind with new carry state.
-  static StmtPtr RebuildLoopLike(const ForStmtPtr& loop, const std::vector<IterArgPtr>& iter_args,
-                                 const StmtPtr& body, const std::vector<VarPtr>& return_vars) {
-    return loop_repair::RebuildForStmt(loop, iter_args, body, return_vars);
-  }
-  static StmtPtr RebuildLoopLike(const WhileStmtPtr& loop, const std::vector<IterArgPtr>& iter_args,
-                                 const StmtPtr& body, const std::vector<VarPtr>& return_vars) {
-    return loop_repair::RebuildWhileStmt(loop, iter_args, body, return_vars);
-  }
-
-  /// Visit a loop's children and rebuild it, without either level's carry handling -- the
-  /// caller applies that itself once the body is in its final shape. A named helper rather
-  /// than a qualified ``IRMutator::VisitStmt_`` call, which would read as skipping this
-  /// class's own override.
-  StmtPtr RebuildWithVisitedChildren(const ForStmtPtr& op) { return IRMutator::VisitStmt_(op); }
-  StmtPtr RebuildWithVisitedChildren(const WhileStmtPtr& op) { return IRMutator::VisitStmt_(op); }
-
-  /// Carry a re-typed value across a nested loop boundary.
-  ///
-  /// Substituting the init value alone leaves the nested ``IterArg`` — and therefore
-  /// everything the nested body deduced from it — at the old type. Re-mint the iter_arg
-  /// from its new init and re-run the closure through the nested body, exactly as the
-  /// outer narrowing does; the loop's own results then follow its re-typed yields.
-  template <typename LoopPtr>
-  StmtPtr PropagateIntoLoop(const LoopPtr& loop, const std::vector<IterArgPtr>& original_iter_args,
-                            const std::vector<VarPtr>& original_return_vars) {
-    const auto& iter_args = loop->iter_args_;
-    const auto& body = loop->body_;
-    if (iter_args.size() != original_iter_args.size()) {
-      return loop;
-    }
-
-    std::map<const Var*, VarPtr> carry_seed;
-    std::vector<IterArgPtr> new_iter_args = iter_args;
-    for (size_t i = 0; i < iter_args.size(); ++i) {
-      const auto& iter_arg = iter_args[i];
-      const auto& init = iter_arg->initValue_;
-      if (!init || !init->GetType()) continue;
-      if (iter_arg->GetType() && structural_equal(iter_arg->GetType(), init->GetType())) continue;
-      auto new_iter_arg =
-          std::make_shared<IterArg>(iter_arg->name_hint_, init->GetType(), init, iter_arg->span_);
-      new_iter_args[i] = new_iter_arg;
-      carry_seed[static_cast<const Var*>(original_iter_args[i].get())] = new_iter_arg;
-    }
-    if (carry_seed.empty()) return loop;
-
-    RetypeClosureMutator retyper(std::move(carry_seed));
-    auto new_body = retyper.VisitStmt(body);
-    auto new_return_vars = RetypeReturnVars(new_body, loop->return_vars_, original_return_vars, this);
-    return RebuildLoopLike(loop, new_iter_args, new_body, new_return_vars);
-  }
-
-  /// Re-type a loop's ``return_vars`` from its (re-typed) yields, and publish each
-  /// replacement to @p publish_to so later statements re-deduce through the new type
-  /// rather than merely substituting the var.
-  static std::vector<VarPtr> RetypeReturnVars(const StmtPtr& new_body, const std::vector<VarPtr>& return_vars,
-                                              const std::vector<VarPtr>& original_return_vars,
-                                              RetypeClosureMutator* publish_to) {
-    const auto new_yields = TrailingYieldValues(new_body);
-    std::vector<VarPtr> new_return_vars = return_vars;
-    if (new_yields.size() != return_vars.size() || original_return_vars.size() != return_vars.size()) {
-      return new_return_vars;
-    }
-    for (size_t i = 0; i < return_vars.size(); ++i) {
-      const auto& rv = return_vars[i];
-      const auto& yield_type = new_yields[i]->GetType();
-      if (!yield_type || (rv->GetType() && structural_equal(rv->GetType(), yield_type))) continue;
-      auto new_rv = std::make_shared<Var>(rv->name_hint_, yield_type, rv->span_);
-      new_return_vars[i] = new_rv;
-      publish_to->RecordReplacement(original_return_vars[i].get(), new_rv);
-    }
-    return new_return_vars;
-  }
-
- private:
-  std::map<const Var*, VarPtr> replaced_;
-};
-
-class NarrowLoopCarryMutator : public RetypeClosureMutator {
- protected:
-  StmtPtr VisitStmt_(const AssignStmtPtr& op) override {
-    // A Var does not carry its defining expression, so remember it: the seed of a carry
-    // is a Var whose definition is the `tile.create` this pass re-declares.
-    if (auto call = As<Call>(op->value_)) defs_[op->var_.get()] = call;
-    return RetypeClosureMutator::VisitStmt_(op);
-  }
-
   /// Splice a rewritten loop's prologue into the enclosing statement list, so the
   /// re-declared seed is a sibling of the loop rather than a nested ``SeqStmts``.
   StmtPtr VisitStmt_(const SeqStmtsPtr& op) override {
@@ -335,75 +374,94 @@ class NarrowLoopCarryMutator : public RetypeClosureMutator {
     return std::make_shared<SeqStmts>(out, op->span_);
   }
 
-  StmtPtr VisitStmt_(const ForStmtPtr& op) override { return VisitLoopAndNarrow(op); }
+  StmtPtr VisitStmt_(const ForStmtPtr& op) override { return VisitLoop(op); }
 
-  StmtPtr VisitStmt_(const WhileStmtPtr& op) override { return VisitLoopAndNarrow(op); }
+  StmtPtr VisitStmt_(const WhileStmtPtr& op) override { return VisitLoop(op); }
 
  private:
-  /// Visit a loop's children, then re-declare every Acc carry the body proves narrower.
-  template <typename LoopPtr>
-  StmtPtr VisitLoopAndNarrow(const LoopPtr& op) {
-    // Inner loops first: a nested carry may itself narrow this loop's yields.
-    auto rebuilt = RebuildWithVisitedChildren(op);
-    auto loop = As<std::remove_const_t<typename LoopPtr::element_type>>(rebuilt);
-    if (!loop) return rebuilt;
-    return NarrowCarries(loop, op->iter_args_, op->return_vars_);
+  /// Whether visiting rewrote any operand of this call -- i.e. whether the value is
+  /// downstream of a var this pass re-typed.
+  static bool OperandsMoved(const ExprPtr& before, const ExprPtr& after) {
+    auto old_call = As<Call>(before);
+    auto new_call = As<Call>(after);
+    if (!old_call || !new_call) return false;
+    if (old_call->args_.size() != new_call->args_.size()) return true;
+    for (size_t i = 0; i < old_call->args_.size(); ++i) {
+      if (old_call->args_[i].get() != new_call->args_[i].get()) return true;
+    }
+    return false;
   }
 
+  static StmtPtr RebuildLoopLike(const ForStmtPtr& loop, const std::vector<IterArgPtr>& iter_args,
+                                 const StmtPtr& body, const std::vector<VarPtr>& return_vars) {
+    return loop_repair::RebuildForStmt(loop, iter_args, body, return_vars);
+  }
+  static StmtPtr RebuildLoopLike(const WhileStmtPtr& loop, const std::vector<IterArgPtr>& iter_args,
+                                 const StmtPtr& body, const std::vector<VarPtr>& return_vars) {
+    return loop_repair::RebuildWhileStmt(loop, iter_args, body, return_vars);
+  }
+
+  /// Settle a loop's carries, then visit its body exactly once.
+  ///
+  /// Two things can move a carry: this loop has a decision of its own, or its init value
+  /// was re-typed by an enclosing rewrite. Both are resolved here, before the body is
+  /// visited, so the body's deducers see the final carry type on their first and only
+  /// pass. Substituting the init alone would leave the ``IterArg`` -- and everything the
+  /// body deduced from it -- at the old type.
   template <typename LoopPtr>
-  StmtPtr NarrowCarries(const LoopPtr& loop, const std::vector<IterArgPtr>& original_iter_args,
-                        const std::vector<VarPtr>& original_return_vars) {
-    const auto& iter_args = loop->iter_args_;
-    const auto& body = loop->body_;
-    const auto& return_vars = loop->return_vars_;
-    if (iter_args.empty() || iter_args.size() != original_iter_args.size()) {
-      return PropagateIntoLoop(loop, original_iter_args, original_return_vars);
-    }
-
-    const auto yields = TrailingYieldValues(body);
-    if (yields.size() != iter_args.size()) {
-      return PropagateIntoLoop(loop, original_iter_args, original_return_vars);
-    }
-
+  StmtPtr VisitLoop(const LoopPtr& op) {
     std::vector<StmtPtr> prologue;
-    std::map<const Var*, VarPtr> carry_seed;
-    std::vector<IterArgPtr> new_iter_args = iter_args;
-    for (size_t i = 0; i < iter_args.size(); ++i) {
-      const auto& iter_arg = iter_args[i];
-      auto init_tile = As<TileType>(iter_arg->GetType());
-      auto yield_tile = As<TileType>(yields[i]->GetType());
-      auto narrowed = NarrowedValidShape(init_tile, yield_tile);
-      if (!narrowed) continue;
-      // Only an L0C carry is re-declared, and `tile.set_validshape` is 2D.
-      if (narrowed->size() != 2) continue;
-      if (yield_tile->GetMemorySpace() != MemorySpace::Acc) continue;
-      // Nothing to reconcile when both readings of the buffer land on the same pitch --
-      // notably a single-fractal-block box, where `ceil(validRow/16)*16` is the physical
-      // row count whatever the valid rows are. The same predicate `AccCompactValid` uses,
-      // so a carry this declines is also a carry the verifier does not ask about, and a
-      // `[16, N]` accumulator keeps the exact form it has today.
-      if (AccPitchesCoincide(narrowed->at(0), init_tile->shape_[0])) continue;
-      if (!ExtentsAreVisibleBeforeLoop(*narrowed, body)) continue;
+    std::vector<IterArgPtr> new_iter_args = op->iter_args_;
+    bool carries_moved = false;
 
-      auto narrowed_init = BuildNarrowedInit(iter_arg->initValue_, init_tile, *narrowed, &prologue);
-      if (!narrowed_init) continue;
+    for (size_t i = 0; i < op->iter_args_.size(); ++i) {
+      const auto& iter_arg = op->iter_args_[i];
+      if (!iter_arg->initValue_) continue;
+      ExprPtr init = VisitExpr(iter_arg->initValue_);
 
-      auto new_iter_arg = std::make_shared<IterArg>(iter_arg->name_hint_, narrowed_init->GetType(),
-                                                    narrowed_init, iter_arg->span_);
+      auto decision = decisions_.find(static_cast<const Var*>(iter_arg.get()));
+      if (decision != decisions_.end()) {
+        if (auto seed = BuildNarrowedInit(iter_arg, decision->second, &prologue)) init = seed;
+      }
+      if (!init || !init->GetType()) continue;
+      if (iter_arg->GetType() && structural_equal(iter_arg->GetType(), init->GetType())) continue;
+
+      auto new_iter_arg =
+          std::make_shared<IterArg>(iter_arg->name_hint_, init->GetType(), init, iter_arg->span_);
       new_iter_args[i] = new_iter_arg;
-      carry_seed[static_cast<const Var*>(original_iter_args[i].get())] = new_iter_arg;
-    }
-    if (carry_seed.empty()) {
-      return PropagateIntoLoop(loop, original_iter_args, original_return_vars);
+      replaced_[static_cast<const Var*>(iter_arg.get())] = new_iter_arg;
+      carries_moved = true;
     }
 
-    RetypeClosureMutator retyper(std::move(carry_seed));
-    auto new_body = retyper.VisitStmt(body);
-    auto new_return_vars = RetypeReturnVars(new_body, return_vars, original_return_vars, this);
-    auto new_loop = RebuildLoopLike(loop, new_iter_args, new_body, new_return_vars);
+    auto new_body = VisitStmt(op->body_);
+    auto new_return_vars = RetypeReturnVars(new_body, op->return_vars_);
+    if (!carries_moved && new_body.get() == op->body_.get() && new_return_vars == op->return_vars_ &&
+        prologue.empty()) {
+      return op;
+    }
+
+    auto new_loop = RebuildLoopLike(op, new_iter_args, new_body, new_return_vars);
     if (prologue.empty()) return new_loop;
     prologue.push_back(new_loop);
     return std::make_shared<SeqStmts>(prologue, new_loop->span_);
+  }
+
+  /// Re-type a loop's ``return_vars`` from its (re-typed) yields, and record each
+  /// replacement so later statements re-deduce through the new type rather than merely
+  /// substituting the var.
+  std::vector<VarPtr> RetypeReturnVars(const StmtPtr& new_body, const std::vector<VarPtr>& return_vars) {
+    const auto new_yields = TrailingYieldValues(new_body);
+    std::vector<VarPtr> new_return_vars = return_vars;
+    if (new_yields.size() != return_vars.size()) return new_return_vars;
+    for (size_t i = 0; i < return_vars.size(); ++i) {
+      const auto& rv = return_vars[i];
+      const auto& yield_type = new_yields[i]->GetType();
+      if (!yield_type || (rv->GetType() && structural_equal(rv->GetType(), yield_type))) continue;
+      auto new_rv = std::make_shared<Var>(rv->name_hint_, yield_type, rv->span_);
+      new_return_vars[i] = new_rv;
+      replaced_[rv.get()] = new_rv;
+    }
+    return new_return_vars;
   }
 
   /// Re-declare a ``tile.create`` seed with the narrowed valid shape.
@@ -413,32 +471,45 @@ class NarrowLoopCarryMutator : public RetypeClosureMutator {
   /// right for a tile whose bytes may already be written but would leave a fresh
   /// accumulator advertising the physical row pitch. Declaring the box lets
   /// ``tile.create``'s own deducer derive the Acc layout for the box it declares.
-  /// Returns null when the init is not a ``tile.create`` this pass can re-declare.
-  ExprPtr BuildNarrowedInit(const ExprPtr& init, const TileTypePtr& init_tile,
-                            const std::vector<ExprPtr>& valid, std::vector<StmtPtr>* prologue) const {
-    auto init_var = AsVarLike(init);
-    if (!init_var) return nullptr;
-    auto def = defs_.find(init_var.get());
-    if (def == defs_.end()) return nullptr;
-    if (!IsOp(def->second, "tile.create")) return nullptr;
+  /// Returns null when the seed is not one this repair can re-declare.
+  ExprPtr BuildNarrowedInit(const IterArgPtr& iter_arg, const std::vector<ExprPtr>& valid,
+                            std::vector<StmtPtr>* prologue) {
+    auto init_tile = As<TileType>(iter_arg->GetType());
+    auto seed = AsVarLike(iter_arg->initValue_);
+    if (!init_tile || !seed || !IsOp(index_.DefiningCall(seed.get()), "tile.create")) return nullptr;
 
-    auto narrowed = acc_init::BuildNarrowedAccInit(init_tile->shape_, valid, init_tile->dtype_,
-                                                   init_var->name_hint_ + "_narrowed", init->span_);
+    // The extents were chosen against the types as the analyzer found them; an enclosing
+    // rewrite may since have replaced the vars they name.
+    std::vector<ExprPtr> visited_valid;
+    visited_valid.reserve(valid.size());
+    for (const auto& extent : valid) visited_valid.push_back(VisitExpr(extent));
+
+    auto narrowed = acc_init::BuildNarrowedAccInit(init_tile->shape_, visited_valid, init_tile->dtype_,
+                                                   seed->name_hint_ + "_narrowed", iter_arg->span_);
     for (auto& stmt : narrowed.stmts) prologue->push_back(std::move(stmt));
     return narrowed.value;
   }
 
-  /// Defining call of each assigned Var, so a carry's seed can be traced back to the
-  /// ``tile.create`` that declared it.
-  std::map<const Var*, CallPtr> defs_;
+  const ScopeIndex& index_;
+  CarryDecisions decisions_;
+  std::map<const Var*, VarPtr> replaced_;
 };
 
 }  // namespace
 
 FunctionPtr NarrowAccCarries(const FunctionPtr& func) {
   if (!func || !func->body_) return func;
-  NarrowLoopCarryMutator mutator;
-  auto new_body = mutator.VisitStmt(func->body_);
+
+  ScopeIndex index;
+  index.Build(func->body_);
+
+  CarryAnalyzer analyzer(index);
+  analyzer.VisitStmt(func->body_);
+  auto decisions = analyzer.Take();
+  if (decisions.empty()) return func;
+
+  CarryRewriter rewriter(index, std::move(decisions));
+  auto new_body = rewriter.VisitStmt(func->body_);
   if (new_body.get() == func->body_.get()) return func;
   auto new_func = MutableCopy(func);
   new_func->body_ = new_body;

--- a/tests/st/runtime/cross_core/test_c2v_narrowed_acc_epilogue.py
+++ b/tests/st/runtime/cross_core/test_c2v_narrowed_acc_epilogue.py
@@ -26,8 +26,14 @@ The two cases here are the same arithmetic through the two readers:
 * ``staged`` sends the accumulator to GM (the ``TSTORE`` reader) over a K wide
   enough that the compiler synthesizes its own K-accumulation loop, whose seed is
   where the chain used to lose the mode (#2470).
+* ``carried`` writes that K loop by hand -- a ``pl.create_tensor`` seed seeded before a
+  ``pl.pipeline`` and rebound under ``if k0 == 0`` -- which is how the model kernel in
+  #2470 spells it. The carry is typed from the seed alone, so the narrowing every matmul
+  in the body produced used to die at the loop boundary and the store read the full box.
 
-Both returned 14336 of 65536 elements wrong before the fix, inside the valid rows.
+The first two returned 14336 of 65536 elements wrong before their fix; the third returned
+75264 of 131072 wrong in the issue's own reproducer, its 48-row tail garbage rather than
+the untouched zeros the others left.
 """
 
 from typing import Any
@@ -42,6 +48,7 @@ VALID_ROWS = 16  # rows that actually hold data
 N_TILE = 128
 K_ONE_BLOCK = 256  # one L0 K block: a single tile.matmul
 K_MULTI_BLOCK = 2048  # several L0 K blocks: a synthesized K-accumulation loop
+K_BLOCK = 512  # per-iteration K slice of the hand-written carry loop
 SCALE = 1.0 / 4096.0
 
 
@@ -186,6 +193,76 @@ class _StagedKSplitCase(PTOTestCase):
         _expected(tensors)
 
 
+class _CarriedKLoopCase(PTOTestCase):
+    """A hand-written K loop whose accumulator is seeded by ``pl.create_tensor``."""
+
+    __test__ = False
+
+    def __init__(self, *, platform=None, config=None):
+        super().__init__(config, platform=platform)
+
+    def get_name(self) -> str:
+        return f"c2v_narrowed_acc_carried_k{K_MULTI_BLOCK}"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            *_io_tensors(K_MULTI_BLOCK),
+            TensorSpec("acc_gm", [M_TILE, N_TILE], DataType.INT32, init_value=torch.zeros),
+        ]
+
+    def get_program(self) -> Any:
+        k = K_MULTI_BLOCK
+
+        @pl.program
+        class CarriedKLoopProgram:
+            @pl.function(type=pl.FunctionType.InCore)
+            def cube(
+                self,
+                x: pl.Tensor[[M_TILE, k], pl.INT8],
+                w: pl.Tensor[[N_TILE, k], pl.INT8],
+                acc_gm: pl.InOut[pl.Tensor[[M_TILE, N_TILE], pl.INT32]],
+            ) -> pl.Tensor[[M_TILE, N_TILE], pl.INT32]:
+                acc = pl.create_tensor([M_TILE, N_TILE], dtype=pl.INT32)
+                for k0 in pl.pipeline(0, k, K_BLOCK, stage=2):
+                    xk = pl.slice(x, [M_TILE, K_BLOCK], [0, k0], valid_shape=[VALID_ROWS, K_BLOCK])
+                    wk = pl.slice(w, [N_TILE, K_BLOCK], [0, k0])
+                    if k0 == 0:
+                        acc = pl.matmul(xk, wk, b_trans=True, out_dtype=pl.INT32)
+                    else:
+                        acc = pl.matmul_acc(acc, xk, wk, b_trans=True)
+                acc_gm[:] = acc
+                return acc_gm
+
+            @pl.function(type=pl.FunctionType.InCore)
+            def dequant(
+                self,
+                acc_gm: pl.Tensor[[M_TILE, N_TILE], pl.INT32],
+                scale: pl.Tensor[[M_TILE, 1], pl.FP32],
+                out: pl.InOut[pl.Tensor[[M_TILE, N_TILE], pl.FP32]],
+            ) -> pl.Tensor[[M_TILE, N_TILE], pl.FP32]:
+                deq = pl.row_expand_mul(pl.cast(acc_gm[:], target_type=pl.FP32, mode="none"), scale)
+                out[:] = pl.fillpad(pl.set_validshape(deq, VALID_ROWS, N_TILE), pad_value=pl.PadValue.zero)
+                return out
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orchestrator(
+                self,
+                x: pl.Tensor[[M_TILE, k], pl.INT8],
+                w: pl.Tensor[[N_TILE, k], pl.INT8],
+                scale: pl.Tensor[[M_TILE, 1], pl.FP32],
+                out: pl.InOut[pl.Tensor[[M_TILE, N_TILE], pl.FP32]],
+                acc_gm: pl.InOut[pl.Tensor[[M_TILE, N_TILE], pl.INT32]],
+            ) -> pl.Tensor[[M_TILE, N_TILE], pl.FP32]:
+                acc_gm = self.cube(x, w, acc_gm)
+                out = self.dequant(acc_gm, scale, out)
+                return out
+
+        return CarriedKLoopProgram
+
+    def compute_expected(self, tensors: dict[str, torch.Tensor], params=None) -> None:
+        _expected(tensors)
+
+
 class TestNarrowedAccEpilogue:
     """A narrowed accumulator must survive both of its readers."""
 
@@ -202,6 +279,13 @@ class TestNarrowedAccEpilogue:
         """The TSTORE path over a compiler-synthesized K loop (#2470)."""
         result = test_runner.run(_StagedKSplitCase(platform=platform))
         assert result.passed, f"GM-staged accumulator failed: {result.error}"
+
+    @pytest.mark.platforms("a2a3")
+    @pytest.mark.parametrize("platform", [pytest.param("a2a3", id="a2a3")])
+    def test_gm_stored_accumulator_carried_by_a_hand_written_loop(self, test_runner, platform):
+        """The TSTORE path over a user-written carry seeded by pl.create_tensor (#2470)."""
+        result = test_runner.run(_CarriedKLoopCase(platform=platform))
+        assert result.passed, f"carried accumulator failed: {result.error}"
 
 
 if __name__ == "__main__":

--- a/tests/ut/ir/operators/test_tile_ops.py
+++ b/tests/ut/ir/operators/test_tile_ops.py
@@ -3057,6 +3057,45 @@ class TestTileSliceReshapeOps:
         with pytest.warns(UserWarning, match="pad_value has no effect"):
             pl.tile.slice(tile_arg, [8, 16], [0, 0], pad_value=pl.PadValue.zero)
 
+    def test_tile_reshape_identity_keeps_the_whole_source_view(self):
+        """An identity reshape is a view onto the same bytes, so it keeps the source view.
+
+        Re-deriving the view from the shape gives the space-agnostic flat default, which
+        ``NormalizeImplicitTileView`` rescues only for a view that collapses — and a
+        narrowed, padded or compact Acc box never does, so the flat layout would stick
+        (issue #2470). ``stride`` and ``start_offset`` are the same story one level down:
+        they *are* the address arithmetic, and dropping them relocates a strided sub-view.
+        """
+        span = ir.Span.unknown()
+        rows = ir.ConstInt(64, DataType.INT32, span)
+        cols = ir.ConstInt(128, DataType.INT32, span)
+        source_view = ir.TileView(
+            valid_shape=[16, 128],
+            stride=[256, 1],
+            start_offset=512,
+            blayout=ir.TileLayout.col_major,
+            slayout=ir.TileLayout.row_major,
+            fractal=1024,
+            compact=ir.CompactMode.normal,
+        )
+        source_type = ir.TileType([rows, cols], DataType.INT32, None, source_view, ir.MemorySpace.Acc)
+        source = ir.Var("acc", source_type, span)
+
+        result = tile.reshape(source, [64, 128]).type
+        view = result.tile_view
+
+        assert isinstance(result, ir.TileType)
+        assert result.memory_space == ir.MemorySpace.Acc
+        assert view.blayout == ir.TileLayout.col_major
+        assert view.slayout == ir.TileLayout.row_major
+        assert view.fractal == 1024
+        assert view.compact == ir.CompactMode.normal
+        assert [int(s.value) for s in view.stride] == [256, 1], (
+            "an identity reshape must keep the source's stride — it is the same addressing"
+        )
+        assert view.start_offset is not None and int(view.start_offset.value) == 512
+        assert [int(v.value) for v in view.valid_shape] == [16, 128]
+
     def test_tile_reshape(self):
         """Test tile.reshape operation."""
         span = ir.Span.unknown()

--- a/tests/ut/ir/operators/test_tile_ops.py
+++ b/tests/ut/ir/operators/test_tile_ops.py
@@ -3082,9 +3082,10 @@ class TestTileSliceReshapeOps:
         source = ir.Var("acc", source_type, span)
 
         result = tile.reshape(source, [64, 128]).type
-        view = result.tile_view
-
         assert isinstance(result, ir.TileType)
+        view = result.tile_view
+        assert view is not None
+
         assert result.memory_space == ir.MemorySpace.Acc
         assert view.blayout == ir.TileLayout.col_major
         assert view.slayout == ir.TileLayout.row_major

--- a/tests/ut/ir/operators/test_tile_ops.py
+++ b/tests/ut/ir/operators/test_tile_ops.py
@@ -28,6 +28,12 @@ _OP_TILE_SLICE = ir.get_op("tile.slice").name
 _OP_TILE_TRANSPOSE = ir.get_op("tile.transpose").name
 
 
+def _const_int(expr: ir.Expr) -> int:
+    """The value of a constant Expr, asserting it is one."""
+    assert isinstance(expr, ir.ConstInt), f"expected a ConstInt, got {type(expr).__name__}"
+    return expr.value
+
+
 def _operand_dtype(expr: ir.Expr) -> DataType:
     """Return a constant operand's dtype, narrowing ``Expr`` for the type checker."""
     assert isinstance(expr, (ir.ConstInt, ir.ConstFloat)), f"expected a constant, got {type(expr).__name__}"
@@ -3091,11 +3097,11 @@ class TestTileSliceReshapeOps:
         assert view.slayout == ir.TileLayout.row_major
         assert view.fractal == 1024
         assert view.compact == ir.CompactMode.normal
-        assert [int(s.value) for s in view.stride] == [256, 1], (
+        assert [_const_int(dim) for dim in view.stride] == [256, 1], (
             "an identity reshape must keep the source's stride — it is the same addressing"
         )
-        assert view.start_offset is not None and int(view.start_offset.value) == 512
-        assert [int(v.value) for v in view.valid_shape] == [16, 128]
+        assert view.start_offset is not None and _const_int(view.start_offset) == 512
+        assert [_const_int(dim) for dim in view.valid_shape] == [16, 128]
 
     def test_tile_reshape(self):
         """Test tile.reshape operation."""

--- a/tests/ut/ir/transforms/test_narrow_loop_carry_valid_shape.py
+++ b/tests/ut/ir/transforms/test_narrow_loop_carry_valid_shape.py
@@ -36,6 +36,9 @@ M_TILE = 64
 K = 1024
 N_TILE = 256
 K_TILE = 512
+FRACTAL_ROWS = 16  # one L0C fractal block: every valid row count packs to the box
+FRACTAL_N_TILE = 128  # pypto-lib's projection tile; keeps the Mat arena within budget
+FRACTAL_K_TILE = 256
 
 _TILE_STORE_OP = ir.get_op("tile.store").name
 _TILE_CREATE_OP = ir.get_op("tile.create").name
@@ -78,6 +81,56 @@ def create_tensor_seeded_acc_2d(
         v = pl.min(M_TILE, pl.read(rows, [b, 0]))
         acc = pl.create_tensor([M_TILE, N_TILE], dtype=pl.INT32)
         for k0 in pl.pipeline(0, K, K_TILE, stage=2):
+            xk = pl.slice(x, [M_TILE, K_TILE], [m0, k0], valid_shape=[v, K_TILE])
+            wk = pl.slice(w, [N_TILE, K_TILE], [0, k0])
+            if k0 == 0:
+                acc = pl.matmul(xk, wk, b_trans=True, out_dtype=pl.INT32)
+            else:
+                acc = pl.matmul_acc(acc, xk, wk, b_trans=True)
+        y[m0 : m0 + M_TILE, :] = acc
+    return y
+
+
+@pl.jit
+def single_fractal_block_acc(
+    x: pl.Tensor[[BLOCKS * FRACTAL_ROWS, K], pl.BF16],
+    w: pl.Tensor[[K, FRACTAL_N_TILE], pl.BF16],
+    rows: pl.Tensor[[BLOCKS, 1], pl.INT32],
+    y: pl.Out[pl.Tensor[[BLOCKS * FRACTAL_ROWS, FRACTAL_N_TILE], pl.FP32]],
+):
+    """A [16, N] accumulator: `ceil(v/16)*16` is 16 for every valid row count it can hold.
+
+    This is the shape pypto-lib's `qkv_proj_rope` projections use, down to the runtime row
+    count computed next to the slice it bounds.
+    """
+    for b in pl.spmd(BLOCKS, name_hint="mm_fractal", allow_early_resolve=True):
+        m0 = b * FRACTAL_ROWS
+        acc = pl.create_tensor([FRACTAL_ROWS, FRACTAL_N_TILE], dtype=pl.FP32)
+        for k0 in pl.pipeline(0, K, FRACTAL_K_TILE, stage=2):
+            v = pl.min(FRACTAL_ROWS, pl.read(rows, [b, 0]))
+            xk = pl.slice(x, [FRACTAL_ROWS, FRACTAL_K_TILE], [m0, k0], valid_shape=[v, FRACTAL_K_TILE])
+            wk = pl.slice(w, [FRACTAL_K_TILE, FRACTAL_N_TILE], [k0, 0])
+            if k0 == 0:
+                acc = pl.matmul(xk, wk, out_dtype=pl.FP32)
+            else:
+                acc = pl.matmul_acc(acc, xk, wk)
+        y[m0 : m0 + FRACTAL_ROWS, :] = acc
+    return y
+
+
+@pl.jit
+def extent_computed_inside_the_loop(
+    x: pl.Tensor[[BLOCKS * M_TILE, K], pl.INT8],
+    w: pl.Tensor[[N_TILE, K], pl.INT8],
+    rows: pl.Tensor[[BLOCKS, 1], pl.INT32],
+    y: pl.Out[pl.Tensor[[BLOCKS * M_TILE, N_TILE], pl.INT32]],
+):
+    """The pitches differ, but the row count is only computed inside the loop body."""
+    for b in pl.spmd(BLOCKS, name_hint="mm_inner_v", allow_early_resolve=True):
+        m0 = b * M_TILE
+        acc = pl.create_tensor([M_TILE, N_TILE], dtype=pl.INT32)
+        for k0 in pl.pipeline(0, K, K_TILE, stage=2):
+            v = pl.min(M_TILE, pl.read(rows, [b, 0]))
             xk = pl.slice(x, [M_TILE, K_TILE], [m0, k0], valid_shape=[v, K_TILE])
             wk = pl.slice(w, [N_TILE, K_TILE], [0, k0])
             if k0 == 0:
@@ -211,6 +264,15 @@ def _loops(program):
     return collector.loops
 
 
+def _incore_functions(program):
+    """The device side of a lowered program; the host orchestration has its own backend."""
+    return [
+        func
+        for func in program.functions.values()
+        if func.func_type in (pl.FunctionType.InCore, pl.FunctionType.AIC, pl.FunctionType.AIV)
+    ]
+
+
 def _stored_tile_type(program):
     """The TileType the single ``tile.store`` reads."""
     stores = _calls(program, _TILE_STORE_OP)
@@ -298,6 +360,76 @@ def test_seed_is_redeclared_as_a_compact_narrowed_box():
     assert any(_tile_view(alias.type).compact == ir.CompactMode.normal for alias in aliases)
 
 
+def test_single_fractal_block_accumulator_is_left_alone():
+    """`ceil(validRow/16)*16 == Rows` leaves writer and reader agreeing anyway.
+
+    A `[16, N]` accumulator packs to its own box whatever its valid rows, so the compact
+    flag cannot change a reader's pitch — the same exemption `AccCompactValid` makes. This
+    is pypto-lib's `qkv_proj_rope` shape, and re-declaring it there was both unnecessary
+    and harmful: its row count is computed inside the loop, so the seed could not name it,
+    and codegen was left with a symbol it could not bind.
+
+    The carry still outlives a narrower yield, which is why this lowers without the
+    verification instrument — that general defect is not what this repair claims.
+    """
+    with passes.PassContext([]):
+        after = _lower(single_fractal_block_acc)
+    stored = _stored_tile_type(after)
+
+    assert not [call for call in _calls(after, _TILE_CREATE_OP) if call.kwargs.get("compact")]
+    assert not _calls(after, _TILE_SET_VALIDSHAPE_OP)
+    assert stored.tile_view is None or stored.tile_view.compact != ir.CompactMode.normal
+
+
+def test_single_fractal_block_accumulator_still_reaches_codegen():
+    """And it compiles all the way to PTO, which is how pypto-lib builds.
+
+    Property verification stays on here (it is what `PassContext([])` keeps); only the
+    per-pass diagnostic instrument is dropped, exactly as a production compile runs.
+    Codegen is the step that catches a hoisted extent: re-declaring the seed with a row
+    count computed inside the loop leaves `pto.tstore`'s valid extent naming a symbol the
+    kernel cannot bind to a dimension, a scalar parameter, or a loop variable.
+    """
+    from pypto.ir.pass_manager import OptimizationStrategy, PassManager  # noqa: PLC0415
+
+    _backend.reset_for_testing()
+    _backend.set_backend_type(BackendType.Ascend910B)
+    with passes.PassContext([]):
+        lowered = PassManager.get_strategy(OptimizationStrategy.Default).run_passes(
+            _jit_program(single_fractal_block_acc)
+        )
+    mlir = codegen.PTOCodegen().generate(ir.Program(_incore_functions(lowered), lowered.name, ir.Span.unknown()))
+
+    assert "pto.tstore" in mlir
+
+
+def test_extent_computed_inside_the_loop_is_declined_loudly():
+    """An extent the seed cannot name is declined, not hoisted.
+
+    The re-declared seed sits before the loop, so an extent computed in the body is not in
+    scope there. Hoisting it would leave codegen with a symbol it cannot bind to a
+    dimension, a scalar parameter, or a loop variable — a worse failure than the one this
+    repair exists to fix. Here the pitches *do* differ, so declining leaves a program that
+    would corrupt data; `AccCompactValid` is what makes that a compile error instead, and
+    this test pins that the two decisions compose into a loud failure rather than a silent
+    one.
+    """
+    from pypto.ir.pass_manager import OptimizationStrategy, PassManager  # noqa: PLC0415
+
+    with passes.PassContext([]):
+        after = _lower(extent_computed_inside_the_loop)
+    assert not [call for call in _calls(after, _TILE_CREATE_OP) if call.kwargs.get("compact")]
+    assert _is_const(_valid_rows(_stored_tile_type(after)), M_TILE)
+
+    _backend.reset_for_testing()
+    _backend.set_backend_type(BackendType.Ascend910B)
+    with pytest.raises(Exception, match="AccCompactValid"):
+        with passes.PassContext([]):
+            PassManager.get_strategy(OptimizationStrategy.Default).run_passes(
+                _jit_program(extent_computed_inside_the_loop)
+            )
+
+
 def test_full_height_carry_is_left_alone():
     """Nothing narrows, so nothing is re-declared and the historical form survives."""
     after = _lower(full_height_acc)
@@ -368,13 +500,7 @@ def test_emitted_pto_stores_at_the_pitch_mad_wrote_at():
     lowered = PassManager.get_strategy(OptimizationStrategy.Default).run_passes(
         _jit_program(create_tensor_seeded_acc)
     )
-    # PTO codegen emits the device side only; the host orchestration has its own backend.
-    incore = [
-        func
-        for func in lowered.functions.values()
-        if func.func_type in (pl.FunctionType.InCore, pl.FunctionType.AIC, pl.FunctionType.AIV)
-    ]
-    mlir = codegen.PTOCodegen().generate(ir.Program(incore, lowered.name, ir.Span.unknown()))
+    mlir = codegen.PTOCodegen().generate(ir.Program(_incore_functions(lowered), lowered.name, ir.Span.unknown()))
 
     stores = [line.strip() for line in mlir.splitlines() if "pto.tstore" in line]
     assert len(stores) == 1, mlir

--- a/tests/ut/ir/transforms/test_narrow_loop_carry_valid_shape.py
+++ b/tests/ut/ir/transforms/test_narrow_loop_carry_valid_shape.py
@@ -93,6 +93,38 @@ def create_tensor_seeded_acc_2d(
 
 
 @pl.jit
+def carry_flows_into_a_later_loop(
+    x: pl.Tensor[[BLOCKS * M_TILE, K], pl.INT8],
+    w: pl.Tensor[[N_TILE, K], pl.INT8],
+    rows: pl.Tensor[[BLOCKS, 1], pl.INT32],
+    y: pl.Out[pl.Tensor[[BLOCKS * M_TILE, N_TILE], pl.INT32]],
+):
+    """Two K loops in sequence: the second carries the accumulator the first repaired.
+
+    The second loop's carry is initialised by a value this repair re-typed, so its own
+    ``IterArg`` -- and everything its body deduces from it -- has to follow, or the body
+    keeps referring to the carry at the width the seed used to have.
+    """
+    for b in pl.spmd(BLOCKS, name_hint="mm_two_loops", allow_early_resolve=True):
+        m0 = b * M_TILE
+        v = pl.min(M_TILE, pl.read(rows, [b, 0]))
+        acc = pl.create_tensor([M_TILE, N_TILE], dtype=pl.INT32)
+        for k0 in pl.pipeline(0, K // 2, K_TILE, stage=2):
+            xk = pl.slice(x, [M_TILE, K_TILE], [m0, k0], valid_shape=[v, K_TILE])
+            wk = pl.slice(w, [N_TILE, K_TILE], [0, k0])
+            if k0 == 0:
+                acc = pl.matmul(xk, wk, b_trans=True, out_dtype=pl.INT32)
+            else:
+                acc = pl.matmul_acc(acc, xk, wk, b_trans=True)
+        for k1 in pl.pipeline(K // 2, K, K_TILE, stage=2):
+            xk2 = pl.slice(x, [M_TILE, K_TILE], [m0, k1], valid_shape=[v, K_TILE])
+            wk2 = pl.slice(w, [N_TILE, K_TILE], [0, k1])
+            acc = pl.matmul_acc(acc, xk2, wk2, b_trans=True)
+        y[m0 : m0 + M_TILE, :] = acc
+    return y
+
+
+@pl.jit
 def single_fractal_block_acc(
     x: pl.Tensor[[BLOCKS * FRACTAL_ROWS, K], pl.BF16],
     w: pl.Tensor[[K, FRACTAL_N_TILE], pl.BF16],
@@ -359,6 +391,30 @@ def test_seed_is_redeclared_as_a_compact_narrowed_box():
     aliases = _calls(after, _TILE_SET_VALIDSHAPE_OP)
     assert aliases, "the compact box is narrowed through tile.set_validshape"
     assert any(_tile_view(alias.type).compact == ir.CompactMode.normal for alias in aliases)
+
+
+def test_a_repaired_carry_reaches_a_later_loops_carry():
+    """A carry initialised by a re-typed value is re-minted, and its body follows.
+
+    Substituting the init alone would leave the second loop's ``IterArg`` at the seed's
+    width while its init is narrow -- the body would deduce against the stale type and the
+    ``TypeCheck`` diagnostic (which this suite installs for every pass) would reject the
+    program before this assertion ran.
+    """
+    after = _lower(carry_flows_into_a_later_loop)
+    stored = _stored_tile_type(after)
+
+    assert not _is_const(_valid_rows(stored), M_TILE)
+    assert _tile_view(stored).compact == ir.CompactMode.normal
+    # Both loops carry the accumulator, and both must declare the narrowed extent.
+    carries = [
+        arg
+        for loop in _loops(after)
+        for arg in loop.iter_args
+        if isinstance(arg.type, ir.TileType) and arg.type.memory_space == ir.MemorySpace.Acc
+    ]
+    assert len(carries) == 2, f"expected both K loops to carry the accumulator, got {len(carries)}"
+    assert all(not _is_const(_valid_rows(arg.type), M_TILE) for arg in carries)
 
 
 def test_single_fractal_block_accumulator_is_left_alone():

--- a/tests/ut/ir/transforms/test_narrow_loop_carry_valid_shape.py
+++ b/tests/ut/ir/transforms/test_narrow_loop_carry_valid_shape.py
@@ -220,6 +220,13 @@ def _stored_tile_type(program):
     return tile_type
 
 
+def _tile_view(tile_type):
+    """The tile's explicit view, which every assertion below requires it to carry."""
+    view = tile_type.tile_view
+    assert view is not None, f"expected an explicit TileView on {tile_type}"
+    return view
+
+
 def _valid_rows(tile_type):
     view = tile_type.tile_view
     if view is None or not view.valid_shape:
@@ -243,17 +250,16 @@ def test_flatten_repairs_an_nd_seeded_carry():
     stored = _stored_tile_type(after)
 
     assert not _is_const(_valid_rows(stored), M_TILE), (
-        "the store must read the accumulator at the extent the matmuls wrote, "
-        f"got {_valid_rows(stored)}"
+        f"the store must read the accumulator at the extent the matmuls wrote, got {_valid_rows(stored)}"
     )
-    assert stored.tile_view.compact == ir.CompactMode.normal, (
+    assert _tile_view(stored).compact == ir.CompactMode.normal, (
         "a row-narrowed accumulator is packed at ceil(validRow/16)*16; without compact "
         "its reader recomputes the physical row pitch instead"
     )
     # The identity `tile.reshape` between the loop and the store must not re-derive the
     # layout from the shape -- that yields the flat default and loses Acc's NZ box.
-    assert stored.tile_view.blayout == ir.TileLayout.col_major
-    assert stored.tile_view.slayout == ir.TileLayout.row_major
+    assert _tile_view(stored).blayout == ir.TileLayout.col_major
+    assert _tile_view(stored).slayout == ir.TileLayout.row_major
     assert stored.memory_space == ir.MemorySpace.Acc
 
 
@@ -270,7 +276,7 @@ def test_convert_tensor_to_tile_ops_repairs_a_2d_seeded_carry():
     stored = _stored_tile_type(after)
 
     assert not _is_const(_valid_rows(stored), M_TILE)
-    assert stored.tile_view.compact == ir.CompactMode.normal
+    assert _tile_view(stored).compact == ir.CompactMode.normal
 
 
 def test_seed_is_redeclared_as_a_compact_narrowed_box():
@@ -289,7 +295,7 @@ def test_seed_is_redeclared_as_a_compact_narrowed_box():
 
     aliases = _calls(after, _TILE_SET_VALIDSHAPE_OP)
     assert aliases, "the compact box is narrowed through tile.set_validshape"
-    assert any(alias.type.tile_view.compact == ir.CompactMode.normal for alias in aliases)
+    assert any(_tile_view(alias.type).compact == ir.CompactMode.normal for alias in aliases)
 
 
 def test_full_height_carry_is_left_alone():

--- a/tests/ut/ir/transforms/test_narrow_loop_carry_valid_shape.py
+++ b/tests/ut/ir/transforms/test_narrow_loop_carry_valid_shape.py
@@ -1,0 +1,384 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Issue #2470: a loop carry must be typed by what its body yields, not by its seed.
+
+An accumulator seeded with ``pl.create_tensor`` before a K-loop is typed from that
+seed alone -- ``ConvertToSSA`` mints the ``IterArg`` from it and
+``ConvertTensorToTileOps`` re-mints it from the converted seed, and both force the
+loop's ``return_var`` to the same type. When every value the body yields is a matmul
+over a row-narrowed left operand, the carry keeps advertising the full box height that
+no ``mad`` ever wrote: the product lands in L0C at an N-fractal stride of
+``ceil(validRow/16)*16`` while the reader after the loop walks the buffer at the
+physical row pitch, scrambling every N-fractal above the first.
+
+The repair (``narrow_loop_carry::NarrowAccCarries``) re-declares such a seed at the
+extent the yields prove, so the existing deducers carry the narrowed, compact type
+through the body and out to the reader on their own. It runs inside the two passes that
+create the mismatch -- ``ConvertTensorToTileOps`` for a 2D seed and ``FlattenTileNdTo2D``
+for an ND one -- so no pipeline stage publishes a carry its own verifiers reject.
+"""
+
+import pypto.language as pl
+import pytest
+from pypto import backend as _backend
+from pypto import codegen, ir, passes
+from pypto.backend import BackendType
+
+BLOCKS = 4
+M_TILE = 64
+K = 1024
+N_TILE = 256
+K_TILE = 512
+
+_TILE_STORE_OP = ir.get_op("tile.store").name
+_TILE_CREATE_OP = ir.get_op("tile.create").name
+_TILE_SET_VALIDSHAPE_OP = ir.get_op("tile.set_validshape").name
+
+
+@pl.jit
+def create_tensor_seeded_acc(
+    x: pl.Tensor[[BLOCKS * M_TILE, K], pl.INT8],
+    w: pl.Tensor[[BLOCKS, N_TILE, K], pl.INT8],
+    rows: pl.Tensor[[BLOCKS, 1], pl.INT32],
+    y: pl.Out[pl.Tensor[[BLOCKS * M_TILE, N_TILE], pl.INT32]],
+):
+    """The issue #2470 shape: a full-height seed, narrowed matmuls, a peeled first K."""
+    for b in pl.spmd(BLOCKS, name_hint="mm_ct", allow_early_resolve=True):
+        m0 = b * M_TILE
+        v = pl.min(M_TILE, pl.read(rows, [b, 0]))
+        acc = pl.create_tensor([1, M_TILE, N_TILE], dtype=pl.INT32)
+        for k0 in pl.pipeline(0, K, K_TILE, stage=2):
+            xk = pl.slice(x, [M_TILE, K_TILE], [m0, k0], valid_shape=[v, K_TILE])
+            wk = w[b : b + 1, 0:N_TILE, k0 : k0 + K_TILE]
+            if k0 == 0:
+                acc = pl.matmul(xk, wk, b_trans=True, out_dtype=pl.INT32)
+            else:
+                acc = pl.matmul_acc(acc, xk, wk, b_trans=True)
+        y[m0 : m0 + M_TILE, :] = pl.reshape(acc, [M_TILE, N_TILE])
+    return y
+
+
+@pl.jit
+def create_tensor_seeded_acc_2d(
+    x: pl.Tensor[[BLOCKS * M_TILE, K], pl.INT8],
+    w: pl.Tensor[[N_TILE, K], pl.INT8],
+    rows: pl.Tensor[[BLOCKS, 1], pl.INT32],
+    y: pl.Out[pl.Tensor[[BLOCKS * M_TILE, N_TILE], pl.INT32]],
+):
+    """The same defect one pass earlier: a 2D seed narrows already in ConvertTensorToTileOps."""
+    for b in pl.spmd(BLOCKS, name_hint="mm_2d", allow_early_resolve=True):
+        m0 = b * M_TILE
+        v = pl.min(M_TILE, pl.read(rows, [b, 0]))
+        acc = pl.create_tensor([M_TILE, N_TILE], dtype=pl.INT32)
+        for k0 in pl.pipeline(0, K, K_TILE, stage=2):
+            xk = pl.slice(x, [M_TILE, K_TILE], [m0, k0], valid_shape=[v, K_TILE])
+            wk = pl.slice(w, [N_TILE, K_TILE], [0, k0])
+            if k0 == 0:
+                acc = pl.matmul(xk, wk, b_trans=True, out_dtype=pl.INT32)
+            else:
+                acc = pl.matmul_acc(acc, xk, wk, b_trans=True)
+        y[m0 : m0 + M_TILE, :] = acc
+    return y
+
+
+@pl.jit
+def full_height_acc(
+    x: pl.Tensor[[BLOCKS * M_TILE, K], pl.INT8],
+    w: pl.Tensor[[BLOCKS, N_TILE, K], pl.INT8],
+    y: pl.Out[pl.Tensor[[BLOCKS * M_TILE, N_TILE], pl.INT32]],
+):
+    """The same kernel with no narrowing: every yield fills the seed's box."""
+    for b in pl.spmd(BLOCKS, name_hint="mm_full", allow_early_resolve=True):
+        m0 = b * M_TILE
+        acc = pl.create_tensor([1, M_TILE, N_TILE], dtype=pl.INT32)
+        for k0 in pl.pipeline(0, K, K_TILE, stage=2):
+            xk = pl.slice(x, [M_TILE, K_TILE], [m0, k0])
+            wk = w[b : b + 1, 0:N_TILE, k0 : k0 + K_TILE]
+            if k0 == 0:
+                acc = pl.matmul(xk, wk, b_trans=True, out_dtype=pl.INT32)
+            else:
+                acc = pl.matmul_acc(acc, xk, wk, b_trans=True)
+        y[m0 : m0 + M_TILE, :] = pl.reshape(acc, [M_TILE, N_TILE])
+    return y
+
+
+@pl.jit
+def vec_carry_narrowed_by_yield(
+    x: pl.Tensor[[M_TILE, N_TILE], pl.FP32],
+    y: pl.Out[pl.Tensor[[M_TILE, N_TILE], pl.FP32]],
+):
+    """A Vec carry whose yields are narrower -- outside this pass's remit."""
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="vec_carry"):
+        seed: pl.Tile[[M_TILE, N_TILE], pl.FP32, pl.Mem.Vec] = pl.tile.create(
+            [M_TILE, N_TILE], dtype=pl.FP32, target_memory=pl.Mem.Vec
+        )
+        for _, (carry,) in pl.pipeline(0, 4, 1, init_values=(seed,), stage=2):
+            narrowed: pl.Tile[
+                [M_TILE, N_TILE],
+                pl.FP32,
+                pl.Mem.Vec,
+                pl.TileView(valid_shape=[16, N_TILE]),
+            ] = pl.tile.set_validshape(carry, 16, N_TILE)
+            acc: pl.Tile[[M_TILE, N_TILE], pl.FP32, pl.Mem.Vec] = pl.yield_(narrowed)
+        y = pl.tile.store(acc, [0, 0], y)
+    return y
+
+
+def _jit_program(kernel):
+    """Specialize a fully annotated JIT function without running passes."""
+    _, _, tensor_meta, scalar_values, scalar_dtypes, per_func_dyn = kernel._bind_args_from_signature({})
+    return kernel._compile_to_program(tensor_meta, scalar_values, scalar_dtypes, per_func_dyn, pl)
+
+
+_TENSOR_PREFIX = (
+    "inline_functions",
+    "unroll_loops",
+    "ctrl_flow_transform",
+    "convert_to_ssa",
+    "simplify",
+    "normalize_stmt_structure",
+    "flatten_call_expr",
+    "outline_hierarchy_scopes",
+    "outline_incore_scopes",
+    "outline_cluster_scopes",
+    "convert_tensor_to_tile_ops",
+    "optimize_orch_tensors",
+    "lower_composite_ops",
+    "flatten_tile_nd_to_2d",
+)
+
+
+def _lower(kernel, stop_after="flatten_tile_nd_to_2d"):
+    """Run the Default prefix up to and including @p stop_after.
+
+    Every pass runs under the UT-wide ``BEFORE_AND_AFTER`` verification installed by
+    ``tests/ut/conftest.py``, so these helpers double as the regression: before the
+    repair, the pass that narrows the matmul left a ``ForStmt`` declaring 64 valid rows
+    and yielding ``min(v, 64)``, and verification rejected it on the spot.
+    """
+    _backend.reset_for_testing()
+    _backend.set_backend_type(BackendType.Ascend910B)
+    program = _jit_program(kernel)
+    for name in _TENSOR_PREFIX:
+        program = getattr(passes, name)()(program)
+        if name == stop_after:
+            break
+    return program
+
+
+class _CallCollector(ir.IRVisitor):
+    """Every ``Call`` to a named operator, in traversal order."""
+
+    def __init__(self, op_name):
+        super().__init__()
+        self.op_name = op_name
+        self.calls = []
+
+    def visit_call(self, op: ir.Call) -> None:
+        if op.op.name == self.op_name:
+            self.calls.append(op)
+        super().visit_call(op)
+
+
+def _calls(program, op_name):
+    collector = _CallCollector(op_name)
+    collector.visit_program(program)
+    return collector.calls
+
+
+class _LoopCollector(ir.IRVisitor):
+    """Every ``ForStmt`` in the program, in traversal order."""
+
+    def __init__(self):
+        super().__init__()
+        self.loops = []
+
+    def visit_for_stmt(self, op: ir.ForStmt) -> None:
+        self.loops.append(op)
+        super().visit_for_stmt(op)
+
+
+def _loops(program):
+    collector = _LoopCollector()
+    collector.visit_program(program)
+    return collector.loops
+
+
+def _stored_tile_type(program):
+    """The TileType the single ``tile.store`` reads."""
+    stores = _calls(program, _TILE_STORE_OP)
+    assert len(stores) == 1, f"expected one tile.store, got {len(stores)}"
+    tile_type = stores[0].args[0].type
+    assert isinstance(tile_type, ir.TileType)
+    return tile_type
+
+
+def _valid_rows(tile_type):
+    view = tile_type.tile_view
+    if view is None or not view.valid_shape:
+        return tile_type.shape[0]
+    return view.valid_shape[0]
+
+
+def _is_const(expr, value):
+    return isinstance(expr, ir.ConstInt) and expr.value == value
+
+
+def test_flatten_repairs_an_nd_seeded_carry():
+    """The issue #2470 reproducer: the store reads the narrowed, compact accumulator.
+
+    An ND ``pl.create_tensor`` seed is only narrowed when ``FlattenTileNdTo2D`` unrolls
+    the ``tile.batch_matmul`` into 2D matmuls, so that is the pass that has to repair the
+    carry. Reaching this assertion at all means the repaired program also passed the
+    ``BEFORE_AND_AFTER`` verification the UT suite installs.
+    """
+    after = _lower(create_tensor_seeded_acc)
+    stored = _stored_tile_type(after)
+
+    assert not _is_const(_valid_rows(stored), M_TILE), (
+        "the store must read the accumulator at the extent the matmuls wrote, "
+        f"got {_valid_rows(stored)}"
+    )
+    assert stored.tile_view.compact == ir.CompactMode.normal, (
+        "a row-narrowed accumulator is packed at ceil(validRow/16)*16; without compact "
+        "its reader recomputes the physical row pitch instead"
+    )
+    # The identity `tile.reshape` between the loop and the store must not re-derive the
+    # layout from the shape -- that yields the flat default and loses Acc's NZ box.
+    assert stored.tile_view.blayout == ir.TileLayout.col_major
+    assert stored.tile_view.slayout == ir.TileLayout.row_major
+    assert stored.memory_space == ir.MemorySpace.Acc
+
+
+def test_convert_tensor_to_tile_ops_repairs_a_2d_seeded_carry():
+    """A 2D seed is narrowed one pass earlier, so it is repaired one pass earlier.
+
+    ``tensor.matmul`` drops its operands' ``valid_shape``, so the carry is still
+    consistent at pipeline input; it stops being consistent the moment
+    ``ConvertTensorToTileOps`` produces a ``tile.matmul`` over a row-narrowed left
+    operand. Stopping the prefix right there pins that the repair happens in the same
+    pass rather than several passes downstream.
+    """
+    after = _lower(create_tensor_seeded_acc_2d, stop_after="convert_tensor_to_tile_ops")
+    stored = _stored_tile_type(after)
+
+    assert not _is_const(_valid_rows(stored), M_TILE)
+    assert stored.tile_view.compact == ir.CompactMode.normal
+
+
+def test_seed_is_redeclared_as_a_compact_narrowed_box():
+    """The narrowed seed is declared, not stamped: ``tile.create(compact=True)``.
+
+    A pass-applied type refinement is discarded the moment a later pass re-deduces the
+    call (``InferTileMemorySpace`` does), whereas the kwarg is re-read by the deducer.
+    ``tile.set_validshape`` then inherits the mode onto the narrowed view without
+    re-interpreting bytes it did not write.
+    """
+    after = _lower(create_tensor_seeded_acc)
+
+    compact_creates = [call for call in _calls(after, _TILE_CREATE_OP) if call.kwargs.get("compact")]
+    assert len(compact_creates) == 1, "the re-declared seed is the only compact tile.create"
+    assert compact_creates[0].kwargs.get("target_memory") == ir.MemorySpace.Acc
+
+    aliases = _calls(after, _TILE_SET_VALIDSHAPE_OP)
+    assert aliases, "the compact box is narrowed through tile.set_validshape"
+    assert any(alias.type.tile_view.compact == ir.CompactMode.normal for alias in aliases)
+
+
+def test_full_height_carry_is_left_alone():
+    """Nothing narrows, so nothing is re-declared and the historical form survives."""
+    after = _lower(full_height_acc)
+    stored = _stored_tile_type(after)
+
+    assert _is_const(_valid_rows(stored), M_TILE)
+    assert not [call for call in _calls(after, _TILE_CREATE_OP) if call.kwargs.get("compact")]
+    assert not _calls(after, _TILE_SET_VALIDSHAPE_OP)
+
+
+def test_vec_carry_is_left_alone():
+    """Only L0C carries are re-declared.
+
+    A Vec seed may hold bytes the first iteration is entitled to read at full height,
+    and no Vec reader derives a stride from the valid row count, so narrowing one would
+    risk changing what a program computes to fix nothing. The kernel below therefore
+    stays type-check invalid, which is why it lowers without the verification instrument:
+    a carry that outlives a narrower yield is a general defect, and this repair only
+    claims the case where it also corrupts data.
+    """
+    with passes.PassContext([]):
+        after = _lower(vec_carry_narrowed_by_yield)
+
+    carries = [
+        iter_arg
+        for loop in _loops(after)
+        for iter_arg in loop.iter_args
+        if isinstance(iter_arg.type, ir.TileType)
+    ]
+    assert carries, "the Vec kernel must still have its carry"
+    assert all(_is_const(_valid_rows(carry.type), M_TILE) for carry in carries)
+    assert not [call for call in _calls(after, _TILE_CREATE_OP) if call.kwargs.get("compact")]
+
+
+@pytest.mark.parametrize("kernel", [create_tensor_seeded_acc, create_tensor_seeded_acc_2d])
+def test_default_pipeline_accepts_the_narrowed_carry(kernel):
+    """The whole Default pipeline, verification on, must accept both reproducers.
+
+    Before the repair the ``AccCompactValid`` property verifier rejected them after
+    ``InferTileMemorySpace``: every ``tile.matmul_acc`` accumulated a runtime row count
+    into a full-height, non-compact buffer.
+    """
+    from pypto.ir.pass_manager import OptimizationStrategy, PassManager  # noqa: PLC0415
+
+    _backend.reset_for_testing()
+    _backend.set_backend_type(BackendType.Ascend910B)
+    pass_manager = PassManager.get_strategy(OptimizationStrategy.Default)
+    result = pass_manager.run_passes(_jit_program(kernel))
+
+    assert result is not None
+
+
+def test_emitted_pto_stores_at_the_pitch_mad_wrote_at():
+    """End to end: the ``pto.tstore`` reads a compact tile at a runtime row extent.
+
+    This is the shape of the defect as it reached the device -- ``TSTORE`` walked L0C at
+    ``srcStride = TileData::Rows`` (the compile-time 64) while ``mad`` had written it at
+    ``ceil(validRow/16)*16``, so store N-fractal j picked up matmul N-fractal 4j and only
+    the first 16 columns of each block survived. Both halves of the agreement are visible
+    in the emitted MLIR: ``compact=1`` on the stored tile, and a dynamic (``?``) row
+    extent on the destination view, which is what makes
+    ``TStoreAccNz2nd``'s ``validRow == gShape3`` precondition hold.
+    """
+    from pypto.ir.pass_manager import OptimizationStrategy, PassManager  # noqa: PLC0415
+
+    _backend.reset_for_testing()
+    _backend.set_backend_type(BackendType.Ascend910B)
+    lowered = PassManager.get_strategy(OptimizationStrategy.Default).run_passes(
+        _jit_program(create_tensor_seeded_acc)
+    )
+    # PTO codegen emits the device side only; the host orchestration has its own backend.
+    incore = [
+        func
+        for func in lowered.functions.values()
+        if func.func_type in (pl.FunctionType.InCore, pl.FunctionType.AIC, pl.FunctionType.AIV)
+    ]
+    mlir = codegen.PTOCodegen().generate(ir.Program(incore, lowered.name, ir.Span.unknown()))
+
+    stores = [line.strip() for line in mlir.splitlines() if "pto.tstore" in line]
+    assert len(stores) == 1, mlir
+    assert "compact=1" in stores[0], (
+        f"the stored accumulator must carry the packed pitch mad wrote at:\n{stores[0]}"
+    )
+    assert "partition_tensor_view<?x" in stores[0], (
+        f"the destination must follow the tile's runtime valid rows:\n{stores[0]}"
+    )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/ut/ir/transforms/test_narrow_loop_carry_valid_shape.py
+++ b/tests/ut/ir/transforms/test_narrow_loop_carry_valid_shape.py
@@ -306,6 +306,26 @@ def _incore_functions(program):
     ]
 
 
+class _AssignVarCollector(ir.IRVisitor):
+    """Every ``AssignStmt`` var whose name starts with a prefix."""
+
+    def __init__(self, prefix: str):
+        super().__init__()
+        self.prefix = prefix
+        self.vars = []
+
+    def visit_assign_stmt(self, op: ir.AssignStmt) -> None:
+        if op.var.name_hint.startswith(self.prefix):
+            self.vars.append(op.var)
+        super().visit_assign_stmt(op)
+
+
+def _assign_vars(program, prefix):
+    collector = _AssignVarCollector(prefix)
+    collector.visit_program(program)
+    return collector.vars
+
+
 def _stored_tile_type(program):
     """The TileType the single ``tile.store`` reads."""
     stores = _calls(program, _TILE_STORE_OP)
@@ -415,6 +435,71 @@ def test_a_repaired_carry_reaches_a_later_loops_carry():
     ]
     assert len(carries) == 2, f"expected both K loops to carry the accumulator, got {len(carries)}"
     assert all(not _is_const(_valid_rows(arg.type), M_TILE) for arg in carries)
+
+
+_TILE_BATCH_MATMUL_ACC_OP = ir.get_op("tile.batch_matmul_acc").name
+_ALIAS_NAME = "acc_alias"
+
+
+class _InsertCarryAlias(ir.IRMutator):
+    """Put a bare SSA copy of the carry between the ``IterArg`` and its accumulate.
+
+    ``alias = acc`` is a legal assignment whose value is not an operator call. A repair
+    that only re-types call results would rewrite the copy's right-hand side and leave the
+    Var it binds at the seed's width — an asymmetry `AssignTypeSymmetry` and the
+    `TypeCheck` diagnostic both reject, and a dead end for the propagation, since the
+    accumulate downstream still reads the old type through the alias.
+    """
+
+    def visit_assign_stmt(self, op: ir.AssignStmt) -> ir.Stmt:
+        rebuilt = super().visit_assign_stmt(op)
+        if not isinstance(rebuilt, ir.AssignStmt):
+            return rebuilt
+        call = rebuilt.value
+        if not isinstance(call, ir.Call) or call.op.name != _TILE_BATCH_MATMUL_ACC_OP:
+            return rebuilt
+        carry = call.args[0]
+        if not isinstance(carry, ir.IterArg):
+            return rebuilt
+
+        alias = ir.Var(_ALIAS_NAME, carry.type, rebuilt.span)
+        through_alias = ir.Call(
+            call.op,
+            [alias, *list(call.args[1:])],
+            dict(call.kwargs),
+            call.type,
+            call.span,
+        )
+        return ir.SeqStmts(
+            [
+                ir.AssignStmt(alias, carry, rebuilt.span),
+                ir.AssignStmt(rebuilt.var, through_alias, rebuilt.span),
+            ],
+            rebuilt.span,
+        )
+
+
+def test_a_bare_alias_of_the_carry_is_re_typed():
+    """The propagation must cross an assignment whose value is not a call.
+
+    Reaching the assertions at all means the repaired program passed the
+    ``BEFORE_AND_AFTER`` verification this suite installs — which is where an alias left
+    at the old type is caught, as an assign-type asymmetry.
+    """
+    before = _lower(create_tensor_seeded_acc, stop_after="lower_composite_ops")
+    with_alias = _InsertCarryAlias().visit_program(before)
+    assert _assign_vars(with_alias, _ALIAS_NAME), "the alias was not injected"
+
+    after = passes.flatten_tile_nd_to_2d()(with_alias)
+
+    aliases = _assign_vars(after, _ALIAS_NAME)
+    assert aliases, "the repair dropped the alias"
+    for var in aliases:
+        assert isinstance(var.type, ir.TileType)
+        assert not _is_const(_valid_rows(var.type), M_TILE), (
+            f"the alias still binds the seed's full height: {var.type}"
+        )
+    assert not _is_const(_valid_rows(_stored_tile_type(after)), M_TILE)
 
 
 def test_single_fractal_block_accumulator_is_left_alone():

--- a/tests/ut/ir/transforms/test_narrow_loop_carry_valid_shape.py
+++ b/tests/ut/ir/transforms/test_narrow_loop_carry_valid_shape.py
@@ -25,6 +25,7 @@ create the mismatch -- ``ConvertTensorToTileOps`` for a 2D seed and ``FlattenTil
 for an ND one -- so no pipeline stage publishes a carry its own verifiers reject.
 """
 
+import pypto
 import pypto.language as pl
 import pytest
 from pypto import backend as _backend
@@ -398,7 +399,8 @@ def test_single_fractal_block_accumulator_still_reaches_codegen():
         lowered = PassManager.get_strategy(OptimizationStrategy.Default).run_passes(
             _jit_program(single_fractal_block_acc)
         )
-    mlir = codegen.PTOCodegen().generate(ir.Program(_incore_functions(lowered), lowered.name, ir.Span.unknown()))
+    device_side = ir.Program(_incore_functions(lowered), lowered.name, ir.Span.unknown())
+    mlir = codegen.PTOCodegen().generate(device_side)
 
     assert "pto.tstore" in mlir
 
@@ -423,7 +425,7 @@ def test_extent_computed_inside_the_loop_is_declined_loudly():
 
     _backend.reset_for_testing()
     _backend.set_backend_type(BackendType.Ascend910B)
-    with pytest.raises(Exception, match="AccCompactValid"):
+    with pytest.raises(pypto.Error, match="AccCompactValid"):
         with passes.PassContext([]):
             PassManager.get_strategy(OptimizationStrategy.Default).run_passes(
                 _jit_program(extent_computed_inside_the_loop)
@@ -500,7 +502,8 @@ def test_emitted_pto_stores_at_the_pitch_mad_wrote_at():
     lowered = PassManager.get_strategy(OptimizationStrategy.Default).run_passes(
         _jit_program(create_tensor_seeded_acc)
     )
-    mlir = codegen.PTOCodegen().generate(ir.Program(_incore_functions(lowered), lowered.name, ir.Span.unknown()))
+    device_side = ir.Program(_incore_functions(lowered), lowered.name, ir.Span.unknown())
+    mlir = codegen.PTOCodegen().generate(device_side)
 
     stores = [line.strip() for line in mlir.splitlines() if "pto.tstore" in line]
     assert len(stores) == 1, mlir


### PR DESCRIPTION
## Summary

Finishes #2470. Its first reproducer — an accumulator seeded by `pl.matmul` itself — was fixed by #2474, and #2531 fixed the C2V push plus the seed `AutoTileMatmulL0` synthesizes when it splits K. The reproducer in the issue's comments is the one both left: an accumulator seeded by **`pl.create_tensor` before the K-loop**, which is how the model kernel spells it.

```python
acc = pl.create_tensor([1, M_TILE, N_TILE], dtype=pl.INT32)      # full height
for k0 in pl.pipeline(0, K, K_TILE, stage=2):
    xk = pl.slice(x, [M_TILE, K_TILE], [m0, k0], valid_shape=[v, K_TILE])   # runtime v
    if k0 == 0:
        acc = pl.matmul(xk, wk, b_trans=True, out_dtype=pl.INT32)
    else:
        acc = pl.matmul_acc(acc, xk, wk, b_trans=True)
y[m0 : m0 + M_TILE, :] = pl.reshape(acc, [M_TILE, N_TILE])
```

**A loop carry is typed from its init value alone.** `ConvertToSSA` mints the `IterArg` from the reaching definition before the loop, `ConvertTensorToTileOps` re-mints it from the converted seed, and both force the loop's `return_var` back to that same type. The yields are never consulted, so the narrowing every matmul in the body produced dies at the loop boundary:

```text
acc__tile      : Tile[[64, 256], INT32]                                <- pl.create_tensor seed
  iter_arg     : Tile[[64, 256], INT32]                                <- typed from the seed
  yield        : Tile[[64, 256], INT32, Acc, valid=[min(v,64), 256], compact]
  return_var   : Tile[[64, 256], INT32]                                <- forced back to the iter_arg
```

`mad` takes M from the L0A operand's valid rows and lays the product out in L0C at an N-fractal stride of `ceil(M/16)*16` (pto-isa `TMatmul.hpp`), so a reader that believes the seed's height walks the buffer at the physical row pitch: with a 64-row box valid to 16, store fractal `j` picks up matmul fractal `4j` and only the first 16 columns of each block survive — **75264 of 131072 elements wrong** in the issue's own device run. Since #2531 it no longer ships silently; the kernel simply does not build:

```
[1] ERROR - AccCompactValid
  Message: 'tile.matmul_acc' accumulates pl.min(v__ssa_v0, 64) valid rows into an
  accumulator that is not compact (function 'mm_ct').
```

## Changes

- **The seed is re-declared at the extent the yields prove.** The seed is the only place the rest of the pipeline reads a carry's type from, so narrowing it lets the existing deducers carry the right type through the body on their own — no invented types. The form is `tile.create(compact=True)` + `tile.set_validshape`, exactly what `AutoTileMatmulL0` builds when it splits K; that builder moves into `acc_init::BuildNarrowedAccInit` (new `utils/acc_init_builder.h`) and both callers now share it, so stamper and re-declarer cannot drift on the compact rule.

- **The repair runs inside the two passes that create the mismatch**, not as a pass of its own. `ConvertTensorToTileOps` narrows a **2D** seed the moment `tensor.matmul` becomes `tile.matmul`; `FlattenTileNdTo2D` narrows an **ND** seed when `tile.batch_matmul` is unrolled into 2D matmuls. Repairing it at the source is what keeps the pipeline verifiable — measured with the repair disabled, each pass otherwise publishes a carry its own `TypeCheck` diagnostic rejects on the spot:

  ```
  Valid shape dimension mismatch in ForStmt: declared iter_arg[0] dimension[0] = 64,
  but yield value[0] dimension[0] = pl.min(v__ssa_v0, 64)
  ```

  That report never reaches production today only because `TypeChecked` is verified once, at `pipeline_input`, where `tensor.matmul` has not yet narrowed anything.

- **An identity `tile.reshape` now keeps its source's layout triple and memory space.** It re-derived the layout from the shape, which yields the space-agnostic flat default; `NormalizeImplicitTileView` rescues that only for a view that *collapses*, and an Acc box that is narrowed, padded or `compact` never does. The flat layout therefore stuck, and the store between the loop and GM read L0C as a plain row-major buffer. This is the `tile.reshape` half of the open question in #2470's comments — the identity case, which is the one this chain hits; a non-identity reshape of an explicit-view tile is still re-derived and still deserves the broader decision about who owns layout for such tiles.

Scope is deliberately narrow, and each limit is a case where widening it would risk changing what a program computes rather than fixing anything:

| Limit | Why |
| --- | --- |
| Acc carries only | L0C is where a stale extent changes the *stride* a reader uses. A Vec seed may hold bytes the first iteration is entitled to read at full height. |
| Seeds defined by `tile.create` only | That is what `pl.create_tensor` lowers to; a loaded tile or a parameter may carry bytes whose layout this must not re-interpret. |
| Provable narrowing only | A yield extent is adopted when it is provably `<=` the declared one, or when the init still fills its physical box (every `valid_shape` is bounded by that box, so a dynamic extent is already trusted to fit). An init that is *itself* already narrowed is never widened on an undecidable relation. |
| Only where the pitches would differ | `AccPitchesCoincide`, shared with the `AccCompactValid` verifier. A single-fractal-block `[16, N]` accumulator packs to its physical rows whatever its valid rows, so it keeps the exact form it has today — which is what pypto-lib's `qkv_proj_rope` projections are. |
| Only where the extent is visible before the loop | The re-declared seed sits there, and the common spelling puts the row count next to the slice it bounds, *inside* the body (`kv_rows = pl.min(KV_M_TILE, t_dim - t0)`). Hoisting that leaves codegen with a symbol it cannot bind. Such a carry is declined; where its pitches genuinely differ, `AccCompactValid` then reports it as a compile error rather than letting it corrupt data. Moving the computation instead would need the extent proven loop-invariant — a larger change than this repair. |

## Validation

Ascend910B backend, `--codegen-only`. The store now reads the accumulator at the pitch `mad` wrote at, and the destination follows the tile's runtime rows so `TStoreAccNz2nd`'s `validRow == gShape3` precondition holds:

```mlir
%acc2d__tile = pto.alloc_tile ... valid_row = %18 ...
    !pto.tile_buf<loc=acc, rows=64, cols=256, blayout=col_major, slayout=row_major, fractal=1024, compact=1>
pto.tstore ins(%acc2d__tile : ...compact=1) outs(%y__ssa_v0_pview : !pto.partition_tensor_view<?x256xi32>)
```

- **11 new UTs** (`tests/ut/ir/transforms/test_narrow_loop_carry_valid_shape.py`): both seed spellings repaired in their own pass, the re-declared form, the full-height and Vec carries that must stay untouched, the whole Default pipeline with verification on for both spellings, the emitted `pto.tstore`, and the two declined shapes — a `[16, N]` accumulator (which also compiles through to PTO codegen, where the first push of this PR reproduced CI's `cannot materialize symbol` failure verbatim) and a loop-local extent.
- **1 new device case** in `tests/st/runtime/cross_core/test_c2v_narrowed_acc_epilogue.py` — the hand-written carry, alongside that file's existing #2510 and #2470 readers.
- Every one of them was confirmed against a build with the repair disabled: the transform UTs fail on the type mismatch, and the ST case does not compile at all (`AccCompactValid`).
- `tests/ut`: **10490 passed**, 1 pre-existing environment failure (`test_symlinked_import_path_still_names_the_caller`, whose subprocess is redirected to the main checkout by this machine's editable install; it fails on an unmodified tree too).
- All `tests/lint` checks pass.

## Reviewer notes

- **The device case ran on a2a3 in CI and passed**, alongside the two this file already had:

  ```
  test_c2v_narrowed_acc_epilogue.py::TestNarrowedAccEpilogue::test_gm_stored_accumulator_carried_by_a_hand_written_loop[a2a3] PASSED
  ```

  It could not be run from my checkout: this environment's `simpler` predates the runtime bump in #2530 (`ImportError: cannot import name 'DeviceMemoryInfo' from '_task_interface'`), which blocks every ST test under `tests/st/runtime` here, including the two pre-existing ones. Locally it was compiled through the full pipeline instead, with its cube `pto.tstore` verified to be `compact=1` into a `16x128` view.
- The `acc_init` extraction preserves `AutoTileMatmulL0`'s behaviour exactly, including the static-full-rectangle short-circuit that keeps the historical single-`tile.create` form byte-for-byte.
- With this and #2531, the `MM_ROW_TILE` workaround in pypto-lib's `models/deepseek_v4_flash_mtp/expert_routed.py` should no longer be needed for either shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
