### PR TITLE
perf(ci): precompile the L3 system tests off the cards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1428,9 +1428,56 @@ jobs:
           pto-isa-commit: ${{ needs.toolchain.outputs.pto_isa_commit }}
           unset-ring: 'true'
 
+      - name: Precompile distributed artifacts (card-free)
+        # Pass 1 of two. Over half of this suite's wall clock used to be compile
+        # work done while holding two NPUs idle: profiling the serial run put
+        # ir.compile + the per-chip ptoas/ccec build at ~277s of ~620s, against
+        # only ~126s of actual device dispatch. None of that needs a card, so it
+        # runs here instead — on the CPU host, fanned out under -n, before any
+        # card is borrowed.
+        #
+        # Each test's program is compiled into a slot under --precompile-dir and
+        # its chip binaries built there; the run then stops at the first device
+        # edge. Pass 2 rebinds each usable slot via
+        # DistributedCompiledProgram.from_dir and avoids recompiling; a missing
+        # or unusable slot falls back to compiling in place. The artifact does
+        # not depend on which cards it will run on (ir.compile consumes
+        # distributed_config only after codegen),
+        # so --device here is a placeholder that exists only to give the cases the
+        # same rank count pass 2 will have -- these two ids are never touched.
+        #
+        # The store is keyed by test id, not by content, which is sound only
+        # because both passes run from this one checkout inside this one job.
+        # RUNNER_TEMP is per-job, so it cannot leak into a later job on this
+        # persistent runner; reusing a store across commits would serve stale
+        # binaries. Do not point this at a shared or persistent directory.
+        #
+        # A codegen regression now fails here, in ~40s, without having claimed an
+        # NPU at all.
+        timeout-minutes: 20
+        run: |
+          source activate.sh
+          rm -rf "$RUNNER_TEMP/dist-precompile"
+          python -m pytest tests/st/distributed -q -n 16 \
+            --precompile-dir="$RUNNER_TEMP/dist-precompile" --precompile-only \
+            --device=0,1 \
+            --ignore=tests/st/distributed/test_l2_multi_orch.py
+
       - name: Test distributed system tests
+        # Pass 2 of two: the device half, still on two cards. --precompile-dir
+        # points at what the card-free step just built, so the borrowed cards do
+        # device work and essentially no compilation (a warm chip sub-build is
+        # ~0.05s against ~1.6s cold). A missing or unusable slot silently falls
+        # back to compiling in place, so this step is correct on its own if pass 1
+        # is ever skipped -- just slower.
+        #
+        # Measured on a two-card box: 746s -> 383s here, with pass 1 adding ~40s
+        # that holds no card. Card-seconds roughly halve. Widening this step with
+        # xdist would cut wall clock further but needs two cards per worker;
+        # tests/st/conftest.py partitions --device for that if it is ever wanted.
+        #
         # The step clock includes both task-submit queueing and the device run.
-        # Keep enough headroom for a typical ~10-minute suite after waiting for
+        # Keep enough headroom for a typical ~7-minute suite after waiting for
         # a two-card slot; --max-time below still caps device execution at 30m,
         # so leave the step budget above that or the runner kills the task
         # before task-submit can report the cap cleanly.
@@ -1443,13 +1490,21 @@ jobs:
         run: |
           source activate.sh
           task-submit --device "$DEVICE_ID" --device-num 2 --timeout 3600 --max-time 1800 \
-            --run "cd $GITHUB_WORKSPACE/dist-checkout && source activate.sh && python -m pytest tests/st/distributed -v --device=\$TASK_DEVICE --ignore=tests/st/distributed/test_l2_multi_orch.py"
+            --run "cd $GITHUB_WORKSPACE/dist-checkout && source activate.sh && python -m pytest tests/st/distributed -v --precompile-dir=$RUNNER_TEMP/dist-precompile --device=\$TASK_DEVICE --ignore=tests/st/distributed/test_l2_multi_orch.py"
 
       - name: Kill orphaned task-submit tasks
         if: always()
         uses: ./.github/actions/kill-orphaned-tasks
         with:
           checkout-path: dist-checkout
