### PR TITLE
docs(user): match the exp doc-block tolerances to the project's transcendental convention

### DIFF
--- a/docs/en/user/performance/01-task-granularity.md
+++ b/docs/en/user/performance/01-task-granularity.md
@@ -179,11 +179,11 @@ def merged_chain(a: pl.Tensor, b: pl.Tensor, out: pl.Out[pl.Tensor]):
 expected = torch.exp(A[:LARGE] + B[:LARGE])
 scratch, out = torch.zeros(LARGE, COLS), torch.zeros(LARGE, COLS)
 two_tasks_via_gm(A[:LARGE], B[:LARGE], scratch, out, config=CFG)
-torch.testing.assert_close(out, expected, rtol=1e-4, atol=1e-4)
+torch.testing.assert_close(out, expected, rtol=3e-3, atol=3e-3)
 
 out = torch.zeros(LARGE, COLS)
 merged_chain(A[:LARGE], B[:LARGE], out, config=CFG)
-torch.testing.assert_close(out, expected, rtol=1e-4, atol=1e-4)
+torch.testing.assert_close(out, expected, rtol=3e-3, atol=3e-3)
 ```
 
 **Cost:** the merged task holds every intermediate live at once.

--- a/docs/en/user/performance/02-runtime-overhead.md
+++ b/docs/en/user/performance/02-runtime-overhead.md
@@ -220,7 +220,7 @@ def early_resolve(a: pl.Tensor, b: pl.Tensor, scratch: pl.Out[pl.Tensor], out: p
 
 scratch, out = fresh(TILE_ROWS), fresh(TILE_ROWS)
 early_resolve(A[:TILE_ROWS], B[:TILE_ROWS], scratch, out, config=CFG)
-torch.testing.assert_close(out, torch.exp(A[:TILE_ROWS] + B[:TILE_ROWS]), rtol=1e-4, atol=1e-4)
+torch.testing.assert_close(out, torch.exp(A[:TILE_ROWS] + B[:TILE_ROWS]), rtol=3e-3, atol=3e-3)
 ```
 
 The scheduler may then pre-stage that task's consumers onto idle cores *before* it

--- a/docs/en/user/performance/04-incore.md
+++ b/docs/en/user/performance/04-incore.md
@@ -25,7 +25,7 @@ A = (indices % 3 - 1).to(torch.float32).reshape(ROWS, TC)
 def check(kernel):
     out = torch.zeros(ROWS, TC, dtype=torch.float32)
     kernel(A, out, config=CFG)
-    torch.testing.assert_close(out, torch.exp(A), rtol=1e-4, atol=1e-4)
+    torch.testing.assert_close(out, torch.exp(A), rtol=3e-3, atol=3e-3)
 ```
 
 ## Double buffering

--- a/docs/zh/user/performance/01-task-granularity.md
+++ b/docs/zh/user/performance/01-task-granularity.md
@@ -150,11 +150,11 @@ def merged_chain(a: pl.Tensor, b: pl.Tensor, out: pl.Out[pl.Tensor]):
 expected = torch.exp(A[:LARGE] + B[:LARGE])
 scratch, out = torch.zeros(LARGE, COLS), torch.zeros(LARGE, COLS)
 two_tasks_via_gm(A[:LARGE], B[:LARGE], scratch, out, config=CFG)
-torch.testing.assert_close(out, expected, rtol=1e-4, atol=1e-4)
+torch.testing.assert_close(out, expected, rtol=3e-3, atol=3e-3)
 
 out = torch.zeros(LARGE, COLS)
 merged_chain(A[:LARGE], B[:LARGE], out, config=CFG)
-torch.testing.assert_close(out, expected, rtol=1e-4, atol=1e-4)
+torch.testing.assert_close(out, expected, rtol=3e-3, atol=3e-3)
 ```
 
 **代价：** 合并后的任务要同时持有每一个中间结果。

