### PR TITLE
feat(distributed): widen InCore reduce_scatter to all four reduce ops

### DIFF
--- a/docs/en/dev/passes/12-lower_composite_ops.md
+++ b/docs/en/dev/passes/12-lower_composite_ops.md
@@ -200,7 +200,7 @@ The `tile.tquant_mx` rule emits the non-composite `tile.tquant_mx_raw` and `tile
 
 ## `pld.tensor.*` distributed collectives
 
-The pass also lowers the `pld.tensor.*` family of window-bound distributed collectives. Each collective is a single composite `Call` that expands into a notify / wait + data-movement recipe, plus a self-clearing epilogue. The data-movement primitive differs by op: `allgather` and ring `allreduce` use `pld.tile.put` (TPUT-based push, auto-chunking through a VEC staging tile), `broadcast` relocates window data with `pld.tile.get` (GM→GM copy), while mesh `allreduce` and `reduce_scatter` pull peer chunks into a UB tile with `pld.tile.remote_load`. Allreduce selects `tile.add`, `tile.maximum`, `tile.minimum`, or `tile.mul`; reduce-scatter currently accumulates with `tile.add`. All seven rules share the same **self-clearing credit-barrier protocol** (`LoweringBuilder::EmitBarrier` + `EmitEpilogueReset`) — see [Barrier-signal protocol](#barrier-signal-protocol) below — so a `signal` buffer is reusable across back-to-back calls, and even inside `for` / `while` / `if`.
+The pass also lowers the `pld.tensor.*` family of window-bound distributed collectives. Each collective is a single composite `Call` that expands into a notify / wait + data-movement recipe, plus a self-clearing epilogue. The data-movement primitive differs by op: `allgather` and ring `allreduce` use `pld.tile.put` (TPUT-based push, auto-chunking through a VEC staging tile), `broadcast` relocates window data with `pld.tile.get` (GM→GM copy), while mesh `allreduce` and `reduce_scatter` pull peer chunks into a UB tile with `pld.tile.remote_load`. Allreduce and reduce-scatter select `tile.add`, `tile.maximum`, `tile.minimum`, or `tile.mul` by `ReduceOp`. All seven rules share the same **self-clearing credit-barrier protocol** (`LoweringBuilder::EmitBarrier` + `EmitEpilogueReset`) — see [Barrier-signal protocol](#barrier-signal-protocol) below — so a `signal` buffer is reusable across back-to-back calls, and even inside `for` / `while` / `if`.
 
 ### Barrier-signal protocol
 
@@ -243,14 +243,14 @@ Compared to the original pull-based allgather (4-arg with a separate `out` tenso
 Decomposes into the same phase shape as `allreduce`'s rectangle path:
 
 - Phase 2a/2b: ready barrier (generation 1)
-- Phase 3: for each peer, `remote_load` chunk `r` from peer `p` and accumulate into a local scratch with `tile.add`
+- Phase 3: for each peer, `remote_load` chunk `r` from peer `p` and accumulate into a local scratch with the `ReduceOp`-matching tile op (`tile.add` / `tile.maximum` / `tile.minimum` / `tile.mul`)
 - Phase 3.5a/3.5b: post-reduce barrier (generation 2)
 - Phase 4: `tile.store` the reduced chunk `r` back into `target[r, 0:SIZE]`
 - Epilogue: subtract 2 from every non-self cell
 
-`target` has shape `[NR, SIZE]`; each rank stages all `NR` chunks before the call. After the call, rank `r`'s row `[r, 0:SIZE]` holds the element-wise sum of chunk `r` across all ranks. The post-reduce barrier is required for the same WAR reason as `allreduce`.
+`target` has shape `[NR, SIZE]`; each rank stages all `NR` chunks before the call. After the call, rank `r`'s row `[r, 0:SIZE]` holds the element-wise reduction of chunk `r` across all ranks (Sum/Max/Min/Prod by `ReduceOp`). The post-reduce barrier is required for the same WAR reason as `allreduce`.
 
-Only `ReduceOp::kSum` is supported in the first version; the C++ deducer rejects `Max` / `Min` / `Prod`.
+All four `ReduceOp`s are supported — `kSum`, `kMax`, `kMin`, and `kProd` — routed through the shared `Reduce()` helper, the same dispatch the allreduce rules use.
 
 ### `pld.tensor.broadcast`
 

--- a/docs/en/user/distributed/02-primitives.md
+++ b/docs/en/user/distributed/02-primitives.md
@@ -14,7 +14,7 @@ lower-level primitives only when building a custom protocol.
 | ---- | ------ | ----------- |
 | `NotifyOp` | `AtomicAdd`, `Set` | Signal deposit mode. `AtomicAdd`: atomically increment the peer's signal slot (use for multi-rank barriers). `Set`: overwrite the peer's signal slot (use for 1:1 handshakes). |
 | `WaitCmp` | `Eq`, `Ge` | Wait predicate. `Eq`: block until signal slot equals expected value. `Ge`: block until signal slot >= expected value. |
-| `ReduceOp` | `Sum`, `Max`, `Min`, `Prod` | Reduction operator for collective operations. Support is per-operation: `allreduce` accepts all four; `reduce_scatter` accepts only `Sum` and rejects the rest at the deducer. |
+| `ReduceOp` | `Sum`, `Max`, `Min`, `Prod` | Reduction operator for collective operations. Support is per-operation: `allreduce` accepts all four; `reduce_scatter` accepts all four on the InCore rail, while the HOST builtin rail currently lowers only `Sum`. |
 | `AtomicType` | `None_`, `Add` | Remote-store combine mode. `None_`: plain store. `Add`: atomically accumulate into peer's destination — requires an `fp32`/`bf16`/`fp16`/`int32`/`int16`/`int8` destination, and a `bf16` destination requires the Ascend910B (A2/A3) profile. |
 | `DistributedTensor` | — | A tensor view bound to a comm-domain window buffer. Every collective and RMA op requires this type on the window side. |
 | `CommCtx` | — | Communication context handle. Produced by `get_comm_ctx()`; consumed by `rank()` and `nranks()`. |

--- a/docs/en/user/ops/01-catalog.md
+++ b/docs/en/user/ops/01-catalog.md
@@ -211,7 +211,7 @@ tutorial at [distributed/00-model.md](../distributed/00-model.md).
 | --------- | --- | ----- | -------- | ------ | ---------------- | ----- |
 | AllReduce | `pld.tensor.allreduce` | `mesh` (InCore + HOST), `ring` (InCore + HOST) | `Sum`, `Max`, `Min`, `Prod` (mesh); `Sum` only (HOST ring) | — | FP16, FP32 (mesh; hard compile-time check); HOST ring: FP32 only (4-byte) | Mesh: O(N) remote traffic per step. Ring: O(N/P) remote traffic per step, 2(P-1) steps. |
 | AllGather | `pld.tensor.allgather` | — | — | — | FP32 only (HOST builtin); any GM dtype (InCore) | Push-based. Input and target must be different buffers. |
-| ReduceScatter | `pld.tensor.reduce_scatter` | — | `Sum` only | — | FP32 only (HOST builtin); any GM dtype (InCore) | Every rank stages all NR chunks before the call. |
+| ReduceScatter | `pld.tensor.reduce_scatter` | — | `Sum`, `Max`, `Min`, `Prod` (InCore); `Sum` only (HOST builtin) | — | FP32 only (HOST builtin); any GM dtype (InCore) | Every rank stages all NR chunks before the call. |
 | Broadcast | `pld.tensor.broadcast` | — | — | — | FP32 only (HOST builtin); any GM dtype (InCore) | Root stages data before the call. |
 | All-to-All | `pld.tensor.all_to_all` | — | — | — | FP32 only (HOST builtin); any GM dtype (InCore) | Personalized exchange. Input and target must be different buffers. |
 | Barrier | `pld.tensor.barrier` | — | — | — | — | Signal is INT32, single-shot per call. |

--- a/docs/zh/dev/passes/12-lower_composite_ops.md
+++ b/docs/zh/dev/passes/12-lower_composite_ops.md
@@ -200,7 +200,7 @@ sin 与 cos 共用同一组多项式系数：cos 路径只在区间归约阶段�
 
 ## `pld.tensor.*` 分布式集合通信算子
 
-本 Pass 同时降级 `pld.tensor.*` 系列的窗口绑定 (window-bound) 分布式集合通信算子。每个集合通信算子都是一个组合 `Call`，展开为 notify / wait + 数据搬运序列，外加自清理尾声。数据搬运原语因算子而异：`allgather` 与 ring `allreduce` 使用 `pld.tile.put`（基于 TPUT 的推送，经 VEC staging tile 自动分块），`broadcast` 用 `pld.tile.get` 搬运窗口数据（GM→GM 拷贝），mesh `allreduce` 与 `reduce_scatter` 用 `pld.tile.remote_load` 把 peer chunk 拉进 UB tile。allreduce 根据规约类型选择 `tile.add`、`tile.maximum`、`tile.minimum` 或 `tile.mul`；reduce-scatter 当前仍用 `tile.add`。七条规则共享同一套**自清理信用屏障协议**（`LoweringBuilder::EmitBarrier` + `EmitEpilogueReset`）—— 参见下方[屏障-信号协议](#屏障-信号协议) —— 因此 `signal` buffer 可以在连续调用之间复用，甚至在 `for` / `while` / `if` 内部也可以。
+本 Pass 同时降级 `pld.tensor.*` 系列的窗口绑定 (window-bound) 分布式集合通信算子。每个集合通信算子都是一个组合 `Call`，展开为 notify / wait + 数据搬运序列，外加自清理尾声。数据搬运原语因算子而异：`allgather` 与 ring `allreduce` 使用 `pld.tile.put`（基于 TPUT 的推送，经 VEC staging tile 自动分块），`broadcast` 用 `pld.tile.get` 搬运窗口数据（GM→GM 拷贝），mesh `allreduce` 与 `reduce_scatter` 用 `pld.tile.remote_load` 把 peer chunk 拉进 UB tile。allreduce 与 reduce-scatter 都根据规约类型选择 `tile.add`、`tile.maximum`、`tile.minimum` 或 `tile.mul`。七条规则共享同一套**自清理信用屏障协议**（`LoweringBuilder::EmitBarrier` + `EmitEpilogueReset`）—— 参见下方[屏障-信号协议](#屏障-信号协议) —— 因此 `signal` buffer 可以在连续调用之间复用，甚至在 `for` / `while` / `if` 内部也可以。
 
 ### 屏障-信号协议
 
@@ -299,14 +299,14 @@ mesh 和 ring 降级均支持 FP16、FP32，以及任意正元素数量下的
 - Phase 2a：notify-all（`AtomicAdd 1`）
 - Phase 2b：wait-all（`Ge 1`）
 - 尾调用：`EmitEpilogueReset`（自清理信用屏障）
-- Phase 3：对每个 peer `p`，`remote_load` 该 peer 的 chunk `r` 并用 `tile.add` 累加到本地 scratch
+- Phase 3：对每个 peer `p`，`remote_load` 该 peer 的 chunk `r` 并用与 `ReduceOp` 匹配的 tile 算子（`tile.add` / `tile.maximum` / `tile.minimum` / `tile.mul`）累加到本地 scratch
 - Phase 3.5a：re-notify（`AtomicAdd 1`）
 - Phase 3.5b：re-wait（`Ge 2`）
 - Phase 4：`tile.store` 把归约后的 chunk `r` 写回 `target[r, 0:SIZE]`
 
-`target` 形状为 `[NR, SIZE]`；每个 rank 在调用前暂存全部 `NR` 个 chunk。调用后 rank `r` 的行 `[r, 0:SIZE]` 持有所有 rank 上 chunk `r` 的逐元素和。post-reduce 屏障与 `allreduce` 出于同样的 WAR 原因而必需。
+`target` 形状为 `[NR, SIZE]`；每个 rank 在调用前暂存全部 `NR` 个 chunk。调用后 rank `r` 的行 `[r, 0:SIZE]` 持有所有 rank 上 chunk `r` 的逐元素归约结果（按 `ReduceOp` 取 Sum/Max/Min/Prod）。post-reduce 屏障与 `allreduce` 出于同样的 WAR 原因而必需。
 
-第一版仅支持 `ReduceOp::kSum`；C++ deducer 会拒绝 `Max` / `Min` / `Prod`。
+四种 `ReduceOp` 均受支持 —— `kSum`、`kMax`、`kMin`、`kProd` —— 通过共享的 `Reduce()` helper 路由，与 allreduce 规则使用的分发一致。
 
 ### `pld.tensor.broadcast`
 

--- a/docs/zh/user/distributed/02-primitives.md
+++ b/docs/zh/user/distributed/02-primitives.md
@@ -13,7 +13,7 @@
 | ---- | ---- | ---- |
 | `NotifyOp` | `AtomicAdd`, `Set` | 信号投递模式。`AtomicAdd`：原子递增对端信号槽（多 rank 屏障）。`Set`：覆盖对端信号槽（1:1 握手）。 |
 | `WaitCmp` | `Eq`, `Ge` | 等待谓词。`Eq`：等于时解除阻塞。`Ge`：大于等于时解除阻塞。 |
-| `ReduceOp` | `Sum`, `Max`, `Min`, `Prod` | 集合通信的规约算子。支持情况按操作而定：`allreduce` 支持全部四种；`reduce_scatter` 仅支持 `Sum`，其余在 deducer 阶段被拒绝。 |
+| `ReduceOp` | `Sum`, `Max`, `Min`, `Prod` | 集合通信的规约算子。支持情况按操作而定：`allreduce` 支持全部四种；`reduce_scatter` 在 InCore 通道支持全部四种（HOST builtin 通道目前仅 lower `Sum`）。 |
 | `AtomicType` | `None_`, `Add` | 远程存储合并模式。`None_`：普通存储。`Add`：原子累加——要求目标为 `fp32`/`bf16`/`fp16`/`int32`/`int16`/`int8`，其中 `bf16` 目标仅支持 Ascend910B（A2/A3）。 |
 | `DistributedTensor` | — | 绑定到通信域 window buffer 的 tensor 视图。 |
 | `CommCtx` | — | 通信上下文句柄。 |

--- a/docs/zh/user/ops/01-catalog.md
+++ b/docs/zh/user/ops/01-catalog.md
@@ -197,7 +197,7 @@ push 与 pop 必须**配对**，且每次 pop 都必须有对应的 `tfree`。�
 | ---- | --- | ---- | -------- | ------ | ------------ | ---- |
 | AllReduce | `pld.tensor.allreduce` | `mesh`（InCore + HOST），`ring`（InCore + HOST） | `Sum`、`Max`、`Min`、`Prod`（mesh）；仅 `Sum`（HOST ring） | — | FP16、FP32（mesh；编译期硬性检查）；HOST ring：仅 FP32（4 字节） | Mesh: 每步 O(N) 远程流量。Ring: 每步 O(N/P) 远程流量，2(P-1) 步。 |
 | AllGather | `pld.tensor.allgather` | — | — | — | 仅 FP32（HOST builtin）；任意 GM dtype（InCore） | 推式。输入和 target 必须是不同的 buffer。 |
-| ReduceScatter | `pld.tensor.reduce_scatter` | — | 仅 `Sum` | — | 仅 FP32（HOST builtin）；任意 GM dtype（InCore） | 每个 rank 在调用前将全部 NR 个数据块写入。 |
+| ReduceScatter | `pld.tensor.reduce_scatter` | — | `Sum`、`Max`、`Min`、`Prod`（InCore）；仅 `Sum`（HOST builtin） | — | 仅 FP32（HOST builtin）；任意 GM dtype（InCore） | 每个 rank 在调用前将全部 NR 个数据块写入。 |
 | Broadcast | `pld.tensor.broadcast` | — | — | — | 仅 FP32（HOST builtin）；任意 GM dtype（InCore） | Root 在调用前将数据写入。 |
 | All-to-All | `pld.tensor.all_to_all` | — | — | — | 仅 FP32（HOST builtin）；任意 GM dtype（InCore） | 个性化交换。输入和 target 必须是不同的 buffer。 |
 | Barrier | `pld.tensor.barrier` | — | — | — | — | Signal 为 INT32，每次调用单次使用。 |

--- a/python/pypto/ir/op/distributed/tensor_ops.py
+++ b/python/pypto/ir/op/distributed/tensor_ops.py
@@ -425,7 +425,8 @@ def reduce_scatter(
 
     Reduce-scatter: element-wise reduce chunks across all ranks, scatter
     one reduced chunk per rank.  ``op`` (:class:`ir.ReduceOp`) selects the
-    reduction operator (Sum only in first version).  Result type is
+    reduction operator — Sum, Max, Min, or Prod on the InCore rail; the
+    HOST builtin rail lowers Sum only.  Result type is
     ``target``'s :class:`ir.DistributedTensorType` (in-place rebind).
 
     LowerCompositeOps expands this into a 5-phase decomposition matching

--- a/python/pypto/language/distributed/op/tensor_ops.py
+++ b/python/pypto/language/distributed/op/tensor_ops.py
@@ -923,8 +923,9 @@ def reduce_scatter(
             ``[world_size, 1]``.  Reusable across calls (2 credits per
             call — ready + post-reduce) — see :func:`allreduce` for the
             shared barrier protocol.
-        op: :class:`pld.ReduceOp` (keyword-only).  ``Sum`` only in
-            first version; ``Max`` / ``Min`` / ``Prod`` reserved.
+        op: :class:`pld.ReduceOp` (keyword-only).  ``Sum``, ``Max``, ``Min``,
+            or ``Prod`` on the InCore rail; the HOST builtin rail lowers
+            ``Sum`` only.
 
     Returns:
         The rebound :class:`pld.DistributedTensor` — rank r's row

--- a/python/pypto/pypto_core/ir.pyi
+++ b/python/pypto/pypto_core/ir.pyi
@@ -2362,9 +2362,9 @@ class ReduceOp(enum.IntEnum):
     .. note::
 
        **Per-operation support:** ``pld.tensor.allreduce`` (both the InCore
-       composite and the HOST builtin) accepts all four values. Other
-       reducing collectives are narrower — ``pld.tensor.reduce_scatter``
-       accepts only :attr:`Sum` and rejects the rest at the deducer.
+       composite and the HOST builtin) accepts all four values. On the
+       InCore rail ``pld.tensor.reduce_scatter`` also accepts all four
+       values; the HOST builtin rail lowers ``Sum`` only.
     """
 
     Sum = 0

--- a/src/ir/op/distributed/collective.cpp
+++ b/src/ir/op/distributed/collective.cpp
@@ -768,11 +768,10 @@ TypePtr DeduceTensorReduceScatterType(const std::vector<ExprPtr>& args,
       << "pld.tensor.reduce_scatter signal must have INT32 element type, got dtype "
       << signal_type->dtype_.ToString();
 
-  // Validate op kwarg — kSum only for first version (same as allreduce).
+  // Validate op kwarg — all four reduce ops supported (mirror allreduce).
   auto op_value = GetRequiredKwarg<int>(kwargs, "op", "pld.tensor.reduce_scatter");
-  CHECK(op_value == static_cast<int>(ReduceOp::kSum))
-      << "pld.tensor.reduce_scatter op must be ReduceOp.Sum (got int " << op_value
-      << "); Max / Min / Prod lowerings are not yet implemented";
+  CHECK(op_value >= static_cast<int>(ReduceOp::kSum) && op_value <= static_cast<int>(ReduceOp::kProd))
+      << "pld.tensor.reduce_scatter op must be ReduceOp.Sum, Max, Min, or Prod (got int " << op_value << ")";
 
   // Result type: same as target (in-place rebind — rank r's row now holds
   // the reduced chunk r).
@@ -787,7 +786,7 @@ REGISTER_OP("pld.tensor.reduce_scatter")
         "rank receives one reduced chunk. `target` has shape [NR, SIZE] — each rank stages "
         "all NR chunks before the call. After the call, rank r's row [r, 0:SIZE] holds the "
         "reduced value of chunk r. `signal` is a window-bound INT32 matrix for the cross-rank "
-        "barrier. `op` selects the reduction operator (Sum only in first version). "
+        "barrier. `op` selects the reduction operator (Sum, Max, Min, Prod). "
         "InCore path: lowered to a 5-phase decomposition by LowerCompositeOps. "
         "HOST builtin path: lowered to builtin.tensor.reduce_scatter per chip by "
         "LowerHostTensorCollectives.")

--- a/src/ir/transforms/lower_composite_ops_pass.cpp
+++ b/src/ir/transforms/lower_composite_ops_pass.cpp
@@ -1997,11 +1997,12 @@ ExprPtr LowerTensorAllGatherRule(const CallPtr& call, const std::vector<ExprPtr>
 //   Phase 3:   acc = load(target, [my_rank, 0], [1, SIZE])
 //              for peer != my_rank:
 //                  recv = remote_load(target, peer, [my_rank, 0], [1, SIZE])
-//                  acc = add(acc, recv)
+//                  acc = Reduce(op, acc, recv)
 //   Phase 3.5: post-reduce barrier (AtomicAdd 1 -> wait Ge generation + 1)
 //              — WAR prevention
 //   Phase 4:   tile.store(acc, [my_rank, 0], target)
-// Returns target (in-place rebind).  kSum only (first version).
+// Returns target (in-place rebind).  All four ReduceOps (kSum/kMax/kMin/kProd)
+// supported — the same dispatch the allreduce rules use.
 // ============================================================================
 
 ExprPtr LowerTensorReduceScatterRule(const CallPtr& call, const std::vector<ExprPtr>& args,
@@ -2020,8 +2021,10 @@ ExprPtr LowerTensorReduceScatterRule(const CallPtr& call, const std::vector<Expr
   ValidateMeshSignalShape(signal_type, "pld.tensor.reduce_scatter", span);
 
   auto op_value = GetRequiredKwarg<int>(call->kwargs_, "op", "pld.tensor.reduce_scatter");
-  INTERNAL_CHECK_SPAN(op_value == static_cast<int>(ReduceOp::kSum), span)
-      << "pld.tensor.reduce_scatter lowering supports ReduceOp::kSum only (got int " << op_value << ")";
+  INTERNAL_CHECK_SPAN(
+      op_value >= static_cast<int>(ReduceOp::kSum) && op_value <= static_cast<int>(ReduceOp::kProd), span)
+      << "pld.tensor.reduce_scatter lowering received unknown ReduceOp " << op_value;
+  const auto reduce_op = static_cast<ReduceOp>(op_value);
 
   auto& reg = OpRegistry::GetInstance();
   auto comm = b.EmitCommSetup(target, span);
@@ -2058,7 +2061,7 @@ ExprPtr LowerTensorReduceScatterRule(const CallPtr& call, const std::vector<Expr
                   OpRegistry::GetInstance().Create("pld.tile.remote_load",
                                                    {target, peer, my_data_offsets, chunk_shape}, {}, span),
                   span);
-              return then_body.Bind("acc_next", then_body.Add(acc, recv, span), span);
+              return then_body.Bind("acc_next", then_body.Reduce(reduce_op, acc, recv, span), span);
             },
             [&](LoweringBuilder&) -> ExprPtr { return acc; }, span);
       },

--- a/tests/st/distributed/collectives/test_l3_tensor_reduce_scatter_intrinsic.py
+++ b/tests/st/distributed/collectives/test_l3_tensor_reduce_scatter_intrinsic.py
@@ -29,23 +29,50 @@ from pypto.ir.distributed_compiled_program import DistributedConfig
 SIZE = 64
 
 
-def _expected_reduce_scatter(inputs: torch.Tensor) -> torch.Tensor:
-    """Per-rank golden: sum of chunk r across all ranks."""
+def _expected_reduce_scatter(inputs: torch.Tensor, reduce_op) -> torch.Tensor:
+    """Per-rank golden: element-wise reduce of chunk r across all ranks."""
     n_ranks = inputs.shape[0]
-    chunks = [inputs[:, 0, r * SIZE : (r + 1) * SIZE].sum(dim=0) for r in range(n_ranks)]
+    chunks = []
+    for r in range(n_ranks):
+        chunk = inputs[:, 0, r * SIZE : (r + 1) * SIZE]
+        if reduce_op == pld.ReduceOp.Sum:
+            reduced = chunk.sum(dim=0)
+        elif reduce_op == pld.ReduceOp.Max:
+            reduced = chunk.max(dim=0).values
+        elif reduce_op == pld.ReduceOp.Min:
+            reduced = chunk.min(dim=0).values
+        elif reduce_op == pld.ReduceOp.Prod:
+            reduced = chunk.prod(dim=0)
+        else:
+            raise ValueError(f"unsupported golden reduce op: {reduce_op}")
+        chunks.append(reduced)
     return torch.stack(chunks).reshape(n_ranks, 1, SIZE)
 
 
-def _make_rank_inputs(n_ranks: int) -> torch.Tensor:
-    """Distinct per-rank tensors with n_ranks contiguous chunks of SIZE each."""
-    rows = [
-        torch.arange(r * 100.0, r * 100.0 + n_ranks * SIZE, dtype=torch.float32).reshape(1, n_ranks * SIZE)
-        for r in range(n_ranks)
-    ]
+def _make_rank_inputs(n_ranks: int, op_name: str) -> torch.Tensor:
+    """Distinct per-rank tensors with n_ranks contiguous chunks of SIZE each.
+
+    For ``prod`` the values are small dyadic rationals (> 0) so the products stay
+    exact in FP32; the other ops use the wide arange spread.
+    """
+    if op_name == "prod":
+        rows = [
+            (
+                1.0 + r * 0.125 + torch.arange(n_ranks * SIZE, dtype=torch.float32).remainder(5) * 0.0625
+            ).reshape(1, n_ranks * SIZE)
+            for r in range(n_ranks)
+        ]
+    else:
+        rows = [
+            torch.arange(r * 100.0, r * 100.0 + n_ranks * SIZE, dtype=torch.float32).reshape(
+                1, n_ranks * SIZE
+            )
+            for r in range(n_ranks)
+        ]
     return torch.stack(rows)
 
 
-def _build_reduce_scatter_program(n_ranks: int):
+def _build_reduce_scatter_program(n_ranks: int, reduce_op):
     """Build an N-rank reduce-scatter program at call time using the intrinsic.
 
     Deferred construction lets this file collect even if the embedded body
@@ -70,7 +97,7 @@ def _build_reduce_scatter_program(n_ranks: int):
                 pl.store(chunk, [j, 0], data)
 
             # Reduce-scatter — one call.
-            data = pld.tensor.reduce_scatter(data, signal, op=pld.ReduceOp.Sum)
+            data = pld.tensor.reduce_scatter(data, signal, op=reduce_op)
 
             # Stage-out: read my reduced chunk.
             acc = pl.load(data, [my_rank, 0], [1, SIZE])
@@ -112,13 +139,22 @@ class TestL3TensorReduceScatterIntrinsic:
     bit-identical to the hand-written ``test_l3_reduce_scatter.py`` reference.
     """
 
+    @pytest.mark.parametrize(
+        ("reduce_op", "op_name"),
+        [
+            (pld.ReduceOp.Sum, "sum"),
+            (pld.ReduceOp.Max, "max"),
+            (pld.ReduceOp.Min, "min"),
+            (pld.ReduceOp.Prod, "prod"),
+        ],
+    )
     @pytest.mark.parametrize("n_ranks", [2, 4])
-    def test_reduce_scatter_intrinsic(self, test_config, device_ids, n_ranks):
+    def test_reduce_scatter_intrinsic(self, test_config, device_ids, n_ranks, reduce_op, op_name):
         """Compile and run mesh reduce-scatter for P=2 or P=4; skip when devices are scarce."""
         if len(device_ids) < n_ranks:
             pytest.skip(f"reduce-scatter P={n_ranks} needs {n_ranks} devices, got {device_ids}")
 
-        program = _build_reduce_scatter_program(n_ranks)
+        program = _build_reduce_scatter_program(n_ranks, reduce_op)
         compiled = ir.compile(
             program,
             platform=test_config.platform,
@@ -128,14 +164,14 @@ class TestL3TensorReduceScatterIntrinsic:
             ),
         )
 
-        inputs = _make_rank_inputs(n_ranks)
+        inputs = _make_rank_inputs(n_ranks, op_name)
         outputs = torch.zeros((n_ranks, 1, SIZE), dtype=torch.float32)
 
         compiled(inputs, outputs)
 
-        expected = _expected_reduce_scatter(inputs)
+        expected = _expected_reduce_scatter(inputs, reduce_op)
         assert torch.allclose(outputs, expected), (
-            f"reduce-scatter intrinsic P={n_ranks} mismatch: "
+            f"reduce-scatter intrinsic ({op_name}) P={n_ranks} mismatch: "
             f"max diff = {(outputs - expected).abs().max().item()}"
         )
 

--- a/tests/ut/ir/transforms/test_lower_composite_ops.py
+++ b/tests/ut/ir/transforms/test_lower_composite_ops.py
@@ -2124,24 +2124,43 @@ def test_reduce_scatter_lowering_is_idempotent():
     ir.assert_structural_equal(twice, once)
 
 
-def test_reduce_scatter_deducer_rejects_unsupported_reduce_op():
-    """First-version lowering supports ``ReduceOp.Sum`` only — the deducer
-    must reject other variants."""
+def _build_reduce_scatter_op_program(reduce_op):
+    """Build a minimal Before program for a given ``pld.tensor.reduce_scatter`` op."""
     SIZE = _REDUCE_SCATTER_SIZE
     nr = _REDUCE_SCATTER_NRANKS
 
-    with pytest.raises((ValueError, TypeError, ParserError)):
+    @pl.program
+    class ReduceScatterOp:
+        @pl.function(type=pl.FunctionType.InCore)
+        def reduce_step(
+            self,
+            data: pl.InOut[pld.DistributedTensor[[nr, SIZE], pl.FP32]],
+            signal: pl.InOut[pld.DistributedTensor[[nr, 1], pl.INT32]],
+        ) -> pld.DistributedTensor[[nr, SIZE], pl.FP32]:
+            data = pld.tensor.reduce_scatter(data, signal, op=reduce_op)
+            return data
 
-        @pl.program
-        class BadOp:
-            @pl.function(type=pl.FunctionType.InCore)
-            def f(
-                self,
-                data: pl.InOut[pld.DistributedTensor[[nr, SIZE], pl.FP32]],
-                signal: pl.InOut[pld.DistributedTensor[[nr, 1], pl.INT32]],
-            ) -> pl.Tensor[[nr, SIZE], pl.FP32]:
-                data = pld.tensor.reduce_scatter(data, signal, op=pld.ReduceOp.Max)
-                return data
+    return ReduceScatterOp
+
+
+def test_reduce_scatter_supports_all_reduce_ops():
+    """All four reduce ops decompose; the accumulate step uses the matching
+    tile op (add / maximum / minimum / mul) instead of a hard-coded tile.add."""
+    op_to_tile_op = {
+        pld.ReduceOp.Sum: "tile.add",
+        pld.ReduceOp.Max: "tile.maximum",
+        pld.ReduceOp.Min: "tile.minimum",
+        pld.ReduceOp.Prod: "tile.mul",
+    }
+    for reduce_op, tile_op in op_to_tile_op.items():
+        After = passes.lower_composite_ops()(_build_reduce_scatter_op_program(reduce_op))
+        op_names = set(_collect_op_names(After))
+        assert "pld.tensor.reduce_scatter" not in op_names, (
+            "lower_composite_ops must remove the composite reduce_scatter call entirely"
+        )
+        assert tile_op in op_names, (
+            f"reduce_scatter({reduce_op}) expected {tile_op} in lowered IR, got {sorted(op_names)}"
+        )
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary

`pld.tensor.reduce_scatter` on the InCore rail now supports all four reduce ops — `ReduceOp.Sum`, `Max`, `Min`, `Prod` — instead of `Sum` only.

## What changes

- **Deducer** (`DeduceTensorReduceScatterType`): accepts the full `kSum..kProd` bound instead of rejecting Max/Min/Prod.
- **Lowering** (`LowerTensorReduceScatterRule`): the accumulate step routes through the shared `Reduce()` helper, mapping each op to the matching tile op (`tile.add` / `tile.maximum` / `tile.minimum` / `tile.mul`) — the same dispatch the allreduce rules use.
- **Tests**
  - Composite UT: asserts each op lowers to its matching tile op and that the composite `reduce_scatter` call is fully removed.
  - ST (`test_l3_tensor_reduce_scatter_intrinsic.py`): parametrized over all four ops at P=2 and P=4 with per-op golden (prod uses dyadic-rational inputs so products stay exact in FP32).
- **Docs** (EN + ZH): `ReduceOp` capability in `02-primitives.md`, the `LowerCompositeOps` reduce_scatter section, and the op catalog — InCore accepts all four; the HOST builtin rail remains `Sum`-only.

## Verification

- sim Docker (a2a3sim):
  - `tests/ut/ir/transforms/test_lower_composite_ops.py`: 126 passed
  - related UTs (op_registry / convert_tensor_to_tile / host_orch_distributed): 449 passed
  - reduce_scatter intrinsic ST (Sum/Prod, P=2/P=4): 4 passed
  - signal-reuse ST (reduce_scatter): 2 passed
- pre-commit `--all-files`: 21/21 green (ruff, pyright, clang-format, cpplint, markdownlint, docs parity)