+
+      - name: Drop the precompile store
+        # Keyed by test id, so it is only ever valid for the commit that built
+        # it. RUNNER_TEMP is per-job, but delete it explicitly rather than rely
+        # on that: a store surviving into another commit's job would hand it
+        # binaries built from different sources.
+        if: always()
+        run: rm -rf "$RUNNER_TEMP/dist-precompile"
 
   pypto-lib-model:
     # No container: each model run borrows an NPU from the host-level

--- a/docs/en/dev/03-runtime-replay.md
+++ b/docs/en/dev/03-runtime-replay.md
@@ -237,6 +237,38 @@ and validated field by field on load — including the `distributed_config` bloc
 — so a hand-edited or truncated sidecar fails with one `ValueError` naming the
 file and the recompile that regenerates it.
 
+### Building the binaries before you have a card
+
+Chip binaries are built the first time a program is prepared or called, which
+puts the whole ptoas/ccec + g++ toolchain on the critical path of a run that is
+already holding devices. `build_binaries()` performs exactly that work and
+nothing else, so it can run on a plain CPU host:
+
+```python
+prog = DistributedCompiledProgram.from_dir("build_output/<jit_dir>/")
+prog.build_binaries()          # ptoas/ccec + g++ only; no NPU, no fork
+```
+
+Each `next_levels/<name>/` sub-build is compiled and its `.o`/`.so` land in that
+sub-build's `cache/`, stamped with the runtime and PTO-ISA identity they were
+built against. A later `prepare()` / `__call__()` on the same directory reuses
+them — from a different process too, and through `from_dir` from a directory
+this object did not produce. Measured on a three-sub-build host collective, a
+warm assembly costs ~0.05s against ~1.6s cold.
+
+The binaries do not depend on `device_ids`: `ir.compile` consumes
+`distributed_config` only after codegen, so a directory built this way replays
+on any card set via the `distributed_config` override above. That is what lets
+compilation and execution be separated in space or time — warm a serving
+worker's binaries before it borrows a device, or precompile a whole test suite
+off the cards and hand the artifacts to a short device run. `tests/st/README.md`
+describes the two-pass form the distributed system tests use.
+
+**This is not a general compile cache.** The reuse is keyed by directory, and
+the generated-kernel binary cache inside it is keyed by position rather than by
+content, so recompiling *different* sources into a directory that already holds
+binaries reuses the stale ones. Build into a fresh directory per commit.
+
 L3 replay forwards runtime DFX fields from `RunConfig` through each chip
 dispatch. Artifacts are written under
 `dfx_outputs/rank{r}/d{k}/`; onboard swimlane uses the graph/timing two-pass

--- a/docs/zh/dev/03-runtime-replay.md
+++ b/docs/zh/dev/03-runtime-replay.md
@@ -218,6 +218,34 @@ post-SSA 名字），chip callables 通过遍历 `next_levels/` 重建；
 （含 `distributed_config` 块）。所以手改或被截断的 sidecar 会以一个
 `ValueError` 失败，并指明文件名与重新编译的修复方式。
 
+### 在拿到卡之前就把二进制编好
+
+芯片二进制默认在第一次 prepare / 调用时才编译，于是整条 ptoas/ccec + g++ 工具链
+就压在一次已经占着卡的运行的关键路径上。`build_binaries()` 只做这部分工作、不做
+别的，因此可以在一台没有 NPU 的 CPU 机器上跑：
+
+```python
+prog = DistributedCompiledProgram.from_dir("build_output/<jit_dir>/")
+prog.build_binaries()          # 只有 ptoas/ccec + g++；不碰 NPU，不 fork
+```
+
+每个 `next_levels/<name>/` 子构建都会被编译，`.o`/`.so` 落在该子构建自己的
+`cache/` 下，并盖上它们所依据的 runtime 与 PTO-ISA 身份图章。之后对同一目录的
+`prepare()` / `__call__()` 会直接复用 —— 换一个进程也算，通过 `from_dir` 复用一个
+并非本对象产出的目录也算。在一个三子构建的 host collective 上实测：冷编 ~1.6s，
+热装配 ~0.05s。
+
+这些二进制与 `device_ids` 无关：`ir.compile` 只在 codegen **之后**才消费
+`distributed_config`，所以这样编出来的目录可以通过上面的 `distributed_config`
+覆盖在任意卡集合上重放。这正是编译与执行得以在空间或时间上分离的原因 —— 既可以
+在 serving worker 借卡之前预热它的二进制，也可以把整个测试套件在卡外预编译、再把
+产物交给一次短暂的上卡运行。`tests/st/README.md` 描述了分布式系统测试采用的两趟
+形式。
+
+**这不是通用的编译缓存。** 复用是按目录为键的，而目录内部那层生成 kernel 的二进制
+缓存又是按位置而非内容为键，所以把**不同的**源码编进一个已有二进制的目录会复用到
+陈旧的产物。请为每个 commit 编进全新目录。
+
 L3 replay 会把 `RunConfig` 中的运行时 DFX 字段透传到每个芯片派发，产物写入
 `dfx_outputs/rank{r}/d{k}/`；onboard 泳道使用
 [运行时 DFX 开关](03-runtime-dfx.md) 里描述的抓图/计时两趟协议。

