### PR TITLE
fix(runtime): support offset H2D copies in copy_to

### DIFF
--- a/docs/en/user/distributed/03-execution.md
+++ b/docs/en/user/distributed/03-execution.md
@@ -30,8 +30,7 @@ directly via `DistributedWorker(compiled)`, importable from
 | `rt.submit(compiled, x, y, z)` | Bounded asynchronous dispatch — returns a `DistributedRunHandle`. |
 | `rt.alloc_tensor(shape, dtype, *, init=None)` | Allocate a worker-resident `DeviceTensor`. `init` copies from host (one-time H2D). |
 | `rt.free_tensor(tensor)` | Release a `DeviceTensor`. |
-| `rt.copy_to(dst_dev_ptr, src_host_ptr, nbytes, *, worker_id=0)` | Explicit staged H2D copy. A host `torch.Tensor` source only needs to be CPU-contiguous and may be created after `prepare()`. |
-| `rt.copy_to_offset(dst_base_ptr, dst_offset, src_host_ptr, nbytes, *, worker_id=0)` | Explicit staged H2D copy into a sub-range of an existing device allocation. |
+| `rt.copy_to(dst_dev_ptr, src_host_ptr, nbytes, *, dst_offset=0, src_offset=0, worker_id=0)` | Explicit staged H2D copy. `dst_offset` and `src_offset` allow addressing sub-ranges: copy from ``src_host_ptr + src_offset`` into ``dst_dev_ptr + dst_offset``. A host `torch.Tensor` source only needs to be CPU-contiguous and may be created after `prepare()`. |
 | `rt.copy_from(dst_host_ptr, src_dev_ptr, nbytes, *, worker_id=0)` | Explicit staged D2H copy. A host `torch.Tensor` destination only needs to be CPU-contiguous and may be created after `prepare()`. |
 | `rt.alloc_stacked_tensor(host_w)` | Shard host_w along dim 0 — shard `i` uploaded to card `i`. Returns `StackedDeviceTensor`. |
 | `rt.free_stacked_tensor(stacked)` | Release all shards of a `StackedDeviceTensor`. |

--- a/docs/en/user/distributed/03-execution.md
+++ b/docs/en/user/distributed/03-execution.md
@@ -30,8 +30,8 @@ directly via `DistributedWorker(compiled)`, importable from
 | `rt.submit(compiled, x, y, z)` | Bounded asynchronous dispatch — returns a `DistributedRunHandle`. |
 | `rt.alloc_tensor(shape, dtype, *, init=None)` | Allocate a worker-resident `DeviceTensor`. `init` copies from host (one-time H2D). |
 | `rt.free_tensor(tensor)` | Release a `DeviceTensor`. |
-| `rt.copy_to(dst_dev_ptr, src_host_ptr, nbytes, *, dst_offset=0, src_offset=0, worker_id=0)` | Explicit staged H2D copy. `dst_offset` and `src_offset` allow addressing sub-ranges: copy from ``src_host_ptr + src_offset`` into ``dst_dev_ptr + dst_offset``. A host `torch.Tensor` source only needs to be CPU-contiguous and may be created after `prepare()`. |
-| `rt.copy_from(dst_host_ptr, src_dev_ptr, nbytes, *, worker_id=0)` | Explicit staged D2H copy. A host `torch.Tensor` destination only needs to be CPU-contiguous and may be created after `prepare()`. |
+| `rt.copy_to(dst_dev_ptr, src_host_ptr, nbytes, *, dst_offset=0, src_offset=0, worker_id=0)` | Explicit staged H2D copy. `dst_offset` and `src_offset` address sub-ranges: copy from `src_host_ptr + src_offset` into `dst_dev_ptr + dst_offset`. `dst_offset + nbytes` must fit the device allocation. A host `torch.Tensor` source only needs to be CPU-contiguous and may be created after `prepare()`. |
+| `rt.copy_from(dst_host_ptr, src_dev_ptr, nbytes, *, dst_offset=0, src_offset=0, worker_id=0)` | Explicit staged D2H copy. `dst_offset` and `src_offset` address sub-ranges: copy from `src_dev_ptr + src_offset` into `dst_host_ptr + dst_offset`. `src_offset + nbytes` must fit the device allocation. A host `torch.Tensor` destination only needs to be CPU-contiguous and may be created after `prepare()`. |
 | `rt.alloc_stacked_tensor(host_w)` | Shard host_w along dim 0 — shard `i` uploaded to card `i`. Returns `StackedDeviceTensor`. |
 | `rt.free_stacked_tensor(stacked)` | Release all shards of a `StackedDeviceTensor`. |
 | `rt.copy_stacked_from(stacked, host_out)` | Staged D2H read-back of every shard into a CPU-contiguous `host_out`; it may be allocated after `prepare()`. |
