### PR TITLE
fix(codegen): support PTOAS v0.60 sort32 on A5

### DIFF
--- a/docs/en/dev/passes/32-init_memref.md
+++ b/docs/en/dev/passes/32-init_memref.md
@@ -7,7 +7,7 @@ Materializes compiler-owned PTO level3 scratch, initializes MemRef for all varia
 This pass performs four tasks:
 
 1. **Normalizes statement structure** (calls NormalizeStmtStructure internally)
-2. **Materializes compiler-owned level3 scratch** for the A2/A3 `tile.ci`, narrowing `tile.cast`, and required `tile.sort32` forms that need an explicit tmp under level3
+2. **Materializes compiler-owned level3 scratch** for the A2/A3 `tile.ci` and narrowing `tile.cast` ABIs, plus required `tile.sort32` forms on A2/A3 and A5
 3. **Initializes MemRef** for TileType and TensorType variables
 4. **Creates `tile.alloc` operations** for each non-DDR MemRef with `addr=-1` (unallocated)
 
@@ -45,7 +45,7 @@ program_with_memrefs = init_pass(program)
 ## Algorithm
 
 1. **Normalize structure**: Call `NormalizeStmtStructure` to ensure flat `SeqStmts` structure
-2. **Materialize level3 scratch**: Under the PyPTO or DSA-RP planner on A2/A3, insert ordinary Vec `tile.create` values for missing compiler-owned `tile.ci`, narrowing `tile.cast`, and required `tile.sort32` scratch. Explicit caller tmp on `tile.sel` / `tile.sels` / `tile.prelu` is preserved. The PTOAS planner and A5 are unchanged.
+2. **Materialize level3 scratch**: Under the PyPTO or DSA-RP planner, insert ordinary Vec `tile.create` values for missing compiler-owned scratch. `tile.ci` and narrowing `tile.cast` remain A2/A3-only, while required `tile.sort32` scratch is materialized on both A2/A3 and A5. Explicit caller tmp on `tile.sel` / `tile.sels` / `tile.prelu` is preserved. The PTOAS planner remains unchanged because its level-2 `PlanMemory` owns implicit scratch.
 3. **Resolve declared allocations**: Collect every one-argument `pl.MemRef(...)` declaration and derive each one's size and memory space from the tiles bound to it (see [Declared allocations](#declared-allocations))
 4. **Initialize MemRef**: Read `memory_space` from `TileType` (set by InferTileMemorySpace), create MemRef objects (addr=-1) and attach to variable types
    - **tile.store**: result shares MemRef with the output tensor argument (specified by `output_reuses_input_arg` registry attribute)

--- a/docs/zh/dev/passes/32-init_memref.md
+++ b/docs/zh/dev/passes/32-init_memref.md
@@ -7,7 +7,7 @@
 此 Pass 执行四项任务：
 
 1. **规范化语句 (Statement) 结构**（内部调用 NormalizeStmtStructure）
-2. **物化编译器负责的 level3 scratch**：处理 A2/A3 上需要 scratch 的 `tile.ci`、窄化 `tile.cast` 和 `tile.sort32`；`tile.sel` / `tile.sels` / `tile.prelu` 的 caller tmp 原样保留
+2. **物化编译器负责的 level3 scratch**：处理 A2/A3 ABI 的 `tile.ci`、窄化 `tile.cast`，以及 A2/A3 与 A5 上需要 scratch 的 `tile.sort32`；`tile.sel` / `tile.sels` / `tile.prelu` 的 caller tmp 原样保留
 3. **为 TileType 和 TensorType 变量初始化 MemRef**
 4. **为每个非 DDR 的 MemRef 创建 `tile.alloc` 操作**，地址为 `addr=-1`（未分配）
 
@@ -45,7 +45,7 @@ program_with_memrefs = init_pass(program)
 ## 算法
 
 1. **规范化结构**：调用 `NormalizeStmtStructure` 确保 `SeqStmts` 为扁平结构
