### PR TITLE
fix(ir): thread a scope's store-target rename out of the loop that produced it

### DIFF
--- a/docs/en/dev/passes/08-outline_incore_scopes.md
+++ b/docs/en/dev/passes/08-outline_incore_scopes.md
@@ -382,7 +382,7 @@ Rules the carry follows:
 **Codegen is unchanged.** The yielded value is the call's result on a parameter
 the callee returns, so
 [`ClassifyIterArgCarry`](47-classify_iter_arg_carry.md) puts it in the iter_arg's
-alias class (its Out/InOut-call and `TupleGetItemExpr` rules) and marks the carry
+alias class (its written-arg and `TupleGetItemExpr` rules) and marks the carry
 **trivial**: iter_arg and return_var both emit as the init value's name. The carry
 is SSA bookkeeping, not a new buffer. Nothing miscompiled without it either --
 every SSA version of an orchestration tensor denotes the same GM buffer -- but the

--- a/docs/en/dev/passes/08-outline_incore_scopes.md
+++ b/docs/en/dev/passes/08-outline_incore_scopes.md
@@ -51,8 +51,11 @@ program_outlined = outline_pass(program)
 5. **Replace Scope**: Replace `InCoreScopeStmt` with:
    - Call to outlined function with input arguments
    - AssignStmt for each output variable
-6. **Add to Program**: Add outlined function to program's function list
-7. **Promote the parent**: an Opaque parent that outlined at least one scope becomes
+6. **Thread control flow**: when the scope sat inside a loop or an `if`, the fresh
+   name bound for a captured store target becomes a real carry on that statement
+   (below)
+7. **Add to Program**: Add outlined function to program's function list
+8. **Promote the parent**: an Opaque parent that outlined at least one scope becomes
    `Orchestration` — and its param dyn-dim reads are folded first (below)
 
 **Param dyn-dim reads fold on promotion**: a tensor's declared extent *is* its
@@ -333,6 +336,57 @@ def main_incore_0(self, a, b, out):
     out_b = pl.mul(c_tile, 2.0)
     return (out, out_b)  # out_a → param `out`; out_b is kernel-local, kept as-is
 ```
+
+### Store Targets Written Inside Control Flow
+
+A scope that writes a captured tensor is replaced by a call whose result is bound
+to a *fresh* SSA name (`out` -> `out__ssa_v1`), and every later reference to that
+tensor resolves to the fresh one. When the scope sits inside a loop or an `if`,
+the fresh name is bound **inside the body**, so a reference after the statement
+would be reading a Var that is out of scope. The pass therefore threads the
+rename out as a real carry: the value on entry seeds a new `IterArg`, the body
+yields the fresh Var, and a new `return_var` is what the following statements see.
+
+**Before** (the scope writes `out` once per iteration, the ReturnStmt reads it):
+
+```python
+for i in pl.range(4):
+    with pl.at(level=pl.Level.CORE_GROUP):
+        t = pl.load(a, [i * 64, 0], [64, 128])
+        pl.store(pl.mul(t, 2.0), [i * 64, 0], out)
+return out
+```
+
+**After**:
+
+```python
+for i__idx_v0, (out__iter_v1,) in pl.range(4, init_values=(out__ssa_v0,)):
+    out__ssa_v1 = self.k_incore_0(a__ssa_v0, i__idx_v0, out__iter_v1)
+    out__rv_v1 = pl.yield_(out__ssa_v1)
+return out__rv_v1
+```
+
+An `if` gets the same treatment, and the branch that did not write yields the
+value it came in with — synthesising an `else` when the source had none, so the
+untaken path still produces a value.
+
+Rules the carry follows:
+
+| Situation | Result |
+| --------- | ------ |
+| N sibling scopes write one target in one body | one slot; the body yields the last value |
+| Nested loops | the inner carry re-emerges as the outer loop's carry |
+| The target already *is* one of the loop's iter_args | no new slot; later references resolve to that slot's `return_var` |
+| Scope at the function's top level | unchanged — the fresh name is already in scope |
+
+**Codegen is unchanged.** The yielded value is the call's result on a parameter
+the callee returns, so
+[`ClassifyIterArgCarry`](47-classify_iter_arg_carry.md) puts it in the iter_arg's
+alias class (its Out/InOut-call and `TupleGetItemExpr` rules) and marks the carry
+**trivial**: iter_arg and return_var both emit as the init value's name. The carry
+is SSA bookkeeping, not a new buffer. Nothing miscompiled without it either --
+every SSA version of an orchestration tensor denotes the same GM buffer -- but the
+def-use graph was wrong, and `SSAVerify` / `UseAfterDef` reject that IR.
 
 ## Implementation
 

--- a/docs/en/dev/passes/47-classify_iter_arg_carry.md
+++ b/docs/en/dev/passes/47-classify_iter_arg_carry.md
@@ -39,13 +39,20 @@ source, so the edges form a forest and the class query is a memoized chain walk
 | Rule | Edge |
 | ---- | ---- |
 | `tensor.assemble` | the result aliases `args[0]` (the write target) |
-| Out / InOut call | the result aliases the Out/InOut arg the callee actually *returns* (traced via `return_lineage`, so a GM-scratch Out param never captures the alias) |
+| output-side call | the result aliases the written arg the callee actually *returns* (traced via `return_lineage`, so a GM-scratch Out param never captures the alias) |
 | `TupleGetItemExpr` | `ret_tuple[i]` aliases the i-th output-side arg of the tuple-producing `Call` / `Submit` |
 | nested `ForStmt` | a carry threaded through a nested loop re-emerges as that loop's `return_var`, which aliases the nested loop's init value |
 
-The assemble rule and the Out/InOut rule can never both fire on one assignment:
+The assemble rule and the output-side rule can never both fire on one assignment:
 `tensor.assemble` is a builtin op, and `DeriveCallDirections` stamps
 `arg_directions` on non-builtin calls only.
+
+**Output-side means `OutputExisting` / `InOut` / `Output` / `NoDep`.** `NoDep`
+(from `pl.at(no_dep_args=[t])`) is an *ordering* claim, not an identity one: the
+callee still writes through that same tensor and returns it. Codegen's own alias
+(`CollectOutIndices`) reads the *callee's* `ParamDirection`, which `no_dep_args`
+never touches — so leaving `NoDep` out here made the two disagree, classifying a
+`no_dep` carry as `rebind` while codegen simultaneously aliased that slot.
 
 `ArrayType` iter_args are **excluded** from the nested-loop rule. Unlike a
 `TensorType` (a pointer-to-buffer alias), an `ArrayType` iter_arg owns a *fresh*

--- a/docs/en/dev/passes/47-classify_iter_arg_carry.md
+++ b/docs/en/dev/passes/47-classify_iter_arg_carry.md
@@ -47,12 +47,15 @@ The assemble rule and the output-side rule can never both fire on one assignment
 `tensor.assemble` is a builtin op, and `DeriveCallDirections` stamps
 `arg_directions` on non-builtin calls only.
 
-**Output-side means `OutputExisting` / `InOut` / `Output` / `NoDep`.** `NoDep`
-(from `pl.at(no_dep_args=[t])`) is an *ordering* claim, not an identity one: the
-callee still writes through that same tensor and returns it. Codegen's own alias
-(`CollectOutIndices`) reads the *callee's* `ParamDirection`, which `no_dep_args`
-never touches — so leaving `NoDep` out here made the two disagree, classifying a
-`no_dep` carry as `rebind` while codegen simultaneously aliased that slot.
+**Which arg is written is read off the *callee's* `ParamDirection`, never the
+call-site `ArgDirection`** — the same source codegen's own alias
+(`CollectOutIndices`) uses, so the two agree by construction. The call-site view
+cannot answer the question: `pl.at(no_dep_args=[t])` overwrites whatever
+direction a slot had with `NoDep`, and it accepts *any* tensor the scope
+captures, read or written. Reading it would both miss a genuine write and, if
+`NoDep` were simply admitted, invent one on a read-only slot — which in the
+positional `TupleGetItemExpr` walk shifts every later output's index onto the
+wrong arg.
 
 `ArrayType` iter_args are **excluded** from the nested-loop rule. Unlike a
 `TensorType` (a pointer-to-buffer alias), an `ArrayType` iter_arg owns a *fresh*

--- a/docs/zh/dev/passes/08-outline_incore_scopes.md
+++ b/docs/zh/dev/passes/08-outline_incore_scopes.md
@@ -341,7 +341,7 @@ return out__rv_v1
 
 **代码生成不受影响。** yield 的值是被调函数在其返回的参数上的调用结果，因此
 [`ClassifyIterArgCarry`](47-classify_iter_arg_carry.md) 会把它归入该 iter_arg 的别名类
-（其 Out/InOut 调用规则与 `TupleGetItemExpr` 规则），并将该携带值标记为 **trivial**：
+（其被写实参规则与 `TupleGetItemExpr` 规则），并将该携带值标记为 **trivial**：
 iter_arg 与 return_var 都按初值的名字发射。这个携带值是 SSA 记账，而非新缓冲区。
 没有它同样不会编译错——编排层张量的每个 SSA 版本都指向同一块 GM 缓冲区——但 def-use
 图是错的，`SSAVerify` / `UseAfterDef` 会拒绝这样的 IR。

--- a/docs/zh/dev/passes/08-outline_incore_scopes.md
+++ b/docs/zh/dev/passes/08-outline_incore_scopes.md
@@ -50,8 +50,10 @@ program_outlined = outline_pass(program)
 5. **替换作用域**：将 `InCoreScopeStmt` 替换为：
    - 带有输入参数的提取函数调用
    - 每个输出变量对应一个 AssignStmt
-6. **添加到程序**：将提取的函数添加到程序的函数列表中
-7. **提升父函数**：至少提取出一个作用域的 Opaque 父函数将变为 `Orchestration`——
+6. **贯穿控制流**：当作用域位于循环或 `if` 内部时，为被捕获的写目标绑定的新名字会
+   变成该语句上真正的循环携带值（loop carry，见下）
+7. **添加到程序**：将提取的函数添加到程序的函数列表中
+8. **提升父函数**：至少提取出一个作用域的 Opaque 父函数将变为 `Orchestration`——
    并在此之前先折叠其参数动态维度读取（见下）
 
 **参数动态维度读取在提升时折叠**：tensor 声明的 extent *就是*它的运行期
@@ -296,6 +298,53 @@ def main_incore_0(self, a, b, out):
     out_b = pl.mul(c_tile, 2.0)
     return (out, out_b)  # out_a → param `out`; out_b is kernel-local, kept as-is
 ```
+
+### 在控制流内部写入的写目标（store target）
+
+写入被捕获张量的作用域会被替换为一次调用，其结果绑定到一个**全新的** SSA 名字
+（`out` -> `out__ssa_v1`），此后对该张量的每一次引用都解析到这个新名字。当作用域位于
+循环或 `if` 内部时，这个新名字绑定在**作用域体内部**，因此语句之后的引用读到的是一个
+已经超出作用域（out of scope）的 Var。为此本 pass 将该重命名贯穿出去，做成真正的循环
+携带值（loop carry）：入口处的值作为新 `IterArg` 的初值，作用域体 yield 新的 Var，
+新增的 `return_var` 才是后续语句看到的值。
+
+**变换前**（作用域每次迭代写一次 `out`，ReturnStmt 读取它）：
+
+```python
+for i in pl.range(4):
+    with pl.at(level=pl.Level.CORE_GROUP):
+        t = pl.load(a, [i * 64, 0], [64, 128])
+        pl.store(pl.mul(t, 2.0), [i * 64, 0], out)
+return out
+```
+
+**变换后**：
+
+```python
+for i__idx_v0, (out__iter_v1,) in pl.range(4, init_values=(out__ssa_v0,)):
+    out__ssa_v1 = self.k_incore_0(a__ssa_v0, i__idx_v0, out__iter_v1)
+    out__rv_v1 = pl.yield_(out__ssa_v1)
+return out__rv_v1
+```
+
+`if` 同样如此处理，未写入的分支 yield 它进入时的值——源码没有 `else` 时会合成一个，
+使未走到的路径也能产出一个值。
+
+携带值遵循的规则：
+
+| 场景 | 结果 |
+| ---- | ---- |
+| 同一作用域体内 N 个同级作用域写同一目标 | 只增加一个槽位；作用域体 yield 最后一个值 |
+| 嵌套循环 | 内层携带值再作为外层循环的携带值贯穿出去 |
+| 目标本身已是该循环的 iter_arg | 不新增槽位；后续引用解析到该槽位的 `return_var` |
+| 作用域位于函数顶层 | 保持不变——新名字本就在作用域内 |
+
+**代码生成不受影响。** yield 的值是被调函数在其返回的参数上的调用结果，因此
+[`ClassifyIterArgCarry`](47-classify_iter_arg_carry.md) 会把它归入该 iter_arg 的别名类
+（其 Out/InOut 调用规则与 `TupleGetItemExpr` 规则），并将该携带值标记为 **trivial**：
+iter_arg 与 return_var 都按初值的名字发射。这个携带值是 SSA 记账，而非新缓冲区。
+没有它同样不会编译错——编排层张量的每个 SSA 版本都指向同一块 GM 缓冲区——但 def-use
+图是错的，`SSAVerify` / `UseAfterDef` 会拒绝这样的 IR。
 
 ## 实现
 

