### PR TITLE
feat(ir): give multi-output operators a declared arity the framework can read

### DIFF
--- a/docs/en/dev/ir/05-operators.md
+++ b/docs/en/dev/ir/05-operators.md
@@ -45,6 +45,8 @@ auto dynamic_dim = make_int(kDynamicDim);
 | `set_arg_effect(i, fn)` | Same, when a kwarg decides it | `.set_arg_effect(2, [](const auto& kw) { ... })` |
 | `no_arg_writes()` | Classified: writes through no argument | `.no_arg_writes()` |
 | `set_write_channel(c)` | Hardware path the op's writes take | `.set_write_channel(WriteChannel::Dma)` |
+| `set_output_arity(N)` | Values produced; `N > 1` means a `TupleType` result — see [Multi-Output Operators](09-multi_output_ops.md) | `.set_output_arity(2)` |
+| `set_workspace_arg(i)` | Argument `i` is compiler-supplied scratch, not a result | `.set_workspace_arg(2)` |
 
 ### Argument effects
 
@@ -1027,6 +1029,8 @@ workspace or silently turn a requested prefetch into a no-op. See
    ```
 
 5. **Add tests** in `tests/ut/ir/` and update `CMakeLists.txt` if needed
+
+**Producing more than one value?** Read [Multi-Output Operators](09-multi_output_ops.md) first — the results belong in a `TupleType`, never in the argument list, and the registry rejects at import any argument such an operator writes that was not declared a workspace.
 
 ## References
 

--- a/docs/en/dev/ir/09-multi_output_ops.md
+++ b/docs/en/dev/ir/09-multi_output_ops.md
@@ -1,0 +1,198 @@
+# Multi-Output Operators
+
+## Overview
+
+Some hardware intrinsics produce more than one value. PTOAS `TGATHER` in its
+compare form writes both the gathered indices and a per-row match count;
+`pto.tgather` names them as two `outs(...)` operands. An operator wrapping such
+an intrinsic is a **multi-output operator**, and PyPTO expresses its results as
+a `TupleType`, never as destination arguments.
+
+**The rule**: register the operator with its *inputs only*. Every output is an
+element of the `TupleType` that `f_deduce_type` returns.
+
+See [Operator System](05-operators.md) for the general registration API and
+[Types and Examples](02-types.md#tupletype) for `TupleType` itself.
+
+## Why destinations must not be arguments
+
+Wrapping a destination-passing-style (DPS) intrinsic, the path of least
+resistance is to mirror the hardware signature and declare the destinations as
+arguments. That is wrong twice over:
+
+```text
+tile.gather_compare(src, kvalue, tmp, dst, cdst)   ← the leak
+  → the caller must allocate dst and cdst
+     but tile allocation belongs to InitMemRef, which owns every tile buffer
+  → the op looks like a 5-input operator
+     so direction inference reads dst/cdst as consumers, and the writes vanish
+```
+
+The second consequence is the dangerous one: an argument nobody classified
+defaults to `ArgEffect::Read`, so no RAW edge is emitted against whoever reads
+the destination, and the failure surfaces on device as stale data rather than at
+compile time. See [Argument effects](05-operators.md#argument-effects).
+
+Expressed as a `TupleType` instead, the results are ordinary SSA values:
+`InitMemRef` allocates each element like any other tile, `MemoryReuse` treats
+them as independent reuse candidates, and nothing about the hardware's DPS shape
+reaches the user.
+
+## Registration
+
+Declare the arity with `set_output_arity(N)` and return an N-element `TupleType`
+from `f_deduce_type`:
+
+```cpp
+// ❌ Wrong — DPS destinations leaked into the argument list
+REGISTER_OP("tile.gather_compare")
+    .add_argument("src", "...")
+    .add_argument("kvalue", "...")
+    .add_argument("tmp", "...")
+    .add_argument("dst", "...")     // leak
+    .add_argument("cdst", "...");   // leak
+
+// ✅ Correct — inputs only; outputs carried by the deduced TupleType
+REGISTER_OP("tile.gather_compare")
+    .add_argument("src", "Source tile (FP16/FP32/INT16/INT32, 2D)")
+    .add_argument("kvalue", "Scalar threshold")
+    .add_argument("tmp", "Workspace tile (UINT8)")
+    .set_output_arity(2)
+    .set_arg_effect(0, ArgEffect::Read)
+    .set_arg_effect(1, ArgEffect::Read)
+    .set_arg_effect(2, ArgEffect::Write)
+    .set_workspace_arg(2)
+    .f_deduce_type([](const auto& args, const auto& kwargs) {
+      return std::make_shared<TupleType>(std::vector<TypePtr>{
+          DeduceDstType(args, kwargs),
+          DeduceCdstType(args, kwargs),
+      });
+    });
+```
+
+| Method | Purpose |
+| ------ | ------- |
+| `set_output_arity(N)` | Declares N produced values. `N > 1` means the deduced result is a `TupleType` of exactly N elements |
+| `set_workspace_arg(i)` | Declares argument `i` to be compiler-supplied scratch — written by the hardware, carrying no result anyone reads |
+
+`set_output_memory(space)` applies to **every** `TileType` element inside the
+`TupleType`. An operator whose outputs live in different memory spaces must set
+`memory_space_` inside `f_deduce_type` instead of relying on that fallback.
+
+### Workspace versus destination
+
+A written argument is one of two things, and the registration must say which:
+
+| Kind | Example | Declaration |
+| ---- | ------- | ----------- |
+| **Workspace** — hardware scratch, no result the caller reads | `tile.gather_compare`'s `tmp`, synthesized by `ConvertTensorToTileOps` | `set_arg_effect(i, ArgEffect::Write)` + `set_workspace_arg(i)` |
+| **Destination** — a result the caller reads | `dst`, `cdst` | Not an argument at all — a `TupleType` element |
+
+The distinction is not cosmetic. A workspace is allocated by the pass that
+synthesizes it and is never read, so it needs no SSA result; a destination is a
+value the program goes on to use.
+
+## What the registry enforces
+
+Two checks, both of which fail loudly rather than letting a leak reach device.
+
+**At import** — `OpRegistry::ValidateMultiOutputOps()` walks every operator with
+arity > 1 and rejects three shapes:
+
+| Rejected | Why |
+| -------- | --- |
+| An argument with no declared effect | The default `Read` is indistinguishable from a destination in hiding |
+| A written argument not declared a workspace | It is either scratch that must say so, or a destination that belongs in the `TupleType` |
+| `set_workspace_arg(i)` naming no argument | An index past the end is a typo that silently protects nothing |
+| A workspace argument the operator never writes | Scratch is hardware-written by definition. Declaring it `Read` — or reaching that through `no_arg_writes()` — is the same dropped dependency edge, wearing a marker that says otherwise |
+| `set_output_reuses_input(N)` | With several results, "the output reuses input N" cannot say which one |
+
+The check works from the argument list, so it catches a destination by the trace
+it leaves — a write nobody declared scratch, or a slot nobody classified at all.
+A destination declared `Read` and never marked a workspace leaves no such trace
+and passes; what stops that one is the convention above, not the registry.
+
+**At call creation** — `OpRegistry::Create` cross-checks the declared arity
+against the deduced type, in both directions: a declared arity of N must deduce
+an N-element `TupleType`, and a deduced `TupleType` must have been declared.
+The second direction matters because codegen reads the arity from the registry;
+a tuple result nobody declared would have no arity to resolve its elements by.
+
+## How a multi-output call flows through the pipeline
+
+```text
+DSL wrapper          dst, cdst = pl.tile.gather_compare(src, kvalue, tmp, ...)
+                     returns (Tile(TupleGetItemExpr(call, 0)),
+                              Tile(TupleGetItemExpr(call, 1)))
+        ↓
+Parser desugaring    _tuple_tmp = tile.gather_compare(src, kvalue, tmp)
+                     dst  = _tuple_tmp[0]
+                     cdst = _tuple_tmp[1]
+        ↓
+InitMemRef           dst and cdst are ordinary TileType vars and each gets its
+                     own MemRef; _tuple_tmp is TupleType and gets none
+        ↓
+MemoryReuse          the tuple temporary carries the call's no-alias inputs onto
+                     every element; each element is an independent candidate
+        ↓
+PTO codegen          PrepareTupleOutputs(op) recovers the element vars from the
+                     `<var> = _tuple_tmp[i]` bindings and allocates them
+```
+
+The DSL wrapper returns one `TupleGetItemExpr` per output over the *same* call;
+`_unwrap_result` in `python/pypto/language/parser/_dsl_invoker.py` recognizes
+that shape generically and hands the parser back the bare `Call` to rebind.
+
+## Codegen
+
+A multi-output op's `Call` does not carry its destinations in `args_` — the
+parser put them in separate `AssignStmt`s — so an emitter looks them up:
+
+```cpp
+static std::string MakeGatherCompareCodegenPTO(const CallPtr& op,
+                                               codegen::CodegenBase& codegen_base) {
+  auto& codegen = AsPto(codegen_base);
+  const auto outs = codegen.PrepareTupleOutputs(op);   // resolve + allocate
+
+  std::ostringstream oss;
+  oss << "pto.tgather ins(" << /* ... inputs ... */ ")"
+      << " outs(" << outs[0].name << ", " << outs[1].name
+      << " : " << outs[0].type_str << ", " << outs[1].type_str << ")";
+  codegen.Emit(oss.str());
+  return "";
+}
+```
+
+`PrepareTupleOutputs` reads the arity from the registry, resolves each element
+var, checks it carries the MemRef `InitMemRef` assigned, and emits its
+`alloc_tile` **eagerly** — the intrinsic writes those buffers before the
+`<var> = tuple[i]` `AssignStmt`s that would otherwise allocate them. The
+emission is idempotent, so those statements then skip re-emitting.
+
+The element bindings are indexed once per function on entry
+(`fs_.tuple_element_index`), so resolving them is a map lookup rather than a
+body rescan per call.
+
+## Adding a multi-output operator
+
+1. Register with inputs only; add `set_output_arity(N)`.
+2. Classify **every** argument with `set_arg_effect`, or `no_arg_writes()` when
+   the operator writes through none of them. The import-time check requires a
+   verdict on each.
+3. Mark any written argument with `set_workspace_arg(i)` — and if it is not
+   scratch, it is a destination and does not belong in the argument list.
+4. Return an N-element `TupleType` from `f_deduce_type`.
+5. Write the DSL wrapper to return a tuple of `TupleGetItemExpr(call, i)` over
+   one call — the parser's unpacking path recognizes that shape.
+6. Write the codegen emitter using `PrepareTupleOutputs(op)`.
+7. Test the registration contract (`tests/ut/ir/operators/test_op_registry.py`
+   picks up any new `set_output_arity(N > 1)` automatically) and the lowering
+   end to end.
+
+## See Also
+
+- [Operator System](05-operators.md) — the general registration API and argument effects
+- [Types and Examples](02-types.md) — `TupleType` and the rest of the type system
+- [Parameter Directions](08-param-directions.md) — how an undeclared write loses its dependency edge
+- [InitMemRef](../passes/32-init_memref.md) — the pass that owns tile allocation
+- [MemoryReuse](../passes/34-memory_reuse.md) — lifetime reuse across tuple elements

--- a/docs/en/dev/ir/index.md
+++ b/docs/en/dev/ir/index.md
@@ -17,6 +17,7 @@ the page covering what you are changing.
 | [IR Builder](06-builder.md) | Constructing IR incrementally — context managers in Python, Begin/End in C++ |
 | [IR Parser](07-parser.md) | Converting Python DSL to IR via `@pl.function` / `@pl.program`, and the SSA properties it enforces |
 | [Parameter Directions](08-param-directions.md) | How `In`/`Out`/`InOut` is inferred — the registry declaration every stage reads, and the four passes that build on it |
+| [Multi-Output Operators](09-multi_output_ops.md) | Operators that produce several values: `TupleType` results, why destinations never become arguments, and what the registry enforces |
 
 ## See Also
 

--- a/docs/zh/dev/ir/05-operators.md
+++ b/docs/zh/dev/ir/05-operators.md
@@ -45,6 +45,8 @@ auto dynamic_dim = make_int(kDynamicDim);
 | `set_arg_effect(i, fn)` | 同上，但由 kwarg 决定 | `.set_arg_effect(2, [](const auto& kw) { ... })` |
 | `no_arg_writes()` | 已分类：不通过任何参数写入 | `.no_arg_writes()` |
 | `set_write_channel(c)` | 算子写入所走的硬件通路 | `.set_write_channel(WriteChannel::Dma)` |
+| `set_output_arity(N)` | 产生的值的个数；`N > 1` 表示结果是 `TupleType`——参见[多输出算子](09-multi_output_ops.md) | `.set_output_arity(2)` |
+| `set_workspace_arg(i)` | 第 `i` 个参数是编译器提供的暂存空间，而非结果 | `.set_workspace_arg(2)` |
 
 ### 参数效应（Argument effects）
 
@@ -950,6 +952,8 @@ a5 或不提供 SDMA provider 的 runtime 上，启用该能力的 worker 会在
    ```
 
 5. **添加测试**，位于 `tests/ut/ir/`，如需要则更新 `CMakeLists.txt`