-2. **物化 level3 scratch**：在 A2/A3 的 PyPTO 或 DSA-RP 规划模式下，为缺失的 `tile.ci`、窄化 `tile.cast` 与必要的 `tile.sort32` scratch 插入普通 Vec `tile.create`。`tile.sel` / `tile.sels` / `tile.prelu` 的 caller tmp 原样保留；PTOAS 规划器与 A5 不变。
+2. **物化 level3 scratch**：在 PyPTO 或 DSA-RP 规划模式下，为缺失的编译器 scratch 插入普通 Vec `tile.create`。`tile.ci` 与窄化 `tile.cast` 仍仅适用于 A2/A3，必要的 `tile.sort32` scratch 则同时适用于 A2/A3 和 A5。`tile.sel` / `tile.sels` / `tile.prelu` 的 caller tmp 原样保留。PTOAS 规划器保持不变，由其 level-2 `PlanMemory` 管理隐式 scratch。
 3. **解析声明式分配**：收集所有单参数 `pl.MemRef(...)` 声明，并从绑定的 tile 推导出每块分配的大小与内存空间（见[声明式分配](#声明式分配)）
 4. **初始化 MemRef**：从 `TileType` 读取 `memory_space`（由 InferTileMemorySpace 设置），创建 MemRef 对象（addr=-1）并附加到变量类型
    - **tile.store**：结果与输出 tensor 参数共享 MemRef（由 `output_reuses_input_arg` 注册表属性指定）

--- a/src/backend/common/pto_ops_datamove.cpp
+++ b/src/backend/common/pto_ops_datamove.cpp
@@ -534,7 +534,9 @@ static std::string MakeSort32CodegenPTO(const std::string& pto_op_name, const Ca
       << "Operation:[" << pto_op_name << "] requires 2 or 3 arguments (src, idx[, tmp]), but got "
       << op->args_.size();
 
-  const bool level3 = codegen.GetBackendHandler()->RequiresLevel3TmpScratch();
+  // Preserve the existing A2/A3 bridge for every planner. A5 additionally
+  // needs it only when PyPTO/DSA-RP emits fixed addresses and invokes level3.
+  const bool level3 = codegen.GetBackendHandler()->RequiresLevel3TmpScratch() || codegen.EmitTileAddr();
   std::string src = codegen.GetExprAsCode(op->args_[0]);
   std::string idx = codegen.GetExprAsCode(op->args_[1]);
   std::string src_type = codegen.GetExprTypeAnnotation(op->args_[0]);
@@ -543,7 +545,7 @@ static std::string MakeSort32CodegenPTO(const std::string& pto_op_name, const Ca
   std::string tmp_type;
   bool use_static_views = false;
   if (level3 && op->args_.size() == 3) {
-    // A2/A3 level3 TSORT32 verifies explicit tmp against static valid_shape.
+    // PTOAS level3 TSORT32 verifies explicit tmp against static valid_shape.
     tmp = EnsureStaticViewTileSsa(op->args_[2], codegen, "sort32_tmp_view");
     tmp_type = codegen.GetViewTileBufTypeStringFromTileType(As<ir::TileType>(op->args_[2]->GetType()));
   } else if (level3) {
@@ -580,7 +582,7 @@ static std::string MakeSort32CodegenPTO(const std::string& pto_op_name, const Ca
   if (use_static_dst && !pto_ops_detail::HasStaticValidShape(dst_tile)) {
     // Keep the result allocation's runtime logical valid_shape for downstream
     // stores, but present TSORT32 with a static view of that allocation's full
-    // physical capacity. PTOAS A2/A3 rejects a dynamic destination view even
+    // physical capacity. PTOAS level3 rejects a dynamic destination view even
     // though the source valid width determines how many tuples are produced.
     auto physical_view = ir::tile_view_semantics::GetEffectiveTileView(*dst_tile);
     physical_view.valid_shape = dst_tile->shape_;

--- a/src/ir/transforms/init_memref.cpp
+++ b/src/ir/transforms/init_memref.cpp
@@ -288,7 +288,7 @@ struct PtoScratchSpec {
   std::string name_component;
 };
 
-/// Materialize A2/A3 level3 scratch before MemRef collection.
+/// Materialize level3 scratch before MemRef collection.
 ///
 /// Optional compiler-owned scratch (`tile.ci`, narrowing `tile.cast`, required
 /// `tile.sort32`) is inserted only when absent. Caller-owned tmp operands on
@@ -297,6 +297,9 @@ struct PtoScratchSpec {
 /// for them. `tile.col_sum` / `tile.row_expand_add` likewise keep caller tmp.
 class MaterializePtoLevel3ScratchMutator : public IRMutator {
  public:
+  explicit MaterializePtoLevel3ScratchMutator(bool materialize_a2a3_scratch)
+      : materialize_a2a3_scratch_(materialize_a2a3_scratch) {}
+
   StmtPtr VisitStmt_(const AssignStmtPtr& op) override {
     auto call = As<Call>(op->value_);
     if (!call) return IRMutator::VisitStmt_(op);
@@ -325,8 +328,9 @@ class MaterializePtoLevel3ScratchMutator : public IRMutator {
   }
 
  private:
-  static std::optional<PtoScratchSpec> GetScratchSpec(const CallPtr& call, const Span& span) {
+  std::optional<PtoScratchSpec> GetScratchSpec(const CallPtr& call, const Span& span) const {
     if (IsOp(call, "tile.ci") && call->args_.size() == 2) {
+      if (!materialize_a2a3_scratch_) return std::nullopt;
       auto result_type = As<TileType>(call->GetType());
       INTERNAL_CHECK_SPAN(result_type, span) << "tile.ci result must be TileType before InitMemRef";
       // PTOAS v0.60 level3 TCI tmp width: 192 FP32 cols for 32-bit dst, 448 for 16-bit dst.
@@ -336,6 +340,7 @@ class MaterializePtoLevel3ScratchMutator : public IRMutator {
     }
 
     if (IsOp(call, "tile.cast") && call->args_.size() == 1) {
+      if (!materialize_a2a3_scratch_) return std::nullopt;
       auto src_type = As<TileType>(call->args_[0]->GetType());
       INTERNAL_CHECK_SPAN(src_type, span) << "tile.cast source must be TileType before InitMemRef";
       const DataType dst = call->GetKwarg<DataType>("target_type");
@@ -358,6 +363,7 @@ class MaterializePtoLevel3ScratchMutator : public IRMutator {
     return std::nullopt;
   }
 
+  bool materialize_a2a3_scratch_ = false;
   std::size_t scratch_counter_ = 0;
 };
 
@@ -1043,12 +1049,11 @@ FunctionPtr TransformInitMemRef(const FunctionPtr& func) {
   }
 
   // PTOAS level2 owns implicit-tmp materialization as part of PlanMemory. PyPTO
-  // and DSA-RP instead emit fixed addresses and invoke level3, so backends that
-  // report RequiresLevel3TmpScratch() must materialize scratch here.
+  // and DSA-RP instead emit fixed addresses and invoke level3. CI/TCVT scratch
+  // remains restricted to A2/A3, while TSORT32 scratch is level-driven.
   const MemoryPlanner planner = ctx ? ctx->GetMemoryPlanner() : MemoryPlanner::PyPTO;
-  if (handler != nullptr && handler->RequiresLevel3TmpScratch() &&
-      (planner == MemoryPlanner::PyPTO || planner == MemoryPlanner::DsaRP)) {
-    MaterializePtoLevel3ScratchMutator materializer;
+  if (handler != nullptr && (planner == MemoryPlanner::PyPTO || planner == MemoryPlanner::DsaRP)) {
+    MaterializePtoLevel3ScratchMutator materializer(handler->RequiresLevel3TmpScratch());
     normalized_func = materializer.VisitFunction(normalized_func);
   }
 

--- a/tests/st/runtime/ops/test_sort.py
+++ b/tests/st/runtime/ops/test_sort.py
@@ -818,16 +818,14 @@ class Sort32GatherMaskFP32TestCase(PTOTestCase):
 # --- Tests ---
 
 
-# sort32/mrgsort intrinsics are A2A3-only (Ascend 910B). Additionally, the
-# a2a3sim simulator value-converts TSORT32 index lanes while the expected
-# outputs in this file reinterpret raw uint32 bits, so the index-checking
-# cases would compare incompatible representations on the simulator. Until
-# ``compute_expected()`` is taught the simulator's lane convention, restrict
-# the whole class to onboard a2a3 only.
+# The focused sort32 regression overrides this class marker for A5 and A5sim.
+# The remaining sort/gather/mrgsort pipelines retain their existing onboard
+# A2/A3 scope, including the known A2/A3 simulator index-lane discrepancy.
 @pytest.mark.platforms("a2a3")
 class TestSort:
     """Test suite for sort32 and mrgsort operations."""
 
+    @pytest.mark.platforms("a2a3", "a5", "a5sim")
     @pytest.mark.parametrize("platform", PLATFORMS)
     def test_sort32_fp32(self, test_runner, platform):
         """Test sort32 with FP32 data: verify descending sort with index tracking."""

--- a/tests/ut/codegen/test_pto_codegen_ops.py
+++ b/tests/ut/codegen/test_pto_codegen_ops.py
@@ -2831,10 +2831,10 @@ class TestMatmulAccCompactCodegen:
 class TestMrgSortCodegen:
     """Tests for mrgsort format1 code generation with constant and variable block_len."""
 
-    def _generate_mlir(self, program_cls) -> str:
+    def _generate_mlir(self, program_cls, backend_type=BackendType.Ascend910B, *, emit_tile_addr=True) -> str:
         """Run PassManager and PTOCodegen on the given program, return MLIR string."""
         backend.reset_for_testing()
-        backend.set_backend_type(BackendType.Ascend910B)
+        backend.set_backend_type(backend_type)
 
         pm = PassManager.get_strategy(OptimizationStrategy.Default)
         optimized = pm.run_passes(program_cls)
@@ -2842,7 +2842,7 @@ class TestMrgSortCodegen:
         funcs = list(optimized.functions.values())
         assert funcs, "Program has no functions"
         single = ir.Program([funcs[0]], funcs[0].name, optimized.span)
-        return codegen_instance.generate(single)
+        return codegen_instance.generate(single, emit_tile_addr=emit_tile_addr)
 
     def test_mrgsort_format1_const_block_len(self):
         """mrgsort with constant block_len=64 should generate pto.tmrgsort with i32 operand."""
@@ -2910,7 +2910,8 @@ class TestMrgSortCodegen:
         ("src_dtype", "output_cols"),
         [(pl.FP32, 128), (pl.FP16, 256)],
     )
-    def test_sort32_dynamic_valid_width_emits_level3_scratch(self, src_dtype, output_cols):
+    @pytest.mark.parametrize("backend_type", [BackendType.Ascend910B, BackendType.Ascend950])
+    def test_sort32_dynamic_valid_width_emits_level3_scratch(self, src_dtype, output_cols, backend_type):
         """A runtime valid width keeps logical output bounds and uses static TSORT capacity."""
 
         @pl.program
@@ -2928,7 +2929,7 @@ class TestMrgSortCodegen:
                 sorted_tile = pl.tile.sort32(src_tile, idx_tile)
                 return pl.store(sorted_tile, [0, 0], out)
 
-        mlir = self._generate_mlir(Prog)
+        mlir = self._generate_mlir(Prog, backend_type)
         line = next(line for line in mlir.splitlines() if "pto.tsort32" in line)
         ins = line.split("ins(", 1)[1].split(":", 1)[0]
         assert ins.count(",") == 2, line
@@ -2939,6 +2940,34 @@ class TestMrgSortCodegen:
         tstore_line = next(line for line in mlir.splitlines() if "pto.tstore" in line)
         assert "%sorted_tile" in tstore_line and "%sort32_dst_view" not in tstore_line, tstore_line
         assert "arith.muli" in mlir, mlir
+
+    @pytest.mark.parametrize(
+        ("backend_type", "emit_tile_addr"),
+        [(BackendType.Ascend950, True), (BackendType.Ascend910B, False)],
+    )
+    def test_static_aligned_sort32_uses_static_views_without_tmp(self, backend_type, emit_tile_addr):
+        """A5 level3 and the existing A2/A3 path expose static aligned widths."""
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                src: pl.Tensor[[1, 64], pl.FP32],
+                idx: pl.Tensor[[1, 64], pl.UINT32],
+                out: pl.Tensor[[1, 128], pl.FP32],
+            ) -> pl.Tensor[[1, 128], pl.FP32]:
+                src_tile = pl.load(src, [0, 0], [1, 64])
+                idx_tile = pl.load(idx, [0, 0], [1, 64])
+                sorted_tile = pl.tile.sort32(src_tile, idx_tile)
+                return pl.store(sorted_tile, [0, 0], out)
+
+        mlir = self._generate_mlir(Prog, backend_type, emit_tile_addr=emit_tile_addr)
+        line = next(line for line in mlir.splitlines() if "pto.tsort32" in line)
+        assert "%sort32_src_view" in line and "%sort32_idx_view" in line, line
+        assert "%sort32_dst_view" in line, line
+        assert "sort32_tmp" not in line, line
+        assert "v_row=?" not in line and "v_col=?" not in line, line
 
 
 class TestConstDtypeCodegen:

--- a/tests/ut/ir/transforms/test_init_memref.py
+++ b/tests/ut/ir/transforms/test_init_memref.py
@@ -1230,7 +1230,7 @@ class TestDynamicValidShape:
 
 
 class TestPtoLevel3Scratch:
-    """Compiler-owned A2/A3 scratch enters the ordinary MemRef pipeline here."""
+    """Compiler-owned level3 scratch enters the ordinary MemRef pipeline here."""
 
     @staticmethod
     def _calls(program: ir.Program, op_name: str) -> list[ir.Call]:
@@ -1340,6 +1340,10 @@ class TestPtoLevel3Scratch:
         after = self._run(self._cast_program(pl.FP32, pl.FP16), BackendType.Ascend910B)
         assert len(self._calls(after, ir.get_op("tile.cast").name)[0].args) == 1
 
+    def test_a5_narrowing_cast_keeps_implicit_tmp_abi(self):
+        after = self._run(self._cast_program(pl.FP32, pl.INT16), BackendType.Ascend950)
+        assert len(self._calls(after, ir.get_op("tile.cast").name)[0].args) == 1
+
     def test_fp16_to_int4_has_no_level3_scratch(self):
         """FP16->INT4 uses native vconv without PTOAS level-3 tcvt tmp."""
         after = self._run(self._cast_program(pl.FP16, pl.INT4), BackendType.Ascend910B)
@@ -1416,8 +1420,9 @@ class TestPtoLevel3Scratch:
             ib.return_stmt(result)
         return ir.Program([f.get_result()], "sort_program", span)
 
-    def test_sort32_dynamic_valid_col_gets_physical_shape_scratch(self):
-        after = self._run(self._sort_program(dynamic_valid_col=True), BackendType.Ascend910B)
+    @pytest.mark.parametrize("backend_type", [BackendType.Ascend910B, BackendType.Ascend950])
+    def test_sort32_dynamic_valid_col_gets_physical_shape_scratch(self, backend_type):
+        after = self._run(self._sort_program(dynamic_valid_col=True), backend_type)
         sort32 = self._calls(after, ir.get_op("tile.sort32").name)[0]
         assert len(sort32.args) == 3
         tmp = cast(ir.TileType, sort32.args[2].type)
@@ -1425,8 +1430,17 @@ class TestPtoLevel3Scratch:
         assert tmp.dtype == ir.DataType.FP32
         assert tmp.memref is not None
 
-    def test_sort32_static_aligned_valid_col_needs_no_scratch(self):
-        after = self._run(self._sort_program(dynamic_valid_col=False), BackendType.Ascend910B)
+    @pytest.mark.parametrize("backend_type", [BackendType.Ascend910B, BackendType.Ascend950])
+    def test_sort32_static_aligned_valid_col_needs_no_scratch(self, backend_type):
+        after = self._run(self._sort_program(dynamic_valid_col=False), backend_type)
+        assert len(self._calls(after, ir.get_op("tile.sort32").name)[0].args) == 2
+
+    def test_a5_ptoas_planner_leaves_sort32_scratch_to_plan_memory(self):
+        after = self._run(
+            self._sort_program(dynamic_valid_col=True),
+            BackendType.Ascend950,
+            planner=passes.MemoryPlanner.PTOAS,
+        )
         assert len(self._calls(after, ir.get_op("tile.sort32").name)[0].args) == 2
 
 


### PR DESCRIPTION
Fixes #2557.

## Summary

- preserve the existing A2/A3 TSORT32 bridge for every planner, while enabling the same static-view handling on A5 only when PyPTO/DSA-RP selects PTOAS Level3
- materialize required TSORT32 scratch on A5 under PyPTO/DSA-RP while leaving A5 TCI/TCVT operand ABIs unchanged
- add focused A5/A5sim regressions and update the InitMemRef pass documentation

The previous compare/select/scatter/syncall/column-reduction changes have been removed so this PR is limited to issue #2557.

## Validation

- `215 passed` in the complete affected codegen and InitMemRef unit-test files
- A2/A3's existing planner path is covered explicitly with `emit_tile_addr=false`
- A5 and A2/A3 TSORT32 compile successfully with local PTOAS v0.60
- A5sim TSORT32 numerical execution passes
- clang-tidy and all pre-commit hooks pass