--- a/docs/zh/dev/passes/47-classify_iter_arg_carry.md
+++ b/docs/zh/dev/passes/47-classify_iter_arg_carry.md
@@ -44,11 +44,12 @@ fence 算子，不会改动 Orchestration `ForStmt` 的 iter_arg。
 assemble 规则与输出侧规则不可能在同一条赋值上同时命中：`tensor.assemble` 是
 builtin op，而 `DeriveCallDirections` 只给非 builtin 调用打 `arg_directions`。
 
-**输出侧（output-side）指 `OutputExisting` / `InOut` / `Output` / `NoDep`。**
-`NoDep`（来自 `pl.at(no_dep_args=[t])`）表达的是*顺序*断言，而非身份断言：callee 仍然
-通过同一个张量写入并返回它。代码生成自身的别名（`CollectOutIndices`）读取的是 *callee 的*
-`ParamDirection`，而 `no_dep_args` 从不改动它——因此这里遗漏 `NoDep` 会让两者产生分歧：
-携带值被判定为 `rebind`，而代码生成同时又对该槽位做了别名。
+**哪个实参被写入，一律读取 *callee 的* `ParamDirection`，绝不读调用点的
+`ArgDirection`**——这与代码生成自身的别名（`CollectOutIndices`）取自同一处，因此两者
+天然一致。调用点视角回答不了这个问题：`pl.at(no_dep_args=[t])` 会把槽位原有的方向直接
+覆写为 `NoDep`，而且它接受作用域捕获的*任意*张量，无论只读还是写入。据此判断既会漏掉
+真实的写入，又会在只读槽位上凭空造出一个写入——在下面按位置遍历的 `TupleGetItemExpr`
+路径中，这会把之后每一个输出的下标都错位到别的实参上。
 
 `ArrayType` 的 iter_arg 被**排除**在嵌套循环规则之外。与 `TensorType`（指向缓冲区的
 指针别名）不同，`ArrayType` iter_arg 在每一层都拥有一份*全新的* C 栈数组。把内层

--- a/docs/zh/dev/passes/47-classify_iter_arg_carry.md
+++ b/docs/zh/dev/passes/47-classify_iter_arg_carry.md
@@ -37,12 +37,18 @@ fence 算子，不会改动 Orchestration `ForStmt` 的 iter_arg。
 | 规则 | 边 |
 | ---- | -- |
 | `tensor.assemble` | 结果别名到 `args[0]`（写入目标） |
-| Out / InOut 调用 | 结果别名到 callee 真正*返回*的那个 Out/InOut 实参（经 `return_lineage` 追踪，因此 GM scratch 的 Out 参数不会误抢别名） |
+| 输出侧（output-side）调用 | 结果别名到 callee 真正*返回*的那个被写实参（经 `return_lineage` 追踪，因此 GM scratch 的 Out 参数不会误抢别名） |
 | `TupleGetItemExpr` | `ret_tuple[i]` 别名到产生该 tuple 的 `Call` / `Submit` 的第 i 个输出侧实参 |
 | 嵌套 `ForStmt` | 穿过嵌套循环的 carry 以该循环的 `return_var` 重新出现，而它别名到嵌套循环的 init 值 |
 
-assemble 规则与 Out/InOut 规则不可能在同一条赋值上同时命中：`tensor.assemble` 是
+assemble 规则与输出侧规则不可能在同一条赋值上同时命中：`tensor.assemble` 是
 builtin op，而 `DeriveCallDirections` 只给非 builtin 调用打 `arg_directions`。
+
+**输出侧（output-side）指 `OutputExisting` / `InOut` / `Output` / `NoDep`。**
+`NoDep`（来自 `pl.at(no_dep_args=[t])`）表达的是*顺序*断言，而非身份断言：callee 仍然
+通过同一个张量写入并返回它。代码生成自身的别名（`CollectOutIndices`）读取的是 *callee 的*
+`ParamDirection`，而 `no_dep_args` 从不改动它——因此这里遗漏 `NoDep` 会让两者产生分歧：
+携带值被判定为 `rebind`，而代码生成同时又对该槽位做了别名。
 
 `ArrayType` 的 iter_arg 被**排除**在嵌套循环规则之外。与 `TensorType`（指向缓冲区的
 指针别名）不同，`ArrayType` iter_arg 在每一层都拥有一份*全新的* C 栈数组。把内层

