### PR TITLE
refactor(ir): let TensorType canonicalize the cross-core boundary view

### DIFF
--- a/src/ir/op/tile_ops/cross_core.cpp
+++ b/src/ir/op/tile_ops/cross_core.cpp
@@ -27,7 +27,6 @@
 #include "pypto/ir/scalar_expr.h"
 #include "pypto/ir/span.h"
 #include "pypto/ir/stmt.h"
-#include "pypto/ir/tile_view_semantics.h"
 #include "pypto/ir/transforms/printer.h"
 #include "pypto/ir/type.h"
 #include "pypto/ir/type_inference.h"
@@ -333,17 +332,10 @@ TypePtr DeduceSplitReshapeTensor(const std::vector<ExprPtr>& args,
   // rationale as the tile deducer). Memory space is a tile-level concept and is
   // re-attached when ConvertTensorToTileOps lowers this to tile.aiv_shard.
   //
-  // Canonicalize a redundant view away, mirroring the tile path: TileType's
-  // constructor drops a tile_view whose valid_shape matches the shape (the
-  // implicit view), but TensorType performs no such canonicalization. So only
-  // attach a tensor_view when the reshaped valid_shape is a genuine partial
-  // (differs from the reshaped shape). A redundant valid_shape == shape view
-  // otherwise breaks the print -> parse round-trip: the printer collapses it to
-  // a bare ``pl.TensorView()`` presence marker that reparses to an empty
-  // valid_shape (structurally != the shape-sized valid_shape).
-  if (tile_view_semantics::ShapeExprListsEquivalent(reshaped.valid, reshaped.shape)) {
-    return std::make_shared<TensorType>(std::move(reshaped.shape), tensor_type->dtype_, std::nullopt);
-  }
+  // A redundant view needs no guard here: TensorType's constructor canonicalizes
+  // it away, clearing a valid_shape equal to the shape and then resetting the
+  // otherwise-default view to nullopt (CanonicalizeTensorViewInPlace). Same as
+  // the tile deducer above, which hands TileType an unconditional TileView.
   TensorView tensor_view({}, TensorLayout::ND, std::move(reshaped.valid));
   return std::make_shared<TensorType>(std::move(reshaped.shape), tensor_type->dtype_, std::nullopt,
                                       std::make_optional(std::move(tensor_view)));

--- a/src/ir/op/tile_ops/cross_core.cpp
+++ b/src/ir/op/tile_ops/cross_core.cpp
@@ -302,9 +302,11 @@ TypePtr DeduceSplitReshapeTensor(const std::vector<ExprPtr>& args,
   const int split = ReadSplitAttr(kwargs, op_name, args[0]->span_);
   if (split == 0) {
     // Task-parallel (NONE) region: the op marks the crossing and preserves the
-    // shape (see DeduceSplitReshape). Return the operand's type unchanged — its
-    // view is already canonical, so re-wrapping it could only break the
-    // print -> parse round-trip the halving path has to work around below.
+    // shape (see DeduceSplitReshape). The operand's type is returned unchanged
+    // rather than rebuilt: a TensorType carries no memory space or tile layout
+    // to strip (which is why the tile deducer rebuilds and this one does not),
+    // and its view was already canonicalized at construction, so a rebuild
+    // would yield a structurally identical type.
     return args[0]->GetType();
   }
 


### PR DESCRIPTION
## What changed

`DeduceSplitReshapeTensor` — the type deducer for `tensor.aiv_shard` / `tensor.aic_gather` — branched on whether the reshaped `valid_shape` equalled the reshaped shape, attaching a `TensorView` only in the partial case. The branch is dead. It is removed, along with the comment that justified it, and the now-unused `tile_view_semantics.h` include.

```cpp
-  // ... TileType's constructor drops a tile_view whose valid_shape matches the
-  // shape (the implicit view), but TensorType performs no such canonicalization.
-  if (tile_view_semantics::ShapeExprListsEquivalent(reshaped.valid, reshaped.shape)) {
-    return std::make_shared<TensorType>(std::move(reshaped.shape), dtype, std::nullopt);
-  }
   TensorView tensor_view({}, TensorLayout::ND, std::move(reshaped.valid));
   return std::make_shared<TensorType>(std::move(reshaped.shape), dtype, std::nullopt,
                                       std::make_optional(std::move(tensor_view)));
```

## Why

The comment's premise was true when written and stopped being true twelve days later:

| Date | Commit | |
|---|---|---|
| 2026-05-03 | `f21c2dd4` (#1266) | `TileType` gains `CanonicalizeTileViewInPlace` — **tile side only** |
| 2026-07-02 | `82083eb7` (#1923) | `tensor.aiv_shard` / `aic_gather` added. The author correctly observes `TensorType` has no mirror, hand-rolls the guard, and records the asymmetry in a comment |
| 2026-07-14 | `3079ba55` (#2031) | `TensorType` gains `CanonicalizeTensorViewInPlace` — asymmetry closed. Does not touch `cross_core.cpp` |

`TensorType`'s constructor now calls `CanonicalizeTensorViewInPlace`, which clears a `valid_shape` equal to the shape and then, finding all four fields at their defaults, resets the view to `nullopt`. And the two predicates are the same function: `ShapeExprListsEquivalent` and `AreExprVectorsEqual` are both a size check plus element-wise `AreExprsEqual`. The guard's condition *is* the constructor's condition, so it could never select a different outcome — both arms built an identical `TensorType`.

The tell is right next door: the tile deducer directly above has no such guard, because on the tile side the constructor had done this since #1266.

The stale comment was the actual cost. It asserts an invariant of the type system that no longer holds, in the file a reader would trust on the subject, and teaches the next author to hand-roll the same thing.

## Behaviour

None. At the DSL level, a fully-valid operand (`pl.aiv_shard(acc)` where `acc` comes straight from `pl.matmul`) took the guarded arm; a narrowed one (`pl.slice(..., valid_shape=[v, K])` feeding the matmul) took the other. Both now go through one path and land on the same type. The tensor-level view is transient regardless: `ConvertTensorToTileOps` re-runs the *tile* deducer via `OpRegistry::Create`, so this `tensor_view_` never reaches codegen.

## Verification

Deduced types compared before vs. after, guard present vs. removed — identical:

| operand | result |
|---|---|
| `Tensor[[16,128]]` | `[8,128]`, `view=None` |
| `Tensor[[16,128]]` + explicit full view | `[8,128]`, `view=None` |
| `Tensor[[16,128]]` valid `[16,100]` | `[8,128]`, `valid_shape=[8,100]` |

- Cross-core / split_aiv / tensor-view-semantics suites: **489 passed**
- Full `tests/ut/`: **10597 passed**, 3 skipped, 3 xfailed
- Lint: `check_english_only`, `check_headers`, `check_op_name_literals`, `check_emitter_check_classification` all pass; full pre-commit hook set green
- No docs referenced the removed claim

## For the reviewer

The load-bearing question is whether the guard's predicate and the constructor's are genuinely the same. `ShapeExprListsEquivalent` ([tile_view_semantics.h:84](https://github.com/hw-native-sys/pypto/blob/main/include/pypto/ir/tile_view_semantics.h#L84)) and `AreExprVectorsEqual` ([expr.cpp:116](https://github.com/hw-native-sys/pypto/blob/main/src/ir/expr.cpp#L116)) each do a size check then element-wise `AreExprsEqual` — no difference in strength, so canonicalization clears exactly the cases the guard caught.
