### PR TITLE
fix(language): preserve tensor subclasses through loop carries

### DIFF
--- a/python/pypto/language/distributed/op/system_ops.py
+++ b/python/pypto/language/distributed/op/system_ops.py
@@ -21,8 +21,8 @@ cross-rank synchronisation primitives:
   that is not :class:`ir.DistributedTensorType`.
 * :func:`notify` / :func:`wait` / :func:`defer_wait` — cross-rank notification,
   blocking wait, and deferred task-completion registration on a window-bound
-  signal matrix. Side-effect-only; the C++ verifier refuses a plain
-  :class:`pl.Tensor` target.
+  signal matrix. Side-effect-only; a plain :class:`pl.Tensor` target is
+  rejected statically by the annotation and again by the C++ verifier.
 * :func:`rank` / :func:`nranks` — CommContext scalar reads (``INT32``). The
   op verifier rejects any argument whose type is not :class:`ir.CommCtxType`.
 
@@ -38,7 +38,6 @@ from collections.abc import Sequence
 
 from pypto.ir.op.distributed import system_ops as _ir_system
 from pypto.language.typing import IntLike, Scalar
-from pypto.language.typing.tensor import Tensor
 from pypto.pypto_core.ir import Call, NotifyOp, WaitCmp
 
 from ..typing.comm_ctx import CommCtx