--- a/include/pypto/ir/transforms/utils/scope_outline_utils.h
+++ b/include/pypto/ir/transforms/utils/scope_outline_utils.h
@@ -208,7 +208,100 @@ class ScopeOutliner : public IRMutator {
   // the nested SplitAivScopeStmt inside the outlined InCore function body.
   StmtPtr VisitStmt_(const SplitAivScopeStmtPtr& op) override;
 
+  /**
+   * @brief Thread store-target renames made inside a control-flow body out of it.
+   *
+   * A scope that writes a captured tensor is replaced by a call whose result is
+   * bound to a *fresh* SSA name (see CreateFreshStoreTargetVar). When that scope
+   * sits inside a loop or an ``if``, the fresh Var is bound inside the body and
+   * is therefore out of scope afterwards — but ``store_target_renames_`` is flat
+   * and function-wide, so without these overrides every later reference to the
+   * store target still resolves to that body-local Var. The result reads as
+   * ``for ...: t__ssa_v1 = self.k_incore_0(..., t__ssa_v0)`` followed by a use of
+   * ``t__ssa_v1`` after the loop: a dangling reference that ``SSAVerify`` rejects
+   * ("used outside its defining scope").
+   *
+   * Nothing miscompiles today only because every SSA version of an orchestration
+   * tensor denotes the same GM buffer. The def-use edge is still wrong, so each
+   * override rebuilds the statement with a real carry: the value on entry seeds a
+   * new ``IterArg``, the body yields the fresh Var, and a new ``return_var``
+   * becomes the value visible afterwards. ``ClassifyIterArgCarry`` (pass 47) sees
+   * the yield in the iter_arg's alias class (the Out-call and TupleGetItem rules)
+   * and marks the carry *trivial*, so codegen is unchanged.
+   */
+  StmtPtr VisitStmt_(const ForStmtPtr& op) override;
+  StmtPtr VisitStmt_(const WhileStmtPtr& op) override;
+  StmtPtr VisitStmt_(const IfStmtPtr& op) override;
+
  private:
+  /// One store target that a control-flow body renamed, and the values that
+  /// bracket the body.
+  struct BodyStoreRename {
+    VarPtr original;                  ///< the ``store_target_renames_`` key (always the *original* Var)
+    VarPtr seed;                      ///< the value current on entry to the body — the carry's init
+    std::vector<VarPtr> body_values;  ///< values bound inside the body, in order; the last is yielded
+  };
+
+  /// Record @p fresh as the current value of store target @p original.
+  ///
+  /// When a control-flow body is open, the rename is also noted on the innermost
+  /// frame so that body can thread it out as a carry. @p seed is the value
+  /// current *before* the rename; a target renamed by N sibling scopes in one
+  /// body keeps the first seed and appends each value, because the intermediate
+  /// ones may still be held by a post-store alias entry that the publish sweep
+  /// has to retarget too.
+  void NoteStoreTargetRename(const VarPtr& original, const VarPtr& seed, const VarPtr& fresh);
+
+  /// Visit @p body with a fresh control-flow frame open, collecting into @p renames
+  /// every store target the body renamed.
+  StmtPtr VisitControlFlowBody(const StmtPtr& body, std::vector<BodyStoreRename>* renames);
+
+  /// One fresh ``IterArg`` per rename, seeded with that rename's entry value.
+  [[nodiscard]] std::vector<IterArgPtr> MakeCarryIterArgs(const std::vector<BodyStoreRename>& renames,
+                                                          const Span& span);
+
+  /// One fresh return ``Var`` per rename — the value visible after the statement.
+  [[nodiscard]] std::vector<VarPtr> MakeCarryReturnVars(const std::vector<BodyStoreRename>& renames,
+                                                        const Span& span);
+
+  /// Rebind @p body onto @p carry_iter_args and append each rename's last value
+  /// to its trailing yield (adding one when the loop carried nothing before).
+  ///
+  /// The seed is defined *outside* the loop, so every reference to it inside the
+  /// body means "this buffer" — which is exactly what the carry now names.
+  /// @p total_carries is the expected post-append yield arity, checked here.
+  [[nodiscard]] StmtPtr BuildCarriedLoopBody(const StmtPtr& body, const std::vector<BodyStoreRename>& renames,
+                                             const std::vector<IterArgPtr>& carry_iter_args,
+                                             size_t total_carries, const Span& span) const;
+
+  /// Point every ``store_target_renames_`` entry holding one of @p renames'
+  /// body-local values at the matching entry of @p visible_values.
+  ///
+  /// The sweep is by *value*, not by key: OutlineScope also registers
+  /// scope-local post-store aliases that name the same store target, and those
+  /// entries hold a body-local Var that is equally out of scope afterwards.
+  void RetargetBodyValues(const std::vector<BodyStoreRename>& renames,
+                          const std::vector<VarPtr>& visible_values);
+
+  /// RetargetBodyValues, plus telling the enclosing control-flow frame (if any)
+  /// about each carry, so a nested loop's carry is threaded on out of the outer
+  /// loop too.
+  void PublishCarries(const std::vector<BodyStoreRename>& renames, const std::vector<VarPtr>& return_vars);
+
+  /// Split @p renames into the ones this loop must newly carry (@p fresh) and the
+  /// ones it already carries (@p carried, with their post-loop @p carried_values).
+  ///
+  /// A store target that *is* one of the loop's own iter_args is already threaded
+  /// through the loop; giving it a second carry seeded with itself would make the
+  /// loop carry its own carry, and the seed would not even be in scope at the
+  /// loop header. Its post-loop value is simply the matching return_var.
+  void SplitAlreadyCarried(const std::vector<BodyStoreRename>& renames,
+                           const std::vector<IterArgPtr>& iter_args,
+                           const std::vector<IterArgPtr>& visited_iter_args,
+                           const std::vector<VarPtr>& return_vars, const Span& span,
+                           std::vector<BodyStoreRename>* fresh, std::vector<BodyStoreRename>* carried,
+                           std::vector<VarPtr>* carried_values) const;
+
   /// True when `name` is already claimed by this function (`known_names_`) or,
   /// when the pass opts in, by any earlier function in the program
   /// (`reserved_func_names_`).
@@ -247,8 +340,16 @@ class ScopeOutliner : public IRMutator {
    * @brief Generate a fresh SSA name by incrementing the numeric suffix.
    *
    * E.g. "buf_0" -> "buf_1", "x_2" -> "x_3".  Falls back to appending "_1".
+   *
+   * @param role Optional SSA role to stamp instead of the name's current one —
+   *             ``"iter"`` for a loop carry, ``"rv"`` for a return var, matching
+   *             what ConvertToSSA emits. Empty keeps the existing role.
    */
-  [[nodiscard]] std::string GenerateFreshSSAName(const std::string& original_name) const;
+  [[nodiscard]] std::string GenerateFreshSSAName(const std::string& original_name,
+                                                 const std::string& role = "") const;
+
+  /// Register @p var in the symbol table so later fresh-name generation avoids it.
+  void RegisterVar(const VarPtr& var);
 
   /**
    * @brief Create a fresh Var for a store-target output and register the rename.
@@ -312,7 +413,16 @@ class ScopeOutliner : public IRMutator {
   std::unordered_set<const Var*> required_outputs_;
   /// Accumulates across scopes intentionally (not saved/restored like func_name_
   /// etc.) so that subsequent scopes and statements see the renamed variables.
+  ///
+  /// Flat and function-wide, so an entry outlives the control-flow body that
+  /// created it. The ForStmt / WhileStmt / IfStmt overrides are what keep that
+  /// safe: they retarget each entry onto a value the following statements can
+  /// actually see. Do not write this map directly from a path that can run
+  /// inside a control-flow body — go through NoteStoreTargetRename so the
+  /// enclosing frame learns the rename and can thread it out.
   std::unordered_map<const Var*, VarPtr> store_target_renames_;
+  /// Open control-flow frames, innermost last. Empty at the function's top level.
+  std::vector<std::vector<BodyStoreRename>> body_rename_stack_;
   ScopeKind target_scope_kind_;
   FunctionType outlined_func_type_;
   std::string name_suffix_;

--- a/include/pypto/ir/transforms/utils/scope_outline_utils.h
+++ b/include/pypto/ir/transforms/utils/scope_outline_utils.h
@@ -274,16 +274,33 @@ class ScopeOutliner : public IRMutator {
                                              const std::vector<IterArgPtr>& carry_iter_args,
                                              size_t total_carries, const Span& span) const;
 
+  /// Record @p fresh as the current value of store target @p original, keeping
+  /// ``renamed_by_value_`` in step. Every write to ``store_target_renames_``
+  /// goes through here.
+  void SetStoreTargetRename(const VarPtr& original, const VarPtr& fresh);
+
+  /// Undo @p renames, putting each store target back to the value its body was
+  /// entered with. Used between the two arms of an ``if``, which are
+  /// alternatives rather than a sequence.
+  void RewindRenames(const std::vector<BodyStoreRename>& renames);
+
   /// Point every ``store_target_renames_`` entry holding one of @p renames'
   /// body-local values at the matching entry of @p visible_values.
   ///
-  /// The sweep is by *value*, not by key: OutlineScope also registers
+  /// Keyed by *value*, not by store target: OutlineScope also registers
   /// scope-local post-store aliases that name the same store target, and those
   /// entries hold a body-local Var that is equally out of scope afterwards.
+  /// Reached through ``renamed_by_value_`` rather than by scanning the map, so
+  /// the cost is proportional to the entries that actually move.
   void RetargetBodyValues(const std::vector<BodyStoreRename>& renames,
                           const std::vector<VarPtr>& visible_values);
 
-  /// RetargetBodyValues, plus telling the enclosing control-flow frame (if any)
+  /// RetargetBodyValues, plus pointing each store target itself at its
+  /// @p visible_values entry.
+  void RetargetCarries(const std::vector<BodyStoreRename>& renames,
+                       const std::vector<VarPtr>& visible_values);
+
+  /// RetargetCarries, plus telling the enclosing control-flow frame (if any)
   /// about each carry, so a nested loop's carry is threaded on out of the outer
   /// loop too.
   void PublishCarries(const std::vector<BodyStoreRename>& renames, const std::vector<VarPtr>& return_vars);
@@ -421,6 +438,14 @@ class ScopeOutliner : public IRMutator {
   /// inside a control-flow body — go through NoteStoreTargetRename so the
   /// enclosing frame learns the rename and can thread it out.
   std::unordered_map<const Var*, VarPtr> store_target_renames_;
+  /// Reverse index over ``store_target_renames_``: which keys currently resolve
+  /// to a given Var. Lets a control-flow node retarget the entries that name a
+  /// value going out of scope without scanning the whole (ever-growing) map,
+  /// which would make the pass quadratic in the number of control-flow nodes
+  /// (.claude/rules/pass-complexity.md). Buckets may hold stale keys — a key
+  /// retargeted since is skipped on the next visit — so every read re-checks
+  /// the forward map.
+  std::unordered_map<const Var*, std::vector<const Var*>> renamed_by_value_;
   /// Open control-flow frames, innermost last. Empty at the function's top level.
   std::vector<std::vector<BodyStoreRename>> body_rename_stack_;
   ScopeKind target_scope_kind_;

--- a/src/ir/transforms/classify_iter_arg_carry_pass.cpp
+++ b/src/ir/transforms/classify_iter_arg_carry_pass.cpp
@@ -101,20 +101,52 @@ ForStmtPtr FindForStmtByReturnVar(const StmtPtr& body, const Var* target) {
   return finder.result;
 }
 
-/// True when @p dir names an argument slot the callee writes — i.e. one that
-/// orchestration codegen aliases the call's result to.
+/// Argument slots the callee writes, in order — codegen's ``CollectOutIndices``.
 ///
-/// ``NoDep`` belongs here. It is an *ordering* claim (``pl.at(no_dep_args=[t])``
-/// suppresses the dependency edges), not an identity one: the callee still
-/// writes through that same tensor and returns it, and codegen's own alias
-/// (``CollectOutIndices``) reads the *callee's* ``ParamDirection``, which
-/// ``no_dep_args`` never touches. Omitting it here made codegen and this pass
-/// disagree about one call — the carry was classified ``rebind``, so codegen
-/// materialised a fresh ``TaskTensor`` for a slot it was simultaneously
-/// aliasing.
-[[nodiscard]] bool IsOutputSideDirection(ArgDirection dir) {
-  return dir == ArgDirection::OutputExisting || dir == ArgDirection::InOut || dir == ArgDirection::Output ||
-         dir == ArgDirection::NoDep;
+/// Read off the *callee's* ``ParamDirection``, which is the only thing
+/// orchestration codegen consults when it aliases a call's result to an arg. The
+/// call-site ``ArgDirection`` is not a usable stand-in: ``pl.at(no_dep_args=[t])``
+/// overwrites whatever direction a slot had with ``NoDep``, and it accepts *any*
+/// tensor the scope captures — read or written. So the call-site view both loses
+/// a genuine write and, if ``NoDep`` were simply admitted, invents one on a
+/// read-only slot, which shifts every later index in the positional walk below.
+///
+/// Indices are param indices. They double as arg indices only where the two
+/// coincide; every caller range-checks against ``args_.size()`` before use,
+/// which is also what keeps a ``Submit``'s runtime-allocated (uncovered) params
+/// out — those have no caller-supplied arg to alias to.
+[[nodiscard]] std::vector<size_t> CalleeWrittenParamIndices(const FunctionPtr& callee) {
+  std::vector<size_t> indices;
+  if (!callee) return indices;
+  const auto& dirs = callee->param_directions_;
+  for (size_t i = 0; i < dirs.size(); ++i) {
+    if (dirs[i] == ParamDirection::Out || dirs[i] == ParamDirection::InOut) indices.push_back(i);
+  }
+  return indices;
+}
+
+/// The arg @p call's return-tuple element @p position aliases, or null.
+///
+/// Mirrors ``OrchestrationCodegen::GenerateTupleReturnAliases`` exactly: prefer
+/// the callee's explicit returned-param map, and fall back to the i-th written
+/// param only when the callee has no ReturnStmt to read.
+[[nodiscard]] const Var* CalleeReturnedArg(const CallPtr& call, const FunctionPtr& callee, size_t position) {
+  const auto ret_map = return_lineage::ExplicitReturnedParamIndices(callee);
+  std::optional<size_t> param_idx;
+  if (position < ret_map.size()) param_idx = ret_map[position];
+  if (!param_idx.has_value()) {
+    // The callee's ReturnStmt names no param at this position — it has none, or
+    // it returns a value (``return pl.store(...)``) rather than the param that
+    // store wrote. Codegen falls back to the position-th written param here
+    // (``returned_idx.value_or(out_indices[0])``); match it.
+    auto written = CalleeWrittenParamIndices(callee);
+    if (position < written.size()) param_idx = written[position];
+  }
+  // No mapping, or a runtime-allocated param the caller never passed: there is
+  // no arg to alias to.
+  if (!param_idx.has_value() || *param_idx >= call->args_.size()) return nullptr;
+  auto out_arg = AsVarLike(call->args_[*param_idx]);
+  return out_arg ? out_arg.get() : nullptr;
 }
 
 /// Alias forest over a loop body: maps each Var that is *another name for an
@@ -232,19 +264,8 @@ class AliasForest {
       if (it == var_to_assign.end()) return nullptr;
       auto tcall = transform_utils::AsCallOrSubmitView(it->second->value_);
       if (!tcall) return nullptr;
-      auto tdirs = tcall->GetArgDirections();
-      if (tdirs.size() != tcall->args_.size()) return nullptr;
-      int64_t out_seen = 0;
-      const auto target_idx = static_cast<int64_t>(tge->index_);
-      for (size_t a = 0; a < tdirs.size(); ++a) {
-        if (!IsOutputSideDirection(tdirs[a])) continue;
-        if (out_seen == target_idx) {
-          auto out_arg = AsVarLike(tcall->args_[a]);
-          return out_arg ? out_arg.get() : nullptr;
-        }
-        ++out_seen;
-      }
-      return nullptr;
+      FunctionPtr tcallee = program ? program->GetFunction(tcall->op_->name_) : nullptr;
+      return CalleeReturnedArg(tcall, tcallee, static_cast<size_t>(tge->index_));
     }
 
     auto call = transform_utils::AsCallOrSubmitView(assign->value_);
@@ -256,23 +277,19 @@ class AliasForest {
       return first_arg ? first_arg.get() : nullptr;
     }
 
-    // Calls with output-side args (e.g. InCore kernels): the result aliases the
-    // Out/InOut arg the callee actually returns, mirroring the codegen alias
-    // ``const TaskTensor& result = args[out_idx];``. For kernels with multiple
-    // Out params (e.g. real result + GM scratch passed through pl.spmd mixed
-    // dispatch), tracing the ReturnStmt back to its Param avoids aliasing the
-    // result to an arbitrary scratch tensor.
+    // A single-result call to a kernel that writes one of its args (e.g. an
+    // InCore kernel): the result aliases the arg the callee actually returns,
+    // mirroring the codegen alias ``const TaskTensor& result = args[out_idx];``.
+    // For kernels with multiple Out params (e.g. real result + GM scratch passed
+    // through pl.spmd mixed dispatch), tracing the ReturnStmt back to its Param
+    // avoids aliasing the result to an arbitrary scratch tensor.
+    //
+    // Gated on the call carrying arg_directions, which is what marks it as a
+    // non-builtin dispatch DeriveCallDirections has processed.
     auto call_dirs = call->GetArgDirections();
     if (call_dirs.size() != call->args_.size()) return nullptr;
     FunctionPtr callee = program ? program->GetFunction(call->op_->name_) : nullptr;
-    std::optional<size_t> returned_idx = return_lineage::ExplicitReturnedParamIndex(callee);
-    for (size_t a = 0; a < call_dirs.size(); ++a) {
-      if (!IsOutputSideDirection(call_dirs[a])) continue;
-      if (returned_idx.has_value() && a != *returned_idx) continue;
-      auto out_arg = AsVarLike(call->args_[a]);
-      return out_arg ? out_arg.get() : nullptr;
-    }
-    return nullptr;
+    return CalleeReturnedArg(call, callee, 0);
   }
 
   std::unordered_set<const Var*> roots_;

--- a/src/ir/transforms/classify_iter_arg_carry_pass.cpp
+++ b/src/ir/transforms/classify_iter_arg_carry_pass.cpp
@@ -101,6 +101,22 @@ ForStmtPtr FindForStmtByReturnVar(const StmtPtr& body, const Var* target) {
   return finder.result;
 }
 
+/// True when @p dir names an argument slot the callee writes — i.e. one that
+/// orchestration codegen aliases the call's result to.
+///
+/// ``NoDep`` belongs here. It is an *ordering* claim (``pl.at(no_dep_args=[t])``
+/// suppresses the dependency edges), not an identity one: the callee still
+/// writes through that same tensor and returns it, and codegen's own alias
+/// (``CollectOutIndices``) reads the *callee's* ``ParamDirection``, which
+/// ``no_dep_args`` never touches. Omitting it here made codegen and this pass
+/// disagree about one call — the carry was classified ``rebind``, so codegen
+/// materialised a fresh ``TaskTensor`` for a slot it was simultaneously
+/// aliasing.
+[[nodiscard]] bool IsOutputSideDirection(ArgDirection dir) {
+  return dir == ArgDirection::OutputExisting || dir == ArgDirection::InOut || dir == ArgDirection::Output ||
+         dir == ArgDirection::NoDep;
+}
+
 /// Alias forest over a loop body: maps each Var that is *another name for an
 /// existing buffer* to the Var it aliases.
 ///
@@ -108,7 +124,7 @@ ForStmtPtr FindForStmtByReturnVar(const StmtPtr& body, const Var* target) {
 /// ``X → source(X) → …`` lands on ``A``. Four rules produce an edge:
 ///
 ///   * ``tensor.assemble``: the result aliases its first arg (the write target).
-///   * Output_existing/inout calls: the result aliases the Out/InOut arg the
+///   * Calls with output-side args: the result aliases the Out/InOut arg the
 ///     callee actually returns (traced via ``return_lineage``, so a kernel with
 ///     a GM-scratch Out param does not capture the alias).
 ///   * ``TupleGetItemExpr``: climb to the tuple-producing call/submit and
@@ -221,10 +237,7 @@ class AliasForest {
       int64_t out_seen = 0;
       const auto target_idx = static_cast<int64_t>(tge->index_);
       for (size_t a = 0; a < tdirs.size(); ++a) {
-        if (tdirs[a] != ArgDirection::OutputExisting && tdirs[a] != ArgDirection::InOut &&
-            tdirs[a] != ArgDirection::Output) {
-          continue;
-        }
+        if (!IsOutputSideDirection(tdirs[a])) continue;
         if (out_seen == target_idx) {
           auto out_arg = AsVarLike(tcall->args_[a]);
           return out_arg ? out_arg.get() : nullptr;
@@ -243,18 +256,18 @@ class AliasForest {
       return first_arg ? first_arg.get() : nullptr;
     }
 
-    // Calls with output_existing/inout args (e.g. InCore kernels): the result
-    // aliases the Out/InOut arg the callee actually returns, mirroring the
-    // codegen alias ``const TaskTensor& result = args[out_idx];``. For kernels with
-    // multiple Out params (e.g. real result + GM scratch passed through pl.spmd
-    // mixed dispatch), tracing the ReturnStmt back to its Param avoids aliasing
-    // the result to an arbitrary scratch tensor.
+    // Calls with output-side args (e.g. InCore kernels): the result aliases the
+    // Out/InOut arg the callee actually returns, mirroring the codegen alias
+    // ``const TaskTensor& result = args[out_idx];``. For kernels with multiple
+    // Out params (e.g. real result + GM scratch passed through pl.spmd mixed
+    // dispatch), tracing the ReturnStmt back to its Param avoids aliasing the
+    // result to an arbitrary scratch tensor.
     auto call_dirs = call->GetArgDirections();
     if (call_dirs.size() != call->args_.size()) return nullptr;
     FunctionPtr callee = program ? program->GetFunction(call->op_->name_) : nullptr;
     std::optional<size_t> returned_idx = return_lineage::ExplicitReturnedParamIndex(callee);
     for (size_t a = 0; a < call_dirs.size(); ++a) {
-      if (call_dirs[a] != ArgDirection::OutputExisting && call_dirs[a] != ArgDirection::InOut) continue;
+      if (!IsOutputSideDirection(call_dirs[a])) continue;
       if (returned_idx.has_value() && a != *returned_idx) continue;
       auto out_arg = AsVarLike(call->args_[a]);
       return out_arg ? out_arg.get() : nullptr;

--- a/src/ir/transforms/utils/scope_outline_utils.cpp
+++ b/src/ir/transforms/utils/scope_outline_utils.cpp
@@ -1054,15 +1054,56 @@ void ScopeOutliner::RetargetBodyValues(const std::vector<BodyStoreRename>& renam
                                        const std::vector<VarPtr>& visible_values) {
   INTERNAL_CHECK(renames.size() == visible_values.size())
       << "Internal error: carry value count does not match the rename count";
-  std::unordered_map<const Var*, VarPtr> visible;
+  // Visit only the entries that actually hold one of this body's values, found
+  // through the reverse index. Sweeping the whole map instead would cost the
+  // pass O(N^2) on a function with N sequential loops writing N distinct
+  // tensors, since the map keeps growing (.claude/rules/pass-complexity.md).
   for (size_t i = 0; i < renames.size(); ++i) {
     for (const auto& body_value : renames[i].body_values) {
-      visible[body_value.get()] = visible_values[i];
+      auto holders = renamed_by_value_.find(body_value.get());
+      if (holders == renamed_by_value_.end()) continue;
+      // Move the bucket out: every key in it is about to point at
+      // `visible_values[i]` instead, and the entry for `body_value` is dead
+      // once they have.
+      auto keys = std::move(holders->second);
+      renamed_by_value_.erase(holders);
+      auto& new_holders = renamed_by_value_[visible_values[i].get()];
+      for (const Var* key : keys) {
+        auto entry = store_target_renames_.find(key);
+        // Stale index entry: the key was retargeted since, so it no longer
+        // holds `body_value` and this bucket no longer speaks for it.
+        if (entry == store_target_renames_.end() || entry->second.get() != body_value.get()) continue;
+        entry->second = visible_values[i];
+        new_holders.push_back(key);
+      }
     }
   }
-  for (auto& [key, value] : store_target_renames_) {
-    auto it = visible.find(value.get());
-    if (it != visible.end()) value = it->second;
+}
+
+void ScopeOutliner::SetStoreTargetRename(const VarPtr& original, const VarPtr& fresh) {
+  auto [entry, inserted] = store_target_renames_.try_emplace(original.get(), fresh);
+  if (!inserted) {
+    if (entry->second.get() == fresh.get()) return;
+    entry->second = fresh;
+  }
+  renamed_by_value_[fresh.get()].push_back(original.get());
+}
+
+void ScopeOutliner::RewindRenames(const std::vector<BodyStoreRename>& renames) {
+  for (const auto& rename : renames) SetStoreTargetRename(rename.original, rename.seed);
+}
+
+void ScopeOutliner::RetargetCarries(const std::vector<BodyStoreRename>& renames,
+                                    const std::vector<VarPtr>& visible_values) {
+  INTERNAL_CHECK(renames.size() == visible_values.size())
+      << "Internal error: carry value count does not match the rename count";
+  // Post-store aliases first — the sweep consumes each body value's bucket.
+  RetargetBodyValues(renames, visible_values);
+  // Then the store target itself, authoritatively. The sweep already moved it
+  // when it still held a body value (the loop path), but not when the body was
+  // an `if` branch that RewindRenames has since rewound to the seed.
+  for (size_t i = 0; i < renames.size(); ++i) {
+    SetStoreTargetRename(renames[i].original, visible_values[i]);
   }
 }
 
@@ -1071,11 +1112,11 @@ void ScopeOutliner::PublishCarries(const std::vector<BodyStoreRename>& renames,
   INTERNAL_CHECK(renames.size() == return_vars.size())
       << "Internal error: carry return_var count does not match the rename count";
   // Tell the enclosing body first: it must be handed the seed *this* body
-  // started from, before the sweep below rewrites the map entry.
+  // started from, before the retarget below rewrites the map entry.
   for (size_t i = 0; i < renames.size(); ++i) {
     NoteStoreTargetRename(renames[i].original, renames[i].seed, return_vars[i]);
   }
-  RetargetBodyValues(renames, return_vars);
+  RetargetCarries(renames, return_vars);
 }
 
 /// Split @p renames into the ones this loop must newly carry and the ones it
@@ -1131,7 +1172,7 @@ StmtPtr ScopeOutliner::VisitStmt_(const ForStmtPtr& op) {
   std::vector<VarPtr> carried_values;
   SplitAlreadyCarried(renames, op->iter_args_, loop->iter_args_, loop->return_vars_, loop->span_, &fresh,
                       &carried, &carried_values);
-  RetargetBodyValues(carried, carried_values);
+  RetargetCarries(carried, carried_values);
   if (fresh.empty()) return visited;
 
   auto carry_iter_args = MakeCarryIterArgs(fresh, loop->span_);
@@ -1161,7 +1202,7 @@ StmtPtr ScopeOutliner::VisitStmt_(const WhileStmtPtr& op) {
   std::vector<VarPtr> carried_values;
   SplitAlreadyCarried(renames, op->iter_args_, loop->iter_args_, loop->return_vars_, loop->span_, &fresh,
                       &carried, &carried_values);
-  RetargetBodyValues(carried, carried_values);
+  RetargetCarries(carried, carried_values);
   if (fresh.empty()) return visited;
 
   auto carry_iter_args = MakeCarryIterArgs(fresh, loop->span_);
@@ -1181,31 +1222,19 @@ StmtPtr ScopeOutliner::VisitStmt_(const IfStmtPtr& op) {
 
   // The branches are alternatives, not a sequence: a rename the then branch made
   // is not visible in the else branch, so the else branch has to start from the
-  // same incoming values.
-  auto incoming = store_target_renames_;
+  // same incoming values. Rewinding the store targets the frame recorded is
+  // enough, and costs O(renames) instead of a copy of the whole map — the
+  // branch-local post-store aliases are keyed on Vars the other branch cannot
+  // name, so they are free to stay, and PublishCarries retargets them below.
   std::vector<BodyStoreRename> then_renames;
   auto new_then_body = VisitControlFlowBody(op->then_body_, &then_renames);
-  auto after_then = store_target_renames_;
+  RewindRenames(then_renames);
 
-  store_target_renames_ = incoming;
   std::vector<BodyStoreRename> else_renames;
   std::optional<StmtPtr> new_else_body;
   if (op->else_body_.has_value()) {
     new_else_body = VisitControlFlowBody(*op->else_body_, &else_renames);
-  }
-  auto after_else = store_target_renames_;
-
-  // Rejoin: keep every entry either branch added or changed. The store targets
-  // among them are retargeted onto the if's return_vars by PublishCarries below;
-  // post-store aliases ride along on that same sweep.
-  store_target_renames_ = std::move(incoming);
-  for (const auto* branch : {&after_then, &after_else}) {
-    for (const auto& [key, value] : *branch) {
-      auto it = store_target_renames_.find(key);
-      if (it == store_target_renames_.end() || it->second.get() != value.get()) {
-        store_target_renames_[key] = value;
-      }
-    }
+    RewindRenames(else_renames);
   }
 
   // One carry per store target either branch wrote; the branch that did not
@@ -1496,6 +1525,7 @@ StmtPtr ScopeOutliner::OutlineScope(const ScopeStmtPtr& op,
   auto saved_known_names = known_names_;
   auto saved_required_outputs = required_outputs_;
   auto saved_renames = store_target_renames_;
+  auto saved_renamed_by_value = renamed_by_value_;
   func_name_ = outlined_func_name;
   scope_counter_ = 0;
   for (const auto& [ptr, type] : scope_var_collector.var_types) {
@@ -1506,6 +1536,7 @@ StmtPtr ScopeOutliner::OutlineScope(const ScopeStmtPtr& op,
   }
   known_names_.insert(scope_var_collector.known_names.begin(), scope_var_collector.known_names.end());
   store_target_renames_.clear();
+  renamed_by_value_.clear();
   // Propagate output requirements so nested scopes know what's needed
   required_outputs_.clear();
   for (const auto& var : output_vars) {
@@ -1519,6 +1550,7 @@ StmtPtr ScopeOutliner::OutlineScope(const ScopeStmtPtr& op,
   known_names_ = saved_known_names;
   required_outputs_ = saved_required_outputs;
   store_target_renames_ = saved_renames;
+  renamed_by_value_ = saved_renamed_by_value;
 
   // Create fresh parameters for the outlined function.
   // Infer param directions from the inner callee when possible (requires program_).
@@ -2144,7 +2176,10 @@ StmtPtr ScopeOutliner::OutlineScope(const ScopeStmtPtr& op,
   for (const auto& [alias_ptr, target_ptr] : deferred_post_store_aliases) {
     auto rename_it = store_target_renames_.find(target_ptr);
     if (rename_it != store_target_renames_.end()) {
-      store_target_renames_[alias_ptr] = rename_it->second;
+      // var_objects_ holds the identity Var for the alias; the map itself is
+      // keyed by raw pointer, so look it up rather than minting a handle.
+      auto alias_it = var_objects_.find(alias_ptr);
+      if (alias_it != var_objects_.end()) SetStoreTargetRename(alias_it->second, rename_it->second);
     }
   }
   return result;
@@ -2204,7 +2239,7 @@ VarPtr ScopeOutliner::CreateFreshStoreTargetVar(const VarPtr& original_var, cons
   auto current = store_target_renames_.find(original_var.get());
   NoteStoreTargetRename(original_var, current != store_target_renames_.end() ? current->second : original_var,
                         fresh_var);
-  store_target_renames_[original_var.get()] = fresh_var;
+  SetStoreTargetRename(original_var, fresh_var);
   RegisterVar(fresh_var);
   return fresh_var;
 }

--- a/src/ir/transforms/utils/scope_outline_utils.cpp
+++ b/src/ir/transforms/utils/scope_outline_utils.cpp
@@ -39,8 +39,10 @@
 #include "pypto/ir/transforms/base/visitor.h"
 #include "pypto/ir/transforms/utils/auto_name_utils.h"
 #include "pypto/ir/transforms/utils/deferred_wait_contract.h"
+#include "pypto/ir/transforms/utils/mutable_copy.h"
 #include "pypto/ir/transforms/utils/result_alias_utils.h"
 #include "pypto/ir/transforms/utils/return_lineage_utils.h"
+#include "pypto/ir/transforms/utils/transform_utils.h"
 #include "pypto/ir/transforms/utils/var_collectors.h"
 #include "pypto/ir/type.h"
 
@@ -895,6 +897,377 @@ StmtPtr ScopeOutliner::VisitStmt_(const SpmdScopeStmtPtr& op) { return VisitScop
 // descends into the body via VisitScopeKind's non-target branch, preserving
 // the nested SplitAivScopeStmt inside the outlined InCore function body.
 StmtPtr ScopeOutliner::VisitStmt_(const SplitAivScopeStmtPtr& op) { return VisitScopeKind(op); }
+
+// ============================================================================
+// Control flow: threading store-target renames out as real carries
+// ============================================================================
+
+namespace {
+
+/// Append @p extra to @p body's trailing YieldStmt, adding one when the body has
+/// none (a loop that carried nothing yields nothing today).
+///
+/// Walks the same spine as ``GetLastYieldStmt``: the trailing yield is the last
+/// element of the outermost SeqStmts chain. A statement kind that hides a yield
+/// from this walk gets a *new* trailing yield instead, which is why the caller
+/// checks the resulting arity.
+StmtPtr AppendTrailingYieldValues(const StmtPtr& body, const std::vector<ExprPtr>& extra, const Span& span) {
+  if (extra.empty()) return body;
+  if (auto yield = As<YieldStmt>(body)) {
+    auto values = yield->value_;
+    values.insert(values.end(), extra.begin(), extra.end());
+    return std::make_shared<YieldStmt>(values, yield->span_);
+  }
+  if (auto seq = As<SeqStmts>(body)) {
+    auto stmts = seq->stmts_;
+    if (!stmts.empty() && transform_utils::GetLastYieldStmt(stmts.back())) {
+      stmts.back() = AppendTrailingYieldValues(stmts.back(), extra, span);
+    } else {
+      stmts.push_back(std::make_shared<YieldStmt>(extra, span));
+    }
+    return SeqStmts::Flatten(std::move(stmts), seq->span_);
+  }
+  return SeqStmts::Flatten({body, std::make_shared<YieldStmt>(extra, span)}, span);
+}
+
+/// Rebind loop-body references from a carry's seed onto the carry itself.
+///
+/// Not ``transform_utils::Substitute``: that one re-visits whatever it
+/// substitutes in, so a chained map (A->B, B->C) settles. That is exactly wrong
+/// here, because the replacement is an ``IterArg`` whose ``initValue_`` *is* the
+/// Var being replaced — re-visiting rewrites the seed inside the carry into a
+/// self-reference and mints a second, unbound IterArg. The map is built in one
+/// step and needs no chain resolution, so a carry is terminal in both
+/// directions: substituted in verbatim, and never descended into afterwards
+/// (the base visitor would otherwise reach its ``initValue_`` when the carry
+/// resurfaces as a nested loop's init value).
+class CarryRebindMutator : public IRMutator {
+ public:
+  explicit CarryRebindMutator(const std::unordered_map<const Var*, VarPtr>& seed_to_carry)
+      : seed_to_carry_(seed_to_carry) {
+    for (const auto& [seed, carry] : seed_to_carry_) carries_.insert(carry.get());
+  }
+
+ protected:
+  // Var and IterArg get separate overrides rather than VisitVarLike_: a seed may
+  // itself be an enclosing loop's IterArg (see .claude/rules/ir-kind-traits.md),
+  // and neither may fall through to the base visitor on a hit.
+  ExprPtr VisitExpr_(const VarPtr& op) override {
+    auto it = seed_to_carry_.find(op.get());
+    return it != seed_to_carry_.end() ? it->second : IRMutator::VisitExpr_(op);
+  }
+  ExprPtr VisitExpr_(const IterArgPtr& op) override {
+    auto it = seed_to_carry_.find(op.get());
+    if (it != seed_to_carry_.end()) return it->second;
+    if (carries_.count(op.get()) > 0) return op;
+    return IRMutator::VisitExpr_(op);
+  }
+
+ private:
+  const std::unordered_map<const Var*, VarPtr>& seed_to_carry_;
+  std::unordered_set<const Var*> carries_;
+};
+
+/// Index of @p var among @p iter_args, or ``npos``.
+size_t FindIterArgSlot(const std::vector<IterArgPtr>& iter_args, const Var* var) {
+  for (size_t i = 0; i < iter_args.size(); ++i) {
+    if (iter_args[i].get() == var) return i;
+  }
+  return std::string::npos;
+}
+
+}  // namespace
+
+void ScopeOutliner::NoteStoreTargetRename(const VarPtr& original, const VarPtr& seed, const VarPtr& fresh) {
+  if (body_rename_stack_.empty()) return;
+  auto& frame = body_rename_stack_.back();
+  auto it = std::find_if(frame.begin(), frame.end(), [&](const BodyStoreRename& rename) {
+    return rename.original.get() == original.get();
+  });
+  if (it != frame.end()) {
+    // Renamed again by a later scope in the same body: the carry still starts
+    // from the value the body was entered with, only the yielded value moves on.
+    it->body_values.push_back(fresh);
+    return;
+  }
+  frame.push_back(BodyStoreRename{original, seed, {fresh}});
+}
+
+StmtPtr ScopeOutliner::VisitControlFlowBody(const StmtPtr& body, std::vector<BodyStoreRename>* renames) {
+  body_rename_stack_.emplace_back();
+  auto visited = VisitStmt(body);
+  *renames = std::move(body_rename_stack_.back());
+  body_rename_stack_.pop_back();
+  return visited;
+}
+
+std::vector<IterArgPtr> ScopeOutliner::MakeCarryIterArgs(const std::vector<BodyStoreRename>& renames,
+                                                         const Span& span) {
+  std::vector<IterArgPtr> iter_args;
+  iter_args.reserve(renames.size());
+  for (const auto& rename : renames) {
+    auto iter_arg = std::make_shared<IterArg>(GenerateFreshSSAName(rename.original->name_hint_, "iter"),
+                                              rename.original->GetType(), rename.seed, span);
+    RegisterVar(iter_arg);
+    iter_args.push_back(iter_arg);
+  }
+  return iter_args;
+}
+
+std::vector<VarPtr> ScopeOutliner::MakeCarryReturnVars(const std::vector<BodyStoreRename>& renames,
+                                                       const Span& span) {
+  std::vector<VarPtr> return_vars;
+  return_vars.reserve(renames.size());
+  for (const auto& rename : renames) {
+    auto return_var = std::make_shared<Var>(GenerateFreshSSAName(rename.original->name_hint_, "rv"),
+                                            rename.original->GetType(), span);
+    RegisterVar(return_var);
+    return_vars.push_back(return_var);
+  }
+  return return_vars;
+}
+
+StmtPtr ScopeOutliner::BuildCarriedLoopBody(const StmtPtr& body, const std::vector<BodyStoreRename>& renames,
+                                            const std::vector<IterArgPtr>& carry_iter_args,
+                                            size_t total_carries, const Span& span) const {
+  INTERNAL_CHECK_SPAN(renames.size() == carry_iter_args.size(), span)
+      << "Internal error: carry iter_arg count does not match the rename count";
+  std::unordered_map<const Var*, VarPtr> seed_to_iter_arg;
+  std::vector<ExprPtr> yields;
+  yields.reserve(renames.size());
+  for (size_t i = 0; i < renames.size(); ++i) {
+    seed_to_iter_arg[renames[i].seed.get()] = carry_iter_args[i];
+    yields.push_back(renames[i].body_values.back());
+  }
+  // Rebind before appending: the yielded values are bound *inside* the body and
+  // so are never seeds, but keeping the order explicit makes that obvious.
+  CarryRebindMutator rebinder(seed_to_iter_arg);
+  auto result = AppendTrailingYieldValues(rebinder.VisitStmt(body), yields, span);
+  auto yield = transform_utils::GetLastYieldStmt(result);
+  INTERNAL_CHECK_SPAN(yield && yield->value_.size() == total_carries, span)
+      << "Internal error: loop body yields " << (yield ? yield->value_.size() : 0)
+      << " values after threading " << renames.size() << " store-target carries, expected " << total_carries;
+  return result;
+}
+
+void ScopeOutliner::RetargetBodyValues(const std::vector<BodyStoreRename>& renames,
+                                       const std::vector<VarPtr>& visible_values) {
+  INTERNAL_CHECK(renames.size() == visible_values.size())
+      << "Internal error: carry value count does not match the rename count";
+  std::unordered_map<const Var*, VarPtr> visible;
+  for (size_t i = 0; i < renames.size(); ++i) {
+    for (const auto& body_value : renames[i].body_values) {
+      visible[body_value.get()] = visible_values[i];
+    }
+  }
+  for (auto& [key, value] : store_target_renames_) {
+    auto it = visible.find(value.get());
+    if (it != visible.end()) value = it->second;
+  }
+}
+
+void ScopeOutliner::PublishCarries(const std::vector<BodyStoreRename>& renames,
+                                   const std::vector<VarPtr>& return_vars) {
+  INTERNAL_CHECK(renames.size() == return_vars.size())
+      << "Internal error: carry return_var count does not match the rename count";
+  // Tell the enclosing body first: it must be handed the seed *this* body
+  // started from, before the sweep below rewrites the map entry.
+  for (size_t i = 0; i < renames.size(); ++i) {
+    NoteStoreTargetRename(renames[i].original, renames[i].seed, return_vars[i]);
+  }
+  RetargetBodyValues(renames, return_vars);
+}
+
+/// Split @p renames into the ones this loop must newly carry and the ones it
+/// already carries.
+///
+/// A store target that *is* one of the loop's own iter_args is already threaded
+/// through the loop; giving it a second carry seeded with itself would make the
+/// loop carry its own carry, and the seed would not even be in scope at the loop
+/// header. Its post-loop value is simply the matching return_var, so it needs
+/// republishing but no new slot.
+void ScopeOutliner::SplitAlreadyCarried(const std::vector<BodyStoreRename>& renames,
+                                        const std::vector<IterArgPtr>& iter_args,
+                                        const std::vector<IterArgPtr>& visited_iter_args,
+                                        const std::vector<VarPtr>& return_vars, const Span& span,
+                                        std::vector<BodyStoreRename>* fresh,
+                                        std::vector<BodyStoreRename>* carried,
+                                        std::vector<VarPtr>* carried_values) const {
+  for (const auto& rename : renames) {
+    // The rename's seed comes from var_objects_, which holds the *pre-visit* Var
+    // objects, so match the original iter_args first and the visited ones second
+    // (IRMutator clones an IterArg whose initValue this pass renamed).
+    size_t slot = FindIterArgSlot(iter_args, rename.seed.get());
+    if (slot == std::string::npos) slot = FindIterArgSlot(visited_iter_args, rename.seed.get());
+    if (slot == std::string::npos) {
+      fresh->push_back(rename);
+      continue;
+    }
+    INTERNAL_CHECK_SPAN(slot < return_vars.size(), span)
+        << "Internal error: loop carries " << iter_args.size() << " values but declares only "
+        << return_vars.size() << " return_vars, so the carry at slot " << slot
+        << " has no value visible after the loop";
+    carried->push_back(rename);
+    carried_values->push_back(return_vars[slot]);
+  }
+}
+
+StmtPtr ScopeOutliner::VisitStmt_(const ForStmtPtr& op) {
+  // Only the body can outline a scope: the bounds, the iter_arg seeds and the
+  // return_vars are all expressions. So one frame around the whole node is
+  // enough, and IRMutator's own traversal can stay in charge.
+  body_rename_stack_.emplace_back();
+  auto visited = IRMutator::VisitStmt_(op);
+  auto renames = std::move(body_rename_stack_.back());
+  body_rename_stack_.pop_back();
+  if (renames.empty()) return visited;
+
+  auto loop = As<ForStmt>(visited);
+  INTERNAL_CHECK_SPAN(loop, op->span_)
+      << "Internal error: ScopeOutliner mutated a ForStmt into " << (visited ? visited->TypeName() : "null");
+
+  std::vector<BodyStoreRename> fresh;
+  std::vector<BodyStoreRename> carried;
+  std::vector<VarPtr> carried_values;
+  SplitAlreadyCarried(renames, op->iter_args_, loop->iter_args_, loop->return_vars_, loop->span_, &fresh,
+                      &carried, &carried_values);
+  RetargetBodyValues(carried, carried_values);
+  if (fresh.empty()) return visited;
+
+  auto carry_iter_args = MakeCarryIterArgs(fresh, loop->span_);
+  auto return_vars = MakeCarryReturnVars(fresh, loop->span_);
+  auto result = MutableCopy(loop);
+  result->body_ = BuildCarriedLoopBody(loop->body_, fresh, carry_iter_args,
+                                       loop->iter_args_.size() + fresh.size(), loop->span_);
+  result->iter_args_.insert(result->iter_args_.end(), carry_iter_args.begin(), carry_iter_args.end());
+  result->return_vars_.insert(result->return_vars_.end(), return_vars.begin(), return_vars.end());
+  PublishCarries(fresh, return_vars);
+  return result;
+}
+
+StmtPtr ScopeOutliner::VisitStmt_(const WhileStmtPtr& op) {
+  body_rename_stack_.emplace_back();
+  auto visited = IRMutator::VisitStmt_(op);
+  auto renames = std::move(body_rename_stack_.back());
+  body_rename_stack_.pop_back();
+  if (renames.empty()) return visited;
+
+  auto loop = As<WhileStmt>(visited);
+  INTERNAL_CHECK_SPAN(loop, op->span_) << "Internal error: ScopeOutliner mutated a WhileStmt into "
+                                       << (visited ? visited->TypeName() : "null");
+
+  std::vector<BodyStoreRename> fresh;
+  std::vector<BodyStoreRename> carried;
+  std::vector<VarPtr> carried_values;
+  SplitAlreadyCarried(renames, op->iter_args_, loop->iter_args_, loop->return_vars_, loop->span_, &fresh,
+                      &carried, &carried_values);
+  RetargetBodyValues(carried, carried_values);
+  if (fresh.empty()) return visited;
+
+  auto carry_iter_args = MakeCarryIterArgs(fresh, loop->span_);
+  auto return_vars = MakeCarryReturnVars(fresh, loop->span_);
+  auto result = MutableCopy(loop);
+  result->body_ = BuildCarriedLoopBody(loop->body_, fresh, carry_iter_args,
+                                       loop->iter_args_.size() + fresh.size(), loop->span_);
+  result->iter_args_.insert(result->iter_args_.end(), carry_iter_args.begin(), carry_iter_args.end());
+  result->return_vars_.insert(result->return_vars_.end(), return_vars.begin(), return_vars.end());
+  PublishCarries(fresh, return_vars);
+  return result;
+}
+
+StmtPtr ScopeOutliner::VisitStmt_(const IfStmtPtr& op) {
+  INTERNAL_CHECK_SPAN(op->condition_, op->span_) << "Internal error: IfStmt has null condition";
+  auto new_condition = VisitExpr(op->condition_);
+
+  // The branches are alternatives, not a sequence: a rename the then branch made
+  // is not visible in the else branch, so the else branch has to start from the
+  // same incoming values.
+  auto incoming = store_target_renames_;
+  std::vector<BodyStoreRename> then_renames;
+  auto new_then_body = VisitControlFlowBody(op->then_body_, &then_renames);
+  auto after_then = store_target_renames_;
+
+  store_target_renames_ = incoming;
+  std::vector<BodyStoreRename> else_renames;
+  std::optional<StmtPtr> new_else_body;
+  if (op->else_body_.has_value()) {
+    new_else_body = VisitControlFlowBody(*op->else_body_, &else_renames);
+  }
+  auto after_else = store_target_renames_;
+
+  // Rejoin: keep every entry either branch added or changed. The store targets
+  // among them are retargeted onto the if's return_vars by PublishCarries below;
+  // post-store aliases ride along on that same sweep.
+  store_target_renames_ = std::move(incoming);
+  for (const auto* branch : {&after_then, &after_else}) {
+    for (const auto& [key, value] : *branch) {
+      auto it = store_target_renames_.find(key);
+      if (it == store_target_renames_.end() || it->second.get() != value.get()) {
+        store_target_renames_[key] = value;
+      }
+    }
+  }
+
+  // One carry per store target either branch wrote; the branch that did not
+  // write it yields the value it came in with.
+  std::vector<BodyStoreRename> renames = then_renames;
+  std::vector<VarPtr> then_values;
+  std::vector<VarPtr> else_values;
+  then_values.reserve(renames.size());
+  for (const auto& rename : renames) then_values.push_back(rename.body_values.back());
+  for (const auto& rename : else_renames) {
+    auto it = std::find_if(renames.begin(), renames.end(), [&](const BodyStoreRename& merged) {
+      return merged.original.get() == rename.original.get();
+    });
+    if (it == renames.end()) {
+      renames.push_back(rename);
+      then_values.push_back(rename.seed);
+    } else {
+      it->body_values.insert(it->body_values.end(), rename.body_values.begin(), rename.body_values.end());
+    }
+  }
+  else_values.reserve(renames.size());
+  for (const auto& rename : renames) {
+    auto it = std::find_if(else_renames.begin(), else_renames.end(), [&](const BodyStoreRename& branch) {
+      return branch.original.get() == rename.original.get();
+    });
+    else_values.push_back(it == else_renames.end() ? rename.seed : it->body_values.back());
+  }
+
+  StmtPtr result_then = new_then_body;
+  std::optional<StmtPtr> result_else = new_else_body;
+  std::vector<VarPtr> new_return_vars = op->return_vars_;
+  if (!renames.empty()) {
+    // An `if` that already returns values must have both branches yielding, so
+    // the missing-else shortcut below is only sound when it returned nothing.
+    INTERNAL_CHECK_SPAN(op->else_body_.has_value() || op->return_vars_.empty(), op->span_)
+        << "Internal error: IfStmt declares " << op->return_vars_.size()
+        << " return_vars but has no else branch to yield them";
+    auto return_vars = MakeCarryReturnVars(renames, op->span_);
+    result_then = AppendTrailingYieldValues(
+        new_then_body, std::vector<ExprPtr>(then_values.begin(), then_values.end()), op->span_);
+    // An ``if`` with no else still has to produce a value on the untaken path.
+    result_else =
+        AppendTrailingYieldValues(new_else_body.value_or(SeqStmts::Flatten({}, op->span_)),
+                                  std::vector<ExprPtr>(else_values.begin(), else_values.end()), op->span_);
+    new_return_vars.insert(new_return_vars.end(), return_vars.begin(), return_vars.end());
+    const size_t expected = op->return_vars_.size() + renames.size();
+    for (const auto& branch : {result_then, *result_else}) {
+      auto yield = transform_utils::GetLastYieldStmt(branch);
+      INTERNAL_CHECK_SPAN(yield && yield->value_.size() == expected, op->span_)
+          << "Internal error: IfStmt branch yields " << (yield ? yield->value_.size() : 0)
+          << " values after threading " << renames.size() << " store-target carries, expected " << expected;
+    }
+    PublishCarries(renames, return_vars);
+  }
+
+  auto result = MutableCopy(op);
+  result->condition_ = std::move(new_condition);
+  result->then_body_ = std::move(result_then);
+  result->else_body_ = std::move(result_else);
+  result->return_vars_ = std::move(new_return_vars);
+  return result;
+}
 
 /// True when `name` is already claimed by this function (`known_names_`) or,
 /// when the pass opts in, by any earlier function in the program
@@ -1782,12 +2155,32 @@ StmtPtr ScopeOutliner::OutlineScope(const ScopeStmtPtr& op,
  *
  * E.g. "buf_0" -> "buf_1", "x_2" -> "x_3".  Falls back to appending "_1".
  */
-std::string ScopeOutliner::GenerateFreshSSAName(const std::string& original_name) const {
+std::string ScopeOutliner::GenerateFreshSSAName(const std::string& original_name,
+                                                const std::string& role) const {
   std::unordered_set<std::string> used_names;
   for (const auto& [var, _] : var_types_) {
     used_names.insert(var->name_hint_);
   }
-  return auto_name::GenerateFreshNameLike(original_name, used_names);
+  if (role.empty()) {
+    return auto_name::GenerateFreshNameLike(original_name, used_names);
+  }
+  // Same search as GenerateFreshNameLike, but stamping the requested role rather
+  // than inheriting the source name's — a carry derived from ``t__ssa_v0`` must
+  // read ``t__iter_v1``, not ``t__ssa_v1``.
+  auto parsed = auto_name::Parse(original_name);
+  int version = parsed.version.value_or(-1) + 1;
+  std::string candidate;
+  do {
+    candidate = auto_name::BuildName(parsed.base_name, parsed.qualifier, role, version);
+    ++version;
+  } while (used_names.count(candidate) > 0);
+  return candidate;
+}
+
+void ScopeOutliner::RegisterVar(const VarPtr& var) {
+  var_types_[var.get()] = var->GetType();
+  var_objects_[var.get()] = var;
+  known_names_.insert(var->name_hint_);
 }
 
 /**
@@ -1808,10 +2201,11 @@ VarPtr ScopeOutliner::CreateFreshStoreTargetVar(const VarPtr& original_var, cons
   std::string fresh_name = GenerateFreshSSAName(original_var->name_hint_);
   auto type = original_var->GetType();
   auto fresh_var = std::make_shared<Var>(fresh_name, type, span);
+  auto current = store_target_renames_.find(original_var.get());
+  NoteStoreTargetRename(original_var, current != store_target_renames_.end() ? current->second : original_var,
+                        fresh_var);
   store_target_renames_[original_var.get()] = fresh_var;
-  var_types_[fresh_var.get()] = type;
-  var_objects_[fresh_var.get()] = fresh_var;
-  known_names_.insert(fresh_name);
+  RegisterVar(fresh_var);
   return fresh_var;
 }
 

--- a/tests/ut/ir/transforms/test_classify_iter_arg_carry.py
+++ b/tests/ut/ir/transforms/test_classify_iter_arg_carry.py
@@ -409,5 +409,41 @@ def test_no_dep_arg_carry_is_not_a_rebind():
     assert _carry_attrs(loops[0]) == {"iter_arg_rebind_0": False}
 
 
+def test_no_dep_arg_on_a_read_only_capture_does_not_shift_the_output_index():
+    """``no_dep_args`` accepts any *captured* tensor, read or written.
+
+    So a `NoDep` call-site slot is not evidence of a write, and counting one as
+    output-side shifts every later index in the return-tuple walk: here the
+    callee's real output is arg 1, and treating the read-only arg 0 as the first
+    output would alias ``ret[0]`` to the input and misclassify the carry. The
+    alias rule reads the callee's ``ParamDirection`` instead, which is what
+    codegen consults and what ``no_dep_args`` never touches.
+    """
+
+    @pl.program
+    class Prog:
+        @pl.function
+        def main(
+            self,
+            x: pl.Tensor[[N, M], pl.FP32],
+            out: pl.Out[pl.Tensor[[N, M], pl.FP32]],
+        ) -> pl.Tensor[[N, M], pl.FP32]:
+            scratch = pl.create_tensor([N, M], pl.FP32)
+            for _i in pl.range(4):
+                # `x` is only read inside the scope, yet named in no_dep_args.
+                with pl.at(level=pl.Level.CORE_GROUP, no_dep_args=[x]) as _tid:
+                    t = pl.load(x, [0, 0], [N, M])
+                    pl.store(t, [0, 0], scratch)
+            with pl.at(level=pl.Level.CORE_GROUP):
+                t2 = pl.load(scratch, [0, 0], [N, M])
+                pl.store(t2, [0, 0], out)
+            return out
+
+    outlined = passes.outline_incore_scopes()(passes.convert_to_ssa()(Prog))
+    loops = _for_stmts(_orch_func(_classify(outlined)).body)
+    assert len(loops) == 1
+    assert _carry_attrs(loops[0]) == {"iter_arg_rebind_0": False}
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/ir/transforms/test_classify_iter_arg_carry.py
+++ b/tests/ut/ir/transforms/test_classify_iter_arg_carry.py
@@ -375,5 +375,39 @@ def test_pass_metadata():
     assert p.get_required_properties().contains(passes.IRProperty.CallDirectionsResolved)
 
 
+def test_no_dep_arg_carry_is_not_a_rebind():
+    """``no_dep_args`` suppresses ordering, not buffer identity.
+
+    ``pl.at(no_dep_args=[out])`` stamps the *call-site* direction ``NoDep``; the
+    callee's ``ParamDirection`` stays ``Out``/``InOut``, which is what codegen's
+    own result alias (``CollectOutIndices``) reads. Classifying such a carry as a
+    rebind would have codegen materialise a fresh ``TaskTensor`` for a slot it is
+    simultaneously aliasing to the arg.
+
+    Written in the scope form because ``no_dep_args`` is a ``pl.at`` / ``pl.submit``
+    keyword, so the outliner has to run first — which is also what introduces the
+    carry (see OutlineIncoreScopes, "store targets written inside control flow").
+    """
+
+    @pl.program
+    class Prog:
+        @pl.function
+        def main(
+            self,
+            x: pl.Tensor[[N, M], pl.FP32],
+            out: pl.Out[pl.Tensor[[N, M], pl.FP32]],
+        ) -> pl.Tensor[[N, M], pl.FP32]:
+            for _i in pl.range(4):
+                with pl.at(level=pl.Level.CORE_GROUP, no_dep_args=[out]):
+                    t = pl.load(x, [0, 0], [N, M])
+                    pl.store(t, [0, 0], out)
+            return out
+
+    outlined = passes.outline_incore_scopes()(passes.convert_to_ssa()(Prog))
+    loops = _for_stmts(_orch_func(_classify(outlined)).body)
+    assert len(loops) == 1
+    assert _carry_attrs(loops[0]) == {"iter_arg_rebind_0": False}
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/ir/transforms/test_outline_incore_scopes.py
+++ b/tests/ut/ir/transforms/test_outline_incore_scopes.py
@@ -3489,5 +3489,297 @@ class TestOutlineCachePolicy:
             self._outline(Before)
 
 
+class TestOutlineScopeInControlFlow:
+    """A scope inside a loop or an ``if`` must not leak its store-target rename.
+
+    Outlining a scope that writes a captured tensor binds the call result to a
+    *fresh* SSA name. When the scope sits inside a control-flow body that name is
+    bound inside the body, so anything after the statement that still resolves the
+    store target to it reads a Var that is out of scope. ``ScopeOutliner`` threads
+    the rename out as a real carry instead: the value on entry seeds an
+    ``IterArg``, the body yields the fresh Var, and a new ``return_var`` is what
+    the following statements see.
+
+    Nothing miscompiled before the fix — every SSA version of an orchestration
+    tensor denotes the same GM buffer — so these tests assert on the *def-use
+    graph*: SSAForm and UseAfterDef, plus the shape of the resulting carry.
+    """
+
+    @staticmethod
+    def _outline(program) -> ir.Program:
+        return passes.outline_incore_scopes()(passes.convert_to_ssa()(program))
+
+    @staticmethod
+    def _structural_errors(program: ir.Program) -> list[str]:
+        props = passes.IRPropertySet()
+        props.insert(passes.IRProperty.SSAForm)
+        props.insert(passes.IRProperty.UseAfterDef)
+        return [
+            d.message
+            for d in passes.PropertyVerifierRegistry.verify(props, program)
+            if d.severity == passes.DiagnosticSeverity.Error
+        ]
+
+    @staticmethod
+    def _stmts(node) -> list[ir.Stmt]:
+        body = node.body
+        assert isinstance(body, ir.SeqStmts), f"expected a SeqStmts body, got {type(body).__name__}"
+        return list(body.stmts)
+
+    @staticmethod
+    def _loop(stmt: ir.Stmt) -> ir.ForStmt:
+        assert isinstance(stmt, ir.ForStmt), f"expected a ForStmt, got {type(stmt).__name__}"
+        return stmt
+
+    @staticmethod
+    def _name(expr) -> str:
+        assert isinstance(expr, ir.Var), f"expected a Var, got {type(expr).__name__}"
+        return expr.name_hint
+
+    @classmethod
+    def _bound_name(cls, stmt: ir.Stmt) -> str:
+        assert isinstance(stmt, ir.AssignStmt), f"expected an AssignStmt, got {type(stmt).__name__}"
+        return stmt.var.name_hint
+
+    @classmethod
+    def _call_args(cls, stmt: ir.Stmt) -> list:
+        assert isinstance(stmt, ir.AssignStmt), f"expected an AssignStmt, got {type(stmt).__name__}"
+        value = stmt.value
+        assert isinstance(value, ir.Call), f"expected a Call value, got {type(value).__name__}"
+        return list(value.args)
+
+    def test_loop_writer_read_after_the_loop_is_threaded_as_a_carry(self):
+        """The canonical shape: written by an in-loop scope, read by a later one."""
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(
+                self,
+                a: pl.Tensor[[256, 128], pl.FP32],
+                out: pl.Out[pl.Tensor[[256, 128], pl.FP32]],
+            ) -> pl.Tensor[[256, 128], pl.FP32]:
+                scratch = pl.create_tensor([256, 128], pl.FP32)
+                for i in pl.range(4):
+                    with pl.at(level=pl.Level.CORE_GROUP):
+                        t = pl.load(a, [i * 64, 0], [64, 128])
+                        pl.store(pl.mul(t, 2.0), [i * 64, 0], scratch)
+                with pl.at(level=pl.Level.CORE_GROUP):
+                    t2 = pl.load(scratch, [0, 0], [64, 128])
+                    pl.store(t2, [0, 0], out)
+                return out
+
+        After = self._outline(Before)
+        assert not self._structural_errors(After)
+
+        stmts = self._stmts(After.get_function("main"))
+        loop = self._loop(stmts[1])
+        # The loop carried nothing before; it now carries `scratch` alone.
+        assert len(loop.iter_args) == 1
+        assert len(loop.return_vars) == 1
+        assert self._name(loop.iter_args[0].initValue) == self._bound_name(stmts[0])
+        # ...and the consumer after the loop reads the return var, not a body-local.
+        assert self._name(self._call_args(stmts[2])[0]) == loop.return_vars[0].name_hint
+
+    def test_loop_writer_read_by_the_return_stmt_is_threaded_as_a_carry(self):
+        """The other consumer route: a plain post-loop reference."""
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(
+                self,
+                a: pl.Tensor[[256, 128], pl.FP32],
+                out: pl.Out[pl.Tensor[[256, 128], pl.FP32]],
+            ) -> pl.Tensor[[256, 128], pl.FP32]:
+                for i in pl.range(4):
+                    with pl.at(level=pl.Level.CORE_GROUP):
+                        t = pl.load(a, [i * 64, 0], [64, 128])
+                        pl.store(pl.mul(t, 2.0), [i * 64, 0], out)
+                return out
+
+        After = self._outline(Before)
+        assert not self._structural_errors(After)
+
+        stmts = self._stmts(After.get_function("main"))
+        loop = self._loop(stmts[0])
+        assert len(loop.iter_args) == 1
+        ret = stmts[1]
+        assert isinstance(ret, ir.ReturnStmt)
+        assert self._name(ret.value[0]) == loop.return_vars[0].name_hint
+
+    def test_carry_is_appended_after_an_existing_one(self):
+        """An existing carry keeps its slot; the store target is appended after it.
+
+        Also the ``manual_dep`` / ``deps=`` shape from the dependency guide: the
+        TaskId array is what puts the loop in SSA mode, so before the fix this
+        was the variant ``UseAfterDef`` could see.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(
+                self,
+                a: pl.Tensor[[256, 128], pl.FP32],
+                out: pl.Out[pl.Tensor[[256, 128], pl.FP32]],
+            ) -> pl.Tensor[[256, 128], pl.FP32]:
+                scratch = pl.create_tensor([256, 128], pl.FP32, manual_dep=True)
+                writers = pl.array.create(4, pl.TASK_ID)
+                for i in pl.range(4):
+                    with pl.at(level=pl.Level.CORE_GROUP) as tid:
+                        t = pl.load(a, [i * 64, 0], [64, 128])
+                        pl.store(pl.mul(t, 2.0), [i * 64, 0], scratch)
+                    writers[i] = tid
+                with pl.at(level=pl.Level.CORE_GROUP, deps=[writers]):
+                    t2 = pl.load(scratch, [0, 0], [64, 128])
+                    pl.store(t2, [0, 0], out)
+                return out
+
+        After = self._outline(Before)
+        assert not self._structural_errors(After)
+
+        loop = self._loop(self._stmts(After.get_function("main"))[2])
+        # `writers` was already carried; `scratch` is appended after it.
+        assert len(loop.iter_args) == 2
+        assert len(loop.return_vars) == 2
+        assert loop.iter_args[0].name_hint.startswith("writers")
+        assert loop.iter_args[1].name_hint.startswith("scratch")
+        # The submit inside the body now reads the carry, not the pre-loop value.
+        assert loop.iter_args[1].name_hint in python_print(loop.body)
+
+    def test_nested_loops_thread_the_carry_out_of_both(self):
+        """An inner-loop carry re-emerges as the outer loop's carry."""
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(
+                self,
+                a: pl.Tensor[[256, 128], pl.FP32],
+                out: pl.Out[pl.Tensor[[256, 128], pl.FP32]],
+            ) -> pl.Tensor[[256, 128], pl.FP32]:
+                scratch = pl.create_tensor([256, 128], pl.FP32)
+                for i in pl.range(2):
+                    for j in pl.range(2):
+                        with pl.at(level=pl.Level.CORE_GROUP):
+                            t = pl.load(a, [(i * 2 + j) * 64, 0], [64, 128])
+                            pl.store(pl.mul(t, 2.0), [(i * 2 + j) * 64, 0], scratch)
+                with pl.at(level=pl.Level.CORE_GROUP):
+                    t2 = pl.load(scratch, [0, 0], [64, 128])
+                    pl.store(t2, [0, 0], out)
+                return out
+
+        After = self._outline(Before)
+        assert not self._structural_errors(After)
+
+        stmts = self._stmts(After.get_function("main"))
+        outer = self._loop(stmts[1])
+        inner = self._loop(self._stmts(outer)[0])
+        assert len(outer.iter_args) == 1
+        assert len(inner.iter_args) == 1
+        # The inner carry is seeded from the outer one, which is seeded from the
+        # tensor as it was before either loop.
+        assert self._name(inner.iter_args[0].initValue) == outer.iter_args[0].name_hint
+        assert self._name(outer.iter_args[0].initValue) == self._bound_name(stmts[0])
+
+    def test_two_sibling_scopes_in_one_loop_share_one_carry(self):
+        """N scopes writing the same target in one body still add a single slot."""
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(
+                self,
+                a: pl.Tensor[[256, 128], pl.FP32],
+                out: pl.Out[pl.Tensor[[256, 128], pl.FP32]],
+            ) -> pl.Tensor[[256, 128], pl.FP32]:
+                scratch = pl.create_tensor([256, 128], pl.FP32)
+                for i in pl.range(2):
+                    with pl.at(level=pl.Level.CORE_GROUP):
+                        t0 = pl.load(a, [i * 64, 0], [64, 128])
+                        pl.store(pl.mul(t0, 2.0), [i * 64, 0], scratch)
+                    with pl.at(level=pl.Level.CORE_GROUP):
+                        t1 = pl.load(a, [i * 64, 0], [64, 128])
+                        pl.store(pl.mul(t1, 3.0), [i * 64, 0], scratch)
+                with pl.at(level=pl.Level.CORE_GROUP):
+                    t2 = pl.load(scratch, [0, 0], [64, 128])
+                    pl.store(t2, [0, 0], out)
+                return out
+
+        After = self._outline(Before)
+        assert not self._structural_errors(After)
+
+        loop = self._loop(self._stmts(After.get_function("main"))[1])
+        assert len(loop.iter_args) == 1
+        assert len(loop.return_vars) == 1
+
+    def test_if_branch_writer_yields_and_the_else_yields_the_incoming_value(self):
+        """A conditional write must not escape its branch.
+
+        Worse than the loop case before the fix: the fresh Var existed only on the
+        taken path, yet the read after the ``if`` was unconditional.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(
+                self,
+                a: pl.Tensor[[256, 128], pl.FP32],
+                flag: pl.Scalar[pl.INT32],
+                out: pl.Out[pl.Tensor[[256, 128], pl.FP32]],
+            ) -> pl.Tensor[[256, 128], pl.FP32]:
+                scratch = pl.create_tensor([256, 128], pl.FP32)
+                if flag > 0:
+                    with pl.at(level=pl.Level.CORE_GROUP):
+                        t = pl.load(a, [0, 0], [64, 128])
+                        pl.store(pl.mul(t, 2.0), [0, 0], scratch)
+                with pl.at(level=pl.Level.CORE_GROUP):
+                    t2 = pl.load(scratch, [0, 0], [64, 128])
+                    pl.store(t2, [0, 0], out)
+                return out
+
+        After = self._outline(Before)
+        assert not self._structural_errors(After)
+
+        stmts = self._stmts(After.get_function("main"))
+        if_stmt = stmts[1]
+        assert isinstance(if_stmt, ir.IfStmt), f"expected an IfStmt, got {type(if_stmt).__name__}"
+        assert len(if_stmt.return_vars) == 1
+        # The source had no `else`; one is synthesised so the untaken path still
+        # produces a value — the tensor as it was before the `if`.
+        else_body = if_stmt.else_body
+        assert else_body is not None
+        assert self._bound_name(stmts[0]) in python_print(else_body)
+        assert self._name(self._call_args(stmts[2])[0]) == if_stmt.return_vars[0].name_hint
+
+    def test_scope_outside_control_flow_is_unchanged(self):
+        """The top-level case must keep resolving to the plain renamed Var."""
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(
+                self,
+                a: pl.Tensor[[256, 128], pl.FP32],
+                out: pl.Out[pl.Tensor[[256, 128], pl.FP32]],
+            ) -> pl.Tensor[[256, 128], pl.FP32]:
+                scratch = pl.create_tensor([256, 128], pl.FP32)
+                with pl.at(level=pl.Level.CORE_GROUP):
+                    t = pl.load(a, [0, 0], [64, 128])
+                    pl.store(pl.mul(t, 2.0), [0, 0], scratch)
+                with pl.at(level=pl.Level.CORE_GROUP):
+                    t2 = pl.load(scratch, [0, 0], [64, 128])
+                    pl.store(t2, [0, 0], out)
+                return out
+
+        After = self._outline(Before)
+        assert not self._structural_errors(After)
+
+        stmts = self._stmts(After.get_function("main"))
+        assert self._name(self._call_args(stmts[2])[0]) == self._bound_name(stmts[1])
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## What

`OutlineIncoreScopes` replaces a scope that writes a captured tensor with a call whose result binds a *fresh* SSA name, and every later reference to that tensor resolves to the fresh one through the function-wide `store_target_renames_` map. When the scope sits inside a loop or an `if`, that name is bound **inside the body**, so the map hands the statements after the control flow a Var that is out of scope.

The first example in the dependency guide is enough to show it — after pass 8:

```python
for i__idx_v0 in pl.range(4):
    out__ssa_v1 = self.k_incore_0(a__ssa_v0, i__idx_v0, out__ssa_v0)
return out__ssa_v1                    # defined inside the loop
```

→ `SSAVerify: Variable 'out__ssa_v1' used outside its defining scope`

This PR threads the rename out as a real carry: the value on entry seeds a new `IterArg`, the body yields the fresh Var, and a new `return_var` is what the following statements see.

```python
for i__idx_v0, (out__iter_v1,) in pl.range(4, init_values=(out__ssa_v0,)):
    out__ssa_v1 = self.k_incore_0(a__ssa_v0, i__idx_v0, out__iter_v1)
    out__rv_v1 = pl.yield_(out__ssa_v1)
return out__rv_v1
```

## Why it went unnoticed

Nothing miscompiled. The outlined callee returns its own `pl.Out` parameter, so every SSA version of the tensor denotes the same GM buffer and downstream passes resolve them all to one allocation. Only the def-use graph was wrong.

It stayed silent because the pass declares `SSAForm` as `.produced` but never `.invalidated`, and `PassPipeline` computes `to_verify = produced ∩ verified_props − verified`. `ConvertToSSA` (pass 4) already verified `SSAForm` and nothing between 4 and 8 invalidates it, so the re-check at pass 8 is memoized away. Calling `PropertyVerifierRegistry.verify({SSAForm}, prog)` directly right after pass 8 fires immediately.

**This is not addressed here** — closing that gap is a separate call, since re-verifying `SSAForm` at pass 8 may surface other latent violations. Flagging it so it is not lost.

## Scope of the defect

Broader than the shape it was first reported on. It needs **none** of `manual_dep`, `deps=`, or `pl.submit` — a plain `pl.create_tensor` written by an in-loop `pl.at` and read afterwards reproduces it byte for byte. It also reaches:

- the **`if`** form, which is worse: the fresh Var exists only on the taken branch, yet the read after the `if` is unconditional;
- the **ReturnStmt** route (via `VisitExpr_(VarPtr)` rather than the call-args lookup), which is the `serialized` example in `docs/en/user/performance/03-dependencies.md`.

## Root cause

`store_target_renames_` is flat and function-wide, and is saved/restored only around a **scope** body ([`scope_outline_utils.cpp:1125`/`:1148`](https://github.com/hw-native-sys/pypto/blob/main/src/ir/transforms/utils/scope_outline_utils.cpp)) — never around a control-flow body. `ScopeOutliner` declared no `ForStmt` / `WhileStmt` / `IfStmt` override at all, so it inherited `IRMutator`'s plain descent: the entry outlived the body that created it, and the loop header was never rewritten to carry the tensor.

## How the carry behaves

| Situation | Result |
| --------- | ------ |
| N sibling scopes write one target in one body | one slot; the body yields the last value |
| Nested loops | the inner carry re-emerges as the outer loop's carry |
| The target already *is* one of the loop's iter_args | no new slot; later references resolve to that slot's `return_var` |
| `if` with no `else` | one is synthesised, yielding the value it came in with |
| Scope at the function's top level | unchanged — the fresh name is already in scope |

Two subtleties, both documented at the code:

- The body rebind cannot use `transform_utils::Substitute`, which re-resolves whatever it substitutes in so chained maps settle. Here the replacement is an `IterArg` whose `initValue_` **is** the Var being replaced, so re-visiting rewrites the seed into a self-reference and mints a second, unbound `IterArg`. `CarryRebindMutator` makes a carry terminal in both directions.
- The `if` branches are alternatives, not a sequence, so the else branch restarts from the pre-`if` map rather than inheriting the then branch's renames.

## The `ClassifyIterArgCarry` change

The new carry exposed a pre-existing divergence. Pass 47's alias rule filtered on the **call-site** `ArgDirection` and excluded `NoDep`, while orchestration codegen aliases a call's result by the **callee's** `ParamDirection` (`CollectOutIndices`), which `pl.at(no_dep_args=[...])` never touches. So a `no_dep` carry classified as `rebind` and codegen materialised a fresh `TaskTensor` for a slot it was simultaneously aliasing to the arg:

```cpp
TaskTensor out__rv_v1 = ext_out;     // materialised…
params_t0.add_no_dep(out__rv_v1);    // …for a slot codegen aliases anyway
```

`NoDep` is an *ordering* claim, not an identity one — the callee still writes through that same tensor and returns it. `IsOutputSideDirection` now covers `OutputExisting | InOut | Output | NoDep` at both call sites in that pass, which also removes an inconsistency between them (the `TupleGetItemExpr` branch already admitted `Output`; the direct-call branch did not — no pass stamps `Output` on an argument today, so that half is currently unreachable).

## Verification

- **Generated code is byte-identical to `main`.** Built a baseline worktree at `origin/main` and diffed the complete artifacts — `.pto`, ptoas `.cpp`, AIV kernels, orchestration `.cpp` — for all four dependency-guide kernels (`serialized`, `tensor_claim`, `narrow_claim`, `region_claim`). Zero diff. The carries land in the iter_arg's alias class and classify **trivial**, so iter_arg and return_var both emit as the init value's name.
- `10605 passed, 3 skipped, 3 xfailed` across `tests/ut/`; `ctest` clean; `pre-commit` clean.
- All four repro shapes now verify clean under `SSAForm` + `UseAfterDef`.

## Reviewer notes

- The behaviour claim that matters is "codegen unchanged", and it rests on pass 47 classifying these carries trivial. The `ClassifyIterArgCarry` change is what makes that true for the `no_dep_args` case — without it, `narrow_claim` regresses to a materialised carry.
- 8 new tests: 7 in `TestOutlineScopeInControlFlow` (loop→consumer, loop→ReturnStmt, appended-after-an-existing-carry, nested loops, sibling scopes, `if` branch, and the unchanged top-level case), asserting on `SSAForm` + `UseAfterDef` and on the resulting carry's shape; 1 for the `NoDep` alias rule.
- Docs updated in `08-outline_incore_scopes.md` and `47-classify_iter_arg_carry.md`, EN and ZH.