--- a/docs/zh/user/performance/02-runtime-overhead.md
+++ b/docs/zh/user/performance/02-runtime-overhead.md
@@ -168,7 +168,7 @@ def early_resolve(a: pl.Tensor, b: pl.Tensor, scratch: pl.Out[pl.Tensor], out: p
 
 scratch, out = fresh(TILE_ROWS), fresh(TILE_ROWS)
 early_resolve(A[:TILE_ROWS], B[:TILE_ROWS], scratch, out, config=CFG)
-torch.testing.assert_close(out, torch.exp(A[:TILE_ROWS] + B[:TILE_ROWS]), rtol=1e-4, atol=1e-4)
+torch.testing.assert_close(out, torch.exp(A[:TILE_ROWS] + B[:TILE_ROWS]), rtol=3e-3, atol=3e-3)
 ```
 
 调度器于是可以在这个任务**完成之前**就把它的消费者预置到空闲核上，等它一结束就用门铃放行。

--- a/docs/zh/user/performance/04-incore.md
+++ b/docs/zh/user/performance/04-incore.md
@@ -24,7 +24,7 @@ A = (indices % 3 - 1).to(torch.float32).reshape(ROWS, TC)
 def check(kernel):
     out = torch.zeros(ROWS, TC, dtype=torch.float32)
     kernel(A, out, config=CFG)
-    torch.testing.assert_close(out, torch.exp(A), rtol=1e-4, atol=1e-4)
+    torch.testing.assert_close(out, torch.exp(A), rtol=3e-3, atol=3e-3)
 ```
 
 ## Double buffer


### PR DESCRIPTION
## Problem

Five runnable doc blocks compare **raw `exp` output** against torch at `rtol=1e-4, atol=1e-4`. That is tighter than the device's `exp` is accurate, so the assertions sit on the edge and fail intermittently.

Measured on the failing one (`01-task-granularity.md:161`, seeded inputs so this is reproducible): expected values span `0.0032 … 253.5`. At the largest elements `rtol=1e-4` permits only **~0.017** absolute. The device lands **0.0259** off — a *relative* error of `1.49e-4`, i.e. only 1.5× over budget, tripping 38–39 of 16384 elements (0.24%, the heavy tail).

Because the margin is that thin, the same block passes some CI runs and fails others. Observed on three runs of #2332 (which does not touch these files): fail, pass, fail — twice with a bit-identical worst-case error at the identical index.

## Why `3e-3`

This repo already has a convention for exactly this distinction:

| Output kind | Reference | Tolerance |
| --- | --- | --- |
| Bounded / normalized — softmax, layernorm, rms_norm | `tests/st/examples/02_intermediate/test_softmax.py`, `test_layer_norm.py`, `test_rms_norm.py` | `rtol=atol=1e-5` |
| **Unbounded transcendental** — gelu / swiglu (sigmoid, i.e. exp-family) | `tests/st/examples/02_intermediate/test_ffn_activations.py` | **`rtol=atol=3e-3`** |

Tight tolerances belong on outputs that are `O(1)` by construction; transcendental results that can grow get `3e-3`. The doc blocks were using `1e-4` on unbounded `exp` output — 30× tighter than the project's own figure for this class. At `3e-3` the observed `1.49e-4` relative error passes with ~20× margin.

This is an alignment to an existing convention, not a number tuned until CI went green.

## Scope

Only the assertions whose compared value is an `exp` result:

- `01-task-granularity.md` :182, :186 — `expected = torch.exp(A[:LARGE] + B[:LARGE])`
- `02-runtime-overhead.md` :223 — `torch.exp(A[:TILE_ROWS] + B[:TILE_ROWS])`
- `04-incore.md` :28 — `torch.exp(A)`

plus the zh mirrors. **Left untouched** at `1e-4`: every `c vs A + B` assertion, and `02-runtime-overhead.md:169`, whose `expected` is `A * 2.0` / `A * 2.0 + 1.0` — plain arithmetic, correctly tight.

Note `02-runtime-overhead.md:223` and `04-incore.md:28` had the same latent fragility and simply had not tripped yet; fixing only the block that failed would have left them as landmines.

## Verification

- `pre-commit` (incl. en/zh parity) and `mkdocs build --strict` clean.
- The affected pages re-run through `tests/docs/run_doc_examples.py --check-parity -p a2a3sim`.

## What this does *not* claim

It explains why the assertion *can* fail. It does not explain why #2332 tripped it in 2 of 4 runs while ~19 other recent runs (main included) did not. A marginal assertion is exactly the kind that fails non-uniformly, but that asymmetry is unexplained and worth a separate look — as is the fact that two failing runs produced a *bit-identical* wrong value while a third run of the same commit produced a correct one, which hints at build-level nondeterminism rather than anything in the test.