@@ -172,14 +172,44 @@ with compiled.prepare(
 ```
 
 The guarantee is about visibility, so it holds in both directions: a listed range may be
-an upload source or a read-back destination. Writability is left to the hardware — a range
-mapped `MAP_SHARED` from a read-only file descriptor faults on write rather than corrupting
-anything. Anything not listed, or allocated after `prepare()`, keeps staging exactly as
-before.
+an upload source or a read-back destination. Anything not listed, or allocated after
+`prepare()`, keeps staging exactly as before.
 
-A named upload source is granted `READ`; only a destination is granted `READWRITE`. That
-matters for a read-only mapping: describing it as writable would tell the runtime a
-consumer may write memory that faults on a write.
+**One allocation, one Buffer.** A listed tensor names its whole *storage*, not the extent
+of the view you passed. Every view of one storage therefore collapses to a single runtime
+Buffer and reaches its own bytes by offset — list `w`, `w[:2]` and `w[2:]` and you still
+get one. This is what keeps the number of Buffers a property of the memory rather than of
+which views you happened to list; a per-view Buffer would name the same bytes twice, and
+one identity may name only one backing.
+
+### Read-only backings
+
+One Buffer carries one access mode, fixed when it is created, so a listed allocation is
+declared writable by default — that is what a read-back destination needs. Wrap an entry
+in `ReadOnlyHostTensor` when the backing is shared but **not** writable, typically a
+`MAP_SHARED` mapping of a read-only file descriptor:
+
+```python
+from pypto.runtime import ReadOnlyHostTensor
+
+with compiled.prepare(
+    inherited_host_tensors=[kv_cache, ReadOnlyHostTensor(weights)],
+) as rt:
+    ...
+```
+
+That allocation's Buffer is then declared `READ`, and a `copy_from` into it raises a
+`ValueError` instead of leaving the forked child to fault on the store. Writability cannot
+be inferred any more than visibility can — torch erases it, a write probe faults rather
+than raising, and `/proc/self/maps` is Linux-only — so marking is a caller guarantee, just
+like listing the tensor in the first place.
+
+Listing one allocation both read-only and writable raises `ValueError`: one allocation has
+one access mode, and neither narrowing nor widening it silently is recoverable.
+
+The marker governs the named-copy descriptor only. Dispatch arguments are named by the
+runtime's own path, which this does not reach, so marking a dispatch IO buffer read-only
+does not stop the child from writing it.
 
 ## One-Shot vs Persistent Worker
 

--- a/docs/en/user/distributed/03-execution.md
+++ b/docs/en/user/distributed/03-execution.md
@@ -31,6 +31,7 @@ directly via `DistributedWorker(compiled)`, importable from
 | `rt.alloc_tensor(shape, dtype, *, init=None)` | Allocate a worker-resident `DeviceTensor`. `init` copies from host (one-time H2D). |
 | `rt.free_tensor(tensor)` | Release a `DeviceTensor`. |
 | `rt.copy_to(dst_dev_ptr, src_host_ptr, nbytes, *, worker_id=0)` | Explicit staged H2D copy. A host `torch.Tensor` source only needs to be CPU-contiguous and may be created after `prepare()`. |
+| `rt.copy_to_offset(dst_base_ptr, dst_offset, src_host_ptr, nbytes, *, worker_id=0)` | Explicit staged H2D copy into a sub-range of an existing device allocation. |
 | `rt.copy_from(dst_host_ptr, src_dev_ptr, nbytes, *, worker_id=0)` | Explicit staged D2H copy. A host `torch.Tensor` destination only needs to be CPU-contiguous and may be created after `prepare()`. |
 | `rt.alloc_stacked_tensor(host_w)` | Shard host_w along dim 0 — shard `i` uploaded to card `i`. Returns `StackedDeviceTensor`. |
 | `rt.free_stacked_tensor(stacked)` | Release all shards of a `StackedDeviceTensor`. |

--- a/docs/zh/user/distributed/03-execution.md
+++ b/docs/zh/user/distributed/03-execution.md
@@ -30,8 +30,8 @@ with compiled.prepare() as rt:
 | `rt.submit(compiled, x, y, z)` | 有界异步分发——返回 `DistributedRunHandle`。 |
 | `rt.alloc_tensor(shape, dtype, *, init=None)` | 分配 worker 常驻的 `DeviceTensor`。`init` 从 host 拷贝（一次性 H2D）。 |
 | `rt.free_tensor(tensor)` | 释放 `DeviceTensor`。 |
-| `rt.copy_to(dst_dev_ptr, src_host_ptr, nbytes, *, dst_offset=0, src_offset=0, worker_id=0)` | 显式 staged H2D 拷贝。`dst_offset` 和 `src_offset` 用于子区间传输：从 ``src_host_ptr + src_offset`` 拷贝到 ``dst_dev_ptr + dst_offset``。host `torch.Tensor` 源只需为 CPU 连续张量，可在 `prepare()` 后创建。 |
-| `rt.copy_from(dst_host_ptr, src_dev_ptr, nbytes, *, worker_id=0)` | 显式 staged D2H 拷贝。host `torch.Tensor` 目标只需为 CPU 连续张量，可在 `prepare()` 后创建。 |
+| `rt.copy_to(dst_dev_ptr, src_host_ptr, nbytes, *, dst_offset=0, src_offset=0, worker_id=0)` | 显式 staged H2D 拷贝。`dst_offset` 和 `src_offset` 用于子区间传输：从 `src_host_ptr + src_offset` 拷贝到 `dst_dev_ptr + dst_offset`。`dst_offset + nbytes` 必须落在 device 分配内。host `torch.Tensor` 源只需为 CPU 连续张量，可在 `prepare()` 后创建。 |
+| `rt.copy_from(dst_host_ptr, src_dev_ptr, nbytes, *, dst_offset=0, src_offset=0, worker_id=0)` | 显式 staged D2H 拷贝。`dst_offset` 和 `src_offset` 用于子区间传输：从 `src_dev_ptr + src_offset` 拷贝到 `dst_host_ptr + dst_offset`。`src_offset + nbytes` 必须落在 device 分配内。host `torch.Tensor` 目标只需为 CPU 连续张量，可在 `prepare()` 后创建。 |
 | `rt.alloc_stacked_tensor(host_w)` | 沿 dim 0 分片 `host_w`——分片 `i` 上传到卡 `i`。返回 `StackedDeviceTensor`。 |
 | `rt.free_stacked_tensor(stacked)` | 释放 `StackedDeviceTensor` 的所有分片。 |
 | `rt.copy_stacked_from(stacked, host_out)` | staged D2H 读回 CPU 连续的 `host_out`；可在 `prepare()` 后分配。 |
@@ -153,11 +153,39 @@ with compiled.prepare(
 ```
 
 这项保证针对的是可见性，因此两个方向都成立：被列入的区间既可作上传源，也可作读回目标。
-可写性交由硬件负责——以只读文件描述符建立的 `MAP_SHARED` 映射在写入时会直接触发错误，
-而不会破坏任何数据。未列入的张量，或在 `prepare()` 之后分配的张量，其行为与此前完全一致。
+未列入的张量，或在 `prepare()` 之后分配的张量，其行为与此前完全一致。
 
-被命名的上传源只授予 `READ`，只有目标才授予 `READWRITE`。这对只读映射很关键：把它
-描述为可写，等于告诉 runtime 消费者可以写一段写入即出错的内存。
+**一次分配，一个 Buffer。** 被列入的张量命名的是它的整个 *storage*，而不是你传入的那个
+视图的范围。因此同一 storage 的所有视图都归并到同一个 runtime Buffer，各自通过 offset
+访问自己的字节——同时列入 `w`、`w[:2]` 和 `w[2:]`，得到的仍然只有一个。这样 Buffer 的
+数量就取决于内存本身，而不取决于你碰巧列入了哪些视图；按视图各建一个会让同一段字节被
+命名两次，而一个 identity 只能命名一份后备内存。
+
+### 只读后备内存
+
+一个 Buffer 只带一种访问模式，且在创建时就定死，因此被列入的分配默认声明为可写——读回
+目标需要的正是这一点。当后备内存是共享但**不可写**时（典型情况是以只读文件描述符建立的
+`MAP_SHARED` 映射），把该项用 `ReadOnlyHostTensor` 包装：
+
+```python
+from pypto.runtime import ReadOnlyHostTensor
+
+with compiled.prepare(
+    inherited_host_tensors=[kv_cache, ReadOnlyHostTensor(weights)],
+) as rt:
+    ...
+```
+
+该分配的 Buffer 随之声明为 `READ`，对它执行 `copy_from` 会抛出 `ValueError`，而不是把
+写入错误留给 fork 出的子进程去触发。可写性和可见性一样无法推断——torch 会把它抹掉，写
+探测只会直接出错而非抛异常，`/proc/self/maps` 又仅限 Linux——所以标记同样是调用方作出的
+保证，与列入该列表本身性质相同。
+
+把同一个分配既列为只读又列为可写会抛出 `ValueError`：一次分配只有一种访问模式，无论
+静默取窄还是取宽都无法挽回。
+
+该标记只作用于命名拷贝的 descriptor。dispatch 参数由 runtime 自己的路径命名，不经过这里，
+因此把一个 dispatch IO buffer 标记为只读并不能阻止子进程写它。
 
 ## One-Shot vs 持久 Worker
 

--- a/docs/zh/user/distributed/03-execution.md
+++ b/docs/zh/user/distributed/03-execution.md
@@ -31,6 +31,7 @@ with compiled.prepare() as rt:
 | `rt.alloc_tensor(shape, dtype, *, init=None)` | 分配 worker 常驻的 `DeviceTensor`。`init` 从 host 拷贝（一次性 H2D）。 |
 | `rt.free_tensor(tensor)` | 释放 `DeviceTensor`。 |
 | `rt.copy_to(dst_dev_ptr, src_host_ptr, nbytes, *, worker_id=0)` | 显式 staged H2D 拷贝。host `torch.Tensor` 源只需为 CPU 连续张量，可在 `prepare()` 后创建。 |
+| `rt.copy_to_offset(dst_base_ptr, dst_offset, src_host_ptr, nbytes, *, worker_id=0)` | 显式 staged H2D 拷贝到常驻设备缓冲区的子区间。 |
 | `rt.copy_from(dst_host_ptr, src_dev_ptr, nbytes, *, worker_id=0)` | 显式 staged D2H 拷贝。host `torch.Tensor` 目标只需为 CPU 连续张量，可在 `prepare()` 后创建。 |
 | `rt.alloc_stacked_tensor(host_w)` | 沿 dim 0 分片 `host_w`——分片 `i` 上传到卡 `i`。返回 `StackedDeviceTensor`。 |
 | `rt.free_stacked_tensor(stacked)` | 释放 `StackedDeviceTensor` 的所有分片。 |

--- a/docs/zh/user/distributed/03-execution.md
+++ b/docs/zh/user/distributed/03-execution.md
@@ -30,8 +30,7 @@ with compiled.prepare() as rt:
 | `rt.submit(compiled, x, y, z)` | 有界异步分发——返回 `DistributedRunHandle`。 |
 | `rt.alloc_tensor(shape, dtype, *, init=None)` | 分配 worker 常驻的 `DeviceTensor`。`init` 从 host 拷贝（一次性 H2D）。 |
 | `rt.free_tensor(tensor)` | 释放 `DeviceTensor`。 |
-| `rt.copy_to(dst_dev_ptr, src_host_ptr, nbytes, *, worker_id=0)` | 显式 staged H2D 拷贝。host `torch.Tensor` 源只需为 CPU 连续张量，可在 `prepare()` 后创建。 |
-| `rt.copy_to_offset(dst_base_ptr, dst_offset, src_host_ptr, nbytes, *, worker_id=0)` | 显式 staged H2D 拷贝到常驻设备缓冲区的子区间。 |
+| `rt.copy_to(dst_dev_ptr, src_host_ptr, nbytes, *, dst_offset=0, src_offset=0, worker_id=0)` | 显式 staged H2D 拷贝。`dst_offset` 和 `src_offset` 用于子区间传输：从 ``src_host_ptr + src_offset`` 拷贝到 ``dst_dev_ptr + dst_offset``。host `torch.Tensor` 源只需为 CPU 连续张量，可在 `prepare()` 后创建。 |
 | `rt.copy_from(dst_host_ptr, src_dev_ptr, nbytes, *, worker_id=0)` | 显式 staged D2H 拷贝。host `torch.Tensor` 目标只需为 CPU 连续张量，可在 `prepare()` 后创建。 |
 | `rt.alloc_stacked_tensor(host_w)` | 沿 dim 0 分片 `host_w`——分片 `i` 上传到卡 `i`。返回 `StackedDeviceTensor`。 |
 | `rt.free_stacked_tensor(stacked)` | 释放 `StackedDeviceTensor` 的所有分片。 |

--- a/python/pypto/ir/distributed_compiled_program.py
+++ b/python/pypto/ir/distributed_compiled_program.py
@@ -52,7 +52,7 @@ from .compiled_program import (
 _META_SCHEMA = 2
 
 if TYPE_CHECKING:
-    from pypto.runtime.distributed_runner import DistributedWorker
+    from pypto.runtime.distributed_runner import DistributedWorker, ReadOnlyHostTensor
     from pypto.runtime.runner import RunConfig
 
 
@@ -481,7 +481,7 @@ class DistributedCompiledProgram:
         reset_persistent_windows: bool | None = None,
         callbacks: dict[str, Callable[..., Any]] | None = None,
         sub_worker_overrides: dict[str, Callable[..., Any]] | None = None,
-        inherited_host_tensors: Sequence[torch.Tensor] | None = None,
+        inherited_host_tensors: "Sequence[torch.Tensor | ReadOnlyHostTensor] | None" = None,
         startup_timeout_s: float | None = None,
     ) -> "DistributedWorker":
         """Prepare a reusable L3 execution handle (setup once, dispatch many).
@@ -548,7 +548,10 @@ class DistributedCompiledProgram:
                 ``MAP_PRIVATE`` backing is unsupported and may upload stale or
                 incorrect data; see :class:`DistributedWorker` for the full
                 contract and for the warning emitted when the guarantee cannot
-                be confirmed.
+                be confirmed. An entry may be wrapped in
+                :class:`~pypto.runtime.ReadOnlyHostTensor` when the backing is
+                shared but not writable, which makes ``copy_from`` into it raise
+                instead of faulting in the forked child.
             startup_timeout_s: Optional positive finite bound, in seconds, for
                 the forked worker hierarchy to report startup readiness. ``None``
                 keeps Simpler's default timeout.

--- a/python/pypto/runtime/__init__.py
+++ b/python/pypto/runtime/__init__.py
@@ -26,7 +26,12 @@ Example::
 
 from .bench import BenchmarkStats, TraceInvocation, TraceSpan, benchmark
 from .device_tensor import DeviceTensor, StackedDeviceTensor
-from .distributed_runner import DistributedRunHandle, DistributedWorker, execute_distributed_compiled
+from .distributed_runner import (
+    DistributedRunHandle,
+    DistributedWorker,
+    ReadOnlyHostTensor,
+    execute_distributed_compiled,
+)
 from .log_config import _ensure_configured as _ensure_log_configured
 from .log_config import configure_log
 from .log_config import current_level as log_level
@@ -57,6 +62,7 @@ __all__ = [
     "StackedDeviceTensor",
     "DistributedWorker",
     "DistributedRunHandle",
+    "ReadOnlyHostTensor",
     "RegistrationHandle",
     "RunConfig",
     "RunResult",

--- a/python/pypto/runtime/distributed_runner.py
+++ b/python/pypto/runtime/distributed_runner.py
@@ -1439,6 +1439,32 @@ def execute_distributed_compiled(
     return compiled(*args, config=config)
 
 
+# ``eq=False`` keeps identity semantics: a generated ``__eq__`` would compare the tensor
+# field with ``==``, which yields a tensor and raises on ``bool()`` for anything but a
+# single element. Equality of two markers is not a question worth answering anyway.
+@dataclass(frozen=True, eq=False)
+class ReadOnlyHostTensor:
+    """An ``inherited_host_tensors`` entry a worker may read but never write.
+
+    Wrap a tensor whose backing is ``MAP_SHARED`` from a read-only fd: it is genuinely
+    visible across processes — so it is worth naming in place rather than staging — and
+    still faults on a write. The allocation's Buffer is then declared ``AccessMode.READ``,
+    which makes the ABI refuse a D2H into it instead of leaving the forked child to fault
+    on the store.
+
+    Writability cannot be inferred, for the same reason visibility cannot: ``torch`` erases
+    it (``torch.from_numpy`` on a read-only array yields a writable tensor), a write probe
+    faults rather than raising, and ``/proc/self/maps`` would tie this to Linux. Marking is
+    therefore a caller guarantee, exactly like listing the tensor in the first place.
+
+    The marker governs the **named-copy** descriptor only. Dispatch arguments are named by
+    the runtime's own path (``Worker.make_tensor_arg``), which this does not reach, so
+    marking a dispatch IO buffer read-only does not stop the child from writing it.
+    """
+
+    tensor: torch.Tensor
+
+
 class DistributedWorker(Worker):
     """L3 distributed execution handle: prepare once, dispatch many.
 
@@ -1475,6 +1501,14 @@ class DistributedWorker(Worker):
     ``False`` for valid external ``MAP_SHARED`` mappings — so it warns once at
     prepare time for the tensors it cannot confirm and proceeds. Listing a tensor
     does not make it a valid direct dispatch argument.
+
+    The guarantee is made per *allocation*: a listed tensor names its whole storage,
+    so every view of one storage shares one Buffer and reaches its own bytes by
+    offset. Wrap an entry in :class:`ReadOnlyHostTensor` when the backing is shared
+    but not writable — a ``MAP_SHARED`` mapping of a read-only fd. That allocation's
+    Buffer is then declared ``READ``, and :meth:`copy_from` into it is refused
+    instead of faulting inside the forked child. Listing the same allocation both
+    read-only and writable is a ``ValueError``: one allocation has one access mode.
 
     ``callbacks`` binds a caller-supplied callable to a SubWorker by name — e.g.
     a real sampling closure. Abstract SubWorkers (declared with a ``...`` body)
@@ -1523,7 +1557,7 @@ class DistributedWorker(Worker):
         reset_persistent_windows: bool | None = None,
         callbacks: dict[str, Callable[..., Any]] | None = None,
         sub_worker_overrides: dict[str, Callable[..., Any]] | None = None,
-        inherited_host_tensors: Sequence[torch.Tensor] | None = None,
+        inherited_host_tensors: Sequence[torch.Tensor | ReadOnlyHostTensor] | None = None,
         startup_timeout_s: float | None = None,
     ) -> None:
         super().__init__()  # initialize Worker ABC state (_owned_tensors)
@@ -1534,42 +1568,8 @@ class DistributedWorker(Worker):
         self._device_buffers: dict[tuple[int, int], Any] = {}
         callbacks = _coalesce_callbacks(callbacks, sub_worker_overrides)
         reset_persistent_windows = _resolve_persistent_window_reset(persistent, reset_persistent_windows)