--- a/python/pypto/ir/distributed_compiled_program.py
+++ b/python/pypto/ir/distributed_compiled_program.py
@@ -573,6 +573,40 @@ class DistributedCompiledProgram:
             startup_timeout_s=startup_timeout_s,
         )
 
+    def build_binaries(self) -> int:
+        """Build every chip sub-build's kernel and orchestration binaries, card-free.
+
+        This is the device-independent half of the work that :meth:`prepare` and
+        :meth:`__call__` would otherwise do on the critical path: each
+        ``next_levels/<name>/`` sub-build is run through the ptoas/ccec and g++
+        toolchains and its ``.o``/``.so`` land in that sub-build's ``cache/``,
+        stamped with the runtime and PTO-ISA identity they were built against.
+        No NPU is touched and no worker is forked, so it can run on a plain CPU
+        host, ahead of time, or concurrently with other programs.
+
+        A later :meth:`prepare` / :meth:`__call__` on this same ``output_dir``
+        reuses those binaries instead of rebuilding them — including from a
+        different process, and (via :meth:`from_dir`) from a build directory this
+        object did not produce. That is what makes "compile everywhere, execute
+        where the cards are" possible: warm a serving worker's binaries before it
+        borrows a device, or precompile a whole test suite off the cards.
+
+        The binaries do not depend on ``device_ids``: the distributed config is
+        consumed only after codegen, so a directory built here replays on any
+        card set (see :meth:`from_dir`'s ``distributed_config`` override).
+
+        Returns:
+            The number of chip sub-builds that were assembled.
+
+        Raises:
+            RuntimeError: The build directory contains no chip-level sub-build,
+                or its sub-builds disagree on the runtime to link against.
+        """
+        from pypto.runtime.distributed_runner import _assemble_chip_callables  # noqa: PLC0415
+
+        chip_callables, _runtime_name, _enable_sdma = _assemble_chip_callables(self)
+        return len(chip_callables)
+
     @staticmethod
     def _build_full_args(input_args, param_infos, output_indices):
         output_set = set(output_indices)

