### PR TITLE
fix(ir): load a cube matmul's left operand into whole NZ fractal boxes

### DIFF
--- a/docs/en/dev/passes/10-convert_tensor_to_tile_ops.md
+++ b/docs/en/dev/passes/10-convert_tensor_to_tile_ops.md
@@ -198,6 +198,14 @@ picks a 16-aligned tile and peels the remainder, and a multiple of 16 can only b
 split into 16-aligned pieces, tail included. It therefore needs no boundary
 special case.
 
+The rule rides on the *demand*, not on one code path. A `tensor.slice` (or any
+`set_output_memory_inherit_input()` chain) feeding a matmul answers the Mat
+requirement at the slice itself rather than through `BridgeInputSpaces`, so
+`ConsumerSpaceReq` carries the box flag alongside the memory space and that
+consumer-driven load boxes the same rows. When several consumers share one
+producer, the rows are boxed only if every one of them asks for it, so a consumer
+that reads the tile at its declared physical shape is never handed a padded one.
+
 Scope, and what is deliberately left out:
 
 | Case | Boxed? | Why |

--- a/docs/en/dev/passes/10-convert_tensor_to_tile_ops.md
+++ b/docs/en/dev/passes/10-convert_tensor_to_tile_ops.md
@@ -198,11 +198,13 @@ picks a 16-aligned tile and peels the remainder, and a multiple of 16 can only b
 split into 16-aligned pieces, tail included. It therefore needs no boundary
 special case.
 
-The rule rides on the *demand*, not on one code path. A `tensor.slice` (or any
-`set_output_memory_inherit_input()` chain) feeding a matmul answers the Mat
-requirement at the slice itself rather than through `BridgeInputSpaces`, so
-`ConsumerSpaceReq` carries the box flag alongside the memory space and that
-consumer-driven load boxes the same rows. When several consumers share one
+The rule rides on the *demand*, not on one code path. Three sites can answer a
+matmul's Mat requirement, and all three box: `BridgeInputSpaces` for an operand
+that is still a tensor at the call; `HandleConsumerDrivenLoad` when a
+`tensor.slice` (or any `set_output_memory_inherit_input()` chain) answers it at
+the producer; and the Phase-1 entry loop when the producer is a parameter, which
+is what a `pl.matmul(pl.set_validshape(a, ...), b)` reaches. `ConsumerSpaceReq`
+therefore carries the box flag alongside the memory space. When several consumers share one
 producer, the rows are boxed only if every one of them asks for it, so a consumer
 that reads the tile at its declared physical shape is never handed a padded one.
 

--- a/docs/en/dev/passes/10-convert_tensor_to_tile_ops.md
+++ b/docs/en/dev/passes/10-convert_tensor_to_tile_ops.md
@@ -160,6 +160,55 @@ When `tensor.slice` feeds into `tensor.matmul` or `tensor.matmul_acc`, the slice
 
 The demand is propagated **through** zero-copy metadata ops that declare `set_output_memory_inherit_input()` — `tensor.slice`, `tensor.view`, `tensor.reshape`, `tensor.reinterpret_view`, `tensor.set_validshape`. So an operand written as `pl.matmul(pl.set_validshape(a[:, :K], rows, K), b)` still loads straight to Mat. An op that aliases its input's storage but omits that declaration breaks the chain: the operand materializes in Vec and needs a `tile.move` to Mat, which is a vector→cube boundary that flips an otherwise pure-CUBE InCore scope to `MIXED` and makes [`ExpandMixedKernel`](22-expand_mixed_kernel.md) split it into an AIC/AIV pair.
 
+## Cube Operand Row Boxing
+
+A cube operand has two independent extents, and only one of them is constrained.
+
+- The **logical** extent is essentially free. `pto.tmatmul` derives `M`, `K`, and
+  `N` from the operands' *valid* region, bounded at `[1, 4095]` with no
+  divisibility rule; `pto.mad` carries a `disable_gemv` clause whose whole
+  purpose is selecting the L0A organization at `%m == 1`.
+- The **physical** extent must be a whole number of NZ fractal boxes. The inner
+  box is 16 rows on every generation and dtype (`FRACTAL_NZ_ROW`). ptoas enforces
+  it directly — `'pto.alloc_tile' op expects result boxed tile rows to be a
+  multiple of innerRows (16)` — and pto-isa's `TExtract` repeats it as a static
+  assertion on the Mat source it reads.
+
+So the left operand of a 2-D `tensor.matmul` bridges into Mat with its row extent
+rounded up to the box, and the tensor's true extent declared as `valid_shape`:
+
+```python
+# Before  (M = 100)
+y = tensor.matmul(a, b)          # a: Tensor[[100, 256]]
+
+# After
+a_mat = pl.tile.load(a, [0, 0], [112, 256], [100, 256], target_memory=pl.Mem.Mat)
+y_tile = pl.tile.matmul(a_mat, b_mat)   # Tile[[112, 512]] valid [100, 512]
+```
+
+The padding is free on both axes of the cost model. A `tile.load` moves only the
+valid extent, so the DMA is unchanged; and the MAD cost is `ceil(M/16)` passes,
+which rounding M up to a multiple of 16 leaves unchanged. The hardware addresses
+the narrower valid region inside the full box through compact mode, and
+`tile.store` writes only the valid rows, so the observable result is identical.
+
+Making M a multiple of 16 here is also what keeps
+[`AutoTileMatmulL0`](16-auto_tile_matmul_l0.md) legal at the boundary: that pass
+picks a 16-aligned tile and peels the remainder, and a multiple of 16 can only be
+split into 16-aligned pieces, tail included. It therefore needs no boundary
+special case.
+
+Scope, and what is deliberately left out:
+
+| Case | Boxed? | Why |
+| ---- | ------ | --- |
+| 2-D `tensor.matmul` left operand | Yes | Its row axis is M, whose box height is 16 for every dtype |
+| Right operand | No | Its rows are `K`, whose granularity is `32 bytes / sizeof(dtype)` — dtype-dependent, and not settled here |
+| `a_trans` left operand | No | The natural load's row axis is K; the zero-copy `tile.transpose_view` makes the *column* axis M |
+| Rank >= 3 operand | No | It lowers to `tile.batch_matmul`, whose rows [`FlattenTileNdTo2D`](13-flatten_tile_nd_to_2d.md) row-packs into one `[B*M, N]` tile — the box rule binds that packed extent, not this dimension |
+| Dynamic row extent | No | No compile-time box to round to |
+| `tensor.matmul_acc` left operand | No | `tile.matmul_acc` requires the accumulator and the product to agree on *physical* M, and the accumulator arrives from a separate `tile.create` this rule cannot reach |
+
 ## Transpose Lowering
 
 `tensor.transpose` lowers to a plain 3-arg **`tile.transpose(input, axis1, axis2)`**. The PTO `pto.ttrans` instruction needs a scratch workspace tile (same shape/dtype as the source), but that scratch is a pure codegen detail — not a semantic operand. [`FlattenTileNdTo2D`](13-flatten_tile_nd_to_2d.md) is the **sole owner** of scratch materialization: it emits the codegen-ready 4-arg form (`tile.create` + `tile.transpose(..., tmp)`) for both 2D and per-page >2D transposes, still before the memory allocator runs (so the scratch gets a real UB address). Keeping scratch out of the high-level op means `tensor.transpose` and the DSL `pl.tile.transpose(tile, axis1, axis2)` stay 1:1 with the semantic operation.

--- a/docs/en/dev/passes/16-auto_tile_matmul_l0.md
+++ b/docs/en/dev/passes/16-auto_tile_matmul_l0.md
@@ -298,8 +298,8 @@ The invariant that makes the peel legal is established upstream, not here:
 [`ConvertTensorToTileOps`](10-convert_tensor_to_tile_ops.md) bridges a 2-D
 matmul's left operand into Mat with its rows rounded up to the box and the true
 extent in `valid_shape`. The `M` this pass sees is therefore already a multiple
-of 16, and `M - (M / m) * m` with both `M` and `m` multiples of 16 is a multiple
-of 16 as well. Every emitted tile — interior and tail alike — is a whole number
+of 16, and `M % m` with both `M` and `m` multiples of 16 is a multiple of 16 as
+well. Every emitted tile — interior and tail alike — is a whole number
 of boxes by construction.
 
 Padding the tensor at conversion is what makes this work; padding it *only* at

--- a/docs/en/dev/passes/16-auto_tile_matmul_l0.md
+++ b/docs/en/dev/passes/16-auto_tile_matmul_l0.md
@@ -286,6 +286,26 @@ out     = pl.tile.store(d, [0, 0], out)
 
 The `tile.cast` is dropped. When the producer needs a K-loop (`k < K`), the K-loop is emitted as usual and its Acc result feeds the *same* single `tile.assemble` — the fold is independent of K tiling.
 
