### PR TITLE
docs(user): size the exp doctest tolerance to the operator's own accuracy

### DIFF
--- a/docs/en/user/performance/01-task-granularity.md
+++ b/docs/en/user/performance/01-task-granularity.md
@@ -179,12 +179,18 @@ def merged_chain(a: pl.Tensor, b: pl.Tensor, out: pl.Out[pl.Tensor]):
 expected = torch.exp(A[:LARGE] + B[:LARGE])
 scratch, out = torch.zeros(LARGE, COLS), torch.zeros(LARGE, COLS)
 two_tasks_via_gm(A[:LARGE], B[:LARGE], scratch, out, config=CFG)
-torch.testing.assert_close(out, expected, rtol=1e-4, atol=1e-4)
+torch.testing.assert_close(out, expected, rtol=1e-3, atol=1e-4)
 
 out = torch.zeros(LARGE, COLS)
 merged_chain(A[:LARGE], B[:LARGE], out, config=CFG)
-torch.testing.assert_close(out, expected, rtol=1e-4, atol=1e-4)
+torch.testing.assert_close(out, expected, rtol=1e-3, atol=1e-4)
 ```
+
+Both comparisons raise only the relative bound, to `rtol=1e-3`: the device's `exp` carries
+its own relative error of roughly `1e-4`, so the `1e-4` the elementwise blocks above use
+would be measuring the operator's accuracy rather than the transformation. `atol` stays at
+`1e-4` so the small outputs, where it is what the bound rests on, are held as tightly as
+everywhere else.
 
 **Cost:** the merged task holds every intermediate live at once.
 

--- a/docs/en/user/performance/02-runtime-overhead.md
+++ b/docs/en/user/performance/02-runtime-overhead.md
@@ -220,7 +220,7 @@ def early_resolve(a: pl.Tensor, b: pl.Tensor, scratch: pl.Out[pl.Tensor], out: p
 
 scratch, out = fresh(TILE_ROWS), fresh(TILE_ROWS)
 early_resolve(A[:TILE_ROWS], B[:TILE_ROWS], scratch, out, config=CFG)
-torch.testing.assert_close(out, torch.exp(A[:TILE_ROWS] + B[:TILE_ROWS]), rtol=1e-4, atol=1e-4)
+torch.testing.assert_close(out, torch.exp(A[:TILE_ROWS] + B[:TILE_ROWS]), rtol=1e-3, atol=1e-4)
 ```
 
 The scheduler may then pre-stage that task's consumers onto idle cores *before* it

--- a/docs/en/user/performance/04-incore.md
+++ b/docs/en/user/performance/04-incore.md
@@ -25,7 +25,7 @@ A = (indices % 3 - 1).to(torch.float32).reshape(ROWS, TC)
 def check(kernel):
     out = torch.zeros(ROWS, TC, dtype=torch.float32)
     kernel(A, out, config=CFG)
-    torch.testing.assert_close(out, torch.exp(A), rtol=1e-4, atol=1e-4)
+    torch.testing.assert_close(out, torch.exp(A), rtol=1e-3, atol=1e-4)
 ```
 
 ## Double buffering

--- a/docs/zh/user/performance/01-task-granularity.md
+++ b/docs/zh/user/performance/01-task-granularity.md
@@ -150,12 +150,16 @@ def merged_chain(a: pl.Tensor, b: pl.Tensor, out: pl.Out[pl.Tensor]):
 expected = torch.exp(A[:LARGE] + B[:LARGE])
 scratch, out = torch.zeros(LARGE, COLS), torch.zeros(LARGE, COLS)
 two_tasks_via_gm(A[:LARGE], B[:LARGE], scratch, out, config=CFG)
-torch.testing.assert_close(out, expected, rtol=1e-4, atol=1e-4)
+torch.testing.assert_close(out, expected, rtol=1e-3, atol=1e-4)
 
 out = torch.zeros(LARGE, COLS)
 merged_chain(A[:LARGE], B[:LARGE], out, config=CFG)
-torch.testing.assert_close(out, expected, rtol=1e-4, atol=1e-4)
+torch.testing.assert_close(out, expected, rtol=1e-3, atol=1e-4)
 ```