--- a/python/pypto/runtime/distributed_runner.py
+++ b/python/pypto/runtime/distributed_runner.py
@@ -370,18 +370,35 @@ def _assemble_chip_callables(
     runtime_name: str | None = None
     enable_sdma = False
     next_levels_dir = compiled.output_dir / "next_levels"
-    if next_levels_dir.is_dir():
-        for chip_dir in sorted(next_levels_dir.iterdir()):
-            if not (chip_dir / "kernel_config.py").exists():
-                continue
-            # Imported lazily — and only once there is a real chip to build — so
-            # the "no chip-level tasks" error path below stays usable without the
-            # heavy device_runner → simpler toolchain import.
-            from pypto.runtime.device_runner import compile_and_assemble  # noqa: PLC0415
+    chip_dirs = (
+        [d for d in sorted(next_levels_dir.iterdir()) if (d / "kernel_config.py").exists()]
+        if next_levels_dir.is_dir()
+        else []
+    )
+    if chip_dirs:
+        # Imported lazily — and only once there is a real chip to build — so
+        # the "no chip-level tasks" error path below stays usable without the
+        # heavy device_runner → simpler toolchain import.
+        from pypto.runtime.device_runner import compile_and_assemble  # noqa: PLC0415
 
-            chip_callable, chip_runtime, chip_runtime_config = compile_and_assemble(
-                chip_dir, compiled.platform
-            )
+        # Sub-builds are independent: each owns its work_dir, its own
+        # ``binary_context_lock``, and its own toolchain invocations, and the
+        # per-sub-build cost is dominated by ptoas/ccec + g++ process startup
+        # rather than by CPU. Building them concurrently turns a P-chip
+        # program's assembly from P serial windows into one — measured on a
+        # host all_to_all_v (4 sub-builds), 6.6s → 1.6s. Results are zipped back
+        # onto ``chip_dirs`` in sorted order so the runtime-mismatch error below
+        # names the same chip regardless of completion order.
+        if len(chip_dirs) == 1:
+            results = [compile_and_assemble(chip_dirs[0], compiled.platform)]
+        else:
+            with ThreadPoolExecutor(
+                max_workers=len(chip_dirs), thread_name_prefix="pypto-chip-build"
+            ) as pool:
+                results = list(pool.map(lambda d: compile_and_assemble(d, compiled.platform), chip_dirs))
+        for chip_dir, (chip_callable, chip_runtime, chip_runtime_config) in zip(
+            chip_dirs, results, strict=True
+        ):
             chip_callables[chip_dir.name] = chip_callable
             enable_sdma = enable_sdma or bool(chip_runtime_config.get("enable_sdma", False))
             if runtime_name is None:

--- a/tests/st/README.md
+++ b/tests/st/README.md
@@ -49,7 +49,9 @@ Test Case Definition → Build IR → Generate Kernels → Compile → Execute �
 
 ## Running Tests
 
-**Important:** The `--forked` flag is required for running system tests.
+**Important:** The `--forked` flag is required for running system tests, except
+for the L3 distributed suite (`tests/st/distributed`), which CI and the
+distributed examples below run without it.
 
 ### Basic Test Execution
 
@@ -206,12 +208,14 @@ The test framework provides extensive configuration through pytest command-line 
 | Option | Default | Description |
 | ------ | ------- | ----------- |
 | `--platform` | `a2a3` | Comma-separated allowlist of target platforms. Each runtime test case is parametrized over `a2a3`, `a5`, `a2a3sim`, `a5sim`; only variants whose id appears here run. |
-| `--device` | `0` | Device ID for hardware tests (0, 1, 2, ...) |
+| `--device` | `0` | Card(s) this session owns: a single id (`0`), an inclusive range (`0-7`), a comma-separated list (`0,1,12`), or a mix. Under `pytest-xdist` the list is partitioned across the workers (see below). |
 | `--strategy` | `Default` | PyPTO optimization strategy (`Default` is the only supported value) |
 | `--save-kernels` | `False` | Save generated kernels and artifacts to disk |
 | `--kernels-dir` | `build_output/{testName}_{timestamp}/` | Custom output directory for saved kernels |
 | `--dump-passes` | `False` | Dump intermediate IR after each compiler pass |
 | `--codegen-only` | `False` | Only generate code, skip runtime execution |
+| `--precompile-dir` | `None` | Shared store for distributed (L3) build artifacts, keyed by test id (see below) |
+| `--precompile-only` | `False` | Card-free pass 1 for `--precompile-dir`: compile and build binaries, then stop before any device work |
 
 ### Usage Examples
 
@@ -228,12 +232,81 @@ pytest tests/st/ -v --forked --save-kernels --kernels-dir ./my_test_outputs
 # Enable compiler pass dumps for debugging
 pytest tests/st/ -v --forked --save-kernels --dump-passes
 
+# Run the L3 distributed suite on two xdist workers, two cards each
+pytest tests/st/distributed -v -n 2 --dist=loadfile --device=0,1,2,3
+
 # Generate code without running (for code inspection)
 pytest tests/st/ -v --forked --codegen-only --save-kernels
 
 # Combine multiple options
 pytest tests/st/ -v --forked --platform=a2a3sim --save-kernels --dump-passes
 ```
+
+### Running on Several Cards at Once (xdist)
+
+Every `pytest-xdist` worker is its own process, so a shared `--device` list would
+put two workers on one card. `tests/st/conftest.py` therefore partitions the list
+across the workers before any fixture reads it, and gives each worker its own
+`PYPTO_PROG_BUILD_DIR` so two workers never share an `ir.compile` output
+directory.
+
+Give each worker as many cards as its heaviest case needs — a distributed case
+takes `device_ids[:n_ranks]` out of its worker's share, and skips itself when the
+share is too small:
+
+```bash
+# 4 cards, 2 workers, 2 ranks per worker
+pytest tests/st/distributed -v -n 2 --dist=loadfile --device=0,1,2,3
+```
+
+`--dist=loadfile` keeps a file's cases on one worker, which matters for files
+whose cases reuse compiled state. Fewer cards than workers is a `UsageError`
+rather than a silently double-booked card; a pool that does not divide evenly
+hands the first workers one extra card each rather than dropping the tail. Both
+rules apply only to runs that touch a card — the card-free modes
+(`--codegen-only`, `--precompile-only`) are exempt and may fan out past the card
+count, as pass 1 below does.
+
+### Precompiling the Distributed Suite Off the Cards
+
+Most of the L3 suite's wall clock is not device work. Profiling the serial run
+put `ir.compile` plus the per-chip ptoas/ccec build at ~277s of ~620s, against
+only ~126s of actual dispatch — all of that compile time spent holding two NPUs
+idle. `--precompile-dir` splits the run in two so the cards only do device work:
+
+```bash
+D=$(mktemp -d)
+
+# Pass 1 — no card is touched, so fan out as wide as the host allows.
+# --device here only fixes the rank count the cases will see; the ids are unused.
+pytest tests/st/distributed -q -n 16 --precompile-dir="$D" --precompile-only --device=0,1
+
+# Pass 2 — on the borrowed cards, reusing what pass 1 built.
+pytest tests/st/distributed -v --precompile-dir="$D" --device=4,5
+```
+
+Measured on a two-card box: 746s → 370s on the cards, with pass 1 adding ~38s
+that holds no card. A codegen regression now fails in pass 1, in ~38s, without
+claiming an NPU at all.
+
+Pass 1 compiles each test's program into a slot under `$D` and builds its chip
+binaries there via `DistributedCompiledProgram.build_binaries()`, then stops at
+the first device edge. Pass 2 rebinds each usable slot with `from_dir` and
+avoids recompiling; a missing or unusable slot falls back to compiling in place,
+as the constraints below spell out. The artifact does not depend on which cards
+it runs on — `ir.compile` consumes `distributed_config` only after codegen — so
+pass 2 hands it the actually-borrowed ids.
+
+Two constraints:
+
+- **The store is keyed by test id, not by content.** That is sound only because
+  both passes run from one checkout: the sources cannot change between them. A
+  store reused across commits would serve stale binaries. Create it fresh and
+  delete it after.
+- **Slots are optional.** A missing or unusable slot falls back to compiling in
+  place, so pass 2 is correct on its own — just slower. Tests that drive the
+  runtime by hand rather than through `prepare()` / `execute_distributed` skip
+  themselves in pass 1 and compile normally in pass 2.
 
 ## Advanced Usage
 

--- a/tests/st/conftest.py
+++ b/tests/st/conftest.py
@@ -181,6 +181,30 @@ def pytest_addoption(parser):
         help="Only generate code, skip runtime execution (default: False)",
     )
     parser.addoption(
+        "--precompile-dir",
+        action="store",
+        default=None,
+        metavar="DIR",
+        help=(
+            "Shared store for distributed (L3) build artifacts, keyed by test id. "
+            "With --precompile-only this is the destination of a card-free compile "
+            "pass; without it, a run reuses whatever that pass left there instead "
+            "of recompiling on the borrowed cards. Both passes must name the same "
+            "DIR and run from the same checkout."
+        ),
+    )
+    parser.addoption(
+        "--precompile-only",
+        action="store_true",
+        default=False,
+        help=(
+            "Card-free pass 1 for --precompile-dir: compile each distributed test's "
+            "program and build its kernel binaries, then skip before any device "
+            "work. Requires --precompile-dir. Touches no NPU, so it can fan out "
+            "with -n as wide as the host allows."
+        ),
+    )
+    parser.addoption(
         "--precompile-workers",
         action="store",
         default=None,
@@ -373,6 +397,69 @@ def _resolve_device_id(raw: str | int) -> int:
     return _parse_device_option(raw)[0]
 
 
+def _is_card_free_session(config: pytest.Config) -> bool:
+    """True when this session never reaches a device, so it needs no card."""
+    return bool(config.getoption("--codegen-only") or config.getoption("--precompile-only"))
+
+
+def _xdist_worker(config: pytest.Config) -> tuple[int, int] | None:
+    """Return ``(worker_index, worker_count)`` under xdist, else ``None``.
+
+    ``config.workerinput`` exists only in a worker process, so this doubles as
+    the "am I running under xdist?" test for the controller and for a plain
+    single-process session.
+    """
+    worker_input = getattr(config, "workerinput", None)
+    if worker_input is None:
+        return None
+    return int(str(worker_input["workerid"]).removeprefix("gw")), int(worker_input["workercount"])
+
+
+def _partition_devices_for_xdist(config: pytest.Config) -> None:
+    """Give each xdist worker a disjoint slice of ``--device``, in place.
+
+    ``--device`` names the cards this pytest *session* owns. Under xdist every
+    worker is a separate process that would otherwise claim the whole list, so
+    two workers would drive the same card concurrently (``halMemCtl EACCES``, or
+    a wedged collective). Rewriting ``config.option.device`` here — before any
+    fixture or the mechanism-A device pool reads it — partitions the pool once
+    and every downstream consumer (``device_ids``, ``_resolve_device_id``,
+    ``start_pipeline``'s queue) inherits the split with no further change.
+
+    A distributed case slices ``device_ids[:n_ranks]`` out of its worker's share,
+    so an L3 suite wants ``--device-num`` = workers x ranks: ``-n 2`` with four
+    borrowed cards runs two 2-rank workers. Cases needing more ranks than one
+    worker holds skip themselves, exactly as they already do on a small runner.
+
+    A pool that does not divide evenly hands the first ``len(devices) %
+    worker_count`` workers one extra card each rather than dropping the tail:
+    three cards across two workers is ``[0, 1]`` + ``[2]``, so a 2-rank case
+    still runs on the first worker instead of skipping on both while a borrowed
+    card sits idle.
+
+    No-op outside xdist, and under the card-free modes ``--codegen-only`` and
+    ``--precompile-only``: neither reaches a device, so such a sweep may fan out
+    as wide as the machine allows (``-n 16`` against a two-card ``--device``)
+    without the partition refusing it for want of cards.
+    """
+    worker = _xdist_worker(config)
+    if worker is None or _is_card_free_session(config):
+        return
+    worker_index, worker_count = worker
+    devices = _parse_device_option(config.option.device)
+    per_worker, remainder = divmod(len(devices), worker_count)
+    if per_worker < 1:
+        raise pytest.UsageError(
+            f"--device lists {len(devices)} card(s) but pytest-xdist started {worker_count} "
+            "workers; each worker needs at least one card of its own. Borrow more cards "
+            "(task-submit --device-num) or lower -n."
+        )
+    start = worker_index * per_worker + min(worker_index, remainder)
+    stop = start + per_worker + (1 if worker_index < remainder else 0)
+    mine = devices[start:stop]
+    config.option.device = ",".join(str(device) for device in mine)
+
+
 def _parse_platform_filter(raw: str) -> tuple[str, ...]:
     """Parse the comma-separated ``--platform`` value into an ordered tuple.
 
@@ -472,10 +559,19 @@ def _redirect_prog_build_dir(request, tmp_path, monkeypatch):
     When ``--save-kernels`` is set the user wants artifacts preserved under
     ``build_output/``, so redirection is skipped — and any ``PYPTO_PROG_BUILD_DIR``
     inherited from the outer environment is cleared so the default base
-    genuinely stays ``build_output``.
+    genuinely stays ``build_output``. That base is per-worker under xdist:
+    ``ir.compile``'s default directory name is ``<program>_<YYYYmmdd_HHMMSS>``,
+    unique per second and program but not per process, so two workers compiling
+    one program in the same second would otherwise share a directory and race on
+    its generated sources and binary cache. (The non-``--save-kernels`` path is
+    already safe: ``tmp_path`` is per test, hence per worker.)
     """
     if request.config.getoption("--save-kernels"):
-        monkeypatch.delenv("PYPTO_PROG_BUILD_DIR", raising=False)
+        worker = _xdist_worker(request.config)
+        if worker is None:
+            monkeypatch.delenv("PYPTO_PROG_BUILD_DIR", raising=False)
+        else:
+            monkeypatch.setenv("PYPTO_PROG_BUILD_DIR", str(Path("build_output") / f"xdist_gw{worker[0]}"))
         return
     monkeypatch.setenv("PYPTO_PROG_BUILD_DIR", str(tmp_path / "build_output"))
 
@@ -658,6 +754,10 @@ def tensor_shape(request):
 # Skip markers
 def pytest_configure(config):
     """Register custom markers and apply early runtime settings."""
+    if config.getoption("--precompile-only") and not config.getoption("--precompile-dir"):
+        raise pytest.UsageError("--precompile-only requires --precompile-dir=DIR to write into.")
+    # Before anything reads --device: under xdist this worker owns only a slice.
+    _partition_devices_for_xdist(config)
     config.addinivalue_line(
         "markers",
         "platforms(*ids, reason=...): restrict the test to the given platform ids "

--- a/tests/st/distributed/conftest.py
+++ b/tests/st/distributed/conftest.py
@@ -9,6 +9,9 @@
 
 """Shared pytest behavior for distributed system tests."""
 
+import hashlib
+import itertools
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -31,3 +34,110 @@ def disable_runtime_execution_in_codegen_only(request, monkeypatch) -> None:
     monkeypatch.setattr("pypto.runtime.distributed_runner.execute_distributed", skip_execution)
     monkeypatch.setattr(DistributedCompiledProgram, "prepare", skip_execution)
     monkeypatch.setattr(DistributedWorker, "__init__", skip_execution)
+
+
+def _artifact_dir(store: Path, nodeid: str, call_index: int) -> Path:
+    """Return this test's slot for its *call_index*-th ``ir.compile``.
+
+    Keyed by test id rather than by content, which is sound only because both
+    passes run from one checkout inside a single CI step: the sources cannot
+    change between them, so a slot's artifact is by construction the one this
+    test would have compiled. It is NOT a general compile cache — reusing a
+    store across commits would serve stale binaries (the generated-kernel binary
+    cache is keyed by position, not content). CI creates the store fresh per job
+    and deletes it after; keep it that way.
+
+    The digest keeps the path short and filesystem-safe; parametrised node ids
+    carry ``[...]``, ``/`` and ``::``.
+    """
+    return store / f"{hashlib.sha256(nodeid.encode()).hexdigest()[:16]}_{call_index}"
+
+
+@pytest.fixture(autouse=True)
+def _precompiled_artifacts(request, monkeypatch) -> None:
+    """Route ``ir.compile`` through the ``--precompile-dir`` artifact store.
+
+    Splits a distributed run into the half that needs no card and the half that
+    does. ``--precompile-only`` (pass 1) compiles each program into its slot and
+    builds the chip binaries there via
+    :meth:`DistributedCompiledProgram.build_binaries`, then skips before any
+    device work — so it can fan out under ``-n`` on a card-free host. A later run
+    naming the same store (pass 2) rebinds each slot with
+    :meth:`DistributedCompiledProgram.from_dir` and never recompiles, leaving the
+    borrowed cards to do only device work.
+
+    The artifact does not depend on the cards it will run on: ``ir.compile``
+    consumes ``distributed_config`` only after codegen, so pass 2 hands its real
+    ``DistributedConfig`` (the actually-borrowed ``device_ids``) to ``from_dir``.
+
+    Degrades to a plain compile whenever a slot is missing — a test whose compile
+    count or node id differs between the passes still runs, just without the
+    saving. Non-distributed programs are left alone: they write no
+    ``distributed_meta.json``, so no slot ever matches them.
+    """
+    store_opt = request.config.getoption("--precompile-dir")
+    if not store_opt:
+        return
+
+    from pypto import ir  # noqa: PLC0415
+    from pypto.ir.distributed_compiled_program import DistributedCompiledProgram  # noqa: PLC0415
+
+    store = Path(store_opt)
+    precompile_only = request.config.getoption("--precompile-only")
+    nodeid = request.node.nodeid
+    call_index = itertools.count()
+    real_compile = ir.compile
+
+    def compile_via_store(program: Any, **kwargs: Any) -> Any:
+        if kwargs.get("output_dir") is not None:
+            # The caller picked its own build directory and reads artifacts back
+            # out of it (``test_l3_manual`` hands that path to a manual L2/L3
+            # flow). Redirecting it into a slot would break the test, so this
+            # call keeps its directory and takes no slot — a decision both passes
+            # reach identically, which is what keeps their slot indices aligned.
+            return real_compile(program, **kwargs)
+        slot = _artifact_dir(store, nodeid, next(call_index))
+        if not precompile_only and (slot / "distributed_meta.json").exists():
+            return DistributedCompiledProgram.from_dir(
+                slot,
+                platform=kwargs.get("platform"),
+                distributed_config=kwargs.get("distributed_config"),
+            )
+        compiled = real_compile(program, output_dir=str(slot), **kwargs)
+        if precompile_only and isinstance(compiled, DistributedCompiledProgram):
+            compiled.build_binaries()
+        return compiled
+
+    monkeypatch.setattr(ir, "compile", compile_via_store)
+
+
+@pytest.fixture(autouse=True)
+def _skip_device_work_when_precompiling(request, monkeypatch) -> None:
+    """Under ``--precompile-only``, stop each test at its first device edge.
+
+    Mirrors :func:`disable_runtime_execution_in_codegen_only`, but deliberately
+    later: the compile *and* the chip-binary build must both happen (that is the
+    point of the pass), so only the execution edges are cut.
+
+    ``simpler.worker.Worker`` is cut too, which is what makes the pass safe to
+    run off the cards without knowing which tests are precompilable. A test that
+    drives the runtime by hand rather than through ``prepare`` /
+    ``execute_distributed`` (``test_l3_manual``) would otherwise reach a real
+    device here; instead it skips, warms nothing, and compiles normally in pass 2.
+    """
+    if not request.config.getoption("--precompile-only"):
+        return
+
+    import simpler.worker  # noqa: PLC0415  # pyright: ignore[reportMissingImports]
+    from pypto.ir.distributed_compiled_program import DistributedCompiledProgram  # noqa: PLC0415
+    from pypto.runtime.distributed_runner import DistributedWorker  # noqa: PLC0415
+
+    def skip_execution(*args: Any, **kwargs: Any) -> None:
+        del args, kwargs
+        pytest.skip("--precompile-only stops before device execution")
+
+    monkeypatch.setattr("pypto.runtime.runner.execute_compiled", skip_execution)
+    monkeypatch.setattr("pypto.runtime.distributed_runner.execute_distributed", skip_execution)
+    monkeypatch.setattr(DistributedCompiledProgram, "prepare", skip_execution)
+    monkeypatch.setattr(DistributedWorker, "__init__", skip_execution)
+    monkeypatch.setattr(simpler.worker.Worker, "__init__", skip_execution)

--- a/tests/ut/ir/test_distributed_compiled_program.py
+++ b/tests/ut/ir/test_distributed_compiled_program.py
@@ -387,5 +387,40 @@ def test_from_dir_output_indices_match_out_params(compiled, tmp_path):
     assert param_infos[2].direction == ParamDirection.Out
 
 
+def test_build_binaries_assembles_every_chip_and_reports_the_count(compiled):
+    """The card-free build delegates to the chip assembler and counts its sub-builds."""
+    with patch(
+        "pypto.runtime.distributed_runner._assemble_chip_callables",
+        return_value=({"chip_orch": object(), "builtin.tensor.allreduce": object()}, "rt", False),
+    ) as assemble:
+        assert compiled.build_binaries() == 2
+    assemble.assert_called_once_with(compiled)
+
+
+def test_build_binaries_touches_no_device(compiled):
+    """It must not construct a Worker — that is the whole point of the split."""
+    with (
+        patch(
+            "pypto.runtime.distributed_runner._assemble_chip_callables",
+            return_value=({"chip_orch": object()}, "rt", False),
+        ),
+        patch("pypto.runtime.distributed_runner._construct_worker") as construct,
+    ):
+        compiled.build_binaries()
+    construct.assert_not_called()
+
+
+def test_build_binaries_propagates_assembler_failure(compiled):
+    """A build directory with no chip sub-build fails loudly rather than reporting 0."""
+    with (
+        patch(
+            "pypto.runtime.distributed_runner._assemble_chip_callables",
+            side_effect=RuntimeError("No chip-level tasks found"),
+        ),
+        pytest.raises(RuntimeError, match="No chip-level tasks found"),
+    ):
+        compiled.build_binaries()
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
- perf(ci): precompile the L3 system tests off the cards

Re-submitted from the fork branch `luohuan19:perf/precompile-l3-system-tests`; supersedes https://github.com/hw-native-sys/pypto/pull/2561 (same commit, 80a62cf8).