+
+**要产生多个值？** 先读[多输出算子](09-multi_output_ops.md)——结果属于 `TupleType`，绝不放进参数列表；凡是这类算子会写、却没有声明为 workspace 的参数，注册表都会在 import 期拒绝。
 
 ## 参考
 

--- a/docs/zh/dev/ir/09-multi_output_ops.md
+++ b/docs/zh/dev/ir/09-multi_output_ops.md
@@ -1,0 +1,156 @@
+# 多输出算子 (Multi-Output Operators)
+
+## 概述
+
+有些硬件指令会产生多个结果。PTOAS `TGATHER` 的 compare 形式同时写出收集到的索引和每行的匹配计数，`pto.tgather` 把它们写作两个 `outs(...)` 操作数。包装这类指令的算子就是**多输出算子 (multi-output operator)**，PyPTO 用 `TupleType` 表达它的结果，绝不用目的参数 (destination argument)。
+
+**规则**：注册时只写*输入*。每个输出都是 `f_deduce_type` 返回的 `TupleType` 中的一个元素。
+
+参见 [算子系统](05-operators.md) 了解通用注册 API，[类型与示例](02-types.md#tupletype) 了解 `TupleType` 本身。
+
+## 为什么目的地不能是参数
+
+包装目的传递风格 (destination-passing-style, DPS) 指令时，最省事的写法是照抄硬件签名，把目的地声明成参数。这样错在两处：
+
+```text
+tile.gather_compare(src, kvalue, tmp, dst, cdst)   ← 泄漏
+  → 调用方必须自己分配 dst 和 cdst
+     但 tile 分配属于 InitMemRef，所有 tile buffer 都归它管
+  → 这个算子看起来像 5 输入算子
+     于是方向推导 (direction inference) 把 dst/cdst 读成消费者，写操作凭空消失
+```
+
+第二条后果才是危险的：没有分类的参数默认为 `ArgEffect::Read`，于是不会对读取该目的地的一方发出 RAW 边，故障会以设备上的陈旧数据形式出现，而不是在编译期报错。参见[算子系统](05-operators.md)的"参数效应"一节。
+
+改用 `TupleType` 表达后，结果就是普通的 SSA 值：`InitMemRef` 像分配任何其他 tile 一样分配每个元素，`MemoryReuse` 把它们当作独立的复用候选，硬件的 DPS 形状完全不会传到用户面前。
+
+## 注册
+
+用 `set_output_arity(N)` 声明输出个数，并从 `f_deduce_type` 返回 N 元 `TupleType`：
+
+```cpp
+// ❌ 错误 —— DPS 目的地泄漏进了参数列表
+REGISTER_OP("tile.gather_compare")
+    .add_argument("src", "...")
+    .add_argument("kvalue", "...")
+    .add_argument("tmp", "...")
+    .add_argument("dst", "...")     // 泄漏
+    .add_argument("cdst", "...");   // 泄漏
+
+// ✅ 正确 —— 只有输入；输出由推导出的 TupleType 承载
+REGISTER_OP("tile.gather_compare")
+    .add_argument("src", "Source tile (FP16/FP32/INT16/INT32, 2D)")
+    .add_argument("kvalue", "Scalar threshold")
+    .add_argument("tmp", "Workspace tile (UINT8)")
+    .set_output_arity(2)
+    .set_arg_effect(0, ArgEffect::Read)
+    .set_arg_effect(1, ArgEffect::Read)
+    .set_arg_effect(2, ArgEffect::Write)
+    .set_workspace_arg(2)
+    .f_deduce_type([](const auto& args, const auto& kwargs) {
+      return std::make_shared<TupleType>(std::vector<TypePtr>{
+          DeduceDstType(args, kwargs),
+          DeduceCdstType(args, kwargs),
+      });
+    });
+```
+
+| 方法 | 用途 |
+| ---- | ---- |
+| `set_output_arity(N)` | 声明产生 N 个值。`N > 1` 表示推导结果是恰好 N 个元素的 `TupleType` |
+| `set_workspace_arg(i)` | 声明参数 `i` 是编译器提供的暂存空间 (scratch)——硬件会写它，但不承载任何人读取的结果 |
+
+`set_output_memory(space)` 会作用于 `TupleType` 内的**每一个** `TileType` 元素。若某算子的输出位于不同内存空间，必须在 `f_deduce_type` 内部设置 `memory_space_`，而不能依赖这一回退路径。
+
+### 暂存空间与目的地
+
+被写入的参数只可能是两者之一，注册必须说清是哪一个：
+
+| 种类 | 示例 | 声明方式 |
+| ---- | ---- | -------- |
+| **暂存空间 (workspace)**——硬件 scratch，不承载任何人读取的结果 | `tile.gather_compare` 的 `tmp`，由 `ConvertTensorToTileOps` 合成 | `set_arg_effect(i, ArgEffect::Write)` + `set_workspace_arg(i)` |
+| **目的地 (destination)**——调用方要读取的结果 | `dst`、`cdst` | 根本不是参数——它是 `TupleType` 的元素 |
+
+这个区分不是修辞。暂存空间由合成它的 pass 分配且从不被读取，因此不需要 SSA 结果；目的地则是程序后续要使用的值。
+
+## 注册表强制的规则
+
+两道检查，都会大声失败，而不是让泄漏溜到设备上。
+
+**import 期**——`OpRegistry::ValidateMultiOutputOps()` 遍历所有 arity > 1 的算子，拒绝三种形状：
+
+| 被拒绝的情况 | 原因 |
+| ------------ | ---- |
+| 存在未声明效应的参数 | 默认的 `Read` 与藏起来的目的地无法区分 |
+| 被写入却未声明为 workspace 的参数 | 它要么是必须自报家门的 scratch，要么是本该放进 `TupleType` 的目的地 |
+| `set_workspace_arg(i)` 指向不存在的参数 | 越界的下标是一个笔误，它什么也保护不了 |
+| 声明为 workspace 却从不被写入的参数 | scratch 按定义就是硬件会写的。把它声明成 `Read`——或者经由 `no_arg_writes()` 落到 `Read`——依然是那条被丢掉的依赖边，只是外面套了一个说法相反的标记 |
+| `set_output_reuses_input(N)` | 有多个结果时，"输出复用输入 N"说不清是哪一个输出 |
+
+这项检查是从参数列表出发的，所以它是靠目的地留下的痕迹来抓它——一处没人声明为 scratch 的写，或者一个根本没人分类的槽位。若某个目的地被声明成 `Read` 且从未标记 workspace，它不留下任何痕迹，因而能通过；拦住这一种的是上面的约定，不是注册表。
+
+**建 call 时**——`OpRegistry::Create` 双向交叉校验声明的 arity 与推导出的类型：声明 N 就必须推导出 N 元 `TupleType`，推导出 `TupleType` 就必须先声明过。第二个方向同样重要，因为 codegen 从注册表读取 arity；没有声明过的 tuple 结果就没有 arity 可用来解析它的元素。
+
+## 多输出调用在流水线中的流转
+
+```text
+DSL 包装器            dst, cdst = pl.tile.gather_compare(src, kvalue, tmp, ...)
+                     返回 (Tile(TupleGetItemExpr(call, 0)),
+                           Tile(TupleGetItemExpr(call, 1)))
+        ↓
+解析器脱糖            _tuple_tmp = tile.gather_compare(src, kvalue, tmp)
+                     dst  = _tuple_tmp[0]
+                     cdst = _tuple_tmp[1]
+        ↓
+InitMemRef           dst 和 cdst 是普通 TileType 变量，各自拿到自己的 MemRef；
+                     _tuple_tmp 是 TupleType，不拿 MemRef
+        ↓
+MemoryReuse          tuple 临时变量把该 call 的 no-alias 输入传递到每个元素上；
+                     每个元素都是独立的复用候选
+        ↓
+PTO codegen          PrepareTupleOutputs(op) 从 `<var> = _tuple_tmp[i]` 绑定中
+                     找回元素变量并为它们分配空间
+```
+
+DSL 包装器为每个输出返回一个指向*同一个* call 的 `TupleGetItemExpr`；`python/pypto/language/parser/_dsl_invoker.py` 中的 `_unwrap_result` 通用地识别这一形状，并把裸 `Call` 交还给解析器重新绑定。
+
+## 代码生成
+
+多输出算子的 `Call` 不在 `args_` 里携带它的目的地——解析器把它们放进了单独的 `AssignStmt`——所以 emitter 需要去查：
+
+```cpp
+static std::string MakeGatherCompareCodegenPTO(const CallPtr& op,
+                                               codegen::CodegenBase& codegen_base) {
+  auto& codegen = AsPto(codegen_base);
+  const auto outs = codegen.PrepareTupleOutputs(op);   // 解析 + 分配
+
+  std::ostringstream oss;
+  oss << "pto.tgather ins(" << /* ... 输入 ... */ ")"
+      << " outs(" << outs[0].name << ", " << outs[1].name
+      << " : " << outs[0].type_str << ", " << outs[1].type_str << ")";
+  codegen.Emit(oss.str());
+  return "";
+}
+```
+
+`PrepareTupleOutputs` 从注册表读取 arity，解析出每个元素变量，检查它带有 `InitMemRef` 赋予的 MemRef，并**提前**发出它的 `alloc_tile`——指令会在那些本该负责分配的 `<var> = tuple[i]` `AssignStmt` 之前就写这些 buffer。发射是幂等的，因此那些语句随后会跳过重复发射。
+
+元素绑定在进入函数时一次性建立索引 (`fs_.tuple_element_index`)，所以解析它们是一次 map 查表，而不是每个 call 都重扫一遍函数体。
+
+## 新增一个多输出算子
+
+1. 只注册输入；加上 `set_output_arity(N)`。
+2. 用 `set_arg_effect` 对**每一个**参数分类；若该算子不通过任何参数写入，则用 `no_arg_writes()`。import 期检查要求每个参数都有明确结论。
+3. 给任何被写入的参数标记 `set_workspace_arg(i)`——如果它不是 scratch，那它就是目的地，不该出现在参数列表里。
+4. 从 `f_deduce_type` 返回 N 元 `TupleType`。
+5. DSL 包装器返回一组指向同一个 call 的 `TupleGetItemExpr(call, i)`——解析器的解包路径认这个形状。
+6. codegen emitter 使用 `PrepareTupleOutputs(op)` 编写。
+7. 测试注册契约（`tests/ut/ir/operators/test_op_registry.py` 会自动发现任何新的 `set_output_arity(N > 1)`）以及端到端的 lowering。
+
+## 参见
+
+- [算子系统](05-operators.md) —— 通用注册 API 与参数效应
+- [类型与示例](02-types.md) —— `TupleType` 及其余类型系统
+- [参数方向](08-param-directions.md) —— 一处未声明的写是如何丢掉它的依赖边的
+- [InitMemRef](../passes/32-init_memref.md) —— 拥有 tile 分配职责的 pass
+- [MemoryReuse](../passes/34-memory_reuse.md) —— 跨 tuple 元素的生命周期复用

--- a/docs/zh/dev/ir/index.md
+++ b/docs/zh/dev/ir/index.md
@@ -16,6 +16,7 @@ IR 定义是整个编译器的真源：pass 可以重写，IR 节点定义不可
 | [IR Builder](06-builder.md) | 增量构造 IR —— Python 用上下文管理器，C++ 用 Begin/End |
 | [IR Parser](07-parser.md) | 通过 `@pl.function` / `@pl.program` 把 Python DSL 转成 IR，以及它强制的 SSA 性质 |
 | [参数方向](08-param-directions.md) | `In`/`Out`/`InOut` 如何被推导——各阶段共同读取的注册表声明，以及基于它的四个 pass |
+| [多输出算子](09-multi_output_ops.md) | 产生多个值的算子：`TupleType` 结果、为什么目的地绝不作为参数，以及注册表强制的规则 |
 
 ## 另请参阅
 

--- a/include/pypto/codegen/pto/pto_codegen.h
+++ b/include/pypto/codegen/pto/pto_codegen.h
@@ -431,6 +431,42 @@ class PTOCodegen : public CodegenBase {
                                                                    size_t arity) const;
 
   /**
+   * @brief Resolve the DPS element vars of a multi-output call's tuple result
+   *
+   * The arity comes from the operator registry (`set_output_arity`), so an
+   * emitter never restates how many outputs its operator has and the two cannot
+   * drift apart.
+   *
+   * @param op A call whose operator declares an output arity greater than 1.
+   * @return Vector of length `arity`; entry i is the Var bound to element i, or
+   *         nullptr if no such consumer exists.
+   */
+  [[nodiscard]] std::vector<ir::VarPtr> ResolveTupleResultElements(const ir::CallPtr& op) const;
+
+  /// One DPS destination of a multi-output op: everything an emitter needs to
+  /// name it in an `outs(...)` clause.
+  struct TupleOutput {
+    std::string name;                               ///< SSA name of the destination buffer
+    std::string type_str;                           ///< `!pto.tile<...>` annotation for the `outs` clause
+    ir::VarPtr var;                                 ///< The Var bound to this tuple element
+    std::shared_ptr<const ir::TileType> tile_type;  ///< Its TileType, MemRef resolved
+  };
+
+  /**
+   * @brief Resolve and allocate every DPS destination of a multi-output call
+   *
+   * Wraps the whole preamble a multi-output emitter would otherwise repeat:
+   * resolve the element vars, check each carries a MemRef, and emit its
+   * `alloc_tile` eagerly — the intrinsic writes those buffers before the
+   * `<var> = tuple[i]` AssignStmts that would normally allocate them. An emitter
+   * is then only the format string for its intrinsic.
+   *
+   * @param op A call whose operator declares an output arity greater than 1.
+   * @return One entry per output, in tuple-element order.
+   */
+  [[nodiscard]] std::vector<TupleOutput> PrepareTupleOutputs(const ir::CallPtr& op);
+
+  /**
    * @brief Override the current result buffer name
    *
    * Allows codegen lambdas to redirect the result to a newly allocated buffer.
@@ -1030,6 +1066,11 @@ class PTOCodegen : public CodegenBase {
     /// to recover the per-tensor CommContext pointer.
     std::map<const ir::Var*, std::string> dist_tensor_to_ctx;
 
+    /// Every `<var> = <tuple>[i]` binding in the current function body, keyed by
+    /// the tuple Var. Built once on function entry so a multi-output emitter
+    /// resolves its destinations by lookup rather than by rescanning the body.
+    std::map<const ir::Var*, std::vector<ir::VarPtr>> tuple_element_index;
+
     std::string current_expr_value;
     std::vector<std::string> yield_buffer;
 
@@ -1070,6 +1111,7 @@ class PTOCodegen : public CodegenBase {
       multi_buffer_regions.clear();
       multi_buffer_region_order.clear();
 
+      tuple_element_index.clear();
       current_function.reset();
       current_result_var.reset();
       current_result_buf.clear();

--- a/include/pypto/ir/op_registry.h
+++ b/include/pypto/ir/op_registry.h
@@ -752,6 +752,27 @@ class OpRegistryEntry {
     return *this;
   }
 
+  /// Declare how many values this operator produces. `N > 1` means the deduced
+  /// result is a `TupleType` with exactly N elements, and every element is an
+  /// output: destination tiles must NOT appear in `add_argument()`, because a
+  /// caller cannot pre-allocate a buffer that `InitMemRef` owns. Default 1.
+  inline OpRegistryEntry& set_output_arity(size_t arity) {
+    CHECK(arity >= 1) << "Operator '" << name_ << "' declared output arity " << arity
+                      << "; every operator produces at least one value";
+    output_arity_ = arity;
+    return *this;
+  }
+
+  /// Declare argument `arg_index` to be compiler-supplied scratch: the hardware
+  /// writes it, but it carries no result the caller reads. This is what
+  /// separates a legitimate workspace — `tile.gather_compare`'s `tmp`, which
+  /// `ConvertTensorToTileOps` synthesizes — from a destination tile leaked into
+  /// the argument list, which `ValidateMultiOutputOps()` rejects.
+  inline OpRegistryEntry& set_workspace_arg(size_t arg_index) {
+    workspace_args_.insert(arg_index);
+    return *this;
+  }
+
   /// True when this operator declared its per-argument effects. False means the
   /// operator has never been classified — an analysis that needs the answer must
   /// say so loudly rather than assume read-only.
@@ -780,6 +801,17 @@ class OpRegistryEntry {
     return arg_effects_->per_arg[arg_index];
   }
 
+  /// True when this operator may write through argument `arg_index` under some
+  /// kwargs. Unlike `GetArgEffect`, this answers without inventing a kwargs set
+  /// to run a kwarg-dependent resolver against — a resolver is entitled to
+  /// reject kwargs no real call would carry.
+  [[nodiscard]] bool MayWriteArg(size_t arg_index) const {
+    if (!arg_effects_.has_value()) return false;
+    if (arg_effects_->kwarg_dependent.count(arg_index) > 0) return true;
+    if (arg_index >= arg_effects_->per_arg.size()) return false;
+    return ArgEffectWrites(arg_effects_->per_arg[arg_index]);
+  }
+
   /// True when this operator writes through at least one argument under some
   /// kwargs. Cheap pre-filter for analyses that only care about writers.
   [[nodiscard]] bool WritesAnyArg() const {
@@ -793,6 +825,25 @@ class OpRegistryEntry {
   [[nodiscard]] std::optional<WriteChannel> GetWriteChannel() const {
     return arg_effects_.has_value() ? arg_effects_->write_channel : std::nullopt;
   }
+
+  /// How many values this operator produces: 1 for an ordinary operator, N > 1
+  /// for a multi-output one whose deduced result is a `TupleType` of N elements.
+  /// Codegen reads the arity from here rather than restating it, so an emitter
+  /// and its registration cannot drift apart.
+  [[nodiscard]] size_t GetOutputArity() const { return output_arity_; }
+
+  /// True when argument `arg_index` was declared scratch via `set_workspace_arg()`.
+  [[nodiscard]] bool IsWorkspaceArg(size_t arg_index) const { return workspace_args_.count(arg_index) > 0; }
+
+  /// Every argument index declared scratch via `set_workspace_arg()`. Exposed as
+  /// the declared set rather than as a per-index predicate so validation can
+  /// catch an index that names no argument at all.
+  [[nodiscard]] const std::set<size_t>& GetWorkspaceArgs() const { return workspace_args_; }
+
+  /// Number of arguments the registration documented. 0 both for an operator
+  /// that declared `no_argument()` and for one that declared neither; `Validate()`
+  /// is what tells those apart.
+  [[nodiscard]] size_t GetArgumentCount() const { return arguments_.has_value() ? arguments_->size() : 0; }
 
   inline OpRegistryEntry& set_internal_only(bool value = true) {
     internal_only_ = value;
@@ -856,8 +907,10 @@ class OpRegistryEntry {
   std::set<size_t> forbid_output_alias_args_;  ///< Input args whose buffer the output must not reuse
   std::optional<core_affinity::CoreAffinity> core_affinity_;     ///< Explicit core-affinity override
   std::optional<core_affinity::CrossCoreRole> cross_core_role_;  ///< Cross-core role (for predicates)
-  bool no_duplicate_{false};   ///< True when the op must not run on a second core (set_no_duplicate)
-  bool internal_only_{false};  ///< True for compiler-created ops only.
+  bool no_duplicate_{false};         ///< True when the op must not run on a second core (set_no_duplicate)
+  bool internal_only_{false};        ///< True for compiler-created ops only.
+  size_t output_arity_{1};           ///< Values produced; > 1 means a TupleType result
+  std::set<size_t> workspace_args_;  ///< Args written as scratch rather than as results
   std::optional<std::string> template_dir_;  ///< Package resource for builtin templates.
 };
 
@@ -1022,6 +1075,28 @@ class OpRegistry {
    * @throws ValueError listing every in-place operator with undeclared effects
    */
   void ValidateArgEffects() const;
+
+  /**
+   * @brief Validate that every multi-output operator expresses its outputs as a
+   *        TupleType result rather than as destination arguments.
+   *
+   * A destination tile in the argument list forces the caller to pre-allocate a
+   * buffer `InitMemRef` owns, and hides the write from direction inference — the
+   * exact leak that makes a hardware DPS signature look like an ordinary
+   * multi-input operator. The registry cannot see a destination directly, so it
+   * checks the two shapes that betray one: an argument nobody classified (the
+   * default `Read` then hides the write), and a written argument that was not
+   * declared scratch via `set_workspace_arg()`.
+   *
+   * Also rejects `set_output_reuses_input(N)` on a multi-output operator: with
+   * several results, "the output reuses input N" cannot say which one.
+   *
+   * Call at module init to catch a leaked destination at import time.
+   *
+   * @throws ValueError listing every multi-output op with an unclassified or
+   *         unmarked written argument
+   */
+  void ValidateMultiOutputOps() const;
 
  private:
   OpRegistry() = default;

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -309,6 +309,7 @@ nav:
           - en/dev/ir/06-builder.md
           - en/dev/ir/07-parser.md
           - en/dev/ir/08-param-directions.md
+          - en/dev/ir/09-multi_output_ops.md
       - Passes:
           - en/dev/passes/index.md
           - en/dev/passes/00-pass_manager.md

--- a/python/bindings/bindings.cpp
+++ b/python/bindings/bindings.cpp
@@ -75,4 +75,9 @@ NB_MODULE(pypto_core, m) {
   // Validate that every in-place op declared what it does to the slot it updates —
   // an undeclared writer reads as a pure consumer and its dependency edge vanishes
   pypto::ir::OpRegistry::GetInstance().ValidateArgEffects();
+
+  // Validate that multi-output ops express their outputs as a TupleType result —
+  // a destination tile in the argument list makes the caller pre-allocate a
+  // buffer InitMemRef owns, and hides the write from direction inference
+  pypto::ir::OpRegistry::GetInstance().ValidateMultiOutputOps();
 }

--- a/python/bindings/modules/ir.cpp
+++ b/python/bindings/modules/ir.cpp
@@ -868,6 +868,26 @@ void BindIR(nb::module_& m) {
       nb::arg("op_name"), "Get an operator instance by name");
 
   ir.def(
+      "get_op_output_arity",
+      [](const std::string& op_name) { return OpRegistry::GetInstance().GetEntry(op_name).GetOutputArity(); },
+      nb::arg("op_name"), "Number of values an operator produces (>1 means a TupleType result)");
+
+  ir.def(
+      "op_arg_is_workspace",
+      [](const std::string& op_name, size_t arg_index) {
+        return OpRegistry::GetInstance().GetEntry(op_name).IsWorkspaceArg(arg_index);
+      },
+      nb::arg("op_name"), nb::arg("arg_index"),
+      "Whether an argument was declared compiler-supplied scratch rather than a result");
+
+  ir.def(
+      "get_op_argument_count",
+      [](const std::string& op_name) {
+        return OpRegistry::GetInstance().GetEntry(op_name).GetArgumentCount();
+      },
+      nb::arg("op_name"), "Number of arguments an operator's registration documents");
+
+  ir.def(
       "get_op_memory_spec",
       [](const std::string& op_name) -> nb::object {
         auto& registry = OpRegistry::GetInstance();

--- a/python/pypto/pypto_core/ir.pyi
+++ b/python/pypto/pypto_core/ir.pyi
@@ -3300,6 +3300,54 @@ def get_op_write_channel(op_name: str) -> WriteChannel | None:
         Exception: If operator is not registered
     """
 
+def get_op_output_arity(op_name: str) -> int:
+    """Number of values an operator produces.
+
+    1 for an ordinary operator; N > 1 for a multi-output operator, whose deduced
+    result is a ``TupleType`` of exactly N elements. Codegen reads the arity from
+    here rather than restating it per emitter.
+
+    Args:
+        op_name: Name of the operator
+
+    Returns:
+        The declared output arity
+
+    Raises:
+        Exception: If operator is not registered
+    """
+
+def op_arg_is_workspace(op_name: str, arg_index: int) -> bool:
+    """Whether an argument is compiler-supplied scratch rather than a result.
+
+    A multi-output operator may write through an argument only when that
+    argument is declared a workspace; an undeclared written argument is a
+    destination tile leaked into the argument list.
+
+    Args:
+        op_name: Name of the operator
+        arg_index: Positional argument index
+
+    Returns:
+        True when the registration declared this argument a workspace
+
+    Raises:
+        Exception: If operator is not registered
+    """
+
+def get_op_argument_count(op_name: str) -> int:
+    """Number of arguments an operator's registration documents.
+
+    Args:
+        op_name: Name of the operator
+
+    Returns:
+        The documented argument count (0 for an operator taking no arguments)
+
+    Raises:
+        Exception: If operator is not registered
+    """
+
 # ========== Op Conversion Registry ==========
 
 def register_op_conversion(from_op: str, to_op: str) -> None:

--- a/src/backend/common/pto_ops_datamove.cpp
+++ b/src/backend/common/pto_ops_datamove.cpp
@@ -14,7 +14,6 @@
  * @brief PTO codegen registration for data-movement / tile-view / shuffle ops.
  */
 
-#include <array>
 #include <cstddef>
 #include <cstdint>
 #include <memory>
@@ -37,7 +36,6 @@
 #include "pypto/ir/scalar_expr.h"
 #include "pypto/ir/storage_size.h"
 #include "pypto/ir/tile_view_semantics.h"
-#include "pypto/ir/transforms/utils/memref_utils.h"
 #include "pypto/ir/type.h"
 #include "src/backend/common/pto_ops_internal.h"
 
@@ -657,35 +655,16 @@ static std::string MakeGatherMaskCodegenPTO(const CallPtr& op, codegen::CodegenB
 //                   : src_ty, kv_ty, tmp_ty)
 //               outs(dst, cdst : dst_ty, cdst_ty)
 //
-// Op surface: 3 inputs / TupleType{dst_TileType, cdst_TileType} output. DPS
+// Op surface: 3 inputs / TupleType{dst_TileType, cdst_TileType} output. The DPS
 // dst/cdst buffers are bound by downstream `<element> = tuple_var[i]`
-// AssignStmts (parser desugaring of `dst, cdst = ...`). Because the framework
-// only pre-binds `fs_.current_result_*` for TileType LHS, multi-output ops
-// must resolve their own DPS targets — done via ResolveTupleResultElements.
+// AssignStmts (parser desugaring of `dst, cdst = ...`) rather than named in
+// args_, so PrepareTupleOutputs recovers and allocates them.
 static std::string MakeGatherCompareCodegenPTO(const CallPtr& op, codegen::CodegenBase& codegen_base) {
   auto& codegen = AsPto(codegen_base);
   INTERNAL_CHECK_SPAN(op->args_.size() == 3, op->span_)
       << "tile.gather_compare requires 3 arguments (src, kvalue, tmp), but got " << op->args_.size();
 
-  ir::VarPtr tuple_var = codegen.GetCurrentResultVar();
-  INTERNAL_CHECK_SPAN(tuple_var, op->span_)
-      << "Internal error: tile.gather_compare codegen requires current_result_var";
-
-  auto element_vars = codegen.ResolveTupleResultElements(tuple_var, /*arity=*/2);
-  INTERNAL_CHECK_SPAN(element_vars[0] && element_vars[1], op->span_)
-      << "Internal error: tile.gather_compare expects two TupleGetItemExpr consumers (dst, cdst), got "
-      << (element_vars[0] ? "dst-yes" : "dst-no") << "/" << (element_vars[1] ? "cdst-yes" : "cdst-no");
-
-  // Eagerly emit alloc_tile for dst/cdst; the later `dst = tuple_var[i]`
-  // AssignStmts skip re-emission via fs_.emitted_tile_alloc_vars.
-  std::array<std::shared_ptr<const ir::TileType>, 2> elem_types;
-  for (size_t i = 0; i < 2; ++i) {
-    elem_types[i] = ir::GetTileTypeWithMemRef(element_vars[i]->GetType());
-    INTERNAL_CHECK_SPAN(elem_types[i], element_vars[i]->span_)
-        << "Internal error: tile.gather_compare element var " << i
-        << " must have TileType with MemRef set by InitMemRef";
-    codegen.EmitAllocTileForVar(element_vars[i], elem_types[i]);
-  }
+  const auto outs = codegen.PrepareTupleOutputs(op);
 
   int cmp_mode = op->GetKwarg<int>("cmp_mode");
   CHECK(cmp_mode >= 0 && cmp_mode < 6) << "tile.gather_compare cmp_mode out of range: " << cmp_mode;
@@ -698,19 +677,15 @@ static std::string MakeGatherCompareCodegenPTO(const CallPtr& op, codegen::Codeg
   std::string src_ty = codegen.GetExprTypeAnnotation(op->args_[0]);
   std::string kv_ty = codegen.GetExprTypeAnnotation(op->args_[1]);
   std::string tmp_ty = codegen.GetExprTypeAnnotation(op->args_[2]);
-  std::string dst = codegen.GetVarName(element_vars[0]);
-  std::string cdst = codegen.GetVarName(element_vars[1]);
-  std::string dst_ty = codegen.GetTileBufTypeStringFromTileType(elem_types[0]);
-  std::string cdst_ty = codegen.GetTileBufTypeStringFromTileType(elem_types[1]);
 
   std::ostringstream oss;
   oss << "pto.tgather ins(" << src << ", " << kvalue << ", " << tmp;
   if (!src_ty.empty() || !kv_ty.empty() || !tmp_ty.empty()) {
     oss << " : " << src_ty << ", " << kv_ty << ", " << tmp_ty;
   }
-  oss << ") outs(" << dst << ", " << cdst;
-  if (!dst_ty.empty() || !cdst_ty.empty()) {
-    oss << " : " << dst_ty << ", " << cdst_ty;
+  oss << ") outs(" << outs[0].name << ", " << outs[1].name;
+  if (!outs[0].type_str.empty() || !outs[1].type_str.empty()) {
+    oss << " : " << outs[0].type_str << ", " << outs[1].type_str;
   }
   oss << ") {cmpMode = #pto<cmp " << kCmpNames[cmp_mode] << ">, offset = " << offset << " : i32}";
 
@@ -1073,30 +1048,14 @@ static std::string MakeTQuantMxCodegenPTO(const CallPtr& op, codegen::CodegenBas
       << "Internal error: tile.tquant_mx_raw reached codegen with unsupported dtype " << dtype.ToString()
       << "; this PR only supports MXFP8 (FP8E4M3FN)";
 
-  ir::VarPtr tuple_var = codegen.GetCurrentResultVar();
-  INTERNAL_CHECK_SPAN(tuple_var, op->span_)
-      << "Internal error: tile.tquant_mx_raw codegen requires current_result_var";
-
-  auto element_vars = codegen.ResolveTupleResultElements(tuple_var, /*arity=*/2);
-  INTERNAL_CHECK_SPAN(element_vars[0] && element_vars[1], op->span_)
-      << "Internal error: tile.tquant_mx_raw expects two TupleGetItemExpr consumers (dst, exp), got "
-      << (element_vars[0] ? "dst-yes" : "dst-no") << "/" << (element_vars[1] ? "exp-yes" : "exp-no");
-
-  std::array<std::shared_ptr<const ir::TileType>, 2> elem_types;
-  for (size_t i = 0; i < 2; ++i) {
-    elem_types[i] = ir::GetTileTypeWithMemRef(element_vars[i]->GetType());
-    INTERNAL_CHECK_SPAN(elem_types[i], element_vars[i]->span_)
-        << "Internal error: tile.tquant_mx_raw element var " << i
-        << " must have TileType with MemRef set by InitMemRef";
-    codegen.EmitAllocTileForVar(element_vars[i], elem_types[i]);
-  }
+  const auto outs = codegen.PrepareTupleOutputs(op);
 
   // Every TQUANT operand must take the static-valid bridge (see EmitStaticValidTileView).
   auto src_view = EmitStaticValidTileView(codegen, op->args_[0], "tquant_src_static");
   auto max_view = EmitStaticValidTileView(codegen, op->args_[1], "tquant_max_static");
   auto scaling_view = EmitStaticValidTileView(codegen, op->args_[2], "tquant_scaling_static");
-  auto dst_view = EmitStaticValidTileView(codegen, element_vars[0], "tquant_dst_static");
-  auto scale_view = EmitStaticValidTileView(codegen, element_vars[1], "tquant_exp_static");
+  auto dst_view = EmitStaticValidTileView(codegen, outs[0].var, "tquant_dst_static");
+  auto scale_view = EmitStaticValidTileView(codegen, outs[1].var, "tquant_exp_static");
 
   std::ostringstream oss;
   oss << "pto.tquant.mx ins(" << src_view.ssa << " : " << src_view.type;

--- a/src/codegen/pto/pto_codegen.cpp
+++ b/src/codegen/pto/pto_codegen.cpp
@@ -11,6 +11,7 @@
 
 #include "pypto/codegen/pto/pto_codegen.h"
 
+#include <algorithm>
 #include <cctype>
 #include <cstddef>
 #include <cstdint>
@@ -496,32 +497,39 @@ bool ShouldAliasArrayUpdateResultToInput(const AssignStmtPtr& stmt) {
 
 const auto& FlattenBody = transform_utils::FlattenToStmts;
 
-// Collects `<var> = TupleGetItemExpr(tuple_var, i)` AssignStmts. IRVisitor
-// auto-recurses through all statement kinds (Seq/For/If/While/Scope/Inline/...),
-// so this stays correct regardless of where the tuple-returning call is nested.
+// Indexes every `<var> = TupleGetItemExpr(tuple_var, i)` AssignStmt in a body,
+// keyed by the tuple Var. One walk builds the whole index, so a multi-output
+// emitter resolves its DPS destinations by lookup rather than by rescanning the
+// body per call. IRVisitor auto-recurses through all statement kinds
+// (Seq/For/If/While/Scope/Inline/...), so this stays correct regardless of where
+// the tuple-returning call is nested.
 class TupleConsumerCollector : public ir::IRVisitor {
  public:
-  explicit TupleConsumerCollector(const ir::Var* tuple_var, size_t arity)
-      : tuple_var_(tuple_var), elements_(arity, nullptr) {}
-
-  [[nodiscard]] const std::vector<ir::VarPtr>& elements() const { return elements_; }
+  [[nodiscard]] std::map<const ir::Var*, std::vector<ir::VarPtr>> Take() { return std::move(index_); }
 
  protected:
   void VisitStmt_(const ir::AssignStmtPtr& op) override {
     if (auto tge = As<ir::TupleGetItemExpr>(op->value_)) {
-      if (auto base = As<ir::Var>(tge->tuple_)) {
-        if (base.get() == tuple_var_ && tge->index_ >= 0 &&
-            static_cast<size_t>(tge->index_) < elements_.size()) {
-          elements_[tge->index_] = op->var_;
-        }
+      if (auto base = As<ir::Var>(tge->tuple_); base && tge->index_ >= 0) {
+        auto& elements = index_[base.get()];
+        const auto index = static_cast<size_t>(tge->index_);
+        if (elements.size() <= index) elements.resize(index + 1, nullptr);
+        // Only one Var can be the hardware destination for an element. A second
+        // binding would silently win, and the first one's own allocation would
+        // stay unwritten for its consumers to read as uninitialized data.
+        INTERNAL_CHECK_SPAN(!elements[index], op->span_)
+            << "Internal error: element " << index << " of tuple '" << base->name_hint_
+            << "' is bound twice, by '" << elements[index]->name_hint_ << "' and '" << op->var_->name_hint_
+            << "'; only one of them can name the destination the "
+            << "instruction writes";
+        elements[index] = op->var_;
       }
     }
     ir::IRVisitor::VisitStmt_(op);
   }
 
  private:
-  const ir::Var* tuple_var_;
-  std::vector<ir::VarPtr> elements_;
+  std::map<const ir::Var*, std::vector<ir::VarPtr>> index_;
 };
 
 }  // namespace
@@ -844,6 +852,16 @@ void PTOCodegen::EmitDeferredCompletionAdapterDeclaration() {
 void PTOCodegen::GenerateFunction(const FunctionPtr& func) {
   fs_.Reset();
   fs_.current_function = func;
+
+  // Index every `<var> = <tuple>[i]` binding once. A multi-output op's Call does
+  // not carry its DPS destinations in args_ — the parser desugars them into
+  // separate AssignStmts — so an emitter has to look them up. Resolving each
+  // call by rescanning the body would be O(body) per call.
+  {
+    TupleConsumerCollector collector;
+    collector.VisitStmt(func->body_);
+    fs_.tuple_element_index = collector.Take();
+  }
 
   // Collect dyn-dim Vars from tensor-parameter shapes once. The same list
   // drives both name reservation (Site A below) and the trailing %argN: index
@@ -2277,11 +2295,48 @@ ir::VarPtr PTOCodegen::GetCurrentResultVar() const { return fs_.current_result_v
 std::vector<ir::VarPtr> PTOCodegen::ResolveTupleResultElements(const ir::VarPtr& tuple_var,
                                                                size_t arity) const {
   INTERNAL_CHECK(tuple_var) << "Internal error: ResolveTupleResultElements requires non-null tuple_var";
-  INTERNAL_CHECK(fs_.current_function)
-      << "Internal error: ResolveTupleResultElements requires current_function";
-  TupleConsumerCollector collector(tuple_var.get(), arity);
-  collector.VisitStmt(fs_.current_function->body_);
-  return collector.elements();
+  std::vector<ir::VarPtr> elements(arity, nullptr);
+  const auto it = fs_.tuple_element_index.find(tuple_var.get());
+  if (it == fs_.tuple_element_index.end()) return elements;
+  const size_t resolved = std::min(arity, it->second.size());
+  std::copy_n(it->second.begin(), resolved, elements.begin());
+  return elements;
+}
+
+std::vector<ir::VarPtr> PTOCodegen::ResolveTupleResultElements(const ir::CallPtr& op) const {
+  INTERNAL_CHECK(op && op->op_)
+      << "Internal error: ResolveTupleResultElements requires a call with an operator";
+  const auto& entry = ir::OpRegistry::GetInstance().GetEntry(op->op_->name_);
+  const size_t arity = entry.GetOutputArity();
+  INTERNAL_CHECK_SPAN(arity > 1, op->span_)
+      << "Internal error: '" << op->op_->name_ << "' has output arity " << arity
+      << "; only a multi-output operator has tuple elements to resolve";
+  return ResolveTupleResultElements(GetCurrentResultVar(), arity);
+}
+
+std::vector<PTOCodegen::TupleOutput> PTOCodegen::PrepareTupleOutputs(const ir::CallPtr& op) {
+  const auto element_vars = ResolveTupleResultElements(op);
+  std::vector<TupleOutput> outputs;
+  outputs.reserve(element_vars.size());
+  for (size_t i = 0; i < element_vars.size(); ++i) {
+    // The hardware writes every destination whether or not the program reads it,
+    // so a missing binding is not "an output nobody wanted" — it is a buffer the
+    // intrinsic is about to scribble into with no allocation behind it.
+    INTERNAL_CHECK_SPAN(element_vars[i], op->span_)
+        << "Internal error: '" << op->op_->name_ << "' output " << i << " has no `<var> = tuple[" << i
+        << "]` binding to name its destination";
+    auto tile_type = ir::GetTileTypeWithMemRef(element_vars[i]->GetType());
+    INTERNAL_CHECK_SPAN(tile_type, element_vars[i]->span_)
+        << "Internal error: '" << op->op_->name_ << "' output " << i
+        << " must have TileType with MemRef set by InitMemRef";
+    // Eagerly allocate: the destinations are written by this instruction, before
+    // the `<var> = tuple[i]` AssignStmts that would otherwise emit them. The
+    // emission is idempotent, so those AssignStmts then skip re-emitting.
+    EmitAllocTileForVar(element_vars[i], tile_type);
+    outputs.push_back(TupleOutput{GetVarName(element_vars[i]), GetTileBufTypeStringFromTileType(tile_type),
+                                  element_vars[i], tile_type});
+  }
+  return outputs;
 }
 
 void PTOCodegen::Emit(const std::string& line) { stream_ << GetIndent() << line << LocSuffix() << "\n"; }

--- a/src/ir/op/tensor_ops/gather.cpp
+++ b/src/ir/op/tensor_ops/gather.cpp
@@ -318,6 +318,11 @@ REGISTER_OP("tensor.gather_compare")
     .set_attr<int>("offset")
     .set_attr<int>("out_cols")
     .set_attr<DataType>("count_dtype")
+    // Two outputs (dst, cdst), carried by the deduced TupleType. Both arguments
+    // are pure reads: the tile-level workspace appears only after
+    // ConvertTensorToTileOps synthesizes it.
+    .set_output_arity(2)
+    .no_arg_writes()
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
       return DeduceTensorGatherCompareType(args, kwargs, "tensor.gather_compare");

--- a/src/ir/op/tile_ops/gather.cpp
+++ b/src/ir/op/tile_ops/gather.cpp
@@ -458,6 +458,16 @@ REGISTER_OP("tile.gather_compare")
     .set_attr<DataType>("count_dtype")
     .set_input_memory(0, MemorySpace::Vec)
     .set_input_memory(2, MemorySpace::Vec)
+    // Two outputs (dst, cdst), carried by the deduced TupleType rather than by
+    // destination arguments — the caller cannot pre-allocate buffers InitMemRef
+    // owns. `tmp` is hardware scratch that ConvertTensorToTileOps synthesizes:
+    // written, but carrying no result anyone reads, so it is declared a
+    // workspace instead of masquerading as a third output.
+    .set_output_arity(2)
+    .set_arg_effect(0, ArgEffect::Read)
+    .set_arg_effect(1, ArgEffect::Read)
+    .set_arg_effect(2, ArgEffect::Write)
+    .set_workspace_arg(2)
     // Output is a TupleType{TileType_dst, TileType_cdst}. set_output_memory applies
     // Vec to every TileType element inside the TupleType.
     .set_output_memory(MemorySpace::Vec)

--- a/src/ir/op/tile_ops/quant_mx.cpp
+++ b/src/ir/op/tile_ops/quant_mx.cpp
@@ -396,6 +396,10 @@ REGISTER_OP("tile.tquant_mx")
     .set_attr<int>("group_axis")
     .set_input_memory(0, MemorySpace::Vec)
     .set_output_memory(MemorySpace::Vec)
+    // Two results (dst, scale), carried by the deduced TupleType; the single
+    // argument is a pure read.
+    .set_output_arity(2)
+    .no_arg_writes()
     .not_inplace_safe()
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
@@ -416,8 +420,15 @@ REGISTER_OP("tile.tquant_mx_raw")
     .set_input_memory(1, MemorySpace::Vec)
     .set_input_memory(2, MemorySpace::Vec)
     .set_output_memory(MemorySpace::Vec)
+    // Two results (raw dst, raw exp), carried by the deduced TupleType. max and
+    // scaling are hardware-written scratch that LowerCompositeOps synthesizes --
+    // written, but carrying no result the caller reads.
+    .set_output_arity(2)
+    .set_arg_effect(0, ArgEffect::Read)
     .set_arg_effect(1, ArgEffect::Write)
     .set_arg_effect(2, ArgEffect::Write)
+    .set_workspace_arg(1)
+    .set_workspace_arg(2)
     .not_inplace_safe()
     .functional_execution_memory_access()
     .f_deduce_type([](const std::vector<ExprPtr>& args,

--- a/src/ir/op_registry.cpp
+++ b/src/ir/op_registry.cpp
@@ -285,6 +285,29 @@ CallPtr OpRegistry::CreateImpl(const std::string& op_name, const std::vector<Exp
   }
   INTERNAL_CHECK_SPAN(result_type, span) << "Type deduction failed for '" + op_name + "'";
 
+  // The declared output arity and the deduced shape must agree. A mismatch means
+  // the registration and its f_deduce_type disagree about what the operator
+  // produces, which would surface much later as a null element var inside
+  // multi-output codegen. The reverse direction matters just as much: a tuple
+  // result nobody declared has no arity for codegen to read, so its elements
+  // would never be resolved.
+  const size_t declared_arity = entry.GetOutputArity();
+  auto deduced_tuple = As<TupleType>(result_type);
+  if (declared_arity > 1) {
+    INTERNAL_CHECK_SPAN(deduced_tuple, span)
+        << "Internal error: '" << op_name << "' declares set_output_arity(" << declared_arity
+        << ") but deduced a non-tuple " << result_type->TypeName();
+    INTERNAL_CHECK_SPAN(deduced_tuple->types_.size() == declared_arity, span)
+        << "Internal error: '" << op_name << "' declares set_output_arity(" << declared_arity
+        << ") but deduced a TupleType with " << deduced_tuple->types_.size() << " elements";
+  } else {
+    INTERNAL_CHECK_SPAN(!deduced_tuple, span)
+        << "Internal error: '" << op_name << "' deduced a TupleType result without declaring "
+        << "set_output_arity(" << deduced_tuple->types_.size()
+        << "); multi-output codegen reads the arity from the registry and would not "
+           "resolve this call's elements";
+  }
+
   // Apply OpMemorySpaceSpec to TileType results that lack memory_space.
   // This ensures the deduced type carries memory_space even when individual
   // type deduction functions omit it (fixes issue #553).
@@ -432,6 +455,97 @@ void OpRegistry::ValidateArgEffects() const {
       msg += "\n  - " + name;
     }
     throw ValueError(msg);
+  }
+}
+
+void OpRegistry::ValidateMultiOutputOps() const {
+  std::vector<std::string> unclassified;
+  std::vector<std::string> leaked_destinations;
+  std::vector<std::string> workspace_out_of_range;
+  std::vector<std::string> workspace_never_written;
+  std::vector<std::string> reuses_input;
+  for (const auto& [name, entry] : registry_) {
+    if (entry.GetOutputArity() <= 1) continue;
+    const size_t arg_count = entry.GetArgumentCount();
+    for (size_t i = 0; i < arg_count; ++i) {
+      // An argument nobody classified defaults to Read, and a destination tile
+      // reads exactly like an input under that default. Demanding a verdict is
+      // what turns the leak from invisible into a registration a reviewer sees.
+      if (!entry.HasDeclaredArgEffect(i)) {
+        unclassified.push_back(name + " (argument " + std::to_string(i) + ")");
+        continue;
+      }
+      // A written argument is either scratch the hardware needs or a result the
+      // caller reads. The first is legitimate and must say so; the second is a
+      // destination that belongs in the TupleType.
+      if (entry.MayWriteArg(i) && !entry.IsWorkspaceArg(i)) {
+        leaked_destinations.push_back(name + " (argument " + std::to_string(i) + ")");
+      }
+    }
+    // A workspace declaration is a claim about an argument that exists and that
+    // the hardware writes. Neither half is implied by the loop above: an index
+    // past the end names nothing, and `.no_arg_writes().set_workspace_arg(0)`
+    // classifies argument 0 as Read while calling it hardware-written scratch.
+    // Either way the operator reads as a pure consumer of a slot it writes.
+    for (size_t i : entry.GetWorkspaceArgs()) {
+      if (i >= arg_count) {
+        workspace_out_of_range.push_back(name + " (argument " + std::to_string(i) + " of " +
+                                         std::to_string(arg_count) + ")");
+      } else if (!entry.MayWriteArg(i)) {
+        workspace_never_written.push_back(name + " (argument " + std::to_string(i) + ")");
+      }
+    }
+    const auto& spec = entry.GetMemorySpec();
+    if (spec.has_value() && spec->output_reuses_input_arg.has_value()) {
+      reuses_input.push_back(name);
+    }
+  }
+  auto fail = [](std::string msg, std::vector<std::string> names) {
+    std::sort(names.begin(), names.end());
+    for (const auto& name : names) msg += "\n  - " + name;
+    throw ValueError(msg);
+  };
+  if (!unclassified.empty()) {
+    fail(
+        "The following multi-output ops left an argument unclassified. An operator that "
+        "returns several values must reach a verdict about every argument it takes: an "
+        "undeclared slot defaults to Read, which is indistinguishable from a destination "
+        "tile smuggled into the argument list. Add .set_arg_effect(<index>, ...) for each "
+        "argument — or .no_arg_writes() when the operator writes through none of them:",
+        std::move(unclassified));
+  }
+  if (!leaked_destinations.empty()) {
+    fail(
+        "The following multi-output ops write through an argument that was never declared "
+        "scratch. A written argument is either a workspace the hardware needs — say so with "
+        ".set_workspace_arg(<index>) — or a destination the caller reads, which must be an "
+        "element of the deduced TupleType instead. A destination in the argument list makes "
+        "the caller pre-allocate a buffer InitMemRef owns:",
+        std::move(leaked_destinations));
+  }
+  if (!workspace_out_of_range.empty()) {
+    fail(
+        "The following multi-output ops declare a workspace argument that does not exist. "
+        "set_workspace_arg() names a positional argument, so an index past the end is a "
+        "typo that silently protects nothing:",
+        std::move(workspace_out_of_range));
+  }
+  if (!workspace_never_written.empty()) {
+    fail(
+        "The following multi-output ops declare a workspace argument the operator never "
+        "writes. A workspace is hardware-written scratch by definition; declaring one Read "
+        "-- or reaching that classification through no_arg_writes() -- leaves direction "
+        "inference treating a real write as a read, which is the dropped dependency edge "
+        "this check exists to prevent. Declare the effect that matches what the hardware "
+        "does, or drop the workspace marker:",
+        std::move(workspace_never_written));
+  }
+  if (!reuses_input.empty()) {
+    fail(
+        "The following multi-output ops declare set_output_reuses_input(N). With several "
+        "results, \"the output reuses input N\" cannot say which one, and InitMemRef would "
+        "bind the tuple temporary rather than an element. Drop the declaration:",
+        std::move(reuses_input));
   }
 }
 

--- a/tests/ut/ir/operators/test_gather_compare.py
+++ b/tests/ut/ir/operators/test_gather_compare.py
@@ -19,13 +19,59 @@ Type contract (enforced by the op's type deduction):
 
 import pypto.language as pl
 import pytest
+from pypto import ir as _ir
 from pypto.language.parser.diagnostics import InvalidOperationError
 
 _VALID_SRC_DTYPES = [pl.FP16, pl.FP32, pl.INT16, pl.INT32]
 _INVALID_SRC_DTYPES = [pl.UINT16, pl.UINT32, pl.UINT8, pl.INT64]
 
 
-def _build_program(cmp_mode: str | int = "eq", offset=0, src_dtype=pl.FP32):
+def _find_call(program, op_name: str):
+    """The single Call to ``op_name`` in ``program``'s only function.
+
+    Asserting on the deduced Call is what makes these type tests actually test
+    the type contract: a substring match on the printed program passes whenever
+    the operator merely *appears*, whatever shape or dtype it deduced.
+    """
+    wanted = _ir.get_op(op_name).name
+    found = []
+
+    class _Collector(_ir.IRVisitor):
+        def visit_call(self, expr):  # type: ignore[override]
+            if expr.op.name == wanted:
+                found.append(expr)
+            super().visit_call(expr)
+
+    for func in program.functions.values():
+        _Collector().visit_stmt(func.body)
+    assert len(found) == 1, f"expected exactly one {op_name} call, found {len(found)}"
+    return found[0]
+
+
+def _static_shape(shaped_type: _ir.ShapedType) -> list[int]:
+    dims: list[int] = []
+    for axis, dim in enumerate(shaped_type.shape):
+        assert isinstance(dim, _ir.ConstInt), f"dimension {axis} is not a static extent"
+        dims.append(dim.value)
+    return dims
+
+
+def _tuple_elements(call) -> list[_ir.ShapedType]:
+    """The deduced result type of a multi-output call, as its output elements."""
+    result_type = call.type
+    assert isinstance(result_type, _ir.TupleType), (
+        f"{call.op.name} must deduce a TupleType, got {type(result_type).__name__}"
+    )
+    elements: list[_ir.ShapedType] = []
+    for i, element in enumerate(result_type.types):
+        assert isinstance(element, _ir.ShapedType), (
+            f"{call.op.name} output {i} must be a shaped type, got {type(element).__name__}"
+        )
+        elements.append(element)
+    return elements
+
+
+def _build_program(cmp_mode: str | int = "eq", offset=0, src_dtype=pl.FP32, count_dtype=pl.INT32):
     @pl.program
     class Program:
         @pl.function(type=pl.FunctionType.InCore)
@@ -34,11 +80,13 @@ def _build_program(cmp_mode: str | int = "eq", offset=0, src_dtype=pl.FP32):
             src: pl.Tensor[[32, 64], src_dtype],
             kvalue: pl.Scalar[src_dtype],
             out_dst: pl.Tensor[[32, 8], pl.INT32],
-            out_cdst: pl.Tensor[[1, 32], pl.INT32],
+            out_cdst: pl.Tensor[[1, 32], count_dtype],
         ):
             s: pl.Tile[[32, 64], src_dtype] = pl.load(src, [0, 0], [32, 64])
             tmp: pl.Tile[[32, 64], pl.UINT8] = pl.tile.create([32, 64], pl.UINT8)
-            d, c = pl.tile.gather_compare(s, kvalue, tmp, cmp_mode=cmp_mode, offset=offset, out_cols=8)
+            d, c = pl.tile.gather_compare(
+                s, kvalue, tmp, cmp_mode=cmp_mode, offset=offset, out_cols=8, count_dtype=count_dtype
+            )
             pl.store(d, [0, 0], out_dst)
             pl.store(c, [0, 0], out_cdst)
 
@@ -50,11 +98,34 @@ class TestTileGatherCompareTypes:
 
     @pytest.mark.parametrize("src_dtype", _VALID_SRC_DTYPES)
     def test_valid_src_dtype(self, src_dtype):
-        prog = _build_program(src_dtype=src_dtype)
-        text = str(prog)
-        assert "tile.gather_compare" in text
-        # dst tile must carry INT32 regardless of src dtype.
-        assert "pl.INT32" in text
+        call = _find_call(_build_program(src_dtype=src_dtype), "tile.gather_compare")
+        dst, cdst = _tuple_elements(call)
+        # dst holds the gathered indices: [rows, out_cols], INT32 whatever src is.
+        assert _static_shape(dst) == [32, 8]
+        assert dst.dtype == pl.INT32
+        # cdst holds one match count per row: [1, rows], count_dtype (INT32 by default).
+        assert _static_shape(cdst) == [1, 32]
+        assert cdst.dtype == pl.INT32
+        # Both destinations live in Vec — set_output_memory reaches every element
+        # of the TupleType, not just the first.
+        assert dst.memory_space == cdst.memory_space == _ir.MemorySpace.Vec
+
+    def test_count_dtype_selects_cdst_dtype(self):
+        call = _find_call(_build_program(count_dtype=pl.UINT32), "tile.gather_compare")
+        dst, cdst = _tuple_elements(call)
+        assert dst.dtype == pl.INT32, "dst indices stay INT32 regardless of count_dtype"
+        assert cdst.dtype == pl.UINT32
+
+    def test_destinations_are_not_arguments(self):
+        """The op takes three inputs; dst and cdst reach the caller as results.
+
+        Naming them in the argument list instead would make the caller allocate
+        buffers InitMemRef owns — see docs/en/dev/ir/08-multi_output_ops.md.
+        """
+        call = _find_call(_build_program(), "tile.gather_compare")
+        assert len(call.args) == 3
+        assert _ir.get_op_output_arity("tile.gather_compare") == 2
+        assert _ir.get_op_argument_count("tile.gather_compare") == 3
 
     @pytest.mark.parametrize("src_dtype", _INVALID_SRC_DTYPES)
     def test_invalid_src_dtype_raises(self, src_dtype):
@@ -85,16 +156,18 @@ class TestTileGatherCompareCmpMode:
     """cmp_mode accepts strings and ints in [0, 5]; otherwise raises."""
 
     def test_default_eq(self):
-        prog = _build_program()
-        assert "tile.gather_compare" in str(prog)
+        call = _find_call(_build_program(), "tile.gather_compare")
+        assert call.kwargs["cmp_mode"] == 0
+        assert call.kwargs["offset"] == 0
 
     def test_gt_with_offset(self):
-        prog = _build_program(cmp_mode="gt", offset=4)
-        assert "tile.gather_compare" in str(prog)
+        call = _find_call(_build_program(cmp_mode="gt", offset=4), "tile.gather_compare")
+        assert call.kwargs["cmp_mode"] == 4
+        assert call.kwargs["offset"] == 4
 
     def test_int_cmp_mode(self):
-        prog = _build_program(cmp_mode=2)  # lt
-        assert "tile.gather_compare" in str(prog)
+        call = _find_call(_build_program(cmp_mode=2), "tile.gather_compare")
+        assert call.kwargs["cmp_mode"] == 2
 
     def test_invalid_cmp_mode_string(self):
         with pytest.raises(InvalidOperationError, match="cmp_mode"):
@@ -125,8 +198,15 @@ class TestTensorGatherCompareTypes:
 
     @pytest.mark.parametrize("src_dtype", _VALID_SRC_DTYPES)
     def test_valid_src_dtype(self, src_dtype):
-        prog = _build_tensor_compare_program(src_dtype=src_dtype)
-        assert "tensor.gather_compare" in str(prog)
+        call = _find_call(_build_tensor_compare_program(src_dtype=src_dtype), "tensor.gather_compare")
+        dst, cdst = _tuple_elements(call)
+        assert _static_shape(dst) == [32, 8]
+        assert dst.dtype == pl.INT32
+        assert _static_shape(cdst) == [1, 32]
+        assert cdst.dtype == pl.INT32
+        # The tensor-level op takes only (input, kvalue): the UINT8 workspace is
+        # synthesized later, by ConvertTensorToTileOps.
+        assert len(call.args) == 2
 
     @pytest.mark.parametrize("src_dtype", _INVALID_SRC_DTYPES)
     def test_invalid_src_dtype_raises(self, src_dtype):
@@ -134,8 +214,9 @@ class TestTensorGatherCompareTypes:
             _build_tensor_compare_program(src_dtype=src_dtype)
 
     def test_compare_with_offset(self):
-        prog = _build_tensor_compare_program(cmp_mode="gt", offset=4)
-        assert "tensor.gather_compare" in str(prog)
+        call = _find_call(_build_tensor_compare_program(cmp_mode="gt", offset=4), "tensor.gather_compare")
+        assert call.kwargs["cmp_mode"] == 4
+        assert call.kwargs["offset"] == 4
 
     def test_mutually_exclusive_index_and_compare(self):
         with pytest.raises(InvalidOperationError, match="mutually exclusive"):

--- a/tests/ut/ir/operators/test_op_registry.py
+++ b/tests/ut/ir/operators/test_op_registry.py
@@ -1338,5 +1338,117 @@ class TestResultAliasContract:
         )
 
 
+class TestMultiOutputOps:
+    """A multi-output operator carries its results in the deduced ``TupleType``.
+
+    The alternative — naming the destination tiles in ``add_argument`` — is the
+    path of least resistance when wrapping a hardware DPS intrinsic, and it is
+    wrong twice over: it makes the caller pre-allocate a buffer ``InitMemRef``
+    owns, and it hides the write from direction inference, which reads an
+    undeclared argument as a pure consumer. ``ValidateMultiOutputOps()`` rejects
+    both shapes at import, so the checks below pin the contract that check
+    maintains rather than re-deriving it.
+    """
+
+    _REPO_ROOT = Path(__file__).resolve().parents[4]
+
+    def _declared_multi_output_ops(self) -> dict[str, int]:
+        """Every operator whose registration calls ``set_output_arity(N > 1)``.
+
+        Scanning the registrations rather than listing names keeps the test
+        growing with the codebase: a new multi-output operator is covered the
+        moment it is registered, with nothing to remember to update here.
+        """
+        found: dict[str, int] = {}
+        for source in sorted((self._REPO_ROOT / "src/ir/op").rglob("*.cpp")):
+            text = source.read_text()
+            for block in re.split(r"\bREGISTER_OP\(", text)[1:]:
+                name_match = re.match(r'"([^"]+)"', block)
+                arity_match = re.search(r"\.set_output_arity\((\d+)\)", block.split(";\n")[0])
+                if name_match and arity_match and int(arity_match.group(1)) > 1:
+                    found[name_match.group(1)] = int(arity_match.group(1))
+        return found
+
+    def test_registrations_are_discoverable(self):
+        """The scan finds the multi-output ops that exist, so the rest is not vacuous."""
+        declared = self._declared_multi_output_ops()
+        assert "tile.gather_compare" in declared, declared
+        assert "tensor.gather_compare" in declared, declared
+
+    def test_declared_arity_reaches_the_registry(self):
+        """Codegen reads the arity from the registry, so the two must agree."""
+        for op_name, arity in self._declared_multi_output_ops().items():
+            assert ir.get_op_output_arity(op_name) == arity, op_name
+
+    def test_every_argument_is_classified(self):
+        """An unclassified argument defaults to ``Read``, which is exactly how a
+        destination tile hides. A multi-output op must reach a verdict on each."""
+        for op_name in self._declared_multi_output_ops():
+            for i in range(ir.get_op_argument_count(op_name)):
+                assert ir.op_has_declared_arg_effect(op_name, i), (
+                    f"{op_name} argument {i} was never classified; the Read it "
+                    f"defaults to is indistinguishable from a destination tile"
+                )
+
+    def test_workspace_declarations_name_a_written_argument(self):
+        """A workspace claims two things: the argument exists, and it is written.
+
+        Neither is implied by the check below, which only walks arguments that
+        exist. An index past the end protects nothing, and a workspace declared
+        ``Read`` — including via ``no_arg_writes()`` — still reads as a pure
+        consumer of a slot the hardware writes.
+        """
+        for op_name in self._declared_multi_output_ops():
+            arg_count = ir.get_op_argument_count(op_name)
+            for i in range(arg_count + 4):
+                if not ir.op_arg_is_workspace(op_name, i):
+                    continue
+                assert i < arg_count, (
+                    f"{op_name} declares argument {i} a workspace but takes only {arg_count}"
+                )
+                assert ir.get_op_arg_effect(op_name, i) != ir.ArgEffect.Read, (
+                    f"{op_name} argument {i} is declared a workspace yet classified Read; "
+                    f"scratch is hardware-written by definition"
+                )
+
+    def test_written_arguments_are_workspaces(self):
+        """A written argument is scratch the hardware needs — which must say so —
+        or a result the caller reads, which belongs in the TupleType instead."""
+        for op_name in self._declared_multi_output_ops():
+            for i in range(ir.get_op_argument_count(op_name)):
+                if ir.get_op_arg_effect(op_name, i) == ir.ArgEffect.Read:
+                    continue
+                assert ir.op_arg_is_workspace(op_name, i), (
+                    f"{op_name} writes argument {i} without declaring it a "
+                    f"workspace; a written argument that carries a result is a "
+                    f"destination and must be a TupleType element"
+                )
+
+    def test_single_output_ops_declare_no_arity(self):
+        """The default arity is what makes ``set_output_arity`` mean something."""
+        assert ir.get_op_output_arity(ir.get_op("tile.add").name) == 1
+        assert ir.get_op_output_arity(ir.get_op("tensor.matmul").name) == 1
+
+    def test_gather_compare_shape(self):
+        """The one multi-output op that exists today, spelled out.
+
+        ``tile.gather_compare`` maps to ``pto.tgather``, which needs three inputs
+        and writes two destinations plus a scratch buffer. Only the scratch is an
+        argument: ``ConvertTensorToTileOps`` synthesizes it, and nobody reads it.
+        """
+        assert ir.get_op_output_arity("tile.gather_compare") == 2
+        assert ir.get_op_argument_count("tile.gather_compare") == 3
+        assert ir.get_op_arg_effect("tile.gather_compare", 0) == ir.ArgEffect.Read
+        assert ir.get_op_arg_effect("tile.gather_compare", 1) == ir.ArgEffect.Read
+        assert ir.get_op_arg_effect("tile.gather_compare", 2) == ir.ArgEffect.Write
+        assert ir.op_arg_is_workspace("tile.gather_compare", 2)
+        assert not ir.op_arg_is_workspace("tile.gather_compare", 0)
+
+        # The tensor-level op has no workspace yet — it appears only after the
+        # tile conversion synthesizes it.
+        assert ir.get_op_output_arity("tensor.gather_compare") == 2
+        assert ir.get_op_argument_count("tensor.gather_compare") == 2
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/ir/transforms/test_init_memref.py
+++ b/tests/ut/ir/transforms/test_init_memref.py
@@ -1474,5 +1474,91 @@ class TestEdgeCases:
             passes.init_mem_ref()(program)
 
 
+class TestMultiOutputElements:
+    """Each element of a multi-output op's TupleType gets its own buffer.
+
+    A multi-output operator carries its results in a ``TupleType`` rather than in
+    destination arguments, so InitMemRef never sees them named in the call. It
+    allocates them through the ordinary per-Var path instead, off the
+    ``<var> = tuple[i]`` bindings the parser emitted — nothing in InitMemRef
+    knows about tuples at all. That the general path genuinely covers the
+    multi-output case is therefore an untested coincidence unless pinned here.
+
+    See ``docs/en/dev/ir/08-multi_output_ops.md``.
+    """
+
+    @staticmethod
+    def _tuple_element_memrefs(program) -> dict[str, ir.MemRef | None]:
+        """MemRef of every var bound to a tuple element, keyed by name hint."""
+        found: dict[str, ir.MemRef | None] = {}
+
+        class _Collector(ir.IRVisitor):
+            def visit_assign_stmt(self, stmt):  # type: ignore[override]
+                if isinstance(stmt.value, ir.TupleGetItemExpr):
+                    tile_type = stmt.var.type
+                    assert isinstance(tile_type, ir.TileType), (
+                        f"{stmt.var.name_hint} is bound to a tuple element but is not a tile"
+                    )
+                    found[stmt.var.name_hint] = tile_type.memref
+                super().visit_assign_stmt(stmt)
+
+        for func in program.functions.values():
+            _Collector().visit_stmt(func.body)
+        return found
+
+    @staticmethod
+    def _build(drop_second_output: bool = False):
+        @pl.program
+        class Before:
+            @pl.function
+            def main(
+                self,
+                src: pl.Tensor[[32, 64], pl.FP32],
+                kvalue: pl.Scalar[pl.FP32],
+                out_dst: pl.Out[pl.Tensor[[32, 8], pl.INT32]],
+                out_cdst: pl.Out[pl.Tensor[[1, 32], pl.INT32]],
+            ):
+                s: pl.Tile[[32, 64], pl.FP32, pl.MemorySpace.Vec] = pl.load(
+                    src, [0, 0], [32, 64], target_memory=pl.Mem.Vec
+                )
+                tmp: pl.Tile[[32, 64], pl.UINT8, pl.MemorySpace.Vec] = pl.tile.create(
+                    [32, 64], pl.UINT8, target_memory=pl.Mem.Vec
+                )
+                d, c = pl.tile.gather_compare(s, kvalue, tmp, cmp_mode="eq", out_cols=8)
+                pl.store(d, [0, 0], out_dst)
+                if not drop_second_output:
+                    pl.store(c, [0, 0], out_cdst)
+
+        return Before
+
+    def test_elements_get_distinct_memrefs(self):
+        after = passes.init_mem_ref()(self._build())
+        memrefs = self._tuple_element_memrefs(after)
+        assert len(memrefs) == 2, f"expected one binding per output, got {sorted(memrefs)}"
+        dst, cdst = memrefs.values()
+        assert dst is not None and cdst is not None, (
+            f"a destination reached codegen with no buffer behind it: {sorted(memrefs)}"
+        )
+        # A MemRef always overlaps itself: without this the negative assertion
+        # below would pass just as well against two objects may_alias cannot read.
+        assert ir.MemRef.may_alias(dst, dst)
+        assert not ir.MemRef.may_alias(dst, cdst), (
+            "the two destinations overlap; pto.tgather writes both in a single "
+            "instruction, so one would clobber the other"
+        )
+
+    def test_unread_element_still_gets_a_buffer(self):
+        """Dropping an output does not make its buffer optional.
+
+        ``pto.tgather`` writes both destinations whichever the program goes on to
+        read, so the unread one still needs an allocation of its own — otherwise
+        the instruction scribbles over whatever happens to sit at that address.
+        """
+        after = passes.init_mem_ref()(self._build(drop_second_output=True))
+        memrefs = self._tuple_element_memrefs(after)
+        assert len(memrefs) == 2, f"a dropped output lost its binding: {sorted(memrefs)}"
+        assert all(m is not None for m in memrefs.values())
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

A multi-output operator carries its results in a `TupleType`, but nothing in the
framework knew how many there were: `f_deduce_type` needs actual arguments, so
the registry could not learn the arity, and codegen restated it per emitter —
`tile.gather_compare`'s hard-codes `arity=2` — with nothing checking that the
two agreed. `set_output_arity(N)` makes the arity declarative, and the registry
now rejects at import the shape that made this fragile in the first place: a
hardware destination declared as an argument. Adding a multi-output operator no
longer means re-deriving the tuple plumbing, and getting it wrong fails at
import instead of on device.

Addresses issue #1326. It does not implement that issue's proposal literally:
the issue assumes a multi-output operator writes through no argument, which
`tile.gather_compare`'s `tmp` disproves — that is a real UINT8 scratch buffer
`ConvertTensorToTileOps` synthesizes and the hardware writes. The check
therefore separates scratch from a leaked destination via `set_workspace_arg()`
rather than banning written arguments outright.

## Why a destination must not be an argument

Wrapping a hardware DPS intrinsic, the path of least resistance is to mirror its
signature and name the destinations as arguments. That makes the caller
pre-allocate buffers `InitMemRef` owns, and it hides the write from direction
inference, where an unclassified argument reads as a pure consumer:

```text
dst declared as an argument, no effect declared
  → the parameter it writes keeps direction In
  → no RAW edge against the kernel that reads it
  → stale data on device, not an error at compile time
```

`ValidateMultiOutputOps()` rejects that at import: a multi-output operator must
reach a verdict about every argument, and any argument it writes must be
declared scratch.

## The second and third multi-output operators

`tile.tquant_mx` and `tile.tquant_mx_raw` landed on main (#2372) while this was
open, which is the first real test of whether the framework carries its weight.
Both now declare `set_output_arity(2)` — they have to, since the registry
refuses a tuple result nobody declared — and `tquant_mx_raw` marks `max` and
`scaling` as workspaces, which its own description already said in prose
("write-only workspace inputs") but nothing could check.

Its emitter had reproduced the DPS preamble verbatim, hard-coded `arity=2` and
all. It now calls `PrepareTupleOutputs()` like `gather_compare`, which is the
duplication this change exists to remove — and it reappeared on its own within a
week of the issue being filed.

The registry-contract test needed no edit to cover them: it scans `src/ir/op`
for `set_output_arity(N > 1)`, so both were picked up the moment they were
declared.

## Changes

- `include/pypto/ir/op_registry.h`, `src/ir/op_registry.cpp`: add
  `set_output_arity(N)` and `set_workspace_arg(i)` plus their accessors;
  `OpRegistry::Create` cross-checks declared arity against the deduced type in
  both directions (a declared N must deduce an N-element `TupleType`, and a
  deduced `TupleType` must have been declared — codegen resolves a call's
  elements by the registry's arity, and an undeclared tuple has none);
  `ValidateMultiOutputOps()` rejects an unclassified argument, a written
  argument not declared scratch, a workspace declaration naming no argument or
  naming one the operator never writes, and `set_output_reuses_input(N)`, which
  cannot say which of several results it means.
- `python/bindings/bindings.cpp`: run the new validation at import, alongside
  `ValidateTileOps` and `ValidateArgEffects`.
- `python/bindings/modules/ir.cpp`, `python/pypto/pypto_core/ir.pyi`: expose
  `get_op_output_arity`, `op_arg_is_workspace`, and `get_op_argument_count`.
- `src/ir/op/{tile_ops,tensor_ops}/gather.cpp`, `src/ir/op/tile_ops/quant_mx.cpp`:
  declare arity 2 on all four multi-output operators, and classify every
  argument — `tile.gather_compare`'s `tmp` and `tile.tquant_mx_raw`'s `max` /
  `scaling` as written workspaces.
- `include/pypto/codegen/pto/pto_codegen.h`, `src/codegen/pto/pto_codegen.cpp`:
  add `PrepareTupleOutputs()`, which resolves a multi-output call's destinations,
  checks each carries its MemRef, and emits its `alloc_tile` eagerly; it reads
  the arity from the registry, so an emitter and its registration cannot drift.
  The `<var> = tuple[i]` bindings are indexed once on function entry instead of
  rescanning the body per call, which was quadratic in the number of
  multi-output calls, and a second binding of one element is now rejected rather
  than silently winning over the first.
- `src/backend/common/pto_ops_datamove.cpp`: the `tile.gather_compare` and
  `tile.tquant_mx_raw` emitters now use that helper; both DPS preambles are gone,
  and with them the last direct uses of `<array>` and `memref_utils.h` in that
  file.
- `docs/{en,zh}/dev/ir/09-multi_output_ops.md`: new page — the convention, what
  the registry enforces, how a multi-output call flows from DSL to codegen, and
  a checklist for adding one, including what the check deliberately cannot see
  (a destination classified `Read` leaves no trace to catch). It is a separate
  page because `05-operators.md` is already over the 1000-line documentation
  limit; that file gains only the two new fluent-API rows and a pointer. Numbered
  09 because `08-param-directions.md` took 08 on main; the two pages cross-link,
  since that one explains the dependency-edge consequence this one asserts.
- `tests/ut/ir/operators/test_op_registry.py`: `TestMultiOutputOps` scans
  `src/ir/op` for every `set_output_arity(N > 1)` and checks the contract through
  the registry, so a new multi-output operator is covered as soon as it is
  registered.
- `tests/ut/ir/operators/test_gather_compare.py`: the type tests asserted
  `"tile.gather_compare" in str(prog)`, which passes whenever the operator merely
  appears, whatever it deduced. They now assert the deduced `TupleType` elements,
  their memory spaces, and the resolved kwargs.
- `tests/ut/ir/transforms/test_init_memref.py`: `TestMultiOutputElements` pins
  that each tuple element gets a non-overlapping buffer, and that a dropped
  output still gets one. `InitMemRef` has no tuple-specific code, so that its
  general path covers the multi-output case was until now untested.

## Behaviour

Unchanged. The post-pipeline IR and the emitted `.pto` for a `gather_compare`
kernel are byte-identical before and after, re-checked against the current base
— including across the new `ArgEffect::Write` declaration on `tmp`, the one
change here that could have moved a dependency edge. For `tquant_mx`, main's own
codegen tests (`tests/ut/codegen/test_quant_mx_codegen.py`, which assert the
emitted `.pto` text) pass unmodified over the rewritten emitter.

Every guard was verified by removing or corrupting a declaration and
rebuilding: dropping `set_workspace_arg(2)` fails the import as a leaked
destination; declaring `tmp` `Read` while keeping the marker fails as a
workspace the operator never writes; `set_workspace_arg(9)` fails as an index
naming no argument; and dropping `set_output_arity(2)` fails call creation with
`deduced a TupleType result without declaring set_output_arity(2)`.

## Verification

- `cmake --build build --parallel 32`: exit 0.
- `pytest tests/ut/ir tests/ut/codegen -q -n 16`: 7852 passed, 5 skipped, 1 xfailed.
- `pytest tests/ut/ -q -n 16`: 10783 passed, 8 skipped, 1 xfailed, 1 failed —
  `test_symlinked_import_path_still_names_the_caller`, a pre-existing local
  environment artifact (its subprocess re-execs with its own `PYTHONPATH` and
  bypasses the editable-import shim this worktree needs), unrelated to this
  range.
- `tests/lint/check_docs_en_zh_parity.py`, `check_docs_nav.py`,
  `check_english_only.py`, `check_op_name_literals.py`,
  `check_op_docstring_parity.py`: all pass.
- `clang-format` 21.1.0, `ruff` format/check, `pyright` over the configured
  scope, `clang-tidy` `misc-include-cleaner` on every changed translation unit,
  and `markdownlint-cli2` over `docs/`: clean.
- No system tests were run locally; the gather compare-form ST cases are skipped
  upstream (`PTOAS handling for gather compare form is broken`), so the `.pto`
  diff above is the available end-to-end evidence.