### PR TITLE
fix(ir): validate tile.load / tile.store shapes and valid_shape elements

### DIFF
--- a/python/pypto/ir/op/tile_ops.py
+++ b/python/pypto/ir/op/tile_ops.py
@@ -217,13 +217,16 @@ def load(
         offsets: Offsets in each dimension (sequence of scalars), or a MakeTuple.
             Always in the source tensor's coordinate system.
         shapes: Shape of the region to load in each dimension (sequence of scalars),
-            or a MakeTuple. Always in the source tensor's coordinate system.
+            or a MakeTuple. Always in the source tensor's coordinate system. Every
+            element must be an integer scalar, as for ``offsets``.
         valid_shape: Valid shape of the tile in each dimension (sequence of scalars), or a
             MakeTuple. When provided, sets TileView.valid_shape in the output TileType.
             When omitted, shapes is used as valid_shape. Useful for dynamic shapes where
             the actual valid data region differs from the allocated tile size.
             Uses the same coordinate convention as shapes. This is a *request*: it
-            narrows the tile, but cannot widen it past what the source has.
+            narrows the tile, but cannot widen it past what the source has. Every
+            element must be an integer scalar — one extent per dimension, never a
+            nested tuple.
         target_memory: Target memory space (MemorySpace.Vec or MemorySpace.Mat).
             ``None`` (the default) leaves the space unset so InferTileMemorySpace
             places the tile from consumer demand; the kwarg is then omitted from
@@ -315,7 +318,8 @@ def store(
         offsets: Offsets in each dimension (sequence of scalars), or a MakeTuple
         output_tensor: Output tensor (TensorType)
         shapes: ND partition shape (sequence of ints), or None for 2D tiles. Normally
-            injected automatically by FlattenTileNdTo2D for ND tensors.
+            injected automatically by FlattenTileNdTo2D for ND tensors. Every element
+            must be an integer scalar, as for ``offsets``.
         span: Optional source span for debugging (auto-captured if not provided)
         atomic: ``AtomicType`` underlying int — 0 (``kNone``, plain overwrite) or
             1 (``kAdd``, atomic-add into global memory). The kwarg is omitted

--- a/python/pypto/ir/utils.py
+++ b/python/pypto/ir/utils.py
@@ -103,6 +103,17 @@ def _normalize_expr(
         return _ir.ConstInt(value, int_dtype, actual_span)
     elif isinstance(value, float):
         return _ir.ConstFloat(value, float_dtype, actual_span)
+    elif isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+        # A nested sequence where a scalar belongs — almost always one bracket
+        # level too many in an offsets / shapes / valid_shape argument. No
+        # operator accepts a nested tuple, so name the mistake here rather than
+        # letting the generic "cannot convert" message stand.
+        raise TypeError(
+            f"Cannot convert {type(value)} to IR expression: expected a scalar, but got the "
+            f"sequence {value!r}. Each element of an offsets / shapes / valid_shape argument is "
+            f"one dimension's extent, so the argument takes a flat sequence of integer scalars "
+            f"-- one bracket level, not nested pairs."
+        )
     else:
         raise TypeError(f"Cannot convert {type(value)} to IR expression")
 

--- a/python/pypto/language/op/tile_ops.py
+++ b/python/pypto/language/op/tile_ops.py
@@ -413,11 +413,14 @@ def load(
             coordinate system. Each element must be an integer scalar — a float
             (``n / 2`` rather than ``n // 2``) or a nested sequence is rejected.
         shapes: Shape of the region to load in each dimension. Always in the
-            source tensor's coordinate system.
+            source tensor's coordinate system. Each element must be an integer
+            scalar, on the same terms as ``offsets``.
         valid_shape: Valid shape of the tile in each dimension. When provided, sets
             TileView.valid_shape in the output TileType. When omitted, shapes is used
             as valid_shape. Uses the same coordinate convention as shapes. Narrows
-            the tile; cannot widen it past what the source has.
+            the tile; cannot widen it past what the source has. Each element must
+            be an integer scalar — one extent per dimension, not a nested
+            ``[start, extent]`` pair.
         target_memory: Target memory space (MemorySpace.Vec or MemorySpace.Mat).
             ``None`` (the default) leaves the space unset for the compiler to place.
             MX-layout tensors require an explicit MemorySpace.Mat.
@@ -477,6 +480,7 @@ def store(
             scalar — a float or a nested sequence is rejected.
         output_tensor: Output tensor
         shapes: Optional ND partition shape. Injected by FlattenTileNdTo2D for ND tensors.
+            Each element must be an integer scalar, on the same terms as ``offsets``.
         atomic: Combine mode for the global-memory write. ``AtomicType.None_``
             (default) overwrites; ``AtomicType.Add`` atomically adds the tile
             into existing GM contents — used for split-K accumulation, where

--- a/src/ir/op/tile_ops/memory.cpp
+++ b/src/ir/op/tile_ops/memory.cpp
@@ -64,27 +64,34 @@ T GetKwarg(const std::vector<std::pair<std::string, std::any>>& kwargs, const st
 
 namespace {
 
-/// Validate that every element of an offsets tuple is an integer scalar.
+/// Validate that every element of a window-geometry tuple is an integer scalar.
 ///
-/// ``tile.load`` / ``tile.store`` declare offsets as "TupleType of integer
-/// ScalarType", and nothing downstream re-derives that: the window-read proofs in
-/// ``InferWindowReadValidShape`` are defined only over integer scalars, so a
-/// non-scalar element makes every bounds obligation *undecidable* rather than
-/// false — the negative-offset and reads-past-the-end checks then pass silently
-/// and codegen lowers whatever the element happens to reduce to. Reject it here,
-/// at the operator boundary, on the same terms ``tensor.slice`` uses for its own
-/// offsets. ``IsInt()`` (not ``IsIndexLike()``) is the bar because every integer
-/// width is a legitimate offset all the way down: ``EmitCastToIndex`` exists
-/// precisely to widen a non-INDEX integer offset at the partition_view site.
-void ValidateOffsetTupleElements(const MakeTuplePtr& offsets, const std::string& op_name) {
-  for (size_t i = 0; i < offsets->elements_.size(); ++i) {
-    const ExprPtr& elem = offsets->elements_[i];
-    CHECK(elem) << op_name << " offset tuple element " << i << " must not be null";
+/// ``tile.load`` / ``tile.store`` declare each of offsets, shapes and valid_shape
+/// as "TupleType of integer ScalarType", and nothing downstream re-derives that:
+/// the window-read proofs in ``InferWindowReadValidShape`` are defined only over
+/// integer scalars, so a non-scalar element makes every bounds obligation
+/// *undecidable* rather than false — the negative-offset, valid-region-fits and
+/// reads-past-the-end checks then pass silently and codegen lowers whatever the
+/// element happens to reduce to (its last leaf, for a nested tuple). Reject it
+/// here, at the operator boundary, on the same terms ``tensor.slice`` uses for
+/// its own shape and offset tuples.
+///
+/// ``IsInt()`` (not ``IsIndexLike()``) is the bar because every integer width is
+/// legitimate all the way down: ``EmitCastToIndex`` exists precisely to widen a
+/// non-INDEX integer offset at the partition_view site.
+///
+/// ``role`` names the operand in the diagnostic using the spelling the DSL
+/// exposes (``offset`` / ``shapes`` / ``valid_shape``), so the message points at
+/// the argument the author actually wrote.
+void ValidateIntScalarTupleElements(const MakeTuplePtr& tuple, const std::string& op_name, const char* role) {
+  for (size_t i = 0; i < tuple->elements_.size(); ++i) {
+    const ExprPtr& elem = tuple->elements_[i];
+    CHECK(elem) << op_name << " " << role << " tuple element " << i << " must not be null";
     auto scalar_type = As<ScalarType>(elem->GetType());
-    CHECK_SPAN(scalar_type, elem->span_) << op_name << " offset tuple element " << i
+    CHECK_SPAN(scalar_type, elem->span_) << op_name << " " << role << " tuple element " << i
                                          << " must be ScalarType, but got " << elem->GetType()->TypeName();
     CHECK_SPAN(scalar_type->dtype_.IsInt(), elem->span_)
-        << op_name << " offset tuple element " << i << " must have integer dtype, but got "
+        << op_name << " " << role << " tuple element " << i << " must have integer dtype, but got "
         << scalar_type->dtype_.ToString();
   }
 }
@@ -141,19 +148,21 @@ TypePtr DeduceTileLoadType(const std::vector<ExprPtr>& args,
   CHECK(offsets_tuple) << "The operator " << op_name
                        << " requires second argument to be a tuple (offsets), but got "
                        << args[1]->GetType()->TypeName();
-  ValidateOffsetTupleElements(offsets_tuple, op_name);
+  ValidateIntScalarTupleElements(offsets_tuple, op_name, "offset");
 
   // Third argument must be TupleType (shapes)
   auto shapes_tuple = As<MakeTuple>(args[2]);
   CHECK(shapes_tuple) << "The operator " << op_name
                       << " requires third argument to be a tuple (shapes), but got "
                       << args[2]->GetType()->TypeName();
+  ValidateIntScalarTupleElements(shapes_tuple, op_name, "shapes");
 
   // Fourth argument must be TupleType (valid_shape)
   auto valid_shape_tuple = As<MakeTuple>(args[3]);
   CHECK(valid_shape_tuple) << "The operator " << op_name
                            << " requires fourth argument to be a tuple (valid shape), but got "
                            << args[3]->GetType()->TypeName();
+  ValidateIntScalarTupleElements(valid_shape_tuple, op_name, "valid_shape");
 
   // Verify offsets, shapes and valid_shape have same number of dimensions
   CHECK(offsets_tuple->elements_.size() == shapes_tuple->elements_.size())
@@ -361,7 +370,7 @@ TypePtr DeduceTileStoreType(const std::vector<ExprPtr>& args,
   CHECK(offsets_tuple) << "The operator " << op_name
                        << " requires second argument to be a tuple (offsets), but got "
                        << args[1]->GetType()->TypeName();
-  ValidateOffsetTupleElements(offsets_tuple, op_name);
+  ValidateIntScalarTupleElements(offsets_tuple, op_name, "offset");
 
   // Third argument must be the output tensor. AsTensorTypeLike accepts both
   // plain TensorType and DistributedTensorType — the latter is needed for the
@@ -383,6 +392,7 @@ TypePtr DeduceTileStoreType(const std::vector<ExprPtr>& args,
                         << " requires optional 4th argument to be a shapes tuple (MakeTuple)";
     CHECK(!shapes_tuple->elements_.empty())
         << "The operator " << op_name << " requires non-empty shapes tuple when provided";
+    ValidateIntScalarTupleElements(shapes_tuple, op_name, "shapes");
     CHECK(shapes_tuple->elements_.size() == offsets_tuple->elements_.size())
         << "The operator " << op_name
         << " requires shapes and offsets to have the same number of dimensions, but got "

--- a/tests/ut/ir/operators/test_tile_ops.py
+++ b/tests/ut/ir/operators/test_tile_ops.py
@@ -5210,6 +5210,122 @@ class TestTileLoadStoreOffsetElements:
                 return pl.store(a, [0, 0], out)
 
 
+class TestTileLoadStoreShapeElements:
+    """tile.load / tile.store shapes and valid_shape must be integer scalars too.
+
+    Same family as the offsets check above, and the same stakes: a non-scalar
+    element makes ``InferWindowReadValidShape``'s obligations undecidable, so the
+    "valid region fits the window" and "reads past the end" checks stop firing
+    and codegen lowers the tuple's last leaf. A nested ``valid_shape`` compiled to
+    a ``tload`` reading 200 rows of a 128-row tensor into a 64-row tile.
+    """
+
+    @staticmethod
+    def _tensor() -> ir.Var:
+        return ir.Var("a", ir.TensorType([128, 128], DataType.FP32), ir.Span.unknown())
+
+    @staticmethod
+    def _nested(first: int, second: int) -> list[ir.Expr]:
+        """A rank-2 tuple one nesting level too deep — ``[[f, s], [f, s]]``."""
+        span = ir.Span.unknown()
+        row = ir.MakeTuple(
+            [ir.ConstInt(first, DataType.INDEX, span), ir.ConstInt(second, DataType.INDEX, span)], span
+        )
+        return [row, row]
+
+    def test_load_rejects_tuple_shapes_element(self):
+        with pytest.raises(ValueError, match=r"tile\.load shapes tuple element 0 must be ScalarType"):
+            tile.load(self._tensor(), [0, 0], self._nested(0, 64))
+
+    def test_load_rejects_float_shapes_element(self):
+        span = ir.Span.unknown()
+        shapes = [ir.ConstFloat(64.0, DataType.FP32, span), ir.ConstInt(64, DataType.INDEX, span)]
+
+        with pytest.raises(ValueError, match=r"tile\.load shapes tuple element 0 must have integer dtype"):
+            tile.load(self._tensor(), [0, 0], shapes)
+
+    def test_load_rejects_tuple_valid_shape_element(self):
+        with pytest.raises(ValueError, match=r"tile\.load valid_shape tuple element 0 must be ScalarType"):
+            tile.load(self._tensor(), [0, 0], [64, 64], self._nested(0, 40))
+
+    def test_load_rejects_float_valid_shape_element(self):
+        span = ir.Span.unknown()
+        valid = [ir.ConstFloat(40.0, DataType.FP32, span), ir.ConstInt(64, DataType.INDEX, span)]
+
+        with pytest.raises(
+            ValueError, match=r"tile\.load valid_shape tuple element 0 must have integer dtype"
+        ):
+            tile.load(self._tensor(), [0, 0], [64, 64], valid)
+
+    def test_load_accepts_non_index_integer_extents(self):
+        """The bar is IsInt, not IsIndexLike — an INT32 extent is legitimate."""
+        span = ir.Span.unknown()
+        shapes = [ir.ConstInt(64, DataType.INT32, span), ir.ConstInt(64, DataType.INT32, span)]
+
+        call = tile.load(self._tensor(), [0, 0], shapes)
+
+        assert isinstance(call.type, ir.TileType)
+
+    def test_load_accepts_symbolic_extents(self):
+        """Dynamic shapes stay legal: a symbolic integer scalar is a valid extent."""
+        span = ir.Span.unknown()
+        rows = ir.Var("rows", ir.ScalarType(DataType.INDEX), span)
+
+        call = tile.load(self._tensor(), [0, 0], [64, 64], [rows, ir.ConstInt(64, DataType.INDEX, span)])
+
+        assert isinstance(call.type, ir.TileType)
+
+    def test_tuple_valid_shape_no_longer_hides_oversized_request(self):
+        """The plain-int form is rejected for exceeding the window; so is the nested one."""
+        with pytest.raises(ValueError, match="which exceeds the window extent"):
+            tile.load(self._tensor(), [0, 0], [64, 64], [200, 64])
+
+        with pytest.raises(ValueError, match=r"tile\.load valid_shape tuple element 0 must be ScalarType"):
+            tile.load(self._tensor(), [0, 0], [64, 64], self._nested(200, 200))
+
+    def test_store_rejects_tuple_shapes_element(self):
+        """tile.store's optional 4th operand carries the ND partition shape."""
+        loaded = tile.load(self._tensor(), [0, 0], [64, 64])
+        tile_var = ir.Var("t", loaded.type, ir.Span.unknown())
+        out = ir.Var("out", ir.TensorType([128, 128], DataType.FP32), ir.Span.unknown())
+
+        with pytest.raises(ValueError, match=r"tile\.store shapes tuple element 0 must be ScalarType"):
+            tile.store(tile_var, [0, 0], out, self._nested(0, 64))
+
+    def test_dsl_load_rejects_nested_valid_shape_positional(self):
+        """The user-facing path: an author who reads valid_shape as [start, extent] pairs.
+
+        Positionally, the parser resolves the closure var into a tuple of tuples,
+        so the deducer is what has to reject it — this spelling used to compile to
+        an out-of-bounds ``tload`` with no diagnostic at any layer. The var is
+        annotated ``Any``, as in the offsets case above, so the shape of the value
+        is only knowable at parse time: exactly what a static checker cannot catch.
+        """
+        pairs: Any = [[0, 40], [0, 56]]
+
+        with pytest.raises(InvalidOperationError, match="valid_shape tuple element 0 must be ScalarType"):
+
+            @pl.function
+            def func(
+                t: pl.Tensor[[128, 128], pl.FP32], out: pl.Tensor[[128, 128], pl.FP32]
+            ) -> pl.Tensor[[128, 128], pl.FP32]:
+                a = pl.load(t, [0, 0], [64, 64], pairs)
+                return pl.store(a, [0, 0], out)
+
+    def test_dsl_load_rejects_nested_valid_shape_keyword(self):
+        """Spelled as a kwarg the list never becomes IR, so the builder reports it."""
+        pairs: Any = [[0, 40], [0, 56]]
+
+        with pytest.raises(InvalidOperationError, match="one bracket level, not nested pairs"):
+
+            @pl.function
+            def func(
+                t: pl.Tensor[[128, 128], pl.FP32], out: pl.Tensor[[128, 128], pl.FP32]
+            ) -> pl.Tensor[[128, 128], pl.FP32]:
+                a = pl.load(t, [0, 0], [64, 64], valid_shape=pairs)
+                return pl.store(a, [0, 0], out)
+
+
 class TestTileCreateOp:
     """Tests for tile.create layout inference."""
 


### PR DESCRIPTION
## Summary

- validate that every element of `tile.load`'s `shapes` / `valid_shape` and `tile.store`'s optional `shapes` is a `ScalarType` with an integer dtype, closing the last three slots in the family #2565 started
- restore the valid-region-fits and reads-past-the-end proofs, which a malformed extent had been silently switching off
- give the DSL's keyword spelling of the same mistake a diagnostic that names it, instead of a bare `Cannot convert <class 'list'>`

## Why

#2565 gave the `offsets` tuple of `tile.load` / `tile.store` an element-wise check. The `shapes` and `valid_shape` tuples on the same two ops never got one, even though both op registrations declare them "TupleType of ScalarType" — so the same silent miscompile stayed reachable through a different argument.

Nothing downstream compensates, by design. `InferWindowReadValidShape`'s obligations are defined only over integer scalars, so a non-scalar element makes them *undecidable* rather than false. The checks then pass, and codegen lowers whatever the element reduces to — its last leaf, for a nested tuple.

A realistic way to write it: reading `valid_shape` as per-dim `[start, extent]` pairs, mirroring the `offsets` / `shapes` pair right before it.

```python
@pl.function(type=pl.FunctionType.InCore)
def kernel(self, a: pl.Tensor[[128, 128], pl.FP32],
           out: pl.Tensor[[128, 128], pl.FP32]) -> pl.Tensor[[128, 128], pl.FP32]:
    # meant: valid_shape=[200, 64] — already too big for a 128-row source
    t = pl.load(a, [0, 0], [64, 64], [[200, 200], [64, 64]])
    return pl.store(t, [0, 0], out)
```

With plain ints, `valid_shape=[200, 64]` is rejected by `tile.load` itself:

```
tile.load valid_shape 0 is 200, which exceeds the window extent 64;
a valid region cannot be larger than the shape that holds it
```

With the extra bracket level it compiled clean, all the way to valid PTO:

```mlir
%t = pto.alloc_tile addr = %c0_i64 valid_row = %c200_index valid_col = %c64_index
     : !pto.tile_buf<loc=vec, dtype=f32, rows=64, cols=64, ...>   // 200 valid rows in a 64-row tile
%a_pview = pto.partition_view %a_view, offsets = [%c0, %c0], sizes = [%c200_index, %c64_index]
pto.tload  ins(%a_pview) outs(%t)                                  // reads 200 rows of a 128-row tensor
pto.tstore ins(%t) outs(%out_pview)                                // writes 200 rows into a 128-row output
```

— an out-of-bounds GM read *and* an out-of-bounds store, no diagnostic at any layer.

The benign case is arguably worse: `valid_shape=[[0, 40], [0, 56]]` emits `valid_row = 40, valid_col = 56`, which looks correct and quietly confirms the wrong mental model.

The other two slots fail less catastrophically but still badly. A nested `shapes` lands in `TileType.shape_` and dies 20 passes later in `InitMemRef` with `InternalError: requires static shape for variable 't__ssa_v0' ... Fix the upstream op` — naming neither `tile.load` nor the nested tuple. `tile.store`'s optional `shapes` is accepted and silently ignored.

## Notes for reviewers

**The bar stays `IsInt()`**, matching what `tensor.slice` enforces for its own `shape` tuple. Non-INDEX integer extents (INT32) and symbolic dynamic extents remain legal — both are covered by a test, since a stricter bar would break ordinary dynamic-shape kernels.

**Only the positional spelling reached the deducer.** The DSL parser turns a list literal into a `MakeTuple` recursively; `_wrap_arg` unwraps exactly one level, so inner `MakeTuple`s arrive as `ir.Expr` and sail through `_to_make_tuple`. Spelled as a kwarg (`valid_shape=[[...]]`) the list never becomes IR at all — it died in `_normalize_expr` with `Cannot convert <class 'list'> to IR expression`, an op-agnostic `TypeError` naming neither the argument nor the mistake. Two spellings of one mistake, two unrelated behaviours. This adds a nested-sequence branch at that shared conversion point, so both now report something actionable. Nothing in-tree matched on the old message.

**Helper rename.** `ValidateOffsetTupleElements` becomes `ValidateIntScalarTupleElements(tuple, op_name, role)`; `role` names the operand with the spelling the DSL exposes (`offset` / `shapes` / `valid_shape`) so the message points at the argument the author wrote. Existing `offset` messages are unchanged.

**DSL tests use an `Any`-annotated closure var**, as the offsets tests do — pyright rejects a nested list literal statically, so the value's shape has to be knowable only at parse time for the test to exercise what a checker cannot catch.

## Testing

- `python -m pytest tests/ut/ir/operators/test_tile_ops.py -k "TileLoadStoreShapeElements or TileLoadStoreOffsetElements" -n "$PYPTO_TEST_JOBS" -v` — 17 passed (10 new)
- `python -m pytest tests/ut/ tests/lint/ -n "$PYPTO_TEST_JOBS"` — 10787 passed, 3 skipped, 1 xfailed
- `python -m pytest tests/st/codegen -n "$PYPTO_TEST_JOBS"` — 60 passed
- `ctest --parallel "$PYPTO_TEST_JOBS"` — 1/1 passed
- `pre-commit run --files src/ir/op/tile_ops/memory.cpp python/pypto/ir/utils.py python/pypto/ir/op/tile_ops.py python/pypto/language/op/tile_ops.py tests/ut/ir/operators/test_tile_ops.py`