-        inherited = tuple(inherited_host_tensors) if inherited_host_tensors is not None else ()
-        for tensor in inherited:
-            if not isinstance(tensor, torch.Tensor):
-                raise TypeError(
-                    "DistributedWorker inherited_host_tensors entries must be torch.Tensor objects, "
-                    f"got {type(tensor).__name__}."
-                )
-            if tensor.device.type != "cpu" or not tensor.is_contiguous():
-                raise ValueError(
-                    "DistributedWorker inherited_host_tensors must be contiguous CPU tensors; "
-                    f"got device={tensor.device} shape={tuple(tensor.shape)}."
-                )
+        inherited, self._inherited_host_spans = self._resolve_inherited_host_tensors(inherited_host_tensors)
         self._inherited_host_tensors = inherited
-        # `copy_to` / `copy_from` stage through a simpler-owned shm Buffer so an ordinary
-        # post-fork tensor is a legal endpoint. That relaxation costs one full copy of the
-        # payload, which a fork-inherited range visible across processes does not need:
-        # parent and child see the same pages, so it can be named in place. Record the
-        # extents here, where the tensors are still in hand, since an address alone says
-        # nothing about its backing.
-        #
-        # Listing a tensor is the caller's guarantee that the backing is cross-process
-        # visible (see the class docstring). It is not inferred, because no portable check
-        # exists: `torch.is_shared()` answers "is this storage a torch shared-memory
-        # allocation", which is a different question. A read-only MAP_SHARED file mapping
-        # built with `mmap` + `from_numpy` is genuinely shared at the OS level and still
-        # reports False, so inference would reject exactly the case that benefits most,
-        # while reading /proc/self/maps would tie this file to Linux and the simulator also
-        # runs on macOS.
-        inherited_host_spans: tuple[tuple[int, int], ...] = tuple(
-            (
-                tensor.data_ptr(),
-                tensor.data_ptr() + tensor.numel() * tensor.element_size(),
-            )
-            for tensor in inherited
-        )
-        self._inherited_host_spans = self._merge_overlapping_spans(inherited_host_spans)
         # `is_shared()` is kept as a one-way signal: True confirms a torch-managed shared
         # backing, False is inconclusive. Warn once rather than per tensor, and never
         # reject or silently fall back to staging — falling back would hide the cost this
@@ -2274,23 +2274,90 @@ class DistributedWorker(Worker):
         return int(info.free_bytes), int(info.total_bytes)
 
     @staticmethod
-    def _merge_overlapping_spans(
-        spans: tuple[tuple[int, int], ...],
-    ) -> tuple[tuple[int, int], ...]:
-        """Canonicalize aliased spans without joining adjacent allocations."""
-        merged: list[tuple[int, int]] = []
-        for start, stop in sorted(set(spans)):
-            if stop <= start:
-                continue
-            if merged and start < merged[-1][1]:
-                previous_start, previous_stop = merged[-1]
-                merged[-1] = (previous_start, max(previous_stop, stop))
-            else:
-                merged.append((start, stop))
-        return tuple(merged)
+    def _storage_span(tensor: torch.Tensor) -> tuple[int, int]:
+        """``(start, stop)`` of the *allocation* backing *tensor*, not of the view itself.
 
-    def _named_buffer_for_span(self, host_ptr: int, nbytes: int) -> Any:
-        """Return the unique runtime Buffer object for one canonical inherited span."""
+        Every view of one storage answers with the identical span, which is what makes one
+        allocation resolve to one Buffer no matter which views the caller listed.
+        """
+        storage = tensor.untyped_storage()
+        base = int(storage.data_ptr())
+        return base, base + int(storage.nbytes())
+
+    @classmethod
+    def _resolve_inherited_host_tensors(
+        cls,
+        entries: Sequence[torch.Tensor | ReadOnlyHostTensor] | None,
+    ) -> tuple[tuple[torch.Tensor, ...], tuple[tuple[tuple[int, int], bool], ...]]:
+        """Validate the listed entries and reduce them to ``(tensors, spans)``.
+
+        `copy_to` / `copy_from` stage through a simpler-owned shm Buffer so an ordinary
+        post-fork tensor is a legal endpoint. That relaxation costs one full copy of the
+        payload, which a fork-inherited range visible across processes does not need: parent
+        and child see the same pages, so it can be named in place. The extents are recorded
+        here, while the tensors are still in hand, since an address alone says nothing about
+        its backing.
+
+        Listing a tensor is the caller's guarantee that the backing is cross-process visible
+        (see the class docstring). It is not inferred, because no portable check exists:
+        ``torch.is_shared()`` answers "is this storage a torch shared-memory allocation",
+        which is a different question. A read-only MAP_SHARED file mapping built with ``mmap``
+        + ``from_numpy`` is genuinely shared at the OS level and still reports False, so
+        inference would reject exactly the case that benefits most, while reading
+        ``/proc/self/maps`` would tie this file to Linux and the simulator also runs on macOS.
+
+        A span is one *allocation* (the tensor's storage), not the listed view's extent: the
+        allocation is the unit a Buffer names, so every view of one storage collapses to one
+        span and reaches its own bytes by offset. Recording view extents instead would make
+        the number of Buffers a function of which views the caller happened to list — two
+        disjoint slices of one storage would name it twice. Naming the storage widens the
+        guarantee from the listed view to the allocation containing it, which holds for free:
+        a storage is one mapping, so if any part of it is cross-process visible, all of it is.
+        This mirrors how the runtime's own dispatch path names a host tensor
+        (``Worker.make_tensor_arg`` memoizes per storage base, then separates views by
+        ``byte_offset``).
+        """
+        listed = tuple(entries) if entries is not None else ()
+        tensors: list[torch.Tensor] = []
+        span_read_only: dict[tuple[int, int], bool] = {}
+        for entry in listed:
+            is_marked = isinstance(entry, ReadOnlyHostTensor)
+            tensor = entry.tensor if is_marked else entry
+            if not isinstance(tensor, torch.Tensor):
+                raise TypeError(
+                    "DistributedWorker inherited_host_tensors entries must be torch.Tensor or "
+                    f"ReadOnlyHostTensor objects, got {type(entry).__name__}."
+                )
+            if tensor.device.type != "cpu" or not tensor.is_contiguous():
+                raise ValueError(
+                    "DistributedWorker inherited_host_tensors must be contiguous CPU tensors; "
+                    f"got device={tensor.device} shape={tuple(tensor.shape)}."
+                )
+            tensors.append(tensor)
+            span = cls._storage_span(tensor)
+            previous = span_read_only.get(span)
+            # One allocation, one Buffer, so one access mode. Taking the narrower would make a
+            # later copy_from fail for a range the caller did list as writable; taking the wider
+            # would discard a read-only guarantee. Neither is recoverable, so refuse instead.
+            if previous is not None and previous != is_marked:
+                raise ValueError(
+                    f"DistributedWorker inherited_host_tensors: the allocation at 0x{span[0]:x} is "
+                    "listed both read-only and writable; one allocation has one access mode."
+                )
+            span_read_only[span] = is_marked
+        return tuple(tensors), tuple(sorted(span_read_only.items()))
+
+    def _named_buffer_for_span(self, host_ptr: int, nbytes: int, *, read_only: bool) -> Any:
+        """Return the unique runtime Buffer object for one inherited allocation.
+
+        The access mode is fixed here and never revisited: one Buffer carries one canonical
+        identity, ``ImportRegistry.materialize`` refuses a second descriptor for an identity it
+        already handed out, and ``re_export`` copies access through rather than narrowing it. A
+        span therefore cannot be READ for uploads and READWRITE for read-backs, so the default is
+        the writable one a bidirectional span needs, and only a span the caller explicitly marked
+        :class:`ReadOnlyHostTensor` keeps READ — which is what lets the ABI refuse a D2H into a
+        mapping that would fault on the store.
+        """
         from simpler.buffer import (  # noqa: PLC0415  # pyright: ignore[reportMissingImports]
             AccessMode,
             BackendKind,
@@ -2313,13 +2380,13 @@ class DistributedWorker(Worker):
                 nbytes,
                 owner,
                 self._buffer_id_seq,
-                access=AccessMode.READWRITE,
+                access=AccessMode.READ if read_only else AccessMode.READWRITE,
                 backend_kind=BackendKind.FORK_SHM,
             )
             self._named_host_buffers[key] = buffer
             return buffer
 
-    def _named_host_buffer(self, host_ptr: int, nbytes: int) -> tuple[Any, int] | None:
+    def _named_host_buffer(self, host_ptr: int, nbytes: int) -> tuple[Any, int, bool] | None:
         """Name a fork-inherited MAP_SHARED host range in place, or ``None`` to stage it.
 
         Only memory registered through ``inherited_host_tensors`` can be named at all: it
@@ -2337,16 +2404,18 @@ class DistributedWorker(Worker):
         A ``MAP_PRIVATE`` backing is unsupported here rather than handled: the child keeps
         reading its pre-fork snapshot, so the caller would upload stale bytes.
 
-        The complete registered span is always wrapped as one ``READWRITE`` Buffer. A requested
-        sub-range returns that same Buffer object plus its relative offset, which the runtime copy
-        API applies without creating another Buffer for the same memory.
+        A whole registered allocation is wrapped as one Buffer. A requested sub-range returns
+        that same Buffer object plus its offset within the allocation and whether the caller
+        marked it read-only, so the runtime copy API reaches the sub-range without a second
+        Buffer for the same memory.
         """
         end = host_ptr + nbytes
-        for start, stop in self._inherited_host_spans:
+        for (start, stop), read_only in self._inherited_host_spans:
             if host_ptr < start or end > stop:
                 continue
             span_nbytes = stop - start
