### PR TITLE
fix(ir): validate that tile.load / tile.store offset elements are integer scalars

### DIFF
--- a/python/pypto/language/op/tile_ops.py
+++ b/python/pypto/language/op/tile_ops.py
@@ -400,7 +400,8 @@ def load(
     Args:
         tensor: Source tensor
         offsets: Offsets in each dimension. Always in the source tensor's
-            coordinate system.
+            coordinate system. Each element must be an integer scalar — a float
+            (``n / 2`` rather than ``n // 2``) or a nested sequence is rejected.
         shapes: Shape of the region to load in each dimension. Always in the
             source tensor's coordinate system.
         valid_shape: Valid shape of the tile in each dimension. When provided, sets
@@ -462,7 +463,8 @@ def store(
 
     Args:
         tile: Source tile
-        offsets: Offsets in each dimension
+        offsets: Offsets in each dimension. Each element must be an integer
+            scalar — a float or a nested sequence is rejected.
         output_tensor: Output tensor
         shapes: Optional ND partition shape. Injected by FlattenTileNdTo2D for ND tensors.
         atomic: Combine mode for the global-memory write. ``AtomicType.None_``

--- a/src/ir/op/tile_ops/memory.cpp
+++ b/src/ir/op/tile_ops/memory.cpp
@@ -65,8 +65,8 @@ namespace {
 
 /// Validate that every element of an offsets tuple is an integer scalar.
 ///
-/// ``tile.load`` / ``tile.store`` declare offsets as "TupleType of ScalarType",
-/// and nothing downstream re-derives that: the window-read proofs in
+/// ``tile.load`` / ``tile.store`` declare offsets as "TupleType of integer
+/// ScalarType", and nothing downstream re-derives that: the window-read proofs in
 /// ``InferWindowReadValidShape`` are defined only over integer scalars, so a
 /// non-scalar element makes every bounds obligation *undecidable* rather than
 /// false — the negative-offset and reads-past-the-end checks then pass silently
@@ -1132,7 +1132,7 @@ REGISTER_OP("tile.load")
     .set_description("Copy data from tensor to unified buffer (tile)")
     .add_argument("tensor", "Source tensor (TensorType)")
     .add_argument("offsets",
-                  "Offsets in each dimension, in source tensor coordinates (TupleType of ScalarType)")
+                  "Offsets in each dimension, in source tensor coordinates (TupleType of integer ScalarType)")
     .add_argument(
         "shapes",
         "Shape of region to load in each dimension, in source tensor coordinates (TupleType of ScalarType)")
@@ -1156,7 +1156,7 @@ REGISTER_OP("tile.store")
     .set_op_category("TileOp")
     .set_description("Copy data from unified buffer (tile) to tensor")
     .add_argument("tile", "Source tile (TileType)")
-    .add_argument("offsets", "Offsets in each dimension (TupleType of ScalarType)")
+    .add_argument("offsets", "Offsets in each dimension (TupleType of integer ScalarType)")
     .add_argument("output_tensor", "Output tensor (TensorType)")
     .add_argument("shapes",
                   "Optional ND partition shape (TupleType). "

--- a/src/ir/op/tile_ops/memory.cpp
+++ b/src/ir/op/tile_ops/memory.cpp
@@ -61,6 +61,35 @@ T GetKwarg(const std::vector<std::pair<std::string, std::any>>& kwargs, const st
   throw ValueError("Missing kwarg: " + key);
 }
 
+namespace {
+
+/// Validate that every element of an offsets tuple is an integer scalar.
+///
+/// ``tile.load`` / ``tile.store`` declare offsets as "TupleType of ScalarType",
+/// and nothing downstream re-derives that: the window-read proofs in
+/// ``InferWindowReadValidShape`` are defined only over integer scalars, so a
+/// non-scalar element makes every bounds obligation *undecidable* rather than
+/// false — the negative-offset and reads-past-the-end checks then pass silently
+/// and codegen lowers whatever the element happens to reduce to. Reject it here,
+/// at the operator boundary, on the same terms ``tensor.slice`` uses for its own
+/// offsets. ``IsInt()`` (not ``IsIndexLike()``) is the bar because every integer
+/// width is a legitimate offset all the way down: ``EmitCastToIndex`` exists
+/// precisely to widen a non-INDEX integer offset at the partition_view site.
+void ValidateOffsetTupleElements(const MakeTuplePtr& offsets, const std::string& op_name) {
+  for (size_t i = 0; i < offsets->elements_.size(); ++i) {
+    const ExprPtr& elem = offsets->elements_[i];
+    CHECK(elem) << op_name << " offset tuple element " << i << " must not be null";
+    auto scalar_type = As<ScalarType>(elem->GetType());
+    CHECK_SPAN(scalar_type, elem->span_) << op_name << " offset tuple element " << i
+                                         << " must be ScalarType, but got " << elem->GetType()->TypeName();
+    CHECK_SPAN(scalar_type->dtype_.IsInt(), elem->span_)
+        << op_name << " offset tuple element " << i << " must have integer dtype, but got "
+        << scalar_type->dtype_.ToString();
+  }
+}
+
+}  // namespace
+
 TypePtr DeduceTileGetBlockIdxType(const std::vector<ExprPtr>& args,
                                   const std::vector<std::pair<std::string, std::any>>& kwargs,
                                   const std::string& op_name) {
@@ -111,6 +140,7 @@ TypePtr DeduceTileLoadType(const std::vector<ExprPtr>& args,
   CHECK(offsets_tuple) << "The operator " << op_name
                        << " requires second argument to be a tuple (offsets), but got "
                        << args[1]->GetType()->TypeName();
+  ValidateOffsetTupleElements(offsets_tuple, op_name);
 
   // Third argument must be TupleType (shapes)
   auto shapes_tuple = As<MakeTuple>(args[2]);
@@ -305,6 +335,7 @@ TypePtr DeduceTileStoreType(const std::vector<ExprPtr>& args,
   CHECK(offsets_tuple) << "The operator " << op_name
                        << " requires second argument to be a tuple (offsets), but got "
                        << args[1]->GetType()->TypeName();
+  ValidateOffsetTupleElements(offsets_tuple, op_name);
 
   // Third argument must be the output tensor. AsTensorTypeLike accepts both
   // plain TensorType and DistributedTensorType — the latter is needed for the

--- a/tests/ut/ir/operators/test_tile_ops.py
+++ b/tests/ut/ir/operators/test_tile_ops.py
@@ -5089,6 +5089,97 @@ class TestTileLoadOp:
         assert Prog is not None
 
 
+class TestTileLoadStoreOffsetElements:
+    """tile.load / tile.store offsets must be integer scalars, as tensor.slice's are.
+
+    A non-scalar element does not merely produce a meaningless op: it makes every
+    window-read bounds obligation undecidable, so the negative-offset and
+    reads-past-the-end checks below stop firing and codegen silently lowers
+    whatever the element reduces to.
+    """
+
+    @staticmethod
+    def _tensor() -> ir.Var:
+        return ir.Var("a", ir.TensorType([128, 128], DataType.FP32), ir.Span.unknown())
+
+    @staticmethod
+    def _nested_offsets() -> list[ir.Expr]:
+        """Offsets one nesting level too deep — ``[[0, 0], [64, 64]]``."""
+        span = ir.Span.unknown()
+
+        def row(value: int) -> ir.MakeTuple:
+            return ir.MakeTuple([ir.ConstInt(value, DataType.INDEX, span)] * 2, span)
+
+        return [row(0), row(64)]
+
+    def test_load_rejects_tuple_offset_element(self):
+        with pytest.raises(ValueError, match="tile.load offset tuple element 0 must be ScalarType"):
+            tile.load(self._tensor(), self._nested_offsets(), [64, 64])
+
+    def test_load_rejects_float_offset_element(self):
+        """A Python ``/`` yields a float; it must not reach codegen as an offset."""
+        span = ir.Span.unknown()
+        offsets = [ir.ConstFloat(64.0, DataType.FP32, span), ir.ConstInt(0, DataType.INDEX, span)]
+
+        with pytest.raises(ValueError, match="tile.load offset tuple element 0 must have integer dtype"):
+            tile.load(self._tensor(), offsets, [64, 64])
+
+    def test_load_accepts_non_index_integer_offset(self):
+        """The bar is IsInt, not IsIndexLike: codegen index_casts a narrower offset."""
+        span = ir.Span.unknown()
+        offsets = [ir.ConstInt(0, DataType.INT32, span), ir.ConstInt(0, DataType.INT32, span)]
+
+        call = tile.load(self._tensor(), offsets, [64, 64])
+
+        assert isinstance(call.type, ir.TileType)
+
+    def test_load_tuple_offset_no_longer_hides_out_of_bounds(self):
+        """The plain-int form is rejected for reading past the end; so is the nested one."""
+        span = ir.Span.unknown()
+        far = [ir.ConstInt(100, DataType.INDEX, span), ir.ConstInt(100, DataType.INDEX, span)]
+        with pytest.raises(ValueError, match="reads past the end of dimension 0"):
+            tile.load(self._tensor(), far, [64, 64])
+
+        nested_far = [ir.MakeTuple([ir.ConstInt(100, DataType.INDEX, span)], span)] * 2
+        with pytest.raises(ValueError, match="tile.load offset tuple element 0 must be ScalarType"):
+            tile.load(self._tensor(), nested_far, [64, 64])
+
+    def _tile_var(self) -> ir.Var:
+        loaded = tile.load(self._tensor(), [0, 0], [64, 64])
+        return ir.Var("t", loaded.type, ir.Span.unknown())
+
+    def test_store_rejects_tuple_offset_element(self):
+        out = ir.Var("out", ir.TensorType([128, 128], DataType.FP32), ir.Span.unknown())
+
+        with pytest.raises(ValueError, match="tile.store offset tuple element 0 must be ScalarType"):
+            tile.store(self._tile_var(), self._nested_offsets(), out)
+
+    def test_store_rejects_float_offset_element(self):
+        span = ir.Span.unknown()
+        out = ir.Var("out", ir.TensorType([128, 128], DataType.FP32), span)
+        offsets = [ir.ConstFloat(0.0, DataType.FP32, span), ir.ConstInt(0, DataType.INDEX, span)]
+
+        with pytest.raises(ValueError, match="tile.store offset tuple element 0 must have integer dtype"):
+            tile.store(self._tile_var(), offsets, out)
+
+    def test_dsl_load_rejects_float_offset(self):
+        """The user-facing path: ``N / 2`` is a float, and the author meant ``N // 2``.
+
+        The closure var is annotated ``Any`` so the offset's dtype is only knowable
+        at parse time — the case a static checker cannot catch for the user.
+        """
+        half: Any = 128 / 2
+
+        with pytest.raises(InvalidOperationError, match="offset tuple element 0 must have integer dtype"):
+
+            @pl.function
+            def func(
+                t: pl.Tensor[[128, 128], pl.FP32], out: pl.Tensor[[128, 128], pl.FP32]
+            ) -> pl.Tensor[[128, 128], pl.FP32]:
+                a: pl.Tile[[64, 64], pl.FP32] = pl.load(t, [half, 0], [64, 64])
+                return pl.store(a, [0, 0], out)
+
+
 class TestTileCreateOp:
     """Tests for tile.create layout inference."""
 

--- a/tests/ut/ir/operators/test_tile_ops.py
+++ b/tests/ut/ir/operators/test_tile_ops.py
@@ -5113,7 +5113,7 @@ class TestTileLoadStoreOffsetElements:
         return [row(0), row(64)]
 
     def test_load_rejects_tuple_offset_element(self):
-        with pytest.raises(ValueError, match="tile.load offset tuple element 0 must be ScalarType"):
+        with pytest.raises(ValueError, match=r"tile\.load offset tuple element 0 must be ScalarType"):
             tile.load(self._tensor(), self._nested_offsets(), [64, 64])
 
     def test_load_rejects_float_offset_element(self):
@@ -5121,7 +5121,7 @@ class TestTileLoadStoreOffsetElements:
         span = ir.Span.unknown()
         offsets = [ir.ConstFloat(64.0, DataType.FP32, span), ir.ConstInt(0, DataType.INDEX, span)]
 
-        with pytest.raises(ValueError, match="tile.load offset tuple element 0 must have integer dtype"):
+        with pytest.raises(ValueError, match=r"tile\.load offset tuple element 0 must have integer dtype"):
             tile.load(self._tensor(), offsets, [64, 64])
 
     def test_load_accepts_non_index_integer_offset(self):
@@ -5141,7 +5141,7 @@ class TestTileLoadStoreOffsetElements:
             tile.load(self._tensor(), far, [64, 64])
 
         nested_far = [ir.MakeTuple([ir.ConstInt(100, DataType.INDEX, span)], span)] * 2
-        with pytest.raises(ValueError, match="tile.load offset tuple element 0 must be ScalarType"):
+        with pytest.raises(ValueError, match=r"tile\.load offset tuple element 0 must be ScalarType"):
             tile.load(self._tensor(), nested_far, [64, 64])
 
     def _tile_var(self) -> ir.Var:
@@ -5151,7 +5151,7 @@ class TestTileLoadStoreOffsetElements:
     def test_store_rejects_tuple_offset_element(self):
         out = ir.Var("out", ir.TensorType([128, 128], DataType.FP32), ir.Span.unknown())
 
-        with pytest.raises(ValueError, match="tile.store offset tuple element 0 must be ScalarType"):
+        with pytest.raises(ValueError, match=r"tile\.store offset tuple element 0 must be ScalarType"):
             tile.store(self._tile_var(), self._nested_offsets(), out)
 
     def test_store_rejects_float_offset_element(self):
@@ -5159,7 +5159,7 @@ class TestTileLoadStoreOffsetElements:
         out = ir.Var("out", ir.TensorType([128, 128], DataType.FP32), span)
         offsets = [ir.ConstFloat(0.0, DataType.FP32, span), ir.ConstInt(0, DataType.INDEX, span)]
 
-        with pytest.raises(ValueError, match="tile.store offset tuple element 0 must have integer dtype"):
+        with pytest.raises(ValueError, match=r"tile\.store offset tuple element 0 must have integer dtype"):
             tile.store(self._tile_var(), offsets, out)
 
     def test_dsl_load_rejects_float_offset(self):

--- a/tests/ut/language/parser/test_closure_var_resolution.py
+++ b/tests/ut/language/parser/test_closure_var_resolution.py
@@ -13,10 +13,13 @@ Verifies that Python globals/closure variables used as positional arguments
 in function calls inside @pl.function bodies are resolved correctly.
 """
 
+import ast
+
 import pypto.language as pl
 import pytest
 from pypto import ir
 from pypto.language.parser.diagnostics import ParserTypeError, UndefinedVariableError
+from pypto.language.parser.expr_evaluator import ExprEvaluator
 
 
 def _first_call(func: ir.Function) -> ir.Call:
@@ -126,19 +129,21 @@ class TestClosureVarAsPositionalArg:
         assert _int_elements(load.args[2]) == [64, 64]
 
     def test_nested_list_closure_var(self):
-        """Nested list closure variable recursively converts to nested MakeTuple."""
-        OFFSETS = [[0, 0], [64, 64]]
+        """Nested list closure variable recursively converts to nested MakeTuple.
 
-        @pl.function
-        def func(
-            t: pl.Tensor[[128, 128], pl.FP32], out: pl.Tensor[[128, 128], pl.FP32]
-        ) -> pl.Tensor[[128, 128], pl.FP32]:
-            a: pl.Tile[[64, 64], pl.FP32] = pl.tile.load(t, OFFSETS, shapes=[64, 64])  # type: ignore[arg-type]
-            result: pl.Tensor[[128, 128], pl.FP32] = pl.tile.store(a, [0, 0], output_tensor=out)
-            return result
+        Asserted on the resolver a positional argument goes through, not through an
+        op call: no operator accepts a nested tuple. Every tuple-valued argument
+        slot in the registry requires integer-scalar elements, so an op used as the
+        vehicle here would (correctly) reject the nested MakeTuple this produces.
+        The op-call path itself is covered by the flat-list case above.
+        """
+        OFFSETS = [[0, 0], [64, 64]]
+        evaluator = ExprEvaluator({"OFFSETS": OFFSETS})
+
+        # The same call parse_name makes for a bare closure-var positional arg.
+        offsets = evaluator.try_eval_as_ir(ast.parse("OFFSETS", mode="eval").body)
 
         # The outer list becomes a MakeTuple whose elements are themselves MakeTuples
-        offsets = _first_call(func).args[1]
         assert isinstance(offsets, ir.MakeTuple)
         rows = list(offsets.elements)
         assert len(rows) == 2


### PR DESCRIPTION
## Summary

- validate that every element of `tile.load` / `tile.store` offsets is a `ScalarType` with an integer dtype, matching what `tensor.slice` already enforces for its own offsets
- restore the negative-offset and reads-past-the-end proofs, which a malformed offset element had been silently switching off
- re-anchor `test_nested_list_closure_var` on the closure-var resolver, since no operator accepts the nested tuple it builds

## Why

Both deducers checked only that the offsets argument is a `MakeTuple` of the right rank, never what its elements are — even though both op registrations declare offsets as `TupleType of ScalarType`.

Nothing downstream compensated, by design. `IsIntegerScalarExpr` treats a non-scalar operand as *undecidable* rather than false, and its comment already names the op deducers as the enforcement point:

> Operators that require stricter scalar-kind validation enforce it in their deducers.

So a malformed element did not merely produce a meaningless op — it disabled the bounds obligations in `InferWindowReadValidShape` too.

The result was a silent miscompile. A nested-tuple offset reached codegen, where `GetExprAsCode` reduced each element to whatever its visitor left behind:

```python
t = pl.load(a, [[11, 22], [33, 44]], [64, 64])   # offsets one level too deep
```

compiled clean, all the way to valid PTO:

```mlir
%0 = arith.maxsi %c22_index, %c0_index : index
%1 = arith.maxsi %c44_index, %c0_index : index
%a_pview = pto.partition_view %a_view, offsets = [%0, %1], sizes = [%c64_index, %c64_index]
```

— a load at offsets `[22, 44]`, wrong data, no diagnostic at any layer. A float offset (`n / 2` where the author meant `n // 2`) survived every pass and died in `EmitCastToIndex` with a message naming neither the operator nor a source location.

Offsets that are *provably* bad were affected the same way. With plain ints, `[100, 100]` and `[-8, 0]` are rejected by `tile.load` itself; wrapping them in a tuple made both checks pass.

## Notes for reviewers

**The bar is `IsInt()`, not `IsIndexLike()`.** `tile.slice` / `tile.assemble` require `IsIndexLike()` (INT64/UINT64/INDEX) for tile-local offsets, but a tensor-coordinate offset of any integer width is legitimate all the way down — `EmitCastToIndex` exists precisely to `arith.index_cast` a non-INDEX one at the `partition_view` site. `IsIndexLike()` here would reject INT32 offsets the backend is written to handle. This matches `tensor.slice`, the sibling window-read op.

**Origin.** #127 introduced this per-element check when it moved shape/offset args to `MakeTuple`, for `tensor.slice` / `tensor.view` / `block.view`. `block.load` still had a variadic `(row_offset, col_offset, height, width)` signature then, so it was out of scope. #154 converted it to the tuple form a week later and copied the `As<MakeTuple>` and rank checks — but not the element loop.

**Test change.** `test_nested_list_closure_var` asserted that a nested list closure var converts recursively to a nested `MakeTuple`, using `tile.load`'s offsets slot as the carrier. That parser behaviour is unchanged and still correct, but no operator in the registry accepts a nested tuple, so the test could only ever have ridden on the missing check. It now drives `ExprEvaluator.try_eval_as_ir` directly — the same call `parse_name` makes for a bare closure-var positional argument — keeping every assertion. The op-call path stays covered by the sibling flat-list test.

**Still open, not addressed here.** The `shapes` and `valid_shape` tuples on these same two ops remain unvalidated: `pl.tile.load(t, [0, 0], [64, 64], [[0, 0], [64, 64]])` is accepted and writes the nested tuple straight into `TileView.valid_shape`, printing as an unparseable `pl.TileView(valid_shape=[[...], [...]])`. Same bug family; the new helper is directly reusable for it. Left out to keep this change scoped to the reported issue.

## Testing

- `python -m pytest tests/ut/ir/operators/test_tile_ops.py -k TestTileLoadStoreOffsetElements -n "$PYPTO_TEST_JOBS" -v` — 7 new cases: tuple and float elements rejected on both ops, INT32 still accepted, bounds checks no longer bypassable, plus one DSL-level case
- `python -m pytest tests/ut/ tests/lint/ -n "$PYPTO_TEST_JOBS"` — 10604 passed, 3 skipped, 3 xfailed
- `ctest --parallel "$PYPTO_TEST_JOBS"` — 1/1 passed
- `pre-commit run --files src/ir/op/tile_ops/memory.cpp python/pypto/language/op/tile_ops.py tests/ut/ir/operators/test_tile_ops.py tests/ut/language/parser/test_closure_var_resolution.py`