@@ -123,7 +122,7 @@ def nranks(ctx: CommCtx) -> Scalar:
 
 
 def notify(
-    target: Tensor,
+    target: DistributedTensor,
     peer: IntLike,
     offsets: Sequence[IntLike],
     value: IntLike,
@@ -148,8 +147,7 @@ def notify(
        window-bound signal tensor.
 
     Args:
-        target: Window-bound :class:`pld.DistributedTensor` signal matrix. The
-            C++ verifier refuses a plain :class:`pl.Tensor`.
+        target: Window-bound :class:`pld.DistributedTensor` signal matrix.
         peer: Peer rank index.
         offsets: Offsets into the remote slice, one per ``target`` dimension.
         value: Scalar payload to deposit at the peer slot.
@@ -160,7 +158,7 @@ def notify(
 
 
 def wait(
-    signal: Tensor,
+    signal: DistributedTensor,
     offsets: Sequence[IntLike],
     expected: IntLike,
     *,
@@ -176,8 +174,7 @@ def wait(
     because it lowers to an IR attr (printed as ``cmp=<int>``).
 
     Args:
-        signal: Window-bound :class:`pld.DistributedTensor` signal matrix. The
-            C++ verifier refuses a plain :class:`pl.Tensor`.
+        signal: Window-bound :class:`pld.DistributedTensor` signal matrix.
         offsets: Offsets into the local slice, one per ``signal`` dimension.
         expected: Scalar threshold value to compare against.
         cmp: :class:`pld.WaitCmp` selecting equality vs greater-or-equal
@@ -187,7 +184,7 @@ def wait(
 
 
 def defer_wait(
-    signal: Tensor,
+    signal: DistributedTensor,
     offsets: Sequence[IntLike],
     expected: IntLike,
     *,

--- a/python/pypto/language/dsl_api.py
+++ b/python/pypto/language/dsl_api.py
@@ -28,18 +28,26 @@ RangeArg = Union[int, "Scalar"]
 # Condition argument type: bool literal or Scalar variable
 CondArg = Union[bool, "Scalar"]
 
-ExprType = TypeVar("ExprType", int, float, "Scalar", "Tensor", "Tile", "Array")
+# Loop-carry TypeVars are *bound*, not constrained, so a concrete subclass
+# survives the carry round trip: ``pl.range(init_values=(dist_tensor,))`` must
+# yield ``DistributedTensor``, not a plain ``Tensor``. A constrained
+# ``TypeVar(..., "Tensor", ...)`` solves to the matching constraint instead of to
+# the argument type, erasing the subclass — which is why ``pld.system.notify`` /
+# ``wait`` had to over-widen their signal parameter. Same rationale as
+# ``unified_ops.T``. ``int`` / ``float`` stay in the bound so ``yield_(1)`` and
+# scalar-literal init values remain valid in the DSL.
+ExprType = TypeVar("ExprType", bound="int | float | Scalar | Tensor | Tile | Array")
 
 
 T = TypeVar("T")
 W = TypeVar("W")
 
-# TypeVars for overloads (int/float included so yield_(1) is valid in DSL)
-T1 = TypeVar("T1", int, float, "Scalar", "Tensor", "Tile", "Array")
-T2 = TypeVar("T2", int, float, "Scalar", "Tensor", "Tile", "Array")
-T3 = TypeVar("T3", int, float, "Scalar", "Tensor", "Tile", "Array")
-T4 = TypeVar("T4", int, float, "Scalar", "Tensor", "Tile", "Array")
-T5 = TypeVar("T5", int, float, "Scalar", "Tensor", "Tile", "Array")
+# TypeVars for overloads (see the bound-vs-constrained note on ExprType above)
+T1 = TypeVar("T1", bound="int | float | Scalar | Tensor | Tile | Array")
+T2 = TypeVar("T2", bound="int | float | Scalar | Tensor | Tile | Array")
+T3 = TypeVar("T3", bound="int | float | Scalar | Tensor | Tile | Array")
+T4 = TypeVar("T4", bound="int | float | Scalar | Tensor | Tile | Array")
+T5 = TypeVar("T5", bound="int | float | Scalar | Tensor | Tile | Array")
 
 
 class RangeIterator(Generic[T]):

--- a/python/pypto/language/op/tile_ops.py
+++ b/python/pypto/language/op/tile_ops.py
@@ -201,9 +201,17 @@ _TensorT = TypeVar("_TensorT", bound=Tensor)
 
 # Constrained TypeVar for the split-axis reshape wrappers (aiv_shard / aic_gather):
 # the operand is either a Tile (legacy @pl.program form) or a Tensor (@pl.jit /
-# pl.spmd form), and the result is the SAME kind as the input. A constrained
-# TypeVar keeps that correlation (Tile -> Tile, Tensor -> Tensor) instead of a
-# ``Tensor | Tile`` union, which would type every result as the union.
+# pl.spmd form), and the result is the SAME kind as the input.
+#
+# Constrained, NOT bound, and deliberately unlike the loop-carry TypeVars in
+# dsl_api: a bound ``Tensor | Tile`` would propagate a DistributedTensor operand
+# into the result type, but AIV/AIC split does not accept one. The deducer
+# matches the operand with ``As<TensorType>``, which is precise-match and returns
+# null for DistributedTensorType by design, so ``tensor.aiv_shard(dist)`` is
+# rejected ("requires argument to be a (non-distributed) TensorType", see
+# DeduceSplitReshapeTensor in src/ir/op/tile_ops/cross_core.cpp). Collapsing the
+# subclass here keeps the annotation from advertising a result the op cannot
+# produce; widening it needs both operation contracts updated first.
 _SplitOperandT = TypeVar("_SplitOperandT", Tensor, Tile)
 
 

--- a/tests/ut/language/test_loop_var_type.py
+++ b/tests/ut/language/test_loop_var_type.py
@@ -10,18 +10,35 @@
 # pyright: reportCallIssue=true
 # pyright: reportArgumentType=true
 
-"""Pyright regression test: loop variables from pl.range/parallel/unroll must be Scalar.
+"""Pyright regression tests for the DSL loop signatures.
 
-If the loop variable type regresses to ``int``, pyright will report:
-  "Argument of type 'int' cannot be assigned to parameter of type 'Scalar'"
-on every ``accept_scalar()`` call below.
+Two properties are pinned here. Both are checked by pyright rather than by an
+assertion, so a regression surfaces as a type error on this file, not a failing
+run.
+
+1. Loop variables from pl.range/parallel/unroll are ``Scalar``. If one regresses
+   to ``int``, pyright reports "Argument of type 'int' cannot be assigned to
+   parameter of type 'Scalar'" on every ``accept_scalar()`` call below.
+2. A loop-carried value keeps its concrete tensor subclass. The carry TypeVars
+   in ``dsl_api`` are *bound*, so they solve to the argument's own type. If one
+   regresses to a constrained ``TypeVar(..., "Tensor", ...)``, the solve
+   collapses the subclass to plain ``Tensor`` and every ``accept_distributed()``
+   call below reports "Argument of type 'Tensor' cannot be assigned to parameter
+   of type 'DistributedTensor'".
 """
 
 import pypto.language as pl
+import pypto.language.distributed as pld
 import pytest
 
 
 def accept_scalar(x: pl.Scalar) -> None: ...
+
+
+def accept_distributed(x: pld.DistributedTensor) -> None: ...
+
+
+def accept_tensor(x: pl.Tensor) -> None: ...
 
 
 class TestLoopVarType:
@@ -46,6 +63,36 @@ class TestLoopVarType:
     def test_unroll_loop_var(self):
         for n in pl.unroll(3):
             accept_scalar(n)
+
+
+class TestLoopCarrySubclass:
+    """Verify a loop-carried DistributedTensor is not widened to plain Tensor.
+
+    ``pld.system.notify`` / ``wait`` / ``defer_wait`` annotate their signal
+    operand as ``DistributedTensor``, matching the C++ deducer. A carried value
+    that lost its subclass could not be passed to them at all, which is the
+    regression these cases pin.
+    """
+
+    def test_range_carry_keeps_distributed_tensor(self):
+        signal = pld.DistributedTensor[[16, 16], pl.INT32]
+        for _i, (carried,) in pl.range(1, init_values=(signal,)):
+            accept_distributed(carried)
+            accept_distributed(pl.yield_(carried))
+
+    def test_while_carry_keeps_distributed_tensor(self):
+        signal = pld.DistributedTensor[[16, 16], pl.INT32]
+        for (carried,) in pl.while_(init_values=(signal,)):
+            accept_distributed(carried)
+            accept_distributed(pl.yield_(carried))
+
+    def test_multi_carry_keeps_each_position(self):
+        """Each carry slot has its own TypeVar, so the subclass survives per slot."""
+        signal = pld.DistributedTensor[[16, 16], pl.INT32]
+        plain = pl.Tensor[[16, 16], pl.INT32]
+        for _i, (dist, tensor) in pl.range(1, init_values=(signal, plain)):
+            accept_distributed(dist)
+            accept_tensor(tensor)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What

`pld.system.notify` / `wait` / `defer_wait` typed their window-bound signal operand as `pl.Tensor`, while the C++ deducers require `DistributedTensorType`:

```cpp
// src/ir/op/distributed/system.cpp
auto dist_type = As<DistributedTensorType>(args[0]->GetType());
CHECK(dist_type) << "pld.system.wait signal must be a DistributedTensor (window-bound), got "
                 << args[0]->GetType()->TypeName();
```

`DistributedTensor` subclasses `Tensor`, so the annotation was too wide rather than wrong: a plain `pl.Tensor` passed static checking and failed only when the IR node was built. This narrows the three parameters and fixes the reason they could not be narrowed before.

## Why the narrowing needed a root-cause fix first

Narrowing alone breaks on a legitimate shape — a signal tensor carried through a loop:

```python
for _i, (carried,) in pl.range(1, init_values=(data,)):   # data: pld.DistributedTensor
    result = pl.yield_(carried)
viewed = pl.tensor.view(result, [16, 16])
pld.system.wait(viewed, offsets=[0, 0], expected=1, cmp=pld.WaitCmp.Eq)
```

`pl.tensor.view` is TypeVar-correct, so the loss is upstream of it. The carry TypeVars in `dsl_api` were **constrained**:

```python
T1 = TypeVar("T1", int, float, "Scalar", "Tensor", "Tile", "Array")
```

A constrained TypeVar solves to the matching *constraint*, not to the argument's own type, so a `DistributedTensor` argument collapses to plain `Tensor` and the subclass is erased at `pl.range`, before `yield_` or `view` ever sees it.

Making them **bound** solves to the argument's own type instead:

| Expression, `data: DistributedTensor` | Before | After |
| --- | --- | --- |
| `pl.range(init_values=(data,))` carry | `Tensor` | `DistributedTensor` |
| `pl.yield_(carried)` | `Tensor` | `DistributedTensor` |
| `pl.tensor.view(result, ...)` | `DistributedTensor` | `DistributedTensor` |

`T1..T5` and `ExprType` are shared by `range` / `parallel` / `unroll` / `pipeline` / `while_` / `yield_`, so one change covers all six.

The two forms are not equivalent, so the substitution was checked rather than assumed:

- **Unrelated types stay rejected.** The constraints are mutually unrelated, so a bound union of the same members rejects `str` exactly as before.
- **The "all occurrences share one constraint" property is never used here.** Every signature gives each carry slot its own TypeVar (`tuple[T1, T2, T3]` is three distinct variables), so nothing is lost. `unified_ops.T` is bound for the same reason.
- **A union argument is newly accepted** (`Tensor | Tile` no longer needs a single matching constraint). That direction is correct — such a carry is valid DSL.

## Why `_SplitOperandT` is deliberately *not* converted

`aiv_shard` / `aic_gather` keep their constrained TypeVar, and the comment now records why. `DeduceSplitReshapeTensor` matches the operand with `As<TensorType>`, which is precise-match and returns null for `DistributedTensorType` **by design** (`include/pypto/ir/kind_traits.h:113-116`), so the op rejects a distributed operand outright. Propagating the subclass there would advertise a result the op cannot produce. Widening it would require updating both operation contracts first.

## Scope

`defer_wait` is narrowed alongside `notify` / `wait`: its deducer carries the same `DistributedTensorType` check.

Annotations only — no runtime behaviour changes.

## Test

`TestLoopCarrySubclass` in `tests/ut/language/test_loop_var_type.py`, which is already a pyright regression file (its `# pyright: reportArgumentType=true` header re-enables the rule `pyproject.toml` disables project-wide). The cases carry a `DistributedTensor` through `pl.range`, `pl.while_`, and `pl.yield_` and feed each result to `accept_distributed(x: DistributedTensor)`, plus a two-slot case pinning that each carry position keeps its own type.

Verified the guard fires: reverting just `T1` to the constrained form makes pyright report `reportArgumentType` at 5 sites in that file.

Closes #2234