+
+这里两处比较只放松了相对界限，取 `rtol=1e-3`：设备上的 `exp` 自身带有约 `1e-4` 的相对误差，
+沿用上面逐元素块里的 `1e-4` 量的就是算子精度，而不是这次变换。`atol` 仍是 `1e-4` —— 输出较小的
+那些元素靠它兜底，那里的松紧和别处一样。
 
 **代价：** 合并后的任务要同时持有每一个中间结果。
 

--- a/docs/zh/user/performance/02-runtime-overhead.md
+++ b/docs/zh/user/performance/02-runtime-overhead.md
@@ -168,7 +168,7 @@ def early_resolve(a: pl.Tensor, b: pl.Tensor, scratch: pl.Out[pl.Tensor], out: p
 
 scratch, out = fresh(TILE_ROWS), fresh(TILE_ROWS)
 early_resolve(A[:TILE_ROWS], B[:TILE_ROWS], scratch, out, config=CFG)
-torch.testing.assert_close(out, torch.exp(A[:TILE_ROWS] + B[:TILE_ROWS]), rtol=1e-4, atol=1e-4)
+torch.testing.assert_close(out, torch.exp(A[:TILE_ROWS] + B[:TILE_ROWS]), rtol=1e-3, atol=1e-4)
 ```
 
 调度器于是可以在这个任务**完成之前**就把它的消费者预置到空闲核上，等它一结束就用门铃放行。

--- a/docs/zh/user/performance/04-incore.md
+++ b/docs/zh/user/performance/04-incore.md
@@ -24,7 +24,7 @@ A = (indices % 3 - 1).to(torch.float32).reshape(ROWS, TC)
 def check(kernel):
     out = torch.zeros(ROWS, TC, dtype=torch.float32)
     kernel(A, out, config=CFG)
-    torch.testing.assert_close(out, torch.exp(A), rtol=1e-4, atol=1e-4)
+    torch.testing.assert_close(out, torch.exp(A), rtol=1e-3, atol=1e-4)
 ```
 
 ## Double buffer


### PR DESCRIPTION
## Summary

Three runnable blocks in the user manual compare a device `pl.exp` against `torch.exp` and
asserted `rtol=1e-4, atol=1e-4` — the bound the surrounding elementwise blocks use. `exp`
turns the device's relative error into a proportionally larger absolute one, and on the CI
simulator runners that error reaches ~1.5e-4, so the assertion sat below the operator's own
accuracy. The two-task block in `01-task-granularity.md` failed on 3 of the 14 most recent
`main` runs of `docs-examples`, always on the same `two_tasks_via_gm` assertion, missing on
12–29 of 16384 elements with a greatest relative difference of ~1.47e-4 against the 1e-4
limit. After this change those three comparisons are sized to the operator rather than to
the reference, and a reader copying the example no longer inherits a tolerance that measures
`exp` instead of the transformation being taught.

Only `rtol` moves. `atol` stays at `1e-4`, because it is what the bound rests on for the
small outputs — there the device's relative error is a negligible absolute one, so raising it
would buy slack no failure asks for and would let a real regression through on exactly the
elements the relative bound does not protect.

No kernel, pass, or API behaviour changes — the examples themselves are untouched, and the
elementwise blocks keep `1e-4`.

## Changes

- `docs/{en,zh}/user/performance/01-task-granularity.md`: both assertions of the merge-InCore
  block go to `rtol=1e-3` (`atol` unchanged), plus a short paragraph saying why this block is looser
  than the elementwise ones above it.
- `docs/{en,zh}/user/performance/02-runtime-overhead.md`: the `early_resolve` block carries
  the same producer→GM→`exp` shape and the same latent failure; same `rtol`.
- `docs/{en,zh}/user/performance/04-incore.md`: the shared `check()` helper of the two
  double-buffering blocks compares against `torch.exp(A)`; same `rtol`.

The zh pages mirror the en code byte for byte, which `run_doc_examples.py --check-parity`
enforces.

## Verification

- `python tests/docs/run_doc_examples.py --pages docs/en/user/performance --check-parity -p a2a3sim`: exit 0 — `parity OK`, 14/14 runnable doc blocks passed.
- `python tests/lint/check_docs_en_zh_parity.py`: exit 0 — 176 paired markdown paths.
- `python tests/lint/check_docs_nav.py`: exit 0 — 176 nav entries cover all 176 pages.
- `python tests/lint/check_docs_symbol_coverage.py`: exit 0 — 238/238 `pl.__all__` symbols documented.
- `python tests/lint/check_english_only.py`: exit 0 — 1336 files passed.