-            return self._named_buffer_for_span(start, span_nbytes), host_ptr - start
+            buffer = self._named_buffer_for_span(start, span_nbytes, read_only=read_only)
+            return buffer, host_ptr - start, read_only
         return None
 
     def copy_to(
@@ -2379,7 +2448,7 @@ class DistributedWorker(Worker):
         src_ptr = int(src_host_ptr) + src_offset
         named_src = self._named_host_buffer(src_ptr, int(nbytes))
         if named_src is not None:
-            src, named_src_offset = named_src
+            src, named_src_offset, _read_only = named_src
             self._w.copy_to(
                 dst,
                 src,
@@ -2395,21 +2464,54 @@ class DistributedWorker(Worker):
         finally:
             self._w.release_buffer(host)
 
-    def copy_from(self, dst_host_ptr: int, src_dev_ptr: int, nbytes: int, *, worker_id: int = 0) -> None:
-        """D2H copy: ``nbytes`` from device *src_dev_ptr* back to host *dst_host_ptr*."""
+    def copy_from(
+        self,
+        dst_host_ptr: int,
+        src_dev_ptr: int,
+        nbytes: int,
+        *,
+        dst_offset: int = 0,
+        src_offset: int = 0,
+        worker_id: int = 0,
+    ) -> None:
+        """D2H copy: ``nbytes`` from ``src_dev_ptr + src_offset`` to ``dst_host_ptr + dst_offset``."""
         self._require_open("copy_from")
         src = self._device_buffer(src_dev_ptr, worker_id, "copy_from")
+        if not isinstance(dst_offset, int) or dst_offset < 0:
+            raise ValueError(f"dst_offset must be a non-negative int, got {dst_offset!r}")
+        if not isinstance(src_offset, int) or src_offset < 0:
+            raise ValueError(f"src_offset must be a non-negative int, got {src_offset!r}")
         if not isinstance(nbytes, int) or nbytes <= 0:
             raise ValueError(f"nbytes must be a positive int, got {nbytes!r}")
-        named_dst = self._named_host_buffer(int(dst_host_ptr), int(nbytes))
+
+        allocation_nbytes = int(src.nbytes)
+        if src_offset + nbytes > allocation_nbytes:
+            raise ValueError(
+                f"DistributedWorker.copy_from(src_offset={src_offset}, nbytes={nbytes}) exceeds "
+                f"allocation size {allocation_nbytes}"
+            )
+
+        dst_ptr = int(dst_host_ptr) + dst_offset
+        named_dst = self._named_host_buffer(dst_ptr, int(nbytes))
         if named_dst is not None:
-            dst, named_dst_offset = named_dst
-            self._w.copy_from(dst, src, dst_offset=named_dst_offset, nbytes=nbytes)
+            dst, named_dst_offset, read_only = named_dst
+            if read_only:
+                raise ValueError(
+                    f"DistributedWorker.copy_from: 0x{dst_ptr:x} lies in a host allocation listed as "
+                    "ReadOnlyHostTensor; a D2H destination must be writable."
+                )
+            self._w.copy_from(
+                dst,
+                src,
+                dst_offset=named_dst_offset,
+                src_offset=src_offset,
+                nbytes=nbytes,
+            )
             return
         host = self._w.create_buffer(nbytes)
         try:
-            self._w.copy_from(host, src)
-            ctypes.memmove(dst_host_ptr, int(host.base), nbytes)
+            self._w.copy_from(host, src, src_offset=src_offset, nbytes=nbytes)
+            ctypes.memmove(dst_ptr, int(host.base), nbytes)
         finally:
             self._w.release_buffer(host)
 

--- a/python/pypto/runtime/distributed_runner.py
+++ b/python/pypto/runtime/distributed_runner.py
@@ -2369,52 +2369,42 @@ class DistributedWorker(Worker):
             )
         return None
 
-    def copy_to(self, dst_dev_ptr: int, src_host_ptr: int, nbytes: int, *, worker_id: int = 0) -> None:
-        """H2D copy: ``nbytes`` from host *src_host_ptr* to device *dst_dev_ptr*."""
-        self._require_open("copy_to")
-        dst = self._device_buffer(dst_dev_ptr, worker_id, "copy_to")
-        if not isinstance(nbytes, int) or nbytes <= 0:
-            raise ValueError(f"nbytes must be a positive int, got {nbytes!r}")
-        src = self._named_host_buffer(int(src_host_ptr), int(nbytes))
-        if src is not None:
-            self._w.copy_to(dst, src)
-            return
-        host = self._w.create_buffer(nbytes)
-        try:
-            ctypes.memmove(int(host.base), src_host_ptr, nbytes)
-            self._w.copy_to(dst, host)
-        finally:
-            self._w.release_buffer(host)
-
-    def copy_to_offset(
+    def copy_to(
         self,
-        dst_base_ptr: int,
-        dst_offset: int,
+        dst_dev_ptr: int,
         src_host_ptr: int,
         nbytes: int,
         *,
+        dst_offset: int = 0,
+        src_offset: int = 0,
         worker_id: int = 0,
     ) -> None:
-        """H2D copy into a validated sub-range of a live device allocation."""
-        self._require_open("copy_to_offset")
-        dst = self._device_buffer(dst_base_ptr, worker_id, "copy_to_offset")
+        """H2D copy: ``nbytes`` from ``src_host_ptr + src_offset`` to ``dst_dev_ptr + dst_offset``."""
+        self._require_open("copy_to")
+        dst = self._device_buffer(dst_dev_ptr, worker_id, "copy_to")
         if not isinstance(dst_offset, int) or dst_offset < 0:
             raise ValueError(f"dst_offset must be a non-negative int, got {dst_offset!r}")
+        if not isinstance(src_offset, int) or src_offset < 0:
+            raise ValueError(f"src_offset must be a non-negative int, got {src_offset!r}")
         if not isinstance(nbytes, int) or nbytes <= 0:
             raise ValueError(f"nbytes must be a positive int, got {nbytes!r}")
+
         allocation_nbytes = int(dst.nbytes)
         if dst_offset + nbytes > allocation_nbytes:
             raise ValueError(
-                f"DistributedWorker.copy_to_offset(dst_offset={dst_offset}, nbytes={nbytes}) exceeds "
+                f"DistributedWorker.copy_to(dst_offset={dst_offset}, nbytes={nbytes}) exceeds "
                 f"allocation size {allocation_nbytes}"
             )
+
+        src_ptr = int(src_host_ptr) + src_offset
+        src = self._named_host_buffer(src_ptr, int(nbytes))
+        if src is not None:
+            self._w.copy_to(dst, src, dst_offset=dst_offset, nbytes=nbytes)
+            return
         host = self._w.create_buffer(nbytes)
         try:
-            ctypes.memmove(int(host.base), src_host_ptr, nbytes)
-            if dst_offset == 0:
-                self._w.copy_to(dst, host)
-            else:
-                self._w.copy_to(dst, host, dst_offset)
+            ctypes.memmove(int(host.base), src_ptr, nbytes)
+            self._w.copy_to(dst, host, dst_offset=dst_offset, nbytes=nbytes)
         finally:
             self._w.release_buffer(host)
 

--- a/python/pypto/runtime/distributed_runner.py
+++ b/python/pypto/runtime/distributed_runner.py
@@ -2386,6 +2386,38 @@ class DistributedWorker(Worker):
         finally:
             self._w.release_buffer(host)
 
+    def copy_to_offset(
+        self,
+        dst_base_ptr: int,
+        dst_offset: int,
+        src_host_ptr: int,
+        nbytes: int,
+        *,
+        worker_id: int = 0,
+    ) -> None:
+        """H2D copy into a validated sub-range of a live device allocation."""
+        self._require_open("copy_to_offset")
+        dst = self._device_buffer(dst_base_ptr, worker_id, "copy_to_offset")
+        if not isinstance(dst_offset, int) or dst_offset < 0:
+            raise ValueError(f"dst_offset must be a non-negative int, got {dst_offset!r}")
+        if not isinstance(nbytes, int) or nbytes <= 0:
+            raise ValueError(f"nbytes must be a positive int, got {nbytes!r}")
+        allocation_nbytes = int(dst.nbytes)
+        if dst_offset + nbytes > allocation_nbytes:
+            raise ValueError(
+                f"DistributedWorker.copy_to_offset(dst_offset={dst_offset}, nbytes={nbytes}) exceeds "
+                f"allocation size {allocation_nbytes}"
+            )
+        host = self._w.create_buffer(nbytes)
+        try:
+            ctypes.memmove(int(host.base), src_host_ptr, nbytes)
+            if dst_offset == 0:
+                self._w.copy_to(dst, host)
+            else:
+                self._w.copy_to(dst, host, dst_offset)
+        finally:
+            self._w.release_buffer(host)
+
     def copy_from(self, dst_host_ptr: int, src_dev_ptr: int, nbytes: int, *, worker_id: int = 0) -> None:
         """D2H copy: ``nbytes`` from device *src_dev_ptr* back to host *dst_host_ptr*."""
         self._require_open("copy_from")

--- a/python/pypto/runtime/distributed_runner.py
+++ b/python/pypto/runtime/distributed_runner.py
@@ -1562,13 +1562,14 @@ class DistributedWorker(Worker):
         # reports False, so inference would reject exactly the case that benefits most,
         # while reading /proc/self/maps would tie this file to Linux and the simulator also
         # runs on macOS.
-        self._inherited_host_spans: tuple[tuple[int, int], ...] = tuple(
+        inherited_host_spans: tuple[tuple[int, int], ...] = tuple(
             (
                 tensor.data_ptr(),
                 tensor.data_ptr() + tensor.numel() * tensor.element_size(),
             )
             for tensor in inherited
         )
+        self._inherited_host_spans = self._merge_overlapping_spans(inherited_host_spans)
         # `is_shared()` is kept as a one-way signal: True confirms a torch-managed shared
         # backing, False is inconclusive. Warn once rather than per tensor, and never
         # reject or silently fall back to staging — falling back would hide the cost this
@@ -1585,18 +1586,13 @@ class DistributedWorker(Worker):
             )
         self._buffer_owner_id: bytes | None = None
         self._buffer_id_seq = 0
-        # One identity per host *range*, not per copy. Both properties this buys are load
-        # bearing: a consumer's ImportRegistry only drops an entry when the owner releases the
-        # Buffer, which a named copy never does, so minting per copy would leave one permanent
-        # ImportedBuffer per copy in every chip child — unbounded for a per-step D2H read-back.
-        # And re-copying the same range must reuse its identity, because one identity may name
-        # only one backing: `materialize` refuses a second descriptor for an identity it has
-        # already handed out.
-        self._named_identities: dict[tuple[int, int, bool], tuple[bytes, int]] = {}
-        # Minting is not atomic (`+=` is load/add/store, and the lazy owner mint is
-        # check-then-act) while `alloc_stacked_tensor` runs one thread per chip through this
-        # path, so the cache and the counter are guarded together.
-        self._named_identity_mu = threading.Lock()
+        # One Buffer object per canonical inherited host span, not per copy. Reusing only its
+        # identity is insufficient: each Python Buffer is an owning runtime handle, so creating
+        # aliases for one backing violates the one-allocation/one-Buffer invariant.
+        self._named_host_buffers: dict[tuple[int, int], Any] = {}
+        # Minting and first creation are not atomic while `alloc_stacked_tensor` runs one thread
+        # per chip through this path, so the cache, owner, and counter are guarded together.
+        self._named_host_buffer_mu = threading.Lock()
         self._persistent = bool(persistent)
         self._reset_persistent_windows = reset_persistent_windows
         self._persistent_error: BaseException | None = None
@@ -2277,23 +2273,34 @@ class DistributedWorker(Worker):
         info = self._w.device_memory_info(worker_id)
         return int(info.free_bytes), int(info.total_bytes)
 
-    def _buffer_identity_for(self, host_ptr: int, nbytes: int, *, writing: bool) -> tuple[bytes, int]:
-        """Return the stable ``(owner_instance_id, buffer_id)`` naming this host range.
+    @staticmethod
+    def _merge_overlapping_spans(
+        spans: tuple[tuple[int, int], ...],
+    ) -> tuple[tuple[int, int], ...]:
+        """Canonicalize aliased spans without joining adjacent allocations."""
+        merged: list[tuple[int, int]] = []
+        for start, stop in sorted(set(spans)):
+            if stop <= start:
+                continue
+            if merged and start < merged[-1][1]:
+                previous_start, previous_stop = merged[-1]
+                merged[-1] = (previous_start, max(previous_stop, stop))
+            else:
+                merged.append((start, stop))
+        return tuple(merged)
 
-        Keyed on the complete inherited span rather than the requested copy range, so one
-        memory allocation has exactly one runtime Buffer identity. Sub-range copies reuse that
-        identity and express their position through the runtime copy offset. Every descriptor
-        uses ``READWRITE`` so the same identity remains valid in both copy directions.
-
-        Held under a lock because ``alloc_stacked_tensor`` drives this from one thread per chip.
-        """
+    def _named_buffer_for_span(self, host_ptr: int, nbytes: int) -> Any:
+        """Return the unique runtime Buffer object for one canonical inherited span."""
         from simpler.buffer import (  # noqa: PLC0415  # pyright: ignore[reportMissingImports]
+            AccessMode,
+            BackendKind,
             mint_owner_instance_id,
+            wrap_fork_inherited,
         )
 
-        key = (int(host_ptr), int(nbytes), False)
-        with self._named_identity_mu:
-            cached = self._named_identities.get(key)
+        key = (int(host_ptr), int(nbytes))
+        with self._named_host_buffer_mu:
+            cached = self._named_host_buffers.get(key)
             if cached is not None:
                 return cached
             owner = self._buffer_owner_id
@@ -2301,13 +2308,18 @@ class DistributedWorker(Worker):
                 owner = mint_owner_instance_id()
                 self._buffer_owner_id = owner
             self._buffer_id_seq += 1
-            identity = (owner, self._buffer_id_seq)
-            self._named_identities[key] = identity
-            return identity
+            buffer = wrap_fork_inherited(
+                host_ptr,
+                nbytes,
+                owner,
+                self._buffer_id_seq,
+                access=AccessMode.READWRITE,
+                backend_kind=BackendKind.FORK_SHM,
+            )
+            self._named_host_buffers[key] = buffer
+            return buffer
 
-    def _named_host_buffer(
-        self, host_ptr: int, nbytes: int, *, writing: bool = False
-    ) -> tuple[Any, int] | None:
+    def _named_host_buffer(self, host_ptr: int, nbytes: int) -> tuple[Any, int] | None:
         """Name a fork-inherited MAP_SHARED host range in place, or ``None`` to stage it.
 
         Only memory registered through ``inherited_host_tensors`` can be named at all: it
@@ -2326,32 +2338,15 @@ class DistributedWorker(Worker):
         reading its pre-fork snapshot, so the caller would upload stale bytes.
 
         The complete registered span is always wrapped as one ``READWRITE`` Buffer. A requested
-        sub-range returns that Buffer plus its relative offset, which the runtime copy API applies
-        without creating another Buffer identity for the same memory.
+        sub-range returns that same Buffer object plus its relative offset, which the runtime copy
+        API applies without creating another Buffer for the same memory.
         """
-        from simpler.buffer import (  # noqa: PLC0415  # pyright: ignore[reportMissingImports]
-            AccessMode,
-            BackendKind,
-            wrap_fork_inherited,
-        )
-
         end = host_ptr + nbytes
         for start, stop in self._inherited_host_spans:
             if host_ptr < start or end > stop:
                 continue
             span_nbytes = stop - start
-            owner, buffer_id = self._buffer_identity_for(start, span_nbytes, writing=writing)
-            return (
-                wrap_fork_inherited(
-                    start,
-                    span_nbytes,
-                    owner,
-                    buffer_id,
-                    access=AccessMode.READWRITE,
-                    backend_kind=BackendKind.FORK_SHM,
-                ),
-                host_ptr - start,
-            )
+            return self._named_buffer_for_span(start, span_nbytes), host_ptr - start
         return None
 
     def copy_to(
@@ -2406,7 +2401,7 @@ class DistributedWorker(Worker):
         src = self._device_buffer(src_dev_ptr, worker_id, "copy_from")
         if not isinstance(nbytes, int) or nbytes <= 0:
             raise ValueError(f"nbytes must be a positive int, got {nbytes!r}")
-        named_dst = self._named_host_buffer(int(dst_host_ptr), int(nbytes), writing=True)
+        named_dst = self._named_host_buffer(int(dst_host_ptr), int(nbytes))
         if named_dst is not None:
             dst, named_dst_offset = named_dst
             self._w.copy_from(dst, src, dst_offset=named_dst_offset, nbytes=nbytes)
@@ -2579,8 +2574,8 @@ class DistributedWorker(Worker):
         # No later copy may name these ranges: the parent has dropped its references, so a
         # copy after this point stages rather than wrapping memory nobody vouches for.
         self._inherited_host_spans = ()
-        with self._named_identity_mu:
-            self._named_identities.clear()
+        with self._named_host_buffer_mu:
+            self._named_host_buffers.clear()
 
     def copy_stacked_from(self, stacked: StackedDeviceTensor, host: torch.Tensor) -> None:
         """Read every shard of *stacked* back to *host* (D2H) — the read-back
@@ -2895,7 +2890,8 @@ class DistributedWorker(Worker):
             finally:
                 self._inherited_host_tensors = ()
                 self._inherited_host_spans = ()
-                self._named_identities.clear()
+                with self._named_host_buffer_mu:
+                    self._named_host_buffers.clear()
                 self._persistent_domains_by_program.clear()
                 if self._close_complete:
                     self._device_buffers.clear()

--- a/python/pypto/runtime/distributed_runner.py
+++ b/python/pypto/runtime/distributed_runner.py
@@ -2280,19 +2280,10 @@ class DistributedWorker(Worker):
     def _buffer_identity_for(self, host_ptr: int, nbytes: int, *, writing: bool) -> tuple[bytes, int]:
         """Return the stable ``(owner_instance_id, buffer_id)`` naming this host range.
 
-        Keyed on the range rather than counted per call, so a range copied N times keeps one
-        identity: the consumer's ``ImportRegistry`` refuses a second descriptor for an identity
-        it has already materialized, and it only drops an entry when the owner releases the
-        Buffer — which the named path never does, since it hands out the caller's own mapping.
-        Per-copy identities would therefore both collide on a re-copy and grow a child's
-        registry without bound. Distinct sub-ranges of one registered tensor still get distinct
-        identities, which is what a sharded upload needs.
-
-        The direction is part of the key because it decides the descriptor's ``access``: a
-        source is named ``READ`` and a destination ``READWRITE``. One identity may name only
-        one backing, so a range copied in both directions under a single identity would have
-        ``materialize`` reject the second descriptor for the changed access. Two identities per
-        range is still bounded — the property that matters is that it does not grow per copy.
+        Keyed on the complete inherited span rather than the requested copy range, so one
+        memory allocation has exactly one runtime Buffer identity. Sub-range copies reuse that
+        identity and express their position through the runtime copy offset. Every descriptor
+        uses ``READWRITE`` so the same identity remains valid in both copy directions.
 
         Held under a lock because ``alloc_stacked_tensor`` drives this from one thread per chip.
         """
@@ -2300,7 +2291,7 @@ class DistributedWorker(Worker):
             mint_owner_instance_id,
         )
 
-        key = (int(host_ptr), int(nbytes), bool(writing))
+        key = (int(host_ptr), int(nbytes), False)
         with self._named_identity_mu:
             cached = self._named_identities.get(key)
             if cached is not None:
@@ -2314,7 +2305,9 @@ class DistributedWorker(Worker):
             self._named_identities[key] = identity
             return identity
 
-    def _named_host_buffer(self, host_ptr: int, nbytes: int, *, writing: bool = False) -> Any:
+    def _named_host_buffer(
+        self, host_ptr: int, nbytes: int, *, writing: bool = False
+    ) -> tuple[Any, int] | None:
         """Name a fork-inherited MAP_SHARED host range in place, or ``None`` to stage it.
 
         Only memory registered through ``inherited_host_tensors`` can be named at all: it
@@ -2332,17 +2325,9 @@ class DistributedWorker(Worker):
         A ``MAP_PRIVATE`` backing is unsupported here rather than handled: the child keeps
         reading its pre-fork snapshot, so the caller would upload stale bytes.
 
-        Writability is left to the MMU rather than tracked here, because visibility and
-        writability are separate properties and one caller guarantee only covers the first.
-        A range mapped ``MAP_SHARED`` from a read-only fd is genuinely shared and still
-        faults on write, so a read-back into it fails immediately instead of corrupting
-        anything. A named source is granted ``READ`` and only a destination ``READWRITE``,
-        so the ABI is never told a consumer may write memory it may not.
-
-        Each range is wrapped on its own rather than offset into a whole-tensor Buffer,
-        because a Buffer carries no offset: a shard's address is interior to its stacked
-        tensor, so per-range wrapping is what keeps one shard's copy from moving the whole
-        stack.
+        The complete registered span is always wrapped as one ``READWRITE`` Buffer. A requested
+        sub-range returns that Buffer plus its relative offset, which the runtime copy API applies
+        without creating another Buffer identity for the same memory.
         """
         from simpler.buffer import (  # noqa: PLC0415  # pyright: ignore[reportMissingImports]
             AccessMode,
@@ -2354,18 +2339,18 @@ class DistributedWorker(Worker):
         for start, stop in self._inherited_host_spans:
             if host_ptr < start or end > stop:
                 continue
-            owner, buffer_id = self._buffer_identity_for(host_ptr, nbytes, writing=writing)
-            return wrap_fork_inherited(
-                host_ptr,
-                nbytes,
-                owner,
-                buffer_id,
-                # A source is read by the child and nothing more, so say so: naming a read-only
-                # mapping READWRITE would tell the ABI the consumer may write memory that faults
-                # on a write, which is the same class of misdeclaration this whole option exists
-                # to remove. FORK_SHM accepts any access, so READ is expressible here.
-                access=AccessMode.READWRITE if writing else AccessMode.READ,
-                backend_kind=BackendKind.FORK_SHM,
+            span_nbytes = stop - start
+            owner, buffer_id = self._buffer_identity_for(start, span_nbytes, writing=writing)
+            return (
+                wrap_fork_inherited(
+                    start,
+                    span_nbytes,
+                    owner,
+                    buffer_id,
+                    access=AccessMode.READWRITE,
+                    backend_kind=BackendKind.FORK_SHM,
+                ),
+                host_ptr - start,
             )
         return None
 
@@ -2397,9 +2382,16 @@ class DistributedWorker(Worker):
             )
 
         src_ptr = int(src_host_ptr) + src_offset
-        src = self._named_host_buffer(src_ptr, int(nbytes))
-        if src is not None:
-            self._w.copy_to(dst, src, dst_offset=dst_offset, nbytes=nbytes)
+        named_src = self._named_host_buffer(src_ptr, int(nbytes))
+        if named_src is not None:
+            src, named_src_offset = named_src
+            self._w.copy_to(
+                dst,
+                src,
+                dst_offset=dst_offset,
+                src_offset=named_src_offset,
+                nbytes=nbytes,
+            )
             return
         host = self._w.create_buffer(nbytes)
         try:
@@ -2414,9 +2406,10 @@ class DistributedWorker(Worker):
         src = self._device_buffer(src_dev_ptr, worker_id, "copy_from")
         if not isinstance(nbytes, int) or nbytes <= 0:
             raise ValueError(f"nbytes must be a positive int, got {nbytes!r}")
-        dst = self._named_host_buffer(int(dst_host_ptr), int(nbytes), writing=True)
-        if dst is not None:
-            self._w.copy_from(dst, src)
+        named_dst = self._named_host_buffer(int(dst_host_ptr), int(nbytes), writing=True)
+        if named_dst is not None:
+            dst, named_dst_offset = named_dst
+            self._w.copy_from(dst, src, dst_offset=named_dst_offset, nbytes=nbytes)
             return
         host = self._w.create_buffer(nbytes)
         try:

--- a/tests/ut/runtime/test_distributed_worker.py
+++ b/tests/ut/runtime/test_distributed_worker.py
@@ -966,57 +966,62 @@ class TestDeviceMemoryApi:
         rt.free(ptr)
         rt.close()
 
-    def test_copy_to_offset_writes_into_device_region(self, patched_setup):
+    def test_copy_to_with_offset_writes_into_device_region(self, patched_setup):
         rt = DistributedWorker(_fake_compiled([_param("a", [16, 16])], []))
         ptr = rt.malloc(128)
         host = (ctypes.c_ubyte * 16)()
         for i in range(16):
             host[i] = i
-        rt.copy_to_offset(ptr, 32, ctypes.addressof(host), 16)
+        rt.copy_to(ptr, ctypes.addressof(host), 16, dst_offset=32)
 
-        call_args = patched_setup["worker"].copy_to.call_args.args
-        assert call_args[0] is rt._buffer_for_ptr(ptr)
-        assert call_args[1] != host
-        assert call_args[2] == 32
-        assert ctypes.string_at(call_args[1].base, 16) == ctypes.string_at(ctypes.addressof(host), 16)
-        patched_setup["worker"].release_buffer.assert_called_once_with(call_args[1])
+        call_args = patched_setup["worker"].copy_to.call_args
+        assert call_args.args[0] is rt._buffer_for_ptr(ptr)
+        assert call_args.args[1] != host
+        assert call_args.kwargs.get("dst_offset") == 32
+        assert call_args.kwargs["nbytes"] == 16
+        assert ctypes.string_at(call_args.args[1].base, 16) == ctypes.string_at(ctypes.addressof(host), 16)
+        patched_setup["worker"].release_buffer.assert_called_once_with(call_args.args[1])
         rt.free(ptr)
         rt.close()
 
-    def test_copy_to_offset_checks_parameters(self, patched_setup):
+    def test_copy_to_with_offset_checks_parameters(self, patched_setup):
         rt = DistributedWorker(_fake_compiled([_param("a", [16, 16])], []))
         ptr = rt.malloc(64)
         host = (ctypes.c_ubyte * 32)()
         bad_offset: Any = "0"
 
         with pytest.raises(ValueError, match="dst_offset must be a non-negative int"):
-            rt.copy_to_offset(ptr, -1, ctypes.addressof(host), 16)
+            rt.copy_to(ptr, ctypes.addressof(host), 16, dst_offset=-1)
         with pytest.raises(ValueError, match="dst_offset must be a non-negative int"):
-            rt.copy_to_offset(ptr, bad_offset, ctypes.addressof(host), 16)
+            rt.copy_to(ptr, ctypes.addressof(host), 16, dst_offset=bad_offset)
+        with pytest.raises(ValueError, match="src_offset must be a non-negative int"):
+            rt.copy_to(ptr, ctypes.addressof(host), 16, src_offset=-1)
+        with pytest.raises(ValueError, match="src_offset must be a non-negative int"):
+            rt.copy_to(ptr, ctypes.addressof(host), 16, src_offset=bad_offset)
         with pytest.raises(ValueError, match="must be a positive int"):
-            rt.copy_to_offset(ptr, 0, ctypes.addressof(host), 0)
+            rt.copy_to(ptr, ctypes.addressof(host), 0, dst_offset=0)
         with pytest.raises(ValueError, match="must be a positive int"):
-            rt.copy_to_offset(ptr, 0, ctypes.addressof(host), -1)
+            rt.copy_to(ptr, ctypes.addressof(host), -1, dst_offset=0)
         with pytest.raises(ValueError, match="exceeds allocation size"):
-            rt.copy_to_offset(ptr, 60, ctypes.addressof(host), 16)
+            rt.copy_to(ptr, ctypes.addressof(host), 16, dst_offset=60)
         with pytest.raises(ValueError, match="interior pointer"):
-            rt.copy_to_offset(ptr + 32, 0, ctypes.addressof(host), 16)
+            rt.copy_to(ptr + 32, ctypes.addressof(host), 16, dst_offset=0)
 
         rt.free(ptr)
         rt.close()
 
-    def test_copy_to_offset_supports_non_default_worker_id(self, patched_setup):
+    def test_copy_to_with_offset_supports_non_default_worker_id(self, patched_setup):
         rt = DistributedWorker(_fake_compiled([_param("a", [16, 16])], []))
         ptr = rt.malloc(64, worker_id=1)
         host = (ctypes.c_ubyte * 16)()
-        rt.copy_to_offset(ptr, 8, ctypes.addressof(host), 8, worker_id=1)
+        rt.copy_to(ptr, ctypes.addressof(host), 8, dst_offset=8, worker_id=1)
 
-        call_args = patched_setup["worker"].copy_to.call_args.args
-        assert call_args[0] is rt._buffer_for_ptr(ptr, worker_id=1)
-        assert call_args[2] == 8
+        call_args = patched_setup["worker"].copy_to.call_args
+        assert call_args.args[0] is rt._buffer_for_ptr(ptr, worker_id=1)
+        assert call_args.kwargs["dst_offset"] == 8
 
         with pytest.raises(ValueError, match="worker_id=0"):
-            rt.copy_to_offset(ptr, 0, ctypes.addressof(host), 8, worker_id=0)
+            rt.copy_to(ptr, ctypes.addressof(host), 8, worker_id=0)
         rt.free(ptr, worker_id=1)
         rt.close()
 

--- a/tests/ut/runtime/test_distributed_worker.py
+++ b/tests/ut/runtime/test_distributed_worker.py
@@ -966,6 +966,60 @@ class TestDeviceMemoryApi:
         rt.free(ptr)
         rt.close()
 
+    def test_copy_to_offset_writes_into_device_region(self, patched_setup):
+        rt = DistributedWorker(_fake_compiled([_param("a", [16, 16])], []))
+        ptr = rt.malloc(128)
+        host = (ctypes.c_ubyte * 16)()
+        for i in range(16):
+            host[i] = i
+        rt.copy_to_offset(ptr, 32, ctypes.addressof(host), 16)
+
+        call_args = patched_setup["worker"].copy_to.call_args.args
+        assert call_args[0] is rt._buffer_for_ptr(ptr)
+        assert call_args[1] != host
+        assert call_args[2] == 32
+        assert ctypes.string_at(call_args[1].base, 16) == ctypes.string_at(ctypes.addressof(host), 16)
+        patched_setup["worker"].release_buffer.assert_called_once_with(call_args[1])
+        rt.free(ptr)
+        rt.close()
+
+    def test_copy_to_offset_checks_parameters(self, patched_setup):
+        rt = DistributedWorker(_fake_compiled([_param("a", [16, 16])], []))
+        ptr = rt.malloc(64)
+        host = (ctypes.c_ubyte * 32)()
+        bad_offset: Any = "0"
+
+        with pytest.raises(ValueError, match="dst_offset must be a non-negative int"):
+            rt.copy_to_offset(ptr, -1, ctypes.addressof(host), 16)
+        with pytest.raises(ValueError, match="dst_offset must be a non-negative int"):
+            rt.copy_to_offset(ptr, bad_offset, ctypes.addressof(host), 16)
+        with pytest.raises(ValueError, match="must be a positive int"):
+            rt.copy_to_offset(ptr, 0, ctypes.addressof(host), 0)
+        with pytest.raises(ValueError, match="must be a positive int"):
+            rt.copy_to_offset(ptr, 0, ctypes.addressof(host), -1)
+        with pytest.raises(ValueError, match="exceeds allocation size"):
+            rt.copy_to_offset(ptr, 60, ctypes.addressof(host), 16)
+        with pytest.raises(ValueError, match="interior pointer"):
+            rt.copy_to_offset(ptr + 32, 0, ctypes.addressof(host), 16)
+
+        rt.free(ptr)
+        rt.close()
+
+    def test_copy_to_offset_supports_non_default_worker_id(self, patched_setup):
+        rt = DistributedWorker(_fake_compiled([_param("a", [16, 16])], []))
+        ptr = rt.malloc(64, worker_id=1)
+        host = (ctypes.c_ubyte * 16)()
+        rt.copy_to_offset(ptr, 8, ctypes.addressof(host), 8, worker_id=1)
+
+        call_args = patched_setup["worker"].copy_to.call_args.args
+        assert call_args[0] is rt._buffer_for_ptr(ptr, worker_id=1)
+        assert call_args[2] == 8
+
+        with pytest.raises(ValueError, match="worker_id=0"):
+            rt.copy_to_offset(ptr, 0, ctypes.addressof(host), 8, worker_id=0)
+        rt.free(ptr, worker_id=1)
+        rt.close()
+
     def test_alloc_tensor_forwards_malloc_and_copy(self, patched_setup):
         compiled = _fake_compiled([_param("a", [16, 16])], [])
         rt = DistributedWorker(compiled)

--- a/tests/ut/runtime/test_distributed_worker.py
+++ b/tests/ut/runtime/test_distributed_worker.py
@@ -47,6 +47,7 @@ from pypto.runtime.bench import (
 from pypto.runtime.distributed_runner import (
     DistributedRunHandle,
     DistributedWorker,
+    ReadOnlyHostTensor,
     _assemble_chip_callables,
     _clear_dfx_dispatch_dirs,
     _collect_l3_swimlane,
@@ -989,9 +990,7 @@ class TestDeviceMemoryApi:
         ptr = rt.malloc(128)
         host = (ctypes.c_ubyte * 64)()
         host_ptr = ctypes.addressof(host)
-        rt._inherited_host_spans = rt._merge_overlapping_spans(
-            ((host_ptr, host_ptr + 48), (host_ptr + 16, host_ptr + 64))
-        )
+        rt._inherited_host_spans = (((host_ptr, host_ptr + 64), False),)
 
         rt.copy_to(ptr, host_ptr, 16, dst_offset=4, src_offset=8)
         first_copy = patched_setup["worker"].copy_to.call_args
@@ -1058,6 +1057,77 @@ class TestDeviceMemoryApi:
         with pytest.raises(ValueError, match="worker_id=0"):
             rt.copy_to(ptr, ctypes.addressof(host), 8, worker_id=0)
         rt.free(ptr, worker_id=1)
+        rt.close()
+
+    def test_copy_from_with_offset_reads_a_device_sub_range(self, patched_setup):
+        """A staged D2H reads `src_offset` into `dst_host_ptr + dst_offset`."""
+        rt = DistributedWorker(_fake_compiled([_param("a", [16, 16])], []))
+        patched_setup["worker"].alloc_child_tensor.return_value = _FakeBuffer(0xDEAD0000, 128)
+        ptr = rt.malloc(128)
+        host = (ctypes.c_ubyte * 64)()
+
+        def _fill(dst_buffer, _src, **_kwargs):
+            ctypes.memset(int(dst_buffer.base), 0xAB, int(dst_buffer.nbytes))
+
+        patched_setup["worker"].copy_from.side_effect = _fill
+        rt.copy_from(ctypes.addressof(host), ptr, 16, dst_offset=8, src_offset=32)
+
+        call_args = patched_setup["worker"].copy_from.call_args
+        assert call_args.args[1] is rt._buffer_for_ptr(ptr)
+        assert call_args.kwargs["src_offset"] == 32
+        assert call_args.kwargs["nbytes"] == 16
+        # dst_offset is resolved host-side for a staged copy, so the staging buffer starts at 0
+        # and the payload lands at `dst_offset` in the caller's memory.
+        assert bytes(host[:8]) == b"\x00" * 8
+        assert bytes(host[8:24]) == b"\xab" * 16
+        assert bytes(host[24:]) == b"\x00" * 40
+        patched_setup["worker"].release_buffer.assert_called_once_with(call_args.args[0])
+        rt.free(ptr)
+        rt.close()
+
+    def test_copy_from_with_offset_checks_parameters(self, patched_setup):
+        rt = DistributedWorker(_fake_compiled([_param("a", [16, 16])], []))
+        patched_setup["worker"].alloc_child_tensor.return_value = _FakeBuffer(0xDEAD0000, 64)
+        ptr = rt.malloc(64)
+        host = (ctypes.c_ubyte * 32)()
+        bad_offset: Any = "0"
+
+        with pytest.raises(ValueError, match="dst_offset must be a non-negative int"):
+            rt.copy_from(ctypes.addressof(host), ptr, 16, dst_offset=-1)
+        with pytest.raises(ValueError, match="dst_offset must be a non-negative int"):
+            rt.copy_from(ctypes.addressof(host), ptr, 16, dst_offset=bad_offset)
+        with pytest.raises(ValueError, match="src_offset must be a non-negative int"):
+            rt.copy_from(ctypes.addressof(host), ptr, 16, src_offset=-1)
+        with pytest.raises(ValueError, match="src_offset must be a non-negative int"):
+            rt.copy_from(ctypes.addressof(host), ptr, 16, src_offset=bad_offset)
+        with pytest.raises(ValueError, match="must be a positive int"):
+            rt.copy_from(ctypes.addressof(host), ptr, 0)
+        with pytest.raises(ValueError, match="exceeds allocation size"):
+            rt.copy_from(ctypes.addressof(host), ptr, 16, src_offset=60)
+        with pytest.raises(ValueError, match="interior pointer"):
+            rt.copy_from(ctypes.addressof(host), ptr + 32, 16)
+
+        rt.free(ptr)
+        rt.close()
+
+    def test_copy_from_offsets_reach_a_named_span_without_a_second_buffer(self, patched_setup):
+        """A named D2H applies the host offset within the span's one Buffer."""
+        host = torch.zeros(16, 4, dtype=torch.float32).share_memory_()
+        rt = DistributedWorker(
+            _fake_compiled([_param("a", [4, 4])], []),
+            inherited_host_tensors=[host],
+        )
+        dev = _resident(rt, (4, 4))
+
+        rt.copy_from(host.data_ptr(), dev.data_ptr, 32, dst_offset=64, src_offset=16)
+
+        call_args = patched_setup["worker"].copy_from.call_args
+        named = call_args.args[0]
+        assert (named.base, named.nbytes) == (host.data_ptr(), host.numel() * host.element_size())
+        assert call_args.kwargs["dst_offset"] == 64
+        assert call_args.kwargs["src_offset"] == 16
+        assert call_args.kwargs["nbytes"] == 32
+        patched_setup["worker"].create_buffer.assert_not_called()
         rt.close()
 
     def test_alloc_tensor_forwards_malloc_and_copy(self, patched_setup):
@@ -3713,15 +3783,25 @@ class TestNamedInheritedHostRanges:
         assert first is second
         rt.close()
 
-    def test_overlapping_views_and_sub_ranges_reuse_one_buffer(self, patched_setup):
-        """Aliased views and sub-ranges reuse one Buffer and differ only by offset."""
+    @pytest.mark.parametrize(
+        "views",
+        [("overlapping", slice(0, 3), slice(1, 4)), ("disjoint", slice(0, 2), slice(2, 4))],
+    )
+    def test_views_of_one_storage_reuse_one_buffer(self, patched_setup, views):
+        """A listed view names its whole storage, so any set of views yields one Buffer.
+
+        The disjoint case is the one a range-overlap heuristic gets wrong: ``host[:2]`` and
+        ``host[2:]`` do not intersect, yet they are one allocation and must not be named twice.
+        """
+        _label, first_view, second_view = views
         host = torch.zeros(4, 4, dtype=torch.float32).share_memory_()
         rt = DistributedWorker(
             _fake_compiled([_param("a", [4, 4])], []),
-            inherited_host_tensors=[host[:3], host[1:]],
+            inherited_host_tensors=[host[first_view], host[second_view]],
         )
         dev = self._dev(rt)
-        half = host.numel() * host.element_size() // 2
+        nbytes = host.numel() * host.element_size()
+        half = nbytes // 2
 
         rt.copy_to(dev.data_ptr, host.data_ptr(), half)
         first_call = patched_setup["worker"].copy_to.call_args
@@ -3730,10 +3810,62 @@ class TestNamedInheritedHostRanges:
 
         first = first_call.args[1]
         second = second_call.args[1]
-        assert (first.base, first.nbytes) == (host.data_ptr(), host.numel() * host.element_size())
+        assert (first.base, first.nbytes) == (host.data_ptr(), nbytes)
         assert first is second
         assert first_call.kwargs["src_offset"] == 0
         assert second_call.kwargs["src_offset"] == half
+        rt.close()
+
+    def test_a_read_only_listing_is_named_read_and_refuses_a_read_back(self, patched_setup):
+        """A ReadOnlyHostTensor span uploads in place but is refused as a D2H destination.
+
+        One Buffer carries one access mode, so the marker is the only way to say a shared
+        backing is not writable; declaring it READWRITE would grant the child a write right
+        over memory that faults on the store.
+        """
+        host = torch.zeros(4, 4, dtype=torch.float32).share_memory_()
+        rt = DistributedWorker(
+            _fake_compiled([_param("a", [4, 4])], []),
+            inherited_host_tensors=[ReadOnlyHostTensor(host)],
+        )
+        dev = self._dev(rt)
+        nbytes = host.numel() * host.element_size()
+
+        rt.copy_to(dev.data_ptr, host.data_ptr(), nbytes)
+        named = patched_setup["worker"].copy_to.call_args.args[1]
+        assert (named.backend_kind, named.access) == ("FORK_SHM", "READ")
+        patched_setup["worker"].create_buffer.assert_not_called()
+
+        with pytest.raises(ValueError, match="ReadOnlyHostTensor"):
+            rt.copy_from(host.data_ptr(), dev.data_ptr, nbytes)
+        rt.close()
+
+    def test_one_allocation_listed_both_ways_is_refused(self, patched_setup):
+        """One allocation has one access mode, so a contradictory listing cannot be resolved."""
+        host = torch.zeros(4, 4, dtype=torch.float32).share_memory_()
+        with pytest.raises(ValueError, match="one allocation has one access mode"):
+            DistributedWorker(
+                _fake_compiled([_param("a", [4, 4])], []),
+                inherited_host_tensors=[host, ReadOnlyHostTensor(host[1:])],
+            )
+
+    def test_a_read_only_marking_leaves_other_allocations_writable(self, patched_setup):
+        """The marker is per allocation, not a mode for the whole list."""
+        weights = torch.zeros(4, 4, dtype=torch.float32).share_memory_()
+        cache = torch.zeros(4, 4, dtype=torch.float32).share_memory_()
+        rt = DistributedWorker(
+            _fake_compiled([_param("a", [4, 4])], []),
+            inherited_host_tensors=[ReadOnlyHostTensor(weights), cache],
+        )
+        dev = self._dev(rt)
+        nbytes = cache.numel() * cache.element_size()
+
+        rt.copy_from(cache.data_ptr(), dev.data_ptr, nbytes)
+        named = patched_setup["worker"].copy_from.call_args.args[0]
+        assert (named.base, named.access) == (cache.data_ptr(), "READWRITE")
+
+        with pytest.raises(ValueError, match="ReadOnlyHostTensor"):
+            rt.copy_from(weights.data_ptr(), dev.data_ptr, nbytes)
         rt.close()
 
     def test_concurrent_sub_ranges_share_one_identity_and_keep_their_offsets(self, patched_setup):
@@ -3749,7 +3881,7 @@ class TestNamedInheritedHostRanges:
             offset = host.data_ptr() + index * row
             named = rt._named_host_buffer(offset, row)
             assert named is not None
-            buffer, relative_offset = named
+            buffer, relative_offset, _read_only = named
             with lock:
                 seen.append((relative_offset, id(buffer)))
 

--- a/tests/ut/runtime/test_distributed_worker.py
+++ b/tests/ut/runtime/test_distributed_worker.py
@@ -986,6 +986,7 @@ class TestDeviceMemoryApi:
 
     def test_copy_to_with_offset_checks_parameters(self, patched_setup):
         rt = DistributedWorker(_fake_compiled([_param("a", [16, 16])], []))
+        patched_setup["worker"].alloc_child_tensor.return_value = _FakeBuffer(0xDEAD0000, 64)
         ptr = rt.malloc(64)
         host = (ctypes.c_ubyte * 32)()
         bad_offset: Any = "0"

--- a/tests/ut/runtime/test_distributed_worker.py
+++ b/tests/ut/runtime/test_distributed_worker.py
@@ -984,6 +984,37 @@ class TestDeviceMemoryApi:
         rt.free(ptr)
         rt.close()
 
+    def test_named_host_offsets_reuse_one_runtime_buffer(self, patched_setup):
+        rt = DistributedWorker(_fake_compiled([_param("a", [16, 16])], []))
+        ptr = rt.malloc(128)
+        host = (ctypes.c_ubyte * 64)()
+        host_ptr = ctypes.addressof(host)
+        rt._inherited_host_spans = ((host_ptr, host_ptr + 64),)
+
+        rt.copy_to(ptr, host_ptr, 16, dst_offset=4, src_offset=8)
+        first_copy = patched_setup["worker"].copy_to.call_args
+        rt.copy_to(ptr, host_ptr, 16, dst_offset=20, src_offset=24)
+        second_copy = patched_setup["worker"].copy_to.call_args
+        rt.copy_from(host_ptr + 40, ptr, 8)
+        reverse_copy = patched_setup["worker"].copy_from.call_args
+
+        first_host = first_copy.args[1]
+        second_host = second_copy.args[1]
+        reverse_host = reverse_copy.args[0]
+        assert first_host.base == second_host.base == reverse_host.base == host_ptr
+        assert first_host.nbytes == second_host.nbytes == reverse_host.nbytes == 64
+        assert (first_host.owner, first_host.buffer_id) == (second_host.owner, second_host.buffer_id)
+        assert (first_host.owner, first_host.buffer_id) == (reverse_host.owner, reverse_host.buffer_id)
+        assert first_host.access == second_host.access == reverse_host.access == "READWRITE"
+        assert first_copy.kwargs["src_offset"] == 8
+        assert second_copy.kwargs["src_offset"] == 24
+        assert reverse_copy.kwargs["dst_offset"] == 40
+        assert first_copy.kwargs["nbytes"] == second_copy.kwargs["nbytes"] == 16
+        assert reverse_copy.kwargs["nbytes"] == 8
+
+        rt.free(ptr)
+        rt.close()
+
     def test_copy_to_with_offset_checks_parameters(self, patched_setup):
         rt = DistributedWorker(_fake_compiled([_param("a", [16, 16])], []))
         patched_setup["worker"].alloc_child_tensor.return_value = _FakeBuffer(0xDEAD0000, 64)
@@ -3406,9 +3437,8 @@ class TestNamedInheritedHostRanges:
         named = patched_setup["worker"].copy_to.call_args.args[1]
         assert isinstance(named, _NamedHostRange)
         assert (named.base, named.nbytes) == (host.data_ptr(), nbytes)
-        # READ, not READWRITE as this asserted before: an upload source is only ever read by the
-        # child, and granting write access to a mapping that may be read-only misdescribes it.
-        assert (named.backend_kind, named.access) == ("FORK_SHM", "READ")
+        # One registered span has one descriptor in both copy directions.
+        assert (named.backend_kind, named.access) == ("FORK_SHM", "READWRITE")
         # The point of naming it: no staging buffer is created at all.
         patched_setup["worker"].create_buffer.assert_not_called()
         rt.close()
@@ -3481,12 +3511,8 @@ class TestNamedInheritedHostRanges:
         assert isinstance(patched_setup["worker"].copy_from.call_args.args[0], _NamedHostRange)
         rt.close()
 
-    def test_a_named_upload_source_is_granted_read_only(self, patched_setup):
-        """An upload source is read by the child and nothing more, so the descriptor says READ.
-
-        Granting READWRITE would tell the ABI a consumer may write memory that, for the
-        read-only file mapping this targets, faults on a write.
-        """
+    def test_a_named_upload_source_uses_the_shared_readwrite_descriptor(self, patched_setup):
+        """An upload reuses the span's direction-independent descriptor."""
         host = torch.zeros(4, 4, dtype=torch.float32)
         rt = DistributedWorker(
             _fake_compiled([_param("a", [4, 4])], []),
@@ -3498,7 +3524,7 @@ class TestNamedInheritedHostRanges:
         rt.copy_to(dev.data_ptr, host.data_ptr(), nbytes)
 
         named = patched_setup["worker"].copy_to.call_args.args[1]
-        assert (named.backend_kind, named.access) == ("FORK_SHM", "READ")
+        assert (named.backend_kind, named.access) == ("FORK_SHM", "READWRITE")
         rt.close()
 
     def test_a_named_read_back_destination_is_granted_readwrite(self, patched_setup):
@@ -3598,15 +3624,8 @@ class TestNamedInheritedHostRanges:
         patched_setup["worker"].create_buffer.assert_not_called()
         rt.close()
 
-    def test_the_same_range_in_both_directions_gets_distinct_identities(self, patched_setup):
-        """One identity may name only one backing, and the two directions differ in access.
-
-        Regression: the identity was keyed on ``(host_ptr, nbytes)`` alone while a source is
-        granted READ and a destination READWRITE, so a copy_to followed by a copy_from on one
-        range reused a single identity under two descriptors — which `ImportRegistry.materialize`
-        rejects for the changed access. Keyed by direction, both are named and reuse stays
-        per-range rather than per-copy.
-        """
+    def test_the_same_span_in_both_directions_reuses_one_identity(self, patched_setup):
+        """One memory span has one READWRITE descriptor in both copy directions."""
         host = torch.zeros(4, 4, dtype=torch.float32).share_memory_()
         rt = DistributedWorker(_fake_compiled([_param("a", [4, 4])], []), inherited_host_tensors=[host])
         dev = self._dev(rt)
@@ -3617,10 +3636,10 @@ class TestNamedInheritedHostRanges:
 
         src = patched_setup["worker"].copy_to.call_args.args[1]
         dst = patched_setup["worker"].copy_from.call_args.args[0]
-        assert (src.access, dst.access) == ("READ", "READWRITE")
-        assert src.buffer_id != dst.buffer_id
+        assert (src.access, dst.access) == ("READWRITE", "READWRITE")
+        assert (src.owner, src.buffer_id) == (dst.owner, dst.buffer_id)
 
-        # Re-copying either direction must still reuse that direction's identity.
+        # Re-copying either direction must still reuse the span's identity.
         rt.copy_to(dev.data_ptr, host.data_ptr(), nbytes)
         assert patched_setup["worker"].copy_to.call_args.args[1].buffer_id == src.buffer_id
         rt.close()
@@ -3691,30 +3710,28 @@ class TestNamedInheritedHostRanges:
         assert (first.owner, first.buffer_id) == (second.owner, second.buffer_id)
         rt.close()
 
-    def test_distinct_sub_ranges_get_distinct_identities(self, patched_setup):
-        """Identity is per range, so a sharded upload's halves must not collide on one name."""
+    def test_distinct_sub_ranges_reuse_the_span_identity(self, patched_setup):
+        """Sub-ranges reuse one Buffer and differ only in their runtime offset."""
         host = torch.zeros(4, 4, dtype=torch.float32).share_memory_()
         rt = DistributedWorker(_fake_compiled([_param("a", [4, 4])], []), inherited_host_tensors=[host])
         dev = self._dev(rt)
         half = host.numel() * host.element_size() // 2
 
         rt.copy_to(dev.data_ptr, host.data_ptr(), half)
-        first = patched_setup["worker"].copy_to.call_args.args[1]
+        first_call = patched_setup["worker"].copy_to.call_args
         rt.copy_to(dev.data_ptr, host.data_ptr() + half, half)
-        second = patched_setup["worker"].copy_to.call_args.args[1]
+        second_call = patched_setup["worker"].copy_to.call_args
 
-        assert first.owner == second.owner
-        assert first.buffer_id != second.buffer_id
+        first = first_call.args[1]
+        second = second_call.args[1]
+        assert (first.base, first.nbytes) == (host.data_ptr(), host.numel() * host.element_size())
+        assert (first.owner, first.buffer_id) == (second.owner, second.buffer_id)
+        assert first_call.kwargs["src_offset"] == 0
+        assert second_call.kwargs["src_offset"] == half
         rt.close()
 
-    def test_concurrent_copies_of_distinct_ranges_never_share_an_identity(self, patched_setup):
-        """The configuration `alloc_stacked_tensor` actually creates: one thread per chip.
-
-        Identity minting is not atomic on its own — `+=` is load/add/store and the first-time
-        owner mint is check-then-act — and two ranges landing on one identity is a hard failure
-        in the consumer, not a silent one. A single-threaded test cannot observe that, so this
-        drives the path concurrently and asserts the mapping is still one-to-one.
-        """
+    def test_concurrent_sub_ranges_share_one_identity_and_keep_their_offsets(self, patched_setup):
+        """Concurrent shard resolution reuses one span identity without losing offsets."""
         host = torch.zeros(64, 4, dtype=torch.float32).share_memory_()
         rt = DistributedWorker(_fake_compiled([_param("a", [4, 4])], []), inherited_host_tensors=[host])
         row = 4 * host.element_size()
@@ -3725,18 +3742,18 @@ class TestNamedInheritedHostRanges:
         def _copy(index: int) -> None:
             offset = host.data_ptr() + index * row
             named = rt._named_host_buffer(offset, row)
+            assert named is not None
+            buffer, relative_offset = named
             with lock:
-                seen.append((offset, (named.owner, named.buffer_id)))
+                seen.append((relative_offset, (buffer.owner, buffer.buffer_id)))
 
         with ThreadPoolExecutor(max_workers=8) as pool:
             list(pool.map(_copy, range(rows)))
 
         identities = [identity for _, identity in seen]
         assert len(seen) == rows
-        # One identity per range, and no range sharing another's: both directions matter, since
-        # a duplicate id makes the child refuse the import and a missing one breaks reuse.
-        assert len(set(identities)) == rows
-        assert len({offset for offset, _ in seen}) == rows
+        assert len(set(identities)) == 1
+        assert {offset for offset, _ in seen} == {index * row for index in range(rows)}
         rt.close()
 
     def test_identity_cache_is_dropped_with_the_ranges_it_names(self, patched_setup):

--- a/tests/ut/runtime/test_distributed_worker.py
+++ b/tests/ut/runtime/test_distributed_worker.py
@@ -989,7 +989,9 @@ class TestDeviceMemoryApi:
         ptr = rt.malloc(128)
         host = (ctypes.c_ubyte * 64)()
         host_ptr = ctypes.addressof(host)
-        rt._inherited_host_spans = ((host_ptr, host_ptr + 64),)
+        rt._inherited_host_spans = rt._merge_overlapping_spans(
+            ((host_ptr, host_ptr + 48), (host_ptr + 16, host_ptr + 64))
+        )
 
         rt.copy_to(ptr, host_ptr, 16, dst_offset=4, src_offset=8)
         first_copy = patched_setup["worker"].copy_to.call_args
@@ -1003,6 +1005,7 @@ class TestDeviceMemoryApi:
         reverse_host = reverse_copy.args[0]
         assert first_host.base == second_host.base == reverse_host.base == host_ptr
         assert first_host.nbytes == second_host.nbytes == reverse_host.nbytes == 64
+        assert first_host is second_host is reverse_host
         assert (first_host.owner, first_host.buffer_id) == (second_host.owner, second_host.buffer_id)
         assert (first_host.owner, first_host.buffer_id) == (reverse_host.owner, reverse_host.buffer_id)
         assert first_host.access == second_host.access == reverse_host.access == "READWRITE"
@@ -3624,7 +3627,7 @@ class TestNamedInheritedHostRanges:
         patched_setup["worker"].create_buffer.assert_not_called()
         rt.close()
 
-    def test_the_same_span_in_both_directions_reuses_one_identity(self, patched_setup):
+    def test_the_same_span_in_both_directions_reuses_one_buffer(self, patched_setup):
         """One memory span has one READWRITE descriptor in both copy directions."""
         host = torch.zeros(4, 4, dtype=torch.float32).share_memory_()
         rt = DistributedWorker(_fake_compiled([_param("a", [4, 4])], []), inherited_host_tensors=[host])
@@ -3637,11 +3640,11 @@ class TestNamedInheritedHostRanges:
         src = patched_setup["worker"].copy_to.call_args.args[1]
         dst = patched_setup["worker"].copy_from.call_args.args[0]
         assert (src.access, dst.access) == ("READWRITE", "READWRITE")
-        assert (src.owner, src.buffer_id) == (dst.owner, dst.buffer_id)
+        assert src is dst
 
-        # Re-copying either direction must still reuse the span's identity.
+        # Re-copying either direction must still reuse the span's Buffer object.
         rt.copy_to(dev.data_ptr, host.data_ptr(), nbytes)
-        assert patched_setup["worker"].copy_to.call_args.args[1].buffer_id == src.buffer_id
+        assert patched_setup["worker"].copy_to.call_args.args[1] is src
         rt.close()
 
     def test_copy_to_stages_a_partially_overlapping_range(self, patched_setup):
@@ -3687,8 +3690,8 @@ class TestNamedInheritedHostRanges:
         assert not isinstance(patched_setup["worker"].copy_to.call_args.args[1], _NamedHostRange)
         rt.close()
 
-    def test_one_range_keeps_one_identity_across_copies(self, patched_setup):
-        """Re-copying a range must reuse its identity, not mint a new one.
+    def test_one_range_keeps_one_buffer_across_copies(self, patched_setup):
+        """Re-copying a range must reuse its Buffer object, not mint a new one.
 
         Two reasons, both in the consumer: ``ImportRegistry.materialize`` refuses a second
         descriptor for an identity it already handed out, so a fresh id per copy would make the
@@ -3707,13 +3710,16 @@ class TestNamedInheritedHostRanges:
         rt.copy_to(dev.data_ptr, host.data_ptr(), nbytes)
         second = patched_setup["worker"].copy_to.call_args.args[1]
 
-        assert (first.owner, first.buffer_id) == (second.owner, second.buffer_id)
+        assert first is second
         rt.close()
 
-    def test_distinct_sub_ranges_reuse_the_span_identity(self, patched_setup):
-        """Sub-ranges reuse one Buffer and differ only in their runtime offset."""
+    def test_overlapping_views_and_sub_ranges_reuse_one_buffer(self, patched_setup):
+        """Aliased views and sub-ranges reuse one Buffer and differ only by offset."""
         host = torch.zeros(4, 4, dtype=torch.float32).share_memory_()
-        rt = DistributedWorker(_fake_compiled([_param("a", [4, 4])], []), inherited_host_tensors=[host])
+        rt = DistributedWorker(
+            _fake_compiled([_param("a", [4, 4])], []),
+            inherited_host_tensors=[host[:3], host[1:]],
+        )
         dev = self._dev(rt)
         half = host.numel() * host.element_size() // 2
 
@@ -3725,7 +3731,7 @@ class TestNamedInheritedHostRanges:
         first = first_call.args[1]
         second = second_call.args[1]
         assert (first.base, first.nbytes) == (host.data_ptr(), host.numel() * host.element_size())
-        assert (first.owner, first.buffer_id) == (second.owner, second.buffer_id)
+        assert first is second
         assert first_call.kwargs["src_offset"] == 0
         assert second_call.kwargs["src_offset"] == half
         rt.close()
@@ -3736,7 +3742,7 @@ class TestNamedInheritedHostRanges:
         rt = DistributedWorker(_fake_compiled([_param("a", [4, 4])], []), inherited_host_tensors=[host])
         row = 4 * host.element_size()
         rows = 64
-        seen: list[tuple[int, tuple[Any, int]]] = []
+        seen: list[tuple[int, int]] = []
         lock = threading.Lock()
 
         def _copy(index: int) -> None:
@@ -3745,29 +3751,29 @@ class TestNamedInheritedHostRanges:
             assert named is not None
             buffer, relative_offset = named
             with lock:
-                seen.append((relative_offset, (buffer.owner, buffer.buffer_id)))
+                seen.append((relative_offset, id(buffer)))
 
         with ThreadPoolExecutor(max_workers=8) as pool:
             list(pool.map(_copy, range(rows)))
 
-        identities = [identity for _, identity in seen]
+        buffer_ids = [buffer_id for _, buffer_id in seen]
         assert len(seen) == rows
-        assert len(set(identities)) == 1
+        assert len(set(buffer_ids)) == 1
         assert {offset for offset, _ in seen} == {index * row for index in range(rows)}
         rt.close()
 
-    def test_identity_cache_is_dropped_with_the_ranges_it_names(self, patched_setup):
+    def test_buffer_cache_is_dropped_with_the_ranges_it_names(self, patched_setup):
         """After the parent releases its references, nothing may keep naming those ranges."""
         host = torch.zeros(4, 4, dtype=torch.float32).share_memory_()
         rt = DistributedWorker(_fake_compiled([_param("a", [4, 4])], []), inherited_host_tensors=[host])
         dev = self._dev(rt)
         nbytes = host.numel() * host.element_size()
         rt.copy_to(dev.data_ptr, host.data_ptr(), nbytes)
-        assert rt._named_identities
+        assert rt._named_host_buffers
 
         rt.release_inherited_host_tensor_refs()
 
-        assert not rt._named_identities
+        assert not rt._named_host_buffers
         rt.close()
 
 


### PR DESCRIPTION
Fixes #2508

## Summary

- Update the `runtime` submodule to `dbdd041e`, which adds offset support to the existing `Worker.copy_to` interface.
- Extend `DistributedWorker.copy_to` with keyword-only `dst_offset` and `src_offset` arguments while preserving backward compatibility.
- Cache and reuse exactly one READWRITE runtime Buffer object for each canonical inherited host memory span, merge overlapping aliases, and express every sub-range through runtime copy offsets.
- Resolve device allocations using the original base pointer and retain ownership, lifetime, access, and bounds validation.
- Support partial H2D updates without overwriting other live regions of the device allocation.
- Update unit tests and English/Chinese documentation accordingly.

## Testing

- Commit hooks passed, including documentation checks, markdownlint, ruff, formatting, and pyright.
- Full PR CI passed for `941e8c26`, including unit tests, codegen, examples, model tests, and all system-test variants.