+## Fractal boundary: why the tail needs no special case
+
+The chooser returns a 16-aligned `(m, n, k)` and this pass peels whatever the
+grid does not cover, so a boundary tile carries `M mod m` physical rows. Those
+rows must still form whole NZ fractal boxes — ptoas rejects anything else with
+`'pto.alloc_tile' op expects result boxed tile rows to be a multiple of
+innerRows (16)`.
+
+The invariant that makes the peel legal is established upstream, not here:
+[`ConvertTensorToTileOps`](10-convert_tensor_to_tile_ops.md) bridges a 2-D
+matmul's left operand into Mat with its rows rounded up to the box and the true
+extent in `valid_shape`. The `M` this pass sees is therefore already a multiple
+of 16, and `M - (M / m) * m` with both `M` and `m` multiples of 16 is a multiple
+of 16 as well. Every emitted tile — interior and tail alike — is a whole number
+of boxes by construction.
+
+Padding the tensor at conversion is what makes this work; padding it *only* at
+the operand would not be enough on its own, because this pass would still
+compute the tail from the unpadded logical `M`.
+
 ## Backend constraints
 
 L0/Mat capacities and fractal alignment come from the active `BackendHandler`. The pass reads from `PassContext::Current()->GetBackendHandler()` when a context is active, and falls back to `pypto::backend::GetBackend()->GetHandler()` for direct callers (e.g. tests that don't wrap in a `PassContext`).

--- a/docs/zh/dev/passes/10-convert_tensor_to_tile_ops.md
+++ b/docs/zh/dev/passes/10-convert_tensor_to_tile_ops.md
@@ -145,6 +145,52 @@ InCore、Spmd、Group 函数在本阶段被跳过 —— 它们已在阶段一 /
 
 该需求会**穿过**声明了 `set_output_memory_inherit_input()` 的零拷贝元数据 op 继续向上传播 —— `tensor.slice`、`tensor.view`、`tensor.reshape`、`tensor.reinterpret_view`、`tensor.set_validshape`。因此 `pl.matmul(pl.set_validshape(a[:, :K], rows, K), b)` 这样的操作数仍然直接加载到 Mat。若某个别名输入存储的 op 漏掉该声明，传播链就会断开：操作数被物化到 Vec，再通过 `tile.move` 桥接到 Mat，而这是一个 vector→cube 边界，会把本应是纯 CUBE 的 InCore scope 判定为 `MIXED`，导致 [`ExpandMixedKernel`](22-expand_mixed_kernel.md) 将其拆分为 AIC/AIV 两个函数。
 
+## Cube 操作数的行分形对齐（Row Boxing）
+
+一个 cube 操作数有两个彼此独立的尺寸概念，而只有其中一个受到约束。
+
+- **逻辑（logical）尺寸**基本不受限。`pto.tmatmul` 从操作数的 *valid* 区域推导
+  `M`、`K`、`N`，取值范围 `[1, 4095]`，没有整除要求；`pto.mad` 的 `disable_gemv`
+  子句存在的唯一目的，就是在 `%m == 1` 时选择 L0A 的组织方式。
+- **物理（physical）尺寸**必须是整数个 NZ 分形块。内层块在所有代次和所有 dtype 下
+  都是 16 行（`FRACTAL_NZ_ROW`）。ptoas 直接强制这一点 ——
+  `'pto.alloc_tile' op expects result boxed tile rows to be a multiple of
+  innerRows (16)` —— pto-isa 的 `TExtract` 也对其读取的 Mat 源 tile 用静态断言
+  重复了同一条约束。
+
+因此 2-D `tensor.matmul` 的左操作数在桥接到 Mat 时，行方向的物理尺寸向上对齐到分形块，
+并把张量的真实尺寸声明为 `valid_shape`：
+
+```python
+# 转换前（M = 100）
+y = tensor.matmul(a, b)          # a: Tensor[[100, 256]]
+
+# 转换后
+a_mat = pl.tile.load(a, [0, 0], [112, 256], [100, 256], target_memory=pl.Mem.Mat)
+y_tile = pl.tile.matmul(a_mat, b_mat)   # Tile[[112, 512]]，valid [100, 512]
+```
+
+这份 padding 在代价模型的两个维度上都是免费的：`tile.load` 只搬运 valid 区域，DMA 不变；
+MAD 的代价是 `ceil(M/16)` 个 pass，把 M 向上取整到 16 的倍数不会改变它。硬件通过
+compact 模式寻址整块内部更窄的 valid 区域，`tile.store` 也只写回 valid 行，因此可观测
+结果完全一致。
+
+在这里把 M 变成 16 的倍数，同时也是
+[`AutoTileMatmulL0`](16-auto_tile_matmul_l0.md) 在边界处保持合法的原因：该 pass 选择
+16 对齐的 tile 并剥离余数，而 16 的倍数只能被切分成同样 16 对齐的块（尾块也不例外），
+所以它不需要任何边界特判。
+
+作用范围，以及刻意排除的情况：
+
+| 情况 | 是否对齐 | 原因 |
+| ---- | -------- | ---- |
+| 2-D `tensor.matmul` 左操作数 | 是 | 其行轴即 M，块高在所有 dtype 下都是 16 |
+| 右操作数 | 否 | 其行是 `K`，粒度为 `32 字节 / sizeof(dtype)`，与 dtype 相关，此处不做结论 |
+| `a_trans` 左操作数 | 否 | 自然加载的行轴是 K，零拷贝 `tile.transpose_view` 使 *列*轴才是 M |
+| rank >= 3 的操作数 | 否 | 它下沉为 `tile.batch_matmul`，其行被 [`FlattenTileNdTo2D`](13-flatten_tile_nd_to_2d.md) 打包成单个 `[B*M, N]` tile —— 分形规则约束的是打包后的尺寸，而非该维度 |
+| 行尺寸为动态值 | 否 | 没有编译期常量可供对齐 |
+| `tensor.matmul_acc` 左操作数 | 否 | `tile.matmul_acc` 要求累加器与乘积的*物理* M 一致，而累加器来自本规则无法触及的另一处 `tile.create` |
+
 ## Transpose 下沉
 
 `tensor.transpose` 下沉为一个 3-arg 的 **`tile.transpose(input, axis1, axis2)`**。PTO 后端的 `pto.ttrans` 指令需要一个 scratch 工作 tile（与源 tile 同 shape/同 dtype），但该 scratch 纯属 codegen 细节，并非语义操作数。[`FlattenTileNdTo2D`](13-flatten_tile_nd_to_2d.md) 是 scratch 物化的**唯一归属**：它为 2D 以及逐页 >2D 的 transpose 统一产出 codegen-ready 的 4-arg 形态（`tile.create` + `tile.transpose(..., tmp)`），且仍在内存分配器之前（scratch 仍能拿到真实 UB 地址）。把 scratch 从高层 op 中移除后，`tensor.transpose` 与 DSL `pl.tile.transpose(tile, axis1, axis2)` 都与语义操作保持 1:1。

--- a/docs/zh/dev/passes/10-convert_tensor_to_tile_ops.md
+++ b/docs/zh/dev/passes/10-convert_tensor_to_tile_ops.md
@@ -180,10 +180,12 @@ compact 模式寻址整块内部更窄的 valid 区域，`tile.store` 也只写�
 16 对齐的 tile 并剥离余数，而 16 的倍数只能被切分成同样 16 对齐的块（尾块也不例外），
 所以它不需要任何边界特判。
 
-这条规则挂在「需求」上，而不是挂在某一条代码路径上。被 matmul 使用的 `tensor.slice`
-（以及任何 `set_output_memory_inherit_input()` 传播链）会在 slice 自身处直接满足 Mat 需求，
-而不经过 `BridgeInputSpaces`，因此 `ConsumerSpaceReq` 在携带内存空间的同时也携带对齐标记，
-该 consumer-driven 加载会做同样的行对齐。当多个消费者共享同一个生产者时，只有它们全部提出
+这条规则挂在「需求」上，而不是挂在某一条代码路径上。有三处可以满足 matmul 的 Mat 需求，
+三处都会做行对齐：操作数在调用点仍是张量时由 `BridgeInputSpaces` 处理；`tensor.slice`
+（以及任何 `set_output_memory_inherit_input()` 传播链）在生产者处满足需求时由
+`HandleConsumerDrivenLoad` 处理；生产者是函数参数时由 Phase-1 入口循环处理 ——
+`pl.matmul(pl.set_validshape(a, ...), b)` 走的正是这一条。因此 `ConsumerSpaceReq`
+在携带内存空间的同时也携带对齐标记。当多个消费者共享同一个生产者时，只有它们全部提出
 该需求时才会对齐，从而保证按声明物理尺寸读取该 tile 的消费者不会拿到被 padding 过的 tile。
 
 作用范围，以及刻意排除的情况：

--- a/docs/zh/dev/passes/10-convert_tensor_to_tile_ops.md
+++ b/docs/zh/dev/passes/10-convert_tensor_to_tile_ops.md
@@ -180,6 +180,12 @@ compact 模式寻址整块内部更窄的 valid 区域，`tile.store` 也只写�
 16 对齐的 tile 并剥离余数，而 16 的倍数只能被切分成同样 16 对齐的块（尾块也不例外），
 所以它不需要任何边界特判。
 
+这条规则挂在「需求」上，而不是挂在某一条代码路径上。被 matmul 使用的 `tensor.slice`
+（以及任何 `set_output_memory_inherit_input()` 传播链）会在 slice 自身处直接满足 Mat 需求，
+而不经过 `BridgeInputSpaces`，因此 `ConsumerSpaceReq` 在携带内存空间的同时也携带对齐标记，
+该 consumer-driven 加载会做同样的行对齐。当多个消费者共享同一个生产者时，只有它们全部提出
+该需求时才会对齐，从而保证按声明物理尺寸读取该 tile 的消费者不会拿到被 padding 过的 tile。
+
 作用范围，以及刻意排除的情况：
 
 | 情况 | 是否对齐 | 原因 |

--- a/docs/zh/dev/passes/16-auto_tile_matmul_l0.md
+++ b/docs/zh/dev/passes/16-auto_tile_matmul_l0.md
@@ -280,7 +280,7 @@ innerRows (16)`。
 [`ConvertTensorToTileOps`](10-convert_tensor_to_tile_ops.md) 在把 2-D matmul 的左
 操作数桥接到 Mat 时，已把行数向上对齐到分形块，并把真实尺寸放入 `valid_shape`。因此本
 pass 看到的 `M` 已经是 16 的倍数；而当 `M` 与 `m` 均为 16 的倍数时，
-`M - (M / m) * m` 同样是 16 的倍数。于是内部块与尾块都天然是整数个分形块。
+`M % m` 同样是 16 的倍数。于是内部块与尾块都天然是整数个分形块。
 
 关键在于「在转换阶段给张量加 padding」：如果只在操作数处补齐，本 pass 仍会用未补齐的
 逻辑 `M` 计算尾块尺寸，问题依旧存在。

--- a/docs/zh/dev/passes/16-auto_tile_matmul_l0.md
+++ b/docs/zh/dev/passes/16-auto_tile_matmul_l0.md
@@ -269,6 +269,22 @@ out     = pl.tile.store(d, [0, 0], out)
 
 `tile.cast` 被删除。当 producer 需要 K-loop（`k < K`）时，照常发出 K-loop，其 Acc 结果喂给*同一个*单次 `tile.assemble` —— 折叠与 K 切分无关。
 
+## 分形边界：尾块为何不需要特判
+
+chooser 返回 16 对齐的 `(m, n, k)`，本 pass 剥离网格未覆盖的部分，因此边界 tile 的物理
+行数是 `M mod m`。这些行同样必须构成完整的 NZ 分形块 —— 否则 ptoas 会直接拒绝：
+`'pto.alloc_tile' op expects result boxed tile rows to be a multiple of
+innerRows (16)`。
+
+使这次剥离保持合法的不变式由上游建立，而不在本 pass：
+[`ConvertTensorToTileOps`](10-convert_tensor_to_tile_ops.md) 在把 2-D matmul 的左
+操作数桥接到 Mat 时，已把行数向上对齐到分形块，并把真实尺寸放入 `valid_shape`。因此本
+pass 看到的 `M` 已经是 16 的倍数；而当 `M` 与 `m` 均为 16 的倍数时，
+`M - (M / m) * m` 同样是 16 的倍数。于是内部块与尾块都天然是整数个分形块。
+
+关键在于「在转换阶段给张量加 padding」：如果只在操作数处补齐，本 pass 仍会用未补齐的
+逻辑 `M` 计算尾块尺寸，问题依旧存在。
+
 ## Backend 约束
 
 L0/Mat 容量与 fractal 对齐都来自当前 `BackendHandler`。Pass 优先从 `PassContext::Current()->GetBackendHandler()` 读取，若无活动 context 则回退到 `pypto::backend::GetBackend()->GetHandler()`（例如未包 `PassContext` 直接调用的测试场景）。

--- a/include/pypto/ir/transforms/op_conversion_registry.h
+++ b/include/pypto/ir/transforms/op_conversion_registry.h
@@ -71,6 +71,14 @@ using ConversionFunc = std::function<ConversionResult(
 struct InputSpaceReq {
   MemorySpace space;                       ///< Required memory space
   std::optional<std::string> trans_kwarg;  ///< Read transpose flag from this kwarg (if any)
+  /// Whether the bridged tile is a *cube* operand, i.e. one the MAD reads out
+  /// of a whole number of NZ fractal boxes.  The logical extent of such an
+  /// operand is essentially free (``pto.mad`` derives ``%m`` from the operand's
+  /// valid rows), but its physical row count must be a multiple of the box
+  /// height, so the bridge load allocates the boxed row count and carries the
+  /// tensor's true extent in ``valid_shape``.  Only the row axis is boxed —
+  /// the column granularity is dtype-dependent and is not settled here.
+  bool cube_row_boxed = false;
 };
 
 /**

--- a/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
+++ b/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
@@ -2045,7 +2045,7 @@ IncoreTransformResult TransformIncoreFunction(const FunctionPtr& func) {
     // Attribute the entry load to the parameter declaration it loads, not to `def`.
     const auto& load_span = var->span_;
     auto offsets = MakeZeroOffsets(tensor_type->shape_.size(), load_span);
-    auto shapes = MakeShapeTuple(tensor_type->shape_, load_span);
+    auto valid = MakeShapeTuple(tensor_type->shape_, load_span);
 
     // Honour the same consumer demand the mutator honours for the loads it
     // creates (see BridgeInputSpaces): a parameter feeding a matmul goes
@@ -2064,8 +2064,19 @@ IncoreTransformResult TransformIncoreFunction(const FunctionPtr& func) {
       load_kwargs.emplace_back("target_memory", entry_req->space);
     }
     AppendCachePolicyKwarg(var, cache_policies, &load_kwargs);
+    // A parameter that reaches a matmul directly, or through an inherit-input
+    // chain such as tensor.set_validshape, is loaded here rather than by
+    // BridgeInputSpaces / HandleConsumerDrivenLoad -- so the same row boxing has
+    // to apply, or the cube operand keeps its unaligned physical row count.
+    ExprPtr shapes = valid;
+    if (entry_req.has_value() && entry_req->cube_row_boxed) {
+      auto boxed = BoxLoadRows(tensor_type->shape_, tensor_type->dtype_, entry_req->space, load_span);
+      if (!AreExprVectorsEqual(boxed, tensor_type->shape_)) {
+        shapes = MakeShapeTuple(boxed, load_span);
+      }
+    }
     auto load_call = MarkCompilerMatBridge(
-        op_registry.Create("tile.load", {var, offsets, shapes, shapes}, load_kwargs, load_span),
+        op_registry.Create("tile.load", {var, offsets, shapes, valid}, load_kwargs, load_span),
         entry_req.has_value() ? entry_req->space : MemorySpace::Vec);
 
     std::string tile_name = MakeTileValueName(var->name_hint_);

--- a/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
+++ b/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
@@ -34,6 +34,7 @@
 #include "pypto/ir/scalar_expr.h"
 #include "pypto/ir/span.h"
 #include "pypto/ir/stmt.h"
+#include "pypto/ir/tile_view_semantics.h"
 #include "pypto/ir/transforms/base/mutator.h"
 #include "pypto/ir/transforms/base/visitor.h"
 #include "pypto/ir/transforms/op_conversion_registry.h"
@@ -78,6 +79,52 @@ CallPtr MarkCompilerMatBridge(const CallPtr& call, MemorySpace space) {
   auto marked = MutableCopy(call);
   marked->attrs_.emplace_back(kCompilerTensorToTileMatBridgeAttr, true);
   return marked;
+}
+
+/// Physical shape a cube bridge load must allocate for @p tensor_type.
+///
+/// PTO-ISA keeps two independent notions of size for a cube operand, and only
+/// one of them is constrained.  The *logical* extent is essentially free:
+/// ``pto.mad`` derives ``%m`` from the operand's valid rows, bounds it at
+/// ``[1, 4095]``, and documents ``%m == 1`` as a first-class case.  The
+/// *physical* extent must be a whole number of NZ fractal boxes — ptoas
+/// enforces exactly that (``'pto.alloc_tile' op expects result boxed tile rows
+/// to be a multiple of innerRows (16)``), and pto-isa's ``TExtract`` repeats it
+/// as a static assertion on the Mat source it reads.  So the allocation is
+/// rounded up to the box and the tensor's true extent rides in ``valid_shape``,
+/// which the hardware already addresses through compact mode.
+///
+/// The padding is free on both axes of the cost model: a load moves only the
+/// valid extent, so no extra DMA; and the MAD cost is ``ceil(M/16)`` passes,
+/// which rounding M up to a multiple of 16 leaves unchanged.
+///
+/// Returns @p tensor_type's shape unchanged — leaving the emitted load
+/// byte-identical to its historical form — unless every precondition holds:
+///
+///   * rank 2.  A rank >= 3 operand lowers to ``tile.batch_matmul``, whose rows
+///     ``FlattenTileNdTo2D`` row-packs into one ``[B*M, N]`` tile; the box rule
+///     binds that packed extent, not this dimension.
+///   * a static row extent.  A dynamic one has no compile-time box to round to.
+///   * a Mat view whose ``slayout`` is row-major, the orientation whose row axis
+///     really is the matmul's M axis.  The transposed dual boxes 16 on the
+///     *column* axis instead and its row granularity is dtype-dependent; that
+///     rule is deliberately not settled here.
+std::vector<ExprPtr> BoxLoadRows(const TensorType& tensor_type, MemorySpace space, const Span& span) {
+  const auto& shape = tensor_type.shape_;
+  if (shape.size() != 2) return shape;
+  auto rows = As<ConstInt>(shape[0]);
+  if (!rows || rows->value_ <= 0) return shape;
+
+  const auto view = tile_view_semantics::GetImplicitTileView(shape, space);
+  if (view.slayout != TileLayout::row_major) return shape;
+  const auto box = tile_view_semantics::GetBoxedTileAlignment(view, tensor_type.dtype_);
+  if (!box || box->rows <= 1) return shape;
+
+  const int64_t remainder = rows->value_ % box->rows;
+  if (remainder == 0) return shape;
+  auto boxed = shape;
+  boxed[0] = std::make_shared<ConstInt>(rows->value_ + box->rows - remainder, DataType::INDEX, span);
+  return boxed;
 }
 
 bool IsPassthroughTensorOp(const CallPtr& call) {
@@ -868,14 +915,22 @@ class TensorToTileMutator : public TypePropagatingMutator {
     // Emit a `tile.load` of `arg` (TensorType) into `space`, append its AssignStmt,
     // and return the bound load Var. The load is always natural; a transposed
     // operand is realised by a zero-copy tile.transpose_view on the result.
-    auto emit_load = [&](const ExprPtr& arg, const TensorTypePtr& tensor_type, MemorySpace space,
-                         size_t idx) -> VarPtr {
+    //
+    // `row_boxed` marks a cube operand (see InputSpaceReq::cube_row_boxed): the
+    // load then allocates a whole number of NZ fractal boxes on the row axis and
+    // declares the tensor's true extent as valid_shape. `BoxLoadRows` returns the
+    // physical shape; it equals `tensor_type->shape_` whenever no padding applies,
+    // so a fractal-sized operand keeps its historical byte-identical load.
+    auto emit_load = [&](const ExprPtr& arg, const TensorTypePtr& tensor_type, MemorySpace space, size_t idx,
+                         bool row_boxed) -> VarPtr {
       auto offsets = MakeZeroOffsets(tensor_type->shape_.size(), call->span_);
-      auto shapes = MakeShapeTuple(tensor_type->shape_, call->span_);
+      auto valid = MakeShapeTuple(tensor_type->shape_, call->span_);
+      auto shapes =
+          row_boxed ? MakeShapeTuple(BoxLoadRows(*tensor_type, space, call->span_), call->span_) : valid;
       std::vector<std::pair<std::string, std::any>> load_kw = {{"target_memory", space}};
       AppendCachePolicyKwarg(arg, cache_policies_, &load_kw);
       auto load = MarkCompilerMatBridge(
-          op_registry_.Create("tile.load", {arg, offsets, shapes, shapes}, load_kw, call->span_), space);
+          op_registry_.Create("tile.load", {arg, offsets, shapes, valid}, load_kw, call->span_), space);
       std::string var_name;
       if (auto var = As<Var>(arg)) {
         auto space_str = MemorySpaceToString(space);
@@ -927,7 +982,11 @@ class TensorToTileMutator : public TypePropagatingMutator {
       if (tensor_type) {
         // GM operand: load NATURAL (2D and ND alike), then reinterpret as its
         // transpose with a zero-copy view when b_trans/a_trans.
-        auto loaded = emit_load(args[idx], tensor_type, req.space, idx);
+        // A transposed operand keeps its natural (unboxed) load: the
+        // tile.transpose_view below reinterprets the row axis as the matmul's K,
+        // so boxing rows here would pad the wrong axis.
+        const bool row_boxed = req.cube_row_boxed && !use_view;
+        auto loaded = emit_load(args[idx], tensor_type, req.space, idx, row_boxed);
         args[idx] = use_view ? emit_view(loaded) : loaded;
         continue;
       }

--- a/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
+++ b/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
@@ -81,7 +81,7 @@ CallPtr MarkCompilerMatBridge(const CallPtr& call, MemorySpace space) {
   return marked;
 }
 
-/// Physical shape a cube bridge load must allocate for @p tensor_type.
+/// Physical shape a cube load must allocate for the window @p shape.
 ///
 /// PTO-ISA keeps two independent notions of size for a cube operand, and only
 /// one of them is constrained.  The *logical* extent is essentially free:
@@ -98,8 +98,8 @@ CallPtr MarkCompilerMatBridge(const CallPtr& call, MemorySpace space) {
 /// valid extent, so no extra DMA; and the MAD cost is ``ceil(M/16)`` passes,
 /// which rounding M up to a multiple of 16 leaves unchanged.
 ///
-/// Returns @p tensor_type's shape unchanged — leaving the emitted load
-/// byte-identical to its historical form — unless every precondition holds:
+/// Returns @p shape unchanged — leaving the emitted load byte-identical to its
+/// historical form — unless every precondition holds:
 ///
 ///   * rank 2.  A rank >= 3 operand lowers to ``tile.batch_matmul``, whose rows
 ///     ``FlattenTileNdTo2D`` row-packs into one ``[B*M, N]`` tile; the box rule
@@ -109,15 +109,15 @@ CallPtr MarkCompilerMatBridge(const CallPtr& call, MemorySpace space) {
 ///     really is the matmul's M axis.  The transposed dual boxes 16 on the
 ///     *column* axis instead and its row granularity is dtype-dependent; that
 ///     rule is deliberately not settled here.
-std::vector<ExprPtr> BoxLoadRows(const TensorType& tensor_type, MemorySpace space, const Span& span) {
-  const auto& shape = tensor_type.shape_;
+std::vector<ExprPtr> BoxLoadRows(const std::vector<ExprPtr>& shape, const DataType& dtype, MemorySpace space,
+                                 const Span& span) {
   if (shape.size() != 2) return shape;
   auto rows = As<ConstInt>(shape[0]);
   if (!rows || rows->value_ <= 0) return shape;
 
   const auto view = tile_view_semantics::GetImplicitTileView(shape, space);
   if (view.slayout != TileLayout::row_major) return shape;
-  const auto box = tile_view_semantics::GetBoxedTileAlignment(view, tensor_type.dtype_);
+  const auto box = tile_view_semantics::GetBoxedTileAlignment(view, dtype);
   if (!box || box->rows <= 1) return shape;
 
   const int64_t remainder = rows->value_ % box->rows;
@@ -406,6 +406,11 @@ struct ConsumerSpaceReq {
   MemorySpace space;  ///< Required memory space. The consumer-driven load is always
                       ///< natural; a transposed (b_trans/a_trans) operand is realised
                       ///< by a zero-copy tile.transpose_view in BridgeInputSpaces.
+  /// Mirror of ``InputSpaceReq::cube_row_boxed``, so a load-like producer that
+  /// answers the demand directly boxes the same rows ``BridgeInputSpaces``
+  /// would have. Set only when the consumer reads the operand *untransposed*:
+  /// a transposed use makes the loaded tile's row axis K, not M.
+  bool cube_row_boxed = false;
 };
 
 /**
@@ -495,12 +500,23 @@ class ConsumerSpaceCollector : public IRVisitor {
     for (const auto& [idx, req] : entry->input_reqs) {
       if (idx >= call->args_.size()) continue;
       if (auto var = As<Var>(call->args_[idx])) {
+        // A transposed use reinterprets the loaded tile's row axis as K, so the
+        // M-axis box rule does not apply to it (see ConsumerSpaceReq).
+        const bool transposed = req.trans_kwarg && call->GetKwarg<bool>(*req.trans_kwarg, false);
+        const ConsumerSpaceReq resolved{req.space, req.cube_row_boxed && !transposed};
         // Prioritize non-Vec spaces: if an existing requirement is the default Vec but this
         // consumer needs a specialized space (Mat/Left/Right/Acc/Bias), override it so the
         // load-like producer can emit the specialized space directly.
-        auto [it, inserted] = consumer_reqs_.try_emplace(var.get(), ConsumerSpaceReq{req.space});
-        if (!inserted && it->second.space == MemorySpace::Vec && req.space != MemorySpace::Vec) {
-          it->second = ConsumerSpaceReq{req.space};
+        auto [it, inserted] = consumer_reqs_.try_emplace(var.get(), resolved);
+        if (inserted) continue;
+        if (it->second.space == MemorySpace::Vec && req.space != MemorySpace::Vec) {
+          it->second = resolved;
+        } else if (it->second.space == resolved.space) {
+          // Several consumers share one producer (e.g. a sliced KV feeding two
+          // matmuls). Box only when every one of them wants it, so a consumer
+          // that reads the tile at its declared physical shape is never handed a
+          // padded one.
+          it->second.cube_row_boxed = it->second.cube_row_boxed && resolved.cube_row_boxed;
         }
       }
     }
@@ -864,14 +880,27 @@ class TensorToTileMutator : public TypePropagatingMutator {
         << "tensor.slice conversion does not support rank-0 tiles; keep one unit axis or use tensor.read "
            "for a scalar result";
 
+    // A cube operand answered here rather than in BridgeInputSpaces must get the
+    // same row boxing, or a sliced left operand keeps its unaligned physical row
+    // count all the way to ptoas. `valid_shape` already names the slice window,
+    // so only the allocation grows. Skipped when the slice drops a dimension:
+    // the result is then not the rank-2 tile the M-axis rule is about.
+    ExprPtr physical_shape_arg = shape_arg;
+    if (req.cube_row_boxed && drop_dims.empty()) {
+      auto boxed = BoxLoadRows(full_shape, tensor_type->dtype_, req.space, call->span_);
+      if (!AreExprVectorsEqual(boxed, full_shape)) {
+        physical_shape_arg = MakeShapeTuple(boxed, call->span_);
+      }
+    }
+
     // The consumer-driven load is always natural; a transposed (b_trans/a_trans)
     // operand gets a zero-copy tile.transpose_view at the matmul site instead.
     std::vector<std::pair<std::string, std::any>> load_kwargs = {{"target_memory", req.space}};
     AppendCachePolicyKwarg(input, cache_policies_, &load_kwargs);
-    auto load_call =
-        MarkCompilerMatBridge(op_registry_.Create("tile.load", {input, offset_arg, shape_arg, valid_shape},
-                                                  load_kwargs, call->span_),
-                              req.space);
+    auto load_call = MarkCompilerMatBridge(
+        op_registry_.Create("tile.load", {input, offset_arg, physical_shape_arg, valid_shape}, load_kwargs,
+                            call->span_),
+        req.space);
 
     auto tile_name = MakeTileValueName(op->var_->name_hint_);
     if (drop_dims.empty()) {
@@ -925,8 +954,10 @@ class TensorToTileMutator : public TypePropagatingMutator {
                          bool row_boxed) -> VarPtr {
       auto offsets = MakeZeroOffsets(tensor_type->shape_.size(), call->span_);
       auto valid = MakeShapeTuple(tensor_type->shape_, call->span_);
-      auto shapes =
-          row_boxed ? MakeShapeTuple(BoxLoadRows(*tensor_type, space, call->span_), call->span_) : valid;
+      auto shapes = row_boxed ? MakeShapeTuple(
+                                    BoxLoadRows(tensor_type->shape_, tensor_type->dtype_, space, call->span_),
+                                    call->span_)
+                              : valid;
       std::vector<std::pair<std::string, std::any>> load_kw = {{"target_memory", space}};
       AppendCachePolicyKwarg(arg, cache_policies_, &load_kw);
       auto load = MarkCompilerMatBridge(

--- a/src/ir/transforms/op_conversion_registry.cpp
+++ b/src/ir/transforms/op_conversion_registry.cpp
@@ -1152,7 +1152,7 @@ void OpConversionRegistry::RegisterMatmulOps() {
         const std::string out_op = nd ? "tile.batch_matmul" : "tile.matmul";
         return ConversionResult{OpRegistry::GetInstance().Create(out_op, {args[0], args[1]}, span)};
       },
-      {{0, {MemorySpace::Mat, "a_trans"}}, {1, {MemorySpace::Mat, "b_trans"}}});
+      {{0, {MemorySpace::Mat, "a_trans", /*cube_row_boxed=*/true}}, {1, {MemorySpace::Mat, "b_trans"}}});
 
   // tensor.matmul_acc: 2D × 2D × 2D → tile.matmul_acc; any operand ≥3D →
   // tile.batch_matmul_acc. Same a_trans/b_trans handling as tensor.matmul.
@@ -1175,6 +1175,13 @@ void OpConversionRegistry::RegisterMatmulOps() {
         if (args.size() == 4) out_args.push_back(args[3]);
         return ConversionResult{OpRegistry::GetInstance().Create(out_op, out_args, span)};
       },
+      // The left operand is deliberately NOT row-boxed here, unlike
+      // tensor.matmul's. tile.matmul_acc requires the accumulator and the
+      // product to agree on *physical* M, and the accumulator arrives from a
+      // separate tile.create whose allocation this rule cannot reach — boxing
+      // only the operand would turn an unaligned M from a ptoas rejection into
+      // an operand-mismatch one. Boxing an accumulator needs consumer-driven
+      // information about the create site and is left as follow-up work.
       {{1, {MemorySpace::Mat, "a_trans"}}, {2, {MemorySpace::Mat, "b_trans"}}});
 }
 

--- a/tests/st/codegen/dsl/test_split_odd_axis_codegen.py
+++ b/tests/st/codegen/dsl/test_split_odd_axis_codegen.py
@@ -22,8 +22,12 @@ The two ways an odd axis reaches the boundary:
 * an odd VALID extent inside an even physical box (``15`` of ``16`` rows: lanes
   hold 8 and 7) -- the shape a real kernel's ragged tail has, since an Acc box is
   fractal-aligned and therefore even;
-* an odd physical BOX (``17`` rows: lanes hold 9 and 8), for tiles whose box is
-  not fractal-bound.
+* an odd physical BOX (``17`` rows: lanes would hold 9 and 8) -- which a
+  Cube->Vector boundary cannot actually carry, because ``tile.aiv_shard``'s cube
+  side is an ``Acc`` and an ``Acc`` box IS fractal-bound. A ``pl.matmul`` reaching
+  that boundary now loads its left operand into whole NZ fractal boxes, so a
+  17-row source arrives as a 32-row box with a 17-row valid extent, whose lanes
+  are 16 and 1 -- unplaceable, and refused with the authoring routes that work.
 
 A deeper tail (``13`` of ``16``) would leave the box partition's lanes 8 and 5 --
 further than one cell apart, so pto-isa could place neither. The compiler
@@ -47,7 +51,7 @@ ROWS, COLS, K = 16, 128, 128
 HALF = ROWS // 2
 ODD_VALID_M = 15  # lanes hold 8 and 7 -> TILE_UP_DOWN_ODD
 DEEP_TAIL_VALID_M = 13  # box lanes 8 and 5 -> rebalanced to 7 and 6
-ODD_BOX_ROWS = 17  # a fully-valid ODD box: lanes hold 9 and 8
+ODD_BOX_ROWS = 17  # an odd source extent; its Acc box is 32, so lanes hold 16 and 1
 ODD_BOX_HALF = (ODD_BOX_ROWS + 1) // 2
 
 
@@ -119,7 +123,12 @@ def explicit_region_odd_box(
     w: pl.Tensor[[COLS, K], pl.BF16],
     out: pl.Out[pl.Tensor[[ODD_BOX_ROWS, COLS], pl.FP32]],
 ) -> pl.Tensor[[ODD_BOX_ROWS, COLS], pl.FP32]:
-    """An explicit ``pl.split_aiv`` region over a fully-valid ODD box (17 rows)."""
+    """An explicit ``pl.split_aiv`` region over an odd (17-row) source extent.
+
+    The 17 rows reach the cube as a 32-row NZ-fractal box carrying a 17-row valid
+    extent, so the region's box partition leaves the lanes 16 and 1 -- further
+    than one cell apart, which pto-isa cannot place.
+    """
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="region_odd"):
         acc = pl.matmul(a[0:ODD_BOX_ROWS, 0:K], w[0:COLS, 0:K], b_trans=True, out_dtype=pl.FP32)
         for aiv_id in pl.split_aiv(2, mode=pl.SplitMode.UP_DOWN):
@@ -308,22 +317,28 @@ def test_rebalance_is_declined_when_a_value_is_split_independently():
     assert "16 / 15" in message
 
 
-def test_explicit_region_odd_box_localizes_the_per_lane_extent():
-    """A fully-valid ODD box is per-lane in an explicit region too.
+def test_explicit_region_odd_box_is_refused_with_unplaceable_lanes():
+    """An odd physical box cannot reach a Cube -> Vector boundary at all.
 
-    ``ReshapeSplitAxis`` gives both lanes the ceil half (9), which is right for
-    the physical box and wrong for the extents pto-isa reads off the popped tile:
-    17 rows split 9 / 8. The region path used to take the "fully valid needs no
-    repair" shortcut here, leaving both lanes at 9 while the transport picked the
-    odd code — lane 1 would then have been placed one row too far.
+    ``tile.aiv_shard``'s cube side is an ``Acc``, and ptoas rejects an ``Acc``
+    allocation whose rows are not a multiple of 16, so the 17-row box this used to
+    assert on was never a shape the backend would accept -- it only survived
+    because ``--codegen-only`` skips assembly. The 17 rows now arrive as a 32-row
+    fractal box carrying a 17-row valid extent, and the region's box partition
+    leaves lane 0 with 16 cells and lane 1 with 1: further than one cell apart, so
+    neither ``TILE_UP_DOWN`` nor its ``_ODD`` sibling can place lane 1's band.
+    The compiler says so, and names the two authoring routes that do work.
+
+    The reachable odd axis -- an odd VALID extent inside an even box -- keeps its
+    positive coverage in ``test_odd_valid_extent_takes_the_odd_split_code`` and
+    ``test_odd_pop_carries_a_per_lane_row_extent_and_the_full_column_box``.
     """
-    printed = str(explicit_region_odd_box.lower(config=RunConfig(platform="a2a3")))
-    aiv = _lowered_half(printed, "aiv")
+    with pytest.raises(ValueError) as exc:
+        explicit_region_odd_box.lower(config=RunConfig(platform="a2a3"))
 
-    assert "pl.tile.tpop_from_aic(split=3)" in aiv, aiv
-    # clamp(17 - aiv_id * 9, 0, 9) -> 9 and 8, on a 9-row box.
-    assert re.search(r"pl\.const\(17, pl\.INDEX\)[^]]*?pl\.const\(9, pl\.INDEX\)", aiv), aiv
-    assert re.search(r"pl\.tile\.store\([^)]*\* 9", aiv), aiv
+    message = str(exc.value)
+    assert "leaves the two AIV lanes 16 and 1 cells" in message, message
+    assert "pl.tile.set_validshape" in message, message
 
 
 @pytest.fixture(scope="session")

--- a/tests/ut/ir/transforms/test_auto_tile_matmul_l0.py
+++ b/tests/ut/ir/transforms/test_auto_tile_matmul_l0.py
@@ -967,6 +967,69 @@ def _matmul_acc_calls(node) -> list:
     return calls
 
 
+_CUBE_M_AXIS_TILE = re.compile(r"pl\.Tile\[\[(\d+), \d+\], [^\]]*?pl\.Mem\.(Left|Acc)")
+
+
+def _cube_m_axis_rows(after) -> list[int]:
+    """Static physical row counts of every ``Left`` / ``Acc`` tile in ``after``.
+
+    Both spaces index the matmul's M axis, whose NZ fractal is 16 rows on every
+    Ascend generation, so their physical row count is directly comparable against
+    that one constant. ``Right`` is deliberately excluded: its rows are ``K``,
+    whose granularity is ``32 bytes / sizeof(dtype)`` and therefore dtype-dependent.
+    """
+    return [int(rows) for rows, _ in _CUBE_M_AXIS_TILE.findall(ir.python_print(after))]
+
+
+class TestAutoTileMatmulL0FractalBoundary:
+    """No cube operand leaves the pass with a sub-fractal physical row count.
+
+    Regression for an M that is not a multiple of 16. The chooser picks a
+    16-aligned tile and the pass peels the remainder, so the tail used to carry
+    ``M mod m`` physical rows -- 36 for ``M = 100`` -- straight into ``Left`` and
+    ``Acc``. ptoas rejects such an allocation outright (``'pto.alloc_tile' op
+    expects result boxed tile rows to be a multiple of innerRows (16)``), and at
+    ``M = 1`` it accepts a one-row cube operand that pto-isa's ``TExtract`` cannot
+    address.
+
+    ``ConvertTensorToTileOps`` now loads the left operand into a whole number of
+    boxes with the true extent in ``valid_shape``, so the M reaching this pass is
+    already a multiple of 16 -- and a multiple of 16 can only be tiled into
+    16-aligned pieces, tail included. The invariant therefore holds for every M,
+    with no boundary special case in the pass.
+    """
+
+    @pytest.mark.parametrize("m_dim", [1, 17, 40, 100, 250])
+    def test_no_sub_fractal_cube_rows_at_any_m(self, m_dim):
+        k_dim, n_dim = 256, 512
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                a: pl.Tensor[[m_dim, k_dim], pl.FP16],
+                b: pl.Tensor[[k_dim, n_dim], pl.FP16],
+                out: pl.Out[pl.Tensor[[m_dim, n_dim], pl.FP32]],
+            ) -> pl.Tensor[[m_dim, n_dim], pl.FP32]:
+                c = pl.matmul(a, b, out_dtype=pl.FP32)
+                out = pl.assemble(out, c, [0, 0])
+                return out
+
+        After = passes.auto_tile_matmul_l0()(_lower_to_tile_ops(Before))
+        rows = _cube_m_axis_rows(After)
+        assert rows, "expected at least one Left/Acc tile in the lowered program"
+        sub_fractal = sorted({r for r in rows if r % 16})
+        assert not sub_fractal, f"sub-fractal cube rows for M={m_dim}: {sub_fractal}"
+
+        # The padding is physical only: the accumulator still names the M the
+        # caller asked for, so the store writes exactly m_dim rows. (An N-tiled
+        # schedule splits the column extent across sub-tiles, so match the row
+        # extent alone.)
+        printed = ir.python_print(After)
+        assert f"valid_shape=[{m_dim}, " in printed, f"the accumulator must carry the true M={m_dim} extent"
+
+
 class TestAutoTileMatmulL0PredicatedAcc:
     """A caller-written ``init_cond`` is threaded through the K-only emitter.
 

--- a/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
+++ b/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
@@ -1673,6 +1673,45 @@ class TestConvertTensorToTileOps:
         )
         _assert_convert_equal(before, expected)
 
+    def test_sliced_matmul_lhs_is_row_boxed_by_the_consumer_driven_load(self):
+        """A sliced left operand is boxed too, not just a bare parameter.
+
+        A ``tensor.slice`` feeding a matmul answers the Mat demand at the slice
+        itself (``HandleConsumerDrivenLoad``) rather than through
+        ``BridgeInputSpaces``, so the box rule has to ride on ``ConsumerSpaceReq``
+        as well. Without that the sliced operand keeps its unaligned physical row
+        count all the way to ptoas. ``valid_shape`` still names the slice window,
+        so only the allocation grows.
+        """
+        param_shape = [32, 128]
+        slice_shape: list[int | ir.Expr] = [17, 128]
+        rhs_shape = [128, 64]
+        out_shape = [17, 64]
+        dtype = DataType.FP16
+        in_specs: list[InSpec] = [("a", param_shape, dtype), ("b", rhs_shape, dtype)]
+
+        def before_body(ib, ins):
+            sliced = ib.let("a_slice", tensor_ops.slice(ins[0], slice_shape, [0, 0]))
+            return ib.let("y", tensor_ops.matmul(sliced, ins[1]))
+
+        def expected_body(ib, params):
+            a_p, b_p = params
+            lhs_mat = ib.let(
+                "a_slice_tile",
+                tile_ops.load(a_p, [0, 0], [32, 128], slice_shape, target_memory=MemorySpace.Mat),
+            )
+            rhs_mat = ib.let(
+                "rhs_mat",
+                tile_ops.load(b_p, [0, 0], rhs_shape, rhs_shape, target_memory=MemorySpace.Mat),
+            )
+            return ib.let("y_tile", tile_ops.matmul(lhs_mat, rhs_mat))
+
+        before = _make_before(in_specs=in_specs, out_shape=out_shape, out_dtype=dtype, body=before_body)
+        expected = _make_expected(
+            in_specs=in_specs, out_shape=out_shape, out_dtype=dtype, body=expected_body, preload=False
+        )
+        _assert_convert_equal(before, expected)
+
     def test_matmul_a_trans_lhs_keeps_its_natural_load(self):
         """A transposed left operand is NOT row-boxed.
 

--- a/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
+++ b/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
@@ -1712,6 +1712,65 @@ class TestConvertTensorToTileOps:
         )
         _assert_convert_equal(before, expected)
 
+    def test_matmul_lhs_reached_through_set_validshape_is_row_boxed(self):
+        """A parameter that reaches the matmul through an inherit-input wrapper.
+
+        ``tensor.set_validshape`` propagates the Mat demand back to the parameter,
+        whose load the pass emits in its Phase-1 entry loop -- neither
+        ``BridgeInputSpaces`` nor ``HandleConsumerDrivenLoad``. That third site
+        needs the same boxing, or a 17-row operand reaches ptoas with 17 physical
+        rows and is rejected.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self, a: pl.Tensor[[17, 128], pl.FP16], b: pl.Tensor[[128, 64], pl.FP16]
+            ) -> pl.Tensor[[17, 64], pl.FP32]:
+                av: pl.Tensor[[17, 128], pl.FP16] = pl.tensor.set_validshape(a, 17, 128)
+                y: pl.Tensor[[17, 64], pl.FP32] = pl.matmul(av, b, out_dtype=pl.FP32)
+                return y
+
+            @pl.function
+            def main(
+                self, a: pl.Tensor[[17, 128], pl.FP16], b: pl.Tensor[[128, 64], pl.FP16]
+            ) -> pl.Tensor[[17, 64], pl.FP32]:
+                y: pl.Tensor[[17, 64], pl.FP32] = self.main_incore_0(a, b)
+                return y
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                a: pl.Tensor[[17, 128], pl.FP16],
+                b: pl.Tensor[[128, 64], pl.FP16],
+                ret0_out: pl.Out[pl.Tensor[[17, 64], pl.FP32]],
+            ) -> pl.Tensor[[17, 64], pl.FP32]:
+                # 17 rows allocated as two whole 16-row NZ boxes; valid_shape keeps
+                # the true extent, so the store still writes exactly 17 rows.
+                a_mat: pl.Tile[[32, 128], pl.FP16, pl.MemorySpace.Mat] = pl.load(
+                    a, [0, 0], [32, 128], [17, 128], target_memory=pl.MemorySpace.Mat
+                )
+                av_tile = pl.tile.set_validshape(a_mat, 17, 128)
+                b_mat: pl.Tile[[128, 64], pl.FP16, pl.MemorySpace.Mat] = pl.load(
+                    b, [0, 0], [128, 64], [128, 64], target_memory=pl.MemorySpace.Mat
+                )
+                y_tile = pl.tile.matmul(av_tile, b_mat)
+                out_store: pl.Tensor[[17, 64], pl.FP32] = pl.store(y_tile, [0, 0], ret0_out)
+                return out_store
+
+            @pl.function
+            def main(
+                self, a: pl.Tensor[[17, 128], pl.FP16], b: pl.Tensor[[128, 64], pl.FP16]
+            ) -> pl.Tensor[[17, 64], pl.FP32]:
+                ret0_out: pl.Tensor[[17, 64], pl.FP32] = pl.create_tensor([17, 64], dtype=pl.FP32)
+                y: pl.Tensor[[17, 64], pl.FP32] = self.main_incore_0(a, b, ret0_out)
+                return y
+
+        _assert_convert_equal(Before, Expected)
+
     def test_matmul_a_trans_lhs_keeps_its_natural_load(self):
         """A transposed left operand is NOT row-boxed.
 

--- a/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
+++ b/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
@@ -1626,6 +1626,90 @@ class TestConvertTensorToTileOps:
         )
         _assert_convert_equal(before, expected)
 
+    @pytest.mark.parametrize(
+        ("name", "rows", "boxed_rows"),
+        [
+            ("single_row", 1, 16),
+            ("just_over_one_box", 17, 32),
+            ("mid_box", 100, 112),
+        ],
+    )
+    def test_matmul_lhs_rows_are_boxed_to_the_cube_fractal(self, name, rows, boxed_rows):
+        """An unaligned matmul M loads a whole number of NZ fractal boxes.
+
+        PTO-ISA separates the two extents of a cube operand: ``pto.mad`` derives
+        ``%m`` from the operand's *valid* rows (``%m == 1`` is a documented case),
+        while the *physical* allocation must be whole 16-row boxes -- ptoas rejects
+        anything else with ``'pto.alloc_tile' op expects result boxed tile rows to
+        be a multiple of innerRows (16)``. So the bridge load allocates the boxed
+        row count and declares the tensor's true extent as ``valid_shape``; the
+        DMA still moves only the valid rows. The right operand's rows are ``K``,
+        whose granularity is dtype-dependent, and are left alone.
+        """
+        lhs_shape = [rows, 128]
+        rhs_shape = [128, 64]
+        out_shape = [rows, 64]
+        dtype = DataType.FP16
+        in_specs: list[InSpec] = [("lhs", lhs_shape, dtype), ("rhs", rhs_shape, dtype)]
+
+        def before_body(ib, ins):
+            return ib.let("y", tensor_ops.matmul(ins[0], ins[1]))
+
+        def expected_body(ib, params):
+            lhs_p, rhs_p = params
+            lhs_mat = ib.let(
+                "lhs_mat",
+                tile_ops.load(lhs_p, [0, 0], [boxed_rows, 128], lhs_shape, target_memory=MemorySpace.Mat),
+            )
+            rhs_mat = ib.let(
+                "rhs_mat",
+                tile_ops.load(rhs_p, [0, 0], rhs_shape, rhs_shape, target_memory=MemorySpace.Mat),
+            )
+            return ib.let("y_tile", tile_ops.matmul(lhs_mat, rhs_mat))
+
+        before = _make_before(in_specs=in_specs, out_shape=out_shape, out_dtype=dtype, body=before_body)
+        expected = _make_expected(
+            in_specs=in_specs, out_shape=out_shape, out_dtype=dtype, body=expected_body, preload=False
+        )
+        _assert_convert_equal(before, expected)
+
+    def test_matmul_a_trans_lhs_keeps_its_natural_load(self):
+        """A transposed left operand is NOT row-boxed.
+
+        ``a_trans`` loads the operand naturally and reinterprets it with a
+        zero-copy ``tile.transpose_view``, so the loaded tile's row axis is the
+        matmul's ``K``, not its ``M``. Boxing rows there would pad the wrong axis;
+        the transposed dual's own granularity is dtype-dependent and is not
+        settled by this rule.
+        """
+        lhs_shape = [128, 17]
+        rhs_shape = [128, 64]
+        out_shape = [17, 64]
+        dtype = DataType.FP16
+        in_specs: list[InSpec] = [("lhs", lhs_shape, dtype), ("rhs", rhs_shape, dtype)]
+
+        def before_body(ib, ins):
+            return ib.let("y", tensor_ops.matmul(ins[0], ins[1], a_trans=True))
+
+        def expected_body(ib, params):
+            lhs_p, rhs_p = params
+            lhs_mat = ib.let(
+                "lhs_mat",
+                tile_ops.load(lhs_p, [0, 0], lhs_shape, lhs_shape, target_memory=MemorySpace.Mat),
+            )
+            lhs_operand = ib.let("lhs_mat_t", tile_ops.transpose_view(lhs_mat))
+            rhs_mat = ib.let(
+                "rhs_mat",
+                tile_ops.load(rhs_p, [0, 0], rhs_shape, rhs_shape, target_memory=MemorySpace.Mat),
+            )
+            return ib.let("y_tile", tile_ops.matmul(lhs_operand, rhs_mat))
+
+        before = _make_before(in_specs=in_specs, out_shape=out_shape, out_dtype=dtype, body=before_body)
+        expected = _make_expected(
+            in_specs=in_specs, out_shape=out_shape, out_dtype=dtype, body=expected_body, preload=False
+        )
+        _assert_convert_equal(before, expected)
+
     def test_mixed_kernel_vec_btrans_moves_to_mat_then_views(self):
         """A Vec compute result (add) feeding a b_trans=True 2D matmul is bridged to Mat
         via a NATURAL tile.move, then transposed by a zero-copy tile.transpose_view — NOT
@@ -3381,10 +3465,17 @@ class TestSliceMatmulConversion:
 
         ``slice_side`` selects which operand of matmul is sliced; ``trans_kw`` selects
         which transpose flag (a_trans/b_trans) is set on the matmul (or ``None`` for none).
+
+        A non-transposed left operand additionally loads a whole number of NZ fractal
+        boxes on its row axis, with the tensor's true extent in ``valid_shape`` — so
+        the ``btrans`` case's one-row ``a`` loads as ``[16, 128]`` valid ``[1, 128]``.
         """
         in_specs: list[InSpec] = [("a", lhs_shape, DataType.BF16), ("b", rhs_shape, DataType.BF16)]
         slice_shape = lhs_shape if slice_side == "lhs" else rhs_shape
         slice_trans = trans_kw == "a_trans" if slice_side == "lhs" else trans_kw == "b_trans"
+        # Row-boxed physical shape of the left operand's load. `a_trans` keeps its
+        # natural (unboxed) load: the transpose_view makes its COLUMN axis the M axis.
+        lhs_load_shape = lhs_shape if trans_kw == "a_trans" else [-(-lhs_shape[0] // 16) * 16, lhs_shape[1]]
 
         def before_body(ib, ins):
             a_in, b_in = ins
@@ -3427,7 +3518,7 @@ class TestSliceMatmulConversion:
             )
             other_tile = ib.let(
                 "lhs_mat",
-                tile_ops.load(a_p, [0, 0], lhs_shape, lhs_shape, target_memory=MemorySpace.Mat),
+                tile_ops.load(a_p, [0, 0], lhs_load_shape, lhs_shape, target_memory=MemorySpace.Mat),
             )
             rhs_operand = (
                 ib.let("b_slice_tile_t", tile_ops.transpose_view(sliced_tile)) if slice_trans else sliced_tile


### PR DESCRIPTION
Supersedes #2568, which fixed the wrong thing. Different diagnosis, different
place, one commit.

## The bug

`pl.matmul` on an M that is not a multiple of 16 does not compile.

| M | today |
| ---: | --- |
| 1 | ptoas **accepts** a one-row `Mat` and a one-row L0A tile; pto-isa's `TExtractToAVector` then fails its own `dstCol` static assertion at the NPU compile stage |
| 17, 40, 100, 250 | ptoas **rejects**: `'pto.alloc_tile' op expects result boxed tile rows to be a multiple of innerRows (16), but got 100` |
| 16, 128 | fine |

The rejection points at the user's DSL line but names ptoas internals and offers
no remedy. `AutoTileMatmulL0` compounds it: it picks a 16-aligned tile and peels
the remainder, so an unaligned M leaves a tail of `M mod m` physical rows — 36 at
M=100, 122 at M=250 — in both `Left` and `Acc`.

## Why

PTO-ISA keeps two independent notions of size for a cube operand, and only one of
them is constrained.

- The **logical** extent is essentially free. `pto.tmatmul` derives M/K/N from the
  operands' *valid* region, bounded at `[1, 4095]` with no divisibility rule, and
  `pto.mad` carries a `disable_gemv` clause whose whole purpose is selecting the
  L0A organization at `%m == 1`.
- The **physical** extent must be whole NZ fractal boxes — 16 rows on every
  generation and dtype. ptoas enforces it, and pto-isa's `TExtract` repeats it as
  a static assertion on the Mat source it reads.

`BuildGemvResultType` already says this in-tree: it gives a one-row GEMV result
exactly 16 physical accumulator rows with `valid_shape = [1, N]`. The
`tile.matmul` path for the same computation was declaring one.

## The fix

`ConvertTensorToTileOps` bridges a 2-D `tensor.matmul`'s left operand into Mat
with its rows rounded up to the box and the tensor's true extent declared as
`valid_shape`:

```python
# M = 100, before
a_mat = pl.tile.load(a, [0, 0], [100, 256], [100, 256], target_memory=pl.Mem.Mat)

# after
a_mat = pl.tile.load(a, [0, 0], [112, 256], [100, 256], target_memory=pl.Mem.Mat)
```

The padding is free on both axes of the cost model: a `tile.load` moves only the
valid extent, and the MAD cost is `ceil(M/16)` passes, which rounding M up leaves
unchanged. Hardware addresses the narrower valid region inside the full box
through compact mode, and `tile.store` writes only the valid rows.

**Fixing it here is what makes the boundary tile legal too.** A multiple of 16 can
only be split into 16-aligned pieces, tail included, so `AutoTileMatmulL0` needs
no boundary special case at all. Padding only the operand would not have sufficed —
the pass would still size the tail from the unpadded logical M.

## Scope, and what is deliberately left out

| Case | Boxed? | Why |
| ---- | ------ | --- |
| 2-D `tensor.matmul` left operand | Yes | Its row axis is M, whose box height is 16 for every dtype |
| Right operand | No | Its rows are `K`, whose granularity is `32 bytes / sizeof(dtype)` |
| `a_trans` left operand | No | The natural load's row axis is K; `tile.transpose_view` makes the *column* axis M |
| Rank >= 3 operand | No | It lowers to `tile.batch_matmul`, whose rows `FlattenTileNdTo2D` row-packs into one `[B*M, N]` tile |
| Dynamic row extent | No | No compile-time box to round to |
| `tensor.matmul_acc` left operand | No | `tile.matmul_acc` requires the accumulator and the product to agree on *physical* M, and the accumulator arrives from a separate `tile.create` this rule cannot reach |

K and N are the same class of hole and are untouched, for two reasons worth
stating: ptoas and `tile_view_semantics::GetBoxedTileAlignment` currently
disagree on the FP32 column granularity (ptoas demands 16, our model says 8), and
padding K would feed uninitialised L1 into the reduction unless the hardware
masks by valid col — unverified. That is a separate investigation, the same one
`PH-AT-007` already declines on.

## What #2568 got wrong

It added a `CubeTileFractalValid` structural verifier that rejected a sub-fractal
cube operand at pipeline input. Two disqualifying properties, both measured:

1. **It rejected legal programs.** Its net effect was "M must be a multiple of 16
   or it does not compile" — M = 17, 40, 100 all rejected. `M = 100` is an
   unremarkable shape.
2. **It missed the actual defect.** It fired at `ConvertTensorToTileOps`, before
   tiling, so it never saw the tail tiles the boundary peel produces.

It stopped the miscompile only as a side effect of refusing the program that
would have produced it. This PR makes those programs compile instead.

It also advised `pl.tile.gemv` as the remedy for `M = 1`. That is an alternative
spelling with a different operand organization, not a fix — the padded `tmatmul`
form is now correct and costs nothing extra in MAD throughput
(`ceil(1/16) == ceil(16/16) == 1`).

## Test plan

- `pytest tests/ut/` — 10786 passed, 3 skipped, 1 xfailed
- `pre-commit run --all-files` — all hooks pass
- **End to end through ptoas** (`ir.compile(..., skip_ptoas=False)`), the check
  the previous work never ran: M in {1, 17, 40, 100, 250} all compile, with no
  sub-fractal `Mat` / `Left` / `Acc` row count at any M. M = 16 and M = 128 emit
  byte-identical kernels.
- New: `TestAutoTileMatmulL0FractalBoundary` asserts the invariant across
  M in {1, 17, 40, 100, 250}; verified it fails on all five without the fix.
- New: three `ConvertTensorToTileOps` cases for the boxed load, plus one pinning
  that an `a_trans` operand keeps its natural load.

One existing expectation moved: `test_slice_then_matmul[btrans]` carried a
one-row `a` as incidental scaffolding, so its expected lhs load is now
`[16, 128]` valid `[1, 128]`. The shape is kept rather than bumped, so the case
now asserts the new lowering instead of merely tolerating it.

## Follow-up, tracked separately

`AutoTileMatmulL0` still does not tile the GEMV family, so a large-K
`pl.tile.gemv` fails an L0 capacity check. #2568's second commit fixes that and
is independent of this one; it needs `align_k = min_k = 512 / bytes_a` on the
gemv path (a one-row L0A operand's whole 512-byte fractal comes from its
columns) before it is mergeable. Worth landing on its own as a dedicated-path
optimisation — not as the fix for `M = 1`, which this PR handles.
